### PR TITLE
Add time since HEAD timestamp to status command

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -108,9 +108,11 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
     content.peerNetwork.peers
   }`
 
-  const blockchainStatus = `HEAD ${content.blockchain.head}, behind: ${TimeUtils.renderSpan(
-    Date.now() - content.blockchain.headTimestamp,
-  )} (${content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'})`
+  const blockchainStatus = `HEAD @ ${
+    content.blockchain.head
+  }, Since HEAD: ${TimeUtils.renderSpan(Date.now() - content.blockchain.headTimestamp)} (${
+    content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'
+  })`
 
   let miningDirectorStatus = `${content.miningDirector.status.toUpperCase()} - ${
     content.miningDirector.miners

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -108,9 +108,9 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
     content.peerNetwork.peers
   }`
 
-  const blockchainStatus = `${content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'} @ HEAD ${
-    content.blockchain.head
-  }`
+  const blockchainStatus = `HEAD ${content.blockchain.head}, behind: ${TimeUtils.renderSpan(
+    Date.now() - content.blockchain.head_timestamp,
+  )} (${content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'})`
 
   let miningDirectorStatus = `${content.miningDirector.status.toUpperCase()} - ${
     content.miningDirector.miners

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -109,7 +109,7 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
   }`
 
   const blockchainStatus = `HEAD ${content.blockchain.head}, behind: ${TimeUtils.renderSpan(
-    Date.now() - content.blockchain.head_timestamp,
+    Date.now() - content.blockchain.headTimestamp,
   )} (${content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'})`
 
   let miningDirectorStatus = `${content.miningDirector.status.toUpperCase()} - ${

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -108,11 +108,9 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
     content.peerNetwork.peers
   }`
 
-  const blockchainStatus = `HEAD @ ${
-    content.blockchain.head
-  }, Since HEAD: ${TimeUtils.renderSpan(Date.now() - content.blockchain.headTimestamp)} (${
-    content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'
-  })`
+  const blockchainStatus = `${content.blockchain.head}, Since HEAD: ${TimeUtils.renderSpan(
+    Date.now() - content.blockchain.headTimestamp,
+  )} (${content.blockchain.synced ? 'SYNCED' : 'NOT SYNCED'})`
 
   let miningDirectorStatus = `${content.miningDirector.status.toUpperCase()} - ${
     content.miningDirector.miners

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -42,6 +42,7 @@ export type GetNodeStatusResponse = {
   blockchain: {
     synced: boolean
     head: string
+    head_timestamp: number
     newBlockSpeed: number
   }
   blockSyncer: {
@@ -129,6 +130,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetNodeStatusResponse> = 
       .object({
         synced: yup.boolean().defined(),
         head: yup.string().defined(),
+        head_timestamp: yup.number().defined(),
         newBlockSpeed: yup.number().defined(),
       })
       .defined(),
@@ -234,6 +236,7 @@ function getStatus(node: IronfishNode): GetNodeStatusResponse {
       head: `${node.chain.head.hash.toString('hex') || ''} (${
         node.chain.head.sequence.toString() || ''
       })`,
+      head_timestamp: node.chain.head.timestamp.getTime(),
       newBlockSpeed: node.metrics.chain_newBlock.avg,
     },
     node: {

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -42,7 +42,7 @@ export type GetNodeStatusResponse = {
   blockchain: {
     synced: boolean
     head: string
-    head_timestamp: number
+    headTimestamp: number
     newBlockSpeed: number
   }
   blockSyncer: {
@@ -130,7 +130,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetNodeStatusResponse> = 
       .object({
         synced: yup.boolean().defined(),
         head: yup.string().defined(),
-        head_timestamp: yup.number().defined(),
+        headTimestamp: yup.number().defined(),
         newBlockSpeed: yup.number().defined(),
       })
       .defined(),
@@ -236,7 +236,7 @@ function getStatus(node: IronfishNode): GetNodeStatusResponse {
       head: `${node.chain.head.hash.toString('hex') || ''} (${
         node.chain.head.sequence.toString() || ''
       })`,
-      head_timestamp: node.chain.head.timestamp.getTime(),
+      headTimestamp: node.chain.head.timestamp.getTime(),
       newBlockSpeed: node.metrics.chain_newBlock.avg,
     },
     node: {


### PR DESCRIPTION
## Summary
Addressing [this issue](https://github.com/iron-fish/ironfish/issues/2147) about the SYNCED  field on the status command being confusing. Changing the output of that status to show the time since the head block (e.g. 30s, 10m etc). I think that would be more informative that just saying chain is SYNCED which we determine by checking if the chain is less than 5 hours behind

## Testing Plan
Local tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
