### PR TITLE
refactor(ironfish): Move decryptedNotes into Account

### DIFF
--- a/ironfish-cli/src/commands/start.test.ts
+++ b/ironfish-cli/src/commands/start.test.ts
@@ -90,13 +90,15 @@ describe('start command', () => {
       getDefaultAccount: jest.fn(),
       createAccount: jest.fn().mockImplementation(
         (name: string) =>
-          new ironfishmodule.Account('id', {
+          new ironfishmodule.Account({
+            id: 'id',
             incomingViewKey: '',
             outgoingViewKey: '',
             publicAddress: '',
             rescan: null,
             spendingKey: '',
             name,
+            decryptedNotes: new Map(),
           }),
       ),
     }

--- a/ironfish/src/account/account.ts
+++ b/ironfish/src/account/account.ts
@@ -1,13 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
-import { BufferMap } from 'buffer-map'
 import MurmurHash3 from 'imurmurhash'
-import { Assert } from '../assert'
-import { Blockchain } from '../blockchain'
-import { Config } from '../fileStores'
-import { Transaction } from '../primitives'
 import { Note } from '../primitives/note'
 import { AccountsValue } from './database/accounts'
 import { DecryptedNotesValue } from './database/decryptedNotes'
@@ -15,16 +9,7 @@ import { DecryptedNotesValue } from './database/decryptedNotes'
 export const ACCOUNT_KEY_LENGTH = 32
 
 export class Account {
-  private readonly chain: Blockchain
-  private readonly config: Config
   private readonly decryptedNotes: Map<string, DecryptedNotesValue>
-  private readonly transactions: BufferMap<
-    Readonly<{
-      transaction: Transaction
-      blockHash: string | null
-      submittedSequence: number | null
-    }>
-  >
 
   readonly id: string
   readonly displayName: string
@@ -37,32 +22,30 @@ export class Account {
 
   constructor({
     id,
-    serializedAccount,
-    chain,
-    config,
+    name,
+    spendingKey,
+    incomingViewKey,
+    outgoingViewKey,
+    publicAddress,
+    rescan,
     decryptedNotes,
-    transactions,
   }: {
     id: string
-    serializedAccount: AccountsValue
-    chain: Blockchain
-    config: Config
+    name: string
+    spendingKey: string
+    incomingViewKey: string
+    outgoingViewKey: string
+    publicAddress: string
+    rescan: number | null
     decryptedNotes: Map<string, DecryptedNotesValue>
-    transactions: BufferMap<
-      Readonly<{
-        transaction: Transaction
-        blockHash: string | null
-        submittedSequence: number | null
-      }>
-    >
   }) {
     this.id = id
-    this.name = serializedAccount.name
-    this.spendingKey = serializedAccount.spendingKey
-    this.incomingViewKey = serializedAccount.incomingViewKey
-    this.outgoingViewKey = serializedAccount.outgoingViewKey
-    this.publicAddress = serializedAccount.publicAddress
-    this.rescan = serializedAccount.rescan
+    this.name = name
+    this.spendingKey = spendingKey
+    this.incomingViewKey = incomingViewKey
+    this.outgoingViewKey = outgoingViewKey
+    this.publicAddress = publicAddress
+    this.rescan = rescan
 
     const prefixHash = new MurmurHash3(this.spendingKey, 1)
       .hash(this.incomingViewKey)
@@ -72,10 +55,7 @@ export class Account {
     const hashSlice = prefixHash.slice(0, 7)
     this.displayName = `${this.name} (${hashSlice})`
 
-    this.chain = chain
-    this.config = config
     this.decryptedNotes = decryptedNotes
-    this.transactions = transactions
   }
 
   serialize(): AccountsValue {
@@ -89,15 +69,12 @@ export class Account {
     }
   }
 
-  async getUnspentNotes(): Promise<
-    ReadonlyArray<{
-      hash: string
-      note: Note
-      index: number | null
-      confirmed: boolean
-    }>
-  > {
-    const minimumBlockConfirmations = this.config.get('minimumBlockConfirmations')
+  getUnspentNotes(): ReadonlyArray<{
+    hash: string
+    index: number | null
+    note: Note
+    transactionHash: Buffer | null
+  }> {
     const unspentNotes = []
 
     for (const [
@@ -107,29 +84,11 @@ export class Account {
       // TODO(rohanjadvani): Remove the accountId check once each account owns
       // its own decrypted notes
       if (accountId === this.id && !spent) {
-        let confirmed = false
-
-        if (transactionHash) {
-          const transaction = this.transactions.get(transactionHash)
-          Assert.isNotUndefined(transaction)
-          const { blockHash } = transaction
-
-          if (blockHash) {
-            const header = await this.chain.getHeader(Buffer.from(blockHash, 'hex'))
-            Assert.isNotNull(header)
-            const main = await this.chain.isHeadChain(header)
-            if (main) {
-              const confirmations = this.chain.head.sequence - header.sequence
-              confirmed = confirmations >= minimumBlockConfirmations
-            }
-          }
-        }
-
         unspentNotes.push({
           hash,
-          note: new Note(serializedNote),
           index: noteIndex,
-          confirmed,
+          note: new Note(serializedNote),
+          transactionHash,
         })
       }
     }

--- a/ironfish/src/account/account.ts
+++ b/ironfish/src/account/account.ts
@@ -2,12 +2,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { BufferMap } from 'buffer-map'
 import MurmurHash3 from 'imurmurhash'
+import { Assert } from '../assert'
+import { Blockchain } from '../blockchain'
+import { Config } from '../fileStores'
+import { Transaction } from '../primitives'
+import { Note } from '../primitives/note'
 import { AccountsValue } from './database/accounts'
+import { DecryptedNotesValue } from './database/decryptedNotes'
 
 export const ACCOUNT_KEY_LENGTH = 32
 
 export class Account {
+  private readonly chain: Blockchain
+  private readonly config: Config
+  private readonly decryptedNotes: Map<string, DecryptedNotesValue>
+  private readonly transactions: BufferMap<
+    Readonly<{
+      transaction: Transaction
+      blockHash: string | null
+      submittedSequence: number | null
+    }>
+  >
+
   readonly id: string
   readonly displayName: string
   name: string
@@ -17,7 +35,27 @@ export class Account {
   publicAddress: string
   rescan: number | null
 
-  constructor(id: string, serializedAccount: AccountsValue) {
+  constructor({
+    id,
+    serializedAccount,
+    chain,
+    config,
+    decryptedNotes,
+    transactions,
+  }: {
+    id: string
+    serializedAccount: AccountsValue
+    chain: Blockchain
+    config: Config
+    decryptedNotes: Map<string, DecryptedNotesValue>
+    transactions: BufferMap<
+      Readonly<{
+        transaction: Transaction
+        blockHash: string | null
+        submittedSequence: number | null
+      }>
+    >
+  }) {
     this.id = id
     this.name = serializedAccount.name
     this.spendingKey = serializedAccount.spendingKey
@@ -33,6 +71,11 @@ export class Account {
       .toString(16)
     const hashSlice = prefixHash.slice(0, 7)
     this.displayName = `${this.name} (${hashSlice})`
+
+    this.chain = chain
+    this.config = config
+    this.decryptedNotes = decryptedNotes
+    this.transactions = transactions
   }
 
   serialize(): AccountsValue {
@@ -44,5 +87,53 @@ export class Account {
       publicAddress: this.publicAddress,
       rescan: this.rescan,
     }
+  }
+
+  async getUnspentNotes(): Promise<
+    ReadonlyArray<{
+      hash: string
+      note: Note
+      index: number | null
+      confirmed: boolean
+    }>
+  > {
+    const minimumBlockConfirmations = this.config.get('minimumBlockConfirmations')
+    const unspentNotes = []
+
+    for (const [
+      hash,
+      { accountId, noteIndex, serializedNote, spent, transactionHash },
+    ] of this.decryptedNotes.entries()) {
+      // TODO(rohanjadvani): Remove the accountId check once each account owns
+      // its own decrypted notes
+      if (accountId === this.id && !spent) {
+        let confirmed = false
+
+        if (transactionHash) {
+          const transaction = this.transactions.get(transactionHash)
+          Assert.isNotUndefined(transaction)
+          const { blockHash } = transaction
+
+          if (blockHash) {
+            const header = await this.chain.getHeader(Buffer.from(blockHash, 'hex'))
+            Assert.isNotNull(header)
+            const main = await this.chain.isHeadChain(header)
+            if (main) {
+              const confirmations = this.chain.head.sequence - header.sequence
+              confirmed = confirmations >= minimumBlockConfirmations
+            }
+          }
+        }
+
+        unspentNotes.push({
+          hash,
+          note: new Note(serializedNote),
+          index: noteIndex,
+          confirmed,
+        })
+      }
+    }
+
+    return unspentNotes
   }
 }

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -156,9 +156,13 @@ export class AccountsDB {
     return meta
   }
 
-  async *loadAccounts(): AsyncGenerator<Account, void, unknown> {
-    for await (const [id, account] of this.accounts.getAllIter()) {
-      yield new Account(id, account)
+  async *loadAccounts(): AsyncGenerator<
+    { id: string; serializedAccount: AccountsValue },
+    void,
+    unknown
+  > {
+    for await (const [id, serializedAccount] of this.accounts.getAllIter()) {
+      yield { id, serializedAccount }
     }
   }
 


### PR DESCRIPTION
## Summary

This copies references to data structures in the wallet to an individual account to improve the account behavior, primarily fetching unspent notes. Currently, the entire map is passed into the account - it will be partitioned by account IDs in a subsequent PR.

## Testing Plan

Covered by existing unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
