### PR TITLE
Only verify spend root in hasValidSpends

### DIFF
--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -514,11 +514,7 @@ export class MerkleTree<
   /**
    * Check if the tree contained the given element when it was the given size.
    */
-  private async contained(
-    value: E,
-    pastSize: number,
-    tx?: IDatabaseTransaction,
-  ): Promise<boolean> {
+  async contained(value: E, pastSize: number, tx?: IDatabaseTransaction): Promise<boolean> {
     return this.db.withTransaction(tx, async (tx) => {
       const elementIndex = await this.leavesIndex.get(this.hasher.merkleHash(value), tx)
 


### PR DESCRIPTION
This is causing add blocks to fail. It's verifying double spends inside of `hasValidSpends` which is called in `verifyConnectedBlock`. We should only verify the spend root after we connect the block, so it's split out here to do that.

The bug is detailed here:
1. Add block
2. Add nullifiers to chain from spends
3. Verify added block
4. Verify nullifiers don't exist in the chain