### PR TITLE
Update response object for deposits head request

### DIFF
--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -63,10 +63,10 @@ export class WebApi {
 
   async headDeposits(): Promise<string | null> {
     const response = await axios
-      .get<{ hash: string }>(`${this.host}/deposits/head`)
+      .get<{ block_hash: string }>(`${this.host}/deposits/head`)
       .catch(() => null)
 
-    return response?.data.hash || null
+    return response?.data.block_hash || null
   }
 
   async headBlocks(): Promise<string | null> {


### PR DESCRIPTION
## Summary
`deposits/head` returns `{block_hash: ""}` instead of `{hash: ""}`

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
