### PR TITLE
Dont materialize unspent notes when creating a tx

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -303,7 +303,7 @@ export class Config extends KeyStore<ConfigOptions> {
       tlsKeyPath: files.resolve(files.join(dataDir, 'certs', 'node-key.pem')),
       tlsCertPath: files.resolve(files.join(dataDir, 'certs', 'node-cert.pem')),
       maxPeers: 50,
-      minimumBlockConfirmations: 12,
+      minimumBlockConfirmations: 2,
       minPeers: 1,
       targetPeers: 50,
       telemetryApi: DEFAULT_TELEMETRY_API,

--- a/ironfish/src/rpc/routes/accounts/getTransactions.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransactions.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { IronfishNode } from '../../../node'
-import { IDatabaseTransaction } from '../../../storage'
 import { Account } from '../../../wallet/account'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { RpcRequest } from '../../request'
@@ -86,7 +85,6 @@ const streamTransaction = async (
   transaction: TransactionValue,
   options?: {
     headSequence?: number | null
-    tx?: IDatabaseTransaction
   },
 ): Promise<void> => {
   const serializedTransaction = serializeRpcAccountTransaction(transaction)

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -91,16 +91,17 @@ export class Account {
     }
   }
 
-  async *getUnspentNotes(): AsyncGenerator<{
-    hash: Buffer
-    index: number | null
-    note: Note
-    transactionHash: Buffer
-  }> {
+  async *getUnspentNotes(): AsyncGenerator<DecryptedNoteValue & { hash: Buffer }> {
     for await (const decryptedNote of this.getNotes()) {
-      if (!decryptedNote.spent) {
-        yield decryptedNote
+      if (decryptedNote.spent) {
+        continue
       }
+
+      if (!decryptedNote.index) {
+        continue
+      }
+
+      yield decryptedNote
     }
   }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -693,11 +693,8 @@ export class Wallet {
     try {
       this.assertHasAccount(sender)
 
-      // check if the chain data is fully synced
       if (!this.isAccountUpToDate(sender)) {
-        throw new Error(
-          `Your node must be synced with the Iron Fish network to send a transaction. `,
-        )
+        throw new Error('Your account must finish scanning before sending a transaction.')
       }
 
       // TODO: If we're spending from multiple accounts, we need to figure out a

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -22,6 +22,7 @@ import { Account } from './account'
 import { NotEnoughFundsError } from './errors'
 import { validateAccount } from './validator'
 import { AccountValue } from './walletdb/accountValue'
+import { DecryptedNoteValue } from './walletdb/decryptedNoteValue'
 import { TransactionValue } from './walletdb/transactionValue'
 import { WalletDB } from './walletdb/walletdb'
 
@@ -597,54 +598,44 @@ export class Wallet {
     })
   }
 
-  private async getUnspentNotes(account: Account): Promise<
-    ReadonlyArray<{
-      hash: Buffer
-      note: Note
-      index: number | null
-      confirmed: boolean
-    }>
-  > {
-    const minimumBlockConfirmations = this.config.get('minimumBlockConfirmations')
-    const notes = []
-    const unspentNotes = account.getUnspentNotes()
+  private async *getUnspentNotes(
+    account: Account,
+    options?: {
+      minimumBlockConfirmations?: number
+    },
+  ): AsyncGenerator<DecryptedNoteValue & { hash: Buffer }> {
+    const minimumBlockConfirmations =
+      options?.minimumBlockConfirmations ?? this.config.get('minimumBlockConfirmations')
 
-    for await (const { hash, note, index, transactionHash } of unspentNotes) {
-      let confirmed = false
+    const headSequence = await this.getAccountHeadSequence(account)
+    if (!headSequence) {
+      return
+    }
 
-      if (transactionHash) {
-        const transaction = await account.getTransaction(transactionHash)
+    for await (const decryptedNote of account.getUnspentNotes()) {
+      if (minimumBlockConfirmations > 0) {
+        const transaction = await account.getTransaction(decryptedNote.transactionHash)
+
         Assert.isNotUndefined(
           transaction,
-          `Transaction '${transactionHash.toString('hex')}' missing for account '${
-            account.id
-          }'`,
+          `Transaction '${decryptedNote.transactionHash.toString(
+            'hex',
+          )}' missing for account '${account.id}'`,
         )
-        const { blockHash } = transaction
 
-        if (blockHash) {
-          const header = await this.chain.getHeader(blockHash)
-          Assert.isNotNull(
-            header,
-            `getUnspentNotes: No header found for hash ${blockHash.toString('hex')}`,
-          )
-          const main = await this.chain.isHeadChain(header)
-          if (main) {
-            const confirmations = this.chain.head.sequence - header.sequence
-            confirmed = confirmations >= minimumBlockConfirmations
-          }
+        if (!transaction.sequence) {
+          continue
+        }
+
+        const confirmations = headSequence - transaction.sequence
+
+        if (confirmations < minimumBlockConfirmations) {
+          continue
         }
       }
 
-      notes.push({
-        confirmed,
-        hash,
-        index,
-        note,
-      })
+      yield decryptedNote
     }
-
-    return notes
   }
 
   async pay(
@@ -697,75 +688,54 @@ export class Wallet {
         throw new Error('Your account must finish scanning before sending a transaction.')
       }
 
-      // TODO: If we're spending from multiple accounts, we need to figure out a
-      // way to split the transaction fee. - deekerno
-      let amountNeeded =
+      const amountNeeded =
         receives.reduce((acc, receive) => acc + receive.amount, BigInt(0)) + transactionFee
 
-      const notesToSpend: Array<{ note: Note; witness: NoteWitness }> = []
-      const unspentNotes = await this.getUnspentNotes(sender)
+      let amount = BigInt(0)
 
-      for (const unspentNote of unspentNotes) {
-        // Skip unconfirmed notes
-        if (unspentNote.index === null || !unspentNote.confirmed) {
+      const notesToSpend: Array<{ note: Note; witness: NoteWitness }> = []
+
+      for await (const unspentNote of this.getUnspentNotes(sender)) {
+        if (unspentNote.note.value() <= BigInt(0)) {
           continue
         }
 
-        if (unspentNote.note.value() > BigInt(0)) {
-          // Double-check that the nullifier for the note isn't in the tree already
-          // This would indicate a bug in the account transaction stores
-          const nullifier = Buffer.from(
-            unspentNote.note.nullifier(sender.spendingKey, BigInt(unspentNote.index)),
-          )
+        Assert.isNotNull(unspentNote.index)
+        Assert.isNotNull(unspentNote.nullifier)
 
-          if (await this.chain.nullifiers.contains(nullifier)) {
-            this.logger.debug(
-              `Note was marked unspent, but nullifier found in tree: ${nullifier.toString(
-                'hex',
-              )}`,
-            )
-
-            // Update our map so this doesn't happen again
-            const noteMapValue = await sender.getDecryptedNote(unspentNote.hash)
-            if (noteMapValue) {
-              this.logger.debug(`Unspent note has index ${String(noteMapValue.index)}`)
-              await sender.updateDecryptedNote(unspentNote.hash, {
-                ...noteMapValue,
-                spent: true,
-              })
-            }
-
-            // Move on to the next note
-            continue
-          }
-
-          // Try creating a witness from the note
-          const witness = await this.chain.notes.witness(unspentNote.index)
-
-          if (witness === null) {
-            this.logger.debug(
-              `Could not create a witness for note with index ${unspentNote.index}`,
-            )
-            continue
-          }
-
-          // Otherwise, push the note into the list of notes to spend
-          this.logger.debug(
-            `Accounts: spending note ${unspentNote.index} ${unspentNote.hash.toString(
-              'hex',
-            )} ${unspentNote.note.value()}`,
-          )
-          notesToSpend.push({ note: unspentNote.note, witness: witness })
-          amountNeeded -= unspentNote.note.value()
+        if (await this.checkNoteOnChainAndRepair(sender, unspentNote)) {
+          continue
         }
 
-        if (amountNeeded <= 0) {
+        // Try creating a witness from the note
+        const witness = await this.chain.notes.witness(unspentNote.index)
+
+        if (witness === null) {
+          this.logger.debug(
+            `Could not create a witness for note with index ${unspentNote.index}`,
+          )
+          continue
+        }
+
+        this.logger.debug(
+          `Accounts: spending note ${unspentNote.index} ${unspentNote.hash.toString(
+            'hex',
+          )} ${unspentNote.note.value()}`,
+        )
+
+        // Otherwise, push the note into the list of notes to spend
+        notesToSpend.push({ note: unspentNote.note, witness: witness })
+        amount += unspentNote.note.value()
+
+        if (amount >= amountNeeded) {
           break
         }
       }
 
-      if (amountNeeded > 0) {
-        throw new NotEnoughFundsError('Insufficient funds')
+      if (amount < amountNeeded) {
+        throw new NotEnoughFundsError(
+          `Insufficient funds: Needed ${amountNeeded.toString()} but have ${amount.toString()}`,
+        )
       }
 
       return this.workerPool.createTransaction(
@@ -783,6 +753,49 @@ export class Wallet {
     } finally {
       unlock()
     }
+  }
+
+  /**
+   * Checks if a note is already on the chain when trying to spend it
+   *
+   * This function should be deleted once the wallet is detached from the chain,
+   * either way. It shouldn't be neccessary. It's just a hold over function to
+   * sanity check from wallet 1.0.
+   *
+   * @returns true if the note is on the chain already
+   */
+  private async checkNoteOnChainAndRepair(
+    sender: Account,
+    unspentNote: DecryptedNoteValue & { hash: Buffer },
+  ): Promise<boolean> {
+    if (!unspentNote.nullifier) {
+      return false
+    }
+
+    const spent = await this.chain.nullifiers.contains(unspentNote.nullifier)
+
+    if (!spent) {
+      return false
+    }
+
+    this.logger.debug(
+      `Note was marked unspent, but nullifier found in tree: ${unspentNote.nullifier.toString(
+        'hex',
+      )}`,
+    )
+
+    // Update our map so this doesn't happen again
+    const noteMapValue = await sender.getDecryptedNote(unspentNote.hash)
+
+    if (noteMapValue) {
+      this.logger.debug(`Unspent note has index ${String(noteMapValue.index)}`)
+      await sender.updateDecryptedNote(unspentNote.hash, {
+        ...noteMapValue,
+        spent: true,
+      })
+    }
+
+    return true
   }
 
   broadcastTransaction(transaction: Transaction): void {
@@ -914,12 +927,15 @@ export class Wallet {
     transaction: TransactionValue,
     options?: {
       headSequence?: number | null
-      tx?: IDatabaseTransaction
+      minimumBlockConfirmations?: number
     },
+    tx?: IDatabaseTransaction,
   ): Promise<TransactionStatus> {
-    const minimumBlockConfirmations = this.config.get('minimumBlockConfirmations')
+    const minimumBlockConfirmations =
+      options?.minimumBlockConfirmations ?? this.config.get('minimumBlockConfirmations')
+
     const headSequence =
-      options?.headSequence ?? (await this.getAccountHeadSequence(account, options?.tx))
+      options?.headSequence ?? (await this.getAccountHeadSequence(account, tx))
 
     if (!headSequence) {
       return TransactionStatus.UNKNOWN


### PR DESCRIPTION
## Summary

This loaded all TX when creating a note and joinin its related
transaction to get its sequence.

## Testing Plan
Run existing tests, and try creating a transaction on a big account.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
