### PR TITLE
Incentivize faucet transaction per number of outputs

### DIFF
--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -180,7 +180,7 @@ export default class Faucet extends IronfishCommand {
     const tx = await client.sendTransaction({
       fromAccountName: account,
       receives,
-      fee: BigInt(FAUCET_FEE).toString(),
+      fee: BigInt(count * FAUCET_FEE).toString(),
     })
 
     speed.add(1)


### PR DESCRIPTION
## Summary
We should incentivize the inclusion of faucet transactions in a block by increasing the fee awarded per output.

## Testing Plan
Manual testing and calculation.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

- [ ] Yes
- [x] No

