### PR TITLE
Use yarn frozen-lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ See https://ironfish.network
       1. Choose `Native Windows`, `x86_64`, choose an empty directory, and click OK.
       1. On the next screen, click `Process`.
       1. Once it finishes, add the `bin` folder containing `cc` to your PATH environment variable.
-1. Run `yarn install` from the root directory to install packages.
-   - If `yarn install` fails with an error that includes "Failed to build cmake", you may need to first install cmake. For example, on macOS:
+1. Run `yarn install --frozen-lockfile` from the root directory to install packages.
+   - If `yarn install --frozen-lockfile` fails with an error that includes "Failed to build cmake", you may need to first install cmake. For example, on macOS:
      1. Run `brew install cmake`, you'll need cmake version 3.15 or higher.
 
-   - If `yarn install` fails with an error that includes "Could NOT find OpenSSL", you may need to first install OpenSSL and add an environment variable. For example, on macOS:
+   - If `yarn install --frozen-lockfile` fails with an error that includes "Could NOT find OpenSSL", you may need to first install OpenSSL and add an environment variable. For example, on macOS:
      1. Run `brew install openssl`
      1. Run `` export OPENSSL_ROOT_DIR=`brew --prefix openssl`  ``
-     1. Run `yarn install` again.
+     1. Run `yarn install --frozen-lockfile` again.
 
-   - If `yarn install` fails with an error that includes "Error: not found: make", "make: cc: Command not found", or "make: g++: Command not found", you may need to [install a C/C++ compiler toolchain](https://github.com/nodejs/node-gyp#on-unix).
+   - If `yarn install --frozen-lockfile` fails with an error that includes "Error: not found: make", "make: cc: Command not found", or "make: g++: Command not found", you may need to [install a C/C++ compiler toolchain](https://github.com/nodejs/node-gyp#on-unix).
      1. On Ubuntu: `apt install build-essential`
      1. On Amazon Linux: `sudo yum groupinstall "Development Tools"`
 
-   - If `yarn install` fails with an error that includes "Error: Could not find any Python installation to use", you may need to install Python3 (required by node-gyp). on MacOS:
+   - If `yarn install --frozen-lockfile` fails with an error that includes "Error: Could not find any Python installation to use", you may need to install Python3 (required by node-gyp). on MacOS:
      1. Run `brew install python`
 
 ## Usage


### PR DESCRIPTION
## Summary
To ensure reproducable and deterministic builds, when performing yarn install, make sure to use the lockfile. Without `--frozen-lockfile`, yarn will update the lockfile rather than using the pinned versions.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
