### PR TITLE
feat(rust): Add test for minting an asset after creating it

### DIFF
--- a/ironfish-rust/src/proofs/circuit/create_asset.rs
+++ b/ironfish-rust/src/proofs/circuit/create_asset.rs
@@ -170,7 +170,7 @@ mod test {
     use rand::{rngs::OsRng, Rng};
     use zcash_primitives::{
         constants::{GH_FIRST_BLOCK, NOTE_COMMITMENT_RANDOMNESS_GENERATOR},
-        pedersen_hash::{self, pedersen_hash},
+        pedersen_hash::{self},
     };
 
     use crate::{primitives::asset_type::AssetInfo, SaplingKey};

--- a/ironfish-rust/src/proofs/circuit/output.rs
+++ b/ironfish-rust/src/proofs/circuit/output.rs
@@ -6,19 +6,12 @@ use bellman::{Circuit, ConstraintSystem, SynthesisError};
 use jubjub::ExtendedPoint;
 use zcash_primitives::constants;
 
-use zcash_primitives::primitives::{PaymentAddress, ProofGenerationKey};
+use zcash_primitives::primitives::PaymentAddress;
 
 use bellman::gadgets::blake2s;
-use bellman::gadgets::boolean::{self, AllocatedBit, Boolean};
-use bellman::gadgets::multipack;
-use bellman::gadgets::num;
-use bellman::gadgets::Assignment;
-use zcash_proofs::circuit::ecc::EdwardsPoint;
+use bellman::gadgets::boolean::{self};
 use zcash_proofs::circuit::{ecc, pedersen_hash};
-use zcash_proofs::constants::{
-    NOTE_COMMITMENT_RANDOMNESS_GENERATOR, NULLIFIER_POSITION_GENERATOR,
-    PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR, VALUE_COMMITMENT_RANDOMNESS_GENERATOR,
-};
+use zcash_proofs::constants::NOTE_COMMITMENT_RANDOMNESS_GENERATOR;
 
 use crate::primitives::asset_type::AssetType;
 use crate::primitives::sapling::ValueCommitment;

--- a/ironfish-rust/src/proofs/circuit/sapling.rs
+++ b/ironfish-rust/src/proofs/circuit/sapling.rs
@@ -4,28 +4,14 @@
 //! The Sapling circuits.
 
 use ff::PrimeField;
-use group::Curve;
 
-use bellman::{Circuit, ConstraintSystem, SynthesisError};
+use bellman::{ConstraintSystem, SynthesisError};
 
-use jubjub::ExtendedPoint;
-use zcash_primitives::constants;
-
-use zcash_primitives::primitives::{PaymentAddress, ProofGenerationKey};
-
-use bellman::gadgets::blake2s;
 use bellman::gadgets::boolean::{self, AllocatedBit, Boolean};
-use bellman::gadgets::multipack;
-use bellman::gadgets::num;
-use bellman::gadgets::Assignment;
+use zcash_proofs::circuit::ecc;
 use zcash_proofs::circuit::ecc::EdwardsPoint;
-use zcash_proofs::circuit::{ecc, pedersen_hash};
-use zcash_proofs::constants::{
-    NOTE_COMMITMENT_RANDOMNESS_GENERATOR, NULLIFIER_POSITION_GENERATOR,
-    PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR, VALUE_COMMITMENT_RANDOMNESS_GENERATOR,
-};
+use zcash_proofs::constants::VALUE_COMMITMENT_RANDOMNESS_GENERATOR;
 
-use crate::primitives::asset_type::AssetType;
 use crate::primitives::sapling::ValueCommitment;
 
 pub const TREE_DEPTH: usize = zcash_primitives::sapling::SAPLING_COMMITMENT_TREE_DEPTH;

--- a/ironfish-rust/src/proofs/circuit/spend.rs
+++ b/ironfish-rust/src/proofs/circuit/spend.rs
@@ -1,5 +1,4 @@
 use ff::PrimeField;
-use group::Curve;
 
 use bellman::{Circuit, ConstraintSystem, SynthesisError};
 
@@ -9,15 +8,14 @@ use zcash_primitives::constants;
 use zcash_primitives::primitives::{PaymentAddress, ProofGenerationKey};
 
 use bellman::gadgets::blake2s;
-use bellman::gadgets::boolean::{self, AllocatedBit, Boolean};
+use bellman::gadgets::boolean::{self};
 use bellman::gadgets::multipack;
 use bellman::gadgets::num;
 use bellman::gadgets::Assignment;
-use zcash_proofs::circuit::ecc::EdwardsPoint;
 use zcash_proofs::circuit::{ecc, pedersen_hash};
 use zcash_proofs::constants::{
     NOTE_COMMITMENT_RANDOMNESS_GENERATOR, NULLIFIER_POSITION_GENERATOR,
-    PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR, VALUE_COMMITMENT_RANDOMNESS_GENERATOR,
+    PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR,
 };
 
 use crate::primitives::asset_type::AssetType;


### PR DESCRIPTION
## Summary

Test mint asset circuit with an asset created from the create asset circuit. This will still need to verify the witness path 

## Testing Plan

Added unit test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
