### PR TITLE
Update account deletion to clean up records in stores

### DIFF
--- a/ironfish/src/rpc/routes/accounts/removeAccount.ts
+++ b/ironfish/src/rpc/routes/accounts/removeAccount.ts
@@ -39,7 +39,7 @@ router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
     }
 
     if (!request.data.confirm) {
-      const balance = await node.wallet.getBalance(account)
+      const balance = await node.wallet.getBalance(account, { minimumBlockConfirmations: 0 })
 
       if (balance.unconfirmed !== BigInt(0)) {
         request.end({ needsConfirm: true })

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -1394,5 +1394,19 @@
         }
       ]
     }
+  ],
+  "Accounts removeAccount should delete account": [
+    {
+      "id": "b9653f65-e19e-4ac4-8764-aee26ef6433f",
+      "name": "test",
+      "spendingKey": "feca055a9c5a1a14fe61986067f7ce74191552b8843901c281710fef33dce66b",
+      "incomingViewKey": "14c92af74870c7f2b23cb52b5464c84654b77ba0533a4e11fd24270d8d390503",
+      "outgoingViewKey": "63a3c3b5713a6ef0eec57224388d2574fd9f506203351b8afa5b4745b3f5fc3f",
+      "publicAddress": "452bbca491048155d90344ce57902e3191ca78c00daa813f8d23a4773fdff5ba4e1ca52872124775456665"
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALdHTrKPg5oofcQv+XGZ/tAqXmm52O84Hn+MhoKc4BGSQR/6nRbK3Rs2l43so/j9JLhdgiXF+mSFGSVrhl9+/ZPag0yKOKB0wuxm6MIUNnKzwENW6xRYZfQwXcQtwWgYkAGhhIa5dzfekqftOTcTjfpDTC8jsN8mI5SwaFv/Umh9rCvQqTlVdOI6+S5/QKDo4bVvDIcQTOepbEj+ryCUe2WxEFRKGu2qwm+uLF+zca33EsF9Ch0rdRofiJCJG/9NwZLrD9/qjhlJL70rr4U80dO8dnHAgfO0TwJ1JZ/WcrW2S+mLUSTgWrcGGg0U/vx+YhlaB1p0HCRA8yKyDIy6yRidUmRdZOaab5eL06NOOiYIApBG59QtLOr4Y29HCCXoT+ScwqiQtEQzLYEb+S4SsxzJuPlGNxxhcZlD8hbYr3RpUBE2agtaXEGKwbA7ArLF8gg64lK5pmXdxxxRDiXnnzUeVp6sH4yto6UOyrRgx7V5iQnZZgR9F3m92wR6ZON1VtDrR0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8XSBvJ9GHps0LNjA6waWfqwfsB86lomjX1Ju8cuysAE0m97qIgQakJx1uVjuYeTQguhwst+4ix5W0vIhzW8rAg=="
+    }
   ]
 }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -198,17 +198,12 @@ export class Wallet {
       this.headHashes.set(accountId, headHash)
     }
 
-    for await (const { accountId } of this.walletDb.loadAccountIdsToCleanup()) {
-      this.accountIdsToCleanup.push(accountId)
-    }
-
     this.chainProcessor.hash = await this.getLatestHeadHash()
   }
 
   private unload(): void {
     this.accounts.clear()
     this.headHashes.clear()
-    this.accountIdsToCleanup.length = 0
 
     this.defaultAccount = null
     this.chainProcessor.hash = null
@@ -1033,10 +1028,8 @@ export class Wallet {
 
       await this.walletDb.removeAccount(account, tx)
       await this.walletDb.removeHeadHash(account, tx)
-      await this.walletDb.saveAccountIdToCleanup(account.id, tx)
     })
 
-    this.accountIdsToCleanup.push(account.id)
     this.accounts.delete(account.id)
     this.onAccountRemoved.emit(account)
   }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1034,6 +1034,10 @@ export class Wallet {
   }
 
   async cleanupDeletedAccounts(): Promise<void> {
+    if (!this.isStarted) {
+      return
+    }
+
     await this.walletDb.cleanupDeletedAccounts(this.eventLoopAbortController.signal)
   }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1038,6 +1038,10 @@ export class Wallet {
       return
     }
 
+    if (this.scan || this.updateHeadState) {
+      return
+    }
+
     await this.walletDb.cleanupDeletedAccounts(this.eventLoopAbortController.signal)
   }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -15,6 +15,7 @@ import { Mutex } from '../mutex'
 import { Note } from '../primitives/note'
 import { Transaction } from '../primitives/transaction'
 import { IDatabaseTransaction } from '../storage/database/transaction'
+import { StorageUtils } from '../storage/database/utils'
 import { BufferUtils, PromiseResolve, PromiseUtils, SetTimeoutToken } from '../utils'
 import { WorkerPool } from '../workerPool'
 import { DecryptedNote, DecryptNoteOptions } from '../workerPool/tasks/decryptNotes'
