### PR TITLE
Provide more info about old clients connecting

### DIFF
--- a/ironfish/src/network/messages.ts
+++ b/ironfish/src/network/messages.ts
@@ -8,6 +8,8 @@ import { SerializedBlock } from '../primitives/block'
 import { Gossip, Rpc } from './messageRouters'
 import { UnwrapPromise } from '../utils'
 import { IronfishVerifier } from '../consensus'
+import { Peer } from './peers/peer'
+import { Connection } from './peers/connections'
 
 /**
  * The type of the message for the purposes of routing within our code.
@@ -477,3 +479,25 @@ export type NewTransactionMessage = Gossip<
   NodeMessageType.NewTransaction,
   UnwrapPromise<ReturnType<IronfishVerifier['verifyNewTransaction']>>
 >
+
+/**
+ * Used to just try to get an identify version, even if the identify is malformed
+ * because we want to debug why someone sent us a malformed identify.
+ * */
+export function getIdentifyVersion(obj: unknown): string | null {
+  if (!isPayloadMessage(obj)) return null
+
+  const payload = obj.payload as Identify['payload']
+
+  if (
+    obj.type === InternalMessageType.identity &&
+    typeof payload === 'object' &&
+    payload != null &&
+    payload.version != null &&
+    (typeof payload.version === 'string' || typeof payload.version === 'number')
+  ) {
+    return String(payload.version)
+  }
+
+  return null
+}

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -99,15 +99,23 @@ export class Peer {
    * try Peer.name or Peer.state.identity.
    */
   get displayName(): string {
-    if (this.state.identity === null) {
-      return 'unidentified'
+    if (this.state.identity !== null) {
+      const identitySlice = this.state.identity.slice(0, 7)
+      if (this.name) {
+        return `${identitySlice} (${this.name})`
+      }
+      return identitySlice
     }
 
-    const identitySlice = this.state.identity.slice(0, 7)
-    if (this.name) {
-      return `${identitySlice} (${this.name})`
+    if (this.address) {
+      const name = this.address
+      if (this.port) {
+        this.name += ':' + String(this.port)
+      }
+      return name
     }
-    return identitySlice
+
+    return 'unidentified'
   }
 
   /**

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -17,6 +17,7 @@ import {
 import {
   DisconnectingMessage,
   DisconnectingReason,
+  getIdentifyVersion,
   IncomingPeerMessage,
   InternalMessageType,
   isDisconnectingMessage,
@@ -887,10 +888,16 @@ export class PeerManager {
   ): void {
     // If we receive any message other than an Identity message, close the connection
     if (!isIdentify(message)) {
-      this.logger.debug(
-        `Disconnecting from ${peer.displayName} - Sent unexpected message ${message.type} while waiting for identity`,
-      )
-      peer.close()
+      let error = `Disconnecting from ${peer.displayName} - Sent unexpected message ${message.type} while waiting for identity`
+
+      // If we can parse out their old version, lets display that instead
+      const oldVersion = getIdentifyVersion(message)
+      if (oldVersion) {
+        error = `Old peer attempted to connect to us from ${peer.displayName}: ${oldVersion}`
+      }
+
+      this.logger.debug(error)
+      peer.close(error)
       return
     }
 


### PR DESCRIPTION
 - Use peer host as name if they are unidentified
 - Print out information about their version if they connect from an old
 version