### PR TITLE
Limit connection attempts per network eventloop

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -134,7 +134,7 @@ export class Config extends KeyStore<ConfigOptions> {
       rpcTcpHost: 'localhost',
       rpcTcpPort: 8020,
       rpcRetryConnect: false,
-      maxPeers: 10000,
+      maxPeers: 50,
       targetPeers: 50,
       telemetryApi: DEFAULT_TELEMETRY_API,
       accountName: DEFAULT_WALLET_NAME,


### PR DESCRIPTION
This is causing the node to freeze. As soon as you get the
bootstrap node's peer list, you try to issue 60+ outbound connection attempts
which is too many and causes node to deadlock.