### PR TITLE
Create GetCompactBlock request and response messages

### DIFF
--- a/ironfish/src/network/messageRegistry.ts
+++ b/ironfish/src/network/messageRegistry.ts
@@ -10,6 +10,7 @@ import {
   GetBlockTransactionsRequest,
   GetBlockTransactionsResponse,
 } from './messages/getBlockTransactions'
+import { GetCompactBlockRequest, GetCompactBlockResponse } from './messages/getCompactBlock'
 import { GossipNetworkMessage } from './messages/gossipNetworkMessage'
 import { IdentifyMessage } from './messages/identify'
 import { NetworkMessage } from './messages/networkMessage'
@@ -52,6 +53,8 @@ const isRpcNetworkMessageType = (type: NetworkMessageType): boolean => {
     NetworkMessageType.PooledTransactionsResponse,
     NetworkMessageType.GetBlockTransactionsRequest,
     NetworkMessageType.GetBlockTransactionsResponse,
+    NetworkMessageType.GetCompactBlockRequest,
+    NetworkMessageType.GetCompactBlockResponse,
   ].includes(type)
 }
 
@@ -84,6 +87,10 @@ const parseRpcNetworkMessage = (
       return GetBlockTransactionsRequest.deserialize(body, rpcId)
     case NetworkMessageType.GetBlockTransactionsResponse:
       return GetBlockTransactionsResponse.deserialize(body, rpcId)
+    case NetworkMessageType.GetCompactBlockRequest:
+      return GetCompactBlockRequest.deserialize(body, rpcId)
+    case NetworkMessageType.GetCompactBlockResponse:
+      return GetCompactBlockResponse.deserialize(body, rpcId)
     default:
       throw new Error(`Unknown RPC network message type: ${type}`)
   }

--- a/ironfish/src/network/messages/getCompactBlock.test.ts
+++ b/ironfish/src/network/messages/getCompactBlock.test.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { SerializedCompactBlock } from '../../primitives/block'
+import { GetCompactBlockRequest, GetCompactBlockResponse } from './getCompactBlock'
+
+describe('GetCompactBlockRequest', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const rpcId = 432
+    const hash = Buffer.alloc(32, 1)
+
+    const message = new GetCompactBlockRequest(hash, rpcId)
+    const buffer = message.serialize()
+    const deserializedMessage = GetCompactBlockRequest.deserialize(buffer, rpcId)
+
+    expect(deserializedMessage).toEqual(message)
+  })
+})
+
+describe('GetCompactBlockResponse', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const compactBlock: SerializedCompactBlock = {
+      header: {
+        graffiti: Buffer.alloc(32, 'graffiti1', 'utf8').toString('hex'),
+        minersFee: '0',
+        noteCommitment: {
+          commitment: Buffer.alloc(32, 1),
+          size: 1,
+        },
+        nullifierCommitment: {
+          commitment: Buffer.alloc(32, 2).toString('hex'),
+          size: 2,
+        },
+        previousBlockHash: Buffer.alloc(32, 2).toString('hex'),
+        randomness: '1',
+        sequence: 2,
+        target: '12',
+        timestamp: 200000,
+      },
+      transactions: [
+        { transaction: Buffer.from('foo'), index: 0 },
+        { transaction: Buffer.from('bar'), index: 2 },
+      ],
+      transactionHashes: [
+        Buffer.alloc(32, 'a'),
+        Buffer.alloc(32, 'b'),
+        Buffer.alloc(32, 'c'),
+        Buffer.alloc(32, 'd'),
+      ],
+    }
+    const rpcId = 432
+
+    const message = new GetCompactBlockResponse(compactBlock, rpcId)
+    const buffer = message.serialize()
+    const deserializedMessage = GetCompactBlockResponse.deserialize(buffer, rpcId)
+
+    expect(deserializedMessage).toEqual(message)
+  })
+})

--- a/ironfish/src/network/messages/getCompactBlock.ts
+++ b/ironfish/src/network/messages/getCompactBlock.ts
@@ -32,11 +32,7 @@ export class GetCompactBlockRequest extends RpcNetworkMessage {
   }
 
   getSize(): number {
-    let size = 0
-
-    size += 32
-
-    return size
+    return 32
   }
 }
 
