### PR TITLE
Make version more prominent in start and status

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -2,7 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import { Assert, IronfishNode, NodeUtils, PrivateIdentity, PromiseUtils } from 'ironfish'
+import {
+  Assert,
+  IronfishNode,
+  NodeUtils,
+  Package,
+  PrivateIdentity,
+  PromiseUtils,
+} from 'ironfish'
 import { Platform } from 'ironfish'
 import tweetnacl from 'tweetnacl'
 import { IronfishCommand, SIGNALS } from '../command'
@@ -160,17 +167,18 @@ export default class Start extends IronfishCommand {
 
     const node = await this.sdk.node({ privateIdentity: privateIdentity })
 
-    const version = Platform.getAgent('cli')
     const nodeName = this.sdk.config.get('nodeName').trim() || null
     const peerPort = this.sdk.config.get('peerPort')
+    const peerAgent = Platform.getAgent('cli')
     const bootstraps = this.sdk.config.getArray('bootstrapNodes')
 
     this.log(`\n${ONE_FISH_IMAGE}`)
-    this.log(`Peer Identity ${node.peerNetwork.localPeer.publicIdentity}`)
-    this.log(`Peer Agent    ${version}`)
-    this.log(`Port          ${peerPort}`)
-    this.log(`Bootstrap     ${bootstraps.join(',') || 'NONE'}`)
+    this.log(`Version       ${Package.version} @ ${Package.git}`)
     this.log(`Node Name     ${nodeName || 'NONE'}`)
+    this.log(`Peer Identity ${node.peerNetwork.localPeer.publicIdentity}`)
+    this.log(`Peer Agent    ${peerAgent}`)
+    this.log(`Peer Port     ${peerPort}`)
+    this.log(`Bootstrap     ${bootstraps.join(',') || 'NONE'}`)
     this.log(` `)
 
     await NodeUtils.waitForOpen(node, () => this.closing)

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -61,7 +61,7 @@ export default class Status extends IronfishCommand {
 }
 
 function renderStatus(content: GetStatusResponse): string {
-  const nodeStatus = `${content.node.status.toUpperCase()} @ ${content.node.version}`
+  const nodeStatus = `${content.node.status.toUpperCase()}`
   let blockSyncerStatus = content.blockSyncer.status.toString().toUpperCase()
 
   Assert.isNotUndefined(content.blockSyncer.syncing)
@@ -100,6 +100,7 @@ function renderStatus(content: GetStatusResponse): string {
   }
 
   return `
+Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
 P2P Network          ${peerNetworkStatus}
 Mining               ${miningDirectorStatus}

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -17,6 +17,7 @@ export type GetStatusResponse = {
   node: {
     status: 'started' | 'stopped' | 'error'
     version: string
+    git: string
   }
   miningDirector: {
     status: 'started' | 'stopped'
@@ -67,6 +68,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
       .object({
         status: yup.string().oneOf(['started', 'stopped', 'error']).defined(),
         version: yup.string().defined(),
+        git: yup.string().defined(),
       })
       .defined(),
     miningDirector: yup
@@ -165,7 +167,8 @@ function getStatus(node: IronfishNode): GetStatusResponse {
     },
     node: {
       status: node.started ? 'started' : 'stopped',
-      version: Package.git,
+      version: Package.version,
+      git: Package.git,
     },
     miningDirector: {
       status: node.miningDirector.isStarted() ? 'started' : 'stopped',

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -103,6 +103,7 @@ export class Worker {
   private spawned() {
     Assert.isNotNull(this.parent)
     this.parent.on('message', this.onMessageFromParent)
+
     // Trigger loading of Sapling parameters if we're in a worker thread
     generateKey()
   }


### PR DESCRIPTION
Common complaint in the community from Discord.

`> ironfish status`
```
Version              0.1.1 @ 8e98f95f618244d4543dd3a70afdeaf9326ff5aa
Node                 STOPPED
P2P Network          WAITING - In: 0 B/s, Out: 0 B/s, peers 0
Mining               STOPPED - 0 miners, 0 mined
Mem Pool             0 tx
Syncer               STOPPED @ 0 blocks per seconds
Blockchain           NOT SYNCED @ HEAD 0000000699f5a57fa9f12e284f3d404acd35fa4e4c8004799f64d599e69c662d (205988)
Workers              STOPPED
```

`> ironfish start`
```
::::::::::          :::::::::::::::::
::::::::::::       :::::::::::::::::::
:::::::::::::     :::::::::::::::::::::
::::::::::::::   ::::::::::::::::::::::::
 ::::::::::::: ::::::::::        :::::::::
   :::::::::::::::::::::          ::::::::::
   :::::::::::::::::::::          :::::::::
 ::::::::::::: ::::::::::        :::::::::
::::::::::::::   ::::::::::::::::::::::::
:::::::::::::     :::::::::::::::::::::
::::::::::::       :::::::::::::::::::
::::::::::           ::::::::::::::::

Version       0.1.1 @ 8e98f95f618244d4543dd3a70afdeaf9326ff5aa
Node Name     BLOCKOPS-1
Peer Identity EYZOvuF1uMyo7ZYZzm3r9rj47eP9a0nMWSdnndv0qjc=
Peer Agent    if/cli/src
Peer Port     9044
Bootstrap     test.bn1.ironfish.network
```