### PR TITLE
Unbind WebSocket event handlers when closing the connection

### DIFF
--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -133,6 +133,20 @@ export class WebSocketConnection extends Connection {
     }
 
     this.setState({ type: 'DISCONNECTED' })
-    this.socket.close()
+
+    // Unbind event handlers, they can still fire with buffered inbound messages after
+    // the socket is closed
+    this.socket.onmessage = null
+    this.socket.onclose = null
+    this.socket.onopen = null
+    this.socket.onerror = null
+
+    // This can throw a "WebSocket was closed before the connection was established"
+    // error -- since we're closing the connection anyway, we can discard any error.
+    try {
+      this.socket.close()
+    } catch {
+      // Discard the errors
+    }
   }
 }


### PR DESCRIPTION
I noticed that sometimes inbound messages will continue to fire event handlers even after we've called `close` on WebSocketConnection. I unbound all the event handlers on close, and this exposed another issue where close throws an error if the connection is still establishing, so I wrapped that in a try/catch.

I haven't noticed the same thing with WebRtcConnection, so I left that as-is.
