### PR TITLE
Move verifier from captain to consensus

### DIFF
--- a/ironfish/src/captain/anchorChain/blockchain/index.ts
+++ b/ironfish/src/captain/anchorChain/blockchain/index.ts
@@ -35,7 +35,7 @@ import {
   StringEncoding,
 } from '../../../storage'
 import { Logger } from '../../../logger'
-import { Verifier } from '../..'
+import { Verifier } from '../../../consensus'
 import Serde from '../../../serde'
 
 export { default as Block, BlockSerde, SerializedBlock } from './Block'

--- a/ironfish/src/captain/anchorChain/strategies/index.ts
+++ b/ironfish/src/captain/anchorChain/strategies/index.ts
@@ -7,7 +7,7 @@ import { NullifierHash, Nullifier } from '../nullifiers'
 import { BlockHash } from '../blockchain/BlockHeader'
 import Transaction from './Transaction'
 import Serde, { JsonSerializable } from '../../../serde'
-import Verifier from '../../Verifier'
+import Verifier from '../../../consensus/verifier'
 import Blockchain from '../blockchain'
 
 export { default as Transaction, Spend } from './Transaction'

--- a/ironfish/src/captain/index.ts
+++ b/ironfish/src/captain/index.ts
@@ -13,7 +13,6 @@ import { JsonSerializable } from '../serde'
 
 import { BlockSyncer, BlockSyncerChainStatus } from './blockSyncer'
 import { IDatabase } from '../storage'
-import Verifier from './Verifier'
 import Blockchain from './anchorChain/blockchain'
 import { Identity } from '../network'
 
@@ -47,7 +46,7 @@ export {
 } from './anchorChain/merkleTree/Witness'
 
 // Exports used in testUtilities
-export { BlockSyncer, BlockSyncerChainStatus, BlocksResponse, Verifier }
+export { BlockSyncer, BlockSyncerChainStatus, BlocksResponse }
 
 /**
  * Captain ensures that the chain is kept in sync with the latest version

--- a/ironfish/src/captain/testUtilities/strategy/testVerifier.ts
+++ b/ironfish/src/captain/testUtilities/strategy/testVerifier.ts
@@ -4,7 +4,7 @@
 
 import { TestTransaction } from './TestTransaction'
 import { SerializedTestTransaction } from './SerializedTypes'
-import Verifier from '../../Verifier'
+import Verifier from '../../../consensus/verifier'
 import { Validity, VerificationResult } from '../../anchorChain/blockchain'
 import { VerificationResultReason } from '../../anchorChain/blockchain/VerificationResult'
 import { TestBlock, TestBlockHeader } from '../helpers'

--- a/ironfish/src/consensus/index.ts
+++ b/ironfish/src/consensus/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import Verifier from './verifier'
+
+export { Verifier }

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -5,7 +5,7 @@
 jest.mock('ws')
 jest.mock('../network')
 
-import { RangeHasher } from './anchorChain/merkleTree'
+import { RangeHasher } from '../captain/anchorChain/merkleTree'
 import {
   TestStrategy,
   makeCaptain,
@@ -14,11 +14,14 @@ import {
   blockHash,
   TestBlockHeader,
   fakeMaxTarget,
-} from './testUtilities'
+} from '../captain/testUtilities'
 
-import Target from './anchorChain/blockchain/Target'
-import { Validity, VerificationResultReason } from './anchorChain/blockchain/VerificationResult'
-import { BlockHeader } from './anchorChain/blockchain'
+import Target from '../captain/anchorChain/blockchain/Target'
+import {
+  Validity,
+  VerificationResultReason,
+} from '../captain/anchorChain/blockchain/VerificationResult'
+import { BlockHeader } from '../captain/anchorChain/blockchain'
 
 describe('Verifier', () => {
   describe('Transactions', () => {

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -2,20 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { default as Block, BlockSerde, SerializedBlock } from './anchorChain/blockchain/Block'
-import Strategy from './anchorChain/strategies'
-import Transaction from './anchorChain/strategies/Transaction'
+import {
+  default as Block,
+  BlockSerde,
+  SerializedBlock,
+} from '../captain/anchorChain/blockchain/Block'
+import Strategy from '../captain/anchorChain/strategies'
+import Transaction from '../captain/anchorChain/strategies/Transaction'
 import { isNewBlockPayload, isNewTransactionPayload } from '../network/messages'
-import BlockHeader from './anchorChain/blockchain/BlockHeader'
-import { Spend } from './anchorChain/strategies/Transaction'
-import Blockchain, { Target } from './anchorChain/blockchain'
+import BlockHeader from '../captain/anchorChain/blockchain/BlockHeader'
+import { Spend } from '../captain/anchorChain/strategies/Transaction'
+import Blockchain, { Target } from '../captain/anchorChain/blockchain'
 import { PayloadType } from '../network'
 import Serde, { BufferSerde, JsonSerializable } from '../serde'
 import {
   Validity,
   VerificationResult,
   VerificationResultReason,
-} from './anchorChain/blockchain/VerificationResult'
+} from '../captain/anchorChain/blockchain/VerificationResult'
 import { IDatabaseTransaction } from '../storage'
 
 export const ALLOWED_BLOCK_FUTURE_SECONDS = 15

--- a/ironfish/src/strategy/index.ts
+++ b/ironfish/src/strategy/index.ts
@@ -19,11 +19,11 @@ import Captain, {
   Validity,
   VerificationResult,
   MerkleHasher,
-  Verifier,
   Witness,
   BlockHeader,
   SerializedBlock,
 } from '../captain'
+import { Verifier } from '../consensus'
 import Blockchain from '../captain/anchorChain/blockchain'
 import Serde from '../serde'
 

--- a/ironfish/src/testUtilities/verifier.ts
+++ b/ironfish/src/testUtilities/verifier.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Verifier } from '../captain'
+import { Verifier } from '../consensus'
 import {
   IronfishBlockchain,
   IronfishNoteEncrypted,


### PR DESCRIPTION
Part of the great repo cleanup, strategy will be here too eventually. They'll both be deleted to form new modules that make up the protocol / consensus.