### PR TITLE
Only broadcast transaction if mempool accepted it

### DIFF
--- a/ironfish/src/account/__fixtures__/accounts.test.ts.fixture
+++ b/ironfish/src/account/__fixtures__/accounts.test.ts.fixture
@@ -2,21 +2,21 @@
   "Accounts should handle transaction created on fork": [
     {
       "name": "a",
-      "spendingKey": "32b7a3a82a355471d14049b05c5c4e953cd1d677fa6b277b4960b01e9686b459",
-      "incomingViewKey": "b6544f7363522bb886f092d051cd4a05e0210cf8b9a569306cac9f00d34cc701",
-      "outgoingViewKey": "85150ab80f61984398c3c0b48ad6611a731fa273645367a0168acda042f96367",
-      "publicAddress": "c55732263544da0ce82583d7e6003f1a556ed473c0c4b6d17cb8d2497ee2b0e1f63c6af751a6f12855b621",
+      "spendingKey": "02a0d0bcf058021fcd2936bdc82a39f011ea6e3e937d911c208400de8d4a9d0c",
+      "incomingViewKey": "bcdc0dba32d1b3929a9cf6293c88c32dde212b3c0d0b9582617c2b7e3d946e03",
+      "outgoingViewKey": "aad9d72e0d28e0b71bd442a25fe4bba7118fed1dd068984d57a058654c518276",
+      "publicAddress": "5645987277c3f9ae1b33e6fd462ff8b0b14af673f373b82475a78c34914cf0d1394cf4d28d253409164e8d",
       "rescan": null,
-      "displayName": "a (c85070f)"
+      "displayName": "a (79347b8)"
     },
     {
       "name": "b",
-      "spendingKey": "966562246a180649acc404469f581977290a76d1831c359dddf7e07c7fc3f78e",
-      "incomingViewKey": "4c92f7b89305ba02fd52f22020365e000602e46b7104a89561161524e6454a01",
-      "outgoingViewKey": "44360120768efe86262e5f8a849b6f1e333751feabec282bc5c83976055341cd",
-      "publicAddress": "eb2ba3d7e7315934e3cf2ab5a1cab016a0378fb196d1a63b8ede64a1debaa30d7781a4092a53c5c5513547",
+      "spendingKey": "48d32e1cdadec6df9b3281027f3663ee5739079e731a8b7082bfaa5d38a9507a",
+      "incomingViewKey": "ea38d6ac383d74bce04c7aa283baf90b848e9a881602351fd2a85b95d947c202",
+      "outgoingViewKey": "d85cc540422995d1b419fff2757afd6567cbce97afe649173a19a73ff0406305",
+      "publicAddress": "90a034910b8159cd3342d6510c0ecdfd7179359728b4d11fca18838c023879e663ddeff405a93992d857f2",
       "rescan": null,
-      "displayName": "b (5f8ed54)"
+      "displayName": "b (340b473)"
     },
     {
       "header": {
@@ -25,7 +25,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:bcZ9OmCt+/ZsBxxpjjI2vgJqJhO2DAn9gYtu26j+50Q="
+            "data": "base64:Yb9Ll5Ik8QOsrm5sb/A7Db16L5vjbF5gCuCDjc8gCwI="
           },
           "size": 4
         },
@@ -33,18 +33,18 @@
           "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
           "size": 1
         },
