### PR TITLE
feat(ironfish-cli): Support TCP RPC for `config:get` and `config:set`

### DIFF
--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
 import { ConfigOptions } from 'ironfish'
-import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey } from '../../flags'
+import { RemoteFlags } from '../../flags'
 import { IronfishCommand } from '../../command'
 import jsonColorizer from 'json-colorizer'
 import { getConnectedClient } from './show'
@@ -21,8 +21,7 @@ export class GetCommand extends IronfishCommand {
   ]
 
   static flags = {
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
+    ...RemoteFlags,
     user: flags.boolean({
       description: 'only show config from the users datadir and not overrides',
     }),

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey } from '../../flags'
+import { RemoteFlags } from '../../flags'
 import { IronfishCommand } from '../../command'
 import { getConnectedClient } from './show'
 
@@ -25,8 +25,7 @@ export class SetCommand extends IronfishCommand {
   ]
 
   static flags = {
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
+    ...RemoteFlags,
     local: flags.boolean({
       default: false,
       description: 'dont connect to the node when updating the config',


### PR DESCRIPTION
Allow node connections over TCP RPC