### PR TITLE
Ensure quit message text is shown for chain:forks

### DIFF
--- a/ironfish-cli/src/commands/chain/forks.ts
+++ b/ironfish-cli/src/commands/chain/forks.ts
@@ -48,14 +48,12 @@ export default class ForksCommand extends IronfishCommand {
 
     const footer = blessed.text({
       bottom: 0,
-      parent: screen,
       content: 'Press Q to quit',
     })
 
     setInterval(() => {
       const now = Date.now()
 
-      footer.clearBaseLine(0)
       status.clearBaseLine(0)
       list.clearBaseLine(0)
       list.setContent('')
@@ -85,6 +83,8 @@ export default class ForksCommand extends IronfishCommand {
       }
 
       status.setContent(`Node: ${String(connected)}, Forks: ${count.toString().padEnd(2, ' ')}`)
+
+      screen.append(footer)
 
       screen.render()
     }, 1000)


### PR DESCRIPTION
## Summary
As seen in https://github.com/iron-fish/ironfish/issues/996, running the `chain:forks` command appears to be unresponsive to users and they are unable to quit. The command is responsive and does in fact work, but the message text `Press Q to quit` does not appear on the bottom of the window as intended. It seems that calling `footer.clearBaseLine(0)` removes the message from the content.

## Testing Plan
All tests pass. Ensured that the message appears as intended on several different terminal emulators.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
