### PR TITLE
refactor(ironfish): Encapsulate transactions inside account

### DIFF
--- a/ironfish/src/account/accounts.test.slow.ts
+++ b/ironfish/src/account/accounts.test.slow.ts
@@ -106,10 +106,9 @@ describe('Accounts', () => {
       unconfirmed: BigInt(2000000000),
     })
 
-    await node.accounts.saveTransactionsToDb()
+    await node.accounts.saveAccountsToDb()
 
     node.accounts['resetAccounts']()
-    node.accounts['transactionMap'].clear()
 
     // Account should now have a balance of 0 after clearing the cache
     await expect(node.accounts.getBalance(account)).resolves.toEqual({
@@ -117,7 +116,7 @@ describe('Accounts', () => {
       unconfirmed: BigInt(0),
     })
 
-    await node.accounts.loadTransactionsFromDb()
+    await node.accounts.loadAccountsFromDb()
 
     // Balance should be back to 2000000000
     await expect(node.accounts.getBalance(account)).resolves.toEqual({

--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -83,7 +83,7 @@ describe('Accounts', () => {
     })
 
     // Check that it was last broadcast at its added height
-    let invalidTxEntry = nodeA.accounts['transactionMap'].get(invalidTx.hash())
+    let invalidTxEntry = accountA.getTransaction(invalidTx.hash())
     expect(invalidTxEntry?.submittedSequence).toEqual(GENESIS_BLOCK_SEQUENCE)
 
     // Check that the TX is not rebroadcast but has it's sequence updated
@@ -94,7 +94,7 @@ describe('Accounts', () => {
     expect(broadcastSpy).toHaveBeenCalledTimes(0)
 
     // It should now be planned to be processed at head + 1
-    invalidTxEntry = nodeA.accounts['transactionMap'].get(invalidTx.hash())
+    invalidTxEntry = accountA.getTransaction(invalidTx.hash())
     expect(invalidTxEntry?.submittedSequence).toEqual(blockB2.header.sequence)
   }, 120000)
 

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -205,7 +205,7 @@ export class AccountsDB {
     await this.transactions.put(transactionHash, serialized, tx)
   }
 
-  async removeTransaction(transactionHash: Buffer, tx?: IDatabaseTransaction): Promise<void> {
+  async deleteTransaction(transactionHash: Buffer, tx?: IDatabaseTransaction): Promise<void> {
     await this.transactions.del(transactionHash, tx)
   }
 
@@ -229,7 +229,7 @@ export class AccountsDB {
     })
   }
 
-  async loadTransactionsIntoMap(
+  async loadTransactions(
     map: BufferMap<{
       transaction: Transaction
       blockHash: string | null

--- a/ironfish/src/rpc/routes/accounts/getTransactions.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransactions.ts
@@ -54,7 +54,9 @@ router.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactio
   GetAccountTransactionsRequestSchema,
   (request, node): void => {
     const account = getAccount(node, request.data.account)
-    const { transactions } = node.accounts.getTransactions(account)
-    request.end({ account: account.displayName, transactions })
+    request.end({
+      account: account.displayName,
+      transactions: account.getTransactionsWithMetadata(),
+    })
   },
 )


### PR DESCRIPTION
## Summary

Move interactions for the transaction map into the account. This still has all transactions for each account, that will be updated in a subsequent PR since this focuses on encapsulation

## Testing Plan

Covered by existing unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
