### PR TITLE
downloads snapshots directly from s3

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -34,7 +34,7 @@ export default class Download extends IronfishCommand {
       char: 'm',
       parse: (input: string) => Promise.resolve(input.trim()),
       description: 'Manifest url to download snapshot from',
-      default: 'https://d1kj1bottktsu0.cloudfront.net/manifest.json',
+      default: 'https://ironfish-snapshots.s3-accelerate.amazonaws.com/manifest.json',
     }),
     path: Flags.string({
       char: 'p',


### PR DESCRIPTION
## Summary

our snapshot file sizes exceed cloudfront limits. there may be a file limit of 50GB (requests for files larger than this fail) and there definitely is a limit of 30GB for caching.

## Testing Plan

local testing with `chain:download` on both the old snapshot that succeeds with cloudfront and the new snapshot that fails with cloudfront

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
