### PR TITLE
fix: restore enableNativeRpcTcpAdapter option, add option for client

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -46,6 +46,13 @@ export type ConfigOptions = {
   getFundsApi: string
   ipcPath: string
   /**
+   * As part of IRO-1759 we are removing 'node-ipc' for RPC. This is
+   * essentially a feature flag for enabling use of the native TCP adapter
+   * without using 'node-ipc'
+   */
+  enableNativeRpcTcpAdapter: boolean
+  enableNativeRpcTcpClient: boolean
+  /**
    * Should the mining director mine, even if we are not synced?
    * Only useful if no miner has been on the network in a long time
    * otherwise you should not turn this on or you'll create useless
@@ -247,6 +254,8 @@ export class Config extends KeyStore<ConfigOptions> {
       enableRpc: true,
       enableRpcIpc: DEFAULT_USE_RPC_IPC,
       enableRpcTcp: DEFAULT_USE_RPC_TCP,
+      enableNativeRpcTcpAdapter: false,
+      enableNativeRpcTcpClient: false,
       enableRpcTls: DEFAULT_USE_RPC_TLS,
       enableSyncing: true,
       enableTelemetry: false,

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -135,7 +135,7 @@ export class IronfishSdk {
     }
 
     let client: IronfishRpcClient
-    if (config.get('enableRpcTcp')) {
+    if (config.get('enableRpcTcp') && config.get('enableNativeRpcTcpClient')) {
       if (config.get('enableRpcTls')) {
         client = new IronfishSecureTcpClient(
           config.get('rpcTcpHost'),
@@ -151,10 +151,16 @@ export class IronfishSdk {
       }
     } else {
       client = new IronfishIpcClient(
-        {
-          mode: 'ipc',
-          socketPath: config.get('ipcPath'),
-        },
+        config.get('enableRpcTcp')
+          ? {
+              mode: 'tcp',
+              host: config.get('rpcTcpHost'),
+              port: config.get('rpcTcpPort'),
+            }
+          : {
+              mode: 'ipc',
+              socketPath: config.get('ipcPath'),
+            },
         logger,
         config.get('rpcRetryConnect'),
       )
@@ -243,25 +249,39 @@ export class IronfishSdk {
         namespaces.push(ApiNamespace.account, ApiNamespace.config)
       }
 
-      if (this.config.get('enableRpcTls')) {
-        await node.rpc.mount(
-          new TlsAdapter(
-            this.config.get('rpcTcpHost'),
-            this.config.get('rpcTcpPort'),
-            this.fileSystem,
-            this.config.get('tlsKeyPath'),
-            this.config.get('tlsCertPath'),
-            this.logger,
-            namespaces,
-          ),
-        )
+      if (this.config.get('enableNativeRpcTcpAdapter')) {
+        if (this.config.get('enableRpcTls')) {
+          await node.rpc.mount(
+            new TlsAdapter(
+              this.config.get('rpcTcpHost'),
+              this.config.get('rpcTcpPort'),
+              this.fileSystem,
+              this.config.get('tlsKeyPath'),
+              this.config.get('tlsCertPath'),
+              this.logger,
+              namespaces,
+            ),
+          )
+        } else {
+          await node.rpc.mount(
+            new TcpAdapter(
+              this.config.get('rpcTcpHost'),
+              this.config.get('rpcTcpPort'),
+              this.logger,
+              namespaces,
+            ),
+          )
+        }
       } else {
         await node.rpc.mount(
-          new TcpAdapter(
-            this.config.get('rpcTcpHost'),
-            this.config.get('rpcTcpPort'),
-            this.logger,
+          new IpcAdapter(
             namespaces,
+            {
+              mode: 'tcp',
+              host: this.config.get('rpcTcpHost'),
+              port: this.config.get('rpcTcpPort'),
+            },
+            this.logger,
           ),
         )
       }


### PR DESCRIPTION
## Summary

we've recently made several changes in the rpc layer:
- native TCP adapter
- native TCP client
- TLS adapter/client

it may be useful to be able to test these features separately. this commit
restores an option for enabling the native TCP adapter and introduces an option
for enabling the native TCP client so that we may enable and test the adapter
and client separately.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
