### PR TITLE
Don't run as root. Use no-new-privileges

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -8,6 +8,9 @@ services:
         tty: true
         restart: always
         command: ["start", "--graffiti", "graffitiExample", "--name", "nodeExample"]
+        user: 1000:1000
+        security_opt:
+        - no-new-privileges:true
 
     miner:
         image: ghcr.io/iron-fish/ironfish:latest
@@ -17,6 +20,9 @@ services:
         mem_limit: 8192M
         restart: always
         command: miners:start --threads -1
+        user: 1000:1000
+        security_opt:
+        - no-new-privileges:true
 
 networks:
     default:


### PR DESCRIPTION
## Summary
Not running docker containers as root is best-practice. Since this is an example for running iron-fish in production, I suggest we add this

Services `node` and `miner` allow for privilege escalation via setuid or setgid binaries. Add `no-new-privileges:true` in 'security_opt' to prevent this.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

[ ] Yes
[ ] No
