### PR TITLE
Abort gossip by having handlers return boolean

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -413,7 +413,7 @@ export class Syncer {
       // TODO jspafford: Increase ban by ban amount, should return from addBlock
       const error = `Peer ${peer.displayName} sent an invalid block: ${reason}`
       this.logger.warn(error)
-      throw new Error(error)
+      throw new VerificationError(error)
     }
 
     if (!connectedToGenesis && !this.loader) {
@@ -450,13 +450,7 @@ export class Syncer {
       return
     }
 
-    await this.addBlock(peer, block).catch((error) => {
-      this.logger.error(
-        `Error when adding new block ${block.header.sequence} from ${
-          peer.displayName
-        }: ${ErrorUtils.renderError(error, !(error instanceof VerificationError))}`,
-      )
-    })
+    await this.addBlock(peer, block)
   }
 
   protected async syncOrphan(peer: Peer, hash: BlockHash): Promise<void> {


### PR DESCRIPTION
Before there was no way to abort the gossip, now we can abort the gossip
by returning true or false from a gossip handler.