### PR TITLE
Update to latest napi-rs to fix BigInt usage

### DIFF
--- a/ironfish-rust-nodejs/Cargo.lock
+++ b/ironfish-rust-nodejs/Cargo.lock
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbca4762c2865296cf6c9b2252fc2d875f005d2903a148b4cd6206bb6f9a686"
+checksum = "17ec66e60f000c78dd7c6215b6fa260e0591e09805024332bc5b3f55acc12244"
 dependencies = [
  "ctor",
  "lazy_static",
@@ -727,9 +727,9 @@ checksum = "ebd4419172727423cf30351406c54f6cc1b354a2cfb4f1dba3e6cd07f6d5522b"
 
 [[package]]
 name = "napi-derive"
-version = "2.0.7"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6978824526532976fe146f71fef50395840d64a6c1af9085a358bdfdd300c7d"
+checksum = "74ac5287a5e94a8728fc82d16c5127acc5eb5b8ad6404ef5f82d6a4ce8d5bdd2"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30623da375dd5a5cae5609b0f0b9915177c03b3dc23a8450cc7dcc14027eee25"
+checksum = "427f4f04525635cdf22005d1be62d6d671bcb5550d694a1efb480a315422b4af"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -1259,9 +1259,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac7fef12f4b59cd0a29339406cc9203ab44e440ddff6b3f5a41455349fa9cf3"
+checksum = "b749ebd2304aa012c5992d11a25d07b406bdbe5f79d371cb7a918ce501a19eb0"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -1272,33 +1272,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
+checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
+checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
+checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
+checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
+checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
 
 [[package]]
 name = "zcash_primitives"

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -10,12 +10,12 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-napi-derive = "2"
+napi-derive = "2.1.0"
 ironfish_rust= { path = "../ironfish-rust", features = ["native"] }
 
 [dependencies.napi]
-version = "2"
+version = "2.1.0"
 features = ["napi6"]
 
 [build-dependencies]
-napi-build = "1"
+napi-build = "1.2.1"

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -115,7 +115,7 @@ export class Transaction {
    * sum(spends) - sum(outputs) - intended_transaction_fee - change = 0
    * aka: self.transaction_fee - intended_transaction_fee - change = 0
    */
-  post(spenderHexKey: string, changeGoesTo?: string | undefined | null, intendedTransactionFee: bigint): TransactionPosted
+  post(spenderHexKey: string, changeGoesTo: string | undefined | null, intendedTransactionFee: bigint): TransactionPosted
   setExpirationSequence(expirationSequence: number): void
 }
 export type NativeSimpleTransaction = SimpleTransaction

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use napi::bindgen_prelude::*;
-use napi::JsBigInt;
 use napi_derive::napi;
 
 use ironfish_rust::note::Memo;
@@ -19,8 +18,8 @@ impl NativeNoteBuilder {
     /// TODO: This works around a concurrency bug when using #[napi(factory)]
     /// in worker threads. It can be merged into NativeNote once the bug is fixed.
     #[napi(constructor)]
-    pub fn new(owner: String, value: JsBigInt, memo: String) -> Result<Self> {
-        let value_u64 = value.get_u64()?.0;
+    pub fn new(owner: String, value: BigInt, memo: String) -> Result<Self> {
+        let value_u64 = value.get_u64().1;
 
         let owner_address = ironfish_rust::PublicAddress::from_hex(SAPLING.clone(), &owner)
             .map_err(|err| Error::from_reason(err.to_string()))?;
@@ -87,8 +86,8 @@ impl NativeNote {
     /// only at the time the note is spent. This key is collected in a massive
     /// 'nullifier set', preventing double-spend.
     #[napi]
-    pub fn nullifier(&self, owner_private_key: String, position: JsBigInt) -> Result<Buffer> {
-        let position_u64 = position.get_u64()?.0;
+    pub fn nullifier(&self, owner_private_key: String, position: BigInt) -> Result<Buffer> {
+        let position_u64 = position.get_u64().1;
 
         let private_key = Key::from_hex(SAPLING.clone(), &owner_private_key)
             .map_err(|err| Error::from_reason(err.to_string()))?;

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -6,7 +6,6 @@ use std::cell::RefCell;
 use std::convert::TryInto;
 
 use napi::bindgen_prelude::*;
-use napi::JsBigInt;
 use napi_derive::napi;
 
 use ironfish_rust::sapling_bls12::{
@@ -217,9 +216,9 @@ impl NativeTransaction {
         &mut self,
         spender_hex_key: String,
         change_goes_to: Option<String>,
-        intended_transaction_fee: JsBigInt,
+        intended_transaction_fee: BigInt,
     ) -> Result<NativeTransactionPosted> {
-        let intended_transaction_fee_u64 = intended_transaction_fee.get_u64()?.0;
+        let intended_transaction_fee_u64 = intended_transaction_fee.get_u64().1;
 
         let spender_key = Key::from_hex(SAPLING.clone(), &spender_hex_key)
             .map_err(|err| Error::from_reason(err.to_string()))?;
@@ -258,9 +257,9 @@ impl NativeSimpleTransaction {
     #[napi(constructor)]
     pub fn new(
         spender_hex_key: String,
-        intended_transaction_fee: JsBigInt,
+        intended_transaction_fee: BigInt,
     ) -> Result<NativeSimpleTransaction> {
-        let intended_transaction_fee_u64 = intended_transaction_fee.get_u64()?.0;
+        let intended_transaction_fee_u64 = intended_transaction_fee.get_u64().1;
 
         let spender_key = Key::from_hex(SAPLING.clone(), &spender_hex_key)
             .map_err(|err| Error::from_reason(err.to_string()))?;


### PR DESCRIPTION
## Summary

NAPI-rs 2.1.0 fixed the BigInt issue I reported previously, so it should be safe to update now.

## Testing Plan

Tests should pass -- they previously failed when there was a BigInt issue with napi-rs.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
