### PR TITLE
changes pool blockSubmitted messages for v2 block explorer

### DIFF
--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -254,15 +254,18 @@ export class MiningPool {
 
       if (result.content.added) {
         const hashRate = await this.estimateHashRate()
-        const hashedHeaderHex = hashedHeader.toString('hex')
 
         this.logger.info(
-          `Block ${hashedHeaderHex} submitted successfully! ${FileUtils.formatHashRate(
-            hashRate,
-          )}/s`,
+          `Block ${hashedHeader.toString(
+            'hex',
+          )} submitted successfully! ${FileUtils.formatHashRate(hashRate)}/s`,
         )
         this.webhooks.map((w) =>
-          w.poolSubmittedBlock(hashedHeaderHex, hashRate, this.stratum.clients.size),
+          w.poolSubmittedBlock(
+            blockTemplate.header.sequence.toString(),
+            hashRate,
+            this.stratum.clients.size,
+          ),
         )
       } else {
         this.logger.info(`Block was rejected: ${result.content.reason}`)

--- a/ironfish/src/mining/webhooks/webhookNotifier.ts
+++ b/ironfish/src/mining/webhooks/webhookNotifier.ts
@@ -40,10 +40,10 @@ export abstract class WebhookNotifier {
     this.sendText('Disconnected from node unexpectedly. Reconnecting.')
   }
 
-  poolSubmittedBlock(hashedHeaderHex: string, hashRate: number, clients: number): void {
+  poolSubmittedBlock(blockHeaderSequence: string, hashRate: number, clients: number): void {
     this.sendText(
-      `Block ${this.renderHashHex(
-        hashedHeaderHex,
+      `Block ${this.renderChainReference(
+        blockHeaderSequence,
         this.explorerBlocksUrl,
       )} submitted successfully! ${FileUtils.formatHashRate(
         hashRate,
@@ -65,7 +65,7 @@ export abstract class WebhookNotifier {
       } users for ${displayIronAmountWithCurrency(
         Number(oreToIron(Number(total.toString()))),
         false,
-      )} in transaction ${this.renderHashHex(
+      )} in transaction ${this.renderChainReference(
         transactionHashHex,
         this.explorerTransactionsUrl,
       )}. Transaction pending (${payoutId})`,
@@ -112,11 +112,11 @@ export abstract class WebhookNotifier {
     )
   }
 
-  private renderHashHex(hashHex: string, explorerUrl: string | null): string {
+  private renderChainReference(chainReference: string, explorerUrl: string | null): string {
     if (explorerUrl == null) {
-      return `\`${hashHex}\``
+      return `\`${chainReference}\``
     }
 
-    return `${explorerUrl + hashHex}`
+    return `${explorerUrl + chainReference}`
   }
 }


### PR DESCRIPTION
## Summary

the v2 block explorer uses '/blocks/<sequence>' instead of '/blocks/<hash>'

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
