### PR TITLE
Delete TargetSerde

### DIFF
--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -6,7 +6,7 @@ import { BlockHashSerdeInstance, GraffitiSerdeInstance, Serde } from '../serde'
 import { Strategy } from '../strategy'
 import { SerializedWasmNoteEncryptedHash, WasmNoteEncryptedHash } from './noteEncrypted'
 import { NullifierHash } from './nullifier'
-import { Target, TargetSerdeInstance } from './target'
+import { Target } from './target'
 
 export type BlockHash = Buffer
 
@@ -229,7 +229,7 @@ export class BlockHeaderSerde implements Serde<BlockHeader, SerializedBlockHeade
           element2.nullifierCommitment.commitment,
         ) &&
       element1.nullifierCommitment.size === element2.nullifierCommitment.size &&
-      TargetSerdeInstance.equals(element1.target, element2.target) &&
+      element1.target.equals(element2.target) &&
       element1.randomness === element2.randomness &&
       element1.timestamp.getTime() === element2.timestamp.getTime() &&
       element1.minersFee === element2.minersFee &&
@@ -253,7 +253,7 @@ export class BlockHeaderSerde implements Serde<BlockHeader, SerializedBlockHeade
           .serialize(header.nullifierCommitment.commitment),
         size: header.nullifierCommitment.size,
       },
-      target: TargetSerdeInstance.serialize(header.target),
+      target: header.target.targetValue.toString(),
       randomness: header.randomness,
       timestamp: header.timestamp.getTime(),
       minersFee: header.minersFee.toString(),
@@ -284,7 +284,7 @@ export class BlockHeaderSerde implements Serde<BlockHeader, SerializedBlockHeade
           .deserialize(data.nullifierCommitment.commitment),
         size: data.nullifierCommitment.size,
       },
-      TargetSerdeInstance.deserialize(data.target),
+      new Target(data.target),
       data.randomness,
       new Date(data.timestamp),
       BigInt(data.minersFee),

--- a/ironfish/src/primitives/target.test.ts
+++ b/ironfish/src/primitives/target.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Target, TargetSerde } from './target'
+import { Target } from './target'
 
 describe('Target', () => {
   it('constructs targets', () => {
@@ -65,28 +65,15 @@ describe('Target', () => {
     expect(Target.meets(BigInt(43), target)).toBe(true)
     expect(Target.meets(BigInt(44), target)).toBe(false)
   })
-})
 
-describe('TargetSerde', () => {
-  const serde = new TargetSerde()
   it('checks target equality', () => {
-    expect(serde.equals(new Target('588888'), new Target('588888'))).toBe(true)
-  })
-  it('serializes and deserializes bytes', () => {
-    const target = new Target(500)
-    const serialized = serde.serialize(target)
-    expect(serialized).toEqual(`500`)
-    const deserialized = serde.deserialize(serialized)
-    expect(serde.equals(deserialized, target)).toBe(true)
-  })
-  it('throws when deserializing incorrect value', () => {
-    expect(() => serde.deserialize('not a number')).toThrowError(
-      `Cannot convert not a number to a BigInt`,
-    )
-    // @ts-expect-error Argument of type '{ not: string; }' is not assignable to parameter of type 'string'.ts(2345)
-    expect(() => serde.deserialize({ not: 'a string' })).toThrowError(
-      `Can only deserialize Target from string or Buffer`,
-    )
+    const a = new Target('588888')
+    const b = new Target('588888')
+    const c = new Target('325434')
+
+    expect(a.equals(b)).toBe(true)
+    expect(a.equals(c)).toBe(false)
+    expect(b.equals(c)).toBe(false)
   })
 })
 

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import type { Serde } from '../serde'
 import { BigIntUtils } from '../utils/bigint'
 
 /**
@@ -217,23 +216,8 @@ export class Target {
   asBytes(): Buffer {
     return BigIntUtils.toBytesBE(this.targetValue, 32)
   }
-}
 
-export class TargetSerde implements Serde<Target, string> {
-  equals(target1: Target, target2: Target): boolean {
-    return target1.targetValue === target2.targetValue
-  }
-
-  serialize(target: Target): string {
-    return target.targetValue.toString()
-  }
-
-  deserialize(data: string | Buffer): Target {
-    if (typeof data === 'string' || data instanceof Buffer) {
-      return new Target(data)
-    }
-    throw new Error('Can only deserialize Target from string or Buffer')
+  equals(other: Target): boolean {
+    return this.targetValue === other.targetValue
   }
 }
-
-export const TargetSerdeInstance = new TargetSerde()

--- a/ironfish/src/serde/PartialHeaderSerde.ts
+++ b/ironfish/src/serde/PartialHeaderSerde.ts
@@ -5,7 +5,7 @@
 import bufio from 'bufio'
 import { WasmNoteEncryptedHash } from '../primitives/noteEncrypted'
 import { NullifierHash } from '../primitives/nullifier'
-import { Target, TargetSerdeInstance } from '../primitives/target'
+import { Target } from '../primitives/target'
 import { Strategy } from '../strategy'
 import { BigIntUtils } from '../utils'
 import { Serde } from '.'
@@ -55,7 +55,7 @@ export default class PartialBlockHeaderSerde implements Serde<PartialBlockHeader
     return {
       sequence: sequence,
       previousBlockHash: previousBlockHash,
-      target: TargetSerdeInstance.deserialize(target),
+      target: new Target(target),
       timestamp: new Date(timestamp),
       minersFee: BigInt(minersFee),
       graffiti: graffiti,


### PR DESCRIPTION
This was not needed and equals() moved to Target class, and serializer
just moved to the relevant serializers that were using it.