### PR TITLE
Create network message for querying for transactions based on hash

### DIFF
--- a/ironfish/src/network/messageRegistry.ts
+++ b/ironfish/src/network/messageRegistry.ts
@@ -15,7 +15,7 @@ import { NewBlockV2Message } from './messages/newBlockV2'
 import { NewTransactionMessage } from './messages/newTransaction'
 import { PeerListMessage } from './messages/peerList'
 import { PeerListRequestMessage } from './messages/peerListRequest'
-import { PooledTrasactionsRequest } from './messages/pooledTransactionsRequest'
+import { PooledTransactionsRequest } from './messages/pooledTransactionsRequest'
 import { RpcNetworkMessage } from './messages/rpcNetworkMessage'
 import { SignalMessage } from './messages/signal'
 import { SignalRequestMessage } from './messages/signalRequest'
@@ -65,7 +65,7 @@ const parseRpcNetworkMessage = (
     case NetworkMessageType.GetBlocksResponse:
       return GetBlocksResponse.deserialize(body, rpcId)
     case NetworkMessageType.PooledTransactionsRequest:
-      return PooledTrasactionsRequest.deserialize(body, rpcId)
+      return PooledTransactionsRequest.deserialize(body, rpcId)
     default:
       throw new Error(`Unknown RPC network message type: ${type}`)
   }

--- a/ironfish/src/network/messageRegistry.ts
+++ b/ironfish/src/network/messageRegistry.ts
@@ -15,6 +15,7 @@ import { NewBlockV2Message } from './messages/newBlockV2'
 import { NewTransactionMessage } from './messages/newTransaction'
 import { PeerListMessage } from './messages/peerList'
 import { PeerListRequestMessage } from './messages/peerListRequest'
+import { PooledTrasactionsRequest } from './messages/pooledTransactionsRequest'
 import { RpcNetworkMessage } from './messages/rpcNetworkMessage'
 import { SignalMessage } from './messages/signal'
 import { SignalRequestMessage } from './messages/signalRequest'
@@ -63,6 +64,8 @@ const parseRpcNetworkMessage = (
       return GetBlocksRequest.deserialize(body, rpcId)
     case NetworkMessageType.GetBlocksResponse:
       return GetBlocksResponse.deserialize(body, rpcId)
+    case NetworkMessageType.PooledTransactionsRequest:
+      return PooledTrasactionsRequest.deserialize(body, rpcId)
     default:
       throw new Error(`Unknown RPC network message type: ${type}`)
   }

--- a/ironfish/src/network/messageRegistry.ts
+++ b/ironfish/src/network/messageRegistry.ts
@@ -40,6 +40,8 @@ const isRpcNetworkMessageType = (type: NetworkMessageType): boolean => {
     NetworkMessageType.GetBlockHashesResponse,
     NetworkMessageType.GetBlocksRequest,
     NetworkMessageType.GetBlocksResponse,
+    NetworkMessageType.PooledTransactionsRequest,
+    NetworkMessageType.PooledTransactionsResponse,
   ].includes(type)
 }
 

--- a/ironfish/src/network/messages/pooledTransactionsRequest.test.ts
+++ b/ironfish/src/network/messages/pooledTransactionsRequest.test.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { blake3 } from '@napi-rs/blake-hash'
+import { v4 as uuid } from 'uuid'
+import { PooledTrasactionsRequest } from './pooledTransactionsRequest'
+
+describe('PooledTrasactionsRequestMessage', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const rpcId = 53242
+    const hashes = [...Array(10)].map((_) => blake3(uuid()))
+
+    const message = new PooledTrasactionsRequest(hashes, rpcId)
+
+    const buffer = message.serialize()
+    const deserializedMessage = PooledTrasactionsRequest.deserialize(buffer, rpcId)
+    expect(deserializedMessage).toEqual(message)
+  })
+})

--- a/ironfish/src/network/messages/pooledTransactionsRequest.test.ts
+++ b/ironfish/src/network/messages/pooledTransactionsRequest.test.ts
@@ -3,17 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { blake3 } from '@napi-rs/blake-hash'
 import { v4 as uuid } from 'uuid'
-import { PooledTrasactionsRequest } from './pooledTransactionsRequest'
+import { PooledTransactionsRequest } from './pooledTransactionsRequest'
 
