### PR TITLE
Refactor meta store to use a more specific encoding

### DIFF
--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -14,10 +14,10 @@ import {
   IDatabaseStore,
   IDatabaseStoreOptions,
   IDatabaseTransaction,
-  JsonEncoding,
   SchemaKey,
   SchemaValue,
   StringEncoding,
+  U32_ENCODING,
 } from '../database'
 import { DatabaseIsLockedError } from '../database/errors'
 import { LevelupBatch } from './batch'
@@ -51,7 +51,7 @@ export class LevelupDatabase extends Database {
     this.metaStore = this.addStore<MetaSchema>({
       name: 'Meta',
       keyEncoding: new StringEncoding(),
-      valueEncoding: new JsonEncoding(),
+      valueEncoding: U32_ENCODING,
     }) as LevelupStore<MetaSchema>
   }
 


### PR DESCRIPTION
## Summary

The meta store only contains the database version field, which is a number.

## Testing Plan

Tests should pass, and we'll do a full manual test on the serialize-database branch when it's finished.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

*All of the database encoding changes should be breaking changes.*

```
[X] Yes
[] No
```
