### PR TITLE
Disable core dumps in Docker image

### DIFF
--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -20,8 +20,10 @@ RUN apt-get update && apt-get install curl -y
 
 WORKDIR /usr/src
 COPY --from=build /ironfish-cli/build.cli/ironfish-cli ./app
+COPY --from=build /ironfish-cli/scripts/entrypoint.sh ./app/
+RUN chmod +x ./app/entrypoint.sh
 
 # TODO: use environment variables for this
 WORKDIR /usr/src/app
-ENTRYPOINT ["./bin/run"]
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["start", "--rpc.ipc", "--rpc.tcp"]

--- a/ironfish-cli/scripts/entrypoint.sh
+++ b/ironfish-cli/scripts/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Disable core dumps
+ulimit -c 0
+
+./bin/run "$@"
+


### PR DESCRIPTION
The WebRTC package is currently segfaulting from time to time, and if your container is set to automatically restart, it can fill up space in the container's root volume with core dumps.

We're planning to address the segfaults coming from the WebRTC package, but this script should disable core dumps to reduce disk consumption for now.

