### PR TITLE
Enable source maps in dev and prod

### DIFF
--- a/ironfish-cli/bin/ironfish
+++ b/ironfish-cli/bin/ironfish
@@ -43,8 +43,8 @@ else
   fi
 
   if [ "$IRONFISH_EXPOSE_GC" == "true" ]; then
-    "$NODE" "--expose-gc" "$DIR/run" "$@"
+    "$NODE" "--expose-gc" "--enable-source-maps" "$DIR/run" "$@"
   else
-    "$NODE" "$DIR/run" "$@"
+    "$NODE" "--enable-source-maps" "$DIR/run" "$@"
   fi
 fi

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -44,7 +44,7 @@
     "lint:fix": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
     "start:dev": "node start",
     "start": "yarn build && yarn start:js",
-    "start:js": "cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect --inspect-publish-uid=http bin/run",
+    "start:js": "cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect --inspect-publish-uid=http --enable-source-maps bin/run",
     "test": "yarn clean && tsc -b && tsc -b tsconfig.test.json && jest  --maxWorkers=1",
     "test:coverage:html": "tsc -b tsconfig.test.json && jest --coverage --coverage-reporters html --testPathIgnorePatterns",
     "test:watch": "tsc -b tsconfig.test.json && jest --watch --coverage false",


### PR DESCRIPTION
## Summary

Source maps weren't being used, but now they will be used. They are
already included in our production bundles.

## Testing Plan
1. Add `throw new Error('Hello World')` anywhere in the code base
2. Test using `yarn start ____`
3. Test using `./bin/ironfish ____`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
