### PR TITLE
Fix codecov token upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         run: yarn test:coverage
 
       - name: Upload coverage
+        if: github.repository == 'iron-fish/ironfish'
         run: CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} ROOT_PATH=$GITHUB_WORKSPACE/ yarn coverage:upload
 
   testslow:
@@ -86,4 +87,5 @@ jobs:
         run: yarn test:slow:coverage
 
       - name: Upload coverage
+        if: github.repository == 'iron-fish/ironfish'
         run: CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} ROOT_PATH=$GITHUB_WORKSPACE/ yarn coverage:upload

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -92,7 +92,6 @@ jobs:
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2.1.0
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-rust-nodejs
 
       # fmt
@@ -137,7 +136,6 @@ jobs:
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2.1.0
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-rust-wasm
 
       # fmt


### PR DESCRIPTION
## Summary

Attempt to fix codecov upload failing on PRs from forks.

The codecov action doesn't require a token for public repositories, so that's why I deleted the token from Rust CI. We should try out the github action for codecov upload for the JS CI when we have some time.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
