### PR TITLE
updates account to store note hashes as buffers

### DIFF
--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -389,7 +389,9 @@ export class Migration013 extends Migration {
       const decryptedNote: DatabaseStoreValue<NewStores['decryptedNotes']> = {
         accountId: account.id,
         noteIndex: nullifierEntry.noteIndex,
-        nullifierHash: nullifierEntry.nullifierHash,
+        nullifierHash: nullifierEntry.nullifierHash
+          ? Buffer.from(nullifierEntry.nullifierHash, 'hex')
+          : null,
         serializedNote: note.serialize(),
         spent: nullifierEntry.spent,
         transactionHash: transactionHash,
@@ -401,7 +403,7 @@ export class Migration013 extends Migration {
         unconfirmedBalances.set(account.id, balance)
       }
 
-      await decryptedNoteStoreNew.put(noteHashHex, decryptedNote, tx)
+      await decryptedNoteStoreNew.put(noteHash, decryptedNote, tx)
 
       decryptedNotes.push(decryptedNote)
     }

--- a/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
@@ -7,14 +7,14 @@ import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
 export const NOTE_SIZE = 43 + 8 + 32 + 32
 
 export type DecryptedNotesStore = IDatabaseStore<{
-  key: string
+  key: Buffer
   value: DecryptedNoteValue
 }>
 
 export interface DecryptedNoteValue {
   accountId: string
   noteIndex: number | null
-  nullifierHash: string | null
+  nullifierHash: Buffer | null
   serializedNote: Buffer
   spent: boolean
   transactionHash: Buffer
@@ -66,7 +66,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
 
     let nullifierHash = null
     if (hasNullifierHash) {
-      nullifierHash = reader.readHash('hex')
+      nullifierHash = reader.readHash()
     }
 
     return { accountId, noteIndex, nullifierHash, serializedNote, spent, transactionHash }

--- a/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
@@ -9,7 +9,6 @@ import {
   IDatabase,
   NullableStringEncoding,
   StringEncoding,
-  StringHashEncoding,
 } from '../../../../storage'
 import { AccountsStore, AccountValue, AccountValueEncoding } from './accounts'
 import { BalancesStore } from './balances'
@@ -69,7 +68,7 @@ export function loadNewStores(db: IDatabase): NewStores {
   const decryptedNotes: DecryptedNotesStore = db.addStore(
     {
       name: 'decryptedNotes',
-      keyEncoding: new StringHashEncoding(),
+      keyEncoding: new BufferEncoding(),
       valueEncoding: new DecryptedNoteValueEncoding(),
     },
     false,

--- a/ironfish/src/rpc/routes/accounts/utils.ts
+++ b/ironfish/src/rpc/routes/accounts/utils.ts
@@ -65,7 +65,7 @@ export function getTransactionNotes(
     let owner
 
     // Try loading the decrypted note from the account
-    const decryptedNoteValue = account.getDecryptedNote(note.merkleHash().toString('hex'))
+    const decryptedNoteValue = account.getDecryptedNote(note.merkleHash())
 
     if (decryptedNoteValue) {
       decryptedNote = new Note(decryptedNoteValue.serializedNote)

--- a/ironfish/src/typedefs/buffer-map.d.ts
+++ b/ironfish/src/typedefs/buffer-map.d.ts
@@ -35,7 +35,7 @@ declare module 'buffer-map' {
     delete(key: Buffer): boolean
     clear(): void
 
-    [Symbol.iterator](): Iterator<[Buffer, T]>
+    [Symbol.iterator](): Iterator<Buffer>
 
     *entries(): Generator<[Buffer, Bufferd]>
     keys(): Iterator<Buffer>

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -465,7 +465,7 @@ export class Account {
     for (let i = unconfirmedSequenceStart; i < headSequence; i++) {
       const noteHashes = this.noteHashesBySequence.get(i)
       if (noteHashes) {
-        for (const hash of noteHashes.toKeys()) {
+        for (const hash of noteHashes) {
           const note = this.decryptedNotes.get(hash)
           Assert.isNotUndefined(note)
           if (!note.spent) {
@@ -475,7 +475,7 @@ export class Account {
       }
     }
 
-    for (const noteHash of this.nonChainNoteHashes.toKeys()) {
+    for (const noteHash of this.nonChainNoteHashes) {
       const note = this.decryptedNotes.get(noteHash)
       Assert.isNotUndefined(note)
       if (!note.spent) {

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BufferMap } from 'buffer-map'
+import { BufferMap, BufferSet } from 'buffer-map'
 import MurmurHash3 from 'imurmurhash'
 import { Assert } from '../assert'
 import { Transaction } from '../primitives'
@@ -16,7 +16,7 @@ export const ACCOUNT_KEY_LENGTH = 32
 
 export class Account {
   private readonly accountsDb: AccountsDB
-  private readonly decryptedNotes: Map<string, DecryptedNoteValue>
+  private readonly decryptedNotes: BufferMap<DecryptedNoteValue>
   private readonly nullifierToNoteHash: BufferMap<Buffer>
   private readonly transactions: BufferMap<
     Readonly<{
@@ -27,8 +27,8 @@ export class Account {
     }>
   >
 
-  private readonly noteHashesBySequence: Map<number, Set<string>>
-  private readonly nonChainNoteHashes: Set<string>
+  private readonly noteHashesBySequence: Map<number, BufferSet>
+  private readonly nonChainNoteHashes: BufferSet
 
   readonly id: string
   readonly displayName: string
@@ -71,7 +71,7 @@ export class Account {
     this.displayName = `${this.name} (${hashSlice})`
 
     this.accountsDb = accountsDb
-    this.decryptedNotes = new Map<string, DecryptedNoteValue>()
+    this.decryptedNotes = new BufferMap<DecryptedNoteValue>()
     this.nullifierToNoteHash = new BufferMap<Buffer>()
     this.transactions = new BufferMap<{
       transaction: Transaction
@@ -80,8 +80,8 @@ export class Account {
       submittedSequence: number | null
     }>()
 
-    this.noteHashesBySequence = new Map<number, Set<string>>()
-    this.nonChainNoteHashes = new Set<string>()
+    this.noteHashesBySequence = new Map<number, BufferSet>()
+    this.nonChainNoteHashes = new BufferSet()
   }
 
   serialize(): AccountValue {
@@ -134,7 +134,7 @@ export class Account {
   }
 
   getNotes(): ReadonlyArray<{
-    hash: string
+    hash: Buffer
     index: number | null
     note: Note
     transactionHash: Buffer
@@ -156,7 +156,7 @@ export class Account {
   }
 
   getUnspentNotes(): ReadonlyArray<{
-    hash: string
+    hash: Buffer
     index: number | null
     note: Note
     transactionHash: Buffer
@@ -164,12 +164,12 @@ export class Account {
     return this.getNotes().filter((note) => !note.spent)
   }
 
-  getDecryptedNote(hash: string): DecryptedNoteValue | undefined {
+  getDecryptedNote(hash: Buffer): DecryptedNoteValue | undefined {
     return this.decryptedNotes.get(hash)
   }
 
   async updateDecryptedNote(
-    noteHash: string,
+    noteHash: Buffer,
     note: Readonly<DecryptedNoteValue>,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
@@ -192,7 +192,7 @@ export class Account {
     })
   }
 
-  private saveDecryptedNoteSequence(transactionHash: Buffer, noteHash: string): void {
+  private saveDecryptedNoteSequence(transactionHash: Buffer, noteHash: Buffer): void {
     const transaction = this.transactions.get(transactionHash)
     Assert.isNotUndefined(
       transaction,
@@ -202,7 +202,7 @@ export class Account {
     const { sequence, blockHash } = transaction
     if (blockHash) {
       Assert.isNotNull(sequence, `sequence required when submitting block hash`)
-      const decryptedNotes = this.noteHashesBySequence.get(sequence) ?? new Set<string>()
+      const decryptedNotes = this.noteHashesBySequence.get(sequence) ?? new BufferSet()
       decryptedNotes.add(noteHash)
       this.noteHashesBySequence.set(sequence, decryptedNotes)
       this.nonChainNoteHashes.delete(noteHash)
@@ -215,8 +215,8 @@ export class Account {
     transaction: Transaction,
     decryptedNotes: Array<{
       noteIndex: number | null
-      nullifier: string | null
-      merkleHash: string
+      nullifier: Buffer | null
+      merkleHash: Buffer
       forSpender: boolean
       account: Account
       serializedNote: Buffer
@@ -271,8 +271,8 @@ export class Account {
     transactionHash: Buffer,
     decryptedNotes: Array<{
       noteIndex: number | null
-      nullifier: string | null
-      merkleHash: string
+      nullifier: Buffer | null
+      merkleHash: Buffer
       forSpender: boolean
       serializedNote: Buffer
     }>,
@@ -283,8 +283,8 @@ export class Account {
         if (!decryptedNote.forSpender) {
           if (decryptedNote.nullifier !== null) {
             await this.updateNullifierNoteHash(
-              Buffer.from(decryptedNote.nullifier, 'hex'),
-              Buffer.from(decryptedNote.merkleHash, 'hex'),
+              decryptedNote.nullifier,
+              decryptedNote.merkleHash,
               tx,
             )
           }
@@ -315,14 +315,14 @@ export class Account {
       const noteHash = this.getNoteHash(spend.nullifier)
 
       if (noteHash) {
-        const decryptedNote = this.getDecryptedNote(noteHash.toString('hex'))
+        const decryptedNote = this.getDecryptedNote(noteHash)
         Assert.isNotUndefined(
           decryptedNote,
           'nullifierToNote mappings must have a corresponding decryptedNote',
         )
 
         await this.updateDecryptedNote(
-          noteHash.toString('hex'),
+          noteHash,
           {
             ...decryptedNote,
             spent: !isRemovingTransaction,
@@ -334,7 +334,7 @@ export class Account {
   }
 
   private async deleteDecryptedNote(
-    noteHash: string,
+    noteHash: Buffer,
     transactionHash: Buffer,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
@@ -415,14 +415,14 @@ export class Account {
   ): Promise<void> {
     await this.accountsDb.database.withTransaction(tx, async (tx) => {
       for (const note of transaction.notes()) {
-        const merkleHash = note.merkleHash().toString('hex')
+        const merkleHash = note.merkleHash()
         const decryptedNote = this.getDecryptedNote(merkleHash)
 
         if (decryptedNote) {
           await this.deleteDecryptedNote(merkleHash, hash, tx)
 
           if (decryptedNote.nullifierHash) {
-            const nullifier = Buffer.from(decryptedNote.nullifierHash, 'hex')
+            const nullifier = decryptedNote.nullifierHash
             await this.deleteNullifier(nullifier, tx)
           }
         }
@@ -432,14 +432,14 @@ export class Account {
         const noteHash = this.getNoteHash(spend.nullifier)
 
         if (noteHash) {
-          const decryptedNote = this.getDecryptedNote(noteHash.toString('hex'))
+          const decryptedNote = this.getDecryptedNote(noteHash)
           Assert.isNotUndefined(
             decryptedNote,
             'nullifierToNote mappings must have a corresponding decryptedNote',
           )
 
           await this.updateDecryptedNote(
-            noteHash.toString('hex'),
+            noteHash,
             {
               ...decryptedNote,
               spent: false,
@@ -465,7 +465,7 @@ export class Account {
     for (let i = unconfirmedSequenceStart; i < headSequence; i++) {
       const noteHashes = this.noteHashesBySequence.get(i)
       if (noteHashes) {
-        for (const hash of noteHashes) {
+        for (const hash of noteHashes.toKeys()) {
           const note = this.decryptedNotes.get(hash)
           Assert.isNotUndefined(note)
           if (!note.spent) {
@@ -475,7 +475,7 @@ export class Account {
       }
     }
 
-    for (const noteHash of this.nonChainNoteHashes.values()) {
+    for (const noteHash of this.nonChainNoteHashes.toKeys()) {
       const note = this.decryptedNotes.get(noteHash)
       Assert.isNotUndefined(note)
       if (!note.spent) {

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -14,7 +14,6 @@ import {
   IDatabaseTransaction,
   NullableStringEncoding,
   StringEncoding,
-  StringHashEncoding,
 } from '../../storage'
 import { createDB } from '../../storage/utils'
 import { WorkerPool } from '../../workerPool'
@@ -54,7 +53,7 @@ export class AccountsDB {
   }>
 
   decryptedNotes: IDatabaseStore<{
-    key: string
+    key: Buffer
     value: DecryptedNoteValue
   }>
 
@@ -110,11 +109,11 @@ export class AccountsDB {
     })
 
     this.decryptedNotes = this.database.addStore<{
-      key: string
+      key: Buffer
       value: DecryptedNoteValue
     }>({
       name: 'decryptedNotes',
-      keyEncoding: new StringHashEncoding(),
+      keyEncoding: new BufferEncoding(),
       valueEncoding: new DecryptedNoteValueEncoding(),
     })
 
@@ -337,7 +336,7 @@ export class AccountsDB {
   }
 
   async saveDecryptedNote(
-    noteHash: string,
+    noteHash: Buffer,
     note: Readonly<DecryptedNoteValue>,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
@@ -346,14 +345,14 @@ export class AccountsDB {
     })
   }
 
-  async deleteDecryptedNote(noteHash: string, tx?: IDatabaseTransaction): Promise<void> {
+  async deleteDecryptedNote(noteHash: Buffer, tx?: IDatabaseTransaction): Promise<void> {
     await this.database.withTransaction(tx, async (tx) => {
       await this.decryptedNotes.del(noteHash, tx)
     })
   }
 
   async replaceDecryptedNotes(
-    map: Map<string, DecryptedNoteValue>,
+    map: BufferMap<DecryptedNoteValue>,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.database.withTransaction(tx, async (tx) => {
@@ -366,7 +365,7 @@ export class AccountsDB {
   }
 
   async *loadDecryptedNotes(tx?: IDatabaseTransaction): AsyncGenerator<{
-    hash: string
+    hash: Buffer
     decryptedNote: DecryptedNoteValue
   }> {
     for await (const [hash, decryptedNote] of this.decryptedNotes.getAllIter(tx)) {

--- a/ironfish/src/wallet/database/decryptedNoteValue.test.ts
+++ b/ironfish/src/wallet/database/decryptedNoteValue.test.ts
@@ -30,7 +30,7 @@ describe('DecryptedNoteValueEncoding', () => {
         accountId: 'uuid',
         spent: true,
         noteIndex: 40,
-        nullifierHash: Buffer.alloc(32, 1).toString('hex'),
+        nullifierHash: Buffer.alloc(32, 1),
         serializedNote: Buffer.alloc(NOTE_SIZE, 1),
         transactionHash: Buffer.alloc(32, 1),
       }

--- a/ironfish/src/wallet/database/decryptedNoteValue.ts
+++ b/ironfish/src/wallet/database/decryptedNoteValue.ts
@@ -13,7 +13,7 @@ export interface DecryptedNoteValue {
   transactionHash: Buffer
   // These fields are populated once the note's transaction is on the main chain
   noteIndex: number | null
-  nullifierHash: string | null
+  nullifierHash: Buffer | null
 }
 
 export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNoteValue> {
@@ -61,7 +61,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
 
     let nullifierHash = null
     if (hasNullifierHash) {
-      nullifierHash = reader.readHash('hex')
+      nullifierHash = reader.readHash()
     }
 
     return { accountId, noteIndex, nullifierHash, serializedNote, spent, transactionHash }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -315,8 +315,8 @@ export class Accounts {
       string,
       Array<{
         noteIndex: number | null
-        nullifier: string | null
-        merkleHash: string
+        nullifier: Buffer | null
+        merkleHash: Buffer
         forSpender: boolean
         account: Account
         serializedNote: Buffer
@@ -330,8 +330,8 @@ export class Accounts {
       string,
       Array<{
         noteIndex: number | null
-        nullifier: string | null
-        merkleHash: string
+        nullifier: Buffer | null
+        merkleHash: Buffer
         forSpender: boolean
         account: Account
         serializedNote: Buffer
@@ -389,8 +389,8 @@ export class Accounts {
   ): Promise<
     Array<{
       noteIndex: number | null
-      nullifier: string | null
-      merkleHash: string
+      nullifier: Buffer | null
+      merkleHash: Buffer
       forSpender: boolean
       account: Account
       serializedNote: Buffer
@@ -404,9 +404,9 @@ export class Accounts {
         decryptedNotes.push({
           account,
           forSpender: decryptedNote.forSpender,
-          merkleHash: decryptedNote.merkleHash.toString('hex'),
+          merkleHash: decryptedNote.merkleHash,
           noteIndex: decryptedNote.index,
-          nullifier: decryptedNote.nullifier ? decryptedNote.nullifier.toString('hex') : null,
+          nullifier: decryptedNote.nullifier ? decryptedNote.nullifier : null,
           serializedNote: decryptedNote.serializedNote,
         })
       }
@@ -609,7 +609,7 @@ export class Accounts {
 
   private async getUnspentNotes(account: Account): Promise<
     ReadonlyArray<{
-      hash: string
+      hash: Buffer
       note: Note
       index: number | null
       confirmed: boolean
@@ -754,9 +754,9 @@ export class Accounts {
 
           // Otherwise, push the note into the list of notes to spend
           this.logger.debug(
-            `Accounts: spending note ${unspentNote.index} ${
-              unspentNote.hash
-            } ${unspentNote.note.value()}`,
+            `Accounts: spending note ${unspentNote.index} ${unspentNote.hash.toString(
+              'hex',
+            )} ${unspentNote.note.value()}`,
           )
           notesToSpend.push({ note: unspentNote.note, witness: witness })
           amountNeeded -= unspentNote.note.value()


### PR DESCRIPTION
## Summary

- changes decryptedNotes key encoding to BufferEncoding
- changes decryptedNotes storage of nullifier from string to buffer
- updates wallet-2 migration for decryptedNotes

- changes noteHashesBySequence and nonChainNoteHashes to use BufferSets to store
  note hashes

## Testing Plan

- ran migrations on partially rescanned pool account
- compared output of `accounts:balance`, `accounts:notes`, `accounts:transactions` between current branch and `accounts-performance` branch

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
