### PR TITLE
Refactor node database serialization in merkle tree

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -17,6 +17,7 @@ import { genesisBlockData } from '../genesis'
 import { createRootLogger, Logger } from '../logger'
 import { MerkleTree } from '../merkletree'
 import { NoteLeafEncoding, NullifierLeafEncoding } from '../merkletree/database/leaves'
+import { NodeEncoding } from '../merkletree/database/nodes'
 import { Meter, MetricsMonitor } from '../metrics'
 import { BAN_SCORE } from '../network/peers/peer'
 import { Block, SerializedBlock } from '../primitives/block'
@@ -202,6 +203,7 @@ export class Blockchain {
       hasher: this.strategy.noteHasher,
       leafIndexKeyEncoding: BUFFER_ENCODING,
       leafEncoding: new NoteLeafEncoding(),
+      nodeEncoding: new NodeEncoding(),
       db: this.db,
       name: 'n',
       depth: 32,
@@ -211,6 +213,7 @@ export class Blockchain {
       hasher: this.strategy.nullifierHasher,
       leafIndexKeyEncoding: BUFFER_ENCODING,
       leafEncoding: new NullifierLeafEncoding(),
+      nodeEncoding: new NodeEncoding(),
       db: this.db,
       name: 'u',
       depth: 32,

--- a/ironfish/src/merkletree/database/leaves.test.ts
+++ b/ironfish/src/merkletree/database/leaves.test.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { generateKey, Note, Transaction, TransactionPosted } from '@ironfish/rust-nodejs'
+import { NoteEncrypted } from '../../primitives/noteEncrypted'
+import { NoteLeafEncoding, NullifierLeafEncoding } from './leaves'
+
+describe('NoteLeafEncoding', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const encoding = new NoteLeafEncoding()
+    const key = generateKey()
+    const note = new Note(key.public_address, 10n, '')
+    const tx = new Transaction()
+    tx.receive(key.spending_key, note)
+    const buf = tx.post_miners_fee()
+    const txp = new TransactionPosted(buf)
+    const noteEncrypted = new NoteEncrypted(txp.getNote(0))
+
+    const noteLeafValue = {
+      index: 7,
+      element: noteEncrypted,
+      merkleHash: Buffer.alloc(32, 'hashOfSibling'),
+      parentIndex: 14,
+    } as const
+
+    const buffer = encoding.serialize(noteLeafValue)
+    const deserializedMessage = encoding.deserialize(buffer)
+    expect(deserializedMessage).toEqual(noteLeafValue)
+  })
+})
+
+describe('NullifierLeafEncoding', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const encoding = new NullifierLeafEncoding()
+
+    const nullifierLeafValue = {
+      index: 7,
+      element: Buffer.alloc(32, 'element'),
+      merkleHash: Buffer.alloc(32, 'hashOfSibling'),
+      parentIndex: 14,
+    } as const
+
+    const buffer = encoding.serialize(nullifierLeafValue)
+    const deserializedMessage = encoding.deserialize(buffer)
+    expect(deserializedMessage).toEqual(nullifierLeafValue)
+  })
+})

--- a/ironfish/src/merkletree/database/nodes.test.ts
+++ b/ironfish/src/merkletree/database/nodes.test.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Side } from '../merkletree'
+import { NodeEncoding } from './nodes'
+
+describe('NodeEncoding', () => {
+  it('serializes a left node into a buffer and deserializes to the original object', () => {
+    const encoding = new NodeEncoding()
+
+    const leftNodeValue = {
+      index: 7,
+      side: Side.Left,
+      hashOfSibling: Buffer.alloc(32, 'hashOfSibling'),
+      parentIndex: 14,
+    } as const
+
+    const buffer = encoding.serialize(leftNodeValue)
+    const deserializedMessage = encoding.deserialize(buffer)
+    expect(deserializedMessage).toEqual(leftNodeValue)
+  })
+
+  it('serializes a right node into a buffer and deserializes to the original object', () => {
+    const encoding = new NodeEncoding()
+
+    const rightNodeValue = {
+      index: 7,
+      side: Side.Right,
+      hashOfSibling: Buffer.alloc(32, 'hashOfSibling'),
+      leftIndex: 14,
+    } as const
+
+    const buffer = encoding.serialize(rightNodeValue)
+    const deserializedMessage = encoding.deserialize(buffer)
+    expect(deserializedMessage).toEqual(rightNodeValue)
+  })
+})

