### PR TITLE
Change mempool status size field to count

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -134,7 +134,7 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
   }
 
   const memPoolStorage = FileUtils.formatMemorySize(content.memPool.sizeBytes)
-  const memPoolStatus = `Size: ${content.memPool.size} tx, Bytes: ${memPoolStorage}`
+  const memPoolStatus = `Count: ${content.memPool.size} tx, Bytes: ${memPoolStorage}`
 
   let workersStatus = `${content.workers.started ? 'STARTED' : 'STOPPED'}`
   if (content.workers.started) {


### PR DESCRIPTION
## Summary

Change the node mempool status 'Size' field to 'Count' to more accurately represent that it displays the transaction count.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
