### PR TITLE
Add synced detection to blockchain

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -88,9 +88,13 @@ function renderStatus(content: GetStatusResponse): string {
     content.peerNetwork.inboundTraffic,
   )}/s, Out: ${FileUtils.formatFileSize(content.peerNetwork.outboundTraffic)}/s`
 
+  const blockchainStatus = `${content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'}, HEAD ${
+    content.blockchain.head
+  }`
+
   return `
-Node:                       ${nodeStatus}
-Blocks syncing:             ${blockSyncerStatus}
-Heaviest head:              ${content.node.heaviestHead}
-P2P Network:                ${peerNetworkStatus}`
+Node:                 ${nodeStatus}
+P2P Network:          ${peerNetworkStatus}
+Blocks syncing:       ${blockSyncerStatus}
+Blockchain:           ${blockchainStatus}`
 }

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -31,3 +31,8 @@ export const GENESIS_SUPPLY_IN_IRON = 42000000
  * should get in rewards.
  */
 export const IRON_FISH_YEAR_IN_BLOCKS = 2100000
+
+/**
+ * The oldest the tip should be before we consider the chain synced
+ */
+export const MAX_SYNCED_AGE_MS = 60 * 1000

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -212,10 +212,10 @@ export class IronfishNode {
     await this.files.mkdir(this.config.chainDatabasePath, { recursive: true })
 
     try {
-      await this.chain.db.open()
+      await this.chain.open()
       await this.accounts.db.open()
     } catch (e) {
-      await this.chain.db.close()
+      await this.chain.close()
       await this.accounts.db.close()
       throw e
     }


### PR DESCRIPTION
https://linear.app/ironfish/issue/IRO-658

The blockchain now has an approximation of weather it's synced or not based on if the heaviest head it has is within 60 seconds. This adds 3 new concepts to Blockchain

 * Blockchain.synced: boolean
 * Blockchain.onSynced: Event
 * Blockchain.head: BlockHeader