### PR TITLE
Revert "IRO-1130: Update default max and target peers values as 8 by default"

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -14,9 +14,6 @@ export const DEFAULT_GET_FUNDS_API = 'https://api.ironfish.network/api/v1/getFun
 export const DEFAULT_TELEMETRY_API = 'https://api.ironfish.network/api/v1/writeTelemetry'
 export const DEFAULT_BOOTSTRAP_NODE = 'test.bn1.ironfish.network'
 export const DEFAULT_DISCORD_INVITE = 'https://discord.gg/EkQkEcm8DH'
-export const DEFAULT_MAX_PEERS = 8
-export const DEFAULT_MIN_PEERS = 1
-export const DEFAULT_TARGET_PEERS = 8
 
 export type ConfigOptions = {
   bootstrapNodes: string[]
@@ -172,9 +169,9 @@ export class Config extends KeyStore<ConfigOptions> {
       rpcTcpHost: 'localhost',
       rpcTcpPort: 8020,
       rpcRetryConnect: false,
-      maxPeers: DEFAULT_MAX_PEERS,
-      minPeers: DEFAULT_MIN_PEERS,
-      targetPeers: DEFAULT_TARGET_PEERS,
+      maxPeers: 50,
+      minPeers: 1,
+      targetPeers: 50,
       telemetryApi: DEFAULT_TELEMETRY_API,
       accountName: DEFAULT_WALLET_NAME,
       generateNewIdentity: false,


### PR DESCRIPTION
Reverts iron-fish/ironfish#353

These changes are good, but we need to hold them up until we can improve the connection issues.

The explanation is that since we are reducing the connections down to 8, we are reducing the changes to find a good connection. Right now, every 50 people you attempt to connect to results in maybe 1 connection. It also takes 30 seconds to time out a connection before you can try a new one.  So with 50, that's 50 concurrent attempts, and with 8 people that's many less attempts.

When connecting generally results in a connection this won't be such a big deal.