### PR TITLE
Wait for all promises to resolve or reject before shutting down

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -266,7 +266,7 @@ export class IronfishNode {
   }
 
   async shutdown(): Promise<void> {
-    await Promise.all([
+    await Promise.allSettled([
       this.accounts.stop(),
       this.syncer.shutdown(),
       this.peerNetwork.stop(),


### PR DESCRIPTION
`Promise.all` will continue as soon as one of the promises rejects, so this switches to `Promise.allSettled` to wait for all promises to either resolve or reject.

I'm not sure that this was actually causing any issues, but it seemed like there could be cases where one of the shutdowns throws, then attempting to close the DBs could break one of the other shutdowns.
