### PR TITLE
renames importSnapshot to chain:download

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -23,10 +23,10 @@ import { LocalFlags } from '../../flags'
 import { ProgressBar } from '../../types'
 import { DEFAULT_SNAPSHOT_BUCKET, SnapshotManifest } from '../../utils'
 
-export default class ImportSnapshot extends IronfishCommand {
+export default class Download extends IronfishCommand {
   static hidden = false
 
-  static description = `Import chain snapshot`
+  static description = `Download and import a chain snapshot`
 
   static flags = {
     ...LocalFlags,
@@ -49,7 +49,7 @@ export default class ImportSnapshot extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { flags } = await this.parse(ImportSnapshot)
+    const { flags } = await this.parse(Download)
 
     const node = await this.sdk.node()
     await NodeUtils.waitForOpen(node)
@@ -81,13 +81,10 @@ export default class ImportSnapshot extends IronfishCommand {
       const fileSize = FileUtils.formatFileSize(manifest.file_size)
 
       if (!flags.confirm) {
-        this.log(
-          `This snapshot (${manifest.file_name}) contains the Iron Fish blockchain up to block ${manifest.block_sequence}. The size of the latest snapshot file is ${fileSize}`,
+        const confirm = await CliUx.ux.confirm(
+          `Download ${fileSize} snapshot to update chain head from block ${node.chain.head.sequence} to ${manifest.block_sequence}?`,
         )
 
-        this.log(`Current head sequence of your local chain: ${node.chain.head.sequence}`)
-
-        const confirm = await CliUx.ux.confirm('Do you wish to continue (Y/N)?')
         if (!confirm) {
           this.log('Snapshot download aborted.')
           this.exit(0)


### PR DESCRIPTION
## Summary

- converts command name to kebab-case 🍢
- changes download confirmation to make block update clearer, removes name of
  snapshot file from message

## Testing Plan

manual testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
