### PR TITLE
feat(ironfish): Convert `CannotSatisfyRequest` to buffer serialization

### DIFF
--- a/ironfish/src/network/messageRouters/globalRpc.test.ts
+++ b/ironfish/src/network/messageRouters/globalRpc.test.ts
@@ -7,7 +7,8 @@ jest.mock('ws')
 
 import '../testUtilities'
 import { mocked } from 'ts-jest/utils'
-import { InternalMessageType, MessageType } from '../messages'
+import { MessageType } from '../messages'
+import { CannotSatisfyRequest } from '../messages/cannotSatisfyRequest'
 import { PeerManager } from '../peers/peerManager'
 import { getConnectedPeer, mockHostsStore, mockLocalPeer } from '../testUtilities'
 import { GlobalRpcRouter } from './globalRpc'
@@ -241,12 +242,7 @@ describe('Global Rpc', () => {
     mocked(nextRpcId).mockReturnValueOnce(34).mockReturnValueOnce(11)
     const promise = router.request({ type: 'test', payload: { test: 'payload' } })
 
-    await router.handle(peer1, {
-      rpcId: 34,
-      direction: Direction.Response,
-      type: InternalMessageType.cannotSatisfyRequest,
-      payload: {},
-    })
+    await router.handle(peer1, new CannotSatisfyRequest(34))
 
     void router.handle(peer2, {
       rpcId: 11,

--- a/ironfish/src/network/messageRouters/globalRpc.ts
+++ b/ironfish/src/network/messageRouters/globalRpc.ts
@@ -4,13 +4,7 @@
 
 import { ArrayUtils } from '../../utils'
 import { Identity } from '../identity'
-import {
-  IncomingPeerMessage,
-  InternalMessageType,
-  Message,
-  MessageType,
-  PayloadType,
-} from '../messages'
+import { IncomingPeerMessage, Message, MessageType, PayloadType } from '../messages'
 import { NetworkMessageType } from '../messages/networkMessage'
 import { RpcNetworkMessage } from '../messages/rpcNetworkMessage'
 import { Peer } from '../peers/peer'
@@ -112,7 +106,7 @@ export class GlobalRpcRouter {
 
       try {
         const response = await this.rpcRouter.requestFrom(peer, { ...message })
-        if (response.message.type !== InternalMessageType.cannotSatisfyRequest) {
+        if (response.message.type !== NetworkMessageType.CannotSatisfyRequest) {
           this.requestFails.get(peerIdentity)?.delete(message.type)
           return response
         }
@@ -135,7 +129,10 @@ export class GlobalRpcRouter {
    * some data or an incoming repsonse. Either way, we just forward it to the
    * RPC handler.
    */
-  async handle(peer: Peer, rpcMessage: IncomingRpcPeerMessage['message']): Promise<void> {
+  async handle(
+    peer: Peer,
+    rpcMessage: IncomingRpcPeerMessage['message'] | RpcNetworkMessage,
+  ): Promise<void> {
     await this.rpcRouter.handle(peer, rpcMessage)
   }
 

--- a/ironfish/src/network/messageRouters/rpc.test.ts
+++ b/ironfish/src/network/messageRouters/rpc.test.ts
@@ -4,6 +4,7 @@
 
 jest.mock('./rpcId')
 import { mocked } from 'ts-jest/utils'
+import { CannotSatisfyRequest } from '../messages/cannotSatisfyRequest'
 import { NetworkError } from '../peers/connections/errors'
 import { PeerManager } from '../peers/peerManager'
 import { getConnectedPeer, mockHostsStore, mockLocalPeer } from '../testUtilities'
@@ -156,8 +157,9 @@ describe('RPC Router', () => {
     router.register('test', handlerMock)
 
     const { peer } = getConnectedPeer(peers)
+    const rpcId = 18
     await router.handle(peer, {
-      rpcId: 18,
+      rpcId,
       direction: Direction.Request,
       type: 'test',
       payload: { test: 'payload' },
@@ -165,12 +167,6 @@ describe('RPC Router', () => {
 
     expect(router['requests'].size).toBe(0)
     expect(sendToMock).toBeCalledTimes(1)
-    expect(sendToMock).toHaveBeenCalledWith(
-      peer,
-      expect.objectContaining({
-        direction: Direction.Response,
-        type: 'cannotSatisfyRequest',
-      }),
-    )
+    expect(sendToMock).toHaveBeenCalledWith(peer, new CannotSatisfyRequest(rpcId))
   })
 })

--- a/ironfish/src/network/messages.ts
+++ b/ironfish/src/network/messages.ts
@@ -10,17 +10,7 @@ import { Identity } from './identity'
 import { Gossip } from './messageRouters'
 import { NetworkMessage } from './messages/networkMessage'
 
-/**
- * The type of the message for the purposes of routing within our code.
- * This includes messages consumed by our connection and peer manager layer,
- * such as identity, signal, and peerList,
- * and message routing types such as gossip, directRPC, and globalRPC.
- */
-export enum InternalMessageType {
-  cannotSatisfyRequest = 'cannotSatisfyRequest',
-}
-
-export type MessageType = InternalMessageType | string
+export type MessageType = string
 export type PayloadType = Record<string, unknown> | undefined
 /**
  * Used for functions that don't care about the contents of the message.

--- a/ironfish/src/network/messages/cannotSatisfyRequest.test.ts
+++ b/ironfish/src/network/messages/cannotSatisfyRequest.test.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { CannotSatisfyRequest } from './cannotSatisfyRequest'
+
+describe('CannotSatisfyRequest', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const rpcId = 0
+    const message = new CannotSatisfyRequest(rpcId)
+    const deserializedMessage = CannotSatisfyRequest.deserialize(rpcId)
+    expect(deserializedMessage).toEqual(message)
+  })
+})

--- a/ironfish/src/network/messages/cannotSatisfyRequest.ts
+++ b/ironfish/src/network/messages/cannotSatisfyRequest.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Direction } from '../messageRouters'
+import { NetworkMessageType } from './networkMessage'
+import { RpcNetworkMessage } from './rpcNetworkMessage'
+
+export class CannotSatisfyRequest extends RpcNetworkMessage {
+  constructor(rpcId: number) {
+    super(NetworkMessageType.CannotSatisfyRequest, Direction.Response, rpcId)
+  }
+
+  serialize(): Buffer {
+    return Buffer.from('')
+  }
+
+  static deserialize(rpcId: number): CannotSatisfyRequest {
+    return new CannotSatisfyRequest(rpcId)
+  }
+
+  getSize(): number {
+    return 0
+  }
+}

--- a/ironfish/src/network/messages/networkMessage.ts
+++ b/ironfish/src/network/messages/networkMessage.ts
@@ -6,13 +6,14 @@ import { Serializable } from '../../common/serializable'
 
 export enum NetworkMessageType {
   Disconnecting = 0,
-  GetBlocksRequest = 1,
-  GetBlocksResponse = 2,
-  Identify = 3,
-  PeerList = 4,
-  PeerListRequest = 5,
-  Signal = 6,
-  SignalRequest = 7,
+  CannotSatisfyRequest = 1,
+  GetBlocksRequest = 2,
+  GetBlocksResponse = 3,
+  Identify = 4,
+  PeerList = 5,
+  PeerListRequest = 6,
+  Signal = 7,
+  SignalRequest = 8,
 }
 
 export abstract class NetworkMessage implements Serializable {

--- a/ironfish/src/network/peers/connections/connection.ts
+++ b/ironfish/src/network/peers/connections/connection.ts
@@ -11,6 +11,7 @@ import { SetTimeoutToken } from '../../../utils'
 import { Identity } from '../../identity'
 import { rpcTimeoutMillis } from '../../messageRouters/rpcId'
 import { LooseMessage } from '../../messages'
+import { CannotSatisfyRequest } from '../../messages/cannotSatisfyRequest'
 import { DisconnectingMessage } from '../../messages/disconnecting'
 import { GetBlocksRequest, GetBlocksResponse } from '../../messages/getBlocks'
 import { IdentifyMessage } from '../../messages/identify'
@@ -245,13 +246,18 @@ export abstract class Connection {
   }
 
   private isRpcNetworkMessageType(type: NetworkMessageType): boolean {
-    return [NetworkMessageType.GetBlocksRequest, NetworkMessageType.GetBlocksResponse].includes(
-      type,
-    )
+    return [
+      NetworkMessageType.CannotSatisfyRequest,
+      NetworkMessageType.GetBlocksRequest,
+      NetworkMessageType.GetBlocksResponse,
+    ].includes(type)
   }
 
   private parseBody({ rpcId, type, body }: NetworkMessageHeader): NetworkMessage {
     switch (type) {
+      case NetworkMessageType.CannotSatisfyRequest:
+        Assert.isNotUndefined(rpcId)
+        return CannotSatisfyRequest.deserialize(rpcId)
       case NetworkMessageType.Disconnecting:
         return DisconnectingMessage.deserialize(body)
       case NetworkMessageType.GetBlocksRequest:


### PR DESCRIPTION
## Summary

Migrate cannot satisfy request response to binary serialization 

## Testing Plan

Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
