### PR TITLE
Add error case in migration for nullifierToNote

### DIFF
--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -125,7 +125,7 @@ export class Migration013 extends Migration {
 
     logger.debug('Migrating: Checking nullifierToNote')
     start = BenchUtils.startSegment()
-    await this.checkNullifierToNote(stores, tx)
+    await this.checkNullifierToNote(stores, node, tx)
     logger.debug('\t' + BenchUtils.renderSegment(BenchUtils.endSegment(start)))
 
     await chainDb.close()
@@ -432,7 +432,11 @@ export class Migration013 extends Migration {
     return { unconfirmedBalances }
   }
 
-  private async checkNullifierToNote(stores: Stores, tx: IDatabaseTransaction) {
+  private async checkNullifierToNote(
+    stores: Stores,
+    node: IronfishNode,
+    tx: IDatabaseTransaction,
+  ) {
     let missing = 0
 
     for await (const noteHash of stores.new.nullifierToNoteHash.getAllValuesIter(tx)) {
@@ -445,7 +449,8 @@ export class Migration013 extends Migration {
 
     if (missing) {
       throw new Error(
-        `Your wallet is corrupt and missing ${missing} notes for nullifiers. You should delete your accounts database and run this again.`,
+        `Your wallet is corrupt and missing ${missing} notes for nullifiers.` +
+          ` If you have backed up your accounts, you should delete your accounts database at ${node.accounts.db.location} and run this again.`,
       )
     }
   }


### PR DESCRIPTION
## Summary
this adds an error case to the migration in case someone tries to migrate a corrupt wallet.

## Testing Plan
Run this with a corrupt wallet, and without.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
