### PR TITLE
Verify transactions in a worker thread

### DIFF
--- a/ironfish/src/account/accounts.test.slow.ts
+++ b/ironfish/src/account/accounts.test.slow.ts
@@ -203,7 +203,7 @@ describe('Accounts', () => {
 
     // Create a block with a miner's fee
     const minersfee2 = await strategy.createMinersFee(
-      transaction.transactionFee(),
+      await transaction.transactionFee(),
       block.header.sequence + BigInt(1),
       generateKey().spending_key,
     )
@@ -268,7 +268,7 @@ describe('Accounts', () => {
       return nodeA.captain.chain.newBlock(
         [transaction],
         await nodeA.strategy.createMinersFee(
-          transaction.transactionFee(),
+          await transaction.transactionFee(),
           BigInt(3),
           generateKey().spending_key,
         ),

--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -20,7 +20,7 @@ describe('Accounts', () => {
     Assert.isNotNull(genesis)
 
     // G -> A1
-    const blockA1 = makeBlockAfter(chain, genesis)
+    const blockA1 = await makeBlockAfter(chain, genesis)
     await chain.addBlock(blockA1)
 
     await node.accounts.updateHead(node)
@@ -28,7 +28,7 @@ describe('Accounts', () => {
     expect(getTransactionsSpy).toBeCalledTimes(2)
 
     // G -> A1 -> A2
-    const blockA2 = makeBlockAfter(chain, blockA1)
+    const blockA2 = await makeBlockAfter(chain, blockA1)
     await chain.addBlock(blockA2)
 
     await node.accounts.updateHead(node)
@@ -38,9 +38,9 @@ describe('Accounts', () => {
     // Add 3 more on a heavier fork. Chain A should be removed first, then chain B added
     // G -> A1 -> A2
     //   -> B1 -> B2 -> B3
-    const blockB1 = makeBlockAfter(chain, genesis)
-    const blockB2 = makeBlockAfter(chain, blockB1)
-    const blockB3 = makeBlockAfter(chain, blockB2)
+    const blockB1 = await makeBlockAfter(chain, genesis)
+    const blockB2 = await makeBlockAfter(chain, blockB1)
+    const blockB3 = await makeBlockAfter(chain, blockB2)
     await chain.addBlock(blockB1)
     await chain.addBlock(blockB2)
     await chain.addBlock(blockB3)

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -681,8 +681,11 @@ export class Accounts {
     // Post the transaction and we're done!
     const transactionPosted = new IronfishTransaction(
       Buffer.from(
-        (await transaction.post(sender.spendingKey, null, transactionFee)).serialize(),
+        (
+          await transaction.post(sender.spendingKey, null, transactionFee, captain.workerPool)
+        ).serialize(),
       ),
+      captain.workerPool,
     )
 
     return transactionPosted

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -12,6 +12,7 @@ import {
   StringEncoding,
 } from '../storage'
 import { IronfishTransaction } from '../strategy'
+import { WorkerPool } from '../workerPool'
 
 export type Account = {
   name: string
@@ -43,6 +44,7 @@ export type AccountsDBMeta = {
 
 export class AccountsDB {
   database: IDatabase
+  workerPool: WorkerPool
 
   accounts: IDatabaseStore<{ key: string; value: Account }>
 
@@ -68,8 +70,9 @@ export class AccountsDB {
     }
   }>
 
-  constructor({ database }: { database: IDatabase }) {
+  constructor({ database, workerPool }: { database: IDatabase; workerPool: WorkerPool }) {
     this.database = database
+    this.workerPool = workerPool
 
     this.meta = database.addStore<{
       key: keyof AccountsDBMeta
@@ -206,7 +209,7 @@ export class AccountsDB {
     for await (const value of this.transactions.getAllValuesIter()) {
       const deserialized = {
         ...value,
-        transaction: new IronfishTransaction(value.transaction),
+        transaction: new IronfishTransaction(value.transaction, this.workerPool),
       }
 
       map.set(deserialized.transaction.transactionHash(), deserialized)

--- a/ironfish/src/blockchain/block.test.ts
+++ b/ironfish/src/blockchain/block.test.ts
@@ -40,7 +40,7 @@ describe('Block', () => {
     nodeTest.strategy.disableMiningReward()
 
     const genesis = await nodeTest.node.seed()
-    const block = makeBlockAfter(nodeTest.captain.chain, genesis)
+    const block = await makeBlockAfter(nodeTest.captain.chain, genesis)
 
     const serialized = nodeTest.captain.blockSerde.serialize(block)
     expect(serialized).toMatchObject({ header: { timestamp: expect.any(Number) } })

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -21,10 +21,10 @@ describe('Blockchain', () => {
     // G -> A1 -> A2
     //         -> B2 -> B3
 
-    const blockA1 = makeBlockAfter(chain, genesis)
-    const blockA2 = makeBlockAfter(chain, blockA1)
-    const blockB2 = makeBlockAfter(chain, blockA1)
-    const blockB3 = makeBlockAfter(chain, blockB2)
+    const blockA1 = await makeBlockAfter(chain, genesis)
+    const blockA2 = await makeBlockAfter(chain, blockA1)
+    const blockB2 = await makeBlockAfter(chain, blockA1)
+    const blockB3 = await makeBlockAfter(chain, blockB2)
 
     // Added in a specific order for the test below
     // so that Genesis, A1, A2, have the same graph,
@@ -88,13 +88,13 @@ describe('Blockchain', () => {
     //               -> C3 -> C4
     //                     -> D4
 
-    const blockA1 = makeBlockAfter(chain, genesis)
-    const blockA2 = makeBlockAfter(chain, blockA1)
-    const blockB2 = makeBlockAfter(chain, blockA1)
-    const blockB3 = makeBlockAfter(chain, blockB2)
-    const blockC3 = makeBlockAfter(chain, blockB2)
-    const blockC4 = makeBlockAfter(chain, blockC3)
-    const blockD4 = makeBlockAfter(chain, blockC3)
+    const blockA1 = await makeBlockAfter(chain, genesis)
+    const blockA2 = await makeBlockAfter(chain, blockA1)
+    const blockB2 = await makeBlockAfter(chain, blockA1)
+    const blockB3 = await makeBlockAfter(chain, blockB2)
+    const blockC3 = await makeBlockAfter(chain, blockB2)
+    const blockC4 = await makeBlockAfter(chain, blockC3)
+    const blockD4 = await makeBlockAfter(chain, blockC3)
 
     const { isAdded: isAddedB3 } = await chain.addBlock(blockB3)
     const { isAdded: isAddedA2 } = await chain.addBlock(blockA2)
@@ -154,10 +154,10 @@ describe('Blockchain', () => {
     // G -> A1 -> A2
     //   -> B1 -> B2
 
-    const blockA1 = makeBlockAfter(chain, genesis)
-    const blockA2 = makeBlockAfter(chain, blockA1)
-    const blockB1 = makeBlockAfter(chain, genesis)
-    const blockB2 = makeBlockAfter(chain, blockB1)
+    const blockA1 = await makeBlockAfter(chain, genesis)
+    const blockA2 = await makeBlockAfter(chain, blockA1)
+    const blockB1 = await makeBlockAfter(chain, genesis)
+    const blockB2 = await makeBlockAfter(chain, blockB1)
 
     const { isAdded: isAddedA1 } = await chain.addBlock(blockA1)
     const { isAdded: isAddedA2 } = await chain.addBlock(blockA2)
@@ -218,7 +218,7 @@ describe('Blockchain', () => {
     expect(blocks[0].hash.equals(genesis.hash)).toBe(true)
 
     // Add another block
-    const block = makeBlockAfter(chain, genesis)
+    const block = await makeBlockAfter(chain, genesis)
     await chain.addBlock(block)
 
     // iterate from genesis -> block
@@ -241,13 +241,13 @@ describe('Blockchain', () => {
     //               -> C3 -> C4
     //                     -> D4
 
-    const blockA1 = makeBlockAfter(chain, genesis)
-    const blockA2 = makeBlockAfter(chain, blockA1)
-    const blockB2 = makeBlockAfter(chain, blockA1)
-    const blockB3 = makeBlockAfter(chain, blockB2)
-    const blockC3 = makeBlockAfter(chain, blockB2)
-    const blockC4 = makeBlockAfter(chain, blockC3)
-    const blockD4 = makeBlockAfter(chain, blockC3)
+    const blockA1 = await makeBlockAfter(chain, genesis)
+    const blockA2 = await makeBlockAfter(chain, blockA1)
+    const blockB2 = await makeBlockAfter(chain, blockA1)
+    const blockB3 = await makeBlockAfter(chain, blockB2)
+    const blockC3 = await makeBlockAfter(chain, blockB2)
+    const blockC4 = await makeBlockAfter(chain, blockC3)
+    const blockD4 = await makeBlockAfter(chain, blockC3)
 
     await addBlocksShuffle(chain, [
       blockA1,

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1496,7 +1496,7 @@ export class Blockchain<
           target,
           0,
           timestamp,
-          minersFee.transactionFee(),
+          await minersFee.transactionFee(),
           graffiti,
         )
 
@@ -1504,7 +1504,7 @@ export class Blockchain<
         if (!previousBlockHash.equals(GENESIS_BLOCK_PREVIOUS)) {
           // since we're creating a block that hasn't been mined yet, don't
           // verify target because it'll always fail target check here
-          const verification = this.verifier.verifyBlock(block, { verifyTarget: false })
+          const verification = await this.verifier.verifyBlock(block, { verifyTarget: false })
 
           if (verification.valid !== Validity.Yes) {
             throw new Error(verification.reason)

--- a/ironfish/src/captain/captain.ts
+++ b/ironfish/src/captain/captain.ts
@@ -15,6 +15,7 @@ import { BlockSyncer, BlockSyncerChainStatus } from './blockSyncer'
 import { IDatabase } from '../storage'
 import Blockchain from '../blockchain'
 import { Identity } from '../network'
+import { WorkerPool } from '../workerPool'
 
 // Exports used in testUtilities
 export { BlockSyncer, BlockSyncerChainStatus, BlocksResponse }
@@ -75,6 +76,10 @@ export class Captain<
    */
   blockSerde: BlockSerde<E, H, T, SE, SH, ST>
   /**
+   * Pool for threaded operations
+   */
+  workerPool: WorkerPool
+  /**
    * Logger instance used in place of console logs
    */
   logger: Logger
@@ -105,6 +110,7 @@ export class Captain<
    */
   private constructor(
     chain: Blockchain<E, H, T, SE, SH, ST>,
+    workerPool: WorkerPool,
     logger: Logger,
     metrics: MetricsMonitor,
   ) {
@@ -113,6 +119,7 @@ export class Captain<
     this.chain = chain
     this.blockSyncer = new BlockSyncer(this, logger)
     this.blockSerde = new BlockSerde(chain.strategy)
+    this.workerPool = workerPool
     this.logger = logger
   }
 
@@ -139,6 +146,7 @@ export class Captain<
     ST
   >(
     db: IDatabase,
+    workerPool: WorkerPool,
     strategy: Strategy<E, H, T, SE, SH, ST>,
     chain?: Blockchain<E, H, T, SE, SH, ST>,
     logger: Logger = createRootLogger(),
@@ -147,7 +155,7 @@ export class Captain<
     logger = logger.withTag('captain')
     metrics = metrics || new MetricsMonitor(logger)
     chain = chain || (await Blockchain.new(db, strategy, logger, metrics))
-    return new Captain(chain, logger, metrics)
+    return new Captain(chain, workerPool, logger, metrics)
   }
 
   /**

--- a/ironfish/src/captain/testUtilities/helpers/anchorChain.ts
+++ b/ironfish/src/captain/testUtilities/helpers/anchorChain.ts
@@ -286,10 +286,10 @@ export async function makeChain(
  * @param chain the chain is not used, only the verifier and strategy from the chain
  * @param after the block the created block should be after
  */
-export function makeBlockAfter(
+export async function makeBlockAfter(
   chain: IronfishBlockchain,
   after: IronfishBlockHeader | IronfishBlock,
-): IronfishBlock {
+): Promise<IronfishBlock> {
   if (after instanceof Block) {
     after = after.header
   }
@@ -324,7 +324,7 @@ export function makeBlockAfter(
 
   const block = new Block(header, [])
 
-  Assert.isTrue(chain.verifier.verifyBlock(block).valid === 1)
+  Assert.isTrue((await chain.verifier.verifyBlock(block)).valid === 1)
   return block
 }
 
@@ -368,7 +368,7 @@ export async function makeBlockWithTransaction(
     return node.captain.chain.newBlock(
       [transaction],
       await node.captain.chain.strategy.createMinersFee(
-        transaction.transactionFee(),
+        await transaction.transactionFee(),
         sequence + BigInt(2),
         from.spendingKey,
       ),

--- a/ironfish/src/captain/testUtilities/helpers/captain.ts
+++ b/ironfish/src/captain/testUtilities/helpers/captain.ts
@@ -21,6 +21,7 @@ import {
 import { SerializedTestTransaction, TestStrategy, TestTransaction } from '../strategy'
 import { makeDbName } from './storage'
 import { MemPool } from '../../../memPool'
+import { WorkerPool } from '../../../workerPool'
 
 export type TestCaptain = Captain<
   string,
@@ -74,10 +75,11 @@ export type TestBlock = Block<
 export async function makeInitialTestCaptain(
   strategy: TestStrategy,
   dbPrefix: string,
+  workerPool: WorkerPool = new WorkerPool(),
 ): Promise<TestCaptain> {
   const db = makeDb(dbPrefix)
   const chain = await makeChainInitial(strategy, db)
-  return await Captain.new(db, strategy, chain)
+  return await Captain.new(db, workerPool, strategy, chain)
 }
 
 /**
@@ -87,11 +89,12 @@ export async function makeInitialTestCaptain(
 export async function makeCaptain(
   strategy: TestStrategy,
   dbPrefix?: string,
+  workerPool: WorkerPool = new WorkerPool(),
 ): Promise<TestCaptain> {
   if (!dbPrefix) dbPrefix = makeDbName()
   const db = makeDb(dbPrefix)
   const chain = await makeChain(strategy, db)
-  return await Captain.new(db, strategy, chain)
+  return await Captain.new(db, workerPool, strategy, chain)
 }
 
 /**
@@ -104,6 +107,7 @@ export async function makeCaptainSyncable(
   strategy: TestStrategy,
   dbPrefix?: string,
   addExtraBlocks = true,
+  workerPool = new WorkerPool(),
 ): Promise<TestCaptain> {
   if (!dbPrefix) dbPrefix = makeDbName()
 
@@ -119,7 +123,7 @@ export async function makeCaptainSyncable(
   }
   await dbFull.close()
 
-  return await Captain.new(db, strategy, chain)
+  return await Captain.new(db, workerPool, strategy, chain)
 }
 
 /**

--- a/ironfish/src/captain/testUtilities/strategy/TestTransaction.ts
+++ b/ironfish/src/captain/testUtilities/strategy/TestTransaction.ts
@@ -27,11 +27,11 @@ export class TestTransaction<H = string> implements Transaction<string, H> {
     this.isValid = isValid
   }
 
-  verify(): VerificationResult {
-    return {
+  verify(): Promise<VerificationResult> {
+    return Promise.resolve({
       valid: this.isValid ? Validity.Yes : Validity.No,
       reason: this.isValid ? undefined : VerificationResultReason.INVALID_TRANSACTION_PROOF,
-    }
+    })
   }
 
   takeReference(): boolean {
@@ -62,8 +62,8 @@ export class TestTransaction<H = string> implements Transaction<string, H> {
     yield* this._spends
   }
 
-  transactionFee(): bigint {
-    return this.totalFees
+  transactionFee(): Promise<bigint> {
+    return Promise.resolve(this.totalFees)
   }
 
   transactionSignature(): Buffer {

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -129,36 +129,37 @@ describe('Verifier', () => {
       )
     })
 
-    it('validates a valid block', () => {
+    it('validates a valid block', async () => {
       const block = makeFakeBlock(strategy, blockHash(4), blockHash(5), 5, 5, 9)
-      expect(captain.chain.verifier.verifyBlock(block).valid).toBe(Validity.Yes)
+      const verification = await captain.chain.verifier.verifyBlock(block)
+      expect(verification.valid).toBe(Validity.Yes)
     })
 
-    it("doesn't validate a block with an invalid header", () => {
+    it("doesn't validate a block with an invalid header", async () => {
       const block = makeFakeBlock(strategy, blockHash(4), blockHash(5), 5, 5, 9)
       block.header.target = new Target(0)
 
-      expect(captain.chain.verifier.verifyBlock(block)).toMatchObject({
+      expect(await captain.chain.verifier.verifyBlock(block)).toMatchObject({
         reason: VerificationResultReason.HASH_NOT_MEET_TARGET,
         valid: 0,
       })
     })
 
-    it("doesn't validate a block with an invalid transaction", () => {
+    it("doesn't validate a block with an invalid transaction", async () => {
       const block = makeFakeBlock(strategy, blockHash(4), blockHash(5), 5, 5, 9)
       block.transactions[1].isValid = false
 
-      expect(captain.chain.verifier.verifyBlock(block)).toMatchObject({
+      expect(await captain.chain.verifier.verifyBlock(block)).toMatchObject({
         reason: VerificationResultReason.INVALID_TRANSACTION_PROOF,
         valid: 0,
       })
     })
 
-    it("doesn't validate a block with incorrect transaction fee", () => {
+    it("doesn't validate a block with incorrect transaction fee", async () => {
       const block = makeFakeBlock(strategy, blockHash(4), blockHash(5), 5, 5, 9)
       block.header.minersFee = BigInt(-1)
 
-      expect(captain.chain.verifier.verifyBlock(block)).toMatchObject({
+      expect(await captain.chain.verifier.verifyBlock(block)).toMatchObject({
         reason: VerificationResultReason.INVALID_MINERS_FEE,
         valid: 0,
       })

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -8,6 +8,7 @@ import { IJSON } from '../serde'
 import { genesisBlockData } from './genesisBlock'
 import { makeGenesisBlock } from './makeGenesisBlock'
 import { IronfishStrategy } from '../strategy'
+import { WorkerPool } from '../workerPool'
 import { AsyncTransactionWorkerPool } from '../strategy/asyncTransactionWorkerPool'
 import { generateKey } from 'ironfish-wasm-nodejs'
 import { createNodeTest } from '../testUtilities'
@@ -30,8 +31,9 @@ describe('Genesis block test', () => {
 
   it('Can start a chain with the existing genesis block', async () => {
     const db = makeDb()
-    const strategy = new IronfishStrategy()
-    const captain = await Captain.new(db, strategy)
+    const workerPool = new WorkerPool()
+    const strategy = new IronfishStrategy(workerPool)
+    const captain = await Captain.new(db, workerPool, strategy)
     await db.open()
 
     const result = IJSON.parse(genesisBlockData) as SerializedBlock<Buffer, Buffer>

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -59,6 +59,7 @@ export async function makeGenesisBlock(
   logger.info('  Posting the initial transaction...')
   const postedInitialTransaction = new IronfishTransaction(
     Buffer.from(initialTransaction.post_miners_fee().serialize()),
+    captain.workerPool,
   )
   transactionList.push(postedInitialTransaction)
 
@@ -103,6 +104,7 @@ export async function makeGenesisBlock(
   logger.info('  Posting the transaction...')
   const postedTransaction = new IronfishTransaction(
     Buffer.from(transaction.post(genesisKey.spending_key, undefined, BigInt(0)).serialize()),
+    captain.workerPool,
   )
   transactionList.push(postedTransaction)
 
@@ -125,6 +127,7 @@ export async function makeGenesisBlock(
   minersFeeTransaction.receive(account.spendingKey, note)
   const postedMinersFeeTransaction = new IronfishTransaction(
     Buffer.from(minersFeeTransaction.post_miners_fee().serialize()),
+    captain.workerPool,
   )
 
   // Create the block. We expect this to add notes and nullifiers on the block

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -127,7 +127,7 @@ export class MemPool<
         return false
       }
     }
-    const validity = transaction.verify()
+    const validity = await transaction.verify()
     if (!validity.valid) {
       return false
     }

--- a/ironfish/src/rpc/routes/mining/successfullyMined.ts
+++ b/ironfish/src/rpc/routes/mining/successfullyMined.ts
@@ -22,7 +22,7 @@ router.register<typeof SuccessfullyMinedRequestSchema, SuccessfullyMinedResponse
   SuccessfullyMinedRequestSchema,
   async (request, node): Promise<void> => {
     if (node.miningDirector) {
-      node.miningDirector.successfullyMined(
+      await node.miningDirector.successfullyMined(
         request.data.randomness,
         request.data.miningRequestId,
       )

--- a/ironfish/src/strategy/asyncTransaction.test.slow.ts
+++ b/ironfish/src/strategy/asyncTransaction.test.slow.ts
@@ -20,6 +20,7 @@ import {
   WasmNoteEncryptedHash,
 } from '.'
 import { makeDb, makeDbName } from '../captain/testUtilities'
+import { WorkerPool } from '../workerPool'
 
 async function makeWasmStrategyTree({
   depth,
@@ -75,7 +76,7 @@ describe('Demonstrates async transaction', () => {
           new IronfishNote(Buffer.from(minerNote.serialize())),
         ),
       ).toBe('')
-      minerTransaction = await transaction.postMinersFee()
+      minerTransaction = await transaction.postMinersFee(new WorkerPool())
       expect(minerTransaction).toBeTruthy()
       expect(minerTransaction.notesLength()).toEqual(1)
     })
@@ -122,7 +123,12 @@ describe('Demonstrates async transaction', () => {
     })
 
     it('Can post the transaction', async () => {
-      publicTransaction = await simpleTransaction.post(spenderKey.spending_key, null, BigInt(2))
+      publicTransaction = await simpleTransaction.post(
+        spenderKey.spending_key,
+        null,
+        BigInt(2),
+        new WorkerPool(),
+      )
       expect(publicTransaction).toBeTruthy()
     })
 
@@ -201,6 +207,7 @@ describe('Demonstrates async transaction', () => {
         receiverKey.spending_key,
         null,
         BigInt(1),
+        new WorkerPool(),
       )
       expect(postedTransaction).toBeTruthy()
       expect(postedTransaction.verify()).toBeTruthy()

--- a/ironfish/src/strategy/asyncTransaction.ts
+++ b/ironfish/src/strategy/asyncTransaction.ts
@@ -15,6 +15,7 @@ import {
   WasmNoteEncryptedHash,
 } from '.'
 import { Witness } from '../merkletree'
+import { WorkerPool } from '../workerPool'
 
 // Messages that the asyncTransactionWorker knows how to handle
 type Request =
@@ -119,7 +120,7 @@ export default class AsyncTransaction {
    *
    * @returns a promise with the posted transaction
    */
-  async postMinersFee(): Promise<IronfishTransaction> {
+  async postMinersFee(workerPool: WorkerPool): Promise<IronfishTransaction> {
     const serializedPosted = await this.promisifyRequest({
       type: 'postMinersFee',
     })
@@ -127,7 +128,7 @@ export default class AsyncTransaction {
       throw new Error('Unable to post transaction')
     }
     this.isPosted = true
-    return new IronfishTransaction(serializedPosted.posted)
+    return new IronfishTransaction(serializedPosted.posted, workerPool)
   }
 
   /**
@@ -139,6 +140,7 @@ export default class AsyncTransaction {
     spenderKey: string,
     changeGoesTo: string | null,
     intendedTransactionFee: bigint,
+    workerPool: WorkerPool,
   ): Promise<IronfishTransaction> {
     const serializedPosted = await this.promisifyRequest({
       type: 'post',
@@ -150,7 +152,7 @@ export default class AsyncTransaction {
       throw new Error('Unable to post transaction')
     }
     this.isPosted = true
-    return new IronfishTransaction(serializedPosted.posted)
+    return new IronfishTransaction(serializedPosted.posted, workerPool)
   }
 
   /**

--- a/ironfish/src/strategy/index.test.ts
+++ b/ironfish/src/strategy/index.test.ts
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { IronfishStrategy } from './'
+import { WorkerPool } from '../workerPool'
 describe('Miners reward', () => {
   let strategy: IronfishStrategy
   beforeAll(() => {
-    strategy = new IronfishStrategy()
+    strategy = new IronfishStrategy(new WorkerPool())
   })
 
   // see https://ironfish.network/docs/whitepaper/4_mining#include-the-miner-reward-based-on-coin-emission-schedule

--- a/ironfish/src/strategy/transaction.ts
+++ b/ironfish/src/strategy/transaction.ts
@@ -13,9 +13,9 @@ export interface Spend<H> {
 
 export interface Transaction<E, H> {
   /**
-   * Verify whether or not all the transactions in the list are valid proofs.
+   * Verify whether the transaction has valid proofs.
    */
-  verify(): VerificationResult
+  verify(): Promise<VerificationResult>
 
   /**
    * The number of notes in the transaction.
@@ -68,7 +68,7 @@ export interface Transaction<E, H> {
    * The transaction fee is the difference between outputs and spends on the
    * transaction.
    */
-  transactionFee(): bigint
+  transactionFee(): Promise<bigint>
 
   /**
    * Get transaction signature for this transaction.

--- a/ironfish/src/workerPool/index.ts
+++ b/ironfish/src/workerPool/index.ts
@@ -1,0 +1,4 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export * from './pool'

--- a/ironfish/src/workerPool/messages.ts
+++ b/ironfish/src/workerPool/messages.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Request and response message types used for communication
+ * between the worker pool and workers.
+ */
+
+export type TransactionFeeRequest = {
+  type: 'transactionFee'
+  requestId: number
+  serializedTransactionPosted: Buffer
+}
+
+export type TransactionFeeResponse = {
+  type: 'transactionFee'
+  requestId: number
+  transactionFee: bigint
+}
+
+export type VerifyTransactionRequest = {
+  type: 'verify'
+  requestId: number
+  serializedTransactionPosted: Buffer
+}
+
+export type VerifyTransactionResponse = {
+  type: 'verify'
+  requestId: number
+  verified: boolean
+}
+
+export type OmitRequestId<T> = Omit<T, 'requestId'>
+
+export type WorkerRequest = TransactionFeeRequest | VerifyTransactionRequest
+export type WorkerResponse = TransactionFeeResponse | VerifyTransactionResponse

--- a/ironfish/src/workerPool/pool.test.slow.ts
+++ b/ironfish/src/workerPool/pool.test.slow.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { generateKey } from 'ironfish-wasm-nodejs'
+import { IronfishStrategy } from '../strategy'
+import { AsyncTransactionWorkerPool } from '../strategy/asyncTransactionWorkerPool'
+import { WorkerPool } from './pool'
+
+describe('Worker Pool', () => {
+  beforeAll(() => {
+    // Pay the cost of setting up Sapling and the DB outside of any test
+    generateKey()
+  })
+
+  it('If pool is empty, executes on main thread', async () => {
+    // Generate a miner's fee transaction
+    const emptyPool = new WorkerPool()
+    const strategy = new IronfishStrategy(emptyPool)
+    const minersFee = await strategy.createMinersFee(
+      BigInt(0),
+      BigInt(0),
+      generateKey().spending_key,
+    )
+    await AsyncTransactionWorkerPool.stop()
+
+    expect(emptyPool['workers'].length).toBe(0)
+    const promise = emptyPool.transactionFee(minersFee)
+    expect(emptyPool['resolvers'].size).toBe(0)
+
+    const fee = await promise
+
+    expect(emptyPool['resolvers'].size).toBe(0)
+    expect(fee).toEqual(BigInt(-500000000))
+  }, 60000)
+
+  it('Terminates all workers when stop is called', async () => {
+    // Generate a miner's fee transaction to create a resolver
+    const pool = new WorkerPool()
+    const strategy = new IronfishStrategy(pool)
+    const minersFee = await strategy.createMinersFee(
+      BigInt(0),
+      BigInt(0),
+      generateKey().spending_key,
+    )
+    await AsyncTransactionWorkerPool.stop()
+
+    pool.start(1)
+
+    expect(pool['workers'].length).toBe(1)
+    expect(pool.started).toBe(true)
+
+    const worker = pool['workers'][0]
+    const terminateSpy = jest.spyOn(worker, 'terminate')
+    void pool.verify(minersFee)
+    expect(pool['resolvers'].size).toBeGreaterThan(0)
+
+    await pool.stop()
+
+    expect(terminateSpy).toBeCalled()
+
+    expect(pool['workers'].length).toBe(0)
+    expect(pool['resolvers'].size).toBe(0)
+    expect(pool.started).toBe(false)
+  }, 60000)
+
+  describe('Worker thread operations', () => {
+    const workerPool: WorkerPool = new WorkerPool()
+
+    beforeEach(() => {
+      workerPool.start(1)
+    })
+
+    afterEach(async () => {
+      await workerPool.stop()
+    })
+
+    it('Resolves promises created by the pool on a worker thread', async () => {
+      // Generate a miner's fee transaction
+      const strategy = new IronfishStrategy(workerPool)
+      const minersFee = await strategy.createMinersFee(
+        BigInt(0),
+        BigInt(0),
+        generateKey().spending_key,
+      )
+      await AsyncTransactionWorkerPool.stop()
+
+      expect(workerPool['workers'].length).toBeGreaterThan(0)
+      const promise = workerPool.transactionFee(minersFee)
+      expect(workerPool['resolvers'].size).toBe(1)
+
+      const fee = await promise
+
+      expect(workerPool['resolvers'].size).toBe(0)
+      expect(fee).toEqual(BigInt(-500000000))
+    }, 60000)
+  })
+})

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { IronfishTransaction } from '../strategy'
+import * as worker from './worker'
+import { Worker } from 'worker_threads'
+import type {
+  OmitRequestId,
+  TransactionFeeRequest,
+  VerifyTransactionRequest,
+  WorkerRequest,
+  WorkerResponse,
+} from './messages'
+
+/**
+ * Manages the creation of worker threads and distribution of jobs to them.
+ */
+export class WorkerPool {
+  private readonly resolvers: Map<number, (response: WorkerResponse) => void> = new Map<
+    number,
+    (response: WorkerResponse) => void
+  >()
+  private workers: Array<Worker> = []
+
+  private _started = false
+  public get started(): boolean {
+    return this._started
+  }
+
+  private workerIndex = 0
+  private lastRequestId = 0
+
+  private sendRequest(
+    request: Readonly<OmitRequestId<WorkerRequest>>,
+  ): Promise<WorkerResponse | null> {
+    const requestId = this.lastRequestId++
+
+    const requestWithId = { ...request, requestId }
+
+    if (this.workers.length === 0) {
+      return Promise.resolve(worker.handleRequest(requestWithId))
+    }
+
+    return this.promisifyRequest(requestWithId)
+  }
+
+  /**
+   * Send a request to the worker thread,
+   * giving it an id and constructing a promise that can be resolved
+   * when the worker thread has issued a response message.
+   */
+  private promisifyRequest(request: Readonly<WorkerRequest>): Promise<WorkerResponse> {
+    const promise: Promise<WorkerResponse> = new Promise((resolve) => {
+      this.resolvers.set(request.requestId, (posted) => resolve(posted))
+    })
+
+    this.workerIndex = (this.workerIndex + 1) % this.workers.length
+    this.workers[this.workerIndex].postMessage(request)
+
+    return promise
+  }
+
+  promisifyResponse(response: WorkerResponse): void {
+    const resolver = this.resolvers.get(response.requestId)
+    if (resolver) {
+      this.resolvers.delete(response.requestId)
+      resolver(response)
+    }
+  }
+
+  start(workers: number): WorkerPool {
+    if (this.started) {
+      return this
+    }
+
+    this._started = true
+
+    // Works around different paths when run under ts-jest
+    let dir = __dirname
+    if (dir.includes('ironfish/src/workerPool')) {
+      dir = dir.replace('ironfish/src/workerPool', 'ironfish/build/src/workerPool')
+    }
+
+    for (let i = 0; i < workers; i++) {
+      const worker = new Worker(dir + '/worker.js')
+      worker.on('message', (value) => this.promisifyResponse(value))
+      this.workers.push(worker)
+    }
+
+    return this
+  }
+
+  async stop(): Promise<undefined> {
+    await Promise.all(this.workers.map((w) => w.terminate()))
+    this.workers = []
+    this.resolvers.clear()
+    this._started = false
+    return
+  }
+
+  async transactionFee(transaction: IronfishTransaction): Promise<bigint> {
+    const request: OmitRequestId<TransactionFeeRequest> = {
+      type: 'transactionFee',
+      serializedTransactionPosted: transaction.serialize(),
+    }
+
+    const response = await this.sendRequest(request)
+
+    if (response === null || response.type !== request.type) {
+      throw new Error('Response type must match request type')
+    }
+
+    return response.transactionFee
+  }
+
+  async verify(transaction: IronfishTransaction): Promise<boolean> {
+    const request: OmitRequestId<VerifyTransactionRequest> = {
+      type: 'verify',
+      serializedTransactionPosted: transaction.serialize(),
+    }
+
+    const response = await this.sendRequest(request)
+
+    if (response === null || response.type !== request.type) {
+      throw new Error('Response type must match request type')
+    }
+
+    return response.verified
+  }
+}

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Handler for Worker messages.
+ */
+
+import { generateKey, WasmTransactionPosted } from 'ironfish-wasm-nodejs'
+import { parentPort, MessagePort } from 'worker_threads'
+import type {
+  TransactionFeeRequest,
+  TransactionFeeResponse,
+  VerifyTransactionRequest,
+  VerifyTransactionResponse,
+  WorkerRequest,
+  WorkerResponse,
+} from './messages'
+
+function handleVerify({
+  requestId,
+  serializedTransactionPosted,
+}: VerifyTransactionRequest): VerifyTransactionResponse {
+  const transaction = WasmTransactionPosted.deserialize(serializedTransactionPosted)
+  const verified = transaction.verify()
+  transaction.free()
+  return { type: 'verify', requestId, verified }
+}
+
+function handleTransactionFee({
+  requestId,
+  serializedTransactionPosted,
+}: TransactionFeeRequest): TransactionFeeResponse {
+  const transaction = WasmTransactionPosted.deserialize(serializedTransactionPosted)
+  const fee = transaction.transactionFee
+  transaction.free()
+  return { type: 'transactionFee', requestId, transactionFee: BigInt(fee) }
+}
+
+function assertNever(x: never): never {
+  throw new Error(`Unexpected value: ${JSON.stringify(x)}`)
+}
+
+export function handleRequest(request: WorkerRequest): WorkerResponse | null {
+  let message: WorkerResponse | null = null
+
+  switch (request.type) {
+    case 'verify':
+      message = handleVerify(request)
+      break
+    case 'transactionFee':
+      message = handleTransactionFee(request)
+      break
+    default: {
+      assertNever(request)
+    }
+  }
+
+  return message
+}
+
+function onMessage(port: MessagePort, request: WorkerRequest) {
+  const response = handleRequest(request)
+
+  if (response !== null) {
+    port.postMessage(response)
+  }
+}
+
+if (parentPort !== null) {
+  // Trigger loading of Sapling parameters if we're in a worker thread
+  generateKey()
+
+  const port = parentPort
+  port.on('message', (request: WorkerRequest) => onMessage(port, request))
+}


### PR DESCRIPTION
Creates a WorkerPool class that starts several worker threads and distributes long-running jobs to them. This should unburden the main thread from block verification, at least, and we can move the other async work into the new WorkerPool as well.

Fixes IRO-649
