### PR TITLE
Add --threads to miners:start command

### DIFF
--- a/ironfish/src/mining/miner.test.ts
+++ b/ironfish/src/mining/miner.test.ts
@@ -58,6 +58,7 @@ describe('Miner', () => {
         },
       ]),
       successfullyMined,
+      1,
     )
     expect(MockPiscina).toHaveBeenCalledTimes(1)
     expect(mock.runTask).toHaveBeenCalledTimes(1)
@@ -92,6 +93,7 @@ describe('Miner', () => {
         },
       ]),
       successfullyMined,
+      1,
     )
     expect(MockPiscina).toHaveBeenCalledTimes(1)
     expect(mock.runTask).toHaveBeenCalledTimes(3)
@@ -130,6 +132,7 @@ describe('Miner', () => {
         successfulPromise,
       ),
       successfullyMined,
+      1,
     )
     expect(successfullyMined).toBeCalledTimes(1)
     expect(MockPiscina).toHaveBeenCalledTimes(1)

--- a/ironfish/src/mining/miner.ts
+++ b/ironfish/src/mining/miner.ts
@@ -148,7 +148,7 @@ async function miner(
     miningRequestId: number
   }>,
   successfullyMined: (randomness: number, miningRequestId: number) => void,
-  numTasks = 1,
+  numTasks: number,
 ): Promise<void> {
   let blockToMineResult = await newBlocksIterator.next()
   if (blockToMineResult.done) return


### PR DESCRIPTION
Add a `--threads` option to the `miners:start` command to allow for mining on multiple cores without running separate instances of `miners:start`. The thread pool was already in place, just not configurable.
