### PR TITLE
Fix ironfish reset by not checking upgrade

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -40,6 +40,9 @@ export default class Reset extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = this.parse(Reset)
 
+    let node = await this.sdk.node({ autoSeed: false })
+    await node.openDB({ upgrade: false })
+
     const backupPath = path.join(this.sdk.config.dataDir, 'accounts.backup.json')
 
     if (fs.existsSync(backupPath)) {
@@ -54,8 +57,6 @@ export default class Reset extends IronfishCommand {
       fs.rmSync(backupPath)
     }
 
-    let node = await this.sdk.node({ autoSeed: false })
-
     const confirmed =
       flags.confirm ||
       (await cli.confirm(
@@ -64,7 +65,6 @@ export default class Reset extends IronfishCommand {
 
     if (!confirmed) return
 
-    await node.openDB()
     const accounts = node.accounts.listAccounts()
     this.log(`Backing up ${accounts.length} accounts to ${backupPath}`)
     const backup = JSON.stringify(accounts, undefined, '  ')

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -137,7 +137,7 @@ export class AccountsDB {
     })
   }
 
-  async open(): Promise<void> {
+  async open(_options?: { upgrade?: boolean }): Promise<void> {
     await this.files.mkdir(this.location, { recursive: true })
     await this.database.open()
   }

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -249,11 +249,13 @@ export class Blockchain<
     return genesisHeader
   }
 
-  async open(): Promise<void> {
+  async open(options?: { upgrade?: boolean }): Promise<void> {
     if (this.opened) return
     this.opened = true
 
-    await this.db.open({ upgrade: this.forceUpgrade })
+    const upgrade = options?.upgrade ?? true
+
+    await this.db.open({ upgrade: upgrade ? this.forceUpgrade : undefined })
 
     let genesisHeader = await this.getHeaderAtSequence(GENESIS_BLOCK_SEQUENCE)
     if (!genesisHeader && this.autoSeed) {

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -215,12 +215,12 @@ export class IronfishNode {
     })
   }
 
-  async openDB(): Promise<void> {
+  async openDB(options?: { upgrade?: boolean }): Promise<void> {
     await this.files.mkdir(this.config.chainDatabasePath, { recursive: true })
 
     try {
-      await this.chain.open()
-      await this.accounts.db.open()
+      await this.chain.open(options)
+      await this.accounts.db.open(options)
     } catch (e) {
       await this.chain.close()
       await this.accounts.db.close()


### PR DESCRIPTION
There are instances where we want to open the DB without running any
upgrades. This introduces a new upgrade argument to accounts and
blockchain open() methods. It only checks for mandatory upgrade when
true is passed.

Later we'll remove this in favor of a better system when we have time
and have added DB checks.