### PR TITLE
remove unused onKnownPeersChanged

### DIFF
--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -198,11 +198,6 @@ export class Peer {
   readonly onMessage: Event<[NetworkMessage, Connection]> = new Event()
 
   /**
-   * Event fired when the knownPeers map changes.
-   */
-  readonly onKnownPeersChanged: Event<[]> = new Event()
-
-  /**
    * Fired when the peer should be banned
    */
   readonly onBanned: Event<[]> = new Event()
@@ -664,7 +659,6 @@ export class Peer {
    */
   dispose(): void {
     this.onStateChanged.clear()
-    this.onKnownPeersChanged.clear()
     this.onMessage.clear()
     this.onBanned.clear()
   }

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -1386,32 +1386,6 @@ describe('PeerManager', () => {
       expect(peer.knownPeers.size).toBe(0)
     })
 
-    it('Does not emit onKnownPeersChanged when peer list stays the same', () => {
-      const peerIdentity = mockIdentity('peer')
-      const newPeerIdentity = mockIdentity('new')
-
-      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
-
-      const { connection, peer } = getConnectedPeer(pm, peerIdentity)
-
-      expect(pm.peers.length).toBe(1)
-      expect(pm.identifiedPeers.size).toBe(1)
-      expect(peer.knownPeers.size).toBe(0)
-
-      const peerList = new PeerListMessage([
-        {
-          identity: Buffer.from(newPeerIdentity),
-          address: peer.address,
-          port: peer.port,
-        },
-      ])
-      const onKnownPeersChangedSpy = jest.spyOn(peer.onKnownPeersChanged, 'emit')
-      peer.onMessage.emit(peerList, connection)
-      peer.onMessage.emit(peerList, connection)
-
-      expect(onKnownPeersChangedSpy).toBeCalledTimes(1)
-    })
-
     it('Links peers when adding a new known peer', () => {
       const peerIdentity = mockIdentity('peer')
       const newPeerIdentity = mockIdentity('new')
@@ -1423,9 +1397,6 @@ describe('PeerManager', () => {
       expect(pm.peers.length).toBe(1)
       expect(pm.identifiedPeers.size).toBe(1)
       expect(peer.knownPeers.size).toBe(0)
-
-      // Clear onKnownPeersChanged handlers to avoid any side effects
-      pm.onKnownPeersChanged.clear()
 
       const peerList = new PeerListMessage([
         {
@@ -1468,9 +1439,6 @@ describe('PeerManager', () => {
       expect(pm.peers.length).toBe(1)
       expect(pm.identifiedPeers.size).toBe(1)
       expect(peer.knownPeers.size).toBe(0)
-
-      // Clear onKnownPeersChanged handlers to avoid any side effects
-      pm.onKnownPeersChanged.clear()
 
       const peerList = new PeerListMessage([
         {


### PR DESCRIPTION
## Summary
Removing `onKnownPeersChanged` event for both the Peer and PeerManager because nothing subscribes to these events. I think we can add this back in if needed but it could help to simplify the code for now

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
