### PR TITLE
Update RpcClient routes to use ApiNamespace enum

### DIFF
--- a/ironfish/src/rpc/clients/rpcClient.ts
+++ b/ironfish/src/rpc/clients/rpcClient.ts
@@ -4,6 +4,7 @@
 import { Logger } from '../../logger'
 import { Response, ResponseEnded } from '../response'
 import {
+  ApiNamespace,
   CreateAccountRequest,
   CreateAccountResponse,
   GetAccountsRequest,
@@ -86,32 +87,40 @@ export abstract class IronfishRpcClient {
   async status(
     params: GetStatusRequest = undefined,
   ): Promise<ResponseEnded<GetStatusResponse>> {
-    return this.request<GetStatusResponse>('node/getStatus', params).waitForEnd()
+    return this.request<GetStatusResponse>(
+      `${ApiNamespace.node}/getStatus`,
+      params,
+    ).waitForEnd()
   }
 
   statusStream(): Response<void, GetStatusResponse> {
-    return this.request<void, GetStatusResponse>('node/getStatus', { stream: true })
+    return this.request<void, GetStatusResponse>(`${ApiNamespace.node}/getStatus`, {
+      stream: true,
+    })
   }
 
   async stopNode(): Promise<ResponseEnded<StopNodeResponse>> {
-    return this.request<StopNodeResponse>('node/stopNode').waitForEnd()
+    return this.request<StopNodeResponse>(`${ApiNamespace.node}/stopNode`).waitForEnd()
   }
 
   getLogStream(): Response<void, GetLogStreamResponse> {
-    return this.request<void, GetLogStreamResponse>('node/getLogStream')
+    return this.request<void, GetLogStreamResponse>(`${ApiNamespace.node}/getLogStream`)
   }
 
   async getAccounts(
     params: GetAccountsRequest = undefined,
   ): Promise<ResponseEnded<GetAccountsResponse>> {
-    return await this.request<GetAccountsResponse>('account/getAccounts', params).waitForEnd()
+    return await this.request<GetAccountsResponse>(
+      `${ApiNamespace.account}/getAccounts`,
+      params,
+    ).waitForEnd()
   }
 
   async getDefaultAccount(
     params: GetDefaultAccountRequest = undefined,
   ): Promise<ResponseEnded<GetDefaultAccountResponse>> {
     return await this.request<GetDefaultAccountResponse>(
-      'account/getDefaultAccount',
+      `${ApiNamespace.account}/getDefaultAccount`,
       params,
     ).waitForEnd()
   }
@@ -119,106 +128,142 @@ export abstract class IronfishRpcClient {
   async createAccount(
     params: CreateAccountRequest,
   ): Promise<ResponseEnded<CreateAccountResponse>> {
-    return await this.request<CreateAccountResponse>('account/create', params).waitForEnd()
+    return await this.request<CreateAccountResponse>(
+      `${ApiNamespace.account}/create`,
+      params,
+    ).waitForEnd()
   }
 
   async useAccount(params: UseAccountRequest): Promise<ResponseEnded<UseAccountResponse>> {
-    return await this.request<UseAccountResponse>('account/use', params).waitForEnd()
+    return await this.request<UseAccountResponse>(
+      `${ApiNamespace.account}/use`,
+      params,
+    ).waitForEnd()
   }
 
   async removeAccount(
     params: RemoveAccountRequest,
   ): Promise<ResponseEnded<RemoveAccountResponse>> {
-    return await this.request<RemoveAccountResponse>('account/remove', params).waitForEnd()
+    return await this.request<RemoveAccountResponse>(
+      `${ApiNamespace.account}/remove`,
+      params,
+    ).waitForEnd()
   }
 
   async getAccountBalance(
     params: GetBalanceRequest = {},
   ): Promise<ResponseEnded<GetBalanceResponse>> {
-    return this.request<GetBalanceResponse>('account/getBalance', params).waitForEnd()
+    return this.request<GetBalanceResponse>(
+      `${ApiNamespace.account}/getBalance`,
+      params,
+    ).waitForEnd()
   }
 
   rescanAccountStream(
     params: RescanAccountRequest = {},
   ): Response<void, RescanAccountResponse> {
-    return this.request<void, RescanAccountResponse>('account/rescanAccount', params)
+    return this.request<void, RescanAccountResponse>(
+      `${ApiNamespace.account}/rescanAccount`,
+      params,
+    )
   }
 
   async exportAccount(
     params: ExportAccountRequest = {},
   ): Promise<ResponseEnded<ExportAccountResponse>> {
-    return this.request<ExportAccountResponse>('account/exportAccount', params).waitForEnd()
+    return this.request<ExportAccountResponse>(
+      `${ApiNamespace.account}/exportAccount`,
+      params,
+    ).waitForEnd()
   }
 
   async importAccount(
     params: ImportAccountRequest,
   ): Promise<ResponseEnded<ImportAccountResponse>> {
-    return this.request<ImportAccountResponse>('account/importAccount', params).waitForEnd()
+    return this.request<ImportAccountResponse>(
+      `${ApiNamespace.account}/importAccount`,
+      params,
+    ).waitForEnd()
   }
 
   async getAccountPublicKey(
     params: GetPublicKeyRequest,
   ): Promise<ResponseEnded<GetPublicKeyResponse>> {
-    return this.request<GetPublicKeyResponse>('account/getPublicKey', params).waitForEnd()
+    return this.request<GetPublicKeyResponse>(
+      `${ApiNamespace.account}/getPublicKey`,
+      params,
+    ).waitForEnd()
   }
 
   async getPeers(
     params: GetPeersRequest = undefined,
   ): Promise<ResponseEnded<GetPeersResponse>> {
-    return this.request<GetPeersResponse>('peer/getPeers', params).waitForEnd()
+    return this.request<GetPeersResponse>(`${ApiNamespace.peer}/getPeers`, params).waitForEnd()
   }
 
   getPeersStream(params: GetPeersRequest = undefined): Response<void, GetPeersResponse> {
-    return this.request<void, GetPeersResponse>('peer/getPeers', { ...params, stream: true })
-  }
-
-  async getWorkersStatus(
-    params: GetWorkersStatusRequest = undefined,
-  ): Promise<ResponseEnded<GetWorkersStatusResponse>> {
-    return this.request<GetWorkersStatusResponse>('worker/getStatus', params).waitForEnd()
-  }
-
-  getWorkersStatusStream(
-    params: GetWorkersStatusRequest = undefined,
-  ): Response<void, GetWorkersStatusResponse> {
-    return this.request<void, GetWorkersStatusResponse>('worker/getStatus', {
+    return this.request<void, GetPeersResponse>(`${ApiNamespace.peer}/getPeers`, {
       ...params,
       stream: true,
     })
   }
 
   async getPeer(params: GetPeerRequest): Promise<ResponseEnded<GetPeerResponse>> {
-    return this.request<GetPeerResponse>('peer/getPeer', params).waitForEnd()
+    return this.request<GetPeerResponse>(`${ApiNamespace.peer}/getPeer`, params).waitForEnd()
   }
 
   getPeerStream(params: GetPeerRequest): Response<void, GetPeerResponse> {
-    return this.request<void, GetPeerResponse>('peer/getPeer', { ...params, stream: true })
+    return this.request<void, GetPeerResponse>(`${ApiNamespace.peer}/getPeer`, {
+      ...params,
+      stream: true,
+    })
   }
 
   async getPeerMessages(
     params: GetPeerMessagesRequest,
   ): Promise<ResponseEnded<GetPeerMessagesResponse>> {
-    return this.request<GetPeerMessagesResponse>('peer/getPeerMessages', params).waitForEnd()
+    return this.request<GetPeerMessagesResponse>(
+      `${ApiNamespace.peer}/getPeerMessages`,
+      params,
+    ).waitForEnd()
   }
 
   getPeerMessagesStream(
     params: GetPeerMessagesRequest,
   ): Response<void, GetPeerMessagesResponse> {
-    return this.request<void, GetPeerMessagesResponse>('peer/getPeerMessages', {
+    return this.request<void, GetPeerMessagesResponse>(`${ApiNamespace.peer}/getPeerMessages`, {
+      ...params,
+      stream: true,
+    })
+  }
+
+  async getWorkersStatus(
+    params: GetWorkersStatusRequest = undefined,
+  ): Promise<ResponseEnded<GetWorkersStatusResponse>> {
+    return this.request<GetWorkersStatusResponse>(
+      `${ApiNamespace.worker}/getStatus`,
+      params,
+    ).waitForEnd()
+  }
+
+  getWorkersStatusStream(
+    params: GetWorkersStatusRequest = undefined,
+  ): Response<void, GetWorkersStatusResponse> {
+    return this.request<void, GetWorkersStatusResponse>(`${ApiNamespace.worker}/getStatus`, {
       ...params,
       stream: true,
     })
   }
 
   onGossipStream(params: OnGossipRequest = undefined): Response<void, OnGossipResponse> {
-    return this.request<void, OnGossipResponse>('event/onGossip', params)
+    return this.request<void, OnGossipResponse>(`${ApiNamespace.event}/onGossip`, params)
   }
 
   async sendTransaction(
     params: SendTransactionRequest,
   ): Promise<ResponseEnded<SendTransactionResponse>> {
     return this.request<SendTransactionResponse>(
-      'transaction/sendTransaction',
+      `${ApiNamespace.transaction}/sendTransaction`,
       params,
     ).waitForEnd()
   }
@@ -226,70 +271,106 @@ export abstract class IronfishRpcClient {
   newBlocksStream(
     params: NewBlocksStreamRequest = undefined,
   ): Response<void, NewBlocksStreamResponse> {
-    return this.request<void, NewBlocksStreamResponse>('miner/newBlocksStream', params)
+    return this.request<void, NewBlocksStreamResponse>(
+      `${ApiNamespace.miner}/newBlocksStream`,
+      params,
+    )
   }
 
   successfullyMined(params: SuccessfullyMinedRequest): Response<SuccessfullyMinedResponse> {
-    return this.request<SuccessfullyMinedResponse>('miner/successfullyMined', params)
-  }
-
-  async getFunds(params: GetFundsRequest): Promise<ResponseEnded<GetFundsResponse>> {
-    return this.request<GetFundsResponse>('faucet/getFunds', params).waitForEnd()
-  }
-
-  async getBlock(params: GetBlockRequest): Promise<ResponseEnded<GetBlockResponse>> {
-    return this.request<GetBlockResponse>('chain/getBlock', params).waitForEnd()
-  }
-
-  async getChainInfo(
-    params: GetChainInfoRequest = undefined,
-  ): Promise<ResponseEnded<GetChainInfoResponse>> {
-    return this.request<GetChainInfoResponse>('chain/getChainInfo', params).waitForEnd()
-  }
-
-  exportChainStream(
-    params: ExportChainStreamRequest = undefined,
-  ): Response<void, ExportChainStreamResponse> {
-    return this.request<void, ExportChainStreamResponse>('chain/exportChainStream', params)
-  }
-
-  followChainStream(
-    params: FollowChainStreamRequest = undefined,
-  ): Response<void, FollowChainStreamResponse> {
-    return this.request<void, FollowChainStreamResponse>('chain/followChainStream', params)
+    return this.request<SuccessfullyMinedResponse>(
+      `${ApiNamespace.miner}/successfullyMined`,
+      params,
+    )
   }
 
   exportMinedStream(
     params: ExportMinedStreamRequest = undefined,
   ): Response<void, ExportMinedStreamResponse> {
-    return this.request<void, ExportMinedStreamResponse>('miner/exportMinedStream', params)
+    return this.request<void, ExportMinedStreamResponse>(
+      `${ApiNamespace.miner}/exportMinedStream`,
+      params,
+    )
+  }
+
+  async getFunds(params: GetFundsRequest): Promise<ResponseEnded<GetFundsResponse>> {
+    return this.request<GetFundsResponse>(
+      `${ApiNamespace.faucet}/getFunds`,
+      params,
+    ).waitForEnd()
+  }
+
+  async getBlock(params: GetBlockRequest): Promise<ResponseEnded<GetBlockResponse>> {
+    return this.request<GetBlockResponse>(`${ApiNamespace.chain}/getBlock`, params).waitForEnd()
+  }
+
+  async getChainInfo(
+    params: GetChainInfoRequest = undefined,
+  ): Promise<ResponseEnded<GetChainInfoResponse>> {
+    return this.request<GetChainInfoResponse>(
+      `${ApiNamespace.chain}/getChainInfo`,
+      params,
+    ).waitForEnd()
+  }
+
+  exportChainStream(
+    params: ExportChainStreamRequest = undefined,
+  ): Response<void, ExportChainStreamResponse> {
+    return this.request<void, ExportChainStreamResponse>(
+      `${ApiNamespace.chain}/exportChainStream`,
+      params,
+    )
+  }
+
+  followChainStream(
+    params: FollowChainStreamRequest = undefined,
+  ): Response<void, FollowChainStreamResponse> {
+    return this.request<void, FollowChainStreamResponse>(
+      `${ApiNamespace.chain}/followChainStream`,
+      params,
+    )
   }
 
   async getBlockInfo(
     params: GetBlockInfoRequest,
   ): Promise<ResponseEnded<GetBlockInfoResponse>> {
-    return this.request<GetBlockInfoResponse>('chain/getBlockInfo', params).waitForEnd()
+    return this.request<GetBlockInfoResponse>(
+      `${ApiNamespace.chain}/getBlockInfo`,
+      params,
+    ).waitForEnd()
   }
 
   async showChain(
     params: ShowChainRequest = undefined,
   ): Promise<ResponseEnded<ShowChainResponse>> {
-    return this.request<ShowChainResponse>('chain/showChain', params).waitForEnd()
+    return this.request<ShowChainResponse>(
+      `${ApiNamespace.chain}/showChain`,
+      params,
+    ).waitForEnd()
   }
 
   async getConfig(
     params: GetConfigRequest = undefined,
   ): Promise<ResponseEnded<GetConfigResponse>> {
-    return this.request<GetConfigResponse>('config/getConfig', params).waitForEnd()
+    return this.request<GetConfigResponse>(
+      `${ApiNamespace.config}/getConfig`,
+      params,
+    ).waitForEnd()
   }
 
   async setConfig(params: SetConfigRequest): Promise<ResponseEnded<SetConfigResponse>> {
-    return this.request<SetConfigResponse>('config/setConfig', params).waitForEnd()
+    return this.request<SetConfigResponse>(
+      `${ApiNamespace.config}/setConfig`,
+      params,
+    ).waitForEnd()
   }
 
   async uploadConfig(
     params: UploadConfigRequest,
   ): Promise<ResponseEnded<UploadConfigResponse>> {
-    return this.request<UploadConfigResponse>('config/uploadConfig', params).waitForEnd()
+    return this.request<UploadConfigResponse>(
+      `${ApiNamespace.config}/uploadConfig`,
+      params,
+    ).waitForEnd()
   }
 }


### PR DESCRIPTION
## Summary

Minor change to RpcClient to utilize the ApiNamespace enum for route definition. Since we have a non-stringly-typed enum already, using it here just minimizes the risk of a typo that breaks a route.

Also reorganized a couple routes to group routes by their namespace a little bit better.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
