### PR TITLE
feat(rust): Add parameters and abstract minting assets to notes

### DIFF
--- a/ironfish-rust/src/proofs/mod.rs
+++ b/ironfish-rust/src/proofs/mod.rs
@@ -1,1 +1,2 @@
 pub mod circuit;
+pub mod notes;

--- a/ironfish-rust/src/proofs/notes/mint_asset_note.rs
+++ b/ironfish-rust/src/proofs/notes/mint_asset_note.rs
@@ -1,0 +1,56 @@
+use std::slice;
+
+use bls12_381::Scalar;
+use group::Curve;
+use rand::{thread_rng, Rng};
+use zcash_primitives::{
+    constants::{GH_FIRST_BLOCK, NOTE_COMMITMENT_RANDOMNESS_GENERATOR},
+    pedersen_hash,
+};
+
+use crate::primitives::asset_type::AssetInfo;
+
+/// A mint asset note represents an asset with newly added supply in an owner's
+/// account
+pub struct MintAssetNote {
+    pub(crate) asset_info: AssetInfo,
+    pub(crate) randomness: jubjub::Fr,
+    pub(crate) value: u64,
+}
+
+impl MintAssetNote {
+    // TODO: carry over all? fns from Note
+    pub fn new(asset_info: AssetInfo, value: u64) -> Self {
+        let mut buffer = [0u8; 64];
+        thread_rng().fill(&mut buffer[..]);
+
+        let randomness: jubjub::Fr = jubjub::Fr::from_bytes_wide(&buffer);
+
+        Self {
+            asset_info,
+            randomness,
+            value,
+        }
+    }
+
+    pub fn commitment(&self) -> Scalar {
+        let mut commitment_plaintext: Vec<u8> = vec![];
+        commitment_plaintext.extend(GH_FIRST_BLOCK);
+        commitment_plaintext.extend(self.asset_info.name());
+        commitment_plaintext.extend(self.asset_info.public_address_bytes());
+        commitment_plaintext.extend(slice::from_ref(self.asset_info.nonce()));
+
+        // TODO: Make a helper function
+        let commitment_hash = jubjub::ExtendedPoint::from(pedersen_hash::pedersen_hash(
+            pedersen_hash::Personalization::NoteCommitment,
+            commitment_plaintext
+                .into_iter()
+                .flat_map(|byte| (0..8).map(move |i| ((byte >> i) & 1) == 1)),
+        ));
+
+        let commitment_full_point =
+            commitment_hash + (NOTE_COMMITMENT_RANDOMNESS_GENERATOR * self.randomness);
+
+        commitment_full_point.to_affine().get_u()
+    }
+}

