### PR TITLE
Adjustment to miners:mined RPC route

### DIFF
--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -9,7 +9,7 @@ import {
   oreToIron,
   TimeUtils,
 } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import readline from 'readline'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
@@ -22,6 +22,10 @@ export class MinedCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    scanForks: Flags.boolean({
+      default: false,
+      description: 'Scan forks for mined blocks',
+    }),
   }
 
   static args = [
@@ -41,7 +45,7 @@ export class MinedCommand extends IronfishCommand {
   ]
 
   async start(): Promise<void> {
-    const { args } = await this.parse(MinedCommand)
+    const { flags, args } = await this.parse(MinedCommand)
     const client = await this.sdk.connectRpc()
 
     this.log('Scanning for mined blocks...')
@@ -49,6 +53,7 @@ export class MinedCommand extends IronfishCommand {
     const stream = client.exportMinedStream({
       start: args.start as number | null,
       stop: args.stop as number | null,
+      forks: flags.scanForks as boolean | null,
     })
 
     const { start, stop } = await AsyncUtils.first(stream.contentStream())

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -60,9 +60,9 @@ export class MinedCommand extends IronfishCommand {
       const { block } = await AsyncUtils.first(stream.contentStream())
       if (block) {
         this.logLineForMinedBlock(block)
-      } else {
-        this.log(`No mined block found for hash ${flags.blockHash}`)
       }
+
+      return
     } else {
       const stream = client.exportMinedStream({
         start: args.start as number | null,

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -53,6 +53,8 @@ export class MinedCommand extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     if (flags.blockHash) {
+      this.log(`Scanning mined blocks for ${flags.blockHash}`)
+
       const stream = client.exportMinedStream({
         blockHash: flags.blockHash as string | null,
       })

--- a/ironfish/src/rpc/routes/mining/exportMined.ts
+++ b/ironfish/src/rpc/routes/mining/exportMined.ts
@@ -68,54 +68,18 @@ router.register<typeof ExportMinedStreamRequestSchema, ExportMinedStreamResponse
 
     request.stream({ start, stop, sequence: 0 })
 
-    let promise = Promise.resolve()
-    let waiting = 0
-
-    for (let i = start; i <= stop; ++i) {
-      promise = promise.then(async () => {
-        const headers = scanForks
-          ? await node.chain.getHeadersAtSequence(i)
-          : [await node.chain.getHeaderAtSequence(i)]
-
-        for (const header of headers) {
-          if (header == null) {
-            break
-          }
-
-          const block = await node.chain.getBlock(header)
-          Assert.isNotNull(block)
-
-          const account = node.accounts
-            .listAccounts()
-            .find((a) => BlockchainUtils.isBlockMine(block, a))
-
-          if (!account) {
-            request.stream({ start, stop, sequence: header.sequence })
-            continue
-          }
-
-          const main = await node.chain.isHeadChain(header)
-          const minersFee = node.chain.strategy.miningReward(header.sequence)
-
-          const result = {
-            main: main,
-            hash: header.hash.toString('hex'),
-            sequence: header.sequence,
-            account: account.name,
-            minersFee: minersFee,
-          }
-
-          request.stream({ start, stop, sequence: header.sequence, block: result })
-        }
+    for await (const block of node.minedBlocksIndexer.getMinedBlocks({
+      scanForks,
+      start,
+      stop,
+    })) {
+      request.stream({
+        start,
+        stop,
+        sequence: block.sequence,
+        block: { ...block, hash: block.hash.toString('hex') },
       })
-
-      if (++waiting > 100) {
-        await promise
-        waiting = 0
-      }
     }
-
-    await promise
 
     request.end()
   },

--- a/ironfish/src/rpc/routes/mining/exportMined.ts
+++ b/ironfish/src/rpc/routes/mining/exportMined.ts
@@ -8,6 +8,7 @@ import { ApiNamespace, router } from '../router'
 
 export type ExportMinedStreamRequest =
   | {
+      blockHash?: string | null
       start?: number | null
       stop?: number | null
       forks?: boolean | null
@@ -15,9 +16,9 @@ export type ExportMinedStreamRequest =
   | undefined
 
 export type ExportMinedStreamResponse = {
-  start: number
-  stop: number
-  sequence: number
+  start?: number
+  stop?: number
+  sequence?: number
   block?: {
     hash: string
     minersFee: number
@@ -29,6 +30,7 @@ export type ExportMinedStreamResponse = {
 
 export const ExportMinedStreamRequestSchema: yup.ObjectSchema<ExportMinedStreamRequest> = yup
   .object({
+    blockHash: yup.string().nullable().optional(),
     start: yup.number().nullable().optional(),
     stop: yup.number().nullable().optional(),
     forks: yup.boolean().nullable().optional(),
@@ -59,13 +61,19 @@ router.register<typeof ExportMinedStreamRequestSchema, ExportMinedStreamResponse
     Assert.isNotNull(node.chain.head, 'head')
     Assert.isNotNull(node.chain.latest, 'latest')
 
-    const scanForks = request.data?.forks == null ? false : true
+    const blockHash = request.data?.blockHash == null ? undefined : request.data.blockHash
 
+    if (blockHash) {
+      const block = await node.minedBlocksIndexer.getMinedBlock(Buffer.from(blockHash, 'hex'))
+      request.stream({ block })
+      request.end()
+    }
+
+    const scanForks = request.data?.forks == null ? false : true
     const { start, stop } = BlockchainUtils.getBlockRange(node.chain, {
       start: request.data?.start,
       stop: request.data?.stop,
     })
-
     request.stream({ start, stop, sequence: 0 })
 
     for await (const block of node.minedBlocksIndexer.getMinedBlocks({
@@ -77,7 +85,7 @@ router.register<typeof ExportMinedStreamRequestSchema, ExportMinedStreamResponse
         start,
         stop,
         sequence: block.sequence,
-        block: { ...block, hash: block.hash.toString('hex') },
+        block,
       })
     }
 

--- a/ironfish/src/rpc/routes/mining/exportMined.ts
+++ b/ironfish/src/rpc/routes/mining/exportMined.ts
@@ -61,7 +61,7 @@ router.register<typeof ExportMinedStreamRequestSchema, ExportMinedStreamResponse
     Assert.isNotNull(node.chain.head, 'head')
     Assert.isNotNull(node.chain.latest, 'latest')
 
-    const blockHash = request.data?.blockHash == null ? undefined : request.data.blockHash
+    const blockHash = request.data?.blockHash ?? undefined
 
     if (blockHash) {
       const block = await node.minedBlocksIndexer.getMinedBlock(Buffer.from(blockHash, 'hex'))


### PR DESCRIPTION
## Summary
- Adjusts `miners:mined` command to use `MinedBlocksIndexer`
- Add CLI flag for scanning forks for mined blocks
- Add CLI flag for searching for mined block info given a block hash

## Testing Plan
Mined blocks on a local chain and ensured that mined blocks were properly returned in each case.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
