### PR TITLE
Rename sequence -> height

### DIFF
--- a/ironfish-cli/src/commands/accounts/rescan.test.ts
+++ b/ironfish-cli/src/commands/accounts/rescan.test.ts
@@ -43,7 +43,7 @@ describe('accounts:rescan', () => {
       .stdout()
       .command(['accounts:rescan'])
       .exit(0)
-      .it('fetches sequences from the client and scans successfully', (ctx) => {
+      .it('fetches heights from the client and scans successfully', (ctx) => {
         expect(contentStream).toHaveBeenCalled()
         expectCli(ctx.stdout).include('Scanning Complete')
       })
@@ -54,7 +54,7 @@ describe('accounts:rescan', () => {
       .stdout()
       .command(['accounts:rescan', '--local'])
       .exit(0)
-      .it('fetches sequences from the node and scans successfully', (ctx) => {
+      .it('fetches heights from the node and scans successfully', (ctx) => {
         expect(contentStream).toHaveBeenCalled()
         expectCli(ctx.stdout).include('Scanning Complete')
       })

--- a/ironfish-cli/src/commands/accounts/rescan.ts
+++ b/ironfish-cli/src/commands/accounts/rescan.ts
@@ -50,8 +50,8 @@ export async function rescan(
   const response = client.rescanAccountStream({ follow, reset })
 
   try {
-    for await (const { sequence } of response.contentStream()) {
-      cli.action.status = `Scanning Block: ${sequence}, ${Math.floor(
+    for await (const { height } of response.contentStream()) {
+      cli.action.status = `Scanning Block: ${height}, ${Math.floor(
         (Date.now() - startedAt) / 1000,
       )} seconds`
     }

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -4,7 +4,7 @@
 import { flags } from '@oclif/command'
 import cli from 'cli-ux'
 import fs from 'fs'
-import { Assert, BlockchainUtils, GENESIS_BLOCK_SEQUENCE } from 'ironfish'
+import { Assert, BlockchainUtils, GENESIS_BLOCK_HEIGHT } from 'ironfish'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
@@ -39,15 +39,15 @@ export default class Export extends IronfishCommand {
     {
       name: 'start',
       parse: parseNumber,
-      default: Number(GENESIS_BLOCK_SEQUENCE),
+      default: Number(GENESIS_BLOCK_HEIGHT),
       required: false,
-      description: 'the sequence to start at (inclusive, genesis block is 1)',
+      description: 'the height to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
       parse: parseNumber,
       required: false,
-      description: 'the sequence to end at (inclusive)',
+      description: 'the height to end at (inclusive)',
     },
   ]
 
@@ -81,14 +81,14 @@ export default class Export extends IronfishCommand {
     progress.start(stop - start + 1, 0)
 
     for (let i = start; i <= stop; ++i) {
-      const blocks = await node.chain.getHeadersAtSequence(i)
+      const blocks = await node.chain.getHeadersAtHeight(i)
 
       for (const block of blocks) {
         const isMain = await node.chain.isHeadChain(block)
 
         result.push({
           hash: block.hash.toString('hex'),
-          seq: Number(block.sequence),
+          height: Number(block.height),
           prev: block.previousBlockHash.toString('hex'),
           main: isMain,
           graffiti: block.graffiti.toString('ascii'),

--- a/ironfish-cli/src/commands/chain/forks.ts
+++ b/ironfish-cli/src/commands/chain/forks.ts
@@ -60,12 +60,12 @@ export default class ForksCommand extends IronfishCommand {
       list.clearBaseLine(0)
       list.setContent('')
 
-      const values = [...forks.values()].sort((a, b) => b.block.sequence - a.block.sequence)
+      const values = [...forks.values()].sort((a, b) => b.block.height - a.block.height)
       let count = 0
 
       let highest = 0
       for (const { block } of values) {
-        highest = Math.max(highest, block.sequence)
+        highest = Math.max(highest, block.height)
       }
 
       for (const { block, time, mined, old } of values) {
@@ -78,7 +78,7 @@ export default class ForksCommand extends IronfishCommand {
         }
 
         const renderedAge = (age / 1000).toFixed(0).padStart(2, ' ')
-        const renderdDiff = (highest - block.sequence).toString().padStart(6)
+        const renderdDiff = (highest - block.height).toString().padStart(6)
 
         list.pushLine(`${block.hash} | ${renderdDiff} | ${renderedAge}s | ${mined}`)
         count++

--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -59,7 +59,7 @@ export default class RepairChain extends IronfishCommand {
     }
 
     Assert.isNotNull(node.chain.head)
-    const total = Number(node.chain.head.sequence)
+    const total = Number(node.chain.head.height)
     const estimate = TimeUtils.renderEstimate(0, total, SPEED_ESTIMATE)
 
     const confirmed =
@@ -89,10 +89,10 @@ export default class RepairChain extends IronfishCommand {
     cli.action.stop()
 
     cli.action.start('Clearing Sequence to hash table')
-    await node.chain.sequenceToHash.clear()
+    await node.chain.heightToHash.clear()
     cli.action.stop()
 
-    const total = Number(node.chain.head.sequence)
+    const total = Number(node.chain.head.height)
     let done = 0
     let head = node.chain.head as IronfishBlockHeader | null
 
@@ -103,8 +103,8 @@ export default class RepairChain extends IronfishCommand {
       estimate: '-',
     })
 
-    while (head && head.sequence > BigInt(0)) {
-      await node.chain.sequenceToHash.put(head.sequence, head.hash)
+    while (head && head.height > BigInt(0)) {
+      await node.chain.heightToHash.put(head.height, head.hash)
       await node.chain.hashToNextHash.put(head.previousBlockHash, head.hash)
 
       head = await node.chain.getHeader(head.previousBlockHash)
@@ -142,13 +142,13 @@ export default class RepairChain extends IronfishCommand {
 
     this.log('\nRepairing MerkleTrees')
 
-    const total = TREE_END ? TREE_END - TREE_START : Number(node.chain.head.sequence)
+    const total = TREE_END ? TREE_END - TREE_START : Number(node.chain.head.height)
     let done = 0
 
     let tx: IDatabaseTransaction | null = null
-    let header = await node.chain.getHeaderAtSequence(TREE_START)
+    let header = await node.chain.getHeaderAtHeight(TREE_START)
     let block = header ? await node.chain.getBlock(header) : null
-    let prev = await node.chain.getHeaderAtSequence(TREE_START - 1)
+    let prev = await node.chain.getHeaderAtHeight(TREE_START - 1)
 
     cli.action.start('Clearing notes MerkleTree')
     await node.chain.notes.truncate(prev ? prev.noteCommitment.size : 0)
@@ -183,7 +183,7 @@ export default class RepairChain extends IronfishCommand {
         const error =
           `\n❗ ERROR adding notes from block` +
           `\nreason: ${String(verify.reason)}` +
-          `\nblock:  ${block.header.hash.toString('hex')} (${block.header.sequence})` +
+          `\nblock:  ${block.header.hash.toString('hex')} (${block.header.height})` +
           `\n\nThis means your database is corrupt and needs to be deleted.` +
           `\nDelete your database at ${node.config.chainDatabasePath}\n`
 
@@ -193,7 +193,7 @@ export default class RepairChain extends IronfishCommand {
 
       done++
 
-      if (TREE_END !== null && Number(block.header.sequence) >= TREE_END) {
+      if (TREE_END !== null && Number(block.header.height) >= TREE_END) {
         break
       }
 

--- a/ironfish-cli/src/commands/chain/show.ts
+++ b/ironfish-cli/src/commands/chain/show.ts
@@ -18,13 +18,13 @@ export default class Show extends IronfishCommand {
       parse: parseNumber,
       default: -50,
       required: false,
-      description: 'the sequence to start at (inclusive, genesis block is 1)',
+      description: 'the height to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
       parse: parseNumber,
       required: false,
-      description: 'the sequence to end at (inclusive)',
+      description: 'the height to end at (inclusive)',
     },
   ]
 

--- a/ironfish-cli/src/commands/peers/list.ts
+++ b/ironfish-cli/src/commands/peers/list.ts
@@ -41,10 +41,10 @@ export class ListCommand extends IronfishCommand {
       default: false,
       description: 'display peer agents',
     }),
-    sequence: flags.boolean({
-      char: 's',
+    height: flags.boolean({
+      char: 'h',
       default: false,
-      description: 'display peer head sequence',
+      description: 'display peer head height',
     }),
     names: flags.boolean({
       char: 'n',
@@ -101,7 +101,7 @@ function renderTable(
     all: boolean
     sort: string
     agents: boolean
-    sequence: boolean
+    height: boolean
   },
 ): string {
   let columns: Table.table.Columns<GetPeerResponsePeer> = {
@@ -133,12 +133,12 @@ function renderTable(
     }
   }
 
-  if (flags.sequence) {
-    columns['sequence'] = {
+  if (flags.height) {
+    columns['height'] = {
       header: 'SEQ',
       minWidth: 2,
       get: (row: GetPeerResponsePeer) => {
-        return row.sequence || '-'
+        return row.height || '-'
       },
     }
   }

--- a/ironfish-graph-explorer/src/index.js
+++ b/ironfish-graph-explorer/src/index.js
@@ -29,13 +29,13 @@ function getNodes() {
         let childOffset = 0
 
         if(!block.main) {
-            childOffset = childOffsets.get(block.seq)
+            childOffset = childOffsets.get(block.height)
             childOffset = childOffset === undefined ? 1 : ++childOffset
-            childOffsets.set(block.seq, childOffset)
+            childOffsets.set(block.height, childOffset)
         }
 
         const nodeOffsetX = (islandOffset * ISLAND_OFFSET) + (childOffset * CHILD_OFFSET)
-        const nodeOffsetY = block.seq * LEVEL_OFFSET
+        const nodeOffsetY = block.height * LEVEL_OFFSET
 
         const graffiti = block.graffiti.replace(/\0/g, '').trim()
 
@@ -44,7 +44,7 @@ function getNodes() {
 
         const node = {
             hash: block.hash,
-            seq: block.seq,
+            height: block.height,
             prev: block.prev,
             main: block.main,
             head: block.head,
@@ -61,11 +61,11 @@ function getNodes() {
         map.set(node.hash, node)
         nodes.push(node)
 
-        if(!lowest || node.seq < lowest.seq) {
+        if(!lowest || node.height < lowest.height) {
             lowest = node
         }
 
-        if(!highest || node.seq > highest.seq) {
+        if(!highest || node.height > highest.height) {
             highest = node
         }
     }
@@ -99,7 +99,7 @@ function renderHash(hash) {
 }
 
 function makeLabel(node) {
-    return `${node.shortHash} - ${node.seq}`
+    return `${node.shortHash} - ${node.height}`
 }
 
 function makeGraph() {
@@ -115,7 +115,7 @@ function makeGraph() {
         nodeElement.innerHTML = (
             `<b>HASH</b>   ${node.hash}<br>` +
             `<b>PREV</b>   ${node.prev}<br>` +
-            `<b>SEQ</b>    ${node.seq}<br>` +
+            `<b>HEIGHT</b> ${node.height}<br>` +
             `<b>GRAFF</b>  ${node.graffiti}<br>` +
             `<b>WORK</b>   ${node.work} (+${node.diff})<br>` +
             `<b>MAIN</b>   ${node.main}<br>` +
@@ -212,7 +212,7 @@ function makeGraph() {
         location: 0,
         threshold: 0.1,
         distance: 1000,
-        keys: [ "shortHash", "hash", "seq"]
+        keys: [ "shortHash", "hash", "height"]
     })
 
     function onNextResult() {

--- a/ironfish-rosetta-api/src/config/openapi.ts
+++ b/ironfish-rosetta-api/src/config/openapi.ts
@@ -62,7 +62,7 @@ const searchBlockEndpointComponents = {
         $ref: '#/components/schemas/Operator',
       },
       seek: {
-        description: 'seek parameter to offset the pagination at a previous block sequence.',
+        description: 'seek parameter to offset the pagination at a previous block height.',
         type: 'integer',
         format: 'int64',
         minimum: 0,
@@ -78,7 +78,7 @@ const searchBlockEndpointComponents = {
         example: 5,
       },
       query: {
-        description: 'query to filter blocks on hash or sequence\n',
+        description: 'query to filter blocks on hash or height\n',
         type: 'string',
       },
     },

--- a/ironfish/src/account/__fixtures__/accounts.test.slow.ts.fixture
+++ b/ironfish/src/account/__fixtures__/accounts.test.slow.ts.fixture
@@ -26,7 +26,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -56,7 +56,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "C00456F9E5A67324844F982446B66763E68FB3E30CB8304EB617BA25D165D9DD",
         "noteCommitment": {
           "commitment": {
@@ -108,7 +108,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -138,7 +138,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -168,7 +168,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "422F8EE5F7EF66D535C4A7EB9CC09D34F22051F48F5F9347A0F5C8E0F3B69B4C",
         "noteCommitment": {
           "commitment": {
@@ -216,7 +216,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -246,7 +246,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "1DE3636FD641A37CDAB4656023E46BDC508DE955706497A5BFBF16A9BD747F79",
         "noteCommitment": {
           "commitment": {
@@ -280,7 +280,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "1DE3636FD641A37CDAB4656023E46BDC508DE955706497A5BFBF16A9BD747F79",
         "noteCommitment": {
           "commitment": {
@@ -310,7 +310,7 @@
     },
     {
       "header": {
-        "sequence": 4,
+        "height": 4,
         "previousBlockHash": "491A15AE22740D13753C4BA22FC8DD422C2977615EF1049970C526C7B83EA626",
         "noteCommitment": {
           "commitment": {
@@ -358,7 +358,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -388,7 +388,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "3252884274B53CCC0DB01E5CE2A761F1B64505E56D6061122161421E35C5155A",
         "noteCommitment": {
           "commitment": {
@@ -422,7 +422,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "3252884274B53CCC0DB01E5CE2A761F1B64505E56D6061122161421E35C5155A",
         "noteCommitment": {
           "commitment": {
@@ -452,7 +452,7 @@
     },
     {
       "header": {
-        "sequence": 4,
+        "height": 4,
         "previousBlockHash": "2D159CE11D2437A066C28415AAE8A1F0C79420D42A8D4CF375A26621322CDDD5",
         "noteCommitment": {
           "commitment": {

--- a/ironfish/src/account/accounts.test.slow.ts
+++ b/ironfish/src/account/accounts.test.slow.ts
@@ -170,7 +170,7 @@ describe('Accounts', () => {
     // Create a block with a miner's fee
     const minersfee2 = await strategy.createMinersFee(
       await transaction.transactionFee(),
-      newBlock.header.sequence + 1,
+      newBlock.header.height + 1,
       generateKey().spending_key,
     )
     const newBlock2 = await chain.newBlock([transaction], minersfee2)
@@ -233,7 +233,7 @@ describe('Accounts', () => {
     // Create a block with a miner's fee
     const minersfee2 = await strategy.createMinersFee(
       await transaction.transactionFee(),
-      newBlock.header.sequence + 1,
+      newBlock.header.height + 1,
       generateKey().spending_key,
     )
     const newBlock2 = await chain.newBlock([transaction], minersfee2)

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -16,7 +16,7 @@ import {
 import { createDB } from '../storage/utils'
 import { WorkerPool } from '../workerPool'
 
-const DATABASE_VERSION = 1
+const DATABASE_VERSION = 2
 
 export type Account = {
   name: string

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -72,7 +72,7 @@ export class AccountsDB {
     value: {
       transaction: Buffer
       blockHash: string | null
-      submittedSequence: number | null
+      submittedHeight: number | null
     }
   }>
 
@@ -125,7 +125,7 @@ export class AccountsDB {
       value: {
         transaction: Buffer
         blockHash: string | null
-        submittedSequence: number | null
+        submittedHeight: number | null
       }
     }>({
       name: 'transactions',
@@ -185,7 +185,7 @@ export class AccountsDB {
     transaction: {
       transaction: IronfishTransaction
       blockHash: string | null
-      submittedSequence: number | null
+      submittedHeight: number | null
     },
     tx?: IDatabaseTransaction,
   ): Promise<void> {
@@ -200,7 +200,7 @@ export class AccountsDB {
     map: BufferMap<{
       transaction: IronfishTransaction
       blockHash: string | null
-      submittedSequence: number | null
+      submittedHeight: number | null
     }>,
   ): Promise<void> {
     await this.transactions.clear()
@@ -220,7 +220,7 @@ export class AccountsDB {
     map: BufferMap<{
       transaction: IronfishTransaction
       blockHash: string | null
-      submittedSequence: number | null
+      submittedHeight: number | null
     }>,
   ): Promise<void> {
     for await (const value of this.transactions.getAllValuesIter()) {

--- a/ironfish/src/blockchain/__fixtures__/blockchain.test.perf.ts.fixture
+++ b/ironfish/src/blockchain/__fixtures__/blockchain.test.perf.ts.fixture
@@ -18,7 +18,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -48,7 +48,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -78,7 +78,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "E2134931967AF725B87204FEB6BDABEC2DEF2CF4DC0DA9D35712C50A1C546B6F",
         "noteCommitment": {
           "commitment": {
@@ -108,7 +108,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "B707236D59B4AA0307B14D68EBB2DC6B597E25D288A96D266AA4A1C4438515AF",
         "noteCommitment": {
           "commitment": {
@@ -138,7 +138,7 @@
     },
     {
       "header": {
-        "sequence": 4,
+        "height": 4,
         "previousBlockHash": "C482D5C150C7BA1F07BA33E2E0869C9856D824836CB8693EE36571D0E61337EB",
         "noteCommitment": {
           "commitment": {
@@ -168,7 +168,7 @@
     },
     {
       "header": {
-        "sequence": 4,
+        "height": 4,
         "previousBlockHash": "E49D6A8ED5360F4EAE44E0F78AE445B77EA85E3764D11F32E58B76D5005BF15E",
         "noteCommitment": {
           "commitment": {
@@ -198,7 +198,7 @@
     },
     {
       "header": {
-        "sequence": 5,
+        "height": 5,
         "previousBlockHash": "3C5867E2092ECCE81AC5B4C82BB2DAEF95574EAE7AA3718A0874AE8A3A1162C4",
         "noteCommitment": {
           "commitment": {
@@ -228,7 +228,7 @@
     },
     {
       "header": {
-        "sequence": 5,
+        "height": 5,
         "previousBlockHash": "CE81D1D7D3F1F30E06D69E4D261F549E3BF51CE813F1E634ADC8ED8A98D6045D",
         "noteCommitment": {
           "commitment": {
@@ -258,7 +258,7 @@
     },
     {
       "header": {
-        "sequence": 6,
+        "height": 6,
         "previousBlockHash": "177CDF697C5F321AD428FE63BC6401FA499E52FE08BAF060AEE01D2D73C293CC",
         "noteCommitment": {
           "commitment": {
@@ -288,7 +288,7 @@
     },
     {
       "header": {
-        "sequence": 6,
+        "height": 6,
         "previousBlockHash": "B4AD9EA732BF2694A6D227681F437AA2C942653BDC10B7EC4F795EE3DBA066AA",
         "noteCommitment": {
           "commitment": {
@@ -318,7 +318,7 @@
     },
     {
       "header": {
-        "sequence": 7,
+        "height": 7,
         "previousBlockHash": "12CD14B05699EA74D0BC4C2E2964D26DDF7A91DF8F1310E3AAC84F8BD6925BDA",
         "noteCommitment": {
           "commitment": {
@@ -348,7 +348,7 @@
     },
     {
       "header": {
-        "sequence": 7,
+        "height": 7,
         "previousBlockHash": "D1200750F5EACE358EDE2ADFB6379AD69A175FA09B712A12C36966F2F1531164",
         "noteCommitment": {
           "commitment": {
@@ -378,7 +378,7 @@
     },
     {
       "header": {
-        "sequence": 8,
+        "height": 8,
         "previousBlockHash": "8179C23DA5B2DD3C284E82EFE8AED653844E4BF27D074943AB5ED4BD109B55BC",
         "noteCommitment": {
           "commitment": {
@@ -408,7 +408,7 @@
     },
     {
       "header": {
-        "sequence": 8,
+        "height": 8,
         "previousBlockHash": "48601944387EC097339D53518202B0A3201D1F60A7E066AB3B4D222505E8D72D",
         "noteCommitment": {
           "commitment": {
@@ -438,7 +438,7 @@
     },
     {
       "header": {
-        "sequence": 9,
+        "height": 9,
         "previousBlockHash": "1EF76D80615212FBFE83DC20D347B4D43397E800A3B913BD10CE26DE2FB806B2",
         "noteCommitment": {
           "commitment": {
@@ -468,7 +468,7 @@
     },
     {
       "header": {
-        "sequence": 9,
+        "height": 9,
         "previousBlockHash": "D6ADB4C042643A541F109E673248ABB9B869B3E2533DBEC6A4B05208D1D32ADE",
         "noteCommitment": {
           "commitment": {
@@ -498,7 +498,7 @@
     },
     {
       "header": {
-        "sequence": 10,
+        "height": 10,
         "previousBlockHash": "F2BF917D3FF009D4DD4E89FABB865FD88F6F6917CCE5500E3F0975DB7535B695",
         "noteCommitment": {
           "commitment": {
@@ -528,7 +528,7 @@
     },
     {
       "header": {
-        "sequence": 10,
+        "height": 10,
         "previousBlockHash": "A69E66151BF4F869EB8B5603AB1E1049DB7B7613E9D4DB6B8AF3978E56185C2C",
         "noteCommitment": {
           "commitment": {
@@ -558,7 +558,7 @@
     },
     {
       "header": {
-        "sequence": 11,
+        "height": 11,
         "previousBlockHash": "E4CA4A527DDD6DBD139C5A92A0A246B1FB8180C490C88934CE4C45573E995F7D",
         "noteCommitment": {
           "commitment": {
@@ -588,7 +588,7 @@
     },
     {
       "header": {
-        "sequence": 11,
+        "height": 11,
         "previousBlockHash": "2E10652CE18E8D7C0CDEA3D5D9339AB2BC5166CC79962459401551A3E5947D7F",
         "noteCommitment": {
           "commitment": {
@@ -618,7 +618,7 @@
     },
     {
       "header": {
-        "sequence": 12,
+        "height": 12,
         "previousBlockHash": "3A87860D3EF44BFD56500D424684A7A88D7EDA8A78DE1EDA1763B2CC3788BCF4",
         "noteCommitment": {
           "commitment": {
@@ -648,7 +648,7 @@
     },
     {
       "header": {
-        "sequence": 12,
+        "height": 12,
         "previousBlockHash": "593A53BF375678A374F6F74B2099345BD355D79D05E2BC32FCBCC02DC546D18F",
         "noteCommitment": {
           "commitment": {
@@ -678,7 +678,7 @@
     },
     {
       "header": {
-        "sequence": 13,
+        "height": 13,
         "previousBlockHash": "1B2E3C193D43E152FD1525A8382B8557EC08243747F45B5B4AEF6A0DB8473A49",
         "noteCommitment": {
           "commitment": {
@@ -708,7 +708,7 @@
     },
     {
       "header": {
-        "sequence": 13,
+        "height": 13,
         "previousBlockHash": "A4DE74AD66FEE94DA52E9D7C24F7CFD52A9F55AEBE4AB0ED07ED61ED88A975B9",
         "noteCommitment": {
           "commitment": {
@@ -738,7 +738,7 @@
     },
     {
       "header": {
-        "sequence": 14,
+        "height": 14,
         "previousBlockHash": "6C6FF236C9EC60A2C7D8BC14CF7D69EA4F048BFF33C72C4867F577A7F655034E",
         "noteCommitment": {
           "commitment": {
@@ -768,7 +768,7 @@
     },
     {
       "header": {
-        "sequence": 14,
+        "height": 14,
         "previousBlockHash": "2A105EB2A53157198103FA4C7698D42CB755213A5FE60D22AAF6CA7E4DBC5377",
         "noteCommitment": {
           "commitment": {
@@ -798,7 +798,7 @@
     },
     {
       "header": {
-        "sequence": 15,
+        "height": 15,
         "previousBlockHash": "EC863DB9F1B62877640D571115C76A9A6FD8EF35429FCDB74C15ECCCF2C76017",
         "noteCommitment": {
           "commitment": {
@@ -828,7 +828,7 @@
     },
     {
       "header": {
-        "sequence": 15,
+        "height": 15,
         "previousBlockHash": "4D1242132D42F2FDAD1E7E7F620ED28DF1CE5FE2473F5EB08A2F5C88561ACB36",
         "noteCommitment": {
           "commitment": {
@@ -858,7 +858,7 @@
     },
     {
       "header": {
-        "sequence": 16,
+        "height": 16,
         "previousBlockHash": "C921D04C736532879A944BE0D1AA310E0259FBAFF7FF8F52F4F0ECDA168AA65A",
         "noteCommitment": {
           "commitment": {
@@ -888,7 +888,7 @@
     },
     {
       "header": {
-        "sequence": 16,
+        "height": 16,
         "previousBlockHash": "69BC829E7D7C759559D741410A4FBC1EC48E9A30A4F3880373D87B7E013A9BF9",
         "noteCommitment": {
           "commitment": {
@@ -918,7 +918,7 @@
     },
     {
       "header": {
-        "sequence": 17,
+        "height": 17,
         "previousBlockHash": "1408D05760250A4617BDB6DEBF3900D657FAFBE6DA656956E7219948F7527BEF",
         "noteCommitment": {
           "commitment": {
@@ -948,7 +948,7 @@
     },
     {
       "header": {
-        "sequence": 17,
+        "height": 17,
         "previousBlockHash": "892E1C4C1D305956E1DAA70FF2AF26ECD76EA8D606C2982775F19B57B03C5141",
         "noteCommitment": {
           "commitment": {
@@ -978,7 +978,7 @@
     },
     {
       "header": {
-        "sequence": 18,
+        "height": 18,
         "previousBlockHash": "AFB08078C12BA0095FA7BCD7BAB2B2FBE34204617DF415FAD650E7D6B89BE96E",
         "noteCommitment": {
           "commitment": {
@@ -1008,7 +1008,7 @@
     },
     {
       "header": {
-        "sequence": 18,
+        "height": 18,
         "previousBlockHash": "9BF1CD09C10A598B73FE00421181A28C266DE8D12C016244D7EFBAD4655A389A",
         "noteCommitment": {
           "commitment": {
@@ -1038,7 +1038,7 @@
     },
     {
       "header": {
-        "sequence": 19,
+        "height": 19,
         "previousBlockHash": "DCC1A8AC472A2C2B63603B5AE91C57688F346BF988EA00CAC75685B6EB5553E5",
         "noteCommitment": {
           "commitment": {
@@ -1068,7 +1068,7 @@
     },
     {
       "header": {
-        "sequence": 19,
+        "height": 19,
         "previousBlockHash": "C7A8B80C0C9C9B98712DE9398B852C7CBDD88FCB817A6031D5A6EF74944A8F21",
         "noteCommitment": {
           "commitment": {
@@ -1098,7 +1098,7 @@
     },
     {
       "header": {
-        "sequence": 20,
+        "height": 20,
         "previousBlockHash": "F28E92535DE91DC3B778C2A6C7387E7E453E397B4B431617E254BB5BC0E71F48",
         "noteCommitment": {
           "commitment": {
@@ -1128,7 +1128,7 @@
     },
     {
       "header": {
-        "sequence": 20,
+        "height": 20,
         "previousBlockHash": "66DB711FB633F0C58258401556F50FF6C8B1046A8D877F2332C248FA5DE1FBC4",
         "noteCommitment": {
           "commitment": {
@@ -1158,7 +1158,7 @@
     },
     {
       "header": {
-        "sequence": 21,
+        "height": 21,
         "previousBlockHash": "731031FFACE7C448AD0A0AB706E5A6D50B21437D6DD6EA947008520797E95CFF",
         "noteCommitment": {
           "commitment": {
@@ -1188,7 +1188,7 @@
     },
     {
       "header": {
-        "sequence": 21,
+        "height": 21,
         "previousBlockHash": "6DD6A5A621934439AB1DD40CEA6A6955CB28133E39D83991F54D3A635484D078",
         "noteCommitment": {
           "commitment": {
@@ -1218,7 +1218,7 @@
     },
     {
       "header": {
-        "sequence": 22,
+        "height": 22,
         "previousBlockHash": "56CA9C42FA33582C4442BE9BEE0A1C0C54CFB8034723848A0901CBE046F62833",
         "noteCommitment": {
           "commitment": {
@@ -1248,7 +1248,7 @@
     },
     {
       "header": {
-        "sequence": 22,
+        "height": 22,
         "previousBlockHash": "1295F2C0FC3338E5E2E1BECE616C914121DC8BC7B31A57D188B641E557946BE7",
         "noteCommitment": {
           "commitment": {
@@ -1278,7 +1278,7 @@
     },
     {
       "header": {
-        "sequence": 23,
+        "height": 23,
         "previousBlockHash": "CC81F8E227BEBCF27A4651723B60A9AEAAF75D48816A10F73872A7B169A2E69F",
         "noteCommitment": {
           "commitment": {
@@ -1308,7 +1308,7 @@
     },
     {
       "header": {
-        "sequence": 23,
+        "height": 23,
         "previousBlockHash": "39F83C284CA92230FC1AD8F67D67BE8C4F74EDD7A937EECA2C1708DB325EEC65",
         "noteCommitment": {
           "commitment": {
@@ -1338,7 +1338,7 @@
     },
     {
       "header": {
-        "sequence": 24,
+        "height": 24,
         "previousBlockHash": "97E68813F6F634B9AFF1ED4DCFC04EFBBD2909A568B57EFDD8307307FDA2BC46",
         "noteCommitment": {
           "commitment": {
@@ -1368,7 +1368,7 @@
     },
     {
       "header": {
-        "sequence": 24,
+        "height": 24,
         "previousBlockHash": "E714AF75DF36582AD2C4F2A9E5335E3597A416C305703D159E3B82C08304443B",
         "noteCommitment": {
           "commitment": {
@@ -1398,7 +1398,7 @@
     },
     {
       "header": {
-        "sequence": 25,
+        "height": 25,
         "previousBlockHash": "72A465CE3AC0217799D01E9753FDE2FE1776B0AFB6790092F433D2B32B9EE0A2",
         "noteCommitment": {
           "commitment": {
@@ -1428,7 +1428,7 @@
     },
     {
       "header": {
-        "sequence": 25,
+        "height": 25,
         "previousBlockHash": "95060EE09F65D8564F9179125D57A1A77F76493CAFC38F7C535AD38166655964",
         "noteCommitment": {
           "commitment": {
@@ -1458,7 +1458,7 @@
     },
     {
       "header": {
-        "sequence": 26,
+        "height": 26,
         "previousBlockHash": "1B9CE8D71745D872B5DECB200B7E36ADB6CDD21C5676F422CF49EB7F116FB180",
         "noteCommitment": {
           "commitment": {
@@ -1488,7 +1488,7 @@
     },
     {
       "header": {
-        "sequence": 26,
+        "height": 26,
         "previousBlockHash": "C2FB2FA8DE31EBBD04A38304E937F0E8BA123E587CA48E4040A0C1DEA8948575",
         "noteCommitment": {
           "commitment": {
@@ -1518,7 +1518,7 @@
     },
     {
       "header": {
-        "sequence": 27,
+        "height": 27,
         "previousBlockHash": "52DA5930DB069E68190647B35A6E61CB44BE77577CE27C7E76BAE2B86E1C2190",
         "noteCommitment": {
           "commitment": {
@@ -1548,7 +1548,7 @@
     },
     {
       "header": {
-        "sequence": 27,
+        "height": 27,
         "previousBlockHash": "67C59C62C1486B7E51EAD09967D7AD440AEF918A6DD6DD09C6D73BD6D10DC965",
         "noteCommitment": {
           "commitment": {
@@ -1578,7 +1578,7 @@
     },
     {
       "header": {
-        "sequence": 28,
+        "height": 28,
         "previousBlockHash": "10EF121ED3AB498E50FB7EE8D8CCA267CDA4D7FBAEB6E4A0A5828205DB06BFC9",
         "noteCommitment": {
           "commitment": {
@@ -1608,7 +1608,7 @@
     },
     {
       "header": {
-        "sequence": 28,
+        "height": 28,
         "previousBlockHash": "C7E12BEFF8EF19245E82682B00BA0B80BFFCB9C33B55A2D8F1C36C7A0CBC7608",
         "noteCommitment": {
           "commitment": {
@@ -1638,7 +1638,7 @@
     },
     {
       "header": {
-        "sequence": 29,
+        "height": 29,
         "previousBlockHash": "7874C57FBE250892F84D80D310E08D18D856676310DB75E8FBDE53037DF7D97F",
         "noteCommitment": {
           "commitment": {
@@ -1668,7 +1668,7 @@
     },
     {
       "header": {
-        "sequence": 29,
+        "height": 29,
         "previousBlockHash": "AB0555861A28ED90EC997738D6CC190E63E478421D4AF373E51B21BC3C0A7C31",
         "noteCommitment": {
           "commitment": {
@@ -1698,7 +1698,7 @@
     },
     {
       "header": {
-        "sequence": 30,
+        "height": 30,
         "previousBlockHash": "31463D49BF0CAEAD27BCED2B11F2A8C36F145FE7DE5EFE7F50480A68BD660DEB",
         "noteCommitment": {
           "commitment": {
@@ -1728,7 +1728,7 @@
     },
     {
       "header": {
-        "sequence": 30,
+        "height": 30,
         "previousBlockHash": "47D8E24B5B4F30C000A9108076559D10835CBD4F6A7BFCA874E523732D0BF774",
         "noteCommitment": {
           "commitment": {
@@ -1758,7 +1758,7 @@
     },
     {
       "header": {
-        "sequence": 31,
+        "height": 31,
         "previousBlockHash": "F5D3969D217D1DC370427377E4C22B6746115D5D3EE0C77251E691B2B19852DE",
         "noteCommitment": {
           "commitment": {
@@ -1788,7 +1788,7 @@
     },
     {
       "header": {
-        "sequence": 31,
+        "height": 31,
         "previousBlockHash": "9E0D46049F6928FADA9733619C51B35C30E11F9A4E7C97FCF3A97794A808F2B5",
         "noteCommitment": {
           "commitment": {
@@ -1818,7 +1818,7 @@
     },
     {
       "header": {
-        "sequence": 32,
+        "height": 32,
         "previousBlockHash": "C87B50C0B828B17D90B9E3C0A35F8549C895EF1EB6B1DA5792CD6512C3BD0D7D",
         "noteCommitment": {
           "commitment": {
@@ -1848,7 +1848,7 @@
     },
     {
       "header": {
-        "sequence": 32,
+        "height": 32,
         "previousBlockHash": "CC67BFFF48F570245C910A7E8392446BA631FCC0608B52145CC544EDCEDC5DDE",
         "noteCommitment": {
           "commitment": {
@@ -1878,7 +1878,7 @@
     },
     {
       "header": {
-        "sequence": 33,
+        "height": 33,
         "previousBlockHash": "1E1E6EF0AF723CAA75021961DCF8C753850AB7E15CF289D1915446A4CCAAAE3C",
         "noteCommitment": {
           "commitment": {
@@ -1908,7 +1908,7 @@
     },
     {
       "header": {
-        "sequence": 33,
+        "height": 33,
         "previousBlockHash": "3F3A2AB411DB95ABBE5BF17D28E96488EFC28B8C29281BCECFAA2E0D4B4D41FF",
         "noteCommitment": {
           "commitment": {
@@ -1938,7 +1938,7 @@
     },
     {
       "header": {
-        "sequence": 34,
+        "height": 34,
         "previousBlockHash": "8C7A82B7E00C8E4525C81F4CCCF72B162C8E33D100A16F17F39649B179EC23DD",
         "noteCommitment": {
           "commitment": {
@@ -1968,7 +1968,7 @@
     },
     {
       "header": {
-        "sequence": 34,
+        "height": 34,
         "previousBlockHash": "45DB4660E27C2442824A8DE3DAB8C413340E14F556542BCEEDC7900F9026EEB0",
         "noteCommitment": {
           "commitment": {
@@ -1998,7 +1998,7 @@
     },
     {
       "header": {
-        "sequence": 35,
+        "height": 35,
         "previousBlockHash": "83C8B7815E015A9DD9DC52BA79DDD8EC34263B0E27C5BE222A872B44DE872F8F",
         "noteCommitment": {
           "commitment": {
@@ -2028,7 +2028,7 @@
     },
     {
       "header": {
-        "sequence": 35,
+        "height": 35,
         "previousBlockHash": "177C0CAA66CFD2C0F7E3EB4229687E4C7A435881606B6ECE8AD4751E384CEF5A",
         "noteCommitment": {
           "commitment": {
@@ -2058,7 +2058,7 @@
     },
     {
       "header": {
-        "sequence": 36,
+        "height": 36,
         "previousBlockHash": "E64AE37DBA943DD78A12303B068B19B664CAE286981B03F9B7246F4AC9EF7FA5",
         "noteCommitment": {
           "commitment": {
@@ -2088,7 +2088,7 @@
     },
     {
       "header": {
-        "sequence": 36,
+        "height": 36,
         "previousBlockHash": "83DB77CE4A4539CD1D497CEE0C4838DB7DB6CAFC15DA21AE76F6C40ECF0895F5",
         "noteCommitment": {
           "commitment": {
@@ -2118,7 +2118,7 @@
     },
     {
       "header": {
-        "sequence": 37,
+        "height": 37,
         "previousBlockHash": "A71DF00B64814E797FC606BD614962404F67801456C6ECA8A184B9F303A82C84",
         "noteCommitment": {
           "commitment": {
@@ -2148,7 +2148,7 @@
     },
     {
       "header": {
-        "sequence": 37,
+        "height": 37,
         "previousBlockHash": "1A9DCBBFC04DAF118AFF413DDCAF29B5E59F30A4FA7FFE226952AFA1067225CA",
         "noteCommitment": {
           "commitment": {
@@ -2178,7 +2178,7 @@
     },
     {
       "header": {
-        "sequence": 38,
+        "height": 38,
         "previousBlockHash": "C95FF833D5A5048CE73CD4FDDEE03281C57150908E9AE922D8CAF7B7E8CA6F75",
         "noteCommitment": {
           "commitment": {
@@ -2208,7 +2208,7 @@
     },
     {
       "header": {
-        "sequence": 38,
+        "height": 38,
         "previousBlockHash": "9C430E65B16B5947D5D2EE47638EBBBB8B539636E875F64E41E8581C22E90ED2",
         "noteCommitment": {
           "commitment": {
@@ -2238,7 +2238,7 @@
     },
     {
       "header": {
-        "sequence": 39,
+        "height": 39,
         "previousBlockHash": "12B2A8BF2CF3B3C0FA49CF6BF578C52013DF340682614808C8096C9568F57307",
         "noteCommitment": {
           "commitment": {
@@ -2268,7 +2268,7 @@
     },
     {
       "header": {
-        "sequence": 39,
+        "height": 39,
         "previousBlockHash": "3B492FB5901D1DEFE7BFB57A9545C0BDBDE573BBBD6E23481F934DC0C43EA76F",
         "noteCommitment": {
           "commitment": {
@@ -2298,7 +2298,7 @@
     },
     {
       "header": {
-        "sequence": 40,
+        "height": 40,
         "previousBlockHash": "5A0FEB9AE96234C4C39A44DA24566596127018AACF13149331D9B992550D6B73",
         "noteCommitment": {
           "commitment": {
@@ -2328,7 +2328,7 @@
     },
     {
       "header": {
-        "sequence": 40,
+        "height": 40,
         "previousBlockHash": "6505631E5BE27D2996C8A78D7018963846CC6EE6A5419B1A91E293B897967308",
         "noteCommitment": {
           "commitment": {
@@ -2358,7 +2358,7 @@
     },
     {
       "header": {
-        "sequence": 41,
+        "height": 41,
         "previousBlockHash": "0D1706AD9A9EAA1BBDC9B9DD948935ECA7F708D55D649D6A3EF24A397CDA6558",
         "noteCommitment": {
           "commitment": {
@@ -2388,7 +2388,7 @@
     },
     {
       "header": {
-        "sequence": 41,
+        "height": 41,
         "previousBlockHash": "63BA549A45BC18AB4C01187C04438180647F72EF78A0A47294F9BC01869FBF5B",
         "noteCommitment": {
           "commitment": {
@@ -2418,7 +2418,7 @@
     },
     {
       "header": {
-        "sequence": 42,
+        "height": 42,
         "previousBlockHash": "2BCAE85BF02DAFD359BD33BE70E7A6451A6598A0405BD27EEA2A12681EE8A6D9",
         "noteCommitment": {
           "commitment": {
@@ -2448,7 +2448,7 @@
     },
     {
       "header": {
-        "sequence": 42,
+        "height": 42,
         "previousBlockHash": "000382D8405424D029E13A234DB1FB4143219A5A6DB300FBB8716E89E35428A1",
         "noteCommitment": {
           "commitment": {
@@ -2478,7 +2478,7 @@
     },
     {
       "header": {
-        "sequence": 43,
+        "height": 43,
         "previousBlockHash": "2420455BF4EA0BFA719F0F100E66A290481841E4B0D7871CBCA31BF876F1E245",
         "noteCommitment": {
           "commitment": {
@@ -2508,7 +2508,7 @@
     },
     {
       "header": {
-        "sequence": 43,
+        "height": 43,
         "previousBlockHash": "A699E4605726D590F82617C69D6A6C8A6143689ADFF6D902C28BB6D2A63C5E44",
         "noteCommitment": {
           "commitment": {
@@ -2538,7 +2538,7 @@
     },
     {
       "header": {
-        "sequence": 44,
+        "height": 44,
         "previousBlockHash": "2BDA0D6FB900DC56782BAF42C10299AD665264E2D71B1C0C980A05BD196EA14E",
         "noteCommitment": {
           "commitment": {
@@ -2568,7 +2568,7 @@
     },
     {
       "header": {
-        "sequence": 44,
+        "height": 44,
         "previousBlockHash": "B0EE22EDE32F2311D7C6504C56F4D28D35B3299A332B7523114D55FD5E6752FB",
         "noteCommitment": {
           "commitment": {
@@ -2598,7 +2598,7 @@
     },
     {
       "header": {
-        "sequence": 45,
+        "height": 45,
         "previousBlockHash": "467845233BE141EEE81FFB6522A77060DC6A3FDA95369D9AF9C5FF73AFF3C8F5",
         "noteCommitment": {
           "commitment": {
@@ -2628,7 +2628,7 @@
     },
     {
       "header": {
-        "sequence": 45,
+        "height": 45,
         "previousBlockHash": "38B022613AFCF0D404218EF409F6D2B554B291640E989EFCC66E2F5524B16FEC",
         "noteCommitment": {
           "commitment": {
@@ -2658,7 +2658,7 @@
     },
     {
       "header": {
-        "sequence": 46,
+        "height": 46,
         "previousBlockHash": "FEA31CFDFFA86A350CBF0FFF0FED09C1F2BC9FA5E828C3946CF9FDEDACA7E0B1",
         "noteCommitment": {
           "commitment": {
@@ -2688,7 +2688,7 @@
     },
     {
       "header": {
-        "sequence": 46,
+        "height": 46,
         "previousBlockHash": "CE8A4304ECFF4FC8715BE9B64BCD8823E6F5634FC5E18D5D06B4BCD5B94D558D",
         "noteCommitment": {
           "commitment": {
@@ -2718,7 +2718,7 @@
     },
     {
       "header": {
-        "sequence": 47,
+        "height": 47,
         "previousBlockHash": "C58EB9265F5E21C0E487F5B03672B9A5853CE2BE2D3C5836A1E456E59787517E",
         "noteCommitment": {
           "commitment": {
@@ -2748,7 +2748,7 @@
     },
     {
       "header": {
-        "sequence": 47,
+        "height": 47,
         "previousBlockHash": "A89B04809A6C161FA062D9E8E8792EE181657BBD281A35F4AE69B65D35D623D0",
         "noteCommitment": {
           "commitment": {
@@ -2778,7 +2778,7 @@
     },
     {
       "header": {
-        "sequence": 48,
+        "height": 48,
         "previousBlockHash": "46D4428198451E187E954338D9E0CCB451208F88A858EB96B9039F3F0EDDA55C",
         "noteCommitment": {
           "commitment": {
@@ -2808,7 +2808,7 @@
     },
     {
       "header": {
-        "sequence": 48,
+        "height": 48,
         "previousBlockHash": "D84AA83E7DEF60500E4CE9BDAA1E2193C534CCB69F53BD9FDDA84967EE82A22F",
         "noteCommitment": {
           "commitment": {
@@ -2838,7 +2838,7 @@
     },
     {
       "header": {
-        "sequence": 49,
+        "height": 49,
         "previousBlockHash": "EF2F37DD6939D0137ED96B885CE39D755EED3CBF2E0C1880FB1091FDA24F6D15",
         "noteCommitment": {
           "commitment": {
@@ -2868,7 +2868,7 @@
     },
     {
       "header": {
-        "sequence": 49,
+        "height": 49,
         "previousBlockHash": "3FC2BC207E417E021B3DD8D8158E460A59B2F5676DEBAFD91D2C86CB53336BE5",
         "noteCommitment": {
           "commitment": {
@@ -2898,7 +2898,7 @@
     },
     {
       "header": {
-        "sequence": 50,
+        "height": 50,
         "previousBlockHash": "CA668DE515057D4C111B8342BCD1922DD49365331F204C790AA847E8F2DBE107",
         "noteCommitment": {
           "commitment": {
@@ -2928,7 +2928,7 @@
     },
     {
       "header": {
-        "sequence": 50,
+        "height": 50,
         "previousBlockHash": "03075EDEA386271923DD6965828DD3CD0B7E4A384622744D86EEA24883BDCB14",
         "noteCommitment": {
           "commitment": {
@@ -2958,7 +2958,7 @@
     },
     {
       "header": {
-        "sequence": 51,
+        "height": 51,
         "previousBlockHash": "D6294C0932E2497753F6115424B9CEF6D0E6E7779A28F2C4081BC1F3907F7C59",
         "noteCommitment": {
           "commitment": {
@@ -2988,7 +2988,7 @@
     },
     {
       "header": {
-        "sequence": 51,
+        "height": 51,
         "previousBlockHash": "4A0B99E08E50C58E64966DE02610E501854475328E7BCB0C762ABFC78E76DD92",
         "noteCommitment": {
           "commitment": {
@@ -3018,7 +3018,7 @@
     },
     {
       "header": {
-        "sequence": 52,
+        "height": 52,
         "previousBlockHash": "BEB89F8B84DCF32FDA53BBC9A62864F8750B81996A8DAA1D7EE0985A089BED80",
         "noteCommitment": {
           "commitment": {
@@ -3048,7 +3048,7 @@
     },
     {
       "header": {
-        "sequence": 52,
+        "height": 52,
         "previousBlockHash": "E7666EDFA123F2A8C016BB0D5328E04BFD01769112DA1C3CCBE5AE321102233B",
         "noteCommitment": {
           "commitment": {
@@ -3078,7 +3078,7 @@
     },
     {
       "header": {
-        "sequence": 53,
+        "height": 53,
         "previousBlockHash": "21BF4B0328C661ED81ADC4922A0A77C7AC0C81BF4978547C06AE63069963C008",
         "noteCommitment": {
           "commitment": {
@@ -3108,7 +3108,7 @@
     },
     {
       "header": {
-        "sequence": 53,
+        "height": 53,
         "previousBlockHash": "8ABF748F531684FF60D8FEBDEA837621550ECC5B7AE3276810C5D2497889B79C",
         "noteCommitment": {
           "commitment": {
@@ -3138,7 +3138,7 @@
     },
     {
       "header": {
-        "sequence": 54,
+        "height": 54,
         "previousBlockHash": "6F272DF2130D8BE351B7FA07772EFD07954E8BA9D08D5C1696C4381A1C8D0BBA",
         "noteCommitment": {
           "commitment": {
@@ -3168,7 +3168,7 @@
     },
     {
       "header": {
-        "sequence": 54,
+        "height": 54,
         "previousBlockHash": "BCE4FA4F8A3D57F3F978D78FA64C019357E377E9438D5A4A688E55FFD54ACEFD",
         "noteCommitment": {
           "commitment": {
@@ -3198,7 +3198,7 @@
     },
     {
       "header": {
-        "sequence": 55,
+        "height": 55,
         "previousBlockHash": "6E058D0D4DEE3D765AE469F0EF6333AE0A1C7C54576D2587DB322A421FD9B7BC",
         "noteCommitment": {
           "commitment": {
@@ -3228,7 +3228,7 @@
     },
     {
       "header": {
-        "sequence": 55,
+        "height": 55,
         "previousBlockHash": "009AD9023724E121B4C36B78F64C85815BB0A7A0F203CC90B7F6BC462508419C",
         "noteCommitment": {
           "commitment": {
@@ -3258,7 +3258,7 @@
     },
     {
       "header": {
-        "sequence": 56,
+        "height": 56,
         "previousBlockHash": "E0209F80D725F1C6935B94C32199ADFBD36321C8049622D767DE140D9060A885",
         "noteCommitment": {
           "commitment": {
@@ -3288,7 +3288,7 @@
     },
     {
       "header": {
-        "sequence": 56,
+        "height": 56,
         "previousBlockHash": "C2D55B5F37EC467B12F4D7EB4397B895CD0519B56B80599B6F7F1CF071F62F4A",
         "noteCommitment": {
           "commitment": {
@@ -3318,7 +3318,7 @@
     },
     {
       "header": {
-        "sequence": 57,
+        "height": 57,
         "previousBlockHash": "61C7BFBEC48BE67A005DD745EAD261EE55314F8E9F1977050A7EAA3C74AC432E",
         "noteCommitment": {
           "commitment": {
@@ -3348,7 +3348,7 @@
     },
     {
       "header": {
-        "sequence": 57,
+        "height": 57,
         "previousBlockHash": "2C07A16C3D6169BB7838E1CF81C108D0B2061EEB91514DF9ED66B57144A20E50",
         "noteCommitment": {
           "commitment": {
@@ -3378,7 +3378,7 @@
     },
     {
       "header": {
-        "sequence": 58,
+        "height": 58,
         "previousBlockHash": "1B683B9A8A2C8FDC981FD281D7410A25AE33E12EF29527304C49C7FB940C522C",
         "noteCommitment": {
           "commitment": {
@@ -3408,7 +3408,7 @@
     },
     {
       "header": {
-        "sequence": 58,
+        "height": 58,
         "previousBlockHash": "571A3EA83801F1A7A30289DC0004E6ED1EE25AC916134156E97673A10B533ED5",
         "noteCommitment": {
           "commitment": {
@@ -3438,7 +3438,7 @@
     },
     {
       "header": {
-        "sequence": 59,
+        "height": 59,
         "previousBlockHash": "5B0DC883EA34CCF9DC682D53AEF09BC296E13B4F724C8F489E7DD394C3B59D5B",
         "noteCommitment": {
           "commitment": {
@@ -3468,7 +3468,7 @@
     },
     {
       "header": {
-        "sequence": 59,
+        "height": 59,
         "previousBlockHash": "36E7339D432AF9427B3230C1683B5D2F654AA686D0AB191A896EDE5F8368BA7A",
         "noteCommitment": {
           "commitment": {
@@ -3498,7 +3498,7 @@
     },
     {
       "header": {
-        "sequence": 60,
+        "height": 60,
         "previousBlockHash": "940CB6BCC1DFC6953F2A3410F869BA5BEA15253BEF427A0B44C7DECE24ECFBEC",
         "noteCommitment": {
           "commitment": {
@@ -3528,7 +3528,7 @@
     },
     {
       "header": {
-        "sequence": 60,
+        "height": 60,
         "previousBlockHash": "8336D4E897B8BCE285D67355DE88A945AC0BC5F59EC8141306BA409882DFAE71",
         "noteCommitment": {
           "commitment": {
@@ -3558,7 +3558,7 @@
     },
     {
       "header": {
-        "sequence": 61,
+        "height": 61,
         "previousBlockHash": "7320E3A32F68D021ED42B8CFF20F13EC820F7B774412DE5F3A34F553F33058AA",
         "noteCommitment": {
           "commitment": {
@@ -3588,7 +3588,7 @@
     },
     {
       "header": {
-        "sequence": 61,
+        "height": 61,
         "previousBlockHash": "11AB0201E39DFCE920D2A740296E1553ACEE85241B3D6B7AFADCA1C9BDAB56C2",
         "noteCommitment": {
           "commitment": {
@@ -3618,7 +3618,7 @@
     },
     {
       "header": {
-        "sequence": 62,
+        "height": 62,
         "previousBlockHash": "1248D7842A2F1D31108957F22FAC006328F41D4081E4DC77329B19CC4C9F4657",
         "noteCommitment": {
           "commitment": {
@@ -3648,7 +3648,7 @@
     },
     {
       "header": {
-        "sequence": 62,
+        "height": 62,
         "previousBlockHash": "129936AA6F128E59D98E906D5B7767E2385A21F1BCD766C07E4E332B8762FC46",
         "noteCommitment": {
           "commitment": {
@@ -3678,7 +3678,7 @@
     },
     {
       "header": {
-        "sequence": 63,
+        "height": 63,
         "previousBlockHash": "2A5A95CEA962C8F68E2C3F38C7A6505B3BB0621D2EF596CB70E5E97F2903A014",
         "noteCommitment": {
           "commitment": {
@@ -3708,7 +3708,7 @@
     },
     {
       "header": {
-        "sequence": 63,
+        "height": 63,
         "previousBlockHash": "F6134121FE07E0CA36722D91C85F3B509463385AE3543EEABB5E04CEA24CC1F6",
         "noteCommitment": {
           "commitment": {
@@ -3738,7 +3738,7 @@
     },
     {
       "header": {
-        "sequence": 64,
+        "height": 64,
         "previousBlockHash": "205C34EDB314396292ABF8862DEE25B27D382B71E87B29C5F4997FB8C5005429",
         "noteCommitment": {
           "commitment": {
@@ -3768,7 +3768,7 @@
     },
     {
       "header": {
-        "sequence": 64,
+        "height": 64,
         "previousBlockHash": "36549B61D543BDE2082C21AA868991C039EC3E64BF90701D2EC9DD4BD5F7585C",
         "noteCommitment": {
           "commitment": {
@@ -3798,7 +3798,7 @@
     },
     {
       "header": {
-        "sequence": 65,
+        "height": 65,
         "previousBlockHash": "F5D5A5DA9020F0F0EE9F4C6D8021452B19DBA8B866D142649ECB5EFE91106E2A",
         "noteCommitment": {
           "commitment": {
@@ -3828,7 +3828,7 @@
     },
     {
       "header": {
-        "sequence": 65,
+        "height": 65,
         "previousBlockHash": "6EFB5E275D7AFDFF812804B6B37B84BE1F712C498FDF607B17569AB4002F97FD",
         "noteCommitment": {
           "commitment": {
@@ -3858,7 +3858,7 @@
     },
     {
       "header": {
-        "sequence": 66,
+        "height": 66,
         "previousBlockHash": "F78B169B3458FF5700EF3169BC758D1522A8C3A16EAA0688F3136B343B13E5FD",
         "noteCommitment": {
           "commitment": {
@@ -3888,7 +3888,7 @@
     },
     {
       "header": {
-        "sequence": 66,
+        "height": 66,
         "previousBlockHash": "859A033885EEAAC8A82516A19072D5C0151705C6D26D070F3D8FE49C843A6187",
         "noteCommitment": {
           "commitment": {
@@ -3918,7 +3918,7 @@
     },
     {
       "header": {
-        "sequence": 67,
+        "height": 67,
         "previousBlockHash": "8D557C23126BE5B8F296FE76AACC8F48CE6DCBFFDF5CA6BAEC8DFC42AA276093",
         "noteCommitment": {
           "commitment": {
@@ -3948,7 +3948,7 @@
     },
     {
       "header": {
-        "sequence": 67,
+        "height": 67,
         "previousBlockHash": "EE86621E514221E838E65E986DE1AEC30B2159A1A6CE04EFAF56E57D98697A0F",
         "noteCommitment": {
           "commitment": {
@@ -3978,7 +3978,7 @@
     },
     {
       "header": {
-        "sequence": 68,
+        "height": 68,
         "previousBlockHash": "C275BC8F752A81F37B31B5308FC3E9E270EC7154294C91B06171FEFB0C786E9E",
         "noteCommitment": {
           "commitment": {
@@ -4008,7 +4008,7 @@
     },
     {
       "header": {
-        "sequence": 68,
+        "height": 68,
         "previousBlockHash": "4A906FDB0CD05D735394DE63435F19309861C616E65C34EB2A41A8FB6F2AA8C4",
         "noteCommitment": {
           "commitment": {
@@ -4038,7 +4038,7 @@
     },
     {
       "header": {
-        "sequence": 69,
+        "height": 69,
         "previousBlockHash": "BD92FD63815FB55EACF2C9E1B90D75D7DFBACE643011AE56152C696FA8318842",
         "noteCommitment": {
           "commitment": {
@@ -4068,7 +4068,7 @@
     },
     {
       "header": {
-        "sequence": 69,
+        "height": 69,
         "previousBlockHash": "18A839862E7E9F2F60B562C66EC94810CF6008B43B0A6311907679601CE7F5A3",
         "noteCommitment": {
           "commitment": {
@@ -4098,7 +4098,7 @@
     },
     {
       "header": {
-        "sequence": 70,
+        "height": 70,
         "previousBlockHash": "C1BB5547ABAEF2B5B18A5C5FFE5C4A62D5FD20E746E1D9D74DF2D282034968C8",
         "noteCommitment": {
           "commitment": {
@@ -4128,7 +4128,7 @@
     },
     {
       "header": {
-        "sequence": 70,
+        "height": 70,
         "previousBlockHash": "159842FAF311E210A09B4CDF33729D16591D0A252075906BE313E5AAD30E3597",
         "noteCommitment": {
           "commitment": {
@@ -4158,7 +4158,7 @@
     },
     {
       "header": {
-        "sequence": 71,
+        "height": 71,
         "previousBlockHash": "27EEAA3A111C77E5EBB125A84A93EA46F96D0E2F543BDDA0CCC42B9618A7F81C",
         "noteCommitment": {
           "commitment": {
@@ -4188,7 +4188,7 @@
     },
     {
       "header": {
-        "sequence": 71,
+        "height": 71,
         "previousBlockHash": "77F363C9E75B6EFD92527DB255B762695FF6981100DB4B3CD4E70E91B00D54F5",
         "noteCommitment": {
           "commitment": {
@@ -4218,7 +4218,7 @@
     },
     {
       "header": {
-        "sequence": 72,
+        "height": 72,
         "previousBlockHash": "3940EF840F85725E3F6745EF97675625C34F24E1BE9B27AE2E42C27CBBE8E80D",
         "noteCommitment": {
           "commitment": {
@@ -4248,7 +4248,7 @@
     },
     {
       "header": {
-        "sequence": 72,
+        "height": 72,
         "previousBlockHash": "3297E8408523759B88BF1030364B1DC0653F4955860D70548BB000BC87ED0DD5",
         "noteCommitment": {
           "commitment": {
@@ -4278,7 +4278,7 @@
     },
     {
       "header": {
-        "sequence": 73,
+        "height": 73,
         "previousBlockHash": "F550C7041A317FB41A6EF272A10A50D026F0A94CB550CEE62C5118819E7AE292",
         "noteCommitment": {
           "commitment": {
@@ -4308,7 +4308,7 @@
     },
     {
       "header": {
-        "sequence": 73,
+        "height": 73,
         "previousBlockHash": "B303402BE1CAD94510D08A5293DF128EFBA459220F1C7FE2F87DDF9BAB1C4476",
         "noteCommitment": {
           "commitment": {
@@ -4338,7 +4338,7 @@
     },
     {
       "header": {
-        "sequence": 74,
+        "height": 74,
         "previousBlockHash": "45CA1EC6C8F291436BC1A0F8CE3C0712294D1CEB6E99EE57D876BE2DEC4F1525",
         "noteCommitment": {
           "commitment": {
@@ -4368,7 +4368,7 @@
     },
     {
       "header": {
-        "sequence": 74,
+        "height": 74,
         "previousBlockHash": "F3C2BDDF3E94ADE7CC02D3DA5BB07001EF699B10BA34F441E69B1D525F99E0F4",
         "noteCommitment": {
           "commitment": {
@@ -4398,7 +4398,7 @@
     },
     {
       "header": {
-        "sequence": 75,
+        "height": 75,
         "previousBlockHash": "3F513CDACFB468F7384E824283604673B6787D83729661986019B5E6CDCBAA02",
         "noteCommitment": {
           "commitment": {
@@ -4428,7 +4428,7 @@
     },
     {
       "header": {
-        "sequence": 75,
+        "height": 75,
         "previousBlockHash": "7E39E8D16A764A441BB4885416CEF08EBD79A8C90BFC56C5F40E18ECC3650503",
         "noteCommitment": {
           "commitment": {
@@ -4458,7 +4458,7 @@
     },
     {
       "header": {
-        "sequence": 76,
+        "height": 76,
         "previousBlockHash": "4F9E600E7BA82B90BF924B86A9D5AB18F84F405B97A256ADEFC2B2165524C242",
         "noteCommitment": {
           "commitment": {
@@ -4488,7 +4488,7 @@
     },
     {
       "header": {
-        "sequence": 76,
+        "height": 76,
         "previousBlockHash": "8CD09D4184F0079B02DDFE194D247C3AE466EB2D62DF15C427ACD7C26C3196FA",
         "noteCommitment": {
           "commitment": {
@@ -4518,7 +4518,7 @@
     },
     {
       "header": {
-        "sequence": 77,
+        "height": 77,
         "previousBlockHash": "27C9528A6D228B625A1880B8644F42D0900EC30660DC91ABB632E9F228B880C5",
         "noteCommitment": {
           "commitment": {
@@ -4548,7 +4548,7 @@
     },
     {
       "header": {
-        "sequence": 77,
+        "height": 77,
         "previousBlockHash": "D8DF4D89A85F21FC30A436708296C3E675CD4FEB2ED48F63213B822B5C932337",
         "noteCommitment": {
           "commitment": {
@@ -4578,7 +4578,7 @@
     },
     {
       "header": {
-        "sequence": 78,
+        "height": 78,
         "previousBlockHash": "82A1B5855EB65F3DD0369F360425A31F16A4CDC676D0C0539D434645129F1650",
         "noteCommitment": {
           "commitment": {
@@ -4608,7 +4608,7 @@
     },
     {
       "header": {
-        "sequence": 78,
+        "height": 78,
         "previousBlockHash": "BC56D5A823FB364E598DB2EEC1492CDF65251745BAAEB81FA93456CCD6A14D64",
         "noteCommitment": {
           "commitment": {
@@ -4638,7 +4638,7 @@
     },
     {
       "header": {
-        "sequence": 79,
+        "height": 79,
         "previousBlockHash": "38630E8E270832EDD12471ABAC1FD83FF491746FD0C3756A558FEC1003744170",
         "noteCommitment": {
           "commitment": {
@@ -4668,7 +4668,7 @@
     },
     {
       "header": {
-        "sequence": 79,
+        "height": 79,
         "previousBlockHash": "9941A79149E43645C1C8113654F6952F4BBA06422E8ED90EAACCFC18872CA876",
         "noteCommitment": {
           "commitment": {
@@ -4698,7 +4698,7 @@
     },
     {
       "header": {
-        "sequence": 80,
+        "height": 80,
         "previousBlockHash": "E1046CA6A49A025D456C62A72A5B5E4FB554278A95486F4751ED09C5A94EFB61",
         "noteCommitment": {
           "commitment": {
@@ -4728,7 +4728,7 @@
     },
     {
       "header": {
-        "sequence": 80,
+        "height": 80,
         "previousBlockHash": "D8BDBEBC9029F13B04ED34F304CBCEB69DBC1990D32D2C5BA4F4FB53261B0B15",
         "noteCommitment": {
           "commitment": {
@@ -4758,7 +4758,7 @@
     },
     {
       "header": {
-        "sequence": 81,
+        "height": 81,
         "previousBlockHash": "1F74CC665E3EE2CC8B88B0D025AEE8484BFC07B37E6331825C9FC6F3751950E8",
         "noteCommitment": {
           "commitment": {
@@ -4788,7 +4788,7 @@
     },
     {
       "header": {
-        "sequence": 81,
+        "height": 81,
         "previousBlockHash": "BF560332D7192DB2AF06841908FD2FF4DD356BF8FFB8BF9B84EE1A25A5CC3D0B",
         "noteCommitment": {
           "commitment": {
@@ -4818,7 +4818,7 @@
     },
     {
       "header": {
-        "sequence": 82,
+        "height": 82,
         "previousBlockHash": "1380E68749E69D0B78F147F7A60C50BFDEF6181D88C88D01303383727C9ABAAB",
         "noteCommitment": {
           "commitment": {
@@ -4848,7 +4848,7 @@
     },
     {
       "header": {
-        "sequence": 82,
+        "height": 82,
         "previousBlockHash": "3F8B2273E845EC5FA73E07C3ECC6943E28CB87B4ABCD6493EF0229B726CF8021",
         "noteCommitment": {
           "commitment": {
@@ -4878,7 +4878,7 @@
     },
     {
       "header": {
-        "sequence": 83,
+        "height": 83,
         "previousBlockHash": "FEA97CEFF0D619CDA2D20C5155E12D6BAC5DB3B0D4B83FE49721E818BC838E6B",
         "noteCommitment": {
           "commitment": {
@@ -4908,7 +4908,7 @@
     },
     {
       "header": {
-        "sequence": 83,
+        "height": 83,
         "previousBlockHash": "24B8EDC5A9261FB51E4BD913BB9AC42232C83CBB90DD9D16DF1A72079B772D8F",
         "noteCommitment": {
           "commitment": {
@@ -4938,7 +4938,7 @@
     },
     {
       "header": {
-        "sequence": 84,
+        "height": 84,
         "previousBlockHash": "33765920659D49635D8FFE5BDFFFE226B756050A6B756FD0D588E3BB0089F139",
         "noteCommitment": {
           "commitment": {
@@ -4968,7 +4968,7 @@
     },
     {
       "header": {
-        "sequence": 84,
+        "height": 84,
         "previousBlockHash": "5D550326568ED7AC59CB3E949A7DFD3C9EE104B114DF7AFB99077D8F51222D70",
         "noteCommitment": {
           "commitment": {
@@ -4998,7 +4998,7 @@
     },
     {
       "header": {
-        "sequence": 85,
+        "height": 85,
         "previousBlockHash": "444C3740D07101718C9C606E2BB6BC3637F10D6FBEBE785366B8DB5E4D8183EF",
         "noteCommitment": {
           "commitment": {
@@ -5028,7 +5028,7 @@
     },
     {
       "header": {
-        "sequence": 85,
+        "height": 85,
         "previousBlockHash": "84DE4C03DF6A99A0FF5C626640161EA42A088D6C301DDBC1EE81F4B19E5B9808",
         "noteCommitment": {
           "commitment": {
@@ -5058,7 +5058,7 @@
     },
     {
       "header": {
-        "sequence": 86,
+        "height": 86,
         "previousBlockHash": "EF33F65A77405DFDF18AB325CB5F45630B2649D1761FCB02320ACF8AF882CA20",
         "noteCommitment": {
           "commitment": {
@@ -5088,7 +5088,7 @@
     },
     {
       "header": {
-        "sequence": 86,
+        "height": 86,
         "previousBlockHash": "71BCBC4E2377DFF9ADC52E0019F7B10251B0A15FFA6E5BE1217C1B20110B0258",
         "noteCommitment": {
           "commitment": {
@@ -5118,7 +5118,7 @@
     },
     {
       "header": {
-        "sequence": 87,
+        "height": 87,
         "previousBlockHash": "1BA410F0CC36A671CE6E91FD76D15B9436424D75FAEBD278D2FD23148CCA1146",
         "noteCommitment": {
           "commitment": {
@@ -5148,7 +5148,7 @@
     },
     {
       "header": {
-        "sequence": 87,
+        "height": 87,
         "previousBlockHash": "46B168A8950F2EA6BBE53ACBB39A436DA58FC12DD510DC3660769B6FFA5BBC8A",
         "noteCommitment": {
           "commitment": {
@@ -5178,7 +5178,7 @@
     },
     {
       "header": {
-        "sequence": 88,
+        "height": 88,
         "previousBlockHash": "84852615B5087E592FEAFF8BC83C894746A3958F49B4B854F985D294E2652AAE",
         "noteCommitment": {
           "commitment": {
@@ -5208,7 +5208,7 @@
     },
     {
       "header": {
-        "sequence": 88,
+        "height": 88,
         "previousBlockHash": "3772A93AD396565DFA1A976570AD07BB1506BD92CD920975073BCA8B35C3ED6A",
         "noteCommitment": {
           "commitment": {
@@ -5238,7 +5238,7 @@
     },
     {
       "header": {
-        "sequence": 89,
+        "height": 89,
         "previousBlockHash": "E2B82E8D9C43D37D617A5433617A4EBE08EB11FD65612D62BDDC34BE65153F0A",
         "noteCommitment": {
           "commitment": {
@@ -5268,7 +5268,7 @@
     },
     {
       "header": {
-        "sequence": 89,
+        "height": 89,
         "previousBlockHash": "3C16229ECEB90A2A7767CDA5CAD546CD9C16D32EAC3FD8036FEA768E47FD7F35",
         "noteCommitment": {
           "commitment": {
@@ -5298,7 +5298,7 @@
     },
     {
       "header": {
-        "sequence": 90,
+        "height": 90,
         "previousBlockHash": "CBB06C1F6FD79CA4524774826F651C4E61EFA2EE3FBDA51A4943A14E07B25629",
         "noteCommitment": {
           "commitment": {
@@ -5328,7 +5328,7 @@
     },
     {
       "header": {
-        "sequence": 90,
+        "height": 90,
         "previousBlockHash": "4D4082CDCD2300BDA9F5E524B892320D9341455E1B31B2C94FFF170F70CCF0D4",
         "noteCommitment": {
           "commitment": {
@@ -5358,7 +5358,7 @@
     },
     {
       "header": {
-        "sequence": 91,
+        "height": 91,
         "previousBlockHash": "92167F90B573797251F47CBD9802422E315282D4F2F562A80B5252D253733417",
         "noteCommitment": {
           "commitment": {
@@ -5388,7 +5388,7 @@
     },
     {
       "header": {
-        "sequence": 91,
+        "height": 91,
         "previousBlockHash": "ABF8386499DAF8B4224C7914FE29D8490CD8C350B652E2B8202EF121E71179FE",
         "noteCommitment": {
           "commitment": {
@@ -5418,7 +5418,7 @@
     },
     {
       "header": {
-        "sequence": 92,
+        "height": 92,
         "previousBlockHash": "E91F59ECF27BA6134EFF336AB0F6D806CCEE2CDA72D151D16B49A7C420774CD3",
         "noteCommitment": {
           "commitment": {
@@ -5448,7 +5448,7 @@
     },
     {
       "header": {
-        "sequence": 92,
+        "height": 92,
         "previousBlockHash": "6CFFD0A088B677BA4A89057F8E3B555E23CD539512FD08A248FC605C0324DACF",
         "noteCommitment": {
           "commitment": {
@@ -5478,7 +5478,7 @@
     },
     {
       "header": {
-        "sequence": 93,
+        "height": 93,
         "previousBlockHash": "4266253D8AB486298C0DE110F33716930AD5DD450BBE056DA9294457A4B0F47C",
         "noteCommitment": {
           "commitment": {
@@ -5508,7 +5508,7 @@
     },
     {
       "header": {
-        "sequence": 93,
+        "height": 93,
         "previousBlockHash": "F30DDAAE06E693C0CCB62619B207ECDE85CCE3E5759FA4E46BF7EB0DCFC39AEB",
         "noteCommitment": {
           "commitment": {
@@ -5538,7 +5538,7 @@
     },
     {
       "header": {
-        "sequence": 94,
+        "height": 94,
         "previousBlockHash": "9A1F079E20B75FC9BED8BF65A4A61917A9CA24DB72DC79685FF408031955CA78",
         "noteCommitment": {
           "commitment": {
@@ -5568,7 +5568,7 @@
     },
     {
       "header": {
-        "sequence": 94,
+        "height": 94,
         "previousBlockHash": "6942E5101F6F4A30F3184EF6E38540C4C8ED7EA6685492B7A69216F60761EF57",
         "noteCommitment": {
           "commitment": {
@@ -5598,7 +5598,7 @@
     },
     {
       "header": {
-        "sequence": 95,
+        "height": 95,
         "previousBlockHash": "7DDB8F4F83DFC44BD7EAC84F45E266ACC978DBC814DFDE5202F2B56C4DE8BC3E",
         "noteCommitment": {
           "commitment": {
@@ -5628,7 +5628,7 @@
     },
     {
       "header": {
-        "sequence": 95,
+        "height": 95,
         "previousBlockHash": "E5AEF059AD1F50E96C0407AE9668861CB2961FDBB7C75AEC16D8FA53F32F94BB",
         "noteCommitment": {
           "commitment": {
@@ -5658,7 +5658,7 @@
     },
     {
       "header": {
-        "sequence": 96,
+        "height": 96,
         "previousBlockHash": "59E1E1CE84A7E0246E9493C4037F59DFE39DCFBC60875236ECC1C90A256FB608",
         "noteCommitment": {
           "commitment": {
@@ -5688,7 +5688,7 @@
     },
     {
       "header": {
-        "sequence": 96,
+        "height": 96,
         "previousBlockHash": "3937E6145A14C2DAC1E9E0EF1829425B9D2A48046A93A13A602CA05B520FF4F8",
         "noteCommitment": {
           "commitment": {
@@ -5718,7 +5718,7 @@
     },
     {
       "header": {
-        "sequence": 97,
+        "height": 97,
         "previousBlockHash": "EED058B891E5487AA1F38EDBC54EFFD0FE518E65497D9790AE41B33297B96779",
         "noteCommitment": {
           "commitment": {
@@ -5748,7 +5748,7 @@
     },
     {
       "header": {
-        "sequence": 97,
+        "height": 97,
         "previousBlockHash": "4137161E4DC2B7F8A0976CF07F31DCFD6EDB330B3C7E24F605C63D4E5DD45BD3",
         "noteCommitment": {
           "commitment": {
@@ -5778,7 +5778,7 @@
     },
     {
       "header": {
-        "sequence": 98,
+        "height": 98,
         "previousBlockHash": "4BAB45B089D923BB5F668333D58B81CF70594F5F47EBB72B1297B799A55FB770",
         "noteCommitment": {
           "commitment": {
@@ -5808,7 +5808,7 @@
     },
     {
       "header": {
-        "sequence": 98,
+        "height": 98,
         "previousBlockHash": "486461B119A212B64EB5F86BA888909F6E0BE458C89A524008A81881A1A0B202",
         "noteCommitment": {
           "commitment": {
@@ -5838,7 +5838,7 @@
     },
     {
       "header": {
-        "sequence": 99,
+        "height": 99,
         "previousBlockHash": "EECB8406263F7E0B6112BF00BAA39692372E16A3383507A92BB693E1A37BFB45",
         "noteCommitment": {
           "commitment": {
@@ -5868,7 +5868,7 @@
     },
     {
       "header": {
-        "sequence": 99,
+        "height": 99,
         "previousBlockHash": "132BDF6C6D4AF9E9059562F260ED507871BE1F6A35533AC596416C58C4719350",
         "noteCommitment": {
           "commitment": {
@@ -5898,7 +5898,7 @@
     },
     {
       "header": {
-        "sequence": 100,
+        "height": 100,
         "previousBlockHash": "50920E1E9DD0CDB811440D5EBCC9998C64A4140E7E2FF483D839D1E6CC5CD699",
         "noteCommitment": {
           "commitment": {
@@ -5928,7 +5928,7 @@
     },
     {
       "header": {
-        "sequence": 100,
+        "height": 100,
         "previousBlockHash": "6C404E7CB8C274918E37990B43D3A7B64704B6167AE123AD10BC54CBA47FC6B7",
         "noteCommitment": {
           "commitment": {
@@ -5958,7 +5958,7 @@
     },
     {
       "header": {
-        "sequence": 101,
+        "height": 101,
         "previousBlockHash": "E91354A9B29BE4C2C330AFFE73F2700C390C5939C9AAB15687DD51C34E54E6F0",
         "noteCommitment": {
           "commitment": {
@@ -5988,7 +5988,7 @@
     },
     {
       "header": {
-        "sequence": 101,
+        "height": 101,
         "previousBlockHash": "D03366752800271048B1B4282016C85208BE9F5F90129B0400891798B2D433EA",
         "noteCommitment": {
           "commitment": {

--- a/ironfish/src/blockchain/__fixtures__/blockchain.test.ts.fixture
+++ b/ironfish/src/blockchain/__fixtures__/blockchain.test.ts.fixture
@@ -18,7 +18,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -48,7 +48,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -78,7 +78,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "ECA09D603527312E4EEF8670DBB3822BBD14A3B186EE223D9E45F957A2335E0A",
         "noteCommitment": {
           "commitment": {
@@ -110,7 +110,7 @@
   "Blockchain abort reorg after verify error": [
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -140,7 +140,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "9FE8B3F549684771140004098301443539E2E9D7C7B8C25EFCA537DB9FF360F1",
         "noteCommitment": {
           "commitment": {
@@ -170,7 +170,7 @@
     },
     {
       "header": {
-        "sequence": 4,
+        "height": 4,
         "previousBlockHash": "EB2BB6808A0F6B143D216E4C1CF07BF56D463323F8B769033EF59AC30DB72128",
         "noteCommitment": {
           "commitment": {
@@ -200,7 +200,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -230,7 +230,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "FAC57A8C497B4CFEAC8FBD78EE5F6D32026C012BBC85C6ECA65864A7908C6F66",
         "noteCommitment": {
           "commitment": {
@@ -260,7 +260,7 @@
     },
     {
       "header": {
-        "sequence": 4,
+        "height": 4,
         "previousBlockHash": "5B7E04DCB1661B6DEBFEE025167F7BDB8D897958CC5CCBA19D16A18EB61D902A",
         "noteCommitment": {
           "commitment": {

--- a/ironfish/src/blockchain/blockchain.old.test.ts
+++ b/ironfish/src/blockchain/blockchain.old.test.ts
@@ -272,10 +272,10 @@ describe('Header consistency is valid against previous', () => {
     `)
   })
 
-  it('Is invalid when the sequence is wrong', async () => {
+  it('Is invalid when the height is wrong', async () => {
     await blockchain.addBlock(block2)
     await blockchain.addBlock(block3)
-    block3.header.sequence = 99
+    block3.header.height = 99
 
     expect(blockchain.verifier.isValidAgainstPrevious(block3, block3.header))
       .toMatchInlineSnapshot(`

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -81,11 +81,11 @@ describe('Blockchain', () => {
     expect((await chain.getPrevious(headerB2))?.hash?.equals(headerA1.hash)).toBe(true)
     expect((await chain.getPrevious(headerB3))?.hash?.equals(headerB2.hash)).toBe(true)
 
-    // getAtSequence
-    expect((await chain.getHashAtSequence(1))?.equals(genesis.header.hash)).toBe(true)
-    expect((await chain.getHashAtSequence(2))?.equals(headerA1.hash)).toBe(true)
-    expect((await chain.getHashAtSequence(3))?.equals(headerB2.hash)).toBe(true)
-    expect((await chain.getHashAtSequence(4))?.equals(headerB3.hash)).toBe(true)
+    // getAtHeight
+    expect((await chain.getHashAtHeight(1))?.equals(genesis.header.hash)).toBe(true)
+    expect((await chain.getHashAtHeight(2))?.equals(headerA1.hash)).toBe(true)
+    expect((await chain.getHashAtHeight(3))?.equals(headerB2.hash)).toBe(true)
+    expect((await chain.getHashAtHeight(4))?.equals(headerB3.hash)).toBe(true)
   }, 10000)
 
   it('iterate', async () => {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -57,7 +57,7 @@ import {
   TransactionsSchema,
 } from './schema'
 
-const DATABASE_VERSION = 1
+const DATABASE_VERSION = 2
 
 export class Blockchain<
   E,

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -6,8 +6,8 @@ import LRU from 'blru'
 import { BufferMap } from 'buffer-map'
 import { Assert } from '../assert'
 import {
+  GENESIS_BLOCK_HEIGHT,
   GENESIS_BLOCK_PREVIOUS,
-  GENESIS_BLOCK_SEQUENCE,
   MAX_SYNCED_AGE_MS,
   TARGET_BLOCK_TIME_MS,
 } from '../consensus'
@@ -51,9 +51,9 @@ import { BlockHeaderEncoding, TransactionArrayEncoding } from './encoding'
 import {
   HashToNextSchema,
   HeadersSchema,
+  HeightToHashesSchema,
+  HeightToHashSchema,
   MetaSchema,
-  SequenceToHashesSchema,
-  SequenceToHashSchema,
   TransactionsSchema,
 } from './schema'
 
@@ -90,10 +90,10 @@ export class Blockchain<
   headers: IDatabaseStore<HeadersSchema<E, H, T, SE, SH, ST>>
   // BlockHash -> BlockHeader
   transactions: IDatabaseStore<TransactionsSchema<T>>
-  // Sequence -> BlockHash[]
-  sequenceToHashes: IDatabaseStore<SequenceToHashesSchema>
-  // Sequence -> BlockHash
-  sequenceToHash: IDatabaseStore<SequenceToHashSchema>
+  // Height -> BlockHash[]
+  heightToHashes: IDatabaseStore<HeightToHashesSchema>
+  // Height -> BlockHash
+  heightToHash: IDatabaseStore<HeightToHashSchema>
   // BlockHash -> BlockHash
   hashToNextHash: IDatabaseStore<HashToNextSchema>
 
@@ -186,14 +186,14 @@ export class Blockchain<
     })
 
     // BigInt -> BlockHash[]
-    this.sequenceToHashes = this.db.addStore({
+    this.heightToHashes = this.db.addStore({
       name: 'bs',
       keyEncoding: NUMBER_ENCODING,
       valueEncoding: BUFFER_ARRAY_ENCODING,
     })
 
     // BigInt -> BlockHash
-    this.sequenceToHash = this.db.addStore({
+    this.heightToHash = this.db.addStore({
       name: 'bS',
       keyEncoding: NUMBER_ENCODING,
       valueEncoding: BUFFER_ENCODING,
@@ -235,7 +235,7 @@ export class Blockchain<
     const result = await this.addBlock(genesis)
     Assert.isTrue(result.isAdded, `Could not seed genesis: ${result.reason || 'unknown'}`)
 
-    const genesisHeader = await this.getHeaderAtSequence(GENESIS_BLOCK_SEQUENCE)
+    const genesisHeader = await this.getHeaderAtHeight(GENESIS_BLOCK_HEIGHT)
     Assert.isNotNull(
       genesisHeader,
       'Added the genesis block to the chain, but could not fetch the header',
@@ -258,7 +258,7 @@ export class Blockchain<
       await this.nullifiers.upgrade()
     }
 
-    let genesisHeader = await this.getHeaderAtSequence(GENESIS_BLOCK_SEQUENCE)
+    let genesisHeader = await this.getHeaderAtHeight(GENESIS_BLOCK_HEIGHT)
     if (!genesisHeader && this.autoSeed) {
       genesisHeader = await this.seed()
     }
@@ -315,7 +315,7 @@ export class Blockchain<
       await this.db.transaction(async (tx) => {
         const hash = block.header.recomputeHash()
 
-        if (!this.hasGenesisBlock && block.header.sequence === GENESIS_BLOCK_SEQUENCE) {
+        if (!this.hasGenesisBlock && block.header.height === GENESIS_BLOCK_HEIGHT) {
           await this.connect(block, null, tx)
           return
         }
@@ -380,12 +380,11 @@ export class Blockchain<
 
     let linear = true
 
-    let [base, fork] =
-      headerA.sequence < headerB.sequence ? [headerA, headerB] : [headerB, headerA]
+    let [base, fork] = headerA.height < headerB.height ? [headerA, headerB] : [headerB, headerA]
 
     while (!base.hash.equals(fork.hash)) {
       // Move
-      while (fork.sequence > base.sequence) {
+      while (fork.height > base.height) {
         const prev = await this.getPrevious(fork, tx)
         Assert.isNotNull(prev)
         fork = prev
@@ -425,7 +424,7 @@ export class Blockchain<
     reachable = true,
   ): AsyncGenerator<BlockHash, void, void> {
     let current = start.hash as BlockHash | null
-    const max = end ? end.sequence - start.sequence : null
+    const max = end ? end.height - start.height : null
     let count = 0
 
     while (current) {
@@ -459,7 +458,7 @@ export class Blockchain<
     reachable = true,
   ): AsyncGenerator<BlockHeader<E, H, T, SE, SH, ST>, void, void> {
     let current = start as BlockHeader<E, H, T, SE, SH, ST> | null
-    const max = end ? start.sequence - end.sequence : null
+    const max = end ? start.height - end.height : null
     let count = 0
 
     while (current) {
@@ -479,8 +478,8 @@ export class Blockchain<
     if (reachable && end && !current?.hash.equals(end.hash)) {
       throw new Error(
         'Failed to iterate between blocks on diverging forks:' +
-          ` current: '${HashUtils.renderHash(current?.hash)}',` +
-          ` current_sequence: '${Number(current?.sequence)}',` +
+          ` curr-hash: '${HashUtils.renderHash(current?.hash)}',` +
+          ` curr-height: '${Number(current?.height)}',` +
           ` end: '${HashUtils.renderHash(end.hash)}'`,
       )
     }
@@ -526,10 +525,10 @@ export class Blockchain<
     this.addSpeed.add(addTime)
     this.updateSynced()
 
-    if (this.logAllBlockAdd || Number(block.header.sequence) % 20 === 0) {
+    if (this.logAllBlockAdd || Number(block.header.height) % 20 === 0) {
       this.logger.info(
         'Added block' +
-          ` seq: ${Number(block.header.sequence)},` +
+          ` height: ${Number(block.header.height)},` +
           ` hash: ${HashUtils.renderHash(block.header.hash)},` +
           ` txs: ${block.transactions.length},` +
           ` progress: ${(this.progress * 100).toFixed(2)}%,` +
@@ -552,7 +551,7 @@ export class Blockchain<
     )
 
     Assert.isFalse(
-      block.header.sequence === GENESIS_BLOCK_SEQUENCE,
+      block.header.height === GENESIS_BLOCK_HEIGHT,
       'You cannot disconnect the genesisBlock',
     )
 
@@ -573,11 +572,11 @@ export class Blockchain<
     Assert.isTrue(
       block.header.previousBlockHash.equals(this.head.hash),
       `Reconnecting block ${block.header.hash.toString('hex')} (${
-        block.header.sequence
+        block.header.height
       }) does not go on current head ${this.head.hash.toString('hex')} (${
-        this.head.sequence - 1
+        this.head.height - 1
       }) expected ${block.header.previousBlockHash.toString('hex')} (${
-        block.header.sequence - 1
+        block.header.height - 1
       })`,
     )
 
@@ -602,7 +601,7 @@ export class Blockchain<
 
       this.logger.warn(
         `Invalid block adding to fork ${HashUtils.renderHash(block.header.hash)} (${
-          block.header.sequence
+          block.header.height
         }): ${reason}`,
       )
 
@@ -615,8 +614,8 @@ export class Blockchain<
 
     this.logger.warn(
       'Added block to fork' +
-        ` seq: ${block.header.sequence},` +
-        ` head-seq: ${this.head.sequence || ''},` +
+        ` height: ${block.header.height},` +
+        ` head-height: ${this.head.height || ''},` +
         ` hash: ${HashUtils.renderHash(block.header.hash)},` +
         ` head-hash: ${this.head.hash ? HashUtils.renderHash(this.head.hash) : ''},` +
         ` work: ${block.header.work},` +
@@ -633,11 +632,11 @@ export class Blockchain<
     if (prev && !block.header.previousBlockHash.equals(this.head.hash)) {
       this.logger.warn(
         `Reorganizing chain from ${HashUtils.renderHash(this.head.hash)} (${
-          this.head.sequence
+          this.head.height
         }) for ${HashUtils.renderHash(block.header.hash)} (${
-          block.header.sequence
+          block.header.height
         }) on prev ${HashUtils.renderHash(block.header.previousBlockHash)} (${
-          block.header.sequence - 1
+          block.header.height - 1
         })`,
       )
 
@@ -650,7 +649,7 @@ export class Blockchain<
 
       this.logger.warn(
         `Invalid block adding to head chain ${HashUtils.renderHash(block.header.hash)} (${
-          block.header.sequence
+          block.header.height
         }): ${reason}`,
       )
 
@@ -661,7 +660,7 @@ export class Blockchain<
     await this.saveBlock(block, prev, false, tx)
     this.head = block.header
 
-    if (block.header.sequence === GENESIS_BLOCK_SEQUENCE) {
+    if (block.header.height === GENESIS_BLOCK_HEIGHT) {
       this.genesis = block.header
     }
 
@@ -722,10 +721,10 @@ export class Blockchain<
 
     this.logger.warn(
       'Reorganized chain.' +
-        ` blocks: ${oldHead.sequence - fork.sequence + (newHead.sequence - fork.sequence)},` +
-        ` old: ${HashUtils.renderHash(oldHead.hash)} (${oldHead.sequence}),` +
-        ` new: ${HashUtils.renderHash(newHead.hash)} (${newHead.sequence}),` +
-        ` fork: ${HashUtils.renderHash(fork.hash)} (${fork.sequence})`,
+        ` blocks: ${oldHead.height - fork.height + (newHead.height - fork.height)},` +
+        ` old: ${HashUtils.renderHash(oldHead.hash)} (${oldHead.height}),` +
+        ` new: ${HashUtils.renderHash(newHead.hash)} (${newHead.height}),` +
+        ` fork: ${HashUtils.renderHash(fork.hash)} (${fork.height})`,
     )
   }
 
@@ -776,10 +775,10 @@ export class Blockchain<
   }
 
   /**
-   * Returns true if the blockchain has any blocks at the given sequence
+   * Returns true if the blockchain has any blocks at the given height
    */
-  async hasHashesAtSequence(sequence: number, tx?: IDatabaseTransaction): Promise<boolean> {
-    const hashes = await this.getHashesAtSequence(sequence, tx)
+  async hasHashesAtHeight(height: number, tx?: IDatabaseTransaction): Promise<boolean> {
+    const hashes = await this.getHashesAtHeight(height, tx)
 
     if (!hashes) {
       return false
@@ -789,10 +788,10 @@ export class Blockchain<
   }
 
   /**
-   * Returns an array of hashes for any blocks at the given sequence
+   * Returns an array of hashes for any blocks at the given height
    */
-  async getHashesAtSequence(sequence: number, tx?: IDatabaseTransaction): Promise<BlockHash[]> {
-    const hashes = await this.sequenceToHashes.get(sequence, tx)
+  async getHashesAtHeight(height: number, tx?: IDatabaseTransaction): Promise<BlockHash[]> {
+    const hashes = await this.heightToHashes.get(height, tx)
 
     if (!hashes) {
       return []
@@ -824,13 +823,13 @@ export class Blockchain<
       const originalNullifierSize = await this.nullifiers.size(tx)
 
       let previousBlockHash
-      let previousSequence
+      let previousHeight
       let target
       const timestamp = new Date()
 
       if (!this.hasGenesisBlock) {
         previousBlockHash = GENESIS_BLOCK_PREVIOUS
-        previousSequence = 0
+        previousHeight = 0
         target = Target.initialTarget()
       } else {
         const heaviestHead = this.head
@@ -843,9 +842,9 @@ export class Blockchain<
           )
         }
         previousBlockHash = heaviestHead.hash
-        previousSequence = heaviestHead.sequence
+        previousHeight = heaviestHead.height
         const previousHeader = await this.getHeader(heaviestHead.previousBlockHash, tx)
-        if (!previousHeader && previousSequence !== 1) {
+        if (!previousHeader && previousHeight !== 1) {
           throw new Error('There is no previous block to calculate a target')
         }
         target = Target.calculateTarget(timestamp, heaviestHead.timestamp, heaviestHead.target)
@@ -873,7 +872,7 @@ export class Blockchain<
 
       const header = new BlockHeader(
         this.strategy,
-        previousSequence + 1,
+        previousHeight + 1,
         previousBlockHash,
         noteCommitment,
         nullifierCommitment,
@@ -973,20 +972,18 @@ export class Blockchain<
   }
 
   /**
-   * Gets the hash of the block at the sequence on the head chain
+   * Gets the hash of the block at the height on the head chain
    */
-  async getHashAtSequence(sequence: number): Promise<BlockHash | null> {
-    const hash = await this.sequenceToHash.get(sequence)
+  async getHashAtHeight(height: number): Promise<BlockHash | null> {
+    const hash = await this.heightToHash.get(height)
     return hash || null
   }
 
   /**
-   * Gets the header of the block at the sequence on the head chain
+   * Gets the header of the block at the height on the head chain
    */
-  async getHeaderAtSequence(
-    sequence: number,
-  ): Promise<BlockHeader<E, H, T, SE, SH, ST> | null> {
-    const hash = await this.sequenceToHash.get(sequence)
+  async getHeaderAtHeight(height: number): Promise<BlockHeader<E, H, T, SE, SH, ST> | null> {
+    const hash = await this.heightToHash.get(height)
 
     if (!hash) {
       return null
@@ -995,11 +992,11 @@ export class Blockchain<
     return this.getHeader(hash)
   }
 
-  async getHeadersAtSequence(
-    sequence: number,
+  async getHeadersAtHeight(
+    height: number,
     tx?: IDatabaseTransaction,
   ): Promise<BlockHeader<E, H, T, SE, SH, ST>[]> {
-    const hashes = await this.sequenceToHashes.get(sequence, tx)
+    const hashes = await this.heightToHashes.get(height, tx)
 
     if (!hashes) {
       return []
@@ -1017,7 +1014,7 @@ export class Blockchain<
   }
 
   async isHeadChain(header: BlockHeader<E, H, T, SE, SH, ST>): Promise<boolean> {
-    const hash = await this.getHashAtSequence(header.sequence)
+    const hash = await this.getHashAtHeight(header.height)
 
     if (!hash) {
       return false
@@ -1054,7 +1051,7 @@ export class Blockchain<
       const block = await this.getBlock(hash, tx)
       Assert.isNotNull(block)
 
-      const next = await this.getHeadersAtSequence(header.sequence + 1, tx)
+      const next = await this.getHeadersAtHeight(header.height + 1, tx)
       if (next && next.some((h) => h.previousBlockHash.equals(header.hash))) {
         throw new Error(`Cannot delete block when ${next.length} blocks are connected`)
       }
@@ -1063,12 +1060,13 @@ export class Blockchain<
         await this.disconnect(block, tx)
       }
 
-      let sequences = await this.sequenceToHashes.get(header.sequence, tx)
-      sequences = (sequences || []).filter((h) => !h.equals(hash))
-      if (sequences.length === 0) {
-        await this.sequenceToHashes.del(header.sequence, tx)
+      let heights = await this.heightToHashes.get(header.height, tx)
+      heights = (heights || []).filter((h) => !h.equals(hash))
+
+      if (heights.length === 0) {
+        await this.heightToHashes.del(header.height, tx)
       } else {
-        await this.sequenceToHashes.put(header.sequence, sequences, tx)
+        await this.heightToHashes.put(header.height, heights, tx)
       }
 
       await this.transactions.del(hash, tx)
@@ -1089,7 +1087,7 @@ export class Blockchain<
     fromBlockHash: Buffer | null = null,
     tx?: IDatabaseTransaction,
   ): AsyncGenerator<
-    { transaction: T; initialNoteIndex: number; sequence: number; blockHash: string },
+    { transaction: T; initialNoteIndex: number; height: number; blockHash: string },
     void,
     unknown
   > {
@@ -1115,7 +1113,7 @@ export class Blockchain<
     header: BlockHeader<E, H, T, SE, SH, ST>,
     tx?: IDatabaseTransaction,
   ): AsyncGenerator<
-    { transaction: T; initialNoteIndex: number; sequence: number; blockHash: string },
+    { transaction: T; initialNoteIndex: number; height: number; blockHash: string },
     void,
     unknown
   > {
@@ -1137,7 +1135,7 @@ export class Blockchain<
         transaction,
         initialNoteIndex: noteIndex,
         blockHash: header.hash.toString('hex'),
-        sequence: header.sequence,
+        height: header.height,
       }
     }
   }
@@ -1152,7 +1150,7 @@ export class Blockchain<
       await this.hashToNextHash.put(prev.hash, block.header.hash, tx)
     }
 
-    await this.sequenceToHash.put(block.header.sequence, block.header.hash, tx)
+    await this.heightToHash.put(block.header.height, block.header.hash, tx)
     await this.meta.put('head', block.header.hash, tx)
 
     let notesIndex = prev?.noteCommitment.size || 0
@@ -1187,7 +1185,7 @@ export class Blockchain<
   ): Promise<void> {
     // TODO: transaction goes here
     await this.hashToNextHash.del(prev.hash, tx)
-    await this.sequenceToHash.del(block.header.sequence, tx)
+    await this.heightToHash.del(block.header.height, tx)
 
     await Promise.all([
       this.notes.truncate(prev.noteCommitment.size, tx),
@@ -1206,7 +1204,7 @@ export class Blockchain<
     tx: IDatabaseTransaction,
   ): Promise<void> {
     const hash = block.header.hash
-    const sequence = block.header.sequence
+    const height = block.header.height
 
     // Update BlockHash -> BlockHeader
     await this.headers.put(hash, block.header, tx)
@@ -1214,9 +1212,9 @@ export class Blockchain<
     // Update BlockHash -> Transaction
     await this.transactions.add(hash, block.transactions, tx)
 
-    // Update Sequence -> BlockHash[]
-    const hashes = await this.sequenceToHashes.get(sequence, tx)
-    await this.sequenceToHashes.put(sequence, (hashes || []).concat(hash), tx)
+    // Update Height -> BlockHash[]
+    const hashes = await this.heightToHashes.get(height, tx)
+    await this.heightToHashes.put(height, (hashes || []).concat(hash), tx)
 
     if (!fork) {
       await this.saveConnect(block, prev, tx)

--- a/ironfish/src/blockchain/schema.ts
+++ b/ironfish/src/blockchain/schema.ts
@@ -31,13 +31,13 @@ export interface TransactionsSchema<T> extends DatabaseSchema {
   value: T[]
 }
 
-export interface SequenceToHashesSchema extends DatabaseSchema {
+export interface HeightToHashesSchema extends DatabaseSchema {
   key: number
   value: BlockHash[]
 }
 
 // Main Chain
-export interface SequenceToHashSchema extends DatabaseSchema {
+export interface HeightToHashSchema extends DatabaseSchema {
   key: number
   value: BlockHash
 }

--- a/ironfish/src/consensus/__fixtures__/verifier.test.ts.fixture
+++ b/ironfish/src/consensus/__fixtures__/verifier.test.ts.fixture
@@ -10,7 +10,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -40,7 +40,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "7C6CD5B83620E0592E49DEA881BE2E310001D65F662B46BFB9D7A00C9D785D36",
         "noteCommitment": {
           "commitment": {
@@ -84,7 +84,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -114,7 +114,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "909DA74507BA8558B67F712134461BFA5CE2F91978077EA8CA5F8B6DDA0DBD15",
         "noteCommitment": {
           "commitment": {
@@ -158,7 +158,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -188,7 +188,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "EC7BF51F63A0666938D67CD149C737829F34E352C8A08D604237778636B9E86B",
         "noteCommitment": {
           "commitment": {
@@ -232,7 +232,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -262,7 +262,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "2B448F4E05A88A0112764D38B7AE7AEB977A334EB19081F7D055388E8FDC4754",
         "noteCommitment": {
           "commitment": {
@@ -306,7 +306,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -336,7 +336,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "6ABC6DF7A563808BABEC417402DC0AE9139BEF36918D6B71654583068B097DF8",
         "noteCommitment": {
           "commitment": {

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -10,9 +10,9 @@
 export const GENESIS_BLOCK_PREVIOUS = Buffer.alloc(32)
 
 /**
- * The sequence of the genesis block starts at 1
+ * The height of the genesis block starts at 1
  */
-export const GENESIS_BLOCK_SEQUENCE = 1
+export const GENESIS_BLOCK_HEIGHT = 1
 
 /**
  * When adding a block, the block can be this amount of seconds into the future

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -25,7 +25,7 @@ import { JsonSerializable } from '../serde'
 import { IDatabaseTransaction } from '../storage'
 import { Strategy } from '../strategy'
 import { WorkerPool } from '../workerPool'
-import { ALLOWED_BLOCK_FUTURE_SECONDS, GENESIS_BLOCK_SEQUENCE } from './consensus'
+import { ALLOWED_BLOCK_FUTURE_SECONDS, GENESIS_BLOCK_HEIGHT } from './consensus'
 
 /**
  * Verifier transctions and blocks
@@ -141,7 +141,7 @@ export class Verifier<
       return { valid: false, reason: VerificationResultReason.INVALID_MINERS_FEE }
     }
 
-    const miningReward = block.header.strategy.miningReward(block.header.sequence)
+    const miningReward = block.header.strategy.miningReward(block.header.height)
     if (minersFee !== BigInt(-1) * (BigInt(miningReward) + totalTransactionFees)) {
       return { valid: false, reason: VerificationResultReason.INVALID_MINERS_FEE }
     }
@@ -219,7 +219,7 @@ export class Verifier<
    *     commitment sizes
    *  -  The timestamp of the block is within a threshold of not being before
    *     the previous block
-   *  -  The block sequence has incremented by one
+   *  -  The block height has incremented by one
    */
   isValidAgainstPrevious(
     current: Block<E, H, T, SE, SH, ST>,
@@ -245,8 +245,8 @@ export class Verifier<
       return { valid: false, reason: VerificationResultReason.BLOCK_TOO_OLD }
     }
 
-    if (current.header.sequence !== previousHeader.sequence + 1) {
-      return { valid: false, reason: VerificationResultReason.SEQUENCE_OUT_OF_ORDER }
+    if (current.header.height !== previousHeader.height + 1) {
+      return { valid: false, reason: VerificationResultReason.HEIGHT_OUT_OF_ORDER }
     }
 
     if (!this.isValidTarget(current.header, previousHeader)) {
@@ -313,7 +313,7 @@ export class Verifier<
     prev: BlockHeader<E, H, T, SE, SH, ST> | null,
     tx: IDatabaseTransaction,
   ): Promise<VerificationResult> {
-    if (block.header.sequence === GENESIS_BLOCK_SEQUENCE) {
+    if (block.header.height === GENESIS_BLOCK_HEIGHT) {
       return { valid: true }
     }
 
@@ -437,7 +437,7 @@ export enum VerificationResultReason {
   NOTE_COMMITMENT_SIZE = 'Note commitment sizes do not match',
   NULLIFIER_COMMITMENT = 'nullifier_commitment',
   NULLIFIER_COMMITMENT_SIZE = 'Nullifier commitment sizes do not match',
-  SEQUENCE_OUT_OF_ORDER = 'Block sequence is out of order',
+  HEIGHT_OUT_OF_ORDER = 'Block height is out of order',
   TOO_FAR_IN_FUTURE = 'timestamp is in future',
   GRAFFITI = 'Graffiti field is not 32 bytes in length',
   DOUBLE_SPEND = 'Double spend',

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -36,7 +36,7 @@ describe('Read genesis block', () => {
     // has been added
     const minersfee = await strategy.createMinersFee(
       BigInt(0),
-      chain.head.sequence + 1,
+      chain.head.height + 1,
       generateKey().spending_key,
     )
     const newBlock = await chain.newBlock([], minersfee)
@@ -111,7 +111,7 @@ describe('Create genesis block', () => {
     // Ensure we can construct blocks after that block
     const minersfee = await strategy.createMinersFee(
       BigInt(0),
-      block.header.sequence + 1,
+      block.header.height + 1,
       generateKey().spending_key,
     )
     const additionalBlock = await chain.newBlock([], minersfee)
@@ -149,7 +149,7 @@ describe('Create genesis block', () => {
     // Ensure we can construct blocks after that block
     const newMinersfee = await strategy.createMinersFee(
       BigInt(0),
-      deserializedBlock.header.sequence + 1,
+      deserializedBlock.header.height + 1,
       generateKey().spending_key,
     )
     const newBlock = await newChain.newBlock([], newMinersfee)

--- a/ironfish/src/genesis/genesisBlock.ts
+++ b/ironfish/src/genesis/genesisBlock.ts
@@ -10,7 +10,7 @@ export const GENESIS_HASH = Buffer.from(
 export const genesisBlockData = `
 {
   "header": {
-    "sequence": 1,
+    "height": 1,
     "previousBlockHash": "0000000000000000000000000000000000000000000000000000000000000000",
     "noteCommitment": {
       "commitment": {

--- a/ironfish/src/mining/__fixtures__/director.test.slow.ts.fixture
+++ b/ironfish/src/mining/__fixtures__/director.test.slow.ts.fixture
@@ -2,7 +2,7 @@
   "Non-fake director tests successfullyMined submits a validly mined block": [
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {

--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -358,7 +358,7 @@ export class MiningDirector<
 
     const minersFee = await this.strategy.createMinersFee(
       totalTransactionFees,
-      blockHeader.sequence + 1,
+      blockHeader.height + 1,
       this._minerAccount.spendingKey,
     )
 
@@ -388,7 +388,7 @@ export class MiningDirector<
       throw Error(`newBlock produced an invalid block: ${message || ''}`)
     }
     this.logger.debug(
-      `Current block  ${newBlock.header.sequence}, has ${newBlock.transactions.length} transactions`,
+      `Current block  ${newBlock.header.height}, has ${newBlock.transactions.length} transactions`,
     )
 
     // For mining, we want a serialized form of the header without the randomness on it
@@ -398,7 +398,7 @@ export class MiningDirector<
     this.miningRequestId++
 
     this.logger.debug(
-      `Emitting a new block ${newBlock.header.sequence} to mine as request ${this.miningRequestId}`,
+      `Emitting a new block ${newBlock.header.height} to mine as request ${this.miningRequestId}`,
     )
     await this.onBlockToMine.emitAsync({
       bytes: asBuffer,
@@ -446,7 +446,7 @@ export class MiningDirector<
 
     this.logger.info(
       `Successfully mined block ${block.header.hash.toString('hex')} (${
-        block.header.sequence
+        block.header.height
       }) has ${block.transactions.length} transactions`,
     )
 
@@ -456,7 +456,7 @@ export class MiningDirector<
       name: 'minedBlock',
       fields: [
         { name: 'difficulty', type: 'integer', value: Number(header.target.toDifficulty()) },
-        { name: 'sequence', type: 'integer', value: Number(header.sequence) },
+        { name: 'height', type: 'integer', value: Number(header.height) },
       ],
     })
 

--- a/ironfish/src/network/messages.test.ts
+++ b/ironfish/src/network/messages.test.ts
@@ -25,7 +25,7 @@ describe('isIdentify', () => {
         version: VERSION_PROTOCOL,
         agent: '',
         head: '',
-        sequence: 1,
+        height: 1,
         work: BigInt(0).toString(),
         port: null,
       },

--- a/ironfish/src/network/messages.ts
+++ b/ironfish/src/network/messages.ts
@@ -95,7 +95,7 @@ export type Identify = Message<
     port: number | null
     head: string
     work: string
-    sequence: number
+    height: number
   }
 >
 
@@ -115,7 +115,7 @@ export function isIdentify(obj: unknown): obj is Identify {
     typeof payload.version === 'number' &&
     typeof payload.head === 'string' &&
     typeof payload.work === 'string' &&
-    typeof payload.sequence === 'number'
+    typeof payload.height === 'number'
   )
 }
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -632,7 +632,7 @@ export class PeerNetwork {
     }
   }
 
-  private async resolveSequenceOrHash(
+  private async resolveHeightOrHash(
     start: string | number,
   ): Promise<IronfishBlockHeader | null> {
     if (typeof start === 'string') {
@@ -641,7 +641,7 @@ export class PeerNetwork {
     }
 
     if (typeof start === 'number') {
-      const header = await this.chain.getHeaderAtSequence(start)
+      const header = await this.chain.getHeaderAtHeight(start)
       if (header) {
         return header
       }
@@ -678,7 +678,7 @@ export class PeerNetwork {
     const start = message.payload.start
     const limit = message.payload.limit
 
-    const from = await this.resolveSequenceOrHash(start)
+    const from = await this.resolveHeightOrHash(start)
     if (!from) {
       return { blocks: [] }
     }
@@ -723,7 +723,7 @@ export class PeerNetwork {
     const start = message.payload.start
     const limit = message.payload.limit
 
-    const from = await this.resolveSequenceOrHash(start)
+    const from = await this.resolveHeightOrHash(start)
     if (!from) {
       return { blocks: [] }
     }
@@ -766,7 +766,7 @@ export class PeerNetwork {
       return await this.node.syncer.addNewBlock(peer, block)
     } catch (error) {
       this.logger.error(
-        `Error when adding new block ${block.header.sequence} from ${
+        `Error when adding new block ${block.header.height} from ${
           peer.displayName
         }: ${ErrorUtils.renderError(error, true)}`,
       )

--- a/ironfish/src/network/peers/localPeer.ts
+++ b/ironfish/src/network/peers/localPeer.ts
@@ -79,7 +79,7 @@ export class LocalPeer {
         port: this.port,
         head: this.chain.head.hash.toString('hex'),
         work: this.chain.head.work.toString(),
-        sequence: Number(this.chain.head.sequence),
+        height: Number(this.chain.head.height),
       },
     }
   }

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -90,9 +90,9 @@ export class Peer {
    */
   work: bigint | null = null
   /**
-   * The peers heaviest head sequence
+   * The peers heaviest head height
    */
-  sequence: number | null = null
+  height: number | null = null
   /**
    * The loggable name of the peer. For a more specific value,
    * try Peer.name or Peer.state.identity.

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -159,7 +159,7 @@ describe('PeerManager', () => {
         agent: '',
 
         head: '',
-        sequence: 1,
+        height: 1,
         work: BigInt(0).toString(),
         port: null,
       },
@@ -272,7 +272,7 @@ describe('PeerManager', () => {
         port: null,
         agent: pm.localPeer.agent,
         head: pm.localPeer.chain.head.hash,
-        sequence: Number(pm.localPeer.chain.head.sequence),
+        height: Number(pm.localPeer.chain.head.height),
         work: pm.localPeer.chain.head.work.toString(),
       },
     })
@@ -707,7 +707,7 @@ describe('PeerManager', () => {
           agent: '',
 
           head: '',
-          sequence: 1,
+          height: 1,
           work: BigInt(0).toString(),
         },
       }
@@ -750,7 +750,7 @@ describe('PeerManager', () => {
           version: VERSION_PROTOCOL_MIN - 1,
           agent: '',
           head: '',
-          sequence: 1,
+          height: 1,
           work: BigInt(0).toString(),
           port: peer.port,
         },
@@ -787,7 +787,7 @@ describe('PeerManager', () => {
           agent: '',
 
           head: '',
-          sequence: 1,
+          height: 1,
           work: BigInt(0).toString(),
           port: peer.port,
         },
@@ -817,7 +817,7 @@ describe('PeerManager', () => {
           agent: '',
 
           head: '',
-          sequence: 1,
+          height: 1,
           work: BigInt(0).toString(),
         },
       }
@@ -866,7 +866,7 @@ describe('PeerManager', () => {
           agent: '',
 
           head: '',
-          sequence: 1,
+          height: 1,
           work: BigInt(0).toString(),
         },
       }
@@ -915,7 +915,7 @@ describe('PeerManager', () => {
           agent: '',
 
           head: '',
-          sequence: 1,
+          height: 1,
           work: BigInt(0).toString(),
         },
       }
@@ -968,7 +968,7 @@ describe('PeerManager', () => {
           agent: '',
 
           head: '',
-          sequence: 1,
+          height: 1,
           work: BigInt(0).toString(),
           port: 9033,
         },

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -1089,7 +1089,7 @@ export class PeerManager {
     peer.version = version
     peer.agent = agent
     peer.head = Buffer.from(message.payload.head, 'hex')
-    peer.sequence = message.payload.sequence
+    peer.height = message.payload.height
     peer.work = BigInt(message.payload.work)
 
     // If we've told the peer to stay disconnected, repeat

--- a/ironfish/src/network/version.ts
+++ b/ironfish/src/network/version.ts
@@ -2,5 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const VERSION_PROTOCOL = 7
-export const VERSION_PROTOCOL_MIN = 7
+export const VERSION_PROTOCOL = 8
+export const VERSION_PROTOCOL_MIN = 8

--- a/ironfish/src/primitives/__fixtures__/block.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/block.test.ts.fixture
@@ -18,7 +18,7 @@
     },
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {
@@ -48,7 +48,7 @@
     },
     {
       "header": {
-        "sequence": 3,
+        "height": 3,
         "previousBlockHash": "B78FDEC6832115B07A4177BC7679AF157BCE79F44619149769A308E720CD003A",
         "noteCommitment": {
           "commitment": {

--- a/ironfish/src/primitives/__snapshots__/blockheader.test.ts.snap
+++ b/ironfish/src/primitives/__snapshots__/blockheader.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Block Header Serde serializes and deserializes a block header 1`] = `
 Object {
   "graffiti": "7465737400000000000000000000000000000000000000000000000000000000",
   "hash": "0500000000000000000000000000000000000000000000000000000000000000",
+  "height": 5,
   "minersFee": "-1",
   "noteCommitment": Object {
     "commitment": "header",
@@ -15,7 +16,6 @@ Object {
   },
   "previousBlockHash": "0000000000000000000000000000000000000000000000000000000000000000",
   "randomness": 25,
-  "sequence": 5,
   "target": "17",
   "timestamp": 1598467858637,
   "work": "0",

--- a/ironfish/src/primitives/blockheader.test.ts
+++ b/ironfish/src/primitives/blockheader.test.ts
@@ -63,9 +63,9 @@ describe('Block Header Serde', () => {
       BigInt(0),
       Buffer.alloc(32),
     )
-    header2.sequence = 6
+    header2.height = 6
     expect(serde.equals(header1, header2)).toBe(false)
-    header2.sequence = 5
+    header2.height = 5
     header2.noteCommitment.commitment = 'Not header'
     expect(serde.equals(header1, header2)).toBe(false)
     header2.noteCommitment.commitment = 'header'

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -37,8 +37,8 @@ export function isBlockLater<
   SH extends JsonSerializable,
   ST,
 >(a: BlockHeader<E, H, T, SE, SH, ST>, b: BlockHeader<E, H, T, SE, SH, ST>): boolean {
-  if (a.sequence !== b.sequence) {
-    return a.sequence > b.sequence
+  if (a.height !== b.height) {
+    return a.height > b.height
   }
 
   return a.hash < b.hash
@@ -56,8 +56,8 @@ export function isBlockHeavier<
     return a.work > b.work
   }
 
-  if (a.sequence !== b.sequence) {
-    return a.sequence > b.sequence
+  if (a.height !== b.height) {
+    return a.height > b.height
   }
 
   if (a.target.toDifficulty() !== b.target.toDifficulty()) {
@@ -79,11 +79,11 @@ export class BlockHeader<
   public strategy: Strategy<E, H, T, SE, SH, ST>
 
   /**
-   * The sequence number of the block. Blocks in a chain increase in ascending
-   * order of sequence. More than one block may have the same sequence,
+   * The height number of the block. Blocks in a chain increase in ascending
+   * order of height. More than one block may have the same height,
    * indicating a fork in the chain, but only one fork is selected at a time.
    */
-  public sequence: number
+  public height: number
 
   /**
    * The hash of the previous block in the chain
@@ -152,7 +152,7 @@ export class BlockHeader<
 
   constructor(
     strategy: Strategy<E, H, T, SE, SH, ST>,
-    sequence: number,
+    height: number,
     previousBlockHash: BlockHash,
     noteCommitment: { commitment: H; size: number },
     nullifierCommitment: { commitment: NullifierHash; size: number },
@@ -165,7 +165,7 @@ export class BlockHeader<
     hash?: Buffer,
   ) {
     this.strategy = strategy
-    this.sequence = sequence
+    this.height = height
     this.previousBlockHash = previousBlockHash
     this.noteCommitment = noteCommitment
     this.nullifierCommitment = nullifierCommitment
@@ -186,7 +186,7 @@ export class BlockHeader<
    */
   serializePartial(): Buffer {
     const serialized = {
-      sequence: this.sequence.toString(),
+      height: this.height.toString(),
       previousBlockHash: BlockHashSerdeInstance.serialize(this.previousBlockHash),
       noteCommitment: {
         commitment: this.strategy
@@ -237,7 +237,7 @@ export class BlockHeader<
 }
 
 export type SerializedBlockHeader<SH> = {
-  sequence: number
+  height: number
   previousBlockHash: string
   noteCommitment: {
     commitment: SH
@@ -273,7 +273,7 @@ export class BlockHeaderSerde<
     element2: BlockHeader<E, H, T, SE, SH, ST>,
   ): boolean {
     return (
-      element1.sequence === element2.sequence &&
+      element1.height === element2.height &&
       this.strategy
         .noteHasher()
         .hashSerde()
@@ -297,7 +297,7 @@ export class BlockHeaderSerde<
 
   serialize(header: BlockHeader<E, H, T, SE, SH, ST>): SerializedBlockHeader<SH> {
     const serialized = {
-      sequence: header.sequence,
+      height: header.height,
       previousBlockHash: BlockHashSerdeInstance.serialize(header.previousBlockHash),
       noteCommitment: {
         commitment: this.strategy
@@ -330,7 +330,7 @@ export class BlockHeaderSerde<
     // as it can be from untrusted sources
     const header = new BlockHeader(
       this.strategy,
-      Number(data.sequence),
+      Number(data.height),
       Buffer.from(BlockHashSerdeInstance.deserialize(data.previousBlockHash)),
       {
         commitment: this.strategy

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -185,8 +185,11 @@ export class BlockHeader<
    * This is used for calculating the hash in miners and for verifying it.[]
    */
   serializePartial(): Buffer {
+    // TODO Jason: We serialize the old sequence here for backwards
+    // compatability or else all the hashes will change. We should
+    // change this when we're ready to reset the network
     const serialized = {
-      height: this.height.toString(),
+      sequence: this.height.toString(),
       previousBlockHash: BlockHashSerdeInstance.serialize(this.previousBlockHash),
       noteCommitment: {
         commitment: this.strategy

--- a/ironfish/src/rpc/routes/accounts/rescanAccount.ts
+++ b/ironfish/src/rpc/routes/accounts/rescanAccount.ts
@@ -6,7 +6,7 @@ import { ValidationError } from '../../adapters/errors'
 import { ApiNamespace, router } from '../router'
 
 export type RescanAccountRequest = { follow?: boolean; reset?: boolean }
-export type RescanAccountResponse = { sequence: number }
+export type RescanAccountResponse = { height: number }
 
 export const RescanAccountRequestSchema: yup.ObjectSchema<RescanAccountRequest> = yup
   .object({
@@ -17,7 +17,7 @@ export const RescanAccountRequestSchema: yup.ObjectSchema<RescanAccountRequest> 
 
 export const RescanAccountResponseSchema: yup.ObjectSchema<RescanAccountResponse> = yup
   .object({
-    sequence: yup.number().defined(),
+    height: yup.number().defined(),
   })
   .defined()
 
@@ -40,8 +40,8 @@ router.register<typeof RescanAccountRequestSchema, RescanAccountResponse>(
     }
 
     if (scan && request.data.follow) {
-      const onTransaction = (sequence: number) => {
-        request.stream({ sequence: Number(sequence) })
+      const onTransaction = (height: number) => {
+        request.stream({ height: Number(height) })
       }
 
       scan.onTransaction.on(onTransaction)

--- a/ironfish/src/rpc/routes/chain/__fixtures__/getBlock.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getBlock.test.ts.fixture
@@ -2,7 +2,7 @@
   "Route chain.getBlock responds with a block": [
     {
       "header": {
-        "sequence": 2,
+        "height": 2,
         "previousBlockHash": "E12B43E9DE68F8FF6F7225AD18C321F2AF123B233F9D54BBDD414DF67CD5978C",
         "noteCommitment": {
           "commitment": {

--- a/ironfish/src/rpc/routes/chain/getBlock.test.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.test.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { GENESIS_BLOCK_SEQUENCE } from '../../../consensus'
+import '../../../testUtilities/matchers'
+import { GENESIS_BLOCK_HEIGHT } from '../../../consensus'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { useMinerBlockFixture } from '../../../testUtilities/fixtures'
 import { createRouteTest } from '../../../testUtilities/routeTest'
@@ -11,9 +12,9 @@ import { GetBlockResponse } from './getBlock'
 describe('Route chain.getBlock', () => {
   const routeTest = createRouteTest()
 
-  it('should fail if no sequence or hash provided', async () => {
+  it('should fail if no height or hash provided', async () => {
     await expect(routeTest.adapter.request('chain/getBlock', {})).rejects.toThrow(
-      'Missing hash or sequence',
+      'Missing hash or height',
     )
   }, 10000)
 
@@ -25,7 +26,7 @@ describe('Route chain.getBlock', () => {
     )
   }, 10000)
 
-  it(`should fail if block can't be found with sequence`, async () => {
+  it(`should fail if block can't be found with height`, async () => {
     await expect(routeTest.adapter.request('chain/getBlock', { index: 5 })).rejects.toThrow(
       'No block found',
     )
@@ -35,8 +36,7 @@ describe('Route chain.getBlock', () => {
     const chain = routeTest.node.chain
 
     const block = await useMinerBlockFixture(chain, 2)
-    const addResult = await chain.addBlock(block)
-    expect(addResult).toMatchObject({ isAdded: true })
+    await expect(chain).toAddBlock(block)
 
     // by hash first
     const hash = BlockHashSerdeInstance.serialize(block.header.hash)
@@ -45,11 +45,11 @@ describe('Route chain.getBlock', () => {
     expect(response.content).toMatchObject({
       timestamp: block.header.timestamp.valueOf(),
       blockIdentifier: {
-        index: Number(block.header.sequence).toString(),
+        index: Number(block.header.height).toString(),
         hash: block.header.hash.toString('hex').toUpperCase(),
       },
       parentBlockIdentifier: {
-        index: Number(GENESIS_BLOCK_SEQUENCE).toString(),
+        index: Number(GENESIS_BLOCK_HEIGHT).toString(),
         hash: block.header.previousBlockHash.toString('hex').toUpperCase(),
       },
       metadata: {
@@ -59,7 +59,7 @@ describe('Route chain.getBlock', () => {
     })
     expect(response.content.transactions).toHaveLength(1)
 
-    // now by sequence
+    // now by height
     response = await routeTest.adapter.request<GetBlockResponse>('chain/getBlock', { index: 2 })
     expect(response.content.blockIdentifier.hash).toEqual(
       block.header.hash.toString('hex').toUpperCase(),

--- a/ironfish/src/rpc/routes/chain/getBlockInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getBlockInfo.ts
@@ -12,7 +12,7 @@ export type GetBlockInfoResponse = {
     graffiti: string
     hash: string
     previousBlockHash: string
-    sequence: number
+    height: number
     timestamp: number
   }
 }
@@ -30,7 +30,7 @@ export const GetBlockInfoResponseSchema: yup.ObjectSchema<GetBlockInfoResponse> 
         graffiti: yup.string().defined(),
         hash: yup.string().defined(),
         previousBlockHash: yup.string().defined(),
-        sequence: yup.number().defined(),
+        height: yup.number().defined(),
         timestamp: yup.number().defined(),
       })
       .defined(),
@@ -53,7 +53,7 @@ router.register<typeof GetBlockInfoRequestSchema, GetBlockInfoResponse>(
         graffiti: header.graffiti.toString('hex'),
         hash: request.data.hash,
         previousBlockHash: header.previousBlockHash.toString('hex'),
-        sequence: Number(header.sequence),
+        height: Number(header.height),
         timestamp: header.timestamp.valueOf(),
       },
     })

--- a/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
@@ -12,13 +12,13 @@ describe('Route chain.getChainInfo', () => {
     const response = await routeTest.adapter.request<GetChainInfoResponse>('chain/getChainInfo')
 
     expect(response.content.currentBlockIdentifier.index).toEqual(
-      routeTest.chain.latest.sequence.toString(),
+      routeTest.chain.latest.height.toString(),
     )
     expect(response.content.genesisBlockIdentifier.index).toEqual(
-      routeTest.chain.genesis.sequence.toString(),
+      routeTest.chain.genesis.height.toString(),
     )
     expect(response.content.oldestBlockIdentifier.index).toEqual(
-      routeTest.chain.head.sequence.toString(),
+      routeTest.chain.head.height.toString(),
     )
     expect(response.content.currentBlockTimestamp).toEqual(
       Number(routeTest.chain.latest.timestamp),

--- a/ironfish/src/rpc/routes/chain/getChainInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { GENESIS_BLOCK_SEQUENCE } from '../../../consensus'
+import { GENESIS_BLOCK_HEIGHT } from '../../../consensus'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { ApiNamespace, router } from '../router'
 
@@ -52,7 +52,7 @@ router.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
 
     const oldestBlockIdentifier = {} as BlockIdentifier
     if (heaviestHeader) {
-      oldestBlockIdentifier.index = heaviestHeader.sequence.toString()
+      oldestBlockIdentifier.index = heaviestHeader.height.toString()
       oldestBlockIdentifier.hash = BlockHashSerdeInstance.serialize(heaviestHeader.hash)
     }
 
@@ -60,12 +60,12 @@ router.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
     const currentBlockIdentifier = {} as BlockIdentifier
     if (latestHeader) {
       currentBlockTimestamp = Number(latestHeader.timestamp)
-      currentBlockIdentifier.index = latestHeader.sequence.toString()
+      currentBlockIdentifier.index = latestHeader.height.toString()
       currentBlockIdentifier.hash = BlockHashSerdeInstance.serialize(latestHeader.hash)
     }
 
     const genesisBlockIdentifier = {} as BlockIdentifier
-    genesisBlockIdentifier.index = GENESIS_BLOCK_SEQUENCE.toString()
+    genesisBlockIdentifier.index = GENESIS_BLOCK_HEIGHT.toString()
     genesisBlockIdentifier.hash = BlockHashSerdeInstance.serialize(node.chain.genesis.hash)
 
     request.end({

--- a/ironfish/src/rpc/routes/chain/utils.ts
+++ b/ironfish/src/rpc/routes/chain/utils.ts
@@ -11,7 +11,7 @@ import { JsonSerializable } from '../../../serde'
 import { BlockchainUtils, HashUtils } from '../../../utils'
 
 const DEFAULT_OPTIONS = {
-  seq: true,
+  height: true,
   work: true,
   indent: '|',
 }
@@ -30,7 +30,7 @@ export async function logChain<
   options: {
     prev?: boolean
     merge?: boolean
-    seq?: boolean
+    height?: boolean
     work?: boolean
     indent?: string
   } = DEFAULT_OPTIONS,
@@ -59,7 +59,7 @@ export async function renderChain<
   stop?: number | null,
   options: {
     prev?: boolean
-    seq?: boolean
+    height?: boolean
     work?: boolean
     indent?: string
   } = DEFAULT_OPTIONS,
@@ -85,7 +85,7 @@ export async function renderChain<
     stop,
   })
 
-  const roots = await chain.getHeadersAtSequence(startHeight)
+  const roots = await chain.getHeadersAtHeight(startHeight)
 
   for (const root of roots) {
     await renderGraph(chain, root, stopHeight, content, options, logger)
@@ -108,7 +108,7 @@ export async function renderGraph<
   content: string[],
   options: {
     prev?: boolean
-    seq?: boolean
+    height?: boolean
     work?: boolean
     indent?: string
   } = DEFAULT_OPTIONS,
@@ -126,8 +126,8 @@ export async function renderGraph<
 
   let rendered = `+- Block ${HashUtils.renderHash(header.hash)}`
 
-  if (options.seq) {
-    rendered += ` (${header.sequence})`
+  if (options.height) {
+    rendered += ` (${header.height})`
   }
   if (options.prev) {
     rendered += ` prev: ${HashUtils.renderHash(header.previousBlockHash)}`
@@ -148,11 +148,11 @@ export async function renderGraph<
 
   content.push(indent + rendered)
 
-  if (header.sequence === end) {
+  if (header.height === end) {
     return
   }
 
-  const next = await chain.getHeadersAtSequence(header.sequence + 1)
+  const next = await chain.getHeadersAtHeight(header.height + 1)
   const children = next.filter((h) => h.previousBlockHash.equals(header.hash))
   const nesting = children.length >= 2
 

--- a/ironfish/src/rpc/routes/events/types.ts
+++ b/ironfish/src/rpc/routes/events/types.ts
@@ -6,7 +6,7 @@ import { IronfishBlock } from '../../../primitives'
 
 export type RpcBlock = {
   hash: string
-  sequence: number
+  height: number
   previousBlockHash: string
   timestamp: number
   transactions: Array<unknown>
@@ -15,7 +15,7 @@ export type RpcBlock = {
 export function serializeRpcBlock(block: IronfishBlock): RpcBlock {
   return {
     hash: block.header.hash.toString('hex'),
-    sequence: Number(block.header.sequence),
+    height: Number(block.header.height),
     previousBlockHash: block.header.previousBlockHash.toString('hex'),
     timestamp: block.header.timestamp.valueOf(),
     transactions: [],
@@ -25,7 +25,7 @@ export function serializeRpcBlock(block: IronfishBlock): RpcBlock {
 export const RpcBlockSchema: yup.ObjectSchema<RpcBlock> = yup
   .object({
     hash: yup.string().defined(),
-    sequence: yup.number().defined(),
+    height: yup.number().defined(),
     previousBlockHash: yup.string().defined(),
     timestamp: yup.number().defined(),
     transactions: yup.array().defined(),

--- a/ironfish/src/rpc/routes/events/utils.ts
+++ b/ironfish/src/rpc/routes/events/utils.ts
@@ -11,7 +11,7 @@ import { JsonSerializable } from '../../../serde'
 import { HashUtils } from '../../../utils'
 
 const DEFAULT_OPTIONS = {
-  seq: true,
+  height: true,
   work: true,
   indent: '|',
 }
@@ -30,7 +30,7 @@ export async function logChain<
   options: {
     prev?: boolean
     merge?: boolean
-    seq?: boolean
+    height?: boolean
     work?: boolean
     indent?: string
   } = DEFAULT_OPTIONS,
@@ -59,7 +59,7 @@ export async function renderChain<
   end?: number | null,
   options: {
     prev?: boolean
-    seq?: boolean
+    height?: boolean
     work?: boolean
     indent?: string
   } = DEFAULT_OPTIONS,
@@ -80,10 +80,10 @@ export async function renderChain<
     '======',
   )
 
-  start = start || chain.genesis.sequence
-  end = end || chain.latest.sequence
+  start = start || chain.genesis.height
+  end = end || chain.latest.height
 
-  const roots = await chain.getHeadersAtSequence(start)
+  const roots = await chain.getHeadersAtHeight(start)
 
   for (const root of roots) {
     await renderGraph(chain, root, end, content, options, logger)
@@ -106,7 +106,7 @@ export async function renderGraph<
   content: string[],
   options: {
     prev?: boolean
-    seq?: boolean
+    height?: boolean
     work?: boolean
     indent?: string
   } = DEFAULT_OPTIONS,
@@ -124,8 +124,8 @@ export async function renderGraph<
 
   let rendered = `+- Block ${HashUtils.renderHash(header.hash)}`
 
-  if (options.seq) {
-    rendered += ` (${header.sequence})`
+  if (options.height) {
+    rendered += ` (${header.height})`
   }
   if (options.prev) {
     rendered += ` prev: ${HashUtils.renderHash(header.previousBlockHash)}`
@@ -146,11 +146,11 @@ export async function renderGraph<
 
   content.push(indent + rendered)
 
-  if (header.sequence === end) {
+  if (header.height === end) {
     return
   }
 
-  const next = await chain.getHeadersAtSequence(header.sequence + 1)
+  const next = await chain.getHeadersAtHeight(header.height + 1)
   const children = next.filter((h) => h.previousBlockHash.equals(header.hash))
   const nesting = children.length >= 2
 

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -117,7 +117,7 @@ function getStatus(node: IronfishNode): GetStatusResponse {
     blockchain: {
       synced: node.chain.synced,
       head: `${node.chain.head.hash.toString('hex') || ''} (${
-        node.chain.head.sequence.toString() || ''
+        node.chain.head.height.toString() || ''
       })`,
     },
     node: {

--- a/ironfish/src/rpc/routes/peers/getPeers.ts
+++ b/ironfish/src/rpc/routes/peers/getPeers.ts
@@ -12,7 +12,7 @@ type PeerResponse = {
   identity: string | null
   version: number | null
   head: string | null
-  sequence: number | null
+  height: number | null
   work: string | null
   agent: string | null
   name: string | null
@@ -57,7 +57,7 @@ export const GetPeersResponseSchema: yup.ObjectSchema<GetPeersResponse> = yup
             name: yup.string().nullable().defined(),
             head: yup.string().nullable().defined(),
             work: yup.string().nullable().defined(),
-            sequence: yup.number().nullable().defined(),
+            height: yup.number().nullable().defined(),
             version: yup.number().nullable().defined(),
             agent: yup.string().nullable().defined(),
             error: yup.string().nullable().defined(),
@@ -143,7 +143,7 @@ function getPeers(network: PeerNetwork): PeerResponse[] {
       agent: peer.agent,
       head: peer.head?.toString('hex') || null,
       work: String(peer.work),
-      sequence: peer.sequence !== null ? Number(peer.sequence) : null,
+      height: peer.height !== null ? Number(peer.height) : null,
       connections: connections,
       error: peer.error !== null ? String(peer.error) : null,
       connectionWebSocket: connectionWebSocket,

--- a/ironfish/src/syncer.test.ts
+++ b/ironfish/src/syncer.test.ts
@@ -51,7 +51,7 @@ describe('Syncer', () => {
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
     peer.work = BigInt(1)
-    peer.sequence = 1
+    peer.height = 1
     peer.head = Buffer.from('')
 
     const startSyncSpy = jest.spyOn(syncer, 'syncFrom')
@@ -77,7 +77,7 @@ describe('Syncer', () => {
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
     peer.work = BigInt(1)
-    peer.sequence = 1
+    peer.height = 1
     peer.head = Buffer.from('')
 
     const startSyncSpy = jest.spyOn(syncer, 'syncFrom')
@@ -107,7 +107,7 @@ describe('Syncer', () => {
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
     peer.work = BigInt(1)
-    peer.sequence = 1
+    peer.height = 1
     peer.head = Buffer.from('')
 
     const startSyncSpy = jest.spyOn(syncer, 'syncFrom')
@@ -150,7 +150,7 @@ describe('Syncer', () => {
     const blockA4 = await makeBlockAfter(chain, blockA3)
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
-    peer.sequence = blockA4.header.sequence
+    peer.height = blockA4.header.height
     peer.head = blockA4.header.hash
     peer.work = BigInt(10)
 
@@ -177,7 +177,7 @@ describe('Syncer', () => {
       .mockImplementationOnce(() => Promise.resolve([strategy.blockSerde.serialize(blockA3)]))
 
     syncer.loader = peer
-    await syncer.syncBlocks(peer, genesis.header.hash, genesis.header.sequence)
+    await syncer.syncBlocks(peer, genesis.header.hash, genesis.header.height)
 
     expect(getBlocksSpy).toBeCalledTimes(4)
     expect(getBlocksSpy).toHaveBeenNthCalledWith(1, peer, genesis.header.hash, 2)
@@ -195,7 +195,7 @@ describe('Syncer', () => {
     const blockA1 = await makeBlockAfter(chain, chain.genesis)
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
-    peer.sequence = blockA1.header.sequence
+    peer.height = blockA1.header.height
     peer.head = blockA1.header.hash
     peer.work = BigInt(10)
 
@@ -206,7 +206,7 @@ describe('Syncer', () => {
 
     syncer.loader = peer
 
-    await syncer.syncBlocks(peer, chain.genesis.hash, chain.genesis.sequence)
+    await syncer.syncBlocks(peer, chain.genesis.hash, chain.genesis.height)
 
     expect(getBlocksSpy).toBeCalledTimes(1)
     expect(peerPunished).toBeCalledTimes(1)

--- a/ironfish/src/testUtilities/fake/strategy.ts
+++ b/ironfish/src/testUtilities/fake/strategy.ts
@@ -143,22 +143,22 @@ export class TestStrategy
   }
 
   /**
-   * Generate a hash from the block's sequence.
+   * Generate a hash from the block's height.
    */
   hashBlockHeader(serializedHeader: Buffer): BlockHash {
     const headerWithoutRandomness = Buffer.from(serializedHeader.slice(8))
     const header = JSON.parse(headerWithoutRandomness.toString()) as Record<string, unknown>
-    const headerSequence = header['sequence']
+    const headerHeight = header['height']
     if (
-      typeof headerSequence !== 'bigint' &&
-      typeof headerSequence !== 'string' &&
-      typeof headerSequence !== 'number'
+      typeof headerHeight !== 'bigint' &&
+      typeof headerHeight !== 'string' &&
+      typeof headerHeight !== 'number'
     ) {
-      throw new Error(`Invalid sequence type in header`)
+      throw new Error(`Invalid height type in header`)
     }
 
-    const sequence = BigInt(headerSequence)
-    const bigIntArray = BigInt64Array.from([sequence])
+    const height = BigInt(headerHeight)
+    const bigIntArray = BigInt64Array.from([height])
     const byteArray = Buffer.from(bigIntArray.buffer)
     const result = Buffer.alloc(32)
     result.set(byteArray)
@@ -167,10 +167,10 @@ export class TestStrategy
 
   createMinersFee(
     totalTransactionFees: bigint,
-    blockSequence: number,
+    blockHeight: number,
     _minerKey: string,
   ): Promise<TestTransaction> {
-    const miningReward = this.miningReward(blockSequence)
+    const miningReward = this.miningReward(blockHeight)
     return Promise.resolve(
       new TestTransaction(
         true,
@@ -181,7 +181,7 @@ export class TestStrategy
     )
   }
 
-  miningReward(_blockSequence: number): number {
+  miningReward(_blockHeight: number): number {
     return 10
   }
 }

--- a/ironfish/src/testUtilities/fake/strategy.ts
+++ b/ironfish/src/testUtilities/fake/strategy.ts
@@ -148,13 +148,14 @@ export class TestStrategy
   hashBlockHeader(serializedHeader: Buffer): BlockHash {
     const headerWithoutRandomness = Buffer.from(serializedHeader.slice(8))
     const header = JSON.parse(headerWithoutRandomness.toString()) as Record<string, unknown>
-    const headerHeight = header['height']
+
+    const headerHeight = header['sequence']
     if (
       typeof headerHeight !== 'bigint' &&
       typeof headerHeight !== 'string' &&
       typeof headerHeight !== 'number'
     ) {
-      throw new Error(`Invalid height type in header`)
+      throw new Error(`Invalid sequence type in header`)
     }
 
     const height = BigInt(headerHeight)

--- a/ironfish/src/testUtilities/fixtures.ts
+++ b/ironfish/src/testUtilities/fixtures.ts
@@ -143,7 +143,7 @@ export async function restoreBlockFixtureToAccounts(
   accounts: Accounts,
 ): Promise<void> {
   for (const transaction of block.transactions) {
-    await accounts.syncTransaction(transaction, { submittedSequence: 1 })
+    await accounts.syncTransaction(transaction, { submittedHeight: 1 })
   }
 }
 
@@ -176,7 +176,7 @@ export async function useBlockFixture(
  */
 export async function useMinerBlockFixture(
   chain: IronfishBlockchain,
-  sequence: number,
+  height: number,
   account?: Account,
   addTransactionsTo?: Accounts,
 ): Promise<IronfishBlock> {
@@ -185,10 +185,7 @@ export async function useMinerBlockFixture(
   return await useBlockFixture(
     chain,
     async () =>
-      chain.newBlock(
-        [],
-        await chain.strategy.createMinersFee(BigInt(0), sequence, spendingKey),
-      ),
+      chain.newBlock([], await chain.strategy.createMinersFee(BigInt(0), height, spendingKey)),
     addTransactionsTo,
   )
 }

--- a/ironfish/src/testUtilities/helpers/blockchain.ts
+++ b/ironfish/src/testUtilities/helpers/blockchain.ts
@@ -20,8 +20,8 @@ export async function makeBlockAfter(
     after = after.header
   }
 
-  const sequence = after.sequence + 1
-  const miningReward = BigInt(chain.strategy.miningReward(sequence))
+  const height = after.height + 1
+  const miningReward = BigInt(chain.strategy.miningReward(height))
 
   if (miningReward !== BigInt(0)) {
     throw new Error(`Must have mining reward disabled but was ${miningReward}`)
@@ -35,7 +35,7 @@ export async function makeBlockAfter(
 
   const header = new BlockHeader(
     chain.strategy,
-    sequence,
+    height,
     after.hash,
     after.noteCommitment,
     after.nullifierCommitment,
@@ -66,9 +66,9 @@ export async function makeBlockWithTransaction(
   from: Account,
   to: Account,
 ): Promise<IronfishBlock> {
-  const sequence = node.chain.head.sequence
+  const height = node.chain.head.height
 
-  const block1 = await useMinerBlockFixture(node.chain, sequence + 1, from, node.accounts)
+  const block1 = await useMinerBlockFixture(node.chain, height + 1, from, node.accounts)
 
   await expect(node.chain).toAddBlock(block1)
   await node.accounts.updateHead()
@@ -86,7 +86,7 @@ export async function makeBlockWithTransaction(
       [transaction],
       await node.chain.strategy.createMinersFee(
         await transaction.transactionFee(),
-        sequence + 2,
+        height + 2,
         from.spendingKey,
       ),
     )

--- a/ironfish/src/testUtilities/matchers/blockchain.ts
+++ b/ironfish/src/testUtilities/matchers/blockchain.ts
@@ -60,7 +60,7 @@ async function toAddBlock(
     return makeResult(false, `Could not add block: ${String(result.reason)}`)
   }
 
-  return makeResult(true, `Expected to not add block at ${String(other.header.sequence)}`)
+  return makeResult(true, `Expected to not add block at ${String(other.header.height)}`)
 }
 
 expect.extend({

--- a/ironfish/src/testUtilities/mocks.ts
+++ b/ironfish/src/testUtilities/mocks.ts
@@ -17,7 +17,7 @@ export function mockAccounts(): any {
 
 export function mockChain(): any {
   return {
-    head: { hash: 'mockhash', sequence: 1, work: BigInt(0) },
+    head: { hash: 'mockhash', height: 1, work: BigInt(0) },
     synced: true,
   }
 }

--- a/ironfish/src/testUtilities/strategy.ts
+++ b/ironfish/src/testUtilities/strategy.ts
@@ -11,11 +11,11 @@ export class IronfishTestStrategy extends IronfishStrategy {
     this._miningReward = 0
   }
 
-  miningReward(sequence: number): number {
+  miningReward(height: number): number {
     if (this._miningReward !== null) {
       return this._miningReward
     }
 
-    return super.miningReward(sequence)
+    return super.miningReward(height)
   }
 }

--- a/ironfish/src/utils/blockchain.ts
+++ b/ironfish/src/utils/blockchain.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Blockchain } from '../blockchain'
-import { GENESIS_BLOCK_SEQUENCE } from '../consensus/consensus'
+import { GENESIS_BLOCK_HEIGHT } from '../consensus/consensus'
 import { Transaction } from '../primitives/transaction'
 import { JsonSerializable } from '../serde'
 
@@ -21,8 +21,8 @@ export function getBlockRange<
     stop?: number | null
   },
 ): { start: number; stop: number } {
-  const min = Number(GENESIS_BLOCK_SEQUENCE)
-  const max = Number(chain.latest.sequence)
+  const min = Number(GENESIS_BLOCK_HEIGHT)
+  const max = Number(chain.latest.height)
 
   let start = range?.start ? range.start : min
   let stop = range?.stop ? range.stop : max


### PR DESCRIPTION
Most coins use the term "height" while we use "sequence". We're changing  that to be in line with most crypto.

We had to leave two places with sequence, because we discovered block hashes aren't calculated using values, but a JSON string-ified buffer of the header. This means that hashes change when the JSON format changes at all,  including names of fields. We WILL fix this in a future change, but it'll require restarting the testnet.

 * https://github.com/iron-fish/ironfish/blob/master/ironfish/src/primitives/blockheader.ts#L189
 * https://github.com/iron-fish/ironfish/blob/master/ironfish/src/testUtilities/fake/strategy.ts#L151