### PR TITLE
Add --workers and nodeWorkers config

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -49,6 +49,10 @@ export default class Start extends IronfishCommand {
       char: 'p',
       description: 'port to run the local ws server on',
     }),
+    workers: flags.integer({
+      description:
+        'number of CPU workers to use for long-running operations. 0 disables (likely to cause performance issues), -1 auto-detects based on CPU cores',
+    }),
     name: flags.string({
       char: 'n',
       description: 'name for the node',
@@ -93,6 +97,9 @@ export default class Start extends IronfishCommand {
     }
     if (flags.port != undefined && flags.port !== this.sdk.config.get('peerPort')) {
       this.sdk.config.setOverride('peerPort', flags.port)
+    }
+    if (flags.workers != undefined && flags.workers !== this.sdk.config.get('nodeWorkers')) {
+      this.sdk.config.setOverride('nodeWorkers', flags.workers)
     }
     if (flags.name != undefined && flags.name.trim() !== this.sdk.config.get('nodeName')) {
       this.sdk.config.setOverride('nodeName', flags.name.trim())

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -74,6 +74,14 @@ export type ConfigOptions = {
    */
   blockGraffiti: string
   nodeName: string
+  /**
+   * The number of CPU workers to use for long-running node operations, like creating
+   * transactions and verifying blocks. 0 disables workers (this is likely to cause
+   * performance issues), and -1 auto-detects based on the number of CPU cores.
+   * Each worker uses several hundred MB of memory, so try a lower value to reduce memory
+   * consumption.
+   */
+  nodeWorkers: number
   p2pSimulateLatency: number
   peerPort: number
   rpcTcpHost: string
@@ -140,6 +148,7 @@ export class Config extends KeyStore<ConfigOptions> {
       miningForce: false,
       blockGraffiti: '',
       nodeName: '',
+      nodeWorkers: -1,
       p2pSimulateLatency: 0,
       peerPort: DEFAULT_WEBSOCKET_PORT,
       rpcTcpHost: 'localhost',

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -238,7 +238,11 @@ export class IronfishNode {
 
     // Work in the worker pool happens concurrently,
     // so we should start it as soon as possible
-    this.workerPool.start(os.cpus().length)
+    let workers = this.config.get('nodeWorkers')
+    if (workers === -1) {
+      workers = os.cpus().length - 1
+    }
+    this.workerPool.start(workers)
 
     if (this.config.get('enableTelemetry')) {
       startCollecting(this.config.get('telemetryApi'))


### PR DESCRIPTION
Adds a --workers flag to the `start` command, as well as a `nodeWorkers` config value. This sets the number of workers in the worker pool to create -- since each worker requires a few hundred MB of memory, this can be useful for reducing memory use on systems with many CPU cores.

