### PR TITLE
Add Rpc prefix to all Rpc types

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -3,11 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
   ConfigOptions,
-  ConnectionError,
   createRootLogger,
   ErrorUtils,
   IronfishSdk,
   Logger,
+  RpcConnectionError,
 } from '@ironfish/sdk'
 import { Command, Config } from '@oclif/core'
 import {
@@ -75,7 +75,7 @@ export abstract class IronfishCommand extends Command {
     } catch (error: unknown) {
       if (hasUserResponseError(error)) {
         this.log(error.codeMessage)
-      } else if (error instanceof ConnectionError) {
+      } else if (error instanceof RpcConnectionError) {
         this.log(`Cannot connect to your node, start your node first.`)
       } else {
         throw error

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { DEFAULT_DISCORD_INVITE, RequestError } from '@ironfish/sdk'
+import { DEFAULT_DISCORD_INVITE, RpcRequestError } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
@@ -74,7 +74,7 @@ export class FaucetCommand extends IronfishCommand {
         email,
       })
     } catch (error: unknown) {
-      if (error instanceof RequestError) {
+      if (error instanceof RpcRequestError) {
         CliUx.ux.action.stop(error.codeMessage)
       } else {
         CliUx.ux.action.stop(

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ConnectionError, Meter, PromiseUtils, RpcSocketClient, WebApi } from '@ironfish/sdk'
+import { Meter, PromiseUtils, RpcConnectionError, RpcSocketClient, WebApi } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -66,7 +66,7 @@ export default class Faucet extends IronfishCommand {
       try {
         await this.startSyncing(client, api, speed)
       } catch (e) {
-        if (e instanceof ConnectionError) {
+        if (e instanceof RpcConnectionError) {
           this.log('Connection error... retrying in 5 seconds')
           await PromiseUtils.sleep(5000)
           continue

--- a/ironfish-cli/src/commands/stop.ts
+++ b/ironfish-cli/src/commands/stop.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ConnectionError, IronfishNode } from '@ironfish/sdk'
+import { IronfishNode, RpcConnectionError } from '@ironfish/sdk'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 
@@ -18,7 +18,7 @@ export default class StopCommand extends IronfishCommand {
     await this.parse(StopCommand)
 
     await this.sdk.client.connect().catch((e) => {
-      if (e instanceof ConnectionError) {
+      if (e instanceof RpcConnectionError) {
         this.exit(0)
       }
       throw e

--- a/ironfish-cli/src/utils/rpc.ts
+++ b/ironfish-cli/src/utils/rpc.ts
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { isResponseUserError, RequestError } from '@ironfish/sdk'
+import { isRpcResponseUserError, RpcRequestError } from '@ironfish/sdk'
 
-export function hasUserResponseError(error: unknown): error is RequestError {
+export function hasUserResponseError(error: unknown): error is RpcRequestError {
   return (
-    error instanceof RequestError && !!error.response && isResponseUserError(error.response)
+    error instanceof RpcRequestError &&
+    !!error.response &&
+    isRpcResponseUserError(error.response)
   )
 }

--- a/ironfish/src/rpc/adapters/ipcAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.test.ts
@@ -6,7 +6,7 @@
 import os from 'os'
 import * as yup from 'yup'
 import { IronfishSdk } from '../../sdk'
-import { RequestError, RpcSocketClient } from '../clients'
+import { RpcRequestError, RpcSocketClient } from '../clients'
 import { ALL_API_NAMESPACES } from '../routes'
 import { ERROR_CODES, ValidationError } from './errors'
 import { RpcIpcAdapter } from './ipcAdapter'
@@ -93,7 +93,7 @@ describe('IpcAdapter', () => {
       expect.assertions(3)
       await response.waitForEnd()
     } catch (error: unknown) {
-      if (!(error instanceof RequestError)) {
+      if (!(error instanceof RpcRequestError)) {
         throw error
       }
       expect(error.status).toBe(402)
@@ -119,7 +119,7 @@ describe('IpcAdapter', () => {
       expect.assertions(3)
       await response.waitForEnd()
     } catch (error: unknown) {
-      if (!(error instanceof RequestError)) {
+      if (!(error instanceof RpcRequestError)) {
         throw error
       }
       expect(error.status).toBe(400)

--- a/ironfish/src/rpc/adapters/ipcAdapter.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.ts
@@ -9,7 +9,7 @@ import { Assert } from '../../assert'
 import { createRootLogger, Logger } from '../../logger'
 import { Meter } from '../../metrics/meter'
 import { YupUtils } from '../../utils/yup'
-import { Request } from '../request'
+import { RpcRequest } from '../request'
 import { ApiNamespace, Router } from '../routes'
 import { RpcServer } from '../server'
 import { IRpcAdapter } from './adapter'
@@ -86,7 +86,7 @@ export class RpcIpcAdapter implements IRpcAdapter {
   server: IpcServer | null = null
   namespaces: ApiNamespace[]
   logger: Logger
-  pending = new Map<IpcSocketId, Request[]>()
+  pending = new Map<IpcSocketId, RpcRequest[]>()
   started = false
   connection: IpcAdapterConnectionInfo
   inboundTraffic = new Meter()
@@ -242,7 +242,7 @@ export class RpcIpcAdapter implements IRpcAdapter {
     Assert.isNotNull(router)
     Assert.isNotNull(server)
 
-    const request = new Request(
+    const request = new RpcRequest(
       message.data,
       (status: number, data?: unknown) => {
         this.emitResponse(socket, message.mid, status, data)

--- a/ironfish/src/rpc/adapters/memoryAdapter.ts
+++ b/ironfish/src/rpc/adapters/memoryAdapter.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../../assert'
 import { PromiseUtils, SetTimeoutToken } from '../../utils'
-import { RequestError } from '../clients/errors'
-import { Request } from '../request'
-import { Response } from '../response'
+import { RpcRequestError } from '../clients/errors'
+import { RpcRequest } from '../request'
+import { RpcResponse } from '../response'
 import { Router } from '../routes'
 import { Stream } from '../stream'
 import { ResponseError } from './errors'
@@ -30,7 +30,7 @@ export class RpcMemoryAdapter {
     const stream = new Stream<TStream>()
     const response = new MemoryResponse(promise, stream, null)
 
-    const request = new Request(
+    const request = new RpcRequest(
       data,
       (status: number, data?: unknown) => {
         response.status = status
@@ -51,7 +51,7 @@ export class RpcMemoryAdapter {
         // Set the response status to the errors status because RequsetError takes it from the response
         response.status = e.status
 
-        const error = new RequestError(response, e.code, e.message, e.stack)
+        const error = new RpcRequestError(response, e.code, e.message, e.stack)
 
         // Do this so in memory requests retain the original stack and are easier to debug
         error.stack = error.codeStack ?? error.stack
@@ -66,8 +66,8 @@ export class RpcMemoryAdapter {
   }
 }
 
-export class MemoryResponse<TEnd, TStream> extends Response<TEnd, TStream> {
-  request: Request<unknown, unknown> | null = null
+export class MemoryResponse<TEnd, TStream> extends RpcResponse<TEnd, TStream> {
+  request: RpcRequest<unknown, unknown> | null = null
   routePromise: Promise<void> | null = null
 
   constructor(
@@ -78,7 +78,7 @@ export class MemoryResponse<TEnd, TStream> extends Response<TEnd, TStream> {
     super(promise, stream, timeout)
   }
 
-  end(...args: Parameters<Request['end']>): ReturnType<Request['end']> {
+  end(...args: Parameters<RpcRequest['end']>): ReturnType<RpcRequest['end']> {
     Assert.isNotNull(this.request)
     return this.request.end(args)
   }

--- a/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
@@ -9,7 +9,7 @@ import { JSONUtils } from '../../../utils'
 import { ErrorUtils } from '../../../utils/error'
 import { YupUtils } from '../../../utils/yup'
 import { MessageBuffer } from '../../messageBuffer'
-import { Request } from '../../request'
+import { RpcRequest } from '../../request'
 import { ApiNamespace, Router } from '../../routes'
 import { RpcServer } from '../../server'
 import { IRpcAdapter } from '../adapter'
@@ -24,7 +24,7 @@ import {
 type SocketClient = {
   id: string
   socket: net.Socket
-  requests: Map<string, Request>
+  requests: Map<string, RpcRequest>
   messageBuffer: MessageBuffer
 }
 
@@ -133,7 +133,7 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
   }
 
   onClientConnection(socket: net.Socket): void {
-    const requests = new Map<string, Request>()
+    const requests = new Map<string, RpcRequest>()
     const client = { socket, requests, id: uuid(), messageBuffer: new MessageBuffer() }
     this.clients.set(client.id, client)
 
@@ -183,7 +183,7 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
       const message = result.result.data
 
       const requestId = uuid()
-      const request = new Request(
+      const request = new RpcRequest(
         message.data,
         (status: number, data?: unknown) => {
           this.emitResponse(client, this.constructMessage(message.mid, status, data), requestId)

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
-import { Response, ResponseEnded } from '../response'
+import { RpcResponse, RpcResponseEnded } from '../response'
 import {
   ApiNamespace,
   BlockTemplateStreamRequest,
@@ -91,34 +91,34 @@ export abstract class RpcClient {
     route: string,
     data?: unknown,
     options?: { timeoutMs?: number | null },
-  ): Response<TEnd, TStream>
+  ): RpcResponse<TEnd, TStream>
 
   async status(
     params: GetStatusRequest = undefined,
-  ): Promise<ResponseEnded<GetStatusResponse>> {
+  ): Promise<RpcResponseEnded<GetStatusResponse>> {
     return this.request<GetStatusResponse>(
       `${ApiNamespace.node}/getStatus`,
       params,
     ).waitForEnd()
   }
 
-  statusStream(): Response<void, GetStatusResponse> {
+  statusStream(): RpcResponse<void, GetStatusResponse> {
     return this.request<void, GetStatusResponse>(`${ApiNamespace.node}/getStatus`, {
       stream: true,
     })
   }
 
-  async stopNode(): Promise<ResponseEnded<StopNodeResponse>> {
+  async stopNode(): Promise<RpcResponseEnded<StopNodeResponse>> {
     return this.request<StopNodeResponse>(`${ApiNamespace.node}/stopNode`).waitForEnd()
   }
 
-  getLogStream(): Response<void, GetLogStreamResponse> {
+  getLogStream(): RpcResponse<void, GetLogStreamResponse> {
     return this.request<void, GetLogStreamResponse>(`${ApiNamespace.node}/getLogStream`)
   }
 
   async getAccounts(
     params: GetAccountsRequest = undefined,
-  ): Promise<ResponseEnded<GetAccountsResponse>> {
+  ): Promise<RpcResponseEnded<GetAccountsResponse>> {
     return await this.request<GetAccountsResponse>(
       `${ApiNamespace.account}/getAccounts`,
       params,
@@ -127,7 +127,7 @@ export abstract class RpcClient {
 
   async getDefaultAccount(
     params: GetDefaultAccountRequest = undefined,
-  ): Promise<ResponseEnded<GetDefaultAccountResponse>> {
+  ): Promise<RpcResponseEnded<GetDefaultAccountResponse>> {
     return await this.request<GetDefaultAccountResponse>(
       `${ApiNamespace.account}/getDefaultAccount`,
       params,
@@ -136,14 +136,14 @@ export abstract class RpcClient {
 
   async createAccount(
     params: CreateAccountRequest,
-  ): Promise<ResponseEnded<CreateAccountResponse>> {
+  ): Promise<RpcResponseEnded<CreateAccountResponse>> {
     return await this.request<CreateAccountResponse>(
       `${ApiNamespace.account}/create`,
       params,
     ).waitForEnd()
   }
 
-  async useAccount(params: UseAccountRequest): Promise<ResponseEnded<UseAccountResponse>> {
+  async useAccount(params: UseAccountRequest): Promise<RpcResponseEnded<UseAccountResponse>> {
     return await this.request<UseAccountResponse>(
       `${ApiNamespace.account}/use`,
       params,
@@ -152,7 +152,7 @@ export abstract class RpcClient {
 
   async removeAccount(
     params: RemoveAccountRequest,
-  ): Promise<ResponseEnded<RemoveAccountResponse>> {
+  ): Promise<RpcResponseEnded<RemoveAccountResponse>> {
     return await this.request<RemoveAccountResponse>(
       `${ApiNamespace.account}/remove`,
       params,
@@ -161,7 +161,7 @@ export abstract class RpcClient {
 
   async getAccountBalance(
     params: GetBalanceRequest = {},
-  ): Promise<ResponseEnded<GetBalanceResponse>> {
+  ): Promise<RpcResponseEnded<GetBalanceResponse>> {
     return this.request<GetBalanceResponse>(
       `${ApiNamespace.account}/getBalance`,
       params,
@@ -170,7 +170,7 @@ export abstract class RpcClient {
 
   rescanAccountStream(
     params: RescanAccountRequest = {},
-  ): Response<void, RescanAccountResponse> {
+  ): RpcResponse<void, RescanAccountResponse> {
     return this.request<void, RescanAccountResponse>(
       `${ApiNamespace.account}/rescanAccount`,
       params,
@@ -179,7 +179,7 @@ export abstract class RpcClient {
 
   async exportAccount(
     params: ExportAccountRequest = {},
-  ): Promise<ResponseEnded<ExportAccountResponse>> {
+  ): Promise<RpcResponseEnded<ExportAccountResponse>> {
     return this.request<ExportAccountResponse>(
       `${ApiNamespace.account}/exportAccount`,
       params,
@@ -188,7 +188,7 @@ export abstract class RpcClient {
 
   async importAccount(
     params: ImportAccountRequest,
-  ): Promise<ResponseEnded<ImportAccountResponse>> {
+  ): Promise<RpcResponseEnded<ImportAccountResponse>> {
     return this.request<ImportAccountResponse>(
       `${ApiNamespace.account}/importAccount`,
       params,
@@ -197,7 +197,7 @@ export abstract class RpcClient {
 
   async getAccountPublicKey(
     params: GetPublicKeyRequest,
-  ): Promise<ResponseEnded<GetPublicKeyResponse>> {
+  ): Promise<RpcResponseEnded<GetPublicKeyResponse>> {
     return this.request<GetPublicKeyResponse>(
       `${ApiNamespace.account}/getPublicKey`,
       params,
@@ -206,7 +206,7 @@ export abstract class RpcClient {
 
   async getAccountNotes(
     params: GetAccountNotesRequest = {},
-  ): Promise<ResponseEnded<GetAccountNotesResponse>> {
+  ): Promise<RpcResponseEnded<GetAccountNotesResponse>> {
     return await this.request<GetAccountNotesResponse>(
       `${ApiNamespace.account}/getAccountNotes`,
       params,
@@ -215,7 +215,7 @@ export abstract class RpcClient {
 
   async getAccountTransaction(
     params: GetAccountTransactionRequest,
-  ): Promise<ResponseEnded<GetAccountTransactionResponse>> {
+  ): Promise<RpcResponseEnded<GetAccountTransactionResponse>> {
     return await this.request<GetAccountTransactionResponse>(
       `${ApiNamespace.account}/getAccountTransaction`,
       params,
@@ -224,7 +224,7 @@ export abstract class RpcClient {
 
   async getAccountTransactions(
     params: GetAccountTransactionsRequest,
-  ): Promise<ResponseEnded<GetAccountTransactionsResponse>> {
+  ): Promise<RpcResponseEnded<GetAccountTransactionsResponse>> {
     return await this.request<GetAccountTransactionsResponse>(
       `${ApiNamespace.account}/getAccountTransactions`,
       params,
@@ -233,22 +233,22 @@ export abstract class RpcClient {
 
   async getPeers(
     params: GetPeersRequest = undefined,
-  ): Promise<ResponseEnded<GetPeersResponse>> {
+  ): Promise<RpcResponseEnded<GetPeersResponse>> {
     return this.request<GetPeersResponse>(`${ApiNamespace.peer}/getPeers`, params).waitForEnd()
   }
 
-  getPeersStream(params: GetPeersRequest = undefined): Response<void, GetPeersResponse> {
+  getPeersStream(params: GetPeersRequest = undefined): RpcResponse<void, GetPeersResponse> {
     return this.request<void, GetPeersResponse>(`${ApiNamespace.peer}/getPeers`, {
       ...params,
       stream: true,
     })
   }
 
-  async getPeer(params: GetPeerRequest): Promise<ResponseEnded<GetPeerResponse>> {
+  async getPeer(params: GetPeerRequest): Promise<RpcResponseEnded<GetPeerResponse>> {
     return this.request<GetPeerResponse>(`${ApiNamespace.peer}/getPeer`, params).waitForEnd()
   }
 
-  getPeerStream(params: GetPeerRequest): Response<void, GetPeerResponse> {
+  getPeerStream(params: GetPeerRequest): RpcResponse<void, GetPeerResponse> {
     return this.request<void, GetPeerResponse>(`${ApiNamespace.peer}/getPeer`, {
       ...params,
       stream: true,
@@ -257,7 +257,7 @@ export abstract class RpcClient {
 
   async getPeerMessages(
     params: GetPeerMessagesRequest,
-  ): Promise<ResponseEnded<GetPeerMessagesResponse>> {
+  ): Promise<RpcResponseEnded<GetPeerMessagesResponse>> {
     return this.request<GetPeerMessagesResponse>(
       `${ApiNamespace.peer}/getPeerMessages`,
       params,
@@ -266,7 +266,7 @@ export abstract class RpcClient {
 
   getPeerMessagesStream(
     params: GetPeerMessagesRequest,
-  ): Response<void, GetPeerMessagesResponse> {
+  ): RpcResponse<void, GetPeerMessagesResponse> {
     return this.request<void, GetPeerMessagesResponse>(`${ApiNamespace.peer}/getPeerMessages`, {
       ...params,
       stream: true,
@@ -275,7 +275,7 @@ export abstract class RpcClient {
 
   async getWorkersStatus(
     params: GetWorkersStatusRequest = undefined,
-  ): Promise<ResponseEnded<GetWorkersStatusResponse>> {
+  ): Promise<RpcResponseEnded<GetWorkersStatusResponse>> {
     return this.request<GetWorkersStatusResponse>(
       `${ApiNamespace.worker}/getStatus`,
       params,
@@ -284,7 +284,7 @@ export abstract class RpcClient {
 
   getWorkersStatusStream(
     params: GetWorkersStatusRequest = undefined,
-  ): Response<void, GetWorkersStatusResponse> {
+  ): RpcResponse<void, GetWorkersStatusResponse> {
     return this.request<void, GetWorkersStatusResponse>(`${ApiNamespace.worker}/getStatus`, {
       ...params,
       stream: true,
@@ -293,7 +293,7 @@ export abstract class RpcClient {
 
   async getRpcStatus(
     params: GetRpcStatusRequest = undefined,
-  ): Promise<ResponseEnded<GetRpcStatusResponse>> {
+  ): Promise<RpcResponseEnded<GetRpcStatusResponse>> {
     return this.request<GetRpcStatusResponse>(
       `${ApiNamespace.rpc}/getStatus`,
       params,
@@ -302,20 +302,20 @@ export abstract class RpcClient {
 
   getRpcStatusStream(
     params: GetRpcStatusRequest = undefined,
-  ): Response<void, GetRpcStatusResponse> {
+  ): RpcResponse<void, GetRpcStatusResponse> {
     return this.request<void, GetRpcStatusResponse>(`${ApiNamespace.rpc}/getStatus`, {
       ...params,
       stream: true,
     })
   }
 
-  onGossipStream(params: OnGossipRequest = undefined): Response<void, OnGossipResponse> {
+  onGossipStream(params: OnGossipRequest = undefined): RpcResponse<void, OnGossipResponse> {
     return this.request<void, OnGossipResponse>(`${ApiNamespace.event}/onGossip`, params)
   }
 
   async sendTransaction(
     params: SendTransactionRequest,
-  ): Promise<ResponseEnded<SendTransactionResponse>> {
+  ): Promise<RpcResponseEnded<SendTransactionResponse>> {
     return this.request<SendTransactionResponse>(
       `${ApiNamespace.transaction}/sendTransaction`,
       params,
@@ -324,14 +324,14 @@ export abstract class RpcClient {
 
   blockTemplateStream(
     params: BlockTemplateStreamRequest = undefined,
-  ): Response<void, BlockTemplateStreamResponse> {
+  ): RpcResponse<void, BlockTemplateStreamResponse> {
     return this.request<void, BlockTemplateStreamResponse>(
       `${ApiNamespace.miner}/blockTemplateStream`,
       params,
     )
   }
 
-  submitBlock(params: SubmitBlockRequest): Promise<ResponseEnded<SubmitBlockResponse>> {
+  submitBlock(params: SubmitBlockRequest): Promise<RpcResponseEnded<SubmitBlockResponse>> {
     return this.request<SubmitBlockResponse>(
       `${ApiNamespace.miner}/submitBlock`,
       params,
@@ -340,27 +340,27 @@ export abstract class RpcClient {
 
   exportMinedStream(
     params: ExportMinedStreamRequest = undefined,
-  ): Response<void, ExportMinedStreamResponse> {
+  ): RpcResponse<void, ExportMinedStreamResponse> {
     return this.request<void, ExportMinedStreamResponse>(
       `${ApiNamespace.miner}/exportMinedStream`,
       params,
     )
   }
 
-  async getFunds(params: GetFundsRequest): Promise<ResponseEnded<GetFundsResponse>> {
+  async getFunds(params: GetFundsRequest): Promise<RpcResponseEnded<GetFundsResponse>> {
     return this.request<GetFundsResponse>(
       `${ApiNamespace.faucet}/getFunds`,
       params,
     ).waitForEnd()
   }
 
-  async getBlock(params: GetBlockRequest): Promise<ResponseEnded<GetBlockResponse>> {
+  async getBlock(params: GetBlockRequest): Promise<RpcResponseEnded<GetBlockResponse>> {
     return this.request<GetBlockResponse>(`${ApiNamespace.chain}/getBlock`, params).waitForEnd()
   }
 
   async getChainInfo(
     params: GetChainInfoRequest = undefined,
-  ): Promise<ResponseEnded<GetChainInfoResponse>> {
+  ): Promise<RpcResponseEnded<GetChainInfoResponse>> {
     return this.request<GetChainInfoResponse>(
       `${ApiNamespace.chain}/getChainInfo`,
       params,
@@ -369,7 +369,7 @@ export abstract class RpcClient {
 
   exportChainStream(
     params: ExportChainStreamRequest = undefined,
-  ): Response<void, ExportChainStreamResponse> {
+  ): RpcResponse<void, ExportChainStreamResponse> {
     return this.request<void, ExportChainStreamResponse>(
       `${ApiNamespace.chain}/exportChainStream`,
       params,
@@ -378,7 +378,7 @@ export abstract class RpcClient {
 
   followChainStream(
     params: FollowChainStreamRequest = undefined,
-  ): Response<void, FollowChainStreamResponse> {
+  ): RpcResponse<void, FollowChainStreamResponse> {
     return this.request<void, FollowChainStreamResponse>(
       `${ApiNamespace.chain}/followChainStream`,
       params,
@@ -387,7 +387,7 @@ export abstract class RpcClient {
 
   async getBlockInfo(
     params: GetBlockInfoRequest,
-  ): Promise<ResponseEnded<GetBlockInfoResponse>> {
+  ): Promise<RpcResponseEnded<GetBlockInfoResponse>> {
     return this.request<GetBlockInfoResponse>(
       `${ApiNamespace.chain}/getBlockInfo`,
       params,
@@ -396,7 +396,7 @@ export abstract class RpcClient {
 
   async showChain(
     params: ShowChainRequest = undefined,
-  ): Promise<ResponseEnded<ShowChainResponse>> {
+  ): Promise<RpcResponseEnded<ShowChainResponse>> {
     return this.request<ShowChainResponse>(
       `${ApiNamespace.chain}/showChain`,
       params,
@@ -405,7 +405,7 @@ export abstract class RpcClient {
 
   getTransactionStream(
     params: GetTransactionStreamRequest,
-  ): Response<void, GetTransactionStreamResponse> {
+  ): RpcResponse<void, GetTransactionStreamResponse> {
     return this.request<void, GetTransactionStreamResponse>(
       `${ApiNamespace.chain}/getTransactionStream`,
       params,
@@ -414,14 +414,14 @@ export abstract class RpcClient {
 
   async getConfig(
     params: GetConfigRequest = undefined,
-  ): Promise<ResponseEnded<GetConfigResponse>> {
+  ): Promise<RpcResponseEnded<GetConfigResponse>> {
     return this.request<GetConfigResponse>(
       `${ApiNamespace.config}/getConfig`,
       params,
     ).waitForEnd()
   }
 
-  async setConfig(params: SetConfigRequest): Promise<ResponseEnded<SetConfigResponse>> {
+  async setConfig(params: SetConfigRequest): Promise<RpcResponseEnded<SetConfigResponse>> {
     return this.request<SetConfigResponse>(
       `${ApiNamespace.config}/setConfig`,
       params,
@@ -430,7 +430,7 @@ export abstract class RpcClient {
 
   async uploadConfig(
     params: UploadConfigRequest,
-  ): Promise<ResponseEnded<UploadConfigResponse>> {
+  ): Promise<RpcResponseEnded<UploadConfigResponse>> {
     return this.request<UploadConfigResponse>(
       `${ApiNamespace.config}/uploadConfig`,
       params,

--- a/ironfish/src/rpc/clients/errors.ts
+++ b/ironfish/src/rpc/clients/errors.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Response } from '../response'
+import { RpcResponse } from '../response'
 
 /*
  The errors in this file are to be used by RPC client implementations
@@ -15,31 +15,31 @@ import { Response } from '../response'
  * The base class for a connection related error. In case someone wants
  * to log and handle any connection related issues.
  */
-export abstract class ConnectionError extends Error {}
+export abstract class RpcConnectionError extends Error {}
 
 /**
  * Thrown when the connection attempt has failed for any reason. Most
  * likely because the server is not running, the server is unreachable,
  * the server is running on a different port, etc...
  */
-export class ConnectionRefusedError extends ConnectionError {}
+export class RpcConnectionRefusedError extends RpcConnectionError {}
 
 /** Thrown when the connection is lost after you've successfully connected.
  *
  * @note In a stateless connection like HTTP this should happen after the request was sent out, but before the response has been returned.
  * @note In a stateful connection like websockets or IPC, this should be thrown any time after you've connected when the connection has been disconnected unexpectly. */
-export class ConnectionLostError extends ConnectionError {}
+export class RpcConnectionLostError extends RpcConnectionError {}
 
 /** Thrown when a response comes back with a code that is between 400 to 500 */
-export class RequestError<TEnd = unknown, TStream = unknown> extends Error {
-  response?: Response<TEnd, TStream> = undefined
+export class RpcRequestError<TEnd = unknown, TStream = unknown> extends Error {
+  response?: RpcResponse<TEnd, TStream> = undefined
   status: number
   code: string
   codeMessage: string
   codeStack: string | null
 
   constructor(
-    response: Response<TEnd, TStream>,
+    response: RpcResponse<TEnd, TStream>,
     code: string,
     codeMessage: string,
     codeStack?: string,
@@ -55,8 +55,8 @@ export class RequestError<TEnd = unknown, TStream = unknown> extends Error {
 }
 
 /** Thrown when the request timeout has been exceeded and the request has been aborted */
-export class RequestTimeoutError<TEnd, TStream> extends RequestError<TEnd, TStream> {
-  constructor(response: Response<TEnd, TStream>, timeoutMs: number, route: string) {
+export class RequestTimeoutError<TEnd, TStream> extends RpcRequestError<TEnd, TStream> {
+  constructor(response: RpcResponse<TEnd, TStream>, timeoutMs: number, route: string) {
     super(response, 'request-timeout', `Timeout of ${timeoutMs} exceeded to ${route}`)
   }
 }

--- a/ironfish/src/rpc/clients/ipcClient.ts
+++ b/ironfish/src/rpc/clients/ipcClient.ts
@@ -7,7 +7,7 @@ import { Event } from '../../event'
 import { createRootLogger, Logger } from '../../logger'
 import { ErrorUtils } from '../../utils'
 import { IpcRequest } from '../adapters'
-import { ConnectionLostError, ConnectionRefusedError } from './errors'
+import { RpcConnectionLostError, RpcConnectionRefusedError } from './errors'
 import { RpcClientConnectionInfo, RpcSocketClient } from './socketClient'
 
 const CONNECT_RETRY_MS = 2000
@@ -76,9 +76,9 @@ export class RpcIpcClient extends RpcSocketClient {
           client.off('connect', onConnect)
 
           if (ErrorUtils.isConnectRefusedError(error)) {
-            reject(new ConnectionRefusedError())
+            reject(new RpcConnectionRefusedError())
           } else if (ErrorUtils.isNoEntityError(error)) {
-            reject(new ConnectionRefusedError())
+            reject(new RpcConnectionRefusedError())
           } else {
             reject(error)
           }
@@ -136,7 +136,7 @@ export class RpcIpcClient extends RpcSocketClient {
     this.client = null
 
     for (const request of this.pending.values()) {
-      request.reject(new ConnectionLostError(request.type))
+      request.reject(new RpcConnectionLostError(request.type))
     }
     this.pending.clear()
 

--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -11,7 +11,7 @@ import {
   ServerSocketRpcSchema,
 } from '../adapters/socketAdapter/protocol'
 import { MessageBuffer } from '../messageBuffer'
-import { ConnectionLostError, ConnectionRefusedError } from './errors'
+import { RpcConnectionLostError, RpcConnectionRefusedError } from './errors'
 import { RpcClientConnectionInfo, RpcSocketClient } from './socketClient'
 
 export class RpcTcpClient extends RpcSocketClient {
@@ -45,9 +45,9 @@ export class RpcTcpClient extends RpcSocketClient {
         client.off('connect', onConnect)
         client.off('error', onError)
         if (ErrorUtils.isConnectRefusedError(error)) {
-          reject(new ConnectionRefusedError())
+          reject(new RpcConnectionRefusedError())
         } else if (ErrorUtils.isNoEntityError(error)) {
-          reject(new ConnectionRefusedError())
+          reject(new RpcConnectionRefusedError())
         } else {
           reject(error)
         }
@@ -130,7 +130,7 @@ export class RpcTcpClient extends RpcSocketClient {
     this.client?.off('close', this.onClientClose)
 
     for (const request of this.pending.values()) {
-      request.reject(new ConnectionLostError(request.type))
+      request.reject(new RpcConnectionLostError(request.type))
     }
     this.pending.clear()
 

--- a/ironfish/src/rpc/clients/tlsClient.ts
+++ b/ironfish/src/rpc/clients/tlsClient.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import tls from 'tls'
 import { ErrorUtils } from '../../utils'
-import { ConnectionRefusedError } from './errors'
+import { RpcConnectionRefusedError } from './errors'
 import { RpcTcpClient } from './tcpClient'
 
 export class RpcTlsClient extends RpcTcpClient {
@@ -20,9 +20,9 @@ export class RpcTlsClient extends RpcTcpClient {
         client.off('secureConnection', onSecureConnect)
         client.off('error', onError)
         if (ErrorUtils.isConnectRefusedError(error)) {
-          reject(new ConnectionRefusedError())
+          reject(new RpcConnectionRefusedError())
         } else if (ErrorUtils.isNoEntityError(error)) {
-          reject(new ConnectionRefusedError())
+          reject(new RpcConnectionRefusedError())
         } else {
           reject(error)
         }

--- a/ironfish/src/rpc/request.ts
+++ b/ironfish/src/rpc/request.ts
@@ -4,7 +4,7 @@
 
 import { Event } from '../event'
 
-export class Request<TRequest = unknown, TResponse = unknown> {
+export class RpcRequest<TRequest = unknown, TResponse = unknown> {
   data: TRequest
   ended = false
   closed = false

--- a/ironfish/src/rpc/response.ts
+++ b/ironfish/src/rpc/response.ts
@@ -3,24 +3,24 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { SetTimeoutToken } from '../utils'
-import { ConnectionLostError } from './clients'
+import { RpcConnectionLostError } from './clients'
 import { Stream } from './stream'
 
-export function isResponseError(response: Response<unknown>): boolean {
-  return isResponseUserError(response) || isResponseServerError(response)
+export function isRpcResponseError(response: RpcResponse<unknown>): boolean {
+  return isRpcResponseUserError(response) || isRpcResponseServerError(response)
 }
 
-export function isResponseServerError(response: Response<unknown>): boolean {
+export function isRpcResponseServerError(response: RpcResponse<unknown>): boolean {
   return response.status >= 500 && response.status <= 599
 }
 
-export function isResponseUserError(response: Response<unknown>): boolean {
+export function isRpcResponseUserError(response: RpcResponse<unknown>): boolean {
   return response.status >= 400 && response.status <= 499
 }
 
-export type ResponseEnded<TEnd> = Exclude<Response<TEnd>, 'content'> & { content: TEnd }
+export type RpcResponseEnded<TEnd> = Exclude<RpcResponse<TEnd>, 'content'> & { content: TEnd }
 
-export class Response<TEnd = unknown, TStream = unknown> {
+export class RpcResponse<TEnd = unknown, TStream = unknown> {
   private promise: Promise<TEnd>
   private stream: Stream<TStream>
   private timeout: SetTimeoutToken | null
@@ -38,9 +38,9 @@ export class Response<TEnd = unknown, TStream = unknown> {
     this.timeout = timeout
   }
 
-  async waitForEnd(): Promise<ResponseEnded<TEnd>> {
+  async waitForEnd(): Promise<RpcResponseEnded<TEnd>> {
     this.content = await this.promise
-    return this as ResponseEnded<TEnd>
+    return this as RpcResponseEnded<TEnd>
   }
 
   async *contentStream(ignoreClose = true): AsyncGenerator<TStream, void> {
@@ -53,7 +53,7 @@ export class Response<TEnd = unknown, TStream = unknown> {
     }
 
     await this.promise.catch((e) => {
-      if (e instanceof ConnectionLostError && ignoreClose) {
+      if (e instanceof RpcConnectionLostError && ignoreClose) {
         return
       }
       throw e

--- a/ironfish/src/rpc/routes/accounts/create.test.slow.ts
+++ b/ironfish/src/rpc/routes/accounts/create.test.slow.ts
@@ -8,7 +8,7 @@
 import { v4 as uuid } from 'uuid'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { ERROR_CODES } from '../../adapters'
-import { RequestError } from '../../clients/errors'
+import { RpcRequestError } from '../../clients/errors'
 
 describe('Route account/create', () => {
   jest.setTimeout(15000)
@@ -56,7 +56,7 @@ describe('Route account/create', () => {
       expect.assertions(3)
       await routeTest.client.request('account/create').waitForEnd()
     } catch (e: unknown) {
-      if (!(e instanceof RequestError)) {
+      if (!(e instanceof RpcRequestError)) {
         throw e
       }
       expect(e.status).toBe(400)
@@ -74,7 +74,7 @@ describe('Route account/create', () => {
       expect.assertions(2)
       await routeTest.client.request('account/create', { name: name }).waitForEnd()
     } catch (e: unknown) {
-      if (!(e instanceof RequestError)) {
+      if (!(e instanceof RpcRequestError)) {
         throw e
       }
       expect(e.status).toBe(400)

--- a/ironfish/src/rpc/routes/faucet/getFunds.test.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import axios, { AxiosError } from 'axios'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { RequestError } from '../../clients'
+import { RpcRequestError } from '../../clients'
 
 jest.mock('axios')
 
@@ -74,7 +74,7 @@ describe('Route faucet.getFunds', () => {
         })
         await expect(
           routeTest.client.request('faucet/getFunds', { accountName, email }).waitForEnd(),
-        ).rejects.toThrow(RequestError)
+        ).rejects.toThrow(RpcRequestError)
       })
     })
 

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -7,7 +7,7 @@ import { YupSchema, YupSchemaResult, YupUtils } from '../../utils'
 import { StrEnumUtils } from '../../utils/enums'
 import { ERROR_CODES } from '../adapters'
 import { ResponseError, ValidationError } from '../adapters/errors'
-import { Request } from '../request'
+import { RpcRequest } from '../request'
 import { RpcServer } from '../server'
 
 export enum ApiNamespace {
@@ -28,7 +28,7 @@ export enum ApiNamespace {
 export const ALL_API_NAMESPACES = StrEnumUtils.getValues(ApiNamespace)
 
 export type RouteHandler<TRequest = unknown, TResponse = unknown> = (
-  request: Request<TRequest, TResponse>,
+  request: RpcRequest<TRequest, TResponse>,
   node: IronfishNode,
 ) => Promise<void> | void
 
@@ -76,7 +76,7 @@ export class Router {
     })
   }
 
-  async route(route: string, request: Request): Promise<void> {
+  async route(route: string, request: RpcRequest): Promise<void> {
     const [namespace, method] = route.split('/')
 
     const namespaceRoutes = this.routes.get(namespace)

--- a/ironfish/src/utils/error.ts
+++ b/ironfish/src/utils/error.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { RequestError } from '../rpc/clients/errors'
+import { RpcRequestError } from '../rpc/clients/errors'
 
 /**
  * This is used to unwrap a message from an error
@@ -15,7 +15,7 @@ export function renderError(error: unknown, stack = false): string {
   }
 
   if (stack) {
-    if (error instanceof RequestError && error.codeStack) {
+    if (error instanceof RpcRequestError && error.codeStack) {
       // stack also contains the error message
       return `${error.message}\n${error.codeStack}`
     }


### PR DESCRIPTION
## Summary

We already did this for server side adapters, but not clients, client errors, and `Response` and `Request`. There are no code changes here, only F2 type renames.

## Testing Plan

Build and run tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
