### PR TITLE
Redundant allocation when sending headerBytes to workers

### DIFF
--- a/ironfish/src/mining/mineHeader.ts
+++ b/ironfish/src/mining/mineHeader.ts
@@ -15,7 +15,7 @@ export function mineHeader({
   job,
 }: {
   miningRequestId: number
-  headerBytesWithoutRandomness: Buffer
+  headerBytesWithoutRandomness: Uint8Array
   initialRandomness: number
   targetValue: string
   batchSize: number

--- a/ironfish/src/workerPool/tasks/mineHeader.ts
+++ b/ironfish/src/workerPool/tasks/mineHeader.ts
@@ -8,7 +8,7 @@ import { mineHeader } from '../../mining/mineHeader'
 export type MineHeaderRequest = {
   type: 'mineHeader'
   batchSize: number
-  headerBytesWithoutRandomness: Uint8Array
+  headerBytesWithoutRandomness: Buffer
   initialRandomness: number
   miningRequestId: number
   targetValue: string
@@ -33,7 +33,7 @@ export function handleMineHeader(
 ): MineHeaderResponse {
   const result = mineHeader({
     batchSize,
-    headerBytesWithoutRandomness: Buffer.from(headerBytesWithoutRandomness),
+    headerBytesWithoutRandomness,
     initialRandomness,
     miningRequestId,
     targetValue,

--- a/ironfish/src/workerPool/tasks/mineHeader.ts
+++ b/ironfish/src/workerPool/tasks/mineHeader.ts
@@ -8,7 +8,7 @@ import { mineHeader } from '../../mining/mineHeader'
 export type MineHeaderRequest = {
   type: 'mineHeader'
   batchSize: number
-  headerBytesWithoutRandomness: Buffer
+  headerBytesWithoutRandomness: Uint8Array
   initialRandomness: number
   miningRequestId: number
   targetValue: string


### PR DESCRIPTION
According to [Buffer API](https://nodejs.org/api/buffer.html#static-method-bufferfromarray), Buffer.from() copies the passed buffer data onto a new Buffer instance if the argument is Uint8Array. When we send headerBytes to the worker, it is casted to Uint8Array and then we call Buffer.from(). It seems unnecessary and we can keep it in Buffer. 