### PR TITLE
Refactor MemoryClient

### DIFF
--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Assert } from '../../assert'
 import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
 import { MemoryAdapter } from '../adapters'
@@ -9,33 +8,24 @@ import { Response } from '../response'
 import { IronfishClient } from './client'
 
 export class IronfishMemoryClient extends IronfishClient {
-  node: IronfishNode | null = null
+  node: IronfishNode
   adapter: MemoryAdapter
 
-  constructor(logger: Logger, node?: IronfishNode) {
+  private constructor(logger: Logger, node: IronfishNode, adapter: MemoryAdapter) {
     super(logger)
 
-    this.adapter = new MemoryAdapter()
-    this.node = node ?? null
+    this.adapter = adapter
+    this.node = node
   }
 
-  async connect(node?: IronfishNode): Promise<void> {
-    if (node === this.node) {
-      return
-    }
-
-    if (node) {
-      this.node = node
-    }
-
-    Assert.isNotNull(this.node, 'Memory RPc client requires a node')
-    await this.node.rpc.mount(this.adapter)
+  static async init(logger: Logger, node: IronfishNode): Promise<IronfishMemoryClient> {
+    const adapter = new MemoryAdapter()
+    await node.rpc.mount(adapter)
+    return new IronfishMemoryClient(logger, node, adapter)
   }
 
   async close(): Promise<void> {
-    if (this.node) {
-      await this.node.rpc.unmount(this.adapter)
-    }
+    await this.node.rpc.unmount(this.adapter)
   }
 
   request<TEnd = unknown, TStream = unknown>(

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../../assert'
-import { createRootLogger, Logger } from '../../logger'
+import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
 import { MemoryAdapter } from '../adapters'
 import { Response } from '../response'
@@ -12,20 +12,20 @@ export class IronfishMemoryClient extends IronfishClient {
   node: IronfishNode | null = null
   adapter: MemoryAdapter
 
-  constructor(options?: { logger?: Logger; node?: IronfishNode }) {
-    super((options?.logger ?? createRootLogger()).withTag('memoryclient'))
+  constructor(logger: Logger, node?: IronfishNode) {
+    super(logger)
 
     this.adapter = new MemoryAdapter()
-    this.node = options?.node ?? null
+    this.node = node ?? null
   }
 
-  async connect(options?: { node: IronfishNode }): Promise<void> {
-    if (options?.node === this.node) {
+  async connect(node?: IronfishNode): Promise<void> {
+    if (node === this.node) {
       return
     }
 
-    if (options?.node) {
-      this.node = options.node
+    if (node) {
+      this.node = node
     }
 
     Assert.isNotNull(this.node, 'Memory RPc client requires a node')

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -89,7 +89,7 @@ describe('IronfishSdk', () => {
         const client = await sdk.connectRpc(true)
 
         expect(connect).toHaveBeenCalledTimes(1)
-        expect(connect).toBeCalledWith({ node })
+        expect(connect).toBeCalledWith(node)
         expect(openDb).toHaveBeenCalledTimes(1)
         expect(client).toMatchObject(sdk.clientMemory)
       })

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -7,7 +7,7 @@ import { Config, DEFAULT_DATA_DIR } from './fileStores'
 import { NodeFileProvider } from './fileSystems'
 import { IronfishNode } from './node'
 import { Platform } from './platform'
-import { IronfishIpcClient } from './rpc'
+import { IronfishIpcClient, IronfishMemoryClient } from './rpc'
 import { IronfishSdk } from './sdk'
 
 describe('IronfishSdk', () => {
@@ -82,16 +82,14 @@ describe('IronfishSdk', () => {
       it('returns and connects `clientMemory` to a node', async () => {
         const sdk = await IronfishSdk.init()
         const node = await sdk.node()
-        const connect = jest.spyOn(sdk.clientMemory, 'connect')
         const openDb = jest.spyOn(node, 'openDB').mockImplementationOnce(async () => {})
         jest.spyOn(sdk, 'node').mockResolvedValueOnce(node)
 
         const client = await sdk.connectRpc(true)
 
-        expect(connect).toHaveBeenCalledTimes(1)
-        expect(connect).toBeCalledWith(node)
         expect(openDb).toHaveBeenCalledTimes(1)
-        expect(client).toMatchObject(sdk.clientMemory)
+        expect(client).toBeInstanceOf(IronfishMemoryClient)
+        expect((client as IronfishMemoryClient).node).toBe(node)
       })
     })
 

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -146,7 +146,7 @@ export class IronfishSdk {
       config.get('rpcRetryConnect'),
     )
 
-    const clientMemory = new IronfishMemoryClient({ logger })
+    const clientMemory = new IronfishMemoryClient(logger)
 
     return new IronfishSdk(
       pkg || IronfishPKG,
@@ -275,7 +275,7 @@ export class IronfishSdk {
     }
 
     const node = await this.node()
-    await this.clientMemory.connect({ node })
+    await this.clientMemory.connect(node)
     await NodeUtils.waitForOpen(node)
     return this.clientMemory
   }

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -30,7 +30,6 @@ import { NodeUtils } from './utils'
 export class IronfishSdk {
   pkg: Package
   client: IronfishIpcClient
-  clientMemory: IronfishMemoryClient
   config: Config
   fileSystem: FileSystem
   logger: Logger
@@ -43,7 +42,6 @@ export class IronfishSdk {
   private constructor(
     pkg: Package,
     client: IronfishIpcClient,
-    clientMemory: IronfishMemoryClient,
     config: Config,
     internal: InternalStore,
     fileSystem: FileSystem,
@@ -54,7 +52,6 @@ export class IronfishSdk {
   ) {
     this.pkg = pkg
     this.client = client
-    this.clientMemory = clientMemory
     this.config = config
     this.internal = internal
     this.fileSystem = fileSystem
@@ -146,12 +143,9 @@ export class IronfishSdk {
       config.get('rpcRetryConnect'),
     )
 
-    const clientMemory = new IronfishMemoryClient(logger)
-
     return new IronfishSdk(
       pkg || IronfishPKG,
       client,
-      clientMemory,
       config,
       internal,
       fileSystem,
@@ -275,8 +269,9 @@ export class IronfishSdk {
     }
 
     const node = await this.node()
-    await this.clientMemory.connect(node)
+    const clientMemory = new IronfishMemoryClient(this.logger)
+    await clientMemory.connect(node)
     await NodeUtils.waitForOpen(node)
-    return this.clientMemory
+    return clientMemory
   }
 }

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -269,8 +269,7 @@ export class IronfishSdk {
     }
 
     const node = await this.node()
-    const clientMemory = new IronfishMemoryClient(this.logger)
-    await clientMemory.connect(node)
+    const clientMemory = await IronfishMemoryClient.init(this.logger, node)
     await NodeUtils.waitForOpen(node)
     return clientMemory
   }

--- a/ironfish/src/testUtilities/routeTest.ts
+++ b/ironfish/src/testUtilities/routeTest.ts
@@ -40,8 +40,7 @@ export class RouteTest extends NodeTest {
     const setup = await super.createSetup()
 
     const logger = createRootLogger().withTag('memoryclient')
-    const client = new IronfishMemoryClient(logger, setup.node)
-    await client.connect()
+    const client = await IronfishMemoryClient.init(logger, setup.node)
     const adapter = client.adapter
 
     return { ...setup, adapter, client }

--- a/ironfish/src/testUtilities/routeTest.ts
+++ b/ironfish/src/testUtilities/routeTest.ts
@@ -4,6 +4,7 @@
 import { Accounts } from '../account'
 import { Blockchain } from '../blockchain'
 import { Verifier } from '../consensus'
+import { createRootLogger } from '../logger'
 import { PeerNetwork } from '../network/peerNetwork'
 import { IronfishNode } from '../node'
 import { MemoryAdapter } from '../rpc/adapters'
@@ -38,7 +39,8 @@ export class RouteTest extends NodeTest {
   }> {
     const setup = await super.createSetup()
 
-    const client = new IronfishMemoryClient({ node: setup.node })
+    const logger = createRootLogger().withTag('memoryclient')
+    const client = new IronfishMemoryClient(logger, setup.node)
     await client.connect()
     const adapter = client.adapter
 


### PR DESCRIPTION
## Summary
The [MemoryClient](https://github.com/iron-fish/ironfish/blob/c6a17e98b1f9add2e5727ae3f03676fe14ad0fac/ironfish/src/rpc/clients/memoryClient.ts#L22) is an interface to all the methods you can call on a node like /getStatus , /accounts/balance  etc. It is similar to the TcpClient or IpcClient but it does not connect to a server remotely. Instead it just makes direct function calls to the node. Because of this we want to refactor it to not have all the same functions that an RpcClient might have such as connect . If it is just making direct function calls then it doesn't make sense to connect  to anything. This should simplify the code quite a bit and make it easier to tackle TCP security because we don't have to worry about the MemoryClient functionality which should be unrelated to TCP connections

## Testing Plan
Unit tests + local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
