### PR TITLE
Add missing files to ironfish-rust-nodejs gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ lerna-debug.log*
 
 # ironfish-rust-nodejs
 ironfish-rust-nodejs/*.map
+ironfish-rust-nodejs/*.d.ts
+ironfish-rust-nodejs/*.tsbuildinfo
 ironfish-rust-nodejs/index.js
 
 # ironfish-cli


### PR DESCRIPTION
There are a few build artifacts missing from the gitignore -- This PR adds them in. 
