### PR TITLE
Change mining message in miner

### DIFF
--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -35,8 +35,9 @@ export class Miner extends IronfishCommand {
 
     const successfullyMined = (randomness: number, miningRequestId: number) => {
       cli.action.stop(
-        `Successfully mined a block on request ${miningRequestId} randomness ${randomness}`,
+        `Submitting mining attempt to node from request ${miningRequestId} with randomness ${randomness}`,
       )
+
       const request = client.successfullyMined({ randomness, miningRequestId })
       request.waitForEnd().catch(() => {
         cli.action.stop('Unable to submit mined block')


### PR DESCRIPTION
The mining message made people think they mined a block which was
submitted, but this message is just for if they mined an attempt that
might get discarded.