### PR TITLE
Add migration for Wallet 2.0

### DIFF
--- a/ironfish/src/account/account.ts
+++ b/ironfish/src/account/account.ts
@@ -188,7 +188,7 @@ export class Account {
 
     const { sequence, blockHash } = transaction
     if (blockHash) {
-      Assert.isNotNull(sequence)
+      Assert.isNotNull(sequence, `sequence required when submitting block hash`)
       const decryptedNotes = this.noteHashesBySequence.get(sequence) ?? new Set<string>()
       decryptedNotes.add(noteHash)
       this.noteHashesBySequence.set(sequence, decryptedNotes)

--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -24,7 +24,7 @@ import { DecryptedNotesValue, DecryptedNotesValueEncoding } from './database/dec
 import { AccountsDBMeta, MetaValue, MetaValueEncoding } from './database/meta'
 import { TransactionsValue, TransactionsValueEncoding } from './database/transactions'
 
-export const VERSION_DATABASE_ACCOUNTS = 11
+export const VERSION_DATABASE_ACCOUNTS = 13
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountId: null,

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -24,8 +24,7 @@ type Stores = {
 export class Migration013 extends Migration {
   path = __filename
 
-  async prepare(node: IronfishNode): Promise<IDatabase> {
-    await node.files.mkdir(node.accounts.db.location, { recursive: true })
+  prepare(node: IronfishNode): IDatabase {
     return createDB({ location: node.accounts.db.location })
   }
 
@@ -37,8 +36,11 @@ export class Migration013 extends Migration {
   ): Promise<void> {
     const startTotal = BenchUtils.startSegment()
 
+    const chainDb = createDB({ location: node.config.chainDatabasePath })
+    await chainDb.open()
+
     const stores: Stores = {
-      old: loadOldStores(db),
+      old: loadOldStores(db, chainDb),
       new: loadNewStores(db),
     }
 
@@ -121,6 +123,7 @@ export class Migration013 extends Migration {
     await stores.old.noteToNullifier.clear(tx)
     logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
 
+    await chainDb.close()
     logger.debug(BenchUtils.renderSegment(BenchUtils.endSegment(startTotal)))
   }
 

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -74,7 +74,7 @@ export class Migration013 extends Migration {
     )
     logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
 
-    logger.debug('Migrating: balanaces')
+    logger.debug('Migrating: balances')
     start = BenchUtils.startSegment()
     await this.migrateBalances(stores.new.balances, unconfirmedBalances, accounts, tx, logger)
     logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -171,7 +171,6 @@ export class Migration013 extends Migration {
     let count = 0
 
     for await (const [nullifier, noteHash] of nullifierToNoteOld.getAllIter(tx)) {
-      logger.debug(`\tMigrating note's nullifier: ${HashUtils.renderHashHex(noteHash)}`)
       await nullifierToNoteHashNew.put(nullifier, noteHash, tx)
       count++
     }

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -1,0 +1,376 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { BufferMap } from 'buffer-map'
+import jsonColorizer from 'json-colorizer'
+import { isFunction } from 'lodash'
+import { v4 as uuid } from 'uuid'
+import { DecryptedNotesValue } from '../../account/database/decryptedNotes'
+import { Assert } from '../../assert'
+import { Logger } from '../../logger'
+import { loggers } from '../../logger/reporters'
+import { IronfishNode } from '../../node'
+import { Transaction } from '../../primitives'
+import { NoteEncrypted } from '../../primitives/noteEncrypted'
+import { DatabaseStoreValue, IDatabase, IDatabaseTransaction } from '../../storage'
+import { createDB } from '../../storage/utils'
+import { BenchUtils, HashUtils, PromiseUtils } from '../../utils'
+import { Migration } from '../migration'
+import { loadNewStores, NewStores } from './013-wallet-2/new/stores'
+import { loadOldStores, OldStores } from './013-wallet-2/old/stores'
+
+type Stores = {
+  old: OldStores
+  new: NewStores
+}
+
+export class Migration013 extends Migration {
+  path = __filename
+
+  async prepare(node: IronfishNode): Promise<IDatabase> {
+    await node.files.mkdir(node.accounts.db.location, { recursive: true })
+    return createDB({ location: node.accounts.db.location })
+  }
+
+  async forward(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<void> {
+    const startTotal = BenchUtils.startSegment()
+
+    const stores: Stores = {
+      old: loadOldStores(db),
+      new: loadNewStores(db),
+    }
+
+    logger.debug('Building a map of notes to which transaction they are in')
+    let start = BenchUtils.startSegment()
+    const noteToTransactionCache = await this.buildNoteToTransactionCache(
+      stores.old.transactions,
+      tx,
+      logger
+    )
+    logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
+
+    logger.debug('Migrating: accounts')
+    start = BenchUtils.startSegment()
+    const accounts = await this.migrateAccounts(
+      stores.old.accounts,
+      stores.new.accounts,
+      tx,
+      logger,
+    )
+    logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
+
+    logger.debug('Migrating: decryptedNotes')
+    start = BenchUtils.startSegment()
+    const { unconfirmedBalances } = await this.migrateDecryptedNotes(
+      stores.old.noteToNullifier,
+      stores.old.transactions,
+      stores.new.decryptedNotes,
+      noteToTransactionCache,
+      accounts,
+      tx,
+      logger
+    )
+    logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
+
+    logger.debug('Migrating: balanaces')
+    start = BenchUtils.startSegment()
+    await this.migrateBalances(
+      stores.new.balances,
+      unconfirmedBalances,
+      accounts,
+      tx,
+      logger,
+    )
+    logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
+
+    logger.debug('Migrating: nullifierToNoteHash')
+    start = BenchUtils.startSegment()
+    await this.migrateNullifierToNoteHash(
+      stores.old.nullifierToNote,
+      stores.new.nullifierToNoteHash,
+      tx,
+      logger,
+    )
+    logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
+
+    logger.debug('Migrating: headHashes')
+    start = BenchUtils.startSegment()
+    await this.migrateHeadHashes(
+      stores.old.meta,
+      stores.new.headHashes,
+      accounts,
+      tx,
+      logger,
+    )
+    logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
+
+    logger.debug('Migrating: meta')
+    start = BenchUtils.startSegment()
+    await this.migrateMeta(
+      stores.old.meta,
+      stores.new.meta,
+      accounts,
+      tx,
+      logger,
+    )
+    logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
+
+    logger.debug('Migrating: Deleting old store nullifierToNote')
+    start = BenchUtils.startSegment()
+    await stores.old.nullifierToNote.clear(tx)
+    logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
+
+    logger.debug('Migrating: Deleting old store noteToNullifier')
+    start = BenchUtils.startSegment()
+    await stores.old.noteToNullifier.clear(tx)
+    logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
+
+    logger.debug(BenchUtils.renderSegment(BenchUtils.endSegment(startTotal)))
+  }
+
+  backward(): Promise<void> {
+    throw new Error()
+  }
+
+  async buildNoteToTransactionCache(
+    transactions: Stores['old']['transactions'],
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<BufferMap<Buffer>> {
+    const noteToTransaction = new BufferMap<Buffer>()
+    let tranactionCount = 0
+
+    for await (const [transactionHash, transactionEntry] of transactions.getAllIter(tx)) {
+      const transaction = new Transaction(transactionEntry.transaction)
+
+      for (const note of transaction.notes()) {
+        const noteHash = note.merkleHash()
+        noteToTransaction.set(noteHash, transactionHash)
+      }
+
+      tranactionCount++
+    }
+
+    logger.debug(
+      `\tFound ${noteToTransaction.size} notes that map to ${tranactionCount} transactions`,
+    )
+
+    return noteToTransaction
+  }
+
+  async migrateBalances(
+    balancesStoreNew: Stores['new']['balances'],
+    unconfirmedBalances: Map<string, bigint>,
+    accounts: { account: DatabaseStoreValue<NewStores['accounts']>; id: string }[],
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<void> {
+    for (const account of accounts) {
+      const balance = unconfirmedBalances.get(account.id)
+
+      if (typeof balance === 'bigint') {
+        logger.debug(`\tCalculated balance ${account.account.name}: ${balance}`)
+        await balancesStoreNew.put(account.id, balance, tx)
+      } else {
+        logger.debug(`\tNo balance for ${account.account.name}, setting to 0`)
+        await balancesStoreNew.put(account.id, BigInt(0), tx)
+      }
+    }
+  }
+
+  async migrateNullifierToNoteHash(
+    nullifierToNoteOld: Stores['old']['nullifierToNote'],
+    nullifierToNoteHashNew: Stores['new']['nullifierToNoteHash'],
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<void> {
+    let count = 0
+
+    for await (const [nullifier, noteHash] of nullifierToNoteOld.getAllIter(tx)) {
+      logger.debug(`\tMigrating note's nullifier: ${HashUtils.renderHashHex(noteHash)}`)
+      await nullifierToNoteHashNew.put(nullifier, noteHash, tx)
+      count++
+    }
+
+    logger.debug(`\tMigrated ${count} nullifiers`)
+  }
+
+  async migrateHeadHashes(
+    metaStoreOld: Stores['old']['meta'],
+    headHashesStoreNew: Stores['new']['headHashes'],
+    accounts: { account: DatabaseStoreValue<NewStores['accounts']>; id: string }[],
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<void> {
+    const headHash = await metaStoreOld.get('headHash', tx)
+
+    for (const account of accounts) {
+      logger.debug(`\tSetting account ${account.account.name} head hash: ${String(headHash)}`)
+      await headHashesStoreNew.put(account.id, headHash ?? null, tx)
+    }
+  }
+
+  async migrateMeta(
+    metaStoreOld: Stores['old']['meta'],
+    metaStoreNew: Stores['new']['meta'],
+    accounts: { account: DatabaseStoreValue<NewStores['accounts']>; id: string }[],
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<void> {
+    const accountName = await metaStoreOld.get('defaultAccountName')
+
+    if (accountName) {
+      const account = accounts.find((a) => a.account.name === accountName)
+
+      if (account) {
+        logger.debug(`\tMigrating default account from ${accountName} -> ${account.id}`)
+        await metaStoreNew.put('defaultAccountId', account.id, tx)
+      } else {
+        logger.warn(`\tCould not migrate default with name ${accountName}`)
+        await metaStoreNew.put('defaultAccountId', null, tx)
+      }
+    }
+
+    await metaStoreOld.del('defaultAccountName', tx)
+    await metaStoreOld.del('headHash', tx)
+  }
+
+  async migrateAccounts(
+    accountsStoreOld: Stores['old']['accounts'],
+    accountsStoreNew: Stores['new']['accounts'],
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<{ account: DatabaseStoreValue<NewStores['accounts']>; id: string }[]> {
+    const accounts = []
+
+    for await (const [accountName, accountValue] of accountsStoreOld.getAllIter(tx)) {
+      const accountId = uuid()
+
+      logger.debug(`\tAssigned account id ${accountName}: ${accountId}`)
+
+      await accountsStoreNew.put(uuid(), accountValue, tx)
+      await accountsStoreOld.del(accountName, tx)
+
+      accounts.push({ id: accountId, account: accountValue })
+    }
+
+    logger.debug(`\tMigrated ${accounts.length} accounts`)
+
+    return accounts
+  }
+
+  async migrateDecryptedNotes(
+    noteToNullifierStoreOld: Stores['old']['noteToNullifier'],
+    transactionStoreOld: Stores['old']['transactions'],
+    decryptedNoteStoreNew: Stores['new']['decryptedNotes'],
+    noteToTransactionCache: BufferMap<Buffer>,
+    accounts: { account: DatabaseStoreValue<NewStores['accounts']>; id: string }[],
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<{ unconfirmedBalances: Map<string, bigint> }> {
+    const decryptedNotes: DatabaseStoreValue<NewStores['decryptedNotes']>[] = []
+    let missingCount = 0
+
+    const unconfirmedBalances = new Map<string, bigint>()
+
+    for await (const [noteHashHex, nullifierEntry] of noteToNullifierStoreOld.getAllIter(tx)) {
+      const noteHash = Buffer.from(noteHashHex, 'hex')
+
+      const transactionHash = noteToTransactionCache.get(noteHash)
+      Assert.isNotUndefined(transactionHash)
+
+      const transactionEntry = await transactionStoreOld.get(transactionHash)
+      Assert.isNotUndefined(transactionEntry)
+
+      const transaction = new Transaction(transactionEntry.transaction)
+      const encryptedNote = findNoteInTranaction(transaction, noteHashHex)
+
+      if (!encryptedNote) {
+        throw new Error(
+          `Could not find note ${noteHashHex} in transaction ${transactionHash.toString(
+            'hex',
+          )}`,
+        )
+      }
+
+      let account = null
+      let note = null
+
+      for (const accountWithId of accounts) {
+        const received = encryptedNote.decryptNoteForOwner(
+          accountWithId.account.incomingViewKey,
+        )
+        if (received) {
+          note = received
+          account = accountWithId
+          break
+        }
+
+        const sent = encryptedNote.decryptNoteForSpender(accountWithId.account.outgoingViewKey)
+        if (sent) {
+          note = sent
+          account = accountWithId
+          break
+        }
+      }
+
+      if (!account || !note) {
+        logger.warn(
+          `\tCould not find the original account that the note ${noteHashHex} was decrypted with, discarding. Tried ${accounts.length} accounts.`,
+        )
+        missingCount++
+        continue
+      }
+
+      const decryptedNote: DatabaseStoreValue<NewStores['decryptedNotes']> = {
+        accountId: account.id,
+        noteIndex: nullifierEntry.noteIndex,
+        nullifierHash: nullifierEntry.nullifierHash,
+        serializedNote: note.serialize(),
+        spent: nullifierEntry.spent,
+        transactionHash: transactionHash,
+      }
+
+      if (!decryptedNote.spent) {
+        let balance = unconfirmedBalances.get(account.id) ?? BigInt(0)
+        balance += note.value()
+        unconfirmedBalances.set(account.id, balance)
+      }
+
+      await decryptedNoteStoreNew.put(noteHashHex, decryptedNote, tx)
+
+      decryptedNotes.push(decryptedNote)
+    }
+
+    if (missingCount) {
+      logger.warn(
+        `\tMigrated ${decryptedNotes.length} but dropped ${missingCount} notes that were not decryptable by any accounts we have.`,
+      )
+    } else {
+      logger.debug(`\tMigrated ${decryptedNotes.length} notes.`)
+    }
+
+    return { unconfirmedBalances }
+  }
+}
+
+function findNoteInTranaction(
+  transaction: Transaction,
+  noteHash: string,
+): NoteEncrypted | null {
+  const noteHashBuffer = Buffer.from(noteHash, 'hex')
+
+  for (const note of transaction.notes()) {
+    if (note.merkleHash().equals(noteHashBuffer)) {
+      return note
+    }
+  }
+
+  return null
+}

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -301,7 +301,12 @@ export class Migration013 extends Migration {
       await transactionsStoreNew.put(transactionHash, migrated, tx)
     }
 
-    logger.debug(`\tMigrated ${countMigrated} and dropped ${countDropped} transactions`)
+    logger.debug(`\tMigrated ${countMigrated} transactions`)
+
+    if (countDropped) {
+      logger.warn(`\tDropped ${countDropped} transactions with missing blocks`)
+    }
+
     return dropped
   }
 
@@ -400,7 +405,7 @@ export class Migration013 extends Migration {
 
     if (countMissingAccount) {
       logger.warn(
-        `\tDropped ${countMissingAccount} notes that were not decryptable by any accounts we have and dropped ${countMissingTx} notes from TX that were dropped because their blocks were missing.`,
+        `\tDropped ${countMissingAccount} notes that were not decryptable by any accounts we have and dropped ${countMissingTx} notes from transactions that were dropped because their blocks were missing.`,
       )
     }
 

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -3,19 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { BufferMap } from 'buffer-map'
-import jsonColorizer from 'json-colorizer'
-import { isFunction } from 'lodash'
 import { v4 as uuid } from 'uuid'
-import { DecryptedNotesValue } from '../../account/database/decryptedNotes'
 import { Assert } from '../../assert'
 import { Logger } from '../../logger'
-import { loggers } from '../../logger/reporters'
 import { IronfishNode } from '../../node'
 import { Transaction } from '../../primitives'
 import { NoteEncrypted } from '../../primitives/noteEncrypted'
 import { DatabaseStoreValue, IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { BenchUtils, HashUtils, PromiseUtils } from '../../utils'
+import { BenchUtils, HashUtils } from '../../utils'
 import { Migration } from '../migration'
 import { loadNewStores, NewStores } from './013-wallet-2/new/stores'
 import { loadOldStores, OldStores } from './013-wallet-2/old/stores'
@@ -51,7 +47,7 @@ export class Migration013 extends Migration {
     const noteToTransactionCache = await this.buildNoteToTransactionCache(
       stores.old.transactions,
       tx,
-      logger
+      logger,
     )
     logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
 
@@ -74,19 +70,13 @@ export class Migration013 extends Migration {
       noteToTransactionCache,
       accounts,
       tx,
-      logger
+      logger,
     )
     logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
 
     logger.debug('Migrating: balanaces')
     start = BenchUtils.startSegment()
-    await this.migrateBalances(
-      stores.new.balances,
-      unconfirmedBalances,
-      accounts,
-      tx,
-      logger,
-    )
+    await this.migrateBalances(stores.new.balances, unconfirmedBalances, accounts, tx, logger)
     logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
 
     logger.debug('Migrating: nullifierToNoteHash')
@@ -101,24 +91,12 @@ export class Migration013 extends Migration {
 
     logger.debug('Migrating: headHashes')
     start = BenchUtils.startSegment()
-    await this.migrateHeadHashes(
-      stores.old.meta,
-      stores.new.headHashes,
-      accounts,
-      tx,
-      logger,
-    )
+    await this.migrateHeadHashes(stores.old.meta, stores.new.headHashes, accounts, tx, logger)
     logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
 
     logger.debug('Migrating: meta')
     start = BenchUtils.startSegment()
-    await this.migrateMeta(
-      stores.old.meta,
-      stores.new.meta,
-      accounts,
-      tx,
-      logger,
-    )
+    await this.migrateMeta(stores.old.meta, stores.new.meta, accounts, tx, logger)
     logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
 
     logger.debug('Migrating: Deleting old store nullifierToNote')

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -245,7 +245,7 @@ export class Migration013 extends Migration {
 
       logger.debug(`\tAssigned account id ${accountName}: ${accountId}`)
 
-      await accountsStoreNew.put(uuid(), accountValue, tx)
+      await accountsStoreNew.put(accountId, accountValue, tx)
       await accountsStoreOld.del(accountName, tx)
 
       accounts.push({ id: accountId, account: accountValue })

--- a/ironfish/src/migrations/data/013-wallet-2/new/accounts.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/accounts.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
+
+const KEY_LENGTH = 32
+const PUBLIC_ADDRESS_LENGTH = 43
+
+export type AccountsStore = IDatabaseStore<{ key: string; value: AccountsValue }>
+
+export interface AccountsValue {
+  name: string
+  spendingKey: string
+  incomingViewKey: string
+  outgoingViewKey: string
+  publicAddress: string
+}
+
+export class AccountsValueEncoding implements IDatabaseEncoding<AccountsValue> {
+  serialize(value: AccountsValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    bw.writeVarString(value.name, 'utf8')
+    bw.writeBytes(Buffer.from(value.spendingKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): AccountsValue {
+    const reader = bufio.read(buffer, true)
+    const name = reader.readVarString('utf8')
+    const spendingKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+
+    return {
+      name,
+      spendingKey,
+      incomingViewKey,
+      outgoingViewKey,
+      publicAddress,
+    }
+  }
+
+  getSize(value: AccountsValue): number {
+    let size = bufio.sizeVarString(value.name, 'utf8')
+    size += KEY_LENGTH
+    size += KEY_LENGTH
+    size += KEY_LENGTH
+    size += PUBLIC_ADDRESS_LENGTH
+
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/new/balances.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/balances.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { IDatabaseStore } from '../../../../storage'
+
+export type BalancesStore = IDatabaseStore<{
+  key: string
+  value: bigint
+}>

--- a/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
+
+export const NOTE_SIZE = 43 + 8 + 32 + 32
+
+export type DecryptedNotesStore = IDatabaseStore<{
+  key: string
+  value: DecryptedNotesValue
+}>
+
+export interface DecryptedNotesValue {
+  accountId: string
+  noteIndex: number | null
+  nullifierHash: string | null
+  serializedNote: Buffer
+  spent: boolean
+  transactionHash: Buffer
+}
+
+export class DecryptedNotesValueEncoding implements IDatabaseEncoding<DecryptedNotesValue> {
+  serialize(value: DecryptedNotesValue): Buffer {
+    const { accountId, nullifierHash, noteIndex, serializedNote, spent, transactionHash } =
+      value
+
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!noteIndex) << 0
+    flags |= Number(!!nullifierHash) << 1
+    flags |= Number(spent) << 2
+    bw.writeU8(flags)
+
+    bw.writeVarString(accountId)
+    bw.writeBytes(serializedNote)
+    bw.writeHash(transactionHash)
+
+    if (noteIndex) {
+      bw.writeU32(noteIndex)
+    }
+    if (nullifierHash) {
+      bw.writeHash(nullifierHash)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): DecryptedNotesValue {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const hasNoteIndex = flags & (1 << 0)
+    const hasNullifierHash = flags & (1 << 1)
+    const spent = Boolean(flags & (1 << 2))
+
+    const accountId = reader.readVarString()
+    const serializedNote = reader.readBytes(NOTE_SIZE)
+    const transactionHash = reader.readHash()
+
+    let noteIndex = null
+    if (hasNoteIndex) {
+      noteIndex = reader.readU32()
+    }
+
+    let nullifierHash = null
+    if (hasNullifierHash) {
+      nullifierHash = reader.readHash('hex')
+    }
+
+    return { accountId, noteIndex, nullifierHash, serializedNote, spent, transactionHash }
+  }
+
+  getSize(value: DecryptedNotesValue): number {
+    let size = 1
+
+    size += bufio.sizeVarString(value.accountId)
+
+    size += NOTE_SIZE
+
+    // transaction hash
+    size += 32
+
+    if (value.noteIndex) {
+      size += 4
+    }
+
+    if (value.nullifierHash) {
+      size += 32
+    }
+
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/new/headHashes.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/headHashes.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { IDatabaseStore } from '../../../../storage'
+
+export type HeadHashesStore = IDatabaseStore<{
+  key: string
+  value: string | null
+}>

--- a/ironfish/src/migrations/data/013-wallet-2/new/meta.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/meta.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
+
+export type MetaStore = IDatabaseStore<{
+  key: keyof AccountsDBMeta
+  value: MetaValue
+}>
+
+export type AccountsDBMeta = {
+  defaultAccountId: string | null
+}
+
+export type MetaValue = AccountsDBMeta[keyof AccountsDBMeta]
+
+export class MetaValueEncoding implements IDatabaseEncoding<MetaValue> {
+  serialize(value: MetaValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    if (value) {
+      bw.writeVarString(value, 'utf8')
+    }
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): MetaValue {
+    const reader = bufio.read(buffer, true)
+    if (reader.left()) {
+      return reader.readVarString('utf8')
+    }
+    return null
+  }
+
+  getSize(value: MetaValue): number {
+    if (!value) {
+      return 0
+    }
+    return bufio.sizeVarString(value, 'utf8')
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/new/noteToNullifier.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/noteToNullifier.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
+
+export type NoteToNullifierStore = IDatabaseStore<{
+  key: string
+  value: NoteToNullifiersValue
+}>
+
+export interface NoteToNullifiersValue {
+  nullifierHash: string | null
+  noteIndex: number | null
+  spent: boolean
+}
+
+export class NoteToNullifiersValueEncoding implements IDatabaseEncoding<NoteToNullifiersValue> {
+  serialize(value: NoteToNullifiersValue): Buffer {
+    const { nullifierHash, noteIndex, spent } = value
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!nullifierHash) << 0
+    flags |= Number(!!noteIndex) << 1
+    flags |= Number(spent) << 2
+    bw.writeU8(flags)
+
+    if (nullifierHash) {
+      bw.writeHash(nullifierHash)
+    }
+    if (noteIndex) {
+      bw.writeU32(noteIndex)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): NoteToNullifiersValue {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const hasNullifierHash = flags & (1 << 0)
+    const hasNoteIndex = flags & (1 << 1)
+    const spent = Boolean(flags & (1 << 2))
+
+    let nullifierHash = null
+    if (hasNullifierHash) {
+      nullifierHash = reader.readHash('hex')
+    }
+
+    let noteIndex = null
+    if (hasNoteIndex) {
+      noteIndex = reader.readU32()
+    }
+
+    return { nullifierHash, noteIndex, spent }
+  }
+
+  getSize(value: NoteToNullifiersValue): number {
+    let size = 1
+    if (value.nullifierHash) {
+      size += 32
+    }
+    if (value.noteIndex) {
+      size += 4
+    }
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/new/nullifierToNoteHash.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/nullifierToNoteHash.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { IDatabaseStore } from '../../../../storage'
+
+export type NullifierToNoteHashStore = IDatabaseStore<{ key: string; value: string }>

--- a/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  BigIntLEEncoding,
+  BUFFER_ENCODING,
+  IDatabase,
+  NullableStringEncoding,
+  StringEncoding,
+  StringHashEncoding,
+} from '../../../../storage'
+import { AccountsStore, AccountsValue, AccountsValueEncoding } from './accounts'
+import { BalancesStore } from './balances'
+import { DecryptedNotesStore, DecryptedNotesValueEncoding } from './decryptedNotes'
+import { HeadHashesStore } from './headHashes'
+import { AccountsDBMeta, MetaStore, MetaValueEncoding } from './meta'
+import { NullifierToNoteHashStore } from './nullifierToNoteHash'
+import { TransactionsStore, TransactionsValueEncoding } from './transactions'
+
+export type NewStores = {
+  meta: MetaStore
+  accounts: AccountsStore
+  nullifierToNoteHash: NullifierToNoteHashStore
+  transactions: TransactionsStore
+  headHashes: HeadHashesStore
+  decryptedNotes: DecryptedNotesStore
+  balances: BalancesStore
+}
+
+export function loadNewStores(db: IDatabase): NewStores {
+  const meta: MetaStore = db.addStore(
+    {
+      name: 'meta',
+      keyEncoding: new StringEncoding<keyof AccountsDBMeta>(),
+      valueEncoding: new MetaValueEncoding(),
+    },
+    false,
+  )
+
+  const headHashes: HeadHashesStore = db.addStore(
+    {
+      name: 'headHashes',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new NullableStringEncoding(),
+    },
+    false,
+  )
+
+  const accounts: AccountsStore = db.addStore<{ key: string; value: AccountsValue }>(
+    {
+      name: 'accounts',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountsValueEncoding(),
+    },
+    false,
+  )
+
+  const balances: BalancesStore = db.addStore<{ key: string; value: bigint }>(
+    {
+      name: 'balances',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new BigIntLEEncoding(),
+    },
+    false,
+  )
+
+  const decryptedNotes: DecryptedNotesStore = db.addStore(
+    {
+      name: 'decryptedNotes',
+      keyEncoding: new StringHashEncoding(),
+      valueEncoding: new DecryptedNotesValueEncoding(),
+    },
+    false,
+  )
+
+  const nullifierToNoteHash: NullifierToNoteHashStore = db.addStore(
+    {
+      name: 'nullifierToNoteHash',
+      keyEncoding: new StringHashEncoding(),
+      valueEncoding: new StringEncoding(),
+    },
+    false,
+  )
+
+  const transactions: TransactionsStore = db.addStore(
+    {
+      name: 'transactions',
+      keyEncoding: BUFFER_ENCODING,
+      valueEncoding: new TransactionsValueEncoding(),
+    },
+    false,
+  )
+
+  return {
+    meta,
+    decryptedNotes,
+    headHashes,
+    balances,
+    nullifierToNoteHash,
+    accounts,
+    transactions,
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/new/transactions.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/transactions.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
+
+export type TransactionsStore = IDatabaseStore<{
+  key: Buffer
+  value: TransactionsValue
+}>
+
+export interface TransactionsValue {
+  transaction: Buffer
+  blockHash: string | null
+  submittedSequence: number | null
+}
+
+export class TransactionsValueEncoding implements IDatabaseEncoding<TransactionsValue> {
+  serialize(value: TransactionsValue): Buffer {
+    const { transaction, blockHash, submittedSequence } = value
+    const bw = bufio.write(this.getSize(value))
+    bw.writeVarBytes(transaction)
+
+    let flags = 0
+    flags |= Number(!!blockHash) << 0
+    flags |= Number(!!submittedSequence) << 1
+    bw.writeU8(flags)
+
+    if (blockHash) {
+      bw.writeHash(blockHash)
+    }
+    if (submittedSequence) {
+      bw.writeU32(submittedSequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): TransactionsValue {
+    const reader = bufio.read(buffer, true)
+    const transaction = reader.readVarBytes()
+
+    const flags = reader.readU8()
+    const hasBlockHash = flags & (1 << 0)
+    const hasSubmittedSequence = flags & (1 << 1)
+
+    let blockHash = null
+    if (hasBlockHash) {
+      blockHash = reader.readHash('hex')
+    }
+
+    let submittedSequence = null
+    if (hasSubmittedSequence) {
+      submittedSequence = reader.readU32()
+    }
+
+    return { transaction, blockHash, submittedSequence }
+  }
+
+  getSize(value: TransactionsValue): number {
+    let size = bufio.sizeVarBytes(value.transaction)
+    size += 1
+    if (value.blockHash) {
+      size += 32
+    }
+    if (value.submittedSequence) {
+      size += 4
+    }
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/old/accounts.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/old/accounts.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
+
+const KEY_LENGTH = 32
+const PUBLIC_ADDRESS_LENGTH = 43
+
+export type AccountsStore = IDatabaseStore<{ key: string; value: AccountsValue }>
+
+export interface AccountsValue {
+  name: string
+  spendingKey: string
+  incomingViewKey: string
+  outgoingViewKey: string
+  publicAddress: string
+  rescan: number | null
+}
+
+export class AccountsValueEncoding implements IDatabaseEncoding<AccountsValue> {
+  serialize(value: AccountsValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    bw.writeVarString(value.name, 'utf8')
+    bw.writeBytes(Buffer.from(value.spendingKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
+
+    if (value.rescan) {
+      bw.writeU8(value.rescan)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): AccountsValue {
+    const reader = bufio.read(buffer, true)
+    const name = reader.readVarString('utf8')
+    const spendingKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+
+    let rescan = null
+    if (reader.left()) {
+      rescan = reader.readU8()
+    }
+
+    return {
+      name,
+      spendingKey,
+      incomingViewKey,
+      outgoingViewKey,
+      publicAddress,
+      rescan,
+    }
+  }
+
+  getSize(value: AccountsValue): number {
+    let size = bufio.sizeVarString(value.name, 'utf8')
+    size += KEY_LENGTH
+    size += KEY_LENGTH
+    size += KEY_LENGTH
+    size += PUBLIC_ADDRESS_LENGTH
+
+    if (value.rescan) {
+      size += 1
+    }
+
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/old/headers.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/old/headers.ts
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { IDatabaseEncoding } from '../../../../storage/database/types'
+import bufio from 'bufio'
+import { Assert } from '../../../../assert'
+import { BlockHeader } from '../../../../primitives/blockheader'
+import { Target } from '../../../../primitives/target'
+import { IDatabaseStore } from '../../../../storage'
+import { BigIntUtils } from '../../../../utils/bigint'
+
+export type HeadersStore = IDatabaseStore<{ key: Buffer; value: HeaderValue }>
+
+export type HeaderValue = {
+  header: BlockHeader
+}
+
+export class HeaderEncoding implements IDatabaseEncoding<HeaderValue> {
+  serialize(value: HeaderValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    bw.writeU32(value.header.sequence)
+    bw.writeHash(value.header.previousBlockHash)
+    bw.writeHash(value.header.noteCommitment.commitment)
+    bw.writeU32(value.header.noteCommitment.size)
+    bw.writeHash(value.header.nullifierCommitment.commitment)
+    bw.writeU32(value.header.nullifierCommitment.size)
+    bw.writeBytes(BigIntUtils.toBytesLE(value.header.target.asBigInt(), 32))
+    bw.writeBytes(BigIntUtils.toBytesLE(value.header.randomness, 8))
+    bw.writeU64(value.header.timestamp.getTime())
+
+    Assert.isTrue(value.header.minersFee <= 0)
+    bw.writeBytes(BigIntUtils.toBytesLE(-value.header.minersFee, 8))
+
+    bw.writeBytes(value.header.graffiti)
+    bw.writeVarBytes(BigIntUtils.toBytesLE(value.header.work))
+    bw.writeHash(value.header.hash)
+
+    return bw.render()
+  }
+
+  deserialize(data: Buffer): HeaderValue {
+    const reader = bufio.read(data, true)
+
+    const sequence = reader.readU32()
+    const previousBlockHash = reader.readHash()
+    const noteCommitment = reader.readHash()
+    const noteCommitmentSize = reader.readU32()
+    const nullifierCommitment = reader.readHash()
+    const nullifierCommitmentSize = reader.readU32()
+    const target = new Target(BigIntUtils.fromBytesLE(reader.readBytes(32)))
+    const randomness = BigIntUtils.fromBytesLE(reader.readBytes(8))
+    const timestamp = reader.readU64()
+    const minersFee = -BigIntUtils.fromBytesLE(reader.readBytes(8))
+    const graffiti = reader.readBytes(32)
+    const work = BigIntUtils.fromBytesLE(reader.readVarBytes())
+    const hash = reader.readHash()
+
+    const header = new BlockHeader(
+      sequence,
+      previousBlockHash,
+      {
+        commitment: noteCommitment,
+        size: noteCommitmentSize,
+      },
+      {
+        commitment: nullifierCommitment,
+        size: nullifierCommitmentSize,
+      },
+      target,
+      randomness,
+      new Date(timestamp),
+      minersFee,
+      graffiti,
+      work,
+      hash,
+    )
+
+    return { header }
+  }
+
+  getSize(value: HeaderValue): number {
+    let size = 0
+    size += 4 // sequence
+    size += 32 // previousBlockHash
+    size += 32 // noteCommitment.commitment
+    size += 4 // noteCommitment.size
+    size += 32 // nullifierCommitment.commitment
+    size += 4 // nullifierCommitment.size
+    size += 32 // target
+    size += 8 // randomness
+    size += 8 // timestamp
+    size += 8 // minersFee
+    size += 32 // graffiti
+    size += bufio.sizeVarBytes(BigIntUtils.toBytesLE(value.header.work))
+    size += 32 // hash
+
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/old/meta.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/old/meta.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
+
+export type MetaStore = IDatabaseStore<{
+  key: keyof AccountsDBMeta
+  value: AccountsDBMeta[keyof AccountsDBMeta]
+}>
+
+export type AccountsDBMeta = {
+  defaultAccountName: string | null
+  headHash: string | null
+}
+
+export type MetaValue = AccountsDBMeta[keyof AccountsDBMeta]
+
+export class MetaValueEncoding implements IDatabaseEncoding<MetaValue> {
+  serialize(value: MetaValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    if (value) {
+      bw.writeVarString(value, 'utf8')
+    }
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): MetaValue {
+    const reader = bufio.read(buffer, true)
+    if (reader.left()) {
+      return reader.readVarString('utf8')
+    }
+    return null
+  }
+
+  getSize(value: MetaValue): number {
+    if (!value) {
+      return 0
+    }
+    return bufio.sizeVarString(value, 'utf8')
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/old/noteToNullifier.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/old/noteToNullifier.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
+
+export type NoteToNullifierStore = IDatabaseStore<{
+  key: string
+  value: NoteToNullifiersValue
+}>
+
+export interface NoteToNullifiersValue {
+  nullifierHash: string | null
+  noteIndex: number | null
+  spent: boolean
+}
+
+export class NoteToNullifiersValueEncoding implements IDatabaseEncoding<NoteToNullifiersValue> {
+  serialize(value: NoteToNullifiersValue): Buffer {
+    const { nullifierHash, noteIndex, spent } = value
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!nullifierHash) << 0
+    flags |= Number(!!noteIndex) << 1
+    flags |= Number(spent) << 2
+    bw.writeU8(flags)
+
+    if (nullifierHash) {
+      bw.writeHash(nullifierHash)
+    }
+    if (noteIndex) {
+      bw.writeU32(noteIndex)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): NoteToNullifiersValue {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const hasNullifierHash = flags & (1 << 0)
+    const hasNoteIndex = flags & (1 << 1)
+    const spent = Boolean(flags & (1 << 2))
+
+    let nullifierHash = null
+    if (hasNullifierHash) {
+      nullifierHash = reader.readHash('hex')
+    }
+
+    let noteIndex = null
+    if (hasNoteIndex) {
+      noteIndex = reader.readU32()
+    }
+
+    return { nullifierHash, noteIndex, spent }
+  }
+
+  getSize(value: NoteToNullifiersValue): number {
+    let size = 1
+    if (value.nullifierHash) {
+      size += 32
+    }
+    if (value.noteIndex) {
+      size += 4
+    }
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/old/nullifierToNote.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/old/nullifierToNote.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { IDatabaseStore } from '../../../../storage'
+
+export type NullifierToNoteStore = IDatabaseStore<{ key: string; value: string }>

--- a/ironfish/src/migrations/data/013-wallet-2/old/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/old/stores.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  BUFFER_ENCODING,
+  IDatabase,
+  StringEncoding,
+  StringHashEncoding,
+} from '../../../../storage'
+import { AccountsStore, AccountsValueEncoding } from './accounts'
+import { AccountsDBMeta, MetaStore, MetaValueEncoding } from './meta'
+import { NoteToNullifierStore, NoteToNullifiersValueEncoding } from './noteToNullifier'
+import { NullifierToNoteStore } from './nullifierToNote'
+import { TransactionsStore, TransactionsValueEncoding } from './transactions'
+
+export type OldStores = {
+  meta: MetaStore
+  accounts: AccountsStore
+  noteToNullifier: NoteToNullifierStore
+  nullifierToNote: NullifierToNoteStore
+  transactions: TransactionsStore
+}
+
+export function loadOldStores(db: IDatabase): OldStores {
+  const meta: MetaStore = db.addStore(
+    {
+      name: 'meta',
+      keyEncoding: new StringEncoding<keyof AccountsDBMeta>(),
+      valueEncoding: new MetaValueEncoding(),
+    },
+    false,
+  )
+
+  const accounts: AccountsStore = db.addStore(
+    {
+      name: 'accounts',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountsValueEncoding(),
+    },
+    false,
+  )
+
+  const noteToNullifier: NoteToNullifierStore = db.addStore(
+    {
+      name: 'noteToNullifier',
+      keyEncoding: new StringHashEncoding(),
+      valueEncoding: new NoteToNullifiersValueEncoding(),
+    },
+    false,
+  )
+
+  const nullifierToNote: NullifierToNoteStore = db.addStore(
+    {
+      name: 'nullifierToNote',
+      keyEncoding: new StringHashEncoding(),
+      valueEncoding: new StringEncoding(),
+    },
+    false,
+  )
+
+  const transactions: TransactionsStore = db.addStore(
+    {
+      name: 'transactions',
+      keyEncoding: BUFFER_ENCODING,
+      valueEncoding: new TransactionsValueEncoding(),
+    },
+    false,
+  )
+
+  return { meta, accounts, noteToNullifier, nullifierToNote, transactions }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/old/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/old/stores.ts
@@ -24,7 +24,7 @@ export type OldStores = {
   headers: HeadersStore
 }
 
-export function loadOldStores(db: IDatabase): OldStores {
+export function loadOldStores(db: IDatabase, chainDb: IDatabase): OldStores {
   const meta: MetaStore = db.addStore(
     {
       name: 'meta',
@@ -70,11 +70,14 @@ export function loadOldStores(db: IDatabase): OldStores {
     false,
   )
 
-  const headers: HeadersStore = db.addStore({
-    name: 'bh',
-    keyEncoding: BUFFER_ENCODING,
-    valueEncoding: new HeaderEncoding(),
-  })
+  const headers: HeadersStore = chainDb.addStore(
+    {
+      name: 'bh',
+      keyEncoding: BUFFER_ENCODING,
+      valueEncoding: new HeaderEncoding(),
+    },
+    false,
+  )
 
   return { meta, accounts, noteToNullifier, nullifierToNote, transactions, headers }
 }

--- a/ironfish/src/migrations/data/013-wallet-2/old/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/old/stores.ts
@@ -9,6 +9,7 @@ import {
   StringHashEncoding,
 } from '../../../../storage'
 import { AccountsStore, AccountsValueEncoding } from './accounts'
+import { HeaderEncoding, HeadersStore } from './headers'
 import { AccountsDBMeta, MetaStore, MetaValueEncoding } from './meta'
 import { NoteToNullifierStore, NoteToNullifiersValueEncoding } from './noteToNullifier'
 import { NullifierToNoteStore } from './nullifierToNote'
@@ -20,6 +21,7 @@ export type OldStores = {
   noteToNullifier: NoteToNullifierStore
   nullifierToNote: NullifierToNoteStore
   transactions: TransactionsStore
+  headers: HeadersStore
 }
 
 export function loadOldStores(db: IDatabase): OldStores {
@@ -68,5 +70,11 @@ export function loadOldStores(db: IDatabase): OldStores {
     false,
   )
 
-  return { meta, accounts, noteToNullifier, nullifierToNote, transactions }
+  const headers: HeadersStore = db.addStore({
+    name: 'bh',
+    keyEncoding: BUFFER_ENCODING,
+    valueEncoding: new HeaderEncoding(),
+  })
+
+  return { meta, accounts, noteToNullifier, nullifierToNote, transactions, headers }
 }

--- a/ironfish/src/migrations/data/013-wallet-2/old/transactions.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/old/transactions.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseStore } from '../../../../storage'
+import { IDatabaseEncoding } from '../../../../storage/database/types'
+
+export type TransactionsStore = IDatabaseStore<{
+  key: Buffer
+  value: TransactionsValue
+}>
+
+export interface TransactionsValue {
+  transaction: Buffer
+  blockHash: string | null
+  submittedSequence: number | null
+}
+
+export class TransactionsValueEncoding implements IDatabaseEncoding<TransactionsValue> {
+  serialize(value: TransactionsValue): Buffer {
+    const { transaction, blockHash, submittedSequence } = value
+    const bw = bufio.write(this.getSize(value))
+    bw.writeVarBytes(transaction)
+
+    let flags = 0
+    flags |= Number(!!blockHash) << 0
+    flags |= Number(!!submittedSequence) << 1
+    bw.writeU8(flags)
+
+    if (blockHash) {
+      bw.writeHash(blockHash)
+    }
+    if (submittedSequence) {
+      bw.writeU32(submittedSequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): TransactionsValue {
+    const reader = bufio.read(buffer, true)
+    const transaction = reader.readVarBytes()
+
+    const flags = reader.readU8()
+    const hasBlockHash = flags & (1 << 0)
+    const hasSubmittedSequence = flags & (1 << 1)
+
+    let blockHash = null
+    if (hasBlockHash) {
+      blockHash = reader.readHash('hex')
+    }
+
+    let submittedSequence = null
+    if (hasSubmittedSequence) {
+      submittedSequence = reader.readU32()
+    }
+
+    return { transaction, blockHash, submittedSequence }
+  }
+
+  getSize(value: TransactionsValue): number {
+    let size = bufio.sizeVarBytes(value.transaction)
+    size += 1
+    if (value.blockHash) {
+      size += 32
+    }
+    if (value.submittedSequence) {
+      size += 4
+    }
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/013-wallet-2/readme.md
+++ b/ironfish/src/migrations/data/013-wallet-2/readme.md
@@ -1,167 +1,56 @@
-## Old Stores
-
-### meta
-  - key:
-    - type: defaultAccountName | headHash
-    - encoder: StringEncoding
-  - value
-    - type: string | null
-    - encoder: MetaValueEncoding
-
-### noteToNullifier
-  - key:
-    - type: string
-    - encoder: StringEncoding
-  - value
-    - type:
-        ```
-        {
-            nullifierHash: string | null
-            noteIndex: number | null
-            spent: boolean
-        }
-        ```
-    - encoder: NoteToNullifiersValueEncoding
-
-### nullifierToNote
-  - key:
-    - type: string
-    - encoder: StringEncoding
-  - value
-    - type: string
-    - encoder: StringEncoding
-
-### accounts
-  - key:
-    - type: string
-    - encoder: StringEncoding
-  - value
-    - type:
-      ```
-      {
-            name: string
-            spendingKey: string
-            incomingViewKey: string
-            outgoingViewKey: string
-            publicAddress: string
-            rescan: number | null
-      }
-      ```
-    - encoder: AccountsValueEncoding
-
-## Removed Stores
- * nullifierToNote
- * noteToNullifier
-
-## Changed Stores
-
-### meta
-  - key:
-    - type: defaultAccountId
-    - encoder: StringEncoding
-  - value
-    - type: string | null
-    - encoder: MetaValueEncoding
-  - notes
-    - Added defaultAccountId
-    - Removed defaultAccountName
-    - Removed headHash
-
-### transactions
-  - key:
-    - type: Buffer
-    - encoder: BufferEncoding
-  - value
-    - type:
-        ```
-        {
-            transaction: Buffer
-            blockHash: string | null
-            submittedSequence: number | null
-        }
-        ```
-    - encoder: TransactionsValueEncoding
-    - notes
-      - Added sequence which is the sequence on the chain or null similar to blockHash
-
-## accounts
-  - key:
-    - type: string
-    - encoder: StringEncoding
-  - value
-    - type:
-      ```
-      {
-          name: string
-          spendingKey: string
-          incomingViewKey: string
-          outgoingViewKey: string
-          publicAddress: string
-      }
-      ```
-    - encoder: AccountsValueEncoding
-  - notes
-    - Removed rescan
-    - Key changed from account name to account id
-
-## New Stores
-
-### nullifierToNoteHash
-  - key:
-    - type: string
-    - encoder: StringHashEncoding
-  - value
-    - type: string
-    - encoder StringEncoding
-
-### headHashes
-  - key:
-    - type: string
-    - encoder: StringEncoding
-  - value
-    - type: string | null
-    - encoder: NullableStringEncoding
-  - notes
-    - This is a map of account id to the blockchain block hash as a hex string that account is updated to.
-
-### balances
-  - key:
-    - type: string
-    - encoder: StringEncoding
-  - value
-    - type: bigint
-    - encoder: BigIntLEEncoding
-  - notes
-    - This is a map of account id to the unconfirmed balance
-
-### decryptedNotes
-  - key:
-    - type: string
-    - encoder: StringHashEncoding
-  - value
-    - type:
-      ```
-      {
-          accountId: string
-          noteIndex: number | null
-          nullifierHash: string | null
-          serializedNote: Buffer
-          spent: boolean
-          transactionHash: Buffer
-      }
-      ```
-    - encoder: DecryptedNotesValueEncoding
-  - notes
-    - This is a collection of all decrypted notes, this used to be `noteToNullifier`
-
 # Summary
-  1. Loop through `noteToNullifier`
-        1. Attempt to decrypt notes to figure out the account ID
-            1. Index into decryptedNotes using above info
-            1. Keep track of unconfirmed balances for each account
-  1. Use unconfirmed balances to index into new `balances` store
-  1. Index new headHashes store for each account using Meta.headHash
-  1. Index accounts by id from old names
-        1. Unindex accounts by name from accounts store
-  1. Delete noteToNullifier
-  1. Delete Meta.headHash
+  - **Changed Stores**
+    - meta
+      - Added defaultAccountId
+      - Removed defaultAccountName
+      - Removed headHash
+    - transactions
+      - Added field `sequence` which is the sequence on the chain or null
+    - accounts
+      - Removed field `rescan`
+      - Added a new field `id` which is a uuid()
+      - Key changed from field `name` to field `id`
+  - **New Stores**
+    - decryptedNotes
+      - This new store represents notes the wallet is able to decrypt. The information in this store came from the old `noteToNullifier`, with new fields that need to be calculated. Most of the migration is calculating this new store. We'll need to redecrypt the note from `noteToNullifier` to figure out which account this comes from.
+    - balance
+      - This is a map of values from the store `accounts.id`, to the unconfirmed balance of that account. Unconfirmed balance is the total of all notes regardless of chain status. This contains the new materialized balance optimization.
+    - headHashes
+      - This is a map of `accounts.id` to the blockchain block hash as a hex string that the account is updated to.
+    - nullifierToNoteHash
+      - This is a map of `decrypytedNotes.nullifierHash` to `note.merkleHash()` in hex form
+      - This replaces the old store `nullifierToNote`
+  - **Deleted Stores**
+    - nullifierToNote
+      - Replaced with nullifierToNoteHash
+    - noteToNullifier
+      - Replaced with decryptedNotes
+
+# Strategy
+  1. Build a map from note hash to transaction hash
+    - The new wallet tracks which transaction a note from but the old wallet doesn't. We need this to quickly figure out which transaction to find the note in.
+  1. Migrate Accounts
+    1. Loop through `accounts`
+      - Generate ids and write them
+      - Index accounts by id from old names
+      - Unindex accounts by name from accounts store
+  1. Migrate `decryptedNotes`
+    1. Loop through `noteToNullifier`
+          1. Attempt to decrypt notes in the TX found using the map from step 1 to figure out the account ID, and transaction hash for the note
+              1. Add a new decryptedNotes for each noteToNullifier value using above info
+              1. Keep track of unconfirmed balances for each account
+  1. Migrate `balances`
+    1. Use unconfirmed balances calculated from migrating decrypted notes to index into new `balances` store
+  1. Migrate `headHashes`
+    1. Index new headHashes store for each account using Meta.headHash
+  1. Migrate `meta`
+  1. Delete store `noteToNullifier`
+  1. Delete store `nullifierToNote`
+
+# Potential issues:
+  - What happens if we cant decrypt a note?
+    - We drop it.
+    - Probably was decrypted previously with an account that hasd been since removed.
+    - Worse case they can rescan
+  - Could there be memory issues?
+    - Yes, we load all transactions, notes, and nullifier into memory during the migration and don't unload them until the migration has finished.

--- a/ironfish/src/migrations/data/013-wallet-2/readme.md
+++ b/ironfish/src/migrations/data/013-wallet-2/readme.md
@@ -50,7 +50,7 @@
 # Potential issues:
   - What happens if we can't decrypt a note?
     - We drop it.
-    - Probably was decrypted previously with an account that hasd been since removed.
+    - Probably was decrypted previously with an account that has been since removed.
     - Worse case they can rescan
   - Could there be memory issues?
     - Yes, we load all transactions, notes, and nullifier into memory during the migration and don't unload them until the migration has finished.

--- a/ironfish/src/migrations/data/013-wallet-2/readme.md
+++ b/ironfish/src/migrations/data/013-wallet-2/readme.md
@@ -1,0 +1,167 @@
+## Old Stores
+
+### meta
+  - key:
+    - type: defaultAccountName | headHash
+    - encoder: StringEncoding
+  - value
+    - type: string | null
+    - encoder: MetaValueEncoding
+
+### noteToNullifier
+  - key:
+    - type: string
+    - encoder: StringEncoding
+  - value
+    - type:
+        ```
+        {
+            nullifierHash: string | null
+            noteIndex: number | null
+            spent: boolean
+        }
+        ```
+    - encoder: NoteToNullifiersValueEncoding
+
+### nullifierToNote
+  - key:
+    - type: string
+    - encoder: StringEncoding
+  - value
+    - type: string
+    - encoder: StringEncoding
+
+### accounts
+  - key:
+    - type: string
+    - encoder: StringEncoding
+  - value
+    - type:
+      ```
+      {
+            name: string
+            spendingKey: string
+            incomingViewKey: string
+            outgoingViewKey: string
+            publicAddress: string
+            rescan: number | null
+      }
+      ```
+    - encoder: AccountsValueEncoding
+
+## Removed Stores
+ * nullifierToNote
+ * noteToNullifier
+
+## Changed Stores
+
+### meta
+  - key:
+    - type: defaultAccountId
+    - encoder: StringEncoding
+  - value
+    - type: string | null
+    - encoder: MetaValueEncoding
+  - notes
+    - Added defaultAccountId
+    - Removed defaultAccountName
+    - Removed headHash
+
+### transactions
+  - key:
+    - type: Buffer
+    - encoder: BufferEncoding
+  - value
+    - type:
+        ```
+        {
+            transaction: Buffer
+            blockHash: string | null
+            submittedSequence: number | null
+        }
+        ```
+    - encoder: TransactionsValueEncoding
+    - notes
+      - Added sequence which is the sequence on the chain or null similar to blockHash
+
+## accounts
+  - key:
+    - type: string
+    - encoder: StringEncoding
+  - value
+    - type:
+      ```
+      {
+          name: string
+          spendingKey: string
+          incomingViewKey: string
+          outgoingViewKey: string
+          publicAddress: string
+      }
+      ```
+    - encoder: AccountsValueEncoding
+  - notes
+    - Removed rescan
+    - Key changed from account name to account id
+
+## New Stores
+
+### nullifierToNoteHash
+  - key:
+    - type: string
+    - encoder: StringHashEncoding
+  - value
+    - type: string
+    - encoder StringEncoding
+
+### headHashes
+  - key:
+    - type: string
+    - encoder: StringEncoding
+  - value
+    - type: string | null
+    - encoder: NullableStringEncoding
+  - notes
+    - This is a map of account id to the blockchain block hash as a hex string that account is updated to.
+
+### balances
+  - key:
+    - type: string
+    - encoder: StringEncoding
+  - value
+    - type: bigint
+    - encoder: BigIntLEEncoding
+  - notes
+    - This is a map of account id to the unconfirmed balance
+
+### decryptedNotes
+  - key:
+    - type: string
+    - encoder: StringHashEncoding
+  - value
+    - type:
+      ```
+      {
+          accountId: string
+          noteIndex: number | null
+          nullifierHash: string | null
+          serializedNote: Buffer
+          spent: boolean
+          transactionHash: Buffer
+      }
+      ```
+    - encoder: DecryptedNotesValueEncoding
+  - notes
+    - This is a collection of all decrypted notes, this used to be `noteToNullifier`
+
+# Summary
+  1. Loop through `noteToNullifier`
+        1. Attempt to decrypt notes to figure out the account ID
+            1. Index into decryptedNotes using above info
+            1. Keep track of unconfirmed balances for each account
+  1. Use unconfirmed balances to index into new `balances` store
+  1. Index new headHashes store for each account using Meta.headHash
+  1. Index accounts by id from old names
+        1. Unindex accounts by name from accounts store
+  1. Delete noteToNullifier
+  1. Delete Meta.headHash

--- a/ironfish/src/migrations/data/013-wallet-2/readme.md
+++ b/ironfish/src/migrations/data/013-wallet-2/readme.md
@@ -48,7 +48,7 @@
   1. Delete store `nullifierToNote`
 
 # Potential issues:
-  - What happens if we cant decrypt a note?
+  - What happens if we can't decrypt a note?
     - We drop it.
     - Probably was decrypted previously with an account that hasd been since removed.
     - Worse case they can rescan

--- a/ironfish/src/migrations/data/013-wallet-2/readme.md
+++ b/ironfish/src/migrations/data/013-wallet-2/readme.md
@@ -51,6 +51,6 @@
   - What happens if we can't decrypt a note?
     - We drop it.
     - Probably was decrypted previously with an account that has been since removed.
-    - Worse case they can rescan
+    - Worst case they can rescan
   - Could there be memory issues?
     - Yes, we load all transactions, notes, and nullifier into memory during the migration and don't unload them until the migration has finished.

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -5,5 +5,6 @@
 import { Migration010 } from './010-blockchain'
 import { Migration011 } from './011-accounts'
 import { Migration012 } from './012-indexer'
+import { Migration013 } from './013-wallet-2'
 
-export const MIGRATIONS = [Migration010, Migration011, Migration012]
+export const MIGRATIONS = [Migration010, Migration011, Migration012, Migration013]


### PR DESCRIPTION
## Summary

This migration will upgrade the wallet schema from 11 to 13, and prevent needing a database reset.

The migration freezes the stores for version 11, and 13 into the data folder for migration for use by the migration. You need to freeze the stores, and cannot use the stores in the wallet because they could change with a new migration introduced after this.

I've outlined all of the changes occurring in this migration here, https://github.com/iron-fish/ironfish/blob/account-migration/ironfish/src/migrations/data/013-wallet-2/readme.md#summary

## Testing Plan

1. Run migration on a wallet and check the balance afterwards to see if it's the same
2. Check the migration has run on a wallet with multiple accounts, and that it works

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
