### PR TITLE
Telemetry for network bandwidth usage per message type

### DIFF
--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -4,6 +4,7 @@
 
 import os from 'os'
 import { createRootLogger, Logger } from '../logger'
+import { NetworkMessageType, NetworkMessageTypeList } from '../network/types'
 import { SetIntervalToken } from '../utils'
 import { Gauge } from './gauge'
 import { Meter } from './meter'
@@ -19,6 +20,8 @@ export class MetricsMonitor {
   readonly p2p_OutboundTraffic: Meter
   readonly p2p_OutboundTraffic_WS: Meter
   readonly p2p_OutboundTraffic_WebRTC: Meter
+  readonly p2p_InboundTrafficByMessage: Map<NetworkMessageType, Meter> = new Map()
+  readonly p2p_OutboundTrafficByMessage: Map<NetworkMessageType, Meter> = new Map()
   readonly p2p_PeersCount: Gauge
 
   readonly heapTotal: Gauge
@@ -40,6 +43,12 @@ export class MetricsMonitor {
     this.p2p_OutboundTraffic = this.addMeter()
     this.p2p_OutboundTraffic_WS = this.addMeter()
     this.p2p_OutboundTraffic_WebRTC = this.addMeter()
+
+    for (const value of NetworkMessageTypeList) {
+      this.p2p_InboundTrafficByMessage.set(value, this.addMeter())
+      this.p2p_OutboundTrafficByMessage.set(value, this.addMeter())
+    }
+
     this.p2p_PeersCount = new Gauge()
 
     this.heapTotal = new Gauge()

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -4,8 +4,8 @@
 
 import os from 'os'
 import { createRootLogger, Logger } from '../logger'
-import { NetworkMessageType, NetworkMessageTypeList } from '../network/types'
-import { SetIntervalToken } from '../utils'
+import { NetworkMessageType } from '../network/types'
+import { NumberEnumUtils, SetIntervalToken } from '../utils'
 import { Gauge } from './gauge'
 import { Meter } from './meter'
 
@@ -44,7 +44,7 @@ export class MetricsMonitor {
     this.p2p_OutboundTraffic_WS = this.addMeter()
     this.p2p_OutboundTraffic_WebRTC = this.addMeter()
 
-    for (const value of NetworkMessageTypeList) {
+    for (const value of NumberEnumUtils.getNumValues(NetworkMessageType)) {
       this.p2p_InboundTrafficByMessage.set(value, this.addMeter())
       this.p2p_OutboundTrafficByMessage.set(value, this.addMeter())
     }

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -151,6 +151,7 @@ export class WebRtcConnection extends Connection {
         this.close(error)
         return
       }
+      this.metrics?.p2p_InboundTrafficByMessage.get(message.type)?.add(byteCount)
 
       if (this.shouldLogMessageType(message.type)) {
         this.logger.debug(
@@ -239,6 +240,7 @@ export class WebRtcConnection extends Connection {
     const byteCount = data.byteLength
     this.metrics?.p2p_OutboundTraffic.add(byteCount)
     this.metrics?.p2p_OutboundTraffic_WebRTC.add(byteCount)
+    this.metrics?.p2p_OutboundTrafficByMessage.get(message.type)?.add(byteCount)
 
     return true
   }

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -87,9 +87,9 @@ export class WebSocketConnection extends Connection {
       }
 
       let message
+      const byteCount = event.data.byteLength
       try {
         message = parseNetworkMessage(event.data)
-        const byteCount = event.data.byteLength
         this.metrics?.p2p_InboundTraffic.add(byteCount)
         this.metrics?.p2p_InboundTraffic_WS.add(byteCount)
       } catch (error) {
@@ -101,6 +101,8 @@ export class WebSocketConnection extends Connection {
         this.close(new NetworkError(message))
         return
       }
+
+      this.metrics?.p2p_InboundTrafficByMessage.get(message.type)?.add(byteCount)
 
       if (this.shouldLogMessageType(message.type)) {
         this.logger.debug(
@@ -136,6 +138,7 @@ export class WebSocketConnection extends Connection {
     const byteCount = data.byteLength
     this.metrics?.p2p_OutboundTraffic.add(byteCount)
     this.metrics?.p2p_OutboundTraffic_WS.add(byteCount)
+    this.metrics?.p2p_OutboundTrafficByMessage.get(message.type)?.add(byteCount)
 
     return true
   }

--- a/ironfish/src/network/types.ts
+++ b/ironfish/src/network/types.ts
@@ -20,12 +20,6 @@ export enum NetworkMessageType {
   SignalRequest = 12,
 }
 
-// Enums contain bi-directional mappings so filter out duplicate enum keys
-// This is used for some cases where we need to do some action for each message type
-export const NetworkMessageTypeList = Object.keys(NetworkMessageType)
-  .map((k) => parseInt(k))
-  .filter((k) => !isNaN(k))
-
 export type IsomorphicWebSocketConstructor = typeof WebSocket | typeof WSWebSocket
 export type IsomorphicWebSocket = WebSocket | WSWebSocket
 export type IsomorphicWebSocketErrorEvent = WSErrorEvent

--- a/ironfish/src/network/types.ts
+++ b/ironfish/src/network/types.ts
@@ -20,6 +20,12 @@ export enum NetworkMessageType {
   SignalRequest = 12,
 }
 
+// Enums contain bi-directional mappings so filter out duplicate enum keys
+// This is used for some cases where we need to do some action for each message type
+export const NetworkMessageTypeList = Object.keys(NetworkMessageType)
+  .map((k) => parseInt(k))
+  .filter((k) => !isNaN(k))
+
 export type IsomorphicWebSocketConstructor = typeof WebSocket | typeof WSWebSocket
 export type IsomorphicWebSocket = WebSocket | WSWebSocket
 export type IsomorphicWebSocketErrorEvent = WSErrorEvent

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -144,6 +144,12 @@ export class Telemetry {
     this.submit({
       measurement: 'node_stats',
       timestamp: new Date(),
+      tags: [
+        {
+          name: 'synced',
+          value: this.chain.synced.toString(),
+        },
+      ],
       fields: [
         {
           name: 'heap_used',

--- a/ironfish/src/utils/enums.ts
+++ b/ironfish/src/utils/enums.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { isNumber } from 'lodash'
+
 export type StrEnumValue<T> = T[keyof T]
 export type StrEnum<T> = Record<keyof T, string>
 
@@ -20,5 +22,17 @@ export class StrEnumUtils {
     }
 
     return false
+  }
+}
+
+export type NumEnum<T> = Record<keyof T, string | number>
+
+export class NumberEnumUtils {
+  /* Return all the possible values of a number enum e.g
+   * enum E1 = { A, B, C} getNumValues(E1) --> [0, 1, 2]
+   * enum E2 = { A = 1, B = 2, C = 3} getNumValues(E2) --> [1, 2, 3]
+   */
+  static getNumValues<T extends NumEnum<T>>(enumType: T): Array<number> {
+    return Object.values(enumType).filter(isNumber)
   }
 }


### PR DESCRIPTION
## Summary
As part of transaction gossip we want to see how much bandwidth we are using to send and received transaction messages. We could combine this work by just adding telemetry metrics for every message type. 

## Testing Plan
Tested on local node

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
