### PR TITLE
Convert telemetry types to strict union types

### DIFF
--- a/ironfish/src/telemetry/interfaces/field.ts
+++ b/ironfish/src/telemetry/interfaces/field.ts
@@ -1,8 +1,19 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export interface Field {
-  name: string
-  type: 'string' | 'boolean' | 'float' | 'integer'
-  value: string | boolean | number
-}
+export type Field =
+  | {
+      name: string
+      type: 'string'
+      value: string
+    }
+  | {
+      name: string
+      type: 'boolean'
+      value: boolean
+    }
+  | {
+      name: string
+      type: 'float' | 'integer'
+      value: number
+    }

--- a/ironfish/src/telemetry/interfaces/tag.ts
+++ b/ironfish/src/telemetry/interfaces/tag.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export type Tag = {
+export interface Tag {
   name: string
   value: string
 }

--- a/ironfish/src/telemetry/interfaces/tag.ts
+++ b/ironfish/src/telemetry/interfaces/tag.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export interface Tag {
+export type Tag = {
   name: string
   value: string
 }


### PR DESCRIPTION
## Summary
The interfaces before did not ensure that if you put "string" that you
then passed a string in the value. These union types now ensure that the
value matches the type that is specified.

## Testing Plan
Run tests, no testing needed.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
