### PR TITLE
Look up brokering peer before sending signal

### DIFF
--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -1076,7 +1076,8 @@ describe('PeerManager', () => {
 
       peer.onMessage.emit(message, connection)
       expect(initWebRtcConnectionMock).toBeCalledTimes(1)
-      expect(initWebRtcConnectionMock).toBeCalledWith(peer, peer, true)
+      expect(initWebRtcConnectionMock).toBeCalledWith(peer, true)
+      expect(pm['getBrokeringPeer'](peer)).toEqual(peer)
     })
 
     it('Sends a disconnect message if we are at max peers', () => {


### PR DESCRIPTION
The brokering peer may no longer be connected when we're attempting to send a signal message through it. We should look up a brokering peer as needed when a new signal message needs to be sent out. This should fix the "Attempting to send a signal message to peer in state CONNECTING/DISCONNECTED" logs.﻿
