### PR TITLE
Set Error.name on all Error subclass

### DIFF
--- a/ironfish-cli/src/utils/s3.ts
+++ b/ironfish-cli/src/utils/s3.ts
@@ -17,6 +17,7 @@ const MINIMUM_MULTIPART_FILE_SIZE = 5 * 1024 * 1024
 const MAX_MULTIPART_NUM = 10000
 
 class UploadToBucketError extends Error {
+  name = this.constructor.name
   error: unknown | undefined
 
   constructor(message?: string, error?: unknown) {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1329,6 +1329,7 @@ export class Blockchain {
 }
 
 export class VerifyError extends Error {
+  name = this.constructor.name
   reason: VerificationResultReason
   score: number
 

--- a/ironfish/src/mining/stratum/errors.ts
+++ b/ironfish/src/mining/stratum/errors.ts
@@ -5,6 +5,8 @@ import * as yup from 'yup'
 import { StratumServerClient } from './stratumServerClient'
 
 export class MessageMalformedError extends Error {
+  name = this.constructor.name
+
   constructor(sender: string, error: yup.ValidationError | string, method?: string) {
     super()
 

--- a/ironfish/src/network/peers/connections/errors.ts
+++ b/ironfish/src/network/peers/connections/errors.ts
@@ -5,6 +5,7 @@
 import { ErrorUtils } from '../../../utils'
 
 export class NetworkError extends Error {
+  name = this.constructor.name
   wrappedError: unknown | null
 
   constructor(message?: string, wrappedError?: unknown) {
@@ -32,6 +33,8 @@ export class HandshakeTimeoutError extends TimeoutError {
 }
 
 export class CannotSatisfyRequestError extends Error {
+  name = this.constructor.name
+
   constructor(message: string | undefined) {
     super(message)
     this.name = 'CannotSatisfyRequestError'
@@ -39,6 +42,7 @@ export class CannotSatisfyRequestError extends Error {
 }
 
 export class RequestTimeoutError extends Error {
+  name = this.constructor.name
   timeoutMs: number
 
   constructor(timeoutMs: number, message?: string) {

--- a/ironfish/src/rpc/adapters/errors.ts
+++ b/ironfish/src/rpc/adapters/errors.ts
@@ -22,6 +22,7 @@ export enum ERROR_CODES {
  * @note Look at the {@link IPCAdapter} implementation for an example
  */
 export class ResponseError extends Error {
+  name = this.constructor.name
   status: number
   code: string
   error: Error | null = null

--- a/ironfish/src/rpc/clients/errors.ts
+++ b/ironfish/src/rpc/clients/errors.ts
@@ -15,7 +15,9 @@ import { RpcResponse } from '../response'
  * The base class for a connection related error. In case someone wants
  * to log and handle any connection related issues.
  */
-export abstract class RpcConnectionError extends Error {}
+export abstract class RpcConnectionError extends Error {
+  name = this.constructor.name
+}
 
 /**
  * Thrown when the connection attempt has failed for any reason. Most
@@ -32,6 +34,7 @@ export class RpcConnectionLostError extends RpcConnectionError {}
 
 /** Thrown when a response comes back with a code that is between 400 to 500 */
 export class RpcRequestError<TEnd = unknown, TStream = unknown> extends Error {
+  name = this.constructor.name
   response?: RpcResponse<TEnd, TStream> = undefined
   status: number
   code: string

--- a/ironfish/src/storage/database/encoding.ts
+++ b/ironfish/src/storage/database/encoding.ts
@@ -49,7 +49,9 @@ export class BufferEncoding implements IDatabaseEncoding<Buffer> {
   deserialize = (buffer: Buffer): Buffer => buffer
 }
 
-export class PrefixSizeError extends Error {}
+export class PrefixSizeError extends Error {
+  name = this.constructor.name
+}
 
 export class PrefixEncoding<TPrefix, TKey> implements IDatabaseEncoding<[TPrefix, TKey]> {
   readonly keyEncoding: IDatabaseEncoding<TKey>

--- a/ironfish/src/storage/database/errors.ts
+++ b/ironfish/src/storage/database/errors.ts
@@ -3,14 +3,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export class TransactionWrongDatabaseError extends Error {
+  name = this.constructor.name
+
   constructor(store: string) {
     super(`Wrong transaction database when using store ${store}`)
   }
 }
 
-export class DuplicateKeyError extends Error {}
+export class DuplicateKeyError extends Error {
+  name = this.constructor.name
+}
 
 export class DatabaseOpenError extends Error {
+  name = this.constructor.name
+
   constructor(message?: string, error?: Error) {
     super(message ?? error?.message)
 

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -19,7 +19,9 @@ const SYNCER_TICK_MS = 10 * 1000
 const LINEAR_ANCESTOR_SEARCH = 3
 const REQUEST_BLOCKS_PER_MESSAGE = 20
 
-class AbortSyncingError extends Error {}
+class AbortSyncingError extends Error {
+  name = this.constructor.name
+}
 
 export class Syncer {
   readonly peerNetwork: PeerNetwork

--- a/ironfish/src/utils/json.ts
+++ b/ironfish/src/utils/json.ts
@@ -5,6 +5,7 @@ import parseJson, { JSONError } from 'parse-json'
 import { Assert } from '../assert'
 
 export class ParseJsonError extends Error {
+  name = this.constructor.name
   jsonMessage: string
   jsonFileName: string
   jsonCodeFrame: string

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -3,5 +3,5 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export class NotEnoughFundsError extends Error {
-    name = this.constructor.name
+  name = this.constructor.name
 }

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -2,4 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export class NotEnoughFundsError extends Error {}
+export class NotEnoughFundsError extends Error {
+    name = this.constructor.name
+}

--- a/ironfish/src/workerPool/tasks/jobAbort.ts
+++ b/ironfish/src/workerPool/tasks/jobAbort.ts
@@ -22,6 +22,7 @@ export class JobAbortedMessage extends WorkerMessage {
 }
 
 export class JobAbortedError extends Error {
+  name = this.constructor.name
   type = 'JobAbortedError'
 
   constructor() {

--- a/ironfish/src/workerPool/tasks/jobError.ts
+++ b/ironfish/src/workerPool/tasks/jobError.ts
@@ -88,6 +88,7 @@ export class JobErrorMessage extends WorkerMessage {
 }
 
 export class JobError extends Error {
+  name = this.constructor.name
   type = 'JobError'
   code: string | undefined = undefined
 


### PR DESCRIPTION
## Summary

So it renders properly inside of Error.toString()

Resolves https://linear.app/ironfish/issue/IRO-2155

## Testing Plan

Create any subclass of an `Error` and use `toString()`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
