### PR TITLE
Fix signals firing twice when running through yarn

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -120,8 +120,10 @@ export abstract class IronfishCommand extends Command {
     const signals: SIGNALS[] = ['SIGINT', 'SIGTERM', 'SIGUSR2']
 
     for (const signal of signals) {
-      const gracefulShutdown = (signal: SIGNALS) => {
-        process.off(signal, gracefulShutdown)
+      const gracefulShutdown = (signal: NodeJS.Signals) => {
+        if (this.closing) {
+          return
+        }
 
         // Allow 3 seconds for graceful termination
         setTimeout(() => {
@@ -139,11 +141,11 @@ export abstract class IronfishCommand extends Command {
         })
       }
 
-      process.on(signal, gracefulShutdown.bind(signal))
+      process.once(signal, gracefulShutdown)
     }
   }
 
-  closeFromSignal(signal: SIGNALS): Promise<unknown> {
+  closeFromSignal(signal: NodeJS.Signals): Promise<unknown> {
     throw new Error(`Not implemented closeFromSignal: ${signal}`)
   }
 }


### PR DESCRIPTION
When running through `yarn start:js`, the signal event handlers are firing twice. We intended to unbind them after the first time they fire, but since we used `.bind` to add them, the unbind wasn't working. This switches to using `process.once` (and updates types as necessary), and also checks the `closing` flag so if multiple signals fire, we don't try to close again.
