### PR TITLE
Track known block hashes on Peers

### DIFF
--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -226,6 +226,11 @@ describe('PeerNetwork', () => {
         const peer2Send = jest.spyOn(peer2, 'send')
         const peer3Send = jest.spyOn(peer3, 'send')
 
+        await peerNetwork.peerManager.onMessage.emitAsync(peer1, {
+          peerIdentity: peer1.getIdentityOrThrow(),
+          message: newBlockMessage,
+        })
+
         await peerNetwork['handleGossipMessage'](peer1, newBlockMessage)
 
         expect(peer1.knownBlockHashes.has(blockA1.header.hash)).toBe(true)

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -44,7 +44,7 @@ import {
   RequestTimeoutError,
 } from './peers/connections'
 import { LocalPeer } from './peers/localPeer'
-import { BAN_SCORE, Peer } from './peers/peer'
+import { BAN_SCORE, KnownBlockHashesValue, Peer } from './peers/peer'
 import { PeerConnectionManager } from './peers/peerConnectionManager'
 import { PeerManager } from './peers/peerManager'
 import { IsomorphicWebSocketConstructor } from './types'
@@ -327,7 +327,7 @@ export class PeerNetwork {
       }
 
       if (peer.send(message)) {
-        peer.knownBlockHashes.set(block.header.hash, false)
+        peer.knownBlockHashes.set(block.header.hash, KnownBlockHashesValue.Sent)
       }
     }
   }

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { BlockHash } from '../../primitives/blockheader'
 import LRU from 'blru'
 import { BufferMap } from 'buffer-map'
 import colors from 'colors/safe'
@@ -196,7 +197,7 @@ export class Peer {
    * Blocks that have been sent or received from this peer. Value is set to true if the block was received
    * from the peer, and false if the block was sent to the peer.
    */
-  readonly knownBlockHashes: LRU<Buffer, boolean> = new LRU<Buffer, boolean>(
+  readonly knownBlockHashes: LRU<BlockHash, boolean> = new LRU<BlockHash, boolean>(
     1024,
     null,
     BufferMap,

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -63,6 +63,11 @@ export type PeerState =
       connections: Readonly<PeerConnectionState>
     }
 
+export enum KnownBlockHashesValue {
+  Received = 1,
+  Sent = 2,
+}
+
 export class Peer {
   readonly pendingRPCMax: number
   readonly logger: Logger
@@ -197,11 +202,10 @@ export class Peer {
    * Blocks that have been sent or received from this peer. Value is set to true if the block was received
    * from the peer, and false if the block was sent to the peer.
    */
-  readonly knownBlockHashes: LRU<BlockHash, boolean> = new LRU<BlockHash, boolean>(
-    1024,
-    null,
-    BufferMap,
-  )
+  readonly knownBlockHashes: LRU<BlockHash, KnownBlockHashesValue> = new LRU<
+    BlockHash,
+    KnownBlockHashesValue
+  >(1024, null, BufferMap)
 
   /**
    * Event fired for every new incoming message that needs to be processed

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import LRU from 'blru'
+import { BufferMap } from 'buffer-map'
 import colors from 'colors/safe'
 import { Event } from '../../event'
 import { createRootLogger, Logger } from '../../logger'
@@ -189,6 +191,16 @@ export class Peer {
   shouldLogMessages = false
 
   loggedMessages: Array<LoggedMessage> = []
+
+  /**
+   * Blocks that have been sent or received from this peer. Value is set to true if the block was received
+   * from the peer, and false if the block was sent to the peer.
+   */
+  readonly knownBlockHashes: LRU<Buffer, boolean> = new LRU<Buffer, boolean>(
+    1024,
+    null,
+    BufferMap,
+  )
 
   /**
    * Event fired for every new incoming message that needs to be processed

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -484,6 +484,11 @@ export class Syncer {
 
     const { added, block } = await this.addBlock(peer, newBlock)
 
+    peer.knownBlockHashes.set(block.header.hash, true)
+    for (const knownPeer of peer.knownPeers.values()) {
+      knownPeer.knownBlockHashes.set(block.header.hash, true)
+    }
+
     if (!peer.sequence || block.header.sequence > peer.sequence) {
       peer.sequence = block.header.sequence
     }

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -9,7 +9,7 @@ import { Event } from './event'
 import { createRootLogger, Logger } from './logger'
 import { Meter, MetricsMonitor } from './metrics'
 import { Peer, PeerNetwork } from './network'
-import { BAN_SCORE, PeerState } from './network/peers/peer'
+import { BAN_SCORE, KnownBlockHashesValue, PeerState } from './network/peers/peer'
 import { Block, SerializedBlock } from './primitives/block'
 import { BlockHeader } from './primitives/blockheader'
 import { Strategy } from './strategy'
@@ -484,9 +484,9 @@ export class Syncer {
 
     const { added, block } = await this.addBlock(peer, newBlock)
 
-    peer.knownBlockHashes.set(block.header.hash, true)
+    peer.knownBlockHashes.set(block.header.hash, KnownBlockHashesValue.Received)
     for (const knownPeer of peer.knownPeers.values()) {
-      knownPeer.knownBlockHashes.set(block.header.hash, true)
+      knownPeer.knownBlockHashes.set(block.header.hash, KnownBlockHashesValue.Received)
     }
 
     if (!peer.sequence || block.header.sequence > peer.sequence) {


### PR DESCRIPTION
## Summary

Adds a knownBlockHashes LRU to peers. This isn't particularly useful with the current block propagation model, but will be used for the next one.

One potentially dangerous area is the gossip was changed to add the block hashes to all knownPeers and determine whether to rebroadcast the message based on the presence of the hash on a peer, rather than looking at the peer's knownPeers directly.

This doesn't cause any problems in testing, and I think the only potential edge cases would be if a peer is rapidly connecting and disconnecting, causing the LRU to get reset, but a block shouldn't get rebroadcast for an extended duration regardless.

Fixes IRO-2226

## Testing Plan

Added a test for gossip, and tested gossip between a network of 3 peers.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
