### PR TITLE
Move account in memory caches to accounts DB

### DIFF
--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -348,6 +348,16 @@ export class Migration013 extends Migration {
 
         // Delete note from old store so that it will not be reprocessed if we resume the migration
         await stores.old.noteToNullifier.del(noteHashHex, tx)
+
+        if (transaction.sequence) {
+          await stores.new.sequenceToNoteHash.put(
+            [accountPrefix, [transaction.sequence, noteHash]],
+            null,
+            tx,
+          )
+        } else {
+          await stores.new.nonChainNoteHashes.put([accountPrefix, noteHash], null, tx)
+        }
       })
 
       countNote++

--- a/ironfish/src/migrations/data/013-wallet-2/new/nonChainNoteHashes.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/nonChainNoteHashes.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { IDatabaseStore } from '../../../../storage'
+
+export type NonChainNoteHashesStore = IDatabaseStore<{
+  key: [Buffer, Buffer]
+  value: null
+}>

--- a/ironfish/src/migrations/data/013-wallet-2/new/sequenceToNoteHash.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/sequenceToNoteHash.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { IDatabaseStore } from '../../../../storage'
+
+export type SequenceToNoteHashStore = IDatabaseStore<{
+  key: [Buffer, [number, Buffer]]
+  value: null
+}>

--- a/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
@@ -6,16 +6,20 @@ import {
   BigIntLEEncoding,
   BufferEncoding,
   IDatabase,
+  NULL_ENCODING,
   NullableBufferEncoding,
   PrefixEncoding,
   StringEncoding,
+  U32_ENCODING,
 } from '../../../../storage'
 import { AccountsStore, AccountValue, AccountValueEncoding } from './accounts'
 import { BalancesStore } from './balances'
 import { DecryptedNotesStore, DecryptedNoteValueEncoding } from './decryptedNotes'
 import { HeadHashesStore } from './headHashes'
 import { AccountsDBMeta, MetaStore, MetaValueEncoding } from './meta'
+import { NonChainNoteHashesStore } from './nonChainNoteHashes'
 import { NullifierToNoteHashStore } from './nullifierToNoteHash'
