### PR TITLE
feat: adds a config variable for pool payout expiration, sets default

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -29,6 +29,7 @@ export const DEFAULT_POOL_DIFFICULTY = '15000000000'
 export const DEFAULT_POOL_ATTEMPT_PAYOUT_INTERVAL = 15 * 60 // 15 minutes
 export const DEFAULT_POOL_SUCCESSFUL_PAYOUT_INTERVAL = 2 * 60 * 60 // 2 hours
 export const DEFAULT_POOL_RECENT_SHARE_CUTOFF = 2 * 60 * 60 // 2 hours
+export const DEFAULT_POOL_PAYOUT_EXPIRATION_SEQUENCE_DELTA = 60
 
 export type ConfigOptions = {
   bootstrapNodes: string[]
@@ -202,6 +203,11 @@ export type ConfigOptions = {
   poolLarkWebhook: ''
 
   /**
+   * The number of blocks after which an unconfirmed pool payout transaction expires.
+   */
+  poolPayoutExpirationSequenceDelta: number
+
+  /**
    * Whether we want the logs to the console to be in JSON format or not. This can be used to log to
    * more easily process logs on a remote server using a log service like Datadog
    */
@@ -289,6 +295,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolRecentShareCutoff: DEFAULT_POOL_RECENT_SHARE_CUTOFF,
       poolDiscordWebhook: '',
       poolLarkWebhook: '',
+      poolPayoutExpirationSequenceDelta: DEFAULT_POOL_PAYOUT_EXPIRATION_SEQUENCE_DELTA,
       jsonLogs: false,
     }
   }

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -28,6 +28,7 @@ export class MiningPoolShares {
   private accountName: string
   private balancePercentPayout: bigint
   private balancePercentPayoutFlag: number | undefined
+  private payoutExpirationSequenceDelta: number
 
   private constructor(options: {
     db: PoolDatabase
@@ -53,6 +54,7 @@ export class MiningPoolShares {
     this.accountName = this.config.get('poolAccountName')
     this.balancePercentPayout = BigInt(this.config.get('poolBalancePercentPayout'))
     this.balancePercentPayoutFlag = options.balancePercentPayoutFlag
+    this.payoutExpirationSequenceDelta = this.config.get('poolPayoutExpirationSequenceDelta')
 
     this.payoutInterval = null
   }
@@ -166,7 +168,7 @@ export class MiningPoolShares {
         fromAccountName: this.accountName,
         receives: transactionReceives,
         fee: transactionReceives.length.toString(),
-        expirationSequenceDelta: 20,
+        expirationSequenceDelta: this.payoutExpirationSequenceDelta,
       })
 
       await this.db.markPayoutSuccess(payoutId, timestamp)


### PR DESCRIPTION
## Summary

we believe that some payout transactions from the pool are expiring. we have a
default expiry of 20 blocks for such transactions. these changes increase the
expiry to 60. with one minute block times this should be roughly equivalent to
half of the duration of the payout interval. adding a config value for this
field will help to change it without a code change if necessary.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
