### PR TITLE
Upgrade fuse.js from 6.4.6 to 6.5.3.

### DIFF
--- a/ironfish-graph-explorer/package.json
+++ b/ironfish-graph-explorer/package.json
@@ -19,6 +19,6 @@
     "webpack-dev-server": "4.6.0"
   },
   "dependencies": {
-    "fuse.js": "6.4.6"
+    "fuse.js": "6.5.3"
   }
 }


### PR DESCRIPTION
## Summary
* The version is 4 versions ahead of the current version.
* The version was released 5 months ago, on 2021-12-23.

Package in npm:
https://www.npmjs.com/package/fuse.js

## Testing Plan
No major testing plan needed

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
None required

```
[ ] Yes
[✓ ] No
```
