### PR TITLE
Move seed into blockchain and make head non-null

### DIFF
--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -62,7 +62,6 @@ export default class Export extends IronfishCommand {
     const node = await this.sdk.node()
     await node.openDB()
     await node.chain.open()
-    await node.seed()
     cli.action.stop('done.')
 
     Assert.isNotNull(node.chain.head, 'head')

--- a/ironfish-cli/src/commands/chain/readdblock.ts
+++ b/ironfish-cli/src/commands/chain/readdblock.ts
@@ -32,7 +32,6 @@ export default class ReAddBlock extends IronfishCommand {
     const node = await this.sdk.node()
     await node.openDB()
     await node.chain.open()
-    await node.seed()
     cli.action.stop('done.')
 
     const block = await node.chain.getBlock(hash)

--- a/ironfish-cli/src/commands/start.test.ts
+++ b/ironfish-cli/src/commands/start.test.ts
@@ -36,7 +36,6 @@ describe('start command', () => {
 
   const setConfig = jest.fn()
   const setOverrideConfig = jest.fn()
-  const seed = jest.fn().mockReturnValue(true)
   const start = jest.fn()
   const waitForShutdown = jest.fn()
 
@@ -89,7 +88,6 @@ describe('start command', () => {
       closeDB: jest.fn(),
       accounts: accounts,
       peerNetwork: peerNetwork,
-      seed: seed,
       config: config,
       internal: internal,
       chain: chain,
@@ -106,7 +104,6 @@ describe('start command', () => {
   afterEach(() => {
     setConfig.mockReset()
     setOverrideConfig.mockReset()
-    seed.mockReset()
     start.mockReset()
     ironfishmodule.IronfishSdk.init = ironFishSdkBackup
   })
@@ -124,9 +121,6 @@ describe('start command', () => {
           `To help improve Ironfish, opt in to collecting telemetry`,
         )
         expect(setConfig).toHaveBeenCalledWith('isFirstRun', false)
-        // generate genesis
-        expectCli(ctx.stdout).include(`Initializing the blockchain`)
-        expect(seed).toHaveBeenCalled()
         // start the node
         expect(start).toHaveBeenCalled()
         expect(waitForShutdown).toHaveBeenCalled()
@@ -146,8 +140,6 @@ describe('start command', () => {
         // welcome message
         expectCli(ctx.stdout).include(`Peer Identity`)
         expect(setConfig).toHaveBeenCalledTimes(0)
-        // generate genesis
-        expect(seed).toHaveBeenCalledTimes(0)
         // start the node
         expect(start).toHaveBeenCalled()
         expect(waitForShutdown).toHaveBeenCalled()

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -4,7 +4,6 @@
 import { flags } from '@oclif/command'
 import { IronfishCommand, SIGNALS } from '../command'
 import { DatabaseIsLockedError, IronfishNode, PromiseUtils } from 'ironfish'
-import cli from 'cli-ux'
 import {
   ConfigFlag,
   ConfigFlagKey,
@@ -138,10 +137,6 @@ export default class Start extends IronfishCommand {
       return startDoneResolve()
     }
 
-    if (!node.chain.hasGenesisBlock) {
-      await this.addGenesisBlock(node)
-    }
-
     if (node.internal.get('isFirstRun')) {
       await this.firstRun(node)
     }
@@ -186,22 +181,6 @@ export default class Start extends IronfishCommand {
         throw e
       }
     }
-  }
-
-  /**
-   * Insert the genesis block into the node
-   */
-  async addGenesisBlock(node: IronfishNode): Promise<void> {
-    cli.action.start('Initializing the blockchain', 'Loading the genesis block', {
-      stdout: true,
-    })
-
-    const result = await node.seed()
-    if (!result) {
-      cli.action.stop('Failed to seed the database with the genesis block.')
-    }
-
-    cli.action.stop('Genesis block loaded successfully')
   }
 
   /**

--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Assert } from '../assert'
 import { makeBlockAfter } from '../testUtilities/helpers/blockchain'
 import { createNodeTest } from '../testUtilities'
 
@@ -13,10 +12,6 @@ describe('Accounts', () => {
     strategy.disableMiningReward()
 
     const getTransactionsSpy = jest.spyOn(chain, 'iterateBlockTransactions')
-
-    // G
-    await node.seed()
-    Assert.isNotNull(chain.genesis)
 
     // G -> A1
     const blockA1 = await makeBlockAfter(chain, chain.genesis)

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -116,11 +116,6 @@ export class Accounts {
       const chainHead = this.chain.head
       const chainTail = this.chain.genesis
 
-      if (!chainHead || !chainTail) {
-        // There is no genesis block, so there's nothing to update to
-        return
-      }
-
       if (!this.headHash) {
         await addBlock(chainTail)
         await this.updateHeadHash(chainTail.hash.toString('hex'))

--- a/ironfish/src/blockchain/blockchain.old.test.ts
+++ b/ironfish/src/blockchain/blockchain.old.test.ts
@@ -7,7 +7,6 @@ import {
   blockHash,
   makeChainInitial,
   makeFakeBlock,
-  makeNextBlock,
   makeNullifier,
   SerializedTestTransaction,
   TestBlockchain,
@@ -42,7 +41,6 @@ describe('Note adding', () => {
     expect(await blockchain.notes.get(0)).toBe('zero')
     expect(await blockchain.notes.get(1)).toBe('one')
     expect(await blockchain.nullifiers.size()).toBe(0)
-    expect(blockchain.head).toBeNull()
     expect(listener).not.toBeCalled()
   })
   it('adds an out of order note only to the loose notes', async () => {
@@ -54,7 +52,6 @@ describe('Note adding', () => {
     expect(blockchain.looseNotes[12]).toBe('twelve')
     expect(await blockchain.notes.size()).toBe(0)
     expect(await blockchain.nullifiers.size()).toBe(0)
-    expect(blockchain.head).toBeNull()
     expect(listener).not.toBeCalled()
   })
   it('syncs loose notes to the tree when the gap fills in', async () => {
@@ -69,7 +66,6 @@ describe('Note adding', () => {
     expect(await blockchain.notes.get(1)).toBe('one')
     expect(await blockchain.notes.get(2)).toBe('two')
     expect(await blockchain.nullifiers.size()).toBe(0)
-    expect(blockchain.head).toBeNull()
     expect(listener).not.toBeCalled()
   })
   it("logs errors if the note doesn't match the previously inserted note that position", async () => {
@@ -106,7 +102,6 @@ describe('Nullifier adding', () => {
     expect(await blockchain.nullifiers.get(0)).toEqualNullifier(nullifier1)
     expect(await blockchain.nullifiers.get(1)).toEqualNullifier(nullifier2)
     expect(await blockchain.notes.size()).toBe(0)
-    expect(blockchain.head).toBeNull()
     expect(listener).not.toBeCalled()
   })
   it('adds an out of order nullifier only to the loose nullifiers', async () => {
@@ -121,7 +116,6 @@ describe('Nullifier adding', () => {
     expect(blockchain.looseNullifiers[12]).toEqualNullifier(nullifier3)
     expect(await blockchain.notes.size()).toBe(0)
     expect(await blockchain.nullifiers.size()).toBe(0)
-    expect(blockchain.head).toBeNull()
     expect(listener).not.toBeCalled()
   })
   it('syncs loose nullifiers to the tree when the gap fills in', async () => {
@@ -139,7 +133,6 @@ describe('Nullifier adding', () => {
     expect(await blockchain.nullifiers.get(1)).toEqualNullifier(nullifier1)
     expect(await blockchain.nullifiers.get(2)).toEqualNullifier(nullifier2)
     expect(await blockchain.notes.size()).toBe(0)
-    expect(blockchain.head).toBeNull()
     expect(listener).not.toBeCalled()
   })
   it("warns if the note doesn't match the previously inserted note that position", async () => {
@@ -273,22 +266,6 @@ describe('New block', () => {
     jest.useRealTimers()
     targetSpy.mockClear()
     targetMeetsSpy.mockClear()
-  })
-
-  it('creates a new block on an empty chain without failing', async () => {
-    const chain = await makeChainInitial(strategy)
-    await chain.notes.add('0')
-    await chain.nullifiers.add(makeNullifier(0))
-    const genesis = await makeNextBlock(chain, true)
-    await chain.addBlock(genesis)
-
-    const block = await makeNextBlock(chain)
-    await chain.addBlock(block)
-
-    expect(await blockchain.notes.size()).toBe(0)
-    expect(await blockchain.nullifiers.size()).toBe(0)
-    expect(blockchain.head).toBe(null)
-    expect(listener).not.toBeCalled()
   })
 
   it('throws an error if the provided transactions are invalid', async () => {

--- a/ironfish/src/blockchain/blockchain.test.perf.ts
+++ b/ironfish/src/blockchain/blockchain.test.perf.ts
@@ -15,7 +15,6 @@ describe('Blockchain', () => {
   it('Add Block with fork', async () => {
     const { node: nodeA } = await nodeTest.createSetup()
     const { node: nodeB } = await nodeTest.createSetup()
-    await Promise.all([nodeA.seed(), nodeB.seed()])
 
     const accountA = await useAccountFixture(nodeA.accounts, 'accountA')
     const accountB = await useAccountFixture(nodeB.accounts, 'accountB')
@@ -58,7 +57,6 @@ describe('Blockchain', () => {
         console.log(`Running Test ${i}`)
 
         const { node } = await nodeTest.createSetup()
-        await node.seed()
 
         const startAll = Date.now()
 

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -10,7 +10,7 @@
 export const GENESIS_BLOCK_PREVIOUS = Buffer.alloc(32)
 
 /**
- * The sequence of the gensis block starts at 1
+ * The sequence of the genesis block starts at 1
  */
 export const GENESIS_BLOCK_SEQUENCE = BigInt(1)
 

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -177,7 +177,7 @@ describe('Verifier', () => {
 
     beforeEach(async () => {
       dateSpy.mockClear()
-      chain = await makeChainFull(strategy)
+      chain = await makeChainFull(strategy, { autoSeed: false })
 
       header = new BlockHeader(
         strategy,

--- a/ironfish/src/mining/director.test.slow.ts
+++ b/ironfish/src/mining/director.test.slow.ts
@@ -65,7 +65,7 @@ describe('Mining director', () => {
   >
 
   beforeEach(async () => {
-    chain = await makeChainGenesis(strategy, makeDbName())
+    chain = await makeChainGenesis(strategy, { dbPrefix: makeDbName() })
 
     verifyBlockAddSpy = jest.spyOn(chain.verifier, 'verifyBlockAdd').mockResolvedValue({
       valid: Validity.Yes,
@@ -117,7 +117,7 @@ describe('Mining director', () => {
     const chainHead = chain.head
     const listenPromise = waitForEmit(director.onBlockToMine)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await chain.onHeadChange.emitAsync(chainHead!.recomputeHash())
+    await chain.onHeadChange.emitAsync(chainHead.recomputeHash())
     const [data] = await listenPromise
     const buffer = Buffer.from(data.bytes)
     const block = JSON.parse(buffer.toString()) as Partial<SerializedBlockHeader<string>>
@@ -145,7 +145,7 @@ describe('Mining director', () => {
     expect(chainHead).toBeDefined()
     const listenPromise = waitForEmit(director.onBlockToMine)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await chain.onHeadChange.emitAsync(chainHead!.recomputeHash())
+    await chain.onHeadChange.emitAsync(chainHead.recomputeHash())
 
     const result = (await listenPromise)[0]
     const buffer = Buffer.from(result.bytes)
@@ -175,7 +175,7 @@ describe('Mining director', () => {
     expect(chainHead).toBeDefined()
     const listenPromise = waitForEmit(director.onBlockToMine)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await chain.onHeadChange.emitAsync(chainHead!.recomputeHash())
+    await chain.onHeadChange.emitAsync(chainHead.recomputeHash())
 
     const result = (await listenPromise)[0]
     const buffer = Buffer.from(result.bytes)
@@ -321,11 +321,8 @@ describe('Non-fake director tests', () => {
       const { strategy, chain, node } = nodeTest
       strategy.disableMiningReward()
 
-      const genesis = await nodeTest.node.seed()
-      Assert.isNotNull(genesis)
-
-      const blockA1 = await makeBlockAfter(chain, genesis)
-      const blockA2 = await makeBlockAfter(chain, genesis)
+      const blockA1 = await makeBlockAfter(chain, chain.genesis)
+      const blockA2 = await makeBlockAfter(chain, chain.genesis)
       node.miningDirector.recentBlocks.set(2, blockA1)
       node.miningDirector.recentBlocks.set(3, blockA2)
 
@@ -343,10 +340,7 @@ describe('Non-fake director tests', () => {
       const { strategy, chain, node } = nodeTest
       strategy.disableMiningReward()
 
-      const genesis = await nodeTest.node.seed()
-      Assert.isNotNull(genesis)
-
-      const block = await makeBlockAfter(chain, genesis)
+      const block = await makeBlockAfter(chain, chain.genesis)
       block.header.nullifierCommitment.size = 999
 
       const addSpy = jest.spyOn(chain, 'addBlock')

--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -38,7 +38,7 @@ type DirectorState = { type: 'STARTED' } | { type: 'STOPPED' }
 /**
  * Responsible for directing miners about which block to mine.
  *
- * Listens for changes to the anchor chain head and emits a 'onBlockToMine' event
+ * Listens for changes to the blockchain head and emits a 'onBlockToMine' event
  * for each one.
  *
  * @typeParam E Note element stored in transactions and the notes Merkle Tree
@@ -220,7 +220,7 @@ export class MiningDirector<
   }
 
   /**
-   * Event listener hooked up to changes in AnchorChain.
+   * Event listener hooked up to changes in Blockchain.
    *
    * When a new head is received it:
    *  * adds any transactions that we were attempting to mine back to the pool

--- a/ironfish/src/primitives/block.test.ts
+++ b/ironfish/src/primitives/block.test.ts
@@ -12,8 +12,6 @@ describe('Block', () => {
   const nodeTest = createNodeTest()
 
   it('correctly counts notes and nullifiers', async () => {
-    await nodeTest.node.seed()
-
     const accountA = await useAccountFixture(nodeTest.node.accounts, 'accountA')
     const accountB = await useAccountFixture(nodeTest.node.accounts, 'accountB')
     const block = await makeBlockWithTransaction(nodeTest.node, accountA, accountB)
@@ -33,8 +31,7 @@ describe('Block', () => {
   it('serializes and deserializes a block', async () => {
     nodeTest.strategy.disableMiningReward()
 
-    const genesis = await nodeTest.node.seed()
-    const block = await makeBlockAfter(nodeTest.chain, genesis)
+    const block = await makeBlockAfter(nodeTest.chain, nodeTest.chain.genesis)
 
     const serialized = nodeTest.strategy.blockSerde.serialize(block)
     expect(serialized).toMatchObject({ header: { timestamp: expect.any(Number) } })

--- a/ironfish/src/rpc/routes/chain/getBlock.test.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.test.ts
@@ -15,7 +15,7 @@ describe('Route chain.getBlock', () => {
     await expect(routeTest.adapter.request('chain/getBlock', {})).rejects.toThrow(
       'Missing hash or sequence',
     )
-  })
+  }, 10000)
 
   it(`should fail if block can't be found with hash`, async () => {
     const hash = BlockHashSerdeInstance.serialize(Buffer.alloc(32, 'blockhashnotfound'))
@@ -23,19 +23,16 @@ describe('Route chain.getBlock', () => {
     await expect(routeTest.adapter.request('chain/getBlock', { hash })).rejects.toThrow(
       'No block found',
     )
-  })
+  }, 10000)
 
   it(`should fail if block can't be found with sequence`, async () => {
     await expect(routeTest.adapter.request('chain/getBlock', { index: 5 })).rejects.toThrow(
       'No block found',
     )
-  })
+  }, 10000)
 
   it('responds with a block', async () => {
-    const node = routeTest.node
     const chain = routeTest.node.chain
-
-    await node.seed()
 
     const block = await useMinerBlockFixture(chain, BigInt(2))
     const addResult = await chain.addBlock(block)

--- a/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
@@ -9,21 +9,19 @@ describe('Route chain.getChainInfo', () => {
   const routeTest = createRouteTest()
 
   it('returns the right object with hash', async () => {
-    await routeTest.node.seed()
-
     const response = await routeTest.adapter.request<GetChainInfoResponse>('chain/getChainInfo')
 
     expect(response.content.currentBlockIdentifier.index).toEqual(
-      routeTest.chain.latest?.sequence.toString(),
+      routeTest.chain.latest.sequence.toString(),
     )
     expect(response.content.genesisBlockIdentifier.index).toEqual(
-      routeTest.chain.genesis?.sequence.toString(),
+      routeTest.chain.genesis.sequence.toString(),
     )
     expect(response.content.oldestBlockIdentifier.index).toEqual(
-      routeTest.chain.head?.sequence.toString(),
+      routeTest.chain.head.sequence.toString(),
     )
     expect(response.content.currentBlockTimestamp).toEqual(
-      Number(routeTest.chain.latest?.timestamp),
+      Number(routeTest.chain.latest.timestamp),
     )
-  }, 7000)
+  }, 10000)
 })

--- a/ironfish/src/rpc/routes/chain/utils.ts
+++ b/ironfish/src/rpc/routes/chain/utils.ts
@@ -73,16 +73,12 @@ export async function renderChain<
 
   content.push(
     '======',
-    `GENESIS: ${chain.genesis?.hash.toString('hex') || '-'}`,
-    `HEAD:    ${chain.head?.hash.toString('hex') || '-'}`,
-    `LATEST:  ${chain.latest?.hash.toString('hex') || '-'}`,
+    `GENESIS: ${chain.genesis.hash.toString('hex') || '-'}`,
+    `HEAD:    ${chain.head.hash.toString('hex') || '-'}`,
+    `LATEST:  ${chain.latest.hash.toString('hex') || '-'}`,
     `TREES:   ${trees.valid ? 'OK' : `ERROR: ${String(trees.reason)}`}`,
     '======',
   )
-
-  if (!chain.genesis || !chain.head || !chain.latest) {
-    return content
-  }
 
   start = start || chain.genesis.sequence
   end = end || chain.latest.sequence

--- a/ironfish/src/rpc/routes/faucet/giveMe.test.ts
+++ b/ironfish/src/rpc/routes/faucet/giveMe.test.ts
@@ -13,7 +13,7 @@ describe('Route faucet.giveMe', () => {
     await expect(
       routeTest.adapter.request('faucet/giveMe', { accountName: 'test-notfound' }),
     ).rejects.toThrow('Account test-notfound could not be found')
-  })
+  }, 10000)
 
   describe('With a default account and the db', () => {
     let accountName = 'test' + Math.random().toString()
@@ -38,7 +38,7 @@ describe('Route faucet.giveMe', () => {
         params: { email, publicKey: publicAddress },
       })
       expect(response.content).toMatchObject(apiResponse)
-    })
+    }, 10000)
 
     it('throws an error if the API request fails', async () => {
       const apiResponse = new Error('API failure') as AxiosError
@@ -46,6 +46,6 @@ describe('Route faucet.giveMe', () => {
       await expect(
         routeTest.adapter.request('faucet/giveMe', { accountName, email }),
       ).rejects.toThrow('API failure')
-    })
+    }, 10000)
   })
 })

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -116,8 +116,8 @@ function getStatus(node: IronfishNode): GetStatusResponse {
     },
     blockchain: {
       synced: node.chain.synced,
-      head: `${node.chain.head?.hash.toString('hex') || ''} (${
-        node.chain.head?.sequence.toString() || ''
+      head: `${node.chain.head.hash.toString('hex') || ''} (${
+        node.chain.head.sequence.toString() || ''
       })`,
     },
     node: {

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -19,6 +19,7 @@ import { Platform } from './platform'
 import { IronfishVerifier } from './consensus'
 import { IronfishStrategy } from './strategy'
 import { FileReporter } from './logger/reporters'
+import { IronfishBlockSerialized } from './primitives/block'
 
 export class IronfishSdk {
   agent: string
@@ -155,7 +156,15 @@ export class IronfishSdk {
     )
   }
 
-  async node({ databaseName }: { databaseName?: string } = {}): Promise<IronfishNode> {
+  async node({
+    databaseName,
+    loadGenesisBlock,
+    autoSeed,
+  }: {
+    databaseName?: string
+    loadGenesisBlock?: () => Promise<IronfishBlockSerialized>
+    autoSeed?: boolean
+  } = {}): Promise<IronfishNode> {
     const webSocket = (await require('ws')) as IsomorphicWebSocketConstructor
     const webRtc = (await require('wrtc')) as IsomorphicWebRtc | undefined
 
@@ -165,6 +174,8 @@ export class IronfishSdk {
       internal: this.internal,
       files: this.fileSystem,
       databaseName: databaseName,
+      loadGenesisBlock: loadGenesisBlock,
+      autoSeed: autoSeed,
       logger: this.logger,
       metrics: this.metrics,
       verifierClass: this.verifierClass,

--- a/ironfish/src/syncer.test.ts
+++ b/ironfish/src/syncer.test.ts
@@ -21,9 +21,8 @@ describe('Syncer', () => {
     expect(syncer.state).toBe('stopped')
   })
 
-  it('should load from peer with more work', async () => {
-    const { node, chain, peerNetwork, syncer } = nodeTest
-    await node.seed()
+  it('should load from peer with more work', () => {
+    const { chain, peerNetwork, syncer } = nodeTest
     Assert.isNotNull(chain.head)
 
     const startSyncSpy = jest.spyOn(syncer, 'startSync').mockImplementation()
@@ -47,8 +46,7 @@ describe('Syncer', () => {
   }, 10000)
 
   it('should sync and then finish from peer', async () => {
-    const { node, peerNetwork, syncer } = nodeTest
-    await node.seed()
+    const { peerNetwork, syncer } = nodeTest
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
     peer.work = BigInt(1)
@@ -74,8 +72,7 @@ describe('Syncer', () => {
   })
 
   it('should stop syncing on error', async () => {
-    const { node, peerNetwork, syncer } = nodeTest
-    await node.seed()
+    const { peerNetwork, syncer } = nodeTest
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
     peer.work = BigInt(1)
@@ -104,9 +101,8 @@ describe('Syncer', () => {
     expect(peer.error).toBe(error)
   })
 
-  it('should stop syncing when peer disconnects', async () => {
-    const { node, peerNetwork, syncer } = nodeTest
-    await node.seed()
+  it('should stop syncing when peer disconnects', () => {
+    const { peerNetwork, syncer } = nodeTest
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
     peer.work = BigInt(1)
@@ -139,8 +135,10 @@ describe('Syncer', () => {
   })
 
   it('should sync blocks', async () => {
-    const { strategy, node, chain, peerNetwork, syncer } = nodeTest
-    const genesis = await node.seed()
+    const { strategy, chain, peerNetwork, syncer } = nodeTest
+
+    const genesis = await chain.getBlock(chain.genesis)
+    Assert.isNotNull(genesis)
 
     strategy.disableMiningReward()
     syncer.blocksPerMessage = 1

--- a/ironfish/src/testUtilities/helpers/blockchain.ts
+++ b/ironfish/src/testUtilities/helpers/blockchain.ts
@@ -66,7 +66,6 @@ export async function makeBlockWithTransaction(
   from: Account,
   to: Account,
 ): Promise<IronfishBlock> {
-  Assert.isNotNull(node.chain.head, 'No genesis block. Call node.seed() first')
   const sequence = node.chain.head.sequence
 
   const block1 = await useMinerBlockFixture(

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -13,7 +13,12 @@ import { ConfigOptions } from '../fileStores/config'
 import { PeerNetwork } from '../network'
 import { Syncer } from '../syncer'
 
-export type NodeTestOptions = { config?: Partial<ConfigOptions> } | undefined
+export type NodeTestOptions =
+  | {
+      config?: Partial<ConfigOptions>
+      autoSeed?: boolean
+    }
+  | undefined
 
 /**
  * Used as an easy wrapper for testing the node, and blockchain. Use
@@ -60,7 +65,7 @@ export class NodeTest {
     const strategyClass = IronfishTestStrategy
 
     const sdk = await IronfishSdk.init({ dataDir, verifierClass, strategyClass })
-    const node = await sdk.node()
+    const node = await sdk.node({ autoSeed: this.options?.autoSeed })
     const strategy = node.strategy as IronfishTestStrategy
     const chain = node.chain
     const peerNetwork = node.peerNetwork
@@ -117,11 +122,11 @@ export function createNodeTest(preserveState = false, options: NodeTestOptions =
   const nodeTest = new NodeTest(options)
 
   if (preserveState) {
-    beforeAll(() => nodeTest.setup())
+    beforeAll(() => nodeTest.setup(), 10000)
     afterEach(() => nodeTest.teardownEach())
     afterAll(() => nodeTest.teardownAll())
   } else {
-    beforeEach(() => nodeTest.setup())
+    beforeEach(() => nodeTest.setup(), 10000)
     afterEach(() => nodeTest.teardownEach())
     afterEach(() => nodeTest.teardownAll())
   }

--- a/ironfish/src/testUtilities/routeTest.ts
+++ b/ironfish/src/testUtilities/routeTest.ts
@@ -67,7 +67,7 @@ export class RouteTest extends NodeTest {
  */
 export function createRouteTest(): RouteTest {
   const routeTest = new RouteTest()
-  beforeAll(() => routeTest.setup())
+  beforeAll(() => routeTest.setup(), 10000)
   afterEach(() => routeTest.teardownEach())
   afterAll(() => routeTest.teardownAll())
   return routeTest

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prebuild": "node tools/node-platform-check && (cd ironfish-wasm && yarn build)",
     "preinstall": "node tools/node-platform-check && (cd ironfish-wasm && yarn build)",
     "test": "lerna run test",
-    "test:coverage": "lerna run test --stream -- --collect-coverage",
+    "test:coverage": "lerna run test --stream --concurrency 1 -- --collect-coverage",
     "test:coverage:html": "lerna run test:coverage:html",
     "test:changed": "lerna run --since origin/master --include-dependents test",
     "test:update": "lerna run test -- -u",


### PR DESCRIPTION
* Removes node.seed() and moves the contents into chain.open(). Added an `autoSeed` option to help the outdated jest tests pass.
* Changes chain.head, chain.latest, and chain.genesis into properties that throw if their backing field is null. These should typically only ever be null if the chain hasn't been initialized with the genesis block, then should be set after that.
