### PR TITLE
tighten logging interface to more easily log in different formats

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -759,10 +759,9 @@ export class Accounts {
 
         // Otherwise, push the note into the list of notes to spend
         this.logger.debug(
-          'Accounts: spending note',
-          unspentNote.index,
-          unspentNote.hash,
-          unspentNote.note.value(),
+          `Accounts: spending note ${unspentNote.index} ${
+            unspentNote.hash
+          } ${unspentNote.note.value()}`,
         )
         notesToSpend.push({ note: unspentNote.note, witness: witness })
         amountNeeded -= unspentNote.note.value()

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -189,6 +189,12 @@ export type ConfigOptions = {
    * The discord webhook URL to post pool critical pool information too
    */
   poolDiscordWebhook: ''
+
+  /**
+   * Whether we want the logs to the console to be in JSON format or not. This can be used to log to
+   * more easily process logs on a remote server using a log service like Datadog
+   */
+  logToConsoleAsJSON: boolean
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -268,6 +274,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolSuccessfulPayoutInterval: DEFAULT_POOL_SUCCESSFUL_PAYOUT_INTERVAL,
       poolRecentShareCutoff: DEFAULT_POOL_RECENT_SHARE_CUTOFF,
       poolDiscordWebhook: '',
+      logToConsoleAsJSON: false,
     }
   }
 }

--- a/ironfish/src/logger/index.ts
+++ b/ironfish/src/logger/index.ts
@@ -2,13 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import type { Consola } from 'consola'
+import type { Consola, ConsolaReporter } from 'consola'
 import consola, { LogLevel } from 'consola'
 import { parseLogLevelConfig } from './logLevelParser'
 import { ConsoleReporter } from './reporters/console'
 export * from './reporters/intercept'
 
-export type Logger = Consola
+export interface Logger {
+  info(message: string, ...args: Record<string, unknown>[]): void
+  error(message: string, ...args: Record<string, unknown>[]): void
+  warn(message: string, ...args: Record<string, unknown>[]): void
+  debug(message: string, ...args: Record<string, unknown>[]): void
+  withTag(tag: string): Logger
+  pauseLogs(): void
+  addReporter(reporter: ConsolaReporter): Logger
+  removeReporter(reporter: ConsolaReporter): Logger
+}
 
 export const ConsoleReporterInstance = new ConsoleReporter()
 

--- a/ironfish/src/logger/jsonLogger.ts
+++ b/ironfish/src/logger/jsonLogger.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { ConsolaReporterLogObject } from 'consola'
+import consola, { LogLevel } from 'consola'
+import { Logger } from './index'
+import { getConsoleLogger, InterceptReporter } from './reporters'
+export * from './reporters/intercept'
+
+export const createJSONLogger = (): Logger => {
+  const JSONReporter = new InterceptReporter((logObj: ConsolaReporterLogObject): void => {
+    const consoleLogger = getConsoleLogger(logObj.type)
+    const objectArgs: Record<string, unknown>[] = logObj.args.filter(
+      (a) => typeof a === 'object',
+    ) as Record<string, unknown>[]
+    const otherArgs = logObj.args.filter((a) => typeof a != 'object')
+
+    const toLog = {
+      ...objectArgs[0],
+      level: logObj.level,
+      tag: logObj.tag,
+      date: logObj.date,
+      message: otherArgs.join(' '),
+    }
+
+    consoleLogger(JSON.stringify(toLog))
+  })
+
+  return consola.create({
+    reporters: [JSONReporter],
+    level: LogLevel.Verbose,
+  })
+}

--- a/ironfish/src/logger/reporters/console.ts
+++ b/ironfish/src/logger/reporters/console.ts
@@ -28,14 +28,13 @@ export const loggers: Record<logType, typeof console.log> = {
   silent: silentLogger,
 }
 
