### PR TITLE
Show status response after disconnect

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -40,6 +40,7 @@ export default class Status extends IronfishCommand {
     const screen = blessed.screen({ smartCSR: true, fullUnicode: true })
     const statusText = blessed.text()
     screen.append(statusText)
+    let previousResponse: GetNodeStatusResponse | null = null
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -47,7 +48,12 @@ export default class Status extends IronfishCommand {
 
       if (!connected) {
         statusText.clearBaseLine(0)
-        statusText.setContent('Node: STOPPED')
+        if (previousResponse != null) {
+          statusText.setContent(renderStatus(previousResponse, flags.all))
+          statusText.insertTop("Node: Disonnected \n")
+        } else {
+          statusText.setContent('Node: STOPPED')
+        }
         screen.render()
         await PromiseUtils.sleep(1000)
         continue
@@ -59,6 +65,7 @@ export default class Status extends IronfishCommand {
         statusText.clearBaseLine(0)
         statusText.setContent(renderStatus(value, flags.all))
         screen.render()
+        previousResponse = value
       }
     }
   }

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -48,12 +48,14 @@ export default class Status extends IronfishCommand {
 
       if (!connected) {
         statusText.clearBaseLine(0)
+
         if (previousResponse) {
           statusText.setContent(renderStatus(previousResponse, flags.all))
           statusText.insertTop('Node: Disconnected \n')
         } else {
           statusText.setContent('Node: STOPPED')
         }
+        
         screen.render()
         await PromiseUtils.sleep(1000)
         continue
@@ -163,7 +165,7 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
     accountStatus = `SCANNING - ${content.accounts.scanning.sequence} / ${content.accounts.scanning.endSequence}`
   }
 
-  return `
+  return `\
 Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
 Node Name            ${nodeName}

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -48,9 +48,9 @@ export default class Status extends IronfishCommand {
 
       if (!connected) {
         statusText.clearBaseLine(0)
-        if (previousResponse != null) {
+        if (previousResponse) {
           statusText.setContent(renderStatus(previousResponse, flags.all))
-          statusText.insertTop("Node: Disonnected \n")
+          statusText.insertTop("Node: Disconnected \n")
         } else {
           statusText.setContent('Node: STOPPED')
         }

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -50,7 +50,7 @@ export default class Status extends IronfishCommand {
         statusText.clearBaseLine(0)
         if (previousResponse) {
           statusText.setContent(renderStatus(previousResponse, flags.all))
-          statusText.insertTop("Node: Disconnected \n")
+          statusText.insertTop('Node: Disconnected \n')
         } else {
           statusText.setContent('Node: STOPPED')
         }

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -55,7 +55,7 @@ export default class Status extends IronfishCommand {
         } else {
           statusText.setContent('Node: STOPPED')
         }
-        
+
         screen.render()
         await PromiseUtils.sleep(1000)
         continue


### PR DESCRIPTION
## Summary
https://linear.app/ironfish/issue/IRO-2569/dont-clear-ironfish-status-on-disconnect

## Testing Plan
local test 
![Screen Shot 2022-09-12 at 3 14 24 PM](https://user-images.githubusercontent.com/4500784/189767970-1950e346-6cdc-493f-b029-a32359ba9f47.png)



## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
