### PR TITLE
Rewrite balance command and add --explain

### DIFF
--- a/ironfish-cli/src/commands/accounts/balance.ts
+++ b/ironfish-cli/src/commands/accounts/balance.ts
@@ -1,7 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { displayIronAmountWithCurrency, oreToIron } from '@ironfish/sdk'
+import { CurrencyUtils, GetBalanceResponse } from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -14,6 +15,22 @@ export class BalanceCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    explain: Flags.boolean({
+      default: false,
+      description: 'Explain your balance',
+    }),
+    all: Flags.boolean({
+      default: false,
+      description: 'Also show pending and unconfirmed balance',
+    }),
+    confirmations: Flags.integer({
+      required: false,
+      description: 'Minimum number of blocks confirmations for a note',
+    }),
+    ore: Flags.boolean({
+      default: false,
+      description: 'Show amounts in ore',
+    }),
   }
 
   static args = [
@@ -26,26 +43,69 @@ export class BalanceCommand extends IronfishCommand {
   ]
 
   async start(): Promise<void> {
-    const { args } = await this.parse(BalanceCommand)
+    const { flags, args } = await this.parse(BalanceCommand)
     const account = args.account as string | undefined
 
     const client = await this.sdk.connectRpc()
 
     const response = await client.getAccountBalance({
-      account: account,
+      account,
+      minimumBlockConfirmations: flags.confirmations,
     })
 
-    const { account: accountResponse, confirmed, unconfirmed } = response.content
+    if (flags.explain) {
+      this.explainBalance(response.content, flags.ore)
+      return
+    }
 
-    this.log(`Account - ${String(accountResponse)}\n`)
+    if (flags.all) {
+      this.log(`Account: ${response.content.account}`)
+      this.log(
+        `Balance:     ${CurrencyUtils.render(response.content.confirmed, true, flags.ore)}`,
+      )
+      this.log(
+        `Unconfirmed: ${CurrencyUtils.render(response.content.unconfirmed, true, flags.ore)}`,
+      )
+      this.log(
+        `Pending:     ${CurrencyUtils.render(response.content.pending, true, flags.ore)}`,
+      )
+      return
+    }
+
+    this.log(`Account: ${response.content.account}`)
+    this.log(`Balance: ${CurrencyUtils.render(response.content.confirmed, true, flags.ore)}`)
+  }
+
+  explainBalance(response: GetBalanceResponse, ore: boolean): void {
+    const unconfirmed = CurrencyUtils.decode(response.unconfirmed)
+    const pending = CurrencyUtils.decode(response.pending)
+    const confirmed = CurrencyUtils.decode(response.confirmed)
+
+    const pendingDelta = pending - unconfirmed
+    const unconfirmedDelta = unconfirmed - confirmed
+
+    this.log(`Account: ${response.account}`)
+    this.log('')
+
+    this.log(`Your balance is made of notes on the chain that are safe to spend`)
+    this.log(`Balance: ${CurrencyUtils.render(confirmed, true, ore)}`)
+    this.log('')
+
     this.log(
-      `The balance is: ${displayIronAmountWithCurrency(oreToIron(Number(unconfirmed)), true)}`,
+      `${response.unconfirmedCount} notes worth ${CurrencyUtils.render(
+        unconfirmedDelta,
+        ore,
+      )} are on the chain within ${response.minimumBlockConfirmations.toString()} blocks of the head`,
     )
+    this.log(`Unconfirmed: ${CurrencyUtils.render(unconfirmed, ore)}`)
+    this.log('')
+
     this.log(
-      `Amount available to spend: ${displayIronAmountWithCurrency(
-        oreToIron(Number(confirmed)),
-        true,
-      )}`,
+      `${response.pendingCount} notes worth ${CurrencyUtils.render(
+        pendingDelta,
+        ore,
+      )} are waiting for miners to add them to the chain`,
     )
+    this.log(`Pending: ${CurrencyUtils.render(pending, ore)}`)
   }
 }

