### PR TITLE
Fix rescan when account head is on a fork

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -566,7 +566,7 @@ export class Accounts {
       transaction,
       initialNoteIndex,
       sequence,
-    } of this.chain.iterateAllTransactions(null, accountHeadHash)) {
+    } of this.chain.iterateTransactions(null, accountHeadHash, undefined, false)) {
       if (scan.isAborted) {
         scan.signalComplete()
         this.scan = null

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -164,7 +164,7 @@ describe('Blockchain', () => {
     expect(blocks[0].hash.equals(genesis.hash)).toBe(true)
   })
 
-  it('should not iterate and jump chains', async () => {
+  it('should not iterate and jump chains and throw error', async () => {
     const { strategy, chain } = nodeTest
     strategy.disableMiningReward()
 
@@ -175,27 +175,32 @@ describe('Blockchain', () => {
     // have a lock on the main chain table. We try to iterate to A2, then do a
     // reorg and see if the next iteration incorrectly yields B3.
     //
-    // G -> A1 -> A2 -> A3
-    //         -> B2 -> B3 -> B4
+    // G -> A1 -> A2 -> A3 -> A4
+    //         -> B2 -> B3 -> B4 -> B5
 
     const blockA1 = await makeBlockAfter(chain, genesis)
     const blockA2 = await makeBlockAfter(chain, blockA1)
     const blockA3 = await makeBlockAfter(chain, blockA2)
+    const blockA4 = await makeBlockAfter(chain, blockA3)
+
     const blockB2 = await makeBlockAfter(chain, blockA1)
     const blockB3 = await makeBlockAfter(chain, blockB2)
     const blockB4 = await makeBlockAfter(chain, blockB3)
+    const blockB5 = await makeBlockAfter(chain, blockB4)
 
     await expect(chain).toAddBlock(blockA1)
     await expect(chain).toAddBlock(blockA2)
     await expect(chain).toAddBlock(blockA3)
+    await expect(chain).toAddBlock(blockA4)
 
-    expect(chain.head.hash.equals(blockA3.header.hash)).toBe(true)
-    expect(chain.latest.hash.equals(blockA3.header.hash)).toBe(true)
+    expect(chain.head.hash.equals(blockA4.header.hash)).toBe(true)
+    expect(chain.latest.hash.equals(blockA4.header.hash)).toBe(true)
 
-    const iter = chain.iterateTo(genesis, blockA2.header)
-    const block1 = await iter.next()
-    const block2 = await iter.next()
-    const block3 = await iter.next()
+    const iter1 = chain.iterateTo(genesis, blockA4.header, undefined, true)
+
+    const block1 = await iter1.next()
+    const block2 = await iter1.next()
+    const block3 = await iter1.next()
 
     expect(block1).toMatchObject({ done: false, value: { hash: genesis.hash } })
     expect(block2).toMatchObject({ done: false, value: { hash: blockA1.header.hash } })
@@ -204,12 +209,65 @@ describe('Blockchain', () => {
     await expect(chain).toAddBlock(blockB2)
     await expect(chain).toAddBlock(blockB3)
     await expect(chain).toAddBlock(blockB4)
+    await expect(chain).toAddBlock(blockB5)
 
-    expect(chain.head.hash.equals(blockB4.header.hash)).toBe(true)
-    expect(chain.latest.hash.equals(blockB4.header.hash)).toBe(true)
+    expect(chain.head.hash.equals(blockB5.header.hash)).toBe(true)
+    expect(chain.latest.hash.equals(blockB5.header.hash)).toBe(true)
 
-    // Should stop instad of yielding block B3
-    const block4 = await iter.next()
+    await expect(iter1.next()).rejects.toThrowError('progress: 3/5')
+  })
+
+  it('should not iterate and jump chains and not throw error', async () => {
+    const { strategy, chain } = nodeTest
+    strategy.disableMiningReward()
+
+    const genesis = chain.genesis
+
+    // This test checks that when iterating a reorg is happening, we don't
+    // suddenly jump chains while the table is being re-written when we don't
+    // have a lock on the main chain table. We try to iterate to A2, then do a
+    // reorg and see if the next iteration incorrectly yields B3.
+    //
+    // G -> A1 -> A2 -> A3 -> A4
+    //         -> B2 -> B3 -> B4 -> B5
+
+    const blockA1 = await makeBlockAfter(chain, genesis)
+    const blockA2 = await makeBlockAfter(chain, blockA1)
+    const blockA3 = await makeBlockAfter(chain, blockA2)
+    const blockA4 = await makeBlockAfter(chain, blockA3)
+
+    const blockB2 = await makeBlockAfter(chain, blockA1)
+    const blockB3 = await makeBlockAfter(chain, blockB2)
+    const blockB4 = await makeBlockAfter(chain, blockB3)
+    const blockB5 = await makeBlockAfter(chain, blockB4)
+
+    await expect(chain).toAddBlock(blockA1)
+    await expect(chain).toAddBlock(blockA2)
+    await expect(chain).toAddBlock(blockA3)
+    await expect(chain).toAddBlock(blockA4)
+
+    expect(chain.head.hash.equals(blockA4.header.hash)).toBe(true)
+    expect(chain.latest.hash.equals(blockA4.header.hash)).toBe(true)
+
+    const iter1 = chain.iterateTo(genesis, blockA4.header, undefined, false)
+
+    const block1 = await iter1.next()
+    const block2 = await iter1.next()
+    const block3 = await iter1.next()
+
+    expect(block1).toMatchObject({ done: false, value: { hash: genesis.hash } })
+    expect(block2).toMatchObject({ done: false, value: { hash: blockA1.header.hash } })
+    expect(block3).toMatchObject({ done: false, value: { hash: blockA2.header.hash } })
+
+    await expect(chain).toAddBlock(blockB2)
+    await expect(chain).toAddBlock(blockB3)
+    await expect(chain).toAddBlock(blockB4)
+    await expect(chain).toAddBlock(blockB5)
+
+    expect(chain.head.hash.equals(blockB5.header.hash)).toBe(true)
+    expect(chain.latest.hash.equals(blockB5.header.hash)).toBe(true)
+
+    const block4 = await iter1.next()
     expect(block4).toMatchObject({ done: true })
   })
 

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -458,29 +458,33 @@ export class Blockchain {
     reachable = true,
   ): AsyncGenerator<BlockHash, void, void> {
     let current = start.hash as BlockHash | null
-    const max = end ? end.sequence - start.sequence : null
+    let last = null as BlockHash | null
+
+    const max = end ? end.sequence - start.sequence + 1 : null
     let count = 0
 
     while (current) {
+      count++
       yield current
 
       if (end && current.equals(end.hash)) {
         break
       }
 
-      if (max !== null && count++ >= max) {
+      if (max !== null && count >= max) {
         break
       }
 
+      last = current
       current = await this.getNextHash(current, tx)
     }
 
     if (reachable && end && !current?.equals(end.hash)) {
       throw new Error(
         'Failed to iterate between blocks on diverging forks:' +
-          ` curr: ${HashUtils.renderHash(current)},` +
+          ` curr: ${HashUtils.renderHash(last)},` +
           ` end: ${HashUtils.renderHash(end.hash)},` +
-          ` progress: ${count}/${String(max)}`,
+          ` progress: ${count}/${String(max ?? '?')}`,
       )
     }
   }

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -417,6 +417,10 @@ export class Blockchain {
     return { fork: base, isLinear: linear }
   }
 
+  /**
+   * Iterate the main chain from left to right inclusive.
+   * Start and end being included in the yielded blocks.
+   * */
   async *iterateTo(
     start: BlockHeader,
     end?: BlockHeader,
@@ -482,8 +486,8 @@ export class Blockchain {
   }
 
   /**
-   * Iterate from start to end with start and end being
-   * included in the yielded blocks.
+   * Iterate the main chain from right to left inclusive.
+   * Start and end being included in the yielded blocks.
    * */
   async *iterateFrom(
     start: BlockHeader,


### PR DESCRIPTION
## Summary

This fixes the issue outlined in github issue [#880](https://github.com/iron-fish/ironfish/issues/880).
This is happening because of how we handle rescans.

1. When a rescan occurs, the wallet will never update itself until the rescan completes.
2. When the node starts and a rescan has started it will always try to rescan first

This means that because the rescan is broken, the wallet is stuck in a broken
state permanently. Let's now dive into why the rescan is broken.

```
G -> A1 -> A2
        -> B2 -> B3

Accounts Head: A2
Chain Head:    B3
```

When we do a rescan, we try to iterate from the genesis block (G) to the
accounts head (A2), but the block chain has re-orged to B3, the newer heaviest
chain. If the accounts head were to update, it would reorganize as well to B3.
Unfortunately, once a scan has started the accounts will wait for the rescan to
finish before updating the accounts head from A2 to B3.

Now the way we try to iterate from G -> A2 is that we use the heaviest chain
iteration. That means we're going to iterate in this order: `G -> A1 -> B2`
before realizing were not on target and fail with the error that's in the
ticket. It's now unrecoverable because there's no way out of this since accounts
is stuck at A2.

The fixes I chose were inspired by Bitcoin, which chose not to solve the problem
exactly. The worst case outcome are that if you are importing an account with a
transction on a fork, you'll potentially think that transaction is added to a
block on a fork, even if it never gets added to a block on the main chain.

The fixes are two fold:
1. Don't error when the account head is unreachable
2. Don't let iterateTo jump chains if we use iteratetoHashes() during a reorg


## Testing Plan
 - [x]  Write tests
 - [x]  Import accounts
 - [x]  Do rescans

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
