### PR TITLE
Export difficulty in chain:export + chain:block

### DIFF
--- a/ironfish/src/rpc/routes/chain/exportChain.ts
+++ b/ironfish/src/rpc/routes/chain/exportChain.ts
@@ -24,6 +24,7 @@ export type ExportChainStreamResponse = {
     graffiti: string
     timestamp: number
     work: string
+    difficulty: string
     head: boolean
     latest: boolean
   }
@@ -49,6 +50,7 @@ export const ExportChainStreamResponseSchema: yup.ObjectSchema<ExportChainStream
         graffiti: yup.string().defined(),
         timestamp: yup.number().defined(),
         work: yup.string().defined(),
+        difficulty: yup.string().defined(),
         head: yup.boolean().defined(),
         latest: yup.boolean().defined(),
       })
@@ -84,6 +86,7 @@ router.register<typeof ExportChainStreamRequestSchema, ExportChainStreamResponse
           graffiti: block.graffiti.toString('ascii'),
           timestamp: block.timestamp.getTime(),
           work: block.work.toString(),
+          difficulty: block.target.toDifficulty().toString(),
           head: block.hash.equals(node.chain.head.hash),
           latest: block.hash.equals(node.chain.latest.hash),
         }

--- a/ironfish/src/rpc/routes/chain/getBlockInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getBlockInfo.ts
@@ -15,6 +15,7 @@ export type GetBlockInfoRequest = {
 export type GetBlockInfoResponse = {
   block: {
     graffiti: string
+    difficulty: string
     hash: string
     previousBlockHash: string
     sequence: number
@@ -46,6 +47,7 @@ export const GetBlockInfoResponseSchema: yup.ObjectSchema<GetBlockInfoResponse> 
     block: yup
       .object({
         graffiti: yup.string().defined(),
+        difficulty: yup.string().defined(),
         hash: yup.string().defined(),
         previousBlockHash: yup.string().defined(),
         sequence: yup.number().defined(),
@@ -132,6 +134,7 @@ router.register<typeof GetBlockInfoRequestSchema, GetBlockInfoResponse>(
     request.status(200).end({
       block: {
         graffiti: header.graffiti.toString('hex'),
+        difficulty: header.target.toDifficulty().toString(),
         hash: header.hash.toString('hex'),
         previousBlockHash: header.previousBlockHash.toString('hex'),
         sequence: Number(header.sequence),

--- a/ironfish/src/rpc/routes/events/types.ts
+++ b/ironfish/src/rpc/routes/events/types.ts
@@ -10,6 +10,8 @@ export type RpcBlock = {
   previousBlockHash: string
   timestamp: number
   transactions: Array<unknown>
+  difficulty: string
+  graffiti: string
 }
 
 export function serializeRpcBlock(block: Block): RpcBlock {
@@ -19,6 +21,8 @@ export function serializeRpcBlock(block: Block): RpcBlock {
     previousBlockHash: block.header.previousBlockHash.toString('hex'),
     timestamp: block.header.timestamp.valueOf(),
     transactions: [],
+    difficulty: block.header.target.toDifficulty().toString(),
+    graffiti: block.header.graffiti.toString('hex'),
   }
 }
 
@@ -29,5 +33,7 @@ export const RpcBlockSchema: yup.ObjectSchema<RpcBlock> = yup
     previousBlockHash: yup.string().defined(),
     timestamp: yup.number().defined(),
     transactions: yup.array().defined(),
+    difficulty: yup.string().defined(),
+    graffiti: yup.string().defined(),
   })
   .defined()


### PR DESCRIPTION
## Summary

Difficulty wasn't sent back in chain:block or export but now it is. This
was requested by jq for ironfishnetwork.com

## Testing Plan

Used the commands

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
