### PR TITLE
Use nullifier tree size to verify spend

### DIFF
--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -170,10 +170,10 @@ export class Verifier {
     tx?: IDatabaseTransaction,
   ): Promise<VerificationResult> {
     return this.chain.db.withTransaction(tx, async (tx) => {
-      const noteSize = await this.chain.notes.size(tx)
+      const nullifierSize = await this.chain.nullifiers.size(tx)
 
       for (const spend of transaction.spends()) {
-        const reason = await this.verifySpend(spend, noteSize, tx)
+        const reason = await this.verifySpend(spend, nullifierSize, tx)
         if (reason) {
           return { valid: false, reason }
         }


### PR DESCRIPTION
## Summary
We were using the notes tree size to verifier the spend, which is not
correct but shouldn't generally cause an issue because the note
tree is bigger than the nullifier tree.

## Testing Plan
Run node for awhile

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[] Yes
[X] No
```
