### PR TITLE
Use lower case hash in explorer links

### DIFF
--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -71,7 +71,7 @@ export class MinedCommand extends IronfishCommand {
         const amount = MathUtils.round(oreToIron(block.minersFee), 2)
 
         const link = linkText(
-          `https://explorer.ironfish.network/blocks/${block.hash.toUpperCase()}`,
+          `https://explorer.ironfish.network/blocks/${block.hash}`,
           'view in web',
         )
 


### PR DESCRIPTION
Lower case [works](https://explorer.ironfish.network/blocks/000000000072a6dee9200ab0fd60764a432b074cc594d84236172815bdb069dc) while upper case [doesn't](https://explorer.ironfish.network/blocks/000000000072A6DEE9200AB0FD60764A432B074CC594D84236172815BDB069DC).