### PR TITLE
Prevent node from starting up if the DB is corrupt

### DIFF
--- a/ironfish-cli/src/commands/start.test.ts
+++ b/ironfish-cli/src/commands/start.test.ts
@@ -30,7 +30,15 @@ jest.mock('ironfish', () => {
 describe('start command', () => {
   let isFirstRun = true
   let hasGenesisBlock = false
-  const chain: { hasGenesisBlock: boolean } = {
+
+  const verifier = {
+    blockMatchesTrees: jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ valid: true, reason: null })),
+  }
+
+  const chain = {
+    verifier: verifier,
     hasGenesisBlock: hasGenesisBlock,
   }
 

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -137,6 +137,17 @@ export default class Start extends IronfishCommand {
       return startDoneResolve()
     }
 
+    const trees = await node.chain.verifier.blockMatchesTrees(node.chain.head)
+    if (!trees.valid) {
+      this.log(
+        `Error starting node: your merkle trees are corrupt: ${String(trees.reason)}.` +
+          `\n  1. Run ironfish chain:repair to attempt repair` +
+          `\n  2. Delete your database at ${node.config.chainDatabasePath}`,
+      )
+
+      this.exit(1)
+    }
+
     if (node.internal.get('isFirstRun')) {
       await this.firstRun(node)
     }


### PR DESCRIPTION
Print a warning and don't let the user start the node if its corrupt