### PR TITLE
Fix backup command by using snapshot upload

### DIFF
--- a/ironfish-cli/src/commands/backup.ts
+++ b/ironfish-cli/src/commands/backup.ts
@@ -1,15 +1,16 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { S3Client } from '@aws-sdk/client-s3'
 import { FileUtils, NodeUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { spawn } from 'child_process'
 import fsAsync from 'fs/promises'
 import os from 'os'
 import path from 'path'
 import { v4 as uuid } from 'uuid'
 import { IronfishCommand } from '../command'
 import { DataDirFlag, DataDirFlagKey, VerboseFlag, VerboseFlagKey } from '../flags'
+import { S3Utils, TarUtils } from '../utils'
 
 export default class Backup extends IronfishCommand {
   static hidden = true
@@ -55,12 +56,13 @@ export default class Backup extends IronfishCommand {
 
     const source = this.sdk.config.dataDir
     const destDir = await fsAsync.mkdtemp(path.join(os.tmpdir(), `ironfish.backup`))
-    const dest = path.join(destDir, `node.${id}.tar.gz`)
+    const destName = `node.${id}.tar.gz`
+    const dest = path.join(destDir, destName)
 
     this.log(`Zipping\n    SRC ${source}\n    DST ${dest}\n`)
     CliUx.ux.action.start(`Zipping ${source}`)
 
-    await this.zipDir(
+    await TarUtils.zipDir(
       source,
       dest,
       flags.accounts ? [] : [path.basename(path.dirname(this.sdk.config.accountDatabasePath))],
@@ -70,60 +72,19 @@ export default class Backup extends IronfishCommand {
     CliUx.ux.action.stop(`done (${FileUtils.formatFileSize(stat.size)})`)
 
     CliUx.ux.action.start(`Uploading to ${bucket}`)
-    await this.uploadToS3(dest, bucket)
+    const s3 = new S3Client({ region: 'us-east-1' })
+    await S3Utils.uploadToBucket(
+      s3,
+      dest,
+      'application/x-compressed-tar',
+      bucket,
+      destName,
+      this.logger.withTag('s3'),
+    )
     CliUx.ux.action.stop(`done`)
-  }
 
-  zipDir(source: string, dest: string, excludes: string[] = []): Promise<number | null> {
-    return new Promise<number | null>((resolve, reject) => {
-      const sourceDir = path.dirname(source)
-      const sourceFile = path.basename(source)
-
-      const args = ['-zcf', dest, '-C', sourceDir, sourceFile]
-
-      for (const exclude of excludes) {
-        args.unshift(exclude)
-        args.unshift('--exclude')
-      }
-
-      const process = spawn('tar', args)
-      process.on('exit', (code) => resolve(code))
-      process.on('close', (code) => resolve(code))
-      process.on('error', (error) => reject(error))
-    })
-  }
-
-  uploadToS3(dest: string, bucket: string): Promise<number | null> {
-    return new Promise<number | null>((resolve, reject) => {
-      const date = new Date().toISOString()
-      const host = `${bucket}.s3.amazonaws.com`
-      const file = path.basename(dest)
-      const contentType = 'application/x-compressed-tar'
-      const acl = 'bucket-owner-full-control'
-
-      const process = spawn(
-        `curl`,
-        [
-          '-X',
-          `PUT`,
-          `-T`,
-          `${dest}`,
-          `-H`,
-          `Host: ${host}`,
-          `-H`,
-          `Date: ${date}`,
-          `-H`,
-          `Content-Type: ${contentType}`,
-          `-H`,
-          `x-amz-acl: ${acl}`,
-          `https://${host}/${file}`,
-        ],
-        { stdio: 'inherit' },
-      )
-
-      process.on('message', (m) => this.log(String(m)))
-      process.on('exit', (code) => resolve(code))
-      process.on('error', (error) => reject(error))
-    })
+    CliUx.ux.action.start(`Removing backup dir ${destDir}`)
+    await fsAsync.rm(destDir, { recursive: true })
+    CliUx.ux.action.stop(`done`)
   }
 }

--- a/ironfish-cli/src/commands/restore.ts
+++ b/ironfish-cli/src/commands/restore.ts
@@ -4,7 +4,6 @@
 import { NodeUtils, PromiseUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import axios from 'axios'
-import { spawn } from 'child_process'
 import fs from 'fs'
 import fsAsync from 'fs/promises'
 import os from 'os'
@@ -12,6 +11,7 @@ import path from 'path'
 import { IronfishCommand } from '../command'
 import { DataDirFlag, DataDirFlagKey, VerboseFlag, VerboseFlagKey } from '../flags'
 import { ProgressBar } from '../types'
+import { TarUtils } from '../utils'
 
 const EXTENSION = '.tar.gz'
 
@@ -84,7 +84,7 @@ export default class Restore extends IronfishCommand {
 
     this.log(`Unzipping\n    SRC ${downloadTo}\n    DST ${unzipTo}`)
     CliUx.ux.action.start(`Unzipping ${path.basename(downloadTo)}`)
-    await this.unzipTar(downloadTo, unzipTo)
+    await TarUtils.unzipTar(downloadTo, unzipTo)
     CliUx.ux.action.stop('done\n')
 
     // We do this because the backup can be created with any datadir name
@@ -100,14 +100,6 @@ export default class Restore extends IronfishCommand {
     await fsAsync.rm(this.sdk.config.dataDir, { recursive: true, force: true })
     await fsAsync.rename(unzipFrom, this.sdk.config.dataDir)
     CliUx.ux.action.stop(`done\n`)
-  }
-
-  unzipTar(source: string, dest: string): Promise<number | null> {
-    return new Promise<number | null>((resolve, reject) => {
-      const process = spawn('tar', ['-xvzf', source, '-C', dest])
-      process.on('exit', (code) => resolve(code))
-      process.on('error', (error) => reject(error))
-    })
   }
 }
 

--- a/ironfish-cli/src/commands/service/snapshot.ts
+++ b/ironfish-cli/src/commands/service/snapshot.ts
@@ -1,26 +1,17 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import {
-  AbortMultipartUploadCommand,
-  CompleteMultipartUploadCommand,
-  CreateMultipartUploadCommand,
-  S3Client,
-  UploadPartCommand,
-} from '@aws-sdk/client-s3'
-import { Assert, FileUtils, NodeUtils } from '@ironfish/sdk'
+import { S3Client } from '@aws-sdk/client-s3'
+import { FileUtils, NodeUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import crypto from 'crypto'
 import fsAsync from 'fs/promises'
 import path from 'path'
-import tar from 'tar'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
-import { DEFAULT_SNAPSHOT_BUCKET, SnapshotManifest } from '../../utils'
+import { DEFAULT_SNAPSHOT_BUCKET, S3Utils, SnapshotManifest } from '../../utils'
+import { TarUtils } from '../../utils/tar'
 
-// AWS requires that upload parts be at least 5MB
-const MINIMUM_MULTIPART_FILE_SIZE = 5 * 1024 * 1024
-const MAX_MULTIPART_NUM = 10000
 const SNAPSHOT_FILE_NAME = `ironfish_snapshot.tar.gz`
 
 export default class CreateSnapshot extends IronfishCommand {
@@ -99,7 +90,7 @@ export default class CreateSnapshot extends IronfishCommand {
 
     this.log(`Zipping\n    SRC ${chainDatabasePath}\n    DST ${snapshotPath}\n`)
     CliUx.ux.action.start(`Zipping ${chainDatabasePath}`)
-    await this.zipDir(chainDatabasePath + '/', snapshotPath)
+    await TarUtils.zipDir(chainDatabasePath + '/', snapshotPath)
     const stat = await fsAsync.stat(snapshotPath)
     const fileSize = stat.size
     CliUx.ux.action.stop(`done (${FileUtils.formatFileSize(fileSize)})`)
@@ -118,15 +109,23 @@ export default class CreateSnapshot extends IronfishCommand {
     if (flags.upload) {
       const snapshotBaseName = path.basename(SNAPSHOT_FILE_NAME, '.tar.gz')
       const snapshotKeyName = `${snapshotBaseName}_${timestamp}.tar.gz`
+
+      const s3 = new S3Client({
+        credentials: {
+          accessKeyId,
+          secretAccessKey,
+        },
+        region,
+      })
+
       CliUx.ux.action.start(`Uploading to ${bucket}`)
-      await this.uploadToBucket(
+      await S3Utils.uploadToBucket(
+        s3,
         snapshotPath,
         'application/x-compressed-tar',
         bucket,
         snapshotKeyName,
-        accessKeyId,
-        secretAccessKey,
-        region,
+        this.logger.withTag('s3'),
       )
       CliUx.ux.action.stop(`done`)
 
@@ -144,14 +143,13 @@ export default class CreateSnapshot extends IronfishCommand {
         .writeFile(manifestPath, JSON.stringify(manifest, undefined, '  '))
         .then(async () => {
           CliUx.ux.action.start(`Uploading latest snapshot information to ${bucket}`)
-          await this.uploadToBucket(
+          await S3Utils.uploadToBucket(
+            s3,
             manifestPath,
             'application/json',
             bucket,
             manifestPath,
-            accessKeyId,
-            secretAccessKey,
-            region,
+            this.logger.withTag('s3'),
           )
           CliUx.ux.action.stop(`done`)
         })
@@ -159,182 +157,5 @@ export default class CreateSnapshot extends IronfishCommand {
       this.log('Snapshot upload complete. Uploaded the following manifest:')
       this.log(JSON.stringify(manifest, undefined, '  '))
     }
-  }
-
-  async zipDir(source: string, dest: string, excludes: string[] = []): Promise<void> {
-    const sourceDir = path.dirname(source)
-    const sourceFile = path.basename(source)
-    const excludeSet = new Set(excludes)
-
-    await tar.create(
-      {
-        gzip: true,
-        file: dest,
-        C: sourceDir,
-        filter: function (path) {
-          if (excludeSet.has(path)) {
-            return false
-          } else {
-            return true
-          }
-        },
-      },
-      [sourceFile],
-    )
-  }
-
-  async uploadToBucket(
-    filePath: string,
-    contentType: string,
-    bucket: string,
-    keyName: string,
-    accessKeyId: string,
-    secretAccessKey: string,
-    region: string,
-  ): Promise<void> {
-    const fileHandle = await fsAsync.open(filePath, 'r')
-
-    const stat = await fsAsync.stat(filePath)
-    const fileSize = stat.size
-    let numParts = MAX_MULTIPART_NUM
-
-    while (fileSize / numParts < MINIMUM_MULTIPART_FILE_SIZE) {
-      numParts /= 2
-    }
-
-    const uploadChunkSize = fileSize / numParts
-
-    const contentStream = fileHandle.createReadStream()
-
-    const s3 = new S3Client({
-      credentials: {
-        accessKeyId,
-        secretAccessKey,
-      },
-      region,
-    })
-
-    const params = {
-      Bucket: bucket,
-      Key: keyName,
-      ContentType: contentType,
-    }
-
-    const uploadId = await s3
-      .send(new CreateMultipartUploadCommand(params))
-      .then((result) => result.UploadId)
-      .catch((err: Error) => {
-        this.logger.error(`Could not create multipart upload to S3: ${err.message}`)
-        throw new Error(err.message)
-      })
-
-    Assert.isNotUndefined(uploadId)
-
-    const uploadPartsPromise = new Promise<{
-      Parts: { ETag: string | undefined; PartNumber: number }[]
-    }>((resolve, reject) => {
-      const partMap: { Parts: { ETag: string | undefined; PartNumber: number }[] } = {
-        Parts: [],
-      }
-
-      let partNum = 1
-      let acc: Buffer | null = null
-
-      contentStream.on('data', (chunk: Buffer) => {
-        if (!acc) {
-          acc = chunk
-        } else {
-          acc = Buffer.concat([acc, chunk])
-        }
-
-        if (acc.length > uploadChunkSize) {
-          contentStream.pause()
-
-          const params = {
-            Bucket: bucket,
-            Key: keyName,
-            PartNumber: partNum,
-            UploadId: uploadId,
-            ContentType: contentType,
-            Body: acc,
-          }
-
-          s3.send(new UploadPartCommand(params))
-            .then((result) => {
-              partMap.Parts.push({ ETag: result.ETag, PartNumber: params.PartNumber })
-              partNum += 1
-              acc = null
-              contentStream.resume()
-            })
-            .catch((err: Error) => {
-              this.logger.error(`Could not upload part to S3 bucket: ${err.message}`)
-              reject(err)
-            })
-        }
-      })
-
-      contentStream.on('close', () => {
-        if (acc) {
-          const params = {
-            Bucket: bucket,
-            Key: keyName,
-            PartNumber: partNum,
-            UploadId: uploadId,
-            ContentType: contentType,
-            Body: acc,
-          }
-
-          s3.send(new UploadPartCommand(params))
-            .then((result) => {
-              partMap.Parts.push({ ETag: result.ETag, PartNumber: params.PartNumber })
-              acc = null
-              resolve(partMap)
-            })
-            .catch((err: Error) => {
-              this.logger.error(`Could not upload last part to S3 bucket: ${err.message}`)
-              reject(err)
-            })
-        }
-      })
-
-      contentStream.on('error', (err) => {
-        this.logger.error(`Could not read file: ${err.message}; aborting upload to S3...`)
-        const params = {
-          Bucket: bucket,
-          Key: keyName,
-          UploadId: uploadId,
-        }
-
-        s3.send(new AbortMultipartUploadCommand(params))
-          .then()
-          .catch((awsErr: Error) => {
-            this.logger.error(`Could not abort S3 upload: ${awsErr.message}`)
-          })
-
-        reject(err)
-      })
-    })
-
-    const partMap = await uploadPartsPromise
-
-    this.logger.debug(
-      `All parts of snapshot have been uploaded. Finalizing multipart upload. Parts: ${partMap.Parts.length}`,
-    )
-
-    const completionParams = {
-      Bucket: bucket,
-      Key: keyName,
-      UploadId: uploadId,
-      MultipartUpload: partMap,
-    }
-
-    await s3
-      .send(new CompleteMultipartUploadCommand(completionParams))
-      .then(() => {
-        this.logger.info(`Multipart upload complete.`)
-      })
-      .catch((err: Error) => {
-        throw new Error(`Could not complete multipart S3 upload: ${err.message}`)
-      })
   }
 }

--- a/ironfish-cli/src/utils/index.ts
+++ b/ironfish-cli/src/utils/index.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './editor'
 export * from './rpc'
+export * from './s3'
 export * from './snapshot'
+export * from './tar'
 export * from './terminal'
 export * from './types'

--- a/ironfish-cli/src/utils/s3.ts
+++ b/ironfish-cli/src/utils/s3.ts
@@ -1,0 +1,183 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateMultipartUploadCommand,
+  S3Client,
+  UploadPartCommand,
+} from '@aws-sdk/client-s3'
+import { Assert, ErrorUtils, Logger } from '@ironfish/sdk'
+import fsAsync from 'fs/promises'
+
+// AWS requires that upload parts be at least 5MB
+const MINIMUM_MULTIPART_FILE_SIZE = 5 * 1024 * 1024
+const MAX_MULTIPART_NUM = 10000
+
+class UploadToBucketError extends Error {
+  error: unknown | undefined
+
+  constructor(message?: string, error?: unknown) {
+    super(message)
+    this.error = error
+  }
+}
+class CreateMultipartError extends UploadToBucketError {}
+class UploadMultipartError extends UploadToBucketError {}
+class UploadLastMultipartError extends UploadToBucketError {}
+class UploadReadFileError extends UploadToBucketError {}
+class UploadFailedError extends UploadToBucketError {}
+
+async function uploadToBucket(
+  s3: S3Client,
+  filePath: string,
+  contentType: string,
+  bucket: string,
+  keyName: string,
+  logger?: Logger,
+): Promise<void> {
+  const fileHandle = await fsAsync.open(filePath, 'r')
+
+  const stat = await fsAsync.stat(filePath)
+  const fileSize = stat.size
+  let numParts = MAX_MULTIPART_NUM
+
+  while (fileSize / numParts < MINIMUM_MULTIPART_FILE_SIZE) {
+    numParts /= 2
+  }
+
+  const uploadChunkSize = fileSize / numParts
+
+  const contentStream = fileHandle.createReadStream()
+
+  const params = {
+    Bucket: bucket,
+    Key: keyName,
+    ContentType: contentType,
+  }
+
+  const uploadId = await s3
+    .send(new CreateMultipartUploadCommand(params))
+    .then((result) => result.UploadId)
+    .catch((err: Error) => {
+      logger?.debug(`Could not create multipart upload to S3: ${err.message}`)
+      throw new CreateMultipartError(`Could not create multipart upload to S3`, err)
+    })
+
+  Assert.isNotUndefined(uploadId)
+
+  const uploadPartsPromise = new Promise<{
+    Parts: { ETag: string | undefined; PartNumber: number }[]
+  }>((resolve, reject) => {
+    const partMap: { Parts: { ETag: string | undefined; PartNumber: number }[] } = {
+      Parts: [],
+    }
+
+    let partNum = 1
+    let acc: Buffer | null = null
+
+    contentStream.on('data', (chunk: Buffer) => {
+      if (!acc) {
+        acc = chunk
+      } else {
+        acc = Buffer.concat([acc, chunk])
+      }
+
+      if (acc.length > uploadChunkSize) {
+        contentStream.pause()
+
+        const params = {
+          Bucket: bucket,
+          Key: keyName,
+          PartNumber: partNum,
+          UploadId: uploadId,
+          ContentType: contentType,
+          Body: acc,
+        }
+
+        s3.send(new UploadPartCommand(params))
+          .then((result) => {
+            partMap.Parts.push({ ETag: result.ETag, PartNumber: params.PartNumber })
+            partNum += 1
+            acc = null
+            contentStream.resume()
+          })
+          .catch((err) => {
+            logger?.debug(`Could not upload part to S3 bucket: ${ErrorUtils.renderError(err)}`)
+            reject(new UploadMultipartError('Could not upload part to S3 bucket', err))
+          })
+      }
+    })
+
+    contentStream.on('close', () => {
+      if (acc) {
+        const params = {
+          Bucket: bucket,
+          Key: keyName,
+          PartNumber: partNum,
+          UploadId: uploadId,
+          ContentType: contentType,
+          Body: acc,
+        }
+
+        s3.send(new UploadPartCommand(params))
+          .then((result) => {
+            partMap.Parts.push({ ETag: result.ETag, PartNumber: params.PartNumber })
+            acc = null
+            resolve(partMap)
+          })
+          .catch((err) => {
+            logger?.debug(
+              `Could not upload last part to S3 bucket: ${ErrorUtils.renderError(err)}`,
+            )
+            reject(new UploadLastMultipartError('Could not upload last part to S3 bucket', err))
+          })
+      }
+    })
+
+    contentStream.on('error', (err) => {
+      logger?.debug(`Could not read file: ${err.message}; aborting upload to S3...`)
+
+      const params = {
+        Bucket: bucket,
+        Key: keyName,
+        UploadId: uploadId,
+      }
+
+      void s3
+        .send(new AbortMultipartUploadCommand(params))
+        .then()
+        .catch(() => {
+          // Ignore error
+        })
+
+      reject(new UploadReadFileError(undefined, err))
+    })
+  })
+
+  const partMap = await uploadPartsPromise
+
+  logger?.debug(
+    `All parts of snapshot have been uploaded. Finalizing multipart upload. Parts: ${partMap.Parts.length}`,
+  )
+
+  const completionParams = {
+    Bucket: bucket,
+    Key: keyName,
+    UploadId: uploadId,
+    MultipartUpload: partMap,
+  }
+
+  await s3
+    .send(new CompleteMultipartUploadCommand(completionParams))
+    .then(() => {
+      logger?.debug(`Multipart upload complete.`)
+    })
+    .catch((err) => {
+      throw new UploadFailedError('Could not complete multipart S3 upload', err)
+    })
+}
+
+export const S3Utils = { uploadToBucket }

--- a/ironfish-cli/src/utils/tar.ts
+++ b/ironfish-cli/src/utils/tar.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { spawn } from 'child_process'
+import path from 'path'
+import tar from 'tar'
+
+async function zipDir(source: string, dest: string, excludes: string[] = []): Promise<void> {
+  const sourceDir = path.dirname(source)
+  const sourceFile = path.basename(source)
+  const excludeSet = new Set(excludes)
+
+  await tar.create(
+    {
+      gzip: true,
+      file: dest,
+      C: sourceDir,
+      filter: function (path) {
+        if (excludeSet.has(path)) {
+          return false
+        } else {
+          return true
+        }
+      },
+    },
+    [sourceFile],
+  )
+}
+
+function unzipTar(source: string, dest: string): Promise<number | null> {
+  return new Promise<number | null>((resolve, reject) => {
+    const process = spawn('tar', ['-xvzf', source, '-C', dest])
+    process.on('exit', (code) => resolve(code))
+    process.on('error', (error) => reject(error))
+  })
+}
+
+export const TarUtils = { zipDir, unzipTar }


### PR DESCRIPTION
## Summary

Backup does not work because files are too big to not use multipart
uploads. This fixes a key command by factoring out the upload code to be
used by backup.

## Testing Plan

Run backup with a public bucket under https://s3.console.aws.amazon.com/s3/buckets

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