+import { SequenceToNoteHashStore } from './sequenceToNoteHash'
 import { TransactionsStore, TransactionValueEncoding } from './transactions'
 
 export type NewStores = {
@@ -26,6 +30,8 @@ export type NewStores = {
   headHashes: HeadHashesStore
   decryptedNotes: DecryptedNotesStore
   balances: BalancesStore
+  nonChainNoteHashes: NonChainNoteHashesStore
+  sequenceToNoteHash: SequenceToNoteHashStore
 }
 
 export function loadNewStores(db: IDatabase): NewStores {
@@ -71,6 +77,22 @@ export function loadNewStores(db: IDatabase): NewStores {
     valueEncoding: new TransactionValueEncoding(),
   })
 
+  const sequenceToNoteHash: SequenceToNoteHashStore = db.addStore({
+    name: 's',
+    keyEncoding: new PrefixEncoding(
+      new BufferEncoding(),
+      new PrefixEncoding(U32_ENCODING, new BufferEncoding(), 4),
+      4,
+    ),
+    valueEncoding: NULL_ENCODING,
+  })
+
+  const nonChainNoteHashes: NonChainNoteHashesStore = db.addStore({
+    name: 'S',
+    keyEncoding: new PrefixEncoding(new BufferEncoding(), new BufferEncoding(), 4),
+    valueEncoding: NULL_ENCODING,
+  })
+
   return {
     meta,
     decryptedNotes,
@@ -79,5 +101,7 @@ export function loadNewStores(db: IDatabase): NewStores {
     nullifierToNoteHash,
     accounts,
     transactions,
+    sequenceToNoteHash,
+    nonChainNoteHashes,
   }
 }

--- a/ironfish/src/storage/database/encoding.test.ts
+++ b/ironfish/src/storage/database/encoding.test.ts
@@ -30,8 +30,8 @@ describe('Encoding', () => {
     it('should prefix keys', async () => {
       await db.open()
 
-      const keyRangeA = StorageUtils.getPrefixKeyRange(Buffer.from('a'), 1)
-      const keyRangeB = StorageUtils.getPrefixKeyRange(Buffer.from('b'), 1)
+      const keyRangeA = StorageUtils.getPrefixKeyRange(Buffer.from('a'))
+      const keyRangeB = StorageUtils.getPrefixKeyRange(Buffer.from('b'))
 
       // Write operations
       await prefixStore.put(['a', 'a'], 'a')

--- a/ironfish/src/storage/database/encoding.ts
+++ b/ironfish/src/storage/database/encoding.ts
@@ -33,6 +33,18 @@ export class U32Encoding implements IDatabaseEncoding<number> {
   }
 }
 
+export class NullEncoding implements IDatabaseEncoding<null> {
+  static EMPTY_BUFFER = Buffer.alloc(0)
+
+  serialize(): Buffer {
+    return NullEncoding.EMPTY_BUFFER
+  }
+
+  deserialize(): null {
+    return null
+  }
+}
+
 export class BufferEncoding implements IDatabaseEncoding<Buffer> {
   serialize = (value: Buffer): Buffer => value
   deserialize = (buffer: Buffer): Buffer => buffer
@@ -46,8 +58,8 @@ export class PrefixEncoding<TPrefix, TKey> implements IDatabaseEncoding<[TPrefix
   readonly prefixSize: number
 
   constructor(
-    keyEncoding: IDatabaseEncoding<TKey>,
     prefixEncoding: IDatabaseEncoding<TPrefix>,
+    keyEncoding: IDatabaseEncoding<TKey>,
     prefixSize: number,
   ) {
     this.keyEncoding = keyEncoding
@@ -59,7 +71,11 @@ export class PrefixEncoding<TPrefix, TKey> implements IDatabaseEncoding<[TPrefix
     const prefixEncoded = this.prefixEncoding.serialize(value[0])
     const keyEncoded = this.keyEncoding.serialize(value[1])
 
-    this.assertPrefixSize(prefixEncoded)
+    if (prefixEncoded.byteLength !== this.prefixSize) {
+      throw new PrefixSizeError(
+        `key prefix expected to be ${this.prefixSize} byte(s) but was ${prefixEncoded.byteLength}`,
+      )
+    }
 
     return Buffer.concat([prefixEncoded, keyEncoded])
   }
@@ -72,20 +88,6 @@ export class PrefixEncoding<TPrefix, TKey> implements IDatabaseEncoding<[TPrefix
     const keyDecoded = this.keyEncoding.deserialize(key)
 
     return [prefixDecoded, keyDecoded]
-  }
-
-  getKeyRange(prefix: TPrefix): DatabaseKeyRange {
-    const encoded = this.prefixEncoding.serialize(prefix)
-    this.assertPrefixSize(encoded)
-    return StorageUtils.getPrefixKeyRange(encoded)
-  }
-
-  private assertPrefixSize(prefix: Buffer): void {
-    if (prefix.byteLength !== this.prefixSize) {
-      throw new PrefixSizeError(
-        `key prefix expected to be byte size ${this.prefixSize} but was ${prefix.byteLength}`,
-      )
-    }
   }
 }
 
@@ -175,3 +177,4 @@ export class BigIntLEEncoding implements IDatabaseEncoding<BigInt> {
 export const BUFFER_TO_STRING_ENCODING = new BufferToStringEncoding()
 export const BUFFER_ENCODING = new BufferEncoding()
 export const U32_ENCODING = new U32Encoding()
+export const NULL_ENCODING = new NullEncoding()

--- a/ironfish/src/storage/database/encoding.ts
+++ b/ironfish/src/storage/database/encoding.ts
@@ -6,8 +6,7 @@ import bufio from 'bufio'
 import hexArray from 'hex-array'
 import { IJSON, IJsonSerializable, Serde } from '../../serde'
 import { BigIntUtils } from '../../utils'
-import { DatabaseKeyRange, IDatabaseEncoding } from './types'
-import { StorageUtils } from './utils'
+import { IDatabaseEncoding } from './types'
 
 export class JsonEncoding<T extends IJsonSerializable> implements IDatabaseEncoding<T> {
   serialize = (value: T): Buffer => Buffer.from(IJSON.stringify(value), 'utf8')

--- a/ironfish/src/storage/database/utils.test.ts
+++ b/ironfish/src/storage/database/utils.test.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { StorageUtils } from '../database/utils'
+
+describe('StorageUtils', () => {
+  describe('getPrefixKeyRange', () => {
+    it('should single byte generate prefix', () => {
+      const prefix = Buffer.alloc(1, 2)
+      const range = StorageUtils.getPrefixKeyRange(prefix)
+
+      expect(range.gte.byteLength).toBe(1)
+      expect(range.lt.byteLength).toBe(1)
+      expect(range.gte[0]).toBe(2)
+      expect(range.lt[0]).toBe(3)
+    })
+
+    it('should multi byte generate prefix', () => {
+      const prefix = Buffer.concat([Buffer.alloc(1, 2), Buffer.alloc(1, 4)])
+      const range = StorageUtils.getPrefixKeyRange(prefix)
+
+      expect(range.gte.byteLength).toBe(2)
+      expect(range.lt.byteLength).toBe(2)
+      expect(range.gte[0]).toBe(2)
+      expect(range.gte[1]).toBe(4)
+      expect(range.lt[0]).toBe(2)
+      expect(range.lt[1]).toBe(5)
+    })
+  })
+})

--- a/ironfish/src/utils/buffer.ts
+++ b/ironfish/src/utils/buffer.ts
@@ -9,6 +9,22 @@ function toHuman(buffer: Buffer): string {
     .trim()
 }
 
+function incrementLE(buffer: Buffer): void {
+  for (let i = 0; i < buffer.length; i++) {
+    if (buffer[i]++ !== 255) {
+      break
+    }
+  }
+}
+
+function incrementBE(buffer: Buffer): void {
+  for (let i = buffer.length - 1; i >= 0; i--) {
+    if (buffer[i]++ !== 255) {
+      break
+    }
+  }
+}
+
 function equalsNullable(a: Buffer | null | undefined, b: Buffer | null | undefined): boolean {
   return a == null || b == null ? a === b : a.equals(b)
 }
@@ -16,4 +32,6 @@ function equalsNullable(a: Buffer | null | undefined, b: Buffer | null | undefin
 export const BufferUtils = {
   toHuman,
   equalsNullable,
+  incrementLE,
+  incrementBE,
 }

--- a/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
@@ -1,0 +1,112 @@
+{
+  "Accounts should store notes at sequence": [
+    {
+      "id": "9ab103a1-ead0-4e7d-9473-e6210f6f9ed1",
+      "name": "accountA",
+      "spendingKey": "24dd77597b4f40172ddb554b348edc582c45baffd7e65560ac29b66fd9c91ce9",
+      "incomingViewKey": "c71c3da3cfbcac7815944a67e70da9137622265d489055638dcd3b96a3e2e803",
+      "outgoingViewKey": "0ce09afb6916b73067a772f51088f93a87021d4ff94c9e050565f94a339e2e16",
+      "publicAddress": "bbe29a522650aa55f81b4f0505e7414bebeefac8ba4a69859dc22e0bf166b39e9989113dd458d46e2aa886"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:9+YVncYjdw93DtS1N4CoKUwefJ9MThu/LZQfDukN/j0="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1663827361679,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "B03605019D4D9403B5343D37C831FBB6E2A28FA50EF6C85F2ACF8819C166951D",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKLeTPLiwtDp0sfvxYzoSuo3wIv1xcpfpaSxllcyjbNpS47+FN7FoFs1yOSbyKp0+JBsZgpTEBqti5uP9V3H0AGCAQtgS9+wb0d5GtgV++8NCPbESPiKtJATYTme+qWiVRDgZlb8+jujFKHJFmY2kPMvRA8jbkTmTgiOdbsiVTdktdiYJmu+28OBqjkSFLTrqqBr5EfuBxfw9x/Uw+cJWNnp6YunHAlAN/T1p7gXKBn3vOvbYTicG+b6aIzmSIoLFJBX0HwKUfaLa9/h1Z09v9lXZ7oRCIUtFbmlsONXOQwvJblCZ6nEiEnsXoWFppK66xP+RSopS8VsWCS4+lh8bk6eYbQ9rsJXOq4+2VZU6Ztoihl7+MIXAqBscqFVLF50Kk2eQkKOQBSak0OWEB09ttnXHWz3Ijx0WjOaB9mlDbJlDv8yLx64Y+iULaqE6i75Val4jEzs/oUA7CMQPG3Td1Qb+M2fOERYLGcQvmSB2bXdGJpCmAGluQPvT59ARL1e/+E9F0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0+Qfhpgg0A6rjvwsFv3YWiXSA7qus9MR6Oz13MS6Ems8oI+90iAmnTiQfTAddAqIE/W/qI37t5LMa8g/N0wSDg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "B03605019D4D9403B5343D37C831FBB6E2A28FA50EF6C85F2ACF8819C166951D",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:ebq2Ya4v0SyMpOvDWn5bG6SXClKTW68WUBirfRvgoDw="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1663827362346,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "5574D1CB688FEB7054E264344E248E1BAC2E1B139FA22954654A880248DAF2B3",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALCY7xyCYynA6223GMh+zeJeHSTCylC6N7BLQ1G8m7vkGDx+ybYP/8wXcF0pRVedQ6g1Kd0QmnPasMxQAlswYeJZMlWQaGsLxn61Iac5RLzaIJw/myKWwOAFJm76geoLjxaLh3W6QgbSpNsz9yrEYhDqMGraVg+M3Z3hVuv00S/V/8cLpyn48xxKZhlPOEu3bqYEBW7F1HRTodzPa5pSmn+vZbrSbNM6Z47O6E17XpjGs8oNb4mCPGNmnwVnEgEUC5oHp/SuaLhMcSTeUgcGvDJ1Fne0tv1TkMQZAH3kaZxnDEnUwmlWSe9wOX/Wbiz6XEo4Ku63rwE1V0Uc+P5HqVT1ugJ34k1tdztCnuZE7ln8PVmU1HsHWGmG1PZkR7VjK/Gh49VGY7AgZr8jxBvwjiszRFyzD8z/Oz6ZZPgyVBT7lpJtkw+BU6ldHlJyK+CZrWa1Pa8fPROVbpuUuCSxmyQXyFPBOOCRrTbCfEE2ks17aWPCvvFda5wMCsE/abLha/s3ZkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwzl85e7DouIm4qM4DK41Obx3pQi+a1rdyyEZfZQQxnc7ej6zu5alJJG7q90FehJStXvyVRuTwfaiurjv/d2OwDQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts should delete transaction": [
+    {
+      "id": "243c71f3-f436-4f63-be48-552d2ccb4db3",
+      "name": "accountA",
+      "spendingKey": "473654f4d0a07a09959587d801232839d01e6d8a71f8f1cba864cd2fb5409d6b",
+      "incomingViewKey": "49cc712b503e8c4804bf326d0685ce80afed2ddcb8acb471136fbd6a46680901",
+      "outgoingViewKey": "0b5f52ab7c9c8eb57b20243a5e459a415cf3624105e0e9dca9d4647ea21aa954",
+      "publicAddress": "8594f955914ee3ae18d7bfeb7228215429fa657a23b2f7b469f0d9a247d64269eb520d31726d04896c2b19"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:T2b/kxY2ZgeyIiLX/bTCbhtoELTTzsN9pLZPGkAk5lo="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1663827363533,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "C8030BE2944CFA980499EF01B6AD81821A129BD843D304100B4C1B9DC1049E1A",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJlnaygeXGvMazJ9S6Vzpkus6CYuTii9co1g8eB0feZbPyo6kyAmFg2wJqlQAdFXQZiOMAHaR2+DN5ahBcx4bdqrDY26jxk61XQ7Zh/SMJS8lZowWplt2/1KZTMtiE0dOhAV84xduki5fdaeo3t3HZ+duO89/+0wuLBpMHDSK+Ucmrfsymo8zUf6ZDmM5+puMqJiPALUw+p7W8N304TF9MvRsXsVXCo+6L1LorawWdsGAAM0o++nSyl8JPO1QgcvF3rSJ6m/eMRtLB6epx32RmZKjITlxjVgT9GZE3n3CjyzxltKKIumQzWx3u3C9C2rKyV3KZbRE71DNGPwZCxjJAilsOhWuBI0zr3fLPymXWw0mB5jsqy7xIYj+GkO1frumlHDn9G2/CblcvNCjWSKl8vwIXcdIjS+5duziqt5pfhjuykki5rUVzfGOxwUmRXPcFZe/W806UJZDqWVwWq3ZzQlo2FdYnHohHGi3CuC5zbNY+nHPRhDHLQ2xxIkFAi8VcbCAEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEix9gsneLLRYJLrf+S2zZWFqqEZFsL5BT/jRoU1aE0qn2HYA0HbmtCAZSOMWiUqFRnlRV8jjfk9Cf8G8EWAJBQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/wallet/__fixtures__/accounts.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/accounts.test.ts.fixture
@@ -503,6 +503,66 @@
           "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJh4g3NUhHvBD15FTaoNjZTVkb5Cc99VqJWFzfxjkikyeLABmiSOMEEly8nHtdf3kpIjVaJ7Y/ZZ/02y9q5c8g7EQVtPASFiz9wwVYrskNwphRmwZqgavFy8pJwuCsoUTQJhzBNUxnyLm8jTeBD5TMqTb4Hk40ACK+Eo2I3FL9O4UxOCn7ECSbGuIN6EAW/5oIIYCsXG95Y/hpZj755VQR2+h+z4fwh03gF058hL9Xg0r6gxF23ubKurW0WKV6gL84ZgyrPO0EvaLcVz+608gdjTIUDCUjnVV1JMcEYNQArscegMHWdv/XxQ74z/MM4q1xtbdn1QmHP0cHcvsBpphRMsIRFUgN/faQ9YjLThFqQe//JNjrm2M4gZRU7P6FKyhUQqGY3YdygiUrptm574U/4dPeRmtCK00h700bgG/NT//v0FZ6PWTIuyv8RoE36ALKmf1QNP9qAs1UiMIzZLbLjAGQn5VlU+C0HsR3UZbcXPLXXmtykJenPewikfAHqCTRb2TUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwdvJVoUzySKpodp+kwV5kaStJZHVjHCh/t0Jtgg4tkd1XTZOqF5AktHAK1LR7xCfx5RxGc1n5DWUqKn7OfO4DA=="
         }
       ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "A5F6FE1AE3F20FA5F547763735D59195807E8C863B77DF251CF512D0389B58DB",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:c9cT5ge6y9XxDCyz0chgxHodkP1Z+3rz2yvnWY3h9Ek="
+          },
+          "size": 6
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12748075573094071260697199444610197482511904927824894683337718312",
+        "randomness": "0",
+        "timestamp": 1663833496185,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "A7FC0A44BF0E82480C7649FBDF5E84E6B488635B61F453B55171C9AA3CC26C40",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALcOvkXNkzpQepto93k8gOg26zJSsywULeF3/0bbE/ojyBH2gS7MUpoDcMtRz52fH6xnit1tYB+r5oVkxEPNCOibV0PBb0kzPFlt51nd24xqw79lPBMGkaBvQEFhESrkjAZWlFuIA+4RsAYTPdCDkY6LMOSgZzH94BpX5YjryeYpU0vVXX8YgOWj4HvXic54LItF0++bdbI3oOm4wXhZ8WtGlhlwEoSBhzecAPv2mqNCtcALxATaQVsvpPlHTmLLIJbrc1Y7LVoSZb3w+waqhwVt79vjNOJt4Rcf2sh7sFOwnYuUEWSr/6hiVnYU43GjBGYkYARj2xy6NZEDkjDVxG7z83Rm2LpxEDQTAOwNs3JCyuSdLKr2lasQYDgZkHNzqTzZmjwquKsm7gjFkS8UsldLLB0N7OUo9O4HmvQ422eX3T3RDHY9PUTrmyovmcqLzqkyF3wcySOM3Ob4jM4AhSAVLvGjTPSdNSwsAP4Yica7GjBZiBKbtjIYCzG18Ion3/yf30JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGgX0tafAN57Bq9YtpC7zh2blvQNUl4pEFtHXIIvj+Q8Ftt7bdpFOv0kLNGDdFMkq3InWP0OB62Ovn3Qwcy1iDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "A7FC0A44BF0E82480C7649FBDF5E84E6B488635B61F453B55171C9AA3CC26C40",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:Md20imPcXOAh3TFZ6OKyeU70/WeTdb/IqTbRG0iiPHM="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12710836793427115092230281943405998905502494236709291365074188333",
+        "randomness": "0",
+        "timestamp": 1663833496354,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "CF3840890A2D58F2D2E3F886E982D888BC797537C99ED0A0F5DE5A091882C21F",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJH87IAYH+KRg2PPfk8yYdAZYHvveSV7Cee2rIZ4SyjQYBFI2rXIooUVnRIkl7CbD6Suoqq3+aPG2Y6DNdsa10RlFDIMW0ncScmhuJkG8GJnkBnkTi2EhbXAP3KqxtIfqhQRjhQ+2sKspXdSq+OR7R4o/ou9+S987xfJx3floumQP7cZWnc3gxsvZivJPCwtNoimDqu9LfohxTODfNsorxsWM+UVP1MsmRDcg9yeahbW+RJqlKIDFDxiO5kduv98aTWnFby9T0ocO5TntB3fvusApK6PipjxIqx9YNNt+y5se+bEDunrve/jDv3D9e6b1fAPsvjCBcLGuL99lYUYmz87TbbuA8uPUhbGZIpIpaciN4tXP73ObJ5kNdVtIfUSHog+R/Qfi1EZcSl8TSoJSGOteWL7axH9tvHP17E1HcV99Te+eWLvji/V4RhtvxoI/GPhDrIN2RYpiDQJUSDeJnE+oDDwzpMSkcJfKBE7L4RKxwToGxHY8NAeHZZ8SLKP0WTaP0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8I22+AzIVM9Y+IUpmAtgzH+u6ujwghxMu6lZULM7SMDdUOuoo/Ao9GoDK/5EO0vmhT3v9KPEAnvqFwWbc0dGBQ=="
+        }
+      ]
     }
   ],
   "Accounts getEarliestHeadHash should return the earliest head hash": [

--- a/ironfish/src/wallet/__fixtures__/accounts.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/accounts.test.ts.fixture
@@ -1,20 +1,20 @@
 {
   "Accounts should handle transaction created on fork": [
     {
+      "id": "78c9a425-429d-4b45-a53e-11ea22f73113",
       "name": "a",
-      "spendingKey": "a6a90f570481a0d4a251fcf73d3ca7ff90f833581aef3f1f6c19af267ebf615c",
-      "incomingViewKey": "f39a68f6135ce35908b5ae2bca725f9cbe995e12b42780d0e04e063256d7dd07",
-      "outgoingViewKey": "7bbb37643e2bd7501ba8efb75250f6e2d4689c130aee3757cbbd741305089e1b",
-      "publicAddress": "385d90b1ef1d91115fb8c80a4a4b16cd7ccf44ff425daaaf61226152c3cfe625932731d6a3a633957b6e2c",
-      "rescan": null
+      "spendingKey": "2526948b2f45344789385227d9902a816b256b7c77f5e50d533b7c10463a6442",
+      "incomingViewKey": "07b7ee61dd7470ff01499d49252297c63a139fe981ea8d22fcec14cdcf92d004",
+      "outgoingViewKey": "fe6179df903840d361387136e952768870a2aac9a769094c4d773c9bf1caa2c0",
+      "publicAddress": "6302eb9b521ef592bdb4b67d0a96a16a4c700bac2821ce884d2b69c921ebb7a979627721f68844b8a6dc39"
     },
     {
+      "id": "0c52fe9e-8ae9-42d7-adcb-d30f1f2feaba",
       "name": "b",
-      "spendingKey": "ec9a1879a76f1504853d053e94f5c74a88360766d1a8b9c71312cb1b2fe07a1a",
-      "incomingViewKey": "119ea33c32e2c9c796e196d4ab0076119050c2de3e7349f56a875b81d3661d02",
-      "outgoingViewKey": "35c7f6fd5bbffc0e88741ee3ad336d683059bcd50fffb8403cdd9f976b5b8162",
-      "publicAddress": "60d4ccd0a432dbd12b16ec5836b9ae7267311f455454dc9abb5b6eb39c0e2a718a2e2bcba8c8fbd2a2cce3",
-      "rescan": null
+      "spendingKey": "449b81a16e7f2519764ba336587971c9dc197b513d3004f97601400b0ff73bf6",
+      "incomingViewKey": "2ed64c5ed5950a5b6c23a9e8708a116cca917a9f6a55ae24fc422745a6ac1d04",
+      "outgoingViewKey": "88687cf1c710a0e69a93403955d60578b0e66558fd06a7812a6c79649cd84ee9",
+      "publicAddress": "8755fe3c3d89df17b3510fb35e9dc744962b2b5d534d79d5344b056efea93894d1a451a3d78ce4c2c6a3f3"
     },
     {
       "header": {
@@ -23,7 +23,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:9iJzOftKudHh0dn7WtXl7QWcbnfkVVGKipzj8syfpRY="
+            "data": "base64:aapUnm/2mmqEBKfYS+FNpCXgWN/2t/DAHG/ywcOcFVg="
           },
           "size": 4
         },
@@ -33,16 +33,16 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1657827940436,
+        "timestamp": 1663827355209,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "CD6DAD0B7A1E65EE3BA7C99B648A16B410B77325C9121624D8C45697955076A9",
+        "hash": "459B1A0A552B5257A57481BDDC5546284FD904EDDE01FCFD19EE046920C6959D",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJcsDm/Kp0RqJOPbUnNDClD2g/vHQwRA0eVige5ecavDLJCTR64I34Vm1OsCvXOTaqiLrkDJGbfoo7wNVThFUCQgJnke/X6QEW0Zkjh6P3n26UdlT63RJ8lz72DBfTjJUAhXpXiy9ML7BrLVOgqf/3XRgrOG2yOvPyVG7o1JPA3zAAgZIaoL4NiLFqpWh+jShrRoM60x7yZwjmlC5cyb4H64U4nyazTXCdEm8/XoMDYYv6YL2N3VTfZms090sfBfLLHao2IHcphyrnS5s5PXUdqsf4SDUUlRSwbYgsNCkGJHhidMQ1We/3C9BtrtdKjS/KjhQLvC+NAgHpkhnrn830yfEGo495NPzuBk35TDFidUSWlfWKxcJWftdm3fVadxnfuY0VKdES6D/fjjfIfdTRNjM6tYxSnvOJLaYD36BTRZIG0W+4kYVGLOUKZckKLpKOb/c3gOxTExUALQrZRG0E+wVrORowvvJKXb0s4802JnEmCGv1QLOx4RBALkrxFKMSXae0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhuR+PutB/g3OzNcvgPe/+s8S+gY8Mi96vohk/Vam+GhTgvsEWmUN1TimjJ0AFWQM3Pftp+hlj7o1W2CUW2djBg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALCWDaEm7h3J7sLZEnqHLsq8GwInQqq6CTt4ZYWMwARPqvgYCdWcWfFa+3UERAAcMY75wMolid/TawnLkJdg4rIBktV73hGIIg+DkveoBh/qGLX73WUaV8TSxcwbaQsvmwVXXUd3VG8+JUwqCFlUPd2NaHVxhGZxAKihMTpBoAd3PVZ6fWFhtJLPYQ4/wMuR1YH1z63F/si3smqWgi74qbUVk73R69/xW98pqkDjm2BpWVL68E5pf+5LfDXMDllFVcoqlMHzOGscGJOMqsKLny4BurkknYNA/hpY/KPaEGhNtv0SpfW1iFiVK6gFkeeLDoczcSzo8JGEgRL52zo/LWAiTe6LZkX70Y5cxwsNk09JdRdQ/4sAugg5GqQztYq063lWYtla2+I3qoNs8XCW4/69b7hGRTqlyVoPAoGc1ItEj8O6FmxFZ4dVqtnAGPRaZDgfYh3Y5/lXAw++OoDb5iJnZdORU1DS8die4rKxoBhCGzz4XMAW1w7Q+FO9Hh1j5m/72UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRmHLi1y7qm4nOQL+BjU+4bDTrC/vQEeNWXBWNnEYZQVb31d/Vk6QsCCsXTO0zq2UDCw4J2Rm7DY8XI8D6zxfDQ=="
         }
       ]
     },
@@ -53,7 +53,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:uSsjGLRHwwwCujyDcVZi8QTJP/c/dA3279ASRs1g4z4="
+            "data": "base64:LAd0HGxU9YYZlz8fz9sBHRPgfECGktWqfgCokH8UCRQ="
           },
           "size": 4
         },
@@ -63,27 +63,27 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1657827940590,
+        "timestamp": 1663827355739,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "474778CA0E3E4815ED9DFAC4B5219647AB5B358EE2AA1478B44903217EDBFA03",
+        "hash": "AE508F68AB9FADF673C49D9515C553CE011467AA83F1458EC3E6C8B14F7E39C9",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALLjENCT89FgJbfBcBfaDkIiZfNiKt3G5JKpyz7Hn6aLiqfOLfODcIX/8G/MvryjGIP/pLaZFoQRVxFN2pHSHj50jP/zdYlaVplRsfrnWqpf08LT72wsVklQC7zE2JwtzRGRe07TExT13v4QdbstNRG4ZfIQVCq3sFIJijhxlSyNTiiSX4nFkvkMrcka7IPwx5gBJpbzXJpG1aTvweb5vh/B/18dkyDJTnr+7FXIRrFM6uSuhBkl+uJAhVtB6P2Ne3u1IxEZ74Xp+q2xKvC4+Ch+nU2suMlCqmaDJcisH0TyymHA1dfyUvdo9LD/UWDeKsjq+hgUSZDJ4Lq9haTxxm9pPUgGu2DabprT8XdO23E9jp893zmYRmh7mAFwfekBwXrlTv9pXesltmSwuQ4GyX7BFE15ERA5O5nOKEMFfYvWpk6NQRH6rbXM2ffsbj2vGPplbydkz+g4SsZLucxQLZLTN4owa6M7atJFkmHPe6g11fq7sQSKkomtlRI6dB4jIX+tIUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw29vdVbKXBUHI5ZVl0Ku6V/Ff30+HESmFbrURRSV9tDtxmL0/gu03NCkoPy0cgZZ3aZ4r19T/d5Rqf4VcSMzcAg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKae6bK8/7ZfW4y4IVzJvLbPGyQHslXdxn1xo5slKXoq+FBXajagg8VrvE2cAotCe7d4252rHNPvRiSPISDmGanwQ73dS+zE/Se8+vMtRP37m/KVFMy8+nw8I0CAwhLzcw7G4H+J+99Whpry70zTTQJFrrE9PmqHdX/b0bcMQiC7tBKQj5AwOL+iOELFRil3XqwU78bcKYyTv8PLf6ARaokBeZf0+nWE67qjdGY7wNrTg5fxmeqTqmPFoz1F9gg5NlXuMujzmJqTIP14fthGYs/tP9Yjvrc+1sEzo18Gm5E79E7YJHJ/MVYBcElO30ehSMxxMEO0PDSb529yxPsm4grjnK621dhjNaTXc4sgO7dvycWHSsL2Y5/eHr8eLUqfPB5Sez/C4p7mcTFpIXWjujCWpSU05ay25KPBhKWH/zEQv7HgV3ToAFVVgBOBMXVdj4LsCqixIyKmfS2Bp4YPJP/Sh3lMdD+i+ZlEIk1DOcE2+tlGHfaykfweCxz45nsSfj7x9kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyOJ2OxqNc8yU89GkBE4c8HHcVoJ8FsxZNWxtgxXDmvJrfULfwsarBPUQLCk5WwKHX8QH6Gh43KrSYpjwfLLbAg=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "474778CA0E3E4815ED9DFAC4B5219647AB5B358EE2AA1478B44903217EDBFA03",
+        "previousBlockHash": "AE508F68AB9FADF673C49D9515C553CE011467AA83F1458EC3E6C8B14F7E39C9",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:fMG/qCIZTdwQrz/1Lu0Cvs8vZAfgAkCp23uJ3D8Rtl8="
+            "data": "base64:XTCZy8AoHnrNanGTFXYy9RXKrQDf/RcW17DOlzWZQ1Y="
           },
           "size": 5
         },
@@ -93,50 +93,50 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1657827940739,
+        "timestamp": 1663827356279,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "8B23E975C83EBD41E4DF37D927AD119230CF75D3438EC271519620D1908C5D86",
+        "hash": "C9EE200581EA683DE82F1B93D3AEF452676A52C6A7D7E186B1F4316401906131",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKPwgBpRf7snlUxES6G4p7VXirDH+a6mFUEbPBvWYwyxQPNtFT3RPcaZKjCEA4bvCqr0V5dTjZl7/E0yeELvC9/vweZOaORqsjX647WPZ5B5TdOq0+0S26CSGPh0dCbcEgV+Tk9s6HBXV5TVrx9MAjJw+WYGEQSe+wys3pzyUVHMtxgqp16Up9DoDWG0T6u4Jrn6+GJoifoWzzvt47/mXXhiMejwx0vt9zT7tQfczuFzgatpEeqMSMP6fncKkLg5YIhQ2X52xvLQBjnJ8B2kZUhDq91DJvQHCDdbk3fNOVhHPJOvF/ZGPjMSJUUDPUfCToCIg52WwMitOU0ROGB8wURbtiDzAc+zd3ZCcHiJpbFYjBRIDMalywgiFaNjz8ZOg/4SJryjeIqbH+t88dfGRuna8Zbnyzq6jmp79aSX0FQRUnIMrNCGhKbbkUA06zZGAVhfppRavvPlJPYlHi+TqB4tx4Nu/4wt1+gNDU+DHC3QYDlsdbDkd3Yn+efncKM07TDGB0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwk1KdDm5V4u8xkihXxSYI4KFm0QuuYoczfvfpye/JcEdt3QBcS/mgFCy7avz+kJldXRH9DZwJHU2wJAQMAuWwCw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALmMViKJXGK+jVEphVTran3gBhqKjo2S5v5Y2MkzZLtwV4WChuDhzyQyECiu2ouuyq86WLUpWyCe1QltR3TuNk1ON8tT5g7b8A0WrFPIXszRoDGnfEBH0hsE8MOvXgaazxLsP6peg/HsmH5Iqmc0fxw/tAXM7sFWi/rhXtA6Ab9O86eKkr5LI9FxFF2ZeGXMr404pMAp7bnN/SiCKmSVxbxSw2AMqX+KOvj1G01iDSKJUKjA/juT2qji9PZperahIEOUIIsRY8Stuf550npisM4PIa/AfeT8b4iSqQqE9fjZGAb5ZAmA7I5bIDlP31rm+KJOFKWkVbGY6VmFq3gbCnINQBf/E3wkgLps3r7/H9b0uTvOfPQKuho2SYOXPFXv8sI1OIE8MGVc2mv45bBNGgC8g+mfuPmuBBcAyehYaN8I2iM+xNhP1Sb1MOCOFlyxzSnfC0tbn0fCMuprZxYIR684xNrYud430qTjZPCTBfVFYD7xEJzvGh3qwE3JWZbAOiU7RUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIDjg4Fyw+dFnVooncrpq1ZcsZ9xXgCc/k4x4jAvNGgi0e/wz84sKhjbx9lyvmiK406hXJDVCd3ws612d5IozBQ=="
         }
       ]
     },
     {
       "type": "Buffer",
-      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAALkhpkA/Ixu+1q8I6ZqgGY0rmWPIGR2j/erLWwSkuo2se980RdCCQxNy9Obj2T4lbqLgL1LzJaRzftHCbCOVVar/Ic+W2gGj3958nQP/IEsPd8RoSrimJGHdODYax6OJ+BnaYWcQxKl2RFAI85bWrSyyJpohyp5mlYIDgxYXHXlDBIQpdTfp3t86GxV/E1lSHILLdFcfoF8IDMk+JBRbM/KKA7XHlaW9/vFyLsTwBKvSGeWI0MAaFv1PVA0+o9608FCaJh38QtEUM5DVuHgpmNX0PRnI7TpWj8eFRGns8UQZgzVnJy819B5ohursnyyWOJNo6109DcK0z+RIQn7mQEX2InM5+0q50eHR2fta1eXtBZxud+RVUYqKnOPyzJ+lFgQAAABczErRucIDlGAIzDVbcm4EgC/MV+m+pvAGT5QNtWCRLxgGPx+65b0TnHZffMGseJChwqHrL8dSgfeQXFBUJVXEbcCWea9BVsxZptUauPatD9TIcxK0fWiRoTW3SmMBMQ2TSzzUhRnOaLtbWM3o+Eup05m5ONh25j1AyIGqaNuk6NwLysf/eGP3Lc+o553MrLuUXn2nrMkK6ihss0pZdEBTik9HSQrjEXqUz0IBuLlBWW9+RmXAkivfQYvtr5NwXIcS65+tL7oh8tdf7Xb2VAdBEmcjx3lVeD59m274n60b9qK6T/44xjyH77KrSVC1MouKu29g61nwuYG3ZqaR7yl/6nXjdKHrlKE8VOdakRkb36NwmR/dUuRe5DgstkfCE1gRzD17yEt4m5F2iMyRutFKI1N48/IBPBFUZSy8P42/iIoE+8MMY5AMf2+Ajhpm8QaY+7/75pcKQdVusF83E0ETXcLTRO5pX5ay1OF+7w7n7mqbTYejU1YaiXKK/cU4vuW2LhX0pwe6vlqd7uxJ0rnGY+5eqPzNnKBIM4n6MWEFYAfr0BGusN7Jj5f8V1ZbIHA4R1ooxBveYRnBRiAZWvnRPnZ2b9jiCPiZ6fOeIkTV2Izq4k3YBAjHeJiOSNrzn3h+0pbNmnbTjZj2ipSePxLL93/FOhn2qT6w3jJJPZEwnkd++8rC26b3Jb8eZVYc8vVjXKRl5SmZefTmtvEwpbHClm8Au08pVxetlq+sRAymbPGDr6gT3xcXIdkpoKve+paEvpxsSodn410F1yU2YIbixNsbhA1d0ExWZ6c9cUaW3EeVe6GAVP2FtUVrnJXAHJn3klpOYiedC3VvSX4TFysX5VyhCinIdp+QzfWziUYGv2i+vRkdHOjRSjcxtW/hwKF2+MFZYxz//H2O0qP1MCxu2tVNDkUb0V3j+ho6z6gx35qWqa40uB40o/0wh5o0VF4pqhW/8gUHA9SFnHVXO3Wnh8MoflRtrG7rFcw1Cl9A1KTpQgYD1lIaMbS/dOydz4KiD/Tbar/hXFxIbMItOrsKSCoxfcXZDKWRZ1kC4YkHjy1/mlnhlGfHD1AFE4jZmKmAiy9zOAT1yZk5TtnhANvB0CVgmOvincRkH5AHT6ot8tdJhFOFYmzCnRgz78LmTn8JXQJZ7yPCiGigAGoiT+eE/A0BfZ5l4fikC2Wn85ck68xBhnusB8x3nc/lN+QNL3jt47XH0J+zUFUjEyeFJcNnmDITySvK9jr6bHxDE3g0xAn3dMvBdx/ROv2opks2kpz8NpjgU/Ij/mav+Os/mOoK1LMijh81D8neJJSXVJPCo9VfhHNMv0Jh4815FzU00YKQhpg5sduXjRYTXv5jh1wWwuJ55OlDTyurprA/g5aZ+MIJJnDq4r39yjQ5bTapiwQ7v+pucdJfKrp/ItS92CqqhINsdkRCmkqS3JLcHE9UHsU48vRCCA=="
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAJnwseVTJh1FIadZA+CxNWelkK3mh4FoQOCFMhn89LNEAJE0ZeJwjGDsgt4azQp+/4so++4XUzXA+6qYIIlA07L8ZLIm/Ju29lKRQGBpRZcMdVpzak1zJNoTmLnaHDjcgAJsYbV5UoFjAvGsRt/LBmRWf8YDI4oHWVbn2bUGn6AyjGSYjPWKrs/GmoQ7/7hcjICH4pO8GVwxvEHFyqa3QvskmXIap9ugU+4d/fy/GV3ZEDQxq3sYTbGAM6syxEXpZAE2xUdX52jxFUfGv6J28xZQXhu5hOOoaqJtMPorYIBZB0Zbq9Vc9zqP+rogvyU836JnZPeAmJbHVS5zJDrqGgBpqlSeb/aaaoQEp9hL4U2kJeBY3/a38MAcb/LBw5wVWAQAAADCBzMuPkrbfcZYbVOnOPn9QcwzZO/MG9sdmygWB8XbKVB62Rk4iqkUEt6FkipmiCCU/CJ2HkuJY1+MhBw14MM6Il+Q/K/gA4yZf/Ncbf8xbgrxSKi8JZ85mPGOgyiKBQiwDZmIav2gpK8hiwW+38RtvAsmW992lFSeSIM7SY8hXoS/CiVjau5+F1ehhRbMWFi2jtouOY+b1aXXEsbUiLk7Jl2qRYwOIifjAAMzRxqX9e0Sb4f/XBkGzaLQCRTY450HmLpEnSsTuIlGECOIlVvICpFpywu2MhR6fCWRz84aF542BkUs4PYf1TvqEOA8l0aquW++JegtlLoq3Jz+KZH9XMkDyXgCCmm1rOhwolb+O63tfLucjyuWxJSncy9ZH6kKU5HvlFb9Qp3iMZ2W4dfkb1RNx2IlXf1JMEIypSFLgeGANuJO1MLpjSIMx9z/ojbmSpuFb9LUaTb5rDN9NJoLq/bouCYTCPJH9rmhdCwifyvu1P5wj7kIHEwfGwQTgw+ab+twcAUk2v0jhSZP65mmUdOAEscQbJ6NVmuGpxRawtiYzGBSMvgWujx3OFUAij50c/cngcafiQWVM8AfDZ48oPbXlE7uVGgVxRrgHWJunYyJRGQw7WS53o6tmJjkyp5ngpXEjMHZYx4Iwub3t46VlkKYTKwfWCkAzE+kPmnSepEegvRgCVJgD8f1EQUKIteMIX4kfPO+IUS0n/FvtxnbxT1CP3Gwv7n8sKQmKmmJjT0bBKcADT3S/Pj6PE+X+fwnfTeFlffw5wR1764anlAN0wTUnw71gmAU7bBBhYQNAkOb3K1V/jBrSDq+2xIvGKBN+JZpHb+l6nT4DMnolu9oMf7UV/HLf8r3G+kzL3Zpa4rsxw1LomEAbLctKz+RMhq1I64v68C/tAUC8fRO8k6yWHg8YDvINOgbMh9842Mz+R3aMKIUk9wUSFnyWuodSKc8xtFAo7fk116GsLGkH8sBvT15xeZiWPVbVlV3Tt+TCmnwiIvTfT86cvfvKEID6pvt9ucRDhlHOrQjMY/k6Qw84CMil5VJqzJEZHbgTHV/+MBUIDCYoNtXrf8TQTrA6aE+0jUqZ3Ae/APeiQCHUcgSAtuuDg5ZHJHRO7kSt8lkUmKt8WEZQVmFjNeH0kKM0q3b6wseUg6pU8LPdsAz+ItWXHqWKxT+OHWmQIEGy1V7amhHGNuNlTdTUcmbwF+1fru4RojBUR5hBpAJdSMYuQl1AKsM5O6SH1n1YdykUV8lkncjEnTn3tnLTvI0FNDx0Nt54dcYjFEcq27d3EKaPov1RfO3BvarXp0qbzHyNqsJm8DnZE3OwLIs8d/0X+WVgOKj4JBqydRBwaC7I0M2Y05y55aCHGy+YYd/cciQr7HR4QJCW8qCMSkTm1ZTzJVBxbLbEandJj8w+SdbOiT++pc5eDEfEMwg6+XnnMn5ZuKrNwXpgV5mBA=="
     }
   ],
   "Accounts updateHeadHash should update head hashes for all existing accounts": [
     {
+      "id": "3b8d4e6e-d06e-47d2-81fc-30895393699c",
       "name": "accountA",
-      "spendingKey": "2f36a72de927610a3b96d9e2e10c4175e6b01cddb2cc7abd9f0a6c331c325a66",
-      "incomingViewKey": "d093e09f487ff91567ae20596ee2d88f73650ebe42bd72a993cbd9571bc8cd06",
-      "outgoingViewKey": "4adcf4f076349fe28349fec014af1d15879d8eff71f1dd43c775a6c62f10592b",
-      "publicAddress": "717552b89874c1fd1bc100c5feef4c4d9af3653d17e5f51e2f35818a52dd249598a24c8702096d05e97ce9",
-      "rescan": null
+      "spendingKey": "ce208cca8fe1ea1edfef26c50b85faa01866cab2af8f0381c1cfdd62de5f3174",
+      "incomingViewKey": "92237bd75f3330d69a779f9cf3b62ea5d584da77685f4789fe87b45243736c01",
+      "outgoingViewKey": "e8c0c52f1cb3fe17d5c1f2169f0cdc34cb64f85bab348bfdadccd9cf6e3f584d",
+      "publicAddress": "cf4882c28f32d8e40356ffe9eb0d05d0128dc8dad49543c2f15e531b51615512152ae497d8230f7075ac5e"
     },
     {
+      "id": "341017b7-3049-48f8-8ca6-9ca936ba0da8",
       "name": "accountB",
-      "spendingKey": "a9192f22576fa8fcf16f1cc110132f686c3333f51e96c5507dd9526e7a6899a0",
-      "incomingViewKey": "5b59a7ff3cb3c6e911600cc0f542961208e2072fd8bdaea502f8038c7bf95602",
-      "outgoingViewKey": "d07b7e412de9ca4b479b78e1bff683cd034b72078793d222833fc088b83c8c08",
-      "publicAddress": "9505c1257bfcf298659c0c8ac81731abff874c10daccfdc26f9a0aafcbed0c4e4251ac2aa71b50d1ca9424",
-      "rescan": null
+      "spendingKey": "531a414b8afb7f8f6cdd5fa64b9c64d2fff8a2f783a1e73172b67735e1006984",
+      "incomingViewKey": "2c580073d889f2f98835fb8e4cb8345c05f242156d23f3de2248fa47e10e2307",
+      "outgoingViewKey": "7a5efb9d31ab511bab0b0918fed5a02c0794466542d076b951b0240dcba237c9",
+      "publicAddress": "6d160eddb067e1ff1877841e371618d89226264b76056db5ae8058c69cce01a5f263827b50dfbfd6da5f51"
     }
   ],
   "Accounts scanTransactions should update head status": [
     {
+      "id": "0e942f61-1830-43c9-9482-639f268b45c7",
       "name": "accountA",
-      "spendingKey": "41b47b3d2ac14d9f0f291a0b0e1e59b15f2501107854eecda825413f52770a07",
-      "incomingViewKey": "9e2275d042e26c27796b428e0b053b146ae2a7f2b22a2fa4cf871ba224d75e05",
-      "outgoingViewKey": "491a6634f91e06a5dce74804a018269122144f792522130bdf6d1d7635db955b",
-      "publicAddress": "0a2d0891aa665ac53b0eec12f3e9d0251c1585a6865bbc6d975de3c9e481ee5a1ca7c9e14cacdc17e931e5",
-      "rescan": null
+      "spendingKey": "c7aefd494f0087d021aa23e920f41ac9ae037af15b2c60d2c8b723f3a74fcc52",
+      "incomingViewKey": "d6eb3c82a75e4d361fb5b79532fac16078909093e82d14ca9f24c388bb5d4407",
+      "outgoingViewKey": "6a2d93bb7017ab470d7f17f972f7e744be92e5a7012149276ab3c8e2580d05b8",
+      "publicAddress": "348b8d7a5f92bf50a6a897c00e1d4f1d064fbb35aca74da1fe26e861cd2256ec311141c00c0fa840b287b1"
     },
     {
       "header": {
@@ -145,7 +145,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:cypBG1/ugEYs9aup8yIlkZsXPf74Ky/cm+ay4K5/Zk4="
+            "data": "base64:dhCPs6KsjXFMC+d6nXVowDyBE7c741nWzNpdZGf/TFY="
           },
           "size": 4
         },
@@ -155,35 +155,35 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1657827942134,
+        "timestamp": 1663827361011,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "A204E1CCE748C8297DD9A3E939ED2435E7017EE4AE6753F73D82BA7AABF4DDD7",
+        "hash": "A1C24C78595739CED7482C133489951A3CA3B1321458755245A6302F20CD2002",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKaQStBwg5DM7/MKNj02eVvywj0bYvrz4PaNlowuXHi4j/7+H+xZAr8pAs6NnHkwzIp41mEbfjb7uwGtP5ScWYmI3vLI348fE+VmLHS/JyNgHHwix9k5g89tzvQWQT2JhQVCprCs9rUxeII1plsSxZDZdIalNx6X3q6hwIE9ffZiiXSaLV34gGCfD9sqsoYKbaBeRmJwgy9STwIgX302O4KheHKrJauo0la8o+iLYodJpF2qWfkvww8cUSd33jJFJHDiAlQ4NLmKOEXRKV0wuMfGIzBjOhhOv+nFsJeH6Q0RuzszqclGePfLUiEd9l1RA4hzCZiIsY9xOOS77nsP/15c1/x5dqHOE4W19SNG9PuoJWIUCVfjBWEjOm1zZmWGn/NumTCyuiPMm/+qbo1/lRUEDgAeGn9NlWyv/Eicrrn8+vKB8eSVsthMhsanCEPydAzhlYmqD2U5Hks6SESzdB/r2U4kAOG09nSz18HTzwjKND3p9BjwcabbE/IsXbtoU5fqykJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwe+phsL5Lqw7mtPJiGN/q6/13pRm8dWRCqOFL3H1ly0YHMxd+Oz48Fa6r3S1R/Z1afBXQxo4ydWZBYnfFBbtVAw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALItTc4cwnGbLSnNgyd3FJ2vLTJFw9t1ObvENmBU4gbG6McSbc84m3mWiZo3yiokJ47mUY0jYtKSUvuma6m4FTrxnSxBUrCd0woM5c/s3p1SaEi5xY+Ps4TLkKhoIVFaVBnrmOCqiJpItJtMWkG1rD72pUjD+2DRK0qTwWX5z1bx91+q5/Axgx1lqjfeTiPhroo8spY+O5gxIoMKMoqxmcBxBzne3LsEXHNJnnUk+iw3OJvkvVP1Prwnqc0dhsOe09Y373Pn1a2i99yPEjEF26lgn+HSgdkJrV6F44T3fwBri9OcThA98dFD8O1r4+vguV/OgcWAjSHEt6BB5iKb9CL64Yf0NYE55WCH4E0+Dag+xlh6STWjTEB56vvPA9JPm9Jm0YaOQeJSDHUIju1lflpNRP2OtgSyjp8f+8Z2fRIcUfLjg4Rk9GEM81mZUhjIjvJ13K9OEQyt4wwvm66+Qua30vbaZDKlu2pO4BM/4cseXNC8sz+qA7qt7YcAQP5nF9E2BkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoFoE0Y7RES6354dU7C9Vtk400UAaACTThy5PubaJ96+eKlogOsuxXxyNc4vp5bBY7saQ8uzciNMvvwsqnXpkAA=="
         }
       ]
     },
     {
+      "id": "140db97a-3331-44c0-8855-2eaafc495972",
       "name": "accountB",
-      "spendingKey": "3944dc647cdd1a5daaf970730f6790c8e4016bd8750c7b209abcdc218f6ec50b",
-      "incomingViewKey": "ee8c8d13c052bc2c80166ababc9a13f0febac9fa507ba44ec21c2bca29ca4a00",
-      "outgoingViewKey": "0c571259a09c7b6d2c3c7daa8d2e13e56a0482067995bec61bd844bc17cf90c8",
-      "publicAddress": "04b3dae4fd42611319c59dd7b52c261348dee67547aad5237eeee565827f261f2ebcbe18e4624e749f2f02",
-      "rescan": null
+      "spendingKey": "1dc1277f5f337eb2d0a03cc8e9859fc8dd34a23d503dc40648b417cd58a467e6",
+      "incomingViewKey": "06e8334efa284ccc85cb7dde2e1413c8dab48ff37eccef888a168beabc603300",
+      "outgoingViewKey": "4b82a077193ec382c5e328401d9a7c35296bd8e7bcce98bd570cbac287760a9f",
+      "publicAddress": "eec83ba30afb1b8863bfb9996c1b6ed66e55e5780cce9d8c54054636d357e6f312c678b5dda3c326996440"
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "A204E1CCE748C8297DD9A3E939ED2435E7017EE4AE6753F73D82BA7AABF4DDD7",
+        "previousBlockHash": "A1C24C78595739CED7482C133489951A3CA3B1321458755245A6302F20CD2002",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:KAB1RWT08UcB7sfTOtQMrxhpwPiNxhWx7N2MpaG/Qg8="
+            "data": "base64:Yw0ItGIgYKh+mA7E4pYHgAakrnIjULpd/ABeLH3A21M="
           },
           "size": 5
         },
