### PR TITLE
Store all test data in the repo

### DIFF
--- a/ironfish-cli/jest.setup.js
+++ b/ironfish-cli/jest.setup.js
@@ -1,9 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 const fs = require('fs')
+const path = require('path')
+
+const TEST_DATA_DIR = path.join(process.cwd(), 'testdbs')
 
 module.exports = async () => {
-  if (fs.existsSync('./testdbs')) {
-    fs.rmSync('./testdbs', { recursive: true })
+  if (fs.existsSync(TEST_DATA_DIR)) {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true })
   }
 
-  fs.mkdirSync('./testdbs')
+  fs.mkdirSync(TEST_DATA_DIR)
 }

--- a/ironfish/jest.setup.js
+++ b/ironfish/jest.setup.js
@@ -2,11 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 const fs = require('fs')
+const path = require('path')
+
+const TEST_DATA_DIR = path.join(process.cwd(), 'testdbs')
 
 module.exports = async () => {
-  if (fs.existsSync('./testdbs')) {
-    fs.rmSync('./testdbs', { recursive: true })
+  if (fs.existsSync(TEST_DATA_DIR)) {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true })
   }
 
-  fs.mkdirSync('./testdbs')
+  fs.mkdirSync(TEST_DATA_DIR)
 }

--- a/ironfish/src/index.test.ts
+++ b/ironfish/src/index.test.ts
@@ -1,6 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-it('should test the CLI', () => {
-  expect(true).toBe(true)
-})

--- a/ironfish/src/storage/database.test.ts
+++ b/ironfish/src/storage/database.test.ts
@@ -5,6 +5,7 @@
 import leveldown from 'leveldown'
 import { v4 as uuid } from 'uuid'
 import { IJsonSerializable } from '../serde'
+import { getUniqueTestDataDir } from '../testUtilities'
 import { PromiseUtils } from '../utils'
 import {
   ArrayEncoding,
@@ -702,7 +703,6 @@ describe('Database', () => {
 })
 
 function createDB() {
-  const id = `./testdbs/${Math.round(Math.random() * Number.MAX_SAFE_INTEGER)}`
-  const db = new LevelupDatabase(leveldown(id))
-  return db
+  const path = getUniqueTestDataDir()
+  return new LevelupDatabase(leveldown(path))
 }

--- a/ironfish/src/testUtilities/helpers/storage.ts
+++ b/ironfish/src/testUtilities/helpers/storage.ts
@@ -8,6 +8,7 @@ import path from 'path'
 import { v4 as uuid } from 'uuid'
 import { IDatabase, LevelupDatabase } from '../../storage'
 import { createDB as createDBStorage } from '../../storage/utils'
+import { TEST_DATA_DIR } from '../utils'
 
 /** Generate a test database name from the given test if not provided*/
 export function makeDbName(): string {
@@ -19,14 +20,14 @@ export function makeDb(name?: string): IDatabase {
   if (!name) {
     name = makeDbName()
   }
-  return new LevelupDatabase(leveldown(`./testdbs/${name}`))
+  return new LevelupDatabase(leveldown(`${TEST_DATA_DIR}/${name}`))
 }
 
 export function makeDbPath(name?: string): string {
   if (!name) {
     name = makeDbName()
   }
-  return `./testdbs/${name}`
+  return `${TEST_DATA_DIR}/${name}`
 }
 
 export async function createTestDB(

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -15,6 +15,7 @@ import { IronfishSdk } from '../sdk'
 import { Syncer } from '../syncer'
 import { WorkerPool } from '../workerPool'
 import { TestStrategy } from './strategy'
+import { getUniqueTestDataDir } from './utils'
 
 export type NodeTestOptions =
   | {
@@ -71,7 +72,7 @@ export class NodeTest {
       options = this.options
     }
 
-    const dataDir = path.join(os.tmpdir(), uuid())
+    const dataDir = getUniqueTestDataDir()
     const strategyClass = TestStrategy
 
     const sdk = await IronfishSdk.init({ dataDir, strategyClass })

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import './matchers'
-import os from 'os'
-import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { Accounts } from '../account'
 import { Blockchain } from '../blockchain'
 import { Verifier } from '../consensus/verifier'

--- a/ironfish/src/testUtilities/utils.ts
+++ b/ironfish/src/testUtilities/utils.ts
@@ -1,6 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import path from 'path'
+import { v4 as uuid } from 'uuid'
+
+export const TEST_DATA_DIR = path.join(process.cwd(), 'testdbs')
 
 /**
  * This is only usable in the jasmine runner
@@ -10,6 +14,10 @@ export function getCurrentTestPath(): string {
   const jasmineAny = global.jasmine as any
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   return jasmineAny.testPath as string
+}
+
+export function getUniqueTestDataDir(): string {
+  return path.join(TEST_DATA_DIR, uuid())
 }
 
 /**


### PR DESCRIPTION
## Summary

This was taking up all the system storage, and not getting cleaned up.
This now stores all test node data directories inside of /testdbs with
our other data. This directory gets deleted at the start of each run.

## Testing Plan

Run tests, and check ./testdbs

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
