### PR TITLE
Try fixing a brew audit error

### DIFF
--- a/ironfish-cli/scripts/build.sh
+++ b/ironfish-cli/scripts/build.sh
@@ -56,7 +56,9 @@ echo "Copying build"
 cp -R ../../build ./
 
 echo "Copying node_modules"
-rsync -L -avrq --exclude='ironfish-cli' ../../../node_modules ./
+# Exclude fsevents to fix brew audit error:
+# "Binaries built for a non-native architecture were installed into ironfish's prefix"
+rsync -L -avrq --exclude='ironfish-cli' --exclude 'fsevents' ../../../node_modules ./
 # Copy node_modules from ironfish-cli folder into the production node_modules folder
 # yarn --production seems to split some packages into different folders for some reason
 cp -R ../../node_modules/* ./node_modules


### PR DESCRIPTION
Brew audit is failing with error "Binaries built for a non-native architecture were installed into ironfishbeta's prefix".

To be correct, our brew formulas should be building from source, but hopefully we can hack around it in the build script.
