### PR TITLE
Fix relative import in pay command

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -12,7 +12,7 @@ import {
   oreToIron,
   isValidAmount,
   MINIMUM_IRON_AMOUNT,
-} from '../../../../ironfish'
+} from 'ironfish'
 
 interface ProgressBar {
   progress: VoidFunction


### PR DESCRIPTION
Looks like the same relative path issue we had with the `accounts:balance` command.
