### PR TITLE
Fix test for duplicate key import

### DIFF
--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -329,9 +329,10 @@ describe('Accounts', () => {
 
       expect(node.accounts.accountExists(account.name)).toEqual(true)
 
-      account.name = 'Different name'
+      const clone = { ...account }
+      clone.name = 'Different name'
 
-      await expect(node.accounts.importAccount(account)).rejects.toThrowError(
+      await expect(node.accounts.importAccount(clone)).rejects.toThrowError(
         'Account already exists with provided spending key',
       )
     })


### PR DESCRIPTION
## Summary

This is now failing on this branch because accounts are in memory.

## Testing Plan
None

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