-describe('PooledTrasactionsRequestMessage', () => {
+describe('PooledTransactionsRequest', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
     const rpcId = 53242
     const hashes = [...Array(10)].map((_) => blake3(uuid()))
 
-    const message = new PooledTrasactionsRequest(hashes, rpcId)
+    const message = new PooledTransactionsRequest(hashes, rpcId)
 
     const buffer = message.serialize()
-    const deserializedMessage = PooledTrasactionsRequest.deserialize(buffer, rpcId)
+    const deserializedMessage = PooledTransactionsRequest.deserialize(buffer, rpcId)
     expect(deserializedMessage).toEqual(message)
   })
 })

--- a/ironfish/src/network/messages/pooledTransactionsRequest.ts
+++ b/ironfish/src/network/messages/pooledTransactionsRequest.ts
@@ -17,7 +17,7 @@ export class PooledTransactionsRequest extends RpcNetworkMessage {
   serialize(): Buffer {
     const bw = bufio.write(this.getSize())
 
-    bw.writeU16(this.transactionHashes.length)
+    bw.writeVarint(this.transactionHashes.length)
 
     for (const hash of this.transactionHashes) {
       bw.writeHash(hash)
@@ -28,7 +28,7 @@ export class PooledTransactionsRequest extends RpcNetworkMessage {
 
   static deserialize(buffer: Buffer, rpcId: number): PooledTransactionsRequest {
     const reader = bufio.read(buffer, true)
-    const transactionHashesLength = reader.readU16()
+    const transactionHashesLength = reader.readVarint()
     const transactionHashes = []
 
     for (let i = 0; i < transactionHashesLength; i++) {
@@ -42,7 +42,7 @@ export class PooledTransactionsRequest extends RpcNetworkMessage {
   getSize(): number {
     let size = 0
 
-    size += 2
+    size += bufio.sizeVarint(this.transactionHashes.length)
 
     size += this.transactionHashes.length * 32
 

--- a/ironfish/src/network/messages/pooledTransactionsRequest.ts
+++ b/ironfish/src/network/messages/pooledTransactionsRequest.ts
@@ -6,7 +6,7 @@ import { TransactionHash } from '../../primitives/transaction'
 import { NetworkMessageType } from '../types'
 import { Direction, RpcNetworkMessage } from './rpcNetworkMessage'
 
-export class PooledTrasactionsRequest extends RpcNetworkMessage {
+export class PooledTransactionsRequest extends RpcNetworkMessage {
   transactionHashes: TransactionHash[]
 
   constructor(transactionHashes: TransactionHash[], rpcId?: number) {
@@ -26,7 +26,7 @@ export class PooledTrasactionsRequest extends RpcNetworkMessage {
     return bw.render()
   }
 
-  static deserialize(buffer: Buffer, rpcId: number): PooledTrasactionsRequest {
+  static deserialize(buffer: Buffer, rpcId: number): PooledTransactionsRequest {
     const reader = bufio.read(buffer, true)
     const transactionHashesLength = reader.readU16()
     const transactionHashes = []
@@ -36,7 +36,7 @@ export class PooledTrasactionsRequest extends RpcNetworkMessage {
       transactionHashes.push(hash)
     }
 
-    return new PooledTrasactionsRequest(transactionHashes, rpcId)
+    return new PooledTransactionsRequest(transactionHashes, rpcId)
   }
 
   getSize(): number {

--- a/ironfish/src/network/messages/pooledTransactionsRequest.ts
+++ b/ironfish/src/network/messages/pooledTransactionsRequest.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { TransactionHash } from '../../primitives/transaction'
+import { NetworkMessageType } from '../types'
+import { Direction, RpcNetworkMessage } from './rpcNetworkMessage'
+
+export class PooledTrasactionsRequest extends RpcNetworkMessage {
+  transactionHashes: TransactionHash[]
+
+  constructor(transactionHashes: TransactionHash[], rpcId?: number) {
+    super(NetworkMessageType.PooledTransactionsRequest, Direction.Request, rpcId)
+    this.transactionHashes = transactionHashes
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+
+    bw.writeU16(this.transactionHashes.length)
+
+    for (const hash of this.transactionHashes) {
+      bw.writeHash(hash)
+    }
+
+    return bw.render()
+  }
+
+  static deserialize(buffer: Buffer, rpcId: number): PooledTrasactionsRequest {
+    const reader = bufio.read(buffer, true)
+    const transactionHashesLength = reader.readU16()
+    const transactionHashes = []
+
+    for (let i = 0; i < transactionHashesLength; i++) {
+      const hash = reader.readBytes(32)
+      transactionHashes.push(hash)
+    }
+
+    return new PooledTrasactionsRequest(transactionHashes, rpcId)
+  }
+
+  getSize(): number {
+    let size = 0
+
+    size += 2
+
+    size += this.transactionHashes.length * 32
+
+    return size
+  }
+}

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -34,6 +34,7 @@ import { NewBlockMessage } from './messages/newBlock'
 import { NewBlockHashesMessage } from './messages/newBlockHashes'
 import { NewBlockV2Message } from './messages/newBlockV2'
 import { NewTransactionMessage } from './messages/newTransaction'
+import { PooledTrasactionsRequest } from './messages/pooledTransactionsRequest'
 import {
   Direction,
   RPC_TIMEOUT_MILLIS,
@@ -547,6 +548,8 @@ export class PeerNetwork {
           })
         } else if (rpcMessage instanceof GetBlocksRequest) {
           responseMessage = await this.onGetBlocksRequest({ peerIdentity, message: rpcMessage })
+        } else if (rpcMessage instanceof PooledTrasactionsRequest) {
+          responseMessage = this.onPooledTrasactionsRequest(rpcId)
         } else {
           throw new Error(`Invalid rpc message type: '${rpcMessage.type}'`)
         }
@@ -686,6 +689,11 @@ export class PeerNetwork {
     })
 
     return new GetBlocksResponse(serialized, rpcId)
+  }
+
+  private onPooledTrasactionsRequest(rpcId: number): CannotSatisfyRequest {
+    // TODO(daniel): implement response for pooled transaction
+    return new CannotSatisfyRequest(rpcId)
   }
 
   private async onNewBlock(message: IncomingPeerMessage<NewBlockMessage>): Promise<boolean> {

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -34,7 +34,7 @@ import { NewBlockMessage } from './messages/newBlock'
 import { NewBlockHashesMessage } from './messages/newBlockHashes'
 import { NewBlockV2Message } from './messages/newBlockV2'
 import { NewTransactionMessage } from './messages/newTransaction'
-import { PooledTrasactionsRequest } from './messages/pooledTransactionsRequest'
+import { PooledTransactionsRequest } from './messages/pooledTransactionsRequest'
 import {
   Direction,
   RPC_TIMEOUT_MILLIS,
@@ -548,8 +548,8 @@ export class PeerNetwork {
           })
         } else if (rpcMessage instanceof GetBlocksRequest) {
           responseMessage = await this.onGetBlocksRequest({ peerIdentity, message: rpcMessage })
-        } else if (rpcMessage instanceof PooledTrasactionsRequest) {
-          responseMessage = this.onPooledTrasactionsRequest(rpcId)
+        } else if (rpcMessage instanceof PooledTransactionsRequest) {
+          responseMessage = this.onPooledTransactionsRequest(rpcId)
         } else {
           throw new Error(`Invalid rpc message type: '${rpcMessage.type}'`)
         }
@@ -691,7 +691,7 @@ export class PeerNetwork {
     return new GetBlocksResponse(serialized, rpcId)
   }
 
-  private onPooledTrasactionsRequest(rpcId: number): CannotSatisfyRequest {
+  private onPooledTransactionsRequest(rpcId: number): CannotSatisfyRequest {
     // TODO(daniel): implement response for pooled transaction
     return new CannotSatisfyRequest(rpcId)
   }

--- a/ironfish/src/network/types.ts
+++ b/ironfish/src/network/types.ts
@@ -18,8 +18,12 @@ export enum NetworkMessageType {
   PeerListRequest = 10,
   Signal = 11,
   SignalRequest = 12,
-  NewBlockHashes = 13,
-  NewBlockV2 = 14,
+  PooledTransactionsRequest = 13,
+  PooledTransactionsResponse = 14,
+  NewPooledTransactionHashes = 15,
+  NewTransactionV2 = 16,
+  NewBlockHashes = 17,
+  NewBlockV2 = 18,
 }
 
 export type IsomorphicWebSocketConstructor = typeof WebSocket | typeof WSWebSocket


### PR DESCRIPTION
## Summary
Outlined in the [transaction gossip proposal](https://coda.io/d/Gossip_d7HSvA-Pxcz/Transaction-Gossip_sulxZ#_luNdn). We should create a new network message that allows nodes to query for transactions by hash. This would be in response to receiving a new gossiped hash from a node.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
