### PR TITLE
Update CONTRIBUTORS.md and supporting information

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @iron-fish/code-review
+* @iron-fish/engineering

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -3,7 +3,7 @@ description: File a bug report
 title: "[issue name]"
 labels: ["bug", "triage"]
 assignees:
-  - iron-fish/code-review
+  - iron-fish/engineering
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/GENERAL.yml
+++ b/.github/ISSUE_TEMPLATE/GENERAL.yml
@@ -2,7 +2,7 @@ name: Report a general issue
 description: In need of help or not sure which other template to pick? Use this!
 title: "[issue name]"
 assignees:
-  - iron-fish/code-review
+  - iron-fish/engineering
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/PROPOSAL.yml
+++ b/.github/ISSUE_TEMPLATE/PROPOSAL.yml
@@ -1,0 +1,15 @@
+name: Fish Improvement Proposal
+description: Used to propose an improvement you would like to make
+title: "FIP: "
+labels: ["FIP"]
+assignees:
+  - iron-fish/engineering
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What change do you want to make?
+      placeholder:
+    validations:
+      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Pull requests are the best way to propose a new change to the codebase.
 1. Create a branch from `staging`
 1. Open a pull request against `staging`
 
-Once the PR is created, one of the maintainers will review it and merge it. Add the right labels to your pull request. Reference to any bugs you're fixing with single lines of the form `Fix #123`
+Once the PR is created, one of the maintainers will review it and merge it. Add the right labels to your pull request. Reference any bugs you're fixing with single lines of the form `Fix #123`
 
 **NOTE:** Read [We will close your PR if](we-will-close-your-pr-if), if you are thinking of working on a complex change.
 
@@ -34,13 +34,13 @@ If you don't know what contribution you can work on, here are a few suggestions:
 If you are working on something in one of these categories, we will not accept your PR if you don't open a Fish Improvement Proposal (FIP).
 
  - Upgrading Package Versions
-   - This is a common attack vector by malicious agents. We lock down our packages for this very reason, and only allolw the core team to upgrade packages unlesse you submit a FIP first explaining why you want to upgrade the package.
+   - This is a common attack vector by malicious agents. We lock down our packages for this very reason, and only allow the core team to upgrade packages unless you submit a FIP first explaining why you want to upgrade the package.
  - Upgrading Node Versions
-   - There is a large impact  in upgrading node versions. Iron Fish takes advantage of many experimental node features that at some are not fully fleshedout. We use workers, and native code boundries. Node is also known to introduce bugs in newer versions, even LTS. Because of this, there is production testing we do on our side when upgrading node to ensure it's compatible. Because of this, we don't allow usersc to upgrade our node versions unless a FIP is filed.
+   - There is a large impact in upgrading node versions. Iron Fish takes advantage of many experimental node features, some of which are not fully fleshed out. We use workers, and native code boundaries. Node is also known to introduce bugs in newer versions, even LTS. Because of this, there is production testing we do on our side when upgrading node to ensure it's compatible. Because of this, we don't allow users to upgrade our node versions unless a FIP is filed.
  - Refactor a core system
-   - Often engineers have visions for core systems, and may be in the process of changing them. FIP's help avoid overlap and to have your changes over-written. Some core systems include, MerkleTree, Blockchain, PeerNetwork, Verifier, Consensus.
- - Making new product design decisions that has no precident
-   - This one is more complicated. If our products works one way, and you open a PR to change the core product principals to work in another way, then we are going to close your PR as it does not fit into our vision. Try to match existing precident as much as possible in your code.
+   - Often engineers have visions for core systems, and may be in the process of changing them. FIP's help avoid overlap and having your changes over-written. Some core systems include, MerkleTree, Blockchain, PeerNetwork, Verifier, Consensus.
+ - Making new product design decisions that has no precedent
+   - This one is more complicated. If our products works one way, and you open a PR to change the core product principles to work in another way, then we are going to close your PR as it does not fit into our vision. Try to match existing precedent as much as possible in your code.
  - Tests for CLI commands
    - They are not useful in their current form. Most of these tests are mocking out the entire node and sending back hand crafted values which are merely asserted and make changes these commands more annoying. We are accepting a FIP for refactoring command tests to be more valuable and not use mocking.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,50 +1,24 @@
 # Contributing
 
