### PR TITLE
Nullifier to note to buffer

### DIFF
--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -187,8 +187,9 @@ export class Migration013 extends Migration {
   ): Promise<void> {
     let count = 0
 
-    for await (const [nullifierHex, noteHash] of nullifierToNoteOld.getAllIter(tx)) {
+    for await (const [nullifierHex, noteHashHex] of nullifierToNoteOld.getAllIter(tx)) {
       const nullifier = Buffer.from(nullifierHex)
+      const noteHash = Buffer.from(noteHashHex)
       await nullifierToNoteHashNew.put(nullifier, noteHash, tx)
       count++
     }

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -188,8 +188,8 @@ export class Migration013 extends Migration {
     let count = 0
 
     for await (const [nullifierHex, noteHashHex] of nullifierToNoteOld.getAllIter(tx)) {
-      const nullifier = Buffer.from(nullifierHex)
-      const noteHash = Buffer.from(noteHashHex)
+      const nullifier = Buffer.from(nullifierHex, 'hex')
+      const noteHash = Buffer.from(noteHashHex, 'hex')
       await nullifierToNoteHashNew.put(nullifier, noteHash, tx)
       count++
     }

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -187,7 +187,8 @@ export class Migration013 extends Migration {
   ): Promise<void> {
     let count = 0
 
-    for await (const [nullifier, noteHash] of nullifierToNoteOld.getAllIter(tx)) {
+    for await (const [nullifierHex, noteHash] of nullifierToNoteOld.getAllIter(tx)) {
+      const nullifier = Buffer.from(nullifierHex)
       await nullifierToNoteHashNew.put(nullifier, noteHash, tx)
       count++
     }

--- a/ironfish/src/migrations/data/013-wallet-2/new/nullifierToNoteHash.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/nullifierToNoteHash.ts
@@ -4,4 +4,4 @@
 
 import { IDatabaseStore } from '../../../../storage'
 
-export type NullifierToNoteHashStore = IDatabaseStore<{ key: string; value: string }>
+export type NullifierToNoteHashStore = IDatabaseStore<{ key: Buffer; value: string }>

--- a/ironfish/src/migrations/data/013-wallet-2/new/nullifierToNoteHash.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/nullifierToNoteHash.ts
@@ -4,4 +4,4 @@
 
 import { IDatabaseStore } from '../../../../storage'
 
-export type NullifierToNoteHashStore = IDatabaseStore<{ key: Buffer; value: string }>
+export type NullifierToNoteHashStore = IDatabaseStore<{ key: Buffer; value: Buffer }>

--- a/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
@@ -79,7 +79,7 @@ export function loadNewStores(db: IDatabase): NewStores {
     {
       name: 'nullifierToNoteHash',
       keyEncoding: new BufferEncoding(),
-      valueEncoding: new StringEncoding(),
+      valueEncoding: new BufferEncoding(),
     },
     false,
   )

--- a/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
@@ -4,6 +4,7 @@
 
 import {
   BigIntLEEncoding,
+  BufferEncoding,
   BUFFER_ENCODING,
   IDatabase,
   NullableStringEncoding,
@@ -77,7 +78,7 @@ export function loadNewStores(db: IDatabase): NewStores {
   const nullifierToNoteHash: NullifierToNoteHashStore = db.addStore(
     {
       name: 'nullifierToNoteHash',
-      keyEncoding: new StringHashEncoding(),
+      keyEncoding: new BufferEncoding(),
       valueEncoding: new StringEncoding(),
     },
     false,

--- a/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
@@ -4,8 +4,8 @@
 
 import {
   BigIntLEEncoding,
-  BufferEncoding,
   BUFFER_ENCODING,
+  BufferEncoding,
   IDatabase,
   NullableStringEncoding,
   StringEncoding,

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -17,7 +17,7 @@ export const ACCOUNT_KEY_LENGTH = 32
 export class Account {
   private readonly accountsDb: AccountsDB
   private readonly decryptedNotes: Map<string, DecryptedNoteValue>
-  private readonly nullifierToNoteHash: BufferMap<string>
+  private readonly nullifierToNoteHash: BufferMap<Buffer>
   private readonly transactions: BufferMap<
     Readonly<{
       transaction: Transaction
@@ -72,7 +72,7 @@ export class Account {
 
     this.accountsDb = accountsDb
     this.decryptedNotes = new Map<string, DecryptedNoteValue>()
-    this.nullifierToNoteHash = new BufferMap<string>()
+    this.nullifierToNoteHash = new BufferMap<Buffer>()
     this.transactions = new BufferMap<{
       transaction: Transaction
       blockHash: string | null
@@ -273,7 +273,7 @@ export class Account {
         if (decryptedNote.nullifier !== null) {
           await this.updateNullifierNoteHash(
             Buffer.from(decryptedNote.nullifier, 'hex'),
-            decryptedNote.merkleHash,
+            Buffer.from(decryptedNote.merkleHash, 'hex'),
             tx,
           )
         }
@@ -303,14 +303,14 @@ export class Account {
       const noteHash = this.getNoteHash(spend.nullifier)
 
       if (noteHash) {
-        const decryptedNote = this.getDecryptedNote(noteHash)
+        const decryptedNote = this.getDecryptedNote(noteHash.toString('hex'))
         Assert.isNotUndefined(
           decryptedNote,
           'nullifierToNote mappings must have a corresponding decryptedNote',
         )
 
         await this.updateDecryptedNote(
-          noteHash,
+          noteHash.toString('hex'),
           {
             ...decryptedNote,
             spent: !isRemovingTransaction,
@@ -354,13 +354,13 @@ export class Account {
     await this.accountsDb.deleteDecryptedNote(noteHash, tx)
   }
 
-  getNoteHash(nullifier: Buffer): string | undefined {
+  getNoteHash(nullifier: Buffer): Buffer | undefined {
     return this.nullifierToNoteHash.get(nullifier)
   }
 
   async updateNullifierNoteHash(
     nullifier: Buffer,
-    noteHash: string,
+    noteHash: Buffer,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     this.nullifierToNoteHash.set(nullifier, noteHash)
@@ -460,14 +460,14 @@ export class Account {
       const noteHash = this.getNoteHash(spend.nullifier)
 
       if (noteHash) {
-        const decryptedNote = this.getDecryptedNote(noteHash)
+        const decryptedNote = this.getDecryptedNote(noteHash.toString('hex'))
         Assert.isNotUndefined(
           decryptedNote,
           'nullifierToNote mappings must have a corresponding decryptedNote',
         )
 
         await this.updateDecryptedNote(
-          noteHash,
+          noteHash.toString('hex'),
           {
             ...decryptedNote,
             spent: false,

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -8,8 +8,8 @@ import { FileSystem } from '../../fileSystems'
 import { Transaction } from '../../primitives/transaction'
 import {
   BigIntLEEncoding,
-  BufferEncoding,
   BUFFER_ENCODING,
+  BufferEncoding,
   IDatabase,
   IDatabaseStore,
   IDatabaseTransaction,

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -8,7 +8,6 @@ import { FileSystem } from '../../fileSystems'
 import { Transaction } from '../../primitives/transaction'
 import {
   BigIntLEEncoding,
-  BUFFER_ENCODING,
   BufferEncoding,
   IDatabase,
   IDatabaseStore,
@@ -130,7 +129,7 @@ export class AccountsDB {
       value: TransactionValue
     }>({
       name: 'transactions',
-      keyEncoding: BUFFER_ENCODING,
+      keyEncoding: new BufferEncoding(),
       valueEncoding: new TransactionValueEncoding(),
     })
   }

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -59,7 +59,7 @@ export class AccountsDB {
     value: DecryptedNoteValue
   }>
 
-  nullifierToNoteHash: IDatabaseStore<{ key: Buffer; value: string }>
+  nullifierToNoteHash: IDatabaseStore<{ key: Buffer; value: Buffer }>
 
   transactions: IDatabaseStore<{
     key: Buffer
@@ -119,10 +119,10 @@ export class AccountsDB {
       valueEncoding: new DecryptedNoteValueEncoding(),
     })
 
-    this.nullifierToNoteHash = this.database.addStore<{ key: Buffer; value: string }>({
+    this.nullifierToNoteHash = this.database.addStore<{ key: Buffer; value: Buffer }>({
       name: 'nullifierToNoteHash',
       keyEncoding: new BufferEncoding(),
-      valueEncoding: new StringEncoding(),
+      valueEncoding: new BufferEncoding(),
     })
 
     this.transactions = this.database.addStore<{
@@ -274,17 +274,17 @@ export class AccountsDB {
 
   async saveNullifierNoteHash(
     nullifier: Buffer,
-    note: string,
+    noteHash: Buffer,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
-    await this.nullifierToNoteHash.put(nullifier, note, tx)
+    await this.nullifierToNoteHash.put(nullifier, noteHash, tx)
   }
 
   async deleteNullifier(nullifier: Buffer, tx?: IDatabaseTransaction): Promise<void> {
     await this.nullifierToNoteHash.del(nullifier, tx)
   }
 
-  async replaceNullifierToNoteHash(map: BufferMap<string>): Promise<void> {
+  async replaceNullifierToNoteHash(map: BufferMap<Buffer>): Promise<void> {
     await this.nullifierToNoteHash.clear()
 
     await this.database.transaction(async (tx) => {
@@ -294,7 +294,7 @@ export class AccountsDB {
     })
   }
 
-  async loadNullifierToNoteHash(map: BufferMap<string>): Promise<void> {
+  async loadNullifierToNoteHash(map: BufferMap<Buffer>): Promise<void> {
     for await (const [key, value] of this.nullifierToNoteHash.getAllIter()) {
       map.set(key, value)
     }

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -8,6 +8,7 @@ import { FileSystem } from '../../fileSystems'
 import { Transaction } from '../../primitives/transaction'
 import {
   BigIntLEEncoding,
+  BufferEncoding,
   BUFFER_ENCODING,
   IDatabase,
   IDatabaseStore,
@@ -58,7 +59,7 @@ export class AccountsDB {
     value: DecryptedNoteValue
   }>
 
-  nullifierToNoteHash: IDatabaseStore<{ key: string; value: string }>
+  nullifierToNoteHash: IDatabaseStore<{ key: Buffer; value: string }>
 
   transactions: IDatabaseStore<{
     key: Buffer
@@ -118,9 +119,9 @@ export class AccountsDB {
       valueEncoding: new DecryptedNoteValueEncoding(),
     })
 
-    this.nullifierToNoteHash = this.database.addStore<{ key: string; value: string }>({
+    this.nullifierToNoteHash = this.database.addStore<{ key: Buffer; value: string }>({
       name: 'nullifierToNoteHash',
-      keyEncoding: new StringHashEncoding(),
+      keyEncoding: new BufferEncoding(),
       valueEncoding: new StringEncoding(),
     })
 
@@ -272,18 +273,18 @@ export class AccountsDB {
   }
 
   async saveNullifierNoteHash(
-    nullifier: string,
+    nullifier: Buffer,
     note: string,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.nullifierToNoteHash.put(nullifier, note, tx)
   }
 
-  async deleteNullifier(nullifier: string, tx?: IDatabaseTransaction): Promise<void> {
+  async deleteNullifier(nullifier: Buffer, tx?: IDatabaseTransaction): Promise<void> {
     await this.nullifierToNoteHash.del(nullifier, tx)
   }
 
-  async replaceNullifierToNoteHash(map: Map<string, string>): Promise<void> {
+  async replaceNullifierToNoteHash(map: BufferMap<string>): Promise<void> {
     await this.nullifierToNoteHash.clear()
 
     await this.database.transaction(async (tx) => {
@@ -293,7 +294,7 @@ export class AccountsDB {
     })
   }
 
-  async loadNullifierToNoteHash(map: Map<string, string>): Promise<void> {
+  async loadNullifierToNoteHash(map: BufferMap<string>): Promise<void> {
     for await (const [key, value] of this.nullifierToNoteHash.getAllIter()) {
       map.set(key, value)
     }


### PR DESCRIPTION
## Summary
This is the first step in removing hex strings from wallet 2.0. We don't ever want to store hex strings.

## Testing Plan
Run wallet 2.0 migrations and check the balance.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
