### PR TITLE
Retype spend from WasmNoteEncryptedHash to Buffer

### DIFF
--- a/ironfish/src/primitives/spend.ts
+++ b/ironfish/src/primitives/spend.ts
@@ -2,14 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { WasmNoteEncryptedHash } from './noteEncrypted'
 import { Nullifier } from './nullifier'
 
-/**
- * TODO: Why is a spends commitment a note hash?
- */
 export interface Spend {
   nullifier: Nullifier
-  commitment: WasmNoteEncryptedHash
+  commitment: Buffer
   size: number
 }


### PR DESCRIPTION
The types end up being the same here (Buffer), but giving it WasmNoteEncryptedHash is a bit confusing because it's the root hash of the tree at a particular size.

