### PR TITLE
feat(ironfish): Add mempool size to metrics monitor

### DIFF
--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -22,7 +22,9 @@ export class MetricsMonitor {
 
   readonly heapTotal: Gauge
   readonly heapUsed: Gauge
+  readonly memPoolSize: Gauge
   readonly rss: Gauge
+
   private memoryInterval: SetIntervalToken | null
   private readonly memoryRefreshPeriodMs = 1000
 
@@ -40,6 +42,7 @@ export class MetricsMonitor {
     this.heapTotal = new Gauge()
     this.heapUsed = new Gauge()
     this.rss = new Gauge()
+    this.memPoolSize = new Gauge()
     this.memoryInterval = null
   }
 

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -209,7 +209,7 @@ export class IronfishNode {
       autoSeed,
     })
 
-    const memPool = new MemPool({ chain: chain, strategy, logger: logger })
+    const memPool = new MemPool({ chain, metrics, strategy, logger })
 
     const accountDB = new AccountsDB({
       location: config.accountDatabasePath,

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -198,7 +198,7 @@ function getStatus(node: IronfishNode): GetStatusResponse {
       blocks: node.miningDirector.blocksMined,
     },
     memPool: {
-      size: node.memPool.size(),
+      size: node.metrics.memPoolSize.value,
     },
     blockSyncer: {
       status: node.syncer.state,


### PR DESCRIPTION
## Summary

This code change adds the node's mempool size into the metrics monitor and pulls this new value instead in the status command.

## Testing Plan

Manually tested

![Screen Shot 2022-02-23 at 1 37 00 PM](https://user-images.githubusercontent.com/5459049/155385207-b8ca9787-ca53-429c-b9ec-30e6c4e8095f.png)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
