### PR TITLE
Small performance improvements to accounts store

### DIFF
--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -24,7 +24,7 @@ describe('Accounts', () => {
     await expect(chain).toAddBlock(blockA1)
 
     await node.accounts.updateHead()
-    expect(node.accounts['headHash']).toEqual(blockA1.header.hash.toString('hex'))
+    expect(node.accounts['headHash']).toEqual(blockA1.header.hash)
     expect(getTransactionsSpy).toBeCalledTimes(2)
 
     // G -> A1 -> A2
@@ -32,7 +32,7 @@ describe('Accounts', () => {
     await expect(chain).toAddBlock(blockA2)
 
     await node.accounts.updateHead()
-    expect(node.accounts['headHash']).toEqual(blockA2.header.hash.toString('hex'))
+    expect(node.accounts['headHash']).toEqual(blockA2.header.hash)
     expect(getTransactionsSpy).toBeCalledTimes(3)
 
     // Add 3 more on a heavier fork. Chain A should be removed first, then chain B added
@@ -47,7 +47,7 @@ describe('Accounts', () => {
     await expect(chain).toAddBlock(blockB3)
 
     await node.accounts.updateHead()
-    expect(node.accounts['headHash']).toEqual(blockB3.header.hash.toString('hex'))
+    expect(node.accounts['headHash']).toEqual(blockB3.header.hash)
     expect(getTransactionsSpy).toBeCalledTimes(8)
   }, 8000)
 
@@ -58,7 +58,7 @@ describe('Accounts', () => {
     const resetSpy = jest.spyOn(node.accounts, 'reset').mockImplementation()
     jest.spyOn(node.accounts, 'eventLoop').mockImplementation(() => Promise.resolve())
 
-    node.accounts['headHash'] = '0'
+    node.accounts['headHash'] = Buffer.from('0')
 
     await node.accounts.start()
     expect(resetSpy).toBeCalledTimes(1)

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -127,18 +127,17 @@ export class Accounts {
         await this.updateHeadHash(chainTail.hash.toString('hex'))
       }
 
-      if (!this.headHash) {
-        throw new Error('headHash should be set previously or to chainTail.hash')
-      }
+      Assert.isNotNull(this.headHash, 'headHash should be set previously or to chainTail.hash')
 
       const accountHeadHash = Buffer.from(this.headHash, 'hex')
+
+      if (chainHead.hash.equals(accountHeadHash)) {
+        return
+      }
+
       const accountHead = await this.chain.getHeader(accountHeadHash)
 
       Assert.isNotNull(accountHead, `Accounts head not found in chain: ${this.headHash}`)
-
-      if (chainHead.hash.equals(accountHead.hash)) {
-        return
-      }
 
       const { fork, isLinear } = await this.chain.findFork(accountHead, chainHead)
       if (!fork) {


### PR DESCRIPTION
## Summary

These are two separate changes that should produce very minor performance improvements to the accounts store. I discovered them while testing nulling out incoming block header hashes.

#### Avoid DB call when accounts head equals chain head

Right now, we call `chain.getHeader` with the accounts head hash, then check the result of that against the chain head hash to see if we need to scan new transactions. But since we already have the account hash, we can check it directly against the chain head hash and early-exit before calling `chain.getHeader`.

#### Cache headHash as a Buffer

We're storing headHash as a string in the accounts DB and caching it as a string on `this.headHash`, but on each event loop, we're converting it from a string to a Buffer in order to pass it to `blockchain.ts`. If we change the type of `this.headHash` to Buffer, we only need to convert it when serializing it to the database and when logging the hash.

## Testing Plan

Tested manually by adding an account with blocks on the chain and syncing to ensure the balance still updates.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
