### PR TITLE
Only mine when we are synced unless forced

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -65,6 +65,11 @@ export default class Start extends IronfishCommand {
       description: 'disable the web socket listen server',
       hidden: true,
     }),
+    forceMining: flags.boolean({
+      default: undefined,
+      description: 'force mining even if we are not synced',
+      hidden: true,
+    }),
   }
 
   node: IronfishNode | null = null
@@ -97,6 +102,12 @@ export default class Start extends IronfishCommand {
     }
     if (flags.worker != undefined && flags.worker !== this.sdk.config.get('isWorker')) {
       this.sdk.config.setOverride('isWorker', flags.worker)
+    }
+    if (
+      flags.forceMining != undefined &&
+      flags.forceMining !== this.sdk.config.get('miningForce')
+    ) {
+      this.sdk.config.setOverride('miningForce', flags.forceMining)
     }
 
     const node = await this.sdk.node()

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -88,9 +88,13 @@ function renderStatus(content: GetStatusResponse): string {
     content.peerNetwork.inboundTraffic,
   )}/s, Out: ${FileUtils.formatFileSize(content.peerNetwork.outboundTraffic)}/s`
 
+  const blockchainStatus = `${content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'}, HEAD ${
+    content.blockchain.head
+  }`
+
   return `
-Node:                       ${nodeStatus}
-Blocks syncing:             ${blockSyncerStatus}
-Heaviest head:              ${content.node.heaviestHead}
-P2P Network:                ${peerNetworkStatus}`
+Node:                 ${nodeStatus}
+P2P Network:          ${peerNetworkStatus}
+Blocks syncing:       ${blockSyncerStatus}
+Blockchain:           ${blockchainStatus}`
 }

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -31,3 +31,8 @@ export const GENESIS_SUPPLY_IN_IRON = 42000000
  * should get in rewards.
  */
 export const IRON_FISH_YEAR_IN_BLOCKS = 2100000
+
+/**
+ * The oldest the tip should be before we consider the chain synced
+ */
+export const MAX_SYNCED_AGE_MS = 60 * 1000

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -37,6 +37,13 @@ export type ConfigOptions = {
    * */
   isWorker: boolean
   /**
+   * Should the mining director mine, even if we are not synced?
+   * Only useful if no miner has been on the network in a long time
+   * otherwise you should not turn this on or you'll create useless
+   * forks while you sync.
+   */
+  miningForce: boolean
+  /**
    * True if you want to send worker peers out to other clients or not
    * */
   broadcastWorkers: boolean
@@ -128,6 +135,7 @@ export class Config extends KeyStore<ConfigOptions> {
       isWorker: false,
       logLevel: '*:info',
       logPrefix: '',
+      miningForce: false,
       blockGraffiti: '',
       nodeName: '',
       p2pSimulateLatency: 0,

--- a/ironfish/src/mining/director.test.slow.ts
+++ b/ironfish/src/mining/director.test.slow.ts
@@ -90,6 +90,7 @@ describe('Mining director', () => {
       chain: chain,
       memPool: memPool,
       strategy: chain.strategy,
+      force: true,
     })
 
     director.setMinerAccount(generateAccount())
@@ -268,6 +269,7 @@ describe('successfullyMined', () => {
       chain: chain,
       memPool: memPool,
       strategy: chain.strategy,
+      force: true,
     })
 
     director.setMinerAccount(generateAccount())
@@ -337,6 +339,7 @@ describe('Recalculating target', () => {
       chain: chain,
       memPool: memPool,
       strategy: chain.strategy,
+      force: true,
     })
 
     director.setMinerAccount(generateAccount())

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -212,10 +212,10 @@ export class IronfishNode {
     await this.files.mkdir(this.config.chainDatabasePath, { recursive: true })
 
     try {
-      await this.chain.db.open()
+      await this.chain.open()
       await this.accounts.db.open()
     } catch (e) {
-      await this.chain.db.close()
+      await this.chain.close()
       await this.accounts.db.close()
       throw e
     }

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -185,6 +185,7 @@ export class IronfishNode {
       memPool: memPool,
       logger: logger,
       graffiti: config.get('blockGraffiti'),
+      force: config.get('miningForce'),
     })
 
     const anonymousTelemetryId = Math.random().toString().substring(2)
@@ -296,10 +297,7 @@ export class IronfishNode {
 
   onPeerNetworkNotReady(): void {
     void this.syncer.shutdown()
-
-    if (this.config.get('enableMiningDirector')) {
-      this.miningDirector.shutdown()
-    }
+    this.miningDirector.shutdown()
   }
 
   onDefaultAccountChange = (account: Account | null): void => {


### PR DESCRIPTION
https://linear.app/ironfish/issue/IRO-657

    This stops the miner from mining when we aren't synced, but allows a
    user to force mining to occur using --forceMining in `ironfish start`