### PR TITLE
sets minWidth for memo column in accounts:notes

### DIFF
--- a/ironfish-cli/src/commands/accounts/notes.ts
+++ b/ironfish-cli/src/commands/accounts/notes.ts
@@ -42,6 +42,8 @@ export class NotesCommand extends IronfishCommand {
           },
           memo: {
             header: 'Memo',
+            // Maximum memo length is 32 bytes
+            minWidth: 33,
           },
           transactionHash: {
             header: 'From Transaction',


### PR DESCRIPTION
## Summary

enforces uniform column width to accommodate different memo lengths between notes. each note is rendered in its own table after changing to streaming responses, so dynamic column width results in uneven columns across rows.

a column width of 33 accommodates the maximum memo length (32 bytes) plus one space between columns

## Testing Plan

Before:
![image](https://user-images.githubusercontent.com/57735705/195198102-65f6e8ba-3c9c-46d4-a39b-d6fc1704e984.png)

After:
![image](https://user-images.githubusercontent.com/57735705/195198147-91c83ac7-3161-4d18-87a8-c0669fd21753.png)


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
