### PR TITLE
Remove rescan, minor cleanups

### DIFF
--- a/ironfish-cli/src/commands/accounts/import.ts
+++ b/ironfish-cli/src/commands/accounts/import.ts
@@ -114,7 +114,6 @@ export class ImportCommand extends IronfishCommand {
       incomingViewKey: incomingViewKey,
       outgoingViewKey: outgoingViewKey,
       publicAddress: publicAddress,
-      rescan: null,
     }
   }
 }

--- a/ironfish/src/account/account.ts
+++ b/ironfish/src/account/account.ts
@@ -33,7 +33,6 @@ export class Account {
   readonly incomingViewKey: string
   readonly outgoingViewKey: string
   publicAddress: string
-  rescan: number | null
 
   constructor({
     id,
@@ -42,7 +41,6 @@ export class Account {
     incomingViewKey,
     outgoingViewKey,
     publicAddress,
-    rescan,
     accountsDb,
   }: {
     id: string
@@ -51,7 +49,6 @@ export class Account {
     incomingViewKey: string
     outgoingViewKey: string
     publicAddress: string
-    rescan: number | null
     accountsDb: AccountsDB
   }) {
     this.id = id
@@ -60,7 +57,6 @@ export class Account {
     this.incomingViewKey = incomingViewKey
     this.outgoingViewKey = outgoingViewKey
     this.publicAddress = publicAddress
-    this.rescan = rescan
 
     const prefixHash = new MurmurHash3(this.spendingKey, 1)
       .hash(this.incomingViewKey)
@@ -87,7 +83,6 @@ export class Account {
       incomingViewKey: this.incomingViewKey,
       outgoingViewKey: this.outgoingViewKey,
       publicAddress: this.publicAddress,
-      rescan: this.rescan,
     }
   }
 

--- a/ironfish/src/account/database/accounts.test.ts
+++ b/ironfish/src/account/database/accounts.test.ts
@@ -5,41 +5,19 @@ import { generateKey } from '@ironfish/rust-nodejs'
 import { AccountsValue, AccountsValueEncoding } from './accounts'
 
 describe('AccountsValueEncoding', () => {
-  describe('with a null rescan', () => {
-    it('serializes the object into a buffer and deserializes to the original object', () => {
-      const encoder = new AccountsValueEncoding()
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const encoder = new AccountsValueEncoding()
 
-      const key = generateKey()
-      const value: AccountsValue = {
-        name: 'foobar👁️🏃🐟',
-        incomingViewKey: key.incoming_view_key,
-        outgoingViewKey: key.outgoing_view_key,
-        publicAddress: key.public_address,
-        spendingKey: key.spending_key,
-        rescan: null,
-      }
-      const buffer = encoder.serialize(value)
-      const deserializedValue = encoder.deserialize(buffer)
-      expect(deserializedValue).toEqual(value)
-    })
-  })
-
-  describe('with a rescan', () => {
-    it('serializes the object into a buffer and deserializes to the original object', () => {
-      const encoder = new AccountsValueEncoding()
-
-      const key = generateKey()
-      const value: AccountsValue = {
-        name: 'foobar👁️🏃🐟',
-        incomingViewKey: key.incoming_view_key,
-        outgoingViewKey: key.outgoing_view_key,
-        publicAddress: key.public_address,
-        spendingKey: key.spending_key,
-        rescan: 1,
-      }
-      const buffer = encoder.serialize(value)
-      const deserializedValue = encoder.deserialize(buffer)
-      expect(deserializedValue).toEqual(value)
-    })
+    const key = generateKey()
+    const value: AccountsValue = {
+      name: 'foobar👁️🏃🐟',
+      incomingViewKey: key.incoming_view_key,
+      outgoingViewKey: key.outgoing_view_key,
+      publicAddress: key.public_address,
+      spendingKey: key.spending_key,
+    }
+    const buffer = encoder.serialize(value)
+    const deserializedValue = encoder.deserialize(buffer)
+    expect(deserializedValue).toEqual(value)
   })
 })

--- a/ironfish/src/account/database/accounts.ts
+++ b/ironfish/src/account/database/accounts.ts
@@ -13,7 +13,6 @@ export interface AccountsValue {
   incomingViewKey: string
   outgoingViewKey: string
   publicAddress: string
-  rescan: number | null
 }
 
 export class AccountsValueEncoding implements IDatabaseEncoding<AccountsValue> {
@@ -24,10 +23,6 @@ export class AccountsValueEncoding implements IDatabaseEncoding<AccountsValue> {
     bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
     bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
     bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
-
-    if (value.rescan) {
-      bw.writeU8(value.rescan)
-    }
 
     return bw.render()
   }
@@ -40,18 +35,12 @@ export class AccountsValueEncoding implements IDatabaseEncoding<AccountsValue> {
     const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
     const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
 
-    let rescan = null
-    if (reader.left()) {
-      rescan = reader.readU8()
-    }
-
     return {
       name,
       spendingKey,
       incomingViewKey,
       outgoingViewKey,
       publicAddress,
-      rescan,
     }
   }
 
@@ -61,10 +50,6 @@ export class AccountsValueEncoding implements IDatabaseEncoding<AccountsValue> {
     size += KEY_LENGTH
     size += KEY_LENGTH
     size += PUBLIC_ADDRESS_LENGTH
-
-    if (value.rescan) {
-      size += 1
-    }
 
     return size
   }

--- a/ironfish/src/rpc/routes/accounts/importAccount.ts
+++ b/ironfish/src/rpc/routes/accounts/importAccount.ts
@@ -49,7 +49,9 @@ router.register<typeof ImportAccountRequestSchema, ImportAccountResponse>(
     const account = await node.accounts.importAccount(request.data.account)
 
     if (request.data.rescan) {
-      void node.accounts.startScanTransactionsFor(account)
+      void node.accounts.scanTransactions()
+    } else {
+      await node.accounts.skipRescan(account)
     }
 
     let isDefaultAccount = false


### PR DESCRIPTION
## Summary

Rescan field on account is now redundant, so let's remove it in favor of using the account head hash

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
