### PR TITLE
Resend ban to StratumClient on reconnection

### DIFF
--- a/ironfish/src/mining/stratum/stratumPeers.ts
+++ b/ironfish/src/mining/stratum/stratumPeers.ts
@@ -23,8 +23,17 @@ export class StratumPeers {
 
   banCount = 0
 
+  protected readonly bannedByIp: Map<
+    string,
+    {
+      until: number
+      reason: DisconnectReason
+      versionExpected?: number
+      message?: string
+    }
+  > = new Map()
+
   protected readonly connectionsByIp: Map<string, number> = new Map()
-  protected readonly bannedByIp: Map<string, number> = new Map()
   protected readonly scoreByIp: Map<string, number> = new Map()
   protected readonly shadowBans: Set<number> = new Set()
   protected eventLoopTimeout: SetTimeoutToken | null = null
@@ -83,23 +92,24 @@ export class StratumPeers {
       versionExpected?: number
     },
   ): void {
-    let until = options?.until ?? Date.now() + FIFTEEN_MINUTES_MS
+    const until = options?.until ?? Date.now() + FIFTEEN_MINUTES_MS
 
-    // Prefer an existing longer ban
-    const existing = this.bannedByIp.get(client.remoteAddress) ?? 0
-    until = Math.max(existing, until)
+    let existing = this.bannedByIp.get(client.remoteAddress)
 
-    this.bannedByIp.set(client.remoteAddress, until)
+    if (!existing || existing.until < until) {
+      existing = {
+        until: until,
+        reason: options?.reason ?? DisconnectReason.UNKNOWN,
+        message: options?.message,
+        versionExpected: options?.versionExpected,
+      }
+    }
+
+    this.bannedByIp.set(client.remoteAddress, existing)
     this.scoreByIp.delete(client.remoteAddress)
     this.banCount++
 
-    this.server.send(client.socket, 'mining.disconnect', {
-      reason: options?.reason ?? DisconnectReason.UNKNOWN,
-      versionExpected: options?.versionExpected,
-      bannedUntil: until,
-      message: options?.message,
-    })
-
+    this.sendBanMessage(client.socket)
     client.close()
     this.onBanned.emit(client)
 
@@ -108,6 +118,25 @@ export class StratumPeers {
         options?.message ?? options?.reason ?? 'unknown'
       } until: ${new Date(until).toUTCString()} (${this.banCount} bans)`,
     )
+  }
+
+  sendBanMessage(socket: net.Socket): void {
+    if (!socket.remoteAddress) {
+      return
+    }
+
+    const ban = this.bannedByIp.get(socket.remoteAddress)
+
+    if (!ban) {
+      return
+    }
+
+    this.server.send(socket, 'mining.disconnect', {
+      reason: ban.reason,
+      versionExpected: ban.versionExpected,
+      bannedUntil: ban.until,
+      message: ban.message,
+    })
   }
 
   isShadowBanned(client: StratumServerClient): boolean {
@@ -119,12 +148,13 @@ export class StratumPeers {
       return false
     }
 
-    const bannedUntil = this.bannedByIp.get(socket.remoteAddress)
-    if (!bannedUntil) {
+    const ban = this.bannedByIp.get(socket.remoteAddress)
+
+    if (!ban?.until) {
       return false
     }
 
-    return bannedUntil > Date.now()
+    return ban.until > Date.now()
   }
 
   isAllowed(socket: net.Socket): boolean {

--- a/ironfish/src/mining/stratum/stratumPeers.ts
+++ b/ironfish/src/mining/stratum/stratumPeers.ts
@@ -93,7 +93,7 @@ export class StratumPeers {
     this.scoreByIp.delete(client.remoteAddress)
     this.banCount++
 
-    this.server.send(client, 'mining.disconnect', {
+    this.server.send(client.socket, 'mining.disconnect', {
       reason: options?.reason ?? DisconnectReason.UNKNOWN,
       versionExpected: options?.versionExpected,
       bannedUntil: until,

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -210,11 +210,15 @@ export class StratumServer {
 
           this.logger.info(`Miner ${idHex} connected (${this.clients.size} total)`)
 
-          this.send(client, 'mining.subscribed', { clientId: client.id, graffiti: graffiti })
-          this.send(client, 'mining.set_target', this.getSetTargetMessage())
+          this.send(client.socket, 'mining.subscribed', {
+            clientId: client.id,
+            graffiti: graffiti,
+          })
+
+          this.send(client.socket, 'mining.set_target', this.getSetTargetMessage())
 
           if (this.hasWork()) {
-            this.send(client, 'mining.notify', this.getNotifyMessage())
+            this.send(client.socket, 'mining.notify', this.getNotifyMessage())
           }
 
           break
@@ -318,24 +322,12 @@ export class StratumServer {
     })
   }
 
-  send(client: StratumServerClient, method: 'mining.notify', body: MiningNotifyMessage): void
-  send(
-    client: StratumServerClient,
-    method: 'mining.disconnect',
-    body: MiningDisconnectMessage,
-  ): void
-  send(
-    client: StratumServerClient,
-    method: 'mining.set_target',
-    body: MiningSetTargetMessage,
-  ): void
-  send(
-    client: StratumServerClient,
-    method: 'mining.subscribed',
-    body: MiningSubscribedMessage,
-  ): void
-  send(client: StratumServerClient, method: 'mining.wait_for_work'): void
-  send(client: StratumServerClient, method: string, body?: unknown): void {
+  send(socket: net.Socket, method: 'mining.notify', body: MiningNotifyMessage): void
+  send(socket: net.Socket, method: 'mining.disconnect', body: MiningDisconnectMessage): void
+  send(socket: net.Socket, method: 'mining.set_target', body: MiningSetTargetMessage): void
+  send(socket: net.Socket, method: 'mining.subscribed', body: MiningSubscribedMessage): void
+  send(socket: net.Socket, method: 'mining.wait_for_work'): void
+  send(socket: net.Socket, method: string, body?: unknown): void {
     const message: StratumMessage = {
       id: this.nextMessageId++,
       method: method,
@@ -343,6 +335,6 @@ export class StratumServer {
     }
 
     const serialized = JSON.stringify(message) + '\n'
-    client.socket.write(serialized)
+    socket.write(serialized)
   }
 }

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -112,6 +112,10 @@ export class StratumServer {
 
   private onConnection(socket: net.Socket): void {
     if (!this.peers.isAllowed(socket)) {
+      if (this.peers.isBanned(socket)) {
+        this.peers.sendBanMessage(socket)
+      }
+
       socket.destroy()
       return
     }


### PR DESCRIPTION
## Summary

When a stratum client is banned and reconnects, resend the ban so they know whey they are rejected. This uses more bandwidth during a DDOS attack but I think the usability improvement is ok. It's split into 2 commits, one is refactoring the send() method to take a socket so we can send data to sockets that aren't fully connected into clients.

## Testing Plan

I throw this into the subscribe call...

```javascript
if (Math.random() > 0.33) {
  this.peers.ban(client, {
    message: `Invalid public address: ${client.publicAddress}`,
  })
  return
}
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