-        "target": "11774687128005142414472362328589515158068367854778146730526769217",
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1652195969768,
+        "timestamp": 1653064654902,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "FB700AB314D16160AE217DD6669C9310DF252A6644BE30C653726B7FD2C583CB",
+        "hash": "CE80A93F9B9BAAE29ADF8F8249C9554CD6FAE34ED198A12743FA8767AC05A95F",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIAxxZdySds0IM1U0k+OBt4nkbBRdDj8Uvkr7IqA+UxU3+X2YK01LM2q9+5ayAZdiqukopc9QzvkbuE0Far1AcLKpyeCGJ/FZLXfjeqoy0fFDivwhs2Y848Ag1nnPh2XSQLrAKLSJS+eqtzUY9C6TqYFvST3JxP3I8cIORXOt0hxQ/CTTiu7jXdMGK4h8EoN/4iiJ78y/ZNupqJUW+rH/ZeSzV4bKCGIB6fkh2PuGKTCETMVFf0D9jqE4bm+91dFFcdVqQpM7puL+hI4rE6tJBrjCCGvu01j7+nT17nkF6TTH9Ph1u0NNxsjTvZCX+3Bx2cvl0hNwtVB03Z4Jr1n/RGR/49QCt9XPZAO7oG1/7pgXdJRvgVHXd/JnFBu/j/xxh9H5KwZT+RvKkWrM7Rj3kAa5BrFGzi53vgc+QB5mVYef2+LucEKLvmZSwhG14VgoIKW+lwXOp30NLVm7bZC57wrYbqFpVUhKf0pb/3tGUyZ8CeRlyUdbNYICGRY/2pQt8BU40JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2F1RKr1nVABfhv2hBuzJJpqU8aOp+RyzWqctjWK0XS/WSYIN2FDLAk+Rv4OKt+rage2mD8hGFcY9IDl1ZYU6Bg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJZBX7C+b6Md5TGBrPVBCrp4bmIFPs6+D2O1kzi9+xqXAi5dShDapuRwLnfRM5mQb4bzKiBYP1GI9fh+oYpGIhiFLljFnluHt+KBkgTqtE69sUTFqZgagMlitmqRwBQNnhaW8Yz0IbWWQlanxPpxbSfBq8EhTSnq6ChgUxwX+X6Johoe07HzK+NhDXROpKlnWrh22LT7gIMlNv0r62GaDRN62r06hWfjiekra641o/58KUPlKecTdmRlfVnWqsFvwlLLVY5wOo6xQ4Ew9fmeabbv7gDA8st1dUGEj1Ol1ZyHDJf45KKmM9JunZ0XOfscbIHbF4Xr1UspojK/Y8dc4QEXzseg6dOxEX9LD4dHtY5SPMFxfGJrl3lE6SsSryfShRujlPcZu3QP8ET6Qwk7ElliyF1Oa9HLGkwzyoDj6IWpqOlpjz/TRoBJqarEytJHNW1C4GgGniT1PAbW1HPQngWSEc0+2P9M38eoM5MMq9iJD8ij/2jVjHMCwZGjTaabE9Zo6EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwHIZw969LNAysVHjTwIiqtnsPNbm+rh6kZHkNIOpGFAhhuOUzRva+r818U5CkIZJLHuQabR0oXzGx2XtiFMNlCg=="
         }
       ]
     },
@@ -55,7 +55,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:UcMlcSR4YJSx2HcFwWZQg2NUQwxCT4MyYC68AJqFI1U="
+            "data": "base64:uTZEU6/RgU2Yu+0vXg6qVE1+CyWUc0UpgSLFl3PMpwE="
           },
           "size": 4
         },
@@ -63,29 +63,29 @@
           "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
           "size": 1
         },
