### PR TITLE
Add fallback if terminal doesn't support hyperlinks

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -62,6 +62,7 @@
     "blessed": "0.1.81",
     "json-colorizer": "2.2.2",
     "segfault-handler": "1.3.0",
+    "supports-hyperlinks": "2.2.0",
     "tweetnacl": "1.0.3",
     "uuid": "8.3.2",
     "ws": "7.5.1"

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
+  Assert,
   AsyncUtils,
   GENESIS_BLOCK_SEQUENCE,
   MathUtils,
@@ -9,7 +10,7 @@ import {
   oreToIron,
   TimeUtils,
 } from '@ironfish/sdk'
-import { CliUx } from '@oclif/core'
+import { CliUx, Flags } from '@oclif/core'
 import readline from 'readline'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
@@ -22,6 +23,13 @@ export class MinedCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    scanForks: Flags.boolean({
+      default: false,
+      description: 'Scan forks for mined blocks',
+    }),
+    blockHash: Flags.string({
+      description: 'Check for mined block given a hash',
+    }),
   }
 
   static args = [
@@ -41,17 +49,37 @@ export class MinedCommand extends IronfishCommand {
   ]
 
   async start(): Promise<void> {
-    const { args } = await this.parse(MinedCommand)
+    const { flags, args } = await this.parse(MinedCommand)
     const client = await this.sdk.connectRpc()
 
-    this.log('Scanning for mined blocks...')
+    if (flags.blockHash) {
+      this.log(`Scanning mined blocks for ${flags.blockHash}`)
+
+      const stream = client.exportMinedStream({
+        blockHash: flags.blockHash as string | null,
+      })
+
+      const { block } = await AsyncUtils.first(stream.contentStream())
+
+      if (block) {
+        this.logLineForMinedBlock(block)
+      } else {
+        this.log(`No mined block found for hash ${flags.blockHash}`)
+      }
+
+      return
+    }
 
     const stream = client.exportMinedStream({
       start: args.start as number | null,
       stop: args.stop as number | null,
+      forks: flags.scanForks as boolean | null,
     })
 
     const { start, stop } = await AsyncUtils.first(stream.contentStream())
+    Assert.isNotUndefined(start)
+    Assert.isNotUndefined(stop)
+
     this.log(`Scanning for mined blocks from ${start} -> ${stop}`)
 
     const speed = new Meter()
@@ -65,22 +93,10 @@ export class MinedCommand extends IronfishCommand {
     progress.start(stop - start + 1, 0)
 
     for await (const { sequence, block } of stream.contentStream()) {
+      Assert.isNotUndefined(sequence)
+
       if (block) {
-        readline.clearLine(process.stdout, -1)
-        readline.cursorTo(process.stdout, 0)
-
-        const amount = MathUtils.round(oreToIron(block.minersFee), 2)
-
-        const link = linkText(
-          `https://explorer.ironfish.network/blocks/${block.hash}`,
-          'view in web',
-        )
-
-        this.log(
-          `${block.hash} ${block.account} ${amount} ${block.main ? 'MAIN' : 'FORK'} ${
-            block.sequence
-          }: ${link}`,
-        )
+        this.logLineForMinedBlock(block)
       }
 
       speed.add(1)
@@ -93,5 +109,29 @@ export class MinedCommand extends IronfishCommand {
 
     progress.update(stop, { estimate: 0, sequence: stop })
     progress.stop()
+  }
+
+  logLineForMinedBlock(block: {
+    hash: string
+    minersFee: number
+    sequence: number
+    main: boolean
+    account: string
+  }): void {
+    readline.clearLine(process.stdout, -1)
+    readline.cursorTo(process.stdout, 0)
+
+    const amount = MathUtils.round(oreToIron(block.minersFee), 2)
+
+    const link = linkText(
+      `https://explorer.ironfish.network/blocks/${block.hash}`,
+      'view in web',
+    )
+
+    this.log(
+      `${block.hash} ${block.account} ${amount} ${block.main ? 'MAIN' : 'FORK'} ${
+        block.sequence
+      }: ${link}`,
+    )
   }
 }

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -12,6 +12,7 @@ import {
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import readline from 'readline'
+import supportsHyperlinks from 'supports-hyperlinks'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -123,10 +124,10 @@ export class MinedCommand extends IronfishCommand {
 
     const amount = MathUtils.round(oreToIron(block.minersFee), 2)
 
-    const link = linkText(
-      `https://explorer.ironfish.network/blocks/${block.hash}`,
-      'view in web',
-    )
+    const explorerLink = `https://explorer.ironfish.network/blocks/${block.hash}`
+    const link = supportsHyperlinks.stdout
+      ? linkText(explorerLink, 'view in web')
+      : explorerLink
 
     this.log(
       `${block.hash} ${block.account} ${amount} ${block.main ? 'MAIN' : 'FORK'} ${

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -54,12 +54,14 @@ export default class Reset extends IronfishCommand {
       this.sdk.config.dataDir,
       HOST_FILE_NAME,
     )
+    const indexDatabasePath = this.sdk.config.indexDatabasePath
 
     const message =
       '\nYou are about to destroy your node databases. The following directories and files will be deleted:\n' +
       `\nAccounts: ${accountDatabasePath}` +
       `\nBlockchain: ${chainDatabasePath}` +
       `\nHosts: ${hostFilePath}` +
+      `\nIndexes: ${indexDatabasePath}` +
       `\n\nAre you sure? (Y)es / (N)o`
 
     confirmed = flags.confirm || (await CliUx.ux.confirm(message))
@@ -75,6 +77,7 @@ export default class Reset extends IronfishCommand {
       fsAsync.rm(accountDatabasePath, { recursive: true, force: true }),
       fsAsync.rm(chainDatabasePath, { recursive: true, force: true }),
       fsAsync.rm(hostFilePath, { recursive: true, force: true }),
+      fsAsync.rm(indexDatabasePath, { recursive: true, force: true }),
     ])
 
     CliUx.ux.action.stop('Databases deleted successfully')

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -85,7 +85,7 @@ export default class Start extends IronfishCommand {
     }),
     generateNewIdentity: Flags.boolean({
       default: false,
-      description: 'genereate new identity for each new start',
+      description: 'generate new identity for each new start',
       hidden: true,
     }),
   }
@@ -93,7 +93,7 @@ export default class Start extends IronfishCommand {
   node: IronfishNode | null = null
 
   /**
-   * This promise is used to wait until start is finished beforer closeFromSignal continues
+   * This promise is used to wait until start is finished before closeFromSignal continues
    * because you can cause errors if you attempt to shutdown while the node is still starting
    * up to reduce shutdown hanging, start should cancel if it detects this.isClosing is true
    * and resolve this promise

--- a/ironfish-cli/src/typedefs/supports-hyperlinks.d.ts
+++ b/ironfish-cli/src/typedefs/supports-hyperlinks.d.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+declare module 'supports-hyperlinks' {
+  export function supportsHyperlink(stream: NodeJS.WriteStream): boolean
+  export const stdout: boolean
+  export const stderr: boolean
+}

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -209,6 +209,10 @@ export class Config extends KeyStore<ConfigOptions> {
     return this.files.join(this.storage.dataDir, 'accounts', this.get('accountName'))
   }
 
+  get indexDatabasePath(): string {
+    return this.files.join(this.storage.dataDir, 'indexes', this.get('databaseName'))
+  }
+
   static GetDefaults(files: FileSystem, dataDir: string): ConfigOptions {
     return {
       bootstrapNodes: [DEFAULT_BOOTSTRAP_NODE],

--- a/ironfish/src/indexers/__fixtures__/minedBlocksIndexer.test.ts.fixture
+++ b/ironfish/src/indexers/__fixtures__/minedBlocksIndexer.test.ts.fixture
@@ -1,0 +1,565 @@
+{
+  "MinedBlockIndexer should add block info to the store when a block is mined": [
+    {
+      "name": "a",
+      "spendingKey": "b418f7d9e31833126c83bd7637cc4445be88f8ce1367207d75b02e007559c8ab",
+      "incomingViewKey": "547b975732baf1f830a9a6a1bc8f63111e527578690f9a4a94927085180cf601",
+      "outgoingViewKey": "258329eaa88e1fd5003eccf1204f2530e15c791d9496df1ab707bf613985d2e4",
+      "publicAddress": "71f40cba7ee26c52ce9490cb08d96a9fc7c894bce08cc61d8cbecf14df656f5ac50af932ec12ca636ea013",
+      "rescan": null,
+      "displayName": "a (c90a683)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:ju8E5COhdze230HNeC47RwmESjMg9wuAJBXCGGY8/gA="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1652398786901,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "8BCF83CB097ABE3F87B95B453E3DC81AC895B1F7AEBC78DC20D435175E660E63",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAKDEGgoPCa8Y0WdK4KNF8kaxhUc1bzmcV4G47mrdn6hkYFDhrRg2LI+khwWdNL3YUZgGVl/jBL3h/KBEul+JkEZ5xik/50NtX4DTlet23uVEs5VrnvgprSUt6XagRnTATAHQzsUuQBUSWQuYGlGh7OSetn0hE/b26vgIlavUbadqPIsWK+XMl6xZsYQEHOg+2IYzfJEUxr3jXjTVGen/GslNQPRY7V1sd7utjF1gexbad5dlzXCL0+hisoXqTl69vd4EaQQXkru2iMRk+MRUVxxGVmUPVh5Cf1gsDWW3+AZQgiW7MrI+y+b/NV9d7KctUnKov7aYxR2FvWvk6GL+2BW6mgMcsTqP1km6p0zeYwPKw7H0oxF8bqyiinE+GGd64L4dmpx9OoQGBl+iKTDYQS8e4TQ5OUM1oJuCYjVyB+jIzDTVaJv7oNYExpYk+qlXdxLiVLyhlGvQoV9Sjk+If4RMT5RNSVL9fztgHXkQDRMyFR+SI8aHXZnXnUi6PdSf3TYXMEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjPT+cZQHVtSI+Fc+i6y9Et5+M88teRrytD9Ddazmq9kyyAbz+ASsRVT2FFVTGbMrOit9de1A09r1PCqD0oneBQ=="
+        }
+      ]
+    }
+  ],
+  "MinedBlockIndexer should change main block to fork on chain fork": [
+    {
+      "name": "a",
+      "spendingKey": "7f1da1a465ae8356a886c37a2ef372495da73fdc337b7fd39cdc905170dcbc5c",
+      "incomingViewKey": "a8282f5de923090e7d97541387066525d147e5604081598a72d4cda634f33b07",
+      "outgoingViewKey": "7c5e3e3a03ae0e8921352cffe43874bf4246199bab2457d9f7d8165f08a2b6bd",
+      "publicAddress": "96f4ca887d35358c9defd78dc348788a6e478ad43524838a0144422fd795ad3268b75fe27252f453e9e8c9",
+      "rescan": null,
+      "displayName": "a (87eef38)"
+    },
+    {
+      "name": "b",
+      "spendingKey": "e4997953ebf507d678e610ce1c256e42fefd949d1eca1a2f47fef54d3d16f308",
+      "incomingViewKey": "cbed483481d81f6b16cb0be12b376d7b115b6f6a2fe5d414932f9ef76c76bc03",
+      "outgoingViewKey": "bcabb7905701d98316eff36ac9bdb5a6232db4aa96d24c9887d94e0e50349168",
+      "publicAddress": "4db6c92a5908bb24c6216691917c75d1a1e7765159db7ae5fa3bbbe6fdf150b2190c38ca6e21d7ded5aac5",
+      "rescan": null,
+      "displayName": "b (4a794cd)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:/beI9P9jC5WRLjFs99c6+FtAbpB3ZKsJQIbTRpCA6QQ="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1652398787223,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "2051F11D925CF0D2920094A26282A7C32336EADC15AD35841F39578A09AFFDF6",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAJbnUdWgMDilXL8stI9PfMEfgTjd9c7KRFpxgqEXzfklzpc8Ql2C04DLeMfZqPbsvqIuWPcdTr2oUJipsWML6loNIIGALv0iOCQIRFGF/kNmi6tG+GkxficmO2yQRr6yXgCeHng+KUnkg5uh7dYxY7ljjzStsgGaAcc66AaUK4Dp7+26fCTRh5LXg2GrOCDZT6hPm3Y5Z5EPUlrYHr0Lzbnotfn0g8P0+l723xA9ePjtDASL6goOS+lNuJLecSnrdsB5wnEFGzsjxnPOnCUiNjYznb2I0Vfvc2YmkJ1dy3Tg/4CCoLdNpeZ+YVVm7WfhZV1hYXpjGk8EWAEzvuU6TEBNffADLkjPUiZj85gANd0SqiKtZGd6+dyhZRq55DN0s4O4KBBU4ghuTzYR92SQz3fC7IqKtlBnKmerfO/5juChF1BGf1i50bB4/VBIKaghZZSf5SQy9iO2f7KXgk4BySuBQUZdIWwsgV78kqMiciplR/aS9JlZxdznXLhxmevqxU25AUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwU4iow+1vAACEHwVz00pp/kBX/U0WjDuNTQREygSgfaSpR5/jrnbJIe9PUZ5ZGdVNaApmDlrfZVuKTWGTUE9AAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:3w+4eES4ASOt5deNqwo5sPSuLtfV1il2iORgVU/RTGw="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1652398787432,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "8BF25D5AD8AD9BFB08566ADE96104EE278CCFA982B0BC3D6011E766C0C7C1696",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIJgUaFYh1bihYNKXZafTJ/XRJjtWrVmuxpC6Nhtt0zqf2WD79P2YLkrqIycK/bPS4YuMwVMLXVqu6jZ3JeuJML8Vk51oOZw5rWynkkc6Tz+Ni2EmR15xFTCENIjzopF7hb/ZTzyFh5qBxv2MKqjac+zzTAj9dni777BYANKkz+v506a6y7kD9cbkZG3ryH8Uq0C5Pb8qtzmjSfx0H0tPxwp9TQi4B38DqEMtlzWSrSfDJXFfjZn+oCMSq2BMudNUAHQyesDBxzky8dhYdjGy4PLxDFFhP0B1HFz0eKAXBG0Tznkf6wwhLf9LCOvFnaA+TxcbyulC9C3MSbUnOH65QQJ6HwqArCqRCJTm8bNcjgiF8tFu9Nyxc1XgDbQfDQSgvLFBjxMBfL0CBNKNU3CPWb114jXIuML68K1MHJr4oITCXwRwh30zyynyQx+uw22NnNf0GuChdm+mr6R94JuFHYGO4WIa3O0rbDmT10LlDimSNPQFwId7AL60pY4QfURRG0kzEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5FQ6/ZFNUdc/8W0Rp15OH1gUFIuPwVc8QKDQ2mPHy768RFwyUnTLqN6cx4HBcMLYh1V1+4bV4CsKaMZjyGlTCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "8BF25D5AD8AD9BFB08566ADE96104EE278CCFA982B0BC3D6011E766C0C7C1696",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:+i9pe6sm1XSbX6DE/+LsBWxNkUEKzcT24Y5+O6ZA2TQ="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1652398787647,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "A5749AFF28970BC9C6006BF57A37C9E34E94FDA535FE9FEAFBAAEC8DEE55462E",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALAo0lAqbhOIrCKHpIfAPhrrnIwgL06ym0/FrYRGHvATyIQHrhDVfMHPT6E9DvQOnaADrVYOw/ki7IafvOT3H4oKvYOb6K36MEq1t9OKmty51+5GnukbbMVudAYV4+1FGBDVoQ+EGDFRIXOEngWS5ZY4oIzmrvPrI87oKN6xLIVyzuOuByr4g1ev7WOHeMUNMICePfCnMe+KqgM1jiwdEeG/MPxnApGCbe0YdP4WTaK9ZxGyxI+RZfV9ogK2lFLjPXCf8E2dF6eV653V2uTue6Am2fCD9OM3fgyadZIbIy1hP74pcCybeJpFxyl80qcv5pt4G8uMEFQYYqAwro3EBnPtRNFtsw8VutvmXq1HIkgruzcqeLhIRm8Xuinx2E/VBoIaFH2eHmIAwNubDv8xANaVjkozYZRk0+6VSmzm78VA9/JzA1dvQJfKP0hyb9o5K/cNO1n/aCdVpFbbrd+UCoCfNBTrjsC3+hvmo+s/dOzCRAHfTdKu9GwkEJRFw7cwvvHUrkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwosK5yEo7T/QqMFHidGiOBmlDa+ouFnUZIE5E+FTH0Jf81HXcmIe7H16ZYSyRnN5au0AAcjGQDE7vUfdt151BQ=="
+        }
+      ]
+    }
+  ],
+  "MinedBlockIndexer getMinedBlocks returns non-fork mined blocks by default in sorted order": [
+    {
+      "name": "a",
+      "spendingKey": "65d1277d149abd32493c623596b79aa10e1d38d450c52576709f4de79784e43b",
+      "incomingViewKey": "08272ecc8647f1181b4fbcd58b6ba39ae0e31de5cd42e10b967d56ad9a8f6906",
+      "outgoingViewKey": "a74f3f26177f74eb03648df70847e9995b9879c426a9099b7592f2b984a474a8",
+      "publicAddress": "4170121ce374d6cddb6aa6d02f3c24aef9c32e89f7d940547821f496ab63f17a9a33f9d117e5f1e2db1266",
+      "rescan": null,
+      "displayName": "a (9bc94d1)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:c9seegzhS4WXj/vWM3nw1+CxhGrXxXZArx0PKHo3HCw="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1652398788244,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "4D4B99EEDF46559AA81AF9F98A2C6839FB6619D6424E1D4A1FB4E59A4857DAF5",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAK9uYt4bDpm80p0IfkDCsDp9ZlLOq2g843garw/W74fm80u7vzH/jyVdZPqXAIjjP5kUDg0muVE2nEcc1OpqoKUeNHS4jWV/cpQhZp80ZlHaV4CfuiqsO/lomkhyDbkz0wS6cIK2oFiNI/ARitbTqkX+cEAH2KoAnd3dXXR+AHhYpDy/0tSuTmST9iLQeHN9FpJtxtxeBWWNzfpsvfvBKIYdudUnkz76W/vZqJSr6+2a+O8zaq7gBZE1chHDKVYVV7w1Gn2M/XDDz+LWz98gwVF5Mod6X6B51IOjwOhrodjAZzPgPBATqsEh2seW4mXcBWDaOi+CiBk1CzgSFieVF0h8xD77fVMsKwWysjtzjh0GqMrPWSLoyrCoBmgi+fOjcv7ajXrXNPJOAF2RTBM40sZJwcZ1l7MSmkNCJ6BhLnU4CxZHVMd0RzipbUTzH+BnT1ArLZmM1iEYWarS/6wImwjv1Hs0UMZ2WxLgbDn8uQcbsdc9GNX62n6V7f2qNMziOWYAhUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdeUSInp7nMf1p6BEEajLeblzWLXih1/dPGdJrTfNQFmfv+DtSElzPk5T4NMUVVSFxDG/rb7ItkJFbw3MVWqXDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "4D4B99EEDF46559AA81AF9F98A2C6839FB6619D6424E1D4A1FB4E59A4857DAF5",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:rlhqeMRFIfIKcVBW850SV4r/K/+xCD/1abje7wgn/Uo="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1652398788446,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "D81ABAD41C191465B67E481A0CF8764A178BD67A2C0DA20DA62B6690756928DD",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAALYsF1p6HQQpF1cHI8fVJ2vim8DcyDzjSDgq+gi5OlUuz+XcISQlGfs/IccdmNd6G4UPT/OD2nAAbSaULSipnOYfssfUzM8IrXOSNRMAbRs2osk2z+tysFI8pNQ/cyO+3QwY5bHLDEwcSxDTJ+6rcVT6giBcZGwvaYYadHlVSzui7zbYFAUr5h/AY0Bh9WA0yKzOEdE3aLFxAwFLRU2XrpzVJWIR/vht0SysWgCWe0qRaNQ8D8+KTdx4X2piVSwNX1vcbHSuGBt24CVG/F4HXNrbwWEHnSH2+IUe75qH7GeG1I8bLql5Sy6Qm4aks/dwLmxYHEHBCmM3ZE3orxkoeFoY/Vu7fZ1oneRAb/9WakvaeXXcTzGOjexUZ6rBGisUhnhxP/IPwj8Xu/E4gTDoxROQQLtS3A+EDaiLKhHdGk85mTVGSfF3iVnoeoIZpN7G8A88AvrLzRe9sk0YL6+z1XEw4LKlz0WCHU5lwrJZOMz/NV2Q4ygyvy/BF4vTEnN4eX5wuEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwkGyFKaHXiCOk66/nLqP2RACN81nPt1kRhWvUGPeAOPH0Zfba+lxfCguvVaDS3zJTVKjddO/6pxDPz/9E1ejaDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "D81ABAD41C191465B67E481A0CF8764A178BD67A2C0DA20DA62B6690756928DD",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:bEnYAPMtLJHWpCVgQ9x20Aw8br02Sl0G6dyNkiIi9Us="
+          },
+          "size": 6
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "randomness": "0",
+        "timestamp": 1652398788648,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "CA583CC5940FF1B394D001D6C3CFAF0742EBE8A7BA963DBB6FDFE43FAAB51984",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAKX+iI2Gvx8DSBJIckVQgQiyaGciyOTUVYPkWejGRy7hzxwAXM+6ROX05zxxvltKyqa+2PhxwhqPqZpxAVGKWp0dDemph/k+TAli4ONdUajjKfUN2MDZje9KS/IIu5dU5xB08y9WyNwLNafspg85r0WeixWjMFwNNJDtaxpwtr6Bjp3mNtupHKBzSHi5sg2jwq4TRCFDu9c3m8dwIGhVpnnge5/bCmLzEftcYbr63NuPpwkqD5rMZknWZjCXGpon58HrbzXg3wq8m3tg9Xi2IntlRog1gCI1JJ384XZ0F9BtWZTLvW2fPxuee+9Nxg5f/kRaP7mpheOdg3bCzd4rFlPLCUAjlxU55I8J78POuZCyjeFKvaJcpQdMk05han5Gy0LWNkLWoHZroioDAW3JJtCUy3tB3lRzhHVbdCTWA/tda+KKMVmz2qcjgrDiD65/UGcaJNOA12bhJIg68o9nsZS/KsLQRGr/Xd9p6nYZX+f8CnYx9uf3KOGtHuBIuv+T3VETCUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwItc2gMkdKCy9WVxRKxg0w/P+BbP9rwm1qU5dQrFMpcE+8NhpbMO7Et053sa9cKn25h2d/837od7SVAvjZS6FAA=="
+        }
+      ]
+    }
+  ],
+  "MinedBlockIndexer getMinedBlocks returns all mined blocks with scanForks flag included": [
+    {
+      "name": "a",
+      "spendingKey": "f75145525806f2e3e51503b55c6364a0fc560d8f8ea371321b4e12f1224fe205",
+      "incomingViewKey": "245ae2d47cd16a486b423c9bdb8ab4433a3dee6c911c5aedf8e7c7394ce17001",
+      "outgoingViewKey": "555e74936caf78e31a70ac071cca59d0e143b2365e826ed3d4ef71c923c77db1",
+      "publicAddress": "172fa52f20a07c04323a9c454d6c324b97037f69a8ea7ddd7b881af061605f044f0f5903b74d51bd8f7fdc",
+      "rescan": null,
+      "displayName": "a (653b926)"
+    },
+    {
+      "name": "b",
+      "spendingKey": "32779e448ec404d29c09e6421dac708c202160c2182ace629e15e7f8a2193e6f",
+      "incomingViewKey": "5d0cb2fe00165a9a689c94a6107b13a3c44f26a443e61388b85b0cd85ccbb003",
+      "outgoingViewKey": "7fd1e911dc13b3412344f1ac832c31e64905e48ca8bf9839b33c735a89a230d6",
+      "publicAddress": "1eba260b4b857288474324df79a7bd9cea1c47725ee2d297ade76fbba23654f9404127f1a205f2200c36d1",
+      "rescan": null,
+      "displayName": "b (4d0fb2e)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:xMYto38G+LAnq5n8+c8wpHXDXZxmhKeUbEtlqDp1Xz4="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1652398788969,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "FF9BEDFDD5E59613652C1F87F5023BE3021A20BAACC37478B7CF6B2DCC448E49",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAIMrTlq6e036Yay017RLNljPuiXoUHDybnd62SR1I8JEOKi8jQFccfJWSoVCMr4k8K4ZSylZ/dzSMEqbVZPFrP+lx9x2iKQIJCBiHyIH8WYiu/XT0YSlhB5Of5G6uWDUWw0dOSrKuVGovetJ+q7Ipfhn1+B9P2V27XgDInPf1FVmuM2jRRAFa+0psKAhUpkKC6+SG+45CbpvR3dF6RrMm/5zOYVbSdP+Jkh9nU/6ZR02D2ujhQyChfO6yOhsImoD8N2KYj8ycfvxFpAMXW/2dYHKBi8/6xIFjSWmr707SAFt7n+Yqo36UFDersj0Ne1TlLq/0mxtoI+/eqvlFjvU6RcMmVUVKOLGZ5hovQO9uI94pS5YknDvHSTwQXAX9f8Fj97Ca0sIL5dlwSHoZrANSa6Gvmn3tn3sjuRn2ZuAzDQ6Rfz+cX3uLJYaTNrxTnDlnhy+TWJXymFYZku+gAqDbaVhFDi8R633dcPGYJv5rPVABaGG0Q41r3mQg4r9aSgoSfPevUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3xPRr9ig4NUM//1sad8qJWArLAZ02kdDkctbhpTdX25c/yUzLFXF8Ji4FukWX1KV2HaCWSKi3yEyOsd/G6qRAg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:3qJTyuYLWQ/18ItNOXU0yI9FpEgGasZrfqRaPooc9yE="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1652398789174,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "3A28722534E037223995884DF9DA5D10947E8DDC0A0178F27118989E7AFA03AD",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAINSfsyVQRhIjWkIOujWjKN62gBly3LDt8vO1YNVPTc/BdYkUOVEs1PvTb/q5Zc4rIC6iyjNI8XSGSZmUrx6HoCnEPOG8bX9ePb4Oxu8qgK//bJUyTrzSDEs4zKbfizcfwhshcCCnQlqjiue8z+4HiWnSnuw9lALDPR5alamp5nDumsGaPHZPOU711QCZwMBSbCmpxaTzoLERDWCxscI6Q64Z+BW0JI5AM7iHGRvcqt0Wwx6yRJCV3m1vSM0X7aphMT74YFYB+O05pEoti3DezDTxlnNtCTc9+atiBBxi/nveVCdHbeaEmeHzlsO2+CelDXuHsoh8pWZaRckSmyVSRzPAZoFFimpPpwcyF73bcShEbVE2YQnKXGdWM0A7qSoUBvoBq+BW2bHlBYTHOWUvxvJF6YHowbYejvxQ7OPbuK7MQ9FPgHkodpUwlDyc4uU2p6tKWKIlCxaIf8c/D+VnHqP92m2SImUx0pnPfO1StcqV7izsI0SyXeRHmQJucj4Y3hpGkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCeScwiZUv/E2+eLlECrlCbq3/c/yP1Y0T2kRkn4yVCfUYjnpkjXPTm/cavFNd6xHM3T79i5PmPkmmVvzPsuWCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "3A28722534E037223995884DF9DA5D10947E8DDC0A0178F27118989E7AFA03AD",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:cnl14fomi8ITtqGpsA6sdOm7uwbjY8ljdTKxu5DEHhs="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1652398789375,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "32C384881DA2971E8884E1C727F7BFFC2A7175B15D6A34C1C3E21165A4E8062B",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIXbFZokFTRyD5UpTTtivKTeBgkqgKWe258aY5ZF8PFdFjwanyz+mdO8VUsuk1CsDITL03jShrVplgf+OXjervEJPNa4d2avNNj7pLD+mIOpjC8U12q7rfQ5ZzBfDtqxuAeRI4VSMyZycvVCmHbZ29TAfzEnVnug3xAV8vAlRARs9b/+IIGlUFSSYtwju7pHH5Vo73wxnaHsjDg8A99aEphZY2Cu6qSPKTK4JwY0Evtjmz0c5fQbPfdgwiYkRkGlZZke/qblrrd6AAv0JGj4e6l9aFkCaQsDRBNfMhJ+HGXAdS8WCxOW/CVS6RNEsjt80KaIPUxGA3mPUaNAU2XPuTruwarwpTwPlBjDA5InJzs9APwtX/P/jN3d8OJpkxmWBz2VbouZ643sEqOGkTG7y70n9WGa7rnqoIF0gnqzNxCrK+d66H6nXuGRQY5V9thriJ/pFozfbl0gEjkUTFWTmRgZyF/kRCEoBG88eCeY8Knw4nTf0Aql/y2mKBkX+q74iexGzUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSoGnQ0OdlvVwxnZSw4grkHaC1SuVH0h6BxCWRY6325RD0HwzLlVHNfW770QCJyWUt/hZ95kE0/Bkw2hl0QKGAw=="
+        }
+      ]
+    }
+  ],
+  "MinedBlockIndexer removeMinedBlocks removes mined block info for a given account": [
+    {
+      "name": "a",
+      "spendingKey": "2e44444985f7bbcd06d79b8c3f19b3451bad2871e0f919237df7cf379145a285",
+      "incomingViewKey": "ba40671176a38939fbde3c064c471d798cb321051efc174cf70d6994bc57ce06",
+      "outgoingViewKey": "818d031da6f26e73e57028b4e9b92fa696e01219eb7b76e79ef1d228a96d4b8b",
+      "publicAddress": "f5ae5164e04cbf20f3f67a9396d9768394c7a940f5430c3848e86d54d31e155336e0eb56cb7f8638966c16",
+      "rescan": null,
+      "displayName": "a (c1056f0)"
+    },
+    {
+      "name": "b",
+      "spendingKey": "0a24b2fdf80276e9eced644009474b543d7fc4ece89280e8a1f16ed2a8527d65",
+      "incomingViewKey": "aeb03a443b2886c33bd29b8602e708897a71bbca5898310311869094b6c64f04",
+      "outgoingViewKey": "452dd52edeb45e7ab5c735eaafecf464462cba2368486f74472dc5fb30b2671b",
+      "publicAddress": "4b2eb2575bce3a1162f19584dc4f6311d6fb398f4b470c112eaf796d84dc15512da8df52704fabec6e5f60",
+      "rescan": null,
+      "displayName": "b (c679b1f)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:Z+taAM5v7jH/w9D2Cf+ikx4pWf5n+TDckpoXMWl8WjI="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1652398789684,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "96E59FC5D5B76220624C8215607CD4E48B9CA0FE40019C33751B09A5FFF6159F",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAALAABYKM73+dppf0eYtsF+oqfTy+wDANVzR/qHPdMZex9sYGnQE6zsSKX7nZKnIXQbjOfzz3s8iNFGisxJv0QJDeYEgwbN6ezcHBXkctm6bAvYjMCVcRgf0hw172GI6DIQuqwaPEDr9glmcAjaLR8lXsCV1ukvRI9zg7v/g2XqN6Oj/I02HhOWiKrOvfP++vv6T1SaFyCyIRD36hNdldLf5ce6LXmV3jURbWQHZWeoOBHbaaItxZ2ZarEd9PbDwDPsWg/pu7SfVphxo3rZ9B8zkUPAz1j20Fg7sYK9SIwP0UOfk/o0sOdEWq3jr+t8SUySL3LHxnCoFvdya9f9F3t1xwL+MNlcXTTj2WLpVOX/FF/74uLh8TVy5yA3pgDo5UxHtgzqNLttxa56O2hQXWzc2kKLsiyOhZfOLV+K+cbYCCIbvJ8U4D8HE3hlQZW1TtcXcGPXP9NAKgNh5lIqI4FZFoJijoHTXwGBIOP+Guhy+sMuVnKar6BVVrYHgKaydP4UXyRUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQwUWCgyrbNIYVVB2j/6XXW8jGLF7plIfyWY46JskIAWN+dr1HJxZpcnhd4vI08xSiYM/+i1/XTMe1NkiQh5WCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "96E59FC5D5B76220624C8215607CD4E48B9CA0FE40019C33751B09A5FFF6159F",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:lcwbU2qf6J+0f6rU+cIF9NIk+xLiY0syKST/2jm71D0="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1652398789886,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "1554A66FF660FC4DD800E6844CB211529AC1E0045C5724673EFEFCD96DB76069",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAKNdAhJ96vIU51vC1TLxECnbUXbGjqef92eO/9dHEMxRVaRiV5xeIqnR8/Md4NjgnavMFx1TeEM+v67yIRSgK+SjRTNOJnKMoo7c5KbHB+d8HbHdkBs89M9yN5rUPzsbPQJT/rn//+OpDwpeMV18K3wV01xx3/AFHbuX8ulc8sohUcy+SUKaSOrrgcSXI6fly5ZS09dj/wagxwHd8MCWfM2hTcwW1ZLNvFFD2n41tTeOTbvYiR6kmhbUXxujN/WfRkh18CNdpy9IS2ZXMaNSqytj2bLCrvoQyFvmeRr7doUcxNe6Y0IQH3AMLRJGn18gZyQtelpxPi2BsuEdgxNM2V0m9r+sZbGRgsmUDwyZpq3VaGvNuAjO1EqMUZFWEo778LSdcD0ybBJ0riJgDo1/cPH0+bSo0xglK5mO9RnxXd9J4cPK5JZPx56nixZMHYTCNhP+ezLoY1Jem9XzZp5+61tnIUjpV8gvnOI9uX0lXJk1XgbdLUfXwz8Q9GoO4NiNPfiGSEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWYcUxISiCt8y50osgX0fe+F2ePNcTkznXZWVIHzFR6P4G0+qbHZOORVbyIKiMaavVAkXJTPjuTMIpPXcZV8YCQ=="
+        }
+      ]
+    }
+  ],
+  "MinedBlockIndexer getMinedBlock returns mined block given a hash": [
+    {
+      "name": "a",
+      "spendingKey": "774ae562bce9437a32695ec964c159f58a34780f90d649539d97b7a1c6283a0b",
+      "incomingViewKey": "e8e8130237ed63dececb27f1fa1accce5d68cfc9fe6d1edd00274af18b01eb05",
+      "outgoingViewKey": "3df5115b86bd157f2c984bcffa01260cb881aa3599c1f8025b263cfe8971cac7",
+      "publicAddress": "3920edb477865f967928dd07025d8c0791fcbd5ede7e33d718d8c73067e69729624b200011eb12bd84e5a7",
+      "rescan": null,
+      "displayName": "a (c415b82)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:0FAWdgczF9eawwAly6aLnqI+dQKXnBr3jRXCgXraFDA="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1652398787961,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "0E77E660983EC63425E53841768A717BC8DE285BEABF4C6BC1BFB7B887083214",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAK73NLFn56wh1S98IIM4S6oGvQcARl5p4Cs3bQI3OonJ7evVZ4hH1BLmIspbHqRVMrQeicHrhBGz+bTW+zalaRdMG3imuYYlSAkGYdmudmnBoEFbux573xm0kcwsAEviaRaSsl2FAWIMewupk0z08EiKdGt1JFLkM4EOnJPAFO+dzFGjUvDJyMpcOVm1nF2JvIdO2892ba6q4AtxzX89xFI1iflGd2TeG/KkzoO1Caz8nG75+P7Vz3oabQihcERsASIUJ8RiTkiFGMD5T2gkPWbJPwf8EJz5uMvalAzRK8cOLUhkAtaWSjrpzGSETCBmToq8VaI1r7iQmnzLifeaY2A9yb8Nu0lOhvkTaRBPv1NTCQ47IFnK+z0aoFmN+0XqyKBQ/c1kxlzYDOJqFrrKFJ/aqZGpUT5Z23pLNLdYUAy2gwd++pZUREqZP6QvlR25nji+hzn434LDhO+nlAX6+VwtQj67DJJ2GL8uFAgy89aozj9wu04tEL2PisXd3eXfsT1GKEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwseGfHZzA9EfEIkWVZlt85rPLk2F9LBVvbQHj+PKXZVt4CptVQzt/NksQj2cHFTso6XqkUHv95xEitOLPnH5UBQ=="
+        }
+      ]
+    }
+  ],
+  "MinedBlockIndexer removeMinedBlocks does not remove mined blocks not associated to given account": [
+    {
+      "name": "a",
+      "spendingKey": "06234985a0b9378fee3e3497605260097ea71506fb406ac6a6a235ba3b15b5bb",
+      "incomingViewKey": "ad357929900a17498872a1ef5cb4f97d848e5b82385664827ac5e511dd85fa05",
+      "outgoingViewKey": "f23ed55888b078b70a0e3d12e706cf3c37a705deffd83ea7299d20403a19d5cd",
+      "publicAddress": "c2a2694c35b92199a7dca9884dd440ffcfab57b1fa3d0f1860aebe57a144fa3ce2b4559a82c9a23bd98fa7",
+      "rescan": null,
+      "displayName": "a (11ee0e4)"
+    },
+    {
+      "name": "b",
+      "spendingKey": "2f31ad722ff6dce724d005de55f46bd2c4a2e4de3e81acda42519e5b1a536609",
+      "incomingViewKey": "c17d578c3fc48aea3f3b8eb00eb7e84471754c792ab952437749e17646c72507",
+      "outgoingViewKey": "8a4ac638f30456634a39a686f5996c3876fc398285c861b2fb898d35267a5c40",
+      "publicAddress": "7088963480d3d1b0766f502efff10443febf11d27115a05fe94aa3ed50bd0df0eb53ac912f08cccfa702a9",
+      "rescan": null,
+      "displayName": "b (cf3d741)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:hNXUL4snR83pEaP3ylp7tAArtgjLvA6htsOWckuVoj4="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1652398790205,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "50133917C8138E2CB4126BC6B0A9940A8BA92712D0F0412C6A18333E74BC70AC",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAI5ZMzwBGTQcmWq5/RTyZRHsTv3PJ8SNVFtY9l28Xv0gFwe/A6uGaNcaUOSASbABzIDYknahZARt54YsXkd7VwZ5Vu1+FvGRYOiStIF8cycFEjpK13cS/MCsMNtYT86o/xiJmmdSxmkj6pf42zNOldrfFTqgaBlV9WIQg/AecpB+olXfJTAo3E5TecQMowa8RaJpVOhcyWAmYYjCJ0gLegVj2TDw6Icu96yxcuUBpiknvMEwoX7n8yAatMbLI2sCTUH5plKbekmRv8Og1pOCMceCh/72Xacy8xiVWnwx38wQZDpz1EcVkgfFmHbwnXgnuZC2FPsAOT3bQ8saNdr58xn3x6FZqZcqRXnTTsmRtGaMzwCYeqx3nLtDJq77I4OwlSKPDRsIQtyro6rkCvltsjvkmfeysot/54g5rj4mjJ7x0SYjz+glstOYONPuNq4PZjayoJGvycArEse8qzvVSCbRUJRtd13Th5zxRvgEF9pEsXhwLoRT5bfoP2L60nWyE+vjdUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwp/pgEz58BZyGduUTIkRTKEii1KG5XR298VVrofT3wom5u0ez3RzOSWnclz4KzsbE7vFQBVV73dHGzY7OGkPzAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "50133917C8138E2CB4126BC6B0A9940A8BA92712D0F0412C6A18333E74BC70AC",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:KucStrxcKuua6BnqPj0UV7C58TTe6uoM85udqbg/onE="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1652398790405,
+        "minersFee": "0",
+        "work": "0",
+        "hash": "AA186F4230413A2D10F828FBFC316C77434C4F3CD80F878AC71A835E1D3D8671",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAKQQQ7BCJcx2KWg0UykVzGh8mtJOc5AS7TCMVlyXyfjjvXydW+eYGAqAzg5LTHVdOoC60/K9ybdno93Lt/zoD42+T3092p21TGSentYFUgnwuYbvsxBX9A1GybR46dvGQhVYsQjIAq1NBL/X1cX2i9adkUlkqgnwFOeKrqM4clzjWQ4fdLJ5nk7b/MyWiGmb/bmvwJF6It9qVQm8C7t7CK1j+9CZY4gR9d9PKRLhQn/Ldt02leeGnexGIZDjgc+LakAX2oFS0xAoi71LJ0xpnxlCMh7wfY7D1AIiAZjwTPYAnOPJec7vhKSp0Q7ik7KLCqrQ94m1A+NiYYkDMr0DpirkpW7KkaFBX/dyTyd1TpeU4oa1EcpHc+mlhYEkyxqJ1NJHxyLWV0jSRZBsw6R4SWDClABKbrGTfwO3x7r1yQrtvwwu2Q8bq5zUlSIWqZVsJ0Jiv/zouJTVCBa+e38bjLJwyK70mPJ6W9AFjO1ySO3wopspFC1iyKVTbfoY+sfraWdWhUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtWQGP6XDFA6AICqRTgfHKHdKCqc4NpHDv1T8kHBvbNqKieVZ5Wsx0L+uzG10wvrphQdJKp9TuLVppzsNDXxgAA=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/indexers/database/accountsToRemove.test.ts
+++ b/ironfish/src/indexers/database/accountsToRemove.test.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { AccountsToRemoveValue, AccountsToRemoveValueEncoding } from './accountsToRemove'
+
+describe('AccountsToRemoveValueEncoding', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const encoder = new AccountsToRemoveValueEncoding()
+
+    const value: AccountsToRemoveValue = {
+      accounts: ['a', 'b', 'c'],
+    }
+
+    const buffer = encoder.serialize(value)
+    const deserializedValue = encoder.deserialize(buffer)
+    expect(deserializedValue).toEqual(value)
+  })
+})

--- a/ironfish/src/indexers/database/accountsToRemove.ts
+++ b/ironfish/src/indexers/database/accountsToRemove.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../storage'
+
+export interface AccountsToRemoveValue {
+  accounts: string[]
+}
+
+export class AccountsToRemoveValueEncoding implements IDatabaseEncoding<AccountsToRemoveValue> {
+  serialize(value: AccountsToRemoveValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    for (const account of value.accounts) {
+      bw.writeVarString(account, 'utf8')
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): AccountsToRemoveValue {
+    const reader = bufio.read(buffer, true)
+
+    const accounts = []
+
+    while (reader.left()) {
+      accounts.push(reader.readVarString('utf8'))
+    }
+
+    return { accounts }
+  }
+
+  getSize(value: AccountsToRemoveValue): number {
+    let size = 0
+
+    for (const account of value.accounts) {
+      size += bufio.sizeVarString(account, 'utf8')
+    }
+
+    return size
+  }
+}

--- a/ironfish/src/indexers/database/meta.test.ts
+++ b/ironfish/src/indexers/database/meta.test.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { MetaValue, MetaValueEncoding } from './meta'
+
+describe('MetaValueEncoding', () => {
+  describe('with a null value', () => {
+    it('serializes the value into a buffer and deserializes to the original value', () => {
+      const encoder = new MetaValueEncoding()
+
+      const value: MetaValue = null
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+
+  describe('with a defined value', () => {
+    it('serializes the value into a buffer and deserializes to the original value', () => {
+      const encoder = new MetaValueEncoding()
+
+      const value: MetaValue = Buffer.alloc(32, 0).toString('hex')
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+})

--- a/ironfish/src/indexers/database/meta.ts
+++ b/ironfish/src/indexers/database/meta.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../storage'
+
+export type MinedBlocksDBMeta = {
+  headHash: string | null
+}
+
+export type MetaValue = MinedBlocksDBMeta[keyof MinedBlocksDBMeta]
+
+export class MetaValueEncoding implements IDatabaseEncoding<MetaValue> {
+  serialize(value: MetaValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    if (value) {
+      bw.writeHash(value)
+    }
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): MetaValue {
+    const reader = bufio.read(buffer, true)
+    if (reader.left()) {
+      return reader.readHash('hex')
+    }
+
+    return null
+  }
+
+  getSize(value: MetaValue): number {
+    if (!value) {
+      return 0
+    }
+
+    return 32
+  }
+}

--- a/ironfish/src/indexers/database/minedBlock.test.ts
+++ b/ironfish/src/indexers/database/minedBlock.test.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { MinedBlockValue, MinedBlockValueEncoding } from './minedBlock'
+
+describe('MinedBlockValueEncoding', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const encoder = new MinedBlockValueEncoding()
+
+    const value: MinedBlockValue = {
+      main: true,
+      sequence: 123,
+      account: 'foobar',
+      minersFee: 20,
+    }
+
+    const buffer = encoder.serialize(value)
+    const deserializedValue = encoder.deserialize(buffer)
+    expect(deserializedValue).toEqual(value)
+  })
+})

--- a/ironfish/src/indexers/database/minedBlock.ts
+++ b/ironfish/src/indexers/database/minedBlock.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../storage'
+
+export interface MinedBlockValue {
+  main: boolean
+  sequence: number
+  account: string
+  minersFee: number
+}
+
+export class MinedBlockValueEncoding implements IDatabaseEncoding<MinedBlockValue> {
+  serialize(value: MinedBlockValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    if (value.main) {
+      bw.writeU8(1)
+    } else {
+      bw.writeU8(0)
+    }
+
+    bw.writeU32(value.sequence)
+    bw.writeVarString(value.account, 'utf8')
+    bw.writeU32(value.minersFee)
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): MinedBlockValue {
+    const reader = bufio.read(buffer, true)
+    const main = Boolean(reader.readU8())
+    const sequence = reader.readU32()
+    const account = reader.readVarString('utf8')
+    const minersFee = reader.readU32()
+
+    return {
+      main,
+      sequence,
+      account,
+      minersFee,
+    }
+  }
+
+  getSize(value: MinedBlockValue): number {
+    let size = 1
+    size += 4
+    size += bufio.sizeVarString(value.account, 'utf8')
+    size += 4
+    return size
+  }
+}

--- a/ironfish/src/indexers/database/sequenceToHashes.test.ts
+++ b/ironfish/src/indexers/database/sequenceToHashes.test.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  SequenceToHashesValue,
+  SequenceToHashesValueEncoding,
+} from '../../blockchain/database/sequenceToHashes'
+
+describe('SequenceToHashesValueEncoding', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const encoder = new SequenceToHashesValueEncoding()
+
+    const value: SequenceToHashesValue = {
+      hashes: [Buffer.alloc(32, 0), Buffer.alloc(32, 1), Buffer.alloc(32, 2)],
+    }
+
+    const buffer = encoder.serialize(value)
+    const deserializedValue = encoder.deserialize(buffer)
+    expect(deserializedValue).toEqual(value)
+  })
+})

--- a/ironfish/src/indexers/database/sequenceToHashes.ts
+++ b/ironfish/src/indexers/database/sequenceToHashes.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../storage'
+
+export interface SequenceToHashesValue {
+  hashes: Buffer[]
+}
+
+export class SequenceToHashesValueEncoding implements IDatabaseEncoding<SequenceToHashesValue> {
+  serialize(value: SequenceToHashesValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    for (const hash of value.hashes) {
+      bw.writeHash(hash)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): SequenceToHashesValue {
+    const reader = bufio.read(buffer, true)
+
+    const hashes = []
+
+    while (reader.left()) {
+      hashes.push(reader.readHash())
+    }
+
+    return { hashes }
+  }
+
+  getSize(value: SequenceToHashesValue): number {
+    return 32 * value.hashes.length
+  }
+}

--- a/ironfish/src/indexers/minedBlocksIndexer.test.ts
+++ b/ironfish/src/indexers/minedBlocksIndexer.test.ts
@@ -1,0 +1,272 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../assert'
+import { createNodeTest, useAccountFixture, useMinerBlockFixture } from '../testUtilities'
+
+describe('MinedBlockIndexer', () => {
+  const nodeTest = createNodeTest()
+
+  it('should add block info to the store when a block is mined', async () => {
+    const { node, strategy, chain } = await nodeTest.createSetup()
+    strategy.disableMiningReward()
+    const genesis = await chain.getBlock(chain.genesis)
+    Assert.isNotNull(genesis)
+
+    await node.minedBlocksIndexer.open()
+    node.minedBlocksIndexer.start()
+
+    const putSpy = jest.spyOn(node.minedBlocksIndexer['minedBlocks'], 'put')
+
+    const accountA = await useAccountFixture(node.accounts, 'a')
+    const blockA1 = await useMinerBlockFixture(chain, undefined, accountA, node.accounts)
+    await expect(chain).toAddBlock(blockA1)
+
+    await node.minedBlocksIndexer.updateHead()
+
+    expect(putSpy).toHaveBeenCalledTimes(1)
+    expect(putSpy).toHaveBeenCalledWith(
+      blockA1.header.hash,
+      {
+        main: true,
+        sequence: blockA1.header.sequence,
+        account: 'a',
+        minersFee: 0,
+      },
+      expect.anything(),
+    )
+
+    await node.minedBlocksIndexer.stop()
+    await node.minedBlocksIndexer.close()
+  })
+
+  it('should change main block to fork on chain fork', async () => {
+    const { node: nodeA, strategy } = await nodeTest.createSetup()
+    const { node: nodeB } = await nodeTest.createSetup()
+    strategy.disableMiningReward()
+
+    const genesis = await nodeA.chain.getBlock(nodeA.chain.genesis)
+    Assert.isNotNull(genesis)
+
+    await nodeA.minedBlocksIndexer.open()
+    nodeA.minedBlocksIndexer.start()
+
+    const putSpy = jest.spyOn(nodeA.minedBlocksIndexer['minedBlocks'], 'put')
+
+    const accountA = await useAccountFixture(nodeA.accounts, 'a')
+    const accountB = await useAccountFixture(nodeA.accounts, 'b')
+
+    const blockA1 = await useMinerBlockFixture(nodeA.chain, undefined, accountA)
+    await expect(nodeA.chain).toAddBlock(blockA1)
+
+    await nodeA.minedBlocksIndexer.updateHead()
+
+    expect(putSpy).toHaveBeenCalledTimes(1)
+    expect(putSpy).toHaveBeenCalledWith(
+      blockA1.header.hash,
+      {
+        main: true,
+        sequence: blockA1.header.sequence,
+        account: 'a',
+        minersFee: 0,
+      },
+      expect.anything(),
+    )
+
+    const blockB1 = await useMinerBlockFixture(nodeB.chain, undefined, accountB)
+    await expect(nodeB.chain).toAddBlock(blockB1)
+    const blockB2 = await useMinerBlockFixture(nodeB.chain, undefined, accountB)
+    await expect(nodeB.chain).toAddBlock(blockB2)
+
+    await expect(nodeA.chain).toAddBlock(blockB1)
+    await expect(nodeA.chain).toAddBlock(blockB2)
+    await nodeA.minedBlocksIndexer.updateHead()
+
+    expect(putSpy).toHaveBeenCalledTimes(4)
+    expect(await nodeA.minedBlocksIndexer['minedBlocks'].get(blockA1.header.hash)).toEqual({
+      main: false,
+      sequence: blockA1.header.sequence,
+      account: 'a',
+      minersFee: 0,
+    })
+
+    await nodeA.minedBlocksIndexer.stop()
+    await nodeA.minedBlocksIndexer.close()
+  })
+
+  it('getMinedBlock returns mined block given a hash', async () => {
+    const { node, strategy } = await nodeTest.createSetup()
+    strategy.disableMiningReward()
+
+    const genesis = await node.chain.getBlock(node.chain.genesis)
+    Assert.isNotNull(genesis)
+
+    await node.minedBlocksIndexer.open()
+    node.minedBlocksIndexer.start()
+
+    const accountA = await useAccountFixture(node.accounts, 'a')
+    const blockA1 = await useMinerBlockFixture(node.chain, undefined, accountA)
+    await expect(node.chain).toAddBlock(blockA1)
+
+    await node.minedBlocksIndexer.updateHead()
+
+    expect(await node.minedBlocksIndexer.getMinedBlock(blockA1.header.hash)).toEqual({
+      main: true,
+      sequence: 2,
+      account: accountA.name,
+      minersFee: 0,
+      hash: blockA1.header.hash.toString('hex'),
+    })
+
+    await node.minedBlocksIndexer.stop()
+    await node.minedBlocksIndexer.close()
+  })
+
+  describe('getMinedBlocks', () => {
+    it('returns non-fork mined blocks by default in sorted order', async () => {
+      const { node, strategy } = await nodeTest.createSetup()
+      strategy.disableMiningReward()
+      const genesis = await node.chain.getBlock(node.chain.genesis)
+      Assert.isNotNull(genesis)
+
+      await node.minedBlocksIndexer.open()
+      node.minedBlocksIndexer.start()
+
+      const accountA = await useAccountFixture(node.accounts, 'a')
+      const blockA1 = await useMinerBlockFixture(node.chain, 2, accountA)
+      await expect(node.chain).toAddBlock(blockA1)
+      const blockA2 = await useMinerBlockFixture(node.chain, 3, accountA)
+      await expect(node.chain).toAddBlock(blockA2)
+      const blockA3 = await useMinerBlockFixture(node.chain, 4, accountA)
+      await expect(node.chain).toAddBlock(blockA3)
+
+      await node.minedBlocksIndexer.updateHead()
+
+      const minedBlocks = []
+
+      for await (const block of node.minedBlocksIndexer.getMinedBlocks({})) {
+        minedBlocks.push(block)
+      }
+
+      expect(minedBlocks.length).toEqual(3)
+      expect(minedBlocks[0].sequence).toBeLessThan(minedBlocks[1].sequence)
+      expect(minedBlocks[0]).toEqual({
+        main: true,
+        sequence: expect.any(Number),
+        account: 'a',
+        minersFee: expect.any(Number),
+        hash: expect.any(String),
+      })
+
+      await node.minedBlocksIndexer.stop()
+      await node.minedBlocksIndexer.close()
+    })
+
+    it('returns all mined blocks with scanForks flag included', async () => {
+      const { node: nodeA, strategy } = await nodeTest.createSetup()
+      const { node: nodeB } = await nodeTest.createSetup()
+      strategy.disableMiningReward()
+
+      const genesis = await nodeA.chain.getBlock(nodeA.chain.genesis)
+      Assert.isNotNull(genesis)
+
+      await nodeA.minedBlocksIndexer.open()
+      nodeA.minedBlocksIndexer.start()
+
+      const accountA = await useAccountFixture(nodeA.accounts, 'a')
+      const accountB = await useAccountFixture(nodeA.accounts, 'b')
+
+      const blockA1 = await useMinerBlockFixture(nodeA.chain, undefined, accountA)
+      await expect(nodeA.chain).toAddBlock(blockA1)
+
+      await nodeA.minedBlocksIndexer.updateHead()
+
+      const blockB1 = await useMinerBlockFixture(nodeB.chain, undefined, accountB)
+      await expect(nodeB.chain).toAddBlock(blockB1)
+      const blockB2 = await useMinerBlockFixture(nodeB.chain, undefined, accountB)
+      await expect(nodeB.chain).toAddBlock(blockB2)
+
+      await expect(nodeA.chain).toAddBlock(blockB1)
+      await expect(nodeA.chain).toAddBlock(blockB2)
+      await nodeA.minedBlocksIndexer.updateHead()
+
+      const minedBlocks = []
+
+      for await (const block of nodeA.minedBlocksIndexer.getMinedBlocks({ scanForks: true })) {
+        minedBlocks.push(block)
+      }
+
+      expect(minedBlocks.length).toEqual(3)
+      expect(minedBlocks[0].main).toBeFalsy()
+
+      await nodeA.minedBlocksIndexer.stop()
+      await nodeA.minedBlocksIndexer.close()
+    })
+  })
+
+  describe('removeMinedBlocks', () => {
+    it('removes mined block info for a given account', async () => {
+      const { node, strategy } = await nodeTest.createSetup()
+      strategy.disableMiningReward()
+
+      const genesis = await node.chain.getBlock(node.chain.genesis)
+      Assert.isNotNull(genesis)
+
+      await node.minedBlocksIndexer.open()
+      node.minedBlocksIndexer.start()
+
+      const accountA = await useAccountFixture(node.accounts, 'a')
+      const accountB = await useAccountFixture(node.accounts, 'b')
+
+      const blockA1 = await useMinerBlockFixture(node.chain, 2, accountA)
+      await expect(node.chain).toAddBlock(blockA1)
+      const blockB1 = await useMinerBlockFixture(node.chain, 3, accountB)
+      await expect(node.chain).toAddBlock(blockB1)
+      await node.minedBlocksIndexer.updateHead()
+
+      await node.minedBlocksIndexer.removeMinedBlocks(accountB.name)
+
+      const minedBlocks = []
+
+      for await (const block of node.minedBlocksIndexer.getMinedBlocks({})) {
+        minedBlocks.push(block)
+      }
+      expect(minedBlocks.length).toEqual(1)
+      expect(minedBlocks[0].account).toEqual(accountA.name)
+
+      await node.minedBlocksIndexer.stop()
+      await node.minedBlocksIndexer.close()
+    })
+
+    it('does not remove mined blocks not associated to given account', async () => {
+      const { node: nodeA, strategy } = await nodeTest.createSetup()
+      const { node: nodeB } = await nodeTest.createSetup()
+      strategy.disableMiningReward()
+
+      const genesis = await nodeA.chain.getBlock(nodeA.chain.genesis)
+      Assert.isNotNull(genesis)
+
+      await nodeA.minedBlocksIndexer.open()
+      nodeA.minedBlocksIndexer.start()
+
+      const accountA = await useAccountFixture(nodeA.accounts, 'a')
+      const accountB = await useAccountFixture(nodeB.accounts, 'b')
+      await nodeA.accounts.importAccount(accountB)
+
+      const blockA1 = await useMinerBlockFixture(nodeA.chain, 2, accountA)
+      await expect(nodeA.chain).toAddBlock(blockA1)
+      const blockB1 = await useMinerBlockFixture(nodeA.chain, 3, accountB)
+      await expect(nodeA.chain).toAddBlock(blockB1)
+      await nodeA.minedBlocksIndexer.updateHead()
+
+      await nodeA.minedBlocksIndexer.removeMinedBlocks('b')
+      expect(await nodeA.minedBlocksIndexer['sequenceToHashes'].get(2)).not.toBeUndefined()
+      expect(await nodeA.minedBlocksIndexer['sequenceToHashes'].get(2)).toEqual({
+        hashes: [blockA1.header.hash],
+      })
+
+      await nodeA.minedBlocksIndexer.stop()
+      await nodeA.minedBlocksIndexer.close()
+    })
+  })
+})

--- a/ironfish/src/indexers/minedBlocksIndexer.ts
+++ b/ironfish/src/indexers/minedBlocksIndexer.ts
@@ -1,0 +1,383 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Accounts } from '../account'
+import { Assert } from '../assert'
+import { Blockchain } from '../blockchain'
+import { ChainProcessor } from '../chainProcessor'
+import { FileSystem } from '../fileSystems'
+import { createRootLogger, Logger } from '../logger'
+import {
+  BufferEncoding,
+  IDatabase,
+  IDatabaseStore,
+  IDatabaseTransaction,
+  StringEncoding,
+  U32Encoding,
+} from '../storage'
+import { createDB } from '../storage/utils'
+import { SetTimeoutToken } from '../utils'
+import { BlockchainUtils, isBlockMine } from '../utils/blockchain'
+import {
+  AccountsToRemoveValue,
+  AccountsToRemoveValueEncoding,
+} from './database/accountsToRemove'
+import { MetaValue, MetaValueEncoding, MinedBlocksDBMeta } from './database/meta'
+import { MinedBlockValue, MinedBlockValueEncoding } from './database/minedBlock'
+import {
+  SequenceToHashesValue,
+  SequenceToHashesValueEncoding,
+} from './database/sequenceToHashes'
+
+const DATABASE_VERSION = 1
+const REMOVAL_KEY = 'accountsToRemove'
+
+const getMinedBlocksDBMetaDefaults = (): MinedBlocksDBMeta => ({
+  headHash: null,
+})
+
+export class MinedBlocksIndexer {
+  protected meta: IDatabaseStore<{
+    key: keyof MinedBlocksDBMeta
+    value: MetaValue
+  }>
+  protected minedBlocks: IDatabaseStore<{ key: Buffer; value: MinedBlockValue }>
+  protected sequenceToHashes: IDatabaseStore<{ key: number; value: SequenceToHashesValue }>
+  protected accountsToRemove: IDatabaseStore<{ key: string; value: AccountsToRemoveValue }>
+
+  protected files: FileSystem
+  protected database: IDatabase
+  protected location: string
+  protected readonly accounts: Accounts
+  protected readonly logger: Logger
+  protected isOpen: boolean
+  protected isStarted: boolean
+  protected rescan: boolean
+  protected eventLoopTimeout: SetTimeoutToken | null = null
+  protected chain: Blockchain
+  protected chainProcessor: ChainProcessor
+
+  constructor({
+    files,
+    location,
+    accounts,
+    chain,
+    logger = createRootLogger(),
+  }: {
+    files: FileSystem
+    location: string
+    accounts: Accounts
+    chain: Blockchain
+    logger?: Logger
+  }) {
+    this.files = files
+    this.location = location
+    this.database = createDB({ location })
+    this.accounts = accounts
+    this.logger = logger
+    this.chain = chain
+    this.isOpen = false
+    this.isStarted = false
+    this.rescan = false
+
+    this.meta = this.database.addStore<{
+      key: keyof MinedBlocksDBMeta
+      value: MinedBlocksDBMeta[keyof MinedBlocksDBMeta]
+    }>({
+      name: 'meta',
+      keyEncoding: new StringEncoding<keyof MinedBlocksDBMeta>(),
+      valueEncoding: new MetaValueEncoding(),
+    })
+
+    this.minedBlocks = this.database.addStore<{ key: Buffer; value: MinedBlockValue }>({
+      name: 'blocks',
+      keyEncoding: new BufferEncoding(),
+      valueEncoding: new MinedBlockValueEncoding(),
+    })
+
+    this.sequenceToHashes = this.database.addStore<{
+      key: number
+      value: SequenceToHashesValue
+    }>({
+      name: 'seqToHash',
+      keyEncoding: new U32Encoding(),
+      valueEncoding: new SequenceToHashesValueEncoding(),
+    })
+
+    this.accountsToRemove = this.database.addStore<{
+      key: string
+      value: AccountsToRemoveValue
+    }>({
+      name: 'accsToRemove',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountsToRemoveValueEncoding(),
+    })
+
+    this.chainProcessor = new ChainProcessor({ logger, chain, head: null })
+
+    this.chainProcessor.onAdd.on(async (header) => {
+      const block = await this.chain.getBlock(header)
+      Assert.isNotNull(block)
+
+      const account = this.accounts.listAccounts().find((a) => isBlockMine(block, a))
+      if (account) {
+        await this.database.transaction(async (tx) => {
+          await this.minedBlocks.put(
+            header.hash,
+            {
+              main: true,
+              sequence: header.sequence,
+              account: account.name,
+              minersFee: Number(header.minersFee),
+            },
+            tx,
+          )
+
+          const hashes = await this.getHashesAtSequence(header.sequence, tx)
+          hashes.push(header.hash)
+          await this.sequenceToHashes.put(header.sequence, { hashes }, tx)
+
+          await this.updateHeadHash(header.hash, tx)
+        })
+      }
+    })
+
+    this.chainProcessor.onRemove.on(async (header) => {
+      await this.database.transaction(async (tx) => {
+        if (await this.minedBlocks.has(header.hash, tx)) {
+          const block = await this.chain.getBlock(header, tx)
+          Assert.isNotNull(block)
+
+          const account = this.accounts.listAccounts().find((a) => isBlockMine(block, a))
+          if (account) {
+            const minedBlock = await this.minedBlocks.get(header.hash, tx)
+            if (minedBlock) {
+              minedBlock.main = false
+              await this.minedBlocks.put(header.hash, minedBlock, tx)
+            }
+          }
+        }
+
+        await this.updateHeadHash(header.previousBlockHash, tx)
+      })
+    })
+
+    this.accounts.onAccountImported.on(() => {
+      this.rescan = true
+    })
+
+    this.accounts.onAccountRemoved.on(async (account) => {
+      const accounts = await this.getAccountsToBeRemoved()
+      accounts.push(account.name)
+      await this.accountsToRemove.put(REMOVAL_KEY, { accounts })
+    })
+  }
+
+  async open(
+    options: { upgrade?: boolean; load?: boolean } = { upgrade: true, load: true },
+  ): Promise<void> {
+    if (this.isOpen) {
+      return
+    }
+
+    this.isOpen = true
+    await this.openDB(options)
+
+    if (options.load) {
+      await this.load()
+    }
+  }
+
+  async close(): Promise<void> {
+    if (!this.isOpen) {
+      return
+    }
+
+    this.isOpen = false
+    await this.closeDB()
+  }
+
+  async openDB(options: { upgrade?: boolean } = { upgrade: true }): Promise<void> {
+    await this.files.mkdir(this.location, { recursive: true })
+    await this.database.open()
+
+    if (options.upgrade) {
+      await this.database.upgrade(DATABASE_VERSION)
+    }
+  }
+
+  async closeDB(): Promise<void> {
+    await this.database.close()
+  }
+
+  async load(): Promise<void> {
+    const meta = await this.loadMinedBlocksMeta()
+    this.chainProcessor.hash = meta.headHash ? Buffer.from(meta.headHash, 'hex') : null
+  }
+
+  async loadMinedBlocksMeta(): Promise<MinedBlocksDBMeta> {
+    const meta = { ...getMinedBlocksDBMetaDefaults() }
+
+    for await (const [key, value] of this.meta.getAllIter()) {
+      meta[key] = value
+    }
+
+    return meta
+  }
+
+  start(): void {
+    if (this.isStarted) {
+      return
+    }
+    this.isStarted = true
+
+    void this.eventLoop()
+  }
+
+  async stop(): Promise<void> {
+    if (!this.isStarted) {
+      return
+    }
+    this.isStarted = false
+
+    if (this.eventLoopTimeout) {
+      clearTimeout(this.eventLoopTimeout)
+    }
+
+    if (this.database.isOpen) {
+      await this.updateHeadHash(this.chainProcessor.hash)
+    }
+  }
+
+  async eventLoop(): Promise<void> {
+    if (!this.isStarted) {
+      return
+    }
+
+    const accountNames = await this.getAccountsToBeRemoved()
+    if (accountNames) {
+      for (const accountName of accountNames) {
+        await this.removeMinedBlocks(accountName)
+      }
+    }
+
+    if (this.rescan) {
+      this.chainProcessor.hash = null
+      this.rescan = false
+    }
+
+    await this.updateHead()
+
+    if (this.isStarted) {
+      this.eventLoopTimeout = setTimeout(() => void this.eventLoop(), 1000)
+    }
+  }
+
+  async updateHead(): Promise<void> {
+    const { hashChanged } = await this.chainProcessor.update()
+
+    if (hashChanged) {
+      this.logger.debug(
+        `Updated MinedBlocksIndexer Head: ${String(this.chainProcessor.hash?.toString('hex'))}`,
+      )
+    }
+  }
+
+  async getHashesAtSequence(sequence: number, tx?: IDatabaseTransaction): Promise<Buffer[]> {
+    const hashes = await this.sequenceToHashes.get(sequence, tx)
+
+    if (!hashes) {
+      return []
+    }
+
+    return hashes.hashes
+  }
+
+  async getAccountsToBeRemoved(): Promise<string[]> {
+    const accounts = await this.accountsToRemove.get(REMOVAL_KEY)
+
+    if (!accounts) {
+      return []
+    }
+
+    return accounts.accounts
+  }
+
+  async updateHeadHash(headHash: Buffer | null, tx?: IDatabaseTransaction): Promise<void> {
+    const hashString = headHash && headHash.toString('hex')
+    await this.meta.put('headHash', hashString, tx)
+  }
+
+  async removeMinedBlocks(accountName: string): Promise<void> {
+    this.logger.debug(`Removing mined blocks for account ${accountName}`)
+
+    const iterator = this.minedBlocks.getAllIter()
+    for await (const [hash, block] of iterator) {
+      if (block.account === accountName) {
+        await this.database.transaction(async (tx) => {
+          let hashes = await this.getHashesAtSequence(block.sequence, tx)
+          hashes = hashes.filter((h) => !h.equals(hash))
+          await this.sequenceToHashes.put(block.sequence, { hashes }, tx)
+          await this.minedBlocks.del(hash, tx)
+        })
+      }
+    }
+
+    const accountsToRemove = await this.getAccountsToBeRemoved()
+    if (accountsToRemove) {
+      accountsToRemove.filter((name) => name !== accountName)
+      await this.accountsToRemove.put(REMOVAL_KEY, { accounts: accountsToRemove })
+    }
+
+    this.logger.debug(`Finished removing mined blocks for account ${accountName}`)
+  }
+
+  async getMinedBlock(
+    blockHash: Buffer,
+  ): Promise<
+    | { main: boolean; sequence: number; account: string; minersFee: number; hash: string }
+    | undefined
+  > {
+    const minedBlock = await this.minedBlocks.get(blockHash)
+
+    return minedBlock ? { hash: blockHash.toString('hex'), ...minedBlock } : undefined
+  }
+
+  async *getMinedBlocks({
+    scanForks,
+    start,
+    stop,
+  }: {
+    scanForks?: boolean
+    start?: number
+    stop?: number
+  }): AsyncGenerator<
+    { main: boolean; sequence: number; account: string; minersFee: number; hash: string },
+    void,
+    unknown
+  > {
+    // eslint-disable-next-line prettier/prettier
+    ({ start, stop } = BlockchainUtils.getBlockRange(this.chain, { start, stop }))
+
+    const accountsToRemove = new Set(await this.getAccountsToBeRemoved()) ?? []
+
+    for (let sequence = start; sequence <= stop; ++sequence) {
+      const hashes = await this.getHashesAtSequence(sequence)
+
+      if (!hashes) {
+        continue
+      }
+
+      for (const hash of hashes) {
+        const minedBlock = await this.minedBlocks.get(hash)
+        if (minedBlock && !accountsToRemove.has(minedBlock.account)) {
+          if (!scanForks && !minedBlock.main) {
+            continue
+          }
+
+          yield { hash: hash.toString('hex'), ...minedBlock }
+        }
+      }
+    }
+  }
+}

--- a/ironfish/src/metrics/meter.ts
+++ b/ironfish/src/metrics/meter.ts
@@ -10,7 +10,7 @@ import { RollingAverage } from './rollingAverage'
  *  * bytes per second
  *
  * This metric will take a sample of how many units were
- * completd each tick cycle and record that in various
+ * completed each tick cycle and record that in various
  * rolling averages.
  *
  * @TODO: Move RollingAverages to exponentially-weighted moving average (EWMA)

--- a/ironfish/src/rpc/routes/mining/exportMined.ts
+++ b/ironfish/src/rpc/routes/mining/exportMined.ts
@@ -8,6 +8,7 @@ import { ApiNamespace, router } from '../router'
 
 export type ExportMinedStreamRequest =
   | {
+      blockHash?: string | null
       start?: number | null
       stop?: number | null
       forks?: boolean | null
@@ -15,9 +16,9 @@ export type ExportMinedStreamRequest =
   | undefined
 
 export type ExportMinedStreamResponse = {
-  start: number
-  stop: number
-  sequence: number
+  start?: number
+  stop?: number
+  sequence?: number
   block?: {
     hash: string
     minersFee: number
@@ -29,6 +30,7 @@ export type ExportMinedStreamResponse = {
 
 export const ExportMinedStreamRequestSchema: yup.ObjectSchema<ExportMinedStreamRequest> = yup
   .object({
+    blockHash: yup.string().nullable().optional(),
     start: yup.number().nullable().optional(),
     stop: yup.number().nullable().optional(),
     forks: yup.boolean().nullable().optional(),
@@ -59,63 +61,33 @@ router.register<typeof ExportMinedStreamRequestSchema, ExportMinedStreamResponse
     Assert.isNotNull(node.chain.head, 'head')
     Assert.isNotNull(node.chain.latest, 'latest')
 
-    const scanForks = request.data?.forks == null ? false : true
+    const blockHash = request.data?.blockHash ?? undefined
 
+    if (blockHash) {
+      const block = await node.minedBlocksIndexer.getMinedBlock(Buffer.from(blockHash, 'hex'))
+      request.stream({ block })
+      request.end()
+    }
+
+    const scanForks = request.data?.forks == null ? false : true
     const { start, stop } = BlockchainUtils.getBlockRange(node.chain, {
       start: request.data?.start,
       stop: request.data?.stop,
     })
-
     request.stream({ start, stop, sequence: 0 })
 
-    let promise = Promise.resolve()
-    let waiting = 0
-
-    for (let i = start; i <= stop; ++i) {
-      promise = promise.then(async () => {
-        const headers = scanForks
-          ? await node.chain.getHeadersAtSequence(i)
-          : [await node.chain.getHeaderAtSequence(i)]
-
-        for (const header of headers) {
-          if (header == null) {
-            break
-          }
-
-          const block = await node.chain.getBlock(header)
-          Assert.isNotNull(block)
-
-          const account = node.accounts
-            .listAccounts()
-            .find((a) => BlockchainUtils.isBlockMine(block, a))
-
-          if (!account) {
-            request.stream({ start, stop, sequence: header.sequence })
-            continue
-          }
-
-          const main = await node.chain.isHeadChain(header)
-          const minersFee = node.chain.strategy.miningReward(header.sequence)
-
-          const result = {
-            main: main,
-            hash: header.hash.toString('hex'),
-            sequence: header.sequence,
-            account: account.name,
-            minersFee: minersFee,
-          }
-
-          request.stream({ start, stop, sequence: header.sequence, block: result })
-        }
+    for await (const block of node.minedBlocksIndexer.getMinedBlocks({
+      scanForks,
+      start,
+      stop,
+    })) {
+      request.stream({
+        start,
+        stop,
+        sequence: block.sequence,
+        block,
       })
-
-      if (++waiting > 100) {
-        await promise
-        waiting = 0
-      }
     }
-
-    await promise
 
     request.end()
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4910,7 +4910,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@4.7.7, handlebars@^4.7.6:
+handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -7154,7 +7154,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@8.0.1, node-notifier@^8.0.0:
+node-notifier@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
   integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
@@ -8639,13 +8639,6 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-getter@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.1.tgz#a3110e1b461d31a9cfc8c5c9ee2e9737ad447102"
-  integrity sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==
-  dependencies:
-    to-object-path "^0.3.0"
-
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
@@ -9233,7 +9226,7 @@ supports-color@^8.1.0, supports-color@^8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-supports-hyperlinks@^2.0.0, supports-hyperlinks@^2.2.0:
+supports-hyperlinks@2.2.0, supports-hyperlinks@^2.0.0, supports-hyperlinks@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
   integrity sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==


### PR DESCRIPTION
## Summary

Some terminals does not support hyperlink, which is diplayed as a result of `miners:mined` command. This PR adds a fallback and displays just an explorer url in such case.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
