### PR TITLE
bumps the CLI version to 0.1.43

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ironfish",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "CLI for running and interacting with an Iron Fish node",
   "author": "Iron Fish <contact@ironfish.network> (https://ironfish.network)",
   "main": "build/src/index.js",


### PR DESCRIPTION
## Summary

bumps the CLI version in order to release fix for `chain:download`

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
