### PR TITLE
Reduce size of the signal and signalRequest messages

### DIFF
--- a/ironfish/src/network/messages/signal.test.ts
+++ b/ironfish/src/network/messages/signal.test.ts
@@ -1,15 +1,16 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { nonceLength } from '../peers/encryption'
 import { SignalMessage } from './signal'
 
 describe('SignalMessage', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
     const message = new SignalMessage({
-      destinationIdentity: 'destination',
-      sourceIdentity: 'source',
-      nonce: 'nonce',
-      signal: 'signal',
+      destinationIdentity: '7stEY4c02HipHyFKrSTY6Cd8ob8SP1uJGAIuvK2EJwA=',
+      sourceIdentity: '6stEY4c02HipHyFKrSTY6Cd8ob8SP1uJGAIuvK2EJwA=',
+      nonce: Buffer.alloc(nonceLength, 1).toString('base64'),
+      signal: Buffer.from('signal', 'utf8').toString('base64'),
     })
 
     const buffer = message.serialize()

--- a/ironfish/src/network/messages/signal.ts
+++ b/ironfish/src/network/messages/signal.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
-import { Identity } from '../identity'
+import { Identity, identityLength } from '../identity'
+import { nonceLength } from '../peers/encryption'
 import { NetworkMessage, NetworkMessageType } from './networkMessage'
 
 interface CreateSignalMessageOptions {
@@ -40,19 +41,19 @@ export class SignalMessage extends NetworkMessage {
 
   serialize(): Buffer {
     const bw = bufio.write(this.getSize())
-    bw.writeVarString(this.destinationIdentity)
-    bw.writeVarString(this.sourceIdentity)
-    bw.writeVarString(this.nonce)
-    bw.writeVarString(this.signal)
+    bw.writeBytes(Buffer.from(this.destinationIdentity, 'base64'))
+    bw.writeBytes(Buffer.from(this.sourceIdentity, 'base64'))
+    bw.writeBytes(Buffer.from(this.nonce, 'base64'))
+    bw.writeBytes(Buffer.from(this.signal, 'base64'))
     return bw.render()
   }
 
   static deserialize(buffer: Buffer): SignalMessage {
     const reader = bufio.read(buffer, true)
-    const destinationIdentity = reader.readVarString()
-    const sourceIdentity = reader.readVarString()
-    const nonce = reader.readVarString()
-    const signal = reader.readVarString()
+    const destinationIdentity = reader.readBytes(identityLength).toString('base64')
+    const sourceIdentity = reader.readBytes(identityLength).toString('base64')
+    const nonce = reader.readBytes(nonceLength).toString('base64')
+    const signal = reader.readBytes(reader.left()).toString('base64')
     return new SignalMessage({
       destinationIdentity,
       sourceIdentity,
@@ -63,10 +64,7 @@ export class SignalMessage extends NetworkMessage {
 
   getSize(): number {
     return (
-      bufio.sizeVarString(this.destinationIdentity) +
-      bufio.sizeVarString(this.sourceIdentity) +
-      bufio.sizeVarString(this.nonce) +
-      bufio.sizeVarString(this.signal)
+      identityLength + identityLength + nonceLength + Buffer.byteLength(this.signal, 'base64')
     )
   }
 }

--- a/ironfish/src/network/messages/signalRequest.test.ts
+++ b/ironfish/src/network/messages/signalRequest.test.ts
@@ -6,8 +6,8 @@ import { SignalRequestMessage } from './signalRequest'
 describe('SignalRequestMessage', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
     const message = new SignalRequestMessage({
-      destinationIdentity: 'destination',
-      sourceIdentity: 'source',
+      destinationIdentity: '7stEY4c02HipHyFKrSTY6Cd8ob8SP1uJGAIuvK2EJwA=',
+      sourceIdentity: '6stEY4c02HipHyFKrSTY6Cd8ob8SP1uJGAIuvK2EJwA=',
     })
 
     const buffer = message.serialize()

--- a/ironfish/src/network/messages/signalRequest.ts
+++ b/ironfish/src/network/messages/signalRequest.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
-import { Identity } from '../identity'
+import { Identity, identityLength } from '../identity'
 import { NetworkMessage, NetworkMessageType } from './networkMessage'
 
 interface CreateSignalRequestMessageOptions {
@@ -28,15 +28,15 @@ export class SignalRequestMessage extends NetworkMessage {
 
   serialize(): Buffer {
     const bw = bufio.write(this.getSize())
-    bw.writeVarString(this.destinationIdentity)
-    bw.writeVarString(this.sourceIdentity)
+    bw.writeBytes(Buffer.from(this.destinationIdentity, 'base64'))
+    bw.writeBytes(Buffer.from(this.sourceIdentity, 'base64'))
     return bw.render()
   }
 
   static deserialize(buffer: Buffer): SignalRequestMessage {
     const reader = bufio.read(buffer, true)
-    const destinationIdentity = reader.readVarString()
-    const sourceIdentity = reader.readVarString()
+    const destinationIdentity = reader.readBytes(identityLength).toString('base64')
+    const sourceIdentity = reader.readBytes(identityLength).toString('base64')
     return new SignalRequestMessage({
       destinationIdentity,
       sourceIdentity,
@@ -44,8 +44,6 @@ export class SignalRequestMessage extends NetworkMessage {
   }
 
   getSize(): number {
-    return (
-      bufio.sizeVarString(this.destinationIdentity) + bufio.sizeVarString(this.sourceIdentity)
-    )
+    return identityLength * 2
   }
 }


### PR DESCRIPTION
## Summary

Reduces the size of the signal and signalRequest messages.

## Testing Plan

Tests should pass, and will retest two nodes connecting in the serialize-networking branch.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
