### PR TITLE
Consolidate memory status

### DIFF
--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -20,6 +20,8 @@ describe('status', () => {
       heapTotal: 2,
       heapUsed: 1,
       rss: 3,
+      memFree: 4,
+      memTotal: 10,
     },
     miningDirector: { status: 'stopped', miners: 0, blocks: 0 },
     memPool: { size: 0 },
@@ -71,7 +73,6 @@ describe('status', () => {
       .it('logs out data for the chain, node, mempool, and syncer', (ctx) => {
         expectCli(ctx.stdout).include('Version')
         expectCli(ctx.stdout).include('Node')
-        expectCli(ctx.stdout).include('Heap Used')
         expectCli(ctx.stdout).include('Memory')
         expectCli(ctx.stdout).include('P2P Network')
         expectCli(ctx.stdout).include('Mining')

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -63,9 +63,6 @@ export default class Status extends IronfishCommand {
 function renderStatus(content: GetStatusResponse): string {
   const nodeStatus = `${content.node.status.toUpperCase()}`
   let telemetryStatus = `${content.telemetry.status.toUpperCase()}`
-  const heapTotal = FileUtils.formatMemorySize(content.memory.heapTotal)
-  const heapUsed = FileUtils.formatMemorySize(content.memory.heapUsed)
-  const rss = FileUtils.formatMemorySize(content.memory.rss)
   let blockSyncerStatus = content.blockSyncer.status.toString().toUpperCase()
 
   Assert.isNotUndefined(content.blockSyncer.syncing)
@@ -108,11 +105,26 @@ function renderStatus(content: GetStatusResponse): string {
     workersStatus += ` - ${content.workers.queued} -> ${content.workers.executing} / ${content.workers.capacity} - ${content.workers.change} jobs Δ, ${content.workers.speed} jobs/s`
   }
 
+  const heapTotal = FileUtils.formatMemorySize(content.memory.heapTotal)
+  const heapUsed = FileUtils.formatMemorySize(content.memory.heapUsed)
+  const rss = FileUtils.formatMemorySize(content.memory.rss)
+  const memFree = FileUtils.formatMemorySize(content.memory.memFree)
+
+  const memoryStatus = `Heap: ${heapUsed} / ${heapTotal} (${(
+    (content.memory.heapUsed / content.memory.heapTotal) *
+    100
+  ).toFixed(1)}%), RSS: ${rss} (${(
+    (content.memory.rss / content.memory.memTotal) *
+    100
+  ).toFixed(1)}%), Free: ${memFree} (${(
+    (1 - content.memory.memFree / content.memory.memTotal) *
+    100
+  ).toFixed(1)}%)`
+
   return `
 Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
-Heap Used            ${heapUsed} / ${heapTotal}
-Memory               ${rss}
+Memory               ${memoryStatus}
 P2P Network          ${peerNetworkStatus}
 Mining               ${miningDirectorStatus}
 Mem Pool             ${memPoolStatus}

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import os from 'os'
 import { createRootLogger, Logger } from '../logger'
 import { SetIntervalToken } from '../utils'
 import { Gauge } from './gauge'
@@ -24,6 +25,8 @@ export class MetricsMonitor {
   readonly heapUsed: Gauge
   readonly memPoolSize: Gauge
   readonly rss: Gauge
+  readonly memFree: Gauge
+  readonly memTotal: number
 
   private memoryInterval: SetIntervalToken | null
   private readonly memoryRefreshPeriodMs = 1000
@@ -42,6 +45,8 @@ export class MetricsMonitor {
     this.heapTotal = new Gauge()
     this.heapUsed = new Gauge()
     this.rss = new Gauge()
+    this.memFree = new Gauge()
+    this.memTotal = os.totalmem()
     this.memPoolSize = new Gauge()
     this.memoryInterval = null
   }
@@ -80,5 +85,6 @@ export class MetricsMonitor {
     this.heapTotal.value = memoryUsage.heapTotal
     this.heapUsed.value = memoryUsage.heapUsed
     this.rss.value = memoryUsage.rss
+    this.memFree.value = os.freemem()
   }
 }

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -22,6 +22,8 @@ export type GetStatusResponse = {
     heapTotal: number
     heapUsed: number
     rss: number
+    memFree: number
+    memTotal: number
   }
   miningDirector: {
     status: 'started' | 'stopped'
@@ -85,6 +87,8 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
         heapTotal: yup.number().defined(),
         heapUsed: yup.number().defined(),
         rss: yup.number().defined(),
+        memFree: yup.number().defined(),
+        memTotal: yup.number().defined(),
       })
       .defined(),
     miningDirector: yup
@@ -195,6 +199,8 @@ function getStatus(node: IronfishNode): GetStatusResponse {
       heapTotal: node.metrics.heapTotal.value,
       heapUsed: node.metrics.heapUsed.value,
       rss: node.metrics.rss.value,
+      memFree: node.metrics.memFree.value,
+      memTotal: node.metrics.memTotal,
     },
     miningDirector: {
       status: node.miningDirector.isStarted() ? 'started' : 'stopped',


### PR DESCRIPTION
## Summary

I consolidated the memory status line into 1 line, and now report it as
heap, rss, avialable. This will be useful to see how much memory people
have on their machines when they report out of memory bugs or crashes
when they paste their status.

```
> ironfish status

Version              0.1.24 @ src
Node                 STARTED
Memory               Heap: 43.07 MiB / 58.11 MiB (74.1%), RSS: 679.09 MiB (1.0%), Free: 14.60 GiB (77.2%)
P2P Network          CONNECTED - In: 144.96 KB/s, Out: 12.65 KB/s, peers 49
Mining               STOPPED - 0 miners, 0 mined
Mem Pool             0 tx
Syncer               IDLE @ 0 blocks per seconds | avg time to add block 25.59 ms
Blockchain           SYNCED @ HEAD 000000000001c44b37ec468d723b2b5367fb51d8bf90031fa96a3e16e1f2f615 (126819)
Telemetry            STARTED - 32 <- 4 pending
Workers              STARTED - 0 -> 0 / 6 - 0 jobs Δ, 0 jobs/s
```

## Testing Plan
Run status

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
