### PR TITLE
feat(ironfish): Only sync transactions for accounts that can decrypt notes

### DIFF
--- a/ironfish/src/account/account.ts
+++ b/ironfish/src/account/account.ts
@@ -162,14 +162,12 @@ export class Account {
     const blockHash = 'blockHash' in params ? params.blockHash : null
     let submittedSequence = 'submittedSequence' in params ? params.submittedSequence : null
 
-    let shouldUpdateTransaction = true
     const record = this.transactions.get(transactionHash)
     if (record) {
       submittedSequence = record.submittedSequence
-      shouldUpdateTransaction = !this.transactionValuesAreEqual(record, transaction, blockHash)
     }
 
-    if (shouldUpdateTransaction) {
+    if (!record || !record.transaction.equals(transaction) || record.blockHash !== blockHash) {
       await this.updateTransaction(
         transactionHash,
         { transaction, blockHash, submittedSequence },
@@ -180,17 +178,6 @@ export class Account {
     const isRemovingTransaction = submittedSequence === null && blockHash === null
     await this.bulkUpdateDecryptedNotes(transactionHash, decryptedNotes, tx)
     await this.processTransactionSpends(transaction, isRemovingTransaction, tx)
-  }
-
-  private transactionValuesAreEqual(
-    record: Readonly<{
-      transaction: Transaction
-      blockHash: string | null
-    }>,
-    transaction: Transaction,
-    blockHash: string | null,
-  ): boolean {
-    return record.transaction.equals(transaction) && record.blockHash === blockHash
   }
 
   async updateTransaction(

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -375,7 +375,9 @@ export class Accounts {
         decryptedNotes.push(...decryptedNotesBatch)
       }
 
-      decryptedNotesByAccountId.set(account.id, decryptedNotes)
+      if (decryptedNotes.length) {
+        decryptedNotesByAccountId.set(account.id, decryptedNotes)
+      }
     }
 
     return decryptedNotesByAccountId


### PR DESCRIPTION
## Summary

* Only return mapping of account IDs -> decrypted notes if notes are available to remove unnecessary `syncTransaction` calls
* Check if transactions need to be updated before hitting the DB

## Testing Plan

Covered by existing unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
