### PR TITLE
Remove extra path from Docker registry url

### DIFF
--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Deploy Node Image to Github
         run: ./ironfish-cli/scripts/deploy-docker.sh
         env:
-          REGISTRY_URL: ghcr.io/iron-fish/ironfish
+          REGISTRY_URL: ghcr.io/iron-fish


### PR DESCRIPTION
There's an extra `/ironfish` on the Docker registry URL -- This removes it.
