### PR TITLE
Clear out header hash on incoming blocks

### DIFF
--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -200,11 +200,13 @@ describe('PeerNetwork', () => {
         message: {
           type: NodeMessageType.NewBlock,
           nonce: 'nonce',
-          payload: { block: Buffer.alloc(0) },
+          payload: { block: { header: { hash: '0' } } },
         },
       })
 
-      expect(peerNetwork['node']['syncer'].addNewBlock).toHaveBeenCalled()
+      expect(peerNetwork['node']['syncer'].addNewBlock).toHaveBeenCalledWith(peer, {
+        header: { hash: undefined },
+      })
     })
 
     describe('when the worker pool is saturated', () => {

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -582,6 +582,11 @@ export class PeerNetwork {
       throw new Error(`Invalid GetBlocksResponse: ${message.type}`)
     }
 
+    // Hashes sent by the network are untrusted. Future messages should remove this field.
+    for (const block of response.message.payload.blocks) {
+      block.header.hash = undefined
+    }
+
     return response.message.payload.blocks
   }
 
@@ -759,6 +764,9 @@ export class PeerNetwork {
     if (!peer) {
       return false
     }
+
+    // Hashes sent by the network are untrusted. Future messages should remove this field.
+    block.header.hash = undefined
 
     try {
       return await this.node.syncer.addNewBlock(peer, block)

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -209,7 +209,7 @@ export type SerializedBlockHeader = {
   minersFee: string
 
   work: string
-  hash: string
+  hash?: string
   graffiti: string
 }
 
@@ -269,6 +269,11 @@ export class BlockHeaderSerde implements Serde<BlockHeader, SerializedBlockHeade
   deserialize(data: SerializedBlockHeader): BlockHeader {
     // TODO: this needs to make assertions on the data format
     // as it can be from untrusted sources
+    let hashBuffer
+    if (data.hash) {
+      hashBuffer = Buffer.from(BlockHashSerdeInstance.deserialize(data.hash))
+    }
+
     const header = new BlockHeader(
       this.strategy,
       Number(data.sequence),
@@ -291,7 +296,7 @@ export class BlockHeaderSerde implements Serde<BlockHeader, SerializedBlockHeade
       BigInt(data.minersFee),
       Buffer.from(GraffitiSerdeInstance.deserialize(data.graffiti)),
       data.work ? BigInt(data.work) : BigInt(0),
-      Buffer.from(BlockHashSerdeInstance.deserialize(data.hash)),
+      hashBuffer,
     )
 
     return header


### PR DESCRIPTION
## Summary

Nulls out the hash field on headers of incoming blocks. There's no known bug as a result of this, but we should remove this field in the future because nodes should be calculating it themselves vs. assuming that other nodes have provided a correct hash.

## Testing Plan

Synced a chain from scratch on this PR with an account with transactions

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
