### PR TITLE
Fix create account / scan race condition

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -925,15 +925,15 @@ export class Accounts {
     })
 
     await this.db.database.transaction(async (tx) => {
-      this.accounts.set(account.id, account)
       await this.db.setAccount(account, tx)
-
       await this.updateHeadHash(account, this.chainProcessor.hash, tx)
-
-      if (setDefault) {
-        await this.setDefaultAccount(account.name, tx)
-      }
     })
+
+    this.accounts.set(account.id, account)
+
+    if (setDefault) {
+      await this.setDefaultAccount(account.name)
+    }
 
     return account
   }


### PR DESCRIPTION
## Summary

There is a bug where we don't wait for the create account transaction to
complete before we insert the account into the in memory stores.

This leads to situations where an account is available to things like rescan,
but haven't been added to the database yet which we require. Because of the
awaits, it's possible to yield back to the code that will update the account
heads. This leads to crashes where you can load an account but it'll crash when
the headHashes table for that account is empty.

We need to wait for the TX to commit, before we expose it to in memory,
or set it as the default.

## Testing Plan
**How to Reproduce Crash**
1. Have a blockchain database with at least 10k blocks (or rescan will finish too fast)
2. Run your node with --verbose to see that it's rescanning
3. Create an account using `yarn start accounts:create test2`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
