### PR TITLE
Fix: add account route for rpctcp

### DIFF
--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -220,6 +220,7 @@ export class IronfishSdk {
 
     if (this.config.get('enableRpcTcp')) {
       const namespaces = [
+        ApiNamespace.account,
         ApiNamespace.chain,
         ApiNamespace.event,
         ApiNamespace.faucet,


### PR DESCRIPTION
## Summary
Mount account based route for rpctcp call.
## Testing Plan
Local test passed.
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[✓] No
```
