### PR TITLE
redundant line breaks in the log of invalid blocks

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -458,9 +458,7 @@ export class Syncer {
           peer.displayName
         } sent an invalid block. score: ${score}, hash: ${HashUtils.renderHash(
           block.header.hash,
-        )} (
-          ${Number(block.header.sequence)}
-        ), reason: ${reason}`,
+        )} (${Number(block.header.sequence)}), reason: ${reason}`,
       )
 
       peer.punish(score, reason)


### PR DESCRIPTION
redundant line breaks in the log of invalid blocks
This issue was introduced in #776 
There are redundant line breaks in the log of invalid blocks, affecting readability

This solved the issue.

## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

 * [ ] Yes
 * [x] No
