### PR TITLE
Add rolling message counting for peers and banning them if they exceed specific amounts

### DIFF
--- a/ironfish/src/network/messages/disconnecting.ts
+++ b/ironfish/src/network/messages/disconnecting.ts
@@ -9,6 +9,7 @@ import { NetworkMessage } from './networkMessage'
 export enum DisconnectingReason {
   ShuttingDown = 0,
   Congested = 1,
+  Banned = 2,
 }
 
 interface CreateDisconnectingMessageOptions {


### PR DESCRIPTION
## Summary

The goal of this is to disallow bad actors from continuing to send arbitrary amounts of messages, valid or not, that could impede performance of your own node.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
