### PR TITLE
Add enableSyncer config setting

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -23,6 +23,7 @@ export type ConfigOptions = {
   enableRpc: boolean
   enableRpcIpc: boolean
   enableRpcTcp: boolean
+  enableSyncing: boolean
   enableTelemetry: boolean
   enableMetrics: boolean
   getFundsApi: string
@@ -128,6 +129,7 @@ export class Config extends KeyStore<ConfigOptions> {
       enableRpc: true,
       enableRpcIpc: true,
       enableRpcTcp: false,
+      enableSyncing: true,
       enableTelemetry: false,
       enableMetrics: true,
       getFundsApi: DEFAULT_GET_FUNDS_API,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -94,6 +94,7 @@ export class IronfishNode {
       maxPeers: config.get('maxPeers'),
       minPeers: config.get('minPeers'),
       listen: config.get('enableListenP2P'),
+      enableSyncing: config.get('enableSyncing'),
       targetPeers: config.get('targetPeers'),
       isWorker: config.get('isWorker'),
       broadcastWorkers: config.get('broadcastWorkers'),
@@ -288,7 +289,9 @@ export class IronfishNode {
   }
 
   onPeerNetworkReady(): void {
-    void this.syncer.start()
+    if (this.config.get('enableSyncing')) {
+      void this.syncer.start()
+    }
 
     if (this.config.get('enableMiningDirector')) {
       void this.miningDirector.start()


### PR DESCRIPTION
Adds a config value to enable the block syncer, defaulted to true. When set to false, the node performs no action when receiving NewBlock and NewTransaction messages, and never sends block request messages to other nodes.

Further additions here would be to add a field to the IDENTIFY message to indicate whether the node syncs blocks, although with upcoming syncer changes, peers shouldn't be sending block requests to nodes without knowledge of which blocks they have.

This config value is only used for testing and may be removed in the future.

