### PR TITLE
Clamp telemetry floats to 0

### DIFF
--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -232,6 +232,15 @@ export class Telemetry {
 
     const fields = this.defaultFields.concat(metric.fields)
 
+    // TODO(jason): RollingAverage can produce a negative number which seems
+    // like it should be a bug. Investigate then delete this TODO. Negative
+    // floats are not allowed by telemetry and produce a 422 error.
+    for (const field of fields) {
+      if (field.type === 'float') {
+        field.value = Math.max(0, field.value)
+      }
+    }
+
     this.points.push({
       ...metric,
       timestamp: metric.timestamp,


### PR DESCRIPTION
## Summary

RollingAverage can produce a negative number which seems
like it should be a bug. Investigate then delete this TODO.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
