### PR TITLE
Migrate to @oclif/core

### DIFF
--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -7,6 +7,6 @@ if (process.platform !== 'win32') {
   require('segfault-handler').registerHandler('segfault.log')
 }
 
-require('@oclif/command').run()
-.then(require('@oclif/command/flush'))
-.catch(require('@oclif/errors/handle'))
+require('@oclif/core').run()
+.then(require('@oclif/core/flush'))
+.catch(require('@oclif/core/handle'))

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -42,8 +42,6 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@oclif/command": "1.8.0",
-    "@oclif/config": "1.17.0",
     "@oclif/core": "1.3.1",
     "@oclif/plugin-help": "3.2.2",
     "@oclif/plugin-not-found": "1.2.4",

--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -78,6 +78,7 @@ export abstract class IronfishCommand extends Command {
   async init(): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     const commandClass = this.constructor as any
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const { flags } = await this.parse(commandClass)
 
     // Get the flags from the flag object which is unknown

--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Config, Command } from '@oclif/core'
+import { Command, Config } from '@oclif/core'
 import { ConfigOptions, ConnectionError, createRootLogger, IronfishSdk, Logger } from 'ironfish'
 import {
   ConfigFlagKey,

--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Command } from '@oclif/command'
-import { IConfig } from '@oclif/config'
+import { Config, Command } from '@oclif/core'
 import { ConfigOptions, ConnectionError, createRootLogger, IronfishSdk, Logger } from 'ironfish'
 import {
   ConfigFlagKey,
@@ -53,7 +52,7 @@ export abstract class IronfishCommand extends Command {
    */
   closing = false
 
-  constructor(argv: string[], config: IConfig) {
+  constructor(argv: string[], config: Config) {
     super(argv, config)
     this.logger = createRootLogger().withTag(this.ctor.id)
   }
@@ -79,7 +78,7 @@ export abstract class IronfishCommand extends Command {
   async init(): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     const commandClass = this.constructor as any
-    const { flags } = this.parse(commandClass)
+    const { flags } = await this.parse(commandClass)
 
     // Get the flags from the flag object which is unknown
     const dataDirFlag = getFlag(flags, DataDirFlagKey)

--- a/ironfish-cli/src/commands/accounts/balance.ts
+++ b/ironfish-cli/src/commands/accounts/balance.ts
@@ -15,14 +15,14 @@ export class BalanceCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       description: 'name of the account to get balance for',
     },
   ]
 
   async start(): Promise<void> {
-    const { args } = this.parse(BalanceCommand)
+    const { args } = await this.parse(BalanceCommand)
     const account = args.account as string | undefined
 
     const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/commands/accounts/balance.ts
+++ b/ironfish-cli/src/commands/accounts/balance.ts
@@ -15,7 +15,7 @@ export class BalanceCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'name of the account to get balance for',
     },

--- a/ironfish-cli/src/commands/accounts/balance.ts
+++ b/ironfish-cli/src/commands/accounts/balance.ts
@@ -15,7 +15,7 @@ export class BalanceCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'name of the account to get balance for',
     },

--- a/ironfish-cli/src/commands/accounts/create.ts
+++ b/ironfish-cli/src/commands/accounts/create.ts
@@ -12,7 +12,7 @@ export class CreateCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       description: 'name of the account',
     },
@@ -23,7 +23,7 @@ export class CreateCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { args } = this.parse(CreateCommand)
+    const { args } = await this.parse(CreateCommand)
     let name = args.name as string
 
     if (!name) {

--- a/ironfish-cli/src/commands/accounts/create.ts
+++ b/ironfish-cli/src/commands/accounts/create.ts
@@ -12,7 +12,7 @@ export class CreateCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'name of the account',
     },

--- a/ironfish-cli/src/commands/accounts/create.ts
+++ b/ironfish-cli/src/commands/accounts/create.ts
@@ -12,7 +12,7 @@ export class CreateCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'name of the account',
     },

--- a/ironfish-cli/src/commands/accounts/export.ts
+++ b/ironfish-cli/src/commands/accounts/export.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import fs from 'fs'
 import { ErrorUtils } from 'ironfish'
 import jsonColorizer from 'json-colorizer'
@@ -16,7 +15,7 @@ export class ExportCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     [ColorFlagKey]: ColorFlag,
-    local: flags.boolean({
+    local: Flags.boolean({
       default: false,
       description: 'Export an account without an online node',
     }),
@@ -25,20 +24,20 @@ export class ExportCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       description: 'name of the account to export',
     },
     {
       name: 'path',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       description: 'a path to export the account to',
     },
   ]
 
   async start(): Promise<void> {
-    const { flags, args } = this.parse(ExportCommand)
+    const { flags, args } = await this.parse(ExportCommand)
     const { color, local } = flags
     const account = args.account as string
     const exportPath = args.path as string | undefined

--- a/ironfish-cli/src/commands/accounts/export.ts
+++ b/ironfish-cli/src/commands/accounts/export.ts
@@ -24,13 +24,13 @@ export class ExportCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'name of the account to export',
     },
     {
       name: 'path',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'a path to export the account to',
     },

--- a/ironfish-cli/src/commands/accounts/export.ts
+++ b/ironfish-cli/src/commands/accounts/export.ts
@@ -24,13 +24,13 @@ export class ExportCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'name of the account to export',
     },
     {
       name: 'path',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'a path to export the account to',
     },

--- a/ironfish-cli/src/commands/accounts/export.ts
+++ b/ironfish-cli/src/commands/accounts/export.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs'
 import { ErrorUtils } from 'ironfish'
 import jsonColorizer from 'json-colorizer'

