### PR TITLE
Properly dispose of WebRTC connections

### DIFF
--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -255,7 +255,7 @@ export class PeerManager {
         .failedConnection(peer.isWhitelisted)
 
       // If we don't have any brokering peers try disposing the peers
-      this.tryDisposePeer(peer)
+      this.tryDisposePeer(peer, ConnectionType.WebRtc)
       return false
     }
 
@@ -863,14 +863,17 @@ export class PeerManager {
    * else returns false and does nothing.
    * @param peer The peer to evaluate
    */
-  private tryDisposePeer(peer: Peer) {
+  private tryDisposePeer(
+    peer: Peer,
+    connectionType: ConnectionType = ConnectionType.WebSocket,
+  ) {
     const hasAConnectedPeer = [...peer.knownPeers.values()].some(
       (p) => p.state.type === 'CONNECTED',
     )
 
     if (
       peer.state.type === 'DISCONNECTED' &&
-      peer.getConnectionRetry(ConnectionType.WebSocket, ConnectionDirection.Outbound)
+      peer.getConnectionRetry(connectionType, ConnectionDirection.Outbound)
         ?.willNeverRetryConnecting
     ) {
       this.addressManager.removePeerAddress(peer)


### PR DESCRIPTION
## Summary

Noticed that my node was not properly disposing of some peers. This is the 'quick-fix', putting up here so I don't forget about it later, but the actual solution probably needs a little more thought.

The reproduction steps:
1. Connect via Websocket
2. Send Identity message to complete the initial Websocket "handshake"
3. Disconnect without ever upograding to WebRTC connection.

The WebRTC connection will retry until Infinity, but because tryDisposePeer only checks Websocket, it will stay forever. This is also a potential memory leak.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
