### PR TITLE
Adding basic validation on account import

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -8,6 +8,7 @@ import {
   displayIronAmountWithCurrency,
   ironToOre,
   isValidAmount,
+  isValidPublicAddress,
   MINIMUM_IRON_AMOUNT,
   oreToIron,
 } from 'ironfish'
@@ -98,8 +99,7 @@ export class Pay extends IronfishCommand {
         required: true,
       })) as string
 
-      // Todo: need better validation for public address
-      if (to.length !== 86) {
+      if (!isValidPublicAddress(to)) {
         this.error(`A valid public address is required`)
       }
     }

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -17,7 +17,7 @@ import { IDatabaseTransaction } from '../storage'
 import { PromiseResolve, PromiseUtils, SetTimeoutToken } from '../utils'
 import { WorkerPool } from '../workerPool'
 import { Account, AccountDefaults, AccountsDB } from './accountsdb'
-
+import { validateAccount } from './validator'
 const REBROADCAST_SEQUENCE_DELTA = 5
 
 type SyncTransactionParams =
@@ -789,11 +789,9 @@ export class Accounts {
   }
 
   async importAccount(toImport: Partial<Account>): Promise<Account> {
-    if (!toImport.name) {
-      throw new Error(`Imported account has no name`)
-    }
+    validateAccount(toImport)
 
-    if (this.accounts.has(toImport.name)) {
+    if (toImport.name && this.accounts.has(toImport.name)) {
       throw new Error(`Account already exists with the name ${toImport.name}`)
     }
 

--- a/ironfish/src/account/index.ts
+++ b/ironfish/src/account/index.ts
@@ -2,4 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './accounts'
+export * from './validator'
 export * from './accountsdb'

--- a/ironfish/src/account/validator.test.ts
+++ b/ironfish/src/account/validator.test.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  isValidIncomingViewKey,
+  isValidOutgoingViewKey,
+  isValidPublicAddress,
+  isValidSpendingKey,
+} from './validator'
+
+describe('account-validator tests', () => {
+  test('valid public address should return true', () => {
+    const VALID_PUBLIC_ADDRESS =
+      'e877d6903692094b67d889c483d09ad2f8438efc8f00c82e1ec3b2ccd1798ceca48216546dbae48c685f50'
+    expect(isValidPublicAddress(VALID_PUBLIC_ADDRESS)).toBe(true)
+  })
+
+  test('public address with non valid character should return false', () => {
+    const INVALID_PUBLIC_ADDRESS =
+      '#877d6903692094b67d889c483d09ad2f8438efc8f00c82e1ec3b2ccd1798ceca48216546dbae48c685f50'
+    expect(isValidPublicAddress(INVALID_PUBLIC_ADDRESS)).toBe(false)
+  })
+
+  test('public address with non valid length should return false', () => {
+    const INVALID_PUBLIC_ADDRESS =
+      'e877d6903692094b67d889c483d09ad2f8438efc8f00c82e1ec3b2ccd1798ceca48216546dbae48c685f5'
+    expect(isValidPublicAddress(INVALID_PUBLIC_ADDRESS)).toBe(false)
+  })
+
+  test('valid spending key should return true', () => {
+    const VALID_SPENDING_KEY =
+      'd89e4a60b0b3edb76faeac12d7b88e660afa0b335fbe04b2ddccdf62dff40d89'
+    expect(isValidSpendingKey(VALID_SPENDING_KEY)).toBe(true)
+  })
+
+  test('spending key with invalid character should return false', () => {
+    const INVALID_SPENDING_KEY =
+      'd89e4a60b0b3edb76fae c12d7b88e660afa0b335fbe04b2ddccdf62dff40d89'
+    expect(isValidSpendingKey(INVALID_SPENDING_KEY)).toBe(false)
+  })
+
+  test('spending key with invalid length should return false', () => {
+    const INVALID_SPENDING_KEY =
+      'd89e4a60b0b3edb76faeac12d7b88e660afa0b335fbe04b2ddccdf62dff40d897'
+    expect(isValidSpendingKey(INVALID_SPENDING_KEY)).toBe(false)
+  })
+
+  test('valid incoming key should return true', () => {
+    const VALID_INCOMING_KEY =
+      '01995c33968f4ab3b7e02e173552bbc2817cca8a651f43c382d7bb07546d9c01'
+    expect(isValidIncomingViewKey(VALID_INCOMING_KEY)).toBe(true)
+  })
+
+  test('incoming key with invalid character should return false', () => {
+    const INVALID_INCOMING_KEY =
+      '%01995c33968f4ab3b7e02e173552%bc2817cca8a651f43c382d7bb07546d9c01'
+    expect(isValidIncomingViewKey(INVALID_INCOMING_KEY)).toBe(false)
+  })
+
+  test('incoming key with invalid length should return false', () => {
+    const INVALID_INCOMING_KEY =
+      '01995c33968f4ab3b7e02e173552bbc2817cca8a651f43c382d7bb07546d9c0'
+    expect(isValidIncomingViewKey(INVALID_INCOMING_KEY)).toBe(false)
+  })
+
+  test('valid outgoing key should return true', () => {
+    const VALID_OUTGOING_KEY =
+      '49534715229172ee0b7bc8acde878a4e37380e76688c8d8f0d27141af52c6b27'
+    expect(isValidOutgoingViewKey(VALID_OUTGOING_KEY)).toBe(true)
+  })
+
+  test('outgoing key with invalid character should return false', () => {
+    const INVALID_OUTGOING_KEY =
+      '49534715229172ee0b7bc8acde878a4e37380e76&88c8d8f0d27141af52c6b27'
+    expect(isValidOutgoingViewKey(INVALID_OUTGOING_KEY)).toBe(false)
+  })
+
+  test('outgoing key with invalid length should return false', () => {
+    const INVALID_OUTGOING_KEY =
+      '49534715229172ee0b7bc8acde878a4e37380e76688c8d8f0d27141af52c6b2dd'
+    expect(isValidOutgoingViewKey(INVALID_OUTGOING_KEY)).toBe(false)
+  })
+})

--- a/ironfish/src/account/validator.ts
+++ b/ironfish/src/account/validator.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Account } from './accountsdb'
+
+const PUBLIC_ADDRESS_LENGTH = 86
+const SPENDING_KEY_LENGTH = 64
+const INCOMING_VIEW_KEY_LENGTH = 64
+const OUTGOING_VIEW_KEY_LENGTH = 64
+
+export function isValidPublicAddress(publicAddress: string): boolean {
+  return publicAddress.length === PUBLIC_ADDRESS_LENGTH && haveAllowedCharacters(publicAddress)
+}
+
+export function isValidSpendingKey(spendingKey: string): boolean {
+  return spendingKey.length === SPENDING_KEY_LENGTH && haveAllowedCharacters(spendingKey)
+}
+
+export function isValidIncomingViewKey(incomingViewKey: string): boolean {
+  return (
+    incomingViewKey.length === INCOMING_VIEW_KEY_LENGTH &&
+    haveAllowedCharacters(incomingViewKey)
+  )
+}
+
+export function isValidOutgoingViewKey(outgoingViewKey: string): boolean {
+  return (
+    outgoingViewKey.length === OUTGOING_VIEW_KEY_LENGTH &&
+    haveAllowedCharacters(outgoingViewKey)
+  )
+}
+
+export function validateAccount(toImport: Partial<Account>): void {
+  if (!toImport.name) {
+    throw new Error(`Imported account has no name`)
+  }
+
+  if (!toImport.publicAddress) {
+    throw new Error(`Imported account has no public address`)
+  }
+
+  if (!isValidPublicAddress(toImport.publicAddress)) {
+    throw new Error(`Provided public address ${toImport.publicAddress} is invalid`)
+  }
+
+  if (!toImport.outgoingViewKey) {
+    throw new Error(`Imported account has no outgoing view key`)
+  }
+
+  if (!isValidOutgoingViewKey(toImport.outgoingViewKey)) {
+    throw new Error(`Provided outgoing view key ${toImport.outgoingViewKey} is invalid`)
+  }
+
+  if (!toImport.incomingViewKey) {
+    throw new Error(`Imported account has no incoming view key`)
+  }
+
+  if (!isValidIncomingViewKey(toImport.incomingViewKey)) {
+    throw new Error(`Provided incoming view key ${toImport.incomingViewKey} is invalid`)
+  }
+
+  if (!toImport.spendingKey) {
+    throw new Error(`Imported account has no spending key`)
+  }
+
+  if (!isValidSpendingKey(toImport.spendingKey)) {
+    throw new Error(`Provided spending key ${toImport.spendingKey} is invalid`)
+  }
+}
+
+function haveAllowedCharacters(text: string): boolean {
+  const validInputRegex = /^[0-9a-z]+$/
+  return validInputRegex.exec(text) != null
+}


### PR DESCRIPTION
Adding library to validate Account keys.
Adding basic validation on account import, this to reduce the risk of adding an account with invalid keys.
