### PR TITLE
Change getStatus() RPC to use new metrics gauge

### DIFF
--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -169,11 +169,9 @@ router.register<typeof GetStatusRequestSchema, GetStatusResponse>(
 )
 
 function getStatus(node: IronfishNode): GetStatusResponse {
-  const peers = node.peerNetwork.peerManager.getConnectedPeers()
-
   const status: GetStatusResponse = {
     peerNetwork: {
-      peers: peers.length,
+      peers: node.metrics.p2p_PeersCount.value,
       isReady: node.peerNetwork.isReady,
       inboundTraffic: Math.max(node.metrics.p2p_InboundTraffic.rate1s, 0),
       outboundTraffic: Math.max(node.metrics.p2p_OutboundTraffic.rate1s, 0),


### PR DESCRIPTION
## Summary
Use the new gauge so we don't have to actually call getConnectedPeers() in the status RPC

## Testing Plan
Run the node and status and watch peer count change

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
