### PR TITLE
Cleanup Sapling references

### DIFF
--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -27,8 +27,8 @@ impl NativeTransactionPosted {
     pub fn new(js_bytes: JsBuffer) -> Result<NativeTransactionPosted> {
         let bytes = js_bytes.into_value()?;
 
-        let transaction = Transaction::read(SAPLING.clone(), bytes.as_ref())
-            .map_err(|err| Error::from_reason(err.to_string()))?;
+        let transaction =
+            Transaction::read(bytes.as_ref()).map_err(|err| Error::from_reason(err.to_string()))?;
 
         Ok(NativeTransactionPosted { transaction })
     }
@@ -271,11 +271,11 @@ pub fn verify_transactions(serialized_transactions: Vec<Buffer>) -> bool {
     let mut transactions: Vec<Transaction> = vec![];
 
     for tx_bytes in serialized_transactions {
-        match Transaction::read(SAPLING.clone(), &mut tx_bytes.as_ref()) {
+        match Transaction::read(&mut tx_bytes.as_ref()) {
             Ok(tx) => transactions.push(tx),
             Err(_) => return false,
         }
     }
 
-    batch_verify_transactions(SAPLING.clone(), transactions.iter()).is_ok()
+    batch_verify_transactions(transactions.iter()).is_ok()
 }

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -10,8 +10,6 @@ use ironfish_rust::{MerkleNoteHash, ProposedTransaction, PublicAddress, SaplingK
 use napi::{bindgen_prelude::*, JsBuffer};
 use napi_derive::napi;
 
-use ironfish_rust::sapling_bls12::SAPLING;
-
 use super::note::NativeNote;
 use super::spend_proof::NativeSpendProof;
 use super::witness::JsWitness;
@@ -160,7 +158,7 @@ impl NativeTransaction {
     #[napi(constructor)]
     pub fn new() -> NativeTransaction {
         NativeTransaction {
-            transaction: ProposedTransaction::new(SAPLING.clone()),
+            transaction: ProposedTransaction::new(),
         }
     }
 

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -8,7 +8,6 @@ use crate::{
     keys::SaplingKey,
     merkle_note::NOTE_ENCRYPTION_MINER_KEYS,
     note::{Memo, Note},
-    sapling_bls12,
     test_util::make_fake_witness,
 };
 
@@ -16,8 +15,7 @@ use zcash_primitives::sapling::redjubjub::Signature;
 
 #[test]
 fn test_transaction() {
-    let sapling = sapling_bls12::SAPLING.clone();
-    let mut transaction = ProposedTransaction::new(sapling.clone());
+    let mut transaction = ProposedTransaction::new();
     let spender_key: SaplingKey = SaplingKey::generate_key();
     let receiver_key: SaplingKey = SaplingKey::generate_key();
     let in_note = Note::new(spender_key.generate_public_address(), 42, Memo::default());
@@ -90,8 +88,7 @@ fn test_transaction() {
 
 #[test]
 fn test_miners_fee() {
-    let sapling = &*sapling_bls12::SAPLING;
-    let mut transaction = ProposedTransaction::new(sapling.clone());
+    let mut transaction = ProposedTransaction::new();
     let receiver_key: SaplingKey = SaplingKey::generate_key();
     let out_note = Note::new(receiver_key.generate_public_address(), 42, Memo::default());
     transaction
@@ -114,13 +111,12 @@ fn test_miners_fee() {
 
 #[test]
 fn test_transaction_signature() {
-    let sapling = sapling_bls12::SAPLING.clone();
     let spender_key = SaplingKey::generate_key();
     let receiver_key = SaplingKey::generate_key();
     let spender_address = spender_key.generate_public_address();
     let receiver_address = receiver_key.generate_public_address();
 
-    let mut transaction = ProposedTransaction::new(sapling);
+    let mut transaction = ProposedTransaction::new();
     let in_note = Note::new(spender_address, 42, Memo::default());
     let out_note = Note::new(receiver_address, 41, Memo::default());
     let witness = make_fake_witness(&in_note);

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -67,7 +67,7 @@ fn test_transaction() {
         .write(&mut serialized_transaction)
         .expect("should be able to serialize transaction");
     let read_back_transaction: Transaction =
-        Transaction::read(sapling, &mut serialized_transaction[..].as_ref())
+        Transaction::read(&mut serialized_transaction[..].as_ref())
             .expect("should be able to deserialize valid transaction");
     assert_eq!(
         public_transaction.transaction_fee,


### PR DESCRIPTION
## Summary

We pass this around in a lot of places. These were probably more relevant before the librustzcash upgrades, but now I think it's cleaner to just use them at the specific call-sites since there's very few of them.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
