### PR TITLE
Removed dependency on NodeJS types

### DIFF
--- a/ironfish/src/metrics/meter.ts
+++ b/ironfish/src/metrics/meter.ts
@@ -22,7 +22,7 @@ export class Meter {
   private _rate5m: RollingAverage
   private _average: RollingAverage
   private _count = 0
-  private _interval: NodeJS.Timeout | null = null
+  private _interval: ReturnType<typeof setInterval> | null = null
   private _intervalMs: number
   private _intervalLastMs: number | null = null
 


### PR DESCRIPTION
This was causing errors like this:

```js
src/metrics/meter.ts:71:5 - error TS2322: Type 'number' is not assignable to type 'Timeout | null'.
     this._interval = setInterval(() => this.update(), this._intervalMs)
```

The reason is because the ironfish project should be compatible with both the web, and node and cannot be dependent on compiling with node types.

* In the web setInterval() returns number
* In node setInterval() returns NodeJS.Timeout

We accidently used the node type Timeout, which returns a different type than number in the browser. Because of that, to make it cross compatible we need to reference the generic instead so we don't hard code it to reference one
single platforms type.

This was only working because we were relying on the @types/node package included by rosetta-api and http-api mono repo packages and were discovered because we use hoisting on yarn.