### PR TITLE
Remove captain.blockSerde

### DIFF
--- a/ironfish/src/account/accounts.test.slow.ts
+++ b/ironfish/src/account/accounts.test.slow.ts
@@ -29,7 +29,7 @@ describe('Accounts', () => {
     // Initialize the database and chain
     const strategy = nodeTest.strategy
     const node = nodeTest.node
-    const captain = nodeTest.captain
+    const chain = nodeTest.chain
 
     const account = await node.accounts.createAccount('test', true)
 
@@ -44,7 +44,7 @@ describe('Accounts', () => {
 
     const result = IJSON.parse(genesisBlockData) as SerializedBlock<Buffer, Buffer>
     const block = strategy._blockSerde.deserialize(result)
-    const addedBlock = await captain.chain.addBlock(block)
+    const addedBlock = await chain.addBlock(block)
     expect(addedBlock.isAdded).toBe(true)
 
     // TODO: This should happen automatically as a result of addBlock
@@ -62,8 +62,8 @@ describe('Accounts', () => {
       block.header.sequence + BigInt(1),
       account.spendingKey,
     )
-    const newBlock = await captain.chain.newBlock([], minersfee)
-    const addResult = await captain.chain.addBlock(newBlock)
+    const newBlock = await chain.newBlock([], minersfee)
+    const addResult = await chain.addBlock(newBlock)
     expect(addResult.isAdded).toBeTruthy()
 
     // TODO: This should happen automatically as a result of addBlock
@@ -80,7 +80,7 @@ describe('Accounts', () => {
     // Initialize the database and chain
     const strategy = nodeTest.strategy
     const node = nodeTest.node
-    const captain = nodeTest.captain
+    const chain = nodeTest.chain
 
     const account = await node.accounts.createAccount('test', true)
 
@@ -94,7 +94,7 @@ describe('Accounts', () => {
 
     const result = IJSON.parse(genesisBlockData) as SerializedBlock<Buffer, Buffer>
     const block = strategy._blockSerde.deserialize(result)
-    const addedBlock = await captain.chain.addBlock(block)
+    const addedBlock = await chain.addBlock(block)
     expect(addedBlock.isAdded).toBe(true)
 
     // Balance after adding the genesis block should be 0
@@ -111,8 +111,8 @@ describe('Accounts', () => {
       block.header.sequence + BigInt(1),
       account.spendingKey,
     )
-    const newBlock = await captain.chain.newBlock([], minersfee)
-    const addResult = await captain.chain.addBlock(newBlock)
+    const newBlock = await chain.newBlock([], minersfee)
+    const addResult = await chain.addBlock(newBlock)
     expect(addResult.isAdded).toBeTruthy()
 
     // Account should now have a balance of 500000000 after adding the miner's fee
@@ -149,6 +149,7 @@ describe('Accounts', () => {
     const strategy = nodeTest.strategy
     const node = nodeTest.node
     const captain = nodeTest.captain
+    const chain = nodeTest.chain
 
     const account = await node.accounts.createAccount('test', true)
 
@@ -161,7 +162,7 @@ describe('Accounts', () => {
 
     const result = IJSON.parse(genesisBlockData) as SerializedBlock<Buffer, Buffer>
     const block = strategy._blockSerde.deserialize(result)
-    const addedBlock = await captain.chain.addBlock(block)
+    const addedBlock = await chain.addBlock(block)
     expect(addedBlock.isAdded).toBe(true)
 
     // Balance after adding the genesis block should be 0
@@ -178,8 +179,8 @@ describe('Accounts', () => {
       block.header.sequence + BigInt(1),
       account.spendingKey,
     )
-    const newBlock = await captain.chain.newBlock([], minersfee)
-    const addResult = await captain.chain.addBlock(newBlock)
+    const newBlock = await chain.newBlock([], minersfee)
+    const addResult = await chain.addBlock(newBlock)
     expect(addResult.isAdded).toBeTruthy()
 
     // Account should now have a balance of 500000000 after adding the miner's fee
@@ -207,8 +208,8 @@ describe('Accounts', () => {
       block.header.sequence + BigInt(1),
       generateKey().spending_key,
     )
-    const newBlock2 = await captain.chain.newBlock([transaction], minersfee2)
-    const addResult2 = await captain.chain.addBlock(newBlock2)
+    const newBlock2 = await chain.newBlock([transaction], minersfee2)
+    const addResult2 = await chain.addBlock(newBlock2)
     expect(addResult2.isAdded).toBeTruthy()
 
     // Balance after adding the transaction that spends 2 should be 499999998
@@ -236,14 +237,14 @@ describe('Accounts', () => {
     )
 
     // Create a block with a miner's fee
-    const block1 = await useBlockFixture(nodeA.captain, async () =>
-      nodeA.captain.chain.newBlock(
+    const block1 = await useBlockFixture(nodeA.chain, async () =>
+      nodeA.chain.newBlock(
         [],
         await nodeA.strategy.createMinersFee(BigInt(0), BigInt(2), accountA.spendingKey),
       ),
     )
 
-    const addedBlock = await nodeA.captain.chain.addBlock(block1)
+    const addedBlock = await nodeA.chain.addBlock(block1)
     expect(addedBlock.isAdded).toBe(true)
 
     // Initial balance should be 500000000
@@ -253,7 +254,7 @@ describe('Accounts', () => {
       unconfirmedBalance: BigInt(500000000),
     })
 
-    const block2 = await useBlockFixture(nodeA.captain, async () => {
+    const block2 = await useBlockFixture(nodeA.chain, async () => {
       // Generate a transaction from account A to account B
       const transaction = await nodeA.accounts.createTransaction(
         nodeA.captain,
@@ -265,7 +266,7 @@ describe('Accounts', () => {
       )
 
       // Create block 2
-      return nodeA.captain.chain.newBlock(
+      return nodeA.chain.newBlock(
         [transaction],
         await nodeA.strategy.createMinersFee(
           await transaction.transactionFee(),
@@ -275,7 +276,7 @@ describe('Accounts', () => {
       )
     })
 
-    await nodeA.captain.chain.addBlock(block2)
+    await nodeA.chain.addBlock(block2)
     await nodeA.accounts.updateHead(nodeA)
 
     // Attempting to create another transaction for account A
@@ -308,33 +309,33 @@ describe('Accounts', () => {
     await nodeA.accounts.importAccount(accountB)
 
     // Create and add A1
-    const blockA1 = await useBlockFixture(nodeA.captain, async () =>
-      nodeA.captain.chain.newBlock(
+    const blockA1 = await useBlockFixture(nodeA.chain, async () =>
+      nodeA.chain.newBlock(
         [],
         await nodeA.strategy.createMinersFee(BigInt(0), BigInt(2), accountA.spendingKey),
       ),
     )
-    let addedBlock = await nodeA.captain.chain.addBlock(blockA1)
+    let addedBlock = await nodeA.chain.addBlock(blockA1)
     expect(addedBlock.isAdded).toBe(true)
 
     // Create and add B1
-    const blockB1 = await useBlockFixture(nodeB.captain, async () =>
-      nodeB.captain.chain.newBlock(
+    const blockB1 = await useBlockFixture(nodeB.chain, async () =>
+      nodeB.chain.newBlock(
         [],
         await nodeB.strategy.createMinersFee(BigInt(0), BigInt(2), accountB.spendingKey),
       ),
     )
-    addedBlock = await nodeB.captain.chain.addBlock(blockB1)
+    addedBlock = await nodeB.chain.addBlock(blockB1)
     expect(addedBlock.isAdded).toBe(true)
 
     // Create and add B2
-    const blockB2 = await useBlockFixture(nodeB.captain, async () =>
-      nodeB.captain.chain.newBlock(
+    const blockB2 = await useBlockFixture(nodeB.chain, async () =>
+      nodeB.chain.newBlock(
         [],
         await nodeB.strategy.createMinersFee(BigInt(0), BigInt(2), accountB.spendingKey),
       ),
     )
-    addedBlock = await nodeB.captain.chain.addBlock(blockB2)
+    addedBlock = await nodeB.chain.addBlock(blockB2)
     expect(addedBlock.isAdded).toBe(true)
 
     // Update account head and check all balances
@@ -354,11 +355,11 @@ describe('Accounts', () => {
     })
 
     // Copy block B1 to nodeA
-    await nodeA.captain.chain.addBlock(blockB1)
+    await nodeA.chain.addBlock(blockB1)
     await nodeA.accounts['updateHead'](nodeA)
 
     // Copy block B2 to nodeA
-    await nodeA.captain.chain.addBlock(blockB2)
+    await nodeA.chain.addBlock(blockB2)
     await nodeA.accounts['updateHead'](nodeA)
     expect(nodeA.accounts.getBalance(accountA)).toEqual({
       confirmedBalance: BigInt(0),
@@ -387,22 +388,22 @@ describe('Accounts', () => {
     await nodeB.accounts.importAccount(accountA)
 
     // Create and add Block 1
-    const block1 = await useBlockFixture(nodeB.captain, async () =>
-      nodeA.captain.chain.newBlock(
+    const block1 = await useBlockFixture(nodeB.chain, async () =>
+      nodeA.chain.newBlock(
         [],
         await nodeA.strategy.createMinersFee(BigInt(0), BigInt(2), accountA.spendingKey),
       ),
     )
-    let addedBlock = await nodeA.captain.chain.addBlock(block1)
+    let addedBlock = await nodeA.chain.addBlock(block1)
     expect(addedBlock.isAdded).toBe(true)
-    addedBlock = await nodeB.captain.chain.addBlock(block1)
+    addedBlock = await nodeB.chain.addBlock(block1)
     expect(addedBlock.isAdded).toBe(true)
 
     await nodeA.accounts['updateHead'](nodeA)
 
     // Create and add A2
     const blockA2 = await useBlockFixture(
-      nodeA.captain,
+      nodeA.chain,
       async () => {
         // Generate a transaction from account A to account B
         const transaction = await nodeA.accounts.createTransaction(
@@ -415,7 +416,7 @@ describe('Accounts', () => {
         )
 
         // Create block A2
-        return nodeA.captain.chain.newBlock(
+        return nodeA.chain.newBlock(
           [transaction],
           await nodeA.strategy.createMinersFee(
             BigInt(0),
@@ -427,27 +428,27 @@ describe('Accounts', () => {
       nodeA.accounts,
     )
 
-    addedBlock = await nodeA.captain.chain.addBlock(blockA2)
+    addedBlock = await nodeA.chain.addBlock(blockA2)
     expect(addedBlock.isAdded).toBe(true)
 
     // Create and add B2
-    const blockB2 = await useBlockFixture(nodeB.captain, async () =>
-      nodeB.captain.chain.newBlock(
+    const blockB2 = await useBlockFixture(nodeB.chain, async () =>
+      nodeB.chain.newBlock(
         [],
         await nodeB.strategy.createMinersFee(BigInt(0), BigInt(3), generateKey().spending_key),
       ),
     )
-    addedBlock = await nodeB.captain.chain.addBlock(blockB2)
+    addedBlock = await nodeB.chain.addBlock(blockB2)
     expect(addedBlock.isAdded).toBe(true)
 
     // Create and add B3
-    const blockB3 = await useBlockFixture(nodeB.captain, async () =>
-      nodeB.captain.chain.newBlock(
+    const blockB3 = await useBlockFixture(nodeB.chain, async () =>
+      nodeB.chain.newBlock(
         [],
         await nodeB.strategy.createMinersFee(BigInt(0), BigInt(4), generateKey().spending_key),
       ),
     )
-    addedBlock = await nodeB.captain.chain.addBlock(blockB3)
+    addedBlock = await nodeB.chain.addBlock(blockB3)
     expect(addedBlock.isAdded).toBe(true)
 
     // Update account head and check all balances
@@ -468,8 +469,8 @@ describe('Accounts', () => {
     })
 
     // Copy block B2 and B3 to nodeA
-    await nodeA.captain.chain.addBlock(blockB2)
-    await nodeA.captain.chain.addBlock(blockB3)
+    await nodeA.chain.addBlock(blockB2)
+    await nodeA.chain.addBlock(blockB3)
     await nodeA.accounts['updateHead'](nodeA)
 
     // B should not have confirmed coins yet because the transaction isn't on a block
@@ -502,18 +503,18 @@ describe('Accounts', () => {
 
     // Create and add Block 1
     const block1 = await useBlockFixture(
-      nodeA.captain,
+      nodeA.chain,
       async () =>
-        nodeA.captain.chain.newBlock(
+        nodeA.chain.newBlock(
           [],
           await nodeA.strategy.createMinersFee(BigInt(0), BigInt(2), accountA.spendingKey),
         ),
       nodeA.accounts,
     )
 
-    let addedBlock = await nodeA.captain.chain.addBlock(block1)
+    let addedBlock = await nodeA.chain.addBlock(block1)
     expect(addedBlock.isAdded).toBe(true)
-    addedBlock = await nodeB.captain.chain.addBlock(block1)
+    addedBlock = await nodeB.chain.addBlock(block1)
     expect(addedBlock.isAdded).toBe(true)
 
     // Generate a transaction from account A to account B
@@ -521,7 +522,7 @@ describe('Accounts', () => {
 
     // Create and add A2
     const blockA2 = await useBlockFixture(
-      nodeB.captain,
+      nodeB.chain,
       async () => {
         // Generate a transaction from account A to account B
         const transaction = await nodeB.accounts.createTransaction(
@@ -534,7 +535,7 @@ describe('Accounts', () => {
         )
 
         // Create block A2
-        return nodeA.captain.chain.newBlock(
+        return nodeA.chain.newBlock(
           [transaction],
           await nodeA.strategy.createMinersFee(
             BigInt(0),
@@ -546,27 +547,27 @@ describe('Accounts', () => {
       nodeB.accounts,
     )
 
-    addedBlock = await nodeA.captain.chain.addBlock(blockA2)
+    addedBlock = await nodeA.chain.addBlock(blockA2)
     expect(addedBlock.isAdded).toBe(true)
 
     // Create and add B2
-    const blockB2 = await useBlockFixture(nodeB.captain, async () =>
-      nodeB.captain.chain.newBlock(
+    const blockB2 = await useBlockFixture(nodeB.chain, async () =>
+      nodeB.chain.newBlock(
         [],
         await nodeB.strategy.createMinersFee(BigInt(0), BigInt(3), generateKey().spending_key),
       ),
     )
-    addedBlock = await nodeB.captain.chain.addBlock(blockB2)
+    addedBlock = await nodeB.chain.addBlock(blockB2)
     expect(addedBlock.isAdded).toBe(true)
 
     // Create and add B3
-    const blockB3 = await useBlockFixture(nodeB.captain, async () =>
-      nodeB.captain.chain.newBlock(
+    const blockB3 = await useBlockFixture(nodeB.chain, async () =>
+      nodeB.chain.newBlock(
         [],
         await nodeB.strategy.createMinersFee(BigInt(0), BigInt(4), generateKey().spending_key),
       ),
     )
-    addedBlock = await nodeB.captain.chain.addBlock(blockB3)
+    addedBlock = await nodeB.chain.addBlock(blockB3)
     expect(addedBlock.isAdded).toBe(true)
 
     // Update account head and check all balances
@@ -587,8 +588,8 @@ describe('Accounts', () => {
     })
 
     // Copy block B2 and B3 to nodeA
-    await nodeA.captain.chain.addBlock(blockB2)
-    await nodeA.captain.chain.addBlock(blockB3)
+    await nodeA.chain.addBlock(blockB2)
+    await nodeA.chain.addBlock(blockB3)
     await nodeA.accounts['updateHead'](nodeA)
 
     // A should have its original coins

--- a/ironfish/src/blockSyncer.test.ts
+++ b/ironfish/src/blockSyncer.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Target, BlockSerde } from './blockchain'
+import { Target } from './blockchain'
 import { BlockSyncer } from './blockSyncer'
 import { RangeHasher } from './merkletree'
 import { Assert } from './assert'
@@ -97,7 +97,7 @@ describe('BlockSyncer', () => {
 
   describe('RequestOneBlock', () => {
     const strategy = new TestStrategy(new RangeHasher())
-    const blockSerde = new BlockSerde(strategy)
+    const blockSerde = strategy.blockSerde
     let onRequestBlockSpy: jest.SpyInstance
     let syncer: TestBlockSyncer
     let targetSpy: jest.SpyInstance

--- a/ironfish/src/blockSyncer.ts
+++ b/ironfish/src/blockSyncer.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import Blockchain, { AddBlockResult } from './blockchain'
-import Block, { BlockSerde, SerializedBlock } from './blockchain/block'
+import Block, { SerializedBlock } from './blockchain/block'
 import { BlockHash } from './blockchain/blockheader'
 import { Transaction } from './strategy/transaction'
 import { BlockRequest } from './network/messages'
@@ -157,7 +157,8 @@ export class BlockSyncer<
   hashSerde: Serde<BlockHash, string>
   blockSerde: Serde<Block<E, H, T, SE, SH, ST>, SerializedBlock<SH, ST>>
   chain: Blockchain<E, H, T, SE, SH, ST>
-  private metrics: MetricsMonitor
+  strategy: Strategy<E, H, T, SE, SH, ST>
+  metrics: MetricsMonitor
 
   private _state: Readonly<ActionState<E, H, T, SE, SH, ST>> = {
     type: 'STOPPED',
@@ -199,11 +200,12 @@ export class BlockSyncer<
   }) {
     this.metrics = options.metrics
     this.chain = options.chain
+    this.strategy = options.strategy
     this.logger = options.logger
     this.peerNetwork = options.peerNetwork
 
     this.hashSerde = new BufferSerde(32)
-    this.blockSerde = new BlockSerde(options.strategy)
+    this.blockSerde = options.strategy.blockSerde
 
     this.blockSyncPromise = Promise.resolve()
     this.blockRequestPromise = Promise.resolve()

--- a/ironfish/src/blockchain/block.test.ts
+++ b/ironfish/src/blockchain/block.test.ts
@@ -10,7 +10,6 @@ import {
   makeBlockAfter,
 } from '../captain/testUtilities'
 import { createNodeTest } from '../testUtilities/nodeTest'
-import { BlockSerde } from './block'
 import { useAccountFixture } from '../testUtilities/fixtures'
 import { SerializedIronfishBlock } from '../strategy'
 
@@ -42,15 +41,15 @@ describe('Block', () => {
     const genesis = await nodeTest.node.seed()
     const block = await makeBlockAfter(nodeTest.captain.chain, genesis)
 
-    const serialized = nodeTest.captain.blockSerde.serialize(block)
+    const serialized = nodeTest.strategy.blockSerde.serialize(block)
     expect(serialized).toMatchObject({ header: { timestamp: expect.any(Number) } })
 
-    const deserialized = nodeTest.captain.blockSerde.deserialize(serialized)
-    expect(nodeTest.captain.blockSerde.equals(deserialized, block)).toBe(true)
+    const deserialized = nodeTest.strategy.blockSerde.deserialize(serialized)
+    expect(nodeTest.strategy.blockSerde.equals(deserialized, block)).toBe(true)
   })
 
   it('throws when deserializing invalid block', () => {
-    const serde = nodeTest.captain.blockSerde
+    const serde = nodeTest.strategy.blockSerde
 
     expect(() =>
       serde.deserialize(({ bad: 'data' } as unknown) as SerializedIronfishBlock),
@@ -59,7 +58,7 @@ describe('Block', () => {
 
   it('check block equality', () => {
     const strategy = new TestStrategy()
-    const serde = new BlockSerde(strategy)
+    const serde = strategy.blockSerde
 
     const block1 = makeFakeBlock(strategy, blockHash(4), blockHash(5), 5, 5, 9)
     const block2 = makeFakeBlock(strategy, blockHash(4), blockHash(5), 5, 5, 9)

--- a/ironfish/src/blockchain/blockchain.test.perf.ts
+++ b/ironfish/src/blockchain/blockchain.test.perf.ts
@@ -27,14 +27,14 @@ describe('Blockchain', () => {
     for (let i = 0; i < 100; ++i) {
       console.log(`Creating Blocks ${i}`)
 
-      const blockA = await useBlockFixture(nodeA.captain, async () =>
+      const blockA = await useBlockFixture(nodeA.chain, async () =>
         nodeA.captain.chain.newBlock(
           [],
           await nodeA.strategy.createMinersFee(BigInt(0), BigInt(2), accountA.spendingKey),
         ),
       )
 
-      const blockB = await useBlockFixture(nodeB.captain, async () =>
+      const blockB = await useBlockFixture(nodeB.chain, async () =>
         nodeB.captain.chain.newBlock(
           [],
           await nodeB.strategy.createMinersFee(BigInt(0), BigInt(2), accountB.spendingKey),

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -296,45 +296,33 @@ describe('Blockchain', () => {
     const { node: nodeB } = await nodeTest.createSetup()
     await Promise.all([nodeA.seed(), nodeB.seed()])
 
-    const notes = await nodeA.captain.chain.notes.size()
-    const nullifiers = await nodeB.captain.chain.nullifiers.size()
+    const notes = await nodeA.chain.notes.size()
+    const nullifiers = await nodeB.chain.nullifiers.size()
 
     const accountA = await useAccountFixture(nodeA.accounts, 'accountA')
     const accountB = await useAccountFixture(nodeB.accounts, 'accountB')
 
-    const blockA1 = await useBlockFixture(nodeA.captain, async () =>
-      nodeA.captain.chain.newBlock(
+    const blockA1 = await useBlockFixture(nodeA.chain, async () =>
+      nodeA.chain.newBlock(
         [],
-        await nodeA.captain.chain.strategy.createMinersFee(
-          BigInt(0),
-          BigInt(2),
-          accountA.spendingKey,
-        ),
+        await nodeA.chain.strategy.createMinersFee(BigInt(0), BigInt(2), accountA.spendingKey),
       ),
     )
 
-    const blockB1 = await useBlockFixture(nodeB.captain, async () =>
-      nodeB.captain.chain.newBlock(
+    const blockB1 = await useBlockFixture(nodeB.chain, async () =>
+      nodeB.chain.newBlock(
         [],
-        await nodeB.captain.chain.strategy.createMinersFee(
-          BigInt(0),
-          BigInt(2),
-          accountB.spendingKey,
-        ),
+        await nodeB.chain.strategy.createMinersFee(BigInt(0), BigInt(2), accountB.spendingKey),
       ),
     )
 
-    await nodeA.captain.chain.addBlock(blockA1)
-    await nodeB.captain.chain.addBlock(blockB1)
+    await nodeA.chain.addBlock(blockA1)
+    await nodeB.chain.addBlock(blockB1)
 
-    const blockB2 = await useBlockFixture(nodeB.captain, async () =>
-      nodeB.captain.chain.newBlock(
+    const blockB2 = await useBlockFixture(nodeB.chain, async () =>
+      nodeB.chain.newBlock(
         [],
-        await nodeB.captain.chain.strategy.createMinersFee(
-          BigInt(0),
-          BigInt(3),
-          accountB.spendingKey,
-        ),
+        await nodeB.chain.strategy.createMinersFee(BigInt(0), BigInt(3), accountB.spendingKey),
       ),
     )
 
@@ -349,35 +337,35 @@ describe('Blockchain', () => {
     expect(minersFeeB2.notesLength()).toBe(1)
 
     // Check nodeA's chain has notes from blockA1
-    expect(await nodeA.captain.chain.notes.size()).toBe(notes + 1)
-    expect(await nodeA.captain.chain.nullifiers.size()).toBe(nullifiers)
-    const addedNoteA1 = (await nodeA.captain.chain.notes.getLeaf(notes)).element
+    expect(await nodeA.chain.notes.size()).toBe(notes + 1)
+    expect(await nodeA.chain.nullifiers.size()).toBe(nullifiers)
+    const addedNoteA1 = (await nodeA.chain.notes.getLeaf(notes)).element
     expect(minersFeeA1.getNote(0).serialize().equals(addedNoteA1.serialize())).toBe(true)
 
     // Check nodeB's chain has notes from blockB1
-    expect(await nodeB.captain.chain.notes.size()).toBe(notes + 1)
-    expect(await nodeB.captain.chain.nullifiers.size()).toBe(nullifiers)
-    let addedNoteB1 = (await nodeB.captain.chain.notes.getLeaf(notes)).element
+    expect(await nodeB.chain.notes.size()).toBe(notes + 1)
+    expect(await nodeB.chain.nullifiers.size()).toBe(nullifiers)
+    let addedNoteB1 = (await nodeB.chain.notes.getLeaf(notes)).element
     expect(minersFeeB1.getNote(0).serialize().equals(addedNoteB1.serialize())).toBe(true)
 
     // Now add blockB2 to nodeB
-    await nodeB.captain.chain.addBlock(blockB2)
+    await nodeB.chain.addBlock(blockB2)
 
     // Check nodeB's chain has notes from blockB2
-    expect(await nodeB.captain.chain.notes.size()).toBe(notes + 2)
-    expect(await nodeB.captain.chain.nullifiers.size()).toBe(nullifiers)
-    let addedNoteB2 = (await nodeB.captain.chain.notes.getLeaf(notes + 1)).element
+    expect(await nodeB.chain.notes.size()).toBe(notes + 2)
+    expect(await nodeB.chain.nullifiers.size()).toBe(nullifiers)
+    let addedNoteB2 = (await nodeB.chain.notes.getLeaf(notes + 1)).element
     expect(minersFeeB2.getNote(0).serialize().equals(addedNoteB2.serialize())).toBe(true)
 
     // Now cause reorg on nodeA
-    await nodeA.captain.chain.addBlock(blockB1)
-    await nodeA.captain.chain.addBlock(blockB2)
+    await nodeA.chain.addBlock(blockB1)
+    await nodeA.chain.addBlock(blockB2)
 
     // Check nodeA's chain has removed blockA1 notes and added blockB1 + blockB2 note
-    expect(await nodeA.captain.chain.notes.size()).toBe(notes + 2)
-    expect(await nodeA.captain.chain.nullifiers.size()).toBe(nullifiers)
-    addedNoteB1 = (await nodeA.captain.chain.notes.getLeaf(notes)).element
-    addedNoteB2 = (await nodeA.captain.chain.notes.getLeaf(notes + 1)).element
+    expect(await nodeA.chain.notes.size()).toBe(notes + 2)
+    expect(await nodeA.chain.nullifiers.size()).toBe(nullifiers)
+    addedNoteB1 = (await nodeA.chain.notes.getLeaf(notes)).element
+    addedNoteB2 = (await nodeA.chain.notes.getLeaf(notes + 1)).element
     expect(minersFeeB1.getNote(0).serialize().equals(addedNoteB1.serialize())).toBe(true)
     expect(minersFeeB2.getNote(0).serialize().equals(addedNoteB2.serialize())).toBe(true)
   }, 20000)

--- a/ironfish/src/captain/captain.ts
+++ b/ironfish/src/captain/captain.ts
@@ -39,7 +39,7 @@ export class Captain<
     this.metrics = metrics
     this.strategy = chain.strategy
     this.chain = chain
-    this.blockSerde = new BlockSerde(chain.strategy)
+    this.blockSerde = chain.strategy.blockSerde
     this.workerPool = workerPool
     this.logger = logger
   }

--- a/ironfish/src/captain/testUtilities/helpers/anchorChain.ts
+++ b/ironfish/src/captain/testUtilities/helpers/anchorChain.ts
@@ -341,21 +341,21 @@ export async function makeBlockWithTransaction(
   from: Account,
   to: Account,
 ): Promise<IronfishBlock> {
-  const head = await node.captain.chain.getHeaviestHead()
+  const head = await node.chain.getHeaviestHead()
   Assert.isNotNull(head, 'No genesis block. Call node.seed() first')
   const sequence = head.sequence
 
   const block1 = await useMinerBlockFixture(
-    node.captain,
+    node.chain,
     sequence + BigInt(1),
     from,
     node.accounts,
   )
 
-  await node.captain.chain.addBlock(block1)
+  await node.chain.addBlock(block1)
   await node.accounts.updateHead(node)
 
-  const block2 = await useBlockFixture(node.captain, async () => {
+  const block2 = await useBlockFixture(node.chain, async () => {
     const transaction = await node.accounts.createTransaction(
       node.captain,
       from,
@@ -365,9 +365,9 @@ export async function makeBlockWithTransaction(
       to.publicAddress,
     )
 
-    return node.captain.chain.newBlock(
+    return node.chain.newBlock(
       [transaction],
-      await node.captain.chain.strategy.createMinersFee(
+      await node.chain.strategy.createMinersFee(
         await transaction.transactionFee(),
         sequence + BigInt(2),
         from.spendingKey,

--- a/ironfish/src/captain/testUtilities/matchers/blockchain.ts
+++ b/ironfish/src/captain/testUtilities/matchers/blockchain.ts
@@ -8,7 +8,6 @@ import { zip } from 'lodash'
 import Blockchain from '../../../blockchain'
 import Block from '../../../blockchain/block'
 import { BlockHash, Sequence } from '../../../blockchain/blockheader'
-import { BlockSerde } from '../../../blockchain/block'
 import { Nullifier } from '../../../blockchain/nullifiers'
 import { SerializedTestTransaction, TestTransaction } from '../strategy'
 import makeError from './makeError'
@@ -94,7 +93,7 @@ expect.extend({
     self: Block<string, string, TestTransaction, string, string, SerializedTestTransaction>,
     other: Block<string, string, TestTransaction, string, string, SerializedTestTransaction>,
   ): jest.CustomMatcherResult {
-    const serde = new BlockSerde(self.header.strategy)
+    const serde = self.header.strategy.blockSerde
     let error: string | null = null
     if (!serde.equals(self, other)) {
       const diffString = diff(self, other)

--- a/ironfish/src/captain/testUtilities/strategy/TestStrategy.ts
+++ b/ironfish/src/captain/testUtilities/strategy/TestStrategy.ts
@@ -12,6 +12,7 @@ import { TestTransactionSerde } from './TestTransactionSerde'
 import { SerializedTestTransaction } from './SerializedTypes'
 import { TestVerifier } from './testVerifier'
 import { TestBlockchain } from '../helpers'
+import { BlockSerde } from '../../../blockchain'
 
 /**
  * Very basic strategy for testing blockchain code. Models notes and hashes
@@ -24,9 +25,19 @@ export class TestStrategy
   _noteHasher: ConcatHasher
   _nullifierHasher: NullifierHasher
 
+  _blockSerde: BlockSerde<
+    string,
+    string,
+    TestTransaction<string>,
+    string,
+    string,
+    SerializedTestTransaction<string>
+  >
+
   constructor(noteHasher = new ConcatHasher()) {
     this._noteHasher = noteHasher
     this._nullifierHasher = new NullifierHasher()
+    this._blockSerde = new BlockSerde(this)
   }
 
   createVerifier(chain: TestBlockchain): TestVerifier {
@@ -43,6 +54,17 @@ export class TestStrategy
 
   transactionSerde(): TestTransactionSerde {
     return new TestTransactionSerde()
+  }
+
+  get blockSerde(): BlockSerde<
+    string,
+    string,
+    TestTransaction<string>,
+    string,
+    string,
+    SerializedTestTransaction<string>
+  > {
+    return this._blockSerde
   }
 
   /**

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { default as Block, BlockSerde, SerializedBlock } from '../blockchain/block'
+import { default as Block, SerializedBlock } from '../blockchain/block'
 import Strategy from '../strategy/strategy'
 import { Transaction, Spend } from '../strategy/transaction'
 import { isNewBlockPayload, isNewTransactionPayload } from '../network/messages'
@@ -49,7 +49,7 @@ export class Verifier<
   constructor(chain: Blockchain<E, H, T, SE, SH, ST>) {
     this.strategy = chain.strategy
     this.chain = chain
-    this.blockSerde = new BlockSerde(chain.strategy)
+    this.blockSerde = chain.strategy.blockSerde
     this.hashSerde = chain.blockHashSerde
   }
 

--- a/ironfish/src/network/messageRouters/fireAndForget.test.ts
+++ b/ironfish/src/network/messageRouters/fireAndForget.test.ts
@@ -5,7 +5,7 @@
 jest.mock('ws')
 
 import ws from 'ws'
-import { mockCaptain, mockNode } from '../../testUtilities/mocks'
+import { mockChain, mockNode, mockStrategy } from '../../testUtilities/mocks'
 import { PeerNetwork, RoutingStyle } from '../peerNetwork'
 import { PeerManager } from '../peers/peerManager'
 import { mockPrivateIdentity, mockLocalPeer, getConnectedPeer } from '../testUtilities'
@@ -51,7 +51,8 @@ describe('FireAndForget Router', () => {
       agent: 'sdk/1/cli',
       webSocket: ws,
       node: mockNode(),
-      captain: mockCaptain(),
+      chain: mockChain(),
+      strategy: mockStrategy(),
     })
 
     const fireAndForgetMock = jest.fn(async () => {})

--- a/ironfish/src/network/messageRouters/gossip.test.ts
+++ b/ironfish/src/network/messageRouters/gossip.test.ts
@@ -12,7 +12,7 @@ import { PeerNetwork, RoutingStyle } from '../peerNetwork'
 import { GossipRouter } from './gossip'
 import { PeerManager } from '../peers/peerManager'
 import { mockLocalPeer, getConnectedPeer } from '../testUtilities'
-import { mockCaptain, mockNode } from '../../testUtilities/mocks'
+import { mockChain, mockNode, mockStrategy } from '../../testUtilities/mocks'
 
 jest.useFakeTimers()
 
@@ -109,7 +109,8 @@ describe('Gossip Router', () => {
       agent: 'sdk/1/cli',
       webSocket: ws,
       node: mockNode(),
-      captain: mockCaptain(),
+      chain: mockChain(),
+      strategy: mockStrategy(),
     })
 
     const gossipMock = jest.fn(async () => {})
@@ -133,7 +134,8 @@ describe('Gossip Router', () => {
       agent: 'sdk/1/cli',
       webSocket: ws,
       node: mockNode(),
-      captain: mockCaptain(),
+      chain: mockChain(),
+      strategy: mockStrategy(),
     })
 
     const gossipMock = jest.fn(async () => {})

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -12,7 +12,7 @@ import { PeerNetwork, RoutingStyle } from './peerNetwork'
 import { getConnectedPeer, mockPrivateIdentity } from './testUtilities'
 import { Assert } from '../assert'
 import { DisconnectingMessage } from './messages'
-import { mockNode, mockCaptain } from '../testUtilities/mocks'
+import { mockNode, mockStrategy, mockChain } from '../testUtilities/mocks'
 
 jest.useFakeTimers()
 
@@ -22,7 +22,8 @@ it('Closes the PeerManager when close is called', () => {
     agent: 'sdk/1/cli',
     webSocket: ws,
     node: mockNode(),
-    captain: mockCaptain(),
+    chain: mockChain(),
+    strategy: mockStrategy(),
   })
 
   const stopSpy = jest.spyOn(peerNetwork.peerManager, 'stop')
@@ -36,7 +37,8 @@ it('Registers a handler', () => {
     agent: 'sdk/1/cli',
     webSocket: ws,
     node: mockNode(),
-    captain: mockCaptain(),
+    chain: mockChain(),
+    strategy: mockStrategy(),
   })
 
   peerNetwork.registerHandler(
@@ -55,7 +57,8 @@ it('ignores a message if validation fails', async () => {
     agent: 'sdk/1/cli',
     webSocket: ws,
     node: mockNode(),
-    captain: mockCaptain(),
+    chain: mockChain(),
+    strategy: mockStrategy(),
   })
 
   const handlerMock = jest.fn(() => {})
@@ -79,7 +82,8 @@ it('changes isReady when peers connect', () => {
     agent: 'sdk/1/cli',
     webSocket: ws,
     node: mockNode(),
-    captain: mockCaptain(),
+    chain: mockChain(),
+    strategy: mockStrategy(),
     minPeers: 1,
   })
 
@@ -113,7 +117,8 @@ it('rejects websocket connections when at max peers', () => {
     agent: 'sdk/1/cli',
     webSocket: wsActual,
     node: mockNode(),
-    captain: mockCaptain(),
+    chain: mockChain(),
+    strategy: mockStrategy(),
     listen: true,
     port: 0,
     minPeers: 1,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -119,7 +119,8 @@ export class IronfishNode {
       webSocket: webSocket,
       webRtc: webRtc,
       node: this,
-      captain: captain,
+      chain: chain,
+      strategy: strategy,
     })
 
     this.syncer = new BlockSyncer({

--- a/ironfish/src/rpc/routes/chain/getBlock.test.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.test.ts
@@ -34,12 +34,11 @@ describe('Route chain.getBlock', () => {
 
   it('responds with a block', async () => {
     const node = routeTest.node
-    const captain = routeTest.node.captain
     const chain = routeTest.node.captain.chain
 
     await node.seed()
 
-    const block = await useMinerBlockFixture(captain, BigInt(2))
+    const block = await useMinerBlockFixture(chain, BigInt(2))
     const addResult = await chain.addBlock(block)
     expect(addResult).toMatchObject({ isAdded: true })
 

--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -188,7 +188,7 @@ router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
     })
 
     // TODO(IRO-289) We need a better way to either serialize directly to buffer or use CBOR
-    const blockBuffer = Buffer.from(JSON.stringify(node.captain.blockSerde.serialize(block)))
+    const blockBuffer = Buffer.from(JSON.stringify(node.strategy.blockSerde.serialize(block)))
 
     request.end({
       blockIdentifier: {

--- a/ironfish/src/strategy/index.ts
+++ b/ironfish/src/strategy/index.ts
@@ -435,6 +435,17 @@ export class IronfishStrategy
     return new TransactionSerde(this.workerPool)
   }
 
+  get blockSerde(): BlockSerde<
+    IronfishNoteEncrypted,
+    WasmNoteEncryptedHash,
+    IronfishTransaction,
+    SerializedWasmNoteEncrypted,
+    SerializedWasmNoteEncryptedHash,
+    SerializedTransaction
+  > {
+    return this._blockSerde
+  }
+
   hashBlockHeader(serializedHeader: Buffer): BlockHash {
     return hashBlockHeader(serializedHeader)
   }

--- a/ironfish/src/strategy/strategy.ts
+++ b/ironfish/src/strategy/strategy.ts
@@ -8,7 +8,7 @@ import { BlockHash } from '../blockchain/blockheader'
 import Transaction from './transaction'
 import Serde, { JsonSerializable } from '../serde'
 import Verifier from '../consensus/verifier'
-import Blockchain from '../blockchain'
+import Blockchain, { BlockSerde } from '../blockchain'
 
 export { default as Transaction, Spend } from './transaction'
 
@@ -47,6 +47,11 @@ export default interface Strategy<
    * Get the object that can serialize and deserialize lists of transactions.
    */
   transactionSerde(): Serde<T, ST>
+
+  /**
+   * Get the object that can serialize and deserialize blocks
+   */
+  readonly blockSerde: BlockSerde<E, H, T, SE, SH, ST>
 
   /**
    * Given the serialized bytes of a block header, return a 32-byte hash of that block.

--- a/ironfish/src/testUtilities/fixtures.ts
+++ b/ironfish/src/testUtilities/fixtures.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Accounts, Account } from '../account'
 import { IJSON } from '../serde'
-import { IronfishBlock, IronfishCaptain, SerializedIronfishBlock } from '../strategy'
+import { IronfishBlock, IronfishBlockchain, SerializedIronfishBlock } from '../strategy'
 import fs from 'fs'
 import path from 'path'
 import { getCurrentTestPath } from './utils'
@@ -151,7 +151,7 @@ export async function restoreBlockFixtureToAccounts(
  * caches that in the fixtures folder next to the current test
  */
 export async function useBlockFixture(
-  captain: IronfishCaptain,
+  chain: IronfishBlockchain,
   generate: FixtureGenerate<IronfishBlock>,
   addTransactionsTo?: Accounts,
 ): Promise<IronfishBlock> {
@@ -162,10 +162,10 @@ export async function useBlockFixture(
       }
     },
     serialize: (block: IronfishBlock): SerializedIronfishBlock => {
-      return captain.blockSerde.serialize(block)
+      return chain.strategy.blockSerde.serialize(block)
     },
     deserialize: (serialized: SerializedIronfishBlock): IronfishBlock => {
-      return captain.blockSerde.deserialize(serialized)
+      return chain.strategy.blockSerde.deserialize(serialized)
     },
   })
 }
@@ -174,7 +174,7 @@ export async function useBlockFixture(
  * Generates a block with a miners fee transaction on the current chain state
  */
 export async function useMinerBlockFixture(
-  captain: IronfishCaptain,
+  chain: IronfishBlockchain,
   sequence: bigint,
   account?: Account,
   addTransactionsTo?: Accounts,
@@ -182,11 +182,11 @@ export async function useMinerBlockFixture(
   const spendingKey = account ? account.spendingKey : generateKey().spending_key
 
   return await useBlockFixture(
-    captain,
+    chain,
     async () =>
-      captain.chain.newBlock(
+      chain.newBlock(
         [],
-        await captain.chain.strategy.createMinersFee(BigInt(0), sequence, spendingKey),
+        await chain.strategy.createMinersFee(BigInt(0), sequence, spendingKey),
       ),
     addTransactionsTo,
   )

--- a/ironfish/src/testUtilities/mocks.ts
+++ b/ironfish/src/testUtilities/mocks.ts
@@ -15,6 +15,14 @@ export function mockAccounts(): any {
   }
 }
 
+export function mockChain(): any {
+  return {}
+}
+
+export function mockStrategy(): any {
+  return {}
+}
+
 export function mockNode(): any {
   return {
     accounts: mockAccounts(),


### PR DESCRIPTION
There shouldn't be so many references to a serializer that should be once. This will be deleted when we move over to binaryh based serialization using bufio in the future, anyway.

 * Add strategy.blockSerde
 * Remove all instantiation of BlockSerde except for one in strategy
 * Remove captain from passing into PeerNetwork, and now pass in Strategy and Chain to get blockSerde
 * Remove lots of now invalid useds of Captain across the codebase