### PR TITLE
Move commands migrations:status and config:show to their root commands

### DIFF
--- a/ironfish-cli/src/commands/config/index.ts
+++ b/ironfish-cli/src/commands/config/index.ts
@@ -8,6 +8,7 @@ import { ColorFlag, ColorFlagKey } from '../../flags'
 import { RemoteFlags } from '../../flags'
 
 export class ShowCommand extends IronfishCommand {
+  static aliases = ['config:show']
   static description = `Print out the entire config`
 
   static flags = {

--- a/ironfish-cli/src/commands/migrations/index.ts
+++ b/ironfish-cli/src/commands/migrations/index.ts
@@ -5,6 +5,7 @@ import { IronfishCommand } from '../../command'
 import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey } from '../../flags'
 
 export class StatusCommand extends IronfishCommand {
+  static aliases = ['migrations:status']
   static description = `List all the migration statuses`
 
   static flags = {


### PR DESCRIPTION
## Summary

Feature #2092, move additional commands (`migrations:status` and `config:show`) to their respective root commands (`migrations` and `config`). Leave in original commands as aliases for now (to be deleted eventually).

## Testing Plan
- Tested both `migrations` and `config` commands to ensure they perform the same operation as `migrations:status` and `config:show`.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
