### PR TITLE
Manually enable JobAbortedError per job

### DIFF
--- a/ironfish/src/workerPool/job.ts
+++ b/ironfish/src/workerPool/job.ts
@@ -21,6 +21,12 @@ export class Job {
   onEnded = new Event<[Job]>()
   onChange = new Event<[Job, Job['status']]>()
 
+  // This determines if JobAbortedError is fed into the response if the job is
+  // aborted. The code base hasn't been upgraded to handle these so it should be
+  // enabled for each job that now properly handles it until all jobs handle it.
+  // Then this should be removed.
+  enableJobAbortError = false
+
   constructor(request: WorkerRequestMessage) {
     this.id = request.jobId
     this.request = request
@@ -53,7 +59,7 @@ export class Job {
       this.worker.jobs.delete(this.id)
     }
 
-    if (this.reject) {
+    if (this.reject && this.enableJobAbortError) {
       this.reject(new JobAbortedError())
     }
   }

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -281,7 +281,10 @@ export class WorkerPool {
       error,
     }
 
-    return this.execute(request)
+    const job = this.execute(request)
+    job.enableJobAbortError = true
+
+    return job
   }
 
   private execute(request: Readonly<WorkerRequest>): Job {


### PR DESCRIPTION
This is a new feature that is causing large errors to be printed when
jobs don't handle the JobAbortedException. In the past when you were
shutting down these jobs would just hang and cause problems. Aborting is
a good behavioural change, but we haven't yet gone through and
upgraded all job call sites.

This adds a new bool to each job that you can turn on depending on the
job if you want to handle the job aborted error.