### PR TITLE
IRO-1142: Increase timeblock to 60 seconds

### DIFF
--- a/ironfish-cli/src/commands/accounts/balance.test.ts
+++ b/ironfish-cli/src/commands/accounts/balance.test.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { expect as expectCli, test } from '@oclif/test'
+import { displayIronAmountWithCurrency, GetBalanceResponse, oreToIron } from 'ironfish'
+
+describe('accounts:balance', () => {
+  const confirmedBalance = '5'
+  const unconfirmedBalance = '10'
+  const responseContent: GetBalanceResponse = {
+    confirmedBalance,
+    unconfirmedBalance,
+  }
+
+  beforeAll(() => {
+    jest.doMock('ironfish', () => {
+      const originalModule = jest.requireActual('ironfish')
+      const client = {
+        connect: jest.fn(),
+        getAccountBalance: jest.fn().mockImplementation(() => ({
+          content: responseContent,
+        })),
+      }
+      const module: typeof jest = {
+        ...originalModule,
+        IronfishSdk: {
+          init: jest.fn().mockImplementation(() => ({
+            client,
+          })),
+        },
+      }
+      return module
+    })
+  })
+
+  afterAll(() => {
+    jest.dontMock('ironfish')
+  })
+
+  describe('fetching the balance for an account', () => {
+    test
+      .stdout()
+      .command(['accounts:balance', 'default'])
+      .exit(0)
+      .it('logs the account balance and available spending balance', (ctx) => {
+        const expectedOutput =
+          `The account balance is: ${displayIronAmountWithCurrency(
+            oreToIron(Number(unconfirmedBalance)),
+            true,
+          )}\n` +
+          `Amount available to spend: ${displayIronAmountWithCurrency(
+            oreToIron(Number(confirmedBalance)),
+            true,
+          )}`
+
+        expectCli(ctx.stdout).include(expectedOutput)
+      })
+  })
+})

--- a/ironfish-cli/src/commands/accounts/balance.test.ts
+++ b/ironfish-cli/src/commands/accounts/balance.test.ts
@@ -25,6 +25,7 @@ describe('accounts:balance', () => {
         ...originalModule,
         IronfishSdk: {
           init: jest.fn().mockImplementation(() => ({
+            connectRpc: jest.fn().mockResolvedValue(client),
             client,
           })),
         },
@@ -43,17 +44,13 @@ describe('accounts:balance', () => {
       .command(['accounts:balance', 'default'])
       .exit(0)
       .it('logs the account balance and available spending balance', (ctx) => {
-        const expectedOutput =
-          `The account balance is: ${displayIronAmountWithCurrency(
-            oreToIron(Number(unconfirmedBalance)),
-            true,
-          )}\n` +
-          `Amount available to spend: ${displayIronAmountWithCurrency(
-            oreToIron(Number(confirmedBalance)),
-            true,
-          )}`
+        expectCli(ctx.stdout).include(
+          displayIronAmountWithCurrency(oreToIron(Number(unconfirmedBalance)), true),
+        )
 
-        expectCli(ctx.stdout).include(expectedOutput)
+        expectCli(ctx.stdout).include(
+          displayIronAmountWithCurrency(oreToIron(Number(confirmedBalance)), true),
+        )
       })
   })
 })

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -49,10 +49,3 @@ export const MAX_REQUESTED_BLOCKS = 50
  * Ideally, it should be in a future refactor.
  */
 export const TARGET_BLOCK_TIME_MS = 60 * 1000
-
-/**
- * The block mining time range that will not increase/decrease difficulty/target
- *
- * NOTE: if block was mined between 40 and 80 seconds -> do nothing (averagate block mining time will be -->> 60 seconds)
- */
-export const TARGET_BLOCK_DO_NOTHING_RANGE_TIME_SECONDS = 40

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -43,9 +43,16 @@ export const MAX_SYNCED_AGE_MS = 60 * 1000
 export const MAX_REQUESTED_BLOCKS = 50
 
 /**
- * The network has a target block time of 15 seconds
+ * The network has a target block time of 60 seconds
  *
  * NOTE: This is not used in target calculation, or IRON_FISH_YEAR_IN_BLOCKS.
  * Ideally, it should be in a future refactor.
  */
-export const TARGET_BLOCK_TIME_MS = 15 * 1000
+export const TARGET_BLOCK_TIME_MS = 60 * 1000
+
+/**
+ * The block mining time range that will not increase/decrease difficulty/target
+ *
+ * NOTE: if block was mined between 40 and 80 seconds -> do nothing (averagate block mining time will be -->> 60 seconds)
+ */
+export const TARGET_BLOCK_DO_NOTHING_RANGE_TIME_SECONDS = 40

