### PR TITLE
Do not include invalidSpend blocks to mined stats

### DIFF
--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -458,14 +458,14 @@ export class MiningDirector {
       }) has ${block.transactions.length} transactions`,
     )
 
-    this.blocksMined++
-
     const { isAdded, reason } = await this.chain.addBlock(block)
 
     if (!isAdded) {
       this.logger.error(`Failed to add mined block to chain with reason ${String(reason)}`)
       return MINED_RESULT.ADD_FAILED
     }
+
+    this.blocksMined++
 
     this.onNewBlock.emit(block)
 


### PR DESCRIPTION
Fixes #649. The blocks mined but invalid due to the 'invalidSpend' are still added to the stats (see below: X), causing confusion. This will fix the output of the status command: 

./ironfish status: 

Version              0.1.9 @ src
Node                 STARTED
Mining               STARTED - 1 miners, X mined
...