-        "target": "11774687128005142414472362328589515158068367854778146730526769217",
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1652195970001,
+        "timestamp": 1653064655196,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "F2E2DA70A88AC898DBA373242E1A8F87B16EDD4D8439C7A7363B192EBCF72F4E",
+        "hash": "26CF4234346CB3DAFDFC019811F22D98AAB57FCF4DDF0F824AEEDB02018E4982",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALkxw68YFGlbZu4c1wKOwEtutPMkig62qMZIZsNaM395MiLCLMZz9ARo/0Pb8UpjT7KA5teDNaYSlEYClTWU3ONOvjh3L3TD7GJOx3La8EkHQYHJqjdlG1D/ET4+r6c+9wM+LN8CVY3dT/IPgx65lUiYyY5voQHXbG0wwy78FGn27Y5LtaqqER29GNVfllgCAauiVi8RlSd+pnugVH35gXFNuK33dYyizrsztFE2lEVmbp95S/knDU9icvasEPySgnn9Bk3suhRCaRZLamWYvTKtwDEQMVnj30qQFfcqpuuN9XIh36kCgISQ4bwe6h9zfSZ6EAnD8bD+lTufg6Fnlkz2qNkjcTUuwUTcHtG7JApVVz6J/4ijYDNy+JheBs33Sq9lwKkrRfwcQ8p97VZtWNR+QvMLeuhBStCIB881ldzE3wfALtSlLGOkX4tJAJDhhNkGVBEjUXT4LhCtTNtS1ICs7maIbXerPOa8Gg8EnXfY1XWXxLaE7bwkZdSIwEUaDYVh9kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/fdzkws/hl9RQxiCNObYi1dUvDOKFVN2fib3zIgQ8RUDsNqdipzI4Tc+cRZdkeBsi/xKrZqvh1dLElUdjvtGCQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAImeveOg2s5RLOkem7ToE7m6Sw5k+btfKQw9phCaupw8twK5q+02U1kb8O5ZJlGc05EGWqx9QJqWRCST/Be37T6OdmJF1hhthkhy464ExUzmSDSLivsBcfxaWuRqCcRnxAOP8e+/rNO/VrxyXLhsvaL9qYbK5r2Fp5XilZg3E2mupdJ0ZN7s/JEDjwwL3tS7xJNnswk1BBmywyoIi9v0mX45cmRcHK/fDwhtRd4UuqqjWunPQtGbw4s498yb7KSu3EWHD2LiFb1WHYT4cvVhdgKFwq4Z6nUz3i+sCXKM1UbDSIC6G75wqvk57pnRziuVB5Q33ToDmtkStp981vavIh/uFaI3M3rG1Bg3CAxtG/ciziKMrFictY7SQaxzP05mkWGzJCPxYj/w/8Vb/yOih8LZzm7fc607opV4pr/+I8L6bLEF/Z08Ctycxv9Y2ZZedtAD3ABFURGLPTRf40hlqwKJVAxp8Sq9V/WauDhlt+gDh+qN0AIDj/pEh0cLGHGoL3KGekJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJZgN8/cYwP9eHE1o3osg8zU2ooUvskJAybYxyLUlojxnI0lbAqOcKK33Vl1ct4WatZwSrjKLsv/0Ot1+MnCMBA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "F2E2DA70A88AC898DBA373242E1A8F87B16EDD4D8439C7A7363B192EBCF72F4E",
+        "previousBlockHash": "26CF4234346CB3DAFDFC019811F22D98AAB57FCF4DDF0F824AEEDB02018E4982",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:5xIBNyg+q12y2usZ6sIBtrr9jM8GR49xRJzTYguwB1Q="
+            "data": "base64:66trNgJ5VHVxNMrIJxq897ZOrFj+N6zGyxGzCiF+xEY="
           },
           "size": 5
         },
@@ -93,24 +93,124 @@
           "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
           "size": 1
         },
