### PR TITLE
Try node-datachannel Docker build

### DIFF
--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -5,7 +5,7 @@ COPY ./ ./
 
 RUN \
     apt-get update && \
-    apt-get install jq rsync -y && \
+    apt-get install jq rsync cmake -y && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y && \
     ./ironfish-cli/scripts/build.sh


### PR DESCRIPTION
Looks like there are some missing build dependencies when building a Docker image with node-datachannel -- will be testing out different build scripts in this PR.
