### PR TITLE
Add transaction fee to payment confirmation message

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.test.ts
+++ b/ironfish-cli/src/commands/accounts/pay.test.ts
@@ -43,7 +43,7 @@ describe('accounts:pay command', () => {
       'with every flag: show the right confirmation message and call sendTransaction if valid',
       (ctx) => {
         expectCli(ctx.stdout).include(
-          `$IRON  2 ($ORE 200,000,000) to  ${to} from the account  ${from}`,
+          `$IRON  2 ($ORE 200,000,000) plus a transaction fee of $IRON  1 ($ORE 100,000,000) to  ${to} from the account  ${from}`,
         )
         expectCli(ctx.stdout).include(`Transaction Hash`)
         expect(sendTransaction).toBeCalledTimes(1)
@@ -121,7 +121,7 @@ describe('accounts:pay command', () => {
       .exit(2)
       .it('show the right error message and call sendTransaction', (ctx) => {
         expectCli(ctx.stdout).include(
-          `$IRON  2 ($ORE 200,000,000) to  ${to} from the account  ${from}`,
+          `$IRON  2 ($ORE 200,000,000) plus a transaction fee of $IRON  1 ($ORE 100,000,000) to  ${to} from the account  ${from}`,
         )
         expect(sendTransaction).toBeCalledTimes(1)
         expectCli(ctx.stdout).include(`An error occurred while sending the transaction.`)

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -134,7 +134,13 @@ export class Pay extends IronfishCommand {
     if (!flags.confirm) {
       this.logger.log(`
 You are about to send:
-${displayIronAmountWithCurrency(amount, true)} to ${to} from the account ${from}
+${displayIronAmountWithCurrency(
+  amount,
+  true,
+)} plus a transaction fee of ${displayIronAmountWithCurrency(
+        fee,
+        true,
+      )} to ${to} from the account ${from}
 
 * This action is NOT reversible *
 `)


### PR DESCRIPTION
Adds transaction fees to the payment confirmation message to add some clarity around how much will be taken from your account.
