### PR TITLE
Add workflows for ironfish sdk and cli

### DIFF
--- a/.github/workflows/deploy-npm-ironfish-cli.yml
+++ b/.github/workflows/deploy-npm-ironfish-cli.yml
@@ -2,7 +2,6 @@ name: Deploy ironfish NPM Package
 
 env:
   DEBUG: 'napi:*'
-  MACOSX_DEPLOYMENT_TARGET: '10.13'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-npm-ironfish-cli.yml
+++ b/.github/workflows/deploy-npm-ironfish-cli.yml
@@ -1,0 +1,42 @@
+name: Deploy ironfish NPM Package
+
+env:
+  DEBUG: 'napi:*'
+  MACOSX_DEPLOYMENT_TARGET: '10.13'
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.13.0'
+          registry-url: 'https://registry.npmjs.org'
+          cache: yarn
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: nodejs
+          working-directory: ironfish-rust-nodejs
+
+      - name: Insert Git hash into ironfish-cli/package.json as gitHash
+        run: |
+          GIT_HASH=$(git rev-parse --short HEAD)
+          cat <<< "$(jq --arg gh "$GIT_HASH" '.gitHash = $gh' < ironfish-cli/package.json)" > ironfish-cli/package.json
+
+      - name: Install dependencies
+        run: yarn --non-interactive --frozen-lockfile
+
+      - name: Publish
+        run: npm publish --access public
+        working-directory: ./ironfish-cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy-npm-ironfish.yml
+++ b/.github/workflows/deploy-npm-ironfish.yml
@@ -1,9 +1,5 @@
 name: Deploy @ironfish/sdk NPM Package
 
-env:
-  DEBUG: 'napi:*'
-  MACOSX_DEPLOYMENT_TARGET: '10.13'
-
 on:
   workflow_dispatch:
 

--- a/.github/workflows/deploy-npm-ironfish.yml
+++ b/.github/workflows/deploy-npm-ironfish.yml
@@ -1,0 +1,43 @@
+name: Deploy @ironfish/sdk NPM Package
+
+env:
+  DEBUG: 'napi:*'
+  MACOSX_DEPLOYMENT_TARGET: '10.13'
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.13.0'
+          registry-url: 'https://registry.npmjs.org'
+          cache: yarn
+
+      - name: Remove lifecycle scripts
+        run: cat <<< "$(jq 'del(.scripts.postinstall)' < package.json)" > package.json
+
+      - name: Insert Git hash into ironfish/package.json as gitHash
+        run: |
+          GIT_HASH=$(git rev-parse --short HEAD)
+          cat <<< "$(jq --arg gh "$GIT_HASH" '.gitHash = $gh' < ironfish/package.json)" > ironfish/package.json
+
+      - name: Install dependencies
+        run: yarn --non-interactive --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+        working-directory: ./ironfish
+
+      - name: Publish
+        run: npm publish --access public
+        working-directory: ./ironfish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -1,8 +1,24 @@
 {
-  "name": "ironfish-cli",
+  "name": "ironfish",
   "version": "0.1.25",
-  "description": "Command line Iron Fish node",
+  "description": "CLI for running and interacting with an Iron Fish node",
   "author": "Iron Fish <contact@ironfish.network> (https://ironfish.network)",
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iron-fish/ironfish.git"
+  },
+  "license": "MPL-2.0",
+  "files": [
+    "/bin",
+    "/build/**/*.js",
+    "/build/**/*.d.ts",
+    "/build/**/*.d.ts.map",
+    "/build/**/*.json",
+    "/npm-shrinkwrap.json",
+    "/oclif.manifest.json"
+  ],
   "engines": {
     "node": "16.x"
   },
@@ -40,15 +56,14 @@
     "oclif:test": "echo NO TESTS",
     "oclif:version": "oclif-dev readme && git add README.md"
   },
