### PR TITLE
feat: uses defaultTransactionExpirationSequenceDelta instead of pool-specific option

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -29,7 +29,6 @@ export const DEFAULT_POOL_DIFFICULTY = '15000000000'
 export const DEFAULT_POOL_ATTEMPT_PAYOUT_INTERVAL = 15 * 60 // 15 minutes
 export const DEFAULT_POOL_SUCCESSFUL_PAYOUT_INTERVAL = 2 * 60 * 60 // 2 hours
 export const DEFAULT_POOL_RECENT_SHARE_CUTOFF = 2 * 60 * 60 // 2 hours
-export const DEFAULT_POOL_PAYOUT_EXPIRATION_SEQUENCE_DELTA = 60
 
 export type ConfigOptions = {
   bootstrapNodes: string[]
@@ -203,11 +202,6 @@ export type ConfigOptions = {
   poolLarkWebhook: ''
 
   /**
-   * The number of blocks after which an unconfirmed pool payout transaction expires.
-   */
-  poolPayoutExpirationSequenceDelta: number
-
-  /**
    * Whether we want the logs to the console to be in JSON format or not. This can be used to log to
    * more easily process logs on a remote server using a log service like Datadog
    */
@@ -295,7 +289,6 @@ export class Config extends KeyStore<ConfigOptions> {
       poolRecentShareCutoff: DEFAULT_POOL_RECENT_SHARE_CUTOFF,
       poolDiscordWebhook: '',
       poolLarkWebhook: '',
-      poolPayoutExpirationSequenceDelta: DEFAULT_POOL_PAYOUT_EXPIRATION_SEQUENCE_DELTA,
       jsonLogs: false,
     }
   }

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -29,7 +29,6 @@ export class MiningPoolShares {
   private accountName: string
   private balancePercentPayout: bigint
   private balancePercentPayoutFlag: number | undefined
-  private payoutExpirationSequenceDelta: number
 
   private constructor(options: {
     db: PoolDatabase
@@ -55,7 +54,6 @@ export class MiningPoolShares {
     this.accountName = this.config.get('poolAccountName')
     this.balancePercentPayout = BigInt(this.config.get('poolBalancePercentPayout'))
     this.balancePercentPayoutFlag = options.balancePercentPayoutFlag
-    this.payoutExpirationSequenceDelta = this.config.get('poolPayoutExpirationSequenceDelta')
 
     this.payoutInterval = null
   }
@@ -169,7 +167,6 @@ export class MiningPoolShares {
         fromAccountName: this.accountName,
         receives: transactionReceives,
         fee: transactionReceives.length.toString(),
-        expirationSequenceDelta: this.payoutExpirationSequenceDelta,
       })
 
       await this.db.markPayoutSuccess(payoutId, timestamp, transaction.content.hash)


### PR DESCRIPTION
## Summary

Revert "feat: adds a config variable for pool payout expiration, sets default (#1587)"

This reverts commit c96f138de90e8311e96a28357d1ae5b30bf5c6f6.

- removes hardcoded sequence delta of 20 for payout transactions

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
