### PR TITLE
Debug command will now show multiple CPU models

### DIFF
--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -26,7 +26,7 @@ export default class Debug extends IronfishCommand {
     const accountsHeadSequence = accountsBlockHeader?.sequence || 'null'
 
     const cpus = os.cpus()
-    const cpuName = cpus[0].model
+    const cpuNames = [...new Set(cpus.map((c) => c.model))]
     const cpuThreads = cpus.length
 
     const memTotal = FileUtils.formatMemorySize(os.totalmem())
@@ -37,7 +37,7 @@ export default class Debug extends IronfishCommand {
 Iron Fish version       ${node.pkg.version} @ ${node.pkg.git}
 Iron Fish library       ${IronfishPKG.version} @ ${IronfishPKG.git}
 Operating system        ${os.type()} ${process.arch}
-CPU model               ${cpuName}
+CPU model(s)            ${cpuNames.toString()}
 CPU threads             ${cpuThreads}
 RAM total               ${memTotal}
 Node version            ${process.version}


### PR DESCRIPTION
## Summary

This is not perfect, as it only checks for unique CPU model names, but it's an improvement over just grabbing the first CPU model name. Also not a huge improvement, just something that occurred to me while seeing people discussing multiple CPUs

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