-export class ConsoleReporter extends TextReporter {
-  getConsoleLogger(logType: logType): typeof console.log {
-    const logger = loggers[logType]
-    Assert.isNotUndefined(logger)
-    return logger
-  }
+export const getConsoleLogger = (logType: logType): typeof console.log => {
+  const logger = loggers[logType]
+  return logger
+}
 
+export class ConsoleReporter extends TextReporter {
   logText(logObj: ConsolaReporterLogObject, args: unknown[]): void {
-    this.getConsoleLogger(logObj.type)(...args)
+    getConsoleLogger(logObj.type)(...args)
   }
 }

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -166,7 +166,9 @@ export class MiningManager {
     const validation = await this.node.chain.verifier.verifyBlock(block)
 
     if (!validation.valid) {
-      this.node.logger.info(`Discarding invalid mined block ${blockDisplay}`, validation.reason)
+      this.node.logger.info(
+        `Discarding invalid mined block ${blockDisplay} ${validation.reason || 'undefined'}`,
+      )
       return MINED_RESULT.INVALID_BLOCK
     }
 

--- a/ironfish/src/mining/poolMiner.ts
+++ b/ironfish/src/mining/poolMiner.ts
@@ -106,10 +106,9 @@ export class MiningPoolMiner {
     Assert.isNotNull(this.graffiti)
 
     this.logger.debug(
-      'new work',
-      this.target.toString('hex'),
-      miningRequestId,
-      `${FileUtils.formatHashRate(this.hashRate.rate1s)}/s`,
+      `new work ${this.target.toString('hex')} ${miningRequestId} ${FileUtils.formatHashRate(
+        this.hashRate.rate1s,
+      )}/s`,
     )
 
     const headerBytes = Buffer.concat([header])
@@ -143,10 +142,9 @@ export class MiningPoolMiner {
         const { miningRequestId, randomness } = blockResult
 
         this.logger.info(
-          'Found share:',
-          randomness,
-          miningRequestId,
-          `${FileUtils.formatHashRate(this.hashRate.rate1s)}/s`,
+          `Found share: ${randomness} ${miningRequestId} ${FileUtils.formatHashRate(
+            this.hashRate.rate1s,
+          )}/s`,
         )
 
         this.stratum.submit(miningRequestId, randomness)

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -123,10 +123,9 @@ export class MiningSoloMiner {
 
   newWork(miningRequestId: number, header: Buffer): void {
     this.logger.debug(
-      'new work',
-      this.target.toString('hex'),
-      miningRequestId,
-      `${FileUtils.formatHashRate(this.hashRate.rate1s)}/s`,
+      `new work ${this.target.toString('hex')}, ${miningRequestId} ${FileUtils.formatHashRate(
+        this.hashRate.rate1s,
+      )}/s`,
     )
 
     const headerBytes = Buffer.concat([header])
@@ -183,10 +182,9 @@ export class MiningSoloMiner {
         const { miningRequestId, randomness } = blockResult
 
         this.logger.info(
-          'Found block:',
-          randomness,
-          miningRequestId,
-          `${FileUtils.formatHashRate(this.hashRate.rate1s)}/s`,
+          `Found block: ${randomness} ${miningRequestId} ${FileUtils.formatHashRate(
+            this.hashRate.rate1s,
+          )}/s`,
         )
 
         void this.submitWork(miningRequestId, randomness, this.graffiti)

--- a/ironfish/src/mining/stratum/stratumClient.ts
+++ b/ironfish/src/mining/stratum/stratumClient.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import net from 'net'
 import { Logger } from '../../logger'
+import { ErrorUtils } from '../../utils'
 import { GraffitiUtils } from '../../utils/graffiti'
 import { SetTimeoutToken } from '../../utils/types'
 import { YupUtils } from '../../utils/yup'
@@ -155,7 +156,7 @@ export class StratumClient {
   }
 
   private onError = (error: unknown): void => {
-    this.logger.error('Stratum Error', error)
+    this.logger.error(`Stratum Error ${ErrorUtils.renderError(error)}`)
   }
 
   private async onData(data: Buffer): Promise<void> {

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -106,9 +106,8 @@ export class StratumServer {
     this.currentWork = mineableHeaderString(block.header)
 
     this.logger.info(
-      'Setting work for request:',
-      this.currentMiningRequestId,
-      `${this.currentWork.toString('hex').slice(0, 50)}...`,
+      `Setting work for request: ${this.currentMiningRequestId}, 
+      ${this.currentWork.toString('hex').slice(0, 50)}...`,
     )
 
     this.broadcast('mining.notify', this.getNotifyMessage())
@@ -138,7 +137,7 @@ export class StratumServer {
 
     socket.on('error', (e) => this.onError(client, e))
 
-    this.logger.debug(`Client ${client.id} connected:`, socket.remoteAddress)
+    this.logger.debug(`Client ${client.id} connected: ${socket.remoteAddress || 'undefined'}`)
     this.clients.set(client.id, client)
   }
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -540,7 +540,7 @@ export class PeerNetwork {
       if (request) {
         request.resolve({ peerIdentity, message: rpcMessage })
       } else {
-        this.logger.debug('Dropping response to unknown request', rpcId)
+        this.logger.debug(`Dropping response to unknown request ${rpcId}`)
       }
     }
   }

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -9,6 +9,7 @@ import { Assert } from '../../../assert'
 import { MAX_MESSAGE_SIZE } from '../../../consensus'
 import { Event } from '../../../event'
 import { MetricsMonitor } from '../../../metrics'
+import { ErrorUtils } from '../../../utils'
 import { parseNetworkMessage } from '../../messageRegistry'
 import { displayNetworkMessageType, NetworkMessage } from '../../messages/networkMessage'
 import { NetworkMessageType } from '../../types'
@@ -146,7 +147,7 @@ export class WebRtcConnection extends Connection {
       try {
         message = parseNetworkMessage(bufferData)
       } catch (error) {
-        this.logger.warn('Unable to parse webrtc message', data)
+        this.logger.warn(`Unable to parse webrtc message ${data.toString()}`)
         this.close(error)
         return
       }
@@ -190,9 +191,9 @@ export class WebRtcConnection extends Connection {
         }
       }
     } catch (error) {
-      const message = 'An error occurred when loading signaling data:'
-      this.logger.debug(message, error)
-      this.close(new NetworkError(message, error))
+      const err = new NetworkError('An error occurred when loading signaling data', error)
+      this.logger.debug(ErrorUtils.renderError(err))
+      this.close(err)
     }
   }
 
@@ -229,8 +230,7 @@ export class WebRtcConnection extends Connection {
       this.logger.debug(
         `Error occurred while sending ${displayNetworkMessageType(
           message.type,
-        )} message in state ${this.state.type}`,
-        e,
+        )} message in state ${this.state.type} ${ErrorUtils.renderError(e)}`,
       )
       this.close(e)
       return false

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -97,7 +97,7 @@ export class WebSocketConnection extends Connection {
         // be punished with some kind of "downgrade" event. This should
         // probably happen at a higher layer of abstraction
         const message = 'error parsing message'
-        this.logger.warn(message, event.data)
+        this.logger.warn(`${message} ${event.data.toString()}`)
         this.close(new NetworkError(message))
         return
       }

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -563,8 +563,9 @@ export class Peer {
 
         if (connection.state.type === 'DISCONNECTED') {
           this.logger.debug(
-            `Connection closing ${connection.type} for ${this.displayName}:`,
-            ErrorUtils.renderError(connection.error) || 'Reason Unknown',
+            `Connection closing ${connection.type} for ${this.displayName}: ${
+              ErrorUtils.renderError(connection.error) || 'Reason Unknown'
+            }`,
           )
 
           if (connection.error !== null) {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -8,7 +8,7 @@ import { Event } from '../../event'
 import { HostsStore } from '../../fileStores/hosts'
 import { createRootLogger, Logger } from '../../logger'
 import { MetricsMonitor } from '../../metrics'
-import { ArrayUtils, SetIntervalToken } from '../../utils'
+import { ArrayUtils, ErrorUtils, SetIntervalToken } from '../../utils'
 import {
   canInitiateWebRTC,
   canKeepDuplicateConnection,
@@ -613,7 +613,7 @@ export class PeerManager {
     if (peer.state.connections.webRtc?.state.type === 'CONNECTED') {
       if (existingPeer.state.type !== 'DISCONNECTED' && existingPeer.state.connections.webRtc) {
         const error = `Replacing duplicate WebRTC connection on ${existingPeer.displayName}`
-        this.logger.debug(new NetworkError(error))
+        this.logger.debug(ErrorUtils.renderError(new NetworkError(error)))
         existingPeer
           .removeConnection(existingPeer.state.connections.webRtc)
           .close(new NetworkError(error))
@@ -936,10 +936,7 @@ export class PeerManager {
 
       if (!destinationPeer) {
         this.logger.debug(
-          'not forwarding disconnect from',
-          messageSender.displayName,
-          'due to unknown peer',
-          message.destinationIdentity,
+          `not forwarding disconnect from ${messageSender.displayName} due to unknown peer ${message.destinationIdentity}`,
         )
         return
       }
@@ -1204,11 +1201,7 @@ export class PeerManager {
   ) {
     if (canInitiateWebRTC(message.sourceIdentity, message.destinationIdentity)) {
       this.logger.debug(
-        'not handling signal request from',
-        message.sourceIdentity,
-        'to',
-        message.destinationIdentity,
-        'because source peer should have initiated',
+        `not handling signal request from ${message.sourceIdentity} to ${message.destinationIdentity} because source peer should have initiated`,
       )
       return
     }
@@ -1231,10 +1224,7 @@ export class PeerManager {
 
       if (!destinationPeer) {
         this.logger.debug(
-          'not forwarding signal request from',
-          messageSender.displayName,
-          'due to unknown peer',
-          message.destinationIdentity,
+          `not forwarding signal request from ${messageSender.displayName} due to unknown peer ${message.destinationIdentity}`,
         )
         return
       }
@@ -1321,10 +1311,7 @@ export class PeerManager {
 
       if (!destinationPeer) {
         this.logger.debug(
-          'not forwarding signal from',
-          messageSender.displayName,
-          'due to unknown peer',
-          message.destinationIdentity,
+          `not forwarding signal from ${messageSender.displayName} due to unknown peer ${message.destinationIdentity}`,
         )
         return
       }
@@ -1373,15 +1360,13 @@ export class PeerManager {
       signalingPeer.state.connections.webRtc === undefined
     ) {
       if (signalingPeer.state.identity === null) {
-        this.logger.log('Peer must have an identity to begin signaling')
+        this.logger.info('Peer must have an identity to begin signaling')
         return
       }
 
       if (!canInitiateWebRTC(signalingPeer.state.identity, message.destinationIdentity)) {
         this.logger.debug(
-          'not handling signal message from',
-          signalingPeer.displayName,
-          'because source peer should have requested signaling',
+          `not handling signal message from ${signalingPeer.displayName} because source peer should have requested signaling`,
         )
         return
       }

--- a/ironfish/src/rpc/adapters/tcpAdapter.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.ts
@@ -109,7 +109,7 @@ export class TcpAdapter implements IAdapter {
     const reqMap = new Map<string, Request>()
     this.pending.set(connId, { sock: socket, reqs: reqMap })
     socket.on('data', (data) => {
-      this.onClientData(socket, data, reqMap).catch((err) => this.logger.log(err))
+      this.onClientData(socket, data, reqMap).catch((err) => this.logger.error(err))
     })
     socket.on('close', () => {
       // When the socket is closed, close all open requests and delete the connection

--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -163,6 +163,6 @@ export class IronfishTcpClient extends IronfishRpcClient {
   }
 
   protected onError(error: unknown): void {
-    this.logger.error(error)
+    this.logger.error(ErrorUtils.renderError(error))
   }
 }


### PR DESCRIPTION
## Summary
To more easily log in different formats we want the logging interface to be more well defined. This PR changes the Logger from taking `(...args: any[])` to taking `(message: string, ...args: []Record<string, undefined>)`. This will make it easier for us to convert our logs to JSON

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
