### PR TITLE
Set proper Error type and message on Insufficient funds case

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -14,7 +14,7 @@ import { NoteWitness } from '../merkletree/witness'
 import { Mutex } from '../mutex'
 import { Note } from '../primitives/note'
 import { Transaction } from '../primitives/transaction'
-import { ValidationError } from '../rpc/adapters/errors'
+import { ERROR_CODES, ValidationError } from '../rpc/adapters/errors';
 import { IDatabaseTransaction } from '../storage/database/transaction'
 import { BufferUtils, PromiseResolve, PromiseUtils, SetTimeoutToken } from '../utils'
 import { WorkerPool } from '../workerPool'
@@ -735,7 +735,11 @@ export class Accounts {
       }
 
       if (amountNeeded > 0) {
-        throw new Error('Insufficient funds')
+        throw new ValidationError(
+          `Insufficient funds`,
+          undefined,
+          ERROR_CODES.INSUFFICIENT_BALANCE,
+        )
       }
 
       return this.workerPool.createTransaction(

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -14,7 +14,7 @@ import { NoteWitness } from '../merkletree/witness'
 import { Mutex } from '../mutex'
 import { Note } from '../primitives/note'
 import { Transaction } from '../primitives/transaction'
-import { ERROR_CODES, ValidationError } from '../rpc/adapters/errors';
+import { ERROR_CODES, ValidationError } from '../rpc/adapters/errors'
 import { IDatabaseTransaction } from '../storage/database/transaction'
 import { BufferUtils, PromiseResolve, PromiseUtils, SetTimeoutToken } from '../utils'
 import { WorkerPool } from '../workerPool'


### PR DESCRIPTION
## Summary

DepositAll command is catching an error with the error code `INSUFFICIENT_BALANCE`, but `createTransaction` was throwing a default Error, without that code, which leads the command to shut down.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
