### PR TITLE
Add repl command to interact with the node

### DIFF
--- a/ironfish-cli/src/commands/repl.ts
+++ b/ironfish-cli/src/commands/repl.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { NodeUtils } from '@ironfish/sdk'
+import { NodeUtils, RpcMemoryClient } from '@ironfish/sdk'
 import fs from 'fs/promises'
 import repl from 'node:repl'
 import path from 'path'
@@ -30,6 +30,7 @@ export default class Repl extends IronfishCommand {
     await this.parse(Repl)
 
     const node = await this.sdk.node()
+    const client = new RpcMemoryClient(this.logger, node)
     await NodeUtils.waitForOpen(node)
 
     this.log('Examples:')
@@ -43,6 +44,8 @@ export default class Repl extends IronfishCommand {
     this.log(`  > accounts.listAccounts().map((a) => a.name)`)
     this.log(`\n  Get the balance of an account`)
     this.log(`  > await accounts.getBalance('default')`)
+    this.log(`\n  Use the RPC node/getStatus`)
+    this.log(`  > (await client.status()).content`)
     this.log('')
 
     const historyPath = path.join(node.config.tempDir, 'repl_history.txt')
@@ -52,6 +55,7 @@ export default class Repl extends IronfishCommand {
 
     const server = repl.start('> ')
     server.context.sdk = this.sdk
+    server.context.client = client
     server.context.node = node
     server.context.chain = node.chain
     server.context.accounts = node.accounts

--- a/ironfish-cli/src/commands/repl.ts
+++ b/ironfish-cli/src/commands/repl.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { NodeUtils } from '@ironfish/sdk'
+import fs from 'fs/promises'
+import repl from 'node:repl'
+import path from 'path'
+import { IronfishCommand } from '../command'
+import {
+  ConfigFlag,
+  ConfigFlagKey,
+  DataDirFlag,
+  DataDirFlagKey,
+  VerboseFlag,
+  VerboseFlagKey,
+} from '../flags'
+
+export const ENABLE_TELEMETRY_CONFIG_KEY = 'enableTelemetry'
+
+export default class Repl extends IronfishCommand {
+  static description = 'An interactive terminal to the node'
+
+  static flags = {
+    [VerboseFlagKey]: VerboseFlag,
+    [ConfigFlagKey]: ConfigFlag,
+    [DataDirFlagKey]: DataDirFlag,
+  }
+
+  async start(): Promise<void> {
+    await this.parse(Repl)
+
+    const node = await this.sdk.node()
+    await NodeUtils.waitForOpen(node)
+
+    this.log('Examples:')
+    this.log('  Get the head block hash')
+    this.log(`  > chain.head.hash.toString('hex')`)
+    this.log('\n  Get the head block sequence')
+    this.log(`  > chain.head.sequence`)
+    this.log('\n  Get a block at a sequence')
+    this.log(`  > await chain.getHeaderAtSequence(1)`)
+    this.log('\n  List all account names')
+    this.log(`  > accounts.listAccounts().map((a) => a.name)`)
+    this.log(`\n  Get the balance of an account`)
+    this.log(`  > await accounts.getBalance('default')`)
+    this.log('')
+
+    const historyPath = path.join(node.config.tempDir, 'repl_history.txt')
+    await fs.mkdir(node.config.tempDir, { recursive: true })
+    this.log(`Storing repl history at ${historyPath}`)
+    this.log('Type .exit or press CTRL+C to quit')
+
+    const server = repl.start('> ')
+    server.context.sdk = this.sdk
+    server.context.node = node
+    server.context.chain = node.chain
+    server.context.accounts = node.accounts
+    server.context.memPool = node.memPool
+
+    // Setup command history file
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    server.setupHistory(historyPath, () => {})
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    await new Promise(() => {})
+  }
+}

--- a/ironfish-cli/src/commands/repl.ts
+++ b/ironfish-cli/src/commands/repl.ts
@@ -15,8 +15,6 @@ import {
   VerboseFlagKey,
 } from '../flags'
 
-export const ENABLE_TELEMETRY_CONFIG_KEY = 'enableTelemetry'
-
 export default class Repl extends IronfishCommand {
   static description = 'An interactive terminal to the node'
 


### PR DESCRIPTION
## Summary

This adds a simple JS repl to interact with the node to read and test
data.

```bash
> ironfish repl

Examples:
  Get the head block hash
  > chain.head.hash.toString('hex')

  Get the head block sequence
  > chain.head.sequence

  Get a block at a sequence
  > await chain.getHeaderAtSequence(1)

  List all account names
  > accounts.listAccounts().map((a) => a.name)

  Get the balance of an account
  > await accounts.getBalance('default')

  Use the RPC node/getStatus
  > (await client.status()).content

Storing repl history at /Users/user/.ironfish/temp/repl_history.txt
Type .exit or press CTRL+C to quit

> await chain.getHeaderAtSequence(1)
BlockHeader {
  sequence: 1,
  previousBlockHash: <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>,
  noteCommitment: {
    commitment: <Buffer 42 23 ab 88 db bd 08 f6 bc ff 1c f6 17 71 b1 9b dd 60 71 4a fa 32 da 04 ab 5f e2 c1 58 40 13 32>,
    size: 3
  },
  nullifierCommitment: {
    commitment: <Buffer e2 48 4d 0b f3 8f 29 ef fd 63 ef 9d 5a 61 20 2f 19 81 29 86 2b 12 84 51 82 a4 ca 77 aa 55 7a 4b>,
    size: 1
  },
  target: Target {
    targetValue: 11579208923731619542357098500868790785326998466564056403945758400n
  },
  randomness: 0n,
  timestamp: 2022-05-10T15:12:53.568Z,
  minersFee: 0n,
  work: 10000000000000n,
  graffiti: <Buffer 67 65 6e 65 73 69 73 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>,
  hash: <Buffer 69 e2 63 e9 31 fa 1a 2a 4b 04 37 a8 ef f7 9f fb 7a 35 3b 63 84 a7 ae ac 9f 90 ac 12 ae 48 11 ef>
}
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
