### PR TITLE
Don't require async predicate in AsyncUtils.find

### DIFF
--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -503,7 +503,7 @@ export class MiningDirector {
 
     for (const transaction of this.memPool.get()) {
       const conflicted = await AsyncUtils.find(transaction.spends(), (spend) => {
-        return Promise.resolve(nullifiers.has(spend.nullifier))
+        return nullifiers.has(spend.nullifier)
       })
 
       if (conflicted) {

--- a/ironfish/src/utils/async.ts
+++ b/ironfish/src/utils/async.ts
@@ -38,7 +38,7 @@ export class AsyncUtils {
 
   static async find<T>(
     iter: Iterable<T> | AsyncIterable<T>,
-    predicate: (item: T) => Promise<boolean>,
+    predicate: ((item: T) => boolean) | ((item: T) => Promise<boolean>),
   ): Promise<T | undefined> {
     for await (const item of iter) {
       if (await predicate(item)) {


### PR DESCRIPTION
## Summary
Just a simple fix that allows you to not half to return a promise in the
predicate.

## Testing Plan
Run lint

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

 * [ ] Yes
 * [x] No
