### PR TITLE
Fix agent not specifying git hash

### DIFF
--- a/ironfish/src/platform.ts
+++ b/ironfish/src/platform.ts
@@ -25,7 +25,7 @@ const getRuntime = ():
 
 const getAgent = (name: string): string => {
   let agent = `ironfish/${name}`
-  if (Package.git) agent += `/${Package.git.slice(8)}`
+  if (Package.git) agent += `/${Package.git.slice(0, 8)}`
   return agent
 }
 


### PR DESCRIPTION
We were slicing the last 8 instead of the first 8, which makes nothing appear in the agent.