### PR TITLE
Move chain:block to blocks:show

### DIFF
--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -5,7 +5,7 @@ import { GraffitiUtils } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
-export default class Block extends IronfishCommand {
+export default class ShowBlock extends IronfishCommand {
   static description = 'Show the block header of a requested hash'
 
   static args = [
@@ -22,7 +22,7 @@ export default class Block extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { args } = this.parse(Block)
+    const { args } = this.parse(ShowBlock)
     const search = args.search as string
 
     const client = await this.sdk.connectRpc()


### PR DESCRIPTION
## Summary
This is more consistent with our other tooling

## Testing Plan
Run 
```js
yarn start:once blocks:show 1
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
[ ] No
```
