### PR TITLE
Fix slow startup when accounts store is full

### DIFF
--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -228,13 +228,13 @@ export class AccountsDB {
       submittedSequence: number | null
     }>,
   ): Promise<void> {
-    for await (const value of this.transactions.getAllValuesIter()) {
+    for await (const [key, value] of this.transactions.getAllIter()) {
       const deserialized = {
         ...value,
         transaction: new Transaction(value.transaction, this.workerPool),
       }
 
-      map.set(deserialized.transaction.hash(), deserialized)
+      map.set(key, deserialized)
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes an issue where the node takes longer to start up as the number of transactions in the accounts database increases.

Fixes IRO-1512

## Testing Plan

Verified it's still possible to shut down/start up the node and check balance.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
