### PR TITLE
Make IpcAdapter.stop() destroy all sockets

### DIFF
--- a/ironfish/src/assert.ts
+++ b/ironfish/src/assert.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Constructor } from './utils/types'
+
 export class Assert {
   static isUnreachable(x: never): never {
     throw new Error(x)
@@ -49,6 +51,16 @@ export class Assert {
 
   static isFalse(x: boolean, message?: string): asserts x is false {
     if (x === true) {
+      throw new Error(message || `Expected value to be false`)
+    }
+  }
+
+  static isInstanceOf<T>(
+    x: unknown,
+    constructor: Constructor<T>,
+    message?: string,
+  ): asserts x is T {
+    if (!(x instanceof constructor)) {
       throw new Error(message || `Expected value to be false`)
     }
   }

--- a/ironfish/src/rpc/adapters/ipcAdapter.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import net from 'net'
 import { IPC, IpcServer, IpcSocket, IpcSocketId } from 'node-ipc'
 import { v4 as uuid } from 'uuid'
 import * as yup from 'yup'
@@ -155,10 +156,14 @@ export class IpcAdapter implements IAdapter {
   async stop(): Promise<void> {
     if (this.started && this.ipc) {
       this.ipc.server.stop()
+
+      for (const socket of this.ipc.server.sockets) {
+        Assert.isInstanceOf(socket, net.Socket)
+        socket.destroy()
+      }
+
       await this.waitForAllToDisconnect()
     }
-
-    return Promise.resolve()
   }
 
   async waitForAllToDisconnect(): Promise<void> {

--- a/ironfish/src/typedefs/node-ipc.d.ts
+++ b/ironfish/src/typedefs/node-ipc.d.ts
@@ -18,38 +18,28 @@ declare module 'event-pubsub' {
 }
 
 declare module 'node-ipc' {
+  import net from 'net'
+  import dgram from 'dgram'
   import EventPubSub from 'event-pubsub'
 
-  export type UdpSocket = unknown
   export type IpcSocketId = string
 
   export type IpcSocket = {
     id: IpcSocketId | undefined
     ipcBuffer: string | undefined
-
-    emit(event: name, data: unknown)
-    write(data: unknown)
-    setEncoding(encoding: string)
-
-    on(name: 'connect', callback: () => void): void
-    on(name: 'close', callback: (socket: UdpSocket | false) => void): void
-    on(name: 'error', callback: (err: unknown) => void): void
-    on(name: 'data', callback: (data: unknown, socket: UdpSocket) => void): void
-    on(name: 'message', callback: (message: unknown, rinfo?: unknown) => void): void
-
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    off(name: string, callback: Function): void
-  }
+  } & (net.Socket | dgram.Socket)
 
   export class IpcServer extends EventPubSub {
     sockets: IpcSocket[]
     start(): void
     stop(): void
+    server: net.Server | dgram.Socket
 
     on(name: 'start', callback: (socket: IpcSocket) => void): void
     on(name: 'data', callback: (data: unknown, socket: IpcSocket) => void): void
     on(name: 'error', callback: (error: unknown) => void): void
     on(name: 'connect', callback: (socket: IpcSocket) => void): void
+    on(name: 'close', callback: (hasError?: boolean) => void): void
     on(
       name: 'socket.disconnected',
       callback: (socket: IpcSocket, destroyedSocketId: IpcSocketId | false) => void,


### PR DESCRIPTION
## Summary
This bug is surfacing because rpc.Stop() is hanging forever, because
underneath is stops all the current adapters. When the IpcAdapter tries
to stop, it waits for all the connections to end. The problem is that
IpcServer.stop() doesn't termiante the connections. This new change will
terminate the underlying connections causing all the connections to end,
thus stopping IpcAdapter.stop() from hanging.

This was first documented in this PR, which a hack was added just to
ignore RPC stop in this case.

https://github.com/iron-fish/ironfish/pull/1011

## Testing Plan
Ran the RPC layer with the node

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
