### PR TITLE
Updated nodejs

### DIFF
--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.0-bullseye as build
+FROM node:16.15.1-bullseye as build
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 COPY ./ ./
@@ -9,7 +9,7 @@ RUN \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     ./ironfish-cli/scripts/build.sh
 
-FROM node:16.13.0-bullseye-slim
+FROM node:16.15.1-bullseye-slim
 EXPOSE 8020:8020
 EXPOSE 9033:9033
 VOLUME /root/.ironfish


### PR DESCRIPTION
## Summary
Updated node.js to the latest LTS stable version 16.15.1 from 16.13.0.

The new version is 7 version ahead of the previous version. The new version was released on June 1st 2022, and is 7 months and 5 days ahead of the previous version.

## Testing Plan
None needed

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[✓ ] No
```
graffiti: ironfishup