### PR TITLE
Log to explicit file if node segfaults

### DIFF
--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-require('segfault-handler').registerHandler()
+require('segfault-handler').registerHandler('segfault.log')
 
 require('@oclif/command').run()
 .then(require('@oclif/command/flush'))


### PR DESCRIPTION
By default, the segfault stacktrace filename will have date/time info, so if running a node that auto-restarts on crash, it has the potential to fill up disk space.

This makes the crashfile name constant so it'll overwrite the previous file if it exists.

