### PR TITLE
Rename accounts:publickey to accounts:address

### DIFF
--- a/ironfish-cli/src/commands/accounts/address.test.ts
+++ b/ironfish-cli/src/commands/accounts/address.test.ts
@@ -4,7 +4,7 @@
 import { GetPublicKeyResponse } from '@ironfish/sdk'
 import { expect as expectCli, test } from '@oclif/test'
 
-describe('accounts:publickey', () => {
+describe('accounts:address', () => {
   const publicKeyResponse: GetPublicKeyResponse = {
     account: 'default',
     publicKey:
@@ -42,9 +42,9 @@ describe('accounts:publickey', () => {
   describe('fetching public key', () => {
     test
       .stdout()
-      .command('accounts:publickey')
+      .command('accounts:address')
       .exit(0)
-      .it('logs account public key', (ctx) => {
+      .it('logs account address', (ctx) => {
         expectCli(ctx.stdout).include(publicKeyResponse.publicKey)
         expectCli(ctx.stdout).include(publicKeyResponse.account)
       })

--- a/ironfish-cli/src/commands/accounts/address.ts
+++ b/ironfish-cli/src/commands/accounts/address.ts
@@ -5,15 +5,18 @@ import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
-export class PublicKeyCommand extends IronfishCommand {
-  static description = `Display or regenerate the account public key`
+export class AddressCommand extends IronfishCommand {
+  static aliases = ['accounts:publickey']
+  static description = `Display or regenerate your account address
+
+  The address for an account is the accounts public key, see more here: https://ironfish.network/docs/whitepaper/5_account`
 
   static flags = {
     ...RemoteFlags,
     generate: Flags.boolean({
       char: 'g',
       default: false,
-      description: 'generate the public key',
+      description: 'generate a new address',
     }),
   }
 
@@ -22,12 +25,12 @@ export class PublicKeyCommand extends IronfishCommand {
       name: 'account',
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
-      description: 'name of the account to get a public key',
+      description: 'name of the account to get the address for',
     },
   ]
 
   async start(): Promise<void> {
-    const { args, flags } = await this.parse(PublicKeyCommand)
+    const { args, flags } = await this.parse(AddressCommand)
     const account = args.account as string | undefined
 
     const client = await this.sdk.connectRpc()

--- a/ironfish/src/rpc/routes/accounts/getPublicKey.ts
+++ b/ironfish/src/rpc/routes/accounts/getPublicKey.ts
@@ -5,13 +5,13 @@ import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
-export type GetPublicKeyRequest = { account?: string; generate: boolean }
+export type GetPublicKeyRequest = { account?: string; generate?: boolean }
 export type GetPublicKeyResponse = { account: string; publicKey: string }
 
 export const GetPublicKeyRequestSchema: yup.ObjectSchema<GetPublicKeyRequest> = yup
   .object({
     account: yup.string().strip(true),
-    generate: yup.boolean().defined(),
+    generate: yup.boolean().defined().default(false),
   })
   .defined()
 


### PR DESCRIPTION
## Summary

I'm doing this because I think this is a more common terminology for
this concept. Yes, it is a public key but most users in our community
know this as the address. I created an alias so the old command is still
usable.

## Testing Plan

Delete your build folder in ironfish-cli and rebuild, then run the commands.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