@@ -193,28 +193,28 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1657827942287,
+        "timestamp": 1663827361723,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "4FA04575A16E39BA51951843732D9D3E304A6C79BA8D587F7CA79767666C4220",
+        "hash": "805E595A0CF7EACA6C52618B053251E38D6EB3DFDAD6380E20B9DDA8A2F43FB7",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALQzoB29ZyuftcsBXFAqiRbxTEPm4eQKMaa2NJriiOofDxrNgntT19yI45h6UH4wrYBjIrr8p+EfNghcnkK9zPfF81JSLjDYkXaznMpy6MSzgeLiN5sMdjOcNgBKQqUUaQWJYEVpGiDAPkOzghRUR0/Qrh+sxkLRcH6FLBfqTvZHjwdkh2Jyf3VTJ2TBr9mJuLeOQYifFpocCltmcc6oXjazQTp1TC8jCxf25tYWg8HcqEQ4fV/Hqlmwp1bdYVTVe9qZ5sE3wFORqnyyNMMlOCRtb1P8JBMEs3oSiI4R2zFZxYw9X56ZEtKvhCRiDoW/2CRf3lq5GFHt+4uY5lZwJgCe7tJ+z51Vp0A712IRiy1P+hxtVuseOK2R2AhfS5tUgG4b2WdSkG6d+uSHyD45wL5y+d/qgPI1WlpBXjEge+AeRFeAEuh1vktD1Q7A1sNIDsyyz91NWCLcjXnh6FgL/AcMoaGC5CGCKqO+f1qF5lK7TqZ0dX9gcsrX/stE0oriFpciykJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaZE83im4+3shil3oLe05tZmmulEGo16E8rFKJEF38aTgm7CFHxBO0XRNGTsvi78xtxI5hWY/OqhfFKBHRV1QCw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALkd2DMVbzz88/zYR+OmKNpn07+LYNda47ynnzznpLnOHDWqC22ySajj3fNO6nbp6ZAORpOHnANqnkSuHCvN+TR9AH7HP+YIusafEHYoJVcXOM08pPLMZDnSJoxWo7UesxFUDQYwx8dCxR200OTitK52wf5NxVhlp1Oo86orAzZtIgu3GfOSHekU0evTJxWvWYBogf1oo1JDxro36DePBjDgTSN9r/dZT05mcLgGRYklFrztRTBnX2spsRd5DVZpaTYR4kHxGtBRGYKdhvwovh3vdCJj0JTPZ7LampjR5Vag4DBJEgbtcjpI+zgGvmHHCP2UpSByZ1zCAeeP/lgA62iPjmc2TAv8uSIxUNtq1MxtvyESkN3yi22kbph4wF/V5PsWAbd8ZJpL1EpqrIuwDGYWPCId3GzJTuS2HkpT+ZhIA6+d1gztYljiLss1MZMtdpv01tDkKwgpe1Ckpu0p0zRqgRioQfxtzqU+3Ok1B+ATaP1Hb049Kb5xZEc1hW7I2HjLs0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwr9kbAatySIVzzG9i360DK8U1+ryB4hHJEHWNEoF/lVINqptRnZhG+zO8osPuxhjPWGXwt/+olV2bFeLTYnghBw=="
         }
       ]
     }
   ],
   "Accounts scanTransactions should rescan and update chain processor": [
     {
+      "id": "cbdea7cd-7b51-417c-8c15-d7267c72f683",
       "name": "accountA",
-      "spendingKey": "7c5d7b2346e1eddfcf79034d40292376e2e84ed648bd2ffb2bd1c99314d8ebfd",
-      "incomingViewKey": "ffdecc49e09a5ff6861ce927a2bc4fe140d5111bc4449ac49797d483364c8607",
-      "outgoingViewKey": "e01d56ec874096ce4602675cd641dd54b4a68127aefa03d6306030a2f5826e96",
-      "publicAddress": "1dc22b2ad21161e0121288946a58b5cfd9805a0aeccb49797df84067bec4a33c70ef832c4ecf59c5904135",
-      "rescan": null
+      "spendingKey": "76f665024e371f720ba72f67f486dd58e6d0854e1dfab6d2d96e17259147da7a",
+      "incomingViewKey": "c1d3d39f81b7b50892d1e9fc30e2a9a2ad187c939d04c37b787d52ac0ad51806",
+      "outgoingViewKey": "063a42bc0da808918485f556350fa7cc0339f6279ad4f99fafe4ae2c1ffddbf5",
+      "publicAddress": "b274cefe75d10eb660d89e96b8a91485fcd0122b84d544776fa00d010e4193e77cd68dd1fd257f37321cdf"
     },
     {
       "header": {
@@ -223,7 +223,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:Ia6BAJMWYUCg7qJ3P/XaxtBfDN5T0ZIfp26sYNSALwQ="
+            "data": "base64:NgImGYUHyXQQXDoyTYwhdEIhzN8vGnrZ/Nq28SczgVY="
           },
           "size": 4
         },
@@ -233,27 +233,27 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1657827942464,
+        "timestamp": 1663827362589,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "D78D4A5519FEC8D98EF6E10B8EBDCE9750A7C205D68E5C15E5DE66C5782C820C",
+        "hash": "5C6022FF472E11EDC4764E6D94272A78C8E5DA9DE61A1F945A12D2988496DB10",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI2N/IxEHZNzpOpzkld7RinuW+aABpLarCkhyZWfBk2hudl35bB4lUgN0z5jSvVSPLHMFv/u0PD0PZuGS4QLpwyWEmCqyMOeCmYJum16AiOdsYIC0TaOLAwfqQS9lt4PfgRr0iZj+l3kzJCAY4RaOIOxg72u4aiC6IXu8RSOzB7x9qF8Ohy7/fu/J/1VuXjh66bVd0G5bNdRCqRWNYGfuqpj9x4gKuC4iI75kRInU2LPlqSzL8h0k20uf1eK3WKPVX2tr7EuUB8P7tASMW9h24aITqbnWFNy8n9r3s/3WpNeUhnqrWio6XSniDl/kU+VRRawsQ/xKJMj667jhNLQjWSzGi5624ogdU7HX0C3KGlJk3wTPIvTGQCb7EO5QuMqxbTQ6ra7NtE8TPw+lipZgZkm3Nj6OMolV8rD/XUAzS4aDeFyaabIamjb4BWXmPSMpvKG/Vgdsj6lcbKeSd7NkUS1DN48CbtaN6lxELUvO64s94rpoyemV4arfBCOnvWjxUgaFkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwa83YCTVGJA81ZkfutRxe/z+2kkj6XvvL0WGHj+T3omvWydTdi84WxU4D0QqQziwLVBU9qXUw3XI8jiATIvcHBw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJkHUOjs5sffGAxLsqtq8R1Ny1ocVFUUdj8LaOenvpTc7gfONAcgh3ziUfxggcrsM7jEQELgwgQ2suapRM6F6joK6+oenImZoEWnjWchwgomvcIDLXt0Yg8JWG4JWSsPDQqZVKisNPeElr1gbX+z5mjSAxqOuSnt0lwalqg6ysm5/j32odkWqJW3VmA7uzJ4o404g85BdixSSB3cE0LPSGpVGnbvGl/us6IQ/I3SWT5LLdRJQ1/+GrsNJ+RTniiErCFB2iQcGyaXxGeag+CScZRtTfUZPuN6K64gwEVwNslBf1Vw/XZfvAiRaJu4mwhMb3cOnboD4kSYVzwk5taYAhfVSuwMy26U0p8PhfRDtQN2z9tfCuyEKMl0ST34IE5FJtG3qIpnVPqIKImvTvnTA3aumQRRXFbGXpuvdnfecC/Tv5yfNYqjd9Euk8kWgxHDl9RSyw4qfpbB9tEdt6oP5P6AHGpJE48TMs5EJCsktz9T/buauW+kF97k7akRLF3XNr0z10JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw474SjYpCr8I5c3Qv1pkEVAKjF2IJFIPIc1xknQQoCRyYtyzKVYy5RFATJBr/aLBNmbwR9Z2tiHExalnfMvLPAQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "D78D4A5519FEC8D98EF6E10B8EBDCE9750A7C205D68E5C15E5DE66C5782C820C",
+        "previousBlockHash": "5C6022FF472E11EDC4764E6D94272A78C8E5DA9DE61A1F945A12D2988496DB10",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:o/4lyYm95G4WC2H5SnoXeZ8noLkPlQcBfflVN2iTBGg="
+            "data": "base64:f6453c6bLReR9kw0WbNB1xVTdGjnlX94maWsKZfnh1U="
           },
           "size": 5
         },
