### PR TITLE
Allow setConfig to parse string arrays

### DIFF
--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -33,6 +33,10 @@ export class SetCommand extends IronfishCommand {
     }),
   }
 
+  static examples = [
+    '$ ironfish config:set bootstrapNodes "test.bn1.ironfish.network,example.com"',
+  ]
+
   async start(): Promise<void> {
     const { args, flags } = this.parse(SetCommand)
     const name = args.name as string

--- a/ironfish/src/rpc/routes/config/setConfig.test.ts
+++ b/ironfish/src/rpc/routes/config/setConfig.test.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createRouteTest } from '../test'
+
+jest.mock('axios')
+
+describe('Route config/setConfig', () => {
+  const routeTest = createRouteTest()
+
+  it('should error if the config name does not exist', async () => {
+    await expect(
+      routeTest.adapter.request('config/setConfig', { name: 'asdf', value: 'asdf' }),
+    ).rejects.toThrow()
+  })
+
+  describe('Convert string to array', () => {
+    it('does not special-case brackets', async () => {
+      const response = await routeTest.adapter.request('config/setConfig', {
+        name: 'bootstrapNodes',
+        value: '[]',
+      })
+      const content = await response.content
+      expect(response.status).toBe(200)
+      expect(content).toBeUndefined()
+      expect(routeTest.sdk.config.get('bootstrapNodes')).toEqual(['[]'])
+    })
+
+    it('should convert strings to arrays', async () => {
+      const response = await routeTest.adapter.request('config/setConfig', {
+        name: 'bootstrapNodes',
+        value: 'test.node.com,test2.node.com',
+      })
+      const content = await response.content
+      expect(response.status).toBe(200)
+      expect(content).toBeUndefined()
+      expect(routeTest.sdk.config.get('bootstrapNodes')).toEqual([
+        'test.node.com',
+        'test2.node.com',
+      ])
+    })
+
+    it('handles single values', async () => {
+      const response = await routeTest.adapter.request('config/setConfig', {
+        name: 'bootstrapNodes',
+        value: 'test.node.com',
+      })
+      const content = await response.content
+      expect(response.status).toBe(200)
+      expect(content).toBeUndefined()
+      expect(routeTest.sdk.config.get('bootstrapNodes')).toEqual(['test.node.com'])
+    })
+
+    it('should strip leading and trailing whitespace', async () => {
+      const response = await routeTest.adapter.request('config/setConfig', {
+        name: 'bootstrapNodes',
+        value: '  node1  ,   node2  ',
+      })
+      const content = await response.content
+      expect(response.status).toBe(200)
+      expect(content).toBeUndefined()
+      expect(routeTest.sdk.config.get('bootstrapNodes')).toEqual(['node1', 'node2'])
+    })
+
+    it('should leave quotes', async () => {
+      const response = await routeTest.adapter.request('config/setConfig', {
+        name: 'bootstrapNodes',
+        value: ' \' node1 \' , " node2 " ',
+      })
+      const content = await response.content
+      expect(response.status).toBe(200)
+      expect(content).toBeUndefined()
+      expect(routeTest.sdk.config.get('bootstrapNodes')).toEqual(["' node1 '", '" node2 "'])
+    })
+  })
+})

--- a/ironfish/src/rpc/routes/config/uploadConfig.ts
+++ b/ironfish/src/rpc/routes/config/uploadConfig.ts
@@ -73,10 +73,23 @@ export function setUnknownConfigValue(
   config.set(sourceKey, value as any)
 }
 
+// Expects string in CSV format with no brackets
+function stringToStringArray(value: string): string[] | null {
+  if (value === '') return []
+
+  // Strip the brackets and split on commas
+  const parsedValue = value.split(',')
+
+  // Trim whitespace, trim leading/trailing quotes if necessary
+  return parsedValue.map((v) => v.trim())
+}
+
 function convertValue(sourceValue: unknown, targetValue: unknown): unknown {
   if (typeof sourceValue !== 'string') {
     throw new ValidationError(
-      `Could not convert ${JSON.stringify(sourceValue)} to ${String(typeof targetValue)}`,
+      `Could not convert ${JSON.stringify(sourceValue)} from ${typeof sourceValue} to ${String(
+        typeof targetValue,
+      )}`,
     )
   }
 
@@ -96,10 +109,16 @@ function convertValue(sourceValue: unknown, targetValue: unknown): unknown {
   } else if (typeof targetValue === 'string') {
     return sourceValue
   } else if (Array.isArray(targetValue)) {
+    const result = stringToStringArray(sourceValue.trim())
+    if (result !== null) {
+      return result
+    }
     targetType = 'array'
   }
 
   throw new ValidationError(
-    `Could not convert ${JSON.stringify(sourceValue)} to ${String(targetType)}`,
+    `Could not convert ${JSON.stringify(sourceValue)} from ${typeof sourceValue} to ${String(
+      targetType,
+    )}`,
   )
 }


### PR DESCRIPTION
Allows for updating the bootstrapNodes config with config:set, like so:

```
ironfish config:set bootstrapNodes "test.bn1.ironfish.network,examplenode.com"
```

Added an example for it to `ironfish config:set --help`.

Fixes #40﻿
