### PR TITLE
Remove short-hand `-d` for `--dry` since it is already in use by the database flag

### DIFF
--- a/ironfish-cli/src/commands/chain/prune.ts
+++ b/ironfish-cli/src/commands/chain/prune.ts
@@ -14,7 +14,6 @@ export default class Prune extends IronfishCommand {
   static flags = {
     ...LocalFlags,
     dry: Flags.boolean({
-      char: 'd',
       default: false,
       description: 'Dry run prune first',
     }),

--- a/ironfish-cli/src/commands/migrations/start.ts
+++ b/ironfish-cli/src/commands/migrations/start.ts
@@ -13,7 +13,8 @@ export class StartCommand extends IronfishCommand {
     [ConfigFlagKey]: ConfigFlag,
     [DataDirFlagKey]: DataDirFlag,
     dry: Flags.boolean({
-      char: 'd',
+      default: false,
+      description: 'Dry run migrations first',
     }),
     quiet: Flags.boolean({
       char: 'q',


### PR DESCRIPTION
## Summary

https://github.com/iron-fish/ironfish/blob/master/ironfish-cli/src/flags.ts#L50

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
