### PR TITLE
Add new renderSpan() to render time to human text

### DIFF
--- a/ironfish/src/utils/time.test.ts
+++ b/ironfish/src/utils/time.test.ts
@@ -12,5 +12,15 @@ describe('TimeUtils', () => {
       expect(TimeUtils.renderEstimate(50, 200, 1)).toEqual('2m 30s')
       expect(TimeUtils.renderEstimate(10, 10000, 1)).toEqual('2h 46m 30s')
     })
+
+    it('should render time spans', () => {
+      expect(TimeUtils.renderSpan(0.005)).toEqual('0.005ms')
+      expect(TimeUtils.renderSpan(0)).toEqual('0ms')
+      expect(TimeUtils.renderSpan(1000)).toEqual('1s')
+      expect(TimeUtils.renderSpan(1010)).toEqual('1s 10ms')
+      expect(TimeUtils.renderSpan(1150)).toEqual('1s 150ms')
+      expect(TimeUtils.renderSpan(330000)).toEqual('5m 30s')
+      expect(TimeUtils.renderSpan(7530000)).toEqual('2h 5m')
+    })
   })
 })

--- a/ironfish/src/utils/time.ts
+++ b/ironfish/src/utils/time.ts
@@ -88,28 +88,6 @@ const renderSpan = (
   }
 
   return parts.join(' ')
-
-  // if (time < MS_PER_MIN) {
-  //   const seconds = Math.floor(time / MS_PER_SEC)
-  //   time -= seconds * MS_PER_SEC
-  //   const milliseconds = time
-  //   return `${seconds.toFixed(0)}s ${milliseconds.toFixed(0)}ms`
-  // }
-
-  // if (time < MS_PER_HOUR) {
-  //   const minutes = Math.floor(time / MS_PER_MIN)
-  //   time -= minutes * MS_PER_MIN
-  //   const seconds = time / MS_PER_SEC
-  //   return `${minutes.toFixed(0)}m ${seconds.toFixed(0)}s`
-  // }
-
-  // const hours = Math.floor(time / MS_PER_HOUR)
-  // time -= hours * MS_PER_HOUR
-  // const minutes = Math.floor(time / MS_PER_MIN)
-  // time -= minutes * MS_PER_MIN
-  // const seconds = Math.floor(time / MS_PER_SEC)
-
-  // return `${hours.toFixed(0)}h ${minutes.toFixed(0)}m ${seconds.toFixed(0)}s`
 }
 
 export const TimeUtils = { renderEstimate, renderSpan }

--- a/ironfish/src/utils/time.ts
+++ b/ironfish/src/utils/time.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { MathUtils } from './math'
+
 const MS_PER_SEC = 1000.0
 const MS_PER_MIN = 60.0 * 1000.0
 const MS_PER_HOUR = 60.0 * 60.0 * 1000.0
