### PR TITLE
Remove unused highlight.js resolution

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -86,9 +86,6 @@
     "ts-jest": "26.5.5",
     "typescript": "4.3.4"
   },
-  "resolutions": {
-    "highlight.js": "10.4.1"
-  },
   "bugs": {
     "url": "https://github.com/iron-fish/ironfish/issues"
   },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "resolutions": {
     "axios": "0.21.4",
     "handlebars": "4.7.7",
-    "node-notifier": "8.0.1",
-    "set-getter": "0.1.1"
+    "node-notifier": "8.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5813,7 +5813,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.7.6:
+handlebars@4.7.7, handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -8061,7 +8061,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^8.0.0:
+node-notifier@8.0.1, node-notifier@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
   integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/97762857/183234843-62177012-4011-409e-8a4e-764527169e04.png)

![image](https://user-images.githubusercontent.com/97762857/183235809-97673bb6-3752-4e80-a852-cd5a3da74dc0.png)


Not in the yarn.lock either, but I learned if you `yarn install` from `/ironfish` you get it added as a dependency. If you `yarn install` from root, you do not. Fun!

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
