### PR TITLE
Add lint rule for Buffer comparison

### DIFF
--- a/config/eslint-config-ironfish/index.js
+++ b/config/eslint-config-ironfish/index.js
@@ -58,6 +58,7 @@ module.exports = {
 
   rules: {
     'ironfish/no-vague-imports': 'error',
+    'ironfish/no-buffer-cmp': 'error',
 
     // Seems to be needed to allow for custom jest matchers
     '@typescript-eslint/no-namespace': [

--- a/config/eslint-plugin-ironfish/file.ts
+++ b/config/eslint-plugin-ironfish/file.ts
@@ -1,0 +1,2 @@
+// This file needs to exist in this folder for the Typescript ESLintUtils.RuleTester
+// https://typescript-eslint.io/docs/development/custom-rules#testing-typed-rules

--- a/config/eslint-plugin-ironfish/index.js
+++ b/config/eslint-plugin-ironfish/index.js
@@ -1,3 +1,11 @@
+const { ESLintUtils } = require("@typescript-eslint/utils");
+
+function getTypeName(parserServices, checker, node) {
+  const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+  const nodeType = checker.getTypeAtLocation(originalNode);
+  return checker.typeToString(nodeType);
+}
+
 module.exports.rules = {
   "no-vague-imports": {
     create(context) {
@@ -7,6 +15,27 @@ module.exports.rules = {
             context.report({
               node,
               message: "Non-specific import. Import a specific file.",
+            });
+          }
+        },
+      };
+    },
+  },
+  "no-buffer-cmp": {
+    create(context) {
+      return {
+        BinaryExpression: function (node) {
+          const parserServices = ESLintUtils.getParserServices(context);
+          const checker = parserServices.program.getTypeChecker();
+
+          const leftType = getTypeName(parserServices, checker, node.left);
+          const rightType = getTypeName(parserServices, checker, node.right);
+
+          if (leftType === "Buffer" || rightType === "Buffer") {
+            context.report({
+              node,
+              message:
+                "Incorrect comparison of Buffers. Use Buffer.equals or Buffer.compare instead.",
             });
           }
         },

--- a/config/eslint-plugin-ironfish/index.test.js
+++ b/config/eslint-plugin-ironfish/index.test.js
@@ -1,8 +1,15 @@
 const { rules } = require("./index");
-const { RuleTester } = require("eslint");
+const { ESLintUtils } = require("@typescript-eslint/utils");
 
-const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: "module" },
+// Remove this once https://github.com/typescript-eslint/typescript-eslint/pull/4656 has been released
+global.afterAll = () => {};
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    project: "./tsconfig.json",
+    tsconfigRootDir: __dirname,
+  },
+  parser: "@typescript-eslint/parser",
 });
 
 ruleTester.run("no-vague-imports", rules["no-vague-imports"], {
@@ -23,6 +30,28 @@ ruleTester.run("no-vague-imports", rules["no-vague-imports"], {
     {
       code: "import foo from '../..'",
       errors: [{ message: /specific/i }],
+    },
+  ],
+});
+
+ruleTester.run("no-buffer-cmp", rules["no-buffer-cmp"], {
+  valid: ["[1] === [1]", "1 >= 1", "false == true", "null != undefined"],
+  invalid: [
+    {
+      code: "Buffer.alloc(1) == false",
+      errors: [{ message: /Incorrect comparison of Buffers/i }],
+    },
+    {
+      code: "null === Buffer.alloc(1)",
+      errors: [{ message: /Incorrect comparison of Buffers/i }],
+    },
+    {
+      code: "Buffer.alloc(1) <= Buffer.alloc(1)",
+      errors: [{ message: /Incorrect comparison of Buffers/i }],
+    },
+    {
+      code: "const x = Buffer.alloc(1); x > 0",
+      errors: [{ message: /Incorrect comparison of Buffers/i }],
     },
   ],
 });

--- a/config/eslint-plugin-ironfish/package.json
+++ b/config/eslint-plugin-ironfish/package.json
@@ -12,5 +12,8 @@
   },
   "scripts": {
     "test": "node index.test.js"
+  },
+  "dependencies": {
+    "@typescript-eslint/utils": "5.14.0"
   }
 }

--- a/config/eslint-plugin-ironfish/tsconfig.json
+++ b/config/eslint-plugin-ironfish/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "comment": "This file needs to exist in this folder for the Typescript ESLintUtils.RuleTester",
+    "url": "https://typescript-eslint.io/docs/development/custom-rules#testing-typed-rules"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1829,7 +1829,7 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/json-schema@^7.0.7":
+"@types/json-schema@^7.0.7", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
@@ -2004,6 +2004,14 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
+"@typescript-eslint/scope-manager@5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz#ea518962b42db8ed0a55152ea959c218cb53ca7b"
+  integrity sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==
+  dependencies:
+    "@typescript-eslint/types" "5.14.0"
+    "@typescript-eslint/visitor-keys" "5.14.0"
+
 "@typescript-eslint/types@4.28.1":
   version "4.28.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.1.tgz#d0f2ecbef3684634db357b9bbfc97b94b828f83f"
@@ -2013,6 +2021,11 @@
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+
+"@typescript-eslint/types@5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.14.0.tgz#96317cf116cea4befabc0defef371a1013f8ab11"
+  integrity sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==
 
 "@typescript-eslint/typescript-estree@4.28.1":
   version "4.28.1"
@@ -2040,6 +2053,31 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz#78b7f7385d5b6f2748aacea5c9b7f6ae62058314"
+  integrity sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==
+  dependencies:
+    "@typescript-eslint/types" "5.14.0"
+    "@typescript-eslint/visitor-keys" "5.14.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.14.0.tgz#6c8bc4f384298cbbb32b3629ba7415f9f80dc8c4"
+  integrity sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.14.0"
+    "@typescript-eslint/types" "5.14.0"
+    "@typescript-eslint/typescript-estree" "5.14.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@4.28.1":
   version "4.28.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz#162a515ee255f18a6068edc26df793cdc1ec9157"
@@ -2055,6 +2093,14 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz#1927005b3434ccd0d3ae1b2ecf60e65943c36986"
+  integrity sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==
+  dependencies:
+    "@typescript-eslint/types" "5.14.0"
+    eslint-visitor-keys "^3.0.0"
 
 JSONStream@^1.0.4, JSONStream@^1.2.1, JSONStream@^1.3.5:
   version "1.3.5"
@@ -3582,7 +3628,7 @@ debug@^3.1.0, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.3:
+debug@^4.3.2, debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -4144,6 +4190,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@7.29.0:
   version "7.29.0"
@@ -5708,7 +5759,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==


### PR DESCRIPTION
## Summary

See pull request #1094  for related fixes.

![image](https://user-images.githubusercontent.com/97762857/157948276-20d78df3-47c4-486d-87c5-09371045f6bb.png)


## Testing Plan

Ran yarn lint locally to compare, doesn't seem to add any appreciable time to lint times. Added some dummy lines in code to test as well.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
