### PR TITLE
Update README with information about preferred installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Iron Fish is a Layer 1 blockchain that provides the strongest privacy guarantees
 
 See https://ironfish.network
 
-## Install
+## Developer Install
+
+The following steps should only be used to install if you are planning on contributing to the Iron Fish codebase. Otherwise, we **strongly** recommend using the installation methods here: https://ironfish.network/docs/onboarding/installation-iron-fish
 
 1. Install [Node.js 16.x](https://nodejs.org/en/download/)
 1. Install [Rust](https://www.rust-lang.org/learn/get-started).
@@ -22,15 +24,19 @@ See https://ironfish.network
       1. On the next screen, click `Process`.
       1. Once it finishes, add the `bin` folder containing `cc` to your PATH environment variable.
 1. Run `yarn install` from the root directory to install packages.
+
    - If `yarn install` fails with an error that includes "Failed to build cmake", you may need to first install cmake. For example, on macOS:
+
      1. Run `brew install cmake`, you'll need cmake version 3.15 or higher.
 
    - If `yarn install` fails with an error that includes "Could NOT find OpenSSL", you may need to first install OpenSSL and add an environment variable. For example, on macOS:
+
      1. Run `brew install openssl`
      1. Run `` export OPENSSL_ROOT_DIR=`brew --prefix openssl`  ``
      1. Run `yarn install` again.
 
    - If `yarn install` fails with an error that includes "Error: not found: make", "make: cc: Command not found", or "make: g++: Command not found", you may need to [install a C/C++ compiler toolchain](https://github.com/nodejs/node-gyp#on-unix).
+
      1. On Ubuntu: `apt install build-essential`
      1. On Amazon Linux: `sudo yum groupinstall "Development Tools"`
 


### PR DESCRIPTION
## Summary

Want to make it clear that we expect normal users to use npm, brew, docker etc instead of building from source, as the other methods are much easier to use

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
