### PR TITLE
Fix benchmark crash when temp directory doesn't exist

### DIFF
--- a/ironfish-cli/src/commands/chain/benchmark.ts
+++ b/ironfish-cli/src/commands/chain/benchmark.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BenchUtils, IronfishSdk } from '@ironfish/sdk'
+import { BenchUtils, IronfishSdk, NodeUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs/promises'
 import path from 'path'
@@ -40,8 +40,7 @@ export default class Benchmark extends IronfishCommand {
 
     CliUx.ux.action.start(`Opening node`)
     const node = await this.sdk.node()
-    await node.openDB()
-    await node.chain.open()
+    await NodeUtils.waitForOpen(node)
     CliUx.ux.action.stop('done.')
 
     if (!flags.tempdir) {
@@ -60,8 +59,7 @@ export default class Benchmark extends IronfishCommand {
       logger: this.logger,
     })
     const tempNode = await tmpSdk.node()
-    await tempNode.openDB()
-    await tempNode.chain.open()
+    await NodeUtils.waitForOpen(tempNode)
     tempNode.workerPool.start()
     CliUx.ux.action.stop('done.')
 

--- a/ironfish-cli/src/commands/chain/benchmark.ts
+++ b/ironfish-cli/src/commands/chain/benchmark.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BenchUtils, IronfishSdk, NodeUtils } from '@ironfish/sdk'
+import { BenchUtils, IronfishSdk, NodeUtils, TimeUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs/promises'
 import path from 'path'
@@ -80,7 +80,7 @@ export default class Benchmark extends IronfishCommand {
       totalMs += BenchUtils.end(startTime)
     }
 
-    this.log(`Total time to import ${blocks} blocks: ${Math.round(totalMs / 1000)}s`)
+    this.log(`Total time to import ${blocks} blocks: ${TimeUtils.renderSpan(totalMs)}`)
 
     // Check that data is consistent
     const nodeNotesHash = await node.chain.notes.pastRoot(header.noteCommitment.size)

--- a/ironfish-cli/src/commands/chain/benchmark.ts
+++ b/ironfish-cli/src/commands/chain/benchmark.ts
@@ -44,9 +44,12 @@ export default class Benchmark extends IronfishCommand {
     await node.chain.open()
     CliUx.ux.action.stop('done.')
 
-    const tempDataDir = await fs.mkdtemp(
-      path.join(flags.tempdir ?? node.config.tempDir, 'benchmark-'),
-    )
+    if (!flags.tempdir) {
+      await fs.mkdir(node.config.tempDir, { recursive: true })
+      flags.tempdir = node.config.tempDir
+    }
+
+    const tempDataDir = await fs.mkdtemp(path.join(flags.tempdir, 'benchmark-'))
 
     CliUx.ux.action.start(`Opening temp node in ${tempDataDir}`)
     const tmpSdk = await IronfishSdk.init({


### PR DESCRIPTION
## Summary

This changes 3 things about the new chain:benchmark command

 - Creates tempdir if it doesn't exist (would crash before) (https://github.com/iron-fish/ironfish/pull/2217/commits/6002ab6ffdb5cc94f0b248b099bbe016680d5a05)
 - Waits for the node DB to become available now versus crashing (https://github.com/iron-fish/ironfish/pull/2217/commits/ba043930fcc22033b2825500ddccf0f597de05f0)
 - Uses TimeUtils.renderSpan to render the bench mark time because it would round down for less than 1 second time before (https://github.com/iron-fish/ironfish/pull/2217/commits/d5f35877eed982158ba1c7eaf3342fed5f0fcfa8)

```
> ironfish chain:benchmark --datadir ~/.ironfis-bench --blocks 1
Opening node... done.
Opening temp node in /Users/jasonspafford/.ironfish4/temp/benchmark-JxFF6K... done.
Total time to import 1 blocks: 0.3354ms
```

## Testing Plan
Run `ironfish chain:benchmark --datadir ~/.ironfish5 --blocks 1`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
