### PR TITLE
Use bigint division in mining pool

### DIFF
--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -126,7 +126,10 @@ export class MiningPoolShares {
 
     let payoutAmount: number
     if (this.balancePercentPayoutFlag !== undefined) {
-      payoutAmount = Number((confirmedBalance * BigInt(this.balancePercentPayoutFlag)) / 100n)
+      payoutAmount = BigIntUtils.divide(
+        confirmedBalance * BigInt(this.balancePercentPayoutFlag),
+        100n,
+      )
     } else {
       payoutAmount = BigIntUtils.divide(confirmedBalance, this.balancePercentPayout)
     }

--- a/ironfish/src/utils/bigint.test.ts
+++ b/ironfish/src/utils/bigint.test.ts
@@ -55,5 +55,12 @@ describe('BigIntUtils', () => {
 
     result = BigIntUtils.divide(max, BigInt(2))
     expect(result).toBe(Number(max) / 2)
+
+    const withPrecision = BigIntUtils.divide(10000n, 37n)
+    const withoutPrecision = Number(10000n / 37n)
+    const withPrecision2 = 10000 / 37
+
+    expect(withPrecision).toBeGreaterThan(withoutPrecision)
+    expect(withPrecision).toBe(withPrecision2)
   })
 })

--- a/ironfish/src/utils/bigint.ts
+++ b/ironfish/src/utils/bigint.ts
@@ -103,6 +103,10 @@ function toBytesBE(value: bigint, size?: number): Buffer {
   return bytes
 }
 
+/**
+ * Divides two BigInt types and returns a number. That has floating
+ * point precision. Regular BigInt division will not have decimals
+ */
 function divide(a: bigint, b: bigint): number {
   const div = a / b
   return Number(div) + Number(a - div * b) / Number(b)


### PR DESCRIPTION
## Summary
Adding some clarity around BigInt.divide function and making sure to use it in mining pool code

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
