### PR TITLE
Cleanup test timeout values

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -54,9 +54,9 @@
     "lint:fix": "tsc -b && tsc -b tsconfig.test.json && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
     "start": "tsc -b -w",
     "test": "tsc -b && tsc -b tsconfig.test.json && jest",
-    "test:slow": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.slow.ts\" --testPathIgnorePatterns",
-    "test:perf": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.perf.ts\" --testPathIgnorePatterns",
-    "test:coverage:html": "tsc -b tsconfig.test.json && jest  --coverage --coverage-reporters html --testPathIgnorePatterns",
+    "test:slow": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.slow.ts\" --testTimeout=60000 --testPathIgnorePatterns",
+    "test:perf": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.perf.ts\" --testTimeout=60000 --testPathIgnorePatterns",
+    "test:coverage:html": "tsc -b tsconfig.test.json && jest --coverage --coverage-reporters html --testPathIgnorePatterns",
     "test:watch": "tsc -b tsconfig.test.json && jest --watch --coverage false"
   },
   "devDependencies": {

--- a/ironfish/src/account/accounts.test.slow.ts
+++ b/ironfish/src/account/accounts.test.slow.ts
@@ -69,7 +69,7 @@ describe('Accounts', () => {
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
-  }, 600000)
+  })
 
   it('Saves and restores transactions from accounts db', async () => {
     // Initialize the database and chain
@@ -125,7 +125,7 @@ describe('Accounts', () => {
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
-  }, 600000)
+  })
 
   it('Lowers the balance after using pay to spend a note', async () => {
     // Initialize the database and chain
@@ -193,7 +193,7 @@ describe('Accounts', () => {
       confirmed: BigInt(1999999998),
       unconfirmed: BigInt(1999999998),
     })
-  }, 600000)
+  })
 
   it('Creates valid transactions when the worker pool is enabled', async () => {
     // Initialize the database and chain
@@ -264,7 +264,7 @@ describe('Accounts', () => {
       confirmed: BigInt(1999999998),
       unconfirmed: BigInt(1999999998),
     })
-  }, 600000)
+  })
 
   it('creates valid transactions with multiple outputs', async () => {
     // Initialize the database and chain
@@ -344,7 +344,7 @@ describe('Accounts', () => {
       confirmed: BigInt(1999999994),
       unconfirmed: BigInt(1999999994),
     })
-  }, 600000)
+  })
 
   it('throws a ValidationError with an invalid expiration sequence', async () => {
     const node = nodeTest.node
@@ -367,7 +367,7 @@ describe('Accounts', () => {
         1,
       ),
     ).rejects.toThrowError(ValidationError)
-  }, 60000)
+  })
 
   it('Expires transactions when calling expireTransactions', async () => {
     // Initialize the database and chain
@@ -451,7 +451,7 @@ describe('Accounts', () => {
       confirmed: BigInt(2000000000),
       unconfirmed: BigInt(2000000000),
     })
-  }, 600000)
+  })
 
   it('Counts notes correctly when a block has transactions not used by any account', async () => {
     const nodeA = nodeTest.node
@@ -520,7 +520,7 @@ describe('Accounts', () => {
         0,
       ),
     ).resolves.toBeTruthy()
-  }, 600000)
+  })
 
   it('Removes notes when rolling back a fork', async () => {
     // Create a block A1 that gives account A money
@@ -582,7 +582,7 @@ describe('Accounts', () => {
       confirmed: BigInt(4000000000),
       unconfirmed: BigInt(4000000000),
     })
-  }, 60000)
+  })
 
   it('Keeps spends created by the node when rolling back a fork', async () => {
     // Create a block 1 that gives account A money
@@ -680,7 +680,7 @@ describe('Accounts', () => {
       confirmed: BigInt(0),
       unconfirmed: BigInt(2),
     })
-  }, 600000)
+  })
 
   it('Undoes spends created by another node when rolling back a fork', async () => {
     // Create a block 1 that gives account A money
@@ -791,5 +791,5 @@ describe('Accounts', () => {
       confirmed: BigInt(0),
       unconfirmed: BigInt(2),
     })
-  }, 600000)
+  })
 })

