### PR TITLE
delete hosts file on "ironfish reset" command

### DIFF
--- a/ironfish/src/fileStores/hosts.ts
+++ b/ironfish/src/fileStores/hosts.ts
@@ -15,11 +15,13 @@ export const HostOptionsDefaults: HostsOptions = {
   priorPeers: [],
 }
 
+export const HOST_FILE_NAME = 'hosts.json'
+
 export class HostsStore extends KeyStore<HostsOptions> {
   logger: Logger
 
-  constructor(files: FileSystem, dataDir: string, configName?: string) {
-    super(files, configName || 'hosts.json', HostOptionsDefaults, dataDir)
+  constructor(files: FileSystem, dataDir: string) {
+    super(files, HOST_FILE_NAME, HostOptionsDefaults, dataDir)
     this.logger = createRootLogger()
   }
 


### PR DESCRIPTION
## Summary
After performing a mandatory upgrade, many peers in the hosts.json file will be on the older version still, so connection attempts are wasted on these peers. I'm not sure that we remove peers from hosts.json until they're disposed in the PeerManager either, so they might hang around for a while.

## Testing Plan
Tested locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
