### PR TITLE
Hide inspect port in use error

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -44,7 +44,7 @@
     "lint:fix": "tsc -b && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
     "start:dev": "node start",
     "start": "yarn build && yarn start:js",
-    "start:js": "cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect --inspect-publish-uid=http --enable-source-maps bin/run",
+    "start:js": "cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run",
     "test": "yarn clean && tsc -b && tsc -b tsconfig.test.json && jest --maxWorkers=1 --passWithNoTests",
     "test:coverage:html": "tsc -b tsconfig.test.json && jest --maxWorkers=1 --passWithNoTests --coverage --coverage-reporters html --testPathIgnorePatterns",
     "test:watch": "tsc -b tsconfig.test.json && jest --watch --coverage false",

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -4,6 +4,7 @@
 import { BoxKeyPair } from '@ironfish/rust-nodejs'
 import { Assert, IronfishNode, NodeUtils, PrivateIdentity, PromiseUtils } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
+import inspector from 'node:inspector'
 import { v4 as uuid } from 'uuid'
 import { IronfishCommand, SIGNALS } from '../command'
 import {
@@ -190,6 +191,9 @@ export default class Start extends IronfishCommand {
     this.log(`Peer Agent    ${node.peerNetwork.localPeer.agent}`)
     this.log(`Peer Port     ${peerPort}`)
     this.log(`Bootstrap     ${bootstraps.join(',') || 'NONE'}`)
+    if (inspector.url()) {
+      this.log(`Inspector     ${String(inspector.url())}`)
+    }
     this.log(` `)
 
     await NodeUtils.waitForOpen(node, () => this.closing)


### PR DESCRIPTION
## Summary

This will use a randomly assigned port if the default inspect port is in use. Otherwise you get a message like this `Starting inspector on 127.0.0.1:9229 failed: address already in use` printed.

## Testing Plan

1. Run `yarn start start`
2. Run `yarn start debug`
3. See that `Starting inspector on 127.0.0.1:9229 failed: address already in use` is not printed

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
