### PR TITLE
Changing max message size for both websocket and

### DIFF
--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -39,7 +39,7 @@ export const MAX_REQUESTED_BLOCKS = 50
  * Max size for a message, for instance when requesting batches of blocks
  * TODO 256MB is way too big
  */
-export const MAX_MESSAGE_SIZE = 268435456 //256mb
+export const MAX_MESSAGE_SIZE = 256 * 1024 * 1024
 
 /**
  * The average time that all blocks should be mined

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -36,6 +36,12 @@ export const MAX_SYNCED_AGE_MS = 12 * 60 * 60 * 1000
 export const MAX_REQUESTED_BLOCKS = 50
 
 /**
+ * Max size for a message, for instance when requesting batches of blocks
+ * TODO 256MB is way too big
+ */
+export const MAX_MESSAGE_SIZE = 268435456 //256mb
+
+/**
  * The average time that all blocks should be mined
  *
  * NOTE: This is not used in target calculation, or IRON_FISH_YEAR_IN_BLOCKS.

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -6,12 +6,12 @@ import type { Logger } from '../../../logger'
 import colors from 'colors/safe'
 import nodeDataChannel from 'node-datachannel'
 import { Assert } from '../../../assert'
+import { MAX_MESSAGE_SIZE } from '../../../consensus'
 import { Event } from '../../../event'
 import { MetricsMonitor } from '../../../metrics'
 import { LooseMessage, NodeMessageType, parseMessage } from '../../messages'
 import { Connection, ConnectionDirection, ConnectionType } from './connection'
 import { NetworkError } from './errors'
-import { MAX_MESSAGE_SIZE } from '../../../consensus'
 
 export type SignalData =
   | {

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -11,6 +11,7 @@ import { MetricsMonitor } from '../../../metrics'
 import { LooseMessage, NodeMessageType, parseMessage } from '../../messages'
 import { Connection, ConnectionDirection, ConnectionType } from './connection'
 import { NetworkError } from './errors'
+import { MAX_MESSAGE_SIZE } from '../../../consensus'
 
 export type SignalData =
   | {
@@ -73,6 +74,7 @@ export class WebRtcConnection extends Connection {
     // TODO: Use our own STUN servers
     this.peer = new nodeDataChannel.PeerConnection('peer', {
       iceServers: ['stun:stun.l.google.com:19302', 'stun:global.stun.twilio.com:3478'],
+      maxMessageSize: MAX_MESSAGE_SIZE,
     })
 
     this.setState({ type: 'CONNECTING' })

--- a/ironfish/src/network/webSocketServer.ts
+++ b/ironfish/src/network/webSocketServer.ts
@@ -4,13 +4,14 @@
 
 import http from 'http'
 import WSWebSocket from 'ws'
+import { MAX_MESSAGE_SIZE } from '../consensus/consensus'
 
 export class WebSocketServer {
   // The server instance
   readonly server: WSWebSocket.Server
 
   constructor(ctor: typeof WSWebSocket.Server, port: number) {
-    this.server = new ctor({ port })
+    this.server = new ctor({ port, maxPayload: MAX_MESSAGE_SIZE })
   }
 
   /**


### PR DESCRIPTION
## Summary
This past weekend a lot of people reported not being able to sync (see https://github.com/iron-fish/ironfish/issues/725 for instance). The problem is that some blocks are starting to get beefy, and when you sync in batches of 20 blocks that message size exceeds the default webrtc max message size. 

This PR sets the max message size for both our webrtc and websocket connections to 256MB to alleviate the problem for now. The real fix is to make sure our batch size doesn't exceed a certain size, which will come later. 

## Testing Plan

Tested locally for both webrtc and websocket connections 

## Breaking Change

No
