### PR TITLE
Create Recent Fee Cache in Queue structure

### DIFF
--- a/ironfish/src/wallet/__fixtures__/recentFeeCache.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/recentFeeCache.test.ts.fixture
@@ -1,0 +1,976 @@
+{
+  "RecentFeeCache setUpCache build recent fee cache": [
+    {
+      "id": "0fce5f5b-d2f3-4256-bc1f-aa3f47a75609",
+      "name": "accountA",
+      "spendingKey": "a7844e92dacec19ac454cc73013e6265c8a0cba6cfc143b147a3adaf0061b8ce",
+      "incomingViewKey": "ddc0b0e214e489d5ba6b5c8ecc4f417638fd153a1c3546ff9ae447f805186001",
+      "outgoingViewKey": "d0672cee43ec61fcd167669c6e0e55972265277bef279eb22577210deb5daf43",
+      "publicAddress": "d7577dad60b94613fdefa36c268633e8ce98eba4cb4f406c0b8fa9e97eec68eb6849f94e7e80b2a73e3a69"
+    },
+    {
+      "id": "8d8d575f-363b-4949-b25e-0e6eff2e4740",
+      "name": "accountB",
+      "spendingKey": "55e3e5f2869fc31d77fa064e0db03c9f9911a63d6bf7149a54848cd961166085",
+      "incomingViewKey": "d06c10991ce3aad48d2ade09f82e9633630c4e1f770989b8db2c83906549f504",
+      "outgoingViewKey": "d0c7ca3dc2f5db0949cdb44a8db216e68a938a6c82dc0fee1fe5aa0216ca0dc3",
+      "publicAddress": "a592bf6a02591bbdc2e3b61bb62b2edbfbd68e7372c0f7292e21ef629d24e15c262a6dd9c7f9dc07c1d665"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:pC2upwelPF8qQ1QI/HtVBN+oUMX7rbGAkEAjCN18wUE="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1665517307307,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "12429A0A3F66DF527FBA325C43B53A52B526DDC93960733DAE1277318719BAEF",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALOWY1+AY3mwIOmXhBQKQqbNDIcIX5pd9BJwHOrjJPVekyrD4AM0mWuiCZ4oTeAt5K49gP5RmdSRAKVHRsDrKXK0peGlyx9BGHB4moi3q8Yio0ouqBqfrZ+geEOXKPtohhnDpFQTr1eq6UZDE0/5/TwOTEz/9+kmZqL9Nka05whgteO/0KxzMSUm+otH6wZW46EsEOnM9qJr/1FYtnWszDAp4lVaubaQ+c41WNfz2a8sZNXPdCOLr28VUvRs175dm1Kri5KNUCz5iVYqxut+VnFXUcfjdn/U515SLgWbalyfu4bY7OA6uKoHNdB0Nx0rymAkGFZ6iPqtgf44Km/xZF+xYZySpRf0iYDJWsoA3Oo+y1LeT8TZfN+ac02gS/z8L3+sUtSE8QFp6pl//gSsj7PDxe3LHqaJnuyQtJnc2AkpvlrkVfREinmFLK1GwggqC5YsKW9gt3P2SScHBohyppNXWWzpqftxUqK/UHmbXozIL9l2kxSyB22HDjnckpGsd+S9iUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwec392d+IW6OWAZcTTBKCnngQb5k3gksq5VOs7e9UA3BF3K2+HnItk4r/QDNVpy8pRdxgSkgE+n4bS4coI6AjDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "12429A0A3F66DF527FBA325C43B53A52B526DDC93960733DAE1277318719BAEF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:Nnicx3xSCLmozPVzKGxPyMUe86g4P5oAmrgLD90h9Tc="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "358E28BD199149FE39D02750E5F190C24A4A7A509FF1E72F8EFE745CDB9599EB",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665517308721,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "E910769256FB3CF35C0390B839511B9BB3FB0A14DC23A4C61CC5628CE04AFBD4",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJEpaIh0pvCd4jBiINbY+QW/A7Orh0YXVnvabZQJNiug3W2zUui2lDRYmTySOSDQx7bnXxjKZ5AEE79ihqRc2jbvBQqhDT2+Q30YKsru4LxNO5cDnzI/IB1MIyhHIG7YrwnL8DKPEH+6pajS1NJ2mempquiPA6cYOwWJqjrwbfon2yz9J89xqW9hR+Cw8ZUF5rnkzOZlwTY52XbVwSOFG2GHOUJv2lw8cv+hAd7bb2OSG9Cm8MBU+syAQKsLHKw2E+jSwRA+86nrmxJYcoi8jiTZWJRs0ePRlnHVM8HIKIrfbkLb/L8SCr+deVCrz9P24bFzfOLrmcXmE8gF4RzabWD6sDSNk3WjZZMtSCygNwbrlFYddCOlRBfxUnyFZa0/tHecQi4xDXHj6CrEGLs06++EPVsv822xwhlBCc9f8squwoqoLO4hz+HS7+hpfVoA2aQhH4oATNSVRPlmO7TPbKp+irTq6LNW9afIoGVpEZIgWnrL4rqgtpd9Ls7JXXpxp/pbakJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxrUGXlW+P99OhCel9WYESLylF1SdURd0Hl1gBdn5+BAvGQ2cy3CgjXJ6RSGN8OP5/1ULVee6CBj7HoB/Ss99Bw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAI42+79aJJ0eDkUCkJdUktw5XQrof6k3RfCxAzQgawOyapObJm4bollk/pr+UyWivZPrrXIbH3cxKAfeapfISVDQ4xrz0tQzqgW1UUuKMBgUx1vJuHYHMic8KOIQ8/64ag0pAdVuzgm49PjWID0R++9fAIYnAOo+cSeIGRyF3XMlMbCA+02reWDjPrJKcSVFPLM0bl+inPpnjekfXNgfyuOX2dnfxlQaDnmaHDkfHu1x+9SFwtM108WIf768N/q45Tn4TNi4dlSMQL7cT0qmZv7jgYcs8V/qB8ICMVnmico9kNPd7jRRw8rRHcC1oZluDSIWKpuVq6fTrUdDRs7RKD+kLa6nB6U8XypDVAj8e1UE36hQxfutsYCQQCMI3XzBQQQAAACt3uTIpTreVlK5Ur0RhZyG96clUZRzMP+4gnLGR38YNDTFVox9QxpMKZWXHy6VeKq6Fao5MpAansIB2KMH8+XYaAOgtkF3j2vctaij3gfC7r9eoRx2SjHI7RuACKZToQW5NurtPRGdeg5mvksrldsEHTuzp9qCA5XWU2xquiSHYEZWGrbjWOzadcqI+XMx9FuziNJBJWH3NANT2sxb/o4FaOozl4p/B0ZSxTA3l0V0/ilKla8y7yySBYwGHLuKp1gFEXAWlnzAD9XfwnHbReSScErA7AUwgfrLrsfYC1nBjeFgvroMJsX8WMeXchfDzNqE7IrLJbiLZgg0LqjUKkW0LL8QCYKMPfxrx9Lq/Hqwntb4cC7dwb6k50N5GS5Iun6gOz1C1P2rBh4aeAWttxfZgUp5OOClF0nEkMr4kt8cO7Au4mQ0ttcS4q4knsqkO7PJ8y6yKzz4gG8vsmgY9m1dUZri7czd5h7dlI7z/wZJR5/ygop+aFkPV+wpRrOkFl1s3PPKcyjxTipRKJHzD01/3nASm+nHt+ptS3a4yOW4F+9DsaSzzHQ5MjBtg2Y9GOXXHdEWPF8AvpeJfCSbTTaFOhQstRf86I/29KoRtrkSXWt4a6mo5k9duNHcqn8+wFR8nAW8nbL6HjwqBZm6YnHPF2YEbk2hpw0ffCRUvfCHQ/hR/shqwJ+US0L+Wyk40ypsiyTfA2y1z13u5tpEys4s9Z7ZsJqVUrE3roowwZnQ5moXzY+K1kqSzNbaqq+g3kS0ReHYmtNCrWzy4nokc0z3bBAKXA6I8dagYNcigei1SYL9KYnnLvSg33WdU5WMf4/1WPHypdfeFU/yBZtBNIU1ffdCT+jp0GkospEsPOM0dbTDVBmOsXCo1YY3wlq15dB7f4IstL58gsL3Ko1cMK9ptbJhRx/IHMt+URpATJgos4LleqdXrLhtrr8fMsIZk0ZgZTA1IG7ucEIA2sYJ14OZ4jiVKHHTcdjWukASfoBxITOU9Jx2DozvbmtTmmdED8XO0F1wcpofuNDLssCw94Mi16o3WwXNxoxFoQEs55ILJFI8Rx7Z9UAM3pGW3maevrgtfE0CY6gqcJfD4MrkEBDHv41EZIPiEy/c9syUDfVVy+DD3RWF3RQI+cKhZ7hIKaGyrJjm0m6k31fqKvvLTBQqm51ogp5phRxe0MkfNxdWCreAcWsTQzuqmvBnW0IwTuR4dFXHUP69vzlemZ4hpLuYW59GxRAlCSgeaOKrzGwbtL29JJQSzObHJDCGMvcb4PAXRbVu9XOMGlDOeMJMo8/+mC7U4lu4qq74kRJJTyHPouvtHYtXarsbLKXqW0Syep5DhhfYAMbIpocaK74qg7JIRkcty77IThxW3iOZpYEbj8fVIfWEAe97bKQkuTREUqTdSlrsmA2ylXOHOlgfMFYYWOMnzM9dwxffmcjtCQZu3SyunzipCA=="
+        }
+      ]
+    }
+  ],
+  "RecentFeeCache setUpCache build recent fee cache with capacity": [
+    {
+      "id": "a999f804-cb41-4df4-85a7-5f14aad1db43",
+      "name": "accountA",
+      "spendingKey": "652db0486b7b43e45a2cd6ee6699a1e63d4ad37dbdfbf1805bbd3fbfce36c1f1",
+      "incomingViewKey": "6060b34338e930ea52c3c29457bcad347e74c9fc051fc4b373b3e15e4e60ea05",
+      "outgoingViewKey": "e5f40c699a38b4978566cce74d6b0a4bb52d0f2e1aa18fd9ed42a59fe38cf5e0",
+      "publicAddress": "1b65ddf0832905610071e87e44c5556f9c769f789e7f075ee17b921f9b8fc96733d5a0c7f3f2184bf0f239"
+    },
+    {
+      "id": "590de0eb-309e-40dd-ae02-6ea3267cc9dc",
+      "name": "accountB",
+      "spendingKey": "d5346077c1c521960033264b98e079942c70bb4100b9a940b523e8b72ba28a5d",
+      "incomingViewKey": "a5c26fb801aaff3aa28144e00ae30b19e15c92dee58c81f031b1b9881edeb900",
+      "outgoingViewKey": "d06c8217e38fa7ebb17855738855b0d94d49fda8bfe472340a50cb3b62205e9b",
+      "publicAddress": "63849f0731d9b15638dfe3c959667cce193a1ea57a7e4ad8fd5ff6a67351b56a92399a3d407051ee499c8e"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:rUKpovJMwZvEYAV7gz8cKRE6bwecNVfEytlK4q0T6AM="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1665522353845,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "7A3F9A9C5669AC7B3870CCAC24E6F8460AF9841C55CAB67CDAE6E2A03FE786CA",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIc2kxhZ4HCOdz503BpDebnEVXJzBa/aRwmSVUZgayzyy8d+Kjnc7ZMcc8vA+eG7AYMt1kcZ+3x5fbQZ2Ogt8qjZMcSOc1Uye4G3ZP+QTbttinDsm4fe+E1jGnXl5Gg9ng+q7rjbL8TpZYDh3fU1uHDM++h36Myvx2S+efN5ix2JPOKB0tEXChkAz8ZmxDXgxIbWpNICI1FsrxzGvoiv6UAG/hDuZkUqGXozm4BzR8s0CmXO9Z4HCdO82JNb2XhezsUc+VMqv9WsUx87CdzMDTuKJdAxEWjsOij3fpjNL945Ip0FG0SSoWP+GzX35zR9r/Gx/eJ5ZouQDAzNrQO/aTX0FpWu3BncRmU0yKEfoE/LVmRM3OwMuqpFf5t68pUzxBmpcr5N+tsDaWNLawSNObAY3YiTYRxLNKRe1wcCYbWKlvskBu9fn+DzugIZ34K9FtAbRsRLQOk33CPqaqe/MNclWGNQryWn+vmYkIyhWkAlfAJLtqKxQ7bpbBwbcHS5A/sRlEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw49a4bE2WqLOJbOvKv4lyAQE6iDDuTig8JIVvt6bvteLsbs+/z8ZIGtKg0dX6jvnqog2FsLkuGdVGqKoGIHBwAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "7A3F9A9C5669AC7B3870CCAC24E6F8460AF9841C55CAB67CDAE6E2A03FE786CA",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:YsK2trB7z0uDBPGR6IT8z/BFJutXcWwqH575N9OsclE="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "2CA1C479AF1992489FB0D5200EA55C9D88ACF2DAE4A1379D8A36DE97CCA0555C",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665522355300,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "908AA784F345D2521C9BE459B0B94F9788D0EC2D59C75B5B7F0A0A232130078A",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIe8NwEgpupiuKNVRT/wQzYT4xZxNC2R+cYHArGoGplc5mpt5djxkf+tSNqcKdZRB7lD7mPfN3kjF02XGIoXBrT1xVsrzc4oKEAYVvJlv1zu5YLcvJZfuHn2hA6g3N35awRuJHVaKNhbkkAlXWdAWOT8Mx3mp63oqCZ0KlBx3PdRnt3796Lr4pOulYzldEANppnW+JU88btjjUxmov9VxcKuhNSe7AoE6J7WM9EkPwoXWfkg7BTz6MjlqaFa+hS/lc0i0e0Vu4QpxvuSoBO+oRGiAou7X5e0SE0pyDjIYBFjwjPNaybcQpXd6Ikya1dyY6JveNDfqEwe8CtoZ3u3Lhp5G2fp4+Ut8n6BlA16xHYi0CmfA5ahKtywHEu3QuxOY4PkPX01aVQLhiKUB/YMVZEmAAWnVrhMr5EJoaeg0LZlZcLij0sp2vYjxKK8pW6TuEU+/Vx9kiCfp4XoeagcLWddDHFTu3+fGIjCPDIb0IktP8cMIdWG7yIl4TuufJJaLRF//kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBcbZjhQksrLrVlaIV61mPMokff0s/KsNXRDPJC0JzIPQLceEqCNrrqg/IuWYA6ZrfWituIqiz3ZT5A/RlkgJAg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAK/WhI+tbCUKFQn6VxQKG31lmDWPH+eFyH30Yf9a1omRi4QqE8jK+9/sXtJPdr9UhIRperVn85TejnJmciLC66n0hy/Y04BIy052vVbIdboTAKmh5ekIEap7oAOM2T5o5hVpEpVQ1yuC7Hcnew66tfomY3dqdoeNnMoGvkeT2TSqgX/F8JqKX+ocgDKN7wwxb7ImN/Flz9FHipaINXD+BccvQcAcIToRBA6qzXeaJvVGckgzepCnhZ45B9DDaeXwmudVeopgssfICH6N6Fplyp7nS4fHiSMr5SzB/4BxeZ0JzOhmgcZHsJkZDsCo9w/OM/k+F8fd+rBevxRnAtn31AetQqmi8kzBm8RgBXuDPxwpETpvB5w1V8TK2UrirRPoAwQAAABGtptSkUUHKt9lG+Tjd/Fc/IdeGn5oyNVBTycS4/VWGZLGQOfM6J4+4xGhNbZiouuoPaeqniSK6BCqkaeftrvyOzvOb9bvl9O3Z0TGCGCtdKwQ0y8QbC9dovyIL+tbbwqpab7yT9cRntsDL4WNrXIzSZYNlIT35obLfOnfZcBhhV3RElOu6JLMpYJXHVDq4QawBXPS/FSZD7UOfj0Vc44TWnocQ5UX7lt3+YmWyoYysGjoDSZNRFK8HV8wTdwt+3QO4ICJVuJh1yYi/yLQG10biHyPkEzCVmdZJIvGp8w+B/E6haDmu9YIGYXLdvd2TxCW42vxoExvtQO8LfGYUhQ/uqqK/OWZSiThjX5kdv8gcn2y90PrqCMJC5urDQ/B7qzjh61bib2UvmIwc0OXkLVr28/exFUPlC/wAoBkXDTlJRG5jY0tUyQwnKZdHLbKxYMq1NN9/TP+jE8r/AC+2dsvOYDs9IL0uZVQYBiE3zABB8xCRXLnbbyIH9HpBcL90JkRZs4KY0YttHLePqxiHZ7TFAbMZDaSZRclfEYb9nOAwH9jH1bWIG4zIMe7KoKpOldZTX9esigUxaspJ2IJ30GDdZzsPxd4FaBaZhhne7/Y/iR+nrPxHshSzZ54WUWaUfMl6tfjCU6WQXpa/SZB3M7qk4I/Xpnrna6I6H1ZgiLaEccM3l9Zjbbd2ism3LHd0Sd6yG9/dmQOIPYTFzGbyvw2OgItt6qsLsApjtzJ0rtx52dXk5W83GTfAimSU1dD/u1DE7F9/7MpBxBGOlMQnVRPqUv9sy0EpYHOkqk+U5KCTYncbbcACztAgBUmf7A3B5GMqb3oBArQcsXeUIPlVcA00UKY1CUcGv5y+e3j+fiA9fdt+wXJ0BrR4oqeac1mGgJNCPwaQnIjhe6SAKtYObkzSxm6aH3UUNtuCtEPnA3/wEerN6xd4ZTLWl9kPiBmV1euFkJIX0GpOCxvmWVpHAV/r2sJHfQeQ0XbmikKnv+/KpgJL5rt1lYpKG/dFa/xgLjJQ2I4IvrFNK0YCm2Gh1hxFbbtKrb5u61uwBNp42XIuWIvZWE80KNVQUO3/p+c9QCjfVznC3CU/iWtM+lz0qViStWThRA/KcDyannJodB+aEDgMu7xI9s2FgCxkxJyAIq1kQgYjG/lTUwlsYYbOuEHr7WQvTpjTELh4DPw++unATHVxMbGtlliVD4ofrkXDwLIzeOITdrZ59apunOdQPh+VgiudtoVPctHo7hMZgqjcoWumAtdg3y9qL/5B9oZrYdrcUUaCiXCTMOOyU/f3Me+V89juukQf9HC1i3r26ZGaArGqYRQdwadrChOTNIs8V+Fo9tZDIBnQh/no2quh6z5adPBNQyJxEFW+ZNmmgkONA7n4DMnjpeBRB1DzEiEAmQWHhKVois36Udfit8PjmbAilfbBUgab7t9jzWAMQ+oaUT/omrJBQ=="
+        }
+      ]
+    },
+    {
+      "id": "7f14d551-4bc1-4d42-ba66-23f37d897ac1",
+      "name": "accountC",
+      "spendingKey": "487c004e7c7110e6ee088e7b73d8781babe5dbbe90eef321614d3932e1882ce7",
+      "incomingViewKey": "9ca3cf13edb7080abffdfc07b0496ee20d671f5e546bf54e4899552a3e0a4601",
+      "outgoingViewKey": "34e767e1cd8dfa7f23103cfabbb11b087c931af734f5f4cb45831be87b88dc15",
+      "publicAddress": "327ab9e6b6547e83644e351e7c96404ca6425a976f34743aaf92154488e3de873770e721eb89023257c5d6"
+    },
+    {
+      "id": "aa2b7be2-2010-4fcc-9435-d66ee6c427b7",
+      "name": "accountD",
+      "spendingKey": "f736805e06df51c427a1d9aaafcef618fd303b54f17c68f924e11d43097be784",
+      "incomingViewKey": "87ef630eae7309440b5c6dc0da01da386a4d0801e5242ff73a9dada14497af03",
+      "outgoingViewKey": "00de23f7dee7e532b680accbda72cbc8eb15e5535bd6c05ffd7f39af3c60231e",
+      "publicAddress": "73b1f99cefc1982569f5e4efa97a3e40e718140587dc24676cdf972481cc5af301e42d3239dbdbc1bd29d0"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "7A3F9A9C5669AC7B3870CCAC24E6F8460AF9841C55CAB67CDAE6E2A03FE786CA",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:FzLG95aYa+A0p+mAGa/3HjOKo8CsTaWFPeaH4JXV3lk="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665522355499,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "5720D730F86195F7A0BE9FA8CCF718EFB8C4F28B0AD381367036496C0E7EF376",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALnuWefLdXhyKff+MAm3qKw0RA3c8pUXRjPpsDpYLzCTHFNbde4VUR5DnfxdcflKx5LLk2KD4E5j8ddBfNgoLxrDOcpCNs0aqiWHZViIptGC5J76Nf9v6Tc0zaA1DDTjbhUrV83BLjoWf61ogHOC+aBEp6TX0dg+QXpZHyJG1iN53dtE/7+Slq5DXVN3+i8jT6glaFbhaPL4PERlTCVLcV4IHEIwXac5BVYC9FR8OnrPL50Fw4t927ExNjF6VY4fv08Xz9f05cTI6fgg/28tg+n8JkMdjLpSCpAr+E1r2E07wIRmks+OI/ZhJTSqdG9CLgY8GqKkdsXLdngPh+yqNhNr/cKNOpr0Gz9IHv8Z1+9XUNKbB+tNgdBgXuOpdCTw26SCGbQ9gCp4Xg1pgp4lsVy0KjQw17sGbW5ZWyYfsSyWSwQ+UpN3Azy2JGvYRNvQkk0jUaqA6CZEga8RyGcD0332FXb34BPOWEBgmk5f537uJbiH1oNDMKCf7x0aUkxZ+Ks910JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdyZETla+4WK0a/mlIJBrgIFKh2qnLu4pbuNSM2MbSRZ0jifB2khxE3HMWGZu1do6hA6kwxM8FAByXNC1CE+8DQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "5720D730F86195F7A0BE9FA8CCF718EFB8C4F28B0AD381367036496C0E7EF376",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:jdRKoDKZvVojDOkuHqWcncWe41KtKIYZLMp33QWMdFA="
+          },
+          "size": 8
+        },
+        "nullifierCommitment": {
+          "commitment": "D2E92E7B0ECBFA4A53AB9D83B23C473108B5571068FB44C7FDF871A4BAB1757C",
+          "size": 2
+        },
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "randomness": "0",
+        "timestamp": 1665522356833,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "735A8F150E4692ECDA5DCCB900C4CA8D12640E5D9C410ECDD620EC64693EAD21",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALN5EW0OXKpRniyiHmOwYwELrXULcf7A7+hhvnpUbYfVmL3fS+Sds50Jr9DdToDVz61I6CFvxNo5M9OgAmJ0jJdr1DKSjG1+Ki0gUjwSDCzot+mw5VF9Lz+RBpvR/T6QuwXCCsnkA/qLpuiK/8KOWVAjCXK/i3mHoI8YuR/orGCszBEcHD4/WPZTIyaRsfu+8a47zG/V/Sf+RNG2UrxPNdna1CzkqN/tUB78MQNuj12L8kPB4v8y27RxfgjxINX9parzDP0LEJ1kcP5Qmy3X43Oq1Ri5HQnXUBvaC5wAeKZzNY0CfkNyyQW1w+C1LQJtqsjkvQNsku9ya9lUZHo7pDe+Bxu5R66C31xYDihyckPKk1MXXMyUAkFYnSSOT7ZLO7s0KVCgZnEyE6K1weBX48luMc8oWYkn6n3lJ0lCKdPKZCFM6wbyp1jo9vdAdtIFsL71IegOeeLrrSGnfKfZ0ycY3OKZd7mWP8zNUmWvl0YzrmAlwZqbbC3Fk5RLXkm8V4LG/EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYkQ18fM0usC/LDi1bdJ1viGaAW5C8THDTfMBokqfhvKWf5/1+nKhGq4llgPN+QFdylfj0UgfOSHJZgltHk5NBg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKOri6/JA7iFLeEiSBJ5Kj8XyBpKtjDJolZwEKbX/soTRA3DXYOSEs6LN1UYv2OFG6NawsTQdwLDfuZJR7mhgM/ijj6RG45Myb5znEPLwKgStZA4yl9/Y85vera9IfXTlg9cQt0X5ucOHJJMSPqSJh3zx1713H8GoRzSC2CkpsRHvesDFWKJgBdMeGVCPY6jCZa1GGpHZyP/X0hYLyteZP+XpMj1dlPS8R5D4xvw6ZJcyi54kwdcX2Sb5OwxmESV1z/jAsN2xpBmaIq3UH9xbhALOn4q3sVdRgcB3rjzI0zIbCtxc7AnU/w/NuC656og7adXX3gG1skm1Wu3itIpyogXMsb3lphr4DSn6YAZr/ceM4qjwKxNpYU95ofgldXeWQUAAADsZ2109GwPbS0Xz5/knH2UocY7fdjMw6Y6ggGu6pN41XafJyY8uhg8RpJABaUcyFUcDtWAfiCMa1vrJNOvv0XYg/Fx9QTfdZH8fFeQe4C/S0UeBi+XZvyV257DKkLK9QqT9lEtl5HztbP5ot/ShiBbcdAxxOPyLMlM3tGCg3YbEQnE59dM31OlBWsmn/u8QuW3xK1E3eOzQqZETbk38qcj5tZUBsBfcVmjiPXcYMg9Q7DnFb3mmC9up0/5Xd2jRWgS37ksVoJ5TuD06j7OUd07sdvOrNIW6qmxb66PG6vtXiXcFvqobmFDuB2HZZYvO3CTcmpqZzS3iKrvWSRk1cb20x4JIwEgjBnd4Cd19hGIWeKiKVQHWK6mQoHwuD+hpq4WlwDIwNMF3SsI4RExMMsK5qHR6NDIJ35LCR7UjRB3DmOzjLUzUtiwpJoHxReL7kzAOiSC74OrtOCmsWxFTLlZG1kFgFRJlGxcRu7VQVdy4huULC6C08SnZVWoGu7rnQYjIilu/yYSQNhyou+bYDi6voNjpJZdGoA7+J6s7mtASN/eWWuWWIV4dy0bI+EMW30Jfg6Kuh9wZKBj7ZjB2J5hkT0bMN6M8izD4QzLvdqBALtpTb6bHX9lxoKyIWCGH7kmyz9mFKr8D/+9DwPAUgBMstdSNQYRTpSo8Q5O14ChnW6zRYKV/uFdyIjtLPXCkJOciWZxUzMKa553WA/KNvYZ0k0DQ3FlvSnBvaAnslpgLwCCc5bJD3HNGmV+4Dl+pyGpQqEReYftlzRJGePEEyXmVSPb1TMNX2jYKVP7jzjjoeDVuqzppEjn+YCkSQILiN0R/mrXsdp+R8h7KW/63IYs3MDEzHZ4wxjrzS4EfATQ0qAiwQlk9C9lZX5UJ3XyMBE9SGPbsUcDI1MglWg7vR7tKnZimyFMI4+xR6L12MzBKtmjW6/nNwNHDtBkTrR3GNr0FgQG8UjwkHVJMuW6Xzm/w0e/B574t2ZR7XQ3U7JzUtmNtcuBc6DGUq2MZ7la40q3L+V3sFup/vwpQWLj3Yn2ACyF5J/qUU+0KzgkqDPfj/JxUrbf7r0feffvYE7hZRZaqAc8/neCydg93+Gb826yfjSP+VrQJdwm2TE2P82rxa0sowNk7o+OcI36zdzDNlitHesNkw2ktxZUMckpPNNiujlyNYI2j8fY/xctPiJjsU3VApzrh7H7HFxzCHBw/ZoooRQPO6NXWDYgePzjlAzLxyN7+Ce+BLRLxkomy7TnyDLD1LEu22cyLx4TBlnse4aDHkBAd68DigxIALSTGYnE+kybPda9Ys+ZgjNvHYCyEFw/WrKkAz8i3FWhqZ5ceIDfK1ik305v6HTUsDWU4w+eWI+eKevbdnSGf3MqOw6T8o1sNuHolJm8UcaHF+NHTdzW8Hi0ZL/PaheUqXOr07hHLLsoL0x33jEfaVB/zt1d1t9rR1sHCw=="
+        }
+      ]
+    }
+  ],
+  "RecentFeeCache setUpCache build recent fee cache with capacity of 1": [
+    {
+      "id": "6c29ee36-8b24-4749-85e6-bf6fd0672e30",
+      "name": "accountA",
+      "spendingKey": "db459268920ce5170e95d22e897af6ea5b23d6319940cfa6ed9ceafa68f99e51",
+      "incomingViewKey": "8e251d92b6e109dfc9faca3182a084a66e674200e77bb158c012132b16c34c05",
+      "outgoingViewKey": "194cd111579b2f4486d87671d987fef78f30ab732d6b7f3565f260370318dc90",
+      "publicAddress": "64a2ad254e2d02d1c33b00d3b066c862ef58f9c75cb3707efc4d8d4d49cfd2acc36b4be4ab1dff09322681"
+    },
+    {
+      "id": "271c820f-ef7a-46dc-b7ac-5c57e7917c63",
+      "name": "accountB",
+      "spendingKey": "2bd09070810e79f71bbc5e65d55c28cbbaef41747cac0df37aa81899a57995fc",
+      "incomingViewKey": "8dcb2c3421508d3360d86d1816729aa259cf80a605879c7f5ec1425965612d05",
+      "outgoingViewKey": "9d968d33f2c6fb93ee123153a315ebf11faa0914a6adba5c200c5375e9b8000d",
+      "publicAddress": "be11a13a1aea16bd63f2bb66b412ff9dc2433310b41d5364ff10985c787268e9d4adc5a9331c55396a845f"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:sqGH9w77Po2C8vKN0zNhUi+DFYtU9BkzSEGJlwg3Nk4="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1665522508064,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "6D74CED047CE9C3BD9DB50404CF7C6CBD1E66DE5F1FBCDF8A72695D297CBA0E3",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIJwuW6wf9jnUH6A15CIV4UnnJwoYwRCov+d+3mCMdKHX9l253IJA0yPnvPsvfAcU7SLZReZHH031AABWV3rPcLSR5lfJoTzrI8gSsZ3ZA+UUBqwQut0ZpxOUwqTkSLFEgALbGSnitaRWqjFp/p38wedKx9xZRUpCk27EtibAt3BeKv1NdbLtslStCZK2bGqoLaSjYRtRdgHk9RAjHbOQ8vEhxRrHlZXuK+HB1iz6Q2lSlpGJnV5ISnwcOdXsJhGcNASsNY2KHGzT/4redmp4YXDmsmtV/8jEU6zZUFF4RkpWN+cp7FirQuPcmG5v28eXg/DzO5OTHA3w06ij2fgcgr8bx7yNplC97xp4ZX6+4WSBme91AZAPgkNVxLXmm00nxfp4UpUjslYwC0zainjEv/j4UCtOChOr5i0Gq3u98sPeii7g3+8yVmfwRcpib7/46NC5JDAilisyVM++QHXheLfGcY0wUFcwkLsQAbAXlptxhzuOXpUtl0TvRncsmbveGAy0EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEoQrKYVOHBa4LBh7GF0K8DOeYzzFgdNEsECOD1OGHM6hkfWOMLg6bIQYIQQYaA2XYh6myLNddlspPWUr3j1rDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "6D74CED047CE9C3BD9DB50404CF7C6CBD1E66DE5F1FBCDF8A72695D297CBA0E3",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:f7wZiT7TbGpFiRrxnUjdxFvNiDngKmsVxTzkJieGlQo="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "52B8A21FA2E05463C501B9C5F1DF4D6BB5D80972DE3131F13A497CB65E5AF5A0",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665522509390,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "D7590B9E61E35D703A69EE56AD2EE567292E954396FC7B4BB7F3DD88F562F467",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKcYD5NvmXLBk7ePnw8yLA1pGZyV+GLkfkFAzpjRDT1gx9nKOZ1duH3rnQQdEEDwU5bduunNWaPm2NQpkw6USp0HFylPS7mE/1Y2NiRkp6at6Rzh03NjfLEPxGe3yY+0hhd0GRlbMVhgYId9Ow3SgOvmWHhtP92x1WjsuOh8CmGQCdH3/e9zekt6xMqU7j85zbiNLKJI2rmhyinAMuVlMiVm59O8AY2EPrN3Bv6kajCyKavQanA1vcqdMbJIj89xoCp4B/zmO5rvTujCQ7SqPMLz9vUjFxsK45u7pGS2H4kQl+8ndOoO9G+m/HUzunKzIAnGAGB3ofKL0TCa1kvyZT+elvt3kDG3Zt9T1cbYrlRs50sMOkGFUjvpVX61ILGO15eH9Y/3fdW22pFTapUAs8ATKpHCEzWlxJwi6s1VBlrHIZlR4oDnDkrhS+fgQXei8tso13h3J/VxXNzpJjL8Y4oDKGnM9DUzil2QpoznpWIFJekOV3gjBmINhFMyCgboS7C4qEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9Zs08MDoer/d/hxBwHPcePiGRHcDxh2YCSrRq69yxvGpPRwzfRCpIDj3NITO0VlwLGww3t39HmP963UqAjuvCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAINVI4cz+YBIVMTALhJ26OnNMrXmaYKjf+9B5fO9SAfhE/exavOLXULX4SGnPRFzZo3OcAD98UMMYvwQmkDRVBEIjx13Cp8T9igc0lmDM5m7iB2LPSDD+x/AP+x4QlaWOhfBSU8s0eZrWXBHwRRePgzgiXspe33bVM6GYHCcudQjIDcVEZx3RPyfH/gusRmffrbZEV94QISv0FGaNM+TzqZ8WkUs3GpQGWXX4d/CSHJLpEV+ban4ycBfXmKZzrZE/CnF0Sb/oVKkTQ+CqF/y/+7GIUwekHtXEX1hMYWqDs8J8gpWcjghZ0IPz1Ffo7IwBuyewMTw1dvjpBBVUOr4hZSyoYf3Dvs+jYLy8o3TM2FSL4MVi1T0GTNIQYmXCDc2TgQAAABqT6JLjiXv2zczMkShTpcB3PNe97y/PN+dN67/Gnfe3B0zPrM2hCFKB7AF+knVPtX2Q3h7KHuCzx0xfPeQ7YsDSJ5ZzFbnxMOdzOpQx0XjvZIdS1T1WHgxeVcjknaytQiz8nfj3wKYVWM6mxc9CRhGJE7mxY+gB+M1V5Xw0pQWl9wzEmR/bUpCkb0g4hhpSnCV3iFjGnrrXN4374sH3OgLWAuoxSgDZh6Vzdf0fiVkXbgN/zcmyQXRiwl9ggVl1vYDQ+a+/UJ4tWJo2NCONxoaTg2Ht58ZWNiShCKwlTs2qJ4Idv8rluJZHQcBdVfzPmWGNcJbfKyJgXhpbmPTmd5knEanKykjeF+JoVwR9H512S8AYMLfI8Q438jrnqivoyWdVs+sZycNVvHP11GyDLOzTs/RqBU2b1KDZRgcvY/OgmxMcRzWmKX4pH1h5pu5SUUAmXvXysmAcTMxh3X5p81hmFI7fg+X6A2Snio56KAJL9wtsQAWeBjduMzG6wV0y5JESvyLd0eNF/PtIm9/w78bUElfP6VPPuNJ31VVcvPaJiqvJgodc1ZZLJtNQuEglJbtvMbBRRztjHOeNGQ7MhEHZaUEogRrH7erI3mkt/9rzjyNNv3y5xR6039GWXkgy5VmhqOJqtIPqap3x05qK7OpuChTIRlHDwEJSZ/Kw7Yc/EkKc/FZQ3oLK0UxemXM5W4ZoqZYT2A3gxBRxJFtPNiCptVv/cFUAT3bz7w94wZO6vTj4ouIJILXRf066YpJEAAXjFQihU63KmTzYtqu+fi7CyRSl9oG4fVmQpLHaff3RzTn1ad2s6ywg1DiwpI1k/lGMiiw+f1Q8HvDQTE6kjh3t3tiEXI3G6e9qz7gmWrnskFAuAVQi5hmRW8vP3bZOvmvhdrO99i7MzVIntMwVZ9jlNTrsy0QMhWw/kkQ1+7tRe67OqoNmGURv2iZ5Of8EBVCQ6+yrI8j+NnjTFg4yjL1MLcgTw/oPqLAUmKhXk5XCXvEQe/afzZBmrsL29WLPx53Rixhmap0piBveFZhVMuMCu3S90wxjEv+YtNr/P++DrjYPAs4afKPyEPw5C6oDOJveBNFazNuJ93XAGwDYLPu1K7+tZYLXjUlsblI6n58KJIrLY4QAlA30T8yjl+gqHuCKjHdl7bfTbqiuql3AyWiMBj0JwFAVxRdfwLRLICVT9N3+qa7V+llNMW/yrVfCVOKd5FFX0pcqPl91jtTrc9svmpuK6gbYzxPiyRkMe32B5pAr6LQp3N6gZxjCBhiNIh1nPWPEsa2dwJm0+zG0zjDDiklTXpHwgxiMV5NpChXzlTxsTp8ujK22s4wvOrh/IbY/ZHqn15qKEGtE9x9TaRZtz1SyRAVbB0a4L69Db9sW/HlNBAgiIk8y0i2Q+W9EtWB/s0qS2HxXTUWrCx0gqvxdboZyfCAdBRLRBDOsbwKmQ7FR+rbDQ=="
+        }
+      ]
+    }
+  ],
+  "RecentFeeCache setUpCache build recent fee cache with more than one transaction": [
+    {
+      "id": "bbeccf60-c2f7-4cf0-8446-c0d22b54fbe0",
+      "name": "accountA",
+      "spendingKey": "c46d7dcb404e7511dbab4b0a55be771f32b6eb706eeca5ad876223c3f9e2bf6d",
+      "incomingViewKey": "2146d319b97aae3907066a8c2d2b4ab140a804461907b050df195ffa5fd22303",
+      "outgoingViewKey": "ea6ff044ed1d74da1515a7de654bdd4d7e294f04d0b1fe036265062d8fb10082",
+      "publicAddress": "7c473aedf150edb2877394ca78821d23c7d0889b6d2b979ca6b9e957a97f0ae57b5d8131447bd59b2097db"
+    },
+    {
+      "id": "6d0e957c-cc9d-43cb-9c5a-4d6fb8fd0b1a",
+      "name": "accountB",
+      "spendingKey": "be05e04e2a0455cc114d73b45f83fbc4e04e71d685dc52eb9e4b943337f810ea",
+      "incomingViewKey": "47e6a84119ff148921ef51a3b0c05e733fa6900ef7009449152ca0b857806601",
+      "outgoingViewKey": "e2977cdbb47a8371a0aabacad9b210e8db20252c16c06c2edbc3421d2e2b8068",
+      "publicAddress": "c8407239e9331e54c8f6171084f7f854b7a0cb475eeca09e8658ab7b99477614539cd2d1681a2944282020"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:Frp+oKSSLLl8J/tGj9QCkGyShL6gUuAPtI0QJZhmvg4="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1665522509653,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "F6B6B8CD697EF9BF4F4F121E241AB697261D7C4452B6C8093B9151A1A2650A3D",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIZ48E8vsA3qNI9ecqzEooY/CgyqXmFyrcnEQN7eWG5R40PWDsTUPtIuKTbInGnYwpXLoVNXamgHfzcZvbZcPPD41TG4n7sQSF18IlJN9hPNnEXftrfu9a9KVsjN8lKfxQn6pOYgmSUjJgj8Dy7CHcDldriLaXikgcZJ20B1tiq+4PR2QzAU+TW6qxlFAhR/iYQLgL9Jzylb1Qk6pWPOPnLIqd3IUPXDQeKZU4FMRLd5UnSr73t5wGAOLhe/fGREQ7yI8b0XqydEQKgAd5Km4JnM0tI2xnG79IUQC10ylpJkuLxi19bA7LMys0PBFENjoQWhxvAXI9DqEXBEMk+bm2lbW/1pFqkpQqxuMs27Me3KpUnrgJP1G+M28YQbi2uEWIFV9NH81J4aSprRt62SRkzxuWkgPlmjO3dbcSEfkPbllsIhtIX3Q/4iqs0X9nKwCL8nyB3wotBtvcjbnUhqZ3DUqHQUYSKIrqCKuFg3E+COH80OuV8/s8iO4bDBD+kVNGzlDUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwC4YKYP5el/Ebc/v5gjlgLBBo0HJ45odP2idu97/qmhgGZTXijmi/BRQj5yuoYmHG6/Mc/QLpi4u+wrm0o8kDAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "F6B6B8CD697EF9BF4F4F121E241AB697261D7C4452B6C8093B9151A1A2650A3D",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:vlQWazlslDMH6Jfdh2rtnmUVbrSlPs7nwt8Y4sHY7l0="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "02AD19D9041A012F898C7FE058D5CAF1F849B96B207969663D46FCD14AC7347D",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665522510911,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "A237F9DE741FD55EA1D588F3177AFCCA26163CA62A05EF16CFADA22DA32086C5",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKN06NUZ9vdfF4bV34JwMDre31LdkU1hBIiNaKik0iY6nrVNnbmvcodvZZmo2A7iu4tvdOBdJIPz558AUPQlraTCI9fQ5BXDJBbkgcZk+b63dMNZkK+OgihBKN1X5rI3IgLzGN9qa6qAuLakZWmaqq+pSuuWPbdcHxwHccmbpKqPWf3Q+xS3zKvSGUISpyhjp7E3mOLcuKWMlSHdu3hMMVolsvca56o3vcHm0CT7rQjUpxlQRdzsBWER7eW6fMcQp+N9JfQF7MjR5zFBsOXAvU+Eb3rJ4n8Cf5pYadnI0ZPmfbJPkV/wy8cSJKu6Fjyl267guDZQpRB3ZWAPmObCYjFX/0q/TCe6gnwgGx75q2yBSdta9kcpb+++3C/dF8z72Id/aAzb1qBvtqc962HCThzq4+sZRN7Vj4cFjUHv6ClLs8Ii/f2RNwIibyiMujxo54qjenjNaK9/UXRByo8Quru3uAhZD21pNwxp3t0hLPu6JJuwWj7hKtTC9b4STLFHo4XidEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOPtg1BpO5Zr1P/lsCCbO6kkM+pG4YNe0PiJMrWvElgAwXrCltJOdLqWMmVVQvkN3WePYZnd8SJMuc63FmF9XBg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAK+qP6x+j4EnLXDav5NWo/Xl1T6ILHw31hRWfcprjCbWjC2yBy6F1xiCUCycrUM0RIAsidHDsPv+ndtq82Ds+fq2FQhTNryuxx9K0bCZpz+RXFooRABb0VENH0pnt7yRthCMPCEIhURx+klGsBfAr6B+ewqEHVnDXNFsxHorkJWp+Bn5czw0n1OfcsLdpaWoEqtf4OCMCWHjN6sUEUwAYr5N7YU+92+p8sZLb+rcTXljNiwggrBSppu0WVwXl/dWSvhIXuiD+bCz8GHL6T1+1erBEAoaM0iLu2cViUbILaAp8sukzEJotLOG3MzbZ1ETIrBYsm2/zV7PHLJEVON2aUMWun6gpJIsuXwn+0aP1AKQbJKEvqBS4A+0jRAlmGa+DgQAAABMEdrUNcKqOi8B5HK9Z3jV2YgkoupqpVgvlvczkeApcSc3DoT1yf0jl58MrvoJOLDK44q7k0PzIBnbuWD4neNg6/u4kZY4++0j7iIyXrs1YOl38Tph1J3E5Cst4f2eBQGun0TAcHCa4PI0BuMD/raK4Ro+66KOLj9B8UDnN5c9KzSmnlJ65ed15AcXfk2/PwuKgp/CVKv9BGAasTRtB7Q4U034Eq8s7znjpA6kr+ZEqk+0ujPS7P6tW0pLb0F8pZsXrbEmQTLUZz+i304tsrtI10EHskuU1VLCmgKIZ+370rJbIN9+UlBA+1ynR8FZfWy4Yhk01LDEUDQTLOxjx2mssRvGVl7lWvU94SfcXLNZ3kMKkODsAtkKszWAXABcWZGbaPcn8uiFE+eZk+Y+FdR3DoFoFHrsF7DVGl6qqQQOPBDBKOFKJOb44WIT10qC37HZI1klH7n/cHdVdoqrBL9pOUm8PG/C1uzWgTWeyvKfA+UlVBNqdYevwehWjI8sxq2DZRhx3UOGd55WSGzvNJRBU+zYvsI4YSgUYSrBucAe7UwZldptGtniObcQ2Yv9VBXOupB2OsTP1yR4lx9ag5Rz7XNcBho2Wrys75i6+U9zuoeVQYGT7IjAasMk+Laz/PNWHtynkpISPy8LO8cotX7Qzt+RFDk2AegZ/szfDHgNEcWXJBWSOqW83RuSOKPXYkWnLHcaAbXvTvbJs1v89uRYbd2olX1S63U8tFGz1KQ8cKWi37dRt5+zeynyhrB74vkrE9PbuWWcx5qKW56EKVkWtCl6d/G4kF6kYPk6kb6QIUdyZbXjNyKWlC19m0rTKlOGkuhq9qNW7oApLTbmSiWBbTgtLyAZz7Wk/Dm8Hit+pJj24hkg/EhhWGG3emNr5Ixa/aZWHNLacqgtw5sOYUPemuH+7kLAUGBxqLYxhVOtrtgxgI5OMtj4Y2LMyF8CTbc2IoqtBkJeaQkksxwSMNL0axhEv+TLRsjoYDMz/UXDD5NyTOA7QI3olYCQEI6Lbqt59eLv7/ITffW4+83ahmSpnpIqmoECF2w6z6GpnuXs+fWkcz620q1liC4GfU/1tCgh5HKEdJNmKx8RZiQ6ppDQC6u/zwPVx22PfSlWNMT7zQXSj8Jy76cIPdPljSurVXgw5w3H9BFmqyQBChjByHpGrGysUr1HXczkIUie5acQXBVumi0D+kIvl14r/hNCEcV7NcCRrOwQepvDq2SifliyYtAMXCORuWrNzKkckiPBp7/6x2xHr+5TlM752vzhSgfifxFptWoNTwDUwaPQ+DqADcSwenMtRBNA16xkPuyIigG8S/sVmWN2c9N+HPV7OXrDy1BM8paFFcu+KsF9+Bf/w12zCG2V7BkLmI5+T2xt/GLC6PtXumhU1EkrCntCs+7yB4olN6EFdmRaeoRxGjdOhcan46DrVreyLtSJzJotXG8ZONf2Cw=="
+        }
+      ]
+    },
+    {
+      "id": "f62347d9-c36f-482d-8855-ed92e1368a53",
+      "name": "accountC",
+      "spendingKey": "9c2d4a705bfc5d90c3c53a2811ac86e54cf717cfec4258743dfb6178840636a8",
+      "incomingViewKey": "2407988611bdb6eab61fc4d988dc664960bd0cadd53065e6aeffba0f48a9d307",
+      "outgoingViewKey": "f5015b94fd755d94850de1aba4c374b8358d5730da6acc8e33c1a138ad975e86",
+      "publicAddress": "e3d01b21b8b5d883585689191f59d328969650bf318d597a3e01a03d715594ff5d83b84df96e9dcb9d4aba"
+    },
+    {
+      "id": "3f45ea24-ca9b-47d8-a6ca-8cc43189883c",
+      "name": "accountD",
+      "spendingKey": "ded2427668e6569273a25857e746bd451c2e78dbb31e1c76d8e68a4f2f22203f",
+      "incomingViewKey": "fc06707676c57651172b5d7c3ca7832ea3c2925f63d8f64bb807641c2c019204",
+      "outgoingViewKey": "06c394369e442d11f851c773ce813279a2c36f86df0003f2236ad5abe813ac4f",
+      "publicAddress": "def88a36472b5745d018befa6f91616eb4fb445c55f0c941edb465ab903f52363c2448e893603b483ff144"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "F6B6B8CD697EF9BF4F4F121E241AB697261D7C4452B6C8093B9151A1A2650A3D",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:Eq+UMp6qmJxUwijLCDo0wrtOT793aUs+dthhDgKWXRA="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665522511091,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "C7856540344EEFEAF89B763D95403BB6E68F25F46E2D1E4161D505B48E9F36C0",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKBWCTTySkzdOwNkTf+daqThNiBPt+85KaQqT+JAAprXTY6SoHwdNm8TyuElg+CdG6lMFIk4QKCAqs7uVFMLVZwYMgVCOmFvnTN5oeGAD11jrs3KazFhrqoIt4VM1WGApReTVcBE59to2d8IqVyALZIgWsS4LjWX6n50cR7sZm413bWs/5S5lIV7mn/7j08CzoPFX0k+dx2TYuXzKpBnN4zgQziqvcEjPD4nkIliz1KQ7+TaCACehWMB/HgWQaX+gRkpmXvAJJaMMRVLmImlpX595Ja68PayHUaHmFer13nkTVmRoOGW7L0vPccMUWHxBpICOGQnLZlEjZsdB6WQkhSGwGorFg2k98NhE19ZkTrrp3SwXnfdAHFaOY2LfWncBjFH3wjqG92eKHAEPFtwp70GHOc+2GNSboxW7HiXllwlt7E0nzC3MOpT2N6yuRs2wnM6e98Db7JMYX/DbJsfBnR4lAjC0iqnQvr7Ssy+zSGFtiWWBCuh+/2znHUBg4Ruis0FU0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwL+5Nl8pRLO9nbmAEzX2ZaFhTwimhFmgDxDs3ve7QEVb/DgniyGN/CGcy6mWZqIvACsOYCAQVCpSqVUcz6EP/Cg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "C7856540344EEFEAF89B763D95403BB6E68F25F46E2D1E4161D505B48E9F36C0",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:zxKC2s6kUUEd0c6dprRyi4f0Hra/XjwKxaLq71dcMRg="
+          },
+          "size": 8
+        },
+        "nullifierCommitment": {
+          "commitment": "84D83836027145592D013F8A9BE605E6BF5CF2F288C9141356A6719684720A96",
+          "size": 2
+        },
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "randomness": "0",
+        "timestamp": 1665522512364,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "395E74A3DF4D4EA6A447F119370DD3201A6A082BBF3E3523AB0A02A6F60244F9",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKGrrp/a28ar4RvSKoZVfNbCtkLqc032HdMmW7WmK6f6d6zaJ6ElG3CcbnWMlbyhM5gBEWm//9Haz/+VxzOWCsupD5TNnPE/qVCboWgLr7oJOy1vy8rVYoByJpdaBlcFhQ6Ore49B/LbCB5r+AxqZqChhnuLzS08avn1UcQyTnS4cDjRbZU46az/2pDJ7di77pb7DqgE5D+J4IINwYakzfI/7UUbMs2Z+noTUQjvaP9uipMtcyHmQRrGqrGNubE6GdeVGd439NJUrkmMIqhuTKhtphHiR97ZaHURHO8WaEEPumDL+e6FlznzjXDexvnErNoHV5Tsw5gDLhxyTaCb0WfVLFcNSPuD9rVCgPT3byaAa2XnGRmQ3vQAm70PSvYgUeGNN7J5XpDmU9Zr6wBhS5p/wfdEjDHduxlG3UGQaF8BCmY4vxuhoKhYJMeACqzA3+a0FybBMqoSyKYy/VhVpCz7FUiNpwxKv6E7JxqE3WIzhiv0zb2lmy2iTA8cWsh+UlOWsUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwL6AD6qsJQC415wV2LSuW5BADuNoQ/zzc/l2afD0RebZE5jS2Hx/TeLzJmrrWREh/LlGTHKTNefswxjbAEAdeBw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKH9vOg8iF8CXS7AuFmACCkDFAGUyC3VIhQ5GC+4iUFqssQFT+x+PqotH8QDYVLeEZa6hzNPoQhfSeP2CF0iFCGpSyP2tJayzPM3J6Rc3m7Gfz5HcIDDog0WK2qLQ7lXUgYX0FwToRwB8dSK+pQNmwV1jLlyyMo/32i8p6MewrnRYKhbbSpu/tsErIeAmmCDrYUxRfjGIUnXaSTlx3Pb/PMlpYOVKcJBUK5rryGgiTugU76cf+afy5GDIHOUXTPoCf/ve/UbLTZWxtbd8AkbOXFJN3390sPWwusrHgHqh8/oNnnmfWl6SjpiGofU/UVuMMDOdHVDKMa8ATSBocbDjRESr5QynqqYnFTCKMsIOjTCu05Pv3dpSz522GEOApZdEAUAAADTHZtIqW11vEnVS60OeKBc8pcrq3dBfX+1z4sGyz67Kb9gjs1szS8kzv4kiyLS236+lCZu/8/tmk1HuVVRgUNdjX6V2H3J8EaR7wz37Cvrnf3pZpaEl4UK67YFz9T8SwiMKExZUX4goYbzNTC2z8LtE3E2ktbhxRplU2BB7lmx1IeA3Bg6FP2PfzYvDb07B3auD0VcqZ1QdxATStBqDlxQizImX3FBD3HJl3bJDJJdOkp3n+x04vbslVAFmftsTdkPw5RAidj6sEU7lCnfB/8aKQId3ju0397mn89xzQGihZED5rbopagwGBMgCXWFo1qw9F6AXSBqar0BLNsohePw6Y2XdJdn2qs+qhsf+uJcQZGizd2idYE+6Cj/9IBKHO/mDAdPc9wgTSdteC98hcIuWLb/tWa6yc0Lv6EdaLJam7gp1v0HZK2vmm2qE6jWRAtLZeGnFFM5ernUvUcnJVI2UxQYpGLrF6fjU19HBHfOaq2U3M1/1UAZbqS9xKaVKdHFf7eVMeGIX8vSvGM9LoywDLCmIDOve0EpqMjVgmyq+5RwkoP2UBdFYQvDVxLzaHEhtog6uPE0dt//GIaAwdOw5wQFVeCLx1Zp4LNJTi/WS4tDu58gKSAZ6+5ONqHRQbUuI+nhvq/Ch7GFuI4eMaBoBI6fSnU8e4q4Z4PADmAsa2+sdOfCMMIOKnJzWdw7h533XxYE4GCEXyabx8ZV9b3ko2s2lrxagM8zml40OjG9bjC6Fot8RHNp7PNr8NSauulEBXCIZsijgzii5+UD9WLg9x3IZ/N4S54IZVMGYX5lzTs1lIPfCW52HzdWa2OvBdpPhJ31CRckGHZ7QJM87BRpfXRxr4QkkxfpRN8MUbX9Z97o5hgJY/ot2sKmmhog7JkccFp/YLMW63+eljAdc/IogTMuDoTuGSFgM7vvZXGFufP+X4q2RfWgj3HbqtCKhw4zls/NHtH97uSzx4zjft3Qi3zgQv1sHwZucbPlFfBilcVl0iatcarJWtDGwEnQHHGG8+8OAnjtP4R6DFideI6jJ89VllEzfMQYB8GyKm1OV7voVcTrhaPqQ1qZbn5H/dWou2aLQwVQtsK9InYorzNLf0tmLdCcbY+x0NZuEOCdOLiSxojEZqtSKL4VEK8vh9CKv7ZMY1IKwwXd92tOCgJ2yPpiY7sPCJzaKawkeTP7bwVWq4ySocR5AE3+6xNLMpTqHLPir/wcbcJlUtnQK/v+cOuHIy1Zg2G/osStzWG5GAjpzX9bBnWlN8ULvJVyf4OIixPTw5nL/3K5v748fORIKWgJOyGiMNp1ZBfgdAj676yTzLjek7bj+vrEXtcYZdEts1RqJHl7EsIunZTPe+LShTS8GfQDPaLAiffGmVdD4o5ROZ4OiCfquvU4Fgzfvg45ylOIBKUhruPnBACurq1tr4nXCLTjoQQqJIWCO9XHQ0RXf6SVBg=="
+        }
+      ]
+    }
+  ],
+  "RecentFeeCache setUpCache build recent fee cache with capacity of 2": [
+    {
+      "id": "a4d01ef7-faae-40b8-b391-a0c5d567b528",
+      "name": "accountA",
+      "spendingKey": "13e5d10fb3e93ff71999d9f7ef141d87dc2f7a1b56a7cfc7f6482b34c93f7b92",
+      "incomingViewKey": "648e04a86cb9865c46329e7a5fdbe959dad7ac1907f48d07a43acb90d9e38707",
+      "outgoingViewKey": "de3190f0213bf45255b9eacffe5667a46dbec4c3f55c8b68c8d7500fd4e58be2",
+      "publicAddress": "800e3da2e35a2529bffdaf20b458095028c31f41034f48d62babcb2858de0bd86cda912b6fe1cfff761fbf"
+    },
+    {
+      "id": "96b45a05-ef22-46f3-a2a4-6c44e6b2c7c7",
+      "name": "accountB",
+      "spendingKey": "852a5f039ac55876784b982239228c4cde02ff1399bd5fa9454d652ca48af62f",
+      "incomingViewKey": "4f813c9c3342a9f892eef7ecb06adbe939e02ff14d5faf1abbbc8959cf97b503",
+      "outgoingViewKey": "38b6911171fe5b6d5624ccd344734e37402c62e20230419d2d3c69e3d473f92e",
+      "publicAddress": "954477300cb777157191166854e687eebe6bd23ac154c3d3da145735630f26021c2b8892a24fb5658f0a3d"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:LHbm4PNK8AWqBWi2kb0zqQbrAqAQaCuX8R3Cgi5vGVo="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1665522512563,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "88835F12C8900746458D6D31E8A8D1E30231949F7FB52BFB177814D59B7CBB66",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALFrakx+qwwO4InpiaTaQHibDlBbcP6fvCp3SjhukME4meLRRwHmsa4pPgkIdwjdIYWQgDabO3gIATfcmYm8leDaAAVnXrcsJ8VdBXU4qP+lG3NFUVN+/QL80RGHIC6s9Q+KzsecFhX4B4tuo4XMQUfQtAeXjG4M3yQvTtvBG6nxNWiqZWuckLJCRhSzcSwu4JJySEELuafiPH+dm9bjF1cT8rrfAcQg8zq3rnwwg+DI8fNNAvlPxMA6eHVvv9tz4ZkJRTRuuQCpQeHUhTZT616axmKGbURjTGJEA7N6auCM4Y61dfqDYsPhiGcg5/XTHfWtdS1M5co2IPYk86V+SAbHG2N8QfQe4KavcGMnw3FEAJ9P3zGFDtnyzTQ1koz57CUARpv2hN9aDXXFRHmb1ozsx3poIal9fBE3fPT42O3UJdBSktLJqYTblZWMbjRWuy62e49+JzsBepCerw36gtmTGAH4aiCQR+qm5zvR2kdaTCqkxa0QXRtTOkZmO2xs3eoDo0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwh+xfOTcaNScakj2gTVQxB3j89ty1kCc3gykn7vMo8YS0HvwV2rNGn3apdTQnH2NopASVlAUZFWBzWgkHmgTfAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "88835F12C8900746458D6D31E8A8D1E30231949F7FB52BFB177814D59B7CBB66",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:cQG4+DvDtaxP5mYN1KK0NInLavP0XrlCBuV2KuqWRTg="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "81A48AB9AE4B9DDF941AA9C3612E67208245BD31B7E01FE40D64F3B92285BD32",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665522514042,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "D3C9324387084D0EA9C5524435D9D3028ECAF012C5C0FA866F6700E88F989934",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIGxeS20sJtWT2+DgpW6KAdvdPG9kQKFsnfeTos59s7g+MBXUE1Qv5O0mW7wYKNOjZalQgShdVgaAt9BFHWNFSN9bHnWqYBtiQdp26c73pDLV7JakLa//NcDWxiBITWifQIeiTSj6P7UwSa9Z//66kWU0UYhdaXt7q1RsapcL7Uk+uT1pQ02xXZuQAzEGPVWO4zgZC+iB9kyHdgtZpqyaUkpwvjN9Dc2i9PmY1iiscSMFCBePEDwz9k2kKqz/HhC/s5rtHs8L18+1M8/t7kWZh/r2Cf+tRQXYxzAQ+C1SO+yogoND5RtTwIraRdTCy+DdeIsa4X/huXdTmcgR7cEYgHsUu0WKeP+2hPmU+PlKCzJjpWtTQR1PcMN3uRRFlXMuVHbOiECrKXoe1gxiBZGLPhlkIFpqmG5thtvZBAToaRDWbQe1opLCkt9sW3wHD2qh3GNo9qevVwMe/xzOLi/dYkpJzKPmWK9TiCItkE3Nt/YxKsEwyPxqrqnsx4KEXxQ72iBv0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3tZNrZ3VZhJLKCAE4cAHgHMFZ7gjrQmeUssXmWWu/6rk0V7L8eYJxYhy9eeXSvpGiP5thoyKaAouc3E4arOjAw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKL+pKDgE5jx0mah9vhYMb4ckdcIa9zMy/HEkzBFVOrpROTPmM/dlGtk31a+OsWmXZGLh8V36rPYK7NenS90M2qjo0AldYMP9d2ytoNeREw0/2VKe6zJyYh1Me2G+Iu0rQ6kFF2xtlxislTkHcOzri6NOnyzD/8gqeX+gK5Z5D4/zCJDabZyqK6gGYrnXayfWKlj/5QMDlVbrkqo+uBx/oEhbsB4X7Gm7MVIAcGLfovqQMeDnwyBnVn31GrrHf2fJtBjPBRC4nDGpgDhg140c84PoFptPI3KvMBLYo3NP5YiXERcL3hdkvx3vqEkJLjNpiLwHfhdlt2EmlAVrDj2oN4sdubg80rwBaoFaLaRvTOpBusCoBBoK5fxHcKCLm8ZWgQAAAAjraLBBlYHIQ97GYS6Mwcu/51pqB0sGXMQ+A3/x0UBI+ZaA2337EOYR/IHwsv2y59IBPYpgMtZ0a/4JBgL2HoFrVmd4q4lX8ytCwa0vmedlzxAXStGG3sZVEpKWjsUfgWDnF3Emi4Q3RUL9dYEjjd5C6vNeGmGbPXnfHvfp+31UrUVmSSP5KhEPR75uyCD1OGhqihrFdsce4snb1RuGzwzUiPS0ME4pEqBgsaO02JAxN+RzifvZqJaL3OBrbHTV74Uq0+kyB7LokKu1DtuVoii/wlfyJ9cHzAfer9kOti1d0Rvegf8kDcnaMf9humwW2ypMC6NAgRb++f/G5hxVtj/RCKsG83/IyaKdsjTIs22EIXDOUu8C1vq0GdQWgYUafGGqKb7AkUPsnXoywxGRF6JeMCUgKk22aIglhd6/pKqtc56lpu1RJGn/tgbkw25c4uNkI6XEKxFI9JFjYlxQV4razFd1mTbU9+iCJ7c4MpV4G3TLhk/IUzhQSUnKvB9SyYvV0+7GMhu/ytWUibV4uvbyLFFOU2KOj2bj61aGO6MniLsmjy5EfjoI9jTvEf+K1sgWiw3V74W46kIJmR7qtMpkpRr8Cs/HXw4nfxe1ob5nRLj2SCy3zVFl+msLgyeVUrHf8ogra6p6ERO/Mvuz+tckxl2od0OF7juGzMXtF0gIjB7Fb+QAb6bvvJPzdg2cSmX0hIGzyv3iaI75imt8jANXn/kjAyDE3LaBxAZ2Wen8kcJUY/3eC/YWOtj9qt4SketjAtyKg953XCXfKLgfoO0BRRqAnJeJEXTJMm9Oa1exigLiKwknmhxwvVt+DE30fNty34OjvFeFWLmDZlzI9jSjrPAqy2Tlx/ZA4KaIje1fGWFIxVD0WB7UxtSSRPYcavRzgJy10onup/jMKOpMBUVmk3tT7hJbMaYtCsVdMp7JwDKJoZfaqN+s4gy2C5n2ljaD9HLCiKL0cEhUGXpwCAug1+8rqyKL4v/n8kHFGNrqhNCe3sL1vOzw2Dm7qjUyGggHVtc6ISK/mzh3XgYsP5Dm+HsU4DZk2p32ECiGkGniQlW7a1l4IfhnAOWgdfKWn2vuHJ6pKe+01kYgNWoc/1L/VirIlvEpsrsUuhapdUZCH++tDuq8HAnYL2Us904OO6fYI6UOvqc5aL4Yc030D0CQaR92NR9hIdq7NBs9YysbduYEwymu1k009lKOz34kJGaQiBIa0/0Vmj5qhcQOk1iI6sofVcRVKJVTgYCTPZEaSPmkvzjxvTmtSdrPnwmtgz/M1M4wKK5Qp8ix+IrepEfOn+K3s7OMPbRHAG/V9QhTHWnscKK/WR+Ghhz3ZWfpERCBraq78iQWK7OdiGlzOeJZCcGa0jNh45bRDwwsUUbLeKG4REcyyw6DYaxZtsN+Ii3ZuT0daWwbojDkVS/qQx1ZUfkPbHW6gQzi8R4QvJQYtTDu5mIBw=="
+        }
+      ]
+    },
+    {
+      "id": "b47730db-7376-4a6f-8fef-bea40bd5dba5",
+      "name": "accountC",
+      "spendingKey": "1cda14fe0856671797b9b59257c575cc5084556b20fdf471b7f671ebc65e81e9",
+      "incomingViewKey": "0561ad5b1cfdf897e4f737f253be383d1d917b0d1b4d343f6bf203f19f8c5b01",
+      "outgoingViewKey": "89f788ffb511744413682ad1dce341401e65f59ab8cbdb5a1e7bb6a1781574b0",
+      "publicAddress": "152368d7f165715bca8cf8c21eaf53932c000ea908d593b9cece6189d782992b47b83840d0f3dac7506541"
+    },
+    {
+      "id": "d18900cf-a3b8-477d-9730-19980f89d14c",
+      "name": "accountD",
+      "spendingKey": "08cda5834d4c5e330a2e2cfd42c8db7c47435eac7cddc7649ebadfbae5d7b8ce",
+      "incomingViewKey": "3efdb57be69588f2920d35e7cfa0b07df2010652660e1e498ba4855108e52b01",
+      "outgoingViewKey": "f8e09249286350d9fab8b576dd7443319b5305379f97970e34572c225da89b20",
+      "publicAddress": "600ec607d2ea3ac81d672b8e9a6d9b1b6b1d08ad9171e7dbfde262e0af64be29cb0cc8e1d9a4bb10a21a91"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "88835F12C8900746458D6D31E8A8D1E30231949F7FB52BFB177814D59B7CBB66",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:iDBmVEZ7HMl/FmboXr0pFDNrmDiRcq42XLCmUfmwUjQ="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665522514236,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "5DDE76667E871A6E3AADD6C244119F957F2207C684B6B471AB29321CA921ECAF",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALJS6cZXeT1jd2buZHjvEQedcmICtWGnRJI/sF+Cak3lbA7KH5M+iX4jrOGuY+yh7a083d6W92eZv350dRo/eU3TfH7ijSa4q/tfqNLQapei7lDx/ZZflIVp3Te+f9AIKBbfiRKrbuYYTV01knktcaxbqQ0wlgwsng8LZxGReKOJcqMWYsw+L0v4SQaEV1hD+YhWX+DA/FSmRqYUcrQ1gPo+1aYMvpJSW6355QAwTeahcx08UxlIG/BBpwo5oMHxgMq9OCbMFmquQmmPbGkc5PeeIL5mVvtTZaooSwtVaxpyXBJi4FEUfCVVRuRUUeioMm/4jCssIGGUJJcOM+HCyRt3gxraYeXsF2O+fPISVNVAV+BzjVhZf94WRgUzN6lMuvqtk6G5J8iQlaceX/9ndbq6pYwr3QCWGnFgywKuAbavDyb96+KOxlA445aToc2ECcG/PSgk5Aipcx99ou6eZP/QXWDBVEXhGLEo54FVe0wBCuYdUMfghp2jF0O0dlxi8p5kT0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDTZFh+VIcVPalDKvKPQf+dJicgL5Wxcj9lrQOF3xLoXb3QsCqE9RZLKA0ayvcmx6TNNwz77bco5cblHnPoRvBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "5DDE76667E871A6E3AADD6C244119F957F2207C684B6B471AB29321CA921ECAF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:FPoj0P60Do4jo1lWXAlxiiRigNpwBrUn/nv/Vsc5mys="
+          },
+          "size": 8
+        },
+        "nullifierCommitment": {
+          "commitment": "E3CE5C9DADC6F8663989CB44802DAB2D3A0282253CCE88D5B81B8395A5B3D645",
+          "size": 2
+        },
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "randomness": "0",
+        "timestamp": 1665522515643,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "2C59C83FBADA863FADE6CB9EFE6976FD2A1141960FD0A0A4411A90733E560AD4",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJSr0woPjH2a+S3VYRUBV4WIAU4qDX1SCZXK6S4HVfwA52ZqixVMq4r7mFE2+K8nXqlpQdJ85x/eEibGuFQg4ZjOpTTgueRPwGvvOqj9pJwtZ4mu3uTod/291g8Cx3BEYhd2k1cBUPxR0x9qGvv8AMww3WQHdccjHNq3sGZRfKaBw9oiN1yl7w/bLSMWatqi7bCiusLizBH+52cAvGKLLGD0cDwpEP1AgXDmwbo9csclGS1IJwmEeql6jWuy2ExkqPDy0zyMsD3VT+OSZTDDeauvT4N/Ju/ridj/Fx2TfVGKr8X5UYAcQtzDDv4AcAjXC29STQxisc+XNNAcmHnfgiSrM3G0K7W744DOAGgn1h9dh+2P5pRcuBqeGpaIW16Bkem6LA4X5U9WPaTeX2km8YzMVkEMGw8GZZNJJt52dO0dOFDO77z0Erej9o4/SBLFJFuvG7oUyAf/EOJLabDy9MiUF1F8K85UU2yBdglZ0DCqsANwS1QDsXBe+ifqXLMqHKzpR0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwg2egkZWE05nQlK76a2NUmJVOgQf30wCb+zuV3t8cnyQC6PXdHnbmd+TD47wZmaLrkhovBOl70E1XTZX9uHLNBQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKq2yIV3VLT3dInfNOW6avAdPlw74v+grSNzC5mEbqxe1IEewQvQO118TjrP/EGctIrMuWr5DkckMxy/Yz97y/kLsUEyFgFMjazHsxiSinhVTyRJAvoQL6BNAeVhMstHQwKm3emSiBPeutIG4B3vaJv6w6pqLPBoMOeDCHe35zOYIyrP4058z5U0VEIsgX6RnJXpILNGpkVijUkJZ2LP+BCJymtPBXe/3sg7Kalrdyc8RYqcZzDJj4MV9FzpM9qKb6+1uZKvkbDZw8OHh2AGdEaS0HD+ui7d6mpmuUFzOtRuiDkYOyjECDk4aFY4zVtN7txJRvbpPBwUESu56nVUKNmIMGZURnscyX8WZuhevSkUM2uYOJFyrjZcsKZR+bBSNAUAAAD6fNA2B2fquG4aH8/fUV3asCfry3QzXucaCcmZtAaDpekGUQ1NDCLHWqC2pLhZM75LnCP2/4jxXO21AvknVuSefUvSb9RkZhX6k2VIRokmzWaQOcH0/Z+b1cFPhoMd8QCrTU7K1kDUsFsoGzVKuMv655iEjAk/8sDWuk+T+BBy2DIWBrAaYMzi7FYJo63L/vuOaVRPj+sqML/rHXaJJ5NmGkIu0aXnoGHLFG1GK7k+f7jiiddP5Z+G5+0aWyVvOKkEzBc4rn+DSXi4zhyafAogvRXA2TS84PRWRyKjF8J0JoKB+jy2CpB3IuYQUe5/hrSrWatyH9oGlh4s6R9GG31r4KFPrD0br71Kypd8bP2l/2y5xNmCxxDF+XGDe3QPjg2CqqwpclAD313vgtSq2TlbNbFAx4bbfdNo6xnIO5nsG/jkyTGazUEWIAe02vak4GbMQBz/c5E9iJDxyC16i1VrIzb8algWyvbPISB9q0eqUZAFgUD2GZ4TwSuysAS2lpskJuh8KnlYMfl9mbSKEDxPnBjmVXmdoYHFiEpSPSOoKt1iECqYOfCk28rMHxrIhXHo61JzrGuHo8The/Je19UlPV5hYCfzfw4t6yXF/kicGXtgVMTxoeP1tVno+DJNjziN2puP4/nmeQ5gVr1Qb1hAp6Fwv6UTL/d8Zkw4s4gZIGaC1WK8e4zJGHaIWpBraN6elB8rQHizpiV6n5yBSjtW12EkRsIwv1ydJ3izme03McmsR6vNm+6b+q5lMeEvR0PflRMcowU8DYKNAtg/b7BpVy0k2pchnDF3gKDQhUNWk24mXZTdGCJCxUE78u9bVocNf1edkzlBX7jTpeMUVY3n6C98u8DWScZCgh4FniP0s9RhtQx48Ku6T10qhFX4yfJzzrQGpXZL3qqShbPQWuHhjkJxJPooaa7gjNWDurFAuOCpFplKgFq5PU0D9aX/5bR8GSFuMgm/WzcxI6qoqNZFGC3zVA3iZj2sq/Wn/fEHGeUi6dRMR+qnjwXntiHRoK1Dqlpr+suM35vJ1IX1COnfHGeeJE179DlgTxjGW2Rw5ttSGzuvxGSDLuWejH7Jbg9SyW6FrRcU8jCeN2QLH3B5/BQwuLKg8O2NtdIFk5zqhqJOsOa9+0arnNz4uxZJduYXrXUvpXafzog0PuzoOeqEkGp0fE2VjG7t7PiRjilRkQwmAQEZmXvZPqg/Vrot/KVBrJoaO1IuEyQP6ZAUv2Qfa4+5aUCQR9A5cvqJR1yVnxxn2YFboVTkDMDwVN+gH/LGDKMFzTaZ+wNvxgnanr/8aL5bDkv8aNpKBJlLF8kLb88CLo8dPAxPtdGguvytayq6sGzceNFt2Ai58OTCvCv9FqLEo50mVYJCBsWxi0AqkZb1yPthXixplNyTeMTAfYigeMa42M0lZLC1tftRgP0eaHMyxobFSuCCyU9ENnz5g3BeMTOkAQ=="
+        }
+      ]
+    }
+  ],
+  "RecentFeeCache add transaction to cache": [
+    {
+      "id": "713a40bc-75b2-4694-b4b4-426d9a59616c",
+      "name": "accountA",
+      "spendingKey": "9836fbb418fbce606d9b2db4e69368981aa368c261178147e670a9916aaeede2",
+      "incomingViewKey": "a6717fee76b32a50e3f7e16528312df845698440fbe8297786f40fcca0e08600",
+      "outgoingViewKey": "0f36c1ed6a0190dd0cab37c125da442623f3fa4459c033479f174811abde1635",
+      "publicAddress": "82b465ac3ba4ae2c3de54e9e25389671a6c95336746a31675423d873e73d20ab2b51c401133d1586f008b9"
+    },
+    {
+      "id": "60d4e41e-13da-42e0-a517-b21fed0c7bf7",
+      "name": "accountB",
+      "spendingKey": "167a4fe8bb85425df7fb35d5252231d2782934d0c76c98504d2c1a94f2711c62",
+      "incomingViewKey": "9efcb047eb02e8e6ca850ab09b6ec1452f6cead4ecaa8dae507de1c8f6fe9903",
+      "outgoingViewKey": "60f4f535acca424d3e036fea2269d9b40084863e2d9cb6dad7e0f432daecc49b",
+      "publicAddress": "6f6743bdb1180688475118ab8f6e0f9e8b9ed15a9d319735fbd7c102cbd7fd2e5267898966524b46d8843e"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:aOcktV6VykdEri0S+VJ8D6aZ1gS2VEr8eRRy2vuoTR4="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1665522935271,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "CF4F340A0AD57DDEE4CFA8421218A3904CB29EDBA9699A79C6A66088001C41AB",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALSBuzfG9eww7rJS9xtrMrSQz81vRJcLbDeMuJe+ZRmg9r/HT1auuVVAywFhMTgXW5Z6O3Cq7shhYuIYc/2djJ0YpY7TcGBafnOL814nn++cLKYawgzu5uzOhgevqtD5iRnJm5hFu2BShKwLcS9TyDnKu2uE4s2xdI0cmvVRB5OkmnY/bJtR9Hfm/2eofzdN85KgTheh8jnp9vpQTNpQd0R8UQHFrd1VmwS8v0wFwABm4j5ugJkJMpGuhP3YA3iY2mNbfXDeWAL43d54iNZU04r5MxEw0iSr7w7LggqcsBOiEmqRmwdW6c8SkvrcFT9jCye8tnXzcjRRVlBAJZBbMUM5ghV2BRc3CK34cq0cYnWhPTUr2xyTI6ZGLU0OYH8GIG2HuJW7osciL7AZU81ouygHGTRMp0bbSSrDdQ2yOcdnW0lz8x1aoMcLS9S/b0ksqRaBTudsevofeTL9SfWEU/Uj8bnMrN2AW2znZIfsosoFDFtX8YzhvQXs1iA9A1yWzRxipkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOgVNwSONW0ndTgPSh83Mx/yEhneeZ02/z9eGvGSMmGCLMSBTS0urACgktoqMetwJtYO05w2wnimecJReO9zYBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "CF4F340A0AD57DDEE4CFA8421218A3904CB29EDBA9699A79C6A66088001C41AB",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:lY/X2CR5QoGecUMuXtU5gHi7Cg7jEwO0agsOVgLWTjo="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "59A859B4BBA7AE9F091CDCBF3908CAC856686B5D00F6E9A4C13D3DD7D3A9A717",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665522936589,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "35502FBDA7404575447D9A67C2257F261FFD88E1726C49B71284658A263B9E0B",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKbwNEqqeczYVYIxk1TgOudkyMO7tXbnEXbWvrC6fPIRQjXQdkNkRsCMm5y0pnwO8ZQIbnWUry0rVB2euWSjUOTcEkh6AVgxCXvcexxo54PilRyovdqVxf0IPeuP7y9qZxFIu8B5yNvad9B6jqpMYkfA2gX8ATUF6O+0+RqWXdStwoL4mgXYDNl/VfBS8JQ0+pCFub3ctIFFvOhTWuA6OxZjgouk25BPyWgjX9EMZktoptptVaL+gsCcqsdidc0P3Ay9GTlfRM3qbTRaEs+JQTab2X9EdpKUKCmg42NChl1jsLhTz9YsxHhPRUHReDE8cfJb/fCb2tZpm20eIvI7N2rzUnryqnkIFO9127K0kuKeS9FGmD+t44E8DdJadJPl7Iume9xuN3qBFtIjqWIOwqoNJiB7ciMg3i+lgoUK1Glu8z1jDqXFOBiSCcvpE7Y2/sfTiB3Yuq1U61UDKkF6rb0HNt71aA5KUTfWO401yDW9nu0bgP4RWnGsUONV2Ko9DiRbnkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwb14A92U1/bR8nki/EDMbedZogKPoIx45lZND5Y/t6KYeDBSz4VhVge6ovw04N9pGAYqEb9QsMqCQzej6tmfEAw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKX+rx1WAcqEu9guUf+mtnTq3kvPt03YKBo8EM7F0jwdzvjPgJ4AaT/XBGk0iuj1kJhT0lAnukxevknfOMHyq/z4T2QAE2VqyLmaU8lB6RrbHk5Nx1TmJY8FnWkrtCjkbxl/no4pK7DRFaWs4AeX4sKotR1ufcrmlFzd04tUV8J7h+QQSWNhGC/dX4qAGClCtqzGlZvSlGSu/31giZf20l2+6e7pigAYzcz5XGOg8FzRcv8BdUjdH6kM/AIooCEXONvX86XBA4HblKAzdIcAOrgNos4EYyIQwfS7725/AMkAumEBKih4UpDgeyFrmHG848fcM4Jyv/rlGOuMX7IPALto5yS1XpXKR0SuLRL5UnwPppnWBLZUSvx5FHLa+6hNHgQAAADmG770CwArF3TgaM1FzUM9Meq926DpfezKEtTwBPxogC9BZ5UYHmdShp3qOZHOsgSL9+oiOJy1ewVJOfWHMXO1WUkDjI+49K5uE5Pkk0CL0gjr38QI+j/FDQ7fmS8fyQqYHCPT6ro/ot1KPwRb2018FC5KChDU3J6+dTzCuBAEJekOmX1RjVcbrtTMWXo2AtSQnPsIlwhVnnvWHiMzsCKV9NJElkQr1XAhZVRZ3fZQMZGbjH329SZadIebmLF4KEMOcn9gaaCFqCeW+yn8OTAX1XygxiRleqJT5lXtm3lFLDbdRqfttyUrlV61dClDe4+AHJZFPwEtZYGmaUW0JxqTKdqBaLkKh6gwC3DNhRP2Fv4bgLf6pnUnXRryU6KAV9qjSwetLoAAtjm1YKh9X/6qCCw3iAC65BBZQwmTR9p3wRbvtwR7RRsdQpft35vTBIUCm4nnw2vAH3NmZqLWFMtkwxyDjHI7cRGvZQnOQkVVhfPeFwyOIw/tAEdHqpBjdrZ5gNd6AjWHAE7ILV6G8IXdsrD9Y61zcO3RPN4eb4dq1P9sbWt+o+IiZpre/kT/Ii+e2Xiv/qiPpiBRwCxZYz3ON6aCyufypgntLuzmzpfbom8LDGWUuOZlfCP+RJWMB6IdGjRv+0CtW+/I/ywRl8CPyzcurV8mZ5xlmU3Hl3Diq/IyWf543vzX7eT85jYn1n39eNbaGgo3wd28SVn4vNaTabaeLTp0SK3OnN5aLP45Tcw7vJenu1iwJcP8xe7nPFssZLsAF+jWn1GRRlFJowBpl+kEhpMZk9/H9s2eicdXV2sEUIcJxfgKLWCX+ror1ZtQOpmp2g3unuW2nyM6IQ45QZGEKpjoQt/wEvkCpJOOLeSNugwFSxalAm/40uyqtPcrrwkxwNY0Jlg24JVVC8D2Kc6kzo9xSVt9GgQmwJsy+DPyRIzZpO23gqhQaxXows+hylvGQuSNwjWP5KxrlA0fQfqX2WT0cxW+2OOHct952JlXFRn2X5A2jyTUy80t1hVq0mitWfWrhN45Wxm0ETIAuUM4l7EXrG/3oyvk43Zu+33QBMSa+I4z4tulVWyVHToo+UjKl9bGpLEXLXwAH1vc6Ypd+A/xPr93VRC0OEOG5hkIgtFIMnRO5cNRAmN6IuJcsDWJ72Jttu/3hn36V9OW2+DngRHagIMXn6R89pfbHROae3Aa58gWg0H+Oh9HWOXUtzGayCwOvF3gEcueO3US0STsrGyEwZrppY3e8nAfdfbraUQemQ7IeuHcjkkbMoA+W6WiQ2Bb0Cne8JQnakB3ar8HVsXYt9JpfsJltolgCuoOEoupGyeiGEsbo9gFkafZRFZzYVNNe8kMkTaBPDHBQ4d4G+zVJohOuoQ84gXqbhjzcHMYcizNI+yGNPPFexnlPwI38qeFDiLQqQ4Kwh3DW+jtCkD0tYEERqA0/nnKUMb7McCOBg=="
+        }
+      ]
+    },
+    {
+      "id": "f68354f2-78c9-4dca-8691-9164e53146a3",
+      "name": "accountC",
+      "spendingKey": "97e8e639d605faaf45ca65275ce84159b7da6f190f8dc070e702023d4d3b09c7",
+      "incomingViewKey": "e167b3bb263d1b808bf9d8b56c755ff31161aeabbe1d822a0a6516f6d41bfe00",
+      "outgoingViewKey": "38dadc864799cb0c251d50f9a25ebe4bcf7615b6a6bbcd1ead6b55cfb2cc25a1",
+      "publicAddress": "00865fb04f8e5762a75cc3535f27121d80017bd1bdcd4973a558b4032fccbaeaed1ef0f47fd129a3f02cbb"
+    },
+    {
+      "id": "fc1bc9a3-5c0b-49cc-a1de-333f3dd47632",
+      "name": "accountD",
+      "spendingKey": "085549bda43ab095074d426a05835f4a214ed89e100536f2930413bb02ea1a6c",
+      "incomingViewKey": "66a10dd3e39a93f19d89dd2b1322ad754a655f2ce14c7a065e2300b952019405",
+      "outgoingViewKey": "e458af10942b29e10ca1bc17265cafa4885143c76d32faa495555a7587d5b327",
+      "publicAddress": "06145518e3deb8d59e16f4a3bf3e57a93e4615d1227f0f348de1a47e7657f956b9f86258a1941f67f06f25"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "CF4F340A0AD57DDEE4CFA8421218A3904CB29EDBA9699A79C6A66088001C41AB",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:6oIgbppHJcxZ5k4WGrdvloO4If6jaG+PL0RQJykAuRA="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665522936825,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "6904C594D4B92450DFF8737CEA8AF60B333CA1F9A821F60628D8C982E79B7BB8",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJBEer9bSJl5bf6KISAm/Cuuidxko70zn5pmeFceQFjnYGnfX5Cc8ucoK1gyKqOrn7lwnYSz5RsbCCmW9SNN0pTFaYZrSlzk0DVWCavb4xxV8HijTmwR9NxYW72jKQjT8BmML3WLtD9amvuCvX3JoEKICTw8wuRsonGUN6H6BDvf5UJ+qy+tGPHdCrnSFVUjHpmpDmi5taIJEOlwam3YJe3PgQWhEBd3JQP5zYhe7lYIC1Agvlvlji1sxkwv0EET6/yKjx1iKKOkJi1nlqCDCVfMCHtUoKgwdYbY5W55tbyARPmxbajpwPvEvtAsKrlPZnaOmUuIU1emj9VYUCkKxl5ScbkzB4Ocq3wRPNQFYOE2CUcKDeSeguEuaSmH8S9tDIFe8QgASTdK/YzZT8TV40rF7gWrZXDVuR2KHU1C8KrX1pn/7S7i5QoExKbmQm0xDQGEOCRgP/7j/SfgIJ6rBFmYaHaB3r2IudUJyD7kiLyU0xdGxcBo7c4wJ0kJqEG0eF/5/UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwT3s/uCL9oBVa5GjXhWytztggY0mpas1+HzT4BtVvrOtvWQTolutICqYbUhumFN6WOv4bDoCyI1V9dhIpMQ73Ag=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "6904C594D4B92450DFF8737CEA8AF60B333CA1F9A821F60628D8C982E79B7BB8",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:hEJQiKRaapDyc5R4qlLktCGLS8PFJg/fq/4lBtIdags="
+          },
+          "size": 8
+        },
+        "nullifierCommitment": {
+          "commitment": "5B83D2C38C38927C7EF1C1AD0AF2C00B980E796CFF626FF114C09894F54E81F2",
+          "size": 2
+        },
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "randomness": "0",
+        "timestamp": 1665522938051,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "B73DF538E366058D99105F897F9745A60C47E2C71E817788ADD8E4E0BC4AE85C",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIS7BGntmvEyVv9kBGo2snAZaL5tXywMJWdiWXgqZS6yAxvctaKXqRHMNgFG8fdxaqqS2brijfYwfau2jaRAbeRFKTEpARy1Y5ThdnTpndshhGDZFyse2yTEOyrSWVcqNgR1P6zpG2ez1/vOW2cAdKlNM8sF6sd3U8OZ+LSRuixwmRJRM03cNXENECOnp5XD+o50U5T19/P+GjkG4ObVytCjC6ZIme8CwoPZrGG6WzCvaPc0KnJsd7ubUKKK+l2d1uOwNbWbcJ0wuNdduKYcBIR82A+iZzoGLscxXzzyu5LYIsH1yLEvf/TQ0IHXomzBu88l8Em0Dr4wzv5h0WY0RE7kw+U3pmEBly30AQUX7vCbNW9+VKVbDKY6wY7sigmtg8tVYoqhTb2/XVpsVpms2h9PUxiiH3DXDHq2R3M3KeKXKm4QZkPEhhp/VSvja4o/vYwNB1BSGhD5VpAsA5x+s9eD4fQuGKJTCofQ6/nDLcAvIQBgCYNRunmZJ9MZmlmRSE0KwUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaAafOkFHpqvvdTD13PMJeDCr3BhPolHn0Uh2c475LzBKO2deKTSIgqvPtnKU6ne5nv+KT4NQIxFEo5vVOqJsAw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALUAxWY9eeEO6qCYAzd84oP87hHiKq5JPbFCxKRGhGbACwEqouA5ABRU2k/c+d+C24ApdlNCwwsfpwoGuJfIfSped3Ku64tedtyWQscaDmeRXVjwOZvz99HrJoFiS7FAvRVz9Uud34IpSOdBxMcVONDOmKVHNS6+v5Ig3ojyir7CcFqmhgFPpInFi63dBP8CtKUpqGXfT873u885ydwqOG2OtFpQPprPRgtlwJqyJMKCrwJTIybltVHlVIFGXKO/YXyZnDnWMaJLrMxvJZrptGgaNgpj/IG4/Mphel4OHY/OYtzsi1ZGsC6CNen8xrODo0r9VzuK1PC3tl3KYefGDGLqgiBumkclzFnmThYat2+Wg7gh/qNob48vRFAnKQC5EAUAAACZxXWgHnmcVa+qP5WcjMqWvo8MXycPT8/O8D6bd1ezzohmS9zllFcibegUfWG9POkbNRuTDmreVhomyjsRlwNuP+uGWsPm1smTyOmgdg4mjBrmfwRcDBR26/9hRQNCRQOiQa+KeD9tX0PHBkNhBZsJIacJfYm/ju6/YlD83HsMtzWzzwX3033spPRf1iWuwBaTYRA7CuOBZRge4dgOlwfroofWDXhi1639Jol23kLCyY3UYHGUIimI8SENeIyXgnkHSUrwoR/58zqC2/saRnFOyqYpFCQj56wEEdcmtsHQytldcyYKi2va7hOWWq0koRWHVWXBENm8S3EjIPtWwuol6oErq8UX7KQb+wfPp3tx3SrEiWeD3yzVP3VFWvbZrS5dPNkUX3IQk2U8uG2a4i9glF8TuTRusR8lbDW9uco7yRQGcpohrNyAEI/dmQpTtapARLqlm+12ZQxz59v0kyhQaz4yVD/rJZmgRNx7QwdEC49wKp3TGfPV87TRPdkLNZIJxSzCtExNOsb3TS62Cv34DMFOfL+LDo/XkhYLLWS8gJSNHQ5njxfJ0D5SfktAKeSgFD8UkxI6bjjm9Rxw7w0qkuQP/SV77Ve6CdEyuH1Li8j7qQyB7WKW+7k2RLZ7MbZc5YWBTBxAknc2fv4cWERJ5+uz6V9f1ft3V6nzp6gqTa0XYTfWhKdgHyYphFqIGIhcRXKoQiL9msBCIka+w68SQBmUxBp4e/x8GksY6lgcdhs2t6MuewGGyhbaoV8uDC74fkwDsTF9PmReiOupt5wNmrmzUa9Z4NXQU4nZ7QqPqCR+VKhlwakI3cTQNecxTFBrpOx0Q4BNGAUwgaPgZ+TrUrK92qNpt3OzyMvBy1f0Se5vgQyH6kRGPc6HSdkx9+HkuGYB2SZvhobl3mLUlzyekl8dR/7ge6ZVnzP5n/IcZgqkcbVsMNMMREk+6sYly46/Xqcx8R2nG05oHFbWy2GKry4Y3BOac1TONvaRjWbbG8yCKlfp1WqXo5JVQfHd8LLGEGndZoVMizPreVM5Eu785ggKpCmCvvDP3RHw7la5iPVMr7Khgyi3uNKH5XIXgA/qaW716b40/UaNRW4ACPuvxCJ1fyL9gQKToGSG7HMYe/k96ZX7gIinvRoIT67PomajyAZfCvKwBCGYC544+yNDnrQgyeD1JEVfTRydfGXWXXcrc0Vm5rKGqRN/GzAHUBzHMUqRf00j0yRYixaC3jN52vELctlIkiRlnibLs6Ph/FjNd2xx2JB+d4Y3J1cZCcAwZZjykCOolRzbCmDTDtOCOG/lyA9HIymLPCAxSLlAbKs7sS1qHmUftVvRNNnag/jlE7TuPqH0YDlcBrI0nJfGobpxoMcLGsP/9MvAhxUZHG/jSJKyZVYtc5nkQeo9UMYSBxrNuspT0t0gfkx/NYuIPyxROcMJbHnzFzijCsO6JnC60J0hCA=="
+        }
+      ]
+    }
+  ],
+  "RecentFeeCache add transaction to cache when cache is full": [
+    {
+      "id": "c5129610-2a24-4199-bc61-b24888b47b4d",
+      "name": "accountA",
+      "spendingKey": "86dbcd3c1eb6aae3ed1389d7637441b552b712b89a45caa0f38c16de9c9abb41",
+      "incomingViewKey": "1031a2c3b14da319e5b272d7924485927e82854faed59db5bfb4ab259760b505",
+      "outgoingViewKey": "ebf71636e6c017f38ab46fc2cc159e40bf78fc59435e534d202903f84ea51992",
+      "publicAddress": "b5e00fd94fa9b450c97fe83276db65dfc1b420d1e2d49a51536c1936fb2550e0a15f47f40cd68b81c7b8b6"
+    },
+    {
+      "id": "22abeafa-2f6a-4609-b3be-a2a1d5214ed2",
+      "name": "accountB",
+      "spendingKey": "90ddb6aa8c65050534e0a7fc9b5b8e4ef8c13352a063d47be99ba781a48989ff",
+      "incomingViewKey": "02f2a21fe572d793feef7a56da4df2cf96fd6bc99731a8223522f7a9111f3f06",
+      "outgoingViewKey": "c20b2de334fc9e8bd9aa2cdeae8cc49e5f9ec990684c2d6e614da7a2ccc22c15",
+      "publicAddress": "cc02ac270dae6529f1d1f3263840d3d0a923206af017e118b56b758ccda2aa9516b228beed5cddafab5356"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:vOP2itHpN4Z+JJuG0vdsiZ03kv3UdnmxJCtI5jWGFiM="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1665523187118,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "97263009717D5783F803604D00C1F364E92FBE0797C91CEA72C68DBA3CECA096",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKgMMeixjFMa2CGfOmnjgHABe8bjEwPyih+iXYxoq/E1B6qf2zdjXdxY4hnBiwnvsYFvTrNCv2eKIql1QXXAWUsrdOHzeEk9nXwm6O3UAJTsBil2VvNW70qn59HC9ihgWhn7IdTammuRXMBHTgdRzFA0tIwQStPJpPA/wVtKd78Azu9f5rXKZxpTDnP2S4tbB4O1M0A1EUSnNxUNQhOpRBk55uRGyU53Xg3PJydv9sl5xNABCp2p8hohwQUmkA4FqYT8aMxY0BgTwoFu9fDQgq7sDSHM4quVamcAW2v/UEazKVtv9zTmyJeeERjhAOkNS3237N1gqCSU+Dx/SvN1AESKZmhoKA8enRUQCh2t2bGy1bx2NcpzFQa5Nztck4LSDOVXLN7GzQe5THPjS+P19qnOQayWiKm9/fLuPTyPEImq6gwd65cl+sudPuI5ILNE3cWUk32ZrzMTJAcPBy2Tv73NyDs+d4Scddw8ZtsOlxjSQv2EpL7e8kOElIZf632wmgoiAkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIKDi9LPezbNYW6nazOkvUniVWKSc4AeXan8ObBeiLQS71ER153XixbI5jUt20WhQatN11jmT/cCvKH8vqaHwCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "97263009717D5783F803604D00C1F364E92FBE0797C91CEA72C68DBA3CECA096",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:DCX3tr3q5q9p3Xb5PL/hpMorLgqjQyIkoeTwJZ4wlms="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "88946B3E0FA3C5AE8E49A6AAC33C12A440F84E756FED2BF22810FD46C1ED712C",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665523188438,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "97B2CC14F912978C5BEF7B3D9B5BF42275F6A06FB784BF9EC90B911054D01993",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJbBRGVenD1z78ZYTzZP4WDuaaFONmwF639NwyIRauWOX8hmpIp4szJy7uDPVUDIG6vHlb9joSCFB/qk+5q4fdBel4S7uy/zkOcpts3Inv3VpHkUrCe5226asydyRcU8awa6j4tqtsDDlr1NAx13bwA1bYVNsy2MPbt5hr9qyfkUIjXbXRPWJyK+EnJBJXelAKBTdMzgN9B8fbrU+h0uUNSTjZ1hK41MU5nBhvXzuyLV9lhWjlm2+R7bWj502pwxfBSgCbvVRcwmHFGFDdhqLTnsAcDS8GnCSD27Jk8Op25KHU+wKJK/tZzqUtwLtaUtoGW67oD2e3Urj3QV664cCk8tO+vNcz2Mt/K34wiNSZcfPSklXOwBeBZ9HOXj+qEmaudG7MJgf+2pq4AlVkmFrE7fEHH9bOjtdmztPyePGMAAs1kDsgm8qZW1Sz9NOh4K+JGwZ+8PZmxUxtaPX2H4ik4wh5sDNkBUL7V+X3q41jIjJlM6cUMyjHR5Xdb9f5zrEtbrBEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNjwEMqKM6R7GDV5eho7gs81mdRkvE+x0CiQ8NQCDF9R4iOj1ohx/a5yyVE7CyIsibm9qSETmnwD/t97/O26GCg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKlY8FpjQb32CgsBYSEuuY2jDDDIMFW01vsJ9yWMDpksULgGswbgHi00u0f3SYcaBLdDIe+5MWZab19PkCYQHmWeEYS2u/QhkMA2+aR45KEPfupsL0EGa0QSXHFN2dWhxRhHwCQ7r+di6DFjQwtqpmawv6H19v7ayB1hAqNeCSlf377wOieWmKyf12qxt3BjSIW5gpYZhUQYEaKPh0ydsjekgzxURsNfAOu6XqOqEvq1uLsYd5VbErgLdEnOFCS831ir/wQx/vOi08dmfeS4mIIMC/qCb1C7bDmGM6iZMxuKyFzry5iuBnKT6vIzvP3FYmlE+Y2i5qY8Or8GIklHwF284/aK0ek3hn4km4bS92yJnTeS/dR2ebEkK0jmNYYWIwQAAACqEyi36i16PDt8wd8Qho3ys1VbX92rWTizT+8Hl80Xyx+4QRszRAr9Zd5ZWM7nb/iUzrMEhlAIHvF8mQvuAudLTzZlQTU4QbSljGNeuh3/KHOqletIazq2PoGaG4PkAgCSGKkeq8+cSg7mF9JWIPg0KttYaS9UaW0WAs7PTjjxRLRGxZM+NsDPgaNFu3s33ZeB2RwSMH76/649Z4tbFk2wmoAjNnJqEnbKxPQPpp1043OFwz40BTAoay1/JAAxziUHN8+1jcicLRUf4XxQJs4Crl3/nFxVynuEXCDHWsXjZMe8qbQ72FFvmmNRdoV2G8OGiDVbdxzM/i1CfhOhNffvKG++36FCB1M2tC0IWJaRqn/Tl11rWnY0zJrqsw4B44X1e9mM8/gVkJKe87AoVTUpg7MUAFt2PXAHELPm8Kfe4/Gc+0ZJpWY8ABGR5M8fv3NKyRYo+GdgaZ/iwlri+LsNJ9AbONfN8krJ80BaeYG+2fgdMGxx/0wqtG0Jg/XbLYOjuTEf2VEywEMbQhs/0NFVoTmnVYcsCyxXbzgXSmqL0MymsCU8LClDY4wrX5xRs4gDszANJzxT+dSHyOP61XSmfnH/Gq/wObzF++Rs4JlAM+3DojLP4x3Iz7mcF4wlNGefvrH8sRlQ7+KgeJrX/vKoC2Mqw8h8WnfbWNWkG92HInZlWvGUWZaf7JZkYWJXGR1L4kHBzUFlLSw2gWWnqhlVhCaLADXEUIwJ5t1oZCWYLqmntomYpDsYrzBv2V+OTpAyN1aWdXTBBWXwlqo3Axe0It5q30ibdmiHPqz7M9Os0sA0mpm1sovDoQSSNt75CBBHPaXMFdiaNSB0cwHhkDBmqI0Y9ZO54tbg8+DCBJWq7nzsIRj9wAXzgpl41z1P30vHeXDcX3Ka3EPxnwdCO+XYw5byIql8M5zOYlIUZ2yDoGuMK5APt7Br2MQCT/iaw3jrKl71mfyolQmIylm4o5o7xXAkaDCWiJZ5FDt2mPjp3yK9oFGABH1q+04aF24MNr/Ot0ViH22MOyUWYmm83Kx+y/4W+47zSML0MtrF2j8Y5YXhWGRk/LWQZEDz+zP/kXOIy0gBxHw6JbyQV6R4E+ZC1Ik3bkzx6nhkvgTrzv1ScFtYTEP3l0L92PFU2nmGuiUgLUFjvhRpqkWTjgpw7PNYVuXgeyYofzY131QyVNQvR8vM6MJWCNV7szkoB4QynLLCMvWKRmYj7ZwlMO0UDx+6PCxDTjTuAn2DKUfxsmqz1mlm3/5iWiOggcHekc0U06KGWJ3jrU/vBcURNwX91/Gnp9DPKANiX8UJRyzZZjq80uZd64JyT3/k7uFtAvMHXlgJVW8m7CAfEzpl8gncY1tuqaoAFzclqMnSwJg1jYSu6J31DcYcEhVBv7tO13mtKv7YCtfdSZ29w5IHgUedUFD8mJeI2zC5PPdvEJ4n0Pg0p7GIHXZ+DA=="
+        }
+      ]
+    },
+    {
+      "id": "88ebb869-e0d9-4605-a11a-86e9bff64b4f",
+      "name": "accountC",
+      "spendingKey": "746fb642e54d3dd9b1259ff2393076dc8dca29ea9893f67a5cee6389acfa0a3d",
+      "incomingViewKey": "7c390ab4cd628ccbe08a43cd52a3124677fddaaaca7b0db4ce69ed03a5194502",
+      "outgoingViewKey": "edb9c594ef8b71433d3dba2365af2792b2bdc1d162bff0054c188563157e1007",
+      "publicAddress": "1d88e0a480f9d574495cc2afb40ef2c52a6c5a7f709900d7e6039bc226aaccdfbfd0f890925c6654179d41"
+    },
+    {
+      "id": "dc1951ba-d64c-43e6-a44c-25daeb433f83",
+      "name": "accountD",
+      "spendingKey": "e3788ff23ef870236f0c78a5a57f36459b494d3d52b2c2f5dbb0adac2888241d",
+      "incomingViewKey": "7f4b596cbcb069c162093facc9f5b0a452fee285d9a8a3ac8fee57aae6591e06",
+      "outgoingViewKey": "cc617079303e9003ae99a3ac049c406ebd685b9fea61d417ccc2d2bed9440529",
+      "publicAddress": "118b3c3c1b9e26758fc17c5783de4bd1b580e663d08742d7cde75cd28e98381d049431ee77e222b4924abb"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "97263009717D5783F803604D00C1F364E92FBE0797C91CEA72C68DBA3CECA096",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:UzCQSmJWzXSi/gwdonuYkTONN02nQPE/EynzhqhF2w8="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1665523188588,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "DBF17A02759BE241AFAB757C9C5D4688749D44CB407BDD37904D972A3A7638BE",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJLe/mo6zpSPIk9lHyokqBmWwTRprZ9rIJrSgz4zirSRZwEGkKr/kpV7/FJv8PgGgY0CuhK/qbbBD9H82VBfosLq47bFRQIWyStGGCVgnjKKGeX9YKgGP2arF/OfUIe3LxeC0NsZEVUxhgv8LEBGbciBj5oxEZxpqM9WFMRy8zjEtKMDAyngW/t2vlTJnEuE3I13Or0IoSxuKUx6UrjM8wOtj8mfZCJpCcJwKqOFOB3wnF1ZYhthvrqJnfHv/ih2oVUYrJ83vU+vbT/ho0IEfuGYB6SXTF+Sq5VNu6FEIp+7wY4wA3JPUVp5lu8+LCDk50w7M4EzyCjIun+TuN5GmzJff1KvofoCw7rLg64l/9W+GyqS/MXeeyfDYFPPjBDfT1LJwLh+OPTPZVSHmqDqonuf6Db3dAxEqyDof8WImBCKYfVgpQN2eVCi/RtMPdIhpMbnFwEUK6TaswtKGVP7ynk2frA7mbvTnwMi7V7Ef+yCGGVBsBp5L0pYTzGzsOGqDm3fQ0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIhp1gLM5T9UA/++caozkKQdTC8ekJNvuS4WepexIdma4ceaj4iBQVa0ncNAZgypUrkbj7e9zEe8io0j/bWCjCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "DBF17A02759BE241AFAB757C9C5D4688749D44CB407BDD37904D972A3A7638BE",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:4LPvRDAKF/BYMxjMcHSwroyX1rT6k6MVPYmLYT1fSxs="
+          },
+          "size": 8
+        },
+        "nullifierCommitment": {
+          "commitment": "69EB5F0A23595F5DC727874DCDEF34BC1256B5D9ACB75E7691422B9DCCE640A7",
+          "size": 2
+        },
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "randomness": "0",
+        "timestamp": 1665523189820,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "C7F9CE8D1275B1A1ACB13492B9442F20790AAF1225C763B9C7A7A8C6F2FD902F",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAJk02nnSYXfcSVKgJzaZoirYybv0OriG75x8rNjAzh23xkWweTRzuILsyx8TheWbxqmLzMVKEiNkrGBkADyLgiHf/fp8UyLbTWV7ZKpoMxtUJ503Ppr/gMcvCZQd9bLm4w+cfLh13mcjDgXBqEhzo4OICQWSBKcZkiyMmKU9ZkZdWcPFDt9MdpkktcyxPzJsbouR/0tokO7Kt7MesCxVT4WAAoztRsvbOMTMAkhJOYLGIMHnGnrpLutg25yYnDEroWtO4J33+R7zGjKrttnKyVh0OpNBUZEN3juPzWE+6ZRunWBr8z/u0IXoek6h0hLeCWJlQj9cX//q3cuwMK1dv0xCAt+WJxFTz4R9csP5NWN/GrYq+UporzvbtVnLfxCvzNX8OU61ZgmtuAjB2NS9mPIR3+JBYSwpDAH71m53kANmaQRPrP8aaibzX5n3ZhZrBN0B9KS0C1pXEdzyy4BuBNzjqGdTTlqpoxvJg4lFsI9tCOjpBbONxeCaTsDJ9+Lx/S6mo0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZ8kbZZuvcv3+M9OytswXNs5kfwuBEODEfCR9yprDaAKsNdLLwJXiziT9xOhlxTLvL1EDjOFIpnQpErw5JV9/Cw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIkZKxFcyE8CQC2jZNEkO72a7lvlJQu7guywBbeESq6DcHyMv4meECGmCkm5AXdFV4m2zGRC5ZpB1oS+FUSum6E8AkBswyerSBhTB7qMk/nrLWmKkVteaToG9t6z76JWXBRlBOwxTPT5xM9jzsEDSqOt9tH/GYraYjRJiPcq3ARiA1DYtccgyQFYWnN5LQFY+4ewXbVlUR3frQm93ijPbP3I0RbaZcBpuGL5sHFDAlwDvFNK70ZIgoyukJhVUiutsHhZvfIm3nstOJkebHsmPGLFh7QWjggbVjSoHVdJUBoWizPdiQGFu2HgQilF47DE4/lQi+ucjqBHmwAA0jItETZTMJBKYlbNdKL+DB2ie5iRM403TadA8T8TKfOGqEXbDwUAAAATfVvYUQ8r3O8wE/AgtTnI0Oqdj+GJsvkDB5gol0JYRrNhFYk05bBGwT4nZUQ+QdBLqz07oCMaelmSeEQBMOwdDR8Q2/HCrbdZGarEIL2bSJuR31cfaALVC9/IjUSRyQOLhOEegIdvU5pmlGbUzbbkanYcowh5ilfKyAIIZaaz6nK/4St1t7zwncdaWQSz3litrxsTI0UXG8PBkr2tjTxBdZieGjtoBUkYRBAMRcoYAptB7pQSgEmjhgTBH08KddIABcAXFT48v5YKSeC15e7sCm7aa1bgkeH5hg44ZP+VxMnzc4VC0mmBpWgXfuhtyTSiXCufTC12XqzIlVW/93HpQ99lLf6haqCkhxTqYUAUwrbAfHfA9Z2E1Vst5lJWj15RaDmhvM+rTLtNiGtO1PVw+FCG/FrbouuY05lhy+DqRZaYVR+RD1ZVAFimpZSavfM2IubVd1gnfN1vukBUs9JIxJsCxIbfbXoA2OlPAqF2N3vHRtbbCZD9D6BD0EdA9fHkS/ZPCYpQ96MLyewLap2HA+sfrPz5y+paxtS981I8evSymuyrgbvCk+0/dWA4qeCNSGaLCTlG1tj//Asf+UjOEx+IHX0icX+K33NODlpqFo0dhpax8gYHvellq4iIKxzY8nXKyXao2996HqZP73d+rJzXlsaC62trUMW21LVaXdcB0xiKGbNYcIfsCawWUGKpvvSRgXogdcRb3VYwYcdrkoB+F9nOw1u23hltCLDXxCyHj5Phu47MF+t0iZrf0bZpNpx+msXEBICH2ljW+3nX9EsW/6HH1XFPQ4NluvpqsPd8NKjnht7b1lU1rVDWde4BFLQP8U/H4F0F5h+Mwlk5EuXlQGTam2Ux1js1gL0frzPkjA63ePkTEkg15B2Sk8gXU+DhQ8L+GuKnO5WcalK8ab4nGYEkMc8RKwgrSVYLE9YKZ43BLsgRaHaE1kDN3afEzipSKcQa+AXsW5PSBaqHqkBTytPwaxRRv9H+lFsTHlLpBgy3UTCd6SNvUxD9KdY871gsXgcxegBXqort57MkHpsH2H+4KY6QdBvsCCT9DKdq+XSy6rxNg2VLkW9ZnS41ogcmdT5vMqDPZGOCR2grK7UpZtiLjaRk/X2rXKijm7dimxNdyryIva3+I2X0/zbR56YKFUsJD9bw+ZVFJqWtI1EO2pH+z/+ydEwXhsUScKr8/4Wss37ZgWb5SBp1bD5MWLdgtzjYJdz5PhYCpmMAV1QBRTBoLmAEFZ2hBP3Etp3wqyxd5Xe4IvM8pHSYlVe4huAD3ymjIn7+4tqSQNfcSyc8azmJmiPGFIFglx2b44ttXi02QKrSimFWAnTp2eSnL7mq07phL+Bk4LEeAGQktExwmVLwFnBiQ5yQPp/szS+srv3dszWhonsNR2zUcNqHRluGvSYp7uNV6rc+1WuwZaCWTzdw38rHbs2eKQxEmJr+olYwBw=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/wallet/queue.ts
+++ b/ironfish/src/wallet/queue.ts
@@ -49,4 +49,11 @@ export class Queue<T> {
     }
     return this._items[index]
   }
