### PR TITLE
feat(cli,ironfish): Add memory usage to status command

### DIFF
--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -15,6 +15,8 @@ describe('status', () => {
       status: 'started',
       version: '0.0.0',
       git: 'src',
+    },
+    memory: {
       heapUsed: 1,
       rss: 2,
     },
@@ -67,8 +69,8 @@ describe('status', () => {
       .it('logs out data for the chain, node, mempool, and syncer', (ctx) => {
         expectCli(ctx.stdout).include('Version')
         expectCli(ctx.stdout).include('Node')
-        expectCli(ctx.stdout).include('Node Heap Used')
-        expectCli(ctx.stdout).include('Node RSS')
+        expectCli(ctx.stdout).include('Heap Used')
+        expectCli(ctx.stdout).include('RSS')
         expectCli(ctx.stdout).include('P2P Network')
         expectCli(ctx.stdout).include('Mining')
         expectCli(ctx.stdout).include('Mem Pool')

--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { expect as expectCli, test } from '@oclif/test'
+import { GetStatusResponse } from 'ironfish'
+
+describe('status', () => {
+  const responseContent: GetStatusResponse = {
+    peerNetwork: { peers: 0, isReady: false, inboundTraffic: 0, outboundTraffic: 0 },
+    blockchain: {
+      synced: true,
+      head: '123',
+    },
+    node: {
+      status: 'started',
+      version: '0.0.0',
+      git: 'src',
+      heapUsed: 1,
+      rss: 2,
+    },
+    miningDirector: { status: 'stopped', miners: 0, blocks: 0 },
+    memPool: { size: 0 },
+    blockSyncer: { status: 'stopped', syncing: { blockSpeed: 0, speed: 0 } },
+    workers: {
+      started: true,
+      workers: 1,
+      executing: 0,
+      queued: 0,
+      capacity: 1,
+      change: 0,
+      speed: 0,
+    },
+  }
+
+  beforeAll(() => {
+    jest.doMock('ironfish', () => {
+      const originalModule = jest.requireActual('ironfish')
+      const client = {
+        connect: jest.fn(),
+        status: jest.fn().mockImplementation(() => ({
+          content: responseContent,
+        })),
+      }
+      const module: typeof jest = {
+        ...originalModule,
+        IronfishSdk: {
+          init: jest.fn().mockImplementation(() => ({
+            client,
+            clientMemory: client,
+            connectRpc: jest.fn().mockResolvedValue(client),
+          })),
+        },
+      }
+      return module
+    })
+  })
+
+  afterAll(() => {
+    jest.dontMock('ironfish')
+  })
+
+  describe('it logs out the status of the node', () => {
+    test
+      .stdout()
+      .command(['status'])
+      .exit(0)
+      .it('logs out data for the chain, node, mempool, and syncer', (ctx) => {
+        expectCli(ctx.stdout).include('Version')
+        expectCli(ctx.stdout).include('Node')
+        expectCli(ctx.stdout).include('Node Heap Used')
+        expectCli(ctx.stdout).include('Node RSS')
+        expectCli(ctx.stdout).include('P2P Network')
+        expectCli(ctx.stdout).include('Mining')
+        expectCli(ctx.stdout).include('Mem Pool')
+        expectCli(ctx.stdout).include('Syncer')
+        expectCli(ctx.stdout).include('Blockchain')
+        expectCli(ctx.stdout).include('Workers')
+      })
+  })
+})

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -8,8 +8,6 @@ import { Assert } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 
-const BYTES_PER_MB = 1024 * 1024
-
 export default class Status extends IronfishCommand {
   static description = 'Show the status of the node'
 
@@ -64,8 +62,8 @@ export default class Status extends IronfishCommand {
 
 function renderStatus(content: GetStatusResponse): string {
   const nodeStatus = `${content.node.status.toUpperCase()}`
-  const nodeHeapUsedMb = (content.node.heapUsed / BYTES_PER_MB).toFixed(2)
-  const nodeRssMb = (content.node.rss / BYTES_PER_MB).toFixed(2)
+  const heapUsed = FileUtils.formatMemorySize(content.memory.heapUsed)
+  const rss = FileUtils.formatMemorySize(content.memory.rss)
   let blockSyncerStatus = content.blockSyncer.status.toString().toUpperCase()
 
   Assert.isNotUndefined(content.blockSyncer.syncing)
@@ -106,8 +104,8 @@ function renderStatus(content: GetStatusResponse): string {
   return `
 Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
-Node Heap Used       ${nodeHeapUsedMb} MB
-Node RSS             ${nodeRssMb} MB
+Heap Used            ${heapUsed}
+RSS                  ${rss}
 P2P Network          ${peerNetworkStatus}
 Mining               ${miningDirectorStatus}
 Mem Pool             ${memPoolStatus}

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -8,6 +8,8 @@ import { Assert } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 
+const BYTES_PER_MB = 1024 * 1024
+
 export default class Status extends IronfishCommand {
   static description = 'Show the status of the node'
 
@@ -62,6 +64,8 @@ export default class Status extends IronfishCommand {
 
 function renderStatus(content: GetStatusResponse): string {
   const nodeStatus = `${content.node.status.toUpperCase()}`
+  const nodeHeapUsedMb = (content.node.heapUsed / BYTES_PER_MB).toFixed(2)
+  const nodeRssMb = (content.node.rss / BYTES_PER_MB).toFixed(2)
   let blockSyncerStatus = content.blockSyncer.status.toString().toUpperCase()
 
   Assert.isNotUndefined(content.blockSyncer.syncing)
@@ -102,6 +106,8 @@ function renderStatus(content: GetStatusResponse): string {
   return `
 Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
+Node Heap Used       ${nodeHeapUsedMb} MB
+Node RSS             ${nodeRssMb} MB
 P2P Network          ${peerNetworkStatus}
 Mining               ${miningDirectorStatus}
 Mem Pool             ${memPoolStatus}

--- a/ironfish/src/rpc/routes/node/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.test.ts
@@ -14,6 +14,8 @@ describe('Route node/getStatus', () => {
     expect(response.content).toMatchObject({
       node: {
         status: 'stopped',
+      },
+      memory: {
         heapUsed: expect.any(Number),
         rss: expect.any(Number),
       },

--- a/ironfish/src/rpc/routes/node/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.test.ts
@@ -14,6 +14,8 @@ describe('Route node/getStatus', () => {
     expect(response.content).toMatchObject({
       node: {
         status: 'stopped',
+        heapUsed: expect.any(Number),
+        rss: expect.any(Number),
       },
       miningDirector: {
         status: 'stopped',

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -18,6 +18,8 @@ export type GetStatusResponse = {
     status: 'started' | 'stopped' | 'error'
     version: string
     git: string
+    heapUsed: number
+    rss: number
   }
   miningDirector: {
     status: 'started' | 'stopped'
@@ -69,6 +71,8 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
         status: yup.string().oneOf(['started', 'stopped', 'error']).defined(),
         version: yup.string().defined(),
         git: yup.string().defined(),
+        heapUsed: yup.number().defined(),
+        rss: yup.number().defined(),
       })
       .defined(),
     miningDirector: yup
@@ -169,6 +173,8 @@ function getStatus(node: IronfishNode): GetStatusResponse {
       status: node.started ? 'started' : 'stopped',
       version: Package.version,
       git: Package.git,
+      heapUsed: node.metrics.heapUsed.get(),
+      rss: node.metrics.rss.get(),
     },
     miningDirector: {
       status: node.miningDirector.isStarted() ? 'started' : 'stopped',

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -18,6 +18,8 @@ export type GetStatusResponse = {
     status: 'started' | 'stopped' | 'error'
     version: string
     git: string
+  }
+  memory: {
     heapUsed: number
     rss: number
   }
@@ -71,6 +73,10 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
         status: yup.string().oneOf(['started', 'stopped', 'error']).defined(),
         version: yup.string().defined(),
         git: yup.string().defined(),
+      })
+      .defined(),
+    memory: yup
+      .object({
         heapUsed: yup.number().defined(),
         rss: yup.number().defined(),
       })
@@ -173,8 +179,10 @@ function getStatus(node: IronfishNode): GetStatusResponse {
       status: node.started ? 'started' : 'stopped',
       version: Package.version,
       git: Package.git,
-      heapUsed: node.metrics.heapUsed.get(),
-      rss: node.metrics.rss.get(),
+    },
+    memory: {
+      heapUsed: node.metrics.heapUsed.value,
+      rss: node.metrics.rss.value,
     },
     miningDirector: {
       status: node.miningDirector.isStarted() ? 'started' : 'stopped',


### PR DESCRIPTION
## Summary

Log out node heap usage and rss with status command.

This PR is opened against #888 until that code change is merged.

## Testing Plan

Added unit test.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
