### PR TITLE
FEAT: more miner status info

### DIFF
--- a/ironfish-cli/src/commands/miners/pools/status.ts
+++ b/ironfish-cli/src/commands/miners/pools/status.ts
@@ -60,6 +60,7 @@ export class PoolStatus extends IronfishCommand {
     const stratum = new StratumClient({
       host: host,
       port: port,
+      clientName: 'default',
       logger: createRootLogger(),
     })
 
@@ -109,7 +110,8 @@ export class PoolStatus extends IronfishCommand {
 
     if (status.addressStatus) {
       result += `\nMining status for address '${status.addressStatus.publicAddress}':\n`
-      result += `Miners:                ${status.addressStatus.miners}\n`
+      result += `Number of miners:      ${status.addressStatus.miners}\n`
+      result += `Active miners:         ${status.addressStatus.activeMiners}\n`
       result += `Hashrate:              ${FileUtils.formatHashRate(
         status.addressStatus.hashRate,
       )}\n`

--- a/ironfish-cli/src/commands/miners/pools/status.ts
+++ b/ironfish-cli/src/commands/miners/pools/status.ts
@@ -60,7 +60,6 @@ export class PoolStatus extends IronfishCommand {
     const stratum = new StratumClient({
       host: host,
       port: port,
-      clientName: 'default',
       logger: createRootLogger(),
     })
 
@@ -111,7 +110,7 @@ export class PoolStatus extends IronfishCommand {
     if (status.addressStatus) {
       result += `\nMining status for address '${status.addressStatus.publicAddress}':\n`
       result += `Number of miners:      ${status.addressStatus.miners}\n`
-      result += `Active miners:         ${status.addressStatus.activeMiners}\n`
+      result += `Connected miners:      ${status.addressStatus.connectedMiners.join(', ')}\n`
       result += `Hashrate:              ${FileUtils.formatHashRate(
         status.addressStatus.hashRate,
       )}\n`

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -35,9 +35,7 @@ export class Miner extends IronfishCommand {
     }),
     name: Flags.string({
       char: 'n',
-      default: 'default',
-      description:
-        'the miner name distinguish different machines such as iron1. Server hostname is recommended',
+      description: 'the miner name distinguishes different miners',
     }),
     address: Flags.string({
       char: 'a',
@@ -75,8 +73,6 @@ export class Miner extends IronfishCommand {
         this.error('The given public address is not valid, please provide a valid one.')
       }
 
-      const minerName = flags.name
-
       let host = this.sdk.config.get('poolHost')
       let port = this.sdk.config.get('poolPort')
 
@@ -93,8 +89,9 @@ export class Miner extends IronfishCommand {
         }
       }
 
+      const nameInfo = flags.name ? ` with name ${flags.name}` : ''
       this.log(
-        `Starting to mine with public address: ${flags.address} at pool ${host}:${port} with name ${minerName}`,
+        `Starting to mine with public address: ${flags.address} at pool ${host}:${port}${nameInfo}`,
       )
 
       const miner = new MiningPoolMiner({
@@ -104,7 +101,7 @@ export class Miner extends IronfishCommand {
         batchSize,
         host: host,
         port: port,
-        minerName,
+        name: flags.name,
       })
 
       miner.start()

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -33,6 +33,12 @@ export class Miner extends IronfishCommand {
       char: 'p',
       description: 'the host and port of the mining pool to connect to such as 92.191.17.232',
     }),
+    name: Flags.string({
+      char: 'n',
+      default: 'default',
+      description:
+        'the miner name distinguish different machines such as iron1. Server hostname is recommended',
+    }),
     address: Flags.string({
       char: 'a',
       description: 'the public address to receive pool payouts',
@@ -69,6 +75,8 @@ export class Miner extends IronfishCommand {
         this.error('The given public address is not valid, please provide a valid one.')
       }
 
+      const minerName = flags.name
+
       let host = this.sdk.config.get('poolHost')
       let port = this.sdk.config.get('poolPort')
 
@@ -85,7 +93,9 @@ export class Miner extends IronfishCommand {
         }
       }
 
-      this.log(`Starting to mine with public address: ${flags.address} at pool ${host}:${port}`)
+      this.log(
+        `Starting to mine with public address: ${flags.address} at pool ${host}:${port} with name ${minerName}`,
+      )
 
       const miner = new MiningPoolMiner({
         threadCount: flags.threads,
@@ -94,6 +104,7 @@ export class Miner extends IronfishCommand {
         batchSize,
         host: host,
         port: port,
+        minerName,
       })
 
       miner.start()

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -430,7 +430,7 @@ export class MiningPool {
 
     let addressMinerCount = 0
 
-    const status = {
+    const status: MiningStatusMessage = {
       name: this.name,
       hashRate: hashRate,
       miners: this.stratum.subscribed,
@@ -456,15 +456,12 @@ export class MiningPool {
         }
       }
 
-      return {
-        ...status,
-        addressStatus: {
-          publicAddress: publicAddress,
-          hashRate: addressHashRate,
-          miners: addressMinerCount,
-          connectedMiners: addressConnectedMiners,
-          sharesPending: addressSharesPending,
-        },
+      status.addressStatus = {
+        publicAddress: publicAddress,
+        hashRate: addressHashRate,
+        miners: addressMinerCount,
+        connectedMiners: addressConnectedMiners,
+        sharesPending: addressSharesPending,
       }
     }
 

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -449,12 +449,16 @@ export class MiningPool {
         this.estimateHashRate(publicAddress),
         this.shares.sharesPendingPayout(publicAddress),
       ])
+      const addressActiveMiners = Array.from(this.stratum.clients.values()).map(
+        (client) => client.clientName,
+      )
       return {
         ...status,
         addressStatus: {
           publicAddress: publicAddress,
           hashRate: addressHashRate,
           miners: addressMinerCount,
+          activeMiners: JSON.stringify(addressActiveMiners),
           sharesPending: addressSharesPending,
         },
       }

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -429,11 +429,6 @@ export class MiningPool {
     ])
 
     let addressMinerCount = 0
-    for (const client of this.stratum.clients.values()) {
-      if (client.subscribed && client.publicAddress === publicAddress) {
-        addressMinerCount++
-      }
-    }
 
     const status = {
       name: this.name,
@@ -449,16 +444,25 @@ export class MiningPool {
         this.estimateHashRate(publicAddress),
         this.shares.sharesPendingPayout(publicAddress),
       ])
-      const addressActiveMiners = Array.from(this.stratum.clients.values()).map(
-        (client) => client.clientName,
-      )
+
+      const addressConnectedMiners: string[] = []
+
+      for (const client of this.stratum.clients.values()) {
+        if (client.subscribed && client.publicAddress === publicAddress) {
+          addressMinerCount++
+          if (client.name) {
+            addressConnectedMiners.push(client.name)
+          }
+        }
+      }
+
       return {
         ...status,
         addressStatus: {
           publicAddress: publicAddress,
           hashRate: addressHashRate,
           miners: addressMinerCount,
-          activeMiners: JSON.stringify(addressActiveMiners),
+          connectedMiners: addressConnectedMiners,
           sharesPending: addressSharesPending,
         },
       }

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -450,9 +450,7 @@ export class MiningPool {
       for (const client of this.stratum.clients.values()) {
         if (client.subscribed && client.publicAddress === publicAddress) {
           addressMinerCount++
-          if (client.name) {
-            addressConnectedMiners.push(client.name)
-          }
+          addressConnectedMiners.push(client.name || `Miner ${client.id}`)
         }
       }
 

--- a/ironfish/src/mining/poolMiner.ts
+++ b/ironfish/src/mining/poolMiner.ts
@@ -35,6 +35,7 @@ export class MiningPoolMiner {
     publicAddress: string
     host: string
     port: number
+    minerName: string
   }) {
     this.logger = options.logger
     this.graffiti = null
@@ -49,6 +50,7 @@ export class MiningPoolMiner {
     this.stratum = new StratumClient({
       host: options.host,
       port: options.port,
+      clientName: options.minerName,
       logger: options.logger,
     })
     this.stratum.onConnected.on(() => this.stratum.subscribe(this.publicAddress))

--- a/ironfish/src/mining/poolMiner.ts
+++ b/ironfish/src/mining/poolMiner.ts
@@ -22,6 +22,7 @@ export class MiningPoolMiner {
   private stopResolve: (() => void) | null
 
   private readonly publicAddress: string
+  private readonly name: string | undefined
 
   graffiti: Buffer | null
   miningRequestId: number
@@ -35,10 +36,11 @@ export class MiningPoolMiner {
     publicAddress: string
     host: string
     port: number
-    minerName: string
+    name?: string
   }) {
     this.logger = options.logger
     this.graffiti = null
+    this.name = options.name
     this.publicAddress = options.publicAddress
     if (!isValidPublicAddress(this.publicAddress)) {
       throw new Error(`Invalid public address: ${this.publicAddress}`)
@@ -50,10 +52,9 @@ export class MiningPoolMiner {
     this.stratum = new StratumClient({
       host: options.host,
       port: options.port,
-      clientName: options.minerName,
       logger: options.logger,
     })
-    this.stratum.onConnected.on(() => this.stratum.subscribe(this.publicAddress))
+    this.stratum.onConnected.on(() => this.stratum.subscribe(this.publicAddress, this.name))
     this.stratum.onSubscribed.on((m) => this.setGraffiti(GraffitiUtils.fromString(m.graffiti)))
     this.stratum.onSetTarget.on((m) => this.setTarget(m.target))
     this.stratum.onNotify.on((m) =>

--- a/ironfish/src/mining/stratum/messages.ts
+++ b/ironfish/src/mining/stratum/messages.ts
@@ -20,7 +20,7 @@ export type MiningDisconnectMessage =
 
 export type MiningSubscribeMessage = {
   version: number
-  clientName: string
+  name?: string
   publicAddress: string
 }
 
@@ -60,7 +60,7 @@ export type MiningStatusMessage = {
   sharesPending: number
   addressStatus?: {
     publicAddress: string
-    activeMiners: string
+    connectedMiners: string[]
     hashRate: number
     miners: number
     sharesPending: number
@@ -111,7 +111,7 @@ export const MiningWaitForWorkSchema: yup.MixedSchema<MiningWaitForWorkMessage> 
 export const MiningSubscribeSchema: yup.ObjectSchema<MiningSubscribeMessage> = yup
   .object({
     version: yup.number().required(),
-    clientName: yup.string().required(),
+    name: yup.string().optional(),
     publicAddress: yup.string().required(),
   })
   .required()
@@ -140,7 +140,7 @@ export const MiningStatusSchema: yup.ObjectSchema<MiningStatusMessage> = yup
     addressStatus: yup
       .object({
         publicAddress: yup.string().required(),
-        activeMiners: yup.string().required(),
+        connectedMiners: yup.array(yup.string().required()).required(),
         hashRate: yup.number().required(),
         miners: yup.number().required(),
         sharesPending: yup.number().required(),

--- a/ironfish/src/mining/stratum/messages.ts
+++ b/ironfish/src/mining/stratum/messages.ts
@@ -20,6 +20,7 @@ export type MiningDisconnectMessage =
 
 export type MiningSubscribeMessage = {
   version: number
+  clientName: string
   publicAddress: string
 }
 
@@ -59,6 +60,7 @@ export type MiningStatusMessage = {
   sharesPending: number
   addressStatus?: {
     publicAddress: string
+    activeMiners: string
     hashRate: number
     miners: number
     sharesPending: number
@@ -109,6 +111,7 @@ export const MiningWaitForWorkSchema: yup.MixedSchema<MiningWaitForWorkMessage> 
 export const MiningSubscribeSchema: yup.ObjectSchema<MiningSubscribeMessage> = yup
   .object({
     version: yup.number().required(),
+    clientName: yup.string().required(),
     publicAddress: yup.string().required(),
   })
   .required()
@@ -137,6 +140,7 @@ export const MiningStatusSchema: yup.ObjectSchema<MiningStatusMessage> = yup
     addressStatus: yup
       .object({
         publicAddress: yup.string().required(),
+        activeMiners: yup.string().required(),
         hashRate: yup.number().required(),
         miners: yup.number().required(),
         sharesPending: yup.number().required(),

--- a/ironfish/src/mining/stratum/messages.ts
+++ b/ironfish/src/mining/stratum/messages.ts
@@ -140,7 +140,7 @@ export const MiningStatusSchema: yup.ObjectSchema<MiningStatusMessage> = yup
     addressStatus: yup
       .object({
         publicAddress: yup.string().required(),
-        connectedMiners: yup.array(yup.string().required()).required(),
+        connectedMiners: yup.array(yup.string().required()).defined(),
         hashRate: yup.number().required(),
         miners: yup.number().required(),
         sharesPending: yup.number().required(),

--- a/ironfish/src/mining/stratum/stratumClient.ts
+++ b/ironfish/src/mining/stratum/stratumClient.ts
@@ -33,6 +33,7 @@ export class StratumClient {
   readonly socket: net.Socket
   readonly host: string
   readonly port: number
+  readonly clientName: string
   readonly logger: Logger
   readonly version: number
 
@@ -56,9 +57,10 @@ export class StratumClient {
   readonly onWaitForWork = new Event<[MiningWaitForWorkMessage]>()
   readonly onStatus = new Event<[MiningStatusMessage]>()
 
-  constructor(options: { host: string; port: number; logger: Logger }) {
+  constructor(options: { host: string; port: number; clientName: string; logger: Logger }) {
     this.host = options.host
     this.port = options.port
+    this.clientName = options.clientName
     this.logger = options.logger
     this.version = STRATUM_VERSION_PROTOCOL
 
@@ -123,6 +125,7 @@ export class StratumClient {
   subscribe(publicAddress: string): void {
     this.send('mining.subscribe', {
       version: this.version,
+      clientName: this.clientName,
       publicAddress: publicAddress,
     })
 

--- a/ironfish/src/mining/stratum/stratumClient.ts
+++ b/ironfish/src/mining/stratum/stratumClient.ts
@@ -33,7 +33,6 @@ export class StratumClient {
   readonly socket: net.Socket
   readonly host: string
   readonly port: number
-  readonly clientName: string
   readonly logger: Logger
   readonly version: number
 
@@ -57,10 +56,9 @@ export class StratumClient {
   readonly onWaitForWork = new Event<[MiningWaitForWorkMessage]>()
   readonly onStatus = new Event<[MiningStatusMessage]>()
 
-  constructor(options: { host: string; port: number; clientName: string; logger: Logger }) {
+  constructor(options: { host: string; port: number; logger: Logger }) {
     this.host = options.host
     this.port = options.port
-    this.clientName = options.clientName
     this.logger = options.logger
     this.version = STRATUM_VERSION_PROTOCOL
 
@@ -122,10 +120,10 @@ export class StratumClient {
     }
   }
 
-  subscribe(publicAddress: string): void {
+  subscribe(publicAddress: string, name?: string): void {
     this.send('mining.subscribe', {
       version: this.version,
-      clientName: this.clientName,
+      name,
       publicAddress: publicAddress,
     })
 

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -205,7 +205,13 @@ export class StratumServer {
             return
           }
 
+          let clientName = 'default'
+          if (body.result.clientName !== undefined) {
+            clientName = body.result.clientName
+          }
+
           client.publicAddress = body.result.publicAddress
+          client.clientName = clientName
           client.subscribed = true
           this.subscribed++
 

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -205,13 +205,8 @@ export class StratumServer {
             return
           }
 
-          let clientName = 'default'
-          if (body.result.clientName !== undefined) {
-            clientName = body.result.clientName
-          }
-
           client.publicAddress = body.result.publicAddress
-          client.clientName = clientName
+          client.name = body.result.name
           client.subscribed = true
           this.subscribed++
 

--- a/ironfish/src/mining/stratum/stratumServerClient.ts
+++ b/ironfish/src/mining/stratum/stratumServerClient.ts
@@ -10,7 +10,7 @@ export class StratumServerClient {
   connected: boolean
   subscribed: boolean
   publicAddress: string | null = null
-  clientName: string | null = null
+  name: string | undefined
   remoteAddress: string
   graffiti: Buffer | null = null
   messageBuffer: string

--- a/ironfish/src/mining/stratum/stratumServerClient.ts
+++ b/ironfish/src/mining/stratum/stratumServerClient.ts
@@ -10,6 +10,7 @@ export class StratumServerClient {
   connected: boolean
   subscribed: boolean
   publicAddress: string | null = null
+  clientName: string | null = null
   remoteAddress: string
   graffiti: Buffer | null = null
   messageBuffer: string


### PR DESCRIPTION
## Summary
Add miner name for each mining server/PC to distinguish different physical machines. For example, if I run 2 mining server on official pool and one of them is down, for now I have to check the mining log for each server. With this PR, I can realize which one is down immediately with miners:status command.
## Testing Plan
Local test.
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
