### PR TITLE
Fix worker pool typing transactions as Buffer instead of Uint8Array

### DIFF
--- a/ironfish/src/workerPool/messages.ts
+++ b/ironfish/src/workerPool/messages.ts
@@ -18,7 +18,7 @@ export type CreateMinersFeeRequest = {
 
 export type CreateMinersFeeResponse = {
   type: 'createMinersFee'
-  serializedTransactionPosted: Buffer
+  serializedTransactionPosted: Uint8Array
 }
 
 export type CreateTransactionRequest = {
@@ -39,7 +39,7 @@ export type CreateTransactionRequest = {
 
 export type CreateTransactionResponse = {
   type: 'createTransaction'
-  serializedTransactionPosted: Buffer
+  serializedTransactionPosted: Uint8Array
 }
 
 export type TransactionFeeRequest = {

--- a/ironfish/src/workerPool/pool.test.slow.ts
+++ b/ironfish/src/workerPool/pool.test.slow.ts
@@ -73,22 +73,32 @@ describe('Worker Pool', () => {
     })
 
     it('Resolves promises created by the pool on a worker thread', async () => {
-      // Generate a miner's fee transaction
       const strategy = new IronfishStrategy(workerPool)
+      expect(workerPool['workers'].length).toBeGreaterThan(0)
+
+      const minersFeePromise = strategy.createMinersFee(
+        BigInt(0),
+        BigInt(0),
+        generateKey().spending_key,
+      )
+      expect(workerPool['resolvers'].size).toBe(1)
+
+      await minersFeePromise
+
+      expect(workerPool['resolvers'].size).toBe(0)
+    }, 60000)
+
+    it('Returns an IronfishTransaction with a Buffer', async () => {
+      const strategy = new IronfishStrategy(workerPool)
+      expect(workerPool['workers'].length).toBeGreaterThan(0)
+
       const minersFee = await strategy.createMinersFee(
         BigInt(0),
         BigInt(0),
         generateKey().spending_key,
       )
 
-      expect(workerPool['workers'].length).toBeGreaterThan(0)
-      const promise = workerPool.transactionFee(minersFee)
-      expect(workerPool['resolvers'].size).toBe(1)
-
-      const fee = await promise
-
-      expect(workerPool['resolvers'].size).toBe(0)
-      expect(fee).toEqual(BigInt(-500000000))
+      expect(minersFee.serialize()).toBeInstanceOf(Buffer)
     }, 60000)
   })
 })

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -121,7 +121,7 @@ export class WorkerPool {
       throw new Error('Response type must match request type')
     }
 
-    return new IronfishTransaction(response.serializedTransactionPosted, this)
+    return new IronfishTransaction(Buffer.from(response.serializedTransactionPosted), this)
   }
 
   async createTransaction(
@@ -155,7 +155,7 @@ export class WorkerPool {
       throw new Error('Response type must match request type')
     }
 
-    return new IronfishTransaction(response.serializedTransactionPosted, this)
+    return new IronfishTransaction(Buffer.from(response.serializedTransactionPosted), this)
   }
 
   async transactionFee(transaction: IronfishTransaction): Promise<bigint> {

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -105,9 +105,18 @@ function handleTransactionFee({
 function handleVerify({
   serializedTransactionPosted,
 }: VerifyTransactionRequest): VerifyTransactionResponse {
-  const transaction = WasmTransactionPosted.deserialize(serializedTransactionPosted)
-  const verified = transaction.verify()
-  transaction.free()
+  let transaction
+
+  let verified = false
+  try {
+    transaction = WasmTransactionPosted.deserialize(serializedTransactionPosted)
+    verified = transaction.verify()
+  } catch {
+    verified = false
+  } finally {
+    transaction?.free()
+  }
+
   return { type: 'verify', verified }
 }
 


### PR DESCRIPTION
When Buffer instances get passed across the worker thread boundary using postMessage, they're copied using the structured clone algorithm and come out on the other side as Uint8Array. This resulted in putting Uint8Arrays into a type that we thought was a Buffer, so in the end the serialization didn't match up. This didn't reproduce in tests originally because they mostly run with the worker pool turned off, so none of the requests/responses were passed across postMessage boundaries.
