### PR TITLE
adds rpc:token cli command

### DIFF
--- a/ironfish-cli/src/commands/rpc/token.ts
+++ b/ironfish-cli/src/commands/rpc/token.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../../command'
+import { LocalFlags } from '../../flags'
+
+export default class Token extends IronfishCommand {
+  static description = 'Get or set the RPC auth token'
+
+  static flags = {
+    ...LocalFlags,
+    token: Flags.string({
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
+      required: false,
+      description: 'Set the RPC auth token to <value>',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(Token)
+
+    const internal = this.sdk.internal
+
+    const token = internal.get('rpcAuthToken')
+
+    if (flags.token) {
+      internal.set('rpcAuthToken', flags.token)
+      await internal.save()
+
+      this.log(`RPC auth token changed from ${token} to ${flags.token}`)
+    } else {
+      if (token) {
+        this.log(`RPC auth token: ${token}`)
+      } else {
+        this.log('No RPC auth token found.')
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

adds a command to retrieve or set the value of the rpcAuthToken key in internal.json

`ironfish rpc:token` prints out the token, if any.

`ironfish rpc:token --token=<value>` sets the token.

Closes https://airtable.com/appIXmGgVqP9QdbCf/pagcUNImP87iLU1r7?FG6K5=recUzR97TjxBboY00

## Testing Plan

![image](https://user-images.githubusercontent.com/57735705/193958473-88b7e290-ae54-470c-a1df-468c7f2c47aa.png)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
