### PR TITLE
Allow getBlockInfo() RPC to search by sequence

### DIFF
--- a/ironfish-cli/src/commands/chain/block.ts
+++ b/ironfish-cli/src/commands/chain/block.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { GraffitiUtils } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
@@ -9,10 +10,10 @@ export default class Block extends IronfishCommand {
 
   static args = [
     {
-      name: 'hash',
+      name: 'search',
       parse: (input: string): string => input.trim(),
       required: true,
-      description: 'the hash of the block to look at',
+      description: 'the hash or sequence of the block to look at',
     },
   ]
 
@@ -22,10 +23,16 @@ export default class Block extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args } = this.parse(Block)
-    const hash = args.hash as string
+    const search = args.search as string
 
-    const client = await this.sdk.connectRpc(true)
-    const data = await client.getBlockInfo({ hash: hash })
+    const client = await this.sdk.connectRpc()
+    const data = await client.getBlockInfo({ search })
+
+    // Render graffiti to human form
+    data.content.block.graffiti = GraffitiUtils.toHuman(
+      Buffer.from(data.content.block.graffiti, 'hex'),
+    )
+
     this.log(JSON.stringify(data.content, undefined, '  '))
   }
 }


### PR DESCRIPTION
The RPC can take both args or you can pass the search to allow the
RPC layer to guess what to search by.

```
> ironfish chain:block 430823
```
```
{
  "block": {
    "graffiti": "Nokrimoz",
    "hash": "0000155828d2d474b02468ab56cca527851d0be7c3aba5c1739c8d102619ab73",
    "previousBlockHash": "00007de95b9da658845c90d5217b2072b8ef1323c97ff4a16d95f7d293465dca",
    "sequence": 430823,
    "timestamp": 1631020094566,
    "transactions": [
      {
        "transactionSignature": "b89c85f180d7b4053e4ff23a1fd62d48a3427dbcf7e3008cbd5879c7a0fb90d20fd718d2c19ec0ad8d729b11e45035b0517b77172e3dbcbdde1c18e8c3cd6e09",
        "transactionHash": "e38f89d3929a504e548fbbaf20512260be8b0353d9dff57a68f82c0ef4c854a6",
        "transactionFee": "-500000000",
        "spends": 0,
        "notes": 1
      }
    ]
  }
}
```

