### PR TITLE
Ban peers that send empty responses to GetBlocks

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -353,11 +353,18 @@ export class Syncer {
         )} (${sequence}) from ${peer.displayName}`,
       )
 
-      const [, ...blocks]: IronfishBlockSerialized[] = await this.peerNetwork.getBlocks(
+      const [
+        headBlock,
+        ...blocks
+      ]: IronfishBlockSerialized[] = await this.peerNetwork.getBlocks(
         peer,
         head,
         this.blocksPerMessage + 1,
       )
+
+      if (headBlock == null) {
+        peer.punish(BAN_SCORE.MAX, 'empty GetBlocks message')
+      }
 
       this.abort(peer)
 


### PR DESCRIPTION
Bans peers if they send an empty response to GetBlocks. Since we only make the request with block hashes we already asked them about, and GetBlocks includes the block you requested, this should indicate a bug if it happens.
