### PR TITLE
Fixed Redundant static lifetime

### DIFF
--- a/ironfish-rust-wasm/src/wasm_structs/witness.rs
+++ b/ironfish-rust-wasm/src/wasm_structs/witness.rs
@@ -11,7 +11,7 @@ use ironfish_rust::witness::{WitnessNode, WitnessTrait};
 use super::panic_hook;
 
 #[wasm_bindgen(typescript_custom_section)]
-const IWITNESS: &'static str = r#"
+const IWITNESS: &str = r#"
 interface IWitness {
     verify(myHash: Uint8Array): bool;
     authPath(): IWitnessNode[];
@@ -42,7 +42,7 @@ extern "C" {
 }
 
 #[wasm_bindgen(typescript_custom_section)]
-const IWITNESSNODE: &'static str = r#"
+const IWITNESSNODE: &str = r#"
 interface IWitnessNode {
     side(): 'Left' | 'Right';
     hashOfSibling(): Uint8Array;


### PR DESCRIPTION
## Summary
Fixed redundant static lifetime.

Static lifetimes on constants or static references are redundant. The lifetime is inferred. Adding 'static to every reference needlessly increases the complexity of the type declaration.

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[✓ ] No
```
graffiti: ironfishup