### PR TITLE
Combine single and multi sendTransaction tests

### DIFF
--- a/ironfish/src/rpc/routes/transactions/__fixtures__/sendTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/transactions/__fixtures__/sendTransaction.test.ts.fixture
@@ -1,30 +1,32 @@
 {
-  "Transactions sendTransaction Connected to the network calls the pay method on the node": [
+  "Transactions sendTransaction calls the pay method on the node with single recipient": [
     {
       "name": "account",
-      "spendingKey": "bf1b4b57f3c878015b9685d6a3094720a9600b3a55e8243a93824d7ca5bb062c",
-      "incomingViewKey": "1ea10eaf29b91b5ebb0d7146aed4a0dcd6e9d5500ac86de6a77b2d1d2ec33000",
-      "outgoingViewKey": "51f81ac0a997ced5cda50f9c70464e0c821fdd41d30ee24dc77a226f200d28e6",
-      "publicAddress": "28043184208f73be7f45f286db285b6f47b9a0cde46cc8bcf173de2670b97508773ef276ec99677e0bbc56",
-      "rescan": null
+      "spendingKey": "333aca5afb61ebf771d68e4403f372a5da1c720dd436c1c2d7614ad8d027a2a9",
+      "incomingViewKey": "8d3678e2adeb0b1079d276c1912631186fe343fe15e618b31e8e9a20863f6201",
+      "outgoingViewKey": "04b1bdddee475557e972511ee723f7f034cccfe95f1d2be2afd13e9af4bbc2c3",
+      "publicAddress": "8642210d70c0c2e84c749f0b7c7626c2bea17c9277b755fac2de117ca41644eeda00822064df7730a0efba",
+      "rescan": null,
+      "displayName": "account (4098086)"
     },
     {
       "type": "Buffer",
-      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALBF0lzbKbZVkbD/G/UMmceJdp1XJoGlRiQ0+HBbSs1rK0FrcUQM0rMiIersFG75fKj1FzJ7AbkfIU/NUwGRNx8x8HAv4ZvU/5vfLfanh2O38iD1PqyzXHrKtlaeT8R51BLxlvzT0hAbULSZttHXaj3yr/lKVvJeYcJ3D7YZznxTVc3YtfiTOYRLsivMvYNg9q9d8aZkSwFHgNkG6ooJm49Jn6aHW8Cl7UZFfG8k59OVWVeQXfuz2UdfkzyUnPpAAjEPa2m3/+R4JFdtFHMJ36jTGSO+BkqU4N3C5LJG60rxiPjkplIacQ4fcMjOCE7PbYDjzUz4sivacIvgLOoeaQAFznos9VWBY1X6lD/N0rl3pTOfbJgVM6ASFoOLgXeSQ0fygGmroFYm9q6ZY+0y3cVS2M3TWi+0Nnt0xwYGW4JEyUUqXLqeMFr4eMT+7H+6z9lIwLFi3iaDnHai/QN4WEfwURxgqdVgzI7e7/I6/hZYyCW7Au4Z+cnZpDD3udbGiFl2tkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwO+9icMZjnYXZpsoeOm+56z/ovNzFVcaGygJZiv06SNaqDvKFskUrXWdrwxetwbILLvrL99f4EpmUXMoDWKViBg=="
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIx00h63WrOrXQ8yk7pzJo+UTbziAn8iHh7g5qiFiAtoTcANJnbEoOeLbW12rHQ1dq2Lkg3zIWIpuBeX20CU1C1lfsZhQz2PC7QPxilCo0U7CJ4B2XhX+PVMqdKOt1ukJgRHxywo2eGAKTRE6DFMoxXHraFVTH+3Tu0uKkkbrg/nZxzDH42wSyrfuW/wc+nkDYSpqljeDAHZbVLc6miZgDd/W6a299YYacKVDyZ+JFc93Y1oF830qG7eE0eD54dIHpzj1fw6fR/xvgKuUTNmnqHC5QOIJgE3uTovxlopskAeZWfuwFeRiEXFceMgglyembZwmH8uQ9H6LDYRLuLiNVknQUGG9g7wDlMkVoiOhjWLZzHCn9QAKSDPcS5KbkfrMt0iDfy2up33SumGLn1ipZBAIpZPxSu9Zm2eR7qr+o26WnyO7veYfOODMeQeMS+wK93LjdkYBiYh/C0nXzUykvxnE6u18yjRTAomuni/Qrt83mVEKUnkVps7uIfWlZ9rofBfW0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwn3gjv5mU45GYZLYr/X0wOB7B6vlhYDEVDLkgKkEwA21W1V2u/fr0Wx9vMhF15zxp68scRMKNFg/MqmguE9shAg=="
     }
   ],
-  "Transactions sendTransaction Connected to the network with multiple recipients calls the pay method on the node": [
+  "Transactions sendTransaction calls the pay method on the node with multiple recipient": [
     {
       "name": "account_multi-output",
-      "spendingKey": "85d1c3ec1c2d67441937864f03ff746202cd52418973ff42752d2e389c811e14",
-      "incomingViewKey": "aca00e04cef733a0d7d51f1c8b07cb6fb88b70b6cda7bb8206b587b1fc462504",
-      "outgoingViewKey": "593d45182ba716880e4b133c8517a7c05d67724043d6e242bbfe75a0c13ecc3b",
-      "publicAddress": "f52f0ef34e724c8c8a0533d4c7fab74854279211fab6f989a064eb03fa6bbbdabfe813627452dfd37f9c63",
-      "rescan": null
+      "spendingKey": "917755932c7787e64a341fce296fcecebac42e0e32eb9e96b136d4227b1d5168",
+      "incomingViewKey": "0ce769e2d749b8b3abd3ddd3ce10bf902d5368fc62e932fcd5e3a73bba4f1f05",
+      "outgoingViewKey": "daa115599e535858b78ea9ea6ef99e73a055cfc985eb12d820092b7ad87c0ceb",
+      "publicAddress": "9c86c4ef947db17678b53b617b15e2c8e4626fa5a4201ea3fa7f957f194f60914e784a806c1cf0452c03a2",
+      "rescan": null,
+      "displayName": "account_multi-output (537e599)"
     },
     {
       "type": "Buffer",
-      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJLBqlv3yvMiuhmLsc+s3EIrT8C0/G3pF2DFhDIwHGFaGPOlvO1TiDgHhX/wB/Kv8rRSSfujcYr0G0CosnJCqFVrYQRvgTrShiHajpG+gq9BM/pdacsEhbqFWEwf0kzabgE7cMQeWW2b8bkieWXocVz3PSw4JfCDd7FBnEqdy2zwDTSTBSe6woNMT1ZzpjR8rrT5R2xpuYhyvERQzuEyZVzMTDMufQl03Fz6gLmO01eWEfYZZ/5Rx3T8vofVh1eK+hKzOrEvCyp0nCX5YqMpl3fzDv4zxRznE8Y0AmyR7BaRiCSp57YV8o6r40M9hpnFgTYzvm4dyyK7q7RwAQma+QC3FyNciteBW51UeBlPtTBVlFeqDcZTM3Ve1HXo5m+w6dZW5ySk6cFC3vpFPnKl+xXzgH5j5T9n4yqdR9ORDRZzcUAsfDv7j4NhwVSqXq4HjAAftHf9D7yqOqwz9Ri+75fjOIdDA5DsJpN5FErtOR0PE4bwqxiXIxoBU4H87MeDoRig5EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTd/NN048Du4Xrl7OLBZFBaBr0HgJr3z+IQFV90y23ouHE6KnQRaqTagT6CL+jvQYvA/q3pquAoObtbt/Sd4pAA=="
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIQlCUKYCDnHQ9bcwccWMEg9/DXe1NOv1QNwILuxM07ArB32w9HCY94qlCUz7Yjgn7WU2gM9zfppQ5JWrNZlxMJoneQtsBbnhFQ91FbqcZxfLbI3L8qqkaKxwH/1MvFBLBac5tjzn3AExzCpcijM42qcRWzvB14dVBfS728PjZx0cPr8GSxLF7tgB7dlt2a9XqRBmLPBapy3oLY6hdx7AzmF9tutbgliEbEHTpGHGcZjyemY3hydHMIXII/TjpylRrR2xEMcxaNiavuceaWFZVHJHSM0ovGdbVkt+ftwln0mEriCdIXnPsnsQ4XpJZVpajQkTmXpSDtvMxA3qmisbGLYzAL0G0BwbRt8cw2i4WjY/FPbJvaB5j5fx/9UCUXgMCZG4ZFJfZ+9a/fhMymOfoWJrBErY/a7uCieP5XIQbChmM8ayuwdMC4Q8nO5yw3iRD1p8n7nwRNuZj0dN+kus3oUAQNJi+5js1ceVRuvJpypx5pPNcHS1WZZu1wkPb4okgQic0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIOFQwQUDTj7tO4PNciZol2gXCkz8fonDYtlTFZpVEUh6SSvtMbnEEulXK9z7JACk51G5WrYCxnXGwkOgrnOBDA=="
     }
   ]
 }

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -51,112 +51,97 @@ describe('Transactions sendTransaction', () => {
   })
 
   it('throws if not connected to network', async () => {
+    routeTest.node.peerNetwork['_isReady'] = false
+
     await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
       'Your node must be connected to the Iron Fish network to send a transaction',
     )
   })
 
-  describe('Connected to the network', () => {
-    it('throws if the chain is outdated', async () => {
-      routeTest.node.peerNetwork['_isReady'] = true
+  it('throws if the chain is outdated', async () => {
+    routeTest.node.peerNetwork['_isReady'] = true
+    routeTest.chain.synced = false
 
-      await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
-        'Your node must be synced with the Iron Fish network to send a transaction. Please try again later',
-      )
-    })
-
-    it('throws if not enough funds', async () => {
-      routeTest.node.peerNetwork['_isReady'] = true
-      routeTest.chain.synced = true
-
-      await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
-        'Your balance is too low. Add funds to your account first',
-      )
-    })
-
-    it('throws if the confirmed balance is too low', async () => {
-      routeTest.node.peerNetwork['_isReady'] = true
-      routeTest.chain.synced = true
-
-      jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
-        Promise.resolve({
-          unconfirmed: BigInt(11),
-          confirmed: BigInt(0),
-        }),
-      )
-
-      await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
-        'Please wait a few seconds for your balance to update and try again',
-      )
-    })
-
-    it('calls the pay method on the node', async () => {
-      routeTest.node.peerNetwork['_isReady'] = true
-      routeTest.chain.synced = true
-      routeTest.node.accounts.pay = jest.fn()
-
-      const account = await useAccountFixture(routeTest.node.accounts, 'account')
-      const tx = await useMinersTxFixture(routeTest.node.accounts, account)
-
-      jest.spyOn(routeTest.node.accounts, 'pay').mockResolvedValue(tx)
-
-      jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
-        Promise.resolve({
-          unconfirmed: BigInt(11),
-          confirmed: BigInt(11),
-        }),
-      )
-
-      const result = await routeTest.client.sendTransaction(TEST_PARAMS)
-      expect(result.content.hash).toEqual(tx.hash().toString('hex'))
-    }, 30000)
-
-    describe('with multiple recipients', () => {
-      it('throws if not enough funds', async () => {
-        routeTest.node.peerNetwork['_isReady'] = true
-        routeTest.chain.synced = true
-
-        await expect(routeTest.client.sendTransaction(TEST_PARAMS_MULTI)).rejects.toThrowError(
-          'Your balance is too low. Add funds to your account first',
-        )
-      })
-
-      it('throws if the confirmed balance is too low', async () => {
-        routeTest.node.peerNetwork['_isReady'] = true
-        routeTest.chain.synced = true
-
-        jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
-          Promise.resolve({
-            unconfirmed: BigInt(21),
-            confirmed: BigInt(0),
-          }),
-        )
-
-        await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
-          'Please wait a few seconds for your balance to update and try again',
-        )
-      })
-
-      it('calls the pay method on the node', async () => {
-        routeTest.node.peerNetwork['_isReady'] = true
-        routeTest.chain.synced = true
-        routeTest.node.accounts.pay = jest.fn()
-
-        const account = await useAccountFixture(routeTest.node.accounts, 'account_multi-output')
-        const tx = await useMinersTxFixture(routeTest.node.accounts, account)
-
-        jest.spyOn(routeTest.node.accounts, 'pay').mockResolvedValue(tx)
-
-        jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
-          Promise.resolve({
-            unconfirmed: BigInt(21),
-            confirmed: BigInt(21),
-          }),
-        )
-
-        const result = await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
-        expect(result.content.hash).toEqual(tx.hash().toString('hex'))
-      }, 30000)
-    })
+    await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
+      'Your node must be synced with the Iron Fish network to send a transaction. Please try again later',
+    )
   })
