### PR TITLE
Abort the ongoing jobs from the previous request

### DIFF
--- a/ironfish/src/mining/miner.ts
+++ b/ironfish/src/mining/miner.ts
@@ -99,6 +99,9 @@ export class Miner {
     // We don't care about the discarded tasks; they will exit soon enough
     this.tasks = {}
 
+    // Abort the ongoing jobs from the previous mine request
+    this.workerPool.abortJobs()
+
     // Reset our search space
     this.randomness = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
 

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -123,8 +123,7 @@ export class WorkerPool {
   }
 
   abortJobs(): void {
-    this.workers.forEach((worker) => 
-      worker.jobs.forEach((job) => job.abort()))
+    this.workers.forEach((worker) => worker.jobs.forEach((job) => job.abort()))
   }
 
   async createMinersFee(spendKey: string, amount: bigint, memo: string): Promise<Transaction> {

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -123,10 +123,10 @@ export class WorkerPool {
   }
 
   abortJobs(): void {
-    this.workers.forEach(worker => 
-      worker.jobs.forEach(job => job.abort()))
+    this.workers.forEach((worker) => 
+      worker.jobs.forEach((job) => job.abort()))
   }
-  
+
   async createMinersFee(spendKey: string, amount: bigint, memo: string): Promise<Transaction> {
     const request: CreateMinersFeeRequest = {
       type: 'createMinersFee',

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -122,6 +122,11 @@ export class WorkerPool {
     await Promise.all(workers.map((w) => w.stop()))
   }
 
+  abortJobs(): void {
+    this.workers.forEach(worker => 
+      worker.jobs.forEach(job => job.abort()))
+  }
+  
   async createMinersFee(spendKey: string, amount: bigint, memo: string): Promise<Transaction> {
     const request: CreateMinersFeeRequest = {
       type: 'createMinersFee',


### PR DESCRIPTION
## Summary
When a new mine request arrives, we should also discard the ongoing jobs on the workers from the previous request. When the batch size is large, those jobs might be long-running and harm the mining performance. 

## Testing Plan
Existing test suite.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ X] No
```
