### PR TITLE
standardizes naming of version constants

### DIFF
--- a/ironfish/src/account/accountsdb.ts
+++ b/ironfish/src/account/accountsdb.ts
@@ -24,7 +24,7 @@ import {
 } from './database/noteToNullifiers'
 import { TransactionsValue, TransactionsValueEncoding } from './database/transactions'
 
-const DATABASE_VERSION = 11
+export const VERSION_DATABASE_ACCOUNTS = 11
 
 export const AccountDefaults: AccountsValue = {
   name: '',
@@ -123,7 +123,7 @@ export class AccountsDB {
   async open(): Promise<void> {
     await this.files.mkdir(this.location, { recursive: true })
     await this.database.open()
-    await this.database.upgrade(DATABASE_VERSION)
+    await this.database.upgrade(VERSION_DATABASE_ACCOUNTS)
   }
 
   async close(): Promise<void> {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -58,7 +58,7 @@ import {
   TransactionsSchema,
 } from './schema'
 
-const DATABASE_VERSION = 10
+export const VERSION_DATABASE_CHAIN = 10
 
 export class Blockchain {
   db: IDatabase
@@ -274,7 +274,7 @@ export class Blockchain {
 
     await this.files.mkdir(this.location, { recursive: true })
     await this.db.open()
-    await this.db.upgrade(DATABASE_VERSION)
+    await this.db.upgrade(VERSION_DATABASE_CHAIN)
 
     let genesisHeader = await this.getHeaderAtSequence(GENESIS_BLOCK_SEQUENCE)
     if (!genesisHeader && this.autoSeed) {

--- a/ironfish/src/indexers/minedBlocksIndexer.ts
+++ b/ironfish/src/indexers/minedBlocksIndexer.ts
@@ -29,7 +29,7 @@ import {
   SequenceToHashesValueEncoding,
 } from './database/sequenceToHashes'
 
-const DATABASE_VERSION = 12
+export const VERSION_DATABASE_INDEXER = 12
 const REMOVAL_KEY = 'accountsToRemove'
 
 const getMinedBlocksDBMetaDefaults = (): MinedBlocksDBMeta => ({
@@ -182,7 +182,7 @@ export class MinedBlocksIndexer {
 
     await this.files.mkdir(this.location, { recursive: true })
     await this.database.open()
-    await this.database.upgrade(DATABASE_VERSION)
+    await this.database.upgrade(VERSION_DATABASE_INDEXER)
     await this.load()
   }
 

--- a/ironfish/src/mining/stratum/stratumClient.ts
+++ b/ironfish/src/mining/stratum/stratumClient.ts
@@ -27,7 +27,7 @@ import {
   StratumMessage,
   StratumMessageSchema,
 } from './messages'
-import { STRATUM_VERSION_PROTOCOL } from './version'
+import { VERSION_PROTOCOL_STRATUM } from './version'
 
 export class StratumClient {
   readonly socket: net.Socket
@@ -60,7 +60,7 @@ export class StratumClient {
     this.host = options.host
     this.port = options.port
     this.logger = options.logger
-    this.version = STRATUM_VERSION_PROTOCOL
+    this.version = VERSION_PROTOCOL_STRATUM
 
     this.started = false
     this.id = null

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -29,7 +29,7 @@ import {
 } from './messages'
 import { StratumPeers } from './stratumPeers'
 import { StratumServerClient } from './stratumServerClient'
-import { STRATUM_VERSION_PROTOCOL, STRATUM_VERSION_PROTOCOL_MIN } from './version'
+import { VERSION_PROTOCOL_STRATUM, VERSION_PROTOCOL_STRATUM_MIN } from './version'
 
 const FIVE_MINUTES_MS = 5 * 60 * 1000
 
@@ -65,8 +65,8 @@ export class StratumServer {
     this.config = options.config
     this.logger = options.logger
 
-    this.version = STRATUM_VERSION_PROTOCOL
-    this.versionMin = STRATUM_VERSION_PROTOCOL_MIN
+    this.version = VERSION_PROTOCOL_STRATUM
+    this.versionMin = VERSION_PROTOCOL_STRATUM_MIN
 
     this.host = options.host ?? this.config.get('poolHost')
     this.port = options.port ?? this.config.get('poolPort')

--- a/ironfish/src/mining/stratum/version.ts
+++ b/ironfish/src/mining/stratum/version.ts
@@ -2,5 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const STRATUM_VERSION_PROTOCOL = 1
-export const STRATUM_VERSION_PROTOCOL_MIN = 1
+export const VERSION_PROTOCOL_STRATUM = 1
+export const VERSION_PROTOCOL_STRATUM_MIN = 1


### PR DESCRIPTION
## Summary

- uses `VERSION_<PROTOCOL | DATABASE>[_<name>]` as a standard pattern for
  version constants
- exports version constants for chain database, account database, and mined
  block indexer so that they can be accessed in sdk clients

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
