### PR TITLE
fix: `ironfish stop` is broken - issue #941

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -307,12 +307,12 @@ export class IronfishNode {
     await this.shutdownPromise
   }
 
-  async shutdown(): Promise<void> {
+  async shutdown(ignoreRpc?: boolean): Promise<void> {
     await Promise.allSettled([
       this.accounts.stop(),
       this.syncer.stop(),
       this.peerNetwork.stop(),
-      this.rpc.stop(),
+      ...(ignoreRpc === true ? [] : [this.rpc.stop()]),
       this.telemetry.stop(),
       this.metrics.stop(),
       this.workerPool.stop(),

--- a/ironfish/src/rpc/routes/node/stopNode.ts
+++ b/ironfish/src/rpc/routes/node/stopNode.ts
@@ -21,7 +21,7 @@ router.register<typeof StopNodeRequestSchema, StopNodeResponse>(
   StopNodeRequestSchema,
   async (request, node): Promise<void> => {
     node.logger.withTag('stopnode').info('Shutting down')
-    await node.shutdown()
+    await node.shutdown(true)
     request.end()
   },
 )


### PR DESCRIPTION
## Summary

tldr: calling `yarn start stop` [doesn’t work properly.](https://github.com/iron-fish/ironfish/issues/941) Node shutdown function in `src/node.ts` never finishes because it hangs on `this.rpc.stop()`.

There are 2 ways to stop the node:

1. SIGINT / SIGTERM / SIGUS2 which initiates a `gracefulShutdown()` in `ironfish-cli/src/commands/`. This successfully processes `closeFromSignal()` in `./start.ts`, which handles `this.node?.shutdown()`.

1. `yarn start stop`. This initiates `start()` in `ironfish-cli/src/commands/stop`, which calls the sdkClient `stopNode()` function. This never completes as the shutdown() function in `src/node.ts` hangs on `this.rpc.stop()`

## Solution
Add an argument for the shutdown() function, ignoreRpc = false. when calling stopNode() from the sdkClient, we can pass a false value so it ignores the rpc.stop() call and continues with the shutdown() gracefully. 

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
