### PR TITLE
Chop leading zeroes from truncated hashes

### DIFF
--- a/ironfish-graph-explorer/src/index.js
+++ b/ironfish-graph-explorer/src/index.js
@@ -94,8 +94,21 @@ function getNodes() {
     return [nodes, links, lowest, highest]
 }
 
-function renderHash(hash) {
-    return `${hash.slice(0, 5)}...${hash.slice(-5)}`
+function renderHash(hashHex) {
+
+    /* Chop off leading zeroes of the hash */
+    var n = 0
+    while (hashHex.charAt(n) == "0") {
+      n++
+    }
+  
+    /* Overflow check on string end */
+    if ((n+5) > hashHex.length) {
+      /* We've exceeded the end of the string, so just revert to the beginning - it's all zeroes anyway. */
+      n = 0
+    }
+  
+    return `${hashHex.slice(n, n+5)}...${hashHex.slice(-5)}`
 }
 
 function makeLabel(node) {

--- a/ironfish/src/utils/hash.ts
+++ b/ironfish/src/utils/hash.ts
@@ -9,7 +9,20 @@ function renderHashHex(hashHex: string | null | undefined): string {
   if (!hashHex) {
     return ''
   }
-  return `${hashHex.slice(0, 5)}...${hashHex.slice(-5)}`
+
+  /* Chop off leading zeroes of the hash */
+  let n = 0
+  while (hashHex.charAt(n) === '0') {
+    n++
+  }
+
+  /* Overflow check on string end */
+  if (n + 5 > hashHex.length) {
+    /* We've exceeded the end of the string, so just revert to the beginning - it's all zeroes anyway. */
+    n = 0
+  }
+
+  return `${hashHex.slice(n, n + 5)}...${hashHex.slice(-5)}`
 }
 
 function renderHash(hash: Buffer | null | undefined): string {


### PR DESCRIPTION
## Summary
It's a waste that the leading 5 characters of truncated hashes are zeroes when printed out. Even the first mined block after genesis had several leading zeroes!

> Reorganizing chain from 00000...79a55 (75581) for 00000...c2dd5 (75581) on prev 00000...0ca3c (75580)
> Reorganized chain. blocks: 1, old: 00000...79a55 (75581), new: 00000...0ca3c (75580), fork: 00000...0ca3c (75580)
> Added block seq: 75600, hash: 00000...9cf55, txs: 1, progress: 100.00%, time: 72.9ms

We can be more efficient by chopping them and displaying more meaningful data.

There are actually a few methods to do this
- Show the first 5 characters after the initial sequence of zeroes and the last 5. (This changeset.)
- Only show the last 10 characters of the hash. (Only one place in the hash to reference.)
- Count the number of leading zeros and display that number separated from the rest of hash. (Confusing and I believe the least preferred method).

I'd like to have included a utility function to use in both renderHashHex and renderHash (graph explorer) but the utilities are all in testscript and it's not clear whether we want to deal with converting TS back to JS for the graph explorer or have JS utilitiy files. Let me know your thoughts on this.

## Testing Plan

Checked output from startup chain syncing:

> Starting sync from n8/qfGG (misha1art). work: +2441906901956764, ours: 82121, theirs: 82303
> Finding ancestor using linear search on last 3 blocks starting at 67d23...6db1c (82121) from peer n8/qfGG (misha1art) at 82303
> Found peer n8/qfGG (misha1art) ancestor 67d23...6db1c, syncing from 82121 -> 82303 (182) after 1 requests
> Requesting 20 blocks starting at 67d23...6db1c (82121) from n8/qfGG (misha1art)
> Added block seq: 82140, hash: e89a9...7685c, txs: 1, progress: 99.79%, time: 25.0ms

`chain:show` command:

> +- Block e95df...4e240
> +- Block 76f81...285fc
> +- Block 75f86...329b1
> +- Block 67d23...6db1c LATEST HEAD

and graph explorer.

Still encountering the issue with `yarn test` returning errors in ironfish-cli

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes - Not breaking code but will require announcement and documentation if adopted to head off user questions.
[ ] No
```
