### PR TITLE
Add support for running commands offline

### DIFF
--- a/ironfish-cli/src/commands/accounts/balance.ts
+++ b/ironfish-cli/src/commands/accounts/balance.ts
@@ -25,9 +25,9 @@ export class BalanceCommand extends IronfishCommand {
     const { args } = this.parse(BalanceCommand)
     const account = args.account as string | undefined
 
-    await this.sdk.client.connect()
+    const client = await this.sdk.connectRpc()
 
-    const response = await this.sdk.client.getAccountBalance({
+    const response = await client.getAccountBalance({
       account: account,
     })
 

--- a/ironfish-cli/src/commands/accounts/create.test.ts
+++ b/ironfish-cli/src/commands/accounts/create.test.ts
@@ -13,15 +13,19 @@ describe('accounts:create command', () => {
 
   beforeEach(() => {
     createAccount = jest.fn().mockReturnValue({ content: {} })
+
+    const client = {
+      connect: jest.fn(),
+      createAccount,
+    }
+
     ironfishmodule.IronfishSdk.init = jest.fn().mockImplementation(() => ({
       accounts: {
         use,
         storage: { configPath: '' },
       },
-      client: {
-        connect: jest.fn(),
-        createAccount,
-      },
+      client: client,
+      connectRpc: jest.fn().mockResolvedValue(client),
     }))
   })
 

--- a/ironfish-cli/src/commands/accounts/create.ts
+++ b/ironfish-cli/src/commands/accounts/create.ts
@@ -32,10 +32,10 @@ export class CreateCommand extends IronfishCommand {
       })) as string
     }
 
-    await this.sdk.client.connect()
+    const client = await this.sdk.connectRpc()
 
     this.log(`Creating account ${name}`)
-    const result = await this.sdk.client.createAccount({ name })
+    const result = await client.createAccount({ name })
 
     const { publicAddress, isDefaultAccount } = result.content
 

--- a/ironfish-cli/src/commands/accounts/export.test.ts
+++ b/ironfish-cli/src/commands/accounts/export.test.ts
@@ -46,7 +46,7 @@ describe('accounts:export', () => {
             fileSystem: {
               resolve: identity,
             },
-            getConnectedClient: jest.fn().mockResolvedValue(client),
+            connectRpc: jest.fn().mockResolvedValue(client),
           })),
         },
       }

