### PR TITLE
Support IDatabaseStore.clear() in a transaction

### DIFF
--- a/ironfish/src/storage/database.test.ts
+++ b/ironfish/src/storage/database.test.ts
@@ -143,6 +143,27 @@ describe('Database', () => {
     expect(await barStore.get('hello')).toEqual(fooHash)
   })
 
+  it('should clear store in a transaction', async () => {
+    await db.open()
+
+    const tx = db.transaction()
+
+    await testStore.put('hello', 2)
+    await testStore.put('hello', 4, tx)
+
+    expect(await testStore.get('hello')).toEqual(2)
+    expect(await testStore.get('hello', tx)).toEqual(4)
+
+    await testStore.clear(tx)
+
+    expect(await testStore.get('hello')).toEqual(2)
+    expect(await testStore.get('hello', tx)).not.toBeDefined()
+
+    await tx.commit()
+
+    expect(await testStore.get('hello')).not.toBeDefined()
+  })
+
   it('should add values', async () => {
     await db.open()
     await db.metaStore.clear()

--- a/ironfish/src/storage/database/store.ts
+++ b/ironfish/src/storage/database/store.ts
@@ -60,7 +60,7 @@ export interface IDatabaseStore<Schema extends DatabaseSchema> {
    *
    * @returns resolves when all keys have been deleted
    */
-  clear(): Promise<void>
+  clear(transaction?: IDatabaseTransaction): Promise<void>
 
   /**
    * Used to get a value from the store at a given key

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -152,8 +152,14 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     return AsyncUtils.materialize(this.getAllKeysIter(transaction))
   }
 
-  async clear(): Promise<void> {
-    await this.db.levelup.clear(this.allKeysRange)
+  async clear(transaction?: IDatabaseTransaction): Promise<void> {
+    if (transaction) {
+      for await (const key of this.getAllKeysIter(transaction)) {
+        await this.del(key, transaction)
+      }
+    } else {
+      await this.db.levelup.clear(this.allKeysRange)
+    }
   }
 
   async put(


### PR DESCRIPTION
## Summary

Need this for migrations

## Testing Plan
Added new tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
