### PR TITLE
Don't accept clients without a remote address

### DIFF
--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -99,6 +99,11 @@ export class StratumServer {
   }
 
   private onConnection(socket: net.Socket): void {
+    if (!socket.remoteAddress) {
+      socket.destroy()
+      return
+    }
+
     const client = StratumServerClient.accept(socket, this.nextMinerId++)
 
     socket.on('data', (data: Buffer) => {
@@ -109,7 +114,7 @@ export class StratumServer {
 
     socket.on('error', (e) => this.onError(client, e))
 
-    this.logger.debug(`Client ${client.id} connected: ${socket.remoteAddress || 'undefined'}`)
+    this.logger.debug(`Client ${client.id} connected: ${client.remoteAddress}`)
     this.clients.set(client.id, client)
   }
 

--- a/ironfish/src/mining/stratum/stratumServerClient.ts
+++ b/ironfish/src/mining/stratum/stratumServerClient.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import net from 'net'
+import { Assert } from '../../assert'
 
 export class StratumServerClient {
   id: number
@@ -9,6 +10,7 @@ export class StratumServerClient {
   connected: boolean
   subscribed: boolean
   publicAddress: string | null = null
+  remoteAddress: string
   graffiti: Buffer | null = null
   messageBuffer: string
 
@@ -18,6 +20,9 @@ export class StratumServerClient {
     this.connected = true
     this.subscribed = false
     this.messageBuffer = ''
+
+    Assert.isNotUndefined(this.socket.remoteAddress)
+    this.remoteAddress = this.socket.remoteAddress
   }
 
   static accept(socket: net.Socket, id: number): StratumServerClient {


### PR DESCRIPTION
## Summary
It should never be undefined, but this provides us a guarantee

## Testing Plan
Run the pool

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
