### PR TITLE
Allow nullable head hash entries

### DIFF
--- a/ironfish/src/account/__fixtures__/accounts.test.ts.fixture
+++ b/ironfish/src/account/__fixtures__/accounts.test.ts.fixture
@@ -2,18 +2,18 @@
   "Accounts should handle transaction created on fork": [
     {
       "name": "a",
-      "spendingKey": "8294d8935b48cc987fc6a07a355b5a762315e5a40e6b7b1c5064fc1395391b90",
-      "incomingViewKey": "a53f1adb409dfab4663604648cbe9289d7da9e40e1fe6d4fa960843d30bcd406",
-      "outgoingViewKey": "7c9d348768fd02529ee957b420a469302715ec1e8024fc15be77e532e04ce8a0",
-      "publicAddress": "ec4a7109d67f7caa91f6a30678caa2c498c01dc005c9415d2386658036f9e623814fc3b27dd2bc01d45c4c",
+      "spendingKey": "b8e1750fe20a75b565b970b83897a3d4f893259e60d70ec26581b424dc3aa3b6",
+      "incomingViewKey": "80da395baed0a71c6795875f17b7f9b69f3d780b42304386fb938d72214dd004",
+      "outgoingViewKey": "086f09b0c58627c835c3dea4cc3b96eb92d82f144c26b18812fd1c8e8c803e76",
+      "publicAddress": "59015e4f5e6f2dac4bd4b7d707ba85a2d95008852d0700c873d844f4c3827e3f65fdc492efa904c1aba00c",
       "rescan": null
     },
     {
       "name": "b",
-      "spendingKey": "7abdcdac673a2d4a9b1e81e1e5b38e7a9d81c469fb6076f86bcfde789e1f0ff9",
-      "incomingViewKey": "a461935fea2661be7ccd22c9b369269e98b7b8928fb1c05f69811a5789db8300",
-      "outgoingViewKey": "507c5b3b4b667769e0d78b0073eeae52a5935475cad34c033a7ed7dc58766bdc",
-      "publicAddress": "5495f67c5ffd4a48bda438567b6ec8f8c231ba5d2aac383c9d99eb9e0b36be38139d679924346988fe0e65",
+      "spendingKey": "04194ad8a32d29c2c046ae58b1d4acf26ff2a89d27e81a60b8b56a97fd4b5b0c",
+      "incomingViewKey": "a1bc5852f3ef76785273e3bfe95f54b3b2cc84ab82d16b0c28173caaac100501",
+      "outgoingViewKey": "d09e1fa13a555979dd15fceec409d3f11fce40598edc98ad4b1921c02fdf4f64",
+      "publicAddress": "7108de820b17b4ff61ed846d1aba0062c1326a40cc42adcd57348decf87dc23d8db93d7531997eab45a6a0",
       "rescan": null
     },
     {
@@ -23,7 +23,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:/CvtPpxbStgGq3b91etRrzzPq/rgWVaY1YS+HHG4ImM="
+            "data": "base64:DQoUPlvgj6/LuxJ9k36R5e4Fmy7vlRaKO8C+khE3fAs="
           },
           "size": 4
         },
@@ -33,16 +33,16 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1656542830567,
+        "timestamp": 1657142800555,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "EE73CE35DC352B6046B99C60F27F68FFBB9847244C2218798B6F6D2D1A8C33C2",
+        "hash": "E6CBED60AD465D687F6E8C3D7A0350123AA083A36F947136E852E10883EB825D",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAINqTYvmzx9Ro5R5F5cUlJOs2P2dfPZE97088xIobqL/X4c0BUB0onG2w5VgYlxL+IDzCBLyxdXIbXt57fES2P8c9xkL/OowbwvfpAkRCE86y2TMxFdIQK3DTkGukr86vAJAeCH6gFfu0a9STO0O80Jrz+gj0hZBnHrmoSn/Cwg2/Bvwg2N55AHFDmpOUXDnu66t2HK/JU2PUVhKJPJWfawYvlZfz82aZ6GaAnfN+xMCJb/oh5hC78x6wCXepDzl6hUJ9sTsHrTLCNbMy1fkG3L1YNo59mEHYh6DJL73UK5qJ+cK6P5mchtYoewOGJWf/pm5I6CtK4Et3qMvo8R3hxhCAYsD8gClsx+mtVZG6feY4W/G0JW09uckxteCaWrgvkH1gd9VFZxcGmKGarIXiNmcjGtlv8LeAAal0Q56pYhpxpN6lXftibuoo4iVlCgvrmRew8eMHqDvDKAaztuk7E7lD6fOoVtmSZ+l+RrLvHAb/v8j6OOKwg2AYMNK3VR0inDwIUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4BX5GMXjJQhzTVwXc5Uiy+F+rWGGTIHMTlDk8e/B4GpFw8px/Slq2O6gBGCJZdn8IZ85hpH9JiVm2HhgHBZiDg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIOk2+5UlLN2IWJDXuvi1iNnn93wwMuxSshrL0NPgJG7F1iI6sOAVBg0NyR503KEFpNxkjcayVLC0CUWNjhp2t2IaxBbjzgLkVI2wvx5srU3pXik2bMSOwbWpHxTmryZJhfj7U0JfDAZq7XGJntnz7vXZICl6v42rUEjYws0pEwPx62nQx7svYtaVlvzsAgSMYyDUS0TLJTyRzJECpXnL0126VNZ4ZLmJgMzPVGpd5MeyFNy6aHBSt/hEXomn1+p8aG5LLdjGkRFsLwG+w1Q1mT+Cw0NvL/QUeIeScN9Kxwgad8PURbhx0J9YIX8C6g29G0cLWT9qSm9ccMVOigjJCmH/p3I2GEsU0C/EP2w8dQQ0jkATubEJBgB1KUCcYNIzUIDabf7/qRkpDfvPEltvEkLu63KJHklrCjNV/vzRFr5Dpvcwdo784V/IYjQmjgEIdjwAoZTXQz92CKcnp0j9KyXaotK89cghdh2adqctoyRJgufzSdWnjeuC1gtIyY52iSMnUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEsmkt1PcG4VmxXwPUa6gldJwwYl26Ca8wrkabilxjBjX2+c570DnDZ+zMvnDhQZMWhTqVI2S/j11QxRMx58HBQ=="
         }
       ]
     },
@@ -53,7 +53,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:DZWDTT3WknBuhhl87VUDWkZTvGewYcXvxd8I/z1W8yE="
+            "data": "base64:Ije4ARbD1b/OWO67i+SIFW3sqoJmbQOY2ZogD3IaFlA="
           },
           "size": 4
         },
@@ -63,27 +63,27 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1656542830717,
+        "timestamp": 1657142800708,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "A1B83865C3177C8079C982339F223DFB322F14AF89E96FEE002D3F6F951EC471",
+        "hash": "162BEB52B05EB23780960B6F75CDB91F373DA8E3615C8BD2F35E4F479F43BB80",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALNBA125nik/WlzwpKovGbVXtpxUQe5ZBzgz3nYsnx3f/v+i8O+yQ1/SvoHB7qbDa6K9fxTm8jcqZkw6a76jH9pTL1B/l51ilzyjZ1gGQ4RUIuWdYhSpoYH2RQswvlI+SAODPGKi5RR7Zm4pBDguVABTG+qJB0o9/B4jvryeIEW1AqAt8o92wDeaNaC5579xyJkPZ0o1oT+VLhtwD2+Wl5GkV5HfO4CJhfj3g3CAMjpoQVrR14nFzLYlG80AVFaIsAQXcOvQoK2aK362c+WUcF/+WTBOX3CQJkPdm9VFBFLTjoPGCJ0GUDeJ9K8iAD2b55NnzGS5ndKp0copzTLfmDI2XZgKjD59pC7vg2xVfP894cFc/9MrWfhfy8a126oYt5NNYZlO7pnThDLVM0S9r5TL8cGmHjIKfN4iBn9iKt86k15mgxA3RqqMwnSIbZiLnTYBcMmwmaqeoJHdSdu9ikPZqUCd+Rp6JtZ/NOmKcAdM3KHCS6786fSnrin84AiVwiGNAEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0n7Bcl2zVy3h+ubr+/+Ahz1/9zC75AyDHMETJvBT4QMGoe8/jqbTrGYig3j/rwH6qBZ+DKASV2RhU9t1U+rQAQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJC2JTmynO57kNelj1/THJH+GoGXk2HSAZzN2dYChxTJJ+bc+h+Slg9VIVBqGWwK/JHmcuj28v8sH9RjGcIx59UFYyyfZG4snA+mZuGDWU73vZpwI+vy0BsmNV0AT1SXbAh3bN6Bx9n+vtReUDKFVcvq97WztRdpiY7XuU5vQUjD1MwhUMhC9Zf9aUmHQYkuh6p0c/28REoi0ymQrWgViqdlJ+FuVd5fbSTkdSXcdnDEEj1Y4eAcQaxZGHydibeRnN59Ng/JzN7sGBXSCiNQUdMXkPTY6jRv3aezS3lo2lSn9ZfPFVY81q+Rs0W/O7hki89PPP8tsTe7FdhARdmyaG4t3roHDaqxArWGVJwh4F3MRxIF8QlxTk9aoblt7d1oM3niru5LvdkXLxCzXeNi7lGNsR42fh/ElniadtfPomVROOBp3Vj08BBgk9qbHLa5dfPJvIxuquiF2Rgi7fCQaHFelpJEvBHxY6xjjOhG5eoeJmAQGDOFVi9pHsaRpZp59TCG20JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwo4/cgkYgHE9xXUS3v8mkqQxJ+8pElIeEyXKWEf1d3mO/j2NeoN1AXMm7XHegLOA+E9jtZpzGgp9rAElYbwaWBw=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "A1B83865C3177C8079C982339F223DFB322F14AF89E96FEE002D3F6F951EC471",
+        "previousBlockHash": "162BEB52B05EB23780960B6F75CDB91F373DA8E3615C8BD2F35E4F479F43BB80",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:qf/sd21GuJh5ccvbHYEXTBjk87Dd2gBPLsG6JZXKeQA="
+            "data": "base64:sYGo9rn2dVhSbW+rGH5y5qfEaltLvP2qA4h44/dpNk0="
           },
           "size": 5
         },
