### PR TITLE
Add locks and move transactions for addBlock

### DIFF
--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -306,8 +306,7 @@ export class Verifier<
   // TODO: Rename to verifyBlock but merge verifyBlock into this
   async verifyBlockAdd(
     block: Block<E, H, T, SE, SH, ST>,
-    prev: BlockHeader<E, H, T, SE, SH, ST> | null,
-    tx: IDatabaseTransaction,
+    prev: BlockHeader<E, H, T, SE, SH, ST> | null
   ): Promise<VerificationResult> {
     if (block.header.sequence === GENESIS_BLOCK_SEQUENCE) {
       return { valid: Validity.Yes }
@@ -332,7 +331,7 @@ export class Verifier<
         return verification
       }
 
-      verification = await this.hasValidSpends(block, tx)
+      verification = await this.hasValidSpends(block)
       if (verification.valid == Validity.No) {
         return verification
       }

--- a/ironfish/src/mutex.test.ts
+++ b/ironfish/src/mutex.test.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Mutex } from './mutex'
+import { PromiseUtils } from './utils'
+
+describe('Mutex', () => {
+  it('should lock and unlock', async () => {
+    const mutex = new Mutex()
+
+    expect(mutex.locked).toBe(false)
+    expect(mutex.waiting).toBe(0)
+
+    const unlock = await mutex.lock()
+
+    expect(mutex.locked).toBe(true)
+    expect(mutex.waiting).toBe(0)
+
+    unlock()
+
+    expect(mutex.locked).toBe(false)
+    expect(mutex.waiting).toBe(0)
+  })
+
+  it('should lock exlusively', async () => {
+    const mutex = new Mutex()
+    const [promiseA, resolveA] = PromiseUtils.split<void>()
+    const [promiseB, resolveB] = PromiseUtils.split<void>()
+    const [promiseC, resolveC] = PromiseUtils.split<void>()
+
+    let mutated = ''
+
+    const test = async (key: string, wait: Promise<void>) => {
+      const unlock = await mutex.lock()
+      await wait
+      mutated = key
+      unlock()
+    }
+
+    expect(mutex.locked).toBe(false)
+    expect(mutex.waiting).toBe(0)
+    expect(mutated).toEqual('')
+
+    const waitA = test('a', promiseA)
+
+    expect(mutex.locked).toBe(true)
+    expect(mutex.waiting).toBe(0)
+    expect(mutated).toEqual('')
+
+    const waitB = test('b', promiseB)
+
+    expect(mutex.locked).toBe(true)
+    expect(mutex.waiting).toBe(1)
+    expect(mutated).toEqual('')
+
+    const waitC = test('c', promiseC)
+
+    expect(mutex.locked).toBe(true)
+    expect(mutex.waiting).toBe(2)
+    expect(mutated).toEqual('')
+
+    resolveA()
+    await waitA
+
+    expect(mutex.locked).toBe(true)
+    expect(mutex.waiting).toBe(1)
+    expect(mutated).toEqual('a')
+
+    resolveB()
+    await waitB
+
+    expect(mutex.locked).toBe(true)
+    expect(mutex.waiting).toBe(0)
+    expect(mutated).toEqual('b')
+
+    resolveC()
+    await waitC
+
+    expect(mutex.locked).toBe(false)
+    expect(mutex.waiting).toBe(0)
+    expect(mutated).toEqual('c')
+  })
+})

--- a/ironfish/src/mutex.ts
+++ b/ironfish/src/mutex.ts
@@ -6,21 +6,33 @@ export type MutexUnlockFunction = () => void
 
 export class Mutex {
   private mutex = Promise.resolve()
+  private _count = 0
+
+  get waiting(): number {
+    return Math.max(this._count - 1, 0)
+  }
+
+  get locked(): boolean {
+    return this._count > 0
+  }
 
   lock(): PromiseLike<MutexUnlockFunction> {
     let begin: (unlock: MutexUnlockFunction) => void
 
     this.mutex = this.mutex.then(() => {
+      this._count--
       return new Promise(begin)
     })
 
     return new Promise<MutexUnlockFunction>((resolve) => {
+      this._count++
       begin = resolve
     })
   }
 
-  async dispatch<T>(fn: (() => T) | (() => PromiseLike<T>)): Promise<T> {
+  async run<T>(fn: (() => T) | (() => PromiseLike<T>)): Promise<T> {
     const unlock = await this.lock()
+
     try {
       return await Promise.resolve(fn())
     } finally {


### PR DESCRIPTION
This does three things

1. Adds a a new Lock class that can be used outside of transactions
2. Moves the global transaction / lock around addBlock down into the actual database operations
3. Uses the new Lock class to lock addBlock without opening a transaction