### PR TITLE
Format miner hash rate using metric system

### DIFF
--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -5,6 +5,7 @@ import { flags } from '@oclif/command'
 import cli from 'cli-ux'
 import {
   AsyncUtils,
+  FileUtils,
   Miner as IronfishMiner,
   MineRequest,
   NewBlocksStreamResponse,
@@ -58,7 +59,9 @@ export class Miner extends IronfishCommand {
     }
 
     const updateHashPower = () => {
-      cli.action.status = `${Math.max(0, Math.floor(miner.hashRate.rate5s))} H/s`
+      const rate = Math.max(0, Math.floor(miner.hashRate.rate5s))
+      const formatted = `${FileUtils.formatHashRate(rate)}/s (${rate})`
+      cli.action.status = formatted
     }
 
     const onStartMine = (request: MineRequest) => {

--- a/ironfish/src/utils/file.test.ts
+++ b/ironfish/src/utils/file.test.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { FileUtils } from './file'
+
+describe('FileUtils', () => {
+  it('format files', () => {
+    expect(FileUtils.formatFileSize(/*               */ 1)).toEqual('1 B')
+    expect(FileUtils.formatFileSize(/*             */ 999)).toEqual('999 B')
+    expect(FileUtils.formatFileSize(/*            */ 1000)).toEqual('1.00 KB')
+    expect(FileUtils.formatFileSize(/*          */ 999999)).toEqual('999.99 KB')
+    expect(FileUtils.formatFileSize(/*         */ 1000000)).toEqual('1.00 MB')
+    expect(FileUtils.formatFileSize(/*       */ 999999999)).toEqual('999.99 MB')
+    expect(FileUtils.formatFileSize(/*      */ 1000000000)).toEqual('1.00 GB')
+    expect(FileUtils.formatFileSize(/*   */ 1000000000000)).toEqual('1.00 TB')
+    expect(FileUtils.formatFileSize(/* */ 999999999999999)).toEqual('999.99 TB')
+    expect(FileUtils.formatFileSize(/**/ 1000000000000000)).toEqual('1.00 PB')
+  })
+
+  it('format hash rate', () => {
+    expect(FileUtils.formatHashRate(/*               */ 1)).toEqual('1 H')
+    expect(FileUtils.formatHashRate(/*             */ 999)).toEqual('999 H')
+    expect(FileUtils.formatHashRate(/*            */ 1000)).toEqual('1.00 KH')
+    expect(FileUtils.formatHashRate(/*          */ 999999)).toEqual('999.99 KH')
+    expect(FileUtils.formatHashRate(/*         */ 1000000)).toEqual('1.00 MH')
+    expect(FileUtils.formatHashRate(/*       */ 999999999)).toEqual('999.99 MH')
+    expect(FileUtils.formatHashRate(/*      */ 1000000000)).toEqual('1.00 GH')
+    expect(FileUtils.formatHashRate(/*   */ 1000000000000)).toEqual('1.00 TH')
+    expect(FileUtils.formatHashRate(/* */ 999999999999999)).toEqual('999.99 TH')
+    expect(FileUtils.formatHashRate(/**/ 1000000000000000)).toEqual('1.00 PH')
+  })
+
+  it('format memory', () => {
+    expect(FileUtils.formatMemorySize(/*                   */ 1)).toEqual('1 B')
+    expect(FileUtils.formatMemorySize(/*                */ 1023)).toEqual('1023 B')
+    expect(FileUtils.formatMemorySize(/*                */ 1024)).toEqual('1.00 KiB')
+    expect(FileUtils.formatMemorySize(/*             */ 1048575)).toEqual('1023.99 KiB')
+    expect(FileUtils.formatMemorySize(/*             */ 1048576)).toEqual('1.00 MiB')
+    expect(FileUtils.formatMemorySize(/*          */ 1073741823)).toEqual('1023.99 MiB')
+    expect(FileUtils.formatMemorySize(/*          */ 1073741824)).toEqual('1.00 GiB')
+    expect(FileUtils.formatMemorySize(/*       */ 1099511627776)).toEqual('1.00 TiB')
+    expect(FileUtils.formatMemorySize(/**/ 1.125899906842623e15)).toEqual('1023.99 TiB')
+    expect(FileUtils.formatMemorySize(/**/ 1.125899906842624e15)).toEqual('1.00 PiB')
+  })
+})

--- a/ironfish/src/utils/file.ts
+++ b/ironfish/src/utils/file.ts
@@ -1,31 +1,55 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-type SizeSuffix = { B: string; KB: string; MB: string; GB: string }
+import { MathUtils } from './math'
 
-const fileSizeSuffix: SizeSuffix = { B: 'B', KB: 'KB', MB: 'MB', GB: 'GB' }
-const memorySizeSuffix: SizeSuffix = { B: 'B', KB: 'KiB', MB: 'MiB', GB: 'GiB' }
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+type SizeSuffix = { B: string; KB: string; MB: string; GB: string; TB: string; PB: string }
 
-const formatFileSize = (
-  bytes: number,
-  base = 1000,
-  suffix: SizeSuffix = fileSizeSuffix,
-): string => {
+const fileSizeSuffix: SizeSuffix = { B: 'B', KB: 'KB', MB: 'MB', GB: 'GB', TB: 'TB', PB: 'PB' }
+const hashRateSuffix: SizeSuffix = { B: 'H', KB: 'KH', MB: 'MH', GB: 'GH', TB: 'TH', PB: 'PH' }
+
+const memorySizeSuffix: SizeSuffix = {
+  B: 'B',
+  KB: 'KiB',
+  MB: 'MiB',
+  GB: 'GiB',
+  TB: 'TiB',
+  PB: 'PiB',
+}
+
+const formatSize = (bytes: number, base: number, suffix: SizeSuffix): string => {
   if (bytes < Math.pow(base, 1)) {
     return `${bytes.toFixed(0)} ${suffix.B}`
   }
   if (bytes < Math.pow(base, 2)) {
-    return (bytes / Math.pow(base, 1)).toFixed(0) + ` ${suffix.KB}`
+    return MathUtils.floor(bytes / Math.pow(base, 1), 2).toFixed(2) + ` ${suffix.KB}`
   }
   if (bytes < Math.pow(base, 3)) {
-    return (bytes / Math.pow(base, 2)).toFixed(2) + ` ${suffix.MB}`
-  } else {
-    return (bytes / Math.pow(base, 3)).toFixed(2) + ` ${suffix.GB}`
+    return MathUtils.floor(bytes / Math.pow(base, 2), 2).toFixed(2) + ` ${suffix.MB}`
   }
+  if (bytes < Math.pow(base, 4)) {
+    return MathUtils.floor(bytes / Math.pow(base, 3), 2).toFixed(2) + ` ${suffix.GB}`
+  }
+  if (bytes < Math.pow(base, 5)) {
+    return MathUtils.floor(bytes / Math.pow(base, 4), 2).toFixed(2) + ` ${suffix.TB}`
+  }
+
+  return MathUtils.floor(bytes / Math.pow(base, 5), 2).toFixed(2) + ` ${suffix.PB}`
+}
+
+const formatFileSize = (bytes: number): string => {
+  return formatSize(bytes, 1000, fileSizeSuffix)
 }
 
 const formatMemorySize = (bytes: number): string => {
-  return formatFileSize(bytes, 1024, memorySizeSuffix)
+  return formatSize(bytes, 1024, memorySizeSuffix)
 }
 
-export const FileUtils = { formatFileSize, formatMemorySize }
+const formatHashRate = (bytes: number): string => {
+  return formatSize(bytes, 1000, hashRateSuffix)
+}
+
+export const FileUtils = { formatFileSize, formatMemorySize, formatHashRate }

--- a/ironfish/src/utils/file.ts
+++ b/ironfish/src/utils/file.ts
@@ -3,9 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { MathUtils } from './math'
 
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 type SizeSuffix = { B: string; KB: string; MB: string; GB: string; TB: string; PB: string }
 
 const fileSizeSuffix: SizeSuffix = { B: 'B', KB: 'KB', MB: 'MB', GB: 'GB', TB: 'TB', PB: 'PB' }

--- a/ironfish/src/utils/math.test.ts
+++ b/ironfish/src/utils/math.test.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { MathUtils } from './math'
+
+describe('MathUtils', () => {
+  it('floor', () => {
+    expect(MathUtils.floor(999, 0).toString()).toEqual('999')
+    expect(MathUtils.floor(999, 2).toString()).toEqual('999')
+    expect(MathUtils.floor(999.999, 0).toString()).toEqual('999')
+    expect(MathUtils.floor(999.999, 1).toString()).toEqual('999.9')
+    expect(MathUtils.floor(999.999, 2).toString()).toEqual('999.99')
+  })
+})

--- a/ironfish/src/utils/math.ts
+++ b/ironfish/src/utils/math.ts
@@ -32,6 +32,16 @@ function round(value: number, places: number): number {
 }
 
 /**
+ * Floor the decimal places to @places
+ */
+function floor(value: number, places: number): number {
+  const multiplier = Math.pow(10, places)
+  const adjusted = value * multiplier
+  const truncated = adjusted < 0 ? Math.ceil(adjusted) : Math.floor(adjusted)
+  return truncated / multiplier
+}
+
+/**
  * Round a number to the nearest threshold increment
  */
 function roundBy(num: number, threshold: number): number {
@@ -46,4 +56,4 @@ function min<T extends number | bigint>(a: T, b: T): T {
   return a > b ? b : a
 }
 
-export const MathUtils = { arrayAverage, arraySum, round, roundBy, min, max }
+export const MathUtils = { arrayAverage, arraySum, round, roundBy, min, max, floor }


### PR DESCRIPTION
## Summary

This PR wil now format the hash rate in metric increments similar to
file sizes while still printing the original value. It also adds tests
for the FileUtils, and fixes a few bugs I saw with rounding that
produced odd values.

```javascript
// old
Mining block 76858 on request 32... ⣷ 2276451 H/s
// new
Mining block 76858 on request 32... ⣷ 2.27 MH/s (2276451)
```

## Testing Plan

Added tests and tested miner locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
