### PR TITLE
Fix abort() not setting aborted in ScanState

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -858,7 +858,6 @@ class ScanState {
   onTransaction = new Event<[sequence: BigInt]>()
 
   private aborted: boolean
-  private running: boolean
   private runningPromise: Promise<void>
   private runningResolve: PromiseResolve<void>
 
@@ -867,7 +866,6 @@ class ScanState {
     this.runningPromise = promise
     this.runningResolve = resolve
 
-    this.running = true
     this.aborted = false
   }
 

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -878,7 +878,7 @@ class ScanState {
   }
 
   async abort(): Promise<void> {
-    this.aborted = false
+    this.aborted = true
     return this.wait()
   }
 

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -882,7 +882,7 @@ class ScanState {
     return this.wait()
   }
 
-  async wait(): Promise<void> {
-    await this.runningPromise
+  wait(): Promise<void> {
+    return this.runningPromise
   }
 }


### PR DESCRIPTION
`aborted` wasn't getting set to true on ScanState, so scans weren't aborting as expected. Also includes a few refactors:

- Remove `running` from ScanState -- it doesn't seem to be used
- Return runningPromise directly from wait()