@@ -263,36 +263,36 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1657827942616,
+        "timestamp": 1663827363115,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "098F534FEF985AF48B98CC1862892DA42C6C3BB30B786AC227E8C4A4733097D8",
+        "hash": "275E91BD8C59357F2ABE8175E721C38E7144F3EA6C5DD8511802C02A72CB0AC8",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKE5HNUm+8nljEY39BAWTJ7FR2RcdoFcNInO2baHQm7lE+bI2HkiKVUiaL7/ml+wQYs6gASpDInZ6qU8Takpy9NqWSA3z1qt0JGHhe5JjgxzmRYF45AGEh/6xShd+XYA/gjwH+G6YGZ71dkNJoUvlbyJq1VyEIp3tBtzt+MvOBwccI/52ubEgl13WKBX0Sd2iqQG1igqgMltheEtPKnbR1YzAPep6TdgjgQNlZzENbTxMRvU8UqHu6hH+H6fd2xQVaq7WltHq7xrrePxgdgB3E5k8iBm3XNgOEApKN3NyeCNQzL2FPveuBhfw0tMgxAuhhg7OYecGYjHm27C+Svavmh1m/ORaw13PR48f1oFq1YTgN/D1cYDyQsiZy3NFQ5vc2bJgL0Jwzk6U0BTjB66PJ0vPV+XS/BoG9lVFBeS59z0DteGm+nRg/akDCBaaCysBeB3SX2NfZwn3F7yXkn7NKL4OrmUWUWsYo/8Eb9g78I5ibQ3cZpdFpGjhfh6PZFuLJ0UHkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEoycrr2egcDtS9bDeG8Ss+NMMwj+wC/9eXSwbRjyGg3Tcmx3//vXnTwbl/Fyov3lr5RfpayLwC/ATZ4qOyKKBQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJYL1e/VIs8XmC0c3Jd6b40vY9b3uF+KWbDKwEwOhuibytJAOe+Sbvs//nVRJgTS3bAnvPjwsT3mBAwsAzMc5+S2a9IB1ewqFrPSu5jAp2z3OnsOKQKlxY3v7hLUC0Wb7RH9vLQRD35xHRxHUHw7AVnqoPseafEh5cBSmCYiKKivHXzIIIldGv7vs8R6DS9KaJTI5Fz+jNVm71620Z2yRjp/yvJWXF3GW6q40tIV3BNH6xHWc40IklB9mzeJ6T5MXFNabzxLdmBc29jVldQ+TsmVfe/yekSBXa3kLauUOCLQSI1PTZV3ueqJe2A+/d7Mg3XcDcsg/c+1ddpW40Kcf0L60uAqoayTNtkvO033imFMDQogXHM5yrhrtj5zGzJ5REqNjxOorlAHr0urbQWPSlrhZ93egkWHF3wL5Y1My+e01rWx+EqUMgj1VIBhe0oEhhKCpE3p7MI1yGegQZKy6j85R5c8Jnqdlzmmp7unqAzs/4KWt4Bl3yrprnqd7LE/i82AOEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWnC+GoeTwLdEPxhYZCyWfL4vehkv6vrQLTO+QfC7XurDwhW8NmPvPWrPREwZwPVvUWf5BSENW9/T7AAmBvxfDA=="
         }
       ]
     }
   ],
   "Accounts getBalance returns balances for unspent notes with minimum confirmations on the main chain": [
     {
+      "id": "0d178688-7e10-4173-b69e-7621671b311a",
       "name": "accountA",
-      "spendingKey": "d2a4ab84d3ef61ba4517d6d0370000c80f3822ae4e515948374b2e9aaa7ee2a4",
-      "incomingViewKey": "d75fcb6f1d98091a42199dbea7f1035b1b9a0b43c0f37a3aa1ac323ccbb22501",
-      "outgoingViewKey": "8a16d313af9dfb1956bcdb7fdcc6d8a13a49b3a3edacb8d7748fd0c23f1e80d9",
-      "publicAddress": "0378767155a6407980704c91f5245b3a719f0b8b27b1792550e9d1f6085714bf2c1046416286f070b162d2",
-      "rescan": null
+      "spendingKey": "84af7de9df815287d5d9a3c4c5f00e5a32b7feafbc75d7ace8279abe9a29f179",
+      "incomingViewKey": "4d26b8d25fbea2a54b2ae3a38d511ddc928c80ce9393c3f8c7c5a14d7d185101",
+      "outgoingViewKey": "302654278b728350df9f2f93f69a30c3d592194483631ff9e6a1d232a1222e31",
+      "publicAddress": "3328816f553bef92e3b8a48a1df1b1eb9de745543630220f4a4a43c0abf3138553e4b49561d96fd3ebf46d"
     },
     {
+      "id": "de0552c0-b972-400a-b459-2ed5b1adc08a",
       "name": "accountB",
-      "spendingKey": "60a71a1376863e86a381b41093bb7275ed24ca3819396e3365a762745749fb6b",
-      "incomingViewKey": "8f9d0659b8cde318e33334999166f0e892d939533b918dbdfc7cc0281e94c200",
-      "outgoingViewKey": "f1b6a83bf96a0934382284aa42930063583cb5f7a4589f24aa56906a41797b9e",
-      "publicAddress": "08c313a49413c6462c311e07844b9feeb71e6b7119dc62d29d2d3396531525c4c53453ad5e26aedc70e9e9",
-      "rescan": null
+      "spendingKey": "0ac6f590aa77c3e3f95cea34b2c917eae3cdea48d7f2c0f03096b72f7acad567",
+      "incomingViewKey": "e3906eeb5eb2f74c3d52e0edf6c13829914f889bc9779553e2c173f6a29d4205",
+      "outgoingViewKey": "099c73e33efa80b7a52c1c73e3df790046dcc576b9e17412246e39e9ee8b1216",
+      "publicAddress": "5249a8804aec0c19a75c7c1a3eaf7d79804f9ef87c22a6c944298897697389aee31ae3c5e387cc5f2e459e"
     },
     {
       "header": {
@@ -301,7 +301,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:mzCwFHkSkVJZT6dYL5ePoYXX/5T9iqDxeNMlxKNszkI="
+            "data": "base64:kg6KBVYMaQ0j/+1OJa5XkxuQy5PpUjh5jw/SwoaWIDg="
           },
           "size": 4
         },
@@ -311,27 +311,27 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1657827942833,
+        "timestamp": 1663827364442,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "0CFA77E83554BFE5D2E9F0D903EA0196227534CC89AA1441CF16B32E6F1EEA59",
+        "hash": "3B9C80579C7F212F531B76D397BF2FD20DBE9BDF6F61AA38909FD05135AE7839",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK+FDKaF3XW8gH03ynbY/WL5RPXasVSvvV6pydebUk9ZQyBbTnlfXOjSVmKr3C/MM7AbLbYRVmrYcyIMcYHeMWbwEmBDdELn3Cc7McQvJ+1lKgpPD9Eb+1GQ8leMNHgjdQPs7gTYqvS7u6kM/RBHdSgRrZaaBvqcJUP/rDWqCrmBomfH9uxzHZuqEIQBb/KBGbky/lBfozvFZ2NS2T1+JHSheAx85i47SjzNSf2uCkVLY55bynqtga6UI47XRCHWUhNO0NF3/tJbRUo7xcDX4PaJfzsgWIAWTSZetXSP7zqViQiQi2p6r2hmz8sgFqSD819o+zcOw80I78XJFhROWgi2kFCbSvqHfalPFG72KWAUXjTeAJ1uyRjqn6NzTpW1P2RPe45xlMs6x7uM82nj5wYBVOmIVsl4xEhmxScEC5nkG6gWkbS7taT8K/xoTR9utr7+z6RZIYvXieXILVc6L5Yk9UfMEreSPWuUzWA7jqx2lxrvd7y1+xfrsYquAPSPZ31IlkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWKvU+fili6K0hzYv19XfoD4h3Lur757yIhm+PrXNZCjUb51d/edk4EGR4vqH3Gs7VD1c6TmeXNpPv+8kGJlvCg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI7x4/dBH0y9j+c6qFgY/esqQLptuYRrey97XTp+ELV7COoqc5cEwz1GPvTXTkKp/rGY10AAgu0qaAtZ4riyW28I2zwVHOmx6A5w//ofJR56cefOOpsMrChdJdKwk8wEmwY5ZWM6Ue/hznAfVA7HbE8tw7hLdXzUlpLw8SqEXe5naqwTMAYFLa0e9CA2/Qqfa7n70dsLX9f+vse8qS9AMq5qVxst8ImW53+gtNGIIXF2oYEXDhZhretGbYzhO2lwUkXE2MFG0gj/jPzYZNsHTHtlFag/MqiytWvj/XOhHxVlDY1JLuvmBoeLAb+KlVGmaWI7vJRbXPWgcMGFyF9FcBqlKDSJcEin/k76B0Pn8c10uC6kilaNf8Cu7hzkaaTPxh9uYSP0eg2SWso8Ci2vM6F81ISXhFM7Ka4xMTkMfeqJ0reeEwiMmOgRpi4pEWGOxxFE1DqXPc8b8yJwf6Ley08/my7xca/WdKGsFBFAtdFxNnvNoXiwIaswAx2O+5WPU31FLUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwpelOnDH7TpX+QWfG42cOdKrOkpHf/pyxKTq4KuVTQCktMYLq5mblIqNyGQ1M4ELE3DP0PnKQsSXOxI+NC3ScBA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "0CFA77E83554BFE5D2E9F0D903EA0196227534CC89AA1441CF16B32E6F1EEA59",
+        "previousBlockHash": "3B9C80579C7F212F531B76D397BF2FD20DBE9BDF6F61AA38909FD05135AE7839",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:uuWCas/+bjNpaYkUZeHmhPKGLLuIgKCCrMVWfdSsXQI="
+            "data": "base64:jg0wTUR+nF+P0pYngMnmpHKUI5F5kwlQcAB9CylLMQ8="
           },
           "size": 5
         },
