### PR TITLE
Fix balance.test.ts

### DIFF
--- a/ironfish-cli/src/commands/accounts/balance.test.ts
+++ b/ironfish-cli/src/commands/accounts/balance.test.ts
@@ -25,6 +25,7 @@ describe('accounts:balance', () => {
         ...originalModule,
         IronfishSdk: {
           init: jest.fn().mockImplementation(() => ({
+            connectRpc: jest.fn().mockResolvedValue(client),
             client,
           })),
         },
@@ -43,17 +44,13 @@ describe('accounts:balance', () => {
       .command(['accounts:balance', 'default'])
       .exit(0)
       .it('logs the account balance and available spending balance', (ctx) => {
-        const expectedOutput =
-          `The account balance is: ${displayIronAmountWithCurrency(
-            oreToIron(Number(unconfirmedBalance)),
-            true,
-          )}\n` +
-          `Amount available to spend: ${displayIronAmountWithCurrency(
-            oreToIron(Number(confirmedBalance)),
-            true,
-          )}`
+        expectCli(ctx.stdout).include(
+          displayIronAmountWithCurrency(oreToIron(Number(unconfirmedBalance)), true),
+        )
 
-        expectCli(ctx.stdout).include(expectedOutput)
+        expectCli(ctx.stdout).include(
+          displayIronAmountWithCurrency(oreToIron(Number(confirmedBalance)), true),
+        )
       })
   })
 })


### PR DESCRIPTION
This test was broken for two reasons. First, sdk.connectRpc() wasn't
being mocked, which was simple enough.

The second issue is that the test
was testing the formatting matched the output of the command, but the
spacing was inconsistent. Now, it only tests that the balance numbers
get output and doesn't care about how the message is rendered.