-  "license": "MPL-2.0",
   "dependencies": {
     "@ironfish/rust-nodejs": "0.1.1",
+    "@ironfish/sdk": "0.0.3",
     "@oclif/core": "1.3.1",
     "@oclif/plugin-help": "3.2.2",
     "@oclif/plugin-not-found": "1.2.4",
     "axios": "0.21.4",
     "blessed": "0.1.81",
-    "ironfish": "*",
     "json-colorizer": "2.2.2",
     "segfault-handler": "1.3.0",
     "tweetnacl": "1.0.3",
@@ -92,18 +107,8 @@
   "bin": {
     "ironfish": "./bin/run"
   },
-  "bugs": "https://github.com/iron-fish/ironfish/issues",
-  "files": [
-    "/bin",
-    "/lib",
-    "/npm-shrinkwrap.json",
-    "/oclif.manifest.json"
-  ],
-  "homepage": "https://github.com/iron-fish/ironfish",
-  "keywords": [
-    "oclif"
-  ],
-  "main": "build/src/index.js",
-  "repository": "iron-fish/ironfish",
-  "types": "build/src/index.d.ts"
+  "bugs": {
+    "url": "https://github.com/iron-fish/ironfish/issues"
+  },
+  "homepage": "https://ironfish.network"
 }

--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -1,8 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  ConfigOptions,
+  ConnectionError,
+  createRootLogger,
+  IronfishSdk,
+  Logger,
+} from '@ironfish/sdk'
 import { Command, Config } from '@oclif/core'
