### PR TITLE
Simple lint to help point out when forgetting to assign filter, etc

### DIFF
--- a/config/eslint-config-ironfish/index.js
+++ b/config/eslint-config-ironfish/index.js
@@ -59,6 +59,7 @@ module.exports = {
   rules: {
     'ironfish/no-vague-imports': 'error',
     'ironfish/no-buffer-cmp': 'error',
+    'ironfish/no-unassigned-expr': 'error',
 
     // Seems to be needed to allow for custom jest matchers
     '@typescript-eslint/no-namespace': [

--- a/config/eslint-plugin-ironfish/index.js
+++ b/config/eslint-plugin-ironfish/index.js
@@ -1,5 +1,7 @@
 const { ESLintUtils } = require("@typescript-eslint/utils");
 
+const assignableFnNames = ["filter", "flat", "flatMap"];
+
 function getTypeName(parserServices, checker, node) {
   const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node);
   const nodeType = checker.getTypeAtLocation(originalNode);
@@ -39,6 +41,22 @@ module.exports.rules = {
             });
           }
         },
+      };
+    },
+  },
+  "no-unassigned-expr": {
+    create(context) {
+      return {
+        "ExpressionStatement > CallExpression > MemberExpression > Identifier":
+          function (node) {
+            if (assignableFnNames.includes(node.name)) {
+              context.report({
+                node,
+                message:
+                  "Return value is unused, this is likely unintentional.",
+              });
+            }
+          },
       };
     },
   },

--- a/config/eslint-plugin-ironfish/index.test.js
+++ b/config/eslint-plugin-ironfish/index.test.js
@@ -55,3 +55,34 @@ ruleTester.run("no-buffer-cmp", rules["no-buffer-cmp"], {
     },
   ],
 });
+
+ruleTester.run("no-unassigned-expr", rules["no-unassigned-expr"], {
+  valid: [
+    `
+      const foo = [1, 2, 3]
+      const x = foo.filter((f) => f === 999)
+    `,
+    `
+      function bar() {
+        const foo = [1, 2, 3]
+        return foo.flatMap((f) => f === 999)
+      }
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+        const foo = [1, 2, 3]
+        foo.filter((f) => f === 999)
+      `,
+      errors: [{ message: /Return value is unused/i }],
+    },
+    {
+      code: `
+        const foo = [1,2,3]
+        foo.flatMap((f) => f === 999)
+      `,
+      errors: [{ message: /Return value is unused/i }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

It's too easy to forget to assign `.filter` etc, let's add a little help. This is probably a _little_ jank, as this could trigger on methods that are correct in this fashion, say if we add some `filter` fn to a random class.  If needed, we can extend this in the future to check for types via TS, so we only check `Array.filter`, for example.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
