### PR TITLE
Fix a bug where tests were timing out

### DIFF
--- a/config/jest.config.base.js
+++ b/config/jest.config.base.js
@@ -6,4 +6,9 @@ module.exports = {
   coverageProvider: "v8",
   coverageReporters: ["text-summary", "json", "clover", "text"],
   testPathIgnorePatterns: ['.*\\.test\\.slow\\.ts$', '.*\\.test\\.perf\\.ts$'],
+
+  // set timeout to a higher value than the default (5000), in order to avoid 
+  // timing out when running tests. 32 seconds should suffice for the existing
+  // tests.
+  testTimeout: 32000
 };

--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -28,26 +28,30 @@ export default class Debug extends IronfishCommand {
   async start(): Promise<void> {
     const node = await this.sdk.node({ autoSeed: false })
 
+    let dbOpen = true
     try {
       await node.openDB()
-
-      this.display(await this.fullOutput(node))
     } catch (err) {
       if (err instanceof DatabaseIsLockedError) {
         this.log('Database in use, skipping output that requires database.')
         this.log('Stop the node and run the debug command again to show full output.\n')
+        dbOpen = false
       } else if (err instanceof DatabaseOpenError) {
         this.log('Database cannot be opened, skipping output that requires database.\n')
         this.log(ErrorUtils.renderError(err, true) + '\n')
-      } else {
-        this.log(`An error occured while opening the database: ${err}`)
+        dbOpen = false
       }
-
-      this.display(this.basicOutput(node));
     }
+
+    let output = this.baseOutput(node)
+    if (dbOpen) {
+      output = new Map([...output, ...(await this.outputRequiringDB(node))])
+    }
+
+    this.display(output)
   }
 
-  basicOutput(node: IronfishNode): Map<string, string> {
+  baseOutput(node: IronfishNode): Map<string, string> {
     const cpus = os.cpus()
     const cpuNames = [...new Set(cpus.map((c) => c.model))]
     const cpuThreads = cpus.length
@@ -85,17 +89,15 @@ export default class Debug extends IronfishCommand {
     ])
   }
 
-  async fullOutput(node: IronfishNode): Promise<Map<string, string>> {
-    const basicOutput = this.basicOutput(node);
-
+  async outputRequiringDB(node: IronfishNode): Promise<Map<string, string>> {
     const accountsMeta = await node.accounts.db.loadAccountsMeta()
     const accountsHeadHash = accountsMeta.headHash !== null ? accountsMeta.headHash : ''
+
     const accountsBlockHeader = await node.chain.getHeader(Buffer.from(accountsHeadHash, 'hex'))
     const accountsHeadInChain = !!accountsBlockHeader
     const accountsHeadSequence = accountsBlockHeader?.sequence || 'null'
 
     return new Map<string, string>([
-      ...basicOutput,
       ['Accounts head hash', `${accountsHeadHash}`],
       ['Accounts head in chain', `${accountsHeadInChain.toString()}`],
       ['Accounts head sequence', `${accountsHeadSequence}`],


### PR DESCRIPTION
## Summary
The default timeout value of jest is set to only 5 seconds. This
period seems insufficient for some tests that apparently take
longer to execute. This PR changes the timeout to 32 seconds,
which should suffice for the current tests. An improvement would be
to make this value get set dynamically according to the specs of the
computer running the tests.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
graffiti: ironfishup