### PR TITLE
Catch error events on the Pool's stratum TCP socket

### DIFF
--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -128,6 +128,8 @@ export class StratumServer {
 
     socket.on('close', () => this.onDisconnect(client))
 
+    socket.on('error', (e) => this.onError(client, e))
+
     this.logger.debug(`Client ${client.id} connected:`, socket.remoteAddress)
     this.clients.set(client.id, client)
   }


### PR DESCRIPTION
## Summary

Discord user rpanic, the creator of peak-pool found an error in our stratum server: we don't catch errors thrown by the server socket, only the client sockets. This fixes that so now errors thrown by the server socket are caught and handled properly, so that the pool no longer crashes on client-connection related errors

## Testing Plan

Can test this by throwing in a process.exit() at the end of StratumClient.subscribe function

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