--- a/ironfish-rust/src/proofs/notes/minting_asset.rs
+++ b/ironfish-rust/src/proofs/notes/minting_asset.rs
@@ -1,0 +1,170 @@
+use bellman::{gadgets::multipack, groth16};
+use bls12_381::{Bls12, Scalar};
+use byteorder::{LittleEndian, WriteBytesExt};
+use group::{Curve, GroupEncoding};
+use jubjub::ExtendedPoint;
+use rand::{rngs::OsRng, thread_rng, Rng};
+use zcash_primitives::{constants::NOTE_COMMITMENT_RANDOMNESS_GENERATOR, pedersen_hash};
+
+use crate::{
+    errors,
+    merkle_note::sapling_auth_path,
+    proofs::circuit::mint_asset::MintAsset,
+    proofs::notes::mint_asset_note::MintAssetNote,
+    sapling_bls12::{self, SAPLING},
+    witness::WitnessTrait,
+    SaplingKey,
+};
+
+pub struct MintAssetParams {
+    /// Proof that the mint asset circuit was valid and successful
+    pub(crate) proof: groth16::Proof<Bls12>,
+
+    /// Randomness used to mint the identifier commitment
+    pub(crate) commitment_randomness: jubjub::Fr,
+
+    // Fields that would exist on "MerkleNote" if we were keeping that pattern:
+
+    // The hash of the note, committing to it's internal state
+    pub(crate) mint_commitment: bls12_381::Scalar,
+
+    // TODO: Size etc
+    pub(crate) encrypted_note: [u8; 12],
+
+    pub(crate) asset_generator: jubjub::ExtendedPoint,
+}
+
+impl MintAssetParams {
+    pub(crate) fn new(
+        minting_key: &SaplingKey,
+        mint_asset_note: &MintAssetNote,
+        witness: &dyn WitnessTrait,
+    ) -> Result<MintAssetParams, errors::SaplingProofError> {
+        let asset_info = mint_asset_note.asset_info;
+        let commitment_randomness = mint_asset_note.randomness;
+        let value = mint_asset_note.value;
+        let commitment = mint_asset_note.commitment();
+        let public_address = asset_info.public_address();
+
+        // Calculate the note contents, as bytes
+        let mut note_contents = vec![];
+
+        // Write the asset generator, cofactor not cleared
+        note_contents.extend(asset_info.asset_type().asset_generator().to_bytes());
+
+        // Writing the value in little endian
+        (&mut note_contents)
+            .write_u64::<LittleEndian>(value)
+            .unwrap();
+
+        // Write g_d
+        note_contents.extend_from_slice(&public_address.diversifier_point.to_bytes());
+
+        // Write pk_d
+        note_contents.extend_from_slice(&public_address.transmission_key.to_bytes());
+
+        assert_eq!(note_contents.len(), 32 + 32 + 32 + 8);
+
+        let note_hash = jubjub::ExtendedPoint::from(pedersen_hash::pedersen_hash(
+            pedersen_hash::Personalization::NoteCommitment,
+            note_contents
+                .into_iter()
+                .flat_map(|byte| (0..8).map(move |i| ((byte >> i) & 1) == 1)),
+        ));
+        let note_full_point =
+            note_hash + (NOTE_COMMITMENT_RANDOMNESS_GENERATOR * commitment_randomness);
+        let note_commitment = note_full_point.to_affine().get_u();
+
+        let identifier_bits = multipack::bytes_to_bits_le(asset_info.asset_type().get_identifier());
+        let identifier_inputs = multipack::compute_multipacking(&identifier_bits);
+
+        let mut buffer = [0u8; 64];
+        thread_rng().fill(&mut buffer[..]);
+        let randomness = jubjub::Fr::from_bytes_wide(&buffer);
+        let value_commitment = asset_info.asset_type().value_commitment(value, randomness);
+
+        let p = ExtendedPoint::from(value_commitment.commitment()).to_affine();
+        let mut inputs = vec![Scalar::zero(); 7];
+        inputs[0] = identifier_inputs[0];
+        inputs[1] = identifier_inputs[1];
+        inputs[2] = commitment;
+        inputs[3] = witness.root_hash();
+        inputs[4] = p.get_u();
+        inputs[5] = p.get_v();
+        inputs[6] = note_commitment;
+
+        let proof_generation_key = minting_key.sapling_proof_generation_key();
+        // Mint proof
+        let circuit = MintAsset {
+            asset_info: Some(asset_info),
+            proof_generation_key: Some(proof_generation_key),
+            commitment_randomness: Some(commitment_randomness),
+            auth_path: sapling_auth_path(witness),
+            anchor: Some(witness.root_hash()),
+            value_commitment: Some(value_commitment),
+        };
+        let proof = groth16::create_random_proof(
+            circuit,
+            &sapling_bls12::SAPLING.mint_asset_params,
+            &mut OsRng,
+        )
+        .expect("Create valid proof");
+
+        // Verify proof
+        groth16::verify_proof(
+            &sapling_bls12::SAPLING.mint_asset_verifying_key,
+            &proof,
+            &inputs[..],
+        )
+        .expect("Can verify proof");
+
+        let params = MintAssetParams {
+            proof,
+            commitment_randomness: mint_asset_note.randomness,
+            mint_commitment: commitment,
+            encrypted_note: [0u8; 12],
+            asset_generator: asset_info.asset_type().asset_generator(),
+        };
+
+        Ok(params)
+    }
+
+    pub fn post(&self) -> Result<MintAssetProof, errors::SaplingProofError> {
+        let mint_asset_proof = MintAssetProof {
+            proof: self.proof.clone(),
+            mint_commitment: self.mint_commitment,
+            encrypted_note: [0u8; 12],
+            asset_generator: self.asset_generator,
+        };
+
+        mint_asset_proof.verify_proof()?;
+
+        Ok(mint_asset_proof)
+    }
+}
+
+#[derive(Clone)]
+pub struct MintAssetProof {
+    pub(crate) proof: groth16::Proof<Bls12>,
+    pub(crate) mint_commitment: bls12_381::Scalar,
+    // TODO: Size made up, copy from MintAssetParams when changed
+    pub(crate) encrypted_note: [u8; 12],
+    pub(crate) asset_generator: jubjub::ExtendedPoint,
+}
+
+impl MintAssetProof {
+    pub fn verify_proof(&self) -> Result<(), errors::SaplingProofError> {
+        let generator_affine = self.asset_generator.to_affine();
+
+        let inputs = [
+            generator_affine.get_u(),
+            generator_affine.get_v(),
+            self.mint_commitment,
+        ];
+
+        // Verify proof
+        groth16::verify_proof(&SAPLING.mint_asset_verifying_key, &self.proof, &inputs)
+            .expect("Can verify proof");
+        Ok(())
+    }
+}

