### PR TITLE
adds 'temp' directory in dataDir, uses it in snapshot commands

### DIFF
--- a/ironfish-cli/src/commands/chain/importSnapshot.ts
+++ b/ironfish-cli/src/commands/chain/importSnapshot.ts
@@ -58,7 +58,7 @@ export default class ImportSnapshot extends IronfishCommand {
     await NodeUtils.waitForOpen(node)
 
     let snapshotPath
-    const tempDir = path.join(os.tmpdir(), uuid())
+    const tempDir = this.sdk.fileSystem.resolve(this.sdk.config.tempDir)
     await fsAsync.mkdir(tempDir, { recursive: true })
 
     if (flags.path) {

--- a/ironfish-cli/src/commands/service/snapshot.ts
+++ b/ironfish-cli/src/commands/service/snapshot.ts
@@ -84,6 +84,7 @@ export default class CreateSnapshot extends IronfishCommand {
 
     if (flags.path) {
       exportDir = this.sdk.fileSystem.resolve(flags.path)
+      await this.sdk.fileSystem.mkdir(exportDir, { recursive: true })
     } else {
       try {
         const tempDir = path.join(os.tmpdir(), uuid())

--- a/ironfish-cli/src/commands/service/snapshot.ts
+++ b/ironfish-cli/src/commands/service/snapshot.ts
@@ -87,7 +87,7 @@ export default class CreateSnapshot extends IronfishCommand {
       await this.sdk.fileSystem.mkdir(exportDir, { recursive: true })
     } else {
       try {
-        const tempDir = path.join(os.tmpdir(), uuid())
+        const tempDir = this.sdk.fileSystem.resolve(this.sdk.config.tempDir)
         exportDir = await fsAsync.mkdir(tempDir, { recursive: true })
       } catch (err) {
         this.log(`Could not create temp folder for snapshot generation`)

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -270,6 +270,10 @@ export class Config extends KeyStore<ConfigOptions> {
     return this.files.join(this.storage.dataDir, 'indexes', this.get('databaseName'))
   }
 
+  get tempDir(): string {
+    return this.files.join(this.storage.dataDir, 'temp')
+  }
+
   static GetDefaults(files: FileSystem, dataDir: string): ConfigOptions {
     return {
       bootstrapNodes: [DEFAULT_BOOTSTRAP_NODE],


### PR DESCRIPTION
## Summary

snapshots are written to and downloaded to a random directory within the
system's `$TEMPDIR`. this can create duplicate snapshots and downloads and makes
the snapshots difficult to find.

- adds `tempDir` getter to config
- replaces os tempDir with node tempDir in snapshot commands

built atop #1911

## Testing Plan

- run `ironfish start --datadir=~/.ironfish-new` to create a new node with a small database
- run `ironfish service:snapshot --datadir=~/.ironfish-new `
- `ls ~/.ironfish-new/temp/ironfish_snapshot.tar.gz`

- run `ironfish chain:importSnapshot --datadir=~/.ironfish-new` (downloading the snapshot from s3 will take a long time, but  you can see that the file is going into `~/.ironfish-new/temp/`)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
