### PR TITLE
Require stratum client version

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -309,7 +309,7 @@ export class Config extends KeyStore<ConfigOptions> {
       minerBatchSize: DEFAULT_MINER_BATCH_SIZE,
       poolName: DEFAULT_POOL_NAME,
       poolAccountName: DEFAULT_POOL_ACCOUNT_NAME,
-      poolBanning: false,
+      poolBanning: true,
       poolBalancePercentPayout: DEFAULT_POOL_BALANCE_PERCENT_PAYOUT,
       poolHost: DEFAULT_POOL_HOST,
       poolPort: DEFAULT_POOL_PORT,

--- a/ironfish/src/mining/stratum/messages.ts
+++ b/ironfish/src/mining/stratum/messages.ts
@@ -19,7 +19,7 @@ export type MiningDisconnectMessage =
   | undefined
 
 export type MiningSubscribeMessage = {
-  version?: number
+  version: number
   publicAddress: string
 }
 
@@ -108,7 +108,7 @@ export const MiningWaitForWorkSchema: yup.MixedSchema<MiningWaitForWorkMessage> 
 
 export const MiningSubscribeSchema: yup.ObjectSchema<MiningSubscribeMessage> = yup
   .object({
-    version: yup.number().optional(),
+    version: yup.number().required(),
     publicAddress: yup.string().required(),
   })
   .required()

--- a/ironfish/src/mining/stratum/stratumPeers.ts
+++ b/ironfish/src/mining/stratum/stratumPeers.ts
@@ -11,7 +11,7 @@ import { DisconnectReason } from './constants'
 import { StratumServer } from './stratumServer'
 import { StratumServerClient } from './stratumServerClient'
 
-const FIFTEEN_MINUTES_MS = 15 * 60 * 1000
+const FIVE_MINUTES_MS = 5 * 60 * 1000
 const PEERS_TICK_MS = 10000
 
 export class StratumPeers {
@@ -100,7 +100,7 @@ export class StratumPeers {
       return
     }
 
-    const until = options?.until ?? Date.now() + FIFTEEN_MINUTES_MS
+    const until = options?.until ?? Date.now() + FIVE_MINUTES_MS
 
     let existing = this.bannedByIp.get(client.remoteAddress)
 

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -31,7 +31,7 @@ import { StratumPeers } from './stratumPeers'
 import { StratumServerClient } from './stratumServerClient'
 import { STRATUM_VERSION_PROTOCOL, STRATUM_VERSION_PROTOCOL_MIN } from './version'
 
-const FIFTEEN_MINUTES_MS = 15 * 60 * 1000
+const FIVE_MINUTES_MS = 5 * 60 * 1000
 
 export class StratumServer {
   readonly server: net.Server
@@ -188,20 +188,11 @@ export class StratumServer {
             return
           }
 
-          // TODO: Remove when making version required
-          if (body.result.version === undefined) {
-            this.peers.shadowBan(client)
-            return
-          }
-
-          // TODO: This undefined check makes version optional, we should require it by
-          // removing this undefined check in a future update once we have given enough
-          // notice after this deploy.
-          if (body.result.version !== undefined && body.result.version < this.versionMin) {
+          if (body.result.version < this.versionMin) {
             this.peers.ban(client, {
               message: `Client version ${body.result.version} does not meet minimum version ${this.versionMin}`,
               reason: DisconnectReason.BAD_VERSION,
-              until: Date.now() + FIFTEEN_MINUTES_MS,
+              until: Date.now() + FIVE_MINUTES_MS,
               versionExpected: this.version,
             })
             return


### PR DESCRIPTION
## Summary
We now require the stratum client version and enable banning. Users should upgrade to 37 before 39 is released.

## Testing Plan
Modify client to send lower version, or undefined version and see what happens.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
