### PR TITLE
retries 'rm' on chain database to address EBUSY errors

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -228,10 +228,8 @@ export default class Download extends IronfishCommand {
     CliUx.ux.action.start(
       `Moving snapshot from ${snapshotDatabasePath} to ${chainDatabasePath}`,
     )
-    if (await this.sdk.fileSystem.exists(chainDatabasePath)) {
-      // chainDatabasePath must be empty before renaming snapshot
-      await fsAsync.rm(chainDatabasePath, { recursive: true })
-    }
+    // chainDatabasePath must be empty before renaming snapshot
+    await fsAsync.rm(chainDatabasePath, { recursive: true, force: true, maxRetries: 10 })
     await fsAsync.rename(snapshotDatabasePath, chainDatabasePath)
     CliUx.ux.action.stop('done')
   }


### PR DESCRIPTION
## Summary

Windows users may run into EBUSY when running chain:download as the command
removes their existing chain database. increase the maxRetries from 0 to 10 to
try to get around this.

- sets maxRetries to 10
- users 'force' to ignore errors when the path does not exist instead of
  checking for the path first

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
