### PR TITLE
Add miners:mined command

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -13,14 +13,7 @@ import {
 } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-
-interface ProgressBar {
-  progress: VoidFunction
-  start: VoidFunction
-  stop: VoidFunction
-  update: (number: number) => void
-  getTotal: () => number
-}
+import { ProgressBar } from '../../types'
 
 export class Pay extends IronfishCommand {
   static description = `Send coins to another account`

--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -7,7 +7,7 @@ import { Assert, BlockHeader, IDatabaseTransaction, IronfishNode, TimeUtils } fr
 import { Meter } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
-import { ProgressBar } from './export'
+import { ProgressBar } from '../../types'
 
 const TREE_BATCH = 1000
 const TREE_START = 1

--- a/ironfish-cli/src/types.ts
+++ b/ironfish-cli/src/types.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export interface ProgressBar {
+  progress: VoidFunction
+  getTotal(): number
+  setTotal(totalValue: number): void
+  start(totalValue?: number, startValue?: number, payload?: Record<string, unknown>): void
+  stop: VoidFunction
+  update(currentValue?: number, payload?: Record<string, unknown>): void
+  update(payload?: Record<string, unknown>): void
+  increment(delta?: number, payload?: Record<string, unknown>): void
+  increment(payload?: Record<string, unknown>): void
+}

--- a/ironfish-cli/src/utils/index.ts
+++ b/ironfish-cli/src/utils/index.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export * from './types'
 export * from './editor'
 export * from './rpc'
+export * from './terminal'
+export * from './types'

--- a/ironfish-cli/src/utils/terminal.ts
+++ b/ironfish-cli/src/utils/terminal.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export function linkText(url: string, text: string): string {
+  const OSC = '\u001B]'
+  const BEL = '\u0007'
+  const SEP = ';'
+
+  return [OSC, '8', SEP, SEP, url, BEL, text, OSC, '8', SEP, SEP, BEL].join('')
+}

--- a/ironfish/src/primitives/block.ts
+++ b/ironfish/src/primitives/block.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { zip } from 'lodash'
+import { Assert } from '../assert'
 import { Serde } from '../serde'
 import { Strategy } from '../strategy'
 import { BlockHeader, BlockHeaderSerde, SerializedBlockHeader } from './blockheader'
@@ -86,6 +87,12 @@ export class Block {
 
   equals(block: Block): boolean {
     return block === this || this.header.strategy.blockSerde.equals(this, block)
+  }
+
+  get minersFee(): Transaction {
+    const tx = this.transactions[this.transactions.length - 1]
+    Assert.isNotUndefined(tx, 'Block has no miners fee')
+    return tx
   }
 }
 

--- a/ironfish/src/rpc/clients/rpcClient.ts
+++ b/ironfish/src/rpc/clients/rpcClient.ts
@@ -54,6 +54,10 @@ import {
   ExportChainStreamResponse,
 } from '../routes/chain/exportChain'
 import { OnGossipRequest, OnGossipResponse } from '../routes/events/onGossip'
+import {
+  ExportMinedStreamRequest,
+  ExportMinedStreamResponse,
+} from '../routes/mining/exportMined'
 import { GetPeerRequest, GetPeerResponse } from '../routes/peers/getPeer'
 import {
   GetPeerMessagesRequest,
@@ -226,6 +230,12 @@ export abstract class IronfishRpcClient {
     params: ExportChainStreamRequest = undefined,
   ): Response<void, ExportChainStreamResponse> {
     return this.request<void, ExportChainStreamResponse>('chain/exportChainStream', params)
+  }
+
+  exportMinedStream(
+    params: ExportMinedStreamRequest = undefined,
+  ): Response<void, ExportMinedStreamResponse> {
+    return this.request<void, ExportMinedStreamResponse>('miner/exportMinedStream', params)
   }
 
   async getBlockInfo(

--- a/ironfish/src/rpc/routes/mining/exportMined.ts
+++ b/ironfish/src/rpc/routes/mining/exportMined.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { Assert } from '../../../assert'
+import { BlockchainUtils } from '../../../utils/blockchain'
+import { ApiNamespace, router } from '../router'
+
+export type ExportMinedStreamRequest =
+  | {
+      start?: number | null
+      stop?: number | null
+    }
+  | undefined
+
+export type ExportMinedStreamResponse = {
+  start: number
+  stop: number
+  sequence: number
+  block?: {
+    hash: string
+    minersFee: number
+    sequence: number
+    main: boolean
+    account: string
+  }
+}
+
+export const ExportMinedStreamRequestSchema: yup.ObjectSchema<ExportMinedStreamRequest> = yup
+  .object({
+    start: yup.number().nullable().optional(),
+    stop: yup.number().nullable().optional(),
+  })
+  .optional()
+
+export const ExportMinedStreamResponseSchema: yup.ObjectSchema<ExportMinedStreamResponse> = yup
+  .object({
+    start: yup.number().defined(),
+    stop: yup.number().defined(),
+    sequence: yup.number().defined(),
+    block: yup
+      .object({
+        hash: yup.string().defined(),
+        minersFee: yup.number().defined(),
+        sequence: yup.number().defined(),
+        main: yup.boolean().defined(),
+        account: yup.string().defined(),
+      })
+      .defined(),
+  })
+  .defined()
+
+router.register<typeof ExportMinedStreamRequestSchema, ExportMinedStreamResponse>(
+  `${ApiNamespace.miner}/exportMinedStream`,
+  ExportMinedStreamRequestSchema,
+  async (request, node): Promise<void> => {
+    Assert.isNotNull(node.chain.head, 'head')
+    Assert.isNotNull(node.chain.latest, 'latest')
+
+    const { start, stop } = BlockchainUtils.getBlockRange(node.chain, {
+      start: request.data?.start,
+      stop: request.data?.stop,
+    })
+
+    request.stream({ start, stop, sequence: 0 })
+
+    for (let i = start; i <= stop; ++i) {
+      const headers = await node.chain.getHeadersAtSequence(i)
+
+      for (const header of headers) {
+        const block = await node.chain.getBlock(header)
+        Assert.isNotNull(block)
+
+        const account = node.accounts
+          .listAccounts()
+          .find((a) => BlockchainUtils.isBlockMine(block, a))
+
+        if (!account) {
+          request.stream({ start, stop, sequence: header.sequence })
+          continue
+        }
+
+        const main = await node.chain.isHeadChain(header)
+        const minersFee = node.chain.strategy.miningReward(header.sequence)
+
+        const result = {
+          main: main,
+          hash: header.hash.toString('hex'),
+          sequence: header.sequence,
+          account: account.name,
+          minersFee: minersFee,
+        }
+
+        request.stream({ start, stop, sequence: header.sequence, block: result })
+      }
+    }
+
+    request.end()
+  },
+)

--- a/ironfish/src/rpc/routes/mining/index.ts
+++ b/ironfish/src/rpc/routes/mining/index.ts
@@ -2,5 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+export * from './exportMined'
 export * from './newBlocksStream'
 export * from './successfullyMined'

--- a/ironfish/src/utils/blockchain.ts
+++ b/ironfish/src/utils/blockchain.ts
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Account } from '../account'
 import { Blockchain } from '../blockchain'
 import { GENESIS_BLOCK_SEQUENCE } from '../consensus/consensus'
+import { Block } from '../primitives'
+import { isTransactionMine } from '../testUtilities/helpers/transaction'
 
 export function getBlockRange(
   chain: Blockchain,
@@ -33,4 +36,8 @@ export function getBlockRange(
   return { start, stop }
 }
 
-export const BlockchainUtils = { getBlockRange }
+export function isBlockMine(block: Block, account: Account): boolean {
+  return isTransactionMine(block.minersFee, account)
+}
+
+export const BlockchainUtils = { isBlockMine, getBlockRange }


### PR DESCRIPTION
This new command will scan all your blocks and print out which blocks
you mined. This is helpful for debugging to see which blocks made it on
the main chain, and which did not.

```bash
> ironfish miners:mined 206952 207325
Exporting mined block from 206952 -> 207325
00000001fb7056ab90496e542c50664d84492a79206319c66c0d50d253a5a7c3 jason 5 MAIN 206952: view in web
00000007e826e3e826ffad744f4aed56f2190460933172b1186329f8bd3c8ee6 jason 5 FORK 207028: view in web
000000046dfd1348351bff5aadb146543e4b0a371d23030910eceaf6e8fff3b4 jason 5 MAIN 207037: view in web
Exporting blocks: [==========------------------------------] 98/374 26% | ETA: 39s
```

https://imgur.com/a/faUwqmi

https://linear.app/ironfish/issue/IRO-845/create-minersmined-command