### PR TITLE
Add nodeName and blockGraffiti to debug command

### DIFF
--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -50,6 +50,9 @@ export default class Debug extends IronfishCommand {
 
     const telemetryEnabled = this.sdk.config.get('enableTelemetry').toString()
 
+    const nodeName = this.sdk.config.get('nodeName').toString()
+    const blockGraffiti = this.sdk.config.get('blockGraffiti').toString()
+
     let cmdInPath: boolean
     try {
       execSync('ironfish --help', { stdio: 'ignore' })
@@ -69,6 +72,8 @@ export default class Debug extends IronfishCommand {
       ['Node version', `${process.version}`],
       ['ironfish in PATH', `${cmdInPath.toString()}`],
       ['Telemetry enabled', `${telemetryEnabled}`],
+      ['Node Name', `${nodeName ? nodeName : 'NONE'}`],
+      ['Block Graffiti', `${blockGraffiti ? blockGraffiti : 'NONE'}`],
     ])
   }
 

--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -72,8 +72,8 @@ export default class Debug extends IronfishCommand {
       ['Node version', `${process.version}`],
       ['ironfish in PATH', `${cmdInPath.toString()}`],
       ['Telemetry enabled', `${telemetryEnabled}`],
-      ['Node Name', `${nodeName ? nodeName : 'NONE'}`],
-      ['Block Graffiti', `${blockGraffiti ? blockGraffiti : 'NONE'}`],
+      ['Node name', `${nodeName}`],
+      ['Block graffiti', `${blockGraffiti}`],
     ])
   }
 


### PR DESCRIPTION
## Summary
FIP: #1858

Adding nodeName and blockGraffiti information to debug command via sdk.config.get()

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
