### PR TITLE
FIX: miner status when start/stop mining - issue #819

### DIFF
--- a/ironfish/src/rpc/routes/mining/newBlocksStream.ts
+++ b/ironfish/src/rpc/routes/mining/newBlocksStream.ts
@@ -67,11 +67,19 @@ router.register<typeof NewBlocksStreamRequestSchema, NewBlocksStreamResponse>(
       })
     }
 
+    if (node.miningDirector.isStarted() === false) {
+      void node.miningDirector.start()
+    }
+
     node.miningDirector.miners++
 
     request.onClose.once(() => {
       node.miningDirector.miners--
       node.miningDirector.onBlockToMine.off(onBlock)
+
+      if (node.miningDirector.miners === 0) {
+        node.miningDirector.shutdown()
+      }
     })
 
     node.miningDirector.onBlockToMine.on(onBlock)


### PR DESCRIPTION
Mining director doesn't correctly update status when start/stopping miner as outline by issue https://github.com/iron-fish/ironfish/issues/819.

in newBlockStream.ts, added logic for start/shutdown miningDirector when miner count changes.

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
