### PR TITLE
Add TCP Secure flag to allow secure config over TCP

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -10,6 +10,7 @@ import {
   DataDirFlagKey,
   RpcTcpHostFlagKey,
   RpcTcpPortFlagKey,
+  RpcTcpSecureFlagKey,
   RpcUseIpcFlagKey,
   RpcUseTcpFlagKey,
   VerboseFlagKey,
@@ -26,6 +27,7 @@ export type FLAGS =
   | typeof RpcUseTcpFlagKey
   | typeof RpcTcpHostFlagKey
   | typeof RpcTcpPortFlagKey
+  | typeof RpcTcpSecureFlagKey
   | typeof VerboseFlagKey
 
 export abstract class IronfishCommand extends Command {
@@ -102,6 +104,11 @@ export abstract class IronfishCommand extends Command {
     const rpcTcpPortFlag = getFlag(flags, RpcTcpPortFlagKey)
     if (typeof rpcTcpPortFlag === 'number') {
       configOverrides.rpcTcpPort = rpcTcpPortFlag
+    }
+
+    const rpcTcpSecureFlag = getFlag(flags, RpcTcpSecureFlagKey)
+    if (typeof rpcTcpSecureFlag === 'boolean') {
+      configOverrides.rpcTcpSecure = rpcTcpSecureFlag
     }
 
     const verboseFlag = getFlag(flags, VerboseFlagKey)

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -24,6 +24,8 @@ import {
   RpcTcpHostFlagKey,
   RpcTcpPortFlag,
   RpcTcpPortFlagKey,
+  RpcTcpSecureFlag,
+  RpcTcpSecureFlagKey,
   RpcUseIpcFlag,
   RpcUseIpcFlagKey,
   RpcUseTcpFlag,
@@ -47,6 +49,7 @@ export default class Start extends IronfishCommand {
     [RpcUseTcpFlagKey]: { ...RpcUseTcpFlag, allowNo: true },
     [RpcTcpHostFlagKey]: RpcTcpHostFlag,
     [RpcTcpPortFlagKey]: RpcTcpPortFlag,
+    [RpcTcpSecureFlagKey]: RpcTcpSecureFlag,
     bootstrap: flags.string({
       char: 'b',
       description: 'comma-separated addresses of bootstrap nodes to connect to',

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -14,6 +14,7 @@ export const RpcUseIpcFlagKey = 'rpc.ipc'
 export const RpcUseTcpFlagKey = 'rpc.tcp'
 export const RpcTcpHostFlagKey = 'rpc.tcp.host'
 export const RpcTcpPortFlagKey = 'rpc.tcp.port'
+export const RpcTcpSecureFlagKey = 'rpc.tcp.secure'
 
 export const VerboseFlag = flags.boolean({
   char: 'v',
@@ -61,6 +62,11 @@ export const RpcTcpPortFlag = flags.integer({
   description: 'the TCP port to listen for connections on',
 })
 
+export const RpcTcpSecureFlag = flags.boolean({
+  default: false,
+  description: 'allow sensitive config to be changed over TCP',
+})
+
 const localFlags: Record<string, IOptionFlag<unknown>> = {}
 localFlags[VerboseFlagKey] = VerboseFlag as unknown as IOptionFlag<unknown>
 localFlags[ConfigFlagKey] = ConfigFlag as unknown as IOptionFlag<unknown>
@@ -81,6 +87,7 @@ remoteFlags[RpcUseTcpFlagKey] = RpcUseTcpFlag as unknown as IOptionFlag<unknown>
 remoteFlags[RpcUseIpcFlagKey] = RpcUseIpcFlag as unknown as IOptionFlag<unknown>
 remoteFlags[RpcTcpHostFlagKey] = RpcTcpHostFlag as unknown as IOptionFlag<unknown>
 remoteFlags[RpcTcpPortFlagKey] = RpcTcpPortFlag as unknown as IOptionFlag<unknown>
+remoteFlags[RpcTcpSecureFlagKey] = RpcTcpSecureFlag as unknown as IOptionFlag<unknown>
 
 /**
  * These flags should usually be used on any command that uses an

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -83,6 +83,7 @@ export type ConfigOptions = {
   peerPort: number
   rpcTcpHost: string
   rpcTcpPort: number
+  rpcTcpSecure: boolean
   rpcRetryConnect: boolean
   /**
    * The maximum number of peers we can be connected to at a time. Past this number,
@@ -175,6 +176,7 @@ export class Config extends KeyStore<ConfigOptions> {
       peerPort: DEFAULT_WEBSOCKET_PORT,
       rpcTcpHost: 'localhost',
       rpcTcpPort: 8020,
+      rpcTcpSecure: false,
       rpcRetryConnect: false,
       maxPeers: 50,
       minPeers: 1,

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -224,6 +224,10 @@ export class IronfishSdk {
         ApiNamespace.worker,
       ]
 
+      if (this.config.get('rpcTcpSecure')) {
+        namespaces.push(ApiNamespace.account, ApiNamespace.config)
+      }
+
       await node.rpc.mount(
         new IpcAdapter(
           namespaces,


### PR DESCRIPTION
## Summary

Adds a `rpc.tcp.secure` flag for the node, which enables the ability to change sensitive config via tcp. Disabled by default.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
