### PR TITLE
loads decryptedNotes without computing unconfirmed balance

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -97,25 +97,7 @@ export class Account {
   async load(): Promise<void> {
     await this.accountsDb.loadNullifierToNoteHash(this.nullifierToNoteHash)
     await this.accountsDb.loadTransactions(this.transactions)
-    await this.loadDecryptedNotesAndBalance()
-  }
-
-  private async loadDecryptedNotesAndBalance(): Promise<void> {
-    let unconfirmedBalance = BigInt(0)
-
-    for await (const { hash, decryptedNote } of this.accountsDb.loadDecryptedNotes()) {
-      if (decryptedNote.accountId === this.id) {
-        this.decryptedNotes.set(hash, decryptedNote)
-
-        if (!decryptedNote.spent) {
-          unconfirmedBalance += new Note(decryptedNote.serializedNote).value()
-        }
-
-        this.saveDecryptedNoteSequence(decryptedNote.transactionHash, hash)
-      }
-    }
-
-    await this.saveUnconfirmedBalance(unconfirmedBalance)
+    await this.accountsDb.loadDecryptedNotes(this.decryptedNotes)
   }
 
   async save(): Promise<void> {

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -321,15 +321,14 @@ export class AccountsDB {
     })
   }
 
-  async *loadDecryptedNotes(): AsyncGenerator<{
-    hash: string
-    decryptedNote: DecryptedNoteValue
-  }> {
+  async loadDecryptedNotes(
+    map: Map<
+      string,
+      { nullifierHash: string | null; noteIndex: number | null; spent: boolean }
+    >,
+  ): Promise<void> {
     for await (const [hash, decryptedNote] of this.decryptedNotes.getAllIter()) {
-      yield {
-        hash,
-        decryptedNote,
-      }
+      map.set(hash, decryptedNote)
     }
   }
 


### PR DESCRIPTION
## Summary

unconfirmed balance is updated every time the decrypted notes store is updated,
so it isn't necessary to recompute unconfirmed balance.

calculating the balance on load has the benefit of ensuring that the balance
matches the decrypted notes store when the node starts, but we read the balance
from the database each time we use it rather than tracking it in memory, so
we're already relying on updating the balance in tandem with the notes.

## Testing Plan

- imported account on `staging`, ran `accounts:balance`
- checked out `feature/no-balance-on-load`, ran wallet 2.0 migration
- ran `accounts:balance`, verified balances unchanged following migration

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
