### PR TITLE
Faucet improvements (fix bug #961)

### DIFF
--- a/ironfish-cli/.yarnrc
+++ b/ironfish-cli/.yarnrc
@@ -1,0 +1,1 @@
+--silent true

--- a/ironfish-cli/.yarnrc
+++ b/ironfish-cli/.yarnrc
@@ -1,1 +1,0 @@
---silent true

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -41,7 +41,7 @@ export class FaucetCommand extends IronfishCommand {
 
     if (!email) {
       email = (await CliUx.ux.prompt('Enter your email to stay updated with Iron Fish', {
-        required: false,
+        required: true,
       })) as string
     }
 
@@ -75,6 +75,13 @@ export class FaucetCommand extends IronfishCommand {
     } catch (error: unknown) {
       if (error instanceof RequestError) {
         CliUx.ux.action.stop(error.codeMessage)
+
+        if (
+          error.codeMessage === 'faucet_max_requests_reached' ||
+          error.codeMessage === 'You entered an invalid email.'
+        ) {
+          this.exit(0)
+        }
       } else {
         CliUx.ux.action.stop(
           'Unfortunately, the faucet request failed. Please try again later.',

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -40,9 +40,10 @@ export class FaucetCommand extends IronfishCommand {
     let email = flags.email
 
     if (!email) {
-      email = (await CliUx.ux.prompt('Enter your email to stay updated with Iron Fish', {
-        required: true,
-      })) as string
+      email =
+        ((await CliUx.ux.prompt('Enter your email to stay updated with Iron Fish', {
+          required: false,
+        })) as string) || undefined
     }
 
     // Create an account if one is not set
@@ -75,13 +76,6 @@ export class FaucetCommand extends IronfishCommand {
     } catch (error: unknown) {
       if (error instanceof RequestError) {
         CliUx.ux.action.stop(error.codeMessage)
-
-        if (
-          error.codeMessage === 'Too many faucet requests' ||
-          error.codeMessage === 'You entered an invalid email.'
-        ) {
-          this.exit(0)
-        }
       } else {
         CliUx.ux.action.stop(
           'Unfortunately, the faucet request failed. Please try again later.',

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -77,7 +77,7 @@ export class FaucetCommand extends IronfishCommand {
         CliUx.ux.action.stop(error.codeMessage)
 
         if (
-          error.codeMessage === 'faucet_max_requests_reached' ||
+          error.codeMessage === 'Too many faucet requests' ||
           error.codeMessage === 'You entered an invalid email.'
         ) {
           this.exit(0)


### PR DESCRIPTION
Improve Faucet
- email should be a required flag in the CLI prompt (because it is required by the client)
- `Too many faucet requests` and `You entered an invalid email.` errors result in `error Command failed with exit code 1.`, as seen in https://github.com/iron-fish/ironfish/issues/961. Improve error handling to exit gracefully here.

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
