### PR TITLE
add payment min fee notice

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -98,7 +98,7 @@ export class Pay extends IronfishCommand {
     if (!fee || Number.isNaN(Number(fee))) {
       fee = (await CliUx.ux.prompt('Enter the fee amount in $IRON', {
         required: true,
-        default: '0.00000001',
+        default: `minimum ${displayIronAmountWithCurrency(MINIMUM_IRON_AMOUNT, false)}`,
       })) as number
 
       if (Number.isNaN(fee)) {


### PR DESCRIPTION
When making a payment, I was only aware of the min payment fee after already submitting all the details.

![Screenshot 2022-02-13 at 14 16 25](https://user-images.githubusercontent.com/2752586/153758237-a2b1de5d-b3ee-4d6d-b6bb-80aa126a0e6f.png)

I propose adding the min fee message along with the `Enter the fee amount...` line.

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
