### PR TITLE
Move telemetry tags to fields

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -191,10 +191,10 @@ export class IronfishNode {
     const telemetry = new Telemetry({
       workerPool,
       logger,
-      defaultTags: [
-        { name: 'node_id', value: internal.get('telemetryNodeId') },
-        { name: 'session_id', value: uuid() },
-        { name: 'version', value: pkg.version },
+      defaultTags: [{ name: 'version', value: pkg.version }],
+      defaultFields: [
+        { name: 'node_id', type: 'string', value: internal.get('telemetryNodeId') },
+        { name: 'session_id', type: 'string', value: uuid() },
       ],
     })
 

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -5,6 +5,7 @@ import { createRootLogger, Logger } from '../logger'
 import { Block } from '../primitives/block'
 import { renderError, SetIntervalToken } from '../utils'
 import { WorkerPool } from '../workerPool'
+import { Field } from './interfaces/field'
 import { Metric } from './interfaces/metric'
 import { Tag } from './interfaces/tag'
 
@@ -14,6 +15,7 @@ export class Telemetry {
   private readonly MAX_RETRIES = 5
 
   private readonly defaultTags: Tag[]
+  private readonly defaultFields: Field[]
   private readonly logger: Logger
   private readonly workerPool: WorkerPool
 
@@ -22,10 +24,16 @@ export class Telemetry {
   private points: Metric[]
   private retries: number
 
-  constructor(options: { workerPool: WorkerPool; logger?: Logger; defaultTags?: Tag[] }) {
+  constructor(options: {
+    workerPool: WorkerPool
+    logger?: Logger
+    defaultTags?: Tag[]
+    defaultFields?: Field[]
+  }) {
     this.logger = options.logger ?? createRootLogger()
     this.workerPool = options.workerPool
     this.defaultTags = options.defaultTags ?? []
+    this.defaultFields = options.defaultFields ?? []
 
     this.flushInterval = null
     this.points = []
@@ -79,10 +87,13 @@ export class Telemetry {
       tags = tags.concat(metric.tags)
     }
 
+    const fields = this.defaultFields.concat(metric.fields)
+
     this.points.push({
       ...metric,
       timestamp: metric.timestamp || new Date(),
       tags,
+      fields,
     })
   }
 


### PR DESCRIPTION
## Summary

We are doing this to reduce cardinality. Indexes are created from the
combination of measurement and tags. This means every node session ends
up getting it's own indexes which blows out our cardinality and causes
causes InfluxDB to stop processing data. You can read more about this
issue here:

https://docs.influxdata.com/influxdb/cloud/write-data/best-practices/resolve-high-cardinality

## Testing Plan
Ran the node

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
