### PR TITLE
Stop streaming when the connection is closed

### DIFF
--- a/ironfish/src/rpc/routes/accounts/getNotes.ts
+++ b/ironfish/src/rpc/routes/accounts/getNotes.ts
@@ -38,6 +38,9 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
     const account = getAccount(node, request.data.account)
 
     for await (const { note, spent, transactionHash } of account.getNotes()) {
+      if (request.closed) {
+        break
+      }
       request.stream({
         amount: note.value().toString(),
         memo: note.memo(),

--- a/ironfish/src/rpc/routes/accounts/getNotes.ts
+++ b/ironfish/src/rpc/routes/accounts/getNotes.ts
@@ -41,6 +41,7 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
       if (request.closed) {
         break
       }
+
       request.stream({
         amount: note.value().toString(),
         memo: note.memo(),

--- a/ironfish/src/rpc/routes/accounts/getTransactions.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransactions.ts
@@ -67,6 +67,7 @@ router.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactio
       if (request.closed) {
         break
       }
+
       await streamTransaction(request, node, account, transaction)
     }
 

--- a/ironfish/src/rpc/routes/accounts/getTransactions.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransactions.ts
@@ -64,6 +64,9 @@ router.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactio
     }
 
     for await (const transaction of account.getTransactions()) {
+      if (request.closed) {
+        break
+      }
       await streamTransaction(request, node, account, transaction)
     }
 

--- a/ironfish/src/rpc/routes/mining/exportMined.ts
+++ b/ironfish/src/rpc/routes/mining/exportMined.ts
@@ -84,6 +84,7 @@ router.register<typeof ExportMinedStreamRequestSchema, ExportMinedStreamResponse
       if (request.closed) {
         break
       }
+
       request.stream({
         start,
         stop,

--- a/ironfish/src/rpc/routes/mining/exportMined.ts
+++ b/ironfish/src/rpc/routes/mining/exportMined.ts
@@ -81,6 +81,9 @@ router.register<typeof ExportMinedStreamRequestSchema, ExportMinedStreamResponse
       start,
       stop,
     })) {
+      if (request.closed) {
+        break
+      }
       request.stream({
         start,
         stop,


### PR DESCRIPTION
## Summary

Fix the bug where some RPCs continue streaming when the request is closed.

## Testing Plan

Ran commands locally.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
