### PR TITLE
Display stack when CLI crashes

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -11,6 +11,7 @@ import {
   RpcConnectionError,
 } from '@ironfish/sdk'
 import { Command, Config } from '@oclif/core'
+import { CLIError, ExitError } from '@oclif/core/lib/errors'
 import {
   ConfigFlagKey,
   DatabaseFlag,
@@ -76,10 +77,18 @@ export abstract class IronfishCommand extends Command {
     } catch (error: unknown) {
       if (hasUserResponseError(error)) {
         this.log(error.codeMessage)
+      } else if (error instanceof ExitError) {
+        throw error
+      } else if (error instanceof CLIError) {
+        throw error
       } else if (error instanceof RpcConnectionError) {
         this.log(`Cannot connect to your node, start your node first.`)
       } else if (error instanceof DatabaseVersionError) {
         this.log(error.message)
+        this.exit(1)
+      } else if (error instanceof Error) {
+        // eslint-disable-next-line no-console
+        console.error(ErrorUtils.renderError(error, true))
         this.exit(1)
       } else {
         throw error


### PR DESCRIPTION
## Summary

This will be helpful when debugging user's problems. The default oclif
error catcher does not do this unless debug mode is enabled.

We need to catch ExitError now because oclif throws an ExitError even if you use this.exit(0) to exit succesfully so we forward those into oclif now.

## Testing Plan

Add some `throw new Error()` and run the command to trigger it.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
