### PR TITLE
Reduce MAX_SYNCED_AGE_MS to 5 hours

### DIFF
--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -28,7 +28,7 @@ export const GENESIS_SUPPLY_IN_IRON = 42000000
 /**
  * The oldest the tip should be before we consider the chain synced
  */
-export const MAX_SYNCED_AGE_MS = 12 * 60 * 60 * 1000
+export const MAX_SYNCED_AGE_MS = 5 * 60 * 60 * 1000
 
 /**
  * The maximum allowed requested blocks by the network


### PR DESCRIPTION
## Summary
Maybe 12 hours was too much. If we fix syncing issues it should be a bit
better, but let's try to tune this lower now with the invalid spend fix.

## Testing Plan
Ran the syncer for a bit

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
