### PR TITLE
remove node from request object

### DIFF
--- a/ironfish/src/rpc/adapters/ipcAdapter.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.ts
@@ -243,7 +243,6 @@ export class IpcAdapter implements IAdapter {
 
     const request = new Request(
       message.data,
-      node,
       (status: number, data?: unknown) => {
         this.emitResponse(socket, message.mid, status, data)
       },

--- a/ironfish/src/rpc/adapters/memoryAdapter.ts
+++ b/ironfish/src/rpc/adapters/memoryAdapter.ts
@@ -69,7 +69,6 @@ export class MemoryAdapter implements IAdapter {
 
     const request = new Request(
       data,
-      server.node,
       (status: number, data?: unknown) => {
         response.status = status
         stream.close()

--- a/ironfish/src/rpc/request.ts
+++ b/ironfish/src/rpc/request.ts
@@ -3,11 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Event } from '../event'
-import { IronfishNode } from '../node'
 
 export class Request<TRequest = unknown, TResponse = unknown> {
   data: TRequest
-  node: IronfishNode
   ended = false
   closed = false
   code: number | null = null
@@ -17,12 +15,10 @@ export class Request<TRequest = unknown, TResponse = unknown> {
 
   constructor(
     data: TRequest,
-    node: IronfishNode,
     onEnd: (status: number, data?: unknown) => void,
     onStream: (data?: unknown) => void,
   ) {
     this.data = data
-    this.node = node
     this.onEnd = onEnd
     this.onStream = onStream
   }


### PR DESCRIPTION
## Summary
Node is not being used on the request object so simplifying this code. It seems like the request being sent to a node should not already know about the node it's being sent to

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
