### PR TITLE
Re-allow invalid spends into mempool and accounts

### DIFF
--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -170,7 +170,14 @@ export class Verifier {
 
         // If the spend references a larger tree size, allow it, so it's possible to
         // store transactions made while the node is a few blocks behind
-        if (result && result !== VerificationResultReason.NOTE_COMMITMENT_SIZE_TOO_LARGE) {
+        // TODO: We're allowing invalid spends currently because we're often creating
+        // spends with tree size + root at the head of the chain, rather than a reasonable confirmation
+        // range back. These blocks (and spends) can eventually become valid if the chain forks to them.
+        if (
+          result &&
+          result !== VerificationResultReason.NOTE_COMMITMENT_SIZE_TOO_LARGE &&
+          result !== VerificationResultReason.INVALID_SPEND
+        ) {
           return result
         }
       }


### PR DESCRIPTION
## Summary

#2037 added additional verification to new transactions to check their spends. For now, we want to allow spends with INVALID_SPEND error into accounts + mempool because we're often creating spends with tree size and root at the head of the chain, rather than a reasonable confirmation range behind it. These blocks (and spends) can become valid if the chain forks to them.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
