### PR TITLE
Set maximum node workers to 6 using new option "nodeWorkersMax"

### DIFF
--- a/ironfish-cli/src/commands/workers/status.ts
+++ b/ironfish-cli/src/commands/workers/status.ts
@@ -50,7 +50,6 @@ export default class Status extends IronfishCommand {
 
       const response = this.sdk.client.getWorkersStatusStream()
       for await (const value of response.contentStream()) {
-        statusText.clearBaseLine(0)
         statusText.setContent(renderStatus(value))
         screen.render()
       }
@@ -74,6 +73,5 @@ function renderStatus(content: GetWorkersStatusResponse): string {
     )}\n`
   }
 
-  return `Workers              ${workersStatus}
-  ${status}`
+  return `Workers: ${workersStatus}\n${status}`
 }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -75,6 +75,10 @@ export type ConfigOptions = {
    * consumption.
    */
   nodeWorkers: number
+  /**
+   * The max number of node workers. See config "nodeWorkers"
+   */
+  nodeWorkersMax: number
   p2pSimulateLatency: number
   peerPort: number
   rpcTcpHost: string
@@ -156,6 +160,7 @@ export class Config extends KeyStore<ConfigOptions> {
       blockGraffiti: '',
       nodeName: '',
       nodeWorkers: -1,
+      nodeWorkersMax: 6,
       p2pSimulateLatency: 0,
       peerPort: DEFAULT_WEBSOCKET_PORT,
       rpcTcpHost: 'localhost',

--- a/ironfish/src/mining/miner.ts
+++ b/ironfish/src/mining/miner.ts
@@ -40,7 +40,7 @@ export class Miner {
   private randomness = 0
 
   constructor(numTasks: number, batchSize = 10000) {
-    this.workerPool = new WorkerPool({ maxWorkers: numTasks })
+    this.workerPool = new WorkerPool({ numWorkers: numTasks })
     this.batchSize = batchSize
     this.hashRate = new Meter()
   }
@@ -102,7 +102,7 @@ export class Miner {
     // Reset our search space
     this.randomness = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
 
-    for (let i = 0; i < this.workerPool.maxWorkers; i++) {
+    for (let i = 0; i < this.workerPool.numWorkers; i++) {
       this.tasks[this.randomness] = this.workerPool.mineHeader(
         request.miningRequestId,
         request.bytes,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -169,7 +169,7 @@ export class IronfishNode {
     if (workers === -1) {
       workers = os.cpus().length - 1
     }
-    const workerPool = new WorkerPool({ metrics, maxWorkers: workers })
+    const workerPool = new WorkerPool({ metrics, numWorkers: workers })
 
     strategyClass = strategyClass || Strategy
     const strategy = new strategyClass(workerPool)

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -168,6 +168,11 @@ export class IronfishNode {
     let workers = config.get('nodeWorkers')
     if (workers === -1) {
       workers = os.cpus().length - 1
+
+      const maxWorkers = config.get('nodeWorkersMax')
+      if (maxWorkers !== -1) {
+        workers = Math.min(workers, maxWorkers)
+      }
     }
     const workerPool = new WorkerPool({ metrics, numWorkers: workers })
 

--- a/ironfish/src/workerPool/pool.test.ts
+++ b/ironfish/src/workerPool/pool.test.ts
@@ -36,7 +36,7 @@ describe('Worker Pool', () => {
   })
 
   it('if pool is empty, executes on main thread', async () => {
-    pool = new WorkerPool({ maxWorkers: 0 })
+    pool = new WorkerPool({ numWorkers: 0 })
     pool.start()
 
     expect(pool.workers.length).toBe(0)
@@ -45,7 +45,7 @@ describe('Worker Pool', () => {
   })
 
   it('executes in worker', async () => {
-    pool = new WorkerPool({ maxWorkers: 1 })
+    pool = new WorkerPool({ numWorkers: 1 })
     pool.start()
 
     expect(pool.workers.length).toBe(1)
@@ -54,7 +54,7 @@ describe('Worker Pool', () => {
   }, 10000)
 
   it('aborts job in worker', async () => {
-    pool = new WorkerPool({ maxWorkers: 1 })
+    pool = new WorkerPool({ numWorkers: 1 })
     pool.start()
 
     expect(pool.workers.length).toBe(1)
@@ -109,7 +109,7 @@ describe('Worker Pool', () => {
   }, 10000)
 
   it('handles job error', async () => {
-    pool = new WorkerPool({ maxWorkers: 1 })
+    pool = new WorkerPool({ numWorkers: 1 })
     pool.start()
 
     let job = pool.sleep(0, 'test')
@@ -138,7 +138,7 @@ describe('Worker Pool', () => {
   }, 10000)
 
   it('should queue up job', () => {
-    pool = new WorkerPool({ maxWorkers: 1, maxJobs: 0 })
+    pool = new WorkerPool({ numWorkers: 1, maxJobs: 0 })
     pool.start()
 
     expect(pool.workers.length).toBe(1)

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -29,7 +29,7 @@ import { getWorkerPath, Worker } from './worker'
 export class WorkerPool {
   readonly maxJobs: number
   readonly maxQueue: number
-  readonly maxWorkers: number
+  readonly numWorkers: number
 
   queue: Array<Job> = []
   workers: Array<Worker> = []
@@ -73,11 +73,11 @@ export class WorkerPool {
 
   constructor(options?: {
     metrics?: MetricsMonitor
-    maxWorkers?: number
+    numWorkers?: number
     maxQueue?: number
     maxJobs?: number
   }) {
-    this.maxWorkers = options?.maxWorkers ?? 1
+    this.numWorkers = options?.numWorkers ?? 1
     this.maxJobs = options?.maxJobs ?? 1
     this.maxQueue = options?.maxQueue ?? 200
     this.change = options?.metrics?.addMeter() ?? null
@@ -93,7 +93,7 @@ export class WorkerPool {
 
     const path = getWorkerPath()
 
-    for (let i = 0; i < this.maxWorkers; i++) {
+    for (let i = 0; i < this.numWorkers; i++) {
       const worker = new Worker({ path, maxJobs: this.maxJobs })
       this.workers.push(worker)
     }


### PR DESCRIPTION
## Summary
We're making this change because many users with very high core
machines are running out of memory because our node is spawning too many
workers. This is causing their machine to run out of memory more than
they expect.

Based on our optimizations I don't think anyone needs to use more than 6
workers. They are mostly idle all the time now. In the case that the
user needs more they can set "nodeWorkersMax" to -1 to disable the cap
completely.

This only is used when auto scaling is used, because we always respect the
end users desired worker configuration if they set it manually.

## Testing Plan

Ran the code, and checked how many workers were created. I also set it to -1 to ensure it still auto scaled up.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
