### PR TITLE
Remove unused status code in Request

### DIFF
--- a/ironfish/src/rpc/request.ts
+++ b/ironfish/src/rpc/request.ts
@@ -8,7 +8,6 @@ export class Request<TRequest = unknown, TResponse = unknown> {
   data: TRequest
   ended = false
   closed = false
-  code: number | null = null
   onEnd: (status: number, data?: TResponse) => void
   onStream: (data?: TResponse) => void
   onClose = new Event<[]>()
@@ -23,11 +22,6 @@ export class Request<TRequest = unknown, TResponse = unknown> {
     this.onStream = onStream
   }
 
-  status(code: number): Request<TRequest, TResponse> {
-    this.code = code
-    return this
-  }
-
   end(data?: TResponse, status?: number): void {
     if (this.ended) {
       throw new Error(`Request has already ended`)
@@ -37,7 +31,7 @@ export class Request<TRequest = unknown, TResponse = unknown> {
       return
     }
     this.onClose.clear()
-    this.onEnd(status || this.code || 200, data)
+    this.onEnd(status || 200, data)
   }
 
   stream(data: TResponse): void {

--- a/ironfish/src/rpc/routes/chain/getBlockInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getBlockInfo.ts
@@ -140,7 +140,7 @@ router.register<typeof GetBlockInfoRequestSchema, GetBlockInfoResponse>(
 
     const main = await node.chain.isHeadChain(header)
 
-    request.status(200).end({
+    request.end({
       block: {
         graffiti: header.graffiti.toString('hex'),
         difficulty: header.target.toDifficulty().toString(),


### PR DESCRIPTION
## Summary
The function `Request.end(data?: TResponse, status?: number)` is taking a status parameter but it is not being used anywhere currently. Every call is just relying on the default 200 status. I'm thinking we should remove this for now unless it starts to be used somewhere


## Testing Plan
Current testing suite

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
