### PR TITLE
Update gitattributes to ignore certain file extensions when looking at line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@
 *.ts text
 *.js text
 *.json text
+*.png -text
+*.params -text


### PR DESCRIPTION
## Summary

Been running into this a lot when dealing with params files. Also have seen it pop up for the png file in the graph explorer module. According to the git docs, this should stop that from happening: https://git-scm.com/docs/gitattributes

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
