### PR TITLE
Show telemetry counts in status

### DIFF
--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -24,7 +24,7 @@ describe('status', () => {
     miningDirector: { status: 'stopped', miners: 0, blocks: 0 },
     memPool: { size: 0 },
     blockSyncer: { status: 'stopped', syncing: { blockSpeed: 0, speed: 0 } },
-    telemetry: { status: 'stopped' },
+    telemetry: { status: 'stopped', pending: 0, submitted: 0 },
     workers: {
       started: true,
       workers: 1,

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -62,7 +62,7 @@ export default class Status extends IronfishCommand {
 
 function renderStatus(content: GetStatusResponse): string {
   const nodeStatus = `${content.node.status.toUpperCase()}`
-  const telemetryStatus = `${content.telemetry.status.toUpperCase()}`
+  let telemetryStatus = `${content.telemetry.status.toUpperCase()}`
   const heapTotal = FileUtils.formatMemorySize(content.memory.heapTotal)
   const heapUsed = FileUtils.formatMemorySize(content.memory.heapUsed)
   const rss = FileUtils.formatMemorySize(content.memory.rss)
@@ -74,6 +74,10 @@ function renderStatus(content: GetStatusResponse): string {
   const speed = content.blockSyncer.syncing.speed
   if (content.blockSyncer.status !== 'IDLE') {
     blockSyncerStatus += ` @ ${speed} blocks per seconds`
+  }
+
+  if (content.telemetry.status === 'started') {
+    telemetryStatus += ` - ${content.telemetry.submitted} <- ${content.telemetry.pending} pending`
   }
 
   if (avgTimeToAddBlock) {

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -49,7 +49,9 @@ export type GetStatusResponse = {
     outboundTraffic: number
   }
   telemetry: {
-    status: string
+    status: 'started' | 'stopped'
+    pending: number
+    submitted: number
   }
   workers: {
     started: boolean
@@ -126,6 +128,8 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
     telemetry: yup
       .object({
         status: yup.string().oneOf(['started', 'stopped']).defined(),
+        pending: yup.number().defined(),
+        submitted: yup.number().defined(),
       })
       .defined(),
     workers: yup
@@ -209,6 +213,8 @@ function getStatus(node: IronfishNode): GetStatusResponse {
     },
     telemetry: {
       status: node.telemetry.isStarted() ? 'started' : 'stopped',
+      pending: node.telemetry.pending,
+      submitted: node.telemetry.submitted,
     },
     workers: {
       started: node.workerPool.started,

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -28,6 +28,7 @@ export class Telemetry {
   private metricsInterval: SetIntervalToken | null
   private points: Metric[]
   private retries: number
+  private _submitted: number
 
   constructor(options: {
     workerPool: WorkerPool
@@ -46,7 +47,16 @@ export class Telemetry {
     this.metricsInterval = null
     this.points = []
     this.retries = 0
+    this._submitted = 0
     this.started = false
+  }
+
+  get pending(): number {
+    return this.points.length
+  }
+
+  get submitted(): number {
+    return this._submitted
   }
 
   start(): void {
@@ -168,6 +178,7 @@ export class Telemetry {
       await this.workerPool.submitTelemetry(points)
       this.logger.debug(`Submitted ${points.length} telemetry points`)
       this.retries = 0
+      this._submitted += points.length
     } catch (error: unknown) {
       this.logger.error(`Error submitting telemetry to API: ${renderError(error)}`)
 


### PR DESCRIPTION
## Summary
This will show the pending and submitted counts in status

```
> ironfish status

Version              0.1.24 @ src
Node                 STARTED
Heap Used            36.66 MiB / 38.86 MiB
Memory               632.40 MiB
P2P Network          CONNECTED - In: 3.01 KB/s, Out: 6.34 KB/s, peers 34
Mining               STOPPED - 0 miners, 0 mined
Mem Pool             0 tx
Syncer               IDLE @ 0.03 blocks per seconds | avg time to add block 18.3 ms
Blockchain           SYNCED @ HEAD 000000000000f195f34bd5b6e375b8fb2d9560137a6a2edda25dbf04740d25fd (126775)
Telemetry            STARTED - 6 <- 3 pending
Workers              STARTED - 0 -> 0 / 6 - 0 jobs Δ, 10.96 jobs/s
```
## Testing Plan
Run status

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
