### PR TITLE
Temp patch for node-ipc malware (CVE-2022-23812)

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -87,6 +87,10 @@
   "resolutions": {
     "highlight.js": "10.4.1"
   },
+  "overrides": {
+    "node-ipc@>9.2.1 <10": "9.2.1",
+    "node-ipc@>10.1.0": "10.1.0"
+  },
   "bugs": {
     "url": "https://github.com/iron-fish/ironfish/issues"
   },


### PR DESCRIPTION
## Summary

node-ipc 9.2.2 added the peacenotwar module, which performs an unauthorized file write on users' filesystem. Overriding temporarily for hotfix. 

## Testing Plan

TBD

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X ] Yes
[ ] No
```
Dep update could cause breaking changes, needs testing. 
