### PR TITLE
Input validation for account name

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -193,3 +193,9 @@ function getFlag(flags: unknown, flag: FLAGS): unknown | null {
       (flags as any)[flag]
     : null
 }
+
+export abstract class InputValidator {
+  public static readonly accountName = new RegExp('[^a-z^A-Z^0-9^_]')
+
+  // Other input validation goes here
+}

--- a/ironfish-cli/src/commands/accounts/address.ts
+++ b/ironfish-cli/src/commands/accounts/address.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Flags } from '@oclif/core'
-import { IronfishCommand } from '../../command'
+import { InputValidator, IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class AddressCommand extends IronfishCommand {
@@ -32,6 +32,11 @@ export class AddressCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { args, flags } = await this.parse(AddressCommand)
     const account = args.account as string | undefined
+
+    // validates account name
+    if (InputValidator.accountName.test(account as string)) {
+      this.error('Invalid account name')
+    }
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/accounts/balance.ts
+++ b/ironfish-cli/src/commands/accounts/balance.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { displayIronAmountWithCurrency, oreToIron } from '@ironfish/sdk'
-import { IronfishCommand } from '../../command'
+import { InputValidator, IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class BalanceCommand extends IronfishCommand {
@@ -28,6 +28,11 @@ export class BalanceCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { args } = await this.parse(BalanceCommand)
     const account = args.account as string | undefined
+
+    // validates account name
+    if (InputValidator.accountName.test(account as string)) {
+      this.error('Invalid account name')
+    }
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/accounts/create.ts
+++ b/ironfish-cli/src/commands/accounts/create.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { CliUx } from '@oclif/core'
-import { IronfishCommand } from '../../command'
+import { InputValidator, IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class CreateCommand extends IronfishCommand {
@@ -26,10 +26,19 @@ export class CreateCommand extends IronfishCommand {
     const { args } = await this.parse(CreateCommand)
     let name = args.name as string
 
+    // validates account name
+    if (InputValidator.accountName.test(name)) {
+      this.error('Invalid account name')
+    }
+
     if (!name) {
       name = (await CliUx.ux.prompt('Enter the name of the account', {
         required: true,
       })) as string
+      // validates account name
+      if (InputValidator.accountName.test(name)) {
+        this.error('Invalid account name')
+      }
     }
 
     const client = await this.sdk.connectRpc()

--- a/ironfish-cli/src/commands/accounts/export.ts
+++ b/ironfish-cli/src/commands/accounts/export.ts
@@ -6,7 +6,7 @@ import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs'
 import jsonColorizer from 'json-colorizer'
 import path from 'path'
-import { IronfishCommand } from '../../command'
+import { InputValidator, IronfishCommand } from '../../command'
 import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../flags'
 
 export class ExportCommand extends IronfishCommand {
@@ -41,6 +41,11 @@ export class ExportCommand extends IronfishCommand {
     const { color, local } = flags
     const account = args.account as string
     const exportPath = args.path as string | undefined
+
+    // validates account name
+    if (InputValidator.accountName.test(account)) {
+      this.error('Invalid account name')
+    }
 
     const client = await this.sdk.connectRpc(local)
     const response = await client.exportAccount({ account })

--- a/ironfish-cli/src/commands/accounts/notes.ts
+++ b/ironfish-cli/src/commands/accounts/notes.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { oreToIron } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
-import { IronfishCommand } from '../../command'
+import { InputValidator, IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class NotesCommand extends IronfishCommand {
@@ -25,6 +25,11 @@ export class NotesCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { args } = await this.parse(NotesCommand)
     const account = args.account as string | undefined
+
+    // validates account name
+    if (InputValidator.accountName.test(account as string)) {
+      this.error('Invalid account name')
+    }
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -11,7 +11,7 @@ import {
   oreToIron,
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { IronfishCommand } from '../../command'
+import { InputValidator, IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { ProgressBar } from '../../types'
 
@@ -65,6 +65,11 @@ export class Pay extends IronfishCommand {
     let from = flags.account?.trim()
     const expirationSequence = flags.expirationSequence
     const memo = flags.memo || ''
+
+    // validates account name
+    if (InputValidator.accountName.test(from as string)) {
+      this.error('Invalid account name')
+    }
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/accounts/remove.ts
+++ b/ironfish-cli/src/commands/accounts/remove.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { CliUx, Flags } from '@oclif/core'
-import { IronfishCommand } from '../../command'
+import { InputValidator, IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class RemoveCommand extends IronfishCommand {
@@ -28,6 +28,11 @@ export class RemoveCommand extends IronfishCommand {
     const { args, flags } = await this.parse(RemoveCommand)
     const confirm = flags.confirm
     const name = (args.name as string).trim()
+
+    // validates account name
+    if (InputValidator.accountName.test(name)) {
+      this.error('Invalid account name')
+    }
 
     const client = await this.sdk.connectRpc()
 

--- a/ironfish-cli/src/commands/accounts/transactions.ts
+++ b/ironfish-cli/src/commands/accounts/transactions.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { oreToIron } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { IronfishCommand } from '../../command'
+import { InputValidator, IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class TransactionsCommand extends IronfishCommand {
@@ -26,6 +26,11 @@ export class TransactionsCommand extends IronfishCommand {
     const { flags } = await this.parse(TransactionsCommand)
     const account = flags.account?.trim()
     const hash = flags.hash?.trim()
+
+    // validates account name
+    if (InputValidator.accountName.test(account as string)) {
+      this.error('Invalid account name')
+    }
 
     if (hash) {
       await this.getTransaction(account, hash)

--- a/ironfish-cli/src/commands/accounts/use.ts
+++ b/ironfish-cli/src/commands/accounts/use.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { IronfishCommand } from '../../command'
+import { InputValidator, IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class UseCommand extends IronfishCommand {
@@ -22,6 +22,11 @@ export class UseCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { args } = await this.parse(UseCommand)
     const name = (args.name as string).trim()
+
+    // validates account name
+    if (InputValidator.accountName.test(name)) {
+      this.error('Invalid account name')
+    }
 
     const client = await this.sdk.connectRpc()
     await client.useAccount({ name })

--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -16,7 +16,7 @@ import {
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import blessed from 'blessed'
-import { IronfishCommand } from '../command'
+import { InputValidator, IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 
 const REGISTER_URL = 'https://testnet.ironfish.network/signup'
@@ -67,6 +67,11 @@ export default class DepositAll extends IronfishCommand {
 
     const accountName =
       flags.account || (await this.client.getDefaultAccount()).content.account?.name
+
+    // validates account name
+    if (InputValidator.accountName.test(accountName as string)) {
+      this.error('Invalid account name')
+    }
 
     if (!accountName) {
       this.log(

--- a/ironfish-cli/src/commands/deposit.ts
+++ b/ironfish-cli/src/commands/deposit.ts
@@ -13,7 +13,7 @@ import {
   WebApi,
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { IronfishCommand } from '../command'
+import { InputValidator, IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 import { ProgressBar } from '../types'
 
@@ -60,6 +60,11 @@ export default class Bank extends IronfishCommand {
 
     const accountName =
       flags.account || (await this.client.getDefaultAccount()).content.account?.name
+
+    // validates account name
+    if (InputValidator.accountName.test(accountName as string)) {
+      this.error('Invalid account name')
+    }
 
     if (!accountName) {
       this.log(


### PR DESCRIPTION
## Summary
Fixes: https://github.com/iron-fish/ironfish/issues/1379

The commit validates account name in the following commands:
accounts:address
accounts:balance
accounts:create
accounts:export
accounts:notes
accounts:pay
accounts:remove
accounts:transactions
accounts:use
deposit
deposit-all
depositAll

The account name can only contain english letters, english numbers and underscores.

The regular expression used in this commit could be changed to meet other requirements.

graffiti: ironfishup

## Testing Plan
Tested successfully

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
