### PR TITLE
Update reset command to work with database changes

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -44,7 +44,8 @@ export default class Reset extends IronfishCommand {
     confirmed = flags.confirm || (await CliUx.ux.confirm(warningMessage))
 
     if (!confirmed) {
-      this.exit(1)
+      this.log('Reset aborted.')
+      this.exit(0)
     }
 
     const accountDatabasePath = this.sdk.config.accountDatabasePath
@@ -59,7 +60,8 @@ export default class Reset extends IronfishCommand {
     confirmed = flags.confirm || (await CliUx.ux.confirm(message))
 
     if (!confirmed) {
-      this.exit(1)
+      this.log('Reset aborted.')
+      this.exit(0)
     }
 
     CliUx.ux.action.start('Deleting databases...')

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -1,11 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { IronfishNode, NodeUtils, PeerNetwork } from '@ironfish/sdk'
+import { IronfishNode, NodeUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import fs from 'fs'
 import fsAsync from 'fs/promises'
-import path from 'path'
 import { IronfishCommand } from '../command'
 import {
   ConfigFlag,
@@ -34,65 +32,48 @@ export default class Reset extends IronfishCommand {
 
   node: IronfishNode | null = null
 
-  peerNetwork: PeerNetwork | null = null
-
   async start(): Promise<void> {
     const { flags } = await this.parse(Reset)
 
-    let node = await this.sdk.node({ autoSeed: false })
-    await NodeUtils.waitForOpen(node, null, { upgrade: false, load: false })
+    let confirmed = flags.confirm
 
-    const backupPath = path.join(this.sdk.config.dataDir, 'accounts.backup.json')
+    const warningMessage =
+      `\n/!\\ WARNING: This will permanently delete your accounts. You can back them up by loading the previous version of ironfish and running ironfish export. /!\\\n` +
+      '\nHave you read the warning? (Y)es / (N)o'
 
-    if (fs.existsSync(backupPath)) {
-      this.log(`There is already an account backup at ${backupPath}`)
-
-      const confirmed = await CliUx.ux.confirm(
-        `\nThis means this failed to run. Delete the accounts backup?\nAre you sure? (Y)es / (N)o`,
-      )
-
-      if (!confirmed) {
-        this.exit(1)
-      }
-
-      fs.rmSync(backupPath)
-    }
-
-    const confirmed =
-      flags.confirm ||
-      (await CliUx.ux.confirm(
-        `\nYou are about to destroy your node data at ${node.config.dataDir}\nAre you sure? (Y)es / (N)o`,
-      ))
+    confirmed = flags.confirm || (await CliUx.ux.confirm(warningMessage))
 
     if (!confirmed) {
-      return
+      this.exit(1)
     }
 
-    const accounts = node.accounts.listAccounts()
-    this.log(`Backing up ${accounts.length} accounts to ${backupPath}`)
-    const backup = JSON.stringify(accounts, undefined, '  ')
-    await fsAsync.writeFile(backupPath, backup)
-    await node.closeDB()
+    const accountDatabasePath = this.sdk.config.accountDatabasePath
+    const chainDatabasePath = this.sdk.config.chainDatabasePath
 
-    CliUx.ux.action.start('Deleting databases')
+    const message =
+      '\nYou are about to destroy your node databases. The following directories will be deleted:\n' +
+      `\nAccounts: ${accountDatabasePath}` +
+      `\nBlockchain: ${chainDatabasePath}` +
+      `\n\nAre you sure? (Y)es / (N)o`
+
+    confirmed = flags.confirm || (await CliUx.ux.confirm(message))
+
+    if (!confirmed) {
+      this.exit(1)
+    }
+
+    CliUx.ux.action.start('Deleting databases...')
 
     await Promise.all([
-      fsAsync.rm(node.config.accountDatabasePath, { recursive: true }),
-      fsAsync.rm(node.config.chainDatabasePath, { recursive: true }),
+      fsAsync.rm(accountDatabasePath, { recursive: true, force: true }),
+      fsAsync.rm(chainDatabasePath, { recursive: true, force: true }),
     ])
 
-    CliUx.ux.action.status = `Importing ${accounts.length} accounts`
-
-    // We create a new node because the old node has cached account data
-    node = await this.sdk.node()
-    await node.openDB()
-    await Promise.all(accounts.map((a) => node.accounts.importAccount(a)))
-    await node.closeDB()
-
+    // Re-initialize the databases
+    const node = await this.sdk.node()
+    await NodeUtils.waitForOpen(node)
     node.internal.set('isFirstRun', true)
     await node.internal.save()
-
-    await fsAsync.rm(backupPath)
 
     CliUx.ux.action.stop('Reset the node successfully.')
   }

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -17,7 +17,7 @@ import {
 } from '../flags'
 
 export default class Reset extends IronfishCommand {
-  static description = 'Reset the node to a fresh state but preserve accounts'
+  static description = 'Reset the node to its initial state'
 
   static flags = {
     [VerboseFlagKey]: VerboseFlag,


### PR DESCRIPTION
## Summary

When starting a node after the database version has been increased, a warning pops up indicating the user should run `ironfish reset`.

However, the reset command also loads some database data in order to attempt to back up the accounts. This will fail, since the database structure has changed. Regardless, the command would never actually back up the accounts, since it doesn't try to load accounts from the database before writing out the backup file.

I think the main use case of the reset command should be to set the databases back to their original state, and upgrading the database should be covered by the database migration project, when that's completed. To this effect, I added an additional warning that running this command will delete your accounts.

### Example CLI output

```
/!\ WARNING: This will permanently delete your accounts. You can back them up by loading the previous version of ironfish and running ironfish export. /!\

Have you read the warning? (Y)es / (N)o: Y

You are about to destroy your node databases. The following directories will be deleted:

Accounts: /Users/derek/.ironfish-1/accounts/default
Blockchain: /Users/derek/.ironfish-1/databases/default

Are you sure? (Y)es / (N)o: N
```

## Testing Plan

Try running reset locally and ensure it deletes everything.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
