### PR TITLE
feat(ironfish): Update telemetry flush and metrics intervals to 5m

### DIFF
--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -16,7 +16,7 @@ export class Telemetry {
   private readonly FLUSH_INTERVAL = 5 * 60 * 1000
   private readonly MAX_POINTS_TO_SUBMIT = 1000
   private readonly MAX_RETRIES = 5
-  private readonly METRICS_INTERVAL = 60 * 1000
+  private readonly METRICS_INTERVAL = 5 * 60 * 1000
 
   private readonly defaultTags: Tag[]
   private readonly defaultFields: Field[]

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -13,7 +13,7 @@ import { Metric } from './interfaces/metric'
 import { Tag } from './interfaces/tag'
 
 export class Telemetry {
-  private readonly FLUSH_INTERVAL = 60 * 1000
+  private readonly FLUSH_INTERVAL = 5 * 60 * 1000
   private readonly MAX_POINTS_TO_SUBMIT = 1000
   private readonly MAX_RETRIES = 5
   private readonly METRICS_INTERVAL = 60 * 1000

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -13,7 +13,7 @@ import { Metric } from './interfaces/metric'
 import { Tag } from './interfaces/tag'
 
 export class Telemetry {
-  private readonly FLUSH_INTERVAL = 5000
+  private readonly FLUSH_INTERVAL = 60 * 1000
   private readonly MAX_POINTS_TO_SUBMIT = 1000
   private readonly MAX_RETRIES = 5
   private readonly METRICS_INTERVAL = 60 * 1000


### PR DESCRIPTION
## Summary

We can reduce the frequency to flush telemetry points to the API.

## Testing Plan

Manually tested and ran the node.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
