### PR TITLE
Fix rescan starting at current head

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -501,7 +501,7 @@ export class Accounts {
       transaction,
       initialNoteIndex,
       sequence,
-    } of this.chain.iterateAllTransactions(accountHeadHash)) {
+    } of this.chain.iterateAllTransactions(null, accountHeadHash)) {
       if (scan.isAborted) {
         scan.signalComplete()
         this.scan = null


### PR DESCRIPTION
The issue is that it was just scanning the head and finishing. It needs
to pass null in the from field to start at the genesis block, not start
at the head and go to the head.

`ironfish accounts:rescan`