### PR TITLE
Send transaction index up in block syncer

### DIFF
--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -34,6 +34,7 @@ export type FollowChainStreamResponse = {
       hash: string
       size: number
       fee: number
+      index: number
       notes: Array<{ commitment: string }>
       spends: Array<{ nullifier: string }>
     }>
@@ -72,6 +73,7 @@ export const FollowChainStreamResponseSchema: yup.ObjectSchema<FollowChainStream
                 hash: yup.string().defined(),
                 size: yup.number().defined(),
                 fee: yup.number().defined(),
+                index: yup.number().defined(),
                 notes: yup
                   .array(
                     yup
@@ -112,7 +114,7 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
     })
 
     const send = (block: Block, type: 'connected' | 'disconnected' | 'fork') => {
-      const transactions = block.transactions.map((transaction) => {
+      const transactions = block.transactions.map((transaction, index) => {
         return transaction.withReference(() => {
           return {
             hash: BlockHashSerdeInstance.serialize(transaction.unsignedHash()),
@@ -120,6 +122,7 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
               JSON.stringify(node.strategy.transactionSerde.serialize(transaction)),
             ).byteLength,
             fee: Number(transaction.fee()),
+            index: index,
             notes: [...transaction.notes()].map((note) => ({
               commitment: note.merkleHash().toString('hex'),
             })),


### PR DESCRIPTION
## Summary
We need the index to properly sort transactions when sending them back with blocks.

## Testing Plan
Check data coming out of the sync command and test that it receives and processes it

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
