### PR TITLE
scanTransactions updates progress incrementally

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -510,10 +510,8 @@ export class Accounts {
         scan.onTransaction.emit(sequence)
       }
 
-      if (blockHeader.sequence % 20 === 0) {
-        for (const account of outdatedAccounts) {
-          await this.updateHeadHash(account, blockHeader.hash)
-        }
+      for (const account of outdatedAccounts) {
+        await this.updateHeadHash(account, blockHeader.hash)
       }
     }
 

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -466,41 +466,55 @@ export class Accounts {
     const scan = new ScanState()
     this.scan = scan
 
-    // If were updating the account head we need to wait until its finished
+    // If we are updating the account head, we need to wait until its finished
     // but setting this.scan is our lock so updating the head doesn't run again
     await this.updateHeadState?.wait()
 
-    const accountHeadHash = this.chainProcessor.hash
+    const startHash = await this.getEarliestHeadHash()
+    const endHash = this.chainProcessor.hash
 
-    const scanStart = await this.getEarliestHeadHash()
+    const outdatedAccounts = this.listAccounts().filter((a) => !this.isAccountUpToDate(a))
 
-    const scanFor = Array.from(this.accounts.values())
-      .filter((a) => a.rescan !== null && a.rescan <= scan.startedAt)
-      .map((a) => a.displayName)
-      .join(', ')
-
-    this.logger.info(`Scanning for transactions${scanFor ? ` for ${scanFor}` : ''}`)
     this.logger.info(
       `Scan starting from earliest found account head hash: ${
-        scanStart ? scanStart.toString('hex') : 'GENESIS'
+        startHash ? startHash.toString('hex') : 'GENESIS'
       }`,
+    )
+    this.logger.info(
+      `Accounts to scan for: ${outdatedAccounts.map((a) => a.displayName).join(', ')}`,
     )
 
     // Go through every transaction in the chain and add notes that we can decrypt
-    for await (const {
-      blockHash,
-      transaction,
-      initialNoteIndex,
-      sequence,
-    } of this.chain.iterateTransactions(scanStart, accountHeadHash, undefined, false)) {
-      if (scan.isAborted) {
-        scan.signalComplete()
-        this.scan = null
-        return
+    for await (const blockHeader of this.chain.iterateBlockHeaders(
+      startHash,
+      endHash,
+      undefined,
+      false,
+    )) {
+      for await (const {
+        blockHash,
+        transaction,
+        initialNoteIndex,
+        sequence,
+      } of this.chain.iterateBlockTransactions(blockHeader)) {
+        if (scan.isAborted) {
+          scan.signalComplete()
+          this.scan = null
+          return
+        }
+
+        await this.syncTransaction(transaction, {
+          blockHash,
+          initialNoteIndex: initialNoteIndex,
+        })
+        scan.onTransaction.emit(sequence)
       }
 
-      await this.syncTransaction(transaction, { blockHash, initialNoteIndex: initialNoteIndex })
-      scan.onTransaction.emit(sequence)
+      if (blockHeader.sequence % 20 === 0) {
+        for (const account of outdatedAccounts) {
+          await this.updateHeadHash(account, blockHeader.hash)
+        }
+      }
     }
 
     for (const account of this.accounts.values()) {
@@ -510,12 +524,12 @@ export class Accounts {
       }
 
       this.headStatus.set(account.id, {
-        headHash: accountHeadHash.toString('hex'),
+        headHash: endHash.toString('hex'),
         upToDate: true,
       })
     }
 
-    await this.updateHeadHashes(accountHeadHash)
+    await this.updateHeadHashes(endHash)
 
     this.logger.info(
       `Finished scanning for transactions after ${Math.floor(

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1120,19 +1120,15 @@ export class Blockchain {
   }
 
   /**
-   * Iterates through transactions, starting from fromHash or the genesis block,
+   * Iterates through block headers, starting from fromHash or the genesis block,
    * to toHash or the heaviest head.
    */
-  async *iterateTransactions(
+  async *iterateBlockHeaders(
     fromHash: Buffer | null = null,
     toHash: Buffer | null = null,
     tx?: IDatabaseTransaction,
     reachable = true,
-  ): AsyncGenerator<
-    { transaction: Transaction; initialNoteIndex: number; sequence: number; blockHash: string },
-    void,
-    unknown
-  > {
+  ): AsyncGenerator<BlockHeader, void, void> {
     let from: BlockHeader | null
     if (fromHash) {
       from = await this.getHeader(fromHash, tx)
@@ -1151,9 +1147,7 @@ export class Blockchain {
     Assert.isNotNull(to, `Expected 'to' not to be null`)
 
     for await (const header of this.iterateTo(from, to, tx, reachable)) {
-      for await (const transaction of this.iterateBlockTransactions(header, tx)) {
-        yield transaction
-      }
+      yield header
     }
   }
 


### PR DESCRIPTION
## Summary

Still technically updates all accounts in the syncTransaction call, but now updates the outdated accounts so that we can save progress if we stop it for any reason

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
