### PR TITLE
Prevent db tx from being used across databases

### DIFF
--- a/ironfish/src/indexers/minedBlocksIndexer.ts
+++ b/ironfish/src/indexers/minedBlocksIndexer.ts
@@ -145,7 +145,7 @@ export class MinedBlocksIndexer {
     this.chainProcessor.onRemove.on(async (header) => {
       await this.database.transaction(async (tx) => {
         if (await this.minedBlocks.has(header.hash, tx)) {
-          const block = await this.chain.getBlock(header, tx)
+          const block = await this.chain.getBlock(header)
           Assert.isNotNull(block)
 
           const account = this.accounts.listAccounts().find((a) => isBlockMine(block, a))

--- a/ironfish/src/storage/database/errors.ts
+++ b/ironfish/src/storage/database/errors.ts
@@ -2,6 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+export class TransactionWrongDatabaseError extends Error {
+  constructor(store: string) {
+    super(`Wrong transaction database when using store ${store}`)
+  }
+}
+
 export class DuplicateKeyError extends Error {}
 
 export class DatabaseOpenError extends Error {


### PR DESCRIPTION
## Summary

You cant use db transactions across code because they buffer reads /
writes that then get committed to the DB they were created for. That
means data from one DB will accidently get written to the wrong DB.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
