### PR TITLE
Peer Persistence

### DIFF
--- a/ironfish/src/fileStores/fileStore.ts
+++ b/ironfish/src/fileStores/fileStore.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { promises as fs } from 'fs'
 import path from 'path'
 import { FileSystem } from '../fileSystems'
 import { JSONUtils, PartialRecursive } from '../utils'
@@ -22,7 +21,7 @@ export class FileStore<T extends Record<string, unknown>> {
   }
 
   async load(): Promise<PartialRecursive<T> | null> {
-    const configExists = await fs
+    const configExists = await this.files
       .access(this.configPath)
       .then(() => true)
       .catch(() => false)
@@ -30,7 +29,7 @@ export class FileStore<T extends Record<string, unknown>> {
     let config = null
 
     if (configExists) {
-      const data = await fs.readFile(this.configPath, { encoding: 'utf8' })
+      const data = await this.files.readFile(this.configPath)
       config = JSONUtils.parse<PartialRecursive<T>>(data, this.configName)
     }
 
@@ -39,7 +38,7 @@ export class FileStore<T extends Record<string, unknown>> {
 
   async save(data: PartialRecursive<T>): Promise<void> {
     const json = JSON.stringify(data, undefined, '    ')
-    await fs.mkdir(this.dataDir, { recursive: true })
-    await fs.writeFile(this.configPath, json)
+    await this.files.mkdir(this.dataDir, { recursive: true })
+    await this.files.writeFile(this.configPath, json)
   }
 }

--- a/ironfish/src/fileSystems/fileSystem.ts
+++ b/ironfish/src/fileSystems/fileSystem.ts
@@ -5,6 +5,7 @@ import type fs from 'fs'
 
 export abstract class FileSystem {
   abstract init(): Promise<FileSystem>
+  abstract access(path: fs.PathLike, mode?: number | undefined): Promise<void>
   abstract writeFile(
     path: string,
     data: string,

--- a/ironfish/src/fileSystems/nodeFileSystem.ts
+++ b/ironfish/src/fileSystems/nodeFileSystem.ts
@@ -19,6 +19,11 @@ export class NodeFileProvider extends FileSystem {
     return this
   }
 
+  async access(path: fs.PathLike, mode?: number | undefined): Promise<void> {
+    Assert.isNotNull(this.fs, `Must call FileSystem.init()`)
+    await this.fs.access(path, mode)
+  }
+
   async writeFile(
     path: string,
     data: string,

--- a/ironfish/src/network/messageRouters/fireAndForget.test.ts
+++ b/ironfish/src/network/messageRouters/fireAndForget.test.ts
@@ -11,6 +11,7 @@ import { AddressManager } from '../peers/addressManager'
 import { PeerManager } from '../peers/peerManager'
 import {
   getConnectedPeer,
+  mockFileSystem,
   mockHostsStore,
   mockLocalPeer,
   mockPrivateIdentity,
@@ -21,7 +22,7 @@ jest.useFakeTimers()
 
 describe('FireAndForget Router', () => {
   it('sends a fire and forget message', () => {
-    const peers = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
     const sendToMock = jest.spyOn(peers, 'sendTo')
 
     const router = new FireAndForgetRouter(peers)
@@ -34,7 +35,7 @@ describe('FireAndForget Router', () => {
   })
 
   it('handles an incoming fire and forget message', async () => {
-    const peers = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
     const router = new FireAndForgetRouter(peers)
 
     const handleMock = jest.fn((_message: IncomingFireAndForgetGeneric<'incoming'>) =>
@@ -52,6 +53,8 @@ describe('FireAndForget Router', () => {
   })
 
   it('routes a fire and forget message as fire and forget', async () => {
+    const addressManager = new AddressManager(mockFileSystem())
+    addressManager.hostsStore = mockHostsStore()
     const network = new PeerNetwork({
       identity: mockPrivateIdentity('local'),
       agent: 'sdk/1/cli',
@@ -59,7 +62,7 @@ describe('FireAndForget Router', () => {
       node: mockNode(),
       chain: mockChain(),
       strategy: mockStrategy(),
-      addressManager: new AddressManager(mockHostsStore()),
+      files: mockFileSystem(),
     })
 
     const fireAndForgetMock = jest.fn(async () => {})
@@ -79,6 +82,6 @@ describe('FireAndForget Router', () => {
     })
 
     expect(fireAndForgetMock).toBeCalled()
-    network.stop()
+    await network.stop()
   })
 })

--- a/ironfish/src/network/messageRouters/fireAndForget.test.ts
+++ b/ironfish/src/network/messageRouters/fireAndForget.test.ts
@@ -11,7 +11,6 @@ import { AddressManager } from '../peers/addressManager'
 import { PeerManager } from '../peers/peerManager'
 import {
   getConnectedPeer,
-  mockFileSystem,
   mockHostsStore,
   mockLocalPeer,
   mockPrivateIdentity,
@@ -22,7 +21,7 @@ jest.useFakeTimers()
 
 describe('FireAndForget Router', () => {
   it('sends a fire and forget message', () => {
-    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
     const sendToMock = jest.spyOn(peers, 'sendTo')
 
     const router = new FireAndForgetRouter(peers)
@@ -35,7 +34,7 @@ describe('FireAndForget Router', () => {
   })
 
   it('handles an incoming fire and forget message', async () => {
-    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
     const router = new FireAndForgetRouter(peers)
 
     const handleMock = jest.fn((_message: IncomingFireAndForgetGeneric<'incoming'>) =>
@@ -53,7 +52,7 @@ describe('FireAndForget Router', () => {
   })
 
   it('routes a fire and forget message as fire and forget', async () => {
-    const addressManager = new AddressManager(mockFileSystem())
+    const addressManager = new AddressManager(mockHostsStore())
     addressManager.hostsStore = mockHostsStore()
     const network = new PeerNetwork({
       identity: mockPrivateIdentity('local'),
@@ -62,7 +61,7 @@ describe('FireAndForget Router', () => {
       node: mockNode(),
       chain: mockChain(),
       strategy: mockStrategy(),
-      files: mockFileSystem(),
+      hostsStore: mockHostsStore(),
     })
 
     const fireAndForgetMock = jest.fn(async () => {})

--- a/ironfish/src/network/messageRouters/globalRpc.test.ts
+++ b/ironfish/src/network/messageRouters/globalRpc.test.ts
@@ -8,9 +8,8 @@ jest.mock('ws')
 import '../testUtilities'
 import { mocked } from 'ts-jest/utils'
 import { InternalMessageType, MessageType } from '../messages'
-import { AddressManager } from '../peers/addressManager'
 import { PeerManager } from '../peers/peerManager'
-import { getConnectedPeer, mockHostsStore, mockLocalPeer } from '../testUtilities'
+import { getConnectedPeer, mockFileSystem, mockLocalPeer } from '../testUtilities'
 import { GlobalRpcRouter } from './globalRpc'
 import { CannotSatisfyRequestError, Direction, RpcRouter } from './rpc'
 import { nextRpcId } from './rpcId'
@@ -25,7 +24,7 @@ describe('select peers', () => {
 
   it('Returns null when no peers available', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
 
     router.register('take', jest.fn())
@@ -34,7 +33,7 @@ describe('select peers', () => {
 
   it('Selects the peer if there is only one', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -46,7 +45,7 @@ describe('select peers', () => {
 
   it('Selects peer2 if peer1 is saturated`', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
     router.register('take', jest.fn())
     const pm = router.rpcRouter.peerManager
@@ -63,7 +62,7 @@ describe('select peers', () => {
 
   it('Selects peer2 if peer1 failed', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -84,7 +83,7 @@ describe('select peers', () => {
 
   it('Selects the peer1 if both failed', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -110,7 +109,7 @@ describe('select peers', () => {
 
   it('Clears requestFails when peers disconnect', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -130,14 +129,14 @@ describe('Global Rpc', () => {
 
   it('Constructs a global RPC Router correctly', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
     expect(router.requestFails.size).toBe(0)
   })
 
   it('Registers a global RPC Handler with the direct rpc router', async () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
     const handler = jest.fn()
     router.register('test', handler)
@@ -161,7 +160,7 @@ describe('Global Rpc', () => {
 
   it('throws when there are no peers available', async () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
 
     router.register('test', () => Promise.resolve(undefined))
@@ -173,7 +172,7 @@ describe('Global Rpc', () => {
     mocked(nextRpcId).mockReturnValue(44)
 
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -198,7 +197,7 @@ describe('Global Rpc', () => {
 
   it('handles a round trip successfully with one peer', async () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -229,7 +228,7 @@ describe('Global Rpc', () => {
 
   it('retries if first attempt returns cannot fulfill request', async () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
     )
 
     const pm = router.rpcRouter.peerManager

--- a/ironfish/src/network/messageRouters/globalRpc.test.ts
+++ b/ironfish/src/network/messageRouters/globalRpc.test.ts
@@ -9,7 +9,7 @@ import '../testUtilities'
 import { mocked } from 'ts-jest/utils'
 import { InternalMessageType, MessageType } from '../messages'
 import { PeerManager } from '../peers/peerManager'
-import { getConnectedPeer, mockFileSystem, mockLocalPeer } from '../testUtilities'
+import { getConnectedPeer, mockHostsStore, mockLocalPeer } from '../testUtilities'
 import { GlobalRpcRouter } from './globalRpc'
 import { CannotSatisfyRequestError, Direction, RpcRouter } from './rpc'
 import { nextRpcId } from './rpcId'
@@ -24,7 +24,7 @@ describe('select peers', () => {
 
   it('Returns null when no peers available', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
 
     router.register('take', jest.fn())
@@ -33,7 +33,7 @@ describe('select peers', () => {
 
   it('Selects the peer if there is only one', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -45,7 +45,7 @@ describe('select peers', () => {
 
   it('Selects peer2 if peer1 is saturated`', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
     router.register('take', jest.fn())
     const pm = router.rpcRouter.peerManager
@@ -62,7 +62,7 @@ describe('select peers', () => {
 
   it('Selects peer2 if peer1 failed', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -83,7 +83,7 @@ describe('select peers', () => {
 
   it('Selects the peer1 if both failed', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -109,7 +109,7 @@ describe('select peers', () => {
 
   it('Clears requestFails when peers disconnect', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -129,14 +129,14 @@ describe('Global Rpc', () => {
 
   it('Constructs a global RPC Router correctly', () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
     expect(router.requestFails.size).toBe(0)
   })
 
   it('Registers a global RPC Handler with the direct rpc router', async () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
     const handler = jest.fn()
     router.register('test', handler)
@@ -160,7 +160,7 @@ describe('Global Rpc', () => {
 
   it('throws when there are no peers available', async () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
 
     router.register('test', () => Promise.resolve(undefined))
@@ -172,7 +172,7 @@ describe('Global Rpc', () => {
     mocked(nextRpcId).mockReturnValue(44)
 
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -197,7 +197,7 @@ describe('Global Rpc', () => {
 
   it('handles a round trip successfully with one peer', async () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
 
     const pm = router.rpcRouter.peerManager
@@ -228,7 +228,7 @@ describe('Global Rpc', () => {
 
   it('retries if first attempt returns cannot fulfill request', async () => {
     const router = new GlobalRpcRouter(
-      new RpcRouter(new PeerManager(mockLocalPeer(), mockFileSystem())),
+      new RpcRouter(new PeerManager(mockLocalPeer(), mockHostsStore())),
     )
 
     const pm = router.rpcRouter.peerManager

--- a/ironfish/src/network/messageRouters/gossip.test.ts
+++ b/ironfish/src/network/messageRouters/gossip.test.ts
@@ -11,7 +11,7 @@ import ws from 'ws'
 import { mockChain, mockNode, mockStrategy } from '../../testUtilities/mocks'
 import { PeerNetwork, RoutingStyle } from '../peerNetwork'
 import { PeerManager } from '../peers/peerManager'
-import { getConnectedPeer, mockFileSystem, mockLocalPeer } from '../testUtilities'
+import { getConnectedPeer, mockHostsStore, mockLocalPeer } from '../testUtilities'
 import { GossipRouter } from './gossip'
 
 jest.useFakeTimers()
@@ -19,7 +19,7 @@ jest.useFakeTimers()
 describe('Gossip Router', () => {
   it('Broadcasts a message on gossip', () => {
     mocked(uuid).mockReturnValue('test_broadcast')
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const broadcastMock = jest.spyOn(pm, 'broadcast').mockImplementation(() => {})
     const router = new GossipRouter(pm)
     router.register('test', jest.fn())
@@ -31,7 +31,7 @@ describe('Gossip Router', () => {
   })
 
   it('Handles an incoming gossip message', async () => {
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const broadcastMock = jest.spyOn(pm, 'broadcast').mockImplementation(() => {})
     const { peer: peer1 } = getConnectedPeer(pm)
     const { peer: peer2 } = getConnectedPeer(pm)
@@ -64,7 +64,7 @@ describe('Gossip Router', () => {
   })
 
   it('Does not process a seen message twice', async () => {
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const broadcastMock = jest.spyOn(pm, 'broadcast').mockImplementation(() => {})
     const { peer: peer1 } = getConnectedPeer(pm)
     const { peer: peer2 } = getConnectedPeer(pm)
@@ -94,7 +94,7 @@ describe('Gossip Router', () => {
   })
 
   it('Does not send messages to peers of peer that sent it', async () => {
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const broadcastMock = jest.spyOn(pm, 'broadcast').mockImplementation(() => {})
     const { peer: peer1 } = getConnectedPeer(pm)
     const { peer: peer2 } = getConnectedPeer(pm)
@@ -124,7 +124,7 @@ describe('Gossip Router', () => {
       node: mockNode(),
       chain: mockChain(),
       strategy: mockStrategy(),
-      files: mockFileSystem(),
+      hostsStore: mockHostsStore(),
     })
 
     const gossipMock = jest.fn(async () => {})
@@ -135,7 +135,7 @@ describe('Gossip Router', () => {
       () => Promise.resolve({ name: '' }),
       () => true,
     )
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const { peer } = getConnectedPeer(pm)
     const message = { type: 'hello', nonce: 'test_handler1', payload: { test: 'payload' } }
     await network['handleMessage'](peer, { peerIdentity: peer.getIdentityOrThrow(), message })
@@ -150,7 +150,7 @@ describe('Gossip Router', () => {
       node: mockNode(),
       chain: mockChain(),
       strategy: mockStrategy(),
-      files: mockFileSystem(),
+      hostsStore: mockHostsStore(),
     })
 
     const gossipMock = jest.fn(async () => {})
@@ -165,7 +165,7 @@ describe('Gossip Router', () => {
     const logFn = jest.fn()
     network['logger'].mock(() => logFn)
 
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const { peer } = getConnectedPeer(pm)
 
     // This is the wrong type so it tests that it fails

--- a/ironfish/src/network/messageRouters/rpc.test.ts
+++ b/ironfish/src/network/messageRouters/rpc.test.ts
@@ -4,10 +4,9 @@
 
 jest.mock('./rpcId')
 import { mocked } from 'ts-jest/utils'
-import { AddressManager } from '../peers/addressManager'
 import { NetworkError } from '../peers/connections/errors'
 import { PeerManager } from '../peers/peerManager'
-import { getConnectedPeer, mockHostsStore, mockLocalPeer } from '../testUtilities'
+import { getConnectedPeer, mockFileSystem, mockLocalPeer } from '../testUtilities'
 import { CannotSatisfyRequestError, Direction, RequestTimeoutError, RpcRouter } from './rpc'
 import { nextRpcId, rpcTimeoutMillis } from './rpcId'
 
@@ -23,7 +22,7 @@ describe('RPC Router', () => {
   })
 
   it('Registers an RPC Handler', () => {
-    const peers = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
     const router = new RpcRouter(peers)
     const handler = jest.fn()
     router.register('test', handler)
@@ -32,7 +31,7 @@ describe('RPC Router', () => {
   })
 
   it('should time out RPC requests', async () => {
-    const peers = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
     const sendToMock = jest.spyOn(peers, 'sendTo')
 
     const { peer } = getConnectedPeer(peers)
@@ -58,7 +57,7 @@ describe('RPC Router', () => {
   })
 
   it('should reject requests when connection disconnects', async () => {
-    const peers = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
     const sendToMock = jest.spyOn(peers, 'sendTo')
 
     const { peer, connection } = getConnectedPeer(peers)
@@ -89,7 +88,7 @@ describe('RPC Router', () => {
   it('should increment and decrement pendingRPC', async () => {
     mocked(nextRpcId).mockReturnValue(91)
 
-    const peers = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
     jest.spyOn(peers, 'sendTo')
     const { peer } = getConnectedPeer(peers, 'peer')
 
@@ -115,7 +114,7 @@ describe('RPC Router', () => {
     mocked(nextRpcId).mockReturnValue(91)
     mocked(rpcTimeoutMillis).mockReturnValue(1000)
 
-    const peers = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
 
     const router = new RpcRouter(peers)
     router.register('test', jest.fn())
@@ -146,7 +145,7 @@ describe('RPC Router', () => {
   it('Catches a cannotSatisfy error and returns the appropriate type', async () => {
     mocked(nextRpcId).mockReturnValue(18)
 
-    const peers = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
     const sendToMock = jest.fn()
     peers.sendTo = sendToMock
 

--- a/ironfish/src/network/messageRouters/rpc.test.ts
+++ b/ironfish/src/network/messageRouters/rpc.test.ts
@@ -6,7 +6,7 @@ jest.mock('./rpcId')
 import { mocked } from 'ts-jest/utils'
 import { NetworkError } from '../peers/connections/errors'
 import { PeerManager } from '../peers/peerManager'
-import { getConnectedPeer, mockFileSystem, mockLocalPeer } from '../testUtilities'
+import { getConnectedPeer, mockHostsStore, mockLocalPeer } from '../testUtilities'
 import { CannotSatisfyRequestError, Direction, RequestTimeoutError, RpcRouter } from './rpc'
 import { nextRpcId, rpcTimeoutMillis } from './rpcId'
 
@@ -22,7 +22,7 @@ describe('RPC Router', () => {
   })
 
   it('Registers an RPC Handler', () => {
-    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
     const router = new RpcRouter(peers)
     const handler = jest.fn()
     router.register('test', handler)
@@ -31,7 +31,7 @@ describe('RPC Router', () => {
   })
 
   it('should time out RPC requests', async () => {
-    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
     const sendToMock = jest.spyOn(peers, 'sendTo')
 
     const { peer } = getConnectedPeer(peers)
@@ -57,7 +57,7 @@ describe('RPC Router', () => {
   })
 
   it('should reject requests when connection disconnects', async () => {
-    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
     const sendToMock = jest.spyOn(peers, 'sendTo')
 
     const { peer, connection } = getConnectedPeer(peers)
@@ -88,7 +88,7 @@ describe('RPC Router', () => {
   it('should increment and decrement pendingRPC', async () => {
     mocked(nextRpcId).mockReturnValue(91)
 
-    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
     jest.spyOn(peers, 'sendTo')
     const { peer } = getConnectedPeer(peers, 'peer')
 
@@ -114,7 +114,7 @@ describe('RPC Router', () => {
     mocked(nextRpcId).mockReturnValue(91)
     mocked(rpcTimeoutMillis).mockReturnValue(1000)
 
-    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
 
     const router = new RpcRouter(peers)
     router.register('test', jest.fn())
@@ -145,7 +145,7 @@ describe('RPC Router', () => {
   it('Catches a cannotSatisfy error and returns the appropriate type', async () => {
     mocked(nextRpcId).mockReturnValue(18)
 
-    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
     const sendToMock = jest.fn()
     peers.sendTo = sendToMock
 

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -13,14 +13,13 @@ import { createNodeTest } from '../testUtilities'
 import { mockChain, mockNode, mockStrategy } from '../testUtilities/mocks'
 import { DisconnectingMessage, NodeMessageType } from './messages'
 import { PeerNetwork, RoutingStyle } from './peerNetwork'
-import { AddressManager } from './peers/addressManager'
-import { getConnectedPeer, mockHostsStore, mockPrivateIdentity } from './testUtilities'
+import { getConnectedPeer, mockFileSystem, mockPrivateIdentity } from './testUtilities'
 
 jest.useFakeTimers()
 
 describe('PeerNetwork', () => {
   describe('stop', () => {
-    it('stops the peer manager', () => {
+    it('stops the peer manager', async () => {
       const peerNetwork = new PeerNetwork({
         identity: mockPrivateIdentity('local'),
         agent: 'sdk/1/cli',
@@ -28,17 +27,17 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        addressManager: new AddressManager(mockHostsStore()),
+        files: mockFileSystem(),
       })
 
       const stopSpy = jest.spyOn(peerNetwork.peerManager, 'stop')
-      peerNetwork.stop()
+      await peerNetwork.stop()
       expect(stopSpy).toBeCalled()
     })
   })
 
   describe('registerHandler', () => {
-    it('stores the type in the routingStyles', () => {
+    it('stores the type in the routingStyles', async () => {
       const peerNetwork = new PeerNetwork({
         identity: mockPrivateIdentity('local'),
         agent: 'sdk/1/cli',
@@ -46,7 +45,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        addressManager: new AddressManager(mockHostsStore()),
+        files: mockFileSystem(),
       })
 
       const type = 'hello'
@@ -57,7 +56,7 @@ describe('PeerNetwork', () => {
         () => {},
       )
       expect(peerNetwork['routingStyles'].get(type)).toBe(RoutingStyle.gossip)
-      peerNetwork.stop()
+      await peerNetwork.stop()
     })
   })
 
@@ -70,7 +69,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        addressManager: new AddressManager(mockHostsStore()),
+        files: mockFileSystem(),
       })
 
       const handlerMock = jest.fn(() => {})
@@ -88,12 +87,12 @@ describe('PeerNetwork', () => {
         message,
       })
       expect(handlerMock).not.toBeCalled()
-      peerNetwork.stop()
+      await peerNetwork.stop()
     })
   })
 
   describe('when peers connect', () => {
-    it('changes isReady', () => {
+    it('changes isReady', async () => {
       const peerNetwork = new PeerNetwork({
         identity: mockPrivateIdentity('local'),
         agent: 'sdk/1/cli',
@@ -102,7 +101,7 @@ describe('PeerNetwork', () => {
         chain: mockChain(),
         strategy: mockStrategy(),
         minPeers: 1,
-        addressManager: new AddressManager(mockHostsStore()),
+        files: mockFileSystem(),
       })
 
       expect(peerNetwork.isReady).toBe(false)
@@ -110,7 +109,7 @@ describe('PeerNetwork', () => {
       const readyChanged = jest.fn()
       peerNetwork.onIsReadyChanged.on(readyChanged)
 
-      peerNetwork.start()
+      await peerNetwork.start()
       expect(peerNetwork.isReady).toBe(false)
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
@@ -119,7 +118,7 @@ describe('PeerNetwork', () => {
       peer.close()
       expect(peerNetwork.isReady).toBe(false)
 
-      peerNetwork.stop()
+      await peerNetwork.stop()
       expect(peerNetwork.isReady).toBe(false)
 
       expect(readyChanged).toBeCalledTimes(2)
@@ -129,7 +128,7 @@ describe('PeerNetwork', () => {
   })
 
   describe('when at max peers', () => {
-    it('rejects websocket connections', () => {
+    it('rejects websocket connections', async () => {
       const wsActual = jest.requireActual<typeof WSWebSocket>('ws')
 
       const peerNetwork = new PeerNetwork({
@@ -143,7 +142,7 @@ describe('PeerNetwork', () => {
         port: 0,
         minPeers: 1,
         maxPeers: 0,
-        addressManager: new AddressManager(mockHostsStore()),
+        files: mockFileSystem(),
       })
 
       const rejectSpy = jest
@@ -151,7 +150,7 @@ describe('PeerNetwork', () => {
         .mockReturnValue(true)
 
       // Start the network so it creates the webSocketServer
-      peerNetwork.start()
+      await peerNetwork.start()
       const server = peerNetwork['webSocketServer']
       Assert.isNotUndefined(server, `server`)
 
@@ -162,7 +161,7 @@ describe('PeerNetwork', () => {
       const sendSpy = jest.spyOn(conn, 'send').mockReturnValue(undefined)
       const closeSpy = jest.spyOn(conn, 'close').mockReturnValue(undefined)
       server.server.emit('connection', conn, req)
-      peerNetwork.stop()
+      await peerNetwork.stop()
 
       expect(rejectSpy).toHaveBeenCalled()
       expect(sendSpy).toHaveBeenCalled()
@@ -185,7 +184,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        addressManager: new AddressManager(mockHostsStore()),
+        files: mockFileSystem(),
       })
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
@@ -224,7 +223,7 @@ describe('PeerNetwork', () => {
             },
           },
           strategy: mockStrategy(),
-          addressManager: new AddressManager(mockHostsStore()),
+          files: mockFileSystem(),
         })
 
         const { accounts, memPool, workerPool } = node
@@ -274,7 +273,7 @@ describe('PeerNetwork', () => {
           node,
           chain,
           strategy: mockStrategy(),
-          addressManager: new AddressManager(mockHostsStore()),
+          files: mockFileSystem(),
         })
 
         const { accounts, memPool } = node
@@ -323,7 +322,7 @@ describe('PeerNetwork', () => {
           node,
           chain,
           strategy: mockStrategy(),
-          addressManager: new AddressManager(mockHostsStore()),
+          files: mockFileSystem(),
         })
 
         // Spy on new transactions
@@ -372,7 +371,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        addressManager: new AddressManager(mockHostsStore()),
+        files: mockFileSystem(),
       }
 
       const peerNetwork1 = new PeerNetwork({ ...networkArgs, enableSyncing: false })
@@ -425,7 +424,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        addressManager: new AddressManager(mockHostsStore()),
+        files: mockFileSystem(),
       }
 
       const peerNetwork1 = new PeerNetwork({ ...networkArgs, enableSyncing: false })

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -13,7 +13,7 @@ import { createNodeTest } from '../testUtilities'
 import { mockChain, mockNode, mockStrategy } from '../testUtilities/mocks'
 import { DisconnectingMessage, NodeMessageType } from './messages'
 import { PeerNetwork, RoutingStyle } from './peerNetwork'
-import { getConnectedPeer, mockFileSystem, mockPrivateIdentity } from './testUtilities'
+import { getConnectedPeer, mockHostsStore, mockPrivateIdentity } from './testUtilities'
 
 jest.useFakeTimers()
 
@@ -27,7 +27,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        files: mockFileSystem(),
+        hostsStore: mockHostsStore(),
       })
 
       const stopSpy = jest.spyOn(peerNetwork.peerManager, 'stop')
@@ -45,7 +45,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        files: mockFileSystem(),
+        hostsStore: mockHostsStore(),
       })
 
       const type = 'hello'
@@ -69,7 +69,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        files: mockFileSystem(),
+        hostsStore: mockHostsStore(),
       })
 
       const handlerMock = jest.fn(() => {})
@@ -101,7 +101,7 @@ describe('PeerNetwork', () => {
         chain: mockChain(),
         strategy: mockStrategy(),
         minPeers: 1,
-        files: mockFileSystem(),
+        hostsStore: mockHostsStore(),
       })
 
       expect(peerNetwork.isReady).toBe(false)
@@ -142,7 +142,7 @@ describe('PeerNetwork', () => {
         port: 0,
         minPeers: 1,
         maxPeers: 0,
-        files: mockFileSystem(),
+        hostsStore: mockHostsStore(),
       })
 
       const rejectSpy = jest
@@ -184,7 +184,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        files: mockFileSystem(),
+        hostsStore: mockHostsStore(),
       })
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
@@ -223,7 +223,7 @@ describe('PeerNetwork', () => {
             },
           },
           strategy: mockStrategy(),
-          files: mockFileSystem(),
+          hostsStore: mockHostsStore(),
         })
 
         const { accounts, memPool, workerPool } = node
@@ -273,7 +273,7 @@ describe('PeerNetwork', () => {
           node,
           chain,
           strategy: mockStrategy(),
-          files: mockFileSystem(),
+          hostsStore: mockHostsStore(),
         })
 
         const { accounts, memPool } = node
@@ -322,7 +322,7 @@ describe('PeerNetwork', () => {
           node,
           chain,
           strategy: mockStrategy(),
-          files: mockFileSystem(),
+          hostsStore: mockHostsStore(),
         })
 
         // Spy on new transactions
@@ -371,7 +371,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        files: mockFileSystem(),
+        hostsStore: mockHostsStore(),
       }
 
       const peerNetwork1 = new PeerNetwork({ ...networkArgs, enableSyncing: false })
@@ -424,7 +424,7 @@ describe('PeerNetwork', () => {
         node: mockNode(),
         chain: mockChain(),
         strategy: mockStrategy(),
-        files: mockFileSystem(),
+        hostsStore: mockHostsStore(),
       }
 
       const peerNetwork1 = new PeerNetwork({ ...networkArgs, enableSyncing: false })

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -109,7 +109,7 @@ describe('PeerNetwork', () => {
       const readyChanged = jest.fn()
       peerNetwork.onIsReadyChanged.on(readyChanged)
 
-      await peerNetwork.start()
+      peerNetwork.start()
       expect(peerNetwork.isReady).toBe(false)
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
@@ -150,7 +150,7 @@ describe('PeerNetwork', () => {
         .mockReturnValue(true)
 
       // Start the network so it creates the webSocketServer
-      await peerNetwork.start()
+      peerNetwork.start()
       const server = peerNetwork['webSocketServer']
       Assert.isNotUndefined(server, `server`)
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -7,6 +7,7 @@ import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { MAX_REQUESTED_BLOCKS } from '../consensus'
 import { Event } from '../event'
+import { FileSystem } from '../fileSystems'
 import { DEFAULT_WEBSOCKET_PORT } from '../fileStores/config'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
@@ -58,7 +59,6 @@ import {
   NodeMessageType,
   PayloadType,
 } from './messages'
-import { AddressManager } from './peers/addressManager'
 import { LocalPeer } from './peers/localPeer'
 import { BAN_SCORE, Peer } from './peers/peer'
 import { PeerConnectionManager } from './peers/peerConnectionManager'
@@ -147,7 +147,8 @@ export class PeerNetwork {
     node: IronfishNode
     strategy: Strategy
     chain: Blockchain
-    addressManager: AddressManager
+    files: FileSystem
+    dataDir?: string
   }) {
     const identity = options.identity || tweetnacl.box.keyPair()
     const enableSyncing = options.enableSyncing ?? true
@@ -178,7 +179,7 @@ export class PeerNetwork {
 
     this.peerManager = new PeerManager(
       this.localPeer,
-      options.addressManager,
+      options.files,
       this.logger,
       this.metrics,
       maxPeers,

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -3,12 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import tweetnacl from 'tweetnacl'
+import { HostsStore } from '..'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { MAX_REQUESTED_BLOCKS } from '../consensus'
 import { Event } from '../event'
 import { DEFAULT_WEBSOCKET_PORT } from '../fileStores/config'
-import { FileSystem } from '../fileSystems'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
 import { IronfishNode } from '../node'
@@ -147,8 +147,7 @@ export class PeerNetwork {
     node: IronfishNode
     strategy: Strategy
     chain: Blockchain
-    files: FileSystem
-    dataDir?: string
+    hostsStore: HostsStore
   }) {
     const identity = options.identity || tweetnacl.box.keyPair()
     const enableSyncing = options.enableSyncing ?? true
@@ -179,13 +178,12 @@ export class PeerNetwork {
 
     this.peerManager = new PeerManager(
       this.localPeer,
-      options.files,
+      options.hostsStore,
       this.logger,
       this.metrics,
       maxPeers,
       targetPeers,
       logPeerMessages,
-      options.dataDir,
     )
     this.peerManager.onMessage.on((peer, message) => this.handleMessage(peer, message))
     this.peerManager.onConnectedPeersChanged.on(() => this.updateIsReady())

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -293,7 +293,7 @@ export class PeerNetwork {
     })
   }
 
-  async start(): Promise<void> {
+  start(): void {
     if (this.started) {
       return
     }
@@ -370,7 +370,7 @@ export class PeerNetwork {
     }
 
     // Start up the PeerManager
-    await this.peerManager.start()
+    this.peerManager.start()
 
     // Start up the PeerConnectionManager
     this.peerConnectionManager.start()
@@ -399,13 +399,11 @@ export class PeerNetwork {
    * outstanding connections.
    */
   async stop(): Promise<void> {
-    await Promise.allSettled([
-      (this.started = false),
-      this.peerConnectionManager.stop(),
-      await this.peerManager.stop(),
-      this.webSocketServer?.close(),
-      this.updateIsReady(),
-    ])
+    this.started = false
+    this.peerConnectionManager.stop()
+    await this.peerManager.stop()
+    this.webSocketServer?.close()
+    this.updateIsReady()
   }
 
   /**

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -185,6 +185,7 @@ export class PeerNetwork {
       maxPeers,
       targetPeers,
       logPeerMessages,
+      options.dataDir,
     )
     this.peerManager.onMessage.on((peer, message) => this.handleMessage(peer, message))
     this.peerManager.onConnectedPeersChanged.on(() => this.updateIsReady())

--- a/ironfish/src/network/peers/addressManager.test.ts
+++ b/ironfish/src/network/peers/addressManager.test.ts
@@ -3,14 +3,27 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 jest.mock('ws')
 
-import { mockHostsStore } from '../testUtilities'
+import { InternalMessageType, PeerList } from '../messages'
+import {
+  getConnectedPeer,
+  getConnectingPeer,
+  getDisconnectedPeer,
+  mockFileSystem,
+  mockHostsStore,
+  mockLocalPeer,
+} from '../testUtilities'
 import { AddressManager } from './addressManager'
+import { ConnectionDirection, ConnectionType } from './connections'
+import { Peer } from './peer'
+import { PeerAddress } from './peerAddress'
+import { PeerManager } from './peerManager'
 
 jest.useFakeTimers()
 
 describe('AddressManager', () => {
   it('constructor loads addresses from HostsStore', () => {
-    const addressManager = new AddressManager(mockHostsStore())
+    const addressManager = new AddressManager(mockFileSystem())
+    addressManager.hostsStore = mockHostsStore()
     expect(addressManager.priorConnectedPeerAddresses).toMatchObject([
       {
         address: '127.0.0.1',
@@ -21,8 +34,133 @@ describe('AddressManager', () => {
       {
         address: '1.1.1.1',
         port: 1111,
-        identity: undefined,
+        identity: null,
+        name: null,
       },
     ])
+  })
+
+  it('addAddressesFromPeerList should add new addresses from a peer list', () => {
+    const addressManager = new AddressManager(mockFileSystem())
+    addressManager.hostsStore = mockHostsStore()
+    expect(addressManager.possiblePeerAddresses.length).toEqual(1)
+    expect(addressManager.possiblePeerAddresses).toMatchObject([
+      {
+        address: '1.1.1.1',
+        port: 1111,
+        identity: null,
+        name: null,
+      },
+    ])
+    const peerList: PeerList = {
+      type: InternalMessageType.peerList,
+      payload: {
+        connectedPeers: [
+          {
+            address: '2.2.2.2',
+            identity: 'blah',
+            name: 'blah',
+            port: 2222,
+          },
+        ],
+      },
+    }
+    addressManager.addAddressesFromPeerList(peerList)
+    expect(addressManager.possiblePeerAddresses.length).toEqual(2)
+    expect(addressManager.possiblePeerAddresses).toContainEqual({
+      address: '2.2.2.2',
+      identity: 'blah',
+      name: 'blah',
+      port: 2222,
+    })
+  })
+
+  it('removePeerAddress should remove a peer address', () => {
+    const addressManager = new AddressManager(mockFileSystem())
+    addressManager.hostsStore = mockHostsStore()
+    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const { peer: peer1 } = getConnectedPeer(pm)
+    const allPeers: Peer[] = [peer1]
+    const allPeerAddresses: PeerAddress[] = []
+
+    for (const peer of allPeers) {
+      allPeerAddresses.push({
+        address: peer.address,
+        port: peer.port,
+        identity: peer.state.identity,
+        name: peer.name,
+      })
+    }
+    addressManager.hostsStore.set('possiblePeers', allPeerAddresses)
+    addressManager.hostsStore.set('priorPeers', allPeerAddresses)
+    addressManager.removePeerAddress(peer1)
+    expect(addressManager.possiblePeerAddresses.length).toEqual(0)
+    expect(addressManager.priorConnectedPeerAddresses.length).toEqual(0)
+  })
+
+  it('getRandomDisconnectedPeer should return a randomly-sampled disconnected peer', () => {
+    const addressManager = new AddressManager(mockFileSystem())
+    addressManager.hostsStore = mockHostsStore()
+    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const { peer: connectedPeer } = getConnectedPeer(pm)
+    const { peer: connectingPeer } = getConnectingPeer(pm)
+    const { peer: disconnectedPeer } = getDisconnectedPeer(pm)
+    const nonDisconnectedPeers: Peer[] = [connectedPeer, connectingPeer]
+    const allPeerAddresses: PeerAddress[] = []
+
+    for (const peer of [...nonDisconnectedPeers, disconnectedPeer]) {
+      allPeerAddresses.push({
+        address: peer.address,
+        port: peer.port,
+        identity: 'boop',
+        name: peer.name,
+      })
+    }
+
+    addressManager.hostsStore.set('priorPeers', allPeerAddresses)
+    addressManager.hostsStore.set('possiblePeers', allPeerAddresses)
+    const sample = addressManager.getRandomDisconnectedPeerAddress(nonDisconnectedPeers)
+    expect(sample).not.toBeNull()
+    if (sample !== null) {
+      expect(allPeerAddresses).toContainEqual(sample)
+      expect(sample.address).toEqual(disconnectedPeer.address)
+      expect(sample.port).toEqual(disconnectedPeer.port)
+    }
+  })
+
+  describe('save', () => {
+    it('save should persist connected peers', async () => {
+      const addressManager = new AddressManager(mockFileSystem())
+      addressManager.hostsStore = mockHostsStore()
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const { peer: connectedPeer } = getConnectedPeer(pm)
+      const { peer: connectingPeer } = getConnectingPeer(pm)
+      const { peer: disconnectedPeer } = getDisconnectedPeer(pm)
+      const address: PeerAddress = {
+        address: connectedPeer.address,
+        port: connectedPeer.port,
+        identity: connectedPeer.state.identity,
+        name: connectedPeer.name,
+      }
+
+      await addressManager.save([connectedPeer, connectingPeer, disconnectedPeer])
+      expect(addressManager.priorConnectedPeerAddresses).toContainEqual(address)
+    })
+
+    it('should not persist peers that will never retry connecting', async () => {
+      const addressManager = new AddressManager(mockFileSystem())
+      addressManager.hostsStore = mockHostsStore()
+      expect(addressManager.priorConnectedPeerAddresses.length).toEqual(1)
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const { peer: connectedPeer } = getConnectedPeer(pm)
+      const { peer: connectingPeer } = getConnectingPeer(pm)
+      const { peer: disconnectedPeer } = getDisconnectedPeer(pm)
+      connectedPeer
+        .getConnectionRetry(ConnectionType.WebSocket, ConnectionDirection.Outbound)
+        ?.neverRetryConnecting()
+
+      await addressManager.save([connectedPeer, connectingPeer, disconnectedPeer])
+      expect(addressManager.priorConnectedPeerAddresses.length).toEqual(0)
+    })
   })
 })

--- a/ironfish/src/network/peers/addressManager.test.ts
+++ b/ironfish/src/network/peers/addressManager.test.ts
@@ -7,7 +7,6 @@ import {
   getConnectedPeer,
   getConnectingPeer,
   getDisconnectedPeer,
-  mockFileSystem,
   mockHostsStore,
   mockLocalPeer,
 } from '../testUtilities'
@@ -21,7 +20,7 @@ jest.useFakeTimers()
 
 describe('AddressManager', () => {
   it('constructor loads addresses from HostsStore', () => {
-    const addressManager = new AddressManager(mockFileSystem())
+    const addressManager = new AddressManager(mockHostsStore())
     addressManager.hostsStore = mockHostsStore()
     expect(addressManager.priorConnectedPeerAddresses).toMatchObject([
       {
@@ -32,9 +31,9 @@ describe('AddressManager', () => {
   })
 
   it('removePeerAddress should remove a peer address', () => {
-    const addressManager = new AddressManager(mockFileSystem())
+    const addressManager = new AddressManager(mockHostsStore())
     addressManager.hostsStore = mockHostsStore()
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const { peer: peer1 } = getConnectedPeer(pm)
     const allPeers: Peer[] = [peer1]
     const allPeerAddresses: PeerAddress[] = []
@@ -54,9 +53,9 @@ describe('AddressManager', () => {
   })
 
   it('getRandomDisconnectedPeer should return a randomly-sampled disconnected peer', () => {
-    const addressManager = new AddressManager(mockFileSystem())
+    const addressManager = new AddressManager(mockHostsStore())
     addressManager.hostsStore = mockHostsStore()
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const { peer: connectedPeer } = getConnectedPeer(pm)
     const { peer: connectingPeer } = getConnectingPeer(pm)
     const disconnectedPeer = getDisconnectedPeer(pm)
@@ -93,9 +92,9 @@ describe('AddressManager', () => {
 
   describe('save', () => {
     it('save should persist connected peers', async () => {
-      const addressManager = new AddressManager(mockFileSystem())
+      const addressManager = new AddressManager(mockHostsStore())
       addressManager.hostsStore = mockHostsStore()
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
       const { peer: connectedPeer } = getConnectedPeer(pm)
       const { peer: connectingPeer } = getConnectingPeer(pm)
       const disconnectedPeer = getDisconnectedPeer(pm)
@@ -111,10 +110,10 @@ describe('AddressManager', () => {
     })
 
     it('should not persist peers that will never retry connecting', async () => {
-      const addressManager = new AddressManager(mockFileSystem())
+      const addressManager = new AddressManager(mockHostsStore())
       addressManager.hostsStore = mockHostsStore()
       expect(addressManager.priorConnectedPeerAddresses.length).toEqual(1)
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
       const { peer: connectedPeer } = getConnectedPeer(pm)
       const { peer: connectingPeer } = getConnectingPeer(pm)
       const disconnectedPeer = getDisconnectedPeer(pm)

--- a/ironfish/src/network/peers/addressManager.test.ts
+++ b/ironfish/src/network/peers/addressManager.test.ts
@@ -59,7 +59,7 @@ describe('AddressManager', () => {
     const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
     const { peer: connectedPeer } = getConnectedPeer(pm)
     const { peer: connectingPeer } = getConnectingPeer(pm)
-    const { peer: disconnectedPeer } = getDisconnectedPeer(pm)
+    const disconnectedPeer = getDisconnectedPeer(pm)
     const nonDisconnectedPeers: Peer[] = [connectedPeer, connectingPeer]
     const allPeerAddresses: PeerAddress[] = []
 
@@ -67,7 +67,7 @@ describe('AddressManager', () => {
       allPeerAddresses.push({
         address: peer.address,
         port: peer.port,
-        identity: 'boop',
+        identity: peer.state.identity,
         name: peer.name,
       })
     }
@@ -98,7 +98,7 @@ describe('AddressManager', () => {
       const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
       const { peer: connectedPeer } = getConnectedPeer(pm)
       const { peer: connectingPeer } = getConnectingPeer(pm)
-      const { peer: disconnectedPeer } = getDisconnectedPeer(pm)
+      const disconnectedPeer = getDisconnectedPeer(pm)
       const address: PeerAddress = {
         address: connectedPeer.address,
         port: connectedPeer.port,
@@ -117,7 +117,7 @@ describe('AddressManager', () => {
       const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
       const { peer: connectedPeer } = getConnectedPeer(pm)
       const { peer: connectingPeer } = getConnectingPeer(pm)
-      const { peer: disconnectedPeer } = getDisconnectedPeer(pm)
+      const disconnectedPeer = getDisconnectedPeer(pm)
       connectedPeer
         .getConnectionRetry(ConnectionType.WebSocket, ConnectionDirection.Outbound)
         ?.neverRetryConnecting()

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -1,10 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Peer, PeerList } from '..'
 import { HostsStore } from '../../fileStores'
 import { FileSystem } from '../../fileSystems'
 import { ArrayUtils } from '../../utils'
+import { Peer, PeerList } from '..'
 import { ConnectionDirection, ConnectionType } from './connections'
 import { PeerAddress } from './peerAddress'
 

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -1,8 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Peer, PeerList } from '..'
 import { HostsStore } from '../../fileStores'
 import { FileSystem } from '../../fileSystems'
+import { ArrayUtils } from '../../utils'
+import { ConnectionDirection, ConnectionType } from './connections'
 import { PeerAddress } from './peerAddress'
 
 /**
@@ -24,5 +27,124 @@ export class AddressManager {
 
   get possiblePeerAddresses(): ReadonlyArray<Readonly<PeerAddress>> {
     return this.hostsStore.getArray('possiblePeers')
+  }
+  /**
+   * Adds addresses associated to peers received from peer list
+   */
+  addAddressesFromPeerList(peerList: PeerList): void {
+    const newAddresses: PeerAddress[] = peerList.payload.connectedPeers.map((peer) => ({
+      address: peer.address,
+      port: peer.port,
+      identity: peer.identity ?? null,
+      name: peer.name ?? null,
+    }))
+
+    const possiblePeerStrings = this.possiblePeerAddresses
+      .filter((peerAddress) => !(peerAddress.address == null) && !(peerAddress.port == null))
+      .map(
+        (filteredPeerAddress) =>
+          //eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          `${filteredPeerAddress.address!}:${filteredPeerAddress.port!}`,
+      )
+    const possiblePeerSet = new Set(possiblePeerStrings)
+
+    const dedupedAddresses = newAddresses.filter(
+      (newAddress) =>
+        !(newAddress.address == null) &&
+        !(newAddress.port == null) &&
+        !possiblePeerSet.has(`${newAddress.address}:${newAddress.port}`),
+    )
+
+    if (dedupedAddresses.length) {
+      this.hostsStore.set('possiblePeers', [...this.possiblePeerAddresses, ...dedupedAddresses])
+    }
+  }
+
+  /**
+   * Returns a peer address for a disconnected peer by using current peers to
+   * filter out peer addresses. It attempts to find a previously-connected
+   * peer address that is not part of an active connection. If there are none,
+   * then it attempts to find a previously-known peer address.
+   */
+  getRandomDisconnectedPeerAddress(peers: Peer[]): PeerAddress | null {
+    if (
+      this.possiblePeerAddresses.length === 0 &&
+      this.priorConnectedPeerAddresses.length === 0
+    ) {
+      return null
+    }
+
+    const currentPeerAddresses = new Set(
+      //eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      peers.filter((peer) => peer.state.identity !== null).map((peer) => peer.state.identity!),
+    )
+
+    const priorConnectedAddressSet = new Set([...this.priorConnectedPeerAddresses])
+
+    const disconnectedPriorAddresses = this.filterConnectedAddresses(
+      priorConnectedAddressSet,
+      currentPeerAddresses,
+    )
+    if (disconnectedPriorAddresses.length) {
+      return ArrayUtils.sampleOrThrow(disconnectedPriorAddresses)
+    } else {
+      const possibleAddressSet = new Set([...this.possiblePeerAddresses])
+      const disconnectedPossibleAddresses = this.filterConnectedAddresses(
+        possibleAddressSet,
+        currentPeerAddresses,
+      )
+      if (disconnectedPossibleAddresses.length) {
+        return ArrayUtils.sampleOrThrow(disconnectedPossibleAddresses)
+      } else {
+        return null
+      }
+    }
+  }
+
+  private filterConnectedAddresses(
+    addressSet: Set<Readonly<PeerAddress>>,
+    connectedPeerAdresses: Set<string>,
+  ): PeerAddress[] {
+    const disconnectedAddresses = [...addressSet].filter(
+      (address) => address.identity !== null && !connectedPeerAdresses.has(address.identity),
+    )
+
+    return disconnectedAddresses
+  }
+
+  /**
+   * Removes address associated with a peer from address stores
+   */
+  removePeerAddress(peer: Peer): void {
+    const filteredPossibles = this.possiblePeerAddresses.filter(
+      (possible) => possible.identity !== peer.state.identity,
+    )
+    const filteredPriorConnected = this.priorConnectedPeerAddresses.filter(
+      (prior) => prior.identity !== peer.state.identity,
+    )
+
+    this.hostsStore.set('possiblePeers', filteredPossibles)
+    this.hostsStore.set('priorPeers', filteredPriorConnected)
+  }
+
+  /**
+   * Persist all currently connected peers and unused peer addresses to disk
+   */
+  async save(peers: Peer[]): Promise<void> {
+    const inUsePeerAddresses = peers
+      .filter(
+        (peer) =>
+          peer.state.type === 'CONNECTED' &&
+          !peer.getConnectionRetry(ConnectionType.WebSocket, ConnectionDirection.Outbound)
+            ?.willNeverRetryConnecting,
+      )
+      .map((peer) => ({
+        address: peer.address,
+        port: peer.port,
+        identity: peer.state.identity ?? null,
+        name: peer.name ?? null,
+      }))
+    this.hostsStore.set('priorPeers', [...inUsePeerAddresses])
+    await this.hostsStore.save()
   }
 }

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { HostsStore } from '../../fileStores'
+import { FileSystem } from '../../fileSystems'
 import { PeerAddress } from './peerAddress'
 
 /**
@@ -9,17 +10,19 @@ import { PeerAddress } from './peerAddress'
  * and provides functionality for persistence of said data.
  */
 export class AddressManager {
-  hosts: HostsStore
+  hostsStore: HostsStore
 
-  constructor(hostsStore: HostsStore) {
-    this.hosts = hostsStore
+  constructor(files: FileSystem, dataDir?: string) {
+    this.hostsStore = new HostsStore(files, dataDir)
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.hostsStore.load()
   }
 
   get priorConnectedPeerAddresses(): ReadonlyArray<Readonly<PeerAddress>> {
-    return this.hosts.getArray('priorPeers')
+    return this.hostsStore.getArray('priorPeers')
   }
 
   get possiblePeerAddresses(): ReadonlyArray<Readonly<PeerAddress>> {
-    return this.hosts.getArray('possiblePeers')
+    return this.hostsStore.getArray('possiblePeers')
   }
 }

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -25,8 +25,7 @@ export class AddressManager {
   /**
    * Returns a peer address for a disconnected peer by using current peers to
    * filter out peer addresses. It attempts to find a previously-connected
-   * peer address that is not part of an active connection. If there are none,
-   * then it attempts to find a previously-known peer address.
+   * peer address that is not part of an active connection.
    */
   getRandomDisconnectedPeerAddress(peerIdentities: string[]): PeerAddress | null {
     if (this.priorConnectedPeerAddresses.length === 0) {

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -75,6 +75,9 @@ export class AddressManager {
    * Persist all currently connected peers and unused peer addresses to disk
    */
   async save(peers: Peer[]): Promise<void> {
+    // TODO: Ideally, we would like persist peers with whom we've
+    // successfully established an outbound Websocket connection at
+    // least once.
     const inUsePeerAddresses: PeerAddress[] = peers.flatMap((peer) => {
       if (
         peer.state.type === 'CONNECTED' &&

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { HostsStore } from '../../fileStores'
-import { FileSystem } from '../../fileSystems'
 import { ArrayUtils } from '../../utils'
 import { Peer } from '..'
 import { ConnectionDirection, ConnectionType } from './connections'
@@ -15,10 +14,8 @@ import { PeerAddress } from './peerAddress'
 export class AddressManager {
   hostsStore: HostsStore
 
-  constructor(files: FileSystem, dataDir?: string) {
-    this.hostsStore = new HostsStore(files, dataDir)
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.hostsStore.load()
+  constructor(hostsStore: HostsStore) {
+    this.hostsStore = hostsStore
   }
 
   get priorConnectedPeerAddresses(): ReadonlyArray<Readonly<PeerAddress>> {

--- a/ironfish/src/network/peers/peerAddress.ts
+++ b/ironfish/src/network/peers/peerAddress.ts
@@ -6,6 +6,6 @@ import { Identity } from '../identity'
 export type PeerAddress = {
   address: string | null
   port: number | null
-  identity?: Identity | null
-  name?: string | null
+  identity: Identity | null
+  name: string | null
 }

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -7,13 +7,12 @@ jest.mock('ws')
 import { createRootLogger } from '../../logger'
 import {
   getConnectedPeer,
-  mockHostsStore,
+  mockFileSystem,
   mockIdentity,
   mockLocalPeer,
   webRtcCanInitiateIdentity,
   webRtcLocalIdentity,
 } from '../testUtilities'
-import { AddressManager } from './addressManager'
 import {
   ConnectionDirection,
   ConnectionType,
@@ -27,7 +26,7 @@ jest.useFakeTimers()
 
 describe('connectToDisconnectedPeers', () => {
   it('Should not connect to disconnected peers without an address or peers', () => {
-    const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
     const peer = pm.getOrCreatePeer(null)
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
     pm['logger'].mockTypes(() => jest.fn())
@@ -39,7 +38,7 @@ describe('connectToDisconnectedPeers', () => {
   })
 
   it('Should connect to disconnected unidentified peers with an address', () => {
-    const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
     const peer = pm.getOrCreatePeer(null)
     peer.setWebSocketAddress('testuri.com', 9033)
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
@@ -54,7 +53,7 @@ describe('connectToDisconnectedPeers', () => {
   })
 
   it('Should connect to disconnected identified peers with an address over WS', () => {
-    const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
     const identity = mockIdentity('peer')
     const peer = pm.getOrCreatePeer(identity)
@@ -76,7 +75,7 @@ describe('connectToDisconnectedPeers', () => {
   })
 
   it('Should connect to webrtc and websockets', () => {
-    const peers = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
 
     const identity = mockIdentity('peer')
     const peer = peers.getOrCreatePeer(identity)
@@ -106,7 +105,7 @@ describe('connectToDisconnectedPeers', () => {
     const peerIdentity = webRtcCanInitiateIdentity()
     const pm = new PeerManager(
       mockLocalPeer({ identity: webRtcLocalIdentity() }),
-      new AddressManager(mockHostsStore()),
+      mockFileSystem(),
     )
     const { peer: brokeringPeer } = getConnectedPeer(pm, 'brokering')
     const peer = pm.getOrCreatePeer(peerIdentity)
@@ -129,7 +128,7 @@ describe('maintainOneConnectionPerPeer', () => {
   it('Should not close WS connection if the WebRTC connection is not in CONNECTED', () => {
     const pm = new PeerManager(
       mockLocalPeer({ identity: webRtcLocalIdentity() }),
-      new AddressManager(mockHostsStore()),
+      mockFileSystem(),
     )
     const peer = pm.connectToWebSocketAddress('testuri')
     const identity = webRtcCanInitiateIdentity()
@@ -178,7 +177,7 @@ describe('maintainOneConnectionPerPeer', () => {
   it('Should close WebSocket connection if a peer has WS and WebRTC connections', () => {
     const pm = new PeerManager(
       mockLocalPeer({ identity: webRtcLocalIdentity() }),
-      new AddressManager(mockHostsStore()),
+      mockFileSystem(),
     )
     const peer = pm.connectToWebSocketAddress('testuri')
     const identity = webRtcCanInitiateIdentity()
@@ -229,7 +228,7 @@ describe('attemptToEstablishWebRtcConnectionsToWSPeers', () => {
   it('Should attempt to establish a WebRTC connection if we have a WebSocket connection', () => {
     const pm = new PeerManager(
       mockLocalPeer({ identity: webRtcLocalIdentity() }),
-      new AddressManager(mockHostsStore()),
+      mockFileSystem(),
     )
     const peer = pm.connectToWebSocketAddress('testuri')
     const identity = webRtcCanInitiateIdentity()

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -7,7 +7,7 @@ jest.mock('ws')
 import { createRootLogger } from '../../logger'
 import {
   getConnectedPeer,
-  mockFileSystem,
+  mockHostsStore,
   mockIdentity,
   mockLocalPeer,
   webRtcCanInitiateIdentity,
@@ -26,7 +26,7 @@ jest.useFakeTimers()
 
 describe('connectToDisconnectedPeers', () => {
   it('Should not connect to disconnected peers without an address or peers', () => {
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const peer = pm.getOrCreatePeer(null)
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
     pm['logger'].mockTypes(() => jest.fn())
@@ -38,7 +38,7 @@ describe('connectToDisconnectedPeers', () => {
   })
 
   it('Should connect to disconnected unidentified peers with an address', () => {
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const peer = pm.getOrCreatePeer(null)
     peer.setWebSocketAddress('testuri.com', 9033)
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
@@ -53,7 +53,7 @@ describe('connectToDisconnectedPeers', () => {
   })
 
   it('Should connect to disconnected identified peers with an address over WS', () => {
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
     const identity = mockIdentity('peer')
     const peer = pm.getOrCreatePeer(identity)
@@ -75,7 +75,7 @@ describe('connectToDisconnectedPeers', () => {
   })
 
   it('Should connect to webrtc and websockets', () => {
-    const peers = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
 
     const identity = mockIdentity('peer')
     const peer = peers.getOrCreatePeer(identity)
@@ -105,7 +105,7 @@ describe('connectToDisconnectedPeers', () => {
     const peerIdentity = webRtcCanInitiateIdentity()
     const pm = new PeerManager(
       mockLocalPeer({ identity: webRtcLocalIdentity() }),
-      mockFileSystem(),
+      mockHostsStore(),
     )
     const { peer: brokeringPeer } = getConnectedPeer(pm, 'brokering')
     const peer = pm.getOrCreatePeer(peerIdentity)
@@ -128,7 +128,7 @@ describe('maintainOneConnectionPerPeer', () => {
   it('Should not close WS connection if the WebRTC connection is not in CONNECTED', () => {
     const pm = new PeerManager(
       mockLocalPeer({ identity: webRtcLocalIdentity() }),
-      mockFileSystem(),
+      mockHostsStore(),
     )
     const peer = pm.connectToWebSocketAddress('testuri')
     const identity = webRtcCanInitiateIdentity()
@@ -177,7 +177,7 @@ describe('maintainOneConnectionPerPeer', () => {
   it('Should close WebSocket connection if a peer has WS and WebRTC connections', () => {
     const pm = new PeerManager(
       mockLocalPeer({ identity: webRtcLocalIdentity() }),
-      mockFileSystem(),
+      mockHostsStore(),
     )
     const peer = pm.connectToWebSocketAddress('testuri')
     const identity = webRtcCanInitiateIdentity()
@@ -228,7 +228,7 @@ describe('attemptToEstablishWebRtcConnectionsToWSPeers', () => {
   it('Should attempt to establish a WebRTC connection if we have a WebSocket connection', () => {
     const pm = new PeerManager(
       mockLocalPeer({ identity: webRtcLocalIdentity() }),
-      mockFileSystem(),
+      mockHostsStore(),
     )
     const peer = pm.connectToWebSocketAddress('testuri')
     const identity = webRtcCanInitiateIdentity()

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -86,6 +86,13 @@ export class PeerConnectionManager {
       }
     }
 
+    if (this.peerManager.canCreateNewConnections()) {
+      const peer = this.peerManager.getRandomDisconnectedPeer()
+      if (peer) {
+        this.connectToEligiblePeers(peer)
+      }
+    }
+
     this.eventLoopTimer = setTimeout(() => this.eventLoop(), EVENT_LOOP_MS)
   }
 

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -87,7 +87,7 @@ export class PeerConnectionManager {
     }
 
     if (this.peerManager.canCreateNewConnections()) {
-      const peer = this.peerManager.getRandomDisconnectedPeer()
+      const peer = this.peerManager.createRandomDisconnectedPeer()
       if (peer) {
         this.connectToEligiblePeers(peer)
       }

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -86,10 +86,10 @@ export class PeerConnectionManager {
       }
     }
 
-    if (this.peerManager.canCreateNewConnections()) {
+    if (connectAttempts < CONNECT_ATTEMPTS_MAX && this.peerManager.canCreateNewConnections()) {
       const peer = this.peerManager.createRandomDisconnectedPeer()
-      if (peer) {
-        this.connectToEligiblePeers(peer)
+      if (peer && this.connectToEligiblePeers(peer)) {
+        connectAttempts++
       }
     }
 

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -46,7 +46,7 @@ import {
   getConnectingPeer,
   getSignalingWebRtcPeer,
   getWaitingForIdentityPeer,
-  mockHostsStore,
+  mockFileSystem,
   mockIdentity,
   mockLocalPeer,
   mockPrivateIdentity,
@@ -55,7 +55,6 @@ import {
   webRtcLocalIdentity,
 } from '../testUtilities'
 import { VERSION_PROTOCOL, VERSION_PROTOCOL_MIN } from '../version'
-import { AddressManager } from './addressManager'
 import {
   ConnectionDirection,
   ConnectionType,
@@ -69,7 +68,7 @@ jest.useFakeTimers()
 describe('PeerManager', () => {
   describe('Dispose peers', () => {
     it('Should not dispose of peers that have a CONNECTED peer', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
@@ -88,7 +87,7 @@ describe('PeerManager', () => {
     })
 
     it('Should dispose of two DISCONNECTED peers that have each other in knownPeers', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
@@ -118,113 +117,9 @@ describe('PeerManager', () => {
     })
   })
 
-  describe('Distribute peers', () => {
-    it('Should send peer list requests to newer protocol version', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
-
-      const { peer: peer1 } = getConnectedPeer(pm, 'peer1')
-
-      peer1.version = 9
-
-      expect(pm.identifiedPeers.size).toBe(1)
-
-      const mockSend = jest.spyOn(peer1, 'send')
-
-      pm['distributePeerList']()
-      expect(mockSend).toBeCalledTimes(1)
-      expect(mockSend).toBeCalledWith({
-        type: InternalMessageType.peerListRequest,
-      })
-    })
-
-    it('Should not send peer list requests to older protocol version', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
-
-      const { peer: peer1 } = getConnectedPeer(pm, 'peer1')
-
-      peer1.version = 8
-
-      expect(pm.identifiedPeers.size).toBe(1)
-
-      const mockSend = jest.spyOn(peer1, 'send')
-
-      pm['distributePeerList']()
-      expect(mockSend).toHaveBeenCalledTimes(1)
-      expect(mockSend).not.toHaveBeenCalledWith({
-        type: InternalMessageType.peerListRequest,
-      })
-    })
-
-    it('Should not send peer list requests to null protocol version', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
-
-      const { peer: peer1 } = getConnectedPeer(pm, 'peer1')
-
-      expect(pm.identifiedPeers.size).toBe(1)
-
-      const mockSend = jest.spyOn(peer1, 'send')
-
-      pm['distributePeerList']()
-      expect(mockSend).toHaveBeenCalledTimes(1)
-      expect(mockSend).not.toHaveBeenCalledWith({
-        type: InternalMessageType.peerListRequest,
-      })
-    })
-
-    it('Should broadcast peer list to older protocol version', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
-
-      const { peer: peer1 } = getConnectedPeer(pm, 'peer1')
-      const { peer: peer2 } = getConnectedPeer(pm, 'peer2')
-
-      peer1.version = 8
-
-      expect(pm.identifiedPeers.size).toBe(2)
-
-      const mockSend = jest.spyOn(peer1, 'send')
-
-      pm['distributePeerList']()
-      expect(mockSend).toBeCalledTimes(1)
-      expect(mockSend).toBeCalledWith({
-        type: InternalMessageType.peerList,
-        payload: {
-          connectedPeers: [
-            { address: 'testuri.com', port: 9033, identity: peer1.getIdentityOrThrow() },
-            { address: 'testuri.com', port: 9033, identity: peer2.getIdentityOrThrow() },
-          ],
-        },
-      })
-    })
-
-    it('Should not broadcast peer list to newer protocol version', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
-
-      const { peer: peer1 } = getConnectedPeer(pm, 'peer1')
-      const { peer: peer2 } = getConnectedPeer(pm, 'peer2')
-
-      peer1.version = 9
-
-      expect(pm.identifiedPeers.size).toBe(2)
-
-      const mockSend = jest.spyOn(peer1, 'send')
-
-      pm['distributePeerList']()
-      expect(mockSend).toBeCalledTimes(1)
-      expect(mockSend).not.toBeCalledWith({
-        type: InternalMessageType.peerList,
-        payload: {
-          connectedPeers: [
-            { address: 'testuri.com', port: 9033, identity: peer1.getIdentityOrThrow() },
-            { address: 'testuri.com', port: 9033, identity: peer2.getIdentityOrThrow() },
-          ],
-        },
-      })
-    })
-  })
-
   it('should handle duplicate connections from the same peer', () => {
     const localPeer = mockLocalPeer({ identity: webRtcLocalIdentity() })
-    const peers = new PeerManager(localPeer, new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(localPeer, mockFileSystem())
 
     const { peer: peerOut, connection: connectionOut } = getWaitingForIdentityPeer(
       peers,
@@ -341,10 +236,7 @@ describe('PeerManager', () => {
 
   it('Sends identity when a connection is successfully made', () => {
     const localIdentity = mockPrivateIdentity('local')
-    const pm = new PeerManager(
-      mockLocalPeer({ identity: localIdentity }),
-      new AddressManager(mockHostsStore()),
-    )
+    const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockFileSystem())
 
     const { peer, connection } = getConnectingPeer(pm)
 
@@ -376,7 +268,7 @@ describe('PeerManager', () => {
 
   it('should disconnect connection on CONNECTED', () => {
     const localPeer = mockLocalPeer()
-    const peers = new PeerManager(localPeer, new AddressManager(mockHostsStore()))
+    const peers = new PeerManager(localPeer, mockFileSystem())
 
     const { peer: peer1, connection: connection1 } = getConnectingPeer(peers)
     const { peer: peer2, connection: connection2 } = getWaitingForIdentityPeer(peers)
@@ -409,7 +301,7 @@ describe('PeerManager', () => {
 
   describe('connect', () => {
     it('Creates a peer and adds it to unidentifiedConnections', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
       expect(pm.peers.length).toBe(0)
 
       const peer = pm.connectToWebSocketAddress('testUri')
@@ -436,7 +328,7 @@ describe('PeerManager', () => {
 
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
       )
       const { connection, brokeringPeer } = getSignalingWebRtcPeer(
         pm,
@@ -469,7 +361,7 @@ describe('PeerManager', () => {
     it('Attempts to establish a WebSocket connection to a peer with a webSocketAddress', () => {
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       // Create the peers
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
@@ -498,7 +390,7 @@ describe('PeerManager', () => {
     it('Attempts to establish a WebRTC connection through brokering peer', () => {
       const peers = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
       )
 
       // Create the peers
@@ -521,7 +413,7 @@ describe('PeerManager', () => {
     it('Can establish a WebRTC connection to a peer using an existing WebSocket connection to the same peer', async () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
       )
 
       const { peer, connection } = getConnectedPeer(pm, webRtcCanInitiateIdentity())
@@ -564,7 +456,7 @@ describe('PeerManager', () => {
     it('Attempts to request WebRTC signaling through brokering peer', () => {
       const peers = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
       )
 
       // Create the peer to broker the connection through
@@ -601,7 +493,7 @@ describe('PeerManager', () => {
     })
 
     it('Does not create a connection if Peer has disconnectUntil set', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
       const { peer } = getConnectedPeer(pm, 'peer')
       peer.close()
 
@@ -620,7 +512,7 @@ describe('PeerManager', () => {
     })
 
     it('Sets disconnectUntil to null if current time is after disconnectUntil', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
       const { peer } = getConnectedPeer(pm, 'peer')
       peer.close()
 
@@ -638,14 +530,7 @@ describe('PeerManager', () => {
     })
 
     it('Does not create a connection to a disconnected Peer above targetPeers', () => {
-      const pm = new PeerManager(
-        mockLocalPeer(),
-        new AddressManager(mockHostsStore()),
-        undefined,
-        undefined,
-        50,
-        1,
-      )
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem(), undefined, undefined, 50, 1)
 
       // Add one connected peer
       getConnectedPeer(pm, 'peer1')
@@ -671,7 +556,7 @@ describe('PeerManager', () => {
   describe('create peers', () => {
     it('Returns the same peer when calling createPeer twice with the same identity', () => {
       const peerIdentity = mockIdentity('peer')
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const peer1 = pm.getOrCreatePeer(peerIdentity)
       const peer1Again = pm.getOrCreatePeer(peerIdentity)
@@ -684,7 +569,7 @@ describe('PeerManager', () => {
     it('Merges peers when an unidentified peer connects with the same identity as an identified webrtc peer', () => {
       const brokerIdentity = mockIdentity('brokering')
       const peerIdentity = webRtcCanInitiateIdentity()
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { peer } = getSignalingWebRtcPeer(pm, brokerIdentity, peerIdentity)
 
@@ -742,7 +627,7 @@ describe('PeerManager', () => {
       const peerIdentity = webRtcCanInitiateIdentity()
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
       )
 
       const { peer, connection } = getConnectedPeer(pm, peerIdentity)
@@ -800,7 +685,7 @@ describe('PeerManager', () => {
   })
 
   it('Emits onConnectedPeersChanged when a peer enters CONNECTED or DISCONNECTED', () => {
-    const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
     const onConnectedPeersChangedMock = jest.fn()
     pm.onConnectedPeersChanged.on(onConnectedPeersChangedMock)
 
@@ -821,7 +706,7 @@ describe('PeerManager', () => {
   describe('Message: Identity', () => {
     it('Adds the peer to identifiedPeers after receiving a valid identity message', () => {
       const other = mockIdentity('other')
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       expect(pm.identifiedPeers.size).toBe(0)
       expect(pm.peers.length).toBe(0)
@@ -858,7 +743,7 @@ describe('PeerManager', () => {
 
     it('Closes the connection when versions do not match', () => {
       const other = mockPrivateIdentity('other')
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { peer, connection } = getWaitingForIdentityPeer(pm)
 
@@ -894,7 +779,7 @@ describe('PeerManager', () => {
     })
 
     it('Closes the connection when an identity message with an invalid public key is sent', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { peer, connection } = getWaitingForIdentityPeer(pm)
 
@@ -931,10 +816,7 @@ describe('PeerManager', () => {
 
     it('Closes the connection if an unidentified peer returns the local identity', () => {
       const localIdentity = mockPrivateIdentity('local')
-      const pm = new PeerManager(
-        mockLocalPeer({ identity: localIdentity }),
-        new AddressManager(mockHostsStore()),
-      )
+      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockFileSystem())
 
       expect(pm.identifiedPeers.size).toBe(0)
       expect(pm.peers.length).toBe(0)
@@ -966,10 +848,7 @@ describe('PeerManager', () => {
 
     it('Closes the connection if an identified peer returns the local identity', () => {
       const localIdentity = mockPrivateIdentity('local')
-      const pm = new PeerManager(
-        mockLocalPeer({ identity: localIdentity }),
-        new AddressManager(mockHostsStore()),
-      )
+      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockFileSystem())
 
       const { peer: peer1 } = getConnectedPeer(pm, 'peer1')
 
@@ -1028,7 +907,7 @@ describe('PeerManager', () => {
     it('Moves the connection to another peer if it returns a different identity', () => {
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
 
@@ -1086,10 +965,7 @@ describe('PeerManager', () => {
     it('Closes the connection if the peer has disconnectUntil set', () => {
       const localIdentity = mockPrivateIdentity('local')
       const peerIdentity = mockIdentity('peer')
-      const pm = new PeerManager(
-        mockLocalPeer({ identity: localIdentity }),
-        new AddressManager(mockHostsStore()),
-      )
+      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockFileSystem())
 
       const { peer } = getConnectedPeer(pm, peerIdentity)
       peer.close()
@@ -1133,7 +1009,7 @@ describe('PeerManager', () => {
 
   describe('Message: SignalRequest', () => {
     it('Forwards SignalRequest message intended for another peer', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { peer: destinationPeer } = getConnectedPeer(pm, webRtcCannotInitiateIdentity())
       const { connection: sourcePeerConnection, peer: sourcePeer } = getConnectedPeer(
@@ -1162,7 +1038,7 @@ describe('PeerManager', () => {
     })
 
     it('Drops SignalRequest message originating from an different peer than sourceIdentity', () => {
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { peer: peer1 } = getConnectedPeer(pm)
       const { peer: peer2 } = getConnectedPeer(pm)
@@ -1187,7 +1063,7 @@ describe('PeerManager', () => {
     it('reject SignalRequest when source peer should initiate', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
       )
       const initWebRtcConnectionMock = jest.fn()
       pm['initWebRtcConnection'] = initWebRtcConnectionMock
@@ -1214,7 +1090,7 @@ describe('PeerManager', () => {
     it('Initiates webRTC connection when request intended for local peer', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
       )
       const initWebRtcConnectionMock = jest.fn()
       pm['initWebRtcConnection'] = initWebRtcConnectionMock
@@ -1243,7 +1119,7 @@ describe('PeerManager', () => {
     it('Sends a disconnect message if we are at max peers', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
         undefined,
         undefined,
         1,
@@ -1279,7 +1155,7 @@ describe('PeerManager', () => {
     it('Does not send a disconnect message if we are at max peers but we have an existing connection to the peer', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
         undefined,
         undefined,
         1,
@@ -1308,7 +1184,7 @@ describe('PeerManager', () => {
     it('Forwards signaling messages intended for another peer', () => {
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { connection: peer1Connection, peer: peer1 } = getConnectedPeer(pm, peer1Identity)
       const { peer: peer2 } = getConnectedPeer(pm, peer2Identity)
@@ -1332,7 +1208,7 @@ describe('PeerManager', () => {
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
       const peer3Identity = mockIdentity('peer3')
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
       const { peer: peer2 } = getConnectedPeer(pm, peer2Identity)
@@ -1358,7 +1234,7 @@ describe('PeerManager', () => {
     it('Sends a disconnect message if we are at max peers', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
         undefined,
         undefined,
         1,
@@ -1396,7 +1272,7 @@ describe('PeerManager', () => {
     it('Does not send a disconnect message if we are at max peers but we have an existing connection to the peer', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
         undefined,
         undefined,
         1,
@@ -1427,7 +1303,7 @@ describe('PeerManager', () => {
 
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
       )
 
       const { connection, brokeringConnection, brokeringPeer } = getSignalingWebRtcPeer(
@@ -1469,7 +1345,7 @@ describe('PeerManager', () => {
 
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
       )
       const { connection, brokeringConnection, brokeringPeer } = getSignalingWebRtcPeer(
         pm,
@@ -1504,7 +1380,7 @@ describe('PeerManager', () => {
 
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        new AddressManager(mockHostsStore()),
+        mockFileSystem(),
       )
       const { connection, brokeringConnection, brokeringPeer } = getSignalingWebRtcPeer(
         pm,
@@ -1536,7 +1412,7 @@ describe('PeerManager', () => {
     it('Sends a peer list message in response', () => {
       const peerIdentity = mockIdentity('peer')
 
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
       const { connection, peer } = getConnectedPeer(pm, peerIdentity)
 
       expect(pm.peers.length).toBe(1)
@@ -1571,10 +1447,7 @@ describe('PeerManager', () => {
       const localIdentity = mockPrivateIdentity('local')
       const peerIdentity = mockIdentity('peer')
 
-      const pm = new PeerManager(
-        mockLocalPeer({ identity: localIdentity }),
-        new AddressManager(mockHostsStore()),
-      )
+      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockFileSystem())
 
       const { connection, peer } = getConnectedPeer(pm, peerIdentity)
 
@@ -1600,7 +1473,7 @@ describe('PeerManager', () => {
       const peerIdentity = mockIdentity('peer')
       const newPeerIdentity = mockIdentity('new')
 
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { connection, peer } = getConnectedPeer(pm, peerIdentity)
 
@@ -1631,7 +1504,7 @@ describe('PeerManager', () => {
       const peerIdentity = mockIdentity('peer')
       const newPeerIdentity = mockIdentity('new')
 
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { connection, peer } = getConnectedPeer(pm, peerIdentity)
 
@@ -1681,7 +1554,7 @@ describe('PeerManager', () => {
       const peerIdentity = mockIdentity('peer')
       const newPeerIdentity = mockIdentity('new')
 
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { connection, peer } = getConnectedPeer(pm, peerIdentity)
 
@@ -1738,7 +1611,7 @@ describe('PeerManager', () => {
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
       const peer3Identity = mockIdentity('peer3')
-      const pm = new PeerManager(mockLocalPeer(), new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
 
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
       const { peer: peer2 } = getConnectedPeer(pm, peer2Identity)
@@ -1763,7 +1636,7 @@ describe('PeerManager', () => {
 
     it('Should set peerRequestedDisconnectUntil on unidentified Peer', () => {
       const localPeer = mockLocalPeer()
-      const pm = new PeerManager(localPeer, new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(localPeer, mockFileSystem())
       const peerIdentity = mockIdentity('peer')
       const { peer, connection } = getConnectingPeer(pm)
       expect(peer.peerRequestedDisconnectUntil).toBeNull()
@@ -1790,7 +1663,7 @@ describe('PeerManager', () => {
 
     it('Should set peerRequestedDisconnectUntil on CONNECTED Peer when sender is not sourceIdentity', () => {
       const localPeer = mockLocalPeer({ identity: webRtcLocalIdentity() })
-      const pm = new PeerManager(localPeer, new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(localPeer, mockFileSystem())
 
       const { peer, brokeringConnection, brokeringPeer } = getSignalingWebRtcPeer(
         pm,
@@ -1821,7 +1694,7 @@ describe('PeerManager', () => {
 
     it('Should set peerRequestedDisconnectUntil on CONNECTED Peer when sender is sourceIdentity', () => {
       const localPeer = mockLocalPeer()
-      const pm = new PeerManager(localPeer, new AddressManager(mockHostsStore()))
+      const pm = new PeerManager(localPeer, mockFileSystem())
       const peerIdentity = mockIdentity('peer')
       const { peer, connection } = getConnectedPeer(pm, peerIdentity)
       expect(peer.peerRequestedDisconnectUntil).toBeNull()

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -46,7 +46,7 @@ import {
   getConnectingPeer,
   getSignalingWebRtcPeer,
   getWaitingForIdentityPeer,
-  mockFileSystem,
+  mockHostsStore,
   mockIdentity,
   mockLocalPeer,
   mockPrivateIdentity,
@@ -68,7 +68,7 @@ jest.useFakeTimers()
 describe('PeerManager', () => {
   describe('Dispose peers', () => {
     it('Should not dispose of peers that have a CONNECTED peer', () => {
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
@@ -87,7 +87,7 @@ describe('PeerManager', () => {
     })
 
     it('Should dispose of two DISCONNECTED peers that have each other in knownPeers', () => {
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
@@ -119,7 +119,7 @@ describe('PeerManager', () => {
 
   it('should handle duplicate connections from the same peer', () => {
     const localPeer = mockLocalPeer({ identity: webRtcLocalIdentity() })
-    const peers = new PeerManager(localPeer, mockFileSystem())
+    const peers = new PeerManager(localPeer, mockHostsStore())
 
     const { peer: peerOut, connection: connectionOut } = getWaitingForIdentityPeer(
       peers,
@@ -236,7 +236,7 @@ describe('PeerManager', () => {
 
   it('Sends identity when a connection is successfully made', () => {
     const localIdentity = mockPrivateIdentity('local')
-    const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockHostsStore())
 
     const { peer, connection } = getConnectingPeer(pm)
 
@@ -268,7 +268,7 @@ describe('PeerManager', () => {
 
   it('should disconnect connection on CONNECTED', () => {
     const localPeer = mockLocalPeer()
-    const peers = new PeerManager(localPeer, mockFileSystem())
+    const peers = new PeerManager(localPeer, mockHostsStore())
 
     const { peer: peer1, connection: connection1 } = getConnectingPeer(peers)
     const { peer: peer2, connection: connection2 } = getWaitingForIdentityPeer(peers)
@@ -301,7 +301,7 @@ describe('PeerManager', () => {
 
   describe('connect', () => {
     it('Creates a peer and adds it to unidentifiedConnections', () => {
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
       expect(pm.peers.length).toBe(0)
 
       const peer = pm.connectToWebSocketAddress('testUri')
@@ -328,7 +328,7 @@ describe('PeerManager', () => {
 
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
       )
       const { connection, brokeringPeer } = getSignalingWebRtcPeer(
         pm,
@@ -361,7 +361,7 @@ describe('PeerManager', () => {
     it('Attempts to establish a WebSocket connection to a peer with a webSocketAddress', () => {
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       // Create the peers
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
@@ -390,7 +390,7 @@ describe('PeerManager', () => {
     it('Attempts to establish a WebRTC connection through brokering peer', () => {
       const peers = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
       )
 
       // Create the peers
@@ -413,7 +413,7 @@ describe('PeerManager', () => {
     it('Can establish a WebRTC connection to a peer using an existing WebSocket connection to the same peer', async () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
       )
 
       const { peer, connection } = getConnectedPeer(pm, webRtcCanInitiateIdentity())
@@ -467,7 +467,7 @@ describe('PeerManager', () => {
     it('Attempts to request WebRTC signaling through brokering peer', () => {
       const peers = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
       )
 
       // Create the peer to broker the connection through
@@ -504,7 +504,7 @@ describe('PeerManager', () => {
     })
 
     it('Does not create a connection if Peer has disconnectUntil set', () => {
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
       const { peer } = getConnectedPeer(pm, 'peer')
       peer.close()
 
@@ -523,7 +523,7 @@ describe('PeerManager', () => {
     })
 
     it('Sets disconnectUntil to null if current time is after disconnectUntil', () => {
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
       const { peer } = getConnectedPeer(pm, 'peer')
       peer.close()
 
@@ -541,7 +541,7 @@ describe('PeerManager', () => {
     })
 
     it('Does not create a connection to a disconnected Peer above targetPeers', () => {
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem(), undefined, undefined, 50, 1)
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore(), undefined, undefined, 50, 1)
 
       // Add one connected peer
       getConnectedPeer(pm, 'peer1')
@@ -567,7 +567,7 @@ describe('PeerManager', () => {
   describe('create peers', () => {
     it('Returns the same peer when calling createPeer twice with the same identity', () => {
       const peerIdentity = mockIdentity('peer')
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const peer1 = pm.getOrCreatePeer(peerIdentity)
       const peer1Again = pm.getOrCreatePeer(peerIdentity)
@@ -580,7 +580,7 @@ describe('PeerManager', () => {
     it('Merges peers when an unidentified peer connects with the same identity as an identified webrtc peer', () => {
       const brokerIdentity = mockIdentity('brokering')
       const peerIdentity = webRtcCanInitiateIdentity()
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { peer } = getSignalingWebRtcPeer(pm, brokerIdentity, peerIdentity)
 
@@ -646,7 +646,7 @@ describe('PeerManager', () => {
       const peerIdentity = webRtcCanInitiateIdentity()
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
       )
 
       const { peer, connection } = getConnectedPeer(pm, peerIdentity)
@@ -704,7 +704,7 @@ describe('PeerManager', () => {
   })
 
   it('Emits onConnectedPeersChanged when a peer enters CONNECTED or DISCONNECTED', () => {
-    const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
     const onConnectedPeersChangedMock = jest.fn()
     pm.onConnectedPeersChanged.on(onConnectedPeersChangedMock)
 
@@ -725,7 +725,7 @@ describe('PeerManager', () => {
   describe('Message: Identity', () => {
     it('Adds the peer to identifiedPeers after receiving a valid identity message', () => {
       const other = mockIdentity('other')
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       expect(pm.identifiedPeers.size).toBe(0)
       expect(pm.peers.length).toBe(0)
@@ -762,7 +762,7 @@ describe('PeerManager', () => {
 
     it('Closes the connection when versions do not match', () => {
       const other = mockPrivateIdentity('other')
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { peer, connection } = getWaitingForIdentityPeer(pm)
 
@@ -798,7 +798,7 @@ describe('PeerManager', () => {
     })
 
     it('Closes the connection when an identity message with an invalid public key is sent', () => {
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { peer, connection } = getWaitingForIdentityPeer(pm)
 
@@ -835,7 +835,7 @@ describe('PeerManager', () => {
 
     it('Closes the connection if an unidentified peer returns the local identity', () => {
       const localIdentity = mockPrivateIdentity('local')
-      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockHostsStore())
 
       expect(pm.identifiedPeers.size).toBe(0)
       expect(pm.peers.length).toBe(0)
@@ -867,7 +867,7 @@ describe('PeerManager', () => {
 
     it('Closes the connection if an identified peer returns the local identity', () => {
       const localIdentity = mockPrivateIdentity('local')
-      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockHostsStore())
 
       const { peer: peer1 } = getConnectedPeer(pm, 'peer1')
 
@@ -926,7 +926,7 @@ describe('PeerManager', () => {
     it('Moves the connection to another peer if it returns a different identity', () => {
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
 
@@ -984,7 +984,7 @@ describe('PeerManager', () => {
     it('Closes the connection if the peer has disconnectUntil set', () => {
       const localIdentity = mockPrivateIdentity('local')
       const peerIdentity = mockIdentity('peer')
-      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockHostsStore())
 
       const { peer } = getConnectedPeer(pm, peerIdentity)
       peer.close()
@@ -1028,7 +1028,7 @@ describe('PeerManager', () => {
 
   describe('Message: SignalRequest', () => {
     it('Forwards SignalRequest message intended for another peer', () => {
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { peer: destinationPeer } = getConnectedPeer(pm, webRtcCannotInitiateIdentity())
       const { connection: sourcePeerConnection, peer: sourcePeer } = getConnectedPeer(
@@ -1057,7 +1057,7 @@ describe('PeerManager', () => {
     })
 
     it('Drops SignalRequest message originating from an different peer than sourceIdentity', () => {
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { peer: peer1 } = getConnectedPeer(pm)
       const { peer: peer2 } = getConnectedPeer(pm)
@@ -1082,7 +1082,7 @@ describe('PeerManager', () => {
     it('reject SignalRequest when source peer should initiate', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
       )
       const initWebRtcConnectionMock = jest.fn()
       pm['initWebRtcConnection'] = initWebRtcConnectionMock
@@ -1109,7 +1109,7 @@ describe('PeerManager', () => {
     it('Initiates webRTC connection when request intended for local peer', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
       )
       const initWebRtcConnectionMock = jest.fn()
       pm['initWebRtcConnection'] = initWebRtcConnectionMock
@@ -1138,7 +1138,7 @@ describe('PeerManager', () => {
     it('Sends a disconnect message if we are at max peers', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
         undefined,
         undefined,
         1,
@@ -1174,7 +1174,7 @@ describe('PeerManager', () => {
     it('Does not send a disconnect message if we are at max peers but we have an existing connection to the peer', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
         undefined,
         undefined,
         1,
@@ -1203,7 +1203,7 @@ describe('PeerManager', () => {
     it('Forwards signaling messages intended for another peer', () => {
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { connection: peer1Connection, peer: peer1 } = getConnectedPeer(pm, peer1Identity)
       const { peer: peer2 } = getConnectedPeer(pm, peer2Identity)
@@ -1227,7 +1227,7 @@ describe('PeerManager', () => {
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
       const peer3Identity = mockIdentity('peer3')
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
       const { peer: peer2 } = getConnectedPeer(pm, peer2Identity)
@@ -1253,7 +1253,7 @@ describe('PeerManager', () => {
     it('Sends a disconnect message if we are at max peers', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
         undefined,
         undefined,
         1,
@@ -1291,7 +1291,7 @@ describe('PeerManager', () => {
     it('Does not send a disconnect message if we are at max peers but we have an existing connection to the peer', () => {
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
         undefined,
         undefined,
         1,
@@ -1322,7 +1322,7 @@ describe('PeerManager', () => {
 
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
       )
 
       const { connection, brokeringConnection, brokeringPeer } = getSignalingWebRtcPeer(
@@ -1364,7 +1364,7 @@ describe('PeerManager', () => {
 
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
       )
       const { connection, brokeringConnection, brokeringPeer } = getSignalingWebRtcPeer(
         pm,
@@ -1399,7 +1399,7 @@ describe('PeerManager', () => {
 
       const pm = new PeerManager(
         mockLocalPeer({ identity: webRtcLocalIdentity() }),
-        mockFileSystem(),
+        mockHostsStore(),
       )
       const { connection, brokeringConnection, brokeringPeer } = getSignalingWebRtcPeer(
         pm,
@@ -1431,7 +1431,7 @@ describe('PeerManager', () => {
     it('Sends a peer list message in response', () => {
       const peerIdentity = mockIdentity('peer')
 
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
       const { connection, peer } = getConnectedPeer(pm, peerIdentity)
 
       expect(pm.peers.length).toBe(1)
@@ -1466,7 +1466,7 @@ describe('PeerManager', () => {
       const localIdentity = mockPrivateIdentity('local')
       const peerIdentity = mockIdentity('peer')
 
-      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer({ identity: localIdentity }), mockHostsStore())
 
       const { connection, peer } = getConnectedPeer(pm, peerIdentity)
 
@@ -1492,7 +1492,7 @@ describe('PeerManager', () => {
       const peerIdentity = mockIdentity('peer')
       const newPeerIdentity = mockIdentity('new')
 
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { connection, peer } = getConnectedPeer(pm, peerIdentity)
 
@@ -1523,7 +1523,7 @@ describe('PeerManager', () => {
       const peerIdentity = mockIdentity('peer')
       const newPeerIdentity = mockIdentity('new')
 
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { connection, peer } = getConnectedPeer(pm, peerIdentity)
 
@@ -1573,7 +1573,7 @@ describe('PeerManager', () => {
       const peerIdentity = mockIdentity('peer')
       const newPeerIdentity = mockIdentity('new')
 
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { connection, peer } = getConnectedPeer(pm, peerIdentity)
 
@@ -1630,7 +1630,7 @@ describe('PeerManager', () => {
       const peer1Identity = mockIdentity('peer1')
       const peer2Identity = mockIdentity('peer2')
       const peer3Identity = mockIdentity('peer3')
-      const pm = new PeerManager(mockLocalPeer(), mockFileSystem())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
       const { peer: peer1 } = getConnectedPeer(pm, peer1Identity)
       const { peer: peer2 } = getConnectedPeer(pm, peer2Identity)
@@ -1655,7 +1655,7 @@ describe('PeerManager', () => {
 
     it('Should set peerRequestedDisconnectUntil on unidentified Peer', () => {
       const localPeer = mockLocalPeer()
-      const pm = new PeerManager(localPeer, mockFileSystem())
+      const pm = new PeerManager(localPeer, mockHostsStore())
       const peerIdentity = mockIdentity('peer')
       const { peer, connection } = getConnectingPeer(pm)
       expect(peer.peerRequestedDisconnectUntil).toBeNull()
@@ -1682,7 +1682,7 @@ describe('PeerManager', () => {
 
     it('Should set peerRequestedDisconnectUntil on CONNECTED Peer when sender is not sourceIdentity', () => {
       const localPeer = mockLocalPeer({ identity: webRtcLocalIdentity() })
-      const pm = new PeerManager(localPeer, mockFileSystem())
+      const pm = new PeerManager(localPeer, mockHostsStore())
 
       const { peer, brokeringConnection, brokeringPeer } = getSignalingWebRtcPeer(
         pm,
@@ -1713,7 +1713,7 @@ describe('PeerManager', () => {
 
     it('Should set peerRequestedDisconnectUntil on CONNECTED Peer when sender is sourceIdentity', () => {
       const localPeer = mockLocalPeer()
-      const pm = new PeerManager(localPeer, mockFileSystem())
+      const pm = new PeerManager(localPeer, mockHostsStore())
       const peerIdentity = mockIdentity('peer')
       const { peer, connection } = getConnectedPeer(pm, peerIdentity)
       expect(peer.peerRequestedDisconnectUntil).toBeNull()

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -450,7 +450,7 @@ describe('PeerManager', () => {
           sdpMid: '0',
         },
       })
-      expect(sendSpy).toBeCalledTimes(1)
+      expect(sendSpy).toBeCalledTimes(2)
     })
 
     it('Attempts to request WebRTC signaling through brokering peer', () => {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -5,6 +5,7 @@
 import type { SignalData } from './connections/webRtcConnection'
 import WSWebSocket from 'ws'
 import { Event } from '../../event'
+import { FileSystem } from '../../fileSystems'
 import { createRootLogger, Logger } from '../../logger'
 import { MetricsMonitor } from '../../metrics'
 import { ArrayUtils, SetIntervalToken } from '../../utils'
@@ -147,20 +148,21 @@ export class PeerManager {
 
   constructor(
     localPeer: LocalPeer,
-    addressManager: AddressManager,
+    files: FileSystem,
     logger: Logger = createRootLogger(),
     metrics?: MetricsMonitor,
     maxPeers = 10000,
     targetPeers = 50,
     logPeerMessages = false,
+    dataDir?: string,
   ) {
     this.logger = logger.withTag('peermanager')
-    this.addressManager = addressManager
     this.metrics = metrics || new MetricsMonitor(this.logger)
     this.localPeer = localPeer
     this.maxPeers = maxPeers
     this.targetPeers = targetPeers
     this.logPeerMessages = logPeerMessages
+    this.addressManager = new AddressManager(files, dataDir)
   }
 
   /**

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -54,12 +54,6 @@ import { Peer } from './peer'
 const MAX_WEBRTC_BROKERING_ATTEMPTS = 5
 
 /**
- * The minimum version at which the peer manager will send peer list requests
- * to a connected peer
- */
-const MIN_VERSION_FOR_PEER_LIST_REQUESTS = 9
-
-/**
  * PeerManager keeps the state of Peers and their underlying connections up to date,
  * determines how to establish a connection to a given Peer, and provides an event
  * bus for Peers, e.g. for listening to incoming messages from all connected peers.
@@ -91,13 +85,21 @@ export class PeerManager {
    * setInterval handle for distributePeerList, which sends out peer lists and
    * requests for peer lists
    */
-  private distributePeerListHandle: SetIntervalToken | undefined
+  private requestPeerListHandle: SetIntervalToken | undefined
 
+  /**
+   * setInterval handle for 
   /**
    * setInterval handle for peer disposal, which removes peers from the list that we
    * no longer care about
    */
   private disposePeersHandle: SetIntervalToken | undefined
+
+  /**
+   * setInterval handle for peer address persistence, which saves connected
+   * peers to disk
+   */
+  private savePeerAddressesHandle: ReturnType<typeof setInterval> | undefined
 
   /**
    * Event fired when a new connection is successfully opened. Sends some identifying
@@ -454,8 +456,7 @@ export class PeerManager {
     }
 
     const canEstablishNewConnection =
-      peer.state.type !== 'DISCONNECTED' ||
-      this.getPeersWithConnection().length < this.targetPeers
+      peer.state.type !== 'DISCONNECTED' || this.canCreateNewConnections()
 
     const disconnectOk =
       peer.peerRequestedDisconnectUntil === null || now >= peer.peerRequestedDisconnectUntil
@@ -482,8 +483,7 @@ export class PeerManager {
     }
 
     const canEstablishNewConnection =
-      peer.state.type !== 'DISCONNECTED' ||
-      this.getPeersWithConnection().length < this.targetPeers
+      peer.state.type !== 'DISCONNECTED' || this.canCreateNewConnections()
 
     const disconnectOk =
       peer.peerRequestedDisconnectUntil === null || now >= peer.peerRequestedDisconnectUntil
@@ -562,6 +562,14 @@ export class PeerManager {
     return [...this.identifiedPeers.values()].filter((p) => {
       return p.state.type === 'CONNECTED'
     })
+  }
+
+  /**
+   * Returns true if the total number of connected peers is less
+   * than the target amount of peers
+   */
+  canCreateNewConnections(): boolean {
+    return this.getPeersWithConnection().length < this.targetPeers
   }
 
   /**
@@ -784,55 +792,54 @@ export class PeerManager {
     }
   }
 
-  start(): void {
-    this.distributePeerListHandle = setInterval(() => this.distributePeerList(), 5000)
-    this.disposePeersHandle = setInterval(() => this.disposePeers(), 2000)
+  async start(): Promise<void> {
+    await Promise.allSettled([
+      (this.requestPeerListHandle = setInterval(() => this.requestPeerList(), 5000)),
+      (this.disposePeersHandle = setInterval(() => this.disposePeers(), 2000)),
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      (this.savePeerAddressesHandle = setInterval(async () => {
+        await this.addressManager.save(this.peers)
+      }, 60000)),
+    ])
   }
 
   /**
    * Call when shutting down the PeerManager to clean up
    * outstanding connections.
    */
-  stop(): void {
-    this.distributePeerListHandle && clearInterval(this.distributePeerListHandle)
+  async stop(): Promise<void> {
+    this.requestPeerListHandle && clearInterval(this.requestPeerListHandle)
     this.disposePeersHandle && clearInterval(this.disposePeersHandle)
+    this.savePeerAddressesHandle && clearInterval(this.savePeerAddressesHandle)
+    await this.addressManager.save(this.peers)
     for (const peer of this.peers) {
       this.disconnect(peer, DisconnectingReason.ShuttingDown, 0)
     }
   }
 
-  private distributePeerList() {
-    const connectedPeers = []
-
-    for (const p of this.identifiedPeers.values()) {
-      if (p.state.type !== 'CONNECTED') {
-        continue
-      }
-
-      connectedPeers.push({
-        identity: p.state.identity,
-        name: p.name || undefined,
-        address: p.address,
-        port: p.port,
-      })
-    }
-
-    const peerList: PeerList = {
-      type: InternalMessageType.peerList,
-      payload: { connectedPeers },
-    }
-
+  private requestPeerList() {
     const peerListRequest: PeerListRequest = {
       type: InternalMessageType.peerListRequest,
     }
 
     for (const peer of this.getConnectedPeers()) {
-      if (peer.version !== null && peer.version >= MIN_VERSION_FOR_PEER_LIST_REQUESTS) {
-        peer.send(peerListRequest)
-        continue
-      }
+      peer.send(peerListRequest)
+    }
+  }
 
-      peer.send(peerList)
+  /**
+   * Gets a random disconnected peer address and returns a peer created from
+   * said address
+   */
+  getRandomDisconnectedPeer(): Peer | null {
+    const peerAddress = this.addressManager.getRandomDisconnectedPeerAddress(this.peers)
+    if (peerAddress) {
+      const peer = this.getOrCreatePeer(peerAddress.identity)
+      peer.setWebSocketAddress(peerAddress.address, peerAddress.port)
+      peer.name = peerAddress.name || null
+      return peer
+    } else {
+      return null
     }
   }
 
@@ -867,6 +874,8 @@ export class PeerManager {
         this.identifiedPeers.delete(peer.state.identity)
       }
       this.peers = this.peers.filter((p) => p !== peer)
+
+      this.addressManager.removePeerAddress(peer)
 
       return true
     }
@@ -1479,6 +1488,8 @@ export class PeerManager {
     }
 
     let changed = false
+
+    this.addressManager.addAddressesFromPeerList(peerList)
 
     const newPeerSet = peerList.payload.connectedPeers.reduce(
       (memo, peer) => {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -832,14 +832,14 @@ export class PeerManager {
     const peerAddress = this.addressManager.getRandomDisconnectedPeerAddress(
       Array.from(this.identifiedPeers.keys()),
     )
-    if (peerAddress) {
-      const peer = this.getOrCreatePeer(peerAddress.identity)
-      peer.setWebSocketAddress(peerAddress.address, peerAddress.port)
-      peer.name = peerAddress.name || null
-      return peer
-    } else {
+    if (!peerAddress) {
       return null
     }
+
+    const peer = this.getOrCreatePeer(peerAddress.identity)
+    peer.setWebSocketAddress(peerAddress.address, peerAddress.port)
+    peer.name = peerAddress.name || null
+    return peer
   }
 
   private disposePeers(): void {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -4,8 +4,8 @@
 
 import type { SignalData } from './connections/webRtcConnection'
 import WSWebSocket from 'ws'
+import { HostsStore } from '../..'
 import { Event } from '../../event'
-import { FileSystem } from '../../fileSystems'
 import { createRootLogger, Logger } from '../../logger'
 import { MetricsMonitor } from '../../metrics'
 import { ArrayUtils, SetIntervalToken } from '../../utils'
@@ -148,13 +148,12 @@ export class PeerManager {
 
   constructor(
     localPeer: LocalPeer,
-    files: FileSystem,
+    hostsStore: HostsStore,
     logger: Logger = createRootLogger(),
     metrics?: MetricsMonitor,
     maxPeers = 10000,
     targetPeers = 50,
     logPeerMessages = false,
-    dataDir?: string,
   ) {
     this.logger = logger.withTag('peermanager')
     this.metrics = metrics || new MetricsMonitor(this.logger)
@@ -162,7 +161,7 @@ export class PeerManager {
     this.maxPeers = maxPeers
     this.targetPeers = targetPeers
     this.logPeerMessages = logPeerMessages
-    this.addressManager = new AddressManager(files, dataDir)
+    this.addressManager = new AddressManager(hostsStore)
   }
 
   /**

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -860,21 +860,22 @@ export class PeerManager {
 
     if (
       peer.state.type === 'DISCONNECTED' &&
-      !hasAConnectedPeer &&
       peer.getConnectionRetry(ConnectionType.WebSocket, ConnectionDirection.Outbound)
         ?.willNeverRetryConnecting
     ) {
-      this.logger.debug(
-        `Disposing of peer with identity ${String(peer.state.identity)} (may be a duplicate)`,
-      )
-
-      peer.dispose()
-      if (peer.state.identity && this.identifiedPeers.get(peer.state.identity) === peer) {
-        this.identifiedPeers.delete(peer.state.identity)
-      }
-      this.peers = this.peers.filter((p) => p !== peer)
-
       this.addressManager.removePeerAddress(peer)
+
+      if (!hasAConnectedPeer) {
+        this.logger.debug(
+          `Disposing of peer with identity ${String(peer.state.identity)} (may be a duplicate)`,
+        )
+
+        peer.dispose()
+        if (peer.state.identity && this.identifiedPeers.get(peer.state.identity) === peer) {
+          this.identifiedPeers.delete(peer.state.identity)
+        }
+        this.peers = this.peers.filter((p) => p !== peer)
+      }
 
       return true
     }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -88,8 +88,6 @@ export class PeerManager {
   private requestPeerListHandle: SetIntervalToken | undefined
 
   /**
-   * setInterval handle for 
-  /**
    * setInterval handle for peer disposal, which removes peers from the list that we
    * no longer care about
    */
@@ -99,7 +97,7 @@ export class PeerManager {
    * setInterval handle for peer address persistence, which saves connected
    * peers to disk
    */
-  private savePeerAddressesHandle: ReturnType<typeof setInterval> | undefined
+  private savePeerAddressesHandle: SetIntervalToken | undefined
 
   /**
    * Event fired when a new connection is successfully opened. Sends some identifying
@@ -793,15 +791,13 @@ export class PeerManager {
     }
   }
 
-  async start(): Promise<void> {
-    await Promise.allSettled([
-      (this.requestPeerListHandle = setInterval(() => this.requestPeerList(), 60000)),
-      (this.disposePeersHandle = setInterval(() => this.disposePeers(), 2000)),
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      (this.savePeerAddressesHandle = setInterval(async () => {
-        await this.addressManager.save(this.peers)
-      }, 60000)),
-    ])
+  start(): void {
+    this.requestPeerListHandle = setInterval(() => this.requestPeerList(), 60000)
+    this.disposePeersHandle = setInterval(() => this.disposePeers(), 2000)
+    this.savePeerAddressesHandle = setInterval(
+      () => void this.addressManager.save(this.peers),
+      60000,
+    )
   }
 
   /**
@@ -832,7 +828,7 @@ export class PeerManager {
    * Gets a random disconnected peer address and returns a peer created from
    * said address
    */
-  getRandomDisconnectedPeer(): Peer | null {
+  createRandomDisconnectedPeer(): Peer | null {
     const peerAddress = this.addressManager.getRandomDisconnectedPeerAddress(this.peers)
     if (peerAddress) {
       const peer = this.getOrCreatePeer(peerAddress.identity)

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -725,7 +725,6 @@ export class PeerManager {
         if (peer.state.type === 'CONNECTED') {
           this.updateIdentifiedPeerMap(peer)
           peer.onStateChanged.off(handler)
-          peer.send({ type: InternalMessageType.peerListRequest })
         }
       }
       peer.onStateChanged.on(handler)
@@ -751,6 +750,12 @@ export class PeerManager {
         this.onDisconnect.emit(peer)
         this.onConnectedPeersChanged.emit()
         this.tryDisposePeer(peer)
+      }
+    })
+
+    peer.onStateChanged.on(({ prevState }) => {
+      if (prevState.type !== 'CONNECTED' && peer.state.type === 'CONNECTED') {
+        peer.send({ type: InternalMessageType.peerListRequest })
       }
     })
 

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -829,7 +829,9 @@ export class PeerManager {
    * said address
    */
   createRandomDisconnectedPeer(): Peer | null {
-    const peerAddress = this.addressManager.getRandomDisconnectedPeerAddress(this.peers)
+    const peerAddress = this.addressManager.getRandomDisconnectedPeerAddress(
+      Array.from(this.identifiedPeers.keys()),
+    )
     if (peerAddress) {
       const peer = this.getOrCreatePeer(peerAddress.identity)
       peer.setWebSocketAddress(peerAddress.address, peerAddress.port)
@@ -1485,8 +1487,6 @@ export class PeerManager {
     }
 
     let changed = false
-
-    this.addressManager.addAddressesFromPeerList(peerList)
 
     const newPeerSet = peerList.payload.connectedPeers.reduce(
       (memo, peer) => {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -82,7 +82,7 @@ export class PeerManager {
   addressManager: AddressManager
 
   /**
-   * setInterval handle for distributePeerList, which sends out peer lists and
+   * setInterval handle for requestPeerList, which sends out peer lists and
    * requests for peer lists
    */
   private requestPeerListHandle: SetIntervalToken | undefined
@@ -727,6 +727,7 @@ export class PeerManager {
         if (peer.state.type === 'CONNECTED') {
           this.updateIdentifiedPeerMap(peer)
           peer.onStateChanged.off(handler)
+          peer.send({ type: InternalMessageType.peerListRequest })
         }
       }
       peer.onStateChanged.on(handler)
@@ -794,7 +795,7 @@ export class PeerManager {
 
   async start(): Promise<void> {
     await Promise.allSettled([
-      (this.requestPeerListHandle = setInterval(() => this.requestPeerList(), 5000)),
+      (this.requestPeerListHandle = setInterval(() => this.requestPeerList(), 60000)),
       (this.disposePeersHandle = setInterval(() => this.disposePeers(), 2000)),
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       (this.savePeerAddressesHandle = setInterval(async () => {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -833,9 +833,15 @@ export class PeerManager {
    * said address
    */
   createRandomDisconnectedPeer(): Peer | null {
-    const peerAddress = this.addressManager.getRandomDisconnectedPeerAddress(
-      Array.from(this.identifiedPeers.keys()),
-    )
+    const connectedPeers = Array.from(this.identifiedPeers.values()).flatMap((peer) => {
+      if (peer.state.type !== 'DISCONNECTED' && peer.state.identity !== null) {
+        return peer.state.identity
+      } else {
+        return []
+      }
+    })
+
+    const peerAddress = this.addressManager.getRandomDisconnectedPeerAddress(connectedPeers)
     if (!peerAddress) {
       return null
     }

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -94,6 +94,25 @@ export function getConnectedPeer(
   return { peer, connection: connection }
 }
 
+export function getDisconnectedPeer(
+  pm: PeerManager,
+  identity?: string | Identity,
+): { peer: Peer; connection: WebSocketConnection } {
+  const { peer, connection } = getConnectingPeer(pm)
+
+  if (!identity) {
+    identity = jest.requireActual<typeof import('uuid')>('uuid').v4()
+  }
+
+  if (!isIdentity(identity)) {
+    identity = mockIdentity(identity)
+  }
+
+  connection.setState({ type: 'DISCONNECTED' })
+
+  return { peer, connection: connection }
+}
+
 export function getSignalingWebRtcPeer(
   pm: PeerManager,
   brokeringPeerIdentity: Identity,

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -94,12 +94,7 @@ export function getConnectedPeer(
   return { peer, connection: connection }
 }
 
-export function getDisconnectedPeer(
-  pm: PeerManager,
-  identity?: string | Identity,
-): { peer: Peer; connection: WebSocketConnection } {
-  const { peer, connection } = getConnectingPeer(pm)
-
+export function getDisconnectedPeer(pm: PeerManager, identity?: string | Identity): Peer {
   if (!identity) {
     identity = jest.requireActual<typeof import('uuid')>('uuid').v4()
   }
@@ -108,9 +103,8 @@ export function getDisconnectedPeer(
     identity = mockIdentity(identity)
   }
 
-  connection.setState({ type: 'DISCONNECTED' })
-
-  return { peer, connection: connection }
+  const peer = pm.getOrCreatePeer(identity)
+  return peer
 }
 
 export function getSignalingWebRtcPeer(

--- a/ironfish/src/network/testUtilities/mockHostsStore.ts
+++ b/ironfish/src/network/testUtilities/mockHostsStore.ts
@@ -24,12 +24,17 @@ class MockFileSystem extends FileSystem {
     return this
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async access(): Promise<void> {
+    throw new Error('File does not exist')
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   async writeFile(): Promise<void> {}
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async readFile(): Promise<string> {
-    return ''
+    return '{}'
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -51,14 +56,16 @@ class MockHostsStore extends HostsStore {
       {
         address: '127.0.0.1',
         port: 9999,
-        identity: undefined,
+        identity: null,
+        name: null,
       },
     ])
     super.set('possiblePeers', [
       {
         address: '1.1.1.1',
         port: 1111,
-        identity: undefined,
+        identity: null,
+        name: null,
       },
     ])
   }
@@ -79,4 +86,8 @@ class MockHostsStore extends HostsStore {
 
 export function mockHostsStore(): MockHostsStore {
   return new MockHostsStore()
+}
+
+export function mockFileSystem(): MockFileSystem {
+  return new MockFileSystem()
 }

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -12,7 +12,6 @@ import { MemPool } from './memPool'
 import { MetricsMonitor } from './metrics'
 import { MiningDirector } from './mining'
 import { PeerNetwork, PrivateIdentity } from './network'
-import { AddressManager } from './network/peers/addressManager'
 import { IsomorphicWebSocketConstructor } from './network/types'
 import { Package } from './package'
 import { Platform } from './platform'
@@ -49,7 +48,6 @@ export class IronfishNode {
     files,
     config,
     internal,
-    hosts,
     accounts,
     strategy,
     metrics,
@@ -59,6 +57,7 @@ export class IronfishNode {
     logger,
     webSocket,
     privateIdentity,
+    dataDir,
   }: {
     pkg: Package
     files: FileSystem
@@ -75,6 +74,7 @@ export class IronfishNode {
     logger: Logger
     webSocket: IsomorphicWebSocketConstructor
     privateIdentity?: PrivateIdentity
+    dataDir?: string
   }) {
     this.files = files
     this.config = config
@@ -108,7 +108,8 @@ export class IronfishNode {
       chain: chain,
       strategy: strategy,
       metrics: this.metrics,
-      addressManager: new AddressManager(hosts),
+      files: this.files,
+      dataDir: dataDir,
     })
 
     this.syncer = new Syncer({

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -284,7 +284,7 @@ export class IronfishNode {
     }
 
     await this.accounts.start()
-    this.peerNetwork.start()
+    await this.peerNetwork.start()
 
     if (this.config.get('enableRpc')) {
       await this.rpc.start()
@@ -304,7 +304,7 @@ export class IronfishNode {
     await Promise.allSettled([
       this.accounts.stop(),
       this.syncer.stop(),
-      this.peerNetwork.stop(),
+      await this.peerNetwork.stop(),
       this.rpc.stop(),
       stopCollecting(),
       this.metrics.stop(),

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -284,7 +284,7 @@ export class IronfishNode {
     }
 
     await this.accounts.start()
-    await this.peerNetwork.start()
+    this.peerNetwork.start()
 
     if (this.config.get('enableRpc')) {
       await this.rpc.start()
@@ -304,7 +304,7 @@ export class IronfishNode {
     await Promise.allSettled([
       this.accounts.stop(),
       this.syncer.stop(),
-      await this.peerNetwork.stop(),
+      this.peerNetwork.stop(),
       this.rpc.stop(),
       stopCollecting(),
       this.metrics.stop(),

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -57,13 +57,12 @@ export class IronfishNode {
     logger,
     webSocket,
     privateIdentity,
-    dataDir,
+    hostsStore,
   }: {
     pkg: Package
     files: FileSystem
     config: Config
     internal: InternalStore
-    hosts: HostsStore
     accounts: Accounts
     chain: Blockchain
     strategy: Strategy
@@ -74,7 +73,7 @@ export class IronfishNode {
     logger: Logger
     webSocket: IsomorphicWebSocketConstructor
     privateIdentity?: PrivateIdentity
-    dataDir?: string
+    hostsStore: HostsStore
   }) {
     this.files = files
     this.config = config
@@ -108,8 +107,7 @@ export class IronfishNode {
       chain: chain,
       strategy: strategy,
       metrics: this.metrics,
-      files: this.files,
-      dataDir: dataDir,
+      hostsStore: hostsStore,
     })
 
     this.syncer = new Syncer({
@@ -165,8 +163,8 @@ export class IronfishNode {
       await internal.load()
     }
 
-    const hosts = new HostsStore(files, dataDir)
-    await hosts.load()
+    const hostsStore = new HostsStore(files, dataDir)
+    await hostsStore.load()
 
     if (databaseName) {
       config.setOverride('databaseName', databaseName)
@@ -226,7 +224,6 @@ export class IronfishNode {
       files,
       config,
       internal,
-      hosts,
       accounts,
       metrics,
       miningDirector: mining,
@@ -235,6 +232,7 @@ export class IronfishNode {
       logger,
       webSocket,
       privateIdentity,
+      hostsStore,
     })
   }
 

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BoxKeyPair } from 'tweetnacl'
 import { PrivateIdentity } from '.'
-import { Config, ConfigOptions, InternalStore } from './fileStores'
+import { Config, ConfigOptions, HostsStore, InternalStore } from './fileStores'
 import { FileSystem, NodeFileProvider } from './fileSystems'
 import {
   createRootLogger,
@@ -37,6 +37,7 @@ export class IronfishSdk {
   logger: Logger
   metrics: MetricsMonitor
   internal: InternalStore
+  hosts: HostsStore
   strategyClass: typeof Strategy | null
   privateIdentity: BoxKeyPair | null | undefined
 
@@ -46,6 +47,7 @@ export class IronfishSdk {
     clientMemory: IronfishMemoryClient,
     config: Config,
     internal: InternalStore,
+    hosts: HostsStore,
     fileSystem: FileSystem,
     logger: Logger,
     metrics: MetricsMonitor,
@@ -56,6 +58,7 @@ export class IronfishSdk {
     this.clientMemory = clientMemory
     this.config = config
     this.internal = internal
+    this.hosts = hosts
     this.fileSystem = fileSystem
     this.logger = logger
     this.metrics = metrics
@@ -99,6 +102,9 @@ export class IronfishSdk {
 
     const internal = new InternalStore(fileSystem, dataDir)
     await internal.load()
+
+    const hosts = new HostsStore(fileSystem, dataDir)
+    await hosts.load()
 
     if (configOverrides) {
       Object.assign(config.overrides, configOverrides)
@@ -151,6 +157,7 @@ export class IronfishSdk {
       clientMemory,
       config,
       internal,
+      hosts,
       fileSystem,
       logger,
       metrics,

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BoxKeyPair } from 'tweetnacl'
 import { PrivateIdentity } from '.'
-import { Config, ConfigOptions, HostsStore, InternalStore } from './fileStores'
+import { Config, ConfigOptions, InternalStore } from './fileStores'
 import { FileSystem, NodeFileProvider } from './fileSystems'
 import {
   createRootLogger,
@@ -37,9 +37,9 @@ export class IronfishSdk {
   logger: Logger
   metrics: MetricsMonitor
   internal: InternalStore
-  hosts: HostsStore
   strategyClass: typeof Strategy | null
   privateIdentity: BoxKeyPair | null | undefined
+  dataDir?: string
 
   private constructor(
     pkg: Package,
@@ -47,22 +47,22 @@ export class IronfishSdk {
     clientMemory: IronfishMemoryClient,
     config: Config,
     internal: InternalStore,
-    hosts: HostsStore,
     fileSystem: FileSystem,
     logger: Logger,
     metrics: MetricsMonitor,
     strategyClass: typeof Strategy | null = null,
+    dataDir?: string,
   ) {
     this.pkg = pkg
     this.client = client
     this.clientMemory = clientMemory
     this.config = config
     this.internal = internal
-    this.hosts = hosts
     this.fileSystem = fileSystem
     this.logger = logger
     this.metrics = metrics
     this.strategyClass = strategyClass
+    this.dataDir = dataDir
   }
 
   static async init({
@@ -102,9 +102,6 @@ export class IronfishSdk {
 
     const internal = new InternalStore(fileSystem, dataDir)
     await internal.load()
-
-    const hosts = new HostsStore(fileSystem, dataDir)
-    await hosts.load()
 
     if (configOverrides) {
       Object.assign(config.overrides, configOverrides)
@@ -157,11 +154,11 @@ export class IronfishSdk {
       clientMemory,
       config,
       internal,
-      hosts,
       fileSystem,
       logger,
       metrics,
       strategyClass,
+      dataDir,
     )
   }
 
@@ -188,6 +185,7 @@ export class IronfishSdk {
       strategyClass: this.strategyClass,
       webSocket: webSocket,
       privateIdentity: privateIdentity,
+      dataDir: this.dataDir,
     })
 
     if (this.config.get('enableRpcIpc')) {


### PR DESCRIPTION
## Summary
This PR implements peer persistence by saving peer addresses to `hosts.json` on a defined interval and at shutdown; connected peers are saved to a `priorPeers` list and possible, un-connected peers are saved to a `possiblePeers` list. If there is persisted peer information at startup, the node will prioritize trying to connect to peers to which it was connected in the past before using the possible peers list.

This also decreases the amount of `peerListRequest` spam by changing the interval to 60 seconds and sending a request upon peer connection.

Note that there is room for optimization in the related code, e.g. capping the amount of `possiblePeers`.
## Testing Plan
Added tests. Ran the node and it successfully connected to the main network with no harmful effects. Starting the node with persisted host information led to a significant speedup in connecting to the network.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
