### PR TITLE
Make iterate errors optional

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -137,7 +137,12 @@ export class Accounts {
 
       // Remove the old fork chain
       if (!isLinear) {
-        for await (const header of this.chain.iterateFrom(accountHead, fork)) {
+        for await (const header of this.chain.iterateFrom(
+          accountHead,
+          fork,
+          undefined,
+          false,
+        )) {
           // Don't remove the fork
           if (!header.hash.equals(fork.hash)) {
             await removeBlock(header)
@@ -147,7 +152,7 @@ export class Accounts {
         }
       }
 
-      for await (const header of this.chain.iterateTo(fork, chainHead)) {
+      for await (const header of this.chain.iterateTo(fork, chainHead, undefined, false)) {
         if (header.hash.equals(fork.hash)) continue
         await addBlock(header)
         await this.updateHeadHash(header.hash.toString('hex'))

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -413,8 +413,9 @@ export class Blockchain<
     start: BlockHeader<E, H, T, SE, SH, ST>,
     end?: BlockHeader<E, H, T, SE, SH, ST>,
     tx?: IDatabaseTransaction,
+    reachable = true,
   ): AsyncGenerator<BlockHeader<E, H, T, SE, SH, ST>, void, void> {
-    for await (const hash of this.iterateToHashes(start, end, tx)) {
+    for await (const hash of this.iterateToHashes(start, end, tx, reachable)) {
       const header = await this.getHeader(hash, tx)
       Assert.isNotNull(header)
       yield header
@@ -425,6 +426,7 @@ export class Blockchain<
     start: BlockHeader<E, H, T, SE, SH, ST>,
     end?: BlockHeader<E, H, T, SE, SH, ST>,
     tx?: IDatabaseTransaction,
+    reachable = true,
   ): AsyncGenerator<BlockHash, void, void> {
     let current = start.hash as BlockHash | null
     const max = end ? end.sequence - start.sequence : null
@@ -444,7 +446,7 @@ export class Blockchain<
       current = await this.getNextHash(current, tx)
     }
 
-    if (end && !current?.equals(end.hash)) {
+    if (reachable && end && !current?.equals(end.hash)) {
       throw new Error(
         'Failed to iterate between blocks on diverging forks:' +
           ` curr: ${HashUtils.renderHash(current)},` +
@@ -458,6 +460,7 @@ export class Blockchain<
     start: BlockHeader<E, H, T, SE, SH, ST>,
     end?: BlockHeader<E, H, T, SE, SH, ST>,
     tx?: IDatabaseTransaction,
+    reachable = true,
   ): AsyncGenerator<BlockHeader<E, H, T, SE, SH, ST>, void, void> {
     let current = start as BlockHeader<E, H, T, SE, SH, ST> | null
     const max = end ? start.sequence - end.sequence : null
@@ -477,7 +480,7 @@ export class Blockchain<
       current = await this.getPrevious(current, tx)
     }
 
-    if (end && !current?.hash.equals(end.hash)) {
+    if (reachable && end && !current?.hash.equals(end.hash)) {
       throw new Error(
         'Failed to iterate between blocks on diverging forks:' +
           ` current: '${HashUtils.renderHash(current?.hash)},'` +


### PR DESCRIPTION
So these errors are used to catch chain corruption, but now that we
fixed chain corruption bugs they are triggering in valid instances. Our
account head updates, but doesn't lock so the chain can be modified
while were iterating due to a reorg. This will cause accounts to
crash because these validation check that we should be able to validate
the entire expected range.

So in accounts it's fine if we have to abort due to a reorg. Honestly
long term we can consider removing these errors once this is polished
and we can be sure there are no more chain corruption issues for sure.