### PR TITLE
Ignore /target dir in build script, minor dockerfile improvements

### DIFF
--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -1,13 +1,17 @@
 FROM node:16.15.1-bullseye as build
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-COPY ./ ./
-
 RUN \
     apt-get update && \
-    apt-get install jq rsync gcc cmake python -y && \
-    curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-    ./ironfish-cli/scripts/build.sh
+    apt-get install jq rsync gcc cmake python -y
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+WORKDIR ./app
+
+COPY ./ ./
+
+RUN ./ironfish-cli/scripts/build.sh
 
 FROM node:16.15.1-bullseye-slim
 EXPOSE 8020:8020
@@ -21,8 +25,8 @@ RUN \
     apt-get install curl libc6 -y
 
 WORKDIR /usr/src
-COPY --from=build /ironfish-cli/build.cli/ironfish-cli ./app
-COPY --from=build /ironfish-cli/scripts/entrypoint.sh ./app/
+COPY --from=build /app/ironfish-cli/build.cli/ironfish-cli ./app
+COPY --from=build /app/ironfish-cli/scripts/entrypoint.sh ./app/
 RUN chmod +x ./app/entrypoint.sh
 
 WORKDIR /usr/src/app

--- a/ironfish-cli/scripts/build.sh
+++ b/ironfish-cli/scripts/build.sh
@@ -59,7 +59,7 @@ cp -R ../../build ./
 echo "Copying node_modules"
 # Exclude fsevents to fix brew audit error:
 # "Binaries built for a non-native architecture were installed into ironfish's prefix"
-rsync -L -avrq --exclude 'target' --exclude 'ironfish' --exclude 'fsevents' ../../../node_modules ./
+rsync -L -avrq --exclude '@ironfish/rust-nodejs/target' --exclude 'ironfish' --exclude 'fsevents' ../../../node_modules ./
 # Copy node_modules from ironfish-cli folder into the production node_modules folder
 # yarn --production seems to split some packages into different folders for some reason
 # if ../../node_modules/ is empty then the cp command will error so skip copying

--- a/ironfish-cli/scripts/build.sh
+++ b/ironfish-cli/scripts/build.sh
@@ -59,7 +59,7 @@ cp -R ../../build ./
 echo "Copying node_modules"
 # Exclude fsevents to fix brew audit error:
 # "Binaries built for a non-native architecture were installed into ironfish's prefix"
-rsync -L -avrq --exclude 'ironfish' --exclude 'fsevents' ../../../node_modules ./
+rsync -L -avrq --exclude 'target' --exclude 'ironfish' --exclude 'fsevents' ../../../node_modules ./
 # Copy node_modules from ironfish-cli folder into the production node_modules folder
 # yarn --production seems to split some packages into different folders for some reason
 # if ../../node_modules/ is empty then the cp command will error so skip copying


### PR DESCRIPTION
## Summary

Takes my local docker image from like 1.3gb to 450mb

Closes IRO-2555

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
