### PR TITLE
Make target configurable in genesis block creation

### DIFF
--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -1,7 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { GenesisBlockInfo, IJSON, makeGenesisBlock } from '@ironfish/sdk'
+import {
+  GENESIS_SUPPLY_IN_IRON,
+  GenesisBlockInfo,
+  IJSON,
+  ironToOre,
+  makeGenesisBlock,
+  Target,
+} from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
@@ -17,13 +24,11 @@ export default class GenesisBlockCommand extends IronfishCommand {
       char: 'a',
       required: false,
       default: 'IronFishGenesisAccount',
-      description: 'the name of the account to use for keys to assign the genesis block to',
+      description: 'The name of the account to use for keys to assign the genesis block to',
     }),
-    coins: Flags.integer({
-      char: 'c',
-      required: false,
-      default: 4200000000000000,
-      description: 'The amount of coins to generate',
+    difficulty: Flags.string({
+      default: Target.minDifficulty().toString(),
+      description: 'The initial difficulty to start the chain with',
     }),
     memo: Flags.string({
       char: 'm',
@@ -35,6 +40,13 @@ export default class GenesisBlockCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(GenesisBlockCommand)
+
+    let target
+    try {
+      target = Target.fromDifficulty(BigInt(flags.difficulty))
+    } catch {
+      this.error(`Invalid value for difficulty: ${flags.difficulty}`, { exit: 1 })
+    }
 
     const node = await this.sdk.node({ autoSeed: false })
     await node.openDB()
@@ -62,22 +74,17 @@ export default class GenesisBlockCommand extends IronfishCommand {
     const info: GenesisBlockInfo = {
       timestamp: Date.now(),
       memo: flags.memo,
+      target,
       allocations: [
         {
           publicAddress: account.publicAddress,
-          amount: flags.coins,
+          amount: ironToOre(GENESIS_SUPPLY_IN_IRON),
         },
       ],
     }
 
     this.log('\nBuilding a genesis block...')
-    const { block } = await makeGenesisBlock(
-      node.chain,
-      info,
-      account,
-      node.workerPool,
-      this.logger,
-    )
+    const { block } = await makeGenesisBlock(node.chain, info, account, this.logger)
 
     this.log(`\nGenesis Block`)
     const serialized = node.strategy.blockSerde.serialize(block)

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -201,7 +201,6 @@ export default class Start extends IronfishCommand {
     }
 
     const newSecretKey = Buffer.from(
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       node.peerNetwork.localPeer.privateIdentity.secretKey,
     ).toString('hex')
     node.internal.set('networkIdentity', newSecretKey)

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -868,7 +868,7 @@ export class Blockchain {
       if (!this.hasGenesisBlock) {
         previousBlockHash = GENESIS_BLOCK_PREVIOUS
         previousSequence = 0
-        target = Target.initialTarget()
+        target = Target.maxTarget()
       } else {
         const heaviestHead = this.head
         if (

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -74,6 +74,7 @@ describe('Create genesis block', () => {
     const info = {
       timestamp: Date.now(),
       memo: 'test',
+      target: Target.maxTarget(),
       allocations: [
         {
           amount: amountNumber,
@@ -83,11 +84,11 @@ describe('Create genesis block', () => {
     }
 
     // Build the genesis block itself
-    const { block } = await makeGenesisBlock(chain, info, account, node.workerPool, node.logger)
+    const { block } = await makeGenesisBlock(chain, info, account, node.logger)
 
     // Check some parameters on it to make sure they match what's expected.
     expect(block.header.timestamp.valueOf()).toEqual(info.timestamp)
-    expect(block.header.target.asBigInt()).toEqual(Target.initialTarget().asBigInt())
+    expect(block.header.target.asBigInt()).toEqual(Target.maxTarget().asBigInt())
 
     // Balance should still be zero, since generating the block should clear out
     // any notes made in the process
@@ -134,9 +135,7 @@ describe('Create genesis block', () => {
 
     // Validate parameters again to make sure they're what's expected
     expect(deserializedBlock.header.timestamp.valueOf()).toEqual(info.timestamp)
-    expect(deserializedBlock.header.target.asBigInt()).toEqual(
-      Target.initialTarget().asBigInt(),
-    )
+    expect(deserializedBlock.header.target.asBigInt()).toEqual(Target.maxTarget().asBigInt())
 
     await newNode.accounts.importAccount(account)
     await newNode.accounts.updateHead()

--- a/ironfish/src/genesis/genesisBlock.ts
+++ b/ironfish/src/genesis/genesisBlock.ts
@@ -2,11 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const GENESIS_HASH = Buffer.from(
-  '4655C8E9B27EEC8129830AD94C970A0AE3C2338B8CB29CBA3AB572ED65ACAC1C',
-  'hex',
-)
-
 export const genesisBlockData = `
 {
   "header": {

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -14,11 +14,11 @@ import { Block } from '../primitives'
 import { Target } from '../primitives/target'
 import { Transaction } from '../primitives/transaction'
 import { GraffitiUtils } from '../utils/graffiti'
-import { WorkerPool } from '../workerPool'
 
 export type GenesisBlockInfo = {
   memo: string
   timestamp: number
+  target: Target
   allocations: {
     publicAddress: string
     amount: number
@@ -34,7 +34,6 @@ export async function makeGenesisBlock(
   chain: Blockchain,
   info: GenesisBlockInfo,
   account: Account,
-  workerPool: WorkerPool,
   logger: Logger,
 ): Promise<{ block: Block }> {
   logger = logger.withTag('makeGenesisBlock')
@@ -148,7 +147,7 @@ export async function makeGenesisBlock(
   )
 
   // Modify the block with any custom properties.
-  block.header.target = Target.initialTarget()
+  block.header.target = info.target
   block.header.timestamp = new Date(info.timestamp)
 
   logger.info('Block complete.')

--- a/ironfish/src/primitives/index.ts
+++ b/ironfish/src/primitives/index.ts
@@ -5,4 +5,5 @@
 export { Block } from './block'
 export { BlockHeader } from './blockheader'
 export { Spend } from './spend'
+export { Target } from './target'
 export { Transaction } from './transaction'

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -57,15 +57,6 @@ export class Target {
   }
 
   /**
-   * The initial target on the genesis block.
-   *
-   * This will need to be hand-tuned.
-   */
-  static initialTarget(): Target {
-    return this.maxTarget()
-  }
-
-  /**
    * Calculate the target for the current block given the timestamp in that
    * block's header, the pervious block's timestamp and previous block's target.
    *


### PR DESCRIPTION
## Summary

Adds a `--difficulty` flag to the `chain:genesisblock` command to allow for generating a genesis block with a specific difficulty.

Also removes the `--coins` flag, since the supply curve is hardcoded to expect a certain number of coins in the genesis block anyway.

Fixes IRO-1849

## Testing Plan

Try generating a genesis block with different `--difficulty` flags and make sure the command changes the resulting `target` field. You can also try replacing `genesisBlock` and check that the mining difficulty changes.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
