### PR TITLE
Add cpu usage statistics to /status command

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -165,12 +165,20 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
     accountStatus = `SCANNING - ${content.accounts.scanning.sequence} / ${content.accounts.scanning.endSequence}`
   }
 
+  const cores = `Cores: ${content.cpu.cores}`
+  const current = `Current: ${content.cpu.percentCurrent.toFixed(1)}%`
+  const rollingAvg = `Rolling Avg: ${content.cpu.percentRollingAvg.toFixed(1)}%`
+  const cpuStatus = debugOutput
+    ? [cores, current, rollingAvg].join(', ')
+    : [cores, current].join(', ')
+
   return `\
 Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
 Node Name            ${nodeName}
 Block Graffiti       ${blockGraffiti}
 Memory               ${memoryStatus}
+CPU                  ${cpuStatus}
 P2P Network          ${peerNetworkStatus}
 Mining               ${miningDirectorStatus}
 Mem Pool             ${memPoolStatus}

--- a/ironfish/src/metrics/cpuMeter.ts
+++ b/ironfish/src/metrics/cpuMeter.ts
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import os from 'os'
+import { HRTime } from '../utils'
+import { RollingAverage } from './rollingAverage'
+
+/**
+ * Calculates an exponentially weighted moving average and rolling average
+ * for CPU usage percentage. This keeps track of the % of overall OS CPU the
+ * current process is using. Overall OS CPU is calculated with the sum of total CPU time
+ * across ALL cores of the machine
+ */
+export class CPUMeter {
+  private _average: RollingAverage
+  private _current = 0
+  private _intervalMs: number
+  private _started = false
+  private _interval: NodeJS.Timer | null = null
+  private _lastReading: {
+    time: HRTime
+    osCpu: os.CpuInfo[]
+    processCpu: NodeJS.CpuUsage
+  } | null = null
+
+  constructor(refreshInterval: number) {
+    this._intervalMs = refreshInterval
+    this._average = new RollingAverage(60)
+  }
+
+  get current(): number {
+    return this._current
+  }
+
+  get rollingAverage(): number {
+    return this._average.average
+  }
+
+  start(): void {
+    if (this._started) {
+      return
+    }
+    this._started = true
+    this._interval = setInterval(() => this.recordCPUDataPoint(), this._intervalMs)
+  }
+
+  stop(): void {
+    if (!this._started) {
+      return
+    }
+    this._started = false
+    this._lastReading = null
+
+    if (this._interval) {
+      clearInterval(this._interval)
+    }
+  }
+
+  reset(): void {
+    this._average.reset()
+    this._lastReading = null
+  }
+
+  private recordCPUDataPoint(): void {
+    const now = process.hrtime()
+    const osCpu = os.cpus()
+    const processCpu = process.cpuUsage()
+    const cpuCores = os.cpus().length
+
+    if (this._lastReading === null) {
+      this._lastReading = { time: now, osCpu, processCpu }
+      return
+    }
+
+    const elapsedCpuTime = this.totalCpuTime(osCpu) - this.totalCpuTime(this._lastReading.osCpu)
+    const elapsedProcessUserTime = processCpu.user - this._lastReading.processCpu.user
+    const elapsedProcessSysTime = processCpu.system - this._lastReading.processCpu.system
+
+    // process time is in nanoseconds, os time is in milliseconds
+    const percProcessCpu =
+      ((elapsedProcessUserTime + elapsedProcessSysTime) / 1000 / elapsedCpuTime) *
+      100 *
+      cpuCores
+
+    this._average.add(percProcessCpu)
+    this._current = percProcessCpu
+
+    this._lastReading = { time: now, osCpu, processCpu }
+  }
+
+  private totalCpuTime(measure: os.CpuInfo[]) {
+    let total = 0
+    for (const cpuInfo of measure) {
+      total +=
+        cpuInfo.times.idle +
+        cpuInfo.times.irq +
+        cpuInfo.times.nice +
+        cpuInfo.times.sys +
+        cpuInfo.times.user
+    }
+    return total
+  }
+}

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -8,6 +8,7 @@ import { createRootLogger, Logger } from '../logger'
 import { Identity } from '../network'
 import { NetworkMessageType } from '../network/types'
 import { NumberEnumUtils, SetIntervalToken } from '../utils'
+import { CPUMeter } from './cpuMeter'
 import { Gauge } from './gauge'
 import { Meter } from './meter'
 
@@ -47,6 +48,8 @@ export class MetricsMonitor {
 
   private memoryInterval: SetIntervalToken | null
   private readonly memoryRefreshPeriodMs = 1000
+
+  readonly cpuMeter = new CPUMeter(500)
 
   constructor({ logger }: { logger?: Logger }) {
     this.logger = logger ?? createRootLogger()
@@ -93,6 +96,7 @@ export class MetricsMonitor {
   start(): void {
     this._started = true
     this._meters.forEach((m) => m.start())
+    this.cpuMeter.start()
 
     this.memoryInterval = setInterval(() => this.refreshMemory(), this.memoryRefreshPeriodMs)
   }
@@ -100,6 +104,7 @@ export class MetricsMonitor {
   stop(): void {
     this._started = false
     this._meters.forEach((m) => m.stop())
+    this.cpuMeter.stop()
 
     if (this.memoryInterval) {
       clearTimeout(this.memoryInterval)

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -19,6 +19,11 @@ export type GetNodeStatusResponse = {
     git: string
     nodeName: string
   }
+  cpu: {
+    cores: number
+    percentRollingAvg: number
+    percentCurrent: number
+  }
   memory: {
     heapMax: number
     heapTotal: number
@@ -98,6 +103,13 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetNodeStatusResponse> = 
         version: yup.string().defined(),
         git: yup.string().defined(),
         nodeName: yup.string().defined(),
+      })
+      .defined(),
+    cpu: yup
+      .object({
+        cores: yup.number().defined(),
+        percentRollingAvg: yup.number().defined(),
+        percentCurrent: yup.number().defined(),
       })
       .defined(),
     memory: yup
@@ -244,6 +256,11 @@ function getStatus(node: IronfishNode): GetNodeStatusResponse {
       version: node.pkg.version,
       git: node.pkg.git,
       nodeName: node.config.get('nodeName'),
+    },
+    cpu: {
+      cores: node.metrics.cpuCores,
+      percentRollingAvg: node.metrics.cpuMeter.rollingAverage,
+      percentCurrent: node.metrics.cpuMeter.current,
     },
     memory: {
       heapMax: node.metrics.heapMax,


### PR DESCRIPTION
## Summary
Adds CPU usage to the status command. Calculates the % of CPU the process is using across all cores of the operating system

## Testing Plan
Tested locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
