### PR TITLE
Add indexes to reset command

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -54,12 +54,14 @@ export default class Reset extends IronfishCommand {
       this.sdk.config.dataDir,
       HOST_FILE_NAME,
     )
+    const indexDatabasePath = this.sdk.config.indexDatabasePath
 
     const message =
       '\nYou are about to destroy your node databases. The following directories and files will be deleted:\n' +
       `\nAccounts: ${accountDatabasePath}` +
       `\nBlockchain: ${chainDatabasePath}` +
       `\nHosts: ${hostFilePath}` +
+      `\nIndexes: ${indexDatabasePath}` +
       `\n\nAre you sure? (Y)es / (N)o`
 
     confirmed = flags.confirm || (await CliUx.ux.confirm(message))
@@ -75,6 +77,7 @@ export default class Reset extends IronfishCommand {
       fsAsync.rm(accountDatabasePath, { recursive: true, force: true }),
       fsAsync.rm(chainDatabasePath, { recursive: true, force: true }),
       fsAsync.rm(hostFilePath, { recursive: true, force: true }),
+      fsAsync.rm(indexDatabasePath, { recursive: true, force: true }),
     ])
 
     CliUx.ux.action.stop('Databases deleted successfully')


### PR DESCRIPTION
## Summary
Added indexes folder to the reset command.

## Testing Plan
Synced blocks into a fresh data directory and successfully ran the reset command.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
