### PR TITLE
Improve memory usage of block syncer

### DIFF
--- a/ironfish/src/assert.ts
+++ b/ironfish/src/assert.ts
@@ -19,6 +19,10 @@ export class Assert {
     if (x !== null) throw new Error(message || `Expected value to be null`)
   }
 
+  static isNever(x: never): asserts x is never {
+    throw new Error(`Expected value to be never: ${JSON.stringify(x)}`)
+  }
+
   static isTrue(x: boolean, message?: string): asserts x is true {
     if (x === false) throw new Error(message || `Expected value to be true`)
   }

--- a/ironfish/src/blockSyncer.ts
+++ b/ironfish/src/blockSyncer.ts
@@ -15,7 +15,7 @@ import {
   PeerNetwork,
   RPC_TIMEOUT_MILLIS,
 } from './network'
-import Serde, { BufferSerde, JsonSerializable } from './serde'
+import Serde, { BlockHashSerdeInstance, JsonSerializable } from './serde'
 import { MetricsMonitor, Meter } from './metrics'
 import { BlocksResponse } from './network/messages'
 import { Logger } from './logger'
@@ -204,7 +204,7 @@ export class BlockSyncer<
     this.logger = options.logger
     this.peerNetwork = options.peerNetwork
 
-    this.hashSerde = new BufferSerde(32)
+    this.hashSerde = BlockHashSerdeInstance
     this.blockSerde = options.strategy.blockSerde
 
     this.blockSyncPromise = Promise.resolve()

