### PR TITLE
Updating IRON_FISH_YEAR_IN_BLOCKS due to block time change

### DIFF
--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -51,6 +51,5 @@ export const TARGET_BUCKET_TIME_IN_SECONDS = 10
  * A ratio of blocks per year that represents an approximation of how many blocks are considered a "year".
  * It's generally an approximation based on TARGET_BLOCK_TIME_IN_SECONDS second block times.
  * It's used in calculating how much a miner should get in rewards.
- * Approximately (365 * 24 * 60 * 60) / TARGET_BLOCK_TIME_IN_SECONDS
  */
 export const IRON_FISH_YEAR_IN_BLOCKS = (365 * 24 * 60 * 60) / TARGET_BLOCK_TIME_IN_SECONDS

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -25,13 +25,6 @@ export const ALLOWED_BLOCK_FUTURE_SECONDS = 15
  */
 export const GENESIS_SUPPLY_IN_IRON = 42000000
 
-/*
- * A ratio of blocks per year that represents an approximation of how many blocks are considered a "year".
- * It's generally an approximation based on 15 second block times. It's used in calculating how much a miner
- * should get in rewards. Approximately (365 * 24  * 60 * 60) / TARGET_BLOCK_TIME_MS
- */
-export const IRON_FISH_YEAR_IN_BLOCKS = 2100000
-
 /**
  * The oldest the tip should be before we consider the chain synced
  */
@@ -53,3 +46,11 @@ export const TARGET_BLOCK_TIME_IN_SECONDS = 60
  * The time range when difficulty and target not change
  */
 export const TARGET_BUCKET_TIME_IN_SECONDS = 10
+
+/*
+ * A ratio of blocks per year that represents an approximation of how many blocks are considered a "year".
+ * It's generally an approximation based on TARGET_BLOCK_TIME_IN_SECONDS second block times.
+ * It's used in calculating how much a miner should get in rewards.
+ * Approximately (365 * 24 * 60 * 60) / TARGET_BLOCK_TIME_IN_SECONDS
+ */
+export const IRON_FISH_YEAR_IN_BLOCKS = (365 * 24 * 60 * 60) / TARGET_BLOCK_TIME_IN_SECONDS

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -282,26 +282,3 @@ describe('Demonstrate the Sapling API', () => {
     })
   })
 })
-
-describe('Miners reward', () => {
-  let strategy: Strategy
-
-  beforeAll(() => {
-    strategy = new Strategy(new WorkerPool())
-  })
-
-  // see https://ironfish.network/docs/whitepaper/4_mining#include-the-miner-reward-based-on-coin-emission-schedule
-  // for more details
-  it('miners reward is properly calculated for year 0-1', () => {
-    let minersReward = strategy.miningReward(1)
-    expect(minersReward).toBe(5 * 10 ** 8)
-
-    minersReward = strategy.miningReward(100000)
-    expect(minersReward).toBe(5 * 10 ** 8)
-  })
-
-  it('miners reward is properly calculated for year 1-2', () => {
-    const minersReward = strategy.miningReward(2100001)
-    expect(minersReward).toBe(475614712)
-  })
-})

--- a/ironfish/src/strategy.test.ts
+++ b/ironfish/src/strategy.test.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { IRON_FISH_YEAR_IN_BLOCKS } from './consensus'
+import { Strategy } from './strategy'
+import { WorkerPool } from './workerPool'
+
+describe('Miners reward', () => {
+  let strategy: Strategy
+
+  beforeAll(() => {
+    strategy = new Strategy(new WorkerPool())
+  })
+
+  // see https://ironfish.network/docs/whitepaper/4_mining#include-the-miner-reward-based-on-coin-emission-schedule
+  // for more details
+
+  // for 60 second block time, miner's block reward in the first year should be 20 IRON
+  it('miners reward is properly calculated for year 0-1', () => {
+    let minersReward = strategy.miningReward(1)
+    expect(minersReward).toBe(20 * 10 ** 8)
+
+    minersReward = strategy.miningReward(IRON_FISH_YEAR_IN_BLOCKS - 1)
+    expect(minersReward).toBe(20 * 10 ** 8)
+  })
+
+  // for 60 second block time, miner's block reward in the second year should be 19 IRON
+  it('miners reward is properly calculated for year 1-2', () => {
+    const minersReward = strategy.miningReward(IRON_FISH_YEAR_IN_BLOCKS + 1)
+    expect(minersReward).toBe(19 * 10 ** 8)
+  })
+})

