### PR TITLE
fix erroring of rsync command

### DIFF
--- a/ironfish-cli/scripts/build.sh
+++ b/ironfish-cli/scripts/build.sh
@@ -62,7 +62,8 @@ echo "Copying node_modules"
 rsync -L -avrq --exclude 'ironfish' --exclude 'fsevents' ../../../node_modules ./
 # Copy node_modules from ironfish-cli folder into the production node_modules folder
 # yarn --production seems to split some packages into different folders for some reason
-rsync -L -avrq --ignore-missing-args ../../node_modules/* ./node_modules
+# if ../../node_modules/ is empty then the cp command will error so skip copying
+cp -R ../../node_modules/* ./node_modules || true
 
 echo ""
 if ! ./bin/run --version > /dev/null; then


### PR DESCRIPTION
## Summary
Tried to use `rsync --ignore-missing-args` to copy files to a folder even if the folder is empty. This works for newer rsync versions but for older rsync versions the `--ignore-missing-args` flag does not exist. The macos virtual environment has the older version of rsync which is what we use to run our [homebrew deploy github action](https://github.com/iron-fish/ironfish/actions/workflows/deploy-brew.yml). So the command was failing there. Changing this to just ignore failures when copying this specific node_modules directory

## Testing Plan
Tested locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
