### PR TITLE
Fix improperly serialized disconnect message

### DIFF
--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -23,7 +23,7 @@ import {
 import { mockChain, mockNode, mockTelemetry } from '../testUtilities/mocks'
 import { createNodeTest } from '../testUtilities/nodeTest'
 import { CannotSatisfyRequest } from './messages/cannotSatisfyRequest'
-import { DisconnectingMessage } from './messages/disconnecting'
+import { DisconnectingMessage, DisconnectingReason } from './messages/disconnecting'
 import {
   GetBlockTransactionsRequest,
   GetBlockTransactionsResponse,
@@ -50,6 +50,7 @@ import {
 } from './testUtilities'
 import { NetworkMessageType } from './types'
 import { VERSION_PROTOCOL } from './version'
+import { parseNetworkMessage } from './messageRegistry'
 
 jest.useFakeTimers()
 
@@ -161,9 +162,11 @@ describe('PeerNetwork', () => {
 
       // Check that the disconnect message was serialized properly
       const args = sendSpy.mock.calls[0][0]
-      expect(typeof args).toEqual('string')
-      const message = JSON.parse(args) as DisconnectingMessage
+      expect(Buffer.isBuffer(args)).toBe(true)
+      const message = parseNetworkMessage(args)
       expect(message.type).toEqual(NetworkMessageType.Disconnecting)
+      Assert.isInstanceOf(message, DisconnectingMessage)
+      expect(message.reason).toEqual(DisconnectingReason.Congested)
     })
   })
 

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../testUtilities'
 import { mockChain, mockNode, mockTelemetry } from '../testUtilities/mocks'
 import { createNodeTest } from '../testUtilities/nodeTest'
+import { parseNetworkMessage } from './messageRegistry'
 import { CannotSatisfyRequest } from './messages/cannotSatisfyRequest'
 import { DisconnectingMessage, DisconnectingReason } from './messages/disconnecting'
 import {
@@ -50,7 +51,6 @@ import {
 } from './testUtilities'
 import { NetworkMessageType } from './types'
 import { VERSION_PROTOCOL } from './version'
-import { parseNetworkMessage } from './messageRegistry'
 
 jest.useFakeTimers()
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -299,7 +299,7 @@ export class PeerNetwork {
             reason: DisconnectingReason.Congested,
             sourceIdentity: this.localPeer.publicIdentity,
           })
-          connection.send(JSON.stringify(disconnect))
+          connection.send(disconnect.serializeWithMetadata())
           connection.close()
           return
         }


### PR DESCRIPTION
## Summary

This is causing a bunch of "Received non-buffer message" disconnects. It shouldn't have been impacting peer connectivity because the message was intended to gracefully disconnect from the peer anyway, but it at least reduces network/improves peer behavior.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
