### PR TITLE
fix #2066, allow chain backup

### DIFF
--- a/ironfish-cli/src/commands/backup.ts
+++ b/ironfish-cli/src/commands/backup.ts
@@ -121,7 +121,6 @@ export default class Backup extends IronfishCommand {
       region,
     })
 
-
     await S3Utils.uploadToBucket(
       s3,
       dest,


### PR DESCRIPTION
## Summary
Closes #2066 

The code for backup actually doesn't try to pass credentials, so this edits it to follow the pattern used in `snapshot.ts`, in which you can provide credentials via flag or via env vars and those will be passed into the `S3Client` constructor

## Testing Plan
Upload now works.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
