### PR TITLE
Update to proper sqlite3 version

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -40,7 +40,7 @@
     "node-ipc": "9.1.3",
     "parse-json": "5.2.0",
     "sqlite": "4.0.23",
-    "sqlite3": "https://github.com/mapbox/node-sqlite3/archive/918052b538b0effe6c4a44c74a16b2749c08a0d2.tar.gz",
+    "sqlite3": "5.0.4",
     "tweetnacl": "1.0.3",
     "uuid": "8.3.2",
     "ws": "7.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7086,23 +7086,7 @@ node-gyp-build@~4.1.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.1.1.tgz#d7270b5d86717068d114cc57fff352f96d745feb"
   integrity sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==
 
-node-gyp@7.x, node-gyp@^7.1.0:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
-  integrity sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
-  dependencies:
-    env-paths "^2.2.0"
-    glob "^7.1.4"
-    graceful-fs "^4.2.3"
-    nopt "^5.0.0"
-    npmlog "^4.1.2"
-    request "^2.88.2"
-    rimraf "^3.0.2"
-    semver "^7.3.2"
-    tar "^6.0.2"
-    which "^2.0.2"
-
-node-gyp@8.4.1, node-gyp@^8.2.0:
+node-gyp@8.4.1, node-gyp@8.x, node-gyp@^8.2.0:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.4.1.tgz#3d49308fc31f768180957d6b5746845fbd429937"
   integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==
@@ -7134,6 +7118,22 @@ node-gyp@^5.0.2:
     semver "^5.7.1"
     tar "^4.4.12"
     which "^1.3.1"
+
+node-gyp@^7.1.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
+  integrity sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
+  dependencies:
+    env-paths "^2.2.0"
+    glob "^7.1.4"
+    graceful-fs "^4.2.3"
+    nopt "^5.0.0"
+    npmlog "^4.1.2"
+    request "^2.88.2"
+    rimraf "^3.0.2"
+    semver "^7.3.2"
+    tar "^6.0.2"
+    which "^2.0.2"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -8950,14 +8950,16 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"sqlite3@https://github.com/mapbox/node-sqlite3/archive/918052b538b0effe6c4a44c74a16b2749c08a0d2.tar.gz":
-  version "5.0.2"
-  resolved "https://github.com/mapbox/node-sqlite3/archive/918052b538b0effe6c4a44c74a16b2749c08a0d2.tar.gz#a06ce45e69b6529cd929ba39ce16ac44cff06826"
+sqlite3@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.0.4.tgz#3ddff8d360dab3f17c596690d8663f353d876187"
+  integrity sha512-ATvAe7JutFv/d+KTbLS58KsKn/t1raL/WGn2qZfZxwsrL/oGSP+0OlbQ2tX5jISvyu6/7JuKze3WkaiP1JAH6A==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.0"
     node-addon-api "^4.2.0"
+    tar "^6.1.11"
   optionalDependencies:
-    node-gyp "7.x"
+    node-gyp "8.x"
 
 sqlite@4.0.23:
   version "4.0.23"


### PR DESCRIPTION
## Summary

sqlite3 package is under new management, which broke the downloads of the pre-compiled binaries. The upside is that they finally released an updated version with the changes we were using, so now we can use the regular npm version. See https://github.com/TryGhost/node-sqlite3/issues/1572 for more information about the change in ownership.

This might also remove/minimize the python dependency: https://github.com/TryGhost/node-sqlite3/pull/1570

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
