### PR TITLE
Move transaction to protectedNamespaces for rpc.tcp

### DIFF
--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -25,7 +25,11 @@ export enum ApiNamespace {
   rpc = 'rpc',
 }
 
-export const API_NAMESPACES_PROTECTED = [ApiNamespace.account, ApiNamespace.config]
+export const API_NAMESPACES_PROTECTED = [
+  ApiNamespace.account,
+  ApiNamespace.config,
+  ApiNamespace.transaction,
+]
 export const ALL_API_NAMESPACES = StrEnumUtils.getValues(ApiNamespace)
 
 export type RouteHandler<TRequest = unknown, TResponse = unknown> = (


### PR DESCRIPTION
## Summary
Transaction route should be protected since IRON token can be sent via transaction/sendTransaction directly.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
