### PR TITLE
Remove server from memory adapter

### DIFF
--- a/ironfish/src/rpc/adapters/memoryAdapter.ts
+++ b/ironfish/src/rpc/adapters/memoryAdapter.ts
@@ -19,7 +19,6 @@ import { ResponseError } from './errors'
  * This is useful any time you want to make requests without hitting an IO layer.
  */
 export class MemoryAdapter implements IAdapter {
-  server: RpcServer | null = null
   router: Router | null = null
 
   start(): Promise<void> {
@@ -31,12 +30,10 @@ export class MemoryAdapter implements IAdapter {
   }
 
   attach(server: RpcServer): void {
-    this.server = server
     this.router = server.getRouter(ALL_API_NAMESPACES)
   }
 
   unattach(): void {
-    this.server = null
     this.router = null
   }
 
@@ -58,10 +55,8 @@ export class MemoryAdapter implements IAdapter {
     data?: unknown,
   ): MemoryResponse<TEnd, TStream> {
     const router = this.router
-    const server = this.server
 
     Assert.isNotNull(router)
-    Assert.isNotNull(server)
 
     const [promise, resolve, reject] = PromiseUtils.split<TEnd>()
     const stream = new Stream<TStream>()


### PR DESCRIPTION
## Summary
Removing an unused field `server` from the `memoryAdapter`. None of the other adapters use server either, just `server.router`

## Testing Plan
Existing tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
