### PR TITLE
feat(ironfish): Make identify message buffer serializable

### DIFF
--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { GetPeerMessagesResponse, GetPeerResponse } from '@ironfish/sdk'
+import {
+  NetworkMessage,
+  NetworkMessageType,
+} from '@ironfish/sdk/src/network/messages/networkMessage'
 import colors from 'colors/safe'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -62,10 +66,13 @@ export class ShowCommand extends IronfishCommand {
     const type = message.brokeringPeerDisplayName
       ? `(broker: ${message.brokeringPeerDisplayName}) ${message.type}`
       : message.type
-    if (message.message instanceof Buffer) {
-      throw new Error('Not implemented')
+
+    let messageType
+    if (message.message instanceof NetworkMessage) {
+      messageType = colors.cyan(NetworkMessageType[message.message.type])
+    } else {
+      messageType = colors.cyan(message.message.type)
     }
-    const messageType = colors.cyan(message.message.type)
     const payload = JSON.stringify(
       'payload' in message.message ? message.message.payload : null,
     )

--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { GetPeerMessagesResponse, GetPeerResponse } from '@ironfish/sdk'
-import {
-  NetworkMessage,
-  NetworkMessageType,
-} from '@ironfish/sdk/src/network/messages/networkMessage'
 import colors from 'colors/safe'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -67,12 +63,9 @@ export class ShowCommand extends IronfishCommand {
       ? `(broker: ${message.brokeringPeerDisplayName}) ${message.type}`
       : message.type
 
-    let messageType
-    if (message.message instanceof NetworkMessage) {
-      messageType = colors.cyan(NetworkMessageType[message.message.type])
-    } else {
-      messageType = colors.cyan(message.message.type)
-    }
+    // TODO(rohanjadvani)
+    // Update to render the enum after the SDK is bumped with new types
+    const messageType = colors.cyan(message.message.type.toString())
     const payload = JSON.stringify(
       'payload' in message.message ? message.message.payload : null,
     )

--- a/ironfish/jest.setup.env.js
+++ b/ironfish/jest.setup.env.js
@@ -19,6 +19,7 @@ jest.mock('node-datachannel', () => {
           close: () => {},
           isOpen: () => {},
           sendMessage: () => {},
+          sendMessageBinary: (_buffer) => {},
         }
       }
     },

--- a/ironfish/src/network/messages.test.ts
+++ b/ironfish/src/network/messages.test.ts
@@ -11,14 +11,12 @@ import {
   GetBlockHashesResponse,
   GetBlocksRequest,
   GetBlocksResponse,
-  Identify,
   InternalMessageType,
   isDisconnectingMessage,
   isGetBlockHashesRequest,
   isGetBlockHashesResponse,
   isGetBlocksRequest,
   isGetBlocksResponse,
-  isIdentify,
   isMessage,
   isNoteRequestPayload,
   isNoteResponse,
@@ -39,25 +37,6 @@ import {
   PeerListRequest,
   Signal,
 } from './messages'
-import { VERSION_PROTOCOL } from './version'
-
-describe('isIdentify', () => {
-  it('Returns true on identity message', () => {
-    const msg: Identify = {
-      type: InternalMessageType.identity,
-      payload: {
-        identity: 'oVHAznOXv4FHdajFYsVNMZm14WHlCdXZz8z55IOhTwI=',
-        version: VERSION_PROTOCOL,
-        agent: '',
-        head: '',
-        sequence: 1,
-        work: BigInt(0).toString(),
-        port: null,
-      },
-    }
-    expect(isIdentify(msg)).toBeTruthy()
-  })
-})
 
 describe('isSignal', () => {
   it('Returns true on signal message', () => {

--- a/ironfish/src/network/messages.ts
+++ b/ironfish/src/network/messages.ts
@@ -8,6 +8,7 @@ import { IJSON } from '../serde'
 import { UnwrapPromise } from '../utils'
 import { Identity, isIdentity } from './identity'
 import { Gossip, Rpc } from './messageRouters'
+import { NetworkMessage } from './messages/networkMessage'
 
 /**
  * The type of the message for the purposes of routing within our code.
@@ -74,54 +75,12 @@ export function isPayloadMessage(
  *
  * Throws an error if it's not a valid message
  */
-export function parseMessage(
-  data: string | Buffer,
-): Message<MessageType, PayloadType> | Buffer {
-  if (data instanceof Buffer) {
-    return data
-  }
+export function parseMessage(data: string): Message<MessageType, PayloadType> {
   const message = IJSON.parse(data)
   if (!isMessage(message)) {
     throw new Error('Message must have a type field')
   }
   return message
-}
-
-/**
- * A message by which a peer can identify itself to another.
- */
-export type Identify = Message<
-  InternalMessageType.identity,
-  {
-    identity: Identity
-    name?: string
-    version: number
-    agent: string
-    port: number | null
-    head: string
-    work: string
-    sequence: number
-  }
->
-
-export function isIdentify(obj: unknown): obj is Identify {
-  if (!isPayloadMessage(obj)) {
-    return false
-  }
-
-  const payload = obj.payload as Identify['payload']
-
-  return (
-    obj.type === InternalMessageType.identity &&
-    typeof payload === 'object' &&
-    payload !== null &&
-    typeof payload.identity === 'string' &&
-    typeof payload.agent === 'string' &&
-    typeof payload.version === 'number' &&
-    typeof payload.head === 'string' &&
-    typeof payload.work === 'string' &&
-    typeof payload.sequence === 'number'
-  )
 }
 
 /**
@@ -256,7 +215,9 @@ export function isDisconnectingMessage(obj: unknown): obj is DisconnectingMessag
  * A message that we have received from a peer, identified by that peer's
  * identity.
  */
-export interface IncomingPeerMessage<M extends Message<MessageType, PayloadType> | Buffer> {
+export interface IncomingPeerMessage<
+  M extends Message<MessageType, PayloadType> | NetworkMessage,
+> {
   peerIdentity: Identity
   message: M
 }

--- a/ironfish/src/network/messages/identify.ts
+++ b/ironfish/src/network/messages/identify.ts
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { Identity } from '../identity'
+import { NetworkMessage, NetworkMessageType } from './networkMessage'
+
+interface CreateIdentifyMessageOptions {
+  agent: string
+  head: string
+  identity: Identity
+  name?: string
+  port: number | null
+  sequence: number
+  version: number
+  work: string
+}
+
+export class IdentifyMessage extends NetworkMessage {
+  readonly agent: string
+  readonly head: string
+  readonly identity: Identity
+  readonly name: string
+  readonly port: number
+  readonly sequence: number
+  readonly version: number
+  readonly work: string
+
+  constructor(
+    {
+      agent,
+      head,
+      identity,
+      name,
+      port,
+      sequence,
+      version,
+      work,
+    }: CreateIdentifyMessageOptions,
+    messageId?: number,
+  ) {
+    super(NetworkMessageType.Identify, messageId)
+    this.agent = agent
+    this.head = head
+    this.identity = identity
+    this.name = name || ''
+    this.port = port || 0
+    this.sequence = sequence
+    this.version = version
+    this.work = work
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+    bw.writeVarString(this.agent)
+    bw.writeVarString(this.head)
+    bw.writeVarString(this.identity)
+    bw.writeVarString(this.name)
+    bw.writeU64(this.port)
+    bw.writeU64(this.sequence)
+    bw.writeU64(this.version)
+    bw.writeVarString(this.work)
+    return bw.render()
+  }
+
+  static deserialize(messageId: number, buffer: Buffer): IdentifyMessage {
+    const reader = bufio.read(buffer, true)
+    const agent = reader.readVarString()
+    const head = reader.readVarString()
+    const identity = reader.readVarString()
+    const name = reader.readVarString()
+    const port = reader.readU64()
+    const sequence = reader.readU64()
+    const version = reader.readU64()
+    const work = reader.readVarString()
+    return new IdentifyMessage(
+      {
+        agent,
+        head,
+        identity,
+        name,
+        port,
+        sequence,
+        version,
+        work,
+      },
+      messageId,
+    )
+  }
+
+  getSize(): number {
+    let size = 0
+    size += bufio.sizeVarString(this.agent)
+    size += bufio.sizeVarString(this.head)
+    size += bufio.sizeVarString(this.identity)
+    size += bufio.sizeVarString(this.name)
+    size += 24
+    size += bufio.sizeVarString(this.work)
+    return size
+  }
+}

--- a/ironfish/src/network/messages/interfaces/networkMessageHeader.ts
+++ b/ironfish/src/network/messages/interfaces/networkMessageHeader.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { NetworkMessageType } from '../networkMessage'
+
+export interface NetworkMessageHeader {
+  messageId: number
+  type: NetworkMessageType
+  body: Buffer
+}

--- a/ironfish/src/network/messages/networkMessage.ts
+++ b/ironfish/src/network/messages/networkMessage.ts
@@ -1,21 +1,34 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
 import { Serializable } from '../../common/serializable'
 
-export enum NetworkMessageType {}
+export enum NetworkMessageType {
+  Identify = 0,
+}
 
 export abstract class NetworkMessage implements Serializable {
   private static id = 0
 
-  readonly networkId: number
+  readonly messageId: number
   readonly type: NetworkMessageType
 
-  constructor(type: NetworkMessageType, networkId?: number) {
-    this.networkId = networkId ?? NetworkMessage.id++
+  constructor(type: NetworkMessageType, messageId?: number) {
+    this.messageId = messageId ?? NetworkMessage.id++
     this.type = type
   }
 
   abstract serialize(): Buffer
   abstract getSize(): number
+
+  serializeWithMetadata(): Buffer {
+    const headerSize = 17
+    const bw = bufio.write(headerSize + this.getSize())
+    bw.writeU64(this.messageId)
+    bw.writeU8(this.type)
+    bw.writeU64(this.getSize())
+    bw.writeBytes(this.serialize())
+    return bw.render()
+  }
 }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -59,6 +59,7 @@ import {
   NodeMessageType,
   PayloadType,
 } from './messages'
+import { NetworkMessage } from './messages/networkMessage'
 import { LocalPeer } from './peers/localPeer'
 import { BAN_SCORE, Peer } from './peers/peer'
 import { PeerConnectionManager } from './peers/peerConnectionManager'
@@ -597,9 +598,13 @@ export class PeerNetwork {
 
   private async handleMessage(
     peer: Peer,
-    incomingMessage: IncomingPeerMessage<LooseMessage>,
+    incomingMessage: IncomingPeerMessage<LooseMessage | NetworkMessage>,
   ): Promise<void> {
     const { message } = incomingMessage
+    if (message instanceof NetworkMessage) {
+      throw new Error('Not implemented')
+    }
+
     let style = this.routingStyles.get(message.type)
     if (style === undefined) {
       if (message.type === InternalMessageType.cannotSatisfyRequest) {

--- a/ironfish/src/network/peers/connections/connection.test.ts
+++ b/ironfish/src/network/peers/connections/connection.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createRootLogger } from '../../../logger'
+import { IdentifyMessage } from '../../messages/identify'
+import { WebRtcConnection } from './webRtcConnection'
+
+describe('Connection', () => {
+  describe('parseMessage', () => {
+    describe('with a malformed header', () => {
+      it('throws an error', () => {
+        const connection = new WebRtcConnection(false, createRootLogger())
+        expect(() => connection.parseMessage(Buffer.from('asdf'))).toThrowError()
+        connection.close()
+      })
+    })
+
+    describe('with a malformed body', () => {
+      it('throws an error', () => {
+        const connection = new WebRtcConnection(false, createRootLogger())
+        const message = new IdentifyMessage({
+          agent: '',
+          head: '',
+          identity: 'identity',
+          port: 9033,
+          sequence: 1,
+          version: 0,
+          work: BigInt(0).toString(),
+        })
+        jest.spyOn(message, 'serialize').mockImplementationOnce(() => Buffer.from('adsf'))
+
+        expect(() => connection.parseMessage(message.serializeWithMetadata())).toThrowError()
+        connection.close()
+      })
+    })
+
+    describe('with a valid message', () => {
+      it('parses the message', () => {
+        const connection = new WebRtcConnection(false, createRootLogger())
+        const message = new IdentifyMessage({
+          agent: '',
+          head: '',
+          identity: 'identity',
+          port: 9033,
+          sequence: 1,
+          version: 0,
+          work: BigInt(0).toString(),
+        })
+
+        expect(connection.parseMessage(message.serializeWithMetadata())).toEqual(message)
+        connection.close()
+      })
+    })
+  })
+})

--- a/ironfish/src/network/peers/connections/webRtcConnection.test.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.test.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../../../assert'
+import { createRootLogger } from '../../../logger'
+import { IdentifyMessage } from '../../messages/identify'
+import { WebRtcConnection } from './webRtcConnection'
+
+describe('WebRtcConnection', () => {
+  describe('send', () => {
+    describe('with no datachannel', () => {
+      it('returns false', () => {
+        const connection = new WebRtcConnection(false, createRootLogger())
+        const message = new IdentifyMessage({
+          agent: '',
+          head: '',
+          identity: 'identity',
+          port: 9033,
+          sequence: 1,
+          version: 0,
+          work: BigInt(0).toString(),
+        })
+        expect(connection.send(message)).toBe(false)
+        connection.close()
+      })
+    })
+
+    describe('with a valid message', () => {
+      it('serializes and sends the message on the datachannel', () => {
+        const connection = new WebRtcConnection(true, createRootLogger())
+        const datachannel = connection['datachannel']
+        Assert.isNotNull(datachannel)
+        jest.spyOn(datachannel, 'isOpen').mockImplementation(() => true)
+        const sendMessageBinary = jest
+          .spyOn(datachannel, 'sendMessageBinary')
+          .mockImplementationOnce(jest.fn())
+        const message = new IdentifyMessage({
+          agent: '',
+          head: '',
+          identity: 'identity',
+          port: 9033,
+          sequence: 1,
+          version: 0,
+          work: BigInt(0).toString(),
+        })
+
+        expect(connection.send(message)).toBe(true)
+        expect(sendMessageBinary).toHaveBeenCalledWith(message.serializeWithMetadata())
+        connection.close()
+      })
+    })
+  })
+})

--- a/ironfish/src/network/peers/connections/webSocketConnection.test.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.test.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import ws from 'ws'
+import { createRootLogger } from '../../../logger'
+import { IdentifyMessage } from '../../messages/identify'
+import { ConnectionDirection } from './connection'
+import { WebSocketConnection } from './webSocketConnection'
+
+jest.mock('ws')
+
+describe('WebSocketConnection', () => {
+  afterAll(() => {
+    jest.unmock('ws')
+  })
+
+  describe('send', () => {
+    describe('with a valid message', () => {
+      it('serializes and sends the message on the datachannel', () => {
+        const connection = new WebSocketConnection(
+          new ws(''),
+          ConnectionDirection.Outbound,
+          createRootLogger(),
+        )
+        const socket = connection['socket']
+        const send = jest.spyOn(socket, 'send').mockImplementationOnce(jest.fn())
+        const message = new IdentifyMessage({
+          agent: '',
+          head: '',
+          identity: 'identity',
+          port: 9033,
+          sequence: 1,
+          version: 0,
+          work: BigInt(0).toString(),
+        })
+
+        expect(connection.send(message)).toBe(true)
+        expect(send).toHaveBeenCalledWith(message.serializeWithMetadata())
+        connection.close()
+      })
+    })
+  })
+})

--- a/ironfish/src/network/peers/localPeer.test.ts
+++ b/ironfish/src/network/peers/localPeer.test.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { mockLocalPeer } from '../testUtilities'
+
+describe('LocalPeer', () => {
+  describe('identify', () => {
+    it('returns an identify message corresponding to the peer', () => {
+      const peer = mockLocalPeer()
+      const message = peer.getIdentifyMessage()
+      expect(message).toMatchObject({
+        agent: peer.agent,
+        head: peer.chain.head.hash.toString('hex'),
+        identity: peer.publicIdentity,
+        sequence: Number(peer.chain.head.sequence),
+        version: peer.version,
+        work: peer.chain.head.work.toString(),
+      })
+    })
+  })
+})

--- a/ironfish/src/network/peers/localPeer.ts
+++ b/ironfish/src/network/peers/localPeer.ts
@@ -5,7 +5,7 @@ import { Assert } from '../../assert'
 import { Blockchain } from '../../blockchain'
 import { WorkerPool } from '../../workerPool'
 import { Identity, PrivateIdentity, privateIdentityToIdentity } from '../identity'
-import { Identify, InternalMessageType } from '../messages'
+import { IdentifyMessage } from '../messages/identify'
 import { IsomorphicWebSocketConstructor } from '../types'
 
 /**
@@ -56,22 +56,19 @@ export class LocalPeer {
   /**
    * Construct an Identify message with our identity and version.
    */
-  getIdentifyMessage(): Identify {
+  getIdentifyMessage(): IdentifyMessage {
     Assert.isNotNull(this.chain.head, 'Cannot connect to the network without a genesis block')
 
-    return {
-      type: InternalMessageType.identity,
-      payload: {
-        identity: this.publicIdentity,
-        version: this.version,
-        agent: this.agent,
-        name: this.name || undefined,
-        port: this.port,
-        head: this.chain.head.hash.toString('hex'),
-        work: this.chain.head.work.toString(),
-        sequence: Number(this.chain.head.sequence),
-      },
-    }
+    return new IdentifyMessage({
+      agent: this.agent,
+      head: this.chain.head.hash.toString('hex'),
+      identity: this.publicIdentity,
+      name: this.name || undefined,
+      port: this.port,
+      sequence: Number(this.chain.head.sequence),
+      version: this.version,
+      work: this.chain.head.work.toString(),
+    })
   }
 
   /**

--- a/ironfish/src/rpc/routes/peers/getPeerMessages.ts
+++ b/ironfish/src/rpc/routes/peers/getPeerMessages.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Connection, PeerNetwork } from '../../../network'
+import { NetworkMessage } from '../../../network/messages/networkMessage'
 import { ApiNamespace, router } from '../router'
 
 type PeerMessage = {
@@ -16,7 +17,7 @@ type PeerMessage = {
         type: string
         payload: Record<string, unknown>
       }
-    | Buffer
+    | NetworkMessage
   timestamp: number
   type: Connection['type']
 }

--- a/ironfish/src/typedefs/bufio.d.ts
+++ b/ironfish/src/typedefs/bufio.d.ts
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 declare module 'bufio' {
-  type Encoding = 'utf8' | 'ascii'
-  type BufferEncoding = 'hex'
-
   class StaticWriter {
     render(): Buffer
     slice(): Buffer
+    writeDouble(value: number): StaticWriter
     writeDoubleBE(value: number): StaticWriter
+    writeU8(value: number): StaticWriter
     writeU64(value: number): StaticWriter
     writeI64(value: number): StaticWriter
-    writeVarString(value: string, enc?: Encoding | null): StaticWriter
+    writeVarString(value: string, enc?: BufferEncoding | null): StaticWriter
     writeVarBytes(value: Buffer): StaticWriter
     writeBytes(value: Buffer): StaticWriter
     writeHash(value: Buffer | string): StaticWriter
@@ -21,10 +20,12 @@ declare module 'bufio' {
   class BufferWriter {
     render(): Buffer
     slice(): Buffer
+    writeDouble(value: number): BufferWriter
     writeDoubleBE(value: number): BufferWriter
+    writeU8(value: number): BufferWriter
     writeU64(value: number): BufferWriter
     writeI64(value: number): BufferWriter
-    writeVarString(value: string, enc?: Encoding | null): BufferWriter
+    writeVarString(value: string, enc?: BufferEncoding | null): BufferWriter
     writeVarBytes(value: Buffer): BufferWriter
     writeBytes(value: Buffer): BufferWriter
     writeHash(value: Buffer | string): BufferWriter
@@ -32,12 +33,15 @@ declare module 'bufio' {
   }
 
   class BufferReader {
+    readU8(): number
     readU64(): number
     readU64BE(): number
     readFloat(): number
     readFloatBE(): number
     readDoubleBE(): number
-    readVarString(enc?: Encoding | null, limit?: number): string
+    readI64(): number
+    readDouble(): number
+    readVarString(enc?: BufferEncoding | null, limit?: number): string
     readVarBytes(): Buffer
     readBytes(size: number, zeroCopy?: boolean): Buffer
 
@@ -47,4 +51,7 @@ declare module 'bufio' {
 
   export function write(size?: number): StaticWriter | BufferWriter
   export function read(data: Buffer, zeroCopy?: boolean): BufferReader
+
+  export function sizeVarBytes(value: Buffer): number
+  export function sizeVarString(value: string, enc?: BufferEncoding): number
 }


### PR DESCRIPTION
## Summary

* Create binary serializable message for peer identity
* Add missing unit tests
* Add type guards for network messages when sending / receiving packets

## Testing Plan

Added unit test and manually ran node.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
