### PR TITLE
removes database name from snapshot on unzip

### DIFF
--- a/ironfish-cli/src/commands/service/snapshot.ts
+++ b/ironfish-cli/src/commands/service/snapshot.ts
@@ -84,6 +84,7 @@ export default class CreateSnapshot extends IronfishCommand {
 
     if (flags.path) {
       exportDir = this.sdk.fileSystem.resolve(flags.path)
+      await this.sdk.fileSystem.mkdir(exportDir, { recursive: true })
     } else {
       try {
         const tempDir = path.join(os.tmpdir(), uuid())


### PR DESCRIPTION
## Summary

when using `service:snapshot` to create a snapshot, the resulting zip file
contains a directory matching the database name. if a user later imports that
snapshot then the database name in the snapshot shouldn't need to match the name
that their node uses.

- uses `strip` to remove the database directory on unzip
- creates a 'snapshot' directory and unzips the contents of the snapshot there
  before moving to the user's database directory

- fixes snapshot to create directories on 'path', importSnapshot to resolve
  'path'

## Testing Plan

- run `ironfish start --datadir=~/.ironfish-new --database=new` to create a new node with a small db
- run `ironfish service:snapshot --datadir=~/.ironfish-new --path=~/.test-new --database=new` to snapshot the database
- run `fish chain:importSnapshot --datadir=~/.ironfish-new --path=~/.test-new/ironfish_snapshot.tar.gz --database=newer` to import the snapshot to a different database name

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
