### PR TITLE
Fix up ChainProcessor and use in Accounts store for processing blocks

### DIFF
--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -24,7 +24,7 @@ describe('Accounts', () => {
     await expect(chain).toAddBlock(blockA1)
 
     await node.accounts.updateHead()
-    expect(node.accounts['headHash']).toEqual(blockA1.header.hash)
+    expect(node.accounts['chainProcessor'].hash).toEqual(blockA1.header.hash)
     expect(getTransactionsSpy).toBeCalledTimes(2)
 
     // G -> A1 -> A2
@@ -32,7 +32,7 @@ describe('Accounts', () => {
     await expect(chain).toAddBlock(blockA2)
 
     await node.accounts.updateHead()
-    expect(node.accounts['headHash']).toEqual(blockA2.header.hash)
+    expect(node.accounts['chainProcessor'].hash).toEqual(blockA2.header.hash)
     expect(getTransactionsSpy).toBeCalledTimes(3)
 
     // Add 3 more on a heavier fork. Chain A should be removed first, then chain B added
@@ -47,18 +47,18 @@ describe('Accounts', () => {
     await expect(chain).toAddBlock(blockB3)
 
     await node.accounts.updateHead()
-    expect(node.accounts['headHash']).toEqual(blockB3.header.hash)
+    expect(node.accounts['chainProcessor'].hash).toEqual(blockB3.header.hash)
     expect(getTransactionsSpy).toBeCalledTimes(8)
   }, 8000)
 
-  it('should reset when headHash does not exist in chain', async () => {
+  it('should reset when chain processor head does not exist in chain', async () => {
     const { node, strategy } = nodeTest
     strategy.disableMiningReward()
 
     const resetSpy = jest.spyOn(node.accounts, 'reset').mockImplementation()
     jest.spyOn(node.accounts, 'eventLoop').mockImplementation(() => Promise.resolve())
 
-    node.accounts['headHash'] = Buffer.from('0')
+    node.accounts['chainProcessor'].hash = Buffer.from('0')
 
     await node.accounts.start()
     expect(resetSpy).toBeCalledTimes(1)

--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -8,48 +8,9 @@ import {
   useMinerBlockFixture,
   useTxFixture,
 } from '../testUtilities'
-import { makeBlockAfter } from '../testUtilities/helpers/blockchain'
 
 describe('Accounts', () => {
   const nodeTest = createNodeTest()
-
-  it('sync account head', async () => {
-    const { node, chain, strategy } = nodeTest
-    strategy.disableMiningReward()
-
-    const getTransactionsSpy = jest.spyOn(chain, 'iterateBlockTransactions')
-
-    // G -> A1
-    const blockA1 = await makeBlockAfter(chain, chain.genesis)
-    await expect(chain).toAddBlock(blockA1)
-
-    await node.accounts.updateHead()
-    expect(node.accounts['chainProcessor'].hash).toEqual(blockA1.header.hash)
-    expect(getTransactionsSpy).toBeCalledTimes(2)
-
-    // G -> A1 -> A2
-    const blockA2 = await makeBlockAfter(chain, blockA1)
-    await expect(chain).toAddBlock(blockA2)
-
-    await node.accounts.updateHead()
-    expect(node.accounts['chainProcessor'].hash).toEqual(blockA2.header.hash)
-    expect(getTransactionsSpy).toBeCalledTimes(3)
-
-    // Add 3 more on a heavier fork. Chain A should be removed first, then chain B added
-    // G -> A1 -> A2
-    //   -> B1 -> B2 -> B3
-    const blockB1 = await makeBlockAfter(chain, chain.genesis)
-    const blockB2 = await makeBlockAfter(chain, blockB1)
-    const blockB3 = await makeBlockAfter(chain, blockB2)
-
-    await expect(chain).toAddBlock(blockB1)
-    await expect(chain).toAddBlock(blockB2)
-    await expect(chain).toAddBlock(blockB3)
-
-    await node.accounts.updateHead()
-    expect(node.accounts['chainProcessor'].hash).toEqual(blockB3.header.hash)
-    expect(getTransactionsSpy).toBeCalledTimes(8)
-  }, 8000)
 
   it('should reset when chain processor head does not exist in chain', async () => {
     const { node, strategy } = nodeTest

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -320,6 +320,7 @@ export class Accounts {
     this.transactionMap.clear()
     this.noteToNullifier.clear()
     this.nullifierToNote.clear()
+    this.chainProcessor.hash = null
     await this.saveTransactionsToDb()
     await this.updateHeadHash(null)
   }

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -3,14 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BufferMap } from 'buffer-map'
 import { generateKey, generateNewPublicAddress } from 'ironfish-rust-nodejs'
-import { Assert } from '..'
+import { ChainProcessor } from '..'
 import { Blockchain } from '../blockchain'
-import { GENESIS_BLOCK_SEQUENCE } from '../consensus'
 import { Event } from '../event'
 import { createRootLogger, Logger } from '../logger'
 import { MemPool } from '../memPool'
 import { NoteWitness } from '../merkletree/witness'
-import { BlockHeader } from '../primitives'
 import { Note } from '../primitives/note'
 import { Transaction } from '../primitives/transaction'
 import { ValidationError } from '../rpc/adapters/errors'
@@ -60,7 +58,7 @@ export class Accounts {
 
   protected rebroadcastAfter: number
   protected defaultAccount: string | null = null
-  protected headHash: Buffer | null = null
+  protected chainProcessor: ChainProcessor
   protected isStarted = false
   protected isOpen = false
   protected eventLoopTimeout: SetTimeoutToken | null = null
@@ -83,6 +81,39 @@ export class Accounts {
     this.db = database
     this.workerPool = workerPool
     this.rebroadcastAfter = rebroadcastAfter ?? 10
+
+    this.chainProcessor = new ChainProcessor({
+      logger: this.logger,
+      chain: chain,
+      head: null,
+    })
+
+    this.chainProcessor.onAdd.on(async (header) => {
+      this.logger.debug(`AccountHead ADD: ${Number(header.sequence) - 1} => ${header.sequence}`)
+
+      for await (const {
+        transaction,
+        blockHash,
+        initialNoteIndex,
+      } of this.chain.iterateBlockTransactions(header)) {
+        await this.syncTransaction(transaction, {
+          blockHash: blockHash,
+          initialNoteIndex: initialNoteIndex,
+        })
+      }
+
+      await this.updateHeadHash(header.hash)
+    })
+
+    this.chainProcessor.onRemove.on(async (header) => {
+      this.logger.debug(`AccountHead DEL: ${header.sequence} => ${Number(header.sequence) - 1}`)
+
+      for await (const { transaction } of this.chain.iterateBlockTransactions(header)) {
+        await this.syncTransaction(transaction, {})
+      }
+
+      await this.updateHeadHash(header.previousBlockHash)
+    })
   }
 
   async updateHead(): Promise<void> {
@@ -93,98 +124,10 @@ export class Accounts {
     this.updateHeadState = new ScanState()
 
     try {
-      const addBlock = async (header: BlockHeader): Promise<void> => {
-        this.logger.debug(
-          `AccountHead ADD: ${Number(header.sequence) - 1} => ${header.sequence}`,
-        )
-
-        for await (const {
-          transaction,
-          blockHash,
-          initialNoteIndex,
-        } of this.chain.iterateBlockTransactions(header)) {
-          await this.syncTransaction(transaction, {
-            blockHash: blockHash,
-            initialNoteIndex: initialNoteIndex,
-          })
-        }
-      }
-
-      const removeBlock = async (header: BlockHeader): Promise<void> => {
-        this.logger.debug(
-          `AccountHead DEL: ${header.sequence} => ${Number(header.sequence) - 1}`,
-        )
-
-        for await (const { transaction } of this.chain.iterateBlockTransactions(header)) {
-          await this.syncTransaction(transaction, {})
-        }
-      }
-
-      const chainHead = this.chain.head
-      const chainTail = this.chain.genesis
-
-      if (!this.headHash) {
-        await addBlock(chainTail)
-        await this.updateHeadHash(chainTail.hash)
-      }
-
-      Assert.isNotNull(this.headHash, 'headHash should be set previously or to chainTail.hash')
-
-      const accountHeadHash = this.headHash
-
-      if (chainHead.hash.equals(accountHeadHash)) {
-        return
-      }
-
-      const accountHead = await this.chain.getHeader(accountHeadHash)
-
-      Assert.isNotNull(
-        accountHead,
-        `Accounts head not found in chain: ${this.headHash.toString('hex')}`,
-      )
-
-      const { fork, isLinear } = await this.chain.findFork(accountHead, chainHead)
-      if (!fork) {
-        return
-      }
-
-      // Remove the old fork chain
-      if (!isLinear) {
-        for await (const header of this.chain.iterateFrom(
-          accountHead,
-          fork,
-          undefined,
-          false,
-        )) {
-          // Don't remove the fork
-          if (!header.hash.equals(fork.hash)) {
-            await removeBlock(header)
-          }
-
-          await this.updateHeadHash(header.hash)
-        }
-      }
-
-      for await (const header of this.chain.iterateTo(fork, chainHead, undefined, false)) {
-        if (header.hash.equals(fork.hash)) {
-          continue
-        }
-        await addBlock(header)
-        await this.updateHeadHash(header.hash)
-      }
+      await this.chainProcessor.update()
 
       this.logger.debug(
-        '\nUpdated Head: \n',
-        `Fork: ${fork.hash.toString('hex')} (${
-          fork.sequence === GENESIS_BLOCK_SEQUENCE ? 'GENESIS' : '???'
-        })`,
-        '\n',
-        'Account:',
-        accountHead?.hash.toString('hex'),
-        '\n',
-        'Chain:',
-        chainHead?.hash.toString('hex'),
-        '\n',
+        `Updated Accounts Head: ${String(this.chainProcessor.hash?.toString('hex'))}`,
       )
     } finally {
       this.updateHeadState.signalComplete()
@@ -217,6 +160,18 @@ export class Accounts {
     }
   }
 
+  async load(): Promise<void> {
+    for await (const account of this.db.loadAccounts()) {
+      this.accounts.set(account.name, account)
+    }
+
+    const meta = await this.db.loadAccountsMeta()
+    this.defaultAccount = meta.defaultAccountName
+    this.chainProcessor.hash = meta.headHash ? Buffer.from(meta.headHash, 'hex') : null
+
+    await this.loadTransactionsFromDb()
+  }
+
   async close(): Promise<void> {
     if (!this.isOpen) {
       return
@@ -232,12 +187,12 @@ export class Accounts {
     }
     this.isStarted = true
 
-    if (this.headHash) {
-      const hasHeadBlock = await this.chain.hasBlock(this.headHash)
+    if (this.chainProcessor.hash) {
+      const hasHeadBlock = await this.chain.hasBlock(this.chainProcessor.hash)
 
       if (!hasHeadBlock) {
         this.logger.error(
-          `Resetting accounts database because accounts head was not found in chain: ${this.headHash.toString(
+          `Resetting accounts database because accounts head was not found in chain: ${this.chainProcessor.hash.toString(
             'hex',
           )}`,
         )
@@ -272,7 +227,7 @@ export class Accounts {
 
     if (this.db.database.isOpen) {
       await this.saveTransactionsToDb()
-      await this.updateHeadHash(this.headHash)
+      await this.updateHeadHash(this.chainProcessor.hash)
     }
   }
 
@@ -355,7 +310,6 @@ export class Accounts {
   }
 
   async updateHeadHash(headHash: Buffer | null): Promise<void> {
-    this.headHash = headHash
     const hashString = headHash && headHash.toString('hex')
     await this.db.setHeadHash(hashString)
   }
@@ -582,7 +536,7 @@ export class Accounts {
       return
     }
 
-    if (this.headHash === null) {
+    if (this.chainProcessor.hash === null) {
       this.logger.debug('Skipping scan, there is no blocks to scan')
       return
     }
@@ -594,7 +548,7 @@ export class Accounts {
     // but setting this.scan is our lock so updating the head doesn't run again
     await this.updateHeadState?.wait()
 
-    const accountHeadHash = this.headHash
+    const accountHeadHash = this.chainProcessor.hash
 
     const scanFor = Array.from(this.accounts.values())
       .filter((a) => a.rescan !== null && a.rescan <= scan.startedAt)
@@ -832,11 +786,11 @@ export class Accounts {
       return
     }
 
-    if (this.headHash === null) {
+    if (this.chainProcessor.hash === null) {
       return
     }
 
-    const head = await this.chain.getHeader(this.headHash)
+    const head = await this.chain.getHeader(this.chainProcessor.hash)
 
     if (head === null) {
       return
@@ -894,11 +848,11 @@ export class Accounts {
       return
     }
 
-    if (this.headHash === null) {
+    if (this.chainProcessor.hash === null) {
       return
     }
 
-    const head = await this.chain.getHeader(this.headHash)
+    const head = await this.chain.getHeader(this.chainProcessor.hash)
 
     if (head === null) {
       return
@@ -1041,18 +995,6 @@ export class Accounts {
     const key = generateNewPublicAddress(account.spendingKey)
     account.publicAddress = key.public_address
     await this.db.setAccount(account)
-  }
-
-  async load(): Promise<void> {
-    for await (const account of this.db.loadAccounts()) {
-      this.accounts.set(account.name, account)
-    }
-
-    const meta = await this.db.loadAccountsMeta()
-    this.defaultAccount = meta.defaultAccountName
-    this.headHash = meta.headHash ? Buffer.from(meta.headHash, 'hex') : null
-
-    await this.loadTransactionsFromDb()
   }
 
   protected assertHasAccount(account: Account): void {

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -124,11 +124,13 @@ export class Accounts {
     this.updateHeadState = new ScanState()
 
     try {
-      await this.chainProcessor.update()
+      const { hashChanged } = await this.chainProcessor.update()
 
-      this.logger.debug(
-        `Updated Accounts Head: ${String(this.chainProcessor.hash?.toString('hex'))}`,
-      )
+      if (hashChanged) {
+        this.logger.debug(
+          `Updated Accounts Head: ${String(this.chainProcessor.hash?.toString('hex'))}`,
+        )
+      }
     } finally {
       this.updateHeadState.signalComplete()
       this.updateHeadState = null

--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -77,11 +77,12 @@ export class ChainProcessor {
       const iter = this.chain.iterateFrom(head, fork, undefined, false)
 
       for await (const remove of iter) {
-        if (!remove.hash.equals(fork.hash)) {
-          await this.remove(remove)
+        if (remove.hash.equals(fork.hash)) {
+          continue
         }
 
-        this.hash = remove.hash
+        await this.remove(remove)
+        this.hash = remove.previousBlockHash
       }
     }
 

--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -35,7 +35,7 @@ export class ChainProcessor {
 
   constructor(options: { logger?: Logger; chain: Blockchain; head: Buffer | null }) {
     this.chain = options.chain
-    this.logger = options.logger ?? createRootLogger()
+    this.logger = (options.logger ?? createRootLogger()).withTag('chainprocessor')
     this.hash = options.head
   }
 

--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -28,20 +28,13 @@ import { BlockHeader } from './primitives'
  */
 export class ChainProcessor {
   chain: Blockchain
-  name: string | null
   hash: Buffer | null = null
   logger: Logger
   onAdd = new Event<[block: BlockHeader]>()
   onRemove = new Event<[block: BlockHeader]>()
 
-  constructor(options: {
-    name?: string
-    logger?: Logger
-    chain: Blockchain
-    head: Buffer | null
-  }) {
+  constructor(options: { logger?: Logger; chain: Blockchain; head: Buffer | null }) {
     this.chain = options.chain
-    this.name = options.name ?? null
     this.logger = options.logger ?? createRootLogger()
     this.hash = options.head
   }

--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -40,11 +40,11 @@ export class ChainProcessor {
     this.hash = options.head
   }
 
-  async add(header: BlockHeader): Promise<void> {
+  private async add(header: BlockHeader): Promise<void> {
     await this.onAdd.emitAsync(header)
   }
 
-  async remove(header: BlockHeader): Promise<void> {
+  private async remove(header: BlockHeader): Promise<void> {
     await this.onRemove.emitAsync(header)
   }
 

--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '.'
 import { Blockchain } from './blockchain'
 import { Event } from './event'
 import { createRootLogger, Logger } from './logger'
@@ -61,9 +62,11 @@ export class ChainProcessor {
     }
 
     const head = await this.chain.getHeader(this.hash)
-    if (!head) {
-      return
-    }
+
+    Assert.isNotNull(
+      head,
+      `Chain processor head not found in chain: ${this.hash.toString('hex')}`,
+    )
 
     const { fork, isLinear } = await this.chain.findFork(head, chainHead)
     if (!fork) {

--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -1,11 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Assert } from '.'
-import { Blockchain } from './blockchain'
+import type { Blockchain } from './blockchain'
+import type { BlockHeader } from './primitives'
+import { Assert } from './assert'
 import { Event } from './event'
 import { createRootLogger, Logger } from './logger'
-import { BlockHeader } from './primitives'
 
 /**
  * This is used to get a non synchronous chain of block events from the blockchain

--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -108,7 +108,6 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
     const processor = new ChainProcessor({
       chain: node.chain,
       logger: node.logger,
-      name: 'FollowChain',
       head: head,
     })
 


### PR DESCRIPTION
## Summary

ChainProcessor was added as part of the syncing service for iterating from one block hash to another, including forks. We can use that same code in `accounts` to reduce some duplication and slim down that file a bit, since it's already fairly large.

I did a bit of refactoring on ChainProcessor in this PR -- The only part that's necessary is setting hash to previousBlockHash when removing blocks. I tried to keep the changes to individual commits so they can be reverted if they're not desirable.

Fixes IRO-1490

## Testing Plan

I ran on a node from scratch and verified that expected transactions still get discovered and added to the balance. Forking is a bit difficult to test on a live chain, but we have a test in accounts.test.ts that validates forking.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
