### PR TITLE
CLI: `chain:forks` now shows graffiti, proper spacing for some columns

### DIFF
--- a/ironfish-cli/src/commands/chain/forks.ts
+++ b/ironfish-cli/src/commands/chain/forks.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { PromiseUtils, TARGET_BLOCK_TIME_IN_SECONDS } from '@ironfish/sdk'
+import { GraffitiUtils, PromiseUtils, TARGET_BLOCK_TIME_IN_SECONDS } from '@ironfish/sdk'
 import { RpcBlock } from '@ironfish/sdk'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
@@ -75,10 +75,14 @@ export default class ForksCommand extends IronfishCommand {
           continue
         }
 
-        const renderedAge = (age / 1000).toFixed(0).padStart(2, ' ')
+        const renderedAge = (age / 1000).toFixed(0).padStart(3)
         const renderdDiff = (highest - block.sequence).toString().padStart(6)
+        const renderedMined = mined.toString().padStart(3)
+        const renderedGraffiti = GraffitiUtils.toHuman(Buffer.from(block.graffiti, 'hex'))
 
-        list.pushLine(`${block.hash} | ${renderdDiff} | ${renderedAge}s | ${mined}`)
+        list.pushLine(
+          `${block.hash} | ${renderdDiff} | ${renderedAge}s | ${renderedMined} | ${renderedGraffiti}`,
+        )
         count++
       }
 


### PR DESCRIPTION
## Summary

Just some minor tweaks since I've been looking at this screen a lot lately. Padding some columns, added graffiti. Graffiti isn't terribly useful, but could be used if we find a pool mining on a fork, we could potentially reach out and debug, notify, etc. Not all of these appear to be currently-mined forks, some seem to be blocks being gossiped around from a while ago.

![image](https://user-images.githubusercontent.com/97762857/172912002-4ac12968-896e-4e6a-95f6-9b26d01e3740.png)

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
