### PR TITLE
Try to actually parse a public address for validation

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -33,6 +33,7 @@ export interface Key {
 export function generateKey(): Key
 export function generateNewPublicAddress(privateKey: string): Key
 export function initializeSapling(): void
+export function isValidPublicAddress(hexAddress: string): boolean
 export class BoxKeyPair {
   constructor()
   static fromHex(secretHex: string): BoxKeyPair

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -236,7 +236,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, NoteEncrypted, Note, TransactionPosted, Transaction, verifyTransactions, generateKey, generateNewPublicAddress, initializeSapling, FoundBlockResult, ThreadPoolHandler } = nativeBinding
+const { KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, NoteEncrypted, Note, TransactionPosted, Transaction, verifyTransactions, generateKey, generateNewPublicAddress, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.KEY_LENGTH = KEY_LENGTH
 module.exports.NONCE_LENGTH = NONCE_LENGTH
@@ -254,3 +254,4 @@ module.exports.generateNewPublicAddress = generateNewPublicAddress
 module.exports.initializeSapling = initializeSapling
 module.exports.FoundBlockResult = FoundBlockResult
 module.exports.ThreadPoolHandler = ThreadPoolHandler
+module.exports.isValidPublicAddress = isValidPublicAddress

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use ironfish_rust::PublicAddress;
 use ironfish_rust::SaplingKey;
 use napi::bindgen_prelude::*;
 use napi::Error;
@@ -112,4 +113,9 @@ impl ThreadPoolHandler {
     pub fn get_hash_rate_submission(&self) -> u32 {
         self.threadpool.get_hash_rate_submission()
     }
+}
+
+#[napi]
+fn is_valid_public_address(hex_address: String) -> bool {
+    PublicAddress::from_hex(&hex_address).is_ok()
 }

--- a/ironfish-rust/src/keys/public_address.rs
+++ b/ironfish-rust/src/keys/public_address.rs
@@ -86,6 +86,10 @@ impl PublicAddress {
     /// be 86 hexadecimal characters representing the 43 bytes of an address
     /// or it fails.
     pub fn from_hex(value: &str) -> Result<Self, errors::SaplingKeyError> {
+        if value.len() != 86 {
+            return Err(errors::SaplingKeyError::InvalidPublicAddress);
+        }
+
         match hex_to_bytes(value) {
             Err(()) => Err(errors::SaplingKeyError::InvalidPublicAddress),
             Ok(bytes) => {
@@ -186,5 +190,21 @@ impl std::fmt::Debug for PublicAddress {
 impl std::cmp::PartialEq for PublicAddress {
     fn eq(&self, other: &Self) -> bool {
         self.hex_public_address() == other.hex_public_address()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::PublicAddress;
+
+    #[test]
+    fn public_address_validation() {
+        let bad_address = "559cc1b263b4093d24f226b81c618d922fc002a5d6e82eae22df82641558bfd63011519750cba37a00eab5";
+        let good_address = "559cc1b263b4093d24f226b81c618d922fc002a5d6e82eae22df82641558bfd63011519750cba37a00eab8";
+
+        let bad_result = PublicAddress::from_hex(bad_address);
+        assert!(bad_result.is_err());
+
+        PublicAddress::from_hex(good_address).expect("returns a valid public address");
     }
 }

--- a/ironfish/src/account/validator.test.ts
+++ b/ironfish/src/account/validator.test.ts
@@ -40,6 +40,12 @@ describe('account-validator tests', () => {
     expect(isValidPublicAddress(INVALID_PUBLIC_ADDRESS)).toBe(false)
   })
 
+  test('public address that is not a valid public address should return false', () => {
+    const INVALID_PUBLIC_ADDRESS =
+      'e877d6903692094b67d889c483d09ad2f8438efc8f01c82e1ec3b2ccd1798ceca48216546dbae48c685f50'
+    expect(isValidPublicAddress(INVALID_PUBLIC_ADDRESS)).toBe(false)
+  })
+
   test('valid spending key should return true', () => {
     const VALID_SPENDING_KEY =
       'd89e4a60b0b3edb76faeac12d7b88e660afa0b335fbe04b2ddccdf62dff40d89'

--- a/ironfish/src/account/validator.ts
+++ b/ironfish/src/account/validator.ts
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { isValidPublicAddress as nativeIsValidPublicAddress } from '@ironfish/rust-nodejs'
 import { AccountsValue } from './database/accounts'
 
-const PUBLIC_ADDRESS_LENGTH = 86
 const SPENDING_KEY_LENGTH = 64
 const INCOMING_VIEW_KEY_LENGTH = 64
 const OUTGOING_VIEW_KEY_LENGTH = 64
 
 export function isValidPublicAddress(publicAddress: string): boolean {
-  return publicAddress.length === PUBLIC_ADDRESS_LENGTH && haveAllowedCharacters(publicAddress)
+  return nativeIsValidPublicAddress(publicAddress)
 }
 
 export function isValidSpendingKey(spendingKey: string): boolean {


### PR DESCRIPTION
## Summary

Just checking that a public address is a hex string of 86 characters is not enough, because it might not be a valid subgroup point when broken down into the diversifier and transmission key pair. So by properly parsing it, we validate that it is indeed an actually valid public key.

Benchmarking the perf difference:
The old node function ran in an average of 1 microsecond, the new function takes around 350 microseconds since it does a lot more work, but 0.3ms is still plenty fast for proper validation.

Closes IRO-2472

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
