### PR TITLE
Move account:transaction to its own command

### DIFF
--- a/ironfish-cli/src/commands/accounts/transaction.ts
+++ b/ironfish-cli/src/commands/accounts/transaction.ts
@@ -6,8 +6,8 @@ import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
-export class TransactionsCommand extends IronfishCommand {
-  static description = `Display the account transactions`
+export class TransactionCommand extends IronfishCommand {
+  static description = `Display an account transaction`
 
   static flags = {
     ...RemoteFlags,
@@ -29,7 +29,7 @@ export class TransactionsCommand extends IronfishCommand {
   ]
 
   async start(): Promise<void> {
-    const { args } = await this.parse(TransactionsCommand)
+    const { args } = await this.parse(TransactionCommand)
     const hash = args.hash as string
     const account = args.account as string | undefined
 

--- a/ironfish-cli/src/commands/accounts/transaction.ts
+++ b/ironfish-cli/src/commands/accounts/transaction.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { CurrencyUtils } from '@ironfish/sdk'
+import { CliUx } from '@oclif/core'
+import { IronfishCommand } from '../../command'
+import { RemoteFlags } from '../../flags'
+
+export class TransactionsCommand extends IronfishCommand {
+  static description = `Display the account transactions`
+
+  static flags = {
+    ...RemoteFlags,
+  }
+
+  static args = [
+    {
+      name: 'hash',
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
+      required: true,
+      description: 'Hash of the transaction',
+    },
+    {
+      name: 'account',
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
+      required: false,
+      description: 'Name of the account',
+    },
+  ]
+
+  async start(): Promise<void> {
+    const { args } = await this.parse(TransactionsCommand)
+    const hash = args.hash as string
+    const account = args.account as string | undefined
+
+    const client = await this.sdk.connectRpc()
+
+    const response = await client.getAccountTransaction({ account, hash })
+
+    if (!response.content.transaction) {
+      this.log(`No transaction found by hash ${hash}`)
+      return
+    }
+
+    this.log(`Transaction: ${hash}`)
+    this.log(`Account: ${response.content.account}`)
+    this.log(`Status: ${response.content.transaction.status}`)
+    this.log(`Miner Fee: ${response.content.transaction.isMinersFee ? `✔` : `x`}`)
+    this.log(`Fee: ${CurrencyUtils.renderIron(response.content.transaction.fee, true)}`)
+    this.log(`Spends Count: ${response.content.transaction.spendsCount}`)
+    this.log(`Notes Count: ${response.content.transaction.notesCount}`)
+
+    if (response.content.transaction.notes.length > 0) {
+      this.log(`---Notes---\n`)
+
+      CliUx.ux.table(response.content.transaction.notes, {
+        amount: {
+          header: 'Amount ($IRON)',
+          get: (note) => CurrencyUtils.renderIron(note.value),
+        },
+        isSpent: {
+          header: 'Spent',
+          get: (note) => (note.spent ? `✔` : `x`),
+        },
+        memo: {
+          header: 'Memo',
+        },
+      })
+    }
+  }
+}

--- a/ironfish-cli/src/commands/accounts/transactions.ts
+++ b/ironfish-cli/src/commands/accounts/transactions.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { oreToIron } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -30,66 +29,7 @@ export class TransactionsCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags, args } = await this.parse(TransactionsCommand)
     const account = args.account as string | undefined
-    const hash = flags.hash?.trim()
-
-    if (hash) {
-      await this.getTransaction(account, hash)
-    } else {
-      await this.getTransactions(account, flags)
-    }
-  }
-
-  async getTransaction(account: string | undefined, hash: string): Promise<void> {
-    const client = await this.sdk.connectRpc()
-
-    const response = await client.getAccountTransaction({ account, hash })
-
-    const {
-      account: accountResponse,
-      transactionHash,
-      transactionInfo,
-      transactionNotes,
-    } = response.content
-
-    this.log(`Account: ${accountResponse}`)
-
-    if (transactionInfo !== null) {
-      this.log(
-        `Transaction: ${transactionHash}\nStatus: ${transactionInfo.status}\nMiner Fee: ${
-          transactionInfo.isMinersFee ? `✔` : `x`
-        }\nFee ($ORE): ${transactionInfo.fee}\nSpends: ${transactionInfo.spends}\n`,
-      )
-    }
-
-    if (transactionNotes.length > 0) {
-      this.log(`---Notes---\n`)
-
-      CliUx.ux.table(transactionNotes, {
-        isOwner: {
-          header: 'Owner',
-          get: (row) => (row.owner ? `✔` : `x`),
-        },
-        amount: {
-          header: 'Amount ($IRON)',
-          get: (row) => oreToIron(row.amount),
-        },
-        memo: {
-          header: 'Memo',
-        },
-        isSpent: {
-          header: 'Spent',
-          get: (row) => {
-            if (row.spent === undefined) {
-              return '-'
-            } else {
-              return row.spent ? `✔` : `x`
-            }
-          },
-        },
-      })
-    }
-
-    this.log(`\n`)
+    await this.getTransactions(account, flags)
   }
 
   async getTransactions(

--- a/ironfish/src/rpc/routes/accounts/types.ts
+++ b/ironfish/src/rpc/routes/accounts/types.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DecryptedNoteValue } from '../../../wallet/database/decryptedNoteValue'
+import { TransactionValue } from '../../../wallet/database/transactionValue'
+
+export type RpcAccountTransaction = {
+  isMinersFee: boolean
+  fee: string
+  notesCount: number
+  spendsCount: number
+}
+
+export type RpcAccountDecryptedNote = {
+  value: string
+  memo: string
+  transactionHash: string
+  spent: boolean
+}
+
+export function serializeRpcAccountTransaction(
+  transaction: TransactionValue,
+): RpcAccountTransaction {
+  return {
+    isMinersFee: transaction.transaction.isMinersFee(),
+    fee: transaction.transaction.fee().toString(),
+    notesCount: transaction.transaction.notesLength(),
+    spendsCount: transaction.transaction.spendsLength(),
+  }
+}
+
+export function serializeRpcAccountDecryptedNote(
+  note: DecryptedNoteValue,
+): RpcAccountDecryptedNote {
+  return {
+    value: note.note.value().toString(),
+    memo: note.note.memo(),
+    transactionHash: note.transactionHash.toString('hex'),
+    spent: note.spent,
+  }
+}

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -415,6 +415,26 @@ export class Account {
   async getHeadHash(tx?: IDatabaseTransaction): Promise<Buffer | null> {
     return this.accountsDb.getHeadHash(this, tx)
   }
+
+  async getTransactionNotes(
+    transaction: Transaction,
+  ): Promise<Array<DecryptedNoteValue & { hash: Buffer }>> {
+    const notes = []
+
+    for (const note of transaction.notes()) {
+      const noteHash = note.merkleHash()
+      const decryptedNote = await this.getDecryptedNote(noteHash)
+
+      if (decryptedNote) {
+        notes.push({
+          ...decryptedNote,
+          hash: noteHash,
+        })
+      }
+    }
+
+    return notes
+  }
 }
 
 export function calculateAccountPrefix(id: string): Buffer {


### PR DESCRIPTION
## Summary

Moved most of the logic out of accounts:transactions into its own command. I feel like that command was overloaded and not doing what you expect anyway. I expect when I pass a TX hash for it to display the same output, but filtered on only that transaction. Instead it has a totally alternate flow.

## Testing Plan

Run `ironfish accounts:transaction`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
