### PR TITLE
Remove ignore-scripts from api builds

### DIFF
--- a/ironfish-http-api/Dockerfile
+++ b/ironfish-http-api/Dockerfile
@@ -5,7 +5,7 @@ COPY ./ ./
 
 RUN \
     apt-get update && \
-    apt-get install rsync -y && \
+    apt-get install jq rsync -y && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y && \
     ./ironfish-http-api/scripts/build.sh

--- a/ironfish-http-api/scripts/build.sh
+++ b/ironfish-http-api/scripts/build.sh
@@ -3,17 +3,25 @@ set -euo pipefail
 cd "$(dirname "$0")"
 cd ../../
 
+if ! command -v jq &> /dev/null; then
+    echo "jq is not installed but is required"
+    exit 1
+fi
+
 if ! command -v rsync &> /dev/null; then
     echo "rsync is not installed but is required"
     exit 1
 fi
 
+echo "Removing lifecycle scripts"
+cat <<< "$(jq 'del(.scripts.prebuild)' < package.json)" > package.json
+cat <<< "$(jq 'del(.scripts.preinstall)' < package.json)" > package.json
+
 echo "Building WASM"
 ( cd ironfish-wasm && yarn run build:node )
 
 echo "Installing from lockfile"
-rm -rf ./node_modules
-yarn --non-interactive --frozen-lockfile --ignore-scripts
+yarn --non-interactive --frozen-lockfile
 
 echo "Building Iron Fish HTTP API project"
 cd ironfish-http-api

--- a/ironfish-rosetta-api/Dockerfile
+++ b/ironfish-rosetta-api/Dockerfile
@@ -5,7 +5,7 @@ COPY ./ ./
 
 RUN \
     apt-get update && \
-    apt-get install rsync -y && \
+    apt-get install jq rsync -y && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y && \
     ./ironfish-rosetta-api/scripts/build.sh

--- a/ironfish-rosetta-api/scripts/build.sh
+++ b/ironfish-rosetta-api/scripts/build.sh
@@ -3,16 +3,25 @@ set -euo pipefail
 cd "$(dirname "$0")"
 cd ../../
 
+if ! command -v jq &> /dev/null; then
+    echo "jq is not installed but is required"
+    exit 1
+fi
+
 if ! command -v rsync &> /dev/null; then
     echo "rsync is not installed but is required"
     exit 1
 fi
 
+echo "Removing lifecycle scripts"
+cat <<< "$(jq 'del(.scripts.prebuild)' < package.json)" > package.json
+cat <<< "$(jq 'del(.scripts.preinstall)' < package.json)" > package.json
+
 echo "Building WASM"
 ( cd ironfish-wasm && yarn run build:node )
 
 echo "Installing from lockfile"
-yarn --non-interactive --frozen-lockfile --ignore-scripts
+yarn --non-interactive --frozen-lockfile
 
 echo "Building Rosetta project"
 cd ironfish-rosetta-api


### PR DESCRIPTION
Both http api, and rosetta api build scripts were using
--ignore-scripts which prevent native modules from being built. We
copied the solution from ironfish-cli which removes the pre and post
scripts which is the intended result of using --ignore-scripts to begin
with but still allows the native module building scripts to be built.