### PR TITLE
Add dry run support to migrator

### DIFF
--- a/ironfish-cli/src/commands/migrations/start.ts
+++ b/ironfish-cli/src/commands/migrations/start.ts
@@ -12,6 +12,9 @@ export class StartCommand extends IronfishCommand {
     ...LocalFlags,
     [ConfigFlagKey]: ConfigFlag,
     [DataDirFlagKey]: DataDirFlag,
+    dry: Flags.boolean({
+      char: 'd',
+    }),
     quiet: Flags.boolean({
       char: 'q',
       default: false,
@@ -22,6 +25,6 @@ export class StartCommand extends IronfishCommand {
     const { flags } = await this.parse(StartCommand)
 
     const node = await this.sdk.node()
-    await node.migrator.migrate({ quiet: flags.quiet })
+    await node.migrator.migrate({ quiet: flags.quiet, dryRun: flags.dry })
   }
 }

--- a/ironfish/src/migrations/migration.ts
+++ b/ironfish/src/migrations/migration.ts
@@ -31,6 +31,7 @@ export abstract class Migration {
     db: IDatabase,
     tx: IDatabaseTransaction,
     logger: Logger,
+    dryRun: boolean,
   ): Promise<void>
 
   abstract backward(
@@ -38,5 +39,6 @@ export abstract class Migration {
     db: IDatabase,
     tx: IDatabaseTransaction,
     logger: Logger,
+    dryRun: boolean,
   ): Promise<void>
 }


### PR DESCRIPTION
## Summary

This will allow you to abort the migration after it's been run. If you
pass this, it will only try to run the last migration.

## Testing Plan

Run migrations with dry run and ensure no writes occurred by re-running the migration.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
