### PR TITLE
Add stratum server peer management

### DIFF
--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -132,7 +132,11 @@ export class MiningPool {
     this.started = true
     await this.shares.start()
 
-    this.logger.info(`Starting stratum server on ${this.stratum.host}:${this.stratum.port}`)
+    this.logger.info(
+      `Starting stratum server v${String(this.stratum.version)} on ${this.stratum.host}:${
+        this.stratum.port
+      }`,
+    )
     this.stratum.start()
 
     this.logger.info('Connecting to node...')
@@ -232,10 +236,10 @@ export class MiningPool {
     try {
       headerBytes = mineableHeaderString(blockTemplate.header)
     } catch (error) {
-      this.logger.debug(`${client.id} sent malformed work. No longer sending work.`)
-      this.stratum.addBadClient(client)
+      this.stratum.peers.punish(client, `${client.id} sent malformed work.`)
       return
     }
+
     const hashedHeader = blake3(headerBytes)
 
     if (hashedHeader.compare(Buffer.from(blockTemplate.header.target, 'hex')) !== 1) {
@@ -424,6 +428,7 @@ export class MiningPool {
       hashRate: hashRate,
       miners: this.stratum.clients.size,
       sharesPending: sharesPending,
+      banCount: this.stratum.peers.banCount,
     }
   }
 }
@@ -433,4 +438,5 @@ export type MiningPoolStatus = {
   hashRate: number
   miners: number
   sharesPending: number
+  banCount: number
 }

--- a/ironfish/src/mining/stratum/stratumPeers.ts
+++ b/ironfish/src/mining/stratum/stratumPeers.ts
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import net from 'net'
+import { Event } from '../../event'
+import { Config } from '../../fileStores/config'
+import { createRootLogger, Logger } from '../../logger'
+import { SetTimeoutToken } from '../../utils'
+import { StratumServerClient } from './stratumServerClient'
+
+const TWO_HOURS_MS = 2 * 60 * 60 * 1000
+const PEERS_TICK_MS = 10000
+
+export class StratumPeers {
+  readonly logger: Logger
+  readonly maxConnectionsByIp: number
+
+  readonly onBanned = new Event<[StratumServerClient]>()
+
+  banCount = 0
+
+  protected readonly connectionsByIp: Map<string, number> = new Map()
+  protected readonly bannedByIp: Map<string, number> = new Map()
+  protected readonly scoreByIp: Map<string, number> = new Map()
+  protected readonly shadowBans: Set<number> = new Set()
+  protected eventLoopTimeout: SetTimeoutToken | null = null
+
+  constructor(options: { maxConnectionsPerIp?: number; config: Config; logger?: Logger }) {
+    this.logger = options.logger ?? createRootLogger()
+
+    this.maxConnectionsByIp =
+      options.maxConnectionsPerIp ?? options.config.get('poolMaxConnectionsPerIp')
+  }
+
+  start(): void {
+    this.eventLoop()
+  }
+
+  stop(): void {
+    if (this.eventLoopTimeout) {
+      clearTimeout(this.eventLoopTimeout)
+    }
+  }
+
+  punish(client: StratumServerClient, reason?: string, amount = 1): void {
+    if (this.isBanned(client.socket)) {
+      return
+    }
+
+    let banScore = this.scoreByIp.get(client.remoteAddress) ?? 0
+    banScore += amount
+
+    if (banScore < 10) {
+      this.scoreByIp.set(client.remoteAddress, banScore)
+      return
+    }
+
+    this.ban(client, reason)
+    this.scoreByIp.delete(client.remoteAddress)
+  }
+
+  shadowBan(client: StratumServerClient): void {
+    this.shadowBans.add(client.id)
+  }
+
+  ban(client: StratumServerClient, reason = 'unknown', until?: number): void {
+    const existing = this.bannedByIp.get(client.remoteAddress) ?? 0
+    until = Math.max(existing, until ?? Date.now() + TWO_HOURS_MS)
+
+    this.bannedByIp.set(client.remoteAddress, until)
+    this.scoreByIp.delete(client.remoteAddress)
+    this.banCount++
+
+    client.close()
+    this.onBanned.emit(client)
+
+    this.logger.info(
+      `Banned ${client.remoteAddress}: ${reason} until: ${new Date(until).toUTCString()} (${
+        this.banCount
+      } bans)`,
+    )
+  }
+
+  isShadowBanned(client: StratumServerClient): boolean {
+    return this.shadowBans.has(client.id)
+  }
+
+  isBanned(socket: net.Socket): boolean {
+    if (!socket.remoteAddress) {
+      return false
+    }
+
+    const bannedUntil = this.bannedByIp.get(socket.remoteAddress)
+    if (!bannedUntil) {
+      return false
+    }
+
+    return bannedUntil > Date.now()
+  }
+
+  isAllowed(socket: net.Socket): boolean {
+    if (!socket.remoteAddress) {
+      return false
+    }
+
+    if (this.isBanned(socket)) {
+      return false
+    }
+
+    const connections = this.connectionsByIp.get(socket.remoteAddress) ?? 0
+    if (this.maxConnectionsByIp > 0 && connections >= this.maxConnectionsByIp) {
+      return false
+    }
+
+    return true
+  }
+
+  addConnectionCount(client: StratumServerClient): void {
+    const count = this.connectionsByIp.get(client.remoteAddress) ?? 0
+    this.connectionsByIp.set(client.remoteAddress, count + 1)
+  }
+
+  removeConnectionCount(client: StratumServerClient): void {
+    const count = this.connectionsByIp.get(client.remoteAddress) ?? 0
+    this.connectionsByIp.set(client.remoteAddress, count - 1)
+
+    if (count - 1 <= 0) {
+      this.connectionsByIp.delete(client.remoteAddress)
+    }
+
+    this.shadowBans.delete(client.id)
+  }
+
+  unpunish(remoteAddress: string, reduceBy = 1): void {
+    let score = this.scoreByIp.get(remoteAddress)
+
+    if (score === undefined) {
+      return
+    }
+
+    score -= reduceBy
+
+    if (score > 0) {
+      this.scoreByIp.set(remoteAddress, score)
+    } else {
+      this.scoreByIp.delete(remoteAddress)
+    }
+  }
+
+  eventLoop(): void {
+    for (const remoteAddress of this.scoreByIp.keys()) {
+      this.unpunish(remoteAddress)
+    }
+
+    this.eventLoopTimeout = setTimeout(() => this.eventLoop(), PEERS_TICK_MS)
+  }
+}

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -169,6 +169,12 @@ export class StratumServer {
             return
           }
 
+          // TODO: Remove when making version required
+          if (body.result.version === undefined) {
+            this.peers.shadowBan(client)
+            return
+          }
+
           // TODO: This undefined check makes version optional, we should require it by
           // removing this undefined check in a future update once we have given enough
           // notice after this deploy.

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -27,7 +27,7 @@ import { StratumPeers } from './stratumPeers'
 import { StratumServerClient } from './stratumServerClient'
 import { STRATUM_VERSION_PROTOCOL, STRATUM_VERSION_PROTOCOL_MIN } from './version'
 
-const FIFTEEN_MINUTES = 15 * 60 * 1000
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000
 
 export class StratumServer {
   readonly server: net.Server
@@ -125,7 +125,7 @@ export class StratumServer {
     this.clients.set(client.id, client)
   }
 
-  // Returns the count of connected clients excluding those marked as bad clients
+  // Returns the count of connected clients
   getClientCount(): number {
     return this.clients.size
   }
@@ -176,7 +176,7 @@ export class StratumServer {
             this.peers.ban(
               client,
               `Client version ${body.result.version} does not meet minimum version ${this.versionMin}`,
-              FIFTEEN_MINUTES,
+              FIFTEEN_MINUTES_MS,
             )
             return
           }

--- a/ironfish/src/mining/webhooks/webhookNotifier.ts
+++ b/ironfish/src/mining/webhooks/webhookNotifier.ts
@@ -100,7 +100,9 @@ export abstract class WebhookNotifier {
     this.sendText(
       `Status for mining pool '${status.name}':\n\tHashrate: ${FileUtils.formatHashRate(
         status.hashRate,
-      )}/s\n\tMiners: ${status.miners}\n\tShares pending: ${status.sharesPending}`,
+      )}/s\n\tMiners: ${status.miners}\n\tShares pending: ${
+        status.sharesPending
+      }\n\tBan Count: ${status.banCount}`,
     )
   }
 


### PR DESCRIPTION
## Summary

This adds a new StratumPeers system, which tracks bad clients and bans them. It also manages ban timers, and punishment timers. This also ports the old badClients concept into a shadow ban, which is needed because we don't reject peers with bad versions yet.

## Testing Plan
Run pool, and connect with malicious client.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
