### PR TITLE
service:sync: Only fetch head from API when no head arg

### DIFF
--- a/ironfish-cli/src/commands/service/sync.ts
+++ b/ironfish-cli/src/commands/service/sync.ts
@@ -65,17 +65,20 @@ export default class Sync extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    this.log(`Fetching head from ${apiHost}`)
-
     const api = new WebApi({ host: apiHost, token: apiToken })
-    const head = await api.head()
+
+    let head = args.head as string | null
+    if (!head) {
+      this.log(`Fetching head from ${apiHost}`)
+      head = await api.head()
+    }
 
     if (head) {
       this.log(`Starting from head ${head}`)
     }
 
     const response = client.followChainStream({
-      head: (args.head || head) as string | null,
+      head: head,
     })
 
     const speed = new Meter()


### PR DESCRIPTION
## Summary

The `service:sync` command fetches the head from the API, but discards it if `args.head` is set. This PR only fetches the API head if it's going to be used, and adjusts the logs accordingly.

This shouldn't change functionality because the code existing code still prioritizes `args.head` if it's set.

## Testing Plan

Ran `service:sync` on an existing node with `args.head` passed and without `args.head` passed.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
