### PR TITLE
Throttle followChain RPC route

### DIFF
--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -63,8 +63,12 @@ export class ChainProcessor {
     // Freeze this value in case it changes while were updating the head
     const chainHead = this.chain.head
 
+    if (chainHead.hash.equals(this.hash)) {
+      return
+    }
+
     const head = await this.chain.getHeader(this.hash)
-    if (!head || chainHead.hash.equals(head.hash)) {
+    if (!head) {
       return
     }
 

--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -6,7 +6,7 @@ import { Assert } from '../../../assert'
 import { ChainProcessor } from '../../../chainProcessor'
 import { Block, BlockHeader } from '../../../primitives'
 import { BlockHashSerdeInstance } from '../../../serde'
-import { GraffitiUtils } from '../../../utils/graffiti'
+import { GraffitiUtils, PromiseUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
 
 export type FollowChainStreamRequest =
@@ -180,6 +180,7 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
 
     while (!request.closed) {
       await processor.update()
+      await PromiseUtils.sleep(1000)
     }
 
     request.end()


### PR DESCRIPTION
## Summary

- Sleep between chainProcessor.update calls

chainProcessor.update was running in a tight loop, but it wasn't locking up the node because it was hitting the DB in each loop iteration. Still, it was using a fair bit more CPU than necessary, so this adds a 1 second sleep between calls.

- Check if head hashes are equal before accessing DB

We can compare the chain head and the chainProcessor head without a DB call, so we can do those checks first to reduce contention and save some CPU as well.

## Testing Plan

Tested running service:sync when already synced, and when starting from scratch.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
