### PR TITLE
Verify rosetta docker build

### DIFF
--- a/ironfish-rosetta-api/scripts/build-docker.sh
+++ b/ironfish-rosetta-api/scripts/build-docker.sh
@@ -10,3 +10,9 @@ docker build . \
     --progress plain \
     --tag ironfish-rosetta-api:latest \
     --file ironfish-rosetta-api/Dockerfile
+
+docker run \
+    --env DOCKER_VERIFY=1 \
+    --interactive \
+    --rm \
+    ironfish-rosetta-api:latest start

--- a/ironfish-rosetta-api/src/index.ts
+++ b/ironfish-rosetta-api/src/index.ts
@@ -17,6 +17,10 @@ import { Logger } from './utils/logger'
 
 const server = new Server()
 
+if (process.env.DOCKER_VERIFY) {
+  process.exit(0)
+}
+
 server
   .open(SERVER_PORT)
   .then(() => {


### PR DESCRIPTION
https://linear.app/ironfish/issue/IRO-724/add-command-to-http-api-and-rosetta-api-to-verify-docker-build

Adds a step to make sure the image at least runs at a basic level