### PR TITLE
Add ability to log to JSON in the console

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -5,6 +5,7 @@ import {
   ConfigOptions,
   ConnectionError,
   createRootLogger,
+  ErrorUtils,
   IronfishSdk,
   Logger,
 } from '@ironfish/sdk'
@@ -157,7 +158,7 @@ export abstract class IronfishCommand extends Command {
 
         this.closing = true
         const promise = this.closeFromSignal(signal).catch((err) => {
-          this.logger.error('Failed to close', err)
+          this.logger.error(`Failed to close ${ErrorUtils.renderError(err)}`)
         })
 
         void promise.then(() => {

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -759,10 +759,9 @@ export class Accounts {
 
         // Otherwise, push the note into the list of notes to spend
         this.logger.debug(
-          'Accounts: spending note',
-          unspentNote.index,
-          unspentNote.hash,
-          unspentNote.note.value(),
+          `Accounts: spending note ${unspentNote.index} ${
+            unspentNote.hash
+          } ${unspentNote.note.value()}`,
         )
         notesToSpend.push({ note: unspentNote.note, witness: witness })
         amountNeeded -= unspentNote.note.value()

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -191,9 +191,16 @@ export type ConfigOptions = {
   poolDiscordWebhook: ''
 
   /**
+
    * The lark webhook URL to post pool critical pool information too
    */
   poolLarkWebhook: ''
+
+  /**
+   * Whether we want the logs to the console to be in JSON format or not. This can be used to log to
+   * more easily process logs on a remote server using a log service like Datadog
+   */
+  logToConsoleAsJSON: boolean
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -274,6 +281,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolRecentShareCutoff: DEFAULT_POOL_RECENT_SHARE_CUTOFF,
       poolDiscordWebhook: '',
       poolLarkWebhook: '',
+      logToConsoleAsJSON: false,
     }
   }
 }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -200,7 +200,7 @@ export type ConfigOptions = {
    * Whether we want the logs to the console to be in JSON format or not. This can be used to log to
    * more easily process logs on a remote server using a log service like Datadog
    */
-  logToConsoleAsJSON: boolean
+  jsonLogs: boolean
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -281,7 +281,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolRecentShareCutoff: DEFAULT_POOL_RECENT_SHARE_CUTOFF,
       poolDiscordWebhook: '',
       poolLarkWebhook: '',
-      logToConsoleAsJSON: false,
+      jsonLogs: false,
     }
   }
 }

--- a/ironfish/src/logger/index.ts
+++ b/ironfish/src/logger/index.ts
@@ -8,7 +8,13 @@ import { parseLogLevelConfig } from './logLevelParser'
 import { ConsoleReporter } from './reporters/console'
 export * from './reporters/intercept'
 
-export type Logger = Consola
+type Loggable = string | number
+export interface Logger extends Consola {
+  info(message: string, args?: Record<string, Loggable>): void
+  error(message: string, args?: Record<string, Loggable>): void
+  warn(message: string, args?: Record<string, Loggable>): void
+  debug(message: string, args?: Record<string, Loggable>): void
+}
 
 export const ConsoleReporterInstance = new ConsoleReporter()
 
@@ -24,6 +30,13 @@ export const setLogLevelFromConfig = (logLevelConfig: string): void => {
   for (const config of parsedConfig) {
     ConsoleReporterInstance.setLogLevel(config[0], config[1])
   }
+}
+
+/**
+ * @param logToJSON Whether console logs should be in JSON format
+ */
+export const setJSONLoggingFromConfig = (logToJSON: boolean): void => {
+  ConsoleReporterInstance.logToJSON = logToJSON
 }
 
 /**

--- a/ironfish/src/logger/index.ts
+++ b/ironfish/src/logger/index.ts
@@ -8,12 +8,20 @@ import { parseLogLevelConfig } from './logLevelParser'
 import { ConsoleReporter } from './reporters/console'
 export * from './reporters/intercept'
 
-type Loggable = string | number
+/**
+ * This interface tries to enforce more structured logs while still
+ * allowing us to use Consola. Knowing the structure of all our
+ * logs has a lot of benefits so going outside this interface. Update this
+ * interface if something with a different structure needs to be logged.
+ */
+type Loggable = string | number | boolean
 export interface Logger extends Consola {
   info(message: string, args?: Record<string, Loggable>): void
+  log(message: string, args?: Record<string, Loggable>): void
   error(message: string, args?: Record<string, Loggable>): void
   warn(message: string, args?: Record<string, Loggable>): void
   debug(message: string, args?: Record<string, Loggable>): void
+  withTag(tag: string): Logger
 }
 
 export const ConsoleReporterInstance = new ConsoleReporter()

