### PR TITLE
Allow for Multiple Receipts in Transactions

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.test.ts
+++ b/ironfish-cli/src/commands/accounts/pay.test.ts
@@ -10,8 +10,30 @@ describe('accounts:pay command', () => {
 
   const ironFishSdkBackup = ironfishmodule.IronfishSdk.init
 
+  const fee = 1
+  const amount = 2
+  const to =
+    '997c586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed'
+  const from =
+    '197c586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed'
+  const memo = 'test memo for a transaction'
+  const hash =
+    'aaaa586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed'
+
   beforeEach(() => {
-    sendTransaction = jest.fn().mockReturnValue({ content: {} })
+    sendTransaction = jest.fn().mockReturnValue({
+      content: {
+        receives: [
+          {
+            publicAddress: to,
+            amount,
+            memo,
+          },
+        ],
+        fromAccountName: from,
+        hash,
+      },
+    })
 
     ironfishmodule.IronfishSdk.init = jest.fn().mockImplementation(() => {
       const client = {
@@ -31,14 +53,6 @@ describe('accounts:pay command', () => {
     sendTransaction.mockReset()
     ironfishmodule.IronfishSdk.init = ironFishSdkBackup
   })
-
-  const fee = 1
-  const amount = 2
-  const to =
-    '997c586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed'
-  const from =
-    '197c586852d1b12da499bcff53595ba37d04e4909dbdb1a75f3bfd90dd7212217a1c2c0da652d187fc52ed'
-  const memo = 'test memo for a transaction'
 
   test
     .stub(cli, 'confirm', () => async () => await Promise.resolve(true))

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -210,7 +210,9 @@ ${displayIronAmountWithCurrency(
       stopProgressBar()
 
       const transaction = result.content
-      const recipients = transaction.receives.map((receive) => receive.publicAddress).join(', ')
+      const recipients = transaction.receives
+        ?.map((receive) => receive.publicAddress)
+        .join(', ')
       this.log(`
 Sending ${displayIronAmountWithCurrency(amount, true)} to ${recipients} from ${
         transaction.fromAccountName

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -210,9 +210,7 @@ ${displayIronAmountWithCurrency(
       stopProgressBar()
 
       const transaction = result.content
-      const recipients = transaction.receives
-        ?.map((receive) => receive.publicAddress)
-        .join(', ')
+      const recipients = transaction.receives.map((receive) => receive.publicAddress).join(', ')
       this.log(`
 Sending ${displayIronAmountWithCurrency(amount, true)} to ${recipients} from ${
         transaction.fromAccountName

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -195,10 +195,14 @@ ${displayIronAmountWithCurrency(
 
     try {
       const result = await client.sendTransaction({
-        amount: ironToOre(amount).toString(),
         fromAccountName: from,
-        memo: memo,
-        toPublicKey: to,
+        receives: [
+          {
+            publicAddress: to,
+            amount: ironToOre(amount).toString(),
+            memo: memo,
+          },
+        ],
         fee: ironToOre(fee).toString(),
         expirationSequence,
       })
@@ -206,8 +210,9 @@ ${displayIronAmountWithCurrency(
       stopProgressBar()
 
       const transaction = result.content
+      const recipients = transaction.receives.map((receive) => receive.publicAddress).join(', ')
       this.log(`
-Sending ${displayIronAmountWithCurrency(amount, true)} to ${transaction.toPublicKey} from ${
+Sending ${displayIronAmountWithCurrency(amount, true)} to ${recipients} from ${
         transaction.fromAccountName
       }
 Transaction Hash: ${transaction.hash}

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -157,10 +157,14 @@ export default class Faucet extends IronfishCommand {
 
     const tx = await client.sendTransaction({
       fromAccountName: account,
-      toPublicKey: faucetTransaction.public_key,
-      amount: BigInt(FAUCET_AMOUNT).toString(),
+      receives: [
+        {
+          publicAddress: faucetTransaction.public_key,
+          amount: BigInt(FAUCET_AMOUNT).toString(),
+          memo: `Faucet for ${faucetTransaction.id}`,
+        },
+      ],
       fee: BigInt(FAUCET_FEE).toString(),
-      memo: `Faucet for ${faucetTransaction.id}`,
     })
 
     speed.add(1)

--- a/ironfish/src/account/accounts.test.slow.ts
+++ b/ironfish/src/account/accounts.test.slow.ts
@@ -163,10 +163,14 @@ describe('Accounts', () => {
     const transaction = await node.accounts.pay(
       node.memPool,
       account,
-      BigInt(2),
+      [
+        {
+          publicAddress: generateKey().public_address,
+          amount: BigInt(2),
+          memo: '',
+        },
+      ],
       BigInt(0),
-      '',
-      generateKey().public_address,
       node.config.get('defaultTransactionExpirationSequenceDelta'),
       0,
     )
@@ -228,10 +232,14 @@ describe('Accounts', () => {
     const transaction = await node.accounts.pay(
       node.memPool,
       account,
-      BigInt(2),
+      [
+        {
+          publicAddress: generateKey().public_address,
+          amount: BigInt(2),
+          memo: '',
+        },
+      ],
       BigInt(0),
-      '',
-      generateKey().public_address,
       node.config.get('defaultTransactionExpirationSequenceDelta'),
     )
 
@@ -268,10 +276,14 @@ describe('Accounts', () => {
       node.accounts.pay(
         node.memPool,
         account,
-        BigInt(2),
+        [
+          {
+            publicAddress: generateKey().public_address,
+            amount: BigInt(2),
+            memo: '',
+          },
+        ],
         BigInt(0),
-        '',
-        generateKey().public_address,
         node.config.get('defaultTransactionExpirationSequenceDelta'),
         1,
       ),
@@ -319,10 +331,14 @@ describe('Accounts', () => {
     const transaction = await node.accounts.pay(
       node.memPool,
       account,
-      BigInt(2),
+      [
+        {
+          publicAddress: generateKey().public_address,
+          amount: BigInt(2),
+          memo: '',
+        },
+      ],
       BigInt(0),
-      '',
-      generateKey().public_address,
       1,
     )
 
@@ -388,10 +404,14 @@ describe('Accounts', () => {
       // Generate a transaction from account A to account B
       const transaction = await nodeA.accounts.createTransaction(
         accountA,
+        [
+          {
+            publicAddress: accountB.publicAddress,
+            amount: BigInt(1),
+            memo: '',
+          },
+        ],
         BigInt(1),
-        BigInt(1),
-        '',
-        accountB.publicAddress,
         0,
       )
 
@@ -414,10 +434,14 @@ describe('Accounts', () => {
     await expect(
       nodeA.accounts.createTransaction(
         accountA,
+        [
+          {
+            publicAddress: accountC.publicAddress,
+            amount: BigInt(1),
+            memo: '',
+          },
+        ],
         BigInt(1),
-        BigInt(1),
-        '',
-        accountC.publicAddress,
         0,
       ),
     ).resolves.toBeTruthy()
@@ -516,10 +540,14 @@ describe('Accounts', () => {
         // Generate a transaction from account A to account B
         const transaction = await nodeA.accounts.createTransaction(
           accountA,
-          BigInt(2),
+          [
+            {
+              publicAddress: accountB.publicAddress,
+              amount: BigInt(2),
+              memo: '',
+            },
+          ],
           BigInt(0),
-          '',
-          accountB.publicAddress,
           0,
         )
 
@@ -613,10 +641,14 @@ describe('Accounts', () => {
         // Generate a transaction from account A to account B
         const transaction = await nodeB.accounts.createTransaction(
           accountA,
-          BigInt(2),
+          [
+            {
+              publicAddress: accountB.publicAddress,
+              amount: BigInt(2),
+              memo: '',
+            },
+          ],
           BigInt(0),
-          '',
-          accountB.publicAddress,
           0,
         )
 

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -689,10 +689,8 @@ export class Accounts {
   async pay(
     memPool: MemPool,
     sender: Account,
-    amount: bigint,
+    receives: { publicAddress: string; amount: bigint; memo: string }[],
     transactionFee: bigint,
-    memo: string,
-    receiverPublicAddress: string,
     defaultTransactionExpirationSequenceDelta: number,
     expirationSequence?: number | null,
   ): Promise<Transaction> {
@@ -709,10 +707,8 @@ export class Accounts {
 
     const transaction = await this.createTransaction(
       sender,
-      amount,
+      receives,
       transactionFee,
-      memo,
-      receiverPublicAddress,
       expirationSequence,
     )
 

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -725,15 +725,16 @@ export class Accounts {
 
   async createTransaction(
     sender: Account,
-    amount: bigint,
+    receives: { publicAddress: string; amount: bigint; memo: string }[],
     transactionFee: bigint,
-    memo: string,
-    receiverPublicAddress: string,
     expirationSequence: number,
   ): Promise<Transaction> {
     this.assertHasAccount(sender)
 
-    let amountNeeded = amount + transactionFee
+    // TODO: If we're spending from multiple accounts, we need to figure out a
+    // way to split the transaction fee. - deekerno
+    let amountNeeded =
+      receives.reduce((acc, receive) => acc + receive.amount, BigInt(0)) + transactionFee
 
     const notesToSpend: Array<{ note: Note; witness: NoteWitness }> = []
     const unspentNotes = this.getUnspentNotes(sender)
@@ -811,13 +812,7 @@ export class Accounts {
         authPath: n.witness.authenticationPath,
         rootHash: n.witness.rootHash,
       })),
-      [
-        {
-          publicAddress: receiverPublicAddress,
-          amount,
-          memo,
-        },
-      ],
+      receives,
       expirationSequence,
     )
   }

--- a/ironfish/src/primitives/transaction.test.slow.ts
+++ b/ironfish/src/primitives/transaction.test.slow.ts
@@ -64,10 +64,14 @@ describe('Accounts', () => {
 
     const transaction = await nodeA.accounts.createTransaction(
       accountA,
+      [
+        {
+          publicAddress: accountB.publicAddress,
+          amount: BigInt(1),
+          memo: '',
+        },
+      ],
       BigInt(1),
-      BigInt(1),
-      '',
-      accountB.publicAddress,
       0,
     )
     expect(await transaction.isMinersFee()).toBe(false)

--- a/ironfish/src/rpc/routes/transactions/__fixtures__/sendTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/transactions/__fixtures__/sendTransaction.test.ts.fixture
@@ -12,5 +12,19 @@
       "type": "Buffer",
       "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALBF0lzbKbZVkbD/G/UMmceJdp1XJoGlRiQ0+HBbSs1rK0FrcUQM0rMiIersFG75fKj1FzJ7AbkfIU/NUwGRNx8x8HAv4ZvU/5vfLfanh2O38iD1PqyzXHrKtlaeT8R51BLxlvzT0hAbULSZttHXaj3yr/lKVvJeYcJ3D7YZznxTVc3YtfiTOYRLsivMvYNg9q9d8aZkSwFHgNkG6ooJm49Jn6aHW8Cl7UZFfG8k59OVWVeQXfuz2UdfkzyUnPpAAjEPa2m3/+R4JFdtFHMJ36jTGSO+BkqU4N3C5LJG60rxiPjkplIacQ4fcMjOCE7PbYDjzUz4sivacIvgLOoeaQAFznos9VWBY1X6lD/N0rl3pTOfbJgVM6ASFoOLgXeSQ0fygGmroFYm9q6ZY+0y3cVS2M3TWi+0Nnt0xwYGW4JEyUUqXLqeMFr4eMT+7H+6z9lIwLFi3iaDnHai/QN4WEfwURxgqdVgzI7e7/I6/hZYyCW7Au4Z+cnZpDD3udbGiFl2tkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwO+9icMZjnYXZpsoeOm+56z/ovNzFVcaGygJZiv06SNaqDvKFskUrXWdrwxetwbILLvrL99f4EpmUXMoDWKViBg=="
     }
+  ],
+  "Transactions sendTransaction Connected to the network with multiple recipients calls the pay method on the node": [
+    {
+      "name": "account_multi-output",
+      "spendingKey": "85d1c3ec1c2d67441937864f03ff746202cd52418973ff42752d2e389c811e14",
+      "incomingViewKey": "aca00e04cef733a0d7d51f1c8b07cb6fb88b70b6cda7bb8206b587b1fc462504",
+      "outgoingViewKey": "593d45182ba716880e4b133c8517a7c05d67724043d6e242bbfe75a0c13ecc3b",
+      "publicAddress": "f52f0ef34e724c8c8a0533d4c7fab74854279211fab6f989a064eb03fa6bbbdabfe813627452dfd37f9c63",
+      "rescan": null
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJLBqlv3yvMiuhmLsc+s3EIrT8C0/G3pF2DFhDIwHGFaGPOlvO1TiDgHhX/wB/Kv8rRSSfujcYr0G0CosnJCqFVrYQRvgTrShiHajpG+gq9BM/pdacsEhbqFWEwf0kzabgE7cMQeWW2b8bkieWXocVz3PSw4JfCDd7FBnEqdy2zwDTSTBSe6woNMT1ZzpjR8rrT5R2xpuYhyvERQzuEyZVzMTDMufQl03Fz6gLmO01eWEfYZZ/5Rx3T8vofVh1eK+hKzOrEvCyp0nCX5YqMpl3fzDv4zxRznE8Y0AmyR7BaRiCSp57YV8o6r40M9hpnFgTYzvm4dyyK7q7RwAQma+QC3FyNciteBW51UeBlPtTBVlFeqDcZTM3Ve1HXo5m+w6dZW5ySk6cFC3vpFPnKl+xXzgH5j5T9n4yqdR9ORDRZzcUAsfDv7j4NhwVSqXq4HjAAftHf9D7yqOqwz9Ri+75fjOIdDA5DsJpN5FErtOR0PE4bwqxiXIxoBU4H87MeDoRig5EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTd/NN048Du4Xrl7OLBZFBaBr0HgJr3z+IQFV90y23ouHE6KnQRaqTagT6CL+jvQYvA/q3pquAoObtbt/Sd4pAA=="
+    }
   ]
 }

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -7,10 +7,14 @@ import { createRouteTest } from '../../../testUtilities/routeTest'
 import { RequestError } from '../../clients/errors'
 
 const TEST_PARAMS = {
-  amount: BigInt(10).toString(),
   fromAccountName: 'existingAccount',
-  memo: '',
-  toPublicKey: 'test2',
+  receives: [
+    {
+      publicAddress: 'test2',
+      amount: BigInt(10).toString(),
+      memo: '',
+    },
+  ],
   fee: BigInt(1).toString(),
 }
 

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -18,6 +18,23 @@ const TEST_PARAMS = {
   fee: BigInt(1).toString(),
 }
 
+const TEST_PARAMS_MULTI = {
+  fromAccountName: 'existingAccount',
+  receives: [
+    {
+      publicAddress: 'test2',
+      amount: BigInt(10).toString(),
+      memo: '',
+    },
+    {
+      publicAddress: 'test3',
+      amount: BigInt(10).toString(),
+      memo: '',
+    },
+  ],
+  fee: BigInt(1).toString(),
+}
+
 describe('Transactions sendTransaction', () => {
   const routeTest = createRouteTest()
 
@@ -124,5 +141,64 @@ describe('Transactions sendTransaction', () => {
       const result = await routeTest.client.sendTransaction(TEST_PARAMS)
       expect(result.content.hash).toEqual(tx.hash().toString('hex'))
     }, 30000)
+
+    describe('with multiple recipients', () => {
+      it('throws if not enough funds', async () => {
+        routeTest.node.peerNetwork['_isReady'] = true
+        routeTest.chain.synced = true
+
+        try {
+          await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
+        } catch (e: unknown) {
+          if (!(e instanceof RequestError)) {
+            throw e
+          }
+          expect(e.message).toContain(
+            'Your balance is too low. Add funds to your account first',
+          )
+        }
+      })
+
+      it('throws if the confirmed balance is too low', async () => {
+        routeTest.node.peerNetwork['_isReady'] = true
+        routeTest.chain.synced = true
+
+        jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce({
+          unconfirmed: BigInt(21),
+          confirmed: BigInt(0),
+        })
+
+        try {
+          await routeTest.client.sendTransaction(TEST_PARAMS)
+        } catch (e: unknown) {
+          if (!(e instanceof RequestError)) {
+            throw e
+          }
+
+          expect(e.message).toContain(
+            'Please wait a few seconds for your balance to update and try again',
+          )
+        }
+      })
+
+      it('calls the pay method on the node', async () => {
+        routeTest.node.peerNetwork['_isReady'] = true
+        routeTest.chain.synced = true
+        routeTest.node.accounts.pay = jest.fn()
+
+        const account = await useAccountFixture(routeTest.node.accounts, 'account_multi-output')
+        const tx = await useMinersTxFixture(routeTest.node.accounts, account)
+
+        jest.spyOn(routeTest.node.accounts, 'pay').mockResolvedValue(tx)
+
+        jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce({
+          unconfirmed: BigInt(21),
+          confirmed: BigInt(21),
+        })
+
+        const result = await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
+        expect(result.content.hash).toEqual(tx.hash().toString('hex'))
+      }, 30000)
+    })
   })
 })

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.ts
@@ -93,7 +93,6 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
     const sum =
       transaction.receives.reduce((acc, receive) => acc + BigInt(receive.amount), BigInt(0)) +
       BigInt(transaction.fee)
-    // const sum = BigInt(transaction.amount) + BigInt(transaction.fee)
 
     if (balance.confirmed < sum && balance.unconfirmed < sum) {
       throw new ValidationError(

--- a/ironfish/src/testUtilities/fixtures.ts
+++ b/ironfish/src/testUtilities/fixtures.ts
@@ -219,10 +219,14 @@ export async function useTxFixture(
     (() => {
       return accounts.createTransaction(
         from,
-        BigInt(1),
+        [
+          {
+            publicAddress: to.publicAddress,
+            amount: BigInt(1),
+            memo: '',
+          },
+        ],
         fee ?? BigInt(0),
-        '',
-        to.publicAddress,
         0,
       )
     })
@@ -318,10 +322,14 @@ export async function useBlockWithTx(
 
     const transaction = await node.accounts.createTransaction(
       from,
+      [
+        {
+          publicAddress: to.publicAddress,
+          amount: BigInt(1),
+          memo: '',
+        },
+      ],
       BigInt(1),
-      BigInt(1),
-      '',
-      to.publicAddress,
       0,
     )
 


### PR DESCRIPTION
## Summary
This PR continues from prior work in allowing for multiple outputs in transactions. It was not necessary to adjust transactions at the native code level and the worker pool already had multiple recipients. This is also the first step in allowing for bulk faucet transactions, which should speed up faucet processing considerably.

## Testing Plan
Tests have been adjusted to use the `receives` object (originally present in `createTransaction.ts` in the worker pool module) in the transaction request object; all tests pass locally.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```