### PR TITLE
Enhanced security/responsible disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,19 @@
 
 ## Reporting a Vulnerability
 
-Please do not file a public issue on Github mentioning the vulnerability. To find out how to disclose a vulnerability, please email us at contact@ironfish.network.
+The Iron Fish team and community take all security bugs in Iron Fish seriously.
+Thank you for improving the security of Iron Fish. We appreciate your efforts and
+responsible disclosure and will make every effort to acknowledge your
+contributions.
+
+Please do not file a public issue on GitHub mentioning the vulnerability. <br>
+To disclose a vulnerability, please email us at: `contact@ironfish.network`.
+
+The lead maintainer will acknowledge your email within 48 hours, and will send a
+more detailed response within 7 days indicating the next steps in handling
+your report. After the initial reply to your report, the security team will
+endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining
+the module.


### PR DESCRIPTION
Improved the security policy based on widely accepted principles for responsible disclosure, as the previous version seemed a bit bare bones and vague.

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
