### PR TITLE
Force pay and deposit commands to connect to a running node

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -66,7 +66,8 @@ export class Pay extends IronfishCommand {
     const expirationSequence = flags.expirationSequence
     const memo = flags.memo || ''
 
-    const client = await this.sdk.connectRpc()
+    await this.sdk.client.connect()
+    const client = this.sdk.client
 
     const status = await client.status()
 

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -66,8 +66,7 @@ export class Pay extends IronfishCommand {
     const expirationSequence = flags.expirationSequence
     const memo = flags.memo || ''
 
-    await this.sdk.client.connect()
-    const client = this.sdk.client
+    const client = await this.sdk.connectRpc(false, true)
 
     const status = await client.status()
 

--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -58,7 +58,8 @@ export default class DepositAll extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(DepositAll)
 
-    this.client = await this.sdk.connectRpc()
+    await this.sdk.client.connect()
+    this.client = this.sdk.client
     this.api = new WebApi()
 
     const fee = flags.fee

--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -58,8 +58,7 @@ export default class DepositAll extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(DepositAll)
 
-    await this.sdk.client.connect()
-    this.client = this.sdk.client
+    this.client = await this.sdk.connectRpc(false, true)
     this.api = new WebApi()
 
     const fee = flags.fee

--- a/ironfish-cli/src/commands/deposit.ts
+++ b/ironfish-cli/src/commands/deposit.ts
@@ -51,7 +51,8 @@ export default class Bank extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(Bank)
 
-    this.client = await this.sdk.connectRpc()
+    await this.sdk.client.connect()
+    this.client = this.sdk.client
     this.api = new WebApi()
 
     const fee = flags.fee

--- a/ironfish-cli/src/commands/deposit.ts
+++ b/ironfish-cli/src/commands/deposit.ts
@@ -51,8 +51,7 @@ export default class Bank extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(Bank)
 
-    await this.sdk.client.connect()
-    this.client = this.sdk.client
+    this.client = await this.sdk.connectRpc(false, true)
     this.api = new WebApi()
 
     const fee = flags.fee


### PR DESCRIPTION
## Summary

These commands currently will spin up a memory client if a node isn't running, but given the node needs to be connected to a network, it doesn't really make sense to do that. Instead, they should only try connecting to a running node.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
