### PR TITLE
Use unsignedHash as note.transactionHash

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -145,7 +145,7 @@ export class Account {
     params: SyncTransactionParams,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
-    const transactionHash = transaction.hash()
+    const transactionHash = transaction.unsignedHash()
     const blockHash = 'blockHash' in params ? params.blockHash : null
     const sequence = 'sequence' in params ? params.sequence : null
     let submittedSequence = 'submittedSequence' in params ? params.submittedSequence : null


### PR DESCRIPTION
## Summary
Use transaction.unsignedHash as note.transactionHash since we use unsignedHash for both getTransaction and explorer. With the signedHash, we have no idea about from which transaction we get this note.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
