### PR TITLE
Stop returning id and AccountValue

### DIFF
--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -178,11 +178,9 @@ export class AccountsDB {
     return meta
   }
 
-  async *loadAccounts(
-    tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{ id: string; serializedAccount: AccountValue }, void, unknown> {
-    for await (const [id, serializedAccount] of this.accounts.getAllIter(tx)) {
-      yield { id, serializedAccount }
+  async *loadAccounts(tx?: IDatabaseTransaction): AsyncGenerator<AccountValue, void, unknown> {
+    for await (const account of this.accounts.getAllValuesIter(tx)) {
+      yield account
     }
   }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -168,14 +168,13 @@ export class Accounts {
   }
 
   private async load(): Promise<void> {
-    for await (const { id, serializedAccount } of this.db.loadAccounts()) {
+    for await (const accountValue of this.db.loadAccounts()) {
       const account = new Account({
-        ...serializedAccount,
-        id,
+        ...accountValue,
         accountsDb: this.db,
       })
 
-      this.accounts.set(id, account)
+      this.accounts.set(account.id, account)
       await account.load()
     }
 


### PR DESCRIPTION
## Summary

`id` is already on AccountValue, we don't need to construct this object.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
