### PR TITLE
Remove isWorker/broadcastWorker code

### DIFF
--- a/ironfish-cli/src/commands/start.test.ts
+++ b/ironfish-cli/src/commands/start.test.ts
@@ -55,7 +55,6 @@ describe('start command', () => {
     const configOptions = {
       enableTelemetry: false,
       nodeName: '',
-      isWorker: false,
       bootstrapNodes: [],
       blockGraffiti: defaultGraffiti,
       generateNewIdentity: false,

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -70,11 +70,6 @@ export default class Start extends IronfishCommand {
       description: 'name for the node',
       hidden: true,
     }),
-    worker: flags.boolean({
-      char: 'w',
-      description: 'is this a worker node',
-      hidden: true,
-    }),
     listen: flags.boolean({
       allowNo: true,
       default: undefined,
@@ -121,7 +116,6 @@ export default class Start extends IronfishCommand {
       logPeerMessages,
       name,
       port,
-      worker,
       workers,
       generateNewIdentity,
     } = flags
@@ -143,9 +137,6 @@ export default class Start extends IronfishCommand {
     }
     if (listen !== undefined && listen !== this.sdk.config.get('enableListenP2P')) {
       this.sdk.config.setOverride('enableListenP2P', listen)
-    }
-    if (worker !== undefined && worker !== this.sdk.config.get('isWorker')) {
-      this.sdk.config.setOverride('isWorker', worker)
     }
     if (forceMining !== undefined && forceMining !== this.sdk.config.get('miningForce')) {
       this.sdk.config.setOverride('miningForce', forceMining)

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -32,15 +32,6 @@ export type ConfigOptions = {
   getFundsApi: string
   ipcPath: string
   /**
-   * Worker nodes are nodes that are intended to only connect to one node
-   * directly and should not be broadcast to other peers. For example, a
-   * single mining director connected to a public node is a worker node.
-   *
-   * Often worker nodes are behind firewalls anyway so they cannot be
-   * connected to.
-   * */
-  isWorker: boolean
-  /**
    * Should the mining director mine, even if we are not synced?
    * Only useful if no miner has been on the network in a long time
    * otherwise you should not turn this on or you'll create useless
@@ -51,10 +42,6 @@ export type ConfigOptions = {
    * If true, track all sent and received network messages per-peer.
    */
   logPeerMessages: boolean
-  /**
-   * True if you want to send worker peers out to other clients or not
-   * */
-  broadcastWorkers: boolean
   /**
    * Log levels are formatted like so:
    * `*:warn,tag:info`
@@ -142,7 +129,6 @@ export class Config extends KeyStore<ConfigOptions> {
 
   static GetDefaults(files: FileSystem, dataDir: string): ConfigOptions {
     return {
-      broadcastWorkers: true,
       bootstrapNodes: [DEFAULT_BOOTSTRAP_NODE],
       databaseName: DEFAULT_DATABASE_NAME,
       editor: '',
@@ -157,7 +143,6 @@ export class Config extends KeyStore<ConfigOptions> {
       enableMetrics: true,
       getFundsApi: DEFAULT_GET_FUNDS_API,
       ipcPath: files.resolve(files.join(dataDir || DEFAULT_DATA_DIR, 'ironfish.ipc')),
-      isWorker: false,
       logLevel: '*:info',
       logPeerMessages: false,
       logPrefix: '',

--- a/ironfish/src/network/messages.ts
+++ b/ironfish/src/network/messages.ts
@@ -89,7 +89,6 @@ export type Identify = Message<
   InternalMessageType.identity,
   {
     identity: Identity
-    isWorker?: boolean
     name?: string
     version: number
     agent: string

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -138,8 +138,6 @@ export class PeerNetwork {
     minPeers?: number
     targetPeers?: number
     enableSyncing?: boolean
-    isWorker?: boolean
-    broadcastWorkers?: boolean
     logPeerMessages?: boolean
     simulateLatency?: number
     logger?: Logger
@@ -170,10 +168,7 @@ export class PeerNetwork {
 
     this.localPeer.port = options.port === undefined ? null : options.port
     this.localPeer.name = options.name || null
-    this.localPeer.isWorker = options.isWorker || false
     this.localPeer.simulateLatency = options.simulateLatency || 0
-    this.localPeer.broadcastWorkers =
-      options.broadcastWorkers === undefined ? true : options.broadcastWorkers
 
     const maxPeers = options.maxPeers || 10000
     const targetPeers = options.targetPeers || 50

--- a/ironfish/src/network/peers/localPeer.ts
+++ b/ironfish/src/network/peers/localPeer.ts
@@ -30,10 +30,6 @@ export class LocalPeer {
   port: number | null
   // optional a human readable name for the node
   name: string | null
-  // is the node a worker node that should not be advertised
-  isWorker = false
-  // should we broadcast worker nodes anyway?
-  broadcastWorkers = true
   // simulated latency in MS that gets added to connection.send
   simulateLatency = 0
 
@@ -55,7 +51,6 @@ export class LocalPeer {
     this.webSocket = webSocket
     this.port = null
     this.name = null
-    this.isWorker = false
   }
 
   /**
@@ -68,7 +63,6 @@ export class LocalPeer {
       type: InternalMessageType.identity,
       payload: {
         identity: this.publicIdentity,
-        isWorker: this.isWorker || undefined,
         version: this.version,
         agent: this.agent,
         name: this.name || undefined,

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -126,11 +126,6 @@ export class Peer {
   }
 
   /**
-   * Is the peer a worker node that should not be advertised
-   */
-  isWorker = false
-
-  /**
    * Is the peer a node we will always attempt to connect to
    */
   isWhitelisted = false

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -1564,36 +1564,6 @@ describe('PeerManager', () => {
       expect(sendToSpy).toBeCalledTimes(1)
       expect(sendToSpy).toHaveBeenCalledWith(peer, peerList)
     })
-
-    it('Does not broadcast worker peers', () => {
-      const peerIdentity = mockIdentity('peer')
-
-      const localPeer = mockLocalPeer()
-      localPeer.broadcastWorkers = false
-
-      const pm = new PeerManager(localPeer, new AddressManager(mockHostsStore()))
-      const { connection, peer } = getConnectedPeer(pm, peerIdentity)
-      peer.isWorker = true
-
-      expect(pm.peers.length).toBe(1)
-      expect(pm.identifiedPeers.size).toBe(1)
-
-      const peerListRequest: PeerListRequest = {
-        type: InternalMessageType.peerListRequest,
-      }
-
-      const emptyPeerList: PeerList = {
-        type: InternalMessageType.peerList,
-        payload: {
-          connectedPeers: [],
-        },
-      }
-
-      const sendToSpy = jest.spyOn(pm, 'sendTo')
-      peer.onMessage.emit(peerListRequest, connection)
-      expect(sendToSpy).toBeCalledTimes(1)
-      expect(sendToSpy).toHaveBeenCalledWith(peer, emptyPeerList)
-    })
   })
 
   describe('Message: PeerList', () => {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -807,12 +807,6 @@ export class PeerManager {
         continue
       }
 
-      // Worker nodes are nodes that should not be broadcast because they are
-      // meant to connect to a single node and perform one function
-      if (p.isWorker && !this.localPeer.broadcastWorkers) {
-        continue
-      }
-
       connectedPeers.push({
         identity: p.state.identity,
         name: p.name || undefined,
@@ -1159,7 +1153,6 @@ export class PeerManager {
     }
 
     peer.name = name
-    peer.isWorker = message.payload.isWorker || false
     peer.version = version
     peer.agent = agent
     peer.head = Buffer.from(message.payload.head, 'hex')
@@ -1461,10 +1454,6 @@ export class PeerManager {
         continue
       }
 
-      if (p.isWorker && !this.localPeer.broadcastWorkers) {
-        continue
-      }
-
       connectedPeers.push({
         identity: p.state.identity,
         name: p.name || undefined,
@@ -1484,12 +1473,6 @@ export class PeerManager {
   private handlePeerListMessage(peerList: PeerList, peer: Peer) {
     if (peer.state.type !== 'CONNECTED') {
       this.logger.warn('Should not handle the peer list message unless peer is connected')
-      return
-    }
-
-    // Workers don't try connect to other peers, so if localPeer is a worker,
-    // we can ignore this message
-    if (this.localPeer.isWorker) {
       return
     }
 

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -95,8 +95,6 @@ export class IronfishNode {
       listen: config.get('enableListenP2P'),
       enableSyncing: config.get('enableSyncing'),
       targetPeers: config.get('targetPeers'),
-      isWorker: config.get('isWorker'),
-      broadcastWorkers: config.get('broadcastWorkers'),
       logPeerMessages: config.get('logPeerMessages'),
       simulateLatency: config.get('p2pSimulateLatency'),
       bootstrapNodes: config.getArray('bootstrapNodes'),


### PR DESCRIPTION
The isWorker/broadcastWorker code isn't used anymore now that our API node architecture has been changed, so we can remove the code to simplify our networking a bit.

This is a breaking change for anyone starting their node with the worker flag, but we're okay with breaking compatibility during the testnet phase.
