### PR TITLE
Handle gossip blocks when we dont have a syncer

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -467,7 +467,7 @@ export class Syncer {
   async addNewBlock(peer: Peer, newBlock: IronfishBlockSerialized): Promise<boolean> {
     // We drop blocks when we are still initially syncing as they
     // will become loose blocks and we can't verify them
-    if (!this.chain.synced) {
+    if (!this.chain.synced && this.loader) {
       return false
     }
 


### PR DESCRIPTION
Before we didn't handle gossip blocks when we were syncing, now we can
do it if we don't have a syncer. This can help fix when we're stuck ina
small network without a lot of blocks being produced. If someone manages
to get a block in the network, and were not synced, this will now kick
off the syncing process