### PR TITLE
Check synced status before starting pay command

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.test.ts
+++ b/ironfish-cli/src/commands/accounts/pay.test.ts
@@ -39,6 +39,7 @@ describe('accounts:pay command', () => {
       const client = {
         connect: jest.fn(),
         getAccountBalance: jest.fn().mockResolvedValue({ content: { confirmed: 1000 } }),
+        status: jest.fn().mockResolvedValue({ content: { blockchain: { synced: true } } }),
         sendTransaction,
       }
 

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -69,6 +69,15 @@ export class Pay extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
+    const status = await client.status()
+
+    if (!status.content.blockchain.synced) {
+      this.log(
+        `Your node must be synced with the Iron Fish network to send a transaction. Please try again later`,
+      )
+      this.exit(1)
+    }
+
     if (!amount || Number.isNaN(amount)) {
       const response = await client.getAccountBalance({ account: from })
 


### PR DESCRIPTION
## Summary

I got caught by filling out all the fields only to get an error at the end. This checks it before the user is prompted with interactive questions.

## Testing Plan
Ran the command

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
