### PR TITLE
Remove copying the entries() twice

### DIFF
--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -117,25 +117,59 @@ export class Telemetry {
   private metricsLoop(): void {
     Assert.isNotNull(this.metrics)
 
-    const inboundTrafficFields: Field[] = [
-      ...this.metrics.p2p_InboundTrafficByMessage.entries(),
-    ].map(([messageType, meter]) => {
-      return {
+    const fields: Field[] = [
+      {
+        name: 'heap_used',
+        type: 'integer',
+        value: this.metrics.heapUsed.value,
+      },
+      {
+        name: 'heap_total',
+        type: 'integer',
+        value: this.metrics.heapTotal.value,
+      },
+      {
+        name: 'inbound_traffic',
+        type: 'float',
+        value: this.metrics.p2p_InboundTraffic.rate5m,
+      },
+      {
+        name: 'outbound_traffic',
+        type: 'float',
+        value: this.metrics.p2p_OutboundTraffic.rate5m,
+      },
+      {
+        name: 'peers_count',
+        type: 'integer',
+        value: this.metrics.p2p_PeersCount.value,
+      },
+      {
+        name: 'mempool_size',
+        type: 'integer',
+        value: this.metrics.memPoolSize.value,
+      },
+      {
+        name: 'head_sequence',
+        type: 'integer',
+        value: this.chain.head.sequence,
+      },
+    ]
+
+    for (const [messageType, meter] of this.metrics.p2p_InboundTrafficByMessage) {
+      fields.push({
         name: 'inbound_traffic_' + NetworkMessageType[messageType].toLowerCase(),
         type: 'float',
         value: meter.rate5m,
-      }
-    })
+      })
+    }
 
-    const outboundTrafficFields: Field[] = [
-      ...this.metrics.p2p_OutboundTrafficByMessage.entries(),
-    ].map(([messageType, meter]) => {
-      return {
+    for (const [messageType, meter] of this.metrics.p2p_OutboundTrafficByMessage) {
+      fields.push({
         name: 'outbound_traffic_' + NetworkMessageType[messageType].toLowerCase(),
         type: 'float',
         value: meter.rate5m,
-      }
-    })
+      })
+    }
 
     this.submit({
       measurement: 'node_stats',
@@ -146,45 +180,7 @@ export class Telemetry {
           value: this.chain.synced.toString(),
         },
       ],
-      fields: [
-        {
-          name: 'heap_used',
-          type: 'integer',
-          value: this.metrics.heapUsed.value,
-        },
-        {
-          name: 'heap_total',
-          type: 'integer',
-          value: this.metrics.heapTotal.value,
-        },
-        {
-          name: 'inbound_traffic',
-          type: 'float',
-          value: this.metrics.p2p_InboundTraffic.rate5m,
-        },
-        {
-          name: 'outbound_traffic',
-          type: 'float',
-          value: this.metrics.p2p_OutboundTraffic.rate5m,
-        },
-        {
-          name: 'peers_count',
-          type: 'integer',
-          value: this.metrics.p2p_PeersCount.value,
-        },
-        {
-          name: 'mempool_size',
-          type: 'integer',
-          value: this.metrics.memPoolSize.value,
-        },
-        {
-          name: 'head_sequence',
-          type: 'integer',
-          value: this.chain.head.sequence,
-        },
-        ...inboundTrafficFields,
-        ...outboundTrafficFields,
-      ],
+      fields,
     })
 
     this.metricsInterval = setTimeout(() => {


### PR DESCRIPTION
This removes copying the message traffic 4 times, for inbound and
outbound. We just use a normal for loop.

## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