--- a/ironfish/src/merkletree/database/nodes.ts
+++ b/ironfish/src/merkletree/database/nodes.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { IDatabaseEncoding } from '../../storage/database/types'
+import bufio from 'bufio'
+import { Side } from '../merkletree'
+
+export type NodeValue<H> = LeftNodeValue<H> | RightNodeValue<H>
+
+type LeftNodeValue<H> = {
+  index: number
+  side: Side.Left
+  hashOfSibling: H
+  parentIndex: number // left nodes have a parent index
+}
+
+type RightNodeValue<H> = {
+  index: number
+  side: Side.Right
+  hashOfSibling: H
+  leftIndex: number // right nodes have a left index
+}
+
+export class NodeEncoding implements IDatabaseEncoding<NodeValue<Buffer>> {
+  serialize(value: NodeValue<Buffer>): Buffer {
+    const bw = bufio.write(this.getSize())
+
+    bw.writeU32(value.index)
+    bw.writeU8(value.side)
+    bw.writeHash(value.hashOfSibling)
+
+    if (value.side === Side.Left) {
+      bw.writeU32(value.parentIndex)
+    } else {
+      bw.writeU32(value.leftIndex)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): NodeValue<Buffer> {
+    const reader = bufio.read(buffer, true)
+
+    const index = reader.readU32()
+    const side = reader.readU8() as Side
+    const hashOfSibling = reader.readHash()
+    const otherIndex = reader.readU32()
+
+    if (side === Side.Left) {
+      const leftNode: LeftNodeValue<Buffer> = {
+        index,
+        side,
+        hashOfSibling,
+        parentIndex: otherIndex,
+      }
+      return leftNode
+    }
+
+    const rightNode: RightNodeValue<Buffer> = {
+      index,
+      side,
+      hashOfSibling,
+      leftIndex: otherIndex,
+    }
+    return rightNode
+  }
+
+  getSize(): number {
+    let size = 0
+    size += 4 // index
+    size += 1 // side
+    size += 32 // merkleHash
+    size += 4 // parentIndex
+    return size
+  }
+}

--- a/ironfish/src/merkletree/database/nodes.ts
+++ b/ironfish/src/merkletree/database/nodes.ts
@@ -27,12 +27,13 @@ export class NodeEncoding implements IDatabaseEncoding<NodeValue<Buffer>> {
     const bw = bufio.write(this.getSize())
 
     bw.writeU32(value.index)
-    bw.writeU8(value.side)
     bw.writeHash(value.hashOfSibling)
 
     if (value.side === Side.Left) {
+      bw.writeU8(0)
       bw.writeU32(value.parentIndex)
     } else {
+      bw.writeU8(1)
       bw.writeU32(value.leftIndex)
     }
 
@@ -43,8 +44,11 @@ export class NodeEncoding implements IDatabaseEncoding<NodeValue<Buffer>> {
     const reader = bufio.read(buffer, true)
 
     const index = reader.readU32()
-    const side = reader.readU8() as Side
     const hashOfSibling = reader.readHash()
+
+    const sideNumber = reader.readU8()
+    const side = sideNumber === 0 ? Side.Left : Side.Right
+
     const otherIndex = reader.readU32()
 
     if (side === Side.Left) {

--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -690,8 +690,8 @@ export class MerkleTree<
 }
 
 export enum Side {
-  Left = 0,
-  Right = 1,
+  Left = 'Left',
+  Right = 'Right',
 }
 
 export type LeafIndex = number

--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -10,12 +10,10 @@ import {
   IDatabaseEncoding,
   IDatabaseStore,
   IDatabaseTransaction,
-  JsonEncoding,
   SchemaValue,
   StringEncoding,
   U32_ENCODING,
 } from '../storage'
-import { NodeEncoding } from './encoding'
 import { MerkleHasher } from './hasher'
 import { CounterSchema, LeavesIndexSchema, LeavesSchema, NodesSchema } from './schema'
 import { depthAtLeafCount, isEmpty, isRight } from './utils'
@@ -42,13 +40,15 @@ export class MerkleTree<
     db,
     leafEncoding,
     leafIndexKeyEncoding,
+    nodeEncoding,
     name = '',
     depth = 32,
   }: {
     hasher: MerkleHasher<E, H, SE, SH>
     db: IDatabase
     leafEncoding: IDatabaseEncoding<LeavesSchema<E, H>['value']>
-    leafIndexKeyEncoding: IDatabaseEncoding<H>
+    leafIndexKeyEncoding: IDatabaseEncoding<LeavesIndexSchema<H>['key']>
+    nodeEncoding: IDatabaseEncoding<NodesSchema<H>['value']>
     name?: string
     depth?: number
   }) {
@@ -77,8 +77,8 @@ export class MerkleTree<
 
     this.nodes = db.addStore({
       name: `${name}n`,
-      keyEncoding: new JsonEncoding<NodesSchema<H>['key']>(),
-      valueEncoding: new NodeEncoding(hasher),
+      keyEncoding: U32_ENCODING,
+      valueEncoding: nodeEncoding,
     })
   }
 
@@ -690,8 +690,8 @@ export class MerkleTree<
 }
 
 export enum Side {
-  Left = 'Left',
-  Right = 'Right',
+  Left = 0,
+  Right = 1,
 }
 
 export type LeafIndex = number

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -13,6 +13,7 @@ import {
 import { Verifier } from './consensus'
 import { MerkleTree } from './merkletree'
 import { NoteLeafEncoding } from './merkletree/database/leaves'
+import { NodeEncoding } from './merkletree/database/nodes'
 import { NoteHasher } from './merkletree/hasher'
 import { Note } from './primitives/note'
 import { NoteEncrypted, NoteEncryptedHash } from './primitives/noteEncrypted'
@@ -44,6 +45,7 @@ async function makeStrategyTree({
     hasher: new NoteHasher(),
     leafIndexKeyEncoding: BUFFER_ENCODING,
     leafEncoding: new NoteLeafEncoding(),
+    nodeEncoding: new NodeEncoding(),
     db: database,
     name: name,
     depth: depth,

--- a/ironfish/src/testUtilities/helpers/merkletree.ts
+++ b/ironfish/src/testUtilities/helpers/merkletree.ts
@@ -4,7 +4,9 @@
 
 import bufio from 'bufio'
 import { MerkleTree } from '../../merkletree'
+import { NodeValue } from '../../merkletree/database/nodes'
 import { StructureHasher } from '../../merkletree/hasher'
+import { Side } from '../../merkletree/merkletree'
 import { IDatabase, IDatabaseEncoding, StringEncoding } from '../../storage'
 import { createDB } from '../helpers/storage'
 
@@ -44,6 +46,51 @@ class StructureLeafEncoding implements IDatabaseEncoding<StructureLeafValue> {
   }
 }
 
+class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
+  serialize(value: NodeValue<string>): Buffer {
+    const bw = bufio.write()
+
+    bw.writeU32(value.index)
+    bw.writeU8(value.side)
+    bw.writeVarString(value.hashOfSibling)
+
+    if (value.side === Side.Left) {
+      bw.writeU32(value.parentIndex)
+    } else {
+      bw.writeU32(value.leftIndex)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): NodeValue<string> {
+    const reader = bufio.read(buffer, true)
+
+    const index = reader.readU32()
+    const side = reader.readU8() as Side
+    const hashOfSibling = reader.readVarString()
+    const otherIndex = reader.readU32()
+
+    if (side === Side.Left) {
+      const leftNode = {
+        index,
+        side,
+        hashOfSibling,
+        parentIndex: otherIndex,
+      }
+      return leftNode
+    }
+
+    const rightNode = {
+      index,
+      side,
+      hashOfSibling,
+      leftIndex: otherIndex,
+    }
+    return rightNode
+  }
+}
+
 export async function makeTree({
   name,
   db,
@@ -63,6 +110,7 @@ export async function makeTree({
     hasher: new StructureHasher(),
     leafIndexKeyEncoding: new StringEncoding(),
     leafEncoding: new StructureLeafEncoding(),
+    nodeEncoding: new StructureNodeEncoding(),
     db: db,
     name: name,
     depth: depth,

--- a/ironfish/src/testUtilities/helpers/merkletree.ts
+++ b/ironfish/src/testUtilities/helpers/merkletree.ts
@@ -51,12 +51,13 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
     const bw = bufio.write()
 
     bw.writeU32(value.index)
-    bw.writeU8(value.side)
     bw.writeVarString(value.hashOfSibling)
 
     if (value.side === Side.Left) {
+      bw.writeU8(0)
       bw.writeU32(value.parentIndex)
     } else {
+      bw.writeU8(1)
       bw.writeU32(value.leftIndex)
     }
 
@@ -67,8 +68,11 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
     const reader = bufio.read(buffer, true)
 
     const index = reader.readU32()
-    const side = reader.readU8() as Side
     const hashOfSibling = reader.readVarString()
+
+    const sideNumber = reader.readU8()
+    const side = sideNumber === 0 ? Side.Left : Side.Right
+
     const otherIndex = reader.readU32()
 
     if (side === Side.Left) {
@@ -77,7 +81,7 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
         side,
         hashOfSibling,
         parentIndex: otherIndex,
-      }
+      } as const
       return leftNode
     }
 
@@ -86,7 +90,7 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
       side,
       hashOfSibling,
       leftIndex: otherIndex,
-    }
+    } as const
     return rightNode
   }
 }

