### PR TITLE
Fix pool payout discord message

### DIFF
--- a/ironfish/src/mining/discord.ts
+++ b/ironfish/src/mining/discord.ts
@@ -4,7 +4,7 @@
 
 import Axios, { AxiosInstance } from 'axios'
 import { createRootLogger, Logger } from '../logger'
-import { displayIronAmountWithCurrency, ErrorUtils } from '../utils'
+import { displayIronAmountWithCurrency, ErrorUtils, oreToIron } from '../utils'
 import { FileUtils } from '../utils/file'
 
 export class Discord {
@@ -55,12 +55,10 @@ export class Discord {
     const total = receives.reduce((m, c) => BigInt(c.amount) + m, BigInt(0))
 
     this.sendText(
-      `Successfully paid out ${
-        receives.length
-      } users for ${total} ${displayIronAmountWithCurrency(
-        Number(total.toString()),
+      `Successfully paid out ${receives.length} users for ${displayIronAmountWithCurrency(
+        Number(oreToIron(Number(total.toString()))),
         false,
-      )} in transaction \`${transactionHashHex}\``,
+      )} in transaction \`${transactionHashHex}\` (${payoutId})`,
     )
   }
 


### PR DESCRIPTION
## Summary

We are printing ore and saying it's iron, but this way it will say that
it's probably displayed in iron.


**OLD**
```
Successfully paid out 21 users for 5493500766 $IRON 5,493,500,766.00000000 in
transaction 34cca2955dcb6d37ac117520c412daa22298268b2fa28f03d74ba9042afbe37f
```

**NEW**
```
Successfully paid out 21 users for $IRON 54.93500766 in transaction
34cca2955dcb6d37ac117520c412daa22298268b2fa28f03d74ba9042afbe37f (3)
```

## Testing Plan
Start new chain and test discord messages with lower payout interval

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
