### PR TITLE
Fix overly large faucet fee

### DIFF
--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -144,12 +144,12 @@ export default class Faucet extends IronfishCommand {
 
     this.warnedFund = false
 
-    const count = Math.min(
+    const maxPossibleRecipients = Math.min(
       Number(BigInt(response.content.confirmed) / BigInt(FAUCET_AMOUNT + FAUCET_FEE)),
       MAX_RECIPIENTS_PER_TRANSACTION,
     )
 
-    const faucetTransactions = await api.getNextFaucetTransactions(count)
+    const faucetTransactions = await api.getNextFaucetTransactions(maxPossibleRecipients)
 
     if (faucetTransactions.length === 0) {
       this.log('No faucet jobs, waiting 5s')

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -180,7 +180,7 @@ export default class Faucet extends IronfishCommand {
     const tx = await client.sendTransaction({
       fromAccountName: account,
       receives,
-      fee: BigInt(count * FAUCET_FEE).toString(),
+      fee: BigInt(faucetTransactions.length * FAUCET_FEE).toString(),
     })
 
     speed.add(1)


### PR DESCRIPTION
## Summary
Changed fee multiplier to use the length of the faucet transaction payload instead of the count used to query the API to get multiple faucet requests. Prior to this change, it resulted in faucet transactions paying out 50 $ORE (as 50 is our current internal limit) instead of X $ORE where X is the amount of faucet requests being fulfilled.

## Testing Plan
Tested manually.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

- [ ] Yes
- [x] No
