### PR TITLE
Add transaction hash to pool payouts table

### DIFF
--- a/ironfish/src/mining/poolDatabase/database.ts
+++ b/ironfish/src/mining/poolDatabase/database.ts
@@ -83,8 +83,16 @@ export class PoolDatabase {
     return null
   }
 
-  async markPayoutSuccess(id: number, timestamp: number): Promise<void> {
-    await this.db.run('UPDATE payout SET succeeded = TRUE WHERE id = ?', id)
+  async markPayoutSuccess(
+    id: number,
+    timestamp: number,
+    transactionHash: string,
+  ): Promise<void> {
+    await this.db.run(
+      'UPDATE payout SET succeeded = TRUE, transactionHash = ? WHERE id = ?',
+      id,
+      transactionHash,
+    )
     await this.db.run(
       "UPDATE share SET payoutId = ? WHERE payoutId IS NULL AND createdAt < datetime(?, 'unixepoch')",
       id,

--- a/ironfish/src/mining/poolDatabase/migrations/003-add-transaction-hash.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/003-add-transaction-hash.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration002 extends Migration {
+  name = '003-add-transaction-hash'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      ALTER TABLE payout ADD COLUMN transactionHash TEXT;
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run(`
+      ALTER TABLE payout DROP COLUMN transactionHash;
+    `)
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -4,5 +4,6 @@
 
 import Migration001 from './001-initial'
 import Migration002 from './002-add-shares-index'
+import Migration003 from './003-add-transaction-hash'
 
-export const MIGRATIONS = [Migration001, Migration002]
+export const MIGRATIONS = [Migration001, Migration002, Migration003]

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -4,6 +4,7 @@
 import { Config } from '../fileStores/config'
 import { Logger } from '../logger'
 import { IronfishRpcClient } from '../rpc/clients/rpcClient'
+import { ErrorUtils } from '../utils'
 import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
 import { SetTimeoutToken } from '../utils/types'
@@ -169,7 +170,7 @@ export class MiningPoolShares {
         expirationSequenceDelta: 20,
       })
 
-      await this.db.markPayoutSuccess(payoutId, timestamp)
+      await this.db.markPayoutSuccess(payoutId, timestamp, transaction.content.hash)
 
       this.discord?.poolPayoutSuccess(
         payoutId,
@@ -185,7 +186,7 @@ export class MiningPoolShares {
         shareCounts.totalShares,
       )
     } catch (e) {
-      this.logger.error('There was an error with the transaction', e)
+      this.logger.error(`There was an error with the transaction ${ErrorUtils.renderError(e)}`)
       this.discord?.poolPayoutError(e)
       this.lark?.poolPayoutError(e)
     }


### PR DESCRIPTION
## Summary
Currently pool payouts don't record which transaction hash they were completed with. This is causing some issues when trying to debug how the payout was completed. We are also running into an issue where some transaction hashes cannot be found and there is no way to work backwards to tell which payouts they were associated with

## Testing Plan
Local testing

DB Fiddle testing the queries: https://www.db-fiddle.com/f/hk54YMjkve6A2QiwvsdBrT/2

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
