### PR TITLE
Add token authentication to TCP RPC

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -14,6 +14,7 @@ import {
   RpcTcpSecureFlag,
   RpcTcpSecureFlagKey,
   RpcUseIpcFlag,
+  RpcTcpTokenFlagKey,
   RpcUseIpcFlagKey,
   RpcUseTcpFlag,
   RpcUseTcpFlagKey,
@@ -33,6 +34,7 @@ export type FLAGS =
   | typeof RpcTcpHostFlagKey
   | typeof RpcTcpPortFlagKey
   | typeof RpcTcpSecureFlagKey
+  | typeof RpcTcpTokenFlagKey
   | typeof VerboseFlagKey
 
 export abstract class IronfishCommand extends Command {
@@ -117,6 +119,11 @@ export abstract class IronfishCommand extends Command {
       rpcTcpSecureFlag !== RpcTcpSecureFlag.default
     ) {
       configOverrides.rpcTcpSecure = rpcTcpSecureFlag
+    }
+
+    const rpcTcpTokenFlag = getFlag(flags, RpcTcpTokenFlagKey)
+    if (typeof rpcTcpTokenFlag === 'string') {
+      configOverrides.rpcTcpToken = rpcTcpTokenFlag
     }
 
     const verboseFlag = getFlag(flags, VerboseFlagKey)

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -21,6 +21,7 @@ export const RpcUseTcpFlagKey = 'rpc.tcp'
 export const RpcTcpHostFlagKey = 'rpc.tcp.host'
 export const RpcTcpPortFlagKey = 'rpc.tcp.port'
 export const RpcTcpSecureFlagKey = 'rpc.tcp.secure'
+export const RpcTcpTokenFlagKey = 'rpc.tcp.token'
 
 export const VerboseFlag = flags.boolean({
   char: 'v',
@@ -71,6 +72,10 @@ export const RpcTcpPortFlag = flags.integer({
 export const RpcTcpSecureFlag = flags.boolean({
   default: false,
   description: 'allow sensitive config to be changed over TCP',
+}
+
+export const RpcTcpTokenFlag = flags.string({
+  description: 'the TCP authentication token to require to make requests',
 })
 
 const localFlags: Record<string, IOptionFlag<unknown>> = {}
@@ -94,6 +99,7 @@ remoteFlags[RpcUseIpcFlagKey] = RpcUseIpcFlag as unknown as IOptionFlag<unknown>
 remoteFlags[RpcTcpHostFlagKey] = RpcTcpHostFlag as unknown as IOptionFlag<unknown>
 remoteFlags[RpcTcpPortFlagKey] = RpcTcpPortFlag as unknown as IOptionFlag<unknown>
 remoteFlags[RpcTcpSecureFlagKey] = RpcTcpSecureFlag as unknown as IOptionFlag<unknown>
+remoteFlags[RpcTcpTokenFlagKey] = RpcTcpTokenFlag as unknown as IOptionFlag<unknown>
 
 /**
  * These flags should usually be used on any command that uses an

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -86,6 +86,7 @@ export type ConfigOptions = {
   rpcTcpHost: string
   rpcTcpPort: number
   rpcTcpSecure: boolean
+  rpcTcpToken: string
   rpcRetryConnect: boolean
   /**
    * The maximum number of peers we can be connected to at a time. Past this number,
@@ -179,6 +180,7 @@ export class Config extends KeyStore<ConfigOptions> {
       rpcTcpHost: 'localhost',
       rpcTcpPort: 8020,
       rpcTcpSecure: false,
+      rpcTcpToken: '',
       rpcRetryConnect: false,
       maxPeers: 50,
       minPeers: 1,

--- a/ironfish/src/typedefs/node-ipc.d.ts
+++ b/ironfish/src/typedefs/node-ipc.d.ts
@@ -27,6 +27,11 @@ declare module 'node-ipc' {
     id: IpcSocketId | undefined
     ipcBuffer: string | undefined
 
+    /**
+     * The remote address of the peer. This is only available in TPC mode
+     */
+    remoteAddress?: string
+
     emit(event: name, data: unknown)
     write(data: unknown)
     setEncoding(encoding: string)


### PR DESCRIPTION
## Summary

Add token authentication to TCP RPC. This is still a WIP. We need to time out out clients that don't auth, and also handle the disconnection reason properly.

## Breaking Change
```
[X] Yes
[ ] No
```
Clients will now auth by default, so they won't be able to connect using TCP anymore without setting the key in their commands.