### PR TITLE
feat(ironfish): Refactor serialization for the accountsdb transaction store

### DIFF
--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -6,7 +6,7 @@ import { BufferMap } from 'buffer-map'
 import { FileSystem } from '../fileSystems'
 import { Transaction } from '../primitives/transaction'
 import {
-  BufferEncoding,
+  BUFFER_ENCODING,
   IDatabase,
   IDatabaseStore,
   IDatabaseTransaction,
@@ -16,6 +16,7 @@ import {
 import { createDB } from '../storage/utils'
 import { WorkerPool } from '../workerPool'
 import { Account } from './account'
+import { TransactionsValue, TransactionsValueEncoding } from './database/transactions'
 
 const DATABASE_VERSION = 3
 
@@ -70,11 +71,7 @@ export class AccountsDB {
 
   transactions: IDatabaseStore<{
     key: Buffer
-    value: {
-      transaction: Buffer
-      blockHash: string | null
-      submittedSequence: number | null
-    }
+    value: TransactionsValue
   }>
 
   constructor({
@@ -130,8 +127,8 @@ export class AccountsDB {
       }
     }>({
       name: 'transactions',
-      keyEncoding: new BufferEncoding(),
-      valueEncoding: new JsonEncoding(),
+      keyEncoding: BUFFER_ENCODING,
+      valueEncoding: new TransactionsValueEncoding(),
     })
   }
 

--- a/ironfish/src/account/database/transactions.test.ts
+++ b/ironfish/src/account/database/transactions.test.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { TransactionsValue, TransactionsValueEncoding } from './transactions'
+
+describe('TransactionsValueEncoding', () => {
+  describe('with a null block hash and sequence', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new TransactionsValueEncoding()
+
+      const value: TransactionsValue = {
+        transaction: Buffer.from('mock-transaction'),
+        blockHash: null,
+        submittedSequence: null,
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+
+  describe('with a null block hash', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new TransactionsValueEncoding()
+
+      const value: TransactionsValue = {
+        transaction: Buffer.from('mock-transaction'),
+        blockHash: null,
+        submittedSequence: 123,
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+
+  describe('with a null sequence', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new TransactionsValueEncoding()
+
+      const value: TransactionsValue = {
+        transaction: Buffer.from('mock-transaction'),
+        blockHash: Buffer.alloc(32, 1).toString('hex'),
+        submittedSequence: null,
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+
+  describe('with all fields defined', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new TransactionsValueEncoding()
+
+      const value: TransactionsValue = {
+        transaction: Buffer.from('mock-transaction'),
+        blockHash: Buffer.alloc(32, 1).toString('hex'),
+        submittedSequence: 123,
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+})

--- a/ironfish/src/account/database/transactions.ts
+++ b/ironfish/src/account/database/transactions.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { IDatabaseEncoding } from '../../storage/database/types'
+import bufio from 'bufio'
+
+export interface TransactionsValue {
+  transaction: Buffer
+  blockHash: string | null
+  submittedSequence: number | null
+}
+
+export class TransactionsValueEncoding implements IDatabaseEncoding<TransactionsValue> {
+  serialize(value: TransactionsValue): Buffer {
+    const { transaction, blockHash, submittedSequence } = value
+    const bw = bufio.write(this.getSize(value))
+    bw.writeVarBytes(transaction)
+
+    let flags = 0
+    flags |= Number(!!blockHash) << 0
+    flags |= Number(!!submittedSequence) << 1
+    bw.writeU8(flags)
+
+    if (blockHash) {
+      bw.writeHash(blockHash)
+    }
+    if (submittedSequence) {
+      bw.writeU32(submittedSequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): TransactionsValue {
+    const reader = bufio.read(buffer, true)
+    const transaction = reader.readVarBytes()
+
+    const flags = reader.readU8()
+    const hasBlockHash = flags & (1 << 0)
+    const hasSubmittedSequence = flags & (1 << 1)
+
+    let blockHash = null
+    if (hasBlockHash) {
+      blockHash = reader.readHash('hex')
+    }
+
+    let submittedSequence = null
+    if (hasSubmittedSequence) {
+      submittedSequence = reader.readU32()
+    }
+
+    return { transaction, blockHash, submittedSequence }
+  }
+
+  getSize(value: TransactionsValue): number {
+    let size = bufio.sizeVarBytes(value.transaction)
+    size += 1
+    if (value.blockHash) {
+      size += 32
+    }
+    if (value.submittedSequence) {
+      size += 4
+    }
+    return size
+  }
+}


### PR DESCRIPTION
## Summary

Use binary serializable encoder for the transactions store in the Accounts DB.

## Testing Plan

Existing unit tests and added new tests for the encoder.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
