### PR TITLE
Always show syncer progress if not synced

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -78,7 +78,7 @@ function renderStatus(content: GetStatusResponse): string {
     blockSyncerStatusDetails.push(`avg time to add block ${avgTimeToAddBlock} ms`)
   }
 
-  if (content.blockSyncer.status === 'syncing') {
+  if (!content.blockchain.synced) {
     blockSyncerStatusDetails.push(
       `progress: ${(content.blockSyncer.syncing.progress * 100).toFixed(2)}%`,
     )


### PR DESCRIPTION
## Summary
This was confusing to users because it wouldnt show your progress if it
hasn't found a peer to sync from. From https://discord.com/channels/771503434028941353/816795916627345450/992069044591145021

## Testing Plan
Run tests and run locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
