### PR TITLE
Add verify command to HTTP api to verify build

### DIFF
--- a/ironfish-http-api/scripts/build-docker.sh
+++ b/ironfish-http-api/scripts/build-docker.sh
@@ -10,3 +10,9 @@ docker build . \
     --progress plain \
     --tag ironfish-http-api:latest \
     --file ironfish-http-api/Dockerfile
+
+docker run \
+    --env DOCKER_VERIFY=1 \
+    --interactive \
+    --rm \
+    ironfish-http-api:latest start

--- a/ironfish-http-api/src/index.ts
+++ b/ironfish-http-api/src/index.ts
@@ -9,6 +9,10 @@ const PORT = 8000
 
 const server = new Server()
 
+if (process.env.DOCKER_VERIFY) {
+  process.exit(0)
+}
+
 server
   .open(PORT)
   .then(() => {


### PR DESCRIPTION
The command just logs and creates a new server, which would have
caught the last error we had in the build.