### PR TITLE
Add displayName to Account and log when creating mining transaction

### DIFF
--- a/ironfish-cli/src/commands/accounts/import.ts
+++ b/ironfish-cli/src/commands/accounts/import.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
 import { cli } from 'cli-ux'
-import { Account, JSONUtils, PromiseUtils } from 'ironfish'
+import { JSONUtils, PromiseUtils, SerializedAccount } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -34,7 +34,7 @@ export class ImportCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    let account: Account | null = null
+    let account: SerializedAccount | null = null
     if (importPath) {
       account = await this.importFile(importPath)
     } else if (process.stdin.isTTY) {
@@ -63,13 +63,13 @@ export class ImportCommand extends IronfishCommand {
     }
   }
 
-  async importFile(path: string): Promise<Account> {
+  async importFile(path: string): Promise<SerializedAccount> {
     const resolved = this.sdk.fileSystem.resolve(path)
     const data = await this.sdk.fileSystem.readFile(resolved)
-    return JSONUtils.parse<Account>(data)
+    return JSONUtils.parse<SerializedAccount>(data)
   }
 
-  async importPipe(): Promise<Account> {
+  async importPipe(): Promise<SerializedAccount> {
     let data = ''
 
     const onData = (dataIn: string): void => {
@@ -85,10 +85,10 @@ export class ImportCommand extends IronfishCommand {
 
     process.stdin.off('data', onData)
 
-    return JSONUtils.parse<Account>(data)
+    return JSONUtils.parse<SerializedAccount>(data)
   }
 
-  async importTTY(): Promise<Account> {
+  async importTTY(): Promise<SerializedAccount> {
     const accountName = (await cli.prompt('Enter the account name', {
       required: true,
     })) as string

--- a/ironfish-cli/src/commands/accounts/list.ts
+++ b/ironfish-cli/src/commands/accounts/list.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { flags } from '@oclif/command'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -9,14 +10,18 @@ export class ListCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    displayName: flags.boolean({
+      default: false,
+      description: `Display a hash of the account's read-only keys along with the account name`,
+    }),
   }
 
   async start(): Promise<void> {
-    this.parse(ListCommand)
+    const { flags } = this.parse(ListCommand)
 
     const client = await this.sdk.connectRpc()
 
-    const response = await client.getAccounts()
+    const response = await client.getAccounts({ displayName: flags.displayName })
 
     if (response.content.accounts.length === 0) {
       this.log('you have no accounts')

--- a/ironfish-cli/src/commands/accounts/which.ts
+++ b/ironfish-cli/src/commands/accounts/which.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { flags } from '@oclif/command'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -13,10 +14,14 @@ export class WhichCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    displayName: flags.boolean({
+      default: false,
+      description: `Display a hash of the account's read-only keys along with the account name`,
+    }),
   }
 
   async start(): Promise<void> {
-    this.parse(WhichCommand)
+    const { flags } = this.parse(WhichCommand)
 
     const client = await this.sdk.connectRpc()
 
@@ -24,7 +29,7 @@ export class WhichCommand extends IronfishCommand {
       content: {
         accounts: [accountName],
       },
-    } = await client.getAccounts({ default: true })
+    } = await client.getAccounts({ default: true, displayName: flags.displayName })
 
     if (!accountName) {
       this.log(

--- a/ironfish/src/account/account.ts
+++ b/ironfish/src/account/account.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import MurmurHash3 from 'imurmurhash'
+import { SerializedAccount } from './accountsdb'
+
+export class Account {
+  readonly displayName: string
+  name: string
+  readonly spendingKey: string
+  readonly incomingViewKey: string
+  readonly outgoingViewKey: string
+  publicAddress: string
+  rescan: number | null
+
+  constructor(serializedAccount: SerializedAccount) {
+    this.name = serializedAccount.name
+    this.spendingKey = serializedAccount.spendingKey
+    this.incomingViewKey = serializedAccount.incomingViewKey
+    this.outgoingViewKey = serializedAccount.outgoingViewKey
+    this.publicAddress = serializedAccount.publicAddress
+    this.rescan = serializedAccount.rescan
+
+    const prefixHash = new MurmurHash3(this.spendingKey, 1)
+      .hash(this.incomingViewKey)
+      .hash(this.outgoingViewKey)
+      .result()
+      .toString(16)
+    const hashSlice = prefixHash.slice(0, 7)
+    this.displayName = `${this.name} (${hashSlice})`
+  }
+
+  serialize(): SerializedAccount {
+    return {
+      name: this.name,
+      spendingKey: this.spendingKey,
+      incomingViewKey: this.incomingViewKey,
+      outgoingViewKey: this.outgoingViewKey,
+      publicAddress: this.publicAddress,
+      rescan: this.rescan,
+    }
+  }
+}

--- a/ironfish/src/account/index.ts
+++ b/ironfish/src/account/index.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export * from './account'
 export * from './accounts'
 export * from './validator'
 export * from './accountsdb'

--- a/ironfish/src/account/validator.ts
+++ b/ironfish/src/account/validator.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Account } from './accountsdb'
+import { SerializedAccount } from './accountsdb'
 
 const PUBLIC_ADDRESS_LENGTH = 86
 const SPENDING_KEY_LENGTH = 64
@@ -31,7 +31,7 @@ export function isValidOutgoingViewKey(outgoingViewKey: string): boolean {
   )
 }
 
-export function validateAccount(toImport: Partial<Account>): void {
+export function validateAccount(toImport: Partial<SerializedAccount>): void {
   if (!toImport.name) {
     throw new Error(`Imported account has no name`)
   }

--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -371,7 +371,7 @@ export class MiningDirector {
       this._minerAccount.spendingKey,
     )
 
-    this.logger.info(
+    this.logger.debug(
       `Constructed miner's reward transaction for account ${this._minerAccount.displayName}, block sequence ${newSequence}`,
     )
 

--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -363,10 +363,16 @@ export class MiningDirector {
       totalTransactionFees += transactionFee
     }
 
+    const newSequence = blockHeader.sequence + 1
+
     const minersFee = await this.strategy.createMinersFee(
       totalTransactionFees,
-      blockHeader.sequence + 1,
+      newSequence,
       this._minerAccount.spendingKey,
+    )
+
+    this.logger.info(
+      `Constructed miner's reward transaction for account ${this._minerAccount.displayName}, block sequence ${newSequence}`,
     )
 
     return [minersFee, blockTransactions]

--- a/ironfish/src/rpc/routes/accounts/exportAccount.ts
+++ b/ironfish/src/rpc/routes/accounts/exportAccount.ts
@@ -41,6 +41,6 @@ router.register<typeof ExportAccountRequestSchema, ExportAccountResponse>(
   ExportAccountRequestSchema,
   (request, node): void => {
     const account = getAccount(node, request.data.account)
-    request.end({ account: account })
+    request.end({ account: account.serialize() })
   },
 )

--- a/ironfish/src/rpc/routes/accounts/getAccounts.ts
+++ b/ironfish/src/rpc/routes/accounts/getAccounts.ts
@@ -6,7 +6,7 @@ import { Account } from '../../../account'
 import { ApiNamespace, router } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type GetAccountsRequest = { default?: boolean } | undefined
+export type GetAccountsRequest = { default?: boolean; displayName?: boolean } | undefined
 export type GetAccountsResponse = { accounts: string[] }
 
 export const GetAccountsRequestSchema: yup.ObjectSchema<GetAccountsRequest> = yup
@@ -37,7 +37,7 @@ router.register<typeof GetAccountsRequestSchema, GetAccountsResponse>(
       accounts = node.accounts.listAccounts()
     }
 
-    const names = accounts.map((a) => a.name)
+    const names = accounts.map((a) => (request.data?.displayName ? a.displayName : a.name))
     request.end({ accounts: names })
   },
 )


### PR DESCRIPTION
## Summary

- Create Account class and add displayName field

Adds a displayName field that includes a hash of the account's private+view keys along with the account name. The `displayName` field doesn't necessarily need to be serialized, but only needs to be generated once, so I created a class for Account that loads in a SerializedAccount object.

- Log account when generating mining reward transaction

Adds a log to the mining director when a mining reward transaction is generated, in order to make it clearer which account is generating the transaction.

## Testing Plan

Tested mining on a fresh chain manually.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
