### PR TITLE
refactor(rust): Move note content and preimage building to util file

### DIFF
--- a/ironfish-rust/src/primitives/asset_type.rs
+++ b/ironfish-rust/src/primitives/asset_type.rs
@@ -19,7 +19,7 @@ pub type AssetIdentifier = [u8; ASSET_IDENTIFIER_LENGTH];
 
 // TODO: This is just a placeholder helper struct, feels pretty awkward to use
 // so probably won't stick around like this
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct AssetInfo {
     // TODO: This functionality should be mostly copied from Memo, same idea.
     // Also consider unicode char indices or something

--- a/ironfish-rust/src/proofs/circuit/create_asset.rs
+++ b/ironfish-rust/src/proofs/circuit/create_asset.rs
@@ -1,18 +1,17 @@
-use std::slice;
-
 use bellman::{
     gadgets::{blake2s, boolean},
     Circuit,
 };
-use zcash_primitives::constants::{GH_FIRST_BLOCK, VALUE_COMMITMENT_GENERATOR_PERSONALIZATION};
+use zcash_primitives::constants::VALUE_COMMITMENT_GENERATOR_PERSONALIZATION;
 use zcash_proofs::{
     circuit::{ecc, pedersen_hash},
     constants::NOTE_COMMITMENT_RANDOMNESS_GENERATOR,
 };
 
-use crate::primitives::{asset_type::AssetInfo, constants::ASSET_IDENTIFIER_PERSONALIZATION};
-
-use super::sapling::slice_into_boolean_vec_le;
+use crate::{
+    primitives::{asset_type::AssetInfo, constants::ASSET_IDENTIFIER_PERSONALIZATION},
+    proofs::circuit::util::hash_asset_info_to_preimage,
+};
 
 pub struct CreateAsset {
     pub asset_info: Option<AssetInfo>,
@@ -26,56 +25,7 @@ impl Circuit<bls12_381::Scalar> for CreateAsset {
         cs: &mut CS,
     ) -> Result<(), bellman::SynthesisError> {
         // Hash the Asset Info pre-image
-        let mut combined_preimage = vec![];
-
-        // TODO: I wonder if we could hard-code this to minimize work?
-        // Not clear to me if the booleanizing is adding substantial time
-        // or if it's just a by-product of the hash taking longer due to
-        // more input. Also not clear if that has security implications
-        // by not witnessing the bits
-        let first_block_bits = slice_into_boolean_vec_le(
-            cs.namespace(|| "booleanize first block"),
-            Some(GH_FIRST_BLOCK),
-            64 * 8,
-        )?;
-
-        assert_eq!(first_block_bits.len(), 64 * 8);
-
-        combined_preimage.extend(first_block_bits);
-
-        let name_bits = slice_into_boolean_vec_le(
-            cs.namespace(|| "booleanize name"),
-            self.asset_info.as_ref().and_then(|i| i.name().into()),
-            32 * 8,
-        )?;
-
-        assert_eq!(name_bits.len(), 32 * 8);
-
-        combined_preimage.extend(name_bits);
-
-        let public_address_bits = slice_into_boolean_vec_le(
-            cs.namespace(|| "booleanize public address"),
-            self.asset_info
-                .as_ref()
-                .and_then(|i| i.public_address_bytes().into()),
-            43 * 8,
-        )?;
-
-        assert_eq!(public_address_bits.len(), 43 * 8);
-
-        combined_preimage.extend(public_address_bits);
-
-        let nonce_bits = slice_into_boolean_vec_le(
-            cs.namespace(|| "booleanize nonce"),
-            self.asset_info
-                .as_ref()
-                .and_then(|i| slice::from_ref(i.nonce()).into()),
-            8,
-        )?;
-
-        assert_eq!(nonce_bits.len(), 8);
-
-        combined_preimage.extend(nonce_bits);
+        let combined_preimage = hash_asset_info_to_preimage(cs, self.asset_info)?;
 
         // Computed identifier bits from the given asset info
         let asset_identifier = blake2s::blake2s(

--- a/ironfish-rust/src/proofs/circuit/create_asset.rs
+++ b/ironfish-rust/src/proofs/circuit/create_asset.rs
@@ -25,7 +25,10 @@ impl Circuit<bls12_381::Scalar> for CreateAsset {
         cs: &mut CS,
     ) -> Result<(), bellman::SynthesisError> {
         // Hash the Asset Info pre-image
-        let combined_preimage = hash_asset_info_to_preimage(cs, self.asset_info)?;
+        let combined_preimage = hash_asset_info_to_preimage(
+            &mut cs.namespace(|| "asset info preimage"),
+            self.asset_info,
+        )?;
 
         // Computed identifier bits from the given asset info
         let asset_identifier = blake2s::blake2s(

--- a/ironfish-rust/src/proofs/circuit/mint_asset.rs
+++ b/ironfish-rust/src/proofs/circuit/mint_asset.rs
@@ -1,13 +1,10 @@
-use std::slice;
-
 use bellman::{
     gadgets::{blake2s, boolean, multipack, num, Assignment},
     Circuit, ConstraintSystem,
 };
 use ff::PrimeField;
-use jubjub::ExtendedPoint;
 use zcash_primitives::{
-    constants::{self, GH_FIRST_BLOCK},
+    constants::{self},
     primitives::ProofGenerationKey,
 };
 use zcash_proofs::{circuit::ecc, constants::PROOF_GENERATION_KEY_GENERATOR};
@@ -18,7 +15,10 @@ use crate::{
         asset_type::AssetInfo, constants::ASSET_IDENTIFIER_PERSONALIZATION,
         sapling::ValueCommitment,
     },
-    proofs::circuit::sapling::{expose_value_commitment, slice_into_boolean_vec_le},
+    proofs::circuit::{
+        sapling::slice_into_boolean_vec_le,
+        util::{build_note_contents, hash_asset_info_to_preimage},
+    },
 };
 
 /// Info Needed:
@@ -51,42 +51,7 @@ impl Circuit<bls12_381::Scalar> for MintAsset {
         cs: &mut CS,
     ) -> Result<(), bellman::SynthesisError> {
         // Asset Commitment Contents
-        let mut identifier_commitment_contents = vec![];
-
-        // TODO: I wonder if we could hard-code this to minimize work?
-        // Not clear to me if the booleanizing is adding substantial time
-        // or if it's just a by-product of the hash taking longer due to
-        // more input. Also not clear if that has security implications
-        // by not witnessing the bits
-        let first_block_bits = slice_into_boolean_vec_le(
-            cs.namespace(|| "booleanize first block"),
-            Some(GH_FIRST_BLOCK),
-            64 * 8,
-        )?;
-
-        assert_eq!(first_block_bits.len(), 64 * 8);
-
-        let name_bits = slice_into_boolean_vec_le(
-            cs.namespace(|| "booleanize asset info name"),
-            self.asset_info.as_ref().and_then(|i| i.name().into()),
-            32 * 8,
-        )?;
-
-        let public_address_bits = slice_into_boolean_vec_le(
-            cs.namespace(|| "booleanize asset info public address"),
-            self.asset_info
-                .as_ref()
-                .and_then(|i| i.public_address_bytes().into()),
-            43 * 8,
-        )?;
-
-        let nonce_bits = slice_into_boolean_vec_le(
-            cs.namespace(|| "booleanize asset info nonce"),
-            self.asset_info
-                .as_ref()
-                .and_then(|i| slice::from_ref(i.nonce()).into()),
-            8,
-        )?;
+        let identifier_commitment_contents = hash_asset_info_to_preimage(cs, self.asset_info)?;
 
         // Public address validation
         // Prover witnesses ak (ensures that it's on the curve)
@@ -171,29 +136,14 @@ impl Circuit<bls12_381::Scalar> for MintAsset {
             .asset_info
             .as_ref()
             .and_then(|ai| Some(ai.asset_type()));
-        // Witness the asset type
-        // TODO: Does this properly verify that the spend note is the right asset generator?
-        // Could this be spoofed, or does this not matter? Need to consider what's public/private
-        // In other words: Does this verify that the actual note's asset generator is valid
-        // Or are we allowing this to be _any_ generator
-        let asset_generator = ecc::EdwardsPoint::witness(
-            cs.namespace(|| "asset_generator"),
-            asset_type
+
+        let public_address_bits = slice_into_boolean_vec_le(
+            cs.namespace(|| "booleanize asset info public address"),
+            self.asset_info
                 .as_ref()
-                .and_then(|at| at.asset_generator().into()),
+                .and_then(|i| i.public_address_bytes().into()),
+            43 * 8,
         )?;
-
-        let value_commitment_generator = ecc::EdwardsPoint::witness(
-            cs.namespace(|| "value commitment generator"),
-            asset_type
-                .as_ref()
-                .and_then(|at| ExtendedPoint::from(at.value_commitment_generator()).into()),
-        )?;
-
-        value_commitment_generator.assert_not_small_order(
-            cs.namespace(|| "value_commitment_generator not small order"),
-        )?;
-
         let calculated_pk_d_bits = pk_d.repr(cs.namespace(|| "representation of pk_d"))?;
         let asset_pk_d_bits = &public_address_bits[88..];
 
@@ -204,11 +154,6 @@ impl Circuit<bls12_381::Scalar> for MintAsset {
                 &calculated_pk_d_bits[i],
             )?;
         }
-
-        identifier_commitment_contents.extend(first_block_bits);
-        identifier_commitment_contents.extend(name_bits);
-        identifier_commitment_contents.extend(public_address_bits);
-        identifier_commitment_contents.extend(nonce_bits);
 
         let asset_identifier = blake2s::blake2s(
             cs.namespace(|| "blake2s(asset info)"),
@@ -317,50 +262,8 @@ impl Circuit<bls12_381::Scalar> for MintAsset {
             rt.inputize(cs.namespace(|| "anchor"))?;
         }
 
-        // Compute note contents:
-        // asset_generator, value (in big endian), g_d, pk_d
-        let mut note_contents = vec![];
-
-        // Place asset_generator in the note
-        note_contents
-            .extend(asset_generator.repr(cs.namespace(|| "representation of asset_generator"))?);
-
-        // Handle the value; we'll need it later for the
-        // dummy input check.
-        let mut value_num = num::Num::zero();
-        {
-            // Get the value in little-endian bit order
-            let value_bits = expose_value_commitment(
-                cs.namespace(|| "value commitment"),
-                value_commitment_generator,
-                self.value_commitment,
-            )?;
-
-            // Compute the note's value as a linear combination
-            // of the bits.
-            let mut coeff = bls12_381::Scalar::one();
-            for bit in &value_bits {
-                value_num = value_num.add_bool_with_coeff(CS::one(), bit, coeff);
-                coeff = coeff.double();
-            }
-
-            // Place the value in the note
-            note_contents.extend(value_bits);
-        }
-
-        // Place g_d in the note
-        note_contents.extend(g_d.repr(cs.namespace(|| "representation of g_d"))?);
-
-        // Place pk_d in the note
-        note_contents.extend(pk_d.repr(cs.namespace(|| "representation of pk_d"))?);
-
-        assert_eq!(
-            note_contents.len(),
-            256 + // asset_generator
-            64 + // value
-            256 + // g_d
-            256 // pk_d
-        );
+        let (note_contents, _) =
+            build_note_contents(cs, asset_type, self.value_commitment, g_d, pk_d)?;
 
         // Compute the hash of the note contents
         let mut cm = pedersen_hash::pedersen_hash(

--- a/ironfish-rust/src/proofs/circuit/mod.rs
+++ b/ironfish-rust/src/proofs/circuit/mod.rs
@@ -4,3 +4,4 @@ pub mod mycircuit;
 pub mod output;
 pub mod sapling;
 pub mod spend;
+pub mod util;

--- a/ironfish-rust/src/proofs/circuit/spend.rs
+++ b/ironfish-rust/src/proofs/circuit/spend.rs
@@ -155,8 +155,13 @@ impl Circuit<bls12_381::Scalar> for Spend {
 
         // Compute note contents:
         // asset_generator, value (in big endian), g_d, pk_d
-        let (note_contents, value_num) =
-            build_note_contents(cs, self.asset_type, self.value_commitment, g_d, pk_d)?;
+        let (note_contents, value_num) = build_note_contents(
+            &mut cs.namespace(|| "note contents preimage"),
+            self.asset_type,
+            self.value_commitment,
+            g_d,
+            pk_d,
+        )?;
 
         // Compute the hash of the note contents
         let mut cm = pedersen_hash::pedersen_hash(

--- a/ironfish-rust/src/proofs/circuit/util.rs
+++ b/ironfish-rust/src/proofs/circuit/util.rs
@@ -1,0 +1,155 @@
+use std::slice;
+
+use bellman::{
+    gadgets::{
+        boolean,
+        num::{self, Num},
+    },
+    SynthesisError,
+};
+use bls12_381::Scalar;
+use jubjub::ExtendedPoint;
+use zcash_primitives::constants::GH_FIRST_BLOCK;
+use zcash_proofs::circuit::ecc::{self, EdwardsPoint};
+
+use super::sapling::slice_into_boolean_vec_le;
+use crate::{
+    primitives::{asset_type::AssetInfo, sapling::ValueCommitment},
+    proofs::circuit::sapling::expose_value_commitment,
+    AssetType,
+};
+
+pub fn hash_asset_info_to_preimage<CS: bellman::ConstraintSystem<bls12_381::Scalar>>(
+    cs: &mut CS,
+    asset_info: Option<AssetInfo>,
+) -> Result<Vec<boolean::Boolean>, SynthesisError> {
+    let mut combined_preimage = vec![];
+
+    // TODO: I wonder if we could hard-code this to minimize work?
+    // Not clear to me if the booleanizing is adding substantial time
+    // or if it's just a by-product of the hash taking longer due to
+    // more input. Also not clear if that has security implications
+    // by not witnessing the bits
+    let first_block_bits = slice_into_boolean_vec_le(
+        cs.namespace(|| "booleanize first block"),
+        Some(GH_FIRST_BLOCK),
+        64 * 8,
+    )?;
+
+    assert_eq!(first_block_bits.len(), 64 * 8);
+
+    combined_preimage.extend(first_block_bits);
+
+    let name_bits = slice_into_boolean_vec_le(
+        cs.namespace(|| "booleanize name"),
+        asset_info.as_ref().and_then(|i| i.name().into()),
+        32 * 8,
+    )?;
+
+    assert_eq!(name_bits.len(), 32 * 8);
+
+    combined_preimage.extend(name_bits);
+
+    let public_address_bits = slice_into_boolean_vec_le(
+        cs.namespace(|| "booleanize public address"),
+        asset_info
+            .as_ref()
+            .and_then(|i| i.public_address_bytes().into()),
+        43 * 8,
+    )?;
+
+    assert_eq!(public_address_bits.len(), 43 * 8);
+
+    combined_preimage.extend(public_address_bits);
+
+    let nonce_bits = slice_into_boolean_vec_le(
+        cs.namespace(|| "booleanize nonce"),
+        asset_info
+            .as_ref()
+            .and_then(|i| slice::from_ref(i.nonce()).into()),
+        8,
+    )?;
+
+    assert_eq!(nonce_bits.len(), 8);
+
+    combined_preimage.extend(nonce_bits);
+
+    Ok(combined_preimage)
+}
+
+pub fn build_note_contents<CS: bellman::ConstraintSystem<bls12_381::Scalar>>(
+    cs: &mut CS,
+    asset_type: Option<AssetType>,
+    value_commitment: Option<ValueCommitment>,
+    g_d: EdwardsPoint,
+    pk_d: EdwardsPoint,
+) -> Result<(Vec<boolean::Boolean>, Num<Scalar>), SynthesisError> {
+    // Witness the asset type
+    // TODO: Does this properly verify that the spend note is the right asset generator?
+    // Could this be spoofed, or does this not matter? Need to consider what's public/private
+    // In other words: Does this verify that the actual note's asset generator is valid
+    // Or are we allowing this to be _any_ generator
+    let asset_generator = ecc::EdwardsPoint::witness(
+        cs.namespace(|| "asset_generator"),
+        asset_type
+            .as_ref()
+            .and_then(|at| at.asset_generator().into()),
+    )?;
+
+    let value_commitment_generator = ecc::EdwardsPoint::witness(
+        cs.namespace(|| "value commitment generator"),
+        asset_type
+            .as_ref()
+            .and_then(|at| ExtendedPoint::from(at.value_commitment_generator()).into()),
+    )?;
+
+    value_commitment_generator
+        .assert_not_small_order(cs.namespace(|| "value_commitment_generator not small order"))?;
+
+    // Compute note contents:
+    // asset_generator, value (in big endian), g_d, pk_d
+    let mut note_contents = vec![];
+
+    // Place asset_generator in the note
+    note_contents
+        .extend(asset_generator.repr(cs.namespace(|| "representation of asset_generator"))?);
+
+    // Handle the value; we'll need it later for the
+    // dummy input check.
+    let mut value_num = num::Num::zero();
+    {
+        // Get the value in little-endian bit order
+        let value_bits = expose_value_commitment(
+            cs.namespace(|| "value commitment"),
+            value_commitment_generator,
+            value_commitment,
+        )?;
+
+        // Compute the note's value as a linear combination
+        // of the bits.
+        let mut coeff = bls12_381::Scalar::one();
+        for bit in &value_bits {
+            value_num = value_num.add_bool_with_coeff(CS::one(), bit, coeff);
+            coeff = coeff.double();
+        }
+
+        // Place the value in the note
+        note_contents.extend(value_bits);
+    }
+
+    // Place g_d in the note
+    note_contents.extend(g_d.repr(cs.namespace(|| "representation of g_d"))?);
+
+    // Place pk_d in the note
+    note_contents.extend(pk_d.repr(cs.namespace(|| "representation of pk_d"))?);
+
+    assert_eq!(
+        note_contents.len(),
+        256 + // asset_generator
+        64 + // value
+        256 + // g_d
+        256 // pk_d
+    );
+
+    Ok((note_contents, value_num))
+}


### PR DESCRIPTION
## Summary

There's duplicated logic when computing the pre-image from asset info or building note contents for hashing. This change moves the repeated code into a utils file. I spent too long debugging a test and it was a minor difference between the two blocks of code.

## Testing Plan

Run this unit test for sanity:
```sh

running 1 test
test proofs::circuit::mint_asset::test::test_create_mint_asset_and_spend_circuit ... ok
```

The mint constraints are broken; I will address that in a subsequent PR.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