@@ -341,27 +341,27 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1657827942983,
+        "timestamp": 1663827365080,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "C873B1C685D045A67F5EAEA79BB6EA09A8652BA42F17B5D82C5F76979CDC3442",
+        "hash": "7AB563C108483FF6AFD50D71DE7A796F1B09CE8B28F2E836D21A090915A6E255",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJe1sB3p0cHSpfb/1Co2xzYMI2dPXK4Bll1ra7WeKvwVreFl+fFZGd7X9bkeGY8S/aurjPekzq6dfHVDCf7di+lksXXElePh+1gbuOUifgNEdFp0GZPG48doWDcTLLxuWhKA2SBMmKeMtYuoAHv9j4j2GdApRX+nn8l3wmkJ8KYSGCKlJH6qZUagTt2K0FuUKpRAIYJ27I1ClqRFRY6/ngfPgPeW3ciBuynpOmkCPkCSDaccPCDJtAo9gxebkYwzv0DmE6y05ASr85omte2Jxmjxg5RRqr6rJBpORdVqu7dy2/FsKi9FGXKnJzal8fNOLFiO7JLBjND0PcUuw6V0aDbbhZ/9C5NxWhMdcbhk1DqJ6bZ+zF8MWjAvCFF6HQJPnwy8iKsMSFtgnmLtA3mjkv5owcEJaHVH8wkCrrayK9JefyirX4HTXkU/uZoPRFarr0tmQjXFakYj/LunZG/ViUaIXFGp17/o0J/mNXOG1q1LkGIpVv0joRyQmGnlVvWv2E9GSEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCcM8HcUmzP1/ZQ2vk0rib5oYxjf1YLuI+fIA+t401G5qZoXsQ/4RH90iB1sfDyPmcCkjHaLGcem+NwFm1Kv/CA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK6ahTqfGExype+BY9EHquMhLyzCk74f9A9VhXm/P+NQC3OvZ4RUhdQ/rywNzIr+P6UeO9AuakD9kYplaTblw4IUXWAINS8tSkOKXDG2tSQLOR5VGEEdDuQNcy4pUFXmAw2BrZkBX8LKC+vhNsgxw/yKMwXEljOOhEZ6AMPLsE9xZfJf1V+85T9wDbhW7VYW3rU/JCkmYfj6gYXSmzVcF5KDVV4STyTjwzgaXLra5KfB6Kw9z43H2/ItmVz4w6Z+eeojzKpkLt17WuA0DhmYfk1bg2uwfZrrOgDl0hgUOpM40/38X3xBmx4iGBzLzDzQEUkEKpTbY4kzZgM/EDjMfl/QwMEYHO19ay/Z/QyV1XUfQd6FWybC0pTVkyx5ICdosHpqIFddrzSqpd3TKsLB+9Uv3Hgnxc2di/fCt+pN5KESJoFhDtS5PBtaPMaV1gNpJNBvs56r3a76+FmdaRoI+ZMhcw00xyxm5tifdMSpNacuYaLEi1Qnxktg5yV5y+NGoCKTIEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwz3Hcvvq4D8YQZw55UcTDDSQjoshLt37FMzoKEbf3H5iHItV9VL1xfupgeeOEZYkZ1bZAEQpglJ++Hdg3nYO7BQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 4,
-        "previousBlockHash": "C873B1C685D045A67F5EAEA79BB6EA09A8652BA42F17B5D82C5F76979CDC3442",
+        "previousBlockHash": "7AB563C108483FF6AFD50D71DE7A796F1B09CE8B28F2E836D21A090915A6E255",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:lZVz8Pvc7ruEmGh/mQwKUb2Pj/VvY9+8JmZ+oaZqiFI="
+            "data": "base64:mWtsZjZp/oedb5rtUGnrsHhOqIa83GrmvD5flj5HLzQ="
           },
           "size": 6
         },
@@ -371,27 +371,27 @@
         },
         "target": "12096396928958695709100635723060514718229275323289987966729581326",
         "randomness": "0",
-        "timestamp": 1657827943137,
+        "timestamp": 1663827365924,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "5D52E622B880B7C7C7742BA06F7046A23F3006D18ECA0BF3B9D2027BCBE11A87",
+        "hash": "39D0497DB99CFF3E4B09157F326A349B8F4D1C62F0AED4FAAE6698F0F09B7DA6",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKSobdl1YpqvWAo18Oa8ikLb1rJXVqF7MaI5g8tfyIuZAlo6pmjVCm9b8Qkl8aDQfo5V4jMcRAxXDRGmaX+Vp6djJxWDZwPWXk8LQNXesmcC+kirL70mm8xNoq3fPtke8gRmAykrouf+T3ie+lpgUpS/tcZ3SCWb5YZKHVJOMf0xTsU528fay4wSBvURfjWPWYH9NG6+iWJ/IuvW7hYH+vSbKp7CukELg586HBRya4LCO3Z6eJ+rapVzcTDjcpyuBnAOBYmIszdoCi9j0Oq8VusXnuWK+8CJlNUx3pMQr3HVRZ8PlB2vjftY1rFhFnYlsmAWPj0vQJEBaeCyJxkTJRn3tm/X80h4Mo6COzDmObEwceuZ5+9zjd2GfDQp3H8ICE1MMoI4eCawICUFdTq5ELkT4glm0fAuHTEHRPULIV8+EKvkWR32oT3OfVCnEnhQYhntEfu+9rEmYRw7l7/0IQc3u8X2VRZdw9eaQxtFGmsqbR4EJvLiAImQPIHgmCQd/QOVe0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwKHi9GUkB/Yz/KMWsxR7Cgbx+vKpU4bgUmNB6obFVJkgkfrJdlPbeoakMxO8zT06Kss+ERD2u+KIRsU/fBJLBg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI8484eKy1Q6Rcx7y0XGblAgMnmIkzt/j53K3a+HX1RDlED9/aMg77UoJsnzm6cmhq3fbnW2GSPIHnJq7+8WPQukWYd7w+cMABp7+yWCfQipRr1ig62AmztA7D9naOo2CwJA/QhHswewZEncEGQ21AumAy4s50Zh8+Gti49R2uSTikqKlMafLmMRw5ijmhFJwI9Db/b3oArCTu1uzhIZ6++FD2qL69O+pGoQjt5gNyrDh/ISIK+qMOo0dxdgj6bzTSZROrwj1z3n5LM3q2n7/RtdfakCxH4jgxUHt7JAHPmttyBt9MwmuKZq8PKz9W014yxFzw3T8aOP4HzPIWzKvQhHQC9j8RZ3/ls2ZxTCkoKeW0EHc8lKSikVjrpyfAFkwXRjSwv6HP24NOzsuT9kcA64ydZz6vqwwSbIRqRzFX1StzVNQtV5AZJHIvpuzTB2+q7g3Hi+OJ4pwSrlpI6VikHjf+qA9o7WANVrgtHV0NriS2Ecew8KjUBlzQLjicEbx/Bv30JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmNapV6Yg5vJhtX68KlaOUMk/4r/6SstRt1qMSI3KMGv6IZGjY4G6Aou6X60h92ra3ZglV7JLYIYmQNmTLlJPBQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 5,
-        "previousBlockHash": "5D52E622B880B7C7C7742BA06F7046A23F3006D18ECA0BF3B9D2027BCBE11A87",
+        "previousBlockHash": "39D0497DB99CFF3E4B09157F326A349B8F4D1C62F0AED4FAAE6698F0F09B7DA6",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:316diTgCFdFmiWJPH+MHJw9XSllB+/isQgym069sYDs="
+            "data": "base64:Nzm5/bqaO55VbfypIcNcJiKEsQNX4dtevvHPk8Y/vkk="
           },
           "size": 7
         },
@@ -401,27 +401,27 @@
         },
         "target": "12061061787010396005823540495362954933337395011119300165635986189",
         "randomness": "0",
-        "timestamp": 1657827943283,
+        "timestamp": 1663827366458,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "882CF6766617348087FFD6C8B606D7AA4F8D6403B559E3DA07A05EE729782817",
+        "hash": "832D5E124C81EB9C2681E2F606D14D9946DA4C00B0390A4EC2CB7584821841AD",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKUJqiy+IBy6hhRQM/2e+al7oyJKIwPiQ6SAoHrJvY5UoFWBHeZ6I4psdfXlTzT5WbbIVKySwq2awSlsXSxKFI38+PCs+6a+7AfBbSrSRRgPqegmOLXtfd8CUtCV8eZlhRXynrrgfwvQyF15+w1OWqFbBbMdhrHtP7fSHCX4jcJHYgHj20ZmtjpFg8rEwwvo/YvJR/PA623nwI9o9AzAzScVOzAvhGesJdNzzY1ZpWxMAijtbHhK/wJw7HvzpKBbF6+ZL2rAqRPVwIGvQBkCYRVgS/fXzvUpWvqMIrui3F4xi3+BsYjGnlQrq/J6ksFO5QOemVbEk3RSJ8/w8/WQOStkJLFkZH5Bq26OoZbPM/yQkA06WL9nSZlx2ZfnNtTFr4pNQfp86MThFBUGDrgrkxqgi9IFYpXiz6VKab1gDW/Qc9LW8Mlm0qBeDZnZlP1M1IGfYo1/tNO2b+ehrgYlHatASZ7b9FA0WcrJ/HdUwSQHVWjBgPcbxoKXvpSblftjD4kjb0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYgK1DuiHm4321cqyzeyGOMpbHCTuacBhVvXcVOgbdAhQrb91EK6sPtUIeSBGuo6mFgVAD/B7IDcrhAaS+hKNDA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJYzjQ6fSc3wvJFS9LrEpc4qRYXbAZPat/VDdAW6fnpRtb9iHA/UZesYW1eTXrC/b6zVUNE/ASLhDHvQqFYfvAtEjYp742jQfsylBnN3R5F9pmtBtz7+u3Vpc37clolfQQqimv2s2xVB6zInqmjlhPBqvn4kwaTo5yegWQvlJQCkYNUxkzo448LzFAeIaDNOjYQfbw5kcCBDEBLoqQTr7tqVLcp4T3sOKHBi2xCguFA/IfKfO7hKxM1H8jhInPqxZrvzkSGoD9m2KUlAOXEdJqxvIxwhK91HBDDpyOAZKJKpC8wqzIuxYQPdvV0Hh6maO64WKyGYmGSkuB4J2OfCHGqqw2zC4v7qhC5RrRNnsl39qbEN3qT80LIZOOAtozxBQl2JQL6m31HESgUlsCiyJWqjrKuQkTD/+Ooe76ktlIvv7xdP5y0Hc9w4KEjznoxPafq0Ggn5p1gRGTYZgNISEF9CRZPSmPD7u8nBO/KroHOkXKXddv22OCN/+/Gkm/dju9NULEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAww5pHEaa/4yraCpPh518YfgryAodAjHIBYlIKrmFjqxsS4yyL7KXwue0aKX+d57jEIwgpF/oQbh3KQnN6zYg9DQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 6,
-        "previousBlockHash": "882CF6766617348087FFD6C8B606D7AA4F8D6403B559E3DA07A05EE729782817",
+        "previousBlockHash": "832D5E124C81EB9C2681E2F606D14D9946DA4C00B0390A4EC2CB7584821841AD",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:x7wBsEn2VXT/471l7EjswLDz+oFiWLMw+VNu3Vf0YmM="
+            "data": "base64:ZmQL5ph1KE1e6izxtmzWYBt5qpVvXllS+Ia8zYjntjQ="
           },
           "size": 8
         },
@@ -431,16 +431,16 @@
         },
         "target": "12025829863586302258274667766838505692576214880101876262606819815",
         "randomness": "0",
-        "timestamp": 1657827943437,
+        "timestamp": 1663827367278,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "BA5D4389077E4E45B612E8F260C889E77BDD2556EA12BDA0B19CDED747B64A75",
+        "hash": "9BC1B352A02B18D8EE7D0E5B93AAA402CAD31C2A34FCBDCA96BB7673ACFABF64",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALfWpq/FkR3ixGIQvQwmpbEk82P1zrnpEjOiB8QpbBdy1/pMmKfixT69tqNQLYAx9bPKFcKMsNtYoNdsWuIJfUavv/red1z4WVAt92I7cBRXfolNF3HBdP5rBNtCRFtLNxGvrpx9N051nFhmWdg/Y7YUcQ2d3h8FBKMGZRZitywuzG8ECt4wgRRr8LKIiVnczq9K51tSxx5qQRlUYj6H3DM9+owkdbhBTFvg5XKlWcZMgGpo4zrUOBeKxBo/VEllkO63UWCeR9DjiHMImK/htiW5c3yW/I8BW4IxrEgY1jeiKG7cPuR4cMU/ox3FrDcLBUn35zEWQ0SYWOAkA6+dkjLxM19VQTU0ihwa+dLdLta4P7G9zNh01AdTMjicSe133yAbmWyNrUyzSQdJiNyGGXnvM/t5tlg5fU0hfXrhBLHhDQjuJrf3fD/cY/iFo50wifFMiSFcBeaR8Fe7CkyCvDrv/ZCpD/F1HRsGutMbVQS28CdcwAtv6u1kJfER+S79GzfTyUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJmalINBJVPs41OFxg0NnPLuqHmF4vUBD6NGefC+xaeQW6HboPCvI89GHSyYx11op/MnDq+BzQhladQpv2C5zBA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKOCPiX89FHImeCF5O9qb26SyQqx2Ig+ZC0uiccP+kf0tCOBXDJpDN1UQzVLrgziyKLS8ljfrFmKrodo1ZWWle/p/C27oZOYwJjrzFci4ErBmmauQgLVKIoVKi4HUGl+zQbqPAk8TsxJM/64S2Fwah3zcUwXf0VaOh9vaHhZosfVlCnP1bC4GGWFVQ2pYh+GPrISPKEYGZ09bsf0X/L313G0m+b3n5fDvqnfcik/OZpo6eeSDpBPlpP1tC0C7pwdTHQ4Cu9HIyfhrQR+8+oNaq46Huw1iVXnfvJtsk25hQRtWzjS2Uc5w27GADaaQS0r3oMonSAPsWko5grg3zni/hbt+xQBK26o0Y/mLfoH7fdTVbg+MKKb2kE7OfpcyWGuF0tHa3PIt48vN5XOc4a9JtPi7DfVzHl950Gy2/pLuPeET01u0zLwjOTqS/Lf0s8lSYGL2p8udiL4aKS7XXUUIKBpyLDuHKd03ZTr1jbCpRrOFORx5zDa0qDOL97aHmWorTYCa0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/NFUeBLMw2ndagv/0AtuPMvkynlO2UOO8MvgDjjdkjO0juMyB7OqvplQx8f3v2VNTQlOEqGLWBUh/UZ3LsqEBg=="
         }
       ]
     },
@@ -451,7 +451,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:ySR3dKglu8tawfTsNPZ4FOZik2Freb2UVmVHxBy7Wx0="
+            "data": "base64:c/F4TEdZU9reGfKzjQlkb7N6jdHbquZ3ic3t2ap6ZW8="
           },
           "size": 4
         },
