### PR TITLE
uses s3 transfer acceleration for snapshot downloads

### DIFF
--- a/ironfish-cli/src/commands/chain/importSnapshot.ts
+++ b/ironfish-cli/src/commands/chain/importSnapshot.ts
@@ -62,8 +62,7 @@ export default class ImportSnapshot extends IronfishCommand {
       snapshotPath = this.sdk.fileSystem.resolve(flags.path)
     } else {
       const bucketUrl = (
-        flags.bucketUrl ||
-        `https://${DEFAULT_SNAPSHOT_BUCKET}.s3-accelerate.us-east-1.amazonaws.com`
+        flags.bucketUrl || `https://${DEFAULT_SNAPSHOT_BUCKET}.s3-accelerate.amazonaws.com`
       ).trim()
       if (!bucketUrl) {
         this.log(`Cannot download snapshot without bucket URL`)

--- a/ironfish-cli/src/commands/chain/importSnapshot.ts
+++ b/ironfish-cli/src/commands/chain/importSnapshot.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
-  DEFAULT_SNAPSHOT_BUCKET_URL,
   ErrorUtils,
   FileUtils,
   Meter,
@@ -22,7 +21,7 @@ import { promisify } from 'util'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 import { ProgressBar } from '../../types'
-import { SnapshotManifest } from '../../utils'
+import { DEFAULT_SNAPSHOT_BUCKET, SnapshotManifest } from '../../utils'
 
 export default class ImportSnapshot extends IronfishCommand {
   static hidden = false
@@ -62,7 +61,10 @@ export default class ImportSnapshot extends IronfishCommand {
     if (flags.path) {
       snapshotPath = this.sdk.fileSystem.resolve(flags.path)
     } else {
-      const bucketUrl = (flags.bucketUrl || DEFAULT_SNAPSHOT_BUCKET_URL || '').trim()
+      const bucketUrl = (
+        flags.bucketUrl ||
+        `https://${DEFAULT_SNAPSHOT_BUCKET}.s3-accelerate.us-east-1.amazonaws.com`
+      ).trim()
       if (!bucketUrl) {
         this.log(`Cannot download snapshot without bucket URL`)
         this.exit(1)

--- a/ironfish-cli/src/utils/snapshot.ts
+++ b/ironfish-cli/src/utils/snapshot.ts
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export const DEFAULT_SNAPSHOT_BUCKET = 'ironfish-snapshots'
+
 export type SnapshotManifest = {
   block_sequence: number
   checksum: string

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -14,9 +14,6 @@ export const DEFAULT_GET_FUNDS_API = 'https://api.ironfish.network/faucet_transa
 export const DEFAULT_TELEMETRY_API = 'https://api.ironfish.network/telemetry'
 export const DEFAULT_BOOTSTRAP_NODE = 'test.bn1.ironfish.network'
 export const DEFAULT_DISCORD_INVITE = 'https://discord.gg/ironfish'
-export const DEFAULT_SNAPSHOT_BUCKET_URL =
-  'https://ironfish-snapshots.s3.us-east-1.amazonaws.com'
-export const DEFAULT_SNAPSHOT_FILE_NAME = `ironfish_snapshot.tar.gz`
 export const DEFAULT_USE_RPC_IPC = true
 export const DEFAULT_USE_RPC_TCP = false
 export const DEFAULT_USE_RPC_TLS = true


### PR DESCRIPTION
## Summary

- moves DEFAULT_BUCKET_ constant to ironfish-cli
- changes constant to bucket instead of URL
- builds bucketUrl from bucket name and uses `s3-accelerate` in URL to use
  transfer acceleration
- changes flag on snapshot from bucketUrl to bucket

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
