### PR TITLE
Add new telemetry for block propagation

### DIFF
--- a/ironfish/src/telemetry/interfaces/metric.ts
+++ b/ironfish/src/telemetry/interfaces/metric.ts
@@ -12,7 +12,7 @@ export interface Metric {
    * A description for the container that the fields measure. Defaults to
    * 'node' because all metrics are submitted from an Iron Fish node.
    */
-  measurement: 'node'
+  measurement: string
 
   /**
    * The name of whatever is being measured.

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -166,4 +166,30 @@ export class Telemetry {
       ],
     })
   }
+
+  submitNewBlockSeen(block: Block, seenAt: Date): void {
+    this.submit({
+      measurement: 'propagation',
+      name: 'propagation',
+      timestamp: seenAt,
+      tags: [
+        {
+          name: 'block_hash',
+          value: block.header.hash.toString('hex'),
+        },
+      ],
+      fields: [
+        {
+          name: 'block_timestamp',
+          type: 'integer',
+          value: block.header.timestamp.valueOf(),
+        },
+        {
+          name: 'block_sequence',
+          type: 'integer',
+          value: block.header.sequence,
+        },
+      ],
+    })
+  }
 }


### PR DESCRIPTION
## Summary

This submits a new telemetry if the block has been successfully added.
I decided to only submit this telemtry so if invalid blocks are sent,
they aren't added to our data points. We also add data points for forks
and not forks, so that we can measure properly.

## Testing Plan
I will submit to local API with local influx attached.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
[ ] No
```
