### PR TITLE
Disconnect WebRTC connection if send throws an error

### DIFF
--- a/ironfish/src/network/peers/connections/connection.ts
+++ b/ironfish/src/network/peers/connections/connection.ts
@@ -93,7 +93,7 @@ export abstract class Connection {
   /**
    * Send a message into this connection.
    */
-  abstract send: (object: LooseMessage) => void
+  abstract send: (object: LooseMessage) => boolean
 
   /**
    * Shutdown the connection, if possible
@@ -177,6 +177,9 @@ export abstract class Connection {
           originalSend(toSend)
         }
       }, latency)
+
+      // TODO: Not currently possible to propagate connection errors from sending
+      return true
     }
 
     this.send = wrapper

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -100,7 +100,7 @@ export class WebSocketConnection extends Connection {
   /**
    * Encode the message to json and send it to the peer
    */
-  send = (message: LooseMessage): void => {
+  send = (message: LooseMessage): boolean => {
     if (this.shouldLogMessageType(message.type)) {
       this.logger.debug(`${colors.yellow('SEND')} ${this.displayName}: ${message.type}`)
     }
@@ -112,6 +112,8 @@ export class WebSocketConnection extends Connection {
     const byteCount = Buffer.from(data).byteLength
     this.metrics?.p2p_OutboundTraffic.add(byteCount)
     this.metrics?.p2p_OutboundTraffic_WS.add(byteCount)
+
+    return true
   }
 
   /**

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -58,7 +58,7 @@ export function getConnectingPeer(
     throw new Error('WebSocket connection should be defined')
   }
 
-  jest.spyOn(peer.state.connections.webSocket, 'send').mockImplementation()
+  jest.spyOn(peer.state.connections.webSocket, 'send').mockImplementation(() => true)
 
   return { peer, connection: peer.state.connections.webSocket }
 }


### PR DESCRIPTION
The webRtcConnection would occasionally be in state `CONNECTED`, but then throw an exception when sending a message. This doesn't seem like a logic error in our code, since the connection must receive an Identity message from the opposite party before setting the connection to 'CONNECTED'.

This PR wraps the `send` in a try/catch and sets the connection to `DISCONNECTED` if it throws an error. I added some tests for it, and it falls back to WebSockets if available.

One issue here is it doesn't propagate the failure to send if the latency simulator is enabled, but that's only used for latency-related testing, so I'm less concerned about it.

Fixes #16
