### PR TITLE
Return Result from Wasm functions

### DIFF
--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -23,7 +23,7 @@ pub enum SaplingKeyError {
 
 impl fmt::Display for SaplingKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{:?}", self)
     }
 }
 
@@ -49,7 +49,7 @@ pub enum SaplingProofError {
 
 impl fmt::Display for SaplingProofError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{:?}", self)
     }
 }
 
@@ -86,7 +86,7 @@ pub enum TransactionError {
 
 impl fmt::Display for TransactionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{:?}", self)
     }
 }
 
@@ -119,7 +119,7 @@ pub enum NoteError {
 
 impl fmt::Display for NoteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{:?}", self)
     }
 }
 

--- a/ironfish-wasm/Cargo.lock
+++ b/ironfish-wasm/Cargo.lock
@@ -211,16 +211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
-dependencies = [
- "cfg-if 0.1.10",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,7 +470,6 @@ dependencies = [
 name = "ironfish_wasm"
 version = "0.1.0"
 dependencies = [
- "console_error_panic_hook",
  "ironfish_rust",
  "js-sys",
  "pairing",

--- a/ironfish-wasm/Cargo.toml
+++ b/ironfish-wasm/Cargo.toml
@@ -12,7 +12,6 @@ rand = {version = "0.7", features = ["wasm-bindgen"]}
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-console_error_panic_hook = "0.1.6"
 ironfish_rust= { path = "../ironfish-rust" }
 js-sys = "0.3.48"
 wasm-bindgen = "0.2.71"

--- a/ironfish-wasm/src/lib.rs
+++ b/ironfish-wasm/src/lib.rs
@@ -2,16 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-extern crate console_error_panic_hook;
 extern crate ironfish_rust;
 extern crate wasm_bindgen;
 
 use ironfish_rust::sapling_bls12;
 
+pub mod panic_hook;
 pub mod wasm_structs;
 
 use std::str;
 use wasm_bindgen::prelude::*;
+use wasm_structs::WasmSaplingKeyError;
 
 #[wasm_bindgen]
 pub struct Key {
@@ -46,7 +47,6 @@ impl Key {
 
 #[wasm_bindgen(js_name = "generateKey")]
 pub fn create_key_to_js() -> Key {
-    console_error_panic_hook::set_once();
     let hasher = sapling_bls12::SAPLING.clone();
     let sapling_key = sapling_bls12::Key::generate_key(hasher);
 
@@ -59,17 +59,17 @@ pub fn create_key_to_js() -> Key {
 }
 
 #[wasm_bindgen(catch, js_name = "generateNewPublicAddress")]
-pub fn create_new_public_key_to_js(private_key: &str) -> Key {
-    console_error_panic_hook::set_once();
+pub fn create_new_public_key_to_js(private_key: &str) -> Result<Key, JsValue> {
     let hasher = sapling_bls12::SAPLING.clone();
-    let sapling_key = sapling_bls12::Key::from_hex(hasher, private_key).unwrap();
+    let sapling_key =
+        sapling_bls12::Key::from_hex(hasher, private_key).map_err(WasmSaplingKeyError)?;
 
-    Key {
+    Ok(Key {
         spending_key: sapling_key.hex_spending_key(),
         incoming_view_key: sapling_key.incoming_view_key().hex_key(),
         outgoing_view_key: sapling_key.outgoing_view_key().hex_key(),
         public_address: sapling_key.generate_public_address().hex_public_address(),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -79,7 +79,7 @@ mod tests {
     #[test]
     fn test_create_new_public_key_to_js() {
         let key1 = create_key_to_js();
-        let key2 = create_new_public_key_to_js(&key1.spending_key);
+        let key2 = create_new_public_key_to_js(&key1.spending_key).unwrap();
 
         assert_eq!(key1.spending_key(), key2.spending_key());
         assert_eq!(key1.incoming_view_key(), key2.incoming_view_key());

--- a/ironfish-wasm/src/panic_hook/mod.rs
+++ b/ironfish-wasm/src/panic_hook/mod.rs
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use wasm_bindgen::prelude::*;
+
+use std::panic;
+
+#[wasm_bindgen]
+extern "C" {
+    type Error;
+
+    #[wasm_bindgen(constructor)]
+    fn new() -> Error;
+
+    #[wasm_bindgen(structural, method, getter)]
+    fn stack(error: &Error) -> String;
+}
+
+fn hook_impl(info: &panic::PanicInfo) {
+    let e = Error::new();
+    let stack = e.stack();
+
+    let er = js_sys::Error::new(&info.to_string());
+    let _ = js_sys::Reflect::set(&er, &"stack".into(), &stack.into());
+
+    wasm_bindgen::throw_val(er.into());
+}
+
+pub fn hook(info: &panic::PanicInfo) {
+    hook_impl(info);
+}
+
+#[inline]
+pub fn set_once() {
+    use std::sync::Once;
+    static SET_HOOK: Once = Once::new();
+    SET_HOOK.call_once(|| {
+        panic::set_hook(Box::new(hook));
+    });
+}

--- a/ironfish-wasm/src/wasm_structs/errors.rs
+++ b/ironfish-wasm/src/wasm_structs/errors.rs
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use ironfish_rust::errors::*;
+
+pub struct WasmIoError(pub std::io::Error);
+pub struct WasmSaplingKeyError(pub SaplingKeyError);
+pub struct WasmSaplingProofError(pub SaplingProofError);
+pub struct WasmTransactionError(pub TransactionError);
+
+impl From<WasmIoError> for wasm_bindgen::JsValue {
+    fn from(e: WasmIoError) -> Self {
+        js_sys::Error::new(&e.0.to_string()).into()
+    }
+}
+
+impl From<WasmSaplingKeyError> for wasm_bindgen::JsValue {
+    fn from(e: WasmSaplingKeyError) -> Self {
+        js_sys::Error::new(&e.0.to_string()).into()
+    }
+}
+
+impl From<WasmSaplingProofError> for wasm_bindgen::JsValue {
+    fn from(e: WasmSaplingProofError) -> Self {
+        js_sys::Error::new(&e.0.to_string()).into()
+    }
+}
+
+impl From<WasmTransactionError> for wasm_bindgen::JsValue {
+    fn from(e: WasmTransactionError) -> Self {
+        js_sys::Error::new(&e.0.to_string()).into()
+    }
+}

--- a/ironfish-wasm/src/wasm_structs/mod.rs
+++ b/ironfish-wasm/src/wasm_structs/mod.rs
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+pub use super::panic_hook;
+
+mod errors;
+pub use errors::*;
+
 mod note_encrypted;
 pub use note_encrypted::WasmNoteEncrypted;
 

--- a/ironfish-wasm/src/wasm_structs/note.rs
+++ b/ironfish-wasm/src/wasm_structs/note.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use super::{panic_hook, WasmIoError, WasmSaplingKeyError};
 use ironfish_rust::note::Memo;
 use ironfish_rust::sapling_bls12::{Key, Note, SAPLING};
 use wasm_bindgen::prelude::*;
@@ -14,26 +15,31 @@ pub struct WasmNote {
 #[wasm_bindgen]
 impl WasmNote {
     #[wasm_bindgen(constructor)]
-    pub fn new(owner: &str, value: u64, memo: &str) -> WasmNote {
-        let owner_address = ironfish_rust::PublicAddress::from_hex(SAPLING.clone(), owner).unwrap();
-        WasmNote {
+    pub fn new(owner: &str, value: u64, memo: &str) -> Result<WasmNote, JsValue> {
+        panic_hook::set_once();
+
+        let owner_address = ironfish_rust::PublicAddress::from_hex(SAPLING.clone(), owner)
+            .map_err(WasmSaplingKeyError)?;
+        Ok(WasmNote {
             note: Note::new(SAPLING.clone(), owner_address, value, Memo::from(memo)),
-        }
+        })
     }
 
     #[wasm_bindgen]
-    pub fn deserialize(bytes: &[u8]) -> WasmNote {
+    pub fn deserialize(bytes: &[u8]) -> Result<WasmNote, JsValue> {
+        panic_hook::set_once();
+
         let hasher = SAPLING.clone();
         let cursor: std::io::Cursor<&[u8]> = std::io::Cursor::new(bytes);
-        let note = Note::read(cursor, hasher).unwrap();
-        WasmNote { note }
+        let note = Note::read(cursor, hasher).map_err(WasmSaplingKeyError)?;
+        Ok(WasmNote { note })
     }
 
     #[wasm_bindgen]
-    pub fn serialize(&self) -> Vec<u8> {
+    pub fn serialize(&self) -> Result<Vec<u8>, JsValue> {
         let mut cursor: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(vec![]);
-        self.note.write(&mut cursor).unwrap();
-        cursor.into_inner()
+        self.note.write(&mut cursor).map_err(WasmIoError)?;
+        Ok(cursor.into_inner())
     }
 
     /// Value this note represents.
@@ -57,8 +63,9 @@ impl WasmNote {
     /// only at the time the note is spent. This key is collected in a massive
     /// 'nullifier set', preventing double-spend.
     #[wasm_bindgen]
-    pub fn nullifier(&self, owner_private_key: &str, position: u64) -> Vec<u8> {
-        let private_key = Key::from_hex(SAPLING.clone(), owner_private_key).unwrap();
-        self.note.nullifier(&private_key, position).to_vec()
+    pub fn nullifier(&self, owner_private_key: &str, position: u64) -> Result<Vec<u8>, JsValue> {
+        let private_key =
+            Key::from_hex(SAPLING.clone(), owner_private_key).map_err(WasmSaplingKeyError)?;
+        Ok(self.note.nullifier(&private_key, position).to_vec())
     }
 }

--- a/ironfish-wasm/src/wasm_structs/spend_proof.rs
+++ b/ironfish-wasm/src/wasm_structs/spend_proof.rs
@@ -4,6 +4,7 @@
 
 use wasm_bindgen::prelude::*;
 
+use super::WasmIoError;
 use ironfish_rust::sapling_bls12::{MerkleNoteHash, SpendProof};
 
 #[wasm_bindgen]
@@ -19,12 +20,12 @@ impl WasmSpendProof {
     }
 
     #[wasm_bindgen(getter, js_name = "rootHash")]
-    pub fn root_hash(&self) -> Vec<u8> {
+    pub fn root_hash(&self) -> Result<Vec<u8>, JsValue> {
         let mut cursor: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(vec![]);
         MerkleNoteHash::new(self.proof.root_hash())
             .write(&mut cursor)
-            .unwrap();
-        cursor.into_inner()
+            .map_err(WasmIoError)?;
+        Ok(cursor.into_inner())
     }
 
     #[wasm_bindgen(getter)]

--- a/ironfish-wasm/src/wasm_structs/witness.rs
+++ b/ironfish-wasm/src/wasm_structs/witness.rs
@@ -8,6 +8,8 @@ use wasm_bindgen::JsCast;
 use ironfish_rust::sapling_bls12::{Bls12, Fr, MerkleNoteHash};
 use ironfish_rust::witness::{WitnessNode, WitnessTrait};
 
+use super::panic_hook;
+
 #[wasm_bindgen(typescript_custom_section)]
 const IWITNESS: &'static str = r#"
 interface IWitness {
@@ -67,12 +69,17 @@ extern "C" {
 /// like transactions.
 impl WitnessTrait<Bls12> for JsWitness {
     fn verify(&self, hash: &MerkleNoteHash) -> bool {
+        panic_hook::set_once();
+
         let mut cursor: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(vec![]);
         hash.write(&mut cursor).unwrap();
+
         self.verify(&cursor.into_inner())
     }
 
     fn get_auth_path(&self) -> Vec<WitnessNode<Fr>> {
+        panic_hook::set_once();
+
         self.auth_path()
             .iter()
             .map(|element| {
@@ -96,6 +103,8 @@ impl WitnessTrait<Bls12> for JsWitness {
     }
 
     fn root_hash(&self) -> Fr {
+        panic_hook::set_once();
+
         // Convert the serialized root hash back to a Fr
         let bytes = self.serialize_root_hash();
         let mut cursor: std::io::Cursor<&[u8]> = std::io::Cursor::new(&bytes);


### PR DESCRIPTION
Changes most Wasm functions to return `Result`s, which allows us to intercept Rust errors and return a JS error from Wasm. 

Also replaces console_error_panic_hook with a panic_hook that throws a more descriptive error directly in the case that something somewhere does `panic` or `unwrap` an Error. The previous error had the generic text `RuntimeError: unreachable executed`, but the message logged from console_error_panic_hook was more useful. In practice, this shouldn't be used often since it's common in Rust to return Result rather than panic or unwrap Results.
