### PR TITLE
Add key ranges to all range based DB ops

### DIFF
--- a/ironfish/src/storage/database.test.ts
+++ b/ironfish/src/storage/database.test.ts
@@ -16,6 +16,7 @@ import {
   StringEncoding,
   TransactionWrongDatabaseError,
 } from './database'
+import { StorageUtils } from './database/utils'
 import { LevelupDatabase, LevelupStore } from './levelup'
 
 type FooValue = {
@@ -65,13 +66,6 @@ describe('Database', () => {
 
   const bazStore = db.addStore<BazSchema>({
     name: 'Baz',
-    keyEncoding: new BufferEncoding(),
-    valueEncoding: new StringEncoding(),
-  })
-
-  // Prefix key is modified during tests, don't use in other tests
-  const testPrefixKeyStore = db.addStore<BazSchema>({
-    name: 'PrefixKey',
     keyEncoding: new BufferEncoding(),
     valueEncoding: new StringEncoding(),
   })
@@ -145,6 +139,7 @@ describe('Database', () => {
 
   it('should clear store', async () => {
     await db.open()
+
     const foo = { hash: 'hello', name: '@ironfish/sdk' }
     const fooHash = Buffer.from(JSON.stringify(foo))
 
@@ -158,6 +153,22 @@ describe('Database', () => {
 
     expect(await fooStore.get('hello')).not.toBeDefined()
     expect(await barStore.get('hello')).toEqual(fooHash)
+  })
+
+  it('should clear store in a range', async () => {
+    await db.open()
+
+    await testStore.clear()
+    await testStore.put('1', 1)
+    await testStore.put('2a', 2)
+    await testStore.put('2b', 3)
+    await testStore.put('3', 4)
+
+    const clearRange = StorageUtils.getPrefixKeyRange(Buffer.from('2'))
+
+    expect(await testStore.getAllKeys()).toMatchObject(['1', '2a', '2b', '3'])
+    await testStore.clear(undefined, clearRange)
+    expect(await testStore.getAllKeys()).toMatchObject(['1', '3'])
   })
 
   it('should clear store in a transaction', async () => {
@@ -179,6 +190,24 @@ describe('Database', () => {
     await tx.commit()
 
     expect(await testStore.get('hello')).not.toBeDefined()
+  })
+
+  it('should clear store in a transaction in a range', async () => {
+    await db.open()
+
+    await db.transaction(async (tx) => {
+      await testStore.clear(tx)
+      await testStore.put('1', 1, tx)
+      await testStore.put('2a', 2, tx)
+      await testStore.put('2b', 3, tx)
+      await testStore.put('3', 3, tx)
+
+      const clearRange = StorageUtils.getPrefixKeyRange(Buffer.from('2'))
+
+      await expect(testStore.getAllKeys(tx)).resolves.toMatchObject(['1', '2a', '2b', '3'])
+      await testStore.clear(tx, clearRange)
+      await expect(testStore.getAllKeys(tx)).resolves.toMatchObject(['1', '3'])
+    })
   })
 
   it('should add values', async () => {
@@ -578,29 +607,41 @@ describe('Database', () => {
   })
 
   describe('DatabaseStore: key and value streams', () => {
-    it('should get all keys', async () => {
+    it('should get all keys and values', async () => {
       await db.open()
+
       await db.metaStore.clear()
       await db.metaStore.put('a', 1000)
       await db.metaStore.put('b', 1001)
       await db.metaStore.put('c', 1002)
       await db.metaStore.put('d', 1003)
 
-      const values = await db.metaStore.getAllValues()
+      await expect(db.metaStore.getAllKeys()).resolves.toMatchObject(['a', 'b', 'c', 'd'])
+      await expect(db.metaStore.getAllValues()).resolves.toMatchObject([1000, 1001, 1002, 1003])
+    })
 
-      expect(values).toHaveLength(4)
-      expect(values).toContain(1000)
-      expect(values).toContain(1001)
-      expect(values).toContain(1002)
-      expect(values).toContain(1003)
+    it('should get all keys and values in a range', async () => {
+      await db.open()
 
-      const keys = await db.metaStore.getAllKeys()
+      await db.metaStore.clear()
+      await db.metaStore.put('a', 1000)
+      await db.metaStore.put('b', 1001)
+      await db.metaStore.put('c', 1002)
+      await db.metaStore.put('d', 1003)
 
-      expect(keys).toHaveLength(4)
-      expect(keys).toContain('a')
-      expect(keys).toContain('b')
-      expect(keys).toContain('c')
-      expect(keys).toContain('d')
+      await expect(
+        db.metaStore.getAllValues(undefined, {
+          gte: Buffer.from('b'),
+          lt: Buffer.from('d'),
+        }),
+      ).resolves.toMatchObject([1001, 1002])
+
+      await expect(
+        db.metaStore.getAllKeys(undefined, {
+          gte: Buffer.from('b'),
+          lt: Buffer.from('d'),
+        }),
+      ).resolves.toMatchObject(['b', 'c'])
     })
 
     it('should encode and decode keys', async () => {
@@ -678,6 +719,12 @@ describe('Database', () => {
     })
 
     it('should not find entries with an off-by-one prefix and empty key', async () => {
+      const testPrefixKeyStore = db.addStore<BazSchema>({
+        name: 'PrefixKey',
+        keyEncoding: new BufferEncoding(),
+        valueEncoding: new StringEncoding(),
+      })
+
       await db.open()
       const keyStore = testPrefixKeyStore as LevelupStore<BazSchema>
       await keyStore.clear()

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -5,11 +5,17 @@
 import { BatchOperation, IDatabaseBatch } from './batch'
 import { IDatabaseStore, IDatabaseStoreOptions } from './store'
 import { IDatabaseTransaction } from './transaction'
-import { DatabaseOptions, DatabaseSchema, SchemaKey, SchemaValue } from './types'
+import {
+  DatabaseKeyRange,
+  DatabaseOptions,
+  DatabaseSchema,
+  SchemaKey,
+  SchemaValue,
+} from './types'
 
-export const DATABASE_ALL_KEY_RANGE = {
+export const DATABASE_ALL_KEY_RANGE: DatabaseKeyRange = {
   gte: Buffer.alloc(0, 0),
-  lte: Buffer.alloc(256, 255),
+  lt: Buffer.alloc(256, 255),
 }
 
 /**

--- a/ironfish/src/storage/database/store.ts
+++ b/ironfish/src/storage/database/store.ts
@@ -4,7 +4,13 @@
 
 import { UnwrapPromise } from '../../utils/types'
 import { IDatabaseTransaction } from './transaction'
-import { DatabaseSchema, IDatabaseEncoding, SchemaKey, SchemaValue } from './types'
+import {
+  DatabaseKeyRange,
+  DatabaseSchema,
+  IDatabaseEncoding,
+  SchemaKey,
+  SchemaValue,
+} from './types'
 
 export type IDatabaseStoreOptions<Schema extends DatabaseSchema> = {
   /** The unique name of the store inside of the database */
@@ -32,36 +38,49 @@ export interface IDatabaseStore<Schema extends DatabaseSchema> {
   /** The [[`IDatabaseEncoding`]] used to serialize values to store in the database */
   valueEncoding: IDatabaseEncoding<SchemaValue<Schema>>
 
-  encode(key: SchemaKey<Schema>): [Buffer]
+  encode(key: Readonly<SchemaKey<Schema>>): [Buffer]
 
   /**
    * Used to serialize the key and value for the database
    *
    * @returns An array with the serialized key and value as Buffers
    */
-  encode(key: SchemaKey<Schema>, value: SchemaValue<Schema>): [Buffer, Buffer]
+  encode(key: Readonly<SchemaKey<Schema>>, value: SchemaValue<Schema>): [Buffer, Buffer]
 
   /* Get an [[`AsyncGenerator`]] that yields all of the key/value pairs in the IDatastore */
   getAllIter(
     transaction?: IDatabaseTransaction,
+    keyRange?: DatabaseKeyRange,
   ): AsyncGenerator<[SchemaKey<Schema>, SchemaValue<Schema>]>
 
   /* Get an [[`AsyncGenerator`]] that yields all of the values in the IDatastore */
-  getAllValuesIter(transaction?: IDatabaseTransaction): AsyncGenerator<SchemaValue<Schema>>
+  getAllValuesIter(
+    transaction?: IDatabaseTransaction,
+    keyRange?: DatabaseKeyRange,
+  ): AsyncGenerator<SchemaValue<Schema>>
   /* Get all of the values in the IDatastore */
-  getAllValues(transaction?: IDatabaseTransaction): Promise<Array<SchemaValue<Schema>>>
+  getAllValues(
+    transaction?: IDatabaseTransaction,
+    keyRange?: DatabaseKeyRange,
+  ): Promise<Array<SchemaValue<Schema>>>
 
   /* Get an [[`AsyncGenerator`]] that yields all of the keys in the IDatastore */
-  getAllKeysIter(transaction?: IDatabaseTransaction): AsyncGenerator<SchemaKey<Schema>>
+  getAllKeysIter(
+    transaction?: IDatabaseTransaction,
+    keyRange?: DatabaseKeyRange,
+  ): AsyncGenerator<SchemaKey<Schema>>
   /* Get all of the keys in the IDatastore */
-  getAllKeys(transaction?: IDatabaseTransaction): Promise<Array<SchemaKey<Schema>>>
+  getAllKeys(
+    transaction?: IDatabaseTransaction,
+    keyRange?: DatabaseKeyRange,
+  ): Promise<Array<SchemaKey<Schema>>>
 
   /**
    * Delete every key in the {@link IDatastore}
    *
    * @returns resolves when all keys have been deleted
    */
-  clear(transaction?: IDatabaseTransaction): Promise<void>
+  clear(transaction?: IDatabaseTransaction, keyRange?: DatabaseKeyRange): Promise<void>
 
   /**
    * Used to get a value from the store at a given key
@@ -72,7 +91,7 @@ export interface IDatabaseStore<Schema extends DatabaseSchema> {
   * @returns resolves with the value if found, or undefined if not found.
   */
   get(
-    key: SchemaKey<Schema>,
+    key: Readonly<SchemaKey<Schema>>,
     transaction?: IDatabaseTransaction,
   ): Promise<SchemaValue<Schema> | undefined>
 
@@ -84,7 +103,7 @@ export interface IDatabaseStore<Schema extends DatabaseSchema> {
   *
   * @returns resolves with true if the key is in the database, or false if it is missing.
   */
-  has(key: SchemaKey<Schema>, transaction?: IDatabaseTransaction): Promise<boolean>
+  has(key: Readonly<SchemaKey<Schema>>, transaction?: IDatabaseTransaction): Promise<boolean>
 
   /**
    * Put a value into the store with the given key.
@@ -96,7 +115,7 @@ export interface IDatabaseStore<Schema extends DatabaseSchema> {
   * @returns A promise that resolves when the operation has been either executed, or added to the transaction.
   */
   put(
-    key: SchemaKey<Schema>,
+    key: Readonly<SchemaKey<Schema>>,
     value: SchemaValue<Schema>,
     transaction?: IDatabaseTransaction,
   ): Promise<void>
@@ -114,7 +133,7 @@ export interface IDatabaseStore<Schema extends DatabaseSchema> {
   * @throws {@link DuplicateKeyError} if the key already exists in the transaction or database
   */
   add(
-    key: SchemaKey<Schema>,
+    key: Readonly<SchemaKey<Schema>>,
     value: SchemaValue<Schema>,
     transaction?: IDatabaseTransaction,
   ): Promise<void>
@@ -127,7 +146,7 @@ export interface IDatabaseStore<Schema extends DatabaseSchema> {
    *
    * @returns A promise that resolves when the operation has been either executed, or added to the transaction.
    */
-  del(key: SchemaKey<Schema>, transaction?: IDatabaseTransaction): Promise<void>
+  del(key: Readonly<SchemaKey<Schema>>, transaction?: IDatabaseTransaction): Promise<void>
 }
 
 export abstract class DatabaseStore<Schema extends DatabaseSchema>
@@ -143,11 +162,14 @@ export abstract class DatabaseStore<Schema extends DatabaseSchema>
     this.valueEncoding = options.valueEncoding
   }
 
-  abstract encode(key: SchemaKey<Schema>): [Buffer]
-  abstract encode(key: SchemaKey<Schema>, value: SchemaValue<Schema>): [Buffer, Buffer]
+  abstract encode(key: Readonly<SchemaKey<Schema>>): [Buffer]
+  abstract encode(
+    key: Readonly<SchemaKey<Schema>>,
+    value: SchemaValue<Schema>,
+  ): [Buffer, Buffer]
 
   abstract get(
-    key: SchemaKey<Schema>,
+    key: Readonly<SchemaKey<Schema>>,
     transaction?: IDatabaseTransaction,
   ): Promise<SchemaValue<Schema> | undefined>
 
@@ -165,21 +187,27 @@ export abstract class DatabaseStore<Schema extends DatabaseSchema>
 
   abstract clear(): Promise<void>
 
-  abstract has(key: SchemaKey<Schema>, transaction?: IDatabaseTransaction): Promise<boolean>
+  abstract has(
+    key: Readonly<SchemaKey<Schema>>,
+    transaction?: IDatabaseTransaction,
+  ): Promise<boolean>
 
   abstract put(
-    key: SchemaKey<Schema>,
+    key: Readonly<SchemaKey<Schema>>,
     value: SchemaValue<Schema>,
     transaction?: IDatabaseTransaction,
   ): Promise<void>
 
   abstract add(
-    key: SchemaKey<Schema>,
+    key: Readonly<SchemaKey<Schema>>,
     value: SchemaValue<Schema>,
     transaction?: IDatabaseTransaction,
   ): Promise<void>
 
-  abstract del(key: SchemaKey<Schema>, transaction?: IDatabaseTransaction): Promise<void>
+  abstract del(
+    key: Readonly<SchemaKey<Schema>>,
+    transaction?: IDatabaseTransaction,
+  ): Promise<void>
 }
 
 export type DatabaseStoreValue<TStore> = TStore extends IDatabaseStore<infer _A>

--- a/ironfish/src/storage/database/types.ts
+++ b/ironfish/src/storage/database/types.ts
@@ -4,7 +4,19 @@
 
 import { IJsonSerializable } from '../../serde'
 
-export type DatabaseKey = bigint | number | string | Date | Buffer | Array<IJsonSerializable>
+export interface DatabaseKeyRange {
+  gte: Buffer
+  lt: Buffer
+}
+
+export type DatabaseKey =
+  | bigint
+  | number
+  | string
+  | Date
+  | Buffer
+  | Array<IJsonSerializable>
+  | unknown
 
 export type DatabaseSchema = {
   key: DatabaseKey

--- a/ironfish/src/storage/database/utils.ts
+++ b/ironfish/src/storage/database/utils.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { DatabaseKeyRange } from './types'
+
+/**
+ * In non relational KV stores, to emulate 'startswith' you often need
+ * to use greaterThan and lessThan using the prefix + a glyph marker. To
+ * search for "App" in a table containing "Apple", "Application", and "Boat"
+ * you would query "gte('App') && lte('App' + 'ff')" Which would return
+ * 'Apple' and 'Application'
+ */
+export function getPrefixKeyRange(prefix: Buffer, byteLength?: number): DatabaseKeyRange {
+  if (byteLength === undefined) {
+    byteLength = prefix.byteLength
+  }
+
+  const prefixHex = prefix.toString('hex')
+  const prefixNumber = parseInt(prefixHex, 16)
+
+  const gte = Buffer.alloc(byteLength)
+  gte.writeUIntBE(prefixNumber, 0, byteLength)
+
+  const lt = Buffer.alloc(byteLength)
+  lt.writeUIntBE(prefixNumber + 1, 0, byteLength)
+
+  return { gte, lt }
+}
+
+export const StorageUtils = { getPrefixKeyRange }

--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -119,7 +119,7 @@ export class LevelupDatabase extends Database {
       if (this.levelup instanceof LevelDOWN) {
         this.levelup.compactRange(
           DATABASE_ALL_KEY_RANGE.gte,
-          DATABASE_ALL_KEY_RANGE.lte,
+          DATABASE_ALL_KEY_RANGE.lt,
           (err) => (err ? reject(err) : resolve()),
         )
       }


### PR DESCRIPTION
## Summary

This now supports key ranges for all range based database operations. That means you can use any operations like clear(), getAllKeys() filtered to a subset of rows.

This also adds a new storage utility file to help generate buffer key range prefixes easily.

## Testing Plan

Run the new written tests, and run the node.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
