### PR TITLE
Standardize account flag to match other commands

### DIFF
--- a/ironfish-cli/src/commands/accounts/remove.ts
+++ b/ironfish-cli/src/commands/accounts/remove.ts
@@ -11,7 +11,8 @@ export class RemoveCommand extends IronfishCommand {
 
   static args = [
     {
-      name: 'name',
+      name: 'account',
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the account',
     },


### PR DESCRIPTION
## Summary

This name was wrong, and it doesnt trim the account like the others. Should we pull out some of these so they are shared?

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