--- a/ironfish/src/account/accounts.test.ts
+++ b/ironfish/src/account/accounts.test.ts
@@ -23,7 +23,7 @@ describe('Accounts', () => {
 
     await node.accounts.start()
     expect(resetSpy).toBeCalledTimes(1)
-  }, 8000)
+  })
 
   it('should handle transaction created on fork', async () => {
     const { node: nodeA } = await nodeTest.createSetup()
@@ -96,7 +96,7 @@ describe('Accounts', () => {
     // It should now be planned to be processed at head + 1
     invalidTxEntry = nodeA.accounts['transactionMap'].get(invalidTx.unsignedHash())
     expect(invalidTxEntry?.submittedSequence).toEqual(blockB2.header.sequence)
-  }, 120000)
+  })
 
   describe('getBalance', () => {
     it('returns balances for unspent notes with minimum confirmations on the main chain', async () => {

--- a/ironfish/src/blockchain/blockchain.test.perf.ts
+++ b/ironfish/src/blockchain/blockchain.test.perf.ts
@@ -157,7 +157,7 @@ describe('Blockchain', () => {
     printResults(await runTest(5, 10))
     printResults(await runTest(5, 50))
     printResults(await runTest(5, 100))
-  }, 780000)
+  })
 })
 
 // Last results on Jason Spafford's Machine

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -33,7 +33,7 @@ describe('Blockchain', () => {
     expect(await chain.nullifiers.size()).toBeGreaterThan(0)
     expect(await chain.getPrevious(genesis.header)).toBe(null)
     expect(await chain.getNext(genesis.header)).toBe(null)
-  }, 10000)
+  })
 
   it('add blocks with forks', async () => {
     const { strategy, chain } = nodeTest
@@ -93,7 +93,7 @@ describe('Blockchain', () => {
     expect((await chain.getHashAtSequence(2))?.equals(headerA1.hash)).toBe(true)
     expect((await chain.getHashAtSequence(3))?.equals(headerB2.hash)).toBe(true)
     expect((await chain.getHashAtSequence(4))?.equals(headerB3.hash)).toBe(true)
-  }, 10000)
+  })
 
   it('iterate', async () => {
     const { strategy, chain } = nodeTest
@@ -411,7 +411,7 @@ describe('Blockchain', () => {
     await expect(node.chain).toAddBlock(blockA3)
     expect(node.chain.head?.hash).toEqualBuffer(blockA3.header.hash)
     expect(await node.chain.notes.size()).toBe(blockA3.header.noteCommitment.size)
-  }, 60000)
+  })
 
   describe('MerkleTrees', () => {
     it('should add notes and nullifiers to trees', async () => {
@@ -593,7 +593,7 @@ describe('Blockchain', () => {
     await expect(nodeTest.chain.newBlock([], minersFee)).rejects.toThrowError(
       `Miner's fee is incorrect`,
     )
-  }, 60000)
+  })
 
   it('should wait to validate spends', async () => {
     /**
@@ -652,7 +652,7 @@ describe('Blockchain', () => {
 
     // We should have reorged to blockA5
     expect(nodeB.chain.head.hash.equals(blockA5.header.hash)).toBe(true)
-  }, 120000)
+  })
 
   it('should add block to fork with tx expiration', async () => {
     /**

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -31,7 +31,7 @@ describe('Verifier', () => {
       )
 
       expect(result).toEqual({ valid: true })
-    }, 60000)
+    })
 
     it('returns false on miners transactions', async () => {
       const tx = await useMinersTxFixture(nodeTest.accounts)
@@ -45,7 +45,7 @@ describe('Verifier', () => {
         reason: VerificationResultReason.ERROR,
         valid: false,
       })
-    }, 60000)
+    })
   })
 
   describe('Block', () => {
@@ -188,7 +188,7 @@ describe('Verifier', () => {
       const { block } = await useBlockWithTx(nodeTest.node)
       expect((await chain.verifier.verifyConnectedSpends(block)).valid).toBe(true)
       expect(Array.from(block.spends())).toHaveLength(1)
-    }, 60000)
+    })
 
     it('is invalid with DOUBLE_SPEND as the reason', async () => {
       const { chain } = nodeTest
@@ -206,7 +206,7 @@ describe('Verifier', () => {
         valid: false,
         reason: VerificationResultReason.DOUBLE_SPEND,
       })
-    }, 60000)
+    })
 
     it('is invalid with ERROR as the reason', async () => {
       const { block } = await useBlockWithTx(nodeTest.node)
@@ -226,7 +226,7 @@ describe('Verifier', () => {
         valid: false,
         reason: VerificationResultReason.ERROR,
       })
-    }, 60000)
+    })
 
     it('a block that spends a note in a previous block is invalid with INVALID_SPEND as the reason', async () => {
       const { chain } = nodeTest
@@ -251,7 +251,7 @@ describe('Verifier', () => {
         valid: false,
         reason: VerificationResultReason.INVALID_SPEND,
       })
-    }, 60000)
+    })
 
     it('a block that spends a note never in the tree is invalid with INVALID_SPEND as the reason', async () => {
       const { chain } = nodeTest
@@ -266,7 +266,7 @@ describe('Verifier', () => {
         valid: false,
         reason: VerificationResultReason.INVALID_SPEND,
       })
-    }, 60000)
+    })
   })
 
   describe('validAgainstPrevious', () => {
@@ -280,7 +280,7 @@ describe('Verifier', () => {
       ).toMatchObject({
         valid: true,
       })
-    }, 30000)
+    })
 
     it('is invalid when the target is wrong', async () => {
       nodeTest.verifier.enableVerifyTarget = true
@@ -293,7 +293,7 @@ describe('Verifier', () => {
         valid: false,
         reason: VerificationResultReason.INVALID_TARGET,
       })
-    }, 30000)
+    })
 
     it("is invalid when the note commitments aren't the same size", async () => {
       const block = await useMinerBlockFixture(nodeTest.chain)
@@ -305,7 +305,7 @@ describe('Verifier', () => {
         valid: false,
         reason: VerificationResultReason.NOTE_COMMITMENT_SIZE,
       })
-    }, 30000)
+    })
 
     it("is invalid when the nullifier commitments aren't the same size", async () => {
       const block = await useMinerBlockFixture(nodeTest.chain)
@@ -317,7 +317,7 @@ describe('Verifier', () => {
         valid: false,
         reason: VerificationResultReason.NULLIFIER_COMMITMENT_SIZE,
       })
-    }, 30000)
+    })
 
     it('Is invalid when the timestamp is in past', async () => {
       const block = await useMinerBlockFixture(nodeTest.chain)
@@ -329,7 +329,7 @@ describe('Verifier', () => {
         valid: false,
         reason: VerificationResultReason.BLOCK_TOO_OLD,
       })
-    }, 30000)
+    })
 
     it('Is invalid when the sequence is wrong', async () => {
       const block = await useMinerBlockFixture(nodeTest.chain)
@@ -341,7 +341,7 @@ describe('Verifier', () => {
         valid: false,
         reason: VerificationResultReason.SEQUENCE_OUT_OF_ORDER,
       })
-    }, 30000)
+    })
   })
 
   describe('blockMatchesTree', () => {

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -146,5 +146,5 @@ describe('Create genesis block', () => {
     )
     const newBlock = await newChain.newBlock([], newMinersfee)
     expect(newBlock).toBeTruthy()
-  }, 600000)
+  })
 })

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -19,7 +19,7 @@ describe('MemPool', () => {
       memPool.acceptTransaction(transaction)
 
       expect(memPool.size()).toBe(1)
-    }, 60000)
+    })
   })
 
   describe('sizeBytes', () => {
@@ -65,7 +65,7 @@ describe('MemPool', () => {
       memPool.onConnectBlock(block)
 
       expect(memPool.sizeBytes()).toBe(size(transaction2))
-    }, 60000)
+    })
   })
 
   describe('exists', () => {
@@ -121,7 +121,7 @@ describe('MemPool', () => {
 
       const transactions = Array.from(memPool.orderedTransactions())
       expect(transactions).toEqual([transactionB, transactionC, transactionA])
-    }, 60000)
+    })
 
     it('does not return transactions that have been removed from the mempool', async () => {
       const { node } = nodeTest
@@ -146,7 +146,7 @@ describe('MemPool', () => {
 
       const transactions = Array.from(generator)
       expect(transactions).toEqual([])
-    }, 60000)
+    })
   })
 
   describe('acceptTransaction', () => {
@@ -163,7 +163,7 @@ describe('MemPool', () => {
         memPool.acceptTransaction(transaction)
 
         expect(memPool.acceptTransaction(transaction)).toBe(false)
-      }, 60000)
+      })
     })
 
     describe('with an expired sequence', () => {
@@ -202,7 +202,7 @@ describe('MemPool', () => {
         memPool.acceptTransaction(transaction)
 
         expect(memPool.acceptTransaction(transaction2)).toBe(false)
-      }, 60000)
+      })
 
       it('returns true with a higher fee', async () => {
         const { node } = nodeTest
@@ -223,7 +223,7 @@ describe('MemPool', () => {
         memPool.acceptTransaction(transaction)
 
         expect(memPool.acceptTransaction(transaction2)).toBe(true)
-      }, 60000)
+      })
     })
 
     describe('with a new hash', () => {
@@ -237,7 +237,7 @@ describe('MemPool', () => {
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
         expect(memPool.acceptTransaction(transaction)).toBe(true)
-      }, 60000)
+      })
 
       it('sets the transaction hash in the mempool map and priority queue', async () => {
         const { node } = nodeTest
@@ -250,7 +250,7 @@ describe('MemPool', () => {
 
         expect(memPool.exists(transaction.hash())).toBe(true)
         expect([...memPool.orderedTransactions()]).toContainEqual(transaction)
-      }, 60000)
+      })
     })
   })
 
@@ -281,7 +281,7 @@ describe('MemPool', () => {
       expect(memPool.exists(transactionB.hash())).toBe(false)
       expect([...memPool.orderedTransactions()]).not.toContainEqual(transactionA)
       expect([...memPool.orderedTransactions()]).not.toContainEqual(transactionB)
-    }, 60000)
+    })
   })
 
   describe('when a block is disconnected', () => {
@@ -307,6 +307,6 @@ describe('MemPool', () => {
 
       expect(memPool.exists(minersFee.hash())).toBe(false)
       expect([...memPool.orderedTransactions()]).not.toContainEqual(minersFee)
-    }, 60000)
+    })
   })
 })

--- a/ironfish/src/mining/manager.test.slow.ts
+++ b/ironfish/src/mining/manager.test.slow.ts
@@ -33,7 +33,7 @@ describe('Mining manager', () => {
     expect(newBlock.transactions).toHaveLength(1)
     expect(currentBlock).toEqual(block)
     expect(isTransactionMine(newBlock.transactions[0], account)).toBe(true)
-  }, 10000)
+  })
 
   it('adds transactions from the mempool', async () => {
     const { node, chain } = nodeTest
@@ -63,7 +63,7 @@ describe('Mining manager', () => {
     expect(currentBlock).toEqual(previous)
     expect(isTransactionMine(newBlock.transactions[0], account)).toBe(true)
     expect(node.memPool.size()).toBe(1)
-  }, 25000)
+  })
 
   it('should not add transactions to block if they have invalid spends', async () => {
     const { node: nodeA } = await nodeTest.createSetup()
@@ -102,7 +102,7 @@ describe('Mining manager', () => {
       nodeA.chain.head.sequence + 1,
     )
     expect(blockTransactions).toHaveLength(0)
-  }, 15000)
+  })
 
   describe('submit block template', () => {
     it('discards block if chain changed', async () => {

--- a/ironfish/src/mining/manager.test.ts
+++ b/ironfish/src/mining/manager.test.ts
@@ -46,5 +46,5 @@ describe('Mining manager', () => {
     results = (await miningManager.getNewBlockTransactions(chain.head.sequence + 1))
       .blockTransactions
     expect(results).toHaveLength(0)
-  }, 10000)
+  })
 })

--- a/ironfish/src/primitives/block.test.ts
+++ b/ironfish/src/primitives/block.test.ts
@@ -28,7 +28,7 @@ describe('Block', () => {
 
     const notes = Array.from(block.allNotes())
     expect(notes).toHaveLength(3)
-  }, 60000)
+  })
 
   it('serializes and deserializes a block', async () => {
     nodeTest.strategy.disableMiningReward()
@@ -79,18 +79,18 @@ describe('Block', () => {
     block4.transactions.pop()
     block4.transactions.push(tx)
     expect(block1.equals(block4)).toBe(false)
-  }, 60000)
+  })
 
   it('validate get minersFee returns the first transaction in a block', async () => {
     const { block } = await useBlockWithTx(nodeTest.node)
     // Miners Fee should be the first transaction in the block
     expect(block.minersFee).toBe(block.transactions[0])
-  }, 60000)
+  })
 
   it('validate get minersFee when no miners fee', async () => {
     nodeTest.strategy.disableMiningReward()
     const block = await makeBlockAfter(nodeTest.chain, nodeTest.chain.genesis)
 
     expect(() => block.minersFee).toThrowError('Block has no miners fee')
-  }, 60000)
+  })
 })

--- a/ironfish/src/primitives/transaction.test.slow.ts
+++ b/ironfish/src/primitives/transaction.test.slow.ts
@@ -25,7 +25,7 @@ describe('Accounts', () => {
     const hashB = transactionB.unsignedHash()
 
     expect(hashA.equals(hashB)).toBe(false)
-  }, 600000)
+  })
 
   it('check if a transaction is a miners fee', async () => {
     const account = await useAccountFixture(nodeTest.accounts)
@@ -75,5 +75,5 @@ describe('Accounts', () => {
       0,
     )
     expect(transaction.isMinersFee()).toBe(false)
-  }, 600000)
+  })
 })

--- a/ironfish/src/rpc/routes/chain/getBlock.test.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.test.ts
@@ -16,7 +16,7 @@ describe('Route chain.getBlock', () => {
     await expect(routeTest.client.request('chain/getBlock', {}).waitForEnd()).rejects.toThrow(
       'Missing hash or sequence',
     )
-  }, 10000)
+  })
 
   it(`should fail if block can't be found with hash`, async () => {
     const hash = BlockHashSerdeInstance.serialize(Buffer.alloc(32, 'blockhashnotfound'))
@@ -24,13 +24,13 @@ describe('Route chain.getBlock', () => {
     await expect(
       routeTest.client.request('chain/getBlock', { hash }).waitForEnd(),
     ).rejects.toThrow('No block found')
-  }, 10000)
+  })
 
   it(`should fail if block can't be found with sequence`, async () => {
     await expect(
       routeTest.client.request('chain/getBlock', { index: 5 }).waitForEnd(),
     ).rejects.toThrow('No block found')
-  }, 10000)
+  })
 
   it('responds with a block', async () => {
     const chain = routeTest.node.chain
@@ -68,5 +68,5 @@ describe('Route chain.getBlock', () => {
     expect(response.content.blockIdentifier.hash).toEqual(
       block.header.hash.toString('hex').toUpperCase(),
     )
-  }, 10000)
+  })
 })

--- a/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
@@ -25,5 +25,5 @@ describe('Route chain.getChainInfo', () => {
     expect(response.content.currentBlockTimestamp).toEqual(
       Number(routeTest.chain.latest.timestamp),
     )
-  }, 10000)
+  })
 })

--- a/ironfish/src/rpc/routes/faucet/getFunds.test.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.test.ts
@@ -17,7 +17,7 @@ describe('Route faucet.getFunds', () => {
           .request('faucet/getFunds', { accountName: 'test-notfound' })
           .waitForEnd(),
       ).rejects.toThrow('Account test-notfound could not be found')
-    }, 10000)
+    })
   })
 
   describe('With a default account and the db', () => {
@@ -57,7 +57,7 @@ describe('Route faucet.getFunds', () => {
           },
           expect.anything(),
         )
-      }, 10000)
+      })
     })
 
     describe('when too many faucet requests have been made', () => {
@@ -85,7 +85,7 @@ describe('Route faucet.getFunds', () => {
         await expect(
           routeTest.client.request('faucet/getFunds', { accountName, email }).waitForEnd(),
         ).rejects.toThrow('API failure')
-      }, 10000)
+      })
     })
   })
 })

--- a/ironfish/src/rpc/routes/mining/blockTemplateStream.test.slow.ts
+++ b/ironfish/src/rpc/routes/mining/blockTemplateStream.test.slow.ts
@@ -34,7 +34,7 @@ describe('Block template stream', () => {
     response.end()
 
     expect(createNewBlockTemplateSpy).toBeCalledTimes(1)
-  }, 10000)
+  })
 
   it('does not crash on expired transactions if the chain head changes rapidly', async () => {
     const node = routeTest.node
@@ -106,5 +106,5 @@ describe('Block template stream', () => {
 
     // newBlock should have thrown an error, but the response should not have crashed
     await expect(newBlockSpy.mock.results[2].value).rejects.toThrowError('Transaction expired')
-  }, 30000)
+  })
 })

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -118,7 +118,7 @@ describe('Transactions sendTransaction', () => {
 
     const result = await routeTest.client.sendTransaction(TEST_PARAMS)
     expect(result.content.hash).toEqual(tx.unsignedHash().toString('hex'))
-  }, 30000)
+  })
 
   it('calls the pay method on the node with multiple recipient', async () => {
     routeTest.node.peerNetwork['_isReady'] = true
@@ -135,7 +135,7 @@ describe('Transactions sendTransaction', () => {
 
     const result = await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
     expect(result.content.hash).toEqual(tx.unsignedHash().toString('hex'))
-  }, 30000)
+  })
 
   it('lets you configure the expiration', async () => {
     const account = await useAccountFixture(routeTest.node.accounts, 'expiration')
@@ -176,5 +176,5 @@ describe('Transactions sendTransaction', () => {
       12345,
       1234,
     )
-  }, 30000)
+  })
 })

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -164,7 +164,7 @@ describe('Demonstrate the Sapling API', () => {
       expect(minersFee['transactionPosted']).toBeNull()
       expect(await workerPool.verify(minersFee, { verifyFees: false })).toEqual({ valid: true })
       expect(minersFee['transactionPosted']).toBeNull()
-    }, 60000)
+    })
 
     it('Holds a posted transaction if a reference is taken', async () => {
       // Generate a miner's fee transaction
@@ -183,7 +183,7 @@ describe('Demonstrate the Sapling API', () => {
       })
 
       expect(minersFee['transactionPosted']).toBeNull()
-    }, 60000)
+    })
 
     it('Does not hold a note if no references are taken', async () => {
       // Generate a miner's fee transaction
@@ -215,7 +215,7 @@ describe('Demonstrate the Sapling API', () => {
       expect(decryptedNote['note']).toBeNull()
       expect(decryptedNote.value()).toBe(BigInt(2000000000))
       expect(decryptedNote['note']).toBeNull()
-    }, 60000)
+    })
   })
 
   describe('Finding notes to spend', () => {

--- a/ironfish/src/syncer.test.ts
+++ b/ironfish/src/syncer.test.ts
@@ -45,7 +45,7 @@ describe('Syncer', () => {
     // Peer should have more work than us now
     syncer.findPeer()
     expect(startSyncSpy).toHaveBeenCalledWith(peer)
-  }, 10000)
+  })
 
   it('should sync and then finish from peer', async () => {
     const { peerNetwork, syncer } = nodeTest

--- a/ironfish/src/workerPool/job.test.slow.ts
+++ b/ironfish/src/workerPool/job.test.slow.ts
@@ -20,7 +20,7 @@ describe('Worker Pool', () => {
     expect(minersFee.serialize()).toBeInstanceOf(Buffer)
 
     expect(workerPool.completed).toBe(1)
-  }, 60000)
+  })
 
   it('verify', async () => {
     const { workerPool } = nodeTest
@@ -36,5 +36,5 @@ describe('Worker Pool', () => {
 
     expect(result.valid).toBe(true)
     expect(workerPool.completed).toBe(1)
-  }, 60000)
+  })
 })

--- a/ironfish/src/workerPool/pool.test.ts
+++ b/ironfish/src/workerPool/pool.test.ts
@@ -52,7 +52,7 @@ describe('Worker Pool', () => {
     expect(pool.workers.length).toBe(1)
     await pool.sleep().result()
     expect(pool.workers.length).toBe(1)
-  }, 10000)
+  })
 
   it('aborts job in worker', async () => {
     pool = new WorkerPool({ numWorkers: 1 })
@@ -77,7 +77,7 @@ describe('Worker Pool', () => {
     expect(pool.workers.length).toBe(1)
     expect(pool.executing).toBe(0)
     expect(pool.queued).toBe(0)
-  }, 10000)
+  })
 
   it('counts queue size', async () => {
     pool = new WorkerPool()
@@ -107,7 +107,7 @@ describe('Worker Pool', () => {
     expect(pool.completed).toBe(2)
     expect(job1.status).toBe('aborted')
     expect(job2.status).toBe('aborted')
-  }, 10000)
+  })
 
   it('handles job error', async () => {
     pool = new WorkerPool({ numWorkers: 1 })
@@ -136,7 +136,7 @@ describe('Worker Pool', () => {
     expect(pool.queued).toBe(0)
     expect(pool.completed).toBe(2)
     expect(job.status).toBe('success')
-  }, 10000)
+  })
 
   it('should queue up job', () => {
     pool = new WorkerPool({ numWorkers: 1, maxJobs: 0 })
@@ -150,5 +150,5 @@ describe('Worker Pool', () => {
     expect(pool.workers.length).toBe(1)
     expect(pool.queued).toBe(1)
     expect(pool.completed).toBe(0)
-  }, 10000)
+  })
 })


### PR DESCRIPTION
## Summary
Fix for https://github.com/iron-fish/ironfish/issues/1968

using these default timeouts
`test` -> 5s (default)
`test:slow` -> 60s
`test:perf` -> 60s

deleting all unnecessary hardcoded timeout values

## Testing Plan
- run yarn test, yarn test:slow, yarn test:pref in `/ironfish`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
