### PR TITLE
Dont set config overrides unless not default value

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -6,13 +6,18 @@ import { IConfig } from '@oclif/config'
 import { ConfigOptions, ConnectionError, createRootLogger, IronfishSdk, Logger } from 'ironfish'
 import {
   ConfigFlagKey,
+  DatabaseFlag,
   DatabaseFlagKey,
   DataDirFlagKey,
   RpcTcpHostFlagKey,
   RpcTcpPortFlagKey,
+  RpcTcpSecureFlag,
   RpcTcpSecureFlagKey,
+  RpcUseIpcFlag,
   RpcUseIpcFlagKey,
+  RpcUseTcpFlag,
   RpcUseTcpFlagKey,
+  VerboseFlag,
   VerboseFlagKey,
 } from './flags'
 import { hasUserResponseError } from './utils'
@@ -82,17 +87,17 @@ export abstract class IronfishCommand extends Command {
     const configOverrides: Partial<ConfigOptions> = {}
 
     const databaseNameFlag = getFlag(flags, DatabaseFlagKey)
-    if (typeof databaseNameFlag === 'string') {
+    if (typeof databaseNameFlag === 'string' && databaseNameFlag !== DatabaseFlag.default) {
       configOverrides.databaseName = databaseNameFlag
     }
 
     const rpcConnectIpcFlag = getFlag(flags, RpcUseIpcFlagKey)
-    if (typeof rpcConnectIpcFlag === 'boolean') {
+    if (typeof rpcConnectIpcFlag === 'boolean' && rpcConnectIpcFlag !== RpcUseIpcFlag.default) {
       configOverrides.enableRpcIpc = rpcConnectIpcFlag
     }
 
     const rpcConnectTcpFlag = getFlag(flags, RpcUseTcpFlagKey)
-    if (typeof rpcConnectTcpFlag === 'boolean') {
+    if (typeof rpcConnectTcpFlag === 'boolean' && rpcConnectTcpFlag !== RpcUseTcpFlag.default) {
       configOverrides.enableRpcTcp = rpcConnectTcpFlag
     }
 
@@ -107,12 +112,15 @@ export abstract class IronfishCommand extends Command {
     }
 
     const rpcTcpSecureFlag = getFlag(flags, RpcTcpSecureFlagKey)
-    if (typeof rpcTcpSecureFlag === 'boolean') {
+    if (
+      typeof rpcTcpSecureFlag === 'boolean' &&
+      rpcTcpSecureFlag !== RpcTcpSecureFlag.default
+    ) {
       configOverrides.rpcTcpSecure = rpcTcpSecureFlag
     }
 
     const verboseFlag = getFlag(flags, VerboseFlagKey)
-    if (typeof verboseFlag === 'boolean' && verboseFlag) {
+    if (typeof verboseFlag === 'boolean' && verboseFlag !== VerboseFlag.default) {
       configOverrides.logLevel = '*:verbose'
     }
 

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -3,7 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
 import { IOptionFlag } from '@oclif/command/lib/flags'
-import { DEFAULT_CONFIG_NAME, DEFAULT_DATA_DIR, DEFAULT_DATABASE_NAME } from 'ironfish'
+import {
+  DEFAULT_CONFIG_NAME,
+  DEFAULT_DATA_DIR,
+  DEFAULT_DATABASE_NAME,
+  DEFAULT_USE_RPC_IPC,
+  DEFAULT_USE_RPC_TCP,
+} from 'ironfish'
 
 export const VerboseFlagKey = 'verbose'
 export const ConfigFlagKey = 'config'
@@ -45,12 +51,12 @@ export const DatabaseFlag = flags.string({
 })
 
 export const RpcUseIpcFlag = flags.boolean({
-  default: true,
+  default: DEFAULT_USE_RPC_IPC,
   description: 'connect to the RPC over IPC (default)',
 })
 
 export const RpcUseTcpFlag = flags.boolean({
-  default: false,
+  default: DEFAULT_USE_RPC_TCP,
   description: 'connect to the RPC over TCP',
 })
 

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -14,6 +14,8 @@ export const DEFAULT_GET_FUNDS_API = 'https://api.ironfish.network/faucet_transa
 export const DEFAULT_TELEMETRY_API = 'https://api.ironfish.network/api/v1/writeTelemetry'
 export const DEFAULT_BOOTSTRAP_NODE = 'test.bn1.ironfish.network'
 export const DEFAULT_DISCORD_INVITE = 'https://discord.gg/EkQkEcm8DH'
+export const DEFAULT_USE_RPC_IPC = true
+export const DEFAULT_USE_RPC_TCP = false
 
 export type ConfigOptions = {
   bootstrapNodes: string[]
@@ -157,8 +159,8 @@ export class Config extends KeyStore<ConfigOptions> {
       enableLogFile: false,
       enableMiningDirector: false,
       enableRpc: true,
-      enableRpcIpc: true,
-      enableRpcTcp: false,
+      enableRpcIpc: DEFAULT_USE_RPC_IPC,
+      enableRpcTcp: DEFAULT_USE_RPC_TCP,
       enableSyncing: true,
       enableTelemetry: false,
       enableMetrics: true,


### PR DESCRIPTION
https://linear.app/ironfish/issue/IRO-1489/fix-flag-defaults-overriding-config-file-values

We found a bug where the base command was setting config overrides for
values that are the same as the flags default value. This causes the
config file to be ignored.

Now, we only set the config override if it's different from the default,
which allows the config not to be over-ridden with the flag default.