### PR TITLE
Allow syncer to sync with peers even when synced

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -16,7 +16,7 @@ import { Strategy } from './strategy'
 import { BenchUtils, ErrorUtils, HashUtils, MathUtils, SetTimeoutToken } from './utils'
 import { ArrayUtils } from './utils/array'
 
-const SYNCER_TICK_MS = 4 * 1000
+const SYNCER_TICK_MS = 10 * 1000
 const LINEAR_ANCESTOR_SEARCH = 3
 const REQUEST_BLOCKS_PER_MESSAGE = 20
 
@@ -104,7 +104,7 @@ export class Syncer {
       return
     }
 
-    if (this.state === 'idle' && !this.chain.synced) {
+    if (this.state === 'idle') {
       this.findPeer()
     }
 


### PR DESCRIPTION
## Summary
This issue was introduced in
https://github.com/iron-fish/ironfish/pull/647 which moved our sync
time definition back 10 hours. This solved another issue, but now when
people become synced they are suddenly stuck because the syncer won't
run anymore.

This is an experimental change, but it allows the syncer to run at any
time when someone has more work than us. Remember, that gossip also
still kicks off a sync as well.

## Testing Plan
Ran locally for awhile to test, but I am only syncing one block at a time because of the syncing bug outlined in the current issues. So I haven't been able to see what happens when you are fully synced.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

[ ] Yes
[x] No
