### PR TITLE
updates wallet.getNotes to read from account's decryptedNotes

### DIFF
--- a/ironfish-cli/src/commands/accounts/notes.test.ts
+++ b/ironfish-cli/src/commands/accounts/notes.test.ts
@@ -11,7 +11,7 @@ describe('accounts:notes', () => {
       {
         amount: 1,
         memo: 'foo',
-        noteTxHash: '1fa5f38c446e52f8842d8c861507744fc3f354992610e1661e033ef316e2d3d1',
+        transactionHash: '1fa5f38c446e52f8842d8c861507744fc3f354992610e1661e033ef316e2d3d1',
         spent: true,
       },
     ],
@@ -53,7 +53,7 @@ describe('accounts:notes', () => {
         expectCli(ctx.stdout).include(responseContent.notes[0].spent ? `✔` : `x`)
         expectCli(ctx.stdout).include(responseContent.notes[0].amount)
         expectCli(ctx.stdout).include(responseContent.notes[0].memo)
-        expectCli(ctx.stdout).include(responseContent.notes[0].noteTxHash)
+        expectCli(ctx.stdout).include(responseContent.notes[0].transactionHash)
       })
   })
 })

--- a/ironfish-cli/src/commands/accounts/notes.test.ts
+++ b/ironfish-cli/src/commands/accounts/notes.test.ts
@@ -9,10 +9,10 @@ describe('accounts:notes', () => {
     account: 'default',
     notes: [
       {
-        spender: true,
         amount: 1,
         memo: 'foo',
         noteTxHash: '1fa5f38c446e52f8842d8c861507744fc3f354992610e1661e033ef316e2d3d1',
+        spent: true,
       },
     ],
   }
@@ -50,7 +50,7 @@ describe('accounts:notes', () => {
       .exit(0)
       .it('logs the notes for the given account', (ctx) => {
         expectCli(ctx.stdout).include(responseContent.account)
-        expectCli(ctx.stdout).include(responseContent.notes[0].spender ? `✔` : `x`)
+        expectCli(ctx.stdout).include(responseContent.notes[0].spent ? `✔` : `x`)
         expectCli(ctx.stdout).include(responseContent.notes[0].amount)
         expectCli(ctx.stdout).include(responseContent.notes[0].memo)
         expectCli(ctx.stdout).include(responseContent.notes[0].noteTxHash)

--- a/ironfish-cli/src/commands/accounts/notes.ts
+++ b/ironfish-cli/src/commands/accounts/notes.ts
@@ -46,7 +46,7 @@ export class NotesCommand extends IronfishCommand {
       memo: {
         header: 'Memo',
       },
-      noteTxHash: {
+      transactionHash: {
         header: 'From Transaction',
       },
     })

--- a/ironfish-cli/src/commands/accounts/notes.ts
+++ b/ironfish-cli/src/commands/accounts/notes.ts
@@ -35,9 +35,9 @@ export class NotesCommand extends IronfishCommand {
     this.log(`\n ${accountResponse} - Account notes\n`)
 
     CliUx.ux.table(notes, {
-      isSpender: {
-        header: 'Spender',
-        get: (row) => (row.spender ? `✔` : `x`),
+      isSpent: {
+        header: 'Spent',
+        get: (row) => (row.spent ? `✔` : `x`),
       },
       amount: {
         header: 'Amount ($IRON)',

--- a/ironfish/src/rpc/routes/accounts/getNotes.ts
+++ b/ironfish/src/rpc/routes/accounts/getNotes.ts
@@ -10,10 +10,10 @@ export type GetAccountNotesRequest = { account?: string }
 export type GetAccountNotesResponse = {
   account: string
   notes: {
-    spender: boolean
     amount: number
     memo: string
     noteTxHash: string
+    spent: boolean
   }[]
 }
 
@@ -30,10 +30,10 @@ export const GetAccountNotesResponseSchema: yup.ObjectSchema<GetAccountNotesResp
       .array(
         yup
           .object({
-            spender: yup.boolean().defined(),
             amount: yup.number().defined(),
             memo: yup.string().trim().defined(),
             noteTxHash: yup.string().defined(),
+            spent: yup.boolean().defined(),
           })
           .defined(),
       )
@@ -46,7 +46,7 @@ router.register<typeof GetAccountNotesRequestSchema, GetAccountNotesResponse>(
   GetAccountNotesRequestSchema,
   (request, node): void => {
     const account = getAccount(node, request.data.account)
-    const { notes } = node.accounts.getNotes(account)
+    const notes = account.getNotes()
     request.end({ account: account.displayName, notes })
   },
 )

--- a/ironfish/src/rpc/routes/accounts/getNotes.ts
+++ b/ironfish/src/rpc/routes/accounts/getNotes.ts
@@ -12,7 +12,7 @@ export type GetAccountNotesResponse = {
   notes: {
     amount: number
     memo: string
-    noteTxHash: string
+    transactionHash: string
     spent: boolean
   }[]
 }
@@ -32,7 +32,7 @@ export const GetAccountNotesResponseSchema: yup.ObjectSchema<GetAccountNotesResp
           .object({
             amount: yup.number().defined(),
             memo: yup.string().trim().defined(),
-            noteTxHash: yup.string().defined(),
+            transactionHash: yup.string().defined(),
             spent: yup.boolean().defined(),
           })
           .defined(),
@@ -53,7 +53,7 @@ router.register<typeof GetAccountNotesRequestSchema, GetAccountNotesResponse>(
       responseNotes.push({
         amount: Number(note.note.value()),
         memo: note.note.memo().replace(/\x00/g, ''),
-        noteTxHash: note.transactionHash.toString('hex'),
+        transactionHash: note.transactionHash.toString('hex'),
         spent: note.spent,
       })
     }

--- a/ironfish/src/rpc/routes/accounts/getNotes.ts
+++ b/ironfish/src/rpc/routes/accounts/getNotes.ts
@@ -47,6 +47,17 @@ router.register<typeof GetAccountNotesRequestSchema, GetAccountNotesResponse>(
   (request, node): void => {
     const account = getAccount(node, request.data.account)
     const notes = account.getNotes()
-    request.end({ account: account.displayName, notes })
+    const responseNotes = []
+
+    for (const note of notes) {
+      responseNotes.push({
+        amount: Number(note.note.value()),
+        memo: note.note.memo().replace(/\x00/g, ''),
+        noteTxHash: note.transactionHash.toString('hex'),
+        spent: note.spent,
+      })
+    }
+
+    request.end({ account: account.displayName, notes: responseNotes })
   },
 )

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BufferMap } from 'buffer-map'
-import { de } from 'date-fns/locale'
 import MurmurHash3 from 'imurmurhash'
 import { Assert } from '../assert'
 import { Transaction } from '../primitives'

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BufferMap } from 'buffer-map'
+import { de } from 'date-fns/locale'
 import MurmurHash3 from 'imurmurhash'
 import { Assert } from '../assert'
 import { Transaction } from '../primitives'
@@ -129,6 +130,27 @@ export class Account {
     this.nullifierToNoteHash.clear()
     this.transactions.clear()
     await this.saveUnconfirmedBalance(BigInt(0))
+  }
+
+  getNotes(): {
+    amount: number
+    memo: string
+    noteTxHash: string
+    spent: boolean
+  }[] {
+    const notes = []
+
+    for (const decryptedNote of this.decryptedNotes.values()) {
+      const note = new Note(decryptedNote.serializedNote)
+      notes.push({
+        amount: Number(note.value()),
+        memo: note.memo().replace(/\x00/g, ''),
+        noteTxHash: decryptedNote.transactionHash.toString('hex'),
+        spent: decryptedNote.spent,
+      })
+    }
+
+    return notes
   }
 
   getUnspentNotes(): ReadonlyArray<{

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -582,49 +582,6 @@ export class Accounts {
     this.scan = null
   }
 
-  getNotes(account: Account): {
-    notes: {
-      spender: boolean
-      amount: number
-      memo: string
-      noteTxHash: string
-    }[]
-  } {
-    this.assertHasAccount(account)
-
-    const notes = []
-
-    for (const { transaction } of account.getTransactions()) {
-      for (const note of transaction.notes()) {
-        let decryptedNote
-        let spender = false
-
-        // Try loading the decrypted note from the account
-        const storedDecryptedNote = account.getDecryptedNote(note.merkleHash().toString('hex'))
-        if (storedDecryptedNote) {
-          decryptedNote = new Note(storedDecryptedNote.serializedNote)
-        }
-
-        if (!decryptedNote) {
-          // Try decrypting the note as the spender
-          decryptedNote = note.decryptNoteForSpender(account.outgoingViewKey)
-          spender = true
-        }
-
-        if (decryptedNote && decryptedNote.value() !== BigInt(0)) {
-          notes.push({
-            spender,
-            amount: Number(decryptedNote.value()),
-            memo: decryptedNote.memo().replace(/\x00/g, ''),
-            noteTxHash: transaction.unsignedHash().toString('hex'),
-          })
-        }
-      }
-    }
-
-    return { notes }
-  }
-
   async getBalance(account: Account): Promise<{ unconfirmed: BigInt; confirmed: BigInt }> {
     this.assertHasAccount(account)
     const headHash = await account.getHeadHash()

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -596,9 +596,14 @@ export class Accounts {
 
     for (const { transaction } of account.getTransactions()) {
       for (const note of transaction.notes()) {
-        // Try decrypting the note as the owner
-        let decryptedNote = note.decryptNoteForOwner(account.incomingViewKey)
+        let decryptedNote
         let spender = false
+
+        // Try loading the decrypted note from the account
+        const storedDecryptedNote = account.getDecryptedNote(note.merkleHash().toString('hex'))
+        if (storedDecryptedNote) {
+          decryptedNote = new Note(storedDecryptedNote.serializedNote)
+        }
 
         if (!decryptedNote) {
           // Try decrypting the note as the spender


### PR DESCRIPTION
## Summary

each account stores decrypted notes that it owns. leveraging this store saves
some decryption time when collecting notes for the 'accounts:notes' command.
it's still necessary to iterate over transactions to decrypt notes where the
account is the spender since these are not stored on the account.

## Testing Plan

- run `accounts:notes > old.txt`
- make/checkout changes
- run `accounts:notes > new.txt`
- compare output with `diff old.txt new.txt`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
