### PR TITLE
Bump protocol version to 3

### DIFF
--- a/ironfish/src/network/version.ts
+++ b/ironfish/src/network/version.ts
@@ -2,5 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const VERSION_PROTOCOL = 2
-export const VERSION_PROTOCOL_MIN = 2
+export const VERSION_PROTOCOL = 3
+export const VERSION_PROTOCOL_MIN = 3


### PR DESCRIPTION
Were doing this because people on the old GIT version were not behaving
properly, and we need to exclude them from the network. They are sending
back random hashes at a requested sequence, rather than at their
heaviest chain.