### PR TITLE
feat(ironfish): Submit offline point and flush when stopping telemetry

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -358,7 +358,7 @@ export class IronfishNode {
         if (newValue) {
           this.telemetry.start()
         } else {
-          this.telemetry.stop()
+          await this.telemetry.stop()
         }
         break
       }

--- a/ironfish/src/telemetry/telemetry.test.ts
+++ b/ironfish/src/telemetry/telemetry.test.ts
@@ -42,6 +42,16 @@ describe('Telemetry', () => {
     telemetry = mockTelemetry()
   })
 
+  describe('stop', () => {
+    it('sends a message for the node to stop and flushes remaining points', async () => {
+      const flush = jest.spyOn(telemetry, 'flush')
+      const submitNodeStopped = jest.spyOn(telemetry, 'submitNodeStopped')
+      await telemetry.stop()
+      expect(flush).toHaveBeenCalledTimes(1)
+      expect(submitNodeStopped).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('submit', () => {
     describe('when disabled', () => {
       it('does nothing', async () => {

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -38,8 +38,10 @@ export class Telemetry {
   }
 
   async stop(): Promise<void> {
-    await this.submitNodeStopped()
-    await this.flush()
+    if (this.enabled) {
+      await this.submitNodeStopped()
+      await this.flush()
+    }
 
     if (this.flushInterval) {
       clearTimeout(this.flushInterval)

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -36,7 +36,10 @@ export class Telemetry {
     }
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
+    await this.submitNodeStopped()
+    await this.flush()
+
     if (this.flushInterval) {
       clearTimeout(this.flushInterval)
     }
@@ -82,5 +85,13 @@ export class Telemetry {
         this.points = points
       }
     }
+  }
+
+  async submitNodeStopped(): Promise<void> {
+    await this.submit({
+      measurement: 'node',
+      name: 'started',
+      fields: [{ name: 'online', type: 'boolean', value: false }],
+    })
   }
 }

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -81,6 +81,7 @@ export class NodeTest {
 
     sdk.config.setOverride('bootstrapNodes', [''])
     sdk.config.setOverride('enableListenP2P', false)
+    sdk.config.setOverride('enableTelemetry', false)
 
     // Allow tests to override default settings
     if (options?.config) {


### PR DESCRIPTION
## Summary

Before shutting the node down or disabling telemetry, submit a point which indicates the node is offline.

## Testing Plan

Manually tested and updated unit tests.

![Screen Shot 2022-02-10 at 2 03 22 PM](https://user-images.githubusercontent.com/5459049/153478473-66a76d47-80c0-4f03-baba-0ce208f49d49.png)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
