### PR TITLE
Fix overlapping values for mining randomness

### DIFF
--- a/ironfish-rust/src/mining/mine.rs
+++ b/ironfish-rust/src/mining/mine.rs
@@ -86,43 +86,66 @@ mod test {
         let header_bytes_base = &mut (0..128).collect::<Vec<u8>>();
         let target = &[0u8; 32];
         let mut start = 0;
-        let batch_size = 12;
-        let step_size = 2;
+        let batch_size = 10;
+        let step_size = 3;
+        // This is a helper var to hold the value of the start of the next batch basically
+        // Batch 1 should only test i values between start (0) and batch_size - 1 (9)
+        // Batch 2 should only test i values between 10 and 19, etc.
+        let mut expected_end = batch_size;
 
-        // Uses i values: 0, 2, 4, 6, 8, 10
+        // Uses i values: 0, 3, 6
         let header_bytes = &mut header_bytes_base.clone();
         let _ = mine_batch(header_bytes, target, start, step_size, batch_size);
 
         let mut cursor = Cursor::new(header_bytes);
         let end = cursor.read_u64::<BigEndian>().unwrap();
-        assert_eq!(end, 10);
+        assert!(end < expected_end);
 
-        // Uses i values: 1, 3, 5, 7, 9, 11
+        // Uses i values: 1, 4, 7
         let header_bytes = &mut header_bytes_base.clone();
         let _ = mine_batch(header_bytes, target, start + 1, step_size, batch_size);
 
         let mut cursor = Cursor::new(header_bytes);
         let end = cursor.read_u64::<BigEndian>().unwrap();
-        assert_eq!(end, 11);
+        assert!(end < expected_end);
+
+        // Uses i values: 2, 5, 8
+        let header_bytes = &mut header_bytes_base.clone();
+        let _ = mine_batch(header_bytes, target, start + 2, step_size, batch_size);
+
+        let mut cursor = Cursor::new(header_bytes);
+        let end = cursor.read_u64::<BigEndian>().unwrap();
+        assert!(end < expected_end);
 
         // Second batch
         start += batch_size;
+        // Simple sanity check to make sure the batch 2 start is not using values from batch 1
+        assert_eq!(start, expected_end);
+        expected_end = start + batch_size;
 
-        // Uses i values: 12, 14, 16, 18, 20, 22
+        // Uses i values: 10, 13, 16
         let header_bytes = &mut header_bytes_base.clone();
         let _ = mine_batch(header_bytes, target, start, step_size, batch_size);
 
         let mut cursor = Cursor::new(header_bytes);
         let end = cursor.read_u64::<BigEndian>().unwrap();
-        assert_eq!(end, 22);
+        assert!(end < expected_end);
 
-        // Uses i values: 13, 15, 17, 19, 21, 23
+        // Uses i values: 11, 14, 17
         let header_bytes = &mut header_bytes_base.clone();
         let _ = mine_batch(header_bytes, target, start + 1, step_size, batch_size);
 
         let mut cursor = Cursor::new(header_bytes);
         let end = cursor.read_u64::<BigEndian>().unwrap();
-        assert_eq!(end, 23);
+        assert!(end < expected_end);
+
+        // Uses i values: 12, 15, 18
+        let header_bytes = &mut header_bytes_base.clone();
+        let _ = mine_batch(header_bytes, target, start + 2, step_size, batch_size);
+
+        let mut cursor = Cursor::new(header_bytes);
+        let end = cursor.read_u64::<BigEndian>().unwrap();
+        assert!(end < expected_end);
     }
 
     #[test]

