### PR TITLE
feat(ironfish): Create store for decryptable notes

### DIFF
--- a/ironfish/src/account/database/decryptableNotes.test.ts
+++ b/ironfish/src/account/database/decryptableNotes.test.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DecryptableNotesValue, DecryptableNotesValueEncoding } from './decryptableNotes'
+
+describe('DecryptableNotesValueEncoding', () => {
+  describe('with a null note index, nullifier hash, and transaction hash', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new DecryptableNotesValueEncoding()
+
+      const value: DecryptableNotesValue = {
+        accountId: 0,
+        noteIndex: null,
+        nullifierHash: null,
+        spent: false,
+        transactionHash: null,
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+
+  describe('with all fields defined', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new DecryptableNotesValueEncoding()
+
+      const value: DecryptableNotesValue = {
+        accountId: 0,
+        spent: true,
+        noteIndex: 40,
+        nullifierHash: Buffer.alloc(32, 1).toString('hex'),
+        transactionHash: Buffer.alloc(32, 1).toString('hex'),
+      }
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expect(deserializedValue).toEqual(value)
+    })
+  })
+})

--- a/ironfish/src/account/database/decryptableNotes.ts
+++ b/ironfish/src/account/database/decryptableNotes.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../storage'
+
+export interface DecryptableNotesValue {
+  accountId: number
+  noteIndex: number | null
+  nullifierHash: string | null
+  spent: boolean
+  transactionHash: string | null
+}
+
+export class DecryptableNotesValueEncoding implements IDatabaseEncoding<DecryptableNotesValue> {
+  serialize(value: DecryptableNotesValue): Buffer {
+    const { accountId, nullifierHash, noteIndex, spent, transactionHash } = value
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!noteIndex) << 0
+    flags |= Number(!!nullifierHash) << 1
+    flags |= Number(!!transactionHash) << 2
+    flags |= Number(spent) << 3
+    bw.writeU8(flags)
+
+    bw.writeU8(accountId)
+    if (noteIndex) {
+      bw.writeU32(noteIndex)
+    }
+    if (nullifierHash) {
+      bw.writeHash(nullifierHash)
+    }
+    if (transactionHash) {
+      bw.writeHash(transactionHash)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): DecryptableNotesValue {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const hasNoteIndex = flags & (1 << 0)
+    const hasNullifierHash = flags & (1 << 1)
+    const hasTransactionHash = flags & (1 << 2)
+    const spent = Boolean(flags & (1 << 3))
+
+    const accountId = reader.readU8()
+
+    let noteIndex = null
+    if (hasNoteIndex) {
+      noteIndex = reader.readU32()
+    }
+
+    let nullifierHash = null
+    if (hasNullifierHash) {
+      nullifierHash = reader.readHash('hex')
+    }
+
+    let transactionHash = null
+    if (hasTransactionHash) {
+      transactionHash = reader.readHash('hex')
+    }
+
+    return { accountId, noteIndex, nullifierHash, spent, transactionHash }
+  }
+
+  getSize(value: DecryptableNotesValue): number {
+    let size = 2
+    if (value.noteIndex) {
+      size += 4
+    }
+    if (value.nullifierHash) {
+      size += 32
+    }
+    if (value.transactionHash) {
+      size += 32
+    }
+    return size
+  }
+}


### PR DESCRIPTION
## Summary

Add a new store which will store decryptable notes and eventually deprecate the `noteToNullifiers` store. Writes will happen to this store in a [subsequent change](https://linear.app/ironfish/issue/IRO-2220/dual-write-to-decryptable-notes-store-when-updating-notes-to) and after the accounts store is updated to hold IDs.

## Testing Plan

Unit test.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
