### PR TITLE
Fix director not mining on change head

### DIFF
--- a/ironfish/src/blockchain/blockchain.old.test.ts
+++ b/ironfish/src/blockchain/blockchain.old.test.ts
@@ -26,7 +26,7 @@ describe('Note adding', () => {
     targetSpy = jest.spyOn(Target, 'minDifficulty').mockReturnValue(BigInt(1))
     blockchain = await makeChainInitial(strategy)
     listener = jest.fn()
-    blockchain.onHeadChange.on(listener)
+    blockchain.onConnectBlock.on(listener)
   })
 
   afterAll(() => [targetSpy.mockClear()])
@@ -67,7 +67,7 @@ describe('Nullifier adding', () => {
   beforeEach(async () => {
     blockchain = await makeChainInitial(strategy)
     listener = jest.fn()
-    blockchain.onHeadChange.on(listener)
+    blockchain.onConnectBlock.on(listener)
   })
 
   it('immediately adds in order nullifiers to the tree', async () => {
@@ -182,7 +182,7 @@ describe('New block', () => {
     targetMeetsSpy = jest.spyOn(Target, 'meets').mockImplementation(() => true)
     blockchain = await makeChainInitial(strategy)
     listener = jest.fn()
-    blockchain.onHeadChange.on(listener)
+    blockchain.onConnectBlock.on(listener)
   })
 
   afterAll(() => {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -97,8 +97,6 @@ export class Blockchain<
   // BlockHash -> BlockHash
   hashToNextHash: IDatabaseStore<HashToNextSchema>
 
-  // When the heaviest head changes
-  onHeadChange = new Event<[hash: BlockHash]>()
   // When ever the blockchain becomes synced
   onSynced = new Event<[]>()
   // When ever a block is added to the heaviest chain and the trees have been updated

--- a/ironfish/src/mining/director.test.slow.ts
+++ b/ironfish/src/mining/director.test.slow.ts
@@ -112,10 +112,11 @@ describe('Mining director', () => {
   })
 
   it('creates a new block to be mined when chain head changes', async () => {
-    const chainHead = chain.head
+    const chainHead = await chain.getBlock(chain.head)
+    Assert.isNotNull(chainHead)
     const listenPromise = waitForEmit(director.onBlockToMine)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await chain.onHeadChange.emitAsync(chainHead.recomputeHash())
+    await chain.onConnectBlock.emitAsync(chainHead)
     const [data] = await listenPromise
     const buffer = Buffer.from(data.bytes)
     const block = JSON.parse(buffer.toString()) as Partial<SerializedBlockHeader<string>>
@@ -139,11 +140,12 @@ describe('Mining director', () => {
         { nullifier: makeNullifier(9), commitment: '0-3', size: 4 },
       ]),
     )
-    const chainHead = chain.head
-    expect(chainHead).toBeDefined()
+    const chainHead = await chain.getBlock(chain.head.hash)
+    Assert.isNotNull(chainHead)
+
     const listenPromise = waitForEmit(director.onBlockToMine)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await chain.onHeadChange.emitAsync(chainHead.recomputeHash())
+    await chain.onConnectBlock.emitAsync(chainHead)
 
     const result = (await listenPromise)[0]
     const buffer = Buffer.from(result.bytes)
@@ -169,11 +171,12 @@ describe('Mining director', () => {
       ]),
     )
 
-    const chainHead = chain.head
-    expect(chainHead).toBeDefined()
+    const chainHead = await chain.getBlock(chain.head.hash)
+    Assert.isNotNull(chainHead)
+
     const listenPromise = waitForEmit(director.onBlockToMine)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await chain.onHeadChange.emitAsync(chainHead.recomputeHash())
+    await chain.onConnectBlock.emitAsync(chainHead)
 
     const result = (await listenPromise)[0]
     const buffer = Buffer.from(result.bytes)

--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -181,8 +181,8 @@ export class MiningDirector<
       this.setMinerAccount(options.account)
     }
 
-    this.chain.onHeadChange.on((newChainHead: BlockHash) => {
-      void this.onChainHeadChange(newChainHead).catch((err) => {
+    this.chain.onConnectBlock.on((head: Block<E, H, T, SE, SH, ST>) => {
+      void this.onChainHeadChange(head.header.hash).catch((err) => {
         this.logger.error(err)
       })
     })

--- a/ironfish/src/rpc/routes/chain/getBlock.test.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import '../../../testUtilities/matchers'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../consensus'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { useMinerBlockFixture } from '../../../testUtilities/fixtures'
@@ -35,8 +36,7 @@ describe('Route chain.getBlock', () => {
     const chain = routeTest.node.chain
 
     const block = await useMinerBlockFixture(chain, 2)
-    const addResult = await chain.addBlock(block)
-    expect(addResult).toMatchObject({ isAdded: true })
+    await expect(chain).toAddBlock(block)
 
     // by hash first
     const hash = BlockHashSerdeInstance.serialize(block.header.hash)


### PR DESCRIPTION
The issue here is that Blockchain.onHeadChange was never being fired. It
also duplicated onConnectBlock, so I just deleted onHeadChange and just
use onConnectBlock.

I also had to change a few places to be able to
listen to onConnectBlock since the old event used to only take the hash.