### PR TITLE
Fixed a bug where not all errors were handled properly

### DIFF
--- a/config/jest.config.base.js
+++ b/config/jest.config.base.js
@@ -6,9 +6,4 @@ module.exports = {
   coverageProvider: "v8",
   coverageReporters: ["text-summary", "json", "clover", "text"],
   testPathIgnorePatterns: ['.*\\.test\\.slow\\.ts$', '.*\\.test\\.perf\\.ts$'],
-
-  // set timeout to a higher value than the default (5000), in order to avoid 
-  // timing out when running tests. 32 seconds should suffice for the existing
-  // tests.
-  testTimeout: 32000
 };

--- a/config/jest.config.base.js
+++ b/config/jest.config.base.js
@@ -6,4 +6,9 @@ module.exports = {
   coverageProvider: "v8",
   coverageReporters: ["text-summary", "json", "clover", "text"],
   testPathIgnorePatterns: ['.*\\.test\\.slow\\.ts$', '.*\\.test\\.perf\\.ts$'],
+
+  // set timeout to a higher value than the default (5000), in order to avoid 
+  // timing out when running tests. 32 seconds should suffice for the existing
+  // tests.
+  testTimeout: 32000
 };


### PR DESCRIPTION
## Summary
The issue #1792 reported a bug where \`ironfish debug' command
had an exception message shown. After investigating the code, it
turned out that not all exceptions were handled by the catch block,
which left the `dbOpen' flag variable set to to (when the database
may not be actually open). This commit also contains a refactoring of
the output collection functions.

## Testing Plan
Tested successfully

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
graffiti: ironfishup