### PR TITLE
Adjust text on miners:mined

### DIFF
--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -43,7 +43,7 @@ export class MinedCommand extends IronfishCommand {
     const { args } = this.parse(MinedCommand)
     const client = await this.sdk.connectRpc()
 
-    this.log('Scanning for mined blocks')
+    this.log('Scanning for mined blocks...')
 
     const stream = client.exportMinedStream({
       start: args.start as number | null,
@@ -51,13 +51,13 @@ export class MinedCommand extends IronfishCommand {
     })
 
     const { start, stop } = await AsyncUtils.first(stream.contentStream())
-    this.log(`Exporting mined block from ${start} -> ${stop}`)
+    this.log(`Scanning for mined blocks from ${start} -> ${stop}`)
 
     const speed = new Meter()
 
     const progress = cli.progress({
       format:
-        'Exporting blocks: [{bar}] {value}/{total} {percentage}% | ETA: {estimate} | SEQ {sequence}',
+        'Scanning blocks: [{bar}] {value}/{total} {percentage}% | ETA: {estimate} | SEQ {sequence}',
     }) as ProgressBar
 
     speed.start()


### PR DESCRIPTION
Clear up potential confusion around `miners:mined` as we are not exporting blocks when running this command.