### PR TITLE
Fix passing empty string bootstrap node to start command

### DIFF
--- a/ironfish-cli/src/commands/start.test.ts
+++ b/ironfish-cli/src/commands/start.test.ts
@@ -32,6 +32,7 @@ describe('start command', () => {
   let hasGenesisBlock = false
 
   const setConfig = jest.fn()
+  const setOverrideConfig = jest.fn()
   const seed = jest.fn().mockReturnValue(true)
   const start = jest.fn()
   const waitForShutdown = jest.fn()
@@ -53,6 +54,7 @@ describe('start command', () => {
     const config = {
       save: jest.fn(),
       set: setConfig,
+      setOverride: setOverrideConfig,
       get: jest.fn().mockImplementation((config: 'enableTelemetry') => configOptions[config]),
       getArray: jest
         .fn()
@@ -105,6 +107,7 @@ describe('start command', () => {
 
   afterEach(() => {
     setConfig.mockReset()
+    setOverrideConfig.mockReset()
     seed.mockReset()
     start.mockReset()
     ironfishmodule.IronfishSdk.init = ironFishSdkBackup
@@ -150,6 +153,20 @@ describe('start command', () => {
         // start the node
         expect(start).toHaveBeenCalled()
         expect(waitForShutdown).toHaveBeenCalled()
+      })
+  })
+
+  describe('Filters out empty string bootstrap nodes', () => {
+    beforeAll(() => {
+      isFirstRun = false
+      hasGenesisBlock = true
+    })
+    test
+      .stdout()
+      .command(['start', '-b', ''])
+      .exit(0)
+      .it('Calls setOverride with an empty array', () => {
+        expect(setOverrideConfig).toHaveBeenCalledWith('bootstrapNodes', [])
       })
   })
 })

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -83,7 +83,7 @@ export default class Start extends IronfishCommand {
     const { flags } = this.parse(Start)
 
     if (flags.bootstrap != undefined) {
-      this.sdk.config.setOverride('bootstrapNodes', flags.bootstrap)
+      this.sdk.config.setOverride('bootstrapNodes', flags.bootstrap.filter(Boolean))
     }
     if (flags.port != undefined && flags.port !== this.sdk.config.get('peerPort')) {
       this.sdk.config.setOverride('peerPort', flags.port)


### PR DESCRIPTION
Fixes a bug where passing `-b ''` to the start command fails to filter out the empty string from the command flag and crashes when starting the PeerNetwork.﻿
