### PR TITLE
use current block for newBlock

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -864,6 +864,7 @@ export class Blockchain {
     userTransactions: Transaction[],
     minersFee: Transaction,
     graffiti?: Buffer,
+    headBlock?: Block
   ): Promise<Block> {
     const transactions = [minersFee, ...userTransactions]
     return await this.db.transaction(async (tx) => {
@@ -880,7 +881,7 @@ export class Blockchain {
         previousSequence = 0
         target = Target.maxTarget()
       } else {
-        const heaviestHead = this.head
+        const heaviestHead = headBlock ? headBlock.header : this.head
         if (
           originalNoteSize !== heaviestHead.noteCommitment.size ||
           originalNullifierSize !== heaviestHead.nullifierCommitment.size

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -131,6 +131,7 @@ export class MiningManager {
       blockTransactions,
       minersFee,
       GraffitiUtils.fromString(this.node.config.get('blockGraffiti')),
+      currentBlock,
     )
 
     this.node.logger.debug(


### PR DESCRIPTION
## Summary
There may be `chain.head` modifications during the call to `createNewBlockTemplate` resulting in incorrect data in the new block template. An `invalid target` exception may occur on call `submitBlock`.

## Testing Plan
No.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
