### PR TITLE
Call build at top level when invoking the app

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -43,7 +43,7 @@
     "lint": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/",
     "lint:fix": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
     "start:dev": "node start",
-    "start": "yarn build && yarn start:js",
+    "start": "yarn --cwd ../ build && yarn start:js",
     "start:js": "cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc bin/run",
     "test": "yarn clean && tsc -b && tsc -b tsconfig.test.json && jest",
     "test:coverage:html": "tsc -b tsconfig.test.json && jest --coverage --coverage-reporters html --testPathIgnorePatterns",


### PR DESCRIPTION
## Summary

We often run into issues where trying to (re-)start the app doesn't re-build all of the apps. Triggering the top level workspace build, we invoke build on all of the apps as expected. This will fix the issues with, example, rust changes not getting picked up when trying to start the app

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
