### PR TITLE
Dont resolve tempDir

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -55,8 +55,7 @@ export default class Download extends IronfishCommand {
     await NodeUtils.waitForOpen(node)
 
     let snapshotPath
-    const tempDir = this.sdk.fileSystem.resolve(this.sdk.config.tempDir)
-    await fsAsync.mkdir(tempDir, { recursive: true })
+    await fsAsync.mkdir(this.sdk.config.tempDir, { recursive: true })
 
     if (flags.path) {
       snapshotPath = this.sdk.fileSystem.resolve(flags.path)
@@ -91,7 +90,7 @@ export default class Download extends IronfishCommand {
         }
       }
 
-      snapshotPath = path.join(tempDir, manifest.file_name)
+      snapshotPath = path.join(this.sdk.config.tempDir, manifest.file_name)
       const snapshotFile = await fsAsync.open(snapshotPath, 'w')
       const bar = CliUx.ux.progress({
         barCompleteChar: '\u2588',
@@ -147,7 +146,7 @@ export default class Download extends IronfishCommand {
     }
 
     // use a standard name, 'snapshot', for the unzipped database
-    const snapshotDatabasePath = this.sdk.fileSystem.join(tempDir, 'snapshot')
+    const snapshotDatabasePath = this.sdk.fileSystem.join(this.sdk.config.tempDir, 'snapshot')
     await this.sdk.fileSystem.mkdir(snapshotDatabasePath, { recursive: true })
 
     CliUx.ux.action.start(`Unzipping ${snapshotPath}`)


### PR DESCRIPTION
## Summary

This is a result of joining datadir, which is always resolved from
config.

https://github.com/iron-fish/ironfish/blob/master/ironfish/src/fileStores/fileStore.ts#L16

## Testing Plan
Run `ironfish chain:download`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
