### PR TITLE
Shrink newBlock and change nonce

### DIFF
--- a/ironfish/src/network/messages/getBlocks.ts
+++ b/ironfish/src/network/messages/getBlocks.ts
@@ -3,8 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
 import { SerializedBlock } from '../../primitives/block'
-import { GraffitiSerdeInstance } from '../../serde'
-import { BigIntUtils } from '../../utils/bigint'
+import { getBlockSize, readBlock, writeBlock } from '../utils/block'
 import { NetworkMessageType } from './networkMessage'
 import { Direction, RpcNetworkMessage } from './rpcNetworkMessage'
 
@@ -54,22 +53,7 @@ export class GetBlocksResponse extends RpcNetworkMessage {
     bw.writeU16(this.blocks.length)
 
     for (const block of this.blocks) {
-      bw.writeU32(block.header.sequence)
-      bw.writeHash(block.header.previousBlockHash)
-      bw.writeHash(block.header.noteCommitment.commitment)
-      bw.writeU32(block.header.noteCommitment.size)
-      bw.writeHash(block.header.nullifierCommitment.commitment)
-      bw.writeU32(block.header.nullifierCommitment.size)
-      bw.writeBytes(BigIntUtils.toBytesLE(BigInt(block.header.target), 32))
-      bw.writeU64(block.header.randomness)
-      bw.writeU64(block.header.timestamp)
-      bw.writeBytes(BigIntUtils.toBytesLE(BigInt(block.header.minersFee), 8))
-      bw.writeBytes(GraffitiSerdeInstance.deserialize(block.header.graffiti))
-
-      bw.writeU16(block.transactions.length)
-      for (const transaction of block.transactions) {
-        bw.writeVarBytes(transaction)
-      }
+      writeBlock(bw, block)
     }
 
     return bw.render()
@@ -81,68 +65,21 @@ export class GetBlocksResponse extends RpcNetworkMessage {
 
     const blocksLength = reader.readU16()
     for (let i = 0; i < blocksLength; i++) {
-      const sequence = reader.readU32()
-      const previousBlockHash = reader.readHash('hex')
-      const noteCommitment = reader.readHash()
-      const noteCommitmentSize = reader.readU32()
-      const nullifierCommitment = reader.readHash('hex')
-      const nullifierCommitmentSize = reader.readU32()
-      const target = BigIntUtils.fromBytesLE(reader.readBytes(32)).toString()
-      const randomness = reader.readU64()
-      const timestamp = reader.readU64()
-      const minersFee = BigIntUtils.fromBytesLE(reader.readBytes(8)).toString()
-      const graffiti = GraffitiSerdeInstance.serialize(reader.readBytes(32))
-
-      const transactionsLength = reader.readU16()
-      const transactions = []
-      for (let j = 0; j < transactionsLength; j++) {
-        transactions.push(reader.readVarBytes())
-      }
-      blocks.push({
-        header: {
-          sequence,
-          previousBlockHash,
-          noteCommitment: {
-            commitment: noteCommitment,
-            size: noteCommitmentSize,
-          },
-          nullifierCommitment: {
-            commitment: nullifierCommitment,
-            size: nullifierCommitmentSize,
-          },
-          target,
-          randomness,
-          timestamp,
-          minersFee,
-          graffiti,
-        },
-        transactions,
-      })
+      const block = readBlock(reader)
+      blocks.push(block)
     }
+
     return new GetBlocksResponse(blocks, rpcId)
   }
 
   getSize(): number {
     let size = 0
     size += 2 // blocks length
-    for (const block of this.blocks) {
-      size += 4 // sequence
-      size += 32 // previousBlockHash
-      size += 32 // noteCommitment.commitment
-      size += 4 // noteCommitment.size
-      size += 32 // nullifierCommitment.commitment
-      size += 4 // nullifierCommitment.size
-      size += 32 // target
-      size += 8 // randomness
-      size += 8 // timestamp
-      size += 8 // minersFee
-      size += 32 // graffiti
 
-      size += 2 // transactions length
-      for (const transaction of block.transactions) {
-        size += bufio.sizeVarBytes(transaction)
-      }
+    for (const block of this.blocks) {
+      size += getBlockSize(block)
     }
+
     return size
   }
 }

--- a/ironfish/src/network/messages/interfaces/networkMessageHeader.ts
+++ b/ironfish/src/network/messages/interfaces/networkMessageHeader.ts
@@ -7,5 +7,5 @@ export interface NetworkMessageHeader {
   body: Buffer
   type: NetworkMessageType
   rpcId?: number
-  nonce?: string
+  nonce?: Buffer
 }

--- a/ironfish/src/network/messages/newBlock.test.ts
+++ b/ironfish/src/network/messages/newBlock.test.ts
@@ -1,31 +1,30 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { SerializedBlock } from '../../primitives/block'
 import { NewBlockMessage } from './newBlock'
 
 describe('NewBlocksMessage', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
-    const nonce = 'nonce'
+    const nonce = Buffer.alloc(16, 2)
     const message = new NewBlockMessage(
       {
         header: {
-          graffiti: 'chipotle',
+          graffiti: Buffer.alloc(32, 'graffiti1', 'utf8').toString('hex'),
           minersFee: '0',
           noteCommitment: {
-            commitment: Buffer.from('commitment'),
+            commitment: Buffer.alloc(32, 1),
             size: 1,
           },
           nullifierCommitment: {
-            commitment: 'commitment',
+            commitment: Buffer.alloc(32, 2).toString('hex'),
             size: 2,
           },
-          previousBlockHash: 'burrito',
+          previousBlockHash: Buffer.alloc(32, 2).toString('hex'),
           randomness: 1,
           sequence: 2,
-          target: 'icecream',
+          target: '12',
           timestamp: 200000,
-          work: '123',
-          hash: 'ramen',
         },
         transactions: [Buffer.from('foo'), Buffer.from('bar'), Buffer.from('baz')],
       },
@@ -34,5 +33,40 @@ describe('NewBlocksMessage', () => {
     const buffer = message.serialize()
     const deserializedMessage = NewBlockMessage.deserialize(buffer, nonce)
     expect(deserializedMessage).toEqual(message)
+  })
+
+  it('strips optional work and hash fields when serializing', () => {
+    const nonce = Buffer.alloc(16, 3)
+    const serializedBlock: SerializedBlock = {
+      header: {
+        graffiti: Buffer.alloc(32, 'graffiti1', 'utf8').toString('hex'),
+        minersFee: '0',
+        noteCommitment: {
+          commitment: Buffer.alloc(32, 4),
+          size: 1,
+        },
+        nullifierCommitment: {
+          commitment: Buffer.alloc(32, 6).toString('hex'),
+          size: 2,
+        },
+        previousBlockHash: Buffer.alloc(32, 2).toString('hex'),
+        randomness: 1,
+        sequence: 2,
+        target: '12',
+        timestamp: 200000,
+        work: '123',
+        hash: 'ramen',
+      },
+      transactions: [Buffer.from('foo'), Buffer.from('bar'), Buffer.from('baz')],
+    }
+
+    const message = new NewBlockMessage(serializedBlock, nonce)
+    const buffer = message.serialize()
+    const deserializedMessage = NewBlockMessage.deserialize(buffer, nonce)
+
+    delete serializedBlock.header.hash
+    delete serializedBlock.header.work
+
+    expect(deserializedMessage.block).toEqual(serializedBlock)
   })
 })

--- a/ironfish/src/network/messages/newBlock.ts
+++ b/ironfish/src/network/messages/newBlock.ts
@@ -3,135 +3,34 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
 import { SerializedBlock } from '../../primitives/block'
+import { getBlockSize, readBlock, writeBlock } from '../utils/block'
 import { GossipNetworkMessage } from './gossipNetworkMessage'
 import { NetworkMessageType } from './networkMessage'
 
 export class NewBlockMessage extends GossipNetworkMessage {
   readonly block: SerializedBlock
 
-  constructor(block: SerializedBlock, nonce: string) {
+  constructor(block: SerializedBlock, nonce?: Buffer) {
     super(NetworkMessageType.NewBlock, nonce)
     this.block = block
   }
 
   serialize(): Buffer {
     const bw = bufio.write(this.getSize())
-    const { header, transactions } = this.block
-    bw.writeU64(header.sequence)
-    bw.writeVarString(header.previousBlockHash)
-    bw.writeVarBytes(header.noteCommitment.commitment)
-    bw.writeU64(header.noteCommitment.size)
-    bw.writeVarString(header.nullifierCommitment.commitment)
-    bw.writeU64(header.nullifierCommitment.size)
-    bw.writeVarString(header.target)
-    bw.writeU64(header.randomness)
-    bw.writeU64(header.timestamp)
-    bw.writeVarString(header.minersFee)
-    if (header.work) {
-      bw.writeU8(1)
-      bw.writeVarString(header.work)
-    } else {
-      bw.writeU8(0)
-    }
-    bw.writeVarString(header.graffiti)
-    if (header.hash) {
-      bw.writeU8(1)
-      bw.writeVarString(header.hash)
-    } else {
-      bw.writeU8(0)
-    }
 
-    bw.writeU64(transactions.length)
-    for (const transaction of transactions) {
-      bw.writeVarBytes(transaction)
-    }
+    writeBlock(bw, this.block)
+
     return bw.render()
   }
 
-  static deserialize(buffer: Buffer, nonce: string): NewBlockMessage {
+  static deserialize(buffer: Buffer, nonce: Buffer): NewBlockMessage {
     const reader = bufio.read(buffer, true)
-    const sequence = reader.readU64()
-    const previousBlockHash = reader.readVarString()
-    const noteCommitment = reader.readVarBytes()
-    const noteCommitmentSize = reader.readU64()
-    const nullifierCommitment = reader.readVarString()
-    const nullifierCommitmentSize = reader.readU64()
-    const target = reader.readVarString()
-    const randomness = reader.readU64()
-    const timestamp = reader.readU64()
-    const minersFee = reader.readVarString()
+    const block = readBlock(reader)
 
-    const workFlag = reader.readU8()
-    let work
-    if (workFlag === 1) {
-      work = reader.readVarString()
-    }
-
-    const graffiti = reader.readVarString()
-    const flag = reader.readU8()
-    let hash
-    if (flag) {
-      hash = reader.readVarString()
-    }
-
-    const transactionsLength = reader.readU64()
-    const transactions = []
-    for (let j = 0; j < transactionsLength; j++) {
-      transactions.push(reader.readVarBytes())
-    }
-    return new NewBlockMessage(
-      {
-        header: {
-          sequence,
-          previousBlockHash,
-          noteCommitment: {
-            commitment: noteCommitment,
-            size: noteCommitmentSize,
-          },
-          nullifierCommitment: {
-            commitment: nullifierCommitment,
-            size: nullifierCommitmentSize,
-          },
-          target,
-          randomness,
-          timestamp,
-          minersFee,
-          work,
-          graffiti,
-          hash,
-        },
-        transactions,
-      },
-      nonce,
-    )
+    return new NewBlockMessage(block, nonce)
   }
 
   getSize(): number {
-    const { header, transactions } = this.block
-    let size = 8
-    size += bufio.sizeVarString(header.previousBlockHash)
-    size += bufio.sizeVarBytes(header.noteCommitment.commitment)
-    size += 8
-    size += bufio.sizeVarString(header.nullifierCommitment.commitment)
-    size += 8
-    size += bufio.sizeVarString(header.target)
-    size += 8
-    size += 8
-    size += bufio.sizeVarString(header.minersFee)
-    size += 1
-    if (header.work) {
-      size += bufio.sizeVarString(header.work)
-    }
-    size += bufio.sizeVarString(header.graffiti)
-    size += 1
-    if (header.hash) {
-      size += bufio.sizeVarString(header.hash)
-    }
-
-    size += 8
-    for (const transaction of transactions) {
-      size += bufio.sizeVarBytes(transaction)
-    }
-    return size
+    return getBlockSize(this.block)
   }
 }

--- a/ironfish/src/network/messages/newTransaction.test.ts
+++ b/ironfish/src/network/messages/newTransaction.test.ts
@@ -5,7 +5,7 @@ import { NewTransactionMessage } from './newTransaction'
 
 describe('NewTransaction', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
-    const nonce = 'nonce'
+    const nonce = Buffer.alloc(16, 1)
     const message = new NewTransactionMessage(Buffer.from('asdf'), nonce)
     const deserializedMessage = NewTransactionMessage.deserialize(message.serialize(), nonce)
     expect(deserializedMessage).toEqual(message)

--- a/ironfish/src/network/messages/newTransaction.ts
+++ b/ironfish/src/network/messages/newTransaction.ts
@@ -9,7 +9,7 @@ import { NetworkMessageType } from './networkMessage'
 export class NewTransactionMessage extends GossipNetworkMessage {
   readonly transaction: SerializedTransaction
 
-  constructor(transaction: SerializedTransaction, nonce: string) {
+  constructor(transaction: SerializedTransaction, nonce?: Buffer) {
     super(NetworkMessageType.NewTransaction, nonce)
     this.transaction = transaction
   }
@@ -20,7 +20,7 @@ export class NewTransactionMessage extends GossipNetworkMessage {
     return bw.render()
   }
 
-  static deserialize(buffer: Buffer, nonce: string): NewTransactionMessage {
+  static deserialize(buffer: Buffer, nonce: Buffer): NewTransactionMessage {
     const reader = bufio.read(buffer, true)
     const transaction = reader.readVarBytes()
     return new NewTransactionMessage(transaction, nonce)

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -183,7 +183,10 @@ describe('PeerNetwork', () => {
         },
         transactions: [],
       }
-      await peerNetwork['handleGossipMessage'](peer, new NewBlockMessage(block, 'nonce'))
+      await peerNetwork['handleGossipMessage'](
+        peer,
+        new NewBlockMessage(block, Buffer.alloc(16, 'nonce')),
+      )
 
       expect(peerNetwork['node']['syncer'].addNewBlock).toHaveBeenCalledWith(peer, block)
     })
@@ -213,7 +216,7 @@ describe('PeerNetwork', () => {
 
         await peerNetwork['onNewTransaction']({
           peerIdentity: '',
-          message: new NewTransactionMessage(Buffer.from(''), 'nonce'),
+          message: new NewTransactionMessage(Buffer.from(''), Buffer.alloc(16, 'nonce')),
         })
 
         expect(acceptTransaction).not.toHaveBeenCalled()
@@ -250,7 +253,7 @@ describe('PeerNetwork', () => {
 
         await peerNetwork['onNewTransaction']({
           peerIdentity: '',
-          message: new NewTransactionMessage(Buffer.from(''), 'nonce'),
+          message: new NewTransactionMessage(Buffer.from(''), Buffer.alloc(16, 'nonce')),
         })
 
         expect(acceptTransaction).not.toHaveBeenCalled()
@@ -289,7 +292,7 @@ describe('PeerNetwork', () => {
 
         await peerNetwork['onNewTransaction']({
           peerIdentity: '',
-          message: new NewTransactionMessage(Buffer.from(''), 'nonce'),
+          message: new NewTransactionMessage(Buffer.from(''), Buffer.alloc(16, 'nonce')),
         })
 
         expect(verifyNewTransactionSpy).toHaveBeenCalled()
@@ -336,7 +339,7 @@ describe('PeerNetwork', () => {
       const peerIdentity = peer.getIdentityOrThrow()
       const gossip = await peerNetwork['onNewBlock']({
         peerIdentity,
-        message: new NewBlockMessage(block, 'nonce'),
+        message: new NewBlockMessage(block, Buffer.alloc(16, 'nonce')),
       })
       expect(gossip).toBe(false)
       expect(peerNetwork['node']['syncer'].addNewBlock).not.toHaveBeenCalled()
@@ -358,7 +361,7 @@ describe('PeerNetwork', () => {
       const peerIdentity = peer.getIdentityOrThrow()
       const gossip = await peerNetwork['onNewTransaction']({
         peerIdentity,
-        message: new NewTransactionMessage(Buffer.from(''), 'nonce'),
+        message: new NewTransactionMessage(Buffer.from(''), Buffer.alloc(16, 'nonce')),
       })
       expect(gossip).toBe(false)
       expect(peerNetwork['chain']['verifier'].verifyNewTransaction).not.toHaveBeenCalled()

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -4,7 +4,6 @@
 
 import { RollingFilter } from 'bfilter'
 import tweetnacl from 'tweetnacl'
-import { v4 as uuid } from 'uuid'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { MAX_REQUESTED_BLOCKS } from '../consensus'
@@ -183,14 +182,14 @@ export class PeerNetwork {
     this.node.accounts.onBroadcastTransaction.on((transaction) => {
       const serializedTransaction = this.strategy.transactionSerde.serialize(transaction)
 
-      this.gossip(new NewTransactionMessage(serializedTransaction, uuid()))
+      this.gossip(new NewTransactionMessage(serializedTransaction))
     })
   }
 
   gossipBlock(block: Block): void {
     const serializedBlock = this.strategy.blockSerde.serialize(block)
 
-    this.gossip(new NewBlockMessage(serializedBlock, uuid()))
+    this.gossip(new NewBlockMessage(serializedBlock))
   }
 
   start(): void {
@@ -309,7 +308,7 @@ export class PeerNetwork {
    * receive the message.
    */
   gossip(message: GossipNetworkMessage): void {
-    this.seenGossipFilter.add(message.nonce, 'utf-8')
+    this.seenGossipFilter.add(message.nonce)
     this.peerManager.broadcast(message)
   }
 
@@ -441,7 +440,7 @@ export class PeerNetwork {
     peer: Peer,
     gossipMessage: GossipNetworkMessage,
   ): Promise<void> {
-    if (!this.seenGossipFilter.added(gossipMessage.nonce, 'utf-8')) {
+    if (!this.seenGossipFilter.added(gossipMessage.nonce)) {
       return
     }
 

--- a/ironfish/src/network/peers/connections/connection.ts
+++ b/ironfish/src/network/peers/connections/connection.ts
@@ -237,7 +237,7 @@ export abstract class Connection {
     if (this.isRpcNetworkMessageType(type)) {
       rpcId = br.readU64()
     } else if (this.isGossipNetworkMessageType(type)) {
-      nonce = br.readVarString()
+      nonce = br.readBytes(16)
     }
     return {
       type,

--- a/ironfish/src/network/utils/block.ts
+++ b/ironfish/src/network/utils/block.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { SerializedBlock } from '../../primitives/block'
+import { GraffitiSerdeInstance } from '../../serde/serdeInstances'
+import { BigIntUtils } from '../../utils/bigint'
+
+export function writeBlock(
+  bw: bufio.StaticWriter | bufio.BufferWriter,
+  block: SerializedBlock,
+): bufio.StaticWriter | bufio.BufferWriter {
+  const { header, transactions } = block
+
+  bw.writeU32(header.sequence)
+  bw.writeHash(header.previousBlockHash)
+  bw.writeHash(header.noteCommitment.commitment)
+  bw.writeU32(header.noteCommitment.size)
+  bw.writeHash(header.nullifierCommitment.commitment)
+  bw.writeU32(header.nullifierCommitment.size)
+  bw.writeBytes(BigIntUtils.toBytesLE(BigInt(header.target), 32))
+  bw.writeU64(header.randomness)
+  bw.writeU64(header.timestamp)
+  bw.writeBytes(BigIntUtils.toBytesLE(BigInt(header.minersFee), 8))
+  bw.writeBytes(GraffitiSerdeInstance.deserialize(header.graffiti))
+
+  bw.writeU16(transactions.length)
+  for (const transaction of transactions) {
+    bw.writeVarBytes(transaction)
+  }
+
+  return bw
+}
+
+export function readBlock(reader: bufio.BufferReader): SerializedBlock {
+  const sequence = reader.readU32()
+  const previousBlockHash = reader.readHash('hex')
+  const noteCommitment = reader.readHash()
+  const noteCommitmentSize = reader.readU32()
+  const nullifierCommitment = reader.readHash('hex')
+  const nullifierCommitmentSize = reader.readU32()
+  const target = BigIntUtils.fromBytesLE(reader.readBytes(32)).toString()
+  const randomness = reader.readU64()
+  const timestamp = reader.readU64()
+  const minersFee = BigIntUtils.fromBytesLE(reader.readBytes(8)).toString()
+  const graffiti = GraffitiSerdeInstance.serialize(reader.readBytes(32))
+
+  const transactionsLength = reader.readU16()
+  const transactions = []
+  for (let j = 0; j < transactionsLength; j++) {
+    transactions.push(reader.readVarBytes())
+  }
+
+  return {
+    header: {
+      sequence,
+      previousBlockHash,
+      noteCommitment: {
+        commitment: noteCommitment,
+        size: noteCommitmentSize,
+      },
+      nullifierCommitment: {
+        commitment: nullifierCommitment,
+        size: nullifierCommitmentSize,
+      },
+      target,
+      randomness,
+      timestamp,
+      minersFee,
+      graffiti,
+    },
+    transactions,
+  }
+}
+
+export function getBlockSize(block: SerializedBlock): number {
+  let size = 0
+  size += 4 // sequence
+  size += 32 // previousBlockHash
+  size += 32 // noteCommitment.commitment
+  size += 4 // noteCommitment.size
+  size += 32 // nullifierCommitment.commitment
+  size += 4 // nullifierCommitment.size
+  size += 32 // target
+  size += 8 // randomness
+  size += 8 // timestamp
+  size += 8 // minersFee
+  size += 32 // graffiti
+
+  size += 2 // transactions length
+  for (const transaction of block.transactions) {
+    size += bufio.sizeVarBytes(transaction)
+  }
+  return size
+}


### PR DESCRIPTION
## Summary

Changes the NewBlock message to use the same serialization as GetBlocksResponse via a util (for now, this could be refactored), and changes nonce on gossip messages to use bytes directly rather than a variable string.

## Testing Plan

Tests should pass, and will manually test serialize-networking once all the changes are ready.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
