### PR TITLE
Reset chainProcessor hash if index head not found in database

### DIFF
--- a/ironfish/src/indexers/minedBlocksIndexer.test.ts
+++ b/ironfish/src/indexers/minedBlocksIndexer.test.ts
@@ -14,7 +14,7 @@ describe('MinedBlockIndexer', () => {
     Assert.isNotNull(genesis)
 
     await node.minedBlocksIndexer.open()
-    node.minedBlocksIndexer.start()
+    await node.minedBlocksIndexer.start()
 
     const putSpy = jest.spyOn(node.minedBlocksIndexer['minedBlocks'], 'put')
 
@@ -49,7 +49,7 @@ describe('MinedBlockIndexer', () => {
     Assert.isNotNull(genesis)
 
     await nodeA.minedBlocksIndexer.open()
-    nodeA.minedBlocksIndexer.start()
+    await nodeA.minedBlocksIndexer.start()
 
     const putSpy = jest.spyOn(nodeA.minedBlocksIndexer['minedBlocks'], 'put')
 
@@ -102,7 +102,7 @@ describe('MinedBlockIndexer', () => {
     Assert.isNotNull(genesis)
 
     await node.minedBlocksIndexer.open()
-    node.minedBlocksIndexer.start()
+    await node.minedBlocksIndexer.start()
 
     const accountA = await useAccountFixture(node.accounts, 'a')
     const blockA1 = await useMinerBlockFixture(node.chain, undefined, accountA)
@@ -130,7 +130,7 @@ describe('MinedBlockIndexer', () => {
       Assert.isNotNull(genesis)
 
       await node.minedBlocksIndexer.open()
-      node.minedBlocksIndexer.start()
+      await node.minedBlocksIndexer.start()
 
       const accountA = await useAccountFixture(node.accounts, 'a')
       const blockA1 = await useMinerBlockFixture(node.chain, 2, accountA)
@@ -171,7 +171,7 @@ describe('MinedBlockIndexer', () => {
       Assert.isNotNull(genesis)
 
       await nodeA.minedBlocksIndexer.open()
-      nodeA.minedBlocksIndexer.start()
+      await nodeA.minedBlocksIndexer.start()
 
       const accountA = await useAccountFixture(nodeA.accounts, 'a')
       const accountB = await useAccountFixture(nodeA.accounts, 'b')
@@ -213,7 +213,7 @@ describe('MinedBlockIndexer', () => {
       Assert.isNotNull(genesis)
 
       await node.minedBlocksIndexer.open()
-      node.minedBlocksIndexer.start()
+      await node.minedBlocksIndexer.start()
 
       const accountA = await useAccountFixture(node.accounts, 'a')
       const accountB = await useAccountFixture(node.accounts, 'b')
@@ -247,7 +247,7 @@ describe('MinedBlockIndexer', () => {
       Assert.isNotNull(genesis)
 
       await nodeA.minedBlocksIndexer.open()
-      nodeA.minedBlocksIndexer.start()
+      await nodeA.minedBlocksIndexer.start()
 
       const accountA = await useAccountFixture(nodeA.accounts, 'a')
       const accountB = await useAccountFixture(nodeB.accounts, 'b')

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -313,7 +313,7 @@ export class IronfishNode {
       await this.rpc.start()
     }
 
-    this.minedBlocksIndexer.start()
+    await this.minedBlocksIndexer.start()
     this.telemetry.submitNodeStarted()
   }
 


### PR DESCRIPTION
## Summary
The head hash of `MinedBlockIndexer`'s meta table should be reset instead of throwing an error, if its head hash in is not found in the chain.

## Testing Plan
Reproduction, as per @NullSoldier:
1. Start the node and sync blocks
2. Delete the `databases` folder
3. Start the node

Ensured that the node now starts properly and logs an error message.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
