### PR TITLE
Use `getAllIter()` to fetch key and value when loading accounts data

### DIFF
--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -236,14 +236,8 @@ export class AccountsDB {
   }
 
   async loadNullifierToNoteMap(map: Map<string, string>): Promise<void> {
-    for await (const nullifierToNoteKey of this.nullifierToNote.getAllKeysIter()) {
-      const value = await this.nullifierToNote.get(nullifierToNoteKey)
-
-      if (!value) {
-        throw new Error('Value must exist if key exists')
-      }
-
-      map.set(nullifierToNoteKey, value)
+    for await (const [key, value] of this.nullifierToNote.getAllIter()) {
+      map.set(key, value)
     }
   }
 
@@ -275,16 +269,8 @@ export class AccountsDB {
       { nullifierHash: string | null; noteIndex: number | null; spent: boolean }
     >,
   ): Promise<void> {
-    await this.database.transaction(async (tx) => {
-      for await (const noteHash of this.decryptableNotes.getAllKeysIter(tx)) {
-        const value = await this.decryptableNotes.get(noteHash)
-
-        if (!value) {
-          throw new Error('Value must exist if key exists')
-        }
-
-        map.set(noteHash, value)
-      }
-    })
+    for await (const [key, value] of this.decryptableNotes.getAllIter()) {
+      map.set(key, value)
+    }
   }
 }


### PR DESCRIPTION
## Summary

Compared timing of `loadTransactionsFromDb` in `accounts.ts` with the ~100k note/transaction datadir:
Before: ~4300ms
After: ~1900ms

Closes IRO-2255

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
