### PR TITLE
Fix CR-LF issue on Windows and GitHub Desktop #923

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# From https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf
+
+*.ts text
+*.js text
+*.json text


### PR DESCRIPTION
## Summary
`yarn lint` fails when running on Windows with a repository pulled via GitHub Desktop. (Issue #923)
I believe the issue is with the addition of carriage returns to each line.

Adding a .gitattributes file to have .ts, .js, and .json files end with LF, not CR-LF when pulled into a Windows environment.

## Testing Plan
`yarn lint` passes with .gitattributes:

> C:\Users\mjolnir\Documents\GitHub\ironfish>yarn lint
> yarn run v1.22.17
> $ lerna run lint -- --max-warnings=0
> lerna notice cli v4.0.0
> lerna info versioning independent
> lerna info Executing command in 2 packages: "yarn run lint --max-warnings=0"
> lerna info run Ran npm script 'lint' in 'ironfish' in 58.3s:
> $ tsc -b && tsc -b tsconfig.test.json && eslint --ext .ts,.tsx,.js,.jsx src/ --max-warnings=0
> lerna info run Ran npm script 'lint' in 'ironfish-cli' in 28.2s:
> $ tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/ --max-warnings=0
> lerna success run Ran npm script 'lint' in 2 packages in 86.5s:
> lerna success - ironfish
> lerna success - ironfish-cli
> Done in 87.50s.

However `yarn test` fails with issues in \ironfish-cli

> C:\Users\mjolnir\Documents\GitHub\ironfish>yarn test
> yarn run v1.22.17
> $ lerna run test
> lerna notice cli v4.0.0
> lerna info versioning independent
> lerna info Executing command in 2 packages: "yarn run test"
> lerna info run Ran npm script 'test' in 'ironfish' in 26.8s:
> $ tsc -b && tsc -b tsconfig.test.json && jest
> lerna ERR! yarn run test exited 1 in 'ironfish-cli'
> lerna ERR! yarn run test stdout:
(and more failures after this...)

Related to #861 ?

Other CLI output - syncing messages from `yarn start start` `yarn start accounts:balance` `yarn start accounts:list` `yarn start miners:start` look properly formatted.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

I believe this will not break Linux/Mac builds, as they use LF, but I have no means to verify that.

```
[ ] Yes
[X] No
```
