### PR TITLE
add telemetry for transaction creation

### DIFF
--- a/ironfish/src/account/accounts.ts
+++ b/ironfish/src/account/accounts.ts
@@ -41,6 +41,7 @@ export class Accounts {
   readonly onAccountImported = new Event<[account: Account]>()
   readonly onAccountRemoved = new Event<[account: Account]>()
   readonly onBroadcastTransaction = new Event<[transaction: Transaction]>()
+  readonly onTransactionCreated = new Event<[transaction: Transaction]>()
 
   scan: ScanState | null = null
   updateHeadState: ScanState | null = null
@@ -841,6 +842,7 @@ export class Accounts {
     await this.syncTransaction(transaction, { submittedSequence: heaviestHead.sequence })
     await memPool.acceptTransaction(transaction)
     this.broadcastTransaction(transaction)
+    this.onTransactionCreated.emit(transaction)
 
     return transaction
   }

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -138,6 +138,10 @@ export class IronfishNode {
       ],
     })
 
+    this.accounts.onTransactionCreated.on((transaction) => {
+      this.telemetry.submitNewTransactionCreated(transaction, new Date())
+    })
+
     this.miningManager.onNewBlock.on((block) => {
       this.telemetry.submitBlockMined(block)
     })

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -354,6 +354,37 @@ export class Telemetry {
     })
   }
 
+  submitNewTransactionCreated(transaction: Transaction, seenAt: Date): void {
+    const hash = transaction.hash()
+
+    if (!this.shouldSubmitTransaction(hash)) {
+      return
+    }
+
+    this.submit({
+      measurement: 'transaction_created',
+      timestamp: seenAt,
+      tags: [
+        {
+          name: 'hash',
+          value: hash.toString('hex'),
+        },
+      ],
+      fields: [
+        {
+          name: 'notes',
+          type: 'integer',
+          value: transaction.notesLength(),
+        },
+        {
+          name: 'spends',
+          type: 'integer',
+          value: transaction.spendsLength(),
+        },
+      ],
+    })
+  }
+
   submitNewTransactionSeen(transaction: Transaction, seenAt: Date): void {
     const hash = transaction.hash()
 

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -401,18 +401,7 @@ export class Telemetry {
           value: hash.toString('hex'),
         },
       ],
-      fields: [
-        {
-          name: 'notes',
-          type: 'integer',
-          value: transaction.notesLength(),
-        },
-        {
-          name: 'spends',
-          type: 'integer',
-          value: transaction.spendsLength(),
-        },
-      ],
+      fields: [],
     })
   }
 


### PR DESCRIPTION
## Summary
In order to track transaction propagation we want to know when the transaction was created. Right now we log transaction propagation but not transaction creation. This means that in a certain timeframe (3hr) our best estimate for when to start looking at propagation time is the first event we see for each transaction. This is not always accurate and we could be starting in the middle of the timeframe for some transactions. Knowing when the transaction was actually first created would be useful for these queries.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
