### PR TITLE
keeps transactions in accountsdb on expiration

### DIFF
--- a/ironfish-cli/src/commands/accounts/transactions.ts
+++ b/ironfish-cli/src/commands/accounts/transactions.ts
@@ -42,6 +42,7 @@ export class TransactionsCommand extends IronfishCommand {
         {
           status: {
             header: 'Status',
+            minWidth: 11,
           },
           creator: {
             header: 'Creator',

--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -358,6 +358,11 @@ export class Migration013 extends Migration {
           )
         } else {
           await stores.new.nonChainNoteHashes.put([accountPrefix, noteHash], null, tx)
+          await stores.new.pendingTransactionHashes.put(
+            [accountPrefix, [transaction.transaction.expirationSequence(), transactionHash]],
+            null,
+            tx,
+          )
         }
       })
 

--- a/ironfish/src/migrations/data/013-wallet-2/new/pendingTransactionHashes.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/pendingTransactionHashes.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { IDatabaseStore } from '../../../../storage'
+
+export type PendingTransactionHashesStore = IDatabaseStore<{
+  key: [Buffer, [number, Buffer]]
+  value: null
+}>

--- a/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/stores.ts
@@ -19,6 +19,7 @@ import { HeadHashesStore } from './headHashes'
 import { AccountsDBMeta, MetaStore, MetaValueEncoding } from './meta'
 import { NonChainNoteHashesStore } from './nonChainNoteHashes'
 import { NullifierToNoteHashStore } from './nullifierToNoteHash'
+import { PendingTransactionHashesStore } from './pendingTransactionHashes'
 import { SequenceToNoteHashStore } from './sequenceToNoteHash'
 import { TransactionsStore, TransactionValueEncoding } from './transactions'
 
@@ -32,6 +33,7 @@ export type NewStores = {
   balances: BalancesStore
   nonChainNoteHashes: NonChainNoteHashesStore
   sequenceToNoteHash: SequenceToNoteHashStore
+  pendingTransactionHashes: PendingTransactionHashesStore
 }
 
 export function loadNewStores(db: IDatabase): NewStores {
@@ -93,6 +95,16 @@ export function loadNewStores(db: IDatabase): NewStores {
     valueEncoding: NULL_ENCODING,
   })
 
+  const pendingTransactionHashes: PendingTransactionHashesStore = db.addStore({
+    name: 'p',
+    keyEncoding: new PrefixEncoding(
+      new BufferEncoding(),
+      new PrefixEncoding(U32_ENCODING, new BufferEncoding(), 4),
+      4,
+    ),
+    valueEncoding: NULL_ENCODING,
+  })
+
   return {
     meta,
     decryptedNotes,
@@ -103,5 +115,6 @@ export function loadNewStores(db: IDatabase): NewStores {
     transactions,
     sequenceToNoteHash,
     nonChainNoteHashes,
+    pendingTransactionHashes,
   }
 }

--- a/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
@@ -69,7 +69,7 @@
       ]
     }
   ],
-  "Accounts should delete transaction": [
+  "Accounts should expire transactions": [
     {
       "id": "243c71f3-f436-4f63-be48-552d2ccb4db3",
       "name": "accountA",

--- a/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
@@ -108,5 +108,45 @@
         }
       ]
     }
+  ],
+  "Accounts should only expire transactions one time": [
+    {
+      "id": "e6f95ed1-1b8e-4407-9b0d-afecc416bb9a",
+      "name": "accountA",
+      "spendingKey": "05623a6b4c8d6dc18779ceba9a11e2d2767c23869737e6ab625ab8a76fd5a730",
+      "incomingViewKey": "3a529a1dfd6f41db3f9f62de029f2d79db76dd8b03fa7377ea3a210465b55307",
+      "outgoingViewKey": "fb199cc5c3d2f00b00956f9a4b649d4dac7e912132a82ea4892a37da244e17a1",
+      "publicAddress": "1abb1b6df4e701ca86f78ed0e86e7f5c33453422a3e19958b6c63f3f2648e4379efb18ac9306302e8caf16"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:EQf1sjEOpmrkD9N7A+vGscM6twv69pHdbTinZrcKNB8="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1664827535795,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "1466893F38F3A324E3D2C69640A1AC1A3326F57D5554BAE2581ECEEEB1C0559F",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKw3FEK5k+jfROpe3qaVYiqFu3c6J5GnWpfTJ0IgAoohR99+7auRKjJg0xqX+rGZYJJWdI2FceYrwI3WMwku0cucDm5LpuuTPhAPBZMvWeE4L6w+1ib2Gsr6Iy1VX43tNAQsfxLKIKAAyUmR0pBbEah/jHXkIWPeX02T9mmYL0MMxpJf9dip0TXxWX/UHpvT75H8DoEG71SE3VC+yfTIi6hIugYzKzIX2v2v2yEOuPZgst9M2YSkHUKGv2VhXMgZQ1vM5OuQPyS47YTdqIZ62503QTeIPnlvbBkLcjI/5DkM5RegibSq8rjuwoFb3jrG/ZWwt6aIEGE3eKk8vNbMLV8o2zweyLwhZCDEWN2SnOADE9xOPpm+GlrP/cJ/j+N4UCS/eqfz0MPwGohJVAGCS5KX36vAlVwIMCq9lfajOnn/93gJgFJFoebb70GiNIFnDZ2KzsFpM679CUf/a9imqOjbI7dqV612USqtmMacamHTD4oiwJqVA3uummpnG7E3FN72aEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOYw86js14x/UItvDiV3giq/5hFvVa3eRvgpOOUD/ONIQtBAEW9QuMUx34lsZvRFNjlhd3wj5qPWSOLclPUiAAg=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -1096,5 +1096,139 @@
         }
       ]
     }
