### PR TITLE
Remove platform check during preinstall phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lint:changed": "lerna run --since origin/master --include-dependents lint",
     "lint:fix": "lerna run lint:fix",
     "lint:ci": "lerna run lint:ci",
-    "preinstall": "node tools/node-platform-check",
     "postinstall": "(cd ironfish-rust-nodejs && yarn build)",
     "test": "lerna run test",
     "test:coverage": "lerna run test --stream --concurrency 1 -- --collect-coverage",

--- a/tools/node-platform-check.js
+++ b/tools/node-platform-check.js
@@ -1,8 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
-if (process.platform === 'darwin' && process.arch === 'arm64') {
-    console.error(`Iron Fish is not currently supported on Apple Silicon. Follow this Github issue for updates on progress: https://github.com/iron-fish/ironfish/issues/9`)
-    process.exitCode = 1   
-}


### PR DESCRIPTION
Apple Silicon should now work properly when building from source, so we can remove the preinstall check that prevented `yarn install` from working.
