### PR TITLE
Remove transaction scope and type

### DIFF
--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -167,7 +167,7 @@ export default class RepairChain extends IronfishCommand {
 
     while (block) {
       if (tx === null) {
-        tx = node.chain.db.transaction(node.chain.db.getStores(), 'readwrite')
+        tx = node.chain.db.transaction()
       }
 
       await node.chain.saveConnect(block, prev || null, tx)

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -203,7 +203,7 @@ export class AccountsDB {
   ): Promise<void> {
     await this.transactions.clear()
 
-    await this.database.transaction([this.transactions], 'readwrite', async (tx) => {
+    await this.database.transaction(async (tx) => {
       for (const [key, value] of map) {
         const serialized = {
           ...value,
@@ -242,7 +242,7 @@ export class AccountsDB {
   async replaceNullifierToNoteMap(map: Map<string, string>): Promise<void> {
     await this.nullifierToNote.clear()
 
-    await this.database.transaction([this.nullifierToNote], 'readwrite', async (tx) => {
+    await this.database.transaction(async (tx) => {
       for (const [key, value] of map) {
         await this.nullifierToNote.put(key, value, tx)
       }
@@ -281,7 +281,7 @@ export class AccountsDB {
   ): Promise<void> {
     await this.noteToNullifier.clear()
 
-    await this.database.transaction([this.noteToNullifier], 'readwrite', async (tx) => {
+    await this.database.transaction(async (tx) => {
       for (const [key, value] of map) {
         await this.noteToNullifier.put(key, value, tx)
       }
@@ -294,7 +294,7 @@ export class AccountsDB {
       { nullifierHash: string | null; noteIndex: number | null; spent: boolean }
     >,
   ): Promise<void> {
-    await this.database.transaction([this.noteToNullifier], 'read', async (tx) => {
+    await this.database.transaction(async (tx) => {
       for await (const noteToNullifierKey of this.noteToNullifier.getAllKeysIter(tx)) {
         const value = await this.noteToNullifier.get(noteToNullifierKey)
 

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -56,15 +56,9 @@ export interface IDatabase {
    * You should not forget to call [[`IDatabaseTransaction.commit`]] or [[`IDatabaseTransaction.abort`]].
    * If you don't you will deadlock the database. This is why it's better and safer to use [[`IDatabase.transaction::OVERLOAD_2`]]
    *
-   * @param scopes The stores you intend to access. Your operation will fail if it's not a store that is not specified here.
-   * @param type Indicates which type of access you are going to perform. You can only do writes in readwrite.
-   *
    * @returns A new transaction
    */
-  transaction(
-    scopes: IDatabaseStore<DatabaseSchema>[],
-    type: 'readwrite' | 'read',
-  ): IDatabaseTransaction
+  transaction(): IDatabaseTransaction
 
   /**
    * Starts a {@link IDatabaseTransaction} and executes your handler with it
@@ -73,10 +67,6 @@ export interface IDatabase {
    * code finishes, the transaction will be either committed or aborted if an
    * exception has been thrown.
    *
-   * @param scopes The stores you intend to access Your operation will fail if
-   * it's not a store that is not specified here.
-   * @param type Indicates which type of access you are going to perform. You
-   * can only do writes in readwrite.
    * @param handler You should pass in a function with your code that you want
    * to run in the transaction. The handler accepts a transaction and any returns
    * are forwarded out.
@@ -84,8 +74,6 @@ export interface IDatabase {
    * @returns Forwards the result of your handler to it's return value
    */
   transaction<TResult>(
-    scopes: IDatabaseStore<DatabaseSchema>[],
-    type: 'readwrite' | 'read',
     handler: (transaction: IDatabaseTransaction) => Promise<TResult>,
   ): Promise<TResult>
 
@@ -97,10 +85,6 @@ export interface IDatabase {
    * Use this when you are given an optional transaction, where you may want
    * to create one if one has not been created.
    *
-   * @param scopes The stores you intend to access Your operation will fail if
-   * it's not a store that is not specified here.
-   * @param type Indicates which type of access you are going to perform. You
-   * can only do writes in readwrite.
    * @param handler You should pass in a function with your code that you want
    * to run in the transaction. The handler accepts a transaction and any returns
    * are forwarded out.
@@ -109,8 +93,6 @@ export interface IDatabase {
    */
   withTransaction<TResult>(
     transaction: IDatabaseTransaction | undefined | null,
-    scopes: IDatabaseStore<DatabaseSchema>[],
-    type: 'readwrite' | 'read',
     handler: (transaction: IDatabaseTransaction) => Promise<TResult>,
   ): Promise<TResult>
 
@@ -143,14 +125,9 @@ export abstract class Database implements IDatabase {
   abstract open(options?: DatabaseOptions): Promise<void>
   abstract close(): Promise<void>
 
-  abstract transaction(
-    scopes: IDatabaseStore<DatabaseSchema>[],
-    type: 'readwrite' | 'read',
-  ): IDatabaseTransaction
+  abstract transaction(): IDatabaseTransaction
 
   abstract transaction<TResult>(
-    scopes: IDatabaseStore<DatabaseSchema>[],
-    type: 'readwrite' | 'read',
     handler: (transaction: IDatabaseTransaction) => Promise<TResult>,
   ): Promise<TResult>
 
@@ -199,12 +176,10 @@ export abstract class Database implements IDatabase {
   */
   async withTransaction<TResult>(
     transaction: IDatabaseTransaction | undefined | null,
-    scopes: IDatabaseStore<DatabaseSchema>[],
-    type: 'readwrite' | 'read',
     handler: (transaction: IDatabaseTransaction) => Promise<TResult>,
   ): Promise<TResult> {
     const created = !transaction
-    transaction = transaction || this.transaction(scopes, type)
+    transaction = transaction || this.transaction()
 
     try {
       await transaction.acquireLock()


### PR DESCRIPTION
### https://github.com/iron-fish/ironfish/pull/254/files?diff=split&w=1

This just removes the two arguments to `IDatabase.transaction()` and `IDatabase.withTransaction` called `scope` and `type.`. You may see some other changes because it reduces 1 level of indent, so now the code. lines all shift.

These were never used. They were going to be used for the web when we
introduce IndexDB, but it's not necessary because we can just use the
code the way it is now, there.