### PR TITLE
fix: throws error if tcp client connection fails

### DIFF
--- a/ironfish/src/rpc/clients/tcpClient.test.ts
+++ b/ironfish/src/rpc/clients/tcpClient.test.ts
@@ -13,18 +13,6 @@ describe('IronfishTcpClient', () => {
   const testPort = 1234
   const client: IronfishTcpClient = new IronfishTcpClient(testHost, testPort)
 
-  it('should connect and disconnect', () => {
-    void client.connect()
-    expect(net.connect).toHaveBeenCalledWith(testPort, testHost)
-
-    // client.client will be null since since the mocked net.connect doesn't
-    // make a connection, so replace it with a socket
-    client.client = new net.Socket()
-
-    client.close()
-    expect(client.client?.end).toHaveBeenCalled()
-  })
-
   it('should send messages in the node-ipc encoding', async () => {
     const messageId = 1
     const route = 'foo/bar'


### PR DESCRIPTION
## Summary

the connect method returns a promise, but does not propagate any connection
errors from connectClient, so that promise always resolves even if connection
fails.

these changes throw the error from connectClient if connection is not retried.

## Testing Plan

1. Run `yarn start status -f --rpc.tcp`
2. See no output
3. Start a node
4. Continue to see no output

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
