### PR TITLE
Temporary fix for double block bug in sync

### DIFF
--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -70,7 +70,7 @@ export class ChainProcessor {
     // a more robust locking mechanism in place (IRO-1212) - deekerno
     const chainHeadHeader = this.chain.head
 
-    const { fork, isLinear } = await this.chain.findFork(head, this.chain.head)
+    const { fork, isLinear } = await this.chain.findFork(head, chainHeadHeader)
     if (!fork) {
       return
     }

--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -65,6 +65,11 @@ export class ChainProcessor {
       return
     }
 
+    // TODO: Using the value of this.chain.head instead of using
+    // this.chain.head directly is a _temporary_ fix until we have
+    // a more robust locking mechanism in place (IRO-1212) - deekerno
+    const chainHeadHeader = this.chain.head
+
     const { fork, isLinear } = await this.chain.findFork(head, this.chain.head)
     if (!fork) {
       return
@@ -82,7 +87,8 @@ export class ChainProcessor {
       }
     }
 
-    const iter = this.chain.iterateTo(fork, this.chain.head, undefined, false)
+    // TODO: Related to IRO-1212 as described above - deekerno
+    const iter = this.chain.iterateTo(fork, chainHeadHeader, undefined, false)
 
     for await (const add of iter) {
       if (add.hash.equals(fork.hash)) {


### PR DESCRIPTION
This is a temporary fix for the double block bug in our API sync
code. Yes, it's only two lines changed. Here's a brief explanation:

In chainProcessor.ts, the API head and the local chain head are
used to find a fork point and whether traversal to said point is
linear in nature. After the fork point is found, the chain processor
generates an iterator using the fork point and the local chain head,
the latter of which was used to find the fork point just a few lines
before. However, it is possible for the local chain head to be updated
in between findFork() and iterateTo() such that the newly generated
iterator has block hashes that were never seen/processed by findFork().
This manifests as an errant 'connected' event leading to several blocks
at the same height instead of a 'disconnected' event being generated
prior to a second connected event. This will only happen when the chain
head is updated in the time between the two aforementioned functions,
which is why there did not seem to be any consistency between the
errant blocks.

Normally, this would be solved by a lock on any instructions using
the local chain head, and we have a mutex class already. However, it
does not currently work well with the chain processor methods, and
since this is an emergency fix (for now), we can use JavaScript's
call by value evaluation strategy to ensure that errant 'connected'
events are less likely while we construct a more robust locking
mechanism.

After running my own tests with this fix for 24 hours and finding no
extra blocks with database queries as well as my own log processors,
I am confident that this temporary fix is stable to ship for now.