### PR TITLE
fix(ironfish): Use `tx` object when updating `noteToNullifier` map

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -487,10 +487,14 @@ export class Accounts {
               )
             }
 
-            await this.updateNoteToNullifierMap(noteHash, {
-              ...nullifier,
-              spent: !isRemovingTransaction,
-            })
+            await this.updateNoteToNullifierMap(
+              noteHash,
+              {
+                ...nullifier,
+                spent: !isRemovingTransaction,
+              },
+              tx,
+            )
           }
         }
       })
@@ -533,10 +537,14 @@ export class Accounts {
             )
           }
 
-          await this.updateNoteToNullifierMap(noteHash, {
-            ...nullifier,
-            spent: false,
-          })
+          await this.updateNoteToNullifierMap(
+            noteHash,
+            {
+              ...nullifier,
+              spent: false,
+            },
+            tx,
+          )
         }
       }
     })


### PR DESCRIPTION
## Summary

Ensure database updates for notes -> nullifiers are atomic within the same transaction.

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
