### PR TITLE
Add DatabaseStoreValue and DatabaseStoreKey

### DIFF
--- a/ironfish/src/storage/database/store.ts
+++ b/ironfish/src/storage/database/store.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { UnwrapPromise } from '../../utils/types'
 import { IDatabaseTransaction } from './transaction'
 import { DatabaseSchema, IDatabaseEncoding, SchemaKey, SchemaValue } from './types'
 
@@ -180,3 +181,11 @@ export abstract class DatabaseStore<Schema extends DatabaseSchema>
 
   abstract del(key: SchemaKey<Schema>, transaction?: IDatabaseTransaction): Promise<void>
 }
+
+export type DatabaseStoreValue<TStore> = TStore extends IDatabaseStore<infer _A>
+  ? Exclude<UnwrapPromise<ReturnType<TStore['get']>>, undefined>
+  : never
+
+export type DatabaseStoreKey<TStore> = TStore extends IDatabaseStore<infer _A>
+  ? Parameters<TStore['get']>[0]
+  : never


### PR DESCRIPTION
## Summary

These types let you extract the key and value from an IDatabaseStore
type. How to use:
```typescript
const store = db.addStore<{ key: string, value: AccountsValue }>(...)

type key = DatabaseStoreKey<typeof store> // string
type value = DatabaseStoreValue<typeof store> // value
```

## Testing Plan
Types only, no tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
