### PR TITLE
Remove dead code in RPC layer

### DIFF
--- a/ironfish/src/rpc/adapters/adapter.ts
+++ b/ironfish/src/rpc/adapters/adapter.ts
@@ -18,12 +18,6 @@ export interface IAdapter {
   attach(server: RpcServer): Promise<void> | void
 
   /**
-   * Called when the adapter has been removed from an RpcServer.
-   * This lets you clean up state you stored in attach()
-   */
-  unattach(): Promise<void> | void
-
-  /**
    * Called when the adapter should start serving requests to the router
    * This is when an adapter would normally listen on a port for data and
    * create {@link Request } for the routing layer.

--- a/ironfish/src/rpc/adapters/ipcAdapter.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.ts
@@ -190,10 +190,6 @@ export class IpcAdapter implements IAdapter {
     this.router = server.getRouter(this.namespaces)
   }
 
-  unattach(): void {
-    this.router = null
-  }
-
   onConnect(socket: IpcSocket): void {
     if (!socket.id) {
       socket.id = uuid()

--- a/ironfish/src/rpc/adapters/memoryAdapter.ts
+++ b/ironfish/src/rpc/adapters/memoryAdapter.ts
@@ -33,10 +33,6 @@ export class MemoryAdapter implements IAdapter {
     this.router = server.getRouter(ALL_API_NAMESPACES)
   }
 
-  unattach(): void {
-    this.router = null
-  }
-
   /**
    * Makes a request against the routing layer with a given route, and data and waits
    * for the response to end. This is used if you want to make a request against a route

--- a/ironfish/src/rpc/adapters/tcpAdapter.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.ts
@@ -104,10 +104,6 @@ export class TcpAdapter implements IAdapter {
     this.router = server.getRouter(this.namespaces)
   }
 
-  unattach(): void {
-    this.router = null
-  }
-
   onClientConnection(socket: net.Socket): void {
     const connId = uuid()
     const reqMap = new Map<string, Request>()

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -24,10 +24,6 @@ export class IronfishMemoryClient extends IronfishClient {
     return new IronfishMemoryClient(logger, node, adapter)
   }
 
-  async close(): Promise<void> {
-    await this.node.rpc.unmount(this.adapter)
-  }
-
   request<TEnd = unknown, TStream = unknown>(
     route: string,
     data?: unknown,

--- a/ironfish/src/rpc/server.ts
+++ b/ironfish/src/rpc/server.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { IronfishNode } from '../node'
-import { ArrayUtils } from '../utils'
 import { IAdapter } from './adapters'
 import { ApiNamespace, Router, router } from './routes'
 
@@ -73,16 +72,5 @@ export class RpcServer {
 
       this._startPromise = promise
     }
-  }
-
-  async unmount(adapter: IAdapter): Promise<boolean> {
-    const removed = ArrayUtils.remove(this.adapters, adapter)
-
-    if (removed) {
-      await adapter.stop()
-      await adapter.unattach()
-    }
-
-    return removed
   }
 }


### PR DESCRIPTION
## Summary
There seems to be a lot of unused code in the RPC layer that getting rid of would greatly simplify future refactoring.

## Testing Plan
Unit tests and local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
