### PR TITLE
Updated fuse.js

### DIFF
--- a/ironfish-graph-explorer/package.json
+++ b/ironfish-graph-explorer/package.json
@@ -19,6 +19,6 @@
     "webpack-dev-server": "4.6.0"
   },
   "dependencies": {
-    "fuse.js": "6.6.0"
+    "fuse.js": "6.6.2"
   }
 }

--- a/ironfish-graph-explorer/src/index.html
+++ b/ironfish-graph-explorer/src/index.html
@@ -6,8 +6,7 @@
     <script src="https://unpkg.com/d3-quadtree@3.0.1/dist/d3-quadtree.min.js" integrity="sha384-JzQQZeN94rbeGRpksNSu8TCkRWLlzTHev53JZngDT0faxrmd9bApgXS5pZWShqJb" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/d3-force@3.0.0/dist/d3-force.min.js" integrity="sha384-RM+ykRJc5/xPC56TVMOAYbZeVThoKXqcRlmRHZZc3YDHDCvFJrsEH2dpLMqL50K8" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/force-graph@1.42.9/dist/force-graph.min.js" integrity="sha384-YESY75UqJTYPnjHzGp6bR5aezOtcOBvoXDpNJzGpSG1SkitYZqVfngK7fRl2Dpu8" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.6" integrity="sha384-UBGmRyNtwBeGap4zdtKXLwUHdLJM9M/aSMLo8NaIzCxnLxYU6F9+V8veOXP3Fakh" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.0" integrity="sha384-vKS98qWgX4gQJC0tU16FPrSCjnsxlCgFGdmidG2jEQ50pZym7Pwoq0bbY23k6BsW" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2" integrity="sha384-vKS98qWgX4gQJC0tU16FPrSCjnsxlCgFGdmidG2jEQ50pZym7Pwoq0bbY23k6BsW" crossorigin="anonymous"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
Removed the outdated version 6.4.6 from the files being fetched. The version 6.4.6 version was 8 versions, 1 year and 6 months, behind the version 6.6.2.

Updated fuse.js from 6.6.0 to 6.6.2. The version 6.6.0 version was 2 versions, 1 month, behind the version 6.6.2

## Testing Plan
No major testing plan needed
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ✓] No
```
