### PR TITLE
Fix parse error for hosts.json

### DIFF
--- a/ironfish/src/fileStores/hosts.ts
+++ b/ironfish/src/fileStores/hosts.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createRootLogger, Logger, ParseJsonError } from '..'
 import { FileSystem } from '../fileSystems'
 import { PeerAddress } from '../network/peers/peerAddress'
 import { KeyStore } from './keyStore'
@@ -16,7 +17,23 @@ export const HostOptionsDefaults: HostsOptions = {
 }
 
 export class HostsStore extends KeyStore<HostsOptions> {
+  logger: Logger
+
   constructor(files: FileSystem, dataDir?: string, configName?: string) {
     super(files, configName || 'hosts.json', HostOptionsDefaults, dataDir)
+    this.logger = createRootLogger()
+  }
+
+  async load(): Promise<void> {
+    try {
+      await super.load()
+    } catch (e) {
+      if (e instanceof ParseJsonError) {
+        this.logger.warn(`Error: Could not parse JSON at ${this.storage.configPath}`)
+        await super.save()
+      } else {
+        throw e
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
There's been some reports of a JSON parse error when reading `hosts.json`; it looks like a null Unicode marker or empty string is being written. While we investigate why that may be happening, it may be prudent to allow for the node to continue to start if there's an error. Thus, for the `hostsStore` class, we try to load `hosts.json` and if there's a `ParseJsonError`, then we get rid of the corrupted content by overwriting with a valid JSON structure (this file is meant to be ephemeral anyways).

## Testing Plan
All tests pass. Additionally, I tested the parsing with a correctly-formed file, an incorrectly-formed file, and a nonexistent file.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
