### PR TITLE
Batch verify transactions

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -14,6 +14,7 @@ export interface NativeSpendProof {
   rootHash: Buffer
   nullifier: Buffer
 }
+export function verifyTransactions(rawTransactions: Array<Buffer>): boolean
 export interface Key {
   spending_key: string
   incoming_view_key: string

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -14,7 +14,7 @@ export interface NativeSpendProof {
   rootHash: Buffer
   nullifier: Buffer
 }
-export function verifyTransactions(rawTransactions: Array<Buffer>): boolean
+export function verifyTransactions(serializedTransactions: Array<Buffer>): boolean
 export interface Key {
   spending_key: string
   incoming_view_key: string

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -236,12 +236,13 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { NoteEncrypted, Note, TransactionPosted, Transaction, generateKey, generateNewPublicAddress, initializeSapling, FoundBlockResult, ThreadPoolHandler } = nativeBinding
+const { NoteEncrypted, Note, TransactionPosted, Transaction, verifyTransactions, generateKey, generateNewPublicAddress, initializeSapling, FoundBlockResult, ThreadPoolHandler } = nativeBinding
 
 module.exports.NoteEncrypted = NoteEncrypted
 module.exports.Note = Note
 module.exports.TransactionPosted = TransactionPosted
 module.exports.Transaction = Transaction
+module.exports.verifyTransactions = verifyTransactions
 module.exports.generateKey = generateKey
 module.exports.generateNewPublicAddress = generateNewPublicAddress
 module.exports.initializeSapling = initializeSapling

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -267,13 +267,11 @@ impl NativeTransaction {
 }
 
 #[napi]
-pub fn verify_transactions(raw_transactions: Vec<Buffer>) -> bool {
+pub fn verify_transactions(serialized_transactions: Vec<Buffer>) -> bool {
     let mut transactions: Vec<Transaction> = vec![];
 
-    for tx_bytes in raw_transactions {
-        let mut cursor = std::io::Cursor::new(tx_bytes);
-
-        match Transaction::read(SAPLING.clone(), &mut cursor) {
+    for tx_bytes in serialized_transactions {
+        match Transaction::read(SAPLING.clone(), &mut tx_bytes.as_ref()) {
             Ok(tx) => transactions.push(tx),
             Err(_) => return false,
         }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -630,14 +630,16 @@ pub fn batch_verify_transactions(
     }
 
     if spend_verifier
-        .verify(&mut OsRng, &sapling.spend_params.vk)
+        // .verify(&mut OsRng, &sapling.spend_params.vk)
+        .verify_multicore(&sapling.spend_params.vk)
         .is_err()
     {
         return Err(SaplingProofError::VerificationFailed.into());
     }
 
     if receipt_verifier
-        .verify(&mut OsRng, &sapling.receipt_params.vk)
+        // .verify(&mut OsRng, &sapling.receipt_params.vk)
+        .verify_multicore(&sapling.receipt_params.vk)
         .is_err()
     {
         return Err(SaplingProofError::VerificationFailed.into());

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -437,10 +437,8 @@ impl Transaction {
             binding_verification_key += spend.value_commitment;
         }
 
-        // TODO: Try verify_multicore
         if spends_verifier
-            // .verify(&mut OsRng, &self.sapling.spend_params.vk)
-            .verify_multicore(&self.sapling.spend_params.vk)
+            .verify(&mut OsRng, &self.sapling.spend_params.vk)
             .is_err()
         {
             return Err(SaplingProofError::VerificationFailed.into());
@@ -455,10 +453,8 @@ impl Transaction {
             binding_verification_key -= receipt.merkle_note.value_commitment;
         }
 
-        // TODO: Try verify_multicore
         if receipts_verifier
-            // .verify(&mut OsRng, &self.sapling.receipt_params.vk)
-            .verify_multicore(&self.sapling.receipt_params.vk)
+            .verify(&mut OsRng, &self.sapling.receipt_params.vk)
             .is_err()
         {
             return Err(SaplingProofError::VerificationFailed.into());
@@ -630,16 +626,14 @@ pub fn batch_verify_transactions(
     }
 
     if spend_verifier
-        // .verify(&mut OsRng, &sapling.spend_params.vk)
-        .verify_multicore(&sapling.spend_params.vk)
+        .verify(&mut OsRng, &sapling.spend_params.vk)
         .is_err()
     {
         return Err(SaplingProofError::VerificationFailed.into());
     }
 
     if receipt_verifier
-        // .verify(&mut OsRng, &sapling.receipt_params.vk)
-        .verify_multicore(&sapling.receipt_params.vk)
+        .verify(&mut OsRng, &sapling.receipt_params.vk)
         .is_err()
     {
         return Err(SaplingProofError::VerificationFailed.into());

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -585,7 +585,7 @@ describe('Blockchain', () => {
   it('newBlock throws an error if the provided transactions are invalid', async () => {
     const minersFee = await useMinersTxFixture(nodeTest.accounts)
 
-    jest.spyOn(nodeTest.verifier, 'verifyTransactionContextual').mockResolvedValue({
+    jest.spyOn(nodeTest.verifier['workerPool'], 'verifyTransactions').mockResolvedValue({
       valid: false,
       reason: VerificationResultReason.INVALID_MINERS_FEE,
     })

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -60,6 +60,8 @@ import {
 
 const DATABASE_VERSION = 10
 
+const START_TIMER = Date.now()
+
 export class Blockchain {
   db: IDatabase
   logger: Logger
@@ -579,6 +581,9 @@ export class Blockchain {
     const addTime = BenchUtils.end(start)
     this.addSpeed.add(addTime)
     this.updateSynced()
+    if (Number(block.header.sequence) % 250 === 0) {
+      console.log('TIME ELAPSED:', Date.now() - START_TIMER)
+    }
 
     if (this.logAllBlockAdd || Number(block.header.sequence) % 20 === 0) {
       this.logger.info(

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -60,8 +60,6 @@ import {
 
 const DATABASE_VERSION = 10
 
-const START_TIMER = Date.now()
-
 export class Blockchain {
   db: IDatabase
   logger: Logger
@@ -581,9 +579,6 @@ export class Blockchain {
     const addTime = BenchUtils.end(start)
     this.addSpeed.add(addTime)
     this.updateSynced()
-    if (Number(block.header.sequence) % 250 === 0) {
-      console.log('TIME ELAPSED:', Date.now() - START_TIMER)
-    }
 
     if (this.logAllBlockAdd || Number(block.header.sequence) % 20 === 0) {
       this.logger.info(

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -63,7 +63,7 @@ describe('Verifier', () => {
     it('rejects a block with an invalid transaction', async () => {
       const block = await useMinerBlockFixture(nodeTest.chain)
 
-      jest.spyOn(nodeTest.verifier, 'verifyTransactionContextual').mockResolvedValue({
+      jest.spyOn(nodeTest.verifier['workerPool'], 'verifyTransactions').mockResolvedValue({
         valid: false,
         reason: VerificationResultReason.VERIFY_TRANSACTION,
       })

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -201,7 +201,6 @@ export class WorkerPool {
       : { valid: false, reason: VerificationResultReason.ERROR }
   }
 
-  // TODO: verify fees?
   async verifyTransactions(transactions: Array<Transaction>): Promise<VerificationResult> {
     const txs = transactions.map((tx) => tx.serialize())
     const request: VerifyTransactionsRequest = new VerifyTransactionsRequest(txs)

--- a/ironfish/src/workerPool/tasks/handlers.ts
+++ b/ironfish/src/workerPool/tasks/handlers.ts
@@ -11,6 +11,7 @@ import { SleepTask } from './sleep'
 import { SubmitTelemetryTask } from './submitTelemetry'
 import { UnboxMessageTask } from './unboxMessage'
 import { VerifyTransactionTask } from './verifyTransaction'
+import { VerifyTransactionsTask } from './verifyTransactions'
 import { WorkerMessage, WorkerMessageType } from './workerMessage'
 import { WorkerTask } from './workerTask'
 
@@ -26,6 +27,7 @@ export const handlers: Record<WorkerMessageType, WorkerTask | undefined> = {
   [WorkerMessageType.SubmitTelemetry]: SubmitTelemetryTask.getInstance(),
   [WorkerMessageType.UnboxMessage]: UnboxMessageTask.getInstance(),
   [WorkerMessageType.VerifyTransaction]: VerifyTransactionTask.getInstance(),
+  [WorkerMessageType.VerifyTransactions]: VerifyTransactionsTask.getInstance(),
 }
 
 export async function handleRequest(request: WorkerMessage, job: Job): Promise<WorkerMessage> {

--- a/ironfish/src/workerPool/tasks/verifyTransactions.ts
+++ b/ironfish/src/workerPool/tasks/verifyTransactions.ts
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { verifyTransactions } from '@ironfish/rust-nodejs'
+import bufio from 'bufio'
+import { WorkerMessage, WorkerMessageType } from './workerMessage'
+import { WorkerTask } from './workerTask'
+
+export class VerifyTransactionsRequest extends WorkerMessage {
+  readonly transactionsPosted: Buffer[]
+
+  constructor(transactionsPosted: Buffer[], jobId?: number) {
+    super(WorkerMessageType.VerifyTransactions, jobId)
+    this.transactionsPosted = transactionsPosted
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+    bw.writeU64(this.transactionsPosted.length)
+    for (const tx of this.transactionsPosted) {
+      bw.writeVarBytes(tx)
+    }
+    return bw.render()
+  }
+
+  static deserialize(jobId: number, buffer: Buffer): VerifyTransactionsRequest {
+    const reader = bufio.read(buffer, true)
+
+    const txLength = reader.readU64()
+    const transactionsPosted = []
+    for (let i = 0; i < txLength; i++) {
+      const tx = reader.readVarBytes()
+      transactionsPosted.push(tx)
+    }
+    return new VerifyTransactionsRequest(transactionsPosted, jobId)
+  }
+
+  getSize(): number {
+    let size = 8
+    for (const tx of this.transactionsPosted) {
+      size += bufio.sizeVarBytes(tx)
+    }
+    return size
+  }
+}
+
+export class VerifyTransactionsResponse extends WorkerMessage {
+  readonly verified: boolean
+
+  constructor(verified: boolean, jobId: number) {
+    super(WorkerMessageType.VerifyTransactions, jobId)
+    this.verified = verified
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+    bw.writeU8(Number(this.verified))
+    return bw.render()
+  }
+
+  static deserialize(jobId: number, buffer: Buffer): VerifyTransactionsResponse {
+    const reader = bufio.read(buffer, true)
+    const verified = Boolean(reader.readU8())
+    return new VerifyTransactionsResponse(verified, jobId)
+  }
+
+  getSize(): number {
+    return 1
+  }
+}
+
+export class VerifyTransactionsTask extends WorkerTask {
+  private static instance: VerifyTransactionsTask | undefined
+
+  static getInstance(): VerifyTransactionsTask {
+    if (!VerifyTransactionsTask.instance) {
+      VerifyTransactionsTask.instance = new VerifyTransactionsTask()
+    }
+    return VerifyTransactionsTask.instance
+  }
+
+  execute({
+    jobId,
+    transactionsPosted,
+  }: VerifyTransactionsRequest): VerifyTransactionsResponse {
+    let verified = false
+
+    try {
+      verified = verifyTransactions(transactionsPosted)
+    } catch (e) {
+      verified = false
+    }
+
+    return new VerifyTransactionsResponse(verified, jobId)
+  }
+}

--- a/ironfish/src/workerPool/tasks/workerMessage.ts
+++ b/ironfish/src/workerPool/tasks/workerMessage.ts
@@ -17,6 +17,7 @@ export enum WorkerMessageType {
   SubmitTelemetry = 8,
   UnboxMessage = 9,
   VerifyTransaction = 10,
+  VerifyTransactions = 11,
 }
 
 export abstract class WorkerMessage implements Serializable {

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -20,6 +20,10 @@ import { SleepRequest, SleepResponse } from './tasks/sleep'
 import { SubmitTelemetryRequest, SubmitTelemetryResponse } from './tasks/submitTelemetry'
 import { UnboxMessageRequest, UnboxMessageResponse } from './tasks/unboxMessage'
 import { VerifyTransactionRequest, VerifyTransactionResponse } from './tasks/verifyTransaction'
+import {
+  VerifyTransactionsRequest,
+  VerifyTransactionsResponse,
+} from './tasks/verifyTransactions'
 import { WorkerMessage, WorkerMessageType } from './tasks/workerMessage'
 
 export class Worker {
@@ -254,6 +258,8 @@ export class Worker {
         return UnboxMessageRequest.deserialize(jobId, request)
       case WorkerMessageType.VerifyTransaction:
         return VerifyTransactionRequest.deserialize(jobId, request)
+      case WorkerMessageType.VerifyTransactions:
+        return VerifyTransactionsRequest.deserialize(jobId, request)
     }
   }
 
@@ -285,6 +291,8 @@ export class Worker {
         return UnboxMessageResponse.deserialize(jobId, response)
       case WorkerMessageType.VerifyTransaction:
         return VerifyTransactionResponse.deserialize(jobId, response)
+      case WorkerMessageType.VerifyTransactions:
+        return VerifyTransactionsResponse.deserialize(jobId, response)
     }
   }
 }


### PR DESCRIPTION
## Summary

This includes a new worker task to verify multiple transactions at a time, which allow us to batch the spend and receipt proof verification. This was a new feature added in bellman 0.11 or 0.12, which lets us speed up the computation time required for verifying blocks.

This will improve speeds in the following scenarios:
- Block syncing (both actual syncing and when new blocks are gossiped)
- Block template verification (when miners find a block)

Here are some benchmarks:

Note that "batch w/ multicore" was a test using `verify_multicore` on the batch verifiers instead of the plain `verify`. This uses an internal-to-bellman `rayon` threadpool. I opted to not include this, as the speed-up is minor and I suspect it might cause issues on machines with less than 8 threads, although I don't have any handy to test on.

```
-- Sync first 1000 blocks
- M1
staging           : ~1m52s
rust upgrades only: ~1m46s
batch 10 notes    : ~1m41s (10% faster)
batch w/ multicore: ~1m35s
- 2015 Quad-core
staging           : ~4m22s
batch 10 notes    : ~3m25s (22% faster)
batch w/ multicore: ~3m22s

-- Sync first 2000 blocks
- M1
staging           : ~8m15s
rust upgrades only: ~7m46s
batch 10 notes    : ~6m46s (18% faster)
batch w/ multicore: ~6m31s
- 2015 Quad-core
staging           : ~19m15s
batch 10 notes    : ~14m12s (27% faster)
batch w/ multicore: ~14m00s
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
