### PR TITLE
refactors wallet transaction deletion

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -443,14 +443,12 @@ export class Accounts {
   }
 
   /**
-   * Removes a transaction from the transaction map and updates
+   * Deletes a transaction from the transaction map and updates
    * the related maps.
    */
-  async removeTransaction(transaction: Transaction): Promise<void> {
-    const transactionHash = transaction.hash()
-
+  async deleteTransaction(transaction: Transaction): Promise<void> {
     for (const account of this.accounts.values()) {
-      await account.deleteTransaction(transactionHash, transaction)
+      await account.deleteTransaction(transaction)
     }
   }
 
@@ -900,7 +898,7 @@ export class Accounts {
         )
 
         if (isExpired) {
-          await this.removeTransaction(transaction)
+          await this.deleteTransaction(transaction)
         }
       }
     }


### PR DESCRIPTION
## Summary

- renames Accounts.removeTransaction to deleteTransaction to match Account
  method
- removes hash from deleteTransaction parameters, reads it from transaction
  passed to the method instead
- renames merkleHash to noteHash

## Testing Plan

purely cosmetic changes 💅 

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
