### PR TITLE
Fix '..' imports

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BufferMap } from 'buffer-map'
 import { generateKey, generateNewPublicAddress } from 'ironfish-rust-nodejs'
-import { ChainProcessor } from '..'
 import { Blockchain } from '../blockchain'
+import { ChainProcessor } from '../chainProcessor'
 import { Event } from '../event'
 import { createRootLogger, Logger } from '../logger'
 import { MemPool } from '../memPool'

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -6,7 +6,7 @@ jest.mock('ws')
 jest.mock('../network')
 
 import '../testUtilities/matchers/blockchain'
-import { Assert } from '..'
+import { Assert } from '../assert'
 import { BlockHeader } from '../primitives'
 import { Target } from '../primitives/target'
 import {

--- a/ironfish/src/fileStores/hosts.ts
+++ b/ironfish/src/fileStores/hosts.ts
@@ -1,9 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { createRootLogger, Logger, ParseJsonError } from '..'
 import { FileSystem } from '../fileSystems'
+import { createRootLogger, Logger } from '../logger'
 import { PeerAddress } from '../network/peers/peerAddress'
+import { ParseJsonError } from '../utils/json'
 import { KeyStore } from './keyStore'
 
 export type HostsOptions = {

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Assert } from '..'
+import { Assert } from '../assert'
 import {
   createNodeTest,
   useAccountFixture,

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -3,12 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import tweetnacl from 'tweetnacl'
-import { HostsStore } from '..'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { MAX_REQUESTED_BLOCKS } from '../consensus'
 import { Event } from '../event'
 import { DEFAULT_WEBSOCKET_PORT } from '../fileStores/config'
+import { HostsStore } from '../fileStores/hosts'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
 import { IronfishNode } from '../node'

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { HostsStore } from '../../fileStores'
 import { ArrayUtils } from '../../utils'
-import { Peer } from '..'
+import { Peer } from '../peers/peer'
 import { ConnectionDirection, ConnectionType } from './connections'
 import { PeerAddress } from './peerAddress'
 

--- a/ironfish/src/network/testUtilities/mockIdentity.ts
+++ b/ironfish/src/network/testUtilities/mockIdentity.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Identity, privateIdentityToIdentity } from '..'
+import { Identity, privateIdentityToIdentity } from '../identity'
 import {
   mockPrivateIdentity,
   webRtcCanInitiateIdentityPrivate,

--- a/ironfish/src/network/testUtilities/mockPrivateIdentity.ts
+++ b/ironfish/src/network/testUtilities/mockPrivateIdentity.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { identityLength, PrivateIdentity } from '..'
+import { identityLength, PrivateIdentity } from '../identity'
 
 // The identities here are in order of:
 // Lowest:   webRtcCanInitiateIdentityPrivate

--- a/ironfish/src/rpc/routes/workers/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/workers/getStatus.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { GetWorkersStatusRequest } from '..'
+import { GetWorkersStatusRequest } from './getStatus'
 
 describe('Route worker/getStatus', () => {
   const routeTest = createRouteTest()

--- a/ironfish/src/workerPool/job.test.slow.ts
+++ b/ironfish/src/workerPool/job.test.slow.ts
@@ -4,7 +4,8 @@
 
 import { generateKey } from 'ironfish-rust-nodejs'
 import tweetnacl from 'tweetnacl'
-import { Assert, privateIdentityToIdentity } from '..'
+import { Assert } from '../assert'
+import { privateIdentityToIdentity } from '../network/identity'
 import { createNodeTest } from '../testUtilities/nodeTest'
 
 describe('Worker Pool', () => {


### PR DESCRIPTION
## Summary
These imports contribute to circular dependency issues and are mostly
created by people using auto import in vscode. Unfortunately there's no
way to fix this in the vscode importer so these kind of crop up. We can
look at creating an eslint rule for these.

## Testing Plan
Build code

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
