### PR TITLE
rust-nodejs version is referencing the wrong version

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "@ironfish/bfilter": "0.0.1",
-    "@ironfish/rust-nodejs": "0.1.9",
+    "@ironfish/rust-nodejs": "0.1.10",
     "@napi-rs/blake-hash": "1.3.1",
     "axios": "0.21.4",
     "blru": "0.1.6",


### PR DESCRIPTION
## Summary

This is causing some REAL weird stuff if you try to install js deps

https://github.com/iron-fish/ironfish/blob/master/ironfish-rust-nodejs/package.json#L3

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
