### PR TITLE
evict transactions cache from account

### DIFF
--- a/ironfish/src/rpc/routes/accounts/getNotes.ts
+++ b/ironfish/src/rpc/routes/accounts/getNotes.ts
@@ -46,11 +46,11 @@ export const GetAccountNotesResponseSchema: yup.ObjectSchema<GetAccountNotesResp
 router.register<typeof GetAccountNotesRequestSchema, GetAccountNotesResponse>(
   `${ApiNamespace.account}/getAccountNotes`,
   GetAccountNotesRequestSchema,
-  (request, node): void => {
+  async (request, node): Promise<void> => {
     const account = getAccount(node, request.data.account)
 
     const responseNotes = []
-    for (const { transaction } of account.getTransactions()) {
+    for await (const { transaction } of account.getTransactions()) {
       responseNotes.push(...getTransactionNotes(account, transaction))
     }
 

--- a/ironfish/src/rpc/routes/accounts/getTransaction.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransaction.ts
@@ -72,7 +72,7 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
     let transactionInfo = null
     const transactionNotes = []
 
-    for (const { transaction, blockHash, sequence } of account.getTransactions()) {
+    for await (const { transaction, blockHash, sequence } of account.getTransactions()) {
       if (unsignedTransactionHash.equals(transaction.unsignedHash())) {
         transactionInfo = {
           status: await getTransactionStatus(

--- a/ironfish/src/rpc/routes/accounts/getTransactions.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransactions.ts
@@ -56,10 +56,9 @@ router.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactio
   GetAccountTransactionsRequestSchema,
   async (request, node): Promise<void> => {
     const account = getAccount(node, request.data.account)
-    const transactions = account.getTransactions()
     const responseTransactions = []
 
-    for (const { transaction, blockHash, sequence } of transactions) {
+    for await (const { transaction, blockHash, sequence } of account.getTransactions()) {
       let transactionCreator = false
 
       for (const spend of transaction.spends()) {

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -179,6 +179,7 @@ export class Account {
       }
 
       this.decryptedNotes.set(noteHash, note)
+      await this.accountsDb.saveDecryptedNote(this, noteHash, note, tx)
 
       const transaction = await this.getTransaction(note.transactionHash, tx)
       this.saveDecryptedNoteSequence(noteHash, transaction?.sequence ?? null)

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -22,7 +22,6 @@ export class Account {
   private readonly accountsDb: AccountsDB
   private readonly decryptedNotes: BufferMap<DecryptedNoteValue>
   private readonly nullifierToNoteHash: BufferMap<Buffer>
-  private readonly transactions: BufferMap<Readonly<TransactionValue>>
 
   private readonly sequenceToNoteHashes: Map<number, BufferSet>
   private readonly nonChainNoteHashes: BufferSet
@@ -69,7 +68,6 @@ export class Account {
     this.accountsDb = accountsDb
     this.decryptedNotes = new BufferMap<DecryptedNoteValue>()
     this.nullifierToNoteHash = new BufferMap<Buffer>()
-    this.transactions = new BufferMap<TransactionValue>()
 
     this.sequenceToNoteHashes = new Map<number, BufferSet>()
     this.nonChainNoteHashes = new BufferSet()
@@ -89,10 +87,6 @@ export class Account {
   async load(): Promise<void> {
     let unconfirmedBalance = BigInt(0)
 
-    for await (const { hash, transactionValue } of this.accountsDb.loadTransactions(this)) {
-      this.transactions.set(hash, transactionValue)
-    }
-
     for await (const { hash, decryptedNote } of this.accountsDb.loadDecryptedNotes(this)) {
       this.decryptedNotes.set(hash, decryptedNote)
 
@@ -100,7 +94,9 @@ export class Account {
         unconfirmedBalance += new Note(decryptedNote.serializedNote).value()
       }
 
-      this.saveDecryptedNoteSequence(decryptedNote.transactionHash, hash)
+      const transaction = await this.getTransaction(decryptedNote.transactionHash)
+
+      this.saveDecryptedNoteSequence(hash, transaction?.sequence ?? null)
     }
 
     await this.saveUnconfirmedBalance(unconfirmedBalance)
@@ -114,7 +110,6 @@ export class Account {
     await this.accountsDb.database.withTransaction(tx, async (tx) => {
       await this.accountsDb.replaceDecryptedNotes(this, this.decryptedNotes, tx)
       await this.accountsDb.replaceNullifierToNoteHash(this, this.nullifierToNoteHash, tx)
-      await this.accountsDb.replaceTransactions(this, this.transactions, tx)
     })
   }
 
@@ -125,7 +120,6 @@ export class Account {
 
     this.decryptedNotes.clear()
     this.nullifierToNoteHash.clear()
-    this.transactions.clear()
 
     await this.saveUnconfirmedBalance(BigInt(0), tx)
   }
@@ -172,6 +166,7 @@ export class Account {
   ): Promise<void> {
     await this.accountsDb.database.withTransaction(tx, async (tx) => {
       const existingNote = this.decryptedNotes.get(noteHash)
+
       if (!existingNote || existingNote.spent !== note.spent) {
         const value = new Note(note.serializedNote).value()
         const currentUnconfirmedBalance = await this.accountsDb.getUnconfirmedBalance(this, tx)
@@ -183,21 +178,15 @@ export class Account {
         }
       }
 
-      this.saveDecryptedNoteSequence(note.transactionHash, noteHash)
       this.decryptedNotes.set(noteHash, note)
-      await this.accountsDb.saveDecryptedNote(this, noteHash, note, tx)
+
+      const transaction = await this.getTransaction(note.transactionHash, tx)
+      this.saveDecryptedNoteSequence(noteHash, transaction?.sequence ?? null)
     })
   }
 
-  private saveDecryptedNoteSequence(transactionHash: Buffer, noteHash: Buffer): void {
-    const transaction = this.transactions.get(transactionHash)
-    Assert.isNotUndefined(
-      transaction,
-      `Transaction undefined for '${transactionHash.toString('hex')}'`,
-    )
-
-    const { sequence, blockHash } = transaction
-    if (blockHash) {
+  private saveDecryptedNoteSequence(noteHash: Buffer, sequence: number | null): void {
+    if (sequence) {
       Assert.isNotNull(sequence, `sequence required when submitting block hash`)
       const decryptedNotes = this.sequenceToNoteHashes.get(sequence) ?? new BufferSet()
       decryptedNotes.add(noteHash)
@@ -220,7 +209,7 @@ export class Account {
     let submittedSequence = 'submittedSequence' in params ? params.submittedSequence : null
 
     await this.accountsDb.database.withTransaction(tx, async (tx) => {
-      const record = this.transactions.get(transactionHash)
+      const record = await this.getTransaction(transactionHash, tx)
       if (record) {
         submittedSequence = record.submittedSequence
       }
@@ -249,7 +238,6 @@ export class Account {
     transactionValue: TransactionValue,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
-    this.transactions.set(hash, transactionValue)
     await this.accountsDb.saveTransaction(this, hash, transactionValue, tx)
   }
 
@@ -330,7 +318,7 @@ export class Account {
         }
       }
 
-      const record = this.transactions.get(transactionHash)
+      const record = await this.getTransaction(transactionHash, tx)
       if (record && record.sequence) {
         const { sequence } = record
         const noteHashes = this.sequenceToNoteHashes.get(sequence)
@@ -364,12 +352,15 @@ export class Account {
     await this.accountsDb.deleteNullifier(this, nullifier, tx)
   }
 
-  getTransaction(hash: Buffer): Readonly<TransactionValue> | undefined {
-    return this.transactions.get(hash)
+  async getTransaction(
+    hash: Buffer,
+    tx?: IDatabaseTransaction,
+  ): Promise<Readonly<TransactionValue> | null> {
+    return await this.accountsDb.loadTransaction(this, hash, tx)
   }
 
-  getTransactions(): Generator<Readonly<TransactionValue>> {
-    return this.transactions.values()
+  getTransactions(tx?: IDatabaseTransaction): AsyncGenerator<Readonly<TransactionValue>> {
+    return this.accountsDb.loadTransactionValues(this, tx)
   }
 
   async deleteTransaction(transaction: Transaction, tx?: IDatabaseTransaction): Promise<void> {
@@ -411,7 +402,6 @@ export class Account {
         }
       }
 
-      this.transactions.delete(transactionHash)
       await this.accountsDb.deleteTransaction(this, transactionHash, tx)
     })
   }

--- a/ironfish/src/wallet/accounts.test.slow.ts
+++ b/ironfish/src/wallet/accounts.test.slow.ts
@@ -187,61 +187,6 @@ describe('Accounts', () => {
     })
   }, 600000)
 
-  it('Loads only the transactions that an account owns a note or spend nullifier for', async () => {
-    // Initialize the database and chain
-    const strategy = nodeTest.strategy
-    const node = nodeTest.node
-    const chain = nodeTest.chain
-
-    const accountA = await node.accounts.createAccount('A', true)
-
-    // Initial balance should be 0
-    await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(accountA)).resolves.toEqual({
-      confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
-    })
-
-    // Create a block with a miner's fee awarded to account A
-    const minersfee = await strategy.createMinersFee(BigInt(0), 2, accountA.spendingKey)
-    const newBlock = await chain.newBlock([], minersfee)
-    const addResult = await chain.addBlock(newBlock)
-    expect(addResult.isAdded).toBeTruthy()
-
-    // Account A should now have a balance of 2000000000 after adding the miner's fee
-    await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(accountA)).resolves.toEqual({
-      confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
-    })
-
-    // Create a second account
-    const accountB = await node.accounts.createAccount('B', true)
-
-    // Account A should have one transaction
-    expect(Array.from(accountA.getTransactions()).length).toEqual(1)
-
-    // Account B should have zero transactions
-    expect(Array.from(accountB.getTransactions()).length).toEqual(0)
-
-    // Clear caches for both accounts
-    await clearAccountCaches(accountA)
-    await clearAccountCaches(accountB)
-
-    // Both accounts should have zero transactions
-    expect(Array.from(accountA.getTransactions()).length).toEqual(0)
-    expect(Array.from(accountB.getTransactions()).length).toEqual(0)
-
-    // Load account data from db
-    await node.accounts.loadAccountsFromDb()
-
-    // Account A should have one transaction
-    expect(Array.from(accountA.getTransactions()).length).toEqual(1)
-
-    // Account B should have zero transactions
-    expect(Array.from(accountB.getTransactions()).length).toEqual(0)
-  }, 600000)
-
   it('Loads only the nullifiers that an account owns a note for', async () => {
     // Initialize the database and chain
     const strategy = nodeTest.strategy
@@ -1053,7 +998,6 @@ describe('Accounts', () => {
 })
 
 async function clearAccountCaches(account: Account): Promise<void> {
-  account['transactions'].clear()
   account['decryptedNotes'].clear()
   account['nullifierToNoteHash'].clear()
   await account['saveUnconfirmedBalance'](BigInt(0))

--- a/ironfish/src/wallet/accounts.test.ts
+++ b/ironfish/src/wallet/accounts.test.ts
@@ -83,7 +83,7 @@ describe('Accounts', () => {
     })
 
     // Check that it was last broadcast at its added height
-    let invalidTxEntry = accountA.getTransaction(invalidTx.hash())
+    let invalidTxEntry = await accountA.getTransaction(invalidTx.hash())
     expect(invalidTxEntry?.submittedSequence).toEqual(GENESIS_BLOCK_SEQUENCE)
 
     // Check that the TX is not rebroadcast but has it's sequence updated
@@ -94,7 +94,7 @@ describe('Accounts', () => {
     expect(broadcastSpy).toHaveBeenCalledTimes(0)
 
     // It should now be planned to be processed at head + 1
-    invalidTxEntry = accountA.getTransaction(invalidTx.hash())
+    invalidTxEntry = await accountA.getTransaction(invalidTx.hash())
     expect(invalidTxEntry?.submittedSequence).toEqual(blockB2.header.sequence)
   })
 

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -275,6 +275,18 @@ export class AccountsDB {
     }
   }
 
+  async *loadTransactionValues(
+    account: Account,
+    tx?: IDatabaseTransaction,
+  ): AsyncGenerator<TransactionValue> {
+    for await (const transactionValue of this.transactions.getAllValuesIter(
+      tx,
+      account.prefixRange,
+    )) {
+      yield transactionValue
+    }
+  }
+
   async loadTransaction(
     account: Account,
     transactionHash: Buffer,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -587,8 +587,8 @@ export class Accounts {
       let confirmed = false
 
       if (transactionHash) {
-        const transaction = account.getTransaction(transactionHash)
-        Assert.isNotUndefined(
+        const transaction = await account.getTransaction(transactionHash)
+        Assert.isNotNull(
           transaction,
           `Transaction '${transactionHash.toString('hex')}' missing for account '${
             account.id
@@ -779,7 +779,7 @@ export class Accounts {
     }
 
     for (const account of this.accounts.values()) {
-      for (const transactionInfo of account.getTransactions()) {
+      for await (const transactionInfo of account.getTransactions()) {
         const { transaction, blockHash, submittedSequence } = transactionInfo
         const transactionHash = transaction.hash()
 
@@ -853,7 +853,7 @@ export class Accounts {
     }
 
     for (const account of this.accounts.values()) {
-      for (const { transaction, blockHash } of account.getTransactions()) {
+      for await (const { transaction, blockHash } of account.getTransactions()) {
         // Skip transactions that are already added to a block
         if (blockHash) {
           continue


### PR DESCRIPTION
## Summary

reads transactions from database instead of holding all transactions in memory.

- converts all reads of transactions to use database
- removes test of loading transactions into cache
- refactors saveDecryptedNoteSequence to take a note hash and a sequence instead of loading a transaction

## Testing Plan

- updated unit tests
- ran `accounts:transactions` on migrated pool account

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
