### PR TITLE
IRO-1123: Send Transactions as a Part of Block Sync Payload

### DIFF
--- a/ironfish-cli/src/api.ts
+++ b/ironfish-cli/src/api.ts
@@ -37,6 +37,7 @@ export class IronfishApi {
       previous_block_hash: block.previous,
       difficulty: block.difficulty,
       graffiti: block.graffiti,
+      main: block.main,
       transactions: block.transactions,
       transactions_count: block.transactions.length,
     }))

--- a/ironfish-cli/src/api.ts
+++ b/ironfish-cli/src/api.ts
@@ -37,7 +37,8 @@ export class IronfishApi {
       previous_block_hash: block.previous,
       difficulty: block.difficulty,
       graffiti: block.graffiti,
-      transactions_count: 0,
+      transactions: block.transactions,
+      transactions_count: block.transactions.length,
     }))
 
     const options = this.options({ 'Content-Type': 'application/json' })

--- a/ironfish-cli/src/api.ts
+++ b/ironfish-cli/src/api.ts
@@ -40,7 +40,6 @@ export class IronfishApi {
       graffiti: block.graffiti,
       main: block.main,
       transactions: block.transactions,
-      transactions_count: block.transactions.length,
     }))
 
     const options = this.options({ 'Content-Type': 'application/json' })

--- a/ironfish-cli/src/commands/chain/sync.ts
+++ b/ironfish-cli/src/commands/chain/sync.ts
@@ -52,7 +52,7 @@ export default class Sync extends IronfishCommand {
 
     if (!apiHost) {
       this.log(
-        `No api host found to upload blocks too. You must set IRONFISH_API_HOST env variable or pass --endpoint flag.`,
+        `No api host found to upload blocks to. You must set IRONFISH_API_HOST env variable or pass --endpoint flag.`,
       )
       this.exit(1)
     }

--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -117,7 +117,6 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
     const send = async (block: Block, type: 'connected' | 'disconnected' | 'fork') => {
       const transactions = await Promise.all(
         block.transactions.map(async (transaction) => {
-
           return {
             hash: BlockHashSerdeInstance.serialize(transaction.transactionHash()),
             size: Buffer.from(

--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -158,17 +158,17 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
     const onAdd = async (header: BlockHeader) => {
       const block = await node.chain.getBlock(header)
       Assert.isNotNull(block)
-      void send(block, 'connected')
+      await send(block, 'connected')
     }
 
     const onRemove = async (header: BlockHeader) => {
       const block = await node.chain.getBlock(header)
       Assert.isNotNull(block)
-      void send(block, 'disconnected')
+      await send(block, 'disconnected')
     }
 
-    const onFork = (block: Block) => {
-      void send(block, 'fork')
+    const onFork = async (block: Block) => {
+      await send(block, 'fork')
     }
 
     processor.onAdd.on(onAdd)

--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -133,10 +133,10 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
               hash: BlockHashSerdeInstance.serialize(transaction.transactionHash()),
               size: transactionBuffer.byteLength,
               notes: [...transaction.notes()].map((note) => ({
-                commitment: Buffer.from(note.merkleHash()).toString('hex'),
+                commitment: note.merkleHash().toString('hex'),
               })),
               spends: [...transaction.spends()].map((spend) => ({
-                nullifier: BlockHashSerdeInstance.serialize(spend.nullifier),
+                nullifier: spend.nullifier.toString('hex'),
               })),
             }
           }),

--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -155,17 +155,17 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
     const onAdd = async (header: BlockHeader) => {
       const block = await node.chain.getBlock(header)
       Assert.isNotNull(block)
-      send(block, 'connected')
+      void send(block, 'connected')
     }
 
     const onRemove = async (header: BlockHeader) => {
       const block = await node.chain.getBlock(header)
       Assert.isNotNull(block)
-      send(block, 'disconnected')
+      void send(block, 'disconnected')
     }
 
     const onFork = (block: Block) => {
-      send(block, 'fork')
+      void send(block, 'fork')
     }
 
     processor.onAdd.on(onAdd)


### PR DESCRIPTION
Changelog
---
- Add transactions array to response object
- Tweak process for converting commitments and nullifiers to hex strings
- Add `main`, `transactions`, and `transactions_count` to block level sync payload
- Add `fee` to transaction level sync payload
- Small grammar correction