### PR TITLE
Add default trait to memo for better memo ergonomics

### DIFF
--- a/ironfish-rust/src/merkle_note.rs
+++ b/ironfish-rust/src/merkle_note.rs
@@ -281,7 +281,7 @@ mod test {
     fn test_view_key_encryption() {
         let spender_key: SaplingKey = SaplingKey::generate_key();
         let receiver_key: SaplingKey = SaplingKey::generate_key();
-        let note = Note::new(receiver_key.generate_public_address(), 42, Memo([0; 32]));
+        let note = Note::new(receiver_key.generate_public_address(), 42, Memo::default());
         let diffie_hellman_keys = note.owner.generate_diffie_hellman_keys();
 
         let mut buffer = [0u8; 64];
@@ -307,7 +307,7 @@ mod test {
     #[test]
     fn test_receipt_invalid_commitment() {
         let spender_key: SaplingKey = SaplingKey::generate_key();
-        let note = Note::new(spender_key.generate_public_address(), 42, Memo([0; 32]));
+        let note = Note::new(spender_key.generate_public_address(), 42, Memo::default());
         let diffie_hellman_keys = note.owner.generate_diffie_hellman_keys();
 
         let mut buffer = [0u8; 64];

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -20,7 +20,7 @@ pub const ENCRYPTED_NOTE_SIZE: usize = 83;
 
 /// Memo field on a Note. Used to encode transaction IDs or other information
 /// about the transaction.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Memo(pub [u8; 32]);
 
 impl From<&str> for Memo {
@@ -102,7 +102,7 @@ impl<'a> Note {
         let randomness: jubjub::Fr = read_scalar(&mut reader)?;
 
         let mut memo_vec = vec![];
-        let mut memo = Memo([0; 32]);
+        let mut memo = Memo::default();
         reader.read_to_end(&mut memo_vec)?;
         assert_eq!(memo_vec.len(), 32);
         memo.0.copy_from_slice(&memo_vec[..]);
@@ -263,7 +263,7 @@ impl<'a> Note {
         let randomness: jubjub::Fr = read_scalar(&mut reader)?;
         let value = reader.read_u64::<LittleEndian>()?;
         let mut memo_vec = vec![];
-        let mut memo = Memo([0; 32]);
+        let mut memo = Memo::default();
         reader.read_to_end(&mut memo_vec)?;
         assert_eq!(memo_vec.len(), 32);
         memo.0.copy_from_slice(&memo_vec[..]);
@@ -321,7 +321,7 @@ mod test {
         let (dh_secret, dh_public) = public_address.generate_diffie_hellman_keys();
         let public_shared_secret =
             shared_secret(&dh_secret, &public_address.transmission_key, &dh_public);
-        let note = Note::new(public_address, 42, Memo([0; 32]));
+        let note = Note::new(public_address, 42, Memo::default());
         let encryption_result = note.encrypt(&public_shared_secret);
 
         let private_shared_secret = owner_key.incoming_view_key().shared_secret(&dh_public);

--- a/ironfish-rust/src/receiving.rs
+++ b/ironfish-rust/src/receiving.rs
@@ -195,7 +195,7 @@ mod test {
     fn test_receipt_round_trip() {
         let sapling = &*sapling_bls12::SAPLING;
         let spender_key: SaplingKey = SaplingKey::generate_key();
-        let note = Note::new(spender_key.generate_public_address(), 42, Memo([0; 32]));
+        let note = Note::new(spender_key.generate_public_address(), 42, Memo::default());
 
         let receipt = ReceiptParams::new(sapling.clone(), &spender_key, &note)
             .expect("should be able to create receipt proof");

--- a/ironfish-rust/src/spending.rs
+++ b/ironfish-rust/src/spending.rs
@@ -424,7 +424,7 @@ mod test {
 
         let note_randomness = random();
 
-        let note = Note::new(public_address, note_randomness, Memo([0; 32]));
+        let note = Note::new(public_address, note_randomness, Memo::default());
         let witness = make_fake_witness(&note);
 
         let spend = SpendParams::new(sapling.clone(), key, &note, &witness)

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -165,7 +165,7 @@ impl ProposedTransaction {
             let change_note = Note::new(
                 change_address,
                 change_amount as u64, // we checked it was positive
-                Memo([0; 32]),
+                Memo::default(),
             );
             self.receive(spender_key, &change_note)?;
         }

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -20,9 +20,9 @@ fn test_transaction() {
     let mut transaction = ProposedTransaction::new(sapling.clone());
     let spender_key: SaplingKey = SaplingKey::generate_key();
     let receiver_key: SaplingKey = SaplingKey::generate_key();
-    let in_note = Note::new(spender_key.generate_public_address(), 42, Memo([0; 32]));
-    let out_note = Note::new(receiver_key.generate_public_address(), 40, Memo([0; 32]));
-    let in_note2 = Note::new(spender_key.generate_public_address(), 18, Memo([0; 32]));
+    let in_note = Note::new(spender_key.generate_public_address(), 42, Memo::default());
+    let out_note = Note::new(receiver_key.generate_public_address(), 40, Memo::default());
+    let in_note2 = Note::new(spender_key.generate_public_address(), 18, Memo::default());
     let witness = make_fake_witness(&in_note);
     let _witness2 = make_fake_witness(&in_note2);
     transaction
@@ -93,7 +93,7 @@ fn test_miners_fee() {
     let sapling = &*sapling_bls12::SAPLING;
     let mut transaction = ProposedTransaction::new(sapling.clone());
     let receiver_key: SaplingKey = SaplingKey::generate_key();
-    let out_note = Note::new(receiver_key.generate_public_address(), 42, Memo([0; 32]));
+    let out_note = Note::new(receiver_key.generate_public_address(), 42, Memo::default());
     transaction
         .receive(&receiver_key, &out_note)
         .expect("It's a valid note");
@@ -121,8 +121,8 @@ fn test_transaction_signature() {
     let receiver_address = receiver_key.generate_public_address();
 
     let mut transaction = ProposedTransaction::new(sapling);
-    let in_note = Note::new(spender_address, 42, Memo([0; 32]));
-    let out_note = Note::new(receiver_address, 41, Memo([0; 32]));
+    let in_note = Note::new(spender_address, 42, Memo::default());
+    let out_note = Note::new(receiver_address, 41, Memo::default());
     let witness = make_fake_witness(&in_note);
 
     transaction


### PR DESCRIPTION
## Summary

- Add derived `Default` trait
- Change usage of `Memo([0; 32])` to `Memo::default()`

There looks like some other cleanup we can do, specifically around serializing/deserializing, but this is a good easy win

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
