### PR TITLE
Expose mining performance times in node status

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -69,7 +69,7 @@ export class Pay extends IronfishCommand {
 
     const client = await this.sdk.connectRpc(false, true)
 
-    const status = await client.status()
+    const status = await client.getNodeStatus()
 
     if (!status.content.blockchain.synced) {
       this.log(

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -111,7 +111,7 @@ export default class Faucet extends IronfishCommand {
     speed: Meter,
     api: WebApi,
   ): Promise<void> {
-    const status = await client.status()
+    const status = await client.getNodeStatus()
 
     if (!status.content.blockchain.synced) {
       this.log('Blockchain not synced, waiting 5s')

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -30,7 +30,7 @@ export default class Status extends IronfishCommand {
     if (!flags.follow) {
       const client = await this.sdk.connectRpc()
       const response = await client.getNodeStatus()
-      this.log(renderStatus(flags, response.content))
+      this.log(renderStatus(response.content, flags.all))
       this.exit(0)
     }
 
@@ -57,14 +57,14 @@ export default class Status extends IronfishCommand {
 
       for await (const value of response.contentStream()) {
         statusText.clearBaseLine(0)
-        statusText.setContent(renderStatus(flags, value))
+        statusText.setContent(renderStatus(value, flags.all))
         screen.render()
       }
     }
   }
 }
 
-function renderStatus(flags: { all: boolean }, content: GetNodeStatusResponse): string {
+function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): string {
   const nodeStatus = `${content.node.status.toUpperCase()}`
   let blockSyncerStatus = content.blockSyncer.status.toString().toUpperCase()
   const blockSyncerStatusDetails: string[] = []
@@ -116,7 +116,7 @@ function renderStatus(flags: { all: boolean }, content: GetNodeStatusResponse): 
     content.miningDirector.miners
   } miners, ${content.miningDirector.blocks} mined`
 
-  if (flags.all) {
+  if (debugOutput) {
     miningDirectorStatus += `, get txs: ${TimeUtils.renderSpan(
       content.miningDirector.newBlockTransactionsSpeed,
     )}, block: ${TimeUtils.renderSpan(

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -19,7 +19,7 @@ export async function verifyCanSend(
   fee: number,
   graffiti: string,
 ): Promise<{ canSend: boolean; errorReason: string | null }> {
-  const status = await client.status()
+  const status = await client.getNodeStatus()
   if (!status.content.blockchain.synced) {
     return {
       canSend: false,

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -876,7 +876,10 @@ export class Blockchain {
     graffiti?: Buffer,
   ): Promise<Block> {
     const transactions = [minersFee, ...userTransactions]
+
     return await this.db.transaction(async (tx) => {
+      const startTime = BenchUtils.start()
+
       const originalNoteSize = await this.notes.size(tx)
       const originalNullifierSize = await this.nullifiers.size(tx)
 
@@ -954,6 +957,8 @@ export class Blockchain {
       // abort this transaction as we've modified the trees just to get new
       // merkle roots, but this block isn't mined or accepted yet
       await tx.abort()
+
+      this.metrics.chain_newBlock.add(BenchUtils.end(startTime))
 
       return block
     })

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -16,6 +16,10 @@ export class MetricsMonitor {
   private _meters: Meter[] = []
   private readonly logger: Logger
 
+  readonly mining_newBlockTemplate: Meter
+  readonly chain_newBlock: Meter
+  readonly mining_newBlockTransactions: Meter
+
   readonly p2p_InboundTraffic: Meter
   readonly p2p_InboundTraffic_WS: Meter
   readonly p2p_InboundTraffic_WebRTC: Meter
@@ -44,6 +48,10 @@ export class MetricsMonitor {
 
   constructor({ logger }: { logger?: Logger }) {
     this.logger = logger ?? createRootLogger()
+
+    this.mining_newBlockTemplate = this.addMeter()
+    this.chain_newBlock = this.addMeter()
+    this.mining_newBlockTransactions = this.addMeter()
 
     this.p2p_InboundTraffic = this.addMeter()
     this.p2p_InboundTraffic_WS = this.addMeter()

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -7,11 +7,13 @@ import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { Event } from '../event'
 import { MemPool } from '../memPool'
+import { MetricsMonitor } from '../metrics'
 import { IronfishNode } from '../node'
 import { Block } from '../primitives/block'
 import { Transaction } from '../primitives/transaction'
 import { BlockTemplateSerde, SerializedBlockTemplate } from '../serde'
 import { AsyncUtils } from '../utils/async'
+import { BenchUtils } from '../utils/bench'
 import { GraffitiUtils } from '../utils/graffiti'
 
 const MAX_TRANSACTIONS_PER_BLOCK = 300
@@ -29,16 +31,23 @@ export class MiningManager {
   private readonly chain: Blockchain
   private readonly memPool: MemPool
   private readonly node: IronfishNode
+  private readonly metrics: MetricsMonitor
 
   blocksMined = 0
   minersConnected = 0
 
   readonly onNewBlock = new Event<[Block]>()
 
-  constructor(options: { chain: Blockchain; node: IronfishNode; memPool: MemPool }) {
+  constructor(options: {
+    chain: Blockchain
+    node: IronfishNode
+    memPool: MemPool
+    metrics: MetricsMonitor
+  }) {
     this.node = options.node
     this.memPool = options.memPool
     this.chain = options.chain
+    this.metrics = options.metrics
   }
 
   /**
@@ -52,6 +61,8 @@ export class MiningManager {
     totalFees: bigint
     blockTransactions: Transaction[]
   }> {
+    const startTime = BenchUtils.start()
+
     // Fetch pending transactions
     const blockTransactions: Transaction[] = []
     const nullifiers = new BufferSet()
@@ -94,6 +105,8 @@ export class MiningManager {
       totalTransactionFees += transactionFee
     }
 
+    this.metrics.mining_newBlockTransactions.add(BenchUtils.end(startTime))
+
     return {
       totalFees: totalTransactionFees,
       blockTransactions,
@@ -107,6 +120,8 @@ export class MiningManager {
    * @returns
    */
   async createNewBlockTemplate(currentBlock: Block): Promise<SerializedBlockTemplate> {
+    const startTime = BenchUtils.start()
+
     const newBlockSequence = currentBlock.header.sequence + 1
 
     const { totalFees, blockTransactions } = await this.getNewBlockTransactions(
@@ -136,6 +151,8 @@ export class MiningManager {
     this.node.logger.debug(
       `Current block template ${newBlock.header.sequence}, has ${newBlock.transactions.length} transactions`,
     )
+
+    this.metrics.mining_newBlockTemplate.add(BenchUtils.end(startTime))
 
     return BlockTemplateSerde.serialize(newBlock, currentBlock)
   }

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -94,7 +94,7 @@ export class IronfishNode {
     this.chain = chain
     this.strategy = strategy
     this.metrics = metrics
-    this.miningManager = new MiningManager({ chain, memPool, node: this })
+    this.miningManager = new MiningManager({ chain, memPool, node: this, metrics })
     this.memPool = memPool
     this.workerPool = workerPool
     this.rpc = new RpcServer(this)

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -34,12 +34,12 @@ import {
   GetFundsRequest,
   GetFundsResponse,
   GetLogStreamResponse,
+  GetNodeStatusRequest,
+  GetNodeStatusResponse,
   GetPeersRequest,
   GetPeersResponse,
   GetPublicKeyRequest,
   GetPublicKeyResponse,
-  GetStatusRequest,
-  GetStatusResponse,
   GetTransactionStreamRequest,
   GetTransactionStreamResponse,
   GetWorkersStatusRequest,
@@ -95,17 +95,17 @@ export abstract class RpcClient {
     options?: { timeoutMs?: number | null },
   ): RpcResponse<TEnd, TStream>
 
-  async status(
-    params: GetStatusRequest = undefined,
-  ): Promise<RpcResponseEnded<GetStatusResponse>> {
-    return this.request<GetStatusResponse>(
+  async getNodeStatus(
+    params: GetNodeStatusRequest = undefined,
+  ): Promise<RpcResponseEnded<GetNodeStatusResponse>> {
+    return this.request<GetNodeStatusResponse>(
       `${ApiNamespace.node}/getStatus`,
       params,
     ).waitForEnd()
   }
 
-  statusStream(): RpcResponse<void, GetStatusResponse> {
-    return this.request<void, GetStatusResponse>(`${ApiNamespace.node}/getStatus`, {
+  statusStream(): RpcResponse<void, GetNodeStatusResponse> {
+    return this.request<void, GetNodeStatusResponse>(`${ApiNamespace.node}/getStatus`, {
       stream: true,
     })
   }


### PR DESCRIPTION
## Summary

This expose 3 new meters in our status related to mining when you pass --all to `ironfish status`

 - Time to construct a new block given transactions
 - Time to calculate transactions from the mem pool for the new block
 - Total time to generate a block template

```
> ironfish status --all

Version              0.1.45 @ src
Node                 STARTED
Node Name            JASON💪💎🚀
Block Graffiti       JASON💪💎🚀
Memory               Heap: 829.85 MiB -> 849.71 MiB / 4.00 GiB (20.2%), RSS: 2.68 GiB (16.8%), Free:
77.87 MiB (99.5%)
P2P Network          CONNECTED - In: 7.35 KB/s, Out: 1.88 KB/s, peers 3
Mining               STARTED - 1 miners, 0 mined, get txs: 0.0638ms, block: 30.5735ms, template:
253.2487ms
Mem Pool             Size: 0 tx, Bytes: 0 B
Syncer               IDLE - progress: 84.49%
Blockchain           NOT SYNCED @ HEAD 000000000005501b3df6494a0b34a5194971e7cefe288ae6c3e32dd2b9f3b8a9
 (136771)
Accounts             00000000000f730acf13ab7528473224b841ac851c502ef7685333410438298d (7803)
Telemetry            STARTED - 0 <- 1 pending
Workers              STARTED - 0 -> 1 / 6 - 0.05 jobs Δ, 408.52 jobs/s
```
Specifically this line
```
Mining               STARTED - 1 miners, 0 mined, get txs: 0.0638ms, block: 30.5735ms, template:
253.2487ms
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
