### PR TITLE
Create GetBlockTransactions request and response messages

### DIFF
--- a/ironfish/src/network/messageRegistry.ts
+++ b/ironfish/src/network/messageRegistry.ts
@@ -6,6 +6,10 @@ import { CannotSatisfyRequest } from './messages/cannotSatisfyRequest'
 import { DisconnectingMessage } from './messages/disconnecting'
 import { GetBlockHashesRequest, GetBlockHashesResponse } from './messages/getBlockHashes'
 import { GetBlocksRequest, GetBlocksResponse } from './messages/getBlocks'
+import {
+  GetBlockTransactionsRequest,
+  GetBlockTransactionsResponse,
+} from './messages/getBlockTransactions'
 import { GossipNetworkMessage } from './messages/gossipNetworkMessage'
 import { IdentifyMessage } from './messages/identify'
 import { NetworkMessage } from './messages/networkMessage'
@@ -45,6 +49,8 @@ const isRpcNetworkMessageType = (type: NetworkMessageType): boolean => {
     NetworkMessageType.GetBlocksResponse,
     NetworkMessageType.PooledTransactionsRequest,
     NetworkMessageType.PooledTransactionsResponse,
+    NetworkMessageType.GetBlockTransactionsRequest,
+    NetworkMessageType.GetBlockTransactionsResponse,
   ].includes(type)
 }
 
@@ -73,6 +79,10 @@ const parseRpcNetworkMessage = (
       return PooledTransactionsRequest.deserialize(body, rpcId)
     case NetworkMessageType.PooledTransactionsResponse:
       return PooledTransactionsResponse.deserialize(body, rpcId)
+    case NetworkMessageType.GetBlockTransactionsRequest:
+      return GetBlockTransactionsRequest.deserialize(body, rpcId)
+    case NetworkMessageType.GetBlockTransactionsResponse:
+      return GetBlockTransactionsResponse.deserialize(body, rpcId)
     default:
       throw new Error(`Unknown RPC network message type: ${type}`)
   }

--- a/ironfish/src/network/messages/getBlockTransactions.test.ts
+++ b/ironfish/src/network/messages/getBlockTransactions.test.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  GetBlockTransactionsRequest,
+  GetBlockTransactionsResponse,
+} from './getBlockTransactions'
+
+describe('GetBlockTransactionsRequest', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const rpcId = 0
+    const blockHash = Buffer.alloc(32, 1)
+    const transactionIndexes = [1, 60000]
+
+    const message = new GetBlockTransactionsRequest(blockHash, transactionIndexes, rpcId)
+    const buffer = message.serialize()
+    const deserializedMessage = GetBlockTransactionsRequest.deserialize(buffer, rpcId)
+
+    expect(deserializedMessage).toEqual(message)
+  })
+})
+
+describe('GetBlockTransactionsResponse', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const rpcId = 0
+    const blockHash = Buffer.alloc(32, 1)
+    const serializedTransactions = [
+      Buffer.alloc(32, 1),
+      Buffer.alloc(32, 2),
+      Buffer.alloc(32, 3),
+    ]
+
+    const message = new GetBlockTransactionsResponse(blockHash, serializedTransactions, rpcId)
+    const buffer = message.serialize()
+    const deserializedMessage = GetBlockTransactionsResponse.deserialize(buffer, rpcId)
+
+    expect(deserializedMessage).toEqual(message)
+  })
+})

