### PR TITLE
Fix readme typo: Typescript => TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Once your environment is setup - you can run the CLI by following [these directi
 
 ## Structure of the repository
 
- - [ironfish](./ironfish/README.md): The library that contains the IronfishSDK and all Ironfish code written in Typescript.
+ - [ironfish](./ironfish/README.md): The library that contains the IronfishSDK and all Ironfish code written in TypeScript.
  - [ironfish-cli](./ironfish-cli/README.md): The main client for Iron Fish as of today. It is a command line interface built on Node. More details on [our documentation](https://ironfish.network/docs/onboarding/iron-fish-tutorial).
  - [ironfish-rust](./ironfish-rust/README.md): Core API for interacting with the transactions and chain and using ZKP.
  - [ironfish-rust-nodejs](./ironfish-rust-nodejs/README.md): Wrapper for `ironfish-rust` as a native NodeJS addon.


### PR DESCRIPTION
https://www.typescriptlang.org/