### PR TITLE
Miner's self reported hashrate needs to take into account how many threads are running

### DIFF
--- a/ironfish-rust/src/mining/thread.rs
+++ b/ironfish-rust/src/mining/thread.rs
@@ -114,7 +114,9 @@ fn process_commands(
                         Some(randomness) => randomness - batch_start,
                         None => batch_size,
                     };
-                    hash_rate_channel.send(work_done as u32).unwrap();
+                    hash_rate_channel
+                        .send((work_done / step_size) as u32)
+                        .unwrap();
 
                     // New command received, this work is now stale, stop working so we can start on new work
                     if let Ok(cmd) = work_receiver.try_recv() {


### PR DESCRIPTION
## Summary

The hashrate reporting from the thread isn't dividing by the total thread count, so it was overestimating hashrate exponentially

Fixes #1173 

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
