### PR TITLE
Change log for sending to not connected peers

### DIFF
--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -396,7 +396,7 @@ export class Peer {
   send(message: LooseMessage): Connection | null {
     // Return early if peer is not in state CONNECTED
     if (this.state.type !== 'CONNECTED') {
-      this.logger.warn(
+      this.logger.debug(
         `Attempted to send a ${message.type} message to ${this.displayName} in state ${this.state.type}`,
       )
       return null


### PR DESCRIPTION
We don't have time to look into and fix these right now, and they're
disturbing users.