### PR TITLE
refactor(ironfish): Encapsulate `nullifierToNote` inside account

### DIFF
--- a/ironfish/src/account/account.ts
+++ b/ironfish/src/account/account.ts
@@ -13,6 +13,7 @@ export const ACCOUNT_KEY_LENGTH = 32
 export class Account {
   private readonly accountsDb: AccountsDB
   private readonly decryptedNotes: Map<string, DecryptedNotesValue>
+  private readonly nullifierToNoteHash: Map<string, string>
 
   readonly id: string
   readonly displayName: string
@@ -60,6 +61,7 @@ export class Account {
 
     this.accountsDb = accountsDb
     this.decryptedNotes = new Map<string, DecryptedNotesValue>()
+    this.nullifierToNoteHash = new Map<string, string>()
   }
 
   serialize(): AccountsValue {
@@ -75,14 +77,17 @@ export class Account {
 
   async load(): Promise<void> {
     await this.accountsDb.loadDecryptedNotes(this.decryptedNotes)
+    await this.accountsDb.loadNullifierToNoteHash(this.nullifierToNoteHash)
   }
 
   async save(): Promise<void> {
     await this.accountsDb.replaceDecryptedNotes(this.decryptedNotes)
+    await this.accountsDb.replaceNullifierToNoteHash(this.nullifierToNoteHash)
   }
 
   reset(): void {
     this.decryptedNotes.clear()
+    this.nullifierToNoteHash.clear()
   }
 
   getUnspentNotes(): ReadonlyArray<{
@@ -125,6 +130,20 @@ export class Account {
 
   async deleteDecryptedNote(noteHash: string, tx?: IDatabaseTransaction): Promise<void> {
     this.decryptedNotes.delete(noteHash)
-    await this.accountsDb.removeDecryptedNotes(noteHash, tx)
+    await this.accountsDb.deleteDecryptedNote(noteHash, tx)
+  }
+
+  getNoteHash(nullifier: string): string | undefined {
+    return this.nullifierToNoteHash.get(nullifier)
+  }
+
+  async updateNullifierNoteHash(nullifier: string, noteHash: string, tx?: IDatabaseTransaction): Promise<void> {
+    this.nullifierToNoteHash.set(nullifier, noteHash)
+    await this.accountsDb.saveNullifierNoteHash(nullifier, noteHash, tx)
+  }
+
+  async deleteNullifier(nullifier: string, tx?: IDatabaseTransaction): Promise<void> {
+    this.nullifierToNoteHash.delete(nullifier)
+    await this.accountsDb.deleteNullifier(nullifier, tx)
   }
 }

--- a/ironfish/src/account/account.ts
+++ b/ironfish/src/account/account.ts
@@ -137,7 +137,11 @@ export class Account {
     return this.nullifierToNoteHash.get(nullifier)
   }
 
-  async updateNullifierNoteHash(nullifier: string, noteHash: string, tx?: IDatabaseTransaction): Promise<void> {
+  async updateNullifierNoteHash(
+    nullifier: string,
+    noteHash: string,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
     this.nullifierToNoteHash.set(nullifier, noteHash)
     await this.accountsDb.saveNullifierNoteHash(nullifier, noteHash, tx)
   }

--- a/ironfish/src/account/accounts.test.slow.ts
+++ b/ironfish/src/account/accounts.test.slow.ts
@@ -109,7 +109,6 @@ describe('Accounts', () => {
     await node.accounts.saveTransactionsToDb()
 
     node.accounts['resetAccounts']()
-    node.accounts['nullifierToNote'].clear()
     node.accounts['transactionMap'].clear()
 
     // Account should now have a balance of 0 after clearing the cache

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -47,7 +47,6 @@ export class Accounts {
       submittedSequence: number | null
     }>
   >()
-  protected readonly nullifierToNote = new Map<string, string>()
   protected readonly headStatus = new Map<
     string,
     { headHash: string | null; upToDate: boolean }
@@ -277,7 +276,6 @@ export class Accounts {
       await account.load()
     }
 
-    await this.db.loadNullifierToNoteMap(this.nullifierToNote)
     await this.db.loadTransactionsIntoMap(this.transactionMap)
   }
 
@@ -286,7 +284,6 @@ export class Accounts {
       await account.save()
     }
 
-    await this.db.replaceNullifierToNoteMap(this.nullifierToNote)
     await this.db.replaceTransactions(this.transactionMap)
   }
 
@@ -305,20 +302,6 @@ export class Accounts {
     } else {
       this.transactionMap.set(transactionHash, transaction)
       await this.db.saveTransaction(transactionHash, transaction, tx)
-    }
-  }
-
-  async updateNullifierToNoteMap(
-    nullifier: string,
-    note: string | null,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    if (note === null) {
-      this.nullifierToNote.delete(nullifier)
-      await this.db.removeNullifierToNote(nullifier, tx)
-    } else {
-      this.nullifierToNote.set(nullifier, note)
-      await this.db.saveNullifierToNote(nullifier, note, tx)
     }
   }
 
@@ -351,7 +334,6 @@ export class Accounts {
   async reset(): Promise<void> {
     this.resetAccounts()
     this.transactionMap.clear()
-    this.nullifierToNote.clear()
     this.chainProcessor.hash = null
     await this.saveTransactionsToDb()
     await this.updateHeadHashes(null)
@@ -505,7 +487,7 @@ export class Accounts {
           // but since we spent the note, we don't need to put it in the nullifierToNote mappings
           if (!forSpender) {
             if (nullifier !== null) {
-              await this.updateNullifierToNoteMap(nullifier, merkleHash, tx)
+              await account.updateNullifierNoteHash(nullifier, merkleHash, tx)
             }
 
             await account.updateDecryptedNote(
@@ -530,7 +512,7 @@ export class Accounts {
         for (const account of this.accounts.values()) {
           for (const spend of transaction.spends()) {
             const nullifier = spend.nullifier.toString('hex')
-            const noteHash = this.nullifierToNote.get(nullifier)
+            const noteHash = account.getNoteHash(nullifier)
 
             if (noteHash) {
               const nullifier = account.getDecryptedNote(noteHash)
@@ -580,28 +562,27 @@ export class Accounts {
             await account.deleteDecryptedNote(merkleHash, tx)
 
             if (decryptedNote.nullifierHash) {
-              await this.updateNullifierToNoteMap(decryptedNote.nullifierHash, null, tx)
+              await account.deleteNullifier(decryptedNote.nullifierHash, tx)
             }
           }
         }
 
         for (const spend of transaction.spends()) {
-          const nullifierHash = spend.nullifier.toString('hex')
-          const noteHash = this.nullifierToNote.get(nullifierHash)
+          const nullifier = spend.nullifier.toString('hex')
+          const noteHash = account.getNoteHash(nullifier)
 
           if (noteHash) {
-            const nullifier = account.getDecryptedNote(noteHash)
-
-            if (!nullifier) {
+            const decryptedNote = account.getDecryptedNote(noteHash)
+            if (!decryptedNote) {
               throw new Error(
-                'nullifierToNote mappings must have a corresponding decryptedNote map',
+                'nullifierToNote mappings must have a corresponding decryptedNote',
               )
             }
 
             await account.updateDecryptedNote(
               noteHash,
               {
-                ...nullifier,
+                ...decryptedNote,
                 spent: false,
               },
               tx,

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -51,7 +51,7 @@ export class AccountsDB {
     value: DecryptedNotesValue
   }>
 
-  nullifierToNote: IDatabaseStore<{ key: string; value: string }>
+  nullifierToNoteHash: IDatabaseStore<{ key: string; value: string }>
 
   transactions: IDatabaseStore<{
     key: Buffer
@@ -105,8 +105,8 @@ export class AccountsDB {
       valueEncoding: new DecryptedNotesValueEncoding(),
     })
 
-    this.nullifierToNote = this.database.addStore<{ key: string; value: string }>({
-      name: 'nullifierToNote',
+    this.nullifierToNoteHash = this.database.addStore<{ key: string; value: string }>({
+      name: 'nullifierToNoteHash',
       keyEncoding: new StringHashEncoding(),
       valueEncoding: new StringEncoding(),
     })
@@ -246,30 +246,30 @@ export class AccountsDB {
     }
   }
 
-  async saveNullifierToNote(
+  async saveNullifierNoteHash(
     nullifier: string,
     note: string,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
-    await this.nullifierToNote.put(nullifier, note, tx)
+    await this.nullifierToNoteHash.put(nullifier, note, tx)
   }
 
-  async removeNullifierToNote(noteHash: string, tx?: IDatabaseTransaction): Promise<void> {
-    await this.nullifierToNote.del(noteHash, tx)
+  async deleteNullifier(nullifier: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.nullifierToNoteHash.del(nullifier, tx)
   }
 
-  async replaceNullifierToNoteMap(map: Map<string, string>): Promise<void> {
-    await this.nullifierToNote.clear()
+  async replaceNullifierToNoteHash(map: Map<string, string>): Promise<void> {
+    await this.nullifierToNoteHash.clear()
 
     await this.database.transaction(async (tx) => {
       for (const [key, value] of map) {
-        await this.nullifierToNote.put(key, value, tx)
+        await this.nullifierToNoteHash.put(key, value, tx)
       }
     })
   }
 
-  async loadNullifierToNoteMap(map: Map<string, string>): Promise<void> {
-    for await (const [key, value] of this.nullifierToNote.getAllIter()) {
+  async loadNullifierToNoteHash(map: Map<string, string>): Promise<void> {
+    for await (const [key, value] of this.nullifierToNoteHash.getAllIter()) {
       map.set(key, value)
     }
   }
@@ -282,7 +282,7 @@ export class AccountsDB {
     await this.decryptedNotes.put(noteHash, note, tx)
   }
 
-  async removeDecryptedNotes(noteHash: string, tx?: IDatabaseTransaction): Promise<void> {
+  async deleteDecryptedNote(noteHash: string, tx?: IDatabaseTransaction): Promise<void> {
     await this.decryptedNotes.del(noteHash, tx)
   }
 


### PR DESCRIPTION
## Summary

Remove nullifier to note hash mapping from wallet and encapsulate behavior inside account

## Testing Plan

Covered by existing unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
