### PR TITLE
improving `accounts` command

### DIFF
--- a/ironfish-cli/src/commands/accounts/balance.test.ts
+++ b/ironfish-cli/src/commands/accounts/balance.test.ts
@@ -6,6 +6,7 @@ import { displayIronAmountWithCurrency, GetBalanceResponse, oreToIron } from 'ir
 
 describe('accounts:balance', () => {
   const responseContent: GetBalanceResponse = {
+    accountName: 'default',
     confirmed: '5',
     unconfirmed: '10',
   }
@@ -42,6 +43,8 @@ describe('accounts:balance', () => {
       .command(['accounts:balance', 'default'])
       .exit(0)
       .it('logs the account balance and available spending balance', (ctx) => {
+        expectCli(ctx.stdout).include(responseContent.accountName)
+
         expectCli(ctx.stdout).include(
           displayIronAmountWithCurrency(oreToIron(Number(responseContent.unconfirmed)), true),
         )

--- a/ironfish-cli/src/commands/accounts/balance.test.ts
+++ b/ironfish-cli/src/commands/accounts/balance.test.ts
@@ -6,7 +6,7 @@ import { displayIronAmountWithCurrency, GetBalanceResponse, oreToIron } from 'ir
 
 describe('accounts:balance', () => {
   const responseContent: GetBalanceResponse = {
-    accountName: 'default',
+    account: 'default',
     confirmed: '5',
     unconfirmed: '10',
   }
@@ -43,7 +43,7 @@ describe('accounts:balance', () => {
       .command(['accounts:balance', 'default'])
       .exit(0)
       .it('logs the account balance and available spending balance', (ctx) => {
-        expectCli(ctx.stdout).include(responseContent.accountName)
+        expectCli(ctx.stdout).include(responseContent.account)
 
         expectCli(ctx.stdout).include(
           displayIronAmountWithCurrency(oreToIron(Number(responseContent.unconfirmed)), true),

--- a/ironfish-cli/src/commands/accounts/balance.ts
+++ b/ironfish-cli/src/commands/accounts/balance.ts
@@ -31,9 +31,9 @@ export class BalanceCommand extends IronfishCommand {
       account: account,
     })
 
-    const { accountName, confirmed, unconfirmed } = response.content
+    const { account: accountResponse, confirmed, unconfirmed } = response.content
 
-    this.log(`Account - ${accountName}\n`)
+    this.log(`Account - ${String(accountResponse)}\n`)
     this.log(
       `The balance is: ${displayIronAmountWithCurrency(oreToIron(Number(unconfirmed)), true)}`,
     )

--- a/ironfish-cli/src/commands/accounts/balance.ts
+++ b/ironfish-cli/src/commands/accounts/balance.ts
@@ -31,13 +31,11 @@ export class BalanceCommand extends IronfishCommand {
       account: account,
     })
 
-    const { confirmed, unconfirmed } = response.content
+    const { accountName, confirmed, unconfirmed } = response.content
 
+    this.log(`Account - ${accountName}\n`)
     this.log(
-      `The account balance is:    ${displayIronAmountWithCurrency(
-        oreToIron(Number(unconfirmed)),
-        true,
-      )}`,
+      `The balance is: ${displayIronAmountWithCurrency(oreToIron(Number(unconfirmed)), true)}`,
     )
     this.log(
       `Amount available to spend: ${displayIronAmountWithCurrency(

--- a/ironfish-cli/src/commands/accounts/pay.test.ts
+++ b/ironfish-cli/src/commands/accounts/pay.test.ts
@@ -140,7 +140,7 @@ describe('accounts:pay command', () => {
     .stub(CliUx.ux, 'confirm', () => async () => await Promise.resolve(true))
     .stdout()
     .command(['accounts:pay', `-t ${to}`, `-f ${from}`])
-    .exit(0)
+    .exit(2)
     .it('without amount flag: show the right error message', () => {
       expect(sendTransaction).toBeCalledTimes(0)
     })

--- a/ironfish-cli/src/commands/accounts/pay.test.ts
+++ b/ironfish-cli/src/commands/accounts/pay.test.ts
@@ -71,7 +71,7 @@ describe('accounts:pay command', () => {
       'with every flag: show the right confirmation message and call sendTransaction if valid',
       (ctx) => {
         expectCli(ctx.stdout).include(
-          `$IRON  2 ($ORE 200,000,000) plus a transaction fee of $IRON  1 ($ORE 100,000,000) to  ${to} from the account  ${from}`,
+          `$IRON 2.00000000 ($ORE 200,000,000) plus a transaction fee of $IRON 1.00000000 ($ORE 100,000,000) to ${to} from the account ${from}`,
         )
         expectCli(ctx.stdout).include(`Transaction Hash`)
         expect(sendTransaction).toBeCalledTimes(1)
@@ -87,7 +87,7 @@ describe('accounts:pay command', () => {
       'without memo flag: show the right confirmation message and call sendTransaction if valid',
       (ctx) => {
         expectCli(ctx.stdout).include(
-          `$IRON  2 ($ORE 200,000,000) plus a transaction fee of $IRON  1 ($ORE 100,000,000) to  ${to} from the account  ${from}`,
+          `$IRON 2.00000000 ($ORE 200,000,000) plus a transaction fee of $IRON 1.00000000 ($ORE 100,000,000) to ${to} from the account ${from}`,
         )
         expectCli(ctx.stdout).include(`Transaction Hash`)
         expect(sendTransaction).toBeCalledTimes(1)
@@ -125,10 +125,10 @@ describe('accounts:pay command', () => {
     .command(['accounts:pay', `-t ${to}`, `-f ${from}`])
     .exit(0)
     .it(
-      'without account flag: show the right confirmation message and call sendTransaction if valid',
+      'without amount flag: show the right confirmation message and call sendTransaction if valid',
       (ctx) => {
         expectCli(ctx.stdout).include(
-          `$IRON 3.00000000 ($ORE 300,000,000) to  ${to} from the account  ${from}`,
+          `$IRON 3.00000000 ($ORE 300,000,000) to ${to} from the account ${from}`,
         )
         expectCli(ctx.stdout).include(`Transaction Hash`)
         expect(sendTransaction).toBeCalledTimes(1)
@@ -141,7 +141,7 @@ describe('accounts:pay command', () => {
     .stdout()
     .command(['accounts:pay', `-t ${to}`, `-f ${from}`])
     .exit(0)
-    .it('without account flag: show the right error message', () => {
+    .it('without amount flag: show the right error message', () => {
       expect(sendTransaction).toBeCalledTimes(0)
     })
 
@@ -185,7 +185,7 @@ describe('accounts:pay command', () => {
       .exit(2)
       .it('show the right error message and call sendTransaction', (ctx) => {
         expectCli(ctx.stdout).include(
-          `$IRON  2 ($ORE 200,000,000) plus a transaction fee of $IRON  1 ($ORE 100,000,000) to  ${to} from the account  ${from}`,
+          `$IRON 2.00000000 ($ORE 200,000,000) plus a transaction fee of $IRON 1.00000000 ($ORE 100,000,000) to ${to} from the account ${from}`,
         )
         expect(sendTransaction).toBeCalledTimes(1)
         expectCli(ctx.stdout).include(`An error occurred while sending the transaction.`)

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -92,7 +92,7 @@ export class Pay extends IronfishCommand {
         ),
       )
 
-      if (Number.isNaN(amount)) {
+      if (Number.isNaN(input)) {
         this.error(`A valid amount is required`)
       }
 
@@ -160,7 +160,7 @@ export class Pay extends IronfishCommand {
 
     if (!isValidPublicAddress(to)) {
       this.log(`A valid public address is required`)
-      this.exit(0)
+      this.exit(1)
     }
 
     if (expirationSequence !== undefined && expirationSequence < 0) {

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -63,8 +63,8 @@ export class Pay extends IronfishCommand {
     let fee = flags.fee as unknown as number
     let to = flags.to
     let from = flags.account
-    let memo = flags.memo
     const expirationSequence = flags.expirationSequence
+    const memo = flags.memo || ''
 
     const client = await this.sdk.connectRpc()
 
@@ -128,13 +128,6 @@ export class Pay extends IronfishCommand {
       }
 
       from = defaultAccount.name
-    }
-
-    if (!memo) {
-      memo =
-        ((await CliUx.ux.prompt('Memo of transaction', {
-          required: false,
-        })) as string) || ''
     }
 
     if (!isValidAmount(amount)) {

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -61,8 +61,8 @@ export class Pay extends IronfishCommand {
     const { flags } = await this.parse(Pay)
     let amount = flags.amount as unknown as number
     let fee = flags.fee as unknown as number
-    let to = flags.to
-    let from = flags.account
+    let to = flags.to?.trim()
+    let from = flags.account?.trim()
     const expirationSequence = flags.expirationSequence
     const memo = flags.memo || ''
 
@@ -90,7 +90,7 @@ export class Pay extends IronfishCommand {
         },
       )) as number
 
-      if (Number.isNaN(amount) || !isValidAmount(amount)) {
+      if (Number.isNaN(amount)) {
         this.error(`A valid amount is required`)
       }
     }
@@ -101,7 +101,7 @@ export class Pay extends IronfishCommand {
         default: '0.00000001',
       })) as number
 
-      if (Number.isNaN(fee) || !isValidAmount(fee)) {
+      if (Number.isNaN(fee)) {
         this.error(`A valid fee amount is required`)
       }
     }
@@ -151,7 +151,8 @@ export class Pay extends IronfishCommand {
     }
 
     if (!isValidPublicAddress(to)) {
-      this.error(`A valid public address is required`)
+      this.log(`A valid public address is required`)
+      this.exit(0)
     }
 
     if (expirationSequence !== undefined && expirationSequence < 0) {

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -426,7 +426,7 @@ export class Accounts {
           const existingT = this.transactionMap.get(transactionHash)
           // If we passed in a submittedSequence, set submittedSequence to that value.
           // Otherwise, if we already have a submittedSequence, keep that value regardless of whether
-          //   submittedSequence was passed in.
+          // submittedSequence was passed in.
           // Otherwise, we don't have an existing sequence or new sequence, so set submittedSequence null
           newSequence = submittedSequence || existingT?.submittedSequence || null
 

--- a/ironfish/src/rpc/routes/accounts/getBalance.ts
+++ b/ironfish/src/rpc/routes/accounts/getBalance.ts
@@ -6,7 +6,7 @@ import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
 export type GetBalanceRequest = { account?: string }
-export type GetBalanceResponse = { confirmed: string; unconfirmed: string }
+export type GetBalanceResponse = { accountName: string; confirmed: string; unconfirmed: string }
 
 export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
   .object({
@@ -16,6 +16,7 @@ export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
 
 export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yup
   .object({
+    accountName: yup.string().defined(),
     unconfirmed: yup.string().defined(),
     confirmed: yup.string().defined(),
   })
@@ -29,6 +30,7 @@ router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
     const { confirmed, unconfirmed } = await node.accounts.getBalance(account)
 
     request.end({
+      accountName: account.displayName,
       confirmed: confirmed.toString(),
       unconfirmed: unconfirmed.toString(),
     })

--- a/ironfish/src/rpc/routes/accounts/getBalance.ts
+++ b/ironfish/src/rpc/routes/accounts/getBalance.ts
@@ -6,7 +6,7 @@ import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
 export type GetBalanceRequest = { account?: string }
-export type GetBalanceResponse = { accountName: string; confirmed: string; unconfirmed: string }
+export type GetBalanceResponse = { account: string; confirmed: string; unconfirmed: string }
 
 export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
   .object({
@@ -16,7 +16,7 @@ export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
 
 export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yup
   .object({
-    accountName: yup.string().defined(),
+    account: yup.string().defined(),
     unconfirmed: yup.string().defined(),
     confirmed: yup.string().defined(),
   })
@@ -30,7 +30,7 @@ router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
     const { confirmed, unconfirmed } = await node.accounts.getBalance(account)
 
     request.end({
-      accountName: account.displayName,
+      account: account.displayName,
       confirmed: confirmed.toString(),
       unconfirmed: unconfirmed.toString(),
     })

--- a/ironfish/src/utils/currency.test.ts
+++ b/ironfish/src/utils/currency.test.ts
@@ -34,6 +34,7 @@ describe('Currency utils', () => {
 
   test('isValidAmount returns the right value', () => {
     expect(isValidAmount(0.0000000000001)).toBe(false)
+    expect(isValidAmount(100000000000000000000000000)).toBe(false)
     expect(isValidAmount(0.00000001)).toBe(true)
     expect(isValidAmount(10.000001)).toBe(true)
   })

--- a/ironfish/src/utils/currency.ts
+++ b/ironfish/src/utils/currency.ts
@@ -6,10 +6,11 @@ const ORE_TICKER = '$ORE'
 const IRON_TICKER = '$IRON'
 const ORE_TO_IRON = 100000000
 export const MINIMUM_IRON_AMOUNT = 1 / ORE_TO_IRON
+export const MAXIMUM_IRON_AMOUNT = 1e12
 const FLOAT = ORE_TO_IRON.toString().length - 1
 
 export const isValidAmount = (amount: number): boolean => {
-  return amount >= MINIMUM_IRON_AMOUNT
+  return amount >= MINIMUM_IRON_AMOUNT && amount <= MAXIMUM_IRON_AMOUNT
 }
 
 export const ironToOre = (amount: number): number => {

--- a/ironfish/src/utils/currency.ts
+++ b/ironfish/src/utils/currency.ts
@@ -6,7 +6,7 @@ const ORE_TICKER = '$ORE'
 const IRON_TICKER = '$IRON'
 const ORE_TO_IRON = 100000000
 export const MINIMUM_IRON_AMOUNT = 1 / ORE_TO_IRON
-export const MAXIMUM_IRON_AMOUNT = 1e12
+export const MAXIMUM_IRON_AMOUNT = 1.8446744e19
 const FLOAT = ORE_TO_IRON.toString().length - 1
 
 export const isValidAmount = (amount: number): boolean => {


### PR DESCRIPTION
## Summary
Some improvements and fixes for the `accounts` command. 

1 - enhancing validation checks for `accounts:pay`
2 - fix long number error. amount and fee values need to be wrapped in `Number()` for `displayIronAmountWithCurrency()`, which fixes issue identified in https://github.com/iron-fish/ironfish/issues/699
3 - add max amount check for `isValidAmount()` to prevent absurdly large values, to fix https://github.com/iron-fish/ironfish/issues/699
4 - add `accountName` for `accounts:balance`.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
