### PR TITLE
Show max heap sizes in debug command

### DIFF
--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -4,6 +4,7 @@
 import { DatabaseIsLockedError, FileUtils, IronfishNode, IronfishPKG } from '@ironfish/sdk'
 import { execSync } from 'child_process'
 import os from 'os'
+import { getHeapStatistics } from 'v8'
 import { IronfishCommand } from '../command'
 import { LocalFlags } from '../flags'
 
@@ -45,6 +46,7 @@ export default class Debug extends IronfishCommand {
     const cpuThreads = cpus.length
 
     const memTotal = FileUtils.formatMemorySize(os.totalmem())
+    const heapTotal = FileUtils.formatMemorySize(getHeapStatistics().total_available_size)
 
     const telemetryEnabled = this.sdk.config.get('enableTelemetry').toString()
 
@@ -63,6 +65,7 @@ export default class Debug extends IronfishCommand {
       ['CPU model(s)', `${cpuNames.toString()}`],
       ['CPU threads', `${cpuThreads}`],
       ['RAM total', `${memTotal}`],
+      ['Heap total', `${heapTotal}`],
       ['Node version', `${process.version}`],
       ['ironfish in PATH', `${cmdInPath.toString()}`],
       ['Telemetry enabled', `${telemetryEnabled}`],


### PR DESCRIPTION
## Summary

This will be helpful to debug out of memory issues and see if people
have increased this some how, or have less than expected.

New Output:
```
Iron Fish version       0.1.38 @ src
Iron Fish library       0.0.16 @ src
Operating system        Darwin arm64
CPU model(s)            Apple M1 Pro
CPU threads             10
RAM total               16.00 GiB
Heap total              4.01 GiB
Node version            v16.15.1
ironfish in PATH        true
Telemetry enabled       false
```

## Testing Plan

Run debug, no test needed.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
