### PR TITLE
Add telemetry for RPC response times and success rate

### DIFF
--- a/ironfish/src/metrics/meter.ts
+++ b/ironfish/src/metrics/meter.ts
@@ -21,7 +21,7 @@ export class Meter {
   private _rate5s: EwmAverage
   private _rate1m: EwmAverage
   private _rate5m: EwmAverage
-  private _average: RollingAverage
+  _average: RollingAverage
   private _count = 0
   private _interval: SetIntervalToken | null = null
   private _intervalMs: number

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -28,6 +28,8 @@ export class MetricsMonitor {
   readonly p2p_OutboundTraffic_WebRTC: Meter
   readonly p2p_InboundTrafficByMessage: Map<NetworkMessageType, Meter> = new Map()
   readonly p2p_OutboundTrafficByMessage: Map<NetworkMessageType, Meter> = new Map()
+  readonly p2p_RpcSuccessRateByMessage: Map<NetworkMessageType, Meter> = new Map()
+  readonly p2p_RpcResponseTimeMsByMessage: Map<NetworkMessageType, Meter> = new Map()
   readonly p2p_PeersCount: Gauge
 
   // Elements of this map are managed by Peer and PeerNetwork
@@ -63,6 +65,10 @@ export class MetricsMonitor {
     for (const value of NumberEnumUtils.getNumValues(NetworkMessageType)) {
       this.p2p_InboundTrafficByMessage.set(value, this.addMeter())
       this.p2p_OutboundTrafficByMessage.set(value, this.addMeter())
+      // Should only need to add meters for RPC messages, but makes the code a bit
+      // cleaner in the current type system to do it this way
+      this.p2p_RpcSuccessRateByMessage.set(value, this.addMeter())
+      this.p2p_RpcResponseTimeMsByMessage.set(value, this.addMeter())
     }
 
     this.p2p_PeersCount = new Gauge()

--- a/ironfish/src/metrics/rollingAverage.ts
+++ b/ironfish/src/metrics/rollingAverage.ts
@@ -81,6 +81,13 @@ export class RollingAverage {
   }
 
   /**
+   * Returns the number of samples in the RollingAverage.
+   */
+  sampleCount(): number {
+    return this._sampleCount
+  }
+
+  /**
    * Returns true if enough samples have been taken to completely fill the sliding window
    * @return true if sample-set saturated
    */

--- a/ironfish/src/network/messageRegistry.ts
+++ b/ironfish/src/network/messageRegistry.ts
@@ -43,7 +43,7 @@ export const parseNetworkMessage = (buffer: Buffer): NetworkMessage => {
   return parseGenericNetworkMessage(type, body)
 }
 
-const isRpcNetworkMessageType = (type: NetworkMessageType): boolean => {
+export const isRpcNetworkMessageType = (type: NetworkMessageType): boolean => {
   return [
     NetworkMessageType.CannotSatisfyRequest,
     NetworkMessageType.GetBlockHashesRequest,

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -7,6 +7,7 @@ import { Config } from '../fileStores/config'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
 import { Identity } from '../network'
+import { isRpcNetworkMessageType } from '../network/messageRegistry'
 import { NetworkMessageType } from '../network/types'
 import { BlockHeader, Transaction } from '../primitives'
 import { Block } from '../primitives/block'
@@ -204,6 +205,26 @@ export class Telemetry {
         type: 'float',
         value: meter.rate5m,
       })
+    }
+
+    for (const [messageType, meter] of this.metrics.p2p_RpcResponseTimeMsByMessage) {
+      if (isRpcNetworkMessageType(messageType) && meter._average.sampleCount() >= 10) {
+        fields.push({
+          name: 'rpc_response_ms_' + NetworkMessageType[messageType].toLowerCase(),
+          type: 'float',
+          value: meter.avg,
+        })
+      }
+    }
+
+    for (const [messageType, meter] of this.metrics.p2p_RpcSuccessRateByMessage) {
+      if (isRpcNetworkMessageType(messageType) && meter._average.sampleCount() >= 10) {
+        fields.push({
+          name: 'rpc_success_' + NetworkMessageType[messageType].toLowerCase(),
+          type: 'float',
+          value: meter.avg,
+        })
+      }
     }
 
     this.submit({

--- a/ironfish/src/utils/bench.ts
+++ b/ironfish/src/utils/bench.ts
@@ -18,7 +18,7 @@ type Segment = {
   mem: number
 }
 
-type HRTime = [seconds: number, nanoseconds: number]
+export type HRTime = [seconds: number, nanoseconds: number]
 
 function startTime(): HRTime {
   return process.hrtime()


### PR DESCRIPTION
## Summary

Adds telemetry messages that log, on a per-message basis, the average response time and average success rate for RPC messages.

The telemetry fields won't be added until sampling at least 10 requests, to avoid biasing the success percentage too much.

## Testing Plan

Tested locally by adding logs in development.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
