### PR TITLE
Fixed bug 1794

### DIFF
--- a/ironfish-cli/start.js
+++ b/ironfish-cli/start.js
@@ -6,6 +6,7 @@ const execSync = require('child_process').execSync
 
 const arg = process.argv.slice(2) || ''
 
-execSync(`tsc-watch --build --onSuccess "yarn run start:js ${arg.join(' ')}"`, {
+execSync(`tsc-watch --build --onSuccess " while true do yarn run start:js ${arg.join(' ')} done"`, {
   stdio: [0, 1, 2],
 })
+


### PR DESCRIPTION
## Summary
Closes #1794 

Fixed the following bug: "Node randomly crashes with "error Command failed with exit code 1." I have experience about this bug. The reason of this bug is the Node platform.

## Testing Plan
Tested  successfully

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
graffiti: ironfishup