### PR TITLE
Add miner information to status command

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -24,15 +24,9 @@ export default class Status extends IronfishCommand {
     const { flags } = this.parse(Status)
 
     if (!flags.follow) {
-      const connected = await this.sdk.client.tryConnect()
-
-      if (!connected) {
-        this.log('Node: STOPPED')
-      } else {
-        const response = await this.sdk.client.status()
-        this.log(renderStatus(response.content))
-      }
-
+      const client = await this.sdk.connectRpc()
+      const response = await client.status()
+      this.log(renderStatus(response.content))
       this.exit(0)
     }
 
@@ -94,9 +88,14 @@ function renderStatus(content: GetStatusResponse): string {
     content.blockchain.head
   }`
 
+  const miningDirectorStatus = `${content.miningDirector.status.toUpperCase()}, ${
+    content.miningDirector.miners
+  } miners, ${content.miningDirector.blocks} mined`
+
   return `
 Node:                 ${nodeStatus}
 P2P Network:          ${peerNetworkStatus}
+Mining:               ${miningDirectorStatus}
 Blocks syncing:       ${blockSyncerStatus}
 Blockchain:           ${blockchainStatus}`
 }

--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -127,6 +127,16 @@ export class MiningDirector {
   private miningRequestId: number
 
   /**
+   * How many blocks the miner has found
+   */
+  blocksMined = 0
+
+  /**
+   * How many blocks the miner has found
+   */
+  miners = 0
+
+  /**
    * Should the miner mine, even if the chain is not synced
    */
   force: boolean
@@ -438,6 +448,8 @@ export class MiningDirector {
         block.header.sequence
       }) has ${block.transactions.length} transactions`,
     )
+
+    this.blocksMined++
 
     const { isAdded, reason } = await this.chain.addBlock(block)
 

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -34,6 +34,7 @@ export class IronfishNode {
   peerNetwork: PeerNetwork
   syncer: Syncer
 
+  started = false
   shutdownPromise: Promise<void> | null = null
   shutdownResolve: (() => void) | null = null
 
@@ -231,6 +232,7 @@ export class IronfishNode {
 
   async start(): Promise<void> {
     this.shutdownPromise = new Promise((r) => (this.shutdownResolve = r))
+    this.started = true
 
     // Work in the worker pool happens concurrently,
     // so we should start it as soon as possible
@@ -280,6 +282,8 @@ export class IronfishNode {
     if (this.shutdownResolve) {
       this.shutdownResolve()
     }
+
+    this.started = false
   }
 
   onPeerNetworkReady(): void {

--- a/ironfish/src/rpc/routes/mining/newBlocksStream.ts
+++ b/ironfish/src/rpc/routes/mining/newBlocksStream.ts
@@ -50,6 +50,11 @@ router.register<typeof NewBlocksStreamRequestSchema, NewBlocksStreamResponse>(
       )
     }
 
+    node.miningDirector.miners++
+    request.onClose.once(() => {
+      node.miningDirector.miners--
+    })
+
     node.miningDirector.onBlockToMine.on((event) => {
       request.stream({
         bytes: event.bytes.toJSON(),

--- a/ironfish/src/rpc/routes/node/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.test.ts
@@ -13,7 +13,10 @@ describe('Route node/getStatus', () => {
 
     expect(response.content).toMatchObject({
       node: {
-        status: 'started',
+        status: 'stopped',
+      },
+      miningDirector: {
+        status: 'stopped',
       },
       blockSyncer: {
         status: 'stopped',

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -16,6 +16,11 @@ export type GetStatusResponse = {
   node: {
     status: 'started' | 'stopped' | 'error'
   }
+  miningDirector: {
+    status: 'started' | 'stopped'
+    miners: number
+    blocks: number
+  }
   blockchain: {
     synced: boolean
     head: string
@@ -47,6 +52,13 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
     node: yup
       .object({
         status: yup.string().oneOf(['started', 'stopped', 'error']).defined(),
+      })
+      .defined(),
+    miningDirector: yup
+      .object({
+        status: yup.string().oneOf(['started', 'stopped']).defined(),
+        miners: yup.number().defined(),
+        blocks: yup.number().defined(),
       })
       .defined(),
     blockchain: yup
@@ -121,7 +133,12 @@ function getStatus(node: IronfishNode): GetStatusResponse {
       })`,
     },
     node: {
-      status: 'started',
+      status: node.started ? 'started' : 'stopped',
+    },
+    miningDirector: {
+      status: node.miningDirector.isStarted() ? 'started' : 'stopped',
+      miners: node.miningDirector.miners,
+      blocks: node.miningDirector.blocksMined,
     },
     blockSyncer: {
       status: node.syncer.state,


### PR DESCRIPTION
This PR adds mining director info to the status command, and makes it so it can be used offline. You can see the new output below.

```bash
> ironfish status
Node:                 STOPPED
P2P Network:          WAITING In: 0 B/s, Out: 0 B/s, peers 0
Mining:               STOPPED, 0 miners, 0 mined
Blocks syncing:       STOPPED @ 0 blocks per seconds
Blockchain:           NOT SYNCED, HEAD 0000274568976dd9f4e7e7900296d6066600ebff313121edb565c23999df4dad (1730)
```

https://linear.app/ironfish/issue/IRO-801/add-mining-director-info-to-status-command
https://linear.app/ironfish/issue/IRO-802/make-status-command-work-offline