### PR TITLE
Fix ironfish tests on Windows

### DIFF
--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -4,6 +4,7 @@
 
 import type { WorkerRequestMessage, WorkerResponseMessage } from './messages'
 import { generateKey } from 'ironfish-rust-nodejs'
+import path from 'path'
 import { MessagePort, parentPort, Worker as WorkerThread } from 'worker_threads'
 import { Assert } from '../assert'
 import { createRootLogger, Logger } from '../logger'
@@ -174,12 +175,16 @@ if (parentPort !== null) {
 }
 
 export function getWorkerPath(): string {
-  // Works around different paths when run under ts-jest
-  let path = __dirname
+  let workerPath = __dirname
 
-  if (path.includes('ironfish/src/workerPool')) {
-    path = path.replace('ironfish/src/workerPool', 'ironfish/build/src/workerPool')
+  // Works around different paths when run under ts-jest
+  const workerPoolPath = path.join('ironfish', 'src', 'workerPool')
+  if (workerPath.includes(workerPoolPath)) {
+    workerPath = workerPath.replace(
+      workerPoolPath,
+      path.join('ironfish', 'build', 'src', 'workerPool'),
+    )
   }
 
-  return path + '/worker.js'
+  return workerPath + '/worker.js'
 }


### PR DESCRIPTION
## Summary

Fixes the `ironfish` tests on Windows. I think the `ironfish-cli` tests are broken, but they seem a bit more complicated to fix. We should probably run these tests on Windows in CI as well.

## Testing Plan

Tests should pass as normal.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
