### PR TITLE
Revert "remove enableNativeRpcTcpAdapter flag and switch to native TCP adapter (#1388)"

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -43,6 +43,12 @@ export type ConfigOptions = {
   getFundsApi: string
   ipcPath: string
   /**
+   * As part of IRO-1759 we are removing 'node-ipc' for RPC. This is
+   * essentially a feature flag for enabling use of the native TCP adapter
+   * without using 'node-ipc'
+   */
+  enableNativeRpcTcpAdapter: boolean
+  /**
    * Should the mining director mine, even if we are not synced?
    * Only useful if no miner has been on the network in a long time
    * otherwise you should not turn this on or you'll create useless
@@ -224,6 +230,7 @@ export class Config extends KeyStore<ConfigOptions> {
       enableRpc: true,
       enableRpcIpc: DEFAULT_USE_RPC_IPC,
       enableRpcTcp: DEFAULT_USE_RPC_TCP,
+      enableNativeRpcTcpAdapter: false,
       enableSyncing: true,
       enableTelemetry: false,
       enableMetrics: true,

--- a/ironfish/src/rpc/adapters/ipcAdapter.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.ts
@@ -68,10 +68,16 @@ export const IpcStreamSchema: yup.ObjectSchema<IpcStream> = yup
   })
   .defined()
 
-export type IpcAdapterConnectionInfo = {
-  mode: 'ipc'
-  socketPath: string
-}
+export type IpcAdapterConnectionInfo =
+  | {
+      mode: 'ipc'
+      socketPath: string
+    }
+  | {
+      mode: 'tcp'
+      host: string
+      port: number
+    }
 
 export class IpcAdapter implements IAdapter {
   router: Router | null = null
@@ -132,8 +138,13 @@ export class IpcAdapter implements IAdapter {
         reject(error)
       }
 
-      this.logger.debug(`Serving RPC on IPC ${this.connection.socketPath}`)
-      ipc.serve(this.connection.socketPath, onServed)
+      if (this.connection.mode === 'ipc') {
+        this.logger.debug(`Serving RPC on IPC ${this.connection.socketPath}`)
+        ipc.serve(this.connection.socketPath, onServed)
+      } else if (this.connection.mode === 'tcp') {
+        this.logger.debug(`Serving RPC on TCP ${this.connection.host}:${this.connection.port}`)
+        ipc.serveNet(this.connection.host, this.connection.port, onServed)
+      }
 
       ipc.server.on('error', onError)
       ipc.server.start()

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -231,14 +231,29 @@ export class IronfishSdk {
       if (this.config.get('rpcTcpSecure')) {
         namespaces.push(ApiNamespace.account, ApiNamespace.config)
       }
-      await node.rpc.mount(
-        new TcpAdapter(
-          this.config.get('rpcTcpHost'),
-          this.config.get('rpcTcpPort'),
-          this.logger,
-          namespaces,
-        ),
-      )
+
+      if (this.config.get('enableNativeRpcTcpAdapter')) {
+        await node.rpc.mount(
+          new TcpAdapter(
+            this.config.get('rpcTcpHost'),
+            this.config.get('rpcTcpPort'),
+            this.logger,
+            namespaces,
+          ),
+        )
+      } else {
+        await node.rpc.mount(
+          new IpcAdapter(
+            namespaces,
+            {
+              mode: 'tcp',
+              host: this.config.get('rpcTcpHost'),
+              port: this.config.get('rpcTcpPort'),
+            },
+            this.logger,
+          ),
+        )
+      }
     }
 
     return node


### PR DESCRIPTION
This reverts commit 6dd1388b49ee43f8b3f5ac2a1a602c740f189e1b.

## Summary

The native TCP RPC was causing payouts to time out on the mining pool. The payout would get created successfully in the sqlite database, but then seem to time out on the sendTransaction call. Reverting this for now so it doesn't block version bumps.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
