### PR TITLE
Add database version and migration errors

### DIFF
--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -92,14 +92,12 @@ export class AccountsDB {
       key: keyof AccountsDBMeta
       value: AccountsDBMeta[keyof AccountsDBMeta]
     }>({
-      version: 1,
       name: 'meta',
       keyEncoding: new StringEncoding<keyof AccountsDBMeta>(),
       valueEncoding: new JsonEncoding(),
     })
 
     this.accounts = this.database.addStore<{ key: string; value: Account }>({
-      version: 1,
       name: 'accounts',
       keyEncoding: new StringEncoding(),
       valueEncoding: new JsonEncoding(),
@@ -109,14 +107,12 @@ export class AccountsDB {
       key: string
       value: { nullifierHash: string; noteIndex: number | null; spent: boolean }
     }>({
-      version: 1,
       name: 'noteToNullifier',
       keyEncoding: new StringEncoding(),
       valueEncoding: new JsonEncoding(),
     })
 
     this.nullifierToNote = this.database.addStore<{ key: string; value: string }>({
-      version: 1,
       name: 'nullifierToNote',
       keyEncoding: new StringEncoding(),
       valueEncoding: new StringEncoding(),
@@ -130,16 +126,20 @@ export class AccountsDB {
         submittedSequence: number | null
       }
     }>({
-      version: 1,
       name: 'transactions',
       keyEncoding: new BufferEncoding(),
       valueEncoding: new JsonEncoding(),
     })
   }
 
-  async open(_options?: { upgrade?: boolean }): Promise<void> {
+  async open(options: { upgrade?: boolean } = { upgrade: true }): Promise<void> {
     await this.files.mkdir(this.location, { recursive: true })
+
     await this.database.open()
+
+    if (options.upgrade) {
+      await this.database.upgrade(1)
+    }
   }
 
   async close(): Promise<void> {

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -16,6 +16,8 @@ import {
 import { createDB } from '../storage/utils'
 import { WorkerPool } from '../workerPool'
 
+const DATABASE_VERSION = 1
+
 export type Account = {
   name: string
   spendingKey: string
@@ -138,7 +140,7 @@ export class AccountsDB {
     await this.database.open()
 
     if (options.upgrade) {
-      await this.database.upgrade(1)
+      await this.database.upgrade(DATABASE_VERSION)
     }
   }
 

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -57,6 +57,8 @@ import {
   TransactionsSchema,
 } from './schema'
 
+const DATABASE_VERSION = 1
+
 export class Blockchain<
   E,
   H,
@@ -251,7 +253,7 @@ export class Blockchain<
     await this.db.open()
 
     if (options.upgrade) {
-      await this.db.upgrade(1)
+      await this.db.upgrade(DATABASE_VERSION)
       await this.notes.upgrade()
       await this.nullifiers.upgrade()
     }

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -52,7 +52,6 @@ import {
   HashToNextSchema,
   HeadersSchema,
   MetaSchema,
-  SCHEMA_VERSION,
   SequenceToHashesSchema,
   SequenceToHashSchema,
   TransactionsSchema,
@@ -165,7 +164,6 @@ export class Blockchain<
 
     // Flat Fields
     this.meta = this.db.addStore({
-      version: SCHEMA_VERSION,
       name: 'bm',
       keyEncoding: new StringEncoding<'head' | 'latest'>(),
       valueEncoding: new JsonEncoding<Buffer>(),
@@ -173,7 +171,6 @@ export class Blockchain<
 
     // BlockHash -> BlockHeader
     this.headers = this.db.addStore({
-      version: SCHEMA_VERSION,
       name: 'bh',
       keyEncoding: BUFFER_ENCODING,
       valueEncoding: new BlockHeaderEncoding(this.strategy.blockHeaderSerde),
@@ -181,7 +178,6 @@ export class Blockchain<
 
     // BlockHash -> Transaction[]
     this.transactions = this.db.addStore({
-      version: SCHEMA_VERSION,
       name: 'bt',
       keyEncoding: BUFFER_ENCODING,
       valueEncoding: new TransactionArrayEncoding(this.strategy.transactionSerde()),
@@ -189,7 +185,6 @@ export class Blockchain<
 
     // BigInt -> BlockHash[]
     this.sequenceToHashes = this.db.addStore({
-      version: SCHEMA_VERSION,
       name: 'bs',
       keyEncoding: NUMBER_ENCODING,
       valueEncoding: BUFFER_ARRAY_ENCODING,
@@ -197,14 +192,12 @@ export class Blockchain<
 
     // BigInt -> BlockHash
     this.sequenceToHash = this.db.addStore({
-      version: SCHEMA_VERSION,
       name: 'bS',
       keyEncoding: NUMBER_ENCODING,
       valueEncoding: BUFFER_ENCODING,
     })
 
     this.hashToNextHash = this.db.addStore({
-      version: SCHEMA_VERSION,
       name: 'bH',
       keyEncoding: BUFFER_ENCODING,
       valueEncoding: BUFFER_ENCODING,
@@ -249,15 +242,19 @@ export class Blockchain<
     return genesisHeader
   }
 
-  async open(options?: { upgrade?: boolean }): Promise<void> {
+  async open(options: { upgrade?: boolean } = { upgrade: true }): Promise<void> {
     if (this.opened) {
       return
     }
     this.opened = true
 
-    const upgrade = options?.upgrade ?? true
+    await this.db.open()
 
-    await this.db.open({ upgrade: upgrade ? this.forceUpgrade : undefined })
+    if (options.upgrade) {
+      await this.db.upgrade(1)
+      await this.notes.upgrade()
+      await this.nullifiers.upgrade()
+    }
 
     let genesisHeader = await this.getHeaderAtSequence(GENESIS_BLOCK_SEQUENCE)
     if (!genesisHeader && this.autoSeed) {
@@ -1244,23 +1241,6 @@ export class Blockchain<
 
     this.synced = true
     this.onSynced.emit()
-  }
-
-  /**
-   * This is useful for now because we don't have a DB version system that works.
-   * to prevent this. See https://linear.app/ironfish/issue/IRO-706
-   */
-  private forceUpgrade = (db: unknown, oldVersion: number): Promise<void> => {
-    if (oldVersion === 0) {
-      return Promise.resolve()
-    }
-
-    this.logger.error(
-      `You are running a newer version of ironfish on an older database.\n` +
-        `Wipe your database using "ironfish reset" or delete your data directory at ~/.ironfish\n`,
-    )
-
-    process.exit(1)
   }
 }
 

--- a/ironfish/src/merkletree/merkletree.test.ts
+++ b/ironfish/src/merkletree/merkletree.test.ts
@@ -31,6 +31,9 @@ describe('Merkle tree', function () {
     const tree2 = await makeTree({ depth: 4, database: database })
     await database.open()
 
+    await tree1.upgrade()
+    await tree2.upgrade()
+
     await tree1.add('a')
     await tree2.add('A')
     await tree2.add('B')

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -36,6 +36,11 @@ export interface IDatabase {
   close(): Promise<void>
 
   /**
+   * Check if the database needs to be upgraded and warn the use
+   */
+  upgrade(version: number): Promise<void>
+
+  /**
    * Add an {@link IDatabaseStore} to the database
    *
    * You can only add a store to the database if the database is not open. This is because some databases only
@@ -124,6 +129,7 @@ export abstract class Database implements IDatabase {
 
   abstract open(options?: DatabaseOptions): Promise<void>
   abstract close(): Promise<void>
+  abstract upgrade(version: number): Promise<void>
 
   abstract transaction(): IDatabaseTransaction
 

--- a/ironfish/src/storage/database/store.ts
+++ b/ironfish/src/storage/database/store.ts
@@ -3,25 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { IDatabaseTransaction } from './transaction'
-import {
-  DatabaseSchema,
-  IDatabaseEncoding,
-  SchemaKey,
-  SchemaValue,
-  UpgradeFunction,
-} from './types'
+import { DatabaseSchema, IDatabaseEncoding, SchemaKey, SchemaValue } from './types'
 
 export type IDatabaseStoreOptions<Schema extends DatabaseSchema> = {
-  /** The schema version of the store. @see {@link IDatabase.addStore} for more information*/
-  version: number
   /** The unique name of the store inside of the database */
   name: string
   /** The encoding used to encode and decode keys in the database */
   keyEncoding: IDatabaseEncoding<SchemaKey<Schema>>
   /** The encoding used to encode and decode values in the database */
   valueEncoding: IDatabaseEncoding<SchemaValue<Schema>>
-  /** Used to auto construct a key from a value inside the store if specified. It can either be a field from the value, or an array of fields from the value */
-  upgrade?: UpgradeFunction
 }
 
 /**
@@ -34,12 +24,8 @@ export type IDatabaseStoreOptions<Schema extends DatabaseSchema> = {
  * You can operate on one or more stores atomically using {@link IDatabase.transaction}
  */
 export interface IDatabaseStore<Schema extends DatabaseSchema> {
-  /** The schema version of the store. @see {@link IDatabase.addStore} for more information*/
-  version: number
-  /** The name of the store inside of the {@link IDatabase} */
+  /** The unique name of the store inside of the database */
   name: string
-  /** Run when when {@link IDatabaseStore.version} changes */
-  upgrade: UpgradeFunction | null
   /** The [[`IDatabaseEncoding`]] used to serialize keys to store in the database */
   keyEncoding: IDatabaseEncoding<SchemaKey<Schema>>
   /** The [[`IDatabaseEncoding`]] used to serialize values to store in the database */
@@ -145,16 +131,12 @@ export interface IDatabaseStore<Schema extends DatabaseSchema> {
 
 export abstract class DatabaseStore<Schema extends DatabaseSchema>
   implements IDatabaseStore<Schema> {
-  version: number
   name: string
-  upgrade: UpgradeFunction | null
   keyEncoding: IDatabaseEncoding<SchemaKey<Schema>>
   valueEncoding: IDatabaseEncoding<SchemaValue<Schema>>
 
   constructor(options: IDatabaseStoreOptions<Schema>) {
-    this.version = options.version
     this.name = options.name
-    this.upgrade = options.upgrade || null
     this.keyEncoding = options.keyEncoding
     this.valueEncoding = options.valueEncoding
   }

--- a/ironfish/src/storage/database/types.ts
+++ b/ironfish/src/storage/database/types.ts
@@ -3,8 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { IJsonSerializable, Serde } from '../../serde'
-import { IDatabase } from './database'
-import { IDatabaseTransaction } from './transaction'
 
 export type DatabaseKey = bigint | number | string | Date | Buffer | Array<IJsonSerializable>
 
@@ -16,15 +14,6 @@ export type DatabaseSchema = {
 export type SchemaKey<Schema extends DatabaseSchema> = Schema['key']
 export type SchemaValue<Schema extends DatabaseSchema> = Schema['value']
 
-export type UpgradeFunction = (
-  db: IDatabase,
-  oldVersion: number,
-  newVersion: number,
-  transaction: IDatabaseTransaction,
-) => Promise<void>
-
-export type DatabaseOptions = {
-  upgrade?: UpgradeFunction
-} & { [key: string]: unknown }
+export type DatabaseOptions = { [key: string]: unknown }
 
 export type IDatabaseEncoding<T> = Serde<T, Buffer>

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -43,6 +43,7 @@ async function makeWasmStrategyTree({
 
   if (openDb) {
     await database.open()
+    await tree.upgrade()
   }
 
   return tree

--- a/ironfish/src/testUtilities/fake/helpers/blockchain.ts
+++ b/ironfish/src/testUtilities/fake/helpers/blockchain.ts
@@ -181,6 +181,9 @@ export async function makeChainInitial(
   })
 
   await chain.db.open()
+  await chain.notes.upgrade()
+  await chain.nullifiers.upgrade()
+
   return chain
 }
 

--- a/ironfish/src/testUtilities/fake/helpers/merkleTree.ts
+++ b/ironfish/src/testUtilities/fake/helpers/merkleTree.ts
@@ -40,6 +40,7 @@ export async function makeTree({
 
   if (openDb) {
     await database.open()
+    await tree.upgrade()
   }
 
   if (characters) {


### PR DESCRIPTION
https://linear.app/ironfish/issue/IRO-699/db-versions-and-migration-error

This adds a new mechanism so we can throw errors when database schemas
change. It will now enforced the DB version and a reset in a less hacky
way. A simple global database version is stored in the DB, and specified
to `db.upgrade(version)`.

If the version mismatches, then an error is thrown. If you are writing a
migration, you can avoid calling this method to run your migration logic
on old code.