### PR TITLE
Remove transactions from accounts when they expire

### DIFF
--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -196,6 +196,10 @@ export class AccountsDB {
     await this.transactions.put(transactionHash, serialized, tx)
   }
 
+  async removeTransaction(transactionHash: Buffer, tx?: IDatabaseTransaction): Promise<void> {
+    await this.transactions.del(transactionHash, tx)
+  }
+
   async replaceTransactions(
     map: BufferMap<{
       transaction: Transaction
@@ -241,6 +245,10 @@ export class AccountsDB {
     await this.nullifierToNote.put(nullifier, note, tx)
   }
 
+  async removeNullifierToNote(noteHash: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.nullifierToNote.del(noteHash, tx)
+  }
+
   async replaceNullifierToNoteMap(map: Map<string, string>): Promise<void> {
     await this.nullifierToNote.clear()
 
@@ -273,6 +281,10 @@ export class AccountsDB {
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.noteToNullifier.put(noteHash, note, tx)
+  }
+
+  async removeNoteToNullifier(noteHash: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.noteToNullifier.del(noteHash, tx)
   }
 
   async replaceNoteToNullifierMap(

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -214,8 +214,9 @@ export class Verifier {
     })
   }
 
-  isExpiredSequence(expirationSequence: number): boolean {
-    return expirationSequence !== 0 && expirationSequence <= this.chain.head.sequence
+  isExpiredSequence(expirationSequence: number, headSequence?: number): boolean {
+    headSequence = headSequence ?? this.chain.head.sequence
+    return expirationSequence !== 0 && expirationSequence <= headSequence
   }
 
   /**


### PR DESCRIPTION
Once transactions have expired, we want to remove them from accounts so that the notes that were spent in the expired transaction become spendable again.
