### PR TITLE
Remove node modules to build locally on linux

### DIFF
--- a/ironfish-http-api/scripts/build.sh
+++ b/ironfish-http-api/scripts/build.sh
@@ -12,6 +12,7 @@ echo "Building WASM"
 ( cd ironfish-wasm && yarn run build:node )
 
 echo "Installing from lockfile"
+rm -rf ./node_modules
 yarn --non-interactive --frozen-lockfile --ignore-scripts
 
 echo "Building Iron Fish HTTP API project"


### PR DESCRIPTION
The issue here is that its copying the node_modules from MAC which is
not compatible on windows. This will cause it to run the GYP which
builds on the actual linux docker container.