--- a/ironfish-rust/src/mining/mine.rs
+++ b/ironfish-rust/src/mining/mine.rs
@@ -64,7 +64,7 @@ mod test {
     #[test]
     fn test_mine_batch_match() {
         let header_bytes = &mut [0, 1, 2, 4, 5, 6, 7, 8];
-        let batch_size = 2;
+        let batch_size = 3;
         let start = 42;
         let step_size = 1;
 

--- a/ironfish-rust/src/mining/mine.rs
+++ b/ironfish-rust/src/mining/mine.rs
@@ -28,8 +28,8 @@ pub(crate) fn mine_batch(
     step_size: usize,
     batch_size: u64,
 ) -> Option<u64> {
-    let end = start + batch_size - 1;
-    for i in (start..end).step_by(step_size) {
+    let end = start + batch_size - step_size as u64;
+    for i in (start..=end).step_by(step_size) {
         randomize_header(i, header_bytes);
         let hash = blake3::hash(header_bytes);
 
@@ -86,43 +86,43 @@ mod test {
         let header_bytes_base = &mut (0..128).collect::<Vec<u8>>();
         let target = &[0u8; 32];
         let mut start = 0;
-        let batch_size = 8;
+        let batch_size = 12;
         let step_size = 2;
 
-        // Uses i values: 0, 2, 4, 6
+        // Uses i values: 0, 2, 4, 6, 8, 10
         let header_bytes = &mut header_bytes_base.clone();
         let _ = mine_batch(header_bytes, target, start, step_size, batch_size);
 
         let mut cursor = Cursor::new(header_bytes);
         let end = cursor.read_u64::<BigEndian>().unwrap();
-        assert_eq!(end, 6);
+        assert_eq!(end, 10);
 
-        // Uses i values: 1, 3, 5, 7
+        // Uses i values: 1, 3, 5, 7, 9, 11
         let header_bytes = &mut header_bytes_base.clone();
         let _ = mine_batch(header_bytes, target, start + 1, step_size, batch_size);
 
         let mut cursor = Cursor::new(header_bytes);
         let end = cursor.read_u64::<BigEndian>().unwrap();
-        assert_eq!(end, 7);
+        assert_eq!(end, 11);
 
         // Second batch
         start += batch_size;
 
-        // Uses i values: 8, 10, 12, 14
+        // Uses i values: 12, 14, 16, 18, 20, 22
         let header_bytes = &mut header_bytes_base.clone();
         let _ = mine_batch(header_bytes, target, start, step_size, batch_size);
 
         let mut cursor = Cursor::new(header_bytes);
         let end = cursor.read_u64::<BigEndian>().unwrap();
-        assert_eq!(end, 14);
+        assert_eq!(end, 22);
 
-        // Uses i values: 9, 11, 13, 15
+        // Uses i values: 13, 15, 17, 19, 21, 23
         let header_bytes = &mut header_bytes_base.clone();
         let _ = mine_batch(header_bytes, target, start + 1, step_size, batch_size);
 
         let mut cursor = Cursor::new(header_bytes);
         let end = cursor.read_u64::<BigEndian>().unwrap();
-        assert_eq!(end, 15);
+        assert_eq!(end, 23);
     }
 
     #[test]

--- a/ironfish-rust/src/mining/mine.rs
+++ b/ironfish-rust/src/mining/mine.rs
@@ -120,7 +120,7 @@ mod test {
 
         // Second batch
         start += batch_size + step_size as u64 - (batch_size % step_size as u64);
-        // Simple sanity check to make sure the batch 2 start is not using values from batch 1
+        // Simple sanity check to make sure this batch is not overlapping values from the previous batch
         assert!(start > end);
 
         // Uses i values: 12, 15, 18, 21
@@ -149,7 +149,7 @@ mod test {
 
         // Third batch
         start += batch_size + step_size as u64 - (batch_size % step_size as u64);
-        // Simple sanity check to make sure the batch 2 start is not using values from batch 2
+        // Simple sanity check to make sure this batch is not overlapping values from the previous batch
         assert!(start > end);
 
         // Uses i values: 24, 27, 30, 33

--- a/ironfish-rust/src/mining/thread.rs
+++ b/ironfish-rust/src/mining/thread.rs
@@ -132,7 +132,7 @@ fn process_commands(
                         println!("Search space exhausted, no longer mining this block.");
                         break;
                     }
-                    batch_start += default_batch_size;
+                    batch_start += batch_size + step_size as u64 - (batch_size % step_size as u64);
                 }
             }
             Command::Pause => {


### PR DESCRIPTION
## Summary

Closes https://github.com/iron-fish/ironfish/issues/2185

Previously, the miner would check values at the batch size boundaries more than once, leading to wasted work. This change prevents that from happening by making the end value less than the start of the next batch size

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
