### PR TITLE
fix(ironfish): Pass in metrics and remove peer network from telemetry

### DIFF
--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -12,10 +12,10 @@ export class MetricsMonitor {
   private _meters: Meter[] = []
   private readonly logger: Logger
 
+  readonly peersCount: Gauge
   readonly p2p_InboundTraffic: Meter
   readonly p2p_InboundTraffic_WS: Meter
   readonly p2p_InboundTraffic_WebRTC: Meter
-
   readonly p2p_OutboundTraffic: Meter
   readonly p2p_OutboundTraffic_WS: Meter
   readonly p2p_OutboundTraffic_WebRTC: Meter
@@ -29,10 +29,10 @@ export class MetricsMonitor {
   constructor({ logger }: { logger?: Logger }) {
     this.logger = logger ?? createRootLogger()
 
+    this.peersCount = new Gauge()
     this.p2p_InboundTraffic = this.addMeter()
     this.p2p_InboundTraffic_WS = this.addMeter()
     this.p2p_InboundTraffic_WebRTC = this.addMeter()
-
     this.p2p_OutboundTraffic = this.addMeter()
     this.p2p_OutboundTraffic_WS = this.addMeter()
     this.p2p_OutboundTraffic_WebRTC = this.addMeter()

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -186,7 +186,10 @@ export class PeerNetwork {
       logPeerMessages,
     )
     this.peerManager.onMessage.on((peer, message) => this.handleMessage(peer, message))
-    this.peerManager.onConnectedPeersChanged.on(() => this.updateIsReady())
+    this.peerManager.onConnectedPeersChanged.on(() => {
+      this.metrics.peersCount.value = this.peerManager.getConnectedPeers().length
+      this.updateIsReady()
+    })
 
     this.peerConnectionManager = new PeerConnectionManager(this.peerManager, this.logger, {
       maxPeers,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -188,17 +188,18 @@ export class IronfishNode {
     strategyClass = strategyClass || Strategy
     const strategy = new strategyClass(workerPool)
 
+    metrics = metrics || new MetricsMonitor({ logger })
+
     const telemetry = new Telemetry({
-      workerPool,
       logger,
+      metrics,
+      workerPool,
       defaultTags: [{ name: 'version', value: pkg.version }],
       defaultFields: [
         { name: 'node_id', type: 'string', value: internal.get('telemetryNodeId') },
         { name: 'session_id', type: 'string', value: uuid() },
       ],
     })
-
-    metrics = metrics || new MetricsMonitor({ logger })
 
     const chain = new Blockchain({
       location: config.chainDatabasePath,

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -4,7 +4,6 @@
 import { Assert } from '../assert'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
-import { PeerNetwork } from '../network'
 import { Block } from '../primitives/block'
 import { renderError, SetIntervalToken } from '../utils'
 import { WorkerPool } from '../workerPool'
@@ -22,7 +21,6 @@ export class Telemetry {
   private readonly defaultFields: Field[]
   private readonly logger: Logger
   private readonly metrics: MetricsMonitor | null
-  private readonly peerNetwork: PeerNetwork | null
   private readonly workerPool: WorkerPool
 
   private started: boolean
@@ -34,14 +32,12 @@ export class Telemetry {
   constructor(options: {
     workerPool: WorkerPool
     metrics?: MetricsMonitor
-    peerNetwork?: PeerNetwork
     logger?: Logger
     defaultTags?: Tag[]
     defaultFields?: Field[]
   }) {
     this.logger = options.logger ?? createRootLogger()
     this.metrics = options.metrics ?? null
-    this.peerNetwork = options.peerNetwork ?? null
     this.workerPool = options.workerPool
     this.defaultTags = options.defaultTags ?? []
     this.defaultFields = options.defaultFields ?? []
@@ -96,40 +92,35 @@ export class Telemetry {
   private metricsLoop(): void {
     Assert.isNotNull(this.metrics)
 
-    const fields: Field[] = [
-      {
-        name: 'heap_used',
-        type: 'integer',
-        value: this.metrics.heapUsed.value,
-      },
-      {
-        name: 'heap_used',
-        type: 'integer',
-        value: this.metrics.heapUsed.value,
-      },
-      {
-        name: 'inbound_traffic',
-        type: 'integer',
-        value: this.metrics.p2p_InboundTraffic.rate1s,
-      },
-      {
-        name: 'outbound_traffic',
-        type: 'integer',
-        value: this.metrics.p2p_OutboundTraffic.rate1s,
-      },
-    ]
-
-    if (this.peerNetwork) {
-      fields.push({
-        name: 'peers_count',
-        type: 'integer',
-        value: this.peerNetwork.peerManager.getConnectedPeers().length,
-      })
-    }
-
     this.submit({
       measurement: 'node_stats',
-      fields,
+      fields: [
+        {
+          name: 'heap_used',
+          type: 'integer',
+          value: this.metrics.heapUsed.value,
+        },
+        {
+          name: 'heap_total',
+          type: 'integer',
+          value: this.metrics.heapTotal.value,
+        },
+        {
+          name: 'inbound_traffic',
+          type: 'float',
+          value: this.metrics.p2p_InboundTraffic.rate1s,
+        },
+        {
+          name: 'outbound_traffic',
+          type: 'float',
+          value: this.metrics.p2p_OutboundTraffic.rate1s,
+        },
+        {
+          name: 'peers_count',
+          type: 'integer',
+          value: this.metrics.peersCount.value,
+        },
+      ],
     })
 
     this.metricsInterval = setTimeout(() => {


### PR DESCRIPTION
## Summary

The peer network and metrics from the node are [not passed](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/node.ts#L191-L199) into the telemetry service, so traffic, peer counts, and heap usage are not collected. This code change fixes the dependencies (and refactors how this data is passed through to the API).

Changes:

1. Fix [duplicate](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/telemetry/telemetry.ts#L100-L109) heap usage and send [heap total](https://github.com/iron-fish/ironfish/blob/81bb9395723f9293d8a665c7f776e186b28919b0/ironfish/src/telemetry/telemetry.ts#L98-L107)
1. Change types in traffic fields to [float](https://github.com/iron-fish/ironfish/blob/81bb9395723f9293d8a665c7f776e186b28919b0/ironfish/src/telemetry/telemetry.ts#L108-L117)
1. Fetch peer counts from a [gauge](https://github.com/iron-fish/ironfish/blob/81bb9395723f9293d8a665c7f776e186b28919b0/ironfish/src/telemetry/telemetry.ts#L121) in the metrics monitor

There were a couple considerations in removing the peer network as an argument in the telemetry constructor:
* There is [coupling](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/node.ts#L110) between the peer network and node. That can be refactored in the future, but this means the peer network cannot be created in the [`init`](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/node.ts#L131) method.
* Moving the telemetry service to the node's constructor makes dependencies difficult. The mining director [requires telemetry](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/node.ts#L224) on creation. If the mining director is moved to the node's constructor, there are [circular dependencies](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/node.ts#L96-L125) between the syncer, peer network, telemetry, and mining director. 
* The mining director has to be created before the peer network to avoid an undefined dereference on [`onNewBlock`](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/network/peerNetwork.ts#L269-L271).

The considerations to use a gauge in the metric monitor:
* This [call](https://github.com/iron-fish/ironfish/blob/81bb9395723f9293d8a665c7f776e186b28919b0/ironfish/src/network/peerNetwork.ts#L190) could have been a method the telemetry service exposes. However, this would cause points to be submitted on every connect / disconnect state transition (which seems more granular / frequent than what we want).
* The metric monitor already is present in the peer network, so adding a gauge that is updated and processed as the telemetry service decides seemed like the cleanest option.

## Testing Plan

Ran node and verified points were present in Influx.

<img width="502" alt="Screen Shot 2022-02-17 at 12 53 42 AM" src="https://user-images.githubusercontent.com/5459049/154414096-c48d1ba5-5c93-4616-b5da-6cadc16afa9f.png">

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