-Thank you for considering contributing to the Iron Fish project. We want to make contributing to this project as easy and transparent as possible, whether it's about:
-
-* Discussing the current state of the code
-* Documenting the code
-* Reporting a bug
-* Reporting a security threat
-* Submitting a fix
-* Suggesting a new feature
-
 We welcome contributions from anyone on the internet, and are grateful for even a one-word correction! Note that we have a [code of conduct](./CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 
+Before you start, you should become familiar with pulling the code down locally, building the code, and running the tests. If you want more information you can visit our [install guide](https://github.com/iron-fish/ironfish#install), or [how to run tests](https://github.com/iron-fish/ironfish#running-tests).
 
 Thanks in advance for your help.
 
+# Contributor Workflow
 
-## We develop with GitHub
+Pull requests are the best way to propose a new change to the codebase.
 
-We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
+1. Fork the repo
+1. Create a branch from `staging`
+1. Open a pull request against `staging`
 
+Once the PR is created, one of the maintainers will review it and merge it. Add the right labels to your pull request. Reference to any bugs you're fixing with single lines of the form `Fix #123`
 
-## Pull Requests Guidelines
+**NOTE:** Read [We will close your PR if](we-will-close-your-pr-if), if you are thinking of working on a complex change.
 
-Pull requests are the best way to propose a new change to the codebase (we use the classic [GitHub Flow](https://guides.github.com/introduction/flow/index.html)).
-
-To create a new pull request:
-1. Fork the repo and check out a new branch from `staging`.
-2. Add test - if your code change doesn't require a test change, please explain why in the PR description.
-   * To run tests from a specific .test.ts file, run `yarn test NAME` where your tests are in NAME.test.ts
-3. Update the documentation - Especially if you've changed APIs or created new functions.
-4. Ensure the entire test suite passes by running `yarn test`.
-5. Make sure your code lints by running `yarn lint`.
-6. Once 4 & 5 are passing, create a new pull request on GitHub targeted at the `staging` branch.
-7. Add the right label to your PR `documentation`, `bug`, `security-issue`, or `enhancement`.
-8. Add a description of what the PR is changing:
-   * What problem is the PR solving
-   * References to any bugs you're fixing with single lines of the form `Fix #123`
-   * Explain if it's adding a breaking change for clients
-   * Explain how you've tested your change
-
-Once the PR is created, one of the maintainers will review it and merge it into the master branch.
-
-If you are thinking of working on a complex change, do not hesitate to discuss the change you wish to make via a GitHub Issue. You can also request feedback early, by opening a WIP pull request or discuss with a maintainer to ensure your work is in line with the philosophy and roadmap of Iron Fish.
-
-
-## Where to start
+# Where to start
 
 Please read our [README.md](./README.md) first, to learn how to set up Iron Fish.
 
@@ -55,32 +29,27 @@ If you don't know what contribution you can work on, here are a few suggestions:
 * Write documentation or fix the existing documentation
 * If you still don't know what could be a good task for you, do not hesitate to contact us.
 
+# You should open a FIP if
 
-## Testing
+If you are working on something in one of these categories, we will not accept your PR if you don't open a Fish Improvement Proposal (FIP).
 
-For our TypeScript codebase, you can run the entire test suite using `yarn test` in the root directory.
-
-For our Rust codebase, you can run the test suites for each project by running `cargo test` in the project directory.
-
-## Continuous integration
-
-After creating a PR on GitHub, the code will be tested automatically by GitHub Action. The tests can take up to 15 minutes to pass. We ask you to test your code on your machine before submitting a PR.
-
-
-## Style Guide
-
-Iron Fish uses `eslint` and `prettier` to maintain consistent formatting on the TypeScript codebase.
-For the Rust codebase, we are using `rustfmt`.
-
-Please run it before submitting a change.
+ - Upgrading Package Versions
+   - This is a common attack vector by malicious agents. We lock down our packages for this very reason, and only allolw the core team to upgrade packages unlesse you submit a FIP first explaining why you want to upgrade the package.
+ - Upgrading Node Versions
+   - There is a large impact  in upgrading node versions. Iron Fish takes advantage of many experimental node features that at some are not fully fleshedout. We use workers, and native code boundries. Node is also known to introduce bugs in newer versions, even LTS. Because of this, there is production testing we do on our side when upgrading node to ensure it's compatible. Because of this, we don't allow usersc to upgrade our node versions unless a FIP is filed.
+ - Refactor a core system
+   - Often engineers have visions for core systems, and may be in the process of changing them. FIP's help avoid overlap and to have your changes over-written. Some core systems include, MerkleTree, Blockchain, PeerNetwork, Verifier, Consensus.
+ - Making new product design decisions that has no precident
+   - This one is more complicated. If our products works one way, and you open a PR to change the core product principals to work in another way, then we are going to close your PR as it does not fit into our vision. Try to match existing precident as much as possible in your code.
+ - Tests for CLI commands
+   - They are not useful in their current form. Most of these tests are mocking out the entire node and sending back hand crafted values which are merely asserted and make changes these commands more annoying. We are accepting a FIP for refactoring command tests to be more valuable and not use mocking.
 
 
-# Licensing
+# Fish Improvement Proposal (FIP)
 
-Any contribution will be under the [MPL-2.0](https://www.mozilla.org/en-US/MPL/2.0/) Software License.
-When you submit a code change, your submissions are understood to be under the same license that covers the project.
+The purpose of a FIP is to explain an improvement you would like to make to Iron Fish, and get consensus from the core development team of Iron Fish. The reason is that we want to make sure your change fits inside of the product vision, and that you don't try to fix a bug in a piece of code already being refactored.
 
-Please contact us if this a concern for you.
+You can submit a FIP by filing an issue here, https://github.com/iron-fish/ironfish/issues/new/choose
 
 
 # Contact Us

--- a/README.md
+++ b/README.md
@@ -60,8 +60,18 @@ Once your environment is setup - you can run the CLI by following [these directi
 - [ironfish-rust-nodejs](./ironfish-rust-nodejs/README.md): Wrapper for `ironfish-rust` as a native NodeJS addon.
 - [ironfish-rust-wasm](./ironfish-rust-wasm/README.md): Wrapper for `ironfish-rust` in WASM.
 
+## Contributing Code
+
+If you want to contribute code, you must first read [our contributing guidelines](./CONTRIBUTING.md) or risk having your pull request closed.
+
 ## Other Repositories
 
 - [iron-fish/homebrew-brew](https://github.com/iron-fish/homebrew-brew): Contains brew formula for installing via the [Brew](https://brew.sh) package manager
 - [iron-fish/website](https://github.com/iron-fish/website): The repo that powers [ironfish.network](https://ironfish.network)
+- [iron-fish/website-testnet](https://github.com/iron-fish/website-testnet): The repo that powers [testnet.ironfish.network](https://testnet.ironfish.network)
+- [iron-fish/ironfish-api](https://github.com/iron-fish/ironfish-api): The repository that powers most Iron Fish API services.
 - [iron-fish/chain-explorer](https://github.com/iron-fish/chain-explorer): A visual tool to explore the block chain and all of its forks.
+
+## Licensing
+
+This code base and any contributions will be under the [MPL-2.0](https://www.mozilla.org/en-US/MPL/2.0/) Software License.


### PR DESCRIPTION
## Summary
This brings a much needed update to our contributor documentation. We're seeing a lot of third party contributors to our repository. Many of these bug fixes are great, but some of them are doing things we want to discourage. This tries to outline what those things are, and gives examples of them.

It also creates a new simple recommendation for making a change that goes against the rules, by filing a Fish Improvement Proposal (FIP).

- Updates CONTRIBUTING.md
- Adds a new FIP proposal issue template
- Updates README.md to mention CONTRIBUTING.md

## Testing Plan
No tests needed

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
