### PR TITLE
Change sort letter from 's' to 'o'

### DIFF
--- a/ironfish-cli/src/commands/peers/list.ts
+++ b/ironfish-cli/src/commands/peers/list.ts
@@ -28,7 +28,7 @@ export class ListCommand extends IronfishCommand {
       description: 'display all information',
     }),
     sort: flags.string({
-      char: 's',
+      char: 'o',
       default: STATE_COLUMN_HEADER,
       description: 'sort by column header',
     }),


### PR DESCRIPTION
Changed sort to 'o' since I think its less common to change this. A new option for sequence will be `s` coming soon.