### PR TITLE
stop setting block hash to upper case in link

### DIFF
--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -71,7 +71,7 @@ export class MinedCommand extends IronfishCommand {
         const amount = MathUtils.round(oreToIron(block.minersFee), 2)
 
         const link = linkText(
-          `https://explorer.ironfish.network/blocks/${block.hash.toUpperCase()}`,
+          `https://explorer.ironfish.network/blocks/${block.hash}`,
           'view in web',
         )
 


### PR DESCRIPTION
hyperlink does not work when the hash is capitalized