### PR TITLE
decouples StratumClient from MiningPoolMiner

### DIFF
--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -96,7 +96,7 @@ export class Miner extends IronfishCommand {
         port: port,
       })
 
-      miner.start()
+      await miner.start()
       if (flags.richOutput) {
         this.displayHashrate(miner)
       }

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -96,7 +96,7 @@ export class Miner extends IronfishCommand {
         port: port,
       })
 
-      await miner.start()
+      miner.start()
       if (flags.richOutput) {
         this.displayHashrate(miner)
       }

--- a/ironfish/src/mining/poolMiner.ts
+++ b/ironfish/src/mining/poolMiner.ts
@@ -132,11 +132,6 @@ export class MiningPoolMiner {
 
   async mine(): Promise<void> {
     while (this.started) {
-      if (!this.stratum.isConnected()) {
-        await PromiseUtils.sleep(500)
-        continue
-      }
-
       if (this.graffiti == null) {
         this.logger.info('Waiting for graffiti from pool...')
         await PromiseUtils.sleep(500)

--- a/ironfish/src/mining/stratum/stratumClient.ts
+++ b/ironfish/src/mining/stratum/stratumClient.ts
@@ -39,6 +39,11 @@ export class StratumClient {
 
   private readonly publicAddress: string
 
+  readonly onSubscribed = new Event<[MiningSubscribedMessage]>()
+  readonly onSetTarget = new Event<[MiningSetTargetMessage]>()
+  readonly onNotify = new Event<[MiningNotifyMessage]>()
+  readonly onWaitForWork = new Event<[MiningWaitForWorkMessage]>()
+
   constructor(options: { publicAddress: string; host: string; port: number; logger: Logger }) {
     this.host = options.host
     this.port = options.port
@@ -154,11 +159,6 @@ export class StratumClient {
   private onError = (error: unknown): void => {
     this.logger.error(`Stratum Error ${ErrorUtils.renderError(error)}`)
   }
-
-  readonly onSubscribed = new Event<[MiningSubscribedMessage]>()
-  readonly onSetTarget = new Event<[MiningSetTargetMessage]>()
-  readonly onNotify = new Event<[MiningNotifyMessage]>()
-  readonly onWaitForWork = new Event<[MiningWaitForWorkMessage]>()
 
   private async onData(data: Buffer): Promise<void> {
     this.messageBuffer += data.toString('utf-8')

--- a/ironfish/src/mining/stratum/stratumClient.ts
+++ b/ironfish/src/mining/stratum/stratumClient.ts
@@ -39,6 +39,7 @@ export class StratumClient {
 
   private readonly publicAddress: string
 
+  readonly onConnected = new Event<[]>()
   readonly onSubscribed = new Event<[MiningSubscribedMessage]>()
   readonly onSetTarget = new Event<[MiningSetTargetMessage]>()
   readonly onNotify = new Event<[MiningNotifyMessage]>()
@@ -61,14 +62,14 @@ export class StratumClient {
     this.socket.on('data', (data) => void this.onData(data).catch((e) => this.onError(e)))
   }
 
-  async start(): Promise<void> {
+  start(): void {
     if (this.started) {
       return
     }
 
     this.started = true
     this.logger.info('Connecting to pool...')
-    await this.startConnecting()
+    void this.startConnecting()
   }
 
   private async startConnecting(): Promise<void> {
@@ -92,6 +93,7 @@ export class StratumClient {
 
     this.connectWarned = false
     this.onConnect()
+    this.onConnected.emit()
   }
 
   stop(): void {


### PR DESCRIPTION
## Summary

background:
the StratumClient and MiningPoolMiner are tightly coupled -- an instance of one
type holds a reference to an instance of the other type. this coupling makes it
difficult to use StratumClient without a MiningPoolMiner. a developer might want
to do this if they were to implement their own miner, or if they wanted to use
the StratumClient to receive messages outside of a mining context (e.g., to get
status information from the pool).

- removes miner property from StratumClient
- modifies StratumClient to emit message bodies after validating

## Testing Plan

tested with local mining pool and miner

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
