### PR TITLE
Reject incoming transactions with negative fees

### DIFF
--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -75,6 +75,16 @@ describe('Verifier', () => {
         captain.chain.verifier.verifyNewTransaction(newTransactionPayload),
       ).rejects.toEqual('Transaction is invalid')
     })
+
+    it('rejects if the transaction has negative fees', async () => {
+      const newTransactionPayload = {
+        transaction: { elements: ['a'], spends: [], totalFees: -5, isValid: true },
+      }
+
+      await expect(
+        captain.chain.verifier.verifyNewTransaction(newTransactionPayload),
+      ).rejects.toEqual('Transaction has negative fees')
+    })
   })
 
   describe('Block', () => {

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -183,6 +183,9 @@ export class Verifier<
     } catch {
       return Promise.reject('Could not deserialize transaction')
     }
+    if ((await transaction.transactionFee()) < 0) {
+      return Promise.reject('Transaction has negative fees')
+    }
     if (!(await transaction.verify()).valid) {
       return Promise.reject('Transaction is invalid')
     }

--- a/ironfish/src/strategy/index.ts
+++ b/ironfish/src/strategy/index.ts
@@ -296,7 +296,7 @@ export class IronfishTransaction
 
   async verify(): Promise<VerificationResult> {
     const result = await this.workerPool.verify(this)
-    return result
+    return result === true
       ? { valid: Validity.Yes }
       : { valid: Validity.No, reason: VerificationResultReason.ERROR }
   }


### PR DESCRIPTION
Incoming transactions with negative fees indicate miner rewards. They'll still pass proof verification, but they should only ever appear on blocks by the miners who created them, not gossiped via the NewTransaction message.

Fixes IRO-650﻿
