### PR TITLE
Add a try-catch around new block creation

### DIFF
--- a/ironfish/src/rpc/routes/accounts/getPublicKey.test.ts
+++ b/ironfish/src/rpc/routes/accounts/getPublicKey.test.ts
@@ -22,7 +22,7 @@ jest.mock('@ironfish/rust-nodejs', () => {
 })
 
 describe('Route account/getPublicKey', () => {
-  const routeTest = createRouteTest()
+  const routeTest = createRouteTest(true)
   let account = {} as Account
   let publicAddress = ''
 

--- a/ironfish/src/rpc/routes/accounts/utils.test.ts
+++ b/ironfish/src/rpc/routes/accounts/utils.test.ts
@@ -7,7 +7,7 @@ import { getAccount } from './utils'
 
 describe('Accounts utils', () => {
   describe('getAccount', () => {
-    const routeTest = createRouteTest()
+    const routeTest = createRouteTest(true)
     const name = 'testAccount'
     let publicAddress = ''
 

--- a/ironfish/src/rpc/routes/mining/__fixtures__/blockTemplateStream.test.slow.ts.fixture
+++ b/ironfish/src/rpc/routes/mining/__fixtures__/blockTemplateStream.test.slow.ts.fixture
@@ -1,4 +1,70 @@
 {
+  "Block template stream does not crash on expired transactions if the chain head changes rapidly": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:6J5/vxZQBBeewmo4/tie++Mxe8sEBhG1EqEPNjAwAQA="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1652375034750,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "94CABF9BC47D28C5E9F8706A1B1EDC783E53536D2B8817F806B8103CB198C25E",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALAJhChWeoE0RZ3GITo1PVzFLlzbQyF6ZB/mwg9cr79dIBXXZhM+VX9Ps77GBdxEQK5jIqCElIZm/zfPa2Qw3W2Zy34sg2OP3gVgYN95NbGkDPER90cu5gh9aUVXetOMjwZmYAtjqFcnKnwr8bcqvAJEEmyxSfl9msrNWCoOJY6T7vfNttIEL9LJ00ZWwrNuHY3enCQ5ZjdeIsPoWDgCZ4dT8HfCfSWBJ3FDPwdh2XFwOvH8vJgoTbAAPiLkS37MQkD78Y0dmUr2WWyLF5BO68xUOrZRmXbmhlMutMpGSKchN0D0InC+ItoDCrDOs+wHcr1XJ83KG5Rh6Wd8Y2n2nTh/pTw3fVj3oJB/p7sm2BfyNzL69xL0m4N3Z5IGpdb4nx6ckY4o0g4zJ67oxgiQAUbA5M+1OcWErNEcfpHVqUYGc1C6DBIPkH9E0KwDOuVUDDKL/sixb0jYd+0qX77yzOE4EUwjGmGlGvxQYxoEam/8UQJ2t7+OAI7p1SAv8FgUSS7q3kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwDfA2UrsPuEyu0iFt/Dd8XwROenYf41DMQIZaPvkdUyRftEvD6FMO7g/mh3elptkqehtN7pu4RyYgY7IoGenAg=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAIZE6iB98M02MLN+43512pzu9dKB1ehNtrKxgy8bMhWwlvcpgdwWLt7ab0ddunowE4/r1ik6q5emIEcJ4lUBdWic5cIkJE6Jg3Q//JGdEENxe1jpnvt+Wnx22cs/u4M4VhaC1Q/yUPLQc/C7rDZz4o1Fw08+rufGMIL7rV9bno68mXSW7b9aXwNe/gVG94hO4Lg01igxO0TAgZ15nU4ZfV1HVTJnqPLYxpRqAh7xBw5HIZibPbxKVSin9Ft69qGmhTQH7NM715SEsl1N9t7P7UIsIyAzt8bY7ubOMct7Uh3yg9CdDvpk8yJseCRiuoeWKt6MvAUHMGvlvRkCSdj+TM7onn+/FlAEF57Cajj+2J774zF7ywQGEbUSoQ82MDABAAQAAAAFyZsucQNPBg7aSjVE+39Lr7YAgEcR5UvD+Tai3dqDScsSGyo+mfEHbZavQocbGmleXxqiyRhwakMk+bXUHmcNwhXU29BHzulQT1KeysGiGS0A7WCZ9wN+cgaq3pH8AQa0crJpmymKe5PkO9ShTvfNNtWduBfqso5mxhCz10TOjOZxfqiGys+W1dsdBLahbQGv0jNf0f9q6WaJvnfOQ80B8Nful90X1QD7arbuErjTpKhjv+3C+VdjdlzCsy7goRwSxJcWyPillYfrsmyrfqSdEsK+8Ha/H4KPDg6We+MiJdQue911ab7BtAVMDFWmEQWCWvniWw0TYGZ+VhCb8Ukc+dTMApsTgVIkRCNn2nzyX0UsQzb40emb5Ms8RWhyFeR3DpdjPFEk0l8U+Fc93HN67EImCZqKRtTkkFJwpGvECP+wNoAXzkoO8YWdn9HyXPDQd7J6ENIlrt/zquPLgppmMUXjoCp8fetwYhHCpEbVMlZaiT/eaZUnThb8hofW1SPmtpStUFntpnQ0HuoTiqVdfv7yPX490LSwKktkU7b0huWL/rUiwqMTMt7vXUQF4N4ahCK7UoqUzh+y5H8xC7sXPhC2q9z6o9UMARjQ2TsvtdMiDDXkXcLHSlxjFfnPT9geXttmDdXjmgusqjAi6nNttloO3/eDBjGHKNDRkLMK983ybw20Fod32HVloKMJ1ioFekednx5LSbsGtFKwDDAL+rYXUbX+A8qtDr7673i6LDqDBbjHQvotQmuu0xps1b6lOx1xAHeHR5cZXbfqWInYgBo6sTspfGre1oaIqzwJV/b3D6DXoJaFlIEsNoUIuqAYgoA4R91Lc28QMnv84Kd2uz8uXugxD19JenG6X1D4meAi1Aae47MVjBoAAUtz1JPbRa3JiX2A7tZFQJ7jPWBaoxq77SopFTRYWh4HN+dIejU9PqnSdtHGlmlq7BAmxpwGoSpsykYWrMXICXPManrQCKhdH+gtQj6Zpigoy+ZQko7Hz3KWvt8xyYlQM2pi6eU8FzX1gAflanoBJzEqyNmXJsPSwLvHTL49m9U2c6Pv58n2ij4aQrb/PvNcLU3ysH2PRhuuYn7A3bDQD//sKCPvXBg0VUxPNaK+3WQJklnSO0q4iAkgPqEkAJJlsULn3v+e7H8geQpzZp2DcbSa/0ESsTJt+Jtfv2B3lDRs3TojraOPx+I+TT4115y0+CbRbsjBvL4N0OM5Qm00PxXHs055k98uIUgov+/6E6x5VqY2cJ8eS366CF/0NE8dhfPzH+16FgPoD84Rkigjl4e9SUzbyc7t0BCPEoolFpfxyQa3pys4WJs36AfxtcCOfXvG3otdGvwa1nnqxL/a1g4KakqBTiAXuZtReawvY+ZBsPPNdJpcrg1d0VC0yyXo6wgCiBfALHjrSTH0mab+JMUHMxAaOiJ2IxBV8LJwYxDBjjxrkhC+GrsJCw=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "94CABF9BC47D28C5E9F8706A1B1EDC783E53536D2B8817F806B8103CB198C25E",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:yJl9GguJ+FriJX3EQ/jPCM8y5xXzgcGWB4uyYC5Zpio="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1652375036705,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "83790FC77217D761D43C3713BA413A3683AC286FAED88B61F293762D19FF6C8F",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAInBeI9LLlnuvrapFMlFe05fTel+hVSe4twir5lWn/31lpvIqzoNdJ7EnvktO1ZSKrcpJy9+h0swLsnczbD6cBArP/zBesUpfnFXpXhT3ltpcdIUtZ/trKqeXmyylRWwPQmTD35BwfjqpZDDxS0+XPbb2oZSKrJDY4GwrjGXivkkv4i92KMoAlZ0BaEN/Z+mnKcbdgH07Q7gfvTmC6yDiQ9xLuxCpwumFixLGC4oy+kOpY0ABmmJSdk5Mm5lWrTH1hHiD7fDQlaJFLWAQd0OZL56OriS+56MaW0nLi2oh2PMrs23PWYcd6VuYamOFv4i0MSIaLpbyLBGaSLjMorwBWiyhFaI0RUJBwoZTyMOlkpGTtMOOuqXMiRNry06f6xacKJnP7+ulqtiKsNspA2DiNxQLIyQOFs0K+ca4fQ4+wThQa6rga9FJApuVClIr9/sUFnOBSnToCKiYjPwXl85/qv6cEXne0tXufwTKfNchP1tCQ77D7csh1S+JvOcTuXg+wFnjkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQ+px4tfqvQLJ6f2lq6GwyYhb95cY+Hk8zHTH245Dh7LJZvbt4ET7h9iv7pMOeZHoKEP56XbZ/xbCSmg5SgLOAA=="
+        }
+      ]
+    }
+  ],
   "Block template stream creates a new block to be mined when chain head changes": [
     {
       "header": {
@@ -7,7 +73,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:4rPIdDN/kQWUj285aa4y0ZB9etmdQQqc55ay2TeOyTs="
+            "data": "base64:AQdpnRMf1GLuQI3kO4Ja2OSPQQFiHlKMBlbGfapX3HM="
           },
           "size": 4
         },
@@ -15,18 +81,18 @@
           "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
           "size": 1
         },
-        "target": "11857109937901178411373668864889641764174846429761593757640456602",
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1652196110680,
+        "timestamp": 1652377453425,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "46D6D8E0A6951FF25B70D7A79FE4929B20CFA79A28AFF5802E87117BCE02EA2A",
+        "hash": "37C1292A06C693A8BC2CF04B3C25669E50B3345708DE4B7EB8E26EC6949F7209",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALMyQxyFCLZSq4Pn7dPYCbK4QyDBlxuM98v+/Lk2uAoD2hsPDOU2T9eEw+bt8MqM1pgQ6XHzg1es87ejiCX/AYPXdAlLERXcjV3UO/+3xqpY056MIsBLTO0dvTNtuPRb9hdLzNe9tLNV6aSIpcbOAtNcC+w9kYP+KdSye8B6GpJn3j+aA2x7TDCpZrNGRDWk7oBBtSHxk2ws8sBk3jUKPQH7PQXID0fWj2U2hVmwFv21gV6MqUt4RS/4JMeaZrY0evkoqbbKxAzid5Bekot6vI3a5aotWwLJzKBdav1XJVIpi1qRE392PYoC4bGo7GN6NjMDzSu+KoaMVV7GkYdZX13RWFYAsPcxOjJLGa5SJuYywk829/lEtaXoobjlZwpQ2HslUv81rLvBVn4N/9l4FmQY7Fs6qN70pDAU5qKMqFuDwQr2UAgdCn6XIFJwYr2hT5JMZ4kK9+pbUsxBJb1Q+Bk6IcxLY+RhYTShbNwqjrktKQNNteilW5mf3GT09WcDG+g7AEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0/fq/Ydw9DcFHG4rufu3jcS3DvfssJZ+dkyq/xB3nt2dG4lw1TPQHBiIeNg+J3Tt4xAJGoNIOkQVv6l79sM1BA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIHgy1EbkjVJO/sDlSdC6LVWLIDYn1c5Ka/OaZAsQwa8wBTlAtWAfLQHYZOWOTDmJJcDCUB8KxAGkNSjsWH526mD5jxQ4YJnmUbUkUczsYBgOBcfoZdZOgeblp4xuYGTVxnHU9SBiUkDrkYy1o7XEIhBbbBNJnDpX35vJbpCy7F27blWaMFwe7WrjKyF7c0Is4gXUx6gGApKWbrDUSgmQnTidf4aES6wGkgESrbET2eXofa7B3ybYRI7pxMrIm4tIDQke1Lhv5+L7oQKmwC5WupJlUtyTFuhlvB/9jjM0klBzenmlnndvc7T0iJZXi0eGSLBuV4nIfb4lD21qWaTaDhYy8RIZX/g8rsv98lFFp9cohvw/cPkrDxiJyQslmrtB7VKFcQyiBrLkIV1VbzaOJykDtQhp4QTQ0jOG69XUAEWGPHcSKgVymDowjbS9kUu9kO9mvLfJHafhWxcCW/5d7+W4m1Jds7xbjTQaA88NTaLUpfgqYKso3BhFlr1k3K8NbgrgUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAzVsj5GvwGwEYG/u6CL+H3H5N/0EMOOnEBN4azTp5VuwEBMZ+2sedUiHSuN5rxf1eIoNJYToun8LQ6fOSUYSCg=="
         }
       ]
     }

