### PR TITLE
Enable fullUnicode rendering for blessed

### DIFF
--- a/ironfish-cli/src/commands/peers/list.ts
+++ b/ironfish-cli/src/commands/peers/list.ts
@@ -66,7 +66,7 @@ export class ListCommand extends IronfishCommand {
     // Console log will create display issues with Blessed
     this.logger.pauseLogs()
 
-    const screen = blessed.screen({ smartCSR: true })
+    const screen = blessed.screen({ smartCSR: true, fullUnicode: true })
     const text = blessed.text()
     screen.append(text)
 

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -33,7 +33,7 @@ export default class Status extends IronfishCommand {
     // Console log will create display issues with Blessed
     this.logger.pauseLogs()
 
-    const screen = blessed.screen({ smartCSR: true })
+    const screen = blessed.screen({ smartCSR: true, fullUnicode: true })
     const statusText = blessed.text()
     screen.append(statusText)
 


### PR DESCRIPTION
## Summary
This will enable rendering of full-width unciode characters in terminals which replaced this characters to '??', '?', ''
I turned on this options in 2 places of code, status command (with possible issue in node name and graffiti) and peers list comand with -fenas flag (here we can get issue with node name).

## Testing Plan
Local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