@@ -93,75 +93,57 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1656542830867,
+        "timestamp": 1657142800855,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "64B920BE9449070F1337A4108B08EE9ECFD9FAB8589635ED515024D3997D4D80",
+        "hash": "EC773BEF851FB275C8EE173E8CDEF393657E790D2E58B97FDEB9327CCBFEBE1B",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIhuuSiCsw8099jJIgIgXIWxJ+sFC05IqMvC6o9pI2nv/yDrHwLFZ/EL/6aDZIELULWesZjHIo+XDKhlCfhjQ38Izrwgxj/NC/kaWXFRMZ/V4Ielz/pZIKV+yJoWFBh9hBXV6QFwqFj2a5NfyNDEeUXMFJLCkV2XwnIks6Pk8QK0ufGzuTtD2tt4+iiy+ulbmIbBa7FH4rpcoH80dPi5rqkhf2mdSrDPJfHF7zIclPLR2YrhLffzoVknWc6HZyFC3I/VJ3lICpFLSbFYrabzoGn8MvW4L34iFdIvLsvtk6xEg3zOrt9NDOnvt4P63cEvHnIwBVDgl8wcgSAo6q3cnEj24R/xKUI0qCogCfGromt/j9Q1h9QxhWRiv5iC0hIP0pU61OZP8/AtBUAL1c0becjZjih1vMsJPoUVntkfPY6dvkIF2inpP1Digd7vvvf8RVXSCkVeWlU5n5aTZgh3aIqDbs5TQ/ARAzChfT5peGrmvJry64/QqM7MrXs/jdeLryxc8kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2uHXJHKEcNaZj//aZ17xiVY/iaOZ0W/KpT5G8MIDBAKGi5Vw5LcaPz3G1SinkOnMZ8XpSf0Rghft35llLmmvCw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK4BgwQrOYXSYpvv2tdrCAwhLajIbxVAdoPIx75L+Ho1JMY4RSpGjIvvNEy9rRLTwK+8Bz8gOBowUm3XN6EWxiadUt+9PEvYXHJcNAW5+4GzcwsYKxlpNg4SsE9KLwF0jQacJHxZMjdnlfY/PbGzW7EX+iSBU8ptN8AwTao/UQ4UEwhpfnjz1FikCpD4a7aMm6Iv8Yjv6J+PnmzMjuHhXNCXbQYDYlt8/oHd75mP7B1FUmjSawVxQpqQIoruTXSJZDPaKwCEjuXlJ6vX2Nu/DxRyjNti9Pvr3wFr9Fv2fsq1cDChZZJNUegds9G9wjjFYW9FItH1QI7JnZSt5ui/eiv54FIlvnGrSH9V1ioU2eWJr14e9mYMuehEywxvM2ou042qo2b3OoX5hY8KUdgd2FGXU7v2tPob6Z+xGE7L4RoeT1IVQSFzzc/sdegN1kCcDlmBL3i7wlw/AbLtV5VHD9r9kgIjx5jvo2fKftWaJfjXLoWOdOhjTePor9qQcMw4Y/KkhEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwo6vp0rn/yc5df7LP7DtYmy9nZ/35bdOqj7GgRysFayRf6cwc5SJnyjyUrwLSP0b0Z81CylXUNA+eG8YC5zCNCw=="
         }
       ]
     },
     {
       "type": "Buffer",
-      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAKjljhsq+2LSjfWbaDJj+QZiYiwUY7ZY/HiRZiBFa1WNqV6ozR9g1cDna+fLYcYz37HH9XA0XUQqoGFLEuf259Engurx5CIoW87yBxIb2mlc3wr4DGnsrqsOdQfYtzhyngL/s7T4V9JaVwdTyLogxtEsJpKmyk8uuCZgLbHVvGQiGosvKSVnGCHImw+sYzPlI5MCzOkF5FkamlbID9d3FU2VUdOTziWUNmTXWFWfUkZd6fVqwvGuQQFZws1YwzqesRilL/n5zbsQQzzYoN/feIoZ0YL1/L2rMwxzqq73LWO8nqAOD1e4O4rpSwZTLVHmcCVET1o0Fsoh11331GjjxhT8K+0+nFtK2Aardv3V61GvPM+r+uBZVpjVhL4ccbgiYwQAAACNhGXsq2nhF64PVLeq+kkfZSv/Sb1N5ZaGaPAAjU7QX//h5L7vT46YGqGnz/7uBxfLPiNW5K8vur1KMzwSWgyrmCUU2NZGbr+yIN6lFHDa0lKwzfuOkz3vN5PJwvn++gSNU8pbImXj9ed6KbaqfF6wVvChxCWPUCqR8tjF8sMjr4kJE6wYgeDosAUCZWgGAyWRRnWfoGJ5oSGxZMwZHK0LM/Qu7uUkOPyx8mly1mkzoMvHTcnpoyJzCjjJBqn9RZIZx9ONy1yv7GfsE9jKt5Km7LodY9Pe3uwA+lQJg5hhWxaEwbO6J8ystzgjynSsOQaoJVwBGbO3kAObWVODXu0D3ao5CkV8/xqihx7I4cot4FQCLv2th3xucCdAGSke+Mi6DXw2yIKdQEYPMa8d/lI+sDVm8IJBUYJI47nM6+J+5YQRqcnhWbTNyIAXXU4Vpa/Cqm5H+H0aJzoZ6ZrHdVhF5L39C5Lvh3OXc8j/94nEerB3ViYQyHvv7/Qyeeh8DDUyK9yl2i9yGYY4WOWAa4SjFc4xto8sdEeGVAJSDFvWRIxkGcz6HE0N6T3mlTRT2xWmJqVqT7Px2eIHAvz1NNiezqLrZj9HJciweLGBqnXDhyMPIJe9ag4qM5dX6/m5OHaER6/qgfsxUjbMWFRAUAGOiDQ3uIQY/0woXCDC87p9jIfrh4ecKw2O/rmaQTuPc8OeP6rQhy06MPMJPIpVsnqMkXSu1EpvWcGDk3kXLM79rSm2W6AiuBfP4yQEOw3oUEnElzsZc3SHUCdjcIYfy899dQae33KAipF/ZmNhgOKkg6D51JMYlUZdGcpHKL1jh3ZbEBYrp2IZZDbxP5PKktL1sV7rS8pq7n7FTEFLgtAiHRde1BMTS76g1FUDm1H6gx0FbMODx86PMkeN6q6dCwlKrtarr5cMr4oLRjWjC4l4WnTe/KfvjIzWsG4nQxgs3/a5va4D3JbsEfUuLwJGqthiMkUBtqlHf7OyoCl/1mqivIOyg6renr7PkZ2nQzEEejCHQ0xlTxTlN/TjbCSvcn+BZvVNcCM5qqQcDZMXrtE4riAL2Ut+/gdR2u689Lv44E1xIkYnTqlLNpIjdnjiLtXjeFi9F8d6UX9Wrtm1cgFoK3+s2n/6jQUYN8obi9MSbodaAyg11QJOpXyOCsg8cHWUV2kmQ8YzTm5eWN3QyTOGqvwRLlSQ1Ao3QiL9u1fRghZiiQlEj9mqBNmZfl4NUbo+6WbvPP+6isPNr8HXm/6eTX1/5eOKeYSUPVR7zgpR0PIf5mAyqfzsiMrhaYDTh6QChyxAG8KCx0jylujAn2A3/c/sYns8NKuMUZRkfSi/D0HHZhwBG+253QCkam0YYweBp03yRFxkLACRWBDraPXaqVPmtemG/BF5HyiG4qeRhgm1cgtgwzHMMPXJcg5zhvLecSwklnV3ITjOLch780/B9I0DHBzxCQ=="
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAK4UbCmlrfrh4ynxJNCQUwyY42WX2WrYvi0dJVp4+2ktaxSfqfzk+DMkenKV3HC2bJRoxZp0hR5BBcPWSGJ7FOpN6S2N7N9xLfldrByHPPwTf8RhT9V/Ve2OnfZv6qT0lBIxMFEqlTik/Nr7hmQnVVdlbdR7sX/yL1jH3YhGgivClFSnj7ABFzFVxleMVMMIn6EeJ6LosfZ1IonbLsTvH1jKhscmZW6rXKlgYAA5pIdoh/hgHnSV77uywQhYKNjs1WTgsiEOzFzS0Eeq1BTEOn9r5dDDpCQaRgXJVtNyKf3nWabgv/C1w4flYoLPIyzvRDld8htsQ7QufqHoy4OSiZMNChQ+W+CPr8u7En2TfpHl7gWbLu+VFoo7wL6SETd8CwQAAAAVXX81aZqxSBHwiKp2SjOELapstERCFxRwyHShuw/jl48YjrZLVm7GTKe/9DDe1uuMo8fTTETUyXbOcEgGQwVage9A6RLE5JG8TSA/1My5M3B5V2JzRPdVEPiFNUKBnweGIVO0eKHA1d/rAiBMHCOn84fQLm8v6gCI8hOm1otipBUCn5b+D5jlWS4ymp2X6M+Lz+BhK/8NX1B7bjHxaYCfEs4iS+1YyrGw7Yd8lsfRxpRwiHyLXCMbv4Au/CetHXYFC2j4x4uSI6/nYDbTvBtrnuvb4jrGPFS8pldHO0k+J4/ksusBF37laaRhJ/414TaSd58k4utaI3Ag1Cuuo6goyJ9oaEJOI7nvSDL0l8x2iwJQb3WMHyeK8cZ0YYP3Ktfq45uv0WuCCJoy5Z0pDqpILXnCaOPcbGFo67OYaD7qbuwnpVjiUUT1LGbEyNBteIaVZKDyDVmv7Vp6lU8QPc5WQsDbqh3deQNwFYjXavx2geHV74ssZl932N97fYpC602OA1dHwYmzH8Kc8Ql3Nr79dK/LGHD4QQ0iMHySF6V1x+JxCJd4lpyEcu0AEwiphwcVvH+e/QKTMyZEYsMXT05qHvjKf5tZLfci3fEs7pzHaNovYhRCoNxdiV3BXM4IdguwjmjMRvBaCLwR+JC4MuuvrtD2wdpYydZmV+TycEk/fK0OZ4aiP5m3xIVZlRUenV95Mx89osMpqW1Vt66PwaHnt2FWKWcaAVqnblzzj50XAw5+Sod8g5cbTk/7m6mdOtUkdSv22/tDH0UvFx0baCeRINebn9j984W5vHTe9wjvyuwoKYN/ee1qcjSNibbOB3aA4d5t1tlOHhQoiGRmxT+6faQQkzT95EvhzNNYOusuRhzyagRhHv6jWGdLeq3cMmujdraoWSpLI/D1QHiS4SWIoCEzttPi0HvjXsTfxCasz4xw+5RQQelPtt6YiRsG7pKSQdrIp1Ei05WjLCgo3z0eV2gH4+Ntt2HJqcexVC1Dcqr037ZwTqyc3tSNZfhBKpuSLojIwIv48bCheo5BneOVbbceM4F2GfxgOgh7JImDBoV5LdXdlvpneMFisc0RGVpTkBAzBnIVs424uE+xHjaP7MdS8jJ8x2OZX39GAwXzHh+qCVbp9k//cBNVX+qY8ClOU6MxK+TZey+ic1sj3SQwvCS34mnbyGHVO3Xk0AZ01CbML15XYqmKkTzQ03w69pPR71hcPBKhyZLCY91RUaXx04La5vHd5mdtJthk8jvtOnwz9FAazEOiRoR35IoxxDDknTjEXq5d77sdhQAnih9wnoNGBp5hWk1CcsTelpsyAWgloRu1o2kDBu3NxDqzZ+4UZ3oBhtPDA7Sm/Y7iVqfdRxLq3jY+Gw+CF6cp3fZ3beHLexTSP8QN2/K9pth6N4g74TxRZk5L6EMrJWT7HpNyI/p7m48HFNWke5AwROE3wBqI7VNBCg=="
     }
   ],