--- a/ironfish/src/primitives/target.test.ts
+++ b/ironfish/src/primitives/target.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { TARGET_BLOCK_TIME_MS } from '..'
 import { bigIntToBytes, bytesToBigInt, Target, TargetSerde } from './target'
 
 describe('Target', () => {
@@ -115,10 +116,11 @@ describe('TargetSerde', () => {
 })
 
 describe('Calculate target', () => {
+  const targetBlockInSeconds = (TARGET_BLOCK_TIME_MS * 2) / 3 / 1000
   it('can increase target (which decreases difficulty) if its taking too long to mine a block (80+ seconds since last block)', () => {
     const now = new Date()
     // for any time 80-120 seconds after the last block, difficulty should decrease by previous block's difficulty / BigInt(2048)
-    for (let i = 80; i < 120; i++) {
+    for (let i = targetBlockInSeconds * 2; i < targetBlockInSeconds * 3; i++) {
       const time = new Date(now.getTime() + i * 1000)
 
       const difficulty = BigInt(231072)
@@ -136,7 +138,7 @@ describe('Calculate target', () => {
     }
 
     // for any time 120-140 seconds after the last block, difficulty should decrease by previous block's difficulty / BigInt(2048) * 2
-    for (let i = 120; i < 140; i++) {
+    for (let i = targetBlockInSeconds * 3; i < targetBlockInSeconds * 3 + 10; i++) {
       const time = new Date(now.getTime() + i * 1000)
 
       const difficulty = BigInt(231072)
@@ -156,7 +158,7 @@ describe('Calculate target', () => {
 
   it('can decrease target (which increases difficulty) if a block is trying to come in too early (1-39 seconds)', () => {
     const now = new Date()
-    for (let i = 1; i < 39; i++) {
+    for (let i = 1; i < targetBlockInSeconds; i++) {
       const time = new Date(now.getTime() + i * 1000)
 
       const difficulty = BigInt(231072)
@@ -176,7 +178,7 @@ describe('Calculate target', () => {
 
   it('keeps difficulty/target of parent block header if time differnece is between 40 and 80 seconds', () => {
     const now = new Date()
-    for (let i = 40; i < 80; i++) {
+    for (let i = targetBlockInSeconds; i < targetBlockInSeconds * 2; i++) {
       const time = new Date(now.getTime() + i * 1000)
 
       const difficulty = BigInt(231072)

--- a/ironfish/src/primitives/target.test.ts
+++ b/ironfish/src/primitives/target.test.ts
@@ -115,11 +115,11 @@ describe('TargetSerde', () => {
 })
 
 describe('Calculate target', () => {
-  it('can increase target (which decreases difficulty) if its taking too long to mine a block (20+ seconds since last block)', () => {
+  it('can increase target (which decreases difficulty) if its taking too long to mine a block (80+ seconds since last block)', () => {
     const now = new Date()
-    // for any time 20-29 seconds after the last block, difficulty should decrease by previous block's difficulty / BigInt(2048)
-    for (let i = 1; i < 10; i++) {
-      const time = new Date(now.getTime() + 20000 + i * 1000)
+    // for any time 80-120 seconds after the last block, difficulty should decrease by previous block's difficulty / BigInt(2048)
+    for (let i = 80; i < 120; i++) {
+      const time = new Date(now.getTime() + i * 1000)
 
       const difficulty = BigInt(231072)
       const target = Target.fromDifficulty(difficulty)
@@ -135,9 +135,9 @@ describe('Calculate target', () => {
       expect(newTarget.asBigInt()).toBeGreaterThan(target.asBigInt())
     }
 
-    // for any time 30-39 seconds after the last block, difficulty should decrease by previous block's difficulty / BigInt(2048) * 2
-    for (let i = 1; i < 10; i++) {
-      const time = new Date(now.getTime() + 30000 + i * 1000)
+    // for any time 120-140 seconds after the last block, difficulty should decrease by previous block's difficulty / BigInt(2048) * 2
+    for (let i = 120; i < 140; i++) {
+      const time = new Date(now.getTime() + i * 1000)
 
       const difficulty = BigInt(231072)
       const target = Target.fromDifficulty(difficulty)
@@ -154,9 +154,9 @@ describe('Calculate target', () => {
     }
   })
 
-  it('can decrease target (which increases difficulty) if a block is trying to come in too early (1-10 seconds)', () => {
+  it('can decrease target (which increases difficulty) if a block is trying to come in too early (1-39 seconds)', () => {
     const now = new Date()
-    for (let i = 1; i < 10; i++) {
+    for (let i = 1; i < 39; i++) {
       const time = new Date(now.getTime() + i * 1000)
 
       const difficulty = BigInt(231072)
@@ -174,9 +174,9 @@ describe('Calculate target', () => {
     }
   })
 
-  it('keeps difficulty/target of parent block header if time differnece is between 10 and 20 seconds', () => {
+  it('keeps difficulty/target of parent block header if time differnece is between 40 and 80 seconds', () => {
     const now = new Date()
-    for (let i = 10; i < 20; i++) {
+    for (let i = 40; i < 80; i++) {
       const time = new Date(now.getTime() + i * 1000)
 
       const difficulty = BigInt(231072)

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { Serde } from '../serde'
-import { TARGET_BLOCK_DO_NOTHING_RANGE_TIME_SECONDS } from '../consensus'
+import { TARGET_BLOCK_TIME_MS } from '../consensus'
 
 function max(a: bigint, b: bigint): bigint {
   if (a > b) {
@@ -201,14 +201,9 @@ export class Target {
     // note that timestamps above are in seconds, and JS timestamps are in ms
 
     // max(1 - (current_block_timestamp - parent_timestamp) / 10, -99)
+    const targetRangeInSeconds = (TARGET_BLOCK_TIME_MS * 2) / 3 / 1000
     const diffInSeconds = (time.getTime() - previousBlockTimestamp.getTime()) / 1000
-    // The logic of this line of code calculation the increase/descreas difficulty
-    // if block was mined less than 40 seconds -> increase difficulty (the block has been found too fast)
-    // if block was mined between 40 and 80 seconds -> do nothing (averagate block mining time will be -->> 60 seconds)
-    // if block was mined more than 80+ seconds -> decrease difficulty
-    const sign = BigInt(
-      Math.max(1 - Math.floor(diffInSeconds / TARGET_BLOCK_DO_NOTHING_RANGE_TIME_SECONDS), -99),
-    )
+    const sign = BigInt(Math.max(1 - Math.floor(diffInSeconds / targetRangeInSeconds), -99))
     const offset = BigInt(previousBlockDifficulty) / BigInt(DIFFICULTY_ADJUSTMENT_DENOMINATOR)
 
     // diff = parent_diff + parent_diff / 2048 * max(1 - (current_block_timestamp - parent_timestamp) / 10, -99)

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { Serde } from '../serde'
+import { TARGET_BLOCK_DO_NOTHING_RANGE_TIME_SECONDS } from '../consensus'
 
 function max(a: bigint, b: bigint): bigint {
   if (a > b) {
@@ -201,7 +202,13 @@ export class Target {
 
     // max(1 - (current_block_timestamp - parent_timestamp) / 10, -99)
     const diffInSeconds = (time.getTime() - previousBlockTimestamp.getTime()) / 1000
-    const sign = BigInt(Math.max(1 - Math.floor(diffInSeconds / 10), -99))
+    // The logic of this line of code calculation the increase/descreas difficulty
+    // if block was mined less than 40 seconds -> increase difficulty (the block has been found too fast)
+    // if block was mined between 40 and 80 seconds -> do nothing (averagate block mining time will be -->> 60 seconds)
+    // if block was mined more than 80+ seconds -> decrease difficulty
+    const sign = BigInt(
+      Math.max(1 - Math.floor(diffInSeconds / TARGET_BLOCK_DO_NOTHING_RANGE_TIME_SECONDS), -99),
+    )
     const offset = BigInt(previousBlockDifficulty) / BigInt(DIFFICULTY_ADJUSTMENT_DENOMINATOR)
 
     // diff = parent_diff + parent_diff / 2048 * max(1 - (current_block_timestamp - parent_timestamp) / 10, -99)

--- a/ironfish/src/primitives/transaction.test.slow.ts
+++ b/ironfish/src/primitives/transaction.test.slow.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { createNodeTest, useAccountFixture } from '../testUtilities'
+import { createNodeTest, useAccountFixture, useMinerBlockFixture } from '../testUtilities'
 
 describe('Accounts', () => {
   const nodeTest = createNodeTest()
@@ -25,5 +25,50 @@ describe('Accounts', () => {
     const hashB = transactionB.transactionHash()
 
     expect(hashA.equals(hashB)).toBe(false)
+  }, 600000)
+
+  it('check if a transaction is a miners fee', async () => {
+    const account = await useAccountFixture(nodeTest.accounts)
+
+    const transactionA = await nodeTest.strategy.createMinersFee(
+      BigInt(0),
+      1,
+      account.spendingKey,
+    )
+
+    const transactionB = await nodeTest.strategy.createMinersFee(
+      BigInt(-1),
+      1,
+      account.spendingKey,
+    )
+
+    expect(await transactionA.isMinersFee()).toBe(true)
+    expect(await transactionB.isMinersFee()).toBe(true)
+  })
+
+  it('check if a transaction is not a miners fee', async () => {
+    const nodeA = nodeTest.node
+
+    // Create an account A
+    const accountA = await useAccountFixture(nodeA.accounts, () =>
+      nodeA.accounts.createAccount('testA'),
+    )
+    const accountB = await useAccountFixture(nodeA.accounts, () =>
+      nodeA.accounts.createAccount('testB'),
+    )
+
+    // Create a block with a miner's fee
+    const block1 = await useMinerBlockFixture(nodeA.chain, 2, accountA)
+    await nodeA.chain.addBlock(block1)
+    await nodeA.accounts.updateHead()
+
+    const transaction = await nodeA.accounts.createTransaction(
+      accountA,
+      BigInt(1),
+      BigInt(1),
+      '',
+      accountB.publicAddress,
+    )
+    expect(await transaction.isMinersFee()).toBe(false)
   }, 600000)
 })

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -92,6 +92,14 @@ export class Transaction {
     })
   }
 
+  async isMinersFee(): Promise<boolean> {
+    return (
+      this.spendsLength() === 0 &&
+      this.notesLength() === 1 &&
+      (await this.transactionFee()) <= 0
+    )
+  }
+
   /**
    * Iterate over all the notes created by this transaction.
    */


### PR DESCRIPTION
This pull request contains:

- increasing average block mining time to 60 seconds
- parameterized the average block mining time
- update tests

We implement the same logic as Ethereum.
ETH logic of changing difficulty with 15 seconds as average mining block:
if the last block is mined between 1 - 9 seconds -> increase difficulty
if the last block is mined between 10 - 20 seconds -> do nothing
if the last block is mined 20+ seconds -> decrease difficulty
The current average block mining time for ETH is around 13.7s [check the current status of network](https://ethstats.net/) 

Our new average block mining time increase from 15 to 60 seconds with logic of update difficulty by the last mined block:
1 - 39 seconds -> increase difficulty
40 - 80 seconds -> do nothing
80+ seconds -> decrease difficulty

The calculation logic for the range of seconds when we do not change the difficulty:
`const targetRangeInSeconds = (TARGET_BLOCK_TIME_MS * 2) / 3 / 1000`
the calculation logic is:
```
target = (window + (2 * window)) / 2
60 = (window + 2 * window) / 2 
15 = (window + 2 * window) / 2
target * 2 = window + 2 * window
120 = window + 2 * window 
30 = window + 2 * window
target * 2 = window * 3
120 = 3 * window
30 = 3 * window
(target * 2) / 3 = window
window =(target * 2) / 3
window = (60 * 2) / 3 = 120 / 3 = 40
window = (15 * 2) / 3 = 30 / 3 = 10
```
The logic of how we change target/difficulty is:
` const sign = BigInt(Math.max(1 - Math.floor(diffInSeconds / targetRangeInSeconds), -99))`
Example of calculation when target is 15 seconds and window is 10:
```
the last block mined time is 5: 
const sign = Math.max(1 - Math.floor(5 / 10), -99) = Math.max(1 - Math.floor(0.5), -99)
const sign = Math.max(1 - 0, -99) = Math.max(1, - 99)
const sign = 1 -> then difficulty will increase

the last block mined time is 14:
const sign = Math.max(1 - Math.floor(14 / 10), -99) = Math.max(1 - Math.floor(1.4), -99)
const sign = Math.max(1 - 1, -99) = Math.max(0, - 99)
const sign = 0 -> then difficulty will not be changed

the last block mined time is 38:
const sign = Math.max(1 - Math.floor(38 / 10), -99) = Math.max(1 - Math.floor(3.8), -99)
const sign = Math.max(1 - 3, -99) = Math.max(-2, - 99)
const sign = -2 -> then difficulty will decrease
```
If sign equals 1 number -> difficulty will be increased
If sign equals 0 -> nothing change
If sign is negative number -> difficulty will decrease

Sandbox for playground:
https://pastebin.com/U03HJcqn