### PR TITLE
Add way to ad-hoc save logs to local database

### DIFF
--- a/ironfish/src/logger/index.ts
+++ b/ironfish/src/logger/index.ts
@@ -6,7 +6,7 @@ import type { Consola } from 'consola'
 import consola, { LogLevel } from 'consola'
 import { parseLogLevelConfig } from './logLevelParser'
 import { ConsoleReporter } from './reporters/console'
-export * from './reporters/intercept'
+export * from './reporters'
 
 /**
  * This interface tries to enforce more structured logs while still
@@ -14,13 +14,14 @@ export * from './reporters/intercept'
  * logs has a lot of benefits so going outside this interface. Update this
  * interface if something with a different structure needs to be logged.
  */
-type Loggable = string | number | boolean
+export type Loggable = string | number | boolean
+export type LogArgs = Record<string, Loggable>
 export interface Logger extends Consola {
-  info(message: string, args?: Record<string, Loggable>): void
-  log(message: string, args?: Record<string, Loggable>): void
-  error(message: string, args?: Record<string, Loggable>): void
-  warn(message: string, args?: Record<string, Loggable>): void
-  debug(message: string, args?: Record<string, Loggable>): void
+  info(message: string, args?: LogArgs): void
+  log(message: string, args?: LogArgs): void
+  error(message: string, args?: LogArgs): void
+  warn(message: string, args?: LogArgs): void
+  debug(message: string, args?: LogArgs): void
   withTag(tag: string): Logger
 }
 

