### PR TITLE
Fix use of clearLine in miners:mined

### DIFF
--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -10,6 +10,7 @@ import {
   oreToIron,
   TimeUtils,
 } from 'ironfish'
+import readline from 'readline'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -65,8 +66,8 @@ export class MinedCommand extends IronfishCommand {
 
     for await (const { sequence, block } of stream.contentStream()) {
       if (block) {
-        process.stdout.clearLine(-1)
-        process.stdout.cursorTo(0)
+        readline.clearLine(process.stdout, -1)
+        readline.cursorTo(process.stdout, 0)
 
         const amount = MathUtils.round(oreToIron(block.minersFee), 2)
 


### PR DESCRIPTION
## Summary

This fix was suggested by Stack Overflow: https://stackoverflow.com/questions/34570452/node-js-stdout-clearline-and-cursorto-functions#comment80319576_34570694

Fixes #599

## Testing Plan

Manually run miners:mined and check that output is the same.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
