### PR TITLE
feat(ironfish): Add heap and rss gauges to `metricsMonitor`

### DIFF
--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { expect as expectCli, test } from '@oclif/test'
+import { GetStatusResponse } from 'ironfish'
+
+describe('status', () => {
+  const responseContent: GetStatusResponse = {
+    peerNetwork: { peers: 0, isReady: false, inboundTraffic: 0, outboundTraffic: 0 },
+    blockchain: {
+      synced: true,
+      head: '123',
+    },
+    node: {
+      status: 'started',
+      version: '0.0.0',
+      git: 'src',
+    },
+    memory: {
+      heapUsed: 1,
+      rss: 2,
+    },
+    miningDirector: { status: 'stopped', miners: 0, blocks: 0 },
+    memPool: { size: 0 },
+    blockSyncer: { status: 'stopped', syncing: { blockSpeed: 0, speed: 0 } },
+    workers: {
+      started: true,
+      workers: 1,
+      executing: 0,
+      queued: 0,
+      capacity: 1,
+      change: 0,
+      speed: 0,
+    },
+  }
+
+  beforeAll(() => {
+    jest.doMock('ironfish', () => {
+      const originalModule = jest.requireActual('ironfish')
+      const client = {
+        connect: jest.fn(),
+        status: jest.fn().mockImplementation(() => ({
+          content: responseContent,
+        })),
+      }
+      const module: typeof jest = {
+        ...originalModule,
+        IronfishSdk: {
+          init: jest.fn().mockImplementation(() => ({
+            client,
+            clientMemory: client,
+            connectRpc: jest.fn().mockResolvedValue(client),
+          })),
+        },
+      }
+      return module
+    })
+  })
+
+  afterAll(() => {
+    jest.dontMock('ironfish')
+  })
+
+  describe('it logs out the status of the node', () => {
+    test
+      .stdout()
+      .command(['status'])
+      .exit(0)
+      .it('logs out data for the chain, node, mempool, and syncer', (ctx) => {
+        expectCli(ctx.stdout).include('Version')
+        expectCli(ctx.stdout).include('Node')
+        expectCli(ctx.stdout).include('Heap Used')
+        expectCli(ctx.stdout).include('RSS')
+        expectCli(ctx.stdout).include('P2P Network')
+        expectCli(ctx.stdout).include('Mining')
+        expectCli(ctx.stdout).include('Mem Pool')
+        expectCli(ctx.stdout).include('Syncer')
+        expectCli(ctx.stdout).include('Blockchain')
+        expectCli(ctx.stdout).include('Workers')
+      })
+  })
+})

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -62,6 +62,8 @@ export default class Status extends IronfishCommand {
 
 function renderStatus(content: GetStatusResponse): string {
   const nodeStatus = `${content.node.status.toUpperCase()}`
+  const heapUsed = FileUtils.formatMemorySize(content.memory.heapUsed)
+  const rss = FileUtils.formatMemorySize(content.memory.rss)
   let blockSyncerStatus = content.blockSyncer.status.toString().toUpperCase()
 
   Assert.isNotUndefined(content.blockSyncer.syncing)
@@ -102,6 +104,8 @@ function renderStatus(content: GetStatusResponse): string {
   return `
 Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
+Heap Used            ${heapUsed}
+RSS                  ${rss}
 P2P Network          ${peerNetworkStatus}
 Mining               ${miningDirectorStatus}
 Mem Pool             ${memPoolStatus}

--- a/ironfish/src/metrics/gauge.ts
+++ b/ironfish/src/metrics/gauge.ts
@@ -2,17 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export class Gauge {
-  private _value: number
+  public value: number
 
   constructor() {
-    this._value = 0
-  }
-
-  get(): number {
-    return this._value
-  }
-
-  set(value: number): void {
-    this._value = value
+    this.value = 0
   }
 }

--- a/ironfish/src/metrics/gauge.ts
+++ b/ironfish/src/metrics/gauge.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export class Gauge {
+  private _value: number
+
+  constructor() {
+    this._value = 0
+  }
+
+  get(): number {
+    return this._value
+  }
+
+  set(value: number): void {
+    this._value = value
+  }
+}

--- a/ironfish/src/metrics/meter.ts
+++ b/ironfish/src/metrics/meter.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { SetTimeoutToken } from '../utils'
+import { SetIntervalToken } from '../utils'
 import { RollingAverage } from './rollingAverage'
 
 /**
@@ -23,7 +23,7 @@ export class Meter {
   private _rate5m: RollingAverage
   private _average: RollingAverage
   private _count = 0
-  private _interval: SetTimeoutToken | null = null
+  private _interval: SetIntervalToken | null = null
   private _intervalMs: number
   private _intervalLastMs: number | null = null
 

--- a/ironfish/src/metrics/meter.ts
+++ b/ironfish/src/metrics/meter.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { SetTimeoutToken } from '../utils'
 import { RollingAverage } from './rollingAverage'
 
 /**
@@ -22,7 +23,7 @@ export class Meter {
   private _rate5m: RollingAverage
   private _average: RollingAverage
   private _count = 0
-  private _interval: ReturnType<typeof setInterval> | null = null
+  private _interval: SetTimeoutToken | null = null
   private _intervalMs: number
   private _intervalLastMs: number | null = null
 

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -3,16 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { createRootLogger, Logger } from '../logger'
+import { Gauge } from './gauge'
 import { Meter } from './meter'
-
-type Metric = {
-  start: () => void
-  stop: () => void
-}
 
 export class MetricsMonitor {
   private _started = false
-  private _metrics: Metric[] = []
+  private _meters: Meter[] = []
   readonly logger: Logger
 
   readonly p2p_InboundTraffic: Meter
@@ -22,6 +18,11 @@ export class MetricsMonitor {
   readonly p2p_OutboundTraffic: Meter
   readonly p2p_OutboundTraffic_WS: Meter
   readonly p2p_OutboundTraffic_WebRTC: Meter
+
+  readonly heapUsed: Gauge
+  readonly rss: Gauge
+  private memoryInterval: ReturnType<typeof setInterval> | undefined
+  private readonly memoryRefreshPeriodMs = 1000
 
   constructor(logger: Logger = createRootLogger()) {
     this.logger = logger
@@ -33,6 +34,9 @@ export class MetricsMonitor {
     this.p2p_OutboundTraffic = this.addMeter()
     this.p2p_OutboundTraffic_WS = this.addMeter()
     this.p2p_OutboundTraffic_WebRTC = this.addMeter()
+
+    this.heapUsed = new Gauge()
+    this.rss = new Gauge()
   }
 
   get started(): boolean {
@@ -41,20 +45,32 @@ export class MetricsMonitor {
 
   start(): void {
     this._started = true
-    this._metrics.forEach((m) => m.start())
+    this._meters.forEach((m) => m.start())
+
+    this.memoryInterval = setInterval(() => this.refreshMemory(), this.memoryRefreshPeriodMs)
   }
 
   stop(): void {
     this._started = false
-    this._metrics.forEach((m) => m.stop())
+    this._meters.forEach((m) => m.stop())
+
+    if (this.memoryInterval) {
+      clearTimeout(this.memoryInterval)
+    }
   }
 
   addMeter(): Meter {
     const meter = new Meter()
-    this._metrics.push(meter)
+    this._meters.push(meter)
     if (this._started) {
       meter.start()
     }
     return meter
+  }
+
+  private refreshMemory(): void {
+    const memoryUsage = process.memoryUsage()
+    this.heapUsed.set(memoryUsage.heapUsed)
+    this.rss.set(memoryUsage.rss)
   }
 }

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { createRootLogger, Logger } from '../logger'
-import { SetTimeoutToken } from '../utils'
+import { SetIntervalToken } from '../utils'
 import { Gauge } from './gauge'
 import { Meter } from './meter'
 
@@ -22,7 +22,7 @@ export class MetricsMonitor {
 
   readonly heapUsed: Gauge
   readonly rss: Gauge
-  private memoryInterval: SetTimeoutToken | null
+  private memoryInterval: SetIntervalToken | null
   private readonly memoryRefreshPeriodMs = 1000
 
   constructor(logger: Logger = createRootLogger()) {

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { createRootLogger, Logger } from '../logger'
+import { SetTimeoutToken } from '../utils'
 import { Gauge } from './gauge'
 import { Meter } from './meter'
 
@@ -21,7 +22,7 @@ export class MetricsMonitor {
 
   readonly heapUsed: Gauge
   readonly rss: Gauge
-  private memoryInterval: ReturnType<typeof setInterval> | undefined
+  private memoryInterval: SetTimeoutToken | null
   private readonly memoryRefreshPeriodMs = 1000
 
   constructor(logger: Logger = createRootLogger()) {
@@ -37,6 +38,7 @@ export class MetricsMonitor {
 
     this.heapUsed = new Gauge()
     this.rss = new Gauge()
+    this.memoryInterval = null
   }
 
   get started(): boolean {
@@ -70,7 +72,7 @@ export class MetricsMonitor {
 
   private refreshMemory(): void {
     const memoryUsage = process.memoryUsage()
-    this.heapUsed.set(memoryUsage.heapUsed)
-    this.rss.set(memoryUsage.rss)
+    this.heapUsed.value = memoryUsage.heapUsed
+    this.rss.value = memoryUsage.rss
   }
 }

--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -15,7 +15,7 @@ import { Target } from '../primitives/target'
 import { Transaction } from '../primitives/transaction'
 import { Strategy } from '../strategy'
 import { submitMetric } from '../telemetry'
-import { AsyncUtils, ErrorUtils, GraffitiUtils } from '../utils'
+import { AsyncUtils, ErrorUtils, GraffitiUtils, SetTimeoutToken } from '../utils'
 
 /**
  * Number of transactions we are willing to store in a single block.
@@ -110,7 +110,7 @@ export class MiningDirector {
    * Setting an interval every 10 seconds to re-calculate the target for the
    * currentBlock based on updated timestamp
    */
-  miningDifficultyChangeTimeout: null | ReturnType<typeof setTimeout>
+  miningDifficultyChangeTimeout: null | SetTimeoutToken
 
   private _state: Readonly<DirectorState> = { type: 'STOPPED' }
 

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -4,7 +4,7 @@
 
 import type { Peer } from './peer'
 import { createRootLogger, Logger } from '../../logger'
-import { ArrayUtils } from '../../utils'
+import { ArrayUtils, SetTimeoutToken } from '../../utils'
 import { PeerManager } from './peerManager'
 
 /**
@@ -27,7 +27,7 @@ export class PeerConnectionManager {
   readonly maxPeers: number
 
   private started = false
-  private eventLoopTimer?: ReturnType<typeof setTimeout>
+  private eventLoopTimer?: SetTimeoutToken
 
   constructor(
     peerManager: PeerManager,

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -7,7 +7,7 @@ import WSWebSocket from 'ws'
 import { Event } from '../../event'
 import { createRootLogger, Logger } from '../../logger'
 import { MetricsMonitor } from '../../metrics'
-import { ArrayUtils } from '../../utils'
+import { ArrayUtils, SetTimeoutToken } from '../../utils'
 import {
   canInitiateWebRTC,
   canKeepDuplicateConnection,
@@ -90,13 +90,13 @@ export class PeerManager {
    * setInterval handle for distributePeerList, which sends out peer lists and
    * requests for peer lists
    */
-  private distributePeerListHandle: ReturnType<typeof setInterval> | undefined
+  private distributePeerListHandle: SetTimeoutToken | undefined
 
   /**
    * setInterval handle for peer disposal, which removes peers from the list that we
    * no longer care about
    */
-  private disposePeersHandle: ReturnType<typeof setInterval> | undefined
+  private disposePeersHandle: SetTimeoutToken | undefined
 
   /**
    * Event fired when a new connection is successfully opened. Sends some identifying

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -7,7 +7,7 @@ import WSWebSocket from 'ws'
 import { Event } from '../../event'
 import { createRootLogger, Logger } from '../../logger'
 import { MetricsMonitor } from '../../metrics'
-import { ArrayUtils, SetTimeoutToken } from '../../utils'
+import { ArrayUtils, SetIntervalToken } from '../../utils'
 import {
   canInitiateWebRTC,
   canKeepDuplicateConnection,
@@ -90,13 +90,13 @@ export class PeerManager {
    * setInterval handle for distributePeerList, which sends out peer lists and
    * requests for peer lists
    */
-  private distributePeerListHandle: SetTimeoutToken | undefined
+  private distributePeerListHandle: SetIntervalToken | undefined
 
   /**
    * setInterval handle for peer disposal, which removes peers from the list that we
    * no longer care about
    */
-  private disposePeersHandle: SetTimeoutToken | undefined
+  private disposePeersHandle: SetIntervalToken | undefined
 
   /**
    * Event fired when a new connection is successfully opened. Sends some identifying

--- a/ironfish/src/rpc/routes/node/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.test.ts
@@ -15,6 +15,10 @@ describe('Route node/getStatus', () => {
       node: {
         status: 'stopped',
       },
+      memory: {
+        heapUsed: expect.any(Number),
+        rss: expect.any(Number),
+      },
       miningDirector: {
         status: 'stopped',
       },

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -19,6 +19,10 @@ export type GetStatusResponse = {
     version: string
     git: string
   }
+  memory: {
+    heapUsed: number
+    rss: number
+  }
   miningDirector: {
     status: 'started' | 'stopped'
     miners: number
@@ -69,6 +73,12 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
         status: yup.string().oneOf(['started', 'stopped', 'error']).defined(),
         version: yup.string().defined(),
         git: yup.string().defined(),
+      })
+      .defined(),
+    memory: yup
+      .object({
+        heapUsed: yup.number().defined(),
+        rss: yup.number().defined(),
       })
       .defined(),
     miningDirector: yup
@@ -169,6 +179,10 @@ function getStatus(node: IronfishNode): GetStatusResponse {
       status: node.started ? 'started' : 'stopped',
       version: Package.version,
       git: Package.git,
+    },
+    memory: {
+      heapUsed: node.metrics.heapUsed.value,
+      rss: node.metrics.rss.value,
     },
     miningDirector: {
       status: node.miningDirector.isStarted() ? 'started' : 'stopped',

--- a/ironfish/src/utils/types.ts
+++ b/ironfish/src/utils/types.ts
@@ -35,6 +35,11 @@ export type UnwrapPromise<T> = T extends Promise<infer U>
  * */
 export type SetTimeoutToken = ReturnType<typeof setTimeout>
 
+/**
+ * The return type of `setInterval`. This type can be used with `clearInterval`.
+ */
+export type SetIntervalToken = ReturnType<typeof setInterval>
+
 export function IsNodeTimeout(timer: number | NodeJS.Timeout): timer is NodeJS.Timeout {
   return typeof timer !== 'number'
 }


### PR DESCRIPTION
## Summary

Add a `Gauge` metric, and collect RSS / Heap Used metrics every second in the metric monitor.

## Testing Plan

Manually tested.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
