### PR TITLE
Switch blake3 to native addon

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -7,9 +7,9 @@
   "main": "build/src",
   "license": "MPL-2.0",
   "dependencies": {
+    "@napi-rs/blake-hash": "1.3.1",
     "axios": "0.21.1",
     "bfilter": "1.0.5",
-    "blake3": "2.1.4",
     "blru": "0.1.6",
     "buffer": "6.0.3",
     "buffer-json": "2.0.0",

--- a/ironfish/src/mining/mineHeader.ts
+++ b/ironfish/src/mining/mineHeader.ts
@@ -22,7 +22,8 @@ export function mineHeader({
   job?: Job
 }): { initialRandomness: number; randomness?: number; miningRequestId?: number } {
   const target = new Target(targetValue)
-  const randomnessBytes = new ArrayBuffer(8)
+  const headerBytes = Buffer.alloc(headerBytesWithoutRandomness.byteLength + 8)
+  headerBytes.set(headerBytesWithoutRandomness, 8)
 
   for (let i = 0; i < batchSize; i++) {
     if (job?.status === 'aborted') {
@@ -34,12 +35,7 @@ export function mineHeader({
       i > Number.MAX_SAFE_INTEGER - initialRandomness
         ? i - (Number.MAX_SAFE_INTEGER - initialRandomness) - 1
         : initialRandomness + i
-    new DataView(randomnessBytes).setFloat64(0, randomness, false)
-
-    const headerBytes = Buffer.concat([
-      Buffer.from(randomnessBytes),
-      headerBytesWithoutRandomness,
-    ])
+    headerBytes.writeDoubleBE(randomness, 0)
 
     const blockHash = hashBlockHeader(headerBytes)
 

--- a/ironfish/src/primitives/nullifier.ts
+++ b/ironfish/src/primitives/nullifier.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { createKeyed } from 'blake3'
+import { Blake3Hasher } from '@napi-rs/blake-hash'
 import { MerkleHasher } from '../merkletree'
 import { BufferSerde, NullifierSerdeInstance } from '../serde'
 
@@ -22,16 +22,16 @@ export class NullifierHasher implements MerkleHasher<Nullifier, NullifierHash, s
   }
 
   merkleHash(element: Nullifier): NullifierHash {
-    const hasher = createKeyed(NULLIFIER_KEY)
+    const hasher = Blake3Hasher.newKeyed(NULLIFIER_KEY)
     hasher.update(element)
-    return hasher.digest()
+    return hasher.digestBuffer()
   }
 
   combineHash(depth: number, left: NullifierHash, right: NullifierHash): NullifierHash {
-    const hasher = createKeyed(COMBINE_KEY)
-    hasher.update([depth])
+    const hasher = Blake3Hasher.newKeyed(COMBINE_KEY)
+    hasher.update(Buffer.from([depth]))
     hasher.update(left)
     hasher.update(right)
-    return hasher.digest()
+    return hasher.digestBuffer()
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,6 +1208,90 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@napi-rs/blake-hash-android-arm-eabi@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-android-arm-eabi/-/blake-hash-android-arm-eabi-1.3.1.tgz#5494bc755b1f89eca347a4a34175dd80e896f729"
+  integrity sha512-KdWI58uT4Y4d2SCIZ94XxrhEBFCiJhBQer4ZV3JMNZ7dJSl5423iF60yzg9JMqbiyv0k3bdEo6DeWSONul0Iug==
+
+"@napi-rs/blake-hash-android-arm64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-android-arm64/-/blake-hash-android-arm64-1.3.1.tgz#192fec518fea2fec2a9c632cf2f5db56fb3fbb98"
+  integrity sha512-vYRkG4ZwiK7ooseDJ9lYYT1tktbsv/QH/F0dPZiGnTToUstECwuk9qoMNUea7GtUY1XDjYg3oWkJ80jhfp1fMg==
+
+"@napi-rs/blake-hash-darwin-arm64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-darwin-arm64/-/blake-hash-darwin-arm64-1.3.1.tgz#6dd45230faff79a817005abd02ba6063e3465afe"
+  integrity sha512-IPvjzVjYbiF6+LSnX7a7odFCzV3bHfm3LiJWukIRzwNW2wXO/WmCRfbsNNZEwkwfa2P1lyCVawgzRym7kHYarw==
+
+"@napi-rs/blake-hash-darwin-x64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-darwin-x64/-/blake-hash-darwin-x64-1.3.1.tgz#2899b561f655c96d7fcf94ba0aab4c240e9df9cb"
+  integrity sha512-44kHNqSEWTNLRiS0JO4FRYKQBF1ODQwcRJWpPvnIe3P8B+/CNXGj8ljIxLNuKh90zAvPu8dxSXVylwAvsrB5GQ==
+
+"@napi-rs/blake-hash-freebsd-x64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-freebsd-x64/-/blake-hash-freebsd-x64-1.3.1.tgz#262364bce7361c32db90c7d87d1d8913042380fa"
+  integrity sha512-1eRrawhLi/e1YXjEqTU+rKRtwPa1MIdeXPguMcF8QTxynnN/FM6cEtp4KwJCfUOE2eTtECR7iS/fAl6/QtFxAw==
+
+"@napi-rs/blake-hash-linux-arm-gnueabihf@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-linux-arm-gnueabihf/-/blake-hash-linux-arm-gnueabihf-1.3.1.tgz#b063f1c3a152e62bcfb462d7d7645c46c57c2a1e"
+  integrity sha512-iG3FiFnD+Y2+c5pSZXQHcjCq4rLJADzXxpGBmm4VoiSrdvLejqzFI7ew/aMTTBf31CjGxs7//xmuDi3dg8Jm4w==
+
+"@napi-rs/blake-hash-linux-arm64-gnu@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-linux-arm64-gnu/-/blake-hash-linux-arm64-gnu-1.3.1.tgz#c01cdc32986eccc5680e229977f325e554340e11"
+  integrity sha512-9XdMKSj0Zbk2qNgAIuygbVhmT3/S9MRH7lVnYVseYI8MSI5gXzMQPp1uwxQx592ashfehja7KKK+aHs4+V0eow==
+
+"@napi-rs/blake-hash-linux-arm64-musl@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-linux-arm64-musl/-/blake-hash-linux-arm64-musl-1.3.1.tgz#88c6bf6e01e212738c6684b1b887c1af9d962b89"
+  integrity sha512-e7uVxJKuhIY4EPTyOQrEd6j6a2jOjdyiYaIChEsF0ptv6GsKjhCVwh2DTimQOeBzk36DwKLdilWmrK0X1DtSsA==
+
+"@napi-rs/blake-hash-linux-x64-gnu@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-linux-x64-gnu/-/blake-hash-linux-x64-gnu-1.3.1.tgz#5a5407c7f85b2913a546a25380669b99ec3ec4e3"
+  integrity sha512-uYmauh/qs5pBUg7jbADd8WHHHFVocFY3s2uUhjv+91zgaNpdjFJa1XoSMmuoxo56FpsSZ5eudRoTcL6q0nw10w==
+
+"@napi-rs/blake-hash-linux-x64-musl@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-linux-x64-musl/-/blake-hash-linux-x64-musl-1.3.1.tgz#8f0534af9d0056a3d9374854be3e5ac072395353"
+  integrity sha512-pQxZfxYfPG+1rZE7R0TbocEzFnrDFhA7Iaz535ztKtI0umP3mOFlbB5fAVI+CxZrv2bg3Ar4LsIGTLs8ZWmqrg==
+
+"@napi-rs/blake-hash-win32-arm64-msvc@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-win32-arm64-msvc/-/blake-hash-win32-arm64-msvc-1.3.1.tgz#9f1fc847735d1505687973ca2dbb9692c4f41548"
+  integrity sha512-k0aPdl8zPYHrpAIV/hWnsT3YnIWaOHE91MSbXGJD+ZJ6qpuHRIu3joCrUnit0g+NTEKUTfqDtWpkjpcFcjAr6g==
+
+"@napi-rs/blake-hash-win32-ia32-msvc@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-win32-ia32-msvc/-/blake-hash-win32-ia32-msvc-1.3.1.tgz#f1d3eedfcabc9b173355d806aef610570ca55e84"
+  integrity sha512-Qw50YPzzwNwSEa8IcRQcPccar/fvDpqJ5B69A/CWm4c8KOcCaNBve1fHVtZPj3PR98TPhs4M0MCjeQsZYzoS7Q==
+
+"@napi-rs/blake-hash-win32-x64-msvc@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash-win32-x64-msvc/-/blake-hash-win32-x64-msvc-1.3.1.tgz#4f828ccd8f09e316698f81115a88df69d8f5fed8"
+  integrity sha512-4t3nQyquw4nb6eg/wXQ5LH9t3HSM++ZYTUGKu8hmBhiLieSnsJdepa8UIdeLiwgU3Rkxg6PLRjFUL6pmzwTTRQ==
+
+"@napi-rs/blake-hash@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/blake-hash/-/blake-hash-1.3.1.tgz#6a67bad575df309582f62d06258b70842e4e2469"
+  integrity sha512-qmzQopWjupf4V84ZqtsrXcYIeW0w/1x2MbUYw1/NA1qgERqURxleXX6AHb1CCesi6Zl2c/vV3P9CAClWMOpfIA==
+  optionalDependencies:
+    "@napi-rs/blake-hash-android-arm-eabi" "1.3.1"
+    "@napi-rs/blake-hash-android-arm64" "1.3.1"
+    "@napi-rs/blake-hash-darwin-arm64" "1.3.1"
+    "@napi-rs/blake-hash-darwin-x64" "1.3.1"
+    "@napi-rs/blake-hash-freebsd-x64" "1.3.1"
+    "@napi-rs/blake-hash-linux-arm-gnueabihf" "1.3.1"
+    "@napi-rs/blake-hash-linux-arm64-gnu" "1.3.1"
+    "@napi-rs/blake-hash-linux-arm64-musl" "1.3.1"
+    "@napi-rs/blake-hash-linux-x64-gnu" "1.3.1"
+    "@napi-rs/blake-hash-linux-x64-musl" "1.3.1"
+    "@napi-rs/blake-hash-win32-arm64-msvc" "1.3.1"
+    "@napi-rs/blake-hash-win32-ia32-msvc" "1.3.1"
+    "@napi-rs/blake-hash-win32-x64-msvc" "1.3.1"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2450,11 +2534,6 @@ bl@^4.0.3:
     buffer "^5.5.0"
     inherits "^2.0.4"
     readable-stream "^3.4.0"
-
-blake3@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/blake3/-/blake3-2.1.4.tgz#78117bc9e80941097fdf7d03e897a9ee595ecd62"
-  integrity sha512-70hmx0lPd6zmtNwxPT4/1P0pqaEUlTJ0noUBvCXPLfMpN0o8PPaK3q7ZlpRIyhrqcXxeMAJSowNm/L9oi/x1XA==
 
 blessed@0.1.81:
   version "0.1.81"


### PR DESCRIPTION
## Summary

The blake3 package doesn't seem to ship a native addon that works properly in node 16, so let's try blake-hash instead.

## Testing Plan

Manually tested by mining on a chain, and existing tests should pass.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
