### PR TITLE
Create transaction fetcher and gossip transactions by hash

### DIFF
--- a/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
@@ -1216,5 +1216,173 @@
         }
       ]
     }
+  ],
+  "PeerNetwork when enable syncing is true handles new transactions broadcasts a new transaction when it is created": [
+    {
+      "name": "accountA",
+      "spendingKey": "b7b06857611ed4cd70514963010694bd7a5e137f0fb4386ba48c641404eec16f",
+      "incomingViewKey": "9e21dc0d887fd784309c2a996ca6bfd381ef8462f70b741d9844a13a7a83ee04",
+      "outgoingViewKey": "42b11f46a90fc46f22e2053b6a3dff1b7fb05638d39d44a7cb629d07efe5ebac",
+      "publicAddress": "efd8de6421d857d1c286284bc92ad11a0178be1692a57ab3a5dba1b8832b85f12d4dc5056409b168adc073",
+      "rescan": null,
+      "displayName": "accountA (9807752)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "58bec9689e9f04d7d519c881764cd5b5d921d1b74834fb02b1f759ab0194f780",
+      "incomingViewKey": "4f98edf16f308a624f44c8f2f9dd0cd1b08433397eca555bfbf33b8375002a00",
+      "outgoingViewKey": "872b4bff45ebbc32228a46ac0296f94f35f8cc2100d6c9f1beba0d963dedcd0b",
+      "publicAddress": "72742e0530021617f5df2ce86a038b688edd3b49a0cd59f711dd77ce25141fd8b26b585057a790cd319b5c",
+      "rescan": null,
+      "displayName": "accountB (c4b86f1)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:6DttdLP4oHnG4zOztmwPeRXLYXmjBmUOpZFR6fW6rS0="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1659655050038,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "62BA75A05C5B96E448E62F16F841B07920DD54B1B3B6A77D9A265A5D823E1B38",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALlM1tXATxT3pMzdKA8qgmtfdAfciG9yoNcyrHvZ7g+r+l71EXc/PRQiE4ZOL1XRPY1g++PfScewcaPAtF2JA5NFCKkaNFMhSsY7WgY0rN+CvL4SLcywYsoqgEuXkrVJjgep/v17CzWa2WPXK3j+PRZEN+A6RWU26Ktv77PKFLJUcjTGHkX+2V682Au42wgCIY5bpRR1tzlYhCF0mPINsbtf182EPjKWBfks3Liil/6If2m4zxRyrrCHZ4+1Qs0mypqQKArBZ9PlsgKaDWuyk74HVqDD0HK4dfBBoJ0QenTBUfHzK/nWmAPs9+Ok/A65xzzGhoYMIOXtG8y0TKmjrBBro/ZbXKMa3A2M/ZHgQvXH/Vw7IjjNqkJ4RGbZGD42qQVPFwRF4diZ44Ia0zfZxkffGZcgVpERLrfCQcvVpgO0MixjVXLxnvU6nP31vgM1J+40nhbe2yOn/boJ8JssbrUj+tVLf7Z0RFqu6whJXVBk3qJS8vNTvGDKNbsYmvd8XwLCikJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5aHkcgOpUrInDE3mglqTkHDfgujfOmobefNz2YOh2qE2khI1/VzTAgR39qAOaM3nw1eTHP0ddB0inVFwj8G+Cg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "62BA75A05C5B96E448E62F16F841B07920DD54B1B3B6A77D9A265A5D823E1B38",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:FAvgB8VXcuKS/sJW7Za/sAGwc/XUQWVaxmluSgrJHUg="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "B8DEA03BC7B586805A84A3149DE1BA84817A15FA2C6215EC071545F4670C232E",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1659655051420,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "7A60DA462E4BA860968A756334AC3ED9FEA4FAB3227C0A3FAEBA0EC186553DBC",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALfCrKXo3fuH7InEE2NdfOEgyhvXAsB7bDnLLInxGvCUQECmYhtNPvxcRjcKJjJdCK3/AI0Q8WtM1aR65WjHGM6fF9FUnR+himqwlpBYQVRkoigagCTZ94XJdMBCP3VakhOp9L5R2ye7VZBO1Vs4iLzxy2YuxbgwxTrPr3VEuN6gtQuJW2p3CamPXujgovEpPK9dAov3d4FxGjRcwzLwRwg5Lc+9xwjs/hl0M28w/lVZq4xbrKGdtTvGqkqwlQwd43P6DZjRKIGjOlFJyLJBp/eYvxatGVIPxbdqSg7cYyM9l1gZXtat5FjQZGP+FBVq3bUgzqKXGgAFuRXzRGOPLwWmsNwZYWXRQVGDIbRJdWJ6FDNRV2Ho66Rc/b+HsZs8nGRy/0xDwG77esTQVYtC/RJ0tzyIXiuT5GZ8aG0KITmPXDyP0fapYfNeDxdP9OBsOqgG9rKBuMfw8sWlcZ9fofMXr+v1MAwl6bCMlIYsi5p610kWVmsWBDm2wS7wnENYWtJqPkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwL1/K2a3xUU+f7Hrg8BrkM3FAvWmYytNJbikcObY4fM79iTP5MB5343GLMOXS5z/OC8d6KPSx8pysmfnu7clfBQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAJGREt1RImv7pSRoupKS220WkFRJykg+Xkhf+bUV8+kG4Q1mldYIPH1djOAWgbzyPqbhH/sv5YF49Gu9uBmLdck0NRJD4OJEuPQI3SxeEmHn9VcxlmlVM2jslcyK4TCLAwfZIGUn2g9OxxhQTwzvObGidtgxwijTDC0sUjQqb3OttfXBL808DF5lOKhDMC91qLMUfZqYqDtHlOsOplGxelkCJa/hq/henlVAQ14yunQkSJc1UaB5iZjqL3vTI+57Ptb15PkJz8CxRoW8jTicqA34KBSsNOOauXKvtDK+npYOS1koBAV0bZBwV9xlhbSxtiE/ukPrUmC7DrBJ+DppfE3oO210s/igecbjM7O2bA95FctheaMGZQ6lkVHp9bqtLQQAAABfubFZQhTbBa3BpDXxDSG72g1obK19s0r2BqizL+XeW4bF2aqEMo3CnzGqDrnmfNpylwKPaAlWwjZ8Z07FMWrvq0ifgmDs3uo6CyOn+qKzxOWWtP/ZdpN7MyGVOhPpLwu2Q2Hll4HijAfDmBAjFWWlr7hYFymU7U6TvmuCPflV0Xw9pXKwuBKZq0DQMvhlFhKsDA7olfDg/Cd4fEdwkOSyiSwESg5y1fveMiXl+XNLrzNr8g5RFSoh6TU1wKCc/yIXS+gxX0wGYvs265dH6KVaLmOGIM1hyyq0teG3GrqPmz+y2mHaqEWbwSQ2+TJuws+gS2D4+rTWPxLynx7uBlsCFAYBz2fDfjTFM9ZjUSlQhRhYcT9J8uw9LplYTlmPaYPgQ52yMT9kv6GNLLSOgFCR9NbWYjmJ3Wz60FmCph90U1p6aKnOVDpICPsVIXYkK3f94RxWu9PqJsJiyWa53UwfBJv8iLO+cBXH2qP2ElGN2meq8DYgorNjl8mAqEOxdN/2e5Fks7ZsTOT/4XgmYROFG04oaH4ZX72ktBq7s0UIggjP7U0mXFufyIErxXoZguQmH1sbjsdaoOCU812psMpXVhaCsvGYPM9Y5NTb8J0C5h9K04cBh/9UOdI+V8vVdLYpyTU38QuKGmIoPAcaroSpdwKW88e3x0gCNkjn9r4su53UeOxsrMQ6KSVi6P1odhH/x4yyIyspAXG8SLvKvE4PVJGpMuIEHFL0bmyzd9kTA2R115IXr/2b1b0KwZiJ6NB9YO/w0t1+pu6FiQHuv7YgJ+n4wsrA9lwrysugQl5Xniepca9tR0ic5Ryih1fZhtEPBAU8ipFAMj8l4EN+lW29f03vivf9masdzw5GHcsuZgoGPQ31lnzKopKQ5ilvsh3ZKI9BdTHgyEgfQkg2sAGVPrxP6q9w7dIug66ckobjmy9sjLPzqsajKIL3eealACE9ANkzQ2jjtyGm6wz1xnm3AllS3w1GsiyjmG6gACLO/PWRLLT+ARLHpfgwz6t7v+4eUX45KBBc14f6s08hHqTld83oVRpNB+nWY1rZdCdf80amOmyta8Cxe5zz9pz7xnG6/QbdLKRtevoWZvEggchtjX/aaYl9Q8XJ0TMYYifgRrNPzYg3sC4y0SpMoaMaEp2KCfBavKhOp4QNfac50jY6IWRWMzGkfsPYuE7B7IxfEsH/8CrwlFtWQBd3qvKtKVjvZfr4EE1pRRcEehkaEOhZMZP1G86zfcnnNnkG2Lt21B3LD5L0h0MpWYCqXJgcXgBQLuDmuPe+x1fKgDh8p+8t9uCks0PDziHvBWlJStn3Ni7zbiX7VxEzwKivrTjTHaW8yIeNxMBRgSoLNgRxOJlRNbuV41wQvqLS6dWr/6iMRuudsiU858efABZqx4KzzV7/K8JWX1W/38dk/L4eRpsUr6YK9gcSHWO2D5E9PrUKI96AUNi7DA=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork when enable syncing is true handles new transactions broadcasts a new transaction but does not send new messages to old peers": [
+    {
+      "name": "accountA",
+      "spendingKey": "af530b4078b3c74f62b30e35ddf051bad61a973093c6d86687fe2d7ae16553fb",
+      "incomingViewKey": "703fe4b28db57b875cb0e713c0286754fc3922b3b2dc10cae3b9cc5504bf0a07",
+      "outgoingViewKey": "7b9862b935e36012d2391fcb0fa02e70691120b531dbb0133385fa7bdf89c3fb",
+      "publicAddress": "3812873bd5afa652a4de1885204ed0a6459e1bffb771ccfcb545d8f4bcf0a7bb5a658f80db69f71e0e0a61",
+      "rescan": null,
+      "displayName": "accountA (b717a3e)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "616065168a3d291d4aea651f1fcac32565595fac970909e2f007c03469c6aac0",
+      "incomingViewKey": "50436b8246b7ff938a5bb4f92f5cf6a5fec3594bbcee180a0a3865a215774501",
+      "outgoingViewKey": "80c800e3c71798054567b93bb15ed3ba2137c0be8f8ad05ba3e2bdf98adf500b",
+      "publicAddress": "86bd8ce3e243c0432fd5f916f7c315712ba568334eb2e9c8ee7e8ed0537522f2ec42a9ccf09147e46cc137",
+      "rescan": null,
+      "displayName": "accountB (d5300ab)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:sovzWCyqDicwo/gNxTv3f/TsqUNcfXaIeas1xy5BEhY="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1659656357386,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "1DDCDE339516384F94D9EBF180C95525C0AB0F30F194765BF7E94DB2B5EEEA79",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI7yykf47ICorFPfbtZqwDgmnbEGqcc1TsiUHLcyhTBUbg558MZNlIVn333tg8CqvaJcjG+32M0I2QXBGDiX+2LJCqULPtbDJiMPP4DkwPyIwO4xr+5OpKsgYNJsVe0jBhAmUMh/oRQZkMavNSZFy2aYk+cc26BG2RzoaBHXBQrQH5XO2R0ZzuUUGFDIiYmfwoKeHsk+e0tfOaCa+i49rdMx/j8GnwoB0OyMBgLdH+h764KqfJymvrcnAOncnRwK1Bfa+1dwnA74V4ev1ytV27kvb29zlg4TNNvaKx6BnVmW9ePAyOkZEaY8HDys3aY9PDUP0huHPTUxnWoeQn4r5D6NtHgKkRbrvviv6Au4vi0nMAUpskW07hOHvQ4M0BSQUwC4/U0nk0AJIhGjXFdNoUMHxFxRmpEizGlzYzNj7jJ6fnVnc2mxPDbUAG+HEqZ02QrGtwHoTdb0ZPzPWXja2bIhJyYKtO5ulnsZ4oxLc9jzyjOHXyl4PP07+44gxMMRBfRgcEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwV+rBA306sK/sgoY4kft6v7qwRFYC/tis4xcDpcsg0CC332Wk/8YF30RV53AYpYEmgmP7nARn0IEm3Obb5y6DBA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "1DDCDE339516384F94D9EBF180C95525C0AB0F30F194765BF7E94DB2B5EEEA79",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:WQ310hcZd7vRqM3Ga73kXwItGPsC69etlxM4IG/lAg8="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "E25E305DC59E60DD3CB803579EC633985D61CB9D3F472350AEB29A91153B7606",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1659656358699,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "CAE46DDEBA18415A43387579D4318E23AA4EDF455E15BF81C9E6EE5FA4AE6E86",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAI9Srqz5aSV4LCqBBDGpjl1HUaKGuTQoG62lL01fQytOeZp81Vi1tIuFv5uEdTlWx4XDkLydpIPYnMoZHzydX2vW6gP8XU9/+uS36Z0vGIcZ+PyObUd7U+0blcpz7+XwLhbK7PtRLv93kUxoUyMII2Njrq+AvKTyLtSvxgLuQMsJRyBcKL2szXDrR9368NBEbYLTsFZJeYmWsQ9u29RcDJRY/jqCTy0OKMP+txCMljQum0sREZNY4c7GzZX+sN2Id9JL2w0M2+YwLhzaM70t3+BC94dqfXmXv9ioyMhoCOeNBsl8RRCQwo4zvDc9u01Xr03nVTBn0HYdvDlIgh1vYBlNkVKinMDmq4Dgb2NT/X+mBmRexI0anKqk0QtuWtnAZOeAYFPx9mwEL9i+uOz75pv7+a8hD9a3sARHD19KHG0uvZnqKPs/bso62KETt7sIGrF1aX9Ckbw6eCYyHiR0wBCmiPG9AzI/ptv+xogL3/dP37W6HDVUXPLRn666Fv5v05Qak0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRvUKUbGJuz/zoehv1WZ6LEsqNhClfjg0Vwo+aXEhdrY2+o68kx9+Z4p54VeMH93xQR+2C/aH0Kudz99qmS+sCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAI1hYnae3hDzyCW5zhOvLNqrXpGuhLRMIuK5WZBmerPF88tiR9iCClYWByPaFI7fK4Lb1kLASYj+HQScQhOnOy5eGYCR9h1RH25nuOXOvxrByMW44yYis/cPxYF3NcQFHgQh0EcnIlSqCumtK6blVuhiQsZRG5oCTDs0BgGjH/gKhLb0cpfnbu8Nq9zJu+Mixox8t2oTFFnyLFzgEm1qIXYDpW+3W9SOVmf3uhXP7eNIzlakKAw8tJ6m29OE7lYPSAnDEf3qLITqkb2YehGiz5WQ5vVFwGMEZxn8ORLT792jPCopbktIFCOW9rd2DjtKyqMW/1Q3mtm7vjV2P5Am1wyyi/NYLKoOJzCj+A3FO/d/9OypQ1x9doh5qzXHLkESFgQAAADv8I7xGUUvVzPUAMUpDv9Al/FBN+dwy3aJWDhE73UGvLm8Yl2GZVBHLDqD2cOviWDtmQzut6LzJQxDIPAb8Suoa4au/GrV9J/aKnltQROEmTUorDBPJi0j7hNh+ss1JQG2zHuLMZoZWiAcjzkBHEAKDIxzQa99NThBonVGwrDkXr7mJFZPRSIESOJy2kF79ASsoHeMqQkccvdBYIlRIhYvtQw383xJ+1ySo54vrafy+7MSKJja7RQw7ZKqW5MQQiwA9muRCt+jz+Ti9dq0P0EoowraBmdgpbN7PBmb3F3NA1u7dY3Ukr7nvIm1aU4trjO5/s3RSoUFqCxJn5KDmWf0HiTNySNaloQQKAdZnXG30j5lls/C+km2h295fzXoUCrCGsKR3QfLqYSH/An9Ar9zMTpmc9jzZvzV09sKH9M+MtkTAP7JVbDMXV6XW0xjLLce1fq9QQoh15wtIEBQSqE5L9GTaxtcqL9kQb/X4VgswFuYskhz6OaUUTVOmOgy3aPL/ym+yr1OuTfv/xlmEOzZzBvgOUdQY1AuwNxf9nlBy8N/sa3iWcScroXorug6UpXEbyuyF+K2fAm+TMYZQRYDM1fXTPsTq8dklLTpdM3bmCJxv+0UzfrhwEg5rmwLH5+0WtR88PU+xo+ThFAeP8J4pje3zDh/9hcS9JPFtvr77H4/W+fLi5s8m5JLt+tp+SZDxPWbZf6WqlHGJMDsvZMvkCW+mH04UmIW+u/4NmxJJ7Bt9retNNNQ/HQ5zPmAeaQROpDGQoxKtzAcQPlAot/6LlqXB9I8AXvobYO2EDNjx5IMD47yn9af5mZy1zDZx6nxENQgbnrrAmIqUgqtAG1d0LkKNVNuRjOlQeuVCzB58rMa3gDiAeKP/xN4h2C1/YGw3q8dp6W4OkViUem+kJGDm8a6RxzveN5ef8NUCCijZTxmKavu79hPTH8gbXDXWpSQrptZ3s9M91h3E12k1opAYx/I7XRjwmgIuYksORTTgmCH7TZgpJoI0pdP23CcFS6H6KUYgyyX3mbKBs63bqSnOKSfH0U/eg5J4dYN18nA0guvdBFWTISZBjzev60e3mq4Vi5Oh6HhpE3v40UbO0VLJgaNMYk8g3n5GklU/KpBOY75NH2+SAoL+UpT3ORDiPcs+v3GHDp5S5rRD9mBDid252tavO1iUNlqAY2maIVuvcPr9kin3jd0s5ES0Yk2vOaTOX95YhC7TgMuCSX1ucfRG+LRcW16FyqCEUMw0Agq3uEJM3nBgX2yma8U/yS8GhkAi8ry8//zmaka0Utx+NAOrgisM19t1t/Xsb2a/+JzQyzzTeof6EE6RVqnUU7R66UO/jHMXsnqnVF5+k96+hok+LBrW19ljFHg1y7NndWOE3CCvEhwNln9iPLiXfBvvOnyjjqw8D32Ku3qQ+mur/n1LzoYJKwDKVaMnkPG8qBQATpvqt1AAg=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/network/__fixtures__/transactionFetcher.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/transactionFetcher.test.ts.fixture
@@ -2,21 +2,21 @@
   "TransactionFetcher does not send a request for a transaction if received NewTransactionMessage from another peer within 500ms": [
     {
       "name": "accountA",
-      "spendingKey": "eaacc7c0699539f76353a81fa739f81988e05a100b571c7055024b5dd9018b4c",
-      "incomingViewKey": "50bdaf1935c9f7b20a06f0e9f22196b48d2f7d83bed40fe338edc1da1ed36406",
-      "outgoingViewKey": "510f9d869d9a5f248f4b5100c0a2a995853b3ec9ee1726fdde228fca9e8a0dd7",
-      "publicAddress": "99af3b55577f445cf05c59d394f4860b998eeaf0e26640a29f4135f50ca97f997cbf25dcf470b636356bb1",
+      "spendingKey": "10a98cf70df1fc662a97724e4e78d0da294a50b59e96805833ecaf4d1707a9ed",
+      "incomingViewKey": "ca35afc39e4f6159d664c0688c5774ebb36a3dd3d79683bdf2585981dbb19a02",
+      "outgoingViewKey": "8ae56b737d4aa41d3082308014606398d66b0ccea96bcae94cd663ab2e2a529c",
+      "publicAddress": "9f8783cb987ac3ab36ac34ae78dfb1f733d0f7ccf46d88ece5a1350c5ad8f6a8b649cdcbb9602a62ebdf28",
       "rescan": null,
-      "displayName": "accountA (9b8ab3c)"
+      "displayName": "accountA (9508cca)"
     },
     {
       "name": "accountB",
-      "spendingKey": "d6f0025643f321f3cec70aeb5737e73ab8f12550bae55f8d03098b2469bf012d",
-      "incomingViewKey": "245c7052e20306596bdfe3d3ff40bfcb2ae57cfad57716fef8f6fa603e687f06",
-      "outgoingViewKey": "1fc3a6082154a80bc85e13a75c5a180776b28dc690e90877b94e9959e7d02691",
-      "publicAddress": "58a57609a755ff16dffeaaf453e171ddc1ff5da37bcb88ad19f16f3d658772c1d147bf708654881767c3a7",
+      "spendingKey": "b5c33788fbb7576b059e5e620c419d3d550e6dfa8a81695e93e200b1c2de8397",
+      "incomingViewKey": "ebbe7456f3165911d090074ab4b8331dfba52d70d23e4ec9bc861e5bd021e903",
+      "outgoingViewKey": "291c7797a91302904a19931abbbd7313827315b3256d2132fbc9bd585bad9119",
+      "publicAddress": "1b70a09f21d65963d2eb342da0abafdbff0c33c694558df1d933bbb664e681bbaebc127311ab56325795be",
       "rescan": null,
-      "displayName": "accountB (2272f24)"
+      "displayName": "accountB (d6e9f37)"
     },
     {
       "header": {
@@ -25,7 +25,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:Gu7d3yPnZZ3YlFMmwZu1UaU/hDGln1v47/CsjmU2/Rk="
+            "data": "base64:yKJ0YgIqllCN0lHLOCKkfi5SFxiC8Po9cIsP20fd5kQ="
           },
           "size": 4
         },
@@ -35,50 +35,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659644442070,
+        "timestamp": 1659989477998,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "C0DE1249707C64EC3EA6B62DC33DE3BD175BFC8E5D890ABE2133960A00769530",
+        "hash": "0A913818CE78F8BCF78944DB2177D538B875C0DE5101F3258CE3E1A641580D2C",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKwNYdu9tHM4d6Bm6r6uwiRN6H7BROh3RI9+jK8glLh/xXwKdH1SYK9oG1gfvZg6F5cX0j8K6Ge6AFrizpEvAmS3r7CxKLRxfKSaV0T+C9+5W0qwRLbvu5htdEipvbLR/g+A3R2mbG+zdA3fFJIOojB+GwR8ww2Hz12RyKUEyw1Cevod7xDUaTfmJ/mVV8cnLIn01ifsxfkvOVPbyMJ+9GzDsJ62anMpP0x9Zxgi5p0xIcA0UCRh4mULViEWdaV9hsSFQAek4APEGbS1Rf42CeHThxOWI3jWFpvjc0z/aYMAYdYGJ0riniN+fplsrhkw5/NoESda/P4YrsEwjn3JNj83shHWIlr6iqO7nf3ADlvneyUcocb0YnM2c1pFcT4wUUxjLGvAzAtK46r5+k2wHxo4JUfeT95yHH1Vlj8QJKwH6CJW5ugym35IEwA51y3ZRXAFTp2DY0BeXhKrpBmjZAbXmfVd4na9IsPnCrkukgnRwIc18z8dedXC3CvooFpw5g+S6EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2yzJBwppzKR+iPhiHDqXHrXqOmM4ac8s5AjaD+20prbXUZg6v5ECn3XF7c8t9Sk9j5ZZb2NsXmJfbvDyyyRwCQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJFzqH+CPXa3JpnaUybiwFFY+21ykzyZgJMsiHUP79cpZecuACY8JoAF/bS4eTsX65cAneVXq576/6Dq2E5v1GaH3onK+N7bn3AZCWWfd6ro+6lI8tLpVYeeb8wTMperbgaiyNv8J5LuXwBkKf1QQ4zW3ThyzDDb9Q+ZFcsUhPOokpW+6WtU6/G0a5bERVUO/IYYZh7viROgP0efFlpT/XL9eyjt0IpCV0vq6KpVfC9KLBXt/OkDoMfcNf81PpDbc6kj3El5T7PdegML4syuezkiqG4efIwDu4hCYSVnmuYKwTPKGG54VEbJrr7dwpYQhGmFwOJYQ00H5u3MPxJg9nCmty1tQltFmisUk3s8hCUL6yX2daNmRtlo1fCNEBYrb3togb74xPVMiX/VZLttUZ3yVhu98EMEJzcwADPGDYRR3fK8E0swgvkj7fI4RTXnHmfzY7GRHyWLxYEhojsLHCnoE0b5T1M7Qti4Nel6oqvX3wmWjVPnAyKgyDrREQ10wBf470JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3JW/ssMT5epQ4D1oTE9+etziVPv03/836Yi+SYwpiwigFTgs6leF53eChcHAm/dGTpoQyEvAiHgmiQtQEVSyCg=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "C0DE1249707C64EC3EA6B62DC33DE3BD175BFC8E5D890ABE2133960A00769530",
+        "previousBlockHash": "0A913818CE78F8BCF78944DB2177D538B875C0DE5101F3258CE3E1A641580D2C",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:fMoulNFtTOck/SIfQKCVCEGQSjL505M5TdysugOqIj4="
+            "data": "base64:I7VZlS7f9eycoCPcGu/+r3R/bbtHFPy8VDVmUa/BMEw="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "9738E74B879C3EDE845BDC557E5BE387B7400CD55EC76787805ED13E094DB622",
+          "commitment": "C864DD1393C9F5B6BA02E4F82B66F2B8BC68B6C367FC8F17B8E220372BEBD1C5",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659644443433,
+        "timestamp": 1659989479339,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "EF5748AB48DB6CAFD3844117247F98F1D1C28CAD08E97A453DE02184145ABF7F",
+        "hash": "406DCE7CBA2D9DDA4AD86425EF2D35007A46F55CF723FB41C2F2B08714D0258F",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKBF0V2wmtms5L/aLuf5/CofxaxiIkcg/enRgU2ydbpqZx2Bb8Ar1RRBcBe09ZgN2bSwBRddU7z/NDCKHRugTZ8hscH3Oj2R1rH4lhxQeTQ6a6zoqBSmvgg7Id0OIiLCWw4CXn0OxrtwvfM2SsD4+KQ9CLlVhbkhjlQeNykIMNU3MvJyTtTuIcfpxZbZfp+/SoBzEseSr0aEV8gWn6uIjU6p/64WNJtvpaiIx54CP76kW7a2l5pE0gvC60ga7J5wxi6YQ5jhQXo6+ymXDrOYIZ+3k9HBvegRSr5NLkM6sqsAC15LlAcmySYUJ+EVGZsnZywTV5lqkLvArAwcyM0lRjIksruKgP43TpigHwaa4DsmaLPA7U75xiui0baL7Y4ZPSKHAuEjtbUVwczPaxrMCItcxOuQur1sWetMWHPmsBcJePCHKoodlLkMyx8UrW6+IgiRyCSe+GtmRR0d9fO3cTWoYu7G11ZJifwTgSuDiRj6dfSRa1KL0rx5qJJnmvxuQCjPDkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4Pn/bQxUGFRA7jcWk48afrbZaDM0V8ouB3GSLYa+N4+u3exS9Su0A0WAebxQgWE9RUxm44DZigV1ii1j+6IaDQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAK0q2JUV5C1uf+R/W+OcH1r45dvMa3HVVlrayvIg//wWtaIEKxnJTSMKWnxpDioWr6kEFUlheAvrqI2xKRnGChrOtiIt5DgQGnSOT7ZlJiz3T5cTv8HUk5e+HLNA0g3roBZQZM0iNK0E6ENa72bj2xyf9nB474c/4LE+9V/nH6O64hts50wuTMDLXZsyAXcwSZLXMFD9m9uuSroPCCPkJdDWCRjnv7XuwECVj9kcXUHkO2XhbVu/SJ+HIcd9WY7tbLOVJEeMysREOaLURbWKviF1UA0IyW0ekJTNApb1DhxB4Qxc7iFqI0cfHh0df/NZZorJif28OlYXGgLeuuitVg9Pn+iOHxhWkKlFCfZeCH/SgBIAAqOBKu9rl/YFL2G4wr08TyxODHP+yYBVh0kpKF9FZVYCLthkQdH8yxx5Q/2BBNU4PwfDNlEgsSvGTjr5zjFv2Sp7eTk7Ew5Jq8FpRJWk3fLlmuWE1GcKMC215eKBntjeqJLF+tqvS1+xdsEnrOas40JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwk8p/E9DSoYAYLSOsq13Lm82XVoyn5SWZM4NC2iX70/9XFtQRVkQa1iILlQxLSg3flT7qMkTx6H4Wu31WJ2WDQ=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALbTH9n4wGHkQBuQQOWOThO+olH9gRTg4RA4HZ1NQ8it+eDaSRNuhQeMG/YpINdhrLIez6zngBcsM6Gv0rub6Ujq8iZVWeqCcfDDlejvP/E3O+sRHboGy9Ne1LEuWl3cmxIPuhSiuDhEkA0jwfbZzQWOmrTuAOAGPmPWfvYp17mWreq31OPfd/qthCqxcN/Rx5FjreBbaPG1jJO4VAb0AKjqUTtmGf/eQJOmXuhJ84J7fuC+bElicIRTyRThH1Rp9ehRsizcBem2gsyM2zHBlWXJ31lPBSeV65hh5bITLW7VNDfMpqcf4G/LBrYYaPJyVH8Ysw++EWHxIOaggwIDpcoa7t3fI+dlndiUUybBm7VRpT+EMaWfW/jv8KyOZTb9GQQAAADCZMPYzJGOZ8Rzr9dfQVyX7dMAdvn1fmckuu5p+uEjM9CihXi6UT71zULsUdGWWXyPGSFuuCwau6FoJWRwmsGwboQxP6kMsL097ry0b7U7zsZqOZuT+Nw1n6fx54rITAOyoAjSKwqYF3wHwNzTK4MECgBFIIxABpEJIS+TrTMUCrNbCrNkNv4gMjhPs9PpqtOK2+xoagmxpD39xTZMAS6tojR2axHU2OXLGVOSQgKjL6IWJZm48S8ZkONDa/oT6O0C1mNYzgD8RFRxhVqMzZxYiOG/OdtepXHCnAF3iXu0Q9n3COdYINIDnHpZrHAVNHuExC+Q5Toc5j8uO//3fxN3/WpQqWSXAxCxp8ssprdvo8Q6WkVCvPXjN1rEdaOTrSZIa15TUfCOwGP2jq+tjMQWQF39EUdi2o+1v7+EeVTomb8Fasxxk4yomZdkUjicmdvTFGHrRlLvTUfcJHY5JWpJCvSrj2yx41F0m6kUhuJAew49ycj/3UV8r78UATfF6ODyid4vn8BNha+9nFwn7x8HssK6bqpcPiccBY64c2WKCirhdVWptegawUh6Q+ayqslIb+DwdjXu1DS+vGADeSrNdfrWnhIDinsR+im6912lORSMgCmF8P3TUXBYC14DH/Qa5SAI1auQPjIOsBVm/btYTwtm6DczempF8dGFdttzQAXSS3bTFD7SztMqYrv9MS+XwXlM7kDc89p1LsdVTechWCSv0C1FsgWC2PbOrPfJbAGOKKRcOz9WiF2mMjQ8sCo+rtzjgfXxK/NvH5tH0HiCOowgZC8uWhYajN688l7SvvcTMZi9gr9tFv7bPh8c+rp6wTrXUxLnUmMRkA98NoM+bxMVB5fGAuboDuTrbR/H2N+cXwKgiSZHe3k2ijU3K3ddkX7PMInVCBpYm2Yc2tfozUFNSHSsZ0PPJaVQCJBK8WtQD5hRS2TkiBKpQ25O7zGfy0DoXWC3UmFai+kEh7remhUu9e6kaAdxx5odH/tymNuv/6kYYHOaXsV9Jkq/WQQDOzvhP/6uWt0RSpbIc1VNczJyB+EPSSdIFsV2Wq/LYrMh1YXiDMzC1jxzZkSExpEtt3H1AUZ6xiMi1TvVrVE/+kXvcLoMAUPeq70RhbXeC3jjqUJQ3zS1EARwpI5uOewNhr75Hwtrxlyyoem8x7D9dtTSJyvL3i4teDWksvQna8ifoA6/rvUTcOy6y5sFe/ubAuvQulJjvz2HtOjwZjQYMyYaF4ChOADTS716IeJatL9vzslOpx+F3b+12gCs+UxP+He63vx38PZKwRrDtepJ+UqCRKGM6gQ3PZfgAMuSYaFcZwWmMLkl1dexRvxQZ3DSeX1K0TDo6NG1FGDMPe+uzuuq6fjnJ7deqiGTFe0Wy8QLIChMSZtcvm3HyNjYqES/GbvaYYrRTom5f/pkeSJ09fveKpBGVoNNMMy6/alNp5vXOjjiAw=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALQNH4TdwihNtd7VoP0LEsD2hwPhQGNEhmisfHMtEzqpb1l/Te4SE0HjE5vbfEUjuY21NM3a9QRAtY9uxi0gKd7GVg4Vo1Lu6KKypEuYPjisd9vai2bxGpHDD2I5z37MDRDDR5HZTnRDBM0od7SGCVtY4P+USAEm4qBANi66Lkg5a0TfAHJGCN1FZEv3Fk4dZbgHOacBtVYcWnd40A0Q56QhD2qHRAyzbwy2HHlzHETAzY/oasGf4G4d2hc9EUC7cHEuV3TlyKZnoXUnKUBBnb2BO5UT/ZgkNkjAmnr2+oWnWQHK5b7v0DRiMkvulAvgd3eeVuj3pjKHeCxESb2cKaHIonRiAiqWUI3SUcs4IqR+LlIXGILw+j1wiw/bR93mRAQAAAAoHgw5rzVSPw8mTMR4CccqXxhEg2ISj3tjUQQFoERnPVecPWmgquzTN8S14S8vTI/PAzr575oZ0uEj5qOVKj5olTwZEny2qscoxQt9gYAPNbj7sDVErP0MDRn0ljGKMgW1LZJg0DzSEhn3/kfFeUaelt2gGrJ83gDuxNCVaLEvGD4MZmxSIF/sUMNG/xLE+IGUwGoTXbIMTord+IdEQB2BokVcO6uk9c2Ey/QkD1ltrl1Y+8YBK+meip6hlKY+B9YIuMfh7QzucOupBvBW2MvwsZ9s6XXA8iWdywuQ9BTbVY4qJSDsUX2VQTc0yLnQDsyOfWhLzpFmSxlNjaawYDGnswIQBTOqZWiEAYs5xYEAkAZvsS3qLlw7Ewb4dBiRQggpHT2+byFdzvmH/ANPGNi1wENv5PQavxd5+J1o4hcAoCkHNLvYFZlxj0BL0NIh9DuSuXGhJKY7/5gNPEFuBFYjzN8Ccn/sbmdu+QsJemg0Lif0U/n9WeA2Qo7+jHvgblh3j82W4pFE++xcwuI66N6xukUL/G/FqRy8JHynBrnBkYb7+CyJ6ldVAWbdXlTd8FzxIOsZpIJqkume2imQTy7DECySr7HJQhFWpcoTFJiuiRHCFUlPpcLqsmb1K90J9ow3L81wQP89QnQ5673cbyBjuQadj8sslNNQ/rQ+F+SCI3sCtAbip8qmV2LxYGhOdm65OJ6RE3Dd4yuE8IEJPVQEGcCUUUrK4t6dT4ACME7gXF4Ys48Gpryu3qy0qwOendWO07Yd6uvvx7bN/tl+HaBmqqU6jJPBcbBUvJS/SCsgZo0Kf4XxZFCp/RM7zXRls/18gwdPw+NRexQMLX9wZ3pmZFVHbOLIA9ptaz6oCjfclyAcXxRH5sSfZuuK6MMUsqXBM23szy0XTYn7E7TsJbVj2APpYa16XxiZdZs70j4nEhVQTqLIhvHcf7UJhmVfmEbMcYBkf+2o38WgkttBAjiqKDKPraeiKm2gfiPL4eKUaBjs75VIwoOtXIbWVw670ArzHMlrSugs4yDGl4krlxZvZD03s4i3E1xgtAbD+kFzj+uQTFH3nQLGCRkgugmF30/AW0acJwilQFMbYz85mTyULSLzSVQ73Qdc8St94Bm6PcdowOTXbnsLPTnUZDQCU3GdQvLS/SIepkxH4GfRRo1gjMZHUMI2C3LMcYEif1MZl1JJ3rV8D9fZXqxoxcdNwmgIJy4w6aJsqMy9HItssfFgLHN0utmV4evLCnVf3RZw9GrzXyG6lnt8eD0wFgSxRj13Yx3NUGb91seCiXlrVhY/bO3a78lCPuwUDZ2gZ8+IVwl819ovldJHCShHyIlhyXfDUfkRWTwTpknUyjHHmX0+tySHDZ++Pp/nYP2vlhGA043Z6usogjFqKb82nfVcl6EpEq/mj9rbIn/XKMbAjJrofpP2lOkyhrsN+3k6+RZFxEndJWFIAg=="
         }
       ]
     }
@@ -86,21 +86,21 @@
   "TransactionFetcher does not send a request for a transaction if received NewTransactionV2Message from another peer within 500ms": [
     {
       "name": "accountA",
-      "spendingKey": "faf35acffda5bceac47c2bba0c213d6dfe49b75c8995b243c23b5594891f5812",
-      "incomingViewKey": "78be41f4ad7e46db8eb2d249087d3189977dd67313c3a910657cde5de6dad706",
-      "outgoingViewKey": "614339005e1f067326dbf31a72116f17c1bf3e3b404d2a171b6f27d285c51efe",
-      "publicAddress": "ac2cb7b7cc69131c355015e12baddd9d32da0f95ec62d3c0f43e571ec571b6567431c01b1c41ea32ececd6",
+      "spendingKey": "23882870aaa1db120452320f5e3a411de06458e0b5a6f4843cc595ecdeae2d6b",
+      "incomingViewKey": "fd8f529b0cdf5181a61e7030d3b0a53088cd4c334ab52ad3bbf313986b084200",
+      "outgoingViewKey": "4fe16880e9c02b1784dbb6eb38143a515fb16ed8accd9e96b1b11249b4909be7",
+      "publicAddress": "631b29ee7301cd700e78a93ae82c798a190b254e80e0c68b70ef57ff4d74a4a52c4694bce8572c5e8467ed",
       "rescan": null,
-      "displayName": "accountA (727caf4)"
+      "displayName": "accountA (29e6616)"
     },
     {
       "name": "accountB",
-      "spendingKey": "0efc415e6fda5f9ca56e0ee61ff29d549950c6ea00f86d2b3abd20bb37f14d68",
-      "incomingViewKey": "e9c89e50fc288dffbef4b70620de515fb7d358de35335e67328f22d32a002203",
-      "outgoingViewKey": "8f84817d13443b0e41e3e9b0a38af625a807f0e7047102a7c9a5874326f70c24",
-      "publicAddress": "2797ccc9b2341d76374bbeab249eba7f2d17f9e0f9ff5a6813dc5feebe90198557a34c57f996b7e2effc50",
+      "spendingKey": "4bdf73dbe8640161c8899e3d96639d34e6ef06ef3415ee1bd6ad46aee92da512",
+      "incomingViewKey": "3a9a27a06b81b75e122175b38260e05a677b780144abf87f5cb6e72e9027e106",
+      "outgoingViewKey": "260f1ccbee6d3125b2b5777aa43099df529bbf635e3d1fbd5ff48a2969007b66",
+      "publicAddress": "4e530c0b2aba78ab9926df85590dfa510243cef8e0d8ebb2ebad4efa9a1058e575734d4fe300debaff3cbe",
       "rescan": null,
-      "displayName": "accountB (59bc2fe)"
+      "displayName": "accountB (4016d08)"
     },
     {
       "header": {
@@ -109,7 +109,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:DIdb2YsOX6mRt2ofn+ZW50lKcB5g/DxUxecnXC2dSCI="
+            "data": "base64:58eS8iloE68vueP45OW+M2D6Bqzl1g/IOyPLqPKAGk4="
           },
           "size": 4
         },
@@ -119,50 +119,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659644443660,
+        "timestamp": 1659989479558,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "AB296D7269CE95ED4F07E8E3129071A287B532E405F4B7A4754C6D6BEFBBDD04",
+        "hash": "4AF36EC9D97098A2A62517985399602876FB36D1A0F66153F09E76C23E36523C",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK47C8+DMncGLDcVoo3Px7c1PthaeW5bkfJAGvA1QqAj0ieIf0gxBJClDO4IMSZSJItlV+uZW+PTr2/hj2EYhje/rs4fAYFazC9RbQWvzY4EZRKwdhsFidKRftUd5kU4pxLhsMV7P0PMsXn6ywdYAXL08S5wmDM7xAD95c5KJjzXzOhxPQ1oHm/PvtQBU85/OZmicypwd9XmfBUyCXhsI1Ex+ol7GJLkWANYUXV7BQajpHNo/0KJkfvxd0O8PQia5yODG7cBvmAc34tl29jLuv+hrUk5eiI6D7/OuZkYVHCrWLgFGxJR7rKLIYJS+xwYsy5CZFNHLkGPv73B9Vpx+EdKl7+JWohur8WOi00NS91LEPsQNg4bz7UZkMKQZSiN1ENhT1QTuhJzYrbb0uID9XaqtOsSg9IuGRFTc4/NipOkBxhQMzRVBZba6z2vK1BU+XgCZXTxvrdpf0QoUAHGHCErU9oJB6/Zv/UenGQFhlLR7/PXZJxBXM7KPYGyIGOQIevKrkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwffuVGYfzgifRAU1k/6D+m8XoCAxm8uDCQCDpLy7ykBsQnE50BMBzLxRKqMLgY1yBIjNPxv7uxdmkW2ovhVwqBQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIpoSAvIV48BBdUk6CbMoUS30rEHf0gy9cS5lJy4kVdugSmkrZ79XCMQhpecR62ZpLSlpt0IOYxNsCAP5Nooa4r9g3Ubk6p6XyZ8X23CC6AO3YVzVlcuQ9O5YQ20gixiSQv8UWs0/HxFgQfqdsiCOyR1aWuTSgwvvr36yVrdLz7w/BJQqlHvOb/bC0VAt93MSpDV8tafSwTv35hnFLr02RWX7gcWoNKJr3kwEZPZTYx0MsQ5Z1z0st92N2FpeyfHEyJq9NRDFDAgo8Cu76d/fusOptLH2jJYSDZsPeD3PBM8LhiDDF0/UPV5rO2s++VclBtr1zbSVxMsUE4iz1IzwjgnTmFeCG92dJYf4TPhsvojptLsaQX+BRFDHF1YEwfFrMGZdRFfEqbeya1BTsgcvR+ug3/RKA/ayE3Kcv2lOM93Wk6bNs67hoYgB+9kauzCJkj4czmfA7YFJ/+OtU2F8ujYNjdDvLREEsliN9xuOzPud6gq1S3DYbQ/NR4idaFGRMAFFUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGGORU8Tnfuwy7BdN3dVJ5dHDFVIjHhU3cu5k8pyGN+Hi7KqObFZvKVfP/DftHAhmtNgKWWGc0EsNi7YRPnSGAw=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "AB296D7269CE95ED4F07E8E3129071A287B532E405F4B7A4754C6D6BEFBBDD04",
+        "previousBlockHash": "4AF36EC9D97098A2A62517985399602876FB36D1A0F66153F09E76C23E36523C",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:KNHKLg0feYzdPGuVthb48DaGdwNr+lF/p8oCty8DeDg="
+            "data": "base64:d8DwTcNaoi226dg1g1hyLBuIb/d3G3RBt1r4/f/HKUo="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "16AA4905059997D4913B9BA6794553C2F2F37DA0433B6F09C65AED857C28C72E",
+          "commitment": "8EA8EC1DCBC090B0D2BE56E6C36FBB9B4DDA3DA88D405FCF6B9DE45EEEDE5710",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659644445041,
+        "timestamp": 1659989480901,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "9CC8FDE42AE93CB19E2E8C7A64E90A07C87112876FE6B26D36CD77671C5EF324",
+        "hash": "A3F6B06C67BFDA79A80B66F6572E3CB70022A5A797EF6DF1957C41C79117C134",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIst8EwuyP2BoOOz6Q6XCL2XxIiVmyVhAhT3tia7TH7QsL/7/gxk53wvwSIuOk7EL7jW2PkknPOeWW6nEUFr4vxJUF0vKvh5ljidJRh0i8MMzrxAMJC0Npo6tqLsLUh9WAVE4GOuO/zzT1qf5/RdEj0cQihruhYXYBzXJy5zztngaZOrPUrCF+wza+q/ae1YKbXgg/ywx6re/DF9w2hkFyyC+Q5zEKU90cl9EK6JlaYSf1rm5dcu5VVaXGkan8BOhIJdHiWG9Xn1tl+uzefZSxNnCc68DaH3/ZqTlFnoEWrilBNg5kFFEjeRTbykAPyaq5nOIYFO20yg7H5ZkYktKgo9ZCH98wbxpVj9zxmQiedMt0Eshs+pA7zlkJeWQYAkAENlojCnpjrwoLtfVs8JRkaMEYO4UrEJdRVKyj9028KrUOwxyrXv2zIVo4MS+DKov++t0KkVfFM9gvVfV+wi3IEcX2R1gR4CwmP7mgW6NdW0hItyuabMTAPXpuvpiR2k3A1LXkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsRNnk+CA/LWGuRH5CijWdm02D1U1SWZLgbB/vISF+1A6dfTYeQ8+q3jbnsGGpy9TMTDB2+KOUpg91bi6UlTTBA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALf3HcPC2yPR1j6mD5kq0w+YO11a5E51R1eI0ZS8zidp0nb+ZbDOC24JW4y0/3Zc8KNkNHTTATlN+DkUgBwM7OjBVEvkgjCqsde0KQhzTmjRSfqrHJcwRU7wkJmZT+hvCwDHo4C0ZkdZ3DQjLE8YYF9CAzUph4R5L/oOamEu2h8tXUmkD8GNlGumpeDXub8+n7k/BkHPyzHk5ILp1LjjzKK0ySC6Kg5xghETU35zaBdUiUL9dylwYcIOmR0LVtYANF8dwbQdQCEttzXFX1WzzO/XQdUNnQQfa+yjNRZtlOFWmdbGICBmoA+60FpfvW0jpi2qqOF3dL8w+zx3/EJPlF+KuDm+UycD177C2qmGuBNQBiBADLfRz/x4I7n/w15Ww7AaYAkSkG5VMuKkG/M8gg33VoNj5Q4Pozmrap8BRa2qi52GUFIbm6A99b/UQ5jmNStf2XzFeenb4dLKe1tQRF6hoJzMIS62rnynH81eJMy58BHfvyaBR2kV2OJWy+Zw0wSHmkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrwH6sPtf5ij9vO1WUxS/uRiTpswHlocMts03QsAvg62XncnAFR8doMriaNtvyxVAP/te+PHccZURbzWtRs6lDQ=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKhs7KNdRKZ6EEKSNCvgOdryZoIxa4GRDxtBXScAJRsLI5v++YDUXOlQYnoYkXKTUrN/1y/faamz3CmBX7mkZYqkUklsPLedg/UzrLtHdkxS8K3nXnBampnjQL1lTbKP8xWkCveM5U3JXcBPBPqIr0kKcJxx4NCbbYxePKpITFpBe+Y5siBU9hd+qgu8Ts5oJ4FkwE0MDDt8qKRodQc8+UPwuzZaOJTUfrceh81/ptn1rIVT2RuWz6L2ZU90wazrnrvky0LRLgfKNZZMYfJWH04c+P8xCQLD1kder9jJN7xeYRfE53Zafa5TpquWnixRmDGIrVvPS/FxqquA9d/jG0wMh1vZiw5fqZG3ah+f5lbnSUpwHmD8PFTF5ydcLZ1IIgQAAAAyL4ClLA1tKxtTYsT9nR58pHJSnAwUE13jL8REIdFxdu16tEh8htxuSNRVIf4GpORSCio4M3lQWCD8oFf38WY/slTgQzWj4l02te/NjxYV1Y8+1uKhiREnhzylELfk2QyG3UH3JzHMXmWvK2YY8XmFo3Zc7/GbSJDvRkA6zRkhtZvNy9WWnfUai0n6vIWDw66JFAWUTcuSb92OaMh6U5/RGqoSmwEf/0S+h4y3YXPWmdXNV5NHHr5/IzXWTcDDHwYRBKuVXfdS18hb5r2JPUK/JRNo/LTkEcXYjaDr/z/NGXfjBWpnNNlbFMZgpor6MUKQvNuGVix94vcH4AiQXyLCbC88nB28fGLL6dLUHEM/KdcH+thzanr81qcpGk1VFLjLpCOG9MbX/wdVBz0RMcwN9a286bZCQjL526jpdlp8KWVDYjJihwRVf3ZFoQK62dfZ9S58satlx17QWUUy0S08fWp/6JyfQG4JxdQd12VXXmdBi/e98v0iMSB1dRX47hDfank7dhy7p/Y3pcFTCZETt1d+N6J/LOdL/gwq0t4MQkPq6aMPe9Tjuc7Yn1srMpN6rC9GvHEbaryxOmhvOpIxfH8Q+mQhuxn/iVsjN5XbfZlclpUFcb25qqa1Z2Ary2C0N49eOFNQrAvU5Wp/YHfvqmDaOIL5uKlOg7zSL26Cog5hld9wAzZ9Irkwo92xqs4NunHXD5AKUNPe62cq3NzJ7LacsoI6e8l0egfNj3zUZsTreLLcYiG14kvReaciqxnMLb0aEi7cun972zpsMV+uEhBF7P9rGBb8jljkVAF+k+etprTYEkZMrbj2ZEoeZUNfHVA7be9sZiqVRlWRx2c3YDR/JSF5Jr5HJKfv3L8qwXlz2RSE7RLG+7Jtvgwvfc7XAu7+9EpY45rQ1C+7It/bvqZ0T+d+R65TyFTVl2e+bYo8lpJSjbbEKKPrJpnGN5kz/fnpsGN0bUHdoivqQ7OgN5hLC1EnoFwB6vzXGjTs9ABVC5XXEWpgQPWRoHGBTmeEA4gip1OISjK0wtztWjbH5ydAEwm+N7v2ONrTwPLtVWagixjHEPo7ydHaEtlQ79qRRzTc8jxbQxApy0HnpylXIuRc91SkytNI2CnwPv6KCWefXu2ia31oxThoEz1gDITCmCCtokx436iikAiLOL6I/7N5unyyVP2nBjwd099O0xxLP+qEXxUm7pDcmFupRSD7XWXFgeutkNb0Ab8/IR8q+wwSY0lbL3YD8KW/vkelnA5DWrWYyAvpjq+qaytv/FcNyY0j7kOOiBqSj0JxN7lwWSM+8OHvSQpfI5jtF88coDznPl8rwaM4I7ZOLYUtC/JuPgVDcffcgMkb1l2QZbBGfk59zWKfHIFaH6iS6oBKEPNuJdYcYjyNGjCZsE6ujKyyPHMvbtMHNYAACmjIpAaGVyzBqq+BZz1jdgslPzBYuIHRbYlPCA=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAJaf8aB8hfDrT2opkqGgHHD43yUEzaMVx4yCBlUqGtFYiaIrN2fv2V2JdSZneIVfNrAxxjG7y8Wi3CbO8HSRNO5Qr6bf04hCgSEg0KrLZC3ZjH+TTws5iDIrMhDboguRwhNV4JdiIXtDwD1CrPb10meb8vTyURjcqOoyimJ8wX0ltpQkudqTeUKi0zAK4ajsioS+b+7U+rJjIDrRKjlYqHViFTyqQkpFmixcWjwb2lHz3Tc5MRsp/rR348Cf29h8PZk/PROKE/iFy8+RiLgBUKxfitIBgNqm57a68Hgp6EuFsL6NbX8kZ0QMf/TjtyzLZIBr9pVshN6EcXqR+zhbC7Hnx5LyKWgTry+54/jk5b4zYPoGrOXWD8g7I8uo8oAaTgQAAAAEpNK04Zb+l+4ylWCRogDP95hAleYJdccKEG5vsi+7MIDduXH6X8JNaiDlzHfpix7nxJhlMURB1Lv9XW2KDS/nd1osGccoMtBcrbXGyPEQlYkbWBLlErpSuNRMoP4hqQqwGEx8L10yAvxMd0t9BX+Q/KUXqOFD6+GQ75khn7Ud8KtK1MyTxsuizd9Z2OC3AjSjQEiMkuLcnL9OnWDDpaLVZaBW5Gp9vwobGSyVr6r4WiXEOv/wOvzQAIjj1m1RBdgZmcwNSq/1iJHVdYdQBDPutvsMdezOvvlG1GKjpg9LFYbUijQowZOOFZ89mfBUe4uZoib0t8Thbqvo2Dn66WBdwHKS7tHxhwAr5gK5NtVISXVnyZgH7usV8v7da+R601908kTQiId0hJS3bn6AwBXY3N8wa2fOjaJdavu/B16TjoHvFGX5xrvsD8ss7Z1KRnTFtQ3mLA2Ll/J0d50OSKE1Vn5aGt1X79e/U0vOHusuVbTW1pdOvC9+aTcF9hByT7QuJ/cGEw1UvkE4X5e3etewbjtIsxjSOV5Z5x8QAwosdHO5rHLJRQxWQlEo1UPMD2BrdR+lAW1gZlaPlxtOEpqzaA406yuHQ4guiebKY4QLTv0Cpd9rBvjqA8j7KrRwRyW/a84KvstM1Awsz2KiSypup0U32LSlAKj8AYquOdFpjx7rBmDgUC18yHiYk8Q52woXchNtXOVdTljKY6jTN1n1iLzNcIqI53quAhBbOvY+iZLt4pGDoCyjngNamtBxMIxdFbjczXxPw36Gc+w/J6tAlxbqUpmCwPX/Sn3CFk2ZbBECG6k8OZxWX3gbtKmh4Ho8ZfIlU71/VH2qBcXgQ+bhS7EkF7XzSIQSnDmJzRpWuzqkXwFC9XW7fA1fGJ4UOflz2SFTUHzTr6EZoAXHT5/OAVVygZatgvlbj8/K9E5OmQdNNplSVIY0T4bC4pQus30eaeasJX0ISf/GrqDYgspJlZo18QIKwITo1v+w82MWlozUjIeJi8QGM5LcY4MoxSB9pTF//8XnN+GwGR3yBEiav+KveYuMiy6oVtI8X5crcC8nill/9ftSW5u1MSe7XCmmPWkqj8B3Zg30fGLmhKGXnL83s+dF93Ym9RzPI8a0lI2o853mMu0D43BXHbQ5qq6Ke/xKVvfnvP+dAoWM5k+GjSNGSpeQ+2QW969gRbB0WgVHKD0OPyh/vSVZjmaM+GSpwmzKPk2aNqnoHKpPD5kp9HgIp8AyCstkmD4m475fMwZJMA99I4dBV6PBT18DwHDRo34flNn7q2OA+aqSUhdon/j+KnsUcrByLPocWFuhVX6ngfdAYpEiJ4S4kcaBUJmgKMNEFr4bLkDfFMWLT18BhWMwL17k06wa1qjybbFlbnXWPWCW8p7c6GkX8VyIFGex3XJnnJxbx43sRoKsHLekOkySlID9oTGE1iHN1jWYSU1d7wYrAg=="
         }
       ]
     }
@@ -170,21 +170,21 @@
   "TransactionFetcher handles transaction response when the fetcher sends a request": [
     {
       "name": "accountA",
-      "spendingKey": "bda858838f5096b5155a2fcd8c9182438486892089ea3c34f54a053fcc5f50ff",
-      "incomingViewKey": "fc33f851fd5b9ebdc35862fb1d012c9c8531d5c64e24c60183b8e41b2445cc06",
-      "outgoingViewKey": "cd88ec385b1db699cb79bb01b8f3c7ad5219aae6f93bed61d505cf628d2da104",
-      "publicAddress": "34ddd3f801a590ee5f4fe639abc585ae70167307c5959eb73cdd57f6dc45c59330e0aa09d88843128ba138",
+      "spendingKey": "738e9516b87b4d2f84fa83f292281a6b958c33a9883376201a1e3b5f7de84837",
+      "incomingViewKey": "04148d82719f8452bc7eca338893c57a7bbc1973a54ecc89f8c322658a3a7001",
+      "outgoingViewKey": "7cd46340537c528dd10aa8258a1859d775c36cbf1b32d214d299a0df4b3914f0",
+      "publicAddress": "24aaf6db6a6e0bd21acfd95891e6d9eac05fc7399a294b363e5d3530708ab1772bc10f878b83faa2079236",
       "rescan": null,
-      "displayName": "accountA (df196e1)"
+      "displayName": "accountA (a11d488)"
     },
     {
       "name": "accountB",
-      "spendingKey": "e39f17503c4db8421fefd74760b9d0ba942f04bd592ee12f96e654689078a222",
-      "incomingViewKey": "6addbe7799d8fe71672567ecda4c826c0f851673aef75bf4981687f5f33e4b06",
-      "outgoingViewKey": "335874402a453ca86cdeaf4352eaff48e8a6b65d3876e0ea9bff0bb21df8d428",
-      "publicAddress": "95469aee164e8680ea97f1ef96e670af2c581061460dc9bfd07f8e2758eda6bfc3ee7c001c6c9542613a65",
+      "spendingKey": "e4c3a0263b1825c98a1b541e4bc305c4f7404b43a1d01dd0919c531e3ec630ea",
+      "incomingViewKey": "df40865c7ea5033c5614e5b8e03f00c16b4d35068c2c71a937a45387a5558600",
+      "outgoingViewKey": "fd3f8c3c48f6d3e3c994ae4a1eee2f5977ffeb86c27499668fb0a768dbbe29e8",
+      "publicAddress": "e8e304f9d16996f947cc63930ef3d4f83f26ca069909cb023286952e8922af3735f1d17f665b92e0c8412e",
       "rescan": null,
-      "displayName": "accountB (89cd6cb)"
+      "displayName": "accountB (10dec2b)"
     },
     {
       "header": {
@@ -193,7 +193,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:vRoLb8amaQgRNtVf1l36rpC9cdzbkFj8xuB5XkYE6hE="
+            "data": "base64:ip+0CZlFTHhbDBCz3/uj7z93faT2BThgNMA4kH3rFVI="
           },
           "size": 4
         },
@@ -203,50 +203,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659644445317,
+        "timestamp": 1659989481120,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "4C898EE52565673B5AD0B0F68549210F3AE8791D5071E0FE30EE6BF746B1EA36",
+        "hash": "7696B3D65A37C12AF9660C9B5D4DF20BDDEA354B108A880EEEAF399738401253",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK0QmvJDQZRhMtBB1l4/Fyj5oHhSKR9cdzD9X5TwebGJ54c3uflW4hIzKmuwX5i/K4k6dxTugjJGRL7I8iCUybXTjUIoqh7DCvLxu8xDneVHj5ujJt6B89IH+4rvhiSQCwVG3LN265S2tOgx16x9usoAI5P7MzX8mBJw9ueuLIufy/GeZauXCluI9LElf9WAhIaocTg0ZLnylJWbOHrv2gEOgCAC9pP7ty+SizmiiqASkr/KKVpTFl12dP0kSbcTuu/dGOjl7bLOztGHBhTElWvhRNh32UM6gdIlUfI2bMVSQxg+GcndHGd0/pCqLrJ0S25igFNyBFy4nkyBFn7xkWgQpuxjwq0UJHMVUW+Eia+gI7BllzlZPXyIOwl+L0b4RKtsdVWoYhF6+mY3wkRcTOb/cOPnFUcktGOHGO2G2Avj8xYes0nG2PeHV+J1b9/0y/1s7U2wXpHAfBUkeclj4qLC41RgORZTjIjEDa+Sgl5nuIseW2ZxJZPR8o99SkTAX5fmg0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAweyLG4NwB/Iy6m8jq82DUquiJsPtfiFoxaqt2vIPD+5zssRraM2uQ4gdVY/0NLX8E4L55p570u3p4+alFNWsyDQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI5N080wh7hNwSVY024pALCmpPN2Trc0k7aIX8g0hv2BSl3tMIdZSONPhoK/9Sdpo65ULRAH0WtifpS52R+TBJxVDlMljsMSR1325HP5tRGLrUaVXVZ1RtIPdrKanIZXmQoPpL6C6G0UxtvnTN7Kd1EclZPYUQtyrZfh2WNwPCd9JEiW8LzyvLkjVaCseVCDybh+Sq9eHnnqa9EAptNgFaTDHtRQMLm+nP6VGoFubc2X0ZQApp+WZ/xrkU6Z3W5QahIoUGpQ6NtIIpg7RAFgsFHNjAHDCPCF64Z8t1+VniKTwx+zp2iiH+PSpXN1xGDO9j1ErJ9IVzdi3cDVtdG3/ytQhiSGqoqWbxyX2hKleXvPZFNlXxfkzbrZe15CoEDdaqc8rrik5l3GvujxuUCwXc9H/8WDpYn68rAsTI6lvM5jHyjj6vRafXXqzJxYTXN2X9pgwf4ESpbe/Q8Vh8nxpzv1cnZORvCJndH9klhn610EA1SL/A4Tk9zcYVSMCdW6NQ8r5UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGpzU+DzG3VlZSCM7mK6nsUoreik67O9/Si80E9Qo71Gt+bTcAMAjANTdvAly3zBTqHEbFb/4xI0Iz49fwnnIBA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "4C898EE52565673B5AD0B0F68549210F3AE8791D5071E0FE30EE6BF746B1EA36",
+        "previousBlockHash": "7696B3D65A37C12AF9660C9B5D4DF20BDDEA354B108A880EEEAF399738401253",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:HKyiDCTvfdzXJpHFXGHDrB9PosVGFxfr3nqd4v0NKjc="
+            "data": "base64:cld1UMw6x1NqCW3K3W3QecZ35yNN7AiM4UoCLwMquy8="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "2046523E85253F7A4601658EFCDCF5EAF5C0A5D423EA104CB362E3515DA18970",
+          "commitment": "C9EB5F8CE3978FB00817FE8EEA0E8B116436CEF7BC1D912E980C49D4B84C5423",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659644446649,
+        "timestamp": 1659989482434,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "5FEE93EB92F993F4BC4FC112A3759C93AF0B5B626BAA6CED807DEC0349CC3DED",
+        "hash": "B4AE1A09F5C37E3D03237685857CE38B8B1EA6025FFC8D571E986C7C46865642",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJNPsmZwYhqiXv8fz2VCKyTv00uBWYtWSFYn3DtajzMc/WnLCUfMq/et0cX4YDUGOZYkoSQyk5SLjXipQQ5ZWRuf71l8rD2vcZlTv99ESGRPKN20QipYn7TcLA0sgOCCmQpVUSBwF8JOs1yIJcx7uF84LcXRu29fp89beFDnUb12nL+xNjjKK1Ilhf9Kyp5JFZCLOaexNPOSN3834CB1ldn6nonKiBc0qQwA1x63DCttX3eQuFWq2JZAxOb+B+WeY/fiPkTMhvJ1RE7yxE/OUylRd+teOSq+HmCgWRc88cBECiTH6zYBBKNh0aEmyYL3ZIVglAxh1V2QicORNRkRUzV2XC3iaQ6YJqFp+T3C/zAyQih5+2r5feO3FZpAqRWxYEPfLAO98y4yOASlYoEGILges7xggpFIPpFjVtY8y/tpoqjCElMyyXJGn8pDS2xTE5mdYIW1+CYGhwc+qcpZJ08cewsF2lHT53AxJsn0b0Ns87nfjahx8DfCOQ1jIU0xhO4IKkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0bIbZXbTFBTXvH5s8IYSftsg3GvWwxHGPSxfAoNvRJnTRzUYZC+w69QtVle5pmy+JhaFilkeP8r5QUcL+c4ABA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIRJsuI+yO7REwG0CWGNqST5RoK/NGqyy+W4qeJjiktUTsY0m+EJcOalvWfEBXHHp5I5+zrVDi0NOW7THY0Vua1axJuRmcmzIjjhgUC2tJynptBOkkwIMLv4JFXjf0FTkhha378rQyjiTzfdUMU7d/RFp+3zn14mh+7BWFyQ+F6q4PU/5kjaKR2Nsqt9D6MiF6FmNeEDkfHRtaYlbDGPfJjUcNiv3nGXNZGBxNLtD0ZvqA2uQz4CP9TEoo7afsemFz43l7Poi6bnpYOXZ1QlNnbN/f5uPM9eBFrJnI/kjYpn3l/wl4HRzbI3qtgxuUl1X+wJsozwB9Z1FzJnwACvqRjTfpQ3NHyCDMrtEpuK6o8n/kYMzio8rKeeCNIzCFG4auwXCqUJWAmfHrL5yykFoJnVNVgx6ieUpNNkoIXZl/wmOlCVSbEoebiaph9BokURhZfL3iKcU3AlvMPRMHVP94ZTccRUy3tChpU1RdTYPzkfcqpVQ7Ih3v7Rmm6Ji6ewB7KgM0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwE6l82qXBw1wrKaSW0RPF6rdRxkK4unavq69wsM3ieUnypjInkhdLDlEHvNd5hcTpvujRLIjDbMQ2XVb3QidVBw=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIrZWYY+vbkw54IywH1EGdYefd9pMrsbioaecPRTyxvdiYs2ien5anTvR4HQOJrH+qwaNfZYxSeTJD5xLatnQuw1zL7a3V5xW7zKKn7nxxBDwVLIhe78zwEDetC6TLC6ygO34h4wovyB2iVL/81KUOGmjFX0QXIM6on6GHorPpAUeZqkx8jN4FzLaK952D75KqJCY9KIuA77tiVcgGXpRHKgKyYBTCHRipv70NXwLzfD5P3oaz/KB5v4+scnNi8kb63vAx3/3ja7L+MJbhEX2r3xRvB23Mnw0HfTyxPEbM4crgOWrqEEjVwgLrU2yzb9O7L/f7KaOYOTjZcz1jq46Fi9GgtvxqZpCBE21V/WXfqukL1x3NuQWPzG4HleRgTqEQQAAAAHnpEDM6znQpjWbwulJ9zV4TbcR3ikHDm3pxChAplzhBWESlc+rLkiP51w6ou82lRafpQBwCohwtUZE67GuidGp0slpv1vmj2uZadzfPgtJB2KKXU4dTar942HaRFWLwKw3zwhlGFgKBQgDhHyx2AMkSAeffNwqcMhNNHR8KVGuKgpmagAO/bB/gDbbAHNp2u4R0RkI5pJVuE/yTOCbKRHhPI7Cju7OIJNQenl1wZsFgni3nqvPJtsg34PUhBQZcEM3qmBK34dQ89VQrGrDU57QBoaZVmcGuXg8kq5ue61sQ3vU96VKP4BFukB2GNSrh2Aw9e/h4yqZIIbEbv7Xcomnk9FC59/kBsu0cloLWBaboCYrFQaNqsYh9YwiXyd9d5zB3P03qvxu7GIaOIr1S3AJABMehSdE7q2/NAAnEjXs07Rgb4vX7pGD0VKN76x9cAgxbhtDIC8gjcnu+yAxW8fUr49DWgg9k5+Q26ndCs0dTKbcfDqtybkuN4XbqymE7ObTLdXTrZfLztQzVpPGz34eZvtGBLmwwL1Ss0N9H7jUqxB8lQG+9wQyG8izSIUvOSrR2JE1NDelo0hEi9NEopGPVkI0XTiDYoQ7IJSrlEzP2o3BkNeoZYIIScnJsHXrHu7p8DYvbcXQx9Meet0r9KJefEIEt8TPrwtCEknrYJONj8HjkMxEuE5aBp4SjD336+9ZnuojMS7O39Us9GU+UijRTUXYRB0SX8Urw4qIN5D717nQYMIbi3DP/j3S8Q1ITtBbS+6nYAQJcHM+x8P6Gui324oO5aP56JQUsE/kRc5YK0xv6tEDqqkHjVg+UhEQVOkJrM7RjYGz6UO3NCvsi56e3zXxw/fhGcj7HD+//HediUwmQvi4kWzwyAZ0KzVnVmnjytTjgm2wG5JDDoOIx2V8uIZkpDHWdFCdiwcb47qhfa0dYleJxzfxRi5xPjJGr8fuZOoYFnyUliW7JRfZVZnBnrS0UuGyh6HYpgtFHB+C/dztLurIqL4N3C+kGghvfC5qysDyBOsFo1gPHzrsLCD5N+rhqEDCf1JqMcFLwxHHXhlCY2i7cibyOJwzbp+fqJLoETMPAnHhDGwJatAQABjdNlD0eo5W5OUVZTR0Bil6MArCQytlmVxqDj6VvYYP006/pIdExT9ixSjTzJgsylgy/g5214Du3Zq56Aw+lcskrBGTeGJ4CzSqKUJgxqoreaUQUxUzchqM20B857gtMO5uHeB9ESsHF/sfoU+n8COiL0YrGYnGg108D4syYGbMC68cCzqK0Gxtl7PUq9usGs9Gh5sPr0iZTlEBJSCsyJhwmm3/1rJ9fxMIg6eoDiOxwgKA7kTZbonupUi+uSsOiGCW6FevpPRvIR6rYvPWcX0ZmSKeXzuR947PF+DfZUG8qlWKz77i5P36WF6yEKoLkxsf5GQ+pXfjiTi0apVh8DSfbOUgziyCw=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKOXK+V7PSMkgYLtRq8H2kWlw5p74eFLhQSutnOfRXSsU8C6AoMMajujrEzEkINu85BGpyk0HKJkV1wMdho/yIai85RRxAw/JzM0mI3bdJuS4op2alX/e9s/YDcqyqEdiAucDN7mp+BJ9HMwmHn8RptA7iA0fc0Xe+sB4+dkbOMx9lwSGX53o8CYzSxgo99lbqtBKTjiOONmAWmcYi9gF4jz2at+Ia2/NA+PuXDZ8dMMrkylukxmeVuevYsCvAYZDmLECx85AarUbNYo2zl4UPBtspZB9r9PREaPfXhdhK6E0GYVFuEQpqXjbveywxw4PHAI78cvM6BF8y+a+msmI9qKn7QJmUVMeFsMELPf+6PvP3d9pPYFOGA0wDiQfesVUgQAAAD+M3IV39lmlybvvcuwXfkb5Jg+sfOlepUFUtCMwB9AVfaOZXvxmOKilCOsmPOyg3M7ciaap7Thc9P9FgDsJLFnMLz5p9aalwroKNxMoktZqhbggyHNO0ixqWDxYmoHxwSxGx3tfvXlcaCSxIfZNN4f/n1wQKLQXw5OLCyqseynLQCFTntdOu1cT6uNbVZfotK5agEKW0gAyoNDhN6QfO0N4aJtB0uIUEFIM/2WhepwWUtC2+LW11RUBMIVxexpkSEZOSG8TZFpZ6mCuMUP8rE0SvDUwdyUF2nyGZLGqpUUkRf8In/ks6nyqZgNJdps1v6VW2v9FaU2aE4ZROZLCsA/ASayD+P4tSz3j4G99s+1ZoKsVHpCQcf/9nnPD3pzMjRYvC3OjFmOwcFIZzOgsH3dFMuXN+nd49hax/8cxiP5rMkKWnwk6lzOY+n7xU1l4m4MxmIIx0yXvIjGn0aIUd4g8JOg+ULmeL3K27pQOdDHwYVTzuV7INI/Iyy3F0RZi6GgJI3fgAALZj0IqYo/yEaDrgBIhlsqn5aXBuL1wkJWvcv7mQPum2eQOn2v/6mqL5ATl+O8k555HsDm5/Uzj0UIVpgdbJiE77Mcyrltm5Q8y6xCSpfHImcycz1dd76NBpd4K3BvejA4hoeENbX6jYxveoj5ABfXemTSAK59m+RTQP8xpE19+wAKiiemd8ERWgbyOwtQMEkntA393rBqeW3HJJmz96wR33Ax0D9b/Nkni+wngZN2o3eg+zv16EsL2E+B8gT6vjdHb3MU6qorZt7b/deu+UQJRbEVTehUyNWCT2OMpbg6eJdWeUNiGpO2ZmmJMRN0/LOFk1OVzZ2x5dxT8gEoFen9WQfE5R96YY15rVdwWQzIRMUfA2iO0Q3mSKpsbNKlSOYCwX8YlYZzNDALvdPeMUjXWbvY6hLKmly5nSUQ8JDjael7mA49bhOX1WsC6VEe7sYk+9p7wpWODe1VOzbSWHnbmfQqyL9J/gSLtg4uNS+q6K4gP8iuWWaOg1fFPFJZRm34LT12yD5LVzZ/hNIyO7xfZyylu+uM5MAkvjfFka1XxNa00fYflQyEydN6TAWGc4veYPTjmgl7SecFz9lSWP4g11koLrygo+7qWk8D4V2Rpd/7Oj3ljXgzo0uK6HKYS0wTNZk9+ik2HzA+9ZUUsEPOkMSQEL25Lv+MOoa/UEGhVJi5heBUDBo5SppHr5c0azs7o/glmivGctsrsz0teRciIvIm4mC7/ea4pZq7AoOZ8pz2gXcsl/u5Pr60e2HtzQTyDoLrvcd9hHL1ueb701yFbyY8SPj3t1Xqnb+pSvAp0QkVazo81w9ntGAwBiRry1HbstMV0eHBwmzhpganH+z0xo0EGA34k7MO+7h0ZGks9271fBLUtNUQw+M8R7OljPBXCOAcxtvuLscY9KD2tA+vETp45AgbofZasbwYcupRAw=="
         }
       ]
     }
@@ -254,21 +254,21 @@
   "TransactionFetcher does not send request when node has transaction in mempool": [
     {
       "name": "accountA",
-      "spendingKey": "0ea72a5715b48bed22e51a815b947f851550219f021a1fd714036511824d6d56",
-      "incomingViewKey": "e6df3a1309ff8b295b6abdb92bb559a3c06b13764b5a6718522ef5b6047b2a05",
-      "outgoingViewKey": "95c2768e5abe037d92d3c7d871d1202dee881f3c592d05c178d0658639f396cf",
-      "publicAddress": "be95f8723ca263f14686bd91f4f6265c9fe19a1499d3f4daf92bca535718a4c977d376637cf595180d91bc",
+      "spendingKey": "08c18653b091602248cce5d2a198f67ec043f83a866d352d196f840a5bd82f25",
+      "incomingViewKey": "218e9ece95bba8e8771742ea0719cccc675aa5327788e3a8cfde34733ace0f05",
+      "outgoingViewKey": "6cf805284d45c0d08c8f95d122684110bb073c8af83d57aac4e282afb2359344",
+      "publicAddress": "f5dc97d1ebd33822c251be5d78f12687e600fab22278c997eb9585974ff83747275a0c2afad98e138b4abf",
       "rescan": null,
-      "displayName": "accountA (1de41a1)"
+      "displayName": "accountA (8344093)"
     },
     {
       "name": "accountB",
-      "spendingKey": "ba0f1b7bf28e2ea9c85b4e0a457a0246643e03e68b9c730116f2abfb85dd428e",
-      "incomingViewKey": "cf489c684b32ccd85c550cb85dfdf8b14fb3510db25dc26b0b693ac93710a100",
-      "outgoingViewKey": "965ddaf696c3a4c7fb3c74ad8068e17af9cb57ccf620a8989882012791dd8281",
-      "publicAddress": "f43499e6256f6db937bc8bdee7bfe98ea9d172a07c2fc9597e4192cced51324164d64c1f6ea2ffce172c72",
+      "spendingKey": "6c855b1fab171a6337f46469472c77fba7f21c1a516c27866cf0ad1c6deecf71",
+      "incomingViewKey": "168d814600004a70624f6dca123dac3f42bdfd2b4130c8105cbf07a975887300",
+      "outgoingViewKey": "57087128e63a754566861f13c7c5e83f0612322eaa5e068eb0a031efaa8fd85f",
+      "publicAddress": "80e5cf9016255d741b6a3ba5fb95cc1e9cd7520e929a8f2cbbf211f910428861a547d4799be9b3c95f0c34",
       "rescan": null,
-      "displayName": "accountB (94f813c)"
+      "displayName": "accountB (8eff54e)"
     },
     {
       "header": {
@@ -277,7 +277,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:nrXHDbVgUYPAR3TeaTDPTO7UimlRGw4apZbtL26Tgzc="
+            "data": "base64:Ym/bzAUG87M+mlwN8WlgkwzurgoH2RxUju5qmhsVdjM="
           },
           "size": 4
         },
@@ -287,50 +287,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659644446882,
+        "timestamp": 1659989482654,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "035F4C644784E66895ECF1E2F52A50FEE90BFEFEFA8CCC7BBC370CF5346CEC98",
+        "hash": "70DD3AF0771B635705F870E07006C5BD3C25452C54BD1815B7F652942D7D15D9",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIPH03p/7rEkqKOdwcnNgNNLJjAj7OAjACt2w8js9nxVkWyv7rgJ7MeQgXB+EX5LCKyHQgqPJ33GG8sl7CDzB3siySGLK1ziVWxau9bOPUd73yCpc2fkKnrXQnq/xdO3ZQkcT0aLmEgY1y+2h7xANFGFRRmMeR4T1M37ZbVES5u45KwI+q97YLSJFDIYd/vRXIXrBJtnabfjQxGNkqZYBbNcZwvChdtTz5D9n7LAx/ziqSwMFeS9vxVZxB3nSXTB19Ucx4b24Sx4YBRekUWN2hJ5CWkFIhK44iBUBcSDjehjCmuWudYFGGA95BoQAMorr8eMt6BIkZ49HFUP1UIigDRbk3xYsSLOIqZ+oAchsgzzXByAeV60N6v1OnIPtyrmL0HO2PR+qTtX5eaVF8CRGvL7JG+ralr1T4vy9cCyrnArp2hAYhoXBu2/rddCh7obesa3Yn2AaGpGi/m9Tg0uetcilWsJL5K2XLbyn9HxIf04dF4bY1GRjCLriI/1bWeHyafF4EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqjylH2l3s1GQrQzNEJg4EAR3ZdFG8kf0FD2CNtbCSkeXvzwUBk0YtMGDBtfF/bywNVx75PcRzKX04ZnD2vzGCA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIJN7jW8A1dotmnJUp94L/Fvf8rHW58VtY1zX2daPd017X4kUz6mnCcXXHi4QeUv9LdDGAyNSVuvGJ4YDDyn+/35QYBjtUEekInExZNmYRf7/oYMMlyHudkJVpIu5RmzZwdDvbJIgA8RiFVwC8dbxwNhyA91OdUsqkqymAWHprEDsYyFZDcE8JEWGj3BNulGQpmTrcid+nJ11+bdFPg16E3PJcwv6xEWjVn+kkJm+O6IBBWJajJfGiVav/KwFWeu84WDoUpIk/6WfMnQIEhg2PCK0naxqABwwRwTXgBJH5Do6EGyea6rf/yUPb9ZWNt4LrFZngQYiK2nktBJsAY4Lz5sQhVwlv5XH6BdwTKatnE35W9y0uJKge3gmwNzxVVJKqFxsTwyFfflxReWkbAGaXR4Egc2B3XExWN37ZyUzgD3hjO1jJnsR8ezRSC/iM96LoIw6+FH4TxsMdnJ/XRw5XYAa93c3NtX/+8aFDiT99OlFR/64wocpHy0YinbGIwRwZIOXkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwC/D6zbFCQQFInbdp4cxT0RKXq4r4GcHxV6BDA4afXIJH+x0ZvSU6joEtVK7qanZh7Fe311GOFKjW/0n7sghQBA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "035F4C644784E66895ECF1E2F52A50FEE90BFEFEFA8CCC7BBC370CF5346CEC98",
+        "previousBlockHash": "70DD3AF0771B635705F870E07006C5BD3C25452C54BD1815B7F652942D7D15D9",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:6C1P5jWFoRXlRcPJttzKqxx8sgZ5CvKZ7CvT7RHFIxA="
+            "data": "base64:a4kJUOqreX6kjYNAY3GgdIMPl3q7eYpGmI5O5g2sEEo="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "EC74336FFCCF2CB40242D97B63673454B17E5DBBE315625299B8251EE29010C4",
+          "commitment": "AA127B2ED1A934932350FA3597E20E49B051BEF7A9E164728070B2435C817958",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659644448208,
+        "timestamp": 1659989484007,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "3A26D4D00828D513E3D424F6F808FCB188283EB55BFFC6B00B485CC3151CF54E",
+        "hash": "E3BB57FD2104A39938E68EF9AEB5E5835C1CA0545945E33964290E31B6001DA1",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALVtaVsc3sop2SAB2XJo0X8fCcoIInC0vmo4YZ0BGiVOBUFT1m6awrwLU+55lREBNY7eHj9P6g2e0EA51PRQnQZrdb9fu+rf+QviqdgO+ZHEGUneylyMoR2Y81dRkJCtJBXdD0jHhwTmWq9wMxpHOJTEORyhDyDiwSz+Zefsv6HUtwKSSw/bomYOR+9OQO7HyYhF71eMNPTBnxssryDJ6fTyMxOXI1WEqFsZ/7yr4hg36dHwWCey6V/TZx42EFG8sdnDNNcCBtMqNS03yjNIWJM1EsgvMpa2FNU6ZT4CupJIra3LAApgAheMT2T2705u6bSCfGTG6zJsEd3M+nWTkgh1va67ZKpi+1w8RDveHUplhkYBfmRZCkZBxgHjz3bsCCj0TfXUWTWnI54RXjtFldVa8CCB84+K3Bt2IGWvqq5vOCnK5p4Ml1B4BTRhhtHDW5ivcTPsOsa4z4wO9ONATtnQZx+wlJq7srohH7OA9dgggQp/0ez2nIoRzhtjZLBFrlOA+kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9bCV4STyZZmkXMaL34qTIlR7AO3/9lMYcJSnmNpIQ4L1JR7hSCq/UvQ7mJLGL0d/BLKt3V/63kCe2d4FrC9cCQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALfY/3QM0hEDWyNgN68O1narMe3jbSl9SOEppz9s45IzP12vt4YGhDlqccz+VwVwr5YEiXlYL+XIcV7zttZxP2mpgOmLmZNws8Tnr8hKJIBKpF//1SFgdv+xkWLB9Lo2Xg/jyvtnvm3d7CaYTa2sAyPNHLAV+XZUO09GepAaMsWtcMG4lWozTKZUl6FXe+qQH6mEp2dZHJ7qRPAhkpPE8Y35YxEs4g3p3uTXrDr+e1mokbEEckynfB93TluLgwYKVxHt1V14JzgKgNb0yqE1n5zdH0VMIC7YpCh5zgJTKxiZxhaigC7yqwsoTfueHLH/xqV9F8a2VUFo0dBlP2qIjDHsLyooCT3zE/z0upY+qx8K0oAbjkyRhzKfF2IVsow/GHp0MARJIMBZEkMIUv1WX3jJH+YsTVgaQt2asLwNljCKkC2SXaboIuiP8xcGavA8nY5CeNMYoKZlVawkk8S1Z9U6SPHwH831COxqFhDTDlLGgu1jwgH7UjTyQsYsCNVhBXs8vEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwl0drqaotyCzVxDSvdw7vxNuoKeZnycF3vNcod/YmXAA+RJD7soSgmECHUMiyGiF5IIB0EEfjKpcfkPgX2zlfBw=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIhDad4KQu7MlC/m1eq4iHeQLhbM7WG4xSuL3SHFXHFPOGPaTZeAjrqvq+z7Csd9tqh6UEKvb6JX4frdoSsnzKWflqOD8+Cj/7oveMcKSG/ApJ9ey04ccia/7EOKCLL28QphNQU9n/210DIgZp6TTkFdlDF9hCShoCRlbAZJoG56nw9f/44QqdDrFnL8QMaipKWXUi2L5bVfjdBo6UFwxagrH7YLNJrnwErC9sum95rwvi8MBqKvWXEXuFI0oPWQ/dYLHHEJ/kl47SxKeQpo3Ae4FlkOPOfZI2mKnVnRrACkCObmzx3ZaLfzMFfykvWemsWAIn/CSu/jgkhKykfYVh2etccNtWBRg8BHdN5pMM9M7tSKaVEbDhqllu0vbpODNwQAAADnR6dKVSClgGsZkPjIYUwpiyrvarJMJEM7Uqz3370oc1MNePYw63mNg/2KKxyMScRvG6aeVAuX9Iaw0bwMAF2mRpOlOPIsiCbgjA1dxH1SkLT+XBWtCd389ktsUiFkEQezFK0hrKhf8m0fKgotn6IZ7SHZhriNFfw3z62lGz9cSA8RI+U9xeDadVgB1JZIwdmA54vTGL562lmceKyeWvY0sf4n1xBtjChJAJaQwbDSyls7hiCs1ktPJAAMuFcnLDcSY7vCLpnAL6NCd+X0YQXdFiWVZ2O8WP5KcJEhz/dOlgk1fzucvIW/Eeo5AldcW06XhoP+kkDR/fc2AhXJCmQPDG3kgXIQHQLXnE1VJIk959TNlEKMKZ5fXMqtYXpcV4gZC8+gQFyGnXwuZ5wrLyZDSrhphTkE/xBX8x+0fE3qltcmmDKtvM6Gh766peGGz5dMD/vrma3Tb9FT7Y5csg9BResJefB+rznc0zL+UpS9K95i19Uohe5zWe91m4h44GjQ9Xry0PFCJuPIe+dSjOV9lEKN3D0BX7BlEuy8t/YTzK+zn5k8yaEnjiQAzp1oy0AaPzvfPCpY540tl4yAjhqrEB/K/V3OZTcWPwnmPnBGpuc3J5fRcnTSWkpx48b/HG4qJETYIUktP/V/P+IOVa+SN3ViVANbotP8xAtfK7n6lLdQRMENG6OexObfLS2xJOl0luWbsE0jqXWcT0l0pOCunok6/IhU2FO+lnNbiBh1gi9OaqPIeVfMyBaZ2AdWOw1r0XAGq//mhHiMXMUrPKHqDHSaSZ+aXt8rBQqMT2oncRVRSYVUjf5tMq5N95LOKHIJe+YDNrhe44otviRi7eq2QOR0/SpwmM7BI1lRkoSBPJUQuw7tzeoveeSqY8DRKG0fR+irizkIZvD7bFupHH7nOn7CMFBNVhA7oRPxN2jgTh+0/IVUASPAkUiXH95eo4w3u05bMR1TPGGNm1XZPJjZ0oTHd9+29bP+d/BKQlTwz8coKuuEC29x2DXEKlpKivG8UYdbCQ1hSeOGV0y2Y8diTZfZkFfxdI2U2CFEVCFS7CU3BHaEi4lmvmBK9IcYp+2hLk1FKuD6RY4kKfoxYoL3CHMjG+ydvH7FSDMZTNIazcv7RENBdEHyO8qJwgPhzKtzygIbO6mgg2jgDY1AYUBFtHVGq11iPFs1HKIkwB53aMsR+ZyBNmvr39YH5B1UAnRqTkmD8E1q6xLOeLVRntZhYywhP1wWRD/NCM9gf5smn0RjkSqVy7o296It/lJGhtN0dDdcFYnLvzbaWOFgZdXD1FtUqv01fmQW2mtM4j5PEVUWsnDaSatNz37rTT6BBlDluEl/Nh8X5klKrdfEhPrJUFRjbqCc4+WCylK2pMLEw3cOVwH2Xl6risOEfyDOklpjBYWZkYWDT9bK5Lcdl3EhJELp7H32Neb2+0biuzgKbYo97yZmCg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKmaccCbdwwktIvH9Qe/OBUZmEYOBg1xbwwWhSjOCx1WBA7MIGXUr8NCyhn05hc2f6W0bCjO1uvAXVrkde/wHQA2ctd8dwwWvnYhr/KbS+88yj8r5BmGfT864DpnHQlpshDQ9VVxj/fG8w4pDYeUaDrCxBX+2eEZvP6y4+fYPMe/DK7dlFyF3Vd9CiFyFTaIiLVWmuZ5zP4cyyox0ebNhqQWXDaxbANFdltyZxS8PFR60HoLhT9IUN1c2WynfS/KrHuG3NczDe6b/Z4FX/7G07Oqrkxm2VmzKWzo5CN24VwjEXqueCn4TI//iC1wuVfYcXH9230Lnks0OY+hReSR4hdib9vMBQbzsz6aXA3xaWCTDO6uCgfZHFSO7mqaGxV2MwQAAABb5tS1jegZiXfxilcL38OlM7qIuPbKT1XZp6RE5gEXiz+uxv+TtlPUyrwPf29RAx2bZM+tD+r0+N/j92XFsh2tJlDT1DVfoln/EyvnS6035oWii8Lm0MAxA++CBk8lBwihVKuB5s+C57eHEOdbVE+Ov0ahD8/n64mnoUZE8cMK0uZhYraEvoRDMWVIyWrA2dyYed2kcl2400TX16PJG/Dld+py80/6FZCgGkjziZeC6jhrshgnNxNZvW9D2MJXFdMOL5EyzRVEDivBoH2Nv1dohr1cYv3+8Frw+G3PLkvtFZGG6xj7pE270T+WEThs13253QV/UXZB9K3qMl8+W5+FYpEKOuUoS8WNnmxNdvJ8u3zIKGzYxo+JMWILTd+mWTPReLJ4ptnJXIpmYMOok3ZrVJhlE3O7H3WGZ/z4V68wzGHKBkSndrOo2HIv/Cz2lD1bfS1+vosxW6FHWbK044pOGlNCPlNdnI6GpgDcfDVkBRsInl4mpRXQ8JYK4419mDxFRDmhP5+aOt/6k9G6njFVJAEClUbwnazEVv0jc3ZsFhLSndbnZWVQYNW5eoHb/QLRFB2NtbNoflCEanjoKR4D5IMnER3zNunQPUrghelAoZArgMhIj+wxRh9eAU6kVkAFRaM0dL6iBDtCG73bvfgi4x1OKHhqIAMhebK0mwJMf4ff0TspprASmHoaE1ziUc/OXyrKT+oPnP+KkZJCcgCAmmnh9hGvZCZmY3+KFJ4YKWvS/rfO1l88PZpyYwTWdrBuEBQUMLbvf3jo3RWnnR1ECHajjMvI2TJoCdvf4WTqjN5T0KhiBMrBlECOovyyMdGwBlZGlMxIl80V2SLZD9gy+Iys+b5DS+UYudnbveNh8YtOtgfgVrAgQKCxMxJ3cAdR6PAN+WuZjSzKiJxPrSRYz6yO3gntHF6GXnwDbCTQfVL/MIlZ9cApCiN/k0ZI8j3XrsKGYHv1o7JAsgJZikgriejfaBmnMBximGAkFLm/7Cl6F8XpS923eJlhmCbBuyiBuFU/VOA0zaFCNI1tZkaumIhm66GegA38F1K47PyTLnfv9hZlDF/zkL/N2Mphb3d4mmnGNjXe3t25crASUisgaPmq5B/trZJPdMa/h3BuKLsPXB8/htjvvpC/R3i9tbAxcWzFgYYO4lQ5+6UNHpNPPrBxMq01+hg6xWM9ZOUfY9OWbdfXnrES/o/7Dbd9s0m2DoNwrLszGQRuAZtZpDdkqPbDzR6f7l9+nz9d6/aw1ihjp8sWEacQBsnaBudeXdMalCGdcE6T9jXjXEr4qvkdR3xCdfgPRjtLo+aXrf+VeiG42xBMlRwwmOaTa3H7E9KeIgfUD6H7rXqPEczDuXbsPG9F8YXwUvopKQHnUob9+NWjo3CimmBoQuibVFkaaiUTyPDJjE2Aa6prB/ZqFLgmeP0QbQRFryhMTZ4ZVg1LhBKtC0n/Cg=="
         }
       ]
     }
@@ -338,21 +338,21 @@
   "TransactionFetcher does not send request when node has transaction in blockchain": [
     {
       "name": "accountA",
-      "spendingKey": "f6f7080469d5167269761f43a703b4bd9ab2f63999bc93800cb33b9e7c233016",
-      "incomingViewKey": "32598322beec39b0d3648f09c0cc21cdff899f07de3298bda4c6c1ca9ee96905",
-      "outgoingViewKey": "6a69694d3b0f333f56d6f2d59450dca8a212c6fc8467db18440542a6837fae91",
-      "publicAddress": "f0eed2beed2094aead7cc320a2d348feb212cce1f4493346266335502f321eacd8b1bd1e1be15c778361a2",
+      "spendingKey": "d37e8fd9ac1ef998b50675f4bcf181d078a16b69dd47530e889ba7c511f5cf4c",
+      "incomingViewKey": "f60d2d47cb356798d136a4ffadee9c4548770e2feb54f5f89a04dce072093b04",
+      "outgoingViewKey": "a5bb7e9e414b2d2ba49fed15beda071a2d3c0637704dd574c36d3e071abebf9c",
+      "publicAddress": "4b0c2dac9b8092b438f69fadd866b6acda3f44a557899cdb1ba95da871baffba5cef557d65822baa2f54cf",
       "rescan": null,
-      "displayName": "accountA (2255539)"
+      "displayName": "accountA (c6414d7)"
     },
     {
       "name": "accountB",
-      "spendingKey": "20026e06661d3a3030d924845d3cc217de5a3ccd4f4c153ae180a0eb17bb1d0e",
-      "incomingViewKey": "c4ef78232fc3cd4409b895c8d97afac05b79b5986c7df94ae0205a36a7e58303",
-      "outgoingViewKey": "ca923b3c44bd42e4b365b481b600439c3cc9c8f75232a4ca1644c63864a290e5",
-      "publicAddress": "d537b52580296f298fe3b2631be19b598e6c68ca767b31e4dbf19d2fb394980044751f4ed70996080cc66a",
+      "spendingKey": "3179415115a67cced5bb4a738d2bef501b093bdcb36026c198875deaae409ede",
+      "incomingViewKey": "a604f80d581577183e3ab3d0099a9bfadc36cec6772fbe476f175582e5eb1102",
+      "outgoingViewKey": "ed6701e3600156e44d7d90c07841986cc466ef50af7a53ed1416972703ead9f5",
+      "publicAddress": "ca5255164bcbd72b0e937d53069ea32a4bba2543a981feb3483ce0e75b4591100795a4483b6ab0a31eb70a",
       "rescan": null,
-      "displayName": "accountB (ea3697f)"
+      "displayName": "accountB (48bd1e6)"
     },
     {
       "header": {
@@ -361,7 +361,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:cxRiLC1sL+6pLsyMZbVH7QPOOE4wKL5/rT6u2GtjSW4="
+            "data": "base64:0G0bFov305A+mGFxevTsGyJCvuiLIvT7pIpAHwiqly8="
           },
           "size": 4
         },
@@ -371,72 +371,72 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659644448443,
+        "timestamp": 1659989484210,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "3975D69BA321680DB7C9E5CAD87CAA5121D615682CD09A5A58377E0214C6D432",
+        "hash": "112D0D88E271CF4E5F0133F6C609110F0850CC38EF9AD4B08CDF970C12534224",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKc1jG1Wj4pISYlR6rrCIh5u4OS/jkcUwAjL9FYQ/lWzEugwhXX1UiY7wmFae6pABasJeBCRWs6Qro0yrV1yzt3wfiJvdtLIACmEkCEnpgNvOAjW8I3BIG8NyRNXHEd3DhMLWudSGGSMiegh5ypO9fQf+rwt1exc1YppWuaCKnuVKXog910B0LQC0ftr6BwesYiAFepuml8Ns6lW2OrqvsQL+wiwtBUsdl3l2LaqKJL+kdmvEeG25MwNnPyncHEWeHOCjwlPXrA2W4KzgvHqdGPG1OBX6/Tq+nRtKbDR9bBzu/nD/q7nibvNFG0EWEyCBkHRBZfxsRDGKGU0r5y1aBGrXCtybXVM2lRjbFCWWY+SuazsWIa2MJLMjuGkSUw6HtKgsq2uppTzhf71cKmct/0viRBart3C3bqGh27ffw2U2cUesZ5OUCRw9s50QUj1ci2VgMCq7fwGxEOcxMyzFClN9JEoQ1Pn0h9JHWd8zov2bc3RCXdxqXSL98CMV5uSOV5AD0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJ/NqlRvFf8rBA6SP7VtLir9WYfl1cRktxUEf2ysYsdWGO7HUIES9zooPmHSjiSG4fyd5d8Up63bM/VaZCuwmDA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKJ6eXuIiiq3fSdDh/pjqvlgJTmFVW1d35pEES7OXj/D6ouEGyc+kOSZxtalaqEjDJjrwIvnLek3foLe+eXXCfZLqOUnBdUba5p6qSQWydZIIDRaD0kZdbSfPubSmI1wKgcRyIiyIzj48LTZK8eKNfpN/KMshmPNEdUtvVIFi2ixQ6mX+KulCKlqoUGNjX3+E5fDWnnIqNz9ptFCBwfWh7UAipnoE/4IuWBt+gnLGipxMoH9i13vxL6Ga4vYMewjHJX3l/QUMscezArr16PqWZjX3Sy4SonVs9Ut4K32wW0bDA3zIZXUWzC8TYlfDDoAT/+zSiCWg6VLHuXayz6mkTLqnlyBT1z2SSHJ7Xgonq+W5DxCYrb9x+T4pKU2V+TuYZrYO+5VQf67/OOrHN2C9I6LdGqVlkN2g/vNE5Z4RZTqIc3uUk3G+40KeyaLVfqEagLGmxkZKKBcI1TxPUyakaYFbvwYgPqjPAkyDM/NaPq9uosQiVMakh+M1F7s3y6fnutbBUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwLQjyPwo6rGWm5nsHlXBfs8hrde1kYkZwrWifGCwxp6EbCFUlSNmut1qf6KOu2X6AekFI/5pXYgF/YQHowLtDQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "3975D69BA321680DB7C9E5CAD87CAA5121D615682CD09A5A58377E0214C6D432",
+        "previousBlockHash": "112D0D88E271CF4E5F0133F6C609110F0850CC38EF9AD4B08CDF970C12534224",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:5hxlZ7KfUYtQXIhc3AhuROGwNUfZUutG44+bNuhu4BA="
+            "data": "base64:3jamOzcD3XZ4jixnit4MtbHa44SE1ofik1uBZ1A40lE="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "C1CDC74473A36631520102411BA1A59850156839DCBCA2CAC4FCBC2652B6E772",
+          "commitment": "EA4E44DE3C0D04F9B16A94BEEDB60655411EFFA6FDA4425E8CE7C1CB5BD44C54",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659644449863,
+        "timestamp": 1659989485566,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "78A8C4D2514B007421C319BAFB332D3DDD60E00F1DB90AC7576A3639C40CC1BD",
+        "hash": "F583F34788F902CEE58B70A93FDBF7E1ADC68BA60BCC22066D8133CF55A8537E",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALFVlAs6xJjGXv+9lUcvHdFtXThokvZ/TcutFbMwRts29DGglhAGC3HCUkWLQA2hxbkkfXbTgvZY3TvMqYLd4tjBtbtfiUEvIKGRMSDfTb/hBudSsJJhu2KpjdUCPxVP9QpqbXeuFP7W1zt+ALsDy+Wl1QA/Lp/gtNGwhWvMlrKcN6A7bNhZghDA5/1Enw1syI/qnPUmeLVw5LQVkg2r6JkDhXl6DM1AD7H4KcXPuyG7BxlbDNk6n/P3BP6yP5Kxn0g+ENi9xgNaaq2e99JfKoMIQD5jzo9k7hUU3dAkO2APlvzsq9egvow6TMw3wBhkUiw7FMcDwTwCDHu8WnE511nucJf25oQkBqsmxuGaI79O4cEVwLP7HC/sNZgdMfPDyZW2osE/+p35FOi+FCeGem74cmIvuju66esWfe4+PKPvb9gnZWXcCCXXLcA7Y40eZSgBhYJM30wceFc81/75Watt59ZVrwea4IQo/6H3p+nqAqka2CYNtRfb9D+icPPcERDwV0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmIVhHExTrLU6XRS/zEyHehIx73Pa7mRDD8dNarjzYtGsXWM3tF1ScoIhXvWa1oPEu17wBPflsJZeowzUp8EiCQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKkIjIu0V2hSVGVMoQGDf5+KALwpSt7i4OqjAQeCO2quuye04TYDJ6TE8L0q88Y39KSyk45VsGOMN/8xG5MEm11RAEgVwG0LUHqBL4ZQ1rUDY/lV1JfBBvErzmWE5lQElQeDR6LcSZ6UyVYywCFRmoO1cE9VXWBuNOW8OMFgUgr0PzdiX14B1b3aGUj+jpFGS4Pm9H85uIiyDLIUIo3P6sj889FLTDmfCWxfWR727PjSv1+sMqQX4KPN6ktPLZoCKd15aKbL6ADoPPwkI7EZc/OO//QM/VYT4kFJdSMFolDu9Nbrcjj+OAoFF8nnWqEB6apKtfR2lsUkwa1qxcJ+IQo3AjfgszvtbLCcoV9w9v3e+enFo4psLvUMaJX4lhpjzj3nh+WTk7sIkr2P7QQH+364dre11PfiHkH1qFJoStbIn/Ml7douw/MMe1uijZbVnD0y4bW9Lmd79WBVCIzZd1yjn7l6o2iNaZZHU5TqBwNBDwm18MGocTAjEY1B+I1rxWernUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhYujfaWwnvgxGj5E6wnBDAetYa91Mbz9P2cja1V7LTzF8xhUfXx4vdfyATqUq8k3qvT33OefORgO/TtUhn5jAA=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKJ89EbayUHVLzLnep6RkZEAdb7wNQK9ABYFo6DXmGiH5luFHj7cT63oHjWpHfUWnoHHPr6oV6AjS8l6884l6iigf52HmJfsmUEoHdCTOgHASyDC0VyvZa5Tx5ULORVhpRbZzgigsbRFlF3lRfYubi91ZF5ONlzT6OFGKcck0pGkI9WZlLEz4pSJRr9vgBtzzrYmWyPxV8LPx6xkZvgUEsqVUPN7cX/KV2e9neXw4gvfassWtjbXIo6lA72TOQW01Pf9LP79gHQtIa3+5ADIytOsqdep9JA+FV7JBQRgfk6fdT9lnhLpL2rNY/Yh/6KeKDDZN7INth7zM27CgAEYdNhzFGIsLWwv7qkuzIxltUftA844TjAovn+tPq7Ya2NJbgQAAAAO0nfYLoLtC0dBs/hSGvGLrV/IjS2GkMzHMBVX3mFN00yoEeYnSOde8250HBSrQ8q+eOfTeLCTTuusJg+lQi1dYblSb8x0B5imykxzrrtD9APPG1g4dqCuTeCVsGzPpQWjxs1FS1NR8hL/CSNpZv5l78ykZzMZGaAxoaEuN8syLTdLk1AGtH25CcdWMAllVP6tvOtwyncwvpw44/Iz6xmbKT+E+sx2we35dO4/d3lox+3GvLheSIvf+dxDrFw9aF0WWdCO96Lym4lfBASr9e72pcZFqWK25bfbkmsUpGoYP0jaNPAFwmVyVkEGwOgQMgCQCo6oTJQdPOx5qRvKjiGi54lI+f+ERwlBtRz0kOSGqpKZd6jqk868doo3YyNl43o/BwizPwsQDP+FZVc/Uq6z8LC8+R281wZZF8LWIF0gK0JI283bCZxpPusA3LiaW6aZKdmWmI+HBqI5FVeWMZARQghjdLLEgmvnQ1kma78e0elHV0rUAoEyRDyf9Ui8leLaziQBWcXhwC3e13cnEnSfTupEKzZOXqxF2oVuVS2bUQYqO3a/0F8uWIiTp+oCrW83etAb6ap1Gsz5eEUwV23otRVRqxzw0LzX9XmdgZHxJol1UBqfqnaW0IGweVNqlxRogOf25bElpD4CHFX7ZQBKrz4wsVWqYTFT4qYWBUS8Qfc0dCIPBicRXdXMWw0lRVUY8qNnHPDiwHUhH6KXH/eARx4TDlAa5z/cCnqe1HwG+W8QfoqQo/PDNuLCoOUupJl8UPrVWTZm2I3pBTaSKpaepFRT52IBZ6TsB4g3XzYujMkWB6IXYr9p0n5tU5Yow34s78FXzbNwCwgCfhMs8xaFJZNP9TKXFKUl4wnzv5GnLws1jQIWPbQwerD9+ScsTDUM96aSfmHC9OkizdDVjPMC8Vs5XEnJtVCj2y2NS4UKkPQOkY5srRBCMWGfoEuWPL0YzxkXaOBPxwYAnipXLSM/Fkw8J3LdLXCn2q38KcHFUArJj2EIM3Fm28i9lQqanDyEpRzGpAi/L/zCO9k1R3ZshO0hEtoHfKnBOqLZzhq3BhxOzadS9X4rMhyyIafsuYoy8gQN3X7fLwnkGpfRvWHIm3qLg2VFpce7q1ZAvnZV5SabbTYx1iXAhqAA6KKYyec3YuoIMhj4Z92gUAlo69+ugPsKynSXORwqhGmHUpYbEj3roA1zpWxJJiMZnOXsPAsSqXohCnbPLB86DVFDq2ibTKJUqj4nj96F6Sr8S3x1k3ybTgV/2BOualQf3+irbKNeKpuoHuZdhvLu3A/F+t6AF0WjMxIIhBcYz6XVMkFAZXh6vI41Sqx7wBIp8wgbKi1+Uu1rFSkcM9lwLwBeOJlW/lVwxBBc0ESruF3e+0Nvk/vqF953CwCZqEe6HuNg7bsKEaMNNJw742Imodpu3VIcaFmmWMPkC/n+jAjWsoJyXZSsbPhXDQ=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAI/jFXhShOcCvxnuV0vwYPcwHbbJLRS4qcxeuMDfuinGDPOGYeMynpDXxBAizFLH9KvZZ3EyoG2kBisftWbSOH33zxmcLLLw1l7RhRAdIoJWcpqTAF8M6LQaMyxq2D5NDxjibNDVGGm0iP0Jz3e5f+iHS2vckp9b9f8OJUKEwN8yec9l1UNsZ/l6ezz8nyLmq5XI5D9XE+FlTQ4nU1jxj7xHD8iHQoG1Lju/je0b2oZsbfYEYj78r40uNW1+cNUbwtYZNt3k7rXdRMUp0WZxMI20FkEWbEJCR7lldE/fXamLxKAQVosFgVc8HAarzlbz2yQwZgoqm4TS4y1DDGM1J6DQbRsWi/fTkD6YYXF69OwbIkK+6Isi9PukikAfCKqXLwQAAADMmPvda7H1WBCl684N8ghGZ/bJ8xOqx2MQM8ndApSOPOjAckae+zyYs9ekfcYPTqW3EeuSDyNzoi1Sxj9lpeDNN71n2zd+H8Dg8xphOLoCz4uw9jkQScHyeOOUnL3H0QGp9C9D4Ecs9ERSP6I6FEF+bE3KDPSMKC34v7XzHvoLPINNi+9HdRcKgWtZYYBNCHqo7VWDMItWOn6izR2MDagy4NQq1lCDbR+3YYJJ5hkuXJ0UU7wK8YrKcKQlsfmmazIETgUY2DsAB6ZHKhKa4WUjfAHSQYQFYBtdgEYK958FNIm+IdlZbLrQhxpyAbJn5EaZ4Ln+9SgxjHqw6TsSZDSIMRPZBkJmQXbXey65GBTntj0EtSjFhsATh1h4A/E4V7/MBbas3X4PoK84cCh3/5wCCrUbjCKaJf8VSM8BmERuy4dpnq+Jg75P9xImzelWUgnpkhgfwJKJIM07R96YmmoEZbulAmae/PSzHY0uq3g5v0sQmkkyvxGRtwRF+CnZTrR1MT7uEH+ZWUmwyxbICiUIL04gXJKsc7OIvorJn24HmR3PUSXajvE/UOBER1qzF2KkZVZoMIQohA4D7R54+OqPGDc4dLgPBoD865hAAMVl2nNLo/x0NMTVbUukZlFNAQM6Z6wXSUCN8sSlL399Qc+Q0cuTqnNzT7b3beaH4r0Ym6+5OK6aIYKArCE26PFxpwS5ZmGx06Zvc+BZkKkZWiCNALN8XYnRfS89tfGOwSjpXyNcyKW2zokW5R24bDBgi9UiPuyXOqzhPvMCtkOaSY1GdrBRVVKdh9Lpp35qVeiozwply4GgGhfalaItMFDHfSZ6lWm3j5LG51/Gj60z4Zk5nMPwh51dHXyPEg3Xc91d8zRe3xfXEmUlcz0Yi0DVp6Z/b+h44yuEzWt4LJFuce6w6RDULAf9X9fj/N5BrCyFfjXqBbNZAseRiE3ZeYMPoeQckk0PrGSDhDZo4AYyWAi1aMb28Lxc9kpST4axIQd6NJf8PSpjr6BtfifEqdA0q3iUmtGAwSlU7B/sOSNaBXQk+8w8AUaMMI0eihq/5qOa7igW19cGubP+Ac2oexZX2knzJgiMHV3H9PR+wOEW2rPl42sMtktfUoQRM3opPbyZroh/MUQ+IipK8f+kNs3E9eXMxBRRJrGa1BdNCNGvhyCN9u+6ZlB3zvbthVVNzT9Q3SF1niQEtznahNGzjJYgN+v4lbWJj5+FXLFxMFp2nlqEyxiOhGQZYs558Fggv6bceeBhQt2gW2PPWUfPy4eUiEqs/pkyCvJh7HEdGItrbYwi0ei/qoVuSXKDnEvH66GHJgAu2Ox98urDo5PMk/hZSYBFVwlTcUPUkMMKl2IRK2HeDMOY9zZFBWXI/NUlwzCqVcGGgirSbj+/T/ker+1bmcLcQhCFfKZOWdlQgNVzTdVcMGxtiGtzTgh4GO7fbyXvzm36LrWOAQ=="
         }
       ]
     }
   ],
-  "TransactionFetcher sends request when node has transaction, but a peer does not": [
+  "TransactionFetcher sends request when node has transaction in mempool, but a peer does not": [
     {
       "name": "accountA",
-      "spendingKey": "e44a21c6aad49501f9ebad09c28e1975859ffcfbbf3f4a8f5ab2d01a020bd4c9",
-      "incomingViewKey": "7380c34b06f439174963f8b23f57bb1e1201660cd6341cb35abab9cb4130d300",
-      "outgoingViewKey": "c38480cc9fce94d1fe5da67b1b33c26aa1ba48d334c85a6c09ad60807f9c2ca9",
-      "publicAddress": "bcbeaf07f3dc52c1fe588a6533c199c54d9bd02ae6bf1a780ec1321ed1a583269084af6474fc7cb3e24ab6",
+      "spendingKey": "4378c9984fb18e60dbaa35d6e27cfb86563f3e6bbd76615faee7da1995558ddb",
+      "incomingViewKey": "b5ad34d62cec14c55346d09ab669bfb16c6f722953e469a327d0b2fdf3aa4e03",
+      "outgoingViewKey": "1f1dc2d2df0d89ceb33c296d94a556ffe928f5e399acc7fbc21d9e8455df90fb",
+      "publicAddress": "0592bffa85e3218d742ee33d6d7d6d2d0f7f72b1efce2e724f988d0f44ccb51017027e0387a21890bbab39",
       "rescan": null,
-      "displayName": "accountA (27ba8b7)"
+      "displayName": "accountA (95c8e6e)"
     },
     {
       "name": "accountB",
-      "spendingKey": "e348354382eb0e55cd48a2eb80099b2baf41ba7b1a2dc55c982d9fdafab5a7ae",
-      "incomingViewKey": "664e90239058bbe089d70c2ab3d2189a9ae53ad43713d997a993e139709ed902",
-      "outgoingViewKey": "54278dd1119af89947d578b903055227f5990edd5ecffebeb561715792678e47",
-      "publicAddress": "95b27eea5e32ac7b9c617f8d202caf3b4a457f119d38f8ff01db32cfce8f73f34a47fbc6ce76420ae18090",
+      "spendingKey": "5f84cdf8bc3b09ecee3397280afdf34fd7dac2b1ed4a80a4e6c950961dab18b4",
+      "incomingViewKey": "0b291447c827df5396c9e1d260909f3d1564f03e0855ff5fb3fda187e7b1e607",
+      "outgoingViewKey": "85dc40edff2400c22f950c6717ebc97b7f3d1c42953e97a876cf24708cc4f49b",
+      "publicAddress": "d0416b0f57f2c9a036ea44a3205bd5adebbd30f71912dc8485112865f2ed49c49643fa1d43d069807061c2",
       "rescan": null,
-      "displayName": "accountB (385d870)"
+      "displayName": "accountB (866f5e3)"
     },
     {
       "header": {
@@ -445,7 +445,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:dQH5RmhH617qQDx0ySO6NOW5NifxGQOWTvSzgi18MA0="
+            "data": "base64:Uaq2D1hJG0OMuNsHDdue0NYwSorRrTrkkEQG17SyUgo="
           },
           "size": 4
         },
@@ -455,50 +455,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659644450096,
+        "timestamp": 1659989485779,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "A34611AE1E98EE0FAE2E9DCC4C89B8810DEE48DB11E98F35A19E68F71D19D862",
+        "hash": "8868BEC9705B14F3D8B3F14B9B07C66CECDDE748CDA9812EECF8398F4CC54CEC",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIxcolw6nscxID77vVqsdyCpegMb8v/dbUl+qFI8Pi3fYFNr0nM0yuzehfWMy03aZrh5NFcOl7r+othoDrljFkL0EowGWMlsErTmCeP4NMNCgyLeUOMNw244Ol+KgtVutwaQZD4dhom1Yp3QvzAs6sFYCB+leRaUfjC+1sQxG0x6U6RqmiKYWnJYSikL8iM1nYWr8ExWw/AYguVOwtZvjCMZ1VFWUfz689a6yu7QZx/4MscDZveT4pHFjAOjE93+aL52e36d1GVIDHmF4APcgb0AC/MBxrL43I5Vx+h7ixTBHuZGsZW6wuRbxgM+KujYp9aKdtB8HxnTXfJCKHfs8UebmjMVDYbLDZW+bvNK77t22sllgD6n2WhVwqJ3yTUwULInrqMc5FQ/QOBxCoVapavteoOPR3TorM4261BUlvl2qSvAB/C/2wTEoCttEdBrL3esM9VpwbMVV9IiyUYLoh+/c+rjTQA74lTU5Ira2Apt5IKJvEqdHI+nYbbKUl0d1hBZ8UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAHjNc1eNVhop+11Ee6xW18omZQT+QfRwFyoFqvRXzskLQCMPojFbE45chp7AvGWzJqZea270/vN0LJp6X/LMDA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI8XBqiLhEjuCBqr+OsELJAO6Bu7+h5DmwNxZ8FzPjil37+uE7ZXhp39gD3XDlES65WmFuqPJHOavtG22dKlRZA3O3ISQAuuZp/WHo+Ek2GevDjHy1fc0K9l6MeONco9AwTBXF5N5J8oXnGETYI7kdnkAFmCTfJB6Z8lSk22SY2iu3XkcIHmhKWHCLbBGmlotKdPSLekAmmxicOQ9NHp6eP6vNdQ6/tmyT9KWfmcXzdfe/fBjTp7tjw7Pcj6xtVl8OPrvSb/nE7rSgRrM3ZpeNjDBBQda7qHobgw802JDC+wnRF+AsWAUEkQK/6Pnk/zM+ZI+1vFVIHN1ZMLPGh1nETtYcZQ/gXDZlLXWTzou32MMLLqV2E58A592L1bWw43QyWAJF0XYmFHbuVrMu70WhedbLNeWZTbrJx8R5Rnx6xIxlh2Uw6PywKpMqdnk+VC6puJuA8r261WRpxat++WTYeTho43L5Lr0q7ywSedpiRHckacRC4CkZqrzQrIhHgWz7sNwkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbAaz9A/TYQ6iW2Is0UsWVdRZAaSS9DF8qMqBOHFPPK5iIJlEO7e72jMbj1QxdLRuNDiVgFZmFktdidyaph8TAA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "A34611AE1E98EE0FAE2E9DCC4C89B8810DEE48DB11E98F35A19E68F71D19D862",
+        "previousBlockHash": "8868BEC9705B14F3D8B3F14B9B07C66CECDDE748CDA9812EECF8398F4CC54CEC",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:gtuMK6T2NmdlbltJEHYGBIc9AP/j1Jo5s7n7XCAxikw="
+            "data": "base64:SmalBPrk83ieHC0UA4ABq4y4Io28wmCKuZSmCn+V63M="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "7FDED1BE05DAECCF07A0269D5878DA48A321016B8844224383425B8BE76ED4A8",
+          "commitment": "BD120725369CAF4B6285675C3B0B959D79235C87DBC55D2693DA0A207BF178BC",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659644451443,
+        "timestamp": 1659989487099,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "446F51A34DC1BB57A32A3C239B486632B434373CE2490D4700FC2F120F310077",
+        "hash": "DA348D4947EB747D2A7A1E79D475C2DC7CD0AACB2162B805CA44B25A73DEABC1",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIe4xbT2CsGffr5nG2t5cGIeYLiVwAgAIJPoBGYph4CI2AsqkLRJIoywnC4ck0BlO7hoDh++zViUogZ39ch34t28lKn8SjFtpSXb+StB7Zpi5xzXtg0/m/PtXYrgt6ROmxX9zCAyu6xCUR47SFxQ97W6ryCOQZqTCArfTA1OwAZnSmESrSyjRad9WqGABlusuIUdjCy8dNdRLCtVaA4bq5YH5/LIx6GzkcqgCIDdG1y9T30SKL/7nbqCV+2Ocx3otyuamvlm7JscQTacp3C01NLxe3NlW3TudShQLepiJDKcWYFAtynR56BED6z8QzOPgUCtiD0HesjG7tIIjfGYBDFh/6tsEdh4rfnr8pM9sBl78c6FAf4f3KBPcAmHTANaCWsrQZjQPSREfjf2C02+b3wnyWgamP6jmJZgHrzfVk3kLq4LrgdGSV7VLok+3kXxYwBufcXoUap49LqoZn3WFlMzP9xUvDdP5UDKDseTh/PuvDLovW6rG7A4OFme5r/34FbS/UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwHVYb8BiYygvwcOmJpLbmHBDoPj2y0NjZEPmXKWaYKUlGV8Y4dPvo8LX9tGMPwDMLLyrbhQJb23EonOJwE/kSBw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAI5LLvOM/46O7N9EYvc2fKHXW/BI4vGf16tdXnlfwFlgKXk1EbnqH85bAKePWvOTP46Wiwbty0tb5s8b+SFeC39ChM36ipX7Ng+u4XVA641rCZkY9NPCVFRif4EWB49KLgO4lcycfuuSxdfMF293lTBlJBVSGsGBANjjzilzKPlR+AoIwYxDz1GN4iDhJXLSyqd8aGwnTW7V615vKLlAQZWtY48V4x1A4zgD+mG0EsjqBXKVbQSJKj0rRufA4CpGl49fdHhR/fz0zrHDraHQijD85uajzAZWzQKrKAKt/0C4ZCqdsivIsSM3Mhs2oZwY/RGyJ6BO3/Is+ez/B2TLkUcQ3LyqcKfZqf5T0jAYcO9eyTknJA97s/9++uQ8VrHiqlabdNIrMLDk/3hvhxSRvyrS+7XJqn4NFqePmIuoV11qoGpL/ipcAjdTrNGVR/CFsQlidaoaX12jEzo60xGWjHQNBqXF4LLeoB3OB2EizllG2TEDtn8M/7zPDgHKBsbw90oRPUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBM0cXFhQPT7JnD+CUMK5OBq+5WrTa1grNXx9RiloqJkoL9nWmPDLHA4onZtAxCmlHlTcviHvIiprS0xTWTmXCg=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKtW0Up9cCgYHzzmrBthdvQMKUfhu3jqMvgi6VSEBZH+FN/8hbKWGxe+m9Ry8papoK0gOoehbFMWo4wW6jy+HE4PW5CePlmtSqlDQd/sWI6aZJDAlQLFszvlxlHxN03RpBbAjDQkxAxzjG5pdDTNjz8AmxOEukESB/SlhxpIaPfBudZYduI1extnVL6TOvxa0osw5bAGvegravrkwrCP4vV2t2nYItaA6yqhFLgasuFfCLTsVxc0gykva4yZuyRvMwZvJaRjOVj8g69YeLbAQXRJJCQ6Y7+8uzRdGfnEv9fvovjzyrX8NyXBi6oMFGhKnYnjHeJDoMlqvnSUEEioFsB1AflGaEfrXupAPHTJI7o05bk2J/EZA5ZO9LOCLXwwDQQAAAD4r/MxJxlxqa2EvA6ak3C23EL3hVZ+CJ8ER/KX75JO8oGKlQhSqrk1/A/YB/mwbpLx4dBOFyv5Ss72zKQbBi/vB03wCAKc9/Q4aEj3tcX1SNuyNd0J7u+rAKSLOa6m6wiU9iqShvGt5IwEjJ2qBu3QNAsZpn+88oX9wUvyrihMgBJUWnidI+h1EytA32KpwMasPVsvPy160zLuDsmp3d5/5l2+Y0xezNOHHc0KNFwn0eHVIeFLKRVphFijg9ss87UZ+XmZhqpqp8fEoz/sCNLCpCt3uoBFuzeBzfZ3zrm4OxVdj4pDL61nQ5IB5bo3dTyQvUlsd5lkSR1X1t8MBtRoyBP/UHCp/YFf60i6XWrmwPZaFSvoJiyVLOC2GWz9/hkd5kGW50vIk6gW+3sjiooIUWECUO8NzWcfpGcOyixTRu2Wr6e5b1ZjsLcPZTNxZT2DUcMXGeCBaDChdo5ZLEdP3SS9VnbPVBziEhuF7M8C8Y66+zbBhZ9N7dT2WW1QDEowNmGd6ppfOcjLaKocbtzicuuDd8IsfAzywuVb+cddAxCd55VlML1ZuzZ/evGkuNzoKbouOeINC0FqnBtWIvjP8f64JXEBVKVoQWYZKsza2Viad3NpdFPkPb3wHcGnK2AguGugZy2fvdlPuK/QJDP1pkz7MamQFlySeNqzwCOY8BttQ+1vWcvlh7aBHssZoIQervIo1q3TZlPg6ljeh9krbPctGtZxkpmnKewwvqo3YyrK3YYSeEeR2EWLmf5WCikD0mWn1Qx9HCFjyrak98N12M3Gj6eAMqnBG9IvaBUaq5IhrYEDCpNw6DzVn2SyQ9y4E05FYSNC5MeFxaAOfp6DBUSGVNvzlNCkPbtQ++c0SmggARByGWvammv96kbOhjWPteecUxXdsf2exk8BEaVo+f5oyFPV2CtXEie3z/mXgWqgoKfZvehCliCKXM2+La9fmDmA6EhIEZ3L5OtgTZX0fGHHVJplF8kZ6p/lYn6JBtcGY0LrreGG9EZzMPmbrQwxtOdrXTVIaKiEJaWeqBSgc8Cwst/GOdapqy8LGKCicZcAnWI6Mu69QpN99SI5aPozh2EKUSL3PmfL7cJOtmKda+SfiSj4VIQFRfOPm7WtQnK6x9ptHSE61ClEiWZlOpVav+wNYMAfg5S8jIPOokfHWwb0BLdEX6lPAT6Ef0FV0XVg8osZPREkSCBkxwB2WlEQTIwCScNH/ZP05T9SkP1MOIKxVLwm0E7TMhgsxL9UNYwLbVP+vSfOchOoR1SgIXn116+Ex+vbJ36vK5IJrOExe97i4cLYfBKgzZ99xdcJCOyda8G7TD/CVbjxgoqn/NIwF1S/oqHDiL36Rs2wWWB0civT/x82hzGZBX7RWNw086HLph+UJrIrILm2Fis50MuarfWtPdcWA8Ejoq/o7tUx92GK9EMVAjN47z/X/6dtF9YT3GpTBw=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIuk4tBNmfu/FtfLiClG1UTo+5TwwMRTAH99rMCTMq7Kuj3W3oHBDuATwo4zoZkJZqhraWlUBQ7TyMw42hVXhx5viv3fDq1jIDafPPqLYsPmlkVzgsDy/+O81WUFlCJ1kQvWImiazB0D1bFIZ/7419BsLFMEB9hcpM2+aFhjC2OEJdwDDJhstWGwsKgF8xY4G464HrptmiaBVafjfhNfVAKXcbxmtG3ZL/IRbVur7aOY8/5tk587ZSwUHU+pkhaoYul21/DjJsihsnCx1hWusP6rYW1aJ3s0b4Z5daT/C3xl0dRHSAhk0E6RqLbYmfvOTGqrUisdOrHqehImUbJnA0dRqrYPWEkbQ4y42wcN257Q1jBKitGtOuSQRAbXtLJSCgQAAAAu+5ePgeZA4loBjjszmNaKhqbAglSWDeheKWiCqr6FaXRTNQNdW04AV+kuvptpEicOBse4fjnWh6vlqRL3yesBIPldfcQqn1vDVogZvwkEApIKj0Rj/emNjE53AVDBoQar/wJnOFympTAvJPcBKyPdP8q474o0RJ3RLcYyLybt9xjVmfsExKnVx//lpUpOMlOJMWRU88jZwGMoX6mPVnl/NxQ6pYcD1jn8QiPTw1qI0M3zG1J+W3o/lkcT8ZYA/VYGQ3z1pJ0FcKMvHsUn5mKJWygNZ6nsTmLMHyk2BC7Ard6e4c4rzvkGV+IohDERAt2SMWAjuDvc0Qu34jpoPAribfrMgKgO3ypnRAd34G9qX7g+HbI3IbIMq54txwMsVKWnwXobyZXxEzUlWoO4OmdzRIA17XjeX3uSpacFJV+KiEU9SMIo/aTUs7r9MQmI7ZADjDXmSf4VawSrIASEcPxcB+XXy3gn35BIPsWllc8kJlvbarxteehqFUKR/63KZMQf1dE4hkRI6ZK0YurOU4hQIrTpxDZYfr0T7wQ5nDW6XNhIWb2Tm3yBm1k4pzAj0Jd8LpecM10HDYs49zN1wW9P5MGflrnDP86DLcZO+QDlJHL7dpvXfaTaqniYUq9fyyxPDgz3rmuw93hxlZMxDz8NxS68vsbMebVjwtQ3bjZL6rv0qBHz0XEPtlQXTmQ7U8UICBd7fcI+iomycskcBW9oVOHNHM2c0IitotoUHoTiji++xKgSxXevlL/nXw64wVf+2XApcKHZH3GvBNKjRfnVUv8s+MB4nqoQoLHnobZkyCYT7I/FDY9ymB2wY+UlaLgGgIOxGFgOiZzK+7XRG/MX4PO3QOR5uPjcb2SPmDQpF8qeGhnLbxAL6g80qfKJaC3SU69J41ayvdw27o2R260jfrbQIiG9fvOL/EELjfg4cqgr4LBpSCXeFUdc6TtqRPhnIyXwE26ovwEnPWm/+F5W6n+pTZ8QteOTuNlmW2Hi87IvYoo3iKyMZqOjD7O02E9a0xe3DLiNU7YkL0cMbBq5N+LNFbkwgVb5kZD+PJN/VEOKAVVuIF3EK+UcbkOU75uEiUFwEgH571mOx0unqPK0PGQdxQrhsSbIBr06dm1VQ6FSA2jOhEuectRKKg5ubcBbXoXQmGPJqja4fNvS9Nzg5qblVOqkejb4UmUglUFFbFJbdUTsTmAF3ivX94y5ZOhl5glEjby7uYfVuoUoAA/fL6RfWhjNzYVaPKppwDukU/nRij0RH9xtOf9aV56gWaVK4OgxaCaPBx+f6mrzYbbKBu3VYB1SiVhZbD+8sadVLpwq8JX1zkf9UEeDzmAVSNJDFp3JUNU2aYCb+fXvFk9H8wwJxqJ3JtP0eYY0hcww4N3VOfgk8oh7CPabJ/LDiuRIfYK+T5zTKzU1+yHQUoLov4a4adGE/kJhC7+GdHfbEkQcWQdlCA=="
         }
       ]
     }
@@ -506,21 +506,21 @@
   "TransactionFetcher requests from another peer if PooledTransactionsRequest times out": [
     {
       "name": "accountA",
-      "spendingKey": "661773dde38ab4046eff74df69a544425da6557c8067a154a4ebcc994a58d72c",
-      "incomingViewKey": "d82a76a6fca763627fa63a7d832093c2999e6af53c6109958c592ce96ccb0304",
-      "outgoingViewKey": "138702c932b13b7fff7c16db6cf93aee7ecd7f69423c3631b25624d0aa48403a",
-      "publicAddress": "3916b5c731a3bab753fa916909ed46e31c77aaac0ae3e9a9f8e706cf64b726b304e00621023494284daa54",
+      "spendingKey": "531b25c37c59095a7b04b56191a629746b578b74e8b554e0dc2aba6e7597b93d",
+      "incomingViewKey": "d2a08ce8c331976edcd2f35bdfce921e4d6d29ffb9ab17fcd992fdf824af0903",
+      "outgoingViewKey": "ce58e58f381dbe4fd60ccf8f7fab0d29f70147e12780e06a82f4a93abf39c719",
+      "publicAddress": "62b58b48ee174200b690509dc22da3fbd15e84ab5fd41a44a7260333a3fd26c85a81cfc431533edaddc1a7",
       "rescan": null,
-      "displayName": "accountA (d0f702f)"
+      "displayName": "accountA (9c1e615)"
     },
     {
       "name": "accountB",
-      "spendingKey": "313817394369be391e38c920d186cd5c29eb6a39cb8fd5a6c24033c02ca1dea9",
-      "incomingViewKey": "7979d5050c101d644ea97409afc59bed500353348c3613b9dab4bf29b34ef806",
-      "outgoingViewKey": "0872dcf43d88dc6374f80ce88ed40c23c4daa5905d87edc98e0553698d8b29d0",
-      "publicAddress": "89e34e2823b9183e4daabedda5302b0b19fb8e80d0e0af02f840eb651adf4ed59032b38ea4ce628960fe1c",
+      "spendingKey": "a0848654a92ca39ae8e0df39a2eef601737a637b1debc95e279c1ade2352ed8d",
+      "incomingViewKey": "2cd2ab560e0958238e69fe4427c563c4e0c4126a339970e8278e0e16508a9003",
+      "outgoingViewKey": "56618fac907d01d81831505ec6154c9e2949c6514b272f690d442090fa147605",
+      "publicAddress": "fc4061a514c290e640e123498c3d9347c51370e009b67b06e642a86f1ff5b0bfb1c1d9429a21670472b6c2",
       "rescan": null,
-      "displayName": "accountB (8ff0e91)"
+      "displayName": "accountB (888c0e3)"
     },
     {
       "header": {
@@ -529,7 +529,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:gy0Ypzg17aq9FCc0ZfcI/JNRc2HzOfV91p5Kif8S5gQ="
+            "data": "base64:eCjTN2rvS9rqr9xrT3dm5ffDAYxEmes4B4Si1Sg5hmA="
           },
           "size": 4
         },
@@ -539,50 +539,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659644451688,
+        "timestamp": 1659989487311,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "0E345F80657A641C5FD138F631C85B9DD44067B811B685560EEEF804903D199A",
+        "hash": "C01C4EBEE3FEDB8093BC996EECD26AE80B49C71E602715EB511094FA69F55797",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIBFKs6iAq8m1EOzD9W05yV4uAMlFKgm81HO5DbD1bJaGFFoXk/dzUVNGyvhcRh1LY7RZ78URqsIWt+xBeP1FI657/7jrwvtOZG6fv8Rk/TkwjL2LHr7PvZ1YawXzD+h5g4ToP8OX2ufWJP4KbMQ1/FqCGa8KWti/DVOulMCSGhLJts+VcTjDsbStI9FnRdm7YIhNYcns9RTfIvIRL0wGGE7jJy40xJ5zpb4p6qqG9Eb+kXE1p3omQu8au9sdxN8YXV84h5cEw6GEr2fsc+N2sOMNt7U3QIvrvzMwoOV+Wket6vaEUYEM9GsQAAd9hi68Brtf6wKCMNUw0jgUcpeaiuwwLr8e42XfsAdFMGnQ64mIX4P/LRCoMnY/L0N1NKRouvadRucvmgM0GA9gyLolXJ2inkrXdJFRUGUWId6Ovz60wGUWVN8RCu8eAhJc+nyKMvVNVDAavTVc+chbnr4E1jITHFFYvlmN5x0jmdtJqgPgTVjdOgN3t8psoB02c74Fj/b8kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWRgRvWhS0+2opSEGvc5dZW78kWgEBc7VV++lj4THEN/WTPEVNR1hD8z/Fz7XXJ9JL/UKyDKcgXxmqg71GLPQCw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIZjbG+5k5DPvkHoYTTaDIwrhP3F1Q4KgiNLsrS4fMUZC+wrE7QSJ1e6O+fHBMs5epk7mWq+7CrZq1Zba1ylV7DsBZCVo+HtFZcNWke9PnhcNM1PPFXhI+yS0SIQGYk85AGkGm9Ab7F6qnAI03eEDqfN2JkHIs2211MFp80O8BwBLE28yuTikmcWPzyXm1TR4bFxnGGHPl+W1IkXhCcuuigEps9QCMFtd/QKRE3iXnDQ4C9iBW8msG7+cTFX6J0Z0qnvO25/dWFeuDIy8q6eBuoFIMQXiCkKxhQjdAiEUaWzO/HFkrLNTGTXrJriclq4RehkqXUEF9fFySvBCWAg2E077Z5KJ00ZKals7o84o4bCnUnJReOufj18oFOL+zxHiHzv2j1l0pa0ANB9IiMD55E8jEllpqCx4PUGxbHetEiSIK3lnLQbwda1xsMRXpcmiL4tK5o+FUjT3zUzRWaBonugOJeMP9gtSz0c4ipP7VlqFUMPw+4L0PbWPky7V39eDUguj0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaWVKTf9FfNGmNEefjt+71lvqhoJ8TgPyDWkdft1AWzvskM0MlmuWdJMy0CZHgvvqOAwmIL/kfL7rp43XK2nmDA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "0E345F80657A641C5FD138F631C85B9DD44067B811B685560EEEF804903D199A",
+        "previousBlockHash": "C01C4EBEE3FEDB8093BC996EECD26AE80B49C71E602715EB511094FA69F55797",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:duvJw0XLOA1wPw3otvokSGYsgK772/7qTgbszmzh8W8="
+            "data": "base64:SE8KN4hFr8cqq4bvep44WNwpuNGmhUYhZp+fO0W3oCw="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "ECADF4074A79BE89DFBE2C17DC292AD580F5FB4BC3F0BD05437BF3F5E65F450A",
+          "commitment": "70B646F198E668D203472102C3E35A15AA18B423B812930E25EBDE965F8B23A9",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659644453031,
+        "timestamp": 1659989488596,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "A560E18A07024469E4C2F1833265A5B020B13EEC66CC9F7E2190D4EC86EC547A",
+        "hash": "674EF3E8336792C789B4DC16A4D58B8EDF56A296AD5E64FCD5A80CFFF04AAD20",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJMbVKsC/WjTSubS+Nc5NCBQ5HjZmROyqcvcurbsD2Lr5URa/AxTK+e3/RjVweacspJ/WCsBITEW/AjSR3VSKL8Dz+5gAkMFyQHhmIt72rogyOTd7rTTUWOnw8GsfTf5bxVuAe5M3i8fXOPQUQPITvXCzuDiwcH3Yb31o6yvxjQzTI3/ymu/x8s1eb0ui8vayqrSMYhK38g8UDYJa67DF9fJGvAx6BPfH4PNaO8wQSuu2dAia118E1Bop8E5ogOIM3CfO2Ffg//e8dXqP5cGceEbmg910nv5dn24YfCssOCA6vv9p4KhjFHoilyexNruF291GNEc+hUgAXPh9s2TckmrMfT9whXjaS2SYkXSMvigexaGluONDCFoitdBP3GsKU9A9E8CEnZxvyWiBNElKP1jVFBEJ4CT5SjsFpgZRbZwOtPqcbwASiFzEBIm10N9LvBoUHF19rZUz2lWQOj8drRMAIiB88dK4ZSugKD6bSe6Jo9/rTVl48/u+jbHnZcWRUHBGUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnyzZpjrNKbpq8r4oprxReJ3iwEKrmfETC6igzf5VCiKtab4stgxIa8ZsHsGariQRj/5q9wxdK7C5Ty5pz1UzDA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJTZVJ+28RuLhlh6W/pFrs/gbBnLiFHXP2vvSIsmhZR1HrBvl0fhUB3LJOyDSkPacqw/5nWHZQ6GHjBa9bFQlSdG+USd1mYPt27YNUKXKHPcTVAK31WNkvhhqy1cKgr1shhPq+xUQZS4s7Wgj1JghvuezawZMNmTof1uq7LlrNithedDpzEzn/8rJytsAuXpva4GlQtU1ymvjHwaSCevbiSDgQlxb9zCBv+kGdZxixPMgnkFsF6J+8vwTsG+NxpnHR1nYSa6j2cRLRcrJvXDVZlP2j4DEhBkLuYRwo10wQEmVlrkjNsHwd6ym1mHq1JPXw8Oteg8zl2ZPIz64kcv2GIhuQINuY9uWCq06qNE4N3unSvOnt8LPtelLI2cINpXZkCO3GzdN6SiFrxlifnAhWBN6O+1m7qxaV5MKZSo9vhcqzC+xYppi8bd97GbqkzZZP79+Agjo8iVqKbtPVMYT87XWH9R12ZVYlxNYNWMTs2FZcG2nNUsbN/GY2M2MULafKFEgUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8fwPfkToOijxcm5qVVqz73Gr8ZMt5MkGoLD5VCg8ulZ1AgXl2z3/ULYl639lQeIaBFbq3+MGDUPlCHp8cdGSBQ=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIOLi6LbI/vArrUS8PLJBcEvTEA5wSH0iXnjIXMK5lB5QdJpWwetFHxKAQZpZht7nKO8/OpyI0t9EKqb+MA6maXXeUsPYA7NVBtqgN0UHHnGe8c1sL/NZZ09yRT0Kf/ZMQyUdbTXuuC5nk8MSZjJthmzEf/GD3torwhBvCtcFm3QcaarM46B9x/BDGJutKFeuqy0NqoPMJ8pfdbvQUJXDgpXqAOFCROygO2WDq/PnpEL/CdpUli4IUcZiPvf865WEn0L+ycADt+Y7t7J9HgZCDMt/K9qoMJPGbSfcGzgv4zkfubnB7FFlZyCnsUQlSKw3yUvlRMAI6mdEeUDu+glZUiDLRinODXtqr0UJzRl9wj8k1FzYfM59X3WnkqJ/xLmBAQAAADvUN6UtUcei8iBxVOPTaIYOfcNcE0kIpyNXIcQPlq6KtIYm8f8zXfHc7/U2bu9z8QF1w8N9veHwmupEXFMpt0U873M98ajlE71YPV0Tgt3mL/ZRU/CWZ70bJU+rq6uKget1LeZ7Qz0GWdjv9pxAvgAD5vVTK4MFCIE8lKPQer+46ZNLdNWCp7xLIM4GAU8zg+n9TmHQsTGJx/OSM/UL33agevivmDE9PbPTVGm8mV+2+MEOg/6BU/T+sG9Yu0in2sA/MtGhgkeLzxXZ/VgitDBm1DyKwnSQABrr7dHdk1CICjZWtdk1nk7Se0pa0HE8cy5wrBrKnXvCZdAzB0VX2QIGzFPnRakkPW3zrdHbQtWiIITWtvkBndi8xYK+kUbnjz+N4mXeEupwZ9R3VilK3kZbIWTcahn6Y8LMRXhqXEO2Jl5/TGVd1Ifk9hA6kh5OLafz+KFDmGFPm7VUdb9oSAkgwy/L0pcrwhk0MUsabKB8ATiJz6rHobfgOWYPSJbyOz8ARQSiH/krHra7X9IX1c9i1BLHscB4PA15wHpDkSnaXAgYNuz8XTsckM2IFkkUK6w14ykAEBzd/hxKMHYGA36nXuw7A3s63+tk4a/11PXHndUlOej/p97Cs7SPR52HlKL6D6C6IJrNG/g8LuMor3FqVPsZVpOLPjisplyhbpixf6foOz/Onh0uVw9CYdY0wcnzvUSVx4JNcfhyIbebjGHNu6nExfuZE/AuvB9VsAH4Rc+TpKASb9IUNmD95djpXEgr9vgZK58zX6gR0cLlEap8pGErDkegIgmh620tAq7P46wCJNOpjc3LevZ3Us6W712FYlBxHg9h9icxoNy9aYT0nDFBpusykRcYt8mqXdyceyQxAwu6Q0mut/I0uxS/eUVUNl1g8zZZeOo7QeXYz5+Wb1wNm7TOKRrS8+/rfZ9aH63raSAWVsyPnKWAy6K3V2UfhXSHtvR2NBCnZ1W4TK1BCuNxeARWoqtPujoMlx8vNhpI/sNlH1yDxTo/gnj7b8x8rQMhmtuWlGhgmodDppfwZYmPVajr3cH8PA5OJxzQ4WFcCBqMnGq9wFqsZh16NMOPE+zODeen09M2du+qzo4iGeKrqP2ad6OZTG3RasJOhcmatswtyK8OmQhv0tRaQEMFUYzw3x1SkLrt4LKQ1TiZX7on2k0gJvHSBmRQiz1c+rT4IBRW1ZQzg7MbGVXoyOcNlvdRXDeLY4NutfyP3p5hIcTZf6BWMGGz3iRch9Vw2kRmF8Lp+5xXn1jV7EOWXBwH8B1X9xlDryaD8/UhBI61mPXexCUhgT1J9BudSjVznvhaW47/TZV/pXkmdQ85bw1tpwkc9VcFP+FCWf9pYH426isDZ1nNma/YRLf2ZfKpb8Oy5IpzZLDOJVlABWBhIO11xRYwJ0Gy4QEhYzjloM6LEXdxNmOAJzUc8IiQAu4TVN8yDEkCw=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKlsONsfHr2JHl83iKz2LLq4nBKb2hCfIXOMZRmaHNAkRe0QCfhA3CFwHkhqSz4erKKZDOlyKcWqqfrVL2y63/cXD0mrVjUpxwJYiSFUvVCnV+1PehAxoWAE5tQHhqL0CAMSDh55PS/Hbq0GvZYGBeQErbWPUB3g2uUBgfnRkWZIb+HuYynTyeM9SnuxX24zwqMyxQiJIqSJg4+hrEc8+ba9NsVhRFjYnu4oMEpqSI0UEmO3q7lhdVAIgPHk+5W/dChXF37Y9C230S4RBB/6g1N5ni733KONJsEM5F2iT7hvFerO3QlmWoFfUc/uptwow+EkJTNoia3MrnxZu/xD1dt4KNM3au9L2uqv3GtPd2bl98MBjESZ6zgHhKLVKDmGYAQAAAAAuF/HZ03OvNyJKwJlO1MOJ9poPWs6772WpQI7RzLjb9ksWri3LkdeBdrSTHb/A5xLQLiAb8DkJcFg8HHLAqCRMt+7F6OGKdIIi262o49GU2PrOIRNN/Q6Em7KqAfSNgiK2ZQLpvo3QsS32zIgNe3GZB/rD1BKXVzj3y7xjcD2GR911q+flnQqzQTRQr/jFPeqsYWSw1m4K2l3rnpTNOWybbKhd3ZUFBZ3BO0Y60lh5on3NQzO/4ghunzEFPm4wDMTuG8vO9K3G8HxQEW5IDnRCi2Votw2LhDbiPPkXO/+Crpk8ukMsYs9jNVhBTyNe/GglPW8casaujgnqZrn1E+hcMtigzchPen8vCM+r4SFk7DSUvRc6W6e+VmV924kkD+BB2Z034GEkTDJ9pZBMytobwZHM2pqVGoxVIgDiNjamHK1BpzV/dWOn5V3JvL3JtQE/NFTfvGy5vP/vf31tpJl+hNAeQMeAyxK7TURXiCse2LM2b4FF4b1uzUllmyv3pq2XHuhpUivHzccqHCYMLOmXZNjFPTyopqf0fZCB9SW/knBd6xVk+PIXjYa2gn/Hhk8yFw+Sws6O+LzD3Pq9kpF+9BJ2H0sYmBYgUkmrS6xpdg3TliuVxlW8MehXWd8u+E02HVf1KTO6j8bydjkDoIemSNhWOEI9KcFTQqCR/N9WzqHHxf09cUvDsHFgUfmr3aonpEsTkxPL5E83cw5FSRr0VdNblucBMvKM4SnjAyuXzh9z4Cfb8GRozus1ltRnnZeCCJBNvFeV++ea9kXnRR4NclUIOTRmh7TaN/lCSGPLa0FVI4THiIcVOmv9kMQalTjt8eQCFKvxRp2Oo6utpwIDsWmQVO+sl28XR6wBuhq9qSeRQtF4quzb4QOsAtZTN54AJNR/SS/7OT+ijKo622RwWDXfj9rfyo2u/p+w/ySSaeSKbkqraUcTVXon/+fJ3cZ0wuDH2YjVNeM0ZbdmxwEl+Vk3zichb4t8b1pa3qyrWmW0G4sJ4ZreXRHE8PxLwG3tp5eiiQJ7b4gKGB5wzrGDpwf8QFrdbuno0rGL0/Jeq1Zx22DwFUaud/lwzVFaUUBNXLW/2B+0/4ELAUFK+3aipL4qcpDipqN4MTdCRn1LRPfQR5Ay35N1DfyMR0JBLehS2t30m8SjqVdc0I/airXxfrNm9CCBi90MysQmMl7Gh0Uta38kJFKDGz7z0vX0hlB7u/FrHgXAY/kThvN0k70DtbgfKpi4mqZ/NbpLouvVHrB6ypBBROlKmV3V2gB0bzJf8cNuyPWyLLfRYNXtKK7FEr8rmCbOibFi5QecRIZv7/wqHX7Yd59XZ023dB1Ibq+ZR4y5ENx/UbY4Lnl6f4z6DNEWd6HOjhLcXP9lWHN26+OrxzILmwe2hgIXV/eQgUPsm2tQxGVlcTs8yYFqJbj36ocnLHnyN6hgk+KG27gXPJV8QqeDA=="
         }
       ]
     }
@@ -590,21 +590,21 @@
   "TransactionFetcher requests from another peer if PooledTransactionsRequest fails because of disconnect": [
     {
       "name": "accountA",
-      "spendingKey": "0e904ea89a7cc5fb935f4b005c3c66cdbe3fa32327dd94eb9e4c1e29e597f06c",
-      "incomingViewKey": "7a168321b24ea0c0236a369df64b4adb38399b3222d912b71c0a1e09bb7ec805",
-      "outgoingViewKey": "c6ca99942bbc57748bdeb9b989ec9db7d6153a83b1098647f0e429247edd10bc",
-      "publicAddress": "2f751740862526c5fb25848d8927ed662abe9f580dbed10bf897815cd9a5fed50cbd9b41e38f8cd0c85fa4",
+      "spendingKey": "7e9b36c63c1104824d489056a5c13e33d8e8575b72e56f8244f5dee76902e2a3",
+      "incomingViewKey": "218042a446a03fc68d9d49d435ea6eb1b7ccb53e40be4bfb2174857e1354b200",
+      "outgoingViewKey": "c4d507936402f40f520fd135a9fe17e1ca837467387e89c2fe3f6032df5c3d90",
+      "publicAddress": "f82f57d1807b592316df568cbd107214c0c45828e1739665eb483ba3239af1c71e68322bf494e21b6ae3a5",
       "rescan": null,
-      "displayName": "accountA (f3aae3d)"
+      "displayName": "accountA (2fd9701)"
     },
     {
       "name": "accountB",
-      "spendingKey": "25476f090ac1f326837df2794c23c921db4ce8013a3a0a5d1398d66b68c920aa",
-      "incomingViewKey": "a5d2dc889b2023eecac86c817f3c36193e03244a938cc58a6e7ac67d9c5b0c06",
-      "outgoingViewKey": "d03b54da035b2dd3f6583931a3f41ea23754161f947fcbf292900c2d7a0bfbee",
-      "publicAddress": "66da9d69b972dc54d54a4e61f30ad11af91a2e9e4a14fabb8bf78882b3e97ea04f2d2b229557a1ef7c79a5",
+      "spendingKey": "1db4c61b9935eee334e4c2556280bba502aa19b8c1b58dc4d4dcf7c1e19158a8",
+      "incomingViewKey": "8b715af3709bc77f9a13e9a61556a29037ab4b75878491b75ac8c871e2b9f104",
+      "outgoingViewKey": "dff69c0d5b15a6d415f591ea9518c595bbe9f53856790984db22b55a4c240ad5",
+      "publicAddress": "87611ad8d3cdf2a40177076cfb8451fe574c880ad8e0310b7eb4815371174ca0a5fc0b3373ef6a2f81d9ee",
       "rescan": null,
-      "displayName": "accountB (45c0a9f)"
+      "displayName": "accountB (4134a8e)"
     },
     {
       "header": {
@@ -613,7 +613,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:9tOeyZijof+EHOG6r/UcKhRrUpGSoutb8hfxkwWXFFM="
+            "data": "base64:ibioEZwGvzVHcdZhOff45xWk6o0aRgCdowpbTb3T1GE="
           },
           "size": 4
         },
@@ -623,50 +623,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659644453249,
+        "timestamp": 1659989488792,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "2101138ABA983E6170184ED2F3AB4D0B994AB73070AF5F92672F1B469E38A4FC",
+        "hash": "CDA828F84CCEBAAB01E183E35E4F8EC1BB4CF15FE1FC9CC2870F639763E9F472",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIR3qQQhJCsxa75UzaxI+a6+6MufpjAkg+K2EGx3ZkpVg45/0DEagRr7phlNfpJRuq+UEAVZsEPq/ibUyU/HhwgaiI0tL0lgZuF1D3CVJOQPWgfMfezks8SQpZVTbV3t+Rf8SkiYdWn+Z1EiWMFJaDaYERS5fkCp5OfK41ltrZQCYzrlBHlZx1+1ELhO+rf0PrWmniS2fqVQXsh68PQADiSqLvT6Ffl2CxVbe5ughll4Xps1Tvck/EPg3Zypf0+o0BWxq+Wg9dQpn4or8Q9jXUJGAmjkGGvX85sXAG0A1+0baAcByud3rkjx7eNz2tt5tusgGnYV74wonxlwJFfOonF0sdNB+Ur7tKisPkP3cZKDCcHkGLJi19TbeOsIUsVN0ffGgI/WEhIL8FUi1/s7tZq7r58tRQXSswbbfaQEJ8QZjzoFzJ1EH9BCxjBN8dkoV+XGSj+SbLKBgY6IiOvnL2TE8i4SrQ+uvTjBqL31jcHohkB9wx5ifYvGrqdV7k5tCTbcn0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYfFlWWBTrOAHAOzHrEBWfKmjwE2LO/fr5fAwpkJvekDyQs2hJliMR6xkA/7GfHteHjr+Lw6y58ClzR4Bh4GZBA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKZfEdS5K2SuiCpEam57tjABJtWbJWK1Zuvv62yuJdPZNhIObnj7QTt3OS6KHOA0taf1DNuOZ5Ph22yXjb2Dq6RUExVIDMLDjDKAip2wVq/e5QU4aPy0XiJJOaRhl2aqdQMaCkQ59EmRMsGdBCf4yfPZS4fUWmuLhsbcsTT7V3DkIM2be0oQGtdjRS55CZDYUrPzaBDvbrwzFD8HvyZtHm82ZTIUMwZl2A2Lg6OlTFDj5aGy/qvrwE76D8MBUgyj6URNmH3ClPZ6OZG3MOBJlpIFMESDJ+KiqdrYHlH16/pmkG0zzitq5a2c5tR/lElssMBardFREfDxjvSR+K/3R2UUakcrfR5BspVz2xJn3XtJyRe87lOxYONMOq3qD3byvSdZXBVmMegArPD+sryLqI+CQPkaeuxdNJYXh9BtLkEkeCr+hUY6r3BAKkF34PNDajGZaiHIdns58aC9glPgSb67p3sVDKXhoWTj/dbD2bqxw5F++OS1Pj4eu5p1RfkVBQiMTkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwnUF+GUYL1z5dlpfXyo/87zIMNCg3G7lI9gPl9bvHcGSS3yb4TUNHh/i9ZjelmSf/csBxILfDlRSC1tD+H6tCw=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "2101138ABA983E6170184ED2F3AB4D0B994AB73070AF5F92672F1B469E38A4FC",
+        "previousBlockHash": "CDA828F84CCEBAAB01E183E35E4F8EC1BB4CF15FE1FC9CC2870F639763E9F472",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:j3rbbHzhq+GvPoZ5rWVRddVGlucc8c312KmhrphreA0="
+            "data": "base64:30LjfOusKnaYFy0H86nRFLuEdCEq/ZfZoZ1OB3yZOxk="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "A23BB75286F8230DEB0826A007FA8A5B9087B0E80F096CA2910F241831C94C14",
+          "commitment": "EC44E21700E394723827703BE86434D8F7C0610532C2F608D4BE22C96705859A",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659644454602,
+        "timestamp": 1659989490202,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "39AB3F0C20F8C985ED223BF1AFEB5CA48A5C216F74C58178A67553343D52728B",
+        "hash": "E7F94C4C1AF36E37A97515C84D1112172FDAF03D6EA082DE957BBF46B4A424AC",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIW4jp62BZEwG1lYQJZk24k1AKu99Xl5rCby0BNuJT47lZkwl1sar/4IyUs1r+UhR4FDWOQ2GgKEu8w1M+jjVw5CliH3s7Fm9lKbqd8IgI2JHA64yJX652fAkBfijyHGZw94utqkxscJcvy/JELALPRohheAKTg5O6ujxQnAmzGhd13VAAKlJBokjaXL8cdQFawEpiyH6y/kRBXdmQGTMtjUtFwAv7tT25/IZtXAIqIj9q4ixQe8tkYBMD2INIzpVULejJOXtI24P0xXAjjyGrSmoth45sZ8VMGHKwYNR5+/9nx/yrKt8MszD9/DIXp1xJZMKrDtcEZcuiHXv8pUsS0RoJR0rAeZpoMUxB7b0NEf7S0LC6jiixzfqE11vCmGjvjEdSHc5GYjDIvnt/iffEJBSijN0GC4YWKHod3HGwkYDkiJ31Sq3MULjUCkkzKJJ6t3Gwsi+AcjrPSNJUOlQk/lJeal/s5sSOrsKAuQMeaj8ajGRqFV9Ki9lMUBH7ycNtjjdUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwElJt1jdCozoPLaRlAr3MUBBUlvNJw7neCKQheDVBu2As1CqNLJVuPpjIGYQbTnbI0JVxfG5xsd30yr81zaMeBQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKNQrCPmz3/JFzP/4e78mhyRUG9K3W+zvKe/gJlj3oSK8zvyTgiQNfCCtMEtS13TAJNmuYe5m4psIq9kv8XoK3iGBR3RayLS97mQcNtxFEBkGnIZa6SQ4Gf5LOngE0t0fANRqC8X3iC+fCdrh5muwMW1vyPhfSFNhSScS7E7R1YrrdC+2Bbx5SEWuPzzRVjTy5H2Q80d5VMp0bBBmikUKpq/G6t5iFtqprdXyy2pA+5KkwY6sRDH6oPiHv+V2jb7dnWp14/OBKNbINGA/ZSEAh+xRCnn9yrHsdbTjJeL8kdYcuQmUp1T+NrBpbD0XQ2RH5RL1fKZzOPNp6WGb/fJMU6LL2S8usm2PEy0UyN8jghlO6pGHU8K2YS57Pl0VOg9RQLp6ibdZDsFFWJzHlDh8+OW2pDspW0svPdp8fO/D/myyICXhCioI0TorPgsF29oGxFVB4CnF+3Dx4krgXltf3C5kdA3gMFsEByFkMvc/c489oyUMl1ohdYXFE7StEsccv0xb0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxm2ZsU+CuVYrXZjFvVGmy4xDcpyqPx5izRZq+AX6KpfjE6NNuvet4HfOCRSoktCwblgYe4cCBpyE8N8UG5pjBA=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAI81ARay5GZ2cpt5C2xCnEkVBhU9Bx3OPL/zo73uiQieTYEm51jj5e1KOgttQwI1n5SiW0qP83/Iyw/2QV2Ab0M9PWVnM601dpKuUdvzK7yqNJWZaOwhj2dZ7UJECKH35wAvcxH+XUCj8r5vXK4osHq/6mHtiuVsTYsOcYYGBP7pZJfktb9oqokuDQGLJQprYLVOYqpf+qqh5o3baHUjB6zBIZjvOLlhNEyp/axEU6E8PiN7uEOJ6T63SHGHdf13nuxZlzPKT7yzka0YlkTcN6HMuIAifUXFaxyl3foEpMyc9hAwg7ksbmAxX8c8UyIiuJIfJ8lvr2nkWJI3wYttt2D2057JmKOh/4Qc4bqv9RwqFGtSkZKi61vyF/GTBZcUUwQAAABTrr7qmyOqces5ITsXLRrm6zbJFkKyi2MONnJ4DHh2zYruNBUBaztjpSU0BC63xKPhdD8L0WxVIV+Xuv7MKPlOD9LhghXwVq4NIDs5r+3hMwQutqo3b+1ho2Umfh7OnwmuchVA8+1KCmxxuY5NNvUbkY+eoK6gYsNqvLSkfNwMX4OUMpnHuBGLl2ftP+QVru6SyIXrR5v7kn6D2Sc4MX/8qonLaxe1tc+KeYrsoaUdCfGuzhZmZG0JLq37fgTOWyQG0CoIe/tgcXFSNFgvkt92aKzeI4Q2SxQIHw7L1BKagb5v+vy+bcV7iFajSfpkJIa0uy1GumKk3J6wPBUfeUs+H0SgtWv2yu76TMr0oy5BcRUIFwymgSuGkzsGwhdHJs0RhEhZJ3i3MHtuwfVQOQQm/ZMkvHs2WQfquMF/nl0ZRIBJ5AXQUSh5DlbrkebmJPTB3/rGodswcFSdpG6HjQ5eHZsTXwLdRkmU1aYWMQsCIw2fwxl8qCyA9blaeZJgMcugyIzbwoO4VAmzDT6HgC6dN83FmvbMAMXTFcZgrHIaMlMVdj7khpRRNTiNnDdIJIg+AhBq2703TSOr1ZTDgVVXZN3I9QGooQMSBRJmreK83KlxKotwr80xZcI4RObkn52xBpSmqZsSsmaq/p+Uh/I4ezLX7pMzOKuEUDRx1X8rx25/if/QikD0nXHtynLDLZuOkvBX0LxO76Zlto7Hf0r8m0Nw761e0Ov76Nrxw8YW0ouS0rDWivrlOyyYa9H3xncAa+GUQplOT8F5LHZ6FWZ8XUAq02Lhu4KkGROYUsFOvRI4GKDmeH1ECW6XstDcMVoGT5G3Y7RtvoY+BHSKWKq5qLr3MmPA3y5704L23zoVFQ+3bg8ts1DEklCe8kf1MFIYUpwCuiNBR/ffZgweI0mUUul20qMcDvq2WE45zK5mQxjOMoYYTgXRFo9ApjIaJRQLu+IiP2PlcIlMGSxDY3tTVsb4mQwZUcZOeI6+33Wky7+oOOlGdAx+FQZhlF0624JTW772wAZrvI8C2Z9YFs89c+KEwhLBbiOQvREABkuB7pbs7WIHFiTtNfXl8B9NMj84M1/R48BeH54m1UrRhChxLgDDmdJcI6ln+sgmgPJx5QiUDFcCLMe4MrxSI1txA9gX+YsELHFJoIljKxpBAAG/kgQY3Lj8aWJ6zxoqku8M2dmdBKEg5ejzREZ/yCqY4ZE4raVObyaxnFCYr2sPTG2l1yXYa2NT2RbvneH70mdQO8WwPnAo82llP8R12BT2jeO6eos2G/FghSKsBg8XvtEG9cR9niK0Sk1ajf05k9i9ySxF7GdglomMRPS7JNYmM3ZoVHLD+KYJvGF7cHwEGG2rFJeHiJrIlYqbMFQFyOkKxfRzi2M9aS+VJ1lAuuERY5SBh7xy11uHfCN1TG5TsU7w0Zk67QPPnuNfUrCUcVYDULKcwJRnCQ=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKLkKZv6ipdBQ6s60jZJgX+fnKpDVsrWAEdVB3rMaOKii/abs3TUyMlnz42FNvIo7o4Zv2NEgmHEDtu5aR6j5+Sz/BsF7kQyiIFo1rdykHc8LbmAlpM67W1WbsbRPSOc2xXgHhvVt4OiHTB5fJ+i06z4TxQHBESZJ+p/VPwHtariUmN+bFb2hixy686uALv0h69Lc+eZILhkCEmE4bYMqLq8mMDV/edAso3cqisNiTmoCfCFvHgeoB8qNufGBiSsMhNLjZ1vCi4RKUcgl4ExK8rZxIobu01RLFJQ/L9oPKk8p/+o/g2zCrktmwL0zZY4vw2CxhdG+f4+44aq7pMTTj6JuKgRnAa/NUdx1mE59/jnFaTqjRpGAJ2jCltNvdPUYQQAAABFczLN0mi9hE8kSSkFaTlIsgzm8Oyo9U736fpExDt+l1PjYXokLonwDeszzObNyOA8IDoegmxXYrLXeBsN/UEXDMdtLFpzD/3xiRraP6w51iaTq12XHrGnegEcLXu4egGWb3psKuvV553/9h74TVoeuuy9iPIJo/ntF849JPm07zOgn+1SWTNc4wdBzdSD0q+tRLDGbswr+SvJzU4hQDvcipt34L6So9Vsp7NafVXHIzCmjpn0CJ7Xmwu/uAOu7Z8JEuiSfB3NvWSHasM5j2enRJALJlU+BkSqVdJJonNwj6H2fKININPJNhkHN6jEyZmoegy5sItAfdiiB5T6s8awGpPfu0rsL0dYvHKt+UhfV3TrwpRu2SAmOlwTAdkCaXgCHqhA4OkSSA2B1LaqcFxXqnUevSQf5eZpFsgNQMJupfJNCP4izWu2/3sA0bl2Cm1bkLeUL7w3OI5FkpIFPfBNFlq/0+BDSnq32nxHfzLzAV0B9lTuN3r5mxKMBUscZsELZdSudv6KhFDXbuDP05q5sND0AXIdHiaRat7go/ViuCDh0HXdTfoIhEluAOnblsMP2a0kaLuBCPRM8Z6oYAYlxHodMgqFXj33HsMqrkuwExQ5YQE61pDhbBvOc00dbZ3wQnl511B9ln6DwgAdtnt2U5SHJQj3XlLpKgwB97ef6nJkJacRa2JQSbrNXbbaqS/UtyhyDPkB35H+KnTX3NCu6y5h+weSRcYOFHCeiBF8CP4aAZfTRQ6jpqC3iJGdOFzHktxjY6u7z9L4UxEbVmaVU9x/6QWmCKBwl+4gldvfnLtJLoP7Q1h+GpfZ7lKnC0XcI+5iLJUawt82D6EbgzT1Jeckx+6m3HljJi6Rex9YdUs3lgicK06b2Xe/iMoU4aVlHB/RPOhAYxXZZyBvBoHmReYnLrV/osnY6e4v7+5H5SQbTbb9sSGxGu61If+XGy52oGC/wNWZ5Pm01sNPnHYMWkQqwtar8TWSNgCtS8o7D+Fk/tBH4fY5WyatLTpVg6hxjcqqIn4kJTu1E0BfiIf7fHEJnYOpyqd71EfTjlZj0uEdRN9Xck6GaPEk3otrzK4RDnGnSwO8XArKXs5gf2By0uX7UPTRtL5OjQVhzQeHMdkmTtV3ZjacCXdx9eUuyqfbhfK9gtPS1TgHF+nwIIRgQ5uuIhIH0E1MToU6HXoHh0a6uvHApwBT/8DrWOkcXJIdwWGZMpys8bByeEPXAaZ8Le9u20a80LQbr8W+w5gBLCzWJDNR6kSUAY3F0o5IYQp+dzzhcalHvL9NrIem0WZWOUxGgenm+iO9jKEoi3nQQda7MI1kBB9qbj7JR34pt99wZ8TA1ADBlP8IXOUvcUEtC7PbTRg7czbnzFONRyj0l+VlNtH1bPYm6N+ppZF7FiJhuShut7GH1sMoBa7+2IUqlnQW0wjgFVbeBgg9WOaBPb5SQlF5Aw=="
         }
       ]
     }

--- a/ironfish/src/network/__fixtures__/transactionFetcher.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/transactionFetcher.test.ts.fixture
@@ -1,0 +1,674 @@
+{
+  "TransactionFetcher does not send a request for a transaction if received NewTransactionMessage from another peer within 500ms": [
+    {
+      "name": "accountA",
+      "spendingKey": "eaacc7c0699539f76353a81fa739f81988e05a100b571c7055024b5dd9018b4c",
+      "incomingViewKey": "50bdaf1935c9f7b20a06f0e9f22196b48d2f7d83bed40fe338edc1da1ed36406",
+      "outgoingViewKey": "510f9d869d9a5f248f4b5100c0a2a995853b3ec9ee1726fdde228fca9e8a0dd7",
+      "publicAddress": "99af3b55577f445cf05c59d394f4860b998eeaf0e26640a29f4135f50ca97f997cbf25dcf470b636356bb1",
+      "rescan": null,
+      "displayName": "accountA (9b8ab3c)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "d6f0025643f321f3cec70aeb5737e73ab8f12550bae55f8d03098b2469bf012d",
+      "incomingViewKey": "245c7052e20306596bdfe3d3ff40bfcb2ae57cfad57716fef8f6fa603e687f06",
+      "outgoingViewKey": "1fc3a6082154a80bc85e13a75c5a180776b28dc690e90877b94e9959e7d02691",
+      "publicAddress": "58a57609a755ff16dffeaaf453e171ddc1ff5da37bcb88ad19f16f3d658772c1d147bf708654881767c3a7",
+      "rescan": null,
+      "displayName": "accountB (2272f24)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:Gu7d3yPnZZ3YlFMmwZu1UaU/hDGln1v47/CsjmU2/Rk="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1659644442070,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "C0DE1249707C64EC3EA6B62DC33DE3BD175BFC8E5D890ABE2133960A00769530",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKwNYdu9tHM4d6Bm6r6uwiRN6H7BROh3RI9+jK8glLh/xXwKdH1SYK9oG1gfvZg6F5cX0j8K6Ge6AFrizpEvAmS3r7CxKLRxfKSaV0T+C9+5W0qwRLbvu5htdEipvbLR/g+A3R2mbG+zdA3fFJIOojB+GwR8ww2Hz12RyKUEyw1Cevod7xDUaTfmJ/mVV8cnLIn01ifsxfkvOVPbyMJ+9GzDsJ62anMpP0x9Zxgi5p0xIcA0UCRh4mULViEWdaV9hsSFQAek4APEGbS1Rf42CeHThxOWI3jWFpvjc0z/aYMAYdYGJ0riniN+fplsrhkw5/NoESda/P4YrsEwjn3JNj83shHWIlr6iqO7nf3ADlvneyUcocb0YnM2c1pFcT4wUUxjLGvAzAtK46r5+k2wHxo4JUfeT95yHH1Vlj8QJKwH6CJW5ugym35IEwA51y3ZRXAFTp2DY0BeXhKrpBmjZAbXmfVd4na9IsPnCrkukgnRwIc18z8dedXC3CvooFpw5g+S6EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2yzJBwppzKR+iPhiHDqXHrXqOmM4ac8s5AjaD+20prbXUZg6v5ECn3XF7c8t9Sk9j5ZZb2NsXmJfbvDyyyRwCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "C0DE1249707C64EC3EA6B62DC33DE3BD175BFC8E5D890ABE2133960A00769530",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:fMoulNFtTOck/SIfQKCVCEGQSjL505M5TdysugOqIj4="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "9738E74B879C3EDE845BDC557E5BE387B7400CD55EC76787805ED13E094DB622",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1659644443433,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "EF5748AB48DB6CAFD3844117247F98F1D1C28CAD08E97A453DE02184145ABF7F",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKBF0V2wmtms5L/aLuf5/CofxaxiIkcg/enRgU2ydbpqZx2Bb8Ar1RRBcBe09ZgN2bSwBRddU7z/NDCKHRugTZ8hscH3Oj2R1rH4lhxQeTQ6a6zoqBSmvgg7Id0OIiLCWw4CXn0OxrtwvfM2SsD4+KQ9CLlVhbkhjlQeNykIMNU3MvJyTtTuIcfpxZbZfp+/SoBzEseSr0aEV8gWn6uIjU6p/64WNJtvpaiIx54CP76kW7a2l5pE0gvC60ga7J5wxi6YQ5jhQXo6+ymXDrOYIZ+3k9HBvegRSr5NLkM6sqsAC15LlAcmySYUJ+EVGZsnZywTV5lqkLvArAwcyM0lRjIksruKgP43TpigHwaa4DsmaLPA7U75xiui0baL7Y4ZPSKHAuEjtbUVwczPaxrMCItcxOuQur1sWetMWHPmsBcJePCHKoodlLkMyx8UrW6+IgiRyCSe+GtmRR0d9fO3cTWoYu7G11ZJifwTgSuDiRj6dfSRa1KL0rx5qJJnmvxuQCjPDkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4Pn/bQxUGFRA7jcWk48afrbZaDM0V8ouB3GSLYa+N4+u3exS9Su0A0WAebxQgWE9RUxm44DZigV1ii1j+6IaDQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALbTH9n4wGHkQBuQQOWOThO+olH9gRTg4RA4HZ1NQ8it+eDaSRNuhQeMG/YpINdhrLIez6zngBcsM6Gv0rub6Ujq8iZVWeqCcfDDlejvP/E3O+sRHboGy9Ne1LEuWl3cmxIPuhSiuDhEkA0jwfbZzQWOmrTuAOAGPmPWfvYp17mWreq31OPfd/qthCqxcN/Rx5FjreBbaPG1jJO4VAb0AKjqUTtmGf/eQJOmXuhJ84J7fuC+bElicIRTyRThH1Rp9ehRsizcBem2gsyM2zHBlWXJ31lPBSeV65hh5bITLW7VNDfMpqcf4G/LBrYYaPJyVH8Ysw++EWHxIOaggwIDpcoa7t3fI+dlndiUUybBm7VRpT+EMaWfW/jv8KyOZTb9GQQAAADCZMPYzJGOZ8Rzr9dfQVyX7dMAdvn1fmckuu5p+uEjM9CihXi6UT71zULsUdGWWXyPGSFuuCwau6FoJWRwmsGwboQxP6kMsL097ry0b7U7zsZqOZuT+Nw1n6fx54rITAOyoAjSKwqYF3wHwNzTK4MECgBFIIxABpEJIS+TrTMUCrNbCrNkNv4gMjhPs9PpqtOK2+xoagmxpD39xTZMAS6tojR2axHU2OXLGVOSQgKjL6IWJZm48S8ZkONDa/oT6O0C1mNYzgD8RFRxhVqMzZxYiOG/OdtepXHCnAF3iXu0Q9n3COdYINIDnHpZrHAVNHuExC+Q5Toc5j8uO//3fxN3/WpQqWSXAxCxp8ssprdvo8Q6WkVCvPXjN1rEdaOTrSZIa15TUfCOwGP2jq+tjMQWQF39EUdi2o+1v7+EeVTomb8Fasxxk4yomZdkUjicmdvTFGHrRlLvTUfcJHY5JWpJCvSrj2yx41F0m6kUhuJAew49ycj/3UV8r78UATfF6ODyid4vn8BNha+9nFwn7x8HssK6bqpcPiccBY64c2WKCirhdVWptegawUh6Q+ayqslIb+DwdjXu1DS+vGADeSrNdfrWnhIDinsR+im6912lORSMgCmF8P3TUXBYC14DH/Qa5SAI1auQPjIOsBVm/btYTwtm6DczempF8dGFdttzQAXSS3bTFD7SztMqYrv9MS+XwXlM7kDc89p1LsdVTechWCSv0C1FsgWC2PbOrPfJbAGOKKRcOz9WiF2mMjQ8sCo+rtzjgfXxK/NvH5tH0HiCOowgZC8uWhYajN688l7SvvcTMZi9gr9tFv7bPh8c+rp6wTrXUxLnUmMRkA98NoM+bxMVB5fGAuboDuTrbR/H2N+cXwKgiSZHe3k2ijU3K3ddkX7PMInVCBpYm2Yc2tfozUFNSHSsZ0PPJaVQCJBK8WtQD5hRS2TkiBKpQ25O7zGfy0DoXWC3UmFai+kEh7remhUu9e6kaAdxx5odH/tymNuv/6kYYHOaXsV9Jkq/WQQDOzvhP/6uWt0RSpbIc1VNczJyB+EPSSdIFsV2Wq/LYrMh1YXiDMzC1jxzZkSExpEtt3H1AUZ6xiMi1TvVrVE/+kXvcLoMAUPeq70RhbXeC3jjqUJQ3zS1EARwpI5uOewNhr75Hwtrxlyyoem8x7D9dtTSJyvL3i4teDWksvQna8ifoA6/rvUTcOy6y5sFe/ubAuvQulJjvz2HtOjwZjQYMyYaF4ChOADTS716IeJatL9vzslOpx+F3b+12gCs+UxP+He63vx38PZKwRrDtepJ+UqCRKGM6gQ3PZfgAMuSYaFcZwWmMLkl1dexRvxQZ3DSeX1K0TDo6NG1FGDMPe+uzuuq6fjnJ7deqiGTFe0Wy8QLIChMSZtcvm3HyNjYqES/GbvaYYrRTom5f/pkeSJ09fveKpBGVoNNMMy6/alNp5vXOjjiAw=="
+        }
+      ]
+    }
+  ],
+  "TransactionFetcher does not send a request for a transaction if received NewTransactionV2Message from another peer within 500ms": [
+    {
+      "name": "accountA",
+      "spendingKey": "faf35acffda5bceac47c2bba0c213d6dfe49b75c8995b243c23b5594891f5812",
+      "incomingViewKey": "78be41f4ad7e46db8eb2d249087d3189977dd67313c3a910657cde5de6dad706",
+      "outgoingViewKey": "614339005e1f067326dbf31a72116f17c1bf3e3b404d2a171b6f27d285c51efe",
+      "publicAddress": "ac2cb7b7cc69131c355015e12baddd9d32da0f95ec62d3c0f43e571ec571b6567431c01b1c41ea32ececd6",
+      "rescan": null,
+      "displayName": "accountA (727caf4)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "0efc415e6fda5f9ca56e0ee61ff29d549950c6ea00f86d2b3abd20bb37f14d68",
+      "incomingViewKey": "e9c89e50fc288dffbef4b70620de515fb7d358de35335e67328f22d32a002203",
+      "outgoingViewKey": "8f84817d13443b0e41e3e9b0a38af625a807f0e7047102a7c9a5874326f70c24",
+      "publicAddress": "2797ccc9b2341d76374bbeab249eba7f2d17f9e0f9ff5a6813dc5feebe90198557a34c57f996b7e2effc50",
+      "rescan": null,
+      "displayName": "accountB (59bc2fe)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:DIdb2YsOX6mRt2ofn+ZW50lKcB5g/DxUxecnXC2dSCI="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1659644443660,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "AB296D7269CE95ED4F07E8E3129071A287B532E405F4B7A4754C6D6BEFBBDD04",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK47C8+DMncGLDcVoo3Px7c1PthaeW5bkfJAGvA1QqAj0ieIf0gxBJClDO4IMSZSJItlV+uZW+PTr2/hj2EYhje/rs4fAYFazC9RbQWvzY4EZRKwdhsFidKRftUd5kU4pxLhsMV7P0PMsXn6ywdYAXL08S5wmDM7xAD95c5KJjzXzOhxPQ1oHm/PvtQBU85/OZmicypwd9XmfBUyCXhsI1Ex+ol7GJLkWANYUXV7BQajpHNo/0KJkfvxd0O8PQia5yODG7cBvmAc34tl29jLuv+hrUk5eiI6D7/OuZkYVHCrWLgFGxJR7rKLIYJS+xwYsy5CZFNHLkGPv73B9Vpx+EdKl7+JWohur8WOi00NS91LEPsQNg4bz7UZkMKQZSiN1ENhT1QTuhJzYrbb0uID9XaqtOsSg9IuGRFTc4/NipOkBxhQMzRVBZba6z2vK1BU+XgCZXTxvrdpf0QoUAHGHCErU9oJB6/Zv/UenGQFhlLR7/PXZJxBXM7KPYGyIGOQIevKrkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwffuVGYfzgifRAU1k/6D+m8XoCAxm8uDCQCDpLy7ykBsQnE50BMBzLxRKqMLgY1yBIjNPxv7uxdmkW2ovhVwqBQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "AB296D7269CE95ED4F07E8E3129071A287B532E405F4B7A4754C6D6BEFBBDD04",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:KNHKLg0feYzdPGuVthb48DaGdwNr+lF/p8oCty8DeDg="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "16AA4905059997D4913B9BA6794553C2F2F37DA0433B6F09C65AED857C28C72E",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1659644445041,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "9CC8FDE42AE93CB19E2E8C7A64E90A07C87112876FE6B26D36CD77671C5EF324",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIst8EwuyP2BoOOz6Q6XCL2XxIiVmyVhAhT3tia7TH7QsL/7/gxk53wvwSIuOk7EL7jW2PkknPOeWW6nEUFr4vxJUF0vKvh5ljidJRh0i8MMzrxAMJC0Npo6tqLsLUh9WAVE4GOuO/zzT1qf5/RdEj0cQihruhYXYBzXJy5zztngaZOrPUrCF+wza+q/ae1YKbXgg/ywx6re/DF9w2hkFyyC+Q5zEKU90cl9EK6JlaYSf1rm5dcu5VVaXGkan8BOhIJdHiWG9Xn1tl+uzefZSxNnCc68DaH3/ZqTlFnoEWrilBNg5kFFEjeRTbykAPyaq5nOIYFO20yg7H5ZkYktKgo9ZCH98wbxpVj9zxmQiedMt0Eshs+pA7zlkJeWQYAkAENlojCnpjrwoLtfVs8JRkaMEYO4UrEJdRVKyj9028KrUOwxyrXv2zIVo4MS+DKov++t0KkVfFM9gvVfV+wi3IEcX2R1gR4CwmP7mgW6NdW0hItyuabMTAPXpuvpiR2k3A1LXkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsRNnk+CA/LWGuRH5CijWdm02D1U1SWZLgbB/vISF+1A6dfTYeQ8+q3jbnsGGpy9TMTDB2+KOUpg91bi6UlTTBA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKhs7KNdRKZ6EEKSNCvgOdryZoIxa4GRDxtBXScAJRsLI5v++YDUXOlQYnoYkXKTUrN/1y/faamz3CmBX7mkZYqkUklsPLedg/UzrLtHdkxS8K3nXnBampnjQL1lTbKP8xWkCveM5U3JXcBPBPqIr0kKcJxx4NCbbYxePKpITFpBe+Y5siBU9hd+qgu8Ts5oJ4FkwE0MDDt8qKRodQc8+UPwuzZaOJTUfrceh81/ptn1rIVT2RuWz6L2ZU90wazrnrvky0LRLgfKNZZMYfJWH04c+P8xCQLD1kder9jJN7xeYRfE53Zafa5TpquWnixRmDGIrVvPS/FxqquA9d/jG0wMh1vZiw5fqZG3ah+f5lbnSUpwHmD8PFTF5ydcLZ1IIgQAAAAyL4ClLA1tKxtTYsT9nR58pHJSnAwUE13jL8REIdFxdu16tEh8htxuSNRVIf4GpORSCio4M3lQWCD8oFf38WY/slTgQzWj4l02te/NjxYV1Y8+1uKhiREnhzylELfk2QyG3UH3JzHMXmWvK2YY8XmFo3Zc7/GbSJDvRkA6zRkhtZvNy9WWnfUai0n6vIWDw66JFAWUTcuSb92OaMh6U5/RGqoSmwEf/0S+h4y3YXPWmdXNV5NHHr5/IzXWTcDDHwYRBKuVXfdS18hb5r2JPUK/JRNo/LTkEcXYjaDr/z/NGXfjBWpnNNlbFMZgpor6MUKQvNuGVix94vcH4AiQXyLCbC88nB28fGLL6dLUHEM/KdcH+thzanr81qcpGk1VFLjLpCOG9MbX/wdVBz0RMcwN9a286bZCQjL526jpdlp8KWVDYjJihwRVf3ZFoQK62dfZ9S58satlx17QWUUy0S08fWp/6JyfQG4JxdQd12VXXmdBi/e98v0iMSB1dRX47hDfank7dhy7p/Y3pcFTCZETt1d+N6J/LOdL/gwq0t4MQkPq6aMPe9Tjuc7Yn1srMpN6rC9GvHEbaryxOmhvOpIxfH8Q+mQhuxn/iVsjN5XbfZlclpUFcb25qqa1Z2Ary2C0N49eOFNQrAvU5Wp/YHfvqmDaOIL5uKlOg7zSL26Cog5hld9wAzZ9Irkwo92xqs4NunHXD5AKUNPe62cq3NzJ7LacsoI6e8l0egfNj3zUZsTreLLcYiG14kvReaciqxnMLb0aEi7cun972zpsMV+uEhBF7P9rGBb8jljkVAF+k+etprTYEkZMrbj2ZEoeZUNfHVA7be9sZiqVRlWRx2c3YDR/JSF5Jr5HJKfv3L8qwXlz2RSE7RLG+7Jtvgwvfc7XAu7+9EpY45rQ1C+7It/bvqZ0T+d+R65TyFTVl2e+bYo8lpJSjbbEKKPrJpnGN5kz/fnpsGN0bUHdoivqQ7OgN5hLC1EnoFwB6vzXGjTs9ABVC5XXEWpgQPWRoHGBTmeEA4gip1OISjK0wtztWjbH5ydAEwm+N7v2ONrTwPLtVWagixjHEPo7ydHaEtlQ79qRRzTc8jxbQxApy0HnpylXIuRc91SkytNI2CnwPv6KCWefXu2ia31oxThoEz1gDITCmCCtokx436iikAiLOL6I/7N5unyyVP2nBjwd099O0xxLP+qEXxUm7pDcmFupRSD7XWXFgeutkNb0Ab8/IR8q+wwSY0lbL3YD8KW/vkelnA5DWrWYyAvpjq+qaytv/FcNyY0j7kOOiBqSj0JxN7lwWSM+8OHvSQpfI5jtF88coDznPl8rwaM4I7ZOLYUtC/JuPgVDcffcgMkb1l2QZbBGfk59zWKfHIFaH6iS6oBKEPNuJdYcYjyNGjCZsE6ujKyyPHMvbtMHNYAACmjIpAaGVyzBqq+BZz1jdgslPzBYuIHRbYlPCA=="
+        }
+      ]
+    }
+  ],
+  "TransactionFetcher handles transaction response when the fetcher sends a request": [
+    {
+      "name": "accountA",
+      "spendingKey": "bda858838f5096b5155a2fcd8c9182438486892089ea3c34f54a053fcc5f50ff",
+      "incomingViewKey": "fc33f851fd5b9ebdc35862fb1d012c9c8531d5c64e24c60183b8e41b2445cc06",
+      "outgoingViewKey": "cd88ec385b1db699cb79bb01b8f3c7ad5219aae6f93bed61d505cf628d2da104",
+      "publicAddress": "34ddd3f801a590ee5f4fe639abc585ae70167307c5959eb73cdd57f6dc45c59330e0aa09d88843128ba138",
+      "rescan": null,
+      "displayName": "accountA (df196e1)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "e39f17503c4db8421fefd74760b9d0ba942f04bd592ee12f96e654689078a222",
+      "incomingViewKey": "6addbe7799d8fe71672567ecda4c826c0f851673aef75bf4981687f5f33e4b06",
+      "outgoingViewKey": "335874402a453ca86cdeaf4352eaff48e8a6b65d3876e0ea9bff0bb21df8d428",
+      "publicAddress": "95469aee164e8680ea97f1ef96e670af2c581061460dc9bfd07f8e2758eda6bfc3ee7c001c6c9542613a65",
+      "rescan": null,
+      "displayName": "accountB (89cd6cb)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:vRoLb8amaQgRNtVf1l36rpC9cdzbkFj8xuB5XkYE6hE="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1659644445317,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "4C898EE52565673B5AD0B0F68549210F3AE8791D5071E0FE30EE6BF746B1EA36",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK0QmvJDQZRhMtBB1l4/Fyj5oHhSKR9cdzD9X5TwebGJ54c3uflW4hIzKmuwX5i/K4k6dxTugjJGRL7I8iCUybXTjUIoqh7DCvLxu8xDneVHj5ujJt6B89IH+4rvhiSQCwVG3LN265S2tOgx16x9usoAI5P7MzX8mBJw9ueuLIufy/GeZauXCluI9LElf9WAhIaocTg0ZLnylJWbOHrv2gEOgCAC9pP7ty+SizmiiqASkr/KKVpTFl12dP0kSbcTuu/dGOjl7bLOztGHBhTElWvhRNh32UM6gdIlUfI2bMVSQxg+GcndHGd0/pCqLrJ0S25igFNyBFy4nkyBFn7xkWgQpuxjwq0UJHMVUW+Eia+gI7BllzlZPXyIOwl+L0b4RKtsdVWoYhF6+mY3wkRcTOb/cOPnFUcktGOHGO2G2Avj8xYes0nG2PeHV+J1b9/0y/1s7U2wXpHAfBUkeclj4qLC41RgORZTjIjEDa+Sgl5nuIseW2ZxJZPR8o99SkTAX5fmg0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAweyLG4NwB/Iy6m8jq82DUquiJsPtfiFoxaqt2vIPD+5zssRraM2uQ4gdVY/0NLX8E4L55p570u3p4+alFNWsyDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "4C898EE52565673B5AD0B0F68549210F3AE8791D5071E0FE30EE6BF746B1EA36",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:HKyiDCTvfdzXJpHFXGHDrB9PosVGFxfr3nqd4v0NKjc="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "2046523E85253F7A4601658EFCDCF5EAF5C0A5D423EA104CB362E3515DA18970",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1659644446649,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "5FEE93EB92F993F4BC4FC112A3759C93AF0B5B626BAA6CED807DEC0349CC3DED",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJNPsmZwYhqiXv8fz2VCKyTv00uBWYtWSFYn3DtajzMc/WnLCUfMq/et0cX4YDUGOZYkoSQyk5SLjXipQQ5ZWRuf71l8rD2vcZlTv99ESGRPKN20QipYn7TcLA0sgOCCmQpVUSBwF8JOs1yIJcx7uF84LcXRu29fp89beFDnUb12nL+xNjjKK1Ilhf9Kyp5JFZCLOaexNPOSN3834CB1ldn6nonKiBc0qQwA1x63DCttX3eQuFWq2JZAxOb+B+WeY/fiPkTMhvJ1RE7yxE/OUylRd+teOSq+HmCgWRc88cBECiTH6zYBBKNh0aEmyYL3ZIVglAxh1V2QicORNRkRUzV2XC3iaQ6YJqFp+T3C/zAyQih5+2r5feO3FZpAqRWxYEPfLAO98y4yOASlYoEGILges7xggpFIPpFjVtY8y/tpoqjCElMyyXJGn8pDS2xTE5mdYIW1+CYGhwc+qcpZJ08cewsF2lHT53AxJsn0b0Ns87nfjahx8DfCOQ1jIU0xhO4IKkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0bIbZXbTFBTXvH5s8IYSftsg3GvWwxHGPSxfAoNvRJnTRzUYZC+w69QtVle5pmy+JhaFilkeP8r5QUcL+c4ABA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIrZWYY+vbkw54IywH1EGdYefd9pMrsbioaecPRTyxvdiYs2ien5anTvR4HQOJrH+qwaNfZYxSeTJD5xLatnQuw1zL7a3V5xW7zKKn7nxxBDwVLIhe78zwEDetC6TLC6ygO34h4wovyB2iVL/81KUOGmjFX0QXIM6on6GHorPpAUeZqkx8jN4FzLaK952D75KqJCY9KIuA77tiVcgGXpRHKgKyYBTCHRipv70NXwLzfD5P3oaz/KB5v4+scnNi8kb63vAx3/3ja7L+MJbhEX2r3xRvB23Mnw0HfTyxPEbM4crgOWrqEEjVwgLrU2yzb9O7L/f7KaOYOTjZcz1jq46Fi9GgtvxqZpCBE21V/WXfqukL1x3NuQWPzG4HleRgTqEQQAAAAHnpEDM6znQpjWbwulJ9zV4TbcR3ikHDm3pxChAplzhBWESlc+rLkiP51w6ou82lRafpQBwCohwtUZE67GuidGp0slpv1vmj2uZadzfPgtJB2KKXU4dTar942HaRFWLwKw3zwhlGFgKBQgDhHyx2AMkSAeffNwqcMhNNHR8KVGuKgpmagAO/bB/gDbbAHNp2u4R0RkI5pJVuE/yTOCbKRHhPI7Cju7OIJNQenl1wZsFgni3nqvPJtsg34PUhBQZcEM3qmBK34dQ89VQrGrDU57QBoaZVmcGuXg8kq5ue61sQ3vU96VKP4BFukB2GNSrh2Aw9e/h4yqZIIbEbv7Xcomnk9FC59/kBsu0cloLWBaboCYrFQaNqsYh9YwiXyd9d5zB3P03qvxu7GIaOIr1S3AJABMehSdE7q2/NAAnEjXs07Rgb4vX7pGD0VKN76x9cAgxbhtDIC8gjcnu+yAxW8fUr49DWgg9k5+Q26ndCs0dTKbcfDqtybkuN4XbqymE7ObTLdXTrZfLztQzVpPGz34eZvtGBLmwwL1Ss0N9H7jUqxB8lQG+9wQyG8izSIUvOSrR2JE1NDelo0hEi9NEopGPVkI0XTiDYoQ7IJSrlEzP2o3BkNeoZYIIScnJsHXrHu7p8DYvbcXQx9Meet0r9KJefEIEt8TPrwtCEknrYJONj8HjkMxEuE5aBp4SjD336+9ZnuojMS7O39Us9GU+UijRTUXYRB0SX8Urw4qIN5D717nQYMIbi3DP/j3S8Q1ITtBbS+6nYAQJcHM+x8P6Gui324oO5aP56JQUsE/kRc5YK0xv6tEDqqkHjVg+UhEQVOkJrM7RjYGz6UO3NCvsi56e3zXxw/fhGcj7HD+//HediUwmQvi4kWzwyAZ0KzVnVmnjytTjgm2wG5JDDoOIx2V8uIZkpDHWdFCdiwcb47qhfa0dYleJxzfxRi5xPjJGr8fuZOoYFnyUliW7JRfZVZnBnrS0UuGyh6HYpgtFHB+C/dztLurIqL4N3C+kGghvfC5qysDyBOsFo1gPHzrsLCD5N+rhqEDCf1JqMcFLwxHHXhlCY2i7cibyOJwzbp+fqJLoETMPAnHhDGwJatAQABjdNlD0eo5W5OUVZTR0Bil6MArCQytlmVxqDj6VvYYP006/pIdExT9ixSjTzJgsylgy/g5214Du3Zq56Aw+lcskrBGTeGJ4CzSqKUJgxqoreaUQUxUzchqM20B857gtMO5uHeB9ESsHF/sfoU+n8COiL0YrGYnGg108D4syYGbMC68cCzqK0Gxtl7PUq9usGs9Gh5sPr0iZTlEBJSCsyJhwmm3/1rJ9fxMIg6eoDiOxwgKA7kTZbonupUi+uSsOiGCW6FevpPRvIR6rYvPWcX0ZmSKeXzuR947PF+DfZUG8qlWKz77i5P36WF6yEKoLkxsf5GQ+pXfjiTi0apVh8DSfbOUgziyCw=="
+        }
+      ]
+    }
+  ],
+  "TransactionFetcher does not send request when node has transaction in mempool": [
+    {
+      "name": "accountA",
+      "spendingKey": "0ea72a5715b48bed22e51a815b947f851550219f021a1fd714036511824d6d56",
+      "incomingViewKey": "e6df3a1309ff8b295b6abdb92bb559a3c06b13764b5a6718522ef5b6047b2a05",
+      "outgoingViewKey": "95c2768e5abe037d92d3c7d871d1202dee881f3c592d05c178d0658639f396cf",
+      "publicAddress": "be95f8723ca263f14686bd91f4f6265c9fe19a1499d3f4daf92bca535718a4c977d376637cf595180d91bc",
+      "rescan": null,
+      "displayName": "accountA (1de41a1)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "ba0f1b7bf28e2ea9c85b4e0a457a0246643e03e68b9c730116f2abfb85dd428e",
+      "incomingViewKey": "cf489c684b32ccd85c550cb85dfdf8b14fb3510db25dc26b0b693ac93710a100",
+      "outgoingViewKey": "965ddaf696c3a4c7fb3c74ad8068e17af9cb57ccf620a8989882012791dd8281",
+      "publicAddress": "f43499e6256f6db937bc8bdee7bfe98ea9d172a07c2fc9597e4192cced51324164d64c1f6ea2ffce172c72",
+      "rescan": null,
+      "displayName": "accountB (94f813c)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:nrXHDbVgUYPAR3TeaTDPTO7UimlRGw4apZbtL26Tgzc="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1659644446882,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "035F4C644784E66895ECF1E2F52A50FEE90BFEFEFA8CCC7BBC370CF5346CEC98",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIPH03p/7rEkqKOdwcnNgNNLJjAj7OAjACt2w8js9nxVkWyv7rgJ7MeQgXB+EX5LCKyHQgqPJ33GG8sl7CDzB3siySGLK1ziVWxau9bOPUd73yCpc2fkKnrXQnq/xdO3ZQkcT0aLmEgY1y+2h7xANFGFRRmMeR4T1M37ZbVES5u45KwI+q97YLSJFDIYd/vRXIXrBJtnabfjQxGNkqZYBbNcZwvChdtTz5D9n7LAx/ziqSwMFeS9vxVZxB3nSXTB19Ucx4b24Sx4YBRekUWN2hJ5CWkFIhK44iBUBcSDjehjCmuWudYFGGA95BoQAMorr8eMt6BIkZ49HFUP1UIigDRbk3xYsSLOIqZ+oAchsgzzXByAeV60N6v1OnIPtyrmL0HO2PR+qTtX5eaVF8CRGvL7JG+ralr1T4vy9cCyrnArp2hAYhoXBu2/rddCh7obesa3Yn2AaGpGi/m9Tg0uetcilWsJL5K2XLbyn9HxIf04dF4bY1GRjCLriI/1bWeHyafF4EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqjylH2l3s1GQrQzNEJg4EAR3ZdFG8kf0FD2CNtbCSkeXvzwUBk0YtMGDBtfF/bywNVx75PcRzKX04ZnD2vzGCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "035F4C644784E66895ECF1E2F52A50FEE90BFEFEFA8CCC7BBC370CF5346CEC98",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:6C1P5jWFoRXlRcPJttzKqxx8sgZ5CvKZ7CvT7RHFIxA="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "EC74336FFCCF2CB40242D97B63673454B17E5DBBE315625299B8251EE29010C4",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1659644448208,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "3A26D4D00828D513E3D424F6F808FCB188283EB55BFFC6B00B485CC3151CF54E",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALVtaVsc3sop2SAB2XJo0X8fCcoIInC0vmo4YZ0BGiVOBUFT1m6awrwLU+55lREBNY7eHj9P6g2e0EA51PRQnQZrdb9fu+rf+QviqdgO+ZHEGUneylyMoR2Y81dRkJCtJBXdD0jHhwTmWq9wMxpHOJTEORyhDyDiwSz+Zefsv6HUtwKSSw/bomYOR+9OQO7HyYhF71eMNPTBnxssryDJ6fTyMxOXI1WEqFsZ/7yr4hg36dHwWCey6V/TZx42EFG8sdnDNNcCBtMqNS03yjNIWJM1EsgvMpa2FNU6ZT4CupJIra3LAApgAheMT2T2705u6bSCfGTG6zJsEd3M+nWTkgh1va67ZKpi+1w8RDveHUplhkYBfmRZCkZBxgHjz3bsCCj0TfXUWTWnI54RXjtFldVa8CCB84+K3Bt2IGWvqq5vOCnK5p4Ml1B4BTRhhtHDW5ivcTPsOsa4z4wO9ONATtnQZx+wlJq7srohH7OA9dgggQp/0ez2nIoRzhtjZLBFrlOA+kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9bCV4STyZZmkXMaL34qTIlR7AO3/9lMYcJSnmNpIQ4L1JR7hSCq/UvQ7mJLGL0d/BLKt3V/63kCe2d4FrC9cCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIhDad4KQu7MlC/m1eq4iHeQLhbM7WG4xSuL3SHFXHFPOGPaTZeAjrqvq+z7Csd9tqh6UEKvb6JX4frdoSsnzKWflqOD8+Cj/7oveMcKSG/ApJ9ey04ccia/7EOKCLL28QphNQU9n/210DIgZp6TTkFdlDF9hCShoCRlbAZJoG56nw9f/44QqdDrFnL8QMaipKWXUi2L5bVfjdBo6UFwxagrH7YLNJrnwErC9sum95rwvi8MBqKvWXEXuFI0oPWQ/dYLHHEJ/kl47SxKeQpo3Ae4FlkOPOfZI2mKnVnRrACkCObmzx3ZaLfzMFfykvWemsWAIn/CSu/jgkhKykfYVh2etccNtWBRg8BHdN5pMM9M7tSKaVEbDhqllu0vbpODNwQAAADnR6dKVSClgGsZkPjIYUwpiyrvarJMJEM7Uqz3370oc1MNePYw63mNg/2KKxyMScRvG6aeVAuX9Iaw0bwMAF2mRpOlOPIsiCbgjA1dxH1SkLT+XBWtCd389ktsUiFkEQezFK0hrKhf8m0fKgotn6IZ7SHZhriNFfw3z62lGz9cSA8RI+U9xeDadVgB1JZIwdmA54vTGL562lmceKyeWvY0sf4n1xBtjChJAJaQwbDSyls7hiCs1ktPJAAMuFcnLDcSY7vCLpnAL6NCd+X0YQXdFiWVZ2O8WP5KcJEhz/dOlgk1fzucvIW/Eeo5AldcW06XhoP+kkDR/fc2AhXJCmQPDG3kgXIQHQLXnE1VJIk959TNlEKMKZ5fXMqtYXpcV4gZC8+gQFyGnXwuZ5wrLyZDSrhphTkE/xBX8x+0fE3qltcmmDKtvM6Gh766peGGz5dMD/vrma3Tb9FT7Y5csg9BResJefB+rznc0zL+UpS9K95i19Uohe5zWe91m4h44GjQ9Xry0PFCJuPIe+dSjOV9lEKN3D0BX7BlEuy8t/YTzK+zn5k8yaEnjiQAzp1oy0AaPzvfPCpY540tl4yAjhqrEB/K/V3OZTcWPwnmPnBGpuc3J5fRcnTSWkpx48b/HG4qJETYIUktP/V/P+IOVa+SN3ViVANbotP8xAtfK7n6lLdQRMENG6OexObfLS2xJOl0luWbsE0jqXWcT0l0pOCunok6/IhU2FO+lnNbiBh1gi9OaqPIeVfMyBaZ2AdWOw1r0XAGq//mhHiMXMUrPKHqDHSaSZ+aXt8rBQqMT2oncRVRSYVUjf5tMq5N95LOKHIJe+YDNrhe44otviRi7eq2QOR0/SpwmM7BI1lRkoSBPJUQuw7tzeoveeSqY8DRKG0fR+irizkIZvD7bFupHH7nOn7CMFBNVhA7oRPxN2jgTh+0/IVUASPAkUiXH95eo4w3u05bMR1TPGGNm1XZPJjZ0oTHd9+29bP+d/BKQlTwz8coKuuEC29x2DXEKlpKivG8UYdbCQ1hSeOGV0y2Y8diTZfZkFfxdI2U2CFEVCFS7CU3BHaEi4lmvmBK9IcYp+2hLk1FKuD6RY4kKfoxYoL3CHMjG+ydvH7FSDMZTNIazcv7RENBdEHyO8qJwgPhzKtzygIbO6mgg2jgDY1AYUBFtHVGq11iPFs1HKIkwB53aMsR+ZyBNmvr39YH5B1UAnRqTkmD8E1q6xLOeLVRntZhYywhP1wWRD/NCM9gf5smn0RjkSqVy7o296It/lJGhtN0dDdcFYnLvzbaWOFgZdXD1FtUqv01fmQW2mtM4j5PEVUWsnDaSatNz37rTT6BBlDluEl/Nh8X5klKrdfEhPrJUFRjbqCc4+WCylK2pMLEw3cOVwH2Xl6risOEfyDOklpjBYWZkYWDT9bK5Lcdl3EhJELp7H32Neb2+0biuzgKbYo97yZmCg=="
+        }
+      ]
+    }
+  ],
+  "TransactionFetcher does not send request when node has transaction in blockchain": [
+    {
+      "name": "accountA",
+      "spendingKey": "f6f7080469d5167269761f43a703b4bd9ab2f63999bc93800cb33b9e7c233016",
+      "incomingViewKey": "32598322beec39b0d3648f09c0cc21cdff899f07de3298bda4c6c1ca9ee96905",
+      "outgoingViewKey": "6a69694d3b0f333f56d6f2d59450dca8a212c6fc8467db18440542a6837fae91",
+      "publicAddress": "f0eed2beed2094aead7cc320a2d348feb212cce1f4493346266335502f321eacd8b1bd1e1be15c778361a2",
+      "rescan": null,
+      "displayName": "accountA (2255539)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "20026e06661d3a3030d924845d3cc217de5a3ccd4f4c153ae180a0eb17bb1d0e",
+      "incomingViewKey": "c4ef78232fc3cd4409b895c8d97afac05b79b5986c7df94ae0205a36a7e58303",
+      "outgoingViewKey": "ca923b3c44bd42e4b365b481b600439c3cc9c8f75232a4ca1644c63864a290e5",
+      "publicAddress": "d537b52580296f298fe3b2631be19b598e6c68ca767b31e4dbf19d2fb394980044751f4ed70996080cc66a",
+      "rescan": null,
+      "displayName": "accountB (ea3697f)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:cxRiLC1sL+6pLsyMZbVH7QPOOE4wKL5/rT6u2GtjSW4="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1659644448443,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "3975D69BA321680DB7C9E5CAD87CAA5121D615682CD09A5A58377E0214C6D432",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKc1jG1Wj4pISYlR6rrCIh5u4OS/jkcUwAjL9FYQ/lWzEugwhXX1UiY7wmFae6pABasJeBCRWs6Qro0yrV1yzt3wfiJvdtLIACmEkCEnpgNvOAjW8I3BIG8NyRNXHEd3DhMLWudSGGSMiegh5ypO9fQf+rwt1exc1YppWuaCKnuVKXog910B0LQC0ftr6BwesYiAFepuml8Ns6lW2OrqvsQL+wiwtBUsdl3l2LaqKJL+kdmvEeG25MwNnPyncHEWeHOCjwlPXrA2W4KzgvHqdGPG1OBX6/Tq+nRtKbDR9bBzu/nD/q7nibvNFG0EWEyCBkHRBZfxsRDGKGU0r5y1aBGrXCtybXVM2lRjbFCWWY+SuazsWIa2MJLMjuGkSUw6HtKgsq2uppTzhf71cKmct/0viRBart3C3bqGh27ffw2U2cUesZ5OUCRw9s50QUj1ci2VgMCq7fwGxEOcxMyzFClN9JEoQ1Pn0h9JHWd8zov2bc3RCXdxqXSL98CMV5uSOV5AD0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJ/NqlRvFf8rBA6SP7VtLir9WYfl1cRktxUEf2ysYsdWGO7HUIES9zooPmHSjiSG4fyd5d8Up63bM/VaZCuwmDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "3975D69BA321680DB7C9E5CAD87CAA5121D615682CD09A5A58377E0214C6D432",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:5hxlZ7KfUYtQXIhc3AhuROGwNUfZUutG44+bNuhu4BA="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "C1CDC74473A36631520102411BA1A59850156839DCBCA2CAC4FCBC2652B6E772",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1659644449863,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "78A8C4D2514B007421C319BAFB332D3DDD60E00F1DB90AC7576A3639C40CC1BD",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALFVlAs6xJjGXv+9lUcvHdFtXThokvZ/TcutFbMwRts29DGglhAGC3HCUkWLQA2hxbkkfXbTgvZY3TvMqYLd4tjBtbtfiUEvIKGRMSDfTb/hBudSsJJhu2KpjdUCPxVP9QpqbXeuFP7W1zt+ALsDy+Wl1QA/Lp/gtNGwhWvMlrKcN6A7bNhZghDA5/1Enw1syI/qnPUmeLVw5LQVkg2r6JkDhXl6DM1AD7H4KcXPuyG7BxlbDNk6n/P3BP6yP5Kxn0g+ENi9xgNaaq2e99JfKoMIQD5jzo9k7hUU3dAkO2APlvzsq9egvow6TMw3wBhkUiw7FMcDwTwCDHu8WnE511nucJf25oQkBqsmxuGaI79O4cEVwLP7HC/sNZgdMfPDyZW2osE/+p35FOi+FCeGem74cmIvuju66esWfe4+PKPvb9gnZWXcCCXXLcA7Y40eZSgBhYJM30wceFc81/75Watt59ZVrwea4IQo/6H3p+nqAqka2CYNtRfb9D+icPPcERDwV0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmIVhHExTrLU6XRS/zEyHehIx73Pa7mRDD8dNarjzYtGsXWM3tF1ScoIhXvWa1oPEu17wBPflsJZeowzUp8EiCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKJ89EbayUHVLzLnep6RkZEAdb7wNQK9ABYFo6DXmGiH5luFHj7cT63oHjWpHfUWnoHHPr6oV6AjS8l6884l6iigf52HmJfsmUEoHdCTOgHASyDC0VyvZa5Tx5ULORVhpRbZzgigsbRFlF3lRfYubi91ZF5ONlzT6OFGKcck0pGkI9WZlLEz4pSJRr9vgBtzzrYmWyPxV8LPx6xkZvgUEsqVUPN7cX/KV2e9neXw4gvfassWtjbXIo6lA72TOQW01Pf9LP79gHQtIa3+5ADIytOsqdep9JA+FV7JBQRgfk6fdT9lnhLpL2rNY/Yh/6KeKDDZN7INth7zM27CgAEYdNhzFGIsLWwv7qkuzIxltUftA844TjAovn+tPq7Ya2NJbgQAAAAO0nfYLoLtC0dBs/hSGvGLrV/IjS2GkMzHMBVX3mFN00yoEeYnSOde8250HBSrQ8q+eOfTeLCTTuusJg+lQi1dYblSb8x0B5imykxzrrtD9APPG1g4dqCuTeCVsGzPpQWjxs1FS1NR8hL/CSNpZv5l78ykZzMZGaAxoaEuN8syLTdLk1AGtH25CcdWMAllVP6tvOtwyncwvpw44/Iz6xmbKT+E+sx2we35dO4/d3lox+3GvLheSIvf+dxDrFw9aF0WWdCO96Lym4lfBASr9e72pcZFqWK25bfbkmsUpGoYP0jaNPAFwmVyVkEGwOgQMgCQCo6oTJQdPOx5qRvKjiGi54lI+f+ERwlBtRz0kOSGqpKZd6jqk868doo3YyNl43o/BwizPwsQDP+FZVc/Uq6z8LC8+R281wZZF8LWIF0gK0JI283bCZxpPusA3LiaW6aZKdmWmI+HBqI5FVeWMZARQghjdLLEgmvnQ1kma78e0elHV0rUAoEyRDyf9Ui8leLaziQBWcXhwC3e13cnEnSfTupEKzZOXqxF2oVuVS2bUQYqO3a/0F8uWIiTp+oCrW83etAb6ap1Gsz5eEUwV23otRVRqxzw0LzX9XmdgZHxJol1UBqfqnaW0IGweVNqlxRogOf25bElpD4CHFX7ZQBKrz4wsVWqYTFT4qYWBUS8Qfc0dCIPBicRXdXMWw0lRVUY8qNnHPDiwHUhH6KXH/eARx4TDlAa5z/cCnqe1HwG+W8QfoqQo/PDNuLCoOUupJl8UPrVWTZm2I3pBTaSKpaepFRT52IBZ6TsB4g3XzYujMkWB6IXYr9p0n5tU5Yow34s78FXzbNwCwgCfhMs8xaFJZNP9TKXFKUl4wnzv5GnLws1jQIWPbQwerD9+ScsTDUM96aSfmHC9OkizdDVjPMC8Vs5XEnJtVCj2y2NS4UKkPQOkY5srRBCMWGfoEuWPL0YzxkXaOBPxwYAnipXLSM/Fkw8J3LdLXCn2q38KcHFUArJj2EIM3Fm28i9lQqanDyEpRzGpAi/L/zCO9k1R3ZshO0hEtoHfKnBOqLZzhq3BhxOzadS9X4rMhyyIafsuYoy8gQN3X7fLwnkGpfRvWHIm3qLg2VFpce7q1ZAvnZV5SabbTYx1iXAhqAA6KKYyec3YuoIMhj4Z92gUAlo69+ugPsKynSXORwqhGmHUpYbEj3roA1zpWxJJiMZnOXsPAsSqXohCnbPLB86DVFDq2ibTKJUqj4nj96F6Sr8S3x1k3ybTgV/2BOualQf3+irbKNeKpuoHuZdhvLu3A/F+t6AF0WjMxIIhBcYz6XVMkFAZXh6vI41Sqx7wBIp8wgbKi1+Uu1rFSkcM9lwLwBeOJlW/lVwxBBc0ESruF3e+0Nvk/vqF953CwCZqEe6HuNg7bsKEaMNNJw742Imodpu3VIcaFmmWMPkC/n+jAjWsoJyXZSsbPhXDQ=="
+        }
+      ]
+    }
+  ],
+  "TransactionFetcher sends request when node has transaction, but a peer does not": [
+    {
+      "name": "accountA",
+      "spendingKey": "e44a21c6aad49501f9ebad09c28e1975859ffcfbbf3f4a8f5ab2d01a020bd4c9",
+      "incomingViewKey": "7380c34b06f439174963f8b23f57bb1e1201660cd6341cb35abab9cb4130d300",
+      "outgoingViewKey": "c38480cc9fce94d1fe5da67b1b33c26aa1ba48d334c85a6c09ad60807f9c2ca9",
+      "publicAddress": "bcbeaf07f3dc52c1fe588a6533c199c54d9bd02ae6bf1a780ec1321ed1a583269084af6474fc7cb3e24ab6",
+      "rescan": null,
+      "displayName": "accountA (27ba8b7)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "e348354382eb0e55cd48a2eb80099b2baf41ba7b1a2dc55c982d9fdafab5a7ae",
+      "incomingViewKey": "664e90239058bbe089d70c2ab3d2189a9ae53ad43713d997a993e139709ed902",
+      "outgoingViewKey": "54278dd1119af89947d578b903055227f5990edd5ecffebeb561715792678e47",
+      "publicAddress": "95b27eea5e32ac7b9c617f8d202caf3b4a457f119d38f8ff01db32cfce8f73f34a47fbc6ce76420ae18090",
+      "rescan": null,
+      "displayName": "accountB (385d870)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:dQH5RmhH617qQDx0ySO6NOW5NifxGQOWTvSzgi18MA0="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1659644450096,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "A34611AE1E98EE0FAE2E9DCC4C89B8810DEE48DB11E98F35A19E68F71D19D862",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIxcolw6nscxID77vVqsdyCpegMb8v/dbUl+qFI8Pi3fYFNr0nM0yuzehfWMy03aZrh5NFcOl7r+othoDrljFkL0EowGWMlsErTmCeP4NMNCgyLeUOMNw244Ol+KgtVutwaQZD4dhom1Yp3QvzAs6sFYCB+leRaUfjC+1sQxG0x6U6RqmiKYWnJYSikL8iM1nYWr8ExWw/AYguVOwtZvjCMZ1VFWUfz689a6yu7QZx/4MscDZveT4pHFjAOjE93+aL52e36d1GVIDHmF4APcgb0AC/MBxrL43I5Vx+h7ixTBHuZGsZW6wuRbxgM+KujYp9aKdtB8HxnTXfJCKHfs8UebmjMVDYbLDZW+bvNK77t22sllgD6n2WhVwqJ3yTUwULInrqMc5FQ/QOBxCoVapavteoOPR3TorM4261BUlvl2qSvAB/C/2wTEoCttEdBrL3esM9VpwbMVV9IiyUYLoh+/c+rjTQA74lTU5Ira2Apt5IKJvEqdHI+nYbbKUl0d1hBZ8UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAHjNc1eNVhop+11Ee6xW18omZQT+QfRwFyoFqvRXzskLQCMPojFbE45chp7AvGWzJqZea270/vN0LJp6X/LMDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A34611AE1E98EE0FAE2E9DCC4C89B8810DEE48DB11E98F35A19E68F71D19D862",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:gtuMK6T2NmdlbltJEHYGBIc9AP/j1Jo5s7n7XCAxikw="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "7FDED1BE05DAECCF07A0269D5878DA48A321016B8844224383425B8BE76ED4A8",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1659644451443,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "446F51A34DC1BB57A32A3C239B486632B434373CE2490D4700FC2F120F310077",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIe4xbT2CsGffr5nG2t5cGIeYLiVwAgAIJPoBGYph4CI2AsqkLRJIoywnC4ck0BlO7hoDh++zViUogZ39ch34t28lKn8SjFtpSXb+StB7Zpi5xzXtg0/m/PtXYrgt6ROmxX9zCAyu6xCUR47SFxQ97W6ryCOQZqTCArfTA1OwAZnSmESrSyjRad9WqGABlusuIUdjCy8dNdRLCtVaA4bq5YH5/LIx6GzkcqgCIDdG1y9T30SKL/7nbqCV+2Ocx3otyuamvlm7JscQTacp3C01NLxe3NlW3TudShQLepiJDKcWYFAtynR56BED6z8QzOPgUCtiD0HesjG7tIIjfGYBDFh/6tsEdh4rfnr8pM9sBl78c6FAf4f3KBPcAmHTANaCWsrQZjQPSREfjf2C02+b3wnyWgamP6jmJZgHrzfVk3kLq4LrgdGSV7VLok+3kXxYwBufcXoUap49LqoZn3WFlMzP9xUvDdP5UDKDseTh/PuvDLovW6rG7A4OFme5r/34FbS/UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwHVYb8BiYygvwcOmJpLbmHBDoPj2y0NjZEPmXKWaYKUlGV8Y4dPvo8LX9tGMPwDMLLyrbhQJb23EonOJwE/kSBw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKtW0Up9cCgYHzzmrBthdvQMKUfhu3jqMvgi6VSEBZH+FN/8hbKWGxe+m9Ry8papoK0gOoehbFMWo4wW6jy+HE4PW5CePlmtSqlDQd/sWI6aZJDAlQLFszvlxlHxN03RpBbAjDQkxAxzjG5pdDTNjz8AmxOEukESB/SlhxpIaPfBudZYduI1extnVL6TOvxa0osw5bAGvegravrkwrCP4vV2t2nYItaA6yqhFLgasuFfCLTsVxc0gykva4yZuyRvMwZvJaRjOVj8g69YeLbAQXRJJCQ6Y7+8uzRdGfnEv9fvovjzyrX8NyXBi6oMFGhKnYnjHeJDoMlqvnSUEEioFsB1AflGaEfrXupAPHTJI7o05bk2J/EZA5ZO9LOCLXwwDQQAAAD4r/MxJxlxqa2EvA6ak3C23EL3hVZ+CJ8ER/KX75JO8oGKlQhSqrk1/A/YB/mwbpLx4dBOFyv5Ss72zKQbBi/vB03wCAKc9/Q4aEj3tcX1SNuyNd0J7u+rAKSLOa6m6wiU9iqShvGt5IwEjJ2qBu3QNAsZpn+88oX9wUvyrihMgBJUWnidI+h1EytA32KpwMasPVsvPy160zLuDsmp3d5/5l2+Y0xezNOHHc0KNFwn0eHVIeFLKRVphFijg9ss87UZ+XmZhqpqp8fEoz/sCNLCpCt3uoBFuzeBzfZ3zrm4OxVdj4pDL61nQ5IB5bo3dTyQvUlsd5lkSR1X1t8MBtRoyBP/UHCp/YFf60i6XWrmwPZaFSvoJiyVLOC2GWz9/hkd5kGW50vIk6gW+3sjiooIUWECUO8NzWcfpGcOyixTRu2Wr6e5b1ZjsLcPZTNxZT2DUcMXGeCBaDChdo5ZLEdP3SS9VnbPVBziEhuF7M8C8Y66+zbBhZ9N7dT2WW1QDEowNmGd6ppfOcjLaKocbtzicuuDd8IsfAzywuVb+cddAxCd55VlML1ZuzZ/evGkuNzoKbouOeINC0FqnBtWIvjP8f64JXEBVKVoQWYZKsza2Viad3NpdFPkPb3wHcGnK2AguGugZy2fvdlPuK/QJDP1pkz7MamQFlySeNqzwCOY8BttQ+1vWcvlh7aBHssZoIQervIo1q3TZlPg6ljeh9krbPctGtZxkpmnKewwvqo3YyrK3YYSeEeR2EWLmf5WCikD0mWn1Qx9HCFjyrak98N12M3Gj6eAMqnBG9IvaBUaq5IhrYEDCpNw6DzVn2SyQ9y4E05FYSNC5MeFxaAOfp6DBUSGVNvzlNCkPbtQ++c0SmggARByGWvammv96kbOhjWPteecUxXdsf2exk8BEaVo+f5oyFPV2CtXEie3z/mXgWqgoKfZvehCliCKXM2+La9fmDmA6EhIEZ3L5OtgTZX0fGHHVJplF8kZ6p/lYn6JBtcGY0LrreGG9EZzMPmbrQwxtOdrXTVIaKiEJaWeqBSgc8Cwst/GOdapqy8LGKCicZcAnWI6Mu69QpN99SI5aPozh2EKUSL3PmfL7cJOtmKda+SfiSj4VIQFRfOPm7WtQnK6x9ptHSE61ClEiWZlOpVav+wNYMAfg5S8jIPOokfHWwb0BLdEX6lPAT6Ef0FV0XVg8osZPREkSCBkxwB2WlEQTIwCScNH/ZP05T9SkP1MOIKxVLwm0E7TMhgsxL9UNYwLbVP+vSfOchOoR1SgIXn116+Ex+vbJ36vK5IJrOExe97i4cLYfBKgzZ99xdcJCOyda8G7TD/CVbjxgoqn/NIwF1S/oqHDiL36Rs2wWWB0civT/x82hzGZBX7RWNw086HLph+UJrIrILm2Fis50MuarfWtPdcWA8Ejoq/o7tUx92GK9EMVAjN47z/X/6dtF9YT3GpTBw=="
+        }
+      ]
+    }
+  ],
+  "TransactionFetcher requests from another peer if PooledTransactionsRequest times out": [
+    {
+      "name": "accountA",
+      "spendingKey": "661773dde38ab4046eff74df69a544425da6557c8067a154a4ebcc994a58d72c",
+      "incomingViewKey": "d82a76a6fca763627fa63a7d832093c2999e6af53c6109958c592ce96ccb0304",
+      "outgoingViewKey": "138702c932b13b7fff7c16db6cf93aee7ecd7f69423c3631b25624d0aa48403a",
+      "publicAddress": "3916b5c731a3bab753fa916909ed46e31c77aaac0ae3e9a9f8e706cf64b726b304e00621023494284daa54",
+      "rescan": null,
+      "displayName": "accountA (d0f702f)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "313817394369be391e38c920d186cd5c29eb6a39cb8fd5a6c24033c02ca1dea9",
+      "incomingViewKey": "7979d5050c101d644ea97409afc59bed500353348c3613b9dab4bf29b34ef806",
+      "outgoingViewKey": "0872dcf43d88dc6374f80ce88ed40c23c4daa5905d87edc98e0553698d8b29d0",
+      "publicAddress": "89e34e2823b9183e4daabedda5302b0b19fb8e80d0e0af02f840eb651adf4ed59032b38ea4ce628960fe1c",
+      "rescan": null,
+      "displayName": "accountB (8ff0e91)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:gy0Ypzg17aq9FCc0ZfcI/JNRc2HzOfV91p5Kif8S5gQ="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1659644451688,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "0E345F80657A641C5FD138F631C85B9DD44067B811B685560EEEF804903D199A",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIBFKs6iAq8m1EOzD9W05yV4uAMlFKgm81HO5DbD1bJaGFFoXk/dzUVNGyvhcRh1LY7RZ78URqsIWt+xBeP1FI657/7jrwvtOZG6fv8Rk/TkwjL2LHr7PvZ1YawXzD+h5g4ToP8OX2ufWJP4KbMQ1/FqCGa8KWti/DVOulMCSGhLJts+VcTjDsbStI9FnRdm7YIhNYcns9RTfIvIRL0wGGE7jJy40xJ5zpb4p6qqG9Eb+kXE1p3omQu8au9sdxN8YXV84h5cEw6GEr2fsc+N2sOMNt7U3QIvrvzMwoOV+Wket6vaEUYEM9GsQAAd9hi68Brtf6wKCMNUw0jgUcpeaiuwwLr8e42XfsAdFMGnQ64mIX4P/LRCoMnY/L0N1NKRouvadRucvmgM0GA9gyLolXJ2inkrXdJFRUGUWId6Ovz60wGUWVN8RCu8eAhJc+nyKMvVNVDAavTVc+chbnr4E1jITHFFYvlmN5x0jmdtJqgPgTVjdOgN3t8psoB02c74Fj/b8kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWRgRvWhS0+2opSEGvc5dZW78kWgEBc7VV++lj4THEN/WTPEVNR1hD8z/Fz7XXJ9JL/UKyDKcgXxmqg71GLPQCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "0E345F80657A641C5FD138F631C85B9DD44067B811B685560EEEF804903D199A",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:duvJw0XLOA1wPw3otvokSGYsgK772/7qTgbszmzh8W8="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "ECADF4074A79BE89DFBE2C17DC292AD580F5FB4BC3F0BD05437BF3F5E65F450A",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1659644453031,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "A560E18A07024469E4C2F1833265A5B020B13EEC66CC9F7E2190D4EC86EC547A",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJMbVKsC/WjTSubS+Nc5NCBQ5HjZmROyqcvcurbsD2Lr5URa/AxTK+e3/RjVweacspJ/WCsBITEW/AjSR3VSKL8Dz+5gAkMFyQHhmIt72rogyOTd7rTTUWOnw8GsfTf5bxVuAe5M3i8fXOPQUQPITvXCzuDiwcH3Yb31o6yvxjQzTI3/ymu/x8s1eb0ui8vayqrSMYhK38g8UDYJa67DF9fJGvAx6BPfH4PNaO8wQSuu2dAia118E1Bop8E5ogOIM3CfO2Ffg//e8dXqP5cGceEbmg910nv5dn24YfCssOCA6vv9p4KhjFHoilyexNruF291GNEc+hUgAXPh9s2TckmrMfT9whXjaS2SYkXSMvigexaGluONDCFoitdBP3GsKU9A9E8CEnZxvyWiBNElKP1jVFBEJ4CT5SjsFpgZRbZwOtPqcbwASiFzEBIm10N9LvBoUHF19rZUz2lWQOj8drRMAIiB88dK4ZSugKD6bSe6Jo9/rTVl48/u+jbHnZcWRUHBGUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnyzZpjrNKbpq8r4oprxReJ3iwEKrmfETC6igzf5VCiKtab4stgxIa8ZsHsGariQRj/5q9wxdK7C5Ty5pz1UzDA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIOLi6LbI/vArrUS8PLJBcEvTEA5wSH0iXnjIXMK5lB5QdJpWwetFHxKAQZpZht7nKO8/OpyI0t9EKqb+MA6maXXeUsPYA7NVBtqgN0UHHnGe8c1sL/NZZ09yRT0Kf/ZMQyUdbTXuuC5nk8MSZjJthmzEf/GD3torwhBvCtcFm3QcaarM46B9x/BDGJutKFeuqy0NqoPMJ8pfdbvQUJXDgpXqAOFCROygO2WDq/PnpEL/CdpUli4IUcZiPvf865WEn0L+ycADt+Y7t7J9HgZCDMt/K9qoMJPGbSfcGzgv4zkfubnB7FFlZyCnsUQlSKw3yUvlRMAI6mdEeUDu+glZUiDLRinODXtqr0UJzRl9wj8k1FzYfM59X3WnkqJ/xLmBAQAAADvUN6UtUcei8iBxVOPTaIYOfcNcE0kIpyNXIcQPlq6KtIYm8f8zXfHc7/U2bu9z8QF1w8N9veHwmupEXFMpt0U873M98ajlE71YPV0Tgt3mL/ZRU/CWZ70bJU+rq6uKget1LeZ7Qz0GWdjv9pxAvgAD5vVTK4MFCIE8lKPQer+46ZNLdNWCp7xLIM4GAU8zg+n9TmHQsTGJx/OSM/UL33agevivmDE9PbPTVGm8mV+2+MEOg/6BU/T+sG9Yu0in2sA/MtGhgkeLzxXZ/VgitDBm1DyKwnSQABrr7dHdk1CICjZWtdk1nk7Se0pa0HE8cy5wrBrKnXvCZdAzB0VX2QIGzFPnRakkPW3zrdHbQtWiIITWtvkBndi8xYK+kUbnjz+N4mXeEupwZ9R3VilK3kZbIWTcahn6Y8LMRXhqXEO2Jl5/TGVd1Ifk9hA6kh5OLafz+KFDmGFPm7VUdb9oSAkgwy/L0pcrwhk0MUsabKB8ATiJz6rHobfgOWYPSJbyOz8ARQSiH/krHra7X9IX1c9i1BLHscB4PA15wHpDkSnaXAgYNuz8XTsckM2IFkkUK6w14ykAEBzd/hxKMHYGA36nXuw7A3s63+tk4a/11PXHndUlOej/p97Cs7SPR52HlKL6D6C6IJrNG/g8LuMor3FqVPsZVpOLPjisplyhbpixf6foOz/Onh0uVw9CYdY0wcnzvUSVx4JNcfhyIbebjGHNu6nExfuZE/AuvB9VsAH4Rc+TpKASb9IUNmD95djpXEgr9vgZK58zX6gR0cLlEap8pGErDkegIgmh620tAq7P46wCJNOpjc3LevZ3Us6W712FYlBxHg9h9icxoNy9aYT0nDFBpusykRcYt8mqXdyceyQxAwu6Q0mut/I0uxS/eUVUNl1g8zZZeOo7QeXYz5+Wb1wNm7TOKRrS8+/rfZ9aH63raSAWVsyPnKWAy6K3V2UfhXSHtvR2NBCnZ1W4TK1BCuNxeARWoqtPujoMlx8vNhpI/sNlH1yDxTo/gnj7b8x8rQMhmtuWlGhgmodDppfwZYmPVajr3cH8PA5OJxzQ4WFcCBqMnGq9wFqsZh16NMOPE+zODeen09M2du+qzo4iGeKrqP2ad6OZTG3RasJOhcmatswtyK8OmQhv0tRaQEMFUYzw3x1SkLrt4LKQ1TiZX7on2k0gJvHSBmRQiz1c+rT4IBRW1ZQzg7MbGVXoyOcNlvdRXDeLY4NutfyP3p5hIcTZf6BWMGGz3iRch9Vw2kRmF8Lp+5xXn1jV7EOWXBwH8B1X9xlDryaD8/UhBI61mPXexCUhgT1J9BudSjVznvhaW47/TZV/pXkmdQ85bw1tpwkc9VcFP+FCWf9pYH426isDZ1nNma/YRLf2ZfKpb8Oy5IpzZLDOJVlABWBhIO11xRYwJ0Gy4QEhYzjloM6LEXdxNmOAJzUc8IiQAu4TVN8yDEkCw=="
+        }
+      ]
+    }
+  ],
+  "TransactionFetcher requests from another peer if PooledTransactionsRequest fails because of disconnect": [
+    {
+      "name": "accountA",
+      "spendingKey": "0e904ea89a7cc5fb935f4b005c3c66cdbe3fa32327dd94eb9e4c1e29e597f06c",
+      "incomingViewKey": "7a168321b24ea0c0236a369df64b4adb38399b3222d912b71c0a1e09bb7ec805",
+      "outgoingViewKey": "c6ca99942bbc57748bdeb9b989ec9db7d6153a83b1098647f0e429247edd10bc",
+      "publicAddress": "2f751740862526c5fb25848d8927ed662abe9f580dbed10bf897815cd9a5fed50cbd9b41e38f8cd0c85fa4",
+      "rescan": null,
+      "displayName": "accountA (f3aae3d)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "25476f090ac1f326837df2794c23c921db4ce8013a3a0a5d1398d66b68c920aa",
+      "incomingViewKey": "a5d2dc889b2023eecac86c817f3c36193e03244a938cc58a6e7ac67d9c5b0c06",
+      "outgoingViewKey": "d03b54da035b2dd3f6583931a3f41ea23754161f947fcbf292900c2d7a0bfbee",
+      "publicAddress": "66da9d69b972dc54d54a4e61f30ad11af91a2e9e4a14fabb8bf78882b3e97ea04f2d2b229557a1ef7c79a5",
+      "rescan": null,
+      "displayName": "accountB (45c0a9f)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:9tOeyZijof+EHOG6r/UcKhRrUpGSoutb8hfxkwWXFFM="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1659644453249,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "2101138ABA983E6170184ED2F3AB4D0B994AB73070AF5F92672F1B469E38A4FC",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIR3qQQhJCsxa75UzaxI+a6+6MufpjAkg+K2EGx3ZkpVg45/0DEagRr7phlNfpJRuq+UEAVZsEPq/ibUyU/HhwgaiI0tL0lgZuF1D3CVJOQPWgfMfezks8SQpZVTbV3t+Rf8SkiYdWn+Z1EiWMFJaDaYERS5fkCp5OfK41ltrZQCYzrlBHlZx1+1ELhO+rf0PrWmniS2fqVQXsh68PQADiSqLvT6Ffl2CxVbe5ughll4Xps1Tvck/EPg3Zypf0+o0BWxq+Wg9dQpn4or8Q9jXUJGAmjkGGvX85sXAG0A1+0baAcByud3rkjx7eNz2tt5tusgGnYV74wonxlwJFfOonF0sdNB+Ur7tKisPkP3cZKDCcHkGLJi19TbeOsIUsVN0ffGgI/WEhIL8FUi1/s7tZq7r58tRQXSswbbfaQEJ8QZjzoFzJ1EH9BCxjBN8dkoV+XGSj+SbLKBgY6IiOvnL2TE8i4SrQ+uvTjBqL31jcHohkB9wx5ifYvGrqdV7k5tCTbcn0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYfFlWWBTrOAHAOzHrEBWfKmjwE2LO/fr5fAwpkJvekDyQs2hJliMR6xkA/7GfHteHjr+Lw6y58ClzR4Bh4GZBA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "2101138ABA983E6170184ED2F3AB4D0B994AB73070AF5F92672F1B469E38A4FC",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:j3rbbHzhq+GvPoZ5rWVRddVGlucc8c312KmhrphreA0="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "A23BB75286F8230DEB0826A007FA8A5B9087B0E80F096CA2910F241831C94C14",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1659644454602,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "39AB3F0C20F8C985ED223BF1AFEB5CA48A5C216F74C58178A67553343D52728B",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIW4jp62BZEwG1lYQJZk24k1AKu99Xl5rCby0BNuJT47lZkwl1sar/4IyUs1r+UhR4FDWOQ2GgKEu8w1M+jjVw5CliH3s7Fm9lKbqd8IgI2JHA64yJX652fAkBfijyHGZw94utqkxscJcvy/JELALPRohheAKTg5O6ujxQnAmzGhd13VAAKlJBokjaXL8cdQFawEpiyH6y/kRBXdmQGTMtjUtFwAv7tT25/IZtXAIqIj9q4ixQe8tkYBMD2INIzpVULejJOXtI24P0xXAjjyGrSmoth45sZ8VMGHKwYNR5+/9nx/yrKt8MszD9/DIXp1xJZMKrDtcEZcuiHXv8pUsS0RoJR0rAeZpoMUxB7b0NEf7S0LC6jiixzfqE11vCmGjvjEdSHc5GYjDIvnt/iffEJBSijN0GC4YWKHod3HGwkYDkiJ31Sq3MULjUCkkzKJJ6t3Gwsi+AcjrPSNJUOlQk/lJeal/s5sSOrsKAuQMeaj8ajGRqFV9Ki9lMUBH7ycNtjjdUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwElJt1jdCozoPLaRlAr3MUBBUlvNJw7neCKQheDVBu2As1CqNLJVuPpjIGYQbTnbI0JVxfG5xsd30yr81zaMeBQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAI81ARay5GZ2cpt5C2xCnEkVBhU9Bx3OPL/zo73uiQieTYEm51jj5e1KOgttQwI1n5SiW0qP83/Iyw/2QV2Ab0M9PWVnM601dpKuUdvzK7yqNJWZaOwhj2dZ7UJECKH35wAvcxH+XUCj8r5vXK4osHq/6mHtiuVsTYsOcYYGBP7pZJfktb9oqokuDQGLJQprYLVOYqpf+qqh5o3baHUjB6zBIZjvOLlhNEyp/axEU6E8PiN7uEOJ6T63SHGHdf13nuxZlzPKT7yzka0YlkTcN6HMuIAifUXFaxyl3foEpMyc9hAwg7ksbmAxX8c8UyIiuJIfJ8lvr2nkWJI3wYttt2D2057JmKOh/4Qc4bqv9RwqFGtSkZKi61vyF/GTBZcUUwQAAABTrr7qmyOqces5ITsXLRrm6zbJFkKyi2MONnJ4DHh2zYruNBUBaztjpSU0BC63xKPhdD8L0WxVIV+Xuv7MKPlOD9LhghXwVq4NIDs5r+3hMwQutqo3b+1ho2Umfh7OnwmuchVA8+1KCmxxuY5NNvUbkY+eoK6gYsNqvLSkfNwMX4OUMpnHuBGLl2ftP+QVru6SyIXrR5v7kn6D2Sc4MX/8qonLaxe1tc+KeYrsoaUdCfGuzhZmZG0JLq37fgTOWyQG0CoIe/tgcXFSNFgvkt92aKzeI4Q2SxQIHw7L1BKagb5v+vy+bcV7iFajSfpkJIa0uy1GumKk3J6wPBUfeUs+H0SgtWv2yu76TMr0oy5BcRUIFwymgSuGkzsGwhdHJs0RhEhZJ3i3MHtuwfVQOQQm/ZMkvHs2WQfquMF/nl0ZRIBJ5AXQUSh5DlbrkebmJPTB3/rGodswcFSdpG6HjQ5eHZsTXwLdRkmU1aYWMQsCIw2fwxl8qCyA9blaeZJgMcugyIzbwoO4VAmzDT6HgC6dN83FmvbMAMXTFcZgrHIaMlMVdj7khpRRNTiNnDdIJIg+AhBq2703TSOr1ZTDgVVXZN3I9QGooQMSBRJmreK83KlxKotwr80xZcI4RObkn52xBpSmqZsSsmaq/p+Uh/I4ezLX7pMzOKuEUDRx1X8rx25/if/QikD0nXHtynLDLZuOkvBX0LxO76Zlto7Hf0r8m0Nw761e0Ov76Nrxw8YW0ouS0rDWivrlOyyYa9H3xncAa+GUQplOT8F5LHZ6FWZ8XUAq02Lhu4KkGROYUsFOvRI4GKDmeH1ECW6XstDcMVoGT5G3Y7RtvoY+BHSKWKq5qLr3MmPA3y5704L23zoVFQ+3bg8ts1DEklCe8kf1MFIYUpwCuiNBR/ffZgweI0mUUul20qMcDvq2WE45zK5mQxjOMoYYTgXRFo9ApjIaJRQLu+IiP2PlcIlMGSxDY3tTVsb4mQwZUcZOeI6+33Wky7+oOOlGdAx+FQZhlF0624JTW772wAZrvI8C2Z9YFs89c+KEwhLBbiOQvREABkuB7pbs7WIHFiTtNfXl8B9NMj84M1/R48BeH54m1UrRhChxLgDDmdJcI6ln+sgmgPJx5QiUDFcCLMe4MrxSI1txA9gX+YsELHFJoIljKxpBAAG/kgQY3Lj8aWJ6zxoqku8M2dmdBKEg5ejzREZ/yCqY4ZE4raVObyaxnFCYr2sPTG2l1yXYa2NT2RbvneH70mdQO8WwPnAo82llP8R12BT2jeO6eos2G/FghSKsBg8XvtEG9cR9niK0Sk1ajf05k9i9ySxF7GdglomMRPS7JNYmM3ZoVHLD+KYJvGF7cHwEGG2rFJeHiJrIlYqbMFQFyOkKxfRzi2M9aS+VJ1lAuuERY5SBh7xy11uHfCN1TG5TsU7w0Zk67QPPnuNfUrCUcVYDULKcwJRnCQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/network/__fixtures__/transactionFetcher.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/transactionFetcher.test.ts.fixture
@@ -2,21 +2,21 @@
   "TransactionFetcher does not send a request for a transaction if received NewTransactionMessage from another peer within 500ms": [
     {
       "name": "accountA",
-      "spendingKey": "10a98cf70df1fc662a97724e4e78d0da294a50b59e96805833ecaf4d1707a9ed",
-      "incomingViewKey": "ca35afc39e4f6159d664c0688c5774ebb36a3dd3d79683bdf2585981dbb19a02",
-      "outgoingViewKey": "8ae56b737d4aa41d3082308014606398d66b0ccea96bcae94cd663ab2e2a529c",
-      "publicAddress": "9f8783cb987ac3ab36ac34ae78dfb1f733d0f7ccf46d88ece5a1350c5ad8f6a8b649cdcbb9602a62ebdf28",
+      "spendingKey": "10a666d53c3d3db92748b10a7a1696fca337d0dbfb31202e36527e35f294e1c0",
+      "incomingViewKey": "7340466fe86a40a3ae393dde80e6e7ee9162a5fc8bc81c0ac88a4db7d679bf01",
+      "outgoingViewKey": "cc31d392488e9311ff50e82857c1d96fa8e9e6a357d657c9585b4477d21b115e",
+      "publicAddress": "2d1c0bfcb50a361ea1f5535527a9c7aa54a86476441219f3e7084bc2062897e2d0dabf6ecbe0f69601331f",
       "rescan": null,
-      "displayName": "accountA (9508cca)"
+      "displayName": "accountA (ffb86de)"
     },
     {
       "name": "accountB",
-      "spendingKey": "b5c33788fbb7576b059e5e620c419d3d550e6dfa8a81695e93e200b1c2de8397",
-      "incomingViewKey": "ebbe7456f3165911d090074ab4b8331dfba52d70d23e4ec9bc861e5bd021e903",
-      "outgoingViewKey": "291c7797a91302904a19931abbbd7313827315b3256d2132fbc9bd585bad9119",
-      "publicAddress": "1b70a09f21d65963d2eb342da0abafdbff0c33c694558df1d933bbb664e681bbaebc127311ab56325795be",
+      "spendingKey": "fe5473e0ec0deca69b6e1079a6e7cc8a48156a64ba95b72e79ba09fbe4a6b334",
+      "incomingViewKey": "07dbb76e5469d7aec7cefe462c779a46f87066f5537b14761ac154d9eed80400",
+      "outgoingViewKey": "ae5276035f01df0af502c395547792112cb23aea4dfa5650390212b33dbc144e",
+      "publicAddress": "d7730bd0109c2d7b97f64c7a376e91ab4d7e7341fbf38adffcd759f213043bc4332be877b5f77e775863ea",
       "rescan": null,
-      "displayName": "accountB (d6e9f37)"
+      "displayName": "accountB (5e95ba8)"
     },
     {
       "header": {
@@ -25,7 +25,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:yKJ0YgIqllCN0lHLOCKkfi5SFxiC8Po9cIsP20fd5kQ="
+            "data": "base64:NPXK8un9i/r39xQ88cGpNinhjXeiTU7wK4Bkl8w/cVo="
           },
           "size": 4
         },
@@ -35,50 +35,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659989477998,
+        "timestamp": 1660092435076,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "0A913818CE78F8BCF78944DB2177D538B875C0DE5101F3258CE3E1A641580D2C",
+        "hash": "15E955DCA7B80901E43FE5347D178E405C748665513C7B3054E84E3A1B829E29",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJFzqH+CPXa3JpnaUybiwFFY+21ykzyZgJMsiHUP79cpZecuACY8JoAF/bS4eTsX65cAneVXq576/6Dq2E5v1GaH3onK+N7bn3AZCWWfd6ro+6lI8tLpVYeeb8wTMperbgaiyNv8J5LuXwBkKf1QQ4zW3ThyzDDb9Q+ZFcsUhPOokpW+6WtU6/G0a5bERVUO/IYYZh7viROgP0efFlpT/XL9eyjt0IpCV0vq6KpVfC9KLBXt/OkDoMfcNf81PpDbc6kj3El5T7PdegML4syuezkiqG4efIwDu4hCYSVnmuYKwTPKGG54VEbJrr7dwpYQhGmFwOJYQ00H5u3MPxJg9nCmty1tQltFmisUk3s8hCUL6yX2daNmRtlo1fCNEBYrb3togb74xPVMiX/VZLttUZ3yVhu98EMEJzcwADPGDYRR3fK8E0swgvkj7fI4RTXnHmfzY7GRHyWLxYEhojsLHCnoE0b5T1M7Qti4Nel6oqvX3wmWjVPnAyKgyDrREQ10wBf470JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3JW/ssMT5epQ4D1oTE9+etziVPv03/836Yi+SYwpiwigFTgs6leF53eChcHAm/dGTpoQyEvAiHgmiQtQEVSyCg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKNEpFAOrWYcz04zc5So0D+dhvEHYf6/BrK7kSedbKlI+ofC/Y6kt20jR+Fcgv+/s47mCUFacc2hEFY4ib9g3LArbtHsLrezk1/veM7wWEL7526OsuV+6r9Y3524OFOHqQgcAy5P7p/uuvaGnpmDrH1P6G7nsq+9YKAEqzFig5Lu94foaNOVLyU3p+PwCeSOkpnCXdGTgiwI+qLtgO7D8Wxdq7+EmW+WhL34OZ2JV3sDKTlCpjj/L+uyU2g9nTV+h2N1tMiTvdzoHw+CsrMwPPB5yLrA5JZC4TXrmDYckHWwJx6eondXMm652pGcV/ve8C8ZyYQuvpjHlQWATZQcnDK4Pef/lGCuMwqFyEFjNerntOFgdta7W9Ua0Bl1J3VgssVoHjN8cN8uPrAJm2UIhpfd19PDMr4+mcUeeuHgPbs1NE7qbGFolfmCTgI4FqZXVWw8BqLJr+BLxP16cpwV2mkLT8dk49wShMbihRUCUn8Pb/rcBcLRWFqNfihywGrTtYtn10JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwiQQL9MvESE3pKvfz44Wh2sHMPyBYlSpABbNj1cyzQU+Ue/rWCG4tjXK+TFRi5/g6fnq5dxO8Y3JlRj5JlJ4/Dg=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "0A913818CE78F8BCF78944DB2177D538B875C0DE5101F3258CE3E1A641580D2C",
+        "previousBlockHash": "15E955DCA7B80901E43FE5347D178E405C748665513C7B3054E84E3A1B829E29",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:I7VZlS7f9eycoCPcGu/+r3R/bbtHFPy8VDVmUa/BMEw="
+            "data": "base64:uVpwNyXeaFAhWTwzGT2W+ULyjcj1WyILWLizl/n6Cm8="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "C864DD1393C9F5B6BA02E4F82B66F2B8BC68B6C367FC8F17B8E220372BEBD1C5",
+          "commitment": "4473FF2A84D5549F0303B8F0CCA5AD6714233FE30A6CC0EE5BBEA4586A583A80",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659989479339,
+        "timestamp": 1660092436410,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "406DCE7CBA2D9DDA4AD86425EF2D35007A46F55CF723FB41C2F2B08714D0258F",
+        "hash": "5BF55D8FB16DAA17818ACE99F89A479DBFC47D2CC654C0488E7389C8A3B9403A",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAK0q2JUV5C1uf+R/W+OcH1r45dvMa3HVVlrayvIg//wWtaIEKxnJTSMKWnxpDioWr6kEFUlheAvrqI2xKRnGChrOtiIt5DgQGnSOT7ZlJiz3T5cTv8HUk5e+HLNA0g3roBZQZM0iNK0E6ENa72bj2xyf9nB474c/4LE+9V/nH6O64hts50wuTMDLXZsyAXcwSZLXMFD9m9uuSroPCCPkJdDWCRjnv7XuwECVj9kcXUHkO2XhbVu/SJ+HIcd9WY7tbLOVJEeMysREOaLURbWKviF1UA0IyW0ekJTNApb1DhxB4Qxc7iFqI0cfHh0df/NZZorJif28OlYXGgLeuuitVg9Pn+iOHxhWkKlFCfZeCH/SgBIAAqOBKu9rl/YFL2G4wr08TyxODHP+yYBVh0kpKF9FZVYCLthkQdH8yxx5Q/2BBNU4PwfDNlEgsSvGTjr5zjFv2Sp7eTk7Ew5Jq8FpRJWk3fLlmuWE1GcKMC215eKBntjeqJLF+tqvS1+xdsEnrOas40JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwk8p/E9DSoYAYLSOsq13Lm82XVoyn5SWZM4NC2iX70/9XFtQRVkQa1iILlQxLSg3flT7qMkTx6H4Wu31WJ2WDQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIdVi2jK0UtBdld40CxNRKtVjWWX1U/T/IpDBF66FbvXxyWRrM/Ui5bcFSoODedeYqofvYJZ0d/iDSeW9tTNspWCSqMFJ0amCGnHxUcby/l6qRvqW87S97AODFHccu845RiEAGj4W8HSRX4Z4foVXVrlXYNYExpzLBUVJmG3Kzvjmqxr1zMP7+XcCbK1u5q9266fn1QPa6Ov3Kt+ENHRJaLqOtYod0FVDpvHAR9jj5mIUaShaRrEbsJVlKZbv9PyffyB9ik0BVydf0P3iFua5pG0qqP53q1KS/qip+hVDSo1U9q+39rO0BHaRo3vlz63eJCWBt/+nX+dundhxQ3QwiFALTkWzonarb/bEPt4CyNvCeTY0LA4519IycLtxMRAErqVlyy3+4WLW789iXzT0sEmhUOh7gGaKJn8JH+eu9pQ7qm00BGkHrIPp8bvq8zuR97yEO8YQ97i6p17hueY4//99mWOun1XF8ynO963XJTmezbSfqXL7xGJtp0dMNBcJa5XxUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw26WS+O6SfjfYG2Ou43LISo77/k3B7WpSzjQA33zlP/FoOJPUx9bZ0/4+kR61JqQKcNMlyUbu+qjGeM57raAUCg=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALQNH4TdwihNtd7VoP0LEsD2hwPhQGNEhmisfHMtEzqpb1l/Te4SE0HjE5vbfEUjuY21NM3a9QRAtY9uxi0gKd7GVg4Vo1Lu6KKypEuYPjisd9vai2bxGpHDD2I5z37MDRDDR5HZTnRDBM0od7SGCVtY4P+USAEm4qBANi66Lkg5a0TfAHJGCN1FZEv3Fk4dZbgHOacBtVYcWnd40A0Q56QhD2qHRAyzbwy2HHlzHETAzY/oasGf4G4d2hc9EUC7cHEuV3TlyKZnoXUnKUBBnb2BO5UT/ZgkNkjAmnr2+oWnWQHK5b7v0DRiMkvulAvgd3eeVuj3pjKHeCxESb2cKaHIonRiAiqWUI3SUcs4IqR+LlIXGILw+j1wiw/bR93mRAQAAAAoHgw5rzVSPw8mTMR4CccqXxhEg2ISj3tjUQQFoERnPVecPWmgquzTN8S14S8vTI/PAzr575oZ0uEj5qOVKj5olTwZEny2qscoxQt9gYAPNbj7sDVErP0MDRn0ljGKMgW1LZJg0DzSEhn3/kfFeUaelt2gGrJ83gDuxNCVaLEvGD4MZmxSIF/sUMNG/xLE+IGUwGoTXbIMTord+IdEQB2BokVcO6uk9c2Ey/QkD1ltrl1Y+8YBK+meip6hlKY+B9YIuMfh7QzucOupBvBW2MvwsZ9s6XXA8iWdywuQ9BTbVY4qJSDsUX2VQTc0yLnQDsyOfWhLzpFmSxlNjaawYDGnswIQBTOqZWiEAYs5xYEAkAZvsS3qLlw7Ewb4dBiRQggpHT2+byFdzvmH/ANPGNi1wENv5PQavxd5+J1o4hcAoCkHNLvYFZlxj0BL0NIh9DuSuXGhJKY7/5gNPEFuBFYjzN8Ccn/sbmdu+QsJemg0Lif0U/n9WeA2Qo7+jHvgblh3j82W4pFE++xcwuI66N6xukUL/G/FqRy8JHynBrnBkYb7+CyJ6ldVAWbdXlTd8FzxIOsZpIJqkume2imQTy7DECySr7HJQhFWpcoTFJiuiRHCFUlPpcLqsmb1K90J9ow3L81wQP89QnQ5673cbyBjuQadj8sslNNQ/rQ+F+SCI3sCtAbip8qmV2LxYGhOdm65OJ6RE3Dd4yuE8IEJPVQEGcCUUUrK4t6dT4ACME7gXF4Ys48Gpryu3qy0qwOendWO07Yd6uvvx7bN/tl+HaBmqqU6jJPBcbBUvJS/SCsgZo0Kf4XxZFCp/RM7zXRls/18gwdPw+NRexQMLX9wZ3pmZFVHbOLIA9ptaz6oCjfclyAcXxRH5sSfZuuK6MMUsqXBM23szy0XTYn7E7TsJbVj2APpYa16XxiZdZs70j4nEhVQTqLIhvHcf7UJhmVfmEbMcYBkf+2o38WgkttBAjiqKDKPraeiKm2gfiPL4eKUaBjs75VIwoOtXIbWVw670ArzHMlrSugs4yDGl4krlxZvZD03s4i3E1xgtAbD+kFzj+uQTFH3nQLGCRkgugmF30/AW0acJwilQFMbYz85mTyULSLzSVQ73Qdc8St94Bm6PcdowOTXbnsLPTnUZDQCU3GdQvLS/SIepkxH4GfRRo1gjMZHUMI2C3LMcYEif1MZl1JJ3rV8D9fZXqxoxcdNwmgIJy4w6aJsqMy9HItssfFgLHN0utmV4evLCnVf3RZw9GrzXyG6lnt8eD0wFgSxRj13Yx3NUGb91seCiXlrVhY/bO3a78lCPuwUDZ2gZ8+IVwl819ovldJHCShHyIlhyXfDUfkRWTwTpknUyjHHmX0+tySHDZ++Pp/nYP2vlhGA043Z6usogjFqKb82nfVcl6EpEq/mj9rbIn/XKMbAjJrofpP2lOkyhrsN+3k6+RZFxEndJWFIAg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIruD9E83+00cCF1v3jqMDFzXUmDS1dWpnxsAnftKyx8DGrRUnWfxGqF6kP9irBLzoTvsywVtE2IWGnyJyGPGZVYQBkXJc4joDUTtnV44Fw1lxRn0OfZ5lP4i7BEyvK1jQD69ROdkDaaVqb1ZmwSQMSbD+Vjh8vHcm9XDG3yLZf3kcYFC6mtlRWZbLNSLDNadqhwCd1eE3Amx0LOIG6ojn1Prb4A3uoktKJIz2DKcGpgv21h63pSqJZOfM/3kXgnGXion7uG82E8oNBRB8oFb5tUzOZEHyeNB0vV7vqzlkPvc9dBB9eNO0a1PjWmKtaF+jo8nZGG/LuUl0YQ+p73ENU09cry6f2L+vf3FDzxwak2KeGNd6JNTvArgGSXzD9xWgQAAACubDy6IV21mPQgG62djKdaz9nE0tIEP/QQqnwqKUYim0KpO/P+sQUNMgF0ZgZPRfG7I9wcQNH2pDHOLzRSltSwi8WWw2cOS2HHNSvoS22iPEqghFG/oCnWVgnVluNlYwKCtnJ93pEkBJ/I04fCyO/BrCPyeOycjNKBp8KzEl7Q6A2uFJSEcJhDm7CuQduIHd64hR8yDLi65xtHisSpa2dwKajC0kW0hKKJPTwNvJkDeVncbVdgWOIpXCCOn3AvYVYLaESllspcYHX16m3mCTB8D3+9J4h0ML7ALvj1BPmu/9ZbvfMWLBFfBrShgVy6GUyqeMuYeOaoiOpLx5qpwMreMCQ10ScY8c7DpctwTcwJ8yrufsFUa0lb5/H1mUpOBya8cLThaU2P4Kdyt0veF1vQw1eSuouia0afwnPy/mFC6e8r3ps01enyR+z3Lwapb/XjBwMoPl1EaP11UZ9kYRRXXhAv0QGWtYFgFnbgywn9YAsG/iY39ANF0R4o/PdIu6e8+4CFsedtav898SdkMurEaN7cALK5cOEE/r6IEDVaSUELDABwIai4ViX6FdFvFPErV+QiZxhHAgVKC/doEy79t5yy9zVnPCdjruWKJs9PQ8gc57xFE7niqMiU8H/CFfbezbL0PsFguiGEyn2wJw/grXDDuaW6FysGhqejpTIl9Zjf0f+CgYXW18JoEGBVtsHt4jxpKmgAmU9txFtWkEenWe4fwDLWlXGV/K8F65H+Q8wLnoM2as7lH42mUWg9H+7Dm9lTD+U0LPKWBt/kJsFNPoqBGe8e3H7gGqZeru/y/V8W2rmZkZY72w7+7DQKtzZSlDQS8/hgIZ0xCYyz0NzS/LBeUiSuJiYKdb1kNpHwcqNuhwFsNHIpxQux9C0MwzeY/EgmLsTOiMb5Bfm47TTRStmQyQIs6QLRlVsrqSvP4dXCdpCeMJ+tAy5V9ZK1B4Zh24HalnKbAasZIgRR9YuqS4XYqKVH8mATTmi0/xhLWVIS47N/AUGnZsBRlBz4g0wuCPKT5uxjnGUru30FFTfM4TqhcUTV904OcF7fzfGp/dw5mhDoxC9yqWK9bBUtC+bm5TfjrfHBd7IJru1cGbirIItFFNsnm58iOEsizdXY0deYZu45ITguibZbtNbBgo92OIauDuxz34lmJX0SrNbDLURSEMHZeBllyanMPmUPZ4tcFyj5bzJhBICgrpRnIZKX9ZfQHb3uYUx7nvMjKf0pIRviB+aVhAb4H9znChlHVgipfJRYwy8AbcH0higRuSUM6QsT8GJpPCfneVI2uOLYzK8oiu9GDwyBqFV5TCcFLBD4pS2UOfYISHilk8fCIfoSAr+/gjtDubOr291O12/XsJzVQ4zYe+oo3CJ4m4oPkKpNP70TvB2ZtCgHIDQi7SkEk18bamSGQBg7xV6zBIQGlscUrdddlJz7vDBl8qRt+3KwBC/SAQ=="
         }
       ]
     }
@@ -86,21 +86,21 @@
   "TransactionFetcher does not send a request for a transaction if received NewTransactionV2Message from another peer within 500ms": [
     {
       "name": "accountA",
-      "spendingKey": "23882870aaa1db120452320f5e3a411de06458e0b5a6f4843cc595ecdeae2d6b",
-      "incomingViewKey": "fd8f529b0cdf5181a61e7030d3b0a53088cd4c334ab52ad3bbf313986b084200",
-      "outgoingViewKey": "4fe16880e9c02b1784dbb6eb38143a515fb16ed8accd9e96b1b11249b4909be7",
-      "publicAddress": "631b29ee7301cd700e78a93ae82c798a190b254e80e0c68b70ef57ff4d74a4a52c4694bce8572c5e8467ed",
+      "spendingKey": "6bb5b9ca7a723a116a049c6d372723b68a7a0b60c3805c74b43e2781c06f8273",
+      "incomingViewKey": "99c9bd72baed71871cb684728f57e1f87c25eb7e7f7cedf8676376074b186107",
+      "outgoingViewKey": "54210b86ed2b9706e7937458248f16269239203b7cce55ab7f636b426992e76d",
+      "publicAddress": "faedd0e2aa246c9453c5bfdb3ecb80e6b0b8987ea25f96b1dcfbea25c86215c5c1e419c7e2d3f8024657c5",
       "rescan": null,
-      "displayName": "accountA (29e6616)"
+      "displayName": "accountA (b94cc8a)"
     },
     {
       "name": "accountB",
-      "spendingKey": "4bdf73dbe8640161c8899e3d96639d34e6ef06ef3415ee1bd6ad46aee92da512",
-      "incomingViewKey": "3a9a27a06b81b75e122175b38260e05a677b780144abf87f5cb6e72e9027e106",
-      "outgoingViewKey": "260f1ccbee6d3125b2b5777aa43099df529bbf635e3d1fbd5ff48a2969007b66",
-      "publicAddress": "4e530c0b2aba78ab9926df85590dfa510243cef8e0d8ebb2ebad4efa9a1058e575734d4fe300debaff3cbe",
+      "spendingKey": "31c485580ed9e072a8a34997864d577724cfd7c0f2ba11aecd671b1b9a314c1b",
+      "incomingViewKey": "a7472d468cc06a022d2c0094a947ea70c913adbcac47ade72f96347a26806f00",
+      "outgoingViewKey": "98b0c592a0968895af8d5c3641c573dcb15939707d2bb6f8096074011e2e139f",
+      "publicAddress": "9351032e30a40d9980b9bf29baafcaf69fd3a789e8d7292c94908f770ce761b3f3803ebcdab23e12d9331d",
       "rescan": null,
-      "displayName": "accountB (4016d08)"
+      "displayName": "accountB (d1c85f7)"
     },
     {
       "header": {
@@ -109,7 +109,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:58eS8iloE68vueP45OW+M2D6Bqzl1g/IOyPLqPKAGk4="
+            "data": "base64:Yl22nwqQIQXJJSZLuFv57myNNy21iQyUHVCY1oH+qhI="
           },
           "size": 4
         },
@@ -119,50 +119,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659989479558,
+        "timestamp": 1660092436629,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "4AF36EC9D97098A2A62517985399602876FB36D1A0F66153F09E76C23E36523C",
+        "hash": "B2DDA071F080845AB888ED3B109ED3F0DC5F9CB880874233B67BF90E8504E54C",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIpoSAvIV48BBdUk6CbMoUS30rEHf0gy9cS5lJy4kVdugSmkrZ79XCMQhpecR62ZpLSlpt0IOYxNsCAP5Nooa4r9g3Ubk6p6XyZ8X23CC6AO3YVzVlcuQ9O5YQ20gixiSQv8UWs0/HxFgQfqdsiCOyR1aWuTSgwvvr36yVrdLz7w/BJQqlHvOb/bC0VAt93MSpDV8tafSwTv35hnFLr02RWX7gcWoNKJr3kwEZPZTYx0MsQ5Z1z0st92N2FpeyfHEyJq9NRDFDAgo8Cu76d/fusOptLH2jJYSDZsPeD3PBM8LhiDDF0/UPV5rO2s++VclBtr1zbSVxMsUE4iz1IzwjgnTmFeCG92dJYf4TPhsvojptLsaQX+BRFDHF1YEwfFrMGZdRFfEqbeya1BTsgcvR+ug3/RKA/ayE3Kcv2lOM93Wk6bNs67hoYgB+9kauzCJkj4czmfA7YFJ/+OtU2F8ujYNjdDvLREEsliN9xuOzPud6gq1S3DYbQ/NR4idaFGRMAFFUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGGORU8Tnfuwy7BdN3dVJ5dHDFVIjHhU3cu5k8pyGN+Hi7KqObFZvKVfP/DftHAhmtNgKWWGc0EsNi7YRPnSGAw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKN5Nsh5L0PrMlklnhVm6hGICUVGmo/35VgaxbZs0CIagqcdRd34kvYSWkvq0tfT8pG3LbiQ6gTDRfjqyvaiY13aAakthTn/nmzVXwnf8RZRoDYUQKfzSM/c1Miuhk2kQxelpotSU4Ptlj7uEDuihtCrnWCPkk1ZN2cQYlRKt4WNiOkBh1VJKgoRwxn/pffTJIV9z6B5ErMJdTv5bzXhQgskYLw12VEXPcHgOg+VH8vX9V6nF/XvfLWEGqnLM+rM5iV22jk8appRy4X8Rf6BtC20ApxGWyktJthHvUerXVWFAPKr/NFXBuVSsZsGvpIF+wp7vTDeke73LwlBPAidDAZWr3ixqxsX530ZSRRAe7zPTcBZDiLq0s/Lc4qMpg/5VeNS+GhNWUtczYKcnMBZLjUPuGPAOrCHs2nwSZgFdcf69w/OUoCMOq+5xuTXyJ4h7+kowGMSSZBPllr2joHXRBEgMQ4kCsIcix8OGohM2sp+xl4ResOqKiDO8jvuwy3utZi9AEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMpHhXJcrDbEK9mt52z2ycLG4oZGEgzFlmg7MsVcwOgppQe2uLvd6zj0RbdIwFmP6T4KWEYOQJjXOqhnT8qjQCw=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "4AF36EC9D97098A2A62517985399602876FB36D1A0F66153F09E76C23E36523C",
+        "previousBlockHash": "B2DDA071F080845AB888ED3B109ED3F0DC5F9CB880874233B67BF90E8504E54C",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:d8DwTcNaoi226dg1g1hyLBuIb/d3G3RBt1r4/f/HKUo="
+            "data": "base64:3zmxUtT1HuCCZA3GhCuP+tY7JpY2b0kZvYE4ytzgpzQ="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "8EA8EC1DCBC090B0D2BE56E6C36FBB9B4DDA3DA88D405FCF6B9DE45EEEDE5710",
+          "commitment": "55FFD8C7C9A60543EE4354F2F25C935794EF58B8A51A0C18DFDBD0F61370068A",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659989480901,
+        "timestamp": 1660092437950,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "A3F6B06C67BFDA79A80B66F6572E3CB70022A5A797EF6DF1957C41C79117C134",
+        "hash": "D821676088C0262BC5062CB0A9ACEF9171A56CF1C0A254F830AF1FF76094DFFF",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALf3HcPC2yPR1j6mD5kq0w+YO11a5E51R1eI0ZS8zidp0nb+ZbDOC24JW4y0/3Zc8KNkNHTTATlN+DkUgBwM7OjBVEvkgjCqsde0KQhzTmjRSfqrHJcwRU7wkJmZT+hvCwDHo4C0ZkdZ3DQjLE8YYF9CAzUph4R5L/oOamEu2h8tXUmkD8GNlGumpeDXub8+n7k/BkHPyzHk5ILp1LjjzKK0ySC6Kg5xghETU35zaBdUiUL9dylwYcIOmR0LVtYANF8dwbQdQCEttzXFX1WzzO/XQdUNnQQfa+yjNRZtlOFWmdbGICBmoA+60FpfvW0jpi2qqOF3dL8w+zx3/EJPlF+KuDm+UycD177C2qmGuBNQBiBADLfRz/x4I7n/w15Ww7AaYAkSkG5VMuKkG/M8gg33VoNj5Q4Pozmrap8BRa2qi52GUFIbm6A99b/UQ5jmNStf2XzFeenb4dLKe1tQRF6hoJzMIS62rnynH81eJMy58BHfvyaBR2kV2OJWy+Zw0wSHmkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrwH6sPtf5ij9vO1WUxS/uRiTpswHlocMts03QsAvg62XncnAFR8doMriaNtvyxVAP/te+PHccZURbzWtRs6lDQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJlfB9cM5McCXZmjD5VqlOenMVRPP7QnE2g5YXLgl6QtWXtj3InubaTRPNVZ0fwQzY7zL4lzzl8Vt2/h+2l1cVHZ+5ZJADU7riU6PCmQRIqIt48bjT9mKb/lR6o1JqO+eQcD9o3FhEPSDu0n+0bY7G0DkVfAWvTrBFkKkbCC0pnrxOLnyCLcZcJl3Uw3BV4l56iYzdNx2NPWfmWJxjE7pFqLhKvMKqpudz78XG/PE1qBMhEo80HRA01gmL4l7ZVhHJZHRKLDVHnlt45r5RfcBff4eyRWnPsp0DNWNfr/D8mi4lmD2qfGglKoDsSCJeGCgIxyAntAKn0x6l4Lq1LHohRKHT5NRxZ6VrMk6Bu5PIUV2/+/W8LFeCProwPt1EYEJXN4ZrQT6JWoXOK59rpU2VTFK7uctJqn5O6Q/iMbFHqBbguQv6GwZ3c/1kgMqxsdDlDjGUybvbDfKdrn4Ctki5vYQJejI4wcLW2OirVFX/n8Tc0YxBgke5CUD3J+qdV1QCFpLEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5NHM+bbtmbp2mj21hMPsG9/X5IrFGPwfwN6zyUo8LIE+kM3so5rfPH01HJhscYeQoANvjj9OOMxMNCqLr9pYCw=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAJaf8aB8hfDrT2opkqGgHHD43yUEzaMVx4yCBlUqGtFYiaIrN2fv2V2JdSZneIVfNrAxxjG7y8Wi3CbO8HSRNO5Qr6bf04hCgSEg0KrLZC3ZjH+TTws5iDIrMhDboguRwhNV4JdiIXtDwD1CrPb10meb8vTyURjcqOoyimJ8wX0ltpQkudqTeUKi0zAK4ajsioS+b+7U+rJjIDrRKjlYqHViFTyqQkpFmixcWjwb2lHz3Tc5MRsp/rR348Cf29h8PZk/PROKE/iFy8+RiLgBUKxfitIBgNqm57a68Hgp6EuFsL6NbX8kZ0QMf/TjtyzLZIBr9pVshN6EcXqR+zhbC7Hnx5LyKWgTry+54/jk5b4zYPoGrOXWD8g7I8uo8oAaTgQAAAAEpNK04Zb+l+4ylWCRogDP95hAleYJdccKEG5vsi+7MIDduXH6X8JNaiDlzHfpix7nxJhlMURB1Lv9XW2KDS/nd1osGccoMtBcrbXGyPEQlYkbWBLlErpSuNRMoP4hqQqwGEx8L10yAvxMd0t9BX+Q/KUXqOFD6+GQ75khn7Ud8KtK1MyTxsuizd9Z2OC3AjSjQEiMkuLcnL9OnWDDpaLVZaBW5Gp9vwobGSyVr6r4WiXEOv/wOvzQAIjj1m1RBdgZmcwNSq/1iJHVdYdQBDPutvsMdezOvvlG1GKjpg9LFYbUijQowZOOFZ89mfBUe4uZoib0t8Thbqvo2Dn66WBdwHKS7tHxhwAr5gK5NtVISXVnyZgH7usV8v7da+R601908kTQiId0hJS3bn6AwBXY3N8wa2fOjaJdavu/B16TjoHvFGX5xrvsD8ss7Z1KRnTFtQ3mLA2Ll/J0d50OSKE1Vn5aGt1X79e/U0vOHusuVbTW1pdOvC9+aTcF9hByT7QuJ/cGEw1UvkE4X5e3etewbjtIsxjSOV5Z5x8QAwosdHO5rHLJRQxWQlEo1UPMD2BrdR+lAW1gZlaPlxtOEpqzaA406yuHQ4guiebKY4QLTv0Cpd9rBvjqA8j7KrRwRyW/a84KvstM1Awsz2KiSypup0U32LSlAKj8AYquOdFpjx7rBmDgUC18yHiYk8Q52woXchNtXOVdTljKY6jTN1n1iLzNcIqI53quAhBbOvY+iZLt4pGDoCyjngNamtBxMIxdFbjczXxPw36Gc+w/J6tAlxbqUpmCwPX/Sn3CFk2ZbBECG6k8OZxWX3gbtKmh4Ho8ZfIlU71/VH2qBcXgQ+bhS7EkF7XzSIQSnDmJzRpWuzqkXwFC9XW7fA1fGJ4UOflz2SFTUHzTr6EZoAXHT5/OAVVygZatgvlbj8/K9E5OmQdNNplSVIY0T4bC4pQus30eaeasJX0ISf/GrqDYgspJlZo18QIKwITo1v+w82MWlozUjIeJi8QGM5LcY4MoxSB9pTF//8XnN+GwGR3yBEiav+KveYuMiy6oVtI8X5crcC8nill/9ftSW5u1MSe7XCmmPWkqj8B3Zg30fGLmhKGXnL83s+dF93Ym9RzPI8a0lI2o853mMu0D43BXHbQ5qq6Ke/xKVvfnvP+dAoWM5k+GjSNGSpeQ+2QW969gRbB0WgVHKD0OPyh/vSVZjmaM+GSpwmzKPk2aNqnoHKpPD5kp9HgIp8AyCstkmD4m475fMwZJMA99I4dBV6PBT18DwHDRo34flNn7q2OA+aqSUhdon/j+KnsUcrByLPocWFuhVX6ngfdAYpEiJ4S4kcaBUJmgKMNEFr4bLkDfFMWLT18BhWMwL17k06wa1qjybbFlbnXWPWCW8p7c6GkX8VyIFGex3XJnnJxbx43sRoKsHLekOkySlID9oTGE1iHN1jWYSU1d7wYrAg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAJLqykXM5Zqbe/EvgVmxbx5/MU4UfCfTQyWDbg2HyhZtYYlM/kkBJem1hpS0e1ZoWqbvn57TAYdH/EPNrTwK2+8Ebsp/1NP5QGSFCdH9QEabkyaqI7Bt8EqGqZOEUScUxwN+eGn84FNb//NEj6ZAaxlOO/kzbT1uZH329lSRbEZN2jOAXHEX+pTW1GjYUGcY64XK+9oB/DiCe31mAEfPF4gvEo9xXeXojxeRpuJlE/gPkvh6+NMbw1IeqAbKJ5THOywtUWjAuLB+2zRJRxliNVQimJSSGogw8KgLL3HKGFIwStaBbNp/NUPLT5ehQO2N/AUuwx4XlxPBz0iN0uIWjutiXbafCpAhBcklJku4W/nubI03LbWJDJQdUJjWgf6qEgQAAABJr+n9My6XzWr5HtpEkHxk5EPZ6WrGcopHhLUX+3Gi7aXxTb4h6AD6y4FtF/HvWUOhtULgxG6u8X7M6XWhunrXbreMZXCTbYO/0FRpR3wvRoCPFGc/zHpqniXD/hM4IguQZ0AGZwLX7F5051GKhn0DBX71qc+jx1TTGj4QCnmu9qzbz6KZ+NjF2Cr0q6NrnIiZ/wV8K9GZ9LFowGvp7uwCx3239K5V9A7EPCTtmyak321aLZAhFndDmLUH2bXh9WgMBTXaDqosn7q13+U5mu8ExfcEYVQKgXQb7kve3gl1KetcaiRo4o0qiRaMohwcrDqs4ktb82V8h2wRKQ+LhHq2enUrgju1xA6MVzfBY/VM4hg6XFCs7SudbnNFbWcfJDDFM4flq3zvLuoI22I3fQIpsPPP9TFyB9q/4E7NQwyairijtPoqC3v2q637GOJagADusyYj/16Y6K/Nj3qTT/8L0Vy7qsZT5T9RmBs9y3edV6Gzlo/gH6AupKtrkF/mURVc+NjMOOvSR0yWerXqwrApFEVyizW4ir8EjZBNeiLLNvVEDHWv9rHB+NoUbtp4QmxQIsXO2SoRsXkslRn58DtpJ2/7VpFZXT64nryWLU9w85mczovXPM0dl0A1+aQDmTeJafPb/7F1i7XAI2NoEyapwyf3/pfLtcQBcFDEksswacmfGMHtIlx08W9q168Om+1b3QAi+pD9ODUNGODgaO6AdEaByT3g78yNz+2zdsr8xtWni5iMli9LSulnIFm5keGgnZ4ZVqjNIYuw18hVGlsd3aPGEO2sfUF6G9hZVkN0o73YprAtuRfwhP5DM5zu8vPPGmH+/ghaZy6gvmdvFa8BpiJb+UOzCPYAMEe4qTRkzVKriAPMMvaoxq0KzllbTam8jXwg5rxxFq8/kyedHAgnGu8kwth76eMkpMn8ad/IhKRK5LijoiQpqBAOi4iaRaAH3iEWntf61HLBq7YET0+1Agx/L3ozeU/i4q3PRA2peb9eDJpz0eMPxko5I8BD92fAFX0CQ2+EusSgkVybI4NQvXinao5TzeSW4mfuitQwBggrGBCbzesSvGiWUUNVQaw08WBoL5OAWSEHABXE692suS5JyCO66TSFZL+VN/ehnBoiRByz8Tu06bDE0MjujSi/g2fDkYCUEk14hTdiLMuA6VTpoTq5IzLy7rxleWOJigI7HgGDNyEkIZBk1ol5B3tZInKo+f+b2pBmfzFCkQN2JgpOepZrKIZ111M8m4+NAfquyK98H2e4qzLXPgfm0TKD5q0TJYdhntTmV+cWVS0nVPTrswBSGwFzlqm9dRY97dwuY8rnciDb0TCG85Hti/F5pV6P/JoWh+aZ/dg1h41PM8Lsd6igHK/FD5Vh6L7LclAtWO8gv45oyO/PUvm1rAlRiZKt+gYBGhm/BFKTZsGX4navCjgc/Q+xy0GG3CUGjLOuvi0qBw=="
         }
       ]
     }
@@ -170,21 +170,21 @@
   "TransactionFetcher handles transaction response when the fetcher sends a request": [
     {
       "name": "accountA",
-      "spendingKey": "738e9516b87b4d2f84fa83f292281a6b958c33a9883376201a1e3b5f7de84837",
-      "incomingViewKey": "04148d82719f8452bc7eca338893c57a7bbc1973a54ecc89f8c322658a3a7001",
-      "outgoingViewKey": "7cd46340537c528dd10aa8258a1859d775c36cbf1b32d214d299a0df4b3914f0",
-      "publicAddress": "24aaf6db6a6e0bd21acfd95891e6d9eac05fc7399a294b363e5d3530708ab1772bc10f878b83faa2079236",
+      "spendingKey": "c7010406fb8a7c54bbe2c689af450eb1991f950d6d2b1575c96b43870db3daca",
+      "incomingViewKey": "3f53715e1853d24900719f3a3d0b90698e6dd53ae30eac4832071d70434a6905",
+      "outgoingViewKey": "c7382a8e9b89ce5dfab70383c439491a69c84a60e93b8cdb4b8b2b6777881d5e",
+      "publicAddress": "a2ec8c02475887a9567ccc637e0138c225a2607d1e11789a8b289c2dc82416a8c174e952c9a4a73f2d3442",
       "rescan": null,
-      "displayName": "accountA (a11d488)"
+      "displayName": "accountA (31fd8f5)"
     },
     {
       "name": "accountB",
-      "spendingKey": "e4c3a0263b1825c98a1b541e4bc305c4f7404b43a1d01dd0919c531e3ec630ea",
-      "incomingViewKey": "df40865c7ea5033c5614e5b8e03f00c16b4d35068c2c71a937a45387a5558600",
-      "outgoingViewKey": "fd3f8c3c48f6d3e3c994ae4a1eee2f5977ffeb86c27499668fb0a768dbbe29e8",
-      "publicAddress": "e8e304f9d16996f947cc63930ef3d4f83f26ca069909cb023286952e8922af3735f1d17f665b92e0c8412e",
+      "spendingKey": "28002dbcd0fc164611d7b41a90699da96133c03115230a2c0055dd563c50424d",
+      "incomingViewKey": "04611476918dee8b447a8157da400bb5cd9564f83fcf436c40250ff8c431cc02",
+      "outgoingViewKey": "ea2bfa8ff2eeb6827f4491dbfe37716bdda609f9939722d477d693b8197745df",
+      "publicAddress": "7966eb36bd7c410b782a9b0c0d502c6efdd803eaf92d56fb2115c9b251b693f95da7125d2804f178ca2911",
       "rescan": null,
-      "displayName": "accountB (10dec2b)"
+      "displayName": "accountB (17a8ca3)"
     },
     {
       "header": {
@@ -193,7 +193,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:ip+0CZlFTHhbDBCz3/uj7z93faT2BThgNMA4kH3rFVI="
+            "data": "base64:wzg7MeJ8DDythPpM+CWZ4BXAaTos7qzJB79osBhcrG8="
           },
           "size": 4
         },
@@ -203,50 +203,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659989481120,
+        "timestamp": 1660092438202,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "7696B3D65A37C12AF9660C9B5D4DF20BDDEA354B108A880EEEAF399738401253",
+        "hash": "96DB287C838B145DEC690C626DB10A385DEA154659CE3988E783E780A41BD946",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI5N080wh7hNwSVY024pALCmpPN2Trc0k7aIX8g0hv2BSl3tMIdZSONPhoK/9Sdpo65ULRAH0WtifpS52R+TBJxVDlMljsMSR1325HP5tRGLrUaVXVZ1RtIPdrKanIZXmQoPpL6C6G0UxtvnTN7Kd1EclZPYUQtyrZfh2WNwPCd9JEiW8LzyvLkjVaCseVCDybh+Sq9eHnnqa9EAptNgFaTDHtRQMLm+nP6VGoFubc2X0ZQApp+WZ/xrkU6Z3W5QahIoUGpQ6NtIIpg7RAFgsFHNjAHDCPCF64Z8t1+VniKTwx+zp2iiH+PSpXN1xGDO9j1ErJ9IVzdi3cDVtdG3/ytQhiSGqoqWbxyX2hKleXvPZFNlXxfkzbrZe15CoEDdaqc8rrik5l3GvujxuUCwXc9H/8WDpYn68rAsTI6lvM5jHyjj6vRafXXqzJxYTXN2X9pgwf4ESpbe/Q8Vh8nxpzv1cnZORvCJndH9klhn610EA1SL/A4Tk9zcYVSMCdW6NQ8r5UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGpzU+DzG3VlZSCM7mK6nsUoreik67O9/Si80E9Qo71Gt+bTcAMAjANTdvAly3zBTqHEbFb/4xI0Iz49fwnnIBA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK0fCJ07N2fAPFYiHCxyY/lusB37F/Fj27N6mRLfjtRwrg6TcaDc/27FqBWM56Bm86cNFrHwOqOHi48UR0kdzMjU0RW7gOYwTLW8+Hd+2j6bvICszAaDLLtdTHuKanoUTw0L2u0scqHq4tvGEXVXUXMVN3deHlO54d/6tCGmjhjmDlgWy50PWFqZT+KwxDiNBJJGpdTFe8Mg3eLNw0hzg5o2GDTad72DXbbiSupJgEpRwbpcy/eMA9+LXJeZ7QqCvoA7fqiiJsBqCN0A/pqWaaFVz/1AeA33Li+/BryYrmewshY7Lfj+X1rVJvwqPPq22/bDakIvWpeq4o0JRvpBKVFFwA0AUqmX2cnOtE0LjUu9Dzj0C40Btnp+C3lOIQYOmRACIY9VA9wOORojDjxVowLKfPzqQ62mAmcSd4TRBUk0ngtu6CTYKWJTRyuDw30sNSvZmh47mesh+MHfGdssLCbooa9eTSds0petHi8rK5r0c9nPCxvxqLeUFI9fmCu5JqvJcUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNwNmloVGb2s5ymuV67+N25UK251n/BNNhZ/gH6HcG9Oy1I9cu/OYkBZmaAkK6hTKwVziteDdJKxpkq/+chtSCw=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "7696B3D65A37C12AF9660C9B5D4DF20BDDEA354B108A880EEEAF399738401253",
+        "previousBlockHash": "96DB287C838B145DEC690C626DB10A385DEA154659CE3988E783E780A41BD946",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:cld1UMw6x1NqCW3K3W3QecZ35yNN7AiM4UoCLwMquy8="
+            "data": "base64:daHbQcvPo3u6qf5UoW/60W4ddLZ9BS4QUyd5Vonh0Sk="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "C9EB5F8CE3978FB00817FE8EEA0E8B116436CEF7BC1D912E980C49D4B84C5423",
+          "commitment": "235FCF2D6549C11ABCA42E56CCEFEECF79401E2FF09930C3B6F6B28BE2844151",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659989482434,
+        "timestamp": 1660092439547,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "B4AE1A09F5C37E3D03237685857CE38B8B1EA6025FFC8D571E986C7C46865642",
+        "hash": "AEE3609594C0B57000B161ED468D79F34AFAA0B0EAD076A35095364BB22A32C8",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIRJsuI+yO7REwG0CWGNqST5RoK/NGqyy+W4qeJjiktUTsY0m+EJcOalvWfEBXHHp5I5+zrVDi0NOW7THY0Vua1axJuRmcmzIjjhgUC2tJynptBOkkwIMLv4JFXjf0FTkhha378rQyjiTzfdUMU7d/RFp+3zn14mh+7BWFyQ+F6q4PU/5kjaKR2Nsqt9D6MiF6FmNeEDkfHRtaYlbDGPfJjUcNiv3nGXNZGBxNLtD0ZvqA2uQz4CP9TEoo7afsemFz43l7Poi6bnpYOXZ1QlNnbN/f5uPM9eBFrJnI/kjYpn3l/wl4HRzbI3qtgxuUl1X+wJsozwB9Z1FzJnwACvqRjTfpQ3NHyCDMrtEpuK6o8n/kYMzio8rKeeCNIzCFG4auwXCqUJWAmfHrL5yykFoJnVNVgx6ieUpNNkoIXZl/wmOlCVSbEoebiaph9BokURhZfL3iKcU3AlvMPRMHVP94ZTccRUy3tChpU1RdTYPzkfcqpVQ7Ih3v7Rmm6Ji6ewB7KgM0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwE6l82qXBw1wrKaSW0RPF6rdRxkK4unavq69wsM3ieUnypjInkhdLDlEHvNd5hcTpvujRLIjDbMQ2XVb3QidVBw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAK+bPqONCiWec0Rs4T526alFMau54p/oM9iXAqFzq8d0ghrUo/HW49dIPJR0icgP0rF3pSNLJg/em0jbr7hTBobM6/ekmD3jakecJLqWlAwFoAmhEUTvR02GxufxLQzFRgDMZUR3mSnTHUYeTCoE4AIvI7jXh7UxHkJh3kBOtglCkpbvImaJEHng0SOh8iwoK7PUk0qJRWQhc75UIMm7e8y0TB+3SVAyyo6vmodjDleG4OFHx/xpq5CN+TyDP/JOwHUJv95EPuYGgvBN3GvxqgLBqG0fmRrG7ZvjuqwUhh61j/6MfiGR3lNw1wouZd286vmUD1iSenx1T3ztkb1AzlpEdaKx2hpsytl3E797ta56Srve3CysG7D7dhC7I3tPmtq/zQg12HRWabCmLL24siZH6YMe24HU1GLw9As3pDAaygRuS+fQsOWarMxlh4Lbw3bE05/aOj6Dk/dFyrlTsEoPaJTNehg2/Ne+/aPCcr6rY1YM/IrVjE4BtnrruYda6v7p8kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwH1p2SWYC7L++SzHkKKxVfHqDydCtNDapG2H876L22srsDsWOc1nQbifze6xoYBucQx+6GEBQFWk6qdYNpo3VBQ=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKOXK+V7PSMkgYLtRq8H2kWlw5p74eFLhQSutnOfRXSsU8C6AoMMajujrEzEkINu85BGpyk0HKJkV1wMdho/yIai85RRxAw/JzM0mI3bdJuS4op2alX/e9s/YDcqyqEdiAucDN7mp+BJ9HMwmHn8RptA7iA0fc0Xe+sB4+dkbOMx9lwSGX53o8CYzSxgo99lbqtBKTjiOONmAWmcYi9gF4jz2at+Ia2/NA+PuXDZ8dMMrkylukxmeVuevYsCvAYZDmLECx85AarUbNYo2zl4UPBtspZB9r9PREaPfXhdhK6E0GYVFuEQpqXjbveywxw4PHAI78cvM6BF8y+a+msmI9qKn7QJmUVMeFsMELPf+6PvP3d9pPYFOGA0wDiQfesVUgQAAAD+M3IV39lmlybvvcuwXfkb5Jg+sfOlepUFUtCMwB9AVfaOZXvxmOKilCOsmPOyg3M7ciaap7Thc9P9FgDsJLFnMLz5p9aalwroKNxMoktZqhbggyHNO0ixqWDxYmoHxwSxGx3tfvXlcaCSxIfZNN4f/n1wQKLQXw5OLCyqseynLQCFTntdOu1cT6uNbVZfotK5agEKW0gAyoNDhN6QfO0N4aJtB0uIUEFIM/2WhepwWUtC2+LW11RUBMIVxexpkSEZOSG8TZFpZ6mCuMUP8rE0SvDUwdyUF2nyGZLGqpUUkRf8In/ks6nyqZgNJdps1v6VW2v9FaU2aE4ZROZLCsA/ASayD+P4tSz3j4G99s+1ZoKsVHpCQcf/9nnPD3pzMjRYvC3OjFmOwcFIZzOgsH3dFMuXN+nd49hax/8cxiP5rMkKWnwk6lzOY+n7xU1l4m4MxmIIx0yXvIjGn0aIUd4g8JOg+ULmeL3K27pQOdDHwYVTzuV7INI/Iyy3F0RZi6GgJI3fgAALZj0IqYo/yEaDrgBIhlsqn5aXBuL1wkJWvcv7mQPum2eQOn2v/6mqL5ATl+O8k555HsDm5/Uzj0UIVpgdbJiE77Mcyrltm5Q8y6xCSpfHImcycz1dd76NBpd4K3BvejA4hoeENbX6jYxveoj5ABfXemTSAK59m+RTQP8xpE19+wAKiiemd8ERWgbyOwtQMEkntA393rBqeW3HJJmz96wR33Ax0D9b/Nkni+wngZN2o3eg+zv16EsL2E+B8gT6vjdHb3MU6qorZt7b/deu+UQJRbEVTehUyNWCT2OMpbg6eJdWeUNiGpO2ZmmJMRN0/LOFk1OVzZ2x5dxT8gEoFen9WQfE5R96YY15rVdwWQzIRMUfA2iO0Q3mSKpsbNKlSOYCwX8YlYZzNDALvdPeMUjXWbvY6hLKmly5nSUQ8JDjael7mA49bhOX1WsC6VEe7sYk+9p7wpWODe1VOzbSWHnbmfQqyL9J/gSLtg4uNS+q6K4gP8iuWWaOg1fFPFJZRm34LT12yD5LVzZ/hNIyO7xfZyylu+uM5MAkvjfFka1XxNa00fYflQyEydN6TAWGc4veYPTjmgl7SecFz9lSWP4g11koLrygo+7qWk8D4V2Rpd/7Oj3ljXgzo0uK6HKYS0wTNZk9+ik2HzA+9ZUUsEPOkMSQEL25Lv+MOoa/UEGhVJi5heBUDBo5SppHr5c0azs7o/glmivGctsrsz0teRciIvIm4mC7/ea4pZq7AoOZ8pz2gXcsl/u5Pr60e2HtzQTyDoLrvcd9hHL1ueb701yFbyY8SPj3t1Xqnb+pSvAp0QkVazo81w9ntGAwBiRry1HbstMV0eHBwmzhpganH+z0xo0EGA34k7MO+7h0ZGks9271fBLUtNUQw+M8R7OljPBXCOAcxtvuLscY9KD2tA+vETp45AgbofZasbwYcupRAw=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKj7gEDw8UW//nHRHM+Jb4wzCoMz2rVRpEK3ovH6K7qdK3wFldv+gn9jdYk8QmqfXLGuJ6ritjYEHflt3Z4TQeJ7Zo0vww4cNTIxtThNIIk33Cim7FKFCrjWLJV/k7nthwTXybWrH8U2q6JFV44Hne/7CvG7nGAvfvklUGBk8Jzd/h1TTjHFRn4pjyTXrpmWSJYZYB9a7DRM1MbnH/Qs1RSa+Rtgd44XmQj2ScRZn8cpg4CPrWrLUO843gyKk0jocoE5R/a8qmLGk4KoT7oPXr/TkP9HngtFtIM9M+D0hQpq6ufOCnSqxRixUUHNHUIuQSNA5owx+v08oTC03gv1aZnDODsx4nwMPK2E+kz4JZngFcBpOizurMkHv2iwGFysbwQAAABwvBaefgp7y1/RK0jpyYDqfCD2hmY3XAdRRkZBQm7LLNLGRu//Vckj4gjrXP/RGmUnw6gCnsm/Gs+V7Vsxl9iP4rY3NVArapicp9OrhUGFHUMWX5RCqqztFv4g8lqc/gOQH8ZSe0x9vjx2xpG6LUnuBFHSoXaq4q6QZoRsj2tXcTDlT5QUmLm7llB9PdiMScCVorvieg8bbL/XLjv0a/lqxpNIfwX7UH6abNiugu3vEt0JEeWWfViJUXthJjceNKwHgwNSqQds/ryuA/E5eyFd07NmVfPm4rBD9zitiB5JadCAqrBfSHgJvqA8zkzzhU6vgRoxqAwPorUmeRIHbkaWctT49eskH0ZKRTqob1h04S/6tRtBu8Hj80kJJR/nnYXZ6CEvxYOJB4E5qLGXH44lIbNPJ3j2FIUCQlQVNmEz4uY8bpqUw/7ioWrgLpY3T95iVZ0zszdzt9yPT4YUv9RtxHkIrCiCjM8366foiZWb5Y2l5SFerTxVAnk0YzN2iecwZepgU0+6Nh3wa2JPpj+XmbGMSXRDQmLUqz0HvXewZXCpE6Ik6U89b0G8a2SMBLfessmew1yQLbAC/NwEhYy3lxGTAcJP0mJANjTKzRvtnFNa2PTXWt9K9ShY5twFH+wqGseGRKxvgIRCVWjCssGcW6RP4onYZZ/7zCuwYRy42HBWdCji9QCKE+/JdW6aQOnIEJzedxFlv6qNe3qUmnZoZ1441ieGrW/nxK5ViMcZiz+/04fb2nEnaBY968SGaVjjTo8RyrhGgg3weoCOkg+yitAccBO2w/O/XeJKyMprSiHETIlImuiJb8udtkH7LnJEX+ErIY6w4JsGzbycMhY1TbOk7n6gIm7gSU5EW3yW5Y4DXAC/mxUtC/4WaJbhP0RXI5hNgZJpvLPZ6Ace5DQaemiZoU/g98ct1O+Izex3czT4+KFjzMDO6YtdIU1i/keVtirm878MJkxgsoS7jFjo9FM8UoxjbwIvTtNciAOh4o4y2lJUdPXpiTU0Xlp8qQ0SByhBIMUVFEifOWkw62j0ZWk+fprgDfNd6UqCtmpsDIlna9SCtX4xkMupAl4Yo6g5hD1+IR76NmNN4UP6EGsALogehDIWI5m36LlbYDccq3dc89MfdaUgOd5DFJJwxb27yJyiy+/eNIEO0BWZwfzhvQ/Hl36PckMsR6v+kibU56DZhB3f5N3XMTQXqGXw0JhZLU8pqOI8TYPvkBXRh213gBX7/KMQEPXOYotzrNQuzjSITojZNginAMLklLqwUSmrjT1rrvcJ7IE7Vf7WFKbGnXVU2t05RqwqyPcuEVVYB/VnLOLG0ZQ6Zv3yi/CFP0RghcusyH4PFhTtTwvd9nZKM9KecP8HDh4HXFeStKqKq0zG2TVv0T47je7VFAw7FYHU5ip1WaS2UwoS1RjpQXzAdciVzXzVHECM1FuOPkTkLkUcjzRkBg=="
         }
       ]
     }
@@ -254,21 +254,21 @@
   "TransactionFetcher does not send request when node has transaction in mempool": [
     {
       "name": "accountA",
-      "spendingKey": "08c18653b091602248cce5d2a198f67ec043f83a866d352d196f840a5bd82f25",
-      "incomingViewKey": "218e9ece95bba8e8771742ea0719cccc675aa5327788e3a8cfde34733ace0f05",
-      "outgoingViewKey": "6cf805284d45c0d08c8f95d122684110bb073c8af83d57aac4e282afb2359344",
-      "publicAddress": "f5dc97d1ebd33822c251be5d78f12687e600fab22278c997eb9585974ff83747275a0c2afad98e138b4abf",
+      "spendingKey": "2c64c5db0e0219c2cba9d29433b226ccff83a7dbe4aa03223a4b955d914e8300",
+      "incomingViewKey": "e03c578c6a6ebac2ec824410f27eed878138b39890a59e9f5afb20fc1cf21c01",
+      "outgoingViewKey": "b09d3d190f2060be7e614aa0bff7128ea2170a089587f6a1ba13c5bba6c88952",
+      "publicAddress": "01e5ffbb763e0bbb60aaed79b997adbbe5d1cfc1ad8bd32453b1f1cf5744c45b699802db126b3f232a6e2f",
       "rescan": null,
-      "displayName": "accountA (8344093)"
+      "displayName": "accountA (dac38d3)"
     },
     {
       "name": "accountB",
-      "spendingKey": "6c855b1fab171a6337f46469472c77fba7f21c1a516c27866cf0ad1c6deecf71",
-      "incomingViewKey": "168d814600004a70624f6dca123dac3f42bdfd2b4130c8105cbf07a975887300",
-      "outgoingViewKey": "57087128e63a754566861f13c7c5e83f0612322eaa5e068eb0a031efaa8fd85f",
-      "publicAddress": "80e5cf9016255d741b6a3ba5fb95cc1e9cd7520e929a8f2cbbf211f910428861a547d4799be9b3c95f0c34",
+      "spendingKey": "69bb66d1f168ad3b81696ea3e7a10b22dd74cb5b4efc1021f9641564cc92e060",
+      "incomingViewKey": "7f2036071b953451038026774828ecf9dc0ef70ac0ae4e07e3e8ae0881c93a00",
+      "outgoingViewKey": "10048f6ac06fb7b50a0ea2a7e4e7944e5766f16a92de4889e05be14f8729ce0c",
+      "publicAddress": "8de874120f3ba71cb298bd0bc5e8b6fa36b2ab440d14d6b4b34cc34344f687cdc42f59cd936f81dddc7785",
       "rescan": null,
-      "displayName": "accountB (8eff54e)"
+      "displayName": "accountB (5ba52fc)"
     },
     {
       "header": {
@@ -277,7 +277,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:Ym/bzAUG87M+mlwN8WlgkwzurgoH2RxUju5qmhsVdjM="
+            "data": "base64:cVJ8V6TRBDV4c1bTbKbzD846MdPdvDQk16nRe2EiB00="
           },
           "size": 4
         },
@@ -287,50 +287,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659989482654,
+        "timestamp": 1660092439774,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "70DD3AF0771B635705F870E07006C5BD3C25452C54BD1815B7F652942D7D15D9",
+        "hash": "0514114F41E6B81EAFAEB8E1542D6D506D011714A8FAF929A6C5601BA884423C",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIJN7jW8A1dotmnJUp94L/Fvf8rHW58VtY1zX2daPd017X4kUz6mnCcXXHi4QeUv9LdDGAyNSVuvGJ4YDDyn+/35QYBjtUEekInExZNmYRf7/oYMMlyHudkJVpIu5RmzZwdDvbJIgA8RiFVwC8dbxwNhyA91OdUsqkqymAWHprEDsYyFZDcE8JEWGj3BNulGQpmTrcid+nJ11+bdFPg16E3PJcwv6xEWjVn+kkJm+O6IBBWJajJfGiVav/KwFWeu84WDoUpIk/6WfMnQIEhg2PCK0naxqABwwRwTXgBJH5Do6EGyea6rf/yUPb9ZWNt4LrFZngQYiK2nktBJsAY4Lz5sQhVwlv5XH6BdwTKatnE35W9y0uJKge3gmwNzxVVJKqFxsTwyFfflxReWkbAGaXR4Egc2B3XExWN37ZyUzgD3hjO1jJnsR8ezRSC/iM96LoIw6+FH4TxsMdnJ/XRw5XYAa93c3NtX/+8aFDiT99OlFR/64wocpHy0YinbGIwRwZIOXkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwC/D6zbFCQQFInbdp4cxT0RKXq4r4GcHxV6BDA4afXIJH+x0ZvSU6joEtVK7qanZh7Fe311GOFKjW/0n7sghQBA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALGayBjRwSPk4nlBE1wl85gBcEZjOJkF2Ut6+Pbeo/AjTDCc48MB4Hh86FHxwjfXALMJT+WC4x4+O87b9oZEgOrUts5TYifq00n7LgZSSvsn5kA6fzGRZHjnlzzMIqn/XAO4CMyPcfJi1jvNYRVsKRBL8XZy3f8ylEchHht0kaYaObAtJEkHKDADL/b+U20nj7QEYtnxzs1Nu5A6LV9lz3VRdBUocwNKXZqqDtlM5Uc3P8v5nKumEZqmtxjpda4ZA1rkrV4LPtsmBhG0ar6iW3VkzC71mRYSQZJhog9dy2/QY01Vqa3Ov3SOR64jYWyUIVwSCrOBgIR18UMIF3ZmMgl8z7nZHEUjLgSkzntaT0TyCcFKPSuJ3pkCb9Si5SJmTLuNxjIYYMopqBCqH4hZjZkCUyn5C2shHbE3eNZe83wizQvdY/Kx4WOdxWKiosiq+cH13st9FP3aGCCwG4TJ24/b3fQckTRSsk9QbiWwgZcXWtIAs47ASmz1W94A3GVhBSiP00JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFJuaWJUJIiqCxW6qdsO9bUMfykzMDAcEXQwC7dLGvZ3LJZ9mYNi+uwEt5maDZI889RP9t5EJ94AOuXiSrW7QDQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "70DD3AF0771B635705F870E07006C5BD3C25452C54BD1815B7F652942D7D15D9",
+        "previousBlockHash": "0514114F41E6B81EAFAEB8E1542D6D506D011714A8FAF929A6C5601BA884423C",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:a4kJUOqreX6kjYNAY3GgdIMPl3q7eYpGmI5O5g2sEEo="
+            "data": "base64:sG3oV+rEaorcQz+Mc3mtzYTCDt2MneuSmY5+JC4TSmg="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "AA127B2ED1A934932350FA3597E20E49B051BEF7A9E164728070B2435C817958",
+          "commitment": "F0C708D24C542E57946548A1416E30B50F0E158B08B37BEC3DAD6C8B61643CD9",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659989484007,
+        "timestamp": 1660092441112,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "E3BB57FD2104A39938E68EF9AEB5E5835C1CA0545945E33964290E31B6001DA1",
+        "hash": "56B406494676B52B8FD66CF192555528A01FF0CF6196CF9DCA42A8F234579719",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALfY/3QM0hEDWyNgN68O1narMe3jbSl9SOEppz9s45IzP12vt4YGhDlqccz+VwVwr5YEiXlYL+XIcV7zttZxP2mpgOmLmZNws8Tnr8hKJIBKpF//1SFgdv+xkWLB9Lo2Xg/jyvtnvm3d7CaYTa2sAyPNHLAV+XZUO09GepAaMsWtcMG4lWozTKZUl6FXe+qQH6mEp2dZHJ7qRPAhkpPE8Y35YxEs4g3p3uTXrDr+e1mokbEEckynfB93TluLgwYKVxHt1V14JzgKgNb0yqE1n5zdH0VMIC7YpCh5zgJTKxiZxhaigC7yqwsoTfueHLH/xqV9F8a2VUFo0dBlP2qIjDHsLyooCT3zE/z0upY+qx8K0oAbjkyRhzKfF2IVsow/GHp0MARJIMBZEkMIUv1WX3jJH+YsTVgaQt2asLwNljCKkC2SXaboIuiP8xcGavA8nY5CeNMYoKZlVawkk8S1Z9U6SPHwH831COxqFhDTDlLGgu1jwgH7UjTyQsYsCNVhBXs8vEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwl0drqaotyCzVxDSvdw7vxNuoKeZnycF3vNcod/YmXAA+RJD7soSgmECHUMiyGiF5IIB0EEfjKpcfkPgX2zlfBw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIeSEczwdmqD8HiYYdOaYEaSVhe2l2lvV2x6GPy2lrr1T0UGRzq5YX3tiOUR7KNY9KiM0vjJpCgHySka/Plt0P1y4mCmi7FHXZqSY8G0MwMrjVEJp/aaGtP4IMURK5DH9BkgIJJw3SNsdqdHjJXY32WLfRsi9wK/E6riRpc0WxgZlHIXjpA1VlipVr5GNJ0nvoMXAfO/EE2bsgpR2TlkYv6orW1y7cQWCUSF0+Jt1x8txSvFD/vkI0Okh89kBTnMPdkjWCw8E83ix5xIjtQblWcOZtIduURM+88mZ2m2lzZzcOkIU7Kikd3co/G/MzyFJELA6NJ2WRKML3b6UX+mwyjDJMckXbErr4DNPRqfd02X0WhSSo4E0VHOYKkGSZO7oH07R1kUWta96LqHZ7zbHHFzj/9yc3nibYdaUPKJF0/dMxhxSjR5cU8ejYRO/LlUW9sgPGnXYt1O2GKBWn1B15+KHe37GylvFLujd/FtNn6b/Nrv2VdkagDPoZSCv1G+ieTUDEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw43/l0KcjEc1CDZ92AoRoaTRw2VYRincaFnkdHGWYW2KBHXDtspch9NfHanpfTa//4QKj6NlqidBRE7dHdZcfDg=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKmaccCbdwwktIvH9Qe/OBUZmEYOBg1xbwwWhSjOCx1WBA7MIGXUr8NCyhn05hc2f6W0bCjO1uvAXVrkde/wHQA2ctd8dwwWvnYhr/KbS+88yj8r5BmGfT864DpnHQlpshDQ9VVxj/fG8w4pDYeUaDrCxBX+2eEZvP6y4+fYPMe/DK7dlFyF3Vd9CiFyFTaIiLVWmuZ5zP4cyyox0ebNhqQWXDaxbANFdltyZxS8PFR60HoLhT9IUN1c2WynfS/KrHuG3NczDe6b/Z4FX/7G07Oqrkxm2VmzKWzo5CN24VwjEXqueCn4TI//iC1wuVfYcXH9230Lnks0OY+hReSR4hdib9vMBQbzsz6aXA3xaWCTDO6uCgfZHFSO7mqaGxV2MwQAAABb5tS1jegZiXfxilcL38OlM7qIuPbKT1XZp6RE5gEXiz+uxv+TtlPUyrwPf29RAx2bZM+tD+r0+N/j92XFsh2tJlDT1DVfoln/EyvnS6035oWii8Lm0MAxA++CBk8lBwihVKuB5s+C57eHEOdbVE+Ov0ahD8/n64mnoUZE8cMK0uZhYraEvoRDMWVIyWrA2dyYed2kcl2400TX16PJG/Dld+py80/6FZCgGkjziZeC6jhrshgnNxNZvW9D2MJXFdMOL5EyzRVEDivBoH2Nv1dohr1cYv3+8Frw+G3PLkvtFZGG6xj7pE270T+WEThs13253QV/UXZB9K3qMl8+W5+FYpEKOuUoS8WNnmxNdvJ8u3zIKGzYxo+JMWILTd+mWTPReLJ4ptnJXIpmYMOok3ZrVJhlE3O7H3WGZ/z4V68wzGHKBkSndrOo2HIv/Cz2lD1bfS1+vosxW6FHWbK044pOGlNCPlNdnI6GpgDcfDVkBRsInl4mpRXQ8JYK4419mDxFRDmhP5+aOt/6k9G6njFVJAEClUbwnazEVv0jc3ZsFhLSndbnZWVQYNW5eoHb/QLRFB2NtbNoflCEanjoKR4D5IMnER3zNunQPUrghelAoZArgMhIj+wxRh9eAU6kVkAFRaM0dL6iBDtCG73bvfgi4x1OKHhqIAMhebK0mwJMf4ff0TspprASmHoaE1ziUc/OXyrKT+oPnP+KkZJCcgCAmmnh9hGvZCZmY3+KFJ4YKWvS/rfO1l88PZpyYwTWdrBuEBQUMLbvf3jo3RWnnR1ECHajjMvI2TJoCdvf4WTqjN5T0KhiBMrBlECOovyyMdGwBlZGlMxIl80V2SLZD9gy+Iys+b5DS+UYudnbveNh8YtOtgfgVrAgQKCxMxJ3cAdR6PAN+WuZjSzKiJxPrSRYz6yO3gntHF6GXnwDbCTQfVL/MIlZ9cApCiN/k0ZI8j3XrsKGYHv1o7JAsgJZikgriejfaBmnMBximGAkFLm/7Cl6F8XpS923eJlhmCbBuyiBuFU/VOA0zaFCNI1tZkaumIhm66GegA38F1K47PyTLnfv9hZlDF/zkL/N2Mphb3d4mmnGNjXe3t25crASUisgaPmq5B/trZJPdMa/h3BuKLsPXB8/htjvvpC/R3i9tbAxcWzFgYYO4lQ5+6UNHpNPPrBxMq01+hg6xWM9ZOUfY9OWbdfXnrES/o/7Dbd9s0m2DoNwrLszGQRuAZtZpDdkqPbDzR6f7l9+nz9d6/aw1ihjp8sWEacQBsnaBudeXdMalCGdcE6T9jXjXEr4qvkdR3xCdfgPRjtLo+aXrf+VeiG42xBMlRwwmOaTa3H7E9KeIgfUD6H7rXqPEczDuXbsPG9F8YXwUvopKQHnUob9+NWjo3CimmBoQuibVFkaaiUTyPDJjE2Aa6prB/ZqFLgmeP0QbQRFryhMTZ4ZVg1LhBKtC0n/Cg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAI49DguivlBXtWmXBrIeSr5x0+WlBaER+aAC0jXroDGYiTcn0o0sOd9GQ7guylj3m42a96OFMnyPO6GlKyJsVy/OSa9nxEhzQIJaAxN1SoHTUuJL7ryne1RCRFnzi3+cKBPX3pprRndcr5vzum6SOIcVa4jtUlRjiI5VR7zJ0FaL8l+cYWBZ/ZRSURvRUWP1tJW+Y9Wts3e4BvgoIUQRoiwh+Tju9Yu8iXLV0yni9cxwpZ9uhDowdadxh1Mr9Xlvxx+sKWKmf1UuOg3t/ro9kvCSc1WyvbLlzRiZXFtJsC4FHhiNWwz4u/GdK1fAPNT/Wbfh87DIGjxyntrpz7iSKmhxUnxXpNEENXhzVtNspvMPzjox0928NCTXqdF7YSIHTQQAAAACm1NZ6uTdOtCM11l00iJ8WJdGNvaVEtqqmFoQv1oqh7y/b+tajMKKalq60G+bl7nnQk1Xe8q2lHwWVfdFwphYufrNS0DpV44S/GHveDwaAawjlGpOWyOdrdnb1UO8/AOpEWHVNVyX9ZagGQp/U2ef1y54zqzJ7Pk8GMUkvNMmaM0rq1CZjMoH/XqRTazT11iAaCXNHxhYXidCsBxlAzr/T3dLbvW03VelvoaN1PtFUSAheNay8tnq4K+pViSCSlIXCeLM9kZL5FdLmOTKWn3GbOYrznt4rrOQX14Q5RbPUWTm81tv4ku8p2KyVD/FnJ2jn51q0Yk3wjoAMHSRvfTl/vqd653aPFUlyBp2MS2IVwkayh6zKd5nDIPVMqouezI5Gc0Gc/DaDnlNutzHvEYZ5106l52/NcxPC1OatwthNYIqMCxNihOPRcnecSOqDQgIqobwNKKfA/Me3yVDv5dqTcY7asTaLO363rZkWgEZ7Dp9IWpwfBT75GpWkNCkZiFp+yZoN46zSvPwBFn9E3Y7R3WVL1WoijO/TCAeApSxFrt9iUfuQegIsrcUHI0Q4QzB+4nNLPNu+A5yc6skzJiyDU0pg7u1WKoI6U7x9OS0gWk6fN9GaBxFHGD5VpSqM0Yot63yVTKDvwT4/LcZlVUKraUU1+PeVPZoSM7AbZMGV/pKVYrvDv2UihcHYrzDk5TCWrbWwLS94ySwRyQv3HbrgD82cc4vj0Wg3TPFVEJuUWEaF4MvKtwdO5v4EslZQsenYCvIbGw5FnDmubsFZkyWt8Gc19FwcBYnWSAsQSd+oPRJyIz6BnyOSNTVGqAcQp5pLERgGailpsp9c3ul+r8FW5pwM16seSsheTHvOsH9ZjBiDxf57+iUUx0rVoCN1HvX6nPtfim5XzKrs6JMepZBnOLxo9E6LBuWFovuSVuta5fTRbAxlfFPIICeCStvtWPo2vNv3tnQXqISLSysE4SAVDbFj8pq41aDT0+u1sRdwt6oG8FJGbwGhHfPLAF4mMlGW3p9xUFMiqY2Qd7xR/sx26HfwrMJI/897UYRmX59CGnwnPzNn+BYI+XvNm24zIU0iDaxeiiIqKcKQO6EUIKDhOYsQ64o8MHrelF/C1kGwGa5K1Q3W+eQxAk1fyLJdZyAIdI/CD+8SKvLzs9eXIC2WrunibTbzhQYPYOv73WR13+01cg/ZPpGuOOl0fd7MKYMbhLq5QkKlZZuOI/1kN5J3CVxqJTNpeF+oqu4wATvcd/bAF2UGAfv1QmzN4owOUsbLmTR0J0deHrp1QE8ggPcd36ffX8FTExmY/wZoFNgqTiL6mET79xn65Q2WRzJUr/Ue27Ycx5zEKrKl34ctKPiH1SfGf3NnbL5naH1crh+hMEA1PhQjxwr0vnDmStdR1bntZb6aSdlhzxtQRQ0vhi+uGQK78a7X8+fWPwfKk6YYcriLIS4AQ=="
         }
       ]
     }
@@ -338,21 +338,21 @@
   "TransactionFetcher does not send request when node has transaction in blockchain": [
     {
       "name": "accountA",
-      "spendingKey": "d37e8fd9ac1ef998b50675f4bcf181d078a16b69dd47530e889ba7c511f5cf4c",
-      "incomingViewKey": "f60d2d47cb356798d136a4ffadee9c4548770e2feb54f5f89a04dce072093b04",
-      "outgoingViewKey": "a5bb7e9e414b2d2ba49fed15beda071a2d3c0637704dd574c36d3e071abebf9c",
-      "publicAddress": "4b0c2dac9b8092b438f69fadd866b6acda3f44a557899cdb1ba95da871baffba5cef557d65822baa2f54cf",
+      "spendingKey": "f263180feaab19aef3c68bfbca85591638681c28f05ac1222d8db94630fdc29d",
+      "incomingViewKey": "2330e757ddf15c204aa8b1675c8617438910c5a471aa2b1c1b3dd5074e247605",
+      "outgoingViewKey": "64a8973bc5c33596db7b4ada58f8365398f306d7086814baf81c91f2cbf05e7d",
+      "publicAddress": "f08660e551bb82a525cb824c5f6758401f352c330fe7ce59856db6880e83d7d21f9ca31a87639413f685b3",
       "rescan": null,
-      "displayName": "accountA (c6414d7)"
+      "displayName": "accountA (d5eb4a0)"
     },
     {
       "name": "accountB",
-      "spendingKey": "3179415115a67cced5bb4a738d2bef501b093bdcb36026c198875deaae409ede",
-      "incomingViewKey": "a604f80d581577183e3ab3d0099a9bfadc36cec6772fbe476f175582e5eb1102",
-      "outgoingViewKey": "ed6701e3600156e44d7d90c07841986cc466ef50af7a53ed1416972703ead9f5",
-      "publicAddress": "ca5255164bcbd72b0e937d53069ea32a4bba2543a981feb3483ce0e75b4591100795a4483b6ab0a31eb70a",
+      "spendingKey": "50a3bc318776708e909b469b6527f8a98f147d89aca82ecfcd7b9df0d9d05578",
+      "incomingViewKey": "dd30f374345124a18fe8889331daaf19fa37e554f1d9c7f9bfc640e4491d1605",
+      "outgoingViewKey": "c804ee245b3d536e6fbb4ef93a1d3f86294e117fca4f1152acc7573fecb39fc1",
+      "publicAddress": "02ad525786185d9bd37190fe36a88f78a2300c4140c648024421fbf308b86a736163e8a8f94dc167efdfc3",
       "rescan": null,
-      "displayName": "accountB (48bd1e6)"
+      "displayName": "accountB (d6ede49)"
     },
     {
       "header": {
@@ -361,7 +361,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:0G0bFov305A+mGFxevTsGyJCvuiLIvT7pIpAHwiqly8="
+            "data": "base64:lYAhO+1d0gx45SZILTSD7XlVirweJDauaDsRVX9y5XA="
           },
           "size": 4
         },
@@ -371,72 +371,72 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659989484210,
+        "timestamp": 1660092441336,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "112D0D88E271CF4E5F0133F6C609110F0850CC38EF9AD4B08CDF970C12534224",
+        "hash": "0E4E8177744C1C3DE447A4903C42446EC07B60A2DAF1F41F06713F18594C748C",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKJ6eXuIiiq3fSdDh/pjqvlgJTmFVW1d35pEES7OXj/D6ouEGyc+kOSZxtalaqEjDJjrwIvnLek3foLe+eXXCfZLqOUnBdUba5p6qSQWydZIIDRaD0kZdbSfPubSmI1wKgcRyIiyIzj48LTZK8eKNfpN/KMshmPNEdUtvVIFi2ixQ6mX+KulCKlqoUGNjX3+E5fDWnnIqNz9ptFCBwfWh7UAipnoE/4IuWBt+gnLGipxMoH9i13vxL6Ga4vYMewjHJX3l/QUMscezArr16PqWZjX3Sy4SonVs9Ut4K32wW0bDA3zIZXUWzC8TYlfDDoAT/+zSiCWg6VLHuXayz6mkTLqnlyBT1z2SSHJ7Xgonq+W5DxCYrb9x+T4pKU2V+TuYZrYO+5VQf67/OOrHN2C9I6LdGqVlkN2g/vNE5Z4RZTqIc3uUk3G+40KeyaLVfqEagLGmxkZKKBcI1TxPUyakaYFbvwYgPqjPAkyDM/NaPq9uosQiVMakh+M1F7s3y6fnutbBUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwLQjyPwo6rGWm5nsHlXBfs8hrde1kYkZwrWifGCwxp6EbCFUlSNmut1qf6KOu2X6AekFI/5pXYgF/YQHowLtDQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALb0fL9/SgSHWanz2tUNVBPiBJDMKUbLNxSbEpgECmRZiuRZzLBC43SxLfHHhrlCwLB4pG34bIpZtX9gvOTL07B/QDMF4FDOByC9E4TKuqDufOfE0FESo+QwHfuMgnnMvgjsz/RcPVzWqdp2GoSGeiC36Wf3RrmVcsIIsr+a5MEj1P3/NF0xb21JmIylTgbLdYjCnubm3r0nWbeK78Pdln2InyDZD2dduOFeWOgAkLB+nrXbn+IMFFvgufghbdxim0eCt458rqrBRqn5YLnl9zrmQPdH0xH7y/5wgaex5SRTaCgD6aVBrxy/zLPpEdwqBM003tcsaps0AVHpZQCMzEOVQBux6Ms8VAL64NZku/RNArKG6rDHAsU5tdy3VfFeVmuqWC8QnjEgHB5BOwr2gaRHEbrCpS7NHnMFikzdFugJ8lpQWBmjxww8iyx6AYf3EQo/RZNbYYjjBMKwWiE08HJ4wTkC5iqiW6OZywJ9+LpLoN4hjD9D92lfF/2XXLd/GrnOtEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIcDaHGDMqZUOIbuFghGUimlL4Pb8BV3QWGtWFEvh4M22kj07cGc3CG67YE6171+BWenX8OcF6+lqnVNuqVDKAQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "112D0D88E271CF4E5F0133F6C609110F0850CC38EF9AD4B08CDF970C12534224",
+        "previousBlockHash": "0E4E8177744C1C3DE447A4903C42446EC07B60A2DAF1F41F06713F18594C748C",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:3jamOzcD3XZ4jixnit4MtbHa44SE1ofik1uBZ1A40lE="
+            "data": "base64:vEVBPD1YEKEne7uzCS78A7ExdvDa/TH+mSOQekKUZBk="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "EA4E44DE3C0D04F9B16A94BEEDB60655411EFFA6FDA4425E8CE7C1CB5BD44C54",
+          "commitment": "4B487C50C149BCAA85C8F954183C1D3543FEF096A634499EED219A6B5E9745C2",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659989485566,
+        "timestamp": 1660092442707,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "F583F34788F902CEE58B70A93FDBF7E1ADC68BA60BCC22066D8133CF55A8537E",
+        "hash": "7B396EEAC7092DB2BB0A0E5595161D93DA68B993E7743DD98C1493686767D6AE",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKkIjIu0V2hSVGVMoQGDf5+KALwpSt7i4OqjAQeCO2quuye04TYDJ6TE8L0q88Y39KSyk45VsGOMN/8xG5MEm11RAEgVwG0LUHqBL4ZQ1rUDY/lV1JfBBvErzmWE5lQElQeDR6LcSZ6UyVYywCFRmoO1cE9VXWBuNOW8OMFgUgr0PzdiX14B1b3aGUj+jpFGS4Pm9H85uIiyDLIUIo3P6sj889FLTDmfCWxfWR727PjSv1+sMqQX4KPN6ktPLZoCKd15aKbL6ADoPPwkI7EZc/OO//QM/VYT4kFJdSMFolDu9Nbrcjj+OAoFF8nnWqEB6apKtfR2lsUkwa1qxcJ+IQo3AjfgszvtbLCcoV9w9v3e+enFo4psLvUMaJX4lhpjzj3nh+WTk7sIkr2P7QQH+364dre11PfiHkH1qFJoStbIn/Ml7douw/MMe1uijZbVnD0y4bW9Lmd79WBVCIzZd1yjn7l6o2iNaZZHU5TqBwNBDwm18MGocTAjEY1B+I1rxWernUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhYujfaWwnvgxGj5E6wnBDAetYa91Mbz9P2cja1V7LTzF8xhUfXx4vdfyATqUq8k3qvT33OefORgO/TtUhn5jAA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKifGggY155M6MKCrjoWRiA8KGLL9e/A4zHEtr72AqcF2OQJ+6R5hF2876qGCVIYNI5N84pefGD9jd6lKmN7v3Gdji8UtT2Ens8h/OMMu5vZ6ahuQzJ84OnNxHBw1NllEQjXGB64/azdzsL4X8oDRueJl/K0kjTxCwebtv1n1HDvXab3JS5IXuDYB7ME0ifOt4qaXqu/DvSwu9SCvehmuFveHs3EiiK+VmVGh8kQg+PhgFJjTBAG21wprgX7NtwHse57Np8Ap0Z7ENteq5N5dYJM7WHBmcJM++GjvooM5qdyHtZNMdN4OjNcMzGXSgdprGZPtwJjJNjF/XSKhu4BLxqb7J1n694RnToQU6Arh50YSvxOG2z8Kdu9TYLdkIbvjSaeEWElJmyXE0icIjJI8dkyhwJ2ic3Z/dVvR5oXBQeunQWG4OjzUuIKk/hXHB/yKIKdoUm227lN3JnTtbLXAJ+gQrcI9KqiyhnJtN8ppGUk40ckWAp6hDhyQNrzommWhyHynEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBue1FsXyVZw+aqo8knbmBI7jObIB68iIpY9g1Yw8YOeqcJYmVVRHscJhyP2YPmdHHFRG+npxc+foZl+XS+ExDA=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAI/jFXhShOcCvxnuV0vwYPcwHbbJLRS4qcxeuMDfuinGDPOGYeMynpDXxBAizFLH9KvZZ3EyoG2kBisftWbSOH33zxmcLLLw1l7RhRAdIoJWcpqTAF8M6LQaMyxq2D5NDxjibNDVGGm0iP0Jz3e5f+iHS2vckp9b9f8OJUKEwN8yec9l1UNsZ/l6ezz8nyLmq5XI5D9XE+FlTQ4nU1jxj7xHD8iHQoG1Lju/je0b2oZsbfYEYj78r40uNW1+cNUbwtYZNt3k7rXdRMUp0WZxMI20FkEWbEJCR7lldE/fXamLxKAQVosFgVc8HAarzlbz2yQwZgoqm4TS4y1DDGM1J6DQbRsWi/fTkD6YYXF69OwbIkK+6Isi9PukikAfCKqXLwQAAADMmPvda7H1WBCl684N8ghGZ/bJ8xOqx2MQM8ndApSOPOjAckae+zyYs9ekfcYPTqW3EeuSDyNzoi1Sxj9lpeDNN71n2zd+H8Dg8xphOLoCz4uw9jkQScHyeOOUnL3H0QGp9C9D4Ecs9ERSP6I6FEF+bE3KDPSMKC34v7XzHvoLPINNi+9HdRcKgWtZYYBNCHqo7VWDMItWOn6izR2MDagy4NQq1lCDbR+3YYJJ5hkuXJ0UU7wK8YrKcKQlsfmmazIETgUY2DsAB6ZHKhKa4WUjfAHSQYQFYBtdgEYK958FNIm+IdlZbLrQhxpyAbJn5EaZ4Ln+9SgxjHqw6TsSZDSIMRPZBkJmQXbXey65GBTntj0EtSjFhsATh1h4A/E4V7/MBbas3X4PoK84cCh3/5wCCrUbjCKaJf8VSM8BmERuy4dpnq+Jg75P9xImzelWUgnpkhgfwJKJIM07R96YmmoEZbulAmae/PSzHY0uq3g5v0sQmkkyvxGRtwRF+CnZTrR1MT7uEH+ZWUmwyxbICiUIL04gXJKsc7OIvorJn24HmR3PUSXajvE/UOBER1qzF2KkZVZoMIQohA4D7R54+OqPGDc4dLgPBoD865hAAMVl2nNLo/x0NMTVbUukZlFNAQM6Z6wXSUCN8sSlL399Qc+Q0cuTqnNzT7b3beaH4r0Ym6+5OK6aIYKArCE26PFxpwS5ZmGx06Zvc+BZkKkZWiCNALN8XYnRfS89tfGOwSjpXyNcyKW2zokW5R24bDBgi9UiPuyXOqzhPvMCtkOaSY1GdrBRVVKdh9Lpp35qVeiozwply4GgGhfalaItMFDHfSZ6lWm3j5LG51/Gj60z4Zk5nMPwh51dHXyPEg3Xc91d8zRe3xfXEmUlcz0Yi0DVp6Z/b+h44yuEzWt4LJFuce6w6RDULAf9X9fj/N5BrCyFfjXqBbNZAseRiE3ZeYMPoeQckk0PrGSDhDZo4AYyWAi1aMb28Lxc9kpST4axIQd6NJf8PSpjr6BtfifEqdA0q3iUmtGAwSlU7B/sOSNaBXQk+8w8AUaMMI0eihq/5qOa7igW19cGubP+Ac2oexZX2knzJgiMHV3H9PR+wOEW2rPl42sMtktfUoQRM3opPbyZroh/MUQ+IipK8f+kNs3E9eXMxBRRJrGa1BdNCNGvhyCN9u+6ZlB3zvbthVVNzT9Q3SF1niQEtznahNGzjJYgN+v4lbWJj5+FXLFxMFp2nlqEyxiOhGQZYs558Fggv6bceeBhQt2gW2PPWUfPy4eUiEqs/pkyCvJh7HEdGItrbYwi0ei/qoVuSXKDnEvH66GHJgAu2Ox98urDo5PMk/hZSYBFVwlTcUPUkMMKl2IRK2HeDMOY9zZFBWXI/NUlwzCqVcGGgirSbj+/T/ker+1bmcLcQhCFfKZOWdlQgNVzTdVcMGxtiGtzTgh4GO7fbyXvzm36LrWOAQ=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALW0fR0YjPSh3PytSLCR8vJGjRrbcZf0B+UcRt1CB37S8dl9v42V3RWP65vPL64kFKlosv2sh2GyEaF0BOwSawu1pcnuy+w0VQIfeCliMa/JZD5HuRq3S19sDDjeotSgghKR9F+2hixSeFMuSLQID6bIyXV0gZxl+szM/8DlF0UNZN4Y5/wV3f01RXR2jLRoC69G5L8fZ+cibaGg4griqjKufT7VCPK8oz8iiI/IWap0ybMfHpbM+OQ1+6/O+PEIoomlIFpbKjJsxU7OPS0YGx6MMQD8AGnvUWShXR+9xfodkGtfqEJ0mr3sjN7GnBXQmP6+SzJKy7wDW49b7HWb/q6VgCE77V3SDHjlJkgtNIPteVWKvB4kNq5oOxFVf3LlcAQAAADGieV1bmuBKuLFyDSSw3u3qQgdzyImcslbBEb9sQy2tkh3GfWsJ3olBYodR5x+WRH9UnwNGoBr+IIku1cX9+KUwmGE7GBc1+1YwDozPObkP8xDqwEOfIQfVUGB8Px9QwOMhjrz8lF+61sq9gMi6JEaRJ0lJSxoUlAqgHyMb2/Wn3BfJP0L0MJaoP+G3d5KAdmKfnQBJaYoDigODZeDPTVPWmc8KW1ndHPfQTPzuy7l2ATQm9He5IhZUnhfFFNtXL0ZPirkfi2CJpCELoWcE5mQyA9gwED/vkUe5c971kGRH8G6dIBlGVx8sDPfmZ60lB6H3eOo7JFgZuOT8eUPrIbuj0xXSVNcacP5qCq8GU6ZxtiijIadtJRzlNnWu6+RdjdXSrfVTO3RVYN6cAYeuwULtGGm6SJB3SnHRyFXPqdHkPd4pPs1oXbCdkGHOgOSypK95r3ZoP/bCHoQx6D/t5VEhVbTIcy9J5M8kGR8BQV1XA4t+26rH70XFdtzjk7l+LnsD8Qp4eIgcg0cAPOW00jIgwiuvyeP8fXC5tjn/y0dTUiGIraV3fUFW/2M6scREs9KV/zPed4AWwUnT66zbdZmulgdzUkC2bQJCd3BCs0tqhTkC8/j+SELQEVEE/ICrhuGz/oDaMsFnEliZr8MfofCxbQxKqf1Kntmer2UAKjDrY559PucoRb0q/p4SaHIuiDi7rreaWxF8Zdt9RDkx+dzRZW5IFo+EewvK0Y01iqiA1BXPZCLxtmlLu+Zt4HS+LHk6PRjFYu4zaCrPTkWi5XsOG+n1X6scc9mTS/WhRP7jfnhZqUS/ifROijjdY/ifCQZsqg1hz2Mi6t/7SWD3yCDwmFQdQoS8QcP/7juy/IxgFMmbAgfAx8JO4YEu+hbPnYYXwp1I2KukW8n8UWbXihUuus5wYKiXA5daocbjF1vFPRIXrRZWDOiBGkwcIgcWpJGjQ2xwP50g/jhdwYu4iJ8r+4TX1HBG+00qMobI51vxlb7TALB2O2jHMHrdPbq36jlZzvxRK/A1WU+fP2w57hwG4dWQyw8nh/Kk+TwX3UCDPOvAfWCOEB5bRrl8NVBhI+M51vsUIiiCETPZjRYba/hL9PfFaXxfKNi1hIDoEMpFDb+mVLQpfsJcZQOxqHOmww7FqFd9t4klj31zgAB6Ktrr7NgKIQ8n3rR0wV2lb1L5gM31kA9BzSDKv2pTQ87u8OBKkBNcrHf+pgH5PT8mm80Tt6IO3+Y654bxs7+09cxvFVNycQE0gArSpy6zluRmsG+xfszaQ5XYXAjlHuKBoXoj2JELtAQgfVdPglmnsHI9z3UtNS1WJfoGk01Yf+hjQCwx8gR8O/h0uP/5BW3Thpi+3twE15gixjWKZzRfXIZcxGjDBDAVcJqyZeHi4HRDlUzWXpn3AIjJnTOiYQnQX1s9AzCSTDKoYUvBhJ9imeNfgH73s81Cg=="
         }
       ]
     }
   ],
-  "TransactionFetcher sends request when node has transaction in mempool, but a peer does not": [
+  "TransactionFetcher gossips transaction but does not request again when node has transaction in mempool": [
     {
       "name": "accountA",
-      "spendingKey": "4378c9984fb18e60dbaa35d6e27cfb86563f3e6bbd76615faee7da1995558ddb",
-      "incomingViewKey": "b5ad34d62cec14c55346d09ab669bfb16c6f722953e469a327d0b2fdf3aa4e03",
-      "outgoingViewKey": "1f1dc2d2df0d89ceb33c296d94a556ffe928f5e399acc7fbc21d9e8455df90fb",
-      "publicAddress": "0592bffa85e3218d742ee33d6d7d6d2d0f7f72b1efce2e724f988d0f44ccb51017027e0387a21890bbab39",
+      "spendingKey": "0902f3f4b15f70646a585c0671c95a8a9e227e8a77caad221accd3f804e89865",
+      "incomingViewKey": "3c5be6ba7df9bcfaf95ffbca148332c6f3104daec02e8ccffb6fde50372ff806",
+      "outgoingViewKey": "ab1a619b3ad579380a265925299f8f20dda61a7027af0e9db5347c81db724baf",
+      "publicAddress": "e2dff19d2b8e90149870fa3c47962577464fa0dd636f45c3fc543f5507421b7d7d38c9117cb93c79822c84",
       "rescan": null,
-      "displayName": "accountA (95c8e6e)"
+      "displayName": "accountA (7dc797f)"
     },
     {
       "name": "accountB",
-      "spendingKey": "5f84cdf8bc3b09ecee3397280afdf34fd7dac2b1ed4a80a4e6c950961dab18b4",
-      "incomingViewKey": "0b291447c827df5396c9e1d260909f3d1564f03e0855ff5fb3fda187e7b1e607",
-      "outgoingViewKey": "85dc40edff2400c22f950c6717ebc97b7f3d1c42953e97a876cf24708cc4f49b",
-      "publicAddress": "d0416b0f57f2c9a036ea44a3205bd5adebbd30f71912dc8485112865f2ed49c49643fa1d43d069807061c2",
+      "spendingKey": "1f751b971436fe725b2a091f73283f7f03eae5aec279da73e8127d33803b88ff",
+      "incomingViewKey": "270e883d6e6ea093079cb13e455e94f460d5ca039cffef91066f5a80e4ef1004",
+      "outgoingViewKey": "a484a35328e60fbee6f678a94bbdf448e91afeb605f56bf91c59250644d0058d",
+      "publicAddress": "aa056ab3b95ab70ef0c5c10b038c3129aec02e06c4dfbf1a0129cb0b5e11604f8c517ef680265f0e1026f2",
       "rescan": null,
-      "displayName": "accountB (866f5e3)"
+      "displayName": "accountB (d5ca5f5)"
     },
     {
       "header": {
@@ -445,7 +445,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:Uaq2D1hJG0OMuNsHDdue0NYwSorRrTrkkEQG17SyUgo="
+            "data": "base64:WBM+0eafDFJSVfHslVpjafQmLjvoW6To/me5h3ks7G4="
           },
           "size": 4
         },
@@ -455,50 +455,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659989485779,
+        "timestamp": 1660092442934,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "8868BEC9705B14F3D8B3F14B9B07C66CECDDE748CDA9812EECF8398F4CC54CEC",
+        "hash": "F5CCD9FDDEDAC1840581159EC11048621E566C5C57DF8C56F497B6ED6ADF9444",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI8XBqiLhEjuCBqr+OsELJAO6Bu7+h5DmwNxZ8FzPjil37+uE7ZXhp39gD3XDlES65WmFuqPJHOavtG22dKlRZA3O3ISQAuuZp/WHo+Ek2GevDjHy1fc0K9l6MeONco9AwTBXF5N5J8oXnGETYI7kdnkAFmCTfJB6Z8lSk22SY2iu3XkcIHmhKWHCLbBGmlotKdPSLekAmmxicOQ9NHp6eP6vNdQ6/tmyT9KWfmcXzdfe/fBjTp7tjw7Pcj6xtVl8OPrvSb/nE7rSgRrM3ZpeNjDBBQda7qHobgw802JDC+wnRF+AsWAUEkQK/6Pnk/zM+ZI+1vFVIHN1ZMLPGh1nETtYcZQ/gXDZlLXWTzou32MMLLqV2E58A592L1bWw43QyWAJF0XYmFHbuVrMu70WhedbLNeWZTbrJx8R5Rnx6xIxlh2Uw6PywKpMqdnk+VC6puJuA8r261WRpxat++WTYeTho43L5Lr0q7ywSedpiRHckacRC4CkZqrzQrIhHgWz7sNwkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbAaz9A/TYQ6iW2Is0UsWVdRZAaSS9DF8qMqBOHFPPK5iIJlEO7e72jMbj1QxdLRuNDiVgFZmFktdidyaph8TAA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALR7GlXNshmCGKKshGtEE5uw8CBewdov5pY4eRQQsPXak1gaSik0GqXippwiMyitE7UCtHnZmQcFrMl+mv4vmARu+NH9q+Tg9QVGcmaN0tubZydqXVYBynr/F5bQm6TZ9wGWn19BvWfE7P13QtVXVyUPc99bf+6bEsBdKUbBLXjuQQRUG/NcawOhPO8U0bkEr6nCVlSP/vDbg7pJ9jLBK0jIKTunGQE2a0fwS0U1KjkGvtRm0aCBr9S9C6Pu9Fs5sQtw0llmjWBmiWrLsTGBSxv1ItsI2dwfOJgCFhnQYEkbQraJPotFQXKluqIK2o+rSjLpeGvJAVWenfWRF6rtAWP+jfve+KkPBal5VtxGdrmwl9/XQXDIyyfw6kJye58d88K2O+O8wULN015sC3qCqMWlB7UYA7qFcDMa2Ig9eDlEyzGETtbZJDuKGy9wzz7EIgu4hAPNrEsVT++kpKsRPypbx2Dbv820XXTuGEknFS7Hj8JI1C72E6zC7r9ADMxEPTJeNEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyErT4waYA8OjfleV2WjN5UPuM1OHErCX5Nh5dWipPWjOKgZis/T4CCarSsZasZm63J24pjQd5aEttY+puVXqBQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "8868BEC9705B14F3D8B3F14B9B07C66CECDDE748CDA9812EECF8398F4CC54CEC",
+        "previousBlockHash": "F5CCD9FDDEDAC1840581159EC11048621E566C5C57DF8C56F497B6ED6ADF9444",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:SmalBPrk83ieHC0UA4ABq4y4Io28wmCKuZSmCn+V63M="
+            "data": "base64:pQdKxkzl7CWSEKJQbbpuOoQ2HCvgdaJMZ9WA2fp3pAc="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "BD120725369CAF4B6285675C3B0B959D79235C87DBC55D2693DA0A207BF178BC",
+          "commitment": "98982D7701D591DBA1F451A4C50ACAA819B5CB5B364C2A24462716BA0C883341",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659989487099,
+        "timestamp": 1660092444368,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "DA348D4947EB747D2A7A1E79D475C2DC7CD0AACB2162B805CA44B25A73DEABC1",
+        "hash": "9C9DBB3E4B8FFABEDD68D7E43510D5BE88FEF170E8ED01184B368FE407FE8511",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAI5LLvOM/46O7N9EYvc2fKHXW/BI4vGf16tdXnlfwFlgKXk1EbnqH85bAKePWvOTP46Wiwbty0tb5s8b+SFeC39ChM36ipX7Ng+u4XVA641rCZkY9NPCVFRif4EWB49KLgO4lcycfuuSxdfMF293lTBlJBVSGsGBANjjzilzKPlR+AoIwYxDz1GN4iDhJXLSyqd8aGwnTW7V615vKLlAQZWtY48V4x1A4zgD+mG0EsjqBXKVbQSJKj0rRufA4CpGl49fdHhR/fz0zrHDraHQijD85uajzAZWzQKrKAKt/0C4ZCqdsivIsSM3Mhs2oZwY/RGyJ6BO3/Is+ez/B2TLkUcQ3LyqcKfZqf5T0jAYcO9eyTknJA97s/9++uQ8VrHiqlabdNIrMLDk/3hvhxSRvyrS+7XJqn4NFqePmIuoV11qoGpL/ipcAjdTrNGVR/CFsQlidaoaX12jEzo60xGWjHQNBqXF4LLeoB3OB2EizllG2TEDtn8M/7zPDgHKBsbw90oRPUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBM0cXFhQPT7JnD+CUMK5OBq+5WrTa1grNXx9RiloqJkoL9nWmPDLHA4onZtAxCmlHlTcviHvIiprS0xTWTmXCg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKysYPrgxrpnNwus/Y6U4UvjVINPh0kjyjXLPPWoGVUgpZB8bUsgON25EChgB5/zYYXbPuhQFup/FwRoVnZ9xeW+DXeB5U8nj0PCCaSGJ2vnyvRbriQeLNraSaksuk0KpwdkUkPFrIF2TsLhCItrqL/K2yCxXWzrID9l2ZOCFSm5WtTC4ZUYos7g7i6Z2bnzdICD7q8l2DQRGgUCez2yL2tRqH5xMquqSUxA+i8v8tbVloHWaCmBL1w7xw6G3DCg8syprirovXi8qKFpZ60/k+Cr9cXmBGYPx8IJ0S4QrnsDOpzgtGhTMBoHZU02r/GLrJDuedyrNxN9Ax0re49ArT75mdhJQayr0hRVxFk3bxG84LYt12GSv8fak/y6/pOINMBbYw4pzJUa2i4/8k/VxIKHE0rm7x2XwAAs3xzMDVKhtysxR95LO48pdEifba2z1WKdsz1h+9K+I6bQ8A+VYvBX7ob/r7SaPqXOc/5YEuYzTN3gk4ckLX/+X4PFPn9uWzFau0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwY+Y2sjRbAE1jg25rsON6Wb/d+eORFAmbdvSWprJMBVDtZRqBAoMlY1Nl0WN5IkVlx/ipU4xTbJC5hQVsl6RqBg=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIuk4tBNmfu/FtfLiClG1UTo+5TwwMRTAH99rMCTMq7Kuj3W3oHBDuATwo4zoZkJZqhraWlUBQ7TyMw42hVXhx5viv3fDq1jIDafPPqLYsPmlkVzgsDy/+O81WUFlCJ1kQvWImiazB0D1bFIZ/7419BsLFMEB9hcpM2+aFhjC2OEJdwDDJhstWGwsKgF8xY4G464HrptmiaBVafjfhNfVAKXcbxmtG3ZL/IRbVur7aOY8/5tk587ZSwUHU+pkhaoYul21/DjJsihsnCx1hWusP6rYW1aJ3s0b4Z5daT/C3xl0dRHSAhk0E6RqLbYmfvOTGqrUisdOrHqehImUbJnA0dRqrYPWEkbQ4y42wcN257Q1jBKitGtOuSQRAbXtLJSCgQAAAAu+5ePgeZA4loBjjszmNaKhqbAglSWDeheKWiCqr6FaXRTNQNdW04AV+kuvptpEicOBse4fjnWh6vlqRL3yesBIPldfcQqn1vDVogZvwkEApIKj0Rj/emNjE53AVDBoQar/wJnOFympTAvJPcBKyPdP8q474o0RJ3RLcYyLybt9xjVmfsExKnVx//lpUpOMlOJMWRU88jZwGMoX6mPVnl/NxQ6pYcD1jn8QiPTw1qI0M3zG1J+W3o/lkcT8ZYA/VYGQ3z1pJ0FcKMvHsUn5mKJWygNZ6nsTmLMHyk2BC7Ard6e4c4rzvkGV+IohDERAt2SMWAjuDvc0Qu34jpoPAribfrMgKgO3ypnRAd34G9qX7g+HbI3IbIMq54txwMsVKWnwXobyZXxEzUlWoO4OmdzRIA17XjeX3uSpacFJV+KiEU9SMIo/aTUs7r9MQmI7ZADjDXmSf4VawSrIASEcPxcB+XXy3gn35BIPsWllc8kJlvbarxteehqFUKR/63KZMQf1dE4hkRI6ZK0YurOU4hQIrTpxDZYfr0T7wQ5nDW6XNhIWb2Tm3yBm1k4pzAj0Jd8LpecM10HDYs49zN1wW9P5MGflrnDP86DLcZO+QDlJHL7dpvXfaTaqniYUq9fyyxPDgz3rmuw93hxlZMxDz8NxS68vsbMebVjwtQ3bjZL6rv0qBHz0XEPtlQXTmQ7U8UICBd7fcI+iomycskcBW9oVOHNHM2c0IitotoUHoTiji++xKgSxXevlL/nXw64wVf+2XApcKHZH3GvBNKjRfnVUv8s+MB4nqoQoLHnobZkyCYT7I/FDY9ymB2wY+UlaLgGgIOxGFgOiZzK+7XRG/MX4PO3QOR5uPjcb2SPmDQpF8qeGhnLbxAL6g80qfKJaC3SU69J41ayvdw27o2R260jfrbQIiG9fvOL/EELjfg4cqgr4LBpSCXeFUdc6TtqRPhnIyXwE26ovwEnPWm/+F5W6n+pTZ8QteOTuNlmW2Hi87IvYoo3iKyMZqOjD7O02E9a0xe3DLiNU7YkL0cMbBq5N+LNFbkwgVb5kZD+PJN/VEOKAVVuIF3EK+UcbkOU75uEiUFwEgH571mOx0unqPK0PGQdxQrhsSbIBr06dm1VQ6FSA2jOhEuectRKKg5ubcBbXoXQmGPJqja4fNvS9Nzg5qblVOqkejb4UmUglUFFbFJbdUTsTmAF3ivX94y5ZOhl5glEjby7uYfVuoUoAA/fL6RfWhjNzYVaPKppwDukU/nRij0RH9xtOf9aV56gWaVK4OgxaCaPBx+f6mrzYbbKBu3VYB1SiVhZbD+8sadVLpwq8JX1zkf9UEeDzmAVSNJDFp3JUNU2aYCb+fXvFk9H8wwJxqJ3JtP0eYY0hcww4N3VOfgk8oh7CPabJ/LDiuRIfYK+T5zTKzU1+yHQUoLov4a4adGE/kJhC7+GdHfbEkQcWQdlCA=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALeDjqATWqtkVmlZYWXlhvm0v423V/DMkGGdDyKIrJl7LCMssCV5E1/aVUYKsTaztq/Np73cIRKd0Olfk7YyQcaZg4R0/OhnIHf+2TU/aRq/fnXTJHDvux1ihSyaUMdjlQ3oXFpZl9ghUvOh1I6390Ib1X1rq4r81qo467d/O5uOWg1Ok3gso0vdTk0+TyAY9oc6Nycgip9KsDN9jH29OpcagZv5GGPSSos/YJonkSz3P7yRSDX7kshHaMsN7LfFF0ktmP7u17TSH6zuvUo7HdAkTFl7D+0nhGxHGYL0vhE/E1/GroDXdOiPtso+rX5csIooEeCi2xQ/4daDptdYRzpYEz7R5p8MUlJV8eyVWmNp9CYuO+hbpOj+Z7mHeSzsbgQAAABFmv6zJRSHRsw61K3Q2aXjnQbxwoiVfuxRgYUXwOWprpcXzNotBFXXksOioUVB3XkRoFwAmjvde8S3gkM9ol/aewvNqkt9yJwq8+cSydbaoitZgL5wM6hIPiZ3dH747w22uMPKH0FQowFvwLkZ0oAqXgUWP4YBNzSnsns7WdB5AylLLIwsaCglwOuGavdkNqaYKIELp0S+hxxZ3eAahHr2HnJuxXxMSyAEmjaygZXqi3qp+qgPTqtwlnSYwdgfwdcCv9UgP9mtc0yt/yv9HFI5zhx28pS6o+mbIiif8bU7zbQaH/X+ZtjS4i6bEKmxdBOB7lviwKtI4HhQ0Bbt4O4wXpLOhtLnwoqDUicde6SOj36LurMCp3s0GO3hsOpWicIvoRy4lGCERwVrBchVbsagYeAZeRIiWKZm68kz5FzoxqhjNYr81XpfSTAB8MHXEA6yiu64dPratCeB1YOUghEns6nexwQL8rI3OVxoye2sSrxFgwHpsOMgIA8vegoTQyEp3Bn/3Vq+Wtl6mIupFSqB/EEPTeoxCsu8i6aYGXhY4/rvrCUrlPRfCRr6SSsiVcbGC5VRqDMwrciZRSPpyAfSJBgWALkTI25y4DUtCUk7ZES0begnacidaQhuLcFpanrkqAujf+kXgoWzbhdKpW9qBnc7Zw1xI2YSSTZNbDbGIh2xOVSGmWdLYwpWU+jPQN2750Nv6iUtxXE5BP/rLYDFR8scr3shRk2lgkR+fce+P8b2oI5Fq8+9AtYwXEhoug7bsYH5A+gaQzcbsMu4044fNcm1GsFDHekwf6mKw7Zb+IChmau8tYmlOH1/aHfsOcKn+NBnC+i4H2tHav314D3ZNVhBjydY4hflsxg+mironhCgNw4dlUehqep2eV9Wu3BgtO+goOmUBQZioWZnjNoCPnXJDCxl8PTbR/ooUuS9U38QQab7WYY4oJ6dt1JmPvoIzgTimWCHW1h8JJVOKzLmgz9yxyYNB7YhHEyKjzuxUYY+9VfHmkRakMid02/MvHmfMPLp0DFDFE+/sLtIalNX5rywbo+8J51bM4TjmEY7yAJ+N83pnJxnIOOXiQVuAeGmrFVZqNF+vJ74lpERq6nVKXBitOVw9YoIJ/7dJ5mhFU6OL7fF0JgYZ9ENyLbCk+kqwm/W9WM9UP03lgVfWNCldKshXoIs8IlHjVNDqC4BEDJmh5qNRdJlaIQQqhxittqy4kjkKxhuglH7wRVRRv7R9odanMOp0FgYkGbiKcJlp7v630BbiCt29MtH5kINKzgcHwMgsoAZvpgPBJxWd7rAnAPAnisFPgI9oz4NLGShvqhVj0EAxfawmuD8ni/ibt9FopksBY61xp6wO0MFreMhyBCsk49Elgn+bKlnqlhF4BaR/grn5aF5rshmJwpzkXq7c8zbsr6txaisqV/C7m6FVPyrq7Nnvd8yEi07ZaY4x5CuuWShBA=="
         }
       ]
     }
@@ -506,21 +506,21 @@
   "TransactionFetcher requests from another peer if PooledTransactionsRequest times out": [
     {
       "name": "accountA",
-      "spendingKey": "531b25c37c59095a7b04b56191a629746b578b74e8b554e0dc2aba6e7597b93d",
-      "incomingViewKey": "d2a08ce8c331976edcd2f35bdfce921e4d6d29ffb9ab17fcd992fdf824af0903",
-      "outgoingViewKey": "ce58e58f381dbe4fd60ccf8f7fab0d29f70147e12780e06a82f4a93abf39c719",
-      "publicAddress": "62b58b48ee174200b690509dc22da3fbd15e84ab5fd41a44a7260333a3fd26c85a81cfc431533edaddc1a7",
+      "spendingKey": "57f2e478552b7df7eb849e88dd723533ff5c1acd0521ff69147cff7db14f744f",
+      "incomingViewKey": "e945982ad75a6edbc9a43cfd16cdd755c9b06b99752785a02e69aa0e977c2004",
+      "outgoingViewKey": "ca111a6e64def356fe7ca5829c3b1df43720b1758bc46bfdf39e9742ead866cf",
+      "publicAddress": "1c744f4131037c19441f21d3c213e4692b9caff0768dd7282f4de17599f0ec9e9b3f1bb0f8fa91d1f0cfd0",
       "rescan": null,
-      "displayName": "accountA (9c1e615)"
+      "displayName": "accountA (edf9efb)"
     },
     {
       "name": "accountB",
-      "spendingKey": "a0848654a92ca39ae8e0df39a2eef601737a637b1debc95e279c1ade2352ed8d",
-      "incomingViewKey": "2cd2ab560e0958238e69fe4427c563c4e0c4126a339970e8278e0e16508a9003",
-      "outgoingViewKey": "56618fac907d01d81831505ec6154c9e2949c6514b272f690d442090fa147605",
-      "publicAddress": "fc4061a514c290e640e123498c3d9347c51370e009b67b06e642a86f1ff5b0bfb1c1d9429a21670472b6c2",
+      "spendingKey": "d822fedbfb2d56b664188ef6c094a0c0dd425b84f96bb69dadc8d6fde038493b",
+      "incomingViewKey": "8a2fc5d183d0934e3fb7051bca2209b2bf6936021946818bcaa58c693af0cc04",
+      "outgoingViewKey": "827ff6e43421360add42626d0683a53c496143ee5d115602dc79408851ad16ca",
+      "publicAddress": "2f8a018ee8818539cbcdf42804cdccb25901a1cf45517bf9b3382a50136fe80ba231990fb271109f4c8aed",
       "rescan": null,
-      "displayName": "accountB (888c0e3)"
+      "displayName": "accountB (8bd8b09)"
     },
     {
       "header": {
@@ -529,7 +529,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:eCjTN2rvS9rqr9xrT3dm5ffDAYxEmes4B4Si1Sg5hmA="
+            "data": "base64:9w2R9oCOVQgxE42AxzIDptEwd7SZZUeX4RezpRvkySo="
           },
           "size": 4
         },
@@ -539,50 +539,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659989487311,
+        "timestamp": 1660092444602,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "C01C4EBEE3FEDB8093BC996EECD26AE80B49C71E602715EB511094FA69F55797",
+        "hash": "283B559F2618DF9AADFAF6B8025C6E1C3C107EE7720D68911BE03F90418E401D",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIZjbG+5k5DPvkHoYTTaDIwrhP3F1Q4KgiNLsrS4fMUZC+wrE7QSJ1e6O+fHBMs5epk7mWq+7CrZq1Zba1ylV7DsBZCVo+HtFZcNWke9PnhcNM1PPFXhI+yS0SIQGYk85AGkGm9Ab7F6qnAI03eEDqfN2JkHIs2211MFp80O8BwBLE28yuTikmcWPzyXm1TR4bFxnGGHPl+W1IkXhCcuuigEps9QCMFtd/QKRE3iXnDQ4C9iBW8msG7+cTFX6J0Z0qnvO25/dWFeuDIy8q6eBuoFIMQXiCkKxhQjdAiEUaWzO/HFkrLNTGTXrJriclq4RehkqXUEF9fFySvBCWAg2E077Z5KJ00ZKals7o84o4bCnUnJReOufj18oFOL+zxHiHzv2j1l0pa0ANB9IiMD55E8jEllpqCx4PUGxbHetEiSIK3lnLQbwda1xsMRXpcmiL4tK5o+FUjT3zUzRWaBonugOJeMP9gtSz0c4ipP7VlqFUMPw+4L0PbWPky7V39eDUguj0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaWVKTf9FfNGmNEefjt+71lvqhoJ8TgPyDWkdft1AWzvskM0MlmuWdJMy0CZHgvvqOAwmIL/kfL7rp43XK2nmDA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIosz759g03HMkNAka6OcTYzbCKIBCxVqM2rHdHoFiY9pfu9pSr78Vwo8DJl2wDn3qW3V6TJ9myvV+KMi0j+Egu02yGDjeqK/N7zAKUj2XSImFwb/j19CpqwJp1ohRAbJRcV1YvRqJo6ARmUopTu28zupKf/uM63hBaOWMTJehzebL8p5ibjk8SV8uj6D1iX8oChHL4ECwNEYzJpeBbH+FI3M7MtotNt792Y0KJP3Tjkmavq1jjEtcbeDIEodv4VR35NrVhocOTMDIw5grH8UGDuoKN4dMgAx09NpEJ7dUA1kNqJTZu0OHEtlTTNi2tsEPdhFz4eydXnp2Adk+W+lh7zf0pxgqs6+JussK82I/b8RRIMNK2qqtBk0bbvR53AyZm+NIufl2p4yqDZEnC61yvN+hdV4X+WlUq3lPrESxOKT/jXPtXMWiv8QgmihI+POzZdA9sP5Yd2u1jwIl0Pgvmi7LfUW2+zJ6LiagkalbBMA2wNDnlgjcEtu9YeQ9RzX7srK0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1090dOSL+pjgoIJn2SYJeqgyJOwMa9SHrsnoBb1qclRw9zFxYw1tsPv14DLmcu0+25wX5gIXJgyPofhjFbt8DA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "C01C4EBEE3FEDB8093BC996EECD26AE80B49C71E602715EB511094FA69F55797",
+        "previousBlockHash": "283B559F2618DF9AADFAF6B8025C6E1C3C107EE7720D68911BE03F90418E401D",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:SE8KN4hFr8cqq4bvep44WNwpuNGmhUYhZp+fO0W3oCw="
+            "data": "base64:6cfBhvlZ+D64Xm9kokF9IvPcjmLRA5PJy1LncnRH3m0="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "70B646F198E668D203472102C3E35A15AA18B423B812930E25EBDE965F8B23A9",
+          "commitment": "DAB1460BB9131DCB6E14F297A634113ABA7BA84B3205DF9D9BE6FDA5BE0B7817",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659989488596,
+        "timestamp": 1660092446145,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "674EF3E8336792C789B4DC16A4D58B8EDF56A296AD5E64FCD5A80CFFF04AAD20",
+        "hash": "7F21C6DC84B14E575B0C31A964F37D03E86B094A385F0BF260BC3D4899F5AA5B",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJTZVJ+28RuLhlh6W/pFrs/gbBnLiFHXP2vvSIsmhZR1HrBvl0fhUB3LJOyDSkPacqw/5nWHZQ6GHjBa9bFQlSdG+USd1mYPt27YNUKXKHPcTVAK31WNkvhhqy1cKgr1shhPq+xUQZS4s7Wgj1JghvuezawZMNmTof1uq7LlrNithedDpzEzn/8rJytsAuXpva4GlQtU1ymvjHwaSCevbiSDgQlxb9zCBv+kGdZxixPMgnkFsF6J+8vwTsG+NxpnHR1nYSa6j2cRLRcrJvXDVZlP2j4DEhBkLuYRwo10wQEmVlrkjNsHwd6ym1mHq1JPXw8Oteg8zl2ZPIz64kcv2GIhuQINuY9uWCq06qNE4N3unSvOnt8LPtelLI2cINpXZkCO3GzdN6SiFrxlifnAhWBN6O+1m7qxaV5MKZSo9vhcqzC+xYppi8bd97GbqkzZZP79+Agjo8iVqKbtPVMYT87XWH9R12ZVYlxNYNWMTs2FZcG2nNUsbN/GY2M2MULafKFEgUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8fwPfkToOijxcm5qVVqz73Gr8ZMt5MkGoLD5VCg8ulZ1AgXl2z3/ULYl639lQeIaBFbq3+MGDUPlCHp8cdGSBQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKZ5AvIFVNGm9wt+pchPyVHbxnOGnvbfgzC7EzwX+rUM9a+Djb5mqItUirzqOe1b4pDoTOTIVnE6gfslCiRsf3QpXrKYgOBZAY3X/mKVP2SElnvZnRotRoF8vQW+0E59tA2ZHvU1ioypi/82zt1XfCd6FrsjQ9eH/7ge0pNsMfAA25aD+2tcB9nWLGFRRtPlbYTrLGkXHCl1YbjR7Q5m/YIyk7OYAoPh8CDrSDySvNzLncfUgErY03FS4t9xyITWtKFKeU+FFwx6f2GlatMNZ2jWjG0vxtH9USMZsKUS3sCq4uhmYBPgg5LXT5HuUF75ojWm77o8qDOwvNIC7QgvrG60rX93teW113FPDDCb2vHhyE++TiJND6y9nPw3Yyk+l7DO1aGLHBiSaY2XYiHBWXkjBIG5M2615Cij7SdCGtTjejb+3p4BSq3YUGziTla5jVADovzYLccJiJ6T2+YLgB2C2zwXad1hx70C5/dwcFyVTzigIvCD1FtqoVeegryQJf4kK0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwu909/Z15aysWlFQEMPnjXT1r162O2uFFm6Xm+SuJTjI36lstjMVD8P1vUlHum68vNXPiJ1IchTHR9Rl7H8QkDQ=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKlsONsfHr2JHl83iKz2LLq4nBKb2hCfIXOMZRmaHNAkRe0QCfhA3CFwHkhqSz4erKKZDOlyKcWqqfrVL2y63/cXD0mrVjUpxwJYiSFUvVCnV+1PehAxoWAE5tQHhqL0CAMSDh55PS/Hbq0GvZYGBeQErbWPUB3g2uUBgfnRkWZIb+HuYynTyeM9SnuxX24zwqMyxQiJIqSJg4+hrEc8+ba9NsVhRFjYnu4oMEpqSI0UEmO3q7lhdVAIgPHk+5W/dChXF37Y9C230S4RBB/6g1N5ni733KONJsEM5F2iT7hvFerO3QlmWoFfUc/uptwow+EkJTNoia3MrnxZu/xD1dt4KNM3au9L2uqv3GtPd2bl98MBjESZ6zgHhKLVKDmGYAQAAAAAuF/HZ03OvNyJKwJlO1MOJ9poPWs6772WpQI7RzLjb9ksWri3LkdeBdrSTHb/A5xLQLiAb8DkJcFg8HHLAqCRMt+7F6OGKdIIi262o49GU2PrOIRNN/Q6Em7KqAfSNgiK2ZQLpvo3QsS32zIgNe3GZB/rD1BKXVzj3y7xjcD2GR911q+flnQqzQTRQr/jFPeqsYWSw1m4K2l3rnpTNOWybbKhd3ZUFBZ3BO0Y60lh5on3NQzO/4ghunzEFPm4wDMTuG8vO9K3G8HxQEW5IDnRCi2Votw2LhDbiPPkXO/+Crpk8ukMsYs9jNVhBTyNe/GglPW8casaujgnqZrn1E+hcMtigzchPen8vCM+r4SFk7DSUvRc6W6e+VmV924kkD+BB2Z034GEkTDJ9pZBMytobwZHM2pqVGoxVIgDiNjamHK1BpzV/dWOn5V3JvL3JtQE/NFTfvGy5vP/vf31tpJl+hNAeQMeAyxK7TURXiCse2LM2b4FF4b1uzUllmyv3pq2XHuhpUivHzccqHCYMLOmXZNjFPTyopqf0fZCB9SW/knBd6xVk+PIXjYa2gn/Hhk8yFw+Sws6O+LzD3Pq9kpF+9BJ2H0sYmBYgUkmrS6xpdg3TliuVxlW8MehXWd8u+E02HVf1KTO6j8bydjkDoIemSNhWOEI9KcFTQqCR/N9WzqHHxf09cUvDsHFgUfmr3aonpEsTkxPL5E83cw5FSRr0VdNblucBMvKM4SnjAyuXzh9z4Cfb8GRozus1ltRnnZeCCJBNvFeV++ea9kXnRR4NclUIOTRmh7TaN/lCSGPLa0FVI4THiIcVOmv9kMQalTjt8eQCFKvxRp2Oo6utpwIDsWmQVO+sl28XR6wBuhq9qSeRQtF4quzb4QOsAtZTN54AJNR/SS/7OT+ijKo622RwWDXfj9rfyo2u/p+w/ySSaeSKbkqraUcTVXon/+fJ3cZ0wuDH2YjVNeM0ZbdmxwEl+Vk3zichb4t8b1pa3qyrWmW0G4sJ4ZreXRHE8PxLwG3tp5eiiQJ7b4gKGB5wzrGDpwf8QFrdbuno0rGL0/Jeq1Zx22DwFUaud/lwzVFaUUBNXLW/2B+0/4ELAUFK+3aipL4qcpDipqN4MTdCRn1LRPfQR5Ay35N1DfyMR0JBLehS2t30m8SjqVdc0I/airXxfrNm9CCBi90MysQmMl7Gh0Uta38kJFKDGz7z0vX0hlB7u/FrHgXAY/kThvN0k70DtbgfKpi4mqZ/NbpLouvVHrB6ypBBROlKmV3V2gB0bzJf8cNuyPWyLLfRYNXtKK7FEr8rmCbOibFi5QecRIZv7/wqHX7Yd59XZ023dB1Ibq+ZR4y5ENx/UbY4Lnl6f4z6DNEWd6HOjhLcXP9lWHN26+OrxzILmwe2hgIXV/eQgUPsm2tQxGVlcTs8yYFqJbj36ocnLHnyN6hgk+KG27gXPJV8QqeDA=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIHmBfMfeLYbqOIuvqfEFhxPUJvBULdwJVVYJumKeutTOhd4oQ41Q8NWQTLQiIJSnqF2NDwwdWerTBjYz1v+2twLP5pQ6cmcsZMrio3A79959qFYCbbc3wakwSj2H2/M6w2rKwUQmyVhskPj3F09BV5HGEot9OCo0lhWdqRoAiqtBtH8D5cslJt5QjdnWaob46dfcBKjg52R91A3wYkVNv3XCeYm4nN6V672v4OboW3P6sJ6R5NtFoTkjkZ+KrhjTtw2qJI4nYvKE2zsC1DQa4WZPxeDWL4Jtmg2JQYyJR3Jt+/Dmirq6jpEiMBaxzZgs6juBLfZUG70KsYjjzZisI33DZH2gI5VCDETjYDHMgOm0TB3tJllR5fhF7OlG+TJKgQAAAD4thdw1leKR2LuCrRDb/edBItorDtik0oDLiuHkligt3oemLIer428aWCOhkm/Jn6vn4RlRIhlDS16GqGG1HJKd37LV9Dkb/KoRHRGdvsBAG72p0XV2zyvCe2E1pIyzgak1JeqsBpabaUEDGuUhUgimh1GijEbnnDUQhfbTo/lC8+IJC1nU/PamsNvVQiaIn6JY6jZcCmdeIEXv5h19LEkR4AmWUaAYssz/2DZJRG9dldsFK84mhwu3m6zotCUBLIOdzC2U7OGM64pzWj1vhw2PuuYHjL5y9IYZjoMveAfMBNoSsj+yxiRFOiQV/j1PtKCFeCNvKsBHoY3b+KJyA/Uv1oqZuwMqteANm0I8g86rXjeWi5vwXgY3NcTYBLYj/55jyWNErgcSk10KVhwTs7C5u+aoupCERElV96hDKePhwz6TgOWTFt3sKctanZ0AaLf0bwhmpKq3AJU+IrlsAUedRhBlFtAxQLYcb/rrul5BYyEvQ+wdOOROfvYz1gfVvHrHp2p/lJpLjBoHtWGwV7rrR0Yw/btDdqBeIiSspggNro5Q6RwZNI6u9AZkAGDijJwQ+HdJOo/EHQSVCqXlLYK99Q3GDAhhs5sYFPI6V9igph3NrTfqcTD2kjz71SL3t0HlGadDUR5XKjJq3ulUu2RP5Qja99BjXin8NQlgvZF5+dwtN++jBTTtAEpbz9rMXIUEG8xXLMeq+Nra1RO6GNNHufBYhlnchkRU0uZXtMAWIFNOaK1bh3Em48Gz1J6X1T2rDgb7hBQ5fwBb4D5ga/FXdfKg1c6CWq7YshuJ8L5aQxKBokVQCOQXM4bxju9u+l1resqa2nU13Y2ZWV2PORi9fXVud8w+7SBR8tpl4NKy4IJiQUzDeGf0LE7vzVq/zfZz/MlP7zFH621Xiy2AePd5n8FPQ0WUpch7QKBW544cc/ZAaYt5fgX2d1Rj99OCzY9Qng+AJr/mcZXQfXK+FVdPomnTyMO3OOSDyHh1oRx/TliJlt/JJhLTsTo9HDZ7DE+DhROAps7xBJk1eJZ0jLss9Vc24g2/S0B5DEMtV0hBbTG01+PMxxo1q4U4foLeUCpbEUAV+OFxPIG/6O9tDLIVVoMszhcSq4E95vxjCvTGZ/lNLGGd2NfCuCYfdWqdU33osGDNUCY/OOybvBJKNVgCmeU/11SxZaDao/4o2bitNL7wkRKBQ1taYX6mST8fGxbTY0Of5wVTxt1iRr2tp4xzfvDxSydl1d4MfCXNe7KEFA5QuL4PncWYD9ZwHbx2ADkOl2PZR78+/R0JdiGnoIuOmroEBzP91kSEXE2LkmM34UOMWAv/w5X6j1BmFTymQxAFGGX/e7zi5huSQNaban7mBesOk38+Xa7I0sXdra8f8bENUod7L9mhM4PmDIhojiJ1Z/8uoyqsw3o3p49MCQDqC/7CCKOT6rAnGtMUQ0wU/L6zM1oAQ=="
         }
       ]
     }
@@ -590,21 +590,21 @@
   "TransactionFetcher requests from another peer if PooledTransactionsRequest fails because of disconnect": [
     {
       "name": "accountA",
-      "spendingKey": "7e9b36c63c1104824d489056a5c13e33d8e8575b72e56f8244f5dee76902e2a3",
-      "incomingViewKey": "218042a446a03fc68d9d49d435ea6eb1b7ccb53e40be4bfb2174857e1354b200",
-      "outgoingViewKey": "c4d507936402f40f520fd135a9fe17e1ca837467387e89c2fe3f6032df5c3d90",
-      "publicAddress": "f82f57d1807b592316df568cbd107214c0c45828e1739665eb483ba3239af1c71e68322bf494e21b6ae3a5",
+      "spendingKey": "a76050cc73f9fc6b88764f85fe58d73c49643635a7e5dcf937656c87af45f2bf",
+      "incomingViewKey": "e481f5124b97f95c16c75bd9a2d1aa8087e27886bdc43f854bf8423250a8ed02",
+      "outgoingViewKey": "c6c7de82d391682919fa82d186e3c0e4a621b7c011d6c64aa90de14792cddbc2",
+      "publicAddress": "e428a541ac0d6e21b87a0a6f2e83906e34a5c386e56c0b388839845f1bbdd13559153d1ff5db1aeac4bf54",
       "rescan": null,
-      "displayName": "accountA (2fd9701)"
+      "displayName": "accountA (d236f85)"
     },
     {
       "name": "accountB",
-      "spendingKey": "1db4c61b9935eee334e4c2556280bba502aa19b8c1b58dc4d4dcf7c1e19158a8",
-      "incomingViewKey": "8b715af3709bc77f9a13e9a61556a29037ab4b75878491b75ac8c871e2b9f104",
-      "outgoingViewKey": "dff69c0d5b15a6d415f591ea9518c595bbe9f53856790984db22b55a4c240ad5",
-      "publicAddress": "87611ad8d3cdf2a40177076cfb8451fe574c880ad8e0310b7eb4815371174ca0a5fc0b3373ef6a2f81d9ee",
+      "spendingKey": "d802e552b1bf3e8f1220ebcfc0e2aed2e5b26883a4bfccd6dc4cfae13dc125ab",
+      "incomingViewKey": "02b7aeb4d0dcd8e931bc7975ee71bc4f8c8d236b1defd68db737df7fe5272f00",
+      "outgoingViewKey": "6538214ca8e4b57e6372ac791e463589644a85ea6b47a5b17aae90cc57a44484",
+      "publicAddress": "2e0c6b53e7fe90eb39a8dc4a7bff1186ceb69d4972da146875c85d252365b79393246226ef024e780f5440",
       "rescan": null,
-      "displayName": "accountB (4134a8e)"
+      "displayName": "accountB (be7e620)"
     },
     {
       "header": {
@@ -613,7 +613,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:ibioEZwGvzVHcdZhOff45xWk6o0aRgCdowpbTb3T1GE="
+            "data": "base64:oPlMdhtFK+5+9FK5kuGJaCm29EaMxEZxMv9xBMFCqjA="
           },
           "size": 4
         },
@@ -623,50 +623,50 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1659989488792,
+        "timestamp": 1660092446360,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "CDA828F84CCEBAAB01E183E35E4F8EC1BB4CF15FE1FC9CC2870F639763E9F472",
+        "hash": "EDD63348C8B08DFD2B5CCB1F2A2E9246D5FD9549948077091E7042EF08217C7E",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKZfEdS5K2SuiCpEam57tjABJtWbJWK1Zuvv62yuJdPZNhIObnj7QTt3OS6KHOA0taf1DNuOZ5Ph22yXjb2Dq6RUExVIDMLDjDKAip2wVq/e5QU4aPy0XiJJOaRhl2aqdQMaCkQ59EmRMsGdBCf4yfPZS4fUWmuLhsbcsTT7V3DkIM2be0oQGtdjRS55CZDYUrPzaBDvbrwzFD8HvyZtHm82ZTIUMwZl2A2Lg6OlTFDj5aGy/qvrwE76D8MBUgyj6URNmH3ClPZ6OZG3MOBJlpIFMESDJ+KiqdrYHlH16/pmkG0zzitq5a2c5tR/lElssMBardFREfDxjvSR+K/3R2UUakcrfR5BspVz2xJn3XtJyRe87lOxYONMOq3qD3byvSdZXBVmMegArPD+sryLqI+CQPkaeuxdNJYXh9BtLkEkeCr+hUY6r3BAKkF34PNDajGZaiHIdns58aC9glPgSb67p3sVDKXhoWTj/dbD2bqxw5F++OS1Pj4eu5p1RfkVBQiMTkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwnUF+GUYL1z5dlpfXyo/87zIMNCg3G7lI9gPl9bvHcGSS3yb4TUNHh/i9ZjelmSf/csBxILfDlRSC1tD+H6tCw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKK/VVP1uXdTMkYGnomjjrTf6qEkg5FWKFI/nFtFIwisqEQCgwu6VV5Xx1n36MAAy4UBGpWYPV+QQruHCWRIC2Ymtz6TY8mfn02BFDgBJq24lxQ+lszibx1fFXglw1nxdAKjzSWD7PlVF7M4fmsFm6iEwehPfrvrSAp0VKmeSiJ1HNb6s16lXP9dJpMWolt6+pUZpvEn6k+mqeibzW6CNeO8SfT9Yx728drNGESsaAZQHVBzqOzkFeVzoz6fdhHkvxmGhY4eW0sjiniCkfb6n3u0BcVoLOcM+XD6LYIb1uM3rFk5h3GUR18oBwAz8QDEVP8EcpZEu1TrCWWh0eWE9Uk4h8Hmu3q1AP1u5fFmFYH4QrVl6Pi940Y9FwDOaAC/YDpq6/+ahdEbNQ2INVgbfBAtCEjiDXF1fwC6JIIhOcjdL6vHrmmSMkB3RtYZ86OPc2AJKmWo1cPI4vowqGoXxNtHd0gPujhu3hOeRxdd8TC7b9zu3u+s7WDX4TZiSI6nMuocHUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjGSn9wA3/K8Yp8j5o0ITNlzkpcW0jyXrIW9iI+Np0QIODxM77oqrTvF+J33m7Q/2pDo+nl6nRyNismB3ZggbCQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "CDA828F84CCEBAAB01E183E35E4F8EC1BB4CF15FE1FC9CC2870F639763E9F472",
+        "previousBlockHash": "EDD63348C8B08DFD2B5CCB1F2A2E9246D5FD9549948077091E7042EF08217C7E",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:30LjfOusKnaYFy0H86nRFLuEdCEq/ZfZoZ1OB3yZOxk="
+            "data": "base64:GEGYIU0VXYJ3fQXFny/9R+/YeJp+tQrn053nKebGnRQ="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "EC44E21700E394723827703BE86434D8F7C0610532C2F608D4BE22C96705859A",
+          "commitment": "2745E24265499AC5DE43277837B8EBEBF22DCB11A2F568381BB868C291FA4809",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1659989490202,
+        "timestamp": 1660092447723,
         "minersFee": "-2000000001",
         "work": "0",
-        "hash": "E7F94C4C1AF36E37A97515C84D1112172FDAF03D6EA082DE957BBF46B4A424AC",
+        "hash": "28DD5208AF9C4FEFB1DAF8A003A64AF694702673B6079566203A8BCB9CFB52D6",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKNQrCPmz3/JFzP/4e78mhyRUG9K3W+zvKe/gJlj3oSK8zvyTgiQNfCCtMEtS13TAJNmuYe5m4psIq9kv8XoK3iGBR3RayLS97mQcNtxFEBkGnIZa6SQ4Gf5LOngE0t0fANRqC8X3iC+fCdrh5muwMW1vyPhfSFNhSScS7E7R1YrrdC+2Bbx5SEWuPzzRVjTy5H2Q80d5VMp0bBBmikUKpq/G6t5iFtqprdXyy2pA+5KkwY6sRDH6oPiHv+V2jb7dnWp14/OBKNbINGA/ZSEAh+xRCnn9yrHsdbTjJeL8kdYcuQmUp1T+NrBpbD0XQ2RH5RL1fKZzOPNp6WGb/fJMU6LL2S8usm2PEy0UyN8jghlO6pGHU8K2YS57Pl0VOg9RQLp6ibdZDsFFWJzHlDh8+OW2pDspW0svPdp8fO/D/myyICXhCioI0TorPgsF29oGxFVB4CnF+3Dx4krgXltf3C5kdA3gMFsEByFkMvc/c489oyUMl1ohdYXFE7StEsccv0xb0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxm2ZsU+CuVYrXZjFvVGmy4xDcpyqPx5izRZq+AX6KpfjE6NNuvet4HfOCRSoktCwblgYe4cCBpyE8N8UG5pjBA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJiBNfCJDnZvPibQAgcxBiy9K0yZqmGfdq1YjC8fpHySG5koi3R+5+saCDa7jOW10YuW2VIP99jXlyZsNPw/EsCVY6SuBaXXrM9rGvjmRfw6qsawPYYEcTWri0QBJ8zv0Bn6Ky1F06fHWOPugER2ZwtbTMP+kPebY2zxyAXTYtfCVhE+EaAM9VUojG4cjEjqNbSPFHXMXkRRkawy9orsc8U0WHfAurmACZDP8Kq1CC2fsRVbv3LgXzDQWWOO6RWiRWxJaQbZtP6Z11TFYH/8wSf05UzbaNd8VtRUSSd1IQlnDkzRwA6xOI3LWl/G7OrpmZ5PqRgidFGUfVWc4J/nTSYvPGJAF574ernuMGxgApXNpgT9QYR6sS0Ve1Paiw97bSH5xXsdqZo3NqfIWOX1SSsTFfNyqnDQ3oXZCUtj35ezNdSNN/58wwkh4cqJMxmtddx2XK1kfHOJL0VUDZp5Q0ZB/OnqdaeTaWIG7FzNHYjNKGbSEPDx+sXMIZKIWB8UvPa23kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtGKh3JPpiNlMrgAKgvzuFrwV82HRMv2i0RqT8lOUl9te2359QTdRR4Uytbn5EVKnQXR9SqNnAT8q6KR0MZ4xCA=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKLkKZv6ipdBQ6s60jZJgX+fnKpDVsrWAEdVB3rMaOKii/abs3TUyMlnz42FNvIo7o4Zv2NEgmHEDtu5aR6j5+Sz/BsF7kQyiIFo1rdykHc8LbmAlpM67W1WbsbRPSOc2xXgHhvVt4OiHTB5fJ+i06z4TxQHBESZJ+p/VPwHtariUmN+bFb2hixy686uALv0h69Lc+eZILhkCEmE4bYMqLq8mMDV/edAso3cqisNiTmoCfCFvHgeoB8qNufGBiSsMhNLjZ1vCi4RKUcgl4ExK8rZxIobu01RLFJQ/L9oPKk8p/+o/g2zCrktmwL0zZY4vw2CxhdG+f4+44aq7pMTTj6JuKgRnAa/NUdx1mE59/jnFaTqjRpGAJ2jCltNvdPUYQQAAABFczLN0mi9hE8kSSkFaTlIsgzm8Oyo9U736fpExDt+l1PjYXokLonwDeszzObNyOA8IDoegmxXYrLXeBsN/UEXDMdtLFpzD/3xiRraP6w51iaTq12XHrGnegEcLXu4egGWb3psKuvV553/9h74TVoeuuy9iPIJo/ntF849JPm07zOgn+1SWTNc4wdBzdSD0q+tRLDGbswr+SvJzU4hQDvcipt34L6So9Vsp7NafVXHIzCmjpn0CJ7Xmwu/uAOu7Z8JEuiSfB3NvWSHasM5j2enRJALJlU+BkSqVdJJonNwj6H2fKININPJNhkHN6jEyZmoegy5sItAfdiiB5T6s8awGpPfu0rsL0dYvHKt+UhfV3TrwpRu2SAmOlwTAdkCaXgCHqhA4OkSSA2B1LaqcFxXqnUevSQf5eZpFsgNQMJupfJNCP4izWu2/3sA0bl2Cm1bkLeUL7w3OI5FkpIFPfBNFlq/0+BDSnq32nxHfzLzAV0B9lTuN3r5mxKMBUscZsELZdSudv6KhFDXbuDP05q5sND0AXIdHiaRat7go/ViuCDh0HXdTfoIhEluAOnblsMP2a0kaLuBCPRM8Z6oYAYlxHodMgqFXj33HsMqrkuwExQ5YQE61pDhbBvOc00dbZ3wQnl511B9ln6DwgAdtnt2U5SHJQj3XlLpKgwB97ef6nJkJacRa2JQSbrNXbbaqS/UtyhyDPkB35H+KnTX3NCu6y5h+weSRcYOFHCeiBF8CP4aAZfTRQ6jpqC3iJGdOFzHktxjY6u7z9L4UxEbVmaVU9x/6QWmCKBwl+4gldvfnLtJLoP7Q1h+GpfZ7lKnC0XcI+5iLJUawt82D6EbgzT1Jeckx+6m3HljJi6Rex9YdUs3lgicK06b2Xe/iMoU4aVlHB/RPOhAYxXZZyBvBoHmReYnLrV/osnY6e4v7+5H5SQbTbb9sSGxGu61If+XGy52oGC/wNWZ5Pm01sNPnHYMWkQqwtar8TWSNgCtS8o7D+Fk/tBH4fY5WyatLTpVg6hxjcqqIn4kJTu1E0BfiIf7fHEJnYOpyqd71EfTjlZj0uEdRN9Xck6GaPEk3otrzK4RDnGnSwO8XArKXs5gf2By0uX7UPTRtL5OjQVhzQeHMdkmTtV3ZjacCXdx9eUuyqfbhfK9gtPS1TgHF+nwIIRgQ5uuIhIH0E1MToU6HXoHh0a6uvHApwBT/8DrWOkcXJIdwWGZMpys8bByeEPXAaZ8Le9u20a80LQbr8W+w5gBLCzWJDNR6kSUAY3F0o5IYQp+dzzhcalHvL9NrIem0WZWOUxGgenm+iO9jKEoi3nQQda7MI1kBB9qbj7JR34pt99wZ8TA1ADBlP8IXOUvcUEtC7PbTRg7czbnzFONRyj0l+VlNtH1bPYm6N+ppZF7FiJhuShut7GH1sMoBa7+2IUqlnQW0wjgFVbeBgg9WOaBPb5SQlF5Aw=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIdD9EiBAb7zHBLyUSwAEQd2j/7dh5bTwzNLFR4Akpi9xfdQyFgnVWiPOqNVfxAZcaSOoIQpC019UqfYy+oX1bJ4FE8nQRppKoxq1uTULLSaekJeRBbr+G390gLLT9UEZxDXAnDPLZvAVseUsqcyIsNg44wzDZTT6a7ynwovS3aEd628srGpyYeFhGt9icFXfa+pnJgOABPVq/7mKUdupK3prwUVsQgOhVF2rrqKW8d+xb4LLetY6WIBh/BfkVzYUu7Or1+xPAlbc+NzD536311TFXd9QlGw6ntCmKANZYuJJjJt5w4RRsTfdkphfYVHHocHbAcSIB0VzKUuYcJaPq6g+Ux2G0Ur7n70UrmS4YloKbb0RozERnEy/3EEwUKqMAQAAADbpIC3l/QIajyz7XP0y/DozHVS23Ed6Wrns3yRczeyVj/w+bjh0ACQAKW3ogpaLld096sP1sxuFN5fwOuTYXO2s1HZlY0G3tdbt91s0xozDaLAtOMbR4BL19T8Fuypjg2ZUt5KYAD8cT4DvZ33BtTAqn1mDO3CmQX5vXE+t1BtFTzf2CdhukGV8fjUufg+JDCjCegQY/L9OWGv2AAlrYIaVIj8w55NMQ3hrNnj0STAOctrMf8D5R/mtFJenJ7Ytv0Xo+q/i+tK35Sl5zE+zD1SCpKtBFvAUhPCErQSITT7uTLcvoAudZKOJVp77a9H84Ou78+QwEA+TtSZ8/yPNlpHycWajzn6aYw4W3A81LguCxqNzlNYYggouiKiIXrGgJNMxJBnTiTPb86RbvhAWZywlEbmLYM51O24TJzjnuZfa8/dF5rB2SBUW2WpIlLkvCv67up6n7agncPhFs60sE089ZzTN9L/Za1E1fdBjIYCo/RwjP00xJlqsZKZgIoTFjFGMdSVWlJl1MTU1l5KM03OJvyNfmPXklA54YKq7SyrE4akOplXxLlOXx/yXLa/aTFcJ6Wqvgh9k4zY4NmUbDK9kH5BBBChFbKoubpQr4GUOvJw6FVvuBkYZe3ouHocFZI+JMSDdQC3tDcGEbmh2qjHuQS8jnwRWIdyxyCG4SJ3KNenAVcLIdQR7sKPtgQbIMu+CWfAA3v8CnU2PzY1sF153XGevAY8axrPmK/aOhtOkKwMe6byr38anUsd6A6aEzCJPSPDo8QLmWOqrs8k4r3v84I5O8HkD2NipIiEf7IGk0N1yJGaR2dZnPDnjMTcoj+5T/TbQuHrwr1tpbYKGZAtpFfqDUo9skCin67qA92ce0BcbgjbZkIoJ/UnDNsUG1vUquFDuSbvEoDavNdsZf3IGYKmMb2NR85ec3l7mv1nwRElAIPS4Q/eES6AlvB6Pqrc4Xx34kjHAKCrOnd/4h6RUOwSPvv0ixihe1nzlBpxp49zbT+o2VNQbxB1q1QOxomx7s6Sh2uAuOTlzlc8JRFb6uXtKYK8czd/4+CKu3a8ZKtaov6yKTBl42sZETeXKTP9/CSDAnD1UeBSg8FOgm1TOTVvFGVdreE3RnVh4oaFL4AVSTsi6z8eNc6ekBzWZi8Dnum//ruRDRCIVFAJdukU89Aw256JI80oInST5gLjMuGTVjQbCKTjPB1T+meDKAo6xiLFxGIihXts0G64q+c7aY2sEwnXHxxk3KI6DyBa2Vk3w/IK2A7fU1knzw8WJrJ4f6DnVR8N4OekNrmF9Fs9L9czkq7LMoVlhL14b1LGb/S0FCDvvR/sgXJJdRxVvsLhFFfiCHJ3Bf8V9smUXo3dF6uBRDFkHCoqlLTE3gSUTtHe+92C809+7cf0y1H8ROjrCZ3g/10IjORNzEvO1UnDoo9E/AJgyYi0mnzgP9tBeIQx1YANDg=="
         }
       ]
     }

--- a/ironfish/src/network/messageRegistry.ts
+++ b/ironfish/src/network/messageRegistry.ts
@@ -19,6 +19,7 @@ import { NewBlockHashesMessage } from './messages/newBlockHashes'
 import { NewBlockV2Message } from './messages/newBlockV2'
 import { NewPooledTransactionHashes } from './messages/newPooledTransactionHashes'
 import { NewTransactionMessage } from './messages/newTransaction'
+import { NewTransactionV2Message } from './messages/newTransactionV2'
 import { PeerListMessage } from './messages/peerList'
 import { PeerListRequestMessage } from './messages/peerListRequest'
 import {
@@ -126,12 +127,14 @@ const parseGenericNetworkMessage = (type: NetworkMessageType, body: Buffer): Net
       return SignalMessage.deserialize(body)
     case NetworkMessageType.SignalRequest:
       return SignalRequestMessage.deserialize(body)
+    case NetworkMessageType.NewPooledTransactionHashes:
+      return NewPooledTransactionHashes.deserialize(body)
+    case NetworkMessageType.NewTransactionV2:
+      return NewTransactionV2Message.deserialize(body)
     case NetworkMessageType.NewBlockHashes:
       return NewBlockHashesMessage.deserialize(body)
     case NetworkMessageType.NewBlockV2:
       return NewBlockV2Message.deserialize(body)
-    case NetworkMessageType.NewPooledTransactionHashes:
-      return NewPooledTransactionHashes.deserialize(body)
     default:
       throw new Error(`Unknown network message type: ${type}`)
   }

--- a/ironfish/src/network/messages/newTransactionV2.test.ts
+++ b/ironfish/src/network/messages/newTransactionV2.test.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { randomBytes, randomInt } from 'crypto'
+import { NewTransactionV2Message } from './newTransactionV2'
+
+describe('NewTransactionV2Message', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const transaction = randomBytes(randomInt(500, 10000))
+
+    const message = new NewTransactionV2Message(transaction)
+
+    const buffer = message.serialize()
+    const deserializedMessage = NewTransactionV2Message.deserialize(buffer)
+    expect(deserializedMessage).toEqual(message)
+  })
+})

--- a/ironfish/src/network/messages/newTransactionV2.test.ts
+++ b/ironfish/src/network/messages/newTransactionV2.test.ts
@@ -6,9 +6,9 @@ import { NewTransactionV2Message } from './newTransactionV2'
 
 describe('NewTransactionV2Message', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
-    const transaction = randomBytes(randomInt(500, 10000))
+    const transactions = [...new Array(10)].map((_) => randomBytes(randomInt(500, 10000)))
 
-    const message = new NewTransactionV2Message(transaction)
+    const message = new NewTransactionV2Message(transactions)
 
     const buffer = message.serialize()
     const deserializedMessage = NewTransactionV2Message.deserialize(buffer)

--- a/ironfish/src/network/messages/newTransactionV2.ts
+++ b/ironfish/src/network/messages/newTransactionV2.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { SerializedTransaction } from '../../primitives/transaction'
+import { NetworkMessageType } from '../types'
+import { NetworkMessage } from './networkMessage'
+
+export class NewTransactionV2Message extends NetworkMessage {
+  readonly transaction: SerializedTransaction
+
+  constructor(transaction: SerializedTransaction) {
+    super(NetworkMessageType.NewTransactionV2)
+    this.transaction = transaction
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+    bw.writeVarBytes(this.transaction)
+    return bw.render()
+  }
+
+  static deserialize(buffer: Buffer): NewTransactionV2Message {
+    const reader = bufio.read(buffer, true)
+    const transaction = reader.readVarBytes()
+    return new NewTransactionV2Message(transaction)
+  }
+
+  getSize(): number {
+    return bufio.sizeVarBytes(this.transaction)
+  }
+}

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -46,15 +46,9 @@ jest.useFakeTimers()
 
 describe('PeerNetwork', () => {
   describe('stop', () => {
+    const nodeTest = createNodeTest()
     it('stops the peer manager', async () => {
-      const peerNetwork = new PeerNetwork({
-        identity: mockPrivateIdentity('local'),
-        agent: 'sdk/1/cli',
-        webSocket: ws,
-        node: mockNode(),
-        chain: mockChain(),
-        hostsStore: mockHostsStore(),
-      })
+      const { peerNetwork } = nodeTest
 
       const stopSpy = jest.spyOn(peerNetwork.peerManager, 'stop')
       await peerNetwork.stop()
@@ -63,15 +57,10 @@ describe('PeerNetwork', () => {
   })
 
   describe('when validation fails', () => {
+    const nodeTest = createNodeTest()
+
     it('throws an exception', async () => {
-      const peerNetwork = new PeerNetwork({
-        identity: mockPrivateIdentity('local'),
-        agent: 'sdk/1/cli',
-        webSocket: ws,
-        node: mockNode(),
-        chain: mockChain(),
-        hostsStore: mockHostsStore(),
-      })
+      const { peerNetwork } = nodeTest
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
       const message = new PeerListMessage([])

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -30,6 +30,7 @@ import {
   GetBlockTransactionsResponse,
 } from './messages/getBlockTransactions'
 import { GetCompactBlockRequest, GetCompactBlockResponse } from './messages/getCompactBlock'
+import { NetworkMessage } from './messages/networkMessage'
 import { NewBlockMessage } from './messages/newBlock'
 import { NewPooledTransactionHashes } from './messages/newPooledTransactionHashes'
 import { NewTransactionMessage } from './messages/newTransaction'
@@ -431,15 +432,16 @@ describe('PeerNetwork', () => {
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
         await memPool.acceptTransaction(transaction)
 
-        const peerIdentity = uuid()
-        const peer = new Peer(peerIdentity)
-        const sendSpy = jest.spyOn(peer, 'send')
+        const { peer, sendSpy } = getConnectedPeersWithSpies(peerNetwork.peerManager, 1)[0]
 
         const rpcId = 432
         const message = new PooledTransactionsRequest([transaction.hash()], rpcId)
         const response = new PooledTransactionsResponse([transaction.serialize()], rpcId)
 
-        peerNetwork.peerManager.onMessage.emit(peer, { peerIdentity, message })
+        peerNetwork.peerManager.onMessage.emit(peer, {
+          peerIdentity: peer.getIdentityOrThrow(),
+          message,
+        })
 
         expect(sendSpy).toHaveBeenCalledWith(response)
       })
@@ -447,27 +449,30 @@ describe('PeerNetwork', () => {
 
     describe('handles new transactions', () => {
       it('does not accept or sync transactions when the worker pool is saturated', async () => {
-        const { peerNetwork, node } = nodeTest
+        const { peerNetwork, workerPool, accounts, node } = nodeTest
+        const { memPool } = node
 
-        const { accounts, memPool, workerPool } = node
         const accountA = await useAccountFixture(accounts, 'accountA')
         const accountB = await useAccountFixture(accounts, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
         Object.defineProperty(workerPool, 'saturated', { get: () => true })
 
-        const acceptTransaction = jest.spyOn(memPool, 'acceptTransaction')
         const syncTransaction = jest.spyOn(accounts, 'syncTransaction')
 
-        const { peer } = getConnectedPeer(peerNetwork.peerManager)
+        const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
+        const { peer: peerWithTransaction } = peers[0]
 
-        const gossip = await peerNetwork['onNewTransaction'](
-          peer,
-          new NewTransactionMessage(transaction.serialize(), Buffer.alloc(16, 'nonce')),
-        )
+        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
+          peerIdentity: peerWithTransaction.getIdentityOrThrow(),
+          message: new NewTransactionMessage(transaction.serialize()),
+        })
 
-        expect(gossip).toBe(false)
-        expect(acceptTransaction).not.toHaveBeenCalled()
+        for (const { sendSpy } of peers) {
+          expect(sendSpy).not.toHaveBeenCalled()
+        }
+
+        expect(memPool.exists(transaction.hash())).toBe(false)
         expect(syncTransaction).not.toHaveBeenCalled()
       })
 
@@ -481,18 +486,21 @@ describe('PeerNetwork', () => {
 
         chain.synced = false
 
-        const acceptTransaction = jest.spyOn(memPool, 'acceptTransaction')
         const syncTransaction = jest.spyOn(accounts, 'syncTransaction')
 
-        const { peer } = getConnectedPeer(peerNetwork.peerManager)
+        const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
+        const { peer: peerWithTransaction } = peers[0]
 
-        const gossip = await peerNetwork['onNewTransaction'](
-          peer,
-          new NewTransactionMessage(transaction.serialize(), Buffer.alloc(16, 'nonce')),
-        )
+        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
+          peerIdentity: peerWithTransaction.getIdentityOrThrow(),
+          message: new NewTransactionMessage(transaction.serialize()),
+        })
 
-        expect(gossip).toBe(false)
-        expect(acceptTransaction).not.toHaveBeenCalled()
+        for (const { sendSpy } of peers) {
+          expect(sendSpy).not.toHaveBeenCalled()
+        }
+
+        expect(memPool.exists(transaction.hash())).toBe(false)
         expect(syncTransaction).not.toHaveBeenCalled()
       })
 
@@ -512,48 +520,67 @@ describe('PeerNetwork', () => {
           'verifyTransactionNoncontextual',
         )
 
-        const { peer } = getConnectedPeer(peerNetwork.peerManager)
-
-        const acceptTransaction = jest.spyOn(node.memPool, 'acceptTransaction')
         const syncTransaction = jest.spyOn(node.accounts, 'syncTransaction')
 
-        const message = new NewTransactionMessage(transaction.serialize())
+        const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
+        const { peer: peerWithTransaction } = peers[0]
+        const peersWithoutTransaction = peers.slice(1)
 
-        let gossip = await peerNetwork['onNewTransaction'](peer, message)
+        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
+          peerIdentity: peerWithTransaction.getIdentityOrThrow(),
+          message: new NewTransactionMessage(transaction.serialize()),
+        })
 
-        expect(gossip).toBe(true)
+        for (const { sendSpy } of peersWithoutTransaction) {
+          const transactionMessages = sendSpy.mock.calls.filter(([message]) => {
+            return (
+              message instanceof NewTransactionMessage ||
+              message instanceof NewTransactionV2Message ||
+              message instanceof NewPooledTransactionHashes
+            )
+          })
+          expect(transactionMessages).toHaveLength(1)
+        }
 
         expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(1)
         expect(verifyTransactionContextual).toHaveBeenCalledTimes(1)
 
         expect(memPool.exists(transaction.hash())).toBe(true)
-        expect(acceptTransaction).toHaveBeenCalledTimes(1)
 
         expect(syncTransaction).toHaveBeenCalledTimes(1)
 
-        expect(peer.state.identity).not.toBeNull()
-        peer.state.identity &&
-          expect(peerNetwork.knowsTransaction(transaction.hash(), peer.state.identity)).toBe(
-            true,
-          )
+        for (const { peer } of peers) {
+          expect(peer.state.identity).not.toBeNull()
+          peer.state.identity &&
+            expect(peerNetwork.knowsTransaction(transaction.hash(), peer.state.identity)).toBe(
+              true,
+            )
+        }
 
-        gossip = await peerNetwork['onNewTransaction'](peer, message)
+        const { peer: peerWithTransaction2 } = peers[1]
+        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction2, {
+          peerIdentity: peerWithTransaction2.getIdentityOrThrow(),
+          message: new NewTransactionMessage(transaction.serialize()),
+        })
 
         // These functions should still only be called once
-        expect(gossip).toBe(false)
+        for (const { sendSpy } of peersWithoutTransaction) {
+          const transactionMessages = sendSpy.mock.calls.filter(([message]) => {
+            return (
+              message instanceof NewTransactionMessage ||
+              message instanceof NewTransactionV2Message ||
+              message instanceof NewPooledTransactionHashes
+            )
+          })
+          expect(transactionMessages).toHaveLength(1)
+        }
 
         expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(1)
         expect(verifyTransactionContextual).toHaveBeenCalledTimes(1)
 
-        expect(acceptTransaction).toHaveBeenCalledTimes(1)
+        expect(memPool.exists(transaction.hash())).toBe(true)
 
         expect(syncTransaction).toHaveBeenCalledTimes(1)
-
-        expect(peer.state.identity).not.toBeNull()
-        peer.state.identity &&
-          expect(peerNetwork.knowsTransaction(transaction.hash(), peer.state.identity)).toBe(
-            true,
-          )
       })
 
       it('does not syncs or gossip invalid transactions', async () => {
@@ -575,16 +602,22 @@ describe('PeerNetwork', () => {
             reason: VerificationResultReason.DOUBLE_SPEND,
           })
 
-        const { peer } = getConnectedPeer(peerNetwork.peerManager)
-
         const acceptTransaction = jest.spyOn(node.memPool, 'acceptTransaction')
         const syncTransaction = jest.spyOn(node.accounts, 'syncTransaction')
 
-        const message = new NewTransactionMessage(transaction.serialize())
+        const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
+        const { peer: peerWithTransaction } = peers[0]
+        const peersWithoutTransaction = peers.slice(1)
 
-        const gossip = await peerNetwork['onNewTransaction'](peer, message)
+        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
+          peerIdentity: peerWithTransaction.getIdentityOrThrow(),
+          message: new NewTransactionMessage(transaction.serialize()),
+        })
 
-        expect(gossip).toBe(false)
+        // Peers should not be sent invalid transaction
+        for (const { sendSpy } of peers) {
+          expect(sendSpy).not.toHaveBeenCalled()
+        }
 
         expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(1)
         expect(verifyTransactionContextual).toHaveBeenCalledTimes(1)
@@ -594,11 +627,24 @@ describe('PeerNetwork', () => {
 
         expect(syncTransaction).not.toHaveBeenCalled()
 
-        expect(peer.state.identity).not.toBeNull()
-        peer.state.identity &&
-          expect(peerNetwork.knowsTransaction(transaction.hash(), peer.state.identity)).toBe(
-            true,
-          )
+        // Peer that were not sent transaction should not be marked
+        for (const { peer } of peersWithoutTransaction) {
+          expect(peer.state.identity).not.toBeNull()
+          peer.state.identity &&
+            expect(peerNetwork.knowsTransaction(transaction.hash(), peer.state.identity)).toBe(
+              false,
+            )
+        }
+
+        // Peer that sent the transaction should have it marked
+        expect(peerWithTransaction.state.identity).not.toBeNull()
+        peerWithTransaction.state.identity &&
+          expect(
+            peerNetwork.knowsTransaction(
+              transaction.hash(),
+              peerWithTransaction.state.identity,
+            ),
+          ).toBe(true)
       })
 
       it('broadcasts a new transaction when it is created', async () => {
@@ -701,7 +747,9 @@ describe('PeerNetwork', () => {
     const nodeTest = createNodeTest(false, { config: { enableSyncing: false } })
 
     it('does not handle blocks', async () => {
-      const { peerNetwork, node } = nodeTest
+      const { peerNetwork, node, chain } = nodeTest
+      chain.synced = false
+
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
 
       const block = {
@@ -738,24 +786,28 @@ describe('PeerNetwork', () => {
     })
 
     it('does not handle transactions', async () => {
-      const { peerNetwork, node } = nodeTest
+      const { peerNetwork, node, chain } = nodeTest
+      chain.synced = false
 
-      const { accounts, memPool, chain } = node
+      const { accounts, memPool } = node
       const accountA = await useAccountFixture(accounts, 'accountA')
       const accountB = await useAccountFixture(accounts, 'accountB')
       const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-      const { peer } = getConnectedPeer(peerNetwork.peerManager)
+      const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 2)
+
+      const { sendSpy } = peers[0] // peer without transaction
+      const { peer: peerWithTransaction } = peers[1]
 
       jest.spyOn(chain.verifier, 'verifyNewTransaction')
       jest.spyOn(memPool, 'acceptTransaction')
 
-      const gossip = await peerNetwork['onNewTransaction'](
-        peer,
-        new NewTransactionMessage(transaction.serialize()),
-      )
+      await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
+        peerIdentity: peerWithTransaction.getIdentityOrThrow(),
+        message: new NewTransactionMessage(transaction.serialize()),
+      })
 
-      expect(gossip).toBe(false)
+      expect(sendSpy).not.toHaveBeenCalled()
       expect(chain.verifier.verifyNewTransaction).not.toHaveBeenCalled()
       expect(memPool.acceptTransaction).not.toHaveBeenCalled()
     })

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -8,7 +8,6 @@ jest.mock('ws')
 import type WSWebSocket from 'ws'
 import http from 'http'
 import net from 'net'
-import { v4 as uuid } from 'uuid'
 import ws from 'ws'
 import { Assert } from '../assert'
 import { VerificationResultReason } from '../consensus/verifier'
@@ -30,7 +29,6 @@ import {
   GetBlockTransactionsResponse,
 } from './messages/getBlockTransactions'
 import { GetCompactBlockRequest, GetCompactBlockResponse } from './messages/getCompactBlock'
-import { NetworkMessage } from './messages/networkMessage'
 import { NewBlockMessage } from './messages/newBlock'
 import { NewPooledTransactionHashes } from './messages/newPooledTransactionHashes'
 import { NewTransactionMessage } from './messages/newTransaction'
@@ -41,7 +39,6 @@ import {
   PooledTransactionsResponse,
 } from './messages/pooledTransactions'
 import { PeerNetwork } from './peerNetwork'
-import { Peer } from './peers/peer'
 import {
   getConnectedPeer,
   getConnectedPeersWithSpies,

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -412,14 +412,9 @@ export class PeerNetwork {
         continue
       }
 
-      let sent
-      if (isUpgraded(peer)) {
-        sent = peer.send(newTransactionMessage)
-      } else {
-        sent = peer.send(message)
-      }
+      const messageToSend = isUpgraded(peer) ? newTransactionMessage : message
 
-      if (sent) {
+      if (peer.send(messageToSend)) {
         this.markKnowsTransaction(hash, peer.state.identity)
       }
     }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -992,18 +992,12 @@ export class PeerNetwork {
   private async onNewTransaction(peer: Peer, message: NewTransactionMessage): Promise<boolean> {
     const received = new Date()
 
-    // Mark the peer as knowing about the transaction as well as their known peers
-    // since they probably sent it to them. We will remove the known peers once we start
-    // gossiping message based on hash
+    // Mark the peer as knowing about the transaction
     const hash = new Transaction(message.transaction).hash()
     peer.state.identity && this.markKnowsTransaction(hash, peer.state.identity)
 
     // Let the fetcher know that a transaction was received and we no longer have to query it
     this.transactionFetcher.receivedTransaction(hash)
-
-    for (const [_, knownPeer] of peer.knownPeers) {
-      knownPeer.state.identity && this.markKnowsTransaction(hash, knownPeer.state.identity)
-    }
 
     if (!this.shouldProcessTransactions()) {
       this.transactionFetcher.removeTransaction(hash)

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -688,7 +688,7 @@ export class PeerNetwork {
 
       // If the transaction is already in the mempool the only thing we have to do is broadcast
       const transaction = this.node.memPool.get(hash)
-      if (transaction) {
+      if (transaction && !this.alreadyHaveTransaction(hash)) {
         const nonce = Buffer.alloc(16, transaction.hash())
         const gossipMessage = new NewTransactionMessage(transaction.serialize(), nonce)
         this.broadcastTransaction(gossipMessage)

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -979,14 +979,14 @@ export class PeerNetwork {
      * When we receive a new transaction we want to test if we have already processed it yet
      * meaning we have it in the mempool or we have it on a block. */
 
-    let peersToSendTo = 0
+    let peersToSendTo = false
     for (const _ of this.connectedPeersWithoutTransaction(hash)) {
-      peersToSendTo++
+      peersToSendTo = true
+      break
     }
 
     return (
-      (this.node.memPool.exists(hash) || this.recentlyAddedToChain.has(hash)) &&
-      peersToSendTo === 0
+      (this.node.memPool.exists(hash) || this.recentlyAddedToChain.has(hash)) && !peersToSendTo
       // && TODO(daniel): also filter recently rejected (expired or invalid) transactions
     )
   }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -374,7 +374,7 @@ export class PeerNetwork {
 
   private broadcastTransaction(message: NewTransactionMessage): void {
     const hash = new Transaction(message.transaction).hash()
-    const isUpgraded = (peer: Peer) => peer.version === null || peer.version < 17
+    const isUpgraded = (peer: Peer) => peer.version !== null && peer.version >= 17
 
     const peersToSendToArray = [...this.connectedPeersWithoutTransaction(hash)]
     const sendHash: Peer[] = []

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -981,7 +981,7 @@ export class PeerNetwork {
     }
 
     return (
-      (this.node.memPool.exists(hash) || this.recentlyAddedToChain.has(hash)) && !peersToSendTo
+      this.recentlyAddedToChain.has(hash) || (this.node.memPool.exists(hash) && !peersToSendTo)
       // && TODO(daniel): also filter recently rejected (expired or invalid) transactions
     )
   }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -661,8 +661,6 @@ export class PeerNetwork {
       const request = this.requests.get(rpcId)
       if (request) {
         request.resolve({ peerIdentity, message: rpcMessage })
-      } else {
-        this.logger.debug(`Dropping response to unknown request ${rpcId}`)
       }
 
       if (rpcMessage instanceof PooledTransactionsResponse) {

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -5,7 +5,6 @@
 import { RollingFilter } from '@ironfish/bfilter'
 import LRU from 'blru'
 import { BufferMap } from 'buffer-map'
-import { el } from 'date-fns/locale'
 import tweetnacl from 'tweetnacl'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -5,7 +5,6 @@
 import ws from 'ws'
 import { Identity, isIdentity } from '../identity'
 import { NetworkMessage } from '../messages/networkMessage'
-import { PeerNetwork } from '../peerNetwork'
 import {
   Connection,
   ConnectionDirection,

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -4,6 +4,8 @@
 
 import ws from 'ws'
 import { Identity, isIdentity } from '../identity'
+import { NetworkMessage } from '../messages/networkMessage'
+import { PeerNetwork } from '../peerNetwork'
 import {
   Connection,
   ConnectionDirection,
@@ -73,6 +75,21 @@ export function getWaitingForIdentityPeer(
 
   expect(peer.state.type).toBe('CONNECTING')
   return { peer, connection: connection }
+}
+
+export const getConnectedPeersWithSpies = (
+  peerManager: PeerManager,
+  count: number,
+): {
+  peer: Peer
+  sendSpy: jest.SpyInstance<Connection | null, [message: NetworkMessage]>
+}[] => {
+  return [...Array<null>(count)].map((_) => {
+    const { peer } = getConnectedPeer(peerManager)
+    const sendSpy = jest.spyOn(peer, 'send')
+
+    return { peer, sendSpy }
+  })
 }
 
 export function getConnectedPeer(

--- a/ironfish/src/network/transactionFetcher.test.ts
+++ b/ironfish/src/network/transactionFetcher.test.ts
@@ -84,13 +84,8 @@ describe('TransactionFetcher', () => {
 
     // Another peer send the full transaction
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
-    const peerIdentity = peer.getIdentityOrThrow()
-    const message = {
-      peerIdentity,
-      message: new NewTransactionMessage(transaction.serialize()),
-    }
 
-    await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
+    await peerNetwork.peerManager.onMessage.emitAsync(peer, newHashMessage(peer, hash))
 
     jest.runOnlyPendingTimers()
 

--- a/ironfish/src/network/transactionFetcher.test.ts
+++ b/ironfish/src/network/transactionFetcher.test.ts
@@ -1,0 +1,403 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { blake3 } from '@napi-rs/blake-hash'
+import { v4 as uuid } from 'uuid'
+import { IronfishNode } from '../node'
+import { TransactionHash } from '../primitives/transaction'
+import { createNodeTest, useAccountFixture, useBlockWithTx } from '../testUtilities'
+import { IncomingPeerMessage } from './messages/networkMessage'
+import { NewPooledTransactionHashes } from './messages/newPooledTransactionHashes'
+import { NewTransactionMessage } from './messages/newTransaction'
+import { NewTransactionV2Message } from './messages/newTransactionV2'
+import {
+  PooledTransactionsRequest,
+  PooledTransactionsResponse,
+} from './messages/pooledTransactions'
+import { PeerNetwork } from './peerNetwork'
+import { Peer } from './peers/peer'
+import { getConnectedPeer } from './testUtilities'
+
+jest.mock('ws')
+jest.useFakeTimers()
+
+const getValidTransactionOnBlock = async (node: IronfishNode) => {
+  const accountA = await useAccountFixture(node.accounts, 'accountA')
+  const accountB = await useAccountFixture(node.accounts, 'accountB')
+  const { transaction, block } = await useBlockWithTx(node, accountA, accountB)
+  return { transaction, accountA, accountB, block }
+}
+
+const getConnectedPeersWithSpies = (peerNetwork: PeerNetwork, count: number) => {
+  return [...Array(count)].map((_) => {
+    const { peer } = getConnectedPeer(peerNetwork.peerManager)
+    const sendSpy = jest.spyOn(peer, 'send')
+
+    return { peer, sendSpy }
+  })
+}
+
+const newHashMessage = (
+  peer: Peer,
+  hash: TransactionHash,
+): IncomingPeerMessage<NewPooledTransactionHashes> => {
+  const peerIdentity = peer.getIdentityOrThrow()
+  return {
+    peerIdentity,
+    message: new NewPooledTransactionHashes([hash]),
+  }
+}
+
+describe('TransactionFetcher', () => {
+  const nodeTest = createNodeTest()
+
+  it('only requests one transaction if multiple hashes are received', async () => {
+    const { peerNetwork, chain } = nodeTest
+    chain.synced = true
+
+    const hash = blake3(uuid())
+
+    const peers = getConnectedPeersWithSpies(peerNetwork, 5)
+    const messagesToSend = peers.map(({ peer, sendSpy }) => {
+      return { peer, message: newHashMessage(peer, hash), peerSpy: sendSpy }
+    })
+
+    messagesToSend.forEach(({ peer, message }) => {
+      peerNetwork.peerManager.onMessage.emit(peer, message)
+    })
+
+    jest.runOnlyPendingTimers()
+
+    const sentPeers = messagesToSend.filter(({ peerSpy }) => {
+      return peerSpy.mock.calls.length > 0
+    })
+
+    expect(sentPeers).toHaveLength(1)
+
+    expect(sentPeers[0].peerSpy).toHaveBeenCalledWith(
+      new PooledTransactionsRequest([hash], expect.any(Number)),
+    )
+
+    await peerNetwork.stop()
+  })
+
+  it('does not send a request for a transaction if received NewTransactionMessage from another peer within 500ms', async () => {
+    const { peerNetwork, chain, node } = nodeTest
+
+    chain.synced = true
+    const { transaction } = await getValidTransactionOnBlock(node)
+
+    const hash = transaction.hash()
+
+    // The hash is received from 5 peers
+    const peers = getConnectedPeersWithSpies(peerNetwork, 5)
+    const messagesToSend = peers.map(({ peer, sendSpy }) => {
+      return { peer, message: newHashMessage(peer, hash), peerSpy: sendSpy }
+    })
+
+    for (const { peer, message } of messagesToSend) {
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
+    }
+
+    // Another peer send the full transaction
+    const { peer } = getConnectedPeer(peerNetwork.peerManager)
+    const peerIdentity = peer.getIdentityOrThrow()
+    const message = {
+      peerIdentity,
+      message: new NewTransactionMessage(transaction.serialize()),
+    }
+
+    await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
+
+    jest.runOnlyPendingTimers()
+
+    const sentPeers = messagesToSend.filter(({ peerSpy }) => {
+      return peerSpy.mock.calls.length > 0
+    })
+
+    expect(sentPeers).toHaveLength(0)
+
+    await peerNetwork.stop()
+  })
+
+  it('does not send a request for a transaction if received NewTransactionV2Message from another peer within 500ms', async () => {
+    const { peerNetwork, chain, node } = nodeTest
+
+    chain.synced = true
+    const { transaction } = await getValidTransactionOnBlock(node)
+
+    const hash = transaction.hash()
+
+    // The hash is received from 5 peers
+    const peers = getConnectedPeersWithSpies(peerNetwork, 5)
+    const messagesToSend = peers.map(({ peer, sendSpy }) => {
+      return { peer, message: newHashMessage(peer, hash), peerSpy: sendSpy }
+    })
+
+    for (const { peer, message } of messagesToSend) {
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
+    }
+
+    // Another peer send the full transaction
+    const { peer } = getConnectedPeer(peerNetwork.peerManager)
+    const peerIdentity = peer.getIdentityOrThrow()
+    const message = {
+      peerIdentity,
+      message: new NewTransactionV2Message(transaction.serialize()),
+    }
+
+    await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
+
+    jest.runOnlyPendingTimers()
+
+    const sentPeers = messagesToSend.filter(({ peerSpy }) => {
+      return peerSpy.mock.calls.length > 0
+    })
+
+    expect(sentPeers).toHaveLength(0)
+
+    await peerNetwork.stop()
+  })
+
+  it('handles transaction response when the fetcher sends a request', async () => {
+    const { peerNetwork, chain, node } = nodeTest
+
+    chain.synced = true
+    const { transaction } = await getValidTransactionOnBlock(node)
+
+    const hash = transaction.hash()
+
+    // The hash is received from 5 peers
+    const messagesToSend = [...Array(5)].map((_) => {
+      const { peer } = getConnectedPeer(peerNetwork.peerManager)
+      const peerIdentity = peer.getIdentityOrThrow()
+      const message: IncomingPeerMessage<NewPooledTransactionHashes> = {
+        peerIdentity,
+        message: new NewPooledTransactionHashes([hash]),
+      }
+
+      const peerSpy = jest.spyOn(peer, 'send')
+
+      return { peer, message, peerSpy }
+    })
+
+    for (const { peer, message } of messagesToSend) {
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
+    }
+
+    // We wait 500ms and then send the request for the transaction to a random peer
+    jest.runOnlyPendingTimers()
+
+    const sentPeers = messagesToSend.filter(({ peerSpy }) => {
+      return peerSpy.mock.calls.length > 0
+    })
+    expect(sentPeers).toHaveLength(1)
+
+    // The peer we requested responds with the full transaction
+    const sentPeer = sentPeers[0].peer
+    const sentMessage = sentPeers[0].peerSpy.mock.calls[0][0]
+    expect(sentMessage).toBeInstanceOf(PooledTransactionsRequest)
+    const rpcId = (sentMessage as PooledTransactionsRequest).rpcId
+    const peerIdentity = sentPeer.getIdentityOrThrow()
+    const message = {
+      peerIdentity,
+      message: new PooledTransactionsResponse([transaction.serialize()], rpcId),
+    }
+
+    expect(node.memPool.exists(transaction.hash())).toBe(false)
+
+    await peerNetwork.peerManager.onMessage.emitAsync(sentPeer, message)
+
+    expect(node.memPool.exists(transaction.hash())).toBe(true)
+
+    // The timeout for the original request ends. This should not affect anything
+    // since we've already received the response
+    jest.runOnlyPendingTimers()
+
+    const sentPeers2 = messagesToSend.filter(({ peerSpy }) => {
+      return peerSpy.mock.calls.length > 0
+    })
+    expect(sentPeers2).toHaveLength(1)
+
+    await peerNetwork.stop()
+  })
+
+  it('does not send request when node has transaction in mempool', async () => {
+    const { peerNetwork, chain, node } = nodeTest
+
+    chain.synced = true
+    const { transaction } = await getValidTransactionOnBlock(node)
+
+    const hash = transaction.hash()
+
+    expect(await node.memPool.acceptTransaction(transaction)).toBe(true)
+
+    const { peer } = getConnectedPeer(peerNetwork.peerManager)
+    const peerIdentity = peer.getIdentityOrThrow()
+    const peerSpy = jest.spyOn(peer, 'send')
+
+    const message: IncomingPeerMessage<NewPooledTransactionHashes> = {
+      peerIdentity,
+      message: new NewPooledTransactionHashes([hash]),
+    }
+
+    expect(peerNetwork.knowsTransaction(hash, peerIdentity)).toBe(false)
+
+    await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
+
+    jest.runOnlyPendingTimers()
+
+    expect(peerSpy.mock.calls).toHaveLength(0)
+
+    await peerNetwork.stop()
+  })
+
+  it('does not send request when node has transaction in blockchain', async () => {
+    const { peerNetwork, chain, node } = nodeTest
+
+    chain.synced = true
+    const { block, transaction } = await getValidTransactionOnBlock(node)
+
+    const hash = transaction.hash()
+
+    await expect(node.chain).toAddBlock(block)
+
+    const { peer } = getConnectedPeer(peerNetwork.peerManager)
+    const peerIdentity = peer.getIdentityOrThrow()
+    const peerSpy = jest.spyOn(peer, 'send')
+
+    const message: IncomingPeerMessage<NewPooledTransactionHashes> = {
+      peerIdentity,
+      message: new NewPooledTransactionHashes([hash]),
+    }
+
+    expect(peerNetwork.knowsTransaction(hash, peerIdentity)).toBe(false)
+
+    await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
+
+    jest.runOnlyPendingTimers()
+
+    expect(peerSpy.mock.calls).toHaveLength(0)
+
+    await peerNetwork.stop()
+  })
+
+  it('sends request when node has transaction, but a peer does not', async () => {
+    const { peerNetwork, chain, node } = nodeTest
+
+    chain.synced = true
+    const { block, transaction } = await getValidTransactionOnBlock(node)
+
+    const hash = transaction.hash()
+
+    await expect(node.chain).toAddBlock(block)
+
+    const { peer: peerWithTransaction } = getConnectedPeer(peerNetwork.peerManager)
+    const { peer: peerWithoutTransaction } = getConnectedPeer(peerNetwork.peerManager)
+    const peerSpy = jest.spyOn(peerWithTransaction, 'send')
+
+    const message: IncomingPeerMessage<NewPooledTransactionHashes> = {
+      peerIdentity: peerWithTransaction.getIdentityOrThrow(),
+      message: new NewPooledTransactionHashes([hash]),
+    }
+
+    await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, message)
+
+    jest.runOnlyPendingTimers()
+
+    expect(peerNetwork.knowsTransaction(hash, peerWithTransaction.getIdentityOrThrow())).toBe(
+      true,
+    )
+    expect(
+      peerNetwork.knowsTransaction(hash, peerWithoutTransaction.getIdentityOrThrow()),
+    ).toBe(false)
+    expect(peerSpy.mock.calls.length).toBe(1)
+
+    await peerNetwork.stop()
+  })
+
+  it('requests from another peer if PooledTransactionsRequest times out', async () => {
+    const { peerNetwork, chain, node } = nodeTest
+
+    chain.synced = true
+    const { transaction } = await getValidTransactionOnBlock(node)
+
+    const hash = transaction.hash()
+
+    // Create 2 peers and 2 hash messages to receive
+    const peers = getConnectedPeersWithSpies(peerNetwork, 2)
+    const messagesToSend = peers.map(({ peer, sendSpy }) => {
+      return { peer, message: newHashMessage(peer, hash), peerSpy: sendSpy }
+    })
+
+    // The first peer sends a hash message
+    const { peer: peer1, message: hashMessage1 } = messagesToSend[0]
+    await peerNetwork.peerManager.onMessage.emitAsync(peer1, hashMessage1)
+
+    // We wait 500ms and then send the request for the transaction to a random peer
+    jest.runOnlyPendingTimers()
+
+    // The second peer sends a hash message
+    const { peer: peer2, message: hashMessage2 } = messagesToSend[1]
+    await peerNetwork.peerManager.onMessage.emitAsync(peer2, hashMessage2)
+
+    // Should only send a request to one peer
+    const sentPeers = messagesToSend.filter(({ peerSpy }) => {
+      return peerSpy.mock.calls.length > 0
+    })
+    expect(sentPeers).toHaveLength(1)
+
+    // The peer we requested times out
+    jest.runOnlyPendingTimers()
+
+    // We should request from the second peer
+    const sentPeers2 = messagesToSend.filter(({ peerSpy }) => {
+      return peerSpy.mock.calls.length > 0
+    })
+    expect(sentPeers2).toHaveLength(2)
+
+    await peerNetwork.stop()
+  })
+
+  it('requests from another peer if PooledTransactionsRequest fails because of disconnect', async () => {
+    const { peerNetwork, chain, node } = nodeTest
+
+    chain.synced = true
+    const { transaction } = await getValidTransactionOnBlock(node)
+
+    // Create 2 peers and 2 hash messages to receive
+    const peers = getConnectedPeersWithSpies(peerNetwork, 2)
+    const messagesToSend = peers.map(({ peer, sendSpy }) => {
+      return { peer, message: newHashMessage(peer, transaction.hash()), peerSpy: sendSpy }
+    })
+
+    // The first peer sends a hash message
+    const { peer: peer1, message: hashMessage1 } = messagesToSend[0]
+    await peerNetwork.peerManager.onMessage.emitAsync(peer1, hashMessage1)
+
+    // We wait 500ms and then send the request for the transaction to a random peer
+    jest.runOnlyPendingTimers()
+
+    // The second peer sends a hash message
+    const { peer: peer2, message: hashMessage2 } = messagesToSend[1]
+    await peerNetwork.peerManager.onMessage.emitAsync(peer2, hashMessage2)
+
+    // Should only send a request to one peer
+    const sentPeers = messagesToSend.filter(({ peerSpy }) => {
+      return peerSpy.mock.calls.length > 0
+    })
+    expect(sentPeers).toHaveLength(1)
+
+    // The peer we requested gets disconnected
+    peer1.close()
+
+    // We should request from the second peer
+    const sentPeers2 = messagesToSend.filter(({ peerSpy }) => {
+      return peerSpy.mock.calls.length > 0
+    })
+    expect(sentPeers2).toHaveLength(2)
+
+    await peerNetwork.stop()
+  })
+})

--- a/ironfish/src/network/transactionFetcher.test.ts
+++ b/ironfish/src/network/transactionFetcher.test.ts
@@ -67,7 +67,7 @@ describe('TransactionFetcher', () => {
     await peerNetwork.stop()
   })
 
-  it('does not send a request for a transaction if received NewTransactionMessage from another peer within 500ms', async () => {
+  it.only('does not send a request for a transaction if received NewTransactionMessage from another peer within 500ms', async () => {
     const { peerNetwork, chain, node } = nodeTest
 
     chain.synced = true
@@ -84,8 +84,13 @@ describe('TransactionFetcher', () => {
 
     // Another peer send the full transaction
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
+    const peerIdentity = peer.getIdentityOrThrow()
+    const message = {
+      peerIdentity,
+      message: new NewTransactionMessage(transaction.serialize()),
+    }
 
-    await peerNetwork.peerManager.onMessage.emitAsync(peer, newHashMessage(peer, hash))
+    await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
     jest.runOnlyPendingTimers()
 
@@ -116,7 +121,7 @@ describe('TransactionFetcher', () => {
     const peerIdentity = peer.getIdentityOrThrow()
     const message = {
       peerIdentity,
-      message: new NewTransactionV2Message(transaction.serialize()),
+      message: new NewTransactionV2Message([transaction.serialize()]),
     }
 
     await peerNetwork.peerManager.onMessage.emitAsync(peer, message)

--- a/ironfish/src/network/transactionFetcher.test.ts
+++ b/ironfish/src/network/transactionFetcher.test.ts
@@ -67,7 +67,7 @@ describe('TransactionFetcher', () => {
     await peerNetwork.stop()
   })
 
-  it.only('does not send a request for a transaction if received NewTransactionMessage from another peer within 500ms', async () => {
+  it('does not send a request for a transaction if received NewTransactionMessage from another peer within 500ms', async () => {
     const { peerNetwork, chain, node } = nodeTest
 
     chain.synced = true

--- a/ironfish/src/network/transactionFetcher.test.ts
+++ b/ironfish/src/network/transactionFetcher.test.ts
@@ -15,9 +15,8 @@ import {
   PooledTransactionsRequest,
   PooledTransactionsResponse,
 } from './messages/pooledTransactions'
-import { PeerNetwork } from './peerNetwork'
 import { Peer } from './peers/peer'
-import { getConnectedPeer } from './testUtilities'
+import { getConnectedPeer, getConnectedPeersWithSpies } from './testUtilities'
 
 jest.mock('ws')
 jest.useFakeTimers()
@@ -27,15 +26,6 @@ const getValidTransactionOnBlock = async (node: IronfishNode) => {
   const accountB = await useAccountFixture(node.accounts, 'accountB')
   const { transaction, block } = await useBlockWithTx(node, accountA, accountB)
   return { transaction, accountA, accountB, block }
-}
-
-const getConnectedPeersWithSpies = (peerNetwork: PeerNetwork, count: number) => {
-  return [...Array(count)].map((_) => {
-    const { peer } = getConnectedPeer(peerNetwork.peerManager)
-    const sendSpy = jest.spyOn(peer, 'send')
-
-    return { peer, sendSpy }
-  })
 }
 
 const newHashMessage = (
@@ -58,7 +48,7 @@ describe('TransactionFetcher', () => {
 
     const hash = blake3(uuid())
 
-    const peers = getConnectedPeersWithSpies(peerNetwork, 5)
+    const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
     const messagesToSend = peers.map(({ peer, sendSpy }) => {
       return { peer, message: newHashMessage(peer, hash), peerSpy: sendSpy }
     })
@@ -91,7 +81,7 @@ describe('TransactionFetcher', () => {
     const hash = transaction.hash()
 
     // The hash is received from 5 peers
-    const peers = getConnectedPeersWithSpies(peerNetwork, 5)
+    const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
     const messagesToSend = peers.map(({ peer, sendSpy }) => {
       return { peer, message: newHashMessage(peer, hash), peerSpy: sendSpy }
     })
@@ -130,7 +120,7 @@ describe('TransactionFetcher', () => {
     const hash = transaction.hash()
 
     // The hash is received from 5 peers
-    const peers = getConnectedPeersWithSpies(peerNetwork, 5)
+    const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
     const messagesToSend = peers.map(({ peer, sendSpy }) => {
       return { peer, message: newHashMessage(peer, hash), peerSpy: sendSpy }
     })
@@ -326,7 +316,7 @@ describe('TransactionFetcher', () => {
     const hash = transaction.hash()
 
     // Create 2 peers and 2 hash messages to receive
-    const peers = getConnectedPeersWithSpies(peerNetwork, 2)
+    const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 2)
     const messagesToSend = peers.map(({ peer, sendSpy }) => {
       return { peer, message: newHashMessage(peer, hash), peerSpy: sendSpy }
     })
@@ -367,7 +357,7 @@ describe('TransactionFetcher', () => {
     const { transaction } = await getValidTransactionOnBlock(node)
 
     // Create 2 peers and 2 hash messages to receive
-    const peers = getConnectedPeersWithSpies(peerNetwork, 2)
+    const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 2)
     const messagesToSend = peers.map(({ peer, sendSpy }) => {
       return { peer, message: newHashMessage(peer, transaction.hash()), peerSpy: sendSpy }
     })

--- a/ironfish/src/network/transactionFetcher.ts
+++ b/ironfish/src/network/transactionFetcher.ts
@@ -25,7 +25,7 @@ type TxState =
     }
 
 /**
- * When a node receives a new transaction hash is needs to query the sender for
+ * When a node receives a new transaction hash it needs to query the sender for
  * the full transaction object. This class encapsulates logic for resolving transaction
  * hashes to full transactions from the network. It operates as a state machine. Each transaction
  * hash has it's own state which changes when peers are queried, requests timeout or a

--- a/ironfish/src/network/transactionFetcher.ts
+++ b/ironfish/src/network/transactionFetcher.ts
@@ -44,7 +44,7 @@ export class TransactionFetcher {
   }
 
   /**
-   * Called when a new transaction hash is received from the newtork
+   * Called when a new transaction hash is received from the network
    * This schedules requests for the hash to be sent out and if
    * requests are already in progress, it adds the peer as a backup source */
   hashReceived(hash: TransactionHash, peer: Peer): void {

--- a/ironfish/src/network/transactionFetcher.ts
+++ b/ironfish/src/network/transactionFetcher.ts
@@ -139,8 +139,7 @@ export class TransactionFetcher {
     // Get the next peer randomly to distribute load more evenly
     const peer = this.popRandomPeer(hash)
     if (!peer) {
-      this.pending.delete(hash)
-      this.sources.delete(hash)
+      this.removeTransaction(hash)
       return
     }
 

--- a/ironfish/src/network/transactionFetcher.ts
+++ b/ironfish/src/network/transactionFetcher.ts
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { BufferMap } from 'buffer-map'
+import { MemPool } from '../memPool'
+import { Transaction, TransactionHash } from '../primitives/transaction'
+import { PooledTransactionsRequest } from './messages/pooledTransactions'
+import { Peer, PeerState } from './peers/peer'
+
+/**
+ * When a node receives a new transaction hash is needs to query the sender for
+ * the full transaction object. This class encapsulates logic for resolving transaction
+ * hashes to full transactions from the network
+ */
+export class TxFetcher {
+  private readonly pending = new BufferMap<
+    | {
+        peer: Peer
+        action: 'REQUEST_SCHEDULED'
+        timeout: NodeJS.Timeout
+      }
+    | {
+        peer: Peer
+        action: 'IN_FLIGHT'
+        timeout: NodeJS.Timeout
+        clearDisconnectHandler: () => void
+      }
+  >()
+
+  private readonly sources = new BufferMap<Set<Peer>>()
+
+  private readonly memPool: MemPool
+
+  constructor(memPool: MemPool) {
+    this.memPool = memPool
+  }
+
+  addSource(hash: TransactionHash, peer: Peer): void {
+    if (this.alreadyResolved(hash)) {
+      return
+    }
+
+    const currentState = this.pending.get(hash)
+
+    if (currentState && currentState.peer === peer) {
+      return
+    }
+
+    const sources = this.sources.get(hash) || new Set<Peer>()
+    sources.add(peer)
+    this.sources.set(hash, sources)
+
+    if (!currentState) {
+      this.fetchFromNextSource(hash)
+    }
+  }
+
+  fetchFromNextSource(hash: TransactionHash): void {
+    if (this.alreadyResolved(hash)) {
+      this.pending.delete(hash)
+      return
+    }
+
+    // Clear the previous source
+    const currentState = this.pending.get(hash)
+    if (currentState && currentState.action === 'IN_FLIGHT') {
+      clearTimeout(currentState.timeout)
+      currentState.clearDisconnectHandler()
+    } else if (currentState && currentState.action === 'REQUEST_SCHEDULED') {
+      clearTimeout(currentState.timeout)
+    }
+
+    // Get the next source
+    const peer = this.popSource(hash)
+    if (!peer) {
+      this.pending.delete(hash)
+      return
+    }
+
+    const timeout = setTimeout(() => this.sendRequest(hash, peer), 500)
+
+    this.pending.set(hash, {
+      peer,
+      action: 'REQUEST_SCHEDULED',
+      timeout,
+    })
+  }
+
+  sendRequest(hash: TransactionHash, peer: Peer): void {
+    if (this.alreadyResolved(hash)) {
+      return
+    }
+
+    const message = new PooledTransactionsRequest([hash])
+
+    const sent = peer.send(message)
+
+    if (!sent) {
+      this.fetchFromNextSource(hash)
+      return
+    }
+
+    const onPeerDisconnect = ({ peer, state }: { peer: Peer; state: PeerState }) => {
+      if (state.type === 'DISCONNECTED') {
+        peer.onStateChanged.off(onPeerDisconnect)
+        this.fetchFromNextSource(hash)
+      }
+    }
+    peer.onStateChanged.on(onPeerDisconnect)
+
+    const clearDisconnectHandler = () => {
+      peer.onStateChanged.off(onPeerDisconnect)
+    }
+
+    const timeout = setTimeout(() => {
+      this.fetchFromNextSource(hash)
+    }, 5000)
+
+    this.pending.set(hash, {
+      peer,
+      action: 'IN_FLIGHT',
+      timeout,
+      clearDisconnectHandler,
+    })
+  }
+
+  transactionResolved(transaction: Transaction): void {
+    const hash = transaction.hash()
+    const currentState = this.pending.get(hash)
+
+    if (currentState && currentState.action === 'IN_FLIGHT') {
+      currentState.clearDisconnectHandler()
+    }
+
+    if (currentState) {
+      clearTimeout(currentState.timeout)
+    }
+
+    this.pending.delete(hash)
+    this.sources.delete(hash)
+  }
+
+  private popSource(hash: TransactionHash): Peer | undefined {
+    const sources = this.sources.get(hash)
+
+    if (!sources) {
+      return undefined
+    }
+
+    let nextSource
+    for (const source of sources.values()) {
+      nextSource = source
+      break
+    }
+
+    if (nextSource) {
+      sources.delete(nextSource)
+    }
+
+    return nextSource
+  }
+
+  private alreadyResolved(hash: TransactionHash): boolean {
+    // TODO(daniel): Also return transactions that were recently added to the chain
+    return this.memPool.exists(hash)
+  }
+}

--- a/ironfish/src/network/transactionFetcher.ts
+++ b/ironfish/src/network/transactionFetcher.ts
@@ -7,7 +7,7 @@ import { BufferMap } from 'buffer-map'
 import { Blockchain } from '../blockchain'
 import { MemPool } from '../memPool'
 import { Block } from '../primitives'
-import { Transaction, TransactionHash } from '../primitives/transaction'
+import { TransactionHash } from '../primitives/transaction'
 import { PooledTransactionsRequest } from './messages/pooledTransactions'
 import { Peer, PeerState } from './peers/peer'
 
@@ -56,7 +56,8 @@ export class TxFetcher {
     })
   }
 
-  /* Called when a new transaction hash is received from the newtork
+  /**
+   * Called when a new transaction hash is received from the newtork
    * This schedules requests for the hash to be sent out and if
    * requests are already in progress, it adds the peer as a backup source */
   hashReceived(hash: TransactionHash, peer: Peer): void {
@@ -78,6 +79,8 @@ export class TxFetcher {
       return
     }
 
+    /* Wait 500ms before requesting a new hash to see if we receive the full
+     * transaction from the network first */
     const timeout = setTimeout(() => {
       if (this.isResolved(hash)) {
         this.removeTransaction(hash)
@@ -94,7 +97,8 @@ export class TxFetcher {
     })
   }
 
-  /* Called when a transaction has been received and confirmed from the network
+  /**
+   * Called when a transaction has been received and confirmed from the network
    * either in a block or in a gossiped transaction request */
   removeTransaction(hash: TransactionHash): void {
     const currentState = this.pending.get(hash)
@@ -111,7 +115,7 @@ export class TxFetcher {
       return
     }
 
-    // Clear the previous source
+    // Clear the previous peer request state
     const currentState = this.pending.get(hash)
     currentState && this.cleanupCallbacks(currentState)
 

--- a/ironfish/src/network/version.ts
+++ b/ironfish/src/network/version.ts
@@ -2,5 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const VERSION_PROTOCOL = 16
+export const VERSION_PROTOCOL = 17
 export const VERSION_PROTOCOL_MIN = 15

--- a/ironfish/src/testUtilities/mocks.ts
+++ b/ironfish/src/testUtilities/mocks.ts
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Event } from '../event'
+import { Block } from '../primitives/block'
+import { IDatabaseTransaction } from '../storage'
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
@@ -37,6 +41,8 @@ export function mockChain(): any {
     verifier: mockVerifier(),
     head: { hash: 'mockhash', sequence: 1, work: BigInt(0) },
     synced: true,
+    onConnectBlock: new Event<[block: Block, tx?: IDatabaseTransaction]>(),
+    onDisconnectBlock: new Event<[block: Block, tx?: IDatabaseTransaction]>(),
   }
 }
 


### PR DESCRIPTION
## Summary
When receiving a new transaction hash from another peer the node needs to fetch the full transaction. The fetcher defines logic for fetching the transaction from one or multiple peers as well as resolving transactions if it hears a gossip message of the full transaction. More is described in the [Transaction Gossip Proposal](https://coda.io/d/Gossip_d7HSvA-Pxcz)

## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
