### PR TITLE
feat(ironfish): Expand `parseMessage` to take `string | Buffer`

### DIFF
--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -62,6 +62,9 @@ export class ShowCommand extends IronfishCommand {
     const type = message.brokeringPeerDisplayName
       ? `(broker: ${message.brokeringPeerDisplayName}) ${message.type}`
       : message.type
+    if (message.message instanceof Buffer) {
+      throw new Error('Not implemented')
+    }
     const messageType = colors.cyan(message.message.type)
     const payload = JSON.stringify(
       'payload' in message.message ? message.message.payload : null,

--- a/ironfish/src/network/messages.ts
+++ b/ironfish/src/network/messages.ts
@@ -74,7 +74,12 @@ export function isPayloadMessage(
  *
  * Throws an error if it's not a valid message
  */
-export function parseMessage(data: string): Message<MessageType, PayloadType> {
+export function parseMessage(
+  data: string | Buffer,
+): Message<MessageType, PayloadType> | Buffer {
+  if (data instanceof Buffer) {
+    return data
+  }
   const message = IJSON.parse(data)
   if (!isMessage(message)) {
     throw new Error('Message must have a type field')
@@ -251,7 +256,7 @@ export function isDisconnectingMessage(obj: unknown): obj is DisconnectingMessag
  * A message that we have received from a peer, identified by that peer's
  * identity.
  */
-export interface IncomingPeerMessage<M extends Message<MessageType, PayloadType>> {
+export interface IncomingPeerMessage<M extends Message<MessageType, PayloadType> | Buffer> {
   peerIdentity: Identity
   message: M
 }

--- a/ironfish/src/network/peers/connections/connection.ts
+++ b/ironfish/src/network/peers/connections/connection.ts
@@ -87,7 +87,7 @@ export abstract class Connection {
    * json obj and verifies that it has a type attribute before being passed
    * in.
    */
-  readonly onMessage: Event<[LooseMessage]> = new Event()
+  readonly onMessage: Event<[LooseMessage] | [Buffer]> = new Event()
 
   /**
    * Send a message into this connection.

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -156,11 +156,15 @@ export class WebRtcConnection extends Connection {
         return
       }
 
-      if (this.shouldLogMessageType(message.type)) {
+      if (message instanceof Buffer) {
+        this.logger.debug(
+          `${colors.yellow('RECV')} ${this.displayName}: ${message.toString('utf8')}`,
+        )
+        this.onMessage.emit(message)
+      } else if (this.shouldLogMessageType(message.type)) {
         this.logger.debug(`${colors.yellow('RECV')} ${this.displayName}: ${message.type}`)
+        this.onMessage.emit(message)
       }
-
-      this.onMessage.emit(message)
     })
   }
 

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -92,10 +92,15 @@ export class WebSocketConnection extends Connection {
         return
       }
 
-      if (this.shouldLogMessageType(message.type)) {
+      if (message instanceof Buffer) {
+        this.logger.debug(
+          `${colors.yellow('RECV')} ${this.displayName}: ${message.toString('utf8')}`,
+        )
+        this.onMessage.emit(message)
+      } else if (this.shouldLogMessageType(message.type)) {
         this.logger.debug(`${colors.yellow('RECV')} ${this.displayName}: ${message.type}`)
+        this.onMessage.emit(message)
       }
-      this.onMessage.emit(message)
     }
   }
 

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -683,9 +683,9 @@ export class Peer {
     }
 
     const { message } = loggedMessage
-    const messageNotInUnloggedTypes =
-      !(message instanceof Buffer) && !UNLOGGED_MESSAGE_TYPES.includes(message.type)
-    if (forceLogMessage || messageNotInUnloggedTypes) {
+    const shouldPushLoggedMessage =
+      message instanceof Buffer || !UNLOGGED_MESSAGE_TYPES.includes(message.type)
+    if (forceLogMessage || shouldPushLoggedMessage) {
       this.loggedMessages.push(loggedMessage)
     }
   }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -901,7 +901,15 @@ export class PeerManager {
    * Note that the identity on IncomingPeerMessage is the identity of the
    * peer that sent it to us, not the original source.
    */
-  private async handleMessage(peer: Peer, connection: Connection, message: LooseMessage) {
+  private async handleMessage(
+    peer: Peer,
+    connection: Connection,
+    message: LooseMessage | Buffer,
+  ) {
+    if (message instanceof Buffer) {
+      throw new Error('Not implemented')
+    }
+
     if (isDisconnectingMessage(message)) {
       this.handleDisconnectingMessage(peer, connection, message)
     } else if (connection.state.type === 'WAITING_FOR_IDENTITY') {

--- a/ironfish/src/rpc/routes/peers/getPeerMessages.ts
+++ b/ironfish/src/rpc/routes/peers/getPeerMessages.ts
@@ -16,6 +16,7 @@ type PeerMessage = {
         type: string
         payload: Record<string, unknown>
       }
+    | Buffer
   timestamp: number
   type: Connection['type']
 }
@@ -94,9 +95,6 @@ function getPeerMessages(network: PeerNetwork, identity: string): Array<PeerMess
   for (const peer of network.peerManager.peers) {
     if (peer.state.identity !== null && peer.state.identity.includes(identity)) {
       return peer.loggedMessages.map((msg) => {
-        if (msg instanceof Buffer) {
-          throw new Error('Not implemented')
-        }
         return {
           ...msg,
         }

--- a/ironfish/src/rpc/routes/peers/getPeerMessages.ts
+++ b/ironfish/src/rpc/routes/peers/getPeerMessages.ts
@@ -94,6 +94,9 @@ function getPeerMessages(network: PeerNetwork, identity: string): Array<PeerMess
   for (const peer of network.peerManager.peers) {
     if (peer.state.identity !== null && peer.state.identity.includes(identity)) {
       return peer.loggedMessages.map((msg) => {
+        if (msg instanceof Buffer) {
+          throw new Error('Not implemented')
+        }
         return {
           ...msg,
         }


### PR DESCRIPTION
## Summary

Expand the type of `parseMessage` to accept a `Buffer`. A lot of utility and helper methods throw an Error if buffers are passed. This is going to an intermediate branch and is unused, so it will be a temporary type guard for now.

## Testing Plan

N/A, will be tested as messages are converted over

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
