### PR TITLE
feat(ironfish): Move metrics monitor inside telemetry

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -198,7 +198,7 @@ export class IronfishNode {
       ],
     })
 
-    metrics = metrics || new MetricsMonitor({ telemetry, logger })
+    metrics = metrics || new MetricsMonitor({ logger })
 
     const chain = new Blockchain({
       location: config.chainDatabasePath,

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -60,9 +60,7 @@ export class Syncer {
     this.logger = logger.withTag('syncer')
     this.telemetry = options.telemetry
 
-    this.metrics =
-      options.metrics ||
-      new MetricsMonitor({ telemetry: options.telemetry, logger: this.logger })
+    this.metrics = options.metrics || new MetricsMonitor({ logger: this.logger })
 
     this.state = 'stopped'
     this.speed = this.metrics.addMeter()

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -1,7 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../assert'
 import { createRootLogger, Logger } from '../logger'
+import { MetricsMonitor } from '../metrics'
 import { Block } from '../primitives/block'
 import { renderError, SetIntervalToken } from '../utils'
 import { WorkerPool } from '../workerPool'
@@ -13,29 +15,35 @@ export class Telemetry {
   private readonly FLUSH_INTERVAL = 5000
   private readonly MAX_POINTS_TO_SUBMIT = 1000
   private readonly MAX_RETRIES = 5
+  private readonly METRICS_INTERVAL = 60 * 1000
 
   private readonly defaultTags: Tag[]
   private readonly defaultFields: Field[]
   private readonly logger: Logger
+  private readonly metrics: MetricsMonitor | null
   private readonly workerPool: WorkerPool
 
   private started: boolean
   private flushInterval: SetIntervalToken | null
+  private metricsInterval: SetIntervalToken | null
   private points: Metric[]
   private retries: number
 
   constructor(options: {
     workerPool: WorkerPool
+    metrics?: MetricsMonitor
     logger?: Logger
     defaultTags?: Tag[]
     defaultFields?: Field[]
   }) {
     this.logger = options.logger ?? createRootLogger()
+    this.metrics = options.metrics ?? null
     this.workerPool = options.workerPool
     this.defaultTags = options.defaultTags ?? []
     this.defaultFields = options.defaultFields ?? []
 
     this.flushInterval = null
+    this.metricsInterval = null
     this.points = []
     this.retries = 0
     this.started = false
@@ -48,6 +56,10 @@ export class Telemetry {
 
     this.started = true
     void this.flushLoop()
+
+    if (this.metrics) {
+      void this.metricsLoop()
+    }
   }
 
   async stop(): Promise<void> {
@@ -61,6 +73,10 @@ export class Telemetry {
       clearTimeout(this.flushInterval)
     }
 
+    if (this.metricsInterval) {
+      clearTimeout(this.metricsInterval)
+    }
+
     this.submitNodeStopped()
     await this.flush()
   }
@@ -71,6 +87,16 @@ export class Telemetry {
     this.flushInterval = setTimeout(() => {
       void this.flushLoop()
     }, this.FLUSH_INTERVAL)
+  }
+
+  private metricsLoop(): void {
+    Assert.isNotNull(this.metrics)
+
+    this.submitMemoryUsage(this.metrics.heapUsed.value, this.metrics.heapTotal.value)
+
+    this.metricsInterval = setTimeout(() => {
+      void this.metricsLoop()
+    }, this.METRICS_INTERVAL)
   }
 
   submit(metric: Metric): void {


### PR DESCRIPTION
## Summary

This code moves the metrics monitor inside the telemetry service so the telemetry service can choose memory data to send on an interval.

## Testing Plan

Existing unit tests and ran node.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
