### PR TITLE
Commit addBlock state after each DB operation

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1255,12 +1255,15 @@ export class Blockchain<
     prev: BlockHeader<E, H, T, SE, SH, ST>,
     tx: IDatabaseTransaction,
   ): Promise<void> {
+    // TODO: transaction goes here
     await this.hashToNextHash.put(prev.hash, block.header.hash, tx)
     await this.sequenceToHash.put(block.header.sequence, block.header.hash, tx)
 
     await this.saveConnect(block, prev, tx)
 
     await this.meta.put('head', prev.hash, tx)
+
+    await tx.update()
   }
 
   private async saveDisconnect(
@@ -1278,6 +1281,8 @@ export class Blockchain<
     ])
 
     await this.meta.put('head', prev.hash, tx)
+
+    await tx.update()
   }
 
   private async saveBlock(
@@ -1312,6 +1317,8 @@ export class Blockchain<
       this.latest = block.header
       await this.meta.put('latest', hash, tx)
     }
+
+    await tx.update()
   }
 
   private updateSynced(): void {

--- a/ironfish/src/storage/database/transaction.ts
+++ b/ironfish/src/storage/database/transaction.ts
@@ -19,6 +19,11 @@
  */
 export interface IDatabaseTransaction {
   /**
+   * Commit the transaction atomically to the database but do not release the database lock
+   * */
+  update(): Promise<void>
+
+  /**
    * Commit the transaction atomically to the database and release the database lock
    * */
   commit(): Promise<void>

--- a/ironfish/src/storage/levelup/transaction.ts
+++ b/ironfish/src/storage/levelup/transaction.ts
@@ -149,16 +149,23 @@ export class LevelupTransaction implements IDatabaseTransaction {
     this.cacheDelete.add(cacheKey)
   }
 
-  async commit(): Promise<void> {
+  async update(): Promise<void> {
     try {
       if (!this.aborting) {
         await this.batch.commit()
       }
     } finally {
-      this.releaseLock()
       this.cache.clear()
       this.cacheDelete.clear()
       this.committing = false
+    }
+  }
+
+  async commit(): Promise<void> {
+    try {
+      await this.update()
+    } finally {
+      this.releaseLock()
     }
   }
 


### PR DESCRIPTION
We had one transaction / lock around blockchain.addBlock(), that if
rolled back, would leave dirty in memory state. To solve that
temporarily, we added a new IDatabaseTransaction.update() function which
updates the database but does not release the lock. This allows us to
commit state to the DB without releasing locks.

Alternatively, we can look at other solutions in the future where
transactions can be moved downwards to the things that need to be
atomic.