-import { ConfigOptions, ConnectionError, createRootLogger, IronfishSdk, Logger } from 'ironfish'
 import {
   ConfigFlagKey,
   DatabaseFlag,

--- a/ironfish-cli/src/commands/accounts/balance.test.ts
+++ b/ironfish-cli/src/commands/accounts/balance.test.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { displayIronAmountWithCurrency, GetBalanceResponse, oreToIron } from '@ironfish/sdk'
 import { expect as expectCli, test } from '@oclif/test'
-import { displayIronAmountWithCurrency, GetBalanceResponse, oreToIron } from 'ironfish'
 
 describe('accounts:balance', () => {
   const responseContent: GetBalanceResponse = {
@@ -12,8 +12,8 @@ describe('accounts:balance', () => {
   }
 
   beforeAll(() => {
-    jest.doMock('ironfish', () => {
-      const originalModule = jest.requireActual('ironfish')
+    jest.doMock('@ironfish/sdk', () => {
+      const originalModule = jest.requireActual('@ironfish/sdk')
       const client = {
         connect: jest.fn(),
         getAccountBalance: jest.fn().mockImplementation(() => ({
@@ -34,7 +34,7 @@ describe('accounts:balance', () => {
   })
 
   afterAll(() => {
-    jest.dontMock('ironfish')
+    jest.dontMock('@ironfish/sdk')
   })
 
   describe('fetching the balance for an account', () => {

--- a/ironfish-cli/src/commands/accounts/balance.ts
+++ b/ironfish-cli/src/commands/accounts/balance.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { displayIronAmountWithCurrency, oreToIron } from 'ironfish'
+import { displayIronAmountWithCurrency, oreToIron } from '@ironfish/sdk'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/accounts/create.test.ts
+++ b/ironfish-cli/src/commands/accounts/create.test.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as ironfishmodule from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { expect as expectCli, test } from '@oclif/test'
-import * as ironfishmodule from 'ironfish'
 
 describe('accounts:create command', () => {
   let createAccount = jest.fn()

--- a/ironfish-cli/src/commands/accounts/export.test.ts
+++ b/ironfish-cli/src/commands/accounts/export.test.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ExportAccountResponse } from '@ironfish/sdk'
 import { test } from '@oclif/test'
-import { ExportAccountResponse } from 'ironfish/src'
 import identity from 'lodash/identity'
 
 describe('accounts:export', () => {
@@ -17,8 +17,8 @@ describe('accounts:export', () => {
   }
 
   beforeAll(() => {
-    jest.doMock('ironfish', () => {
-      const originalModule = jest.requireActual('ironfish')
+    jest.doMock('@ironfish/sdk', () => {
+      const originalModule = jest.requireActual('@ironfish/sdk')
       const client = {
         connect: jest.fn(),
         exportAccount: jest.fn().mockImplementation(() => ({
@@ -54,7 +54,7 @@ describe('accounts:export', () => {
   })
 
   afterAll(() => {
-    jest.dontMock('ironfish')
+    jest.dontMock('@ironfish/sdk')
     jest.dontMock('fs')
   })
 

--- a/ironfish-cli/src/commands/accounts/export.ts
+++ b/ironfish-cli/src/commands/accounts/export.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ErrorUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs'
-import { ErrorUtils } from 'ironfish'
 import jsonColorizer from 'json-colorizer'
 import path from 'path'
 import { IronfishCommand } from '../../command'

--- a/ironfish-cli/src/commands/accounts/import.ts
+++ b/ironfish-cli/src/commands/accounts/import.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { JSONUtils, PromiseUtils, SerializedAccount } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { JSONUtils, PromiseUtils, SerializedAccount } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/accounts/list.test.ts
+++ b/ironfish-cli/src/commands/accounts/list.test.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { GetAccountsResponse } from '@ironfish/sdk'
 import { expect as expectCli, test } from '@oclif/test'
-import { GetAccountsResponse } from 'ironfish'
 
 describe('accounts:list', () => {
   const responseContent: GetAccountsResponse = {
@@ -10,8 +10,8 @@ describe('accounts:list', () => {
   }
 
   beforeAll(() => {
-    jest.doMock('ironfish', () => {
-      const originalModule = jest.requireActual('ironfish')
+    jest.doMock('@ironfish/sdk', () => {
+      const originalModule = jest.requireActual('@ironfish/sdk')
 
       const client = {
         connect: jest.fn(),
@@ -34,7 +34,7 @@ describe('accounts:list', () => {
   })
 
   afterAll(() => {
-    jest.dontMock('ironfish')
+    jest.dontMock('@ironfish/sdk')
   })
 
   describe('fetching all accounts', () => {

--- a/ironfish-cli/src/commands/accounts/pay.test.ts
+++ b/ironfish-cli/src/commands/accounts/pay.test.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as ironfishmodule from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { expect as expectCli, test } from '@oclif/test'
-import * as ironfishmodule from 'ironfish'
 
 describe('accounts:pay command', () => {
   let sendTransaction = jest.fn()

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { CliUx, Flags } from '@oclif/core'
 import {
   displayIronAmountWithCurrency,
   ironToOre,
@@ -10,7 +9,8 @@ import {
   isValidPublicAddress,
   MINIMUM_IRON_AMOUNT,
   oreToIron,
-} from 'ironfish'
+} from '@ironfish/sdk'
+import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { ProgressBar } from '../../types'

--- a/ironfish-cli/src/commands/accounts/remove.test.ts
+++ b/ironfish-cli/src/commands/accounts/remove.test.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as ironfish from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { expect as expectCli, test } from '@oclif/test'
-import * as ironfish from 'ironfish'
 
 describe('accounts:remove', () => {
   let removeAccount: jest.Mock<

--- a/ironfish-cli/src/commands/accounts/rescan.test.ts
+++ b/ironfish-cli/src/commands/accounts/rescan.test.ts
@@ -9,8 +9,8 @@ describe('accounts:rescan', () => {
   })
 
   beforeAll(() => {
-    jest.mock('ironfish', () => {
-      const originalModule = jest.requireActual('ironfish')
+    jest.mock('@ironfish/sdk', () => {
+      const originalModule = jest.requireActual('@ironfish/sdk')
       const client = {
         connect: jest.fn(),
         rescanAccountStream: jest.fn().mockImplementation(() => ({
@@ -35,7 +35,7 @@ describe('accounts:rescan', () => {
   })
 
   afterAll(() => {
-    jest.unmock('ironfish')
+    jest.unmock('@ironfish/sdk')
   })
 
   describe('with no flags', () => {

--- a/ironfish-cli/src/commands/accounts/use.test.ts
+++ b/ironfish-cli/src/commands/accounts/use.test.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as ironfish from '@ironfish/sdk'
 import { expect as expectCli, test } from '@oclif/test'
-import * as ironfish from 'ironfish'
 
 describe('accounts:use', () => {
   const useAccount = jest.fn<ironfish.UseAccountResponse, [ironfish.UseAccountRequest]>()

--- a/ironfish-cli/src/commands/accounts/which.test.ts
+++ b/ironfish-cli/src/commands/accounts/which.test.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as ironfish from '@ironfish/sdk'
 import { expect as expectCli, test } from '@oclif/test'
-import * as ironfish from 'ironfish'
 
 describe('accounts:which', () => {
   let getAccounts: jest.Mock<ironfish.GetAccountsResponse, [ironfish.GetAccountsRequest]>

--- a/ironfish-cli/src/commands/backup.ts
+++ b/ironfish-cli/src/commands/backup.ts
@@ -1,10 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { FileUtils, NodeUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { spawn } from 'child_process'
 import fsAsync from 'fs/promises'
-import { FileUtils, NodeUtils } from 'ironfish'
 import os from 'os'
 import path from 'path'
 import { v4 as uuid } from 'uuid'

--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { GraffitiUtils } from 'ironfish'
+import { GraffitiUtils } from '@ironfish/sdk'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { AsyncUtils, GENESIS_BLOCK_SEQUENCE } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs'
-import { AsyncUtils, GENESIS_BLOCK_SEQUENCE } from 'ironfish'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'

--- a/ironfish-cli/src/commands/chain/forks.ts
+++ b/ironfish-cli/src/commands/chain/forks.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { PromiseUtils, TARGET_BLOCK_TIME_IN_SECONDS } from '@ironfish/sdk'
+import { RpcBlock } from '@ironfish/sdk'
 import blessed from 'blessed'
-import { PromiseUtils, TARGET_BLOCK_TIME_IN_SECONDS } from 'ironfish'
-import { RpcBlock } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { GenesisBlockInfo, IJSON, makeGenesisBlock } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
-import { GenesisBlockInfo, IJSON, makeGenesisBlock } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -1,9 +1,15 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  Assert,
+  BlockHeader,
+  IDatabaseTransaction,
+  IronfishNode,
+  TimeUtils,
+} from '@ironfish/sdk'
+import { Meter } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { Assert, BlockHeader, IDatabaseTransaction, IronfishNode, TimeUtils } from 'ironfish'
-import { Meter } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 import { ProgressBar } from '../../types'

--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DEFAULT_CONFIG_NAME, JSONUtils } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { mkdtemp, readFile, writeFile } from 'fs'
-import { DEFAULT_CONFIG_NAME, JSONUtils } from 'ironfish'
 import os from 'os'
 import path from 'path'
 import { promisify } from 'util'
@@ -44,7 +44,7 @@ export class EditCommand extends IronfishCommand {
     const output = JSON.stringify(response.content, undefined, '   ')
 
     const tmpDir = os.tmpdir()
-    const folderPath = await mkdtempAsync(path.join(tmpDir, 'ironfish'))
+    const folderPath = await mkdtempAsync(path.join(tmpDir, '@ironfish/sdk'))
     const filePath = path.join(folderPath, DEFAULT_CONFIG_NAME)
 
     await writeFileAsync(filePath, output)

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ConfigOptions } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
-import { ConfigOptions } from 'ironfish'
 import jsonColorizer from 'json-colorizer'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'

--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DatabaseIsLockedError, FileUtils, IronfishNode, IronfishPKG } from '@ironfish/sdk'
 import { execSync } from 'child_process'
-import { DatabaseIsLockedError, FileUtils, IronfishNode, IronfishPKG } from 'ironfish'
 import os from 'os'
 import { IronfishCommand } from '../command'
 import { LocalFlags } from '../flags'

--- a/ironfish-cli/src/commands/faucet.test.ts
+++ b/ironfish-cli/src/commands/faucet.test.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as ironfishmodule from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { expect as expectCli, test } from '@oclif/test'
-import * as ironfishmodule from 'ironfish'
 
 describe('faucet command', () => {
   let accountName: string | null = null

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { DEFAULT_DISCORD_INVITE, RequestError } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { DEFAULT_DISCORD_INVITE, RequestError } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 import { ONE_FISH_IMAGE, TWO_FISH_IMAGE } from '../images'

--- a/ironfish-cli/src/commands/logs.ts
+++ b/ironfish-cli/src/commands/logs.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ConsoleReporterInstance, IJSON, IronfishNode } from '@ironfish/sdk'
 import { logType } from 'consola'
-import { ConsoleReporterInstance, IJSON, IronfishNode } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CliUx } from '@oclif/core'
 import {
   AsyncUtils,
   GENESIS_BLOCK_SEQUENCE,
@@ -9,7 +8,8 @@ import {
   Meter,
   oreToIron,
   TimeUtils,
-} from 'ironfish'
+} from '@ironfish/sdk'
+import { CliUx } from '@oclif/core'
 import readline from 'readline'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'

--- a/ironfish-cli/src/commands/miners/pool/start.ts
+++ b/ironfish-cli/src/commands/miners/pool/start.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Discord, MiningPool, StringUtils } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
-import { Discord, MiningPool, StringUtils } from 'ironfish'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
 

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -1,15 +1,15 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags } from '@oclif/core'
-import dns from 'dns'
 import {
   DEFAULT_POOL_PORT,
   GraffitiUtils,
   isValidPublicAddress,
   MiningPoolMiner,
   MiningSoloMiner,
-} from 'ironfish'
+} from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
+import dns from 'dns'
 import os from 'os'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'

--- a/ironfish-cli/src/commands/peers/list.ts
+++ b/ironfish-cli/src/commands/peers/list.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { GetPeersResponse, PromiseUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import blessed from 'blessed'
-import { GetPeersResponse, PromiseUtils } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { GetPeerMessagesResponse, GetPeerResponse } from '@ironfish/sdk'
 import colors from 'colors/safe'
-import { GetPeerMessagesResponse, GetPeerResponse } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -1,10 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IronfishNode, NodeUtils, PeerNetwork } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs'
 import fsAsync from 'fs/promises'
-import { IronfishNode, NodeUtils, PeerNetwork } from 'ironfish'
 import path from 'path'
 import { IronfishCommand } from '../command'
 import {

--- a/ironfish-cli/src/commands/restore.ts
+++ b/ironfish-cli/src/commands/restore.ts
@@ -1,12 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { NodeUtils, PromiseUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import axios from 'axios'
 import { spawn } from 'child_process'
 import fs from 'fs'
 import fsAsync from 'fs/promises'
-import { NodeUtils, PromiseUtils } from 'ironfish'
 import os from 'os'
 import path from 'path'
 import { IronfishCommand } from '../command'

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ConnectionError, IronfishIpcClient, Meter, PromiseUtils, WebApi } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
-import { ConnectionError, IronfishIpcClient, Meter, PromiseUtils, WebApi } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/service/sync.ts
+++ b/ironfish-cli/src/commands/service/sync.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { FollowChainStreamResponse, Meter, TimeUtils, WebApi } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
-import { FollowChainStreamResponse, Meter, TimeUtils, WebApi } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/start.test.ts
+++ b/ironfish-cli/src/commands/start.test.ts
@@ -1,13 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as ironfishmodule from '@ironfish/sdk'
 import { expect as expectCli, test } from '@oclif/test'
-import * as ironfishmodule from 'ironfish'
 import { v4 as uuid } from 'uuid'
 import { IronfishCliPKG } from '../package'
 
-jest.mock('ironfish', () => {
-  const originalModule = jest.requireActual('ironfish')
+jest.mock('@ironfish/sdk', () => {
+  const originalModule = jest.requireActual('@ironfish/sdk')
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return {

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert, IronfishNode, NodeUtils, PrivateIdentity, PromiseUtils } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
-import { Assert, IronfishNode, NodeUtils, PrivateIdentity, PromiseUtils } from 'ironfish'
 import tweetnacl from 'tweetnacl'
 import { v4 as uuid } from 'uuid'
 import { IronfishCommand, SIGNALS } from '../command'

--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { GetStatusResponse } from '@ironfish/sdk'
 import { expect as expectCli, test } from '@oclif/test'
-import { GetStatusResponse } from 'ironfish'
 
 describe('status', () => {
   const responseContent: GetStatusResponse = {
@@ -39,8 +39,8 @@ describe('status', () => {
   }
 
   beforeAll(() => {
-    jest.doMock('ironfish', () => {
-      const originalModule = jest.requireActual('ironfish')
+    jest.doMock('@ironfish/sdk', () => {
+      const originalModule = jest.requireActual('@ironfish/sdk')
       const client = {
         connect: jest.fn(),
         status: jest.fn().mockImplementation(() => ({
@@ -62,7 +62,7 @@ describe('status', () => {
   })
 
   afterAll(() => {
-    jest.dontMock('ironfish')
+    jest.dontMock('@ironfish/sdk')
   })
 
   describe('it logs out the status of the node', () => {

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -1,10 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { FileUtils, GetStatusResponse, PromiseUtils } from '@ironfish/sdk'
+import { Assert } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import blessed from 'blessed'
-import { FileUtils, GetStatusResponse, PromiseUtils } from 'ironfish'
-import { Assert } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 

--- a/ironfish-cli/src/commands/stop.ts
+++ b/ironfish-cli/src/commands/stop.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ConnectionError, IronfishNode } from 'ironfish'
+import { ConnectionError, IronfishNode } from '@ironfish/sdk'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 

--- a/ironfish-cli/src/commands/testnet.ts
+++ b/ironfish-cli/src/commands/testnet.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { WebApi } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { WebApi } from 'ironfish'
 import { IronfishCommand } from '../command'
 import { DataDirFlag, DataDirFlagKey, VerboseFlag, VerboseFlagKey } from '../flags'
 import { ENABLE_TELEMETRY_CONFIG_KEY } from './start'

--- a/ironfish-cli/src/commands/workers/status.ts
+++ b/ironfish-cli/src/commands/workers/status.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { GetWorkersStatusResponse, PromiseUtils } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import blessed from 'blessed'
-import { GetWorkersStatusResponse, PromiseUtils } from 'ironfish'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -1,14 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags, Interfaces } from '@oclif/core'
 import {
   DEFAULT_CONFIG_NAME,
   DEFAULT_DATA_DIR,
   DEFAULT_DATABASE_NAME,
   DEFAULT_USE_RPC_IPC,
   DEFAULT_USE_RPC_TCP,
-} from 'ironfish'
+} from '@ironfish/sdk'
+import { Flags, Interfaces } from '@oclif/core'
 
 type CompletableOptionFlag = Interfaces.CompletableOptionFlag<unknown>
 

--- a/ironfish-cli/src/hooks/version.ts
+++ b/ironfish-cli/src/hooks/version.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /* eslint-disable no-console */
+import { Platform } from '@ironfish/sdk'
 import { Hook } from '@oclif/core'
-import { Platform } from 'ironfish'
 import { IronfishCliPKG } from '../package'
 
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/ironfish-cli/src/package.ts
+++ b/ironfish-cli/src/package.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { getPackageFrom } from 'ironfish'
+import { getPackageFrom } from '@ironfish/sdk'
 import pkg from '../package.json'
 
 export const IronfishCliPKG = getPackageFrom(pkg)

--- a/ironfish-cli/src/utils/editor.ts
+++ b/ironfish-cli/src/utils/editor.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert, Config } from '@ironfish/sdk'
 import { spawn } from 'child_process'
-import { Assert, Config } from 'ironfish'
 
 export function launchEditor(file: string, config?: Config): Promise<number | null> {
   let editor = process.env.EDITOR

--- a/ironfish-cli/src/utils/rpc.ts
+++ b/ironfish-cli/src/utils/rpc.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { isResponseUserError, RequestError } from 'ironfish'
+import { isResponseUserError, RequestError } from '@ironfish/sdk'
 
 export function hasUserResponseError(error: unknown): error is RequestError {
   return (

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -1,10 +1,21 @@
 {
-  "name": "ironfish",
-  "version": "0.0.1",
-  "private": true,
+  "name": "@ironfish/sdk",
+  "version": "0.0.3",
+  "description": "SDK for running and interacting with an Iron Fish node",
   "author": "Iron Fish <contact@ironfish.network> (https://ironfish.network)",
-  "main": "build/src",
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iron-fish/ironfish.git"
+  },
   "license": "MPL-2.0",
+  "files": [
+    "build/**/*.js",
+    "build/**/*.d.ts",
+    "build/**/*.d.ts.map",
+    "build/**/*.json"
+  ],
   "dependencies": {
     "@ironfish/rust-nodejs": "0.1.1",
     "@napi-rs/blake-hash": "1.3.1",
@@ -14,7 +25,7 @@
     "buffer": "6.0.3",
     "buffer-json": "2.0.0",
     "buffer-map": "0.0.7",
-    "bufio": "^1.0.7",
+    "bufio": "1.0.7",
     "colors": "1.4.0",
     "consola": "2.15.0",
     "date-fns": "2.16.1",
@@ -24,14 +35,15 @@
     "level-errors": "2.0.1",
     "leveldown": "5.6.0",
     "levelup": "4.4.0",
-    "lodash": "^4.17.20",
+    "lodash": "4.17.21",
     "node-datachannel": "0.1.12",
     "node-ipc": "9.1.3",
     "parse-json": "5.1.0",
     "sqlite": "4.0.23",
     "sqlite3": "5.0.2",
     "tweetnacl": "1.0.3",
-    "uuid": "^8.3.0",
+    "uuid": "8.3.2",
+    "ws": "7.5.1",
     "yup": "0.29.3"
   },
   "scripts": {
@@ -70,10 +82,13 @@
     "jest": "26.6.3",
     "prettier": "2.3.2",
     "ts-jest": "26.5.5",
-    "typescript": "4.3.4",
-    "ws": "7.5.1"
+    "typescript": "4.3.4"
   },
   "resolutions": {
     "highlight.js": "10.4.1"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/iron-fish/ironfish/issues"
+  },
+  "homepage": "https://ironfish.network"
 }

--- a/ironfish/src/storage/database.test.ts
+++ b/ironfish/src/storage/database.test.ts
@@ -102,7 +102,7 @@ describe('Database', () => {
 
   it('should store and get values', async () => {
     await db.open()
-    const foo = { hash: 'hello', name: 'ironfish' }
+    const foo = { hash: 'hello', name: '@ironfish/sdk' }
     const fooHash = Buffer.from(JSON.stringify(foo))
 
     await fooStore.put('hello', foo)
@@ -124,7 +124,7 @@ describe('Database', () => {
 
   it('should clear store', async () => {
     await db.open()
-    const foo = { hash: 'hello', name: 'ironfish' }
+    const foo = { hash: 'hello', name: '@ironfish/sdk' }
     const fooHash = Buffer.from(JSON.stringify(foo))
 
     await fooStore.put('hello', foo)
@@ -210,7 +210,7 @@ describe('Database', () => {
     it('should batch array of writes', async () => {
       await db.open()
 
-      const foo = { hash: 'hello', name: 'ironfish' }
+      const foo = { hash: 'hello', name: '@ironfish/sdk' }
       const fooHash = Buffer.from(JSON.stringify(foo))
 
       await db.batch([
@@ -237,7 +237,7 @@ describe('Database', () => {
     it('should batch chained of writes', async () => {
       await db.open()
 
-      const foo = { hash: 'hello', name: 'ironfish' }
+      const foo = { hash: 'hello', name: '@ironfish/sdk' }
       const fooHash = Buffer.from(JSON.stringify(foo))
 
       await db
@@ -268,7 +268,7 @@ describe('Database', () => {
     it('should write in transaction manually', async () => {
       await db.open()
 
-      const foo = { hash: 'hello', name: 'ironfish' }
+      const foo = { hash: 'hello', name: '@ironfish/sdk' }
       const fooHash = Buffer.from(JSON.stringify(foo))
 
       let transaction = db.transaction()
@@ -332,7 +332,7 @@ describe('Database', () => {
     it('should write in transaction automatically', async () => {
       await db.open()
 
-      const foo = { hash: 'hello', name: 'ironfish' }
+      const foo = { hash: 'hello', name: '@ironfish/sdk' }
       const fooHash = Buffer.from(JSON.stringify(foo))
 
       await expect(() =>
@@ -373,7 +373,7 @@ describe('Database', () => {
     it('should cache transaction operations', async () => {
       await db.open()
 
-      const foo = { hash: 'hello', name: 'ironfish' }
+      const foo = { hash: 'hello', name: '@ironfish/sdk' }
       const bar = { hash: 'hello', name: 'world' }
 
       // With an automatic transaction

--- a/yarn.lock
+++ b/yarn.lock
@@ -2768,7 +2768,7 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-bufio@^1.0.7, bufio@~1.0.6:
+bufio@1.0.7, bufio@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/bufio/-/bufio-1.0.7.tgz#b7f63a1369a0829ed64cc14edf0573b3e382a33e"
   integrity sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==
@@ -6870,7 +6870,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@4.x, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.5.1, lodash@^4.7.0:
+lodash@4.17.21, lodash@4.x, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.5.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Summary

Updates the package.json in the `ironfish` and `ironfish-cli` folder to prepare for publishing to npm. The `ironfish` folder will be published as `@ironfish/sdk` and the `ironfish-cli` folder will be published as `ironfish`.`

## Testing Plan

`npm install -g ironfish` and verify that the node starts up.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
