### PR TITLE
Include hash when iterating DecryptedNotes

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -81,10 +81,10 @@ export class Account {
   }
 
   async load(): Promise<void> {
-    for await (const { hash, decryptedNote } of this.accountsDb.loadDecryptedNotes(this)) {
+    for await (const decryptedNote of this.accountsDb.loadDecryptedNotes(this)) {
       const transaction = await this.getTransaction(decryptedNote.transactionHash)
 
-      this.saveDecryptedNoteSequence(hash, transaction?.sequence ?? null)
+      this.saveDecryptedNoteSequence(decryptedNote.hash, transaction?.sequence ?? null)
     }
   }
 
@@ -108,14 +108,8 @@ export class Account {
     transactionHash: Buffer
     spent: boolean
   }> {
-    for await (const { hash, decryptedNote } of this.accountsDb.loadDecryptedNotes(this)) {
-      yield {
-        hash,
-        index: decryptedNote.index,
-        note: decryptedNote.note,
-        transactionHash: decryptedNote.transactionHash,
-        spent: decryptedNote.spent,
-      }
+    for await (const decryptedNote of this.accountsDb.loadDecryptedNotes(this)) {
+      yield decryptedNote
     }
   }
 

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -101,13 +101,7 @@ export class Account {
     await this.saveUnconfirmedBalance(BigInt(0), tx)
   }
 
-  async *getNotes(): AsyncGenerator<{
-    hash: Buffer
-    index: number | null
-    note: Note
-    transactionHash: Buffer
-    spent: boolean
-  }> {
+  async *getNotes(): AsyncGenerator<DecryptedNoteValue & { hash: Buffer }> {
     for await (const decryptedNote of this.accountsDb.loadDecryptedNotes(this)) {
       yield decryptedNote
     }

--- a/ironfish/src/wallet/database/accountsdb.ts
+++ b/ironfish/src/wallet/database/accountsdb.ts
@@ -347,17 +347,14 @@ export class AccountsDB {
   async *loadDecryptedNotes(
     account: Account,
     tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{
-    hash: Buffer
-    decryptedNote: DecryptedNoteValue
-  }> {
+  ): AsyncGenerator<DecryptedNoteValue & { hash: Buffer }> {
     for await (const [[_, hash], decryptedNote] of this.decryptedNotes.getAllIter(
       tx,
       account.prefixRange,
     )) {
       yield {
+        ...decryptedNote,
         hash,
-        decryptedNote,
       }
     }
   }


### PR DESCRIPTION
## Summary

If we just include the hash at the AccountDB level, we don't need to construct these objects further up. We should probably move hash to DecryptedNoteValue later.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
