### PR TITLE
feat: adds script for generating key and cert for tls

### DIFF
--- a/ironfish-cli/scripts/generate-tls-keys.sh
+++ b/ironfish-cli/scripts/generate-tls-keys.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! command -v openssl &> /dev/null ]; then
+  echo "openssl is not installed but is required"
+  exit 1
+fi
+
+keyPath=${keyPath:-"node-key.pem"}
+certPath=${certPath:-"node-cert.pem"}
+certSubject=${certSubject:-"/O=Iron Fish"}
+
+while [ $# -gt 0 ]; do
+  case $1 in
+    --keyPath) declare keyPath=$2;;
+    --certPath) declare certPath=$2;;
+    --certSubject) declare certSubject=$2;;
+    *) break;
+  esac;
+  shift
+done
+
+echo "Generating node server private key at $keyPath"
+openssl genrsa -out $keyPath 2048 &> /dev/null
+# generate certificate signing request
+openssl req -new -key $keyPath -out csr.pem -subj "$certSubject"
+echo "Generating self-signed node server certificate at $certPath"
+openssl x509 -req -in csr.pem -signkey $keyPath -out $certPath &> /dev/null
+# dispose of request
+rm csr.pem

--- a/ironfish-cli/scripts/generate-tls-keys.sh
+++ b/ironfish-cli/scripts/generate-tls-keys.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+print_usage() {
+  cat << EOF
+
+  generate-tls-keys.sh
+
+  generates a private key and a x509 public certificate for enabling TLS
+
+    options:
+      --keyPath      the output path for the private key. default value 'node-key.pem'
+      --certPath     the output path for the public certificate. default value 'node-cert.pem'
+      --certSubject  the subject for the x509 public certificate. default value '/O=Iron Fish'
+      --signKeyPath  the input path of the certificate signing key. uses the generated private key to self-sign by default
+
+EOF
+}
+
 if [ ! command -v openssl &> /dev/null ]; then
   echo "openssl is not installed but is required"
   exit 1
@@ -18,7 +34,7 @@ while [ $# -gt 0 ]; do
     --certPath) declare certPath=$2;;
     --certSubject) declare certSubject=$2;;
     --signKeyPath) declare signKeyPath=$2;;
-    *) break;
+    *) print_usage; exit 0;;
   esac;
   shift
 done
@@ -26,8 +42,8 @@ done
 echo "Generating node server private key at $keyPath"
 openssl genrsa -out $keyPath 2048 &> /dev/null
 # generate certificate signing request
-openssl req -new -key $keyPath -out csr.pem -subj "$certSubject"
+openssl req -new -days 365 -key $keyPath -out csr.pem -subj "$certSubject"
 echo "Generating node server certificate at $certPath, signing with sign key at $signKeyPath"
 openssl x509 -req -in csr.pem -signkey $signKeyPath -out $certPath &> /dev/null
-# dispose of request
+# dispose of request file
 rm csr.pem

--- a/ironfish-cli/scripts/generate-tls-keys.sh
+++ b/ironfish-cli/scripts/generate-tls-keys.sh
@@ -9,12 +9,15 @@ fi
 keyPath=${keyPath:-"node-key.pem"}
 certPath=${certPath:-"node-cert.pem"}
 certSubject=${certSubject:-"/O=Iron Fish"}
+# generates self-signed certificates by default
+signKeyPath=${signKeyPath:-$keyPath}
 
 while [ $# -gt 0 ]; do
   case $1 in
     --keyPath) declare keyPath=$2;;
     --certPath) declare certPath=$2;;
     --certSubject) declare certSubject=$2;;
+    --signKeyPath) declare signKeyPath=$2;;
     *) break;
   esac;
   shift
@@ -24,7 +27,7 @@ echo "Generating node server private key at $keyPath"
 openssl genrsa -out $keyPath 2048 &> /dev/null
 # generate certificate signing request
 openssl req -new -key $keyPath -out csr.pem -subj "$certSubject"
-echo "Generating self-signed node server certificate at $certPath"
-openssl x509 -req -in csr.pem -signkey $keyPath -out $certPath &> /dev/null
+echo "Generating node server certificate at $certPath, signing with sign key at $signKeyPath"
+openssl x509 -req -in csr.pem -signkey $signKeyPath -out $certPath &> /dev/null
 # dispose of request
 rm csr.pem


### PR DESCRIPTION
## Summary
starting a tcp server over TLS requires a private key and a public cert for the
server. this script executes the steps required to generate a private key and a
self-signed certificate for the server.

- uses default private key path of 'node-key.pem'
- uses default certificate path of 'node-cert.pem'
- uses default cert subject of '/O=Iron Fish', where 'O' refers to
  'organization'
  
this follows from the changes implemented for IRO-1498. the script generates the key and cert used to establish secure connections between the secure TCP adapter and secure client.

moving the key and cert into the node's data directory isn't within the purview
of this script.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
