### PR TITLE
Allow config:edit to reference the config

### DIFF
--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -35,7 +35,7 @@ export class EditCommand extends IronfishCommand {
     if (!flags.remote) {
       const configPath = this.sdk.config.storage.configPath
       this.log(`Editing ${configPath}`)
-      const code = await launchEditor(configPath)
+      const code = await launchEditor(configPath, this.sdk.config)
       this.exit(code || undefined)
     }
 
@@ -48,7 +48,7 @@ export class EditCommand extends IronfishCommand {
     const filePath = path.join(folderPath, DEFAULT_CONFIG_NAME)
 
     await writeFileAsync(filePath, output)
-    const code = await launchEditor(filePath)
+    const code = await launchEditor(filePath, this.sdk.config)
 
     if (code !== 0) {
       this.exit(code || undefined)


### PR DESCRIPTION
## Summary

Pass config into `launchEditor` so it can fall back to config key `editor` if `$EDITOR` is not picked up

Fixes #964 

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
