### PR TITLE
Update transaction statuses text

### DIFF
--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -541,7 +541,7 @@ describe('Accounts', () => {
         },
       )
 
-      expect(transactionStatus).toEqual(TransactionStatus.UNCONFIRMED)
+      expect(transactionStatus).toEqual(TransactionStatus.CONFIRMING)
     })
 
     it('should show confirmed transactions as confirmed', async () => {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -29,7 +29,7 @@ export enum TransactionStatus {
   CONFIRMED = 'confirmed',
   EXPIRED = 'expired',
   PENDING = 'pending',
-  UNCONFIRMED = 'unconfirmed',
+  CONFIRMING = 'confirming',
   UNKNOWN = 'unknown',
 }
 
@@ -931,7 +931,7 @@ export class Wallet {
     if (transaction.sequence) {
       const isConfirmed = headSequence - transaction.sequence >= minimumBlockConfirmations
 
-      return isConfirmed ? TransactionStatus.CONFIRMED : TransactionStatus.UNCONFIRMED
+      return isConfirmed ? TransactionStatus.CONFIRMED : TransactionStatus.CONFIRMING
     } else {
       const isExpired = this.chain.verifier.isExpiredSequence(
         transaction.transaction.expirationSequence(),


### PR DESCRIPTION
## Summary
Update for https://github.com/iron-fish/ironfish/issues/2317. Changing `unconfirmed` to `confirming` for transaction statuses.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