@@ -461,27 +461,27 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1657827943591,
+        "timestamp": 1663827367848,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "91C6BF7F4FAD6594B3C90DBFBB62CC61DB8CC87EC96E6CFF51C0E8AF08F374EA",
+        "hash": "393DC7FF30D232399E6E3C7D2E382F08C428272D1ADBD725339A4536298A794C",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIUBY/9iXI4I24p6GdRAW1Sq1T+qNEjbTKR7mBKHOoOJGDQcaIP1iIykRRndoY3IDbeWYehHyFZoB13WXl5EUQEXfjLJlfxbiIU+ulICd1N4DEHN6XmGYYhTqZcYmPAdPA/QooeVoFXZkWantRAcT7yDlvlBobJ7jMvHf8j3plEh/l+HLv0Yxq3SQ/QsbJbsTqe5rRveS9N6J82Ykwozz5F7i4CZZdn+0tEP/impfFxrU4ObYkFgH3I52pnGvd3fQ2e4GvzxOC9NSiZ63lhZA64eDLK8EmZ7odwdEyrOXd7nL7w17I52VrAK8DJpE2MVM/tgSmnmIqyAZo89gsL+WlwaIGZPm5CGOXMvz7SD7u8spd1691M2+RP/C2cIL9a4FikcD+rsm7hpzYXxAYOFKQMrfek4vwnYT6lokDccyzo9+KVb1xXe5Z1WY6JTtSjWmGcdDYdzgmBFd3W4uKIi69ukBGQ719qDAe/FPoxdsXefSVnOlvJth6tuThltEMIFRmmdt0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwuokMHDjqTcuV6c/MaJxkcoPrehQ1jqOi0TD5kOJJ3EOPkrcr49GgQWM2fmg9Aj9SOQNBk1EjgMfGUFchriPYCA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJmNXq2WqF6EbIkutvbConcQ63nlHnNGWC+QtAjKVQvnLd/rK0s5JjIVfrZl2RevTaRMnBz1OrvEAlXro5qGX36umF5h7pA0vUWBDtVPBzlupq7OeseIQwS/bOkxybfvZQ6lSpIovCzOI3TWR1bXZj15ThwzhlzT6To9FHnXjGBLJSj9XrS5it0dISQP5yYuA7EUUTDhm6spWVDj3mLe8axzFgQs7RqMfXbFo9wLUg3bcc7KEWX4dpLZYQFggZZm2JjlRjdAYYudjID/jedjCihjozcqgvy/yrfSCGgEkknSVy8tV9YFsGlKHoamF2dqa9wt4gh9dtBwND3sDU53nkW5+YPXsix1GjdmsVKG7+JgG3HBHk8p5T5ErqIUre1AnEKI05kmB8/HT1qSMHy2a/z7kQS3omT3AKWrlhuV6G33d3DJW5SDfcXlpY2AFZ4edoog8rcfGZ3/d/UFfToVeFh+6/VnZOnTGV5NmVxGN0QWJJaFAXpyiR1nYQuxDJQIMeYveUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoo5L55I5C3H6iHhNTghCJQCvERbKwVSEybgtXhYCZhnNMY6xm8gB8sERGdn6QN1+OJDxjXvFvxYAQTCHv0VRDQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "91C6BF7F4FAD6594B3C90DBFBB62CC61DB8CC87EC96E6CFF51C0E8AF08F374EA",
+        "previousBlockHash": "393DC7FF30D232399E6E3C7D2E382F08C428272D1ADBD725339A4536298A794C",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:qhrKTeF06s4Jm9wUsmFh7eTwkDO8ZNboiFL981zbtj8="
+            "data": "base64:vpU0eVyf/TcGRrOC+6NguPOdHXkdcA/ktKoBffy35Rw="
           },
           "size": 5
         },
@@ -491,112 +491,52 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1657827943738,
+        "timestamp": 1663827368412,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "D78F75C2684CC80E3A82D1702F06527E5FF0A1BA37F08795129B311498904816",
+        "hash": "A5F6FE1AE3F20FA5F547763735D59195807E8C863B77DF251CF512D0389B58DB",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALn3fcM3i2pxjQZWgWK0+NVp/AuXBSSmyB+5PBCSr0R9TysmdIb5pi4OkV6ykWQcg6fzupRSDgwNtskaQTxX5PFdBDQ1eefvYObS+BLjIXFlyN5F5xGIk+Z1vI9iIcb/RRi50fusRhkHtTBDFei+08j4X+CAzJw0jdjtbTw6KTv2tJ1JImsy0UU9i+OFLr61CJWJhtLP0tqx29a1Ls/ei5e/LF9FHCq7ltxYD6+dfBnCj2HyxTj1f1ILXDUcSfoa1vNDm62t6W9D6MtlKuy3v1Z+ciMqDXhkLqsSYLj2q+yognrjocPksVD0GcWNnv1IFTubSmDT7IzvypdTdh5ykxCTXgq+i+pTAIChDCkD5wTMEzaWI3gw5dHfhE8XcYPiDe79zwIfsetzONmf+2K+eliShSAcU5+i7fHgfn0tAPAbhixkMtXlzMQ1VrlVnkA16G9cow5JN4fNDhVxvaexv3Tf8dTnP/viYZF8SZIspbwHlYhvhdL0hesM5eoLYImBai88x0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwS40AcjxCI36/ZL1a9zLiZrq5j4tg3V1B9US7VN5shwxXU23yWZvGOWomBezaJp68JTcX+9gPA0TFzRhvLmUJDg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "D78F75C2684CC80E3A82D1702F06527E5FF0A1BA37F08795129B311498904816",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:uw5e6K2Cn06Ywy68NJFh+6drtJTNjimK4Dbm7mveCgo="
-          },
-          "size": 6
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1657827943888,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "A3759AA162B83A79D4DF1D3FAA827047372C650B185F720267CE13272C2C2A2A",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIfrgKCT6gGHHm4xT2BSjKqUPe17OSPzNGwafpLxayaTU1BPEBl2k9t3y6gJaza8WoubbbxG5UCf7TjGkabNJh1UVg0w+M6TywI9aLltUiZVPw2KxOIJi+x4mcgJMHCtxQ4B8kJMcXMX/OPnde41Rg1CcKKivuJpy6nPE1jKLqg+dVnnd2Y8rJX0LQ+FXJPZA5MylEEtlkxnSdGYsoEMqdg/yjf/mHGGPgF3fmeHWg7pKFmh/yFIIveFWe9pH24PS1KsHo2aXWOVEoJEOn44WLIth/29lI8AFVGdabMyAUAvYUq3lC6dJFI1029EZdi0BlIHMn282N8S96ha+Or4hlr8D8PpM41YPgQ9DoDvEgZreVoFy0izPOE2lff1UzEqmTXV+l5a2VQhSdfJCpovEzPodrcQEF22zLxbdeEz7MUSd42WxOfnPnaNISC3Lw2n5HlcYfEil6fTe72wEtgwA2mMcKKGrq7lQJCYgRVLtjdEJOXIWYt8O5w5WN6kmSiiDTSNK0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAweSOkhWHEemjOZ3TqCwC/YEaduqJiY1BcP0T/BoIaQw/P+6cEfii8AMMZteTrwGw18hRf3KiulIVPNeJ7CtI3BQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "A3759AA162B83A79D4DF1D3FAA827047372C650B185F720267CE13272C2C2A2A",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:N+BAoFeCyyvBR4UdIwl1tQkLkWxwotEykQJKn3QMsjE="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12061061787010396005823540495362954933337395011119300165635986189",
-        "randomness": "0",
-        "timestamp": 1657827944036,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "0F73868C63A3163E8C3130D1323D98B815C290700E3D564B3351B01EDB95CC79",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIKC5hHxf95rzSclZVL2EJD4/N3sIRIzvcNxAHTkxCERyQ7B5Y+M28L34UDZOxV/eKHxoatKoQkOLvJ8mYYEq1RKMVqi0QPlDNQXY3SHs1ziReXma1OzqbfqdRd+W8d5qAiwJvaGV5G47w2n9xNxCX7RmFuWUMeCCkYUtQcReObFmRT6H/gqKUEa3OUfyR/26pSmsNMEs0ZM/BMx9eqlcY0wDMxqsyuWSeqjUZjDpSRNILYUBfVGqVexe8+yhsrSUIB4Itvjan4ue2roNyaDrl+NZSgViZ8nQRca0jkwhXXI1Yawvh1Wn77vEN86Iw48HXc+Uo2ka9EqoBE/BnuIyGQfSviV30REy5OnRKsjgLuwlOeBuZRL1kUMuQA7GO70q+mW3QLF0uHwExbOCDIbLoeF4Eo4dkqAQE9HOWJ8/12ur6+Cl7NKSxjnLSZGTJxnOMfvUUjOKYLvvmOt3Xntp4WQNTvIqN/RvTk4JN8GejjCnbW5Q45gyDWOSIg8Ra41D1yoXEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaONKOC4UoNneCOBBqz/i28sw09hqBcuak2CCoIbEmZQzfLK8Vz5LrqHF/1CBC7etLO1zJnCLOYZW+xRmy2EvDQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJh4g3NUhHvBD15FTaoNjZTVkb5Cc99VqJWFzfxjkikyeLABmiSOMEEly8nHtdf3kpIjVaJ7Y/ZZ/02y9q5c8g7EQVtPASFiz9wwVYrskNwphRmwZqgavFy8pJwuCsoUTQJhzBNUxnyLm8jTeBD5TMqTb4Hk40ACK+Eo2I3FL9O4UxOCn7ECSbGuIN6EAW/5oIIYCsXG95Y/hpZj755VQR2+h+z4fwh03gF058hL9Xg0r6gxF23ubKurW0WKV6gL84ZgyrPO0EvaLcVz+608gdjTIUDCUjnVV1JMcEYNQArscegMHWdv/XxQ74z/MM4q1xtbdn1QmHP0cHcvsBpphRMsIRFUgN/faQ9YjLThFqQe//JNjrm2M4gZRU7P6FKyhUQqGY3YdygiUrptm574U/4dPeRmtCK00h700bgG/NT//v0FZ6PWTIuyv8RoE36ALKmf1QNP9qAs1UiMIzZLbLjAGQn5VlU+C0HsR3UZbcXPLXXmtykJenPewikfAHqCTRb2TUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwdvJVoUzySKpodp+kwV5kaStJZHVjHCh/t0Jtgg4tkd1XTZOqF5AktHAK1LR7xCfx5RxGc1n5DWUqKn7OfO4DA=="
         }
       ]
     }
   ],
   "Accounts getEarliestHeadHash should return the earliest head hash": [
     {
+      "id": "9a312f95-faf5-4dc5-8196-b7362946bd10",
       "name": "accountA",
-      "spendingKey": "3126a3a942470b76758f571ab932d9072cb3473b026919133c5950d69d7317fe",
-      "incomingViewKey": "6db835591c776522cb7a9085298f194a37c64768f91e2c74c6cb935537e1a202",
-      "outgoingViewKey": "658d284885ec1c99154857c69fe3c0dfb1a9d9b1166c3f8cb65f81b1c55d2648",
-      "publicAddress": "e6676c998cb20a8967a9e6638944c4ac9ff5c7056318b4cec18cfd670625e81d4d65f9127e9f6a3e9fc682",
-      "rescan": null
+      "spendingKey": "1a6c728fb0fe5779da37bbf2ef6fe844436350c4785106bddb27b0768dcff474",
+      "incomingViewKey": "806852481a2ca8ff01cb240d923ac8fd50071d33dbcda90d5046c7d783ef1507",
+      "outgoingViewKey": "784ac3cf2e24cf61121d37ec930fe38fc02c3e9b0432e0a204fb69124945ddcc",
+      "publicAddress": "28dba0f8cf4ba2e1ee1af542dce1bbf90b235a475eee4389c38914b74c2eaff6f6e5a777f1a8ac2ce0816a"
     },
     {
+      "id": "17ad3970-7d4a-4578-b3c3-21d8618e0623",
       "name": "accountB",
-      "spendingKey": "af9e9e94c519b2d90fbb3b27279f176b39e2b25a1f536e531146b49cedfec935",
-      "incomingViewKey": "8f239675a219f6846e5f39d792e3ee802e1b615c8a8f348f798e03dd0e0f7400",
-      "outgoingViewKey": "6295b2b65c10fca4b10bd95a459d810f915d8da316159505a04b79f8ec627b58",
-      "publicAddress": "2cc1dc055ed0363783abf8d2c826fc9065da5a4baa87af58ed4b0357cfd58f2c1559991f521cf471a8af1e",
-      "rescan": null
+      "spendingKey": "97ab04185bc39821018d2d407f3e8336a8490a066a7e205927d472710d2d554e",
+      "incomingViewKey": "d1f493aed8672c94c6d7bd12c1ce83e5cfbd3ef581303aec83630e648685f107",
+      "outgoingViewKey": "67d00ec4d12ce9a0561a4ecdf730dc999758ec6a9b82f2ccea41dd99914b374b",
+      "publicAddress": "64bc7d1780136efd4a2c2bad36a397f21163d949658dc0912bf6a1af469755c89299f5c1222dd67467d1e9"
     },
     {
+      "id": "b19e08f6-a491-4a10-8df2-03ba6934bbc1",
       "name": "accountC",
-      "spendingKey": "1346f8e448bfdcc6616673641019e1d71ff6d9e8ca111df7c33a24b5632ab5e6",
-      "incomingViewKey": "c184d491c5acdf67047f56c5717beaeccd5f1a9e49080c7ad2455c57c645e605",
-      "outgoingViewKey": "099aaa52311e35a7d76a736e5020725d521a93aa475a320355d025d3f141f6d3",
-      "publicAddress": "7d0783eedf2d2ba22deed5147be3829037b495f40b3d51bd5feeee8426c219292d6abbb2b430ec380d593b",
-      "rescan": null
+      "spendingKey": "a0258a2d7de9e247c31bd16fa36c25ed150ebf47547ceccc6b6e05d650278870",
+      "incomingViewKey": "133c4172e9962846c79120b209bff61e2956315c1da0797995654bc2c23bf500",
+      "outgoingViewKey": "e5de2f41800e2e844d1d21b8620e55ed6da8b9926ab60679f813c10f070468c8",
+      "publicAddress": "0285e04d8a7656986c773d47c9eeb6450277dfb6c948a43328c72da4706b0874e3242520355a6ef177b1e3"
     },
     {
+      "id": "19e4fb6d-ab37-410d-84f9-599a97893d90",
       "name": "accountD",
-      "spendingKey": "af8404ec80b0054628e2543fd5bf8f3d8d925b506bbe69d278e0761e3f964b6a",
-      "incomingViewKey": "02cc17f4b26adfe10119573daf28a667e84674733c54724bb03b4103f6a8e007",
-      "outgoingViewKey": "759c5455de75d58b115d491ca56182f0be6ab3157fb4e415296c37fb261db25f",
-      "publicAddress": "a21de62668f82acb8895ae1ca9f6232da5b57e5dbf4fb1283581d223f99a78ba5fd1ce1b8003416b3ed4d1",
-      "rescan": null
+      "spendingKey": "ac1e0b858c27ddbf481494e6925310e509d7c079e3af581668a4dc08eeb8cf11",
+      "incomingViewKey": "36649746650e4cc239e9c08e9cccbbf11e1e09810cc61d54d2789ee43622de04",
+      "outgoingViewKey": "e13dee16337bc36f557fa1ae1572f804b204231a6a364b3b4a511518a86f48b3",
+      "publicAddress": "2d068b6393255c744d65bb4b09f6daf7ccfc91f278339504ad5bf5b96d5ee116d10acabd81907bfa1e3cf0"
     },
     {
       "header": {
@@ -605,7 +545,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:+bgcV+E+cel8WyW9x4+ypxRM+ErFOYvSqKRZyAGRvGE="
+            "data": "base64:Zs9/m5gL5hyeCrcfmVEIXkYC+TZ6UWjACZ9v0UORBQA="
           },
           "size": 4
         },
@@ -615,27 +555,27 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1657827944272,
+        "timestamp": 1663827369719,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "E7A5402AAE327475A5EAA68831BA4101CDDBDB13B0928B401CD360A5409ED7B1",
+        "hash": "05B770AC83BC400ADE0E8A28F6E443041A5A7EB6BCEEDF3C21B01EBD95066DCA",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKP0A+B7fmd/V1kEioAPuRC0w3M3KqD3nG9qoU59gU7vKYKo0AMaodM4nWXaK2F8+pLMFz5rfT1JKbSw5D9N6tcIraor1Nk5w+wttHVDGaTubs02xVWgm4aPTf4G9ouMZgEUVAVRmtZN98T8DrpJkUFuHUzKm8Ug5pixmAxTABz8xh+grP0jfWjAVwRd56PoGILchaGBjQgxVu+8NB5ZfkrsT9CGCFdlDtQJolPqGPpYzD3u9B+o4HF517fdx4lPW4Uf+lO48f8pSR0wzkTAnGIG4wiL2tiw9JZcCtMfqXETu6Rs9+brAx3hxD0sjvcMPdK4P5WUYMVVVHDAxPV+DhYd4ASCYm3S7QEP0vAE6A4uYN38IuTn926VcMTxMoBrjLz3lpRiEOmFs7VyiAWpc22ClScNr+6bXbWEKn0mPZeZxjNnc8x87mg2zQAsDlComeddgeOHZaCmGo4aTKRXSQMMn/o0iAet+cDEiesRnmtXArvYjN5KLIuVdpYr/lQific9IEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwErzIIybcn8nnyRZJDqAI6xOhsdGH89TnNRn6NiqX2hGNlYT04RvnYfP7cJYGeXLrRhxxqMW0H0/gy2nqslXAAQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJArx4t/PMSR44nEdRsxSY7hbjffwIHY6muRSsNO5RwScxJc+aLndwBUEeWJlDb6SJm+9fvXLxXO66pizWZ6qUCrUwa4YQhY9CIW79WpjS1jIwhDaV41tCC4gxoWzXH97gPLmTFK5fLVAFF7/C50Wua6OA4TyzQ8pBVqJ5sNqaq1Es6f+9poF4QVx6s02JSt0avIJOpDXoagss3f2WzxZWnj6kxV2WOOKUVIsdyVSAaoxYh1b3WUgzaTIzYQtbuOOq/NTGjdvimaG97rb0l8rOB910fhaQ7YAUKP/OhQKeU2Mc2e3TLfpqRNKLgTiW6QFs0j3BkHdLoB1fn8JN6z5XEwhYLXWgb6WqjL1iO4QVQvqx3wrUJOKE1Uws4RGniWpJQp26o233MUkDE7+R4annEEkKfYfOI6uZPtWPWqv3jUE8ja1PdN3WI9jcox5Fu/6gC16V5ncuMYdsO1P0JAyIQr0OOwb7zNY38Is4uPII99sg2YUIl1J823pqMV3+E0lon74kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8+VAu/HX8cqgIZTVo3UZhPaxu90cEfEmpuMHT3MPr2u86WGjD1bzxlZ+J58QyyaY3UASlvHXEtv7Mc3oG00mCw=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "E7A5402AAE327475A5EAA68831BA4101CDDBDB13B0928B401CD360A5409ED7B1",
+        "previousBlockHash": "05B770AC83BC400ADE0E8A28F6E443041A5A7EB6BCEEDF3C21B01EBD95066DCA",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:tw0/M/Jyu8laG3poIeLn71L4rgrMAHMkluVDL8xN/SM="
+            "data": "base64:SCoSzHwSXk0MKWDA3SLHfHkA4yBGq2b7XRfgZ5UGDio="
           },
           "size": 5
         },
