### PR TITLE
Add option to disable miner pool client banning

### DIFF
--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -43,6 +43,10 @@ export class StartPool extends IronfishCommand {
     balancePercentPayout: Flags.integer({
       description: 'whether the pool should payout or not. useful for solo miners',
     }),
+    banning: Flags.boolean({
+      description: 'whether the pool should ban peers for errors or bad behavior',
+      allowNo: true,
+    }),
   }
 
   pool: MiningPool | null = null
@@ -118,6 +122,7 @@ export class StartPool extends IronfishCommand {
       host: host,
       port: port,
       balancePercentPayoutFlag: flags.balancePercentPayout,
+      banning: flags.banning,
     })
 
     await this.pool.start()

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -159,6 +159,11 @@ export type ConfigOptions = {
   poolAccountName: string
 
   /**
+   * Should pool clients be banned for perceived bad behavior
+   */
+  poolBanning: boolean
+
+  /**
    * The percent of the confirmed balance of the pool's account that it will payout
    */
   poolBalancePercentPayout: number
@@ -304,6 +309,7 @@ export class Config extends KeyStore<ConfigOptions> {
       minerBatchSize: DEFAULT_MINER_BATCH_SIZE,
       poolName: DEFAULT_POOL_NAME,
       poolAccountName: DEFAULT_POOL_ACCOUNT_NAME,
+      poolBanning: false,
       poolBalancePercentPayout: DEFAULT_POOL_BALANCE_PERCENT_PAYOUT,
       poolHost: DEFAULT_POOL_HOST,
       poolPort: DEFAULT_POOL_PORT,

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -60,6 +60,7 @@ export class MiningPool {
     webhooks?: WebhookNotifier[]
     host?: string
     port?: number
+    banning?: boolean
   }) {
     this.rpc = options.rpc
     this.logger = options.logger
@@ -70,6 +71,7 @@ export class MiningPool {
       logger: this.logger,
       host: options.host,
       port: options.port,
+      banning: options.banning,
     })
     this.config = options.config
     this.shares = options.shares
@@ -102,6 +104,7 @@ export class MiningPool {
     host?: string
     port?: number
     balancePercentPayoutFlag?: number
+    banning?: boolean
   }): Promise<MiningPool> {
     const shares = await MiningPoolShares.init({
       rpc: options.rpc,
@@ -120,6 +123,7 @@ export class MiningPool {
       host: options.host,
       port: options.port,
       shares,
+      banning: options.banning,
     })
   }
 

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -56,6 +56,7 @@ export class StratumServer {
     logger: Logger
     port?: number
     host?: string
+    banning?: boolean
   }) {
     this.pool = options.pool
     this.config = options.config
@@ -74,6 +75,7 @@ export class StratumServer {
     this.peers = new StratumPeers({
       config: this.config,
       server: this,
+      banning: options.banning,
     })
 
     this.server = net.createServer((s) => this.onConnection(s))


### PR DESCRIPTION
## Summary

This is in case people don't want it, or we need an escape hatch if this ends up over banning people.

## Testing Plan

Run the pool and enable / disable the option and set the version wrong, or send wrong messages.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
