### PR TITLE
FIX: miners:mined status when completed - issue #748

### DIFF
--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -90,5 +90,8 @@ export class MinedCommand extends IronfishCommand {
         sequence,
       })
     }
+
+    progress.update(stop, { estimate: 0, sequence: stop })
+    progress.stop()
   }
 }


### PR DESCRIPTION
Adding a progress update to the end of mined.ts to update scanning progress at 100%. 

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
