### PR TITLE
Refactor default dataDir in node and sdk

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -3,11 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { FileSystem } from '../fileSystems'
-import { DEFAULT_DATA_DIR } from './fileStore'
 import { KeyStore } from './keyStore'
 
 export const DEFAULT_CONFIG_NAME = 'config.json'
 export const DEFAULT_DATABASE_NAME = 'default'
+export const DEFAULT_DATA_DIR = '~/.ironfish'
 export const DEFAULT_WALLET_NAME = 'default'
 export const DEFAULT_WEBSOCKET_PORT = 9033
 export const DEFAULT_GET_FUNDS_API = 'https://api.ironfish.network/faucet_transactions'

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -191,12 +191,12 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
   .defined()
 
 export class Config extends KeyStore<ConfigOptions> {
-  constructor(files: FileSystem, dataDir?: string, configName?: string) {
+  constructor(files: FileSystem, dataDir: string, configName?: string) {
     super(
       files,
       configName || DEFAULT_CONFIG_NAME,
-      Config.GetDefaults(files, dataDir || DEFAULT_DATA_DIR),
-      dataDir || DEFAULT_DATA_DIR,
+      Config.GetDefaults(files, dataDir),
+      dataDir,
       ConfigOptionsSchema,
     )
   }
@@ -224,7 +224,7 @@ export class Config extends KeyStore<ConfigOptions> {
       enableTelemetry: false,
       enableMetrics: true,
       getFundsApi: DEFAULT_GET_FUNDS_API,
-      ipcPath: files.resolve(files.join(dataDir || DEFAULT_DATA_DIR, 'ironfish.ipc')),
+      ipcPath: files.resolve(files.join(dataDir, 'ironfish.ipc')),
       logLevel: '*:info',
       logPeerMessages: false,
       logPrefix: '',

--- a/ironfish/src/fileStores/fileStore.ts
+++ b/ironfish/src/fileStores/fileStore.ts
@@ -5,17 +5,15 @@ import path from 'path'
 import { FileSystem } from '../fileSystems'
 import { JSONUtils, PartialRecursive } from '../utils'
 
-export const DEFAULT_DATA_DIR = '~/.ironfish'
-
 export class FileStore<T extends Record<string, unknown>> {
   files: FileSystem
   dataDir: string
   configPath: string
   configName: string
 
-  constructor(files: FileSystem, configName: string, dataDir?: string) {
+  constructor(files: FileSystem, configName: string, dataDir: string) {
     this.files = files
-    this.dataDir = files.resolve(dataDir || DEFAULT_DATA_DIR)
+    this.dataDir = files.resolve(dataDir)
     this.configName = configName
     this.configPath = path.join(this.dataDir, configName)
   }

--- a/ironfish/src/fileStores/hosts.ts
+++ b/ironfish/src/fileStores/hosts.ts
@@ -18,7 +18,7 @@ export const HostOptionsDefaults: HostsOptions = {
 export class HostsStore extends KeyStore<HostsOptions> {
   logger: Logger
 
-  constructor(files: FileSystem, dataDir?: string, configName?: string) {
+  constructor(files: FileSystem, dataDir: string, configName?: string) {
     super(files, configName || 'hosts.json', HostOptionsDefaults, dataDir)
     this.logger = createRootLogger()
   }

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -17,7 +17,7 @@ export const InternalOptionsDefaults: InternalOptions = {
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {
-  constructor(files: FileSystem, dataDir?: string, configName?: string) {
+  constructor(files: FileSystem, dataDir: string, configName?: string) {
     super(files, configName || 'internal.json', InternalOptionsDefaults, dataDir)
   }
 }

--- a/ironfish/src/fileStores/keyStore.ts
+++ b/ironfish/src/fileStores/keyStore.ts
@@ -25,7 +25,7 @@ export class KeyStore<TSchema extends Record<string, unknown>> {
     files: FileSystem,
     configName: string,
     defaults: TSchema,
-    dataDir?: string,
+    dataDir: string,
     schema?: yup.ObjectSchema<TSchema | Partial<TSchema>>,
   ) {
     this.files = files

--- a/ironfish/src/network/testUtilities/mockHostsStore.ts
+++ b/ironfish/src/network/testUtilities/mockHostsStore.ts
@@ -51,7 +51,7 @@ class MockFileSystem extends FileSystem {
 
 class MockHostsStore extends HostsStore {
   constructor() {
-    super(new MockFileSystem())
+    super(new MockFileSystem(), "~/.ironfish")
     super.set('priorPeers', [
       {
         address: '127.0.0.1',

--- a/ironfish/src/network/testUtilities/mockHostsStore.ts
+++ b/ironfish/src/network/testUtilities/mockHostsStore.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { HostsOptions, HostsStore } from '../../fileStores'
+import { DEFAULT_DATA_DIR, HostsOptions, HostsStore } from '../../fileStores'
 import { FileSystem } from '../../fileSystems'
 import { PeerAddress } from '../peers/peerAddress'
 
@@ -51,7 +51,7 @@ class MockFileSystem extends FileSystem {
 
 class MockHostsStore extends HostsStore {
   constructor() {
-    super(new MockFileSystem(), "~/.ironfish")
+    super(new MockFileSystem(), DEFAULT_DATA_DIR)
     super.set('priorPeers', [
       {
         address: '127.0.0.1',

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -154,17 +154,18 @@ export class IronfishNode {
   }): Promise<IronfishNode> {
     logger = logger.withTag('ironfishnode')
 
+    const dataDirOrDefault = dataDir || DEFAULT_DATA_DIR
     if (!config) {
-      config = new Config(files, dataDir || DEFAULT_DATA_DIR)
+      config = new Config(files, dataDirOrDefault)
       await config.load()
     }
 
     if (!internal) {
-      internal = new InternalStore(files, dataDir)
+      internal = new InternalStore(files, dataDirOrDefault)
       await internal.load()
     }
 
-    const hostsStore = new HostsStore(files, dataDir)
+    const hostsStore = new HostsStore(files, dataDirOrDefault)
     await hostsStore.load()
 
     if (databaseName) {

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -5,7 +5,13 @@ import os from 'os'
 import { v4 as uuid } from 'uuid'
 import { Accounts, AccountsDB } from './account'
 import { Blockchain } from './blockchain'
-import { Config, ConfigOptions, DEFAULT_DATA_DIR, HostsStore, InternalStore, } from './fileStores'
+import {
+  Config,
+  ConfigOptions,
+  DEFAULT_DATA_DIR,
+  HostsStore,
+  InternalStore,
+} from './fileStores'
 import { FileSystem } from './fileSystems'
 import { createRootLogger, Logger } from './logger'
 import { MemPool } from './memPool'

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -153,19 +153,19 @@ export class IronfishNode {
     privateIdentity?: PrivateIdentity
   }): Promise<IronfishNode> {
     logger = logger.withTag('ironfishnode')
+    dataDir = dataDir || DEFAULT_DATA_DIR
 
-    const dataDirOrDefault = dataDir || DEFAULT_DATA_DIR
     if (!config) {
-      config = new Config(files, dataDirOrDefault)
+      config = new Config(files, dataDir)
       await config.load()
     }
 
     if (!internal) {
-      internal = new InternalStore(files, dataDirOrDefault)
+      internal = new InternalStore(files, dataDir)
       await internal.load()
     }
 
-    const hostsStore = new HostsStore(files, dataDirOrDefault)
+    const hostsStore = new HostsStore(files, dataDir)
     await hostsStore.load()
 
     if (databaseName) {

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -5,7 +5,7 @@ import os from 'os'
 import { v4 as uuid } from 'uuid'
 import { Accounts, AccountsDB } from './account'
 import { Blockchain } from './blockchain'
-import { Config, ConfigOptions, HostsStore, InternalStore } from './fileStores'
+import { Config, ConfigOptions, DEFAULT_DATA_DIR, HostsStore, InternalStore, } from './fileStores'
 import { FileSystem } from './fileSystems'
 import { createRootLogger, Logger } from './logger'
 import { MemPool } from './memPool'
@@ -155,7 +155,7 @@ export class IronfishNode {
     logger = logger.withTag('ironfishnode')
 
     if (!config) {
-      config = new Config(files, dataDir)
+      config = new Config(files, dataDir || DEFAULT_DATA_DIR)
       await config.load()
     }
 

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import os from 'os'
 import { Accounts } from './account'
-import { Config } from './fileStores'
+import { Config, DEFAULT_DATA_DIR } from './fileStores'
 import { NodeFileProvider } from './fileSystems'
 import { IronfishNode } from './node'
 import { Platform } from './platform'
@@ -57,6 +57,23 @@ describe('IronfishSdk', () => {
       expect(node.config).toBe(sdk.config)
       expect(node.accounts).toBeInstanceOf(Accounts)
       expect(node.config.get('databaseName')).toBe('foo')
+    })
+
+    it('should initialize an SDK with the default dataDir if none is passed in', async () => {
+      const fileSystem = new NodeFileProvider()
+      await fileSystem.init()
+
+      const sdk = await IronfishSdk.init({
+        configName: 'foo.config.json',
+        fileSystem: fileSystem,
+      })
+
+      const expectedDir = fileSystem.resolve(DEFAULT_DATA_DIR)
+      expect(sdk.config.dataDir).toBe(expectedDir)
+      expect(sdk.config.storage.dataDir).toBe(expectedDir)
+
+      const node = await sdk.node({ databaseName: 'foo' })
+      expect(node.config).toBe(sdk.config)
     })
   })
 

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -94,12 +94,12 @@ export class IronfishSdk {
     }
 
     logger = logger.withTag('ironfishsdk')
+    dataDir = dataDir || DEFAULT_DATA_DIR
 
-    const dataDirOrDefault = dataDir || DEFAULT_DATA_DIR;
-    const config = new Config(fileSystem, dataDirOrDefault, configName)
+    const config = new Config(fileSystem, dataDir, configName)
     await config.load()
 
-    const internal = new InternalStore(fileSystem, dataDirOrDefault)
+    const internal = new InternalStore(fileSystem, dataDir)
     await internal.load()
 
     if (configOverrides) {

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BoxKeyPair } from 'tweetnacl'
-import { Config, ConfigOptions, InternalStore } from './fileStores'
+import { Config, ConfigOptions, DEFAULT_DATA_DIR, InternalStore } from './fileStores'
 import { FileSystem, NodeFileProvider } from './fileSystems'
 import {
   createRootLogger,
@@ -95,7 +95,7 @@ export class IronfishSdk {
 
     logger = logger.withTag('ironfishsdk')
 
-    const config = new Config(fileSystem, dataDir, configName)
+    const config = new Config(fileSystem, dataDir || DEFAULT_DATA_DIR, configName)
     await config.load()
 
     const internal = new InternalStore(fileSystem, dataDir)

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -37,7 +37,7 @@ export class IronfishSdk {
   internal: InternalStore
   strategyClass: typeof Strategy | null
   privateIdentity: BoxKeyPair | null | undefined
-  dataDir?: string
+  dataDir: string
 
   private constructor(
     pkg: Package,
@@ -49,7 +49,7 @@ export class IronfishSdk {
     logger: Logger,
     metrics: MetricsMonitor,
     strategyClass: typeof Strategy | null = null,
-    dataDir?: string,
+    dataDir: string,
   ) {
     this.pkg = pkg
     this.client = client

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -95,10 +95,11 @@ export class IronfishSdk {
 
     logger = logger.withTag('ironfishsdk')
 
-    const config = new Config(fileSystem, dataDir || DEFAULT_DATA_DIR, configName)
+    const dataDirOrDefault = dataDir || DEFAULT_DATA_DIR;
+    const config = new Config(fileSystem, dataDirOrDefault, configName)
     await config.load()
 
-    const internal = new InternalStore(fileSystem, dataDir)
+    const internal = new InternalStore(fileSystem, dataDirOrDefault)
     await internal.load()
 
     if (configOverrides) {


### PR DESCRIPTION
## Summary
Doing some refactoring and moving the default dataDir up to the level of the node and sdk. We don't want to set defaults deep in the code

## Testing Plan
Running current test suite

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
