### PR TITLE
Add peers count to ironfish status

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -86,7 +86,9 @@ function renderStatus(content: GetStatusResponse): string {
     content.peerNetwork.isReady ? 'CONNECTED' : 'WAITING'
   } In: ${FileUtils.formatFileSize(
     content.peerNetwork.inboundTraffic,
-  )}/s, Out: ${FileUtils.formatFileSize(content.peerNetwork.outboundTraffic)}/s`
+  )}/s, Out: ${FileUtils.formatFileSize(content.peerNetwork.outboundTraffic)}/s, peers ${
+    content.peerNetwork.peers
+  }`
 
   const blockchainStatus = `${content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'}, HEAD ${
     content.blockchain.head

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -28,6 +28,7 @@ export type GetStatusResponse = {
     }
   }
   peerNetwork: {
+    peers: number
     isReady: boolean
     inboundTraffic: number
     outboundTraffic: number
@@ -56,6 +57,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
       .defined(),
     peerNetwork: yup
       .object({
+        peers: yup.number().defined(),
         isReady: yup.boolean().defined(),
         inboundTraffic: yup.number().defined(),
         outboundTraffic: yup.number().defined(),
@@ -103,8 +105,11 @@ router.register<typeof GetStatusRequestSchema, GetStatusResponse>(
 )
 
 function getStatus(node: IronfishNode): GetStatusResponse {
+  const peers = node.peerNetwork.peerManager.getConnectedPeers()
+
   const status: GetStatusResponse = {
     peerNetwork: {
+      peers: peers.length,
       isReady: false,
       inboundTraffic: 0,
       outboundTraffic: 0,


### PR DESCRIPTION
```
Node:                 STARTED
P2P Network:          CONNECTED In: 0 B/s, Out: 0 B/s, peers 22
Blocks syncing:       SYNCING @ 0.48 blocks per seconds | avg time to add block 47.67 ms
Blockchain:           SYNCED, HEAD 000001b726e59c33dcbc74eca13809292e311aae90b38cb247e9dab027b88a12 (74049)
```