### PR TITLE
Add: TLS. Pin version. Integrity

### DIFF
--- a/ironfish-graph-explorer/src/index.html
+++ b/ironfish-graph-explorer/src/index.html
@@ -1,11 +1,11 @@
 <head>
-    <script src="http://unpkg.com/lodash"></script>
-    <script src="http://unpkg.com/d3-dsv"></script>
-    <script src="http://unpkg.com/dat.gui"></script>
-    <script src="http://unpkg.com/d3-quadtree"></script>
-    <script src="http://unpkg.com/d3-force"></script>
-    <script src="http://unpkg.com/force-graph"></script>
-    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.6"></script>
+    <script src="https://unpkg.com/lodash@4.17.21/lodash.js" integrity="sha384-l3ZPesZ3gDMDOrzjEodAMRyQlQnAR6KFZN2hnIr+h8Y80fuKlD1jsjdxJpKr9XgP" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/d3-dsv@3.0.1/dist/d3-dsv.min.js" integrity="sha384-QTuAP8b3+tctYMpejPx7M6nrfFyoXhpKxzK9H81mTlVdbsUSL+cF3cViC/WOpLHF" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/dat.gui@0.7.9/build/dat.gui.js" integrity="sha384-kj1cvUBTnBiozvyYqnrTS0GiWQ50FtHYOd8GAZd6GPGVnCIvwGSz0uMnJR6YuyNr" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/d3-quadtree@3.0.1/dist/d3-quadtree.min.js" integrity="sha384-JzQQZeN94rbeGRpksNSu8TCkRWLlzTHev53JZngDT0faxrmd9bApgXS5pZWShqJb" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/d3-force@3.0.0/dist/d3-force.min.js" integrity="sha384-RM+ykRJc5/xPC56TVMOAYbZeVThoKXqcRlmRHZZc3YDHDCvFJrsEH2dpLMqL50K8" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/force-graph@1.42.9/dist/force-graph.min.js" integrity="sha384-YESY75UqJTYPnjHzGp6bR5aezOtcOBvoXDpNJzGpSG1SkitYZqVfngK7fRl2Dpu8" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.6" integrity="sha384-UBGmRyNtwBeGap4zdtKXLwUHdLJM9M/aSMLo8NaIzCxnLxYU6F9+V8veOXP3Fakh" crossorigin="anonymous"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
The 'integrity' attribute allows for the browser to verify that externally hosted files (for example from a CDN) are delivered without unexpected manipulation. Without this attribute, if an attacker can modify the externally hosted resource, this could lead to XSS and other types of attacks. To prevent this, include the base64-encoded cryptographic hash of the resource (file) you’re telling the browser to fetch in the 'integrity' attribute for all externally hosted files.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
