### PR TITLE
clean up snapshot download after import

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -50,6 +50,7 @@ export default class Download extends IronfishCommand {
       default: true,
       description: 'Remove downloaded snapshot file after import',
       allowNo: true,
+      hidden: true,
     }),
   }
 

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -40,11 +40,16 @@ export default class Download extends IronfishCommand {
       char: 'p',
       parse: (input: string) => Promise.resolve(input.trim()),
       required: false,
-      description: 'Path to snapshot file',
+      description: 'Path to a downloaded snapshot file to import',
     }),
     confirm: Flags.boolean({
       default: false,
-      description: 'Confirm without asking',
+      description: 'Confirm download without asking',
+    }),
+    cleanup: Flags.boolean({
+      default: true,
+      description: 'Remove downloaded snapshot file after import',
+      allowNo: true,
     }),
   }
 
@@ -230,6 +235,12 @@ export default class Download extends IronfishCommand {
     CliUx.ux.action.start(`Unzipping ${snapshotPath} to ${chainDatabasePath}`)
     await this.unzip(snapshotPath, chainDatabasePath)
     CliUx.ux.action.stop('done')
+
+    if (flags.cleanup) {
+      CliUx.ux.action.start(`Cleaning up snapshot file at ${snapshotPath}`)
+      await fsAsync.rm(snapshotPath)
+      CliUx.ux.action.stop('done')
+    }
   }
 
   async unzip(source: string, dest: string): Promise<void> {


### PR DESCRIPTION
## Summary

the snapshot file downloaded from s3 is ~50GB in size. after unzipping the snapshot and moving the database into place the snapshot file remains.

changes `chain:download` to automatically remove the snapshot file after a successful import.

- adds 'cleanup' and 'no-cleanup' options to `chain:download`
- factors download logic into separate method for readability
- adds error message to failed imports with direction on how to retry importing a downloaded snapshot

## Testing Plan

tested importing a snapshot locally with and without cleanup

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
