### PR TITLE
Remove unnecessary transaction verification

### DIFF
--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -187,16 +187,7 @@ export class Verifier {
    * the mempool and rebroadcasted to the network.
    */
   async verifyNewTransaction(transaction: Transaction): Promise<VerificationResult> {
-    try {
-      // Transaction is lazily deserialized, so we use takeReference()
-      // to force deserialization errors here
-      transaction.takeReference()
-      transaction.returnReference()
-    } catch (e) {
-      return { valid: false, reason: VerificationResultReason.DESERIALIZATION }
-    }
-
-    // Next, check the spends are valid and not already in the chain
+    // Check the spends are valid and not already in the chain
     const reason = await this.chain.db.withTransaction(null, async (tx) => {
       const nullifierSize = await this.chain.nullifiers.size(tx)
       const notesSize = await this.chain.notes.size(tx)


### PR DESCRIPTION
## Summary

Transactions have to be turned into Rust transactions when we run verification in the worker pool anyway, so we may as well not do it on the main thread (since it's fairly slow)

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
