### PR TITLE
Make ironfish reset wait for node to close

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -5,7 +5,7 @@ import { flags } from '@oclif/command'
 import cli from 'cli-ux'
 import fs from 'fs'
 import fsAsync from 'fs/promises'
-import { IronfishNode, PeerNetwork } from 'ironfish'
+import { IronfishNode, NodeUtils, PeerNetwork } from 'ironfish'
 import path from 'path'
 import { IronfishCommand } from '../command'
 import {
@@ -41,7 +41,7 @@ export default class Reset extends IronfishCommand {
     const { flags } = this.parse(Reset)
 
     let node = await this.sdk.node({ autoSeed: false })
-    await node.openDB({ upgrade: false })
+    await NodeUtils.waitForOpen(node, null, { upgrade: false })
 
     const backupPath = path.join(this.sdk.config.dataDir, 'accounts.backup.json')
 

--- a/ironfish/src/utils/node.ts
+++ b/ironfish/src/utils/node.ts
@@ -9,12 +9,16 @@ import { PromiseUtils } from './promise'
 /**
  * Try to open the node DB's and wait until they can be opened
  */
-async function waitForOpen(node: IronfishNode, abort?: () => boolean): Promise<void> {
+async function waitForOpen(
+  node: IronfishNode,
+  abort?: null | (() => boolean),
+  options?: { upgrade?: boolean },
+): Promise<void> {
   let logged = false
 
   while (!abort || !abort()) {
     try {
-      await node.openDB()
+      await node.openDB(options)
       return
     } catch (e) {
       if (e instanceof DatabaseIsLockedError) {


### PR DESCRIPTION
Before it would just crash, now it'll wait for the existing node to
close.