### PR TITLE
Add debug command with accounts head info

### DIFF
--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -34,8 +34,8 @@ export default class Debug extends IronfishCommand {
     const telemetryEnabled = this.sdk.config.get('enableTelemetry').toString()
 
     this.log(`
-Ironfish version        ${Package.version} @ ${Package.git}
-Operating System        ${os.type()} ${process.arch}
+Iron Fish version       ${Package.version} @ ${Package.git}
+Operating system        ${os.type()} ${process.arch}
 CPU model               ${cpuName}
 CPU threads             ${cpuThreads}
 RAM total               ${memTotal}

--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -1,7 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { NodeUtils, Package } from 'ironfish'
+import { FileUtils, NodeUtils, Package } from 'ironfish'
+import os from 'os'
 import { IronfishCommand } from '../command'
 import { LocalFlags } from '../flags'
 
@@ -24,14 +25,22 @@ export default class Debug extends IronfishCommand {
     const accountsHeadInChain = !!accountsBlockHeader
     const accountsHeadSequence = accountsBlockHeader?.sequence || 'null'
 
-    // Note that this will return win32 for Windows even if on 64-bit
-    // Full list: https://nodejs.org/api/process.html#process_process_platform
-    const userOS = process.platform
+    const cpus = os.cpus()
+    const cpuName = cpus[0].model
+    const cpuThreads = cpus.length
+
+    const memTotal = FileUtils.formatMemorySize(os.totalmem())
+
+    const telemetryEnabled = this.sdk.config.get('enableTelemetry').toString()
 
     this.log(`
 Ironfish version        ${Package.version} @ ${Package.git}
-Operating System        ${userOS}
+Operating System        ${os.type()} ${process.arch}
+CPU model               ${cpuName}
+CPU threads             ${cpuThreads}
+RAM total               ${memTotal}
 Node version            ${process.version}
+Telemetry enabled       ${telemetryEnabled}
 Accounts head hash      ${accountsHeadHash}
 Accounts head in chain  ${accountsHeadInChain.toString()}
 Accounts head sequence  ${accountsHeadSequence}

--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { FileUtils, NodeUtils, Package } from 'ironfish'
+import { FileUtils, IronfishPKG, NodeUtils } from 'ironfish'
 import os from 'os'
 import { IronfishCommand } from '../command'
 import { LocalFlags } from '../flags'
@@ -34,7 +34,8 @@ export default class Debug extends IronfishCommand {
     const telemetryEnabled = this.sdk.config.get('enableTelemetry').toString()
 
     this.log(`
-Iron Fish version       ${Package.version} @ ${Package.git}
+Iron Fish version       ${node.pkg.version} @ ${node.pkg.git}
+Iron Fish library       ${IronfishPKG.version} @ ${IronfishPKG.git}
 Operating system        ${os.type()} ${process.arch}
 CPU model               ${cpuName}
 CPU threads             ${cpuThreads}

--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { NodeUtils, Package } from 'ironfish'
+import { IronfishCommand } from '../command'
+import { LocalFlags } from '../flags'
+
+export default class Debug extends IronfishCommand {
+  static description = 'Show debug information to help locate issues'
+  static hidden = true
+
+  static flags = {
+    ...LocalFlags,
+  }
+
+  async start(): Promise<void> {
+    const node = await this.sdk.node({ autoSeed: false })
+    await NodeUtils.waitForOpen(node, null, { upgrade: false })
+
+    const accountsMeta = await node.accounts.db.loadAccountsMeta()
+    const accountsHeadHash = accountsMeta.headHash !== null ? accountsMeta.headHash : ''
+
+    const accountsBlockHeader = await node.chain.getHeader(Buffer.from(accountsHeadHash, 'hex'))
+    const accountsHeadInChain = !!accountsBlockHeader
+    const accountsHeadSequence = accountsBlockHeader?.sequence || 'null'
+
+    // Note that this will return win32 for Windows even if on 64-bit
+    // Full list: https://nodejs.org/api/process.html#process_process_platform
+    const userOS = process.platform
+
+    this.log(`
+Ironfish version        ${Package.version} @ ${Package.git}
+Operating System        ${userOS}
+Node version            ${process.version}
+Accounts head hash      ${accountsHeadHash}
+Accounts head in chain  ${accountsHeadInChain.toString()}
+Accounts head sequence  ${accountsHeadSequence}
+    `)
+  }
+}


### PR DESCRIPTION
## Summary

Create a `debug` command for the CLI which will house data that will be helpful in debugging issues. For now, just has accounts head information, and a few bits about the OS and tool versions.

Resolves IRO-1484

## Testing Plan

`yarn start:once debug`
`yarn start:once debug --datadir ~/.null`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
