### PR TITLE
Fix stop syncing when we hit a duplicate

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -462,6 +462,10 @@ export class Syncer {
    */
   protected onPeerStateChanged = ({ peer, state }: { peer: Peer; state: PeerState }): void => {
     if (state.type !== 'CONNECTED') {
+      this.logger.info(
+        `Peer ${peer.displayName} disconnected (${peer.state.type}) while syncing.`,
+      )
+
       this.stopSync(peer)
     }
   }

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -407,11 +407,11 @@ export class Syncer {
         await this.syncOrphan(peer, block.header.hash)
       }
 
-      return { added: false, block, reason: VerificationResultReason.ORPHAN }
+      return { added: true, block, reason: VerificationResultReason.ORPHAN }
     }
 
     if (reason === VerificationResultReason.DUPLICATE) {
-      return { added: false, block, reason: VerificationResultReason.DUPLICATE }
+      return { added: true, block, reason: VerificationResultReason.DUPLICATE }
     }
 
     if (reason) {


### PR DESCRIPTION
it was stopping syncing when we hit a duplicate, instead we should keep syncing as long as the blocks are valid, and in sequence.