### PR TITLE
Dont restart syncing if the API does not respond

### DIFF
--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -5,7 +5,7 @@
 import axios, { AxiosError, AxiosRequestConfig } from 'axios'
 import { FollowChainStreamResponse } from './rpc/routes/chain/followChain'
 import { Metric } from './telemetry'
-import { UnwrapPromise } from './utils/types'
+import { HasOwnProperty, UnwrapPromise } from './utils/types'
 
 type FaucetTransaction = {
   object: 'faucet_transaction'
@@ -64,7 +64,14 @@ export class WebApi {
   async headDeposits(): Promise<string | null> {
     const response = await axios
       .get<{ block_hash: string }>(`${this.host}/deposits/head`)
-      .catch(() => null)
+      .catch((e) => {
+        // The API returns 404 for no head
+        if (IsAxiosError(e) && e.response?.status === 404) {
+          return null
+        }
+
+        throw e
+      })
 
     return response?.data.block_hash || null
   }
@@ -72,7 +79,14 @@ export class WebApi {
   async headBlocks(): Promise<string | null> {
     const response = await axios
       .get<{ hash: string }>(`${this.host}/blocks/head`)
-      .catch(() => null)
+      .catch((e) => {
+        // The API returns 404 for no head
+        if (IsAxiosError(e) && e.response?.status === 404) {
+          return null
+        }
+
+        throw e
+      })
 
     return response?.data.hash || null
   }
@@ -214,4 +228,8 @@ export class WebApi {
       throw new Error(`Token required for endpoint`)
     }
   }
+}
+
+export function IsAxiosError(e: unknown): e is AxiosError {
+  return typeof e === 'object' && e != null && HasOwnProperty(e, 'isAxiosError')
 }


### PR DESCRIPTION
## Summary
If any error occurs it would just restart syncing. Now it only assumes it should start from the genesis block if the API returns a 404, which is an expected response.

https://github.com/iron-fish/ironfish-api/blob/master/src/events/deposits.controller.ts#L41

## Testing Plan
Modify the URL And check the results of what this does.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
