### PR TITLE
pool: limit number of concurrent tcp connections per ip

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -291,7 +291,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolSuccessfulPayoutInterval: DEFAULT_POOL_SUCCESSFUL_PAYOUT_INTERVAL,
       poolRecentShareCutoff: DEFAULT_POOL_RECENT_SHARE_CUTOFF,
       poolDiscordWebhook: '',
-      poolMaxConnectionsPerIp: 20,
+      poolMaxConnectionsPerIp: 0,
       poolLarkWebhook: '',
       jsonLogs: false,
     }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -195,7 +195,8 @@ export type ConfigOptions = {
   poolDiscordWebhook: ''
 
   /**
-   * The maximum number of concurrent open connections per remote address
+   * The maximum number of concurrent open connections per remote address.
+   * Setting this to 0 disabled the limit
    */
   poolMaxConnectionsPerIp: number
 

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -195,6 +195,11 @@ export type ConfigOptions = {
   poolDiscordWebhook: ''
 
   /**
+   * The maximum number of concurrent open connections per remote address
+   */
+  poolMaxConnectionsPerIp: number
+
+  /**
 
    * The lark webhook URL to post pool critical pool information too
    */
@@ -286,6 +291,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolSuccessfulPayoutInterval: DEFAULT_POOL_SUCCESSFUL_PAYOUT_INTERVAL,
       poolRecentShareCutoff: DEFAULT_POOL_RECENT_SHARE_CUTOFF,
       poolDiscordWebhook: '',
+      poolMaxConnectionsPerIp: 1,
       poolLarkWebhook: '',
       jsonLogs: false,
     }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -291,7 +291,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolSuccessfulPayoutInterval: DEFAULT_POOL_SUCCESSFUL_PAYOUT_INTERVAL,
       poolRecentShareCutoff: DEFAULT_POOL_RECENT_SHARE_CUTOFF,
       poolDiscordWebhook: '',
-      poolMaxConnectionsPerIp: 1,
+      poolMaxConnectionsPerIp: 20,
       poolLarkWebhook: '',
       jsonLogs: false,
     }

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -334,7 +334,7 @@ export class StratumServer {
     }
 
     const connectionsByIp = this.openConnections.get(socket.remoteAddress) ?? 0
-    if (connectionsByIp >= this.maxOpenConnections) {
+    if (this.maxOpenConnections > 0 && connectionsByIp >= this.maxOpenConnections) {
       return false
     }
 


### PR DESCRIPTION
## Summary

Introduce a tracker which counts the number of active connections to the pool per external IP-address. If the maximum number is reached, decline future transactions. 

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