-  "Accounts updateHeadHash should update head hashes for existing accounts": [
+  "Accounts updateHeadHash should update head hashes for all existing accounts": [
     {
       "name": "accountA",
-      "spendingKey": "17667355ae9192a9922c3b75a3723385edc554695b920c8c7175e3361568ff3c",
-      "incomingViewKey": "4ccb01dda418b2919b081013be6f86a6904e7ff52915885b46e502a8df27ba05",
-      "outgoingViewKey": "de423a005d524f3939f1c9252526c0673ec7f6bff918227825278709d84e42df",
-      "publicAddress": "daaaf8663be9a608da92e10905e2972523579206be78f834290200cb6ec72052ac9d1e3b722263d43314a2",
+      "spendingKey": "a7cd2362c9b1badd8945d9c8a65debaffdf4f8191093000b78b1e41cc9e5e274",
+      "incomingViewKey": "cb1a495c1d0087a5c25443393c9d25ed4f210c41f9a7b6f85fd6b18059aabb01",
+      "outgoingViewKey": "49de85ed1b0635bf4806096784eb1e3e06c1f5be35df3afc64972ef29a2d3dc8",
+      "publicAddress": "24e9f5ad625b167dd7570193e153863b3b2709d2e4906dede35b7a914bd352bddab945131fab062361dd4b",
       "rescan": null
     },
     {
       "name": "accountB",
-      "spendingKey": "a9664acca7568b057638e3b726ced79f607ac5c4bc6bb372864dd79d490b1e7b",
-      "incomingViewKey": "bc596b9a74175561150d5526af4ce3ec187258b121ddd86cdc6966d643e98b03",
-      "outgoingViewKey": "31a416578ef95fe76c31e129cff262f4dde000796b47325991f6fa07cabc736d",
-      "publicAddress": "7b487793bc58b623d7b71d069740a368547b04f50e612a403972040618385c01385116ca76f8554e0b8f4d",
-      "rescan": null
-    }
-  ],
-  "Accounts updateHeadHash should remove entries when called with null": [
-    {
-      "name": "accountA",
-      "spendingKey": "6b29c754438ff9a140bd9fbb43f4adb2004dc47f03be9667c857278cf70def1b",
-      "incomingViewKey": "6ddb24bae3c78cbd2dc95e4260eee1e2448b3af32c02e1bd636148233a673b00",
-      "outgoingViewKey": "5febaacbbe3530b52babb3abe3b405e2555add690a6019284428a77e3fc5d01d",
-      "publicAddress": "119c996562b8443a7cd6176d0593da317dc7199f3cd2afe5375d96a53fbd38ca9f281cf1f8cde3807bc4b0",
-      "rescan": null
-    },
-    {
-      "name": "accountB",
-      "spendingKey": "a6494ffab0b69fae158c25872dbe099bf34de379e929ed4d208ce69268f0e7e8",
-      "incomingViewKey": "127a0cc0f2cffd35c503679daf25d70ca802930ec6c7ff28f879aaf928975f01",
-      "outgoingViewKey": "0b31f9845cc59a549c47f98ac0e1ff70fb1a305b2bd100594402d45e162295c3",
-      "publicAddress": "eaf42ccb15e15422389171e697923281162912c4e81613cd0900c971222e2a2990f27a2b2b792d9ce6b8b2",
+      "spendingKey": "6492ae5fc7608776b3c950d6ff3529c95e4a563566d7d9869a20ad38e0d70202",
+      "incomingViewKey": "37060e4737644bd510184066897f8fc87ce5b38a0a910548c126b1b2de5e2004",
+      "outgoingViewKey": "428fa396f4f9b3c58e66e15870851da44654fa6da33b32ead3466dfc0b84fc17",
+      "publicAddress": "a9391ea4b15f890b87fe3e4bc469ba30e48b3bacbd5e99c271a2efc46425cacb4383e03b50b9db30b98d5e",
       "rescan": null
     }
   ],
   "Accounts getBalance returns balances for unspent notes with minimum confirmations on the main chain": [
     {
       "name": "accountA",
-      "spendingKey": "4481f8d27efaa529157cc8aa2534c490f5f188fe6c3634ec2ce4dd8ccf9b4126",
-      "incomingViewKey": "a25317181569120ac643fa148c0796667e269280600dc2994bb36f3bc4c73100",
-      "outgoingViewKey": "4a0bd08efe0cf328058e9a6e50545f0bd35dc716cb20a327e82b9bf32600c4c3",
-      "publicAddress": "381da49f41f2fe392d5dad94f4ede917592012d82a2eff6fe8b898ca2c4177bc8094746c6e8259268b6218",
+      "spendingKey": "789a0072889ff6db3b308459db8bcb227c2417281cf5feec45eee1c8e4b7b06b",
+      "incomingViewKey": "271cb1e8d4cec5a30ff6c2805e1f09f3d81d932e7801e66dc4ea61bebfcaa103",
+      "outgoingViewKey": "db43d9466a4a50a499e966097cdc5b01a9feab09d2b9b8baf32305e63d1a4c82",
+      "publicAddress": "d9004d41df688507137246cb238f86665cdeaa999ce076c1cee71768e0aaeefdb27d20fe0bc1d21f962473",
       "rescan": null
     },
     {
       "name": "accountB",
-      "spendingKey": "513ebe21418cfd783e77ba5b2b84a4d08cfaa7ca18e58aa97b05135cd02e5e90",
-      "incomingViewKey": "73c87a9f5b0176744905727b4676c6a6820f8c99fd97f26d87d7d1d0acc2b100",
-      "outgoingViewKey": "d3c4b28cb3e97d3490734a5aa9ef94c2f5c8fa6d5bb6d0516271906b2ae197e1",
-      "publicAddress": "e6c937f96061b5c154afd5519cb5d790ceb42457f1beb25dd0db30842a6cdc36288bb7bbbbd5fa4f988686",
+      "spendingKey": "50e1dd9baa8744e11c2c1a6b9edb3dc5eb671ead6dcd7e5c771cc997d79f5e6c",
+      "incomingViewKey": "7fae66bf0172e34c64e6d657cc4199efeac54e7d9eef5cc15796c1175c2ac500",
+      "outgoingViewKey": "7b1313ede7e29ec55bb6b3011a4dcd8dc4322940f0391c8917efb4d596c89e48",
+      "publicAddress": "702d79bfc22d6bf7be17989baca21abca463ead3ce1109e7a401be449da4401e0eef11d4d43fbbab46576d",
       "rescan": null
     },
     {
@@ -171,7 +153,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:03jVk+isCPgj/PEnmnvaeM6mL2C5Lbj/dQaGW/DjWWA="
+            "data": "base64:N1eLROdh1VOg/8w+B5/I6ck5ZD1g1fXS9AxxwI6eKy0="
           },
           "size": 4
         },
@@ -181,27 +163,27 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1656542832358,
+        "timestamp": 1657142802298,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "460FBCDE52D802126D44F9D00399760630AE35170C1C7D6B3B560A9591970022",
+        "hash": "82D7B6B9B30B866528FBF52F3A66B5ABBE0175818BAB05D333F6FDCA5BC1942D",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKIo0ScXqbGY4gpP5M6T8J6wERRsqdS2HnRSsSwW7cz4+qaribMiSVXe/Fbyc/pVFbbG/4AufGLCPpXXryu6nrvqaqkf37aQfFB/uQps2/Q/S3u0lTdsQplIGOL6PNHhBQvyVk5oogTcNp+WBWDqUIKxjBvVpk8oF73zWevS3ZHC0igkQNAoBhp8l+rWG240XoRoe6oe6u24prZl+eITnNCG//741n6q7OqbCW8k4mxIyA56LysJX37GmlMW0z8DHXE78kK4Ca/1wO3DTSDnZUOlxedOks6ucIwmGXgsUnzLccAKFG1U90ydJkCd33m/Ar2c1ZIgGGhzjKVQr1vzckzq98o6TN02tGWeYO80PwjlEQW4hX8cX4D0YIQfhuHx5rKfPwjmafp8SoFu7ltb8Vleu0KMxDgEo5rQ0PPS6Lt+oYDYCt7emMRSXw3cJcI+G60XyOz4ifEImWcXnKyvFxkanDtPkHyO92YlcndlKnNqPHf3e2cyvq1PxLSJ2vp7V7kuCUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvLyqJfSN7OYSiw04/0AkxPfXGdURwERX/iabAQkNSMIDaNeqZD+ocN2xZuWUPpSigUvPmFSkQbfqIYewMkDxBg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIedp0EKHhg3w8C524j5CUGZFiGm7Pqu7tQZBXKRNBrLlZfViNZRThsPBUU6qdkQk4Q+xVi42cSuIgRoOwjs1tgQhBf2oqgjMSP49j+kPKU1/S9vtSzQhDe1z4I41HUKkgVhfLy5F6vrbRFgch5llhg2yXqfoWXPUNF+WWJ6FvNXaxnBOm4EQ26bkTULApfcp4RhEaZ7lbLF/uUWxVDvXCEbfbHZsW3VJqfHWveTAE26SeZx9UfiAgxCzx/MtGVAFw+fWM8D9XoF58lU2TtapY85HrfCGPk6NrYwRd34o6C1OR0rtRr77iQQbzHom7WJpkqPbaJQAStKXaypYQerygWs8MgQ8g4bjbj8FEMe9HSbvmtKWrkr3nbWsQlvHT03YrjRW9l1CJkUxyMz81+Wd2DV5MEfHkQEfJ3hlwu2YZvRZ4uuUXKkvJJQ4J12lPRs12G1oJDPp7MPKDV9NmzizW436osRhldoT/jX6trdv2lbEUdO37ZxeYjoFdjHUwBHy2iRa0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQC32U0lVuRFiJbjk/orm0nStGHgQWN/akpQCM3teHIqUcVyAfs610FgLl8qz5qJiG8G5kCon/TglDaad2TKIDA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "460FBCDE52D802126D44F9D00399760630AE35170C1C7D6B3B560A9591970022",
+        "previousBlockHash": "82D7B6B9B30B866528FBF52F3A66B5ABBE0175818BAB05D333F6FDCA5BC1942D",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:jDzDoA4YgZCUVZIUOiy0jkWsBmKv2Nmm5A2duvlVAho="
+            "data": "base64:RtfrvZfge3K3II3FimLCXGUbQRYL+Zcam0icrVgY3lE="
           },
           "size": 5
         },
