### PR TITLE
Reset accounts when accounts head does not exist in the chain

### DIFF
--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -51,6 +51,19 @@ describe('Accounts', () => {
     expect(getTransactionsSpy).toBeCalledTimes(8)
   }, 8000)
 
+  it('should reset when headHash does not exist in chain', async () => {
+    const { node, strategy } = nodeTest
+    strategy.disableMiningReward()
+
+    const resetSpy = jest.spyOn(node.accounts, 'reset').mockImplementation()
+    jest.spyOn(node.accounts, 'eventLoop').mockImplementation(() => Promise.resolve())
+
+    node.accounts['headHash'] = '0'
+
+    await node.accounts.start()
+    expect(resetSpy).toBeCalledTimes(1)
+  }, 8000)
+
   it('should handle transaction created on fork', async () => {
     const { node: nodeA } = await nodeTest.createSetup()
     const { node: nodeB } = await nodeTest.createSetup()

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1105,9 +1105,8 @@ export class Blockchain {
       to = this.head
     }
 
-    if (!to || !from) {
-      return
-    }
+    Assert.isNotNull(from, `Expected 'from' not to be null`)
+    Assert.isNotNull(to, `Expected 'to' not to be null`)
 
     for await (const header of this.iterateTo(from, to, tx)) {
       for await (const transaction of this.iterateBlockTransactions(header, tx)) {

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -268,7 +268,7 @@ export class IronfishNode {
       this.metrics.start()
     }
 
-    this.accounts.start()
+    await this.accounts.start()
     this.peerNetwork.start()
 
     if (this.config.get('enableRpc')) {


### PR DESCRIPTION
If the accounts head does not exist in the chain, the accounts will currently fail to update the head or rescan transactions.

This updates the reset command to also clear the accounts head, and also throws errors when a header could not be found for a given block. Also, on startup, it checks whether the accounts head exists on chain and resets if not.
