### PR TITLE
Dont require passing args into getChainInfo

### DIFF
--- a/ironfish-rosetta-api/src/services/Network.ts
+++ b/ironfish-rosetta-api/src/services/Network.ts
@@ -30,7 +30,7 @@ export const NetworkStatus = async (
   const rpc = await RPCClient.init()
   await rpc.sdk.client.connect()
 
-  const chainInfo: ResponseEnded<GetChainInfoResponse> = await rpc.sdk.client.getChainInfo({})
+  const chainInfo: ResponseEnded<GetChainInfoResponse> = await rpc.sdk.client.getChainInfo()
 
   if (!chainInfo || !chainInfo.content) {
     throw new Error(`Chain info data not found`)

--- a/ironfish-rosetta-api/src/syncer/Syncer.ts
+++ b/ironfish-rosetta-api/src/syncer/Syncer.ts
@@ -63,7 +63,7 @@ export class Syncer {
 
     Logger.debug('Syncer connected')
 
-    const networkStatus = await this.rpc.sdk.client.getChainInfo({})
+    const networkStatus = await this.rpc.sdk.client.getChainInfo()
 
     // no latest block
     if (!networkStatus || !networkStatus.content) {

--- a/ironfish/src/rpc/clients/rpcClient.ts
+++ b/ironfish/src/rpc/clients/rpcClient.ts
@@ -180,7 +180,7 @@ export abstract class IronfishRpcClient {
   }
 
   async getChainInfo(
-    params: GetChainInfoRequest,
+    params: GetChainInfoRequest = undefined,
   ): Promise<ResponseEnded<GetChainInfoResponse>> {
     return this.request<GetChainInfoResponse>('chain/getChainInfo', params).waitForEnd()
   }

--- a/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
@@ -11,10 +11,7 @@ describe('Route chain.getChainInfo', () => {
   it('returns the right object with hash', async () => {
     await routeTest.node.seed()
 
-    const response = await routeTest.adapter.request<GetChainInfoResponse>(
-      'chain/getChainInfo',
-      {},
-    )
+    const response = await routeTest.adapter.request<GetChainInfoResponse>('chain/getChainInfo')
 
     expect(response.content.currentBlockIdentifier.index).toEqual(
       routeTest.chain.latest?.sequence.toString(),

--- a/ironfish/src/rpc/routes/chain/getChainInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.ts
@@ -4,11 +4,9 @@
 import { GENESIS_BLOCK_SEQUENCE } from '../../../consensus'
 import { Assert } from '../../../assert'
 import * as yup from 'yup'
-
 import { ApiNamespace, router } from '../router'
 import { BlockHashSerdeInstance } from '../../../serde'
 
-export type GetChainInfoRequest = Record<string, never>
 export type BlockIdentifier = { index: string; hash: string }
 
 export interface ChainInfo {
@@ -17,12 +15,13 @@ export interface ChainInfo {
   oldestBlockIdentifier: BlockIdentifier
   currentBlockTimestamp: number
 }
+
+export type GetChainInfoRequest = Record<string, never> | undefined
 export type GetChainInfoResponse = ChainInfo
 
-export const GetChainInfoRequestSchema: yup.ObjectSchema<GetChainInfoRequest> = yup
-  .object<Record<string, never>>()
-  .noUnknown()
-  .defined()
+export const GetChainInfoRequestSchema: yup.MixedSchema<GetChainInfoRequest> = yup
+  .mixed()
+  .oneOf([undefined] as const)
 
 export const GetChainInfoResponseSchema: yup.ObjectSchema<GetChainInfoResponse> = yup
   .object({
@@ -50,6 +49,7 @@ router.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
 
     const latestHeader = node.chain.latest
     const heaviestHeader = node.chain.head
+
     const oldestBlockIdentifier = {} as BlockIdentifier
     if (heaviestHeader) {
       oldestBlockIdentifier.index = heaviestHeader.sequence.toString()


### PR DESCRIPTION
This makes it so you don't need to pass an empty object in, you can just
pass nothing. This RPC api takes no arguments.