### PR TITLE
Fix incorrectly kicking peers if we have the TX

### DIFF
--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -82,7 +82,7 @@ export class MemPool {
   async acceptTransaction(transaction: Transaction): Promise<boolean> {
     const hash = transaction.hash()
 
-    if (this.transactions.has(hash)) {
+    if (this.exists(hash)) {
       return false
     }
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -701,6 +701,10 @@ export class PeerNetwork {
       message.message.transaction,
     )
 
+    if (this.node.memPool.exists(verifiedTransaction.hash())) {
+      return true
+    }
+
     const count = this.badMessageCounter.get(message.peerIdentity)
     if (await this.node.memPool.acceptTransaction(verifiedTransaction)) {
       await this.node.accounts.syncTransaction(verifiedTransaction, {})

--- a/ironfish/src/testUtilities/mocks.ts
+++ b/ironfish/src/testUtilities/mocks.ts
@@ -7,6 +7,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
+export function mockTransaction(): any {
+  return { hash: jest.fn().mockReturnValue(Buffer.alloc(32, 'test')) }
+}
+
 export function mockEvent(): any {
   return { on: jest.fn() }
 }
@@ -67,6 +71,7 @@ export function mockMiningManager(): any {
 function mockMempool(): unknown {
   return {
     acceptTransaction: jest.fn(),
+    exists: jest.fn().mockReturnValue(false),
   }
 }
 


### PR DESCRIPTION
## Summary

There is a bug where users are being kicked from connections if they
rebroadcast transactions to us that we already have. The issue is that
wallest are programmed to rebroadcast transactions if we don't accept
them up until their expiry time. However, acceptTransaction() returns
false if we already have the transaction. We also punish any user
for if acceptTransaction() returns false. You can see the issue
here.

## Testing Plan
Update tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
