### PR TITLE
Move telemetry payloads to Telemetry

### DIFF
--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -97,22 +97,7 @@ export class MetricsMonitor {
 
   private async submitMemoryTelemetry(): Promise<void> {
     if (this.telemetry) {
-      await this.telemetry.submit({
-        measurement: 'node',
-        name: 'memory',
-        fields: [
-          {
-            name: 'heap_used',
-            type: 'integer',
-            value: this.heapUsed.value,
-          },
-          {
-            name: 'heap_total',
-            type: 'integer',
-            value: this.heapTotal.value,
-          },
-        ],
-      })
+      await this.telemetry.submitMemUsage(this.heapUsed.value, this.heapTotal.value)
     }
   }
 }

--- a/ironfish/src/mining/director.ts
+++ b/ironfish/src/mining/director.ts
@@ -501,22 +501,7 @@ export class MiningDirector {
 
     this.onNewBlock.emit(block)
 
-    await this.telemetry.submit({
-      measurement: 'node',
-      name: 'block_mined',
-      fields: [
-        {
-          name: 'difficulty',
-          type: 'integer',
-          value: Number(block.header.target.toDifficulty()),
-        },
-        {
-          name: 'sequence',
-          type: 'integer',
-          value: Number(block.header.sequence),
-        },
-      ],
-    })
+    await this.telemetry.submitBlockMined(block)
 
     return MINED_RESULT.SUCCESS
   }

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -296,11 +296,7 @@ export class IronfishNode {
       await this.rpc.start()
     }
 
-    await this.telemetry.submit({
-      measurement: 'node',
-      name: 'started',
-      fields: [{ name: 'online', type: 'boolean', value: true }],
-    })
+    await this.telemetry.submitNodeStarted()
   }
 
   async waitForShutdown(): Promise<void> {

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Config } from '../fileStores'
 import { Logger } from '../logger'
+import { Block } from '../primitives/block'
 import { renderError, SetIntervalToken } from '../utils'
 import { WorkerPool } from '../workerPool'
 import { Metric } from './interfaces/metric'
@@ -82,5 +83,51 @@ export class Telemetry {
         this.points = points
       }
     }
+  }
+
+  async submitNodeStarted(): Promise<void> {
+    await this.submit({
+      measurement: 'node',
+      name: 'started',
+      fields: [{ name: 'online', type: 'boolean', value: true }],
+    })
+  }
+
+  async submitBlockMined(block: Block): Promise<void> {
+    await this.submit({
+      measurement: 'node',
+      name: 'block_mined',
+      fields: [
+        {
+          name: 'difficulty',
+          type: 'integer',
+          value: Number(block.header.target.toDifficulty()),
+        },
+        {
+          name: 'sequence',
+          type: 'integer',
+          value: Number(block.header.sequence),
+        },
+      ],
+    })
+  }
+
+  async submitMemUsage(heapUsed: number, heapTotal: number): Promise<void> {
+    await this.submit({
+      measurement: 'node',
+      name: 'memory',
+      fields: [
+        {
+          name: 'heap_used',
+          type: 'integer',
+          value: heapUsed,
+        },
+        {
+          name: 'heap_total',
+          type: 'integer',
+          value: heapTotal,
+        },
+      ],
+    })
   }
 }


### PR DESCRIPTION
## Summary
Moved the telemetry specific payloads into the telemetry system
with the greater non telemetry code not crafting telemetry payloads
manually. This keeps the telemetry format kind of isolated inside the
telemetry system, and also protects them from being modified. It's also
nice because you can see all the telemetry points we have in one
place.

## Testing Plan
Ran tests

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
