### PR TITLE
feat(api): Add method to fetch paginated event records

### DIFF
--- a/ironfish-http-api-v2/src/common/constants.ts
+++ b/ironfish-http-api-v2/src/common/constants.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// Pagination limits
+export const DEFAULT_LIMIT = 20
+export const MAX_LIMIT = 100

--- a/ironfish-http-api-v2/src/common/interfaces/pagination-options.ts
+++ b/ironfish-http-api-v2/src/common/interfaces/pagination-options.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export interface PaginationOptions {
+  after?: number
+  before?: number
+  limit?: number
+}

--- a/ironfish-http-api-v2/src/events/events.service.ts
+++ b/ironfish-http-api-v2/src/events/events.service.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Injectable } from '@nestjs/common'
+import { DEFAULT_LIMIT, MAX_LIMIT } from '../common/constants'
 import { PrismaService } from '../prisma/prisma.service'
+import { ListEventsOptions } from './interfaces/list-events-options'
 import { Event, Prisma } from '.prisma/client'
 
 @Injectable()
@@ -12,6 +14,26 @@ export class EventsService {
   async find(input: Prisma.EventWhereUniqueInput): Promise<Event | null> {
     return this.prisma.event.findUnique({
       where: input,
+    })
+  }
+
+  async list(options: ListEventsOptions): Promise<Event[]> {
+    const backwards = options.before !== undefined
+    const cursorId = options.before ?? options.after
+    const cursor = cursorId ? { id: cursorId } : undefined
+    const limit = Math.min(MAX_LIMIT, options.limit || DEFAULT_LIMIT)
+    const order = backwards ? 'desc' : 'asc'
+    const skip = cursor ? 1 : 0
+    return this.prisma.event.findMany({
+      cursor,
+      orderBy: {
+        id: order,
+      },
+      skip,
+      take: limit,
+      where: {
+        account_id: options.accountId,
+      },
     })
   }
 }

--- a/ironfish-http-api-v2/src/events/interfaces/list-events-options.ts
+++ b/ironfish-http-api-v2/src/events/interfaces/list-events-options.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { PaginationOptions } from '../../common/interfaces/pagination-options'
+
+export interface ListEventsOptions extends PaginationOptions {
+  accountId?: number
+}


### PR DESCRIPTION
Introduces a method which can be used to fetch a chunk of events for an account with cursor-based pagination.