### PR TITLE
Properly propagate job error stack

### DIFF
--- a/ironfish/src/workerPool/errors.ts
+++ b/ironfish/src/workerPool/errors.ts
@@ -22,9 +22,18 @@ export class JobError extends Error {
       this.type =
         typeof error === 'object' ? error?.constructor.name ?? typeof error : 'unknown'
 
+      this.code = undefined
+      this.stack = undefined
       this.message = ErrorUtils.renderError(error)
-      this.stack = ErrorUtils.isNodeError(error) ? error.stack : undefined
-      this.code = ErrorUtils.isNodeError(error) ? error.code : undefined
+
+      if (error instanceof Error) {
+        this.code = error.name
+        this.stack = error.stack
+
+        if (ErrorUtils.isNodeError(error)) {
+          this.code = error.code
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Stacks from job errors were not being properly assigned and propagated through the RPC layer. This change should allow us to identify potential sources of errors more quickly.

## Testing Plan
Threw an error in one of the worker pool tasks and called said task. Ran through a debugger and made sure that the stack is available.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