--- a/ironfish/src/logger/logDatabase.ts
+++ b/ironfish/src/logger/logDatabase.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Database, open } from 'sqlite'
+import sqlite3 from 'sqlite3'
+import { NodeFileProvider } from '../fileSystems'
+import { LogArgs } from './index'
+
+export class LogsDatabase {
+  private db: Database
+  private createdTables: string[] = []
+
+  constructor(db: Database) {
+    this.db = db
+  }
+
+  static async init(dataDir: string): Promise<LogsDatabase> {
+    const fs = new NodeFileProvider()
+    await fs.init()
+
+    const logsDBFolder = fs.join(dataDir, 'logs')
+    await fs.mkdir(logsDBFolder, { recursive: true })
+
+    const db = await open({
+      filename: fs.join(logsDBFolder, `/${Date.now()}-database.sqlite`),
+      driver: sqlite3.Database,
+    })
+
+    return new LogsDatabase(db)
+  }
+
+  private async createTableIfNotExists(tableName: string, entry: LogArgs) {
+    const existingTable: string | undefined = await this.db.get(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name=?;`,
+      tableName,
+    )
+
+    // First check that the table does not already exist
+    if (this.createdTables.includes(tableName) || existingTable === tableName) {
+      return
+    }
+
+    const rows = Object.keys(entry)
+      .map((k) => {
+        switch (typeof entry[k]) {
+          case 'string':
+            return `${k} STRING`
+          case 'boolean':
+            return `${k} BOOLEAN`
+          case 'number':
+            return `${k} INTEGER`
+          default:
+            return undefined
+        }
+      })
+      .filter((r) => r !== undefined)
+
+    const statement =
+      `CREATE TABLE ${tableName}` + `(id INTEGER PRIMARY KEY, ${rows.join(', ')});`
+
+    await this.db.run(statement)
+    this.createdTables.push(tableName)
+  }
+
+  // **NOT SECURE** for SQL injection but only using for logs
+  async insert(entry: LogArgs, tableName: string): Promise<void> {
+    await this.createTableIfNotExists(tableName, entry)
+    const keys = Object.keys(entry)
+
+    const statement =
+      `INSERT INTO ${tableName}` +
+      `(${keys.join(',')})` +
+      `VALUES (${keys.map((_) => '?').join(', ')})`
+
+    await this.db.run(statement, ...Object.values(entry))
+  }
+
+  async stop(): Promise<void> {
+    await this.db.close()
+  }
+}

--- a/ironfish/src/logger/reporters/console.ts
+++ b/ironfish/src/logger/reporters/console.ts
@@ -5,7 +5,7 @@
 // The reporter intentionally logs to the console, so disable the lint
 /* eslint-disable no-console */
 
-import { ConsolaReporterLogObject, logType } from 'consola'
+import { ConsolaReporterLogObject, LogLevel, logType } from 'consola'
 import { Assert } from '../../assert'
 import { IJSON } from '../../serde'
 import { TextReporter } from './text'
@@ -35,7 +35,9 @@ export const getConsoleLogger = (logType: logType): typeof console.log => {
   return logger
 }
 
-export const logObjToJSON = (logObj: ConsolaReporterLogObject): string => {
+export const logObjToJSON = (
+  logObj: ConsolaReporterLogObject,
+): Record<string, unknown> & { message: string; level: LogLevel; tag: string; date: Date } => {
   const objectArgs: Record<string, unknown>[] = logObj.args.filter(
     (a) => typeof a === 'object',
   ) as Record<string, unknown>[]
@@ -49,7 +51,7 @@ export const logObjToJSON = (logObj: ConsolaReporterLogObject): string => {
     message: otherArgs.join(' '),
   }
 
-  return IJSON.stringify(toLog)
+  return toLog
 }
 
 export class ConsoleReporter extends TextReporter {
@@ -57,6 +59,6 @@ export class ConsoleReporter extends TextReporter {
 
   logText(logObj: ConsolaReporterLogObject, args: unknown[]): void {
     const logger = getConsoleLogger(logObj.type)
-    this.logToJSON ? logger(logObjToJSON(logObj)) : logger(...args)
+    this.logToJSON ? logger(IJSON.stringify(logObjToJSON(logObj))) : logger(...args)
   }
 }

--- a/ironfish/src/logger/reporters/index.ts
+++ b/ironfish/src/logger/reporters/index.ts
@@ -5,3 +5,4 @@
 export * from './console'
 export * from './file'
 export * from './intercept'
+export * from './logsDBReporter'

--- a/ironfish/src/logger/reporters/logsDBReporter.ts
+++ b/ironfish/src/logger/reporters/logsDBReporter.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ConsolaReporterLogObject } from 'consola'
+import { LogArgs } from '../index'
+import { LogsDatabase } from '../logDatabase'
+import { logObjToJSON } from './console'
+import { InterceptReporter } from './intercept'
+
+export const createNewLogsDBReporter = async (dataDir: string): Promise<InterceptReporter> => {
+  const db = await LogsDatabase.init(dataDir)
+
+  return new InterceptReporter((logObj: ConsolaReporterLogObject): void => {
+    const json = logObjToJSON(logObj)
+    if ('dbTable' in json) {
+      const filteredEntry = Object.fromEntries(
+        Object.entries(json).filter(([key]) => {
+          return !['dbTable', 'message', 'tag', 'date', 'level'].includes(key)
+        }),
+      )
+      void db.insert(filteredEntry as LogArgs, json.dbTable as string)
+    }
+  })
+}


### PR DESCRIPTION
## Summary
We need way to easily and flexibly get visibility into stats about the node. How many transaction messages are we receiving from nodes? Are there duplicate gossip messages? Are certain peers sending more than others?

We have a few different ways that we keep track of node stats currently (like [Meter](https://github.com/iron-fish/ironfish/blob/staging/ironfish/src/metrics/meter.ts)). But these stats are stored in memory and are not accessible to other systems without creating RPC endpoints. They also aren't as flexible as a SQL database.

For gaining visibility into gossip messages, I would like to create an easy way to save ad-hoc events to a database (like new transaction/block message) to a database to be able to analyze them more in-depth. Ideally this approach will be helpful for future use-cases as well

Here is an example of how a log line might be modified to use this database.
Original log line:
```typescript
    this.logger.info('INCOMING_TRANSACTION', {
      hash,
      inMemPool,
      peer
    })
```

Modified log line:
```typescript
    this.logger.info('INCOMING_TRANSACTION', {
      hash,
      inMemPool,
      peer,
      dbTable: 'transactions',
    })
```

This will create a database when the node starts up, a new table `transactions` and insert all the log lines into this table. The database table will be in the `.ironfish` data directory

You also need to add the dbReporter to the current logger
```typescript
const dbReporter = await createNewLogsDBReporter(config.dataDir)
logger = logger.addReporter(dbReporter)
```
## Testing Plan
Local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