@@ -211,27 +193,27 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1656542832506,
+        "timestamp": 1657142802447,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "ECDD4F55DCB9AF2D743319955F7984D87807FE73019525DBAB29D367161F3315",
+        "hash": "CFA41EFECFD8493441FE7549CE13E3F87B42C10F1EB8DDFF4CD248CA7AB73B4F",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKrMhFYyQpQHRsMOPAf9j8EhixPJ4rPTmnvdH8C5qB+HhKtPhwFK6n2u+h8EzpJCdqtEF1gpS2HOUfitL25DcHlsP8gOxdiWlVHbIIoJg8pI0T1z4YDBDCNN7E8jUivN+xNPb1dZfgoQTTz4ef9jH//25uMcXqxnFc9ZpoD3c9LU9mDHCeu1hVGwzCCFSule86+kjAbTMLImwRnRXat9+6QWAf64hNw87sf/A2BssTjLNHKXyBKaRZxrT7iVMX01Sa4a2PebVg4vwJZaLoV7RxeN4hWv5Dm+x51Fnz4UJMoefm14bBbNTZle4N7RIsQeFN7stdHSucHUxULWe4MRznBWHne4RIZZKGKE/wOK2jiRAQteNmFsOG8efJ3pXlorFMyIjdp5adCABGGQ+I0ot56M+Zr9B7ULZ4omePDiiP5lLM885sXryR8Akj9l5FH4gojF9R/sdgiUP1tngLEDit+lbAsn7zd6s8BEoCM9BcAST/nUdk+Svwb6OMBS+rVk4ydpgUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAww3sS3MHeNsjHhQ0eTyVDS+Yqo4mmmuzww34Y9ZYtOsPb/w+1YpvTVdrLzUgCa24IC/d4Qmzq4zdHIWZOvtFKCg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAILrNiLuUZm0w58Ll0sAtgMO0BkoJ3r3d6wtFCUGoAg5bpD/HFYAe9iP3jlnoNuQtaOB+7wsvraSRg5XZVak3meiI9tzstOwF4nCRips1L0/KDVqX+AEsQhUhrBL/dx8GxHdiYWxDDDWlAMPHLk/D4ad2Qxdg+C6VRUlvJpicfzXakfxZv0OveP9VaZqJakcspIb4w2lJqzqrq/CcK/MAdNztZ2HLFd5o+HNJ2KgnLlP+WQIBU0+FEhrJH28cZV8iLz8AtIcaQ+XWjQETFfus5ADBI3Xz/myx/nQsUkVAOAtDJ488OkAneg30c3hcWjvcL4F5xCAz2xcmj+pbyC3lQPLExJmovlhFg7LsbaGdG7FEquE+u2BoM70KFaJENumgHee91FdGkmtB7+u/KlFEZNeIEsl/at2rP/dRV6xSSZduI9Ip6GrTbsws4eYLp+P+cJnh5sGW8FiLKbnAQ1x9y6F/yV8D04xqwarPSHZlqmqMAvALgPtsyiaz2BG6QIxDveB0EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw671E0wY6bor3TJzvkvY2WFA+/nyLgeWNrsWT+g9Zzbq9FGnVu4JFesjW3IPG3OlYKFovwQtBvoLYuZFz26JXAA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 4,
-        "previousBlockHash": "ECDD4F55DCB9AF2D743319955F7984D87807FE73019525DBAB29D367161F3315",
+        "previousBlockHash": "CFA41EFECFD8493441FE7549CE13E3F87B42C10F1EB8DDFF4CD248CA7AB73B4F",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:sP+SIBYKvvh8K2GEORq3wnps3yE0cUX582JEYWqP1hc="
+            "data": "base64:07fIjxKgXK2wH+12bL/rVe1JRE8FBYnxmfGTitBpnh0="
           },
           "size": 6
         },
@@ -241,27 +223,27 @@
         },
         "target": "12096396928958695709100635723060514718229275323289987966729581326",
         "randomness": "0",
-        "timestamp": 1656542832655,
+        "timestamp": 1657142802595,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "922D22D4FCCB4C5D88C11AFD774670158AC224453FBD53E3F2A27D18D497FE27",
+        "hash": "EBC52DD4A039638EEC5A81B01E9A6CE42C8E18E815C2B468CF7314ED7E1B7114",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKNL+50eghf/QqVH3Vc4uaUqmJ1BNTJjzkRvKCs+em7A9jg/h/JaN6tBIQJUMM/QVLLAk2gouxW3JZ8f4gPbOp94otBvK5d9w0S51nKf/NvwwCqvqXLjMqO2bQhSPyfa1AMxaP/mdZH4o2Ui2jJYJU32f8ZQ36sPwgv6IfLLRJWFl7e3+IG0KD/cdIDDA6/hR7kuXuOjH3nCNEaMBcwf6U8NWlI/opEI7rqZqyRN/M8jp7EiIszSZkFwkUTIejZ/+QM30LnJXo0KmhXgi9mYKvZrjI5NiEcJDZ9WEPhOk8+cS4rXr6431OIT1Nz0K2IMF/mG1XDpJLftUJ99WnmjBwLzZqcvh1O6p6Iphs4+PLA9vjtunODMP8zNoMU5TN1w3Nj3Ao3ft5f6dS6y5OMcpatYjkpy1+cA7+K+DMbxUhN3rmi5gSJ9/+7LKkJqXFOWxNrYF7KSzvm8Ik3MYsWXlvoxEKb70tnf5r5DofaUrnJEgXbpbjmtw94bwocZB3CIhjljkkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwgUc86YEdBd1Xue5Ve18bp1ifIa5h6nAxQG4DVyPHt9/Rs++G7OvEGamzlbxUtccLmz5b3m550ftCh+tutZoZAQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJbUiTqBjmvQCIIasmCJcty/Amd8fwG6pOp0LafUhqVaj3/giMkXcJH1RlUwJHHp/LWfn4DGC9Bicjrg30u8AEuWjwsYwEcWqRsqDG+qNLMrovKlR454h+gFDVR7YPfHpRaPgVvsqagptHKj1H642zeCSE7i6LnYxi88ZH8MmbBxh1XDY5tr8gKFuNVFpjnil4o1NXWJ9aS/hdxP9InrXAHulcY0gY6DB7sGQAKplevzZU8s93E2X3Lm/ozLto2Gg0Jl5dhyF22esi/5femeqOWWHADp5TBAkm4eEm5N9sWTqoLUGcqRXKgMVIYZeJdKEhCzi3OWr509jGTlauieORkF8HOGa8ZBUhTlHbjWX9H8pXVt1lE63F5VpeENn4nTvFHclBaNi/XLTQdBIuBEuT2WdDCH4UZGLyWkaqORUBMXGNKJ7DBwJy7xiaTRLzm0LlTG3KVBZsgp9O09/uEIxJUINSGt8C1Ep3JEfMIZBLsAAP6cBe1Uv9U/ujxq9FYa4FHOkUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9vmNUjFmJffJdZACm/y9xS2XYZLKC0tweOmSVvwQD93b8d+HxNdGaniJGdrSG60TyFUyxhiLeexvJBx33Z5mAQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 5,
-        "previousBlockHash": "922D22D4FCCB4C5D88C11AFD774670158AC224453FBD53E3F2A27D18D497FE27",
+        "previousBlockHash": "EBC52DD4A039638EEC5A81B01E9A6CE42C8E18E815C2B468CF7314ED7E1B7114",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:O2XPCRy0eq/ZVIm8+5ghWjmOb2Dd5/yEXyl/K69+mhE="
+            "data": "base64:j/ub8OiSFmqvvZyVTQh9rlMfD41pwcTdaklKymjbeSM="
           },
           "size": 7
         },