@@ -65,10 +61,6 @@ export class GetCompactBlockResponse extends RpcNetworkMessage {
   }
 
   getSize(): number {
-    let size = 0
-
-    size += getCompactBlockSize(this.compactBlock)
-
-    return size
+    return getCompactBlockSize(this.compactBlock)
   }
 }

--- a/ironfish/src/network/messages/getCompactBlock.ts
+++ b/ironfish/src/network/messages/getCompactBlock.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { SerializedCompactBlock } from '../../primitives/block'
+import { NetworkMessageType } from '../types'
+import { getCompactBlockSize, readCompactBlock, writeCompactBlock } from '../utils/block'
+import { Direction, RpcNetworkMessage } from './rpcNetworkMessage'
+
+export class GetCompactBlockRequest extends RpcNetworkMessage {
+  readonly blockHash: Buffer
+
+  constructor(blockHash: Buffer, rpcId?: number) {
+    super(NetworkMessageType.GetCompactBlockRequest, Direction.Request, rpcId)
+    this.blockHash = blockHash
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+
+    bw.writeHash(this.blockHash)
+
+    return bw.render()
+  }
+
+  static deserialize(buffer: Buffer, rpcId: number): GetCompactBlockRequest {
+    const reader = bufio.read(buffer, true)
+
+    const blockHash = reader.readHash()
+
+    return new GetCompactBlockRequest(blockHash, rpcId)
+  }
+
+  getSize(): number {
+    let size = 0
+
+    size += 32
+
+    return size
+  }
+}
+
+export class GetCompactBlockResponse extends RpcNetworkMessage {
+  readonly compactBlock: SerializedCompactBlock
+
+  constructor(compactBlock: SerializedCompactBlock, rpcId: number) {
+    super(NetworkMessageType.GetCompactBlockResponse, Direction.Response, rpcId)
+    this.compactBlock = compactBlock
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+
+    writeCompactBlock(bw, this.compactBlock)
+
+    return bw.render()
+  }
+
+  static deserialize(buffer: Buffer, rpcId: number): GetCompactBlockResponse {
+    const reader = bufio.read(buffer, true)
+
+    const compactBlock = readCompactBlock(reader)
+
+    return new GetCompactBlockResponse(compactBlock, rpcId)
+  }
+
+  getSize(): number {
+    let size = 0
+
+    size += getCompactBlockSize(this.compactBlock)
+
+    return size
+  }
+}

--- a/ironfish/src/network/messages/newBlockV2.ts
+++ b/ironfish/src/network/messages/newBlockV2.ts
@@ -32,10 +32,6 @@ export class NewBlockV2Message extends NetworkMessage {
   }
 
   getSize(): number {
-    let size = 0
-
-    size += getCompactBlockSize(this.compactBlock)
-
-    return size
+    return getCompactBlockSize(this.compactBlock)
   }
 }

--- a/ironfish/src/network/messages/newBlockV2.ts
+++ b/ironfish/src/network/messages/newBlockV2.ts
@@ -1,10 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import bufio, { sizeVarBytes, sizeVarint } from 'bufio'
-import { CompactBlockTransaction, SerializedCompactBlock } from '../../primitives/block'
+import bufio from 'bufio'
+import { SerializedCompactBlock } from '../../primitives/block'
 import { NetworkMessageType } from '../types'
