### PR TITLE
Add witness hash method to transactions

### DIFF
--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -83,7 +83,7 @@ describe('Accounts', () => {
     })
 
     // Check that it was last broadcast at its added height
-    let invalidTxEntry = nodeA.accounts['transactionMap'].get(invalidTx.hash())
+    let invalidTxEntry = nodeA.accounts['transactionMap'].get(invalidTx.unsignedHash())
     expect(invalidTxEntry?.submittedSequence).toEqual(GENESIS_BLOCK_SEQUENCE)
 
     // Check that the TX is not rebroadcast but has it's sequence updated
@@ -94,7 +94,7 @@ describe('Accounts', () => {
     expect(broadcastSpy).toHaveBeenCalledTimes(0)
 
     // It should now be planned to be processed at head + 1
-    invalidTxEntry = nodeA.accounts['transactionMap'].get(invalidTx.hash())
+    invalidTxEntry = nodeA.accounts['transactionMap'].get(invalidTx.unsignedHash())
     expect(invalidTxEntry?.submittedSequence).toEqual(blockB2.header.sequence)
   }, 120000)
 

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -435,7 +435,7 @@ export class Accounts {
 
       return this.db.database.transaction(async (tx) => {
         if (notes.length > 0) {
-          const transactionHash = transaction.hash()
+          const transactionHash = transaction.unsignedHash()
 
           const existingT = this.transactionMap.get(transactionHash)
           // If we passed in a submittedSequence, set submittedSequence to that value.
@@ -513,7 +513,7 @@ export class Accounts {
    * the related maps.
    */
   async removeTransaction(transaction: Transaction): Promise<void> {
-    const transactionHash = transaction.hash()
+    const transactionHash = transaction.unsignedHash()
 
     await this.db.database.transaction(async (tx) => {
       await this.updateTransactionMap(transactionHash, null, tx)
@@ -649,7 +649,7 @@ export class Accounts {
             spender,
             amount: Number(decryptedNote.value()),
             memo: decryptedNote.memo().replace(/\x00/g, ''),
-            noteTxHash: transaction.hash().toString('hex'),
+            noteTxHash: transaction.unsignedHash().toString('hex'),
           })
         }
       }
@@ -1067,7 +1067,7 @@ export class Accounts {
             transactionMapValue.blockHash && transactionMapValue.submittedSequence
               ? 'completed'
               : 'pending',
-          hash: transaction.hash().toString('hex'),
+          hash: transaction.unsignedHash().toString('hex'),
           isMinersFee: transaction.isMinersFee(),
           fee: Number(transaction.fee()),
           notes: transaction.notesLength(),
@@ -1106,7 +1106,7 @@ export class Accounts {
     if (transactionMapValue) {
       const transaction = transactionMapValue.transaction
 
-      if (transaction.hash().toString('hex') === hash) {
+      if (transaction.unsignedHash().toString('hex') === hash) {
         for (const note of transaction.notes()) {
           // Try decrypting the note as the owner
           let decryptedNote = note.decryptNoteForOwner(account.incomingViewKey)

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -214,7 +214,7 @@ describe('MemPool', () => {
 
         await memPool.acceptTransaction(transaction)
 
-        const hash = transaction.hash()
+        const hash = transaction.unsignedHash()
         expect(add).toHaveBeenCalledTimes(1)
         expect(add).toHaveBeenCalledWith({ fee: transaction.fee(), hash })
         expect(set).toHaveBeenCalledTimes(1)
@@ -291,8 +291,8 @@ describe('MemPool', () => {
         accountB,
         accountA,
       )
-      const hashA = transactionA.hash()
-      const hashB = transactionB.hash()
+      const hashA = transactionA.unsignedHash()
+      const hashB = transactionB.unsignedHash()
 
       await memPool.acceptTransaction(transactionA)
       await memPool.acceptTransaction(transactionB)
@@ -328,11 +328,11 @@ describe('MemPool', () => {
 
       await chain.removeBlock(block.header.hash)
 
-      const hash = transaction.hash()
+      const hash = transaction.unsignedHash()
       expect(transactions.get(hash)).not.toBeUndefined()
       expect(add).toHaveBeenCalledWith({ fee: transaction.fee(), hash })
 
-      const minersHash = minersFee.hash()
+      const minersHash = minersFee.unsignedHash()
       expect(transactions.get(minersHash)).toBeUndefined()
       expect(add).not.toHaveBeenCalledWith({
         fee: block.minersFee.fee(),

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -80,7 +80,7 @@ export class MemPool {
    * Accepts a transaction from the network
    */
   async acceptTransaction(transaction: Transaction, shouldVerify = true): Promise<boolean> {
-    const hash = transaction.hash()
+    const hash = transaction.unsignedHash()
     const sequence = transaction.expirationSequence()
 
     if (this.exists(hash)) {
@@ -170,7 +170,7 @@ export class MemPool {
     let addedTransactions = 0
 
     for (const transaction of block.transactions) {
-      const hash = transaction.hash()
+      const hash = transaction.unsignedHash()
 
       if (this.transactions.has(hash)) {
         continue
@@ -190,7 +190,7 @@ export class MemPool {
   }
 
   private addTransaction(transaction: Transaction): void {
-    const hash = transaction.hash()
+    const hash = transaction.unsignedHash()
     this.transactions.set(hash, transaction)
 
     for (const spend of transaction.spends()) {
@@ -202,7 +202,7 @@ export class MemPool {
   }
 
   private deleteTransaction(transaction: Transaction): boolean {
-    const hash = transaction.hash()
+    const hash = transaction.unsignedHash()
     this.transactions.delete(hash)
 
     for (const spend of transaction.spends()) {

--- a/ironfish/src/mining/manager.test.ts
+++ b/ironfish/src/mining/manager.test.ts
@@ -37,7 +37,7 @@ describe('Mining manager', () => {
     let results = (await miningManager.getNewBlockTransactions(chain.head.sequence + 1))
       .blockTransactions
     expect(results).toHaveLength(1)
-    expect(results[0].hash().equals(transaction.hash())).toBe(true)
+    expect(results[0].unsignedHash().equals(transaction.unsignedHash())).toBe(true)
 
     // It shouldn't be returned after 1 more block is added
     const block2 = await useMinerBlockFixture(chain)

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -705,7 +705,7 @@ export class PeerNetwork {
     if (!valid) {
       Assert.isNotUndefined(reason)
       this.logger.debug(
-        `Invalid transaction '${transaction.hash().toString('hex')}': ${reason}`,
+        `Invalid transaction '${transaction.unsignedHash().toString('hex')}': ${reason}`,
       )
       return false
     }
@@ -717,7 +717,7 @@ export class PeerNetwork {
     // If we know the mempool already has this transaction, we know that
     // the mempool won't accept it, but it is still a valid transaction
     // so we want to gossip it.
-    if (this.node.memPool.exists(transaction.hash())) {
+    if (this.node.memPool.exists(transaction.unsignedHash())) {
       return true
     }
 

--- a/ironfish/src/primitives/transaction.test.slow.ts
+++ b/ironfish/src/primitives/transaction.test.slow.ts
@@ -21,8 +21,8 @@ describe('Accounts', () => {
       account.spendingKey,
     )
 
-    const hashA = transactionA.hash()
-    const hashB = transactionB.hash()
+    const hashA = transactionA.unsignedHash()
+    const hashB = transactionB.unsignedHash()
 
     expect(hashA.equals(hashB)).toBe(false)
   }, 600000)

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { TransactionPosted } from '@ironfish/rust-nodejs'
+import { blake3 } from '@napi-rs/blake-hash'
 import bufio from 'bufio'
 import { Serde } from '../serde'
 import { NoteEncrypted } from './noteEncrypted'
@@ -180,6 +181,14 @@ export class Transaction {
    */
   hash(): TransactionHash {
     return this.withReference((t) => t.hash())
+  }
+
+  /**
+   * Genereate the hash of a transaction that includes the witness (signature) data.
+   * Used for cases where a signature needs to be commited to in the hash like P2P transaction gossip
+   */
+  witnessHash(): TransactionHash {
+    return blake3(this.transactionPostedSerialized)
   }
 
   equals(other: Transaction): boolean {

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -177,9 +177,10 @@ export class Transaction {
   }
 
   /**
-   * Get the transaction hash.
+   * Get the transaction hash that does not include the signature. This is the hash that
+   * that is signed by transaction creator
    */
-  hash(): TransactionHash {
+  unsignedHash(): TransactionHash {
     return this.withReference((t) => t.hash())
   }
 
@@ -187,7 +188,7 @@ export class Transaction {
    * Genereate the hash of a transaction that includes the witness (signature) data.
    * Used for cases where a signature needs to be commited to in the hash like P2P transaction gossip
    */
-  witnessHash(): TransactionHash {
+  hash(): TransactionHash {
     return blake3(this.transactionPostedSerialized)
   }
 

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -178,7 +178,7 @@ export class Transaction {
 
   /**
    * Get the transaction hash that does not include the signature. This is the hash that
-   * that is signed by transaction creator
+   * is signed when the transaction is created
    */
   unsignedHash(): TransactionHash {
     return this.withReference((t) => t.hash())

--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -115,7 +115,7 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
       const transactions = block.transactions.map((transaction) => {
         return transaction.withReference(() => {
           return {
-            hash: BlockHashSerdeInstance.serialize(transaction.hash()),
+            hash: BlockHashSerdeInstance.serialize(transaction.unsignedHash()),
             size: Buffer.from(
               JSON.stringify(node.strategy.transactionSerde.serialize(transaction)),
             ).byteLength,

--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -175,7 +175,7 @@ router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
 
       return {
         transaction_identifier: {
-          hash: BlockHashSerdeInstance.serialize(transaction.hash()),
+          hash: BlockHashSerdeInstance.serialize(transaction.unsignedHash()),
         },
         operations: [],
         metadata: {

--- a/ironfish/src/rpc/routes/chain/getBlockInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getBlockInfo.ts
@@ -129,7 +129,7 @@ router.register<typeof GetBlockInfoRequestSchema, GetBlockInfoResponse>(
 
       transactions.push({
         signature: tx.transactionSignature().toString('hex'),
-        hash: tx.hash().toString('hex'),
+        hash: tx.unsignedHash().toString('hex'),
         fee: fee.toString(),
         spends: tx.spendsLength(),
         notes: tx.notesLength(),

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -124,7 +124,7 @@ router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
 
         if (notes.length) {
           transactions.push({
-            hash: tx.hash().toString('hex'),
+            hash: tx.unsignedHash().toString('hex'),
             isMinersFee: tx.isMinersFee(),
             notes: notes,
           })

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -117,7 +117,7 @@ describe('Transactions sendTransaction', () => {
     })
 
     const result = await routeTest.client.sendTransaction(TEST_PARAMS)
-    expect(result.content.hash).toEqual(tx.hash().toString('hex'))
+    expect(result.content.hash).toEqual(tx.unsignedHash().toString('hex'))
   }, 30000)
 
   it('calls the pay method on the node with multiple recipient', async () => {
@@ -134,7 +134,7 @@ describe('Transactions sendTransaction', () => {
     })
 
     const result = await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
-    expect(result.content.hash).toEqual(tx.hash().toString('hex'))
+    expect(result.content.hash).toEqual(tx.unsignedHash().toString('hex'))
   }, 30000)
 
   it('lets you configure the expiration', async () => {

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.ts
@@ -133,7 +133,7 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
     request.end({
       receives: transaction.receives,
       fromAccountName: account.name,
-      hash: transactionPosted.hash().toString('hex'),
+      hash: transactionPosted.unsignedHash().toString('hex'),
     })
   },
 )

--- a/ironfish/src/testUtilities/mocks.ts
+++ b/ironfish/src/testUtilities/mocks.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 export function mockTransaction(): any {
-  return { hash: jest.fn().mockReturnValue(Buffer.alloc(32, 'test')) }
+  return { unsignedHash: jest.fn().mockReturnValue(Buffer.alloc(32, 'test')) }
 }
 
 export function mockEvent(): any {


### PR DESCRIPTION
## Summary
For P2P transaction gossip we need a hash of the transaction that commits to the witness (signature). We will use this hash to record which transactions have been gossiped to which peers. Zcash's [ZIP-239](https://zips.z.cash/zip-0239#motivation) provides a good explanation of this need and how using a hash that does not commit to the witness can be a security flaw for transaction gossip

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
