### PR TITLE
Fix brew login token

### DIFF
--- a/.github/workflows/deploy-node-github-beta.yml
+++ b/.github/workflows/deploy-node-github-beta.yml
@@ -16,9 +16,10 @@ jobs:
           node-version: "14.16.0"
 
       - name: Login to Github Registry
-        run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_ACTOR} --password-stdin ghcr.io
+        run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_USER} --password-stdin ghcr.io
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USER: ${{ secrets.BREW_GITHUB_USERNAME }}
+          GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}
 
       - name: Build Node Image
         run: ./ironfish-cli/scripts/build-docker.sh

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -16,9 +16,10 @@ jobs:
           node-version: "14.16.0"
 
       - name: Login to Github Registry
-        run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_ACTOR} --password-stdin ghcr.io
+        run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_USER} --password-stdin ghcr.io
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USER: ${{ secrets.BREW_GITHUB_USERNAME }}
+          GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}
 
       - name: Build Node Image
         run: ./ironfish-cli/scripts/build-docker.sh


### PR DESCRIPTION
The GITHUB_TOKEN does not seem to be working even when we allow it
permissions. It gets no write access. This might be a bug on githubs
side, but most likely we need to look if they changed how authentication
works.