### PR TITLE
Replace node-ipc server native node TCP functionality

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -43,6 +43,12 @@ export type ConfigOptions = {
   getFundsApi: string
   ipcPath: string
   /**
+   * As part of IRO-1759 we are removing 'node-ipc' for RPC. This is
+   * essentially a feature flag for enabling use of the native TCP adapter
+   * without using 'node-ipc'
+   */
+  enableNativeRpcTcpAdapter: boolean
+  /**
    * Should the mining director mine, even if we are not synced?
    * Only useful if no miner has been on the network in a long time
    * otherwise you should not turn this on or you'll create useless
@@ -220,6 +226,7 @@ export class Config extends KeyStore<ConfigOptions> {
       enableRpc: true,
       enableRpcIpc: DEFAULT_USE_RPC_IPC,
       enableRpcTcp: DEFAULT_USE_RPC_TCP,
+      enableNativeRpcTcpAdapter: false,
       enableSyncing: true,
       enableTelemetry: false,
       enableMetrics: true,

--- a/ironfish/src/rpc/adapters/tcpAdapter.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.ts
@@ -151,7 +151,7 @@ export class TcpAdapter implements IAdapter {
 
       if (this.router == null) {
         this.emitResponse(socket, this.constructMalformedRequest(data), reqMap)
-        return 
+        return
       } else {
         try {
           await this.router.route(message.type, request)

--- a/ironfish/src/rpc/adapters/tcpAdapter.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.ts
@@ -1,0 +1,207 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import net from 'net'
+import * as yup from 'yup'
+import { createRootLogger, Logger } from '../../logger'
+import { YupUtils } from '../../utils/yup'
+import { Request } from '../request'
+import { ApiNamespace, Router } from '../routes'
+import { RpcServer } from '../server'
+import { IAdapter } from './adapter'
+import { ERROR_CODES, ResponseError } from './errors'
+import { IpcError, IpcRequest, IpcResponse, IpcStream } from './ipcAdapter'
+
+// Message type that node-ipc client sends over a TCP socket
+type IncomingNodeIpc = {
+  type: 'message'
+  data: IpcRequest
+}
+
+// Message type that node-ipc client listens for over a TCP socket
+type OutgoingNodeIpc =
+  | { type: 'message'; data: IpcResponse }
+  | { type: 'malformedRequest'; data: IpcError }
+  | { type: 'stream'; data: IpcStream }
+
+export const IncomingNodeIpcSchema: yup.ObjectSchema<IncomingNodeIpc> = yup
+  .object({
+    type: yup.string().oneOf(['message']).required(),
+    data: yup
+      .object({
+        mid: yup.number().required(),
+        type: yup.string().required(),
+        data: yup.mixed().notRequired(),
+      })
+      .required(),
+  })
+  .required()
+
+export class TcpAdapter implements IAdapter {
+  logger: Logger
+  host: string
+  port: number
+  server: net.Server | null = null
+  router: Router | null = null
+  namespaces: ApiNamespace[]
+
+  constructor(
+    host: string,
+    port: number,
+    logger: Logger = createRootLogger(),
+    namespaces: ApiNamespace[],
+  ) {
+    this.host = host
+    this.port = port
+    this.logger = logger.withTag('tcpadapter')
+    this.namespaces = namespaces
+  }
+
+  start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server = net.createServer((socket) => this.onClientConnection(socket))
+
+      this.server.on('error', (err) => {
+        reject(err)
+      })
+
+      this.server.listen(
+        {
+          host: this.host,
+          port: this.port,
+          exclusive: true,
+        },
+        () => {
+          resolve()
+        },
+      )
+    })
+  }
+
+  stop(): Promise<void> {
+    this.logger.debug(`tcpAdapter stopped: ${this.host}:${this.port}`)
+    return Promise.resolve()
+  }
+
+  attach(server: RpcServer): void {
+    this.router = server.getRouter(this.namespaces)
+  }
+
+  unattach(): void {
+    this.router = null
+  }
+
+  onClientConnection(socket: net.Socket): void {
+    socket.on('data', (data) => {
+      this.onClientData(socket, data).catch((err) => this.logger.error(err))
+    })
+    socket.on('close', () => {
+      //TODO: possibly keep track of ongoing reqeusts on this connection and
+      // cancel all of them. This seems like an optimization but not a requirement
+      this.logger.debug(`client connection closed: ${this.host}:${this.port}`)
+    })
+    socket.on('error', (error: Error) => {
+      this.logger.debug(`${this.host}:${this.port} has error : ${error.message}`)
+    })
+  }
+
+  async onClientData(socket: net.Socket, data: Buffer): Promise<void> {
+    const dataString = data.toString('utf8').trim()
+    const result = await YupUtils.tryValidate(IncomingNodeIpcSchema, dataString)
+
+    if (result.error) {
+      this.logger.log(
+        `${this.host}:${this.port} Error parsing message : ${result.error.message} raw: ${dataString} `,
+      )
+    } else {
+      const message = result.result.data
+
+      const request = new Request(
+        message.data,
+        (status: number, data?: unknown) => {
+          const res = this.encodeNodeIpc(this.constructMessage(message.mid, status, data))
+          socket.write(res)
+        },
+        (data: unknown) => {
+          const res = this.encodeNodeIpc(this.constructStream(message.mid, data))
+          socket.write(res)
+        },
+      )
+
+      if (this.router == null) {
+        this.logger.log('handling incoming connection on unmounted adapter')
+      } else {
+        try {
+          await this.router.route(message.type, request)
+        } catch (error: unknown) {
+          if (error instanceof ResponseError) {
+            const res = this.encodeNodeIpc(
+              this.constructMessage(message.mid, error.status, {
+                code: error.code,
+                message: error.message,
+                stack: error.stack,
+              }),
+            )
+            socket.write(res)
+          } else {
+            throw error
+          }
+        }
+      }
+    }
+  }
+
+  // `constructResponse`,  `constructStream` and `constructMalformedRequest` construct messages to return
+  // to a 'node-ipc' client. Once we remove 'node-ipc' we can return our own messages
+  // The '\f' is for handling the delimeter that 'node-ipc' expects when parsing
+  // messages it received. See 'node-ipc' parsing/formatting logic here:
+  // https://github.com/RIAEvangelist/node-ipc/blob/master/entities/EventParser.js
+  encodeNodeIpc(ipcResponse: OutgoingNodeIpc): string {
+    return JSON.stringify(ipcResponse) + '\f'
+  }
+
+  constructMessage(messageId: number, status: number, data: unknown): OutgoingNodeIpc {
+    return {
+      type: 'message',
+      data: {
+        id: messageId,
+        status: status,
+        data: data,
+      },
+    }
+  }
+
+  constructStream(messageId: number, data: unknown): OutgoingNodeIpc {
+    return {
+      type: 'stream',
+      data: {
+        id: messageId,
+        data: data,
+      },
+    }
+  }
+
+  constructMalformedRequest(data: unknown): OutgoingNodeIpc {
+    const error = new Error(`Malformed request rejected`)
+    const ipcError = {
+      code: ERROR_CODES.ERROR,
+      message: error.message,
+      stack: error.stack,
+    }
+
+    if (
+      typeof data === 'object' &&
+      data !== null &&
+      'id' in data &&
+      typeof (data as { id: unknown })['id'] === 'number'
+    ) {
+      const id = (data as { id: unknown })['id'] as number
+      return this.constructMessage(id, 500, ipcError)
+    }
+
+    return {
+      type: 'malformedRequest',
+      data: ipcError,
+    }
+  }
+}

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -19,6 +19,7 @@ import { IronfishNode } from './node'
 import { IronfishPKG, Package } from './package'
 import { Platform } from './platform'
 import { IpcAdapter } from './rpc/adapters/ipcAdapter'
+import { TcpAdapter } from './rpc/adapters/tcpAdapter'
 import { IronfishIpcClient } from './rpc/clients/ipcClient'
 import { IronfishMemoryClient } from './rpc/clients/memoryClient'
 import { IronfishRpcClient } from './rpc/clients/rpcClient'
@@ -231,17 +232,28 @@ export class IronfishSdk {
         namespaces.push(ApiNamespace.account, ApiNamespace.config)
       }
 
-      await node.rpc.mount(
-        new IpcAdapter(
-          namespaces,
-          {
-            mode: 'tcp',
-            host: this.config.get('rpcTcpHost'),
-            port: this.config.get('rpcTcpPort'),
-          },
-          this.logger,
-        ),
-      )
+      if (this.config.get('enableNativeRpcTcpAdapter')) {
+        await node.rpc.mount(
+          new TcpAdapter(
+            this.config.get('rpcTcpHost'),
+            this.config.get('rpcTcpPort'),
+            this.logger,
+            namespaces,
+          ),
+        )
+      } else {
+        await node.rpc.mount(
+          new IpcAdapter(
+            namespaces,
+            {
+              mode: 'tcp',
+              host: this.config.get('rpcTcpHost'),
+              port: this.config.get('rpcTcpPort'),
+            },
+            this.logger,
+          ),
+        )
+      }
     }
 
     return node


### PR DESCRIPTION
## Summary
The node module `node-ipc` is a simple wrapper around native node `net` code. It's possible to replace this library with native TCP sockets from the `net`  lib. This PR is to replace the `node-ipc` server functionality but still expects requests to be formatted as if they are from `node-ipc` clients. Later we will replace the `node-ipc` client as well

## Testing Plan
Existing testing suite

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
