### PR TITLE
Fix balance migration in 013

### DIFF
--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -220,6 +220,7 @@ export class Migration013 extends Migration {
       await accountsDb.withTransaction(tx, async (tx) => {
         await stores.new.accounts.put(migrated.id, migrated, tx)
         await stores.old.accounts.del(accountName, tx)
+        await stores.new.balances.put(migrated.id, BigInt(0), tx)
       })
 
       count++


### PR DESCRIPTION
## Summary

It was not filling out a balance for any accounts without notes which would cause crashes

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