@@ -271,27 +253,27 @@
         },
         "target": "12061061787010396005823540495362954933337395011119300165635986189",
         "randomness": "0",
-        "timestamp": 1656542832804,
+        "timestamp": 1657142802747,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "E1AF9C9487BA83EE74D5E0C5286A563BF1B266B408D69E8E5FE15674A5082899",
+        "hash": "C6795E1ED63EAAC0AA036B29CD1FFD56EC5004EA8F5ED0E62D8C3C2C13F588D9",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIVYaosz9qKowPb3pt+qfEX0Ja/RCuM5aTlq2tJ0/7pJPj5G1ADZdCji8JAorVTzgoJT0qsT2107eybDkooAgaBFuzpv/p3Pb3CSGzhNMTC0UMelHzWHN5Jm+TEjzk7jCgyNLg9fkqKU31kSehCp3eQi3I+t3aNlq4eJQ2RjFn72UUDT0KqipOGl0GuI69wHxKG5YG3+dbWqiVRW1so5nm/MIZIsYqwE/j1/glf9+6sjdw6JHwUsaryK8ld17j4PfJIc2/kM6HoT+bd+oK0qBkQPKnyGIFU1sRIlmqHYL8uZQBYqzRb6cAjAeTzDETzOmljfn+gCBHFhCoanGjT/sUUkCoO8LBo2rgBABFeVEjE4fVmkTtqtPhKts4Weza5F8bj+DUkaxQo++yj7f30qTDBxbAlASErLLKfh7Hz89hMnUijkLEgRrxnaeTGhuaZQP544ViwXflj6y6xNWt/1V/hbQzqGTA+sTQupWUWGSjJHfWCF8t98WDV6UtyASpgmGP0O2kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwk+nygEp8EUIBE0H9C5mlQUZh0ie339wN8QYkcEeDqb6VRkXjmmi2fiFKZ3sfZj25enEVL0tvu/08gCjc9K85AA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALN+N24KFX1HWQYIrY3iDj2yUPPokuqUQfF1j+T1MPprVl6b9dlwmikeqmETRNrTcYMoYAVGb10EfcN60LPrflCFU6P+4DANBg2U/0+SvhlkCL9ihz3BZti69QkoYK/slQxDG24IXxM/rSEtKTtzFQf+Nmo+bV6Ee+AmVoclv3nUzMCzD+4XJcqcZcGXlW8GQJVsgu3QsWGro4VhUiTcQorTFuSa0U8VRTPb+yqJ3P7Xzqv/jyPHYLdqQbrA9dvN9w1UwBncjXOMHeYG7PH8fqw4rQaWaNgY7vXEiVHy3gIvcOzYQHyrD7qNRLhFNtFXGldT48Tgl3TFyIyzPGcgaA3kHfIXdFkXNn8j58wdpHqlrifRoRKbcQEzJSPwGLj1MPnqiTUaZGojZTUY2UGl51z63ehNmAjrhA1RNvL8iIkcbl9MTAZN+Y50Le5xKTEiAsWN7aqHLBjOzITNSgluPPQB2vh+iSUZZAYAwo1jYfMMFBhA/p3pM8cD5MK8I3CLGvtukkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8noUphS2YTguAiqx2SKXbilpDqJXhyWGvr0dQSUTYRfTSDOhoHfVx4StRayc6RdY89KJrvINB8bTbda4VVG9BA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 6,
-        "previousBlockHash": "E1AF9C9487BA83EE74D5E0C5286A563BF1B266B408D69E8E5FE15674A5082899",
+        "previousBlockHash": "C6795E1ED63EAAC0AA036B29CD1FFD56EC5004EA8F5ED0E62D8C3C2C13F588D9",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:cbnapjbKp25AXy2mpSpy9A6m9qa1Kl7zfKAg8/Npeg4="
+            "data": "base64:KjzdbIqhFiYLOjDBT6wOhKUQ7nvWjflN/ZEF5x8t+wc="
           },
           "size": 8
         },
@@ -301,16 +283,16 @@
         },
         "target": "12025829863586302258274667766838505692576214880101876262606819815",
         "randomness": "0",
-        "timestamp": 1656542832955,
+        "timestamp": 1657142802894,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "90A671AC0D624331CC35B371B7FF4CFEC03A160C18205F8966796006D2E90598",
+        "hash": "1FB34C1A48D37128FFA81C41AD399F9C2C6C978EFC45E22A2FAB896C43D3FA66",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJfklsX/29oqe7N30TlnSsNtG6c6bKeewwSA/mgYnG0euroNDH/v00CUygiuyGyS9q+pQGcS6CvpuZXaacjMdKgHNF7ywUpCnoPeCdP2M2vRpVnR7ceQx+8bEf5+PmHtghmGlkjAGpb7GE71K6/aeGKDFI9HT0FKQjvGa0gNjuHgyGYMSSxckzNWRjMc4uYeDIsU+rdJbmaGSPdCSXEUAI6YayGq8PVi4Xw5ZqLlGc9vfhQZUJZEAwApPg8hvybOuZGdnDZliRaWO3SPex1X8EQ8pdOaqDOwQFlfcAngfumsgkYfi6ceGH6WXKl0Dx52+q4sidHOSRg2UrZVK3VAxjml3e8Kx/7suhAI56irm6W6b6wcXn89Fcda0DyW6eHgT2nfkVhN8C1r4GzNwUb/sA5VlNI8U6crCyyK0yVo3ig5zaa5hLzoGPEc1zQPUqHxi3muEBd4aakGLX56gHbfjYmguBimYuoK6ctcHT9GM1ZYMCNY8CNi6WBvqEwM3FYvv8L5kUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw10GClPPhUObchLLQ9Ah/2Ibsw82IcG+Qc7JUUy6pm+HnKbO2nKuAHaBNUVgxKg+HryiOV0pfn2PsMeEFCCppAQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJjRHL+vn916w8lWiZEFRTbKYonnbsKVesrwoQkwRz05T+CX3bh/B9/jDjm3rNNUgZFxvRVmNbryOmf8EJEV6KBMUaczH97WRyOknXmBZ2UJgkzw6cdbi3gciLCWyq27tRBbkKmik/EJlvEiGd9spZun6jzxhXIJuYC2PKrbp6RLPC70Qm336NZgAhVkOVaSzolI+d19tCha8PwnfJ7fEnxkhVHZNqp4hN4k0gg4OKObXzhgWQT11bqwXSHxsmEpZZm/nrtfJX7ZZg6tNCgGELbnXX/C55EwSAM3kstmVTFdlUz4v6upuuw3jNfZ+jrKsHxnXGqlm7aLz23sidO7blal859ivVj+5z3fv6tRt7S4WzHa0Ik/ve5cctszZkp/ZyTsKPTHcZPYEfD2tbP7JsLLzxNNaQc0utCF/28jFn8AOmvL5XAguv0vtAz+InjR1/KhpiYhtgMSfUFxma0gh+qlPjAhjqV2tMPCRYjpSJNvQjjBzOcHu5yTYsq3Z4550q77QEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwixhqRFAlaTQk0DvA18ZzLgda9wgJW+VDTf/BYOE7b+ZbXDV2dOvfHiBhkyrpLss/xqIOn4hJGzwmLpI4eMS1CA=="
         }
       ]
     },
@@ -321,7 +303,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:rPkf20+4w7NfqafYTNF8avMHTQinyezPrbFz4NJbPGo="
+            "data": "base64:+80YMXI1kNUdqUSGi0AqB1ZF/4VobdOPfR7/oqE/eWg="
           },
           "size": 4
         },
