### PR TITLE
Reduce coverage requirements down

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,20 +12,20 @@ coverage:
     patch:
       default:
         target: auto
-        threshold: 50%
+        threshold: 0%
     project:
       default:
-        target: 63%
+        target: 10%
       ironfish-rust:
-        target: 53%
+        target: 10%
         flags:
           - ironfish-rust
       ironfish-cli:
-        target: 50%
+        target: 10%
         flags:
           - ironfish-cli
       ironfish:
-        target: 60%
+        target: 10%
         flags:
           - ironfish
       event:


### PR DESCRIPTION
## Summary

We are reducing converage requirements down until large refactoring
projects are complete. We will increase this before main net launch and
find the correct target and improve our code coverage.

We'll most likely also refactor our testing infrastructure, like how we
handle fixtures.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
