### PR TITLE
feat(ironfish): Refactor serialization for accountsdb noteToNullifiers

### DIFF
--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -16,6 +16,7 @@ import {
 import { createDB } from '../storage/utils'
 import { WorkerPool } from '../workerPool'
 import { Account } from './account'
+import { NoteToNullifiersValue } from './database/noteToNullifiers'
 import { TransactionsValue, TransactionsValueEncoding } from './database/transactions'
 
 const DATABASE_VERSION = 3
@@ -64,7 +65,7 @@ export class AccountsDB {
   // Transaction-related database stores
   noteToNullifier: IDatabaseStore<{
     key: string
-    value: { nullifierHash: string | null; noteIndex: number | null; spent: boolean }
+    value: NoteToNullifiersValue
   }>
 
   nullifierToNote: IDatabaseStore<{ key: string; value: string }>

--- a/ironfish/src/account/database/noteToNullifiers.test.ts
+++ b/ironfish/src/account/database/noteToNullifiers.test.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { NoteToNullifiersValue, NoteToNullifiersValueEncoding } from './noteToNullifiers'
+
+describe('NoteToNullifiersValueEncoding', () => {
+  describe('with a null nullifier hash and index', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new NoteToNullifiersValueEncoding()
+
+      const value: NoteToNullifiersValue = {
+        spent: false,
+        noteIndex: null,
+        nullifierHash: null,
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+
+  describe('with a null nullifier hash', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new NoteToNullifiersValueEncoding()
+
+      const value: NoteToNullifiersValue = {
+        spent: false,
+        noteIndex: 40,
+        nullifierHash: null,
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+
+  describe('with a null note index', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new NoteToNullifiersValueEncoding()
+
+      const value: NoteToNullifiersValue = {
+        spent: false,
+        noteIndex: null,
+        nullifierHash: Buffer.alloc(32, 1).toString('hex'),
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+
+  describe('with all fields defined', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new NoteToNullifiersValueEncoding()
+
+      const value: NoteToNullifiersValue = {
+        spent: false,
+        noteIndex: 40,
+        nullifierHash: Buffer.alloc(32, 1).toString('hex'),
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+})

--- a/ironfish/src/account/database/noteToNullifiers.ts
+++ b/ironfish/src/account/database/noteToNullifiers.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../storage'
+
+export interface NoteToNullifiersValue {
+  nullifierHash: string | null
+  noteIndex: number | null
+  spent: boolean
+}
+
+export class NoteToNullifiersValueEncoding implements IDatabaseEncoding<NoteToNullifiersValue> {
+  serialize(value: NoteToNullifiersValue): Buffer {
+    const { nullifierHash, noteIndex, spent } = value
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!nullifierHash) << 0
+    flags |= Number(!!noteIndex) << 1
+    flags |= Number(spent) << 2
+    bw.writeU8(flags)
+
+    if (nullifierHash) {
+      bw.writeHash(nullifierHash)
+    }
+    if (noteIndex) {
+      bw.writeU32(noteIndex)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): NoteToNullifiersValue {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const hasNullifierHash = flags & (1 << 0)
+    const hasNoteIndex = flags & (1 << 1)
+    const spent = Boolean(flags & (1 << 2))
+
+    let nullifierHash = null
+    if (hasNullifierHash) {
+      nullifierHash = reader.readHash('hex')
+    }
+
+    let noteIndex = null
+    if (hasNoteIndex) {
+      noteIndex = reader.readU32()
+    }
+
+    return { nullifierHash, noteIndex, spent }
+  }
+
+  getSize(value: NoteToNullifiersValue): number {
+    let size = 1
+    if (value.nullifierHash) {
+      size += 32
+    }
+    if (value.noteIndex) {
+      size += 4
+    }
+    return size
+  }
+}


### PR DESCRIPTION
## Summary

Use binary serialization encoder for the `noteToNullifiers` store in the Accounts DB

## Testing Plan

Added unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
