### PR TITLE
Add RSS to telemetry payload (#1917)

### DIFF
--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -159,6 +159,11 @@ export class Telemetry {
         value: this.metrics.heapTotal.value,
       },
       {
+        name: 'rss',
+        type: 'integer',
+        value: this.metrics.rss.value,
+      },
+      {
         name: 'inbound_traffic',
         type: 'float',
         value: this.metrics.p2p_InboundTraffic.rate5m,


### PR DESCRIPTION
## Summary
Adds RSS value to periodic telemetry payload.

## Testing Plan
Adjust telemetry whitelist in API and ensure that values are being added.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
