### PR TITLE
uses 'manifest.json' for s3 key name

### DIFF
--- a/ironfish-cli/src/commands/service/snapshot.ts
+++ b/ironfish-cli/src/commands/service/snapshot.ts
@@ -149,7 +149,7 @@ export default class CreateSnapshot extends IronfishCommand {
             manifestPath,
             'application/json',
             bucket,
-            manifestPath,
+            'manifest.json',
             this.logger.withTag('s3'),
           )
           CliUx.ux.action.stop(`done`)


### PR DESCRIPTION
## Summary

don't use local path as S3 key

## Testing Plan

manual testing of manifest upload

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
