### PR TITLE
Have DecryptedNoteValue encoder handle Note

### DIFF
--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -312,7 +312,7 @@ export class Migration013 extends Migration {
       const decryptedNote = {
         accountId: ownerAccount.id,
         index: nullifierEntry.noteIndex,
-        serializedNote: ownerNote.serialize(),
+        note: ownerNote,
         spent: nullifierEntry.spent,
         transactionHash: transactionHash,
         nullifier: nullifierEntry.nullifierHash

--- a/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
+import { Note, NOTE_LENGTH } from '../../../../primitives/note'
 import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
 
 export const NOTE_SIZE = 43 + 8 + 32 + 32
@@ -11,18 +12,20 @@ export type DecryptedNotesStore = IDatabaseStore<{
   value: DecryptedNoteValue
 }>
 
+
 export interface DecryptedNoteValue {
   accountId: string
-  index: number | null
-  nullifier: Buffer | null
-  serializedNote: Buffer
+  note: Note
   spent: boolean
   transactionHash: Buffer
+  // These fields are populated once the note's transaction is on the main chain
+  index: number | null
+  nullifier: Buffer | null
 }
 
 export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNoteValue> {
   serialize(value: DecryptedNoteValue): Buffer {
-    const { accountId, nullifier, index, serializedNote, spent, transactionHash } = value
+    const { accountId, nullifier, index, note, spent, transactionHash } = value
     const bw = bufio.write(this.getSize(value))
 
     let flags = 0
@@ -32,7 +35,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
     bw.writeU8(flags)
 
     bw.writeVarString(accountId)
-    bw.writeBytes(serializedNote)
+    bw.writeBytes(note.serialize())
     bw.writeHash(transactionHash)
 
     if (index) {
@@ -54,7 +57,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
     const spent = Boolean(flags & (1 << 2))
 
     const accountId = reader.readVarString()
-    const serializedNote = reader.readBytes(NOTE_SIZE)
+    const serializedNote = reader.readBytes(NOTE_LENGTH)
     const transactionHash = reader.readHash()
 
     let index = null
@@ -67,13 +70,15 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
       nullifier = reader.readHash()
     }
 
-    return { accountId, index, nullifier, serializedNote, spent, transactionHash }
+    const note = new Note(serializedNote)
+
+    return { accountId, index, nullifier, note, spent, transactionHash }
   }
 
   getSize(value: DecryptedNoteValue): number {
     let size = 1
     size += bufio.sizeVarString(value.accountId)
-    size += NOTE_SIZE
+    size += NOTE_LENGTH
 
     // transaction hash
     size += 32

--- a/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
@@ -10,7 +10,6 @@ export type DecryptedNotesStore = IDatabaseStore<{
   value: DecryptedNoteValue
 }>
 
-
 export interface DecryptedNoteValue {
   accountId: string
   note: Note

--- a/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
@@ -5,8 +5,6 @@ import bufio from 'bufio'
 import { Note, NOTE_LENGTH } from '../../../../primitives/note'
 import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
 
-export const NOTE_SIZE = 43 + 8 + 32 + 32
-
 export type DecryptedNotesStore = IDatabaseStore<{
   key: [Buffer, Buffer]
   value: DecryptedNoteValue

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -65,4 +65,8 @@ export class Note {
     this.returnReference()
     return buf
   }
+
+  equals(other: Note): boolean {
+    return this.noteSerialized.equals(other.noteSerialized)
+  }
 }

--- a/ironfish/src/rpc/routes/accounts/utils.ts
+++ b/ironfish/src/rpc/routes/accounts/utils.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { IronfishNode } from '../../../node'
-import { Note, Transaction } from '../../../primitives'
+import { Transaction } from '../../../primitives'
 import { Account } from '../../../wallet'
 import { ValidationError } from '../../adapters'
 

--- a/ironfish/src/rpc/routes/accounts/utils.ts
+++ b/ironfish/src/rpc/routes/accounts/utils.ts
@@ -70,7 +70,7 @@ export async function getTransactionNotes(
     const decryptedNoteValue = await account.getDecryptedNote(note.merkleHash())
 
     if (decryptedNoteValue) {
-      decryptedNote = new Note(decryptedNoteValue.serializedNote)
+      decryptedNote = decryptedNoteValue.note
       owner = true
     } else {
       // Try decrypting the note using the outgoingViewKey

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -112,7 +112,7 @@ export class Account {
       yield {
         hash,
         index: decryptedNote.index,
-        note: new Note(decryptedNote.serializedNote),
+        note: decryptedNote.note,
         transactionHash: decryptedNote.transactionHash,
         spent: decryptedNote.spent,
       }
@@ -145,7 +145,7 @@ export class Account {
       const existingNote = await this.getDecryptedNote(noteHash)
 
       if (!existingNote || existingNote.spent !== note.spent) {
-        const value = new Note(note.serializedNote).value()
+        const value = note.note.value()
         const currentUnconfirmedBalance = await this.accountsDb.getUnconfirmedBalance(this, tx)
 
         if (note.spent) {
@@ -239,7 +239,7 @@ export class Account {
             accountId: this.id,
             nullifier: decryptedNote.nullifier,
             index: decryptedNote.index,
-            serializedNote: decryptedNote.serializedNote,
+            note: new Note(decryptedNote.serializedNote),
             spent: false,
             transactionHash,
           },
@@ -284,7 +284,7 @@ export class Account {
     await this.accountsDb.database.withTransaction(tx, async (tx) => {
       const existingNote = await this.getDecryptedNote(noteHash)
       if (existingNote) {
-        const note = new Note(existingNote.serializedNote)
+        const note = existingNote.note
         const value = note.value()
         const currentUnconfirmedBalance = await this.accountsDb.getUnconfirmedBalance(this, tx)
 
@@ -394,7 +394,7 @@ export class Account {
           const note = await this.getDecryptedNote(hash)
           Assert.isNotUndefined(note)
           if (!note.spent) {
-            confirmed -= new Note(note.serializedNote).value()
+            confirmed -= note.note.value()
           }
         }
       }
@@ -404,7 +404,7 @@ export class Account {
       const note = await this.getDecryptedNote(noteHash)
       Assert.isNotUndefined(note)
       if (!note.spent) {
-        confirmed -= new Note(note.serializedNote).value()
+        confirmed -= note.note.value()
       }
     }
 

--- a/ironfish/src/wallet/database/__fixtures__/decryptedNoteValue.test.ts.fixture
+++ b/ironfish/src/wallet/database/__fixtures__/decryptedNoteValue.test.ts.fixture
@@ -1,0 +1,30 @@
+{
+  "DecryptedNoteValueEncoding with a null note index and nullifier hash serializes the object into a buffer and deserializes to the original object": [
+    {
+      "id": "664e5286-551c-4ac2-b92b-d1d32d0b6488",
+      "name": "test",
+      "spendingKey": "45b76e653891a87420d2cebbe13cb45b14721bcaee720e004f555f9ddda89c14",
+      "incomingViewKey": "010f8da4e22d741277478122cf97db19a7e2de09dd670646840c91d5b7806402",
+      "outgoingViewKey": "a68e34d4f5500198a7f1d645675e7d67f49f646856818a148cd121a1f3723e9f",
+      "publicAddress": "d5a6b59da59c37a69139f9b5b1975772c7b2b0a1d1d43163863e8a7b184af742944defea18e30a4043190b"
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIJTIQGXiVnL/n4BmlHHZ1B2jz9rQinb0znR37GvnHQSILu29pcICL/kRrGfn8U4I7VYb5q4C7kZMoBxVNZIHN27SmGVMUpAQJdkC+D+NN74BGDbUGPrkJ2LYmw6vEz+ORHAvLPIhxYah0gRMRO/bydhQAUUXmSAf3eRkTsvymJ0zNEjRUxGNwn9/uo8k4asHZGMNZ2dRwtZWpPoNmoJrbDo3Zu6P13zCQp9UCELej6xqFbEH9gtfg37qHVc1/y+i+NKrPL9/xMgLqHMn9GuubZSAyx9w5or43JtQXO+4p1gHlrqD5L19jAvvTYqvCAwfKyMLoxMVCq1Ph99XWx4f0uaYgxJBltyTF38gxJrQFjYu0oGxrAHAbPS1rTdJ6cMBtuJ8rblOjCitZio/wXsJjWoJkw3elnIERqxUL9tGkHdlGcK5auSFwZj75W7u5cjtCnNTaWHjebI5b5kfCkEH63Zuw8xyyzWeSVkBoGiZlDIxFjLYx1GDJZGFQZ2AdY7w+RrvUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+5NT1mEFDffbMKBJ6FwiHrxPs9qoAsDCBenF1Qshm7vFtRAixQehAGuMPJmRt3M6/YDWEIICKb7NjzYj4BhMBQ=="
+    }
+  ],
+  "DecryptedNoteValueEncoding with all fields defined serializes the object into a buffer and deserializes to the original object": [
+    {
+      "id": "86ce58e7-02db-48e1-99e8-7a7292b21805",
+      "name": "test",
+      "spendingKey": "cbbf50faacf805e9287e50de5b80c83838fc2d2fcc8837fe0bce862b4cb2ad44",
+      "incomingViewKey": "23219ef389b96382e7f05d313134068700081fd78337729491ae2972b3090b01",
+      "outgoingViewKey": "1d17a782093ee7c8bf369c1503b07fad6bd860436f721f9e86723ecb23eedd3c",
+      "publicAddress": "1072b981b5243b0c3c52d247ede341e26700a4cfb45c587918c0b89ab099314d23e5dd2dfc9fab30eb793d"
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKYHHM18XqoXLIL/ubgqK/bVFCKSHYJK6ZnBk9YcIfjWrvlu7cSVJjKC9OHCyTkVkoo/7etN0HJj3/TjzPuyRa5Mewh6I9Knx5NylctdugsEaGr8Kj+J86ZLEG+btB/GsQ6enhURAXukk+Y56esbot8WB/Lr4b+ZWVyEKWU/GV6hskWDFOsHa30zLpzcNF/I+4DTFwxQPxMIFgckpP3WW93mjXGrWVz8qAHAMipu1jOcC76lNpwJAinDO8ijxlNfQosJSBGLWtmwhJu50lneA/Lmwln1ys5kK0ay841aPw4Oytp+SDhoCx947jOCaWRCMk2uw0n2cKv9lczx6CguVUOzUAonGGSu0usxSx+QngBYRc0gSNGEOUV09KV1jEsDWLr7lxGAEpgCfOJEo/AaL20MWIuc6yGNd3jyZM2c/fjbq43PBQ30rvXYVDWPniLAE7+k999qtpVi5o/4rjDyii3CGh78SMgUKOPCUHTNfYYOLPke/hBzk9jzmf88GqiKVKubVkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbiBREeP549K1wj7WW0dI5zLIEZpLk1hRMM4FczdIi6wm1t/SeaHcjGBh6CDrTFoY5LKfHu1eS7AacjBilcIpAw=="
+    }
+  ]
+}

--- a/ironfish/src/wallet/database/decryptedNoteValue.test.ts
+++ b/ironfish/src/wallet/database/decryptedNoteValue.test.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../../assert'
-import { Note, NOTE_LENGTH } from '../../primitives/note'
 import { createNodeTest, useAccountFixture, useMinersTxFixture } from '../../testUtilities'
 import { DecryptedNoteValue, DecryptedNoteValueEncoding } from './decryptedNoteValue'
 


### PR DESCRIPTION
## Summary
We're just doing the same here that we did to TransactionValue already.

## Testing Plan
Run migration again

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
