### PR TITLE
Fix RPC stream kills process on disconnect

### DIFF
--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -319,7 +319,7 @@ export class MiningPool {
   }
 
   private async processNewBlocks() {
-    for await (const payload of this.rpc.blockTemplateStream().contentStream(true)) {
+    for await (const payload of this.rpc.blockTemplateStream().contentStream()) {
       Assert.isNotUndefined(payload.previousBlockInfo)
       this.restartCalculateTargetInterval()
 

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -148,7 +148,7 @@ export class MiningSoloMiner {
   }
 
   private async processNewBlocks() {
-    for await (const payload of this.rpc.blockTemplateStream().contentStream(true)) {
+    for await (const payload of this.rpc.blockTemplateStream().contentStream()) {
       Assert.isNotUndefined(payload.previousBlockInfo)
 
       const currentHeadTarget = new Target(Buffer.from(payload.previousBlockInfo.target, 'hex'))

--- a/ironfish/src/rpc/adapters/ipcAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.test.ts
@@ -96,12 +96,13 @@ describe('IpcAdapter', () => {
     await ipc.start()
     await client.connect()
 
-    client.request('foo/bar').contentStream()
+    const next = client.request('foo/bar').contentStream().next()
 
     client.close()
     waitResolve()
 
     expect.assertions(0)
+    await next
   })
 
   it('should handle errors', async () => {

--- a/ironfish/src/rpc/adapters/ipcAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.test.ts
@@ -5,6 +5,7 @@ import os from 'os'
 import * as yup from 'yup'
 import { Assert } from '../../assert'
 import { IronfishSdk } from '../../sdk'
+import { PromiseUtils } from '../../utils/promise'
 import { RpcRequestError } from '../clients'
 import { RpcIpcClient } from '../clients/ipcClient'
 import { ALL_API_NAMESPACES } from '../routes/router'
@@ -83,6 +84,24 @@ describe('IpcAdapter', () => {
 
     await response.waitForEnd()
     expect(response.content).toBe(undefined)
+  })
+
+  it('should not crash on disconnect while streaming', async () => {
+    const [waitPromise, waitResolve] = PromiseUtils.split<void>()
+
+    ipc.router?.register('foo/bar', yup.object({}), async () => {
+      await waitPromise
+    })
+
+    await ipc.start()
+    await client.connect()
+
+    client.request('foo/bar').contentStream()
+
+    client.close()
+    waitResolve()
+
+    expect.assertions(0)
   })
 
   it('should handle errors', async () => {

--- a/ironfish/src/rpc/clients/socketClient.ts
+++ b/ironfish/src/rpc/clients/socketClient.ts
@@ -103,7 +103,7 @@ export abstract class RpcSocketClient extends RpcClient {
       if (timeout) {
         clearTimeout(timeout)
       }
-      stream.close()
+      stream.close(...args)
       reject(...args)
     }
 

--- a/ironfish/src/rpc/response.ts
+++ b/ironfish/src/rpc/response.ts
@@ -49,8 +49,10 @@ export class RpcResponse<TEnd = unknown, TStream = unknown> {
    * not propagated
    */
   async *contentStream(ignoreClose = true): AsyncGenerator<TStream, void> {
-    this.promise.catch((e) => {
-      throw e
+    this.promise.catch(() => {
+      // In the streaming case the error is piped through the stream instead
+      // and we handle it there (below). The same error is piped through this promise
+      // but since we are already handling it in the stream we can ignore this one
     })
 
     if (this.timeout) {

--- a/ironfish/src/rpc/stream.ts
+++ b/ironfish/src/rpc/stream.ts
@@ -63,13 +63,13 @@ export class Stream<T> implements AsyncIterable<T> {
   }
 
   next(): Promise<IteratorResult<T>> {
-    if (this.error) {
-      return Promise.reject(this.error)
-    }
-
     if (this.buffer.length > 0) {
       const value = this.buffer.shift()
       return Promise.resolve({ done: false, value: value as T })
+    }
+
+    if (this.error) {
+      return Promise.reject(this.error)
     }
 
     if (this.closed) {

--- a/ironfish/src/rpc/stream.ts
+++ b/ironfish/src/rpc/stream.ts
@@ -31,8 +31,6 @@ export class Stream<T> implements AsyncIterable<T> {
   buffer: T[] = []
   waiting: [PromiseResolve<IteratorResult<T>>, PromiseReject][] = []
 
-  // Stream can either be open or closed
-  // It can be closed because of an error or just closed normally
   closed = false
   error: unknown
 
@@ -65,13 +63,13 @@ export class Stream<T> implements AsyncIterable<T> {
   }
 
   next(): Promise<IteratorResult<T>> {
+    if (this.error) {
+      return Promise.reject(this.error)
+    }
+
     if (this.buffer.length > 0) {
       const value = this.buffer.shift()
       return Promise.resolve({ done: false, value: value as T })
-    }
-
-    if (this.error) {
-      return Promise.reject(this.error)
     }
 
     if (this.closed) {

--- a/ironfish/src/rpc/stream.ts
+++ b/ironfish/src/rpc/stream.ts
@@ -1,32 +1,66 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { PromiseResolve } from '../utils'
+import { PromiseReject, PromiseResolve } from '../utils'
 
+/*
+ * A Stream takes a stream of data and transforms it into an iterable
+ * On one end the writer of the data is calling stream.write(data)
+ * and on the other end the consumer of the data is calling stream.next()
+ *
+ * If stream.next() is called before data is written then the request will be queued
+ * up in the `waiting` list by saving functions to resolve and reject the request
+ *
+ * stream.next()      -> [(res, rej)]               a resolve and reject for the data is queued in `waiting`
+ * stream.next()      -> [(res, rej), (res, rej)]
+ * stream.write(data) -> [(res, rej)]               the first Promise in waiting is resolved with the data
+ * stream.write(data) -> []                         the final Promise in waiting is resolved with the data
+ *
+ * If stream.write() is called before the reader requests with stream.next() then the
+ * data will be queued up in the `buffer` list
+ *
+ * stream.write(1) -> [1]                            data is queued up in the buffer
+ * stream.write(2) -> [1, 2]
+ * stream.write(3) -> [1, 2, 3]
+ * stream.next()   -> [2, 3]                         data is consumed from the buffer and resolved to next()
+ * stream.next()   -> [3]
+ *
+ * Because Stream implements AsyncIterable it can also be used in for...in loops
+ */
 export class Stream<T> implements AsyncIterable<T> {
   buffer: T[] = []
-  waiting: PromiseResolve<IteratorResult<T>>[] = []
+  waiting: [PromiseResolve<IteratorResult<T>>, PromiseReject][] = []
+
+  // Stream can either be open or closed
+  // It can be closed because of an error or just closed normally
   closed = false
+  error: unknown
 
   write(value: T): void {
     if (this.closed) {
       return
     }
 
-    if (this.waiting.length) {
-      const waiting = this.waiting.shift() as PromiseResolve<IteratorResult<T>>
-      waiting({ done: false, value: value })
+    const waiting = this.waiting.shift()
+    if (waiting) {
+      const [resolve] = waiting
+      resolve({ done: false, value: value })
       return
     }
 
     this.buffer.push(value)
   }
 
-  close(): void {
+  close(e?: unknown): void {
     this.closed = true
+    this.error = e
 
-    for (const resolve of this.waiting) {
-      resolve({ value: null, done: true })
+    for (const [resolve, reject] of this.waiting) {
+      if (!e) {
+        resolve({ value: null, done: true })
+      } else {
+        reject(e)
+      }
     }
   }
 
@@ -36,12 +70,16 @@ export class Stream<T> implements AsyncIterable<T> {
       return Promise.resolve({ done: false, value: value as T })
     }
 
+    if (this.error) {
+      return Promise.reject(this.error)
+    }
+
     if (this.closed) {
       return Promise.resolve({ value: null, done: true })
     }
 
-    return new Promise<IteratorResult<T>>((resolve) => {
-      this.waiting.push(resolve)
+    return new Promise<IteratorResult<T>>((resolve, reject) => {
+      this.waiting.push([resolve, reject])
     })
   }
 


### PR DESCRIPTION
## Summary
Reported [here](https://github.com/iron-fish/ironfish/issues/2148). When a server disconnects from a client during a streaming request it causes the client to crash. This is because the handling of the disconnect error (`.catch()`) is not attached until after `reject` is called on the request. This causes the `reject` to be treated as an unhandled promise reject. This default behavior for this in node is to crash the process. This fix adds a `.catch` statement so that even if the error is ignored it still will not crash the process

## Testing Plan
Local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
