### PR TITLE
Update rmdirSync to rmSync

### DIFF
--- a/ironfish-cli/jest.setup.js
+++ b/ironfish-cli/jest.setup.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 
 module.exports = async () => {
   if (fs.existsSync('./testdbs')) {
-    fs.rmdirSync('./testdbs', { recursive: true })
+    fs.rmSync('./testdbs', { recursive: true })
   }
 
   fs.mkdirSync('./testdbs')

--- a/ironfish/jest.setup.js
+++ b/ironfish/jest.setup.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 
 module.exports = async () => {
   if (fs.existsSync('./testdbs')) {
-    fs.rmdirSync('./testdbs', { recursive: true })
+    fs.rmSync('./testdbs', { recursive: true })
   }
 
   fs.mkdirSync('./testdbs')


### PR DESCRIPTION
There's a deprecation warning for rmdirSync on Node 16, so we can swap over to using rmSync now.
