### PR TITLE
Add GetUnspentNotes worker pool task

### DIFF
--- a/ironfish/src/account/accounts.test.slow.ts
+++ b/ironfish/src/account/accounts.test.slow.ts
@@ -41,7 +41,7 @@ describe('Accounts', () => {
     await node.accounts.updateHead()
 
     // Initial balance should be 0
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
@@ -49,7 +49,7 @@ describe('Accounts', () => {
     await node.accounts.updateHead()
 
     // Balance after adding the genesis block should be 0
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
@@ -63,7 +63,7 @@ describe('Accounts', () => {
     await node.accounts.updateHead()
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -79,14 +79,14 @@ describe('Accounts', () => {
 
     // Initial balance should be 0
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
@@ -99,7 +99,7 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -111,7 +111,7 @@ describe('Accounts', () => {
     node.accounts['transactionMap'].clear()
 
     // Account should now have a balance of 0 after clearing the cache
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
@@ -119,7 +119,7 @@ describe('Accounts', () => {
     await node.accounts.loadTransactionsFromDb()
 
     // Balance should be back to 2000000000
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -134,14 +134,14 @@ describe('Accounts', () => {
     const account = await node.accounts.createAccount('test', true)
 
     // Initial balance should be 0
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
@@ -154,7 +154,7 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -187,7 +187,7 @@ describe('Accounts', () => {
 
     // Balance after adding the transaction that spends 2 should be 1999999998
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(1999999998),
       unconfirmed: BigInt(1999999998),
     })
@@ -203,14 +203,14 @@ describe('Accounts', () => {
     const account = await node.accounts.createAccount('test', true)
 
     // Initial balance should be 0
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
@@ -223,7 +223,7 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -259,7 +259,7 @@ describe('Accounts', () => {
 
     // Balance after adding the transaction that spends 2 should be 1999999998
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(1999999998),
       unconfirmed: BigInt(1999999998),
     })
@@ -275,14 +275,14 @@ describe('Accounts', () => {
     const account = await node.accounts.createAccount('test', true)
 
     // Initial balance should be 0
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
@@ -295,7 +295,7 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -340,7 +340,7 @@ describe('Accounts', () => {
 
     // Balance after adding the transaction that spends 2 should be 1999999998
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(1999999994),
       unconfirmed: BigInt(1999999994),
     })
@@ -383,14 +383,14 @@ describe('Accounts', () => {
     node.accounts['isStarted'] = true
 
     // Initial balance should be 0
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
@@ -403,7 +403,7 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
     await node.accounts.updateHead()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -424,14 +424,14 @@ describe('Accounts', () => {
     )
 
     // Transaction should be unconfirmed
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(1999999998),
     })
 
     // Expiring transactions should not yet remove the transaction
     await node.accounts.expireTransactions()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(1999999998),
     })
@@ -449,7 +449,7 @@ describe('Accounts', () => {
     // Expiring transactions should now remove the transaction
     await node.accounts.updateHead()
     await node.accounts.expireTransactions()
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -476,7 +476,7 @@ describe('Accounts', () => {
 
     // Initial balance should be 2000000000
     await nodeA.accounts.updateHead()
-    expect(nodeA.accounts.getBalance(accountA)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -560,15 +560,15 @@ describe('Accounts', () => {
     // Update account head and check all balances
     await nodeA.accounts.updateHead()
     await nodeB.accounts.updateHead()
-    expect(nodeA.accounts.getBalance(accountA)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
-    expect(nodeA.accounts.getBalance(accountB)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountB)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
-    expect(nodeB.accounts.getBalance(accountB)).toEqual({
+    await expect(nodeB.accounts.getBalance(accountB)).resolves.toEqual({
       confirmed: BigInt(4000000000),
       unconfirmed: BigInt(4000000000),
     })
@@ -580,11 +580,11 @@ describe('Accounts', () => {
     // Copy block B2 to nodeA
     await nodeA.chain.addBlock(blockB2)
     await nodeA.accounts.updateHead()
-    expect(nodeA.accounts.getBalance(accountA)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(2000000000),
     })
-    expect(nodeA.accounts.getBalance(accountB)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountB)).resolves.toEqual({
       confirmed: BigInt(4000000000),
       unconfirmed: BigInt(4000000000),
     })
@@ -658,15 +658,15 @@ describe('Accounts', () => {
     await nodeA.accounts.updateHead()
     await nodeB.accounts.updateHead()
 
-    expect(nodeA.accounts.getBalance(accountA)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
       confirmed: BigInt(1999999998),
       unconfirmed: BigInt(1999999998),
     })
-    expect(nodeA.accounts.getBalance(accountB)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountB)).resolves.toEqual({
       confirmed: BigInt(2),
       unconfirmed: BigInt(2),
     })
-    expect(nodeB.accounts.getBalance(accountA)).toEqual({
+    await expect(nodeB.accounts.getBalance(accountA)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -678,11 +678,11 @@ describe('Accounts', () => {
 
     // B should not have confirmed coins yet because the transaction isn't on a block
     // A should not have confirmed coins any more because the transaction is pending
-    expect(nodeA.accounts.getBalance(accountA)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(1999999998),
     })
-    expect(nodeA.accounts.getBalance(accountB)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountB)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(2),
     })
@@ -769,15 +769,15 @@ describe('Accounts', () => {
     await nodeA.accounts.updateHead()
     await nodeB.accounts.updateHead()
 
-    expect(nodeA.accounts.getBalance(accountA)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
       confirmed: BigInt(1999999998),
       unconfirmed: BigInt(1999999998),
     })
-    expect(nodeA.accounts.getBalance(accountB)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountB)).resolves.toEqual({
       confirmed: BigInt(2),
       unconfirmed: BigInt(2),
     })
-    expect(nodeB.accounts.getBalance(accountA)).toEqual({
+    await expect(nodeB.accounts.getBalance(accountA)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(1999999998),
     })
@@ -789,11 +789,11 @@ describe('Accounts', () => {
 
     // A should have its original coins
     // B should not have the coins any more
-    expect(nodeA.accounts.getBalance(accountA)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(3999999998),
     })
-    expect(nodeA.accounts.getBalance(accountB)).toEqual({
+    await expect(nodeA.accounts.getBalance(accountB)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(2),
     })

--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -44,7 +44,7 @@ describe('Accounts', () => {
 
     // Check nodeA balance
     await nodeA.accounts.updateHead()
-    expect(nodeA.accounts.getBalance(accountA)).toMatchObject({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
@@ -54,7 +54,7 @@ describe('Accounts', () => {
     expect(broadcastSpy).toHaveBeenCalledTimes(0)
 
     await nodeA.accounts.updateHead()
-    expect(nodeA.accounts.getBalance(accountA)).toMatchObject({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(0),
       unconfirmed: BigInt(1999999999),
     })
@@ -77,7 +77,7 @@ describe('Accounts', () => {
     })
 
     await nodeA.accounts.updateHead()
-    expect(nodeA.accounts.getBalance(accountA)).toMatchObject({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(0),
       unconfirmed: BigInt(3999999999),
     })

--- a/ironfish/src/blockchain/blockchain.test.perf.ts
+++ b/ironfish/src/blockchain/blockchain.test.perf.ts
@@ -56,8 +56,8 @@ describe('Blockchain', () => {
       blocksB.push(blockB)
     }
 
-    const balanceA = nodeA.accounts.getBalance(accountA)
-    const balanceB = nodeB.accounts.getBalance(accountB)
+    const balanceA = await nodeA.accounts.getBalance(accountA)
+    const balanceB = await nodeB.accounts.getBalance(accountB)
 
     // You'll need to update this if the block reward changes
     expect(balanceA.confirmed).toEqual(BigInt(1999999901))

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -91,7 +91,7 @@ describe('Create genesis block', () => {
 
     // Balance should still be zero, since generating the block should clear out
     // any notes made in the process
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
@@ -104,7 +104,7 @@ describe('Create genesis block', () => {
     await node.accounts.updateHead()
 
     // Check that the balance is what's expected
-    expect(node.accounts.getBalance(account)).toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
       confirmed: amountBigint,
       unconfirmed: amountBigint,
     })
@@ -142,7 +142,7 @@ describe('Create genesis block', () => {
     await newNode.accounts.updateHead()
     await newNode.accounts.scanTransactions()
 
-    expect(newNode.accounts.getBalance(account)).toEqual({
+    await expect(newNode.accounts.getBalance(account)).resolves.toEqual({
       confirmed: amountBigint,
       unconfirmed: amountBigint,
     })

--- a/ironfish/src/rpc/routes/accounts/getBalance.ts
+++ b/ironfish/src/rpc/routes/accounts/getBalance.ts
@@ -24,9 +24,9 @@ export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yu
 router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
   `${ApiNamespace.account}/getBalance`,
   GetBalanceRequestSchema,
-  (request, node): void => {
+  async (request, node): Promise<void> => {
     const account = getAccount(node, request.data.account)
-    const { confirmed, unconfirmed } = node.accounts.getBalance(account)
+    const { confirmed, unconfirmed } = await node.accounts.getBalance(account)
 
     request.end({
       confirmed: confirmed.toString(),

--- a/ironfish/src/rpc/routes/accounts/removeAccount.ts
+++ b/ironfish/src/rpc/routes/accounts/removeAccount.ts
@@ -39,7 +39,7 @@ router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
     }
 
     if (!request.data.confirm) {
-      const balance = node.accounts.getBalance(account)
+      const balance = await node.accounts.getBalance(account)
 
       if (balance.unconfirmed !== BigInt(0)) {
         request.end({ needsConfirm: true })

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -105,10 +105,12 @@ describe('Transactions sendTransaction', () => {
       routeTest.node.peerNetwork['_isReady'] = true
       routeTest.chain.synced = true
 
-      jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce({
-        unconfirmed: BigInt(11),
-        confirmed: BigInt(0),
-      })
+      jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
+        Promise.resolve({
+          unconfirmed: BigInt(11),
+          confirmed: BigInt(0),
+        }),
+      )
 
       try {
         await routeTest.client.sendTransaction(TEST_PARAMS)
@@ -133,10 +135,12 @@ describe('Transactions sendTransaction', () => {
 
       jest.spyOn(routeTest.node.accounts, 'pay').mockResolvedValue(tx)
 
-      jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce({
-        unconfirmed: BigInt(11),
-        confirmed: BigInt(11),
-      })
+      jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
+        Promise.resolve({
+          unconfirmed: BigInt(11),
+          confirmed: BigInt(11),
+        }),
+      )
 
       const result = await routeTest.client.sendTransaction(TEST_PARAMS)
       expect(result.content.hash).toEqual(tx.hash().toString('hex'))
@@ -163,10 +167,12 @@ describe('Transactions sendTransaction', () => {
         routeTest.node.peerNetwork['_isReady'] = true
         routeTest.chain.synced = true
 
-        jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce({
-          unconfirmed: BigInt(21),
-          confirmed: BigInt(0),
-        })
+        jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
+          Promise.resolve({
+            unconfirmed: BigInt(21),
+            confirmed: BigInt(0),
+          }),
+        )
 
         try {
           await routeTest.client.sendTransaction(TEST_PARAMS)
@@ -191,10 +197,12 @@ describe('Transactions sendTransaction', () => {
 
         jest.spyOn(routeTest.node.accounts, 'pay').mockResolvedValue(tx)
 
-        jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce({
-          unconfirmed: BigInt(21),
-          confirmed: BigInt(21),
-        })
+        jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
+          Promise.resolve({
+            unconfirmed: BigInt(21),
+            confirmed: BigInt(21),
+          }),
+        )
 
         const result = await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
         expect(result.content.hash).toEqual(tx.hash().toString('hex'))

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.ts
@@ -89,7 +89,7 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
     }
 
     // Check that the node account is updated
-    const balance = node.accounts.getBalance(account)
+    const balance = await node.accounts.getBalance(account)
     const sum =
       transaction.receives.reduce((acc, receive) => acc + BigInt(receive.amount), BigInt(0)) +
       BigInt(transaction.fee)

--- a/ironfish/src/workerPool/messages.ts
+++ b/ironfish/src/workerPool/messages.ts
@@ -6,6 +6,7 @@ import { JobErrorSerialized } from './errors'
 import { BoxMessageRequest, BoxMessageResponse } from './tasks/boxMessage'
 import { CreateMinersFeeRequest, CreateMinersFeeResponse } from './tasks/createMinersFee'
 import { CreateTransactionRequest, CreateTransactionResponse } from './tasks/createTransaction'
+import { GetUnspentNotesRequest, GetUnspentNotesResponse } from './tasks/getUnspentNotes'
 import { MineHeaderRequest, MineHeaderResponse } from './tasks/mineHeader'
 import { SleepRequest, SleepResponse } from './tasks/sleep'
 import { TransactionFeeRequest, TransactionFeeResponse } from './tasks/transactionFee'
@@ -39,6 +40,7 @@ export type WorkerResponseMessage = {
 export type WorkerRequest =
   | CreateMinersFeeRequest
   | CreateTransactionRequest
+  | GetUnspentNotesRequest
   | TransactionFeeRequest
   | VerifyTransactionRequest
   | BoxMessageRequest
@@ -50,6 +52,7 @@ export type WorkerRequest =
 export type WorkerResponse =
   | CreateMinersFeeResponse
   | CreateTransactionResponse
+  | GetUnspentNotesResponse
   | TransactionFeeResponse
   | VerifyTransactionResponse
   | BoxMessageResponse

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -7,6 +7,7 @@ import type {
   BoxMessageRequest,
   CreateMinersFeeRequest,
   CreateTransactionRequest,
+  GetUnspentNotesRequest,
   MineHeaderRequest,
   SleepRequest,
   TransactionFeeRequest,
@@ -50,6 +51,7 @@ export class WorkerPool {
     ['verify', { complete: 0, error: 0, queue: 0, execute: 0 }],
     ['sleep', { complete: 0, error: 0, queue: 0, execute: 0 }],
     ['createTransaction', { complete: 0, error: 0, queue: 0, execute: 0 }],
+    ['getUnspentNotes', { complete: 0, error: 0, queue: 0, execute: 0 }],
     ['boxMessage', { complete: 0, error: 0, queue: 0, execute: 0 }],
     ['unboxMessage', { complete: 0, error: 0, queue: 0, execute: 0 }],
     ['mineHeader', { complete: 0, error: 0, queue: 0, execute: 0 }],
@@ -276,6 +278,33 @@ export class WorkerPool {
       initialRandomness: response.initialRandomness,
       miningRequestId: response.miningRequestId,
       randomness: response.randomness,
+    }
+  }
+
+  async getUnspentNotes(
+    serializedTransactionPosted: Buffer,
+    accountIncomingViewKeys: Array<string>,
+  ): Promise<{
+    notes: ReadonlyArray<{
+      account: string
+      hash: string
+      note: Buffer
+    }>
+  }> {
+    const request: GetUnspentNotesRequest = {
+      type: 'getUnspentNotes',
+      serializedTransactionPosted,
+      accounts: accountIncomingViewKeys,
+    }
+
+    const response = await this.execute(request).result()
+
+    if (response === null || response.type !== request.type) {
+      throw new Error('Response type must match request type')
+    }
+
+    return {
+      notes: response.notes,
     }
   }
 

--- a/ironfish/src/workerPool/tasks/getUnspentNotes.ts
+++ b/ironfish/src/workerPool/tasks/getUnspentNotes.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { NoteEncrypted, TransactionPosted } from 'ironfish-rust-nodejs'
+
+export type GetUnspentNotesRequest = {
+  type: 'getUnspentNotes'
+  serializedTransactionPosted: Buffer
+  accounts: string[]
+}
+
+export type GetUnspentNotesResponse = {
+  type: 'getUnspentNotes'
+  notes: Array<{
+    account: string
+    hash: string
+    note: Buffer
+  }>
+}
+
+export function handleGetUnspentNotes({
+  accounts,
+  serializedTransactionPosted,
+}: GetUnspentNotesRequest): GetUnspentNotesResponse {
+  const transaction = TransactionPosted.deserialize(serializedTransactionPosted)
+
+  const results: GetUnspentNotesResponse['notes'] = []
+
+  for (let i = 0; i < transaction.notesLength; i++) {
+    const serializedNote = transaction.getNote(i)
+    const note = NoteEncrypted.deserialize(serializedNote)
+
+    // Notes can be spent and received by the same Account.
+    // Try decrypting the note as its owner
+    for (const account of accounts) {
+      const decryptedNote = note.decryptNoteForOwner(account)
+
+      if (decryptedNote) {
+        results.push({
+          hash: note.merkleHash().toString('hex'),
+          note: decryptedNote.serialize(),
+          account: account,
+        })
+
+        break
+      }
+    }
+  }
+
+  return { type: 'getUnspentNotes', notes: results }
+}

--- a/ironfish/src/workerPool/tasks/index.ts
+++ b/ironfish/src/workerPool/tasks/index.ts
@@ -8,6 +8,7 @@ import { Job } from '../job'
 import { handleBoxMessage } from './boxMessage'
 import { handleCreateMinersFee } from './createMinersFee'
 import { handleCreateTransaction } from './createTransaction'
+import { handleGetUnspentNotes } from './getUnspentNotes'
 import { handleMineHeader } from './mineHeader'
 import { handleSleep } from './sleep'
 import { handleTransactionFee } from './transactionFee'
@@ -15,6 +16,7 @@ import { handleUnboxMessage } from './unboxMessage'
 import { handleVerifyTransaction } from './verifyTransaction'
 
 export { CreateTransactionRequest, CreateTransactionResponse } from './createTransaction'
+export { GetUnspentNotesRequest, GetUnspentNotesResponse } from './getUnspentNotes'
 export { BoxMessageRequest, BoxMessageResponse } from './boxMessage'
 export { CreateMinersFeeRequest, CreateMinersFeeResponse } from './createMinersFee'
 export { MineHeaderRequest, MineHeaderResponse } from './mineHeader'
@@ -37,6 +39,9 @@ export async function handleRequest(
       break
     case 'createTransaction':
       response = handleCreateTransaction(body)
+      break
+    case 'getUnspentNotes':
+      response = handleGetUnspentNotes(body)
       break
     case 'transactionFee':
       response = handleTransactionFee(body)


### PR DESCRIPTION
## Summary

Adds a worker pool task for getUnspentNotes, which is used when calculating an account's balance. Note that this does not make the balance calculation faster, just frees up the main thread when doing balance work.

I'm not sure if this is the right level of abstraction for worker pool tasks -- this'll probably have to be tweaked as more functionality in the accounts store is moved to the worker pool.

## Testing Plan

Balance calculation should work as before.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