-        "target": "11740291742042881642188457353024386171232138562511437803558702248",
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1652195970221,
+        "timestamp": 1653064655467,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "8666F1A75E07229C26A1743F2B435A740DA8CD10394034DA6E0031C86BB261F1",
+        "hash": "949F08CA82C53C760E1278E42D617D4E1A56B3FEF19B9C2DEA36D21275CD7523",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKSG5JUtwmqm9uorcCymVO3rjwVJ/eCknHo35qz+CNuRxpujs5Sw8jAJGjwgebF9woGkaUHp2PBCleAVfIO2qOMikAJ93tCjNggqo51ydxf2brVhLQyB1k8Z49x3rn4PYRD6yq+8hCg3FsHYKWNL66dD3LkIuy81B8ZmIrja+njXjbtk4kHS2RMby3X4fzmqDpPNpFXAhoLZFKO1D2rxD7Pl81RUfp5m07eTmYtSNtgb0IDeR/pDXxX3CVlde1KWeRhH06fkiqA8vO8vxfGdseIFyxHjXYX4jLU2spGwjw6TzSbzG33NNHv2SrtvsZGLRO3D/QEAYJw9zeSguqCN+WKzfcLlxa6NvanMQQXujIgxpAoW5Rqira5KjgnySLJ+Lu09vFrc6Zjd9uloOtQcisqPY0+uOVYHssjKRmzlbNsXzHdCiMS9svNHGtR3zeWz1Ak8Flzu2rMdZ2eLiBny8JEmJSx3QARegErvCfXZ2R0xs/EkIpDGlw4ThEuPvxKvRvdITEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwj4aX/GFz1urgli16XyLn+uGwQYiTEoHRfBF8144AvipVn+vOix9QcHa4kfrmpG5bDDqF36IGR04Bd0oIQr4eAQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJIEOtpcTPZ/0gqYjNK2OCpSYntUCBCIEA+2Pud//lqtzrapPXqqavuB1u5zk9IRI6FohzjhbSwJceXk2kAaT3ksFxGaB70KTrcpibizM2ZDdX0WnyoPQJSsdGI9Tn4rTwGAVasSzIXU33x+BgQ91Ua9NeghlG8jqOzuiQlV47YciQycD29zdKKrv4lb3XL+HrYU6st8I45iTpQix++V8Xb0ghZk0me8Y6VwjCepwmdb9Yj62tdmqiCwLrAEagyrLIqiLnqCPfpCjU6VmkzHy1XH9GKpWlGHhFRrvz0168vdLUCh1nLKY7cLlu89RaSNrlKK2bT53WHfLvrxQoK0JQtPYiKXASi8+3/tNZCUcEf3qKLZnaEERcaJeZRM4QcBcq3K/xCV1tbLjkw11VHGvcMhXW17+aQwr3tQUCAFKxvHFVaH2UrvmEYJ8gRKVoxCTrRHFUtnO/pWu5vSwCQeQSyd+tA7NyXu6MlyP35QPkjimXOT/tsmjhVFXEiFCzQ2pohIPkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw96QP6H0R3ruVOUpkt/TxwxmKX1Opgv79tf8LfEeiyBpr+k8ZPPteLCZycVNyX3OCN+s9TAThVEFZtdNymxt7Bg=="
         }
       ]
     },
     {
       "type": "Buffer",
-      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAALXb85JH5PCP4Uc+CqTqRR+id6cafm7tvc9sqW/tKPP/QjFf5loddl3BwKpy+rOXuYAH6pzu399NNb6c3BpsyrvhzB7qRZii4nBpjul47j/nxB52GZ44XxCc0spM53yDdwpfz/p93QCy6I4AgA9RposszmTdUg00KjkRAJXJPyexq5K2W727oCXirDLZQ2Of2K5HUzjpQSrtVQFog4Jtvka4hRSKaLCy7Oa94VmXYg86GPeKWfN2K6v1a/a57UJfPS0O+yofcQbLAY2k6rpIxp4gSCfctgyzbjl/cvtrfbM3Z1sR1Svf6DAau6erNTgRIjwpt85V1QbFbQTUoCAHNWRtxn06YK379mwHHGmOMja+AmomE7YMCf2Bi27bqP7nRAQAAAD9sO/mCQhAjyOFTFY9eQCeXJeTkssPVzzl8W+AK8ttAkvOtkFMwLgUXLJ6Pkkuc7OYluqCqJuIL1QM9Qm8X6iqoxSMPLqw5h6BeDSoM9WpkxWuq8/dR9mMkGWbSgeM2QCMN065WEXolXkZ704aq6q67v52ZJXeG6cq5//GXIrO3FGK8oPFVzwUATC6KNfnD+mnKbX0EOL/NaZS/YE7hnuOWduhg7aC8ZiaQUWM43YDTTGTXQnosISRIFfUvtaykXMLU/YEYbSlq3CC7/MS0fZd+quSAqQ16TfXBZafLsTVTmwSVHsg1dX7u7NHzZcx+iSv4gVwMnoxAMwMfZFTYdeDKDopHpl2XEl/26Iqh7RE0n1KH6SMB/n4KDpvncArslL9yyRRWUXUniKCnNNTiO2jRF+Jdf+3s7M/mh13OdB5RZZ5buri2G1ZMaugzzgrPr+QyTI0wVZcrHM/pDbq/cQgJ17fMAqgeDSB/4sCqmKX4HenTGkiP5wofcv6vAym1wyJZyVCwkABRi72nRcF5WtybeT3luya3eMAaqyUyb7RYaAudbG+DpAiDkdgNUApxx1Ihk8YYoR76K6DkUrV5zGkpS7m2eksn0fhxaW4bTYjufQ83cNLigjWKe577qIrQiDuZGdBZmxNHJq+hzNCkgEc0o4dUM4HJ93IQzC6rMfK+rtBqrxkIPMbf+9M6PDUtcCptuNjw/MmtF9zE7oTQ6ZFYiTq/eglWjTSI0RcMQumfe6S87hSw0TgVUDLsoqB20gzpxDvZr+C6Vc2Vsbkl42a1v8d6zP7kI9M9HshNBF5r/92upO0T3kUtFkLj81oUtEQAeuQSqi1h6I/dULTH+mqZNccyQQ5I5S/bppj3mr46PGoTAZHpat21kRcOWbQcd8GHCSrKj++GczSxE99+q7ydM+Wzs+QuMMJBaf3GPK/VlrARZDgdPBlLJ0j2cyEOItYgrN5KqvORLpziWr26EvFvLsdrZgXHQZNtGOZ6AIO/3EfNBaZ5y6R9Qxno2yOHuI7AV7JQG0saAzTRZSkiW6krkfbNB83rTnMLXmN2mucijwlj4jfqmaPt1feg3AU1n3oaQThpnAgAaDORHIT6HoCaq9kx84zYSxlsEJJYTjkIXogCs1KFSABmoIwmfNVeevePcNfEaYqt6GznutTl+LwUCBRjfab81baP1km8kezKbPNHYAKlrYMwcEMdZUhaySIMpIWNmJnka6tb1sTtKBrnWtZcv+np2x74e8Rj95NdzLW3wOhP53t1AvMMUx1qjbMkA2OvLYpdxDTi8lmd/CsucbzKuyFF4n3m2paFXF4PJHSF3L+ni2p1luKrBKUzCnhgUtthwfDLgsXys2+NyCaLGnsAkrGITJm8ZM9KZNBFZqSziCSkgBwIMk2PCHqa6NmgzlcQINI/jI3r5HDyUlbAsgKDqCrscktis2lyk+Tkgip5PLVCw=="
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAALYBxfHYwAI7jVDDjk8ZbmXXKTXGnmvuS4oDzv7LheTG1kRL+vXK/e/HyAlBIAPTuaW1IyIzEUihY42hHd54y8MLLVV8vDv+fO+lf/Dqw2nXOZPmGQViC5ouoojnRb23zA4bZl5XrYP/UIi+doe8HJSoFR4BEGSJLnXHEW/lZS9ugLjj/O03xjmF8Mse23PPfpbHXZ6UTsGnufVvHlj4SZ/DYgId/w2w7N9sZLqLCX6/JVc0g/Uuh5RyWZ2D5YIcvpc/rZ88KkobOrkCkZ5jyGPm62pZDfvjOkGq1x5iDz1bN7JAleTuU70R2M6kUbL7AuEAHOtZBW8cjHgaGfxosFxhv0uXkiTxA6yubmxv8DsNvXovm+NsXmAK4IONzyALAgQAAAAIV9LHCGdGuLStFyv4VMUWCY7ZKEb4Q+qQI2MdOleZJ9XJduAhAm1kOFKThoL93dj6RxDrPCxC577z3kdLsa06/lsCqsUSwoxRsA5LMhuoPLuVeEakAGptfr4PWVk3PgCV+9CV6Vgyi5W/uuf2IZqzy21RsVBp+BDaozLzxdfj8ZTvzP/4MhxL5V+2knho6kOQgOsXOcQcRk0T+YGxZF23/fmqU1qPvV0YGLPnxGyVuQbU2BndId5c02xFAuWLYUEYrmVwqfff3FJO0UhxisuIRjbkVHVnBxNyXgr0FfJhc3mAL9QJWKPUJtSLwiMtWj+FBliB2aYvPXKwsmdtYWJTKyt/yfellafFvJHjrdiuhVd6dC9cMPA/APXBRiowEDswwMVN2H0a0noFIcfe/NZ0qaekwPsQB9fYLGzIxQppcLON1yKGeoMA8rNFLy+cMuL5xVy7MVw7PUlszmPFycwR6Hz86f5zOGHzu5xOz/f8ETn859TFbnRHJv8JzQUA909Oh9IXDRsPmor5zqPKn68aunjYHfu/EVhAYm6ULI04v7dno+yGIuL4+IFAP541oW0KjYWtL0V6wyBqU6bSAnSxTrPiqEbbevKjMcOU428G2VGj8zIbBIMdHxWjYWpg1c6ZSK2wmonvJln9rM8LbmhifjdNF5HeeIcCIgFy9cUTwY5SUYMpkgKfTdtfRoRqIw8PxCzSw3vj7LLr7PLqAj8jJpK5Qsdi+cTGksPSEKslhTeyobIHW8EJJhGjldv6tnvr2tAxmKjFc4LNfY+9TFEXvDnYPrQpYpNBABD8zQmJHejUroA5tymiNzJ1yqRw0q1l7CnOBWXMFNtvTGaDjS8HBQuUgsEn1q9V3uOfxRtNB2aIAQz54sE/7W7fsXy5WNXO8UIl9k+j1c3XaPDoxGMWpdkr71iCnAfRSw6emPf0wWTmgY7FCQy/VMwRyCEIzHC61VbeLupiuLYB8Zb9v8JTYzS1FEv2y2bk82vGse5Y8WbcezXJZzIkFNYcx3v2PFA84XUMo523j4e/ah+f4XKTR4fHO8pR9cfyYJ3M2KlZDzAtcGLbQvMic4FEzThdgyILf2NyZNarPKNMAK2D17GTcdjcAu1A8wbgTXp0cdBNo86PcjzsLd5+BF7eNJsRWuum7RqLWiZFa+5scZpvw7R/FrMYkQOiE7mR+vCqX5mdlvVIrkUtFScISR1F9J6aMYrDOxRHazsvehmu5jIvvE8+CQHbJdG2CN7LjVwZcKIVX3Hi2DDrHh/0L87HVV7E2fMfpbTqSbapeg2uAHULWdZfhnME86n+y+SulHFiatpsJ+oOYkCc8N3CSbwE9tYxtj14Bq2NQ83xXty1OsLYWtMFr77iMf9A0Z+ZAV/mMY8jbOXcNOeYSQVJHJ525yDdsGHMzFpVdTpDESfXdzuSH/48/jL/K5/x3/fFALNMsVVLkwaiGKM6DQ=="
+    }
+  ],
+  "Accounts pay should create and broadcast a transaction": [
+    {
+      "name": "accountA",
+      "spendingKey": "82bbbb72cd467e9f8dbfc22cd1b579ce50d01494b45656de09af69333230fdb6",
+      "incomingViewKey": "67f6230dba4e33dbe439ce0cc76538515830b126c86f1c6688d801220331ca06",
+      "outgoingViewKey": "5cd35f89d51cf6cd46ea700bf21460e1174c11b14d4f9f9224ba655c20b2b9b9",
+      "publicAddress": "bc630aae711b74c0119cbda469f689d22ec7e78141afee74efd9b5300f924684b878b4c80cadfb64b34d20",
+      "rescan": null,
+      "displayName": "accountA (2324a11)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "f9c2f13e44859f7d5c865f7c5c8949a15ba77d56a46e9b270dcb5edb4663312e",
+      "incomingViewKey": "c835c4fe885ea7ca05f36255fecfc0f618001da16f5970bd003110553a376203",
+      "outgoingViewKey": "700dde58b0e99d48448ef700b695c18955e208052db08d381c99abea94b12e44",
+      "publicAddress": "bfe579fd38dfd1722daad3de7c32d8e64996e37b959716ee13b55a8fc15db124c251b44172dcc76b4d6ec7",
+      "rescan": null,
+      "displayName": "accountB (3cdc467)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:DrhYFCWm6/Dg+Yuiva/PhpC8cuhhvA8qTs+DB5oodSc="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1653064658114,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "144B75841666511F68D428324AA84EE87672B53EAD5AA17AA57CC649E4594434",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKp9IKEq6lzS0jxIBC1l5nSQeyulhYsDqIKEg4/GnS+mFjPRbQh/WmqfwSLLfSGShJloN00/4nPiStRxNVUZn5Dh7TTggSU0giceLsYmffvsxWIdGqEtKob3Ok3OXfNXBRmoVZ7W9scRyDBqxpMH+oLcRapBCBknBFxCcd+E1tsKJMswqIjzG30olUFjMWxVIZjtBNSAEmOttdBAPJnWnBE1ci0iH+Gai385qWFmrpBfpjlYNU9q1IUTxETmUif9IclPg+V7TvqIZ6QN//sOuYT//pGX1rnVGNQ/eUcFZgDFryOKUvYWzQ9d4BfdaFxQj5iVv6mVatawuSo8W9ZEglNhGP7rC+BvlhI7q+lKMl2QGi7akNpIYLEGtnktRoJzAN+DNSWAezeViWqEnDWBZNkHBpworA7ofllZcUrGQsb3d5awjWd9n8+bCTuYtzW1girZ614PJfneMqQCsYYjDw1H3nFHCNrMgKOCny8Yz16xmuLUQxQHFl0uQXoqYstn+TzSikJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwY5pbS9NtgR01HHomKzaVgE0WO/UZHF7wHqvpH5nDRa9iqolaYeGhlGkAfYSUCWLgY7suO736tLKShwEZPCB5BQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts pay should not sync and broadcast a transaction rejected by the mempool": [
+    {
+      "name": "accountA",
+      "spendingKey": "3924895649d6143c317ded57ddc3063f7d7b35ddf65980bcad21df5c33a4a1e8",
+      "incomingViewKey": "b07f0d59f863358c79107fb6f99b34034a5621efd7943e230d5ab431fc6cdc04",
+      "outgoingViewKey": "ce9388fed757ec162c9a62fd14085357cca0e208853931f09ad0e51f6acfe8ea",
+      "publicAddress": "fce8ffbbb57e03d60250483777a82a6b0aeaf77b7596d7e576a3513ed06933ae4f3b78a9983bd181d1f31b",
+      "rescan": null,
+      "displayName": "accountA (da1c43d)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "88a3ec2b95bba61de0d4abb50aea74965b59afba3902e2d59cf3fe7bbe2f5df9",
+      "incomingViewKey": "338639394420c62ab98ad0e99f025707cb9e75a42256dd68612e3af76158e902",
+      "outgoingViewKey": "a3785f2ee289381dcde929de988b37c4da080ed1ecd0bc2232f031ba8cd28446",
+      "publicAddress": "1bdaa92a64e212b7050c28b24bfa036dc5e6e82db46b7a523853ccf4a49f64d89a9e2c1fda833fb345d1a1",
+      "rescan": null,
+      "displayName": "accountB (c089a0e)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:Sk0IZ4f/D2AtdCoYjLMtvi/j/DoCUqQgKoFO9n2RNxg="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1653064660511,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "79F75A32FFCAF659AAF4A3741AD30AA1B7F18DC67B4AA0DF331DFD0F1A4B2869",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIIhsfOyimc2M4iIGgDY/e64CiF7pY/gASkgW7a70rr0wKxv/+I9RcQc3z1y9ELIK7CwJmr3hMYz7fB+hc7BeiIf52gjP3YZdyUEmYd4EIVDKCC/r4/0iUpfSQlt4gST6Qg4997N6XMEJzHU2aYAvBU2O9OkuK1sA4lbHYS4RO1Vg9fwWnOyFHd9PF5x6CcrG63wR211O1f3G2QUXhFdcvCuyU2fYM+zLef6snlBJN+g+s1dYQgbQtpFIOEu7FaqVlm7dMo5eQ7KKZZC/dYl+a7v8rwrZR7sQTPg96KVQJacFhhRBc1d07XTuBr8k9nXynCFMExYtemOsOWub6ZOKBJI0b4whj/8pPjyoVZod5Wo4MLcLmrXYy1ysj8sMLw1kuxbbl0SFDygqTJkNOG1/hCHl/+C0aYSqr6Fdbds/dXpd+xIyGnALI8w3WytB9DVKoXE6f7Bk38AJqTA+vKKv+fwk8pMMoL2KKPy6OBtDj/DqSSnjopqogWCcSGs5z6u90fVekJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1u18kBjQJMsMCc0bzpUyXwJvsrmrqBc75KeTWo1JQFnggxnT0RcByL2FdH3AEzkB8RY/i0qrtpZV04/8k/gICQ=="
+        }
+      ]
     }
   ]
 }

