### PR TITLE
Remove rpcRetryConnect from TCP adapters

### DIFF
--- a/ironfish-cli/src/commands/stop.ts
+++ b/ironfish-cli/src/commands/stop.ts
@@ -17,7 +17,7 @@ export default class StopCommand extends IronfishCommand {
   async start(): Promise<void> {
     await this.parse(StopCommand)
 
-    await this.sdk.client.connect({ retryConnect: false }).catch((e) => {
+    await this.sdk.client.connect().catch((e) => {
       if (e instanceof ConnectionError) {
         this.exit(0)
       }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -99,7 +99,6 @@ export type ConfigOptions = {
   rpcTcpHost: string
   rpcTcpPort: number
   rpcTcpSecure: boolean
-  rpcRetryConnect: boolean
   tlsKeyPath: string
   tlsCertPath: string
   /**
@@ -266,7 +265,6 @@ export class Config extends KeyStore<ConfigOptions> {
       rpcTcpHost: 'localhost',
       rpcTcpPort: 8020,
       rpcTcpSecure: false,
-      rpcRetryConnect: false,
       tlsKeyPath: files.resolve(files.join(dataDir, 'certs', 'node-key.pem')),
       tlsCertPath: files.resolve(files.join(dataDir, 'certs', 'node-cert.pem')),
       maxPeers: 50,

--- a/ironfish/src/rpc/clients/rpcClient.ts
+++ b/ironfish/src/rpc/clients/rpcClient.ts
@@ -52,7 +52,7 @@ export abstract class IronfishRpcClient extends IronfishClient {
   onClose = new Event<[]>()
 
   async tryConnect(): Promise<boolean> {
-    return this.connect({ retryConnect: false })
+    return this.connect()
       .then(() => true)
       .catch((e: unknown) => {
         if (e instanceof ConnectionError) {

--- a/ironfish/src/rpc/clients/secureTcpClient.ts
+++ b/ironfish/src/rpc/clients/secureTcpClient.ts
@@ -7,7 +7,7 @@ import { ConnectionRefusedError } from './errors'
 import { IronfishTcpClient } from './tcpClient'
 
 export class IronfishSecureTcpClient extends IronfishTcpClient {
-  async connectClient(): Promise<void> {
+  async connect(): Promise<void> {
     return new Promise((resolve, reject): void => {
       const onSecureConnect = () => {
         client.off('secureConnection', onSecureConnect)

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -156,7 +156,6 @@ export class IronfishSdk {
           socketPath: config.get('ipcPath'),
         },
         logger,
-        config.get('rpcRetryConnect'),
       )
     }
 


### PR DESCRIPTION
## Summary

This feature was not working to begin with, and not well supported. I
will remove the rest from the IPC client once we delete the IPC client
and adapter soon.

## Testing Plan
Ran the node and RPC layer

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
