### PR TITLE
unzip snapshot directly to chainDatabasePath

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -215,21 +215,28 @@ export default class Download extends IronfishCommand {
       }
     }
 
-    const chainDatabasePath = this.sdk.fileSystem.resolve(this.sdk.config.chainDatabasePath)
+    try {
+      const chainDatabasePath = this.sdk.fileSystem.resolve(this.sdk.config.chainDatabasePath)
 
-    // chainDatabasePath must be empty before unzipping snapshot
-    CliUx.ux.action.start(
-      `Removing existing chain data at ${chainDatabasePath} before importing snapshot`,
-    )
-    await fsAsync.rm(chainDatabasePath, { recursive: true, force: true, maxRetries: 10 })
-    CliUx.ux.action.stop('done')
+      // chainDatabasePath must be empty before unzipping snapshot
+      CliUx.ux.action.start(
+        `Removing existing chain data at ${chainDatabasePath} before importing snapshot`,
+      )
+      await fsAsync.rm(chainDatabasePath, { recursive: true, force: true, maxRetries: 10 })
+      CliUx.ux.action.stop('done')
 
-    // ensure that chainDatabasePath exists
-    await fsAsync.mkdir(chainDatabasePath, { recursive: true })
+      // ensure that chainDatabasePath exists
+      await fsAsync.mkdir(chainDatabasePath, { recursive: true })
 
-    CliUx.ux.action.start(`Unzipping ${snapshotPath} to ${chainDatabasePath}`)
-    await this.unzip(snapshotPath, chainDatabasePath)
-    CliUx.ux.action.stop('done')
+      CliUx.ux.action.start(`Unzipping ${snapshotPath} to ${chainDatabasePath}`)
+      await this.unzip(snapshotPath, chainDatabasePath)
+      CliUx.ux.action.stop('done')
+    } catch (e) {
+      this.logger.error(
+        `Failed to import snapshot. Run \`ironfish chain:download --path ${snapshotPath}\` to retry import without download`,
+      )
+      throw e
+    }
   }
 
   async unzip(source: string, dest: string): Promise<void> {

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -215,22 +215,20 @@ export default class Download extends IronfishCommand {
       }
     }
 
-    // use a standard name, 'snapshot', for the unzipped database
-    const snapshotDatabasePath = this.sdk.fileSystem.join(this.sdk.config.tempDir, 'snapshot')
-    await this.sdk.fileSystem.mkdir(snapshotDatabasePath, { recursive: true })
-
-    CliUx.ux.action.start(`Unzipping ${snapshotPath}`)
-    await this.unzip(snapshotPath, snapshotDatabasePath)
-    CliUx.ux.action.stop('done')
-
     const chainDatabasePath = this.sdk.fileSystem.resolve(this.sdk.config.chainDatabasePath)
 
+    // chainDatabasePath must be empty before unzipping snapshot
     CliUx.ux.action.start(
-      `Moving snapshot from ${snapshotDatabasePath} to ${chainDatabasePath}`,
+      `Removing existing chain data at ${chainDatabasePath} before importing snapshot`,
     )
-    // chainDatabasePath must be empty before renaming snapshot
     await fsAsync.rm(chainDatabasePath, { recursive: true, force: true, maxRetries: 10 })
-    await fsAsync.rename(snapshotDatabasePath, chainDatabasePath)
+    CliUx.ux.action.stop('done')
+
+    // ensure that chainDatabasePath exists
+    await fsAsync.mkdir(chainDatabasePath, { recursive: true })
+
+    CliUx.ux.action.start(`Unzipping ${snapshotPath} to ${chainDatabasePath}`)
+    await this.unzip(snapshotPath, chainDatabasePath)
     CliUx.ux.action.stop('done')
   }
 

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -215,28 +215,21 @@ export default class Download extends IronfishCommand {
       }
     }
 
-    try {
-      const chainDatabasePath = this.sdk.fileSystem.resolve(this.sdk.config.chainDatabasePath)
+    const chainDatabasePath = this.sdk.fileSystem.resolve(this.sdk.config.chainDatabasePath)
 
-      // chainDatabasePath must be empty before unzipping snapshot
-      CliUx.ux.action.start(
-        `Removing existing chain data at ${chainDatabasePath} before importing snapshot`,
-      )
-      await fsAsync.rm(chainDatabasePath, { recursive: true, force: true, maxRetries: 10 })
-      CliUx.ux.action.stop('done')
+    // chainDatabasePath must be empty before unzipping snapshot
+    CliUx.ux.action.start(
+      `Removing existing chain data at ${chainDatabasePath} before importing snapshot`,
+    )
+    await fsAsync.rm(chainDatabasePath, { recursive: true, force: true, maxRetries: 10 })
+    CliUx.ux.action.stop('done')
 
-      // ensure that chainDatabasePath exists
-      await fsAsync.mkdir(chainDatabasePath, { recursive: true })
+    // ensure that chainDatabasePath exists
+    await fsAsync.mkdir(chainDatabasePath, { recursive: true })
 
-      CliUx.ux.action.start(`Unzipping ${snapshotPath} to ${chainDatabasePath}`)
-      await this.unzip(snapshotPath, chainDatabasePath)
-      CliUx.ux.action.stop('done')
-    } catch (e) {
-      this.logger.error(
-        `Failed to import snapshot. Run \`ironfish chain:download --path ${snapshotPath}\` to retry import without download`,
-      )
-      throw e
-    }
+    CliUx.ux.action.start(`Unzipping ${snapshotPath} to ${chainDatabasePath}`)
+    await this.unzip(snapshotPath, chainDatabasePath)
+    CliUx.ux.action.stop('done')
   }
 
   async unzip(source: string, dest: string): Promise<void> {


### PR DESCRIPTION
## Summary

we previously unzipped the snapshot to the 'temp' directory before moving files to the chain database. unzipping directly to the chain database directory will skip the move step and may circumvent errors users have run into while moving files

- remove contents of chainDatabasePath before unzipping
- ensure that chainDatabasePath exists
- unzip directly into chainDatabasePath

## Testing Plan

local chain:download

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
