### PR TITLE
Update codecov action to 1.4.1

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Upload code coverage to Codecov
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1.4.1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-rust
@@ -99,7 +99,7 @@ jobs:
 
       # upload code coverage to Codecov
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1.4.1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-wasm


### PR DESCRIPTION
Codecov recently had a security issue with their bash script used to upload coverage -- The Github action used the bash script, and added checksum verification in a recent version: https://github.com/codecov/codecov-action/releases
