### PR TITLE
Dont rebroadcast transactions if not synced

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -714,6 +714,10 @@ export class Accounts {
       return
     }
 
+    if (!this.chain.synced) {
+      return
+    }
+
     const heaviestHead = this.chain.head
     if (heaviestHead === null) {
       return


### PR DESCRIPTION
https://linear.app/ironfish/issue/IRO-728/dont-rebroadcast-transactions-if-synced-is-false-on-the-blockchain

We don't wanna rebroadcast while were downloading blocks