### PR TITLE
Comparisons fixed

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -77,7 +77,7 @@ export class Pay extends IronfishCommand {
       this.exit(1)
     }
 
-    if (amount == null || Number.isNaN(amount)) {
+    if (amount === null || Number.isNaN(amount)) {
       const response = await client.getAccountBalance({ account: from })
 
       const input = Number(
@@ -99,7 +99,7 @@ export class Pay extends IronfishCommand {
       amount = input
     }
 
-    if (fee == null || Number.isNaN(fee)) {
+    if (fee === null || Number.isNaN(fee)) {
       const input = Number(
         await CliUx.ux.prompt('Enter the fee amount in $IRON', {
           required: true,

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -59,7 +59,7 @@ export class Miner extends IronfishCommand {
     const batchSize = this.sdk.config.get('minerBatchSize')
 
     if (flags.pool) {
-      if (flags.address == null) {
+      if (flags.address === null) {
         this.error(
           "Can't mine from a pool without a public address. Use `-a address-goes-here` to provide one.",
         )

--- a/ironfish/src/account/validator.ts
+++ b/ironfish/src/account/validator.ts
@@ -71,5 +71,5 @@ export function validateAccount(toImport: Partial<AccountsValue>): void {
 
 function haveAllowedCharacters(text: string): boolean {
   const validInputRegex = /^[0-9a-f]+$/
-  return validInputRegex.exec(text.toLowerCase()) != null
+  return validInputRegex.exec(text.toLowerCase()) !== null
 }

--- a/ironfish/src/assert.ts
+++ b/ironfish/src/assert.ts
@@ -75,7 +75,7 @@ export class Assert {
     x: T,
     message?: string,
   ): asserts x is Exclude<T, null | undefined | 0 | false | ''> {
-    const isFalsey = x == null || x === 0 || x === '' || x === false
+    const isFalsey = x === null || x === 0 || x === '' || x === false
 
     if (isFalsey) {
       throw new Error(message || `Expected value to be truthy`)

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -370,7 +370,7 @@ export class MiningPool {
 
   private isDuplicateSubmission(clientId: number, randomness: string): boolean {
     const submissions = this.recentSubmissions.get(clientId)
-    if (submissions == null) {
+    if (submissions === null) {
       return false
     }
     return submissions.includes(randomness)
@@ -378,7 +378,7 @@ export class MiningPool {
 
   private addWorkSubmission(clientId: number, randomness: string): void {
     const submissions = this.recentSubmissions.get(clientId)
-    if (submissions == null) {
+    if (submissions === null) {
       this.recentSubmissions.set(clientId, [randomness])
     } else {
       submissions.push(randomness)

--- a/ironfish/src/mining/poolDatabase/database.ts
+++ b/ironfish/src/mining/poolDatabase/database.ts
@@ -76,7 +76,7 @@ export class PoolDatabase {
      `
 
     const result = await this.db.run(query, successfulPayoutCutoff, attemptPayoutCutoff)
-    if (result.changes !== 0 && result.lastID != null) {
+    if (result.changes !== 0 && result.lastID !== null) {
       return result.lastID
     }
 
@@ -97,7 +97,7 @@ export class PoolDatabase {
       "SELECT COUNT(id) AS count FROM share WHERE createdAt > datetime(?, 'unixepoch')",
       timestamp,
     )
-    if (result == null) {
+    if (result === null) {
       return 0
     }
     return result.count

--- a/ironfish/src/mining/poolMiner.ts
+++ b/ironfish/src/mining/poolMiner.ts
@@ -130,7 +130,7 @@ export class MiningPoolMiner {
         continue
       }
 
-      if (this.graffiti == null) {
+      if (this.graffiti === null) {
         this.logger.info('Waiting for graffiti from pool...')
         await PromiseUtils.sleep(500)
         continue
@@ -138,7 +138,7 @@ export class MiningPoolMiner {
 
       const blockResult = this.threadPool.getFoundBlock()
 
-      if (blockResult != null) {
+      if (blockResult !== null) {
         const { miningRequestId, randomness } = blockResult
 
         this.logger.info(

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -113,7 +113,7 @@ export class MiningPoolShares {
 
     // Create a payout in the DB as a form of a lock
     const payoutId = await this.db.newPayout(timestamp)
-    if (payoutId == null) {
+    if (payoutId === null) {
       this.logger.info(
         'Another payout may be in progress or a payout was made too recently, skipping.',
       )
@@ -199,7 +199,7 @@ export class MiningPoolShares {
       const address = share.publicAddress
       const shareCount = shareMap.get(address)
 
-      if (shareCount != null) {
+      if (shareCount !== null) {
         shareMap.set(address, shareCount + 1)
       } else {
         shareMap.set(address, 1)

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -178,7 +178,7 @@ export class MiningSoloMiner {
     while (this.started) {
       const blockResult = this.threadPool.getFoundBlock()
 
-      if (blockResult != null) {
+      if (blockResult !== null) {
         const { miningRequestId, randomness } = blockResult
 
         this.logger.info(

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -119,7 +119,7 @@ export class StratumServer {
   }
 
   hasWork(): boolean {
-    return this.currentWork != null
+    return this.currentWork !== null
   }
 
   addBadClient(client: StratumServerClient): void {

--- a/ironfish/src/rpc/adapters/tcpAdapter.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.ts
@@ -154,7 +154,7 @@ export class TcpAdapter implements IAdapter {
     )
     reqMap.set(reqId, request)
 
-    if (this.router == null) {
+    if (this.router === null) {
       this.emitResponse(socket, this.constructMalformedRequest(data), reqMap)
       return
     }

--- a/ironfish/src/rpc/routes/mining/blockTemplateStream.ts
+++ b/ironfish/src/rpc/routes/mining/blockTemplateStream.ts
@@ -102,7 +102,7 @@ router.register<typeof BlockTemplateStreamRequestSchema, BlockTemplateStreamResp
 
     // Send an initial block template to the requester so they can begin working immediately
     const currentHeadBlock = await node.chain.getBlock(node.chain.head)
-    if (currentHeadBlock != null) {
+    if (currentHeadBlock !== null) {
       await streamNewBlockTemplate(currentHeadBlock)
     }
 


### PR DESCRIPTION
## Summary
Compared to null with a type-checking operator in multiple files. Comparing to null without a type-checking operator will evaluate to true when comparing to not just a null, but to an undefined value as well.

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ✓] No
```
graffiti: ironfishup