### PR TITLE
feat(ironfish): Generate telemetry node id in internal store

### DIFF
--- a/ironfish-cli/src/commands/start.test.ts
+++ b/ironfish-cli/src/commands/start.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { expect as expectCli, test } from '@oclif/test'
 import * as ironfishmodule from 'ironfish'
+import { v4 as uuid } from 'uuid'
 import { IronfishCliPKG } from '../package'
 
 jest.mock('ironfish', () => {
@@ -31,6 +32,7 @@ jest.mock('ironfish', () => {
 describe('start command', () => {
   let isFirstRun = true
   let hasGenesisBlock = false
+  let telemetryNodeId = ''
   const defaultGraffiti = 'default-graffiti'
 
   const verifier = {
@@ -64,6 +66,7 @@ describe('start command', () => {
     const internalOptions = {
       isFirstRun,
       networkIdentity: '',
+      telemetryNodeId,
     }
 
     const config = {
@@ -138,6 +141,7 @@ describe('start command', () => {
           `To help improve Ironfish, opt in to collecting telemetry`,
         )
         expect(setConfig).toHaveBeenCalledWith('isFirstRun', false)
+        expect(setConfig).toHaveBeenCalledWith('telemetryNodeId', expect.any(String))
         // start the node
         expect(start).toHaveBeenCalled()
         expect(waitForShutdown).toHaveBeenCalled()
@@ -148,6 +152,7 @@ describe('start command', () => {
     beforeAll(() => {
       isFirstRun = false
       chain.hasGenesisBlock = true
+      telemetryNodeId = uuid()
     })
     test
       .stdout()
@@ -160,6 +165,21 @@ describe('start command', () => {
         // start the node
         expect(start).toHaveBeenCalled()
         expect(waitForShutdown).toHaveBeenCalled()
+      })
+  })
+
+  describe('when first run is false and without a node id in the store', () => {
+    beforeAll(() => {
+      isFirstRun = false
+      telemetryNodeId = ''
+    })
+    test
+      .stdout()
+      .command(['start'])
+      .exit(0)
+      .it('sets the node id', () => {
+        expect(setConfig).toHaveBeenCalledTimes(2)
+        expect(setConfig).toHaveBeenCalledWith('telemetryNodeId', expect.any(String))
       })
   })
 

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -4,6 +4,7 @@
 import { flags } from '@oclif/command'
 import { Assert, IronfishNode, NodeUtils, PrivateIdentity, PromiseUtils } from 'ironfish'
 import tweetnacl from 'tweetnacl'
+import { v4 as uuid } from 'uuid'
 import { IronfishCommand, SIGNALS } from '../command'
 import {
   ConfigFlag,
@@ -204,6 +205,11 @@ export default class Start extends IronfishCommand {
       await this.firstRun(node)
     }
 
+    if (!node.internal.get('telemetryNodeId')) {
+      node.internal.set('telemetryNodeId', uuid())
+      await node.internal.save()
+    }
+
     await node.start()
     this.node = node
 
@@ -247,6 +253,7 @@ export default class Start extends IronfishCommand {
     }
 
     node.internal.set('isFirstRun', false)
+    node.internal.set('telemetryNodeId', uuid())
     await node.internal.save()
   }
 

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -7,11 +7,13 @@ import { KeyStore } from './keyStore'
 export type InternalOptions = {
   isFirstRun: boolean
   networkIdentity: string
+  telemetryNodeId: string
 }
 
 export const InternalOptionsDefaults: InternalOptions = {
   isFirstRun: true,
   networkIdentity: '',
+  telemetryNodeId: '',
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -212,12 +212,11 @@ export class IronfishNode {
       force: config.get('miningForce'),
     })
 
-    const defaultTags = [
+    setDefaultTags([
       { name: 'node_id', value: internal.get('telemetryNodeId') },
       { name: 'session_id', value: uuid() },
       { name: 'version', value: pkg.version },
-    ]
-    setDefaultTags(defaultTags)
+    ])
 
     return new IronfishNode({
       pkg,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import os from 'os'
+import { v4 as uuid } from 'uuid'
 import { Account, Accounts, AccountsDB } from './account'
 import { Blockchain } from './blockchain'
 import { Config, ConfigOptions, HostsStore, InternalStore } from './fileStores'
@@ -10,7 +11,7 @@ import { createRootLogger, Logger } from './logger'
 import { MemPool } from './memPool'
 import { MetricsMonitor } from './metrics'
 import { MiningDirector } from './mining'
-import { PeerNetwork, PrivateIdentity, privateIdentityToIdentity } from './network'
+import { PeerNetwork, PrivateIdentity } from './network'
 import { AddressManager } from './network/peers/addressManager'
 import { IsomorphicWebSocketConstructor } from './network/types'
 import { Package } from './package'
@@ -211,14 +212,11 @@ export class IronfishNode {
       force: config.get('miningForce'),
     })
 
-    const anonymousTelemetryId = Math.random().toString().substring(2)
     const defaultTags = [
+      { name: 'node_id', value: internal.get('telemetryNodeId') },
+      { name: 'session_id', value: uuid() },
       { name: 'version', value: pkg.version },
-      { name: 'session_id', value: anonymousTelemetryId },
     ]
-    if (privateIdentity) {
-      defaultTags.push({ name: 'node_id', value: privateIdentityToIdentity(privateIdentity) })
-    }
     setDefaultTags(defaultTags)
 
     return new IronfishNode({

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -10,7 +10,7 @@ import { createRootLogger, Logger } from './logger'
 import { MemPool } from './memPool'
 import { MetricsMonitor } from './metrics'
 import { MiningDirector } from './mining'
-import { PeerNetwork, PrivateIdentity } from './network'
+import { PeerNetwork, PrivateIdentity, privateIdentityToIdentity } from './network'
 import { AddressManager } from './network/peers/addressManager'
 import { IsomorphicWebSocketConstructor } from './network/types'
 import { Package } from './package'
@@ -212,10 +212,14 @@ export class IronfishNode {
     })
 
     const anonymousTelemetryId = Math.random().toString().substring(2)
-    setDefaultTags([
+    const defaultTags = [
       { name: 'version', value: pkg.version },
       { name: 'session_id', value: anonymousTelemetryId },
-    ])
+    ]
+    if (privateIdentity) {
+      defaultTags.push({ name: 'node_id', value: privateIdentityToIdentity(privateIdentity) })
+    }
+    setDefaultTags(defaultTags)
 
     return new IronfishNode({
       pkg,


### PR DESCRIPTION
## Summary

Generates a unique node id for telemetry in the internal store. This value is reset on every first run or set if it does not already exist on start.

## Testing Plan

Manually tested and updated unit test.

![Screen Shot 2022-01-31 at 3 42 01 PM](https://user-images.githubusercontent.com/5459049/151869841-cb56d812-1432-48e8-9c17-81e4417c6e4b.png)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
