### PR TITLE
feat(ironfish): Store serialized notes in the accounts db

### DIFF
--- a/ironfish/src/account/database/decryptableNotes.test.ts
+++ b/ironfish/src/account/database/decryptableNotes.test.ts
@@ -1,7 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { DecryptableNotesValue, DecryptableNotesValueEncoding } from './decryptableNotes'
+import {
+  DecryptableNotesValue,
+  DecryptableNotesValueEncoding,
+  NOTE_SIZE,
+} from './decryptableNotes'
 
 describe('DecryptableNotesValueEncoding', () => {
   describe('with a null note index, nullifier hash, and transaction hash', () => {
@@ -13,6 +17,7 @@ describe('DecryptableNotesValueEncoding', () => {
         noteIndex: null,
         nullifierHash: null,
         spent: false,
+        serializedNote: Buffer.alloc(NOTE_SIZE, 1),
         transactionHash: null,
       }
       const buffer = encoder.serialize(value)
@@ -30,6 +35,7 @@ describe('DecryptableNotesValueEncoding', () => {
         spent: true,
         noteIndex: 40,
         nullifierHash: Buffer.alloc(32, 1).toString('hex'),
+        serializedNote: Buffer.alloc(NOTE_SIZE, 1),
         transactionHash: Buffer.alloc(32, 1),
       }
       const buffer = encoder.serialize(value)


### PR DESCRIPTION
## Summary

Store serialized notes that are decryptable by accounts in the node directly in the database. This enables fetching unspent notes (and computing balance) much faster. We can also remove the worker pool job.

## Testing Plan

Covered by existing unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
[ ] No
```
