### PR TITLE
feat: adds links to block explorer in webhook messages

### DIFF
--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -71,6 +71,8 @@ export class StartPool extends IronfishCommand {
         new Discord({
           webhook: discordWebhook,
           logger: this.logger,
+          explorerBlocksUrl: this.sdk.config.get('explorerBlocksUrl'),
+          explorerTransactionsUrl: this.sdk.config.get('explorerTransactionsUrl'),
         }),
       )
 
@@ -83,6 +85,8 @@ export class StartPool extends IronfishCommand {
         new Lark({
           webhook: larkWebhook,
           logger: this.logger,
+          explorerBlocksUrl: this.sdk.config.get('explorerBlocksUrl'),
+          explorerTransactionsUrl: this.sdk.config.get('explorerTransactionsUrl'),
         }),
       )
 

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -19,7 +19,8 @@ export const DEFAULT_USE_RPC_TCP = false
 export const DEFAULT_USE_RPC_TLS = true
 export const DEFAULT_MINER_BATCH_SIZE = 25000
 export const DEFAULT_EXPLORER_BLOCKS_URL = 'https://explorer.ironfish.network/blocks/'
-export const DEFAULT_EXPLORER_TRANSACTIONS_URL = 'https://explorer.ironfish.network/transaction/'
+export const DEFAULT_EXPLORER_TRANSACTIONS_URL =
+  'https://explorer.ironfish.network/transaction/'
 
 // Pool defaults
 export const DEFAULT_POOL_NAME = 'Iron Fish Pool'

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -18,6 +18,8 @@ export const DEFAULT_USE_RPC_IPC = true
 export const DEFAULT_USE_RPC_TCP = false
 export const DEFAULT_USE_RPC_TLS = true
 export const DEFAULT_MINER_BATCH_SIZE = 25000
+export const DEFAULT_EXPLORER_BLOCKS_URL = 'https://explorer.ironfish.network/blocks/'
+export const DEFAULT_EXPLORER_TRANSACTIONS_URL = 'https://explorer.ironfish.network/transaction/'
 
 // Pool defaults
 export const DEFAULT_POOL_NAME = 'Iron Fish Pool'
@@ -205,6 +207,16 @@ export type ConfigOptions = {
    * more easily process logs on a remote server using a log service like Datadog
    */
   jsonLogs: boolean
+
+  /**
+   * URL for viewing block information in a block explorer
+   */
+  explorerBlocksUrl: string
+
+  /**
+   * URL for viewing transaction information in a block explorer
+   */
+  explorerTransactionsUrl: string
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -288,6 +300,8 @@ export class Config extends KeyStore<ConfigOptions> {
       poolDiscordWebhook: '',
       poolLarkWebhook: '',
       jsonLogs: false,
+      explorerBlocksUrl: DEFAULT_EXPLORER_BLOCKS_URL,
+      explorerTransactionsUrl: DEFAULT_EXPLORER_TRANSACTIONS_URL,
     }
   }
 }

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -228,14 +228,15 @@ export class MiningPool {
 
       if (result.content.added) {
         const hashRate = await this.estimateHashRate()
+        const hashedHeaderHex = hashedHeader.toString('hex')
 
         this.logger.info(
-          `Block ${hashedHeader.toString(
-            'hex',
-          )} submitted successfully! ${FileUtils.formatHashRate(hashRate)}/s`,
+          `Block ${hashedHeaderHex} submitted successfully! ${FileUtils.formatHashRate(
+            hashRate,
+          )}/s`,
         )
         this.webhooks.map((w) =>
-          w.poolSubmittedBlock(hashedHeader, hashRate, this.stratum.clients.size),
+          w.poolSubmittedBlock(hashedHeaderHex, hashRate, this.stratum.clients.size),
         )
       } else {
         this.logger.info(`Block was rejected: ${result.content.reason}`)

--- a/ironfish/src/mining/webhooks/webhookNotifier.ts
+++ b/ironfish/src/mining/webhooks/webhookNotifier.ts
@@ -83,6 +83,6 @@ export abstract class WebhookNotifier {
       return `\`${hashHex}\``
     }
 
-    return `[${hashHex}](${explorerUrl + hashHex})`
+    return `${explorerUrl + hashHex}`
   }
 }

