### PR TITLE
Switch download to use manifestUrl

### DIFF
--- a/ironfish-cli/src/utils/url.ts
+++ b/ironfish-cli/src/utils/url.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { ErrorUtils } from '@ironfish/sdk'
+
+const tryParseUrl = (url: string): URL | null => {
+  try {
+    return new URL(url)
+  } catch (e) {
+    if (e instanceof TypeError && ErrorUtils.isNodeError(e) && e.code === 'ERR_INVALID_URL') {
+      return null
+    }
+    throw e
+  }
+}
+
+function splitPathName(pathName: string): string[] {
+  return pathName.split('/').filter((s) => !!s.trim())
+}
+
+function joinPathName(parts: string[]): string {
+  return parts.join('/')
+}
+
+export const UrlUtils = { tryParseUrl, joinPathName, splitPathName }


### PR DESCRIPTION
## Summary

Switched this ot use bucketUrl so give the community more power in
hosting their own snapshot repositories.

With manifest URL you can point it at ANY url that resolves to a manifest file, and you don't have to give it a URL with a relative manifest. This means you can write an API that resolves to a manifest.

## Testing Plan
Run `ironfish chain:download`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
