### PR TITLE
Add serializable job error to worker pool

### DIFF
--- a/ironfish/src/workerPool/job.ts
+++ b/ironfish/src/workerPool/job.ts
@@ -4,9 +4,9 @@
 
 import { Event } from '../event'
 import { PromiseReject, PromiseResolve, PromiseUtils } from '../utils'
-import { JobAbortedError } from './tasks/jobError'
 import { WorkerRequestMessage, WorkerResponse, WorkerResponseMessage } from './messages'
 import { handleRequest } from './tasks'
+import { JobAbortedError } from './tasks/jobError'
 import { WorkerMessage } from './tasks/workerMessage'
 import { Worker } from './worker'
 

--- a/ironfish/src/workerPool/job.ts
+++ b/ironfish/src/workerPool/job.ts
@@ -4,7 +4,7 @@
 
 import { Event } from '../event'
 import { PromiseReject, PromiseResolve, PromiseUtils } from '../utils'
-import { JobAbortedError } from './errors'
+import { JobAbortedError } from './tasks/jobError'
 import { WorkerRequestMessage, WorkerResponse, WorkerResponseMessage } from './messages'
 import { handleRequest } from './tasks'
 import { WorkerMessage } from './tasks/workerMessage'

--- a/ironfish/src/workerPool/messages.ts
+++ b/ironfish/src/workerPool/messages.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { JobErrorSerialized } from './errors'
 import { BoxMessageRequest, BoxMessageResponse } from './tasks/boxMessage'
 import { CreateMinersFeeRequest, CreateMinersFeeResponse } from './tasks/createMinersFee'
 import { CreateTransactionRequest, CreateTransactionResponse } from './tasks/createTransaction'