+
+  /**
+   * Get all items in the queue
+   */
+  getAll(): T[] {
+    return this._items
+  }
 }

--- a/ironfish/src/wallet/queue.ts
+++ b/ironfish/src/wallet/queue.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export class Queue<T> {
+  private _items: T[] = []
+
+  constructor(private capacity: number = Infinity) {}
+
+  /**
+   * Adds @param item to the queue as the last element
+   */
+  enqueue(item: T): void {
+    if (this.isFull()) {
+      throw Error('Queue has reached max capacity, you cannot add more items')
+    }
+    this._items.push(item)
+  }
+
+  /**
+   * Remove the first element in the queue. If the queue is empty, returns `undefined`
+   */
+  dequeue(): T | undefined {
+    return this._items.shift()
+  }
+
+  /**
+   * return the number of elements in the queue
+   */
+  size(): number {
+    return this._items.length
+  }
+
+  /**
+   * Returns true if the queue size reaches the capacity
+   */
+  isFull(): boolean {
+    return this.capacity === this.size()
+  }
+
+  /**
+   * Get the item in the queue by index
+   */
+  get(index: number): T | undefined {
+    if (index < 0 || index >= this._items.length) {
+      return undefined
+    }
+    return this._items[index]
+  }
+}

--- a/ironfish/src/wallet/recentFeeCache.test.ts
+++ b/ironfish/src/wallet/recentFeeCache.test.ts
@@ -23,7 +23,11 @@ describe('RecentFeeCache', () => {
   })
 
   it('setUpCache build recent fee cache with capacity of 1', async () => {
-    const recentFeeCache = new RecentFeeCache(node.chain, 1, 1)
+    const recentFeeCache = new RecentFeeCache({
+      chain: node.chain,
+      recentBlocksNum: 1,
+      txSampleSize: 1,
+    })
     await recentFeeCache.setUpCache()
 
     block = await node.chain.getBlock(node.chain.latest.hash)
@@ -37,7 +41,11 @@ describe('RecentFeeCache', () => {
     const accountD = await useAccountFixture(wallet, 'accountD')
     await useBlockWithTx(node, accountC, accountD)
 
-    const recentFeeCache = new RecentFeeCache(node.chain, 1, 1)
+    const recentFeeCache = new RecentFeeCache({
+      chain: node.chain,
+      recentBlocksNum: 1,
+      txSampleSize: 1,
+    })
     await recentFeeCache.setUpCache()
 
     block = await node.chain.getBlock(node.chain.latest.hash)
@@ -58,7 +66,11 @@ describe('RecentFeeCache', () => {
     const accountD = await useAccountFixture(wallet, 'accountD')
     const { transaction: transaction2 } = await useBlockWithTx(node, accountC, accountD)
 
-    const recentFeeCache = new RecentFeeCache(node.chain, 1, 2)
+    const recentFeeCache = new RecentFeeCache({
+      chain: node.chain,
+      recentBlocksNum: 1,
+      txSampleSize: 2,
+    })
     await recentFeeCache.setUpCache()
 
     block = await node.chain.getBlock(node.chain.latest.hash)
@@ -95,7 +107,11 @@ describe('RecentFeeCache', () => {
     const accountD = await useAccountFixture(wallet, 'accountD')
     const { transaction: transaction2 } = await useBlockWithTx(node, accountC, accountD)
 
-    const recentFeeCache = new RecentFeeCache(node.chain, 1, 1)
+    const recentFeeCache = new RecentFeeCache({
+      chain: node.chain,
+      recentBlocksNum: 1,
+      txSampleSize: 1,
+    })
     await recentFeeCache.setUpCache()
 
     recentFeeCache.addTransactionToCache(transaction2)

--- a/ironfish/src/wallet/recentFeeCache.test.ts
+++ b/ironfish/src/wallet/recentFeeCache.test.ts
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../assert'
+import { IronfishNode } from '../node'
+import { Block } from '../primitives'
+import { createNodeTest, useAccountFixture, useBlockWithTx } from '../testUtilities'
+import { RecentFeeCache } from './recentFeeCache'
+import { Wallet } from './wallet'
+
+describe('RecentFeeCache', () => {
+  const nodeTest = createNodeTest()
+  let node: IronfishNode
+  let block: Block | null
+  let wallet: Wallet
+
+  beforeEach(async () => {
+    node = nodeTest.node
+    wallet = node.wallet
+    const accountA = await useAccountFixture(wallet, 'accountA')
+    const accountB = await useAccountFixture(wallet, 'accountB')
+    await useBlockWithTx(node, accountA, accountB)
+  })
+
+  it('setUpCache build recent fee cache with capacity of 1', async () => {
+    const recentFeeCache = new RecentFeeCache(node.chain, 1, 1)
+    await recentFeeCache.setUpCache()
+
+    block = await node.chain.getBlock(node.chain.latest.hash)
+    Assert.isNotNull(block)
+
+    expect(recentFeeCache.getSuggestedFee(60)).toBe(block.transactions[0].fee())
+  })
+
+  it('setUpCache build recent fee cache with more than one transaction', async () => {
+    const accountC = await useAccountFixture(wallet, 'accountC')
+    const accountD = await useAccountFixture(wallet, 'accountD')
+    await useBlockWithTx(node, accountC, accountD)
+
+    const recentFeeCache = new RecentFeeCache(node.chain, 1, 1)
+    await recentFeeCache.setUpCache()
+
+    block = await node.chain.getBlock(node.chain.latest.hash)
+    Assert.isNotNull(block)
+
+    expect(recentFeeCache.getCacheSize()).toBe(1)
+    let lowestFee = block.transactions[0].fee()
+    block.transactions.forEach((tx) => {
+      if (tx.fee() < lowestFee) {
+        lowestFee = tx.fee()
+      }
+    })
+    expect(recentFeeCache.getSuggestedFee(60)).toBe(lowestFee)
+  })
+
+  it.only('add transaction to cache', async () => {
+    const accountC = await useAccountFixture(wallet, 'accountC')
+    const accountD = await useAccountFixture(wallet, 'accountD')
+    const { transaction: transaction2 } = await useBlockWithTx(node, accountC, accountD)
+
+    const recentFeeCache = new RecentFeeCache(node.chain, 1, 2)
+    await recentFeeCache.setUpCache()
+
+    block = await node.chain.getBlock(node.chain.latest.hash)
+    Assert.isNotNull(block)
+
+    recentFeeCache.addFee(transaction2)
+
+    let lowestFee = block.transactions[0].fee()
+    let highestFee = block.transactions[0].fee()
+    block.transactions.forEach((tx) => {
+      if (tx.fee() < lowestFee) {
+        lowestFee = tx.fee()
+      }
+      if (tx.fee() > highestFee) {
+        highestFee = tx.fee()
+      }
+    })
+
+    if (transaction2.fee() < lowestFee) {
+      lowestFee = transaction2.fee()
+    }
+
+    if (transaction2.fee() > highestFee) {
+      highestFee = transaction2.fee()
+    }
+
+    expect(recentFeeCache.getCacheSize()).toBe(2)
+    expect(recentFeeCache.getSuggestedFee(40)).toBe(lowestFee)
+    expect(recentFeeCache.getSuggestedFee(60)).toBe(highestFee)
+  })
+
+  it.only('add transaction to cache when cache is full', async () => {
+    const accountC = await useAccountFixture(wallet, 'accountC')
+    const accountD = await useAccountFixture(wallet, 'accountD')
+    const { transaction: transaction2, block: block2 } = await useBlockWithTx(
+      node,
+      accountC,
+      accountD,
+    )
+
+    const recentFeeCache = new RecentFeeCache(node.chain, 1, 1)
+    await recentFeeCache.setUpCache()
+
+    recentFeeCache.addFee(transaction2)
+
+    expect(recentFeeCache.getCacheSize()).toBe(1)
+    expect(recentFeeCache.getSuggestedFee(60)).toBe(transaction2.fee())
+  })
+})

--- a/ironfish/src/wallet/recentFeeCache.test.ts
+++ b/ironfish/src/wallet/recentFeeCache.test.ts
@@ -53,7 +53,7 @@ describe('RecentFeeCache', () => {
     expect(recentFeeCache.getSuggestedFee(60)).toBe(lowestFee)
   })
 
-  it.only('add transaction to cache', async () => {
+  it('add transaction to cache', async () => {
     const accountC = await useAccountFixture(wallet, 'accountC')
     const accountD = await useAccountFixture(wallet, 'accountD')
     const { transaction: transaction2 } = await useBlockWithTx(node, accountC, accountD)
@@ -64,7 +64,7 @@ describe('RecentFeeCache', () => {
     block = await node.chain.getBlock(node.chain.latest.hash)
     Assert.isNotNull(block)
 
-    recentFeeCache.addFee(transaction2)
+    recentFeeCache.addTransactionToCache(transaction2)
 
     let lowestFee = block.transactions[0].fee()
     let highestFee = block.transactions[0].fee()
@@ -90,19 +90,15 @@ describe('RecentFeeCache', () => {
     expect(recentFeeCache.getSuggestedFee(60)).toBe(highestFee)
   })
 
-  it.only('add transaction to cache when cache is full', async () => {
+  it('add transaction to cache when cache is full', async () => {
     const accountC = await useAccountFixture(wallet, 'accountC')
     const accountD = await useAccountFixture(wallet, 'accountD')
-    const { transaction: transaction2, block: block2 } = await useBlockWithTx(
-      node,
-      accountC,
-      accountD,
-    )
+    const { transaction: transaction2 } = await useBlockWithTx(node, accountC, accountD)
 
     const recentFeeCache = new RecentFeeCache(node.chain, 1, 1)
     await recentFeeCache.setUpCache()
 
-    recentFeeCache.addFee(transaction2)
+    recentFeeCache.addTransactionToCache(transaction2)
 
     expect(recentFeeCache.getCacheSize()).toBe(1)
     expect(recentFeeCache.getSuggestedFee(60)).toBe(transaction2.fee())

--- a/ironfish/src/wallet/recentFeeCache.ts
+++ b/ironfish/src/wallet/recentFeeCache.ts
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../assert'
+import { Blockchain } from '../blockchain'
+import { createRootLogger, Logger } from '../logger'
+import { PriorityQueue } from '../memPool'
+import { MetricsMonitor } from '../metrics'
+import { Block, Transaction } from '../primitives'
+import { Queue } from './queue'
+
+export class RecentFeeCache {
+  private queue: Queue<Transaction>
+  readonly chain: Blockchain
+  private readonly logger: Logger
+  private readonly metrics: MetricsMonitor
+  private numOfRecentBlocks = 10
+  private numOfTxSamples = 3
+  private defaultSuggestedFee = BigInt(2)
+
+  constructor(
+    chain: Blockchain,
+    recentBlocksNum?: number,
+    txSampleSize?: number,
+    metrics?: MetricsMonitor,
+    logger?: Logger,
+  ) {
+    this.logger = logger || createRootLogger()
+    this.numOfRecentBlocks = recentBlocksNum ?? this.numOfRecentBlocks
+    this.numOfTxSamples = txSampleSize ?? this.numOfTxSamples
+
+    this.queue = new Queue<Transaction>(this.numOfRecentBlocks * this.numOfTxSamples)
+    this.chain = chain
+    this.logger.withTag('recentFeeCache')
+    this.metrics = metrics || new MetricsMonitor({ logger: this.logger })
+  }
+
+  async setUpCache(): Promise<void> {
+    // Mempool is empty
+    let currentBlockHash = this.chain.latest.hash
+
+    for (let i = 0; i < this.numOfRecentBlocks; i++) {
+      const currentBlock = await this.chain.getBlock(currentBlockHash)
+      Assert.isNotNull(currentBlock, 'No block found')
+
+      const lowestFeeTransactions = this.getLowestFeeTransactions(currentBlock)
+      lowestFeeTransactions.forEach((tx) => {
+        if (this.queue.isFull()) {
+          return
+        }
+        this.queue.enqueue(tx)
+      })
+
+      currentBlockHash = currentBlock.header.previousBlockHash
+    }
+  }
+
+  /**
+   * Add recent transactions to fee cache
+   */
+
+  addFee(transaction: Transaction): boolean {
+    if (this.queue.isFull()) {
+      this.deleteOldestTransaction()
+    }
+    try {
+      this.queue.enqueue(transaction)
+      return true
+    } catch {
+      this.logger.error(`Error enqueue transaction to Recent Fee Cache`)
+      return false
+    }
+  }
+
+  /**
+   * Delete the least recent transactions from fee cache
+   */
+  deleteOldestTransaction(): void {
+    this.queue.dequeue()
+  }
+
+  getLowestFeeTransactions(
+    block: Block,
+    numOfTransactions?: number | undefined,
+  ): Transaction[] {
+    const lowestTxFees = new PriorityQueue<Transaction>(
+      // TODO: @yajun compare transaction fee rate per byte when transaction size is available
+      (txA, txB) => {
+        if (txA.fee() === txB.fee()) {
+          return txA.hash().compare(txB.hash()) > 0
+        }
+        return txA.fee() > txB.fee()
+      },
+      (t) => t.hash().toString('hex'),
+    )
+    const size = numOfTransactions ?? this.numOfTxSamples
+
+    block.transactions.forEach((transaction) => {
+      lowestTxFees.add(transaction)
+      while (lowestTxFees.size() > size) {
+        lowestTxFees.poll()
+      }
+    })
+
+    const transactions: Transaction[] = []
+
+    while (lowestTxFees.size() > 0) {
+      const transaction = lowestTxFees.poll()
+      if (transaction) {
+        transactions.push(transaction)
+      }
+    }
+
+    return transactions.reverse()
+  }
+
+  getSuggestedFee(percentile: number): bigint {
+    if (this.queue.size() < this.numOfRecentBlocks) {
+      return this.defaultSuggestedFee
+    }
+
+    const transaction = this.queue.get(Math.round(((this.queue.size() - 1) * percentile) / 100))
+    if (!transaction) {
+      return this.defaultSuggestedFee
+    }
+    return transaction.fee()
+  }
+
+  getCacheSize(): number {
+    return this.queue.size()
+  }
+}


### PR DESCRIPTION
## Summary
Refactor Fee estimation. https://github.com/iron-fish/ironfish/pull/2075

- Create a queue class
- Create Recent Fee Cache with add, delete and get suggest fee methods

## Testing Plan
unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@hughy @NullSoldier @mirayadav 