### PR TITLE
small text updates

### DIFF
--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -108,7 +108,7 @@ export class Miner extends IronfishCommand {
     }
 
     if (!flags.pool) {
-      this.log(`Starting to mine with graffiti: ${graffiti} connecting to node`)
+      this.log(`Starting to mine with graffiti: ${graffiti}`)
 
       const rpc = this.sdk.client
 

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -87,8 +87,8 @@ export class StratumServer {
 
     this.clients = new Map()
     this.badClients = new Set()
-    this.nextMinerId = 0
-    this.nextMessageId = 0
+    this.nextMinerId = 1
+    this.nextMessageId = 1
 
     this.server = net.createServer((s) => this.onConnection(s))
   }


### PR DESCRIPTION
## Summary
2 small text updates

1) start mining pool connected id at 1 and not 0
![Screenshot 2022-05-30 at 21 18 44](https://user-images.githubusercontent.com/2752586/171061310-e8d82ca8-7c04-4d27-8ae9-0f99188e796e.png)

2) redundant 'connected to node' msg that can be removed from solo mining start log
![Screenshot 2022-05-30 at 22 38 16](https://user-images.githubusercontent.com/2752586/171061462-2488b614-51aa-4385-b2da-e32938f28810.png)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
