### PR TITLE
Allow for Bulk Faucet Transactions

### DIFF
--- a/ironfish-cli/scripts/run-network-macos.sh
+++ b/ironfish-cli/scripts/run-network-macos.sh
@@ -21,7 +21,6 @@ CWD="$(pwd)"
 NODE1="yarn start:once start -v -p 9034 -n peer1 -b localhost:9033 --datadir ~/.ironfish1"
 NODE2="yarn start:once start -v -p 9035 -n peer2 -b localhost:9033 --datadir ~/.ironfish2 --no-listen"
 NODE3="yarn start:once start -v -p 9036 -n peer3 -b localhost:9033 --datadir ~/.ironfish3 --no-listen"
-# MINER="yarn start:once miners:start --datadir=~/.ironfish1"
 NODE2_LIST="yarn start:once peers:list -fenas --datadir ~/.ironfish1"
 
 osascript <<END
@@ -56,17 +55,6 @@ osascript <<END
   tell application "System Events"
     tell process "Terminal" to keystroke "t" using command down
   end tell
-
-  # tell application "Terminal"
-  #   activate
-  #   do script "cd $CWD && $MINER" in selected tab of the front window
-  #   delay 0.5
-  #   activate
-  # end tell
-
-  # tell application "System Events"
-  #   tell process "Terminal" to keystroke "t" using command down
-  # end tell
 
   tell application "Terminal"
     activate

--- a/ironfish-cli/scripts/run-network-macos.sh
+++ b/ironfish-cli/scripts/run-network-macos.sh
@@ -18,9 +18,10 @@ rm -rf ~/.ironfish2/databases
 rm -rf ~/.ironfish3/databases
 
 CWD="$(pwd)"
-NODE1="yarn start:once start -v -p 9034 -w -n peer1 -b localhost:9033 --datadir ~/.ironfish1"
-NODE2="yarn start:once start -v -p 9035 -w -n peer2 -b localhost:9033 --datadir ~/.ironfish2 --no-listen"
-NODE3="yarn start:once start -v -p 9036 -w -n peer3 -b localhost:9033 --datadir ~/.ironfish3 --no-listen"
+NODE1="yarn start:once start -v -p 9034 -n peer1 -b localhost:9033 --datadir ~/.ironfish1"
+NODE2="yarn start:once start -v -p 9035 -n peer2 -b localhost:9033 --datadir ~/.ironfish2 --no-listen"
+NODE3="yarn start:once start -v -p 9036 -n peer3 -b localhost:9033 --datadir ~/.ironfish3 --no-listen"
+# MINER="yarn start:once miners:start --datadir=~/.ironfish1"
 NODE2_LIST="yarn start:once peers:list -fenas --datadir ~/.ironfish1"
 
 osascript <<END
@@ -55,6 +56,17 @@ osascript <<END
   tell application "System Events"
     tell process "Terminal" to keystroke "t" using command down
   end tell
