### PR TITLE
Use path.join for worker file path

### DIFF
--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -102,7 +102,7 @@ export class WorkerPool {
       this.workers.push(worker)
     }
 
-    this.logger.debug(`Started worker pool with ${this.numWorkers} worker ${path}`)
+    this.logger.debug(`Started worker pool with ${this.numWorkers} workers using ${path}`)
   }
 
   async stop(): Promise<void> {

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -186,5 +186,5 @@ export function getWorkerPath(): string {
     )
   }
 
-  return workerPath + '/worker.js'
+  return path.join(workerPath, 'worker.js')
 }


### PR DESCRIPTION
## Summary

This doesn't fix any bugs, just makes the worker file path use consistent OS-relative path separators, which looks a bit nicer in the logs.

Also updates the text of the log when the worker pool starts to look a bit nicer.

## Testing Plan

Node should start up as expected on Windows and non-Windows.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