+
+  it('throws if not enough funds', async () => {
+    routeTest.node.peerNetwork['_isReady'] = true
+    routeTest.chain.synced = true
+
+    await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
+      'Your balance is too low. Add funds to your account first',
+    )
+
+    await expect(routeTest.client.sendTransaction(TEST_PARAMS_MULTI)).rejects.toThrowError(
+      'Your balance is too low. Add funds to your account first',
+    )
+  })
+
+  it('throws if the confirmed balance is too low', async () => {
+    routeTest.node.peerNetwork['_isReady'] = true
+    routeTest.chain.synced = true
+
+    jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
+      Promise.resolve({
+        unconfirmed: BigInt(11),
+        confirmed: BigInt(0),
+      }),
+    )
+
+    await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
+      'Please wait a few seconds for your balance to update and try again',
+    )
+
+    jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
+      Promise.resolve({
+        unconfirmed: BigInt(21),
+        confirmed: BigInt(0),
+      }),
+    )
+
+    await expect(routeTest.client.sendTransaction(TEST_PARAMS_MULTI)).rejects.toThrowError(
+      'Please wait a few seconds for your balance to update and try again',
+    )
+  })
+
+  it('calls the pay method on the node with single recipient', async () => {
+    routeTest.node.peerNetwork['_isReady'] = true
+    routeTest.chain.synced = true
+
+    const account = await useAccountFixture(routeTest.node.accounts, 'account')
+    const tx = await useMinersTxFixture(routeTest.node.accounts, account)
+
+    jest.spyOn(routeTest.node.accounts, 'pay').mockResolvedValue(tx)
+    jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
+      Promise.resolve({
+        unconfirmed: BigInt(11),
+        confirmed: BigInt(11),
+      }),
+    )
+
+    const result = await routeTest.client.sendTransaction(TEST_PARAMS)
+    expect(result.content.hash).toEqual(tx.hash().toString('hex'))
+  }, 30000)
+
+  it('calls the pay method on the node with multiple recipient', async () => {
+    routeTest.node.peerNetwork['_isReady'] = true
+    routeTest.chain.synced = true
+
+    const account = await useAccountFixture(routeTest.node.accounts, 'account_multi-output')
+    const tx = await useMinersTxFixture(routeTest.node.accounts, account)
+
+    jest.spyOn(routeTest.node.accounts, 'pay').mockResolvedValue(tx)
+    jest.spyOn(routeTest.node.accounts, 'getBalance').mockReturnValueOnce(
+      Promise.resolve({
+        unconfirmed: BigInt(21),
+        confirmed: BigInt(21),
+      }),
+    )
+
+    const result = await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
+    expect(result.content.hash).toEqual(tx.hash().toString('hex'))
+  }, 30000)
 })


### PR DESCRIPTION
## Summary

I wanted to combine these multi tests since they are very very simple now that the error catching is so small. I think it's also nice to see that the single test just checks against a few inputs.

## Testing Plan
Run testse

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
