### PR TITLE
Fix a bug where tests were timing out

### DIFF
--- a/config/jest.config.base.js
+++ b/config/jest.config.base.js
@@ -6,4 +6,9 @@ module.exports = {
   coverageProvider: "v8",
   coverageReporters: ["text-summary", "json", "clover", "text"],
   testPathIgnorePatterns: ['.*\\.test\\.slow\\.ts$', '.*\\.test\\.perf\\.ts$'],
+
+  // set timeout to a higher value than the default (5000), in order to avoid 
+  // timing out when running tests. 32 seconds should suffice for the existing
+  // tests.
+  testTimeout: 32000
 };


### PR DESCRIPTION
## Summary
The default timeout value of jest is set to only 5 seconds. This period seems insufficient for some tests that apparently take
longer to execute. This PR changes the timeout to 32 seconds, which should suffice for the current tests. An improvement would be to make this value get set dynamically according to the specs of the computer running the tests.

This is a continuation of a previous PR: https://github.com/iron-fish/ironfish/pull/1895 . For some reason I could not reopen it. Come back here after having a look at that. 

So turns out that the way I solved it is really the recommended way of solving such issues:

![IMG-20220808-WA0015](https://user-images.githubusercontent.com/92462002/183532311-2d59ccae-1827-4b8f-8f66-184aff09c311.jpg)
This is from the official documentation of "jest" (the framework used to write unit-tests)
Here is the documentation, if you'd like to have a look at it:
https://jest-bot.github.io/jest/docs/troubleshooting.html

Let me know if this solves the issue. If not, i'll try to work on another way

## Testing Plan
Tested successfully

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
graffiti: ironfishup