### PR TITLE
Refactor WebAPI .catch to always surface error message

### DIFF
--- a/ironfish/src/rpc/routes/faucet/getFunds.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.ts
@@ -44,14 +44,14 @@ router.register<typeof GetFundsRequestSchema, GetFundsResponse>(
       .catch((error: AxiosError<{ code: string; message?: string }>) => {
         if (error.response) {
           const { data, status } = error.response
-          if (data.code === 'faucet_max_requests_reached' && data.message) {
-            throw new ResponseError(data.message, ERROR_CODES.ERROR, status)
-          } else if (status === 422) {
+          if (status === 422) {
             throw new ResponseError(
               'You entered an invalid email.',
               ERROR_CODES.VALIDATION,
               status,
             )
+          } else if (data.message) {
+            throw new ResponseError(data.message, ERROR_CODES.ERROR, status)
           }
         }
 


### PR DESCRIPTION
## Summary

Previously, it was special-cased to only surface the error message if it was a specific error type. This change allows it to function the same way for any error given that it has a custom message to surface.

![image](https://user-images.githubusercontent.com/97762857/166725756-99c9ee68-5ad2-4765-9f54-384c003fe34f.png)


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
