### PR TITLE
Send peer list to connected peers instead of identified peers

### DIFF
--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -772,10 +772,8 @@ export class PeerManager {
    * Send a message to all connected peers.
    */
   broadcast(message: LooseMessage): void {
-    for (const peer of this.identifiedPeers.values()) {
-      if (peer.state.type === 'CONNECTED') {
-        peer.send(message)
-      }
+    for (const peer of this.getConnectedPeers()) {
+      peer.send(message)
     }
   }
 
@@ -827,7 +825,7 @@ export class PeerManager {
       type: InternalMessageType.peerListRequest,
     }
 
-    for (const peer of this.identifiedPeers.values()) {
+    for (const peer of this.getConnectedPeers()) {
       if (peer.version !== null && peer.version >= MIN_VERSION_FOR_PEER_LIST_REQUESTS) {
         peer.send(peerListRequest)
         continue


### PR DESCRIPTION
We were mistakenly sending out peer lists to disconnected and connecting peers as well as connected peers.