### PR TITLE
Pool database: Add index on createdAt for share table

### DIFF
--- a/ironfish/src/mining/poolDatabase/migrations/002-add-shares-index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/002-add-shares-index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration002 extends Migration {
+  name = '002-add-shares-index'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE INDEX idx_share_created_at ON share (createdAt);
+     `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP INDEX IF EXISTS idx_share_created_at;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -3,5 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import Migration001 from './001-initial'
+import Migration002 from './002-add-shares-index'
 
-export const MIGRATIONS = [Migration001]
+export const MIGRATIONS = [Migration001, Migration002]


### PR DESCRIPTION
## Summary

Quick addition to the pool database to potentially increase IO throughput. Can verify the change here: https://www.db-fiddle.com/f/69hrM4VPVFR23Xt7Hd7SPb/0

## Testing Plan

Testing locally on existing pool database

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
