### PR TITLE
test(ironfish): Fix `strategy.test.slow.ts` to use new transaction verification

### DIFF
--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -88,11 +88,8 @@ describe('Demonstrate the Sapling API', () => {
       const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spending_key)
 
       const verifier = new Verifier(nodeTest.chain)
-      const serialized = strategy.transactionSerde.serialize(minersFee)
 
-      await expect(verifier.verifyNewTransaction(serialized)).rejects.toThrowError(
-        'Transaction has negative fees',
-      )
+      expect(await verifier.verifyTransaction(minersFee)).toMatchObject({ valid: false })
     }, 60000)
   })
 
@@ -174,7 +171,7 @@ describe('Demonstrate the Sapling API', () => {
       const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spending_key)
 
       expect(minersFee['wasmTransactionPosted']).toBeNull()
-      expect(await minersFee.verify()).toEqual({ valid: true })
+      expect(await minersFee.verify({ verifyFees: false })).toEqual({ valid: true })
       expect(minersFee['wasmTransactionPosted']).toBeNull()
     }, 60000)
 

--- a/ironfish/src/workerPool/job.test.slow.ts
+++ b/ironfish/src/workerPool/job.test.slow.ts
@@ -33,7 +33,7 @@ describe('Worker Pool', () => {
     const genesis = await nodeTest.node.chain.getBlock(nodeTest.node.chain.head.hash)
     Assert.isNotNull(genesis)
     const transaction = genesis.transactions[0]
-    const verified = await workerPool.verify(transaction)
+    const verified = await workerPool.verify(transaction, { verifyFees: false })
 
     expect(verified).toBe(true)
     expect(workerPool.completed).toBe(1)


### PR DESCRIPTION
I had auto-merge enabled on my [previous pull request](https://github.com/iron-fish/ironfish/pull/355), which merged without slow tests passing. This code change fixes the broken slow tests.