### PR TITLE
GetUnspentNotes: de-couple spawning worker tasks from waiting for them to finish

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -616,12 +616,18 @@ export class Accounts {
   ): Promise<ReadonlyArray<{ hash: string; note: Note; index: number | null }>> {
     const unspentNotes = []
 
+    const notePromises = []
     for (const transactionMapValue of this.transactionMap.values()) {
-      const result = await this.workerPool.getUnspentNotes(
-        transactionMapValue.transaction.serialize(),
-        [account.incomingViewKey],
+      notePromises.push(
+        this.workerPool.getUnspentNotes(transactionMapValue.transaction.serialize(), [
+          account.incomingViewKey,
+        ]),
       )
+    }
 
+    const results = await Promise.all(notePromises)
+
+    for (const result of results) {
       for (const note of result.notes) {
         const map = this.noteToNullifier.get(note.hash)
 


### PR DESCRIPTION
## Summary

Before:
![image](https://user-images.githubusercontent.com/97762857/170593842-65b9490d-cca7-42ce-8169-ad75c70289f7.png)

After:
![image](https://user-images.githubusercontent.com/97762857/170593879-0fb3d119-0ecf-4163-b58d-51b7262bc75f.png)


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
