### PR TITLE
Upgrade napi-rs and remove NoteBuilder

### DIFF
--- a/ironfish-rust-nodejs/Cargo.lock
+++ b/ironfish-rust-nodejs/Cargo.lock
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ec66e60f000c78dd7c6215b6fa260e0591e09805024332bc5b3f55acc12244"
+checksum = "f88bea662fb056d2115af6a362f89ba8147b26665f3860cc458d25e555d6e60b"
 dependencies = [
  "ctor",
  "lazy_static",
@@ -727,9 +727,9 @@ checksum = "ebd4419172727423cf30351406c54f6cc1b354a2cfb4f1dba3e6cd07f6d5522b"
 
 [[package]]
 name = "napi-derive"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ac5287a5e94a8728fc82d16c5127acc5eb5b8ad6404ef5f82d6a4ce8d5bdd2"
+checksum = "a4f3a8ed8cdbf81628c394ef5ad22bf9e6af312552bca0b8918b0a3c06ab750d"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427f4f04525635cdf22005d1be62d6d671bcb5550d694a1efb480a315422b4af"
+checksum = "6b12b293d2214c58765fbed84d9359d22384cb6f4d9610ed4d807040ed7f47ee"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -1259,9 +1259,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b749ebd2304aa012c5992d11a25d07b406bdbe5f79d371cb7a918ce501a19eb0"
+checksum = "0128fa8e65e0616e45033d68dc0b7fbd521080b7844e5cad3a4a4d201c4b2bd2"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -1272,33 +1272,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "zcash_primitives"

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -10,11 +10,11 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-napi-derive = "2.1.0"
+napi-derive = "2.2.0"
 ironfish_rust= { path = "../ironfish-rust", features = ["native"] }
 
 [dependencies.napi]
-version = "2.1.0"
+version = "2.2.0"
 features = ["napi6"]
 
 [build-dependencies]

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -38,18 +38,10 @@ export class NoteEncrypted {
   /** Returns undefined if the note was unable to be decrypted with the given key. */
   decryptNoteForSpender(outgoingHexKey: string): Buffer | undefined | null
 }
-export type NativeNoteBuilder = NoteBuilder
-export class NoteBuilder {
-  /**
-   * TODO: This works around a concurrency bug when using #[napi(factory)]
-   * in worker threads. It can be merged into NativeNote once the bug is fixed.
-   */
-  constructor(owner: string, value: bigint, memo: string)
-  serialize(): Buffer
-}
 export type NativeNote = Note
 export class Note {
-  constructor(bytes: Buffer)
+  constructor(owner: string, value: bigint, memo: string)
+  static deserialize(bytes: Buffer): NativeNote
   serialize(): Buffer
   /** Value this note represents. */
   value(): bigint

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -236,10 +236,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { NoteEncrypted, NoteBuilder, Note, TransactionPosted, Transaction, generateKey, generateNewPublicAddress, FoundBlockResult, ThreadPoolHandler } = nativeBinding
+const { NoteEncrypted, Note, TransactionPosted, Transaction, generateKey, generateNewPublicAddress, FoundBlockResult, ThreadPoolHandler } = nativeBinding
 
 module.exports.NoteEncrypted = NoteEncrypted
-module.exports.NoteBuilder = NoteBuilder
 module.exports.Note = Note
 module.exports.TransactionPosted = TransactionPosted
 module.exports.Transaction = Transaction

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -8,37 +8,6 @@ use napi_derive::napi;
 use ironfish_rust::note::Memo;
 use ironfish_rust::sapling_bls12::{Key, Note, SAPLING};
 
-#[napi(js_name = "NoteBuilder")]
-pub struct NativeNoteBuilder {
-    pub(crate) note: Note,
-}
-
-#[napi]
-impl NativeNoteBuilder {
-    /// TODO: This works around a concurrency bug when using #[napi(factory)]
-    /// in worker threads. It can be merged into NativeNote once the bug is fixed.
-    #[napi(constructor)]
-    pub fn new(owner: String, value: BigInt, memo: String) -> Result<Self> {
-        let value_u64 = value.get_u64().1;
-
-        let owner_address = ironfish_rust::PublicAddress::from_hex(SAPLING.clone(), &owner)
-            .map_err(|err| Error::from_reason(err.to_string()))?;
-        Ok(NativeNoteBuilder {
-            note: Note::new(SAPLING.clone(), owner_address, value_u64, Memo::from(memo)),
-        })
-    }
-
-    #[napi]
-    pub fn serialize(&self) -> Result<Buffer> {
-        let mut arr: Vec<u8> = vec![];
-        self.note
-            .write(&mut arr)
-            .map_err(|err| Error::from_reason(err.to_string()))?;
-
-        Ok(Buffer::from(arr))
-    }
-}
-
 #[napi(js_name = "Note")]
 pub struct NativeNote {
     pub(crate) note: Note,
@@ -47,7 +16,18 @@ pub struct NativeNote {
 #[napi]
 impl NativeNote {
     #[napi(constructor)]
-    pub fn new(bytes: Buffer) -> Result<Self> {
+    pub fn new(owner: String, value: BigInt, memo: String) -> Result<Self> {
+        let value_u64 = value.get_u64().1;
+
+        let owner_address = ironfish_rust::PublicAddress::from_hex(SAPLING.clone(), &owner)
+            .map_err(|err| Error::from_reason(err.to_string()))?;
+        Ok(NativeNote {
+            note: Note::new(SAPLING.clone(), owner_address, value_u64, Memo::from(memo)),
+        })
+    }
+
+    #[napi(factory)]
+    pub fn deserialize(bytes: Buffer) -> Result<Self> {
         let hasher = SAPLING.clone();
         let note = Note::read(bytes.as_ref(), hasher)
             .map_err(|err| Error::from_reason(err.to_string()))?;

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -6,7 +6,6 @@ import type { Account } from '../account'
 import {
   generateKey,
   Note as NativeNote,
-  NoteBuilder as NativeNoteBuilder,
   Transaction as NativeTransaction,
 } from '@ironfish/rust-nodejs'
 import { Blockchain } from '../blockchain'
@@ -53,11 +52,9 @@ export async function makeGenesisBlock(
   const genesisKey = generateKey()
   // Create a genesis note granting the genesisKey allocationSum coins.
   const genesisNote = new NativeNote(
-    new NativeNoteBuilder(
-      genesisKey.public_address,
-      BigInt(allocationSum),
-      info.memo,
-    ).serialize(),
+    genesisKey.public_address,
+    BigInt(allocationSum),
+    info.memo,
   )
 
   // Create a miner's fee transaction for the block.
@@ -67,9 +64,8 @@ export async function makeGenesisBlock(
   // This transaction will cause block.verify to fail, but we skip block verification
   // throughout the code when the block header's previousBlockHash is GENESIS_BLOCK_PREVIOUS.
   logger.info(`Generating a miner's fee transaction for the block...`)
-  const note = new NativeNote(
-    new NativeNoteBuilder(account.publicAddress, BigInt(0), '').serialize(),
-  )
+  const note = new NativeNote(account.publicAddress, BigInt(0), '')
+
   const minersFeeTransaction = new NativeTransaction()
   minersFeeTransaction.receive(account.spendingKey, note)
   const postedMinersFeeTransaction = new Transaction(
@@ -131,9 +127,7 @@ export async function makeGenesisBlock(
     logger.info(
       `  Generating a receipt for ${alloc.amount} coins for ${alloc.publicAddress}...`,
     )
-    const note = new NativeNote(
-      new NativeNoteBuilder(alloc.publicAddress, BigInt(alloc.amount), info.memo).serialize(),
-    )
+    const note = new NativeNote(alloc.publicAddress, BigInt(alloc.amount), info.memo)
     transaction.receive(genesisKey.spending_key, note)
   }
 

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -20,7 +20,7 @@ export class Note {
   takeReference(): NativeNote {
     this.referenceCount++
     if (this.note === null) {
-      this.note = new NativeNote(this.noteSerialized)
+      this.note = NativeNote.deserialize(this.noteSerialized)
     }
     return this.note
   }

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -7,7 +7,6 @@ import {
   generateNewPublicAddress,
   Key,
   Note as NativeNote,
-  NoteBuilder as NativeNoteBuilder,
   Transaction as NativeTransaction,
   TransactionPosted as NativeTransactionPosted,
 } from '@ironfish/rust-nodejs'
@@ -99,7 +98,7 @@ describe('Demonstrate the Sapling API', () => {
     it('Can create a miner reward', () => {
       const owner = generateNewPublicAddress(spenderKey.spending_key).public_address
 
-      minerNote = new NativeNote(new NativeNoteBuilder(owner, BigInt(42), '').serialize())
+      minerNote = new NativeNote(owner, BigInt(42), '')
 
       const transaction = new NativeTransaction()
       expect(transaction.receive(spenderKey.spending_key, minerNote)).toBe('')
@@ -139,9 +138,7 @@ describe('Demonstrate the Sapling API', () => {
 
     it('Can add a receive to the transaction', () => {
       receiverKey = generateKey()
-      const receivingNote = new NativeNote(
-        new NativeNoteBuilder(receiverKey.public_address, BigInt(40), '').serialize(),
-      )
+      const receivingNote = new NativeNote(receiverKey.public_address, BigInt(40), '')
       const result = transaction.receive(spenderKey.spending_key, receivingNote)
       expect(result).toEqual('')
     })
@@ -275,15 +272,11 @@ describe('Demonstrate the Sapling API', () => {
       expect(transaction.spend(receiverKey.spending_key, note, witness)).toBe('')
       receiverNote.returnReference()
 
-      const noteForSpender = new NativeNote(
-        new NativeNoteBuilder(spenderKey.public_address, BigInt(10), '').serialize(),
-      )
+      const noteForSpender = new NativeNote(spenderKey.public_address, BigInt(10), '')
       const receiverNoteToSelf = new NativeNote(
-        new NativeNoteBuilder(
-          generateNewPublicAddress(receiverKey.spending_key).public_address,
-          BigInt(29),
-          '',
-        ).serialize(),
+        generateNewPublicAddress(receiverKey.spending_key).public_address,
+        BigInt(29),
+        '',
       )
 
       expect(transaction.receive(receiverKey.spending_key, noteForSpender)).toBe('')

--- a/ironfish/src/workerPool/tasks/createMinersFee.ts
+++ b/ironfish/src/workerPool/tasks/createMinersFee.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { generateNewPublicAddress, Note, NoteBuilder, Transaction } from '@ironfish/rust-nodejs'
+import { generateNewPublicAddress, Note, Transaction } from '@ironfish/rust-nodejs'
 
 export type CreateMinersFeeRequest = {
   type: 'createMinersFee'
@@ -24,7 +24,7 @@ export function handleCreateMinersFee({
   // Generate a public address from the miner's spending key
   const minerPublicAddress = generateNewPublicAddress(spendKey).public_address
 
-  const minerNote = new Note(new NoteBuilder(minerPublicAddress, amount, memo).serialize())
+  const minerNote = new Note(minerPublicAddress, amount, memo)
 
   const transaction = new Transaction()
   transaction.receive(spendKey, minerNote)

--- a/ironfish/src/workerPool/tasks/createTransaction.ts
+++ b/ironfish/src/workerPool/tasks/createTransaction.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Note, NoteBuilder, Transaction } from '@ironfish/rust-nodejs'
+import { Note, Transaction } from '@ironfish/rust-nodejs'
 import { Witness } from '../../merkletree'
 import { NoteHasher } from '../../merkletree/hasher'
 import { Side } from '../../merkletree/merkletree'
@@ -43,7 +43,7 @@ export function handleCreateTransaction({
   transaction.setExpirationSequence(expirationSequence)
 
   for (const spend of spends) {
-    const note = new Note(spend.note)
+    const note = Note.deserialize(spend.note)
     transaction.spend(
       spendKey,
       note,
@@ -52,7 +52,7 @@ export function handleCreateTransaction({
   }
 
   for (const { publicAddress, amount, memo } of receives) {
-    const note = new Note(new NoteBuilder(publicAddress, amount, memo).serialize())
+    const note = new Note(publicAddress, amount, memo)
     transaction.receive(spendKey, note)
   }
 


### PR DESCRIPTION
## Summary

The upgraded version of NAPI-rs fixes factory functions causing intermittent errors when run in worker threads. This allows us to get rid of the NativeNoteBuilder that we added to work around the issue, saving an extra serialization.

## Testing Plan

Tests should pass, and if you're interested in verifying that the fix seems to work, you can check out my repro in https://github.com/dguenther/napi-rs-issues/tree/1073.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
