### PR TITLE
Changed getBalance() to take confirmations

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -368,12 +368,14 @@ export class Account {
   }
 
   async getBalance(
-    unconfirmedSequenceStart: number,
     headSequence: number,
+    minimumBlockConfirmations: number,
     tx?: IDatabaseTransaction,
   ): Promise<{ unconfirmed: BigInt; confirmed: BigInt }> {
     const unconfirmed = await this.getUnconfirmedBalance(tx)
     let confirmed = unconfirmed
+
+    const unconfirmedSequenceStart = headSequence - minimumBlockConfirmations
 
     for (let i = unconfirmedSequenceStart; i < headSequence; i++) {
       const noteHashes = this.sequenceToNoteHashes.get(i)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -568,11 +568,11 @@ export class Accounts {
       const header = await this.chain.getHeader(headHash)
       Assert.isNotNull(header, `Missing block header for hash '${headHash.toString('hex')}'`)
 
-      const headSequence = header.sequence
-      const unconfirmedSequenceStart =
-        headSequence - this.config.get('minimumBlockConfirmations')
-
-      return account.getBalance(unconfirmedSequenceStart, headSequence, tx)
+      return account.getBalance(
+        header.sequence,
+        this.config.get('minimumBlockConfirmations'),
+        tx,
+      )
     })
   }
 


### PR DESCRIPTION
## Summary

It was too hard to figure out if these were exclusive or inclusive, so they don't need to be passed around anymore.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
