### PR TITLE
Add AbortSignal to ChainProcessor.update

### DIFF
--- a/config/jestNodeEnvironment.js
+++ b/config/jestNodeEnvironment.js
@@ -13,6 +13,7 @@ class CustomNodeEnvironment extends NodeEnvironment {
           Uint32Array: Uint32Array,
           Uint8Array: Uint8Array,
           ArrayBuffer: ArrayBuffer,
+          AbortController: AbortController,
         }),
       }),
     );

--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -172,15 +172,17 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
     processor.onAdd.on(onAdd)
     processor.onRemove.on(onRemove)
     node.chain.onForkBlock.on(onFork)
+    const abortController = new AbortController()
 
     request.onClose.on(() => {
+      abortController.abort()
       processor.onAdd.off(onAdd)
       processor.onRemove.off(onRemove)
       node.chain.onForkBlock.off(onFork)
     })
 
     while (!request.closed) {
-      await processor.update()
+      await processor.update({ signal: abortController.signal })
       await PromiseUtils.sleep(1000)
     }
 


### PR DESCRIPTION
## Summary

Allows for canceling a ChainProcessor.update call midway through. ChainProcessor.update has the potential to be long-running, which can block shutdown of the node. Particularly relevant in Accounts, which waits for updateHead to finish before writing to the DB on shutdown.

Fixes IRO-1513

## Testing Plan

Updating the account balance should still work, and shutting down the node while updating the balance should not prevent the node from continuing to recalculate balance after starting it back up.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
