### PR TITLE
Fix facuet using wrong client

### DIFF
--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -65,7 +65,7 @@ export class FaucetCommand extends IronfishCommand {
     })
 
     try {
-      await this.sdk.client.getFunds({
+      await client.getFunds({
         accountName,
         email,
       })


### PR DESCRIPTION
## Summary

If you try to use the faucet when the node is running, it will fail
silently but say it succeeded. This is because connect offline, then try
to connect using IPC and the error is not handled properly.

## Testing Plan
Request from faucet offline and online

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
