### PR TITLE
Change max synced age ms to use block time

### DIFF
--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -28,7 +28,7 @@ export const GENESIS_SUPPLY_IN_IRON = 42000000
 /**
  * The oldest the tip should be before we consider the chain synced
  */
-export const MAX_SYNCED_AGE_MS = 60 * 1000
+export const MAX_SYNCED_AGE_MS = 12 * 60 * 60 * 1000
 
 /**
  * The maximum allowed requested blocks by the network


### PR DESCRIPTION
This was originally meant to be 4x block time, but since we changed the
block time, this is out of sync. It's causing people to no longer be in
sync much more frequently with our slower block times.