### PR TITLE
renames decrypted note fields for consistency

### DIFF
--- a/ironfish/src/wallet/database/decryptedNoteValue.test.ts
+++ b/ironfish/src/wallet/database/decryptedNoteValue.test.ts
@@ -10,7 +10,7 @@ describe('DecryptedNoteValueEncoding', () => {
 
       const value: DecryptedNoteValue = {
         accountId: 'uuid',
-        noteIndex: null,
+        index: null,
         nullifierHash: null,
         spent: false,
         serializedNote: Buffer.alloc(NOTE_SIZE, 1),
@@ -29,7 +29,7 @@ describe('DecryptedNoteValueEncoding', () => {
       const value: DecryptedNoteValue = {
         accountId: 'uuid',
         spent: true,
-        noteIndex: 40,
+        index: 40,
         nullifierHash: Buffer.alloc(32, 1),
         serializedNote: Buffer.alloc(NOTE_SIZE, 1),
         transactionHash: Buffer.alloc(32, 1),

--- a/ironfish/src/wallet/database/decryptedNoteValue.ts
+++ b/ironfish/src/wallet/database/decryptedNoteValue.ts
@@ -12,18 +12,17 @@ export interface DecryptedNoteValue {
   spent: boolean
   transactionHash: Buffer
   // These fields are populated once the note's transaction is on the main chain
-  noteIndex: number | null
+  index: number | null
   nullifierHash: Buffer | null
 }
 
 export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNoteValue> {
   serialize(value: DecryptedNoteValue): Buffer {
-    const { accountId, nullifierHash, noteIndex, serializedNote, spent, transactionHash } =
-      value
+    const { accountId, nullifierHash, index, serializedNote, spent, transactionHash } = value
     const bw = bufio.write(this.getSize(value))
 
     let flags = 0
-    flags |= Number(!!noteIndex) << 0
+    flags |= Number(!!index) << 0
     flags |= Number(!!nullifierHash) << 1
     flags |= Number(spent) << 2
     bw.writeU8(flags)
@@ -32,8 +31,8 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
     bw.writeBytes(serializedNote)
     bw.writeHash(transactionHash)
 
-    if (noteIndex) {
-      bw.writeU32(noteIndex)
+    if (index) {
+      bw.writeU32(index)
     }
     if (nullifierHash) {
       bw.writeHash(nullifierHash)
@@ -46,7 +45,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
     const reader = bufio.read(buffer, true)
 
     const flags = reader.readU8()
-    const hasNoteIndex = flags & (1 << 0)
+    const hasIndex = flags & (1 << 0)
     const hasNullifierHash = flags & (1 << 1)
     const spent = Boolean(flags & (1 << 2))
 
@@ -54,9 +53,9 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
     const serializedNote = reader.readBytes(NOTE_SIZE)
     const transactionHash = reader.readHash()
 
-    let noteIndex = null
-    if (hasNoteIndex) {
-      noteIndex = reader.readU32()
+    let index = null
+    if (hasIndex) {
+      index = reader.readU32()
     }
 
     let nullifierHash = null
@@ -64,7 +63,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
       nullifierHash = reader.readHash()
     }
 
-    return { accountId, noteIndex, nullifierHash, serializedNote, spent, transactionHash }
+    return { accountId, index, nullifierHash, serializedNote, spent, transactionHash }
   }
 
   getSize(value: DecryptedNoteValue): number {
@@ -73,7 +72,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
     // transaction hash
     size += 32
 
-    if (value.noteIndex) {
+    if (value.index) {
       size += 4
     }
     if (value.nullifierHash) {

--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -34,7 +34,7 @@ describe('DecryptNotesResponse', () => {
         {
           forSpender: false,
           index: 1,
-          merkleHash: Buffer.alloc(32, 1),
+          hash: Buffer.alloc(32, 1),
           nullifier: Buffer.alloc(32, 1),
           serializedNote: Buffer.alloc(NOTE_LENGTH, 1),
         },
@@ -75,7 +75,7 @@ describe('DecryptNotesTask', () => {
             forSpender: false,
             index,
             nullifier: expect.any(Buffer),
-            merkleHash: expect.any(Buffer),
+            hash: expect.any(Buffer),
             serializedNote: expect.any(Buffer),
           },
         ],

--- a/ironfish/src/workerPool/tasks/decryptNotes.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.ts
@@ -19,7 +19,7 @@ export interface DecryptNoteOptions {
 export interface DecryptedNote {
   index: number | null
   forSpender: boolean
-  merkleHash: Buffer
+  hash: Buffer
   nullifier: Buffer | null
   serializedNote: Buffer
 }
@@ -120,7 +120,7 @@ export class DecryptNotesResponse extends WorkerMessage {
         flags |= Number(!!note.nullifier) << 1
         flags |= Number(note.forSpender) << 2
         bw.writeU8(flags)
-        bw.writeHash(note.merkleHash)
+        bw.writeHash(note.hash)
         bw.writeBytes(note.serializedNote)
 
         if (note.index) {
@@ -152,7 +152,7 @@ export class DecryptNotesResponse extends WorkerMessage {
       const hasIndex = flags & (1 << 0)
       const hasNullifier = flags & (1 << 1)
       const forSpender = Boolean(flags & (1 << 2))
-      const merkleHash = reader.readHash()
+      const hash = reader.readHash()
       const serializedNote = reader.readBytes(NOTE_LENGTH)
 
       let index = null
@@ -168,7 +168,7 @@ export class DecryptNotesResponse extends WorkerMessage {
       notes.push({
         forSpender,
         index,
-        merkleHash,
+        hash,
         nullifier,
         serializedNote,
       })
@@ -228,7 +228,7 @@ export class DecryptNotesTask extends WorkerTask {
         decryptedNotes.push({
           index: currentNoteIndex,
           forSpender: false,
-          merkleHash: note.merkleHash(),
+          hash: note.merkleHash(),
           nullifier:
             currentNoteIndex !== null
               ? receivedNote.nullifier(spendingKey, BigInt(currentNoteIndex))
@@ -244,7 +244,7 @@ export class DecryptNotesTask extends WorkerTask {
         decryptedNotes.push({
           index: currentNoteIndex,
           forSpender: true,
-          merkleHash: note.merkleHash(),
+          hash: note.merkleHash(),
           nullifier: null,
           serializedNote: spentNote.serialize(),
         })


### PR DESCRIPTION
## Summary

DecryptedNote deserialized from worker tasks is very similar to
DecryptedNoteValue. these changes rename 'merkleHash' in DecryptedNote to 'hash'
and rename 'noteIndex' in DecryptedNoteValue to 'index'. some additional
refactoring of syncTransaction (removing account from parameters and return
values of decryptNotesFromTransaction) allows us to use the DecryptedNote type
in place of anonymous types in the wallet.

- renames merkleHash to hash
- renames noteIndex to index
- uses DecryptedNote type instead of anonymous types

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
