### PR TITLE
Fix ironfish recursive package during docker build

### DIFF
--- a/ironfish-cli/scripts/build.sh
+++ b/ironfish-cli/scripts/build.sh
@@ -59,7 +59,7 @@ cp -R ../../build ./
 echo "Copying node_modules"
 # Exclude fsevents to fix brew audit error:
 # "Binaries built for a non-native architecture were installed into ironfish's prefix"
-rsync -L -avrq --exclude='ironfish-cli' --exclude 'fsevents' ../../../node_modules ./
+rsync -L -avrq --exclude 'ironfish' --exclude 'fsevents' ../../../node_modules ./
 # Copy node_modules from ironfish-cli folder into the production node_modules folder
 # yarn --production seems to split some packages into different folders for some reason
 cp -R ../../node_modules/* ./node_modules


### PR DESCRIPTION
## Summary

ironfish-cli got renamde to ironfish causing the exclude to be missed. updated that to use the new package name

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
