### PR TITLE
Fix deprecated use of rmDir

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -78,8 +78,8 @@ export default class Reset extends IronfishCommand {
     cli.action.start('Deleting databases')
 
     await Promise.all([
-      fsAsync.rmdir(node.config.accountDatabasePath, { recursive: true }),
-      fsAsync.rmdir(node.config.chainDatabasePath, { recursive: true }),
+      fsAsync.rm(node.config.accountDatabasePath, { recursive: true }),
+      fsAsync.rm(node.config.chainDatabasePath, { recursive: true }),
     ])
 
     cli.action.status = `Importing ${accounts.length} accounts`


### PR DESCRIPTION
```
DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
    at emitRecursiveRmdirWarning (node:internal/fs/utils:816:13)
    at Object.rmdir (node:internal/fs/promises:542:5)
    at Reset.start (/Users/jspafford/projects/fish/ironfish-cli/build/commands/reset.js:48:32)
    at async Reset.run (/Users/jspafford/projects/fish/ironfish-cli/build/command.js:22:13)
    at async Reset._run (/Users/jspafford/projects/fish/node_modules/@oclif/command/lib/command.js:43:20)
    at async Config.runCommand (/Users/jspafford/projects/fish/node_modules/@oclif/config/lib/config.js:173:24)
    at async Main.run (/Users/jspafford/projects/fish/node_modules/@oclif/command/lib/main.js:27:9)
    at async Main._run (/Users/jspafford/projects/fish/node_modules/@oclif/command/lib/command.js:43:20)
```