### PR TITLE
Add flag for logging per-peer network traffic

### DIFF
--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import colors from 'colors/safe'
+import { GetPeerMessagesResponse, GetPeerResponse } from 'ironfish'
+import { IronfishCommand } from '../../command'
+import { RemoteFlags } from '../../flags'
+
+type GetPeerResponsePeer = NonNullable<GetPeerResponse['peer']>
+type GetPeerMessagesResponseMessages = GetPeerMessagesResponse['messages'][0]
+
+export class ShowCommand extends IronfishCommand {
+  static description = `Display info about a peer`
+
+  static args = [
+    {
+      name: 'identity',
+      required: true,
+      description: 'identity of the peer',
+    },
+  ]
+
+  static flags = {
+    ...RemoteFlags,
+  }
+
+  async start(): Promise<void> {
+    const { args } = this.parse(ShowCommand)
+
+    const identity = (args.identity as string).trim()
+
+    await this.sdk.client.connect()
+    const [peer, messages] = await Promise.all([
+      this.sdk.client.getPeer({ identity }),
+      this.sdk.client.getPeerMessages({ identity }),
+    ])
+
+    if (peer.content.peer === null) {
+      this.log(`No peer found containing identity '${identity}'.`)
+      this.exit(1)
+    }
+
+    this.log(this.renderPeer(peer.content.peer))
+    if (messages.content.messages.length === 0) {
+      this.log('No messages sent or received. Did you start your node with --logPeerMessages?')
+    } else {
+      for (const message of messages.content.messages) {
+        this.log(this.renderMessage(message))
+      }
+    }
+
+    this.exit(0)
+  }
+
+  renderPeer(peer: GetPeerResponsePeer): string {
+    return `Identity: ${String(peer.identity)}\nState: ${peer.state}`
+  }
+
+  renderMessage(message: GetPeerMessagesResponseMessages): string {
+    const time = new Date(message.timestamp).toLocaleTimeString()
+    const direction = colors.yellow(message.direction === 'send' ? 'SEND' : 'RECV')
+    const type = message.brokeringPeerDisplayName
+      ? `(broker: ${message.brokeringPeerDisplayName}) ${message.type}`
+      : message.type
+    const messageType = colors.cyan(message.message.type)
+    const payload = JSON.stringify(
+      'payload' in message.message ? message.message.payload : null,
+    )
+
+    return `${time} ${direction} ${type}: ${messageType} ${payload}`
+  }
+}

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -52,6 +52,11 @@ export default class Start extends IronfishCommand {
       description:
         'number of CPU workers to use for long-running operations. 0 disables (likely to cause performance issues), -1 auto-detects based on CPU cores',
     }),
