### PR TITLE
Use consensus transaction size in mempool

### DIFF
--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -19,7 +19,7 @@ describe('MemPool', () => {
 
       memPool.acceptTransaction(transaction)
 
-      expect(memPool.size()).toBe(1)
+      expect(memPool.count()).toBe(1)
     })
   })
 
@@ -39,10 +39,7 @@ describe('MemPool', () => {
       memPool.acceptTransaction(transaction)
 
       const size = (tx: Transaction) => {
-        const spendSize = [...tx.spends()].reduce((sum, spend) => {
-          return sum + spend.nullifier.byteLength + tx.hash().byteLength
-        }, 0)
-        return getTransactionSize(tx.serialize()) + tx.hash().byteLength + spendSize + 32 + 8
+        return getTransactionSize(tx.serialize())
       }
 
       expect(memPool.sizeBytes()).toBe(size(transaction))

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../assert'
+import { getTransactionSize } from '../network/utils/serializers'
 import { Transaction } from '../primitives'
 import { createNodeTest, useAccountFixture, useBlockWithTx } from '../testUtilities'
 
@@ -41,7 +42,7 @@ describe('MemPool', () => {
         const spendSize = [...tx.spends()].reduce((sum, spend) => {
           return sum + spend.nullifier.byteLength + tx.hash().byteLength
         }, 0)
-        return tx.serialize().byteLength + tx.hash().byteLength + spendSize + 32 + 8
+        return getTransactionSize(tx.serialize()) + tx.hash().byteLength + spendSize + 32 + 8
       }
 
       expect(memPool.sizeBytes()).toBe(size(transaction))

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -7,6 +7,7 @@ import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
+import { getTransactionSize } from '../network/utils/serializers'
 import { Block, BlockHeader } from '../primitives'
 import { Transaction, TransactionHash } from '../primitives/transaction'
 import { PriorityQueue } from './priorityQueue'
@@ -221,7 +222,7 @@ export class MemPool {
     }
 
     this.transactions.set(hash, transaction)
-    this.transactionsBytes += transaction.serialize().byteLength + hash.byteLength
+    this.transactionsBytes += getTransactionSize(transaction.serialize()) + hash.byteLength
 
     for (const spend of transaction.spends()) {
       if (!this.nullifiers.has(spend.nullifier)) {
@@ -244,7 +245,7 @@ export class MemPool {
       return false
     }
 
-    this.transactionsBytes -= transaction.serialize().byteLength + hash.byteLength
+    this.transactionsBytes -= getTransactionSize(transaction.serialize()) + hash.byteLength
 
     for (const spend of transaction.spends()) {
       if (this.nullifiers.delete(spend.nullifier)) {

--- a/ironfish/src/mining/manager.test.slow.ts
+++ b/ironfish/src/mining/manager.test.slow.ts
@@ -47,9 +47,9 @@ describe('Mining manager', () => {
 
     const transaction = await useTxFixture(node.wallet, account, account)
 
-    expect(node.memPool.size()).toBe(0)
+    expect(node.memPool.count()).toBe(0)
     node.memPool.acceptTransaction(transaction)
-    expect(node.memPool.size()).toBe(1)
+    expect(node.memPool.count()).toBe(1)
 
     const spy = jest.spyOn(BlockTemplateSerde, 'serialize')
     spy.mockClear()
@@ -62,7 +62,7 @@ describe('Mining manager', () => {
     expect(newBlock.transactions).toHaveLength(2)
     expect(currentBlock).toEqual(previous)
     expect(isTransactionMine(newBlock.transactions[0], account)).toBe(true)
-    expect(node.memPool.size()).toBe(1)
+    expect(node.memPool.count()).toBe(1)
   })
 
   it('should not add transactions to block if they have invalid spends', async () => {


### PR DESCRIPTION
## Summary

Use sum of transaction sizes as mempool consensus size. Rename `memPool.size()` function to `memPool.count()` to more accurately represent what it returns.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
