### PR TITLE
Fix Faucet API Request

### DIFF
--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -151,7 +151,7 @@ export default class Faucet extends IronfishCommand {
 
     const faucetTransactions = await api.getNextFaucetTransactions(count)
 
-    if (!faucetTransactions || faucetTransactions.length === 0) {
+    if (faucetTransactions.length === 0) {
       this.log('No faucet jobs, waiting 5s')
       await PromiseUtils.sleep(5000)
       return

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -144,8 +144,8 @@ export default class Faucet extends IronfishCommand {
 
     this.warnedFund = false
 
-    const count = Math.max(
-      Number(BigInt(response.content.confirmed) / BigInt(FAUCET_AMOUNT)),
+    const count = Math.min(
+      Number(BigInt(response.content.confirmed) / BigInt(FAUCET_AMOUNT + FAUCET_FEE)),
       MAX_RECIPIENTS_PER_TRANSACTION,
     )
 

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -2,13 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import axios, { AxiosError, AxiosRequestConfig } from 'axios'
+import axios, { AxiosRequestConfig } from 'axios'
 import { FollowChainStreamResponse } from './rpc/routes/chain/followChain'
-import { HasOwnProperty, UnwrapPromise } from './utils/types'
-
-function IsAxiosError(e: unknown): e is AxiosError {
-  return typeof e === 'object' && e != null && HasOwnProperty(e, 'isAxiosError')
-}
+import { UnwrapPromise } from './utils/types'
 
 type FaucetTransaction = {
   object: 'faucet_transaction'
@@ -29,7 +25,7 @@ export class WebApi {
   getFundsEndpoint: string | null
 
   constructor(options?: { host?: string; token?: string; getFundsEndpoint?: string }) {
-    let host = options?.host ?? 'https://api-production.ironfish.network'
+    let host = options?.host ?? 'https://api.ironfish.network'
 
     if (host.endsWith('/')) {
       host = host.slice(0, -1)
@@ -93,23 +89,15 @@ export class WebApi {
     return response.data
   }
 
-  async getNextFaucetTransactions(count: number): Promise<FaucetTransaction[] | null> {
+  async getNextFaucetTransactions(count: number): Promise<FaucetTransaction[]> {
     this.requireToken()
 
-    try {
-      const response = await axios.get<{ data: FaucetTransaction[] }>(
-        `${this.host}/faucet_transactions/next?count=${count}`,
-        this.options(),
-      )
+    const response = await axios.get<{ data: FaucetTransaction[] }>(
+      `${this.host}/faucet_transactions/next?count=${count}`,
+      this.options(),
+    )
 
-      return response.data.data
-    } catch (e) {
-      if (IsAxiosError(e) && e.response?.status === 404) {
-        return null
-      }
-
-      throw e
-    }
+    return response.data.data
   }
 
   async startFaucetTransaction(id: number): Promise<FaucetTransaction> {


### PR DESCRIPTION
## Summary
The faucet was incorrectly configured to do the max amount of faucet requests possible in a transaction. Practically, we want to have an upper bound to this number. This PR also removes workarounds that were present for the API.

## Testing Plan
Manual testing through each case.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.


- [ ] Yes
- [x] No

