### PR TITLE
Simplify verify block function

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -703,14 +703,18 @@ describe('Blockchain', () => {
     const { node } = await nodeTest.createSetup()
     const block = await useMinerBlockFixture(node.chain)
 
-    let result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, { verifyPrev: true })
+    let result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, {
+      verifyPrev: true,
+    })
     expect(result).toMatchObject({
       valid: true,
     })
 
     block.header.timestamp = new Date(0)
 
-    result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, { verifyPrev: true })
+    result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, {
+      verifyPrev: true,
+    })
     expect(result).toMatchObject({
       valid: false,
       reason: VerificationResultReason.BLOCK_TOO_OLD,
@@ -751,7 +755,9 @@ describe('Blockchain', () => {
     //Force one byte of the hash to not match the previous hash of the block.
     node.chain.genesis.hash[0] = node.chain.genesis.hash[0] ^ 0xff
 
-    const result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, { verifyPrev: true })
+    const result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, {
+      verifyPrev: true,
+    })
     expect(result).toMatchObject({
       valid: false,
       reason: VerificationResultReason.PREV_HASH_MISMATCH,
@@ -764,7 +770,9 @@ describe('Blockchain', () => {
 
     block.header.minersFee = BigInt(-1)
 
-    const result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, { verifyPrev: true })
+    const result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, {
+      verifyPrev: true,
+    })
     expect(result).toMatchObject({
       valid: false,
       reason: VerificationResultReason.MINERS_FEE_MISMATCH,

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -703,14 +703,14 @@ describe('Blockchain', () => {
     const { node } = await nodeTest.createSetup()
     const block = await useMinerBlockFixture(node.chain)
 
-    let result = await node.chain.verifier.verifyBlockAdd(block, node.chain.genesis)
+    let result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, { verifyPrev: true })
     expect(result).toMatchObject({
       valid: true,
     })
 
     block.header.timestamp = new Date(0)
 
-    result = await node.chain.verifier.verifyBlockAdd(block, node.chain.genesis)
+    result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, { verifyPrev: true })
     expect(result).toMatchObject({
       valid: false,
       reason: VerificationResultReason.BLOCK_TOO_OLD,
@@ -735,7 +735,7 @@ describe('Blockchain', () => {
     const { node } = await nodeTest.createSetup()
     const block = await useMinerBlockFixture(node.chain)
 
-    const result = await node.chain.verifier.verifyBlockAdd(block, null)
+    const result = await node.chain.verifier.verifyBlock(block, null, { verifyPrev: true })
     expect(result).toMatchObject({
       valid: false,
       reason: VerificationResultReason.PREV_HASH_NULL,
@@ -751,7 +751,7 @@ describe('Blockchain', () => {
     //Force one byte of the hash to not match the previous hash of the block.
     node.chain.genesis.hash[0] = node.chain.genesis.hash[0] ^ 0xff
 
-    const result = await node.chain.verifier.verifyBlockAdd(block, node.chain.genesis)
+    const result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, { verifyPrev: true })
     expect(result).toMatchObject({
       valid: false,
       reason: VerificationResultReason.PREV_HASH_MISMATCH,
@@ -764,7 +764,7 @@ describe('Blockchain', () => {
 
     block.header.minersFee = BigInt(-1)
 
-    const result = await node.chain.verifier.verifyBlockAdd(block, node.chain.genesis)
+    const result = await node.chain.verifier.verifyBlock(block, node.chain.genesis, { verifyPrev: true })
     expect(result).toMatchObject({
       valid: false,
       reason: VerificationResultReason.MINERS_FEE_MISMATCH,

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -642,7 +642,7 @@ export class Blockchain {
     prev: BlockHeader | null,
     tx: IDatabaseTransaction,
   ): Promise<void> {
-    const { valid, reason } = await this.verifier.verifyBlockAdd(block, prev)
+    const { valid, reason } = await this.verifier.verifyBlock(block, prev, { verifyPrev: true })
 
     if (!valid) {
       Assert.isNotUndefined(reason)
@@ -692,7 +692,7 @@ export class Blockchain {
       await this.reorganizeChain(prev, tx)
     }
 
-    const { valid, reason } = await this.verifier.verifyBlockAdd(block, prev)
+    const { valid, reason } = await this.verifier.verifyBlock(block, prev, { verifyPrev: true })
     if (!valid) {
       Assert.isNotUndefined(reason)
 
@@ -933,7 +933,9 @@ export class Blockchain {
       if (!previousBlockHash.equals(GENESIS_BLOCK_PREVIOUS)) {
         // since we're creating a block that hasn't been mined yet, don't
         // verify target because it'll always fail target check here
-        const verification = await this.verifier.verifyBlock(block, { verifyTarget: false })
+        const verification = await this.verifier.verifyBlock(block, null, {
+          verifyTarget: false,
+        })
 
         if (!verification.valid) {
           throw new Error(verification.reason)


### PR DESCRIPTION
## Summary
Cleaning up `/concensus/verifier.ts`. Combining `verifyBlock` and `verifyBlockAdd` functions into one. 

## Testing Plan
Run node, and wait for new blocks to verify. 
Run tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
