### PR TITLE
feat(ironfish): Add config variable for minimum block confirmations

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -141,6 +141,12 @@ export type ConfigOptions = {
   minerBatchSize: number
 
   /**
+   * The minimum number of block confirmations needed when computing account
+   * balance.
+   */
+  minimumBlockConfirmations: number
+
+  /**
    * The name that the pool will use in block graffiti and transaction memo.
    */
   poolName: string
@@ -263,6 +269,7 @@ export class Config extends KeyStore<ConfigOptions> {
       rpcTcpSecure: false,
       rpcRetryConnect: false,
       maxPeers: 50,
+      minimumBlockConfirmations: 12,
       minPeers: 1,
       targetPeers: 50,
       telemetryApi: DEFAULT_TELEMETRY_API,


### PR DESCRIPTION
## Summary

Add a configuration in the file store for the minimum number of block confirmations required when computing an account balance (during fetching or sending in a transaction)

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
