### PR TITLE
refactor(ironfish): Remove `keyPath` from store and `KnownKeys` type

### DIFF
--- a/ironfish/src/storage/database.test.ts
+++ b/ironfish/src/storage/database.test.ts
@@ -111,7 +111,7 @@ describe('Database', () => {
 
     await db.open({ upgrade: runMigrations })
     expect(await testStore.get('oldVersion')).toBe(0)
-    expect(await testStore.get('newVersion')).toBe(8)
+    expect(await testStore.get('newVersion')).toBe(7)
   })
 
   it('should run store migrations', async () => {

--- a/ironfish/src/storage/database/types.ts
+++ b/ironfish/src/storage/database/types.ts
@@ -28,11 +28,3 @@ export type DatabaseOptions = {
 } & { [key: string]: unknown }
 
 export type IDatabaseEncoding<T> = Serde<T, Buffer>
-
-export type KnownKeys<T> = {
-  [K in keyof T]: string extends K ? never : number extends K ? never : K
-} extends {
-  [_ in keyof T]: infer U
-}
-  ? U
-  : never

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -156,15 +156,16 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     await this.db.levelup.clear(this.allKeysRange)
   }
 
-  async put(value: SchemaValue<Schema>, transaction?: IDatabaseTransaction): Promise<void>
   async put(
     key: SchemaKey<Schema>,
     value: SchemaValue<Schema>,
     transaction?: IDatabaseTransaction,
   ): Promise<void>
   async put(a: unknown, b: unknown, c?: unknown): Promise<void> {
-    const { key: rawKey, value, transaction } = parsePut<Schema>(a, b, c)
-    const key = rawKey === undefined ? this.makeKey(value) : rawKey
+    const { key, value, transaction } = parsePut<Schema>(a, b, c)
+    if (key === undefined) {
+      throw new Error('No key defined')
+    }
 
     if (ENABLE_TRANSACTIONS && transaction instanceof LevelupTransaction) {
       return transaction.put(this, key, value)
@@ -174,15 +175,16 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     await this.db.levelup.put(encodedKey, encodedValue)
   }
 
-  async add(value: SchemaValue<Schema>, transaction?: IDatabaseTransaction): Promise<void>
   async add(
     key: SchemaKey<Schema>,
     value: SchemaValue<Schema>,
     transaction?: IDatabaseTransaction,
   ): Promise<void>
   async add(a: unknown, b: unknown, c?: unknown): Promise<void> {
-    const { key: rawKey, value, transaction } = parsePut<Schema>(a, b, c)
-    const key = rawKey === undefined ? this.makeKey(value) : rawKey
+    const { key, value, transaction } = parsePut<Schema>(a, b, c)
+    if (key === undefined) {
+      throw new Error('No key defined')
+    }
 
     if (ENABLE_TRANSACTIONS && transaction instanceof LevelupTransaction) {
       return transaction.add(this, key, value)


### PR DESCRIPTION
Cleaning up some logic for constructing a key path for the store