### PR TITLE
Log when syncing does not start from orphan blocks

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -437,11 +437,14 @@ export class Syncer {
       this.logger.info(
         `Peer ${peer.displayName} sent orphan ${HashUtils.renderBlockHeaderHash(
           block.header,
-        )} (${block.header.sequence}), syncing orphan chain.`,
+        )} (${block.header.sequence})`,
       )
 
       if (!this.loader) {
+        this.logger.info(`Syncing orphan chain from ${peer.displayName}`)
         this.startSync(peer)
+      } else {
+        this.logger.info(`Sync already in progress from ${this.loader.displayName}`)
       }
 
       return { added: false, block, reason: VerificationResultReason.ORPHAN }


### PR DESCRIPTION
## Summary

The current logs indicate syncing will start when receiving an orphan block, but in actuality, syncing only starts if there isn't already an ongoing sync. This adds another log to make it clearer whether the sync was initiated or not.

## Testing Plan

Tests should pass.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
[ ] No
```
