### PR TITLE
small test script cleanup

### DIFF
--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -101,7 +101,6 @@ describe('Create genesis block', () => {
     const addBlock = await chain.addBlock(block)
     expect(addBlock.isAdded).toBeTruthy()
 
-    // TODO: this should happen automatically in addBlock
     await node.accounts.updateHead()
 
     // Check that the balance is what's expected

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -246,19 +246,9 @@ describe('MemPool', () => {
       const add = jest.spyOn(queue, 'add')
       const accountA = await useAccountFixture(accounts, 'accountA')
       const accountB = await useAccountFixture(accounts, 'accountB')
-      const { block } = await useBlockWithTx(node, accountA, accountB)
+      const { block, transaction } = await useBlockWithTx(node, accountA, accountB)
+      const minersFee = block.transactions[0]
 
-      // TODO: Remove this and use return value of useBlockWithTx when miners
-      // miners fee is always first on the block
-      let minersFee
-      let transaction
-      for (const tx of block.transactions) {
-        if (tx.isMinersFee()) {
-          minersFee = tx
-        } else {
-          transaction = tx
-        }
-      }
       Assert.isNotUndefined(minersFee)
       Assert.isNotUndefined(transaction)
 


### PR DESCRIPTION
## Summary
- `ironfish/src/memPool/memPool.test.ts` doesn't need to loop through block txs to get the miner's fee. use the first block.
- code comment in `ironfish/src/genesis/genesis.test.slow.ts` is not needed. should've been removed with https://github.com/iron-fish/ironfish/commit/5beeedc2f5cd149da04379aed8c92bd48f52741a.

## Testing Plan
run yarn test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
