### PR TITLE
Fix transaction withReference and use in followChain

### DIFF
--- a/ironfish/src/primitives/block.ts
+++ b/ironfish/src/primitives/block.ts
@@ -47,13 +47,15 @@ export class Block {
       t.takeReference()
     }
 
-    try {
-      return callback()
-    } finally {
+    const result = callback()
+
+    Promise.resolve(result).finally(() => {
       for (const t of this.transactions) {
         t.returnReference()
       }
-    }
+    })
+
+    return result
   }
 
   /**

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -58,11 +58,14 @@ export class Transaction {
    */
   withReference<R>(callback: (transaction: TransactionPosted) => R): R {
     const transaction = this.takeReference()
-    try {
-      return callback(transaction)
-    } finally {
+
+    const result = callback(transaction)
+
+    Promise.resolve(result).finally(() => {
       this.returnReference()
-    }
+    })
+
+    return result
   }
 
   /**

--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -115,19 +115,21 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
     const send = async (block: Block, type: 'connected' | 'disconnected' | 'fork') => {
       const transactions = await Promise.all(
         block.transactions.map(async (transaction) => {
-          return {
-            hash: BlockHashSerdeInstance.serialize(transaction.hash()),
-            size: Buffer.from(
-              JSON.stringify(node.strategy.transactionSerde.serialize(transaction)),
-            ).byteLength,
-            fee: Number(await transaction.fee()),
-            notes: [...transaction.notes()].map((note) => ({
-              commitment: note.merkleHash().toString('hex'),
-            })),
-            spends: [...transaction.spends()].map((spend) => ({
-              nullifier: spend.nullifier.toString('hex'),
-            })),
-          }
+          return transaction.withReference(async () => {
+            return {
+              hash: BlockHashSerdeInstance.serialize(transaction.hash()),
+              size: Buffer.from(
+                JSON.stringify(node.strategy.transactionSerde.serialize(transaction)),
+              ).byteLength,
+              fee: Number(await transaction.fee()),
+              notes: [...transaction.notes()].map((note) => ({
+                commitment: note.merkleHash().toString('hex'),
+              })),
+              spends: [...transaction.spends()].map((spend) => ({
+                nullifier: spend.nullifier.toString('hex'),
+              })),
+            }
+          })
         }),
       )
 

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -182,11 +182,15 @@ describe('Demonstrate the Sapling API', () => {
       const strategy = new Strategy(new WorkerPool())
       const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spending_key)
 
-      minersFee.withReference(() => {
+      await minersFee.withReference(async () => {
         expect(minersFee['transactionPosted']).not.toBeNull()
 
         expect(minersFee.notesLength()).toEqual(1)
         expect(minersFee['transactionPosted']).not.toBeNull()
+
+        // Reference returning happens on the promise jobs queue, so use an await
+        // to delay until reference returning is expected to happen
+        return Promise.resolve()
       })
 
       expect(minersFee['transactionPosted']).toBeNull()


### PR DESCRIPTION
## Summary

Added a `transaction.withReference` around the transaction use in `followChain` to avoid some duplicate deserialization calls.

I also noticed that `transaction.withReference` wasn't working correctly for async callbacks -- The callback would execute, then call the `finally` to drop the reference before the callback was finished. Fixed this without making `transaction.withReference` async by creating a separate `Promise.resolve()` to wrap the result and calling `finally` on that one.

## Testing Plan

Synced a fresh database locally and also ran a node that was already synced up. Ran followChain with these changes to make sure it still works

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
