### PR TITLE
Move merkle tree construction into Blockchain

### DIFF
--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -104,7 +104,7 @@ describe('Verifier', () => {
 
     it('extracts a valid block', async () => {
       const block = makeFakeBlock(strategy, blockHash(1), blockHash(2), 2, 5, 6)
-      const serializedBlock = chain.verifier.blockSerde.serialize(block)
+      const serializedBlock = chain.strategy.blockSerde.serialize(block)
 
       const {
         block: newBlock,
@@ -132,7 +132,7 @@ describe('Verifier', () => {
     it('rejects if the block is not valid', async () => {
       const block = makeFakeBlock(strategy, blockHash(1), blockHash(2), 2, 5, 6)
       block.transactions[0].isValid = false
-      const serializedBlock = chain.verifier.blockSerde.serialize(block)
+      const serializedBlock = chain.strategy.blockSerde.serialize(block)
       const newBlockPayload = { block: serializedBlock }
 
       await expect(chain.verifier.verifyNewBlock(newBlockPayload)).rejects.toEqual(

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -15,7 +15,7 @@ import {
 } from '../primitives/noteEncrypted'
 import { isNewBlockPayload, isNewTransactionPayload } from '../network/messages'
 import { PayloadType } from '../network'
-import { Serde, BufferSerde, JsonSerializable } from '../serde'
+import { JsonSerializable } from '../serde'
 import {
   IronfishTransaction,
   SerializedTransaction,
@@ -24,6 +24,7 @@ import {
 } from '../primitives/transaction'
 import { Strategy } from '../strategy'
 import { Target } from '../primitives/target'
+
 /**
  * Verifier transctions and blocks
  *
@@ -50,8 +51,6 @@ export class Verifier<
 > {
   strategy: Strategy<E, H, T, SE, SH, ST>
   chain: Blockchain<E, H, T, SE, SH, ST>
-  blockSerde: Serde<Block<E, H, T, SE, SH, ST>, SerializedBlock<SH, ST>>
-  hashSerde: BufferSerde
 
   /**
    * Used to disable verifying the target on the Verifier for testing purposes
@@ -61,8 +60,6 @@ export class Verifier<
   constructor(chain: Blockchain<E, H, T, SE, SH, ST>) {
     this.strategy = chain.strategy
     this.chain = chain
-    this.blockSerde = chain.strategy.blockSerde
-    this.hashSerde = chain.blockHashSerde
   }
 
   /**
@@ -83,7 +80,7 @@ export class Verifier<
     }
     let block
     try {
-      block = this.blockSerde.deserialize(payload.block)
+      block = this.strategy.blockSerde.deserialize(payload.block)
     } catch {
       return Promise.reject('Could not deserialize block')
     }

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -32,7 +32,7 @@ describe('Genesis block test', () => {
     const db = makeDb()
     const workerPool = new WorkerPool()
     const strategy = new IronfishStrategy(workerPool)
-    const chain = await Blockchain.new(db, strategy)
+    const chain = new Blockchain(db, strategy)
     await db.open()
 
     const result = IJSON.parse(genesisBlockData) as SerializedBlock<Buffer, Buffer>

--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -38,11 +38,11 @@ export default class MerkleTree<
   leaves: IDatabaseStore<LeavesSchema<E, H>>
   nodes: IDatabaseStore<NodesSchema<H>>
 
-  private constructor(
+  constructor(
     readonly merkleHasher: MerkleHasher<E, H, SE, SH>,
     readonly db: IDatabase,
     readonly treeName: string,
-    readonly treeDepth: number,
+    readonly treeDepth: number = 32,
   ) {
     class LeafEncoding implements IDatabaseEncoding<LeavesSchema<E, H>['value']> {
       serialize = (value: LeavesSchema<E, H>['value']): Buffer => {
@@ -123,24 +123,6 @@ export default class MerkleTree<
       valueEncoding: new NodeEncoding(),
       keyPath: 'index',
     })
-  }
-
-  /**
-   * Construct a new merkle tree given a concrete merklehasher instance.
-   */
-  static async new<E, H, SE extends JsonSerializable, SH extends JsonSerializable>(
-    hasher: MerkleHasher<E, H, SE, SH>,
-    db: IDatabase,
-    treeName: string,
-    treeDepth?: number,
-  ): Promise<MerkleTree<E, H, SE, SH>>
-  static async new<E, H, SE extends JsonSerializable, SH extends JsonSerializable>(
-    hasher: MerkleHasher<E, H, SE, SH>,
-    db: IDatabase,
-    treeName: string,
-    treeDepth = 32,
-  ): Promise<MerkleTree<E, H, SE, SH>> {
-    return Promise.resolve(new MerkleTree(hasher, db, treeName, treeDepth))
   }
 
   /**

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -51,6 +51,7 @@ import { IronfishStrategy } from '../strategy'
 import { IronfishBlockchain } from '../blockchain'
 import { SerializedWasmNoteEncrypted } from '../primitives/noteEncrypted'
 import { SerializedTransaction } from '../primitives/transaction'
+import { BlockHashSerdeInstance } from '../serde'
 
 /**
  * The routing style that should be used for a message of a given type
@@ -230,7 +231,7 @@ export class PeerNetwork {
 
   /** Used to request a block by header hash or sequence */
   requestBlocks(hash: Buffer, nextBlockDirection: boolean, peer?: Identity): void {
-    const serializedHash = this.chain.blockHashSerde.serialize(hash)
+    const serializedHash = BlockHashSerdeInstance.serialize(hash)
 
     const request: BlockRequest = {
       type: NodeMessageType.Blocks,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -174,7 +174,7 @@ export class IronfishNode {
     const strategy = new strategyClass(workerPool, verifierClass)
 
     const chaindb = createDB({ location: config.chainDatabasePath })
-    const chain = await Blockchain.new(chaindb, strategy, logger, metrics)
+    const chain = new Blockchain(chaindb, strategy, logger, metrics)
 
     const memPool = new MemPool({ chain: chain, strategy: strategy, logger: logger })
 

--- a/ironfish/src/rpc/routes/chain/getBlock.test.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.test.ts
@@ -6,6 +6,7 @@ import { createRouteTest } from '../../../testUtilities/routeTest'
 import { useMinerBlockFixture } from '../../../testUtilities/fixtures'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../consensus'
 import { GetBlockResponse } from './getBlock'
+import { BlockHashSerdeInstance } from '../../../serde'
 
 describe('Route chain.getBlock', () => {
   const routeTest = createRouteTest()
@@ -17,9 +18,7 @@ describe('Route chain.getBlock', () => {
   })
 
   it(`should fail if block can't be found with hash`, async () => {
-    const hash = routeTest.node.chain.blockHashSerde.serialize(
-      Buffer.alloc(32, 'blockhashnotfound'),
-    )
+    const hash = BlockHashSerdeInstance.serialize(Buffer.alloc(32, 'blockhashnotfound'))
 
     await expect(routeTest.adapter.request('chain/getBlock', { hash })).rejects.toThrow(
       'No block found',
@@ -43,7 +42,7 @@ describe('Route chain.getBlock', () => {
     expect(addResult).toMatchObject({ isAdded: true })
 
     // by hash first
-    const hash = routeTest.node.chain.blockHashSerde.serialize(block.header.hash)
+    const hash = BlockHashSerdeInstance.serialize(block.header.hash)
     let response = await routeTest.adapter.request<GetBlockResponse>('chain/getBlock', { hash })
 
     expect(response.content).toMatchObject({

--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -6,6 +6,7 @@ import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
 import { ValidationError } from '../../adapters'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../consensus'
+import { BlockHashSerdeInstance } from '../../../serde'
 
 export type GetBlockRequest = { index?: number; hash?: string }
 
@@ -117,7 +118,7 @@ router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
     let sequence = null
 
     if (request.data.hash) {
-      hashBuffer = node.chain.blockHashSerde.deserialize(request.data.hash)
+      hashBuffer = BlockHashSerdeInstance.deserialize(request.data.hash)
     }
 
     if (request.data.index) {
@@ -165,7 +166,7 @@ router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
       }))
 
       const spends = [...transaction.spends()].map((spend) => ({
-        nullifier: node.chain.blockHashSerde.serialize(spend.nullifier),
+        nullifier: BlockHashSerdeInstance.serialize(spend.nullifier),
       }))
 
       // TODO(IRO-289) We need a better way to either serialize directly to buffer or use CBOR
@@ -175,7 +176,7 @@ router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
 
       return {
         transaction_identifier: {
-          hash: node.chain.blockHashSerde.serialize(transaction.transactionHash()),
+          hash: BlockHashSerdeInstance.serialize(transaction.transactionHash()),
         },
         operations: [],
         metadata: {
@@ -193,11 +194,11 @@ router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
     request.end({
       blockIdentifier: {
         index: block.header.sequence.toString(),
-        hash: node.chain.blockHashSerde.serialize(block.header.hash),
+        hash: BlockHashSerdeInstance.serialize(block.header.hash),
       },
       parentBlockIdentifier: {
         index: parentBlock.header.sequence.toString(),
-        hash: node.chain.blockHashSerde.serialize(parentBlock.header.hash),
+        hash: BlockHashSerdeInstance.serialize(parentBlock.header.hash),
       },
       timestamp: block.header.timestamp.getTime(),
       transactions,

--- a/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
@@ -7,6 +7,7 @@ import { RangeHasher } from '../../../merkletree'
 
 import { blockHash, makeFakeBlock, TestStrategy } from '../../../testUtilities/fake'
 import { GetChainInfoResponse } from './getChainInfo'
+import { BlockHashSerdeInstance } from '../../../serde'
 
 describe('Route chain.getChainInfo', () => {
   const routeTest = createRouteTest()
@@ -20,7 +21,10 @@ describe('Route chain.getChainInfo', () => {
     routeTest.node.chain.getLatestHead = jest.fn().mockReturnValue(latestHeader)
     routeTest.node.chain.getHeaviestHead = jest.fn().mockReturnValue(heaviestHeader)
     routeTest.node.chain.getAtSequence = jest.fn().mockReturnValue([genesis])
-    routeTest.node.chain.blockHashSerde.serialize = jest.fn((value) => value.toString())
+
+    jest
+      .spyOn(BlockHashSerdeInstance, 'serialize')
+      .mockImplementation((value) => value.toString())
 
     routeTest.node.chain.headers.get = jest.fn().mockImplementation((hash: Buffer) => {
       if (hash.equals(latestHeader.hash)) {

--- a/ironfish/src/rpc/routes/chain/getChainInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.ts
@@ -6,6 +6,7 @@ import { Assert } from '../../../assert'
 import * as yup from 'yup'
 
 import { ApiNamespace, router } from '../router'
+import { BlockHashSerdeInstance } from '../../../serde'
 
 export type GetChainInfoRequest = Record<string, never>
 export type BlockIdentifier = { index: string; hash: string }
@@ -50,7 +51,7 @@ router.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
     const oldestBlockIdentifier = {} as BlockIdentifier
     if (heaviestHeader) {
       oldestBlockIdentifier.index = heaviestHeader.sequence.toString()
-      oldestBlockIdentifier.hash = node.chain.blockHashSerde.serialize(heaviestHeader.hash)
+      oldestBlockIdentifier.hash = BlockHashSerdeInstance.serialize(heaviestHeader.hash)
     }
 
     let currentBlockTimestamp = Number()
@@ -58,7 +59,7 @@ router.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
     if (latestHeader) {
       currentBlockTimestamp = Number(latestHeader.timestamp)
       currentBlockIdentifier.index = latestHeader.sequence.toString()
-      currentBlockIdentifier.hash = node.chain.blockHashSerde.serialize(latestHeader.hash)
+      currentBlockIdentifier.hash = BlockHashSerdeInstance.serialize(latestHeader.hash)
     }
 
     const genesisBlockHash = await node.chain.getGenesisHash()
@@ -66,7 +67,7 @@ router.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
 
     const genesisBlockIdentifier = {} as BlockIdentifier
     genesisBlockIdentifier.index = GENESIS_BLOCK_SEQUENCE.toString()
-    genesisBlockIdentifier.hash = node.chain.blockHashSerde.serialize(genesisBlockHash)
+    genesisBlockIdentifier.hash = BlockHashSerdeInstance.serialize(genesisBlockHash)
 
     request.end({
       currentBlockIdentifier,

--- a/ironfish/src/rpc/routes/chain/utils.ts
+++ b/ironfish/src/rpc/routes/chain/utils.ts
@@ -6,7 +6,7 @@ import { Blockchain, GRAPH_ID_NULL } from '../../../blockchain'
 import { Graph } from '../../../blockchain/graph'
 import { Block } from '../../../primitives/block'
 import { Transaction } from '../../../primitives/transaction'
-import { JsonSerializable } from '../../../serde'
+import { BlockHashSerdeInstance, JsonSerializable } from '../../../serde'
 import { HashUtils } from '../../../utils'
 
 /**
@@ -48,21 +48,21 @@ export async function printGraph<
   const blockHash = block.header.hash.toString('hex')
   seen.add(blockHash)
 
-  const isLatest = chain.blockHashSerde.equals(block.header.hash, genesisGraph.latestHash)
+  const isLatest = BlockHashSerdeInstance.equals(block.header.hash, genesisGraph.latestHash)
     ? ' LATEST'
     : ''
 
   const isHeaviest =
     genesisGraph.heaviestHash &&
-    chain.blockHashSerde.equals(block.header.hash, genesisGraph.heaviestHash)
+    BlockHashSerdeInstance.equals(block.header.hash, genesisGraph.heaviestHash)
       ? ' HEAVY'
       : ''
 
-  const isTail = chain.blockHashSerde.equals(block.header.hash, genesisGraph.tailHash)
+  const isTail = BlockHashSerdeInstance.equals(block.header.hash, genesisGraph.tailHash)
     ? ' TAIL'
     : ''
 
-  const isGenesis = chain.blockHashSerde.equals(
+  const isGenesis = BlockHashSerdeInstance.equals(
     block.header.hash,
     (await chain.getGenesisHash()) || Buffer.from(''),
   )

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -35,7 +35,7 @@ async function makeWasmStrategyTree({
   if (!name) name = makeDbName()
   if (!database) database = makeDb(name)
 
-  const tree = await MerkleTree.new(new NoteHasher(), database, name, depth)
+  const tree = new MerkleTree(new NoteHasher(), database, name, depth)
 
   if (openDb) {
     await database.open()

--- a/ironfish/src/testUtilities/fake/helpers/blockchain.ts
+++ b/ironfish/src/testUtilities/fake/helpers/blockchain.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Assert } from '../../../assert'
-import { createRootLogger } from '../../../logger'
 import { GENESIS_BLOCK_PREVIOUS } from '../../../consensus'
 import { IDatabase } from '../../../storage'
 import { makeDb, makeDbName } from '../../helpers/storage'
@@ -186,11 +185,7 @@ export async function makeChainInitial(
 ): Promise<TestBlockchain> {
   const db =
     typeof dbPrefix === 'string' || dbPrefix === undefined ? makeDb(dbPrefix) : dbPrefix
-  const chain = Blockchain.new(
-    db,
-    strategy || new TestStrategy(new RangeHasher()),
-    createRootLogger(),
-  )
+  const chain = new Blockchain(db, strategy || new TestStrategy(new RangeHasher()))
 
   await db.open()
   return chain
@@ -371,7 +366,7 @@ export async function makeBlockchain(): Promise<
   const database = makeDb(name)
 
   const strategy = new TestStrategy(new RangeHasher())
-  const chain = await Blockchain.new(database, strategy, createRootLogger())
+  const chain = new Blockchain(database, strategy)
 
   await database.open()
   return chain

--- a/ironfish/src/testUtilities/fake/helpers/merkleTree.ts
+++ b/ironfish/src/testUtilities/fake/helpers/merkleTree.ts
@@ -32,7 +32,7 @@ export async function makeTree({
   if (!name) name = makeDbName()
   if (!database) database = makeDb(name)
 
-  const tree = await MerkleTree.new(new StructureHasher(), database, name, depth)
+  const tree = new MerkleTree(new StructureHasher(), database, name, depth)
 
   if (openDb) {
     await database.open()

--- a/ironfish/src/testUtilities/fake/matchers/blockchain.ts
+++ b/ironfish/src/testUtilities/fake/matchers/blockchain.ts
@@ -11,7 +11,7 @@ import { BlockHash, Sequence } from '../../../primitives/blockheader'
 import { Nullifier } from '../../../primitives/nullifier'
 import { SerializedTestTransaction, TestTransaction } from '../strategy'
 import makeError from './makeError'
-import { BufferSerde } from '../../../serde'
+import { BlockHashSerdeInstance, BufferSerde } from '../../../serde'
 
 declare global {
   namespace jest {
@@ -62,7 +62,7 @@ expect.extend({
       if (hashesForSequence) {
         for (const candidate of hashesForSequence) {
           if (error !== null) break
-          if (chain.blockHashSerde.equals(candidate, hash)) {
+          if (BlockHashSerdeInstance.equals(candidate, hash)) {
             error = `Hash ${String(hash)} exists in sequences index for ${sequence}`
           }
         }
@@ -183,7 +183,7 @@ expect.extend({
         for (const [actual, expected] of zip(actualHashes, hashes)) {
           if (error !== null) break
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          if (!chain.blockHashSerde.equals(Buffer.from(actual!), Buffer.from(expected!))) {
+          if (!BlockHashSerdeInstance.equals(Buffer.from(actual!), Buffer.from(expected!))) {
             const diffString = diff(actual, expected)
             error = `Hashes for sequence ${sequence} don't match\n\nDifference:\n\n${String(
               diffString,

--- a/ironfish/src/testUtilities/fake/strategy.ts
+++ b/ironfish/src/testUtilities/fake/strategy.ts
@@ -8,11 +8,11 @@ import { MemPool } from '../../memPool'
 import { NullifierHasher } from '../../primitives/nullifier'
 import { TestVerifier } from './verifier'
 import { Blockchain } from '../../blockchain'
-import { BlockHeader, BlockHash } from '../../primitives/blockheader'
+import { BlockHeader, BlockHash, BlockHeaderSerde } from '../../primitives/blockheader'
 import { Strategy } from '../../strategy'
 import { Validity, VerificationResult, VerificationResultReason } from '../../consensus'
 import { StringUtils } from '../../utils'
-import { Serde, BufferSerde, IJSON } from '../../serde'
+import { Serde, BufferSerde, IJSON, StringSerde } from '../../serde'
 import { Block, BlockSerde } from '../../primitives/block'
 import { Spend, Transaction } from '../../primitives/transaction'
 
@@ -90,10 +90,23 @@ export class TestStrategy
     SerializedTestTransaction<string>
   >
 
+  _noteSerde: StringSerde
+
+  _blockHeaderSerde: BlockHeaderSerde<
+    string,
+    string,
+    TestTransaction<string>,
+    string,
+    string,
+    SerializedTestTransaction<string>
+  >
+
   constructor(noteHasher = new ConcatHasher()) {
     this._noteHasher = noteHasher
     this._nullifierHasher = new NullifierHasher()
     this._blockSerde = new BlockSerde(this)
+    this._blockHeaderSerde = new BlockHeaderSerde(this)
+    this._noteSerde = this._noteHasher.elementSerde()
   }
 
   createVerifier(chain: TestBlockchain): TestVerifier {
@@ -110,6 +123,21 @@ export class TestStrategy
 
   transactionSerde(): TestTransactionSerde {
     return new TestTransactionSerde()
+  }
+
+  get noteSerde(): StringSerde {
+    return this._noteSerde
+  }
+
+  get blockHeaderSerde(): BlockHeaderSerde<
+    string,
+    string,
+    TestTransaction<string>,
+    string,
+    string,
+    SerializedTestTransaction<string>
+  > {
+    return this._blockHeaderSerde
   }
 
   get blockSerde(): BlockSerde<


### PR DESCRIPTION
This PR moves merkle tree construction into blockchain. The constructor now constructs the trees, as it should because the blockchain is dependent on them and the only one who uses them.

To do this, it also removes MerkleTree.new() and Blockchain.new() static functions