### PR TITLE
Add TcpAdapter waiting for clients to disconnect

### DIFF
--- a/ironfish/src/rpc/adapters/tcpAdapter.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.ts
@@ -119,11 +119,26 @@ export class TcpAdapter implements IAdapter {
       })
     })
 
+    await this.waitForAllToDisconnect()
+
     this.logger.debug(`tcpAdapter stopped: ${this.host}:${this.port}`)
   }
 
   attach(server: RpcServer): void {
     this.router = server.getRouter(this.namespaces)
+  }
+
+  async waitForAllToDisconnect(): Promise<void> {
+    const clients = Array.from(this.clients.values())
+    await Promise.all(clients.map((c) => this.waitForClientToDisconnect(c)))
+  }
+
+  waitForClientToDisconnect(client: TcpAdapterClient): Promise<void> {
+    return new Promise<void>((resolve) => {
+      client.socket.once('close', () => {
+        resolve()
+      })
+    })
   }
 
   onClientConnection(socket: net.Socket): void {


### PR DESCRIPTION
## Summary

I noticed that the TcpAdapter does not wait for clients to close, which
means there are clients still connected, and RPC routes still executing
onceo TcpAdapter.stop() has finished executing. We genenerally want
stop() to finish when TcpAdapter has fully stopped, and not in the
middle.

## Testing Plan

Call `ironfish stop` to test this code path

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
