### PR TITLE
Add the ability to exclude the chain DB in backup

### DIFF
--- a/ironfish-cli/src/utils/tar.ts
+++ b/ironfish-cli/src/utils/tar.ts
@@ -9,7 +9,7 @@ import tar from 'tar'
 async function zipDir(source: string, dest: string, excludes: string[] = []): Promise<void> {
   const sourceDir = path.dirname(source)
   const sourceFile = path.basename(source)
-  const excludeSet = new Set(excludes)
+  const patterns = excludes.map((e) => new RegExp(e))
 
   await tar.create(
     {
@@ -17,7 +17,7 @@ async function zipDir(source: string, dest: string, excludes: string[] = []): Pr
       file: dest,
       C: sourceDir,
       filter: function (path) {
-        if (excludeSet.has(path)) {
+        if (patterns.find((p) => p.test(path))) {
           return false
         } else {
           return true


### PR DESCRIPTION
## Summary

This let's you only upload accounts if you want. This also fixes matching the excludes as patterns which is how the built in CLI excludes works.

## Testing Plan

Run `ironfish backup --no-mined --no-chain --acounts`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
