### PR TITLE
Miner cmd: add hashrate as rich cli ux action

### DIFF
--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -139,6 +139,6 @@ export class Miner extends IronfishCommand {
       CliUx.ux.action.status = formatted
     }
 
-    this.updateInterval = setInterval(() => updateHashPower(), 1000)
+    this.updateInterval = setInterval(updateHashPower, 1000)
   }
 }

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -2,13 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
+  FileUtils,
   GraffitiUtils,
   isValidPublicAddress,
   MiningPoolMiner,
   MiningSoloMiner,
   parseUrl,
+  SetIntervalToken,
 } from '@ironfish/sdk'
-import { Flags } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import dns from 'dns'
 import os from 'os'
 import { IronfishCommand } from '../../command'
@@ -16,6 +18,8 @@ import { RemoteFlags } from '../../flags'
 
 export class Miner extends IronfishCommand {
   static description = `Start a miner and subscribe to new blocks for the node`
+
+  updateInterval: SetIntervalToken | null = null
 
   static flags = {
     ...RemoteFlags,
@@ -32,6 +36,11 @@ export class Miner extends IronfishCommand {
     address: Flags.string({
       char: 'a',
       description: 'the public address to receive pool payouts',
+    }),
+    richOutput: Flags.boolean({
+      default: true,
+      allowNo: true,
+      description: 'enable fancy hashpower display',
     }),
   }
 
@@ -87,7 +96,14 @@ export class Miner extends IronfishCommand {
       })
 
       miner.start()
+      if (flags.richOutput) {
+        this.displayHashrate(miner)
+      }
+
       await miner.waitForStop()
+      if (this.updateInterval) {
+        clearInterval(this.updateInterval)
+      }
     }
 
     if (!flags.pool) {
@@ -103,7 +119,26 @@ export class Miner extends IronfishCommand {
       })
 
       miner.start()
+      if (flags.richOutput) {
+        this.displayHashrate(miner)
+      }
+
       await miner.waitForStop()
+      if (this.updateInterval) {
+        clearInterval(this.updateInterval)
+      }
     }
+  }
+
+  displayHashrate(miner: MiningPoolMiner | MiningSoloMiner): void {
+    CliUx.ux.action.start(`Hashrate`)
+
+    const updateHashPower = () => {
+      const rate = Math.max(0, Math.floor(miner.hashRate.rate5s))
+      const formatted = `${FileUtils.formatHashRate(rate)}/s (${rate})`
+      CliUx.ux.action.status = formatted
+    }
+
+    this.updateInterval = setInterval(() => updateHashPower(), 1000)
   }
 }


### PR DESCRIPTION
## Summary

- Can be disabled with `--no-richOutput`

![image](https://user-images.githubusercontent.com/97762857/167496694-4821408d-2bf9-4ffa-b9a2-884122773248.png)

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
