### PR TITLE
feat(ironfish): Move note decryption when syncing transactions to worker pool

### DIFF
--- a/ironfish/src/account/account.ts
+++ b/ironfish/src/account/account.ts
@@ -5,6 +5,8 @@
 import MurmurHash3 from 'imurmurhash'
 import { AccountsValue } from './database/accounts'
 
+export const ACCOUNT_KEY_LENGTH = 32
+
 export class Account {
   readonly displayName: string
   name: string

--- a/ironfish/src/account/accounts.test.slow.ts
+++ b/ironfish/src/account/accounts.test.slow.ts
@@ -17,13 +17,15 @@ describe('Accounts', () => {
   let targetMeetsSpy: jest.SpyInstance
   let targetSpy: jest.SpyInstance
 
-  beforeAll(() => {
+  beforeAll(async () => {
     targetMeetsSpy = jest.spyOn(Target, 'meets').mockImplementation(() => true)
-
     targetSpy = jest.spyOn(Target, 'calculateTarget').mockImplementation(acceptsAllTarget)
+
+    await nodeTest.setup()
+    nodeTest.workerPool.start()
   })
 
-  afterEach(async () => {
+  afterAll(async () => {
     await nodeTest.node.workerPool.stop()
   })
 
@@ -198,7 +200,6 @@ describe('Accounts', () => {
     const strategy = nodeTest.strategy
     const node = nodeTest.node
     const chain = nodeTest.chain
-    node.accounts['workerPool'].start()
 
     const account = await node.accounts.createAccount('test', true)
 
@@ -270,7 +271,6 @@ describe('Accounts', () => {
     const strategy = nodeTest.strategy
     const node = nodeTest.node
     const chain = nodeTest.chain
-    node.accounts['workerPool'].start()
 
     const account = await node.accounts.createAccount('test', true)
 
@@ -348,8 +348,6 @@ describe('Accounts', () => {
 
   it('throws a ValidationError with an invalid expiration sequence', async () => {
     const node = nodeTest.node
-    node.accounts['workerPool'].start()
-
     const account = await node.accounts.createAccount('test', true)
 
     // Spend the balance with an invalid expiration

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -383,6 +383,7 @@ export class Accounts {
           account.spendingKey,
           currentNoteIndex,
         )
+
         if (decryptedNote) {
           notes.push({
             account,

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -382,17 +382,21 @@ export class Accounts {
         }
 
         if (decryptNotesPayloads.length >= batchSize) {
-          decryptedNotes.concat(
-            await this.decryptNotesFromTransaction(account, decryptNotesPayloads),
+          const decryptedNotesBatch = await this.decryptNotesFromTransaction(
+            account,
+            decryptNotesPayloads,
           )
+          decryptedNotes.push(...decryptedNotesBatch)
           decryptNotesPayloads = []
         }
       }
 
       if (decryptNotesPayloads.length) {
-        decryptedNotes.concat(
-          await this.decryptNotesFromTransaction(account, decryptNotesPayloads),
+        const decryptedNotesBatch = await this.decryptNotesFromTransaction(
+          account,
+          decryptNotesPayloads,
         )
+        decryptedNotes.push(...decryptedNotesBatch)
       }
     }
 

--- a/ironfish/src/common/constants.ts
+++ b/ironfish/src/common/constants.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export const KEY_LENGTH = 32
+export const NOTE_LENGTH = 43 + 8 + 32 + 32

--- a/ironfish/src/common/constants.ts
+++ b/ironfish/src/common/constants.ts
@@ -1,6 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export const ENCRYPTED_NOTE_LENGTH = 32 + 32 + 32 + 83 + 16 + 64 + 16
-export const KEY_LENGTH = 32
-export const NOTE_LENGTH = 43 + 8 + 32 + 32

--- a/ironfish/src/common/constants.ts
+++ b/ironfish/src/common/constants.ts
@@ -1,5 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export const ENCRYPTED_NOTE_LENGTH = 32 + 32 + 32 + 83 + 16 + 64 + 16
 export const KEY_LENGTH = 32
 export const NOTE_LENGTH = 43 + 8 + 32 + 32

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -5,6 +5,8 @@
 import { Note as NativeNote } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
 
+export const NOTE_LENGTH = 43 + 8 + 32 + 32
+
 export class Note {
   private readonly noteSerialized: Buffer
   private note: NativeNote | null = null

--- a/ironfish/src/primitives/noteEncrypted.ts
+++ b/ironfish/src/primitives/noteEncrypted.ts
@@ -7,6 +7,8 @@ import bufio from 'bufio'
 import { Serde } from '../serde'
 import { Note } from './note'
 
+export const ENCRYPTED_NOTE_LENGTH = 32 + 32 + 32 + 83 + 16 + 64 + 16
+
 export type NoteEncryptedHash = Buffer
 export type SerializedNoteEncryptedHash = Buffer
 export type SerializedNoteEncrypted = Buffer

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -17,7 +17,12 @@ import { RoundRobinQueue } from './roundrobinqueue'
 import { BoxMessageRequest, BoxMessageResponse } from './tasks/boxMessage'
 import { CreateMinersFeeRequest, CreateMinersFeeResponse } from './tasks/createMinersFee'
 import { CreateTransactionRequest, CreateTransactionResponse } from './tasks/createTransaction'
-import { DecryptedNote, DecryptNotesRequest, DecryptNotesResponse } from './tasks/decryptNotes'
+import {
+  DecryptedNote,
+  DecryptNoteOptions,
+  DecryptNotesRequest,
+  DecryptNotesResponse,
+} from './tasks/decryptNotes'
 import { GetUnspentNotesRequest, GetUnspentNotesResponse } from './tasks/getUnspentNotes'
 import { SleepRequest } from './tasks/sleep'
 import { SubmitTelemetryRequest } from './tasks/submitTelemetry'
@@ -227,27 +232,15 @@ export class WorkerPool {
     return response
   }
 
-  async decryptNotes(
-    serializedNote: Buffer,
-    incomingViewKey: string,
-    outgoingViewKey: string,
-    spendingKey: string,
-    currentNoteIndex: number | null,
-  ): Promise<DecryptedNote | null> {
-    const request = new DecryptNotesRequest(
-      serializedNote,
-      incomingViewKey,
-      outgoingViewKey,
-      spendingKey,
-      currentNoteIndex,
-    )
+  async decryptNotes(payloads: DecryptNoteOptions[]): Promise<Array<DecryptedNote | null>> {
+    const request = new DecryptNotesRequest(payloads)
 
     const response = await this.execute(request).result()
     if (!(response instanceof DecryptNotesResponse)) {
       throw new Error('Invalid response')
     }
 
-    return response.note
+    return response.notes
   }
 
   async getUnspentNotes(

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -17,6 +17,7 @@ import { RoundRobinQueue } from './roundrobinqueue'
 import { BoxMessageRequest, BoxMessageResponse } from './tasks/boxMessage'
 import { CreateMinersFeeRequest, CreateMinersFeeResponse } from './tasks/createMinersFee'
 import { CreateTransactionRequest, CreateTransactionResponse } from './tasks/createTransaction'
+import { DecryptedNote, DecryptNotesRequest, DecryptNotesResponse } from './tasks/decryptNotes'
 import { GetUnspentNotesRequest, GetUnspentNotesResponse } from './tasks/getUnspentNotes'
 import { SleepRequest } from './tasks/sleep'
 import { SubmitTelemetryRequest } from './tasks/submitTelemetry'
@@ -49,6 +50,7 @@ export class WorkerPool {
     [WorkerMessageType.BoxMessage, { complete: 0, error: 0, queue: 0, execute: 0 }],
     [WorkerMessageType.CreateMinersFee, { complete: 0, error: 0, queue: 0, execute: 0 }],
     [WorkerMessageType.CreateTransaction, { complete: 0, error: 0, queue: 0, execute: 0 }],
+    [WorkerMessageType.DecryptNotes, { complete: 0, error: 0, queue: 0, execute: 0 }],
     [WorkerMessageType.GetUnspentNotes, { complete: 0, error: 0, queue: 0, execute: 0 }],
     [WorkerMessageType.JobAborted, { complete: 0, error: 0, queue: 0, execute: 0 }],
     [WorkerMessageType.Sleep, { complete: 0, error: 0, queue: 0, execute: 0 }],
@@ -223,6 +225,29 @@ export class WorkerPool {
     }
 
     return response
+  }
+
+  async decryptNotes(
+    serializedNote: Buffer,
+    incomingViewKey: string,
+    outgoingViewKey: string,
+    spendingKey: string,
+    currentNoteIndex: number | null,
+  ): Promise<DecryptedNote | null> {
+    const request = new DecryptNotesRequest(
+      serializedNote,
+      incomingViewKey,
+      outgoingViewKey,
+      spendingKey,
+      currentNoteIndex,
+    )
+
+    const response = await this.execute(request).result()
+    if (!(response instanceof DecryptNotesResponse)) {
+      throw new Error('Invalid response')
+    }
+
+    return response.note
   }
 
   async getUnspentNotes(

--- a/ironfish/src/workerPool/tasks/__fixtures__/decryptNotes.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/decryptNotes.test.ts.fixture
@@ -1,0 +1,17 @@
+{
+  "DecryptNotesTask execute posts the miners fee transaction": [
+    {
+      "name": "test",
+      "spendingKey": "7e4311d2d61fe05587816d10193c60e98b2085dfb0ecbdb42639e09f7811d48f",
+      "incomingViewKey": "4b418a76a156199bc160a6d0b4c647177f2535a96cdf57e5fa3f24963ed80203",
+      "outgoingViewKey": "82c5d61ff38c3c651200e8610016683d4cc3a37eec533c11810d6e13f1754099",
+      "publicAddress": "433c13f7f1a89a2dbcc0e9a4c16ee89dfc80050a5a7abe4ff78308a2317ca9645cc344b9e77f82f44bdfab",
+      "rescan": null,
+      "displayName": "test (e18c3e4)"
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKxFAxjseyN6tbSvSA1vpDAS7hqhvxkJXUCIIR19E6jZW2X5zBWk9tRvqo8oBcCfBpncqwMSReNVwfa2B16FY7wlWeotVuiitIAStwgvZQui7YpY/DP9E+zP1L/eWEK3axbLD7CdgHNnHfYlg46+H77B1wns/7SPSMgN72pFK7Z9wWea5qd4ewfAouVGPlKcY4XBGAFVViy/fxSygO3PAdmdHRd0Dj4+sBJnes47aKIbVWkSo2q83zLIMXRazcs5zoPIGgFGo3Gk5MoDVw7hyIHvI8g68uiwd25iYsaoDERxWKudu7GJLhR/Ngz/CHSCKWmE/mBBnc90gexUQA+STWcz6JlySpFECW58DfXFqcoYADGyzipIAWeYzF12aX0In1XiCUy6uhIXBypivn7kDYRdHcuIVmTDGCNGN+u45eaOCTaSWuWJ6PB5uG5tn85ZPQxBfR0yagKx1yVrxkEIuJNU71Cr6hY0iJ6L+g74f2IlyeOjGUWEhyF0gh59RGU6jsPzbEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnrNSQFABAWtSbSfXnM/U6b7bZ6Alcp93UXzhSv3rdr52sS0AR2uyLi69PQbx8jtU6IroaSbQm+lXqIbhujOfBg=="
+    }
+  ]
+}

--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -1,14 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { KEY_LENGTH, NOTE_LENGTH } from '../../common/constants'
+import { ENCRYPTED_NOTE_LENGTH, KEY_LENGTH, NOTE_LENGTH } from '../../common/constants'
 import { createNodeTest, useAccountFixture, useMinersTxFixture } from '../../testUtilities'
 import { DecryptNotesRequest, DecryptNotesResponse, DecryptNotesTask } from './decryptNotes'
 
 describe('DecryptNotesRequest', () => {
   it('serializes the object to a buffer and deserializes to the original object', () => {
     const request = new DecryptNotesRequest(
-      Buffer.alloc(NOTE_LENGTH, 1),
+      Buffer.alloc(ENCRYPTED_NOTE_LENGTH, 1),
       Buffer.alloc(KEY_LENGTH, 1).toString('hex'),
       Buffer.alloc(KEY_LENGTH, 1).toString('hex'),
       Buffer.alloc(KEY_LENGTH, 1).toString('hex'),

--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { KEY_LENGTH, NOTE_LENGTH } from '../../common/constants'
+import { createNodeTest, useAccountFixture, useMinersTxFixture } from '../../testUtilities'
+import { DecryptNotesRequest, DecryptNotesResponse, DecryptNotesTask } from './decryptNotes'
+
+describe('DecryptNotesRequest', () => {
+  it('serializes the object to a buffer and deserializes to the original object', () => {
+    const request = new DecryptNotesRequest(
+      Buffer.alloc(NOTE_LENGTH, 1),
+      Buffer.alloc(KEY_LENGTH, 1).toString('hex'),
+      Buffer.alloc(KEY_LENGTH, 1).toString('hex'),
+      Buffer.alloc(KEY_LENGTH, 1).toString('hex'),
+      2,
+      0,
+    )
+    const buffer = request.serialize()
+    const deserializedRequest = DecryptNotesRequest.deserialize(request.jobId, buffer)
+    expect(deserializedRequest).toEqual(request)
+  })
+})
+
+describe('DecryptNotesResponse', () => {
+  it('serializes the object to a buffer and deserializes to the original object', () => {
+    const response = new DecryptNotesResponse(
+      {
+        forSpender: false,
+        index: 1,
+        merkleHash: Buffer.alloc(32, 1),
+        nullifier: Buffer.alloc(32, 1),
+        serializedNote: Buffer.alloc(NOTE_LENGTH, 1),
+      },
+      0,
+    )
+    const buffer = response.serialize()
+    const deserializedResponse = DecryptNotesResponse.deserialize(response.jobId, buffer)
+    expect(deserializedResponse).toEqual(response)
+  })
+})
+
+describe('DecryptNotesTask', () => {
+  const nodeTest = createNodeTest()
+
+  describe('execute', () => {
+    it('posts the miners fee transaction', async () => {
+      const account = await useAccountFixture(nodeTest.accounts)
+      const transaction = await useMinersTxFixture(nodeTest.accounts, account)
+
+      const task = new DecryptNotesTask()
+      const index = 2
+      const request = new DecryptNotesRequest(
+        transaction.getNote(0).serialize(),
+        account.incomingViewKey,
+        account.outgoingViewKey,
+        account.spendingKey,
+        2,
+      )
+      const response = task.execute(request)
+
+      expect(response).toMatchObject({
+        note: {
+          forSpender: false,
+          index,
+          nullifier: expect.any(Buffer),
+          merkleHash: expect.any(Buffer),
+          serializedNote: expect.any(Buffer),
+        },
+      })
+    })
+  })
+})

--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -1,18 +1,24 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ENCRYPTED_NOTE_LENGTH, KEY_LENGTH, NOTE_LENGTH } from '../../common/constants'
+import { ACCOUNT_KEY_LENGTH } from '../../account'
+import { NOTE_LENGTH } from '../../primitives/note'
+import { ENCRYPTED_NOTE_LENGTH } from '../../primitives/noteEncrypted'
 import { createNodeTest, useAccountFixture, useMinersTxFixture } from '../../testUtilities'
 import { DecryptNotesRequest, DecryptNotesResponse, DecryptNotesTask } from './decryptNotes'
 
 describe('DecryptNotesRequest', () => {
   it('serializes the object to a buffer and deserializes to the original object', () => {
     const request = new DecryptNotesRequest(
-      Buffer.alloc(ENCRYPTED_NOTE_LENGTH, 1),
-      Buffer.alloc(KEY_LENGTH, 1).toString('hex'),
-      Buffer.alloc(KEY_LENGTH, 1).toString('hex'),
-      Buffer.alloc(KEY_LENGTH, 1).toString('hex'),
-      2,
+      [
+        {
+          serializedNote: Buffer.alloc(ENCRYPTED_NOTE_LENGTH, 1),
+          incomingViewKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
+          outgoingViewKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
+          spendingKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
+          currentNoteIndex: 2,
+        },
+      ],
       0,
     )
     const buffer = request.serialize()
@@ -24,13 +30,16 @@ describe('DecryptNotesRequest', () => {
 describe('DecryptNotesResponse', () => {
   it('serializes the object to a buffer and deserializes to the original object', () => {
     const response = new DecryptNotesResponse(
-      {
-        forSpender: false,
-        index: 1,
-        merkleHash: Buffer.alloc(32, 1),
-        nullifier: Buffer.alloc(32, 1),
-        serializedNote: Buffer.alloc(NOTE_LENGTH, 1),
-      },
+      [
+        {
+          forSpender: false,
+          index: 1,
+          merkleHash: Buffer.alloc(32, 1),
+          nullifier: Buffer.alloc(32, 1),
+          serializedNote: Buffer.alloc(NOTE_LENGTH, 1),
+        },
+        null,
+      ],
       0,
     )
     const buffer = response.serialize()
@@ -49,23 +58,27 @@ describe('DecryptNotesTask', () => {
 
       const task = new DecryptNotesTask()
       const index = 2
-      const request = new DecryptNotesRequest(
-        transaction.getNote(0).serialize(),
-        account.incomingViewKey,
-        account.outgoingViewKey,
-        account.spendingKey,
-        2,
-      )
+      const request = new DecryptNotesRequest([
+        {
+          serializedNote: transaction.getNote(0).serialize(),
+          incomingViewKey: account.incomingViewKey,
+          outgoingViewKey: account.outgoingViewKey,
+          spendingKey: account.spendingKey,
+          currentNoteIndex: 2,
+        },
+      ])
       const response = task.execute(request)
 
       expect(response).toMatchObject({
-        note: {
-          forSpender: false,
-          index,
-          nullifier: expect.any(Buffer),
-          merkleHash: expect.any(Buffer),
-          serializedNote: expect.any(Buffer),
-        },
+        notes: [
+          {
+            forSpender: false,
+            index,
+            nullifier: expect.any(Buffer),
+            merkleHash: expect.any(Buffer),
+            serializedNote: expect.any(Buffer),
+          },
+        ],
       })
     })
   })

--- a/ironfish/src/workerPool/tasks/decryptNotes.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
-import { KEY_LENGTH, NOTE_LENGTH } from '../../common/constants'
+import { ENCRYPTED_NOTE_LENGTH, KEY_LENGTH, NOTE_LENGTH } from '../../common/constants'
 import { NoteEncrypted } from '../../primitives/noteEncrypted'
 import { WorkerMessage, WorkerMessageType } from './workerMessage'
 import { WorkerTask } from './workerTask'
@@ -60,7 +60,7 @@ export class DecryptNotesRequest extends WorkerMessage {
     const reader = bufio.read(buffer, true)
 
     const hasCurrentNoteIndex = Boolean(reader.readU8())
-    const serializedNote = reader.readBytes(NOTE_LENGTH)
+    const serializedNote = reader.readBytes(ENCRYPTED_NOTE_LENGTH)
     const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
     const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
     const spendingKey = reader.readBytes(KEY_LENGTH).toString('hex')
@@ -81,7 +81,7 @@ export class DecryptNotesRequest extends WorkerMessage {
   }
 
   getSize(): number {
-    let size = 1 + NOTE_LENGTH + KEY_LENGTH + KEY_LENGTH + KEY_LENGTH
+    let size = 1 + ENCRYPTED_NOTE_LENGTH + KEY_LENGTH + KEY_LENGTH + KEY_LENGTH
     if (this.currentNoteIndex) {
       size += 4
     }

--- a/ironfish/src/workerPool/tasks/decryptNotes.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.ts
@@ -1,0 +1,242 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { KEY_LENGTH, NOTE_LENGTH } from '../../common/constants'
+import { NoteEncrypted } from '../../primitives/noteEncrypted'
+import { WorkerMessage, WorkerMessageType } from './workerMessage'
+import { WorkerTask } from './workerTask'
+
+export interface DecryptedNote {
+  index: number | null
+  forSpender: boolean
+  merkleHash: Buffer
+  nullifier: Buffer | null
+  serializedNote: Buffer
+}
+
+export class DecryptNotesRequest extends WorkerMessage {
+  readonly serializedNote: Buffer
+  readonly incomingViewKey: string
+  readonly outgoingViewKey: string
+  readonly spendingKey: string
+  readonly currentNoteIndex: number | null
+
+  constructor(
+    serializedNote: Buffer,
+    incomingViewKey: string,
+    outgoingViewKey: string,
+    spendingKey: string,
+    currentNoteIndex: number | null,
+    jobId?: number,
+  ) {
+    super(WorkerMessageType.DecryptNotes, jobId)
+    this.serializedNote = serializedNote
+    this.incomingViewKey = incomingViewKey
+    this.outgoingViewKey = outgoingViewKey
+    this.spendingKey = spendingKey
+    this.currentNoteIndex = currentNoteIndex
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+
+    const hasCurrentNoteIndex = Number(!!this.currentNoteIndex)
+    bw.writeU8(hasCurrentNoteIndex)
+
+    bw.writeBytes(this.serializedNote)
+    bw.writeBytes(Buffer.from(this.incomingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(this.outgoingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(this.spendingKey, 'hex'))
+
+    if (this.currentNoteIndex) {
+      bw.writeU32(this.currentNoteIndex)
+    }
+
+    return bw.render()
+  }
+
+  static deserialize(jobId: number, buffer: Buffer): DecryptNotesRequest {
+    const reader = bufio.read(buffer, true)
+
+    const hasCurrentNoteIndex = Boolean(reader.readU8())
+    const serializedNote = reader.readBytes(NOTE_LENGTH)
+    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const spendingKey = reader.readBytes(KEY_LENGTH).toString('hex')
+
+    let currentNoteIndex = null
+    if (hasCurrentNoteIndex) {
+      currentNoteIndex = reader.readU32()
+    }
+
+    return new DecryptNotesRequest(
+      serializedNote,
+      incomingViewKey,
+      outgoingViewKey,
+      spendingKey,
+      currentNoteIndex,
+      jobId,
+    )
+  }
+
+  getSize(): number {
+    let size = 1 + NOTE_LENGTH + KEY_LENGTH + KEY_LENGTH + KEY_LENGTH
+    if (this.currentNoteIndex) {
+      size += 4
+    }
+    return size
+  }
+}
+
+export class DecryptNotesResponse extends WorkerMessage {
+  readonly note: DecryptedNote | null
+
+  constructor(note: DecryptedNote | null, jobId: number) {
+    super(WorkerMessageType.DecryptNotes, jobId)
+    this.note = note
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+
+    const hasDecryptedNote = Number(!!this.note)
+    bw.writeU8(hasDecryptedNote)
+
+    if (this.note) {
+      let flags = 0
+      flags |= Number(!!this.note.index) << 0
+      flags |= Number(!!this.note.nullifier) << 1
+      flags |= Number(this.note.forSpender)
+      bw.writeU8(flags)
+      bw.writeHash(this.note.merkleHash)
+      bw.writeBytes(this.note.serializedNote)
+
+      if (this.note.index) {
+        bw.writeU32(this.note.index)
+      }
+
+      if (this.note.nullifier) {
+        bw.writeHash(this.note.nullifier)
+      }
+    }
+
+    return bw.render()
+  }
+
+  static deserialize(jobId: number, buffer: Buffer): DecryptNotesResponse {
+    const reader = bufio.read(buffer)
+
+    const hasDecryptedNote = reader.readU8()
+    if (!hasDecryptedNote) {
+      return new DecryptNotesResponse(null, jobId)
+    }
+
+    const flags = reader.readU8()
+    const hasIndex = flags & (1 << 0)
+    const hasNullifier = flags & (1 << 1)
+    const forSpender = Boolean(flags & (1 << 2))
+    const merkleHash = reader.readHash()
+    const serializedNote = reader.readBytes(NOTE_LENGTH)
+
+    let index = null
+    if (hasIndex) {
+      index = reader.readU32()
+    }
+
+    let nullifier = null
+    if (hasNullifier) {
+      nullifier = reader.readHash()
+    }
+
+    return new DecryptNotesResponse(
+      {
+        forSpender,
+        index,
+        merkleHash,
+        nullifier,
+        serializedNote,
+      },
+      jobId,
+    )
+  }
+
+  getSize(): number {
+    let size = 1
+
+    if (this.note) {
+      size += 1 + 32 + NOTE_LENGTH
+
+      if (this.note.index) {
+        size += 4
+      }
+
+      if (this.note.nullifier) {
+        size += 32
+      }
+    }
+
+    return size
+  }
+}
+
+export class DecryptNotesTask extends WorkerTask {
+  private static instance: DecryptNotesTask | undefined
+
+  static getInstance(): DecryptNotesTask {
+    if (!DecryptNotesTask.instance) {
+      DecryptNotesTask.instance = new DecryptNotesTask()
+    }
+    return DecryptNotesTask.instance
+  }
+
+  execute({
+    serializedNote,
+    incomingViewKey,
+    outgoingViewKey,
+    spendingKey,
+    currentNoteIndex,
+    jobId,
+  }: DecryptNotesRequest): DecryptNotesResponse {
+    const note = new NoteEncrypted(serializedNote)
+
+    // Try decrypting the note as the owner
+    const receivedNote = note.decryptNoteForOwner(incomingViewKey)
+    if (receivedNote) {
+      if (receivedNote.value() !== BigInt(0)) {
+        return new DecryptNotesResponse(
+          {
+            index: currentNoteIndex,
+            forSpender: false,
+            merkleHash: note.merkleHash(),
+            nullifier:
+              currentNoteIndex !== null
+                ? receivedNote.nullifier(spendingKey, BigInt(currentNoteIndex))
+                : null,
+            serializedNote: receivedNote.serialize(),
+          },
+          jobId,
+        )
+      }
+    }
+
+    // Try decrypting the note as the spender
+    const spentNote = note.decryptNoteForSpender(outgoingViewKey)
+    if (spentNote) {
+      if (spentNote.value() !== BigInt(0)) {
+        return new DecryptNotesResponse(
+          {
+            index: currentNoteIndex,
+            forSpender: true,
+            merkleHash: note.merkleHash(),
+            nullifier: null,
+            serializedNote: spentNote.serialize(),
+          },
+          jobId,
+        )
+      }
+    }
+
+    return new DecryptNotesResponse(null, jobId)
+  }
+}

--- a/ironfish/src/workerPool/tasks/decryptNotes.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.ts
@@ -2,10 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
-import { ENCRYPTED_NOTE_LENGTH, KEY_LENGTH, NOTE_LENGTH } from '../../common/constants'
-import { NoteEncrypted } from '../../primitives/noteEncrypted'
+import { ACCOUNT_KEY_LENGTH } from '../../account'
+import { NOTE_LENGTH } from '../../primitives/note'
+import { ENCRYPTED_NOTE_LENGTH, NoteEncrypted } from '../../primitives/noteEncrypted'
 import { WorkerMessage, WorkerMessageType } from './workerMessage'
 import { WorkerTask } from './workerTask'
+
+export interface DecryptNoteOptions {
+  serializedNote: Buffer
+  incomingViewKey: string
+  outgoingViewKey: string
+  spendingKey: string
+  currentNoteIndex: number | null
+}
 
 export interface DecryptedNote {
   index: number | null
@@ -16,41 +25,29 @@ export interface DecryptedNote {
 }
 
 export class DecryptNotesRequest extends WorkerMessage {
-  readonly serializedNote: Buffer
-  readonly incomingViewKey: string
-  readonly outgoingViewKey: string
-  readonly spendingKey: string
-  readonly currentNoteIndex: number | null
+  readonly payloads: Array<DecryptNoteOptions>
 
-  constructor(
-    serializedNote: Buffer,
-    incomingViewKey: string,
-    outgoingViewKey: string,
-    spendingKey: string,
-    currentNoteIndex: number | null,
-    jobId?: number,
-  ) {
+  constructor(payloads: Array<DecryptNoteOptions>, jobId?: number) {
     super(WorkerMessageType.DecryptNotes, jobId)
-    this.serializedNote = serializedNote
-    this.incomingViewKey = incomingViewKey
-    this.outgoingViewKey = outgoingViewKey
-    this.spendingKey = spendingKey
-    this.currentNoteIndex = currentNoteIndex
+    this.payloads = payloads
   }
 
   serialize(): Buffer {
     const bw = bufio.write(this.getSize())
 
-    const hasCurrentNoteIndex = Number(!!this.currentNoteIndex)
-    bw.writeU8(hasCurrentNoteIndex)
+    bw.writeU8(this.payloads.length)
+    for (const payload of this.payloads) {
+      const hasCurrentNoteIndex = Number(!!payload.currentNoteIndex)
+      bw.writeU8(hasCurrentNoteIndex)
 
-    bw.writeBytes(this.serializedNote)
-    bw.writeBytes(Buffer.from(this.incomingViewKey, 'hex'))
-    bw.writeBytes(Buffer.from(this.outgoingViewKey, 'hex'))
-    bw.writeBytes(Buffer.from(this.spendingKey, 'hex'))
+      bw.writeBytes(payload.serializedNote)
+      bw.writeBytes(Buffer.from(payload.incomingViewKey, 'hex'))
+      bw.writeBytes(Buffer.from(payload.outgoingViewKey, 'hex'))
+      bw.writeBytes(Buffer.from(payload.spendingKey, 'hex'))
 
-    if (this.currentNoteIndex) {
-      bw.writeU32(this.currentNoteIndex)
+      if (payload.currentNoteIndex) {
+        bw.writeU32(payload.currentNoteIndex)
+      }
     }
 
     return bw.render()
@@ -58,66 +55,81 @@ export class DecryptNotesRequest extends WorkerMessage {
 
   static deserialize(jobId: number, buffer: Buffer): DecryptNotesRequest {
     const reader = bufio.read(buffer, true)
+    const payloads = []
 
-    const hasCurrentNoteIndex = Boolean(reader.readU8())
-    const serializedNote = reader.readBytes(ENCRYPTED_NOTE_LENGTH)
-    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
-    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
-    const spendingKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const length = reader.readU8()
+    for (let i = 0; i < length; i++) {
+      const hasCurrentNoteIndex = Boolean(reader.readU8())
+      const serializedNote = reader.readBytes(ENCRYPTED_NOTE_LENGTH)
+      const incomingViewKey = reader.readBytes(ACCOUNT_KEY_LENGTH).toString('hex')
+      const outgoingViewKey = reader.readBytes(ACCOUNT_KEY_LENGTH).toString('hex')
+      const spendingKey = reader.readBytes(ACCOUNT_KEY_LENGTH).toString('hex')
 
-    let currentNoteIndex = null
-    if (hasCurrentNoteIndex) {
-      currentNoteIndex = reader.readU32()
+      let currentNoteIndex = null
+      if (hasCurrentNoteIndex) {
+        currentNoteIndex = reader.readU32()
+      }
+
+      payloads.push({
+        serializedNote,
+        incomingViewKey,
+        outgoingViewKey,
+        spendingKey,
+        currentNoteIndex,
+      })
     }
 
-    return new DecryptNotesRequest(
-      serializedNote,
-      incomingViewKey,
-      outgoingViewKey,
-      spendingKey,
-      currentNoteIndex,
-      jobId,
-    )
+    return new DecryptNotesRequest(payloads, jobId)
   }
 
   getSize(): number {
-    let size = 1 + ENCRYPTED_NOTE_LENGTH + KEY_LENGTH + KEY_LENGTH + KEY_LENGTH
-    if (this.currentNoteIndex) {
-      size += 4
+    let size = 1
+    for (const payload of this.payloads) {
+      size += 1
+      size += ENCRYPTED_NOTE_LENGTH
+      size += ACCOUNT_KEY_LENGTH
+      size += ACCOUNT_KEY_LENGTH
+      size += +ACCOUNT_KEY_LENGTH
+      if (payload.currentNoteIndex) {
+        size += 4
+      }
     }
     return size
   }
 }
 
 export class DecryptNotesResponse extends WorkerMessage {
-  readonly note: DecryptedNote | null
+  readonly notes: Array<DecryptedNote | null>
 
-  constructor(note: DecryptedNote | null, jobId: number) {
+  constructor(notes: Array<DecryptedNote | null>, jobId: number) {
     super(WorkerMessageType.DecryptNotes, jobId)
-    this.note = note
+    this.notes = notes
   }
 
   serialize(): Buffer {
     const bw = bufio.write(this.getSize())
 
-    const hasDecryptedNote = Number(!!this.note)
-    bw.writeU8(hasDecryptedNote)
+    bw.writeU8(this.notes.length)
+    for (const note of this.notes) {
+      const hasDecryptedNote = Number(!!note)
+      bw.writeU8(hasDecryptedNote)
 
-    if (this.note) {
-      let flags = 0
-      flags |= Number(!!this.note.index) << 0
-      flags |= Number(!!this.note.nullifier) << 1
-      flags |= Number(this.note.forSpender)
-      bw.writeU8(flags)
-      bw.writeHash(this.note.merkleHash)
-      bw.writeBytes(this.note.serializedNote)
+      if (note) {
+        let flags = 0
+        flags |= Number(!!note.index) << 0
+        flags |= Number(!!note.nullifier) << 1
+        flags |= Number(note.forSpender) << 2
+        bw.writeU8(flags)
+        bw.writeHash(note.merkleHash)
+        bw.writeBytes(note.serializedNote)
 
-      if (this.note.index) {
-        bw.writeU32(this.note.index)
-      }
+        if (note.index) {
+          bw.writeU32(note.index)
+        }
 
-      if (this.note.nullifier) {
-        bw.writeHash(this.note.nullifier)
+        if (note.nullifier) {
+          bw.writeHash(note.nullifier)
+        }
       }
     }
 
@@ -126,53 +138,61 @@ export class DecryptNotesResponse extends WorkerMessage {
 
   static deserialize(jobId: number, buffer: Buffer): DecryptNotesResponse {
     const reader = bufio.read(buffer)
+    const notes = []
 
-    const hasDecryptedNote = reader.readU8()
-    if (!hasDecryptedNote) {
-      return new DecryptNotesResponse(null, jobId)
-    }
+    const length = reader.readU8()
+    for (let i = 0; i < length; i++) {
+      const hasDecryptedNote = reader.readU8()
+      if (!hasDecryptedNote) {
+        notes.push(null)
+        continue
+      }
 
-    const flags = reader.readU8()
-    const hasIndex = flags & (1 << 0)
-    const hasNullifier = flags & (1 << 1)
-    const forSpender = Boolean(flags & (1 << 2))
-    const merkleHash = reader.readHash()
-    const serializedNote = reader.readBytes(NOTE_LENGTH)
+      const flags = reader.readU8()
+      const hasIndex = flags & (1 << 0)
+      const hasNullifier = flags & (1 << 1)
+      const forSpender = Boolean(flags & (1 << 2))
+      const merkleHash = reader.readHash()
+      const serializedNote = reader.readBytes(NOTE_LENGTH)
 
-    let index = null
-    if (hasIndex) {
-      index = reader.readU32()
-    }
+      let index = null
+      if (hasIndex) {
+        index = reader.readU32()
+      }
 
-    let nullifier = null
-    if (hasNullifier) {
-      nullifier = reader.readHash()
-    }
+      let nullifier = null
+      if (hasNullifier) {
+        nullifier = reader.readHash()
+      }
 
-    return new DecryptNotesResponse(
-      {
+      notes.push({
         forSpender,
         index,
         merkleHash,
         nullifier,
         serializedNote,
-      },
-      jobId,
-    )
+      })
+    }
+
+    return new DecryptNotesResponse(notes, jobId)
   }
 
   getSize(): number {
     let size = 1
 
-    if (this.note) {
-      size += 1 + 32 + NOTE_LENGTH
+    for (const note of this.notes) {
+      size += 1
 
-      if (this.note.index) {
-        size += 4
-      }
+      if (note) {
+        size += 1 + 32 + NOTE_LENGTH
 
-      if (this.note.nullifier) {
-        size += 32
+        if (note.index) {
+          size += 4
+        }
+
+        if (note.nullifier) {
+          size += 32
+        }
       }
     }
 
@@ -190,53 +210,50 @@ export class DecryptNotesTask extends WorkerTask {
     return DecryptNotesTask.instance
   }
 
-  execute({
-    serializedNote,
-    incomingViewKey,
-    outgoingViewKey,
-    spendingKey,
-    currentNoteIndex,
-    jobId,
-  }: DecryptNotesRequest): DecryptNotesResponse {
-    const note = new NoteEncrypted(serializedNote)
+  execute({ payloads, jobId }: DecryptNotesRequest): DecryptNotesResponse {
+    const decryptedNotes = []
 
-    // Try decrypting the note as the owner
-    const receivedNote = note.decryptNoteForOwner(incomingViewKey)
-    if (receivedNote) {
-      if (receivedNote.value() !== BigInt(0)) {
-        return new DecryptNotesResponse(
-          {
-            index: currentNoteIndex,
-            forSpender: false,
-            merkleHash: note.merkleHash(),
-            nullifier:
-              currentNoteIndex !== null
-                ? receivedNote.nullifier(spendingKey, BigInt(currentNoteIndex))
-                : null,
-            serializedNote: receivedNote.serialize(),
-          },
-          jobId,
-        )
+    for (const {
+      serializedNote,
+      incomingViewKey,
+      outgoingViewKey,
+      spendingKey,
+      currentNoteIndex,
+    } of payloads) {
+      const note = new NoteEncrypted(serializedNote)
+
+      // Try decrypting the note as the owner
+      const receivedNote = note.decryptNoteForOwner(incomingViewKey)
+      if (receivedNote && receivedNote.value() !== BigInt(0)) {
+        decryptedNotes.push({
+          index: currentNoteIndex,
+          forSpender: false,
+          merkleHash: note.merkleHash(),
+          nullifier:
+            currentNoteIndex !== null
+              ? receivedNote.nullifier(spendingKey, BigInt(currentNoteIndex))
+              : null,
+          serializedNote: receivedNote.serialize(),
+        })
+        continue
       }
+
+      // Try decrypting the note as the spender
+      const spentNote = note.decryptNoteForSpender(outgoingViewKey)
+      if (spentNote && spentNote.value() !== BigInt(0)) {
+        decryptedNotes.push({
+          index: currentNoteIndex,
+          forSpender: true,
+          merkleHash: note.merkleHash(),
+          nullifier: null,
+          serializedNote: spentNote.serialize(),
+        })
+        continue
+      }
+
+      decryptedNotes.push(null)
     }
 
-    // Try decrypting the note as the spender
-    const spentNote = note.decryptNoteForSpender(outgoingViewKey)
-    if (spentNote) {
-      if (spentNote.value() !== BigInt(0)) {
-        return new DecryptNotesResponse(
-          {
-            index: currentNoteIndex,
-            forSpender: true,
-            merkleHash: note.merkleHash(),
-            nullifier: null,
-            serializedNote: spentNote.serialize(),
-          },
-          jobId,
-        )
-      }
-    }
-
-    return new DecryptNotesResponse(null, jobId)
+    return new DecryptNotesResponse(decryptedNotes, jobId)
   }
 }

--- a/ironfish/src/workerPool/tasks/handlers.ts
+++ b/ironfish/src/workerPool/tasks/handlers.ts
@@ -5,6 +5,7 @@ import { Job } from '../job'
 import { BoxMessageTask } from './boxMessage'
 import { CreateMinersFeeTask } from './createMinersFee'
 import { CreateTransactionTask } from './createTransaction'
+import { DecryptNotesTask } from './decryptNotes'
 import { GetUnspentNotesTask } from './getUnspentNotes'
 import { SleepTask } from './sleep'
 import { SubmitTelemetryTask } from './submitTelemetry'
@@ -17,6 +18,7 @@ export const handlers: Record<WorkerMessageType, WorkerTask | undefined> = {
   [WorkerMessageType.BoxMessage]: BoxMessageTask.getInstance(),
   [WorkerMessageType.CreateMinersFee]: CreateMinersFeeTask.getInstance(),
   [WorkerMessageType.CreateTransaction]: CreateTransactionTask.getInstance(),
+  [WorkerMessageType.DecryptNotes]: DecryptNotesTask.getInstance(),
   [WorkerMessageType.GetUnspentNotes]: GetUnspentNotesTask.getInstance(),
   [WorkerMessageType.JobAborted]: undefined,
   [WorkerMessageType.JobError]: undefined,

--- a/ironfish/src/workerPool/tasks/workerMessage.ts
+++ b/ironfish/src/workerPool/tasks/workerMessage.ts
@@ -9,13 +9,14 @@ export enum WorkerMessageType {
   BoxMessage = 0,
   CreateMinersFee = 1,
   CreateTransaction = 2,
-  GetUnspentNotes = 3,
-  JobAborted = 4,
-  JobError = 5,
-  Sleep = 6,
-  SubmitTelemetry = 7,
-  UnboxMessage = 8,
-  VerifyTransaction = 9,
+  DecryptNotes = 3,
+  GetUnspentNotes = 4,
+  JobAborted = 5,
+  JobError = 6,
+  Sleep = 7,
+  SubmitTelemetry = 8,
+  UnboxMessage = 9,
+  VerifyTransaction = 10,
 }
 
 export abstract class WorkerMessage implements Serializable {

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -12,6 +12,7 @@ import { Job } from './job'
 import { BoxMessageRequest, BoxMessageResponse } from './tasks/boxMessage'
 import { CreateMinersFeeRequest, CreateMinersFeeResponse } from './tasks/createMinersFee'
 import { CreateTransactionRequest, CreateTransactionResponse } from './tasks/createTransaction'
+import { DecryptNotesRequest, DecryptNotesResponse } from './tasks/decryptNotes'
 import { GetUnspentNotesRequest, GetUnspentNotesResponse } from './tasks/getUnspentNotes'
 import { JobAbortedError, JobAbortedMessage } from './tasks/jobAbort'
 import { JobError, JobErrorMessage } from './tasks/jobError'
@@ -237,6 +238,8 @@ export class Worker {
         return CreateMinersFeeRequest.deserialize(jobId, request)
       case WorkerMessageType.CreateTransaction:
         return CreateTransactionRequest.deserialize(jobId, request)
+      case WorkerMessageType.DecryptNotes:
+        return DecryptNotesRequest.deserialize(jobId, request)
       case WorkerMessageType.GetUnspentNotes:
         return GetUnspentNotesRequest.deserialize(jobId, request)
       case WorkerMessageType.JobAborted:
@@ -266,6 +269,8 @@ export class Worker {
         return CreateMinersFeeResponse.deserialize(jobId, response)
       case WorkerMessageType.CreateTransaction:
         return CreateTransactionResponse.deserialize(jobId, response)
+      case WorkerMessageType.DecryptNotes:
+        return DecryptNotesResponse.deserialize(jobId, response)
       case WorkerMessageType.GetUnspentNotes:
         return GetUnspentNotesResponse.deserialize(jobId, response)
       case WorkerMessageType.JobAborted:


### PR DESCRIPTION
## Summary

We currently decrypt notes in the main thread when syncing transactions in the accounts module. This code change migrates this processing to the worker pool.

Note: We return a `serializedNote` from the worker job. This is currently unused in `staging`, but is part of the other broader accounts changes.

## Testing Plan

Created unit tests for serialization; existing unit tests should cover logic.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
