### PR TITLE
Remove account and config RPC calls from TCP

### DIFF
--- a/ironfish-cli/src/commands/config/show.ts
+++ b/ironfish-cli/src/commands/config/show.ts
@@ -4,21 +4,14 @@
 import { flags } from '@oclif/command'
 import jsonColorizer from 'json-colorizer'
 import { IronfishCommand } from '../../command'
-import {
-  ColorFlag,
-  ColorFlagKey,
-  ConfigFlag,
-  ConfigFlagKey,
-  DataDirFlag,
-  DataDirFlagKey,
-} from '../../flags'
+import { ColorFlag, ColorFlagKey } from '../../flags'
+import { RemoteFlags } from '../../flags'
 
 export class ShowCommand extends IronfishCommand {
   static description = `Print out the entire config`
 
   static flags = {
-    [ConfigFlagKey]: ConfigFlag,
-    [DataDirFlagKey]: DataDirFlag,
+    ...RemoteFlags,
     [ColorFlagKey]: ColorFlag,
     user: flags.boolean({
       description: 'only show config from the users datadir and not overrides',

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -184,21 +184,21 @@ export class IronfishSdk {
       privateIdentity: privateIdentity,
     })
 
-    const namespaces = [
-      ApiNamespace.account,
-      ApiNamespace.chain,
-      ApiNamespace.config,
-      ApiNamespace.event,
-      ApiNamespace.faucet,
-      ApiNamespace.miner,
-      ApiNamespace.node,
-      ApiNamespace.peer,
-      ApiNamespace.transaction,
-      ApiNamespace.telemetry,
-      ApiNamespace.worker,
-    ]
-
     if (this.config.get('enableRpcIpc')) {
+      const namespaces = [
+        ApiNamespace.account,
+        ApiNamespace.chain,
+        ApiNamespace.config,
+        ApiNamespace.event,
+        ApiNamespace.faucet,
+        ApiNamespace.miner,
+        ApiNamespace.node,
+        ApiNamespace.peer,
+        ApiNamespace.transaction,
+        ApiNamespace.telemetry,
+        ApiNamespace.worker,
+      ]
+
       await node.rpc.mount(
         new IpcAdapter(
           namespaces,
@@ -212,6 +212,18 @@ export class IronfishSdk {
     }
 
     if (this.config.get('enableRpcTcp')) {
+      const namespaces = [
+        ApiNamespace.chain,
+        ApiNamespace.event,
+        ApiNamespace.faucet,
+        ApiNamespace.miner,
+        ApiNamespace.node,
+        ApiNamespace.peer,
+        ApiNamespace.transaction,
+        ApiNamespace.telemetry,
+        ApiNamespace.worker,
+      ]
+
       await node.rpc.mount(
         new IpcAdapter(
           namespaces,


### PR DESCRIPTION
## Summary

This removes RPC routes in the accounts and config namespace from being
mounted in the TCP adapter. This is to prevent a an attack where
users can have their graffiti changed. This is a short term fix because
the real fix is to add RPC token authentication.

Accessing one of these routes via TCP will now display the following error

```
No route found config/getConfig in namespace config for method getConfig
```
## Testing Plan

Tested lcoally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