@@ -645,52 +585,52 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1657827944421,
+        "timestamp": 1663827370226,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "3F677551B2A80BF53DEF408CBF5A10250859805627EB4679899D353852EABA83",
+        "hash": "F0086A5E0B6A682293AAC4513658884DC92BFC2EF45B88BB6DEA58CB6C63A940",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALOxq1khcFFS0jzxoffQ9xZUYhVqtEBwFc8UD4XSbl0y4m33ARRnvUUbl4JPBe01eaEI1GC83hh6tKnwmAALOlTwaUCLd2G+UfYZsseNPG4W7S4gZrWZPjBCMDHl+GANRQO3pPMht8DDqmOPNfko8OSceu1wuQB7TfGcupvfmZYA2Dfyp+NFBPFIbpM1QcMcMZkyHU3dyS5ntLcZqPKg1f9hfb8JFvoOe2zGWDf/Yj8XvVE/zlecOgeHusKc9dThNZLBFfIB3/CsgOdZuPY7GZjNR9XwVXl2RHnnZ3BvsasYI3whlkExfRsf59tpJEsxX3n8IMsdU0+woPPPiRKwEQ3B6oqmD5TJKl9UyrfFkxoyeBB2iPGRzjl2A9LsEAQNzq3h8PXEWnWWfXrMx3A80SefQA3EyOi08xnatxO4MGR/xhUx0WiJk0Q/msdzxzjdJsVzEuh+t/iA9DT9ZhrhO31e4dvV5Vt70njXGGLYp+OfrIKGxJFYnJ5u7pFebcX9Sd9nP0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmc4lkp6eX3crirEpNR10ALEc8hRwqy9tGephaGjs3W4QJeMy1CJzwhQu7s7Q9O+3D00x7hq8RreV3gQW1ftvDA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIDtrjISmhNSVnuW8eDHB0W+u2zC0N1v42KlJAJDVeNQ0d4AIcWll3tUpv4Pvg/B06kEuQF4NopZMq+7DH3XCyuTDtr1/5K69l+Dl6kviDknVYpt4euwsbzgsTLLJq/98gUp7PwxO2ycvxIC6qMzN+/owqH2poKEsnNrKDro0gUcoNzJyhpa5UiQM+LHnGwui4W8XUdRypDoriVTAbI+5CXS/kfy2JdueItHQ1px9zmTkDXBz755ksjDXPxjDzCOCJPCnY/+aRLaZtiuNmE+arkd1T6Mflm4Zz40QeB2q1pVBr/QFfP2teqa6AHldUbp6nWmYKNU23eL+V4Mwg0OKVaCwvecew8l9/R/hKkH2pCnEHcOMOWYv3FxfgOlUWAL6PzcWdqDXEoWAROcOW4tV6kpIjpq/d+4WfZ/HqlDcMQFoVZpfMx1QziY0Y4vbGaZ3wbDXV3mW/olgPf0fzUrkvd8T2eV9rs6HehFPt6Oh172m503f+cV9A9si0VOzC6gFokTvUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+jLhxesCNFdr1E9s3MYjYfVK5wX7ucOGhgLWrQh7dEBI7CT42BA9Qbha+G4QJEjlsZ55uZGddrGuJapYOFDCAA=="
         }
       ]
     }
   ],
   "Accounts getLatestHeadHash should return the latest head hash": [
     {
+      "id": "f3aaf098-0129-471b-b8b4-a9104d1be3fc",
       "name": "accountA",
-      "spendingKey": "98e0672d6f033030e18e2d6fd933242592f869372a774579428e3072205b5c24",
-      "incomingViewKey": "1a20a513bf5cd558d2ca55872bc575979e72f556611888f091be60c4c2347500",
-      "outgoingViewKey": "a676a8295800055c2bc94f72477427339029dbf93d76e23ba0e3d48ebdbafdc9",
-      "publicAddress": "077042bcd129e6c5906393bf19f5d2bc5c56550c02a3e898bf01f9a4ea1ce26bdc759fb25327010bfb252f",
-      "rescan": null
+      "spendingKey": "4ef3470db0853bedbbb93635ce65cb45f48dc23a41b784292757698e98d5d73a",
+      "incomingViewKey": "502d99bcafd966c6cc388b5fe6b93824d4b764e21f3ef427ff61ff62dd067305",
+      "outgoingViewKey": "cce3a70749b29c84af14a26b7daa9d298aa628a1cfd41aec9205d175dc4df123",
+      "publicAddress": "0a29f332eb77837dc29977e8ee3092dc91ce17aca099dee78ca84a1e149b9b1b7541fc69745ed62f13bd2f"
     },
     {
+      "id": "29a1fb0c-76c7-48b9-8dda-60d4c8a5e630",
       "name": "accountB",
-      "spendingKey": "5e95fd34ed78009711fbeac0d591e342ec62dff2d16a06758efbd04917ccc6df",
-      "incomingViewKey": "d1a69d383892439b44ab8c5a84204ba9b7f4956715526910f900654a9300aa06",
-      "outgoingViewKey": "80063e7c589acc5b3c85fd210adb7a64c578de66783867b77fdb9f2a65ba2209",
-      "publicAddress": "5fd1fc25ef6887d667c7781dd76a4e53d6d05179e09ecbdd9fdbe24f0d34b033f928c4bf726fe9cac1da53",
-      "rescan": null
+      "spendingKey": "6624e6240865293f944aeeb26b4418b8ded9c83e3409a4df73132e73763874af",
+      "incomingViewKey": "46808c407a29d8f914861722c38cce8e15801c13954f351b94dc878d10223904",
+      "outgoingViewKey": "a1ea04f8b85cca81c4d36bf86d88b039a9268ca46e372e51fca95ef83734700d",
+      "publicAddress": "e554cb5fe5d186ecd1c6d0be0a112b479e172a8f807db279d5be7192f4ea856df770826581d9dfdd2ec99a"
     },
     {
+      "id": "5fb9d96e-77b0-4bea-a30c-73009b240353",
       "name": "accountC",
-      "spendingKey": "d39f72e4ebd75f3aec6664fc8ceb2cdcdea9c3423dc8c43e3181045794725da6",
-      "incomingViewKey": "d0bbc506c5df67bb93ee3a026459066ded3bb1202c040b042a81af7bb38f8301",
-      "outgoingViewKey": "017fd57edfbe7cf5b22d6e970a7883d758549c876ca35fd738e35dd55014be81",
-      "publicAddress": "0769b2510ba2dd2f9e17414a42e048d546e58dbf57a0ad4e2b1d650d9f31353efa4458f2a2ff36a5081d1d",
-      "rescan": null
+      "spendingKey": "83ba87cbc17edc4ad645f23d67a21b9ff1b44d7f7d08f4bc025fb3dfd707b1c8",
+      "incomingViewKey": "97b635928f28383beb47cae67fb55501d8fa30199960f42e84553e619a74e705",
+      "outgoingViewKey": "b72eb85f69476c163ba606159ec9276820e38a0bd6349896aefeea8754761949",
+      "publicAddress": "80afc9acbe7b977df28eb19f3bce20ab747d477b9a8f43067a9150494172bfff650769d4bbd6d2ad0d08da"
     },
     {
+      "id": "a1241e59-2e9c-4c05-82c3-0e2bc05e6e3b",
       "name": "accountD",
-      "spendingKey": "8201deddca28ed1db89eef4f0c136179511a07ed4da582d607bc3e7f3fd647c2",
-      "incomingViewKey": "fddcb490828afc84e00b3e2d5231e9a5c2597cac3349170ac082180ba5988804",
-      "outgoingViewKey": "2e73f63f184e4ced85f9bf11fcbf17c48b8545f8402746dd62b6f86bcace220d",
-      "publicAddress": "3099cae94adebf82607e4fbb458457844bb047f6d27c3725e6d4abc5338558cd8854f090f85a6286a7209a",
-      "rescan": null
+      "spendingKey": "cc6157a1c7f6e9ec422c647828d1fa79d81f9dfb83bfd63bb97ce7f97b2681c3",
+      "incomingViewKey": "83e8ca930648a6e3538c21c4d619f5496da5617f982e269c56af221928e9d604",
+      "outgoingViewKey": "c557d82195aa1fd501ee60fd252c7f90063e11c0924e70d667f30eb6f77877c0",
+      "publicAddress": "e123fd62eabd00819d5890114d9304e5508c699acba16f1d4937b8d8520e2c92f3c71542dad532046ac66d"
     },
     {
       "header": {
@@ -699,7 +639,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:KfwuQLJtwzNXU4DN2SeuGPx9pkbeSxY+oo/6JijzMic="
+            "data": "base64:yrAKlFDYqmghbuY9d65B8uYvN4swukVvbwhz8j5v7mg="
           },
           "size": 4
         },
@@ -709,27 +649,27 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1657827944596,
+        "timestamp": 1663827372182,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "C028FAD754A841DCDA76D81B39478F48869FB9F82C1D696D500D5B23563C30C7",
+        "hash": "735B2C553BDBADE98D21F3631DE1909A77A809910E97328E4686FD04D30E5A83",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKvim3y252pSYzx97Fk0gSsBVIaqGwTKT1K8pn1lbIqnrwjhLMHnYTJKR6rRu+/n/qoLY6OrYT6XwiMHDS0PakMHGqGvLO408QEm7PGwFI/LufpXrycZCS6M1zEOX9+zdAcHwjfmQ1icN5B5do5exyJBD7M/RPe7s3Td7lgVgNJ1YU9YYN3l8I7+rOZ/PVv0t7cvmcBcHxCW5XarCTfdH9WsxX6dZGac349juPgWVkMOiLL9cr0j4Bag2C3dAMpM677JnZLi3H6mbPj9Mrc/VK41BAhNxhB31TCXoT7KDOEtm8xhHtlGBYR7ckNcrg9xcd76d6AofGk0qwzoW2RjuUKQ6j7149ORUCDmNQQfESRPyYm69ClY+3FpcOAdjHR0NkCtc00+WfgK2ZrqGzYbXVF+bcokbUCn5S4FCw3XZfbSHZSuVMe+x3Bk0nIohXG91oQY3C0rDoAFWZCjv1zX0Wl10Loc5J5wZ0TWw3WMbBw/op8NO2hRu0EIVu87VExI/oGBVkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwfj3Gwe2qCZYfF21u/tzSKFPrugXa4cA2hVTxqVMhz97mMCAipFHo0cdrjB7VVbfFXen/1Sq9r/j3F1aSQQjoCw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALY39rlsukmoLQQo+43qYOahwRW8yWvCbgGGvY2W8DU2+4E6RdlgsR8Z+CoeJC0RpIkH5v6YcX5OVMhi4y1v+QjerRnRjKeMP7JZEwNpTINloPw0ITQpjHZkUCwjB+MOZhWNTaaTX2MYg9y9441qjHLKgMVVeJ1wlB4sb+w6lmTwd1ObdBZBioOBWLjSMLX1aoSdfDsXCI0EswUiuZjX2KfTHRk1DTgJBxUq9lnDnHxb3F8cOKJXexDn6TaDKMHs5tDls/on89RQQ5crnNmEGGK1d60c/dtW+IgXnjkDiUNx84/wMdG7lwqzQUOtTEPP6JJu6/248YyBLjliNqrLCm8KsLFuoePClklNCakND7Bf3EvM/Je2G3o6VYlya7zqRCiX7dWJre8QU5iXA4SldIyAREsANKE5dQ+f9S4etl8YTBoNXdIgYy39WYa7dfco0aL93wu/lUt8ZDIlgHIUopPNRT7dKBHkmjCoFTqubq7YnE1d0LByrU5b2y8BRkuhrV7KckJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEoOTdiDM+NTRwWqWstPj5h3TG9yXfSV+8GfI2A0d6vEaM+gsi+ly9mSg66sIrvG80KeQPd1vWclQg8c4I0JLBQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "C028FAD754A841DCDA76D81B39478F48869FB9F82C1D696D500D5B23563C30C7",
+        "previousBlockHash": "735B2C553BDBADE98D21F3631DE1909A77A809910E97328E4686FD04D30E5A83",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:q9HcCFs+60Q/Y/dMHmqZbW00dIW3qVgGMJ9flUpXcEc="
+            "data": "base64:PoYRFVBY+EjHu9/QOwTBkrD5Yntaqc8XkTmryg8uRz0="
           },
           "size": 5
         },
