### PR TITLE
Add messageQueue to workerPool

### DIFF
--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -18,6 +18,7 @@ import {
 import { Validity, VerificationResultReason } from './verifier'
 import { Target } from '../primitives/target'
 import { BlockHeader } from '../primitives/blockheader'
+import { WorkerPool } from '../workerPool'
 
 describe('Verifier', () => {
   describe('Transactions', () => {
@@ -109,7 +110,7 @@ describe('Verifier', () => {
       const {
         block: newBlock,
         serializedBlock: newSerializedBlock,
-      } = await chain.verifier.verifyNewBlock({ block: serializedBlock })
+      } = await chain.verifier.verifyNewBlock({ block: serializedBlock }, new WorkerPool())
 
       expect(newBlock.header.hash.equals(block.header.hash)).toBe(true)
       expect(newSerializedBlock.header.previousBlockHash).toEqual(
@@ -118,15 +119,15 @@ describe('Verifier', () => {
     })
 
     it('rejects if payload is not a serialized block', async () => {
-      await expect(chain.verifier.verifyNewBlock({ notA: 'Block' })).rejects.toEqual(
-        'Payload is not a serialized block',
-      )
+      await expect(
+        chain.verifier.verifyNewBlock({ notA: 'Block' }, new WorkerPool()),
+      ).rejects.toEqual('Payload is not a serialized block')
     })
 
     it('rejects if the block cannot be deserialized', async () => {
-      await expect(chain.verifier.verifyNewBlock({ block: { not: 'valid' } })).rejects.toEqual(
-        'Could not deserialize block',
-      )
+      await expect(
+        chain.verifier.verifyNewBlock({ block: { not: 'valid' } }, new WorkerPool()),
+      ).rejects.toEqual('Could not deserialize block')
     })
 
     it('rejects if the block is not valid', async () => {
@@ -135,9 +136,9 @@ describe('Verifier', () => {
       const serializedBlock = chain.strategy.blockSerde.serialize(block)
       const newBlockPayload = { block: serializedBlock }
 
-      await expect(chain.verifier.verifyNewBlock(newBlockPayload)).rejects.toEqual(
-        'Block is invalid',
-      )
+      await expect(
+        chain.verifier.verifyNewBlock(newBlockPayload, new WorkerPool()),
+      ).rejects.toEqual('Block is invalid')
     })
 
     it('validates a valid block', async () => {

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -194,7 +194,7 @@ export class PeerNetwork {
       NodeMessageType.NewBlock,
       RoutingStyle.gossip,
       (p) => {
-        return this.chain.verifier.verifyNewBlock(p)
+        return this.chain.verifier.verifyNewBlock(p, this.node.workerPool)
       },
       (message) => this.onNewBlock(message),
     )

--- a/ironfish/src/workerPool/pool.test.slow.ts
+++ b/ironfish/src/workerPool/pool.test.slow.ts
@@ -48,7 +48,7 @@ describe('Worker Pool', () => {
     expect(pool.started).toBe(true)
 
     const worker = pool['workers'][0]
-    const terminateSpy = jest.spyOn(worker, 'terminate')
+    const terminateSpy = jest.spyOn(worker.worker, 'terminate')
     void pool.verify(minersFee)
     expect(pool['resolvers'].size).toBeGreaterThan(0)
 


### PR DESCRIPTION
Adds a message queue to the worker pool class. The queue message limit is only optionally enforced right now, since our code probably will break in unexpected ways if we reject the worker pool Promises.

The NewBlock handler will drop incoming blocks if the message queue is full. This should help with memory growth as well.

Fixes IRO-656