### PR TITLE
Cache unsigned hash on Transaction, same way we cache the signed hash

### DIFF
--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -21,6 +21,7 @@ export class Transaction {
   private readonly _notes: NoteEncrypted[]
   private readonly _signature: Buffer
   private _hash?: TransactionHash
+  private _unsignedHash?: TransactionHash
 
   private transactionPosted: TransactionPosted | null = null
   private referenceCount = 0
@@ -181,7 +182,8 @@ export class Transaction {
    * is signed when the transaction is created
    */
   unsignedHash(): TransactionHash {
-    return this.withReference((t) => t.hash())
+    this._unsignedHash = this._unsignedHash || this.withReference((t) => t.hash())
+    return this._unsignedHash
   }
 
   /**


### PR DESCRIPTION
## Summary

This shouldn't get called very often, but wallet2.0 is definitely calling it a lot

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