@@ -739,28 +679,28 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1657827944744,
+        "timestamp": 1663827372900,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "B08A37B62896EF119D256E8AB4D8AC3C0ECBFB82D03D8E6F567279C3249E624B",
+        "hash": "634E20522B294FBE676CC4A58D9578D8C2CF1DE0F32FDAFAE3315FA6F809E138",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJedQ2ZfGAJiDKb/WzArVNcjMAgZWttlvCA/gJmB0BaSzDrqJrt9YVB/WR6q02Zb34NmHTGLJWO6OR9Ce9a0WGlk4aO3nit4uS5jqtn8/8UBhP0D4iAoEt6CnSsUKL5V1QLJUNn/3SAJLItrxTr2u9VJSmCjXf/KZu/KlyIZ+B09TJOsix+2fZ4w4MGngceQ6rOz1lkFZLjpxjQWz/lMfLtlfSy69u8conWVzEM9VO2z+CV32nO53qYekYEv99EC+ZHkLEWPGO1Tb3/x7MZ8HM9Yh7rEPn/kWrrJt4LJ6H6pdJtUw4cwWPcG0AeZ9aITUyFwNvyO14uUl6jhkZsYDARPvDp9H83uc6PvcyMIPEzqLopNMNOGQtZcSYFLGpOZ2anZkWEAEOPsw3EkLtR8UVB7EHSLuC+uh9hI41nb/M7ZdHSJG3OfDjOv2lYXurlXOtfEOFSxYhJvSF64G1EscahFVatZiP8zT2QaKQFzhRNprh7VOX/7TIVIZvGqexV68V58+UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGsAoyanVMCYL8RqGm5N9bWl9CLB0gE194fu0SQk8FMO8rgGgigVXYkbIhMJy6KgDFEbyF6c7kNLaTEYfqx0TBQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIGJMD+AhkUHiDEnw8QcUUMFJI/w2rsQyb9j2N54JoEVrglrAjHLg/TGVqK/aLbGrKe3mZ79la0nnBv73yAciigQqNX0wpvFOD0jfWF4pxvJTNpwiNdjUfK+xwCQ9+/pkQCtf2FmKYeuFbO5OpfAVq1aLQ59nCwl3rSFJz1HdPs0+VtvGU2C4DeXuu71QN4GdJBuyowR5IJXyAHkLiClRVVWBLLWhurlzpF9Ve4zHqxZJnpDMz8+4+1ApPED7ljNOyIK9evFWaQxA7ZF3OAjZUTqqqOuEVSBV6Jwnu07FFeZBcbAqjuquwgucJlua2GvCEC2xLRTYKMYWcN8KIzMr28q3KLZkg7lQHmJDoynNoGR5vsjQtCtaXSL64ush73K6drzLufOL3sQDXGHHmtJgPtCg6Yhu62VLu66WPil3Qu89KTweAPBVonkivUD6lM8N6I8yrHQFzA6c8vi3k/t0btiDqGiE8G5K2fzXU0bvGHLkBFLLA6qlnYgqOA+8tYD/exctEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw17S9f1qgk61oxUM5IYdeTRi4qUTW5wC+VxA6IFzIgxN0N3fM9uLn1M1c6GgFjHiunIb158NdibOwHmeyyz59AA=="
         }
       ]
     }
   ],
   "Accounts loadHeadHashes should properly saturate headStatus": [
     {
+      "id": "dd32fca6-4f15-4684-b982-9f035e49a5fc",
       "name": "accountA",
-      "spendingKey": "8aa04e72e8ce7dde3d5be1377a8f6111a489c8b01807b5808a8d97e99eb7e9b1",
-      "incomingViewKey": "defc5de7d51bed5d3ca8bd30cdb5a0dd3637b476ddb65df85c2c8504c3d9a405",
-      "outgoingViewKey": "036d25a403353fb1e3b8013589ed9fb6622fe26c3a02942d372ad96ad535f689",
-      "publicAddress": "c546448529ae7e154821e1e98bed30d816c55b5c7bbb1b938f27de7272de822144a73feef14e3fb8ccae40",
-      "rescan": null
+      "spendingKey": "d2e4667dde1db922389ad42b297e95c36e9ac61a915030d838174250a51bc3e4",
+      "incomingViewKey": "14313ac0edfcb4b0354b637afa04d186944b70dc24fe6690828a4cb21623e206",
+      "outgoingViewKey": "eab57a9cfc418039556faae397463ad4748f5d801fe6135b61fc790f1eefb5ef",
+      "publicAddress": "6668b738f9202a2f517005c7e7ec0ab8c8b9cc41f440165de893314a192f52dad8b7813e76f4537c9b6e25"
     },
     {
       "header": {
@@ -769,7 +709,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:H97VHIbbb91ItybKAgCiKgWm/skvVaa+a4YGH4NJdTw="
+            "data": "base64:5x1EQ1FTdt5u8Vifecf12Pu2UTO1NZj736/8KjqSWRo="
           },
           "size": 4
         },
@@ -779,35 +719,35 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1657827944917,
+        "timestamp": 1663827373860,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "08680163061FBF152608EBA2B0B2BB657C4799224608F38209F4FCDC9B725C24",
+        "hash": "124BF5C9BC25F8E00F0F613AF8EF8927893DC5D448EC429D42A85D9C03004169",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAITuiMQ6JaGrDw+wwiD8SvaYK8wVV5zKwxJdAYEfsdASSmj1pFtVCqjS5wkQg/1EbIgmUmGP3wLU22pIv2bEWe162t5Za9XZ7QUx6zWpJ1sVvWx95HhHeMRFDsCTlptIXwnPQXr2hJh1z8Y84tIeuPUytV8roRcMHpLne/r5gwlj1A8GKFpiOylgXKJsG6sexaEEThCq9Xej3Oy4668w6xGe7emtMQMaMehC/3OdvtG4EdgYiXkXu1sYkCcMdva1taInbxqRC/h0tioImt1dJdwqPEmcLcwl6h1Ib23zHnMObF6deHN5EWEac1xQfg8VyvnHbD6yje3WO/QcZ50xORnY5Zztq7F/xci92h0YrFkMiwAyU3IRpTmCcZ6/+JkPA56OxJbQ4f+6ZdRy33+6D+rwBf4lHkAYfv7TNMjzqS/+mm247RIXNPXwgfQ814BbJF1xRtiNx2jEiygkbkps8JUQhZP8IfGmUD8l0WpkjQLe+z83qHj49LdrgYNskW6t92uH9UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwY5NfzFjRLqXlqBeCxSVadrG2JkpVYqgrPPNlNE19DdH8UZu7ABxs4A5cnJC6r2wPje993GicdTdx0uYaenW+DQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK8nIBPZXNONTMqjs2i727js5R8zD1JvbIuaL3ShTedn+7l7mCxxJt84FN5TygcYM5AQCT9VgLPOPRRbW3o9uc2ifaYkep9fieFnMgLquQTEWGkq9g49O//l07SEpn6KvgjNSF60JR8vyY6E2kBZjNAKDU6X4vfvc71eJ6ToIC9sZxfuGCcW2gaS8ofKYFre2YwzuwNp20fMQFvtxGfALeIfJd7l9zuSY125H6l55iWtx9+iPMXpwHchDRhQLXYIjZO0H3utGcC8S0XTXM1q6yuJrGcJq1iemR4fE+Bt1dgtXbBms2TIz4UShfakQHg6d7mCPw3tQIZjaF5JJz3f5wwJ34JTTLzx2H4oMpNtWmB9Jq/r0lSFPiWJSUxDZC+ltYPHs/jx0MYaaqMiqdA1iaTmcXjdQNswQ7nhOEpMpxNh4X5lhcpejzedKMn+IGlQx2O1Yu+5XJuUn191oAYFElbjdauUK/QwiIhNNsJNMr1K4i9Q9y0sekug6MjcZvKbLl+PfUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwzAefctyaF4E1VYVeeopIgFtpaRiOoftEZ2Tr76Q88lTWr4lntqG4Mq87xucKZv7t0r0RkeE8mZkTT5f4AfKdBA=="
         }
       ]
     },
     {
+      "id": "635aa60b-e5fa-4cd3-9260-42f0ac0c27ea",
       "name": "accountB",
-      "spendingKey": "0c086e4682716dbe2883c8c2f41b3d8dfcc42bddc39621f4fceb695834d70deb",
-      "incomingViewKey": "b5b052569ded7ae5f9e31c3db07d980fbab65f81dfaf5d6497ce2a8ebb389a02",
-      "outgoingViewKey": "f0d874ec1ccc1fe5512cb7b9512e00487140014fdb83db1979de9e8daae9e6bc",
-      "publicAddress": "3b91b38d34fef02d80e024849afb43f944e4829dab13a311b04dea3096288e0eca75a21289ecad30f68c9d",
-      "rescan": null
+      "spendingKey": "223dfd27fc30c1b38094e12d568bc7156eed482ceea2e2f2c486bb0667a8b3b3",
+      "incomingViewKey": "2f525ab091b562bba0674c7ee7401889302c9e77056aa2ba46e862defa83b200",
+      "outgoingViewKey": "2fabc0d62c85d7fe84fbadbd5b688fad962d657e827339eafdcb3e9fbf14ea9d",
+      "publicAddress": "678b4890ae3bf4ad7f539f29eae4bb3b348de13ad10e6baf26d49c9c9b47427bd1afaca62ceab36a7d41ea"
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "08680163061FBF152608EBA2B0B2BB657C4799224608F38209F4FCDC9B725C24",
+        "previousBlockHash": "124BF5C9BC25F8E00F0F613AF8EF8927893DC5D448EC429D42A85D9C03004169",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:WA9pS40OEdyAOfcSiAvHYKp5Hixk24EUJfT5O5iXflg="
+            "data": "base64:0Uwm2/3fhYif0voIWkYDFGOQteQqdmmHesFklVuikGs="
           },
           "size": 5
         },
@@ -817,40 +757,38 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1657827945076,
+        "timestamp": 1663827374420,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "AAD05EDE9D6BA182B6916BC2029A9C0AF5E09053D5D36DA009D62B115A433FE2",
+        "hash": "4AAA81BF2E2B7E5E2CF435F1DE567B9C468FB64015C8C1B888FE4C6DD663DA97",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAISpIEOXWKTy+g07/LpfruxuzhmpANxPwcV/Z9Wu60G9iTxO/Mm4eau7vGzJi6vz5qvaJkMb5mbMCkFFkRYmY+ebO346a+GHGWIHhSC6WrV6BoYtu4oqCPbdredyhPWAjQ/q68kmxB/DB9U/gEq1njVoQCvbZ/XUFiFSiG+9KnkGJq9zZcCB+WSmiwVaQ7Kar5MOQHkRGr1ewwLLoYLFAOixjgxGmp0HsLkSzgwB/AUhD3eaJK7jcE7V74/TjE1O/F93keq+Lk04kryU/NQXSV6hawj6fbJ+MyhhBe1Kt4WZhlnNnf+5va0AsD8Izd1BTePqIRHhyyZBqIQzEihG/VHNT47f9T/TDy/kD45+f0vVcY3y2NQFxg2P9iVXCPYmDdevA6uR0Eiv250K2GGhwxL891LnQy7+1Ro2G+SfsdRI+cBdPSrC47tSs069TF1A/jNhDBCsQPzdr3Z3kJlLU/zbh7S3gzJE+47U6HU7FjtFeKnRZMwXyEh2IouyibAarCLY/0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCXMP17QBzgMaXaxS9VN8taA5sC/yLq/EIl6ljeuVvpIjwhqT7JtvQjyNrZFxsckixL4rZQUzgK5h7J6WF6fnCQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALH4t/JKV+1HJCIZ20HQ+F+GaDukj0IcEXqNjw61kMbhsln0YNaPCdiLRd+d7Cf3xK1gyi+sYTrOn5dn62pmi0qJpfupWdFpZUCGBOSgBN6w6CUfeQWrq37Ya4l6KU2HRQKHDCfP6g/pIEN2w6frgxOiwuaapRbzGmgNnZMf98E2vob9J8aHnD85jskMO3XfMK29QvsBFmvPEBEXKSvbJ7pjrESgszzH6t9bYmGAy5veYVOH2dFwKyQDQB0568cJEAZAO8B+HpBq+G/Wx8q29lpUddlGQ92mcCow86Et3T5OR2DgcYnCKMus+kGT/n1drvytyfk9ARw194nhZCreREpMX0JuJMyHPxqYc8/GqzWWTsdub99Ikmle6QTTzonFOr2zWO68Ph8NcW3XiHmhIxrwaPwzXYkTssW8ScyBTaMh34eqp1DbHpvqP8aOjfuSIeCt8SU2UPmETsLrdxtumFxyZQOqKwnDUzJGCxMr+YLQje7ZN3B2Xc6mO4DZtEIzPpKuREJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvFYXkI3MadqCo9Ox74e/oC9hSmcyBtfAkC3Q7jI9WkeDSFKGZLDykRARzToxlyjDtfO/HdW6n7IeM9kAyXc6CQ=="
         }
       ]
     }
   ],
   "Accounts importAccount should not import accounts with duplicate name": [
     {
+      "id": "47cd47ac-b761-432f-9b6a-3da86203b48a",
       "name": "accountA",
-      "spendingKey": "9240d026aa875a1e554c4f4b9b3b794ca41fc746b08e78eeeca5a0afaf9b1fe1",
-      "incomingViewKey": "01f5e2f7abac51207ed30b038c9b3093fe7a72472b6e6b6c9deef934ebd2a905",
-      "outgoingViewKey": "3ccd54821ee5664f7f1b5b6b9d91b1e275b1d2d85293d824588f3789199c5791",
-      "publicAddress": "0721c505866ed4d5943159d278853a1ab70ae3a9351bfad183fa3f94333ef7e9c8dfeb62799b3cb94b7d28",
-      "rescan": null,
-      "displayName": "accountA (8696ea6)"
+      "spendingKey": "21a49b1c7e813e80bdf4c14b7c645db479c28e44deb30ab43b36ac52f5a2d9ac",
+      "incomingViewKey": "b990c2655e942f11eaa4fb5b9e494a7c2ddae6a86de3820f3098bb2d60de3f06",
+      "outgoingViewKey": "e29720f758f028693efbc1497bbd65fb4409af5c041689a31440c3a82adbbac2",
+      "publicAddress": "032d63c56dfa6791c8bea2a06eebc48c989989d011e33a327f3d2aca42c62fb3f674b0e7b71d53ffe81d6e"
     }
   ],
   "Accounts importAccount should not import accounts with duplicate keys": [
     {
+      "id": "e5b0ae7f-5652-4f96-a9eb-2f3f6f6d79df",
       "name": "accountA",
-      "spendingKey": "bde02ada91666ab8bb2bf28a5fa949e746f08623a673ecc5a8e9a5342beafa6f",
-      "incomingViewKey": "cad6842815ae4462da832eb98a25a37eca7a1a1d9a0db69aa920b1086d387a03",
-      "outgoingViewKey": "12adcab8428605f5d3c180a13eee964984096cfee9a864ec47c6b9cb86da3f4b",
-      "publicAddress": "3f942976c90f97ed349bbb1dd0147a30a9e7f9dfa1ec700d2a374b16427ab06aec1cc04e97e3893d886200",
-      "rescan": null,
-      "displayName": "accountA (e383892)"
+      "spendingKey": "9ca3aaaec5a3f7243062beac7143e2793eddda1a8fae078d1ad7b18a6c42f414",
+      "incomingViewKey": "38d7327c6a5a16a19ec739ac44268b174c2e7f0d5291fb8e19cbb547a754c405",
+      "outgoingViewKey": "d79ed126894405db0123141cd1b3e6078723afeb182b18c221d06b2a73fb843b",
+      "publicAddress": "3470b9be503e7b7f7080b21040b59d72986017bf09b44e7cb7190b2099659bfae9bfb34465fa7f4e6a7dbe"
     }
   ]
 }

--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../assert'
+import { createNodeTest, useAccountFixture, useMinerBlockFixture } from '../testUtilities'
+import { AsyncUtils } from '../utils/async'
+
+describe('Accounts', () => {
+  const nodeTest = createNodeTest()
+
+  it('should store notes at sequence', async () => {
+    const { node } = nodeTest
+
+    const account = await useAccountFixture(node.accounts, 'accountA')
+
+    const block1 = await useMinerBlockFixture(node.chain, undefined, account, node.accounts)
+    await expect(node.chain).toAddBlock(block1)
+
+    const block2 = await useMinerBlockFixture(node.chain, undefined, account, node.accounts)
+    await expect(node.chain).toAddBlock(block2)
+
+    // From block1
+    const note1Encrypted = Array.from(block1.allNotes())[0]
+    const note1 = note1Encrypted.decryptNoteForOwner(account.incomingViewKey)
+    Assert.isNotUndefined(note1)
+
+    // From block2
+    const note2Encrypted = Array.from(block2.allNotes())[0]
+    const note2 = note2Encrypted.decryptNoteForOwner(account.incomingViewKey)
+    Assert.isNotUndefined(note2)
+
+    let noteHashesNotOnChain = await AsyncUtils.materialize(
+      node.accounts.db.loadNoteHashesNotOnChain(account),
+    )
+    let notesInSequence = await AsyncUtils.materialize(
+      node.accounts.db.loadNotesInSequenceRange(account, 0, 3),
+    )
+    let notesInSequence2 = await AsyncUtils.materialize(
+      node.accounts.db.loadNotesInSequenceRange(account, 1, 1),
+    )
+    let notesInSequence3 = await AsyncUtils.materialize(
+      node.accounts.db.loadNotesInSequenceRange(account, 2, 2),
+    )
+
+    expect(noteHashesNotOnChain).toHaveLength(2)
+    expect(noteHashesNotOnChain).toContainEqual(note1Encrypted.merkleHash())
+    expect(noteHashesNotOnChain).toContainEqual(note2Encrypted.merkleHash())
+    expect(notesInSequence).toHaveLength(0)
+    expect(notesInSequence2).toHaveLength(0)
+    expect(notesInSequence3).toHaveLength(0)
+
+    await node.accounts.updateHead()
+
+    noteHashesNotOnChain = await AsyncUtils.materialize(
+      node.accounts.db.loadNoteHashesNotOnChain(account),
+    )
+    notesInSequence = await AsyncUtils.materialize(
+      node.accounts.db.loadNotesInSequenceRange(account, 0, 4),
+    )
+    notesInSequence2 = await AsyncUtils.materialize(
+      node.accounts.db.loadNotesInSequenceRange(account, 2, 2),
+    )
+    notesInSequence3 = await AsyncUtils.materialize(
+      node.accounts.db.loadNotesInSequenceRange(account, 3, 3),
+    )
+    const notesInSequenceAfter = AsyncUtils.materialize(
+      node.accounts.db.loadNotesInSequenceRange(account, 4, 10),
+    )
+
+    expect(noteHashesNotOnChain).toHaveLength(0)
+    expect(notesInSequence2).toHaveLength(1)
+    expect(notesInSequence2).toContainEqual(
+      expect.objectContaining({
+        hash: note1Encrypted.merkleHash(),
+      }),
+    )
+
+    expect(notesInSequence3).toHaveLength(1)
+    expect(notesInSequence3).toContainEqual(
+      expect.objectContaining({
+        hash: note2Encrypted.merkleHash(),
+      }),
+    )
+
+    // Check the notes are returned and in order
+    expect(notesInSequence).toHaveLength(2)
+    expect(notesInSequence[0].hash).toEqual(note1Encrypted.merkleHash())
+    expect(notesInSequence[1].hash).toEqual(note2Encrypted.merkleHash())
+
+    // And that no notes are returned in a range where there are none
+    await expect(notesInSequenceAfter).resolves.toHaveLength(0)
+  })
+
+  it('should delete transaction', async () => {
+    const { node } = nodeTest
+
+    const account = await useAccountFixture(node.accounts, 'accountA')
+
+    const block = await useMinerBlockFixture(node.chain, undefined, account, node.accounts)
+    const tx = block.transactions[0]
+    const noteEncrypted = Array.from(block.allNotes())[0]
+    const note = noteEncrypted.decryptNoteForOwner(account.incomingViewKey)
+    Assert.isNotUndefined(note)
+
+    await expect(AsyncUtils.materialize(account.getNotes())).resolves.toHaveLength(1)
+
+    await expect(
+      AsyncUtils.materialize(node.accounts.db.loadNoteHashesNotOnChain(account)),
+    ).resolves.toHaveLength(1)
+
+    await expect(account.getBalance(1, 1)).resolves.toMatchObject({
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(2000000000),
+    })
+
+    await account.deleteTransaction(tx)
+
+    await expect(AsyncUtils.materialize(account.getNotes())).resolves.toHaveLength(0)
+
+    await expect(
+      AsyncUtils.materialize(node.accounts.db.loadNoteHashesNotOnChain(account)),
+    ).resolves.toHaveLength(0)
+
+    await expect(account.getBalance(1, 1)).resolves.toMatchObject({
+      confirmed: BigInt(0),
+      unconfirmed: BigInt(0),
+    })
+  })
+})

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -352,7 +352,7 @@ export class Account {
       const unconfirmedSequenceEnd = headSequence
 
       const unconfirmedSequenceStart = Math.max(
-        unconfirmedSequenceEnd - minimumBlockConfirmations,
+        unconfirmedSequenceEnd - minimumBlockConfirmations + 1,
         GENESIS_BLOCK_SEQUENCE,
       )
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -175,7 +175,6 @@ export class Accounts {
       })
 
       this.accounts.set(account.id, account)
-      await account.load()
     }
 
     const meta = await this.db.loadAccountsMeta()
@@ -189,10 +188,6 @@ export class Accounts {
   }
 
   private unload(): void {
-    for (const account of this.accounts.values()) {
-      account.unload()
-    }
-
     this.accounts.clear()
     this.headHashes.clear()
 


### PR DESCRIPTION
## Summary

This PR will remove `sequenceToNoteHashes` and `nonChainNoteHashes`. These two are being moved to database stores that will be fetched from using range queries.

## Testing Plan

 - Added new tests
 - Rerun migration

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
