### PR TITLE
Pin cargo-cp-artifact at 0.1.5

### DIFF
--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cargo-cp-artifact": "^0.1",
+    "cargo-cp-artifact": "0.1.5",
     "typescript": "4.3.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2633,7 +2633,7 @@ cardinal@^2.1.1:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
 
-cargo-cp-artifact@^0.1:
+cargo-cp-artifact@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/cargo-cp-artifact/-/cargo-cp-artifact-0.1.5.tgz#2c35f7d658f22acfe9b1fa2774344d9a389efd14"
   integrity sha512-mWwNdfrEyvMPxDHoAhbCYwQBNP3RyW9bV+yi5VaaHtVZqoDXbGU5JQF5qG7s65SJhqP7HIVAQD7wZM6Fk2COuw==


### PR DESCRIPTION
Don't like self upgrading libraries. You can get exploited that way.