### PR TITLE
Rename all RPC adapter classes

### DIFF
--- a/ironfish-cli/src/commands/deposit.ts
+++ b/ironfish-cli/src/commands/deposit.ts
@@ -5,11 +5,11 @@
 import {
   Assert,
   displayIronAmountWithCurrency,
-  IronfishClient,
   ironToOre,
   isValidAmount,
   MINIMUM_IRON_AMOUNT,
   oreToIron,
+  RpcClient,
   WebApi,
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
@@ -23,7 +23,7 @@ const IRON_TO_SEND = 0.1
 export default class Bank extends IronfishCommand {
   static description = 'Deposit $IRON for testnet points'
 
-  client: IronfishClient | null = null
+  client: RpcClient | null = null
   api: WebApi | null = new WebApi()
 
   static flags = {

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ConnectionError, IronfishRpcClient, Meter, PromiseUtils, WebApi } from '@ironfish/sdk'
+import { ConnectionError, Meter, PromiseUtils, RpcSocketClient, WebApi } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -77,7 +77,7 @@ export default class Faucet extends IronfishCommand {
     }
   }
 
-  async startSyncing(client: IronfishRpcClient, api: WebApi, speed: Meter): Promise<void> {
+  async startSyncing(client: RpcSocketClient, api: WebApi, speed: Meter): Promise<void> {
     const connected = await client.tryConnect()
 
     if (!connected) {
@@ -106,7 +106,7 @@ export default class Faucet extends IronfishCommand {
   }
 
   async processNextTransaction(
-    client: IronfishRpcClient,
+    client: RpcSocketClient,
     account: string,
     speed: Meter,
     api: WebApi,

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -7,7 +7,7 @@ import { Assert } from '../assert'
 import { Config } from '../fileStores/config'
 import { Logger } from '../logger'
 import { Target } from '../primitives/target'
-import { IronfishRpcClient } from '../rpc/clients'
+import { RpcSocketClient } from '../rpc/clients'
 import { SerializedBlockTemplate } from '../serde/BlockTemplateSerde'
 import { BigIntUtils } from '../utils/bigint'
 import { ErrorUtils } from '../utils/error'
@@ -23,7 +23,7 @@ const RECALCULATE_TARGET_TIMEOUT = 10000
 
 export class MiningPool {
   readonly stratum: StratumServer
-  readonly rpc: IronfishRpcClient
+  readonly rpc: RpcSocketClient
   readonly logger: Logger
   readonly shares: MiningPoolShares
   readonly config: Config
@@ -52,7 +52,7 @@ export class MiningPool {
   recalculateTargetInterval: SetTimeoutToken | null
 
   private constructor(options: {
-    rpc: IronfishRpcClient
+    rpc: RpcSocketClient
     shares: MiningPoolShares
     config: Config
     logger: Logger
@@ -94,7 +94,7 @@ export class MiningPool {
   }
 
   static async init(options: {
-    rpc: IronfishRpcClient
+    rpc: RpcSocketClient
     config: Config
     logger: Logger
     discord?: Discord

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Config } from '../fileStores/config'
 import { Logger } from '../logger'
-import { IronfishRpcClient } from '../rpc/clients/rpcClient'
+import { RpcSocketClient } from '../rpc/clients/socketClient'
 import { ErrorUtils } from '../utils'
 import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
@@ -13,7 +13,7 @@ import { Lark } from './lark'
 import { DatabaseShare, PoolDatabase } from './poolDatabase'
 
 export class MiningPoolShares {
-  readonly rpc: IronfishRpcClient
+  readonly rpc: RpcSocketClient
   readonly config: Config
   readonly logger: Logger
   readonly discord: Discord | null
@@ -32,7 +32,7 @@ export class MiningPoolShares {
 
   private constructor(options: {
     db: PoolDatabase
-    rpc: IronfishRpcClient
+    rpc: RpcSocketClient
     config: Config
     logger: Logger
     discord?: Discord
@@ -59,7 +59,7 @@ export class MiningPoolShares {
   }
 
   static async init(options: {
-    rpc: IronfishRpcClient
+    rpc: RpcSocketClient
     config: Config
     logger: Logger
     discord?: Discord

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -7,7 +7,7 @@ import { Assert } from '../assert'
 import { Logger } from '../logger'
 import { Meter } from '../metrics/meter'
 import { Target } from '../primitives/target'
-import { IronfishRpcClient } from '../rpc/clients/rpcClient'
+import { RpcSocketClient } from '../rpc/clients/socketClient'
 import { SerializedBlockTemplate } from '../serde/BlockTemplateSerde'
 import { BigIntUtils } from '../utils/bigint'
 import { ErrorUtils } from '../utils/error'
@@ -22,7 +22,7 @@ export class MiningSoloMiner {
   readonly hashRate: Meter
   readonly threadPool: ThreadPoolHandler
   readonly logger: Logger
-  readonly rpc: IronfishRpcClient
+  readonly rpc: RpcSocketClient
 
   private started: boolean
   private stopPromise: Promise<void> | null
@@ -48,7 +48,7 @@ export class MiningSoloMiner {
     batchSize: number
     logger: Logger
     graffiti: Buffer
-    rpc: IronfishRpcClient
+    rpc: RpcSocketClient
   }) {
     this.rpc = options.rpc
     this.logger = options.logger

--- a/ironfish/src/rpc/adapters/adapter.ts
+++ b/ironfish/src/rpc/adapters/adapter.ts
@@ -8,7 +8,7 @@ import { RpcServer } from '../server'
  * An adapter represents a network transport that accepts incoming requests
  * and routes them into the router.
  */
-export interface IAdapter {
+export interface IRpcAdapter {
   /**
    * Called when the adapter has been added to an RpcServer.
    * This lets you get access to both the RpcServer, and the

--- a/ironfish/src/rpc/adapters/ipcAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.test.ts
@@ -6,15 +6,15 @@
 import os from 'os'
 import * as yup from 'yup'
 import { IronfishSdk } from '../../sdk'
-import { IronfishRpcClient, RequestError } from '../clients'
+import { RequestError, RpcSocketClient } from '../clients'
 import { ALL_API_NAMESPACES } from '../routes'
 import { ERROR_CODES, ValidationError } from './errors'
-import { IpcAdapter } from './ipcAdapter'
+import { RpcIpcAdapter } from './ipcAdapter'
 
 describe('IpcAdapter', () => {
-  let ipc: IpcAdapter
+  let ipc: RpcIpcAdapter
   let sdk: IronfishSdk
-  let client: IronfishRpcClient
+  let client: RpcSocketClient
 
   beforeEach(async () => {
     const dataDir = os.tmpdir()
@@ -24,7 +24,7 @@ describe('IpcAdapter', () => {
     sdk.config.setOverride('enableRpcIpc', false)
 
     const node = await sdk.node()
-    ipc = new IpcAdapter(ALL_API_NAMESPACES, {
+    ipc = new RpcIpcAdapter(ALL_API_NAMESPACES, {
       mode: 'ipc',
       socketPath: sdk.config.get('ipcPath'),
     })

--- a/ironfish/src/rpc/adapters/ipcAdapter.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.ts
@@ -11,7 +11,7 @@ import { YupUtils } from '../../utils/yup'
 import { Request } from '../request'
 import { ApiNamespace, Router } from '../routes'
 import { RpcServer } from '../server'
-import { IAdapter } from './adapter'
+import { IRpcAdapter } from './adapter'
 import { ERROR_CODES, ResponseError } from './errors'
 
 export type IpcRequest = {
@@ -79,7 +79,7 @@ export type IpcAdapterConnectionInfo =
       port: number
     }
 
-export class IpcAdapter implements IAdapter {
+export class RpcIpcAdapter implements IRpcAdapter {
   router: Router | null = null
   ipc: IPC | null = null
   server: IpcServer | null = null

--- a/ironfish/src/rpc/adapters/memoryAdapter.ts
+++ b/ironfish/src/rpc/adapters/memoryAdapter.ts
@@ -16,7 +16,7 @@ import { ResponseError } from './errors'
  *
  * This is useful any time you want to make requests without hitting an IO layer.
  */
-export class MemoryAdapter {
+export class RpcMemoryAdapter {
   /**
    * Makes a request against the routing layer with a given route, and data and returns
    * a response for you to accumulate the streaming results, or wait for a response

--- a/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
@@ -11,7 +11,7 @@ import { MessageBuffer } from '../../messageBuffer'
 import { Request } from '../../request'
 import { ApiNamespace, Router } from '../../routes'
 import { RpcServer } from '../../server'
-import { IAdapter } from '../adapter'
+import { IRpcAdapter } from '../adapter'
 import { ERROR_CODES, ResponseError } from '../errors'
 import {
   ClientSocketRpcSchema,
@@ -27,7 +27,7 @@ type SocketClient = {
   messageBuffer: MessageBuffer
 }
 
-export abstract class SocketAdapter implements IAdapter {
+export abstract class RpcSocketAdapter implements IRpcAdapter {
   logger: Logger
   host: string
   port: number

--- a/ironfish/src/rpc/adapters/tcpAdapter.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.ts
@@ -4,9 +4,9 @@
 import net from 'net'
 import { createRootLogger, Logger } from '../../logger'
 import { ApiNamespace } from '../routes'
-import { SocketAdapter } from './socketAdapter/socketAdapter'
+import { RpcSocketAdapter } from './socketAdapter/socketAdapter'
 
-export class TcpAdapter extends SocketAdapter {
+export class RpcTcpAdapter extends RpcSocketAdapter {
   constructor(
     host: string,
     port: number,

--- a/ironfish/src/rpc/adapters/tlsAdapter.ts
+++ b/ironfish/src/rpc/adapters/tlsAdapter.ts
@@ -7,9 +7,9 @@ import tls from 'tls'
 import { FileSystem } from '../../fileSystems'
 import { createRootLogger, Logger } from '../../logger'
 import { ApiNamespace } from '../routes'
-import { SocketAdapter } from './socketAdapter/socketAdapter'
+import { RpcSocketAdapter } from './socketAdapter/socketAdapter'
 
-export class TlsAdapter extends SocketAdapter {
+export class RpcTlsAdapter extends RpcSocketAdapter {
   readonly fileSystem: FileSystem
   readonly nodeKeyPath: string
   readonly nodeCertPath: string

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -73,7 +73,7 @@ import {
   GetPeerMessagesResponse,
 } from '../routes/peers/getPeerMessages'
 
-export abstract class IronfishClient {
+export abstract class RpcClient {
   readonly logger: Logger
 
   constructor(logger: Logger) {

--- a/ironfish/src/rpc/clients/index.ts
+++ b/ironfish/src/rpc/clients/index.ts
@@ -4,4 +4,4 @@
 export * from './errors'
 export * from './client'
 export * from './memoryClient'
-export * from './rpcClient'
+export * from './socketClient'

--- a/ironfish/src/rpc/clients/ipcClient.ts
+++ b/ironfish/src/rpc/clients/ipcClient.ts
@@ -8,11 +8,11 @@ import { createRootLogger, Logger } from '../../logger'
 import { ErrorUtils } from '../../utils'
 import { IpcRequest } from '../adapters'
 import { ConnectionLostError, ConnectionRefusedError } from './errors'
-import { IronfishRpcClient, RpcClientConnectionInfo } from './rpcClient'
+import { RpcClientConnectionInfo, RpcSocketClient } from './socketClient'
 
 const CONNECT_RETRY_MS = 2000
 
-export class IronfishIpcClient extends IronfishRpcClient {
+export class RpcIpcClient extends RpcSocketClient {
   ipc: IPC | null = null
   ipcPath: string | null = null
   client: IpcClient | null = null

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -3,11 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
-import { MemoryAdapter, MemoryResponse } from '../adapters'
+import { MemoryResponse, RpcMemoryAdapter } from '../adapters'
 import { ALL_API_NAMESPACES, Router } from '../routes'
-import { IronfishClient } from './client'
+import { RpcClient } from './client'
 
-export class IronfishMemoryClient extends IronfishClient {
+export class RpcMemoryClient extends RpcClient {
   node: IronfishNode
   router: Router
 
@@ -29,6 +29,6 @@ export class IronfishMemoryClient extends IronfishClient {
       throw new Error(`MemoryAdapter does not support timeoutMs`)
     }
 
-    return MemoryAdapter.requestStream<TEnd, TStream>(this.router, route, data)
+    return RpcMemoryAdapter.requestStream<TEnd, TStream>(this.router, route, data)
   }
 }

--- a/ironfish/src/rpc/clients/socketClient.ts
+++ b/ironfish/src/rpc/clients/socketClient.ts
@@ -9,7 +9,7 @@ import { PromiseUtils, SetTimeoutToken, YupUtils } from '../../utils'
 import { IpcErrorSchema, IpcResponseSchema, IpcStreamSchema } from '../adapters'
 import { isResponseError, Response } from '../response'
 import { Stream } from '../stream'
-import { IronfishClient } from './client'
+import { RpcClient } from './client'
 import { ConnectionError, RequestError, RequestTimeoutError } from './errors'
 
 const REQUEST_TIMEOUT_MS = null
@@ -25,7 +25,7 @@ export type RpcClientConnectionInfo =
       port: number
     }
 
-export abstract class IronfishRpcClient extends IronfishClient {
+export abstract class RpcSocketClient extends RpcClient {
   abstract client: IpcClient | net.Socket | null
   abstract isConnected: boolean
   abstract connection: Partial<RpcClientConnectionInfo>

--- a/ironfish/src/rpc/clients/tcpClient.test.ts
+++ b/ironfish/src/rpc/clients/tcpClient.test.ts
@@ -4,14 +4,14 @@
 import net from 'net'
 import { YupUtils } from '../../utils'
 import { ClientSocketRpcSchema, MESSAGE_DELIMITER } from '../adapters/socketAdapter/protocol'
-import { IronfishTcpClient } from './tcpClient'
+import { RpcTcpClient } from './tcpClient'
 
 jest.mock('net')
 
 describe('IronfishTcpClient', () => {
   const testHost = 'testhost'
   const testPort = 1234
-  const client: IronfishTcpClient = new IronfishTcpClient(testHost, testPort)
+  const client: RpcTcpClient = new RpcTcpClient(testHost, testPort)
 
   it('should send messages in the node-ipc encoding', async () => {
     const messageId = 1

--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -12,9 +12,9 @@ import {
 } from '../adapters/socketAdapter/protocol'
 import { MessageBuffer } from '../messageBuffer'
 import { ConnectionLostError, ConnectionRefusedError } from './errors'
-import { IronfishRpcClient, RpcClientConnectionInfo } from './rpcClient'
+import { RpcClientConnectionInfo, RpcSocketClient } from './socketClient'
 
-export class IronfishTcpClient extends IronfishRpcClient {
+export class RpcTcpClient extends RpcSocketClient {
   client: net.Socket | null = null
   protected readonly host: string
   protected readonly port: number

--- a/ironfish/src/rpc/clients/tlsClient.ts
+++ b/ironfish/src/rpc/clients/tlsClient.ts
@@ -4,9 +4,9 @@
 import tls from 'tls'
 import { ErrorUtils } from '../../utils'
 import { ConnectionRefusedError } from './errors'
-import { IronfishTcpClient } from './tcpClient'
+import { RpcTcpClient } from './tcpClient'
 
-export class IronfishSecureTcpClient extends IronfishTcpClient {
+export class RpcTlsClient extends RpcTcpClient {
   async connect(): Promise<void> {
     return new Promise((resolve, reject): void => {
       const onSecureConnect = () => {

--- a/ironfish/src/rpc/server.ts
+++ b/ironfish/src/rpc/server.ts
@@ -3,13 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { IronfishNode } from '../node'
-import { IAdapter } from './adapters'
+import { IRpcAdapter } from './adapters'
 import { ApiNamespace, Router, router } from './routes'
 
 export class RpcServer {
   readonly node: IronfishNode
 
-  private readonly adapters: IAdapter[] = []
+  private readonly adapters: IRpcAdapter[] = []
   private readonly router: Router
   private _isRunning = false
   private _startPromise: Promise<unknown> | null = null
@@ -57,7 +57,7 @@ export class RpcServer {
   }
 
   /** Adds an adapter to the RPC server and starts it if the server has already been started */
-  async mount(adapter: IAdapter): Promise<void> {
+  async mount(adapter: IRpcAdapter): Promise<void> {
     this.adapters.push(adapter)
     await adapter.attach(this)
 

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -7,7 +7,7 @@ import { Config, DEFAULT_DATA_DIR } from './fileStores'
 import { NodeFileProvider } from './fileSystems'
 import { IronfishNode } from './node'
 import { Platform } from './platform'
-import { IronfishMemoryClient, IronfishRpcClient } from './rpc'
+import { RpcClient, RpcMemoryClient } from './rpc'
 import { IronfishSdk } from './sdk'
 
 describe('IronfishSdk', () => {
@@ -25,7 +25,7 @@ describe('IronfishSdk', () => {
       })
 
       expect(sdk.config).toBeInstanceOf(Config)
-      expect(sdk.client).toBeInstanceOf(IronfishRpcClient)
+      expect(sdk.client).toBeInstanceOf(RpcClient)
       expect(sdk.fileSystem).toBe(fileSystem)
 
       expect(sdk.config.storage.dataDir).toBe(dataDir)
@@ -88,8 +88,8 @@ describe('IronfishSdk', () => {
         const client = await sdk.connectRpc(true)
 
         expect(openDb).toHaveBeenCalledTimes(1)
-        expect(client).toBeInstanceOf(IronfishMemoryClient)
-        expect((client as IronfishMemoryClient).node).toBe(node)
+        expect(client).toBeInstanceOf(RpcMemoryClient)
+        expect((client as RpcMemoryClient).node).toBe(node)
       })
     })
 

--- a/ironfish/src/testUtilities/routeTest.ts
+++ b/ironfish/src/testUtilities/routeTest.ts
@@ -7,8 +7,8 @@ import { Verifier } from '../consensus'
 import { createRootLogger } from '../logger'
 import { PeerNetwork } from '../network/peerNetwork'
 import { IronfishNode } from '../node'
-import { MemoryAdapter } from '../rpc/adapters'
-import { IronfishMemoryClient } from '../rpc/clients'
+import { RpcMemoryAdapter } from '../rpc/adapters'
+import { RpcMemoryClient } from '../rpc/clients'
 import { IronfishSdk } from '../sdk'
 import { Syncer } from '../syncer'
 import { WorkerPool } from '../workerPool'
@@ -21,8 +21,8 @@ import { TestStrategy } from './strategy'
  * the RouteTest
  */
 export class RouteTest extends NodeTest {
-  adapter!: MemoryAdapter
-  client!: IronfishMemoryClient
+  adapter!: RpcMemoryAdapter
+  client!: RpcMemoryClient
 
   async createSetup(): Promise<{
     sdk: IronfishSdk
@@ -34,12 +34,12 @@ export class RouteTest extends NodeTest {
     peerNetwork: PeerNetwork
     syncer: Syncer
     workerPool: WorkerPool
-    client: IronfishMemoryClient
+    client: RpcMemoryClient
   }> {
     const setup = await super.createSetup()
 
     const logger = createRootLogger().withTag('memoryclient')
-    const client = new IronfishMemoryClient(logger, setup.node)
+    const client = new RpcMemoryClient(logger, setup.node)
 
     return { ...setup, client }
   }


### PR DESCRIPTION
## Summary

This renames them to be inline with the RPC system, and makes clients
names consistent with adapter names.

```
IronfishClient -> RpcClient
    IronfishRpcClient -> RpcSocketClient
        IronfishIcpClient       -> RcpIpcClient
        IronfishTcpClient       -> RcpTcpClient
        IronfishSecureTcpClient -> RcpTlsClient
        MemoryClient            -> RpcMemoryClient

IAdapter -> IRpcAdapter
    SocketAdapter -> RpcSocketAdapter
        IpcAdapter    -> RpcIpcAdapter
        TcpAdapter    -> RpcTcpAdapter
        TlsAdapter    -> RpcTlsAdapter
        MemoryAdapter -> RpcMemoryAdapter
```

## Testing Plan
Ran the node, and build the project

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
