### PR TITLE
Fix a bug where tests were timing out

### DIFF
--- a/config/jest.config.base.js
+++ b/config/jest.config.base.js
@@ -6,4 +6,9 @@ module.exports = {
   coverageProvider: "v8",
   coverageReporters: ["text-summary", "json", "clover", "text"],
   testPathIgnorePatterns: ['.*\\.test\\.slow\\.ts$', '.*\\.test\\.perf\\.ts$'],
+  
+  // set timeout to a higher value than the default (5000), in order to avoid 
+  // timing out when running tests. 32 seconds should suffice for the existing
+  // tests.
+  testTimeout: 32000
 };


### PR DESCRIPTION
## Summary
The default timeout value of jest is set to only 5 seconds. This
period seems insufficient for some tests that apparently take
longer to execute. This PR changes the timeout to 32 seconds,
which should suffice for the current tests. An improvement would be
to make this value get set dynamically according to the specs of the
computer running the tests.

A previous PR https://github.com/iron-fish/ironfish/pull/1891 was closed. I mixed up branches there, so had to make a new branch, and then open the request again. 

[danield9tqh](https://github.com/danield9tqh) in the previous PR asked which tests are timing out?
The tests that are timing out are Ironfish/cli

## Testing Plan
Tested passed

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
graffiti: ironfishup