### PR TITLE
Improve mined command usability

### DIFF
--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -2,7 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import cli from 'cli-ux'
-import { AsyncUtils, GENESIS_BLOCK_SEQUENCE, MathUtils, oreToIron } from 'ironfish'
+import {
+  AsyncUtils,
+  GENESIS_BLOCK_SEQUENCE,
+  MathUtils,
+  Meter,
+  oreToIron,
+  TimeUtils,
+} from 'ironfish'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -46,10 +53,14 @@ export class MinedCommand extends IronfishCommand {
     const { start, stop } = await AsyncUtils.first(stream.contentStream())
     this.log(`Exporting mined block from ${start} -> ${stop}`)
 
+    const speed = new Meter()
+
     const progress = cli.progress({
-      format: 'Exporting blocks: [{bar}] {value}/{total} {percentage}% | ETA: {eta}s',
+      format:
+        'Exporting blocks: [{bar}] {value}/{total} {percentage}% | ETA: {estimate} | SEQ {sequence}',
     }) as ProgressBar
 
+    speed.start()
     progress.start(stop - start + 1, 0)
 
     for await (const { sequence, block } of stream.contentStream()) {
@@ -71,7 +82,12 @@ export class MinedCommand extends IronfishCommand {
         )
       }
 
-      progress.update(sequence - start)
+      speed.add(1)
+
+      progress.update(sequence - start, {
+        estimate: TimeUtils.renderEstimate(sequence - start, stop - start, speed.rate5s),
+        sequence,
+      })
     }
   }
 }

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -539,6 +539,7 @@ export class Accounts {
         // Notes can be spent and received by the same Account.
         // Try decrypting the note as its owner
         const receivedNote = note.decryptNoteForOwner(account.incomingViewKey)
+
         if (receivedNote) {
           const noteHashHex = Buffer.from(note.merkleHash()).toString('hex')
 

--- a/ironfish/src/rpc/clients/ipcClient.ts
+++ b/ironfish/src/rpc/clients/ipcClient.ts
@@ -170,7 +170,7 @@ export class IronfishIpcClient extends IronfishRpcClient {
       timeoutMs?: number | null
     } = {},
   ): Response<TEnd, TStream> {
-    Assert.isNotNull(this.client)
+    Assert.isNotNull(this.client, 'Connect first using IpcClient.connect()')
 
     const [promise, resolve, reject] = PromiseUtils.split<TEnd>()
     const messageId = ++this.messageIds

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -40,6 +40,7 @@ export class IronfishMemoryClient extends IronfishRpcClient {
     if (options.timeoutMs) {
       throw new Error(`MemoryAdapter does not support timeoutMs`)
     }
+
     return this.adapter.requestStream<TEnd, TStream>(route, data)
   }
 }


### PR DESCRIPTION
The mined command was good, but very slow, this makes a few
improvements

 - Processes and scans 100 blocks at a time now
 - Show time estimate using time estimater
 - Make iterateTransaction method more robust
 - Add option to also scan and include forks