### PR TITLE
Allow submitting telemetry without fields

### DIFF
--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -228,16 +228,16 @@ export class Telemetry {
       return
     }
 
-    if (metric.fields.length === 0) {
-      throw new Error('Cannot submit metrics without fields')
-    }
-
     let tags = this.defaultTags
     if (metric.tags) {
       tags = tags.concat(metric.tags)
     }
 
     const fields = this.defaultFields.concat(metric.fields)
+
+    if (fields.length === 0) {
+      throw new Error('Cannot submit metrics without fields')
+    }
 
     // TODO(jason): RollingAverage can produce a negative number which seems
     // like it should be a bug. Investigate then delete this TODO. Negative


### PR DESCRIPTION
## Summary
There was a bug introduced in https://github.com/iron-fish/ironfish/pull/1981. When trying to submit without fields we throw an error. However we should check to see if fields are empty after we have concatenated default fields.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
