### PR TITLE
refactor(cli): Fix typo when starting miner

### DIFF
--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -85,7 +85,7 @@ export class Miner extends IronfishCommand {
         }
       }
 
-      this.log(`Staring to mine with public address: ${flags.address} at pool ${host}:${port}`)
+      this.log(`Starting to mine with public address: ${flags.address} at pool ${host}:${port}`)
 
       const miner = new MiningPoolMiner({
         threadCount: flags.threads,


### PR DESCRIPTION
## Summary

Fix typo `Staring` -> `Starting`

## Testing Plan

Run the node

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
