### PR TITLE
Move block syncer add speed to blockchain

### DIFF
--- a/ironfish/src/blockSyncer.ts
+++ b/ironfish/src/blockSyncer.ts
@@ -47,14 +47,6 @@ export const ALLOWED_TRANSITIONS_TO_FROM = {
   ['REQUESTING']: ['SYNCING', 'IDLE'],
 }
 
-/**
- * Responsible for the metrics used in the status command.
- */
-export type BlockSyncerChainStatus = {
-  blockAddingSpeed: Meter
-  speed: Meter
-}
-
 export type Request = {
   hash: BlockHash
   fromPeer?: Identity
@@ -175,7 +167,7 @@ export class BlockSyncer<
     type: 'STOPPED',
   }
 
-  public status: BlockSyncerChainStatus
+  speed: Meter
 
   private blockSyncPromise: Promise<void>
   public blockRequestPromise: Promise<void>
@@ -225,10 +217,7 @@ export class BlockSyncer<
     this.gossippedBlocksForProcessing = []
     this.requestedBlocksForProcessing = []
 
-    this.status = {
-      blockAddingSpeed: this.metrics.addMeter(),
-      speed: this.metrics.addMeter(),
-    }
+    this.speed = this.metrics.addMeter()
   }
 
   get state(): Readonly<ActionState<E, H, T, SE, SH, ST>> {
@@ -472,8 +461,7 @@ export class BlockSyncer<
       )
 
       // Metrics status update
-      this.status.speed.add(1)
-      this.status.blockAddingSpeed.add(timeToAddBlock)
+      this.speed.add(1)
 
       if (!addBlockResult.isAdded || !addBlockResult.resolvedGraph) {
         this.logger.debug(

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -130,8 +130,8 @@ function getStatus(node: IronfishNode): GetStatusResponse {
   status.peerNetwork.outboundTraffic = node.metrics.p2p_OutboundTraffic.rate5s
 
   status.blockSyncer.syncing = {
-    blockSpeed: MathUtils.round(node.syncer.status.blockAddingSpeed.avg, 2),
-    speed: MathUtils.round(node.syncer.status.speed.rate1m, 2),
+    blockSpeed: MathUtils.round(node.chain.addSpeed.avg, 2),
+    speed: MathUtils.round(node.syncer.speed.rate1m, 2),
   }
 
   return status

--- a/ironfish/src/utils/bench.ts
+++ b/ironfish/src/utils/bench.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+type HRTime = [seconds: number, nanoseconds: number]
+
+function start(): HRTime {
+  return process.hrtime()
+}
+
+/**
+ * @returns milliseconds since start
+ */
+function end(start: HRTime): number {
+  const [sec, nanosec] = process.hrtime(start)
+  return sec * 1000 + nanosec / 1e6
+}
+
+export const BenchUtils = { start, end }

--- a/ironfish/src/utils/index.ts
+++ b/ironfish/src/utils/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './array'
 export * from './async'
+export * from './bench'
 export * from './currency'
 export * from './enums'
 export * from './error'


### PR DESCRIPTION
Previously the block syncer was measuring add speed, but now its being
measured by the block chain so all adds are bench marked.