### PR TITLE
Shrink the size of the peer list messages

### DIFF
--- a/ironfish/src/network/messages/peerList.test.ts
+++ b/ironfish/src/network/messages/peerList.test.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { identityLength } from '../identity'
 import { PeerListMessage } from './peerList'
 
 describe('PeerListMessage', () => {
@@ -8,13 +9,13 @@ describe('PeerListMessage', () => {
     const message = new PeerListMessage([
       {
         address: 'address',
-        identity: 'identity',
+        identity: Buffer.alloc(identityLength, 123),
         port: 9033,
         name: 'name',
       },
       {
         address: null,
-        identity: 'identity',
+        identity: Buffer.alloc(identityLength, 456),
         port: null,
       },
     ])

--- a/ironfish/src/network/messages/peerListRequest.ts
+++ b/ironfish/src/network/messages/peerListRequest.ts
@@ -9,7 +9,7 @@ export class PeerListRequestMessage extends NetworkMessage {
   }
 
   serialize(): Buffer {
-    return Buffer.from('')
+    return Buffer.alloc(0)
   }
 
   static deserialize(): PeerListRequestMessage {

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -1351,7 +1351,7 @@ describe('PeerManager', () => {
       const peerListRequest = new PeerListRequestMessage()
       const peerList = new PeerListMessage([
         {
-          identity: peer.getIdentityOrThrow(),
+          identity: Buffer.from(peer.getIdentityOrThrow(), 'base64'),
           address: peer.address,
           port: peer.port,
         },
@@ -1377,7 +1377,7 @@ describe('PeerManager', () => {
 
       const peerList = new PeerListMessage([
         {
-          identity: privateIdentityToIdentity(localIdentity),
+          identity: Buffer.from(privateIdentityToIdentity(localIdentity), 'base64'),
           address: peer.address,
           port: peer.port,
         },
@@ -1400,7 +1400,7 @@ describe('PeerManager', () => {
 
       const peerList = new PeerListMessage([
         {
-          identity: newPeerIdentity,
+          identity: Buffer.from(newPeerIdentity),
           address: peer.address,
           port: peer.port,
         },
@@ -1429,7 +1429,7 @@ describe('PeerManager', () => {
 
       const peerList = new PeerListMessage([
         {
-          identity: newPeerIdentity,
+          identity: Buffer.from(newPeerIdentity, 'base64'),
           address: peer.address,
           port: peer.port,
         },
@@ -1474,7 +1474,7 @@ describe('PeerManager', () => {
 
       const peerList = new PeerListMessage([
         {
-          identity: newPeerIdentity,
+          identity: Buffer.from(newPeerIdentity, 'base64'),
           address: peer.address,
           port: peer.port,
         },

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -1439,7 +1439,7 @@ export class PeerManager {
       }
 
       connectedPeers.push({
-        identity: p.state.identity,
+        identity: Buffer.from(p.state.identity, 'base64'),
         name: p.name || undefined,
         address: p.address,
         port: p.port,
@@ -1460,7 +1460,11 @@ export class PeerManager {
 
     const newPeerSet = peerList.connectedPeers.reduce(
       (memo, peer) => {
-        memo.set(peer.identity, peer)
+        const newPeer = {
+          ...peer,
+          identity: peer.identity.toString('base64'),
+        }
+        memo.set(newPeer.identity, newPeer)
         return memo
       },
       new Map<

--- a/ironfish/src/typedefs/bufio.d.ts
+++ b/ironfish/src/typedefs/bufio.d.ts
@@ -8,8 +8,10 @@ declare module 'bufio' {
     writeDouble(value: number): StaticWriter
     writeDoubleBE(value: number): StaticWriter
     writeU8(value: number): StaticWriter
+    writeU16(value: number): StaticWriter
     writeU64(value: number): StaticWriter
     writeI64(value: number): StaticWriter
+    writeString(value: string, enc?: BufferEncoding | null): StaticWriter
     writeVarString(value: string, enc?: BufferEncoding | null): StaticWriter
     writeVarBytes(value: Buffer): StaticWriter
     writeBytes(value: Buffer): StaticWriter
@@ -23,8 +25,10 @@ declare module 'bufio' {
     writeDouble(value: number): BufferWriter
     writeDoubleBE(value: number): BufferWriter
     writeU8(value: number): BufferWriter
+    writeU16(value: number): BufferWriter
     writeU64(value: number): BufferWriter
     writeI64(value: number): BufferWriter
+    writeString(value: string, enc?: BufferEncoding | null): BufferWriter
     writeVarString(value: string, enc?: BufferEncoding | null): BufferWriter
     writeVarBytes(value: Buffer): BufferWriter
     writeBytes(value: Buffer): BufferWriter
@@ -35,6 +39,7 @@ declare module 'bufio' {
   class BufferReader {
     left(): number
     readU8(): number
+    readU16(): number
     readU64(): number
     readU64BE(): number
     readFloat(): number
@@ -42,9 +47,10 @@ declare module 'bufio' {
     readDoubleBE(): number
     readI64(): number
     readDouble(): number
+    readBytes(size: number, zeroCopy?: boolean): Buffer
+    readString(size: number, enc?: BufferEncoding | null): string
     readVarString(enc?: BufferEncoding | null, limit?: number): string
     readVarBytes(): Buffer
-    readBytes(size: number, zeroCopy?: boolean): Buffer
 
     readHash(enc: BufferEncoding): string
     readHash(enc?: null): Buffer


### PR DESCRIPTION
## Summary

Saves a few bytes when encoding the identities in the peer list, plus a couple extra for the sizes of certain things.

## Testing Plan

Tests should pass, and will sync two nodes to each other in the serialize-networking branch before merging.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
