### PR TITLE
Update the genesis script to use a pre-existing genesis account

### DIFF
--- a/tools/reset-network-genesis.sh
+++ b/tools/reset-network-genesis.sh
@@ -19,11 +19,8 @@ cd "$(dirname "$0")"
 (
     echo "Regenerating genesis block"
     cd ../ironfish-cli
-    yarn start:once chain:genesisblock
+    yarn start:once chain:genesisblock -a IronFishGenesisAccount
 
     echo ""
     echo "Copy the above block into genesisBlock.ts"
-
-    echo "Exporting Genesis Account for securing"
-    yarn start:once accounts:export IronFishGenesisAccount
 )


### PR DESCRIPTION
## Summary

Generates the genesis block using a pre-existing account rather than creating a new account and exporting it at the end. Has the benefit of making it optional to create a new account when generating a new genesis block.

## Testing Plan

None needed

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
