### PR TITLE
Add docker-compose.yml for creating a test network

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.9'
+
+services:
+    node1:
+        container_name: ironfish-beta-1
+        image: ghcr.io/iron-fish/ironfish-beta:latest
+        ports:
+            - "8001:8001"
+            - "9001:9001"
+        networks:
+            - node_network
+        command: start -v --name node1 --rpc.tcp --rpc.tcp.host=0.0.0.0 --rpc.tcp.port=8001 --port 9001 --bootstrap='' --forceMining --datadir /ironfishdata
+        volumes:
+            - ~/.ironfish-beta-1:/ironfishdata
+
+    node2:
+        container_name: ironfish-beta-2
+        image: ghcr.io/iron-fish/ironfish-beta:latest
+        ports:
+            - "8002:8002"
+            - "9002:9002"
+        networks:
+            - node_network
+        command: start -v --name node2 --rpc.tcp --rpc.tcp.host=0.0.0.0 --rpc.tcp.port=8002 --port 9002 --bootstrap='node1:9001' --datadir /ironfishdata
+        volumes:
+            - ~/.ironfish-beta-2:/ironfishdata
+
+    miner:
+        container_name: ironfish-miner
+        image: ghcr.io/iron-fish/ironfish-beta:latest
+        depends_on:
+            - "node1"
+        networks:
+            - node_network
+        command: miners:start --rpc.tcp --rpc.tcp.host=node1 --rpc.tcp.port=8001
+
+networks:
+    node_network:
+        


### PR DESCRIPTION
Adds a docker-compose file that simplifies starting two test nodes and a miner connected to one of the nodes.