+    graffiti: flags.string({
+      char: 'g',
+      default: undefined,
+      description: 'Set the graffiti for the node',
+    }),
     name: flags.string({
       char: 'n',
       description: 'name for the node',
@@ -73,10 +78,10 @@ export default class Start extends IronfishCommand {
       description: 'force mining even if we are not synced',
       hidden: true,
     }),
-    graffiti: flags.string({
-      char: 'g',
+    logPeerMessages: flags.boolean({
       default: undefined,
-      description: 'Set the graffiti for the node',
+      description: 'track all messages sent and received by peers',
+      hidden: true,
     }),
   }
 
@@ -95,7 +100,17 @@ export default class Start extends IronfishCommand {
     this.startDonePromise = startDonePromise
 
     const { flags } = this.parse(Start)
-    const { bootstrap, forceMining, graffiti, listen, name, port, worker, workers } = flags
+    const {
+      bootstrap,
+      forceMining,
+      graffiti,
+      listen,
+      logPeerMessages,
+      name,
+      port,
+      worker,
+      workers,
+    } = flags
 
     if (bootstrap !== undefined) {
       this.sdk.config.setOverride('bootstrapNodes', bootstrap.filter(Boolean))
@@ -105,6 +120,9 @@ export default class Start extends IronfishCommand {
     }
     if (workers !== undefined && workers !== this.sdk.config.get('nodeWorkers')) {
       this.sdk.config.setOverride('nodeWorkers', workers)
+    }
+    if (graffiti !== undefined && graffiti !== this.sdk.config.get('blockGraffiti')) {
+      this.sdk.config.setOverride('blockGraffiti', graffiti)
     }
     if (name !== undefined && name.trim() !== this.sdk.config.get('nodeName')) {
       this.sdk.config.setOverride('nodeName', name.trim())
@@ -118,8 +136,11 @@ export default class Start extends IronfishCommand {
     if (forceMining !== undefined && forceMining !== this.sdk.config.get('miningForce')) {
       this.sdk.config.setOverride('miningForce', forceMining)
     }
-    if (graffiti !== undefined && graffiti !== this.sdk.config.get('blockGraffiti')) {
-      this.sdk.config.setOverride('blockGraffiti', graffiti)
+    if (
+      logPeerMessages !== undefined &&
+      logPeerMessages !== this.sdk.config.get('logPeerMessages')
+    ) {
+      this.sdk.config.setOverride('logPeerMessages', logPeerMessages)
     }
 
     const node = await this.sdk.node()

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -46,6 +46,10 @@ export type ConfigOptions = {
    */
   miningForce: boolean
   /**
+   * If true, track all sent and received network messages per-peer.
+   */
+  logPeerMessages: boolean
+  /**
    * True if you want to send worker peers out to other clients or not
    * */
   broadcastWorkers: boolean
@@ -146,6 +150,7 @@ export class Config extends KeyStore<ConfigOptions> {
       ipcPath: files.resolve(files.join(dataDir || DEFAULT_DATA_DIR, 'ironfish.ipc')),
       isWorker: false,
       logLevel: '*:info',
+      logPeerMessages: false,
       logPrefix: '',
       miningForce: false,
       blockGraffiti: '',

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -140,6 +140,7 @@ export class PeerNetwork {
     enableSyncing?: boolean
     isWorker?: boolean
     broadcastWorkers?: boolean
+    logPeerMessages?: boolean
     simulateLatency?: number
     logger?: Logger
     metrics?: MetricsMonitor
@@ -176,6 +177,7 @@ export class PeerNetwork {
 
     const maxPeers = options.maxPeers || 10000
     const targetPeers = options.targetPeers || 50
+    const logPeerMessages = options.logPeerMessages ?? false
 
     this.peerManager = new PeerManager(
       this.localPeer,
@@ -183,6 +185,7 @@ export class PeerNetwork {
       this.metrics,
       maxPeers,
       targetPeers,
+      logPeerMessages,
     )
     this.peerManager.onMessage.on((peer, message) => this.handleMessage(peer, message))
     this.peerManager.onConnectedPeersChanged.on(() => this.updateIsReady())

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -94,6 +94,7 @@ export class IronfishNode {
       targetPeers: config.get('targetPeers'),
       isWorker: config.get('isWorker'),
       broadcastWorkers: config.get('broadcastWorkers'),
+      logPeerMessages: config.get('logPeerMessages'),
       simulateLatency: config.get('p2pSimulateLatency'),
       bootstrapNodes: config.getArray('bootstrapNodes'),
       webSocket: webSocket,

--- a/ironfish/src/rpc/clients/rpcClient.ts
+++ b/ironfish/src/rpc/clients/rpcClient.ts
@@ -50,6 +50,11 @@ import { ImportAccountRequest, ImportAccountResponse } from '../routes/accounts/
 import { RemoveAccountRequest, RemoveAccountResponse } from '../routes/accounts/removeAccount'
 import { RescanAccountRequest, RescanAccountResponse } from '../routes/accounts/rescanAccount'
 import { OnGossipRequest, OnGossipResponse } from '../routes/events/onGossip'
+import { GetPeerRequest, GetPeerResponse } from '../routes/peers/getPeer'
+import {
+  GetPeerMessagesRequest,
+  GetPeerMessagesResponse,
+} from '../routes/peers/getPeerMessages'
 
 export abstract class IronfishRpcClient {
   readonly logger: Logger
@@ -151,6 +156,29 @@ export abstract class IronfishRpcClient {
 
   getPeersStream(params: GetPeersRequest = undefined): Response<void, GetPeersResponse> {
     return this.request<void, GetPeersResponse>('peer/getPeers', { ...params, stream: true })
+  }
+
+  async getPeer(params: GetPeerRequest): Promise<ResponseEnded<GetPeerResponse>> {
+    return this.request<GetPeerResponse>('peer/getPeer', params).waitForEnd()
+  }
+
+  getPeerStream(params: GetPeerRequest): Response<void, GetPeerResponse> {
+    return this.request<void, GetPeerResponse>('peer/getPeer', { ...params, stream: true })
+  }
+
+  async getPeerMessages(
+    params: GetPeerMessagesRequest,
+  ): Promise<ResponseEnded<GetPeerMessagesResponse>> {
+    return this.request<GetPeerMessagesResponse>('peer/getPeerMessages', params).waitForEnd()
+  }
+
+  getPeerMessagesStream(
+    params: GetPeerMessagesRequest,
+  ): Response<void, GetPeerMessagesResponse> {
+    return this.request<void, GetPeerMessagesResponse>('peer/getPeerMessages', {
+      ...params,
+      stream: true,
+    })
   }
 
   onGossipStream(params: OnGossipRequest = undefined): Response<void, OnGossipResponse> {

--- a/ironfish/src/rpc/routes/peers/getPeer.ts
+++ b/ironfish/src/rpc/routes/peers/getPeer.ts
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { Connection, PeerNetwork } from '../../../network'
+import { ApiNamespace, router } from '../router'
+import { PeerResponse } from './getPeers'
+
+type ConnectionState = Connection['state']['type'] | ''
+
+export type GetPeerRequest = {
+  identity: string
+  stream?: boolean
+}
+
+export type GetPeerResponse = {
+  peer: PeerResponse | null
+}
+
+export const GetPeerRequestSchema: yup.ObjectSchema<GetPeerRequest> = yup
+  .object({
+    identity: yup.string().defined(),
+    stream: yup.boolean().optional(),
+  })
+  .defined()
+
+export const GetPeerResponseSchema: yup.ObjectSchema<GetPeerResponse> = yup
+  .object({
+    peer: yup
+      .object({
+        state: yup.string().defined(),
+        address: yup.string().nullable().defined(),
+        port: yup.number().nullable().defined(),
+        identity: yup.string().nullable().defined(),
+        name: yup.string().nullable().defined(),
+        head: yup.string().nullable().defined(),
+        work: yup.string().nullable().defined(),
+        sequence: yup.number().nullable().defined(),
+        version: yup.number().nullable().defined(),
+        agent: yup.string().nullable().defined(),
+        error: yup.string().nullable().defined(),
+        connections: yup.number().defined(),
+        connectionWebSocket: yup.string<ConnectionState>().defined(),
+        connectionWebSocketError: yup.string().defined(),
+        connectionWebRTC: yup.string<ConnectionState>().defined(),
+        connectionWebRTCError: yup.string().defined(),
+      })
+      .defined(),
+  })
+  .defined()
+
+router.register<typeof GetPeerRequestSchema, GetPeerResponse>(
+  `${ApiNamespace.peer}/getPeer`,
+  GetPeerRequestSchema,
+  (request, node): void => {
+    const peerNetwork = node.peerNetwork
+
+    if (!peerNetwork) {
+      request.end({ peer: null })
+      return
+    }
+
+    const peer = getPeer(peerNetwork, request.data.identity)
+
+    if (!request.data.stream) {
+      request.end({ peer })
+      return
+    }
+
+    request.stream({ peer })
+
+    const interval = setInterval(() => {
+      const peer = getPeer(peerNetwork, request.data.identity)
+      request.stream({ peer })
+    }, 1000)
+
+    request.onClose.on(() => {
+      clearInterval(interval)
+    })
+  },
+)
+
+function getPeer(network: PeerNetwork, identity: string): PeerResponse | null {
+  for (const peer of network.peerManager.peers) {
+    if (peer.state.identity !== null && peer.state.identity.includes(identity)) {
+      let connections = 0
+      let connectionWebRTC: ConnectionState = ''
+      let connectionWebSocket: ConnectionState = ''
+      let connectionWebRTCError = ''
+      let connectionWebSocketError = ''
+
+      if (peer.state.type !== 'DISCONNECTED') {
+        if (peer.state.connections.webSocket) {
+          connectionWebSocket = peer.state.connections.webSocket.state.type
+          connectionWebSocketError = String(peer.state.connections.webSocket.error || '')
+        }
+
+        if (peer.state.connections.webRtc) {
+          connectionWebRTC = peer.state.connections.webRtc.state.type
+          connectionWebRTCError = String(peer.state.connections.webRtc.error || '')
+        }
+      }
+
+      if (connectionWebSocket !== '') {
+        connections++
+      }
+      if (connectionWebRTC !== '') {
+        connections++
+      }
+
+      return {
+        state: peer.state.type,
+        address: peer.address,
+        port: peer.port,
+        identity: peer.state.identity,
+        name: peer.name,
+        version: peer.version,
+        agent: peer.agent,
+        head: peer.head?.toString('hex') || null,
+        work: String(peer.work),
+        sequence: peer.sequence !== null ? Number(peer.sequence) : null,
+        connections: connections,
+        error: peer.error !== null ? String(peer.error) : null,
+        connectionWebSocket: connectionWebSocket,
+        connectionWebSocketError: connectionWebSocketError,
+        connectionWebRTC: connectionWebRTC,
+        connectionWebRTCError: connectionWebRTCError,
+      }
+    }
+  }
+
+  return null
+}

--- a/ironfish/src/rpc/routes/peers/getPeerMessages.ts
+++ b/ironfish/src/rpc/routes/peers/getPeerMessages.ts
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { Connection, PeerNetwork } from '../../../network'
+import { ApiNamespace, router } from '../router'
+
+type PeerMessage = {
+  brokeringPeerDisplayName?: string
+  direction: 'send' | 'receive'
+  message:
+    | {
+        type: string
+      }
+    | {
+        type: string
+        payload: Record<string, unknown>
+      }
+  timestamp: number
+  type: Connection['type']
+}
+
+export type GetPeerMessagesRequest = {
+  identity: string
+  stream?: boolean
+}
+
+export type GetPeerMessagesResponse = {
+  messages: Array<PeerMessage>
+}
+
+export const GetPeerMessagesRequestSchema: yup.ObjectSchema<GetPeerMessagesRequest> = yup
+  .object({
+    identity: yup.string().defined(),
+    stream: yup.boolean().optional(),
+  })
+  .defined()
+
+export const GetPeerMessagesResponseSchema: yup.ObjectSchema<GetPeerMessagesResponse> = yup
+  .object({
+    messages: yup
+      .array(
+        yup
+          .object({
+            brokeringPeerDisplayName: yup.string().optional(),
+            direction: yup.string<'send' | 'receive'>().defined(),
+            message: yup
+              .object({
+                type: yup.string().defined(),
+                payload: yup.object().optional(),
+              })
+              .defined(),
+            timestamp: yup.number().defined(),
+            type: yup.string<Connection['type']>().defined(),
+          })
+          .defined(),
+      )
+      .defined(),
+  })
+  .defined()
+
+router.register<typeof GetPeerMessagesRequestSchema, GetPeerMessagesResponse>(
+  `${ApiNamespace.peer}/getPeerMessages`,
+  GetPeerMessagesRequestSchema,
+  (request, node): void => {
+    const peerNetwork = node.peerNetwork
+
+    if (!peerNetwork) {
+      request.end({ messages: [] })
+      return
+    }
+
+    const messages = getPeerMessages(peerNetwork, request.data.identity)
+
+    if (!request.data.stream) {
+      request.end({ messages })
+      return
+    }
+
+    request.stream({ messages })
+
+    const interval = setInterval(() => {
+      const messages = getPeerMessages(peerNetwork, request.data.identity)
+      request.stream({ messages })
+    }, 1000)
+
+    request.onClose.on(() => {
+      clearInterval(interval)
+    })
+  },
+)
+
+function getPeerMessages(network: PeerNetwork, identity: string): Array<PeerMessage> {
+  for (const peer of network.peerManager.peers) {
+    if (peer.state.identity !== null && peer.state.identity.includes(identity)) {
+      return peer.loggedMessages.map((msg) => {
+        return {
+          ...msg,
+        }
+      })
+    }
+  }
+
+  return []
+}

--- a/ironfish/src/rpc/routes/peers/getPeers.ts
+++ b/ironfish/src/rpc/routes/peers/getPeers.ts
@@ -7,7 +7,7 @@ import { ApiNamespace, router } from '../router'
 
 type ConnectionState = Connection['state']['type'] | ''
 
-type PeerResponse = {
+export type PeerResponse = {
   state: string
   identity: string | null
   version: number | null

--- a/ironfish/src/rpc/routes/peers/index.ts
+++ b/ironfish/src/rpc/routes/peers/index.ts
@@ -3,3 +3,5 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export * from './getPeers'
+export * from './getPeer'
+export * from './getPeerMessages'


### PR DESCRIPTION
Adds a `--logPeerMessages` flag and a `peers:show` command to allow for viewing per-peer network messages. This should make it easier to debug differences in WebRTC signaling behavior.

Some special-casing is required to handle brokered messages and signal message encryption, which makes the logic more complex than it should be.
