### PR TITLE
Provide the default bucket URL in the parameters

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -33,8 +33,8 @@ export default class Download extends IronfishCommand {
     bucketUrl: Flags.string({
       char: 'b',
       parse: (input: string) => Promise.resolve(input.trim()),
-      required: false,
       description: 'Bucket URL to download snapshot from',
+      default: `https://${DEFAULT_SNAPSHOT_BUCKET}.s3-accelerate.amazonaws.com`,
     }),
     path: Flags.string({
       char: 'p',
@@ -61,15 +61,13 @@ export default class Download extends IronfishCommand {
     if (flags.path) {
       snapshotPath = this.sdk.fileSystem.resolve(flags.path)
     } else {
-      const bucketUrl = (
-        flags.bucketUrl || `https://${DEFAULT_SNAPSHOT_BUCKET}.s3-accelerate.amazonaws.com`
-      ).trim()
-      if (!bucketUrl) {
+      if (!flags.bucketUrl) {
         this.log(`Cannot download snapshot without bucket URL`)
         this.exit(1)
       }
 
-      const manifest = (await axios.get<SnapshotManifest>(`${bucketUrl}/manifest.json`)).data
+      const manifest = (await axios.get<SnapshotManifest>(`${flags.bucketUrl}/manifest.json`))
+        .data
 
       if (manifest.database_version > VERSION_DATABASE_CHAIN) {
         this.log(
@@ -112,7 +110,7 @@ export default class Download extends IronfishCommand {
       await axios({
         method: 'GET',
         responseType: 'stream',
-        url: `${bucketUrl}/${manifest.file_name}`,
+        url: `${flags.bucketUrl}/${manifest.file_name}`,
       })
         .then(async (response: { data: IncomingMessage }) => {
           response.data.on('data', (chunk: { length: number }) => {


### PR DESCRIPTION
## Summary

This shows up in help and helps users to understand what the URL should
be to customize it without reading our code.

```
> ironfish chain:download --help
Download and import a chain snapshot

USAGE
  $ ironfish chain:download [-v] [--config <value>] [--datadir <value>] [-d <value>] [-b <value>] [-p <value>] [--confirm]

FLAGS
  -b, --bucketUrl=<value>  [default: https://ironfish-snapshots.s3-accelerate.amazonaws.com] Bucket URL to download snapshot from
  -d, --database=<value>   [default: default] the name of the database to use
  -p, --path=<value>       Path to snapshot file
  -v, --verbose            set logging level to verbose
  --config=<value>         [default: config.json] the name of the config file to use
  --confirm                confirm without asking
  --datadir=<value>        [default: ~/.ironfish] the path to the data dir

DESCRIPTION
  Download and import a chain snapshot
```

## Testing Plan
Run `chain:download` and `chain:download --help`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
