### PR TITLE
Minor typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Once your environment is setup - you can run the CLI by following [these directi
 ## Structure of the repository
 
 - [ironfish](./ironfish/README.md): The library that contains the IronfishSDK and all Ironfish code written in TypeScript.
-- [ironfish-cli](./ironfish-cli/README.md): The main client for Iron Fish as of today. It is a command line interface built on Node. More details on [our documentation](https://ironfish.network/docs/onboarding/iron-fish-tutorial).
+- [ironfish-cli](./ironfish-cli/README.md): The main client for Iron Fish as of today. It is a command-line interface built on Node. More details in [our documentation](https://ironfish.network/docs/onboarding/iron-fish-tutorial).
 - [ironfish-rust](./ironfish-rust/README.md): Core API for interacting with the transactions and chain and using ZKP.
 - [ironfish-rust-nodejs](./ironfish-rust-nodejs/README.md): Wrapper for `ironfish-rust` as a native NodeJS addon.
 - [ironfish-rust-wasm](./ironfish-rust-wasm/README.md): Wrapper for `ironfish-rust` in WASM.


### PR DESCRIPTION
## Summary

`More details on our documentation` -> `More details in our documentation`
And hypenating `command line interface` -> `command-line interface`

## Testing Plan

n/a

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ x] No
```