--- a/ironfish/src/logger/reporters/console.test.ts
+++ b/ironfish/src/logger/reporters/console.test.ts
@@ -7,7 +7,7 @@
 
 import { LogLevel, logType } from 'consola'
 import { format } from 'date-fns'
-import { ConsoleReporter, loggers } from './console'
+import { ConsoleReporter, getConsoleLogger, loggers } from './console'
 
 describe('setLogLevel', () => {
   it('sets defaultMinimumLogLevel when tag is *', () => {
@@ -147,12 +147,10 @@ describe('getConsoleLogger', () => {
     ['ready', console.info],
     ['start', console.info],
   ])('returns the right console logger for %s', (type, expected) => {
-    const reporter = new ConsoleReporter()
-    expect(reporter['getConsoleLogger'](type as unknown as logType)).toEqual(expected)
+    expect(getConsoleLogger(type as unknown as logType)).toEqual(expected)
   })
 
   it('should throw an error when passing an invalid logType', () => {
-    const reporter = new ConsoleReporter()
-    expect(() => reporter['getConsoleLogger']('test' as unknown as logType)).toThrowError()
+    expect(() => getConsoleLogger('test' as unknown as logType)).toThrowError()
   })
 })

--- a/ironfish/src/logger/reporters/console.ts
+++ b/ironfish/src/logger/reporters/console.ts
@@ -28,14 +28,34 @@ export const loggers: Record<logType, typeof console.log> = {
   silent: silentLogger,
 }
 
-export class ConsoleReporter extends TextReporter {
-  getConsoleLogger(logType: logType): typeof console.log {
-    const logger = loggers[logType]
-    Assert.isNotUndefined(logger)
-    return logger
+export const getConsoleLogger = (logType: logType): typeof console.log => {
+  const logger = loggers[logType]
+  Assert.isNotUndefined(logger)
+  return logger
+}
+
+export const logObjToJSON = (logObj: ConsolaReporterLogObject): string => {
+  const objectArgs: Record<string, unknown>[] = logObj.args.filter(
+    (a) => typeof a === 'object',
+  ) as Record<string, unknown>[]
+  const otherArgs = logObj.args.filter((a) => typeof a != 'object')
+
+  const toLog = {
+    ...objectArgs[0],
+    level: logObj.level,
+    tag: logObj.tag,
+    date: logObj.date,
+    message: otherArgs.join(' '),
   }
 
+  return JSON.stringify(toLog)
+}
+
+export class ConsoleReporter extends TextReporter {
+  logToJSON = false
+
   logText(logObj: ConsolaReporterLogObject, args: unknown[]): void {
-    this.getConsoleLogger(logObj.type)(...args)
+    const logger = getConsoleLogger(logObj.type)
+    this.logToJSON ? logger(logObjToJSON(logObj)) : logger(...args)
   }
 }

--- a/ironfish/src/logger/reporters/console.ts
+++ b/ironfish/src/logger/reporters/console.ts
@@ -7,6 +7,7 @@
 
 import { ConsolaReporterLogObject, logType } from 'consola'
 import { Assert } from '../../assert'
+import { IJSON } from '../../serde'
 import { TextReporter } from './text'
 
 const silentLogger = (): void => {
@@ -48,7 +49,7 @@ export const logObjToJSON = (logObj: ConsolaReporterLogObject): string => {
     message: otherArgs.join(' '),
   }
 
-  return JSON.stringify(toLog)
+  return IJSON.stringify(toLog)
 }
 
 export class ConsoleReporter extends TextReporter {

--- a/ironfish/src/mining/lark.ts
+++ b/ironfish/src/mining/lark.ts
@@ -27,7 +27,7 @@ export class Lark {
     }
 
     this.client.post(this.webhook, { msg_type: 'text', content: { text: text } }).catch((e) => {
-      this.logger.error('Error sending lark message', e)
+      this.logger.error(`Error sending lark message: ${ErrorUtils.renderError(e)}`)
     })
   }
 

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -166,7 +166,9 @@ export class MiningManager {
     const validation = await this.node.chain.verifier.verifyBlock(block)
 
     if (!validation.valid) {
-      this.node.logger.info(`Discarding invalid mined block ${blockDisplay}`, validation.reason)
+      this.node.logger.info(
+        `Discarding invalid mined block ${blockDisplay} ${validation.reason || 'undefined'}`,
+      )
       return MINED_RESULT.INVALID_BLOCK
     }
 

--- a/ironfish/src/mining/poolMiner.ts
+++ b/ironfish/src/mining/poolMiner.ts
@@ -106,10 +106,9 @@ export class MiningPoolMiner {
     Assert.isNotNull(this.graffiti)
 
     this.logger.debug(
-      'new work',
-      this.target.toString('hex'),
-      miningRequestId,
-      `${FileUtils.formatHashRate(this.hashRate.rate1s)}/s`,
+      `new work ${this.target.toString('hex')} ${miningRequestId} ${FileUtils.formatHashRate(
+        this.hashRate.rate1s,
+      )}/s`,
     )
 
     const headerBytes = Buffer.concat([header])
@@ -143,10 +142,9 @@ export class MiningPoolMiner {
         const { miningRequestId, randomness } = blockResult
 
         this.logger.info(
-          'Found share:',
-          randomness,
-          miningRequestId,
-          `${FileUtils.formatHashRate(this.hashRate.rate1s)}/s`,
+          `Found share: ${randomness} ${miningRequestId} ${FileUtils.formatHashRate(
+            this.hashRate.rate1s,
+          )}/s`,
         )
 
         this.stratum.submit(miningRequestId, randomness)

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -123,10 +123,9 @@ export class MiningSoloMiner {
 
   newWork(miningRequestId: number, header: Buffer): void {
     this.logger.debug(
-      'new work',
-      this.target.toString('hex'),
-      miningRequestId,
-      `${FileUtils.formatHashRate(this.hashRate.rate1s)}/s`,
+      `new work ${this.target.toString('hex')}, ${miningRequestId} ${FileUtils.formatHashRate(
+        this.hashRate.rate1s,
+      )}/s`,
     )
 
     const headerBytes = Buffer.concat([header])
@@ -183,10 +182,9 @@ export class MiningSoloMiner {
         const { miningRequestId, randomness } = blockResult
 
         this.logger.info(
-          'Found block:',
-          randomness,
-          miningRequestId,
-          `${FileUtils.formatHashRate(this.hashRate.rate1s)}/s`,
+          `Found block: ${randomness} ${miningRequestId} ${FileUtils.formatHashRate(
+            this.hashRate.rate1s,
+          )}/s`,
         )
 
         void this.submitWork(miningRequestId, randomness, this.graffiti)

--- a/ironfish/src/mining/stratum/stratumClient.ts
+++ b/ironfish/src/mining/stratum/stratumClient.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import net from 'net'
 import { Logger } from '../../logger'
+import { ErrorUtils } from '../../utils'
 import { GraffitiUtils } from '../../utils/graffiti'
 import { SetTimeoutToken } from '../../utils/types'
 import { YupUtils } from '../../utils/yup'
@@ -155,7 +156,7 @@ export class StratumClient {
   }
 
   private onError = (error: unknown): void => {
-    this.logger.error('Stratum Error', error)
+    this.logger.error(`Stratum Error ${ErrorUtils.renderError(error)}`)
   }
 
   private async onData(data: Buffer): Promise<void> {

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -106,9 +106,8 @@ export class StratumServer {
     this.currentWork = mineableHeaderString(block.header)
 
     this.logger.info(
-      'Setting work for request:',
-      this.currentMiningRequestId,
-      `${this.currentWork.toString('hex').slice(0, 50)}...`,
+      `Setting work for request: ${this.currentMiningRequestId}, 
+      ${this.currentWork.toString('hex').slice(0, 50)}...`,
     )
 
     this.broadcast('mining.notify', this.getNotifyMessage())
@@ -138,7 +137,7 @@ export class StratumServer {
 
     socket.on('error', (e) => this.onError(client, e))
 
-    this.logger.debug(`Client ${client.id} connected:`, socket.remoteAddress)
+    this.logger.debug(`Client ${client.id} connected: ${socket.remoteAddress || 'undefined'}`)
     this.clients.set(client.id, client)
   }
 

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -106,8 +106,9 @@ export class StratumServer {
     this.currentWork = mineableHeaderString(block.header)
 
     this.logger.info(
-      `Setting work for request: ${this.currentMiningRequestId}, 
-      ${this.currentWork.toString('hex').slice(0, 50)}...`,
+      `Setting work for request: ${this.currentMiningRequestId} ${this.currentWork
+        .toString('hex')
+        .slice(0, 50)}...`,
     )
 
     this.broadcast('mining.notify', this.getNotifyMessage())

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -540,7 +540,7 @@ export class PeerNetwork {
       if (request) {
         request.resolve({ peerIdentity, message: rpcMessage })
       } else {
-        this.logger.debug('Dropping response to unknown request', rpcId)
+        this.logger.debug(`Dropping response to unknown request ${rpcId}`)
       }
     }
   }

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -9,6 +9,7 @@ import { Assert } from '../../../assert'
 import { MAX_MESSAGE_SIZE } from '../../../consensus'
 import { Event } from '../../../event'
 import { MetricsMonitor } from '../../../metrics'
+import { ErrorUtils } from '../../../utils'
 import { parseNetworkMessage } from '../../messageRegistry'
 import { displayNetworkMessageType, NetworkMessage } from '../../messages/networkMessage'
 import { NetworkMessageType } from '../../types'
@@ -146,7 +147,7 @@ export class WebRtcConnection extends Connection {
       try {
         message = parseNetworkMessage(bufferData)
       } catch (error) {
-        this.logger.warn('Unable to parse webrtc message', data)
+        this.logger.warn(`Unable to parse webrtc message ${data.toString()}`)
         this.close(error)
         return
       }
@@ -190,9 +191,9 @@ export class WebRtcConnection extends Connection {
         }
       }
     } catch (error) {
-      const message = 'An error occurred when loading signaling data:'
-      this.logger.debug(message, error)
-      this.close(new NetworkError(message, error))
+      const err = new NetworkError('An error occurred when loading signaling data', error)
+      this.logger.debug(ErrorUtils.renderError(err))
+      this.close(err)
     }
   }
 
@@ -229,8 +230,7 @@ export class WebRtcConnection extends Connection {
       this.logger.debug(
         `Error occurred while sending ${displayNetworkMessageType(
           message.type,
-        )} message in state ${this.state.type}`,
-        e,
+        )} message in state ${this.state.type} ${ErrorUtils.renderError(e)}`,
       )
       this.close(e)
       return false

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -97,7 +97,7 @@ export class WebSocketConnection extends Connection {
         // be punished with some kind of "downgrade" event. This should
         // probably happen at a higher layer of abstraction
         const message = 'error parsing message'
-        this.logger.warn(message, event.data)
+        this.logger.warn(`${message} ${event.data.toString()}`)
         this.close(new NetworkError(message))
         return
       }

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -563,8 +563,9 @@ export class Peer {
 
         if (connection.state.type === 'DISCONNECTED') {
           this.logger.debug(
-            `Connection closing ${connection.type} for ${this.displayName}:`,
-            ErrorUtils.renderError(connection.error) || 'Reason Unknown',
+            `Connection closing ${connection.type} for ${this.displayName}: ${
+              ErrorUtils.renderError(connection.error) || 'Reason Unknown'
+            }`,
           )
 
           if (connection.error !== null) {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -8,7 +8,7 @@ import { Event } from '../../event'
 import { HostsStore } from '../../fileStores/hosts'
 import { createRootLogger, Logger } from '../../logger'
 import { MetricsMonitor } from '../../metrics'
-import { ArrayUtils, SetIntervalToken } from '../../utils'
+import { ArrayUtils, ErrorUtils, SetIntervalToken } from '../../utils'
 import {
   canInitiateWebRTC,
   canKeepDuplicateConnection,
@@ -613,7 +613,7 @@ export class PeerManager {
     if (peer.state.connections.webRtc?.state.type === 'CONNECTED') {
       if (existingPeer.state.type !== 'DISCONNECTED' && existingPeer.state.connections.webRtc) {
         const error = `Replacing duplicate WebRTC connection on ${existingPeer.displayName}`
-        this.logger.debug(new NetworkError(error))
+        this.logger.debug(ErrorUtils.renderError(new NetworkError(error)))
         existingPeer
           .removeConnection(existingPeer.state.connections.webRtc)
           .close(new NetworkError(error))
@@ -936,10 +936,7 @@ export class PeerManager {
 
       if (!destinationPeer) {
         this.logger.debug(
-          'not forwarding disconnect from',
-          messageSender.displayName,
-          'due to unknown peer',
-          message.destinationIdentity,
+          `not forwarding disconnect from ${messageSender.displayName} due to unknown peer ${message.destinationIdentity}`,
         )
         return
       }
@@ -1204,11 +1201,7 @@ export class PeerManager {
   ) {
     if (canInitiateWebRTC(message.sourceIdentity, message.destinationIdentity)) {
       this.logger.debug(
-        'not handling signal request from',
-        message.sourceIdentity,
-        'to',
-        message.destinationIdentity,
-        'because source peer should have initiated',
+        `not handling signal request from ${message.sourceIdentity} to ${message.destinationIdentity} because source peer should have initiated`,
       )
       return
     }
@@ -1231,10 +1224,7 @@ export class PeerManager {
 
       if (!destinationPeer) {
         this.logger.debug(
-          'not forwarding signal request from',
-          messageSender.displayName,
-          'due to unknown peer',
-          message.destinationIdentity,
+          `not forwarding signal request from ${messageSender.displayName} due to unknown peer ${message.destinationIdentity}`,
         )
         return
       }
@@ -1321,10 +1311,7 @@ export class PeerManager {
 
       if (!destinationPeer) {
         this.logger.debug(
-          'not forwarding signal from',
-          messageSender.displayName,
-          'due to unknown peer',
-          message.destinationIdentity,
+          `not forwarding signal from ${messageSender.displayName} due to unknown peer ${message.destinationIdentity}`,
         )
         return
       }
@@ -1373,15 +1360,13 @@ export class PeerManager {
       signalingPeer.state.connections.webRtc === undefined
     ) {
       if (signalingPeer.state.identity === null) {
-        this.logger.log('Peer must have an identity to begin signaling')
+        this.logger.info('Peer must have an identity to begin signaling')
         return
       }
 
       if (!canInitiateWebRTC(signalingPeer.state.identity, message.destinationIdentity)) {
         this.logger.debug(
-          'not handling signal message from',
-          signalingPeer.displayName,
-          'because source peer should have requested signaling',
+          `not handling signal message from ${signalingPeer.displayName} because source peer should have requested signaling`,
         )
         return
       }

--- a/ironfish/src/rpc/adapters/tcpAdapter.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.ts
@@ -104,7 +104,7 @@ export class TcpAdapter implements IAdapter {
     const reqMap = new Map<string, Request>()
     this.pending.set(connId, { sock: socket, reqs: reqMap })
     socket.on('data', (data) => {
-      this.onClientData(socket, data, reqMap).catch((err) => this.logger.log(err))
+      this.onClientData(socket, data, reqMap).catch((err) => this.logger.error(err))
     })
     socket.on('close', () => {
       // When the socket is closed, close all open requests and delete the connection

--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -158,6 +158,6 @@ export class IronfishTcpClient extends IronfishRpcClient {
   }
 
   protected onError(error: unknown): void {
-    this.logger.error(error)
+    this.logger.error(ErrorUtils.renderError(error))
   }
 }

--- a/ironfish/src/rpc/routes/node/getLogStream.test.ts
+++ b/ironfish/src/rpc/routes/node/getLogStream.test.ts
@@ -38,7 +38,7 @@ describe('Route node/getLogStream', () => {
 
     const response = await routeTest.client.request('node/getLogStream').waitForRoute()
 
-    routeTest.node.logger.info(BigInt(2))
+    routeTest.node.logger.info(`${BigInt(2)}`)
     const { value } = await response.contentStream().next()
 
     response.end()
@@ -48,7 +48,7 @@ describe('Route node/getLogStream', () => {
       level: LogLevel.Info.toString(),
       tag: expect.stringContaining('ironfishnode'),
       type: 'info',
-      args: '["2n"]',
+      args: '["2"]',
       date: expect.anything(),
     })
   })

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -7,6 +7,7 @@ import { FileSystem, NodeFileProvider } from './fileSystems'
 import {
   createRootLogger,
   Logger,
+  setJSONLoggingFromConfig,
   setLogColorEnabledFromConfig,
   setLogLevelFromConfig,
   setLogPrefixFromConfig,
@@ -117,6 +118,8 @@ export class IronfishSdk {
     }
 
     setLogColorEnabledFromConfig(true)
+
+    setJSONLoggingFromConfig(config.get('logToConsoleAsJSON'))
 
     const logFile = config.get('enableLogFile')
 

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -119,7 +119,7 @@ export class IronfishSdk {
 
     setLogColorEnabledFromConfig(true)
 
-    setJSONLoggingFromConfig(config.get('logToConsoleAsJSON'))
+    setJSONLoggingFromConfig(config.get('jsonLogs'))
 
     const logFile = config.get('enableLogFile')
 


### PR DESCRIPTION
## Summary
For a better way to parse the output of logs we want the ability to log to JSON in the console.

This PR also includes changes to log lines to make parsing logs safer. It will be easier to log in different formats if the logging interface is more well defined. This PR changes the Logger from taking (...args: any[]) to taking (message: string, ...args: []Record<string, string | number>). This will make it easier for us to convert our logs to JSON

## Testing Plan
Testing locally and unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
