### PR TITLE
Add reconnect timeout to disconnect

### DIFF
--- a/ironfish/src/mining/stratum/stratumClient.ts
+++ b/ironfish/src/mining/stratum/stratumClient.ts
@@ -154,7 +154,7 @@ export class StratumClient {
     this.miner.waitForWork()
 
     this.logger.info('Disconnected from pool unexpectedly. Reconnecting.')
-    void this.startConnecting()
+    this.connectTimeout = setTimeout(() => void this.startConnecting(), 5000)
   }
 
   private onError = (error: unknown): void => {


### PR DESCRIPTION
## Summary

This matches the reconnect delay time we have in our normal connection
process here, https://github.com/iron-fish/ironfish/blob/6dfc736e0f1fbfeeebaeb67962d7c73bc3072626/ironfish/src/mining/stratum/stratumClient.ts#L89

## Testing Plan
Run node and force disconnects

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
