### PR TITLE
Remove 0 metrics from telemetry

### DIFF
--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -186,6 +186,9 @@ export class Telemetry {
     ]
 
     for (const [messageType, meter] of this.metrics.p2p_InboundTrafficByMessage) {
+      if (!meter.rate5m) {
+        continue
+      }
       fields.push({
         name: 'inbound_traffic_' + NetworkMessageType[messageType].toLowerCase(),
         type: 'float',
@@ -194,6 +197,9 @@ export class Telemetry {
     }
 
     for (const [messageType, meter] of this.metrics.p2p_OutboundTrafficByMessage) {
+      if (!meter.rate5m) {
+        continue
+      }
       fields.push({
         name: 'outbound_traffic_' + NetworkMessageType[messageType].toLowerCase(),
         type: 'float',


### PR DESCRIPTION
## Summary
When no network messages have been sent for a certain message type, we don't want to send those messages to telemetry

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
