### PR TITLE
feat(ironfish): Batch jobs to fetch unspent notes

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -690,14 +690,14 @@ export class Accounts {
           jobs = []
         }
       }
+    }
 
-      if (jobs.length) {
-        const responses = await Promise.all(jobs)
+    if (jobs.length) {
+      const responses = await Promise.all(jobs)
 
-        for (const { blockHash, notes } of responses) {
-          for (const note of notes) {
-            yield { blockHash, note }
-          }
+      for (const { blockHash, notes } of responses) {
+        for (const note of notes) {
+          yield { blockHash, note }
         }
       }
     }

--- a/ironfish/src/workerPool/tasks/getUnspentNotes.ts
+++ b/ironfish/src/workerPool/tasks/getUnspentNotes.ts
@@ -6,7 +6,7 @@ import bufio from 'bufio'
 import { WorkerMessage, WorkerMessageType } from './workerMessage'
 import { WorkerTask } from './workerTask'
 
-interface Note {
+export interface UnspentNote {
   account: string
   hash: string
   note: Buffer
@@ -65,9 +65,9 @@ export class GetUnspentNotesRequest extends WorkerMessage {
 }
 
 export class GetUnspentNotesResponse extends WorkerMessage {
-  readonly notes: Note[]
+  readonly notes: UnspentNote[]
 
-  constructor(notes: Note[], jobId: number) {
+  constructor(notes: UnspentNote[], jobId: number) {
     super(WorkerMessageType.GetUnspentNotes, jobId)
     this.notes = notes
   }


### PR DESCRIPTION
## Summary

This code change is a follow-up to this [PR](https://github.com/iron-fish/ironfish/pull/1518). The changes are effectively the same, but includes a batch size to reduce starvation within the worker pool.

Running this locally seems to give around a 5-6x speedup.

## Testing Plan

Run the node (`accounts:balance` and `deposit`).

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