@@ -331,27 +313,27 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1656542833107,
+        "timestamp": 1657142803045,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "1388B975DC5C87AE17A0117A1DF03642C64E6CA7827787A22B31AC0AA2EE141E",
+        "hash": "344CA9525C28456A4F41CDC730FBF9D9A51F3DA360310412C008BFB1B6319D59",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK0gdthq2LmWKSKgGunQnvZdsnyBGj8RjsE63stZ5rs9/ugB3w6FeIzDxk8DhboYVrGmJce5LtHGylckcb/Yx3NJ1FBbjqc+cNIqnFvlb1pI02JIb5ChXy7GWz37NjejzRj0G8UDCf/Uvx/rvDN+021fy2GejSXkAixTTdIjZ3n+yIQLAwCZaca76ifFwHDd8IX6VQHGhK8S0EueqdLZd46Bys4r/lq1X5ypafuSYjZUuC7Ur9hyPFhWVo8H4R0Uet5IHXHV8Og1hQ9Jd3MHxVhY3xeNJuyjMVPXo/3bSB0jD1Hrx+Y5YxuP9HfyV+jDSWu5a/fyRfnFtKgVSzTDZlDzSwfaNONUmBAb/ARvY3PmkG9MXLRAyMzY2W1rKkzVNTNCF4o/V/XOd4iqwbBh9ExiTqhxtqrQT/ws9nDECSXf3hYFLqJTgulnYbnM6JCVQeWCsimYEzjMMdqN2dgJ2GxwFkbgPTJOVqJjE4YO1GN0RecUiv7gFNLB5i/6isCR1wE6pEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDb7O0DLGwfxQK80EToRbQ+MSZemIKJltF9c47aTv5ckHB6DKuNOFxOw2PJR/0GX2HLGcPAmk9Ukq4pMuJuSFCQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIwz4LcSIvOZZnDA11xocLRaXaPYhk02ehX0ZYd/8/GJYvjOAopWJKZMCW5e5GvyWKk9wOgmooz7LKvf+BGNPuhVU8rdKPu+qKKB9XTEiEjGYoYjlsu28s3YbbtvrGwMvxhv21Ptu1vYLAGVu37TpSIrGKt/B4hEZjZaPGJb+bdZCqOsUlnF/p2L9qJb2EAj948bavxWz7SBKarQk4sJJvivKc7GhYAQZfpkvxAl+8xPv152Zr5ua6eF/Xd3nh/b8fjxYajnAJW8gkWME33kLM/jwWOqipNPVhGckyITY1g5mwtYU4v26zynjEBAMW9JlLZhszqSLWpK3URTYwhKTWJCTufU71F08OalwhFApL55XLmZqnkzohyRDXMCSwxsISrAF7J78EYQHN7PLPMCe5brgKPBLsINIWKad3UhgOnGYWlAjpYcUmmdiin/AC99IhTU/vYPB7Fd7y+lzdiSaWjcuSkjy5EgzpQpV+VGcB3LySvT7N1ZD5IlL+Fb6dwMjLRDTEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTsg3YnRgntzu+gOmRq+9Ts3DDJ5nDTXyqhmjvfpfGFy3OZW8RacXad+u3uigkBlDgEtGfuWA+ccKevf/rcWeAA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "1388B975DC5C87AE17A0117A1DF03642C64E6CA7827787A22B31AC0AA2EE141E",
+        "previousBlockHash": "344CA9525C28456A4F41CDC730FBF9D9A51F3DA360310412C008BFB1B6319D59",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:v9ZKDKvjIuGvvMgOR8IC6b02LHWgX3rWxpliGJodtwc="
+            "data": "base64:DLHIix+2wY+PgJ3TTGQojRZdfjEhPUtedvv/uSMKtgk="
           },
           "size": 5
         },
@@ -361,27 +343,27 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1656542833255,
+        "timestamp": 1657142803193,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "A3394712BF0D71B6D31606423C9D426DC9CA173B455F36169A76A9D25B6B5B36",
+        "hash": "46A7A1E35208D364AD689A34E81298AE9F41B2DF06E8E8DE591303A9404BBBB0",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK2gLCtQVnPxo0iBWxwaw8x0A4sKrKSNDPK90ZCilxWNsG3IpfpUIWmZP+y3ZE7Ho4/RaQZrEFy7YJnFsL1fw/Icy3+OCWzTo4bJGQBM1ySxLB8CUBIrHDvlOT14mH0toBb9n6t4GzgsKcQ0ej2qAxhjdzJuG6ixI8N0aIFRvl8N5KOEyj3wGQp9imdW6J5c8pHd7JeTmiyxoWe8fPeXNj0arou2MH1UHVkKtFJzQoEJgrLBf2ypgr5Xf7qxVLH5OayBqqHAmkCmGaakDNaUp9QIBmzzq+4Uxxit2soQat+fp21yHbPwt62UKHsBwOmIjLsWZRCZoyzyklAVdGFkoAUPHTZblehQtYgzQTiB4sl/Nc0XpGuIkpbArUItCw1M2ELL/2Goyk00vqjaX9iTOSFeLQeaMnO00ngxS0m2qgCNtiVmaSizwk2rY6clFIOI8PgVFyqChbeM685c6y9BelT98G19il4JP85/g0bTh9I8Q7Y5yuN/oko/Ke8KeAKnT33Sg0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsdHTk7RzKgHxkQMMLzKrAJl66ArgBYce4G0czUFfSprhOkw7HWFazLYomUAokKWLLOV65YEI1Snv6fMnjtP8DQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKkXTsp1GrvVC+8zSOlz0gFOwG+2Jhl9PyH1CGCOipFInPHG+IWA0Dxy4Qbzq21ACpCuycxwtmi/QzocvjIaB4LXZs9sfvX3RzhIHEOiYG4rs7bqobzzjLYQ53pltkm1hwgv7OSZQpQc5VyU2VT84UwUNiV1Ax6sUQ2lttErEBIMwV78vmQw+GmgwWkLGHiZPrRYxNQIFbqZja2ZZIfXbgOdD3OLRIG6rMjNxRSmsngUX/roPvPXljFZZ6YomUF86JnXcStqFwk4vN5xMFnkfEJd+tsjY5pb9NUXkBGWOkeS5xuuxEAeeTCxyN8MuYL2b8j/MX6TL+q1ehbHMZ50TQxXcv5Qe6hDeXlKl+4jvRH7+PbGSeGaBVJt4dqvOKNg5ra1fuz6VzJevOPC3BUIRW54zDsaWeBgMNyAdt6h/mLgczPMMFdy4KIYKU58GT8t08Bm3xsuxGuL8gP9mgFKtXoPeyrp6Ru+cMFNPEHVq9XjIoOAZPXuMfAUau1WYUYg30b26kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwpykI+WQTZ1NxwkJkZfvVIAQE1C4M0GOfmrqxl2roTufmbKdWvFyWxf5JV9Rgacgj5wfj2+y6aVfnBCq0KoLlBA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 4,
-        "previousBlockHash": "A3394712BF0D71B6D31606423C9D426DC9CA173B455F36169A76A9D25B6B5B36",
+        "previousBlockHash": "46A7A1E35208D364AD689A34E81298AE9F41B2DF06E8E8DE591303A9404BBBB0",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:ij/MhJ4MjEZlaIlkVsIIrZjyRkuhEby9ABE1Ww6lhmY="
+            "data": "base64:26NXe5L0tzNQSnrAOqnFV6BbEEwm8ZN5n/94ROP/Dlc="
           },
           "size": 6
         },
@@ -391,27 +373,27 @@
         },
         "target": "12096396928958695709100635723060514718229275323289987966729581326",
         "randomness": "0",
-        "timestamp": 1656542833403,
+        "timestamp": 1657142803340,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "D17A45D55B2DA2328F83B54F4BA96965962944691BDEF1647E8618B83F71715F",
+        "hash": "A52E9669EEB2FD28D03000354B352B1F7BA275671E79F8FC51189323623B2141",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKpSj7Zi1pmyG1XOt/nwe4bh7sI+hl6Y2xQKZhqvBYCeaOSUbQ0tRuRBTrQ6HXdRRbHo+Ji2LZUxTdL9aEjaW2O+7F1+WYyNM9q+VtSHZEs9xOq33sTlGN82jKVy1tPvlQpDjL9/RCQ1Jd8YKkzWauXNjmckvA4n+Dz3An1oXTOjnqOE4dluBtb8YtwE0ay/roEoQjR3ZQ4TcwJwU9clEzBnK+e8aayXgxRuRdSktfXnX5f4tldTufAxbk2Bej767+PekFyh9R/UoUZ0Zb4ZvqjrhVIm79G+oflNpimKa0AVlXFPLp0IRyvH+w3H1v9/HCl0RLdhSBz8eC6PBE7XZ1Kxj9ZByupAPQAAFLOZV3qpry+CLXhgvottGmbTetZXSc1Yu565j08TSF7C1bjXTRK5Hr1IMhBiRulfwYBPhk3FNbLoHo+eDJeR67J+l9ADsuqibFc/IOt8G5BvbpnsXo9rH+KgoU+t7h5JJurzXwQqi/xefqBJr1Ja41dw9u+hCe+FgUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyeuR8DIapPkweUJ4vMi6Fe+MwjSkP8ciOTVD/WLZTqLfaoz92qrHlXQFwH8n6uDTW1Euy0KrKe4VZ6SRPWd2Dg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAITjSpk6I0k3F7KD8oYBndE4OQtrKTWH+iz1p1OW3DRljhEHRwS40LgETN048vzVLY8U9WpSfV4vJ4+q6GOTFA2AVlLpqc6FYvW9lfzcoPG4WFRAbvLuEhpJ6RqBLrfXMgAUDMVo5FGVRH8sa9uC4613vTchAk5WWwxqI0CZ3KPMTuhPWVtQ0EEe3Qk1m8YYlLP/l4pMWtfWlY74LiEF6zfQ+kGu6KPc9RsYISywZL1dcumn0k0UhGZSkET4Ss5AqKi94Cu9HxgiDVel+FSl82ZffARU5m477429BcqRrvm4M1TsEpLkKUF3/yF608IkuBsiKirEZf95rng5yit7LVuGzWn6ozW7wRuolul8tNZyxyhlKdYQ4H4AbHPFaF30AKk2e+Lvx51gvUCdtKuUNOcT2hMuaVttdCeMUYB7xKwKanTpYrFBrBreDW0X0N6SU0NBA/NVBAzkj2ccnWa2REUPE4uF1TqcnFWW1ci7pnh8ITQxPhPRe8zwS0SiIPZkEtP0OEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9TELwE5l4m5MrLwmP/elQr1+UDz52ZJ1PQWkrPUfxyORIZRPD/8ACWfB1dzUWJhAF22we59ey+Uhte/XWbkeDA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 5,
-        "previousBlockHash": "D17A45D55B2DA2328F83B54F4BA96965962944691BDEF1647E8618B83F71715F",
+        "previousBlockHash": "A52E9669EEB2FD28D03000354B352B1F7BA275671E79F8FC51189323623B2141",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:H1rfeD49lqI+2ZDHb6ZEafahN8Dqa3ABWNvZLjWjlRo="
+            "data": "base64:rO8aeEYP4uVFtXfgw/GhgBz2iYni3bcrFpCxbc1r1WM="
           },
           "size": 7
         },
