### PR TITLE
Move export chain logic to RPC route

### DIFF
--- a/ironfish/src/rpc/clients/rpcClient.ts
+++ b/ironfish/src/rpc/clients/rpcClient.ts
@@ -49,6 +49,10 @@ import { ExportAccountRequest, ExportAccountResponse } from '../routes/accounts/
 import { ImportAccountRequest, ImportAccountResponse } from '../routes/accounts/importAccount'
 import { RemoveAccountRequest, RemoveAccountResponse } from '../routes/accounts/removeAccount'
 import { RescanAccountRequest, RescanAccountResponse } from '../routes/accounts/rescanAccount'
+import {
+  ExportChainStreamRequest,
+  ExportChainStreamResponse,
+} from '../routes/chain/exportChain'
 import { OnGossipRequest, OnGossipResponse } from '../routes/events/onGossip'
 import { GetPeerRequest, GetPeerResponse } from '../routes/peers/getPeer'
 import {
@@ -216,6 +220,12 @@ export abstract class IronfishRpcClient {
     params: GetChainInfoRequest = undefined,
   ): Promise<ResponseEnded<GetChainInfoResponse>> {
     return this.request<GetChainInfoResponse>('chain/getChainInfo', params).waitForEnd()
+  }
+
+  exportChainStream(
+    params: ExportChainStreamRequest = undefined,
+  ): Response<void, ExportChainStreamResponse> {
+    return this.request<void, ExportChainStreamResponse>('chain/exportChainStream', params)
   }
 
   async getBlockInfo(

--- a/ironfish/src/rpc/routes/chain/exportChain.ts
+++ b/ironfish/src/rpc/routes/chain/exportChain.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { Assert } from '../../../assert'
+import { BlockchainUtils } from '../../../utils/blockchain'
+import { ApiNamespace, router } from '../router'
+
+export type ExportChainStreamRequest =
+  | {
+      start?: number | null
+      stop?: number | null
+    }
+  | undefined
+
+export type ExportChainStreamResponse = {
+  start: number
+  stop: number
+  block?: {
+    hash: string
+    seq: number
+    prev: string
+    main: boolean
+    graffiti: string
+    work: string
+    head: boolean
+    latest: boolean
+  }
+}
+
+export const ExportChainStreamRequestSchema: yup.ObjectSchema<ExportChainStreamRequest> = yup
+  .object({
+    start: yup.number().nullable().optional(),
+    stop: yup.number().nullable().optional(),
+  })
+  .optional()
+
+export const ExportChainStreamResponseSchema: yup.ObjectSchema<ExportChainStreamResponse> = yup
+  .object({
+    start: yup.number().defined(),
+    stop: yup.number().defined(),
+    block: yup
+      .object({
+        hash: yup.string().defined(),
+        seq: yup.number().defined(),
+        prev: yup.string().defined(),
+        main: yup.boolean().defined(),
+        graffiti: yup.string().defined(),
+        work: yup.string().defined(),
+        head: yup.boolean().defined(),
+        latest: yup.boolean().defined(),
+      })
+      .defined(),
+  })
+  .defined()
+
+router.register<typeof ExportChainStreamRequestSchema, ExportChainStreamResponse>(
+  `${ApiNamespace.chain}/exportChainStream`,
+  ExportChainStreamRequestSchema,
+  async (request, node): Promise<void> => {
+    Assert.isNotNull(node.chain.head, 'head')
+    Assert.isNotNull(node.chain.latest, 'latest')
+
+    const { start, stop } = BlockchainUtils.getBlockRange(node.chain, {
+      start: request.data?.start,
+      stop: request.data?.stop,
+    })
+
+    request.stream({ start, stop })
+
+    for (let i = start; i <= stop; ++i) {
+      const blocks = await node.chain.getHeadersAtSequence(i)
+
+      for (const block of blocks) {
+        const isMain = await node.chain.isHeadChain(block)
+
+        const result = {
+          main: isMain,
+          hash: block.hash.toString('hex'),
+          seq: block.sequence,
+          prev: block.previousBlockHash.toString('hex'),
+          graffiti: block.graffiti.toString('ascii'),
+          work: block.work.toString(),
+          head: block.hash.equals(node.chain.head.hash),
+          latest: block.hash.equals(node.chain.latest.hash),
+        }
+
+        request.stream({ start, stop, block: result })
+      }
+    }
+
+    request.end()
+  },
+)

--- a/ironfish/src/rpc/routes/chain/index.ts
+++ b/ironfish/src/rpc/routes/chain/index.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+export * from './exportChain'
 export * from './getBlock'
-export * from './showChain'
-export * from './getChainInfo'
 export * from './getBlockInfo'
+export * from './getChainInfo'
+export * from './showChain'

--- a/ironfish/src/utils/async.ts
+++ b/ironfish/src/utils/async.ts
@@ -18,4 +18,12 @@ export class AsyncUtils {
     }
     return count
   }
+
+  static async first<T>(iter: AsyncIterable<T>): Promise<T> {
+    for await (const result of iter) {
+      return result
+    }
+
+    throw new Error('No element found when expecting first in iter')
+  }
 }


### PR DESCRIPTION
Because this was just in the command, you couldnt export a chain segment
from a running node. Now that it's an RPC route you can do it on a
running node.

https://linear.app/ironfish/issue/IRO-803/move-chain-export-logic-from-command-to-rpc-route