### PR TITLE
Any user-inputtable strings being serialized use utf8 encoding

### DIFF
--- a/ironfish/src/account/database/accounts.test.ts
+++ b/ironfish/src/account/database/accounts.test.ts
@@ -11,7 +11,7 @@ describe('AccountsValueEncoding', () => {
 
       const key = generateKey()
       const value: AccountsValue = {
-        name: 'foobar',
+        name: 'foobar👁️🏃🐟',
         incomingViewKey: key.incoming_view_key,
         outgoingViewKey: key.outgoing_view_key,
         publicAddress: key.public_address,
@@ -30,7 +30,7 @@ describe('AccountsValueEncoding', () => {
 
       const key = generateKey()
       const value: AccountsValue = {
-        name: 'foobar',
+        name: 'foobar👁️🏃🐟',
         incomingViewKey: key.incoming_view_key,
         outgoingViewKey: key.outgoing_view_key,
         publicAddress: key.public_address,

--- a/ironfish/src/account/database/accounts.ts
+++ b/ironfish/src/account/database/accounts.ts
@@ -19,7 +19,7 @@ export interface AccountsValue {
 export class AccountsValueEncoding implements IDatabaseEncoding<AccountsValue> {
   serialize(value: AccountsValue): Buffer {
     const bw = bufio.write(this.getSize(value))
-    bw.writeVarString(value.name)
+    bw.writeVarString(value.name, 'utf8')
     bw.writeBytes(Buffer.from(value.spendingKey, 'hex'))
     bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
     bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
@@ -34,7 +34,7 @@ export class AccountsValueEncoding implements IDatabaseEncoding<AccountsValue> {
 
   deserialize(buffer: Buffer): AccountsValue {
     const reader = bufio.read(buffer, true)
-    const name = reader.readVarString()
+    const name = reader.readVarString('utf8')
     const spendingKey = reader.readBytes(KEY_LENGTH).toString('hex')
     const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
     const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
@@ -56,7 +56,7 @@ export class AccountsValueEncoding implements IDatabaseEncoding<AccountsValue> {
   }
 
   getSize(value: AccountsValue): number {
-    let size = bufio.sizeVarString(value.name)
+    let size = bufio.sizeVarString(value.name, 'utf8')
     size += KEY_LENGTH
     size += KEY_LENGTH
     size += KEY_LENGTH

--- a/ironfish/src/account/database/meta.test.ts
+++ b/ironfish/src/account/database/meta.test.ts
@@ -19,7 +19,7 @@ describe('MetaValueEncoding', () => {
     it('serializes the value into a buffer and deserializes to the original value', () => {
       const encoder = new MetaValueEncoding()
 
-      const value: MetaValue = 'foobar'
+      const value: MetaValue = 'foobar👁️🏃🐟'
       const buffer = encoder.serialize(value)
       const deserializedValue = encoder.deserialize(buffer)
       expect(deserializedValue).toEqual(value)

--- a/ironfish/src/account/database/meta.ts
+++ b/ironfish/src/account/database/meta.ts
@@ -15,7 +15,7 @@ export class MetaValueEncoding implements IDatabaseEncoding<MetaValue> {
   serialize(value: MetaValue): Buffer {
     const bw = bufio.write(this.getSize(value))
     if (value) {
-      bw.writeVarString(value)
+      bw.writeVarString(value, 'utf8')
     }
     return bw.render()
   }
@@ -23,7 +23,7 @@ export class MetaValueEncoding implements IDatabaseEncoding<MetaValue> {
   deserialize(buffer: Buffer): MetaValue {
     const reader = bufio.read(buffer, true)
     if (reader.left()) {
-      return reader.readVarString()
+      return reader.readVarString('utf8')
     }
     return null
   }
@@ -32,6 +32,6 @@ export class MetaValueEncoding implements IDatabaseEncoding<MetaValue> {
     if (!value) {
       return 0
     }
-    return bufio.sizeVarString(value)
+    return bufio.sizeVarString(value, 'utf8')
   }
 }

--- a/ironfish/src/network/messages/identify.test.ts
+++ b/ironfish/src/network/messages/identify.test.ts
@@ -7,10 +7,10 @@ import { IdentifyMessage } from './identify'
 describe('IdentifyMessage', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
     const message = new IdentifyMessage({
-      agent: 'agent',
+      agent: 'agent👁️🏃🐟',
       head: Buffer.alloc(32, 'head'),
       identity: Buffer.alloc(identityLength, 'identity').toString('base64'),
-      name: 'name',
+      name: 'name👁️🏃🐟',
       port: 9033,
       sequence: 1,
       version: 1,

--- a/ironfish/src/network/messages/identify.ts
+++ b/ironfish/src/network/messages/identify.ts
@@ -52,10 +52,10 @@ export class IdentifyMessage extends NetworkMessage {
   serialize(): Buffer {
     const bw = bufio.write(this.getSize())
     bw.writeBytes(Buffer.from(this.identity, 'base64'))
-    bw.writeVarString(this.name)
+    bw.writeVarString(this.name, 'utf8')
     bw.writeU16(this.port)
     bw.writeU16(this.version)
-    bw.writeVarString(this.agent)
+    bw.writeVarString(this.agent, 'utf8')
     bw.writeU32(this.sequence)
     bw.writeHash(this.head)
     bw.writeVarBytes(BigIntUtils.toBytesLE(this.work))
@@ -65,10 +65,10 @@ export class IdentifyMessage extends NetworkMessage {
   static deserialize(buffer: Buffer): IdentifyMessage {
     const reader = bufio.read(buffer, true)
     const identity = reader.readBytes(identityLength).toString('base64')
-    const name = reader.readVarString()
+    const name = reader.readVarString('utf8')
     const port = reader.readU16()
     const version = reader.readU16()
-    const agent = reader.readVarString()
+    const agent = reader.readVarString('utf8')
     const sequence = reader.readU32()
     const head = reader.readHash()
     const work = BigIntUtils.fromBytesLE(reader.readVarBytes())
@@ -87,10 +87,10 @@ export class IdentifyMessage extends NetworkMessage {
   getSize(): number {
     let size = 0
     size += identityLength
-    size += bufio.sizeVarString(this.name)
+    size += bufio.sizeVarString(this.name, 'utf8')
     size += 2 // port
     size += 2 // version
-    size += bufio.sizeVarString(this.agent)
+    size += bufio.sizeVarString(this.agent, 'utf8')
     size += 4 // sequence
     size += 32 // head
     size += bufio.sizeVarBytes(BigIntUtils.toBytesLE(this.work))

--- a/ironfish/src/workerPool/tasks/getUnspentNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/getUnspentNotes.test.ts
@@ -24,7 +24,7 @@ describe('GetUnspentNotesResponse', () => {
   it('serializes the object to a buffer and deserializes to the original object', () => {
     const notes = [
       {
-        account: 'foo',
+        account: 'foo👁️🏃🐟',
         hash: 'bar',
         note: Buffer.from('baz'),
       },

--- a/ironfish/src/workerPool/tasks/getUnspentNotes.ts
+++ b/ironfish/src/workerPool/tasks/getUnspentNotes.ts
@@ -76,7 +76,7 @@ export class GetUnspentNotesResponse extends WorkerMessage {
     const bw = bufio.write(this.getSize())
     bw.writeU64(this.notes.length)
     for (const note of this.notes) {
-      bw.writeVarString(note.account)
+      bw.writeVarString(note.account, 'utf8')
       bw.writeVarString(note.hash)
       bw.writeVarBytes(note.note)
     }
@@ -89,7 +89,7 @@ export class GetUnspentNotesResponse extends WorkerMessage {
 
     const notesLength = reader.readU64()
     for (let i = 0; i < notesLength; i++) {
-      const account = reader.readVarString()
+      const account = reader.readVarString('utf8')
       const hash = reader.readVarString()
       const note = reader.readVarBytes()
       notes.push({ account, hash, note })
@@ -101,7 +101,7 @@ export class GetUnspentNotesResponse extends WorkerMessage {
   getSize(): number {
     let size = 8
     for (const note of this.notes) {
-      size += bufio.sizeVarString(note.account)
+      size += bufio.sizeVarString(note.account, 'utf8')
       size += bufio.sizeVarString(note.hash)
       size += bufio.sizeVarBytes(note.note)
     }


### PR DESCRIPTION
## Summary

More serialization encoding changes for any user-inputtable strings. Continuation of #1282 

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
