### PR TITLE
Remove rpcTcpSecure CLI flag

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -21,8 +21,6 @@ import {
   RpcAuthFlagKey,
   RpcTcpHostFlagKey,
   RpcTcpPortFlagKey,
-  RpcTcpSecureFlag,
-  RpcTcpSecureFlagKey,
   RpcTcpTlsFlag,
   RpcTcpTlsFlagKey,
   RpcUseIpcFlag,
@@ -45,7 +43,6 @@ export type FLAGS =
   | typeof RpcUseTcpFlagKey
   | typeof RpcTcpHostFlagKey
   | typeof RpcTcpPortFlagKey
-  | typeof RpcTcpSecureFlagKey
   | typeof RpcTcpTlsFlagKey
   | typeof VerboseFlagKey
   | typeof RpcAuthFlagKey
@@ -137,14 +134,6 @@ export abstract class IronfishCommand extends Command {
     const rpcTcpPortFlag = getFlag(flags, RpcTcpPortFlagKey)
     if (typeof rpcTcpPortFlag === 'number') {
       configOverrides.rpcTcpPort = rpcTcpPortFlag
-    }
-
-    const rpcTcpSecureFlag = getFlag(flags, RpcTcpSecureFlagKey)
-    if (
-      typeof rpcTcpSecureFlag === 'boolean' &&
-      rpcTcpSecureFlag !== RpcTcpSecureFlag.default
-    ) {
-      configOverrides.rpcTcpSecure = rpcTcpSecureFlag
     }
 
     const rpcTcpTlsFlag = getFlag(flags, RpcTcpTlsFlagKey)

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -22,7 +22,6 @@ export const RpcUseIpcFlagKey = 'rpc.ipc'
 export const RpcUseTcpFlagKey = 'rpc.tcp'
 export const RpcTcpHostFlagKey = 'rpc.tcp.host'
 export const RpcTcpPortFlagKey = 'rpc.tcp.port'
-export const RpcTcpSecureFlagKey = 'rpc.tcp.secure'
 export const RpcTcpTlsFlagKey = 'rpc.tcp.tls'
 export const RpcAuthFlagKey = 'rpc.auth'
 
@@ -72,11 +71,6 @@ export const RpcTcpPortFlag = Flags.integer({
   description: 'The TCP port to listen for connections on',
 })
 
-export const RpcTcpSecureFlag = Flags.boolean({
-  default: false,
-  description: 'Allow sensitive config to be changed over TCP',
-})
-
 export const RpcTcpTlsFlag = Flags.boolean({
   default: DEFAULT_USE_RPC_TLS,
   description: 'Encrypt TCP connection to the RPC over TLS',
@@ -107,7 +101,6 @@ remoteFlags[RpcUseTcpFlagKey] = RpcUseTcpFlag as unknown as CompletableOptionFla
 remoteFlags[RpcUseIpcFlagKey] = RpcUseIpcFlag as unknown as CompletableOptionFlag
 remoteFlags[RpcTcpHostFlagKey] = RpcTcpHostFlag as unknown as CompletableOptionFlag
 remoteFlags[RpcTcpPortFlagKey] = RpcTcpPortFlag as unknown as CompletableOptionFlag
-remoteFlags[RpcTcpSecureFlagKey] = RpcTcpSecureFlag as unknown as CompletableOptionFlag
 remoteFlags[RpcTcpTlsFlagKey] = RpcTcpTlsFlag as unknown as CompletableOptionFlag
 remoteFlags[RpcAuthFlagKey] = RpcAuthFlag as unknown as CompletableOptionFlag
 

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -103,7 +103,6 @@ export type ConfigOptions = {
   peerPort: number
   rpcTcpHost: string
   rpcTcpPort: number
-  rpcTcpSecure: boolean
   tlsKeyPath: string
   tlsCertPath: string
   /**
@@ -301,7 +300,6 @@ export class Config extends KeyStore<ConfigOptions> {
       peerPort: DEFAULT_WEBSOCKET_PORT,
       rpcTcpHost: 'localhost',
       rpcTcpPort: 8020,
-      rpcTcpSecure: false,
       tlsKeyPath: files.resolve(files.join(dataDir, 'certs', 'node-key.pem')),
       tlsCertPath: files.resolve(files.join(dataDir, 'certs', 'node-cert.pem')),
       maxPeers: 50,

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -119,7 +119,6 @@ describe('IronfishSdk', () => {
         const sdk = await IronfishSdk.init({
           configOverrides: {
             enableRpcTcp: true,
-            rpcTcpSecure: true,
           },
         })
 
@@ -157,7 +156,6 @@ describe('IronfishSdk', () => {
         configOverrides: {
           enableRpcTcp: true,
           enableRpcTls: false,
-          rpcTcpSecure: true,
         },
       })
 


### PR DESCRIPTION
## Summary

This flag was unused, removing it should also trigger people to know that something important has changed in our security model.

## Testing Plan
Try to pass in the flag

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
