### PR TITLE
feat(cli,ironfish): Show heap total in status and rename RSS to Memory

### DIFF
--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -71,7 +71,7 @@ describe('status', () => {
         expectCli(ctx.stdout).include('Version')
         expectCli(ctx.stdout).include('Node')
         expectCli(ctx.stdout).include('Heap Used')
-        expectCli(ctx.stdout).include('RSS')
+        expectCli(ctx.stdout).include('Memory')
         expectCli(ctx.stdout).include('P2P Network')
         expectCli(ctx.stdout).include('Mining')
         expectCli(ctx.stdout).include('Mem Pool')

--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -17,8 +17,9 @@ describe('status', () => {
       git: 'src',
     },
     memory: {
+      heapTotal: 2,
       heapUsed: 1,
-      rss: 2,
+      rss: 3,
     },
     miningDirector: { status: 'stopped', miners: 0, blocks: 0 },
     memPool: { size: 0 },

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -62,6 +62,7 @@ export default class Status extends IronfishCommand {
 
 function renderStatus(content: GetStatusResponse): string {
   const nodeStatus = `${content.node.status.toUpperCase()}`
+  const heapTotal = FileUtils.formatMemorySize(content.memory.heapTotal)
   const heapUsed = FileUtils.formatMemorySize(content.memory.heapUsed)
   const rss = FileUtils.formatMemorySize(content.memory.rss)
   let blockSyncerStatus = content.blockSyncer.status.toString().toUpperCase()
@@ -104,8 +105,8 @@ function renderStatus(content: GetStatusResponse): string {
   return `
 Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
-Heap Used            ${heapUsed}
-RSS                  ${rss}
+Heap Used            ${heapUsed} / ${heapTotal}
+Memory               ${rss}
 P2P Network          ${peerNetworkStatus}
 Mining               ${miningDirectorStatus}
 Mem Pool             ${memPoolStatus}

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -20,6 +20,7 @@ export class MetricsMonitor {
   readonly p2p_OutboundTraffic_WS: Meter
   readonly p2p_OutboundTraffic_WebRTC: Meter
 
+  readonly heapTotal: Gauge
   readonly heapUsed: Gauge
   readonly rss: Gauge
   private memoryInterval: SetIntervalToken | null
@@ -36,6 +37,7 @@ export class MetricsMonitor {
     this.p2p_OutboundTraffic_WS = this.addMeter()
     this.p2p_OutboundTraffic_WebRTC = this.addMeter()
 
+    this.heapTotal = new Gauge()
     this.heapUsed = new Gauge()
     this.rss = new Gauge()
     this.memoryInterval = null
@@ -72,6 +74,7 @@ export class MetricsMonitor {
 
   private refreshMemory(): void {
     const memoryUsage = process.memoryUsage()
+    this.heapTotal.value = memoryUsage.heapTotal
     this.heapUsed.value = memoryUsage.heapUsed
     this.rss.value = memoryUsage.rss
   }

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -19,6 +19,7 @@ export type GetStatusResponse = {
     git: string
   }
   memory: {
+    heapTotal: number
     heapUsed: number
     rss: number
   }
@@ -76,6 +77,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
       .defined(),
     memory: yup
       .object({
+        heapTotal: yup.number().defined(),
         heapUsed: yup.number().defined(),
         rss: yup.number().defined(),
       })
@@ -180,6 +182,7 @@ function getStatus(node: IronfishNode): GetStatusResponse {
       git: node.pkg.git,
     },
     memory: {
+      heapTotal: node.metrics.heapTotal.value,
       heapUsed: node.metrics.heapUsed.value,
       rss: node.metrics.rss.value,
     },


### PR DESCRIPTION
## Summary

* Add a gauge for total heap
* Show Memory instead of RSS in the status command

## Testing Plan

Updated unit test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
