### PR TITLE
Revert "fix: removes default createRootLogger from RPC adapters and clients"

### DIFF
--- a/ironfish/src/rpc/adapters/ipcAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.test.ts
@@ -5,7 +5,6 @@
 /* eslint-disable jest/no-conditional-expect */
 import os from 'os'
 import * as yup from 'yup'
-import { createRootLogger } from '../../logger'
 import { IronfishSdk } from '../../sdk'
 import { IronfishRpcClient, RequestError } from '../clients'
 import { ALL_API_NAMESPACES } from '../routes'
@@ -25,14 +24,10 @@ describe('IpcAdapter', () => {
     sdk.config.setOverride('enableRpcIpc', false)
 
     const node = await sdk.node()
-    ipc = new IpcAdapter(
-      ALL_API_NAMESPACES,
-      {
-        mode: 'ipc',
-        socketPath: sdk.config.get('ipcPath'),
-      },
-      createRootLogger().withTag('ipcadaptertest'),
-    )
+    ipc = new IpcAdapter(ALL_API_NAMESPACES, {
+      mode: 'ipc',
+      socketPath: sdk.config.get('ipcPath'),
+    })
 
     await node.rpc.mount(ipc)
 

--- a/ironfish/src/rpc/adapters/ipcAdapter.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.ts
@@ -6,7 +6,7 @@ import { IPC, IpcServer, IpcSocket, IpcSocketId } from 'node-ipc'
 import { v4 as uuid } from 'uuid'
 import * as yup from 'yup'
 import { Assert } from '../../assert'
-import { Logger } from '../../logger'
+import { createRootLogger, Logger } from '../../logger'
 import { YupUtils } from '../../utils/yup'
 import { Request } from '../request'
 import { ApiNamespace, Router } from '../routes'
@@ -92,7 +92,7 @@ export class IpcAdapter implements IAdapter {
   constructor(
     namespaces: ApiNamespace[],
     connection: IpcAdapterConnectionInfo,
-    logger: Logger,
+    logger: Logger = createRootLogger(),
   ) {
     this.namespaces = namespaces
     this.connection = connection

--- a/ironfish/src/rpc/adapters/tcpAdapter.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.ts
@@ -4,7 +4,7 @@
 import net from 'net'
 import { v4 as uuid } from 'uuid'
 import * as yup from 'yup'
-import { Logger } from '../../logger'
+import { createRootLogger, Logger } from '../../logger'
 import { YupUtils } from '../../utils/yup'
 import { Request } from '../request'
 import { ApiNamespace, Router } from '../routes'
@@ -48,7 +48,12 @@ export class TcpAdapter implements IAdapter {
   namespaces: ApiNamespace[]
   pending = new Map<string, { sock: net.Socket; reqs: Map<string, Request> }>()
 
-  constructor(host: string, port: number, logger: Logger, namespaces: ApiNamespace[]) {
+  constructor(
+    host: string,
+    port: number,
+    logger: Logger = createRootLogger(),
+    namespaces: ApiNamespace[],
+  ) {
     this.host = host
     this.port = port
     this.logger = logger.withTag('tcpadapter')

--- a/ironfish/src/rpc/clients/ipcClient.ts
+++ b/ironfish/src/rpc/clients/ipcClient.ts
@@ -4,7 +4,7 @@
 import { IPC, IpcClient } from 'node-ipc'
 import { Assert } from '../../assert'
 import { Event } from '../../event'
-import { Logger } from '../../logger'
+import { createRootLogger, Logger } from '../../logger'
 import { ErrorUtils } from '../../utils'
 import { IpcRequest } from '../adapters'
 import { ConnectionLostError, ConnectionRefusedError } from './errors'
@@ -24,7 +24,7 @@ export class IronfishIpcClient extends IronfishRpcClient {
 
   constructor(
     connection: Partial<RpcClientConnectionInfo> = {},
-    logger: Logger,
+    logger: Logger = createRootLogger(),
     retryConnect = false,
   ) {
     super(logger.withTag('ipcclient'))

--- a/ironfish/src/rpc/clients/tcpClient.test.ts
+++ b/ironfish/src/rpc/clients/tcpClient.test.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { createRootLogger } from '../../logger'
 import { YupUtils } from '../../utils'
 import { IncomingNodeIpcSchema } from '../adapters'
 import { IronfishTcpClient } from './tcpClient'
@@ -11,11 +10,7 @@ jest.mock('net')
 describe('IronfishTcpClient', () => {
   const testHost = 'testhost'
   const testPort = 1234
-  const client: IronfishTcpClient = new IronfishTcpClient(
-    testHost,
-    testPort,
-    createRootLogger().withTag('tcpclienttest'),
-  )
+  const client: IronfishTcpClient = new IronfishTcpClient(testHost, testPort)
 
   afterEach(() => {
     jest.resetAllMocks()

--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import net from 'net'
 import * as yup from 'yup'
-import { Logger } from '../../logger'
+import { createRootLogger, Logger } from '../../logger'
 import { ErrorUtils, SetTimeoutToken, YupUtils } from '../../utils'
 import { ConnectionRefusedError } from './errors'
 import { IronfishRpcClient, RpcClientConnectionInfo } from './rpcClient'
@@ -32,7 +32,12 @@ export class IronfishTcpClient extends IronfishRpcClient {
   isConnected = false
   connection: RpcClientConnectionInfo
 
-  constructor(host: string, port: number, logger: Logger, retryConnect = false) {
+  constructor(
+    host: string,
+    port: number,
+    logger: Logger = createRootLogger(),
+    retryConnect = false,
+  ) {
     super(logger.withTag('tcpclient'))
     this.host = host
     this.port = port


### PR DESCRIPTION
Reverts iron-fish/ironfish#1498

on second thought...

requiring that a logger is passed to constructors in the RPC layer has a couple of disadvantages that I'm aware of:

1. it runs counter to the way we've implemented and/or are implementing things through other parts of the codebase
2. a logger isn't a functional requirement for these classes: i expect to need to pass a host and a port for a TCP client, but not necessarily a logger

the benefits to passing a logger into these constructors only accrue when we take the time to configure the logger first and pass it in. a requirement for the logger alone doesn't get us that