### PR TITLE
Fix telemetry serializing floats

### DIFF
--- a/ironfish/src/workerPool/tasks/submitTelemetry.test.ts
+++ b/ironfish/src/workerPool/tasks/submitTelemetry.test.ts
@@ -12,6 +12,9 @@ import {
 
 describe('SubmitTelemetryRequest', () => {
   it('serializes the object to a buffer and deserializes to the original object', () => {
+    const unsafeInteger = 0.2
+    expect(Number.isSafeInteger(unsafeInteger)).toBe(false)
+
     const mockMetric: Metric = {
       measurement: 'node',
       fields: [
@@ -30,9 +33,15 @@ describe('SubmitTelemetryRequest', () => {
           type: 'integer',
           value: 10,
         },
+        {
+          name: 'buz',
+          type: 'float',
+          value: unsafeInteger,
+        },
       ],
       timestamp: new Date(),
     }
+
     const request = new SubmitTelemetryRequest([mockMetric], GraffitiUtils.fromString(''))
     const buffer = request.serialize()
     const deserializedRequest = SubmitTelemetryRequest.deserialize(request.jobId, buffer)

--- a/ironfish/src/workerPool/tasks/submitTelemetry.ts
+++ b/ironfish/src/workerPool/tasks/submitTelemetry.ts
@@ -41,6 +41,8 @@ export class SubmitTelemetryRequest extends WorkerMessage {
             bw.writeU8(Number(field.value))
             break
           case 'float':
+            bw.writeDouble(field.value)
+            break
           case 'integer':
             bw.writeU64(field.value)
             break
@@ -84,7 +86,11 @@ export class SubmitTelemetryRequest extends WorkerMessage {
             fields.push({ name, type, value })
             break
           }
-          case 'float':
+          case 'float': {
+            const value = reader.readDouble()
+            fields.push({ name, type, value })
+            break
+          }
           case 'integer': {
             const value = reader.readU64()
             fields.push({ name, type, value })


### PR DESCRIPTION
## Summary

Serializing almost any float would cause an error as the float would be
serialized as a uint which will cause bufio to throw an error. Floats
need to be written as doubles in bufio.

See more here, https://github.com/bcoin-org/bufio/blob/91ae6c93899ff9fad7d7cee9afd2a1c4933ca984/lib/encoding.js#L441-L444

## Testing Plan

Added a new test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
