### PR TITLE
Drop NewBlock gossip messages if connections have buffered messages

### DIFF
--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -5,7 +5,7 @@
 import SimplePeer, { SignalData } from 'simple-peer'
 import { Event } from '../../../event'
 import type { Logger } from '../../../logger'
-import { LooseMessage, parseMessage } from '../../messages'
+import { LooseMessage, NodeMessageType, parseMessage } from '../../messages'
 import { Connection, ConnectionDirection, ConnectionType } from './connection'
 import { NetworkError } from './errors'
 import { IsomorphicWebRtc } from '../../types'
@@ -128,6 +128,10 @@ export class WebRtcConnection extends Connection {
    * Encode the message to json and send it to the peer
    */
   send = (message: LooseMessage): boolean => {
+    if (message.type === NodeMessageType.NewBlock && this.peer.bufferSize > 0) {
+      return false
+    }
+
     if (this.shouldLogMessageType(message.type)) {
       this.logger.debug(`${colors.yellow('SEND')} ${this.displayName}: ${message.type}`)
     }

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -5,7 +5,7 @@
 import type { Logger } from '../../../logger'
 import { Connection, ConnectionDirection, ConnectionType } from './connection'
 import { NetworkError } from './errors'
-import { LooseMessage, parseMessage } from '../../messages'
+import { LooseMessage, NodeMessageType, parseMessage } from '../../messages'
 import { IsomorphicWebSocket, IsomorphicWebSocketErrorEvent } from '../../types'
 import { MetricsMonitor } from '../../../metrics'
 import colors from 'colors/safe'
@@ -101,6 +101,10 @@ export class WebSocketConnection extends Connection {
    * Encode the message to json and send it to the peer
    */
   send = (message: LooseMessage): boolean => {
+    if (message.type === NodeMessageType.NewBlock && this.socket.bufferedAmount > 0) {
+      return false
+    }
+
     if (this.shouldLogMessageType(message.type)) {
       this.logger.debug(`${colors.yellow('SEND')} ${this.displayName}: ${message.type}`)
     }

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -389,10 +389,7 @@ export class Peer {
       }
     }
 
-    this.logger.debug(
-      `Sending ${message.type} message to ${this.displayName} failed, dropping message`,
-    )
-
+    // The message could not be sent on any connection
     return null
   }
 


### PR DESCRIPTION
NewBlock gossip messages should be optional, though they may not be right now. If NewBlock messages are missed, our block syncer should be able to proactively detect when it's missing blocks and seek them out from peers.

Accomplishes two things:
* Decreasing memory consumption during high volume of NewBlock messages. The outgoing buffers for the WS and WebRtc connections were backing up with messages to forward.
* Improving network congestion -- this should indirectly prioritize sending other messages over NewBlock messages, which should at least prevent the case where a node is trying to respond to an RPC call, but the socket's buffer is backed up with NewBlock messages.

Fixes IRO-655