### PR TITLE
Improve json parse error checking

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -38,7 +38,7 @@
     "lodash": "4.17.21",
     "node-datachannel": "0.2.4",
     "node-ipc": "9.1.3",
-    "parse-json": "5.1.0",
+    "parse-json": "5.2.0",
     "sqlite": "4.0.23",
     "sqlite3": "https://github.com/mapbox/node-sqlite3/archive/918052b538b0effe6c4a44c74a16b2749c08a0d2.tar.gz",
     "tweetnacl": "1.0.3",

--- a/ironfish/src/utils/json.test.ts
+++ b/ironfish/src/utils/json.test.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { JSONUtils, ParseJsonError } from './json'
+
+describe('JSONUtils', () => {
+  it('tryParse', () => {
+    expect(JSONUtils.tryParse('')).toEqual([null, expect.any(ParseJsonError)])
+    expect(JSONUtils.tryParse('foo')).toEqual([null, expect.any(ParseJsonError)])
+    expect(JSONUtils.tryParse('{"foo"')).toEqual([null, expect.any(ParseJsonError)])
+    expect(JSONUtils.tryParse('{}')).toEqual([{}, null])
+    expect(JSONUtils.tryParse('{"foo":"bar"}')).toEqual([{ foo: 'bar' }, null])
+  })
+})

--- a/ironfish/src/utils/json.ts
+++ b/ironfish/src/utils/json.ts
@@ -4,10 +4,6 @@
 import parseJson, { JSONError } from 'parse-json'
 import { Assert } from '../assert'
 
-function IsParseJsonError(e: unknown): e is JSONError {
-  return typeof e === 'object' && !!e && 'codeFrame' in e
-}
-
 export class ParseJsonError extends Error {
   jsonMessage: string
   jsonFileName: string
@@ -38,7 +34,7 @@ function tryParse<T = unknown>(
     const config = parseJson(data, fileName || '') as T
     return [config, null]
   } catch (e) {
-    if (IsParseJsonError(e)) {
+    if (e instanceof JSONError) {
       const error = new ParseJsonError(e.fileName, e.message, e.codeFrame)
       return [null, error]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7761,10 +7761,10 @@ parse-conflict-json@^2.0.1:
     just-diff "^5.0.1"
     just-diff-apply "^4.0.1"
 
-parse-json@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.1.0.tgz#f96088cdf24a8faa9aea9a009f2d9d942c999646"
-  integrity sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
+parse-json@5.2.0, parse-json@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     error-ex "^1.3.1"
@@ -7778,16 +7778,6 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
-
-parse-json@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
-  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    error-ex "^1.3.1"
-    json-parse-even-better-errors "^2.3.0"
-    lines-and-columns "^1.1.6"
 
 parse-path@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
## Summary

- Update parse-json to 5.2.0 which exports JSONError, allowing us to use `instanceof` to type check it
- Add some basic unit test coverage

## Testing Plan

- Unit tests
- Manually tested: `rm hosts.json`, `touch hosts.json`, also tried `echo asdf > hosts.json`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
