### PR TITLE
Lock database before executing transaction handlers

### DIFF
--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -602,7 +602,7 @@ export default class MerkleTree<
       async (tx) => {
         const authenticationPath: WitnessNode<H>[] = []
 
-        const leafCount = await this.size()
+        const leafCount = await this.size(tx)
         if (leafCount === 0 || index >= leafCount) {
           return null
         }

--- a/ironfish/src/storage/database.test.ts
+++ b/ironfish/src/storage/database.test.ts
@@ -564,23 +564,23 @@ describe('Database', () => {
     it('should wait for a lock before executing the handler', async () => {
       await db.open()
 
-      let value = null
+      let value = ''
 
       const [waitingPromise, waitingResolve] = PromiseUtils.split<void>()
 
       // Queue up two transactions
       const t1 = db.transaction([db.metaStore], 'readwrite', async () => {
-        value = 't1'
+        value += 't1'
         await waitingPromise
       })
 
       const t2 = db.transaction([db.metaStore], 'readwrite', async () => {
-        value = 't2'
+        value += 't2'
         await waitingPromise
       })
 
       const t3 = db.transaction([db.metaStore], 'readwrite', async () => {
-        value = 't3'
+        value += 't3'
         await waitingPromise
       })
 
@@ -595,7 +595,7 @@ describe('Database', () => {
 
       // t2's handler should have executed,
       // then t3's handler should have executed
-      expect(value).toEqual('t3')
+      expect(value).toEqual('t1t2t3')
     })
   })
 

--- a/ironfish/src/storage/database.test.ts
+++ b/ironfish/src/storage/database.test.ts
@@ -569,7 +569,7 @@ describe('Database', () => {
       const [waitingPromise, waitingResolve] = PromiseUtils.split<void>()
 
       // Queue up two transactions
-      const t1 = db.withTransaction(null, [db.metaStore], 'readwrite', async () => {
+      const t1 = db.transaction([db.metaStore], 'readwrite', async () => {
         value = 't1'
         await waitingPromise
       })
@@ -578,6 +578,8 @@ describe('Database', () => {
         value = 't2'
         await waitingPromise
       })
+
+      await PromiseUtils.sleep(0)
 
       // t2's handler should not have been called yet
       expect(value).toEqual('t1')

--- a/ironfish/src/storage/database.test.ts
+++ b/ironfish/src/storage/database.test.ts
@@ -574,8 +574,13 @@ describe('Database', () => {
         await waitingPromise
       })
 
-      const t2 = db.withTransaction(null, [db.metaStore], 'readwrite', async () => {
+      const t2 = db.transaction([db.metaStore], 'readwrite', async () => {
         value = 't2'
+        await waitingPromise
+      })
+
+      const t3 = db.transaction([db.metaStore], 'readwrite', async () => {
+        value = 't3'
         await waitingPromise
       })
 
@@ -586,10 +591,11 @@ describe('Database', () => {
 
       // Resolve the promise and wait for the transactions to finish
       waitingResolve()
-      await Promise.all([t1, t2])
+      await Promise.all([t1, t2, t3])
 
-      // t2's handler should have executed
-      expect(value).toEqual('t2')
+      // t2's handler should have executed,
+      // then t3's handler should have executed
+      expect(value).toEqual('t3')
     })
   })
 

--- a/ironfish/src/storage/database.test.ts
+++ b/ironfish/src/storage/database.test.ts
@@ -584,6 +584,10 @@ describe('Database', () => {
         await waitingPromise
       })
 
+      // We need this here to flush the pending promises synchronously,
+      // because if you don't, then t1 won't execute eagerly because of
+      // how Mutex is implemented. Mutex.lock depends on deferred promise
+      // execution and cannot execute eagerly.
       await PromiseUtils.sleep(0)
 
       // t2's handler should not have been called yet

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -205,6 +205,7 @@ export abstract class Database implements IDatabase {
     transaction = transaction || this.transaction(scopes, type)
 
     try {
+      await transaction.acquireLock()
       const result = await handler(transaction)
       if (created) await transaction.commit()
       return result

--- a/ironfish/src/storage/database/transaction.ts
+++ b/ironfish/src/storage/database/transaction.ts
@@ -19,6 +19,11 @@
  */
 export interface IDatabaseTransaction {
   /**
+   * Lock the database
+   */
+  acquireLock(): Promise<void>
+
+  /**
    * Commit the transaction atomically to the database but do not release the database lock
    * */
   update(): Promise<void>


### PR DESCRIPTION
The database code runs transaction handlers immediately and doesn't block them until they reach a database call, so logic in the transaction handlers that's dependent on external state could be incorrect. We were seeing issues that seemed to stem from this because we forgot to pass in the transactions in all cases, but it seems safer for now to lock around the entire transaction handler and reduce the amount of work being done inside of transaction handlers if possible.