--- a/ironfish-cli/src/commands/accounts/import.ts
+++ b/ironfish-cli/src/commands/accounts/import.ts
@@ -21,7 +21,7 @@ export class ImportCommand extends IronfishCommand {
   static args = [
     {
       name: 'path',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'a path to import the account from',
     },

--- a/ironfish-cli/src/commands/accounts/import.ts
+++ b/ironfish-cli/src/commands/accounts/import.ts
@@ -21,7 +21,7 @@ export class ImportCommand extends IronfishCommand {
   static args = [
     {
       name: 'path',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'a path to import the account from',
     },

--- a/ironfish-cli/src/commands/accounts/import.ts
+++ b/ironfish-cli/src/commands/accounts/import.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { JSONUtils, PromiseUtils, SerializedAccount } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'

--- a/ironfish-cli/src/commands/accounts/import.ts
+++ b/ironfish-cli/src/commands/accounts/import.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import { JSONUtils, PromiseUtils, SerializedAccount } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -12,7 +11,7 @@ export class ImportCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    rescan: flags.boolean({
+    rescan: Flags.boolean({
       allowNo: true,
       default: true,
       description: 'rescan the blockchain once the account is imported',
@@ -22,14 +21,14 @@ export class ImportCommand extends IronfishCommand {
   static args = [
     {
       name: 'path',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       description: 'a path to import the account from',
     },
   ]
 
   async start(): Promise<void> {
-    const { flags, args } = this.parse(ImportCommand)
+    const { flags, args } = await this.parse(ImportCommand)
     const importPath = args.path as string | undefined
 
     const client = await this.sdk.connectRpc()
@@ -49,7 +48,7 @@ export class ImportCommand extends IronfishCommand {
     }
 
     const result = await client.importAccount({
-      account: account,
+      account: account!,
       rescan: flags.rescan,
     })
 

--- a/ironfish-cli/src/commands/accounts/import.ts
+++ b/ironfish-cli/src/commands/accounts/import.ts
@@ -44,11 +44,11 @@ export class ImportCommand extends IronfishCommand {
 
     if (account === null) {
       this.log('No account to import provided')
-      this.exit(1)
+      return this.exit(1)
     }
 
     const result = await client.importAccount({
-      account: account!,
+      account: account,
       rescan: flags.rescan,
     })
 

--- a/ironfish-cli/src/commands/accounts/list.ts
+++ b/ironfish-cli/src/commands/accounts/list.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -10,14 +10,14 @@ export class ListCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    displayName: flags.boolean({
+    displayName: Flags.boolean({
       default: false,
       description: `Display a hash of the account's read-only keys along with the account name`,
     }),
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(ListCommand)
+    const { flags } = await this.parse(ListCommand)
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import {
   displayIronAmountWithCurrency,
   ironToOre,
@@ -27,31 +26,31 @@ export class Pay extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    account: flags.string({
+    account: Flags.string({
       char: 'f',
       description: 'the account to send money from',
     }),
-    amount: flags.string({
+    amount: Flags.string({
       char: 'a',
       description: 'amount of coins to send',
     }),
-    to: flags.string({
+    to: Flags.string({
       char: 't',
       description: 'the public address of the recipient',
     }),
-    fee: flags.string({
+    fee: Flags.string({
       char: 'o',
       description: 'the fee amount in IRON',
     }),
-    memo: flags.string({
+    memo: Flags.string({
       char: 'm',
       description: 'the memo of transaction',
     }),
-    confirm: flags.boolean({
+    confirm: Flags.boolean({
       default: false,
       description: 'confirm without asking',
     }),
-    expirationSequence: flags.integer({
+    expirationSequence: Flags.integer({
       char: 'e',
       description:
         'The block sequence after which the transaction will be removed from the mempool. Set to 0 for no expiration.',
@@ -59,7 +58,7 @@ export class Pay extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(Pay)
+    const { flags } = await this.parse(Pay)
     let amount = flags.amount as unknown as number
     let fee = flags.fee as unknown as number
     let to = flags.to

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import {
   displayIronAmountWithCurrency,
   ironToOre,

--- a/ironfish-cli/src/commands/accounts/publickey.ts
+++ b/ironfish-cli/src/commands/accounts/publickey.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -10,7 +10,7 @@ export class PublicKeyCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    generate: flags.boolean({
+    generate: Flags.boolean({
       char: 'g',
       default: false,
       description: 'generate the public key',
@@ -20,14 +20,14 @@ export class PublicKeyCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       description: 'name of the account to get a public key',
     },
   ]
 
   async start(): Promise<void> {
-    const { args, flags } = this.parse(PublicKeyCommand)
+    const { args, flags } = await this.parse(PublicKeyCommand)
     const account = args.account as string | undefined
 
     const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/commands/accounts/publickey.ts
+++ b/ironfish-cli/src/commands/accounts/publickey.ts
@@ -20,7 +20,7 @@ export class PublicKeyCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'name of the account to get a public key',
     },

--- a/ironfish-cli/src/commands/accounts/publickey.ts
+++ b/ironfish-cli/src/commands/accounts/publickey.ts
@@ -20,7 +20,7 @@ export class PublicKeyCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'name of the account to get a public key',
     },

--- a/ironfish-cli/src/commands/accounts/remove.ts
+++ b/ironfish-cli/src/commands/accounts/remove.ts
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -20,13 +19,13 @@ export class RemoveCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    confirm: flags.boolean({
+    confirm: Flags.boolean({
       description: 'suppress the confirmation prompt',
     }),
   }
 
   async start(): Promise<void> {
-    const { args, flags } = this.parse(RemoveCommand)
+    const { args, flags } = await this.parse(RemoveCommand)
     const confirm = flags.confirm
     const name = (args.name as string).trim()
 

--- a/ironfish-cli/src/commands/accounts/remove.ts
+++ b/ironfish-cli/src/commands/accounts/remove.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/accounts/rescan.ts
+++ b/ironfish-cli/src/commands/accounts/rescan.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { hasUserResponseError } from '../../utils'

--- a/ironfish-cli/src/commands/accounts/rescan.ts
+++ b/ironfish-cli/src/commands/accounts/rescan.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+
+import { Flags, CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { hasUserResponseError } from '../../utils'
@@ -12,23 +12,23 @@ export class RescanCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    detach: flags.boolean({
+    detach: Flags.boolean({
       default: false,
       description: 'if a scan is already happening, follow that scan instead',
     }),
-    reset: flags.boolean({
+    reset: Flags.boolean({
       default: false,
       description:
         'clear the in-memory and disk caches before rescanning. note that this removes all pending transactions',
     }),
-    local: flags.boolean({
+    local: Flags.boolean({
       default: false,
       description: 'Force the rescan to not connect via RPC',
     }),
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(RescanCommand)
+    const { flags } = await this.parse(RescanCommand)
     const { detach, reset, local } = flags
     const client = await this.sdk.connectRpc(local)
 

--- a/ironfish-cli/src/commands/accounts/use.ts
+++ b/ironfish-cli/src/commands/accounts/use.ts
@@ -20,7 +20,7 @@ export class UseCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { args } = this.parse(UseCommand)
+    const { args } = await this.parse(UseCommand)
     const name = (args.name as string).trim()
 
     const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/commands/accounts/which.ts
+++ b/ironfish-cli/src/commands/accounts/which.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -14,14 +14,14 @@ export class WhichCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    displayName: flags.boolean({
+    displayName: Flags.boolean({
       default: false,
       description: `Display a hash of the account's read-only keys along with the account name`,
     }),
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(WhichCommand)
+    const { flags } = await this.parse(WhichCommand)
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/backup.ts
+++ b/ironfish-cli/src/commands/backup.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { spawn } from 'child_process'
 import fsAsync from 'fs/promises'
 import { FileUtils, NodeUtils } from 'ironfish'

--- a/ironfish-cli/src/commands/backup.ts
+++ b/ironfish-cli/src/commands/backup.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import { spawn } from 'child_process'
 import fsAsync from 'fs/promises'
 import { FileUtils, NodeUtils } from 'ironfish'
@@ -19,12 +18,12 @@ export default class Backup extends IronfishCommand {
   static flags = {
     [VerboseFlagKey]: VerboseFlag,
     [DataDirFlagKey]: DataDirFlag,
-    lock: flags.boolean({
+    lock: Flags.boolean({
       default: true,
       allowNo: true,
       description: 'wait for the database to stop being used',
     }),
-    accounts: flags.boolean({
+    accounts: Flags.boolean({
       default: false,
       allowNo: true,
       description: 'export the accounts',
@@ -40,7 +39,7 @@ export default class Backup extends IronfishCommand {
   ]
 
   async start(): Promise<void> {
-    const { flags, args } = this.parse(Backup)
+    const { flags, args } = await this.parse(Backup)
     const bucket = (args.bucket as string).trim()
 
     let id = uuid().slice(0, 5)

--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -11,7 +11,7 @@ export default class ShowBlock extends IronfishCommand {
   static args = [
     {
       name: 'search',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: true,
       description: 'the hash or sequence of the block to look at',
     },

--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -11,7 +11,7 @@ export default class ShowBlock extends IronfishCommand {
   static args = [
     {
       name: 'search',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: true,
       description: 'the hash or sequence of the block to look at',
     },
@@ -22,7 +22,7 @@ export default class ShowBlock extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { args } = this.parse(ShowBlock)
+    const { args } = await this.parse(ShowBlock)
     const search = args.search as string
 
     const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -11,7 +11,7 @@ export default class ShowBlock extends IronfishCommand {
   static args = [
     {
       name: 'search',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'the hash or sequence of the block to look at',
     },

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -16,7 +16,7 @@ export default class Export extends IronfishCommand {
     ...RemoteFlags,
     path: Flags.string({
       char: 'p',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       default: '../ironfish-graph-explorer/src/data.json',
       description: 'a path to export the chain to',
@@ -26,14 +26,14 @@ export default class Export extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: async (input: string) => parseNumber(input),
+      parse: async (input: string) => Promise.resolve(parseNumber(input)),
       default: Number(GENESIS_BLOCK_SEQUENCE),
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: async (input: string) => parseNumber(input),
+      parse: async (input: string) => Promise.resolve(parseNumber(input)),
       required: false,
       description: 'the sequence to end at (inclusive)',
     },

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -16,7 +16,7 @@ export default class Export extends IronfishCommand {
     ...RemoteFlags,
     path: Flags.string({
       char: 'p',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       default: '../ironfish-graph-explorer/src/data.json',
       description: 'a path to export the chain to',
@@ -26,14 +26,14 @@ export default class Export extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: async (input: string) => Promise.resolve(parseNumber(input)),
+      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
       default: Number(GENESIS_BLOCK_SEQUENCE),
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: async (input: string) => Promise.resolve(parseNumber(input)),
+      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
       required: false,
       description: 'the sequence to end at (inclusive)',
     },

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import fs from 'fs'
 import { AsyncUtils, GENESIS_BLOCK_SEQUENCE } from 'ironfish'
 import { parseNumber } from '../../args'
@@ -15,9 +14,9 @@ export default class Export extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    path: flags.string({
+    path: Flags.string({
       char: 'p',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       default: '../ironfish-graph-explorer/src/data.json',
       description: 'a path to export the chain to',
@@ -27,21 +26,21 @@ export default class Export extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: parseNumber,
+      parse: async (input: string) => parseNumber,
       default: Number(GENESIS_BLOCK_SEQUENCE),
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: parseNumber,
+      parse: async (input: string) => parseNumber,
       required: false,
       description: 'the sequence to end at (inclusive)',
     },
   ]
 
   async start(): Promise<void> {
-    const { flags, args } = this.parse(Export)
+    const { flags, args } = await this.parse(Export)
     const path = this.sdk.fileSystem.resolve(flags.path)
 
     const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs'
 import { AsyncUtils, GENESIS_BLOCK_SEQUENCE } from 'ironfish'
 import { parseNumber } from '../../args'

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -26,14 +26,14 @@ export default class Export extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: async (input: string) => parseNumber,
+      parse: async (input: string) => parseNumber(input),
       default: Number(GENESIS_BLOCK_SEQUENCE),
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: async (input: string) => parseNumber,
+      parse: async (input: string) => parseNumber(input),
       required: false,
       description: 'the sequence to end at (inclusive)',
     },

--- a/ironfish-cli/src/commands/chain/forks.ts
+++ b/ironfish-cli/src/commands/chain/forks.ts
@@ -17,7 +17,7 @@ export default class ForksCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    this.parse(ForksCommand)
+    await this.parse(ForksCommand)
     this.logger.pauseLogs()
 
     let connected = false

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import { GenesisBlockInfo, IJSON, makeGenesisBlock } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
@@ -13,19 +13,19 @@ export default class GenesisBlockCommand extends IronfishCommand {
 
   static flags = {
     ...LocalFlags,
-    account: flags.string({
+    account: Flags.string({
       char: 'a',
       required: false,
       default: 'IronFishGenesisAccount',
       description: 'the name of the account to use for keys to assign the genesis block to',
     }),
-    coins: flags.integer({
+    coins: Flags.integer({
       char: 'c',
       required: false,
       default: 4200000000000000,
       description: 'The amount of coins to generate',
     }),
-    memo: flags.string({
+    memo: Flags.string({
       char: 'm',
       required: false,
       default: 'Genesis Block',
@@ -34,7 +34,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(GenesisBlockCommand)
+    const { flags } = await this.parse(GenesisBlockCommand)
 
     const node = await this.sdk.node({ autoSeed: false })
     await node.openDB()

--- a/ironfish-cli/src/commands/chain/readdblock.ts
+++ b/ironfish-cli/src/commands/chain/readdblock.ts
@@ -18,7 +18,7 @@ export default class ReAddBlock extends IronfishCommand {
   static args = [
     {
       name: 'hash',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: true,
       description: 'the hash of the block in hex format',
     },

--- a/ironfish-cli/src/commands/chain/readdblock.ts
+++ b/ironfish-cli/src/commands/chain/readdblock.ts
@@ -18,7 +18,7 @@ export default class ReAddBlock extends IronfishCommand {
   static args = [
     {
       name: 'hash',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'the hash of the block in hex format',
     },

--- a/ironfish-cli/src/commands/chain/readdblock.ts
+++ b/ironfish-cli/src/commands/chain/readdblock.ts
@@ -38,11 +38,11 @@ export default class ReAddBlock extends IronfishCommand {
 
     if (!block) {
       this.log(`No block found with hash ${hash.toString('hex')}`)
-      this.exit(0)
+      return this.exit(0)
     }
 
     await node.chain.removeBlock(hash)
-    await node.chain.addBlock(block!)
+    await node.chain.addBlock(block)
 
     this.log('Block has been reimported.')
   }

--- a/ironfish-cli/src/commands/chain/readdblock.ts
+++ b/ironfish-cli/src/commands/chain/readdblock.ts
@@ -18,14 +18,14 @@ export default class ReAddBlock extends IronfishCommand {
   static args = [
     {
       name: 'hash',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: true,
       description: 'the hash of the block in hex format',
     },
   ]
 
   async start(): Promise<void> {
-    const { args } = this.parse(ReAddBlock)
+    const { args } = await this.parse(ReAddBlock)
     const hash = Buffer.from(args.hash as string, 'hex')
 
     CliUx.ux.action.start(`Opening node`)
@@ -42,7 +42,7 @@ export default class ReAddBlock extends IronfishCommand {
     }
 
     await node.chain.removeBlock(hash)
-    await node.chain.addBlock(block)
+    await node.chain.addBlock(block!)
 
     this.log('Block has been reimported.')
   }

--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { Assert, BlockHeader, IDatabaseTransaction, IronfishNode, TimeUtils } from 'ironfish'
 import { Meter } from 'ironfish'
 import { IronfishCommand } from '../../command'

--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -183,7 +183,7 @@ export default class RepairChain extends IronfishCommand {
           `\nDelete your database at ${node.config.chainDatabasePath}\n`
 
         this.log(error)
-        this.exit(1)
+        return this.exit(1)
       }
 
       done++
@@ -193,8 +193,8 @@ export default class RepairChain extends IronfishCommand {
       }
 
       prev = block.header
-      header = await node.chain.getNext(block.header, tx!)
-      block = header ? await node.chain.getBlock(header, tx!) : null
+      header = await node.chain.getNext(block.header, tx)
+      block = header ? await node.chain.getBlock(header, tx) : null
 
       speed.add(1)
       progress.increment()
@@ -203,8 +203,8 @@ export default class RepairChain extends IronfishCommand {
         speed: speed.rate1s.toFixed(0),
       })
 
-      if (tx!.size > TREE_BATCH) {
-        await tx!.commit()
+      if (tx.size > TREE_BATCH) {
+        await tx.commit()
         tx = null
       }
     }

--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import { Assert, BlockHeader, IDatabaseTransaction, IronfishNode, TimeUtils } from 'ironfish'
 import { Meter } from 'ironfish'
 import { IronfishCommand } from '../../command'
@@ -21,12 +20,12 @@ export default class RepairChain extends IronfishCommand {
 
   static flags = {
     ...LocalFlags,
-    confirm: flags.boolean({
+    confirm: Flags.boolean({
       char: 'c',
       default: false,
       description: 'force confirmation to repair',
     }),
-    force: flags.boolean({
+    force: Flags.boolean({
       char: 'f',
       default: false,
       description: 'force merkle tree reconstruction',
@@ -34,7 +33,7 @@ export default class RepairChain extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(RepairChain)
+    const { flags } = await this.parse(RepairChain)
 
     const speed = new Meter()
     const progress = CliUx.ux.progress({
@@ -194,8 +193,8 @@ export default class RepairChain extends IronfishCommand {
       }
 
       prev = block.header
-      header = await node.chain.getNext(block.header, tx)
-      block = header ? await node.chain.getBlock(header, tx) : null
+      header = await node.chain.getNext(block.header, tx!)
+      block = header ? await node.chain.getBlock(header, tx!) : null
 
       speed.add(1)
       progress.increment()
@@ -204,8 +203,8 @@ export default class RepairChain extends IronfishCommand {
         speed: speed.rate1s.toFixed(0),
       })
 
-      if (tx.size > TREE_BATCH) {
-        await tx.commit()
+      if (tx!.size > TREE_BATCH) {
+        await tx!.commit()
         tx = null
       }
     }

--- a/ironfish-cli/src/commands/chain/show.ts
+++ b/ironfish-cli/src/commands/chain/show.ts
@@ -15,14 +15,14 @@ export default class Show extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: async (input: string) => parseNumber(input),
+      parse: async (input: string) => Promise.resolve(parseNumber(input)),
       default: -50,
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: async (input: string) => parseNumber(input),
+      parse: async (input: string) => Promise.resolve(parseNumber(input)),
       required: false,
       description: 'the sequence to end at (inclusive)',
     },

--- a/ironfish-cli/src/commands/chain/show.ts
+++ b/ironfish-cli/src/commands/chain/show.ts
@@ -15,21 +15,21 @@ export default class Show extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: parseNumber,
+      parse: async (input: string) => parseNumber,
       default: -50,
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: parseNumber,
+      parse: async (input: string) => parseNumber,
       required: false,
       description: 'the sequence to end at (inclusive)',
     },
   ]
 
   async start(): Promise<void> {
-    const { args } = this.parse(Show)
+    const { args } = await this.parse(Show)
     const start = args.start as number | null
     const stop = args.stop as number | null
 

--- a/ironfish-cli/src/commands/chain/show.ts
+++ b/ironfish-cli/src/commands/chain/show.ts
@@ -15,14 +15,14 @@ export default class Show extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: async (input: string) => Promise.resolve(parseNumber(input)),
+      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
       default: -50,
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: async (input: string) => Promise.resolve(parseNumber(input)),
+      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
       required: false,
       description: 'the sequence to end at (inclusive)',
     },

--- a/ironfish-cli/src/commands/chain/show.ts
+++ b/ironfish-cli/src/commands/chain/show.ts
@@ -15,14 +15,14 @@ export default class Show extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: async (input: string) => parseNumber,
+      parse: async (input: string) => parseNumber(input),
       default: -50,
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: async (input: string) => parseNumber,
+      parse: async (input: string) => parseNumber(input),
       required: false,
       description: 'the sequence to end at (inclusive)',
     },

--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import { mkdtemp, readFile, writeFile } from 'fs'
 import { DEFAULT_CONFIG_NAME, JSONUtils } from 'ironfish'
 import os from 'os'
@@ -23,14 +23,14 @@ export class EditCommand extends IronfishCommand {
   static flags = {
     [ConfigFlagKey]: ConfigFlag,
     [DataDirFlagKey]: DataDirFlag,
-    remote: flags.boolean({
+    remote: Flags.boolean({
       default: false,
       description: 'connect to the node when editing the config',
     }),
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(EditCommand)
+    const { flags } = await this.parse(EditCommand)
 
     if (!flags.remote) {
       const configPath = this.sdk.config.storage.configPath

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -13,7 +13,7 @@ export class GetCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'name of the config item',
     },

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import { ConfigOptions } from 'ironfish'
 import jsonColorizer from 'json-colorizer'
 import { IronfishCommand } from '../../command'
@@ -13,7 +13,7 @@ export class GetCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: true,
       description: 'name of the config item',
     },
@@ -21,14 +21,14 @@ export class GetCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    user: flags.boolean({
+    user: Flags.boolean({
       description: 'only show config from the users datadir and not overrides',
     }),
-    local: flags.boolean({
+    local: Flags.boolean({
       default: false,
       description: 'dont connect to the node when displaying the config',
     }),
-    color: flags.boolean({
+    color: Flags.boolean({
       default: true,
       allowNo: true,
       description: 'should colorize the output',
@@ -36,7 +36,7 @@ export class GetCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { args, flags } = this.parse(GetCommand)
+    const { args, flags } = await this.parse(GetCommand)
     const name = (args.name as string).trim()
 
     const client = await this.sdk.connectRpc(flags.local)

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -13,7 +13,7 @@ export class GetCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: true,
       description: 'name of the config item',
     },

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -11,13 +11,13 @@ export class SetCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: true,
       description: 'name of the config item',
     },
     {
       name: 'value',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: true,
       description: 'value of the config item',
     },
@@ -25,7 +25,7 @@ export class SetCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    local: flags.boolean({
+    local: Flags.boolean({
       default: false,
       description: 'dont connect to the node when updating the config',
     }),
@@ -36,7 +36,7 @@ export class SetCommand extends IronfishCommand {
   ]
 
   async start(): Promise<void> {
-    const { args, flags } = this.parse(SetCommand)
+    const { args, flags } = await this.parse(SetCommand)
     const name = args.name as string
     const value = args.value as string
 

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -11,13 +11,13 @@ export class SetCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'name of the config item',
     },
     {
       name: 'value',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'value of the config item',
     },

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -11,13 +11,13 @@ export class SetCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: true,
       description: 'name of the config item',
     },
     {
       name: 'value',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: true,
       description: 'value of the config item',
     },

--- a/ironfish-cli/src/commands/config/show.ts
+++ b/ironfish-cli/src/commands/config/show.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import jsonColorizer from 'json-colorizer'
 import { IronfishCommand } from '../../command'
 import { ColorFlag, ColorFlagKey } from '../../flags'
@@ -13,17 +13,17 @@ export class ShowCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     [ColorFlagKey]: ColorFlag,
-    user: flags.boolean({
+    user: Flags.boolean({
       description: 'only show config from the users datadir and not overrides',
     }),
-    local: flags.boolean({
+    local: Flags.boolean({
       default: false,
       description: 'dont connect to the node when displaying the config',
     }),
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(ShowCommand)
+    const { flags } = await this.parse(ShowCommand)
 
     const client = await this.sdk.connectRpc(flags.local)
     const response = await client.getConfig({ user: flags.user })

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import { DEFAULT_DISCORD_INVITE, RequestError } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
@@ -16,18 +15,18 @@ export class FaucetCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    force: flags.boolean({
+    force: Flags.boolean({
       default: false,
       description: 'Force the faucet to try to give you coins even if its disabled',
     }),
-    email: flags.string({
+    email: Flags.string({
       hidden: true,
       description: 'Email to use to get funds',
     }),
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(FaucetCommand)
+    const { flags } = await this.parse(FaucetCommand)
 
     if (FAUCET_DISABLED && !flags.force) {
       this.log(`❌ The faucet is currently disabled. Check ${DEFAULT_DISCORD_INVITE} ❌`)

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import { DEFAULT_DISCORD_INVITE, RequestError } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'

--- a/ironfish-cli/src/commands/logs.ts
+++ b/ironfish-cli/src/commands/logs.ts
@@ -16,7 +16,7 @@ export default class LogsCommand extends IronfishCommand {
   node: IronfishNode | null = null
 
   async start(): Promise<void> {
-    this.parse(LogsCommand)
+    await this.parse(LogsCommand)
 
     await this.sdk.client.connect()
 

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -27,14 +27,14 @@ export class MinedCommand extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: async (input: string) => parseNumber,
+      parse: async (input: string) => parseNumber(input),
       default: Number(GENESIS_BLOCK_SEQUENCE),
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: async (input: string) => parseNumber,
+      parse: async (input: string) => parseNumber(input),
       required: false,
       description: 'the sequence to end at (inclusive)',
     },

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -27,14 +27,14 @@ export class MinedCommand extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: async (input: string) => parseNumber(input),
+      parse: async (input: string) => Promise.resolve(parseNumber(input)),
       default: Number(GENESIS_BLOCK_SEQUENCE),
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: async (input: string) => parseNumber(input),
+      parse: async (input: string) => Promise.resolve(parseNumber(input)),
       required: false,
       description: 'the sequence to end at (inclusive)',
     },

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -27,21 +27,21 @@ export class MinedCommand extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: parseNumber,
+      parse: async (input: string) => parseNumber,
       default: Number(GENESIS_BLOCK_SEQUENCE),
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: parseNumber,
+      parse: async (input: string) => parseNumber,
       required: false,
       description: 'the sequence to end at (inclusive)',
     },
   ]
 
   async start(): Promise<void> {
-    const { args } = this.parse(MinedCommand)
+    const { args } = await this.parse(MinedCommand)
     const client = await this.sdk.connectRpc()
 
     this.log('Scanning for mined blocks...')

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -27,14 +27,14 @@ export class MinedCommand extends IronfishCommand {
   static args = [
     {
       name: 'start',
-      parse: async (input: string) => Promise.resolve(parseNumber(input)),
+      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
       default: Number(GENESIS_BLOCK_SEQUENCE),
       required: false,
       description: 'the sequence to start at (inclusive, genesis block is 1)',
     },
     {
       name: 'stop',
-      parse: async (input: string) => Promise.resolve(parseNumber(input)),
+      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
       required: false,
       description: 'the sequence to end at (inclusive)',
     },

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import {
   AsyncUtils,
   FileUtils,
@@ -20,7 +19,7 @@ export class Miner extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    threads: flags.integer({
+    threads: Flags.integer({
       char: 't',
       default: 1,
       description:
@@ -29,7 +28,7 @@ export class Miner extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(Miner)
+    const { flags } = await this.parse(Miner)
 
     if (flags.threads === 0 || flags.threads < -1) {
       throw new Error('--threads must be a positive integer or -1.')

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import {
   AsyncUtils,
   FileUtils,

--- a/ironfish-cli/src/commands/peers/list.ts
+++ b/ironfish-cli/src/commands/peers/list.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import blessed from 'blessed'
 import { GetPeersResponse, PromiseUtils } from 'ironfish'
 import { IronfishCommand } from '../../command'
@@ -17,36 +16,36 @@ export class ListCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    follow: flags.boolean({
+    follow: Flags.boolean({
       char: 'f',
       default: false,
       description: 'follow the peers list live',
     }),
-    all: flags.boolean({
+    all: Flags.boolean({
       default: false,
       description: 'show all peers, not just connected peers',
     }),
-    extended: flags.boolean({
+    extended: Flags.boolean({
       char: 'e',
       default: false,
       description: 'display all information',
     }),
-    sort: flags.string({
+    sort: Flags.string({
       char: 'o',
       default: STATE_COLUMN_HEADER,
       description: 'sort by column header',
     }),
-    agents: flags.boolean({
+    agents: Flags.boolean({
       char: 'a',
       default: false,
       description: 'display peer agents',
     }),
-    sequence: flags.boolean({
+    sequence: Flags.boolean({
       char: 's',
       default: false,
       description: 'display peer head sequence',
     }),
-    names: flags.boolean({
+    names: Flags.boolean({
       char: 'n',
       default: false,
       description: 'display node names',
@@ -55,7 +54,7 @@ export class ListCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(ListCommand)
+    const { flags } = await this.parse(ListCommand)
 
     if (!flags.follow) {
       await this.sdk.client.connect()

--- a/ironfish-cli/src/commands/peers/list.ts
+++ b/ironfish-cli/src/commands/peers/list.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import blessed from 'blessed'
 import { GetPeersResponse, PromiseUtils } from 'ironfish'
 import { IronfishCommand } from '../../command'

--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -25,7 +25,7 @@ export class ShowCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { args } = this.parse(ShowCommand)
+    const { args } = await this.parse(ShowCommand)
 
     const identity = (args.identity as string).trim()
 
@@ -40,7 +40,7 @@ export class ShowCommand extends IronfishCommand {
       this.exit(1)
     }
 
-    this.log(this.renderPeer(peer.content.peer))
+    this.log(this.renderPeer(peer.content.peer!))
     if (messages.content.messages.length === 0) {
       this.log('No messages sent or received. Did you start your node with --logPeerMessages?')
     } else {

--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -37,10 +37,10 @@ export class ShowCommand extends IronfishCommand {
 
     if (peer.content.peer === null) {
       this.log(`No peer found containing identity '${identity}'.`)
-      this.exit(1)
+      return this.exit(1)
     }
 
-    this.log(this.renderPeer(peer.content.peer!))
+    this.log(this.renderPeer(peer.content.peer))
     if (messages.content.messages.length === 0) {
       this.log('No messages sent or received. Did you start your node with --logPeerMessages?')
     } else {

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import fs from 'fs'
 import fsAsync from 'fs/promises'
 import { IronfishNode, NodeUtils, PeerNetwork } from 'ironfish'
@@ -27,7 +26,7 @@ export default class Reset extends IronfishCommand {
     [ConfigFlagKey]: ConfigFlag,
     [DataDirFlagKey]: DataDirFlag,
     [DatabaseFlagKey]: DatabaseFlag,
-    confirm: flags.boolean({
+    confirm: Flags.boolean({
       default: false,
       description: 'confirm without asking',
     }),
@@ -38,7 +37,7 @@ export default class Reset extends IronfishCommand {
   peerNetwork: PeerNetwork | null = null
 
   async start(): Promise<void> {
-    const { flags } = this.parse(Reset)
+    const { flags } = await this.parse(Reset)
 
     let node = await this.sdk.node({ autoSeed: false })
     await NodeUtils.waitForOpen(node, null, { upgrade: false, load: false })

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs'
 import fsAsync from 'fs/promises'
 import { IronfishNode, NodeUtils, PeerNetwork } from 'ironfish'

--- a/ironfish-cli/src/commands/restore.ts
+++ b/ironfish-cli/src/commands/restore.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { CliUx } from '@oclif/core'
+import { Flags, CliUx } from '@oclif/core'
 import axios from 'axios'
 import { spawn } from 'child_process'
 import fs from 'fs'
@@ -23,7 +22,7 @@ export default class Restore extends IronfishCommand {
   static flags = {
     [VerboseFlagKey]: VerboseFlag,
     [DataDirFlagKey]: DataDirFlag,
-    lock: flags.boolean({
+    lock: Flags.boolean({
       default: true,
       allowNo: true,
       description: 'wait for the database to stop being used',
@@ -44,7 +43,7 @@ export default class Restore extends IronfishCommand {
   ]
 
   async start(): Promise<void> {
-    const { flags, args } = this.parse(Restore)
+    const { flags, args } = await this.parse(Restore)
 
     const bucket = (args.bucket as string).trim()
     let name = (args.name as string).trim()

--- a/ironfish-cli/src/commands/restore.ts
+++ b/ironfish-cli/src/commands/restore.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import axios from 'axios'
 import { spawn } from 'child_process'
 import fs from 'fs'

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import { ConnectionError, IronfishIpcClient, Meter, PromiseUtils, WebApi } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -19,15 +19,15 @@ export default class Faucet extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    api: flags.string({
+    api: Flags.string({
       char: 'a',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       description: 'API host to sync to',
     }),
-    token: flags.string({
+    token: Flags.string({
       char: 't',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       description: 'API host token to authenticate with',
     }),
@@ -36,7 +36,7 @@ export default class Faucet extends IronfishCommand {
   warnedFund = false
 
   async start(): Promise<void> {
-    const { flags } = this.parse(Faucet)
+    const { flags } = await this.parse(Faucet)
 
     const apiHost = (flags.api || process.env.IRONFISH_API_HOST || '').trim()
     const apiToken = (flags.token || process.env.IRONFISH_API_TOKEN || '').trim()

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -21,13 +21,13 @@ export default class Faucet extends IronfishCommand {
     ...RemoteFlags,
     api: Flags.string({
       char: 'a',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'API host to sync to',
     }),
     token: Flags.string({
       char: 't',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'API host token to authenticate with',
     }),

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -21,13 +21,13 @@ export default class Faucet extends IronfishCommand {
     ...RemoteFlags,
     api: Flags.string({
       char: 'a',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'API host to sync to',
     }),
     token: Flags.string({
       char: 't',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'API host token to authenticate with',
     }),

--- a/ironfish-cli/src/commands/service/sync.ts
+++ b/ironfish-cli/src/commands/service/sync.ts
@@ -21,13 +21,13 @@ export default class Sync extends IronfishCommand {
     ...RemoteFlags,
     endpoint: Flags.string({
       char: 'e',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'API host to sync to',
     }),
     token: Flags.string({
       char: 'e',
-      parse: async (input: string) => Promise.resolve(input.trim()),
+      parse: (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'API host token to authenticate with',
     }),

--- a/ironfish-cli/src/commands/service/sync.ts
+++ b/ironfish-cli/src/commands/service/sync.ts
@@ -21,13 +21,13 @@ export default class Sync extends IronfishCommand {
     ...RemoteFlags,
     endpoint: Flags.string({
       char: 'e',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'API host to sync to',
     }),
     token: Flags.string({
       char: 'e',
-      parse: async (input: string) => input.trim(),
+      parse: async (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'API host token to authenticate with',
     }),

--- a/ironfish-cli/src/commands/service/sync.ts
+++ b/ironfish-cli/src/commands/service/sync.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import { FollowChainStreamResponse, Meter, TimeUtils, WebApi } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -19,15 +19,15 @@ export default class Sync extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    endpoint: flags.string({
+    endpoint: Flags.string({
       char: 'e',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       description: 'API host to sync to',
     }),
-    token: flags.string({
+    token: Flags.string({
       char: 'e',
-      parse: (input: string): string => input.trim(),
+      parse: async (input: string) => input.trim(),
       required: false,
       description: 'API host token to authenticate with',
     }),
@@ -42,7 +42,7 @@ export default class Sync extends IronfishCommand {
   ]
 
   async start(): Promise<void> {
-    const { flags, args } = this.parse(Sync)
+    const { flags, args } = await this.parse(Sync)
 
     const apiHost = (flags.endpoint || process.env.IRONFISH_API_HOST || '').trim()
     const apiToken = (flags.token || process.env.IRONFISH_API_TOKEN || '').trim()

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import { Assert, IronfishNode, NodeUtils, PrivateIdentity, PromiseUtils } from 'ironfish'
 import tweetnacl from 'tweetnacl'
 import { v4 as uuid } from 'uuid'
@@ -43,46 +43,46 @@ export default class Start extends IronfishCommand {
     [RpcTcpHostFlagKey]: RpcTcpHostFlag,
     [RpcTcpPortFlagKey]: RpcTcpPortFlag,
     [RpcTcpSecureFlagKey]: RpcTcpSecureFlag,
-    bootstrap: flags.string({
+    bootstrap: Flags.string({
       char: 'b',
       description: 'comma-separated addresses of bootstrap nodes to connect to',
       multiple: true,
     }),
-    port: flags.integer({
+    port: Flags.integer({
       char: 'p',
       description: 'port to run the local ws server on',
     }),
-    workers: flags.integer({
+    workers: Flags.integer({
       description:
         'number of CPU workers to use for long-running operations. 0 disables (likely to cause performance issues), -1 auto-detects based on CPU cores',
     }),
-    graffiti: flags.string({
+    graffiti: Flags.string({
       char: 'g',
       default: undefined,
       description: 'Set the graffiti for the node',
     }),
-    name: flags.string({
+    name: Flags.string({
       char: 'n',
       description: 'name for the node',
       hidden: true,
     }),
-    listen: flags.boolean({
+    listen: Flags.boolean({
       allowNo: true,
       default: undefined,
       description: 'disable the web socket listen server',
       hidden: true,
     }),
-    forceMining: flags.boolean({
+    forceMining: Flags.boolean({
       default: undefined,
       description: 'force mining even if we are not synced',
       hidden: true,
     }),
-    logPeerMessages: flags.boolean({
+    logPeerMessages: Flags.boolean({
       default: undefined,
       description: 'track all messages sent and received by peers',
       hidden: true,
     }),
-    generateNewIdentity: flags.boolean({
+    generateNewIdentity: Flags.boolean({
       default: false,
       description: 'genereate new identity for each new start',
       hidden: true,
@@ -103,7 +103,7 @@ export default class Start extends IronfishCommand {
     const [startDonePromise, startDoneResolve] = PromiseUtils.split<void>()
     this.startDonePromise = startDonePromise
 
-    const { flags } = this.parse(Start)
+    const { flags } = await this.parse(Start)
     const {
       bootstrap,
       forceMining,

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import blessed from 'blessed'
 import { FileUtils, GetStatusResponse, PromiseUtils } from 'ironfish'
 import { Assert } from 'ironfish'
@@ -13,7 +13,7 @@ export default class Status extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    follow: flags.boolean({
+    follow: Flags.boolean({
       char: 'f',
       default: false,
       description: 'follow the status of the node live',
@@ -21,7 +21,7 @@ export default class Status extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(Status)
+    const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
       const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/commands/stop.ts
+++ b/ironfish-cli/src/commands/stop.ts
@@ -15,7 +15,7 @@ export default class StopCommand extends IronfishCommand {
   node: IronfishNode | null = null
 
   async start(): Promise<void> {
-    this.parse(StopCommand)
+    await this.parse(StopCommand)
 
     await this.sdk.client.connect({ retryConnect: false }).catch((e) => {
       if (e instanceof ConnectionError) {

--- a/ironfish-cli/src/commands/swim.ts
+++ b/ironfish-cli/src/commands/swim.ts
@@ -12,7 +12,7 @@ export default class SwimCommand extends IronfishCommand {
   static hidden = true
 
   async start(): Promise<void> {
-    this.parse(SwimCommand)
+    await this.parse(SwimCommand)
 
     const images = [ONE_FISH_IMAGE, TWO_FISH_IMAGE]
     const image = images[Math.round(Math.random() * (images.length - 1))]

--- a/ironfish-cli/src/commands/testnet.ts
+++ b/ironfish-cli/src/commands/testnet.ts
@@ -64,20 +64,19 @@ export default class Testnet extends IronfishCommand {
     //Assert.isNotNull(userId, `Could not figure out testnet user id from ${userArg}`)
     if (userId === null) {
       this.log(`Could not figure out testnet user id from ${userArg}`)
-      this.exit(1)
+      return this.exit(1)
     }
 
     // request user from API
     this.log(`Asking Iron Fish who user ${userId} is...`)
 
     const api = new WebApi()
-    const user = await api.getUser(userId!)
+    const user = await api.getUser(userId)
 
     if (!user) {
       this.log(`Could not find a user with id ${userId}`)
-      this.exit(1)
+      return this.exit(1)
     }
-    Assert.isNotNull(user, 'error')
 
     this.log('')
     this.log(`Hello ${user.graffiti}!`)
@@ -91,8 +90,8 @@ export default class Testnet extends IronfishCommand {
     const existingGraffiti = (await node.getConfig({ name: 'blockGraffiti' })).content
       .blockGraffiti
 
-    const updateNodeName = existingNodeName !== user!.graffiti && !flags.skipName
-    const updateGraffiti = existingGraffiti !== user!.graffiti && !flags.skipGraffiti
+    const updateNodeName = existingNodeName !== user.graffiti && !flags.skipName
+    const updateGraffiti = existingGraffiti !== user.graffiti && !flags.skipGraffiti
     const needsUpdate = updateNodeName || updateGraffiti
 
     if (!needsUpdate) {
@@ -104,7 +103,7 @@ export default class Testnet extends IronfishCommand {
       if (updateNodeName) {
         this.log(
           `You are about to change your NODE NAME from ${existingNodeName || '{NOT SET}'} to ${
-            user!.graffiti
+            user.graffiti
           }`,
         )
       }
@@ -112,7 +111,7 @@ export default class Testnet extends IronfishCommand {
       if (updateGraffiti) {
         this.log(
           `You are about to change your GRAFFITI from ${existingGraffiti || '{NOT SET}'} to ${
-            user!.graffiti
+            user.graffiti
           }`,
         )
       }
@@ -126,16 +125,16 @@ export default class Testnet extends IronfishCommand {
     }
 
     if (updateNodeName) {
-      await node.setConfig({ name: 'nodeName', value: user!.graffiti })
+      await node.setConfig({ name: 'nodeName', value: user.graffiti })
       this.log(
-        `✅ Updated NODE NAME from ${existingNodeName || '{NOT SET}'} to ${user!.graffiti}`,
+        `✅ Updated NODE NAME from ${existingNodeName || '{NOT SET}'} to ${user.graffiti}`,
       )
     }
 
     if (updateGraffiti) {
-      await node.setConfig({ name: 'blockGraffiti', value: user!.graffiti })
+      await node.setConfig({ name: 'blockGraffiti', value: user.graffiti })
       this.log(
-        `✅ Updated GRAFFITI from ${existingGraffiti || '{NOT SET}'} to ${user!.graffiti}`,
+        `✅ Updated GRAFFITI from ${existingGraffiti || '{NOT SET}'} to ${user.graffiti}`,
       )
     }
   }

--- a/ironfish-cli/src/commands/testnet.ts
+++ b/ironfish-cli/src/commands/testnet.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { CliUx, Flags } from '@oclif/core'
 import { WebApi } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { DataDirFlag, DataDirFlagKey, VerboseFlag, VerboseFlagKey } from '../flags'

--- a/ironfish-cli/src/commands/testnet.ts
+++ b/ironfish-cli/src/commands/testnet.ts
@@ -61,7 +61,6 @@ export default class Testnet extends IronfishCommand {
       userId = Number(userArg)
     }
 
-    //Assert.isNotNull(userId, `Could not figure out testnet user id from ${userArg}`)
     if (userId === null) {
       this.log(`Could not figure out testnet user id from ${userArg}`)
       return this.exit(1)

--- a/ironfish-cli/src/commands/testnet.ts
+++ b/ironfish-cli/src/commands/testnet.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, CliUx } from '@oclif/core'
-import { Assert, WebApi } from 'ironfish'
+import { WebApi } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { DataDirFlag, DataDirFlagKey, VerboseFlag, VerboseFlagKey } from '../flags'
 

--- a/ironfish-cli/src/commands/workers/status.ts
+++ b/ironfish-cli/src/commands/workers/status.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
+import { Flags } from '@oclif/core'
 import blessed from 'blessed'
 import { GetWorkersStatusResponse, PromiseUtils } from 'ironfish'
 import { IronfishCommand } from '../../command'
@@ -12,7 +12,7 @@ export default class Status extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    follow: flags.boolean({
+    follow: Flags.boolean({
       char: 'f',
       default: false,
       description: 'follow the status of the node live',
@@ -20,7 +20,7 @@ export default class Status extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags } = this.parse(Status)
+    const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
       const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { flags } from '@oclif/command'
-import { IOptionFlag } from '@oclif/command/lib/flags'
+import { Flags, Interfaces } from '@oclif/core'
 import {
   DEFAULT_CONFIG_NAME,
   DEFAULT_DATA_DIR,
@@ -22,62 +21,62 @@ export const RpcTcpHostFlagKey = 'rpc.tcp.host'
 export const RpcTcpPortFlagKey = 'rpc.tcp.port'
 export const RpcTcpSecureFlagKey = 'rpc.tcp.secure'
 
-export const VerboseFlag = flags.boolean({
+export const VerboseFlag = Flags.boolean({
   char: 'v',
   default: false,
   description: 'set logging level to verbose',
 })
 
-export const ColorFlag = flags.boolean({
+export const ColorFlag = Flags.boolean({
   default: true,
   allowNo: true,
   description: 'should colorize the output',
 })
 
-export const ConfigFlag = flags.string({
+export const ConfigFlag = Flags.string({
   default: DEFAULT_CONFIG_NAME,
   description: 'the name of the config file to use',
 })
 
-export const DataDirFlag = flags.string({
+export const DataDirFlag = Flags.string({
   default: DEFAULT_DATA_DIR,
   description: 'the path to the data dir',
 })
 
-export const DatabaseFlag = flags.string({
+export const DatabaseFlag = Flags.string({
   char: 'd',
   default: DEFAULT_DATABASE_NAME,
   description: 'the name of the database to use',
 })
 
-export const RpcUseIpcFlag = flags.boolean({
+export const RpcUseIpcFlag = Flags.boolean({
   default: DEFAULT_USE_RPC_IPC,
   description: 'connect to the RPC over IPC (default)',
 })
 
-export const RpcUseTcpFlag = flags.boolean({
+export const RpcUseTcpFlag = Flags.boolean({
   default: DEFAULT_USE_RPC_TCP,
   description: 'connect to the RPC over TCP',
 })
 
-export const RpcTcpHostFlag = flags.string({
+export const RpcTcpHostFlag = Flags.string({
   description: 'the TCP host to listen for connections on',
 })
 
-export const RpcTcpPortFlag = flags.integer({
+export const RpcTcpPortFlag = Flags.integer({
   description: 'the TCP port to listen for connections on',
 })
 
-export const RpcTcpSecureFlag = flags.boolean({
+export const RpcTcpSecureFlag = Flags.boolean({
   default: false,
   description: 'allow sensitive config to be changed over TCP',
 })
 
-const localFlags: Record<string, IOptionFlag<unknown>> = {}
-localFlags[VerboseFlagKey] = VerboseFlag as unknown as IOptionFlag<unknown>
-localFlags[ConfigFlagKey] = ConfigFlag as unknown as IOptionFlag<unknown>
-localFlags[DataDirFlagKey] = DataDirFlag as unknown as IOptionFlag<unknown>
-localFlags[DatabaseFlagKey] = DatabaseFlag as unknown as IOptionFlag<unknown>
+const localFlags: Record<string, Interfaces.CompletableOptionFlag<unknown>> = {}
+localFlags[VerboseFlagKey] = VerboseFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+localFlags[ConfigFlagKey] = ConfigFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+localFlags[DataDirFlagKey] = DataDirFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+localFlags[DatabaseFlagKey] = DatabaseFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
 
 /**
  * These flags should usually be used on any command that starts a node,
@@ -85,15 +84,15 @@ localFlags[DatabaseFlagKey] = DatabaseFlag as unknown as IOptionFlag<unknown>
  */
 export const LocalFlags = localFlags
 
-const remoteFlags: Record<string, IOptionFlag<unknown>> = {}
-remoteFlags[VerboseFlagKey] = VerboseFlag as unknown as IOptionFlag<unknown>
-remoteFlags[ConfigFlagKey] = ConfigFlag as unknown as IOptionFlag<unknown>
-remoteFlags[DataDirFlagKey] = DataDirFlag as unknown as IOptionFlag<unknown>
-remoteFlags[RpcUseTcpFlagKey] = RpcUseTcpFlag as unknown as IOptionFlag<unknown>
-remoteFlags[RpcUseIpcFlagKey] = RpcUseIpcFlag as unknown as IOptionFlag<unknown>
-remoteFlags[RpcTcpHostFlagKey] = RpcTcpHostFlag as unknown as IOptionFlag<unknown>
-remoteFlags[RpcTcpPortFlagKey] = RpcTcpPortFlag as unknown as IOptionFlag<unknown>
-remoteFlags[RpcTcpSecureFlagKey] = RpcTcpSecureFlag as unknown as IOptionFlag<unknown>
+const remoteFlags: Record<string, Interfaces.CompletableOptionFlag<unknown>> = {}
+remoteFlags[VerboseFlagKey] = VerboseFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+remoteFlags[ConfigFlagKey] = ConfigFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+remoteFlags[DataDirFlagKey] = DataDirFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+remoteFlags[RpcUseTcpFlagKey] = RpcUseTcpFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+remoteFlags[RpcUseIpcFlagKey] = RpcUseIpcFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+remoteFlags[RpcTcpHostFlagKey] = RpcTcpHostFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+remoteFlags[RpcTcpPortFlagKey] = RpcTcpPortFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+remoteFlags[RpcTcpSecureFlagKey] = RpcTcpSecureFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
 
 /**
  * These flags should usually be used on any command that uses an

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -10,6 +10,8 @@ import {
   DEFAULT_USE_RPC_TCP,
 } from 'ironfish'
 
+type CompletableOptionFlag = Interfaces.CompletableOptionFlag<unknown>
+
 export const VerboseFlagKey = 'verbose'
 export const ConfigFlagKey = 'config'
 export const ColorFlagKey = 'color'
@@ -72,11 +74,11 @@ export const RpcTcpSecureFlag = Flags.boolean({
   description: 'allow sensitive config to be changed over TCP',
 })
 
-const localFlags: Record<string, Interfaces.CompletableOptionFlag<unknown>> = {}
-localFlags[VerboseFlagKey] = VerboseFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
-localFlags[ConfigFlagKey] = ConfigFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
-localFlags[DataDirFlagKey] = DataDirFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
-localFlags[DatabaseFlagKey] = DatabaseFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+const localFlags: Record<string, CompletableOptionFlag> = {}
+localFlags[VerboseFlagKey] = VerboseFlag as unknown as CompletableOptionFlag
+localFlags[ConfigFlagKey] = ConfigFlag as unknown as CompletableOptionFlag
+localFlags[DataDirFlagKey] = DataDirFlag as unknown as CompletableOptionFlag
+localFlags[DatabaseFlagKey] = DatabaseFlag as unknown as CompletableOptionFlag
 
 /**
  * These flags should usually be used on any command that starts a node,
@@ -84,15 +86,15 @@ localFlags[DatabaseFlagKey] = DatabaseFlag as unknown as Interfaces.CompletableO
  */
 export const LocalFlags = localFlags
 
-const remoteFlags: Record<string, Interfaces.CompletableOptionFlag<unknown>> = {}
-remoteFlags[VerboseFlagKey] = VerboseFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
-remoteFlags[ConfigFlagKey] = ConfigFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
-remoteFlags[DataDirFlagKey] = DataDirFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
-remoteFlags[RpcUseTcpFlagKey] = RpcUseTcpFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
-remoteFlags[RpcUseIpcFlagKey] = RpcUseIpcFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
-remoteFlags[RpcTcpHostFlagKey] = RpcTcpHostFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
-remoteFlags[RpcTcpPortFlagKey] = RpcTcpPortFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
-remoteFlags[RpcTcpSecureFlagKey] = RpcTcpSecureFlag as unknown as Interfaces.CompletableOptionFlag<unknown>
+const remoteFlags: Record<string, CompletableOptionFlag> = {}
+remoteFlags[VerboseFlagKey] = VerboseFlag as unknown as CompletableOptionFlag
+remoteFlags[ConfigFlagKey] = ConfigFlag as unknown as CompletableOptionFlag
+remoteFlags[DataDirFlagKey] = DataDirFlag as unknown as CompletableOptionFlag
+remoteFlags[RpcUseTcpFlagKey] = RpcUseTcpFlag as unknown as CompletableOptionFlag
+remoteFlags[RpcUseIpcFlagKey] = RpcUseIpcFlag as unknown as CompletableOptionFlag
+remoteFlags[RpcTcpHostFlagKey] = RpcTcpHostFlag as unknown as CompletableOptionFlag
+remoteFlags[RpcTcpPortFlagKey] = RpcTcpPortFlag as unknown as CompletableOptionFlag
+remoteFlags[RpcTcpSecureFlagKey] = RpcTcpSecureFlag as unknown as CompletableOptionFlag
 
 /**
  * These flags should usually be used on any command that uses an

--- a/ironfish-cli/src/hooks/version.ts
+++ b/ironfish-cli/src/hooks/version.ts
@@ -7,6 +7,7 @@ import { Hook } from '@oclif/core'
 import { Platform } from 'ironfish'
 import { IronfishCliPKG } from '../package'
 
+// eslint-disable-next-line @typescript-eslint/require-await
 const VersionHook: Hook<'init'> = async () => {
   const isVersionCmd = process.argv[2] === 'version'
   const hasDashVersion = process.argv.some((a) => a === '--version')

--- a/ironfish-cli/src/hooks/version.ts
+++ b/ironfish-cli/src/hooks/version.ts
@@ -3,11 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /* eslint-disable no-console */
-import { Hook } from '@oclif/config'
+import { Hook } from '@oclif/core'
 import { Platform } from 'ironfish'
 import { IronfishCliPKG } from '../package'
 
-const VersionHook: Hook<'init'> = (): void => {
+const VersionHook: Hook<'init'> = async () => {
   const isVersionCmd = process.argv[2] === 'version'
   const hasDashVersion = process.argv.some((a) => a === '--version')
   const showVersion = isVersionCmd || hasDashVersion

--- a/ironfish-cli/src/index.ts
+++ b/ironfish-cli/src/index.ts
@@ -1,4 +1,4 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export { run } from '@oclif/command'
+export { run } from '@oclif/core'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,7 +1399,7 @@
     supports-color "^5.4.0"
     tslib "^1"
 
-"@oclif/command@1.8.0", "@oclif/command@^1.5.10", "@oclif/command@^1.5.20", "@oclif/command@^1.6", "@oclif/command@^1.6.0", "@oclif/command@^1.8.0":
+"@oclif/command@^1.5.10", "@oclif/command@^1.5.20", "@oclif/command@^1.6", "@oclif/command@^1.6.0", "@oclif/command@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.8.0.tgz#c1a499b10d26e9d1a611190a81005589accbb339"
   integrity sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==
@@ -1411,7 +1411,7 @@
     debug "^4.1.1"
     semver "^7.3.2"
 
-"@oclif/config@1.17.0", "@oclif/config@^1.12.6", "@oclif/config@^1.12.8", "@oclif/config@^1.15.1", "@oclif/config@^1.17.0":
+"@oclif/config@^1.12.6", "@oclif/config@^1.12.8", "@oclif/config@^1.15.1", "@oclif/config@^1.17.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.17.0.tgz#ba8639118633102a7e481760c50054623d09fcab"
   integrity sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==


### PR DESCRIPTION
## Summary
[@oclif/command](https://classic.yarnpkg.com/en/package/@oclif/command), [@oclif/config](https://classic.yarnpkg.com/en/package/@oclif/config) were put into maintenance mode. It is 2nd PR of migration Ironfish to new version of [@oclif/core](https://github.com/oclif/core) CLI packages ([check first PR #969](https://github.com/iron-fish/ironfish/pull/969)).

As it was in 1st PR all changes were made by [migration instructions](https://github.com/oclif/core/blob/main/MIGRATION.md).

## Testing Plan
The changes that have been made are pretty simple:
1. Import types and interfaces from @oclif/core instead of @oclif/command
1. Fix code in ironfish-cli/flags.ts and ironfish-cli/command.ts to use new version of types and interfaces
1. Replace **flags.*** to **Flags.*** in all commands
1. Replace **this.parse(...)** by **await this.parse(...)** in all commands
1. Replace flags parse function to async version in all commands
1. Remove ald modules @oclif/cconfig and @oclif/command

Run **yarn test**. Also, all commands were tested manually.


## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```