### PR TITLE
feat: adds message buffering to rpc tcp sockets

### DIFF
--- a/ironfish/src/rpc/adapters/socketAdapter/protocol.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/protocol.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 
+export const MESSAGE_DELIMITER = '\f'
+
 export type ClientSocketRpc = {
   type: 'message'
   data: SocketRpcRequest

--- a/ironfish/src/rpc/clients/tcpClient.test.ts
+++ b/ironfish/src/rpc/clients/tcpClient.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import net from 'net'
 import { YupUtils } from '../../utils'
-import { ClientSocketRpcSchema } from '../adapters/socketAdapter/protocol'
+import { ClientSocketRpcSchema, MESSAGE_DELIMITER } from '../adapters/socketAdapter/protocol'
 import { IronfishTcpClient } from './tcpClient'
 
 jest.mock('net')
@@ -24,7 +24,7 @@ describe('IronfishTcpClient', () => {
           mid: messageId,
           type: route,
         },
-      }) + '\f'
+      }) + MESSAGE_DELIMITER
 
     const result = await YupUtils.tryValidate(ClientSocketRpcSchema, expectedMessage.trim())
     expect(result.error).toBe(null)

--- a/ironfish/src/rpc/messageBuffer.test.ts
+++ b/ironfish/src/rpc/messageBuffer.test.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { MessageBuffer } from './messageBuffer'
+
+describe('MesssageBuffer', () => {
+  const delimiter = '\n'
+  const firstMessage = 'foo'
+  const secondMessage = 'bar'
+  let messageBuffer: MessageBuffer
+
+  beforeEach(() => {
+    messageBuffer = new MessageBuffer(delimiter)
+  })
+
+  it('should read message strings from buffer', () => {
+    const buffer = Buffer.from(firstMessage + delimiter, 'utf-8')
+    messageBuffer.write(buffer)
+    const messages = messageBuffer.readMessages()
+    expect(messages).toEqual([firstMessage])
+  })
+
+  it('should split messages by delimiter, in order', () => {
+    const expectedMessages = [firstMessage, secondMessage]
+    const buffer = Buffer.from(expectedMessages.join(delimiter) + delimiter, 'utf-8')
+    messageBuffer.write(buffer)
+    const messages = messageBuffer.readMessages()
+    expect(messages).toEqual(expectedMessages)
+  })
+
+  it('should hold messages in buffer until delimiter is read', () => {
+    const buffer = Buffer.from(firstMessage, 'utf-8')
+    messageBuffer.write(buffer)
+    let messages = messageBuffer.readMessages()
+    expect(messages).toEqual([])
+
+    messageBuffer.write(Buffer.from(delimiter, 'utf-8'))
+    messages = messageBuffer.readMessages()
+    expect(messages).toEqual([firstMessage])
+  })
+
+  it('should consume buffered messages on read', () => {
+    const buffer = Buffer.from(firstMessage + delimiter, 'utf-8')
+    messageBuffer.write(buffer)
+    let messages = messageBuffer.readMessages()
+    expect(messages).toEqual([firstMessage])
+
+    messages = messageBuffer.readMessages()
+    expect(messages).toEqual([])
+  })
+
+  it('should clear messages on clear', () => {
+    const buffer = Buffer.from(firstMessage + delimiter, 'utf-8')
+    messageBuffer.write(buffer)
+    messageBuffer.clear()
+    const messages = messageBuffer.readMessages()
+    expect(messages).toEqual([])
+  })
+})

--- a/ironfish/src/rpc/messageBuffer.ts
+++ b/ironfish/src/rpc/messageBuffer.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { MESSAGE_DELIMITER } from './adapters/socketAdapter/protocol'
+
+export class MessageBuffer {
+  private readonly delimiter: string
+  private buffer: string
+
+  constructor(delimiter = MESSAGE_DELIMITER) {
+    this.delimiter = delimiter
+    this.buffer = ''
+  }
+
+  write(data: Buffer): void {
+    this.buffer += data.toString('utf-8')
+  }
+
+  clear(): void {
+    this.buffer = ''
+  }
+
+  readMessages(): string[] {
+    const lastDelimiterIndex = this.buffer.lastIndexOf(this.delimiter)
+
+    // buffer contains no full messages
+    if (lastDelimiterIndex === -1) {
+      return []
+    }
+
+    const messages = this.buffer.substring(0, lastDelimiterIndex).trim().split(this.delimiter)
+    this.buffer = this.buffer.substring(lastDelimiterIndex + 1)
+    return messages
+  }
+}


### PR DESCRIPTION
## Summary
a tcp socket is modeled as a stream of bytes. we use tcp sockets to send and
receive json-formatted messages, but there is no guarantee that a tcp segment
will contain a full message or messages. it's possible, especially with larger
messages, that we read data from the socket in the middle of a message.
attempting to parse such partial messages results in json parsing errors.

- implements a MessageBuffer class to encapsulate the logic required
for buffering partial messages read from a socket

- adds a MessageBuffer to TcpClient
- adds a MessageBuffer to each SocketClient
- updates 'data' event listeners to use MessageBuffers
- adds MESSAGE_DELIMITER to protocol definitions


## Testing Plan
- `yarn test` tests pass
- local testing running node and commands over tcp
- local testing running node and pool

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
