### PR TITLE
Change signal log from `name` to `displayName`

### DIFF
--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -1262,7 +1262,7 @@ export class PeerManager {
       ) {
         this.logger.debug(
           'not handling signal message from',
-          signalingPeer.name,
+          signalingPeer.displayName,
           'because source peer should have requested signaling',
         )
         return


### PR DESCRIPTION
This was showing up in our logs as "not handling signal message from null" instead of displaying the identity if the peer has no name.
