### PR TITLE
Update fuse.js

### DIFF
--- a/ironfish-graph-explorer/package.json
+++ b/ironfish-graph-explorer/package.json
@@ -19,6 +19,6 @@
     "webpack-dev-server": "4.6.0"
   },
   "dependencies": {
-    "fuse.js": "6.4.6"
+    "fuse.js": "6.6.0"
   }
 }

--- a/ironfish-graph-explorer/src/index.html
+++ b/ironfish-graph-explorer/src/index.html
@@ -1,4 +1,5 @@
 <head>
+    <!-- Generated from https://www.srihash.org/ -->
     <script src="https://unpkg.com/lodash@4.17.21/lodash.js" integrity="sha384-l3ZPesZ3gDMDOrzjEodAMRyQlQnAR6KFZN2hnIr+h8Y80fuKlD1jsjdxJpKr9XgP" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/d3-dsv@3.0.1/dist/d3-dsv.min.js" integrity="sha384-QTuAP8b3+tctYMpejPx7M6nrfFyoXhpKxzK9H81mTlVdbsUSL+cF3cViC/WOpLHF" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/dat.gui@0.7.9/build/dat.gui.js" integrity="sha384-kj1cvUBTnBiozvyYqnrTS0GiWQ50FtHYOd8GAZd6GPGVnCIvwGSz0uMnJR6YuyNr" crossorigin="anonymous"></script>
@@ -6,6 +7,7 @@
     <script src="https://unpkg.com/d3-force@3.0.0/dist/d3-force.min.js" integrity="sha384-RM+ykRJc5/xPC56TVMOAYbZeVThoKXqcRlmRHZZc3YDHDCvFJrsEH2dpLMqL50K8" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/force-graph@1.42.9/dist/force-graph.min.js" integrity="sha384-YESY75UqJTYPnjHzGp6bR5aezOtcOBvoXDpNJzGpSG1SkitYZqVfngK7fRl2Dpu8" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.6" integrity="sha384-UBGmRyNtwBeGap4zdtKXLwUHdLJM9M/aSMLo8NaIzCxnLxYU6F9+V8veOXP3Fakh" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.0" integrity="sha384-vKS98qWgX4gQJC0tU16FPrSCjnsxlCgFGdmidG2jEQ50pZym7Pwoq0bbY23k6BsW" crossorigin="anonymous"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
The recommended version is 5 versions ahead of the current version.
The recommended version was released 22 days ago, on 2022-05-03.

## Testing Plan
No major testing plan needed

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
None required.
```
[ ] Yes
[✓ ] No
```
graffiti: ironfishup