### PR TITLE
Lower the block sync amount from 100 to 20

### DIFF
--- a/ironfish-cli/src/commands/service/sync.ts
+++ b/ironfish-cli/src/commands/service/sync.ts
@@ -7,7 +7,7 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 const RAW_MAX_UPLOAD = Number(process.env.MAX_UPLOAD)
-const MAX_UPLOAD = isNaN(RAW_MAX_UPLOAD) ? 100 : RAW_MAX_UPLOAD
+const MAX_UPLOAD = isNaN(RAW_MAX_UPLOAD) ? 20 : RAW_MAX_UPLOAD
 const NEAR_SYNC_THRESHOLD = 5
 
 export default class Sync extends IronfishCommand {


### PR DESCRIPTION
## Summary

100 is too much for a single request given the current block times. This will lead to more requests during a total re-sync, but if the syncer falls behind, it takes an incredible amount of time to catch up given this size.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
