### PR TITLE
Only load data in open when upgrading the DB

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -60,6 +60,7 @@ export class Accounts {
   protected defaultAccount: string | null = null
   protected headHash: string | null = null
   protected isStarted = false
+  protected isOpen = false
   protected eventLoopTimeout: SetTimeoutToken | null = null
 
   constructor({
@@ -197,6 +198,25 @@ export class Accounts {
     }
 
     return false
+  }
+
+  async open(
+    options: { upgrade?: boolean; load?: boolean } = { upgrade: true, load: true },
+  ): Promise<void> {
+    await this.db.open(options)
+
+    if (options.load) {
+      await this.load()
+    }
+  }
+
+  async close(): Promise<void> {
+    if (!this.isOpen) {
+      return
+    }
+
+    this.isOpen = false
+    await this.db.close()
   }
 
   start(): void {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -247,12 +247,14 @@ export class Blockchain {
     return genesisHeader
   }
 
-  async open(options: { upgrade?: boolean } = { upgrade: true }): Promise<void> {
+  async open(
+    options: { upgrade?: boolean; load?: boolean } = { upgrade: true, load: true },
+  ): Promise<void> {
     if (this.opened) {
       return
     }
-    this.opened = true
 
+    this.opened = true
     await this.db.open()
 
     if (options.upgrade) {

--- a/ironfish/src/utils/node.ts
+++ b/ironfish/src/utils/node.ts
@@ -12,7 +12,7 @@ import { PromiseUtils } from './promise'
 async function waitForOpen(
   node: IronfishNode,
   abort?: null | (() => boolean),
-  options?: { upgrade?: boolean },
+  options: { upgrade?: boolean; load?: boolean } = { upgrade: true, load: true },
 ): Promise<void> {
   let logged = false
 


### PR DESCRIPTION
When we are not upgrading the data version, it means we are doing a
migration which means data should not be loaded.