### PR TITLE
Fix mined stats and logs for forks

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -318,14 +318,13 @@ export class Blockchain {
     reason: VerificationResultReason | null
     score: number | null
   }> {
-    let isFork = null
+    let connectResult = null
     try {
-      await this.db.transaction(async (tx) => {
+      connectResult = await this.db.transaction(async (tx) => {
         const hash = block.header.recomputeHash()
 
         if (!this.hasGenesisBlock && block.header.sequence === GENESIS_BLOCK_SEQUENCE) {
-          await this.connect(block, null, tx)
-          return
+          return await this.connect(block, null, tx)
         }
 
         if (this.isInvalid(block)) {
@@ -350,20 +349,20 @@ export class Blockchain {
           throw new VerifyError(VerificationResultReason.ORPHAN)
         }
 
-        await this.connect(block, previous, tx)
-
-        isFork = !this.head.hash.equals(block.header.hash)
+        const connectResult = await this.connect(block, previous, tx)
 
         await this.resolveOrphans(block)
+
+        return connectResult
       })
     } catch (e) {
       if (e instanceof VerifyError) {
-        return { isAdded: false, isFork: isFork, reason: e.reason, score: e.score }
+        return { isAdded: false, isFork: null, reason: e.reason, score: e.score }
       }
       throw e
     }
 
-    return { isAdded: true, isFork: isFork, reason: null, score: null }
+    return { isAdded: true, isFork: connectResult.isFork, reason: null, score: null }
   }
 
   /**
@@ -524,13 +523,15 @@ export class Blockchain {
     block: Block,
     prev: BlockHeader | null,
     tx: IDatabaseTransaction,
-  ): Promise<void> {
+  ): Promise<{ isFork: boolean }> {
     const start = BenchUtils.start()
 
     const work = block.header.target.toDifficulty()
     block.header.work = (prev ? prev.work : BigInt(0)) + work
 
-    if (!this.isEmpty && !isBlockHeavier(block.header, this.head)) {
+    const isFork = !this.isEmpty && !isBlockHeavier(block.header, this.head)
+
+    if (isFork) {
       await this.addForkToChain(block, prev, tx)
     } else {
       await this.addHeadToChain(block, prev, tx)
@@ -550,6 +551,8 @@ export class Blockchain {
           ` time: ${addTime.toFixed(1)}ms`,
       )
     }
+
+    return { isFork: isFork }
   }
 
   private async disconnect(block: Block, tx: IDatabaseTransaction): Promise<void> {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -237,7 +237,7 @@ export class Blockchain {
 
     const result = await this.addBlock(genesis)
     Assert.isTrue(result.isAdded, `Could not seed genesis: ${result.reason || 'unknown'}`)
-    Assert.isTrue(result.isFork === false)
+    Assert.isEqual(result.isFork, false)
 
     const genesisHeader = await this.getHeaderAtSequence(GENESIS_BLOCK_SEQUENCE)
     Assert.isNotNull(
@@ -523,7 +523,8 @@ export class Blockchain {
   private async connect(
     block: Block,
     prev: BlockHeader | null,
-    tx: IDatabaseTransaction): Promise<void> {
+    tx: IDatabaseTransaction,
+  ): Promise<void> {
     const start = BenchUtils.start()
 
     const work = block.header.target.toDifficulty()

--- a/ironfish/src/mining/director.test.slow.ts
+++ b/ironfish/src/mining/director.test.slow.ts
@@ -290,6 +290,7 @@ describe('Mining director', () => {
 
       jest.spyOn(chain, 'addBlock').mockResolvedValue({
         isAdded: false,
+        isFork: null,
         reason: VerificationResultReason.INVALID_TARGET,
         score: 0,
       })

--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -463,18 +463,22 @@ export class MiningDirector {
       return MINED_RESULT.INVALID_BLOCK
     }
 
-    this.logger.info(
-      `Successfully mined block ${block.header.hash.toString('hex')} (${
-        block.header.sequence
-      }) has ${block.transactions.length} transactions`,
-    )
-
-    const { isAdded, reason } = await this.chain.addBlock(block)
+    const { isAdded, reason, isFork } = await this.chain.addBlock(block)
 
     if (!isAdded) {
       this.logger.error(`Failed to add mined block to chain with reason ${String(reason)}`)
       return MINED_RESULT.ADD_FAILED
     }
+
+    if (isFork) {
+      return MINED_RESULT.FORK
+    }
+
+    this.logger.info(
+      `Successfully mined block ${block.header.hash.toString('hex')} (${
+        block.header.sequence
+      }) has ${block.transactions.length} transactions`,
+    )
 
     this.blocksMined++
 
@@ -550,5 +554,6 @@ export enum MINED_RESULT {
   CHAIN_CHANGED = 'CHAIN_CHANGED',
   INVALID_BLOCK = 'INVALID_BLOCK',
   ADD_FAILED = 'ADD_FAILED',
+  FORK = 'FORK',
   SUCCESS = 'SUCCESS',
 }


### PR DESCRIPTION
## Summary
There is too much confusion about whether we (as testnet users) have mined a block successfully or not. The reason is mostly about the logs. Ironfish logs the following message for the failed blocks as well. 
> _Successfully mined block 00000000076ef9860eba6ba1009946f9d6f3573e3f5ad2d0fdeb06177a6ade01 (15879) has 2 transactions_

miners:mined is also accurate, but it is very slow and occasionally hangs. That's why it is really important for users to easily understand whether they mine or not. 

This PR fixes this issue. When we log the 'Successfully mined block' message, it is now always accurate. 'status' command will also give the accurate stats for the current run.

Addressing #702.

## Testing Plan

## Breaking Change
```
[ ] Yes
```
