### PR TITLE
Allow non unqiue IDatabaseStore

### DIFF
--- a/ironfish/src/merkletree/merkletree.test.ts
+++ b/ironfish/src/merkletree/merkletree.test.ts
@@ -4,6 +4,7 @@
 
 import '../testUtilities/matchers/merkletree'
 import { makeTree } from '../testUtilities/helpers/merkletree'
+import { createTestDB } from '../testUtilities/helpers/storage'
 import { MerkleTree, Side } from './merkletree'
 import { depthAtLeafCount } from './utils'
 
@@ -17,12 +18,14 @@ describe('Merkle tree', function () {
   })
 
   it("doesn't reset db on second run", async () => {
-    const tree1 = await makeTree()
+    const { location } = await createTestDB(false)
+
+    const tree1 = await makeTree({ location })
     await tree1.add('a')
     await expect(tree1.size()).resolves.toBe(1)
     await tree1.db.close()
 
-    const tree2 = await makeTree({ db: tree1.db })
+    const tree2 = await makeTree({ location })
     await expect(tree2.size()).resolves.toBe(1)
     await tree2.db.close()
   })

--- a/ironfish/src/storage/database.test.ts
+++ b/ironfish/src/storage/database.test.ts
@@ -10,7 +10,6 @@ import { PromiseUtils } from '../utils'
 import {
   ArrayEncoding,
   BufferEncoding,
-  DatabaseOpenError,
   DatabaseSchema,
   DatabaseVersionError,
   DuplicateKeyError,

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { BatchOperation, IDatabaseBatch } from './batch'
-import { DatabaseIsOpenError } from './errors'
 import { IDatabaseStore, IDatabaseStoreOptions } from './store'
 import { IDatabaseTransaction } from './transaction'
 import { DatabaseOptions, DatabaseSchema, SchemaKey, SchemaValue } from './types'
@@ -52,6 +51,7 @@ export interface IDatabase {
    */
   addStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,
+    requireUnique?: boolean,
   ): IDatabaseStore<Schema>
 
   /** Get all the stores added with [[`IDatabase.addStore`]] */
@@ -126,7 +126,7 @@ export interface IDatabase {
 }
 
 export abstract class Database implements IDatabase {
-  stores = new Map<string, IDatabaseStore<DatabaseSchema>>()
+  stores = new Array<IDatabaseStore<DatabaseSchema>>()
 
   abstract get isOpen(): boolean
 
@@ -157,24 +157,21 @@ export abstract class Database implements IDatabase {
   ): IDatabaseStore<Schema>
 
   getStores(): Array<IDatabaseStore<DatabaseSchema>> {
-    return Array.from(this.stores.values())
+    return Array.from(this.stores)
   }
 
   addStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,
+    requireUnique = true,
   ): IDatabaseStore<Schema> {
-    if (this.isOpen) {
-      throw new DatabaseIsOpenError(
-        `Cannot add store ${options.name} while the database is open`,
-      )
-    }
-    const existing = this.stores.get(options.name)
-    if (existing) {
-      return existing as IDatabaseStore<Schema>
+    const existing = this.stores.find((s) => s.name === options.name)
+
+    if (existing && requireUnique) {
+      throw new Error(`Store with name ${options.name} already exists`)
     }
 
     const store = this._createStore<Schema>(options)
-    this.stores.set(options.name, store)
+    this.stores.push(store)
     return store
   }
 

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -164,10 +164,12 @@ export abstract class Database implements IDatabase {
     options: IDatabaseStoreOptions<Schema>,
     requireUnique = true,
   ): IDatabaseStore<Schema> {
-    const existing = this.stores.find((s) => s.name === options.name)
+    if (requireUnique) {
+      const existing = this.stores.find((s) => s.name === options.name)
 
-    if (existing && requireUnique) {
-      throw new Error(`Store with name ${options.name} already exists`)
+      if (existing) {
+        throw new Error(`Store with name ${options.name} already exists`)
+      }
     }
 
     const store = this._createStore<Schema>(options)

--- a/ironfish/src/testUtilities/helpers/merkletree.ts
+++ b/ironfish/src/testUtilities/helpers/merkletree.ts
@@ -8,7 +8,7 @@ import { NodeValue } from '../../merkletree/database/nodes'
 import { StructureHasher } from '../../merkletree/hasher'
 import { Side } from '../../merkletree/merkletree'
 import { IDatabase, IDatabaseEncoding, StringEncoding } from '../../storage'
-import { createDB } from '../helpers/storage'
+import { createTestDB } from '../helpers/storage'
 
 type StructureLeafValue = {
   element: string
@@ -90,16 +90,19 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
 export async function makeTree({
   name,
   db,
+  location,
   depth,
   leaves,
 }: {
   name?: string
   db?: IDatabase
+  location?: string
   depth?: number
   leaves?: string
 } = {}): Promise<MerkleTree<string, string, string, string>> {
   if (!db) {
-    db = await createDB()
+    const { db: database } = await createTestDB(undefined, location)
+    db = database
   }
 
   const tree = new MerkleTree({

--- a/ironfish/src/testUtilities/helpers/storage.ts
+++ b/ironfish/src/testUtilities/helpers/storage.ts
@@ -29,8 +29,14 @@ export function makeDbPath(name?: string): string {
   return `./testdbs/${name}`
 }
 
-export async function createDB(open = false): Promise<IDatabase> {
-  const location = path.join(os.tmpdir(), uuid())
+export async function createTestDB(
+  open = false,
+  location?: string,
+): Promise<{ db: IDatabase; location: string }> {
+  if (!location) {
+    location = path.join(os.tmpdir(), uuid())
+  }
+
   const database = createDBStorage({ location })
 
   afterEach(async () => database?.close())
@@ -39,5 +45,8 @@ export async function createDB(open = false): Promise<IDatabase> {
     await database.open()
   }
 
-  return database
+  return {
+    db: database,
+    location,
+  }
 }


### PR DESCRIPTION
## Summary

We need the ability to create non unique stores in the DB layer. The
only reason we even had this restriction is because of indexed DB. It
will only be used during migrations.

## Testing Plan
Run new tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
