### PR TITLE
Dont gossip blocks when we don't add the block

### DIFF
--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -748,7 +748,7 @@ export class PeerNetwork {
     if (!peer) return false
 
     try {
-      await this.node.syncer.addNewBlock(peer, block)
+      return await this.node.syncer.addNewBlock(peer, block)
     } catch (error) {
       this.logger.error(
         `Error when adding new block ${block.header.sequence} from ${
@@ -758,8 +758,6 @@ export class PeerNetwork {
 
       return false
     }
-
-    return true
   }
 
   private async onNewTransaction(

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -462,26 +462,28 @@ export class Syncer {
     return { added: true, block, reason: reason || null }
   }
 
-  async addNewBlock(peer: Peer, newBlock: IronfishBlockSerialized): Promise<void> {
+  async addNewBlock(peer: Peer, newBlock: IronfishBlockSerialized): Promise<boolean> {
     // We drop blocks when we are still initially syncing as they
     // will become loose blocks and we can't verify them
     if (!this.chain.synced) {
-      return
+      return false
     }
 
     if (this.loader) {
-      return
+      return false
     }
 
     if (whitelist.size && !whitelist.has(peer.name || '')) {
-      return
+      return false
     }
 
-    const { block } = await this.addBlock(peer, newBlock)
+    const { added, block } = await this.addBlock(peer, newBlock)
 
     if (!peer.sequence || block.header.sequence > peer.sequence) {
       peer.sequence = block.header.sequence
     }
+
+    return added
   }
 
   protected async syncOrphan(peer: Peer, hash: BlockHash): Promise<void> {


### PR DESCRIPTION
We should only gossip blocks when we added them, because if we gossip a
block, it signals to others that we also have that block on our chain.
It's useful because if someone gets our gossip block, and its an orphan,
they will want to download the chain from us to that oprhan. So if we
gossip without adding, then that won't work.

Many coins distinguish this as announce vs broadcast, where announce
tells people we have it, and broadcast gossips it without indicating we
have it or not. Announce sends entire hash, broadcast sends entire
block.

If you look at the code, there is one situation here where we have the
block but we don't gossip it, and that's when it's a duplicate and we
already have it. At that point we don't regossip it out. We can
determine if we should be gossiping it out later in this case.