### PR TITLE
Remove "Balance" suffix from result of getBalance()

### DIFF
--- a/ironfish-cli/src/commands/accounts/balance.test.ts
+++ b/ironfish-cli/src/commands/accounts/balance.test.ts
@@ -5,11 +5,9 @@ import { expect as expectCli, test } from '@oclif/test'
 import { displayIronAmountWithCurrency, GetBalanceResponse, oreToIron } from 'ironfish'
 
 describe('accounts:balance', () => {
-  const confirmedBalance = '5'
-  const unconfirmedBalance = '10'
   const responseContent: GetBalanceResponse = {
-    confirmedBalance,
-    unconfirmedBalance,
+    confirmed: '5',
+    unconfirmed: '10',
   }
 
   beforeAll(() => {
@@ -45,11 +43,11 @@ describe('accounts:balance', () => {
       .exit(0)
       .it('logs the account balance and available spending balance', (ctx) => {
         expectCli(ctx.stdout).include(
-          displayIronAmountWithCurrency(oreToIron(Number(unconfirmedBalance)), true),
+          displayIronAmountWithCurrency(oreToIron(Number(responseContent.unconfirmed)), true),
         )
 
         expectCli(ctx.stdout).include(
-          displayIronAmountWithCurrency(oreToIron(Number(confirmedBalance)), true),
+          displayIronAmountWithCurrency(oreToIron(Number(responseContent.confirmed)), true),
         )
       })
   })

--- a/ironfish-cli/src/commands/accounts/balance.ts
+++ b/ironfish-cli/src/commands/accounts/balance.ts
@@ -31,17 +31,17 @@ export class BalanceCommand extends IronfishCommand {
       account: account,
     })
 
-    const { confirmedBalance, unconfirmedBalance } = response.content
+    const { confirmed, unconfirmed } = response.content
 
     this.log(
       `The account balance is:    ${displayIronAmountWithCurrency(
-        oreToIron(Number(unconfirmedBalance)),
+        oreToIron(Number(unconfirmed)),
         true,
       )}`,
     )
     this.log(
       `Amount available to spend: ${displayIronAmountWithCurrency(
-        oreToIron(Number(confirmedBalance)),
+        oreToIron(Number(confirmed)),
         true,
       )}`,
     )

--- a/ironfish-cli/src/commands/accounts/pay.test.ts
+++ b/ironfish-cli/src/commands/accounts/pay.test.ts
@@ -16,7 +16,7 @@ describe('accounts:pay command', () => {
     ironfishmodule.IronfishSdk.init = jest.fn().mockImplementation(() => {
       const client = {
         connect: jest.fn(),
-        getAccountBalance: jest.fn().mockResolvedValue({ content: { confirmedBalance: 1000 } }),
+        getAccountBalance: jest.fn().mockResolvedValue({ content: { confirmed: 1000 } }),
         sendTransaction,
       }
 

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -64,19 +64,18 @@ export class Pay extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     if (!amount || Number.isNaN(amount)) {
-      const responseBalance = await client.getAccountBalance({
-        account: from,
-      })
-      const { confirmedBalance } = responseBalance.content
+      const response = await client.getAccountBalance({ account: from })
+
       amount = (await cli.prompt(
         `Enter the amount in $IRON (balance available: ${displayIronAmountWithCurrency(
-          oreToIron(Number(confirmedBalance)),
+          oreToIron(Number(response.content.confirmed)),
           false,
         )})`,
         {
           required: true,
         },
       )) as number
+
       if (Number.isNaN(amount)) {
         this.error(`A valid amount is required`)
       }

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -126,11 +126,11 @@ export default class Faucet extends IronfishCommand {
 
     const response = await client.getAccountBalance({ account })
 
-    if (BigInt(response.content.confirmedBalance) < BigInt(FAUCET_AMOUNT + FAUCET_FEE)) {
+    if (BigInt(response.content.confirmed) < BigInt(FAUCET_AMOUNT + FAUCET_FEE)) {
       if (!this.warnedFund) {
         this.log(
           `Faucet has insufficient funds. Needs ${FAUCET_AMOUNT + FAUCET_FEE} but has ${
-            response.content.confirmedBalance
+            response.content.confirmed
           }. Waiting on more funds.`,
         )
 

--- a/ironfish/src/account/accounts.test.slow.ts
+++ b/ironfish/src/account/accounts.test.slow.ts
@@ -41,16 +41,16 @@ describe('Accounts', () => {
 
     // Initial balance should be 0
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
 
     await node.accounts.updateHead()
 
     // Balance after adding the genesis block should be 0
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
 
     // Create a block with a miner's fee
@@ -63,8 +63,8 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 500000000 after adding the miner's fee
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(500000000),
-      unconfirmedBalance: BigInt(500000000),
+      confirmed: BigInt(500000000),
+      unconfirmed: BigInt(500000000),
     })
   }, 600000)
 
@@ -79,15 +79,15 @@ describe('Accounts', () => {
     // Initial balance should be 0
     await node.accounts.updateHead()
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
 
     // Create a block with a miner's fee
@@ -99,8 +99,8 @@ describe('Accounts', () => {
     // Account should now have a balance of 500000000 after adding the miner's fee
     await node.accounts.updateHead()
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(500000000),
-      unconfirmedBalance: BigInt(500000000),
+      confirmed: BigInt(500000000),
+      unconfirmed: BigInt(500000000),
     })
 
     await node.accounts.saveTransactionsToDb()
@@ -111,16 +111,16 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 0 after clearing the cache
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
 
     await node.accounts.loadTransactionsFromDb()
 
     // Balance should be back to 500000000
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(500000000),
-      unconfirmedBalance: BigInt(500000000),
+      confirmed: BigInt(500000000),
+      unconfirmed: BigInt(500000000),
     })
   }, 600000)
 
@@ -134,15 +134,15 @@ describe('Accounts', () => {
 
     // Initial balance should be 0
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
 
     // Create a block with a miner's fee
@@ -154,8 +154,8 @@ describe('Accounts', () => {
     // Account should now have a balance of 500000000 after adding the miner's fee
     await node.accounts.updateHead()
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(500000000),
-      unconfirmedBalance: BigInt(500000000),
+      confirmed: BigInt(500000000),
+      unconfirmed: BigInt(500000000),
     })
 
     // Spend the balance
@@ -181,8 +181,8 @@ describe('Accounts', () => {
     // Balance after adding the transaction that spends 2 should be 499999998
     await node.accounts.updateHead()
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(499999998),
-      unconfirmedBalance: BigInt(499999998),
+      confirmed: BigInt(499999998),
+      unconfirmed: BigInt(499999998),
     })
   }, 600000)
 
@@ -197,15 +197,15 @@ describe('Accounts', () => {
 
     // Initial balance should be 0
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
 
     // Create a block with a miner's fee
@@ -217,8 +217,8 @@ describe('Accounts', () => {
     // Account should now have a balance of 500000000 after adding the miner's fee
     await node.accounts.updateHead()
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(500000000),
-      unconfirmedBalance: BigInt(500000000),
+      confirmed: BigInt(500000000),
+      unconfirmed: BigInt(500000000),
     })
 
     // Spend the balance
@@ -244,8 +244,8 @@ describe('Accounts', () => {
     // Balance after adding the transaction that spends 2 should be 499999998
     await node.accounts.updateHead()
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(499999998),
-      unconfirmedBalance: BigInt(499999998),
+      confirmed: BigInt(499999998),
+      unconfirmed: BigInt(499999998),
     })
   }, 600000)
 
@@ -271,8 +271,8 @@ describe('Accounts', () => {
     // Initial balance should be 500000000
     await nodeA.accounts.updateHead()
     expect(nodeA.accounts.getBalance(accountA)).toEqual({
-      confirmedBalance: BigInt(500000000),
-      unconfirmedBalance: BigInt(500000000),
+      confirmed: BigInt(500000000),
+      unconfirmed: BigInt(500000000),
     })
 
     const block2 = await useBlockFixture(nodeA.chain, async () => {
@@ -345,16 +345,16 @@ describe('Accounts', () => {
     await nodeA.accounts.updateHead()
     await nodeB.accounts.updateHead()
     expect(nodeA.accounts.getBalance(accountA)).toEqual({
-      confirmedBalance: BigInt(500000000),
-      unconfirmedBalance: BigInt(500000000),
+      confirmed: BigInt(500000000),
+      unconfirmed: BigInt(500000000),
     })
     expect(nodeA.accounts.getBalance(accountB)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
     expect(nodeB.accounts.getBalance(accountB)).toEqual({
-      confirmedBalance: BigInt(1000000000),
-      unconfirmedBalance: BigInt(1000000000),
+      confirmed: BigInt(1000000000),
+      unconfirmed: BigInt(1000000000),
     })
 
     // Copy block B1 to nodeA
@@ -365,12 +365,12 @@ describe('Accounts', () => {
     await nodeA.chain.addBlock(blockB2)
     await nodeA.accounts.updateHead()
     expect(nodeA.accounts.getBalance(accountA)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(500000000),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(500000000),
     })
     expect(nodeA.accounts.getBalance(accountB)).toEqual({
-      confirmedBalance: BigInt(1000000000),
-      unconfirmedBalance: BigInt(1000000000),
+      confirmed: BigInt(1000000000),
+      unconfirmed: BigInt(1000000000),
     })
   }, 60000)
 
@@ -438,16 +438,16 @@ describe('Accounts', () => {
     await nodeB.accounts.updateHead()
 
     expect(nodeA.accounts.getBalance(accountA)).toEqual({
-      confirmedBalance: BigInt(499999998),
-      unconfirmedBalance: BigInt(499999998),
+      confirmed: BigInt(499999998),
+      unconfirmed: BigInt(499999998),
     })
     expect(nodeA.accounts.getBalance(accountB)).toEqual({
-      confirmedBalance: BigInt(2),
-      unconfirmedBalance: BigInt(2),
+      confirmed: BigInt(2),
+      unconfirmed: BigInt(2),
     })
     expect(nodeB.accounts.getBalance(accountA)).toEqual({
-      confirmedBalance: BigInt(500000000),
-      unconfirmedBalance: BigInt(500000000),
+      confirmed: BigInt(500000000),
+      unconfirmed: BigInt(500000000),
     })
 
     // Copy block B2 and B3 to nodeA
@@ -458,12 +458,12 @@ describe('Accounts', () => {
     // B should not have confirmed coins yet because the transaction isn't on a block
     // A should not have confirmed coins any more because the transaction is pending
     expect(nodeA.accounts.getBalance(accountA)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(499999998),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(499999998),
     })
     expect(nodeA.accounts.getBalance(accountB)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(2),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(2),
     })
   }, 600000)
 
@@ -544,16 +544,16 @@ describe('Accounts', () => {
     await nodeB.accounts.updateHead()
 
     expect(nodeA.accounts.getBalance(accountA)).toEqual({
-      confirmedBalance: BigInt(499999998),
-      unconfirmedBalance: BigInt(499999998),
+      confirmed: BigInt(499999998),
+      unconfirmed: BigInt(499999998),
     })
     expect(nodeA.accounts.getBalance(accountB)).toEqual({
-      confirmedBalance: BigInt(2),
-      unconfirmedBalance: BigInt(2),
+      confirmed: BigInt(2),
+      unconfirmed: BigInt(2),
     })
     expect(nodeB.accounts.getBalance(accountA)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(499999998),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(499999998),
     })
 
     // Copy block B2 and B3 to nodeA
@@ -564,12 +564,12 @@ describe('Accounts', () => {
     // A should have its original coins
     // B should not have the coins any more
     expect(nodeA.accounts.getBalance(accountA)).toEqual({
-      confirmedBalance: BigInt(500000000),
-      unconfirmedBalance: BigInt(999999998),
+      confirmed: BigInt(500000000),
+      unconfirmed: BigInt(999999998),
     })
     expect(nodeA.accounts.getBalance(accountB)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(2),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(2),
     })
   }, 600000)
 })

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -562,23 +562,25 @@ export class Accounts {
     return unspentNotes
   }
 
-  getBalance(account: Account): { unconfirmedBalance: BigInt; confirmedBalance: BigInt } {
+  getBalance(account: Account): { unconfirmed: BigInt; confirmed: BigInt } {
     this.assertHasAccount(account)
 
     const notes = this.getUnspentNotes(account)
 
-    let unconfirmedBalance = BigInt(0)
-    let confirmedBalance = BigInt(0)
+    let unconfirmed = BigInt(0)
+    let confirmed = BigInt(0)
 
     for (const note of notes) {
       const value = note.note.value()
-      unconfirmedBalance += value
+
+      unconfirmed += value
+
       if (note.index !== null) {
-        confirmedBalance += value
+        confirmed += value
       }
     }
 
-    return { unconfirmedBalance, confirmedBalance }
+    return { unconfirmed, confirmed }
   }
 
   async pay(

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -92,8 +92,8 @@ describe('Create genesis block', () => {
     // Balance should still be zero, since generating the block should clear out
     // any notes made in the process
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: BigInt(0),
-      unconfirmedBalance: BigInt(0),
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
     })
 
     // Add the block to the chain
@@ -105,8 +105,8 @@ describe('Create genesis block', () => {
 
     // Check that the balance is what's expected
     expect(node.accounts.getBalance(account)).toEqual({
-      confirmedBalance: amountBigint,
-      unconfirmedBalance: amountBigint,
+      confirmed: amountBigint,
+      unconfirmed: amountBigint,
     })
 
     // Ensure we can construct blocks after that block
@@ -143,8 +143,8 @@ describe('Create genesis block', () => {
     await newNode.accounts.scanTransactions()
 
     expect(newNode.accounts.getBalance(account)).toEqual({
-      confirmedBalance: amountBigint,
-      unconfirmedBalance: amountBigint,
+      confirmed: amountBigint,
+      unconfirmed: amountBigint,
     })
 
     // Ensure we can construct blocks after that block

--- a/ironfish/src/rpc/routes/accounts/getBalance.ts
+++ b/ironfish/src/rpc/routes/accounts/getBalance.ts
@@ -6,7 +6,7 @@ import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
 export type GetBalanceRequest = { account?: string }
-export type GetBalanceResponse = { confirmedBalance: string; unconfirmedBalance: string }
+export type GetBalanceResponse = { confirmed: string; unconfirmed: string }
 
 export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
   .object({
@@ -16,8 +16,8 @@ export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
 
 export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yup
   .object({
-    unconfirmedBalance: yup.string().defined(),
-    confirmedBalance: yup.string().defined(),
+    unconfirmed: yup.string().defined(),
+    confirmed: yup.string().defined(),
   })
   .defined()
 
@@ -26,10 +26,11 @@ router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
   GetBalanceRequestSchema,
   (request, node): void => {
     const account = getAccount(node, request.data.account)
-    const { confirmedBalance, unconfirmedBalance } = node.accounts.getBalance(account)
+    const { confirmed, unconfirmed } = node.accounts.getBalance(account)
+
     request.end({
-      confirmedBalance: confirmedBalance.toString(),
-      unconfirmedBalance: unconfirmedBalance.toString(),
+      confirmed: confirmed.toString(),
+      unconfirmed: unconfirmed.toString(),
     })
   },
 )

--- a/ironfish/src/rpc/routes/accounts/removeAccount.ts
+++ b/ironfish/src/rpc/routes/accounts/removeAccount.ts
@@ -41,7 +41,7 @@ router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
     if (!request.data.confirm) {
       const balance = node.accounts.getBalance(account)
 
-      if (balance.unconfirmedBalance !== BigInt(0)) {
+      if (balance.unconfirmed !== BigInt(0)) {
         request.end({ needsConfirm: true })
         return
       }

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -85,8 +85,8 @@ describe('Transactions sendTransaction', () => {
       routeTest.chain.synced = true
 
       jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce({
-        unconfirmedBalance: BigInt(11),
-        confirmedBalance: BigInt(0),
+        unconfirmed: BigInt(11),
+        confirmed: BigInt(0),
       })
 
       try {
@@ -113,8 +113,8 @@ describe('Transactions sendTransaction', () => {
       jest.spyOn(routeTest.node.accounts, 'pay').mockResolvedValue(tx)
 
       jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce({
-        unconfirmedBalance: BigInt(11),
-        confirmedBalance: BigInt(11),
+        unconfirmed: BigInt(11),
+        confirmed: BigInt(11),
       })
 
       const result = await routeTest.client.sendTransaction(TEST_PARAMS)

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.ts
@@ -68,7 +68,7 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
     const balance = node.accounts.getBalance(account)
     const sum = BigInt(transaction.amount) + BigInt(transaction.fee)
 
-    if (balance.confirmedBalance < sum && balance.unconfirmedBalance < sum) {
+    if (balance.confirmed < sum && balance.unconfirmed < sum) {
       throw new ValidationError(
         `Your balance is too low. Add funds to your account first`,
         undefined,
@@ -76,7 +76,7 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
       )
     }
 
-    if (balance.confirmedBalance < sum) {
+    if (balance.confirmed < sum) {
       throw new ValidationError(
         `Please wait a few seconds for your balance to update and try again`,
         undefined,


### PR DESCRIPTION
Just removing this because it feels redundent. The result of this is the
balance, so you can write...

 > const balance = accounts.getBalance()

then address the balances by `balance.confirmed` or
`balance.unconfirmed` which seems simpler than `balance.confirmedBalance`