### PR TITLE
Add a round robin queue to the worker pool

### DIFF
--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -13,6 +13,7 @@ import { Transaction } from '../primitives/transaction'
 import { Metric } from '../telemetry/interfaces/metric'
 import { WorkerMessageStats } from './interfaces/workerMessageStats'
 import { Job } from './job'
+import { RoundRobinQueue } from './roundrobinqueue'
 import { BoxMessageRequest, BoxMessageResponse } from './tasks/boxMessage'
 import { CreateMinersFeeRequest, CreateMinersFeeResponse } from './tasks/createMinersFee'
 import { CreateTransactionRequest, CreateTransactionResponse } from './tasks/createTransaction'
@@ -37,7 +38,7 @@ export class WorkerPool {
   readonly numWorkers: number
   readonly logger: Logger
 
-  queue: Array<Job> = []
+  queue = new RoundRobinQueue()
   workers: Array<Worker> = []
   started = false
   completed = 0
@@ -117,9 +118,11 @@ export class WorkerPool {
     const queue = this.queue
 
     this.workers = []
-    this.queue = []
 
     queue.forEach((j) => j.abort())
+
+    queue.clearAll()
+
     await Promise.all(workers.map((w) => w.stop()))
   }
 
@@ -286,14 +289,14 @@ export class WorkerPool {
 
     // If we already have queue, put it at the end of the queue
     if (this.queue.length > 0) {
-      this.queue.push(job)
+      this.queue.enqueue(request.type, job)
       return job
     }
 
     const worker = this.workers.find((w) => w.canTakeJobs)
 
     if (!worker) {
-      this.queue.push(job)
+      this.queue.enqueue(request.type, job)
       return job
     }
 
@@ -311,7 +314,7 @@ export class WorkerPool {
       return
     }
 
-    const job = this.queue.shift()
+    const job = this.queue.nextJob()
     if (!job) {
       return
     }

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -119,9 +119,7 @@ export class WorkerPool {
 
     this.workers = []
 
-    queue.forEach((j) => j.abort())
-
-    queue.clearAll()
+    queue.abortAll()
 
     await Promise.all(workers.map((w) => w.stop()))
   }

--- a/ironfish/src/workerPool/roundrobinqueue.ts
+++ b/ironfish/src/workerPool/roundrobinqueue.ts
@@ -5,15 +5,13 @@
 import { Job } from './job'
 import { WorkerMessageType } from './tasks/workerMessage'
 
-// Simple queue that will iterate over each type of job sequentially so that each job type
-// will be guaranteed not to be backed up by one type queueing many jobs. This does not
-// solve the issue of long-running jobs, however. Luckily, this is not something we
-// have had to worry about yet.
 export class RoundRobinQueue {
   private queueMap: Map<WorkerMessageType, Array<Job>>
   private lastMapIndex = 0
 
-  // Returns the total length of all queues
+  /**
+   * Returns the total length of all queues.
+   */
   get length(): number {
     let length = 0
 
@@ -24,7 +22,12 @@ export class RoundRobinQueue {
     return length
   }
 
-  // Instantiates the queue with a map of each key with an empty array value
+  /**
+   * Simple queue that will iterate over each type of job sequentially so that each job type
+   * will be guaranteed not to be backed up by one type queueing many jobs. This does not
+   * solve the issue of long-running jobs, however. Luckily, this is not something we
+   * have had to worry about yet.
+   */
   constructor() {
     this.queueMap = new Map()
 
@@ -39,16 +42,9 @@ export class RoundRobinQueue {
     }
   }
 
-  // Executes a function with every job across all queues
-  forEach(fn: (j: Job) => void): void {
-    for (const queue of this.queueMap.values()) {
-      for (const job of queue) {
-        fn(job)
-      }
-    }
-  }
-
-  // Add a job to that type's queue
+  /**
+   * Add a job to that type's queue
+   */
   enqueue(type: WorkerMessageType, job: Job): void {
     const typeQueue = this.queueMap.get(type)
 
@@ -59,8 +55,10 @@ export class RoundRobinQueue {
     typeQueue.push(job)
   }
 
-  // Get the next job across all queues. Will iterate over each type
-  // starting from the type after the last executed job's type.
+  /**
+   * Get the next job across all queues. Will iterate over each type
+   * starting from the type after the last executed job's type.
+   */
   nextJob(): Job | undefined {
     // Increment the key index, wrapping around when reaching the end.
     const nextIndex = (this.lastMapIndex + 1) % this.queueMap.size

--- a/ironfish/src/workerPool/roundrobinqueue.ts
+++ b/ironfish/src/workerPool/roundrobinqueue.ts
@@ -49,7 +49,7 @@ export class RoundRobinQueue {
     const typeQueue = this.queueMap.get(type)
 
     if (!typeQueue) {
-      return
+      throw new Error(`Unknown job type given when trying to queue job: ${type}`)
     }
 
     typeQueue.push(job)

--- a/ironfish/src/workerPool/roundrobinqueue.ts
+++ b/ironfish/src/workerPool/roundrobinqueue.ts
@@ -87,9 +87,16 @@ export class RoundRobinQueue {
     }
   }
 
-  clearAll(): void {
-    for (const key of this.queueMap.keys()) {
-      this.queueMap.set(key, [])
+  /**
+   * Abort all existing jobs that have been queued, and empty the queues.
+   */
+  abortAll(): void {
+    for (const [type, queue] of this.queueMap.entries()) {
+      for (const job of queue) {
+        job.abort()
+      }
+
+      this.queueMap.set(type, [])
     }
   }
 }

--- a/ironfish/src/workerPool/roundrobinqueue.ts
+++ b/ironfish/src/workerPool/roundrobinqueue.ts
@@ -60,17 +60,12 @@ export class RoundRobinQueue {
    * starting from the type after the last executed job's type.
    */
   nextJob(): Job | undefined {
-    // Increment the key index, wrapping around when reaching the end.
-    const nextIndex = (this.lastMapIndex + 1) % this.queueMap.size
-
     const queueEntries = Array.from(this.queueMap.values())
 
-    // Create a shallow array beginning from the next type
-    // after the last executed type, wrapping around to the
-    // last executed type.
-    const nextInLine = queueEntries.slice(nextIndex).concat(queueEntries.slice(0, nextIndex))
+    for (let i = 1; i <= queueEntries.length; i++) {
+      const index = (this.lastMapIndex + i) % queueEntries.length
 
-    for (const [index, queue] of nextInLine.entries()) {
+      const queue = queueEntries[index]
       if (!queue.length) {
         continue
       }

--- a/ironfish/src/workerPool/roundrobinqueue.ts
+++ b/ironfish/src/workerPool/roundrobinqueue.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Job } from './job'
+import { WorkerMessageType } from './tasks/workerMessage'
+
+// Simple queue that will iterate over each type of job sequentially so that each job type
+// will be guaranteed not to be backed up by one type queueing many jobs. This does not
+// solve the issue of long-running jobs, however. Luckily, this is not something we
+// have had to worry about yet.
+export class RoundRobinQueue {
+  private queueMap: Map<WorkerMessageType, Array<Job>>
+  private lastMapIndex = 0
+
+  // Returns the total length of all queues
+  get length(): number {
+    let length = 0
+
+    for (const queue of this.queueMap.values()) {
+      length += queue.length
+    }
+
+    return length
+  }
+
+  // Instantiates the queue with a map of each key with an empty array value
+  constructor() {
+    this.queueMap = new Map()
+
+    // Numerical enums return all keys, then all values as strings when
+    // trying to enumerate them, so we need to grab only the valid numerical values.
+    const enumKeys = Object.keys(WorkerMessageType)
+      .map((v) => Number(v))
+      .filter((v) => !isNaN(v))
+
+    for (const key of enumKeys) {
+      this.queueMap.set(key, [])
+    }
+  }
+
+  // Executes a function with every job across all queues
+  forEach(fn: (j: Job) => void): void {
+    for (const queue of this.queueMap.values()) {
+      for (const job of queue) {
+        fn(job)
+      }
+    }
+  }
+
+  // Add a job to that type's queue
+  enqueue(type: WorkerMessageType, job: Job): void {
+    const typeQueue = this.queueMap.get(type)
+
+    if (!typeQueue) {
+      return
+    }
+
+    typeQueue.push(job)
+  }
+
+  // Get the next job across all queues. Will iterate over each type
+  // starting from the type after the last executed job's type.
+  nextJob(): Job | undefined {
+    // Increment the key index, wrapping around when reaching the end.
+    const nextIndex = (this.lastMapIndex + 1) % this.queueMap.size
+
+    const queueEntries = Array.from(this.queueMap.values())
+
+    // Create a shallow array beginning from the next type
+    // after the last executed type, wrapping around to the
+    // last executed type.
+    const nextInLine = queueEntries.slice(nextIndex).concat(queueEntries.slice(0, nextIndex))
+
+    for (const [index, queue] of nextInLine.entries()) {
+      if (!queue.length) {
+        continue
+      }
+
+      const nextJob = queue.shift()
+      if (!nextJob) {
+        continue
+      }
+
+      this.lastMapIndex = index
+      return nextJob
+    }
+  }
+
+  clearAll(): void {
+    for (const key of this.queueMap.keys()) {
+      this.queueMap.set(key, [])
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Prior to this change, the worker pool could receive a large number of jobs for one job type, which would effectively block other job types from executing until they are finished. Ideally, consumers of a job queue should not have to worry about stalling other job types, so this creates a simple round robin queue, which just iterates over the types each time a job is executed to ensure they are all executed in a somewhat timely fashion.

Closes IRO-2095

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