--- a/ironfish-rust/src/proofs/notes/mod.rs
+++ b/ironfish-rust/src/proofs/notes/mod.rs
@@ -1,0 +1,2 @@
+pub mod mint_asset_note;
+pub mod minting_asset;

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -5,8 +5,12 @@
 pub mod miners_fee;
 pub mod transfer;
 use crate::{
-    create_asset_note::CreateAssetNote, creating_asset::CreateAssetParams,
-    primitives::asset_type::AssetType, receiving::OutputSignature, spending::SpendSignature,
+    create_asset_note::CreateAssetNote,
+    creating_asset::CreateAssetParams,
+    primitives::asset_type::AssetType,
+    proofs::notes::{mint_asset_note::MintAssetNote, minting_asset::MintAssetParams},
+    receiving::OutputSignature,
+    spending::SpendSignature,
 };
 
 use super::{
@@ -73,7 +77,8 @@ pub struct ProposedTransaction {
     receipts: Vec<ReceiptParams>,
 
     // TODO: Look into actions like penumbra or some abstraction
-    create_assets: Vec<CreateAssetParams>,
+    create_asset_params: Vec<CreateAssetParams>,
+    mint_asset_params: Vec<MintAssetParams>,
 
     /// The balance of all the spends minus all the receipts. The difference
     /// is the fee paid to the miner for mining the transaction.
@@ -96,7 +101,8 @@ impl ProposedTransaction {
             binding_verification_key: ExtendedPoint::identity(),
             spends: vec![],
             receipts: vec![],
-            create_assets: vec![],
+            create_asset_params: vec![],
+            mint_asset_params: vec![],
             transaction_fee: 0,
             expiration_sequence: 0,
         }
@@ -156,8 +162,19 @@ impl ProposedTransaction {
 
         // TODO: bvk/bsk??
 
-        self.create_assets.push(params);
+        self.create_asset_params.push(params);
 
+        Ok(())
+    }
+
+    pub fn mint_asset(
+        &mut self,
+        spender_key: &SaplingKey,
+        mint_asset_note: &MintAssetNote,
+        witness: &dyn WitnessTrait,
+    ) -> Result<(), SaplingProofError> {
+        let params = MintAssetParams::new(spender_key, mint_asset_note, witness)?;
+        self.mint_asset_params.push(params);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Start migrating to the new pattern and move params / descriptions for minting assets into a struct

## Testing Plan

Added unit tests for mint asset proof

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
