### PR TITLE
Fix reconnect updating the chain head to the wrong hash

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1212,7 +1212,7 @@ export class Blockchain<
 
     await this.saveConnect(block, prev, tx)
 
-    await this.meta.put('head', prev.hash, tx)
+    await this.meta.put('head', block.header.hash, tx)
 
     await tx.update()
   }


### PR DESCRIPTION
This should be the hash of the connected block rather than the previous block.
