### PR TITLE
Use ResponseError and don't make manual responses

### DIFF
--- a/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
@@ -209,27 +209,23 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
       )
       client.requests.set(requestId, request)
 
-      if (this.router == null || this.router.server == null) {
-        this.emitResponse(client, this.constructUnmountedAdapter())
-        return
-      }
-
-      // Authentication
-      if (this.enableAuthentication) {
-        if (!message.auth) {
-          this.emitResponse(client, this.constructUnauthenticatedRequest(message))
-          return
-        }
-
-        const isAuthenticated = this.router.server.authenticate(message.auth)
-
-        if (!isAuthenticated) {
-          this.emitResponse(client, this.constructUnauthenticatedRequest(message))
-          return
-        }
-      }
-
       try {
+        if (this.router == null || this.router.server == null) {
+          throw new ResponseError('Tried to connect to unmounted adapter')
+        }
+
+        // Authentication
+        if (this.enableAuthentication) {
+          const isAuthenticated = this.router.server.authenticate(message.auth)
+
+          if (!isAuthenticated) {
+            const error = message.auth
+              ? 'Failed authentication'
+              : 'Missing authentication token'
+            throw new ResponseError(error, ERROR_CODES.UNAUTHENTICATED, 401)
+          }
+        }
+
         await this.router.route(message.type, request)
       } catch (error: unknown) {
         if (error instanceof ResponseError) {
@@ -318,37 +314,5 @@ export abstract class RpcSocketAdapter implements IRpcAdapter {
       type: 'malformedRequest',
       data: data,
     }
-  }
-
-  constructUnmountedAdapter(): ServerSocketRpc {
-    const error = new Error(`Tried to connect to unmounted adapter`)
-
-    const data: SocketRpcError = {
-      code: ERROR_CODES.ERROR,
-      message: error.message,
-      stack: error.stack,
-    }
-
-    return {
-      type: 'error',
-      data: data,
-    }
-  }
-
-  constructUnauthenticatedRequest(request: SocketRpcRequest): ServerSocketRpc {
-    let error: Error
-    if (!request.auth) {
-      error = new Error(`Missing authentication token`)
-    } else {
-      error = new Error(`Failed authentication`)
-    }
-
-    const data: SocketRpcError = {
-      code: ERROR_CODES.UNAUTHENTICATED,
-      message: error.message,
-      stack: error.stack,
-    }
-
-    return this.constructMessage(request.mid, 401, data)
   }
 }

--- a/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
+++ b/ironfish/src/rpc/adapters/socketAdapter/socketAdapter.ts
@@ -19,7 +19,6 @@ import {
   MESSAGE_DELIMITER,
   ServerSocketRpc,
   SocketRpcError,
-  SocketRpcRequest,
 } from './protocol'
 
 type SocketClient = {

--- a/ironfish/src/rpc/server.ts
+++ b/ironfish/src/rpc/server.ts
@@ -78,7 +78,7 @@ export class RpcServer {
   }
 
   /** Authenticate the RPC request */
-  authenticate(requestAuthToken: string | undefined): boolean {
+  authenticate(requestAuthToken: string | undefined | null): boolean {
     if (!requestAuthToken) {
       this.logger.debug(`Missing Auth token in RPC request.`)
       return false
@@ -86,7 +86,7 @@ export class RpcServer {
 
     const rpcAuthToken = this.node.internal.get('rpcAuthToken')
 
-    if (!rpcAuthToken || rpcAuthToken === '') {
+    if (!rpcAuthToken) {
       this.logger.debug(`Missing RPC Auth token in internal.json config.`)
       return false
     }


### PR DESCRIPTION
## Summary

Review with https://github.com/iron-fish/ironfish/pull/2269/files?diff=split&w=1

This code was constructing response manually, when we already support that through ResponseError handling in the adapter.

This is fixing this comment: https://github.com/iron-fish/ironfish/pull/2224/files#r979296411

## Testing Plan

Covered by existing tests. IT will be sending back the same thing to the client.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
