### PR TITLE
fix: transaction errors & account balance issues

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -734,10 +734,10 @@ export class Accounts {
           )
 
           // Update our map so this doesn't happen again
-          const noteMapValue = this.noteToNullifier.get(nullifier.toString('hex'))
+          const noteMapValue = this.noteToNullifier.get(unspentNote.hash)
           if (noteMapValue) {
             this.logger.debug(`Unspent note has index ${String(noteMapValue.noteIndex)}`)
-            await this.updateNoteToNullifierMap(nullifier.toString('hex'), {
+            await this.updateNoteToNullifierMap(unspentNote.hash, {
               ...noteMapValue,
               spent: true,
             })


### PR DESCRIPTION
## Summary
Many bugs have been reported relating to tx failures and account balance problems. I've hit these myself quite consistently.

While debugging, I found that https://github.com/iron-fish/ironfish/blob/master/ironfish/src/account/accounts.ts#L714-L740 in `accounts/createTransaction` is causing the problem. This wouldn't update successfully, the tx would then fail with `Insufficient funds`, and querying the account balance afterward would show incorrect values. 

`nullifier.toString('hex')` should be `unspentNote.hash` 👇 
```
          // Update our map so this doesn't happen again
          const noteMapValue = this.noteToNullifier.get(nullifier.toString('hex'))
          if (noteMapValue) {
            this.logger.debug(`Unspent note has index ${String(noteMapValue.noteIndex)}`)
            await this.updateNoteToNullifierMap(nullifier.toString('hex'), {
              ...noteMapValue,
              spent: true,
            })
          }
```

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
