### PR TITLE
Dont kick peers from sending duplicate blocks

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -401,6 +401,9 @@ export class Syncer {
       return { added: false, block, reason: VerificationResultReason.ORPHAN }
     }
 
+    if (reason === VerificationResultReason.DUPLICATE) {
+      return { added: false, block, reason: VerificationResultReason.DUPLICATE }
+    }
 
     if (reason) {
       // TODO jspafford: Increase ban by ban amount, should return from addBlock

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -387,12 +387,9 @@ export class Syncer {
     Assert.isNotNull(this.chain.head)
 
     const block = this.chain.strategy.blockSerde.deserialize(serialized)
+    const { isAdded, reason } = await this.chain.addBlock(block)
 
-    // TODO: after addBlock has removed blocks and doesn't add
-    // orphans, we should move this back below the verification
-    // checking and banning
-    const isOrphan = !(await this.chain.hasBlock(block.header.previousBlockHash))
-    if (isOrphan) {
+    if (reason === VerificationResultReason.ORPHAN) {
       this.logger.info(
         `Peer ${peer.displayName} sent orphan at ${block.header.sequence}, syncing orphan chain.`,
       )
@@ -404,7 +401,6 @@ export class Syncer {
       return { added: false, block, reason: VerificationResultReason.ORPHAN }
     }
 
-    const { isAdded, reason } = await this.chain.addBlock(block)
 
     if (reason) {
       // TODO jspafford: Increase ban by ban amount, should return from addBlock


### PR DESCRIPTION
The first commit just cleans up some code now that the block chain has been refactored.

The second code stops syncer peers from being disconnected if they send a block we already have, which they shouldn't, but wasn't possible until the block chain refactor.