### PR TITLE
Minor rescan improvements

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -60,7 +60,7 @@ export class Accounts {
 
   protected readonly accounts = new Map<string, Account>()
   readonly db: AccountsDB
-  protected readonly logger: Logger
+  readonly logger: Logger
   readonly workerPool: WorkerPool
   readonly chain: Blockchain
   private readonly config: Config
@@ -580,6 +580,10 @@ export class Accounts {
   }
 
   async scanTransactions(): Promise<void> {
+    if (!this.isOpen) {
+      throw new Error('Cannot start a scan if accounts are not loaded')
+    }
+
     if (this.scan) {
       this.logger.info('Skipping Scan, already scanning.')
       return

--- a/ironfish/src/rpc/routes/accounts/rescanAccount.ts
+++ b/ironfish/src/rpc/routes/accounts/rescanAccount.ts
@@ -36,8 +36,13 @@ router.register<typeof RescanAccountRequestSchema, RescanAccountResponse>(
       if (request.data.reset) {
         await node.accounts.reset()
       }
+
       void node.accounts.scanTransactions()
       scan = node.accounts.scan
+
+      if (!scan) {
+        node.accounts.logger.warn(`Attempted to start accounts scan but one did not start.`)
+      }
     }
 
     if (scan && request.data.follow) {


### PR DESCRIPTION
## Summary

This adds a couple of improvements to rescan

 - Simplifies the flags
 - Throws an error if we manage to do this on an unloaded
   accounts
 - Warns if we start a scan and a scan was not started

## Testing Plan
Run rescan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