--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -126,7 +126,7 @@ describe('Accounts', () => {
 
       expect(broadcastSpy).toHaveBeenCalledTimes(1)
       expect(broadcastSpy).toHaveBeenCalledWith(tx)
-    })
+    }, 10000)
 
     it('should not sync and broadcast a transaction rejected by the mempool', async () => {
       const { node } = nodeTest
@@ -159,6 +159,6 @@ describe('Accounts', () => {
       expect(acceptTxSpy).toHaveBeenCalledTimes(1)
       expect(broadcastSpy).not.toHaveBeenCalled()
       expect(syncSpy).not.toHaveBeenCalled()
-    })
+    }, 10000)
   })
 })

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -683,7 +683,10 @@ export class Accounts {
     )
 
     await this.syncTransaction(transaction, { submittedSequence: heaviestHead.sequence })
-    await memPool.acceptTransaction(transaction)
+    const accepted = await memPool.acceptTransaction(transaction)
+    if (!accepted) {
+      throw new ValidationError('Mempool rejected this transaction')
+    }
     this.broadcastTransaction(transaction)
 
     return transaction

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -682,11 +682,12 @@ export class Accounts {
       expirationSequence,
     )
 
-    await this.syncTransaction(transaction, { submittedSequence: heaviestHead.sequence })
     const accepted = await memPool.acceptTransaction(transaction)
     if (!accepted) {
       throw new ValidationError('Mempool rejected this transaction')
     }
+
+    await this.syncTransaction(transaction, { submittedSequence: heaviestHead.sequence })
     this.broadcastTransaction(transaction)
 
     return transaction


### PR DESCRIPTION
## Summary

We allow the `pay` function to broadcast a transaction regardless of whether our local mempool accepts it or not. If our mempool rejects it, we probably shouldn't broadcast it, as others would probably reject it as well, leading to wasted gossip

Note to self: This likely shouldn't be necessarily possible, need to confirm this first with a test.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
