### PR TITLE
Upgrade Node.js version to 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14.16.0'
+          node-version: '16.13.0'
           cache: 'yarn'
 
       - name: Install packages
@@ -41,7 +41,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14.16.0'
+          node-version: '16.13.0'
           cache: 'yarn'
 
       - name: Cache Rust
@@ -70,7 +70,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14.16.0'
+          node-version: '16.13.0'
           cache: 'yarn'
 
       - name: Cache Rust

--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14.16.0'
+          node-version: '16.13.0'
           cache: 'yarn'
 
       - name: Build Ironfish CLI

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See https://ironfish.network
 
 ## Install
 
-1. Install [Node.js 14.x](https://nodejs.org/en/download/)
+1. Install [Node.js 16.x](https://nodejs.org/en/download/)
 1. Install [Rust](https://www.rust-lang.org/learn/get-started).
 1. Install [Yarn](https://classic.yarnpkg.com/en/docs/install).
 1. Windows:

--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.6-bullseye as build
+FROM node:16.13.0-bullseye as build
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 COPY ./ ./
@@ -9,7 +9,7 @@ RUN \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     ./ironfish-cli/scripts/build.sh
 
-FROM node:14.17.6-bullseye-slim
+FROM node:16.13.0-bullseye-slim
 EXPOSE 8020:8020
 EXPOSE 9033:9033
 VOLUME /root/.ironfish

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -4,7 +4,7 @@
   "description": "Command line Iron Fish node",
   "author": "Iron Fish <contact@ironfish.network> (https://ironfish.network)",
   "engines": {
-    "node": "14.x"
+    "node": "16.x"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",


### PR DESCRIPTION
Upgrades Node.js to the latest LTS, version 16.

I tested this on an M1 Mac Mini and it seems to build and run fine. However, our Homebrew workflow needs to be updated, probably to use bottles, because the current version assumes x86 when uploading the build artifacts. So we can't yet remove the platform check script forbidding Apple Silicon from running.
