### PR TITLE
Sync transactions counts transactions in buffer instead of blocks

### DIFF
--- a/ironfish-cli/src/commands/service/syncTransactions.ts
+++ b/ironfish-cli/src/commands/service/syncTransactions.ts
@@ -14,7 +14,7 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 const RAW_MAX_UPLOAD = Number(process.env.MAX_UPLOAD)
-const MAX_UPLOAD = isNaN(RAW_MAX_UPLOAD) ? 100 : RAW_MAX_UPLOAD
+const MAX_UPLOAD = isNaN(RAW_MAX_UPLOAD) ? 500 : RAW_MAX_UPLOAD
 const NEAR_SYNC_THRESHOLD = 5
 
 export default class SyncTransactions extends IronfishCommand {
@@ -120,7 +120,11 @@ export default class SyncTransactions extends IronfishCommand {
         Math.abs(content.head.sequence - content.block.sequence) < NEAR_SYNC_THRESHOLD
 
       // Should we commit the current batch?
-      const committing = buffer.length === MAX_UPLOAD || finishing
+      let txLength = 0
+      for (const block of buffer) {
+        txLength += block.transactions.length
+      }
+      const committing = txLength >= MAX_UPLOAD || finishing
 
       this.log(
         `${content.type}: ${content.block.hash} - ${content.block.sequence}${


### PR DESCRIPTION
## Summary

For sync transactions we don't actually care about the number of blocks, but rather the number of transactions. 500 is probably low, but given the current state of the API I'd rather err on the side of caution

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
