### PR TITLE
Switch simple-peer to iron-fish fork

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -26,7 +26,7 @@
     "node-ipc": "9.1.3",
     "parse-json": "5.1.0",
     "piscina": "^2.1.0",
-    "simple-peer": "9.11.0",
+    "simple-peer": "git://github.com/iron-fish/simple-peer.git#c69822c",
     "tweetnacl": "1.0.3",
     "uuid": "^8.3.0",
     "yup": "0.29.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8349,11 +8349,6 @@ node-fetch@2.6.1, node-fetch@^2.2.0, node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-forge@0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
-
 node-gyp-build@^4.2.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
@@ -10501,10 +10496,9 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-simple-peer@9.11.0:
+"simple-peer@git://github.com/iron-fish/simple-peer.git#c69822c":
   version "9.11.0"
-  resolved "https://registry.yarnpkg.com/simple-peer/-/simple-peer-9.11.0.tgz#e8d27609c7a610c3ddd75767da868e8daab67571"
-  integrity sha512-qvdNu/dGMHBm2uQ7oLhQBMhYlrOZC1ywXNCH/i8I4etxR1vrjCnU6ZSQBptndB1gcakjo2+w4OHo7Sjza1SHxg==
+  resolved "git://github.com/iron-fish/simple-peer.git#c69822cabbfbf2a110726c168056e43ac4f4be9d"
   dependencies:
     buffer "^6.0.3"
     debug "^4.3.1"


### PR DESCRIPTION
The version is pinned at this commit: https://github.com/iron-fish/simple-peer/commit/c69822cabbfbf2a110726c168056e43ac4f4be9d

It's based off of v9.11.0, and has two commits to address the following issues:

* Avoid segfault when calling RTCPeerConnection.localDescription
* Change "Ignoring unsupported ICE candidate" from console.warn to a debug log 

Fixes #146
Fixes #145