### PR TITLE
Add timeouts to select ironfish-cli tests

### DIFF
--- a/ironfish-cli/src/commands/accounts/export.test.ts
+++ b/ironfish-cli/src/commands/accounts/export.test.ts
@@ -59,6 +59,7 @@ describe('accounts:export', () => {
   })
 
   describe('with no flags', () => {
+    jest.setTimeout(10000)
     test
       .stdout()
       .command(['accounts:export', 'default'])

--- a/ironfish-cli/src/commands/accounts/rescan.test.ts
+++ b/ironfish-cli/src/commands/accounts/rescan.test.ts
@@ -39,6 +39,7 @@ describe('accounts:rescan', () => {
   })
 
   describe('with no flags', () => {
+    jest.setTimeout(10000)
     test
       .stdout()
       .command(['accounts:rescan'])

--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -63,6 +63,7 @@ describe('status', () => {
   })
 
   describe('it logs out the status of the node', () => {
+    jest.setTimeout(10000)
     test
       .stdout()
       .command(['status'])


### PR DESCRIPTION
## Summary
After #861 was resolved by #859, the ironfish-cli tests would then fail. It seemed odd that something used consistently for all pre-commit validation would fail in Windows.

I took a guess that increasing the timeout would help. I couldn't find where jest.setTimeout.Error is set, so I added timeouts (another guess that these are the correct/"best" places) and things passed. I'm also guessing that the added setTimeout() calls have local scope and don't affect other tests.

I would appreciate some feedback on this fix. I **hate** fixing apparent timing issues by increasing values.

## Testing Plan

Ran `yarn test` a few times with changes. All passed.
Total execution time (From the `Done in Xs` completion message) was
62, 47, 51, 55, 50 seconds.
Surprising amount of variability with the results. (I'm running a i5-10210U @ 1.6Ghz.)

There is probably some risk that people running on slower processors or with simultaneous heavy workloads will exceed these timeouts.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
