### PR TITLE
Shuffle peers list before attempting connections

### DIFF
--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -4,6 +4,7 @@
 
 import type { Peer } from './peer'
 import { createRootLogger, Logger } from '../../logger'
+import { ArrayUtils } from '../../utils'
 import { PeerManager } from './peerManager'
 
 /**
@@ -65,7 +66,9 @@ export class PeerConnectionManager {
   private eventLoop() {
     let connectAttempts = 0
 
-    for (const peer of this.peerManager.peers) {
+    const shuffledPeers = ArrayUtils.shuffle(this.peerManager.peers)
+
+    for (const peer of shuffledPeers) {
       this.maintainOneConnectionPerPeer(peer)
 
       if (connectAttempts >= CONNECT_ATTEMPTS_MAX) {

--- a/ironfish/src/utils/array.ts
+++ b/ironfish/src/utils/array.ts
@@ -4,8 +4,19 @@
 
 import { Assert } from '../assert'
 
-function shuffle<T>(array: Array<T>): Array<T> {
-  return array.slice().sort(() => Math.random() - 0.5)
+/**
+ * Randomizes the order of elements in a given array and returns a new array.
+ */
+function shuffle<T>(array: ReadonlyArray<T>): Array<T> {
+  // From https://stackoverflow.com/a/12646864
+  const sliceArr = array.slice()
+
+  for (let i = sliceArr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[sliceArr[i], sliceArr[j]] = [sliceArr[j], sliceArr[i]]
+  }
+
+  return sliceArr
 }
 
 function sampleOrThrow<T>(array: Array<T>): T {


### PR DESCRIPTION
Since we only attempt to connect to five peers per event loop, we're biasing our connection attempts to the front of the peers list. I'm not sure this has been an issue in practice, but hopefully should help spread connections between newer and older peers.

Also changes the algorithm for array shuffling to fix biasing the shuffle.
