### PR TITLE
Reduce synced time to 1hr (60 blocks)

### DIFF
--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -26,11 +26,6 @@ export const ALLOWED_BLOCK_FUTURE_SECONDS = 15
 export const GENESIS_SUPPLY_IN_IRON = 42000000
 
 /**
- * The oldest the tip should be before we consider the chain synced
- */
-export const MAX_SYNCED_AGE_MS = 5 * 60 * 60 * 1000
-
-/**
  * The maximum allowed requested blocks by the network
  */
 export const MAX_REQUESTED_BLOCKS = 50
@@ -47,6 +42,11 @@ export const MAX_MESSAGE_SIZE = 256 * 1024 * 1024
  * NOTE: This is not used in target calculation, or IRON_FISH_YEAR_IN_BLOCKS.
  */
 export const TARGET_BLOCK_TIME_IN_SECONDS = 60
+
+/**
+ * The oldest the tip should be before we consider the chain synced (60 blocks)
+ */
+export const MAX_SYNCED_AGE_MS = 60 * TARGET_BLOCK_TIME_IN_SECONDS * 1000
 
 /**
  * The time range when difficulty and target not change


### PR DESCRIPTION
## Summary
Reduce the time to consider the chain `SYNCED` from 5hrs to 1hr. This affects things like whether the node processes incoming transactions or not. We've been seeing that when nodes are not on the latest HEAD but are still considered `SYNCED`, the mempool starts to fill up. This is because there are potentially 5hrs worth of transactions that might be added to the mempool. If that number of transactions is too large it could cause a cycle where the node slows down and just becomes further and further behind leading to more transactions building up.

The long term solution to this would be to add an efficient limit on the size of the mempool so that when one transaction comes in, the lowest priority transaction will be evicted. Reducing the synced time however is a short term fix that will relieve some of the buildup of transactions

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
