### PR TITLE
Add a field for pasting `debug` command output to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -25,6 +25,12 @@ body:
       description: What version of our software are you running?
       placeholder: ex. v0.0.0
   - type: textarea
+    id: debug
+    attributes:
+      label: Debug output
+      description: Please copy and paste the output of `ironfish debug` / `yarn start:once debug` (same as you run any other `ironfish` commands).  This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
     id: logs
     attributes:
       label: Relevant log output


### PR DESCRIPTION
## Summary

Just more data to help triage issues faster by adding a field for `debug` output in the bug template.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
