### PR TITLE
replaces s3 bucket url with cloudfront url in chain:snapshot

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -20,7 +20,7 @@ import tar from 'tar'
 import { promisify } from 'util'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
-import { DEFAULT_SNAPSHOT_BUCKET, SnapshotManifest } from '../../snapshot'
+import { SnapshotManifest } from '../../snapshot'
 import { ProgressBar } from '../../types'
 import { UrlUtils } from '../../utils/url'
 
@@ -35,7 +35,7 @@ export default class Download extends IronfishCommand {
       char: 'm',
       parse: (input: string) => Promise.resolve(input.trim()),
       description: 'Bucket URL to download snapshot from',
-      default: `https://${DEFAULT_SNAPSHOT_BUCKET}.s3-accelerate.amazonaws.com/manifest.json`,
+      default: 'https://d1kj1bottktsu0.cloudfront.net/manifest.json',
     }),
     path: Flags.string({
       char: 'p',
@@ -62,7 +62,7 @@ export default class Download extends IronfishCommand {
       snapshotPath = this.sdk.fileSystem.resolve(flags.path)
     } else {
       if (!flags.manifestUrl) {
-        this.log(`Cannot download snapshot without bucket URL`)
+        this.log(`Cannot download snapshot without manifest URL`)
         this.exit(1)
       }
 

--- a/ironfish-cli/src/commands/service/snapshot.ts
+++ b/ironfish-cli/src/commands/service/snapshot.ts
@@ -9,7 +9,7 @@ import fsAsync from 'fs/promises'
 import path from 'path'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
-import { DEFAULT_SNAPSHOT_BUCKET, SnapshotManifest } from '../../snapshot'
+import { SnapshotManifest } from '../../snapshot'
 import { S3Utils, TarUtils } from '../../utils'
 
 const SNAPSHOT_FILE_NAME = `ironfish_snapshot.tar.gz`
@@ -30,6 +30,7 @@ export default class CreateSnapshot extends IronfishCommand {
       parse: (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'S3 bucket to upload snapshot to',
+      default: 'ironfish-snapshots',
     }),
     accessKeyId: Flags.string({
       char: 'a',

--- a/ironfish-cli/src/commands/service/snapshot.ts
+++ b/ironfish-cli/src/commands/service/snapshot.ts
@@ -61,7 +61,7 @@ export default class CreateSnapshot extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(CreateSnapshot)
 
-    const bucket = (flags.bucket || DEFAULT_SNAPSHOT_BUCKET).trim()
+    const bucket = flags.bucket
     const accessKeyId = (flags.accessKeyId || process.env.AWS_ACCESS_KEY_ID || '').trim()
     const secretAccessKey = (
       flags.secretAccessKey ||

--- a/ironfish-cli/src/snapshot.ts
+++ b/ironfish-cli/src/snapshot.ts
@@ -1,8 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export const DEFAULT_SNAPSHOT_BUCKET = 'ironfish-snapshots'
-
 export type SnapshotManifest = {
   block_sequence: number
   checksum: string


### PR DESCRIPTION
## Summary

- changes flag from 'bucketUrl' to 'url'
- makes default url cloudfront distribution url
- moves DEFAULT_SNAPSHOT_BUCKET definition to snapshot command -- the only place
  it's used

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
