### PR TITLE
Fix block syncer status

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -72,7 +72,8 @@ function renderStatus(content: GetStatusResponse): string {
 
   const avgTimeToAddBlock = content.blockSyncer.syncing.blockSpeed
   const speed = content.blockSyncer.syncing.speed
-  if (content.blockSyncer.status !== 'IDLE') {
+
+  if (content.blockSyncer.status !== 'idle') {
     blockSyncerStatus += ` @ ${speed} blocks per seconds`
   }
 

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -115,7 +115,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
       .defined(),
     blockSyncer: yup
       .object({
-        status: yup.string().oneOf(['started', 'stopped', 'error']).defined(),
+        status: yup.string().oneOf(['stopped', 'idle', 'stopping', 'syncing']).defined(),
         error: yup.string().optional(),
         syncing: yup
           .object({

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -36,7 +36,7 @@ export type GetStatusResponse = {
     head: string
   }
   blockSyncer: {
-    status: string
+    status: 'stopped' | 'idle' | 'stopping' | 'syncing'
     syncing?: {
       blockSpeed: number
       speed: number


### PR DESCRIPTION
## Summary

Tech PR to fix wrong usage of type system: 
1. GetStatusResponseSchema::blockSyncer.status has wrong list of possible values
1. GetStatusResponse::blockSyncer.status was `string` instead of union of literals. Because of which condition [`content.blockSyncer.status === 'IDLE'`](https://github.com/iron-fish/ironfish/blob/1f3dc311c6db990313f81ae7d8046d19e8b2ce93/ironfish-cli/src/commands/status.ts#L75) was always false - content.blockSyncer.status could be `idle` but not `IDLE`.

## Testing Plan
Run `yearn test`. 


## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```