### PR TITLE
Remove indices from merkle tree database values

### DIFF
--- a/ironfish/src/merkletree/database/leaves.test.ts
+++ b/ironfish/src/merkletree/database/leaves.test.ts
@@ -17,7 +17,6 @@ describe('NoteLeafEncoding', () => {
     const noteEncrypted = new NoteEncrypted(txp.getNote(0))
 
     const noteLeafValue = {
-      index: 7,
       element: noteEncrypted,
       merkleHash: Buffer.alloc(32, 'hashOfSibling'),
       parentIndex: 14,
@@ -34,7 +33,6 @@ describe('NullifierLeafEncoding', () => {
     const encoding = new NullifierLeafEncoding()
 
     const nullifierLeafValue = {
-      index: 7,
       element: Buffer.alloc(32, 'element'),
       merkleHash: Buffer.alloc(32, 'hashOfSibling'),
       parentIndex: 14,

--- a/ironfish/src/merkletree/database/leaves.ts
+++ b/ironfish/src/merkletree/database/leaves.ts
@@ -7,7 +7,6 @@ import bufio from 'bufio'
 import { NoteEncrypted } from '../../primitives/noteEncrypted'
 
 export interface LeafValue<T> {
-  index: number
   element: T
   merkleHash: Buffer
   parentIndex: number
@@ -24,7 +23,6 @@ export class NoteLeafEncoding implements IDatabaseEncoding<NoteLeafValue> {
   serialize(value: NoteLeafValue): Buffer {
     const bw = bufio.write(this.getSize())
 
-    bw.writeU32(value.index)
     bw.writeBytes(value.element.serialize())
     bw.writeHash(value.merkleHash)
     bw.writeU32(value.parentIndex)
@@ -35,13 +33,11 @@ export class NoteLeafEncoding implements IDatabaseEncoding<NoteLeafValue> {
   deserialize(buffer: Buffer): NoteLeafValue {
     const reader = bufio.read(buffer, true)
 
-    const index = reader.readU32()
     const element = new NoteEncrypted(reader.readBytes(NOTE_BYTES))
     const merkleHash = reader.readHash()
     const parentIndex = reader.readU32()
 
     return {
-      index,
       element,
       merkleHash,
       parentIndex,
@@ -50,7 +46,6 @@ export class NoteLeafEncoding implements IDatabaseEncoding<NoteLeafValue> {
 
   getSize(): number {
     let size = 0
-    size += 4 // index
     size += NOTE_BYTES // element
     size += 32 // merkleHash
     size += 4 // parentIndex
@@ -62,7 +57,6 @@ export class NullifierLeafEncoding implements IDatabaseEncoding<NullifierLeafVal
   serialize(value: NullifierLeafValue): Buffer {
     const bw = bufio.write(this.getSize())
 
-    bw.writeU32(value.index)
     bw.writeBytes(value.element)
     bw.writeHash(value.merkleHash)
     bw.writeU32(value.parentIndex)
@@ -73,13 +67,11 @@ export class NullifierLeafEncoding implements IDatabaseEncoding<NullifierLeafVal
   deserialize(buffer: Buffer): NullifierLeafValue {
     const reader = bufio.read(buffer, true)
 
-    const index = reader.readU32()
     const element = reader.readBytes(NULLIFIER_BYTES)
     const merkleHash = reader.readHash()
     const parentIndex = reader.readU32()
 
     return {
-      index,
       element,
       merkleHash,
       parentIndex,
@@ -88,7 +80,6 @@ export class NullifierLeafEncoding implements IDatabaseEncoding<NullifierLeafVal
 
   getSize(): number {
     let size = 0
-    size += 4 // index
     size += NULLIFIER_BYTES // element
     size += 32 // merkleHash
     size += 4 // parentIndex

--- a/ironfish/src/merkletree/database/nodes.test.ts
+++ b/ironfish/src/merkletree/database/nodes.test.ts
@@ -9,7 +9,6 @@ describe('NodeEncoding', () => {
     const encoding = new NodeEncoding()
 
     const leftNodeValue = {
-      index: 7,
       side: Side.Left,
       hashOfSibling: Buffer.alloc(32, 'hashOfSibling'),
       parentIndex: 14,
@@ -24,7 +23,6 @@ describe('NodeEncoding', () => {
     const encoding = new NodeEncoding()
 
     const rightNodeValue = {
-      index: 7,
       side: Side.Right,
       hashOfSibling: Buffer.alloc(32, 'hashOfSibling'),
       leftIndex: 14,

--- a/ironfish/src/merkletree/database/nodes.ts
+++ b/ironfish/src/merkletree/database/nodes.ts
@@ -9,14 +9,12 @@ import { Side } from '../merkletree'
 export type NodeValue<H> = LeftNodeValue<H> | RightNodeValue<H>
 
 type LeftNodeValue<H> = {
-  index: number
   side: Side.Left
   hashOfSibling: H
   parentIndex: number // left nodes have a parent index
 }
 
 type RightNodeValue<H> = {
-  index: number
   side: Side.Right
   hashOfSibling: H
   leftIndex: number // right nodes have a left index
@@ -26,7 +24,6 @@ export class NodeEncoding implements IDatabaseEncoding<NodeValue<Buffer>> {
   serialize(value: NodeValue<Buffer>): Buffer {
     const bw = bufio.write(this.getSize())
 
-    bw.writeU32(value.index)
     bw.writeHash(value.hashOfSibling)
 
     if (value.side === Side.Left) {
@@ -43,7 +40,6 @@ export class NodeEncoding implements IDatabaseEncoding<NodeValue<Buffer>> {
   deserialize(buffer: Buffer): NodeValue<Buffer> {
     const reader = bufio.read(buffer, true)
 
-    const index = reader.readU32()
     const hashOfSibling = reader.readHash()
 
     const sideNumber = reader.readU8()
@@ -53,7 +49,6 @@ export class NodeEncoding implements IDatabaseEncoding<NodeValue<Buffer>> {
 
     if (side === Side.Left) {
       const leftNode: LeftNodeValue<Buffer> = {
-        index,
         side,
         hashOfSibling,
         parentIndex: otherIndex,
@@ -62,7 +57,6 @@ export class NodeEncoding implements IDatabaseEncoding<NodeValue<Buffer>> {
     }
 
     const rightNode: RightNodeValue<Buffer> = {
-      index,
       side,
       hashOfSibling,
       leftIndex: otherIndex,
@@ -72,7 +66,6 @@ export class NodeEncoding implements IDatabaseEncoding<NodeValue<Buffer>> {
 
   getSize(): number {
     let size = 0
-    size += 4 // index
     size += 1 // side
     size += 32 // merkleHash
     size += 4 // parentIndex

--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -237,7 +237,6 @@ export class MerkleTree<
             element: leftLeaf.element,
             merkleHash: leftLeaf.merkleHash,
             parentIndex: newParentIndex,
-            index: leftLeafIndex,
           },
           tx,
         )
@@ -350,7 +349,6 @@ export class MerkleTree<
           element,
           merkleHash,
           parentIndex: newParentIndex,
-          index: indexOfNewLeaf,
         },
         tx,
       )
@@ -360,14 +358,13 @@ export class MerkleTree<
   }
 
   async addLeaf(
-    index: LeafIndex,
-    value: { index: LeafIndex; element: E; merkleHash: H; parentIndex: NodeIndex },
+    index: LeavesSchema<E, H>['key'],
+    value: LeavesSchema<E, H>['value'],
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.leaves.put(
       index,
       {
-        index: index,
         element: value.element,
         merkleHash: value.merkleHash,
         parentIndex: value.parentIndex,
@@ -412,9 +409,10 @@ export class MerkleTree<
       if (pastSize === 1) {
         await this.counter.put('Nodes', 1, tx)
 
-        const firstLeaf = await this.getLeaf(0, tx)
+        const index = 0
+        const firstLeaf = await this.getLeaf(index, tx)
         firstLeaf.parentIndex = 0
-        await this.addLeaf(firstLeaf.index, firstLeaf, tx)
+        await this.addLeaf(index, firstLeaf, tx)
         return
       }
 

--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -226,7 +226,6 @@ export class MerkleTree<
             side: Side.Left,
             parentIndex: 0,
             hashOfSibling,
-            index: newParentIndex,
           },
           tx,
         )
@@ -298,7 +297,6 @@ export class MerkleTree<
                   side: Side.Left,
                   hashOfSibling: previousParent.hashOfSibling,
                   parentIndex: nextNodeIndex,
-                  index: previousParentIndex,
                 },
                 tx,
               )
@@ -445,7 +443,7 @@ export class MerkleTree<
       }
 
       parent.parentIndex = 0
-      await this.nodes.put(parent.index, parent, tx)
+      await this.nodes.put(parentIndex, parent, tx)
       await this.counter.put('Nodes', maxParentIndex + 1, tx)
       await this.rehashRightPath(tx)
     })
@@ -647,7 +645,6 @@ export class MerkleTree<
               side: Side.Left,
               hashOfSibling: parentHash,
               parentIndex: node.parentIndex,
-              index: parentIndex,
             },
             tx,
           )
@@ -662,7 +659,7 @@ export class MerkleTree<
           // hash because we set it correctly when we inserted it. But the left
           // node needs to have its hashOfSibling set to our current hash.
           if (node.leftIndex === undefined) {
-            throw new Error(`Expected node ${node.index} to have left node`)
+            throw new Error(`Expected node ${parentIndex} to have left node`)
           }
 
           const leftNode = await this.getNode(node.leftIndex, tx)
@@ -673,7 +670,6 @@ export class MerkleTree<
               side: Side.Left,
               parentIndex: leftNode.parentIndex,
               hashOfSibling: parentHash,
-              index: node.leftIndex,
             },
             tx,
           )

--- a/ironfish/src/merkletree/schema.ts
+++ b/ironfish/src/merkletree/schema.ts
@@ -15,7 +15,6 @@ export type CounterSchema = CounterEntry<'Leaves'> | CounterEntry<'Nodes'>
 export interface LeavesSchema<E, H> extends DatabaseSchema {
   key: LeafIndex
   value: {
-    index: LeafIndex
     element: E
     merkleHash: H
     parentIndex: NodeIndex

--- a/ironfish/src/merkletree/schema.ts
+++ b/ironfish/src/merkletree/schema.ts
@@ -27,7 +27,6 @@ export interface LeavesIndexSchema<H extends DatabaseKey> extends DatabaseSchema
 }
 
 export type NodeValue<H> = {
-  index: NodeIndex
   side: Side
   hashOfSibling: H
   parentIndex?: NodeIndex // left nodes have a parent index

--- a/ironfish/src/testUtilities/helpers/merkletree.ts
+++ b/ironfish/src/testUtilities/helpers/merkletree.ts
@@ -46,7 +46,6 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
   serialize(value: NodeValue<string>): Buffer {
     const bw = bufio.write()
 
-    bw.writeU32(value.index)
     bw.writeVarString(value.hashOfSibling)
 
     if (value.side === Side.Left) {
@@ -63,7 +62,6 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
   deserialize(buffer: Buffer): NodeValue<string> {
     const reader = bufio.read(buffer, true)
 
-    const index = reader.readU32()
     const hashOfSibling = reader.readVarString()
 
     const sideNumber = reader.readU8()
@@ -73,7 +71,6 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
 
     if (side === Side.Left) {
       const leftNode = {
-        index,
         side,
         hashOfSibling,
         parentIndex: otherIndex,
@@ -82,7 +79,6 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
     }
 
     const rightNode = {
-      index,
       side,
       hashOfSibling,
       leftIndex: otherIndex,

--- a/ironfish/src/testUtilities/helpers/merkletree.ts
+++ b/ironfish/src/testUtilities/helpers/merkletree.ts
@@ -11,7 +11,6 @@ import { IDatabase, IDatabaseEncoding, StringEncoding } from '../../storage'
 import { createDB } from '../helpers/storage'
 
 type StructureLeafValue = {
-  index: number
   element: string
   merkleHash: string
   parentIndex: number
@@ -21,7 +20,6 @@ class StructureLeafEncoding implements IDatabaseEncoding<StructureLeafValue> {
   serialize(value: StructureLeafValue): Buffer {
     const bw = bufio.write()
 
-    bw.writeU32(value.index)
     bw.writeVarString(value.element)
     bw.writeVarString(value.merkleHash)
     bw.writeU32(value.parentIndex)
@@ -32,13 +30,11 @@ class StructureLeafEncoding implements IDatabaseEncoding<StructureLeafValue> {
   deserialize(buffer: Buffer): StructureLeafValue {
     const bw = bufio.read(buffer, true)
 
-    const index = bw.readU32()
     const element = bw.readVarString()
     const merkleHash = bw.readVarString()
     const parentIndex = bw.readU32()
 
     return {
-      index,
       element,
       merkleHash,
       parentIndex,

--- a/ironfish/src/testUtilities/matchers/merkletree.ts
+++ b/ironfish/src/testUtilities/matchers/merkletree.ts
@@ -83,7 +83,6 @@ expect.extend({
         hashOfSibling,
         leftIndex: otherIndex,
         parentIndex: otherIndex,
-        index,
       }
 
       let expected


### PR DESCRIPTION
## Summary

The merkle tree is storing the keys of the database as fields on the value object as well. This is unnecessary, since they're always the same in both places, so we can remove them from the values object.

## Testing Plan

Connected two nodes and mined on both of them

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
