### PR TITLE
feat(ironfish): Convert telemetry submission to serializable messages

### DIFF
--- a/ironfish/src/typedefs/bufio.d.ts
+++ b/ironfish/src/typedefs/bufio.d.ts
@@ -2,15 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 declare module 'bufio' {
-  type Encoding = 'utf8' | 'ascii'
-  type BufferEncoding = 'hex'
-
   class StaticWriter {
     render(): Buffer
     slice(): Buffer
+    writeU8(value: number): StaticWriter
     writeU64(value: number): StaticWriter
     writeI64(value: number): StaticWriter
-    writeVarString(value: string, enc?: Encoding | null): StaticWriter
+    writeVarString(value: string, enc?: BufferEncoding | null): StaticWriter
     writeVarBytes(value: Buffer): StaticWriter
     writeBytes(value: Buffer): StaticWriter
     writeHash(value: Buffer | string): StaticWriter
@@ -20,9 +18,10 @@ declare module 'bufio' {
   class BufferWriter {
     render(): Buffer
     slice(): Buffer
+    writeU8(value: number): BufferWriter
     writeU64(value: number): BufferWriter
     writeI64(value: number): BufferWriter
-    writeVarString(value: string, enc?: Encoding | null): BufferWriter
+    writeVarString(value: string, enc?: BufferEncoding | null): BufferWriter
     writeVarBytes(value: Buffer): BufferWriter
     writeBytes(value: Buffer): BufferWriter
     writeHash(value: Buffer | string): BufferWriter
@@ -30,8 +29,9 @@ declare module 'bufio' {
   }
 
   class BufferReader {
+    readU8(): number
     readU64(): number
-    readVarString(enc?: Encoding | null, limit?: number): string
+    readVarString(enc?: BufferEncoding | null, limit?: number): string
     readVarBytes(): Buffer
     readBytes(size: number, zeroCopy?: boolean): Buffer
 
@@ -41,4 +41,6 @@ declare module 'bufio' {
 
   export function write(size?: number): StaticWriter | BufferWriter
   export function read(data: Buffer, zeroCopy?: boolean): BufferReader
+
+  export function sizeVarString(value: string, enc?: BufferEncoding): number
 }

--- a/ironfish/src/workerPool/messages.ts
+++ b/ironfish/src/workerPool/messages.ts
@@ -9,7 +9,6 @@ import { CreateTransactionRequest, CreateTransactionResponse } from './tasks/cre
 import { GetUnspentNotesRequest, GetUnspentNotesResponse } from './tasks/getUnspentNotes'
 import { MineHeaderRequest, MineHeaderResponse } from './tasks/mineHeader'
 import { SleepRequest, SleepResponse } from './tasks/sleep'
-import { SubmitTelemetryRequest, SubmitTelemetryResponse } from './tasks/submitTelemetry'
 import { TransactionFeeRequest, TransactionFeeResponse } from './tasks/transactionFee'
 import { UnboxMessageRequest, UnboxMessageResponse } from './tasks/unboxMessage'
 import { VerifyTransactionRequest, VerifyTransactionResponse } from './tasks/verifyTransaction'
@@ -46,7 +45,6 @@ export type WorkerRequest =
   | JobAbortRequest
   | MineHeaderRequest
   | SleepRequest
-  | SubmitTelemetryRequest
   | TransactionFeeRequest
   | UnboxMessageRequest
   | VerifyTransactionRequest
@@ -59,7 +57,6 @@ export type WorkerResponse =
   | JobErrorResponse
   | MineHeaderResponse
   | SleepResponse
-  | SubmitTelemetryResponse
   | TransactionFeeResponse
   | UnboxMessageResponse
   | VerifyTransactionResponse

--- a/ironfish/src/workerPool/tasks/handlers.ts
+++ b/ironfish/src/workerPool/tasks/handlers.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { SubmitTelemetryTask } from './submitTelemetry'
+import { WorkerMessageType } from './workerMessage'
+import { WorkerTask } from './workerTask'
+
+export const handlers: Record<WorkerMessageType, WorkerTask> = {
+  [WorkerMessageType.SubmitTelemetry]: SubmitTelemetryTask.getInstance(),
+}

--- a/ironfish/src/workerPool/tasks/submitTelemetry.test.ts
+++ b/ironfish/src/workerPool/tasks/submitTelemetry.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Metric } from '../../telemetry'
+import { WebApi } from '../../webApi'
+import {
+  SubmitTelemetryRequest,
+  SubmitTelemetryResponse,
+  SubmitTelemetryTask,
+} from './submitTelemetry'
+
+describe('SubmitTelemetryRequest', () => {
+  it('serializes the object to a buffer and deserializes to the original object', () => {
+    const mockMetric: Metric = {
+      measurement: 'node',
+      fields: [
+        {
+          name: 'heap_used',
+          type: 'integer',
+          value: 0,
+        },
+      ],
+    }
+    const request = new SubmitTelemetryRequest([mockMetric])
+    const buffer = request.serialize()
+    const deserializedRequest = SubmitTelemetryRequest.deserialize(request.jobId, buffer)
+    expect(deserializedRequest).toEqual(request)
+  })
+})
+
+describe('SubmitTelemetryResponse', () => {
+  it('serializes the object to a buffer and deserializes to the original object', () => {
+    const response = new SubmitTelemetryResponse(0)
+    const deserializedResponse = SubmitTelemetryResponse.deserialize(response.jobId)
+    expect(deserializedResponse).toEqual(response)
+  })
+})
+
+describe('SubmitTelemetryTask', () => {
+  describe('execute', () => {
+    it('submits points to the API', async () => {
+      const submitTelemetryPointsToApi = jest
+        .spyOn(WebApi.prototype, 'submitTelemetry')
+        .mockImplementationOnce(jest.fn())
+      const mockMetric: Metric = {
+        measurement: 'node',
+        fields: [
+          {
+            name: 'heap_used',
+            type: 'integer',
+            value: 0,
+          },
+        ],
+      }
+      const points = [mockMetric]
+      const task = new SubmitTelemetryTask()
+      const request = new SubmitTelemetryRequest(points)
+
+      await task.execute(request)
+      expect(submitTelemetryPointsToApi).toHaveBeenCalledWith({ points })
+    })
+  })
+})

--- a/ironfish/src/workerPool/tasks/submitTelemetry.ts
+++ b/ironfish/src/workerPool/tasks/submitTelemetry.ts
@@ -1,22 +1,71 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
 import { Metric } from '../../telemetry/interfaces/metric'
 import { WebApi } from '../../webApi'
+import { WorkerMessage, WorkerMessageType } from './workerMessage'
+import { WorkerTask } from './workerTask'
 
-export type SubmitTelemetryRequest = {
-  type: 'submitTelemetry'
+export class SubmitTelemetryRequest extends WorkerMessage {
+  json: string
   points: Metric[]
+
+  constructor(points: Metric[], jobId?: number) {
+    super(WorkerMessageType.SubmitTelemetry, jobId)
+    this.json = JSON.stringify(points)
+    this.points = points
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+    bw.writeVarString(this.json, 'utf8')
+    return bw.render()
+  }
+
+  static deserialize(jobId: number, buffer: Buffer): SubmitTelemetryRequest {
+    const reader = bufio.read(buffer, true)
+    const json = reader.readVarString('utf8')
+    const points = JSON.parse(json) as Metric[]
+    return new SubmitTelemetryRequest(points, jobId)
+  }
+
+  getSize(): number {
+    return bufio.sizeVarString(this.json, 'utf8')
+  }
 }
 
-export type SubmitTelemetryResponse = {
-  type: 'submitTelemetry'
+export class SubmitTelemetryResponse extends WorkerMessage {
+  constructor(jobId: number) {
+    super(WorkerMessageType.SubmitTelemetry, jobId)
+  }
+
+  serialize(): Buffer {
+    return Buffer.from('')
+  }
+
+  static deserialize(jobId: number): SubmitTelemetryResponse {
+    return new SubmitTelemetryResponse(jobId)
+  }
+
+  getSize(): number {
+    return 0
+  }
 }
 
-export async function submitTelemetry({
-  points,
-}: SubmitTelemetryRequest): Promise<SubmitTelemetryResponse> {
-  const api = new WebApi()
-  await api.submitTelemetry({ points })
-  return { type: 'submitTelemetry' }
+export class SubmitTelemetryTask extends WorkerTask {
+  private static instance: SubmitTelemetryTask | undefined
+
+  static getInstance(): SubmitTelemetryTask {
+    if (!SubmitTelemetryTask.instance) {
+      SubmitTelemetryTask.instance = new SubmitTelemetryTask()
+    }
+    return SubmitTelemetryTask.instance
+  }
+
+  async execute({ jobId, points }: SubmitTelemetryRequest): Promise<SubmitTelemetryResponse> {
+    const api = new WebApi()
+    await api.submitTelemetry({ points })
+    return new SubmitTelemetryResponse(jobId)
+  }
 }

--- a/ironfish/src/workerPool/tasks/workerTask.ts
+++ b/ironfish/src/workerPool/tasks/workerTask.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { WorkerMessage } from './workerMessage'
 
-export interface Serializable {
-  serialize(): Buffer
-  getSize(): number
+export abstract class WorkerTask {
+  abstract execute(request: WorkerMessage): WorkerMessage | Promise<WorkerMessage>
 }


### PR DESCRIPTION
## Summary

* Add a request, response, and task class for submitting telemetry
* Remove `deserialize` from `Serializable`. Make this `static` instead per child class
* Use NodeJS `BufferEncoding` type in `bufio.d.ts` and add some more methods / functions
* Add union types for `Buffer`s, `UInt8Array`, and `WorkerMessage`. This change and most added type guards are temporary and will be cleaned up when merging `serializable-worker-pool` to `staging`

Some notes:
* I put a config of handlers [here](https://github.com/iron-fish/ironfish/compare/serialize-worker-pool...feature/iro-1613?expand=1#diff-f9de8a5c7cdfb19380c8e5bf337f48dff0f1ef6fc26a6837ee23f3eb31d28e06R8-R10) that use singletons from a child class. I'm open to refactoring this. I chose this since the types are cleaner since the abstract class can be used (vs trying to type a single exported function).
* The current response is not really used, so the methods return empty buffers / objects / strings. I thought that was cleaner than having errors.

## Testing Plan

Added unit tests and manually verified in Influx with a test version

![Screen Shot 2022-03-09 at 2 16 07 PM](https://user-images.githubusercontent.com/5459049/157515043-b248697e-c97f-4a41-ae8a-79dcb07e3656.png)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
