### PR TITLE
Force users to wipe DB from old version

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -260,7 +260,7 @@ export class Blockchain<
     if (this.opened) return
     this.opened = true
 
-    await this.db.open()
+    await this.db.open({ upgrade: this.forceUpgrade })
 
     let genesisHeader = await this.getHeaderAtSequence(GENESIS_BLOCK_SEQUENCE)
     if (!genesisHeader && this.autoSeed) {
@@ -1274,6 +1274,21 @@ export class Blockchain<
 
     this.synced = true
     this.onSynced.emit()
+  }
+
+  /**
+   * This is useful for now because we don't have a DB version system that works.
+   * to prevent this. See https://linear.app/ironfish/issue/IRO-706
+   */
+  private forceUpgrade = (db: unknown, oldVersion: number): Promise<void> => {
+    if (oldVersion === 0) return Promise.resolve()
+
+    this.logger.error(
+      `You are running a newer version of ironfish on an older database.\n` +
+        `Wipe your database using "ironfish reset" or delete your data directory at ~/.ironfish\n`,
+    )
+
+    process.exit(1)
   }
 }
 

--- a/ironfish/src/blockchain/schema.ts
+++ b/ironfish/src/blockchain/schema.ts
@@ -7,7 +7,7 @@ import { Transaction } from '../primitives/transaction'
 import { JsonSerializable } from '../serde'
 import { DatabaseSchema } from '../storage'
 
-export const SCHEMA_VERSION = 1
+export const SCHEMA_VERSION = 2
 
 export interface MetaSchema extends DatabaseSchema {
   key: 'head' | 'latest'


### PR DESCRIPTION
https://linear.app/ironfish/issue/IRO-706/warn-users-to-delete-db-from-betanet-upgrades

DONT MERGE THIS until we are ready to release to testnet.

This adds a hack that forces users to delete their database with a good
understandable error that will reduce questions in discord.