### PR TITLE
Support logging in migrations

### DIFF
--- a/ironfish-cli/src/commands/migrations/start.ts
+++ b/ironfish-cli/src/commands/migrations/start.ts
@@ -1,23 +1,27 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey } from '../../flags'
+import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey, LocalFlags } from '../../flags'
 
 export class StartCommand extends IronfishCommand {
   static description = `Run migrations`
 
   static flags = {
+    ...LocalFlags,
     [ConfigFlagKey]: ConfigFlag,
     [DataDirFlagKey]: DataDirFlag,
+    quiet: Flags.boolean({
+      char: 'q',
+      default: false,
+    }),
   }
 
   async start(): Promise<void> {
-    await this.parse(StartCommand)
+    const { flags } = await this.parse(StartCommand)
 
     const node = await this.sdk.node()
-    await node.migrator.migrate()
-
-    this.exit(0)
+    await node.migrator.migrate({ quiet: flags.quiet })
   }
 }

--- a/ironfish/src/logger/index.ts
+++ b/ironfish/src/logger/index.ts
@@ -35,8 +35,8 @@ export const ConsoleReporterInstance = new ConsoleReporter()
 export const setLogLevelFromConfig = (logLevelConfig: string): void => {
   const parsedConfig = parseLogLevelConfig(logLevelConfig)
 
-  for (const config of parsedConfig) {
-    ConsoleReporterInstance.setLogLevel(config[0], config[1])
+  for (const [tag, level] of parsedConfig) {
+    ConsoleReporterInstance.setLogLevel(tag, level)
   }
 }
 

--- a/ironfish/src/migrations/migration.ts
+++ b/ironfish/src/migrations/migration.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { FileSystem } from '../fileSystems'
+import { Logger } from '../logger'
 import { IronfishNode } from '../node'
 import { IDatabase, IDatabaseTransaction } from '../storage'
 
@@ -24,6 +25,18 @@ export abstract class Migration {
   }
 
   abstract prepare(node: IronfishNode): Promise<IDatabase> | IDatabase
-  abstract forward(node: IronfishNode, db: IDatabase, tx: IDatabaseTransaction): Promise<void>
-  abstract backward(node: IronfishNode, db: IDatabase, tx: IDatabaseTransaction): Promise<void>
+
+  abstract forward(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<void>
+
+  abstract backward(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<void>
 }


### PR DESCRIPTION
## Summary

If you wanted logging in migrations you would need to use console.log,
but now we generate a logger per migration with a tag that has the
migration name. We also use logger levels, to silence it so we don't
need a conditional logger.

## Testing Plan

1. Run `migrations:start`
2. Run `migrations:start --quiet`
3. Run `migrations:status`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
