### PR TITLE
Change transaction log level to debug

### DIFF
--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -62,7 +62,7 @@ export class MemPool<
     this.logger.debug('fee: ', fee)
 
     this.transactions.set(hash, transaction)
-    this.logger.info(`Accepted tx ${hash}, poolsize ${this.size()}`)
+    this.logger.debug(`Accepted tx ${hash}, poolsize ${this.size()}`)
   }
 
   /**


### PR DESCRIPTION
This is the main log that shows up during normal operation of a node with the default log levels set, I think it's okay to move it to debug since it's not as user-readable.
