### PR TITLE
Add AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to brew workflow

### DIFF
--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -59,5 +59,7 @@ jobs:
       - name: Deploy Ironfish CLI Brew
         run: ./ironfish-cli/scripts/deploy-brew.sh
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           BREW_GITHUB_USERNAME: ${{ secrets.BREW_GITHUB_USERNAME }}
           BREW_GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}


### PR DESCRIPTION
The Deploy Brew workflow fails with "Set AWS_ACCESS_KEY_ID before running deploy-brew.sh". Looks like we need to pass those env vars in via the deploy-brew.yml file.