--- a/ironfish/src/workerPool/tasks/createTransaction.test.slow.ts
+++ b/ironfish/src/workerPool/tasks/createTransaction.test.slow.ts
@@ -4,6 +4,7 @@
 
 import { Assert } from '../../assert'
 import { NoteLeafEncoding } from '../../merkletree/database/leaves'
+import { NodeEncoding } from '../../merkletree/database/nodes'
 import { NoteHasher } from '../../merkletree/hasher'
 import { MerkleTree, Side } from '../../merkletree/merkletree'
 import { NoteEncrypted, NoteEncryptedHash } from '../../primitives/noteEncrypted'
@@ -38,6 +39,7 @@ async function makeStrategyTree({
     hasher: new NoteHasher(),
     leafIndexKeyEncoding: BUFFER_ENCODING,
     leafEncoding: new NoteLeafEncoding(),
+    nodeEncoding: new NodeEncoding(),
     db: database,
     name: name,
     depth: depth,


### PR DESCRIPTION
## Summary

Adds an Encoding class for Nodes in the merkle tree. The encoding uses binary serialization to write the merkle tree node into the key/value store.

## Testing Plan

Tests should pass, and will do a complete manual test on the serialize-database branch.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

*Everything in the database serialization will be breaking changes*

```
[X] Yes
[] No
```
