### PR TITLE
Remove .entires() call on iterating a map

### DIFF
--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -183,7 +183,7 @@ export class Telemetry {
       },
     ]
 
-    for (const [messageType, meter] of this.metrics.p2p_InboundTrafficByMessage.entries()) {
+    for (const [messageType, meter] of this.metrics.p2p_InboundTrafficByMessage) {
       fields.push({
         name: 'inbound_traffic_' + NetworkMessageType[messageType].toLowerCase(),
         type: 'float',
@@ -191,7 +191,7 @@ export class Telemetry {
       })
     }
 
-    for (const [messageType, meter] of this.metrics.p2p_OutboundTrafficByMessage.entries()) {
+    for (const [messageType, meter] of this.metrics.p2p_OutboundTrafficByMessage) {
       fields.push({
         name: 'outbound_traffic_' + NetworkMessageType[messageType].toLowerCase(),
         type: 'float',


### PR DESCRIPTION
## Summary
The default map iterator uses entries()

## Testing Plan
Run normal tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