@@ -20,11 +19,6 @@ import { VerifyTransactionRequest, VerifyTransactionResponse } from './tasks/ver
 
 export type JobAbortRequest = {
   type: 'jobAbort'
-}
-
-export type JobErrorResponse = {
-  type: 'jobError'
-  error: JobErrorSerialized
 }
 
 export type WorkerRequestMessage = {
@@ -54,7 +48,6 @@ export type WorkerResponse =
   | CreateMinersFeeResponse
   | CreateTransactionResponse
   | GetUnspentNotesResponse
-  | JobErrorResponse
   | MineHeaderResponse
   | SleepResponse
   | TransactionFeeResponse

--- a/ironfish/src/workerPool/pool.test.ts
+++ b/ironfish/src/workerPool/pool.test.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import '../testUtilities/matchers'
-import { JobAbortedError } from './errors'
+import { JobAbortedError } from './tasks/jobError'
 import { WorkerPool } from './pool'
-import { SerializableJobError } from './tasks/jobError'
+import { JobError } from './tasks/jobError'
 
 describe('Worker Pool', () => {
   let pool: WorkerPool
@@ -120,7 +120,7 @@ describe('Worker Pool', () => {
     expect(pool.executing).toBe(1)
 
     await expect(job.response()).rejects.toThrowError('test')
-    await expect(job.response()).toRejectErrorInstance(SerializableJobError)
+    await expect(job.response()).toRejectErrorInstance(JobError)
     expect(job.status).toBe('error')
 
     expect(pool.workers.length).toBe(1)

--- a/ironfish/src/workerPool/pool.test.ts
+++ b/ironfish/src/workerPool/pool.test.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import '../testUtilities/matchers'
-import { JobAbortedError } from './tasks/jobError'
 import { WorkerPool } from './pool'
+import { JobAbortedError } from './tasks/jobError'
 import { JobError } from './tasks/jobError'
 
 describe('Worker Pool', () => {

--- a/ironfish/src/workerPool/pool.test.ts
+++ b/ironfish/src/workerPool/pool.test.ts
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import '../testUtilities/matchers'
-import { JobAbortedError, JobError } from './errors'
+import { JobAbortedError } from './errors'
 import { WorkerPool } from './pool'
+import { SerializableJobError } from './tasks/jobError'
 
 describe('Worker Pool', () => {
   let pool: WorkerPool
@@ -119,7 +120,7 @@ describe('Worker Pool', () => {
     expect(pool.executing).toBe(1)
 
     await expect(job.response()).rejects.toThrowError('test')
-    await expect(job.response()).toRejectErrorInstance(JobError)
+    await expect(job.response()).toRejectErrorInstance(SerializableJobError)
     expect(job.status).toBe('error')
 
     expect(pool.workers.length).toBe(1)

--- a/ironfish/src/workerPool/tasks/handlers.ts
+++ b/ironfish/src/workerPool/tasks/handlers.ts
@@ -5,6 +5,7 @@ import { SubmitTelemetryTask } from './submitTelemetry'
 import { WorkerMessageType } from './workerMessage'
 import { WorkerTask } from './workerTask'
 
-export const handlers: Record<WorkerMessageType, WorkerTask> = {
+export const handlers: Record<WorkerMessageType, WorkerTask | undefined> = {
+  [WorkerMessageType.JobError]: undefined,
   [WorkerMessageType.SubmitTelemetry]: SubmitTelemetryTask.getInstance(),
 }

--- a/ironfish/src/workerPool/tasks/index.ts
+++ b/ironfish/src/workerPool/tasks/index.ts
@@ -35,6 +35,9 @@ export async function handleRequest(
 
   if (!('body' in request)) {
     const handler = handlers[request.type]
+    if (!handler) {
+      throw new Error()
+    }
     return handler.execute(request)
   }
 

--- a/ironfish/src/workerPool/tasks/jobError.ts
+++ b/ironfish/src/workerPool/tasks/jobError.ts
@@ -1,12 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
 import { ErrorUtils } from '../../utils'
 import { WorkerMessage, WorkerMessageType } from './workerMessage'
 
 export class SerializableJobError extends WorkerMessage {
-  errorType: string = 'JobError'
+  errorType = 'JobError'
   code: string | undefined
   stack: string | undefined
-  message: string = ''
+  message = ''
 
   constructor(id?: number, error?: unknown) {
     super(WorkerMessageType.JobError, id)

--- a/ironfish/src/workerPool/tasks/jobError.ts
+++ b/ironfish/src/workerPool/tasks/jobError.ts
@@ -47,7 +47,7 @@ export class SerializableJobError extends WorkerMessage {
     return bw.render()
   }
 
-  static deserialize(jobId: number, buffer: Buffer): SerializableJobError {
+  static deserialize(jobId: number, buffer: Buffer): JobError {
     const br = bufio.read(buffer, true)
 
     const errorType = br.readVarString('utf8')
@@ -74,7 +74,7 @@ export class SerializableJobError extends WorkerMessage {
     err.code = code
     err.stack = stack
 
-    return err
+    return new JobError(err)
   }
 
   getSize(): number {
@@ -85,3 +85,21 @@ export class SerializableJobError extends WorkerMessage {
     return errorTypeSize + messageSize + codeSize + stackSize
   }
 }
+
+export class JobError extends Error {
+  type = 'JobError'
+  code: string | undefined = undefined
+
+  constructor(serializableJobError?: SerializableJobError) {
+    super()
+
+    if (serializableJobError) {
+      this.code = serializableJobError.code
+      this.stack = serializableJobError.stack
+      this.message = serializableJobError.message
+      this.type = serializableJobError.errorType
+    }
+  }
+}
+
+export class JobAbortedError extends JobError {}

--- a/ironfish/src/workerPool/tasks/jobError.ts
+++ b/ironfish/src/workerPool/tasks/jobError.ts
@@ -1,0 +1,84 @@
+import bufio from 'bufio'
+import { ErrorUtils } from '../../utils'
+import { WorkerMessage, WorkerMessageType } from './workerMessage'
+
+export class SerializableJobError extends WorkerMessage {
+  errorType: string = 'JobError'
+  code: string | undefined
+  stack: string | undefined
+  message: string = ''
+
+  constructor(error?: unknown) {
+    super(WorkerMessageType.JobError)
+
+    if (error) {
+      this.errorType =
+        typeof error === 'object' ? error?.constructor.name ?? typeof error : 'unknown'
+
+      this.code = undefined
+      this.stack = undefined
+      this.message = ErrorUtils.renderError(error)
+
+      if (error instanceof Error) {
+        this.code = error.name
+        this.stack = error.stack
+
+        if (ErrorUtils.isNodeError(error)) {
+          this.code = error.code
+        }
+      }
+    }
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write()
+    bw.writeVarString(this.errorType, 'utf8')
+    bw.writeVarString(this.message, 'utf8')
+    if (this.code) {
+      bw.writeVarString(this.code, 'utf8')
+    }
+    if (this.stack) {
+      bw.writeVarString(this.stack, 'utf8')
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): SerializableJobError {
+    const br = bufio.read(buffer, true)
+
+    const errorType = br.readVarString('utf8')
+    const message = br.readVarString('utf8')
+
+    let stack = undefined
+    let code = undefined
+
+    try {
+      code = br.readVarString('utf8')
+    } catch {
+      code = undefined
+    }
+
+    try {
+      stack = br.readVarString('utf8')
+    } catch {
+      stack = undefined
+    }
+
+    const err = new SerializableJobError()
+    err.errorType = errorType
+    err.message = message
+    err.code = code
+    err.stack = stack
+
+    return err
+  }
+
+  getSize(): number {
+    const errorTypeSize = bufio.sizeVarString(this.errorType, 'utf8')
+    const messageSize = bufio.sizeVarString(this.message, 'utf8')
+    const codeSize = this.code ? bufio.sizeVarString(this.code, 'utf8') : 0
+    const stackSize = this.stack ? bufio.sizeVarString(this.stack, 'utf8') : 0
+    return errorTypeSize + messageSize + codeSize + stackSize
+  }
+}

--- a/ironfish/src/workerPool/tasks/jobError.ts
+++ b/ironfish/src/workerPool/tasks/jobError.ts
@@ -8,8 +8,8 @@ export class SerializableJobError extends WorkerMessage {
   stack: string | undefined
   message: string = ''
 
-  constructor(error?: unknown) {
-    super(WorkerMessageType.JobError)
+  constructor(id?: number, error?: unknown) {
+    super(WorkerMessageType.JobError, id)
 
     if (error) {
       this.errorType =
@@ -44,7 +44,7 @@ export class SerializableJobError extends WorkerMessage {
     return bw.render()
   }
 
-  deserialize(buffer: Buffer): SerializableJobError {
+  static deserialize(jobId: number, buffer: Buffer): SerializableJobError {
     const br = bufio.read(buffer, true)
 
     const errorType = br.readVarString('utf8')
@@ -65,7 +65,7 @@ export class SerializableJobError extends WorkerMessage {
       stack = undefined
     }
 
-    const err = new SerializableJobError()
+    const err = new SerializableJobError(jobId)
     err.errorType = errorType
     err.message = message
     err.code = code

--- a/ironfish/src/workerPool/tasks/jobError.ts
+++ b/ironfish/src/workerPool/tasks/jobError.ts
@@ -11,8 +11,8 @@ export class SerializableJobError extends WorkerMessage {
   stack: string | undefined
   message = ''
 
-  constructor(id?: number, error?: unknown) {
-    super(WorkerMessageType.JobError, id)
+  constructor(jobId?: number, error?: unknown) {
+    super(WorkerMessageType.JobError, jobId)
 
     if (error) {
       this.errorType =
@@ -47,6 +47,7 @@ export class SerializableJobError extends WorkerMessage {
     return bw.render()
   }
 
+  // We return JobError so the error can be propagated to a calling Promise's reject method
   static deserialize(jobId: number, buffer: Buffer): JobError {
     const br = bufio.read(buffer, true)
 

--- a/ironfish/src/workerPool/tasks/workerMessage.ts
+++ b/ironfish/src/workerPool/tasks/workerMessage.ts
@@ -6,7 +6,8 @@ import bufio from 'bufio'
 import { Serializable } from '../../common/serializable'
 
 export enum WorkerMessageType {
-  SubmitTelemetry = 0,
+  JobError = 0,
+  SubmitTelemetry = 1,
 }
 
 export abstract class WorkerMessage implements Serializable {

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -13,6 +13,7 @@ import { JobError } from './errors'
 import { Job } from './job'
 import { SubmitTelemetryRequest, SubmitTelemetryResponse } from './tasks/submitTelemetry'
 import { WorkerMessage, WorkerMessageType } from './tasks/workerMessage'
+import { SerializableJobError } from './tasks/jobError'
 
 export class Worker {
   thread: WorkerThread | null = null
@@ -150,13 +151,7 @@ export class Worker {
         this.send(response)
       })
       .catch((e: unknown) => {
-        this.send({
-          jobId: job.id,
-          body: {
-            type: 'jobError',
-            error: new JobError(e).serialize(),
-          },
-        })
+        this.send(new SerializableJobError(job.id, e))
       })
       .finally(() => {
         this.jobs.delete(job.id)

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -228,17 +228,21 @@ export class Worker {
     switch (type) {
       case WorkerMessageType.SubmitTelemetry:
         return SubmitTelemetryRequest.deserialize(jobId, request)
+      case WorkerMessageType.JobError:
+        throw new Error('JobError should not be sent as a request')
     }
   }
 
   private parseResponse(
     jobId: number,
     type: WorkerMessageType,
-    _response: Buffer,
+    response: Buffer,
   ): WorkerMessage {
     switch (type) {
       case WorkerMessageType.SubmitTelemetry:
         return SubmitTelemetryResponse.deserialize(jobId)
+      case WorkerMessageType.JobError:
+        return SerializableJobError.deserialize(jobId, response)
     }
   }
 }

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -224,10 +224,10 @@ export class Worker {
 
   private parseRequest(jobId: number, type: WorkerMessageType, request: Buffer): WorkerMessage {
     switch (type) {
-      case WorkerMessageType.SubmitTelemetry:
-        return SubmitTelemetryRequest.deserialize(jobId, request)
       case WorkerMessageType.JobError:
         throw new Error('JobError should not be sent as a request')
+      case WorkerMessageType.SubmitTelemetry:
+        return SubmitTelemetryRequest.deserialize(jobId, request)
     }
   }
 


### PR DESCRIPTION
## Summary
Added serializable job error to worker pool and adjusted worker pool to use serializable job error instead of the old job error class.

## Testing Plan
Ensured the node still runs properly and a thrown error gets serialized and deserialized correctly.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