@@ -14,35 +16,100 @@ const MS_PER_HOUR = 60.0 * 60.0 * 1000.0
  */
 const renderEstimate = (done: number, total: number, speed: number): string => {
   const remaining = total - done
-  let estimateSec = (remaining / speed) * 1000
+  const estimate = (remaining / speed) * 1000
 
   if (speed <= 0) {
     return 'N/A'
   }
 
-  if (estimateSec < 1000) {
+  if (estimate < 1000) {
     return 'soon'
   }
 
-  if (estimateSec < MS_PER_MIN) {
-    const seconds = Math.floor(estimateSec / MS_PER_SEC)
-    return `${seconds.toFixed(0)}s`
-  }
-
-  if (estimateSec < MS_PER_HOUR) {
-    const minutes = Math.floor(estimateSec / MS_PER_MIN)
-    estimateSec -= minutes * MS_PER_MIN
-    const seconds = estimateSec / MS_PER_SEC
-    return `${minutes.toFixed(0)}m ${seconds.toFixed(0)}s`
-  }
-
-  const hours = Math.floor(estimateSec / MS_PER_HOUR)
-  estimateSec -= hours * MS_PER_HOUR
-  const minutes = Math.floor(estimateSec / MS_PER_MIN)
-  estimateSec -= minutes * MS_PER_MIN
-  const seconds = Math.floor(estimateSec / MS_PER_SEC)
-
-  return `${hours.toFixed(0)}h ${minutes.toFixed(0)}m ${seconds.toFixed(0)}s`
+  return renderSpan(estimate, {
+    forceMillisecond: false,
+    forceSecond: true,
+    forceMinute: true,
+    forceHour: true,
+    hideMilliseconds: true,
+  })
 }
 
-export const TimeUtils = { renderEstimate }
+/**
+ * @param time time in milliseconds
+ */
+const renderSpan = (
+  time: number,
+  options?: {
+    forceHour?: boolean
+    forceMinute?: boolean
+    forceSecond?: boolean
+    forceMillisecond?: boolean
+    hideMilliseconds?: boolean
+  },
+): string => {
+  if (time < 1) {
+    return `${MathUtils.round(time, 4)}ms`
+  }
+
+  const parts = []
+  let magnitude = 0
+
+  if (time >= MS_PER_HOUR && (magnitude <= 5 || options?.forceHour)) {
+    const hours = Math.floor(time / MS_PER_HOUR)
+    time -= hours * MS_PER_HOUR
+    parts.push(`${hours.toFixed(0)}h`)
+    magnitude = Math.max(magnitude, 4)
+  }
+
+  if (time >= MS_PER_MIN && (magnitude <= 4 || options?.forceMinute)) {
+    const minutes = Math.floor(time / MS_PER_MIN)
+    time -= minutes * MS_PER_MIN
+    parts.push(`${minutes.toFixed(0)}m`)
+    magnitude = Math.max(magnitude, 3)
+  }
+
+  if (time >= MS_PER_SEC && (magnitude <= 3 || options?.forceSecond)) {
+    const seconds = Math.floor(time / MS_PER_SEC)
+    time -= seconds * MS_PER_SEC
+    parts.push(`${seconds.toFixed(0)}s`)
+    magnitude = Math.max(magnitude, 2)
+  }
+
+  if (time > 0 && (magnitude <= 2 || options?.forceMillisecond)) {
+    if (!options?.hideMilliseconds) {
+      if (magnitude === 0) {
+        parts.push(`${MathUtils.round(time, 4)}ms`)
+      } else {
+        parts.push(`${time.toFixed(0)}ms`)
+      }
+    }
+    magnitude = Math.max(magnitude, 1)
+  }
+
+  return parts.join(' ')
+
+  // if (time < MS_PER_MIN) {
+  //   const seconds = Math.floor(time / MS_PER_SEC)
+  //   time -= seconds * MS_PER_SEC
+  //   const milliseconds = time
+  //   return `${seconds.toFixed(0)}s ${milliseconds.toFixed(0)}ms`
+  // }
+
+  // if (time < MS_PER_HOUR) {
+  //   const minutes = Math.floor(time / MS_PER_MIN)
+  //   time -= minutes * MS_PER_MIN
+  //   const seconds = time / MS_PER_SEC
+  //   return `${minutes.toFixed(0)}m ${seconds.toFixed(0)}s`
+  // }
+
+  // const hours = Math.floor(time / MS_PER_HOUR)
+  // time -= hours * MS_PER_HOUR
+  // const minutes = Math.floor(time / MS_PER_MIN)
+  // time -= minutes * MS_PER_MIN
+  // const seconds = Math.floor(time / MS_PER_SEC)
+
+  // return `${hours.toFixed(0)}h ${minutes.toFixed(0)}m ${seconds.toFixed(0)}s`
+}
+
+export const TimeUtils = { renderEstimate, renderSpan }


### PR DESCRIPTION
## Summary
This new function is useful when rendering milliseconds as human amounts
of time. IE: 1150 milliseconds is 1s and 150ms. Useful for count downs,
or estimations.

## Testing Plan
Run new tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
