### PR TITLE
Abort rescan if aborted after waiting for head

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -335,9 +335,11 @@ export class IronfishNode {
       this.rpc.stop(),
       this.telemetry.stop(),
       this.metrics.stop(),
-      this.workerPool.stop(),
       this.minedBlocksIndexer.stop(),
     ])
+
+    // Do after to avoid unhandled error from aborted jobs
+    await Promise.allSettled([this.workerPool.stop()])
 
     if (this.shutdownResolve) {
       this.shutdownResolve()


### PR DESCRIPTION
## Summary

When were rescanning, we start a scan, then wait for the lock on the
updateHead() method. However, this may take a long time. It's possible
the head updating was aborted because the node is shutting down. The
issue is that we don't also check if the scan was aborted as soon as
the updateHead() lock is released.

This means we could start scanning when the node is shutting down which
will prevent it from shutting down properly.

## Testing Plan
1. Have a lot of blocks to scan
2. `yarn start  accounts:rescan --reset --local`
3. `yarn start start`
4. Close node in the middle of the reset
5. Start node, it'll start updating the head right away but it will take a long time
6. `yarn start  accounts:rescan --reset`
    * This should get stuck at waiting for scan to start
7. `ironfish stop`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
