### PR TITLE
fix: don't log 'failed to connect' in TCP client if connection successful

### DIFF
--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -47,15 +47,16 @@ export class IronfishTcpClient extends IronfishRpcClient {
       .then(() => true)
       .catch(() => false)
 
-    if (!connected && this.retryConnect) {
-      this.logger.warn(
-        `Failed to connect to ${String(this.host)}:${String(this.port)}, retrying`,
-      )
-      this.connectTimeout = setTimeout(() => void this.connect(), CONNECT_RETRY_MS)
-      return
+    if (!connected) {
+      if (this.retryConnect) {
+        this.logger.warn(
+          `Failed to connect to ${String(this.host)}:${String(this.port)}, retrying`,
+        )
+        this.connectTimeout = setTimeout(() => void this.connect(), CONNECT_RETRY_MS)
+        return
+      }
+      this.logger.warn(`Failed to connect to ${String(this.host)}:${String(this.port)}`)
     }
-
-    this.logger.warn(`Failed to connect to ${String(this.host)}:${String(this.port)}`)
   }
 
   async connectClient(): Promise<void> {


### PR DESCRIPTION
## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
