### PR TITLE
Only store peers in CONNECTED or CONNECTING states

### DIFF
--- a/ironfish/src/event.ts
+++ b/ironfish/src/event.ts
@@ -75,6 +75,17 @@ export class Event<A extends unknown[]> {
   clear(): void {
     this.handlers.clear()
   }
+
+  /**
+   * Removes all handlers from the event in the next tick.
+   * Useful if you want to clear an event, but allow remaining
+   * handlers to execute
+   */
+  clearAfter(): void {
+    setImmediate(() => {
+      this.handlers.clear()
+    })
+  }
 }
 
 /**

--- a/ironfish/src/network/peers/addressManager.test.ts
+++ b/ironfish/src/network/peers/addressManager.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 jest.mock('ws')
 
+import { Assert } from '../../assert'
 import {
   getConnectedPeer,
   getConnectingPeer,
@@ -11,6 +12,7 @@ import {
   mockLocalPeer,
 } from '../testUtilities'
 import { AddressManager } from './addressManager'
+import { ConnectionRetry } from './connectionRetry'
 import { ConnectionDirection, ConnectionType } from './connections'
 import { Peer } from './peer'
 import { PeerAddress } from './peerAddress'
@@ -20,7 +22,8 @@ jest.useFakeTimers()
 
 describe('AddressManager', () => {
   it('constructor loads addresses from HostsStore', () => {
-    const addressManager = new AddressManager(mockHostsStore())
+    const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
+    const addressManager = new AddressManager(mockHostsStore(), pm)
     addressManager.hostsStore = mockHostsStore()
     expect(addressManager.priorConnectedPeerAddresses).toMatchObject([
       {
@@ -31,9 +34,9 @@ describe('AddressManager', () => {
   })
 
   it('removePeerAddress should remove a peer address', () => {
-    const addressManager = new AddressManager(mockHostsStore())
-    addressManager.hostsStore = mockHostsStore()
     const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
+    const addressManager = new AddressManager(mockHostsStore(), pm)
+    addressManager.hostsStore = mockHostsStore()
     const { peer: peer1 } = getConnectedPeer(pm)
     const allPeers: Peer[] = [peer1]
     const allPeerAddresses: PeerAddress[] = []
@@ -52,9 +55,9 @@ describe('AddressManager', () => {
   })
 
   it('getRandomDisconnectedPeer should return a randomly-sampled disconnected peer', () => {
-    const addressManager = new AddressManager(mockHostsStore())
-    addressManager.hostsStore = mockHostsStore()
     const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
+    const addressManager = new AddressManager(mockHostsStore(), pm)
+    addressManager.hostsStore = mockHostsStore()
     const { peer: connectedPeer } = getConnectedPeer(pm)
     const { peer: connectingPeer } = getConnectingPeer(pm)
     const disconnectedPeer = getDisconnectedPeer(pm)
@@ -91,9 +94,9 @@ describe('AddressManager', () => {
 
   describe('save', () => {
     it('save should persist connected peers', async () => {
-      const addressManager = new AddressManager(mockHostsStore())
-      addressManager.hostsStore = mockHostsStore()
       const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
+      const addressManager = new AddressManager(mockHostsStore(), pm)
+      addressManager.hostsStore = mockHostsStore()
       const { peer: connectedPeer } = getConnectedPeer(pm)
       const { peer: connectingPeer } = getConnectingPeer(pm)
       const disconnectedPeer = getDisconnectedPeer(pm)
@@ -109,16 +112,28 @@ describe('AddressManager', () => {
     })
 
     it('should not persist peers that will never retry connecting', async () => {
-      const addressManager = new AddressManager(mockHostsStore())
+      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
+      const addressManager = new AddressManager(mockHostsStore(), pm)
       addressManager.hostsStore = mockHostsStore()
       expect(addressManager.priorConnectedPeerAddresses.length).toEqual(1)
-      const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
       const { peer: connectedPeer } = getConnectedPeer(pm)
       const { peer: connectingPeer } = getConnectingPeer(pm)
       const disconnectedPeer = getDisconnectedPeer(pm)
-      connectedPeer
-        .getConnectionRetry(ConnectionType.WebSocket, ConnectionDirection.Outbound)
-        ?.neverRetryConnecting()
+
+      pm.peerCandidateMap.set(connectedPeer.getIdentityOrThrow(), {
+        address: null,
+        port: null,
+        neighbors: new Set(),
+        webRtcRetry: new ConnectionRetry(),
+        websocketRetry: new ConnectionRetry(),
+      })
+      const retry = pm.getConnectionRetry(
+        connectedPeer.getIdentityOrThrow(),
+        ConnectionType.WebSocket,
+        ConnectionDirection.Outbound,
+      )
+      Assert.isNotNull(retry)
+      retry.neverRetryConnecting()
 
       await addressManager.save([connectedPeer, connectingPeer, disconnectedPeer])
       expect(addressManager.priorConnectedPeerAddresses.length).toEqual(0)

--- a/ironfish/src/network/peers/addressManager.test.ts
+++ b/ironfish/src/network/peers/addressManager.test.ts
@@ -126,6 +126,8 @@ describe('AddressManager', () => {
         neighbors: new Set(),
         webRtcRetry: new ConnectionRetry(),
         websocketRetry: new ConnectionRetry(),
+        localRequestedDisconnectUntil: null,
+        peerRequestedDisconnectUntil: null,
       })
       const retry = pm.getConnectionRetry(
         connectedPeer.getIdentityOrThrow(),

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -4,7 +4,6 @@
 import { HostsStore } from '../../fileStores'
 import { ArrayUtils } from '../../utils'
 import { Peer } from '../peers/peer'
-import { ConnectionDirection, ConnectionType } from './connections'
 import { PeerAddress } from './peerAddress'
 import { PeerManager } from './peerManager'
 
@@ -71,21 +70,14 @@ export class AddressManager {
   }
 
   /**
-   * Persist all currently connected peers and unused peer addresses to disk
+   * Persist all currently connected peers to disk
    */
