### PR TITLE
Blockchain test coverage

### DIFF
--- a/ironfish/src/utils/blockutil.test.ts
+++ b/ironfish/src/utils/blockutil.test.ts
@@ -14,23 +14,27 @@ describe('getBlockRange', () => {const workerPool = new WorkerPool()
   const strategy = new Strategy(workerPool)
   const chain = new Blockchain({ location: makeDbPath(), strategy })
 
-  it('converts empty array to 0', async () => {
+  it('Initialization', async () => {
     await chain.open()
     chain.latest.sequence = 10000
-
-    const {start, stop } = getBlockRange(chain)
-
-      //console.log( {start}, {stop})
-      console.log( start, stop)
   })
 
-  it('converts empty array to 0', async () => {
-    //await chain.open()
-    //chain.latest.sequence = 10000
+  it('prototype', async () => {
+    const param = {start: 2000, stop: 200}
 
-    const {start, stop } = getBlockRange(chain)
+    //const {start, stop } = getBlockRange(chain, {start: 2000, stop: 200 })
+    const {start, stop } = getBlockRange(chain, param)
+      
+    expect(start).toEqual(2000)    
+    expect(stop).toEqual(2000)
+  })
 
-      //console.log( {start}, {stop})
-      console.log( chain.latest.sequence)
+  it('G < b < e < M', async () => {
+    const param = {start: 200, stop: 2000}
+
+    const {start, stop } = getBlockRange(chain, param)
+      
+    expect(start).toEqual(200)    
+    expect(stop).toEqual(2000)
   })
 })

--- a/ironfish/src/utils/blockutil.test.ts
+++ b/ironfish/src/utils/blockutil.test.ts
@@ -7,14 +7,30 @@ import { GENESIS_BLOCK_SEQUENCE } from '../consensus/consensus'
 import { Strategy } from '../strategy'
 import { makeDbPath } from '../testUtilities/helpers/storage'
 import { WorkerPool } from '../workerPool'
+import { getBlockRange } from './blockchain'
+
 
 describe('getBlockRange', () => {const workerPool = new WorkerPool()
   const strategy = new Strategy(workerPool)
   const chain = new Blockchain({ location: makeDbPath(), strategy })
 
   it('converts empty array to 0', async () => {
-    //await chain.open()
+    await chain.open()
     chain.latest.sequence = 10000
-      console.log("hit the jackpot")
+
+    const {start, stop } = getBlockRange(chain)
+
+      //console.log( {start}, {stop})
+      console.log( start, stop)
+  })
+
+  it('converts empty array to 0', async () => {
+    //await chain.open()
+    //chain.latest.sequence = 10000
+
+    const {start, stop } = getBlockRange(chain)
+
+      //console.log( {start}, {stop})
+      console.log( chain.latest.sequence)
   })
 })

--- a/ironfish/src/utils/blockutil.test.ts
+++ b/ironfish/src/utils/blockutil.test.ts
@@ -11,12 +11,14 @@ import { getBlockRange } from './blockchain'
 // Strategy for testing:
 // Consider a line of numbers to choose for the input parameters
 // <-----N1---N2----0G---P1---P2---H---X1---X2----->
-// Where N1, N2 are negative
+// Where N1, N2 are negative (count backward from height)
 // G is the genesis block (1)
 // P1 and P2 are positive numbers in the range of blocks
 // H is the height of the chain
 // X1 and X2 exceed the height of the chain
 
+// Blockchain is needed by getBlockRange()
+// Set it up before running tests
 const workerPool = new WorkerPool()
 const strategy = new Strategy(workerPool)
 const chain = new Blockchain({ location: makeDbPath(), strategy })
@@ -56,25 +58,23 @@ describe('getBlockRange', () => {
 */
 
 describe.each([
-  {Xstart: 9000, Xstop: 900, expectedStart: 9000, expectedStop: 9000},
-  {Xstart: 700, Xstop: 7000, expectedStart: 700, expectedStop: 7000},
-])('Test ${Xstart}, ${Xstop}', ({Xstart, Xstop, expectedStart, expectedStop}) => {
+  // P1, P2 cases
+  { param: { start: 9000, stop: 900 }, expectedStart: 9000, expectedStop: 9000 },
+  { param: { start: 900, stop: 9000 }, expectedStart: 900, expectedStop: 9000 },
 
+  // N1, N2 cases
+  { param: { start: -9000, stop: -8000 }, expectedStart: 1000, expectedStop: 2000 },
+  { param: { start: -8000, stop: -9000 }, expectedStart: 2000, expectedStop: 2000 },
   /*
-  const workerPool = new WorkerPool()
-  const strategy = new Strategy(workerPool)
-  const chain = new Blockchain({ location: makeDbPath(), strategy })
-*/
-
-  test(`returns ${expectedStart} ${expectedStop}`, () => {
-/*
-    const { start, stop } = getBlockRange(chain, {start: Xstart, stop: Xstop}})
+  { param: { start: , stop:  }, expectedStart: , expectedStop:  },
+  { param: { start: , stop:  }, expectedStart: , expectedStop:  },
+  { param: { start: , stop:  }, expectedStart: , expectedStop:  },
+  { param: { start: , stop:  }, expectedStart: , expectedStop:  },
+  */
+])('Test input parameters', ({ param, expectedStart, expectedStop }) => {
+  test(`${param.start}, ${param.stop} returns ${expectedStart} ${expectedStop}`, () => {
+    const { start, stop } = getBlockRange(chain, { start: param.start, stop: param.stop })
     expect(start).toEqual(expectedStart)
     expect(stop).toEqual(expectedStop)
-    */
-   
-    expect(Xstart).toEqual(expectedStart)
-    expect(Xstop).toEqual(expectedStop)
-  });
-});
-
+  })
+})

--- a/ironfish/src/utils/blockutil.test.ts
+++ b/ironfish/src/utils/blockutil.test.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Blockchain } from '../blockchain'
-import { GENESIS_BLOCK_SEQUENCE } from '../consensus/consensus'
 import { Strategy } from '../strategy'
 import { makeDbPath } from '../testUtilities/helpers/storage'
 import { WorkerPool } from '../workerPool'
@@ -17,6 +16,9 @@ import { getBlockRange } from './blockchain'
 // H is the height of the chain
 // X1 and X2 exceed the height of the chain
 
+// Notes for documentation:
+// Zeroes get immediately converted to min/max in the function
+
 // Blockchain is needed by getBlockRange()
 // Set it up before running tests
 const workerPool = new WorkerPool()
@@ -28,35 +30,6 @@ beforeAll(async () => {
   chain.latest.sequence = 10000
 })
 
-/*
-describe('getBlockRange', () => {
-  const workerPool = new WorkerPool()
-  const strategy = new Strategy(workerPool)
-  const chain = new Blockchain({ location: makeDbPath(), strategy })
-
-  it('Initialization', async () => {
-    await chain.open()
-    chain.latest.sequence = 10000
-  })
-
-  it('prototype', () => {
-    const param = { start: 2000, stop: 200 }
-
-    const { start, stop } = getBlockRange(chain, param)
-    expect(start).toEqual(param.start)
-    expect(stop).toEqual(param.start)
-  })
-
-  it('G < b < e < M', () => {
-    const param = { start: 200, stop: 2000 }
-
-    const { start, stop } = getBlockRange(chain, param)
-    expect(start).toEqual(param.start)
-    expect(stop).toEqual(param.stop)
-  })
-})
-*/
-
 describe.each([
   // P1, P2 cases
   { param: { start: 9000, stop: 900 }, expectedStart: 9000, expectedStop: 9000 },
@@ -65,16 +38,59 @@ describe.each([
   // N1, N2 cases
   { param: { start: -9000, stop: -8000 }, expectedStart: 1000, expectedStop: 2000 },
   { param: { start: -8000, stop: -9000 }, expectedStart: 2000, expectedStop: 2000 },
-  /*
-  { param: { start: , stop:  }, expectedStart: , expectedStop:  },
-  { param: { start: , stop:  }, expectedStart: , expectedStop:  },
-  { param: { start: , stop:  }, expectedStart: , expectedStop:  },
-  { param: { start: , stop:  }, expectedStart: , expectedStop:  },
-  */
-])('Test input parameters', ({ param, expectedStart, expectedStop }) => {
+
+  // N, P cases
+  { param: { start: -9000, stop: 3000 }, expectedStart: 1000, expectedStop: 3000 },
+  { param: { start: 3000, stop: -9000 }, expectedStart: 3000, expectedStop: 3000 },
+
+  { param: { start: 1000, stop: -7000 }, expectedStart: 1000, expectedStop: 3000 },
+  { param: { start: -7000, stop: 1000 }, expectedStart: 3000, expectedStop: 3000 },
+
+  // N, 0 cases
+  { param: { start: -9000, stop: 0 }, expectedStart: 1000, expectedStop: 10000 },
+  { param: { start: 0, stop: -9000 }, expectedStart: 1, expectedStop: 1000 },
+
+  // P, 0 cases
+  { param: { start: 40, stop: 0 }, expectedStart: 40, expectedStop: 10000 },
+  { param: { start: 0, stop: 40 }, expectedStart: 1, expectedStop: 40 },
+
+  // H, 0 cases
+  { param: { start: 10000, stop: 0 }, expectedStart: 10000, expectedStop: 10000 },
+  { param: { start: 0, stop: 10000 }, expectedStart: 1, expectedStop: 10000 },
+
+  // P, H cases
+  { param: { start: 100, stop: 10000 }, expectedStart: 100, expectedStop: 10000 },
+  { param: { start: 10000, stop: 100 }, expectedStart: 10000, expectedStop: 10000 },
+
+  // X1, X2 cases
+  { param: { start: 11000, stop: 12000 }, expectedStart: 10000, expectedStop: 10000 },
+  { param: { start: 12000, stop: 11000 }, expectedStart: 10000, expectedStop: 10000 },
+
+  // N, H cases
+  { param: { start: -9000, stop: 10000 }, expectedStart: 1000, expectedStop: 10000 },
+  { param: { start: 10000, stop: -9000 }, expectedStart: 10000, expectedStop: 10000 },
+
+  // N1, N2 cases. |N1| > H
+  { param: { start: -17000, stop: -8000 }, expectedStart: 1, expectedStop: 2000 },
+  { param: { start: -8000, stop: -17000 }, expectedStart: 2000, expectedStop: 2000 },
+
+  // N1, N2 cases. |N1| > H, |N2| > H
+  { param: { start: -17000, stop: -18000 }, expectedStart: 1, expectedStop: 1 },
+  { param: { start: -18000, stop: -17000 }, expectedStart: 1, expectedStop: 1 },
+
+  // null cases
+  { param: { start: null, stop: 6000 }, expectedStart: 1, expectedStop: 6000 },
+  { param: { start: 6000, stop: null }, expectedStart: 6000, expectedStop: 10000 },
+
+  // fractional cases
+  { param: { start: 3.14, stop: 6.28 }, expectedStart: 3, expectedStop: 6 },
+  { param: { start: 6.28, stop: 3.14 }, expectedStart: 6, expectedStop: 6 },
+])('getBlockRange', ({ param, expectedStart, expectedStop }) => {
   test(`${param.start}, ${param.stop} returns ${expectedStart} ${expectedStop}`, () => {
-    const { start, stop } = getBlockRange(chain, { start: param.start, stop: param.stop })
+    const { start, stop } = getBlockRange(chain, param)
     expect(start).toEqual(expectedStart)
     expect(stop).toEqual(expectedStop)
   })
 })
+
+//jkTODO add separate null tests to placate lint?

--- a/ironfish/src/utils/blockutil.test.ts
+++ b/ironfish/src/utils/blockutil.test.ts
@@ -17,6 +17,16 @@ import { getBlockRange } from './blockchain'
 // H is the height of the chain
 // X1 and X2 exceed the height of the chain
 
+const workerPool = new WorkerPool()
+const strategy = new Strategy(workerPool)
+const chain = new Blockchain({ location: makeDbPath(), strategy })
+
+beforeAll(async () => {
+  await chain.open()
+  chain.latest.sequence = 10000
+})
+
+/*
 describe('getBlockRange', () => {
   const workerPool = new WorkerPool()
   const strategy = new Strategy(workerPool)
@@ -43,3 +53,28 @@ describe('getBlockRange', () => {
     expect(stop).toEqual(param.stop)
   })
 })
+*/
+
+describe.each([
+  {Xstart: 9000, Xstop: 900, expectedStart: 9000, expectedStop: 9000},
+  {Xstart: 700, Xstop: 7000, expectedStart: 700, expectedStop: 7000},
+])('Test ${Xstart}, ${Xstop}', ({Xstart, Xstop, expectedStart, expectedStop}) => {
+
+  /*
+  const workerPool = new WorkerPool()
+  const strategy = new Strategy(workerPool)
+  const chain = new Blockchain({ location: makeDbPath(), strategy })
+*/
+
+  test(`returns ${expectedStart} ${expectedStop}`, () => {
+/*
+    const { start, stop } = getBlockRange(chain, {start: Xstart, stop: Xstop}})
+    expect(start).toEqual(expectedStart)
+    expect(stop).toEqual(expectedStop)
+    */
+   
+    expect(Xstart).toEqual(expectedStart)
+    expect(Xstop).toEqual(expectedStop)
+  });
+});
+

--- a/ironfish/src/utils/blockutil.test.ts
+++ b/ironfish/src/utils/blockutil.test.ts
@@ -3,14 +3,22 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Blockchain } from '../blockchain'
 import { GENESIS_BLOCK_SEQUENCE } from '../consensus/consensus'
- 
 import { Strategy } from '../strategy'
 import { makeDbPath } from '../testUtilities/helpers/storage'
 import { WorkerPool } from '../workerPool'
 import { getBlockRange } from './blockchain'
 
+// Strategy for testing:
+// Consider a line of numbers to choose for the input parameters
+// <-----N1---N2----0G---P1---P2---H---X1---X2----->
+// Where N1, N2 are negative
+// G is the genesis block (1)
+// P1 and P2 are positive numbers in the range of blocks
+// H is the height of the chain
+// X1 and X2 exceed the height of the chain
 
-describe('getBlockRange', () => {const workerPool = new WorkerPool()
+describe('getBlockRange', () => {
+  const workerPool = new WorkerPool()
   const strategy = new Strategy(workerPool)
   const chain = new Blockchain({ location: makeDbPath(), strategy })
 
@@ -19,22 +27,19 @@ describe('getBlockRange', () => {const workerPool = new WorkerPool()
     chain.latest.sequence = 10000
   })
 
-  it('prototype', async () => {
-    const param = {start: 2000, stop: 200}
+  it('prototype', () => {
+    const param = { start: 2000, stop: 200 }
 
-    //const {start, stop } = getBlockRange(chain, {start: 2000, stop: 200 })
-    const {start, stop } = getBlockRange(chain, param)
-      
-    expect(start).toEqual(2000)    
-    expect(stop).toEqual(2000)
+    const { start, stop } = getBlockRange(chain, param)
+    expect(start).toEqual(param.start)
+    expect(stop).toEqual(param.start)
   })
 
-  it('G < b < e < M', async () => {
-    const param = {start: 200, stop: 2000}
+  it('G < b < e < M', () => {
+    const param = { start: 200, stop: 2000 }
 
-    const {start, stop } = getBlockRange(chain, param)
-      
-    expect(start).toEqual(200)    
-    expect(stop).toEqual(2000)
+    const { start, stop } = getBlockRange(chain, param)
+    expect(start).toEqual(param.start)
+    expect(stop).toEqual(param.stop)
   })
 })

--- a/ironfish/src/utils/blockutil.test.ts
+++ b/ironfish/src/utils/blockutil.test.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Blockchain } from '../blockchain'
+import { GENESIS_BLOCK_SEQUENCE } from '../consensus/consensus'
+ 
+import { Strategy } from '../strategy'
+import { makeDbPath } from '../testUtilities/helpers/storage'
+import { WorkerPool } from '../workerPool'
+
+describe('getBlockRange', () => {const workerPool = new WorkerPool()
+  const strategy = new Strategy(workerPool)
+  const chain = new Blockchain({ location: makeDbPath(), strategy })
+
+  it('converts empty array to 0', async () => {
+    //await chain.open()
+    chain.latest.sequence = 10000
+      console.log("hit the jackpot")
+  })
+})


### PR DESCRIPTION
## Summary
Increase test coverage of utils/blockchain.ts (93.61% lines).
Note: the name of the new file is blockutil.test.ts, not blockchain.test.ts due to an interaction with running `yarn test blockchain` - both blockchain.test.ts files execute, but none of the "describe" nor "it" messages are printed out.
Also leaving isBlockMine() untested - it's a trivial function and makes more sense to be tested with transaction.ts

## Testing Plan
Yarn link, yarn test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