-import { getBlockHeaderSize, readBlockHeader, writeBlockHeader } from '../utils/block'
+import { getCompactBlockSize, readCompactBlock, writeCompactBlock } from '../utils/block'
 import { NetworkMessage } from './networkMessage'
 
 export class NewBlockV2Message extends NetworkMessage {
@@ -18,18 +18,7 @@ export class NewBlockV2Message extends NetworkMessage {
   serialize(): Buffer {
     const bw = bufio.write(this.getSize())
 
-    writeBlockHeader(bw, this.compactBlock.header)
-
-    bw.writeVarint(this.compactBlock.transactionHashes.length)
-    for (const transactionHash of this.compactBlock.transactionHashes) {
-      bw.writeHash(transactionHash)
-    }
-
-    bw.writeVarint(this.compactBlock.transactions.length)
-    for (const transaction of this.compactBlock.transactions) {
-      bw.writeVarint(transaction.index)
-      bw.writeVarBytes(transaction.transaction)
-    }
+    writeCompactBlock(bw, this.compactBlock)
 
     return bw.render()
   }
@@ -37,28 +26,7 @@ export class NewBlockV2Message extends NetworkMessage {
   static deserialize(buffer: Buffer): NewBlockV2Message {
     const reader = bufio.read(buffer, true)
 
-    const header = readBlockHeader(reader)
-
-    const transactionHashes: Buffer[] = []
-    const transactionHashesLength = reader.readVarint()
-    for (let i = 0; i < transactionHashesLength; i++) {
-      const transactionHash = reader.readHash()
-      transactionHashes.push(transactionHash)
-    }
-
-    const transactions: CompactBlockTransaction[] = []
-    const transactionsLength = reader.readVarint()
-    for (let i = 0; i < transactionsLength; i++) {
-      const index = reader.readVarint()
-      const transaction = reader.readVarBytes()
-      transactions.push({ index, transaction })
-    }
-
-    const compactBlock: SerializedCompactBlock = {
-      header,
-      transactionHashes,
-      transactions,
-    }
+    const compactBlock = readCompactBlock(reader)
 
     return new NewBlockV2Message(compactBlock)
   }
@@ -66,16 +34,7 @@ export class NewBlockV2Message extends NetworkMessage {
   getSize(): number {
     let size = 0
 
-    size += getBlockHeaderSize()
-
-    size += sizeVarint(this.compactBlock.transactionHashes.length)
-    size += 32 * this.compactBlock.transactionHashes.length
-
-    size += sizeVarint(this.compactBlock.transactions.length)
-    for (const transaction of this.compactBlock.transactions) {
-      size += sizeVarint(transaction.index)
-      size += sizeVarBytes(transaction.transaction)
-    }
+    size += getCompactBlockSize(this.compactBlock)
 
     return size
   }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -30,6 +30,7 @@ import {
   GetBlockTransactionsRequest,
   GetBlockTransactionsResponse,
 } from './messages/getBlockTransactions'
+import { GetCompactBlockRequest, GetCompactBlockResponse } from './messages/getCompactBlock'
 import { GossipNetworkMessage } from './messages/gossipNetworkMessage'
 import {
   displayNetworkMessageType,
@@ -565,6 +566,8 @@ export class PeerNetwork {
           responseMessage = this.onPooledTransactionsRequest(rpcMessage, rpcId)
         } else if (rpcMessage instanceof GetBlockTransactionsRequest) {
           responseMessage = await this.onGetBlockTransactionsRequest(peer, rpcMessage)
+        } else if (rpcMessage instanceof GetCompactBlockRequest) {
+          responseMessage = this.onGetCompactBlockRequest()
         } else {
           throw new Error(`Invalid rpc message type: '${rpcMessage.type}'`)
         }
@@ -789,6 +792,11 @@ export class PeerNetwork {
     }
 
     return new GetBlockTransactionsResponse(message.blockHash, transactions, message.rpcId)
+  }
+
+  private onGetCompactBlockRequest(): GetCompactBlockResponse {
+    // TODO(IRO-2317): Implement a handler for compact block requests
+    throw new CannotSatisfyRequestError('Compact block requests are not yet supported.')
   }
 
   private async onNewBlock(message: IncomingPeerMessage<NewBlockMessage>): Promise<boolean> {

--- a/ironfish/src/network/types.ts
+++ b/ironfish/src/network/types.ts
@@ -26,6 +26,8 @@ export enum NetworkMessageType {
   NewBlockV2 = 18,
   GetBlockTransactionsRequest = 19,
   GetBlockTransactionsResponse = 20,
+  GetCompactBlockRequest = 21,
+  GetCompactBlockResponse = 22,
 }
 
 export type IsomorphicWebSocketConstructor = typeof WebSocket | typeof WSWebSocket


### PR DESCRIPTION
## Summary

Adds a GetCompactBlock RPC message for the new block propagation model. The handlers will come in future PRs.

Fixes IRO-2315
Fixes IRO-2316

## Testing Plan

Added tests for the messages.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
