### PR TITLE
Share close functionality between socket adapters

### DIFF
--- a/ironfish/src/rpc/clients/ipcClient.ts
+++ b/ironfish/src/rpc/clients/ipcClient.ts
@@ -7,7 +7,7 @@ import { Event } from '../../event'
 import { createRootLogger, Logger } from '../../logger'
 import { ErrorUtils } from '../../utils'
 import { IpcRequest } from '../adapters'
-import { RpcConnectionLostError, RpcConnectionRefusedError } from './errors'
+import { RpcConnectionRefusedError } from './errors'
 import { RpcClientConnectionInfo, RpcSocketClient } from './socketClient'
 
 const CONNECT_RETRY_MS = 2000
@@ -135,12 +135,7 @@ export class RpcIpcClient extends RpcSocketClient {
     this.client.off('error', this.onClientError)
     this.client = null
 
-    for (const request of this.pending.values()) {
-      request.reject(new RpcConnectionLostError(request.type))
-    }
-    this.pending.clear()
-
-    this.onClose.emit()
+    this.handleClose()
   }
 
   protected onClientError = (error: unknown): void => {

--- a/ironfish/src/rpc/clients/socketClient.ts
+++ b/ironfish/src/rpc/clients/socketClient.ts
@@ -10,7 +10,12 @@ import { IpcErrorSchema, IpcResponseSchema, IpcStreamSchema } from '../adapters'
 import { isRpcResponseError, RpcResponse } from '../response'
 import { Stream } from '../stream'
 import { RpcClient } from './client'
-import { RequestTimeoutError, RpcConnectionError, RpcRequestError } from './errors'
+import {
+  RequestTimeoutError,
+  RpcConnectionError,
+  RpcConnectionLostError,
+  RpcRequestError,
+} from './errors'
 
 const REQUEST_TIMEOUT_MS = null
 
@@ -34,10 +39,10 @@ export abstract class RpcSocketClient extends RpcClient {
   abstract close(): void
   protected abstract send(messageId: number, route: string, data: unknown): void
 
-  timeoutMs: number | null = REQUEST_TIMEOUT_MS
-  messageIds = 0
+  private timeoutMs: number | null = REQUEST_TIMEOUT_MS
+  private messageIds = 0
 
-  pending = new Map<
+  private pending = new Map<
     number,
     {
       response: RpcResponse<unknown>
@@ -137,6 +142,21 @@ export abstract class RpcSocketClient extends RpcClient {
     }
 
     pending.stream.write(result.data)
+  }
+
+  /*
+   * Should be called by all implementers when the connection is closed by the other side (server).
+   * This cleans up all the pending requests by rejecting them with a RpcConnectionLostError
+   *
+   * TODO: we should probably also have a cleanup function for when the client closes itself
+   */
+  protected handleClose = (): void => {
+    for (const request of this.pending.values()) {
+      request.reject(new RpcConnectionLostError(request.type))
+    }
+
+    this.pending.clear()
+    this.onClose.emit()
   }
 
   protected handleEnd = async (data: unknown): Promise<void> => {

--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -11,7 +11,7 @@ import {
   ServerSocketRpcSchema,
 } from '../adapters/socketAdapter/protocol'
 import { MessageBuffer } from '../messageBuffer'
-import { RpcConnectionLostError, RpcConnectionRefusedError } from './errors'
+import { RpcConnectionRefusedError } from './errors'
 import { RpcClientConnectionInfo, RpcSocketClient } from './socketClient'
 
 export class RpcTcpClient extends RpcSocketClient {
@@ -129,12 +129,7 @@ export class RpcTcpClient extends RpcSocketClient {
     this.client?.off('data', this.onClientData)
     this.client?.off('close', this.onClientClose)
 
-    for (const request of this.pending.values()) {
-      request.reject(new RpcConnectionLostError(request.type))
-    }
-    this.pending.clear()
-
-    this.onClose.emit()
+    this.handleClose()
   }
 
   protected onMessage = (data: unknown): void => {


### PR DESCRIPTION
## Summary
Both the `IPCClient` and the `TCPClient` implemented cleaning up and rejecting all the pending requests when the connection was closed by the server. This functionality is the same for both clients so should probably be done at the `SocketClient` level. Also `IPCClient` and `TCPClient` should not be concerned with pending requests, they should only know about how to transfer data to and from the server, not the content of the data (i.e. messageId)

## Testing Plan
Local testing + unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
