### PR TITLE
Add custom eslint rule for imports ending in '.'

### DIFF
--- a/config/eslint-config-ironfish/index.js
+++ b/config/eslint-config-ironfish/index.js
@@ -17,6 +17,7 @@ module.exports = {
 
   plugins: [
     'header',
+    'ironfish',
     'jest', 
     'prettier', 
     'simple-import-sort',
@@ -65,6 +66,7 @@ module.exports = {
   ],
 
   rules: {
+    'ironfish/no-vague-imports': 'error',
     // Seems to be needed to allow for custom jest matchers
     '@typescript-eslint/no-namespace': ['error', {
       allowDeclarations: true

--- a/config/eslint-config-ironfish/package.json
+++ b/config/eslint-config-ironfish/package.json
@@ -13,6 +13,7 @@
     "@typescript-eslint/parser": "4.28.1",
     "eslint": "7.29.0",
     "eslint-config-prettier": "8.3.0",
+    "eslint-plugin-ironfish": "*",
     "eslint-plugin-jest": "24.3.6",
     "eslint-plugin-prettier": "3.4.0",
     "prettier": "2.3.2"

--- a/config/eslint-plugin-ironfish/index.js
+++ b/config/eslint-plugin-ironfish/index.js
@@ -1,0 +1,16 @@
+module.exports.rules = {
+  "no-vague-imports": {
+    create(context) {
+      return {
+        ImportDeclaration: function (node) {
+          if (/\.$/.test(node.source.value)) {
+            context.report({
+              node,
+              message: "Non-specific import. Import a specific file.",
+            });
+          }
+        },
+      };
+    },
+  },
+};

--- a/config/eslint-plugin-ironfish/package.json
+++ b/config/eslint-plugin-ironfish/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "eslint-plugin-ironfish",
+    "version": "0.1.0",
+    "private": true,
+    "author": "Iron Fish <contact@ironfish.network> (https://ironfish.network)",
+    "license": "MPL-2.0",
+    "files": [
+      "index.js"
+    ],
+    "peerDependencies": {
+      "eslint": "7.29.0"
+    }
+  }
+  

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,7 @@
   "packages": [
     "config/eslint-config-ironfish-react",
     "config/eslint-config-ironfish",
+    "config/eslint-plugin-ironfish",
     "ironfish-cli",
     "ironfish",
     "ironfish-rust-nodejs",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ironfish-cli",
     "config/eslint-config-ironfish-react",
     "config/eslint-config-ironfish",
+    "config/eslint-plugin-ironfish",
     "ironfish",
     "ironfish-rust-nodejs",
     "ironfish-rust-wasm/nodejs",


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/97762857/157500158-83c89124-e351-401b-8007-12be8260d536.png)

Few more things I need to do:
- [ ] Add unit tests
- [ ] Verify if we absolutely have to create a separate project or if it can live in `eslint-config-ironfish`
- [ ] Settle on better naming/messaging

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
