### PR TITLE
loads chain database as part of wallet 2.0 migration

### DIFF
--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -123,6 +123,7 @@ export class Migration013 extends Migration {
     await stores.old.noteToNullifier.clear(tx)
     logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
 
+    await chainDb.close()
     logger.debug(BenchUtils.renderSegment(BenchUtils.endSegment(startTotal)))
   }
 

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -24,8 +24,7 @@ type Stores = {
 export class Migration013 extends Migration {
   path = __filename
 
-  async prepare(node: IronfishNode): Promise<IDatabase> {
-    await node.files.mkdir(node.accounts.db.location, { recursive: true })
+  prepare(node: IronfishNode): IDatabase {
     return createDB({ location: node.accounts.db.location })
   }
 
@@ -37,8 +36,11 @@ export class Migration013 extends Migration {
   ): Promise<void> {
     const startTotal = BenchUtils.startSegment()
 
+    const chainDb = createDB({ location: node.config.chainDatabasePath })
+    await chainDb.open()
+
     const stores: Stores = {
-      old: loadOldStores(db),
+      old: loadOldStores(db, chainDb),
       new: loadNewStores(db),
     }
 

--- a/ironfish/src/migrations/data/013-wallet-2/old/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/old/stores.ts
@@ -24,7 +24,7 @@ export type OldStores = {
   headers: HeadersStore
 }
 
-export function loadOldStores(db: IDatabase): OldStores {
+export function loadOldStores(db: IDatabase, chainDb: IDatabase): OldStores {
   const meta: MetaStore = db.addStore(
     {
       name: 'meta',
@@ -70,11 +70,14 @@ export function loadOldStores(db: IDatabase): OldStores {
     false,
   )
 
-  const headers: HeadersStore = db.addStore({
-    name: 'bh',
-    keyEncoding: BUFFER_ENCODING,
-    valueEncoding: new HeaderEncoding(),
-  })
+  const headers: HeadersStore = chainDb.addStore(
+    {
+      name: 'bh',
+      keyEncoding: BUFFER_ENCODING,
+      valueEncoding: new HeaderEncoding(),
+    },
+    false,
+  )
 
   return { meta, accounts, noteToNullifier, nullifierToNote, transactions, headers }
 }


### PR DESCRIPTION
## Summary

migration relies on block headers to set sequences in transactions during
migration. headers are present in chain database, so we need to load the chain
database as part of the accounts migration.

- creates and opens chain db at start of wallet migration
- adds old headers store to chain db instead of accounts db

## Testing Plan

- ran migration locally and verified that no transactions were dropped following changes

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
