### PR TITLE
Fix unsubscribing from the incorrect event

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -151,13 +151,13 @@ export default class Download extends IronfishCommand {
       await new Promise<void>((resolve, reject) => {
         const onWriterError = (e: unknown) => {
           writer.removeListener('close', onWriterClose)
-          writer.removeListener('onWriterError', onWriterError)
+          writer.removeListener('error', onWriterError)
           reject(e)
         }
 
         const onWriterClose = () => {
           writer.removeListener('close', onWriterClose)
-          writer.removeListener('onWriterError', onWriterError)
+          writer.removeListener('error', onWriterError)
           resolve()
         }
 


### PR DESCRIPTION
## Summary
This was a simple copy paste error that is being fixed. It should be _ok_ without this, but this properly cleans up the event.

## Testing Plan
Run `ironfish chain:download`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
