### PR TITLE
IRO-1173: Enable faucet and point to new production API

### DIFF
--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -9,6 +9,8 @@ import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 import { ONE_FISH_IMAGE, TWO_FISH_IMAGE } from '../images'
 
+const FAUCET_DISABLED = false
+
 export class FaucetCommand extends IronfishCommand {
   static description = `Receive coins from the Iron Fish official Faucet`
 
@@ -23,7 +25,7 @@ export class FaucetCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = this.parse(FaucetCommand)
 
-    if (!flags.force) {
+    if (FAUCET_DISABLED && !flags.force) {
       this.log(`❌ The faucet is currently disabled. Check ${DEFAULT_DISCORD_INVITE} ❌`)
       this.exit(1)
     }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -10,7 +10,8 @@ export const DEFAULT_CONFIG_NAME = 'config.json'
 export const DEFAULT_DATABASE_NAME = 'default'
 export const DEFAULT_WALLET_NAME = 'default'
 export const DEFAULT_WEBSOCKET_PORT = 9033
-export const DEFAULT_GET_FUNDS_API = 'https://api.ironfish.network/api/v1/getFunds'
+export const DEFAULT_GET_FUNDS_API =
+  'https://api-production.ironfish.network/faucet_transactions'
 export const DEFAULT_TELEMETRY_API = 'https://api.ironfish.network/api/v1/writeTelemetry'
 export const DEFAULT_BOOTSTRAP_NODE = 'test.bn1.ironfish.network'
 export const DEFAULT_DISCORD_INVITE = 'https://discord.gg/EkQkEcm8DH'

--- a/ironfish/src/rpc/routes/faucet/giveMe.test.ts
+++ b/ironfish/src/rpc/routes/faucet/giveMe.test.ts
@@ -34,8 +34,9 @@ describe('Route faucet.giveMe', () => {
       const response = await routeTest.adapter.request('faucet/giveMe', { accountName, email })
       expect(response.status).toBe(200)
 
-      expect(axios.post).toHaveBeenCalledWith(routeTest.node.config.get('getFundsApi'), null, {
-        params: { email, publicKey: publicAddress },
+      expect(axios.post).toHaveBeenCalledWith(routeTest.node.config.get('getFundsApi'), {
+        email,
+        public_key: publicAddress,
       })
       expect(response.content).toMatchObject(apiResponse)
     }, 10000)

--- a/ironfish/src/rpc/routes/faucet/giveMe.ts
+++ b/ironfish/src/rpc/routes/faucet/giveMe.ts
@@ -37,11 +37,9 @@ router.register<typeof GiveMeRequestSchema, GiveMeResponse>(
     }
 
     await axios
-      .post(getFundsApi, null, {
-        params: {
-          email: request.data.email,
-          publicKey: account.publicAddress,
-        },
+      .post(getFundsApi, {
+        email: request.data.email,
+        public_key: account.publicAddress,
       })
       .then(({ data }: AxiosResponse) => {
         request.end(data)

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.ts
@@ -12,6 +12,7 @@ export type SendTransactionRequest = {
   transactionFee: string
   memo: string
 }
+
 export type SendTransactionResponse = {
   fromAccountName: string
   toPublicKey: string


### PR DESCRIPTION
This turns the faucet back on and points it at the new production
API that we've been working on.

https://linear.app/ironfish/issue/IRO-1173/point-faucet-at-new-api