### PR TITLE
Add test for trees being updated

### DIFF
--- a/ironfish/src/captain/anchorChain/blockchain/fixtures/Blockchain_should_notes_to_trees_1
+++ b/ironfish/src/captain/anchorChain/blockchain/fixtures/Blockchain_should_notes_to_trees_1
@@ -1,0 +1,8 @@
+{
+  "name": "accountA",
+  "spendingKey": "267986d70edb78a34da9aedb50006ee6c620c436dd5bc834b24dabb7df6558d6",
+  "incomingViewKey": "caa712f0ac41bb5a46041a3cc85cb3594cb1299c91c1801529177e39ea766f00",
+  "outgoingViewKey": "fd3613ac5bdb0d1a9b6af857f7f983728378a4a66874e5cc49b52a5144a3bd22",
+  "publicAddress": "93da7e89b37b9edfb00e3abd07c6fd8c18ebbaee8493534093e2558e9c5b915f30f38cc729d3abc857503e",
+  "rescan": null
+}

--- a/ironfish/src/captain/anchorChain/blockchain/fixtures/Blockchain_should_notes_to_trees_2
+++ b/ironfish/src/captain/anchorChain/blockchain/fixtures/Blockchain_should_notes_to_trees_2
@@ -1,0 +1,8 @@
+{
+  "name": "accountB",
+  "spendingKey": "10b91a63bc735c56e37dc3db9ea1233d3a8db55ebc40ba5f84e83851090107f8",
+  "incomingViewKey": "7cf81ae18c4ec53d082cb2e05a2543e9b245c063f7751fa1d85b3189acb9e801",
+  "outgoingViewKey": "5fefbe969013dafaa8c99d68de8d2237b2c14e99e74763b2123ad223c9e5c837",
+  "publicAddress": "8b618e579a3a8e5636e7c21a8dc65da6d57ba4b0f05cc9c09174d07d0e7707cbec141a0173f6219e4ad980",
+  "rescan": null
+}

--- a/ironfish/src/captain/anchorChain/blockchain/fixtures/Blockchain_should_notes_to_trees_3
+++ b/ironfish/src/captain/anchorChain/blockchain/fixtures/Blockchain_should_notes_to_trees_3
@@ -1,0 +1,33 @@
+{
+  "header": {
+    "sequence": "2",
+    "previousBlockHash": "A1BA91BD54FCFE97D0DF8FE1F66B6217197B96CD52DB97FAD58B275E164600AB",
+    "noteCommitment": {
+      "commitment": {
+        "type": "Buffer",
+        "data": "base64:5tBHCBaqIYb+wZVhfkaDdau+nWbSNYIrZR5GYw1cOGI="
+      },
+      "size": 4
+    },
+    "nullifierCommitment": {
+      "commitment": "78A72F2020CE738CBA3A8995C0EBCA23C83A4CE2ADD7927210EAA2DE6466E0C9",
+      "size": 1
+    },
+    "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+    "randomness": 0,
+    "timestamp": 1617757183834,
+    "minersFee": "-500000000",
+    "isValid": false,
+    "work": "0",
+    "graphId": 0,
+    "count": 0,
+    "hash": "7E4ADC64EBB1395292CD940A1F4CE25E4EB6C86CB7F345BD3F3C40DF5F413693",
+    "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "transactions": [
+    {
+      "type": "Buffer",
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAACbMuL/////gnOduIwZq8jpN6O7Gsz5OMky4p2y5SNIIlp+RPSaFz/vQ6DmnKc8rwPuwMWOlKICg1tpmSZwCTFVskFkTnlGqWdT9dhrCZF1Z0iIL9ctdv+VFJa7ER1jzHyxl4yMpU6yFooAX5RdFoQDUVLA3oIC1lipHQQ1tEYe/DyUTtL6ebHRWnDN/VibdDtoQ1DCuzwkmeFmzH67JDOKo2Xgz7mmhlSlZF+U7bZfDb24pB6bp3hGR2UhsLbHxKkWIgQ8kI6ptrsuNDBcbWxeOT3Ssh0cR1TumGlij3qQhIHVTDlQT987/qdAHfUGpO7sP3eEvNFL3NWZRfPTbrXBEJSkXO3abyIZOvBUxlJ8Rf8787UHuaKhwwPCFfig6UkCerFva+3tpDuo1/MEqNJ7OXsVPcLvavn+YfD4M2IRUA9hSCgKBEaJmREcujXN1DUCENMu/wBF2xNVprLvcKETqDb4JxZYUofaYW2jY1K34lg+oY/BWsAHjqkfekBTzpC6Hzr70KbIWuAHQmVhbnN0YWxrIG5vdGUgZW5jcnlwdGlvbiBtaW5lciBrZXkwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDDgmYhZ21jS/HW4d/dSDradjgNkwfLy4cXVzqjViQlaumCQBiTAx2t/DxrRKJeIPd0YfBSxukBW0fBC0ZTLXzEA"
+    }
+  ]
+}