@@ -421,16 +403,16 @@
         },
         "target": "12061061787010396005823540495362954933337395011119300165635986189",
         "randomness": "0",
-        "timestamp": 1656542833553,
+        "timestamp": 1657142803489,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "2F1DFB599484C7CCDBC19309DE01DF3A892C079B4219F6BACCB337361792BBE0",
+        "hash": "9286FBEF1A1A789B6F63C2053A17D56CBA068B9C0C89545C61D7BC486BAA651B",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJR/lYiHFRPVWtuNGRG+eA8N8coaLHaT975yxasUPHpsh+dUV5tlgvlJxw+lRN4504obPhui3xPxjVvoPA57VD3YqW4WZ7AHKDr+g/Kl6C42ta64r1dnQkQk1gy7b5KXugtBhNdtYEajYSgeSa+kY27+tt7Sy3tx0Zn3czLpogVm3I7I29i4S2uH8uPfHRduM4/1TPxsah9gtRS/cuYZ0x7n8TIJ+TyzOIVI7P+EZdFdlxIoVPdNf1alPPt8WU2Dgbu97QN6Pva9n93pgkwGEfTAoJHYfGUmYVwbfKS3W6vC5xzyjnIb4gvlpeV098e61f3AZ6tul4B/1WtQBbFSVluepJBOJbzSkRowbdIU4tGOhehrpK2e3Y8XoeWo//abPE1hqSw9vZ+WqASDXOj6hTorp0RIiC/8O1mj6KOAozhU6+bqAVEMX7a3edj4e5rIfggh4qlmW3HOAA/mUww+U6SZYCHsczo+PIioyNZiGZazXpNKYJ1ShdEUkaV8E1+y0gUxuEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOWDMpnGTkUkwPyOmcWOOwreBtu2rHkG41nIktbboAmGxqDZQQhleVvuHQ49BIfsnZP0hZ6Wb5s7gv0qxYQMSBA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKDBFmQcS9jQ+7H4mSsdA8juxVioSYE96k+gmktRMGNeucbFUBJDqGHnzFjEwKUiUI3nIGdda0ca+tM6uUDXZ4KuTmj/P/u/wcgI681pET11jNyRtXnClRWUeoslFQx45hk5IxJ6f6eIC1GYenRrZaVqSVRJunZc2trDoQXbcpXMn00DGyuDSND8HB0r6xWqD4GgtmGHXxhDVe0rwn87UywQvwJHs9vmDw/xUaJOScAGFqi2J063RdvV9c0UM3iWPQ127PwEBgVJN0WYn4960Un34zV4al6gcSuLyW1D0XIJ2b6Cy/FVYXY13ecQitT2sdaK1A1f1hhrsPEWbVQszV+7PeyOgyA1kIVdkkNjfg/BoLxnDMtOGntUixC2msGIQnJnCmkw8HVmTSbdyOkY9RCSaNe1ymsISW+zRtgN3p/BZxclwdRNXri9IfMcn7g2dU8BIjFKqyw6MU8Jw5RGmoPGAMfHlCMdWtTcj64J13E3eYMIqE4ABQjSfbfKg4bIK6t4skJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwPmRAQeeyyUhSm3Qg4pMxjaf0tnFDdghivWjPQU2sEBAqXYK35jvvKN0mKI5X/uHRxwEE0+KYrl4/dZj1xtgaAw=="
         }
       ]
     }
@@ -438,26 +420,34 @@
   "Accounts getEarliestHeadHash should return the earliest existing head hash": [
     {
       "name": "accountA",
-      "spendingKey": "23e00a0325e94674b752294e629869b58ec16deb7a4ca3618b0dba033e45ffc9",
-      "incomingViewKey": "9e92df70c24e4031d4e7f16a9b9f638b3d4c95c9cdb7953595d168f5a603d004",
-      "outgoingViewKey": "45783d9403c7ed6b88e5ac9ec9787d533aabc91fb7a357b3d30e5d4beab17760",
-      "publicAddress": "a88d9a334f648588fb60f63295f29542a6bf76a46232aeff47f72fa25ff9e77be5ffba037cc4d11152e533",
+      "spendingKey": "0c70294d470d259b7586df98cddc24fc36479b188d42c2e67c6da06d9c63c17d",
+      "incomingViewKey": "a53aeb55f36fcf2b09307f6a98fa3a4f816bdd493e9a20637e91749d6eb05403",
+      "outgoingViewKey": "18be89ed00eaba44ddd924e2e1c3dcf31f4e1ab84247a3c2b2f9ba14277513f5",
+      "publicAddress": "e74d049f5d75437e15427a15c4919158a721be62f6078ad5f0e25f03e58a4e0830216427ffd915dd580735",
       "rescan": null
     },
     {
       "name": "accountB",
-      "spendingKey": "cf2e399d8773a7d99af41877fbeac3f9b78055483fb973711e030892bfab14d1",
-      "incomingViewKey": "d50089fe8e8c34532eeacb842bcbc88f6fad25230fc43a3b7155855874a84507",
-      "outgoingViewKey": "c0e447eefab71da01a20be5c6344703e2ca7e8ea6b280cc8fb0c17e8d5245504",
-      "publicAddress": "cf862ca645f817bc89e7ed384ccbaea25cd160fc6445985bb292ab59bc5050bed80b080dba3bc84a4df831",
+      "spendingKey": "cf8f85e6a50513d6b33ec4924fd0a5905a34536bbdc0cd4cbefd9951066825b7",
+      "incomingViewKey": "963beb7234bad3d5f56d488ba47aecb51027a345158ddb37f51989425b161405",
+      "outgoingViewKey": "5cfef65835bd118079115e830dd9f0f5fd74671b74d8e6ec7680dac66816844e",
+      "publicAddress": "75440f5764fb571930ef52f2a74199672612ee8215b4af24a5a9dcbac91e6d59f6b09bb319f2ca1014d8d6",
       "rescan": null
     },
     {
       "name": "accountC",
-      "spendingKey": "02a2e25e6bf3ef6513c77a2f0f9738ee040d88907698379a4ca760978bfc1ad4",
-      "incomingViewKey": "065fbb6ddc00760e14f42cda33cad5eaa900c8b320a9e87fa18d5f4e1a276803",
-      "outgoingViewKey": "e9fac6c63e7687632469507226089a4825d5074596de817d189acaa25e76c201",
-      "publicAddress": "b13b26b5ffc6ea63ccfeecd55657d35238580ee03942f56f4abad093d88f0f016caf8d3e070f6d3d137c39",
+      "spendingKey": "80f56cfa42be2436004dbef89a0a95a0879463c2ff72c78cf3d1d754f3e62e31",
+      "incomingViewKey": "df887d2aba5b66d59be84566eab82c129d65a7b12f64d3f345873d7b04de0707",
+      "outgoingViewKey": "afee43387a79fce13497d62422dc1b649765ee566a111aa3c03ee8e4f1e5ab0a",
+      "publicAddress": "565e5b80cab285b6d8e2477971e48481c86b1ff20e46cf0727bc44e78ce66edb56508bb09e8e41bbe1f9cd",
+      "rescan": null
+    },
+    {
+      "name": "accountD",
+      "spendingKey": "f0b9c469de6510fe201a7523871b79763a5d915c685ce90d349d95b7242e642b",
+      "incomingViewKey": "4710c94ff05bc1a262dc1cc443b70045bd6a64ead040cd451adca77350321c03",
+      "outgoingViewKey": "5a067eb1c1521340e221fa0fdfe52f4b2002553da2d0856eafe498e4357750a7",
+      "publicAddress": "354e359fa9b3c2d2dbdadf347dd667ab80d4a765a444a84ce166d9c8961e9778a3095c6a6fe2437f7a38cb",
       "rescan": null
     },
     {
@@ -467,7 +457,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:7F9NvOROJQT9kwH3oF1ATY2s6tVcyqtFxQ2aGpikxV0="
+            "data": "base64:5grnwy5fZxHXMy0mUOgRJDmPyQTfFhMdI8awXI3B7DU="
           },
           "size": 4
         },
