### PR TITLE
feat: clarify when chain changes your mine block is lost

### DIFF
--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -440,7 +440,12 @@ export class MiningDirector {
     this.recentBlocks.remove(miningRequestId)
 
     if (!this.chain.head || !block.header.previousBlockHash.equals(this.chain.head.hash)) {
-      this.logger.debug('Discarding block that no longer attaches to heaviest head')
+      this.logger.info(
+        `Discarding mined block ${block.header.hash.toString('hex')} (${
+          block.header.sequence
+        }) that no longer attaches to heaviest head`
+      )
+
       return MINED_RESULT.CHAIN_CHANGED
     }
 


### PR DESCRIPTION
## Summary

Clarified wording when you mine a block, but it is not accepted due to the chain being ahead already. This should help with a lot of the "I mined a block but don't see it" questions.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
