### PR TITLE
Make miner pool stratum host and port flag configurable

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -21,6 +21,7 @@ export const DEFAULT_USE_RPC_TCP = false
 export const DEFAULT_POOL_NAME = 'Iron Fish Pool'
 export const DEFAULT_POOL_ACCOUNT_NAME = 'default'
 export const DEFAULT_POOL_BALANCE_PERCENT_PAYOUT = 10
+export const DEFAULT_POOL_HOST = '0.0.0.0'
 export const DEFAULT_POOL_PORT = 9034
 export const DEFAULT_POOL_DIFFICULTY = '15000000000'
 export const DEFAULT_POOL_ATTEMPT_PAYOUT_INTERVAL = 15 * 60 // 15 minutes
@@ -149,6 +150,11 @@ export type ConfigOptions = {
   poolBalancePercentPayout: number
 
   /**
+   * The host that the pool is listening for miner connections on.
+   */
+  poolHost: string
+
+  /**
    * The port that the pool is listening for miner connections on.
    */
   poolPort: number
@@ -244,6 +250,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolName: DEFAULT_POOL_NAME,
       poolAccountName: DEFAULT_POOL_ACCOUNT_NAME,
       poolBalancePercentPayout: DEFAULT_POOL_BALANCE_PERCENT_PAYOUT,
+      poolHost: DEFAULT_POOL_HOST,
       poolPort: DEFAULT_POOL_PORT,
       poolDifficulty: DEFAULT_POOL_DIFFICULTY,
       poolAttemptPayoutInterval: DEFAULT_POOL_ATTEMPT_PAYOUT_INTERVAL,

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -55,6 +55,8 @@ export class MiningPool {
     config: Config
     logger?: Logger
     discord?: Discord
+    host?: string
+    port?: number
   }) {
     this.rpc = options.rpc
     this.logger = options.logger ?? createRootLogger()
@@ -63,6 +65,8 @@ export class MiningPool {
       pool: this,
       config: options.config,
       logger: this.logger,
+      host: options.host,
+      port: options.port,
     })
     this.config = options.config
     this.shares = options.shares
@@ -91,6 +95,8 @@ export class MiningPool {
     logger?: Logger
     discord?: Discord
     enablePayouts?: boolean
+    host?: string
+    port?: number
   }): Promise<MiningPool> {
     const shares = await MiningPoolShares.init({
       rpc: options.rpc,
@@ -105,6 +111,8 @@ export class MiningPool {
       logger: options.logger,
       config: options.config,
       discord: options.discord,
+      host: options.host,
+      port: options.port,
       shares,
     })
   }
@@ -118,7 +126,7 @@ export class MiningPool {
     this.started = true
     await this.shares.start()
 
-    this.logger.info('Starting stratum server...')
+    this.logger.info(`Starting stratum server on ${this.stratum.host}:${this.stratum.port}`)
     this.stratum.start()
 
     this.logger.info('Connecting to node...')

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -59,7 +59,8 @@ export class StratumServer {
   readonly config: Config
   readonly logger: Logger
 
-  private port: number
+  readonly port: number
+  readonly host: string
 
   clients: Map<number, StratumServerClient>
   nextMinerId: number
@@ -68,12 +69,19 @@ export class StratumServer {
   currentWork: Buffer | null = null
   currentMiningRequestId: number | null = null
 
-  constructor(options: { pool: MiningPool; config: Config; logger?: Logger }) {
+  constructor(options: {
+    pool: MiningPool
+    config: Config
+    logger?: Logger
+    port?: number
+    host?: string
+  }) {
     this.pool = options.pool
     this.config = options.config
     this.logger = options.logger ?? createRootLogger()
 
-    this.port = this.config.get('poolPort')
+    this.host = options.host ?? this.config.get('poolHost')
+    this.port = options.port ?? this.config.get('poolPort')
 
     this.clients = new Map()
     this.nextMinerId = 0
@@ -83,7 +91,7 @@ export class StratumServer {
   }
 
   start(): void {
-    this.server.listen(this.port, '0.0.0.0')
+    this.server.listen(this.port, this.host)
   }
 
   stop(): void {


### PR DESCRIPTION
## Summary

This adds a new --host command to the mining pool which specifies the host information to bind to. It can be a host, a port, or both for usability

## Testing Plan
Run the pool

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
