### PR TITLE
IRO-1184: Fix Bug in Backup Command

### DIFF
--- a/ironfish-cli/src/commands/backup.ts
+++ b/ironfish-cli/src/commands/backup.ts
@@ -72,7 +72,7 @@ export default class Backup extends IronfishCommand {
 
     cli.action.start(`Uploading to ${bucket}`)
     await this.uploadToS3(dest, bucket)
-    cli.action.start(`done`)
+    cli.action.stop(`done`)
   }
 
   zipDir(source: string, dest: string, excludes: string[] = []): Promise<number | null> {
@@ -80,7 +80,7 @@ export default class Backup extends IronfishCommand {
       const sourceDir = path.dirname(source)
       const sourceFile = path.basename(source)
 
-      const args = ['-zcvf', dest, '-C', sourceDir, sourceFile]
+      const args = ['-zcf', dest, '-C', sourceDir, sourceFile]
 
       for (const exclude of excludes) {
         args.unshift(exclude)
@@ -89,6 +89,7 @@ export default class Backup extends IronfishCommand {
 
       const process = spawn('tar', args)
       process.on('exit', (code) => resolve(code))
+      process.on('close', (code) => resolve(code))
       process.on('error', (error) => reject(error))
     })
   }


### PR DESCRIPTION
Prior to this PR, the backup command might hang on the archive export step. It seems that this was mainly caused by some weirdness in the verbosity flag. The effect of this issue manifested itself as the terminal reporting that an archival was still in progress for a presumably infinite amount of time. This assumption was bolstered by checking the growth in the file size of the archive during this process; it showed that the file only grew to be ~50% of the size one would expect given the size of the data before archival and then stopped growing entirely.

Changelog
---
- Fix infinite time for archival bug by removing verbosity flag
- Add event handler on process close
- Fix prompt update on resolution of S3 upload