@@ -477,27 +467,27 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1656542833798,
+        "timestamp": 1657142803732,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "2FD05A1D9E5BE62E196C569E08ACC23218767F1B04FDCDD2CCD754968335980F",
+        "hash": "B8A9791158ABDDE4BF368506518F80873CF0C36C846AE951E9EB3C23E034BABF",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIEPlCFcjsJC9GKvcM6bcnMIVv2wasRqAKZkWvzw2HL4iojKCiiOgUX96aOuy6ACq7X37DPLouvZCFqWvJLAes2vEyOVn34Hwq3zT0s0iZh+PLMI1AFWBzyujiW32vxwMBRzH8GJlrIubrk6Ve6qFBUO3q67ArHO+hgYjAvBkXt6IS29TZN7h1bjIGBuSK1duLjIeh6SvceifKXBdxCJFS2Y2OQhySDPnTqFF9vOKhHLdZgu7TFZb6DCiwzhXkFigMhn0Aq6uv4KTebsXis4ZleLqhjjBTiKUjR8KTp60e2m1WXQ48KYjJXuu+NrY4KZHrKHa9S8CemxhFWk4kHklSqkWUIqLIcf3ctvh446sAkxPm/zpK7KUq4NDsehucAkMtrItCmpuh3lYXccXgG3PDZlDtvOkfoWRm6m1N/VPXcaEuRncLjUj7jq69d4PYKDdULGh62SBa38ZfRxQqCRQhGUEuh9KPxs9gbA+nXIGV0WRTBPq38tROhbC3s9Q0F9ohTSBUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwe0rpkX3XB6h9Oa8oIX/+Vp3jgw4PpUtyRivw3EysmQfW4JDkUIEf//aayV0U8sexMcoRh4c7HPF/Eotop6pCw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIFRRlRIbT5iyZsBussrbEDuadjvsUJaHbGMLIEdrAsH78/3fi3D+tzePSLOpvtNVqXtZ3ICGgV77mzqj+gaAZf71hjBB7u6pwf3XsGTeyhW7Tfc4ECslRs8nCJDoDMZWgpdaBUDZrAfw1yRRt270vNIqsoVx+EoayFrJJkv/PiIvEJo2IHSti7kg5CLoeWGh63DHENZXte7eNqYyyNPW7ITAzNMl85EFEBgVDG64Bz70chhciQorW30UHSk1Y1Hb5VurcrsNox2Y0WYlbAJJQ6glRr2rEhPzi6qQs8QGnRVg4jnB1XLoSh1AGuvymAqXEtcKOX2Z4//jZvLNeSE8Wn2Tg+PzQ7x1Ke2/w5AOFSMCaCl3EUKH1hu5v6GPfWGW4KZLkSPiBBa3Vw64QDs/2sSTeUP4iU//nH/UulSc+wVaG0AsPsnIvMu0sczujTEXzIdoJ+auVmyM1hFOyspxp40uT/WRbtwVXD8GcoigM3mloQzNcDN9MaqMKX7Ky2NrSSJ/kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnW6QGhL56IQEhLY0VHb3kyNoturqSdbpmwFL89MA8Ta1XVEk+xx1zgIRmNiuct5x9Rst5XCVHEFlX0hdnppHAg=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "2FD05A1D9E5BE62E196C569E08ACC23218767F1B04FDCDD2CCD754968335980F",
+        "previousBlockHash": "B8A9791158ABDDE4BF368506518F80873CF0C36C846AE951E9EB3C23E034BABF",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:ZwUZjIa1Mcd5Sp9ivlRRIJb+B2xEbV1wHSjh/ooUMTo="
+            "data": "base64:S1ib3+cMLlXvbKgmx02sN9EpcjD0yvQBpgidcDv0UTI="
           },
           "size": 5
         },
@@ -507,16 +497,16 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1656542833954,
+        "timestamp": 1657142803880,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "462A4B4AEFF4617452E589DA006222AFCE4CC04511DD5EE232BE13F952B66A8F",
+        "hash": "FFECA52F48FB196B76A30E05CCC6E00DB599EE25CE28C4DD478F9F23FF8D8054",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJSZ7gYkYVLxjlRn7P2BpdLc/kerlf2mNnbrIt9n9I9LbiW5W9U91i37mkCAc5ccCKW4arkOxElxVVNMMyQDudA2adCLT6p9baTAGrdXaoRrd5872YOCtq6kdet1/KThpQwohqe54mSFtM/QhkeD8UswJFkfHWvFXe/8tkwD+5J8hw4ZiX41DCnKnkC78B3by6ocuZgRDO0UCvkce05ZU7majlCZ4qMu0K4LjmZmRv43ZerIFDiTXoxt7v9571WGULYO8x1S/5ZcQqi5I0vi93HQWwyXDWgcT753CB596yAGHpfjJ/oty3U9JGOZmSSuRAC1++6zxpO5xOp+se+ZqjP3Z6TTe9Pl+82xy/vWlQcvYb+fNlbFbARYbELLGWmRmMyGrqgAN47mbe+2PckAucnemeD2S65FOAT+Hkk0K3fpYND02NlTHZpvz2jEsqolN7c6xIVC5nrLWlmPW9XR+YpsB4maM8yk1NDGS5PE5kYNpB0c/X0DIYjfAGlEn5GSh/4ZLkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLdb0+NRUKaFtGXIeX0oVmojmZM/Cf3I8+1rAzLmq1l7uWKx/kje3QroHLJMjnTf5TD/yUst2CfziNePpMdWyAA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKyZ0+BxAOoioCturzjiICQsN13WnpFfRNAJg2O98zwLd2vINVr26mO40/PvyYrFyrMheImjNmr9pOnQF2ZP0dlmgikZjbrDKbKJPTq/5Lk7sPMEHYW+iHR8QV5zcjFYJgXRbs70jZZeJK1NXAG0TQ+5iq9q9n/kiBfCpafG73nP5ETbPiTfJPtfMf5rCtVOlo4RE1W/chLY269xOFfzzkOod3pLn2WAb7Zom7AZud39gfSsOIS452NG58zrRnp5ILrCGjAd0bh3MXRMBwl/RzdqW1NZEHRGxdybaWaMZx2U9SNByzr96qD3h87/Z/HskzpKARCLb/o36OWMrZgVgjw9+JYhvl6oeATpH90hEtc1EKvHjzg3nCpYxQxX9wlghc4l6qv0/rYfM35pBntL/CCd0bu38ySjqPJ6jgEXCuxcHCDHa2X8psdMfIhhndj26QyIBQtim/fvhyqhkZy96C7NPFn03DNFeAfaIdoz38PF/Z2bYE1m/oP36XCK7er/6aTSZkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwj3heudO5ESPaIpt9TmFouB0nMrvMFGTrEwDpMZRjV79EURNMXVLqqG5mOTXV2UMGmq55V5zTFFh0qF/ejsj8DQ=="
         }
       ]
     }

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -10,6 +10,7 @@ import {
   IDatabase,
   IDatabaseStore,
   IDatabaseTransaction,
+  NullableStringEncoding,
   StringEncoding,
   StringHashEncoding,
 } from '../storage'
@@ -42,7 +43,7 @@ export class AccountsDB {
 
   headHashes: IDatabaseStore<{
     key: string
-    value: string
+    value: string | null
   }>
 
   decryptedNotes: IDatabaseStore<{
@@ -82,11 +83,11 @@ export class AccountsDB {
 
     this.headHashes = this.database.addStore<{
       key: string
-      value: string
+      value: string | null
     }>({
       name: 'headHashes',
       keyEncoding: new StringEncoding(),
-      valueEncoding: new StringEncoding(),
+      valueEncoding: new NullableStringEncoding(),
     })
 
     this.accounts = this.database.addStore<{ key: string; value: AccountsValue }>({
@@ -162,7 +163,7 @@ export class AccountsDB {
     }
   }
 
-  async saveHeadHash(account: Account, headHash: string): Promise<void> {
+  async saveHeadHash(account: Account, headHash: string | null): Promise<void> {
     await this.headHashes.put(account.id, headHash)
   }
 
@@ -174,17 +175,7 @@ export class AccountsDB {
     await this.headHashes.clear()
   }
 
-  async replaceHeadHashes(map: Map<string, string>): Promise<void> {
-    await this.headHashes.clear()
-
-    await this.database.transaction(async (tx) => {
-      for (const [key, value] of map) {
-        await this.headHashes.put(key, value, tx)
-      }
-    })
-  }
-
-  async loadHeadHashesMap(map: Map<string, string>): Promise<void> {
+  async loadHeadHashesMap(map: Map<string, string | null>): Promise<void> {
     for await (const [accountId, headHash] of this.headHashes.getAllIter()) {
       map.set(accountId, headHash)
     }

--- a/ironfish/src/storage/database/encoding.ts
+++ b/ironfish/src/storage/database/encoding.ts
@@ -50,6 +50,26 @@ export class StringHashEncoding implements IDatabaseEncoding<string> {
   }
 }
 
+export class NullableStringEncoding implements IDatabaseEncoding<string | null> {
+  serialize(value: string | null): Buffer {
+    const size = value ? bufio.sizeVarString(value, 'utf8') : 0
+
+    const buffer = bufio.write(size)
+    if (value) {
+      buffer.writeVarString(value, 'utf8')
+    }
+    return buffer.render()
+  }
+
+  deserialize(buffer: Buffer): string | null {
+    const reader = bufio.read(buffer, true)
+    if (reader.left()) {
+      return reader.readVarString('utf8')
+    }
+    return null
+  }
+}
+
 export class ArrayEncoding<T extends IJsonSerializable[]> extends JsonEncoding<T> {}
 
 export default class BufferToStringEncoding implements Serde<Buffer, string> {


### PR DESCRIPTION
## Summary

While working on tracking which accounts were updated, I realized having this map as a sort-of inbetween state of having some accounts, but not unscanned/imported accounts was causing much more complicated logic than just allowing nullable values in the map.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
