### PR TITLE
Added the u flag

### DIFF
--- a/ironfish/src/utils/graffiti.ts
+++ b/ironfish/src/utils/graffiti.ts
@@ -13,7 +13,7 @@ function fromString(graffiti: string): Buffer {
 function toHuman(graffiti: Buffer): string {
   return graffiti
     .toString('utf8')
-    .replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
+    .replace(/[\u0000-\u001F\u007F-\u009F]/gu, '')
     .trim()
 }
 

--- a/ironfish/src/utils/memo.ts
+++ b/ironfish/src/utils/memo.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 function toHuman(memo: string): string {
-  return memo.replace(/[\u0000-\u001F\u007F-\u009F]/g, '').trim()
+  return memo.replace(/[\u0000-\u001F\u007F-\u009F]/gu, '').trim()
 }
 
 export const MemoUtils = {


### PR DESCRIPTION
## Summary
Added the u flag with regular expressions, which enables correct handling of UTF-16 surrogate pairs, and ensures the correct behavior of regex character ranges.


## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ✓] No
```
graffiti: ironfishup