### PR TITLE
changes headHashes to encode values as buffers

### DIFF
--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -93,7 +93,7 @@ export default class Debug extends IronfishCommand {
     await node.accounts.load()
     const output = new Map<string, string>()
 
-    const headHashes = new Map<string, string | null>()
+    const headHashes = new Map<string, Buffer | null>()
     for await (const { accountId, headHash } of node.accounts.db.loadHeadHashes()) {
       headHashes.set(accountId, headHash)
     }
@@ -101,9 +101,7 @@ export default class Debug extends IronfishCommand {
     for (const [accountId, headHash] of headHashes.entries()) {
       const account = node.accounts.getAccount(accountId)
 
-      const blockHeader = headHash
-        ? await node.chain.getHeader(Buffer.from(headHash, 'hex'))
-        : null
+      const blockHeader = headHash ? await node.chain.getHeader(headHash) : null
       const headInChain = !!blockHeader
       const headSequence = blockHeader?.sequence || 'null'
 
@@ -111,7 +109,10 @@ export default class Debug extends IronfishCommand {
 
       output.set(`Account ${shortId} uuid`, `${accountId}`)
       output.set(`Account ${shortId} name`, `${account?.name || `ACCOUNT NOT FOUND`}`)
-      output.set(`Account ${shortId} head hash`, `${headHash ?? 'NULL'}`)
+      output.set(
+        `Account ${shortId} head hash`,
+        `${headHash ? headHash.toString('hex') : 'NULL'}`,
+      )
       output.set(`Account ${shortId} head in chain`, `${headInChain.toString()}`)
       output.set(`Account ${shortId} sequence`, `${headSequence}`)
     }

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -211,7 +211,11 @@ export class Migration013 extends Migration {
 
     for (const account of accounts) {
       logger.debug(`\tSetting account ${account.account.name} head hash: ${String(headHash)}`)
-      await headHashesStoreNew.put(account.id, headHash ?? null, tx)
+      await headHashesStoreNew.put(
+        account.id,
+        headHash ? Buffer.from(headHash, 'hex') : null,
+        tx,
+      )
     }
   }
 

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -207,15 +207,12 @@ export class Migration013 extends Migration {
     tx: IDatabaseTransaction,
     logger: Logger,
   ): Promise<void> {
-    const headHash = await metaStoreOld.get('headHash', tx)
+    const headHashHex = await metaStoreOld.get('headHash', tx)
+    const headHash = headHashHex ? Buffer.from(headHashHex, 'hex') : null
 
     for (const account of accounts) {
       logger.debug(`\tSetting account ${account.account.name} head hash: ${String(headHash)}`)
-      await headHashesStoreNew.put(
-        account.id,
-        headHash ? Buffer.from(headHash, 'hex') : null,
-        tx,
-      )
+      await headHashesStoreNew.put(account.id, headHash, tx)
     }
   }
 

--- a/ironfish/src/migrations/data/013-wallet-2/new/headHashes.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/headHashes.ts
@@ -6,5 +6,5 @@ import { IDatabaseStore } from '../../../../storage'
 
 export type HeadHashesStore = IDatabaseStore<{
   key: string
-  value: string | null
+  value: Buffer | null
 }>

--- a/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
@@ -7,7 +7,7 @@ import {
   BUFFER_ENCODING,
   BufferEncoding,
   IDatabase,
-  NullableStringEncoding,
+  NullableBufferEncoding,
   StringEncoding,
 } from '../../../../storage'
 import { AccountsStore, AccountValue, AccountValueEncoding } from './accounts'
@@ -42,7 +42,7 @@ export function loadNewStores(db: IDatabase): NewStores {
     {
       name: 'headHashes',
       keyEncoding: new StringEncoding(),
-      valueEncoding: new NullableStringEncoding(),
+      valueEncoding: new NullableBufferEncoding(),
     },
     false,
   )

--- a/ironfish/src/storage/database/encoding.ts
+++ b/ironfish/src/storage/database/encoding.ts
@@ -37,6 +37,29 @@ export class BufferEncoding implements IDatabaseEncoding<Buffer> {
   deserialize = (buffer: Buffer): Buffer => buffer
 }
 
+export class NullableBufferEncoding implements IDatabaseEncoding<Buffer | null> {
+  serialize = (value: Buffer | null): Buffer => {
+    const size = value ? bufio.sizeVarBytes(value) : 0
+
+    const buffer = bufio.write(size)
+    if (value) {
+      buffer.writeVarBytes(value)
+    }
+
+    return buffer.render()
+  }
+
+  deserialize(buffer: Buffer): Buffer | null {
+    const reader = bufio.read(buffer, true)
+
+    if (reader.left()) {
+      return reader.readVarBytes()
+    }
+
+    return null
+  }
+}
+
 export class StringHashEncoding implements IDatabaseEncoding<string> {
   serialize(value: string): Buffer {
     const buffer = bufio.write(32)

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -523,7 +523,7 @@ export class Account {
     await this.accountsDb.saveUnconfirmedBalance(this, balance, tx)
   }
 
-  async getHeadHash(tx?: IDatabaseTransaction): Promise<string | null> {
+  async getHeadHash(tx?: IDatabaseTransaction): Promise<Buffer | null> {
     return this.accountsDb.getHeadHash(this, tx)
   }
 }

--- a/ironfish/src/wallet/accounts.test.ts
+++ b/ironfish/src/wallet/accounts.test.ts
@@ -103,7 +103,6 @@ describe('Accounts', () => {
       const { node } = nodeTest
 
       const newHeadHash = Buffer.alloc(32, 1)
-      const newHeadHashHex = newHeadHash.toString('hex')
 
       const accountA = await useAccountFixture(node.accounts, 'accountA')
       const accountB = await useAccountFixture(node.accounts, 'accountB')
@@ -113,8 +112,8 @@ describe('Accounts', () => {
       await node.accounts.updateHeadHashes(newHeadHash)
 
       expect(saveHeadHashSpy).toHaveBeenCalledTimes(2)
-      expect(saveHeadHashSpy).toHaveBeenNthCalledWith(1, accountA, newHeadHashHex, undefined)
-      expect(saveHeadHashSpy).toHaveBeenNthCalledWith(2, accountB, newHeadHashHex, undefined)
+      expect(saveHeadHashSpy).toHaveBeenNthCalledWith(1, accountA, newHeadHash, undefined)
+      expect(saveHeadHashSpy).toHaveBeenNthCalledWith(2, accountB, newHeadHash, undefined)
     })
   })
 
@@ -140,7 +139,7 @@ describe('Accounts', () => {
       let headStatusB = node.accounts['headHashes'].get(accountB.id)
 
       // Confirm pre-rescan state
-      expect(headStatusA).toEqual(blockB.header.hash.toString('hex'))
+      expect(headStatusA).toEqual(blockB.header.hash)
       expect(headStatusB).toEqual(null)
 
       await node.accounts.scanTransactions()
@@ -148,8 +147,8 @@ describe('Accounts', () => {
       headStatusA = node.accounts['headHashes'].get(accountA.id)
       headStatusB = node.accounts['headHashes'].get(accountB.id)
 
-      expect(headStatusA).toEqual(blockB.header.hash.toString('hex'))
-      expect(headStatusB).toEqual(blockB.header.hash.toString('hex'))
+      expect(headStatusA).toEqual(blockB.header.hash)
+      expect(headStatusB).toEqual(blockB.header.hash)
     })
 
     it('should rescan and update chain processor', async () => {
@@ -252,8 +251,8 @@ describe('Accounts', () => {
       const blockB = await useMinerBlockFixture(node.chain, 3, accountA)
       await node.chain.addBlock(blockB)
 
-      node.accounts['headHashes'].set(accountA.id, blockA.header.hash.toString('hex'))
-      node.accounts['headHashes'].set(accountB.id, blockB.header.hash.toString('hex'))
+      node.accounts['headHashes'].set(accountA.id, blockA.header.hash)
+      node.accounts['headHashes'].set(accountB.id, blockB.header.hash)
       node.accounts['headHashes'].set(accountC.id, null)
 
       expect(await node.accounts.getEarliestHeadHash()).toEqual(null)
@@ -274,8 +273,8 @@ describe('Accounts', () => {
       const blockB = await useMinerBlockFixture(node.chain, 3, accountA)
       await node.chain.addBlock(blockB)
 
-      node.accounts['headHashes'].set(accountA.id, blockA.header.hash.toString('hex'))
-      node.accounts['headHashes'].set(accountB.id, blockB.header.hash.toString('hex'))
+      node.accounts['headHashes'].set(accountA.id, blockA.header.hash)
+      node.accounts['headHashes'].set(accountB.id, blockB.header.hash)
       node.accounts['headHashes'].set(accountC.id, null)
 
       expect(await node.accounts.getLatestHeadHash()).toEqual(blockB.header.hash)
@@ -304,7 +303,7 @@ describe('Accounts', () => {
 
       const headStatusA = node.accounts['headHashes'].get(accountA.id)
       const headStatusB = node.accounts['headHashes'].get(accountB.id)
-      expect(headStatusA).toEqual(blockB.header.hash.toString('hex'))
+      expect(headStatusA).toEqual(blockB.header.hash)
       expect(headStatusB).toEqual(null)
     })
   })

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -12,7 +12,7 @@ import {
   IDatabase,
   IDatabaseStore,
   IDatabaseTransaction,
-  NullableStringEncoding,
+  NullableBufferEncoding,
   StringEncoding,
 } from '../../storage'
 import { createDB } from '../../storage/utils'
@@ -44,7 +44,7 @@ export class AccountsDB {
 
   headHashes: IDatabaseStore<{
     key: string
-    value: string | null
+    value: Buffer | null
   }>
 
   balances: IDatabaseStore<{
@@ -89,11 +89,11 @@ export class AccountsDB {
 
     this.headHashes = this.database.addStore<{
       key: string
-      value: string | null
+      value: Buffer | null
     }>({
       name: 'headHashes',
       keyEncoding: new StringEncoding(),
-      valueEncoding: new NullableStringEncoding(),
+      valueEncoding: new NullableBufferEncoding(),
     })
 
     this.accounts = this.database.addStore<{ key: string; value: AccountValue }>({
@@ -189,7 +189,7 @@ export class AccountsDB {
     }
   }
 
-  async getHeadHash(account: Account, tx?: IDatabaseTransaction): Promise<string | null> {
+  async getHeadHash(account: Account, tx?: IDatabaseTransaction): Promise<Buffer | null> {
     return await this.database.withTransaction(tx, async (tx) => {
       const headHash = await this.headHashes.get(account.id, tx)
       Assert.isNotUndefined(headHash)
@@ -199,7 +199,7 @@ export class AccountsDB {
 
   async saveHeadHash(
     account: Account,
-    headHash: string | null,
+    headHash: Buffer | null,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.database.withTransaction(tx, async (tx) => {
@@ -219,7 +219,7 @@ export class AccountsDB {
 
   async *loadHeadHashes(
     tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{ accountId: string; headHash: string | null }, void, unknown> {
+  ): AsyncGenerator<{ accountId: string; headHash: Buffer | null }, void, unknown> {
     for await (const [accountId, headHash] of this.headHashes.getAllIter(tx)) {
       yield { accountId, headHash }
     }


### PR DESCRIPTION
## Summary

makes storage of hashes consistent with other wallet datastores.

- defines NullableBufferEncoding
- updates wallet-2 migration

## Testing Plan

ran migration
ran some accounts commands and verified output
ran the node and verified that account head hash progresses

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
