### PR TITLE
remove enableNativeRpcTcpAdapter flag and switch to native TCP adapter

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -43,12 +43,6 @@ export type ConfigOptions = {
   getFundsApi: string
   ipcPath: string
   /**
-   * As part of IRO-1759 we are removing 'node-ipc' for RPC. This is
-   * essentially a feature flag for enabling use of the native TCP adapter
-   * without using 'node-ipc'
-   */
-  enableNativeRpcTcpAdapter: boolean
-  /**
    * Should the mining director mine, even if we are not synced?
    * Only useful if no miner has been on the network in a long time
    * otherwise you should not turn this on or you'll create useless
@@ -226,7 +220,6 @@ export class Config extends KeyStore<ConfigOptions> {
       enableRpc: true,
       enableRpcIpc: DEFAULT_USE_RPC_IPC,
       enableRpcTcp: DEFAULT_USE_RPC_TCP,
-      enableNativeRpcTcpAdapter: false,
       enableSyncing: true,
       enableTelemetry: false,
       enableMetrics: true,

--- a/ironfish/src/rpc/adapters/ipcAdapter.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.ts
@@ -68,16 +68,10 @@ export const IpcStreamSchema: yup.ObjectSchema<IpcStream> = yup
   })
   .defined()
 
-export type IpcAdapterConnectionInfo =
-  | {
-      mode: 'ipc'
-      socketPath: string
-    }
-  | {
-      mode: 'tcp'
-      host: string
-      port: number
-    }
+export type IpcAdapterConnectionInfo = {
+  mode: 'ipc'
+  socketPath: string
+}
 
 export class IpcAdapter implements IAdapter {
   router: Router | null = null
@@ -138,13 +132,8 @@ export class IpcAdapter implements IAdapter {
         reject(error)
       }
 
-      if (this.connection.mode === 'ipc') {
-        this.logger.debug(`Serving RPC on IPC ${this.connection.socketPath}`)
-        ipc.serve(this.connection.socketPath, onServed)
-      } else if (this.connection.mode === 'tcp') {
-        this.logger.debug(`Serving RPC on TCP ${this.connection.host}:${this.connection.port}`)
-        ipc.serveNet(this.connection.host, this.connection.port, onServed)
-      }
+      this.logger.debug(`Serving RPC on IPC ${this.connection.socketPath}`)
+      ipc.serve(this.connection.socketPath, onServed)
 
       ipc.server.on('error', onError)
       ipc.server.start()

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -231,29 +231,14 @@ export class IronfishSdk {
       if (this.config.get('rpcTcpSecure')) {
         namespaces.push(ApiNamespace.account, ApiNamespace.config)
       }
-
-      if (this.config.get('enableNativeRpcTcpAdapter')) {
-        await node.rpc.mount(
-          new TcpAdapter(
-            this.config.get('rpcTcpHost'),
-            this.config.get('rpcTcpPort'),
-            this.logger,
-            namespaces,
-          ),
-        )
-      } else {
-        await node.rpc.mount(
-          new IpcAdapter(
-            namespaces,
-            {
-              mode: 'tcp',
-              host: this.config.get('rpcTcpHost'),
-              port: this.config.get('rpcTcpPort'),
-            },
-            this.logger,
-          ),
-        )
-      }
+      await node.rpc.mount(
+        new TcpAdapter(
+          this.config.get('rpcTcpHost'),
+          this.config.get('rpcTcpPort'),
+          this.logger,
+          namespaces,
+        ),
+      )
     }
 
     return node


### PR DESCRIPTION
## Summary
We added the enableNativeRpcTcpAdapter  to test out the new TCP server functionality that was created in https://github.com/iron-fish/ironfish/pull/1214. That functionality has been tested for the the last few weeks by team members running nodes locally so we want to officially transition to the new adapter and remove the flag.

## Testing Plan
Testing by team members

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