--- a/ironfish/src/captain/anchorChain/blockchain/fixtures/Blockchain_should_notes_to_trees_4
+++ b/ironfish/src/captain/anchorChain/blockchain/fixtures/Blockchain_should_notes_to_trees_4
@@ -1,0 +1,33 @@
+{
+  "header": {
+    "sequence": "2",
+    "previousBlockHash": "A1BA91BD54FCFE97D0DF8FE1F66B6217197B96CD52DB97FAD58B275E164600AB",
+    "noteCommitment": {
+      "commitment": {
+        "type": "Buffer",
+        "data": "base64:URGEyMskgKjSBh9K+8f8Olli9KGoqWAmylOamPTBgmI="
+      },
+      "size": 4
+    },
+    "nullifierCommitment": {
+      "commitment": "78A72F2020CE738CBA3A8995C0EBCA23C83A4CE2ADD7927210EAA2DE6466E0C9",
+      "size": 1
+    },
+    "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+    "randomness": 0,
+    "timestamp": 1617757188783,
+    "minersFee": "-500000000",
+    "isValid": false,
+    "work": "0",
+    "graphId": 0,
+    "count": 0,
+    "hash": "B56C8D3B6039D6122DEDCA77D0DFFFBC4A78AEEC8BCF41BB516508B268BBB602",
+    "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "transactions": [
+    {
+      "type": "Buffer",
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAACbMuL/////rgnMArzufmLzhYe+XNJqnOu8vB5PCjgRPe8XblvIpA5YYV9bM3Iac+WUd/xOVSruqtzMx2aQSiQQlf+kTwO/j8LL7c11bO/eP9Cm8XKmHEAhpaFwfXNOLxARiE6Jg5nFFDCmVJxJ75zG9p5zsr6tNn2XbatPD2fFTQ8w+ZzNPZ45bzx/F7KzQDLZc1Va7Pg7hFBV1WjbmW7/Rr3bsCT/NkKWNdY4q8n6CSV1+7B6BOq6uTbJHjoWBugNEsqKAiTZ2FSyesRfsQC1tJ1TZ55H4yJgVTcA63IKHceNhwa24+1fCJrMDVj3/vQq1SedgLiFSh6MPkfPl+Z9JV7OPj3oVVrIUimWv/ObpOs+VhJ2BO0wFW52dgOSjGByE2n+qikjkiZjuA6empyJMnIYfvQBo2T+I4SHWkJBOn2ewaeXiDSBYChjzSO3/qAO/rD6fjrYhJc3R+PWP2EYcfe7/zcjQY0W5DjAFfWh5F54Wbz2vGjx2iv29s8Q9VAOCSId5G3rtI1TQmVhbnN0YWxrIG5vdGUgZW5jcnlwdGlvbiBtaW5lciBrZXkwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDD+NczFiFSWJa3X7276OucQRB95x1P2tfdb33k7nlRnsAJdrpFw7myn/IreKpE456FJTzsMXezzs3R03uRf3vQK"
+    }
+  ]
+}

--- a/ironfish/src/captain/anchorChain/blockchain/fixtures/Blockchain_should_notes_to_trees_5
+++ b/ironfish/src/captain/anchorChain/blockchain/fixtures/Blockchain_should_notes_to_trees_5
@@ -1,0 +1,33 @@
+{
+  "header": {
+    "sequence": "3",
+    "previousBlockHash": "B56C8D3B6039D6122DEDCA77D0DFFFBC4A78AEEC8BCF41BB516508B268BBB602",
+    "noteCommitment": {
+      "commitment": {
+        "type": "Buffer",
+        "data": "base64:SlS8f+eEFyG6jakt2YDkH/ITqKZWWG9ZpBIlXj8AqU0="
+      },
+      "size": 5
+    },
+    "nullifierCommitment": {
+      "commitment": "78A72F2020CE738CBA3A8995C0EBCA23C83A4CE2ADD7927210EAA2DE6466E0C9",
+      "size": 1
+    },
+    "target": "882992383764307249142653314182893391999679604880738805815775866336575232",
+    "randomness": 0,
+    "timestamp": 1617757193730,
+    "minersFee": "-500000000",
+    "isValid": false,
+    "work": "0",
+    "graphId": 0,
+    "count": 0,
+    "hash": "AEF67CBC3F772C75CA0BC35011FFF2A1DD37D17E2A4A3556E0AA6F3A13BCC53A",
+    "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "transactions": [
+    {
+      "type": "Buffer",
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAACbMuL/////iVtX+BUPgA2TpUNqSdIx0RrVtc3Zfri2ciD9tZjufAXzIHlXNNDbqmaM3tRFq0RVgpXl9HAXPFhc5urU2+04qAkgRV0mkXt4pJNlt/o4xMoooFNkQLrxVasWOuvCQDApFkLLu5EGB5HULwu8cUc/G0kEpBa+DrBF1njbNB/m+0rvLdvGL+Btc7qwi1hie3WxkCZvw7nGqBVF9N90Ks2CV8Ld+4Zepr5wgGUhUkmgOAIBCf8cgSk47fv8GHILRv/scsOB45spUhbNBuzyZyvow1A0UH7y4vrwe9FCHu7C/zmP97y4Tp9ydQFI2kpK/7rOc2JRoWSUIIEMIJSSBR0EG3w0aIUN35d2iS3EGd6RrbILGuOoB3oosecfXV4y2jIfFN6xanuO43udtNdTm2ciLGwjK8ZIgMN+XyNsqFQJ76uKlWlQ0ESOzY5elt2kClXqzUBtQoInvU+BiE0W9F1btQTXX946HgyQbwfieREqAp33d7dnu3HDgtJgnwY9chsLo6WkQmVhbnN0YWxrIG5vdGUgZW5jcnlwdGlvbiBtaW5lciBrZXkwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDACwlkvDOET6X/2fQ8U2pNtzbRKJOVW2Kkyy3hz5IK8FFHDA3npufYeWzRxvyaDKX1WVOjCybOOFitCo5g3zWEL"
+    }
+  ]
+}


### PR DESCRIPTION
We had a bug where when a re-org happened, the note / nullifier trees
were trimmed too far back. The forking points notes / nullifiers were
also removed. This adds a test to make sure that the trees are
updated on a linear add, but also properly pruned and re-added during a
re-org.

This replaces the test that was in the file previously. Fixtures have
been updated.