### PR TITLE
Change defaultAccountName in db to defaultAccountId

### DIFF
--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -27,7 +27,7 @@ import { TransactionsValue, TransactionsValueEncoding } from './database/transac
 const DATABASE_VERSION = 5
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
-  defaultAccountName: null,
+  defaultAccountId: null,
   headHash: null,
 })
 
@@ -132,8 +132,8 @@ export class AccountsDB {
     await this.accounts.del(id)
   }
 
-  async setDefaultAccount(name: AccountsDBMeta['defaultAccountName']): Promise<void> {
-    await this.meta.put('defaultAccountName', name)
+  async setDefaultAccount(id: AccountsDBMeta['defaultAccountId']): Promise<void> {
+    await this.meta.put('defaultAccountId', id)
   }
 
   async setHeadHash(hash: AccountsDBMeta['headHash']): Promise<void> {

--- a/ironfish/src/account/database/meta.ts
+++ b/ironfish/src/account/database/meta.ts
@@ -5,7 +5,7 @@ import bufio from 'bufio'
 import { IDatabaseEncoding } from '../../storage'
 
 export type AccountsDBMeta = {
-  defaultAccountName: string | null
+  defaultAccountId: string | null
   headHash: string | null
 }
 


### PR DESCRIPTION
## Summary

Part 1 of 2 for changing the meta store to the new format: rename `defaultAccountName` to `defaultAccountId` and associated changes.

These changes were just to make the internal logic more consistent around using the id. I think another improvement to consider is making the functions on `accounts` all work off id instead of name, but need to think through that more and didn't want to gum up this PR too much

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[ ] No
```
