### PR TITLE
Disable segfault-handler on Windows

### DIFF
--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 
-require('segfault-handler').registerHandler('segfault.log')
+// segfault-handler causes crashes in node-webrtc on Windows because
+// it catches all exceptions rather than only exceptions that would
+// crash the process
+if (process.platform !== 'win32') {
+  require('segfault-handler').registerHandler('segfault.log')
+}
 
 require('@oclif/command').run()
 .then(require('@oclif/command/flush'))


### PR DESCRIPTION
segfault-handler seems to cause crashes on Windows, or at least spams the logs with segfaults that don't always crash the process. After disabling it on Windows, the node appears to run stably.
