### PR TITLE
Fix chain:export progress bar

### DIFF
--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -67,7 +67,7 @@ export default class Export extends IronfishCommand {
 
     for await (const result of stream.contentStream()) {
       results.push(result.block)
-      progress.increment()
+      progress.update((result.block?.seq || 0) - start + 1) // +1 because start is inclusive
     }
 
     progress.stop()

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -67,7 +67,7 @@ export default class Export extends IronfishCommand {
 
     for await (const result of stream.contentStream()) {
       results.push(result.block)
-      progress.update(result.block?.seq || 0)
+      progress.increment()
     }
 
     progress.stop()

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -67,7 +67,7 @@ export default class Export extends IronfishCommand {
 
     for await (const result of stream.contentStream()) {
       results.push(result.block)
-      progress.update((result.block?.seq || 0) - start + 1) // +1 because start is inclusive
+      progress.update((result.block?.seq || 0) - start + 1)
     }
 
     progress.stop()


### PR DESCRIPTION
## Summary
Currently, block sequence is displayed as a number of processed blocks in a progress bar. This can lead to incorrect number if user passed a block to start from:
![176679308-d2fb7dbd-2c6c-4d76-814a-1236b1cda3fa](https://user-images.githubusercontent.com/59533234/176681109-99d11c3c-1b00-4e1f-8820-eb893cf5acc6.png)

This PR fixes this issue:
![176679357-65d6b040-d1b4-4826-aa3c-bce9bf0d7a12](https://user-images.githubusercontent.com/59533234/176681147-a35d2662-c976-43b3-bfde-5fa05181b13a.png)

## Testing Plan
Tested locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
