### PR TITLE
adds 'spender' notes back into accounts CLI output

### DIFF
--- a/ironfish-cli/src/commands/accounts/notes.test.ts
+++ b/ironfish-cli/src/commands/accounts/notes.test.ts
@@ -9,6 +9,7 @@ describe('accounts:notes', () => {
     account: 'default',
     notes: [
       {
+        owner: true,
         amount: 1,
         memo: 'foo',
         transactionHash: '1fa5f38c446e52f8842d8c861507744fc3f354992610e1661e033ef316e2d3d1',
@@ -50,6 +51,7 @@ describe('accounts:notes', () => {
       .exit(0)
       .it('logs the notes for the given account', (ctx) => {
         expectCli(ctx.stdout).include(responseContent.account)
+        expectCli(ctx.stdout).include(responseContent.notes[0].owner ? `✔` : `x`)
         expectCli(ctx.stdout).include(responseContent.notes[0].spent ? `✔` : `x`)
         expectCli(ctx.stdout).include(responseContent.notes[0].amount)
         expectCli(ctx.stdout).include(responseContent.notes[0].memo)

--- a/ironfish-cli/src/commands/accounts/notes.ts
+++ b/ironfish-cli/src/commands/accounts/notes.ts
@@ -35,9 +35,9 @@ export class NotesCommand extends IronfishCommand {
     this.log(`\n ${accountResponse} - Account notes\n`)
 
     CliUx.ux.table(notes, {
-      isSpent: {
-        header: 'Spent',
-        get: (row) => (row.spent ? `✔` : `x`),
+      isOwner: {
+        header: 'Owner',
+        get: (row) => (row.owner ? `✔` : `x`),
       },
       amount: {
         header: 'Amount ($IRON)',
@@ -48,6 +48,16 @@ export class NotesCommand extends IronfishCommand {
       },
       transactionHash: {
         header: 'From Transaction',
+      },
+      isSpent: {
+        header: 'Spent',
+        get: (row) => {
+          if (row.spent === undefined) {
+            return '-'
+          } else {
+            return row.spent ? `✔` : `x`
+          }
+        },
       },
     })
 

--- a/ironfish-cli/src/commands/accounts/transactions.test.ts
+++ b/ironfish-cli/src/commands/accounts/transactions.test.ts
@@ -36,6 +36,7 @@ describe('accounts:transactions', () => {
     },
     transactionNotes: [
       {
+        owner: true,
         spent: true,
         amount: 1,
         memo: 'foo',
@@ -113,6 +114,9 @@ describe('accounts:transactions', () => {
         expectCli(ctx.stdout).include(responseContentTransaction.transactionInfo?.spends)
 
         // transaction notes
+        expectCli(ctx.stdout).include(
+          responseContentTransaction.transactionNotes[0].owner ? `✔` : `x`,
+        )
         expectCli(ctx.stdout).include(
           responseContentTransaction.transactionNotes[0].spent ? `✔` : `x`,
         )

--- a/ironfish-cli/src/commands/accounts/transactions.ts
+++ b/ironfish-cli/src/commands/accounts/transactions.ts
@@ -60,9 +60,9 @@ export class TransactionsCommand extends IronfishCommand {
       this.log(`---Notes---\n`)
 
       CliUx.ux.table(transactionNotes, {
-        isSpent: {
-          header: 'Spent',
-          get: (row) => (row.spent ? `✔` : `x`),
+        isOwner: {
+          header: 'Owner',
+          get: (row) => (row.owner ? `✔` : `x`),
         },
         amount: {
           header: 'Amount ($IRON)',
@@ -70,6 +70,16 @@ export class TransactionsCommand extends IronfishCommand {
         },
         memo: {
           header: 'Memo',
+        },
+        isSpent: {
+          header: 'Spent',
+          get: (row) => {
+            if (row.spent === undefined) {
+              return '-'
+            } else {
+              return row.spent ? `✔` : `x`
+            }
+          },
         },
       })
     }

--- a/ironfish/src/primitives/index.ts
+++ b/ironfish/src/primitives/index.ts
@@ -4,6 +4,7 @@
 
 export { Block, BlockSerde } from './block'
 export { BlockHeader } from './blockheader'
+export { Note } from './note'
 export { Spend } from './spend'
 export { Target } from './target'
 export { Transaction } from './transaction'

--- a/ironfish/src/rpc/routes/accounts/getNotes.ts
+++ b/ironfish/src/rpc/routes/accounts/getNotes.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
-import { getAccount } from './utils'
+import { getAccount, getTransactionNotes } from './utils'
 
 export type GetAccountNotesRequest = { account?: string }
 
@@ -51,7 +51,7 @@ router.register<typeof GetAccountNotesRequestSchema, GetAccountNotesResponse>(
 
     const responseNotes = []
     for (const { transaction } of account.getTransactions()) {
-      responseNotes.push(...account.getTransactionNotes(transaction))
+      responseNotes.push(...getTransactionNotes(account, transaction))
     }
 
     request.end({ account: account.displayName, notes: responseNotes })

--- a/ironfish/src/rpc/routes/accounts/getNotes.ts
+++ b/ironfish/src/rpc/routes/accounts/getNotes.ts
@@ -10,10 +10,11 @@ export type GetAccountNotesRequest = { account?: string }
 export type GetAccountNotesResponse = {
   account: string
   notes: {
+    owner: boolean
     amount: number
     memo: string
     transactionHash: string
-    spent: boolean
+    spent: boolean | undefined
   }[]
 }
 
@@ -30,10 +31,11 @@ export const GetAccountNotesResponseSchema: yup.ObjectSchema<GetAccountNotesResp
       .array(
         yup
           .object({
+            owner: yup.boolean().defined(),
             amount: yup.number().defined(),
             memo: yup.string().trim().defined(),
             transactionHash: yup.string().defined(),
-            spent: yup.boolean().defined(),
+            spent: yup.boolean(),
           })
           .defined(),
       )
@@ -46,16 +48,10 @@ router.register<typeof GetAccountNotesRequestSchema, GetAccountNotesResponse>(
   GetAccountNotesRequestSchema,
   (request, node): void => {
     const account = getAccount(node, request.data.account)
-    const notes = account.getNotes()
-    const responseNotes = []
 
-    for (const note of notes) {
-      responseNotes.push({
-        amount: Number(note.note.value()),
-        memo: note.note.memo(),
-        transactionHash: note.transactionHash.toString('hex'),
-        spent: note.spent,
-      })
+    const responseNotes = []
+    for (const { transaction } of account.getTransactions()) {
+      responseNotes.push(...account.getTransactionNotes(transaction))
     }
 
     request.end({ account: account.displayName, notes: responseNotes })

--- a/ironfish/src/rpc/routes/accounts/getTransaction.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransaction.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
-import { getAccount, getTransactionStatus } from './utils'
+import { getAccount, getTransactionNotes, getTransactionStatus } from './utils'
 
 export type GetAccountTransactionRequest = { account?: string; hash: string }
 
@@ -88,7 +88,7 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
         spends: transaction.spendsLength(),
       }
 
-      transactionNotes.push(...account.getTransactionNotes(transaction))
+      transactionNotes.push(...getTransactionNotes(account, transaction))
     }
 
     request.end({

--- a/ironfish/src/rpc/routes/accounts/getTransaction.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransaction.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Note } from '../../../primitives/note'
 import { ApiNamespace, router } from '../router'
 import { getAccount, getTransactionStatus } from './utils'
 
@@ -19,9 +18,10 @@ export type GetAccountTransactionResponse = {
     spends: number
   } | null
   transactionNotes: {
+    owner: boolean
     amount: number
     memo: string
-    spent: boolean
+    spent: boolean | undefined
   }[]
 }
 
@@ -51,9 +51,10 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
         .array(
           yup
             .object({
+              owner: yup.boolean().defined(),
               amount: yup.number().defined(),
               memo: yup.string().trim().defined(),
-              spent: yup.boolean().defined(),
+              spent: yup.boolean(),
             })
             .defined(),
         )
@@ -68,8 +69,8 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
     const account = getAccount(node, request.data.account)
 
     let transactionInfo = null
-    const transactionNotes = []
     const transactionValue = account.getTransaction(Buffer.from(request.data.hash, 'hex'))
+    const transactionNotes = []
 
     if (transactionValue) {
       const { transaction, blockHash, sequence } = transactionValue
@@ -87,22 +88,7 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
         spends: transaction.spendsLength(),
       }
 
-      for (const note of transaction.notes()) {
-        // Try loading the note from the account
-        const decryptedNoteValue = account.getDecryptedNote(note.merkleHash().toString('hex'))
-
-        if (decryptedNoteValue) {
-          const decryptedNote = new Note(decryptedNoteValue.serializedNote)
-
-          if (decryptedNote.value() !== BigInt(0)) {
-            transactionNotes.push({
-              amount: Number(decryptedNote.value()),
-              memo: decryptedNote.memo(),
-              spent: decryptedNoteValue?.spent,
-            })
-          }
-        }
-      }
+      transactionNotes.push(...account.getTransactionNotes(transaction))
     }
 
     request.end({

--- a/ironfish/src/rpc/routes/accounts/utils.ts
+++ b/ironfish/src/rpc/routes/accounts/utils.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { IronfishNode } from '../../../node'
+import { Note, Transaction } from '../../../primitives'
 import { Account } from '../../../wallet'
 import { ValidationError } from '../../adapters'
 
@@ -45,4 +46,47 @@ export async function getTransactionStatus(
   } else {
     return headSequence > expirationSequence ? 'expired' : 'pending'
   }
+}
+
+export function getTransactionNotes(
+  account: Account,
+  transaction: Transaction,
+): ReadonlyArray<{
+  owner: boolean
+  amount: number
+  memo: string
+  transactionHash: string
+  spent: boolean | undefined
+}> {
+  const transactionNotes = []
+
+  for (const note of transaction.notes()) {
+    let decryptedNote
+    let owner
+
+    // Try loading the decrypted note from the account
+    const decryptedNoteValue = account.getDecryptedNote(note.merkleHash().toString('hex'))
+
+    if (decryptedNoteValue) {
+      decryptedNote = new Note(decryptedNoteValue.serializedNote)
+      owner = true
+    } else {
+      // Try decrypting the note using the outgoingViewKey
+      decryptedNote = note.decryptNoteForSpender(account.outgoingViewKey)
+      owner = false
+    }
+    if (decryptedNote) {
+      if (decryptedNote.value() !== BigInt(0)) {
+        transactionNotes.push({
+          owner,
+          amount: Number(decryptedNote.value()),
+          memo: decryptedNote.memo().replace(/\x00/g, ''),
+          transactionHash: transaction.hash().toString('hex'),
+          spent: decryptedNoteValue?.spent,
+        })
+      }
+    }
+  }
+
+  return transactionNotes
 }

--- a/ironfish/src/rpc/routes/accounts/utils.ts
+++ b/ironfish/src/rpc/routes/accounts/utils.ts
@@ -80,7 +80,7 @@ export function getTransactionNotes(
         transactionNotes.push({
           owner,
           amount: Number(decryptedNote.value()),
-          memo: decryptedNote.memo().replace(/\x00/g, ''),
+          memo: decryptedNote.memo(),
           transactionHash: transaction.hash().toString('hex'),
           spent: decryptedNoteValue?.spent,
         })

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -486,44 +486,4 @@ export class Account {
   async getHeadHash(): Promise<string | null> {
     return this.accountsDb.getHeadHash(this)
   }
-
-  getTransactionNotes(transaction: Transaction): ReadonlyArray<{
-    owner: boolean
-    amount: number
-    memo: string
-    transactionHash: string
-    spent: boolean | undefined
-  }> {
-    const transactionNotes = []
-
-    for (const note of transaction.notes()) {
-      let decryptedNote
-      let owner
-
-      // Try loading the decrypted note from the account
-      const decryptedNoteValue = this.getDecryptedNote(note.merkleHash().toString('hex'))
-
-      if (decryptedNoteValue) {
-        decryptedNote = new Note(decryptedNoteValue.serializedNote)
-        owner = true
-      } else {
-        // Try decrypting the note using the outgoingViewKey
-        decryptedNote = note.decryptNoteForSpender(this.outgoingViewKey)
-        owner = false
-      }
-      if (decryptedNote) {
-        if (decryptedNote.value() !== BigInt(0)) {
-          transactionNotes.push({
-            owner,
-            amount: Number(decryptedNote.value()),
-            memo: decryptedNote.memo().replace(/\x00/g, ''),
-            transactionHash: transaction.hash().toString('hex'),
-            spent: decryptedNoteValue?.spent,
-          })
-        }
-      }
-    }
-
-    return transactionNotes
-  }
 }

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -486,4 +486,44 @@ export class Account {
   async getHeadHash(): Promise<string | null> {
     return this.accountsDb.getHeadHash(this)
   }
+
+  getTransactionNotes(transaction: Transaction): ReadonlyArray<{
+    owner: boolean
+    amount: number
+    memo: string
+    transactionHash: string
+    spent: boolean | undefined
+  }> {
+    const transactionNotes = []
+
+    for (const note of transaction.notes()) {
+      let decryptedNote
+      let owner
+
+      // Try loading the decrypted note from the account
+      const decryptedNoteValue = this.getDecryptedNote(note.merkleHash().toString('hex'))
+
+      if (decryptedNoteValue) {
+        decryptedNote = new Note(decryptedNoteValue.serializedNote)
+        owner = true
+      } else {
+        // Try decrypting the note using the outgoingViewKey
+        decryptedNote = note.decryptNoteForSpender(this.outgoingViewKey)
+        owner = false
+      }
+      if (decryptedNote) {
+        if (decryptedNote.value() !== BigInt(0)) {
+          transactionNotes.push({
+            owner,
+            amount: Number(decryptedNote.value()),
+            memo: decryptedNote.memo().replace(/\x00/g, ''),
+            transactionHash: transaction.hash().toString('hex'),
+            spent: decryptedNoteValue?.spent,
+          })
+        }
+      }
+    }
+
+    return transactionNotes
+  }
 }


### PR DESCRIPTION
## Summary

each account's decryptedNotes store tracks notes that the account owns, but not
outgoing 'spender' notes that were created by transactions that the account
created.

these outgoing notes are useful for seeing a full 'statement' of an account's
activity.

outside of this sort of CLI output there's currently no need to store decrypted
outgoing notes for an account.

- defines `getTransactionNotes` account method to get decrypted note
  information (incoming and outgoing) for a transaction's notes
- adds 'owner' field to accounts:transactions and accounts:notes commands. owner
  makes a bit more sense here than 'spender'.

## Testing Plan

example output for `accounts:transactions -t . . .`:
```
Account: default (ebfb2c0)
Transaction: c9155dd1df98b64e6525a94a53ad831da11726e80317771e231c01f9fd9ad3c6
Status: completed
Miner Fee: x
Fee ($ORE): 125
Spends: 3

---Notes---

 Owner Amount ($IRON) Memo                             Spent 
 ───── ────────────── ──────────────────────────────── ───── 
 x     0.26676475     Iron Fish Pool payout Tue, 10 Ma -     
 x     0.95034945     Iron Fish Pool payout Tue, 10 Ma -     
 x     1.75064373     Iron Fish Pool payout Tue, 10 Ma -     
 x     1.13375022     Iron Fish Pool payout Tue, 10 Ma -     
 x     0.83363987     Iron Fish Pool payout Tue, 10 Ma -     
 x     0.21674636     Iron Fish Pool payout Tue, 10 Ma -  
 . . . 
 ```
 
 example output for `accounts:notes`:
 ```
  default (ebfb2c0) - Account notes

 Owner Amount ($IRON) Memo                             From Transaction                                                 Spent 
 ───── ────────────── ──────────────────────────────── ──────────────────────────────────────────────────────────────── ───── 
 ✔     20.00000013                                     ee048b594c0cb7837aadeb3e7cc01b2af3af23a67a9423a0346c7407e6e7e11e ✔     
 ✔     20.00000036                                     913dd34845d62f032fb079682f3e69f827256d3e57a21075210545f1bf09ef27 ✔     
 ✔     20.00000074                                     a82979f1897a4c3ac1879e5b3138ab5b524245673ef0ffef33f0009983e5c6f7 x     
 ✔     20.00000026                                     4655d197cce6b9b22839b45cc13e059b36bf7e1a6081b433665a40811e830119 ✔     
 ✔     20.00000062                                     7386c1f481e0e68cdda246d650ce291760bdd6fabd3a8a60e35c0a2688f0c2cc x     
 ✔     20.00000026                                     8762386ed891f84b46fb868f725e82ca34e920e85d6ccb96f8761183624b3911 ✔     
 ✔     20.00001059                                     673c1d3ff601e845db8a66aa2ce48a18c99ebfbe91ecd106ec3fe4b7fadaee76 ✔     
 ✔     20.00000033                                     5ae01787ed9dafb74601d25fd778c772a09c80a2c95a50a093ad1f40db3c8c20 x     
 ✔     20.00000003                                     18a54fd7cb2230efbc43d129269951ed42294cc0a63e32365b762c4a5ca211e6 ✔     
 ✔     20.00001079                                     6fa47069c24b7b145c6dd054eb9dff9506e4df1b86a9d5d633c6b0b2319df9dd x     
 ✔     20.00000006                                     07de2beacbf780e8857c33cec9bc01f08dc05ae193858e12745b3fef70c8491f ✔     
 ✔     20.00000009                                     d54873a78fe6dbe91a427754911a6b32734654ecede3f544fc28556e67240395 x     
 ✔     20.00000003                                     346cf139aadd6c12b78ae89ff813fe7a322c8e33da717a898ea10d57537f95da ✔     
 ✔     20.00000009                                     71d4e0f985ead8d3a889ffc85c8ca0e1b4f9afa04af6d079a06abb2fd5576bb9 x     
 ✔     20.00000007                                     3f70c0a8955ae19c9ba22e92ce41e77f6d79da83234016e637cb3c6a84fe6250 ✔     
 ✔     20.00000012                                     bd9b5cbb51813966061c4c78715505c46d2c3186472e3868fd247f4f36b4915b ✔     
 ✔     20.00000018                                     666cc3e7ba3d548364982ace29be27d101b75eef2f209cdf7ca11f078f064100 x     
 ✔     20.00000006                                     f0bbc4672ff447d2b93fba25fec9dfd44dd01dc22d61de4e80c279955204ca43 ✔     
 ✔     20.00000026                                     b6be7068d30f56aee733e1bbcfa322ec9c69ff0d0363bc0e874fe2dd6e36715d ✔     
 ✔     20.00000014                                     899a035502b4d1e9787603d4a1bc7c88ac9d23b8508e1c8692a1e83cd6f5d6a5 ✔     
 ✔     20.00000011                                     471948769502391a1ecd17bccc9eabb7d01d5e34d4996698e76bdd206af1412e x     
 x     0.60902575     Iron Fish Pool payout Wed, 11 Ma aa2674e88e0d60a599b3610698cc831115dbb51cc7dd0103d7ceb82f26c4a945 -     
 x     7.53451856     Iron Fish Pool payout Wed, 11 Ma aa2674e88e0d60a599b3610698cc831115dbb51cc7dd0103d7ceb82f26c4a945 -     
 x     0.19140809     Iron Fish Pool payout Wed, 11 Ma aa2674e88e0d60a599b3610698cc831115dbb51cc7dd0103d7ceb82f26c4a945 -     
 x     0.93963972     Iron Fish Pool payout Wed, 11 Ma aa2674e88e0d60a599b3610698cc831115dbb51cc7dd0103d7ceb82f26c4a945 -     
 x     0.7830331      Iron Fish Pool payout Wed, 11 Ma aa2674e88e0d60a599b3610698cc831115dbb51cc7dd0103d7ceb82f26c4a945 -     
 x     1.09624635     Iron Fish Pool payout Wed, 11 Ma aa2674e88e0d60a599b3610698cc831115dbb51cc7dd0103d7ceb82f26c4a945 - 
 ```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
