### PR TITLE
Encode message when disconnecting user

### DIFF
--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -5,8 +5,13 @@
 jest.mock('ws')
 
 import ws from 'ws'
+import type WSWebSocket from 'ws'
+import http from 'http'
+import net from 'net'
 import { PeerNetwork, RoutingStyle } from './peerNetwork'
 import { getConnectedPeer, mockPrivateIdentity } from './testUtilities'
+import { Assert } from '../assert'
+import { DisconnectingMessage } from './messages'
 
 jest.useFakeTimers()
 
@@ -77,4 +82,49 @@ it('changes isReady when peers connect', () => {
   expect(readyChanged).toBeCalledTimes(2)
   expect(readyChanged).toHaveBeenNthCalledWith(1, true)
   expect(readyChanged).toHaveBeenNthCalledWith(2, false)
+})
+
+it('rejects websocket connections when at max peers', () => {
+  const wsActual = jest.requireActual<typeof WSWebSocket>('ws')
+
+  const peerNetwork = new PeerNetwork(
+    mockPrivateIdentity('local'),
+    'sdk/1/cli',
+    wsActual,
+    undefined,
+    {
+      enableListen: true,
+      port: 0,
+      minPeersReady: 1,
+      maxPeers: 0,
+    },
+  )
+
+  const rejectSpy = jest
+    .spyOn(peerNetwork.peerManager, 'shouldRejectDisconnectedPeers')
+    .mockReturnValue(true)
+
+  // Start the network so it creates the webSocketServer
+  peerNetwork.start()
+  const server = peerNetwork['webSocketServer']
+  Assert.isNotUndefined(server, `server`)
+
+  const socket = new net.Socket()
+  const req = new http.IncomingMessage(socket)
+  const conn = new ws('test')
+
+  const sendSpy = jest.spyOn(conn, 'send').mockReturnValue(undefined)
+  const closeSpy = jest.spyOn(conn, 'close').mockReturnValue(undefined)
+  server.server.emit('connection', conn, req)
+  peerNetwork.stop()
+
+  expect(rejectSpy).toHaveBeenCalled()
+  expect(sendSpy).toHaveBeenCalled()
+  expect(closeSpy).toHaveBeenCalled()
+
+  // Check that the disconnect message was serialized properly
+  const args = sendSpy.mock.calls[0][0]
+  expect(typeof args).toEqual('string')
+  const message = JSON.parse(args) as DisconnectingMessage
+  expect(message.type).toEqual('disconnecting')
 })

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -113,7 +113,7 @@ export class PeerNetwork {
     this.metrics = metrics || new MetricsMonitor(this.logger)
 
     this.localPeer = new LocalPeer(localIdentity, localVersion, webSocket, webRtc)
-    this.localPeer.port = options.port || null
+    this.localPeer.port = options.port === undefined ? null : options.port
     this.localPeer.name = options.name || null
     this.localPeer.isWorker = options.isWorker || false
     this.localPeer.simulateLatency = options.simulateLatency || 0
@@ -173,6 +173,10 @@ export class PeerNetwork {
         let address: string | null = null
 
         if (this.peerManager.shouldRejectDisconnectedPeers()) {
+          this.logger.debug(
+            'Disconnecting inbound websocket connection because the node has max peers',
+          )
+
           const disconnect: DisconnectingMessage = {
             type: InternalMessageType.disconnecting,
             payload: {
@@ -182,10 +186,7 @@ export class PeerNetwork {
               disconnectUntil: Date.now() + 1000 * 60 * 5,
             },
           }
-          connection.send(disconnect)
-          this.logger.debug(
-            'Disconnecting inbound websocket connection because the node has max peers',
-          )
+          connection.send(JSON.stringify(disconnect))
           connection.close()
           return
         }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -256,6 +256,7 @@ export class PeerManager {
 
     if (address) {
       const url = parseUrl(address)
+
       if (url.hostname) {
         hostname = url.hostname
         port = url.port


### PR DESCRIPTION
The message wasn't encoded when disconnecting users when you are at your max connections. This causes a crash because you can't send an object over WebSocket, you need to encode it to a string, or a buffer.

We'll look at cleaning up the code in another PR so that our wrapper connection only ever gets emitted from WebSocketServer, so this type of issue cannot happen again in the future.

Fixes IRO-635