@@ -65,6 +66,7 @@ export class Wallet {
   protected isStarted = false
   protected isOpen = false
   protected eventLoopTimeout: SetTimeoutToken | null = null
+  protected readonly accountIdsToCleanup: string[] = []
   private readonly createTransactionMutex: Mutex
   private readonly eventLoopAbortController: AbortController
   private eventLoopPromise: Promise<void> | null = null
@@ -197,12 +199,17 @@ export class Wallet {
       this.headHashes.set(accountId, headHash)
     }
 
+    for await (const { accountId } of this.db.loadAccountIdsToCleanup()) {
+      this.accountIdsToCleanup.push(accountId)
+    }
+
     this.chainProcessor.hash = await this.getLatestHeadHash()
   }
 
   private unload(): void {
     this.accounts.clear()
     this.headHashes.clear()
+    this.accountIdsToCleanup.length = 0
 
     this.defaultAccount = null
     this.chainProcessor.hash = null
@@ -276,6 +283,7 @@ export class Wallet {
     await this.updateHead()
     await this.expireTransactions()
     await this.rebroadcastTransactions()
+    await this.cleanupDeletedAccounts()
 
     if (this.isStarted) {
       this.eventLoopTimeout = setTimeout(() => void this.eventLoop(), 1000)
@@ -1026,10 +1034,29 @@ export class Wallet {
 
       await this.walletDb.removeAccount(account, tx)
       await this.walletDb.removeHeadHash(account, tx)
+      await this.walletDb.saveAccountIdToCleanup(account.id, tx)
     })
 
+    this.accountIdsToCleanup.push(account.id)
     this.accounts.delete(account.id)
     this.onAccountRemoved.emit(account)
+  }
+
+  async cleanupDeletedAccounts(): Promise<void> {
+    setTimeout(() => void this.cleanupDeletedAccounts(), 100000)
+    while (this.accountIdsToCleanup.length !== 0) {
+      const accountId = this.accountIdsToCleanup[0]
+      const prefixRange = StorageUtils.getPrefixKeyRange(calculateAccountPrefix(accountId))
+      await this.db.database.transaction(async (tx) => {
+        await this.db.clearDecryptedNotesForPrefixRange(prefixRange, tx)
+        await this.db.clearNullifierToNoteHashForPrefixRange(prefixRange, tx)
+        await this.db.clearTransactionsForPrefixRange(prefixRange, tx)
+        await this.db.clearSequenceToNoteHashForPrefixRange(prefixRange, tx)
+        await this.db.clearNonChainNoteHashesForPrefixRange(prefixRange, tx)
+        await this.db.removeAccountIdToCleanup(accountId, tx)
+      })
+      this.accountIdsToCleanup.pop()
+    }
   }
 
   get hasDefaultAccount(): boolean {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -15,7 +15,6 @@ import { Mutex } from '../mutex'
 import { Note } from '../primitives/note'
 import { Transaction } from '../primitives/transaction'
 import { IDatabaseTransaction } from '../storage/database/transaction'
-import { StorageUtils } from '../storage/database/utils'
 import { BufferUtils, PromiseResolve, PromiseUtils, SetTimeoutToken } from '../utils'
 import { WorkerPool } from '../workerPool'
 import { DecryptedNote, DecryptNoteOptions } from '../workerPool/tasks/decryptNotes'
@@ -66,7 +65,6 @@ export class Wallet {
   protected isStarted = false
   protected isOpen = false
   protected eventLoopTimeout: SetTimeoutToken | null = null
-  protected readonly accountIdsToCleanup: string[] = []
   private readonly createTransactionMutex: Mutex
   private readonly eventLoopAbortController: AbortController
   private eventLoopPromise: Promise<void> | null = null

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -15,7 +15,6 @@ import { Mutex } from '../mutex'
 import { Note } from '../primitives/note'
 import { Transaction } from '../primitives/transaction'
 import { IDatabaseTransaction } from '../storage/database/transaction'
-import { StorageUtils } from '../storage/database/utils'
 import { BufferUtils, PromiseResolve, PromiseUtils, SetTimeoutToken } from '../utils'
 import { WorkerPool } from '../workerPool'
 import { DecryptedNote, DecryptNoteOptions } from '../workerPool/tasks/decryptNotes'
@@ -66,11 +65,11 @@ export class Wallet {
   protected isStarted = false
   protected isOpen = false
   protected eventLoopTimeout: SetTimeoutToken | null = null
-  protected readonly accountIdsToCleanup: string[] = []
   private readonly createTransactionMutex: Mutex
   private readonly eventLoopAbortController: AbortController
   private eventLoopPromise: Promise<void> | null = null
   private eventLoopResolve: PromiseResolve<void> | null = null
+  private readonly accountIdsToCleanup: string[] = []
 
   constructor({
     chain,
@@ -199,7 +198,7 @@ export class Wallet {
       this.headHashes.set(accountId, headHash)
     }
 
-    for await (const { accountId } of this.db.loadAccountIdsToCleanup()) {
+    for await (const { accountId } of this.walletDb.loadAccountIdsToCleanup()) {
       this.accountIdsToCleanup.push(accountId)
     }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -15,6 +15,7 @@ import { Mutex } from '../mutex'
 import { Note } from '../primitives/note'
 import { Transaction } from '../primitives/transaction'
 import { IDatabaseTransaction } from '../storage/database/transaction'
+import { StorageUtils } from '../storage/database/utils'
 import { BufferUtils, PromiseResolve, PromiseUtils, SetTimeoutToken } from '../utils'
 import { WorkerPool } from '../workerPool'
 import { DecryptedNote, DecryptNoteOptions } from '../workerPool/tasks/decryptNotes'
@@ -65,6 +66,7 @@ export class Wallet {
   protected isStarted = false
   protected isOpen = false
   protected eventLoopTimeout: SetTimeoutToken | null = null
+  protected readonly accountIdsToCleanup: string[] = []
   private readonly createTransactionMutex: Mutex
   private readonly eventLoopAbortController: AbortController
   private eventLoopPromise: Promise<void> | null = null

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -69,7 +69,6 @@ export class Wallet {
   private readonly eventLoopAbortController: AbortController
   private eventLoopPromise: Promise<void> | null = null
   private eventLoopResolve: PromiseResolve<void> | null = null
-  private readonly accountIdsToCleanup: string[] = []
 
   constructor({
     chain,

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -22,7 +22,6 @@ import {
   StringEncoding,
   U32_ENCODING,
 } from '../../storage'
-import { DatabaseKeyRange } from '../../storage/database/types'
 import { StorageUtils } from '../../storage/database/utils'
 import { createDB } from '../../storage/utils'
 import { WorkerPool } from '../../workerPool'

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -269,21 +269,6 @@ export class WalletDB {
       yield { accountId, headHash }
     }
   }
-  async saveAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
-    await this.accountIdsToCleanup.put(accountId, null, tx)
-  }
-
-  async removeAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
-    await this.accountIdsToCleanup.del(accountId, tx)
-  }
-
-  async *loadAccountIdsToCleanup(
-    tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{ accountId: string }, void, unknown> {
-    for await (const [accountId] of this.accountIdsToCleanup.getAllIter(tx)) {
-      yield { accountId }
-    }
-  }
 
   async saveTransaction(
     account: Account,

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -21,7 +21,6 @@ import {
   StringEncoding,
   U32_ENCODING,
 } from '../../storage'
-import { DatabaseKeyRange } from '../../storage/database/types'
 import { StorageUtils } from '../../storage/database/utils'
 import { createDB } from '../../storage/utils'
 import { WorkerPool } from '../../workerPool'

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -85,14 +85,11 @@ export class WalletDB {
     value: TransactionValue
   }>
 
-<<<<<<< HEAD:ironfish/src/wallet/walletdb/walletdb.ts
   pendingTransactionHashes: IDatabaseStore<{
     key: [Account['prefix'], [number, TransactionHash]]
     value: null
   }>
 
-=======
->>>>>>> 3ac967d8 (Passively delete records in stores when an account is removed):ironfish/src/wallet/database/accountsdb.ts
   accountIdsToCleanup: IDatabaseStore<{
     key: Account['id']
     value: null
@@ -173,7 +170,6 @@ export class WalletDB {
       valueEncoding: new TransactionValueEncoding(),
     })
 
-<<<<<<< HEAD:ironfish/src/wallet/walletdb/walletdb.ts
     this.pendingTransactionHashes = this.db.addStore({
       name: 'p',
       keyEncoding: new PrefixEncoding(
@@ -185,9 +181,6 @@ export class WalletDB {
     })
 
     this.accountIdsToCleanup = this.db.addStore({
-=======
-    this.accountIdsToCleanup = this.database.addStore({
->>>>>>> 3ac967d8 (Passively delete records in stores when an account is removed):ironfish/src/wallet/database/accountsdb.ts
       name: 'A',
       keyEncoding: new StringEncoding(),
       valueEncoding: NULL_ENCODING,

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -267,21 +267,6 @@ export class WalletDB {
       yield { accountId, headHash }
     }
   }
-  async saveAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
-    await this.accountIdsToCleanup.put(accountId, null, tx)
-  }
-
-  async removeAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
-    await this.accountIdsToCleanup.del(accountId, tx)
-  }
-
-  async *loadAccountIdsToCleanup(
-    tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{ accountId: string }, void, unknown> {
-    for await (const [accountId] of this.accountIdsToCleanup.getAllIter(tx)) {
-      yield { accountId }
-    }
-  }
 
   async saveTransaction(
     account: Account,
@@ -304,33 +289,12 @@ export class WalletDB {
     await this.transactions.clear(tx, account.prefixRange)
   }
 
-  async clearTransactionsForPrefixRange(
-    prefixRange: DatabaseKeyRange,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.transactions.clear(tx, prefixRange)
-  }
-
   async clearSequenceToNoteHash(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.sequenceToNoteHash.clear(tx, account.prefixRange)
   }
 
-  async clearSequenceToNoteHashForPrefixRange(
-    prefixRange: DatabaseKeyRange,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.sequenceToNoteHash.clear(tx, prefixRange)
-  }
-
   async clearNonChainNoteHashes(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.nonChainNoteHashes.clear(tx, account.prefixRange)
-  }
-
-  async clearNonChainNoteHashesForPrefixRange(
-    prefixRange: DatabaseKeyRange,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.nonChainNoteHashes.clear(tx, prefixRange)
   }
 
   async *loadTransactions(
@@ -426,13 +390,6 @@ export class WalletDB {
 
   async clearNullifierToNoteHash(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.nullifierToNoteHash.clear(tx, account.prefixRange)
-  }
-
-  async clearNullifierToNoteHashForPrefixRange(
-    prefixRange: DatabaseKeyRange,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.nullifierToNoteHash.clear(tx, prefixRange)
   }
 
   async replaceNullifierToNoteHash(
@@ -538,13 +495,6 @@ export class WalletDB {
 
   async clearDecryptedNotes(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.decryptedNotes.clear(tx, account.prefixRange)
-  }
-
-  async clearDecryptedNotesForPrefixRange(
-    prefixRange: DatabaseKeyRange,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.decryptedNotes.clear(tx, prefixRange)
   }
 
   async *loadDecryptedNotes(

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -22,6 +22,7 @@ import {
   StringEncoding,
   U32_ENCODING,
 } from '../../storage'
+import { DatabaseKeyRange } from '../../storage/database/types'
 import { StorageUtils } from '../../storage/database/utils'
 import { createDB } from '../../storage/utils'
 import { WorkerPool } from '../../workerPool'
@@ -268,6 +269,21 @@ export class WalletDB {
       yield { accountId, headHash }
     }
   }
+  async saveAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.accountIdsToCleanup.put(accountId, null, tx)
+  }
+
+  async removeAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.accountIdsToCleanup.del(accountId, tx)
+  }
+
+  async *loadAccountIdsToCleanup(
+    tx?: IDatabaseTransaction,
+  ): AsyncGenerator<{ accountId: string }, void, unknown> {
+    for await (const [accountId] of this.accountIdsToCleanup.getAllIter(tx)) {
+      yield { accountId }
+    }
+  }
 
   async saveTransaction(
     account: Account,
@@ -290,12 +306,33 @@ export class WalletDB {
     await this.transactions.clear(tx, account.prefixRange)
   }
 
+  async clearTransactionsForPrefixRange(
+    prefixRange: DatabaseKeyRange,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    await this.transactions.clear(tx, prefixRange)
+  }
+
   async clearSequenceToNoteHash(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.sequenceToNoteHash.clear(tx, account.prefixRange)
   }
 
+  async clearSequenceToNoteHashForPrefixRange(
+    prefixRange: DatabaseKeyRange,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    await this.sequenceToNoteHash.clear(tx, prefixRange)
+  }
+
   async clearNonChainNoteHashes(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.nonChainNoteHashes.clear(tx, account.prefixRange)
+  }
+
+  async clearNonChainNoteHashesForPrefixRange(
+    prefixRange: DatabaseKeyRange,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    await this.nonChainNoteHashes.clear(tx, prefixRange)
   }
 
   async *loadTransactions(
@@ -391,6 +428,13 @@ export class WalletDB {
 
   async clearNullifierToNoteHash(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.nullifierToNoteHash.clear(tx, account.prefixRange)
+  }
+
+  async clearNullifierToNoteHashForPrefixRange(
+    prefixRange: DatabaseKeyRange,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    await this.nullifierToNoteHash.clear(tx, prefixRange)
   }
 
   async replaceNullifierToNoteHash(
@@ -496,6 +540,13 @@ export class WalletDB {
 
   async clearDecryptedNotes(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.decryptedNotes.clear(tx, account.prefixRange)
+  }
+
+  async clearDecryptedNotesForPrefixRange(
+    prefixRange: DatabaseKeyRange,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    await this.decryptedNotes.clear(tx, prefixRange)
   }
 
   async *loadDecryptedNotes(

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -526,7 +526,6 @@ export class WalletDB {
     await this.balances.put(account.id, balance, tx)
   }
 
-<<<<<<< HEAD:ironfish/src/wallet/walletdb/walletdb.ts
   async *loadExpiredTransactions(
     account: Account,
     headSequence: number,
@@ -589,8 +588,6 @@ export class WalletDB {
   async cleanupDeletedAccounts(signal?: AbortSignal): Promise<void> {
     let recordsToCleanup = 1000
 
-    const accountIdsToCleanup = await this.accountIdsToCleanup.getAll()
-
     const stores: Array<
       IDatabaseStore<{
         key: Readonly<unknown>
@@ -604,7 +601,7 @@ export class WalletDB {
       this.decryptedNotes,
     ]
 
-    for (const [accountId] of accountIdsToCleanup) {
+    for (const [accountId] of await this.accountIdsToCleanup.getAll()) {
       const prefix = calculateAccountPrefix(accountId)
       const prefixRange = StorageUtils.getPrefixKeyRange(prefix)
 
@@ -620,18 +617,6 @@ export class WalletDB {
       }
 
       await this.accountIdsToCleanup.del(accountId)
-    }
-  }
-
-  async saveAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
-    await this.accountIdsToCleanup.put(accountId, null, tx)
-  }
-
-  async *loadAccountIdsToCleanup(
-    tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{ accountId: string }, void, unknown> {
-    for await (const [accountId] of this.accountIdsToCleanup.getAllIter(tx)) {
-      yield { accountId }
     }
   }
 }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -589,8 +589,9 @@ export class WalletDB {
 
   async cleanupDeletedAccounts(signal?: AbortSignal): Promise<void> {
     let recordsToCleanup = 1000
+
     const accountIdsToCleanup = await this.accountIdsToCleanup.getAll()
-<<<<<<< HEAD
+
     const stores: Array<
       IDatabaseStore<{
         key: Readonly<unknown>
@@ -632,69 +633,6 @@ export class WalletDB {
   ): AsyncGenerator<{ accountId: string }, void, unknown> {
     for await (const [accountId] of this.accountIdsToCleanup.getAllIter(tx)) {
       yield { accountId }
-=======
-
-    for (const [accountId] of accountIdsToCleanup) {
-      const prefix = calculateAccountPrefix(accountId)
-      const prefixRange = StorageUtils.getPrefixKeyRange(prefix)
-
-      for await (const [transactionHash] of this.transactions.getAllKeysIter(
-        undefined,
-        prefixRange,
-      )) {
-        if (signal?.aborted === false || recordsToCleanup === 0) {
-          return
-        }
-        await this.transactions.del([prefix, transactionHash])
-        recordsToCleanup--
-      }
-
-      for await (const [_, sequenceToNoteHash] of this.sequenceToNoteHash.getAllKeysIter(
-        undefined,
-        prefixRange,
-      )) {
-        if (signal?.aborted === false || recordsToCleanup === 0) {
-          return
-        }
-        await this.sequenceToNoteHash.del([prefix, sequenceToNoteHash])
-        recordsToCleanup--
-      }
-
-      for await (const [nonChainNoteHashes] of this.nonChainNoteHashes.getAllKeysIter(
-        undefined,
-        prefixRange,
-      )) {
-        if (signal?.aborted === false || recordsToCleanup === 0) {
-          return
-        }
-        await this.nonChainNoteHashes.del([prefix, nonChainNoteHashes])
-        recordsToCleanup--
-      }
-
-      for await (const [nullifierToNoteHash] of this.nullifierToNoteHash.getAllKeysIter(
-        undefined,
-        prefixRange,
-      )) {
-        if (signal?.aborted === false || recordsToCleanup === 0) {
-          return
-        }
-        await this.nullifierToNoteHash.del([prefix, nullifierToNoteHash])
-        recordsToCleanup--
-      }
-
-      for await (const [decryptedNotes] of this.decryptedNotes.getAllKeysIter(
-        undefined,
-        prefixRange,
-      )) {
-        if (signal?.aborted === false || recordsToCleanup === 0) {
-          return
-        }
-        await this.decryptedNotes.del([prefix, decryptedNotes])
-        recordsToCleanup--
-      }
-
-      await this.accountIdsToCleanup.del(accountId)
->>>>>>> 4df4eca2 (Move cleanup code into walletdb)
     }
   }
 }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -590,6 +590,7 @@ export class WalletDB {
   async cleanupDeletedAccounts(signal?: AbortSignal): Promise<void> {
     let recordsToCleanup = 1000
     const accountIdsToCleanup = await this.accountIdsToCleanup.getAll()
+<<<<<<< HEAD
     const stores: Array<
       IDatabaseStore<{
         key: Readonly<unknown>
@@ -631,6 +632,69 @@ export class WalletDB {
   ): AsyncGenerator<{ accountId: string }, void, unknown> {
     for await (const [accountId] of this.accountIdsToCleanup.getAllIter(tx)) {
       yield { accountId }
+=======
+
+    for (const [accountId] of accountIdsToCleanup) {
+      const prefix = calculateAccountPrefix(accountId)
+      const prefixRange = StorageUtils.getPrefixKeyRange(prefix)
+
+      for await (const [transactionHash] of this.transactions.getAllKeysIter(
+        undefined,
+        prefixRange,
+      )) {
+        if (signal?.aborted === false || recordsToCleanup === 0) {
+          return
+        }
+        await this.transactions.del([prefix, transactionHash])
+        recordsToCleanup--
+      }
+
+      for await (const [_, sequenceToNoteHash] of this.sequenceToNoteHash.getAllKeysIter(
+        undefined,
+        prefixRange,
+      )) {
+        if (signal?.aborted === false || recordsToCleanup === 0) {
+          return
+        }
+        await this.sequenceToNoteHash.del([prefix, sequenceToNoteHash])
+        recordsToCleanup--
+      }
+
+      for await (const [nonChainNoteHashes] of this.nonChainNoteHashes.getAllKeysIter(
+        undefined,
+        prefixRange,
+      )) {
+        if (signal?.aborted === false || recordsToCleanup === 0) {
+          return
+        }
+        await this.nonChainNoteHashes.del([prefix, nonChainNoteHashes])
+        recordsToCleanup--
+      }
+
+      for await (const [nullifierToNoteHash] of this.nullifierToNoteHash.getAllKeysIter(
+        undefined,
+        prefixRange,
+      )) {
+        if (signal?.aborted === false || recordsToCleanup === 0) {
+          return
+        }
+        await this.nullifierToNoteHash.del([prefix, nullifierToNoteHash])
+        recordsToCleanup--
+      }
+
+      for await (const [decryptedNotes] of this.decryptedNotes.getAllKeysIter(
+        undefined,
+        prefixRange,
+      )) {
+        if (signal?.aborted === false || recordsToCleanup === 0) {
+          return
+        }
+        await this.decryptedNotes.del([prefix, decryptedNotes])
+        recordsToCleanup--
+      }
+
+      await this.accountIdsToCleanup.del(accountId)
+>>>>>>> 4df4eca2 (Move cleanup code into walletdb)
     }
   }
 }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -578,6 +578,7 @@ export class WalletDB {
     await this.balances.put(account.id, balance, tx)
   }
 
+<<<<<<< HEAD:ironfish/src/wallet/walletdb/walletdb.ts
   async *loadExpiredTransactions(
     account: Account,
     headSequence: number,
@@ -670,5 +671,70 @@ export class WalletDB {
 
       await this.accountIdsToCleanup.del(accountId)
     }
+=======
+  async cleanupAccount(
+    accountId: string,
+    recordsToCleanup: number,
+  ): Promise<[recordsToCleanup: number, cleaned: boolean]> {
+    const prefix = calculateAccountPrefix(accountId)
+    const prefixRange = StorageUtils.getPrefixKeyRange(prefix)
+
+    for await (const [transactionHash] of this.transactions.getAllKeysIter(
+      undefined,
+      prefixRange,
+    )) {
+      if (recordsToCleanup === 0) {
+        return [recordsToCleanup, false]
+      }
+      await this.transactions.del([prefix, transactionHash])
+      recordsToCleanup--
+    }
+
+    for await (const [_, sequenceToNoteHash] of this.sequenceToNoteHash.getAllKeysIter(
+      undefined,
+      prefixRange,
+    )) {
+      if (recordsToCleanup === 0) {
+        return [recordsToCleanup, false]
+      }
+      await this.sequenceToNoteHash.del([prefix, sequenceToNoteHash])
+      recordsToCleanup--
+    }
+
+    for await (const [nonChainNoteHashes] of this.nonChainNoteHashes.getAllKeysIter(
+      undefined,
+      prefixRange,
+    )) {
+      if (recordsToCleanup === 0) {
+        return [recordsToCleanup, false]
+      }
+      await this.nonChainNoteHashes.del([prefix, nonChainNoteHashes])
+      recordsToCleanup--
+    }
+
+    for await (const [nullifierToNoteHash] of this.nullifierToNoteHash.getAllKeysIter(
+      undefined,
+      prefixRange,
+    )) {
+      if (recordsToCleanup === 0) {
+        return [recordsToCleanup, false]
+      }
+      await this.nullifierToNoteHash.del([prefix, nullifierToNoteHash])
+      recordsToCleanup--
+    }
+
+    for await (const [decryptedNotes] of this.decryptedNotes.getAllKeysIter(
+      undefined,
+      prefixRange,
+    )) {
+      if (recordsToCleanup === 0) {
+        return [recordsToCleanup, false]
+      }
+      await this.decryptedNotes.del([prefix, decryptedNotes])
+      recordsToCleanup--
+    }
+
+    return [recordsToCleanup, true]
+>>>>>>> 3ec0de49 (Remove timeout for cleanupAccounts and push cleanup logic to accountsdb):ironfish/src/wallet/database/accountsdb.ts
   }
 }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -12,7 +12,6 @@ import {
   BigIntLEEncoding,
   BUFFER_ENCODING,
   BufferEncoding,
-  DatabaseStoreKey,
   IDatabase,
   IDatabaseStore,
   IDatabaseTransaction,

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -269,21 +269,6 @@ export class WalletDB {
       yield { accountId, headHash }
     }
   }
-  async saveAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
-    await this.accountIdsToCleanup.put(accountId, null, tx)
-  }
-
-  async removeAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
-    await this.accountIdsToCleanup.del(accountId, tx)
-  }
-
-  async *loadAccountIdsToCleanup(
-    tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{ accountId: string }, void, unknown> {
-    for await (const [accountId] of this.accountIdsToCleanup.getAllIter(tx)) {
-      yield { accountId }
-    }
-  }
 
   async saveTransaction(
     account: Account,
@@ -306,33 +291,12 @@ export class WalletDB {
     await this.transactions.clear(tx, account.prefixRange)
   }
 
-  async clearTransactionsForPrefixRange(
-    prefixRange: DatabaseKeyRange,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.transactions.clear(tx, prefixRange)
-  }
-
   async clearSequenceToNoteHash(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.sequenceToNoteHash.clear(tx, account.prefixRange)
   }
 
-  async clearSequenceToNoteHashForPrefixRange(
-    prefixRange: DatabaseKeyRange,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.sequenceToNoteHash.clear(tx, prefixRange)
-  }
-
   async clearNonChainNoteHashes(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.nonChainNoteHashes.clear(tx, account.prefixRange)
-  }
-
-  async clearNonChainNoteHashesForPrefixRange(
-    prefixRange: DatabaseKeyRange,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.nonChainNoteHashes.clear(tx, prefixRange)
   }
 
   async *loadTransactions(
@@ -428,13 +392,6 @@ export class WalletDB {
 
   async clearNullifierToNoteHash(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.nullifierToNoteHash.clear(tx, account.prefixRange)
-  }
-
-  async clearNullifierToNoteHashForPrefixRange(
-    prefixRange: DatabaseKeyRange,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.nullifierToNoteHash.clear(tx, prefixRange)
   }
 
   async replaceNullifierToNoteHash(
@@ -540,13 +497,6 @@ export class WalletDB {
 
   async clearDecryptedNotes(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.decryptedNotes.clear(tx, account.prefixRange)
-  }
-
-  async clearDecryptedNotesForPrefixRange(
-    prefixRange: DatabaseKeyRange,
-    tx?: IDatabaseTransaction,
-  ): Promise<void> {
-    await this.decryptedNotes.clear(tx, prefixRange)
   }
 
   async *loadDecryptedNotes(
@@ -671,70 +621,17 @@ export class WalletDB {
 
       await this.accountIdsToCleanup.del(accountId)
     }
-=======
-  async cleanupAccount(
-    accountId: string,
-    recordsToCleanup: number,
-  ): Promise<[recordsToCleanup: number, cleaned: boolean]> {
-    const prefix = calculateAccountPrefix(accountId)
-    const prefixRange = StorageUtils.getPrefixKeyRange(prefix)
+  }
 
-    for await (const [transactionHash] of this.transactions.getAllKeysIter(
-      undefined,
-      prefixRange,
-    )) {
-      if (recordsToCleanup === 0) {
-        return [recordsToCleanup, false]
-      }
-      await this.transactions.del([prefix, transactionHash])
-      recordsToCleanup--
+  async saveAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.accountIdsToCleanup.put(accountId, null, tx)
+  }
+
+  async *loadAccountIdsToCleanup(
+    tx?: IDatabaseTransaction,
+  ): AsyncGenerator<{ accountId: string }, void, unknown> {
+    for await (const [accountId] of this.accountIdsToCleanup.getAllIter(tx)) {
+      yield { accountId }
     }
-
-    for await (const [_, sequenceToNoteHash] of this.sequenceToNoteHash.getAllKeysIter(
-      undefined,
-      prefixRange,
-    )) {
-      if (recordsToCleanup === 0) {
-        return [recordsToCleanup, false]
-      }
-      await this.sequenceToNoteHash.del([prefix, sequenceToNoteHash])
-      recordsToCleanup--
-    }
-
-    for await (const [nonChainNoteHashes] of this.nonChainNoteHashes.getAllKeysIter(
-      undefined,
-      prefixRange,
-    )) {
-      if (recordsToCleanup === 0) {
-        return [recordsToCleanup, false]
-      }
-      await this.nonChainNoteHashes.del([prefix, nonChainNoteHashes])
-      recordsToCleanup--
-    }
-
-    for await (const [nullifierToNoteHash] of this.nullifierToNoteHash.getAllKeysIter(
-      undefined,
-      prefixRange,
-    )) {
-      if (recordsToCleanup === 0) {
-        return [recordsToCleanup, false]
-      }
-      await this.nullifierToNoteHash.del([prefix, nullifierToNoteHash])
-      recordsToCleanup--
-    }
-
-    for await (const [decryptedNotes] of this.decryptedNotes.getAllKeysIter(
-      undefined,
-      prefixRange,
-    )) {
-      if (recordsToCleanup === 0) {
-        return [recordsToCleanup, false]
-      }
-      await this.decryptedNotes.del([prefix, decryptedNotes])
-      recordsToCleanup--
-    }
-
-    return [recordsToCleanup, true]
->>>>>>> 3ec0de49 (Remove timeout for cleanupAccounts and push cleanup logic to accountsdb):ironfish/src/wallet/database/accountsdb.ts
   }
 }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -269,6 +269,21 @@ export class WalletDB {
       yield { accountId, headHash }
     }
   }
+  async saveAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.accountIdsToCleanup.put(accountId, null, tx)
+  }
+
+  async removeAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.accountIdsToCleanup.del(accountId, tx)
+  }
+
+  async *loadAccountIdsToCleanup(
+    tx?: IDatabaseTransaction,
+  ): AsyncGenerator<{ accountId: string }, void, unknown> {
+    for await (const [accountId] of this.accountIdsToCleanup.getAllIter(tx)) {
+      yield { accountId }
+    }
+  }
 
   async saveTransaction(
     account: Account,

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -85,11 +85,14 @@ export class WalletDB {
     value: TransactionValue
   }>
 
+<<<<<<< HEAD:ironfish/src/wallet/walletdb/walletdb.ts
   pendingTransactionHashes: IDatabaseStore<{
     key: [Account['prefix'], [number, TransactionHash]]
     value: null
   }>
 
+=======
+>>>>>>> 3ac967d8 (Passively delete records in stores when an account is removed):ironfish/src/wallet/database/accountsdb.ts
   accountIdsToCleanup: IDatabaseStore<{
     key: Account['id']
     value: null
@@ -170,6 +173,7 @@ export class WalletDB {
       valueEncoding: new TransactionValueEncoding(),
     })
 
+<<<<<<< HEAD:ironfish/src/wallet/walletdb/walletdb.ts
     this.pendingTransactionHashes = this.db.addStore({
       name: 'p',
       keyEncoding: new PrefixEncoding(
@@ -181,6 +185,9 @@ export class WalletDB {
     })
 
     this.accountIdsToCleanup = this.db.addStore({
+=======
+    this.accountIdsToCleanup = this.database.addStore({
+>>>>>>> 3ac967d8 (Passively delete records in stores when an account is removed):ironfish/src/wallet/database/accountsdb.ts
       name: 'A',
       keyEncoding: new StringEncoding(),
       valueEncoding: NULL_ENCODING,
@@ -265,6 +272,21 @@ export class WalletDB {
   ): AsyncGenerator<{ accountId: string; headHash: Buffer | null }, void, unknown> {
     for await (const [accountId, headHash] of this.headHashes.getAllIter(tx)) {
       yield { accountId, headHash }
+    }
+  }
+  async saveAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.accountIdsToCleanup.put(accountId, null, tx)
+  }
+
+  async removeAccountIdToCleanup(accountId: string, tx?: IDatabaseTransaction): Promise<void> {
+    await this.accountIdsToCleanup.del(accountId, tx)
+  }
+
+  async *loadAccountIdsToCleanup(
+    tx?: IDatabaseTransaction,
+  ): AsyncGenerator<{ accountId: string }, void, unknown> {
+    for await (const [accountId] of this.accountIdsToCleanup.getAllIter(tx)) {
+      yield { accountId }
     }
   }
 

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -588,26 +588,25 @@ export class WalletDB {
   async cleanupDeletedAccounts(signal?: AbortSignal): Promise<void> {
     let recordsToCleanup = 1000
 
-    const stores: Array<
-      IDatabaseStore<{
-        key: Readonly<unknown>
-        value: unknown
-      }>
-    > = [
+    const stores: IDatabaseStore<{
+      key: Readonly<unknown>
+      value: unknown
+    }>[] = [
       this.transactions,
       this.sequenceToNoteHash,
       this.nonChainNoteHashes,
       this.nullifierToNoteHash,
+      this.pendingTransactionHashes,
       this.decryptedNotes,
     ]
 
     for (const [accountId] of await this.accountIdsToCleanup.getAll()) {
       const prefix = calculateAccountPrefix(accountId)
-      const prefixRange = StorageUtils.getPrefixKeyRange(prefix)
+      const range = StorageUtils.getPrefixKeyRange(prefix)
 
       for (const store of stores) {
-        for await (const key of store.getAllKeysIter(undefined, prefixRange)) {
-          if (signal?.aborted === false || recordsToCleanup === 0) {
+        for await (const key of store.getAllKeysIter(undefined, range)) {
+          if (signal?.aborted === true || recordsToCleanup === 0) {
             return
           }
 


### PR DESCRIPTION
## Summary

Clear records in stores for a deleted account. Adds a store to keep track of IDs of accounts that have yet to be cleaned up and then processes this clean up in the background.

## Testing Plan

Ran `accounts:remove` locally.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
