### PR TITLE
Updated node to version 18.2.0

### DIFF
--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.0-bullseye as build
+FROM node:18.2.0-bullseye as build
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 COPY ./ ./
@@ -9,7 +9,7 @@ RUN \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     ./ironfish-cli/scripts/build.sh
 
-FROM node:16.13.0-bullseye-slim
+FROM node:18.2.0-bullseye-slim
 EXPOSE 8020:8020
 EXPOSE 9033:9033
 VOLUME /root/.ironfish


### PR DESCRIPTION
## Summary
Updated node to the latest stable version 18.2.0. The previous version 16.13, which was outdated by 26 versions.
## Testing Plan
None needed
## Breaking Change
None
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[✓ ] No
```
graffiti: ironfishup