### PR TITLE
feat(ironfish): Update accounts store to use UUIDs instead of names

### DIFF
--- a/ironfish-cli/src/commands/start.test.ts
+++ b/ironfish-cli/src/commands/start.test.ts
@@ -90,7 +90,7 @@ describe('start command', () => {
       getDefaultAccount: jest.fn(),
       createAccount: jest.fn().mockImplementation(
         (name: string) =>
-          new ironfishmodule.Account({
+          new ironfishmodule.Account('id', {
             incomingViewKey: '',
             outgoingViewKey: '',
             publicAddress: '',

--- a/ironfish/src/account/account.ts
+++ b/ironfish/src/account/account.ts
@@ -6,6 +6,7 @@ import MurmurHash3 from 'imurmurhash'
 import { AccountsValue } from './database/accounts'
 
 export class Account {
+  readonly id: string
   readonly displayName: string
   name: string
   readonly spendingKey: string
@@ -14,7 +15,8 @@ export class Account {
   publicAddress: string
   rescan: number | null
 
-  constructor(serializedAccount: AccountsValue) {
+  constructor(id: string, serializedAccount: AccountsValue) {
+    this.id = id
     this.name = serializedAccount.name
     this.spendingKey = serializedAccount.spendingKey
     this.incomingViewKey = serializedAccount.incomingViewKey

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -26,15 +26,6 @@ import { TransactionsValue, TransactionsValueEncoding } from './database/transac
 
 const DATABASE_VERSION = 5
 
-export const AccountDefaults: AccountsValue = {
-  name: '',
-  spendingKey: '',
-  incomingViewKey: '',
-  outgoingViewKey: '',
-  publicAddress: '',
-  rescan: null,
-}
-
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountName: null,
   headHash: null,
@@ -135,11 +126,11 @@ export class AccountsDB {
   }
 
   async setAccount(account: Account): Promise<void> {
-    await this.accounts.put(account.name, account.serialize())
+    await this.accounts.put(account.id, account.serialize())
   }
 
-  async removeAccount(name: string): Promise<void> {
-    await this.accounts.del(name)
+  async removeAccount(id: string): Promise<void> {
+    await this.accounts.del(id)
   }
 
   async setDefaultAccount(name: AccountsDBMeta['defaultAccountName']): Promise<void> {
@@ -161,8 +152,8 @@ export class AccountsDB {
   }
 
   async *loadAccounts(): AsyncGenerator<Account, void, unknown> {
-    for await (const account of this.accounts.getAllValuesIter()) {
-      yield new Account(account)
+    for await (const [id, account] of this.accounts.getAllIter()) {
+      yield new Account(id, account)
     }
   }
 


### PR DESCRIPTION
## Summary

Currently the accounts store in the database uses names as keys. This code change updates the keys to be UUIDs so we have cleaner references in our decryptable notes store and makes it easier to allow for account name updates in the future.

> It is possible to have the same account in the database (or different nodes), but they will have different IDs. We don't need to derive IDs from the keys since this will just be used as a foreign key in other stores.

There will be a subsequent PR to update the meta store to store a default account ID instead of default account name.

## Testing Plan

Manually ran node:

```sh
▶ ironfish accounts:list --datadir=~/.ironfish-1
Now using node v16.6.2 (npm v7.20.3)
yarn run v1.22.19
$ yarn build && yarn start:js accounts:list '--datadir=~/.ironfish-1'
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node bin/run accounts:list '--datadir=~/.ironfish-1'
[
  Account {
    id: 'a72b103c-226e-4595-8585-1c8e5049848c',
    name: 'default',
    spendingKey: '<redacted>',
    incomingViewKey: '<redacted>',
    outgoingViewKey: '<redacted>',
    publicAddress: '<redacted>',
    rescan: null,
    displayName: 'default (441bf37)'
  }
]
default
✨  Done in 10.20s.
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
[ ] No
```
