### PR TITLE
Add nodeName and blockGraffiti to status and debug command

### DIFF
--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -50,6 +50,9 @@ export default class Debug extends IronfishCommand {
 
     const telemetryEnabled = this.sdk.config.get('enableTelemetry').toString()
 
+    const nodeName = this.sdk.config.get('nodeName').toString()
+    const blockGraffiti = this.sdk.config.get('blockGraffiti').toString()
+
     let cmdInPath: boolean
     try {
       execSync('ironfish --help', { stdio: 'ignore' })
@@ -69,6 +72,8 @@ export default class Debug extends IronfishCommand {
       ['Node version', `${process.version}`],
       ['ironfish in PATH', `${cmdInPath.toString()}`],
       ['Telemetry enabled', `${telemetryEnabled}`],
+      ['Node Name', `${nodeName ? nodeName : 'NONE'}`],
+      ['Block Graffiti', `${blockGraffiti ? blockGraffiti : 'NONE'}`],
     ])
   }
 

--- a/ironfish-cli/src/commands/status.test.ts
+++ b/ironfish-cli/src/commands/status.test.ts
@@ -15,6 +15,7 @@ describe('status', () => {
       status: 'started',
       version: '0.0.0',
       git: 'src',
+      nodeName: 'my node',
     },
     memory: {
       heapMax: 5,
@@ -24,7 +25,7 @@ describe('status', () => {
       memFree: 4,
       memTotal: 10,
     },
-    miningDirector: { status: 'started', miners: 0, blocks: 0 },
+    miningDirector: { status: 'started', miners: 0, blocks: 0, blockGraffiti: 'my graffiti' },
     memPool: { size: 0 },
     blockSyncer: { status: 'stopped', syncing: { blockSpeed: 0, speed: 0, progress: 0 } },
     telemetry: { status: 'stopped', pending: 0, submitted: 0 },
@@ -74,6 +75,8 @@ describe('status', () => {
       .it('logs out data for the chain, node, mempool, and syncer', (ctx) => {
         expectCli(ctx.stdout).include('Version')
         expectCli(ctx.stdout).include('Node')
+        expectCli(ctx.stdout).include('Node Name')
+        expectCli(ctx.stdout).include('Block Graffiti')
         expectCli(ctx.stdout).include('Memory')
         expectCli(ctx.stdout).include('P2P Network')
         expectCli(ctx.stdout).include('Mining')

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -92,6 +92,12 @@ function renderStatus(content: GetStatusResponse): string {
     telemetryStatus += ` - ${content.telemetry.submitted} <- ${content.telemetry.pending} pending`
   }
 
+  const nodeName = `${content.node.nodeName ? content.node.nodeName : 'NONE'}`
+
+  const blockGraffiti = `${
+    content.miningDirector.blockGraffiti ? content.miningDirector.blockGraffiti : 'NONE'
+  }`
+
   const peerNetworkStatus = `${
     content.peerNetwork.isReady ? 'CONNECTED' : 'WAITING'
   } - In: ${FileUtils.formatFileSize(
@@ -135,6 +141,8 @@ function renderStatus(content: GetStatusResponse): string {
   return `
 Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
+Node Name            ${nodeName}
+Block Graffiti       ${blockGraffiti}
 Memory               ${memoryStatus}
 P2P Network          ${peerNetworkStatus}
 Mining               ${miningDirectorStatus}

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -17,6 +17,7 @@ export type GetStatusResponse = {
     status: 'started' | 'stopped' | 'error'
     version: string
     git: string
+    nodeName?: string
   }
   memory: {
     heapMax: number
@@ -30,6 +31,7 @@ export type GetStatusResponse = {
     status: 'started'
     miners: number
     blocks: number
+    blockGraffiti?: string
   }
   memPool: {
     size: number
@@ -82,6 +84,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
         status: yup.string().oneOf(['started', 'stopped', 'error']).defined(),
         version: yup.string().defined(),
         git: yup.string().defined(),
+        nodeName: yup.string().optional(),
       })
       .defined(),
     memory: yup
@@ -99,6 +102,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetStatusResponse> = yup
         status: yup.string().oneOf(['started']).defined(),
         miners: yup.number().defined(),
         blocks: yup.number().defined(),
+        blockGraffiti: yup.string().optional(),
       })
       .defined(),
     memPool: yup
@@ -198,6 +202,7 @@ function getStatus(node: IronfishNode): GetStatusResponse {
       status: node.started ? 'started' : 'stopped',
       version: node.pkg.version,
       git: node.pkg.git,
+      nodeName: node.config.config.nodeName,
     },
     memory: {
       heapMax: node.metrics.heapMax,
@@ -211,6 +216,7 @@ function getStatus(node: IronfishNode): GetStatusResponse {
       status: 'started',
       miners: node.miningManager.minersConnected,
       blocks: node.miningManager.blocksMined,
+      blockGraffiti: node.config.config.blockGraffiti,
     },
     memPool: {
       size: node.metrics.memPoolSize.value,


### PR DESCRIPTION
## Summary
FIP:  #1858

Status command getting nodeName and blockGraffiti from RPC payload.
Debug command getting this variables with using sdk config.get() 

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
