### PR TITLE
Fix block hash rename

### DIFF
--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -71,10 +71,10 @@ export class WebApi {
 
   async headBlocks(): Promise<string | null> {
     const response = await axios
-      .get<{ block_hash: string }>(`${this.host}/blocks/head`)
+      .get<{ hash: string }>(`${this.host}/blocks/head`)
       .catch(() => null)
 
-    return response?.data.block_hash || null
+    return response?.data.hash || null
   }
 
   async uploadDeposits(deposits: ApiDepositUpload[]): Promise<void> {


### PR DESCRIPTION
## Summary
Block head response was accidentally renamed from `.hash` to `.block_hash` in https://github.com/iron-fish/ironfish/pull/1181. Fixing that change here

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
