### PR TITLE
Install wasm-pack from wasm-pack website

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See https://ironfish.network
       1. Choose `Native Windows`, `x86_64`, choose an empty directory, and click OK.
       1. On the next screen, click `Process`.
       1. Once it finishes, add the `bin` folder containing `cc` to your path.
-1. Run `cargo install wasm-pack` to install the WebAssembly wrapper generator.
+1. Install [wasm-pack](https://rustwasm.github.io/wasm-pack/).
 1. Run `yarn install` from the root directory to install packages.
 
 ## Usage

--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -7,7 +7,7 @@ RUN \
     apt-get update && \
     apt-get install jq rsync -y && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-    cargo install wasm-pack && \
+    curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y && \
     ./ironfish-cli/scripts/build.sh
 
 FROM node:14.16.0-slim

--- a/ironfish-http-api/Dockerfile
+++ b/ironfish-http-api/Dockerfile
@@ -7,7 +7,7 @@ RUN \
     apt-get update && \
     apt-get install rsync -y && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-    cargo install wasm-pack && \
+    curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y && \
     ./ironfish-http-api/scripts/build.sh
 
 FROM node:14.16.0

--- a/ironfish-rosetta-api/Dockerfile
+++ b/ironfish-rosetta-api/Dockerfile
@@ -7,7 +7,7 @@ RUN \
     apt-get update && \
     apt-get install rsync -y && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-    cargo install wasm-pack && \
+    curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y && \
     ./ironfish-rosetta-api/scripts/build.sh
 
 FROM node:14.16.0

--- a/ironfish-wasm/build.js
+++ b/ironfish-wasm/build.js
@@ -23,7 +23,7 @@ if(buildNode) {
     });
     if (result.error) {
         if (result.error.message.includes('ENOENT')) {
-            console.error('wasm-pack is not installed. See README.md for install instructions.')
+            console.error('wasm-pack is not installed. Install from https://rustwasm.github.io/wasm-pack')
         } else {
             console.error(result.error.message);
         }

--- a/ironfish-wasm/build.js
+++ b/ironfish-wasm/build.js
@@ -23,7 +23,7 @@ if(buildNode) {
     });
     if (result.error) {
         if (result.error.message.includes('ENOENT')) {
-            console.error('wasm-pack is not installed. Run `cargo install wasm-pack`.')
+            console.error('wasm-pack is not installed. See README.md for install instructions.')
         } else {
             console.error(result.error.message);
         }


### PR DESCRIPTION
This speeds up builds significantly, since using `cargo install` compiles wasm-pack locally. It also might simplify the dependency installation process on Windows (not certain on that though).

