### PR TITLE
Add handler for GetBlockTransactionsRequest

### DIFF
--- a/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
@@ -1,22 +1,13 @@
 {
-  "PeerNetwork when enable syncing is true handles requests for mempool transactions should respond to PooledTransactionsRequest": [
+  "PeerNetwork handles requests for block transactions should respond to GetBlockTransactionsRequest": [
     {
       "name": "accountA",
-      "spendingKey": "d390e6b9d3ed68509a6f4f1446b3c98407e0be4533d2afdc9d045792cc207a40",
-      "incomingViewKey": "b0d8343c4f3f7031389bccdce093bed653ff2b7588497c7bbc91be05e55d4901",
-      "outgoingViewKey": "be38e6483f37afcac5a801e84de6391f8932f4df585aa494c871cfbfa88be71d",
-      "publicAddress": "f1735b1ab1e7c4ac4e24443e945928a0046bbdcbccb074ba0ae0dfbd49db62d28e71f073f284473f673257",
+      "spendingKey": "6325c8d87a62b85b1dc60f96b9d550d0c256b5dacc6b6297f2ce40c0c1c8482c",
+      "incomingViewKey": "883e271b5672509f3764cfa9bace6b7c0ab6da48193dac331d1df95514fbf106",
+      "outgoingViewKey": "64815e94dff54dd48262bd6c06b754fc0b435a26f49c4cc8c99c6bb67f20cd19",
+      "publicAddress": "ff636a98116bb46d0b52899d960fbf1131460fb79c6d425d34fedadb2014f696e8d453be5bf240ef6c9532",
       "rescan": null,
-      "displayName": "accountA (c892bd4)"
-    },
-    {
-      "name": "accountB",
-      "spendingKey": "2637c469940080df3a8245da1af881b85d47e188611807398ea7adf21537f813",
-      "incomingViewKey": "94b62f3795ddcc0f1ca88449efedecb0b173eea9ea99354fb8704e3cbe6a4401",
-      "outgoingViewKey": "d8fbe2e1e5f898bced7c7443943d6aa8f2e092ee5dec15f9179018dbbbcb673d",
-      "publicAddress": "c0787192c8e97919109067fbd729be2e07138deef5b8f46a2cb9819f5a4775d979739736d0b039f2c48cea",
-      "rescan": null,
-      "displayName": "accountB (9bca23c)"
+      "displayName": "accountA (189f0cf)"
     },
     {
       "header": {
@@ -25,7 +16,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:sYKF79buSkuvT2bW4fSZa2LOXbKSSrR4qVuOwygYXCs="
+            "data": "base64:fwUyDoz8jf5X/lXszRCSnNEozmzZKQBykDMUgUEQaWM="
           },
           "size": 4
         },
@@ -35,50 +26,449 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1657654038985,
+        "timestamp": 1657919215115,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "30E04389180E683AF9A9A73FE9DA5B6DF24AA1057FDCD462BF768F78EE7E7A43",
+        "hash": "0B95EE4557B8CD6F052FE9BEC593EEB57560C94472E979F0C6685486FBF7423E",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIdy/55Gz8Sg/fPaDoXFY+3ge4iafkzB8GsjzzbV7ldVnbaedGgc87aJT9eNa5ekpIs+HI6rrxhjWIMP6Jusjb36AA/754itr8rcTG80XHrwx3Da9Nr6KNSL7lC3i/Y6LBCW4SF1BHdvTMDfkKEefjc7M8B5wJOGS7f5SMMtkh6dzahA+4M6EHGpKeE2n6ivqbQqwpJCw5XkqY7YHlSiR2xn1pGy7QpocuZF69bXS+i0L2pZH3+nYJvwVSljgXvtVe0eGH3sbiRbhrFgTi8UOwI+cA6RCxs0JizXDsnMrP0aVR4ofPpTwtqc9tOcOGVqs7xUpFKYdirI77y/cgQ7Sl6AmaqDZRHTsDQfxK03uKso7DxXFJS6BEH5+gsRmrvzrfdORl3gcuIAe1I7udI5kMAlItsjzW1CcIwIiaQNZPO3alFqbIMK0rDSORxYNiwfQTcs+QYibQLL91lNGl4YeoHwzTbIsT0qKnfHFgXDAjWrqeQHiUjazcZkLqQ7uPEsVDqXw0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwO0KJf65vKIsjGFYftIqbR5Tu5+TNtWFh6p6S1icpE9p94BhQ5/vEjq/o2DJaMVyfbp2beAZvaGBuBLQ5hIYXBg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKS/wevMmd8s7N7szKfl4/LnNAfZfXHN5w0aEUyZbXhRIWG3bKA936lXcfIh6uExPY/ZJb8FXgJJeF6Pr8d7HOsjSQ78C0vnJwvA7hjDT0KkoHxQrh3pLtSeWzrP3fkyTAu2JPnOFYBE6uzvdp5MAJXJqDliDuUpn7Wnmd0mELaf19wfzN9iW/40LBC1WBqmbq/foe7KLcYNcfrazHVbsss0I9JYnGvD6q/WjQVdOw+gO4hIjsCEsgELfNnmPhEbyq1eE+OS87eI3BGkHs3GGsHSp5vw0W5VjpndpD/mPjdPAPJVmxLh0Y+ijV0A/IpidTcpCkTLq9klu/yJ10URXQbZ+gUYqfixV5EHT/zHWqMboUZINFGZID4EGiqUi1DcKN71eAc8Sx1CBjEPduDN9aJ4pnOISWdOIJP2TfHIrZ99J3W3req3ZLhBi9Vj65QxNROIbw2xZfA/T6khxCFkFLOk+Dc/bN79Lckl1/7loMUgFtTPzHYXEEFCB+f2fR1TVSKvjUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw7GRvaqDlVQUyOfHYulgLfVAasYKzhmVGPnBQqdpYqXJR1x+XL6GMhqAXd7x8PxQnNTVkdioDORv6YOnFLKFZCQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK92ZD6SlASPsOi/YvZEKPsorHw8327XqfdEypGJGMav+sUs4KyKFvrx7fkbznE1/JaxC794SR9L7NnkBzOYPqNdQ9ySafbmabtE0IegxtdBk1xxCYexV95aRwJ9/X5r1hgq4WUsK7mDUZnZdbTFCT4JcOCUQy5MtUCmC7HCwLxGkkgK9KDqubFhqxdQUroOoY0+2YPMEPLl3rPe3VrwGf/03P5nuL6B4vFWZj1bpxa1HCBZQm2hbuxZ+zMnJyJjaYXjN8Xc4kEA0JbAZg5VKpmUR+inRr+nV7GO/ZxKVW0BTo0iJHLE0P7B+wfvkFovsJo/+dvMGbXDvr+v0T1F1T1iLHX3NQB5jMn8t0hT2esx+/CM6nZmFgOSKDRaP+vX4W4U1HmzYgweH9OUFkfLzAAPtkYvxJ4PGG3jji5rOaArX+vdT/8Sjo+I3MZMwTbLtO0I/yR7baYKJq5bvLjf84ADfQ7xt851UIaYn66qxhCaK0SULnA6CO7KVInVgjYTj92LiEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwg6zoFuf2dXkEVx0QHWyHu3cJMlguASkm1Wm5s6XcecIDNIPr0akJikGUXoNCNwn7S2E0UVy19qEqaekFvOF8Bw=="
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIVe50KC6ZI0mENFFylLRrnXb84J2cmEojppYKH98UlKJ9ix545U3MTiqxlQ/VesAa4lNrkHxMcFma6d9+DLK1fKE0hrRSThXglzn0l4R37x/EBkK8XfXBbLCi83paBs+wgJ0zEdUhXh1A+LqIlASFZ6qhD3Ok25+AIRG3pl4T/GdbN/9dWIYKAbtIWsxNGrt4h295qvbpq6VGWlH4TDT4QIGcZnZ8GnUCN8D2kFFRKt7KRcXLynL+MVkUgb6efQ5hMUeWcZ7usMYkA2bjWaa3ihIowmLAUUbff43dQO5y/K+ZecjNw/ixfOEGCxErqNtRNuigciEX1SDWrKuvjrehKRcx/0BeZJMz41WnDQA5VAsJRUZb5qVEdC9FL2SPBst2fN3NqYR4t90JbvGLjNR8tDY0d8PKulpzR3gkyIS5iHGFkLmFSHqNffZJGTVig4JifnhUWDWiSztsk+SiommstdR5wn9k3ZO7eG5WiHeh02cHpsn8Qsar5/Nqe1Xi30osPJc0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIuOlkXBD2T6+zqDtFfyM9pnD7afHPx6oZ4ROVUR0Qj4UU6vn1qDgabVS/qadl4VwIr0ZOuhzd1Fz/nLJrykVAA=="
+    }
+  ],
+  "PeerNetwork when enable syncing is true handles requests for mempool transactions should respond to PooledTransactionsRequest": [
+    {
+      "name": "accountA",
+      "spendingKey": "37a43e95f5e40013b33aa0d38847f63abd774bd2f3df93537e83f2e5c046d067",
+      "incomingViewKey": "708b262697ff5b4e38aa81b989203a01e702457236175cbe4baf4484fa6aab07",
+      "outgoingViewKey": "ec630e6e2254be8679a6a0960cf6f085e49592d04a761fcedd7c9f0b623be289",
+      "publicAddress": "1b4cd27fa8cac1844e5643b168b6a98c42ef7f7aa7d44c639b32eaae6090636919a1798a631a22299edeb0",
+      "rescan": null,
+      "displayName": "accountA (31c287e)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "3e5c5e6b4912419ab72cc3a9852a4d931ade9b3d4d0eaa6914cbe3a75e3811f7",
+      "incomingViewKey": "e9f2af3da7d9dff388f847a2543c35fd6d364f9a94f4d09ec88965f0acb3b102",
+      "outgoingViewKey": "892d3ee0c798b6f270aea3d965da7e9cca596ed6bd016eca752739e829e36b20",
+      "publicAddress": "f635701c74e7dd31706241329bbbfe1999c181a915b023a9af79f531656b72fd232a97a57549c39eb8175e",
+      "rescan": null,
+      "displayName": "accountB (dc34864)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:QtycpIps5TqBW2jyASrBh71y+s5jy8dWpGW4+zSwH1Q="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1657919215802,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "2E370C7D0697BC00FD5804DB8485CFBBBE0795CCA09C3D28FCB6399ED7913850",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALbYlnM17saJn6IGoW/lf2Av7UGB+RqYwHrAd7Df2+HjgsbdUSFQKHy9Y9QXsaYCYZC4pjrQMCP5TYMH9VrI4vX9g0vCRMEyZNzUg4eV4lztUSxl+CGctlHG6ObdsxOCEQ6sq3l1WRIet+0MDYQUkmn/X/gfPqQjHotqGTT/+LxWAROtXoB7Xc/9D3equT48tJixj1nQr1SOChw7vRizhzQnRxN36BxvitcJxnLUjV7oKI0BR1K3CRv19IL1wJq2lF0q4C3XLkvSpai0OSAbdAqysnHC9zUQbt+6YYZIfoGBIzE6UWkh0jbiahFHfVL/dT6EtRnlQ42elDCigTyPVxWzHSDBtd/zBEp9HA1bppoKd7vVZ7EGF4Yg/4r7O24HSCGRoy6IBnMMO4tnRHOUYleY/6o+0j8hVC1HbfLaqOUs3cqLkjQSGFC5Z9Ar88y844j1/UICQnJ/f0peiRKVRl8Ly9O+UFXmRILWFgP9Z0aM2lsvbexKCh0K9TID/1dTsIr/c0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwB0aUPZyeV2ap+BFszayEKOm9abgDt9xswuL95Jb6zyMmATdZLq0NPEMjrdLASRDXerLg8FA6RTDKgJsOD8wWDQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "30E04389180E683AF9A9A73FE9DA5B6DF24AA1057FDCD462BF768F78EE7E7A43",
+        "previousBlockHash": "2E370C7D0697BC00FD5804DB8485CFBBBE0795CCA09C3D28FCB6399ED7913850",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:5R3zS8vETSIKPKH699k7Y59jle7/l/CYHNkCridDRnA="
+            "data": "base64:7HcjjKnlslhG5dh3wNEYoAbKl9GCNDzAj3CZFDK0+l0="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "BE88E5150940D00E25C80941C549385267B9223F9AADC353E318902610467E0F",
+          "commitment": "B21A33819BE166AD063795FC07E4B68B41CCCD1301AB165A27C19EF13091A402",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1657654041602,
+        "timestamp": 1657919217621,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "AF135A4ECC0EE0D76140C2BB6CC8106232DA76D1F3D2AEAD3DD1446F0713C1ED",
+        "hash": "61D91E7C8DEFC1DFB1ECE584614FAA2A2A0092B8A32868F45FB803F4EFC15428",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALLgzEG3wUsgMAHB8ZNcwJjNfy+iJsLdxEwSwp5FSyZt+Tt2cUVlp81zB4EwLxftiag/unGic72hzqN5FFaCzA5yFRnwB9jq8vOz9Of+o43CxSWOExgH4ev0uSZzZHhAxAmae9A7tXUVdFPrkPSVv3Oo50oAhXyb4Wtj3l3SRJNNrlE73N7d3myfX3sOk2YCcKEI8TnkS0U3AmRdvWuL/m/ufZ6hPySyJE3T7++XbfhxV/H/2E9WZWKXRhCttoEQEzu6SsqzetyD3SdEQSV68p6Q1TDBYv7VDOOER5UfkkTHol2pbQ7TV3Ievm54b0d9aaoj7Da1IWb5l+h0YVWzHWubmIOgSfiKDi86rGqR178Q1/fp4EK+GHaouYlC/X37mtl3SETDFWmpyw6AVRaTnve6Eir1Fpz+gsSl+L78iW7MfvpkD4XUVygFTquNbs0mSGOx85uqTGndGoD5XWeu6PkZ2sQMdYpwOF2uaTmnUx8MgeFH0Br+bkxcafAOKQyhyYB/okJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQbuJSGX3mLzCSaQ0Nfg71y7t6r5TQtEH2wWHCH0JqY2SDWLUj6LuuaiVPzi8XquIgGMGAQC2G22cj1uy9HBhAQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKNSRr8et7D0lLYLu7hmg2rPV1/o5rFG6oMFrOdIWTOGz8fJN8Vcw+AUOBY5KfBmcpUhRyYRGmSzCcOIwrNiwjWWa5yxFWrpjtS7NUAhIAdb5Z2Je+Oau27y4i6+VQfbTxJKdvadlNWkAuZXpOIPtLNW3wqekrS7FZDPDgXAFIy2LjULG/J+FasEWy/P4Qib1JnX6SK6n20hlwdqtPBcWqTtzs5hLEye9piEo0HF/t64mrvShBD1dnkD51WJPP/WHVGq7qL+JQK5YNwRyPIUnnwZ5rtf6H6pwXqY8eV6p3nG/DOm5z1G5QQ+34uJ4Xw3AtrBzRr1aeOQQTY4j8uFmSoeJP1TuwXeLOPuziwHggpHj+79j6E8kMW9cDPZqC68CBQwKvZp1EQ1s3VpLm1fX9SmqPAs/DNZRN4sm1iS1ft8K18691zdSkZpAlaUuLSIXNQbB/Gh1wI6WcYLq8zub1SRklAuk1uw5JUbVeCqOz6ATS8kACmXIhMxe9yzrya70sFzkUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5draYiQuCXl5BGGFMeI0Ob33ByAnkgPXQRhaewmbXehY2R9ElA78QueE+pgj8NMvJc/vHFoLni46KMaHJdVgDQ=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKd6wRug4RvfPVu1thQjwz/6fxnm/DpU6P74KMXHpdg/0P04GWkIoheeMGaYmUgE0q/Z51a5mk4a/m6yNEtBp8ssfgb/Ni8JXY19NzMFvAlXDXodzdu6cx0KZ2u7bQYn4Q4nM3mHciDZNCoVYJFTjTT7fYvHxbljwC4Ai5E6jnRNsAs3hv4Kz8Jnkhj3vFXRFYoQalF1jTMzFHESWrINKxKxCbgpgl7SSjPMmXmzIeuUC2l7jakPE7S67KaDcW58yggTImR6lndEGOzGr+BA0yLlk7ELJsGyJZr6jacPPsujmfsmOutGq+GeE9EvsfWNzjn13Z9ZNfIqlCC6YJV7Wl+xgoXv1u5KS69PZtbh9JlrYs5dspJKtHipW47DKBhcKwQAAACQgF37Vga7Q/gev+NAK2/ye65L85mwx5rvEbXWtIcS5Xey4jt0lxYLWvuYHo9kXY7Wz75KkoKY+gJrWc7bhXks3nlFi7GnapAn1ofejMAQtpOm/mPDPKkOtIri8+YmgAGPwvjGp5T1LwVsiqCQ88vJKUTwyJSBMfNx4zf4nkCN0P4/XG8DhVx+oIvokpHdiXmtGb9tKrZUFarb4X9AOmluJoZ7MRE0odL2+AvM3ivTA27uBeoWOtA7aUbXPstCYAYMkWH6rEM0Bt3NY3v5Kh9/aSDAmukkeFfp2f2cDlwkHd9fyj9EzBH7hiuZT1PDZ2C5Vp8F+E5cW1JKj7dwT2KoZNWvsriU1bgVMb9H+3goy2Gb+cr3Ek0Be8A9h3AEwso1bSTLX51rGv2yOvNJ/RWDI3aI/iP58Ij4KwljKRyfTM/qeInUl4da7nPCs+Y5s/iBprSuvUv/b/D2H+CSRqFg2DvDA/xiS3PiTBS1kfoq/4k6jwGx/iLwi/B4gKDNTTPVlYu+3CMJo2g0xoVU7k17wYhBQXGrD5KxJtiikO0BynZiQ/2UjyBMlV+Db+xHK0pP1sp6OCt5HdAScEJK/TJSqVMLJjqPdu6jsX961h4uNkFxhYZPxRRjBooCwyJz1rXQikG0JbLRDwa8zpTs1DJZTMhsN04A1p/hf2iEjsf3Y14g3gAQyacGHkYCuDVdXcJskMuFJeSpQRsUuaW9M+P93MOGCMzgK427+xwAdk2slSZt8I2Rz+PPPzOVmw6JM24t0WU4TpkRfWreUq8wrdxT/GNi9/4jD36K4g0eJGJloptRm5gCxhJxWnm75OlO6C8YbNkdD+NQxbzdyBWnQCnaUQ4hLVovNrAkyMqgqNpyJ9tkLRlmh8gTnHr+hQ6BCfESpQ/bVlzd9u6OECx8wYe586/GlxP9RBNq8sr7mDbZgNY8Ppd60m70wmSHAKsTjI5tQUsjMP8UBInsM9i+DyfdbzzJSfTaKMDFKUIJLzCq5uqjTD0HS1NOsGSScWwVpVjOPgKWgYV2J/G84yegut5opspbOTznoXq3mwVtZKaGWBFSfFtr9k4JIqTHCAr2t6Uo+0763DbGsrfj47nQRUPgo1HOJ+TIY/Q/KWABZ/nCAWf2P77H+5yHQVtVR6vBZfdlGpjrGv0fgNaDNV3BF1uvCdEyHLxzjAolQkRuBW2KHd+Yo2FaWrMmZLgYaL8y+N+Pa7d3AnYFSDmlXpcTsZF+yXOcW5POraq1Zz7vSkuBPmN4YYiIUJLQ+rdXS0tAdAdNCXFhaxlNCEC8p6SJ/I1azrzfNv5Y/o4Ns5ARNhSCsOnU1II43jqjW7691RRZfKpj/miOB7TtuIBzik5ZSZGcFiM4LQQ4Lj+C4+SZSSAFPBOciXop+cv1YJUJ/KSanZSDJUcQNRcX9/zuEi9dUw1KHdZGqXLzKIF8vCLCnj8McZLM5kvWCA=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKJBslGNAx8IthsQHN8kSeg+pbuy4+RZz25F/qRbuLHaOT2+gQU+AWH6t7PdBCyjRatXbxKFEOM8NJz/WZIvUMsKgduONbOeTt3EMwnc+E9Gx/XuWFg0a1MB7jV9Jz4GgQAHGrU8SmbgNs2ZjQTKNIdnq7kte8BDgyHKTdMbysKKH9mWKjv2nw8ozVBY99zBNKcyCA0CzkQWhgF+Ot9lk/h6U2WNRxQ1Yo+fqqqHWBW+dRfqIrOpIPAzNa09H19idlEi4zBTe2X1QQuHqAubexMpJebj+DbiUx3SuWQEQTQmNYJbqVp0OvlUA5AUF0dcM878j1OW2da9BS4SNhEj2stC3JykimzlOoFbaPIBKsGHvXL6zmPLx1akZbj7NLAfVAQAAACteY+uKpystsu4B6493KJdwIKIeyAEmQP2U0hpvsFu25aTdGnc3YpQRyfskp3IUnijdo7D5F1RVntgQgSKK0VDJA0CTxo0AFy5teYwmxURdCL2/29XtBvUys+kHg22hQSGtceHWGtWvf5+qcd9FbSVZBsP68nq7N5nQVqsKOewVH1yKSD+j43SDbh8UN/WsMKuT+3Z5zM5nbzyQrPtjWi0UHOAqTCNeBbO0EPzBYJ5lW5aRTnntJg6OogkiaLP5BUKWXdfGctAyFI6fO+blRN0G5SiFFpBqQqfC/Puj3Ox8zF6RwiLDlKPNJ0L4/G137mv5ohOjADO9YHJml4s05TOUpi9CvYqfQtl/JhOm6cMXYVKqF13zFoY7SgaPjxWogerIYRNBLZQbUd1ANxqy2svxGN/OaiuEP8XxUeFAdB41VZ7vLRYAFEbzW7SoKeNN2qwX11vBhxxfRPJyUP6hJsA0GSPsnerEM06H44/tdtITNAg9KEOxTNthrfcdW2slSc6NcnrW0w2otPQEAW8bNpZCjvLfkkywsakpnau1xhUxAeNUStJkAeU/3RO/DOkDDIS0PRzAYWNLFcAVV6Cj0w1Z4bSEQkVW/pgDEMFeMMR7xn1yuV8JxUOxmgrdNdH/LEG0yAnEvbsCWbMLOT3Dnd04MGGVFMqMU03aa+sdv1+I9uecZC4zQdX6Nd+0mGSNZ2zRtCoGq/8FkTuIl3UuVBixRzLQ8VdUhawiRwGX9DI6/OCNaZ6yhGocXPkDivzU48+PdkPMCv2/2KNGMX9JaLGk4ugm7JGD2mKxsFmDPrvVfAGzo4jh7UnKiKU7Nov2/d0WIl8pPAToHln89M0be4xK5LpSSxdXwcz5SvKrEaPZQeYGxBo8R/4M3C9LxD0/exy0MHtSoaejqv8JFHNnnYPqJVhQ+leced+NOgFWjrpqyJDV4Q5vLBEkTTM2QYfJtGbM+9c/FLuqKjOIb/WnOT9/zPxNOepWcKZR8JaNxCFGWW3GNKHUsm+xwU+ypGmHtItthvKxpAWGnDW1+e9peHRzP5VrJQoPfT1xwZFnHVO9G15OUAGfhXm/rpfFF/eyeKwiE/xfkk9lODpePWFfMVcUuFnaospA9wLZB2Bd7cInzzlmrWpZby5Z2zJ0yyPWssuMjzahrtS7HGrKgPm76hwsMriuRLhzDAD1bwCfHualewjtfjQcFufxMVvhsQR9m0EyZzU1Z8W7sbIM1NFG0XqtvbnC8FHSDT8QCyyIouXlwkVXsn/82yTVnPUEDgTE+iqXkETfKrgJn27DZtB+RCBck1AKputRdpGYCi9anc9spFQGnYdrPhtpXnETrkjZW9/DnseeimDWpFxCpnR1EZXRbcVnVb9W7pSbEyfzn93Jqe/43yxddr9eUxcn0NQlm6RvMPYVIV4F2u3Pc+wsTQyqq1WrEs7EHlJ5FsePzpkzVnfpIy9BA=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork handles requests for block transactions responds with CannotSatisfy when requesting transactions from an old block": [
+    {
+      "name": "accountA",
+      "spendingKey": "31063a3d01db19ae006b1bc60fec9c5cfa543f5b5a89c410ebb40cfb26d15522",
+      "incomingViewKey": "e1d67516fcca0d2b801f194a64d46a9f417c1bf0caa433bcd1f5eee0f1726700",
+      "outgoingViewKey": "e1b3dd29d01dc7f1aafc447c59ec3cb1002d39cdef3f852b24bbd0aa8d933e8a",
+      "publicAddress": "efce9d8c216d9d0d802c6c13e96ca3cb198211141e872a2f55f67fc18966990d835a93a26527b444556eb9",
+      "rescan": null,
+      "displayName": "accountA (c388301)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:b42NP4ozGuC5TOpuezO1LM9Z7Shl1MhAhYk3JFUyS1U="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1657933738296,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "9AD3E352DB934051F61FB03A93D3A88E607016C736248928D6947D61E62F289F",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI2b6/XFx5L8uulcV2iowOs5QcCTpk4raK+2B2idaY1x6zIsreMCCpISX8ImSE0yV6kelWb43CBSQ7HOlQeqbpV0omoKozb/XW9CfLlt3vVpfRi+Xu0XpE7l2sxHaN9+5hJ75rHDZsmEEzTCHXH6FEeRWmaS8OV7zyCiFILMw8T1Z9L8pXxnNCd8oVAYK6ytbomc1+bsCmUdT01tO4LFu5LDSq0Rp2V2U4KeBlCF+Zn2lwjOZwr6cycU6UKVhBKHKOEOquMKAaBm1DF0xQrz6MPajSOCQ7TAXftYAMj03cpgPeHsTbz6R8JDgKoe+RRHVPjjJ75MQFn3iAFed1vOb3HQd+l+uBBeo6pcMpf0n6tjo26f4duWpu3rFzI8QpT7NOI62pCTnCOHKYGhwpBoNf6CS3+9//42UMA7drufpWonvqjjLI3nBldDJkA6VS65o6gLN9LuRVWf7LSnWYQKH4/OwDbez0klJ0FzniGBvYgAmW4wymw5qcQzWxfSyYbIWu0WJ0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsv410SxqBwD/okxiuJwmucTTdMWjL1lYwg7haniCLw/WvnELCjLmaLdynfNH9xsngqZYH1I0bf4lZAnyLy+kCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9AD3E352DB934051F61FB03A93D3A88E607016C736248928D6947D61E62F289F",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:ucne6CupWNvi7PHo9tcmJlpieoRCk6J0kDURMW3rgEg="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1657933738499,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "D34096197C73B50E7592C4387A63649F6AD912D86683242FDE9C5F2F9FF29632",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIkNDWgEUDHcqeCddZp6bPJxglNfB19Ebl4HYVBjSNfzJcvxqTOI20sLBh2Af3KRPaI77es9say+u0UVmD33xm1nBz7ItEWqm96TvXPMo0hzC2joePgGJPU3JV6hlHDYQBLDSZAhizwu+jlF4R/XDYBJYkk07LrVkuvN4ic/m1NDt41CCAZWu3ArP+9ee3XbVrlwQ0nczTF2/hdrhlB7vkR8MXIuWKDefLTcJOiXIJSXLLxZwtPSeq/Flfp5o2x+z7lflLyhlHd2pme92aXscvESQa6slpY2Ii2kggc2hk3zxfAXd4sgvVNB95KZDtMJYweyXajSqJOyNWjmnDF6sFHlrejb4GuJU7BCkCcHeTKZ+AOmVVqCQBDD89ydfWzwQnS2t+ii6Z2huvEE2Url9db0rpWwvgwfy8tuhTaI9/SXxY4FJInv4RxokTgfnAKX6XNJM2qyEB8+eLh20U+QU8EJM0UCORI4OSGuL2dyckHOT8cANUNBfxAXFtJtK8TD/RMZ8UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOLhgTOA4ckfwXiA0LDB59L+ogRAqPlYP9U6yj4lZ2G0u5lyGyycUCwUU6vbxoaM/NAQyWfNyGw0R1qhSoYCZBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "D34096197C73B50E7592C4387A63649F6AD912D86683242FDE9C5F2F9FF29632",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:/8JHXtJeaOHLwQr5vhU/1zHOaFyk9zdS81ry/GRUUBc="
+          },
+          "size": 6
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "randomness": "0",
+        "timestamp": 1657933738706,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "E407D514E183AF88143A9261963DDA2487D54933E685E450479040C066C224D3",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALbxSxzdJqDLDiv0STFsNe/7nlK5rrU1pV5lYlwzTQnwDcb8k+gDS01/wnrbyHk1CKUT88f5FHgRY05U6jjjT2AUvZVs1RIjMq0duqlamHSDRgbXJQkIGaAg5dVh4iEGeRiq0IU8HTFPjoR64Q90h3JC5cRF9L68M+WF4w8nHT5CTpDUfmx92cyLeGkbIDraeqyyRooyrHIhFoxmfnqORusydp0iTopesbZxMZenWG1eOsHsrMrpi37nel+KqQyWRv/JCGz6aqgAC+PHwB5s3jOmWBuPp+OL5CiuE5gNq8sLNGDtdQA+wWf/rZna02EMhy6ju506Zdd+nKyIEEu4VA7z9VIx1/an6S8O6wUf3AsZ/Go8GTffLQPeJQgFiKubOgzUWiQr7gHKjnZsRXnvR/TuMFGgOt7ia7NF27aSHkD2wR005PP5+GHz/SNydE1nNw7TgLiB7zVuCLzptPZbleTw2X+kqLoZqTRs1Zi/ouLrUCsbsduiGQYeOZHSvM6FuNuL7kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwf4uDWcHJa0pGU4HRpI3p+thA4oOgee1OizqQEKfXkCOZaNV2cTjPWuEE8SwYyvQrUwJ215wPGDrB/IHSV8KYAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "E407D514E183AF88143A9261963DDA2487D54933E685E450479040C066C224D3",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:lGK9TdZpMX0LOLVONW5928UUsZtoAOJdRRqnM69lwCk="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12061061787010396005823540495362954933337395011119300165635986189",
+        "randomness": "0",
+        "timestamp": 1657933738914,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "A8D7B6F309E0A6555A5A3ECE37522FF9575C95D2861EACD59FF36542D185EE4A",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALeVBaCjYk/WilsNwUuvhR1Ftc523Xv/ke8oDUTZTYvcYKK6XJsOKALkr9Em/spGRLZ5kOGWmlDk0ETA6OI9K5D6hA160EVE2agr0WjuvjL2kcEjc0rGvVkUI6dwAGN/ZhOyFlXVGAtc9ko/7qeacxVRnbZQw94BG7tTD2Zh6LOqnS9OuISpl3ePagtwLXtr04N2zKrO93v8wbgBiWgW+Pv4/gtId0uf/P1qXKp8Afw3UE+MQkYTyCytYmfEtzn1ujiriMqZ3HjM3h049wYAZgo0Qtvxj+psgsSXTcxyqOmKcYSJ5g0sRXxQNfGK6hD2pqi8kHTpgWCSeERyoV+8sT6s4OmqAJkU7fkU8xBpPi5YmMNxMK91/aYdmhCZXD+H0d1qYbStHeXLnplKBFprv+XehssjKUwqCzCqdg35I5LCayhahbU1jhCd86CNOcm89OTSbmUoYb8xazlcNTUmy+Rv4HF7dj+ZW/5iBTL3MhAc3hJSNCZNRGIZNX/IHUP/B/WzCkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0FfebnNnrMTEf2wuboEYKL0EkY/24/Zj14+JGoR4lse7syOJ5gHqz0VxWDsE66ZjfuErqlgdF5t5ceq5zYJaDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "A8D7B6F309E0A6555A5A3ECE37522FF9575C95D2861EACD59FF36542D185EE4A",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:uqmW0In8PtCbqPm53wlesZ6xE98x7rMlBznW4+oa+yY="
+          },
+          "size": 8
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12025829863586302258274667766838505692576214880101876262606819815",
+        "randomness": "0",
+        "timestamp": 1657933739122,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "22F21B4225EA199BF2B4F42E2FD46E4FDDCD5087E148B9CC7536E6786479FC2B",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKBgqV7X6m7l5vgzpw9s1DApV2DzKejEDq0Pks4BTCDYc1IceZEGFht1xirSkE60/qYlMd0KitsnkKl7Gi1bd804/T/8XxhYhF84QzNRLG78VJ0xzLSZnmyqXS24CDhgzg5JmhqR9SKyxNM9vwsDLB2dR9GYr8C1yjrkDHIkQEyzOYJKizLLi0pjyzJB5MOgE5B1u09Uu7RfBMjiB2apE44DclOE+1/mHF9e7AFgVJC9QObSAhUXU0uOCEMOsbN3FoJqY7tdeXXlRPx0s2jUTu2EMkB6e+3bxVt7Cl2FhcrUQ/7HB/AWLq7Hjl9mjTDoJHR2Nx+1uMUdFZ3yJS4JL0Fz/lX7WP0+lTs4VuQogNHxRD+ZlFkm+CE+wBWONDA3Ukl+dhA57QcgxEdMG4ZbWY3rIpjjJiUl8CpXTnNSqztcwX8D5BxCWlvnXeiHJ3wD3Y6zGNZ1RDc5H+0NRLgoONSIPh9uQuwkEJu9cZS8aUaFoHzZ776yLcE0+nF3allNFORmvEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQts0dwRydQof14ZONBrvBghswWWvCwMKcI57oImSIpG10Z1r0xIDOavm3TXmeokvF10nO6w0Va745PJa4eKfBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 7,
+        "previousBlockHash": "22F21B4225EA199BF2B4F42E2FD46E4FDDCD5087E148B9CC7536E6786479FC2B",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:wYf4SpSIpdful45E+QQ94ZWZHFuh1Ld9aAsS2fOdQCw="
+          },
+          "size": 9
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "11990700857169164717082710772570183491930269097200881904675918796",
+        "randomness": "0",
+        "timestamp": 1657933739378,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "3E946D065583EDA840CE4C3722B98AED187CA842F5D87B12179C9E38D5A056F1",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAId3a+tiKYLp610ZCEF7udInxdqMK4ksCpseD5kNivdsToDfIeDcfPlPC+sMRZA4krSTVa/66cXkCb/3jax/p1V8ZRx91vtSxnJYNh3MNa/gda3MTC7p1bfSaUwKV+QhSBKPe0PTYIL043GQ0M4nFOVJ3jbvWQiYSI0xLwb/qUlKrsN0TLuv2egY2Y7iqR16z7CDz0ozztOPKfzOpwSUW8H1z0zrFXGZbVfB8pvPm0YbTm6M1xwPO6xLvSQA0h8v36+kNd68fjdQOngUDO6AnjJKZOsvWqnF+ICerSgvC9G19145Xe+aN0VEBGwd//V5cebdHwOTcgkxIqMcA3xQIFcb/ChuDgMTvzF9Ga9MTv3Ri4FDeDvome2hD/I//BgBWlNdPYwjeJvhh/CZCpubctYQMJFtKiTD5uuXW/qsOZaqvxBstfYi/41HEHfwLrZ6y2jhUdxLPWbNMhJBaFbvaBMfEUYWnoTWxASr/daaMGGSsl5q7iyRi1t1HljSVOqZTvkkL0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwc+iwfSnhq5i3ePC3CMG17Rtykh37OW+iWAT5rIfwP5lFrWrA6b48JxQFl6yPkdzT0m/Fygl95otNVxvqJfaOCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 8,
+        "previousBlockHash": "3E946D065583EDA840CE4C3722B98AED187CA842F5D87B12179C9E38D5A056F1",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:fjVnelBuztx+2NXKmIMM6UyKJa/PxspXQU+jJ3s5xTY="
+          },
+          "size": 10
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "11955674467133905615778385529071885511802019030914353583564766831",
+        "randomness": "0",
+        "timestamp": 1657933739587,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "3408AC2E971B5B684C608A62FBB63B2ED01776AE5195B19D544049CBA689D3A6",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALbCojy021vDVD1twCBVx5LF+6ggd7VhCAL7ka2fbKHu59g/6NNYC4YoGArnAQQXw4UlQjtULmapraIyf762RHOF+6EQ0hmmZF0VzYTli3j+xWoN1LbDXWeyhKiWxYRyghIWMH9xMS+a42zZQ9FeofNxm8jHWbgn8ZiSVs3l55EelFCCKBJgPLS7OewLwOVkkJQEhS78Rr6RRxbUMZYVyo6YquClokp+Cps7wNxa+W0+CFJHxZ1HJsIVZ7p0AohwKHYFV9026KQEXCHNIK8zZ6Lqr8fQKtwqPTxtW3UntEXC4ecrJi767uXIsK/oCVHe9ZOF3XHaTZpF/3ywjQyJKyOlL7u2TPL1OW3sZ3xnMM0Y1/eqEewq4aMcwyJs4AGCCoeDjpyijqO7q3qDF6hJyqpQqy3rT/+D+v3GU5EgPT5iPjSDgold948kBuoUYyyX0pmHrZucWTStGhBWRfB2SVEqCdPMDNER+P8jBxTi/L0LhOlEzV7sYtLlFocm46N0+aoOmkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbKYX7Eu8rf2eSEDoIT/FdsL+F5AqFSg9R7OCSzgISbVmHW5fg1Kw/C6aAzEGQDiP9TZKcIKFvXt1Sp0dmq4TCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 9,
+        "previousBlockHash": "3408AC2E971B5B684C608A62FBB63B2ED01776AE5195B19D544049CBA689D3A6",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:Rl9c07D02WZgD6/2gMeuQzdDW0oa7lYHF7sEsSuAWzU="
+          },
+          "size": 11
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "11920750393717796238846226084969796965426598578295419613793756371",
+        "randomness": "0",
+        "timestamp": 1657933739792,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "D632E5C1ED253F8AC72FBDD5C6DF7BD2A035D55DC8A60C01148E9EE8B9787E59",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAITlsd6ZMNleWKBAo+nkZSG098W/ZFXBlxxSUhsqK1UziwMUBELxNoLgcc/zq4V1XrNEw3BOtK9xacFB8septBaPE9hBRh5KOsGEyEp3NfWC7OtmBcRcIrL+AM4joXJduASbcebkibAKQVO9jeKsSfP3btNWrsxPysNR94Y8rVBWD60UPQBV/E8zplbloh6ona2DWc3HxsB3aNJFN4A6MfyTpeZDP/LF+OA2B1xy083s21A0O806ShyFlYSWNpKqGC6qYrk6SDOtjj9JyzOJsEh3IkTlgH9LYlKD8pBq3inbcBz1QskoqjW98Us8W3TDPobFC91OOgJtY8+6+63PUDkAFVTBeX0jBLUXMD6+M0M3N5UyPN9LRs8q+D5oIZFHQWN+H/cer9qPxyd0db4McBzVsPsBv0yWfznpogSustGuTVyqgNFxp2hBBvGnLmejQ+qcqrA0l4lFi4CwKPeubfB0h9w8VYvwl09dIyGkR03S7iepzuHGTOaDjQsUYzbKms2PDUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYWMgiydlCGVIbm+B42j3ax8SIrxOC58YNkF/X/GjS8pdw7uQybxm18q+mJB6ugG11kL6cScOFNYeM11zb6CZAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 10,
+        "previousBlockHash": "D632E5C1ED253F8AC72FBDD5C6DF7BD2A035D55DC8A60C01148E9EE8B9787E59",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:x4oPDeAQ57enVK63PaDFbf+5YPWU/iG+jOWSPn6fc2g="
+          },
+          "size": 12
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "11885928338042840138431459557475737066488812714660327041753257392",
+        "randomness": "0",
+        "timestamp": 1657933739998,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "1C5807671CAD48D93CB2100113497D216FDC8D3E38D36BC3B44ADACA490C1589",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJRKPVC92p0dn6AItzjH16RgR5MRhe280ytej1IzWbNc7f0fTjEnOD2A9j5altzJY6qLGwAQQCvaL3jVn/hT0wy4+X29YUSiFXm9ClUTwIxGIpHHqAR5tL5q6G/yr/imbhAjl54IDJR9TeVQ2U1lnRy9BEYVEvgPNzTo5PshubNQQjeWaifaEUjcLdmAsdQdK6/q6/Pnw8/pj5BxhOOrM9YpjS2Gf2Bk0iifNuG8phec/RuCpl3ywN/izG0M4HGbqDd+qZAbBashkQr7+CgiwmWDWRftgRIsabTwnnL6rrQTjDu1Z/IYRpMh0GH9GGfW+P6EpgwUlEsiwf36xyfymVBeuTLVLYP7bPt9k6i80S6f9OqdTXTie94HocRNUkNVQdl85cBXkEFQ46dVIHLNicqz/e2QDM98rC0PWYc7F1XeJeD9sdbEK7vXxe4PLV+ndapmAH19WRB/cJPeOUgAFn9vAqFIxhFp8DoBwhg6tHCYriWjcRqupZiO+3ywnLjEJLzi8UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQI4daqU8JAGW3tHr6i4IWzfX5RCeNM1Yg6zC3kKdkDG6gCJ+J4LdraxeLyjNakPy0G8TPbDE0MOgSp3q6iT2CA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 11,
+        "previousBlockHash": "1C5807671CAD48D93CB2100113497D216FDC8D3E38D36BC3B44ADACA490C1589",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:0VwVxN2P7+nkOa/Y907z0GZQzrlk/7gqNY5TensrRCs="
+          },
+          "size": 13
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "11851208002100917213291164050251833837485038071682851766015085646",
+        "randomness": "0",
+        "timestamp": 1657933740216,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "56A634E29C1DB204F2ECF6BE68C7ED84546712279EC48C22F8AF791CC555D454",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALegaczaJbmw9fmQVfmFRJ6O3r5SJo0sIZ7rnZ/SVXfyo/1Frx8tU9le03i11TUrMpJanfkEJi8dhC9HmRVkm/ZlIZ4XjaI47ghoYGO6GVmb1lCfAdRDHEpcBKxUZduFLQ8GsIEgHIeEM1Ww38e6Ic04o4tP/4pYwB6smdfD0SHIMMreQWKrv+b0nzHiqMxrfpmGdvxeEHFT9vYBxFqkpvWxusqBg/1On6xV7J6ITA4NMnvipaSW7Tn204nPNhJ8+7Qmep0Ic84TJmFyy18gr3ZuUOSio3BmiFJX/Xvq8GkAsYawepn/TLn8DrcbMEx1/QDta/C87ajrsVDWktVlxyhy5G0d6zOfrtNcn5uuQOyWMTdoo8cV4LgAn83+1AgnaRrvJs4AAzfUCYoid2+80/dai6icZ1ydzQeM/Nf+CipuFmmJ4x/dsz0LMCEmmJZ7XZ9H2+w8CTMKY2TtH591YOQ8+8Vc9Y9Pbf9osmSEDENDYgQitp4pyJyj0uJc38aK6C7AlEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwr4pWNnRBWuOI1IxCtKKGWfhIwlrxMQyMWSFIMVyzU9nNjyhq8y0+9HsuHJKjxbbiiZO8Ag0JRvq++N4G6iUzBQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 12,
+        "previousBlockHash": "56A634E29C1DB204F2ECF6BE68C7ED84546712279EC48C22F8AF791CC555D454",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:uUnS6kh6n3YWPat+gOAWX/AjBNUxAchCEQTa1nhd7E4="
+          },
+          "size": 14
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "11816589088761074346815455615246704045296818506535256123086689763",
+        "randomness": "0",
+        "timestamp": 1657933740433,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "78837DE6CB0C16D90945D50D73139A21CFB8FDEBB4BE4A63F340858F95D9AA06",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIYqDpOHPBlGYVcQuPfhWOYsL3NQpAbOIjbCJdkc4IKYq/8I/vFD8PjL6K0ygdMBP61oS3xzMg1JrvkQN2Kvj5agJzUPUdLNhy30VES6whJyV6AibtOwvEXt5dvifyfNjgktsldXQPlupYsAO3cmjDBJs80yIOzUo3lTYgjti+o9e0wtJHENy5gqwtwYgV5UZpSBQwmLtEaZM71NivWuCWCcEdK2hGYexkOhSd05IWbO9tv4hDZMSz9vXNgLgLpTUhe6pcV7l1EVXkkj5nIibuYP+McmRKF0X03/ygl+NN5SbzawlFBNx6H+NET2Mj3MLmDQNr9lMjQyhD+Ya4ixWBEDfeljiNpx3U8vaJc8C1vqVegzUv9CH243RnvxnpttQYYHtq/ZX3M2m5uNVLC/1v3WhgZLzXdF0llTh/AyE1jN9L5YMPxH6pLb+HpIoeBFcjXWXhvHCro6xgUc7/KFYwUsw6cArL/efs53PE+uVDsfOd4g9Zs6fbr3iVa0iMD2rteiQkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXgRCH2QisRbemy15mBzsObTfxSIqbKNYxxadVJvIeQ13m4/MWY3xqR3naBSoKb5PYyIt4IfP4exGg6H2aKYABA=="
         }
       ]
     }

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -249,13 +249,13 @@ describe('PeerNetwork', () => {
       expect(sendSpy).toHaveBeenCalledWith(response)
     })
 
