### PR TITLE
Migrate from deprecated cli-ux to @oclif/core

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@oclif/command": "1.8.0",
     "@oclif/config": "1.17.0",
+    "@oclif/core": "1.3.1",
     "@oclif/plugin-help": "3.2.2",
     "@oclif/plugin-not-found": "1.2.4",
     "axios": "0.21.4",

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -49,7 +49,6 @@
     "@oclif/plugin-not-found": "1.2.4",
     "axios": "0.21.4",
     "blessed": "0.1.81",
-    "cli-ux": "^5.5.0",
     "ironfish": "*",
     "ironfish-rust-nodejs": "*",
     "json-colorizer": "2.2.2",

--- a/ironfish-cli/src/commands/accounts/create.test.ts
+++ b/ironfish-cli/src/commands/accounts/create.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { expect as expectCli, test } from '@oclif/test'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import * as ironfishmodule from 'ironfish'
 
 describe('accounts:create command', () => {
@@ -47,7 +47,7 @@ describe('accounts:create command', () => {
     })
 
   test
-    .stub(cli, 'prompt', () => async () => await Promise.resolve(name))
+    .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve(name))
     .stdout()
     .command(['accounts:create'])
     .exit(0)

--- a/ironfish-cli/src/commands/accounts/create.test.ts
+++ b/ironfish-cli/src/commands/accounts/create.test.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { expect as expectCli, test } from '@oclif/test'
 import { CliUx } from '@oclif/core'
+import { expect as expectCli, test } from '@oclif/test'
 import * as ironfishmodule from 'ironfish'
 
 describe('accounts:create command', () => {

--- a/ironfish-cli/src/commands/accounts/create.ts
+++ b/ironfish-cli/src/commands/accounts/create.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -27,7 +27,7 @@ export class CreateCommand extends IronfishCommand {
     let name = args.name as string
 
     if (!name) {
-      name = (await cli.prompt('Enter the name of the account', {
+      name = (await CliUx.ux.prompt('Enter the name of the account', {
         required: true,
       })) as string
     }

--- a/ironfish-cli/src/commands/accounts/export.ts
+++ b/ironfish-cli/src/commands/accounts/export.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import fs from 'fs'
 import { ErrorUtils } from 'ironfish'
 import jsonColorizer from 'json-colorizer'
@@ -61,7 +61,7 @@ export class ExportCommand extends IronfishCommand {
         if (fs.existsSync(resolved)) {
           this.log(`There is already an account backup at ${exportPath}`)
 
-          const confirmed = await cli.confirm(
+          const confirmed = await CliUx.ux.confirm(
             `\nOverwrite the account backup with new file?\nAre you sure? (Y)es / (N)o`,
           )
 

--- a/ironfish-cli/src/commands/accounts/import.ts
+++ b/ironfish-cli/src/commands/accounts/import.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import { cli } from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import { JSONUtils, PromiseUtils, SerializedAccount } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -89,23 +89,23 @@ export class ImportCommand extends IronfishCommand {
   }
 
   async importTTY(): Promise<SerializedAccount> {
-    const accountName = (await cli.prompt('Enter the account name', {
+    const accountName = (await CliUx.ux.prompt('Enter the account name', {
       required: true,
     })) as string
 
-    const spendingKey = (await cli.prompt('Enter the account spending key', {
+    const spendingKey = (await CliUx.ux.prompt('Enter the account spending key', {
       required: true,
     })) as string
 
-    const incomingViewKey = (await cli.prompt('Enter the account incoming view key', {
+    const incomingViewKey = (await CliUx.ux.prompt('Enter the account incoming view key', {
       required: true,
     })) as string
 
-    const outgoingViewKey = (await cli.prompt('Enter the account outgoing view key', {
+    const outgoingViewKey = (await CliUx.ux.prompt('Enter the account outgoing view key', {
       required: true,
     })) as string
 
-    const publicAddress = (await cli.prompt('Enter the account public address', {
+    const publicAddress = (await CliUx.ux.prompt('Enter the account public address', {
       required: true,
     })) as string
 

--- a/ironfish-cli/src/commands/accounts/pay.test.ts
+++ b/ironfish-cli/src/commands/accounts/pay.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { expect as expectCli, test } from '@oclif/test'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import * as ironfishmodule from 'ironfish'
 
 describe('accounts:pay command', () => {
@@ -56,7 +56,7 @@ describe('accounts:pay command', () => {
   })
 
   test
-    .stub(cli, 'confirm', () => async () => await Promise.resolve(true))
+    .stub(CliUx.ux, 'confirm', () => async () => await Promise.resolve(true))
     .stdout()
     .command([
       'accounts:pay',
@@ -79,7 +79,7 @@ describe('accounts:pay command', () => {
     )
 
   test
-    .stub(cli, 'confirm', () => async () => await Promise.resolve(true))
+    .stub(CliUx.ux, 'confirm', () => async () => await Promise.resolve(true))
     .stdout()
     .command(['accounts:pay', `-a ${amount}`, `-t ${to}`, `-f ${from}`, `-o ${fee}`])
     .exit(0)
@@ -95,8 +95,8 @@ describe('accounts:pay command', () => {
     )
 
   test
-    .stub(cli, 'prompt', () => async () => await Promise.resolve(to))
-    .stub(cli, 'confirm', () => async () => await Promise.resolve(true))
+    .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve(to))
+    .stub(CliUx.ux, 'confirm', () => async () => await Promise.resolve(true))
     .stdout()
     .command(['accounts:pay', `-a ${amount}`, `-f ${from}`, `-o ${fee}`])
     .exit(0)
@@ -109,8 +109,8 @@ describe('accounts:pay command', () => {
     )
 
   test
-    .stub(cli, 'prompt', () => async () => await Promise.resolve('not correct address'))
-    .stub(cli, 'confirm', () => async () => await Promise.resolve(true))
+    .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve('not correct address'))
+    .stub(CliUx.ux, 'confirm', () => async () => await Promise.resolve(true))
     .stdout()
     .command(['accounts:pay', `-a ${amount}`, `-f ${from}`])
     .exit(2)
@@ -119,8 +119,8 @@ describe('accounts:pay command', () => {
     })
 
   test
-    .stub(cli, 'prompt', () => async () => await Promise.resolve(3))
-    .stub(cli, 'confirm', () => async () => await Promise.resolve(true))
+    .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve(3))
+    .stub(CliUx.ux, 'confirm', () => async () => await Promise.resolve(true))
     .stdout()
     .command(['accounts:pay', `-t ${to}`, `-f ${from}`])
     .exit(0)
@@ -136,8 +136,8 @@ describe('accounts:pay command', () => {
     )
 
   test
-    .stub(cli, 'prompt', () => async () => await Promise.resolve('non right value'))
-    .stub(cli, 'confirm', () => async () => await Promise.resolve(true))
+    .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve('non right value'))
+    .stub(CliUx.ux, 'confirm', () => async () => await Promise.resolve(true))
     .stdout()
     .command(['accounts:pay', `-t ${to}`, `-f ${from}`])
     .exit(0)
@@ -146,7 +146,7 @@ describe('accounts:pay command', () => {
     })
 
   test
-    .stub(cli, 'confirm', () => async () => await Promise.resolve(false))
+    .stub(CliUx.ux, 'confirm', () => async () => await Promise.resolve(false))
     .stdout()
     .command(['accounts:pay', `-a ${amount}`, `-t ${to}`, `-f ${from}`, `-o ${fee}`])
     .exit(0)
@@ -156,7 +156,7 @@ describe('accounts:pay command', () => {
 
   describe('with an invalid expiration sequence', () => {
     test
-      .stub(cli, 'confirm', () => async () => await Promise.resolve(true))
+      .stub(CliUx.ux, 'confirm', () => async () => await Promise.resolve(true))
       .stdout()
       .command([
         'accounts:pay',
@@ -179,7 +179,7 @@ describe('accounts:pay command', () => {
       sendTransaction = jest.fn().mockRejectedValue('an error')
     })
     test
-      .stub(cli, 'confirm', () => async () => await Promise.resolve(true))
+      .stub(CliUx.ux, 'confirm', () => async () => await Promise.resolve(true))
       .stdout()
       .command(['accounts:pay', `-a ${amount}`, `-t ${to}`, `-f ${from}`, `-o ${fee}`])
       .exit(2)

--- a/ironfish-cli/src/commands/accounts/pay.test.ts
+++ b/ironfish-cli/src/commands/accounts/pay.test.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { expect as expectCli, test } from '@oclif/test'
 import { CliUx } from '@oclif/core'
+import { expect as expectCli, test } from '@oclif/test'
 import * as ironfishmodule from 'ironfish'
 
 describe('accounts:pay command', () => {

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { flags } from '@oclif/command'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import {
   displayIronAmountWithCurrency,
   ironToOre,
@@ -81,7 +81,7 @@ export class Pay extends IronfishCommand {
     if (!amount || Number.isNaN(amount)) {
       const response = await client.getAccountBalance({ account: from })
 
-      amount = (await cli.prompt(
+      amount = (await CliUx.ux.prompt(
         `Enter the amount in $IRON (balance available: ${displayIronAmountWithCurrency(
           oreToIron(Number(response.content.confirmed)),
           false,
@@ -97,7 +97,7 @@ export class Pay extends IronfishCommand {
     }
 
     if (!fee || Number.isNaN(Number(fee))) {
-      fee = (await cli.prompt('Enter the fee amount in $IRON', {
+      fee = (await CliUx.ux.prompt('Enter the fee amount in $IRON', {
         required: true,
         default: '0.00000001',
       })) as number
@@ -108,7 +108,7 @@ export class Pay extends IronfishCommand {
     }
 
     if (!to) {
-      to = (await cli.prompt('Enter the the public address of the recipient', {
+      to = (await CliUx.ux.prompt('Enter the the public address of the recipient', {
         required: true,
       })) as string
 
@@ -170,7 +170,7 @@ ${displayIronAmountWithCurrency(
 * This action is NOT reversible *
 `)
 
-      const confirm = await cli.confirm('Do you confirm (Y/N)?')
+      const confirm = await CliUx.ux.confirm('Do you confirm (Y/N)?')
       if (!confirm) {
         this.log('Transaction aborted.')
         this.exit(0)
@@ -179,7 +179,7 @@ ${displayIronAmountWithCurrency(
 
     // Run the progress bar for about 2 minutes
     // Chances are that the transaction will finish faster (error or faster computer)
-    const bar = cli.progress({
+    const bar = CliUx.ux.progress({
       barCompleteChar: '\u2588',
       barIncompleteChar: '\u2591',
       format: 'Creating the transaction: [{bar}] {percentage}% | ETA: {eta}s',

--- a/ironfish-cli/src/commands/accounts/remove.test.ts
+++ b/ironfish-cli/src/commands/accounts/remove.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { expect as expectCli, test } from '@oclif/test'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import * as ironfish from 'ironfish'
 
 describe('accounts:remove', () => {
@@ -31,7 +31,7 @@ describe('accounts:remove', () => {
 
   describe('with no flags', () => {
     test
-      .stub(cli, 'prompt', () => async () => await Promise.resolve(name))
+      .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve(name))
       .stdout()
       .command(['accounts:remove', name])
       .exit(0)
@@ -47,7 +47,7 @@ describe('accounts:remove', () => {
     const incorrectName = 'foobar'
 
     test
-      .stub(cli, 'prompt', () => async () => await Promise.resolve(incorrectName))
+      .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve(incorrectName))
       .stdout()
       .command(['accounts:remove', name])
       .exit(1)

--- a/ironfish-cli/src/commands/accounts/remove.test.ts
+++ b/ironfish-cli/src/commands/accounts/remove.test.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { expect as expectCli, test } from '@oclif/test'
 import { CliUx } from '@oclif/core'
+import { expect as expectCli, test } from '@oclif/test'
 import * as ironfish from 'ironfish'
 
 describe('accounts:remove', () => {

--- a/ironfish-cli/src/commands/accounts/remove.ts
+++ b/ironfish-cli/src/commands/accounts/remove.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { flags } from '@oclif/command'
-import { cli } from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -35,7 +35,7 @@ export class RemoveCommand extends IronfishCommand {
     const response = await client.removeAccount({ name, confirm })
 
     if (response.content.needsConfirm) {
-      const value = (await cli.prompt(`Are you sure? Type ${name} to confirm`)) as string
+      const value = (await CliUx.ux.prompt(`Are you sure? Type ${name} to confirm`)) as string
 
       if (value !== name) {
         this.log(`Aborting: ${value} did not match ${name}`)

--- a/ironfish-cli/src/commands/accounts/rescan.ts
+++ b/ironfish-cli/src/commands/accounts/rescan.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { hasUserResponseError } from '../../utils'
@@ -32,7 +32,7 @@ export class RescanCommand extends IronfishCommand {
     const { detach, reset, local } = flags
     const client = await this.sdk.connectRpc(local)
 
-    cli.action.start('Rescanning Transactions', 'Asking node to start scanning', {
+    CliUx.ux.action.start('Rescanning Transactions', 'Asking node to start scanning', {
       stdout: true,
     })
 
@@ -40,19 +40,19 @@ export class RescanCommand extends IronfishCommand {
 
     try {
       for await (const { sequence, startedAt } of response.contentStream()) {
-        cli.action.status = `Scanning Block: ${sequence}, ${Math.floor(
+        CliUx.ux.action.status = `Scanning Block: ${sequence}, ${Math.floor(
           (Date.now() - startedAt) / 1000,
         )} seconds`
       }
     } catch (error) {
       if (hasUserResponseError(error)) {
-        cli.action.stop(error.codeMessage)
+        CliUx.ux.action.stop(error.codeMessage)
         return
       }
 
       throw error
     }
 
-    cli.action.stop(detach ? 'Scan started in background' : 'Scanning Complete')
+    CliUx.ux.action.stop(detach ? 'Scan started in background' : 'Scanning Complete')
   }
 }

--- a/ironfish-cli/src/commands/backup.ts
+++ b/ironfish-cli/src/commands/backup.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
 import { spawn } from 'child_process'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import fsAsync from 'fs/promises'
 import { FileUtils, NodeUtils } from 'ironfish'
 import os from 'os'
@@ -59,7 +59,7 @@ export default class Backup extends IronfishCommand {
     const dest = path.join(destDir, `node.${id}.tar.gz`)
 
     this.log(`Zipping\n    SRC ${source}\n    DST ${dest}\n`)
-    cli.action.start(`Zipping ${source}`)
+    CliUx.ux.action.start(`Zipping ${source}`)
 
     await this.zipDir(
       source,
@@ -68,11 +68,11 @@ export default class Backup extends IronfishCommand {
     )
 
     const stat = await fsAsync.stat(dest)
-    cli.action.stop(`done (${FileUtils.formatFileSize(stat.size)})`)
+    CliUx.ux.action.stop(`done (${FileUtils.formatFileSize(stat.size)})`)
 
-    cli.action.start(`Uploading to ${bucket}`)
+    CliUx.ux.action.start(`Uploading to ${bucket}`)
     await this.uploadToS3(dest, bucket)
-    cli.action.stop(`done`)
+    CliUx.ux.action.stop(`done`)
   }
 
   zipDir(source: string, dest: string, excludes: string[] = []): Promise<number | null> {

--- a/ironfish-cli/src/commands/backup.ts
+++ b/ironfish-cli/src/commands/backup.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import { spawn } from 'child_process'
 import { CliUx } from '@oclif/core'
+import { spawn } from 'child_process'
 import fsAsync from 'fs/promises'
 import { FileUtils, NodeUtils } from 'ironfish'
 import os from 'os'

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import fs from 'fs'
 import { AsyncUtils, GENESIS_BLOCK_SEQUENCE } from 'ironfish'
 import { parseNumber } from '../../args'
@@ -54,7 +54,7 @@ export default class Export extends IronfishCommand {
     const { start, stop } = await AsyncUtils.first(stream.contentStream())
     this.log(`Exporting chain from ${start} -> ${stop} to ${path}`)
 
-    const progress = cli.progress({
+    const progress = CliUx.ux.progress({
       format: 'Exporting blocks: [{bar}] {value}/{total} {percentage}% | ETA: {eta}s',
     }) as ProgressBar
 

--- a/ironfish-cli/src/commands/chain/readdblock.ts
+++ b/ironfish-cli/src/commands/chain/readdblock.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
@@ -28,11 +28,11 @@ export default class ReAddBlock extends IronfishCommand {
     const { args } = this.parse(ReAddBlock)
     const hash = Buffer.from(args.hash as string, 'hex')
 
-    cli.action.start(`Opening node`)
+    CliUx.ux.action.start(`Opening node`)
     const node = await this.sdk.node()
     await node.openDB()
     await node.chain.open()
-    cli.action.stop('done.')
+    CliUx.ux.action.stop('done.')
 
     const block = await node.chain.getBlock(hash)
 

--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import { Assert, BlockHeader, IDatabaseTransaction, IronfishNode, TimeUtils } from 'ironfish'
 import { Meter } from 'ironfish'
 import { IronfishCommand } from '../../command'
@@ -37,15 +37,15 @@ export default class RepairChain extends IronfishCommand {
     const { flags } = this.parse(RepairChain)
 
     const speed = new Meter()
-    const progress = cli.progress({
+    const progress = CliUx.ux.progress({
       format: '{title}: [{bar}] {value}/{total} {percentage}% {speed}/sec | {estimate}',
     }) as ProgressBar
 
-    cli.action.start(`Opening node`)
+    CliUx.ux.action.start(`Opening node`)
     const node = await this.sdk.node()
     await node.openDB()
     await node.chain.open()
-    cli.action.stop('done.')
+    CliUx.ux.action.stop('done.')
 
     if (node.chain.isEmpty) {
       this.log(`Chain is too corrupt. Delete your DB at ${node.config.chainDatabasePath}`)
@@ -58,7 +58,7 @@ export default class RepairChain extends IronfishCommand {
 
     const confirmed =
       flags.confirm ||
-      (await cli.confirm(
+      (await CliUx.ux.confirm(
         `\n⚠️ If you start repairing your database, you MUST finish the\n` +
           `process or your database will be in a corrupt state. Repairing\n` +
           `may take ${estimate} or longer.\n\n` +
@@ -78,13 +78,13 @@ export default class RepairChain extends IronfishCommand {
   async repairChain(node: IronfishNode, speed: Meter, progress: ProgressBar): Promise<void> {
     Assert.isNotNull(node.chain.head)
 
-    cli.action.start('Clearing hash to next hash table')
+    CliUx.ux.action.start('Clearing hash to next hash table')
     await node.chain.hashToNextHash.clear()
-    cli.action.stop()
+    CliUx.ux.action.stop()
 
-    cli.action.start('Clearing Sequence to hash table')
+    CliUx.ux.action.start('Clearing Sequence to hash table')
     await node.chain.sequenceToHash.clear()
-    cli.action.stop()
+    CliUx.ux.action.stop()
 
     const total = Number(node.chain.head.sequence)
     let done = 0
@@ -146,13 +146,13 @@ export default class RepairChain extends IronfishCommand {
     let block = header ? await node.chain.getBlock(header) : null
     let prev = await node.chain.getHeaderAtSequence(TREE_START - 1)
 
-    cli.action.start('Clearing notes MerkleTree')
+    CliUx.ux.action.start('Clearing notes MerkleTree')
     await node.chain.notes.truncate(prev ? prev.noteCommitment.size : 0)
-    cli.action.stop()
+    CliUx.ux.action.stop()
 
-    cli.action.start('Clearing nullifier MerkleTree')
+    CliUx.ux.action.start('Clearing nullifier MerkleTree')
     await node.chain.nullifiers.truncate(prev ? prev.nullifierCommitment.size : 0)
-    cli.action.stop()
+    CliUx.ux.action.stop()
 
     speed.reset()
     progress.start(total, TREE_START, {

--- a/ironfish-cli/src/commands/faucet.test.ts
+++ b/ironfish-cli/src/commands/faucet.test.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { expect as expectCli, test } from '@oclif/test'
 import { CliUx } from '@oclif/core'
+import { expect as expectCli, test } from '@oclif/test'
 import * as ironfishmodule from 'ironfish'
 
 describe('faucet command', () => {
@@ -65,7 +65,11 @@ describe('faucet command', () => {
     .do(() => {
       accountName = 'myAccount'
     })
-    .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve('johann@ironfish.network'))
+    .stub(
+      CliUx.ux,
+      'prompt',
+      () => async () => await Promise.resolve('johann@ironfish.network'),
+    )
     .stdout()
     .command(['faucet', '--force'])
     .exit(0)
@@ -86,7 +90,11 @@ describe('faucet command', () => {
       accountName = 'myAccount'
       getFunds.mockRejectedValue('Error')
     })
-    .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve('johann@ironfish.network'))
+    .stub(
+      CliUx.ux,
+      'prompt',
+      () => async () => await Promise.resolve('johann@ironfish.network'),
+    )
     .stdout()
     .command(['faucet', '--force'])
     .exit(1)

--- a/ironfish-cli/src/commands/faucet.test.ts
+++ b/ironfish-cli/src/commands/faucet.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { expect as expectCli, test } from '@oclif/test'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import * as ironfishmodule from 'ironfish'
 
 describe('faucet command', () => {
@@ -50,7 +50,7 @@ describe('faucet command', () => {
     .do(() => {
       accountName = null
     })
-    .stub(cli, 'prompt', () => async () => await Promise.resolve('nameOfTheAccount'))
+    .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve('nameOfTheAccount'))
     .stdout()
     .command(['faucet', '--force'])
     .exit(0)
@@ -65,7 +65,7 @@ describe('faucet command', () => {
     .do(() => {
       accountName = 'myAccount'
     })
-    .stub(cli, 'prompt', () => async () => await Promise.resolve('johann@ironfish.network'))
+    .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve('johann@ironfish.network'))
     .stdout()
     .command(['faucet', '--force'])
     .exit(0)
@@ -86,7 +86,7 @@ describe('faucet command', () => {
       accountName = 'myAccount'
       getFunds.mockRejectedValue('Error')
     })
-    .stub(cli, 'prompt', () => async () => await Promise.resolve('johann@ironfish.network'))
+    .stub(CliUx.ux, 'prompt', () => async () => await Promise.resolve('johann@ironfish.network'))
     .stdout()
     .command(['faucet', '--force'])
     .exit(1)

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -60,9 +60,13 @@ export class FaucetCommand extends IronfishCommand {
       await client.createAccount({ name: accountName, default: true })
     }
 
-    CliUx.ux.action.start('Collecting your funds', 'Sending a request to the Iron Fish network', {
-      stdout: true,
-    })
+    CliUx.ux.action.start(
+      'Collecting your funds',
+      'Sending a request to the Iron Fish network',
+      {
+        stdout: true,
+      },
+    )
 
     try {
       await client.getFunds({
@@ -73,7 +77,9 @@ export class FaucetCommand extends IronfishCommand {
       if (error instanceof RequestError) {
         CliUx.ux.action.stop(error.codeMessage)
       } else {
-        CliUx.ux.action.stop('Unfortunately, the faucet request failed. Please try again later.')
+        CliUx.ux.action.stop(
+          'Unfortunately, the faucet request failed. Please try again later.',
+        )
       }
 
       this.exit(1)

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { flags } from '@oclif/command'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import { DEFAULT_DISCORD_INVITE, RequestError } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
@@ -41,7 +41,7 @@ export class FaucetCommand extends IronfishCommand {
     let email = flags.email
 
     if (!email) {
-      email = (await cli.prompt('Enter your email to stay updated with Iron Fish', {
+      email = (await CliUx.ux.prompt('Enter your email to stay updated with Iron Fish', {
         required: false,
       })) as string
     }
@@ -53,14 +53,14 @@ export class FaucetCommand extends IronfishCommand {
     if (!accountName) {
       this.log(`You don't have a default account set up yet. Let's create one first!`)
       accountName =
-        ((await cli.prompt('Please enter the name of your new Iron Fish account', {
+        ((await CliUx.ux.prompt('Please enter the name of your new Iron Fish account', {
           required: false,
         })) as string) || 'default'
 
       await client.createAccount({ name: accountName, default: true })
     }
 
-    cli.action.start('Collecting your funds', 'Sending a request to the Iron Fish network', {
+    CliUx.ux.action.start('Collecting your funds', 'Sending a request to the Iron Fish network', {
       stdout: true,
     })
 
@@ -71,15 +71,15 @@ export class FaucetCommand extends IronfishCommand {
       })
     } catch (error: unknown) {
       if (error instanceof RequestError) {
-        cli.action.stop(error.codeMessage)
+        CliUx.ux.action.stop(error.codeMessage)
       } else {
-        cli.action.stop('Unfortunately, the faucet request failed. Please try again later.')
+        CliUx.ux.action.stop('Unfortunately, the faucet request failed. Please try again later.')
       }
 
       this.exit(1)
     }
 
-    cli.action.stop('Success')
+    CliUx.ux.action.stop('Success')
     this.log(
       `
 

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import {
   AsyncUtils,
   GENESIS_BLOCK_SEQUENCE,
@@ -56,7 +56,7 @@ export class MinedCommand extends IronfishCommand {
 
     const speed = new Meter()
 
-    const progress = cli.progress({
+    const progress = CliUx.ux.progress({
       format:
         'Scanning blocks: [{bar}] {value}/{total} {percentage}% | ETA: {estimate} | SEQ {sequence}',
     }) as ProgressBar

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import {
   AsyncUtils,
   FileUtils,
@@ -61,16 +61,16 @@ export class Miner extends IronfishCommand {
     const updateHashPower = () => {
       const rate = Math.max(0, Math.floor(miner.hashRate.rate5s))
       const formatted = `${FileUtils.formatHashRate(rate)}/s (${rate})`
-      cli.action.status = formatted
+      CliUx.ux.action.status = formatted
     }
 
     const onStartMine = (request: MineRequest) => {
-      cli.action.start(`Mining block ${request.sequence} on request ${request.miningRequestId}`)
+      CliUx.ux.action.start(`Mining block ${request.sequence} on request ${request.miningRequestId}`)
       updateHashPower()
     }
 
     const onStopMine = () => {
-      cli.action.start('Waiting for next block')
+      CliUx.ux.action.start('Waiting for next block')
       updateHashPower()
     }
 
@@ -108,7 +108,7 @@ export class Miner extends IronfishCommand {
         (value) => ({ ...value, bytes: Buffer.from(value.bytes.data) }),
       )
 
-      cli.action.start('Waiting for director to send work.')
+      CliUx.ux.action.start('Waiting for director to send work.')
 
       const hashPowerInterval = setInterval(updateHashPower, 1000)
 

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -65,7 +65,9 @@ export class Miner extends IronfishCommand {
     }
 
     const onStartMine = (request: MineRequest) => {
-      CliUx.ux.action.start(`Mining block ${request.sequence} on request ${request.miningRequestId}`)
+      CliUx.ux.action.start(
+        `Mining block ${request.sequence} on request ${request.miningRequestId}`,
+      )
       updateHashPower()
     }
 

--- a/ironfish-cli/src/commands/peers/list.ts
+++ b/ironfish-cli/src/commands/peers/list.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
+import { CliUx } from '@oclif/core'
 import blessed from 'blessed'
-import { cli, Table } from 'cli-ux'
 import { GetPeersResponse, PromiseUtils } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -104,7 +104,7 @@ function renderTable(
     sequence: boolean
   },
 ): string {
-  let columns: Table.table.Columns<GetPeerResponsePeer> = {
+  let columns: CliUx.Table.table.Columns<GetPeerResponsePeer> = {
     identity: {
       header: 'IDENTITY',
       get: (row: GetPeerResponsePeer) => {
@@ -200,7 +200,7 @@ function renderTable(
 
   let result = ''
 
-  cli.table(peers, columns, {
+  CliUx.ux.table(peers, columns, {
     printLine: (line) => (result += `${String(line)}\n`),
     extended: flags.extended,
     sort: flags.sort,

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import fs from 'fs'
 import fsAsync from 'fs/promises'
 import { IronfishNode, NodeUtils, PeerNetwork } from 'ironfish'
@@ -48,7 +48,7 @@ export default class Reset extends IronfishCommand {
     if (fs.existsSync(backupPath)) {
       this.log(`There is already an account backup at ${backupPath}`)
 
-      const confirmed = await cli.confirm(
+      const confirmed = await CliUx.ux.confirm(
         `\nThis means this failed to run. Delete the accounts backup?\nAre you sure? (Y)es / (N)o`,
       )
 
@@ -61,7 +61,7 @@ export default class Reset extends IronfishCommand {
 
     const confirmed =
       flags.confirm ||
-      (await cli.confirm(
+      (await CliUx.ux.confirm(
         `\nYou are about to destroy your node data at ${node.config.dataDir}\nAre you sure? (Y)es / (N)o`,
       ))
 
@@ -75,14 +75,14 @@ export default class Reset extends IronfishCommand {
     await fsAsync.writeFile(backupPath, backup)
     await node.closeDB()
 
-    cli.action.start('Deleting databases')
+    CliUx.ux.action.start('Deleting databases')
 
     await Promise.all([
       fsAsync.rm(node.config.accountDatabasePath, { recursive: true }),
       fsAsync.rm(node.config.chainDatabasePath, { recursive: true }),
     ])
 
-    cli.action.status = `Importing ${accounts.length} accounts`
+    CliUx.ux.action.status = `Importing ${accounts.length} accounts`
 
     // We create a new node because the old node has cached account data
     node = await this.sdk.node()
@@ -95,6 +95,6 @@ export default class Reset extends IronfishCommand {
 
     await fsAsync.rm(backupPath)
 
-    cli.action.stop('Reset the node successfully.')
+    CliUx.ux.action.stop('Reset the node successfully.')
   }
 }

--- a/ironfish-cli/src/commands/restore.ts
+++ b/ironfish-cli/src/commands/restore.ts
@@ -4,7 +4,7 @@
 import { flags } from '@oclif/command'
 import axios from 'axios'
 import { spawn } from 'child_process'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import fs from 'fs'
 import fsAsync from 'fs/promises'
 import { NodeUtils, PromiseUtils } from 'ironfish'
@@ -71,7 +71,7 @@ export default class Restore extends IronfishCommand {
 
     this.log(`Downloading\n    SRC: ${downloadFrom}\n    DST:   ${downloadDir}`)
 
-    const progress = cli.progress({
+    const progress = CliUx.ux.progress({
       format: 'Downloading backup: [{bar}] {percentage}% | ETA: {eta}s',
     }) as ProgressBar
 
@@ -84,23 +84,23 @@ export default class Restore extends IronfishCommand {
     progress.stop()
 
     this.log(`Unzipping\n    SRC ${downloadTo}\n    DST ${unzipTo}`)
-    cli.action.start(`Unzipping ${path.basename(downloadTo)}`)
+    CliUx.ux.action.start(`Unzipping ${path.basename(downloadTo)}`)
     await this.unzipTar(downloadTo, unzipTo)
-    cli.action.stop('done\n')
+    CliUx.ux.action.stop('done\n')
 
     // We do this because the backup can be created with any datadir name
     // So anything could be inside of the zip file. We want it to match our
     // specified data dir though.
-    cli.action.start(`Gettting backup name`)
+    CliUx.ux.action.start(`Gettting backup name`)
     const backupName = (await fsAsync.readdir(unzipTo))[0]
     const unzipFrom = path.join(unzipTo, backupName)
-    cli.action.stop(`${backupName}\n`)
+    CliUx.ux.action.stop(`${backupName}\n`)
 
     this.log(`Moving\n    SRC ${unzipFrom}\n    DST ${this.sdk.config.dataDir}`)
-    cli.action.start(`Moving to ${this.sdk.config.dataDir}`)
+    CliUx.ux.action.start(`Moving to ${this.sdk.config.dataDir}`)
     await fsAsync.rm(this.sdk.config.dataDir, { recursive: true, force: true })
     await fsAsync.rename(unzipFrom, this.sdk.config.dataDir)
-    cli.action.stop(`done\n`)
+    CliUx.ux.action.stop(`done\n`)
   }
 
   unzipTar(source: string, dest: string): Promise<number | null> {

--- a/ironfish-cli/src/commands/restore.ts
+++ b/ironfish-cli/src/commands/restore.ts
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
+import { CliUx } from '@oclif/core'
 import axios from 'axios'
 import { spawn } from 'child_process'
-import { CliUx } from '@oclif/core'
 import fs from 'fs'
 import fsAsync from 'fs/promises'
 import { NodeUtils, PromiseUtils } from 'ironfish'

--- a/ironfish-cli/src/commands/swim.ts
+++ b/ironfish-cli/src/commands/swim.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../command'
 import { ONE_FISH_IMAGE, TWO_FISH_IMAGE } from '../images'
 
@@ -40,7 +40,7 @@ export default class SwimCommand extends IronfishCommand {
       console.clear()
       this.renderPixels(pixels)
       this.log('The hex fish are coming...')
-      await cli.wait(32)
+      await CliUx.ux.wait(32)
     }
 
     // eslint-disable-next-line no-console

--- a/ironfish-cli/src/commands/testnet.ts
+++ b/ironfish-cli/src/commands/testnet.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { flags } from '@oclif/command'
-import cli from 'cli-ux'
+import { CliUx } from '@oclif/core'
 import { WebApi } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { DataDirFlag, DataDirFlagKey, VerboseFlag, VerboseFlagKey } from '../flags'
@@ -42,7 +42,7 @@ export default class Testnet extends IronfishCommand {
     let userArg = ((args.user as string | undefined) || '').trim()
 
     if (!userArg) {
-      userArg = (await cli.prompt(
+      userArg = (await CliUx.ux.prompt(
         'Enter the user id or url to a testnet user like https://testnet.ironfish.network/users/1080\nUser ID or URL',
         {
           required: true,
@@ -116,7 +116,7 @@ export default class Testnet extends IronfishCommand {
         )
       }
 
-      const confirmed = flags.confirm || (await cli.confirm(`Are you SURE? (y)es / (n)o`))
+      const confirmed = flags.confirm || (await CliUx.ux.confirm(`Are you SURE? (y)es / (n)o`))
       if (!confirmed) {
         return
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3020,7 +3020,7 @@ cli-ux@^4.9.0:
     treeify "^1.1.0"
     tslib "^1.9.3"
 
-cli-ux@^5.2.1, cli-ux@^5.5.0:
+cli-ux@^5.2.1:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-5.6.3.tgz#eecdb2e0261171f2b28f2be6b18c490291c3a287"
   integrity sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==
@@ -3173,10 +3173,18 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014"
+  integrity sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
 
 color-support@^1.1.2:
   version "1.1.3"
@@ -5156,7 +5164,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.7.6:
+handlebars@4.7.7, handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -5560,6 +5568,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -7487,7 +7500,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^8.0.0:
+node-notifier@8.0.1, node-notifier@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
   integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
@@ -9008,7 +9021,7 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-getter@^0.1.0:
+set-getter@0.1.1, set-getter@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.1.tgz#a3110e1b461d31a9cfc8c5c9ee2e9737ad447102"
   integrity sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==
@@ -9097,6 +9110,13 @@ simple-get@^3.0.3:
     decompress-response "^4.2.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,6 +1423,41 @@
     is-wsl "^2.1.1"
     tslib "^2.0.0"
 
+"@oclif/core@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.3.1.tgz#6bf178e69eec0330fbf3655881f4266d452c96f3"
+  integrity sha512-Lq1SqdjyNI9oowavTQ8q7S5YHCzNe38Xmt1UgPiYHTrd9MeeYJwlkzGhSuflZNtsmWFLFkpf0ps0+H1QWmKA2A==
+  dependencies:
+    "@oclif/linewrap" "^1.0.0"
+    "@oclif/screen" "^3.0.2"
+    ansi-escapes "^4.3.0"
+    ansi-styles "^4.2.0"
+    cardinal "^2.1.1"
+    chalk "^4.1.2"
+    clean-stack "^3.0.1"
+    cli-progress "^3.10.0"
+    debug "^4.3.3"
+    ejs "^3.1.6"
+    fs-extra "^9.1.0"
+    get-package-type "^0.1.0"
+    globby "^11.0.4"
+    hyperlinker "^1.0.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.13.1"
+    lodash "^4.17.21"
+    natural-orderby "^2.0.3"
+    object-treeify "^1.1.4"
+    password-prompt "^1.1.2"
+    semver "^7.3.5"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    supports-color "^8.1.1"
+    supports-hyperlinks "^2.2.0"
+    tslib "^2.3.1"
+    widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
+
 "@oclif/dev-cli@^1":
   version "1.26.0"
   resolved "https://registry.yarnpkg.com/@oclif/dev-cli/-/dev-cli-1.26.0.tgz#e3ec294b362c010ffc8948003d3770955c7951fd"
@@ -1540,6 +1575,11 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
   integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
+
+"@oclif/screen@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-3.0.2.tgz#969054308fe98d130c02844a45cc792199b75670"
+  integrity sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==
 
 "@oclif/test@^1":
   version "1.2.8"
@@ -2854,7 +2894,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2912,7 +2952,7 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
-clean-stack@^3.0.0:
+clean-stack@^3.0.0, clean-stack@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz#155bf0b2221bf5f4fba89528d24c5953f17fe3a8"
   integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
@@ -2930,6 +2970,13 @@ cli-cursor@^3.1.0:
   integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
   dependencies:
     restore-cursor "^3.1.0"
+
+cli-progress@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.10.0.tgz#63fd9d6343c598c93542fdfa3563a8b59887d78a"
+  integrity sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==
+  dependencies:
+    string-width "^4.2.0"
 
 cli-progress@^3.4.0:
   version "3.9.1"
@@ -3126,18 +3173,10 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-color-string@1.5.5:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014"
-  integrity sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==
-  dependencies:
-    color-name "^1.0.0"
-    simple-swizzle "^0.2.2"
 
 color-support@^1.1.2:
   version "1.1.3"
@@ -3535,6 +3574,13 @@ debug@^3.1.0, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -3818,7 +3864,7 @@ ejs@^2.5.9, ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-ejs@^3.1.5:
+ejs@^3.1.5, ejs@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.6.tgz#5bfd0a0689743bb5268b3550cceeebbc1702822a"
   integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==
@@ -4423,6 +4469,17 @@ fast-glob@^3.0.3, fast-glob@^3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.2.9:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -4994,6 +5051,18 @@ globby@^11.0.1, globby@^11.0.2, globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+globby@^11.0.4:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^3.0.0"
+
 globby@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-4.1.0.tgz#080f54549ec1b82a6c60e631fc82e1211dbe95f8"
@@ -5087,7 +5156,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@4.7.7, handlebars@^4.7.6:
+handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -5351,6 +5420,11 @@ ignore@^5.1.1, ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
   integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
 
+ignore@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
 immediate@^3.2.3:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.3.0.tgz#1aef225517836bcdf7f2a2de2600c79ff0269266"
@@ -5486,11 +5560,6 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
-
-is-arrayish@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
-  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -6969,7 +7038,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3, merge2@^1.3.0:
+merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -7277,7 +7346,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-natural-orderby@^2.0.1:
+natural-orderby@^2.0.1, natural-orderby@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
   integrity sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==
@@ -7418,7 +7487,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@8.0.1, node-notifier@^8.0.0:
+node-notifier@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
   integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
@@ -8939,7 +9008,7 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-getter@0.1.1, set-getter@^0.1.0:
+set-getter@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.1.tgz#a3110e1b461d31a9cfc8c5c9ee2e9737ad447102"
   integrity sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==
@@ -9028,13 +9097,6 @@ simple-get@^3.0.3:
     decompress-response "^4.2.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
-
-simple-swizzle@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
-  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
-  dependencies:
-    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -9546,7 +9608,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.1.0:
+supports-color@^8.1.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -9561,7 +9623,7 @@ supports-hyperlinks@^1.0.1:
     has-flag "^2.0.0"
     supports-color "^5.0.0"
 
-supports-hyperlinks@^2.0.0, supports-hyperlinks@^2.1.0:
+supports-hyperlinks@^2.0.0, supports-hyperlinks@^2.1.0, supports-hyperlinks@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
   integrity sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==
@@ -9905,7 +9967,7 @@ tslib@^1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
## Summary
[cli-ux](https://classic.yarnpkg.com/en/package/cli-ux) package is deprecated now. This PR contains migration from cli-ux to [@oclif/core](https://classic.yarnpkg.com/en/package/@oclif/core).

All changes were made by instructions from [package migration manual](https://github.com/oclif/core/blob/main/src/cli-ux/README.md).

Also, there are some other "old" @oclif/* packages in project (like [@oclif/command](https://classic.yarnpkg.com/en/package/@oclif/command), [@oclif/config](https://classic.yarnpkg.com/en/package/@oclif/config), etc). They all marked as "in maintenance mode" and replaced by @oclif/core. It's probably better to do their migration in another PR.

## Testing Plan
Whole refactoring pretty transparent: import another namespace from new package and use it instead of old one. I tested every refactored command manually and ran `yarn test` for sure. All tests passed.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```