### PR TITLE
Add BlockTemplateStream RPC endpoint

### DIFF
--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -2,14 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { BufferMap } from 'buffer-map'
+import { BufferMap, BufferSet } from 'buffer-map'
 import FastPriorityQueue from 'fastpriorityqueue'
+import { AsyncUtils } from '..'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { createRootLogger, Logger } from '../logger'
 import { Block, BlockHeader } from '../primitives'
 import { Transaction, TransactionHash } from '../primitives/transaction'
 import { Strategy } from '../strategy'
+
+const MAX_TRANSACTIONS_PER_BLOCK = 10
 
 interface MempoolEntry {
   fee: bigint
@@ -92,6 +95,58 @@ export class MemPool {
 
     this.logger.debug(`Accepted tx ${hash.toString('hex')}, poolsize ${this.size()}`)
     return true
+  }
+
+  async getNewBlockTransactions(sequence: number): Promise<{
+    totalFees: bigint
+    blockTransactions: Transaction[]
+  }> {
+    // Fetch pending transactions
+    const blockTransactions: Transaction[] = []
+    const nullifiers = new BufferSet()
+    for (const transaction of this.get()) {
+      if (blockTransactions.length >= MAX_TRANSACTIONS_PER_BLOCK) {
+        break
+      }
+
+      const isExpired = this.chain.verifier.isExpiredSequence(
+        transaction.expirationSequence(),
+        sequence,
+      )
+      if (isExpired) {
+        continue
+      }
+
+      const isConflicted = await AsyncUtils.find(transaction.spends(), (spend) => {
+        return nullifiers.has(spend.nullifier)
+      })
+      if (isConflicted) {
+        continue
+      }
+
+      const { valid: isValid } = await this.chain.verifier.verifyTransactionSpends(transaction)
+      if (!isValid) {
+        continue
+      }
+
+      for (const spend of transaction.spends()) {
+        nullifiers.add(spend.nullifier)
+      }
+
+      blockTransactions.push(transaction)
+    }
+
+    // Sum the transaction fees
+    let totalTransactionFees = BigInt(0)
+    const transactionFees = await Promise.all(blockTransactions.map((t) => t.fee()))
+    for (const transactionFee of transactionFees) {
+      totalTransactionFees += transactionFee
+    }
+
+    return {
+      totalFees: totalTransactionFees,
+      blockTransactions,
+    }
   }
 
   onConnectBlock(block: Block): void {

--- a/ironfish/src/rpc/clients/rpcClient.ts
+++ b/ironfish/src/rpc/clients/rpcClient.ts
@@ -4,6 +4,8 @@
 import { Logger } from '../../logger'
 import { Response, ResponseEnded } from '../response'
 import {
+  BlockTemplateStreamRequest,
+  BlockTemplateStreamResponse,
   CreateAccountRequest,
   CreateAccountResponse,
   GetAccountsRequest,
@@ -227,6 +229,12 @@ export abstract class IronfishRpcClient {
     params: NewBlocksStreamRequest = undefined,
   ): Response<void, NewBlocksStreamResponse> {
     return this.request<void, NewBlocksStreamResponse>('miner/newBlocksStream', params)
+  }
+
+  blockTemplateStream(
+    params: BlockTemplateStreamRequest = undefined,
+  ): Response<void, BlockTemplateStreamResponse> {
+    return this.request<void, BlockTemplateStreamResponse>('miner/blockTemplateStream', params)
   }
 
   successfullyMined(params: SuccessfullyMinedRequest): Response<SuccessfullyMinedResponse> {

--- a/ironfish/src/rpc/routes/mining/blockTemplateStream.ts
+++ b/ironfish/src/rpc/routes/mining/blockTemplateStream.ts
@@ -1,0 +1,178 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { BufferSet } from 'buffer-map'
+import * as yup from 'yup'
+import {
+  Assert,
+  AsyncUtils,
+  Block,
+  BlockTemplateSerde,
+  GraffitiUtils,
+  SerializedBlockTemplate,
+  Transaction,
+} from '../../..'
+import { ValidationError } from '../..'
+import { ApiNamespace, router } from '..'
+
+// TODO: This should live somewhere else
+const MAX_TRANSACTIONS_PER_BLOCK = 10
+
+export type BlockTemplateStreamRequest = Record<string, never> | undefined
+export type BlockTemplateStreamResponse = SerializedBlockTemplate
+
+export const BlockTemplateStreamRequestSchema: yup.MixedSchema<BlockTemplateStreamRequest> = yup
+  .mixed()
+  .oneOf([undefined] as const)
+// TODO: is there a way to make a yup schema re-usable?
+// this is a lot of boilerplate we end up having to duplicate for the work submit endpoint
+export const BlockTemplateStreamResponseSchema: yup.ObjectSchema<BlockTemplateStreamResponse> =
+  yup
+    .object({
+      header: yup
+        .object({
+          sequence: yup.number().required(),
+          previousBlockHash: yup.string().required(),
+          noteCommitment: yup
+            .object({
+              commitment: yup.string().required(),
+              size: yup.number().required(),
+            })
+            .required()
+            .defined(),
+          nullifierCommitment: yup
+            .object({
+              commitment: yup.string().required(),
+              size: yup.number().required(),
+            })
+            .required()
+            .defined(),
+          target: yup.string().required(),
+          randomness: yup.number().required(),
+          timestamp: yup.number().required(),
+          minersFee: yup.string().required(),
+          graffiti: yup.string().required(),
+        })
+        .required()
+        .defined(),
+      transactions: yup.array().of(yup.string().required()).required().defined(),
+      previousBlockInfo: yup
+        .object({
+          difficulty: yup.string().required(),
+          timestamp: yup.number().required(),
+        })
+        .required()
+        .defined(),
+    })
+    .required()
+    .defined()
+
+router.register<typeof BlockTemplateStreamRequestSchema, BlockTemplateStreamResponse>(
+  `${ApiNamespace.miner}/blockTemplateStream`,
+  BlockTemplateStreamRequestSchema,
+  async (request, node): Promise<void> => {
+    // Construct a new block template and send it to the stream listener
+    const onConnectBlock = async (block: Block) => {
+      const newBlockSequence = block.header.sequence + 1
+      // TODO: is there somewhere we can put this that makes more sense and is easier to test? memPool kinda makes sense
+      // Fetch pending transactions and associated fees
+      const blockTransactions: Transaction[] = []
+      const nullifiers = new BufferSet()
+      for (const transaction of node.memPool.get()) {
+        if (blockTransactions.length >= MAX_TRANSACTIONS_PER_BLOCK) {
+          break
+        }
+
+        const isExpired = node.chain.verifier.isExpiredSequence(
+          transaction.expirationSequence(),
+          newBlockSequence,
+        )
+        if (isExpired) {
+          continue
+        }
+
+        const isConflicted = await AsyncUtils.find(transaction.spends(), (spend) => {
+          return nullifiers.has(spend.nullifier)
+        })
+        if (isConflicted) {
+          continue
+        }
+
+        const { valid: isValid } = await node.chain.verifier.verifyTransactionSpends(
+          transaction,
+        )
+        if (!isValid) {
+          continue
+        }
+
+        for (const spend of transaction.spends()) {
+          nullifiers.add(spend.nullifier)
+        }
+
+        blockTransactions.push(transaction)
+      }
+
+      // Sum the transaction fees
+      let totalTransactionFees = BigInt(0)
+      const transactionFees = await Promise.all(blockTransactions.map((t) => t.fee()))
+      for (const transactionFee of transactionFees) {
+        totalTransactionFees += transactionFee
+      }
+
+      const account = node.accounts.getDefaultAccount()
+      Assert.isNotNull(account)
+
+      // Calculate the final fee for the miner of this block
+      const minersFee = await node.strategy.createMinersFee(
+        totalTransactionFees,
+        newBlockSequence,
+        account.spendingKey,
+      )
+      node.logger.debug(
+        `Constructed miner's reward transaction for account ${account.displayName}, block sequence ${newBlockSequence}`,
+      )
+
+      // Create the new block as a template for mining
+      const newBlock = await node.chain.newBlock(
+        blockTransactions,
+        minersFee,
+        // TODO: cache the config checks if needed for performance
+        GraffitiUtils.fromString(node.config.get('blockGraffiti')),
+      )
+
+      node.logger.debug(
+        `Current block template ${newBlock.header.sequence}, has ${newBlock.transactions.length} transactions`,
+      )
+
+      const serializedBlock = BlockTemplateSerde.serialize(newBlock, block)
+      request.stream(serializedBlock)
+    }
+
+    if (!node.chain.synced && !node.config.get('miningForce')) {
+      // TODO: Raise a proper error to the requester
+      throw new ValidationError('Node is not synced, try again once the node is fully synced')
+    }
+
+    // Wrap the listener function to avoid a deadlock from chain.newBlock()
+    const timeoutWrappedListener = (block: Block) => {
+      setTimeout(() => {
+        void onConnectBlock(block)
+      })
+    }
+
+    // Begin listening for chain head changes to generate new block templates to send to listeners
+    node.chain.onConnectBlock.on(timeoutWrappedListener)
+
+    // Send an initial block template to the requester so they can begin working immediately
+    const currentHeadBlock = await node.chain.getBlock(node.chain.head)
+    if (currentHeadBlock != null) {
+      await onConnectBlock(currentHeadBlock)
+    }
+
+    // If the listener stops listening, we no longer need to generate new block templates
+    // TODO: Verify that this would work for 2 listeners
+    request.onClose.once(() => {
+      node.chain.onConnectBlock.off(timeoutWrappedListener)
+    })
+  },
+)

--- a/ironfish/src/rpc/routes/mining/index.ts
+++ b/ironfish/src/rpc/routes/mining/index.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+export * from './blockTemplateStream'
 export * from './exportMined'
 export * from './newBlocksStream'
 export * from './successfullyMined'

--- a/ironfish/src/serde/BlockTemplateSerde.ts
+++ b/ironfish/src/serde/BlockTemplateSerde.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { BigIntUtils, Block, BlockHeader, Strategy } from '..'
+import { NoteEncryptedHashSerde } from '../primitives/noteEncrypted'
+import { Target } from '../primitives/target'
+import { NullifierSerdeInstance } from '.'
+
+export type SerializedBlockTemplate = {
+  header: {
+    sequence: number
+    previousBlockHash: string
+    noteCommitment: {
+      commitment: string
+      size: number
+    }
+    nullifierCommitment: {
+      commitment: string
+      size: number
+    }
+    target: string
+    randomness: number
+    timestamp: number
+    minersFee: string
+    graffiti: string
+  }
+  transactions: string[]
+  previousBlockInfo: {
+    difficulty: string
+    timestamp: number
+  }
+}
+
+export class BlockTemplateSerde {
+  static serialize(block: Block, previousBlock: Block): SerializedBlockTemplate {
+    const header = {
+      sequence: block.header.sequence,
+      previousBlockHash: block.header.previousBlockHash.toString('hex'),
+      noteCommitment: {
+        commitment: block.header.noteCommitment.commitment.toString('hex'),
+        size: block.header.noteCommitment.size,
+      },
+      nullifierCommitment: {
+        commitment: block.header.nullifierCommitment.commitment.toString('hex'),
+        size: block.header.nullifierCommitment.size,
+      },
+      target: BigIntUtils.toBytesBE(block.header.target.asBigInt(), 32).toString('hex'),
+      randomness: 0,
+      timestamp: block.header.timestamp.getTime(),
+      minersFee: BigIntUtils.toBytesBE(block.header.minersFee, 8).toString('hex'),
+      graffiti: block.header.graffiti.toString('hex'),
+    }
+    // TODO: Does this work for a genesis block? needs some form of optional data, or pre-filled in genesis case.
+    const previousBlockInfo = {
+      difficulty: BigIntUtils.toBytesBE(previousBlock.header.target.asBigInt(), 32).toString(
+        'hex',
+      ),
+      timestamp: previousBlock.header.timestamp.getTime(),
+    }
+
+    const transactions = block.transactions.map((t) => t.serialize().toString('hex'))
+    return {
+      header,
+      transactions,
+      previousBlockInfo,
+    }
+  }
+
+  static deserialize(strategy: Strategy, blockTemplate: SerializedBlockTemplate): Block {
+    const noteHasher = new NoteEncryptedHashSerde()
+    const header = new BlockHeader(
+      strategy,
+      blockTemplate.header.sequence,
+      Buffer.from(blockTemplate.header.previousBlockHash, 'hex'),
+      {
+        commitment: noteHasher.deserialize(
+          Buffer.from(blockTemplate.header.noteCommitment.commitment, 'hex'),
+        ),
+        size: blockTemplate.header.noteCommitment.size,
+      },
+      {
+        commitment: NullifierSerdeInstance.deserialize(
+          blockTemplate.header.nullifierCommitment.commitment,
+        ),
+        size: blockTemplate.header.nullifierCommitment.size,
+      },
+      new Target(Buffer.from(blockTemplate.header.target, 'hex')),
+      blockTemplate.header.randomness,
+      new Date(blockTemplate.header.timestamp),
+      BigInt(-1) * BigIntUtils.fromBytes(Buffer.from(blockTemplate.header.minersFee, 'hex')),
+      Buffer.from(blockTemplate.header.graffiti, 'hex'),
+    )
+    const transactions = blockTemplate.transactions.map((t) =>
+      strategy.transactionSerde.deserialize(Buffer.from(t, 'hex')),
+    )
+
+    return new Block(header, transactions)
+  }
+}

--- a/ironfish/src/serde/index.ts
+++ b/ironfish/src/serde/index.ts
@@ -4,6 +4,7 @@
 
 export { default as StringSerde } from './StringSerde'
 export { default as Uint8ArraySerde } from './Uint8ArraySerde'
+export * from './BlockTemplateSerde'
 export * from './BufferSerde'
 export * from './serdeInstances'
 export { IJSON } from './iJson'


### PR DESCRIPTION
## Summary

The new BlockTemplateStream RPC endpoint will provide all of the pieces necessary for miners and pools to construct and modify block headers however they need. This is the first step to enabling pools by enabling ways for miners to modify, for example, the block header's graffiti to ensure work is not being duplicated between miners.

Currently very WIP, wanted to start getting eyes on this early while I flesh it out.

The idea here is that we can merge this without any breaking changes. This way, we can keep the PR size manageable for this and the following PRs, and it gives us the opportunity to start experimenting with it before we deprecate the existing endpoints. It also gives us a path forward for deprecating the other endpoints.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
