### PR TITLE
Revert "Make breaking change into check boxes (#756)"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,5 +7,7 @@
 Is this a breaking change? If yes, add notes below on why this is breaking and
 what additional work is required, if any.
 
- * [ ] Yes
- * [ ] No
+```
+[ ] Yes
+[ ] No
+```


### PR DESCRIPTION
## Summary

This reverts commit 5321de01e6635b621e28db8af597bb053432a34e.

Github interprets these check boxes as tasks, so we'll revert this change.

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
