### PR TITLE
Combine MemoryAdapter and MemoryClient functionality

### DIFF
--- a/ironfish/src/rpc/adapters/memoryAdapter.ts
+++ b/ironfish/src/rpc/adapters/memoryAdapter.ts
@@ -9,7 +9,6 @@ import { Response, ResponseEnded } from '../response'
 import { ALL_API_NAMESPACES, Router } from '../routes'
 import { RpcServer } from '../server'
 import { Stream } from '../stream'
-import { IAdapter } from './adapter'
 import { ResponseError } from './errors'
 
 /**
@@ -18,18 +17,10 @@ import { ResponseError } from './errors'
  *
  * This is useful any time you want to make requests without hitting an IO layer.
  */
-export class MemoryAdapter implements IAdapter {
-  router: Router | null = null
+export class MemoryAdapter {
+  router: Router
 
-  start(): Promise<void> {
-    return Promise.resolve()
-  }
-
-  stop(): Promise<void> {
-    return Promise.resolve()
-  }
-
-  attach(server: RpcServer): void {
+  constructor(server: RpcServer) {
     this.router = server.getRouter(ALL_API_NAMESPACES)
   }
 
@@ -51,8 +42,6 @@ export class MemoryAdapter implements IAdapter {
     data?: unknown,
   ): MemoryResponse<TEnd, TStream> {
     const router = this.router
-
-    Assert.isNotNull(router)
 
     const [promise, resolve, reject] = PromiseUtils.split<TEnd>()
     const stream = new Stream<TStream>()

--- a/ironfish/src/rpc/adapters/memoryAdapter.ts
+++ b/ironfish/src/rpc/adapters/memoryAdapter.ts
@@ -5,44 +5,27 @@ import { Assert } from '../../assert'
 import { PromiseUtils, SetTimeoutToken } from '../../utils'
 import { RequestError } from '../clients/errors'
 import { Request } from '../request'
-import { Response, ResponseEnded } from '../response'
-import { ALL_API_NAMESPACES, Router } from '../routes'
-import { RpcServer } from '../server'
+import { Response } from '../response'
+import { Router } from '../routes'
 import { Stream } from '../stream'
 import { ResponseError } from './errors'
 
 /**
  * This class provides a way to route requests directly against the routing layer
- * return a response from the route The two methods are `request` and `requestStream`
+ * return a response from the route
  *
  * This is useful any time you want to make requests without hitting an IO layer.
  */
 export class MemoryAdapter {
-  router: Router
-
-  constructor(server: RpcServer) {
-    this.router = server.getRouter(ALL_API_NAMESPACES)
-  }
-
-  /**
-   * Makes a request against the routing layer with a given route, and data and waits
-   * for the response to end. This is used if you want to make a request against a route
-   * that starts and ends and doesn't stream forever
-   */
-  async request<TEnd = unknown>(route: string, data?: unknown): Promise<ResponseEnded<TEnd>> {
-    return this.requestStream<TEnd, unknown>(route, data).waitForEnd()
-  }
-
   /**
    * Makes a request against the routing layer with a given route, and data and returns
    * a response for you to accumulate the streaming results, or wait for a response
    */
-  requestStream<TEnd = unknown, TStream = unknown>(
+  static requestStream<TEnd = unknown, TStream = unknown>(
+    router: Router,
     route: string,
     data?: unknown,
   ): MemoryResponse<TEnd, TStream> {
-    const router = this.router
-
     const [promise, resolve, reject] = PromiseUtils.split<TEnd>()
     const stream = new Stream<TStream>()
     const response = new MemoryResponse(promise, stream, null)

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -4,18 +4,17 @@
 import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
 import { MemoryAdapter, MemoryResponse } from '../adapters'
+import { ALL_API_NAMESPACES, Router } from '../routes'
 import { IronfishClient } from './client'
 
 export class IronfishMemoryClient extends IronfishClient {
   node: IronfishNode
-  adapter: MemoryAdapter
+  router: Router
 
   constructor(logger: Logger, node: IronfishNode) {
     super(logger)
 
-    const adapter = new MemoryAdapter(node.rpc)
-
-    this.adapter = adapter
+    this.router = node.rpc.getRouter(ALL_API_NAMESPACES)
     this.node = node
   }
 
@@ -30,6 +29,6 @@ export class IronfishMemoryClient extends IronfishClient {
       throw new Error(`MemoryAdapter does not support timeoutMs`)
     }
 
-    return this.adapter.requestStream<TEnd, TStream>(route, data)
+    return MemoryAdapter.requestStream<TEnd, TStream>(this.router, route, data)
   }
 }

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -3,8 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
-import { MemoryAdapter } from '../adapters'
-import { Response } from '../response'
+import { MemoryAdapter, MemoryResponse } from '../adapters'
 import { IronfishClient } from './client'
 
 export class IronfishMemoryClient extends IronfishClient {
@@ -26,7 +25,7 @@ export class IronfishMemoryClient extends IronfishClient {
     options: {
       timeoutMs?: number | null
     } = {},
-  ): Response<TEnd, TStream> {
+  ): MemoryResponse<TEnd, TStream> {
     if (options.timeoutMs) {
       throw new Error(`MemoryAdapter does not support timeoutMs`)
     }

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -11,17 +11,13 @@ export class IronfishMemoryClient extends IronfishClient {
   node: IronfishNode
   adapter: MemoryAdapter
 
-  private constructor(logger: Logger, node: IronfishNode, adapter: MemoryAdapter) {
+  constructor(logger: Logger, node: IronfishNode) {
     super(logger)
+
+    const adapter = new MemoryAdapter(node.rpc)
 
     this.adapter = adapter
     this.node = node
-  }
-
-  static async init(logger: Logger, node: IronfishNode): Promise<IronfishMemoryClient> {
-    const adapter = new MemoryAdapter()
-    await node.rpc.mount(adapter)
-    return new IronfishMemoryClient(logger, node, adapter)
   }
 
   request<TEnd = unknown, TStream = unknown>(

--- a/ironfish/src/rpc/routes/accounts/create.test.slow.ts
+++ b/ironfish/src/rpc/routes/accounts/create.test.slow.ts
@@ -18,7 +18,9 @@ describe('Route account/create', () => {
 
     const name = uuid()
 
-    const response = await routeTest.adapter.request<any>('account/create', { name })
+    const response = await routeTest.client
+      .request<any>('account/create', { name })
+      .waitForEnd()
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
       name: name,
@@ -38,7 +40,9 @@ describe('Route account/create', () => {
 
     const name = uuid()
 
-    const response = await routeTest.adapter.request<any>('account/create', { name })
+    const response = await routeTest.client
+      .request<any>('account/create', { name })
+      .waitForEnd()
     expect(response.content).toMatchObject({
       name: name,
       publicAddress: expect.any(String),
@@ -50,7 +54,7 @@ describe('Route account/create', () => {
   it('should validate request', async () => {
     try {
       expect.assertions(3)
-      await routeTest.adapter.request('account/create')
+      await routeTest.client.request('account/create').waitForEnd()
     } catch (e: unknown) {
       if (!(e instanceof RequestError)) {
         throw e
@@ -68,7 +72,7 @@ describe('Route account/create', () => {
 
     try {
       expect.assertions(2)
-      await routeTest.adapter.request('account/create', { name: name })
+      await routeTest.client.request('account/create', { name: name }).waitForEnd()
     } catch (e: unknown) {
       if (!(e instanceof RequestError)) {
         throw e

--- a/ironfish/src/rpc/routes/accounts/getPublicKey.test.ts
+++ b/ironfish/src/rpc/routes/accounts/getPublicKey.test.ts
@@ -33,10 +33,12 @@ describe('Route account/getPublicKey', () => {
   })
 
   it('should return the account data', async () => {
-    const response = await routeTest.adapter.request<any>('account/getPublicKey', {
-      account: account.name,
-      generate: false,
-    })
+    const response = await routeTest.client
+      .request<any>('account/getPublicKey', {
+        account: account.name,
+        generate: false,
+      })
+      .waitForEnd()
 
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
@@ -46,10 +48,12 @@ describe('Route account/getPublicKey', () => {
   })
 
   it('should regenerate the account key', async () => {
-    const response = await routeTest.adapter.request<any>('account/getPublicKey', {
-      account: account.name,
-      generate: true,
-    })
+    const response = await routeTest.client
+      .request<any>('account/getPublicKey', {
+        account: account.name,
+        generate: true,
+      })
+      .waitForEnd()
 
     expect(response.status).toBe(200)
     expect(response.content.account).toEqual(account.name)

--- a/ironfish/src/rpc/routes/accounts/rescanAccount.test.ts
+++ b/ironfish/src/rpc/routes/accounts/rescanAccount.test.ts
@@ -30,9 +30,11 @@ describe('account/rescanAccount', () => {
       routeTest.node.accounts.scan = scan
 
       try {
-        await routeTest.adapter.request<RescanAccountResponse>('account/rescanAccount', {
-          follow: false,
-        })
+        await routeTest.client
+          .request<RescanAccountResponse>('account/rescanAccount', {
+            follow: false,
+          })
+          .waitForEnd()
       } catch (error) {
         expect(error.status).toBe(400)
       }
@@ -45,10 +47,12 @@ describe('account/rescanAccount', () => {
         const { node } = routeTest
         const reset = jest.spyOn(node.accounts, 'reset')
 
-        await routeTest.adapter.request<RescanAccountResponse>('account/rescanAccount', {
-          follow: false,
-          reset: true,
-        })
+        await routeTest.client
+          .request<RescanAccountResponse>('account/rescanAccount', {
+            follow: false,
+            reset: true,
+          })
+          .waitForEnd()
 
         expect(reset).toHaveBeenCalledTimes(1)
       })
@@ -58,20 +62,21 @@ describe('account/rescanAccount', () => {
       const { node } = routeTest
       const scanTransactions = jest.spyOn(node.accounts, 'scanTransactions')
 
-      await routeTest.adapter.request<RescanAccountResponse>('account/rescanAccount', {
-        follow: false,
-      })
+      await routeTest.client
+        .request<RescanAccountResponse>('account/rescanAccount', {
+          follow: false,
+        })
+        .waitForEnd()
 
       expect(scanTransactions).toHaveBeenCalledTimes(1)
     })
 
     it('returns a 200 status code', async () => {
-      const response = await routeTest.adapter.request<RescanAccountResponse>(
-        'account/rescanAccount',
-        {
+      const response = await routeTest.client
+        .request<RescanAccountResponse>('account/rescanAccount', {
           follow: false,
-        },
-      )
+        })
+        .waitForEnd()
 
       expect(response.status).toBe(200)
     })
@@ -84,9 +89,11 @@ describe('account/rescanAccount', () => {
       node.accounts.scan = scan
       const wait = jest.spyOn(scan, 'wait').mockImplementationOnce(async () => {})
 
-      await routeTest.adapter.request<RescanAccountResponse>('account/rescanAccount', {
-        follow: true,
-      })
+      await routeTest.client
+        .request<RescanAccountResponse>('account/rescanAccount', {
+          follow: true,
+        })
+        .waitForEnd()
 
       expect(wait).toHaveBeenCalledTimes(1)
     })
@@ -97,12 +104,11 @@ describe('account/rescanAccount', () => {
       node.accounts.scan = scan
       jest.spyOn(scan, 'wait').mockImplementationOnce(async () => {})
 
-      const response = await routeTest.adapter.request<RescanAccountResponse>(
-        'account/rescanAccount',
-        {
+      const response = await routeTest.client
+        .request<RescanAccountResponse>('account/rescanAccount', {
           follow: true,
-        },
-      )
+        })
+        .waitForEnd()
 
       expect(response.status).toBe(200)
     })

--- a/ironfish/src/rpc/routes/chain/getBlock.test.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.test.ts
@@ -13,7 +13,7 @@ describe('Route chain.getBlock', () => {
   const routeTest = createRouteTest()
 
   it('should fail if no sequence or hash provided', async () => {
-    await expect(routeTest.adapter.request('chain/getBlock', {})).rejects.toThrow(
+    await expect(routeTest.client.request('chain/getBlock', {}).waitForEnd()).rejects.toThrow(
       'Missing hash or sequence',
     )
   }, 10000)
@@ -21,15 +21,15 @@ describe('Route chain.getBlock', () => {
   it(`should fail if block can't be found with hash`, async () => {
     const hash = BlockHashSerdeInstance.serialize(Buffer.alloc(32, 'blockhashnotfound'))
 
-    await expect(routeTest.adapter.request('chain/getBlock', { hash })).rejects.toThrow(
-      'No block found',
-    )
+    await expect(
+      routeTest.client.request('chain/getBlock', { hash }).waitForEnd(),
+    ).rejects.toThrow('No block found')
   }, 10000)
 
   it(`should fail if block can't be found with sequence`, async () => {
-    await expect(routeTest.adapter.request('chain/getBlock', { index: 5 })).rejects.toThrow(
-      'No block found',
-    )
+    await expect(
+      routeTest.client.request('chain/getBlock', { index: 5 }).waitForEnd(),
+    ).rejects.toThrow('No block found')
   }, 10000)
 
   it('responds with a block', async () => {
@@ -40,7 +40,9 @@ describe('Route chain.getBlock', () => {
 
     // by hash first
     const hash = BlockHashSerdeInstance.serialize(block.header.hash)
-    let response = await routeTest.adapter.request<GetBlockResponse>('chain/getBlock', { hash })
+    let response = await routeTest.client
+      .request<GetBlockResponse>('chain/getBlock', { hash })
+      .waitForEnd()
 
     expect(response.content).toMatchObject({
       timestamp: block.header.timestamp.valueOf(),
@@ -60,7 +62,9 @@ describe('Route chain.getBlock', () => {
     expect(response.content.transactions).toHaveLength(1)
 
     // now by sequence
-    response = await routeTest.adapter.request<GetBlockResponse>('chain/getBlock', { index: 2 })
+    response = await routeTest.client
+      .request<GetBlockResponse>('chain/getBlock', { index: 2 })
+      .waitForEnd()
     expect(response.content.blockIdentifier.hash).toEqual(
       block.header.hash.toString('hex').toUpperCase(),
     )

--- a/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
@@ -9,7 +9,9 @@ describe('Route chain.getChainInfo', () => {
   const routeTest = createRouteTest()
 
   it('returns the right object with hash', async () => {
-    const response = await routeTest.adapter.request<GetChainInfoResponse>('chain/getChainInfo')
+    const response = await routeTest.client
+      .request<GetChainInfoResponse>('chain/getChainInfo')
+      .waitForEnd()
 
     expect(response.content.currentBlockIdentifier.index).toEqual(
       routeTest.chain.latest.sequence.toString(),

--- a/ironfish/src/rpc/routes/config/getConfig.test.ts
+++ b/ironfish/src/rpc/routes/config/getConfig.test.ts
@@ -8,25 +8,29 @@ describe('Route config/getConfig', () => {
 
   it('should error if the config name does not exist', async () => {
     await expect(
-      routeTest.adapter.request('config/getConfig', { name: 'asdf' }),
+      routeTest.client.request('config/getConfig', { name: 'asdf' }).waitForEnd(),
     ).rejects.toThrow()
   })
 
   it('returns value of the requested ConfigOptions', async () => {
     const target = { minerBatchSize: 10000 }
-    const response = await routeTest.adapter.request('config/getConfig', {
-      name: 'minerBatchSize',
-    })
+    const response = await routeTest.client
+      .request('config/getConfig', {
+        name: 'minerBatchSize',
+      })
+      .waitForEnd()
     expect(response.status).toBe(200)
     expect(response.content).toEqual(target)
   })
 
   it('returns nothing when no datadir exists', async () => {
     const target = {}
-    const response = await routeTest.adapter.request('config/getConfig', {
-      name: 'minerBatchSize',
-      user: true,
-    })
+    const response = await routeTest.client
+      .request('config/getConfig', {
+        name: 'minerBatchSize',
+        user: true,
+      })
+      .waitForEnd()
     expect(response.status).toBe(200)
     expect(response.content).toEqual(target)
   })

--- a/ironfish/src/rpc/routes/config/setConfig.test.ts
+++ b/ironfish/src/rpc/routes/config/setConfig.test.ts
@@ -10,16 +10,20 @@ describe('Route config/setConfig', () => {
 
   it('should error if the config name does not exist', async () => {
     await expect(
-      routeTest.adapter.request('config/setConfig', { name: 'asdf', value: 'asdf' }),
+      routeTest.client
+        .request('config/setConfig', { name: 'asdf', value: 'asdf' })
+        .waitForEnd(),
     ).rejects.toThrow()
   })
 
   describe('Convert string to array', () => {
     it('does not special-case brackets', async () => {
-      const response = await routeTest.adapter.request('config/setConfig', {
-        name: 'bootstrapNodes',
-        value: '[]',
-      })
+      const response = await routeTest.client
+        .request('config/setConfig', {
+          name: 'bootstrapNodes',
+          value: '[]',
+        })
+        .waitForEnd()
       const content = await response.content
       expect(response.status).toBe(200)
       expect(content).toBeUndefined()
@@ -27,10 +31,12 @@ describe('Route config/setConfig', () => {
     })
 
     it('should convert strings to arrays', async () => {
-      const response = await routeTest.adapter.request('config/setConfig', {
-        name: 'bootstrapNodes',
-        value: 'test.node.com,test2.node.com',
-      })
+      const response = await routeTest.client
+        .request('config/setConfig', {
+          name: 'bootstrapNodes',
+          value: 'test.node.com,test2.node.com',
+        })
+        .waitForEnd()
       const content = await response.content
       expect(response.status).toBe(200)
       expect(content).toBeUndefined()
@@ -41,10 +47,12 @@ describe('Route config/setConfig', () => {
     })
 
     it('handles single values', async () => {
-      const response = await routeTest.adapter.request('config/setConfig', {
-        name: 'bootstrapNodes',
-        value: 'test.node.com',
-      })
+      const response = await routeTest.client
+        .request('config/setConfig', {
+          name: 'bootstrapNodes',
+          value: 'test.node.com',
+        })
+        .waitForEnd()
       const content = await response.content
       expect(response.status).toBe(200)
       expect(content).toBeUndefined()
@@ -52,10 +60,12 @@ describe('Route config/setConfig', () => {
     })
 
     it('should strip leading and trailing whitespace', async () => {
-      const response = await routeTest.adapter.request('config/setConfig', {
-        name: 'bootstrapNodes',
-        value: '  node1  ,   node2  ',
-      })
+      const response = await routeTest.client
+        .request('config/setConfig', {
+          name: 'bootstrapNodes',
+          value: '  node1  ,   node2  ',
+        })
+        .waitForEnd()
       const content = await response.content
       expect(response.status).toBe(200)
       expect(content).toBeUndefined()
@@ -63,10 +73,12 @@ describe('Route config/setConfig', () => {
     })
 
     it('should leave quotes', async () => {
-      const response = await routeTest.adapter.request('config/setConfig', {
-        name: 'bootstrapNodes',
-        value: ' \' node1 \' , " node2 " ',
-      })
+      const response = await routeTest.client
+        .request('config/setConfig', {
+          name: 'bootstrapNodes',
+          value: ' \' node1 \' , " node2 " ',
+        })
+        .waitForEnd()
       const content = await response.content
       expect(response.status).toBe(200)
       expect(content).toBeUndefined()

--- a/ironfish/src/rpc/routes/faucet/getFunds.test.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.test.ts
@@ -13,7 +13,9 @@ describe('Route faucet.getFunds', () => {
   describe('if the account does not exist in the DB', () => {
     it('should fail', async () => {
       await expect(
-        routeTest.adapter.request('faucet/getFunds', { accountName: 'test-notfound' }),
+        routeTest.client
+          .request('faucet/getFunds', { accountName: 'test-notfound' })
+          .waitForEnd(),
       ).rejects.toThrow('Account test-notfound could not be found')
     }, 10000)
   })
@@ -37,10 +39,12 @@ describe('Route faucet.getFunds', () => {
           .fn()
           .mockImplementationOnce(() => Promise.resolve({ data: { id: 5 } }))
 
-        const response = await routeTest.adapter.request('faucet/getFunds', {
-          accountName,
-          email,
-        })
+        const response = await routeTest.client
+          .request('faucet/getFunds', {
+            accountName,
+            email,
+          })
+          .waitForEnd()
 
         // Response gives back string for ID
         expect(response).toMatchObject({ status: 200, content: { id: '5' } })
@@ -69,7 +73,7 @@ describe('Route faucet.getFunds', () => {
           }
         })
         await expect(
-          routeTest.adapter.request('faucet/getFunds', { accountName, email }),
+          routeTest.client.request('faucet/getFunds', { accountName, email }).waitForEnd(),
         ).rejects.toThrow(RequestError)
       })
     })
@@ -79,7 +83,7 @@ describe('Route faucet.getFunds', () => {
         const apiResponse = new Error('API failure') as AxiosError
         axios.post = jest.fn().mockRejectedValueOnce(apiResponse)
         await expect(
-          routeTest.adapter.request('faucet/getFunds', { accountName, email }),
+          routeTest.client.request('faucet/getFunds', { accountName, email }).waitForEnd(),
         ).rejects.toThrow('API failure')
       }, 10000)
     })

--- a/ironfish/src/rpc/routes/mining/blockTemplateStream.test.slow.ts
+++ b/ironfish/src/rpc/routes/mining/blockTemplateStream.test.slow.ts
@@ -19,9 +19,7 @@ describe('Block template stream', () => {
 
     const createNewBlockTemplateSpy = jest.spyOn(miningManager, 'createNewBlockTemplate')
 
-    const response = await routeTest.adapter
-      .requestStream('miner/blockTemplateStream')
-      .waitForRoute()
+    const response = await routeTest.client.request('miner/blockTemplateStream').waitForRoute()
 
     // onConnectBlock can trigger while generating fixtures or if this test is run in isolation,
     // which would call createNewBlockTemplate twice, so we can clear the listener to ensure it
@@ -90,7 +88,7 @@ describe('Block template stream', () => {
     const newBlockSpy = jest.spyOn(node.chain, 'newBlock')
 
     // Start the request
-    const response = routeTest.adapter.requestStream('miner/blockTemplateStream')
+    const response = routeTest.client.request('miner/blockTemplateStream')
 
     // Add the transaction to the route mempool
     await routeTest.node.memPool.acceptTransaction(tx)

--- a/ironfish/src/rpc/routes/node/getLogStream.test.ts
+++ b/ironfish/src/rpc/routes/node/getLogStream.test.ts
@@ -13,7 +13,7 @@ describe('Route node/getLogStream', () => {
     // Start accepting logs again
     routeTest.node.logger.resume()
 
-    const response = await routeTest.adapter.requestStream('node/getLogStream').waitForRoute()
+    const response = await routeTest.client.request('node/getLogStream').waitForRoute()
 
     routeTest.node.logger.info('Hello', { foo: 2 })
     const { value } = await response.contentStream().next()
@@ -36,7 +36,7 @@ describe('Route node/getLogStream', () => {
     // Start accepting logs again
     routeTest.node.logger.resume()
 
-    const response = await routeTest.adapter.requestStream('node/getLogStream').waitForRoute()
+    const response = await routeTest.client.request('node/getLogStream').waitForRoute()
 
     routeTest.node.logger.info(BigInt(2))
     const { value } = await response.contentStream().next()

--- a/ironfish/src/rpc/routes/node/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.test.ts
@@ -7,7 +7,7 @@ describe('Route node/getStatus', () => {
   const routeTest = createRouteTest()
 
   it('should get status', async () => {
-    const response = await routeTest.adapter.request('node/getStatus')
+    const response = await routeTest.client.request('node/getStatus').waitForEnd()
 
     expect(response.status).toBe(200)
 

--- a/ironfish/src/rpc/routes/node/stopNode.test.ts
+++ b/ironfish/src/rpc/routes/node/stopNode.test.ts
@@ -9,7 +9,7 @@ describe('Route node.getStatus', () => {
   it('should get status', async () => {
     routeTest.node.shutdown = jest.fn()
 
-    const response = await routeTest.adapter.request('node/stopNode')
+    const response = await routeTest.client.request('node/stopNode').waitForEnd()
     expect(response.status).toBe(200)
     expect(response.content).toBe(undefined)
     expect(routeTest.node.shutdown).toHaveBeenCalled()

--- a/ironfish/src/rpc/routes/workers/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/workers/getStatus.test.ts
@@ -9,7 +9,9 @@ describe('Route worker/getStatus', () => {
 
   it('should get status', async () => {
     const request: GetWorkersStatusRequest = { stream: false }
-    const response = await routeTest.adapter.request('worker/getStatus', { request })
+    const response = await routeTest.client
+      .request('worker/getStatus', { request })
+      .waitForEnd()
 
     expect(response.status).toBe(200)
 

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -269,7 +269,7 @@ export class IronfishSdk {
     }
 
     const node = await this.node()
-    const clientMemory = await IronfishMemoryClient.init(this.logger, node)
+    const clientMemory = new IronfishMemoryClient(this.logger, node)
     await NodeUtils.waitForOpen(node)
     return clientMemory
   }

--- a/ironfish/src/testUtilities/routeTest.ts
+++ b/ironfish/src/testUtilities/routeTest.ts
@@ -40,7 +40,7 @@ export class RouteTest extends NodeTest {
     const setup = await super.createSetup()
 
     const logger = createRootLogger().withTag('memoryclient')
-    const client = await IronfishMemoryClient.init(logger, setup.node)
+    const client = new IronfishMemoryClient(logger, setup.node)
     const adapter = client.adapter
 
     return { ...setup, adapter, client }

--- a/ironfish/src/testUtilities/routeTest.ts
+++ b/ironfish/src/testUtilities/routeTest.ts
@@ -34,31 +34,19 @@ export class RouteTest extends NodeTest {
     peerNetwork: PeerNetwork
     syncer: Syncer
     workerPool: WorkerPool
-    adapter: MemoryAdapter
     client: IronfishMemoryClient
   }> {
     const setup = await super.createSetup()
 
     const logger = createRootLogger().withTag('memoryclient')
     const client = new IronfishMemoryClient(logger, setup.node)
-    const adapter = client.adapter
 
-    return { ...setup, adapter, client }
+    return { ...setup, client }
   }
 
   async setup(): Promise<void> {
-    const {
-      sdk,
-      node,
-      strategy,
-      chain,
-      accounts,
-      peerNetwork,
-      syncer,
-      workerPool,
-      client,
-      adapter,
-    } = await this.createSetup()
+    const { sdk, node, strategy, chain, accounts, peerNetwork, syncer, workerPool, client } =
+      await this.createSetup()
 
     this.sdk = sdk
     this.node = node
@@ -68,7 +56,6 @@ export class RouteTest extends NodeTest {
     this.syncer = syncer
     this.peerNetwork = peerNetwork
     this.client = client
-    this.adapter = adapter
     this.workerPool = workerPool
   }
 }


### PR DESCRIPTION
## Summary
The MemoryAdaper is supposed to be analogous to a TcpAdapter and IpcAdapter . All 3 implement the IAdapter  interface that can start and stop the adapter. The main difference of the MemoryAdaper  is that it is not running a server. It does not need to be stopped or started. It is just making function calls directly to the internal Router  code.

This also means that the idea of a client (MemoryClient) server (MemoryAdaper) relationship doesn't make much sense since the client and server are directly connected they should be the same code. For this reason we want to get rid of the MemoryAdapter  and just call Router.route  directly from the MemoryClient . Either that or greatly reduce the code in each and remove unnecessary orchestration.

## Testing Plan
Unit tests + local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