--- a/ironfish/src/mining/webhooks/webhookNotifier.ts
+++ b/ironfish/src/mining/webhooks/webhookNotifier.ts
@@ -83,7 +83,6 @@ export abstract class WebhookNotifier {
       return `\`${hashHex}\``
     }
 
-    const hashHexUrl = explorerUrl + hashHex
-    return `[${hashHex}](${hashHexUrl})`
+    return `[${hashHex}](${explorerUrl + hashHex})`
   }
 }

--- a/ironfish/src/mining/webhooks/webhookNotifier.ts
+++ b/ironfish/src/mining/webhooks/webhookNotifier.ts
@@ -7,15 +7,22 @@ import { createRootLogger, Logger } from '../../logger'
 import { displayIronAmountWithCurrency, ErrorUtils, oreToIron } from '../../utils'
 import { FileUtils } from '../../utils/file'
 
-const BLOCK_EXPLORER_URL = 'https://explorer.ironfish.network'
-
 export abstract class WebhookNotifier {
   protected readonly webhook: string | null = null
   protected readonly client: AxiosInstance | null = null
   protected readonly logger: Logger
+  protected readonly explorerBlocksUrl: string | null = null
+  protected readonly explorerTransactionsUrl: string | null = null
 
-  constructor(options: { webhook: string | null; logger?: Logger }) {
+  constructor(options: {
+    webhook: string | null
+    logger?: Logger
+    explorerBlocksUrl?: string | null
+    explorerTransactionsUrl?: string | null
+  }) {
     this.logger = options.logger ?? createRootLogger()
+    this.explorerBlocksUrl = options.explorerBlocksUrl ?? null
+    this.explorerTransactionsUrl = options.explorerTransactionsUrl ?? null
 
     if (options.webhook) {
       this.webhook = options.webhook
@@ -34,11 +41,11 @@ export abstract class WebhookNotifier {
   }
 
   poolSubmittedBlock(hashedHeaderHex: string, hashRate: number, clients: number): void {
-    const blockUrl = [BLOCK_EXPLORER_URL, 'blocks', hashedHeaderHex].join('/')
-    const blockLink = `[${hashedHeaderHex}](${blockUrl})`
-
     this.sendText(
-      `Block ${blockLink} submitted successfully! ${FileUtils.formatHashRate(
+      `Block ${this.renderHashHex(
+        hashedHeaderHex,
+        this.explorerBlocksUrl,
+      )} submitted successfully! ${FileUtils.formatHashRate(
         hashRate,
       )}/s with ${clients} miners`,
     )
@@ -52,16 +59,16 @@ export abstract class WebhookNotifier {
   ): void {
     const total = receives.reduce((m, c) => BigInt(c.amount) + m, BigInt(0))
 
-    const transactionUrl = [BLOCK_EXPLORER_URL, 'transaction', transactionHashHex].join('/')
-    const transactionLink = `[${transactionHashHex}](${transactionUrl})`
-
     this.sendText(
       `Successfully created payout of ${totalShareCount} shares to ${
         receives.length
       } users for ${displayIronAmountWithCurrency(
         Number(oreToIron(Number(total.toString()))),
         false,
-      )} in transaction ${transactionLink}. Transaction pending (${payoutId})`,
+      )} in transaction ${this.renderHashHex(
+        transactionHashHex,
+        this.explorerTransactionsUrl,
+      )}. Transaction pending (${payoutId})`,
     )
   }
 
@@ -69,5 +76,14 @@ export abstract class WebhookNotifier {
     this.sendText(
       `Error while sending payout transaction: ${ErrorUtils.renderError(error, true)}`,
     )
+  }
+
+  private renderHashHex(hashHex: string, explorerUrl: string | null): string {
+    if (explorerUrl == null) {
+      return `\`${hashHex}\``
+    }
+
+    const hashHexUrl = explorerUrl + hashHex
+    return `[${hashHex}](${hashHexUrl})`
   }
 }


### PR DESCRIPTION
## Summary
- hyperlinks block header hash hex string and transaction hash hex string to
  block explorer
- changes message in transaction success to indicate transaction created, but
  pending
## Testing Plan
created discord server and webhook, tested messages with local pool
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
