### PR TITLE
Send known peers in PeerList message

### DIFF
--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -1409,10 +1409,6 @@ export class PeerManager {
         continue
       }
 
-      if (peer.knownPeers.has(p.state.identity)) {
-        continue
-      }
-
       connectedPeers.push({
         identity: Buffer.from(p.state.identity, 'base64'),
         name: p.name || undefined,


### PR DESCRIPTION
## Summary

While testing out #1683, I noticed that extra block messages were being sent in a network of 3 connected nodes. I found that we were filtering out knownPeers from the PeerList message we send in response to PeerListRequest message. This seems like a convenient bandwidth optimization, but since we also use knownPeers for reducing bandwidth as part of our gossip strategy, it causes extra gossip messages to be sent.

I suspect that transaction and block bandwidth will likely outweigh the bandwidth saved from not including known peers in the PeerList response. The upcoming block/transaction gossip model won't rely on knownPeers either.

See the example below:

### Example

In this example, we have 3 nodes: A, B, and C. Each node is connected to each other node. If, as Node A, I'm aware that Node B is connected to Node C, then when Node B requests a peerlist from me, I won't include Node C in the message. As a result, Node B won't know that I'm connected to Node C. If Node C happens to mine a block, it will broadcast the block to Node A and B. Node B, not knowing that Node A is connected to Node C, will also broadcast the block to Node A.

## Testing Plan

Started up 3 interconnected nodes and verified that extra gossip messages were no longer sent.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
