### PR TITLE
Fix miner's fee transactions re-entering the mempool

### DIFF
--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -113,10 +113,16 @@ export class MemPool {
     for (const transaction of block.transactions) {
       const hash = transaction.hash()
 
-      if (!this.transactions.has(hash)) {
-        await this.addTransaction(transaction)
-        addedTransactions++
+      if (this.transactions.has(hash)) {
+        continue
       }
+
+      if (await transaction.isMinersFee()) {
+        continue
+      }
+
+      await this.addTransaction(transaction)
+      addedTransactions++
     }
 
     this.logger.debug(`Added ${addedTransactions} transactions`)


### PR DESCRIPTION
When blocks are disconnected, miner's fee transactions were getting added to the mempool, which then caused a block verification error when creating a block in the mining director.

