### PR TITLE
Throw sendTransaction error in deposit-all

### DIFF
--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -223,9 +223,9 @@ export default class DepositAll extends IronfishCommand {
 
           const transaction = result.content
           txs.push(transaction)
-        } catch (error: unknown) {
+        } catch (error) {
           screen.destroy()
-          process.exit(2)
+          throw error
         }
       }
 


### PR DESCRIPTION
## Summary

I noticed my depositAll would crash without an error. We now show the
error properly so it can be debugged.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
