### PR TITLE
feat: adds 'connect' and 'error' listeners to tcp client before connection

### DIFF
--- a/ironfish/src/rpc/clients/secureTcpClient.ts
+++ b/ironfish/src/rpc/clients/secureTcpClient.ts
@@ -2,40 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import tls from 'tls'
-import { ErrorUtils } from '../../utils'
-import { ConnectionRefusedError } from './errors'
+import { Assert } from '../../assert'
 import { IronfishTcpClient } from './tcpClient'
 
 export class IronfishSecureTcpClient extends IronfishTcpClient {
-  async connectClient(): Promise<void> {
-    return new Promise((resolve, reject): void => {
-      const onSecureConnect = () => {
-        client.off('secureConnection', onSecureConnect)
-        client.off('error', onError)
-        this.onConnect()
-        resolve()
-      }
-
-      const onError = (error: unknown) => {
-        client.off('secureConnection', onSecureConnect)
-        client.off('error', onError)
-        if (ErrorUtils.isConnectRefusedError(error)) {
-          reject(new ConnectionRefusedError())
-        } else if (ErrorUtils.isNoEntityError(error)) {
-          reject(new ConnectionRefusedError())
-        } else {
-          reject(error)
-        }
-      }
-
-      const options = {
-        rejectUnauthorized: false,
-      }
-
-      this.logger.debug(`Connecting to ${String(this.host)}:${String(this.port)}`)
-      const client = tls.connect(this.port, this.host, options, onSecureConnect)
-      client.on('error', onError)
-      this.client = client
-    })
+  protected async connectClient(): Promise<void> {
+    const connectPromise = super.connectClient()
+    Assert.isNotNull(this.client)
+    this.client = new tls.TLSSocket(this.client, { rejectUnauthorized: false })
+    return connectPromise
   }
 }

--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -61,14 +61,14 @@ export class IronfishTcpClient extends IronfishRpcClient {
       this.logger.error(`Failed to connect to ${String(this.host)}:${String(this.port)}`)
       throw connectionError
     }
+    this.onConnect()
   }
 
-  async connectClient(): Promise<void> {
+  protected async connectClient(): Promise<void> {
     return new Promise((resolve, reject): void => {
       const onConnect = () => {
         client.off('connect', onConnect)
         client.off('error', onError)
-        this.onConnect()
         resolve()
       }
 
@@ -85,11 +85,16 @@ export class IronfishTcpClient extends IronfishRpcClient {
       }
 
       this.logger.debug(`Connecting to ${String(this.host)}:${String(this.port)}`)
-      const client = net.connect(this.port, this.host)
+      const client = new net.Socket()
+      this.client = client
       client.on('error', onError)
       client.on('connect', onConnect)
-      this.client = client
+      client.connect(this.port, this.host)
     })
+  }
+
+  protected setClient(client: net.Socket): void {
+    this.client = client
   }
 
   close(): void {


### PR DESCRIPTION
## Summary

it's possible that a client could emit a 'connect' or 'error' event before the
listener functions are added to the instance.

- constructs an unconnected socket and adds listeners before beginning
  connection
- overrides 'connectClient' in TLS client implementation to wrap socket as TLS
  socket before returning connection promise
- moves call to 'onConnect' to end of 'connect' method to ensure that 'data' and
  'close' listeners are attached to the correct client instance

## Testing Plan

- started node locally, ran `status`, `status -f`, and ran pool locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
