### PR TITLE
Fix Buffer not using .compare to check equality

### DIFF
--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -22,7 +22,7 @@ export function isBlockLater(a: BlockHeader, b: BlockHeader): boolean {
     return a.sequence > b.sequence
   }
 
-  return a.hash < b.hash
+  return a.hash.compare(b.hash) < 0
 }
 
 export function isBlockHeavier(a: BlockHeader, b: BlockHeader): boolean {
@@ -38,7 +38,7 @@ export function isBlockHeavier(a: BlockHeader, b: BlockHeader): boolean {
     return a.target.toDifficulty() > b.target.toDifficulty()
   }
 
-  return a.hash < b.hash
+  return a.hash.compare(b.hash) < 0
 }
 
 export class BlockHeader {


### PR DESCRIPTION
## Summary
If you use < > or == it doesn't do what you think. You want to check the
contents by using .compare.

## Testing Plan
Write tests and run node

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
