### PR TITLE
 handles 'close' event instead of 'end' event

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -153,7 +153,7 @@ export default class Download extends IronfishCommand {
           reject(e)
         })
 
-        writer.on('end', () => {
+        writer.on('close', () => {
           resolve()
         })
 


### PR DESCRIPTION
## Summary

WriteStream emits 'close'. 'end' is never emitted, so the download does not
resolve at completion.

## Testing Plan

- modify `chain:download` to download the manifest instead of a snapshot, see that it finishes download successfully after change. patch for testing attached:
[test.patch.txt](https://github.com/iron-fish/ironfish/files/9274012/test.patch.txt)
 

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
