### PR TITLE
adds method to get transaction by unsignedHash

### DIFF
--- a/ironfish/src/rpc/routes/accounts/getTransaction.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransaction.ts
@@ -66,7 +66,7 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
     const account = getAccount(node, request.data.account)
 
     const transactionHash = Buffer.from(request.data.hash, 'hex')
-    const transaction = await account.getTransaction(transactionHash)
+    const transaction = await account.getTransactionByUnsignedHash(transactionHash)
 
     if (!transaction) {
       return request.end({

--- a/ironfish/src/rpc/routes/accounts/getTransactions.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransactions.ts
@@ -61,7 +61,7 @@ router.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactio
 
     if (request.data.hash) {
       const hash = Buffer.from(request.data.hash, 'hex')
-      const transaction = await account.getTransaction(hash)
+      const transaction = await account.getTransactionByUnsignedHash(hash)
 
       if (transaction) {
         await streamTransaction(request, node, account, transaction)

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -294,6 +294,17 @@ export class Account {
     return await this.accountsDb.loadTransaction(this, hash, tx)
   }
 
+  async getTransactionByUnsignedHash(
+    unsignedHash: Buffer,
+    tx?: IDatabaseTransaction,
+  ): Promise<Readonly<TransactionValue> | undefined> {
+    for await (const transactionValue of this.getTransactions(tx)) {
+      if (unsignedHash.equals(transactionValue.transaction.unsignedHash())) {
+        return transactionValue
+      }
+    }
+  }
+
   getTransactions(tx?: IDatabaseTransaction): AsyncGenerator<Readonly<TransactionValue>> {
     return this.accountsDb.loadTransactions(this, tx)
   }


### PR DESCRIPTION
## Summary

updates getTransaction and getTransactions to use getTransactionByUnsignedHash to load specific transactions from the account.

we need to search by unsignedHash (for now) because we use the unsigned hash for the transaction in the block explorer and cli output. users have no way of finding the other hash.

## Testing Plan

![image](https://user-images.githubusercontent.com/57735705/193148605-ed738fb3-38ea-490b-a7a3-26ed1a201ab6.png)


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