--- a/ironfish/src/network/messages/getBlockTransactions.ts
+++ b/ironfish/src/network/messages/getBlockTransactions.ts
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio, { sizeVarBytes, sizeVarint } from 'bufio'
+import { NetworkMessageType } from '../types'
+import { Direction, RpcNetworkMessage } from './rpcNetworkMessage'
+
+export class GetBlockTransactionsRequest extends RpcNetworkMessage {
+  readonly blockHash: Buffer
+  readonly transactionIndexes: number[]
+
+  constructor(blockHash: Buffer, transactionIndexes: number[], rpcId?: number) {
+    super(NetworkMessageType.GetBlockTransactionsRequest, Direction.Request, rpcId)
+    this.blockHash = blockHash
+    this.transactionIndexes = transactionIndexes
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+    bw.writeHash(this.blockHash)
+
+    bw.writeVarint(this.transactionIndexes.length)
+    for (const transactionIndex of this.transactionIndexes) {
+      bw.writeVarint(transactionIndex)
+    }
+
+    return bw.render()
+  }
+
+  static deserialize(buffer: Buffer, rpcId: number): GetBlockTransactionsRequest {
+    const reader = bufio.read(buffer, true)
+    const blockHash = reader.readHash()
+
+    const transactionIndexesLength = reader.readVarint()
+    const transactionIndexes = []
+    for (let i = 0; i < transactionIndexesLength; i++) {
+      const transactionIndex = reader.readVarint()
+      transactionIndexes.push(transactionIndex)
+    }
+
+    return new GetBlockTransactionsRequest(blockHash, transactionIndexes, rpcId)
+  }
+
+  getSize(): number {
+    let size = 0
+    size += 32
+    size += sizeVarint(this.transactionIndexes.length)
+    for (const transactionIndex of this.transactionIndexes) {
+      size += sizeVarint(transactionIndex)
+    }
+    return size
+  }
+}
+
+export class GetBlockTransactionsResponse extends RpcNetworkMessage {
+  readonly blockHash: Buffer
+  readonly serializedTransactions: Buffer[]
+
+  constructor(blockHash: Buffer, serializedTransactions: Buffer[], rpcId: number) {
+    super(NetworkMessageType.GetBlockTransactionsResponse, Direction.Response, rpcId)
+    this.blockHash = blockHash
+    this.serializedTransactions = serializedTransactions
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+    bw.writeHash(this.blockHash)
+
+    bw.writeVarint(this.serializedTransactions.length)
+    for (const serializedTransaction of this.serializedTransactions) {
+      bw.writeVarBytes(serializedTransaction)
+    }
+
+    return bw.render()
+  }
+
+  static deserialize(buffer: Buffer, rpcId: number): GetBlockTransactionsResponse {
+    const reader = bufio.read(buffer, true)
+    const blockHash = reader.readHash()
+
+    const serializedTransactionsLength = reader.readVarint()
+    const serializedTransactions = []
+    for (let i = 0; i < serializedTransactionsLength; i++) {
+      serializedTransactions.push(reader.readVarBytes())
+    }
+
+    return new GetBlockTransactionsResponse(blockHash, serializedTransactions, rpcId)
+  }
+
+  getSize(): number {
+    let size = 0
+    size += 32
+    size += sizeVarint(this.serializedTransactions.length)
+    for (const serializedTransaction of this.serializedTransactions) {
+      size += sizeVarBytes(serializedTransaction)
+    }
+    return size
+  }
+}

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -26,6 +26,10 @@ import { CannotSatisfyRequest } from './messages/cannotSatisfyRequest'
 import { DisconnectingMessage, DisconnectingReason } from './messages/disconnecting'
 import { GetBlockHashesRequest, GetBlockHashesResponse } from './messages/getBlockHashes'
 import { GetBlocksRequest, GetBlocksResponse } from './messages/getBlocks'
+import {
+  GetBlockTransactionsRequest,
+  GetBlockTransactionsResponse,
+} from './messages/getBlockTransactions'
 import { GossipNetworkMessage } from './messages/gossipNetworkMessage'
 import {
   displayNetworkMessageType,
@@ -556,6 +560,8 @@ export class PeerNetwork {
           responseMessage = await this.onGetBlocksRequest({ peerIdentity, message: rpcMessage })
         } else if (rpcMessage instanceof PooledTransactionsRequest) {
           responseMessage = this.onPooledTransactionsRequest(rpcMessage, rpcId)
+        } else if (rpcMessage instanceof GetBlockTransactionsRequest) {
+          responseMessage = this.onGetBlockTransactionsRequest(rpcMessage)
         } else {
           throw new Error(`Invalid rpc message type: '${rpcMessage.type}'`)
         }
@@ -710,6 +716,13 @@ export class PeerNetwork {
     }
 
     return new PooledTransactionsResponse(transactions, rpcId)
+  }
+
+  private onGetBlockTransactionsRequest(
+    message: GetBlockTransactionsRequest,
+  ): GetBlockTransactionsResponse {
+    // TODO(IRO-2279): Implement a handler for this
+    return new GetBlockTransactionsResponse(message.blockHash, [], message.rpcId)
   }
 
   private async onNewBlock(message: IncomingPeerMessage<NewBlockMessage>): Promise<boolean> {

--- a/ironfish/src/network/types.ts
+++ b/ironfish/src/network/types.ts
@@ -24,6 +24,8 @@ export enum NetworkMessageType {
   NewTransactionV2 = 16,
   NewBlockHashes = 17,
   NewBlockV2 = 18,
+  GetBlockTransactionsRequest = 19,
+  GetBlockTransactionsResponse = 20,
 }
 
 export type IsomorphicWebSocketConstructor = typeof WebSocket | typeof WSWebSocket


### PR DESCRIPTION
## Summary

Adds a GetBlockTransactions RPC message for the new block propagation model. The handlers will come in future PRs.

Fixes IRO-2233
Fixes IRO-2232

## Testing Plan

Added a unit test for the message itself. Node should start up

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
