### PR TITLE
Make batch size configurable for miner

### DIFF
--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -39,7 +39,8 @@ export class Miner extends IronfishCommand {
     }
 
     const client = this.sdk.client
-    const miner = new IronfishMiner(flags.threads)
+    const batchSize = this.sdk.config.get('minerBatchSize')
+    const miner = new IronfishMiner(flags.threads, batchSize)
 
     const successfullyMined = (request: MineRequest, randomness: number) => {
       this.log(

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -183,7 +183,7 @@ export class Config extends KeyStore<ConfigOptions> {
       accountName: DEFAULT_WALLET_NAME,
       generateNewIdentity: false,
       blocksPerMessage: 20,
-      minerBatchSize: 100000
+      minerBatchSize: 10000
     }
   }
 }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -115,6 +115,11 @@ export type ConfigOptions = {
    * The default number of blocks to request per message when syncing.
    */
   blocksPerMessage: number
+
+  /**
+   * The number of hashes processed by miner per worker request.
+   */
+   minerBatchSize: number
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -178,6 +183,7 @@ export class Config extends KeyStore<ConfigOptions> {
       accountName: DEFAULT_WALLET_NAME,
       generateNewIdentity: false,
       blocksPerMessage: 20,
+      minerBatchSize: 100000
     }
   }
 }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -119,7 +119,7 @@ export type ConfigOptions = {
   /**
    * The number of hashes processed by miner per worker request.
    */
-   minerBatchSize: number
+  minerBatchSize: number
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -183,7 +183,7 @@ export class Config extends KeyStore<ConfigOptions> {
       accountName: DEFAULT_WALLET_NAME,
       generateNewIdentity: false,
       blocksPerMessage: 20,
-      minerBatchSize: 10000
+      minerBatchSize: 10000,
     }
   }
 }

--- a/ironfish/src/mining/miner.test.ts
+++ b/ironfish/src/mining/miner.test.ts
@@ -8,6 +8,7 @@ import { mineHeader } from './mineHeader'
 import { Miner, MineRequest } from './miner'
 
 jest.mock('../primitives/blockheader')
+const testBatchSize = 100
 
 /**
  * Make an iterable of blocks suitable for async generation
@@ -29,7 +30,7 @@ async function* makeAsync(
 
 describe('Miner', () => {
   it('mines', async () => {
-    const miner = new Miner(1)
+    const miner = new Miner(1, testBatchSize)
 
     const mineHeaderSpy = jest.spyOn(miner.workerPool, 'mineHeader')
     const stopSpy = jest.spyOn(miner.workerPool, 'stop')
@@ -54,7 +55,7 @@ describe('Miner', () => {
   })
 
   it('reschedules on new block', async () => {
-    const miner = new Miner(1)
+    const miner = new Miner(1, testBatchSize)
 
     const mineHeaderSpy = jest.spyOn(miner.workerPool, 'mineHeader')
     const stopSpy = jest.spyOn(miner.workerPool, 'stop')
@@ -91,7 +92,7 @@ describe('Miner', () => {
   })
 
   it('calls successfullyMined', async () => {
-    const miner = new Miner(1)
+    const miner = new Miner(1, testBatchSize)
     jest
       .spyOn(miner.workerPool, 'mineHeader')
       .mockImplementation((_id, _bytes, initialRandomness, _targetValue, _batchSize) => {

--- a/ironfish/src/mining/miner.ts
+++ b/ironfish/src/mining/miner.ts
@@ -39,7 +39,7 @@ export class Miner {
   private tasks: Record<number, Promise<MineResult>> = {}
   private randomness = 0
 
-  constructor(numTasks: number, batchSize = 10000) {
+  constructor(numTasks: number, batchSize: number) {
     this.workerPool = new WorkerPool({ numWorkers: numTasks })
     this.batchSize = batchSize
     this.hashRate = new Meter()


### PR DESCRIPTION
## Summary
Playing with batchSize can impact the hash rate. A faster processor can benefit from a higher batchSize. Making it configurable can give more flexibility to miners. 

## Testing Plan
Manually tested via 
```
./ironfish config:set minerBatchSize <newBatchSize> 
./ironfish config:show
```
When I set a very low batch size, I noticed that the hash rate significantly slows down. 

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ X] No
```
