### PR TITLE
Drop notes where their transaction is missing

### DIFF
--- a/ironfish/src/migrations/data/013-wallet-2.ts
+++ b/ironfish/src/migrations/data/013-wallet-2.ts
@@ -275,7 +275,12 @@ export class Migration013 extends Migration {
     )) {
       const noteHash = Buffer.from(noteHashHex, 'hex')
       const transactionHash = await noteToTransaction.get(noteHash)
-      Assert.isNotUndefined(transactionHash)
+
+      if (!transactionHash) {
+        countMissingTx++
+        speed.add(1)
+        continue
+      }
 
       const transaction = await transactionsCache.get(transactionHash)
 


### PR DESCRIPTION
## Summary

User's are hitting this when running migration 13. We can only just drop these TX, similar to if the TX is missing from the cahce. Unsure how user's DB's are getting into this state. It could be left over data from deleted accounts.

## Testing Plan

Run migration on accounts at version 12, and comment out updating the transactionCache so all TX will be missing.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
