### PR TITLE
Update rpc protect rules with auth

### DIFF
--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -25,7 +25,11 @@ export enum ApiNamespace {
   rpc = 'rpc',
 }
 
-export const API_NAMESPACES_PROTECTED = [ApiNamespace.account, ApiNamespace.config]
+export const API_NAMESPACES_PROTECTED = [
+  ApiNamespace.account,
+  ApiNamespace.config,
+  ApiNamespace.transaction,
+]
 export const ALL_API_NAMESPACES = StrEnumUtils.getValues(ApiNamespace)
 
 export type RouteHandler<TRequest = unknown, TResponse = unknown> = (

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -208,11 +208,9 @@ export class IronfishSdk {
     })
 
     if (this.config.get('enableRpcIpc')) {
-      const namespaces = ALL_API_NAMESPACES
-
       await node.rpc.mount(
         new RpcIpcAdapter(
-          namespaces,
+          ALL_API_NAMESPACES,
           {
             mode: 'ipc',
             socketPath: this.config.get('ipcPath'),
@@ -241,7 +239,7 @@ export class IronfishSdk {
             this.config.get('tlsCertPath'),
             node,
             this.logger,
-            namespaces,
+            ALL_API_NAMESPACES,
           ),
         )
       } else {


### PR DESCRIPTION
## Summary
1. Move transaction based routes to protected for rpc request over tcp as mentioned before. https://github.com/iron-fish/ironfish/pull/2131
2. Since we have activated auth system for rpc request over tls, we should use all namespace for request over tls and auth system is responsible for rpc security.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
