### PR TITLE
Remove verifier.verifyNewBlock

### DIFF
--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -49,34 +49,6 @@ describe('Verifier', () => {
   describe('Block', () => {
     const nodeTest = createNodeTest()
 
-    it('extracts a valid block', async () => {
-      const block = await useMinerBlockFixture(nodeTest.chain)
-      const serialized = nodeTest.strategy.blockSerde.serialize(block)
-
-      const result = await nodeTest.node.chain.verifier.verifyNewBlock(
-        serialized,
-        nodeTest.node.workerPool,
-      )
-
-      expect(result.block.header.hash.equals(block.header.hash)).toBe(true)
-
-      expect(result.serializedBlock.header.previousBlockHash).toEqual(
-        serialized.header.previousBlockHash,
-      )
-    })
-
-    it('rejects a invalid network block', async () => {
-      // should have invalid target
-      nodeTest.verifier.enableVerifyTarget = true
-
-      const block = await useMinerBlockFixture(nodeTest.chain)
-      const serializedBlock = nodeTest.chain.strategy.blockSerde.serialize(block)
-
-      await expect(
-        nodeTest.chain.verifier.verifyNewBlock(serializedBlock, nodeTest.node.workerPool),
-      ).rejects.toEqual('Block is invalid')
-    })
-
     it('rejects a block with an invalid header', async () => {
       // should have invalid target
       nodeTest.verifier.enableVerifyTarget = true

--- a/ironfish/src/testUtilities/mocks.ts
+++ b/ironfish/src/testUtilities/mocks.ts
@@ -16,8 +16,15 @@ export function mockAccounts(): any {
   }
 }
 
+export function mockVerifier(): any {
+  return {
+    verifyNewTransaction: jest.fn().mockResolvedValue({}),
+  }
+}
+
 export function mockChain(): any {
   return {
+    verifier: mockVerifier(),
     head: { hash: 'mockhash', sequence: 1, work: BigInt(0) },
     synced: true,
   }
@@ -34,6 +41,7 @@ export function mockNode(): any {
     miningDirector: mockDirector(),
     syncer: mockSyncer(),
     workerPool: mockWorkerPool(),
+    chain: mockChain(),
   }
 }
 


### PR DESCRIPTION
## Summary
This code was only being used in tests, also the tests were still passing even though the tested function was not called anymore. So I altered the tests so they would fail in this case.

## Testing Plan
Ran tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

 * [ ] Yes
 * [x] No

