### PR TITLE
Increase the max queue default size for the worker pool

### DIFF
--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -83,7 +83,7 @@ export class WorkerPool {
   }) {
     this.numWorkers = options?.numWorkers ?? 1
     this.maxJobs = options?.maxJobs ?? 1
-    this.maxQueue = options?.maxQueue ?? 200
+    this.maxQueue = options?.maxQueue ?? 500
     this.change = options?.metrics?.addMeter() ?? null
     this.speed = options?.metrics?.addMeter() ?? null
     this.logger = options?.logger ?? createRootLogger()


### PR DESCRIPTION
## Summary

The original value of 200 is not ideal anymore, as we have code that can kick off 300 jobs at a time, which would cause other jobs to be skipped. One example of this is when a block comes in, we kick off a `VerifyTransaction` job for every transaction in the block, which currently can be 301. If a gossiped transaction comes in at the same time, we are likely to not gossip that transaction when checking if the queue is saturated, even though it will no longer be momentarily. With a value of 500, we can expect a block to come in, with some leeway for other jobs before we count it as saturated.

This is a band-aid fix, ideally we can come up with a better way to consider a queue maxed/saturated. Perhaps based on the number of jobs/second that the pool has done within the last minute, so this value could instead of based on expected number of seconds to process the backlog

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
