### PR TITLE
deposit-all should not exit if balance changes

### DIFF
--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -232,6 +232,7 @@ export default class DepositAll extends IronfishCommand {
           ) {
             // Our balance changed while trying to create a payout, ignore this error
             await PromiseUtils.sleep(30000)
+            continue
           }
 
           screen.destroy()

--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -5,11 +5,13 @@
 import {
   Assert,
   displayIronAmountWithCurrency,
+  ERROR_CODES,
   ironToOre,
   MINIMUM_IRON_AMOUNT,
   oreToIron,
   PromiseUtils,
   RpcClient,
+  RpcRequestError,
   SendTransactionResponse,
   WebApi,
 } from '@ironfish/sdk'
@@ -224,6 +226,14 @@ export default class DepositAll extends IronfishCommand {
           const transaction = result.content
           txs.push(transaction)
         } catch (error) {
+          if (
+            error instanceof RpcRequestError &&
+            error.code === ERROR_CODES.INSUFFICIENT_BALANCE
+          ) {
+            // Our balance changed while trying to create a payout, ignore this error
+            await PromiseUtils.sleep(30000)
+          }
+
           screen.destroy()
           throw error
         }


### PR DESCRIPTION
## Summary

Before if balance changes while creating a transaction, it would crash
before.

## Testing Plan

Throw a `NotEnoughFundsError` inside of sendTransaction to trigger this.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
