### PR TITLE
fix docker build script

### DIFF
--- a/ironfish-cli/scripts/build.sh
+++ b/ironfish-cli/scripts/build.sh
@@ -62,7 +62,7 @@ echo "Copying node_modules"
 rsync -L -avrq --exclude 'ironfish' --exclude 'fsevents' ../../../node_modules ./
 # Copy node_modules from ironfish-cli folder into the production node_modules folder
 # yarn --production seems to split some packages into different folders for some reason
-cp -R ../../node_modules/* ./node_modules
+rsync -L -avrq --ignore-missing-args ../../node_modules/* ./node_modules
 
 echo ""
 if ! ./bin/run --version > /dev/null; then


### PR DESCRIPTION
## Summary
We previously had some `node_mode` being downloaded to the `ironfish-cli/node_modules` folder (`tweetnacl`). When this dependency was removed in https://github.com/iron-fish/ironfish/pull/1872 `ironfish-cli/node_modules` was empty. This caused the copy command to fail because the folder was empty. Changing the copy command to be resilient to the folder being empty 

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
