### PR TITLE
Send tx hash to API faucet complete

### DIFF
--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -171,6 +171,6 @@ export default class Faucet extends IronfishCommand {
       } (5m avg ${speed.rate5m.toFixed(2)})`,
     )
 
-    await api.completeFaucetTransaction(faucetTransaction.id)
+    await api.completeFaucetTransaction(faucetTransaction.id, tx.content.transactionHash)
   }
 }

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -124,12 +124,12 @@ export class WebApi {
     return response.data
   }
 
-  async completeFaucetTransaction(id: number): Promise<FaucetTransaction> {
+  async completeFaucetTransaction(id: number, hash: string): Promise<FaucetTransaction> {
     this.requireToken()
 
     const response = await axios.post<FaucetTransaction>(
       `${this.host}/faucet_transactions/${id}/complete`,
-      undefined,
+      { hash },
       this.options(),
     )
 


### PR DESCRIPTION
When ever the faucet now completes a FaucetTransaction, it will send the
hash up along during the complete event for storage.

https://linear.app/ironfish/issue/IRO-1226/send-tx-hash-to-api-faucet-complete