### PR TITLE
Convert all camel case commands to snake case

### DIFF
--- a/ironfish-cli/src/commands/chain/readd-block.ts
+++ b/ironfish-cli/src/commands/chain/readd-block.ts
@@ -6,6 +6,8 @@ import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
 export default class ReAddBlock extends IronfishCommand {
+  static aliases = ['chain:readdblock']
+
   static description =
     'Remove and readd a block on the chain if it has no other blocks after it'
 

--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -23,6 +23,7 @@ const REGISTER_URL = 'https://testnet.ironfish.network/signup'
 const IRON_TO_SEND = 0.1
 
 export default class DepositAll extends IronfishCommand {
+  static aliases = ['depositAll']
   static description = 'Deposit $IRON for testnet points'
 
   client: RpcClient | null = null

--- a/ironfish-cli/src/commands/service/sync-transactions.ts
+++ b/ironfish-cli/src/commands/service/sync-transactions.ts
@@ -18,6 +18,7 @@ const MAX_UPLOAD = isNaN(RAW_MAX_UPLOAD) ? 500 : RAW_MAX_UPLOAD
 const NEAR_SYNC_THRESHOLD = 5
 
 export default class SyncTransactions extends IronfishCommand {
+  static aliases = ['service:syncTransactions']
   static hidden = true
 
   static description = 'Upload transactions to an HTTP API using IronfishApi'


### PR DESCRIPTION
## Summary

Convert all camel case commands to snake case. We should not use commands like `chain:resetBlocks` it should always be `chain:reset-blocks`. This is the standard git uses, and the one we will use too. However, you should avoid using snake case at all cost and always try to user a single word if you absolutely can even if it's less descriptive. 

## Testing Plan

No testing needed.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```

No breaking changes because all commands were hidden, but they had aliases added anyway.