### PR TITLE
Fix accounts:transactions to show expiration by default

### DIFF
--- a/ironfish-cli/src/commands/accounts/transactions.ts
+++ b/ironfish-cli/src/commands/accounts/transactions.ts
@@ -129,7 +129,6 @@ export class TransactionsCommand extends IronfishCommand {
         },
         expiration: {
           header: 'Expiration',
-          extended: true,
         },
       },
       {


### PR DESCRIPTION
## Summary
The expiration was set to extended which requires the accounts:transactions 
command to be flaged with -x to show expiration sequence.

Fixes: https://github.com/iron-fish/ironfish/issues/1997

## Testing Plan
Tested successfully

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
graffiti: ironfishup