### PR TITLE
Add syncing progress to status

### DIFF
--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -25,7 +25,7 @@ describe('status', () => {
     },
     miningDirector: { status: 'stopped', miners: 0, blocks: 0 },
     memPool: { size: 0 },
-    blockSyncer: { status: 'stopped', syncing: { blockSpeed: 0, speed: 0 } },
+    blockSyncer: { status: 'stopped', syncing: { blockSpeed: 0, speed: 0, progress: 0 } },
     telemetry: { status: 'stopped', pending: 0, submitted: 0 },
     workers: {
       started: true,

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -64,14 +64,15 @@ function renderStatus(content: GetStatusResponse): string {
   const nodeStatus = `${content.node.status.toUpperCase()}`
   let telemetryStatus = `${content.telemetry.status.toUpperCase()}`
   let blockSyncerStatus = content.blockSyncer.status.toString().toUpperCase()
+  const blockSyncerStatusDetails: string[] = []
 
   Assert.isNotUndefined(content.blockSyncer.syncing)
 
   const avgTimeToAddBlock = content.blockSyncer.syncing.blockSpeed
   const speed = content.blockSyncer.syncing.speed
 
-  if (content.blockSyncer.status !== 'idle') {
-    blockSyncerStatus += ` @ ${speed} blocks per seconds`
+  if (content.blockSyncer.status === 'syncing') {
+    blockSyncerStatusDetails.push(`${speed} blocks per seconds`)
   }
 
   if (content.telemetry.status === 'started') {
@@ -79,12 +80,14 @@ function renderStatus(content: GetStatusResponse): string {
   }
 
   if (avgTimeToAddBlock) {
-    blockSyncerStatus += ` | avg time to add block ${avgTimeToAddBlock} ms`
+    blockSyncerStatusDetails.push(`avg time to add block ${avgTimeToAddBlock} ms`)
   }
 
   if (content.blockSyncer.status === 'syncing') {
-    blockSyncerStatus += `, progress: ${(content.blockSyncer.syncing.progress * 100).toFixed(2)}%`
+    blockSyncerStatusDetails.push(`progress: ${(content.blockSyncer.syncing.progress * 100).toFixed(2)}%`)
   }
+
+  blockSyncerStatus += blockSyncerStatusDetails.length > 0 ? ` - ${blockSyncerStatusDetails.join(', ')}` : ''
 
   const peerNetworkStatus = `${
     content.peerNetwork.isReady ? 'CONNECTED' : 'WAITING'

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -79,10 +79,14 @@ function renderStatus(content: GetStatusResponse): string {
   }
 
   if (content.blockSyncer.status === 'syncing') {
-    blockSyncerStatusDetails.push(`progress: ${(content.blockSyncer.syncing.progress * 100).toFixed(2)}%`)
+    blockSyncerStatusDetails.push(
+      `progress: ${(content.blockSyncer.syncing.progress * 100).toFixed(2)}%`,
+    )
   }
 
-  blockSyncerStatus += blockSyncerStatusDetails.length > 0 ? ` - ${blockSyncerStatusDetails.join(', ')}` : ''
+  blockSyncerStatus += blockSyncerStatusDetails.length
+    ? ` - ${blockSyncerStatusDetails.join(', ')}`
+    : ''
 
   if (content.telemetry.status === 'started') {
     telemetryStatus += ` - ${content.telemetry.submitted} <- ${content.telemetry.pending} pending`

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -82,6 +82,10 @@ function renderStatus(content: GetStatusResponse): string {
     blockSyncerStatus += ` | avg time to add block ${avgTimeToAddBlock} ms`
   }
 
+  if (content.blockSyncer.status === 'syncing') {
+    blockSyncerStatus += `, progress: ${(content.blockSyncer.syncing.progress * 100).toFixed(2)}%`
+  }
+
   const peerNetworkStatus = `${
     content.peerNetwork.isReady ? 'CONNECTED' : 'WAITING'
   } - In: ${FileUtils.formatFileSize(

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -62,9 +62,9 @@ export default class Status extends IronfishCommand {
 
 function renderStatus(content: GetStatusResponse): string {
   const nodeStatus = `${content.node.status.toUpperCase()}`
-  let telemetryStatus = `${content.telemetry.status.toUpperCase()}`
   let blockSyncerStatus = content.blockSyncer.status.toString().toUpperCase()
   const blockSyncerStatusDetails: string[] = []
+  let telemetryStatus = `${content.telemetry.status.toUpperCase()}`
 
   Assert.isNotUndefined(content.blockSyncer.syncing)
 
@@ -73,10 +73,6 @@ function renderStatus(content: GetStatusResponse): string {
 
   if (content.blockSyncer.status === 'syncing') {
     blockSyncerStatusDetails.push(`${speed} blocks per seconds`)
-  }
-
-  if (content.telemetry.status === 'started') {
-    telemetryStatus += ` - ${content.telemetry.submitted} <- ${content.telemetry.pending} pending`
   }
 
   if (avgTimeToAddBlock) {
@@ -88,6 +84,10 @@ function renderStatus(content: GetStatusResponse): string {
   }
 
   blockSyncerStatus += blockSyncerStatusDetails.length > 0 ? ` - ${blockSyncerStatusDetails.join(', ')}` : ''
+
+  if (content.telemetry.status === 'started') {
+    telemetryStatus += ` - ${content.telemetry.submitted} <- ${content.telemetry.pending} pending`
+  }
 
   const peerNetworkStatus = `${
     content.peerNetwork.isReady ? 'CONNECTED' : 'WAITING'

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -69,10 +69,9 @@ function renderStatus(content: GetStatusResponse): string {
   Assert.isNotUndefined(content.blockSyncer.syncing)
 
   const avgTimeToAddBlock = content.blockSyncer.syncing.blockSpeed
-  const speed = content.blockSyncer.syncing.speed
 
   if (content.blockSyncer.status === 'syncing') {
-    blockSyncerStatusDetails.push(`${speed} blocks per seconds`)
+    blockSyncerStatusDetails.push(`${content.blockSyncer.syncing.speed} blocks per seconds`)
   }
 
   if (avgTimeToAddBlock) {

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -42,6 +42,7 @@ export type GetStatusResponse = {
     syncing?: {
       blockSpeed: number
       speed: number
+      progress: number
     }
   }
   peerNetwork: {
@@ -125,6 +126,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
           .object({
             blockSpeed: yup.number().defined(),
             speed: yup.number().defined(),
+            progress: yup.number().defined(),
           })
           .optional(),
       })
@@ -215,6 +217,7 @@ function getStatus(node: IronfishNode): GetStatusResponse {
       syncing: {
         blockSpeed: MathUtils.round(node.chain.addSpeed.avg, 2),
         speed: MathUtils.round(node.syncer.speed.rate1m, 2),
+        progress: node.chain.getProgress(),
       },
     },
     telemetry: {


### PR DESCRIPTION
## Summary

Refactoring of Syncer section:
1. Syncer section of status looks different from others: `@` as first delimiter for "@ 12.3 blocks per seconds" message and `|` as second delimiter for "| avg time to add block 34.5 ms" message. Almost all other sections uses `-` and `,`.
1. A lot of questions in many chats "why miner is not mining". The problem - miner wait until node syncing. Show progress of syncing helps to resolve issue.

New look of status:

![pm4aWSK](https://user-images.githubusercontent.com/743584/155857884-77482a17-bff5-45c3-a6e6-2f0ad067287a.png)

![WnUntHO](https://user-images.githubusercontent.com/743584/155857892-a76eb56e-17d3-4804-ab58-42f1405e21f1.png)

## Testing Plan
Manual testing:
1. Reset database by `ironfish reset` and run node to watch progress in status (long operation).
1. Run `ironfish status -f` to watch all states of syncer.

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and what additional work is required, if any.

```
[ ] Yes
[x] No
```