### PR TITLE
feat(ironfish): Make disconnecting message buffer serializable

### DIFF
--- a/ironfish/src/network/messages.test.ts
+++ b/ironfish/src/network/messages.test.ts
@@ -4,14 +4,11 @@
 
 import { createNodeTest, useBlockWithTx } from '../testUtilities'
 import {
-  DisconnectingMessage,
-  DisconnectingReason,
   GetBlockHashesRequest,
   GetBlockHashesResponse,
   GetBlocksRequest,
   GetBlocksResponse,
   InternalMessageType,
-  isDisconnectingMessage,
   isGetBlockHashesRequest,
   isGetBlockHashesResponse,
   isGetBlocksRequest,
@@ -94,34 +91,6 @@ describe('isPeerList', () => {
     }
 
     expect(isPeerList(msg)).toBeFalsy()
-  })
-})
-
-describe('isDisconnectingMessage', () => {
-  it('Returns true on Disconnecting message', () => {
-    const msg: DisconnectingMessage = {
-      type: InternalMessageType.disconnecting,
-      payload: {
-        sourceIdentity: 'oVHAznOXv4FHdajFYsVNMZm14WHlCdXZz8z55IOhTwI=',
-        destinationIdentity: 'oVHAznOXv4FHdajFYsVNMZm14WHlCdXZz8z55IOhTwI=',
-        reason: DisconnectingReason.ShuttingDown,
-        disconnectUntil: Date.now(),
-      },
-    }
-    expect(isDisconnectingMessage(msg)).toBeTruthy()
-  })
-
-  it('Returns true on null destinationIdentity', () => {
-    const msg: DisconnectingMessage = {
-      type: InternalMessageType.disconnecting,
-      payload: {
-        sourceIdentity: 'oVHAznOXv4FHdajFYsVNMZm14WHlCdXZz8z55IOhTwI=',
-        destinationIdentity: null,
-        reason: DisconnectingReason.ShuttingDown,
-        disconnectUntil: Date.now(),
-      },
-    }
-    expect(isDisconnectingMessage(msg)).toBeTruthy()
   })
 })
 

--- a/ironfish/src/network/messages.ts
+++ b/ironfish/src/network/messages.ts
@@ -23,7 +23,6 @@ export enum InternalMessageType {
   peerList = 'peerList',
   peerListRequest = 'peerListRequest',
   cannotSatisfyRequest = 'cannotSatisfyRequest',
-  disconnecting = 'disconnecting',
 }
 
 export type MessageType = InternalMessageType | string
@@ -177,37 +176,6 @@ export function isPeerList(obj: unknown): obj is PeerList {
     payload !== null &&
     Array.isArray(payload.connectedPeers) &&
     payload.connectedPeers.every((v) => isIdentity(v.identity))
-  )
-}
-
-export enum DisconnectingReason {
-  ShuttingDown = 0,
-  Congested = 1,
-}
-
-export type DisconnectingMessage = Message<
-  InternalMessageType.disconnecting,
-  {
-    sourceIdentity: Identity
-    // Can be null if we're sending the message to an unidentified Peer
-    destinationIdentity: Identity | null
-    reason: DisconnectingReason
-    disconnectUntil: number
-  }
->
-
-export function isDisconnectingMessage(obj: unknown): obj is DisconnectingMessage {
-  if (!isPayloadMessage(obj)) {
-    return false
-  }
-  const payload = obj.payload as DisconnectingMessage['payload']
-  return (
-    obj.type === InternalMessageType.disconnecting &&
-    payload !== null &&
-    typeof payload.sourceIdentity === 'string' &&
-    (typeof payload.destinationIdentity === 'string' || payload.destinationIdentity === null) &&
-    typeof payload.reason === 'number' &&
-    typeof payload.disconnectUntil === 'number'
   )
 }
 

--- a/ironfish/src/network/messages/disconnecting.test.ts
+++ b/ironfish/src/network/messages/disconnecting.test.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DisconnectingMessage, DisconnectingReason } from './disconnecting'
+
+describe('DisconnectingMessage', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const message = new DisconnectingMessage({
+      destinationIdentity: null,
+      disconnectUntil: 123,
+      reason: DisconnectingReason.Congested,
+      sourceIdentity: 'source',
+    })
+
+    const buffer = message.serialize()
+    const deserializedMessage = DisconnectingMessage.deserialize(buffer)
+    expect(deserializedMessage).toEqual(message)
+  })
+})

