### PR TITLE
fix(ironfish): Remove `submittedSequence` check in `accounts:transactions`

### DIFF
--- a/ironfish/src/rpc/routes/accounts/getTransactions.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransactions.ts
@@ -54,9 +54,9 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
 router.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactionsResponse>(
   `${ApiNamespace.account}/getAccountTransactions`,
   GetAccountTransactionsRequestSchema,
-  (request, node): void => {
+  async (request, node): Promise<void> => {
     const account = getAccount(node, request.data.account)
-    const { transactions } = node.accounts.getTransactions(account)
+    const transactions = await node.accounts.getTransactions(account)
     request.end({ account: account.displayName, transactions })
   },
 )


### PR DESCRIPTION
## Summary

If you submit transactions that make it onto the main chain on an account and import that account (in a separate directory, machine, etc.), your transactions will show as `pending` since `submittedSequence` was never populated for these records. That value is only set for locally initiated transactions. We should update the check to use `blockHash`. This PR also updates the status to include a `forked` status.

<img width="301" alt="Screen Shot 2022-07-19 at 8 09 39 PM" src="https://user-images.githubusercontent.com/5459049/179868625-1da67bb3-b12e-4a0f-81d3-fcd85ee0d554.png">

cc @wd021 

## Testing Plan

Manual test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
