### PR TITLE
reverts to unzipping and moving snapshot download

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -227,6 +227,11 @@ export default class Download extends IronfishCommand {
       }
     }
 
+    // use a standard name, 'snapshot', for the unzipped database
+    const snapshotDatabasePath = this.sdk.fileSystem.join(this.sdk.config.tempDir, 'snapshot')
+    await fsAsync.mkdir(snapshotDatabasePath, { recursive: true })
+    await this.unzip(snapshotPath, snapshotDatabasePath)
+
     const chainDatabasePath = this.sdk.fileSystem.resolve(this.sdk.config.chainDatabasePath)
 
     // chainDatabasePath must be empty before unzipping snapshot
@@ -236,10 +241,11 @@ export default class Download extends IronfishCommand {
     await fsAsync.rm(chainDatabasePath, { recursive: true, force: true, maxRetries: 10 })
     CliUx.ux.action.stop('done')
 
-    // ensure that chainDatabasePath exists
-    await fsAsync.mkdir(chainDatabasePath, { recursive: true })
-
-    await this.unzip(snapshotPath, chainDatabasePath)
+    CliUx.ux.action.start(
+      `Moving snapshot files from ${snapshotDatabasePath} to ${chainDatabasePath}`,
+    )
+    await fsAsync.rename(snapshotDatabasePath, chainDatabasePath)
+    CliUx.ux.action.stop('done')
 
     if (flags.cleanup) {
       CliUx.ux.action.start(`Cleaning up snapshot file at ${snapshotPath}`)


### PR DESCRIPTION
## Summary

some users have run into errors when downloading snapshots when they do not have enough space for both the snapshot archive and the unzipped snapshot. unzipping directly into place has the unfortunate side-effect of leaving the node in an unrecoverable state if the unzipping operation fails: the download process removes all files from the database before beginning to unzip.

these changes revert to unzipping to a temporary location before moving the snapshot files into the database

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
