### PR TITLE
delete the hosts.json file on a database reset

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -56,7 +56,7 @@ export default class Reset extends IronfishCommand {
     )
 
     const message =
-      '\nYou are about to destroy your node databases. The following directories will be deleted:\n' +
+      '\nYou are about to destroy your node databases. The following directories and files will be deleted:\n' +
       `\nAccounts: ${accountDatabasePath}` +
       `\nBlockchain: ${chainDatabasePath}` +
       `\nHosts File: ${hostFilePath}` +

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -59,7 +59,7 @@ export default class Reset extends IronfishCommand {
       '\nYou are about to destroy your node databases. The following directories and files will be deleted:\n' +
       `\nAccounts: ${accountDatabasePath}` +
       `\nBlockchain: ${chainDatabasePath}` +
-      `\nHosts File: ${hostFilePath}` +
+      `\nHosts: ${hostFilePath}` +
       `\n\nAre you sure? (Y)es / (N)o`
 
     confirmed = flags.confirm || (await CliUx.ux.confirm(message))

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { IronfishNode, NodeUtils } from '@ironfish/sdk'
+import { HOST_FILE_NAME, IronfishNode } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import fsAsync from 'fs/promises'
 import { IronfishCommand } from '../command'
@@ -50,11 +50,16 @@ export default class Reset extends IronfishCommand {
 
     const accountDatabasePath = this.sdk.config.accountDatabasePath
     const chainDatabasePath = this.sdk.config.chainDatabasePath
+    const hostFilePath: string = this.sdk.config.files.join(
+      this.sdk.config.dataDir,
+      HOST_FILE_NAME,
+    )
 
     const message =
       '\nYou are about to destroy your node databases. The following directories will be deleted:\n' +
       `\nAccounts: ${accountDatabasePath}` +
       `\nBlockchain: ${chainDatabasePath}` +
+      `\nHosts File: ${hostFilePath}` +
       `\n\nAre you sure? (Y)es / (N)o`
 
     confirmed = flags.confirm || (await CliUx.ux.confirm(message))
@@ -69,14 +74,9 @@ export default class Reset extends IronfishCommand {
     await Promise.all([
       fsAsync.rm(accountDatabasePath, { recursive: true, force: true }),
       fsAsync.rm(chainDatabasePath, { recursive: true, force: true }),
+      fsAsync.rm(hostFilePath, { recursive: true, force: true }),
     ])
 
-    // Re-initialize the databases
-    const node = await this.sdk.node()
-    await NodeUtils.waitForOpen(node)
-    node.internal.set('isFirstRun', true)
-    await node.internal.save()
-
-    CliUx.ux.action.stop('Reset the node successfully.')
+    CliUx.ux.action.stop('Databases deleted successfully')
   }
 }

--- a/ironfish/src/fileStores/hosts.ts
+++ b/ironfish/src/fileStores/hosts.ts
@@ -15,11 +15,13 @@ export const HostOptionsDefaults: HostsOptions = {
   priorPeers: [],
 }
 
+export const HOST_FILE_NAME = 'hosts.json'
+
 export class HostsStore extends KeyStore<HostsOptions> {
   logger: Logger
 
-  constructor(files: FileSystem, dataDir: string, configName?: string) {
-    super(files, configName || 'hosts.json', HostOptionsDefaults, dataDir)
+  constructor(files: FileSystem, dataDir: string) {
+    super(files, HOST_FILE_NAME, HostOptionsDefaults, dataDir)
     this.logger = createRootLogger()
   }
 


### PR DESCRIPTION
## Summary
After performing a mandatory upgrade, many peers in the hosts.json file will be on the older version still, so connection attempts are wasted on these peers. I'm not sure that we remove peers from hosts.json until they're disposed in the PeerManager either, so they might hang around for a while.

## Testing Plan
Locally tested

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
