### PR TITLE
changes updateSynced to update to false

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1315,11 +1315,12 @@ export class Blockchain {
   }
 
   private updateSynced(): void {
-    if (this.synced) {
+    if (this.head.timestamp.valueOf() < Date.now() - MAX_SYNCED_AGE_MS) {
+      this.synced = false
       return
     }
 
-    if (this.head.timestamp.valueOf() < Date.now() - MAX_SYNCED_AGE_MS) {
+    if (this.synced) {
       return
     }
 


### PR DESCRIPTION
## Summary

updateSynced never updates synced to false. if the node is running but falls behind the chain (e.g., due to network connectivity, thread starvation, or other interruption) then synced will not be updated to reflect that the node is out of sync until the node is restarted.

- changes synced to false if chain head timestamp doesn't meet synced criteria
- only emits onSynced if synced changes from false to true

relates to #2326

## Testing Plan

TODO: update tests that rely on `chain.synced`, which depends on time

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
