### PR TITLE
separates clearing databases from replacing keys

### DIFF
--- a/ironfish/src/wallet/accounts.test.slow.ts
+++ b/ironfish/src/wallet/accounts.test.slow.ts
@@ -108,7 +108,9 @@ describe('Accounts', () => {
 
     await node.accounts.saveAccountsToDb()
 
-    await node.accounts['resetAccounts']()
+    for (const account of node.accounts.listAccounts()) {
+      await account.reset()
+    }
 
     // Account should now have a balance of 0 after clearing the cache
     await expect(node.accounts.getBalance(account)).resolves.toEqual({
@@ -165,7 +167,9 @@ describe('Accounts', () => {
 
     await node.accounts.saveAccountsToDb()
 
-    await node.accounts['resetAccounts']()
+    for (const account of node.accounts.listAccounts()) {
+      await account.reset()
+    }
 
     // Account should now have a balance of 0 after clearing the cache
     await expect(node.accounts.getBalance(accountA)).resolves.toEqual({
@@ -687,7 +691,9 @@ describe('Accounts', () => {
     })
 
     // Reload accounts to simulate node restart
-    await node.accounts['resetAccounts']()
+    for (const account of node.accounts.listAccounts()) {
+      await account.reset()
+    }
     await node.accounts.loadAccountsFromDb()
 
     // Create a block with a miner's fee

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -214,9 +214,7 @@ export class AccountsDB {
   }
 
   async removeHeadHashes(tx?: IDatabaseTransaction): Promise<void> {
-    await this.database.withTransaction(tx, async (tx) => {
-      await this.headHashes.clear(tx)
-    })
+    await this.headHashes.clear(tx)
   }
 
   async *loadHeadHashes(
@@ -253,9 +251,7 @@ export class AccountsDB {
   }
 
   async clearTransactions(tx?: IDatabaseTransaction): Promise<void> {
-    await this.database.withTransaction(tx, async (tx) => {
-      await this.transactions.clear(tx)
-    })
+    await this.transactions.clear(tx)
   }
 
   async replaceTransactions(
@@ -337,9 +333,7 @@ export class AccountsDB {
   }
 
   async clearNullifierToNoteHash(tx?: IDatabaseTransaction): Promise<void> {
-    await this.database.withTransaction(tx, async (tx) => {
-      await this.nullifierToNoteHash.clear(tx)
-    })
+    await this.nullifierToNoteHash.clear(tx)
   }
 
   async replaceNullifierToNoteHash(
@@ -370,9 +364,7 @@ export class AccountsDB {
   }
 
   async clearDecryptedNotes(tx?: IDatabaseTransaction): Promise<void> {
-    await this.database.withTransaction(tx, async (tx) => {
-      await this.decryptedNotes.clear(tx)
-    })
+    await this.decryptedNotes.clear(tx)
   }
 
   async replaceDecryptedNotes(

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -252,6 +252,12 @@ export class AccountsDB {
     })
   }
 
+  async clearTransactions(tx?: IDatabaseTransaction): Promise<void> {
+    await this.database.withTransaction(tx, async (tx) => {
+      await this.transactions.clear(tx)
+    })
+  }
+
   async replaceTransactions(
     map: BufferMap<{
       transaction: Transaction
@@ -262,8 +268,6 @@ export class AccountsDB {
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.database.withTransaction(tx, async (tx) => {
-      await this.transactions.clear(tx)
-
       for (const [key, value] of map) {
         const serialized = {
           ...value,
@@ -332,13 +336,17 @@ export class AccountsDB {
     })
   }
 
+  async clearNullifierToNoteHash(tx?: IDatabaseTransaction): Promise<void> {
+    await this.database.withTransaction(tx, async (tx) => {
+      await this.nullifierToNoteHash.clear(tx)
+    })
+  }
+
   async replaceNullifierToNoteHash(
     map: BufferMap<Buffer>,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.database.withTransaction(tx, async (tx) => {
-      await this.nullifierToNoteHash.clear(tx)
-
       for (const [key, value] of map) {
         await this.nullifierToNoteHash.put(key, value, tx)
       }
@@ -361,13 +369,17 @@ export class AccountsDB {
     })
   }
 
+  async clearDecryptedNotes(tx?: IDatabaseTransaction): Promise<void> {
+    await this.database.withTransaction(tx, async (tx) => {
+      await this.decryptedNotes.clear(tx)
+    })
+  }
+
   async replaceDecryptedNotes(
     map: BufferMap<DecryptedNoteValue>,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.database.withTransaction(tx, async (tx) => {
-      await this.decryptedNotes.clear(tx)
-
       for (const [key, value] of map) {
         await this.decryptedNotes.put(key, value, tx)
       }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -294,7 +294,9 @@ export class Accounts {
     await this.db.database.transaction(async (tx) => {
       await this.resetAccounts(tx)
       this.chainProcessor.hash = null
-      await this.saveAccountsToDb(tx)
+      await this.db.clearDecryptedNotes(tx)
+      await this.db.clearNullifierToNoteHash(tx)
+      await this.db.clearTransactions(tx)
       await this.updateHeadHashes(null, tx)
     })
   }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -294,14 +294,14 @@ export class Accounts {
     await this.db.database.transaction(async (tx) => {
       await this.resetAccounts(tx)
       this.chainProcessor.hash = null
-      await this.db.clearDecryptedNotes(tx)
-      await this.db.clearNullifierToNoteHash(tx)
-      await this.db.clearTransactions(tx)
       await this.updateHeadHashes(null, tx)
     })
   }
 
   private async resetAccounts(tx?: IDatabaseTransaction): Promise<void> {
+    await this.db.clearDecryptedNotes(tx)
+    await this.db.clearNullifierToNoteHash(tx)
+    await this.db.clearTransactions(tx)
     for (const account of this.accounts.values()) {
       await account.reset(tx)
     }


### PR DESCRIPTION
## Summary

the `replace*` methods in the wallet database clear all keys for a datastore
before setting the key-value pairs from a map passed to the method. however,
each map might only have key-value pairs for a single account in the wallet.
this results in clearing all decrypted notes from the database whenever an
account saves its decrypted notes map.

- adds test of saving and reloading with multiple accounts
- moves `clear` out of `replace*` methods into a separate method for each
  datastore
- uses `clear` in `Accounts.reset` instead of using `saveAccountsToDb` to clear
  keys from the database

## Testing Plan

- adds unit test to verify decryptedNotes aren't cleared by save from another account

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
