### PR TITLE
Add fallback mined block url if terminal doesn't support hyperlinks

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -62,6 +62,7 @@
     "blessed": "0.1.81",
     "json-colorizer": "2.2.2",
     "segfault-handler": "1.3.0",
+    "supports-hyperlinks": "2.2.0",
     "tweetnacl": "1.0.3",
     "uuid": "8.3.2",
     "ws": "7.5.1"

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -12,7 +12,6 @@ import {
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import readline from 'readline'
-import supportsHyperlinks from 'supports-hyperlinks'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -124,10 +123,10 @@ export class MinedCommand extends IronfishCommand {
 
     const amount = MathUtils.round(oreToIron(block.minersFee), 2)
 
-    const explorerLink = `https://explorer.ironfish.network/blocks/${block.hash}`
-    const link = supportsHyperlinks.stdout
-      ? linkText(explorerLink, 'view in web')
-      : explorerLink
+    const link = linkText(
+      `https://explorer.ironfish.network/blocks/${block.hash}`,
+      'view in web',
+    )
 
     this.log(
       `${block.hash} ${block.account} ${amount} ${block.main ? 'MAIN' : 'FORK'} ${

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -12,6 +12,7 @@ import {
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import readline from 'readline'
+import supportsHyperlinks from 'supports-hyperlinks'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -123,10 +124,10 @@ export class MinedCommand extends IronfishCommand {
 
     const amount = MathUtils.round(oreToIron(block.minersFee), 2)
 
-    const link = linkText(
-      `https://explorer.ironfish.network/blocks/${block.hash}`,
-      'view in web',
-    )
+    const explorerLink = `https://explorer.ironfish.network/blocks/${block.hash}`
+    const link = supportsHyperlinks.stdout
+      ? linkText(explorerLink, 'view in web')
+      : explorerLink
 
     this.log(
       `${block.hash} ${block.account} ${amount} ${block.main ? 'MAIN' : 'FORK'} ${

--- a/ironfish-cli/src/typedefs/supports-hyperlinks.d.ts
+++ b/ironfish-cli/src/typedefs/supports-hyperlinks.d.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+declare module 'supports-hyperlinks' {
+  export function supportsHyperlink(stream: NodeJS.WriteStream): boolean
+  export const stdout: boolean
+  export const stderr: boolean
+}

--- a/ironfish-cli/src/utils/terminal.ts
+++ b/ironfish-cli/src/utils/terminal.ts
@@ -2,7 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export function linkText(url: string, text: string): string {
+import supportsHyperlinks from 'supports-hyperlinks'
+
+export function linkText(url: string, text: string, stdout = true): string {
+  const supported = stdout ? supportsHyperlinks.stdout : supportsHyperlinks.stderr
+
+  if (!supported) {
+    return url
+  }
+
   const OSC = '\u001B]'
   const BEL = '\u0007'
   const SEP = ';'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4910,7 +4910,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@4.7.7, handlebars@^4.7.6:
+handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -7154,7 +7154,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@8.0.1, node-notifier@^8.0.0:
+node-notifier@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
   integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
@@ -8639,13 +8639,6 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-getter@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.1.tgz#a3110e1b461d31a9cfc8c5c9ee2e9737ad447102"
-  integrity sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==
-  dependencies:
-    to-object-path "^0.3.0"
-
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
@@ -9233,7 +9226,7 @@ supports-color@^8.1.0, supports-color@^8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-supports-hyperlinks@^2.0.0, supports-hyperlinks@^2.2.0:
+supports-hyperlinks@2.2.0, supports-hyperlinks@^2.0.0, supports-hyperlinks@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
   integrity sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==


### PR DESCRIPTION
## Summary

Some terminals does not support hyperlink, which is diplayed as a result of miners:mined command. This PR adds a fallback and displays just an explorer url in such case.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
