### PR TITLE
Deposit cmd shows tx confirmation fee in correct denomination

### DIFF
--- a/ironfish-cli/src/commands/deposit.ts
+++ b/ironfish-cli/src/commands/deposit.ts
@@ -164,7 +164,7 @@ Depositing ${displayIronAmountWithCurrency(IRON_TO_SEND, true)} from ${
         transaction.fromAccountName
       }
 Transaction Hash: ${transaction.hash}
-Transaction fee: ${displayIronAmountWithCurrency(fee, true)}
+Transaction fee: ${displayIronAmountWithCurrency(feeInIron, true)}
 
 Find the transaction on https://explorer.ironfish.network/transaction/${
         transaction.hash


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/97762857/167456089-6dd4dd89-6438-480e-9844-37aa947a3185.png)


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
