### PR TITLE
Fixed bug 1050

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -42,6 +42,7 @@
     "lint": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/",
     "lint:fix": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
     "start:dev": "node start",
+	"start:once": "yarn build && yarn start:js",
     "start": "yarn build && yarn start:js",
     "start:js": "cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node bin/run",
     "test": "yarn clean && tsc -b && tsc -b tsconfig.test.json && jest",


### PR DESCRIPTION
## Summary
To execute shell commander ‘yarn start:once accounts:balance’ , ‘start:once’ script is registered in package.json file, but it didn't have this script. So I added the code and tested it.
Close #1050 

## Testing Plan
![Test-1050](https://user-images.githubusercontent.com/92462002/179646619-876c9d7a-41cd-4c32-b7d2-a865e3ee3b8b.jpg)
Tested successfully

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
graffiti: ironfishup