+  ],
+  "Accounts expireTransactions should not expire transactions with expiration sequence ahead of the chain": [
+    {
+      "id": "bab86fd3-7cb4-4503-8455-0436153927aa",
+      "name": "accountA",
+      "spendingKey": "74e5af121224258d0724191d751c2b6512ef6a7167448b37492686ae647ca006",
+      "incomingViewKey": "082fffd7ead9a56c839f97fb8128e6a2e856dea3c73364c9cfdb259c26c3df06",
+      "outgoingViewKey": "a9807386a430f767ece8f59e784214df02e1ff724d6a8583483110b6c7e2eeab",
+      "publicAddress": "401af9e0f25434c95feb19074cc79ddcfa9aa289a18f6cf45f9f40507b45716b809931a4b2900964e76db2"
+    },
+    {
+      "id": "f61ed246-2e6b-4d35-ba14-125541162e9a",
+      "name": "accountB",
+      "spendingKey": "14c34292cbb363e7520ef45bb6822df10028411e83a0ddec38267baf428da7be",
+      "incomingViewKey": "16714562128ea58a319bc577b4eff0414c2f406a1c73cc7849be8365042eb506",
+      "outgoingViewKey": "f4b8f8f149944eec209750f8f7afdfe8cf23392e544ff0ecea46134a6c8f93ca",
+      "publicAddress": "8dad9ddb55506f70d9d61897af5d8fc34b80c07d0cddebaf0cea4177c6dd110a8b25d0e2227514cc939ec5"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:AgyPDpv1FeVzfhet9yWJfgwaPs2M/I6JqEYVllWn0CE="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1664845798140,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "68F75AD31CADC50368BB440E45D127E07FD1AF885589BB4F63D54121274EB86C",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALEBuuDmeJrX20quII6UmRz5Z+FYU798S0fTaqgd+YgAJAGgAUW/rZNMjFkXI1+/go26I6NE7oddwTD9trxfW0/01y3JbFAzlZc4QHe+vheDBi95daCuwS/WBdnbcUkiUAB/xoebcAIQgezKntQRTG1nts55dgNTSdOkUwCYALYpuSNYGI2bxhKfgaOZz1aIAbYVrUKGvm6CVYWmGa7Lbm9xs+StFE3kYsQOVpzu4LwiFwKGgm8oddMv9w0jIh2mlin4penPvrwaR1JrSU7vpzSTdx5tJsFaoQtEoeIwkiSEF9Y5qN16snxVm5GxMcfqGdaqqme1Vex5g7AaQwVtRQm7F/RxZaesDfBix2hTmGnzYzNIURNmZwC6TjXZV+DXqNgh7nSu0DgT+yFLZ8eLMT9jdSS+HqrdR5HUQn5Ur+XCTXbQVAH+Zc4knoxYEBSA2vxviGvi7ZqkMlDhgAEi3KSv7TzdvmK1784rRE6ht7ZMOe+dHiOb+N9vQtgtWf22m8OdUUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcD0qr6Mo0WgvgFustpCNxDA7AyQTfs7P8tjZ8p+fs+YMfnQq2C8TPFNOiICm4lbREourLXKKB1y5AxYUP9afCg=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAABAAAAKTE+XZ2xovC0RIazz4ClXp4QpiGP1N8SV9Z4/Y8xCdAl2A1SQoYbblimd1xWbvphpA+zk3eukoVl2nUXagzphxCyzF0xum+IwEGZyh05OvvaFq5I3BjkrTEaRFl9dqAnwc2HCTnOrdM/BrxGmU3cz7kRvkKPRH/bz2r9PRO3BP1Fx4oULgWSU4YdEFbewBVGqS/zrU86mrenCfxzLe1oZXGQO44zCVLt4SzlURrxRoSBoGdaWtoPh541WKsCbDVP0NyuYxJXbVIQG2MFh2JXCAPPbAM8rffn6iTMziMADgq0lNhSgArT+V+k7cY2CvQ6w7AVZ19voNjJKabNCMH7j8CDI8Om/UV5XN+F633JYl+DBo+zYz8jomoRhWWVafQIQQAAADvYQrjF3OPAwimKGqclviFMEUOH43oYkY4NiHUsJziYQhDahiR6eG1270zX2S2pgjk8+/oU2nQQAvHwg/yrBDkdok69vl5MYQttRHYnJFC3CnZk4uoPdfMBMJcozMSHQWo/yJknxkG+5UatSHs5N0XtuPg14ykGFIWC8nEpi4Aoo1xTqKJpCJrkPJJe+v3Y/CsiWvsG9bNgRmp7FA7JBqJz/npyJCBausZvnTibJKQUpmUNBxoWUmZf2VntYbDUnALJw1jxHjGqZTNhKkwrGJloifc8k978AsEhsiFif0QRLvmunj7ms1+EIevvDX+Pq2PNSjeZDXkKcPew/VAvaJs5tjQeb4STDF8bW4eOUUlRBDa9gXWSiqv9+t0QDRHaOwO+fYyhIWyJlAhS+XT0CooveMSMZ+QiH11xRNJS3AZCXnYt9kSw+OfmHf3GAe3LlD0hd6JfpFQAje88pcv3PMwk/QnZJqch3EDXNkGO4OhKL75QY6mncMazGK8xMC2brChpMhVB6nT4Us9jcrOI9b5eUagdgHatpdawGhQiQkoMOg4mEGkS4MLKmZQZ0l7XRWh5Ooy5wux56y9eFPaRRp3EuIdSn2aapAj/85dtSm5BFUy3z30PgJVEKmHWIxHr313ocUkf97Lbb32vPV0eQ9n5kp1d/4+gkSgIy6F9VxTrbdRlAznYub3ivG7JH/bxtCEx6yWZkaKPnJBkqtuD1VN6Sw6Pbz9KGKRrkdJ6J9f9lTcCZT//3iHRhxh7U5TIxpZWmsm6KUYps6wNm7nn1IJoy3xWAsHoNA8A02VoY8llX6gVoqAFoi1zixqZ5kOmA3U4O/1uC0fYdgSmpcZc/m93oRYn8zaTVHziWBDKBZQH3djCBK7YnXuFwyg/s5xr9FizXpnc+8lIi0+M7jQ16adD+UkKjFGo3KYEb+rFzih7H+9VbPytn/jD4A+mo0QN8vybpHpKYnKTOKfX5PmhOvxuYB/hYYJ7+1Myokgu8IUW2Rf0tf6xW5kVlKXf5sLiLQs52Ol+7GOLKuqC9xXPD1Ldx5gblF7TjDW8e+bZLN9f/KTe68EiMantKlXxEZp+dCHBho361nUL0uKKRcvaZoV/AU+5byg/KYw/vG++WZ7OOxS25Dov4yvx4cd0ic4to45ob9Rf+DTOEeVkB/PIlsbB80bdeyQPLG5CBTwXR/FSxIu4juqCct64RO1iHkDy1trKYX4++zCqVsY2QK/LUwmCsfqqbiYM9WIF2pqr5ABycggSbpxbaZ2SJRn7CnJzS/4s3xElA4stnlkYplVdMpEmqJiN4eGeafYStxpN5Jl+P9BYu/XK0Zny5ToMdZwe+dBUlQQ1XxABRbsMwL4ajN4wg12a5cGJuTQnkm2ydvFEz0KlDKNnwaagq9BqjUBdVQ8M7LGohlQMJR6QeHkCLGd9tFXcyMBO95Pb5w1OnvS+03n5R0yCA=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "68F75AD31CADC50368BB440E45D127E07FD1AF885589BB4F63D54121274EB86C",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:HL9M0Rjs3nqZ3ypuQ6fVs2BzniIwb4wUZNEWJqxgx1s="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1664845800024,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "6CE3F9807A93F175F772C905E18E8FB1135BB4D7E7F2FA44A2E9C590E7A4056D",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIEOB4RnVDJpmz1jibEs6XAfDSs8IBjEFJtNMBw9+3esDNS9ada1eloBReXL5O2u7JKoksZsnhQhf5H7LtvkSKbrBkJc5HLVZpPsWJeDO727nAtZ2l44+QmVV0ev6defwBkZnJNLVwNy0X2AZjRCssYQ9AVwLFW6qfiG6CV2hq0EMYCJolZarr+jqQYyjywAt5LbcjSxeKvce/y6xR5O2pdza835T+/uUXjUAfvq82XFFikTGlzOqsnVLtWboVpDBwTF10jmcvUO0R7Uf6GHIYOkpWQO17Q944MawOZgEnkyzT5RoG5u1HwC+hMb5WAjztEqmztujCo9b5rBr8TWe1VTsdwuL0wMno+FCH3KF1hxZiGxB2yusf9mne6kVscS7j5kv/sAYDzHjPiyoBsAfvDiMEc2jqcy6LomlLP8SNCBP7j4tyCtN3+R87pAwrq5NK2fGsB7ZvoOUtOcLuYGT666bv8V69fiHjOjU2wZVindVBA8mrjiEaPX1Ea+2zQWPftdT0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwlmgwwrDbG/JR3FGnfrqtJHNCV1eE804PUOTJn0LTlKSTdEMOX+jnA+7dEidbOhTxM2Xrj+7YI97Cj6AMHvjfAA=="
+        }
+      ]
+    }
+  ],
+  "Accounts expireTransactions should not expire transactions with expiration sequence of 0": [
+    {
+      "id": "8bbe9c4a-404b-4f1c-bc29-ab77b8e31367",
+      "name": "accountA",
+      "spendingKey": "157a6403be53c9549761f01b2c3012edcf5252a539ca348252e25c2df7c3ece0",
+      "incomingViewKey": "c763c70b43080ff6e0bc9d1e2e1670b46beda5226f941350fda78bfe4adbcd01",
+      "outgoingViewKey": "721bbb70feebfd7321ee0df6bb99db89b6d2df409b6bed8327758f4a31386539",
+      "publicAddress": "38617bd44dd7a8a64ada9adcc4b912cb7006766638c3757893ec606b60ef7ac484763881fe98c6a1d2cce9"
+    },
+    {
+      "id": "e0bef66f-9798-4c70-8ecb-2fa5a087ab26",
+      "name": "accountB",
+      "spendingKey": "530b60fe543c393bdd046bbef84a65c8b728855ebe21ee346012647763fd0b5b",
+      "incomingViewKey": "f87245b296cae727150325395efae8ae08bf067229c82361a50db7ea8d479f04",
+      "outgoingViewKey": "614cb46c02237873721ff56eb7c967e4e748c3feecc6350bd107e12744c09c7d",
+      "publicAddress": "62aa6ca10847b4edfe353af2e071f076bb243d9bd947104f38c1a8b1231c67d03a5e47fbe6b84126b74bc4"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:UjZYGYE+5BxdL3sirmasRZJchmanGqj/nwA1PW5tVnM="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1664846131649,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "AAEB026B1F733F2B7EFB72D1562582DFDFFC26067FE460EC67520AC0FE286C46",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKojLWr8H/WO7DS3OKeHYldG2xfMg1qE5GjzlKzL0p3r791LSSXYl5QHbmUX7KJigpiT9vBmhz7CtJ1VEHFWpFbOQQ5hZ9U+hPjWxPZygU5FW/72E4mtpI1RpI/cq16NHAEVYxtzmRNXrWaQ5qosdBXErGR530E9U35naaw6J76u0xrFMkyC6yY40i5a42YOWZn93pLXh/+e10m98htHZ9vRP5/AZI/u1ap+HndSnQDfwgqxKRjaxiiEdmEMUFZ9X+WH0kFm2ebzaCdHS4N/68X0mtWh/tjhcbvYULf+MT7XX6MerfdxHT3tZTXjE4RPGgtr7WLfcImWb7BZbTLOByDPTV/t77tDTjbpjlXZ6W22Ki2q8Ha9ZsRZ5Sle6DUUvb3wbj5P9X9sZK/o2ODHbT9Z97o4ZYBad0PNHwf9JOgIrmlu7P6kGbgUMsWLKSifsj381stPcvuzbUliUerv43mYKZHcjbBqLtPO68hMH4pqhxQSFgJQTnEso4w8lwsbsGOo+EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvaEgaYboVIMWT0UsBB2Deiqgu65wqJZnaw8sdEFfuLgw1Wq13JTk6j/lRKd84hmKzJCAyH0F9mia27uVJjctCQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAJPXZiIuP3J6zOauzYZEu8QzKykK+mxXLMmeH04ZJBY4MRgJu1ahGVmEPBOhmB28r6ndrt1iK92d91O2DsF7Ms6ezuoBMbGJ/U11X/9wdNktclzMeq3werAaGvy7yBT2gBHwomrGALA/y/IgDxkmh60RWHFMSjsIr69ncUSsyVy9/a8gQusGNNTweTYU06Oa97RJZoyyE4yOfV453duuA1hzlCkziFfjMvhIQIMRMSUsouQ5LugrZQXu7LTq4NkMB+MndUzZRfZymXhu5zcWycIhDLaHC+dx1GTHiH8kmvqbyUiGQfX137F7CfK63Lmx/eal6dOEabjmnlQt8fsB0GdSNlgZgT7kHF0veyKuZqxFklyGZqcaqP+fADU9bm1WcwQAAADt4bWly5lTFMfiZzMGrRjLedxI0VUafFeIkZcrVsIkRRclJ5Eb3L+N1YyrdmtafeyRRIv3a71k768nP8WZMUDRpBn1aPoD9+COOZFJHnvEegUfllvJH7W56DArj4ugYQ20kJDgZCbDQPaSVai68QZ4nFuvul5AiIU3XyHUfk3HiTrK4cixp2V5Ni3uukTUbwOvZFCh2CoVXNo87Od2SsYNyqD2bgMeyyeLK9ork3wE/QYe2BUUaDCrDWYmEdaI+Q4Sdda8NIxK8kRU2Yg1XxyVkmD92wOC+09+Eg4/glVZjXzkOWu6D9b/OJpOK6XCbBGjzIhghi2WNxZPutumzFPGzBh6Y4v07ipaJL7RLKdRHxgBNWmazyvwuffBkQQ0tgIRLyQXnzw2SmENgzpgJMtZVm/xwt16K3sUq0ZOuq7vEnI94KEH9/cc0bTODGs22GTkd/XnObj4M0Typ7bz7+ZyLgK9cKL1KTyucGhFfxQloTIsk7kv7HYXXvyTcQyLxgLg7w3HDnQ5dzOozlg6HJ5p0O7CKc6xteP89ThkumwkgG3Pdsn1pu8NwywtgT6Yh4/GSosVWgvDgNrf3UEVl8Os41vrJhYy0vjhTf9qqH72h20DM0pVETLVEeAdnllTxRKPam4hjHV7Gy/3iBCssQgFcIA2sQUYWQtelNeoIwpuD1nhc0VaE11rrry597fCUIDEccL23HeaqklxzTx2yq91pLGTHBI85KtW44R4/i63CKSxT6SCyka70yhemdv7oPYU3cueI1Eb7SfMWfymELBNlXg5GBlJmjpwG9OnqMBpOmx6/4wAm6YrjSECafFjVK/uZjhwXPnj4oO9IaQrPQ0nVauYRgWMsyjC10RviqftzymnCRJJRC3/bG1hnVLGFr9SDtRNsTYCYOEzAfSqMI2Ena2XybJjCzozVoF9h/FNuPWwS6+WJxMXYnsXPgbOznLThGsBOVV4IVtszxs7P4ObAhgnUE0KTsTfppuydis04pfb7Me6ESYEhObR1CLYIU+EvHqmhkJ2Od198LZWTyETZByr4OroLECsdIJgj9Qf3ckrTB6JfbPn1r6l97ya78bnCATQpTNQXgsFSS0XGLMIqEXlhOZOnzDvNzAYQjh5IZIPK2n6A2mVzK8paLlePIvDFatdDW4vbQGI4vT0wDt3j4buFboUhC280fm8ACKsZCMIWlbYfq7z7lNQbWm2TSIftqTdhrExpwwcL3Oscnr72r0ZhAvxxOsqA2rGrHdNexUuUcQxKn3rwxhggiiZCTzN8pvPp6v/Kk77t6W5io6ZfIPS+WHNYSUzuPv9MExy78qKrWEat328T4xJS+YNG6FTRKwNi8Z/50XowP4HnLPxzQfKx+UUf60Q87WBNJ+Ifyuuz5BG3dxCmrxUJOb35oBpIQfMEUAPkHRNkQoG1lKWqO6T67eeylWVBH64v6fCvGcn4Bl0CA=="
+    }
   ]
 }

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -850,5 +850,251 @@
       "outgoingViewKey": "d79ed126894405db0123141cd1b3e6078723afeb182b18c221d06b2a73fb843b",
       "publicAddress": "3470b9be503e7b7f7080b21040b59d72986017bf09b44e7cb7190b2099659bfae9bfb34465fa7f4e6a7dbe"
     }
