### PR TITLE
Fix ordering issue in creating telemetry node id

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -157,6 +157,11 @@ export default class Start extends IronfishCommand {
       this.sdk.config.setOverride('generateNewIdentity', generateNewIdentity)
     }
 
+    if (!this.sdk.internal.get('telemetryNodeId')) {
+      this.sdk.internal.set('telemetryNodeId', uuid())
+      await this.sdk.internal.save()
+    }
+
     const privateIdentity = this.getPrivateIdentity()
 
     const node = await this.sdk.node({ privateIdentity: privateIdentity })
@@ -204,11 +209,6 @@ export default class Start extends IronfishCommand {
 
     if (node.internal.get('isFirstRun')) {
       await this.firstRun(node)
-    }
-
-    if (!node.internal.get('telemetryNodeId')) {
-      node.internal.set('telemetryNodeId', uuid())
-      await node.internal.save()
     }
 
     await node.start()


### PR DESCRIPTION
## Summary

The issue is that Node.Init() happens before the telemetry node id is
created for the first time. We simply move that up, and configure it on
the SDK itself which gets passed to the constructed node.

## Testing Plan

Ran the node with a reproduction case.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
