### PR TITLE
add flag to override pool balance payout percentage

### DIFF
--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -34,6 +34,9 @@ export class StartPool extends IronfishCommand {
       allowNo: true,
       description: 'whether the pool should payout or not. useful for solo miners',
     }),
+    balancePercentPayout: Flags.integer({
+      description: 'whether the pool should payout or not. useful for solo miners',
+    }),
   }
 
   pool: MiningPool | null = null
@@ -89,6 +92,7 @@ export class StartPool extends IronfishCommand {
       discord,
       host: host,
       port: port,
+      balancePercentPayoutFlag: flags.balancePercentPayout,
     })
 
     await this.pool.start()

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -49,7 +49,7 @@ export class MiningPool {
 
   recalculateTargetInterval: SetTimeoutToken | null
 
-  constructor(options: {
+  private constructor(options: {
     rpc: IronfishIpcClient
     shares: MiningPoolShares
     config: Config
@@ -97,6 +97,7 @@ export class MiningPool {
     enablePayouts?: boolean
     host?: string
     port?: number
+    balancePercentPayoutFlag?: number
   }): Promise<MiningPool> {
     const shares = await MiningPoolShares.init({
       rpc: options.rpc,
@@ -104,6 +105,7 @@ export class MiningPool {
       logger: options.logger,
       discord: options.discord,
       enablePayouts: options.enablePayouts,
+      balancePercentPayoutFlag: options.balancePercentPayoutFlag,
     })
 
     return new MiningPool({


### PR DESCRIPTION
## Summary
Addresses https://github.com/iron-fish/ironfish/issues/1419. This change adds a flag to the `miners:pools:start` command to correctly override `balancePercentPayout` in the config.

Currently the config variable `poolBalancePercentPayout` doesn't represent an actual percentage because we are using it incorrectly. Instead it represents a divisor. So
- `config.poolBalancePercentPayout = 2` would pay out 50%
- `config.poolBalancePercentPayout = 3` would pay out 33%
- `config.poolBalancePercentPayout = 4` would pay out 25%
- etc

This change allows you to run `ironfish miners:pools:start --balancePercentPayout=30` and it will actually pay out 30%. If you do not pass in the `--balancePercentPayout` flag, it will retain it's original functionality. This is temporary to allow people running pools to migrate over to using a correct percentage. The old config variable will be removed or updated to calculate correctly in a future release.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
