### PR TITLE
Add total memory and OS CPU core count to startup telemetry

### DIFF
--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -37,6 +37,8 @@ export class MetricsMonitor {
   readonly memTotal: number
   readonly heapMax: number
 
+  readonly cpuCores: number
+
   private memoryInterval: SetIntervalToken | null
   private readonly memoryRefreshPeriodMs = 1000
 
@@ -66,6 +68,8 @@ export class MetricsMonitor {
     this.memoryInterval = null
 
     this.heapMax = getHeapStatistics().total_available_size
+
+    this.cpuCores = os.cpus().length
   }
 
   get started(): boolean {

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -281,9 +281,18 @@ export class Telemetry {
   }
 
   submitNodeStarted(): void {
+    let fields: Field[] = [{ name: 'online', type: 'boolean', value: true }]
+
+    if (this.metrics) {
+      fields = fields.concat([
+        { name: 'cpu_cores', type: 'integer', value: this.metrics.cpuCores },
+        { name: 'memory_total', type: 'integer', value: this.metrics.memTotal },
+      ])
+    }
+
     this.submit({
       measurement: 'node_started',
-      fields: [{ name: 'online', type: 'boolean', value: true }],
+      fields,
       timestamp: new Date(),
     })
   }


### PR DESCRIPTION
## Summary
Address IRO-2362 and IRO-2363. Adds stats for total memory and OS CPU core count.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
