### PR TITLE
Remove duplicated commands from ironfish-cli.

### DIFF
--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -25,8 +25,7 @@ const REGISTER_URL = 'https://testnet.ironfish.network/signup'
 const IRON_TO_SEND = 0.1
 
 export default class DepositAll extends IronfishCommand {
-  static aliases = ['depositAll']
-  static description = 'Deposit $IRON for testnet points'
+  static description = 'Deposit all $IRON for testnet points'
 
   client: RpcClient | null = null
   api: WebApi | null = new WebApi()


### PR DESCRIPTION
Currently in help we see two commands deposit-all and depositAll which doing the same things.
```
  deposit-all  Deposit $IRON for testnet points
  depositAll   Deposit $IRON for testnet points
```
In the previous tasks were decided to use kebab-case instead of camelCase in commands.
After this change we will have only one command:
```
deposit-all  Deposit all $IRON for testnet points
```

## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ No ] 
```
