### PR TITLE
Remove shrinkwraprs

### DIFF
--- a/ironfish-rust-nodejs/Cargo.lock
+++ b/ironfish-rust-nodejs/Cargo.lock
@@ -419,12 +419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
 name = "equihash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,19 +596,9 @@ dependencies = [
  "lazy_static",
  "rand 0.7.3",
  "rust-crypto-wasm",
- "shrinkwraprs",
  "tiny-bip39",
  "zcash_primitives",
  "zcash_proofs",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1031,19 +1015,6 @@ dependencies = [
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug",
-]
-
-[[package]]
-name = "shrinkwraprs"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83695fde96cbe9e08f0e4eb96b1b56fdbd44f2098ee27462dda964c7745fddc7"
-dependencies = [
- "bitflags",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/ironfish-rust-wasm/Cargo.lock
+++ b/ironfish-rust-wasm/Cargo.lock
@@ -400,12 +400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
 name = "equihash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,7 +568,6 @@ dependencies = [
  "lazy_static",
  "rand 0.7.3",
  "rust-crypto-wasm",
- "shrinkwraprs",
  "tiny-bip39",
  "zcash_primitives",
  "zcash_proofs",
@@ -590,15 +583,6 @@ dependencies = [
  "rand 0.7.3",
  "wasm-bindgen",
  "zcash_primitives",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -950,19 +934,6 @@ dependencies = [
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug",
-]
-
-[[package]]
-name = "shrinkwraprs"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83695fde96cbe9e08f0e4eb96b1b56fdbd44f2098ee27462dda964c7745fddc7"
-dependencies = [
- "bitflags",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/ironfish-rust/Cargo.lock
+++ b/ironfish-rust/Cargo.lock
@@ -400,12 +400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
 name = "equihash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,19 +568,9 @@ dependencies = [
  "lazy_static",
  "rand 0.7.3",
  "rust-crypto-wasm",
- "shrinkwraprs",
  "tiny-bip39",
  "zcash_primitives",
  "zcash_proofs",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -929,19 +913,6 @@ dependencies = [
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug",
-]
-
-[[package]]
-name = "shrinkwraprs"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83695fde96cbe9e08f0e4eb96b1b56fdbd44f2098ee27462dda964c7745fddc7"
-dependencies = [
- "bitflags",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -30,7 +30,6 @@ blake2s_simd = "0.5"
 blake3 = "1.3.0"
 rand = "0.7"
 rust-crypto-wasm = "0.3.1" # in favor of rust-crypto as this one is wasm friendly
-shrinkwraprs = "0.2.1"
 tiny-bip39 = "0.8.0"
 
 [patch.crates-io]

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -5,9 +5,6 @@
 #[macro_use]
 extern crate lazy_static;
 
-#[macro_use]
-extern crate shrinkwraprs;
-
 use bellman::groth16;
 use bls12_381::Bls12;
 

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -20,7 +20,7 @@ pub const ENCRYPTED_NOTE_SIZE: usize = 83;
 
 /// Memo field on a Note. Used to encode transaction IDs or other information
 /// about the transaction.
-#[derive(Shrinkwrap, Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Memo(pub [u8; 32]);
 
 impl From<&str> for Memo {
@@ -207,7 +207,7 @@ impl<'a> Note {
         bytes_to_encrypt[11..43].clone_from_slice(self.randomness.to_repr().as_ref());
 
         LittleEndian::write_u64_into(&[self.value], &mut bytes_to_encrypt[43..51]);
-        bytes_to_encrypt[51..].copy_from_slice(&self.memo[..]);
+        bytes_to_encrypt[51..].copy_from_slice(&self.memo.0[..]);
         let mut encrypted_bytes = [0; ENCRYPTED_NOTE_SIZE + aead::MAC_SIZE];
         aead::encrypt(shared_secret, &bytes_to_encrypt, &mut encrypted_bytes);
 


### PR DESCRIPTION
## Summary

Removes the shrinkwraprs library, since we're not really using it anywhere.

## Testing Plan

Tests should pass as expected

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
