### PR TITLE
Add IRONFISH_EXPOSE_GC to expose garbage collector

### DIFF
--- a/ironfish-cli/bin/ironfish
+++ b/ironfish-cli/bin/ironfish
@@ -41,5 +41,10 @@ else
   if [ "$DEBUG" == "*" ]; then
     echoerr IRONFISH_BINPATH="$IRONFISH_BINPATH" "$NODE" "$DIR/run" "$@"
   fi
-  "$NODE" "$DIR/run" "$@"
+
+  if [ "$IRONFISH_EXPOSE_GC" == "true" ]; then
+    "$NODE" "--expose-gc" "$DIR/run" "$@"
+  else
+    "$NODE" "$DIR/run" "$@"
+  fi
 fi

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -43,7 +43,7 @@
     "lint:fix": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
     "start:dev": "node start",
     "start": "yarn build && yarn start:js",
-    "start:js": "cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node bin/run",
+    "start:js": "cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc bin/run",
     "test": "yarn clean && tsc -b && tsc -b tsconfig.test.json && jest",
     "test:coverage:html": "tsc -b tsconfig.test.json && jest --coverage --coverage-reporters html --testPathIgnorePatterns",
     "test:watch": "tsc -b tsconfig.test.json && jest --watch --coverage false",

--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -82,6 +82,7 @@ export default class Debug extends IronfishCommand {
       ['Heap total', `${heapTotal}`],
       ['Node version', `${process.version}`],
       ['ironfish in PATH', `${cmdInPath.toString()}`],
+      ['Garbage Collector Exposed', `${String(!!global.gc)}`],
       ['Telemetry enabled', `${telemetryEnabled}`],
       ['Node name', `${nodeName}`],
       ['Block graffiti', `${blockGraffiti}`],


### PR DESCRIPTION
## Summary

Exposing the garbage collector is a useful thing for developers. We can
start taking advantage of it in new memory bench marking tools that can
do certain things if the GC is exposed.

## Testing Plan
1. Run debug command with yarn
2. Run debug command with ./bin/ironfish with `IRONFISH_EXPOSE_GC` as `true`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
