### PR TITLE
Update deploy-node-github.yml

### DIFF
--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -1,6 +1,9 @@
 name: Deploy Node Image to Github
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   Deploy:
     name: Deploy


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

StepSecurity is working on securing GitHub workflows and [OSSF Scorecards](https://github.com/ossf/scorecard) recommends using StepSecurity's secure-workflows online tool [app.stepsecurity.io](https://github.com/cosmos/cosmos-sdk/pull/app.stepsecurity.io) to improve the security of GitHub workflows.

The `Token-Permissions` category has a score of 0/10 in Scorecards for this repo.

We have fixed one of the repo's workflows for you by adding permissions for the involved jobs. You can secure the rest of the workflows for improved security by using the StepSecurity online tool at [app.stepsecurity.io](https://app.stepsecurity.io/).