### PR TITLE
Add serializable interface and base serializable worker message class

### DIFF
--- a/ironfish/src/common/serializable.ts
+++ b/ironfish/src/common/serializable.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import bufio from 'bufio'
+
+export interface Serializable {
+  serialize(bw: bufio.BufferWriter): Buffer
+  deserialize(buffer: Buffer): Serializable
+  getSize(): number
+}

--- a/ironfish/src/common/serializable.ts
+++ b/ironfish/src/common/serializable.ts
@@ -5,7 +5,7 @@
 import bufio from 'bufio'
 
 export interface Serializable {
-  serialize(bw: bufio.BufferWriter): Buffer
+  serialize(): Buffer
   deserialize(buffer: Buffer): Serializable
   getSize(): number
 }

--- a/ironfish/src/common/serializable.ts
+++ b/ironfish/src/common/serializable.ts
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import bufio from 'bufio'
-
 export interface Serializable {
   serialize(): Buffer
   deserialize(buffer: Buffer): Serializable

--- a/ironfish/src/workerPool/serializableMessage.ts
+++ b/ironfish/src/workerPool/serializableMessage.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import bufio from 'bufio'
+import { Serializable } from '../common/serializable'
+
+export enum WorkerMessageType {
+  BoxMessage = 'boxMessage',
+  CreateMinersFee = 'createMinersFee',
+  CreateTransaction = 'createTransaction',
+  GetUnspentNotes = 'getUnspentNotes',
+  MineHeader = 'mineHeader',
+  Sleep = 'sleep',
+  SubmitTelemetry = 'submitTelemetry',
+  TransactionFee = 'transactionFee',
+  UnboxMessage = 'unboxMessage',
+  VerifyTransaction = 'verifyTransaction',
+}
+
+export abstract class SerializableWorkerMessage implements Serializable {
+  constructor(id: number, type: WorkerMessageType) {
+    this.id = id
+    this.type = type
+  }
+
+  id: number
+
+  type: WorkerMessageType
+
+  abstract serialize(bw: bufio.BufferWriter): Buffer
+
+  abstract deserialize(buffer: Buffer): Serializable
+
+  abstract getSize(): number
+
+  serializeWithMetadata(): Buffer {
+    const bw = bufio.write()
+    bw.writeU64(this.id)
+    bw.writeVarString(this.type)
+    bw.writeBytes(this.serialize(bw))
+    return bw.render()
+  }
+}

--- a/ironfish/src/workerPool/serializableMessage.ts
+++ b/ironfish/src/workerPool/serializableMessage.ts
@@ -27,7 +27,7 @@ export abstract class WorkerMessage implements Serializable {
     this.type = type
   }
 
-  abstract serialize(bw: bufio.BufferWriter): Buffer
+  abstract serialize(): Buffer
 
   abstract deserialize(buffer: Buffer): Serializable
 
@@ -37,7 +37,7 @@ export abstract class WorkerMessage implements Serializable {
     const bw = bufio.write()
     bw.writeU64(this.id)
     bw.writeVarString(this.type)
-    bw.writeBytes(this.serialize(bw))
+    bw.writeBytes(this.serialize())
     return bw.render()
   }
 }

--- a/ironfish/src/workerPool/serializableMessage.ts
+++ b/ironfish/src/workerPool/serializableMessage.ts
@@ -18,15 +18,14 @@ export enum WorkerMessageType {
   VerifyTransaction = 'verifyTransaction',
 }
 
-export abstract class SerializableWorkerMessage implements Serializable {
+export abstract class WorkerMessage implements Serializable {
+  id: number
+  type: WorkerMessageType
+
   constructor(id: number, type: WorkerMessageType) {
     this.id = id
     this.type = type
   }
-
-  id: number
-
-  type: WorkerMessageType
 
   abstract serialize(bw: bufio.BufferWriter): Buffer
 

--- a/ironfish/src/workerPool/workerMessage.ts
+++ b/ironfish/src/workerPool/workerMessage.ts
@@ -5,18 +5,7 @@
 import bufio from 'bufio'
 import { Serializable } from '../common/serializable'
 
-export enum WorkerMessageType {
-  BoxMessage = 'boxMessage',
-  CreateMinersFee = 'createMinersFee',
-  CreateTransaction = 'createTransaction',
-  GetUnspentNotes = 'getUnspentNotes',
-  MineHeader = 'mineHeader',
-  Sleep = 'sleep',
-  SubmitTelemetry = 'submitTelemetry',
-  TransactionFee = 'transactionFee',
-  UnboxMessage = 'unboxMessage',
-  VerifyTransaction = 'verifyTransaction',
-}
+export enum WorkerMessageType {}
 
 export abstract class WorkerMessage implements Serializable {
   id: number
@@ -36,7 +25,6 @@ export abstract class WorkerMessage implements Serializable {
   serializeWithMetadata(): Buffer {
     const bw = bufio.write()
     bw.writeU64(this.id)
-    bw.writeVarString(this.type)
     bw.writeBytes(this.serialize())
     return bw.render()
   }


### PR DESCRIPTION
_Please note that this PR is being opened against the `serialize-worker-pool` branch._

## Summary
Added a serializable interface; it's placed in a top-level common folder in order to aid future serialization efforts. Also, added a base serializable worker message class; each task request/response type will be adjusted to use this new class.

## Testing Plan
All tests pass.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
