### PR TITLE
Use built-in no-unused-expressions lint

### DIFF
--- a/config/eslint-config-ironfish/index.js
+++ b/config/eslint-config-ironfish/index.js
@@ -60,6 +60,12 @@ module.exports = {
     'ironfish/no-vague-imports': 'error',
     'ironfish/no-buffer-cmp': 'error',
 
+    // Catches expressions that aren't assigned
+    '@typescript-eslint/no-unused-expressions': [
+      'error',
+      { allowShortCircuit: true, allowTernary: true },
+    ],
+
     // Seems to be needed to allow for custom jest matchers
     '@typescript-eslint/no-namespace': [
       'error',

--- a/ironfish/src/mining/stratum/errors.ts
+++ b/ironfish/src/mining/stratum/errors.ts
@@ -15,7 +15,7 @@ export class MessageMalformedError extends Error {
       if (method) {
         this.message += ` (${method})`
       }
-      this.message + `: ${error.message}`
+      this.message += `: ${error.message}`
     }
   }
 }


### PR DESCRIPTION
## Summary

Supercedes #1764 

Turns out they do have a built-in rule for this, I just overlooked it when I was perusing the rules list. 

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
