### PR TITLE
Add cmake to http-api and rosetta API builds

### DIFF
--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /usr/src
 COPY --from=build /ironfish-cli/build.cli/ironfish-cli ./app
 COPY --from=build /ironfish-cli/scripts/entrypoint.sh ./app/
 RUN chmod +x ./app/entrypoint.sh
-# TODO: use environment variables for this
+
 WORKDIR /usr/src/app
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["start", "--rpc.ipc", "--rpc.tcp"]

--- a/ironfish-http-api/Dockerfile
+++ b/ironfish-http-api/Dockerfile
@@ -4,14 +4,20 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 COPY ./ ./
 
 RUN \
+    echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install jq rsync -y && \
+    apt-get install jq rsync gcc cmake -y && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y && \
     ./ironfish-http-api/scripts/build.sh
 
 FROM node:14.16.0
 EXPOSE 8000:8000
+
+RUN \
+    echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install curl libc6 -y
 
 WORKDIR /usr/src
 COPY --from=build /ironfish-http-api/build.api/ironfish-http-api ./app

--- a/ironfish-rosetta-api/Dockerfile
+++ b/ironfish-rosetta-api/Dockerfile
@@ -4,14 +4,20 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 COPY ./ ./
 
 RUN \
+    echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install jq rsync -y && \
+    apt-get install jq rsync gcc cmake -y && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y && \
     ./ironfish-rosetta-api/scripts/build.sh
 
 FROM node:14.16.0
 EXPOSE 8080:8080
+
+RUN \
+    echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install curl libc6 -y
 
 WORKDIR /usr/src
 COPY --from=build /ironfish-rosetta-api/build.rosetta/ironfish-rosetta-api ./app


### PR DESCRIPTION
These builds were failing because they didn't have cmake, so I took the
cmake install from the CLI docker. Later if we publish ironfish to
NPM these other dockers won't have to build it.