### PR TITLE
Move max upload in syncer to flag

### DIFF
--- a/ironfish-cli/src/commands/service/sync.ts
+++ b/ironfish-cli/src/commands/service/sync.ts
@@ -6,8 +6,6 @@ import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
-const RAW_MAX_UPLOAD = Number(process.env.MAX_UPLOAD)
-const MAX_UPLOAD = isNaN(RAW_MAX_UPLOAD) ? 20 : RAW_MAX_UPLOAD
 const NEAR_SYNC_THRESHOLD = 5
 
 export default class Sync extends IronfishCommand {
@@ -26,10 +24,16 @@ export default class Sync extends IronfishCommand {
       description: 'API host to sync to',
     }),
     token: Flags.string({
-      char: 'e',
+      char: 't',
       parse: (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'API host token to authenticate with',
+    }),
+    maxUpload: Flags.integer({
+      char: 'm',
+      required: false,
+      default: isNaN(Number(process.env.MAX_UPLOAD)) ? 20 : Number(process.env.MAX_UPLOAD),
+      description: 'The max number of blocks to sync in once batch',
     }),
   }
 
@@ -100,7 +104,7 @@ export default class Sync extends IronfishCommand {
         Math.abs(content.head.sequence - content.block.sequence) < NEAR_SYNC_THRESHOLD
 
       // Should we commit the current batch?
-      const committing = buffer.length === MAX_UPLOAD || finishing
+      const committing = buffer.length === flags.maxUpload || finishing
 
       this.log(
         `${content.type}: ${content.block.hash} - ${content.block.sequence}${


### PR DESCRIPTION
## Summary

I moved the max upload to a flag default in case we need to change this again, so we don't need to change the code. We can just terraform a configuration change. The value also shows up in the --help this way.

```
> ironfish service:sync --help

FLAGS
  -m, --maxUpload=<value>  [default: 20] The max number of blocks to sync in once batch
```

## Testing Plan
Run the command and play with inputs

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