--- a/ironfish/src/strategy.ts
+++ b/ironfish/src/strategy.ts
@@ -76,10 +76,14 @@ export class Strategy {
 
     const annualReward = (GENESIS_SUPPLY_IN_IRON / 4) * Math.E ** (-0.05 * yearsAfterLaunch)
 
-    reward = this.convertIronToOre(annualReward / IRON_FISH_YEAR_IN_BLOCKS)
+    reward = this.convertIronToOre(this.mRound(annualReward / IRON_FISH_YEAR_IN_BLOCKS, 0.125))
     this.miningRewardCachedByYear.set(yearsAfterLaunch, reward)
 
     return reward
+  }
+
+  mRound(num: number, threshold: number): number {
+    return threshold * Math.round(num / threshold)
   }
 
   convertIronToOre(iron: number): number {

--- a/ironfish/src/strategy.ts
+++ b/ironfish/src/strategy.ts
@@ -10,6 +10,7 @@ import { NoteEncrypted } from './primitives/noteEncrypted'
 import { NullifierHasher } from './primitives/nullifier'
 import { Transaction, TransactionSerde } from './primitives/transaction'
 import { Serde } from './serde'
+import { MathUtils } from './utils'
 import { WorkerPool } from './workerPool'
 
 /**
@@ -76,14 +77,13 @@ export class Strategy {
 
     const annualReward = (GENESIS_SUPPLY_IN_IRON / 4) * Math.E ** (-0.05 * yearsAfterLaunch)
 
-    reward = this.convertIronToOre(this.mRound(annualReward / IRON_FISH_YEAR_IN_BLOCKS, 0.125))
+    reward = this.convertIronToOre(
+      MathUtils.roundBy(annualReward / IRON_FISH_YEAR_IN_BLOCKS, 0.125),
+    )
+
     this.miningRewardCachedByYear.set(yearsAfterLaunch, reward)
 
     return reward
-  }
-
-  mRound(num: number, threshold: number): number {
-    return threshold * Math.round(num / threshold)
   }
 
   convertIronToOre(iron: number): number {

--- a/ironfish/src/utils/math.ts
+++ b/ironfish/src/utils/math.ts
@@ -31,6 +31,13 @@ function round(value: number, places: number): number {
   return Math.round(value * scalar) / scalar
 }
 
+/**
+ * Round a number to the nearest threshold increment
+ */
+function roundBy(num: number, threshold: number): number {
+  return threshold * Math.round(num / threshold)
+}
+
 function max<T extends number | bigint>(a: T, b: T): T {
   return a > b ? a : b
 }
@@ -39,4 +46,4 @@ function min<T extends number | bigint>(a: T, b: T): T {
   return a > b ? b : a
 }
 
-export const MathUtils = { arrayAverage, arraySum, round, min, max }
+export const MathUtils = { arrayAverage, arraySum, round, roundBy, min, max }


### PR DESCRIPTION
Please see this doc: 
https://docs.google.com/spreadsheets/d/1b2ZKY3vpEyk5GPB3TCjWFK4v_dfaokVsxydc8-NigAM/edit#gid=0

TL;DR 
We used to have 15 second block times and with our emissions curve (and a tiny bit of tweaking) the first year past launch had 5 coins per block as the block reward. 
We then changed our block time to 60 seconds and using the same equation our block rewards would be 19.9771 coins per block. 
Since we're using a decay function to lower inflation and decrease block reward per year, our equation makes it hard to have round numbers per block, especially if we'll be changing block time. 
In this PR the proposal is to **round** the block reward to the nearest 0.125 of a coin to make the block rewards easier to read and not be prone to rounding errors. 
Due to the decision to round the block reward to the nearest 0.125 of a coin our emissions curve is going to change. 
Before this PR, our emissions curve had an asymptotic cap (e.g. unlike Bitcoin we didn't have a hard cap, but block rewards gradually approached 0 after 80 or so years). 
In this PR, due to the rounding decision, our emissions would indeed reach 0 after a certain point, making Iron Fish be deflationary/have a fixed supply, which it arguably did before anyway. 

To see graphs and such of old emissions curve and the new one that resulted due to this rounding decision, please see: https://docs.google.com/spreadsheets/d/1b2ZKY3vpEyk5GPB3TCjWFK4v_dfaokVsxydc8-NigAM/edit#gid=0
