### PR TITLE
Remove dots because oclif already adds them

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -152,7 +152,7 @@ export default class Download extends IronfishCommand {
 
     CliUx.ux.action.start(`Unzipping ${snapshotPath}`)
     await this.unzip(snapshotPath, snapshotDatabasePath)
-    CliUx.ux.action.stop('...done')
+    CliUx.ux.action.stop('done')
 
     const chainDatabasePath = this.sdk.fileSystem.resolve(this.sdk.config.chainDatabasePath)
 
@@ -164,7 +164,7 @@ export default class Download extends IronfishCommand {
       await fsAsync.rm(chainDatabasePath, { recursive: true })
     }
     await fsAsync.rename(snapshotDatabasePath, chainDatabasePath)
-    CliUx.ux.action.stop('...done')
+    CliUx.ux.action.stop('done')
   }
 
   async unzip(source: string, dest: string): Promise<void> {


### PR DESCRIPTION
## Summary
*Before*
```
Moving snapshot from... ...done
```
*After*
```
Moving snapshot from ...done
```

## Testing Plan
Run `chain:download`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
