### PR TITLE
Remove captain from mining director

### DIFF
--- a/ironfish/src/captain/captain.ts
+++ b/ironfish/src/captain/captain.ts
@@ -4,10 +4,9 @@
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { default as Block, BlockSerde } from '../blockchain/block'
+import { BlockSerde } from '../blockchain/block'
 import Strategy from '../strategy/strategy'
 import Transaction from '../strategy/transaction'
-import { Event } from '../event'
 import { MetricsMonitor } from '../metrics'
 import { createRootLogger, Logger } from '../logger'
 import { JsonSerializable } from '../serde'
@@ -30,12 +29,6 @@ export class Captain<
   workerPool: WorkerPool
   logger: Logger
   metrics: MetricsMonitor
-
-  /**
-   * Emitted when a new block has been created, such as
-   * when a new block has been mined.
-   */
-  onNewBlock = new Event<[Block<E, H, T, SE, SH, ST>]>()
 
   private constructor(
     chain: Blockchain<E, H, T, SE, SH, ST>,
@@ -70,15 +63,5 @@ export class Captain<
     metrics = metrics || new MetricsMonitor(logger)
     chain = chain || (await Blockchain.new(db, strategy, logger, metrics))
     return new Captain(chain, workerPool, logger, metrics)
-  }
-
-  /**
-   * Submit a freshly mined block to be forwarded to the p2p network
-   *
-   * This method would only be used by miners.
-   * @param block the block that has been mined by an external miner or pool.
-   */
-  emitBlock(block: Block<E, H, T, SE, SH, ST>): void {
-    this.onNewBlock.emit(block)
   }
 }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -205,7 +205,7 @@ export class PeerNetwork {
       async (message) => await this.onNewTransaction(message),
     )
 
-    this.captain.onNewBlock.on((block) => {
+    this.node.miningDirector.onNewBlock.on((block) => {
       const serializedBlock = this.captain.blockSerde.serialize(block)
 
       this.gossip({

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -193,7 +193,11 @@ export class IronfishNode {
     const memPool = new MemPool(captain, logger)
     const accounts = new Accounts({ database: accountDB })
 
-    const mining = new MiningDirector(captain, memPool, logger, {
+    const mining = new MiningDirector({
+      chain: chain,
+      strategy: strategy,
+      memPool: memPool,
+      logger: logger,
       graffiti: config.get('blockGraffiti'),
     })
 

--- a/ironfish/src/testUtilities/mocks.ts
+++ b/ironfish/src/testUtilities/mocks.ts
@@ -18,17 +18,22 @@ export function mockAccounts(): any {
 export function mockNode(): any {
   return {
     accounts: mockAccounts(),
+    miningDirector: mockDirector(),
   }
 }
 
 export function mockCaptain(): any {
-  return {
-    onNewBlock: mockEvent(),
-  }
+  return {}
 }
 
 export function mockPeerNetwork(): any {
   return {
     requestBlocks: jest.fn(),
+  }
+}
+
+export function mockDirector(): any {
+  return {
+    onNewBlock: mockEvent(),
   }
 }


### PR DESCRIPTION
This removes captain usage from mining director, and moves the mining
event it had on it, into the director itself.