### PR TITLE
Allowed characters should be limited to hexadecimal, and be case insensitive

### DIFF
--- a/ironfish/src/account/validator.test.ts
+++ b/ironfish/src/account/validator.test.ts
@@ -16,9 +16,21 @@ describe('account-validator tests', () => {
     expect(isValidPublicAddress(VALID_PUBLIC_ADDRESS)).toBe(true)
   })
 
+  test('valid uppercase public address should return true', () => {
+    const VALID_PUBLIC_ADDRESS =
+      'E877D6903692094B67D889C483D09AD2F8438EFC8F00C82E1EC3B2CCD1798CECA48216546DBAE48C685F50'
+    expect(isValidPublicAddress(VALID_PUBLIC_ADDRESS)).toBe(true)
+  })
+
   test('public address with non valid character should return false', () => {
     const INVALID_PUBLIC_ADDRESS =
       '#877d6903692094b67d889c483d09ad2f8438efc8f00c82e1ec3b2ccd1798ceca48216546dbae48c685f50'
+    expect(isValidPublicAddress(INVALID_PUBLIC_ADDRESS)).toBe(false)
+  })
+
+  test('public address with non valid hex character should return false', () => {
+    const INVALID_PUBLIC_ADDRESS =
+      'g877d6903692094b67d889c483d09ad2f8438efc8f00c82e1ec3b2ccd1798ceca48216546dbae48c685f50'
     expect(isValidPublicAddress(INVALID_PUBLIC_ADDRESS)).toBe(false)
   })
 

--- a/ironfish/src/account/validator.ts
+++ b/ironfish/src/account/validator.ts
@@ -70,6 +70,6 @@ export function validateAccount(toImport: Partial<SerializedAccount>): void {
 }
 
 function haveAllowedCharacters(text: string): boolean {
-  const validInputRegex = /^[0-9a-z]+$/
-  return validInputRegex.exec(text) != null
+  const validInputRegex = /^[0-9a-f]+$/
+  return validInputRegex.exec(text.toLowerCase()) != null
 }


### PR DESCRIPTION
## Summary

`haveAllowedCharacters` allowed any letter from the alphabet, which is not correct since they are always hexadecimal representation. Also seemed kind of arbitrary that we only allowed lowercase, so changed that too.

Closes IRO-1797 (probably)

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
