### PR TITLE
Remove account name from accounts:notes and accounts:transactions output

### DIFF
--- a/ironfish-cli/src/commands/accounts/notes.ts
+++ b/ironfish-cli/src/commands/accounts/notes.ts
@@ -29,14 +29,10 @@ export class NotesCommand extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     const response = client.getAccountNotesStream({ account })
-    let firstResponse = true
 
-    for await (const { account: accountResponse, note } of response.contentStream()) {
-      const noHeader = firstResponse ? false : true
-      if (firstResponse) {
-        this.log(`\n ${accountResponse} - Account notes\n`)
-        firstResponse = false
-      }
+    let showHeader = true
+
+    for await (const note of response.contentStream()) {
       CliUx.ux.table(
         [note],
         {
@@ -61,9 +57,9 @@ export class NotesCommand extends IronfishCommand {
             },
           },
         },
-        { 'no-header': noHeader },
+        { 'no-header': !showHeader },
       )
+      showHeader = false
     }
-    this.log(`\n`)
   }
 }

--- a/ironfish-cli/src/commands/accounts/transactions.ts
+++ b/ironfish-cli/src/commands/accounts/transactions.ts
@@ -35,11 +35,8 @@ export class TransactionsCommand extends IronfishCommand {
     const response = client.getAccountTransactionsStream({ account, hash: flags.hash })
 
     let showHeader = true
-    for await (const { account, transaction } of response.contentStream()) {
-      if (showHeader) {
-        this.log(`\n${account} - Account transactions\n`)
-      }
 
+    for await (const transaction of response.contentStream()) {
       CliUx.ux.table(
         [transaction],
         {

--- a/ironfish/src/rpc/routes/accounts/getNotes.ts
+++ b/ironfish/src/rpc/routes/accounts/getNotes.ts
@@ -8,13 +8,10 @@ import { getAccount } from './utils'
 export type GetAccountNotesStreamRequest = { account?: string }
 
 export type GetAccountNotesStreamResponse = {
-  account: string
-  note: {
-    amount: string
-    memo: string
-    transactionHash: string
-    spent: boolean | undefined
-  }
+  amount: string
+  memo: string
+  transactionHash: string
+  spent: boolean | undefined
 }
 
 export const GetAccountNotesStreamRequestSchema: yup.ObjectSchema<GetAccountNotesStreamRequest> =
@@ -27,15 +24,10 @@ export const GetAccountNotesStreamRequestSchema: yup.ObjectSchema<GetAccountNote
 export const GetAccountNotesStreamResponseSchema: yup.ObjectSchema<GetAccountNotesStreamResponse> =
   yup
     .object({
-      account: yup.string().defined(),
-      note: yup
-        .object({
-          amount: yup.string().defined(),
-          memo: yup.string().trim().defined(),
-          transactionHash: yup.string().defined(),
-          spent: yup.boolean(),
-        })
-        .defined(),
+      amount: yup.string().defined(),
+      memo: yup.string().trim().defined(),
+      transactionHash: yup.string().defined(),
+      spent: yup.boolean(),
     })
     .defined()
 
@@ -47,13 +39,10 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
 
     for await (const { note, spent, transactionHash } of account.getNotes()) {
       request.stream({
-        account: account.displayName,
-        note: {
-          amount: note.value().toString(),
-          memo: note.memo(),
-          transactionHash: transactionHash.toString('hex'),
-          spent,
-        },
+        amount: note.value().toString(),
+        memo: note.memo(),
+        transactionHash: transactionHash.toString('hex'),
+        spent,
       })
     }
 

--- a/ironfish/src/rpc/routes/accounts/getTransactions.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransactions.ts
@@ -13,17 +13,14 @@ import { getAccount, getTransactionStatus } from './utils'
 export type GetAccountTransactionsRequest = { account?: string; hash?: string }
 
 export type GetAccountTransactionsResponse = {
-  account: string
-  transaction: {
-    creator: boolean
-    status: string
-    hash: string
-    isMinersFee: boolean
-    fee: string
-    notesCount: number
-    spendsCount: number
-    expirationSequence: number
-  }
+  creator: boolean
+  status: string
+  hash: string
+  isMinersFee: boolean
+  fee: string
+  notesCount: number
+  spendsCount: number
+  expirationSequence: number
 }
 
 export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTransactionsRequest> =
@@ -37,19 +34,14 @@ export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTra
 export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTransactionsResponse> =
   yup
     .object({
-      account: yup.string().defined(),
-      transaction: yup
-        .object({
-          creator: yup.boolean().defined(),
-          status: yup.string().defined(),
-          hash: yup.string().defined(),
-          isMinersFee: yup.boolean().defined(),
-          fee: yup.string().defined(),
-          notesCount: yup.number().defined(),
-          spendsCount: yup.number().defined(),
-          expirationSequence: yup.number().defined(),
-        })
-        .defined(),
+      creator: yup.boolean().defined(),
+      status: yup.string().defined(),
+      hash: yup.string().defined(),
+      isMinersFee: yup.boolean().defined(),
+      fee: yup.string().defined(),
+      notesCount: yup.number().defined(),
+      spendsCount: yup.number().defined(),
+      expirationSequence: yup.number().defined(),
     })
     .defined()
 
@@ -110,8 +102,5 @@ const streamTransaction = async (
     status,
   }
 
-  request.stream({
-    account: account.name,
-    transaction: serialized,
-  })
+  request.stream(serialized)
 }


### PR DESCRIPTION
## Summary

Remove the account name header from the output for `accounts:notes` and `accounts:transactions` (and correspondingly remove this field from `GetAccountTransactionsResponse` and `GetAccountNotesResponse`. The user either enters the specifies the account or the default account is used, so displaying the account name is redundant.

## Testing Plan

Ran the commands with test notes/transactions.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
