### PR TITLE
Dont snapshot resolve after reject

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -149,13 +149,20 @@ export default class Download extends IronfishCommand {
       })
 
       await new Promise<void>((resolve, reject) => {
-        writer.on('error', (e) => {
+        const onWriterError = (e: unknown) => {
+          writer.removeListener('close', onWriterClose)
+          writer.removeListener('onWriterError', onWriterError)
           reject(e)
-        })
+        }
 
-        writer.on('close', () => {
+        const onWriterClose = () => {
+          writer.removeListener('close', onWriterClose)
+          writer.removeListener('onWriterError', onWriterError)
           resolve()
-        })
+        }
+
+        writer.on('error', onWriterError)
+        writer.on('close', onWriterClose)
 
         response.data.on('error', (e) => {
           writer.destroy(e)


### PR DESCRIPTION
## Summary

There is a simple issue here in that during an error, resolve() is
called after reject() is called. This is because 'close' is ALWAYS
called no matter what if the stream finishes, or there is an error.

You can verify this if you add console logs to the writer handlers in
the staging branch.

## Testing Plan

1. Add console logs to writer handers
2. Cause an error to happen and see that 'error' is fired then 'close' is fired
3. This causes reject() then resolve() to trigger

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
