### PR TITLE
Dont drop gossip messages if you are syncing

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -471,10 +471,6 @@ export class Syncer {
       return false
     }
 
-    if (this.loader) {
-      return false
-    }
-
     if (whitelist.size && !whitelist.has(peer.name || '')) {
       return false
     }


### PR DESCRIPTION
I think this is preventing syncing from handling gossips while were in
the middle of syncing orphan chains from others.