### PR TITLE
filters nullifiers and transactions by account on load

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -116,9 +116,9 @@ export class Account {
 
       const transactionHash = decryptedNote.transactionHash
       const transaction = await this.accountsDb.loadTransaction(transactionHash)
-      Assert.isNotUndefined(
+      Assert.isNotNull(
         transaction,
-        `Transaction undefined for '${transactionHash.toString('hex')}'`,
+        `Transaction not found for '${transactionHash.toString('hex')}'`,
       )
 
       this.transactions.set(transactionHash, transaction)

--- a/ironfish/src/wallet/accounts.test.slow.ts
+++ b/ironfish/src/wallet/accounts.test.slow.ts
@@ -156,6 +156,20 @@ describe('Accounts', () => {
     // Create a second account
     const accountB = await node.accounts.createAccount('B', true)
 
+    // Account A should have one transaction
+    expect(Array.from(accountA.getTransactions()).length).toEqual(1)
+
+    // Account B should have zero transactions
+    expect(Array.from(accountB.getTransactions()).length).toEqual(0)
+
+    // Clear caches for both accounts
+    await accountA.reset()
+    await accountB.reset()
+
+    // Both accounts should have zero transactions
+    expect(Array.from(accountA.getTransactions()).length).toEqual(0)
+    expect(Array.from(accountB.getTransactions()).length).toEqual(0)
+
     // Load account data from db
     await node.accounts.loadAccountsFromDb()
 
@@ -196,6 +210,20 @@ describe('Accounts', () => {
 
     // Create a second account
     const accountB = await node.accounts.createAccount('B', true)
+
+    // Account A should have one nullifier
+    expect(accountA['nullifierToNoteHash'].size).toEqual(1)
+
+    // Account B should have zero nullifiers
+    expect(Array.from(accountB['nullifierToNoteHash']).length).toEqual(0)
+
+    // Clear caches for both accounts
+    await accountA.reset()
+    await accountB.reset()
+
+    // Both accounts should have zero nullifiers
+    expect(Array.from(accountA['nullifierToNoteHash']).length).toEqual(0)
+    expect(Array.from(accountB['nullifierToNoteHash']).length).toEqual(0)
 
     // Load account data from db
     await node.accounts.loadAccountsFromDb()
@@ -602,6 +630,7 @@ describe('Accounts', () => {
     })
 
     // Reload accounts to simulate node restart
+    await node.accounts['resetAccounts']()
     await node.accounts.loadAccountsFromDb()
 
     // Create a block with a miner's fee

--- a/ironfish/src/wallet/accounts.test.slow.ts
+++ b/ironfish/src/wallet/accounts.test.slow.ts
@@ -125,6 +125,88 @@ describe('Accounts', () => {
     })
   }, 600000)
 
+  it('Loads only the transactions that an account owns a note or spend nullifier for', async () => {
+    // Initialize the database and chain
+    const strategy = nodeTest.strategy
+    const node = nodeTest.node
+    const chain = nodeTest.chain
+
+    const accountA = await node.accounts.createAccount('A', true)
+
+    // Initial balance should be 0
+    await node.accounts.updateHead()
+    await expect(node.accounts.getBalance(accountA)).resolves.toEqual({
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
+    })
+
+    // Create a block with a miner's fee awarded to account A
+    const minersfee = await strategy.createMinersFee(BigInt(0), 2, accountA.spendingKey)
+    const newBlock = await chain.newBlock([], minersfee)
+    const addResult = await chain.addBlock(newBlock)
+    expect(addResult.isAdded).toBeTruthy()
+
+    // Account A should now have a balance of 2000000000 after adding the miner's fee
+    await node.accounts.updateHead()
+    await expect(node.accounts.getBalance(accountA)).resolves.toEqual({
+      confirmed: BigInt(2000000000),
+      unconfirmed: BigInt(2000000000),
+    })
+
+    // Create a second account
+    const accountB = await node.accounts.createAccount('B', true)
+
+    // Load account data from db
+    await node.accounts.loadAccountsFromDb()
+
+    // Account A should have one transaction
+    expect(Array.from(accountA.getTransactions()).length).toEqual(1)
+
+    // Account B should have zero transactions
+    expect(Array.from(accountB.getTransactions()).length).toEqual(0)
+  }, 600000)
+
+  it('Loads only the nullifiers that an account owns a note for', async () => {
+    // Initialize the database and chain
+    const strategy = nodeTest.strategy
+    const node = nodeTest.node
+    const chain = nodeTest.chain
+
+    const accountA = await node.accounts.createAccount('A', true)
+
+    // Initial balance should be 0
+    await node.accounts.updateHead()
+    await expect(node.accounts.getBalance(accountA)).resolves.toEqual({
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
+    })
+
+    // Create a block with a miner's fee awarded to account A
+    const minersfee = await strategy.createMinersFee(BigInt(0), 2, accountA.spendingKey)
+    const newBlock = await chain.newBlock([], minersfee)
+    const addResult = await chain.addBlock(newBlock)
+    expect(addResult.isAdded).toBeTruthy()
+
+    // Account A should now have a balance of 2000000000 after adding the miner's fee
+    await node.accounts.updateHead()
+    await expect(node.accounts.getBalance(accountA)).resolves.toEqual({
+      confirmed: BigInt(2000000000),
+      unconfirmed: BigInt(2000000000),
+    })
+
+    // Create a second account
+    const accountB = await node.accounts.createAccount('B', true)
+
+    // Load account data from db
+    await node.accounts.loadAccountsFromDb()
+
+    // Account A should have one nullifier
+    expect(accountA['nullifierToNoteHash'].size).toEqual(1)
+
+    // Account B should have zero nullifiers
+    expect(accountB['nullifierToNoteHash'].size).toEqual(0)
+  }, 600000)
+
   it('Lowers the balance after using pay to spend a note', async () => {
     // Initialize the database and chain
     const strategy = nodeTest.strategy
@@ -431,6 +513,96 @@ describe('Accounts', () => {
       confirmed: BigInt(0),
       unconfirmed: BigInt(1999999998),
     })
+
+    // Create a block with a miner's fee
+    const minersfee2 = await strategy.createMinersFee(
+      transaction.fee(),
+      newBlock.header.sequence + 1,
+      generateKey().spending_key,
+    )
+    const newBlock2 = await chain.newBlock([], minersfee2)
+    const addResult2 = await chain.addBlock(newBlock2)
+    expect(addResult2.isAdded).toBeTruthy()
+
+    // Expiring transactions should now remove the transaction
+    await node.accounts.updateHead()
+    await node.accounts.expireTransactions()
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+      confirmed: BigInt(2000000000),
+      unconfirmed: BigInt(2000000000),
+    })
+  }, 600000)
+
+  it('Expires transactions when calling expireTransactions with restarts', async () => {
+    // Initialize the database and chain
+    const strategy = nodeTest.strategy
+    const node = nodeTest.node
+    const chain = nodeTest.chain
+
+    const account = await node.accounts.createAccount('test', true)
+
+    // Create a second account
+    await node.accounts.createAccount('test2')
+
+    // Mock that accounts is started for the purposes of the test
+    node.accounts['isStarted'] = true
+
+    // Initial balance should be 0
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
+    })
+
+    // Balance after adding the genesis block should be 0
+    await node.accounts.updateHead()
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
+    })
+
+    // Create a block with a miner's fee
+    const minersfee = await strategy.createMinersFee(BigInt(0), 2, account.spendingKey)
+    const newBlock = await chain.newBlock([], minersfee)
+    const addResult = await chain.addBlock(newBlock)
+    expect(addResult.isAdded).toBeTruthy()
+
+    // Account should now have a balance of 2000000000 after adding the miner's fee
+    await node.accounts.updateHead()
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+      confirmed: BigInt(2000000000),
+      unconfirmed: BigInt(2000000000),
+    })
+
+    // Spend the balance, setting expiry soon
+    const transaction = await node.accounts.pay(
+      node.memPool,
+      account,
+      [
+        {
+          publicAddress: generateKey().public_address,
+          amount: BigInt(2),
+          memo: '',
+        },
+      ],
+      BigInt(0),
+      1,
+    )
+
+    // Transaction should be unconfirmed
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(1999999998),
+    })
+
+    // Expiring transactions should not yet remove the transaction
+    await node.accounts.expireTransactions()
+    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(1999999998),
+    })
+
+    // Reload accounts to simulate node restart
+    await node.accounts.loadAccountsFromDb()
 
     // Create a block with a miner's fee
     const minersfee2 = await strategy.createMinersFee(

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -298,15 +298,12 @@ export class AccountsDB {
   async loadTransaction(
     transactionHash: Buffer,
     tx?: IDatabaseTransaction,
-  ): Promise<
-    | {
-        transaction: Transaction
-        blockHash: Buffer | null
-        sequence: number | null
-        submittedSequence: number | null
-      }
-    | undefined
-  > {
+  ): Promise<{
+    transaction: Transaction
+    blockHash: Buffer | null
+    sequence: number | null
+    submittedSequence: number | null
+  } | null> {
     const transactionValue = await this.transactions.get(transactionHash, tx)
 
     if (transactionValue) {
@@ -315,6 +312,8 @@ export class AccountsDB {
         transaction: new Transaction(transactionValue.transaction),
       }
     }
+
+    return null
   }
 
   async saveNullifierNoteHash(


### PR DESCRIPTION
## Summary

fixes transaction expiration with multiple accounts

expiring transactions on a wallet with multiple accounts may fail with `Error:
nullifierToNote mappings must have a corresponding decryptedNote`.

expiring transactions deletes the transaction from all accounts in the wallet.
each account loads all transactions and all nullifiers from the database, but
loads only the decrypted notes that it owns. the error occurs when a transaction
uses a nullifier to try to load a decrypted note that it does not own.

the solution suggested here is for each account to load only the nullifiers that
correspond to decrypted notes that the account owns. along with filtering
nullifiers by account it makes sense to filter transactions by account.

- adds test of expiring transactions on node with multiple accounts
- builds nullifierToNoteHash mapping while loading notes
- reduces the nullifiers tracked by an account to only those that map to a
  decrypted note that belongs to that account.
- filters transactions by account to only those transactions where an account
  either owns a note that was spent in the transaction or a note output by the
  transaction.
- adds tests of loading transactions and nullifiers by account

- renames Accounts.removeTransaction to deleteTransaction to match Account
- refactors Account.deleteTransaction
        - renames merkleHash to noteHash
        - removes hash parameter, reads hash from transaction parameter

## Testing Plan

- adds unit tests
- run a local node with multiple accounts, send a transaction and have it expire without error

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
