### PR TITLE
Close TCP server on tcpAdapter stop()

### DIFF
--- a/ironfish/src/rpc/adapters/tcpAdapter.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.ts
@@ -89,7 +89,15 @@ export class TcpAdapter implements IAdapter {
       })
       sock.destroy()
     })
-    return Promise.resolve()
+    return new Promise((resolve, reject) => {
+      this.server?.close((error) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve()
+        }
+      })
+    })
   }
 
   attach(server: RpcServer): void {


### PR DESCRIPTION
## Summary
This should have gone in with https://github.com/iron-fish/ironfish/pull/1214. Making sure to clean up the TCP server once the adapter is stopped

## Testing Plan
Current testing suite

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
