### PR TITLE
Improving pay and deposit commands

### DIFF
--- a/ironfish/src/utils/currency.ts
+++ b/ironfish/src/utils/currency.ts
@@ -24,20 +24,28 @@ export const oreToIron = (amount: number): number => {
   return amount / ORE_TO_IRON
 }
 
+export const displayIronAmount = (amount: number): string => {
+  return amount.toLocaleString(undefined, {
+    minimumFractionDigits: FLOAT,
+    maximumFractionDigits: FLOAT,
+  })
+}
+
+export const displayOreAmount = (amount: number): string => {
+  return ironToOre(amount).toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
 /*
  * Return a string with the format $IRON X.XXXXXXXX ($ORE X^8)
  */
 export const displayIronAmountWithCurrency = (amount: number, displayOre: boolean): string => {
-  let iron = `${IRON_TICKER} ${amount.toLocaleString(undefined, {
-    minimumFractionDigits: FLOAT,
-    maximumFractionDigits: FLOAT,
-  })}`
+  let iron = `${IRON_TICKER} ${displayIronAmount(amount)}`
 
   if (displayOre) {
-    iron += ` (${ORE_TICKER} ${ironToOre(amount).toLocaleString(undefined, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    })})`
+    iron += ` (${ORE_TICKER} ${displayOreAmount(amount)})`
   }
 
   return iron


### PR DESCRIPTION
## Summary
1 - `deposit` and `deposit-all` by default will now use dynamic fee (p25 of last 100 blocks) instead of 1 ORE
```
wd021@DWs-MacBook-Pro ironfish-cli % yarn start deposit-all
You are about to deposit all your $IRON to the Iron Fish deposit account. Each transaction will use a fee of $IRON 0.00000013 ($ORE 13). The memos will contain the graffiti "wd021".
```
```
wd021@DWs-MacBook-Pro ironfish-cli % yarn start deposit

Your balance is $IRON 2.18146315 ($ORE 218,146,315).

You are about to send $IRON 0.10000000 ($ORE 10,000,000) plus a transaction fee of $IRON 0.00000013 ($ORE 13) to the Iron Fish deposit account.
Your remaining balance after this transaction will be $IRON 2.08146302 ($ORE 208,146,302).
The memo will contain the graffiti "wd021".
```

2 - `accounts:pay` will now display dynamic fee, max possible spend in prompt.
```
wd021@DWs-MacBook-Pro ironfish-cli % yarn start accounts:pay

Enter the fee amount in $IRON (min: 0.00000001, dynamic: 0.00000013): 0.00000013
Enter the amount in $IRON (balance available: 2.18146315, max: 2.18146302): 2.18146302

```

## Testing Plan
- test `deposit` `deposit-all` and `accounts:pay` commands

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