--- a/ironfish/src/rpc/routes/mining/blockTemplateStream.test.slow.ts
+++ b/ironfish/src/rpc/routes/mining/blockTemplateStream.test.slow.ts
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { useMinerBlockFixture } from '../../../testUtilities'
+import { createNodeTest, useMinerBlockFixture, useTxFixture } from '../../../testUtilities'
 import { flushTimeout } from '../../../testUtilities/helpers/tests'
 import { createRouteTest } from '../../../testUtilities/routeTest'
+import { PromiseUtils } from '../../../utils'
 
 describe('Block template stream', () => {
   const routeTest = createRouteTest()
@@ -36,4 +37,76 @@ describe('Block template stream', () => {
 
     expect(createNewBlockTemplateSpy).toBeCalledTimes(1)
   }, 10000)
+
+  it('does not crash on expired transactions if the chain head changes rapidly', async () => {
+    const node = routeTest.node
+    const { chain } = routeTest.node
+    routeTest.node.config.set('miningForce', true)
+
+    const account = await node.accounts.createAccount('testAccount', true)
+
+    // Create another node
+    const nodeTest = createNodeTest()
+    await nodeTest.setup()
+    await nodeTest.accounts.importAccount(account)
+    await nodeTest.accounts.setDefaultAccount(account.name)
+
+    // Generate a block
+    const block2 = await useMinerBlockFixture(
+      nodeTest.chain,
+      2,
+      account,
+      nodeTest.node.accounts,
+    )
+
+    // Generate a transaction on that block with an expiry at sequence 3
+    await expect(nodeTest.chain).toAddBlock(block2)
+    await nodeTest.accounts.updateHead()
+    const tx = await useTxFixture(
+      nodeTest.node.accounts,
+      account,
+      account,
+      undefined,
+      undefined,
+      3,
+    )
+
+    // Generate another block
+    const block3 = await useMinerBlockFixture(nodeTest.chain, 3, account, nodeTest.accounts)
+
+    // Done with the first node, we can take it down
+    await nodeTest.teardownEach()
+    await nodeTest.teardownAll()
+
+    // Now, spy on some functions
+    const actual = node.strategy.createMinersFee
+    const [p, res] = PromiseUtils.split<void>()
+
+    jest.spyOn(node.strategy, 'createMinersFee').mockImplementation(async (a, b, c) => {
+      await p
+      return await actual.bind(node.strategy)(a, b, c)
+    })
+
+    const newBlockSpy = jest.spyOn(node.chain, 'newBlock')
+
+    // Start the request
+    const response = routeTest.adapter.requestStream('miner/blockTemplateStream')
+
+    // Add the transaction to the route mempool
+    await routeTest.node.memPool.acceptTransaction(tx)
+
+    // Add both blocks to the route node
+    await expect(chain).toAddBlock(block2)
+    await expect(chain).toAddBlock(block3)
+
+    // Resolve the createMinersSpy promise, allowing block creation to proceed to newBlock
+    res()
+
+    // Finish up the response
+    await flushTimeout()
+    await expect(response.waitForRoute()).resolves.toEqual(expect.anything())
+
+    // newBlock should have thrown an error, but the response should not have crashed
+    await expect(newBlockSpy.mock.results[2].value).rejects.toThrowError('Transaction expired')
+  }, 30000)
 })

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -35,7 +35,7 @@ const TEST_PARAMS_MULTI = {
 }
 
 describe('Transactions sendTransaction', () => {
-  const routeTest = createRouteTest()
+  const routeTest = createRouteTest(true)
 
   beforeAll(async () => {
     await routeTest.node.accounts.createAccount('existingAccount', true)

--- a/ironfish/src/testUtilities/routeTest.ts
+++ b/ironfish/src/testUtilities/routeTest.ts
@@ -75,10 +75,18 @@ export class RouteTest extends NodeTest {
 /** Call this to create a {@link RouteTest} and ensure its test lifecycle
  * methods are called properly like beforeEach, beforeAll, etc
  */
-export function createRouteTest(): RouteTest {
+export function createRouteTest(preserveState = false): RouteTest {
   const routeTest = new RouteTest()
-  beforeAll(() => routeTest.setup(), 10000)
-  afterEach(() => routeTest.teardownEach())
-  afterAll(() => routeTest.teardownAll())
+
+  if (preserveState) {
+    beforeAll(() => routeTest.setup(), 10000)
+    afterEach(() => routeTest.teardownEach())
+    afterAll(() => routeTest.teardownAll())
+  } else {
+    beforeEach(() => routeTest.setup(), 10000)
+    afterEach(() => routeTest.teardownEach())
+    afterEach(() => routeTest.teardownAll())
+  }
+
   return routeTest
 }


### PR DESCRIPTION
## Summary

Fixes the transaction expiration crash when mining. I added a test for it, but the test takes quite a bit of setup to get working, so I could use a second opinion on it.

Fixes IRO-1876

## Testing Plan

New test should pass.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
