### PR TITLE
Shrink identify message

### DIFF
--- a/ironfish/src/network/messages/identify.test.ts
+++ b/ironfish/src/network/messages/identify.test.ts
@@ -1,19 +1,20 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { identityLength } from '../identity'
 import { IdentifyMessage } from './identify'
 
 describe('IdentifyMessage', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
     const message = new IdentifyMessage({
       agent: 'agent',
-      head: 'head',
-      identity: 'identity',
+      head: Buffer.alloc(32, 'head'),
+      identity: Buffer.alloc(identityLength, 'identity').toString('base64'),
       name: 'name',
       port: 9033,
       sequence: 1,
       version: 1,
-      work: '123',
+      work: BigInt('123'),
     })
 
     const buffer = message.serialize()

--- a/ironfish/src/network/messages/rpcNetworkMessage.ts
+++ b/ironfish/src/network/messages/rpcNetworkMessage.ts
@@ -21,14 +21,14 @@ export abstract class RpcNetworkMessage extends NetworkMessage {
   constructor(type: NetworkMessageType, direction: Direction, rpcId?: number) {
     super(type)
     this.direction = direction
-    this.rpcId = rpcId ?? RpcNetworkMessage.id++
+    this.rpcId = rpcId ?? (RpcNetworkMessage.id = ++RpcNetworkMessage.id % 0xffff)
   }
 
   serializeWithMetadata(): Buffer {
-    const headerSize = 9
+    const headerSize = 3
     const bw = bufio.write(headerSize + this.getSize())
     bw.writeU8(this.type)
-    bw.writeU64(this.rpcId)
+    bw.writeU16(this.rpcId)
     bw.writeBytes(this.serialize())
     return bw.render()
   }

--- a/ironfish/src/network/peers/connections/connection.test.ts
+++ b/ironfish/src/network/peers/connections/connection.test.ts
@@ -20,12 +20,12 @@ describe('Connection', () => {
         const connection = new WebRtcConnection(false, createRootLogger())
         const message = new IdentifyMessage({
           agent: '',
-          head: '',
+          head: Buffer.alloc(32, 0),
           identity: 'identity',
           port: 9033,
           sequence: 1,
           version: 0,
-          work: BigInt(0).toString(),
+          work: BigInt(0),
         })
         jest.spyOn(message, 'serialize').mockImplementationOnce(() => Buffer.from('adsf'))
 
@@ -39,12 +39,12 @@ describe('Connection', () => {
         const connection = new WebRtcConnection(false, createRootLogger())
         const message = new IdentifyMessage({
           agent: '',
-          head: '',
-          identity: 'identity',
+          head: Buffer.alloc(32, 0),
+          identity: Buffer.alloc(32, 'identity').toString('base64'),
           port: 9033,
           sequence: 1,
           version: 0,
-          work: BigInt(0).toString(),
+          work: BigInt(0),
         })
 
         expect(connection.parseMessage(message.serializeWithMetadata())).toEqual(message)

--- a/ironfish/src/network/peers/connections/connection.ts
+++ b/ironfish/src/network/peers/connections/connection.ts
@@ -235,7 +235,7 @@ export abstract class Connection {
     const br = bufio.read(message)
     const type = br.readU8()
     if (this.isRpcNetworkMessageType(type)) {
-      rpcId = br.readU64()
+      rpcId = br.readU16()
     } else if (this.isGossipNetworkMessageType(type)) {
       nonce = br.readVarString()
     }

--- a/ironfish/src/network/peers/connections/webRtcConnection.test.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.test.ts
@@ -13,12 +13,12 @@ describe('WebRtcConnection', () => {
         const connection = new WebRtcConnection(false, createRootLogger())
         const message = new IdentifyMessage({
           agent: '',
-          head: '',
+          head: Buffer.alloc(32, 0),
           identity: 'identity',
           port: 9033,
           sequence: 1,
           version: 0,
-          work: BigInt(0).toString(),
+          work: BigInt(0),
         })
         expect(connection.send(message)).toBe(false)
         connection.close()
@@ -36,12 +36,12 @@ describe('WebRtcConnection', () => {
           .mockImplementationOnce(jest.fn())
         const message = new IdentifyMessage({
           agent: '',
-          head: '',
-          identity: 'identity',
+          head: Buffer.alloc(32, 0),
+          identity: Buffer.alloc(32, 'identity').toString('base64'),
           port: 9033,
           sequence: 1,
           version: 0,
-          work: BigInt(0).toString(),
+          work: BigInt(0),
         })
 
         expect(connection.send(message)).toBe(true)

--- a/ironfish/src/network/peers/connections/webSocketConnection.test.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.test.ts
@@ -26,12 +26,12 @@ describe('WebSocketConnection', () => {
         const send = jest.spyOn(socket, 'send').mockImplementationOnce(jest.fn())
         const message = new IdentifyMessage({
           agent: '',
-          head: '',
-          identity: 'identity',
+          head: Buffer.alloc(32, 0),
+          identity: Buffer.alloc(32, 'identity').toString('base64'),
           port: 9033,
           sequence: 1,
           version: 0,
-          work: BigInt(0).toString(),
+          work: BigInt(0),
         })
 
         expect(connection.send(message)).toBe(true)

--- a/ironfish/src/network/peers/localPeer.test.ts
+++ b/ironfish/src/network/peers/localPeer.test.ts
@@ -14,7 +14,7 @@ describe('LocalPeer', () => {
         identity: peer.publicIdentity,
         sequence: Number(peer.chain.head.sequence),
         version: peer.version,
-        work: peer.chain.head.work.toString(),
+        work: peer.chain.head.work,
       })
     })
   })

--- a/ironfish/src/network/peers/localPeer.ts
+++ b/ironfish/src/network/peers/localPeer.ts
@@ -61,13 +61,13 @@ export class LocalPeer {
 
     return new IdentifyMessage({
       agent: this.agent,
-      head: this.chain.head.hash.toString('hex'),
+      head: this.chain.head.hash,
       identity: this.publicIdentity,
       name: this.name || undefined,
       port: this.port,
       sequence: Number(this.chain.head.sequence),
       version: this.version,
-      work: this.chain.head.work.toString(),
+      work: this.chain.head.work,
     })
   }
 

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -138,12 +138,12 @@ describe('PeerManager', () => {
     const identity = webRtcCannotInitiateIdentity()
     const message = new IdentifyMessage({
       agent: '',
-      head: '',
+      head: Buffer.alloc(32, 0),
       identity: identity,
       port: null,
       sequence: 1,
       version: VERSION_PROTOCOL,
-      work: BigInt(0).toString(),
+      work: BigInt(0),
     })
 
     // Identify peerOut
@@ -251,7 +251,7 @@ describe('PeerManager', () => {
       agent: pm.localPeer.agent,
       head: pm.localPeer.chain.head.hash,
       sequence: Number(pm.localPeer.chain.head.sequence),
-      work: pm.localPeer.chain.head.work.toString(),
+      work: pm.localPeer.chain.head.work,
     })
   })
 
@@ -720,12 +720,12 @@ describe('PeerManager', () => {
 
       const identify = new IdentifyMessage({
         agent: '',
-        head: '',
+        head: Buffer.alloc(32, 0),
         identity: other,
         port: peer.port,
         sequence: 1,
         version: VERSION_PROTOCOL,
-        work: BigInt(0).toString(),
+        work: BigInt(0),
       })
       peer.onMessage.emit(identify, connection)
 
@@ -761,12 +761,12 @@ describe('PeerManager', () => {
 
       const identify = new IdentifyMessage({
         agent: '',
-        head: '',
+        head: Buffer.alloc(32, 0),
         identity: privateIdentityToIdentity(other),
         port: peer.port,
         sequence: 1,
         version: VERSION_PROTOCOL_MIN - 1,
-        work: BigInt(0).toString(),
+        work: BigInt(0),
       })
       peer.onMessage.emit(identify, connection)
 
@@ -794,12 +794,12 @@ describe('PeerManager', () => {
 
       const identify = new IdentifyMessage({
         agent: '',
-        head: '',
+        head: Buffer.alloc(32, 0),
         identity: 'test',
         port: peer.port,
         sequence: 1,
         version: VERSION_PROTOCOL,
-        work: BigInt(0).toString(),
+        work: BigInt(0),
       })
       peer.onMessage.emit(identify, connection)
       expect(closeSpy).toBeCalled()
@@ -819,12 +819,12 @@ describe('PeerManager', () => {
 
       const identify = new IdentifyMessage({
         agent: '',
-        head: '',
+        head: Buffer.alloc(32, 0),
         identity: privateIdentityToIdentity(localIdentity),
         port: 9033,
         sequence: 1,
         version: VERSION_PROTOCOL,
-        work: BigInt(0).toString(),
+        work: BigInt(0),
       })
       connection.onMessage.emit(identify)
 
@@ -864,12 +864,12 @@ describe('PeerManager', () => {
 
       const identify = new IdentifyMessage({
         agent: '',
-        head: '',
+        head: Buffer.alloc(32, 0),
         identity: privateIdentityToIdentity(localIdentity),
         port: 9033,
         sequence: 1,
         version: VERSION_PROTOCOL,
-        work: BigInt(0).toString(),
+        work: BigInt(0),
       })
       connection.onMessage.emit(identify)
 
@@ -909,12 +909,12 @@ describe('PeerManager', () => {
 
       const identify = new IdentifyMessage({
         agent: '',
-        head: '',
+        head: Buffer.alloc(32, 0),
         identity: peer2Identity,
         port: peer1.port,
         sequence: 1,
         version: VERSION_PROTOCOL,
-        work: BigInt(0).toString(),
+        work: BigInt(0),
       })
       connection.onMessage.emit(identify)
 
@@ -959,12 +959,12 @@ describe('PeerManager', () => {
       const sendSpy = jest.spyOn(connection, 'send')
       const id = new IdentifyMessage({
         agent: '',
-        head: '',
+        head: Buffer.alloc(32, 0),
         identity: peerIdentity,
         port: 9033,
         sequence: 1,
         version: VERSION_PROTOCOL,
-        work: BigInt(0).toString(),
+        work: BigInt(0),
       })
       connection.onMessage.emit(id)
 

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -1152,9 +1152,9 @@ export class PeerManager {
     peer.name = name
     peer.version = version
     peer.agent = agent
-    peer.head = Buffer.from(message.head, 'hex')
+    peer.head = message.head
     peer.sequence = message.sequence
-    peer.work = BigInt(message.work)
+    peer.work = message.work
 
     // If we've told the peer to stay disconnected, repeat
     // the disconnection time before closing the connection


### PR DESCRIPTION
## Summary

The last of the message-shrinking PRs -- this one reduces the size of the RPC ID to 16 bits as well.

## Testing Plan

Tests should pass, and will do a final review+test on the serialize-networking branch once everything is merged in.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
