### PR TITLE
Update syncer API doc strings

### DIFF
--- a/ironfish-cli/src/api.ts
+++ b/ironfish-cli/src/api.ts
@@ -5,6 +5,10 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { FollowChainStreamResponse } from 'ironfish'
 
+/**
+ *  The API should be compatible with the Ironfish API here:
+ *  https://github.com/iron-fish/ironfish-api/blob/master/src/blocks/blocks.controller.ts
+ */
 export class IronfishApi {
   host: string
   token: string

--- a/ironfish-cli/src/commands/chain/sync.ts
+++ b/ironfish-cli/src/commands/chain/sync.ts
@@ -14,10 +14,7 @@ export default class Sync extends IronfishCommand {
   static hidden = true
 
   static description = `
-    Upload blocks to an HTTP API
-
-    The API should be compatible with the Ironfish API here:
-    https://github.com/iron-fish/ironfish-api/blob/master/src/blocks/blocks.controller.ts
+    Upload blocks to an HTTP API using IronfishApi
   `
 
   static flags = {


### PR DESCRIPTION
The documentation link should be on the IronfishAPI class now in the
place that uses it. It was only this way before because it used to do
straight CURL requests inside the code here.