+
+  # tell application "Terminal"
+  #   activate
+  #   do script "cd $CWD && $MINER" in selected tab of the front window
+  #   delay 0.5
+  #   activate
+  # end tell
+
+  # tell application "System Events"
+  #   tell process "Terminal" to keystroke "t" using command down
+  # end tell
 
   tell application "Terminal"
     activate

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -186,9 +186,11 @@ export default class Faucet extends IronfishCommand {
     speed.add(1)
 
     this.log(
-      `COMPLETING: ${JSON.stringify(faucetTransactions, ['id', 'public_key'], '   ')} ${
-        tx.content.hash
-      } (5m avg ${speed.rate5m.toFixed(2)})`,
+      `COMPLETING: ${JSON.stringify(
+        faucetTransactions,
+        ['id', 'public_key', 'started_at'],
+        '   ',
+      )} ${tx.content.hash} (5m avg ${speed.rate5m.toFixed(2)})`,
     )
 
     for (const faucetTransaction of faucetTransactions) {

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -147,7 +147,7 @@ export default class Faucet extends IronfishCommand {
 
     this.warnedFund = false
 
-    const faucetTransactions = await api.getNextFaucetTransaction(
+    const faucetTransactions = await api.getNextFaucetTransactions(
       MAX_RECIPIENTS_PER_TRANSACTION,
     )
 

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -157,7 +157,13 @@ export default class Faucet extends IronfishCommand {
       return
     }
 
-    this.log(`Starting ${JSON.stringify(faucetTransactions, undefined, '   ')}`)
+    this.log(
+      `Starting ${JSON.stringify(
+        faucetTransactions,
+        ['id', 'public_key', 'started_at'],
+        '   ',
+      )}`,
+    )
 
     for (const faucetTransaction of faucetTransactions) {
       await api.startFaucetTransaction(faucetTransaction.id)
@@ -180,7 +186,7 @@ export default class Faucet extends IronfishCommand {
     speed.add(1)
 
     this.log(
-      `COMPLETING: ${JSON.stringify(faucetTransactions)} ${
+      `COMPLETING: ${JSON.stringify(faucetTransactions, ['id', 'public_key'], '   ')} ${
         tx.content.hash
       } (5m avg ${speed.rate5m.toFixed(2)})`,
     )

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -93,12 +93,12 @@ export class WebApi {
     return response.data
   }
 
-  async getNextFaucetTransaction(): Promise<FaucetTransaction | null> {
+  async getNextFaucetTransaction(count: number): Promise<FaucetTransaction[] | null> {
     this.requireToken()
 
     try {
-      const response = await axios.get<FaucetTransaction>(
-        `${this.host}/faucet_transactions/next`,
+      const response = await axios.get<FaucetTransaction[]>(
+        `${this.host}/faucet_transactions/next?count=${count}`,
         this.options(),
       )
 

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -93,16 +93,16 @@ export class WebApi {
     return response.data
   }
 
-  async getNextFaucetTransaction(count: number): Promise<FaucetTransaction[] | null> {
+  async getNextFaucetTransactions(count: number): Promise<FaucetTransaction[] | null> {
     this.requireToken()
 
     try {
-      const response = await axios.get<FaucetTransaction[]>(
+      const response = await axios.get<{ object: string; data: FaucetTransaction[] }>(
         `${this.host}/faucet_transactions/next?count=${count}`,
         this.options(),
       )
 
-      return response.data
+      return response.data.data
     } catch (e) {
       if (IsAxiosError(e) && e.response?.status === 404) {
         return null

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -97,7 +97,7 @@ export class WebApi {
     this.requireToken()
 
     try {
-      const response = await axios.get<{ object: string; data: FaucetTransaction[] }>(
+      const response = await axios.get<{ data: FaucetTransaction[] }>(
         `${this.host}/faucet_transactions/next?count=${count}`,
         this.options(),
       )


### PR DESCRIPTION
## Summary
These changes allow the faucet service command to get multiple requests from the API so that faucet transactions can be done in bulk.

## Testing Plan

1. Adjust your configuration with the following values:
-- `getFundsApi`: `'http://localhost:8003/faucet_transactions'`
-- `miningForce`:  true
2. Mock your own chain by doing the following:
-- Adjust `ironfish-cli/scripts/run-network-macos.sh` to include a miner, using `~/.ironfish1` as its data folder
-- Start one node using itself as a bootstrap node:
--- `yarn start:once start -b 127.0.0.1:9033 --datadir=~/batch_faucet_test`
-- Run `run-network-macos.sh` and allow for blocks to be mined on the chain.
3. Set the following environment variables:
-- `IRONFISH_API_HOST="http://localhost:8003"`
-- `IRONFISH_API_TOKEN="test"`
4. Start the Iron Fish API locally using the instructions in its README.
5. Open a terminal and check the balances of the accounts:
-- `yarn start:once accounts:balance --datadir=~/.ironfish2`
-- `yarn start:once accounts:balance --datadir=~/.ironfish3`
6. Send a request from each account to the faucet using one of the other created data folders:
--`yarn start:once faucet --datadir=~/.ironfish2`
--`yarn start:once faucet --datadir=~/.ironfish3`
7. At this time, you can check the `faucet_transactions` table in your local API database using your preferred tool.
-- You should see your pending requests in the table with their public keys corresponding to each data folder.
8. Open up another terminal and run `yarn start:once service:faucet --datadir=~/.ironfish1`. You should then the client connect to the node, fetch your requests from the local API, and batch them into one transaction. The client should then report that there are no faucet jobs as the amount of requests will be smaller than the max requests per transaction (this is set to 5 at this time).
9. Check the balances of the accounts once more; they should have increased by the intended faucet amount (5 ORE at this time).
10. Check the `faucet_transactions` table in your local API database for the two transactions; the requests should have a start date and a completion date, and they should also have the same transaction hash.

You can repeat steps 6-10 to generate more requests than are allowed to be included in a transaction; the client will continue to process them all until there are no more unfulfilled requests. Keep in mind that we enforce a limit on requests per public key or email; if you hit this limit, you can delete the second and third data folders and re-run the network mocking script to recreate a new account.

## Breaking Change

- [ ] Yes
- [x] No

The API currently supports behavior from both prior to this PR (only gets a single faucet request) and after this PR would be merged (gets multiple faucet requests). After this PR is merged, the API will be changed to only allow for multiple requests.