### PR TITLE
Materialize subscribed count

### DIFF
--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -428,21 +428,17 @@ export class MiningPool {
       this.shares.sharesPendingPayout(),
     ])
 
-    let minerCount = 0
     let addressMinerCount = 0
     for (const client of this.stratum.clients.values()) {
-      if (client.subscribed) {
-        minerCount++
-        if (client.publicAddress === publicAddress) {
-          addressMinerCount++
-        }
+      if (client.subscribed && client.publicAddress === publicAddress) {
+        addressMinerCount++
       }
     }
 
     const status = {
       name: this.name,
       hashRate: hashRate,
-      miners: minerCount,
+      miners: this.stratum.subscribed,
       sharesPending: sharesPending,
       banCount: this.stratum.peers.banCount,
     }


### PR DESCRIPTION
## Summary

This PR will materialize subscribe count when people connect and
disconnect. Then we can use that number in places, and also return it in
getStatus().

I also adjusted a broadcast log to log how many people we ended up
broadcasting to.

## Testing Plan
Run the pool locally and look at the debug logs

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
