### PR TITLE
If there is no default account on startup, create one

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -210,6 +210,10 @@ export default class Start extends IronfishCommand {
       await this.firstRun(node)
     }
 
+    if (!node.accounts.getDefaultAccount()) {
+      await this.setDefaultAccount(node)
+    }
+
     await node.start()
     this.node = node
 
@@ -238,23 +242,27 @@ export default class Start extends IronfishCommand {
       this.log(` > ironfish config:set ${ENABLE_TELEMETRY_CONFIG_KEY} true`)
     }
 
-    if (!node.accounts.getDefaultAccount()) {
-      this.log('')
-
-      if (!node.accounts.accountExists(DEFAULT_ACCOUNT_NAME)) {
-        const account = await node.accounts.createAccount(DEFAULT_ACCOUNT_NAME, true)
-
-        this.log(`New default account created: ${account.name}`)
-        this.log(`Account's public address: ${account.publicAddress}`)
-      } else {
-        this.log(`The default account is now: ${DEFAULT_ACCOUNT_NAME}`)
-        await node.accounts.setDefaultAccount(DEFAULT_ACCOUNT_NAME)
-      }
-    }
-
     this.log('')
     node.internal.set('isFirstRun', false)
     node.internal.set('telemetryNodeId', uuid())
+    await node.internal.save()
+  }
+
+  /**
+   * Information displayed if there is no default account for the node
+   */
+  async setDefaultAccount(node: IronfishNode): Promise<void> {
+    if (!node.accounts.accountExists(DEFAULT_ACCOUNT_NAME)) {
+      const account = await node.accounts.createAccount(DEFAULT_ACCOUNT_NAME, true)
+
+      this.log(`New default account created: ${account.name}`)
+      this.log(`Account's public address: ${account.publicAddress}`)
+    } else {
+      this.log(`The default account is now: ${DEFAULT_ACCOUNT_NAME}`)
+      await node.accounts.setDefaultAccount(DEFAULT_ACCOUNT_NAME)
+    }
+
+    this.log('')
     await node.internal.save()
   }
 


### PR DESCRIPTION
## Summary
After running ironfish reset, the node used to create an account for the user if one didn't exist on next startup. We broke that with a [recent change](https://github.com/iron-fish/ironfish/pull/1288/files#diff-f746f6e76b029871c0e5cc11c3752b1043ac76a0cee18e8eaf8bae23ebdf916cL74) to ironfish reset. This changes functionality to not only create a default account if it's the first run but instead check every time if there are any accounts and if not, create a default.

## Testing Plan
Tested locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
