### PR TITLE
Only scan transactions for accounts where it is relevant

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -494,7 +494,7 @@ export class Accounts {
 
       if (startHashHex === headStatus.headHash) {
         accounts.push(account)
-      } else {
+      } else if (!headStatus.upToDate) {
         remainingAccounts.push(account)
       }
     }

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -558,7 +558,7 @@ export class Accounts {
       }
     }
 
-    for (const account of this.accounts.values()) {
+    for (const account of accounts) {
       if (account.rescan !== null && account.rescan <= scan.startedAt) {
         account.rescan = null
         await this.db.setAccount(account)

--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -483,8 +483,10 @@ export class Accounts {
     const startHash = await this.getEarliestHeadHash()
     const endHash = this.chainProcessor.hash
 
+    // Accounts that need to be updated at the current scan sequence
     const accounts: Array<Account> = []
-    const remainingAccounts: Array<Account> = []
+    // Accounts that need to be updated at future scan sequences
+    let remainingAccounts: Array<Account> = []
 
     const startHashHex = startHash ? startHash.toString('hex') : null
 
@@ -541,21 +543,21 @@ export class Accounts {
       }
 
       const hashHex = blockHeader.hash.toString('hex')
+      const newRemainingAccounts = []
 
-      let i = 0
-      while (i < remainingAccounts.length) {
-        const account = remainingAccounts[i]
-        const headStatus = this.headStatus.get(account.id)
+      for (const remainingAccount of remainingAccounts) {
+        const headStatus = this.headStatus.get(remainingAccount.id)
         Assert.isNotUndefined(headStatus)
 
         if (headStatus.headHash === hashHex) {
-          remainingAccounts.splice(i, 1)
-          accounts.push(account)
-          this.logger.debug(`Adding ${account.displayName} to scan`)
+          accounts.push(remainingAccount)
+          this.logger.debug(`Adding ${remainingAccount.displayName} to scan`)
         } else {
-          i += 1
+          newRemainingAccounts.push(remainingAccount)
         }
       }
+
+      remainingAccounts = newRemainingAccounts
     }
 
     for (const account of accounts) {


### PR DESCRIPTION
## Summary

**Builds on #1775**

Scans transactions for accounts that are specifically relevant, so we aren't scanning transactions for accounts that don't need it, and don't "set back" account progress

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
