### PR TITLE
feat(ironfish): Don't parse messages if websocket connection receives non-buffer

### DIFF
--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -78,11 +78,14 @@ export class WebSocketConnection extends Connection {
     }
 
     this.socket.onmessage = (event: MessageEvent) => {
+      if (!Buffer.isBuffer(event.data)) {
+        return
+      }
+
       let message
       try {
-        const bufferData = Buffer.from(event.data)
-        message = this.parseMessage(bufferData)
-        const byteCount = bufferData.byteLength
+        message = this.parseMessage(event.data)
+        const byteCount = event.data.byteLength
         this.metrics?.p2p_InboundTraffic.add(byteCount)
         this.metrics?.p2p_InboundTraffic_WS.add(byteCount)
       } catch (error) {

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -79,6 +79,9 @@ export class WebSocketConnection extends Connection {
 
     this.socket.onmessage = (event: MessageEvent) => {
       if (!Buffer.isBuffer(event.data)) {
+        const message = 'Received non-buffer message'
+        this.logger.warn(message, event.data)
+        this.close(new NetworkError(message))
         return
       }
 


### PR DESCRIPTION
## Summary

See title

## Testing Plan

Run node

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
