### PR TITLE
Log hosts json parsing error as debug instead of warn

### DIFF
--- a/ironfish/src/fileStores/hosts.ts
+++ b/ironfish/src/fileStores/hosts.ts
@@ -28,7 +28,9 @@ export class HostsStore extends KeyStore<HostsOptions> {
       await super.load()
     } catch (e) {
       if (e instanceof ParseJsonError) {
-        this.logger.warn(`Error: Could not parse JSON at ${this.storage.configPath}`)
+        this.logger.debug(
+          `Error: Could not parse JSON at ${this.storage.configPath}, overwriting file.`,
+        )
         await super.save()
       } else {
         throw e


### PR DESCRIPTION
## Summary

- This is an error from which we recover, so avoid surfacing it in normal execution so that users don't get concerned about it
- Explain that we are overwriting it, in case people are looking for the error/file

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
