### PR TITLE
Add a flag to skip payouts for the pool

### DIFF
--- a/ironfish-cli/src/commands/miners/pool/start.ts
+++ b/ironfish-cli/src/commands/miners/pool/start.ts
@@ -15,8 +15,9 @@ export class StartPool extends IronfishCommand {
       char: 'd',
       description: 'a discord webhook URL to send critical information to',
     }),
-    disablePayouts: Flags.boolean({
-      default: false,
+    payouts: Flags.boolean({
+      default: true,
+      allowNo: true,
       description: 'whether the pool should payout or not. useful for solo miners',
     }),
   }
@@ -54,7 +55,7 @@ export class StartPool extends IronfishCommand {
     this.pool = await MiningPool.init({
       config: this.sdk.config,
       rpc,
-      enablePayouts: !flags.disablePayouts,
+      enablePayouts: flags.payouts,
       discord,
     })
 

--- a/ironfish-cli/src/commands/miners/pool/start.ts
+++ b/ironfish-cli/src/commands/miners/pool/start.ts
@@ -15,6 +15,10 @@ export class StartPool extends IronfishCommand {
       char: 'd',
       description: 'a discord webhook URL to send critical information to',
     }),
+    disablePayouts: Flags.boolean({
+      default: false,
+      description: 'whether the pool should payout or not. useful for solo miners',
+    }),
   }
 
   pool: MiningPool | null = null
@@ -50,6 +54,7 @@ export class StartPool extends IronfishCommand {
     this.pool = await MiningPool.init({
       config: this.sdk.config,
       rpc,
+      enablePayouts: !flags.disablePayouts,
       discord,
     })
 

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -90,12 +90,14 @@ export class MiningPool {
     config: Config
     logger?: Logger
     discord?: Discord
+    enablePayouts?: boolean
   }): Promise<MiningPool> {
     const shares = await MiningPoolShares.init({
       rpc: options.rpc,
       config: options.config,
       logger: options.logger,
       discord: options.discord,
+      enablePayouts: options.enablePayouts,
     })
 
     return new MiningPool({

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -17,6 +17,7 @@ export class MiningPoolShares {
   readonly discord: Discord | null
 
   private readonly db: PoolDatabase
+  private enablePayouts: boolean
   private payoutInterval: SetTimeoutToken | null
 
   private poolName: string
@@ -31,12 +32,14 @@ export class MiningPoolShares {
     config: Config
     logger?: Logger
     discord?: Discord
+    enablePayouts?: boolean
   }) {
     this.db = options.db
     this.rpc = options.rpc
-    this.logger = options.logger ?? createRootLogger()
     this.config = options.config
+    this.logger = options.logger ?? createRootLogger()
     this.discord = options.discord ?? null
+    this.enablePayouts = options.enablePayouts ?? true
 
     this.poolName = this.config.get('poolName')
     this.recentShareCutoff = this.config.get('poolRecentShareCutoff')
@@ -52,6 +55,7 @@ export class MiningPoolShares {
     config: Config
     logger?: Logger
     discord?: Discord
+    enablePayouts?: boolean
   }): Promise<MiningPoolShares> {
     const db = await PoolDatabase.init({
       config: options.config,
@@ -60,14 +64,17 @@ export class MiningPoolShares {
     return new MiningPoolShares({
       db,
       rpc: options.rpc,
-      logger: options.logger,
       config: options.config,
+      logger: options.logger,
       discord: options.discord,
+      enablePayouts: options.enablePayouts,
     })
   }
 
   async start(): Promise<void> {
-    this.startPayoutInterval()
+    if (this.enablePayouts) {
+      this.startPayoutInterval()
+    }
     await this.db.start()
   }
 


### PR DESCRIPTION
## Summary

This allows solo miners with multiple mining machines to utilize the pool without having to create pointless transactions that will waste IRON on transaction fees

## Testing Plan

Tested that the flag was set correctly in both cases of disablePayout being provided and not provided

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
