### PR TITLE
feat(ironfish): Create `StringHashEncoding` for hash keys in stores

### DIFF
--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -12,6 +12,7 @@ import {
   IDatabaseTransaction,
   JsonEncoding,
   StringEncoding,
+  StringHashEncoding,
 } from '../storage'
 import { createDB } from '../storage/utils'
 import { WorkerPool } from '../workerPool'
@@ -108,13 +109,13 @@ export class AccountsDB {
       value: NoteToNullifiersValue
     }>({
       name: 'noteToNullifier',
-      keyEncoding: new StringEncoding(),
+      keyEncoding: new StringHashEncoding(),
       valueEncoding: new NoteToNullifiersValueEncoding(),
     })
 
     this.nullifierToNote = this.database.addStore<{ key: string; value: string }>({
       name: 'nullifierToNote',
-      keyEncoding: new StringEncoding(),
+      keyEncoding: new StringHashEncoding(),
       valueEncoding: new StringEncoding(),
     })
 

--- a/ironfish/src/storage/database/encoding.ts
+++ b/ironfish/src/storage/database/encoding.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import bufio from 'bufio'
 import hexArray from 'hex-array'
 import { IJSON, IJsonSerializable, Serde } from '../../serde'
 import { IDatabaseEncoding } from './types'
@@ -57,6 +58,24 @@ export class U32Encoding implements IDatabaseEncoding<number> {
 export class BufferEncoding implements IDatabaseEncoding<Buffer> {
   serialize = (value: Buffer): Buffer => value
   deserialize = (buffer: Buffer): Buffer => buffer
+
+  equals(): boolean {
+    throw new Error('You should never use this')
+  }
+}
+
+export class StringHashEncoding implements IDatabaseEncoding<string> {
+  serialize(value: string): Buffer {
+    const buffer = bufio.write(32)
+    buffer.writeHash(value)
+    return buffer.render()
+  }
+
+  deserialize(buffer: Buffer): string {
+    const reader = bufio.read(buffer, true)
+    const hash = reader.readHash()
+    return hash.toString('hex')
+  }
 
   equals(): boolean {
     throw new Error('You should never use this')


### PR DESCRIPTION
## Summary

The Accounts DB has two stores with hash strings as keys. This PR introduces a new encoding for these keys to be written as buffer hashes.

## Testing Plan

Will test after changes are merged in the `serialize-database` intermediate branch.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
