### PR TITLE
Add neg sequence in chain:block to show from head

### DIFF
--- a/ironfish/src/rpc/routes/chain/getBlockInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getBlockInfo.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { GENESIS_BLOCK_SEQUENCE } from '../../../consensus'
 import { BlockHeader } from '../../../primitives'
 import { ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
@@ -89,6 +90,14 @@ router.register<typeof GetBlockInfoRequestSchema, GetBlockInfoResponse>(
       } else {
         request.data.hash = search
       }
+    }
+
+    // Use negative numbers to start from the head of the chain
+    if (request.data.sequence && request.data.sequence < 0) {
+      request.data.sequence = Math.max(
+        node.chain.head.sequence + request.data.sequence + 1,
+        GENESIS_BLOCK_SEQUENCE,
+      )
     }
 
     if (request.data.hash) {


### PR DESCRIPTION
## Summary

You can now pass negative sequences in chain:block to start from the
head. So if you pass -1 you'll now get the head block.

## Testing Plan

Tested commands locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
