### PR TITLE
adds output path option for snapshot download

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -42,6 +42,12 @@ export default class Download extends IronfishCommand {
       required: false,
       description: 'Path to a downloaded snapshot file to import',
     }),
+    outputPath: Flags.string({
+      char: 'o',
+      parse: (input: string) => Promise.resolve(input.trim()),
+      required: false,
+      description: 'Output path to download the snapshot file to',
+    }),
     confirm: Flags.boolean({
       default: false,
       description: 'Confirm download without asking',
@@ -104,10 +110,10 @@ export default class Download extends IronfishCommand {
         snapshotUrl = url.toString()
       }
 
-      this.log(`Downloading snapshot from ${snapshotUrl}`)
-
       await fsAsync.mkdir(this.sdk.config.tempDir, { recursive: true })
-      snapshotPath = path.join(this.sdk.config.tempDir, manifest.file_name)
+      snapshotPath = flags.outputPath || path.join(this.sdk.config.tempDir, manifest.file_name)
+
+      this.log(`Downloading snapshot from ${snapshotUrl} to ${snapshotPath}`)
 
       const bar = CliUx.ux.progress({
         barCompleteChar: '\u2588',


### PR DESCRIPTION
## Summary

some users may want to download snapshots to a location other than datadir/temp. for instance, a user might want to download the snapshot file to a separate mounted disk.

- adds `-o` option for full download path

## Testing Plan

local testing with `chain:download -o`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
