### PR TITLE
Increase peer banscores when sending invalid limits in block/hash requests

### DIFF
--- a/ironfish/src/network/messageRouters/rpc.ts
+++ b/ironfish/src/network/messageRouters/rpc.ts
@@ -241,7 +241,9 @@ export class RpcRouter {
         }
       }
 
-      this.peerManager.sendTo(peer, responseMessage)
+      if (peer.state.type === 'CONNECTED') {
+        this.peerManager.sendTo(peer, responseMessage)
+      }
     } else {
       const request = this.requests.get(rpcId)
       if (request) {

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -42,7 +42,7 @@ import {
   CannotSatisfyRequestError,
   IncomingGossipGeneric,
 } from './messageRouters'
-import { Peer } from './peers/peer'
+import { BAN_SCORE, Peer } from './peers/peer'
 import { LocalPeer } from './peers/localPeer'
 import { Identity } from './identity'
 import { parseUrl } from './utils/parseUrl'
@@ -652,15 +652,20 @@ export class PeerNetwork {
   ): Promise<GetBlockHashesResponse['payload']> {
     const peer = this.peerManager.getPeerOrThrow(request.peerIdentity)
 
-    if (request.message.payload.limit === 0) {
-      // TODO: increase banscore LOW
+    if (request.message.payload.limit <= 0) {
+      peer.punish(
+        BAN_SCORE.LOW,
+        `Peer sent GetBlockHashes with limit of ${request.message.payload.limit}`,
+      )
       return { blocks: [] }
     }
 
     if (request.message.payload.limit > MAX_REQUESTED_BLOCKS) {
-      // TODO: increase banscore MAX
+      peer.punish(
+        BAN_SCORE.MAX,
+        `Peer sent GetBlockHashes with limit of ${request.message.payload.limit}`,
+      )
       const error = new CannotSatisfyRequestError(`Requested more than ${MAX_REQUESTED_BLOCKS}`)
-      peer.close(error)
       throw error
     }
 
@@ -689,14 +694,19 @@ export class PeerNetwork {
     const peer = this.peerManager.getPeerOrThrow(request.peerIdentity)
 
     if (request.message.payload.limit === 0) {
-      // TODO: increase banscore LOW
+      peer.punish(
+        BAN_SCORE.LOW,
+        `Peer sent GetBlocks with limit of ${request.message.payload.limit}`,
+      )
       return { blocks: [] }
     }
 
     if (request.message.payload.limit > MAX_REQUESTED_BLOCKS) {
-      // TODO: increase banscore MAX
+      peer.punish(
+        BAN_SCORE.MAX,
+        `Peer sent GetBlocks with limit of ${request.message.payload.limit}`,
+      )
       const error = new CannotSatisfyRequestError(`Requested more than ${MAX_REQUESTED_BLOCKS}`)
-      peer.close(error)
       throw error
     }
 

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -433,7 +433,14 @@ export class Peer {
   }
 
   getConnectionRetry(type: ConnectionType, direction: ConnectionDirection.Inbound): null
-  getConnectionRetry(type: ConnectionType, direction: ConnectionDirection): ConnectionRetry
+  getConnectionRetry(
+    type: ConnectionType,
+    direction: ConnectionDirection.Outbound,
+  ): ConnectionRetry
+  getConnectionRetry(
+    type: ConnectionType,
+    direction: ConnectionDirection,
+  ): ConnectionRetry | null
   getConnectionRetry(
     type: ConnectionType,
     direction: ConnectionDirection,

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -607,7 +607,7 @@ export class Peer {
     }
 
     this.logger.info(`Peer ${this.displayName} has been banned: ${reason || 'UNKNOWN'}`)
-    this.close(`BANNED: ${reason || 'UNKNOWN'}`)
+    this.close(new Error(`BANNED: ${reason || 'UNKNOWN'}`))
     this.onBanned.emit()
     return true
   }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -900,7 +900,7 @@ export class PeerManager {
     }
 
     if (this.banned.has(identity)) {
-      peer.getConnectionRetry(connection.type, connection.direction).neverRetryConnecting()
+      peer.getConnectionRetry(connection.type, connection.direction)?.neverRetryConnecting()
       peer.close(new Error('banned'))
       return
     }


### PR DESCRIPTION
Also fixes a few additional issues I ran into when testing the banning:

- Throw an error when banning the peer
- Drop RPC responses if peer is no longer connected
- Fix typing of neverRetryConnecting