--- a/ironfish/src/blockchain/__snapshots__/nullifiers.test.ts.snap
+++ b/ironfish/src/blockchain/__snapshots__/nullifiers.test.ts.snap
@@ -560,19 +560,4 @@ Object {
 }
 `;
 
-exports[`NullifierHasher constructs a nullifier hasher 1`] = `
-NullifierHasher {
-  "_elementSerde": BufferSerde {
-    "serde": Uint8ArraySerde {
-      "size": 32,
-    },
-    "size": 32,
-  },
-  "_hashSerde": BufferSerde {
-    "serde": Uint8ArraySerde {
-      "size": 32,
-    },
-    "size": 32,
-  },
-}
-`;
+exports[`NullifierHasher constructs a nullifier hasher 1`] = `NullifierHasher {}`;

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -7,7 +7,7 @@ import { Transaction } from '../strategy/transaction'
 import Block from './block'
 import Verifier, { Validity, VerificationResultReason } from '../consensus/verifier'
 import BlockHeader, { BlockHeaderSerde, BlockHash } from './blockheader'
-import Serde, { BufferSerde, JsonSerializable } from '../serde'
+import Serde, { BlockHashSerdeInstance, BufferSerde, JsonSerializable } from '../serde'
 import { Target } from './target'
 import { Graph } from './graph'
 import { MetricsMonitor } from '../metrics'
@@ -118,7 +118,7 @@ export class Blockchain<
     metrics: MetricsMonitor,
   ) {
     this.blockHeaderSerde = new BlockHeaderSerde(strategy)
-    this.blockHashSerde = new BufferSerde(32)
+    this.blockHashSerde = BlockHashSerdeInstance
     this.noteSerde = notes.merkleHasher.elementSerde()
 
     this.logger = logger.withTag('blockchain')

--- a/ironfish/src/blockchain/nullifiers.ts
+++ b/ironfish/src/blockchain/nullifiers.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { MerkleHasher } from '../merkletree'
-import { BufferSerde } from '../serde'
+import { BufferSerde, NullifierSerdeInstance } from '../serde'
 
 import { createKeyed } from 'blake3-wasm'
 
@@ -14,19 +14,12 @@ const NULLIFIER_KEY = Buffer.alloc(32, 'IRONFISH BLAKE3 NULLIFIER PRSNAL')
 const COMBINE_KEY = Buffer.alloc(32, 'IRONFISH NULLIFIER COMBINE HASHS')
 
 export class NullifierHasher implements MerkleHasher<Nullifier, NullifierHash, string, string> {
-  _elementSerde: BufferSerde
-  _hashSerde: BufferSerde
-
-  constructor() {
-    this._elementSerde = new BufferSerde(32)
-    this._hashSerde = new BufferSerde(32)
-  }
   elementSerde(): BufferSerde {
-    return this._elementSerde
+    return NullifierSerdeInstance
   }
 
   hashSerde(): BufferSerde {
-    return this._hashSerde
+    return NullifierSerdeInstance
   }
 
   merkleHash(element: Nullifier): NullifierHash {

--- a/ironfish/src/blockchain/target.ts
+++ b/ironfish/src/blockchain/target.ts
@@ -293,3 +293,5 @@ export class TargetSerde implements Serde<Target, string> {
     return new Target(data)
   }
 }
+
+export const TargetSerdeInstance = new TargetSerde()

--- a/ironfish/src/serde/index.ts
+++ b/ironfish/src/serde/index.ts
@@ -5,6 +5,7 @@
 export { default as StringSerde } from './StringSerde'
 export { default as Uint8ArraySerde } from './Uint8ArraySerde'
 export * from './BufferSerde'
+export * from './serdeInstances'
 export { IJSON } from './iJson'
 
 export type JsonSerializable =

--- a/ironfish/src/serde/serdeInstances.ts
+++ b/ironfish/src/serde/serdeInstances.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { BufferSerde } from './BufferSerde'
+
+const BufferSerde32Instance = new BufferSerde(32)
+
+export const BlockHashSerdeInstance = BufferSerde32Instance
+export const GraffitiSerdeInstance = BufferSerde32Instance
+export const NullifierSerdeInstance = BufferSerde32Instance

--- a/ironfish/src/strategy/index.ts
+++ b/ironfish/src/strategy/index.ts
@@ -409,6 +409,7 @@ export class IronfishStrategy
     SerializedWasmNoteEncryptedHash,
     SerializedTransaction
   >
+  _transactionSerde: TransactionSerde
   private _verifierClass: typeof IronfishVerifier
   private miningRewardCachedByYear: Map<number, number>
   private readonly workerPool: WorkerPool
@@ -416,6 +417,7 @@ export class IronfishStrategy
   constructor(workerPool: WorkerPool, verifierClass: typeof IronfishVerifier | null = null) {
     this._noteHasher = new NoteHasher()
     this._nullifierHasher = new NullifierHasher()
+    this._transactionSerde = new TransactionSerde(workerPool)
     this._blockSerde = new BlockSerde(this)
     this._verifierClass = verifierClass || Verifier
     this.miningRewardCachedByYear = new Map<number, number>()
@@ -431,7 +433,7 @@ export class IronfishStrategy
   }
 
   transactionSerde(): TransactionSerde {
-    return new TransactionSerde(this.workerPool)
+    return this._transactionSerde
   }
 
   get blockSerde(): BlockSerde<

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -8,6 +8,7 @@
 
 import { generateKey, WasmTransactionPosted } from 'ironfish-wasm-nodejs'
 import { parentPort, MessagePort } from 'worker_threads'
+import { Assert } from '../assert'
 import type {
   TransactionFeeRequest,
   TransactionFeeResponse,
@@ -37,10 +38,6 @@ function handleTransactionFee({
   return { type: 'transactionFee', requestId, transactionFee: BigInt(fee) }
 }
 
-function assertNever(x: never): never {
-  throw new Error(`Unexpected value: ${JSON.stringify(x)}`)
-}
-
 export function handleRequest(request: WorkerRequest): WorkerResponse | null {
   let message: WorkerResponse | null = null
 
@@ -52,7 +49,7 @@ export function handleRequest(request: WorkerRequest): WorkerResponse | null {
       message = handleTransactionFee(request)
       break
     default: {
-      assertNever(request)
+      Assert.isNever(request)
     }
   }
 


### PR DESCRIPTION
The main fix here is to cap the size of blocksForProcessing, since it can grow unbounded. Also made a change to avoid allocating a new Serde class when functions are called, most notably the transactionSerde and the Serdes in BlockHeader.

- Limit new Serde instance allocations
- Limit the number of entries in blocksForProcessing