--- a/ironfish/src/network/messages/disconnecting.ts
+++ b/ironfish/src/network/messages/disconnecting.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { Identity } from '../identity'
+import { NetworkMessage, NetworkMessageType } from './networkMessage'
+
+export enum DisconnectingReason {
+  ShuttingDown = 0,
+  Congested = 1,
+}
+
+interface CreateDisconnectingMessageOptions {
+  // Can be null if we're sending the message to an unidentified Peer
+  destinationIdentity: Identity | null
+  disconnectUntil: number
+  reason: DisconnectingReason
+  sourceIdentity: Identity
+}
+
+export class DisconnectingMessage extends NetworkMessage {
+  readonly destinationIdentity: Identity | null
+  readonly disconnectUntil: number
+  readonly reason: DisconnectingReason
+  readonly sourceIdentity: Identity
+
+  constructor({
+    destinationIdentity,
+    disconnectUntil,
+    reason,
+    sourceIdentity,
+  }: CreateDisconnectingMessageOptions) {
+    super(NetworkMessageType.Disconnecting)
+    this.destinationIdentity = destinationIdentity
+    this.disconnectUntil = disconnectUntil
+    this.reason = reason
+    this.sourceIdentity = sourceIdentity
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+    bw.writeU64(this.disconnectUntil)
+    bw.writeU8(this.reason)
+    bw.writeVarString(this.sourceIdentity)
+    if (this.destinationIdentity) {
+      bw.writeVarString(this.destinationIdentity)
+    }
+    return bw.render()
+  }
+
+  static deserialize(buffer: Buffer): DisconnectingMessage {
+    const reader = bufio.read(buffer, true)
+    const disconnectUntil = reader.readU64()
+    const reason = reader.readU8()
+    const sourceIdentity = reader.readVarString()
+    let destinationIdentity = null
+    if (reader.left()) {
+      destinationIdentity = reader.readVarString()
+    }
+    return new DisconnectingMessage({
+      destinationIdentity,
+      disconnectUntil,
+      reason,
+      sourceIdentity,
+    })
+  }
+
+  getSize(): number {
+    let size = 0
+    size += 8
+    size += 1
+    size += bufio.sizeVarString(this.sourceIdentity)
+    if (this.destinationIdentity) {
+      size += bufio.sizeVarString(this.destinationIdentity)
+    }
+    return size
+  }
+}

--- a/ironfish/src/network/messages/identify.test.ts
+++ b/ironfish/src/network/messages/identify.test.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IdentifyMessage } from './identify'
+
+describe('IdentifyMessage', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const message = new IdentifyMessage({
+      agent: 'agent',
+      head: 'head',
+      identity: 'identity',
+      name: 'name',
+      port: 9033,
+      sequence: 1,
+      version: 1,
+      work: '123',
+    })
+
+    const buffer = message.serialize()
+    const deserializedMessage = IdentifyMessage.deserialize(buffer)
+    expect(deserializedMessage).toEqual(message)
+  })
+})