--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -139,7 +139,7 @@ export default class DepositAll extends IronfishCommand {
 
     let balanceResp = await this.client.getAccountBalance({ account: accountName })
     let confirmedBalance = Number(balanceResp.content.confirmed)
-    let unconfirmedBalance = Number(balanceResp.content.unconfirmed)
+    let pendingBalance = Number(balanceResp.content.pending)
 
     // Console log will create display issues with Blessed
     this.logger.pauseLogs()
@@ -186,7 +186,7 @@ export default class DepositAll extends IronfishCommand {
           oreToIron(Number(confirmedBalance)),
           false,
         )}, Unconfirmed - ${displayIronAmountWithCurrency(
-          oreToIron(Number(unconfirmedBalance)),
+          oreToIron(Number(pendingBalance)),
           false,
         )}`,
       )
@@ -199,10 +199,10 @@ export default class DepositAll extends IronfishCommand {
     while (true) {
       balanceResp = await this.client.getAccountBalance({ account: accountName })
       confirmedBalance = Number(balanceResp.content.confirmed)
-      unconfirmedBalance = Number(balanceResp.content.unconfirmed)
+      pendingBalance = Number(balanceResp.content.pending)
 
       // terminate condition
-      if (terminate && unconfirmedBalance < ironToOre(IRON_TO_SEND) + fee) {
+      if (terminate && pendingBalance < ironToOre(IRON_TO_SEND) + fee) {
         screen.destroy()
         process.exit(0)
       }

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -85,9 +85,9 @@ describe('Create genesis block', () => {
 
     // Balance should still be zero, since generating the block should clear out
     // any notes made in the process
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Add the block to the chain
@@ -97,9 +97,9 @@ describe('Create genesis block', () => {
     await node.accounts.updateHead()
 
     // Check that the balance is what's expected
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: amountBigint,
-      unconfirmed: amountBigint,
+      pending: amountBigint,
     })
 
     // Ensure we can construct blocks after that block
@@ -133,9 +133,9 @@ describe('Create genesis block', () => {
     await newNode.accounts.updateHead()
     await newNode.accounts.scanTransactions()
 
-    await expect(newNode.accounts.getBalance(accountNewNode)).resolves.toEqual({
+    await expect(newNode.accounts.getBalance(accountNewNode)).resolves.toMatchObject({
       confirmed: amountBigint,
-      unconfirmed: amountBigint,
+      pending: amountBigint,
     })
 
     // Ensure we can construct blocks after that block

--- a/ironfish/src/rpc/routes/accounts/getBalance.ts
+++ b/ironfish/src/rpc/routes/accounts/getBalance.ts
@@ -5,8 +5,17 @@ import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
-export type GetBalanceRequest = { account?: string }
-export type GetBalanceResponse = { account: string; confirmed: string; unconfirmed: string }
+export type GetBalanceRequest = { account?: string; minimumBlockConfirmations?: number }
+
+export type GetBalanceResponse = {
+  account: string
+  confirmed: string
+  pending: string
+  pendingCount: number
+  unconfirmed: string
+  unconfirmedCount: number
+  minimumBlockConfirmations: number
+}
 
 export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
   .object({
@@ -18,7 +27,11 @@ export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yu
   .object({
     account: yup.string().defined(),
     unconfirmed: yup.string().defined(),
+    unconfirmedCount: yup.number().defined(),
+    pending: yup.string().defined(),
+    pendingCount: yup.number().defined(),
     confirmed: yup.string().defined(),
+    minimumBlockConfirmations: yup.number().defined(),
   })
   .defined()
 
@@ -26,13 +39,22 @@ router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
   `${ApiNamespace.account}/getBalance`,
   GetBalanceRequestSchema,
   async (request, node): Promise<void> => {
+    const minimumBlockConfirmations = Math.max(
+      request.data.minimumBlockConfirmations ?? node.config.get('minimumBlockConfirmations'),
+      0,
+    )
+
     const account = getAccount(node, request.data.account)
-    const { confirmed, unconfirmed } = await node.accounts.getBalance(account)
+    const balance = await node.accounts.getBalance(account, { minimumBlockConfirmations })
 
     request.end({
       account: account.displayName,
-      confirmed: confirmed.toString(),
-      unconfirmed: unconfirmed.toString(),
+      confirmed: balance.confirmed.toString(),
+      pending: balance.pending.toString(),
+      pendingCount: balance.pendingCount,
+      unconfirmed: balance.unconfirmed.toString(),
+      unconfirmedCount: balance.unconfirmedCount,
+      minimumBlockConfirmations,
     })
   },
 )

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -101,6 +101,9 @@ describe('Transactions sendTransaction', () => {
     jest.spyOn(routeTest.node.accounts, 'getBalance').mockResolvedValueOnce({
       unconfirmed: BigInt(11),
       confirmed: BigInt(0),
+      pending: BigInt(0),
+      pendingCount: 0,
+      unconfirmedCount: 0,
     })
 
     await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
@@ -116,6 +119,9 @@ describe('Transactions sendTransaction', () => {
     jest.spyOn(routeTest.node.accounts, 'getBalance').mockResolvedValueOnce({
       unconfirmed: BigInt(21),
       confirmed: BigInt(0),
+      pending: BigInt(0),
+      pendingCount: 0,
+      unconfirmedCount: 0,
     })
 
     await expect(routeTest.client.sendTransaction(TEST_PARAMS_MULTI)).rejects.toThrowError(
@@ -139,6 +145,9 @@ describe('Transactions sendTransaction', () => {
     jest.spyOn(routeTest.node.accounts, 'getBalance').mockResolvedValueOnce({
       unconfirmed: BigInt(11),
       confirmed: BigInt(11),
+      pending: BigInt(0),
+      pendingCount: 0,
+      unconfirmedCount: 0,
     })
 
     await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
@@ -161,6 +170,9 @@ describe('Transactions sendTransaction', () => {
     jest.spyOn(routeTest.node.accounts, 'getBalance').mockResolvedValueOnce({
       unconfirmed: BigInt(11),
       confirmed: BigInt(11),
+      pending: BigInt(0),
+      pendingCount: 0,
+      unconfirmedCount: 0,
     })
 
     const result = await routeTest.client.sendTransaction(TEST_PARAMS)
@@ -178,6 +190,9 @@ describe('Transactions sendTransaction', () => {
     jest.spyOn(routeTest.node.accounts, 'getBalance').mockResolvedValueOnce({
       unconfirmed: BigInt(21),
       confirmed: BigInt(21),
+      pending: BigInt(0),
+      pendingCount: 0,
+      unconfirmedCount: 0,
     })
 
     const result = await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
@@ -194,6 +209,9 @@ describe('Transactions sendTransaction', () => {
     jest.spyOn(routeTest.node.accounts, 'getBalance').mockResolvedValue({
       unconfirmed: BigInt(100000),
       confirmed: BigInt(100000),
+      pending: BigInt(0),
+      pendingCount: 0,
+      unconfirmedCount: 0,
     })
 
     const paySpy = jest.spyOn(routeTest.node.accounts, 'pay').mockResolvedValue(tx)

--- a/ironfish/src/utils/currency.ts
+++ b/ironfish/src/utils/currency.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { BigIntUtils } from './bigint'
+
 const ORE_TICKER = '$ORE'
 const IRON_TICKER = '$IRON'
 const ORE_TO_IRON = 100000000
@@ -20,8 +22,12 @@ export const ironToOre = (amount: number): number => {
   return Math.round(iron * pow) / pow
 }
 
-export const oreToIron = (amount: number): number => {
-  return amount / ORE_TO_IRON
+export const oreToIron = (amount: number | bigint): number => {
+  if (typeof amount === 'number') {
+    return amount / ORE_TO_IRON
+  } else {
+    return BigIntUtils.divide(amount, BigInt(ORE_TO_IRON))
+  }
 }
 
 export const displayIronAmount = (amount: number): string => {
@@ -49,4 +55,68 @@ export const displayIronAmountWithCurrency = (amount: number, displayOre: boolea
   }
 
   return iron
+}
+
+function decode(amount: string): bigint {
+  return BigInt(amount)
+}
+
+function encode(amount: bigint): string {
+  return amount.toString()
+}
+
+function renderIron(amount: bigint | string, ticker = false): string {
+  if (typeof amount === 'string') {
+    amount = decode(amount)
+  }
+
+  const amountIron = oreToIron(amount)
+
+  const iron = amountIron.toLocaleString(undefined, {
+    minimumFractionDigits: 8,
+    maximumFractionDigits: 8,
+  })
+
+  if (ticker) {
+    return `$IRON ${iron}`
+  }
+
+  return iron
+}
+
+function renderOre(amount: bigint | string, ticker = false): string {
+  if (typeof amount === 'string') {
+    amount = decode(amount)
+  }
+
+  const ore = amount.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+
+  if (ticker) {
+    return `$ORE ${ore}`
+  }
+
+  return ore
+}
+
+function render(amount: bigint | string, ticker = false, ore = false): string {
+  if (typeof amount === 'string') {
+    amount = decode(amount)
+  }
+
+  if (ore) {
+    return renderOre(amount, ticker)
+  } else {
+    return renderIron(amount, ticker)
+  }
+}
+
+export const CurrencyUtils = {
+  encode,
+  decode,
+  renderIron,
+  renderOre,
+  render,
 }

--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -110,7 +110,7 @@ describe('Accounts', () => {
 
     await expect(account.getBalance(1, 1)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
 
     await account.deleteTransaction(tx)
@@ -123,7 +123,7 @@ describe('Accounts', () => {
 
     await expect(account.getBalance(1, 1)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
   })
 })

--- a/ironfish/src/wallet/accounts.test.slow.ts
+++ b/ironfish/src/wallet/accounts.test.slow.ts
@@ -43,17 +43,17 @@ describe('Accounts', () => {
     await node.accounts.updateHead()
 
     // Initial balance should be 0
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     await node.accounts.updateHead()
 
     // Balance after adding the genesis block should be 0
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Create a block with a miner's fee
@@ -65,9 +65,9 @@ describe('Accounts', () => {
     await node.accounts.updateHead()
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
   })
 
@@ -80,16 +80,16 @@ describe('Accounts', () => {
     const account = await node.accounts.createAccount('test', true)
 
     // Initial balance should be 0
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Create a block with a miner's fee
@@ -100,9 +100,9 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
 
     // Spend the balance
@@ -133,9 +133,9 @@ describe('Accounts', () => {
 
     // Balance after adding the transaction that spends 2 should be 1999999998
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(1999999998),
-      unconfirmed: BigInt(1999999998),
+      pending: BigInt(1999999998),
     })
   })
 
@@ -148,16 +148,16 @@ describe('Accounts', () => {
     const account = await node.accounts.createAccount('test', true)
 
     // Initial balance should be 0
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Create a block with a miner's fee
@@ -168,9 +168,9 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
 
     // Spend the balance
@@ -204,9 +204,9 @@ describe('Accounts', () => {
 
     // Balance after adding the transaction that spends 2 should be 1999999998
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(1999999998),
-      unconfirmed: BigInt(1999999998),
+      pending: BigInt(1999999998),
     })
   })
 
@@ -219,16 +219,16 @@ describe('Accounts', () => {
     const account = await node.accounts.createAccount('test', true)
 
     // Initial balance should be 0
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Create a block with a miner's fee
@@ -239,9 +239,9 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
 
     const transaction = await node.accounts.pay(
@@ -284,9 +284,9 @@ describe('Accounts', () => {
 
     // Balance after adding the transaction that spends 2 should be 1999999998
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(1999999994),
-      unconfirmed: BigInt(1999999994),
+      pending: BigInt(1999999994),
     })
   })
 
@@ -325,16 +325,16 @@ describe('Accounts', () => {
     node.accounts['isStarted'] = true
 
     // Initial balance should be 0
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Create a block with a miner's fee
@@ -345,9 +345,9 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
 
     // Spend the balance, setting expiry soon
@@ -365,17 +365,17 @@ describe('Accounts', () => {
       1,
     )
 
-    // Transaction should be unconfirmed
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    // Transaction should be pending
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(1999999998),
+      pending: BigInt(1999999998),
     })
 
     // Expiring transactions should not yet remove the transaction
     await node.accounts.expireTransactions()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(1999999998),
+      pending: BigInt(1999999998),
     })
 
     // Create a block with a miner's fee
@@ -391,9 +391,9 @@ describe('Accounts', () => {
     // Expiring transactions should now remove the transaction
     await node.accounts.updateHead()
     await node.accounts.expireTransactions()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
   })
 
@@ -412,16 +412,16 @@ describe('Accounts', () => {
     await node.accounts.createAccount('test2')
 
     // Initial balance should be 0
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Balance after adding the genesis block should be 0
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
 
     // Create a block with a miner's fee
@@ -431,9 +431,9 @@ describe('Accounts', () => {
 
     // Account should now have a balance of 2000000000 after adding the miner's fee
     await node.accounts.updateHead()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
 
     // Spend the balance, setting expiry soon
@@ -452,16 +452,16 @@ describe('Accounts', () => {
     )
 
     // Transaction should be unconfirmed
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(1999999998),
+      pending: BigInt(1999999998),
     })
 
     // Expiring transactions should not yet remove the transaction
     await node.accounts.expireTransactions()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(1999999998),
+      pending: BigInt(1999999998),
     })
 
     await node.accounts.close()
@@ -480,9 +480,9 @@ describe('Accounts', () => {
     // Expiring transactions should now remove the transaction
     await node.accounts.updateHead()
     await node.accounts.expireTransactions()
-    await expect(node.accounts.getBalance(account)).resolves.toEqual({
+    await expect(node.accounts.getBalance(account)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
   }, 600000)
 
@@ -501,9 +501,9 @@ describe('Accounts', () => {
 
     // Initial balance should be 2000000000
     await nodeA.accounts.updateHead()
-    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
 
     const block2 = await useBlockFixture(nodeA.chain, async () => {
@@ -581,17 +581,17 @@ describe('Accounts', () => {
     // Update account head and check all balances
     await nodeA.accounts.updateHead()
     await nodeB.accounts.updateHead()
-    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
-    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(0),
+      pending: BigInt(0),
     })
-    await expect(nodeB.accounts.getBalance(accountB)).resolves.toEqual({
+    await expect(nodeB.accounts.getBalance(accountB)).resolves.toMatchObject({
       confirmed: BigInt(4000000000),
-      unconfirmed: BigInt(4000000000),
+      pending: BigInt(4000000000),
     })
 
     // Copy block B1 to nodeA
@@ -601,13 +601,13 @@ describe('Accounts', () => {
     // Copy block B2 to nodeA
     await nodeA.chain.addBlock(blockB2)
     await nodeA.accounts.updateHead()
-    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
-    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toMatchObject({
       confirmed: BigInt(4000000000),
-      unconfirmed: BigInt(4000000000),
+      pending: BigInt(4000000000),
     })
   })
 
@@ -679,17 +679,17 @@ describe('Accounts', () => {
     await nodeA.accounts.updateHead()
     await nodeB.accounts.updateHead()
 
-    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(1999999998),
-      unconfirmed: BigInt(1999999998),
+      pending: BigInt(1999999998),
     })
-    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toMatchObject({
       confirmed: BigInt(2),
-      unconfirmed: BigInt(2),
+      pending: BigInt(2),
     })
-    await expect(nodeB.accounts.getBalance(accountANodeB)).resolves.toEqual({
+    await expect(nodeB.accounts.getBalance(accountANodeB)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
 
     // Copy block B2 and B3 to nodeA
@@ -699,13 +699,13 @@ describe('Accounts', () => {
 
     // B should not have confirmed coins yet because the transaction isn't on a block
     // A should not have confirmed coins any more because the transaction is pending
-    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(1999999998),
+      pending: BigInt(1999999998),
     })
-    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(2),
+      pending: BigInt(2),
     })
   })
 
@@ -790,17 +790,17 @@ describe('Accounts', () => {
     await nodeA.accounts.updateHead()
     await nodeB.accounts.updateHead()
 
-    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(1999999998),
-      unconfirmed: BigInt(1999999998),
+      pending: BigInt(1999999998),
     })
-    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toMatchObject({
       confirmed: BigInt(2),
-      unconfirmed: BigInt(2),
+      pending: BigInt(2),
     })
-    await expect(nodeB.accounts.getBalance(accountANodeB)).resolves.toEqual({
+    await expect(nodeB.accounts.getBalance(accountANodeB)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(1999999998),
+      pending: BigInt(1999999998),
     })
 
     // Copy block B2 and B3 to nodeA
@@ -810,13 +810,13 @@ describe('Accounts', () => {
 
     // A should have its original coins
     // B should not have the coins any more
-    await expect(nodeA.accounts.getBalance(accountA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(3999999998),
+      pending: BigInt(3999999998),
     })
-    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toEqual({
+    await expect(nodeA.accounts.getBalance(accountBNodeA)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(2),
+      pending: BigInt(2),
     })
   })
 })

--- a/ironfish/src/wallet/accounts.test.ts
+++ b/ironfish/src/wallet/accounts.test.ts
@@ -46,7 +46,7 @@ describe('Accounts', () => {
     await nodeA.accounts.updateHead()
     await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(2000000000),
-      unconfirmed: BigInt(2000000000),
+      pending: BigInt(2000000000),
     })
 
     // This transaction will be invalid after the reorg
@@ -56,7 +56,7 @@ describe('Accounts', () => {
     await nodeA.accounts.updateHead()
     await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(1999999999),
+      pending: BigInt(1999999999),
     })
 
     await expect(nodeA.chain).toAddBlock(blockB1)
@@ -79,7 +79,7 @@ describe('Accounts', () => {
     await nodeA.accounts.updateHead()
     await expect(nodeA.accounts.getBalance(accountA)).resolves.toMatchObject({
       confirmed: BigInt(0),
-      unconfirmed: BigInt(3999999999),
+      pending: BigInt(3999999999),
     })
 
     // Check that it was last broadcast at its added height
@@ -232,13 +232,13 @@ describe('Accounts', () => {
       expect(nodeA.chain.head.hash.equals(blockA5.header.hash)).toBe(true)
       expect(nodeB.chain.head.hash.equals(blockA5.header.hash)).toBe(true)
 
-      expect(await nodeA.accounts.getBalance(accountA)).toEqual({
+      expect(await nodeA.accounts.getBalance(accountA)).toMatchObject({
         confirmed: BigInt(6000000000),
-        unconfirmed: BigInt(10000000000),
+        pending: BigInt(10000000000),
       })
-      expect(await nodeB.accounts.getBalance(accountB)).toEqual({
+      expect(await nodeB.accounts.getBalance(accountB)).toMatchObject({
         confirmed: BigInt(0),
-        unconfirmed: BigInt(0),
+        pending: BigInt(0),
       })
     })
   })


### PR DESCRIPTION
## Summary
I started this PR by trying to add an explain flag to balance. I now pass through all the data used to calculate balance through the API so that it can be explained. I'm half considering that these should be a different RPC, but we can pass them through for now.

I started creating a new CurrencyUtils because the existing one is a mess. Things that take amounts are taking numbers, which should be an immediate sign that overflow errors are happening since amounts are bigint and numbers are capped at 54 bits in Javascript. I can't go in and fix all the old places so I figure we should just start creating a new one and delete the old ones in another PR.

This also changes balance to not show the unconfirmed balance by default and hides it behind the explain flag. Too many people were getting confused by unconfirmed, which btw wasn't even unconfirmed it was your pending balance.

This PR now has 3 distinct balance definitions which are more correct:
 - confirmed: All notes on the main chain NOT in the confirmation range
 - unconfirmed: All notes on the main chain even if they are in the confirmation range
 - pending: All notes on the main chain or in transactions not mined yet


```
> ironfish accounts:balance
Account: jason (b500383)
Balance: $IRON 393.18339367
```
```
> ironfish accounts:balance --explain
Account: json (b500383)

Your balance is made of mined notes that are safe to spend
Balance: $IRON 393.18339367

0 notes worth $IRON 0.00000000 are mined but are within 12 blocks of head of the chain
Unconfirmed: $IRON 393.18339367

0 notes worth $IRON 0.00000000 are waiting on miners to mine them
Pending: $IRON 393.18339367
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
