### PR TITLE
Allow version to be driven by lib consumer

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ironfish-cli",
-  "version": "0.0.0",
+  "version": "0.1.19",
   "description": "Command line Iron Fish node",
   "author": "Iron Fish <contact@ironfish.network> (https://ironfish.network)",
   "engines": {

--- a/ironfish-cli/scripts/build.sh
+++ b/ironfish-cli/scripts/build.sh
@@ -18,8 +18,13 @@ if ! command -v git &> /dev/null; then
     exit 1
 fi
 
-echo "Inserting GIT hash into ironfish/package.json as gitHash"
+
 GIT_HASH=$(git rev-parse --short HEAD)
+
+echo "Inserting GIT hash into ironfish-cli/package.json as gitHash"
+cat <<< "$(jq --arg gh "$GIT_HASH" '.gitHash = $gh' < ironfish-cli/package.json)" > ironfish-cli/package.json
+
+echo "Inserting GIT hash into ironfish/package.json as gitHash"
 cat <<< "$(jq --arg gh "$GIT_HASH" '.gitHash = $gh' < ironfish/package.json)" > ironfish/package.json
 
 echo "Installing from lockfile"

--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -20,6 +20,7 @@ import {
   VerboseFlag,
   VerboseFlagKey,
 } from './flags'
+import { IronfishCliPKG } from './package'
 import { hasUserResponseError } from './utils'
 
 export type SIGNALS = 'SIGTERM' | 'SIGINT' | 'SIGUSR2'
@@ -125,7 +126,7 @@ export abstract class IronfishCommand extends Command {
     }
 
     this.sdk = await IronfishSdk.init({
-      agent: 'cli',
+      pkg: IronfishCliPKG,
       configOverrides: configOverrides,
       configName: typeof configFlag === 'string' ? configFlag : undefined,
       dataDir: typeof dataDirFlag === 'string' ? dataDirFlag : undefined,

--- a/ironfish-cli/src/commands/start.test.ts
+++ b/ironfish-cli/src/commands/start.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { expect as expectCli, test } from '@oclif/test'
 import * as ironfishmodule from 'ironfish'
+import { IronfishCliPKG } from '../package'
 
 jest.mock('ironfish', () => {
   const originalModule = jest.requireActual('ironfish')
@@ -106,6 +107,7 @@ describe('start command', () => {
       config: config,
       internal: internal,
       chain: chain,
+      pkg: IronfishCliPKG,
     }
 
     ironfishmodule.IronfishSdk.init = jest.fn().mockImplementation(() => ({

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -2,15 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import {
-  Assert,
-  IronfishNode,
-  NodeUtils,
-  Package,
-  PrivateIdentity,
-  PromiseUtils,
-} from 'ironfish'
-import { Platform } from 'ironfish'
+import { Assert, IronfishNode, NodeUtils, PrivateIdentity, PromiseUtils } from 'ironfish'
 import tweetnacl from 'tweetnacl'
 import { IronfishCommand, SIGNALS } from '../command'
 import {
@@ -170,15 +162,14 @@ export default class Start extends IronfishCommand {
     const nodeName = this.sdk.config.get('nodeName').trim() || null
     const blockGraffiti = this.sdk.config.get('blockGraffiti').trim() || null
     const peerPort = this.sdk.config.get('peerPort')
-    const peerAgent = Platform.getAgent('cli')
     const bootstraps = this.sdk.config.getArray('bootstrapNodes')
 
     this.log(`\n${ONE_FISH_IMAGE}`)
-    this.log(`Version       ${Package.version} @ ${Package.git}`)
+    this.log(`Version       ${node.pkg.version} @ ${node.pkg.git}`)
     this.log(`Node Name     ${nodeName || 'NONE'}`)
     this.log(`Graffiti      ${blockGraffiti || 'NONE'}`)
     this.log(`Peer Identity ${node.peerNetwork.localPeer.publicIdentity}`)
-    this.log(`Peer Agent    ${peerAgent}`)
+    this.log(`Peer Agent    ${node.peerNetwork.localPeer.agent}`)
     this.log(`Peer Port     ${peerPort}`)
     this.log(`Bootstrap     ${bootstraps.join(',') || 'NONE'}`)
     this.log(` `)

--- a/ironfish-cli/src/hooks/version.ts
+++ b/ironfish-cli/src/hooks/version.ts
@@ -4,8 +4,8 @@
 
 /* eslint-disable no-console */
 import { Hook } from '@oclif/config'
-import { Package } from 'ironfish'
 import { Platform } from 'ironfish'
+import { IronfishCliPKG } from '../package'
 
 const VersionHook: Hook<'init'> = (): void => {
   const isVersionCmd = process.argv[2] === 'version'
@@ -15,9 +15,9 @@ const VersionHook: Hook<'init'> = (): void => {
   if (showVersion) {
     const runtime = Platform.getRuntime()
 
-    console.log(`name       ${Package.name}`)
-    console.log(`version    ${Package.version}`)
-    console.log(`git        ${Package.git}`)
+    console.log(`name       ${IronfishCliPKG.name}`)
+    console.log(`version    ${IronfishCliPKG.version}`)
+    console.log(`git        ${IronfishCliPKG.git}`)
     console.log(`runtime    ${runtime.type}/${runtime.runtime}`)
 
     return process.exit(0)

--- a/ironfish-cli/src/package.ts
+++ b/ironfish-cli/src/package.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { getPackageFrom } from 'ironfish'
+import pkg from '../package.json'
+
+export const IronfishCliPKG = getPackageFrom(pkg)

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ironfish",
-  "version": "0.1.19",
-  "gitHash": "",
+  "version": "0.0.0",
   "private": true,
   "author": "Iron Fish <contact@ironfish.network> (https://ironfish.network)",
   "main": "build/src",

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -11,6 +11,8 @@ import { DEFAULT_WEBSOCKET_PORT } from '../fileStores/config'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
 import { IronfishNode } from '../node'
+import { IronfishPKG } from '../package'
+import { Platform } from '../platform'
 import { Block } from '../primitives'
 import { SerializedBlock } from '../primitives/block'
 import { BlockHeader } from '../primitives/blockheader'
@@ -128,7 +130,7 @@ export class PeerNetwork {
 
   constructor(options: {
     identity?: PrivateIdentity
-    agent: string
+    agent?: string
     webSocket: IsomorphicWebSocketConstructor
     listen?: boolean
     port?: number
@@ -159,7 +161,7 @@ export class PeerNetwork {
 
     this.localPeer = new LocalPeer(
       identity,
-      options.agent,
+      options.agent || Platform.getAgent(IronfishPKG),
       VERSION_PROTOCOL,
       options.chain,
       options.node.workerPool,

--- a/ironfish/src/package.ts
+++ b/ironfish/src/package.ts
@@ -2,11 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import pkg from '../package.json'
+import pkgJson from '../package.json'
 
-export const Package = {
-  name: pkg.name,
-  license: pkg.license,
-  version: pkg.version,
-  git: pkg.gitHash || 'src',
+interface PackageJson {
+  name: string
+  license: string
+  version: string
+  gitHash?: string
 }
+
+export type Package = {
+  name: string
+  license: string
+  version: string
+  git: string
+}
+
+export const getPackageFrom = (p: PackageJson): Package => ({
+  name: p.name,
+  license: p.license,
+  version: p.version,
+  git: p.gitHash || 'src',
+})
+
+export const IronfishPKG = getPackageFrom(pkgJson)

--- a/ironfish/src/platform.ts
+++ b/ironfish/src/platform.ts
@@ -23,12 +23,15 @@ const getRuntime = ():
   return { type: 'unknown', runtime: 'unknown' }
 }
 
-const getAgent = (name: string): string => {
-  let agent = `if/${name}`
-  if (Package.git) {
-    agent += `/${Package.git.slice(0, 8)}`
-  }
-  return agent
+/**
+ * Returns a user agent that combines the name and version components
+ *
+ * ironfish-cli/0.1.19/src
+ * ironfish-sdk/0.1.19/36c71af
+ * ironfish-sdk/0.1.19/src
+ */
+const getAgent = (pkg: Package): string => {
+  return `${pkg.name}/${pkg.version}/${pkg.git.slice(0, 8)}`
 }
 
 export const Platform = { getAgent, getRuntime }

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { IronfishNode } from '../../../node'
-import { Package } from '../../../package'
 import { MathUtils, PromiseUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
 
@@ -177,8 +176,8 @@ function getStatus(node: IronfishNode): GetStatusResponse {
     },
     node: {
       status: node.started ? 'started' : 'stopped',
-      version: Package.version,
-      git: Package.git,
+      version: node.pkg.version,
+      git: node.pkg.git,
     },
     memory: {
       heapUsed: node.metrics.heapUsed.value,

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -16,6 +16,7 @@ import { FileReporter } from './logger/reporters'
 import { MetricsMonitor } from './metrics'
 import { IsomorphicWebSocketConstructor } from './network/types'
 import { IronfishNode } from './node'
+import { IronfishPKG, Package } from './package'
 import { Platform } from './platform'
 import {
   ApiNamespace,
@@ -28,7 +29,7 @@ import { Strategy } from './strategy'
 import { NodeUtils } from './utils'
 
 export class IronfishSdk {
-  agent: string
+  pkg: Package
   client: IronfishIpcClient
   clientMemory: IronfishMemoryClient
   config: Config
@@ -40,7 +41,7 @@ export class IronfishSdk {
   privateIdentity: BoxKeyPair | null | undefined
 
   private constructor(
-    agent: string,
+    pkg: Package,
     client: IronfishIpcClient,
     clientMemory: IronfishMemoryClient,
     config: Config,
@@ -50,7 +51,7 @@ export class IronfishSdk {
     metrics: MetricsMonitor,
     strategyClass: typeof Strategy | null = null,
   ) {
-    this.agent = agent
+    this.pkg = pkg
     this.client = client
     this.clientMemory = clientMemory
     this.config = config
@@ -62,7 +63,7 @@ export class IronfishSdk {
   }
 
   static async init({
-    agent,
+    pkg,
     configName,
     configOverrides,
     fileSystem,
@@ -71,7 +72,7 @@ export class IronfishSdk {
     metrics,
     strategyClass,
   }: {
-    agent?: string
+    pkg?: Package
     configName?: string
     configOverrides?: Partial<ConfigOptions>
     fileSystem?: FileSystem
@@ -144,10 +145,8 @@ export class IronfishSdk {
 
     const clientMemory = new IronfishMemoryClient(logger)
 
-    agent = agent || 'sdk'
-
     return new IronfishSdk(
-      agent,
+      pkg || IronfishPKG,
       client,
       clientMemory,
       config,
@@ -171,7 +170,7 @@ export class IronfishSdk {
     const webSocket = (await require('ws')) as IsomorphicWebSocketConstructor
 
     const node = await IronfishNode.init({
-      agent: Platform.getAgent(this.agent),
+      pkg: this.pkg,
       config: this.config,
       internal: this.internal,
       files: this.fileSystem,


### PR DESCRIPTION
## Summary

This makes a change so that previously, the version sent out everywhere
and the agent string was driven by the library. This doesn't tell the
full story, because the real version is the person who is consuming the
library and potentially writing custom code on top of the
library.

This lets users who consume the library override the package and produce
their own agent and version library using the new Package type that you
can produce from a Package.json file and pass down into the node.

https://linear.app/ironfish/issue/IRO-1392/fix-node-versioning

```js
// old
Peer Agent    if/cli/36c71af
// new
Peer Agent    ironfish-cli/0.1.19/36c71af
```

## Testing Plan

Test using brew beta and locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
