### PR TITLE
Move "new work" messages to debug

### DIFF
--- a/ironfish/src/mining/poolMiner.ts
+++ b/ironfish/src/mining/poolMiner.ts
@@ -104,7 +104,7 @@ export class MiningPoolMiner {
   newWork(miningRequestId: number, header: Buffer): void {
     Assert.isNotNull(this.graffiti)
 
-    this.logger.info(
+    this.logger.debug(
       'new work',
       this.target.toString('hex'),
       miningRequestId,

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -122,7 +122,7 @@ export class MiningSoloMiner {
   }
 
   newWork(miningRequestId: number, header: Buffer): void {
-    this.logger.info(
+    this.logger.debug(
       'new work',
       this.target.toString('hex'),
       miningRequestId,


### PR DESCRIPTION
## Summary

The goal is to allow miners a cleaner log output so that they only see the block found/submitted messages, which are higher value than the new work messages. The new work messages can still be displayed by passing the `-v` or `--verbose` flag

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
