### PR TITLE
Return a Buffer instead of a NativeNote from decryption functions

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -34,9 +34,9 @@ export class NoteEncrypted {
    */
   static combineHash(depth: number, left: Buffer, right: Buffer): Buffer
   /** Returns undefined if the note was unable to be decrypted with the given key. */
-  decryptNoteForOwner(incomingHexKey: string): NativeNote | undefined | null
+  decryptNoteForOwner(incomingHexKey: string): Buffer | undefined | null
   /** Returns undefined if the note was unable to be decrypted with the given key. */
-  decryptNoteForSpender(outgoingHexKey: string): NativeNote | undefined | null
+  decryptNoteForSpender(outgoingHexKey: string): Buffer | undefined | null
 }
 export type NativeNoteBuilder = NoteBuilder
 export class NoteBuilder {

--- a/ironfish/src/primitives/noteEncrypted.ts
+++ b/ironfish/src/primitives/noteEncrypted.ts
@@ -43,8 +43,7 @@ export class NoteEncrypted {
     const note = this.takeReference().decryptNoteForOwner(ownerHexKey)
     this.returnReference()
     if (note) {
-      const serializedNote = note.serialize()
-      return new Note(Buffer.from(serializedNote))
+      return new Note(note)
     }
   }
 
@@ -52,8 +51,7 @@ export class NoteEncrypted {
     const note = this.takeReference().decryptNoteForSpender(spenderHexKey)
     this.returnReference()
     if (note) {
-      const serializedNote = note.serialize()
-      return new Note(Buffer.from(serializedNote))
+      return new Note(note)
     }
   }
 

--- a/ironfish/src/workerPool/tasks/getUnspentNotes.ts
+++ b/ironfish/src/workerPool/tasks/getUnspentNotes.ts
@@ -39,7 +39,7 @@ export function handleGetUnspentNotes({
       if (decryptedNote) {
         results.push({
           hash: note.merkleHash().toString('hex'),
-          note: decryptedNote.serialize(),
+          note: decryptedNote,
           account: account,
         })
 


### PR DESCRIPTION
## Summary

In debugging issue #1022, I used mat-if/chaos (https://github.com/iron-fish/ironfish/commit/dafb58cf71ca641fa9fce3722ce88065094554b6) to help reproduce the issue. I was able to fix a bunch of the crashing on that branch with this change, but I'm not sure that this will completely address the crashing in that issue mentioned earlier.

## Testing Plan

Ran the makefile and chaos script from the above commit.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
