### PR TITLE
Add version to stratum handshake

### DIFF
--- a/ironfish/src/mining/stratum/messages.ts
+++ b/ironfish/src/mining/stratum/messages.ts
@@ -10,6 +10,7 @@ export type StratumMessage = {
 }
 
 export type MiningSubscribeMessage = {
+  version: number
   publicAddress: string
 }
 
@@ -68,6 +69,7 @@ export const MiningWaitForWorkSchema: yup.MixedSchema<MiningWaitForWorkMessage> 
 
 export const MiningSubscribeSchema: yup.ObjectSchema<MiningSubscribeMessage> = yup
   .object({
+    version: yup.number().required(),
     publicAddress: yup.string().required(),
   })
   .required()

--- a/ironfish/src/mining/stratum/stratumClient.ts
+++ b/ironfish/src/mining/stratum/stratumClient.ts
@@ -22,6 +22,7 @@ import {
   StratumMessage,
   StratumMessageSchema,
 } from './messages'
+import { STRATUM_VERSION_PROTOCOL } from './version'
 
 export class StratumClient {
   readonly socket: net.Socket
@@ -106,8 +107,10 @@ export class StratumClient {
 
   subscribe(): void {
     this.send('mining.subscribe', {
+      version: STRATUM_VERSION_PROTOCOL,
       publicAddress: this.publicAddress,
     })
+
     this.logger.info('Listening to pool for new work')
   }
 

--- a/ironfish/src/mining/stratum/version.ts
+++ b/ironfish/src/mining/stratum/version.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export const STRATUM_VERSION_PROTOCOL = 1
+export const STRATUM_VERSION_PROTOCOL_MIN = 1


### PR DESCRIPTION
## Summary

This is the first step in handling clients properly. We now require the version in the handshake. Anyone that connects with a lower version gets shadow banned. I temporary expanded the shadow banning but plan to remove it shortly when I add real banning and punishing.

## Testing Plan

Run the pool locally and mine, and also mess with sending the wrong stratum version.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
