### PR TITLE
Use node-datachannel instead of simple-peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ See https://ironfish.network
       1. Once it finishes, add the `bin` folder containing `cc` to your PATH environment variable.
 1. Install [wasm-pack](https://rustwasm.github.io/wasm-pack/).
 1. Run `yarn install` from the root directory to install packages.
+   * If `yarn install` fails with an error that includes "Could NOT find OpenSSL", you may need to first install OpenSSL and add an environment variable. For example, on macOS:
+      1. Run `brew install openssl`
+      1. Run ``export OPENSSL_ROOT_DIR=`brew --prefix openssl` ``
+      1. Run `yarn install` again.
 
 ## Usage
 

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -52,7 +52,6 @@
     "segfault-handler": "1.3.0",
     "tweetnacl": "1.0.3",
     "uuid": "8.3.2",
-    "wrtc": "0.4.7",
     "ws": "7.5.1"
   },
   "oclif": {

--- a/ironfish/jest.setup.env.js
+++ b/ironfish/jest.setup.env.js
@@ -4,6 +4,27 @@
 const consola = require('consola')
 const { generateKey } = require('ironfish-wasm-nodejs')
 
+jest.mock('node-datachannel', () => {
+  return {
+    PeerConnection: class {
+      onLocalDescription() {}
+      onLocalCandidate() {}
+      onDataChannel() {}
+      createDataChannel() {
+        return {
+          onOpen: () => {},
+          onError: () => {},
+          onClosed: () => {},
+          onMessage: () => {},
+          close: () => {},
+          isOpen: () => {},
+          sendMessage: () => {},
+        }
+      }
+    },
+  }
+})
+
 beforeAll(() => {
   // This causes the WASM to be initialized, which is 1 time 2 second cost for each test suite
   if (process.env.TEST_INIT_WASM) {

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -22,10 +22,10 @@
     "level-errors": "2.0.1",
     "leveldown": "5.6.0",
     "levelup": "4.4.0",
-    "lodash": "4.17.21",
+    "lodash": "^4.17.20",
+    "node-datachannel": "0.1.4",
     "node-ipc": "9.1.3",
     "parse-json": "5.1.0",
-    "simple-peer": "git://github.com/iron-fish/simple-peer.git#c69822c",
     "tweetnacl": "1.0.3",
     "uuid": "^8.3.0",
     "yup": "0.29.3"

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -51,7 +51,6 @@
     "@types/leveldown": "4.0.2",
     "@types/levelup": "4.3.0",
     "@types/lodash": "4.14.170",
-    "@types/simple-peer": "9.6.2",
     "@types/uuid": "^8.0.1",
     "@types/ws": "7.4.5",
     "@types/yup": "0.29.10",

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -60,7 +60,7 @@ import { LocalPeer } from './peers/localPeer'
 import { BAN_SCORE, Peer } from './peers/peer'
 import { PeerConnectionManager } from './peers/peerConnectionManager'
 import { PeerManager } from './peers/peerManager'
-import { IsomorphicWebRtc, IsomorphicWebSocketConstructor } from './types'
+import { IsomorphicWebSocketConstructor } from './types'
 import { parseUrl } from './utils/parseUrl'
 import { VERSION_PROTOCOL } from './version'
 import { WebSocketServer } from './webSocketServer'
@@ -129,7 +129,6 @@ export class PeerNetwork {
     identity?: PrivateIdentity
     agent: string
     webSocket: IsomorphicWebSocketConstructor
-    webRtc?: IsomorphicWebRtc
     listen?: boolean
     port?: number
     bootstrapNodes?: string[]
@@ -165,7 +164,6 @@ export class PeerNetwork {
       options.chain,
       options.node.workerPool,
       options.webSocket,
-      options.webRtc,
     )
 
     this.localPeer.port = options.port === undefined ? null : options.port

--- a/ironfish/src/network/peers/connections/connection.ts
+++ b/ironfish/src/network/peers/connections/connection.ts
@@ -63,7 +63,7 @@ export abstract class Connection {
   /**
    * Indicates the current state of the connection.
    */
-  private _state: Readonly<ConnectionState> = { type: 'CONNECTING' }
+  private _state: Readonly<ConnectionState> = { type: 'DISCONNECTED' }
   get state(): Readonly<ConnectionState> {
     return this._state
   }
@@ -129,6 +129,7 @@ export abstract class Connection {
       }
 
       if (
+        state.type === 'CONNECTING' ||
         state.type === 'REQUEST_SIGNALING' ||
         state.type === 'SIGNALING' ||
         state.type === 'WAITING_FOR_IDENTITY'

--- a/ironfish/src/network/peers/connections/errors.ts
+++ b/ironfish/src/network/peers/connections/errors.ts
@@ -23,7 +23,7 @@ export class TimeoutError extends NetworkError {
 }
 
 export class HandshakeTimeoutError extends TimeoutError {
-  readonly state: 'REQUEST_SIGNALING' | 'SIGNALING' | 'WAITING_FOR_IDENTITY'
+  readonly state: 'CONNECTING' | 'REQUEST_SIGNALING' | 'SIGNALING' | 'WAITING_FOR_IDENTITY'
 
   constructor(state: HandshakeTimeoutError['state'], timeoutMs: number, message?: string) {
     super(timeoutMs, message || `${state} timed out after ${timeoutMs}ms`)

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import nodeDataChannel from 'node-datachannel'
 import type { Logger } from '../../../logger'
 import colors from 'colors/safe'
+import nodeDataChannel from 'node-datachannel'
+import { Assert } from '../../../assert'
 import { Event } from '../../../event'
 import { MetricsMonitor } from '../../../metrics'
 import { LooseMessage, NodeMessageType, parseMessage } from '../../messages'
 import { Connection, ConnectionDirection, ConnectionType } from './connection'
 import { NetworkError } from './errors'
-import { Assert } from '../../../assert'
 
 export type SignalData =
   | {
@@ -187,7 +187,9 @@ export class WebRtcConnection extends Connection {
    * Encode the message to json and send it to the peer
    */
   send = (message: LooseMessage): boolean => {
-    if (!this.datachannel) return false
+    if (!this.datachannel) {
+      return false
+    }
 
     if (message.type === NodeMessageType.NewBlock && this.datachannel.bufferedAmount() > 0) {
       return false
@@ -236,7 +238,9 @@ export class WebRtcConnection extends Connection {
     }
 
     this.setState({ type: 'DISCONNECTED' })
+
     this.datachannel?.close()
+
     try {
       this.peer.close()
     } catch (e) {

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -71,9 +71,11 @@ export class WebRtcConnection extends Connection {
     }
 
     // TODO: Use our own STUN servers
-    this.peer = new nodeDataChannel.PeerConnection('Peer1', {
+    this.peer = new nodeDataChannel.PeerConnection('peer', {
       iceServers: ['stun:stun.l.google.com:19302', 'stun:global.stun.twilio.com:3478'],
     })
+
+    this.setState({ type: 'CONNECTING' })
 
     this.peer.onLocalDescription((sdp, type) => {
       // The TypeScript types for "type" in this callback might not be accurate.
@@ -178,6 +180,7 @@ export class WebRtcConnection extends Connection {
       } else {
         this.peer.setRemoteDescription(data.sdp, data.type)
         this.receivedDescription = true
+
         while (this.candidateQueue.length > 0) {
           const data = this.candidateQueue.shift()
           if (data) {

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -2,32 +2,58 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import nodeDataChannel from 'node-datachannel'
 import type { Logger } from '../../../logger'
 import colors from 'colors/safe'
-import SimplePeer, { SignalData } from 'simple-peer'
 import { Event } from '../../../event'
 import { MetricsMonitor } from '../../../metrics'
 import { LooseMessage, NodeMessageType, parseMessage } from '../../messages'
-import { IsomorphicWebRtc } from '../../types'
 import { Connection, ConnectionDirection, ConnectionType } from './connection'
 import { NetworkError } from './errors'
+import { Assert } from '../../../assert'
+
+export type SignalData =
+  | {
+      type: nodeDataChannel.DescriptionType
+      sdp: string
+    }
+  | CandidateSignal
+
+type CandidateSignal = {
+  type: 'candidate'
+  candidate: {
+    candidate: string
+    sdpMid: string
+    sdpMLineIndex: number
+  }
+}
 
 /**
- * Light wrapper of WebRtc SimplePeer that knows how to send and receive
+ * Light wrapper of node-datachannel that knows how to send and receive
  * LooseMessages instead of strings/data.
  */
 export class WebRtcConnection extends Connection {
-  private readonly peer: SimplePeer.Instance
+  private readonly peer: nodeDataChannel.PeerConnection
+  private datachannel: nodeDataChannel.DataChannel | null = null
 
   /**
-   * Event fired when the peer wants to signal its remote peer that an offer,
-   * answer, or ice candidate is available
+   * True if we've received an SDP message from the peer.
+   */
+  private receivedDescription = false
+
+  /**
+   * Queue for ICE candidates until we've received an SDP message from the peer.
+   */
+  private candidateQueue: CandidateSignal[] = []
+
+  /**
+   * Event fired when the PeerConnection has an SDP message or ICE candidate to send to
+   * the remote peer.
    */
   onSignal = new Event<[SignalData]>()
 
   constructor(
     initiator: boolean,
-    wrtc: IsomorphicWebRtc,
     logger: Logger,
     metrics?: MetricsMonitor,
     options: { simulateLatency?: number } = {},
@@ -44,43 +70,58 @@ export class WebRtcConnection extends Connection {
       this.addLatencyWrapper()
     }
 
-    // TODO: This is using google STUN internally, we need to
-    // make it use any of the websocket peers
-    this.peer = new SimplePeer({ initiator, wrtc })
-
-    this.peer.on('close', () => {
-      this.setState({ type: 'DISCONNECTED' })
+    // TODO: Use our own STUN servers
+    this.peer = new nodeDataChannel.PeerConnection('Peer1', {
+      iceServers: ['stun:stun.l.google.com:19302', 'stun:global.stun.twilio.com:3478'],
     })
 
-    this.peer.on('error', (error: Error) => {
-      this._error = error
-      this.setState({ type: 'DISCONNECTED' })
+    this.peer.onLocalDescription((sdp, type) => {
+      // The TypeScript types for "type" in this callback might not be accurate.
+      // They should be https://www.w3.org/TR/webrtc/#dom-rtcsdptype
+      this.onSignal.emit({ type, sdp })
     })
 
-    this.peer.on('connect', () => {
+    this.peer.onLocalCandidate((candidate, mid) => {
+      this.onSignal.emit({
+        type: 'candidate',
+        candidate: {
+          candidate: candidate,
+          sdpMid: mid,
+          // sdpMLineIndex isn't used by node-datachannel, but helps compatibility
+          // with node-webrtc (and probably browser WebRTC)
+          sdpMLineIndex: 0,
+        },
+      })
+    })
+
+    this.peer.onDataChannel((dc: nodeDataChannel.DataChannel) => {
+      Assert.isNull(this.datachannel)
+      this.initializeDataChannel(dc)
+    })
+
+    if (initiator) {
+      this.initializeDataChannel(this.peer.createDataChannel(''))
+    }
+  }
+
+  initializeDataChannel(dc: nodeDataChannel.DataChannel): void {
+    this.datachannel = dc
+
+    this.datachannel.onOpen(() => {
       if (this.state.type !== 'WAITING_FOR_IDENTITY' && this.state.type !== 'CONNECTED') {
         this.setState({ type: 'WAITING_FOR_IDENTITY' })
       }
     })
 
-    this.peer.on('signal', (signal: SignalData) => {
-      if (this.state.type !== 'CONNECTED' && this.state.type !== 'WAITING_FOR_IDENTITY') {
-        this.setState({ type: 'SIGNALING' })
-      }
-
-      this.onSignal.emit(signal)
+    this.datachannel.onError((e) => {
+      this.close(new NetworkError(e))
     })
 
-    this.peer.on('data', (data: string | Uint8Array) => {
-      // simple-peer will sometimes emit data before emitting 'connect', so
-      // make sure the connection state is updated
-      if (this.state.type === 'SIGNALING') {
-        this.setState({ type: 'WAITING_FOR_IDENTITY' })
-        this.logger.debug(
-          'Received data before WebRTC connect event fired, setting peer to WAITING_FOR_IDENTITY',
-        )
-      }
+    this.datachannel.onClosed(() => {
+      this.close()
+    })
 
+    this.datachannel.onMessage((data: string | Uint8Array) => {
       let stringdata
       if (data instanceof Uint8Array) {
         stringdata = new TextDecoder().decode(data)
@@ -98,7 +139,7 @@ export class WebRtcConnection extends Connection {
         message = parseMessage(stringdata)
       } catch (error) {
         this.logger.warn('Unable to parse webrtc message', stringdata)
-        this.peer.destroy()
+        this.close(error)
         return
       }
 
@@ -118,7 +159,23 @@ export class WebRtcConnection extends Connection {
       if (this.state.type === 'DISCONNECTED' || this.state.type === 'CONNECTING') {
         this.setState({ type: 'SIGNALING' })
       }
-      this.peer.signal(data)
+
+      if (data.type === 'candidate') {
+        if (this.receivedDescription) {
+          this.peer.addRemoteCandidate(data.candidate.candidate, data.candidate.sdpMid)
+        } else {
+          this.candidateQueue.push(data)
+        }
+      } else {
+        this.peer.setRemoteDescription(data.sdp, data.type)
+        this.receivedDescription = true
+        while (this.candidateQueue.length > 0) {
+          const data = this.candidateQueue.shift()
+          if (data) {
+            this.peer.addRemoteCandidate(data.candidate.candidate, data.candidate.sdpMid)
+          }
+        }
+      }
     } catch (error) {
       const message = 'An error occurred when loading signaling data:'
       this.logger.debug(message, error)
@@ -130,7 +187,9 @@ export class WebRtcConnection extends Connection {
    * Encode the message to json and send it to the peer
    */
   send = (message: LooseMessage): boolean => {
-    if (message.type === NodeMessageType.NewBlock && this.peer.bufferSize > 0) {
+    if (!this.datachannel) return false
+
+    if (message.type === NodeMessageType.NewBlock && this.datachannel.bufferedAmount() > 0) {
       return false
     }
 
@@ -138,9 +197,15 @@ export class WebRtcConnection extends Connection {
       this.logger.debug(`${colors.yellow('SEND')} ${this.displayName}: ${message.type}`)
     }
 
+    if (!this.datachannel.isOpen()) {
+      this.logger.debug('Datachannel no longer open, closing connection')
+      this.close()
+      return false
+    }
+
     const data = JSON.stringify(message)
     try {
-      this.peer.send(data)
+      this.datachannel.sendMessage(data)
     } catch (e) {
       this.logger.debug(
         `Error occurred while sending ${message.type} message in state ${this.state.type}`,
@@ -171,6 +236,13 @@ export class WebRtcConnection extends Connection {
     }
 
     this.setState({ type: 'DISCONNECTED' })
-    this.peer.destroy()
+    this.datachannel?.close()
+    try {
+      this.peer.close()
+    } catch (e) {
+      // peer.close() may throw "It seems peer-connection is closed" if the
+      // peer connection has been disposed already
+    }
+    this.datachannel = null
   }
 }

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -78,10 +78,19 @@ export class WebRtcConnection extends Connection {
     this.peer.onLocalDescription((sdp, type) => {
       // The TypeScript types for "type" in this callback might not be accurate.
       // They should be https://www.w3.org/TR/webrtc/#dom-rtcsdptype
+
+      if (this.state.type !== 'CONNECTED' && this.state.type !== 'WAITING_FOR_IDENTITY') {
+        this.setState({ type: 'SIGNALING' })
+      }
+
       this.onSignal.emit({ type, sdp })
     })
 
     this.peer.onLocalCandidate((candidate, mid) => {
+      if (this.state.type !== 'CONNECTED' && this.state.type !== 'WAITING_FOR_IDENTITY') {
+        this.setState({ type: 'SIGNALING' })
+      }
+
       this.onSignal.emit({
         type: 'candidate',
         candidate: {

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -48,6 +48,8 @@ export class WebSocketConnection extends Connection {
 
     if (this.socket.readyState === this.socket.OPEN) {
       this.setState({ type: 'WAITING_FOR_IDENTITY' })
+    } else {
+      this.setState({ type: 'CONNECTING' })
     }
 
     this.socket.onerror = (...args: unknown[]) => {

--- a/ironfish/src/network/peers/localPeer.ts
+++ b/ironfish/src/network/peers/localPeer.ts
@@ -6,7 +6,7 @@ import { IronfishBlockchain } from '../../blockchain'
 import { WorkerPool } from '../../workerPool'
 import { Identity, PrivateIdentity, privateIdentityToIdentity } from '../identity'
 import { Identify, InternalMessageType } from '../messages'
-import { IsomorphicWebRtc, IsomorphicWebSocketConstructor } from '../types'
+import { IsomorphicWebSocketConstructor } from '../types'
 
 /**
  * Wraps configuration needed for establishing connections with other peers
@@ -25,8 +25,6 @@ export class LocalPeer {
   readonly version: number
   // constructor for either a Node WebSocket or a browser WebSocket
   readonly webSocket: IsomorphicWebSocketConstructor
-  // optional object containing a Node implementation of WebRTC
-  readonly webRtc: IsomorphicWebRtc
 
   // optional port the local peer is listening on
   port: number | null
@@ -46,7 +44,6 @@ export class LocalPeer {
     chain: IronfishBlockchain,
     workerPool: WorkerPool,
     webSocket: IsomorphicWebSocketConstructor,
-    webRtc?: IsomorphicWebRtc,
   ) {
     this.privateIdentity = identity
     this.publicIdentity = privateIdentityToIdentity(identity)
@@ -56,7 +53,6 @@ export class LocalPeer {
     this.version = version
 
     this.webSocket = webSocket
-    this.webRtc = webRtc
     this.port = null
     this.name = null
     this.isWorker = false

--- a/ironfish/src/network/peers/peer.test.ts
+++ b/ironfish/src/network/peers/peer.test.ts
@@ -5,24 +5,6 @@
 import * as encryption from './encryption'
 
 jest.mock('ws')
-jest.mock('node-datachannel', () => {
-  return {
-    PeerConnection: class {
-      onLocalDescription = () => {}
-      onLocalCandidate = () => {}
-      onDataChannel = () => {}
-      createDataChannel = () => ({
-        onOpen: () => {},
-        onError: () => {},
-        onClosed: () => {},
-        onMessage: () => {},
-        close: () => {},
-        isOpen: () => {},
-        sendMessage: () => {},
-      })
-    },
-  }
-})
 jest.mock('./encryption', () => {
   const originalModule = jest.requireActual<typeof encryption>('./encryption')
 
@@ -204,7 +186,9 @@ describe('Handles WebRTC message send failure', () => {
     // Time out requesting signaling
     connection.setState({ type: 'CONNECTED', identity: mockIdentity('peer') })
     peer.setWebRtcConnection(connection)
-    if (!connection['datachannel']) throw new Error('Should have datachannel')
+    if (!connection['datachannel']) {
+      throw new Error('Should have datachannel')
+    }
     jest.spyOn(connection['datachannel'], 'sendMessage').mockImplementation(() => {
       throw new Error('Error')
     })

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -3,7 +3,22 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 jest.mock('ws')
-jest.mock('simple-peer')
+jest.mock('node-datachannel', () => {
+  return {
+    PeerConnection: class {
+      onLocalDescription = () => {}
+      onLocalCandidate = () => {}
+      onDataChannel = () => {}
+      createDataChannel = () => ({
+        onOpen: () => {},
+        onError: () => {},
+        onClosed: () => {},
+        onMessage: () => {},
+        close: () => {},
+      })
+    },
+  }
+})
 
 import { createRootLogger } from '../../logger'
 import {

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -3,22 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 jest.mock('ws')
-jest.mock('node-datachannel', () => {
-  return {
-    PeerConnection: class {
-      onLocalDescription = () => {}
-      onLocalCandidate = () => {}
-      onDataChannel = () => {}
-      createDataChannel = () => ({
-        onOpen: () => {},
-        onError: () => {},
-        onClosed: () => {},
-        onMessage: () => {},
-        close: () => {},
-      })
-    },
-  }
-})
 
 import { createRootLogger } from '../../logger'
 import {

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -5,7 +5,22 @@
 import * as encryption from './encryption'
 
 jest.mock('ws')
-jest.mock('simple-peer')
+jest.mock('node-datachannel', () => {
+  return {
+    PeerConnection: class {
+      onLocalDescription = () => {}
+      onLocalCandidate = () => {}
+      onDataChannel = () => {}
+      createDataChannel = () => ({
+        onOpen: () => {},
+        onError: () => {},
+        onClosed: () => {},
+        onMessage: () => {},
+        close: () => {},
+      })
+    },
+  }
+})
 jest.mock('./encryption', () => {
   const originalModule = jest.requireActual<typeof encryption>('./encryption')
 
@@ -14,7 +29,16 @@ jest.mock('./encryption', () => {
     boxMessage: jest
       .fn()
       .mockReturnValue({ nonce: 'boxMessageNonce', boxedMessage: 'boxMessageMessage' }),
-    unboxMessage: jest.fn().mockReturnValue(JSON.stringify({ type: 'offer' })),
+    unboxMessage: jest.fn().mockReturnValue(
+      JSON.stringify({
+        type: 'candidate',
+        candidate: {
+          candidate: '',
+          sdpMLineIndex: 0,
+          sdpMid: '0',
+        },
+      }),
+    ),
   }
 })
 
@@ -347,7 +371,12 @@ describe('PeerManager', () => {
       const sendSpy = jest.spyOn(brokeringPeer, 'send')
 
       await connection.onSignal.emitAsync({
-        type: 'offer',
+        type: 'candidate',
+        candidate: {
+          candidate: '',
+          sdpMLineIndex: 0,
+          sdpMid: '0',
+        },
       })
 
       expect(sendSpy).toBeCalledTimes(1)
@@ -440,7 +469,14 @@ describe('PeerManager', () => {
       expect(pm.identifiedPeers.size).toBe(1)
       expect(pm.peers).toHaveLength(1)
       const sendSpy = jest.spyOn(connection, 'send')
-      await peer.state.connections.webRtc.onSignal.emitAsync({ type: 'offer' })
+      await peer.state.connections.webRtc.onSignal.emitAsync({
+        type: 'candidate',
+        candidate: {
+          candidate: '',
+          sdpMLineIndex: 0,
+          sdpMid: '0',
+        },
+      })
       expect(sendSpy).toBeCalledTimes(1)
     })
 
@@ -1300,7 +1336,12 @@ describe('PeerManager', () => {
 
       expect(signalSpy).toBeCalledTimes(1)
       expect(signalSpy).toBeCalledWith({
-        type: 'offer',
+        type: 'candidate',
+        candidate: {
+          candidate: '',
+          sdpMLineIndex: 0,
+          sdpMid: '0',
+        },
       })
     })
 

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -5,22 +5,7 @@
 import * as encryption from './encryption'
 
 jest.mock('ws')
-jest.mock('node-datachannel', () => {
-  return {
-    PeerConnection: class {
-      onLocalDescription = () => {}
-      onLocalCandidate = () => {}
-      onDataChannel = () => {}
-      createDataChannel = () => ({
-        onOpen: () => {},
-        onError: () => {},
-        onClosed: () => {},
-        onMessage: () => {},
-        close: () => {},
-      })
-    },
-  }
-})
+
 jest.mock('./encryption', () => {
   const originalModule = jest.requireActual<typeof encryption>('./encryption')
 

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { SignalData } from './connections/webRtcConnection'
-import nodeDataChannel from 'node-datachannel'
 import WSWebSocket from 'ws'
 import { Event } from '../../event'
 import { createRootLogger, Logger } from '../../logger'
@@ -787,7 +786,6 @@ export class PeerManager {
     for (const peer of this.peers) {
       this.disconnect(peer, DisconnectingReason.ShuttingDown, 0)
     }
-    nodeDataChannel.cleanup()
   }
 
   /**

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import type { SignalData } from 'simple-peer'
+import type { SignalData } from './connections/webRtcConnection'
+import nodeDataChannel from 'node-datachannel'
 import WSWebSocket from 'ws'
 import { Event } from '../../event'
 import { createRootLogger, Logger } from '../../logger'
@@ -315,13 +316,9 @@ export class PeerManager {
    * @param initiator Set to true if we are initiating a connection with `peer`
    */
   private initWebRtcConnection(peer: Peer, initiator: boolean): WebRtcConnection {
-    const connection = new WebRtcConnection(
-      initiator,
-      this.localPeer.webRtc,
-      this.logger,
-      this.metrics,
-      { simulateLatency: this.localPeer.simulateLatency },
-    )
+    const connection = new WebRtcConnection(initiator, this.logger, this.metrics, {
+      simulateLatency: this.localPeer.simulateLatency,
+    })
 
     connection.onSignal.on(async (data) => {
       let errorMessage
@@ -790,6 +787,7 @@ export class PeerManager {
     for (const peer of this.peers) {
       this.disconnect(peer, DisconnectingReason.ShuttingDown, 0)
     }
+    nodeDataChannel.cleanup()
   }
 
   /**

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -137,7 +137,14 @@ export function getSignalingWebRtcPeer(
   const connection = peer.state.connections.webRtc
 
   // Send a signal to trigger the connection into a SIGNALING state
-  connection?.signal({})
+  connection?.signal({
+    type: 'candidate',
+    candidate: {
+      candidate: '',
+      sdpMLineIndex: 0,
+      sdpMid: '0',
+    },
+  })
   expect(connection?.state.type).toBe('SIGNALING')
   if (connection?.state.type !== 'SIGNALING') {
     throw new Error('Connection')

--- a/ironfish/src/network/testUtilities/mockLocalPeer.ts
+++ b/ironfish/src/network/testUtilities/mockLocalPeer.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import wrtc from 'wrtc'
 import ws from 'ws'
 import { IronfishBlockchain } from '../../blockchain'
 import { mockChain } from '../../testUtilities/mocks'
@@ -26,13 +25,5 @@ export function mockLocalPeer({
   version?: number
   chain?: IronfishBlockchain
 } = {}): LocalPeer {
-  return new LocalPeer(
-    identity,
-    agent,
-    version,
-    chain || mockChain(),
-    new WorkerPool(),
-    ws,
-    wrtc,
-  )
+  return new LocalPeer(identity, agent, version, chain || mockChain(), new WorkerPool(), ws)
 }

--- a/ironfish/src/network/types.ts
+++ b/ironfish/src/network/types.ts
@@ -7,25 +7,3 @@ import { ErrorEvent as WSErrorEvent } from 'ws'
 export type IsomorphicWebSocketConstructor = typeof WebSocket | typeof WSWebSocket
 export type IsomorphicWebSocket = WebSocket | WSWebSocket
 export type IsomorphicWebSocketErrorEvent = WSErrorEvent
-
-type WebRtcInterface = {
-  MediaStream: MediaStream
-  MediaStreamTrack: MediaStreamTrack
-  RTCDataChannel: RTCDataChannel
-  RTCDataChannelEvent: RTCDataChannelEvent
-  RTCDtlsTransport: RTCDtlsTransport
-  RTCIceCandidate: RTCIceCandidate
-  RTCIceTransport: RTCIceTransport
-  RTCPeerConnection: RTCPeerConnection
-  RTCPeerConnectionIceEvent: RTCPeerConnectionIceEvent
-  RTCRtpReceiver: RTCRtpReceiver
-  RTCRtpSender: RTCRtpSender
-  RTCRtpTransceiver: RTCRtpTransceiver
-  RTCSctpTransport: RTCSctpTransport
-  RTCSessionDescription: RTCSessionDescription
-  getUserMedia: (constraints?: MediaStreamConstraints) => Promise<MediaStream>
-  mediaDevices: MediaDevices
-}
-
-// if wrtc is undefined, simple-peer will use browser functions
-export type IsomorphicWebRtc = WebRtcInterface | undefined

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -13,7 +13,7 @@ import { MetricsMonitor } from './metrics'
 import { MiningDirector } from './mining'
 import { IronfishMiningDirector } from './mining/director'
 import { PeerNetwork } from './network'
-import { IsomorphicWebRtc, IsomorphicWebSocketConstructor } from './network/types'
+import { IsomorphicWebSocketConstructor } from './network/types'
 import { RpcServer } from './rpc/server'
 import { IronfishStrategy } from './strategy'
 import { Syncer } from './syncer'
@@ -52,7 +52,6 @@ export class IronfishNode {
     memPool,
     workerPool,
     logger,
-    webRtc,
     webSocket,
   }: {
     agent: string
@@ -67,7 +66,6 @@ export class IronfishNode {
     memPool: IronfishMemPool
     workerPool: WorkerPool
     logger: Logger
-    webRtc?: IsomorphicWebRtc
     webSocket: IsomorphicWebSocketConstructor
   }) {
     this.files = files
@@ -98,7 +96,6 @@ export class IronfishNode {
       simulateLatency: config.get('p2pSimulateLatency'),
       bootstrapNodes: config.getArray('bootstrapNodes'),
       webSocket: webSocket,
-      webRtc: webRtc,
       node: this,
       chain: chain,
       strategy: strategy,
@@ -129,7 +126,6 @@ export class IronfishNode {
     files,
     verifierClass,
     strategyClass,
-    webRtc,
     webSocket,
   }: {
     agent: string
@@ -143,7 +139,6 @@ export class IronfishNode {
     files: FileSystem
     verifierClass: typeof IronfishVerifier | null
     strategyClass: typeof IronfishStrategy | null
-    webRtc?: IsomorphicWebRtc
     webSocket: IsomorphicWebSocketConstructor
   }): Promise<IronfishNode> {
     logger = logger.withTag('ironfishnode')
@@ -211,7 +206,6 @@ export class IronfishNode {
       memPool,
       workerPool,
       logger,
-      webRtc,
       webSocket,
     })
   }

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -14,7 +14,7 @@ import {
 } from './logger'
 import { FileReporter } from './logger/reporters'
 import { MetricsMonitor } from './metrics'
-import { IsomorphicWebRtc, IsomorphicWebSocketConstructor } from './network/types'
+import { IsomorphicWebSocketConstructor } from './network/types'
 import { IronfishNode } from './node'
 import { Platform } from './platform'
 import {
@@ -171,7 +171,6 @@ export class IronfishSdk {
     autoSeed?: boolean
   } = {}): Promise<IronfishNode> {
     const webSocket = (await require('ws')) as IsomorphicWebSocketConstructor
-    const webRtc = (await require('wrtc')) as IsomorphicWebRtc | undefined
 
     const node = await IronfishNode.init({
       agent: Platform.getAgent(this.agent),
@@ -184,7 +183,6 @@ export class IronfishSdk {
       metrics: this.metrics,
       verifierClass: this.verifierClass,
       strategyClass: this.strategyClass,
-      webRtc: webRtc,
       webSocket: webSocket,
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2005,13 +2005,6 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/simple-peer@9.6.2":
-  version "9.6.2"
-  resolved "https://registry.yarnpkg.com/@types/simple-peer/-/simple-peer-9.6.2.tgz#a72afb6bd280fc4083d37e00247b30975304c071"
-  integrity sha512-FirllZ8397Qo8LfAgD4UuMgIOQmP1zdcP2eFNRDpaFDGQs42j2XxKOcTcvYZjXHv4HD7hgoNXzjB6iiEspKniw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/sinon@*":
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.2.tgz#f360d2f189c0fd433d14aeb97b9d705d7e4cc0e4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,7 +3462,7 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.5.2:
+color-string@1.5.5, color-string@^1.5.2:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014"
   integrity sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==
@@ -5828,7 +5828,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.7.6:
+handlebars@4.7.7, handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -8354,7 +8354,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^8.0.0:
+node-notifier@8.0.1, node-notifier@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
   integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
@@ -10298,7 +10298,7 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-getter@^0.1.0:
+set-getter@0.1.1, set-getter@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.1.tgz#a3110e1b461d31a9cfc8c5c9ee2e9737ad447102"
   integrity sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2905,7 +2905,7 @@ buffer-writer@2.0.0:
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
   integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
 
-buffer@6.0.3, buffer@^6.0.3:
+buffer@6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -4019,7 +4019,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -4032,6 +4032,13 @@ debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -4067,6 +4074,13 @@ decompress-response@^3.2.0, decompress-response@^3.3.0:
   integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
   dependencies:
     mimic-response "^1.0.0"
+
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
+  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  dependencies:
+    mimic-response "^2.0.0"
 
 dedent@^0.7.0:
   version "0.7.0"
@@ -4184,7 +4198,7 @@ detect-indent@^6.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
-detect-libc@^1.0.2:
+detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -4267,13 +4281,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-domexception@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
-  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
-  dependencies:
-    webidl-conversions "^4.0.2"
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -4464,11 +4471,6 @@ err-code@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
   integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
-
-err-code@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/err-code/-/err-code-3.0.1.tgz#a444c7b992705f2b120ee320b09972eef331c920"
-  integrity sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==
 
 errlop@^2.0.0:
   version "2.2.0"
@@ -4894,6 +4896,11 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
 expect@^26.6.2:
   version "26.6.2"
@@ -5427,11 +5434,6 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-browser-rtc@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz#d1494e299b00f33fc8e9d6d3343ba4ba99711a2c"
-  integrity sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==
-
 get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -5582,6 +5584,11 @@ gitconfiglocal@^1.0.0:
   integrity sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=
   dependencies:
     ini "^1.3.2"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
 github-slugger@^1.2.1:
   version "1.3.0"
@@ -6081,7 +6088,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6112,7 +6119,7 @@ ignore-walk@3.0.3:
   dependencies:
     minimatch "^3.0.4"
 
-ignore-walk@^3.0.1, ignore-walk@^3.0.3:
+ignore-walk@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"
   integrity sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==
@@ -7600,7 +7607,7 @@ lodash.zipobject@^4.1.3:
   resolved "https://registry.yarnpkg.com/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz#b399f5aba8ff62a746f6979bf20b214f964dbef8"
   integrity sha1-s5n1q6j/YqdG9peb8gshT5ZNvvg=
 
-lodash@4.17.21, lodash@4.x, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.5.1, lodash@^4.7.0:
+lodash@4.17.21, lodash@4.x, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.5.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7949,6 +7956,11 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
+mimic-response@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
+  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -7970,7 +7982,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -8060,7 +8072,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp-classic@^0.5.2:
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
@@ -8211,6 +8223,11 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+napi-build-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
+  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
+
 napi-macros@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/napi-macros/-/napi-macros-2.0.0.tgz#2b6bae421e7b96eb687aa6c77a7858640670001b"
@@ -8230,15 +8247,6 @@ ncp@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
-
-needle@^2.2.1:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
-  integrity sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
 
 negotiator@0.6.2, negotiator@^0.6.2:
   version "0.6.2"
@@ -8272,10 +8280,24 @@ nock@^13.0.0:
     lodash.set "^4.3.2"
     propagate "^2.0.0"
 
+node-abi@^2.7.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.0.tgz#8be53bf3e7945a34eea10e0fc9a5982776cf550b"
+  integrity sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg==
+  dependencies:
+    semver "^5.4.1"
+
 node-cleanup@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
+
+node-datachannel@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/node-datachannel/-/node-datachannel-0.1.4.tgz#10300833b8365367cbdf2414f2a9f669ca9e200c"
+  integrity sha512-eEMGmnJVI3BuIQ+uEWNPbuCs7kOoD7fDrEzlm2ZJyU+YL3fv+XmmPFDCERMnCKYB2PJo/fEt3ZR3VWe1ZVHYPQ==
+  dependencies:
+    prebuild-install "^5.3.6"
 
 node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
@@ -8351,22 +8373,6 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-pre-gyp@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz#df9ab7b68dd6498137717838e4f92a33fc9daa42"
-  integrity sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4"
-
 node-releases@^1.1.71:
   version "1.1.73"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
@@ -8387,6 +8393,11 @@ nodemon@^2.0.6:
     touch "^3.1.0"
     undefsafe "^2.0.3"
     update-notifier "^4.1.0"
+
+noop-logger@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
+  integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
 
 nopt@^4.0.1:
   version "4.0.3"
@@ -8459,7 +8470,7 @@ npm-api@^1.0.0:
     node-fetch "^2.6.0"
     paged-request "^2.0.1"
 
-npm-bundled@^1.0.1, npm-bundled@^1.1.1:
+npm-bundled@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.2.tgz#944c78789bd739035b70baa2ca5cc32b8d860bc1"
   integrity sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==
@@ -8500,15 +8511,6 @@ npm-package-arg@^8.0.0, npm-package-arg@^8.0.1, npm-package-arg@^8.1.0, npm-pack
     hosted-git-info "^4.0.1"
     semver "^7.3.4"
     validate-npm-package-name "^3.0.0"
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
 
 npm-packlist@^2.1.4:
   version "2.2.2"
@@ -8570,7 +8572,7 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.0.1, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -9441,6 +9443,27 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
+prebuild-install@^5.3.6:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.6.tgz#7c225568d864c71d89d07f8796042733a3f54291"
+  integrity sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^2.7.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^3.0.3"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -9668,7 +9691,7 @@ query-string@^6.13.8:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
-queue-microtask@^1.2.2, queue-microtask@^1.2.3:
+queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
@@ -9677,13 +9700,6 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
-
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -10174,7 +10190,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -10206,7 +10222,7 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@>=0.6.0, sax@^1.2.4:
+sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -10238,7 +10254,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -10378,17 +10394,19 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-"simple-peer@git://github.com/iron-fish/simple-peer.git#c69822c":
-  version "9.11.0"
-  resolved "git://github.com/iron-fish/simple-peer.git#c69822cabbfbf2a110726c168056e43ac4f4be9d"
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
+  integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
   dependencies:
-    buffer "^6.0.3"
-    debug "^4.3.1"
-    err-code "^3.0.1"
-    get-browser-rtc "^1.1.0"
-    queue-microtask "^1.2.3"
-    randombytes "^2.1.0"
-    readable-stream "^3.6.0"
+    decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -11060,7 +11078,7 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4, tar@^4.4.12:
+tar@^4.4.12:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -11846,11 +11864,6 @@ wcwidth@>=1.0.1, wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
-webidl-conversions@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
-  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -11897,6 +11910,11 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
 which@^1.2.9, which@^1.3.1:
   version "1.3.1"
@@ -12068,15 +12086,6 @@ write-pkg@^4.0.0:
     sort-keys "^2.0.0"
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
-
-wrtc@0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/wrtc/-/wrtc-0.4.7.tgz#c61530cd662713e50bffe64b7a78673ce070426c"
-  integrity sha512-P6Hn7VT4lfSH49HxLHcHhDq+aFf/jd9dPY7lDHeFhZ22N3858EKuwm2jmnlPzpsRGEPaoF6XwkcxY5SYnt4f/g==
-  dependencies:
-    node-pre-gyp "^0.13.0"
-  optionalDependencies:
-    domexception "^1.0.1"
 
 ws@7.5.1, ws@^7.4.5:
   version "7.5.1"


### PR DESCRIPTION
We've seen some issues with node-webrtc including segfaults and difficulty building for less-common platforms like ARM Macs. This PR tests out node-datachannel as a replacement, since we really only need the datachannel part of WebRTC.

This will require some work in the future to support browsers -- at that point we should either add support for node-datachannel to simple-peer (unfortunately it won't be a drop-in replacement), or implement an equivalent to simple-peer in WebRTCConnection.

Fixes IRO-684

## TODO

* [x] Rebase on staging once staging is re-branched from master
* [x] Test building on Windows to see if README needs to be updated. On M1, it needs OpenSSL to be installed and an env var to be set pointing at the root directory. (e.g. `brew install openssl`, then `export OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@1.1`)