--- a/ironfish-cli/src/commands/accounts/export.ts
+++ b/ironfish-cli/src/commands/accounts/export.ts
@@ -23,7 +23,7 @@ export class ExportCommand extends IronfishCommand {
     {
       name: 'account',
       parse: (input: string): string => input.trim(),
-      required: true,
+      required: false,
       description: 'name of the account to export',
     },
     {

--- a/ironfish-cli/src/commands/accounts/export.ts
+++ b/ironfish-cli/src/commands/accounts/export.ts
@@ -40,7 +40,7 @@ export class ExportCommand extends IronfishCommand {
     const account = args.account as string
     const exportPath = args.path as string | undefined
 
-    const client = await this.sdk.getConnectedClient(local)
+    const client = await this.sdk.connectRpc(local)
     const response = await client.exportAccount({ account })
 
     let output = JSON.stringify(response.content.account, undefined, '   ')

--- a/ironfish-cli/src/commands/accounts/import.ts
+++ b/ironfish-cli/src/commands/accounts/import.ts
@@ -32,7 +32,7 @@ export class ImportCommand extends IronfishCommand {
     const { flags, args } = this.parse(ImportCommand)
     const importPath = args.path as string | undefined
 
-    await this.sdk.client.connect()
+    const client = await this.sdk.connectRpc()
 
     let account: Account | null = null
     if (importPath) {
@@ -48,7 +48,7 @@ export class ImportCommand extends IronfishCommand {
       this.exit(1)
     }
 
-    const result = await this.sdk.client.importAccount({
+    const result = await client.importAccount({
       account: account,
       rescan: flags.rescan,
     })

--- a/ironfish-cli/src/commands/accounts/list.test.ts
+++ b/ironfish-cli/src/commands/accounts/list.test.ts
@@ -12,17 +12,20 @@ describe('accounts:list', () => {
   beforeAll(() => {
     jest.doMock('ironfish', () => {
       const originalModule = jest.requireActual('ironfish')
+
       const client = {
         connect: jest.fn(),
         getAccounts: jest.fn().mockImplementation(() => ({
           content: responseContent,
         })),
       }
+
       const module: typeof jest = {
         ...originalModule,
         IronfishSdk: {
           init: jest.fn().mockImplementation(() => ({
             client,
+            connectRpc: jest.fn().mockResolvedValue(client),
           })),
         },
       }

--- a/ironfish-cli/src/commands/accounts/list.ts
+++ b/ironfish-cli/src/commands/accounts/list.ts
@@ -14,9 +14,9 @@ export class ListCommand extends IronfishCommand {
   async start(): Promise<void> {
     this.parse(ListCommand)
 
-    await this.sdk.client.connect()
+    const client = await this.sdk.connectRpc()
 
-    const response = await this.sdk.client.getAccounts()
+    const response = await client.getAccounts()
 
     if (response.content.accounts.length === 0) {
       this.log('you have no accounts')

--- a/ironfish-cli/src/commands/accounts/pay.test.ts
+++ b/ironfish-cli/src/commands/accounts/pay.test.ts
@@ -13,13 +13,18 @@ describe('accounts:pay command', () => {
   beforeEach(() => {
     sendTransaction = jest.fn().mockReturnValue({ content: {} })
 
-    ironfishmodule.IronfishSdk.init = jest.fn().mockImplementation(() => ({
-      client: {
+    ironfishmodule.IronfishSdk.init = jest.fn().mockImplementation(() => {
+      const client = {
         connect: jest.fn(),
         getAccountBalance: jest.fn().mockResolvedValue({ content: { confirmedBalance: 1000 } }),
         sendTransaction,
-      },
-    }))
+      }
+
+      return {
+        client: client,
+        connectRpc: jest.fn().mockResolvedValue(client),
+      }
+    })
   })
 
   afterEach(() => {

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -61,10 +61,10 @@ export class Pay extends IronfishCommand {
     let to = flags.to
     let from = flags.account
 
-    await this.sdk.client.connect()
+    const client = await this.sdk.connectRpc()
 
     if (!amount || Number.isNaN(amount)) {
-      const responseBalance = await this.sdk.client.getAccountBalance({
+      const responseBalance = await client.getAccountBalance({
         account: from,
       })
       const { confirmedBalance } = responseBalance.content
@@ -105,7 +105,7 @@ export class Pay extends IronfishCommand {
     }
 
     if (!from) {
-      const response = await this.sdk.client.getDefaultAccount()
+      const response = await client.getDefaultAccount()
       const defaultAccount = response.content.account
 
       if (!defaultAccount) {
@@ -185,7 +185,7 @@ ${displayIronAmountWithCurrency(
     }
 
     try {
-      const result = await this.sdk.client.sendTransaction({
+      const result = await client.sendTransaction({
         amount: ironToOre(amount).toString(),
         fromAccountName: from,
         memo: '',

--- a/ironfish-cli/src/commands/accounts/publickey.ts
+++ b/ironfish-cli/src/commands/accounts/publickey.ts
@@ -30,9 +30,9 @@ export class PublicKeyCommand extends IronfishCommand {
     const { args, flags } = this.parse(PublicKeyCommand)
     const account = args.account as string | undefined
 
-    await this.sdk.client.connect()
+    const client = await this.sdk.connectRpc()
 
-    const response = await this.sdk.client.getAccountPublicKey({
+    const response = await client.getAccountPublicKey({
       account: account,
       generate: flags.generate,
     })

--- a/ironfish-cli/src/commands/accounts/remove.test.ts
+++ b/ironfish-cli/src/commands/accounts/remove.test.ts
@@ -17,12 +17,16 @@ describe('accounts:remove', () => {
       content: { needsConfirm: true },
     }))
 
-    ironfish.IronfishSdk.init = jest.fn().mockImplementationOnce(() => ({
-      client: {
-        connect: jest.fn(),
+    ironfish.IronfishSdk.init = jest.fn().mockImplementationOnce(() => {
+      const client = {
         removeAccount,
-      },
-    }))
+      }
+
+      return {
+        client: client,
+        connectRpc: jest.fn().mockResolvedValue(client),
+      }
+    })
   })
 
   describe('with no flags', () => {
@@ -56,7 +60,7 @@ describe('accounts:remove', () => {
 
   describe('with the confirmation flag', () => {
     beforeEach(() => {
-      removeAccount = jest.fn().mockImplementationOnce(() => ({
+      removeAccount = jest.fn().mockImplementation(() => ({
         content: {},
       }))
     })
@@ -65,7 +69,7 @@ describe('accounts:remove', () => {
       .stdout()
       .command(['accounts:remove', '--confirm', name])
       .exit(0)
-      .it('calls `removeAccount` once and logs an error', (ctx) => {
+      .it('successfully removes account', (ctx) => {
         expect(removeAccount).toHaveBeenCalledTimes(1)
         expect(removeAccount.mock.calls[0][0]).toMatchObject({ name, confirm: true })
         expectCli(ctx.stdout).include(`Account '${name}' successfully removed.`)

--- a/ironfish-cli/src/commands/accounts/remove.ts
+++ b/ironfish-cli/src/commands/accounts/remove.ts
@@ -30,9 +30,9 @@ export class RemoveCommand extends IronfishCommand {
     const confirm = flags.confirm
     const name = (args.name as string).trim()
 
-    await this.sdk.client.connect()
+    const client = await this.sdk.connectRpc()
 
-    const response = await this.sdk.client.removeAccount({ name, confirm })
+    const response = await client.removeAccount({ name, confirm })
 
     if (response.content.needsConfirm) {
       const value = (await cli.prompt(`Are you sure? Type ${name} to confirm`)) as string
@@ -42,7 +42,7 @@ export class RemoveCommand extends IronfishCommand {
         this.exit(1)
       }
 
-      await this.sdk.client.removeAccount({ name, confirm: true })
+      await client.removeAccount({ name, confirm: true })
     }
 
     this.log(`Account '${name}' successfully removed.`)

--- a/ironfish-cli/src/commands/accounts/rescan.test.ts
+++ b/ironfish-cli/src/commands/accounts/rescan.test.ts
@@ -26,7 +26,7 @@ describe('accounts:rescan', () => {
             node: jest.fn().mockImplementation(() => ({
               openDB: jest.fn(),
             })),
-            getConnectedClient: jest.fn().mockResolvedValue(client),
+            connectRpc: jest.fn().mockResolvedValue(client),
           })),
         },
       }

--- a/ironfish-cli/src/commands/accounts/rescan.ts
+++ b/ironfish-cli/src/commands/accounts/rescan.ts
@@ -31,7 +31,7 @@ export class RescanCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = this.parse(RescanCommand)
     const { follow, reset, local } = flags
-    const client = await this.sdk.getConnectedClient(local)
+    const client = await this.sdk.connectRpc(local)
 
     await rescan(client, follow, reset)
   }

--- a/ironfish-cli/src/commands/accounts/use.test.ts
+++ b/ironfish-cli/src/commands/accounts/use.test.ts
@@ -9,11 +9,14 @@ describe('accounts:use', () => {
   const name = 'default'
 
   beforeEach(() => {
+    const client = {
+      useAccount,
+      connect: jest.fn(),
+    }
+
     ironfish.IronfishSdk.init = jest.fn().mockImplementationOnce(() => ({
-      client: {
-        useAccount,
-        connect: jest.fn(),
-      },
+      client: client,
+      connectRpc: jest.fn().mockResolvedValue(client),
     }))
   })
 

--- a/ironfish-cli/src/commands/accounts/use.ts
+++ b/ironfish-cli/src/commands/accounts/use.ts
@@ -23,8 +23,8 @@ export class UseCommand extends IronfishCommand {
     const { args } = this.parse(UseCommand)
     const name = (args.name as string).trim()
 
-    await this.sdk.client.connect()
-    await this.sdk.client.useAccount({ name })
+    const client = await this.sdk.connectRpc()
+    await client.useAccount({ name })
     this.log(`The default account is now: ${name}`)
   }
 }

--- a/ironfish-cli/src/commands/accounts/which.test.ts
+++ b/ironfish-cli/src/commands/accounts/which.test.ts
@@ -9,12 +9,17 @@ describe('accounts:which', () => {
   const name = 'default'
 
   beforeEach(() => {
-    ironfish.IronfishSdk.init = jest.fn().mockImplementationOnce(() => ({
-      client: {
+    ironfish.IronfishSdk.init = jest.fn().mockImplementationOnce(() => {
+      const client = {
         connect: jest.fn(),
         getAccounts,
-      },
-    }))
+      }
+
+      return {
+        client: client,
+        connectRpc: jest.fn().mockResolvedValue(client),
+      }
+    })
   })
 
   describe('without a default account', () => {

--- a/ironfish-cli/src/commands/accounts/which.ts
+++ b/ironfish-cli/src/commands/accounts/which.ts
@@ -18,13 +18,13 @@ export class WhichCommand extends IronfishCommand {
   async start(): Promise<void> {
     this.parse(WhichCommand)
 
-    await this.sdk.client.connect()
+    const client = await this.sdk.connectRpc()
 
     const {
       content: {
         accounts: [accountName],
       },
-    } = await this.sdk.client.getAccounts({ default: true })
+    } = await client.getAccounts({ default: true })
 
     if (!accountName) {
       this.log(

--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -39,7 +39,7 @@ export class EditCommand extends IronfishCommand {
       this.exit(code || undefined)
     }
 
-    const client = await this.sdk.getConnectedClient(!flags.remote)
+    const client = await this.sdk.connectRpc(!flags.remote)
     const response = await client.getConfig({ user: true })
     const output = JSON.stringify(response.content, undefined, '   ')
 

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -39,7 +39,7 @@ export class GetCommand extends IronfishCommand {
     const { args, flags } = this.parse(GetCommand)
     const name = (args.name as string).trim()
 
-    const client = await this.sdk.getConnectedClient(flags.local)
+    const client = await this.sdk.connectRpc(flags.local)
 
     const response = await client.getConfig({
       user: flags.user,

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -40,7 +40,7 @@ export class SetCommand extends IronfishCommand {
     const name = args.name as string
     const value = args.value as string
 
-    const client = await this.sdk.getConnectedClient(flags.local)
+    const client = await this.sdk.connectRpc(flags.local)
     await client.setConfig({ name, value })
 
     this.exit(0)

--- a/ironfish-cli/src/commands/config/show.ts
+++ b/ironfish-cli/src/commands/config/show.ts
@@ -32,7 +32,7 @@ export class ShowCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = this.parse(ShowCommand)
 
-    const client = await this.sdk.getConnectedClient(flags.local)
+    const client = await this.sdk.connectRpc(flags.local)
     const response = await client.getConfig({ user: flags.user })
 
     let output = JSON.stringify(response.content, undefined, '   ')

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -60,7 +60,7 @@ describe('IronfishSdk', () => {
     })
   })
 
-  describe('getConnectedClient', () => {
+  describe('connectRpc', () => {
     describe('when local is true', () => {
       it('returns and connects `clientMemory` to a node', async () => {
         const sdk = await IronfishSdk.init()
@@ -69,7 +69,7 @@ describe('IronfishSdk', () => {
         const openDb = jest.spyOn(node, 'openDB').mockImplementationOnce(async () => {})
         jest.spyOn(sdk, 'node').mockResolvedValueOnce(node)
 
-        const client = await sdk.getConnectedClient(true)
+        const client = await sdk.connectRpc(true)
 
         expect(connect).toHaveBeenCalledTimes(1)
         expect(connect).toBeCalledWith(node)
@@ -83,7 +83,7 @@ describe('IronfishSdk', () => {
         const sdk = await IronfishSdk.init()
         const connect = jest.spyOn(sdk.client, 'connect').mockImplementationOnce(async () => {})
 
-        const client = await sdk.getConnectedClient(false)
+        const client = await sdk.connectRpc(false)
 
         expect(connect).toHaveBeenCalledTimes(1)
         expect(client).toMatchObject(sdk.client)

--- a/ironfish/src/strategy.ts
+++ b/ironfish/src/strategy.ts
@@ -68,12 +68,14 @@ export class Strategy {
    */
   miningReward(sequence: number): number {
     const yearsAfterLaunch = Math.floor(Number(sequence) / IRON_FISH_YEAR_IN_BLOCKS)
+
     let reward = this.miningRewardCachedByYear.get(yearsAfterLaunch)
     if (reward) {
       return reward
     }
 
     const annualReward = (GENESIS_SUPPLY_IN_IRON / 4) * Math.E ** (-0.05 * yearsAfterLaunch)
+
     reward = this.convertIronToOre(annualReward / IRON_FISH_YEAR_IN_BLOCKS)
     this.miningRewardCachedByYear.set(yearsAfterLaunch, reward)
 


### PR DESCRIPTION
Added a new connectRpc SDK command that helps connect users to their
node when there is no node running by either connecting to, or starting
a node.

https://linear.app/ironfish/issue/IRO-784/make-commands-be-able-to-run-with-no-node-running