### PR TITLE
Fix ancestor search considering islands cache hit

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -241,7 +241,6 @@ export class Blockchain<
     const header = await this.headers.get(hash, tx)
 
     if (!header) {
-      this.logger.debug(`Couldn't get header ${hash.toString('hex')} when resolving graph`)
       return null
     }
 
@@ -251,7 +250,6 @@ export class Blockchain<
   async resolveGraph(graphId: number, tx?: IDatabaseTransaction): Promise<Graph | null> {
     let graph = await this.getGraph(graphId, tx)
     if (!graph) {
-      this.logger.debug(`Could not resolve graph with id ${graphId}`)
       return null
     }
 
@@ -407,7 +405,7 @@ export class Blockchain<
     return await this.getGraphPath(blockOrHash.graphId, toGraphId, tx)
   }
 
-  protected async getGraphPath(
+  async getGraphPath(
     graphIdOrGraph: number | Graph,
     toGraphId: number | null = null,
     tx?: IDatabaseTransaction,

--- a/ironfish/src/blockchain/index.ts
+++ b/ironfish/src/blockchain/index.ts
@@ -3,3 +3,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export * from './blockchain'
+export * from './graph'

--- a/ironfish/src/index.ts
+++ b/ironfish/src/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './account'
 export * from './assert'
+export * from './blockchain'
 export * from './fileStores'
 export * from './fileSystems'
 export * from './genesis'


### PR DESCRIPTION
This fixes a bug where you get stuck trying to sync an orphan block
island. It's because some how orphan block islands are being added to
the database, even though were syncing left to right now. The issue is
once this happens, you will find an ancestor on the island, and try to
sync from there. This is slower, but will now not consider island blocks
a cache hit.

Note that this can all be deleted once we remove graphs, remove adding
islands from blockchain.