### PR TITLE
Fix passing comma-separated bootstrap nodes to start

### DIFF
--- a/ironfish-cli/src/commands/start.test.ts
+++ b/ironfish-cli/src/commands/start.test.ts
@@ -175,6 +175,40 @@ describe('start command', () => {
       })
   })
 
+  describe('Allows for multiple bootstrap nodes', () => {
+    beforeAll(() => {
+      isFirstRun = false
+      hasGenesisBlock = true
+    })
+    test
+      .stdout()
+      .command(['start', '-b', '127.0.0.1:9033', '-b', '127.0.0.1:9034'])
+      .exit(0)
+      .it('Allows for multiple bootstrap nodes', () => {
+        expect(setOverrideConfig).toHaveBeenCalledWith('bootstrapNodes', [
+          '127.0.0.1:9033',
+          '127.0.0.1:9034',
+        ])
+      })
+  })
+
+  describe('Allows for comma-separated bootstrap nodes', () => {
+    beforeAll(() => {
+      isFirstRun = false
+      hasGenesisBlock = true
+    })
+    test
+      .stdout()
+      .command(['start', '-b', '127.0.0.1:9033, 127.0.0.1:9034'])
+      .exit(0)
+      .it('Allows for comma-separated bootstrap nodes', () => {
+        expect(setOverrideConfig).toHaveBeenCalledWith('bootstrapNodes', [
+          '127.0.0.1:9033',
+          '127.0.0.1:9034',
+        ])
+      })
+  })
+
   describe('with the graffiti override', () => {
     describe('when the graffiti is the same as the config graffiti', () => {
       test

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -121,7 +121,13 @@ export default class Start extends IronfishCommand {
     } = flags
 
     if (bootstrap !== undefined) {
-      this.sdk.config.setOverride('bootstrapNodes', bootstrap.filter(Boolean))
+      // Parse comma-separated bootstrap nodes
+      const bootstrapNodes = bootstrap
+        .flatMap((b) => b.split(','))
+        .filter(Boolean)
+        .map((b) => b.trim())
+
+      this.sdk.config.setOverride('bootstrapNodes', bootstrapNodes)
     }
     if (port !== undefined && port !== this.sdk.config.get('peerPort')) {
       this.sdk.config.setOverride('peerPort', port)


### PR DESCRIPTION
## Summary

The start command docs indicate you can pass comma-separated bootstrap nodes, but trying to do so does not work. Fixed by parsing comma-separated values out of the bootstrap flag.

Fixes #771

## Testing Plan

Added unit tests for the start command.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
