### PR TITLE
Fix staging test failures

### DIFF
--- a/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
@@ -110,6 +110,7 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
       return
     }
 
+    this.started = false
     this.inboundTraffic.stop()
     this.outboundTraffic.stop()
 

--- a/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
@@ -120,14 +120,8 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
       client.messageBuffer.clear()
     })
 
-    await new Promise<void>((resolve, reject) => {
-      this.server?.close((error) => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve()
-        }
-      })
+    await new Promise<void>((resolve) => {
+      this.server?.close(() => resolve())
     })
 
     await this.waitForAllToDisconnect()

--- a/ironfish/src/rpc/adapters/tcpAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.test.ts
@@ -45,7 +45,7 @@ describe('TcpAdapter', () => {
     tcp = new RpcTcpAdapter('localhost', 0, undefined, ALL_API_NAMESPACES)
 
     await node.rpc.mount(tcp)
-  })
+  }, 20000)
 
   afterEach(() => {
     client?.close()
@@ -67,7 +67,7 @@ describe('TcpAdapter', () => {
 
     const response = await client.request('foo/bar', 'hello world').waitForEnd()
     expect(response.content).toBe('hello world')
-  })
+  }, 20000)
 
   it('should stream message', async () => {
     await tcp?.start()
@@ -90,7 +90,7 @@ describe('TcpAdapter', () => {
 
     await response.waitForEnd()
     expect(response.content).toBe(undefined)
-  })
+  }, 20000)
 
   it('should handle errors', async () => {
     await tcp?.start()
@@ -113,7 +113,7 @@ describe('TcpAdapter', () => {
       code: 'hello-error',
       codeMessage: 'hello error',
     })
-  })
+  }, 20000)
 
   it('should handle request errors', async () => {
     await tcp?.start()
@@ -139,7 +139,7 @@ describe('TcpAdapter', () => {
       code: ERROR_CODES.VALIDATION,
       codeMessage: expect.stringContaining('this must be defined'),
     })
-  })
+  }, 20000)
 
   it('should succeed when authentication pass', async () => {
     Assert.isNotUndefined(tcp)
@@ -158,5 +158,5 @@ describe('TcpAdapter', () => {
 
     const response = await client.request('foo/bar', 'hello world').waitForEnd()
     expect(response.content).toBe('hello world')
-  })
+  }, 20000)
 })

--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -68,9 +68,9 @@ export class RpcTcpClient extends RpcSocketClient {
   }
 
   close(): void {
-    this.client?.end()
-
+    this.client?.destroy()
     this.messageBuffer.clear()
+
     if (this.connectTimeout) {
       clearTimeout(this.connectTimeout)
     }

--- a/ironfish/src/rpc/clients/tcpClient.ts
+++ b/ironfish/src/rpc/clients/tcpClient.ts
@@ -133,8 +133,12 @@ export class RpcTcpClient extends RpcSocketClient {
   protected onClientClose = (): void => {
     this.isConnected = false
     this.messageBuffer.clear()
-    this.client?.off('data', this.onClientData)
-    this.client?.off('close', this.onClientClose)
+
+    if (this.client) {
+      this.client.off('data', this.onClientData)
+      this.client.off('close', this.onClientClose)
+      this.client = null
+    }
 
     this.handleClose()
   }


### PR DESCRIPTION
## Summary

Tracking down this https://github.com/iron-fish/ironfish/actions/runs/3140473380/jobs/5101893603
```
@ironfish/sdk: node:internal/errors:464
@ironfish/sdk:     ErrorCaptureStackTrace(err);
@ironfish/sdk:     ^
@ironfish/sdk: Error: Server is not running.
@ironfish/sdk:     at new NodeError (node:internal/errors:371:5)
@ironfish/sdk:     at Server.close (node:net:1628:12)
@ironfish/sdk:     at Object.onceWrapper (node:events:509:28)
@ironfish/sdk:     at Server.emit (node:events:390:28)
@ironfish/sdk:     at emitCloseNT (node:net:1681:8)
@ironfish/sdk:     at processTicksAndRejections (node:internal/process/task_queues:82:21) {
@ironfish/sdk:   code: 'ERR_SERVER_NOT_RUNNING'
@ironfish/sdk: }
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
