### PR TITLE
Shrink disconnecting message

### DIFF
--- a/ironfish/src/network/messages/cannotSatisfyRequest.ts
+++ b/ironfish/src/network/messages/cannotSatisfyRequest.ts
@@ -10,7 +10,7 @@ export class CannotSatisfyRequest extends RpcNetworkMessage {
   }
 
   serialize(): Buffer {
-    return Buffer.from('')
+    return Buffer.alloc(0)
   }
 
   static deserialize(rpcId: number): CannotSatisfyRequest {

--- a/ironfish/src/network/messages/disconnecting.test.ts
+++ b/ironfish/src/network/messages/disconnecting.test.ts
@@ -1,19 +1,33 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { identityLength } from '../identity'
 import { DisconnectingMessage, DisconnectingReason } from './disconnecting'
 
 describe('DisconnectingMessage', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
     const message = new DisconnectingMessage({
       destinationIdentity: null,
-      disconnectUntil: 123,
+      disconnectUntil: 1000,
       reason: DisconnectingReason.Congested,
-      sourceIdentity: 'source',
+      sourceIdentity: Buffer.alloc(identityLength, 123).toString('base64'),
     })
 
     const buffer = message.serialize()
     const deserializedMessage = DisconnectingMessage.deserialize(buffer)
     expect(deserializedMessage).toEqual(message)
+  })
+
+  it('converts millisecond precision to second precision when serializing the message', () => {
+    const message = new DisconnectingMessage({
+      destinationIdentity: null,
+      disconnectUntil: 1649968932977,
+      reason: DisconnectingReason.Congested,
+      sourceIdentity: Buffer.alloc(identityLength, 123).toString('base64'),
+    })
+
+    const buffer = message.serialize()
+    const deserializedMessage = DisconnectingMessage.deserialize(buffer)
+    expect(deserializedMessage.disconnectUntil).toEqual(1649968933000)
   })
 })

--- a/ironfish/src/typedefs/bufio.d.ts
+++ b/ironfish/src/typedefs/bufio.d.ts
@@ -9,6 +9,7 @@ declare module 'bufio' {
     writeDoubleBE(value: number): StaticWriter
     writeU8(value: number): StaticWriter
     writeU16(value: number): StaticWriter
+    writeU32(value: number): BufferWriter
     writeU64(value: number): StaticWriter
     writeI64(value: number): StaticWriter
     writeString(value: string, enc?: BufferEncoding | null): StaticWriter
@@ -26,6 +27,7 @@ declare module 'bufio' {
     writeDoubleBE(value: number): BufferWriter
     writeU8(value: number): BufferWriter
     writeU16(value: number): BufferWriter
+    writeU32(value: number): BufferWriter
     writeU64(value: number): BufferWriter
     writeI64(value: number): BufferWriter
     writeString(value: string, enc?: BufferEncoding | null): BufferWriter
@@ -40,6 +42,7 @@ declare module 'bufio' {
     left(): number
     readU8(): number
     readU16(): number
+    readU32(): number
     readU64(): number
     readU64BE(): number
     readFloat(): number


### PR DESCRIPTION
## Summary

Reduces the size of the disconnecting message. Rounds the disconnect timestamp to seconds and puts it in a u32 instead of a u64.

## Testing Plan

Tests should pass, and will test the serialize-networking branch again before opening that PR.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
