### PR TITLE
Bump network version to 12

### DIFF
--- a/ironfish/src/network/version.ts
+++ b/ironfish/src/network/version.ts
@@ -2,5 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const VERSION_PROTOCOL = 11
-export const VERSION_PROTOCOL_MIN = 11
+export const VERSION_PROTOCOL = 12
+export const VERSION_PROTOCOL_MIN = 12


### PR DESCRIPTION
## Summary
Bump network version to 12 and make the required version 12 too. We want to test if the latest protocol fixes change syncing, so we should require people to upgrade to know.

## Testing Plan
---

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
[ ] No
```
