### PR TITLE
Add version to status command

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -61,7 +61,7 @@ export default class Status extends IronfishCommand {
 }
 
 function renderStatus(content: GetStatusResponse): string {
-  const nodeStatus = content.node.status.toUpperCase()
+  const nodeStatus = `${content.node.status.toUpperCase()} @ ${content.node.version}`
   let blockSyncerStatus = content.blockSyncer.status.toString().toUpperCase()
 
   Assert.isNotUndefined(content.blockSyncer.syncing)
@@ -78,17 +78,17 @@ function renderStatus(content: GetStatusResponse): string {
 
   const peerNetworkStatus = `${
     content.peerNetwork.isReady ? 'CONNECTED' : 'WAITING'
-  } In: ${FileUtils.formatFileSize(
+  } - In: ${FileUtils.formatFileSize(
     content.peerNetwork.inboundTraffic,
   )}/s, Out: ${FileUtils.formatFileSize(content.peerNetwork.outboundTraffic)}/s, peers ${
     content.peerNetwork.peers
   }`
 
-  const blockchainStatus = `${content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'}, HEAD ${
+  const blockchainStatus = `${content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'} @ HEAD ${
     content.blockchain.head
   }`
 
-  const miningDirectorStatus = `${content.miningDirector.status.toUpperCase()}, ${
+  const miningDirectorStatus = `${content.miningDirector.status.toUpperCase()} - ${
     content.miningDirector.miners
   } miners, ${content.miningDirector.blocks} mined`
 

--- a/ironfish-cli/src/hooks/version.ts
+++ b/ironfish-cli/src/hooks/version.ts
@@ -17,7 +17,7 @@ const VersionHook: Hook<'init'> = (): void => {
 
     console.log(`name       ${Package.name}`)
     console.log(`version    ${Package.version}`)
-    console.log(`git        ${Package.git || 'src'}`)
+    console.log(`git        ${Package.git}`)
     console.log(`runtime    ${runtime.type}/${runtime.runtime}`)
 
     return process.exit(0)

--- a/ironfish/src/package.ts
+++ b/ironfish/src/package.ts
@@ -8,5 +8,5 @@ export const Package = {
   name: pkg.name,
   license: pkg.license,
   version: pkg.version,
-  git: pkg.gitHash,
+  git: pkg.gitHash || 'src',
 }

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { IronfishNode } from '../../../node'
+import { Package } from '../../../package'
 import { MathUtils, PromiseUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
 
@@ -15,6 +16,7 @@ export type GetStatusRequest =
 export type GetStatusResponse = {
   node: {
     status: 'started' | 'stopped' | 'error'
+    version: string
   }
   miningDirector: {
     status: 'started' | 'stopped'
@@ -52,6 +54,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
     node: yup
       .object({
         status: yup.string().oneOf(['started', 'stopped', 'error']).defined(),
+        version: yup.string().defined(),
       })
       .defined(),
     miningDirector: yup
@@ -134,6 +137,7 @@ function getStatus(node: IronfishNode): GetStatusResponse {
     },
     node: {
       status: node.started ? 'started' : 'stopped',
+      version: Package.git,
     },
     miningDirector: {
       status: node.miningDirector.isStarted() ? 'started' : 'stopped',


### PR DESCRIPTION
This sends the git hash back in status so we can see what version people
are using when they post their status in discord.

```
Node:                 STOPPED @ 0bda2ef
P2P Network:          WAITING - In: 0 B/s, Out: 0 B/s, peers 0
Mining:               STOPPED - 0 miners, 0 mined
Blocks syncing:       STOPPED @ 0 blocks per seconds
Blockchain:           NOT SYNCED @ HEAD 000004531420c9a368a809253ebdcfeeb264acea5b917fcbf10211c5ecbe0c78 (793
```