-  async save(peers: Peer[]): Promise<void> {
+  async save(): Promise<void> {
     // TODO: Ideally, we would like persist peers with whom we've
     // successfully established an outbound Websocket connection at
     // least once.
-    const inUsePeerAddresses: PeerAddress[] = peers.flatMap((peer) => {
-      if (
-        peer.state.type === 'CONNECTED' &&
-        !this.peerManager.getConnectionRetry(
-          peer.state.identity,
-          ConnectionType.WebSocket,
-          ConnectionDirection.Outbound,
-        )?.willNeverRetryConnecting
-      ) {
+    const inUsePeerAddresses: PeerAddress[] = this.peerManager.peers.flatMap((peer) => {
+      if (peer.state.type === 'CONNECTED') {
         return {
           address: peer.address,
           port: peer.port,

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -6,6 +6,7 @@ import { ArrayUtils } from '../../utils'
 import { Peer } from '../peers/peer'
 import { ConnectionDirection, ConnectionType } from './connections'
 import { PeerAddress } from './peerAddress'
+import { PeerManager } from './peerManager'
 
 /**
  * AddressManager stores the necessary data for connecting to new peers
@@ -13,9 +14,11 @@ import { PeerAddress } from './peerAddress'
  */
 export class AddressManager {
   hostsStore: HostsStore
+  peerManager: PeerManager
 
-  constructor(hostsStore: HostsStore) {
+  constructor(hostsStore: HostsStore, peerManager: PeerManager) {
     this.hostsStore = hostsStore
+    this.peerManager = peerManager
   }
 
   get priorConnectedPeerAddresses(): ReadonlyArray<Readonly<PeerAddress>> {
@@ -77,8 +80,11 @@ export class AddressManager {
     const inUsePeerAddresses: PeerAddress[] = peers.flatMap((peer) => {
       if (
         peer.state.type === 'CONNECTED' &&
-        !peer.getConnectionRetry(ConnectionType.WebSocket, ConnectionDirection.Outbound)
-          .willNeverRetryConnecting
+        !this.peerManager.getConnectionRetry(
+          peer.state.identity,
+          ConnectionType.WebSocket,
+          ConnectionDirection.Outbound,
+        )?.willNeverRetryConnecting
       ) {
         return {
           address: peer.address,

--- a/ironfish/src/network/peers/connectionRetry.ts
+++ b/ironfish/src/network/peers/connectionRetry.ts
@@ -26,6 +26,15 @@ export class ConnectionRetry {
   private disconnectUntil = 0
 
   /**
+   * If true, a failed connection will not cause ConnectionRetry to stop retrying.
+   */
+  private shouldNeverExpire = false
+
+  constructor(shouldNeverExpire = false) {
+    this.shouldNeverExpire = shouldNeverExpire
+  }
+
+  /**
    * Call this if new connection attempts should never be made.
    */
   neverRetryConnecting(): void {
@@ -59,12 +68,12 @@ export class ConnectionRetry {
    * Call this when a connection to a peer fails.
    * @param now The current time
    */
-  failedConnection(isWhitelisted = false, now: number = Date.now()): void {
+  failedConnection(now: number = Date.now()): void {
     let disconnectUntil = Infinity
 
     if (this.failedRetries < retryIntervals.length) {
       disconnectUntil = now + retryIntervals[this.failedRetries]
-    } else if (isWhitelisted) {
+    } else if (this.shouldNeverExpire) {
       disconnectUntil = now + retryIntervals[retryIntervals.length - 1]
     }
 

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -81,7 +81,7 @@ export class WebSocketConnection extends Connection {
     this.socket.onmessage = (event: MessageEvent) => {
       if (!Buffer.isBuffer(event.data)) {
         const message = 'Received non-buffer message'
-        this.logger.warn(message, event.data)
+        this.logger.debug(message, event.data)
         this.close(new NetworkError(message))
         return
       }

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -81,7 +81,7 @@ export class WebSocketConnection extends Connection {
     this.socket.onmessage = (event: MessageEvent) => {
       if (!Buffer.isBuffer(event.data)) {
         const message = 'Received non-buffer message'
-        this.logger.debug(message, event.data)
+        this.logger.warn(message, event.data)
         this.close(new NetworkError(message))
         return
       }

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -162,14 +162,6 @@ export class Peer {
   /** how many outbound connections does the peer have */
   pendingRPC = 0
 
-  private readonly supportedConnections: {
-    [ConnectionType.WebSocket]: ConnectionRetry
-    [ConnectionType.WebRtc]: ConnectionRetry
-  } = {
-    WebRtc: new ConnectionRetry(),
-    WebSocket: new ConnectionRetry(),
-  }
-
   /**
    * The reason why the Peer requested to disconnect from us.
    */
@@ -513,25 +505,6 @@ export class Peer {
     return state.type === 'DISCONNECTED'
       ? { webRtc: undefined, webSocket: undefined }
       : state.connections
-  }
-
-  getConnectionRetry(type: ConnectionType, direction: ConnectionDirection.Inbound): null
-  getConnectionRetry(
-    type: ConnectionType,
-    direction: ConnectionDirection.Outbound,
-  ): ConnectionRetry
-  getConnectionRetry(
-    type: ConnectionType,
-    direction: ConnectionDirection,
-  ): ConnectionRetry | null
-  getConnectionRetry(
-    type: ConnectionType,
-    direction: ConnectionDirection,
-  ): ConnectionRetry | null {
-    if (direction === ConnectionDirection.Inbound) {
-      return null
-    }
-    return this.supportedConnections[type]
   }
 
   private readonly connectionMessageHandlers: Map<

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -162,11 +162,6 @@ export class Peer {
   /** how many outbound connections does the peer have */
   pendingRPC = 0
 
-  /**
-   * A map of peers connected to this peer, shared by the PeerList message.
-   */
-  knownPeers: Map<Identity, Peer> = new Map<Identity, Peer>()
-
   private readonly supportedConnections: {
     [ConnectionType.WebSocket]: ConnectionRetry
     [ConnectionType.WebRtc]: ConnectionRetry

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -143,11 +143,6 @@ export class Peer {
   }
 
   /**
-   * Is the peer a node we will always attempt to connect to
-   */
-  isWhitelisted = false
-
-  /**
    * address associated with this peer
    */
   private _address: string | null = null

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -251,36 +251,40 @@ export class Peer {
 
   /**
    * Sets a WebRTC connection on the peer, moving it into the CONNECTING state if necessary.
-   * Ignores the connection if the peer already has a WebRTC connection.
+   * Returns the existing connection if the peer already has a WebRTC connection.
    * @param connection The WebRTC connection to set
    */
-  setWebRtcConnection(connection: WebRtcConnection): void {
+  setWebRtcConnection(connection: WebRtcConnection): WebRtcConnection | null {
+    let existingConnection = null
     if (this.state.type !== 'DISCONNECTED' && this.state.connections.webRtc) {
-      this.logger.warn('Already have a WebRTC connection, ignoring the new one')
-      return
+      existingConnection = this.state.connections.webRtc
     }
 
     const webSocket =
       this.state.type !== 'DISCONNECTED' ? this.state.connections.webSocket : undefined
 
     this.setState(this.computeStateFromConnections(webSocket, connection))
+
+    return existingConnection
   }
 
   /**
    * Sets a WebSocket connection on the peer, moving it into the CONNECTING state if necessary.
-   * Ignores the connection if the peer already has a WebSocket connection.
+   * Returns the existing connection if the peer already has a WebSocket connection.
    * @param connection The WebSocket connection to set
    */
-  setWebSocketConnection(connection: WebSocketConnection): void {
+  setWebSocketConnection(connection: WebSocketConnection): WebSocketConnection | null {
+    let existingConnection = null
     if (this.state.type !== 'DISCONNECTED' && this.state.connections.webSocket) {
-      this.logger.debug('Already have a WebSocket connection, ignoring the new one')
-      return
+      existingConnection = this.state.connections.webSocket
     }
 
     const webRtc =
       this.state.type !== 'DISCONNECTED' ? this.state.connections.webRtc : undefined
 
     this.setState(this.computeStateFromConnections(connection, webRtc))
+
+    return existingConnection
   }
 
   private computeStateFromConnections(

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -10,7 +10,6 @@ import { createRootLogger, Logger } from '../../logger'
 import { MetricsMonitor } from '../../metrics'
 import { ErrorUtils } from '../../utils'
 import { Identity } from '../identity'
-import { DisconnectingReason } from '../messages/disconnecting'
 import { displayNetworkMessageType, NetworkMessage } from '../messages/networkMessage'
 import { NetworkMessageType } from '../types'
 import { WebRtcConnection, WebSocketConnection } from './connections'
@@ -166,28 +165,6 @@ export class Peer {
 
   /** how many outbound connections does the peer have */
   pendingRPC = 0
-
-  /**
-   * The reason why the Peer requested to disconnect from us.
-   */
-  peerRequestedDisconnectReason: DisconnectingReason | null = null
-
-  /**
-   * UTC timestamp. If set, the peer manager should not initiate connections to the
-   * Peer until after the timestamp.
-   */
-  peerRequestedDisconnectUntil: number | null = null
-
-  /**
-   * The reason why we requested the Peer not to connect to us.
-   */
-  localRequestedDisconnectReason: DisconnectingReason | null = null
-
-  /**
-   * UTC timestamp. If set, the peer manager should not accept connections from the
-   * Peer until after the timestamp.
-   */
-  localRequestedDisconnectUntil: number | null = null
 
   shouldLogMessages = false
 

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -643,7 +643,7 @@ export class Peer {
    * Clean up all resources managed by the peer.
    */
   dispose(): void {
-    this.onStateChanged.clear()
+    this.onStateChanged.clearAfter()
     this.onMessage.clear()
     this.onBanned.clear()
     this.disposeMessageMeter()

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -60,9 +60,11 @@ describe('connectToDisconnectedPeers', () => {
     peer.setWebSocketAddress('testuri.com', 9033)
 
     // We want to test websocket only
-    peer
-      .getConnectionRetry(ConnectionType.WebRtc, ConnectionDirection.Outbound)
-      .neverRetryConnecting()
+    pm.getConnectionRetry(
+      identity,
+      ConnectionType.WebRtc,
+      ConnectionDirection.Outbound,
+    )?.neverRetryConnecting()
 
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
     pcm.start()
@@ -110,8 +112,12 @@ describe('connectToDisconnectedPeers', () => {
     const { peer: brokeringPeer } = getConnectedPeer(pm, 'brokering')
     const peer = pm.getOrCreatePeer(peerIdentity)
     // Link the peers
-    brokeringPeer.knownPeers.set(peerIdentity, peer)
-    peer.knownPeers.set(brokeringPeer.getIdentityOrThrow(), brokeringPeer)
+    pm.peerCandidateMap
+      .get(brokeringPeer.getIdentityOrThrow())
+      ?.neighbors.add(peer.getIdentityOrThrow())
+    pm.peerCandidateMap
+      .get(peer.getIdentityOrThrow())
+      ?.neighbors.add(brokeringPeer.getIdentityOrThrow())
 
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
     pcm.start()

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -4,6 +4,7 @@
 
 jest.mock('ws')
 
+import { Assert } from '../../assert'
 import { createRootLogger } from '../../logger'
 import {
   getConnectedPeer,
@@ -13,6 +14,7 @@ import {
   webRtcCanInitiateIdentity,
   webRtcLocalIdentity,
 } from '../testUtilities'
+import { ConnectionRetry } from './connectionRetry'
 import {
   ConnectionDirection,
   ConnectionType,
@@ -39,13 +41,27 @@ describe('connectToDisconnectedPeers', () => {
 
   it('Should connect to disconnected unidentified peers with an address', () => {
     const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
+
     const peer = pm.getOrCreatePeer(null)
     peer.setWebSocketAddress('testuri.com', 9033)
+    pm['tryDisposePeer'](peer)
+
+    pm.peerCandidateMap.set(peer.getWebSocketAddress(), {
+      address: 'testuri.com',
+      port: 9033,
+      neighbors: new Set(),
+      webRtcRetry: new ConnectionRetry(),
+      websocketRetry: new ConnectionRetry(),
+      localRequestedDisconnectUntil: null,
+      peerRequestedDisconnectUntil: null,
+    })
+
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
     pcm.start()
-    expect(peer.state).toEqual({
+    expect(pm.peers.length).toBe(1)
+    expect(pm.peers[0].state).toEqual({
       type: 'CONNECTING',
-      identity: null,
+      identity: peer.getWebSocketAddress(),
       connections: {
         webSocket: expect.any(WebSocketConnection),
       },
@@ -56,20 +72,30 @@ describe('connectToDisconnectedPeers', () => {
     const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
     const identity = mockIdentity('peer')
-    const peer = pm.getOrCreatePeer(identity)
-    peer.setWebSocketAddress('testuri.com', 9033)
+    pm.peerCandidateMap.set(identity, {
+      address: 'testuri.com',
+      port: 9033,
+      neighbors: new Set(),
+      webRtcRetry: new ConnectionRetry(),
+      websocketRetry: new ConnectionRetry(),
+      localRequestedDisconnectUntil: null,
+      peerRequestedDisconnectUntil: null,
+    })
 
     // We want to test websocket only
-    pm.getConnectionRetry(
+    const retry = pm.getConnectionRetry(
       identity,
       ConnectionType.WebRtc,
       ConnectionDirection.Outbound,
-    )?.neverRetryConnecting()
+    )
+    Assert.isNotNull(retry)
+    retry.neverRetryConnecting()
 
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
     pcm.start()
 
-    expect(peer.state).toEqual({
+    expect(pm.peers.length).toBe(1)
+    expect(pm.peers[0].state).toEqual({
       type: 'CONNECTING',
       identity: identity,
       connections: { webSocket: expect.any(WebSocketConnection) },
@@ -80,13 +106,15 @@ describe('connectToDisconnectedPeers', () => {
     const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
 
     const identity = mockIdentity('peer')
-    const peer = peers.getOrCreatePeer(identity)
-    peer.setWebSocketAddress('testuri.com', 9033)
-
-    // Check both connections are eligible to connect to
-    expect(peers.canConnectToWebRTC(peer)).toBe(true)
-    expect(peers.canConnectToWebSocket(peer)).toBe(true)
-    expect(peer.state.type).toBe('DISCONNECTED')
+    peers.peerCandidateMap.set(identity, {
+      address: 'testuri.com',
+      port: 9033,
+      neighbors: new Set(),
+      webRtcRetry: new ConnectionRetry(),
+      websocketRetry: new ConnectionRetry(),
+      localRequestedDisconnectUntil: null,
+      peerRequestedDisconnectUntil: null,
+    })
 
     const peerConnections = new PeerConnectionManager(peers, createRootLogger(), {
       maxPeers: 50,
@@ -94,6 +122,8 @@ describe('connectToDisconnectedPeers', () => {
     peerConnections.start()
 
     // Check now that were connecting to websockets and webrtc failed
+    expect(peers.peers.length).toBe(1)
+    const peer = peers.peers[0]
     expect(peers.canConnectToWebRTC(peer)).toBe(false)
     expect(peers.canConnectToWebSocket(peer)).toBe(false)
     expect(peer.state).toEqual({
@@ -110,18 +140,30 @@ describe('connectToDisconnectedPeers', () => {
       mockHostsStore(),
     )
     const { peer: brokeringPeer } = getConnectedPeer(pm, 'brokering')
-    const peer = pm.getOrCreatePeer(peerIdentity)
     // Link the peers
-    pm.peerCandidateMap
-      .get(brokeringPeer.getIdentityOrThrow())
-      ?.neighbors.add(peer.getIdentityOrThrow())
-    pm.peerCandidateMap
-      .get(peer.getIdentityOrThrow())
-      ?.neighbors.add(brokeringPeer.getIdentityOrThrow())
+    pm.peerCandidateMap.set(brokeringPeer.getIdentityOrThrow(), {
+      address: null,
+      port: null,
+      neighbors: new Set([peerIdentity]),
+      webRtcRetry: new ConnectionRetry(),
+      websocketRetry: new ConnectionRetry(),
+      localRequestedDisconnectUntil: null,
+      peerRequestedDisconnectUntil: null,
+    })
+    pm.peerCandidateMap.set(peerIdentity, {
+      address: null,
+      port: null,
+      neighbors: new Set([brokeringPeer.getIdentityOrThrow()]),
+      webRtcRetry: new ConnectionRetry(),
+      websocketRetry: new ConnectionRetry(),
+      localRequestedDisconnectUntil: null,
+      peerRequestedDisconnectUntil: null,
+    })
 
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
     pcm.start()
 
+    const peer = pm.getPeerOrThrow(peerIdentity)
     expect(peer.state).toEqual({
       type: 'CONNECTING',
       identity: peerIdentity,

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -18,6 +18,11 @@ const EVENT_LOOP_MS = 2000
 const CONNECT_ATTEMPTS_MAX = 5
 
 /**
+ * The maximum number of connection upgrades each eventloop tick
+ */
+const UPGRADE_ATTEMPTS_MAX = 5
+
+/**
  * PeerConnectionManager periodically determines whether to open new connections and/or
  * close existing connections on peers.
  */
@@ -64,25 +69,40 @@ export class PeerConnectionManager {
   }
 
   private eventLoop() {
-    let connectAttempts = 0
-
-    const shuffledPeers = ArrayUtils.shuffle(this.peerManager.peers)
-
-    for (const peer of shuffledPeers) {
+    let upgradeAttempts = 0
+    for (const peer of this.peerManager.peers) {
       this.maintainOneConnectionPerPeer(peer)
 
-      if (connectAttempts >= CONNECT_ATTEMPTS_MAX) {
+      if (upgradeAttempts >= UPGRADE_ATTEMPTS_MAX) {
         continue
-      }
-      if (this.connectToEligiblePeers(peer)) {
-        connectAttempts++
       }
 
-      if (connectAttempts >= CONNECT_ATTEMPTS_MAX) {
-        continue
-      }
       if (this.attemptToEstablishWebRtcConnectionsToWSPeer(peer)) {
-        connectAttempts++
+        upgradeAttempts++
+      }
+    }
+
+    let connectAttempts = 0
+    const shuffledPeerCandidates = ArrayUtils.shuffle([
+      ...this.peerManager.peerCandidateMap.keys(),
+    ])
+
+    for (const peerCandidateIdentity of shuffledPeerCandidates) {
+      if (connectAttempts >= CONNECT_ATTEMPTS_MAX) {
+        break
+      }
+
+      if (!this.peerManager.identifiedPeers.has(peerCandidateIdentity)) {
+        const val = this.peerManager.peerCandidateMap.get(peerCandidateIdentity)
+        if (val) {
+          const peer = this.peerManager.getOrCreatePeer(peerCandidateIdentity)
+          peer.name = val.name ?? null
+          peer.setWebSocketAddress(val.address, val.port)
+          if (this.connectToEligiblePeers(peer)) {
+            connectAttempts++
+          }
+          // else, maybe delete from peer candidates?
+        }
       }
     }
 

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -100,8 +100,9 @@ export class PeerConnectionManager {
           peer.setWebSocketAddress(val.address, val.port)
           if (this.connectToEligiblePeers(peer)) {
             connectAttempts++
+          } else {
+            this.peerManager.tryDisposePeer(peer)
           }
-          // else, maybe delete from peer candidates?
         }
       }
     }
@@ -110,6 +111,8 @@ export class PeerConnectionManager {
       const peer = this.peerManager.createRandomDisconnectedPeer()
       if (peer && this.connectToEligiblePeers(peer)) {
         connectAttempts++
+      } else if (peer) {
+        this.peerManager.tryDisposePeer(peer)
       }
     }
 

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -119,13 +119,17 @@ export class PeerConnectionManager {
   private connectToEligiblePeers(peer: Peer): boolean {
     if (peer.state.type !== 'CONNECTED') {
       if (this.peerManager.canConnectToWebRTC(peer)) {
+        console.log('attempting webrtc')
         if (this.peerManager.connectToWebRTC(peer)) {
+          console.log('webrtc succ')
           return true
         }
       }
-
+      
       if (this.peerManager.canConnectToWebSocket(peer)) {
+        console.log('attempting ws')
         if (this.peerManager.connectToWebSocket(peer)) {
+          console.log('ws succ')
           return true
         }
       }

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -119,17 +119,13 @@ export class PeerConnectionManager {
   private connectToEligiblePeers(peer: Peer): boolean {
     if (peer.state.type !== 'CONNECTED') {
       if (this.peerManager.canConnectToWebRTC(peer)) {
-        console.log('attempting webrtc')
         if (this.peerManager.connectToWebRTC(peer)) {
-          console.log('webrtc succ')
           return true
         }
       }
-      
+
       if (this.peerManager.canConnectToWebSocket(peer)) {
-        console.log('attempting ws')
         if (this.peerManager.connectToWebSocket(peer)) {
-          console.log('ws succ')
           return true
         }
       }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -1319,7 +1319,9 @@ export class PeerManager {
     }
 
     if (messageSender.state.identity !== null) {
-      this.peerCandidateMap.get(message.sourceIdentity)?.neighbors.add(messageSender.state.identity)
+      this.peerCandidateMap
+        .get(message.sourceIdentity)
+        ?.neighbors.add(messageSender.state.identity)
     }
 
     // Ignore the request if we're at max peers and don't have an existing connection
@@ -1409,7 +1411,9 @@ export class PeerManager {
     }
 
     if (messageSender.state.identity !== null) {
-      this.peerCandidateMap.get(message.sourceIdentity)?.neighbors.add(messageSender.state.identity)
+      this.peerCandidateMap
+        .get(message.sourceIdentity)
+        ?.neighbors.add(messageSender.state.identity)
     }
 
     // Ignore the request if we're at max peers and don't have an existing connection

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -8,7 +8,7 @@ import { Event } from '../../event'
 import { HostsStore } from '../../fileStores/hosts'
 import { createRootLogger, Logger } from '../../logger'
 import { MetricsMonitor } from '../../metrics'
-import { ArrayUtils, ErrorUtils, SetIntervalToken } from '../../utils'
+import { ArrayUtils, SetIntervalToken } from '../../utils'
 import {
   canInitiateWebRTC,
   canKeepDuplicateConnection,
@@ -1155,6 +1155,13 @@ export class PeerManager {
           originalPeer.address !== null
         ) {
           peer.setWebSocketAddress(originalPeer.address, originalPeer.port)
+          const candidate = this.peerCandidateMap.get(identity)
+          if (candidate) {
+            candidate.address = originalPeer.address
+            candidate.port = originalPeer.port
+            // Reset ConnectionRetry since some component of the address changed
+            candidate.websocketRetry.successfulConnection()
+          }
           originalPeer.setWebSocketAddress(null, null)
         }
         peer.setWebSocketConnection(connection)

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -501,7 +501,11 @@ export class PeerManager {
       peer.state.type === 'DISCONNECTED' || peer.state.connections.webSocket === null
 
     const retryOk =
-      this.peerCandidateMap.get(alternateIdentity)?.websocketRetry.canConnect ?? true
+      this.getConnectionRetry(
+        alternateIdentity,
+        ConnectionType.WebSocket,
+        ConnectionDirection.Outbound,
+      )?.canConnect ?? true
 
     return (
       canEstablishNewConnection &&
@@ -534,7 +538,11 @@ export class PeerManager {
       peer.state.type === 'DISCONNECTED' || peer.state.connections.webRtc === undefined
 
     const retryOk =
-      this.peerCandidateMap.get(peer.state.identity)?.webRtcRetry.canConnect ?? true
+      this.getConnectionRetry(
+        peer.state.identity,
+        ConnectionType.WebRtc,
+        ConnectionDirection.Outbound,
+      )?.canConnect ?? true
 
     return canEstablishNewConnection && disconnectOk && hasNoConnection && retryOk
   }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -247,7 +247,6 @@ export class PeerManager {
     peer.peerRequestedDisconnectReason = null
 
     if (peer.state.identity === null) {
-      console.log('no identity')
       return false
     }
 
@@ -266,13 +265,11 @@ export class PeerManager {
       )?.failedConnection(peer.isWhitelisted)
 
       // If we don't have any brokering peers try disposing the peers
-      console.log('no broker')
       this.tryDisposePeer(peer)
       return false
     }
 
     if (canInitiateWebRTC(this.localPeer.publicIdentity, peer.state.identity)) {
-      console.log('initiating')
       this.initWebRtcConnection(peer, true)
       return true
     }
@@ -285,7 +282,6 @@ export class PeerManager {
     const connection = this.initWebRtcConnection(peer, false)
     connection.setState({ type: 'REQUEST_SIGNALING' })
     brokeringPeer.send(signal)
-    console.log('requesting signaling')
     return true
   }
 
@@ -517,14 +513,6 @@ export class PeerManager {
       retryOk = this.peerCandidateMap.get(peer.state.identity)?.webRtcRetry.canConnect ?? false
     }
 
-    console.log(
-      canEstablishNewConnection,
-      disconnectOk,
-      hasNoConnection,
-      retryOk,
-      peer.state.identity !== null,
-    )
-
     return (
       canEstablishNewConnection &&
       disconnectOk &&
@@ -616,7 +604,6 @@ export class PeerManager {
     }
 
     if (peer.state.identity === null) {
-      console.log('gbp - unidentified')
       // Cannot find a brokering peer of an unidentified peer
       return null
     }
@@ -627,14 +614,11 @@ export class PeerManager {
     // The peer candidate map tracks any brokering peer candidates
     const val = this.peerCandidateMap.get(peer.state.identity)
     if (!val) {
-      console.log('gbp - no peer candidate')
       return null
     }
 
     for (const neighbor of val.neighbors) {
-      console.log('neighbor', neighbor)
       const neighborPeer = this.identifiedPeers.get(neighbor)
-      console.log('neighborPeer', neighborPeer)
       if (!neighborPeer || neighborPeer.state.type !== 'CONNECTED') {
         val.neighbors.delete(neighbor)
         continue
@@ -644,7 +628,6 @@ export class PeerManager {
     }
 
     if (candidates.length === 0) {
-      console.log('gbp - no candidate')
       return null
     }
 

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -807,10 +807,7 @@ export class PeerManager {
   start(): void {
     this.requestPeerListHandle = setInterval(() => this.requestPeerList(), 60000)
     this.disposePeersHandle = setInterval(() => this.disposePeers(), 2000)
-    this.savePeerAddressesHandle = setInterval(
-      () => void this.addressManager.save(this.peers),
-      60000,
-    )
+    this.savePeerAddressesHandle = setInterval(() => void this.addressManager.save(), 60000)
   }
 
   /**
@@ -821,7 +818,7 @@ export class PeerManager {
     this.requestPeerListHandle && clearInterval(this.requestPeerListHandle)
     this.disposePeersHandle && clearInterval(this.disposePeersHandle)
     this.savePeerAddressesHandle && clearInterval(this.savePeerAddressesHandle)
-    await this.addressManager.save(this.peers)
+    await this.addressManager.save()
     for (const peer of this.peers) {
       this.disconnect(peer, DisconnectingReason.ShuttingDown, 0)
     }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -196,14 +196,13 @@ export class PeerManager {
         address: url.hostname,
         port: url.port,
         neighbors: new Set(),
-        webRtcRetry: new ConnectionRetry(),
-        websocketRetry: new ConnectionRetry(),
+        webRtcRetry: new ConnectionRetry(isWhitelisted),
+        websocketRetry: new ConnectionRetry(isWhitelisted),
         localRequestedDisconnectUntil: null,
         peerRequestedDisconnectUntil: null,
       })
     }
 
-    peer.isWhitelisted = isWhitelisted
     this.connectToWebSocket(peer)
     return peer
   }
@@ -234,7 +233,7 @@ export class PeerManager {
           peer.state.identity,
           ConnectionType.WebSocket,
           ConnectionDirection.Outbound,
-        )?.failedConnection(peer.isWhitelisted)
+        )?.failedConnection()
       }
 
       return false
@@ -284,7 +283,7 @@ export class PeerManager {
         peer.state.identity,
         ConnectionType.WebRtc,
         ConnectionDirection.Outbound,
-      )?.failedConnection(peer.isWhitelisted)
+      )?.failedConnection()
 
       return false
     }
@@ -469,7 +468,7 @@ export class PeerManager {
           peer.state.identity,
           connection.type,
           connection.direction,
-        )?.failedConnection(peer.isWhitelisted)
+        )?.failedConnection()
       } else if (connection.state.type === 'CONNECTED') {
         this.getConnectionRetry(
           connection.state.identity,
@@ -1080,7 +1079,7 @@ export class PeerManager {
         identity,
         connection.type,
         connection.direction,
-      )?.failedConnection(peer.isWhitelisted)
+      )?.failedConnection()
       peer.close(new Error(`Identity ${identity} does not match expected format`))
       return
     }
@@ -1093,7 +1092,7 @@ export class PeerManager {
         identity,
         connection.type,
         connection.direction,
-      )?.failedConnection(peer.isWhitelisted)
+      )?.failedConnection()
       peer.close(new Error(error))
       return
     }
@@ -1116,7 +1115,7 @@ export class PeerManager {
         identity,
         connection.type,
         connection.direction,
-      )?.failedConnection(peer.isWhitelisted)
+      )?.failedConnection()
       peer.close(new Error(`Peer name length exceeds 32: ${name.length}}`))
       return
     }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -879,10 +879,6 @@ export class PeerManager {
     if (peer.state.type === 'DISCONNECTED') {
       this.addressManager.removePeerAddress(peer)
 
-      this.logger.debug(
-        `Disposing of peer with identity ${String(peer.state.identity)} (may be a duplicate)`,
-      )
-
       peer.dispose()
       if (peer.state.identity && this.identifiedPeers.get(peer.state.identity) === peer) {
         this.identifiedPeers.delete(peer.state.identity)

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -689,24 +689,12 @@ export class PeerManager {
     }
 
     if (peer.state.connections.webRtc?.state.type === 'CONNECTED') {
-      const existingConnection = existingPeer.setWebRtcConnection(peer.state.connections.webRtc)
-      if (existingConnection) {
-        const error = `Replacing duplicate WebRTC connection on ${existingPeer.displayName}`
-        this.logger.debug(ErrorUtils.renderError(new NetworkError(error)))
-        existingConnection.close(new NetworkError(error))
-      }
+      existingPeer.replaceWebRtcConnection(peer.state.connections.webRtc)
       peer.removeConnection(peer.state.connections.webRtc)
     }
 
     if (peer.state.connections.webSocket?.state.type === 'CONNECTED') {
-      const existingConnection = existingPeer.setWebSocketConnection(
-        peer.state.connections.webSocket,
-      )
-      if (existingConnection) {
-        const error = `Replacing duplicate WebSocket connection on ${existingPeer.displayName}`
-        this.logger.debug(ErrorUtils.renderError(new NetworkError(error)))
-        existingConnection.close(new NetworkError(error))
-      }
+      existingPeer.replaceWebSocketConnection(peer.state.connections.webSocket)
       peer.removeConnection(peer.state.connections.webSocket)
     }
 

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -812,6 +812,7 @@ export class PeerManager {
    * outstanding connections.
    */
   async stop(): Promise<void> {
+    this.requestPeerListHandle && clearInterval(this.requestPeerListHandle)
     this.disposePeersHandle && clearInterval(this.disposePeersHandle)
     this.savePeerAddressesHandle && clearInterval(this.savePeerAddressesHandle)
     await this.addressManager.save(this.peers)

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -877,7 +877,7 @@ export class PeerManager {
    * else returns false and does nothing.
    * @param peer The peer to evaluate
    */
-  private tryDisposePeer(peer: Peer) {
+  tryDisposePeer(peer: Peer): boolean {
     if (peer.state.type === 'DISCONNECTED') {
       this.addressManager.removePeerAddress(peer)
 

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -89,6 +89,12 @@ export class PeerManager {
   addressManager: AddressManager
 
   /**
+   * setInterval handle for requestPeerList, which sends out peer lists and
+   * requests for peer lists
+   */
+  private requestPeerListHandle: SetIntervalToken | undefined
+
+  /**
    * setInterval handle for peer disposal, which removes peers from the list that we
    * no longer care about
    */
@@ -793,6 +799,7 @@ export class PeerManager {
   }
 
   start(): void {
+    this.requestPeerListHandle = setInterval(() => this.requestPeerList(), 60000)
     this.disposePeersHandle = setInterval(() => this.disposePeers(), 2000)
     this.savePeerAddressesHandle = setInterval(
       () => void this.addressManager.save(this.peers),
@@ -810,6 +817,14 @@ export class PeerManager {
     await this.addressManager.save(this.peers)
     for (const peer of this.peers) {
       this.disconnect(peer, DisconnectingReason.ShuttingDown, 0)
+    }
+  }
+
+  private requestPeerList() {
+    const peerListRequest = new PeerListRequestMessage()
+
+    for (const peer of this.getConnectedPeers()) {
+      peer.send(peerListRequest)
     }
   }
 

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -1319,6 +1319,10 @@ export class PeerManager {
       })
     }
 
+    if (messageSender.state.identity !== null) {
+      this.peerCandidateMap.get(message.sourceIdentity)?.neighbors.add(messageSender.state.identity)
+    }
+
     // Ignore the request if we're at max peers and don't have an existing connection
     if (this.shouldRejectDisconnectedPeers()) {
       if (!targetPeer || targetPeer.state.type !== 'CONNECTED') {
@@ -1403,6 +1407,10 @@ export class PeerManager {
         )
       }
       return
+    }
+
+    if (messageSender.state.identity !== null) {
+      this.peerCandidateMap.get(message.sourceIdentity)?.neighbors.add(messageSender.state.identity)
     }
 
     // Ignore the request if we're at max peers and don't have an existing connection

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { SignalData } from './connections/webRtcConnection'
+import LRU from 'blru'
 import WSWebSocket from 'ws'
 import { Event } from '../../event'
 import { HostsStore } from '../../fileStores/hosts'
@@ -73,7 +74,7 @@ export class PeerManager {
    */
   peers: Array<Peer> = []
 
-  peerCandidateMap: Map<
+  peerCandidateMap: LRU<
     string,
     {
       name?: string
@@ -83,7 +84,7 @@ export class PeerManager {
       webRtcRetry: ConnectionRetry
       websocketRetry: ConnectionRetry
     }
-  > = new Map()
+  > = new LRU(1000)
 
   addressManager: AddressManager
 
@@ -607,10 +608,10 @@ export class PeerManager {
       // Cannot find a brokering peer of an unidentified peer
       return null
     }
-    
+
     // Find another peer to broker the connection
     const candidates = []
-    
+
     // The peer candidate map tracks any brokering peer candidates
     const val = this.peerCandidateMap.get(peer.state.identity)
     if (!val) {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -288,8 +288,6 @@ export class PeerManager {
         ConnectionDirection.Outbound,
       )?.failedConnection(peer.isWhitelisted)
 
-      // If we don't have any brokering peers try disposing the peers
-      this.tryDisposePeer(peer)
       return false
     }
 

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -259,19 +259,17 @@ export class PeerManager {
       return false
     }
 
-    if (peer.state.identity) {
-      const candidate = this.peerCandidateMap.get(peer.state.identity)
-      if (candidate) {
-        // If we're trying to connect to the peer, we don't care about limiting the peer's connections to us
-        candidate.localRequestedDisconnectUntil = null
-
-        // Clear out peerRequestedDisconnect if we passed it
-        candidate.peerRequestedDisconnectUntil = null
-      }
-    }
-
     if (peer.state.identity === null) {
       return false
+    }
+
+    const candidate = this.peerCandidateMap.get(peer.state.identity)
+    if (candidate) {
+      // If we're trying to connect to the peer, we don't care about limiting the peer's connections to us
+      candidate.localRequestedDisconnectUntil = null
+
+      // Clear out peerRequestedDisconnect if we passed it
+      candidate.peerRequestedDisconnectUntil = null
     }
 
     // Make sure we can find at least one brokering peer before we create the connection

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -156,8 +156,8 @@ export function getSignalingWebRtcPeer(
   const peer = pm.getOrCreatePeer(peerIdentity)
 
   // Link the peers
-  brokeringPeer.knownPeers.set(peerIdentity, peer)
-  peer.knownPeers.set(brokeringPeerIdentity, brokeringPeer)
+  // brokeringPeer.knownPeers.set(peerIdentity, peer)
+  // peer.knownPeers.set(brokeringPeerIdentity, brokeringPeer)
 
   // Verify peer2 is not connected
   expect(peer.address).toBeNull()

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -37,12 +37,6 @@ export function getConnectingPeer(
     peer.setWebSocketConnection(connection)
   }
 
-  if (disposable) {
-    peer
-      .getConnectionRetry(ConnectionType.WebSocket, ConnectionDirection.Outbound)
-      ?.neverRetryConnecting()
-  }
-
   expect(peer.state).toEqual({
     type: 'CONNECTING',
     identity: peer.state.identity,

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import ws from 'ws'
+import { Assert } from '../../assert'
 import { Identity, isIdentity } from '../identity'
 import { IncomingPeerMessage, NetworkMessage } from '../messages/networkMessage'
 import { ConnectionRetry } from '../peers/connectionRetry'
@@ -148,6 +149,11 @@ export function getSignalingWebRtcPeer(
     brokeringPeerIdentity,
   )
   const peer = pm.getOrCreatePeer(peerIdentity)
+
+  // We don't expect this function to be called multiple times, so make sure
+  // we're not resetting pre-existing peer candidate data.
+  Assert.isFalse(pm.peerCandidateMap.has(brokeringPeerIdentity))
+  Assert.isFalse(pm.peerCandidateMap.has(peerIdentity))
 
   // Link the peers
   pm.peerCandidateMap.set(brokeringPeerIdentity, {

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -160,8 +160,8 @@ export function getSignalingWebRtcPeer(
     localRequestedDisconnectUntil: null,
   })
   pm.peerCandidateMap.set(peerIdentity, {
-    address: brokeringPeer.address,
-    port: brokeringPeer.port,
+    address: peer.address,
+    port: peer.port,
     neighbors: new Set([brokeringPeerIdentity]),
     webRtcRetry: new ConnectionRetry(),
     websocketRetry: new ConnectionRetry(),

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -9,7 +9,6 @@ import { ConnectionRetry } from '../peers/connectionRetry'
 import {
   Connection,
   ConnectionDirection,
-  ConnectionType,
   WebRtcConnection,
   WebSocketConnection,
 } from '../peers/connections'
@@ -19,7 +18,6 @@ import { mockIdentity } from './mockIdentity'
 
 export function getConnectingPeer(
   pm: PeerManager,
-  disposable = true,
   direction = ConnectionDirection.Outbound,
   identity?: string | Identity,
 ): { peer: Peer; connection: WebSocketConnection } {
@@ -62,11 +60,10 @@ export function getConnectingPeer(
 
 export function getWaitingForIdentityPeer(
   pm: PeerManager,
-  disposable = true,
   direction = ConnectionDirection.Outbound,
   identity?: string | Identity,
 ): { peer: Peer; connection: WebSocketConnection } {
-  const { peer, connection } = getConnectingPeer(pm, disposable, direction, identity)
+  const { peer, connection } = getConnectingPeer(pm, direction, identity)
   connection.setState({ type: 'WAITING_FOR_IDENTITY' })
 
   expect(peer.state.type).toBe('CONNECTING')
@@ -159,6 +156,8 @@ export function getSignalingWebRtcPeer(
     neighbors: new Set([peerIdentity]),
     webRtcRetry: new ConnectionRetry(),
     websocketRetry: new ConnectionRetry(),
+    peerRequestedDisconnectUntil: null,
+    localRequestedDisconnectUntil: null,
   })
   pm.peerCandidateMap.set(peerIdentity, {
     address: brokeringPeer.address,
@@ -166,6 +165,8 @@ export function getSignalingWebRtcPeer(
     neighbors: new Set([brokeringPeerIdentity]),
     webRtcRetry: new ConnectionRetry(),
     websocketRetry: new ConnectionRetry(),
+    peerRequestedDisconnectUntil: null,
+    localRequestedDisconnectUntil: null,
   })
 
   // Verify peer2 is not connected


### PR DESCRIPTION
## Summary

Opening this as a draft to give some visibility into the work here.

### TODO

* [x] Move connectionRetry out of Peer so we don't have to keep disconnected Peers
* [x] Move disconnectUntil out of Peer so we don't have to keep disconnected Peers
* [x] Measure memory usage before + after
* [x] <s>Cap number of peerCandidates in the peerCandidateMap?</s>
* [x] If memory usage is improved, write a doc + clean it up
* [x] Re-enable fetching Peers on a timer
* [x] <s>Remove tryDispose function</s>
* [x] Fix tests

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
