### PR TITLE
Replace gossip nonce filter with seen transaction filter

### DIFF
--- a/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
@@ -472,5 +472,677 @@
         }
       ]
     }
+  ],
+  "PeerNetwork when enable syncing is true handles new transactions does not accept or sync transactions when the worker pool is saturated": [
+    {
+      "name": "accountA",
+      "spendingKey": "62f7462138ed7867de47d5b9de01d07ce2b59f2ae7df1ee9ea7101a2e56cd7a2",
+      "incomingViewKey": "68fc72ee5cf1a5e52b431cd1436b1bedad38d415a2d2287f06b04e94dca88a04",
+      "outgoingViewKey": "5ef18b6d010d90149527f5c8c17005fea580649ec170916dc1d0bdc43db1911c",
+      "publicAddress": "36d129cfcdfaddd1f871d4f001fac277d70b1495eabe72111e4f3f445b26bca13fe0b6b06c6ad2d454652c",
+      "rescan": null,
+      "displayName": "accountA (44955aa)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "94ce3832757caf722134ce35fc3b2167318e726f5f0d738204435b0baab1c189",
+      "incomingViewKey": "50faaf0c3a577da904918496ee742bc4d4246fb0811cb44e9fb5e6eca1ed1d05",
+      "outgoingViewKey": "3cbb8233a52a6c932a0ddc9fb3ab692ee3c73fdff20051626ecd2c2e4d2f342b",
+      "publicAddress": "c287b57439fd52efd70872509fbdd99711c871a991142da64aa6c617cf72570ad4ff30368a6880a9c4efd7",
+      "rescan": null,
+      "displayName": "accountB (187daa9)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:i9QODzfvBYmWctflDeEBp9l9R0Z8uPOJtwWYUceGYy8="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1658426820704,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "7F0B65DA9ACA244A499D9F8518AAB744C9079F3EC389EA667E8A27324A9E87DC",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALPvhWdG8IoQ4Vua/KO4R8AF23GDV7COwYtA3CTik3xqa+sPQGOVZ8Et3XLX1l94NKvLmbL0p3HkrpcuI4QmUYFezj3HGBu8FqJDlSi1iqDSal04n7vrGx/zOBZGOXh6IRmrQUzAOYVeaK99vo7no030T+JEs68hnTfJBu2/oYjiKyZ1XzRea1ApW7h98zcR0qNvZUZ4u1p3Uc/cNdFkeHjwtyFUh0B2L0gvCUHySr/Vyuq5GkZfp4Tcs2Vk/knsE2irLZenFKC9UwbEi+FjeaDQBEWHqSiqkqWVHB+5pNXKL39/DyN59D9m0Q4HlMR/ott0PI125AXnL4R47DdN7xLrIxOd31TyO9ybAiRZ7JCiosxLSOx8QC62CCUcGwvN6Z9F/Gx8W6qgIqtXUuc9UBZWS1YP1PZc/0EBLiKhhiB6Lh/MyXdXvmg73WJDKthhfRrvyGzuieIxPSrHX1BU/z4u/vSBIYt95UTaIT2vrKdGaiMQtw8Or82N4Ty1yInohZdUfUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0p9m7rQPbx3AwHjAbWsiSJi8ynX5bUDvlMr4LuIgTIxkF0mIm8aQsBTWOf/c4gLZriBi/faxpS4MVEHobJGjDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "7F0B65DA9ACA244A499D9F8518AAB744C9079F3EC389EA667E8A27324A9E87DC",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:s53FInp30YowO/A5ho4+sOAekvMRfrtZ/Te07QXqqxM="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "7EE9AC05F274128E5B7BF08FB33254BBF4358E3983711EBA919B1DE7B981CEE7",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1658426822002,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "7F477009399EC4FC6EE3ACB8BFACE701863851F8A0FFF89CB75135E9EF0AE9A0",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALcUffmJXBEyv4wqGc58k9XkQhVFn+PrKa4Zoz6PnLjgStXGZYkuGHC5Zd8Wm0KmF7FTPoII8UYqxjH+nVsZQjigZyJH/NA3UxpkqxHQpcldP+e0enO85MWFrs/VDyGT9xjHsh6PDSd2unmAXoVbSfycdhLNYAdh3WRWLVMfqvezKVlTcliSu4eLdondtsT8z42UOx2FsCRVqxjdJDzs4UeF2NClC1k0qfmC/t3M17LV7kC+RRixUo8i/+zsRJTIDAxedBRCCbCNxLI5ksLaBDQWIFVDPGJugS0IbhSwxJqfRrMPwiFUaGVdKH0ojEueB1tLwkwcOWHSNtw6XXM9EmukXpYd1d3NNCUNBpX3JOT+Ict2oB/02BlWFjMTNl1NDnP6+ZGRRoAYCNDKJF7rfsxG1YsN7RCBOSdZ5p5i7GMbuD0MPyb/wZ1S6mp8IY0ijJWQx2s3T5Asq/KDqugsj8o1uW4zhuZFEtSef1VeS+FRRQtYtsp+FHdiyF6U6XbPRAv3+0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLj05ECzriHicNRavRKpN4GiuiLbjOqpPNOuY/Fy6bYduw7yfOUVzmpMFPWD0ht1PjLb3G32WSPlheyvddncCCw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIPb+15U8IKJ0t17Hh7n02Xc+hy5JKxPcVwEZOPDDMBItfARiPMQVaI97Sslg4P5z4Y3MNinbHOgfvhKCRdOCOC/WYUyTWfdgw7m6COJejByDRibQQXjiH/svxLUW0q8OQQPegruLI4CqMo9w08REYZLyZRFR7raVPAIg5I9/Hm7iqE7Noq/m0ZMYKquYFQirZCvjHX5viYQYXSeggZ3vimSpw09ya0ye9k7hmCtSw31+tAslgNIc+D6OA0zb6r7tqxiFX1UwdLMW1PibHk7t2a4KxF7AJLFmal3m0CqupPDa7K0MLyODx068Ft+ADpR1ZkHKXY+0Lilrm/RIc24p6GL1A4PN+8FiZZy1+UN4QGn2X1HRny484m3BZhRx4ZjLwQAAABu5f8+PxEvXKbWrnV9EUIicBNqvTQhIy0WNFFCawgLrgrPTBwlwOSLqa07kt3r6kWi3WZWDn3yGpRFIZO5KayBUlt1lqlEUPp9Bj84c+kqucJt+OmzKx7Cca/rBZcMMw6X372gScqwKr7U+UVdkM/yWzKbjG3RKg04LxeKDDZYnb+0DHNRm5EIevfw4+h8oLOZtgfqCXmP7EENKg1IHdCtOKm9IhCeiHQQSx1i62Ii3/yQwqq20rIQPjft0EgwcroNWjw3L5d9LmyCBAE737yGQQ2H+f0cjKCGrR47S9fVRKZwis/MVkSfXJgSPBSzhbiKOFdqCbp47s/YYST4Z5Z8DON+HmTqpLIBCd8CW3XZKF/DqzodTsnYs5p/f2tDFRu/UDCvDDF6gPPRtKl6riOINjXxeV2b7hqld2/UtGjOCIQzKn6gofcsR7NyZVgV9M7+wME4X5/RQ1bruyRg0uAfVKDITL6YVP2UfSbjFMtbdH0JoeD4nEM6TWEC+oW9WVTVqWXhM2ekc75bGrxiOvAEVSb8/V8c5ec+Z/5vRKLRaj1+HsN6kGxTIY6hQAtbflVM9w/emT/JGnR8u07JxoWRiPXoQCrc2EcQgTBGgBs3GTKfITNQUC87ikBPNkvuPBvrW7ILzKcPOscPFlv11PQPwfhxVqZvWm7Nbk8jcj+9HrnJaQIcXBq7ng9UMWvaLXECwyWqoSyzO9CJBVvvOlRKwRp7BJz9DlBcJenZfG2xQULterKze8ltxFq2lEuChvlmJJJIWzgf8FO6ekY31LVVUt0u/PUwmgMrTmdcPGM24LCWXo02sb3CGm8i5CQKEIBoNCsiwKUv41i1+S+OBRACMKfpj5Rvd6Xv9LkbLxkXM38C0RB4p1f7bnsYv9aup+IftVgMvPVbzNtY0SCw6uB1gw1GWI4vSa4kx2hMtYYmndDLoIFchySiRcQsXuEZu8qZ2E5aokL0eA7KBESLu5m2g433A375lHXFPNiEdzJHXnalkm/mKbcdIwp5kW8DLKsbLo/3NllUzVuPbPbTXtOgmY8EeCgSyNS7XevxTbxt5jN1uGHsevisAzVzIs+O5S/WbSC/x1ao/94brzuUUIA76OgtzmTyaoQ/oq7FMJErduXpAiME0RiU5OJ5jHPHVKpKy7STbrRtqUYNwqYvEdiH3h1jWvW9jeTIze5XWUWU84vrcq9xo1YzxQPiRqD8LIThOGnkSWLg0Eu4nIyPxx2sKcPv/Myp83PC4+xAXtaeffELLGYW2XTgiBvYxRo+RVurLwfqdq88yB4RqEZYJVAWRuqikhBzJe7ifayme8fUYrGDd1ws+HSBDcZFckB72/xfqKt7Wu8ySHHFb03tPeIZLQbTg/4iloregjM6j3cg5rVDO0DMRbQXgUNeayBrKHdDpoSNemg2s7ZpHp9why5tJ0gx/8vpkCkKH0ecVQ7yWKbLL49oDg=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork when enable syncing is true handles new transactions does not accept or sync transactions when the node is syncing": [
+    {
+      "name": "accountA",
+      "spendingKey": "111f35cea8eaad4b1c5d0a67cab58cf7fae6360ff62ee88e888f0281396afd06",
+      "incomingViewKey": "1311bfa851c92810936f3b02d9b5350f944019f1749cd9b47740545db1bc8406",
+      "outgoingViewKey": "558a3d4e0584431516162eea67542196630279a01b339ad45ae5eaae5621f0dc",
+      "publicAddress": "8b520828e49732888e9c9eaa519de1dc8624d3ce644e9df0da4e800b101ea38daa434002b99e2ac552209f",
+      "rescan": null,
+      "displayName": "accountA (1c93df7)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "d226e838ccb02f6a064154e8c2dcf1a3a4fe18aeaedcd49c206de0ed83384cfe",
+      "incomingViewKey": "f1764329b625bbc028f3458bec1b31223a77ac9572552d5c99edf6386d9b6404",
+      "outgoingViewKey": "4fd0b7434e452f94b27df7f54d1de22cf8f30bffdc69af218accdfac64d49be4",
+      "publicAddress": "a5bf896950c8d4aaf9840fcba0effbf47b3a5b6c3abfc9d531f52b781533c5bb254c7ffee44e3d216715a7",
+      "rescan": null,
+      "displayName": "accountB (42a264c)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:aPBFGCO+3/XTvHfa7BDlAsZNEebHBQI4sFo0q4TjCB0="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1658426998422,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "64F1A40C9DC5AFCA76957B03E292BFAA68F3CE26944C839A1B30BEBA209AFDEA",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKknsA0epyqsSLA1EhcBX4OCONKNZ2YsgLdteK0TqpR76SYjtKcLKlm1QzmPnqnPV7JUanx2J2A7kDberC2IrippzsMc4NrkHS9UlBVWuZ78vWll+Jqp5ymgsZ5bss2QhBAiBGC7fG/cpd+ezTD1llIIoytV1OXT+1R3ktpgXfKKoj3ENW8oqMUcnJdPvwwTerNr8qz7RKg+JjgJ2nAu2h6LzMY65gPoO9m9agkowfEo4XlYao9e2QnlJMHBis0A/V+5o5v7LmvLInW9TCknsLBemxHyxerNL2phpWhY5U1GeKfCPFFVJ8x04krbM3ZX2W/qBgAT7OHGqbcrN5Ltj1Jc5lJ/h0Yt3DS5e34Gq9kHPXhBBIAESW1LOv5iCjNE8687OoP/CcznY507lr1zQ99ukvFBI8RW/8WHw6ZDhfYNkuGrpHJZES5eQFup1trtsKGN1MY3t3fCYMlup3wd6FbdP8ojStKWrrcZyDmEKoCY8sQNkIR54yXjB2bMtLGG1ZdJq0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5Y0T4cNPuAnhMOfPiyR/loWS9oRaGGUTFSh1vLaejgtoqyFf9/ONRtTHj6h8Yjt9lRLaUntws668ps3tuePuBA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "64F1A40C9DC5AFCA76957B03E292BFAA68F3CE26944C839A1B30BEBA209AFDEA",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:fgTdm4rewqUVJ9vkHa+1R/BpTS0re89OHhz4kugltAI="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "AE6974AFFD3E539E0B6C5E6CE22A328D36C2CA8B41D864EDB9653F32B0E56687",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1658426999711,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "9EE659E4EAB703B9C4412F6F7521B5D3C298957E7F7368671056A91F064F3A23",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIpwM67pzhO+jqyZl+GVhhp3VQH03F6NOcS4FpKKa8qIY4FfeT9a/fYO7tsgpKEuqKld/ypfDQkq+f8lU6pItvICrnlLVSls416vxH6gEAlRI878rNTGna9guZXVqHmptw0D+InaJ4nSf7yPjq5kx/e7V7/C/XBnYATgVXwz+15GK6HmhhHy/dzIq8B9s2/5iY2sURcN03MbXISlApNTktHjc7pjbvvJUChraqChjpEhKil1t4xnIISXl314XH+DRa6oattzA0l+Dc9YMgpZ/7g9t7ocGfOVego3PVNoctgNwh1C/CQ1U7LlTe1M2VcHhX3Fj9PnZRvC8Wq3j0vkXlOWm9Lkb1eyibr30vm/mLMAZRZ2nFM3n5qTUWlSNc7hQTOoWHM95Fci9/sY6opSbCmJ8DmBxPbB3SgafqgtJRZtXyxLrYTpJkbP00r1bEEf8BeEsAbsA6q1HTZ95d2NUsm/5gpblEPgPBVckJvWcsdS9iirsF/AGrXoFXS4lwygSderzkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAF3rkZ5q+OofRZtx1bqnqXsR8of0ouwwN+dEntvltdIIHWgKrjxzyGJ3dOvL96vFrMM3D85HGPNbUz5ep8w2Cg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKAI0Fe2EiorE6LTf5eZLSR9BDxPGdpxWLvX462z8jkAw75IdRV8n9FTE9UIi4PbHak62tW5bXBFopvb4v1gPebu7dy4UplTErsjm3Qwn6xj44eYrsI/2MdhXM08LV7azhmSRhcZgVIzwo5Gw3xszokMxW1Db9B8FB2QWsJBuFSvuWWliDEVn4K11eqOTTZST6Oc1vAy+JAWTZKAKrBamXUHX0h03q+uuRmJhrpB6cB9z5s6RhD0wjwQ7Gzn0w++HRVIp8Y+rdeeWimkwDxlaqE+Iv6bfn7Xl1JgX4R/aZMxBNLRl44mwXMZjf7joZlRbXI+eqxINh4bK55dvl0z+nFo8EUYI77f9dO8d9rsEOUCxk0R5scFAjiwWjSrhOMIHQQAAAA3iDR7pEBp5mlP55XusCryqcVkFYwGRnbS0jD3cHWCT1F0/rqJLcG843ZSelqColM7h+gS9kJoDXQkb3S33KRoWyKgM3CJUd8P71B40p4Mfak4sduEhoPbs2GolgOOVQytmm6IhSboZlqR98CZngfnPfLLwcHgQZe8/x0VS8sy5wQFfrnfFXIY8WqgFQN74qGjlAE0wSZAlBHwZk57Yc9yX1CjQrOq6rTCGcbGIWrx4lxuqzOs3mpODrcFOkOmSI0YpcLgwMy7PE4/dVXIwYa2V7lUCqTj44WAF4dEICOOPanGBIzSI8AB7WHp7KwJ5PGYuDoELmFTanZQaLvNBgkViIH2OKCzTSiKLCHHV82SH+F3+Hynfg1z54fZ5ChZXreh/+8aJFAfm2fhXFPMr5lpD2E5fnr99q+nsgj4HNwccgn5TNE3Pk2Y3DZNpOWGf/vvu1YZLA3n8WK/7HlETAxqHGe4AUJ9gtr2QieW0qTAnwnvYbz/yehxIQdE8yEBQLFMOJulu4bm7W30jGj12HQfFZ+8Zqiaa+NlChEUXr3MjbugETBYFo/qFTssT6BJ/2dpwSra+dkAEzvYmS4v8HMmweNkjz3hiFQ7hPBEr456nuYvCSKiPlCfFoK9zqkvV0VZet63/8XyVb5RqoHvR8aKLs8k9TRwvB/CQ8OtWmzW49L71OOx/Z4qD416njnKiUpZcQWlk/uBcQHA/vPhdL+l6vDM6ALeVPbxnytCDCvlvM/007J7HQKLe8Fd4ofX87q2OYeUo2S9w+BzjvXiTIUGJMWgv2cP1L9xyQquR6p0gpBEsIfKxZFiucmOSS0Te39ul4EjGL/y+wb9IXx0NY/z804k17SW/4LRmxc147FD+rBppgLnKUEAV2+Z1SrZpzmurYCHQERVQtfL0Pk3O85fGI1har1VhkZIXSw7TwkqqOOVGbHGrUP3yESCGI+bjYkUlB+yYsroBxk7Y/7Aazxry1D3DniawQqpVupsoJR2d+p4pY/sl065EGqTpTaHpCmVxc69d9QMS87tmIZkXyavPrWVUqdmNrE5pdnqB/73511XiEyfYdb8p/h1q5nqEmD6A12zZiHNHNnRpLdh2vZyg3oiNVmOeqp51P2M42lgdo4t8x05m36UbvhAoHoQEZ1y16rsxtzynq/TrYTzSz5MHqlbqXb75CSUrT2G3Iz5nigS4HhvDMLBaJrmuVvHFJtJes7HpgBtCMXAJReXqf6eGLSpqscwU5yMXZTz0Fko+Dq4ffqLvXr0c9KH2/yS5NwhuPdVKLJT9YCdYKgcSEIY4VG2xTE0Yz4oi+Fn7+Cw0hOqC1RkczCH+Y/ZcpEe8HBaB6iBpsIeBMRJikXmogWGuVlcgtqr5gi1gQTiy5HaYkZ7nmhNLiL5oxxuRXZZ8mW+sYHI84Ye1OohwfPzL6B+ZT6lnKC/RgA7VLQSmB8+jnLhjWdLCg=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork when enable syncing is true handles new transactions verifies and syncs transactions": [
+    {
+      "name": "accountA",
+      "spendingKey": "d1d1f750cbad6ded9d0d797ee1f7525511503d717bc2cff2060ad325633d9b20",
+      "incomingViewKey": "d2a0d8b01f0912dd8918b318706408aed7b20337a13a48acb0014eff44f86e05",
+      "outgoingViewKey": "a333d70c135f28684b31f86f0a2b87d8ccbb8658387d75b8adb11772e9be2a8d",
+      "publicAddress": "4da7fa95d70ed7043f75fb5ba5ea7e5c2fc941b386f2799a62cf3ee292095a3cff1341f725d5bf4f0bb0b7",
+      "rescan": null,
+      "displayName": "accountA (84f855d)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "3d3291f03b1783fff1fc933ba9c0391b63b22cdc176204c769cc0120efd03543",
+      "incomingViewKey": "51f0c6e128d20f1f543a1484c76388b098f9a5478ebb8c7eaf916df06ee62f07",
+      "outgoingViewKey": "a846ea92121ff2324071e4bf67014e085c1ea3b50140c3b845fcf2bf451dd1d8",
+      "publicAddress": "b2977d6f55b5b02a8a4984e5fbd61654e4880838a675fe26e47ac76eb3297589a346fb0611ad65886cc71b",
+      "rescan": null,
+      "displayName": "accountB (1499f8f)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:7TB5vI6vKkBLK7yz4zlMhPS2fFF3gbytPW+tS3VIEg4="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1658427798671,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "9DD2FAF37C38605F54DEDE919E1619D882A1B5FB5AC39ED175E8762C3C32B207",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKCmD2dAjPdA5wN1FqfytRsMfxbHXHFEqKITwruMywwpc2D5sAxg+0EQOvAL0M6Q+aeslU1D20GaU2NCSXMdvPOcS6AUuOHEeJkcOUx43LI0sojH+go1WQje2BR+F6Vz3gfMA4icQTBsyT9t6mwq3JO3mTeCYqRqoj0XYdaZrp6KWCW/EbxvHZsrbjtfv3sIFZCQDsr5tIjJsn7Dc7fIEQPB+QJpyka6pyAcJzCdx5y3PpOPR5GzGnDw6XyhYsWGGJEYGwGbxol9wiW9zCtEAZzaZc6BgqqU46IkfgGV9rqYkd0lym+AkrHmEMxihJywaRYwb5kKafRWtH+SnGBGCVdJXu+bjmPeu7/V+o4A9pWSFJ98SxXZskEQUWeHBXDc6SHmoXXAMK5Gpv7cMXo6WH0QIi09HdN1on/9E2Ok6iTix2LlHYyPWTEJDo5EXyJyziU7mvsoVLDTWbt/K0+MrOwfe+cDtaO0vbp1zuvupyEGw7eGlSidXmGtgA2kNbQvbmFTNkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/mKffaHs7T6AocnmS02n/TnYjWNVTkY7Q1p/yhFV7k9/xMh9vrV5awDjs5b8/HnNaeVLHvlbh1IevbbKltr2Cg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9DD2FAF37C38605F54DEDE919E1619D882A1B5FB5AC39ED175E8762C3C32B207",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:cJh3Yfvk2ixWO5yf7g/w1IDgXjB+kzToVbFJ4ixJvxo="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "8D82985CE7691D9435AF05BD948DD1627AF9A034ED2C5A450F67CC9E6B5992E5",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1658427799958,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "C36CFB22FB71716651D0A7A13C7AA8BDFD184274D9F8B8963020E5B38BABE7D9",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIeWZ3sTDS72F/vKiJH+QghI7+gG3EyjsL33f5d6QvmBpktGhtRxUURd2uIw6mB0vrNnXSj6MHzXBo+LeoZxBoZplSA/CP2ZNZ11x1rdaGYoXIr9VUljgVs19y1EGJTzEQFQYaBVnFGIQZ2RWEWNyKjP78VIEAHp+MsCEDDFC6BPSDFlem5S+ZhhTre7ar94rJFaGDin7xJYkpj0mkDZn+QE3Ifbjm3X2FzLcJCC5grXSLyOmdacv7BrDwRSZhpGAb+fiOSPDgOeix6Ap1KaHBBLoJa/msb2/jaaxX/SnbsN18DXgG88nlZjL4DMBg/i19LGf6n18DM+331dsoZ3Elj3UhBM002P4LrztPs/dWmDzJo6evJrlta4PzMVcIJvSVafUvMXPPWLFqdvqb6JCwLSk92J6ETuCuElVVzMNjHVGbv1Y/u4IcfiEhvC+inQ0aLS0YJWhfgURu/AYYerJRLd/FaPAuZUXDfJ3G62k7McpN/q1F4PFuJXLp03VQY07RpcQ0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwlOnTGVbT3avYefkMHR8XKXxP1xZkwijiiUwbVvz/cmnnjG0m8iCTD7x8/CtXefNTpbQzi2H3zhuT67Hf4FDbCA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKkg9z3GZs+vhfGXMyi8gTDTgHNr/N4C9atNeJdgHfPE4t9i+iTMVgIPXEvxUq4pea/XU0ZLyYtbc/8EWIQ2fV9X4yotW1Ed8SOFJrEuMfjYnmmhG3K0mXw4F1HzCp67XAmA72wEGYCwONuBVb2Bt/uPKryK2IJLYqdT4Fn9lQQrzPJeijI50mAjl3CzpcNDAYy/BGZn07qjFfB76AtCpOjZKUfWf9fns73mV1Ss5z37qeWXqBqiKaDp7oi5p8P8TKy24trKVTwN9WT4MTJyeQ4RyMA33dhpojssDjacxJPPNXDjSLaLUoS0C/1MM8utF21l/wRrd/MJn/nPyWwtUNrtMHm8jq8qQEsrvLPjOUyE9LZ8UXeBvK09b61LdUgSDgQAAADYOVLagqZ5l5dU7EXdmli3n+SOGlEEswuaR2fJRZ8HjNwTfqAOM705AY0lsbSk6nplHCjIsz6wAQvuodLnzZ4UKx6guEhXd+xfoeJh6c4690EC62TwRdUfnbtYfPoUNwunQIrDyXOjRKSY5erIfeobf9b6f+HZfbjT9E89R1TTa/UVeYunSE5KlaL+aa3hetaZzcZRjB5Pfj//Btjbe+6H1Kp6vk+hnwSxQzSLR4Wk9CuRswp5TE8fWOVy59KGscYHrumTRMnFi9DC1fDXDGRRIuUrqxgooqeu+nJ1zxiMVG5fkDjh1ybClFdjsFOS8KaFrhLC73D/6yCFf1gR0AKtGzxiJwbvzkatI1A9/rci+uoYpudzVcg3yODuKmYwx7a0gYo0kQ1zA1BOEN6AvUjuUeWtRATFovxHffldLd+lRgZlT8+SioCy4cNq+x5N72JrA1b9XT+RNZSg5m/nK8IpGFkOTQvvP/6VbbzronHIMV3ragRl4ZkQkiXNnwZSnt2NSW0P4aLCWnbE3KTOmT2YB5eoFldU6vO6ZQ9hR/3S0RZXtpH74cfyiTAUxHihjUmnBdOjdkKOPoeP1ljQCcMpAC60f1qa2ildacN9Aw1LzAFe+ATOOfaL6cgAwsHycZCm9Z9e0Jt+TYd1fx8svVvx0+2iIqDF8H9r7zswepItXarXeKy03Loc77OYCEYvH7xafDb89aMeX3NQP2hoSdIjeiXdMSNDsln69g7Squ24WlgNkasqDGHE9dFPxKuuS89W+odZ2EO0yq9p/AO69+BR8QvufK1cxbjalpXilOpO09N9K6X/TBmV7vY6h3dCGxM+CSRRW/y1tLmq/tK2BI2qkfUQKmqRNQ5FGw2vS8OHAm1QhQsw3k/7a/TwPKJeVh5NrnjOQO06+kf/TF5g1qrqx/rsbcW/34lolmrz2CLgmN0XU6geUpOrfTj9waJLiNztNQgZL8+NvNhwNAQUPCoIJa5N/BVH1z0V3roXKaOF8YlhEDeXXtL2oszzxvut4gnIBEEPjUacMYu8vSo/Jjv+tIwM8gmgVN6A6Z70crHPk6qU9xYtNChbO4Mk/Rh7WXakk05puwQD1pQUUQJT3FpiuDDHBxME1aWiULAfZj5B4iWn4xcChviSJXevqGAA3sU3RfONx2jbdcino3mUaM1VR/SWQT/Sf8BDMube8HXRQCNIvRQ5T3ZEz2YGwEakumKSTYe3PI39yygRL2nXwu5YAm0SbNslbh/96G7QhVYyW2keh7Uin5dWu3Rgx19NrPVcZlsZZS+mpvc8RNe3TmyuT5FDS47LY9HvCzoC2ImSnYI1Qfa64KtAi9HgGt+bhhJ7F4ytTBx0m8arMRDavlJWRVczy2rd2BWBVS48aXBQsHgrh/XrtwgIlyNBcws3a9IkxRbglMQ9UUdrnsVwZSSpTvIVEv2HAEGuIrqpAf/0fcZ7M78gCQ=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork when enable syncing is false does not handle transactions": [
+    {
+      "name": "accountA",
+      "spendingKey": "e273679867ce8e5036355137b5167928fcb25212e365654c08996a70cfa15b7e",
+      "incomingViewKey": "7c664de66883a2380be2072fbf33b150a16cd1dc4483519c13ac41f7dd064707",
+      "outgoingViewKey": "25678ec54f478bcbdffcf3e6f63c09c37081b844ae3170e311fab75c8ffc6875",
+      "publicAddress": "0b1ae078737e859177b86b3e5ca9baf9955ec20c06e1c9b02c2b55f7b035d8d51dd8296c2f251a29d8b25f",
+      "rescan": null,
+      "displayName": "accountA (2220ccd)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "28aa5003000abed5382883ddb95867893459bcb858f7fb8b8931abadf731baf9",
+      "incomingViewKey": "70c27f50ae81c78b4f06f75c9cce197be70bb664065add52ce7f6a56b2e58c07",
+      "outgoingViewKey": "d5b75f0eec5a4551e436dcc3dd75cc4b44b42a49ef0ef9d0d0aacdfe102c6a96",
+      "publicAddress": "835ac76486dd9c206759d86425d6b91f339c1e8ce3334d7febc2277baf9a8c8293631d067bb02ea4951310",
+      "rescan": null,
+      "displayName": "accountB (4b19fbf)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:f6oAl866kPU3EqZ9ef7gt890a3k+41LnKQ+7y9Q0bWE="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1658428238341,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "146F9F9726D2B8872A67559873C71757F5A6626F1974579AF5732D9E28F350EA",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKpB+td/eH+fMybh9/HEGoPH5muPCmEbZiR6A/wnzQ+tAgKPkn/R8bThk6eZuNWEFJZrPnZvgy39ZdV1BfhPUXI5IxEyI0cu1tLeS4kth6JbFcZxCKvuS7zKD7qlEwM3UxFyWQeQp3LsMRPkrFc9BkokaWeTiqqJSkuvRAiFFpXuxnK3lP3B2cbPGVYeUhKtM7btV/Z2hm8rN+QHHQuWxNB0TH2UyFmzEuncBW8qZ2EA9FHSonoyuVbZr5zsmFZIneHoPvI8SbZocxgxgyr4gzWmPMEB+VLD1McWdohds9W05aX09RiEG8beNJNt1hafgR+pcg722gP/taTRGtSR7guCR+19QkdtEYBEPC23nay1KL6PL7QspShtomdjxiTL7mi+qdPqKvnuor5FGLYFw6esLCgM5Nv+NlZzOLFrC4veJ1mM10ssFtiYqRnFK17l3Yc10sMC5TypxO19dFr3qpSkGFD/dZlETlSw0MsY1FxW4No5NUt7s43hRI1jCg8A6uTyeEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2qaTyBubg22EPR0ZFgDQj8Zp/6DJDUZaxAFEQ6uZM2WAA/xjJP/4lLLZqoJSQRzrztIqeIjvXEPOlmxedhTjCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "146F9F9726D2B8872A67559873C71757F5A6626F1974579AF5732D9E28F350EA",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:c/H/tGVjyMxaoxDM2nh1JhKiEd9dxmci5ytKofRT/ys="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "D7A923764E2D56DEE5475E9B594E817F5B5438EE36346868AA3DE7198478F694",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1658428239685,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "49A9E2707A78FD9885C6E71F10EBC650837C67455C2864FEE966C54956E0D81F",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJYl5C/8ZBvxJGoeV1Ovvia5jb/lKQJpVtUXJ7QzVk6HixBOINVjEqOXFhGm7MOrqof02ddIknf7B9A7YYT9gmStTpOyq4I0Aarvrvw5N/UM8ZOdzmfCmcRhOf05fMOCJA08KbZW3IbyMY9yii8XM6DZ+2siNsQSxmGoMwSMLkzKhqNn50sKl3dR/Ijs/X7ti7Nt4x7am1msIEJNsUdQgqsiG30rU/SVyEhJgWE5VAOp2b+2oqacrKmZq4e3TSVLznPxod4pDdDCwCbxd5uxfpfg6YYWXyZcQf3EzGjAW79D2v6vxvA6u2GreW3KKt+kfChUzDQrOslwKgMYFTgAZjDgXm4/3+/c97uyvw2Mo5PTZ7s2tpBY4w4Sk2fMd55LpYbJiMRgAJQSlhZAmyY9KK1igCsaJc7Rj/j+ekJnVcoXZw+KMiHA9Cb7h7SwdWLF+muW31kTkln9iD5rHt8sK9hNLQOrZQ2rb4B1mOHjaFyhDT8VsahKuc7JoyxnsbX67tsX3EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhNweF8sl7OlEsiq1ew8PUoQ8h3xMXYnHLAYtYoYj9hUBcmy9fX6gX/6821YCOC4nBm2WVv5fk0hWEFfX8kl6BQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAK2SK4Xv8vnHmQLzOecqa2wmr7vYJlE3nY9KluO8YL373kv+/J4itmZBnidhSOkJ0ri3MkvUIuCeNnEvTF9VdXViaWtP6MKMyZAoYdOzlSgePdE6HViWIG4SSO673kJUQhEeG2DtPla2tbEGUw85uBCP09YAAVjvsndB3SECEy8uFU37VZUFGXjw820yiGjQtKYOHqsMVolU2U5LW/cf/aLpAIWTMxb0qVRQT9/pyN6S3+wLw9BwazKycrmWIOOi99XXQpeAaDN6wXLf8DSp5kAJRuuQUJrOeIqaBC70jU+qONWec5hw9MKPdymPI6dLBsGLF8dvTrYxqSyq8HBp8c5/qgCXzrqQ9TcSpn15/uC3z3RreT7jUucpD7vL1DRtYQQAAADJsePzpCK32etzMl0IFmpRHKBFdRjDY9g7GU50TpSxuDMqGdvE4+hY3uLjr3pNQhI0Re1H6ywHLOO1dt+MmsPhZ77bkcUhxbz6Aa6ss3lok03m8sLHDJ9TA3cnTmOQRw6y4uCCIredOT1zvRl4ioULo0OcBRzxkySzfmNPkLWAnKogyWMaRbTTGI3QAAewndW3eXGaDjhV+hEMWu0+8ukFUaakXGIqVS1JXpLnt+jTkAkIKV5OeXOKkQhSi35XOgEZ6KU9tZEcqkGZGvzWiAR39a9KlSyNZd33vxRWsrgtqIyifWEYVOYCjQp5demrT0m20kUohD55VHHXKh1hkkrP/oWxV0ka+PScc5pE1vpl82C8IVOFh+T8xbCh/5tCKpxnBJv5c7tQ+pzF13ubq/T42yd4rWwkrRtrzPIYhB3D50KaUkV3rq3BMlOTDm/GOw5hWisT5qU7qxW1GuFGgyY7MsYVhRXQf+qkfSHfgSLArU3wJ/FdqH/AiqQHnmpbdFe/AetcnBsAkDzKUeYuRkjZYFy02PrtChdObmxjvRwVfljJWMZqStpb7pC132NA2GH2FHl2yd2HxvRxvbT9KHFHhB6X8TZHlgMZnkIsiNWvoL6RNNosLHa6kxBdM9nCQWdBpWE38uu92kv2uAUxPZW+jYMW9G1zhHI+/pfKV/16PubQIarY4mD0Ny0yJ6yBVZ54e8MY3V/hX/poub5cjiUNdGZD3VDHYLrhc18XEgAWjYKQcbVjUfsOIv7Tl8RwZWfEHzu4L/yuGGyC49jjBNGRrHTR475Dn/VlP0cqLidPMWYLOLQl/vI43IaboPimFdU6kB33T1njhTNI5UWchBMnJRWwm/qs5X1N26GXRBedKjhcsQfK+53kxTAWz0F8fv/RnJ9TddmZ1vxiWf23vUmnTJ8t7CIF3uojkpvRy5ELZK+ToJcFR+5NIwRboX9VikxlFHRRghXiO1RvROlSUIezJMsd1SFiH+l4o/aQYyeU8kGnIM58cmeDbOGyzDVl7HFVvvn9wjkP1iZk1s1nCvIJibZC91Uqntv/jhN5ehr0ufhM547rc3aMuETrt+hS2HMrrCg7RtSjNYd084+25JXP0ZeLKqPJcSdB9UTgciXQkQ8dR+eanDtRAmS8wUhkLiBoeYrBeTnSYt1MQPoBnTidD154G85KwmjYW0l1twuMx5sjxKv2pFplLKvVEeazi1KTlBmrl1h1zqUjwR90LAukUYev3+wzcWds+eXjxVVJcPY1kqbP+bvOAA9zgD9K4tVwkW08l/YZRtKDTYkdJm6IWYNps5X8Pi8BUE6CyN78f1TffvCwinyFyfiB9MwKO2X6V7i4mez6d0zwtPXD0q9VQoZFTI8ulGKnfGlnE1c2IARl5oC5H0+pEK1Q6eJLF/Lbl8HhLcs0nUCiqgrVtc69n8zHSXTbjLU1kUI2iw9Zlinyy85CDA=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork when enable syncing is true handles new transactions does not": [
+    {
+      "name": "accountA",
+      "spendingKey": "fb9b754f7913dad5575c5fc08f845841e09430e7e45e1cb22c5b0f4c55d495ff",
+      "incomingViewKey": "3148b9dfc664bd4955b83243200a6a13adc942cb0a4352eaa9b59b659927d307",
+      "outgoingViewKey": "7110ea83d37d08be89f13a3d506e31686d36bb974d0182787f3f31a7d656afc9",
+      "publicAddress": "6a63475e678505b03fefda628f2b83059e96a47711b4e6ecb67d8be8738648818f4b198ad7efa25724e54a",
+      "rescan": null,
+      "displayName": "accountA (7b89fd7)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "44aa169e1d21fb4e69b0256885235c4549c618cc77eca8e12c03e89fcbc76ce8",
+      "incomingViewKey": "5098c62235197da9a36baf0267b84bc2a83b166f53eb027b6e0302291ed57503",
+      "outgoingViewKey": "ac2e572edf0eda9d7bf8a9d7b0e9bc9dd5fe6ddd6c0d2405dd7494ad3cce1bf7",
+      "publicAddress": "21c283d0b9637b24a88ac3fe1a123b72630dc2e454a778503686e0624282168ca8f7875171180ee22f88de",
+      "rescan": null,
+      "displayName": "accountB (5e20942)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:G5cHN5Tb4/xNQ9RU73NnXq4fcGxX383NNyvzHXJFjBs="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1658429041490,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "9725441CDA4FDE591663D865A93903267EFBEB67ADEEA57C250927BC98D58206",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKg/+k7CAk1MQ1gBZsa/+R/mLj6e7Pi8rAguGWERSArWeHpyUO0OxV/Pza6AP4AQKbAutcm3vDQ/z+krmqtmNAr9eJ0ZQpJn8O0YTqFOSyCRnrIpYG9zHHYxKfIoPPqt5A2hEK7TqrqAcRJda0Qpb55Fz4vDi9OyqkQy3jgHORLEDkYjdeKTj51CIAvZD+tI5YYw9uk1mAig5fQocw5Sz3jMoQl0nvIXu3g4OBklpgmowkvNvbP/0O7L0Gc8CdSui7LVSZMRgkjN3s+uep/XiZF8jLTjXSZkicJAMOhlPB6YGSfu86WxeNox8prexVj/njxERQ2ya1TqdeSf/M9nCEEHR4NBWhNGve6T7WFVMLVrllSIPnZ5jhTOS8cPgdO7rA7X0XxD45SWx07A/IbOBtBSLjXn9B7RrJxkmB6GC9msvyY1mHLC3DIe7y6DCOajGLmkiTS2a9AM+Y0Aee+cPUTzH8nRTO7/86ypX6Y735MmXcaskM9u+PRO/L1rwkWi9P4MfkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwgdj7vStMAXN0yfWESiUL51zfFpjSWtuzhUFBlyS2tj6I0Bj1WDyLiNxiqEelHi6wbs/DNRyBhECfgY6aUECTAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9725441CDA4FDE591663D865A93903267EFBEB67ADEEA57C250927BC98D58206",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:rWtkE7zNxakbwEbQ4wWpoJ6bsvUPU06mIlvDanJ5JRw="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "0BB2FE3ECADB29601CECBEBAD04F78E2F97E16583348875935E1400B6D0EA407",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1658429042774,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "986919700F3D1AA1AB63DF0221877733DD06D6C88656E8544E44638FDEBB7A04",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIv+MUkUU2asUmzSpdWOliLSnl+EW9OmQskh0QbW8k50A39pzZXMkbLspI3AniLSTYaLjbUdON48kBPAj41SZmbhKLehGVV5IXl6BhgwQzwu7nxlIeQxqfY6zL+aJ2NFkhJMU/rdidalORmwzgRCO4fJz84LmIddCDhfMz+jJExb+b2pG2kk0gv7wE9949z8CJL8OFV0kQOO0Pptc4ePI08k37tHDcyhPVqvdOlnt1QvWvafrzSwJtuXq0rcVPF4eJU8fKCRWD0PVLomEUxKvx+71XSJAXCpV/pzLtqbPZ9kK7YUeaSex/A2MewXFJPwaWp/v4xSLEFNnpvy6ZnbjCKtPbAxG+KzVkTMgw1TNPAlmPYEcZ7/8OsqaqgR9ww6RSk+Y/GqIXZBPORbMvYLToInwqV5uFJXBm2qKWQU3rAi5z86CeDHcARhKd6eyCGULLh4537v9RWPmn8LXjMEkPlvdkJdvKF/L6qVBpTeYl+9IkpzpKRCFAzSTUX6hzIU10FXIkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjnnOgC0dmH6zd+uT988W+h3osGZF4qTJPCcvyvoqDggYZI1MbxFXtlFIJLCm1cO/DRxuJEeRSDPzTxUNEq9WAA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIgnHqpfZMpSECQo/nRYDU2siNdYc+HU4t9hVynl1iqGmE7byMJqwxOFJ/KwbnfBTrH/deenSy7hU5XNrl1TSTg2k4D81uzSW99u7AGnXxsi0MQX36iLkp2iGGR//KDu8xCEhJCGGDU2jcgSN65RVJedR0C/Qitk2pse9QxkFWZ+4owrFjLM8p6wuA6KKq1vG6UdeSui7TyJmqsK9+IaYCeH0xuboHzJp62m+BxwDzFR6BOYro6oJ9IshAG4IagbogrtZVCTdN1YfS4EtrT5jdsHTqmFR3oLdsyTft64W20wD976k736LYKXX8mUmuWx8OPKxERluT41uymlbVyy+QUblwc3lNvj/E1D1FTvc2derh9wbFffzc03K/MdckWMGwQAAAAyFS7tt+lxicbnW2yLJfRjLi3rmFgvK8AFe/yyqkht9jkyaeWWFaqFPLFtVTgylS5RpnFlVogqQLF0AjZwzhwuYDXqA4CwufuoPQDI447Bzvfg/u/9uYjt/POi8LWsmAeS/ygLUw7NPR8R5ahdzx4EFallqBZO1rihWvX/kQSbNFIsVLInDt5T2ydj2LveVoeRMLebJU1o2yuxSRETQOyjtmaEc4Dv65oj1JzEtnjpcvskDDzHNWqA55/n79EX4PsAWUesZkhkcXpGdunGS/KmCLy/QVWwzbzVpP3/rKtbmRjZIgH/hxYjoOkw4WlUSlCYrIIt+bA6/fj/FCEw9rrVXnASw+r//G8dq2AKAA19M9dxK+Gd2HU+2iz23Ln7yUvuK70RTjZYR7np0lTeSQCR9zdAMdmJbyuFhvbMXw6u7kgdq5dDYLAJaX2va0AZ34JWupLLbx0cNOHHqUVfPGRRftJrbMUnYsKr0GNzprCki6yDDhXGMgpo8DC7Irgyr4uwLocNxprGCo+MCMzaz7G21jLM+WvYGb2ebnoYfkOJj6+cFRPK2duxgWri7I4rO6bHBItyxprI5lu0FZ5JBd8+UJTKa+stJGOrxT4i2sCIkp+TdI8Ve//XwuwA83653jttxHIKCrS2+HarQSF1scvrE1T9ebwvAjOAAZQyO3jTuL1gTbp2mHfDgR71eQaYiPcopXIAv0CgDe6hUOsl5lTP1Ec+5eDBffimCC2VNAgPzK7X87cTOq13OaLndkQtszco8otN7Ix3UpJ14LyN8ZItYw5vCb8HetrSZltavA4Gbcb3m4jwFIntNLchW9VsIxZP5ht/W4EeoBhtBRkRoh2LnuZlSHqQXU1xOb4EuMFOOVl1RwPbnS9lo9pVHj7uWuGZ0aD6Ervia0RIy7xyEa7EyWCHLUXpfUuhfRChdHrMelei8oWVg+CG2btqpwECcQdelgDXTYjVBZzOtcKparReGXsU7WyVJeQJlva0dNDER+pyWvWrnuYyQLKx4es5zi6Vxh4k6E9pt+f4UaB7FPUpyV7x2WakB2HGK/UxNHzZDpS33njlocJm7l7u9ZsnMptYmQnOJAyzHVVtCwRViKfDwPMi1gIM8IZSB54VGvfHue9rpVkYWW9Zr5Unhg5GoqR/3clI5Unwc3q1xProL4RFXLB911FS6sGYKJEH183tZMna215fCIm4RDpl59yaxV4V8ThJpdUP1gUcrxbIYnDIuRDVKtzxsG3P5FQGU3/iU1W3OCJEP97Eb2ADiEUVmv404yJQo/MQGhfWGCV4C9IK6GuP3VEYKvjQF8TUjUwM3OtEuDHmNZSCEDtbEbPW1SR02J+gDXc6cmRJM8Q3GD35fGZwCoL/VZ+xJixH1uAiaauYB2baCUzWWrSVpilAezql9IQ+NGM5S1iU+A/3hDWRZKxq62cTsjhQhNhyDUiR/4MWVevWBg=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork when enable syncing is true handles new transactions verifies and syncs transactions once": [
+    {
+      "name": "accountA",
+      "spendingKey": "78ec873287b3dbf046f914c2b75a3d8447da3c191d7bb9745a0739f951c3405b",
+      "incomingViewKey": "946106e96698d6c9cec8c792392723935551696935979c1920f5ef7ec166d904",
+      "outgoingViewKey": "12022025258023ac3608cc30aa93dda7fb35c25602b0c4a0a28727a7ff0bfd78",
+      "publicAddress": "c76f8365d184ff7b03d93ee89a6675c75d9592c904b156b9a64279928b333bf77343a5b898637f1c1e8347",
+      "rescan": null,
+      "displayName": "accountA (ff6687f)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "ca465b2cc1454c86a7aa2c710fcc6cbd00c40e737a5dd074a56d7f8231ac684c",
+      "incomingViewKey": "d7341a567fd28de1fa316d9aed4e6c44cf8948cac939c8a5a2f2b2cf3f515f00",
+      "outgoingViewKey": "c035e62ff445c9549fa061d36090fc4d71544bae912b366ad5fcb8ba6e45fee3",
+      "publicAddress": "26df71d02f3770bcd7c48a3f700511784722960382d81685b3e7156f93dd04c719919e16d16d972e07ef9b",
+      "rescan": null,
+      "displayName": "accountB (3540f67)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:1h7LyMtZ3o8rrF7RfKl4uCR2EnthO52s/9I1in967wU="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1658429137153,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "1A82ACF132CBC189A32E2FCF1A2A78D39A52A2CE1B704F438D4DAC2DA39B38A1",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIJj5ExoMCcdBcoeJA+KBKGy+7CgaPka+JCvWbgpUk4Fy5WnOwMStP3YqCQxtAWeToiLmvFmZbalaPD9hyUkIk45/ajMzKp8g7TuhVRTUnIe3LgjHLWHOAIgLeRln+BqUBFD2oEI124SC70VKg6dBZqEx47zOcqnbmAT3EXaXC+o4js6ShQstOxgn6GO67Cc/7FMk5hfn0x2oHRzHSf1pB+ec2KfvWCdVtUxIojOcYTmxR+TRhR+1G+Oox7MPLNiCRZUjQpf0bbgo192R7FfO0Jk8VJRRO+jkHwYflDo8pZxficAQGwroCCOJfV74BEdvpR6GD/KjCP7idDyemCUjADLidOWZMUL/4Pf5ysOQXoZ5U0QZfC/jHHfPOGwjjoSnjVtRb9sX+lRtt4phTc0GolbaFja/8Kr6MUp/Kk1jl677c9Qys35EKwQ/sRyL0XDP6LDH/9JPIlL8ZA6BOos7kDQrynscJL3wCTE/Fg4G09B6SaZOaHEU79MraEjly72kWWLdkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLFnui+Bi4fP0o+WFFQ2s0zBFxgLfES9DNmUoPmEoG4EngM2u4GlUGbB7NWz6UcIxl0eDJ+pDUP8qLI3qdztrDg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "1A82ACF132CBC189A32E2FCF1A2A78D39A52A2CE1B704F438D4DAC2DA39B38A1",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:/9yoJgOH52bp4F8WjuQgF2JCmlllXaRVbBkeXERw+QA="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "3BF89EC9275FC83251FCC5B8203942CC9398234D1A866768FB37FAFE10505FF1",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1658429138437,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "335E857A6A09FEC4A411EB2DD289C3A3812AFEA26BE80226A02291AA6D808490",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIeFod+sxufxtRleyw90lXF76wnGsab71qw1gzmreQJ8OPSiwg1flNrKNOd5zbkxEKTZNgBGRLn6HxT8P0XmYEyVJRH4D7L1NE2CxaOUgDX1K4mN6RelQqhVs1mzIjTFvABEjPzmsy0JyHqwgtHiRL+Dfx+jr01exEpfRXMM7jsuiEqLSWKTeSYpEe8mQlyEqLTP8ljgPAL51/qqwdOadoWRFFWA4+RiYKusU8HuJeuHiDnr/7zVYtxIyo35sXqCskn517z0TQwDVcsxWg/2ay9Co6o7j+636mDJM9UP0Kut8FwLM2y+mZ0qkwlI1sOH4GAupNmJghvurT+FNhkImDnfaRJekj8Eop3Yb4M3T4YLvN0x89RDJVPI95jZY8vvjsqjz/LVxjq6iHCOyk+rSU+3WxGHRR207emjQnJFtQgs1kpneQ9nr8mLQCcgkGLIrd6+rZG47A8iX15MZReCF6VWBEgadA2AmqwNbYhr3SA1XeEyUAnZTTBgx4BxpTdgYMM9w0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwunHJxGi+VOo0RjcJIvKobDQMonzhGraMM/3lylbPsL01mZZyk/Xuohey+EAeDZgr4zIEklqlTkbGufyvH2lQCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKg0GJN2PIp96gEc9h4SrNRKidim+eMYBiO7HVyOBrLk+sCvjuLviuUASGpYhz59z7d1BHp6MsidQKalvAlMSVtJdjiZlBTxDKixAGXb/SCfTLHS2Bh0aYdiNUIq4SS08QD56ctLhyEjlEgEW7/BfvAowtf0CWeMYrPnJLQnuIQfyeU4nrb0aEikLivsqNcptLJxx0XLtat/F7LiEgzVR3NdN5qz+3MLZm7hTSJGKTTicqBX3D+ZGVrHN0CPqTtmlJA9iP3mplKB93HXgJYXhqOASrCZUsgThNt5D6qgB8zc4CjtvscrUxkdnl1Qarfmq6Y7rJ6ocKxdbibc9LljYd7WHsvIy1nejyusXtF8qXi4JHYSe2E7naz/0jWKf3rvBQQAAAAHdOLiiwuShZyVWVrrqmFW790+uoQ/pLwSWaqHJPua0ILwn473ZlsBrsdUp4evTVmLK/ccNK76ISbtIONuUT3mYaBQvCDXwBqq3VyyJftLuVhzLMjqmt5Ka3wwtNstQgGYhrKOOI1oywtrkg9hyDXdDin0eETKEK+YfCL3CParnBDiMdo/QfT4IIW7B0h60CSiODFy4HpxMVZI5D4xdxMDiCrbNiDvnl11oJaZzS06xllFbeSNW+nv1zQeQmbZFucVgTJrmO8EcV4EVqRY3UPI6/98GUgz3gdGA1jXLo4NJSFXiB5GVhUPQAaoyIrjTM6EriBXTQbvcKyVDQvqZje191RYNZWtAijbVPdvfpdbQyYfWTrrOC9wmsSejExTWB+JgpBgqdMfIf9gTdfKt0gq2ZFuJfQnGzeHKfMANfKx05WRj7BXgF1VgbhFGddTaX7CTmbjutJbBzDzaN61XmQEd45PtVkbLpaZh+PbcHMau2tILhLTu5vbM4gieDR5+o7Mkvpnu8zUxRClzkp2m/mVW19lD2nwm9ziWUAXrpp0dqaE+Y3KMhlqv645QWFPub+UJUT5OZUGodKwAbC0nR2i/FT2B9Ylc2z1p8hIKyuK1l/m51j8V5Myns4VoapTCLH2q60rVhOl5/GAUY9IgECtSvbBSFRgvbq/EYD8+8DUAWDaPtuBH+ZgfgvumXu70rZkrlyk9nTrLvg/gb18U8a18UwPgkCRuiKHri9yZ2aJyv11WKSDALSEMma0lnK0/le+TQZcItAAOb+69i8+qSbySXf4cpqL6OIx/lzZWOFcpfBhcaNvP3IduB7KAj1/lb1s5cjGIV9nu3tlG9UF80IuicKWSrxwTTsrxXR2YgShZkA0TRVHLxQCEwSKLc3F7tEeKsCM3mqYJbq5g5hVz0hyzjHTGB6O3EtTl+PppwEU3YoAyoLpEUijvU03J7wI/cX8E9Y7XJBvcj3w653uS8LiE4JD+CFKMg89MNuNx2p/heJMMTO3V+Cu4YBHHPB6W9w6yMjgTXe0OcY1g8nfCQS+celzA9vAOqkJZSFuapmxO5pS19dbpxz3XmHOXgIUD6tQah04gW3rb6/yXvmrsZ40Gq7r8sRR8R6Gkbc+kdrZ7VY0UNq6GqgNPyF2Qdh5OD6pCz3tUvrbRS/JV9kXPY4B3NziaKaQDBP1IsVRAJdi7AyOiuFK3FaOtIbqtk2xZljwAKGNuHDGIZT8way+txUzWtli+JTuh74G61TzlNTyY4ltowCXmUjsl4fxnd52uvhZwTLrb/nbGfwy6fVrS2nkduwVIPjAMwwfv53g19tSuHsVKT0ZMTsyDLFLTeXoTLzoKFTwr6g4K8BXmA71vyeeKd4Zr0w+O7JPRwocporeeJnQebDy6loPIjwBq/fcCpeqwXpsjY1sKS4+j95D7cJW6uw1bDlAOp1C84Gj7Gr0agcojvvvAg=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork when enable syncing is true handles new transactions verifies and syncs the same transaction once": [
+    {
+      "name": "accountA",
+      "spendingKey": "1269be94490d4a7ebfbfd4e752421d5825b55334e512d359c849ed88f46c3f4b",
+      "incomingViewKey": "7af3ca3963bbce65d222e30d9a52e738aefc6846bd39b81210ea5ea1a7025005",
+      "outgoingViewKey": "3d9aa595115f520cdf5e67c5db8043f868c318d482c7abf9fdc2314f44588104",
+      "publicAddress": "9a9394f0e34a27d1ec872373f58cc6a5422ebb4693ee1b70ba268fd2645fd61397245b726e8723146be281",
+      "rescan": null,
+      "displayName": "accountA (9c18d88)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "89d9032d2af680e57a26113204bc6f09f7bd8663a69c21c560b3ef3917c94f3c",
+      "incomingViewKey": "6ccab7b2560fd8d60d791dc02941f77c4969476e3f4b955bb074f95340cc1601",
+      "outgoingViewKey": "e6721e6c600dff32f45fb801dd13857b8199ea08e806cd45d97b00a6c39eca41",
+      "publicAddress": "a5fd63c1e3cfaa90ac697957c422d8ed44c3860f76c451e110a6380a3d0b5085a4c1f31978df7261598abe",
+      "rescan": null,
+      "displayName": "accountB (2ec1e94)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:rGcw+x5jFVI6QqhO8ZIyWFQfYNtWZb4aUpVFJZOmFGo="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1658429847656,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "D82A555C85BB2536DBAEA078B584A90BD17CCBFB3A83E025CF8C2C75DF4133E3",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIGuJ+x7gyIm2Wgb3s8GO6Zzq2N/ZMllh6Dy6ipZZvP4mtjETXFgytfkm/CutkdRSo55dFCgmz+VblGH01kLutCi/JLmwaFMJOL8dGuihpzizG5NaSwdIwFtHTOs2/zB/w3DpnfrUb32iqUL3aWrLongPcP47MMRtF5YSvafAuLaPF9ibT8iCcxTpJ1FTgepOohhT7BWHRzcOovI59UarRw+BpSznWpy/wKEP7ZLd+k5t4mGBG8RfpHfORiB4Aq0TumxCDCo6h2It/iDWrv0N7xJOPrMOGJhpAjEJedODRxjurzND6EtuLtFQ3+O3fRpz85FdqVgaMIKvpvUozXUJyqoQooJRJTNn79hZz/L24tmToWiUyYx5H89DtTNsqcgJ7/9hudREpoeATXVd/xymyD3FWPgb4LPlxSax0XMJ4aqNx4MeIiY2zN06MYw9dVqW6Zb3KY+sVlHSnqan1vF3p1mqYbgRnUPfQgrLB5nXUDMPVA4rvPflS1kp5guL9CTqgIcm0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvfFfdVIYvJFzgTSBleCq+spsAfca53QQ95yXfreAIbR68VdtnZ6jkS94EpwwfgKWpsd2bLl2NtWEiGl7QP9nCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "D82A555C85BB2536DBAEA078B584A90BD17CCBFB3A83E025CF8C2C75DF4133E3",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:2O2xK+zM+hjeAxBDCIhrIZ4JTp3GyzwMFgLVN3uBhD0="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "EFCB8074C4F183800792B2B30CF217CDDABD607C8D7EA9DD87101BB7F2999B75",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1658429849916,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "B02EAF2D1744EADF99B7BE3690F49451DE14C7FEA2F4EBFB6ECEA45AB8A2594F",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAK4oEK0VLKC7EGuIV7Sz1Y/SyFiLZoltCvgZgRBobaS10lQhvcunE8U/Zudd3+rDQoeBM8F46T3zeXOEzKvCj479ci7z+ITW4VQTViGCeedNoZFj7A9lu6KI3WyMrOV5NRZXavdgnIrzN5jrNFqsGZBTcCndlzyCoFKbmhop0BEcJpOS8HYoayV6UiXDQEkue7dms8wXlVmxotp89bLdqMIjvphoXUJULYs22haPqgwtzmKX05stfZoUB8gKS9epiK9z/95iIdACfJ5vmGCbYiQYqjULqW2AQWAMgAgfFZoACGLqRXImz8LgHWpV95UYhuQ8M81tn+bx5n/8dc1pwynwZBUHfKNquoefj3eq/OjIqOnAjYT33thDMS2NuCmvuhK7KNEBO/ZWBJU4Rq5dE0W4+qVpiUBdCUK8hFFFDGPibGBaWmfv3yNR4yJsmx3JMyNfGc/eK6fdgdssGw12/sRV1gsSNu9sa6yKzjVQ8vpZDsjmrD5ZjXGylenNfVi+gSkSlEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdJUyJAD+UiWkE6EoVMA0/Mpe+lrkl8UlliJE07NFd5MdmieJY13KPUq7KddWT6SHJwMJk6s96Ik7H2YAgS9BCA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALhr2FGZa1rRrhU0IdTRpf4d7bmuyKbe0T/f90o/YA1zLrA2oJ2FKbPLTPJetoebgKL/mHi5jDO0QIop66UU0OgX7ws/hDxGmiaHKPNrWZA/rv3FcNQIxLCMlZCUa3wEOxLG8xnwZbzKEi064d+WHEJA4BgNyTtqLvDGpFbvqO9/mQ3XUcXwCLpLl6VK15JnVrICTmB7h1D32riNioAkVspnej85bD1yluiTVRJ/5VYfyXv9Ql6mpn9gQ5vSGIc9bUQalgz5Cjp6lyTwFb7mJTg+iWli2jArPhcX/jz9Of0R+WCduA0kLJPv1ugor1P/l+aW0oRrkxeqwPBisoWsNpisZzD7HmMVUjpCqE7xkjJYVB9g21ZlvhpSlUUlk6YUagQAAABoEDbGHfjsRB+OzSQPDeEUrDu/W9N1CNHP8b3TUa+l33jX+lqD12U3UkierltHiY+mpZrSpdf0MA/f0UlTlrOdIjJV+6CKfrQUVmU5vqJxIJQaogQyo1sFAO5FEtkPbAaZTNcIIKIAwpzzFNayW3qWFKkbi+hGLppGBR4qy9PuvgMMzVRG8XTsOthgNndvA8mie0wvei4RIu07mEnR0cEkJy1kZlQV+LjZX7RaU2EUYN3KpHv2bmp4xrb6llOIPlIKUK7Ryb+Y5Q5hxa++G/cAGOzQN+F0VO5zcVQvqLlgQoGoHUJIP+fja83cOrYTjK63r6lZE8MlFJaR8z5JjzNMord+t54RdRs2u2iJ18pkG+MAf0Hn5Lq7C9ZiIKokTOQjJou0w031cIOxSgPPgWhArX36Ush+1/sIho6zAcsh8eewbe7ubNcgC9OUFR1ygEA43XuTYIMv67MLqAWhyrUNrVTq7n6KwW5foO6RQxP88njP38uVdkwkCZ/GzbW4zq8KX1EN+/lj6fTSQaSwqlMeWTpIhePDpfdP2ripvx4rnVEheLt+Z8clOtE0upMo499cnipL7iSgpIPfz/7ZvNOIkmncfXfM/jmLs9dCLfjn61e626kkdprS/Nxc3Vk7iar7BGxg6WiNEbjTJxca8qM1IPRqd006xqn7HfcNkM9r296TZUG9cviguggEe3Gn/mA/3pzuuRtIiNF1GhHeW6qq8pq2spAH/Zz9ixI21Bt7I8K+zYd2m0ygtVaG8EmSC+fKU9J7wcq/YuzCcbc79mmoOvYEZzRQsj2EIaWVzDZqsalpsoe3L3rnzGWvyxR44A14hGwkToROjDddAM8AcxAU2rX9oi7pEAIYmGDhs6oAlS/wFQZ2SJ/k+5/YCt7Knhd3+5lOJQ/ee8ZwdiZ4/ypu6LIPOkLWdC8v803dnbXVmA6735Epb21fSIJi8SIbyXJrDGNfcKTFKtsqtECeFFwnydN2jSbsobcRerSyHbhExhf3e9qkErwv45wfqIYV4raX3TWKJQfqbHq6HtdDEvLI79zuMAZ9NzCHPCYfpuVo1e3hImmomJvGBEebSoUJj3Ad5wumhyHW3fD6fw8m5m0U5jkiHlg1RjXGb1mFTU6m3dTntCm0XLqGsk9505YJwtfFnEEbVSOZex1Wcn39P7UW12kV94V4h7qCG2KQ92c9KBFOjzUU6UC4wS5TVkRuvxTmLiwh+lTbCBVWtTTUdaIL/5A7Of/4lY83ZZOBfCuW8Gwah7AvN/riNpDqHr4PkE56w675Orn8upZwWSfsy3pi1dSFDwbmxkKek7ga8wjxJkFag1c2OZef973Q6lcmKDPPU5FfWeYS3AxAYBNZl/xVLvlfNlaliopHKEsAiDok9rOgYpjZJVOln7oLIJqRBwwdoLtXWiK5bzT5UedDz8SiDKdzj/w4nOtYT0a34rnHDMI4vB4VAw=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork when enable syncing is true handles new transactions does not syncs or gossip invalid transactions": [
+    {
+      "name": "accountA",
+      "spendingKey": "811f6b0fede10fa14d3acf76d21dabc13244ae25457f63067d97f8d34ac35e08",
+      "incomingViewKey": "825a1cf8ef9ec431c88caf1b828ef70e211bc491a8a8bcc34392197c0e4b7f00",
+      "outgoingViewKey": "97c48231481909002747e889052fd3b854b1bc24782623281beba5556e49ab44",
+      "publicAddress": "a43f4f0e5b90da6e6ba7a5e2d29957a80bc2e61e4b23aa1fde001cc5f90f37350d068ab6cdc24be5435cab",
+      "rescan": null,
+      "displayName": "accountA (faf3fc9)"
+    },
+    {
+      "name": "accountB",
+      "spendingKey": "f7cbc6b71593286d5cb6eb343a904084451531d13c2d59c55dab3071e7d4c798",
+      "incomingViewKey": "4432c7ccaac016505e4ce9fba50f5d5595126390b34bdd0504c6608468063000",
+      "outgoingViewKey": "f5c18a8f1b7e82c84ad4b904d23b4aac79ba649da903e1c653f50d4c63374c71",
+      "publicAddress": "19a97fa900e886e75600ce96bd3f8f892d1deb7ce7c6ad77f1bc3437e70d18229a20af326460547f6f3caf",
+      "rescan": null,
+      "displayName": "accountB (a35dd8c)"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:7rTHmHhGxzjYxKCwuYxDoJjprIaWDjjGI84NAV0QZgw="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1658429850376,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "4151D8FE83F00DFC5019AFBFF2B8A77156120B53EF194C8CE1B5B243A7F2D63E",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI1JNKEfuL0puUaO9pptvvGV4gfI+1T+xyYTrkVcGVJLYuBOoyCgPxKU32CtUwMbH7KUS9+AUq8ymiY6Mqfioh7wPpA1InbbbaAM3MwHj9OO8Ia1kQvFgFDQMZz+8m1nsgelzY1QkUbtoNGHYpGnzoZZhDkYg9XAHW+In1D1w3FERb163UBUS4QymFLPZ2qA/4x8SvgNM1ZpZQaKwlRZ7uHZjftRrTwfCZ/cUheTXXSwY1G+FN/O2zPnmOwpB/zHIEKx4kqIdV6b3gZDykj1NrsP3EbDaqwY0pIcAAZShcpyjMaocq44jNGbRnX+dRstj1f/l42Yo6xZV/hWsDAwm1Or5BVdzk6qjUMI+gJk2iktLhMSfLosENoXHbWEN3iRXVJdoV1cCpQgExj38VC/RKNursUcrolS6MMfLBTvJbZh7FW//A2HNkWn95MFySz4BpPnh8gcn5fhQC+lClbTA3DTEO20sxxMmrZzfLTIiIRvMHI3IGi0Bx0e6QyT7r9vVp2wKkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4PiRQHZDvs0E8JNeWu83gy0WLVJW+MzbxZYyCDVo2lcyNz9JAvfmpPLw7C+MDJGMUd06TdVZtlNrk8t5ueP+Cw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "4151D8FE83F00DFC5019AFBFF2B8A77156120B53EF194C8CE1B5B243A7F2D63E",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:yrCKll3T6spGGip9F9Eb0e52xfodaeV/Hg4Jj6SGTgE="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "1FF37B23589C4A9CD0667A5780BF0FA46799C0A4AE5CD826D93F102274429566",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1658429851987,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "E36BB1D4B2B1881BADE1AD78CF2B6C18288FAEB3119ED1958BA11E3754FAE8E3",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJDa7rlZodpfh2lMmnjjjw66DoltZAg8u0Qtj9Mog6k51Si28dS1XJ9/6slE4NB9JaSWfEO6j931kVUY+lrOSuuMXB2Ppb+hpQL/jOl7vTUINUfgZr7OqghZaUhZju34kRhhpl4BT9BbX9hGZtXqnExcgradRSq/mKrNZjAqvQjXG5+BTMZ58KHuTLYfMydSJJiewlvcqcWXuZYFeEXBa/3WvT6eJi8HrMtc8BdYlgBbOua55qYZHfaXkzeuvj35BAIA5agtr6KXOKjXnLbM/cG5GExPGvc73NWSJN3JlowrdiS46HaeCL0patSFbc79xkMnCzvp+gK5FVPoS6vl8UXx2Qf52qPe0hD8DfwEyF/SWgPnQUnkHJnwtvtQeDcJPZDVIaB9c9RLTitE19Ri3ZJecVOWFJ6pW0vqpRabRhJBY/zXxkfu6PGPUdUh7p2Dn5CEyOZT36kXHQ+pYlKKVyf4eSOCesi19qWGtXCM5eqT32zaLPPseom/e8oyA75BAxyGTkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjKgGQPWXu+ttNsP16mN2+oIyKSQPxTmyeCsWMPXRL74ughVF4ZNER8gEX6czdj359p4Z50Nu0jzyEXcFQIaRBg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKGJKK2HD1CGJ/SFDqbmdd7/WgXlCu/wQKSwUWdA3K+a6hnZD4XkW0AlFctvUh72i7WnMkcEVmL2bA1Ddg18rdGEL+Ov/rXR9j0cetBPwejbnd007g8cNnhWNmfGOUDSbA1sSZgiATL0I0cyixZ0gul9QBaGKdiSlFJm/qCcta2RYeox1r1DGDdD5g8NbckiQatU2lIEP7yKUGQM1vg43ObDwAoZeyMz8spd54B+cljjbYKDltbkkIhc4nHCSjzaZR70Gv+FTGQ1tfWHcTb6Vw3aptCFIwlTq8+ynh0LoyJMArjKac2VpmizPh341mFw3J1KqhtKlkG7K9u330WeSynutMeYeEbHONjEoLC5jEOgmOmshpYOOMYjzg0BXRBmDAQAAACBz/qnrayAWgS/EzM+XQuF4nmzn7JSfUtrz4yNLrR4DTWkGmat/Qsl33WD1GDrQiCMdDoYonBrH+DEU3UH7JIOj1FIE5ilbv+humZifOOHGzDI10BUaxLru8e8oyuBGAOGAKSYW0Viuai+x6fz4yrsyQJwYYwDwdZ+DaEa5UnYsINLrUkXUEwREmEqAI/MDjugCnnmAlTExZ2dOkBeSYnE85XVLceFIX++EYSYqiRQhhMnHOm2BdQYjUWnUgpy6MoNMKb2GHc036AplM/W8sYyMIFzc6RAGj7fK05bxA6FKoWpS41Dte9WpTZL6Dt69fGxbkcf0MY+GiS87pfGGPLEVPbo06d/qC2zXpVA5P0r+mQBlKy+VFlRx33MZl2duM06Bmy6ZvOOXI/xjwShAf0bHoS18BH/Scl1qYrAfUaqapObV3YYx7ZIwKKqeOJWOc4DizlWysnRmVMs3bU3bIlHLBcXGGKMgJEvYslh/9M+ug3e1h624oSosAh9bHpvRqK8rhZopendlokxVICjF5pLCohPRpIjAqF0KSV5wja52dz8++120jjIrO7+9KxiYB+L92vQY9RNSiug1mi5jdPeUJ1SR7L5EkQbmwce9uzmzXB6WZKwhzKxM3ftqDgaXHiunvwfu2jzLM7HrvVfT8Gg/Lkf12HIOXcBluJbfx+AGr5jln621njFPIFivWcuWdxCUQAYeZq2iVh/qzgAiLPcAuk7VYsPcDba3DFpM7DigyC21Lkp+OS1IMGoaocMB30sSR/NmNjv4BwfYGl7eU3GTVHrbYwwNNvOkgGbXEt3Zpnd/IP/CM6a5lElmxQjKssiCkPcToczhAbS8xCGNSfmeoBF8nAmUjAvwXJ/yYWIuYxHEBT+wnG84HQQZwXOWkKYbBWlfqoPaBZlQYyyc1QZy4nw7pzi9O2JnVHt/DsK4VMiz44XX9e0M+O2j6fi9xqVNMRouCnpC1JG4waUVFWODTPx9HzLDnRJ8smcB89hhz5Csn73rCetgoDbvXfZk3NcAOD7v2n+MJgiAp9n2fAY4KPDUYHHnGyfYp311AA441EZMIQdRejUOb3TzoWfMmQ7zV9lVZo8ZrJaTCXK/yVewaAYH4g5tjuuruX/poU80YSAHwosFUYHyUerUMsNUyAY29QkpbNTMAQyfPLuyL4oHEf5eVgtCpJdY56VN/gEyhW/oacZ2R752EGuP0RU8/D0cS5pFzCbavcPh/QLrBoac3UyYeUIHpO2IvOh5ixGOl7b7uOyAUj5Xicz1b1zLmGy+6Ngob5mYTKudGVcHS45VhLFSkqYUp65hV8WzzXUQqK6hnE7lDbU1MBTh+lYNO4AjnQv4/ws+QwKfwwDOy7F4YnEfSfSktity7Q961ufKbDmrPo1ryKtiUfewaADT4a4Sac8sABARpcDHbeR2aSL0AwZ9gOpKFkmxr5pGcYzdi2X6eA1Bg=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -11,6 +11,7 @@ import net from 'net'
 import { v4 as uuid } from 'uuid'
 import ws from 'ws'
 import { Assert } from '../assert'
+import { VerificationResultReason } from '../consensus/verifier'
 import { BlockSerde } from '../primitives/block'
 import {
   useAccountFixture,
@@ -19,7 +20,7 @@ import {
   useMinersTxFixture,
 } from '../testUtilities'
 import { makeBlockAfter } from '../testUtilities/helpers/blockchain'
-import { mockChain, mockNode, mockTransaction, mockWorkerPool } from '../testUtilities/mocks'
+import { mockChain, mockNode } from '../testUtilities/mocks'
 import { createNodeTest } from '../testUtilities/nodeTest'
 import { CannotSatisfyRequest } from './messages/cannotSatisfyRequest'
 import { DisconnectingMessage } from './messages/disconnecting'
@@ -394,170 +395,171 @@ describe('PeerNetwork', () => {
     })
 
     describe('handles new transactions', () => {
-      describe('when the worker pool is saturated', () => {
-        it('does not accept or sync transactions', async () => {
-          const node = mockNode()
-          const peerNetwork = new PeerNetwork({
-            identity: mockPrivateIdentity('local'),
-            agent: 'sdk/1/cli',
-            webSocket: ws,
-            node,
-            chain: {
-              ...mockChain(),
-              verifier: {
-                verifyNewTransaction: jest.fn(),
-              },
-            },
-            hostsStore: mockHostsStore(),
-          })
+      const nodeTest = createNodeTest()
+      it('does not accept or sync transactions when the worker pool is saturated', async () => {
+        const { peerNetwork, node } = nodeTest
 
-          const { accounts, memPool, workerPool } = node
-          jest.spyOn(workerPool, 'saturated').mockImplementationOnce(() => false)
-          const acceptTransaction = jest.spyOn(memPool, 'acceptTransaction')
-          const syncTransaction = jest.spyOn(accounts, 'syncTransaction')
+        const { accounts, memPool, workerPool } = node
+        const accountA = await useAccountFixture(accounts, 'accountA')
+        const accountB = await useAccountFixture(accounts, 'accountB')
+        const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-          const gossip = await peerNetwork['onNewTransaction']({
-            peerIdentity: '',
-            message: new NewTransactionMessage(Buffer.from(''), Buffer.alloc(16, 'nonce')),
-          })
+        Object.defineProperty(workerPool, 'saturated', { get: () => true })
 
-          expect(gossip).toBe(false)
-          expect(acceptTransaction).not.toHaveBeenCalled()
-          expect(syncTransaction).not.toHaveBeenCalled()
-        })
+        const acceptTransaction = jest.spyOn(memPool, 'acceptTransaction')
+        const syncTransaction = jest.spyOn(accounts, 'syncTransaction')
+
+        const { peer } = getConnectedPeer(peerNetwork.peerManager)
+
+        const gossip = await peerNetwork['onNewTransaction'](
+          peer,
+          new NewTransactionMessage(transaction.serialize(), Buffer.alloc(16, 'nonce')),
+        )
+
+        expect(gossip).toBe(false)
+        expect(acceptTransaction).not.toHaveBeenCalled()
+        expect(syncTransaction).not.toHaveBeenCalled()
       })
 
-      describe('when the node is syncing', () => {
-        it('does not accept or sync transactions', async () => {
-          const chain = {
-            ...mockChain(),
-            synced: false,
-            verifier: {
-              verifyNewTransaction: jest.fn(),
-            },
-          }
-          const node = {
-            ...mockNode(),
-            chain,
-          }
-          const peerNetwork = new PeerNetwork({
-            identity: mockPrivateIdentity('local'),
-            agent: 'sdk/1/cli',
-            webSocket: ws,
-            node,
-            chain,
-            hostsStore: mockHostsStore(),
-          })
+      it('does not accept or sync transactions when the node is syncing', async () => {
+        const { peerNetwork, node } = nodeTest
 
-          const { accounts, memPool } = node
-          const acceptTransaction = jest.spyOn(memPool, 'acceptTransaction')
-          const syncTransaction = jest.spyOn(accounts, 'syncTransaction')
+        const { accounts, memPool, chain } = node
+        const accountA = await useAccountFixture(accounts, 'accountA')
+        const accountB = await useAccountFixture(accounts, 'accountB')
+        const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-          const gossip = await peerNetwork['onNewTransaction']({
-            peerIdentity: '',
-            message: new NewTransactionMessage(Buffer.from(''), Buffer.alloc(16, 'nonce')),
-          })
+        chain.synced = false
 
-          expect(gossip).toBe(false)
-          expect(acceptTransaction).not.toHaveBeenCalled()
-          expect(syncTransaction).not.toHaveBeenCalled()
-        })
+        const acceptTransaction = jest.spyOn(memPool, 'acceptTransaction')
+        const syncTransaction = jest.spyOn(accounts, 'syncTransaction')
+
+        const { peer } = getConnectedPeer(peerNetwork.peerManager)
+
+        const gossip = await peerNetwork['onNewTransaction'](
+          peer,
+          new NewTransactionMessage(transaction.serialize(), Buffer.alloc(16, 'nonce')),
+        )
+
+        expect(gossip).toBe(false)
+        expect(acceptTransaction).not.toHaveBeenCalled()
+        expect(syncTransaction).not.toHaveBeenCalled()
       })
 
-      describe('accepts new transactions', () => {
-        it('verifies and syncs transactions', async () => {
-          const chain = mockChain()
-          const workerPool = {
-            ...mockWorkerPool,
-            saturated: false,
-          }
-          const node = {
-            ...mockNode(),
-            chain,
-            workerPool,
-          }
+      it('verifies and syncs the same transaction once', async () => {
+        const { peerNetwork, node } = nodeTest
+        const { accounts, memPool, chain } = node
 
-          const peerNetwork = new PeerNetwork({
-            identity: mockPrivateIdentity('local'),
-            agent: 'sdk/1/cli',
-            webSocket: ws,
-            node,
-            chain,
-            hostsStore: mockHostsStore(),
+        chain.synced = true
+        const accountA = await useAccountFixture(accounts, 'accountA')
+        const accountB = await useAccountFixture(accounts, 'accountB')
+        const { transaction } = await useBlockWithTx(node, accountA, accountB)
+
+        const verifyNewTransactionSpy = jest.spyOn(node.chain.verifier, 'verifyNewTransaction')
+
+        const verifyTransactionContextual = jest.spyOn(
+          node.chain.verifier,
+          'verifyTransactionNoncontextual',
+        )
+
+        const { peer } = getConnectedPeer(peerNetwork.peerManager)
+
+        const acceptTransaction = jest.spyOn(node.memPool, 'acceptTransaction')
+        const syncTransaction = jest.spyOn(node.accounts, 'syncTransaction')
+
+        const message = new NewTransactionMessage(transaction.serialize())
+
+        let gossip = await peerNetwork['onNewTransaction'](peer, message)
+
+        expect(gossip).toBe(true)
+
+        expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(1)
+        expect(verifyTransactionContextual).toHaveBeenCalledTimes(1)
+
+        expect(memPool.exists(transaction.hash())).toBe(true)
+        expect(acceptTransaction).toHaveBeenCalledTimes(1)
+
+        expect(syncTransaction).toHaveBeenCalledTimes(1)
+
+        expect(peer.state.identity).not.toBeNull()
+        peer.state.identity &&
+          expect(peerNetwork.knowsTransaction(transaction.hash(), peer.state.identity)).toBe(
+            true,
+          )
+
+        gossip = await peerNetwork['onNewTransaction'](peer, message)
+
+        // These functions should still only be called once
+        expect(gossip).toBe(false)
+
+        expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(1)
+        expect(verifyTransactionContextual).toHaveBeenCalledTimes(1)
+
+        expect(acceptTransaction).toHaveBeenCalledTimes(1)
+
+        expect(syncTransaction).toHaveBeenCalledTimes(1)
+
+        expect(peer.state.identity).not.toBeNull()
+        peer.state.identity &&
+          expect(peerNetwork.knowsTransaction(transaction.hash(), peer.state.identity)).toBe(
+            true,
+          )
+      })
+
+      it('does not syncs or gossip invalid transactions', async () => {
+        const { peerNetwork, node } = nodeTest
+        const { accounts, memPool, chain } = node
+
+        chain.synced = true
+
+        const accountA = await useAccountFixture(accounts, 'accountA')
+        const accountB = await useAccountFixture(accounts, 'accountB')
+        const { transaction } = await useBlockWithTx(node, accountA, accountB)
+
+        const verifyNewTransactionSpy = jest.spyOn(node.chain.verifier, 'verifyNewTransaction')
+
+        const verifyTransactionContextual = jest
+          .spyOn(node.chain.verifier, 'verifyTransactionNoncontextual')
+          .mockResolvedValueOnce({
+            valid: false,
+            reason: VerificationResultReason.DOUBLE_SPEND,
           })
 
-          // Spy on new transactions
-          const verifyNewTransactionSpy = jest
-            .spyOn(node.chain.verifier, 'verifyNewTransaction')
-            .mockReturnValue(mockTransaction())
+        const { peer } = getConnectedPeer(peerNetwork.peerManager)
 
-          const verifyTransactionContextual = jest
-            .spyOn(node.chain.verifier, 'verifyTransactionNoncontextual')
-            .mockReturnValue({ valid: true })
+        const acceptTransaction = jest.spyOn(node.memPool, 'acceptTransaction')
+        const syncTransaction = jest.spyOn(node.accounts, 'syncTransaction')
 
-          expect(node.workerPool.saturated).toEqual(false)
+        const message = new NewTransactionMessage(transaction.serialize())
 
-          const message = {
-            peerIdentity: '',
-            message: new NewTransactionMessage(Buffer.from(''), Buffer.alloc(16, 'nonce')),
-          }
+        const gossip = await peerNetwork['onNewTransaction'](peer, message)
 
-          const exists = jest.spyOn(node.memPool, 'exists').mockReturnValue(false)
-          const acceptTransaction = jest
-            .spyOn(node.memPool, 'acceptTransaction')
-            .mockReturnValueOnce(true)
-          const syncTransaction = jest.spyOn(node.accounts, 'syncTransaction')
+        expect(gossip).toBe(false)
 
-          let gossip = await peerNetwork['onNewTransaction'](message)
-          expect(gossip).toBe(true)
-          expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(1)
-          expect(verifyTransactionContextual).toHaveBeenCalledTimes(1)
-          expect(acceptTransaction).toHaveBeenCalledTimes(1)
-          expect(syncTransaction).toHaveBeenCalledTimes(1)
+        expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(1)
+        expect(verifyTransactionContextual).toHaveBeenCalledTimes(1)
 
-          acceptTransaction.mockReturnValueOnce(false)
+        expect(memPool.exists(transaction.hash())).toBe(false)
+        expect(acceptTransaction).not.toHaveBeenCalled()
 
-          gossip = await peerNetwork['onNewTransaction'](message)
-          expect(gossip).toBe(false)
-          expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(2)
-          expect(verifyTransactionContextual).toHaveBeenCalledTimes(2)
-          expect(acceptTransaction).toHaveBeenCalledTimes(2)
-          expect(syncTransaction).toHaveBeenCalledTimes(2)
+        expect(syncTransaction).not.toHaveBeenCalled()
 
-          exists.mockReturnValueOnce(true)
-
-          gossip = await peerNetwork['onNewTransaction'](message)
-          expect(gossip).toBe(true)
-          expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(3)
-          expect(verifyTransactionContextual).toHaveBeenCalledTimes(3)
-          expect(acceptTransaction).toHaveBeenCalledTimes(2)
-          expect(syncTransaction).toHaveBeenCalledTimes(3)
-
-          verifyTransactionContextual.mockReturnValue({ valid: false, reason: 'foo' })
-
-          gossip = await peerNetwork['onNewTransaction'](message)
-          expect(gossip).toBe(false)
-          expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(4)
-          expect(verifyTransactionContextual).toHaveBeenCalledTimes(4)
-          expect(acceptTransaction).toHaveBeenCalledTimes(2)
-          expect(syncTransaction).toHaveBeenCalledTimes(3)
-        })
+        expect(peer.state.identity).not.toBeNull()
+        peer.state.identity &&
+          expect(peerNetwork.knowsTransaction(transaction.hash(), peer.state.identity)).toBe(
+            true,
+          )
       })
     })
   })
 
   describe('when enable syncing is false', () => {
+    const nodeTest = createNodeTest(false, { config: { enableSyncing: false } })
+
     it('does not handle blocks', async () => {
-      const peerNetwork = new PeerNetwork({
-        identity: mockPrivateIdentity('local'),
-        agent: 'sdk/1/cli',
-        webSocket: ws,
-        node: mockNode(),
-        chain: mockChain(),
-        hostsStore: mockHostsStore(),
-        enableSyncing: false,
-      })
+      const { peerNetwork, node } = nodeTest
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
+
       const block = {
         header: {
           graffiti: 'chipotle',
@@ -581,34 +583,39 @@ describe('PeerNetwork', () => {
         transactions: [],
       }
 
+      jest.spyOn(node.syncer, 'addNewBlock')
+
       const peerIdentity = peer.getIdentityOrThrow()
       const gossip = await peerNetwork['onNewBlock']({
         peerIdentity,
         message: new NewBlockMessage(block, Buffer.alloc(16, 'nonce')),
       })
+
       expect(gossip).toBe(false)
-      expect(peerNetwork['node']['syncer'].addNewBlock).not.toHaveBeenCalled()
+      expect(node.syncer.addNewBlock).not.toHaveBeenCalled()
     })
 
     it('does not handle transactions', async () => {
-      const peerNetwork = new PeerNetwork({
-        identity: mockPrivateIdentity('local'),
-        agent: 'sdk/1/cli',
-        webSocket: ws,
-        node: mockNode(),
-        chain: mockChain(),
-        hostsStore: mockHostsStore(),
-        enableSyncing: false,
-      })
+      const { peerNetwork, node } = nodeTest
+
+      const { accounts, memPool, chain } = node
+      const accountA = await useAccountFixture(accounts, 'accountA')
+      const accountB = await useAccountFixture(accounts, 'accountB')
+      const { transaction } = await useBlockWithTx(node, accountA, accountB)
+
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
 
-      const peerIdentity = peer.getIdentityOrThrow()
-      const gossip = await peerNetwork['onNewTransaction']({
-        peerIdentity,
-        message: new NewTransactionMessage(Buffer.from(''), Buffer.alloc(16, 'nonce')),
-      })
+      jest.spyOn(chain.verifier, 'verifyNewTransaction')
+      jest.spyOn(memPool, 'acceptTransaction')
+
+      const gossip = await peerNetwork['onNewTransaction'](
+        peer,
+        new NewTransactionMessage(transaction.serialize()),
+      )
+
       expect(gossip).toBe(false)
-      expect(peerNetwork['chain']['verifier'].verifyNewTransaction).not.toHaveBeenCalled()
+      expect(chain.verifier.verifyNewTransaction).not.toHaveBeenCalled()
+      expect(memPool.acceptTransaction).not.toHaveBeenCalled()
     })
   })
 })

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -116,6 +116,9 @@ export class PeerNetwork {
     boolean
   >(8192, null, BufferMap)
 
+  // A cache that keeps track of which peers have seen which transactions. This allows
+  // us to not send the same transaction to a peer more than once. TODO(daniel): We want to
+  // change this to use an RLU cache so that we don't get false positives
   private readonly knownTransactionFilter: RollingFilter = new RollingFilter(
     GOSSIP_FILTER_SIZE * 50,
     GOSSIP_FILTER_FP_RATE,

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { RollingFilter } from '@ironfish/bfilter'
+import LRU from 'blru'
+import { BufferMap } from 'buffer-map'
 import tweetnacl from 'tweetnacl'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
@@ -18,9 +20,9 @@ import { Platform } from '../platform'
 import { Transaction } from '../primitives'
 import { BlockSerde, SerializedBlock } from '../primitives/block'
 import { BlockHeader } from '../primitives/blockheader'
-import { SerializedTransaction } from '../primitives/transaction'
+import { SerializedTransaction, TransactionHash } from '../primitives/transaction'
 import { ErrorUtils } from '../utils'
-import { PrivateIdentity } from './identity'
+import { Identity, PrivateIdentity } from './identity'
 import { CannotSatisfyRequest } from './messages/cannotSatisfyRequest'
 import { DisconnectingMessage, DisconnectingReason } from './messages/disconnecting'
 import { GetBlockHashesRequest, GetBlockHashesResponse } from './messages/getBlockHashes'
@@ -106,6 +108,18 @@ export class PeerNetwork {
   private readonly seenGossipFilter: RollingFilter
   private readonly requests: Map<RpcId, RpcRequest>
   private readonly enableSyncing: boolean
+
+  // A cache that keeps track of transactions we've synced to the wallet so we don't
+  // waste time verifying, validating and syncing them multiple times
+  private readonly syncedTransactionHashes: LRU<TransactionHash, boolean> = new LRU<
+    TransactionHash,
+    boolean
+  >(8192, null, BufferMap)
+
+  private readonly knownTransactionFilter: RollingFilter = new RollingFilter(
+    GOSSIP_FILTER_SIZE * 50,
+    GOSSIP_FILTER_FP_RATE,
+  )
 
   /**
    * If the peer network is ready for messages to be sent or not
@@ -199,7 +213,17 @@ export class PeerNetwork {
     this.node.accounts.onBroadcastTransaction.on((transaction) => {
       const serializedTransaction = transaction.serialize()
 
-      this.gossip(new NewTransactionMessage(serializedTransaction))
+      const message = new NewTransactionMessage(serializedTransaction)
+
+      for (const peer of this.peerManager.identifiedPeers.values()) {
+        if (peer.state.type !== 'CONNECTED') {
+          continue
+        }
+
+        if (peer.send(message)) {
+          this.markKnowsTransaction(transaction.hash(), peer.state.identity)
+        }
+      }
     })
   }
 
@@ -314,16 +338,6 @@ export class PeerNetwork {
   }
 
   /**
-   * Send the message to all connected peers with the expectation that they
-   * will forward it to their other peers. The goal is for everyone to
-   * receive the message.
-   */
-  private gossip(message: GossipNetworkMessage): void {
-    this.seenGossipFilter.add(message.nonce)
-    this.peerManager.broadcast(message)
-  }
-
-  /**
    * Send a block to all connected peers who haven't yet received the block.
    */
   private broadcastBlock(message: NewBlockMessage): void {
@@ -344,29 +358,35 @@ export class PeerNetwork {
     }
   }
 
+  knowsTransaction(hash: TransactionHash, peerId: Identity): boolean {
+    const toTest = Buffer.concat([hash, Buffer.from(peerId)])
+    return this.knownTransactionFilter.test(toTest)
+  }
+
+  private markKnowsTransaction(hash: TransactionHash, peerId: Identity): void {
+    const toAdd = Buffer.concat([hash, Buffer.from(peerId)])
+    this.knownTransactionFilter.add(toAdd)
+  }
+
+  private connectedPeersWithoutTransaction(hash: TransactionHash): ReadonlyArray<Peer> {
+    return [...this.peerManager.identifiedPeers.values()].filter((p) => {
+      return p.state.type === 'CONNECTED' && !this.knowsTransaction(hash, p.state.identity)
+    })
+  }
+
   private broadcastTransaction(
-    gossipMessage: NewTransactionMessage,
-    peerIdentity: string,
+    message: NewTransactionMessage,
+    peersToSendTo: ReadonlyArray<Peer>,
   ): void {
-    const peersConnections =
-      this.peerManager.identifiedPeers.get(peerIdentity)?.knownPeers || new Map<string, Peer>()
-
-    for (const activePeer of this.peerManager.getConnectedPeers()) {
-      if (activePeer.state.type !== 'CONNECTED') {
-        throw new Error('Peer not in state CONNECTED returned from getConnectedPeers')
-      }
-
-      // To reduce network noise, we don't send the message back to the peer that
-      // sent it to us, or any of the peers connected to it
-      if (
-        activePeer.state.identity === peerIdentity ||
-        (peersConnections.has(activePeer.state.identity) &&
-          peersConnections.get(activePeer.state.identity)?.state.type === 'CONNECTED')
-      ) {
+    for (const peer of peersToSendTo) {
+      if (peer.state.type !== 'CONNECTED') {
         continue
       }
 
-      activePeer.send(gossipMessage)
+      if (peer.send(message)) {
+        const hash = new Transaction(message.transaction).hash()
+        this.markKnowsTransaction(hash, peer.state.identity)
+      }
     }
   }
 
@@ -514,20 +534,19 @@ export class PeerNetwork {
     peer: Peer,
     gossipMessage: GossipNetworkMessage,
   ): Promise<void> {
-    if (!this.seenGossipFilter.added(gossipMessage.nonce)) {
-      return
-    }
-
     const peerIdentity = peer.getIdentityOrThrow()
 
     if (gossipMessage instanceof NewBlockMessage) {
+      if (!this.seenGossipFilter.added(gossipMessage.nonce)) {
+        return
+      }
       const gossip = await this.onNewBlock({ peerIdentity, message: gossipMessage })
 
       if (gossip) {
         this.broadcastBlock(gossipMessage)
       }
     } else if (gossipMessage instanceof NewTransactionMessage) {
-      await this.onNewTransaction({ peerIdentity, message: gossipMessage })
+      await this.onNewTransaction(peer, gossipMessage)
     } else {
       throw new Error(`Invalid gossip message type: '${gossipMessage.type}'`)
     }
@@ -814,10 +833,18 @@ export class PeerNetwork {
     }
   }
 
-  private async onNewTransaction(
-    message: IncomingPeerMessage<NewTransactionMessage>,
-  ): Promise<boolean> {
+  private async onNewTransaction(peer: Peer, message: NewTransactionMessage): Promise<boolean> {
     const received = new Date()
+
+    // Mark the peer as knowing about the transaction as well as their known peers
+    // since they probably sent it to them. We will remove the known peers once we start
+    // gossiping message based on hash
+    const hash = new Transaction(message.transaction).hash()
+    peer.state.identity && this.markKnowsTransaction(hash, peer.state.identity)
+
+    for (const [_, knownPeer] of peer.knownPeers) {
+      knownPeer.state.identity && this.markKnowsTransaction(hash, knownPeer.state.identity)
+    }
 
     if (!this.enableSyncing) {
       return false
@@ -836,8 +863,22 @@ export class PeerNetwork {
       return false
     }
 
+    const peersToSendTo = this.connectedPeersWithoutTransaction(hash)
+
+    /*
+     * When we receive a new transaction we want to (1) sync it to the wallet (2) add it to the mempool
+     * and (3) send it to peers who haven't received it yet. If we've already done these 3 things then
+     * return early and don't validate and verify the transaction again */
+    if (
+      this.syncedTransactionHashes.has(hash) &&
+      this.node.memPool.exists(hash) &&
+      peersToSendTo.length === 0
+    ) {
+      return false
+    }
+
     // Force lazy deserialization of the transaction as a first sanity check
-    const transaction = this.chain.verifier.verifyNewTransaction(message.message.transaction)
+    const transaction = this.chain.verifier.verifyNewTransaction(message.transaction)
 
     // Validate the transaction, so that the account and mempool do not receive
     // an invalid transaction, and we do not gossip.
@@ -855,18 +896,19 @@ export class PeerNetwork {
     // The accounts need to know about the transaction since it could be
     // relevant to the accounts, despite coming from a different node.
     await this.node.accounts.syncTransaction(transaction, {})
+    this.syncedTransactionHashes.set(hash, true)
 
     // If we know the mempool already has this transaction, we know that
     // the mempool won't accept it, but it is still a valid transaction
     // so we want to gossip it.
     if (this.node.memPool.exists(transaction.hash())) {
-      this.broadcastTransaction(message.message, message.peerIdentity)
+      this.broadcastTransaction(message, peersToSendTo)
       return true
     }
 
     if (await this.node.memPool.acceptTransaction(transaction, false)) {
       this.onTransactionAccepted.emit(transaction, received)
-      this.broadcastTransaction(message.message, message.peerIdentity)
+      this.broadcastTransaction(message, peersToSendTo)
       return true
     }
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -358,22 +358,6 @@ export class PeerNetwork {
     }
   }
 
-  knowsTransaction(hash: TransactionHash, peerId: Identity): boolean {
-    const toTest = Buffer.concat([hash, Buffer.from(peerId)])
-    return this.knownTransactionFilter.test(toTest)
-  }
-
-  private markKnowsTransaction(hash: TransactionHash, peerId: Identity): void {
-    const toAdd = Buffer.concat([hash, Buffer.from(peerId)])
-    this.knownTransactionFilter.add(toAdd)
-  }
-
-  private connectedPeersWithoutTransaction(hash: TransactionHash): ReadonlyArray<Peer> {
-    return [...this.peerManager.identifiedPeers.values()].filter((p) => {
-      return p.state.type === 'CONNECTED' && !this.knowsTransaction(hash, p.state.identity)
-    })
-  }
-
   private broadcastTransaction(
     message: NewTransactionMessage,
     peersToSendTo: ReadonlyArray<Peer>,
@@ -388,6 +372,22 @@ export class PeerNetwork {
         this.markKnowsTransaction(hash, peer.state.identity)
       }
     }
+  }
+
+  knowsTransaction(hash: TransactionHash, peerId: Identity): boolean {
+    const toTest = Buffer.concat([hash, Buffer.from(peerId)])
+    return this.knownTransactionFilter.test(toTest)
+  }
+
+  private markKnowsTransaction(hash: TransactionHash, peerId: Identity): void {
+    const toAdd = Buffer.concat([hash, Buffer.from(peerId)])
+    this.knownTransactionFilter.add(toAdd)
+  }
+
+  private connectedPeersWithoutTransaction(hash: TransactionHash): ReadonlyArray<Peer> {
+    return [...this.peerManager.identifiedPeers.values()].filter((p) => {
+      return p.state.type === 'CONNECTED' && !this.knowsTransaction(hash, p.state.identity)
+    })
   }
 
   /**

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -741,15 +741,6 @@ export class PeerManager {
     return !!peer.state.identity && this.banned.has(peer.state.identity)
   }
 
-  /**
-   * Send a message to all connected peers.
-   */
-  broadcast(message: NetworkMessage): void {
-    for (const peer of this.getConnectedPeers()) {
-      peer.send(message)
-    }
-  }
-
   start(): void {
     this.requestPeerListHandle = setInterval(() => this.requestPeerList(), 60000)
     this.disposePeersHandle = setInterval(() => this.disposePeers(), 2000)


### PR DESCRIPTION
## Summary
Outlined in the [transaction gossip proposal](https://coda.io/d/Gossip_d7HSvA-Pxcz/Transaction-Gossip_sulxZ#_luNdn). Create an rolling bloom filter that stores which transaction hashes different peers have seen.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
