### PR TITLE
Bump up the default batch size

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -269,7 +269,7 @@ export class Config extends KeyStore<ConfigOptions> {
       accountName: DEFAULT_WALLET_NAME,
       generateNewIdentity: false,
       blocksPerMessage: 20,
-      minerBatchSize: 10000,
+      minerBatchSize: 25000,
       poolName: DEFAULT_POOL_NAME,
       poolAccountName: DEFAULT_POOL_ACCOUNT_NAME,
       poolBalancePercentPayout: DEFAULT_POOL_BALANCE_PERCENT_PAYOUT,

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -16,6 +16,7 @@ export const DEFAULT_BOOTSTRAP_NODE = 'test.bn1.ironfish.network'
 export const DEFAULT_DISCORD_INVITE = 'https://discord.gg/ironfish'
 export const DEFAULT_USE_RPC_IPC = true
 export const DEFAULT_USE_RPC_TCP = false
+export const DEFAULT_MINER_BATCH_SIZE = 25000
 
 // Pool defaults
 export const DEFAULT_POOL_NAME = 'Iron Fish Pool'
@@ -269,7 +270,7 @@ export class Config extends KeyStore<ConfigOptions> {
       accountName: DEFAULT_WALLET_NAME,
       generateNewIdentity: false,
       blocksPerMessage: 20,
-      minerBatchSize: 25000,
+      minerBatchSize: DEFAULT_MINER_BATCH_SIZE,
       poolName: DEFAULT_POOL_NAME,
       poolAccountName: DEFAULT_POOL_ACCOUNT_NAME,
       poolBalancePercentPayout: DEFAULT_POOL_BALANCE_PERCENT_PAYOUT,

--- a/ironfish/src/rpc/routes/config/getConfig.test.ts
+++ b/ironfish/src/rpc/routes/config/getConfig.test.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DEFAULT_MINER_BATCH_SIZE } from '../../../fileStores/config'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 
 describe('Route config/getConfig', () => {
@@ -13,7 +14,7 @@ describe('Route config/getConfig', () => {
   })
 
   it('returns value of the requested ConfigOptions', async () => {
-    const target = { minerBatchSize: 10000 }
+    const target = { minerBatchSize: DEFAULT_MINER_BATCH_SIZE }
     const response = await routeTest.client
       .request('config/getConfig', {
         name: 'minerBatchSize',


### PR DESCRIPTION
## Summary

We've been using the same default batch size of 10,000 since before we made the miner ~20-30x faster. Making the batch size 2.5x is fairly conservative, but should still result in slightly less time spent on things that are not actually hashing to find valid blocks. Even on my laptop, I was running a batch size of 50k in ~15ms. Note that I don't really expect this to have much impact, just something that occurred to me recently and was an easy change.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
