### PR TITLE
Reject pending requests on disconnect

### DIFF
--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -6,7 +6,7 @@ import { Assert } from '../../assert'
 import { createRootLogger, Logger } from '../../logger'
 import { ErrorUtils, SetTimeoutToken, YupUtils } from '../../utils'
 import { ServerSocketRpc, ServerSocketRpcSchema } from '../adapters/socketAdapter/protocol'
-import { ConnectionRefusedError } from './errors'
+import { ConnectionLostError, ConnectionRefusedError } from './errors'
 import { IronfishRpcClient, RpcClientConnectionInfo } from './rpcClient'
 
 const NODE_IPC_DELIMITER = '\f'
@@ -146,6 +146,11 @@ export class IronfishTcpClient extends IronfishRpcClient {
     this.isConnected = false
     this.client?.off('data', this.onClientData)
     this.client?.off('close', this.onClientClose)
+
+    for (const request of this.pending.values()) {
+      request.reject(new ConnectionLostError(request.type))
+    }
+    this.pending.clear()
 
     this.onClose.emit()
   }


### PR DESCRIPTION
## Summary

The RPCTcpClient does not reject pending requests when you lose
connection to the server. This causes the client to hang indefinitely
after it loses connection to the server.

## Testing Plan
1. Run `yarn start start -b="" --rpc.tcp"`
2. Run `yarn start status -f --rpc.tcp`
3. Close the RPC server / node
4. Watch the client hang forever

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