--- a/ironfish/src/network/messages/identify.ts
+++ b/ironfish/src/network/messages/identify.ts
@@ -26,20 +26,17 @@ export class IdentifyMessage extends NetworkMessage {
   readonly version: number
   readonly work: string
 
-  constructor(
-    {
-      agent,
-      head,
-      identity,
-      name,
-      port,
-      sequence,
-      version,
-      work,
-    }: CreateIdentifyMessageOptions,
-    messageId?: number,
-  ) {
-    super(NetworkMessageType.Identify, messageId)
+  constructor({
+    agent,
+    head,
+    identity,
+    name,
+    port,
+    sequence,
+    version,
+    work,
+  }: CreateIdentifyMessageOptions) {
+    super(NetworkMessageType.Identify)
     this.agent = agent
     this.head = head
     this.identity = identity
@@ -63,7 +60,7 @@ export class IdentifyMessage extends NetworkMessage {
     return bw.render()
   }
 
-  static deserialize(messageId: number, buffer: Buffer): IdentifyMessage {
+  static deserialize(buffer: Buffer): IdentifyMessage {
     const reader = bufio.read(buffer, true)
     const agent = reader.readVarString()
     const head = reader.readVarString()
@@ -73,19 +70,16 @@ export class IdentifyMessage extends NetworkMessage {
     const sequence = reader.readU64()
     const version = reader.readU64()
     const work = reader.readVarString()
-    return new IdentifyMessage(
-      {
-        agent,
-        head,
-        identity,
-        name,
-        port,
-        sequence,
-        version,
-        work,
-      },
-      messageId,
-    )
+    return new IdentifyMessage({
+      agent,
+      head,
+      identity,
+      name,
+      port,
+      sequence,
+      version,
+      work,
+    })
   }
 
   getSize(): number {

--- a/ironfish/src/network/messages/interfaces/networkMessageHeader.ts
+++ b/ironfish/src/network/messages/interfaces/networkMessageHeader.ts
@@ -4,7 +4,6 @@
 import { NetworkMessageType } from '../networkMessage'
 
 export interface NetworkMessageHeader {
-  messageId: number
   type: NetworkMessageType
   body: Buffer
 }

--- a/ironfish/src/network/messages/networkMessage.ts
+++ b/ironfish/src/network/messages/networkMessage.ts
@@ -5,17 +5,14 @@ import bufio from 'bufio'
 import { Serializable } from '../../common/serializable'
 
 export enum NetworkMessageType {
-  Identify = 0,
+  Disconnecting = 0,
+  Identify = 1,
 }
 
 export abstract class NetworkMessage implements Serializable {
-  private static id = 0
-
-  readonly messageId: number
   readonly type: NetworkMessageType
 
-  constructor(type: NetworkMessageType, messageId?: number) {
-    this.messageId = messageId ?? NetworkMessage.id++
+  constructor(type: NetworkMessageType) {
     this.type = type
   }
 
@@ -23,9 +20,8 @@ export abstract class NetworkMessage implements Serializable {
   abstract getSize(): number
 
   serializeWithMetadata(): Buffer {
-    const headerSize = 17
+    const headerSize = 9
     const bw = bufio.write(headerSize + this.getSize())
-    bw.writeU64(this.messageId)
     bw.writeU8(this.type)
     bw.writeU64(this.getSize())
     bw.writeBytes(this.serialize())

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -11,7 +11,9 @@ import ws from 'ws'
 import { Assert } from '../assert'
 import { createNodeTest } from '../testUtilities'
 import { mockChain, mockNode, mockStrategy } from '../testUtilities/mocks'
-import { DisconnectingMessage, NodeMessageType } from './messages'
+import { NodeMessageType } from './messages'
+import { DisconnectingMessage } from './messages/disconnecting'
+import { NetworkMessageType } from './messages/networkMessage'
 import { PeerNetwork, RoutingStyle } from './peerNetwork'
 import { getConnectedPeer, mockHostsStore, mockPrivateIdentity } from './testUtilities'
 
@@ -171,7 +173,7 @@ describe('PeerNetwork', () => {
       const args = sendSpy.mock.calls[0][0]
       expect(typeof args).toEqual('string')
       const message = JSON.parse(args) as DisconnectingMessage
-      expect(message.type).toEqual('disconnecting')
+      expect(message.type).toEqual(NetworkMessageType.Disconnecting)
     })
   })
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -41,8 +41,6 @@ import {
   isNewBlockPayload,
 } from './messages'
 import {
-  DisconnectingMessage,
-  DisconnectingReason,
   GetBlockHashesRequest,
   GetBlocksRequest,
   IncomingPeerMessage,
@@ -59,6 +57,7 @@ import {
   NodeMessageType,
   PayloadType,
 } from './messages'
+import { DisconnectingMessage, DisconnectingReason } from './messages/disconnecting'
 import { NetworkMessage } from './messages/networkMessage'
 import { LocalPeer } from './peers/localPeer'
 import { BAN_SCORE, Peer } from './peers/peer'
@@ -323,15 +322,12 @@ export class PeerNetwork {
             'Disconnecting inbound websocket connection because the node has max peers',
           )
 
-          const disconnect: DisconnectingMessage = {
-            type: InternalMessageType.disconnecting,
-            payload: {
-              sourceIdentity: this.localPeer.publicIdentity,
-              destinationIdentity: null,
-              reason: DisconnectingReason.Congested,
-              disconnectUntil: this.peerManager.getCongestedDisconnectUntilTimestamp(),
-            },
-          }
+          const disconnect = new DisconnectingMessage({
+            destinationIdentity: null,
+            disconnectUntil: this.peerManager.getCongestedDisconnectUntilTimestamp(),
+            reason: DisconnectingReason.Congested,
+            sourceIdentity: this.localPeer.publicIdentity,
+          })
           connection.send(JSON.stringify(disconnect))
           connection.close()
           return

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -6,7 +6,8 @@ import { Event } from '../../event'
 import { createRootLogger, Logger } from '../../logger'
 import { ErrorUtils } from '../../utils'
 import { Identity } from '../identity'
-import { DisconnectingReason, InternalMessageType, LooseMessage } from '../messages'
+import { InternalMessageType, LooseMessage } from '../messages'
+import { DisconnectingReason } from '../messages/disconnecting'
 import { NetworkMessage, NetworkMessageType } from '../messages/networkMessage'
 import { ConnectionRetry } from './connectionRetry'
 import { WebRtcConnection, WebSocketConnection } from './connections'
@@ -424,7 +425,7 @@ export class Peer {
    * Sends a message over the peer's connection if CONNECTED, else drops it.
    * @param message The message to send.
    */
-  send(message: LooseMessage): Connection | null {
+  send(message: LooseMessage | NetworkMessage): Connection | null {
     // Return early if peer is not in state CONNECTED
     if (this.state.type !== 'CONNECTED') {
       this.logger.debug(
@@ -440,7 +441,7 @@ export class Peer {
       if (this.state.connections.webRtc.send(message)) {
         this.pushLoggedMessage({
           direction: 'send',
-          message: message,
+          message,
           timestamp: Date.now(),
           type: ConnectionType.WebRtc,
         })
@@ -457,7 +458,7 @@ export class Peer {
       if (this.state.connections.webSocket.send(message)) {
         this.pushLoggedMessage({
           direction: 'send',
-          message: message,
+          message,
           timestamp: Date.now(),
           type: ConnectionType.WebSocket,
         })

--- a/ironfish/src/typedefs/bufio.d.ts
+++ b/ironfish/src/typedefs/bufio.d.ts
@@ -33,6 +33,7 @@ declare module 'bufio' {
   }
 
   class BufferReader {
+    left(): number
     readU8(): number
     readU64(): number
     readU64BE(): number


### PR DESCRIPTION
## Summary

* Migrate disconnecting message to be buffer serializable
* Add missing unit tests for identify
* Remove message id from network message

## Testing Plan

Added unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
