### PR TITLE
updates wallet to store transactions by hash with signature

### DIFF
--- a/ironfish/src/rpc/routes/accounts/utils.ts
+++ b/ironfish/src/rpc/routes/accounts/utils.ts
@@ -81,7 +81,7 @@ export function getTransactionNotes(
           owner,
           amount: Number(decryptedNote.value()),
           memo: decryptedNote.memo(),
-          transactionHash: transaction.hash().toString('hex'),
+          transactionHash: transaction.unsignedHash().toString('hex'),
           spent: decryptedNoteValue?.spent,
         })
       }

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -225,7 +225,7 @@ export class Account {
     params: SyncTransactionParams,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
-    const transactionHash = transaction.unsignedHash()
+    const transactionHash = transaction.hash()
     const blockHash = 'blockHash' in params ? params.blockHash : null
     const sequence = 'sequence' in params ? params.sequence : null
     let submittedSequence = 'submittedSequence' in params ? params.submittedSequence : null

--- a/ironfish/src/wallet/accounts.test.ts
+++ b/ironfish/src/wallet/accounts.test.ts
@@ -83,7 +83,7 @@ describe('Accounts', () => {
     })
 
     // Check that it was last broadcast at its added height
-    let invalidTxEntry = accountA.getTransaction(invalidTx.unsignedHash())
+    let invalidTxEntry = accountA.getTransaction(invalidTx.hash())
     expect(invalidTxEntry?.submittedSequence).toEqual(GENESIS_BLOCK_SEQUENCE)
 
     // Check that the TX is not rebroadcast but has it's sequence updated
@@ -94,7 +94,7 @@ describe('Accounts', () => {
     expect(broadcastSpy).toHaveBeenCalledTimes(0)
 
     // It should now be planned to be processed at head + 1
-    invalidTxEntry = accountA.getTransaction(invalidTx.unsignedHash())
+    invalidTxEntry = accountA.getTransaction(invalidTx.hash())
     expect(invalidTxEntry?.submittedSequence).toEqual(blockB2.header.sequence)
   }, 120000)
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -448,7 +448,7 @@ export class Accounts {
    * the related maps.
    */
   async removeTransaction(transaction: Transaction): Promise<void> {
-    const transactionHash = transaction.unsignedHash()
+    const transactionHash = transaction.hash()
 
     for (const account of this.accounts.values()) {
       await account.deleteTransaction(transactionHash, transaction)
@@ -817,7 +817,7 @@ export class Accounts {
     for (const account of this.accounts.values()) {
       for (const transactionInfo of account.getTransactions()) {
         const { transaction, blockHash, submittedSequence } = transactionInfo
-        const transactionHash = transaction.unsignedHash()
+        const transactionHash = transaction.hash()
 
         // Skip transactions that are already added to a block
         if (blockHash) {


### PR DESCRIPTION
## Summary

- updates transaction stores
- updates wallet 2 migration
- removes unnecessary extra deletes from old transaction store in migrations

there is an issue with this approach -- the block explorer uses unsigned hashes,
so the `accounts:transactions -t <hash>` command needs to loop through all of
an account's transactions to find one by unsigned hash.

## Testing Plan

ran migration, tested `accounts:notes`, `accounts:transactions`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