+  ],
+  "Accounts expireTransactions should only expire transactions one time": [
+    {
+      "id": "e8dbd2c5-9371-4695-8885-f194b2361b61",
+      "name": "accountA",
+      "spendingKey": "0cf29cfa504257adcddd404dd22d3fcfb51937b4e580252744b35960d55977b6",
+      "incomingViewKey": "a45e2ac39d004fbc1501ac09389891ad61e52fbee23b091bbe7b870c7b788006",
+      "outgoingViewKey": "556656c4f1983f3e4ae4c4a463d4a4d281391bc324b089fc8a567a7e69013280",
+      "publicAddress": "3ccbc6d140c171b6e27353529b43f97e44160419e8c5606fba28151b2090352707a2c32665f8f7b83356d3"
+    },
+    {
+      "id": "c793c253-02b2-43ea-8886-b142471f0ee8",
+      "name": "accountB",
+      "spendingKey": "6060fa238761178ff399f4178706d4b57c4d6353118da76a0d066d1d205efba9",
+      "incomingViewKey": "5aebd2314a9e4937be14b4ed3258a2202ae4afaa58c0c972fad6315d27534007",
+      "outgoingViewKey": "f9b928af650b0d0a2611945c91654b2557965efe09f3c6e490460f151fa5fbd4",
+      "publicAddress": "913b502bf47d29d2562a26a0be1a641081b0faa781df7c27c14afa64e04dc459242e80b30e86dd9c261c2d"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:M5GDfNfdCKff7zMtyAksUxA6mM26SKFhI8fmLoARZ0w="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1664827928372,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "B02F130E6F6221414AA8448142CCB382DAD0D6D94F12ED3A99FBD2C323A58FAC",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIS+wRwM3SRexbzcry5YZtYRQ3Fu5VMU6RBrc/4yPpEibGFdw85JwHm2TeiS5NX786oM53dqK1C1CZgUXqvr7aUEP6wAe/6cnTXRICWPT5ua3TCC/o2qHSVhuPMZ9U1wNAN1/088NlhLUFpVmjkWQ93MhUDtjn2ntfVO7WD/Wxro1/fJjK+llGBnfN0yPqz7/Zgwsp+ugQgwzeK5XjMbx7SrGy8iYld6PHU2AFw3bT1KJOCor32JTJ4T7B300LZwdjDjgWFODYObTg6CuyyR04fdPO7rliQhbioBlwQhCYiWveMQHDmSjwB7HQwCocQxJY1FMeF8EXyZD3g8Q0eVbxkPdEbfLR8OgP9cHw6iT2DuqBgluu3OqiRUl2FR3pmlRxcq/+JySjBOuiUbv2TvgwoQyTg26mCv4mffmDosIBNcJ2LTYMYjf0n7kPTsirAnSVWTcecjCYJg37UsNLa+HPspEdNZIUpTZfYmnz3h29pObUXh8P0x4FYIcRR61uAeNAVaCEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsNNDS9LyrqP+ZwnQZ8uiwDvLU3d0nCE9htTSW0nMzyZvRhVoO48L3DdcpzWE/1I0rHdTdys7igfN3t9TeDu/AQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAQAAAIYGg024fjNbplU2eHr/jnSHnLs1rzFq4mS2OR/tIFuela81PkZ32hF6hbN5ED6+XLKJCRYGSJNzqqweRoaG2BWtQuJ9+TeDNvXAtwDyiCfWuNl53PAjAjIV8QT8nT5XGQ5Gk9inYWxs5o8+nDfZ5eLyYya9alzC0PxEL0SyI4fSTYSk1GNl/kO5SfSk8YHWUZhqJLQWsVK99704X/CtBXjTUFjxKmYWXdzmp5dw5sqwdi05Rn8jiN0IfzovosozYRV+P7m5oq/HtwpmsB63LSR5sMz8feoc82fORr8vQLGMWXOGlbNVS5kfRoYeUQB5lko+EHTGtoy5/MHT8HEdduYzkYN8190Ip9/vMy3ICSxTEDqYzbpIoWEjx+YugBFnTAQAAAABZhgg2Yu0q8hSjSwn7j/5yIxgQooOkp3hrTskgoN1WXnocuLTE6urAwu5b2lt4AXCwH9jG3zxniD4bv7yP7ngeFmIA0OuU9jmEKf6Jn86xLPr8mBmACTxNOjiYgLlwAKZiL62hNKwesO7zjPuhfBKVzT3WBy8k1HHxs8ATudDw77Xwk/9gFpRTOPawUhQI/GKLj6Ii5923TMukXGGvfPYKQF4oDge3Frpc4Zgal6YSbrSW6X/j/pFYosYvrOGdgQIsTk47Wb98ZuUhfIkmFTd6aArzkDdYqTK59tL06dlqyfTxv8xqOALC5QTNL58W6uh6unLayT+emSLIjRroPnzuZKJcl5ToGggVh1JiZJqMCqLKOgqSRbR6T9wziaUKE6XtTH8e6kXDGz2v7zHG3pst4vz5MK5oxvoT44GYcCHmfw9r1CCYPkxyEBAQxdN4LaRv0M5eQ/JSxgyiP1IfgwMzS4GIHFETnZggsXnuUy9kQVMV+0f9+q790k6ASOTDzdBMvpvvzJr5kuZywFsoOJc6AsXjp5s640Mn6mxTx5+ThHMXn0uHiL470lylifRl3c7ZAu0Cb/gqjNWJ8u9tdvTrSRQDG1OuiCnKOjava/08/fZ5X1J8qJA2zEFUqRwFNjlvriu0omI96TJ3k2KiMe0drW1t3r5QRiW/gF9UNmfiMMlb8h6/gM+I7tTwNTA3qaYofrgoZTqylJbLixF4d7mjT7ZcVusWkmHN83idxtxI4CL9bFOfQIZshgC8pbuS0lTNhMnzGuVJVaHwKdfPVcQDSBMbELJtVgCcLFYjM7SR0cu/ZTCNuYPjA74X6xMYtwfWPgXcnrazfhQA7Sj7iIXdM3da+LGnnyeAUeuNS4J017e/QAw55ZQlTg9ZitKZdH4K1XbOyiCmRZFVo8ZyfdFjyPunPANNAADkcM1I/MwtQWrJbl9Y7AfHRnPMciVFPn4MlwZ1pjCaerQriC9HFSo6C1P7vpNShFkR08nh03NnthFDrhuJGtjQxeY4nsu47EvaN14L69RDKnD7RTKN548YY/FYdzf63meyeqcuC5JpVB2+lYlII48MRsnr/MdfBzfKU3GVji7hM6o0j8SkvEJG7iY3ylxxXaAiZtBkW0wclgMieFPVW4af82rOUlvVBsNq+LtOvJBVfcU4RxF/4khm1hW09H5c8VZNh1HH9YzoOiQfyEraNHN5qT7Td/AVeTPOS2wa+erwUHseiIhjj43XVpSPCCpTQnZZylh3cTG1TIgG0BxsHhRE/3tPcAq84S0dFH7wJaHpyM9sMXrczPIOyyoBIAUYYECnNTYjrYmrjzoUqORUC0eAIwQ4TWAjVOkkwbhbrqiCIz7PPfOftPlHMkVjUsXl7GSsONIkEo26gB6kQkn4It/68XKIs7LViK0E2GIZsvg8cs/kJUJB7eEN0t0TbJZJvnm+DjmUsSiUrhNkujCCw=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "B02F130E6F6221414AA8448142CCB382DAD0D6D94F12ED3A99FBD2C323A58FAC",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:oX530X4WsL/vj1XceWX8TMauCYkCSap/JmhXrsssyyU="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1664827930325,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "2CC8D39890A3EE739D2BC322A612E64F4DF8D9981FC29A49BEEE813A4E6F33AE",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJcye6WWP/07v7UXOS1QA5HL2pqdD5imE+y8fibOooXUr6zsXavm3TZ4xkM48rQqL7AjVKMvIyHzOskpv8Vyi6iKsLwdwGAW/C5ZfNKc9hOc88duCWxo9IQIAqBbmCQ6cQxvtMCUCD7+PZFtXe4YCXS5GfzTWAFep3kNH2yOYtJ14Nlr+eOGZBo5nw1BzzN4pLInLdJrXAv6+2UYxYREfkpdsyKIydJ7fPifaw8n3DylWyEf5cij3Doyn9LXYA/i+CWWo1jopynkLjhYOGEe3G8KRS0v3n0K7t4XATOxxRAfcGAPbrekyztEJ5phXAIwEziLiNbIgIRWSE18/guZsl9lJ1XB8jvm+2YG1CV0e79NgU76z32+/1VXIUwdkhsyZ0r09QHLY/gFDxicDDyRlnbz+URTiHfx2TODH6HbheLMkP9UcczekS5Ro+rL3nNQHzUwZp9I6lzGhvRDfO/TAWPdNATcw4phltiEV18+xV5QsyOHsSQqHXnP2OVhLdR1RglmHEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmCrzs545oQJcIvOtkOeqpeakh6S9HWhQf4CE0MHFNxtxksZ5VQlD837RZe6WjANJkHop27oqQj+aNPmj5waFBg=="
+        }
+      ]
+    }
+  ],
+  "Accounts expireTransactions should expire transactions for all accounts": [
+    {
+      "id": "4135dff6-73f9-4cc4-9ca2-a5d3006cfc6a",
+      "name": "accountA",
+      "spendingKey": "ae31a33a9035a6df2fdfff9c454e918bd86f934e2dd318f82218aa1c80e00576",
+      "incomingViewKey": "1dfeb3fdf62ef7d2bc407ec53955a9f37a67165fecbf97a688d6433cdfbf1a06",
+      "outgoingViewKey": "862a076bdcd4cf3fd678789ab5792162d26b163a4090dfec6bee65872d2a73c8",
+      "publicAddress": "73c115b1803faa2e8e00dddfe364b8d8c3dbe466f2a2660079493017c6a060a79ecc59f1930985e6ae105c"
+    },
+    {
+      "id": "01b77181-3a4c-4a37-8c62-32d73b364f16",
+      "name": "accountB",
+      "spendingKey": "a0ca18b20e947dbf9e331da95c2cfc00bb54c253642de5a289178b4b23f0bd21",
+      "incomingViewKey": "cd63d38df092cbe842b095abdbd171bba26900f24ab97b076f7a34418210e406",
+      "outgoingViewKey": "1237ff82c60ecb88715c91ffcba25ffd1a62347611c6cdfd89fedc201de682b3",
+      "publicAddress": "f52be585551eb3384d807248f1725fcdeb8713ac57d9313c5e1a0b087cb6d4633cfce306d4365a53018087"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:cWo5wJ2mCHiCwOROgOR57TCrzQ/oH+WWwNiha6n9MCo="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1664830820476,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "6E236580879F420E7BB3421B008603DDC9B1D689DFB9DF9261AC85791C49F059",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALghZdHG4eFFyrIMcQiTWIfBireJHYmd/IhyTWE/l5brpZtQLV3E5R7vG6qF/UWvAYqA9kFe0qK+5JFfoX64LEV4TV9MRf29oFrlxXQaN9/C9/VSyuut4nX8JAHqn69TJwNI4yP9YWaqRAF1XfuI2VOMC55dPiqcEvH5636KygkAIb5wknyk5jqh6P4g+I2jxan07B8ObCMalEsobGFy0ET8bqoVucKPtRmTUGKn/tQeIyl07mzC3WVAPvG60oSwU9SRwYr+Ugsa975A+fwIFND4wMu0ctK/0DocDGj/kC1UJAZRygib71QWtHm/51B96ivgaRgs9rvJKDmGf8b5v2xn1tm3ojKgbPJsZ2cGNKX7Y4OQvBjDAol5VUbY1D7QDOZd6eCb7KDthPuSgMyWv3JW7jZQLaCKmNh6t2TIAFmqe3Bz2THqxWJHaw4eCTj+dzTJpR2t7YRKXWdEaPk5JEOVD6VxchcZana7tCLXf4Jkkw77P2mr+EeoXMFKgmSUALwSO0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMdZ/YjG9Uygx9zgugmCsAd4STQ3Q40QXn8i9XI5cetX7bMtOboDOodhAi6J+gd9bs18ONkfy7UN8ZcWezWk/AA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAQAAAKWE/SNkUJKekqRuLXqd46f2JblvqSAtz5onrQqJ6qJQ0djdRYrPwnceFX+xy6YsNoufa+qzdsaTlf5vs92INPA33vPBiD5i379es8np8Pe3M6TisykEB88D5MRj7C+s+BQIFFi7ioGok/ssf46Tp9/nWIvcbeHjutoL5ujE7jUEkokCuJR+BNpuEh0tMfChK4vfvubr0kvaAWC6jk2g2sOSrnlTGo6mmrr3xpvWqpEYZnt8JriVyu2j9+N87h7UFj0Ymbgzs81Sot/w0vxNlrvmNYVoBawJmVPXYJ955NwfA5UjzZZPTWTtEMJPRi1/ymqvWzOmIJM15TNsO97DxK1xajnAnaYIeILA5E6A5HntMKvND+gf5ZbA2KFrqf0wKgQAAAAf1gHfgomOWVlDReeIa0OSgAtRDGVUhkcTRTp0ONaY0uz2BYkouaB1vGBbDE0eDz98QGT5iOCAPXthY8uZaUKg7A4lP0QA0bFPZoZphLEBqS4/yrW8inyGyIbNnKMsuQCTcLYaBpa2mOGcnzPR61LR9VJ0X5BNFE4eciqYc8awQP+332XwW4NjkfFZtTpyMk2Mc8PmnkueotYd3vwmWqZYDengY4k+W8OeGMLgl2QMIrFu5K1U0XjcZjggDKQRB20THy06WkbAqu/vb/7ZIjbQPQa3UK8g/Lsq5kooPIE5KLJE3QbRY4zkTQl6Ew4sxKaPokEC0BT9Xfe2N+CZLOxFsiS07N7s0Q3ywvFLR77yczmJcU9hJxWA4zyto2RhPu6gPKOT77CClQxaboop31vs0Z2OrO8cs7DGYLBU9M7tv+mjCv8eIwDa4SxGjpzqCbtKIHXi47jhA3hMBQeQ0ps7LLx6c5a7sHCjoyYrrIZg3IgqveBYcsTo5YAHJMW7Dmbgiok6vV7LDTrUgTK74JdJ7ouQyOAWsEOMlAp/UWulTKna3/3JksuiomgPmpOPSS4xuYNz8WXjlSb7Q4it4QcxsRci1Z4HaZc6/DGYxGhTcSk5/mQV3SENn59C8Xb4WiopZi6VKAt1Ha8fvJyAjNH6e/lBlLefu0XMf2c8nGgbg0JaZwPjdv/AFd5Krhocfsk0hTcf2Z5zL+L51AcJq7dbK7FxbJyK4n3ZaXRsTGP1OVp+erC3z01R/ugzytARhzVGr/t8PumeVXcsVYmxfnUGCtLOp97vOXpDDNNEezAFDW9PVo9AT8Mf0D0PNOXNFEqf0nDg5g7a24LvDmh74jmdiqFhyn3V3CQO4ZTzLJhuQwS/tRZHjOxm0DIJWBrF09tUMZDX/iAUJ7hK5jCOfEAnWPFEJ0wGf3Q0S340yjKI6Qo6lpJocRGt3Eiol8fRMGhpWuoU5o9nEaE5oEL9BlUIdXuODtrV/JJZDkm4HozdLB2ttasD9+af9mKqwhdm9hjQEkGy9BYgOVjSr13fYG5RYIjZdYJfgYiJVCebKM3RgSV9D3Jxq6cqw69vFBzx9nHOZAHrAZGAH/r+UMxS6i+fCgaO+Dye8kLg5d5K1jo5kQgAAlQrgxcLJ0wBdeNn+bX6lE3xTwlNHnAdy1bYH6JQGOGP5CrPQtypn4jj8HSHkJi90C0o73GmETU3HEMn27mJEG7JPLNKKqdO2Vmdk2/QyLnWoq6V6MPJFIICsv+FMdjzxqj5VL5QPioKpExUXWfqa7Zqdj1Cj4LCHMkLNtkA1Zn1H9zuDd4kvGpe2vnH1axSa6XDK30MwDjEPVGNuvhj/ArpmgLZc9XbkN5kmfbQkozWTAjaDkfbCzDIB6ZfQNS9/at4jKf8ufoCaYExHHJlE6Co3qXTTT5lfVOP6/1xu+UgOxivSLBHOdeCvcSe/64Oqn6FDQ=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "6E236580879F420E7BB3421B008603DDC9B1D689DFB9DF9261AC85791C49F059",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:ynZGR8L4UOqqQ5PPLuEIBUzhz31Tpaj4w3RnszUMKTo="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1664830822447,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "76BEB40A58B43CF19140CD99A1B7708F6F44B643133D806241F5CFF3C1DC784A",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKaNZCu5r14VzynNTY97uQtjlq4gH2/3YyNyQMvgKfdmNVeg4vO7tgFyog/n2tWc4KpBotvWZJAWgAyAYvr97EFuUoyxsTY8lNiebl774QpyMbT9cD65C1FkY9ueGK48IA1Wc3HkcNtlnZIxADq29UX2Ptt4JtFSdFYkdJoa+Fpju1T+oakpzP7IlPJIe31S/6JYs+ju3W5lPU9n70j9Dk8ucSoJ+GjEpqHgOHDQftjo3DPJsyr9Y9e68uCKlDQV4scShPE4WdaeWU/EkIBg6Tiifu6DsWhXesGm/OQMffE3pXj7mHTQ+/jD9Hqz2Y8EgRAQuKJZaoRDObfkPV+67Boq6ojBvAlTN9/jsu2zpGp2fNBP9YEVArT9pdobBWkk7M/HU43JfYbJp0fnvaf3sVJNiCEv5l073n1e5OsghEmEmtR+V/6FbG+N5kG07Vl5K+jpcBtcupjOpOulPCPQN3ggtJcs/V9YJA79ClzAfrflvxXiMrpBIeT5xQbA0df61DG2iEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBeLRKOyhWj0RZ+0alZgSqB+IExlgM0oFavKsmyqk+mxSSIHYTkZZe/vxrBJz5JJwtM9yKPLI+JsipeOGeVkYBA=="
+        }
+      ]
+    }
+  ],
+  "Accounts expireTransactions should expire transactions for all affected accounts": [
+    {
+      "id": "b9199c8f-39b9-4e52-9f01-2991e6d76fc0",
+      "name": "accountA",
+      "spendingKey": "9dd1b22079d9edf4db50eb15ac6b163a78dabfefa169d0565348ac1b1eb72ef5",
+      "incomingViewKey": "0e8763e1225d88c0b74ebc3585ca1472e29dafcc3d3f6c88a20482c5808f5507",
+      "outgoingViewKey": "4a96e46145d89fb86aa1af888f8dbf49af8d033e43ef04f6f4f9ada7124423b4",
+      "publicAddress": "06954d625e7b65d3b8eb8cc19e69711f8c1fbfc46c2f61f70e867e96561f64663f4388ac69f2c7230ca5d9"
+    },
+    {
+      "id": "59b00331-8797-4af3-b6a1-baac176b269d",
+      "name": "accountB",
+      "spendingKey": "2f8d1a8a480e0682365fbcdbc2c5204ca4df32568eec6b6718af435c64082eaa",
+      "incomingViewKey": "65e99899814a9c228882032964e790e16229627e34eb3f4373f2443ef44f1604",
+      "outgoingViewKey": "d93e249b0304477c3384ad08a65ff6e5b8a45b0a431adef1e8a18813edc03920",
+      "publicAddress": "30eb2d62bfd7b645bccfef64961a0f43decde1360768cc977d8cae6dc951a4398144a426d9299d427b003e"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:jUGAFIImrwWyxdZ6rDuruUOK+tNIRTW8cg9rQZUjdVY="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1664841510553,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "EDAF32C56B3BE0BB63211F6707741F723A0E13969014EFBB7E2BC9E9EFBE658D",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK6xWRqp7/Znyr9/8xxWj7SSbM3DRqEgrTPxKQ6RdggoV6OEJmfojGQVkGntJPsyBqzEV2H2Qh3t74pgeewk0/uaV/8ARrLHr6OuXygZH2mmuKLAczf1LM4CYC6dZLXu/hViA8JK7pHWljEiT5IHWR5djglhM/49W1IVcViREm67Y7o0nQbEtPkpmuVA+hnt4IDqCFecuvyHzQQOBZ6A/1ERzmUhVPb7sR7mJsByfmepqD0Jk/bw21eeLYUbeExzcL6Sd2A8cVS0FZKi+hQr8qCqlEpdNmAO6l0whi4z6SSDCjpXRHjUXRUF3n3osr/lq0UIO0PzSvgpdsteUSFTCQ7kMXGvXrE3/ffXImCuy0mZ72JIeIJQWRM8m5XiW07z0U6MiD/hYHK199QeuSF/v5oQ16m/6wfjb7N4vGLmEoXu18s7YF0zQHeQlD2XdhGPSaKSQq3vZ03zFpGRWbGTXLUGXMlYvIWq5ntUz+q3P3aBR6sWBWIU/ZHqhg/BKodtK9snZkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/mp4juHC502XkTx+yT6qLC7M00RG9l4thmFrfljmhYVAsrpp5fxKuaUe/20a8lswNTYX75WkDwgXegIZ36fBBw=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAQAAAIAgon+51hLPTpREUU0lUb85rTyNpscbA+5kOe1fJlCQjoON9zlGO7pe2bBJ0q4K7I6V7JT4tqbMHNw+6h8kTxD0b6DLdjBOHMrVy2/5Yea6QX2zufwIMwzXtSIgjDXFeQYYDGsM+Oj/z2WEbGXfH6LpLUxlSMWCyikUDpkh5h1M23vd/ItEDKX7bzUtibw8YpSIGR8hhL0Fcst2D9+JbmY7ksKbqCGCyxDGWu/Sn9B+yIeeDNxh1lnFncgjB3ujvvHywtDnalHyQAzZ1/jX8gUTXEBT8yUmyoTBK1cAoVeNmJB/+4DZC98sxWycPd/4ZlafvTgDbmF9MDz/ZePdEiKNQYAUgiavBbLF1nqsO6u5Q4r600hFNbxyD2tBlSN1VgQAAAAI4d2OLy84gRDpCwFrdDfcIo5Udo7jHFok25HV2USJRfYQuVltHmOsBdlizlih106YiBmi8WJZekT+zXZQw7YQkb4MGCnOxCOLg1M4LivcpF1EwYj/2YU5ZK/CbhhLTA6iEFacXSZV0/HYGQtmZaJWoao486zRB689raJAf2ZA7hu8F93YuD+4wkaQwawLkqWvlHYPW/k4Z+Baz7X6a8pj1aakaI1+ic1ggPphbGyg9gK4Rpgy4nLSKIw+fgWoM3wMaUMOrW0tg6E9ni0ipJMFOvCI73lCUsk4RiJKBh3tpfum3Jp8+/B+FR49zhQO6QCtNvMv3jRc4cPPlemBj1r7wVIvfuqnqNSX9JRyM311eV1ZEofYCpXUtxwSSAiQiaAwZ/AKSA3Pk7m989R2NcGpofdW0Rh9o8FMaYYUD1puVZItaaViTADX5kwlHRqanCjnU8JsxxtJbsM7Osh3hcxAUiPPRJr+rpPZuEWwnBr/mfQc73Q1DY43GBhOL+dGR9cVPmpXZrfchlIeR8mKMKaccU2YieTD1+kysTpmSvitjHZyuE/+Iridu0hyYUPU2Y0+k1KbCi+f9W7SvdKcbrC6n/nb7pEpV4MSYOTpYl4gBiqiB2MO8pxDuMxm7kuUXQjBxKgLNgI19/g2EPMhkeDyG2fga/pvYZWEiBr4tv0bMNCTRjR/OmFNfYRhB+9su3hHqTnS9w45XoikxEx/KZmzjIutubokmwHJpHRIhK9r/NqXLId3kYoPp3cHgb9G2AXTYOnr3kZm0OwYUgi04jeRGmQ0nuYU9HMb3l+2lcKf+K7yAKU0wTtpDcDuhH6mHTeRd+3kc2BsvKKUmwfESXB1av4aFRPLRj3QXD8i2113aSXlDw2hoco62inD8odcJ7sk3+NKZAWJP48l5AJxmv9rUthFguDOCUYCKeeb4ZQD7R0YqKlA/ZOQhRXJcvJroSyIJ1PV1AR6rBFoEqoHWHKy3Z55R61o58R5gOHIsbpJicOyD7MJ/MT/3vo4+MojaLwaeGeJNjc88NnXbykIokwuB061csSKgUN1O9ZM8E7oOKCrJzkq2AZ+FjoGHk5kScweshg8ZVyF1JSGEFjMsaMhBMbCZsoHeTyPbeec7Uv5vbjxvbiUJLys4+C6dSHJNNi7TDYpUZ3+C/Dvrq9yIKAdRecD4C0o9zV9Ozloe6TqcT2w+Lv/PUGdIihfqVaDWasKz83orwvK+97NFqNGF00qzbSVrjAsEHg8N3IXxzzwuok2rl3RJBGrVFD/nqvdyvuzv350pS/2UdtMg98b08NImBNjDiqZOOxX+xwE1C0l3OdMrzyjNiNZUJ7J5cNuigV9VH96rfg8wTnX/lpmNnrrnRUonahRiXzaPL2waRVEpKg6TdFULhAEeaOFI5Tx8J8l44boARQK5ey/EVHHd6g4ANptKG4J7Duw31JXCY8wRdIkQSQPAw=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "EDAF32C56B3BE0BB63211F6707741F723A0E13969014EFBB7E2BC9E9EFBE658D",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:QMjhe4MKMrG+SJouG2trX4NQhow2nEm545gd3eloXyE="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1664841512478,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "C625B355109DB3D38FADE185E6C4ED646177E88B90ABE70A36E31D5776BFBE96",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKP8RK1T4ab9wvmdtVT9pXBUi/t7K1FjEEPXG1YSDS0oISjMAFayZi4yTJOSuCF9HKGC3IoBxhYyu2sEhGsPWqdWkM6xFjtywPTx+XtSKB7peClce1pQYZKJybW1O0k4EQgiIXeapGLuICg3ONe8iF5NUJt6UjVRgoNckdpWnige8R4IkOhKIYYj8D57KMAFuLIW6Mchg03zDKm4VWa+oyPVPkw/T+zVRSmjNkqkZQ2ZgA+am8mdBLQMcZUpNmCu9mnGxjM50qqfbr1o9qg6apo+7gKdKa38zNNTLi3TahU6ft+7OKuhLuQ099ilQwNjlCi9TW5p4pI1U+IyOeRyMi3nr7hNhP1eyozxNt3UUcC/hXvqY8FyXaAZUduouzBXFOSw8T/9WCR4cqgUPLmo1adD1Xv/IBWbORrbvvmHuHbQ1RtvN7+CQwQMh6endXqrXynAfBQtpctQKMGXqxC+xU561WKHUyzZEt+Qn+Doij1RrX/gzs/eTdavVoSb0TeW7aduNkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQu6wbwOSoMwsd4qpRNeKu/lYD8QpRScFmWpL05IaX5erkMr+9ivQ8w6Kez4zrbZ1HZmeTVu6KAbS9si8uccsCQ=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -91,7 +91,7 @@ describe('Accounts', () => {
     await expect(notesInSequenceAfter).resolves.toHaveLength(0)
   })
 
-  it('should delete transaction', async () => {
+  it('should expire transactions', async () => {
     const { node } = nodeTest
 
     const account = await useAccountFixture(node.wallet, 'accountA')
@@ -113,7 +113,7 @@ describe('Accounts', () => {
       pending: BigInt(2000000000),
     })
 
-    await account.deleteTransaction(tx)
+    await account.expireTransaction(tx)
 
     await expect(AsyncUtils.materialize(account.getNotes())).resolves.toHaveLength(0)
 
@@ -125,5 +125,8 @@ describe('Accounts', () => {
       confirmed: BigInt(0),
       pending: BigInt(0),
     })
+
+    // record of expired transaction is preserved
+    await expect(account.getTransaction(tx.hash())).resolves.toBeDefined()
   })
 })

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -304,7 +304,7 @@ export class Account {
     return this.walletDb.loadTransactions(this, tx)
   }
 
-  async deleteTransaction(transaction: Transaction, tx?: IDatabaseTransaction): Promise<void> {
+  async expireTransaction(transaction: Transaction, tx?: IDatabaseTransaction): Promise<void> {
     const transactionHash = transaction.hash()
 
     await this.walletDb.db.withTransaction(tx, async (tx) => {
@@ -341,8 +341,6 @@ export class Account {
           )
         }
       }
-
-      await this.walletDb.deleteTransaction(this, transactionHash, tx)
     })
   }
 

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -11,7 +11,6 @@ import {
   useMinerBlockFixture,
 } from '../testUtilities'
 import { acceptsAllTarget } from '../testUtilities/helpers/blockchain'
-import { AsyncUtils } from '../utils'
 
 describe('Accounts', () => {
   const nodeTest = createNodeTest()

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -11,6 +11,7 @@ import {
   useMinerBlockFixture,
 } from '../testUtilities'
 import { acceptsAllTarget } from '../testUtilities/helpers/blockchain'
+import { AsyncUtils } from '../utils'
 
 describe('Accounts', () => {
   const nodeTest = createNodeTest()
@@ -362,7 +363,7 @@ describe('Accounts', () => {
         },
       ],
       BigInt(0),
-      1,
+      newBlock.header.sequence,
     )
 
     // Transaction should be pending
@@ -448,7 +449,7 @@ describe('Accounts', () => {
         },
       ],
       BigInt(0),
-      1,
+      newBlock.header.sequence,
     )
 
     // Transaction should be unconfirmed

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -394,13 +394,9 @@ export class Wallet {
     })
   }
 
-  /**
-   * Deletes a transaction from the transaction map and updates
-   * the related maps.
-   */
-  async deleteTransaction(transaction: Transaction): Promise<void> {
+  async expireTransaction(transaction: Transaction): Promise<void> {
     for (const account of this.accounts.values()) {
-      await account.deleteTransaction(transaction)
+      await account.expireTransaction(transaction)
     }
   }
 
@@ -882,7 +878,7 @@ export class Wallet {
         )
 
         if (isExpired) {
-          await this.deleteTransaction(transaction)
+          await this.expireTransaction(transaction)
         }
       }
     }


### PR DESCRIPTION
## Summary

users sending transactions want to know the status of their transactions and to know if their transactions have expired without being processed. if expired transactions are deleted from the database then there is no record that they were attempted.

changes 'deleteTransaction' to 'expireTransaction' and does not delete expired transactions from the database. still deletes notes from expired transactions from the database since the account doesn't own these notes

wallet will lose any record of expired transactions on reset since there is no history of expired transactions on the chain

## Testing Plan

sent an expired transaction, saw its status in 'accounts:transactions'

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