-    it('bans the peer when requesting transactions past the end of the block', async () => {
+    it('responds with CannotSatisfy when requesting transactions past the end of the block', async () => {
       const { peerNetwork, node } = nodeTest
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
       const peerIdentity = peer.getIdentityOrThrow()
 
-      const punishSpy = jest.spyOn(peer, 'punish')
+      const sendSpy = jest.spyOn(peer, 'send')
 
       const rpcId = 432
       const genesisBlock = await node.chain.getBlock(node.chain.genesis.hash)
@@ -266,26 +266,28 @@ describe('PeerNetwork', () => {
         [genesisBlock.transactions.length + 1],
         rpcId,
       )
+      const response = new CannotSatisfyRequest(rpcId)
 
       await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
 
-      expect(punishSpy).toReturnWith(true)
+      expect(sendSpy).toHaveBeenCalledWith(response)
     })
 
-    it('bans the peer when requesting transactions with negative indexes', async () => {
+    it('responds with CannotSatisfy when requesting transactions with negative indexes', async () => {
       const { peerNetwork, node } = nodeTest
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
       const peerIdentity = peer.getIdentityOrThrow()
 
-      const punishSpy = jest.spyOn(peer, 'punish')
+      const sendSpy = jest.spyOn(peer, 'send')
 
       const rpcId = 432
       const message = new GetBlockTransactionsRequest(node.chain.genesis.hash, [-1], rpcId)
+      const response = new CannotSatisfyRequest(rpcId)
 
       await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
 
-      expect(punishSpy).toReturnWith(true)
+      expect(sendSpy).toHaveBeenCalledWith(response)
     })
   })
 

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -11,7 +11,12 @@ import net from 'net'
 import { v4 as uuid } from 'uuid'
 import ws from 'ws'
 import { Assert } from '../assert'
-import { useAccountFixture, useBlockWithTx } from '../testUtilities'
+import {
+  useAccountFixture,
+  useBlockWithTx,
+  useMinerBlockFixture,
+  useMinersTxFixture,
+} from '../testUtilities'
 import { makeBlockAfter } from '../testUtilities/helpers/blockchain'
 import {
   mockChain,
@@ -21,7 +26,12 @@ import {
   mockWorkerPool,
 } from '../testUtilities/mocks'
 import { createNodeTest } from '../testUtilities/nodeTest'
+import { CannotSatisfyRequest } from './messages/cannotSatisfyRequest'
 import { DisconnectingMessage } from './messages/disconnecting'
+import {
+  GetBlockTransactionsRequest,
+  GetBlockTransactionsResponse,
+} from './messages/getBlockTransactions'
 import { NewBlockMessage } from './messages/newBlock'
 import { NewTransactionMessage } from './messages/newTransaction'
 import { PeerListMessage } from './messages/peerList'
@@ -160,6 +170,122 @@ describe('PeerNetwork', () => {
       expect(typeof args).toEqual('string')
       const message = JSON.parse(args) as DisconnectingMessage
       expect(message.type).toEqual(NetworkMessageType.Disconnecting)
+    })
+  })
+
+  describe('handles requests for block transactions', () => {
+    const nodeTest = createNodeTest()
+
+    it('should respond to GetBlockTransactionsRequest', async () => {
+      const { peerNetwork, node } = nodeTest
+
+      const account = await useAccountFixture(node.accounts, 'accountA')
+      const block = await useMinerBlockFixture(node.chain, undefined, account, node.accounts)
+      const transaction1 = block.transactions[0]
+      const transaction2 = await useMinersTxFixture(node.accounts, account)
+      const transaction3 = await useMinersTxFixture(node.accounts, account)
+
+      await expect(node.chain).toAddBlock(block)
+
+      await node.chain.transactions.put(block.header.hash, {
+        transactions: [transaction1, transaction2, transaction3],
+      })
+
+      const { peer } = getConnectedPeer(peerNetwork.peerManager)
+      const peerIdentity = peer.getIdentityOrThrow()
+
+      const sendSpy = jest.spyOn(peer, 'send')
+
+      const rpcId = 432
+      const message = new GetBlockTransactionsRequest(block.header.hash, [0, 1], rpcId)
+      const response = new GetBlockTransactionsResponse(
+        block.header.hash,
+        [transaction1.serialize(), transaction3.serialize()],
+        rpcId,
+      )
+
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+
+      expect(sendSpy).toHaveBeenCalledWith(response)
+    })
+
+    it('responds with CannotSatisfy when requesting transactions from an old block', async () => {
+      const { peerNetwork, node } = nodeTest
+
+      const account = await useAccountFixture(node.accounts, 'accountA')
+      for (let i = 0; i < 11; i++) {
+        const block = await useMinerBlockFixture(node.chain, undefined, account, node.accounts)
+        await expect(node.chain).toAddBlock(block)
+      }
+
+      const { peer } = getConnectedPeer(peerNetwork.peerManager)
+      const peerIdentity = peer.getIdentityOrThrow()
+
+      const sendSpy = jest.spyOn(peer, 'send')
+
+      const rpcId = 432
+      const message = new GetBlockTransactionsRequest(node.chain.genesis.hash, [0], rpcId)
+      const response = new CannotSatisfyRequest(rpcId)
+
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+
+      expect(sendSpy).toHaveBeenCalledWith(response)
+    })
+
+    it('responds with CannotSatisfy on missing hash', async () => {
+      const { peerNetwork } = nodeTest
+
+      const { peer } = getConnectedPeer(peerNetwork.peerManager)
+      const peerIdentity = peer.getIdentityOrThrow()
+
+      const sendSpy = jest.spyOn(peer, 'send')
+
+      const rpcId = 432
+      const message = new GetBlockTransactionsRequest(Buffer.alloc(32, 1), [0, 1], rpcId)
+      const response = new CannotSatisfyRequest(rpcId)
+
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+
+      expect(sendSpy).toHaveBeenCalledWith(response)
+    })
+
+    it('bans the peer when requesting transactions past the end of the block', async () => {
+      const { peerNetwork, node } = nodeTest
+
+      const { peer } = getConnectedPeer(peerNetwork.peerManager)
+      const peerIdentity = peer.getIdentityOrThrow()
+
+      const punishSpy = jest.spyOn(peer, 'punish')
+
+      const rpcId = 432
+      const genesisBlock = await node.chain.getBlock(node.chain.genesis.hash)
+      Assert.isNotNull(genesisBlock)
+
+      const message = new GetBlockTransactionsRequest(
+        node.chain.genesis.hash,
+        [genesisBlock.transactions.length + 1],
+        rpcId,
+      )
+
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+
+      expect(punishSpy).toReturnWith(true)
+    })
+
+    it('bans the peer when requesting transactions with negative indexes', async () => {
+      const { peerNetwork, node } = nodeTest
+
+      const { peer } = getConnectedPeer(peerNetwork.peerManager)
+      const peerIdentity = peer.getIdentityOrThrow()
+
+      const punishSpy = jest.spyOn(peer, 'punish')
+
+      const rpcId = 432
+      const message = new GetBlockTransactionsRequest(node.chain.genesis.hash, [-1], rpcId)
+
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+
+      expect(punishSpy).toReturnWith(true)
     })
   })
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -73,6 +73,8 @@ import { WebSocketServer } from './webSocketServer'
 const GOSSIP_FILTER_SIZE = 100000
 const GOSSIP_FILTER_FP_RATE = 0.000001
 
+const MAX_GET_BLOCK_TRANSACTIONS_DEPTH = 10
+
 type RpcRequest = {
   resolve: (value: IncomingPeerMessage<RpcNetworkMessage>) => void
   reject: (e: unknown) => void
@@ -561,7 +563,7 @@ export class PeerNetwork {
         } else if (rpcMessage instanceof PooledTransactionsRequest) {
           responseMessage = this.onPooledTransactionsRequest(rpcMessage, rpcId)
         } else if (rpcMessage instanceof GetBlockTransactionsRequest) {
-          responseMessage = this.onGetBlockTransactionsRequest(rpcMessage)
+          responseMessage = await this.onGetBlockTransactionsRequest(peer, rpcMessage)
         } else {
           throw new Error(`Invalid rpc message type: '${rpcMessage.type}'`)
         }
@@ -718,11 +720,73 @@ export class PeerNetwork {
     return new PooledTransactionsResponse(transactions, rpcId)
   }
 
-  private onGetBlockTransactionsRequest(
+  private async onGetBlockTransactionsRequest(
+    peer: Peer,
     message: GetBlockTransactionsRequest,
-  ): GetBlockTransactionsResponse {
-    // TODO(IRO-2279): Implement a handler for this
-    return new GetBlockTransactionsResponse(message.blockHash, [], message.rpcId)
+  ): Promise<GetBlockTransactionsResponse> {
+    const block = await this.chain.db.withTransaction(null, async (tx) => {
+      const header = await this.chain.getHeader(message.blockHash, tx)
+
+      if (header === null) {
+        throw new CannotSatisfyRequestError(
+          `Peer requested transactions for block ${message.blockHash.toString(
+            'hex',
+          )} that isn't in the database`,
+        )
+      }
+
+      if (header.sequence < this.chain.head.sequence - MAX_GET_BLOCK_TRANSACTIONS_DEPTH) {
+        throw new CannotSatisfyRequestError(
+          `Peer requested transactions for block ${message.blockHash.toString(
+            'hex',
+          )} with sequence ${header.sequence} while chain head is at sequence ${
+            this.chain.head.sequence
+          }`,
+        )
+      }
+
+      const block = await this.chain.getBlock(header, tx)
+
+      Assert.isNotNull(
+        block,
+        'Database should contain transactions if it contains block header',
+      )
+
+      return block
+    })
+
+    if (message.transactionIndexes.length > block.transactions.length) {
+      const errorMessage = `Requested ${
+        message.transactionIndexes.length
+      } transactions for block ${block.header.hash.toString('hex')} that contains ${
+        block.transactions.length
+      } transactions`
+      peer.punish(BAN_SCORE.MAX, errorMessage)
+      throw new CannotSatisfyRequestError(errorMessage)
+    }
+
+    const transactions = []
+    let currentIndex = 0
+    for (const transactionIndex of message.transactionIndexes) {
+      if (transactionIndex < 0) {
+        const errorMessage = `Requested negative transaction index`
+        peer.punish(BAN_SCORE.MAX, errorMessage)
+        throw new CannotSatisfyRequestError(errorMessage)
+      }
+
+      currentIndex += transactionIndex
+
+      if (currentIndex >= block.transactions.length) {
+        const errorMessage = `Requested transaction index past the end of the block's transactions`
+        peer.punish(BAN_SCORE.MAX, errorMessage)
+        throw new CannotSatisfyRequestError(errorMessage)
+      }
+
+      transactions.push(block.transactions[currentIndex].serialize())
+      currentIndex++
+    }
+
+    return new GetBlockTransactionsResponse(message.blockHash, transactions, message.rpcId)
   }
 
   private async onNewBlock(message: IncomingPeerMessage<NewBlockMessage>): Promise<boolean> {

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -761,7 +761,6 @@ export class PeerNetwork {
       } transactions for block ${block.header.hash.toString('hex')} that contains ${
         block.transactions.length
       } transactions`
-      peer.punish(BAN_SCORE.MAX, errorMessage)
       throw new CannotSatisfyRequestError(errorMessage)
     }
 
@@ -770,7 +769,6 @@ export class PeerNetwork {
     for (const transactionIndex of message.transactionIndexes) {
       if (transactionIndex < 0) {
         const errorMessage = `Requested negative transaction index`
-        peer.punish(BAN_SCORE.MAX, errorMessage)
         throw new CannotSatisfyRequestError(errorMessage)
       }
 
@@ -778,7 +776,6 @@ export class PeerNetwork {
 
       if (currentIndex >= block.transactions.length) {
         const errorMessage = `Requested transaction index past the end of the block's transactions`
-        peer.punish(BAN_SCORE.MAX, errorMessage)
         throw new CannotSatisfyRequestError(errorMessage)
       }
 


### PR DESCRIPTION
## Summary

Adds a handler for GetBlockTransactionsRequest, which responds with the transactions on a given block corresponding to the differentially-encoded indexes.

Note that this message isn't sent in the block propagation code yet.

## Testing Plan

Added tests for the message handler.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
