### PR TITLE
uses account name instead of displayName in rpc

### DIFF
--- a/ironfish/src/rpc/routes/accounts/getBalance.ts
+++ b/ironfish/src/rpc/routes/accounts/getBalance.ts
@@ -48,7 +48,7 @@ router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
     const balance = await node.wallet.getBalance(account, { minimumBlockConfirmations })
 
     request.end({
-      account: account.displayName,
+      account: account.name,
       confirmed: balance.confirmed.toString(),
       pending: balance.pending.toString(),
       pendingCount: balance.pendingCount,

--- a/ironfish/src/rpc/routes/accounts/getTransaction.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransaction.ts
@@ -71,7 +71,7 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
 
     if (!transaction) {
       return request.end({
-        account: account.displayName,
+        account: account.name,
         transaction: null,
       })
     }


### PR DESCRIPTION
## Summary

changes accounts commands to output the account name (e.g., 'default') instead of the displayName (e.g., 'default (1234567)') that includes characters from an account ID that isn't meaningful to the user.

some users have been confused by the extra characters and wondered whether they map to the account's keys somehow.

## Testing Plan

before:
![image](https://user-images.githubusercontent.com/57735705/195658409-aff396e6-bb49-4c84-b462-9a7e5b2fc245.png)

after:
![image](https://user-images.githubusercontent.com/57735705/195658288-c56c5e4e-ec0d-4044-beac-b96876bebe42.png)


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
