### PR TITLE
changes RecentFeeCache to use fee rates

### DIFF
--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -46,7 +46,7 @@ export const TARGET_BLOCK_TIME_IN_SECONDS = 60
 /**
  * The oldest the tip should be before we consider the chain synced (60 blocks)
  */
-export const MAX_SYNCED_AGE_MS = 600000 * TARGET_BLOCK_TIME_IN_SECONDS * 1000
+export const MAX_SYNCED_AGE_MS = 60 * TARGET_BLOCK_TIME_IN_SECONDS * 1000
 
 /**
  * The time range when difficulty and target not change

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -46,7 +46,7 @@ export const TARGET_BLOCK_TIME_IN_SECONDS = 60
 /**
  * The oldest the tip should be before we consider the chain synced (60 blocks)
  */
-export const MAX_SYNCED_AGE_MS = 60 * TARGET_BLOCK_TIME_IN_SECONDS * 1000
+export const MAX_SYNCED_AGE_MS = 600000 * TARGET_BLOCK_TIME_IN_SECONDS * 1000
 
 /**
  * The time range when difficulty and target not change

--- a/ironfish/src/memPool/recentFeeCache.test.ts
+++ b/ironfish/src/memPool/recentFeeCache.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../assert'
 import { createNodeTest, useBlockWithTx, useBlockWithTxs } from '../testUtilities'
-import { RecentFeeCache } from './recentFeeCache'
+import { getFeeRate, RecentFeeCache } from './recentFeeCache'
 
 describe('RecentFeeCache', () => {
   const nodeTest = createNodeTest()
@@ -25,7 +25,7 @@ describe('RecentFeeCache', () => {
       })
       await recentFeeCache.setUp()
 
-      expect(recentFeeCache.getSuggestedFee(60)).toBe(transaction.fee())
+      expect(recentFeeCache.estimateFeeRate(60)).toBe(getFeeRate(transaction))
     })
 
     it('should build recent fee cache with more than one transaction', async () => {
@@ -59,7 +59,7 @@ describe('RecentFeeCache', () => {
       await recentFeeCache.setUp()
 
       expect(recentFeeCache.size()).toBe(1)
-      expect(recentFeeCache.getSuggestedFee(60)).toBe(transaction2.fee())
+      expect(recentFeeCache.estimateFeeRate(60)).toBe(getFeeRate(transaction2))
     })
   })
 
@@ -85,7 +85,7 @@ describe('RecentFeeCache', () => {
       recentFeeCache.onConnectBlock(block, node.memPool)
 
       expect(recentFeeCache.size()).toBe(1)
-      expect(recentFeeCache.getSuggestedFee(60)).toBe(transaction.fee())
+      expect(recentFeeCache.estimateFeeRate(60)).toBe(getFeeRate(transaction))
     })
 
     it('should exclude transactions from a block that are not in the mempool', async () => {
@@ -150,7 +150,7 @@ describe('RecentFeeCache', () => {
       recentFeeCache.onConnectBlock(block2, node.memPool)
 
       expect(recentFeeCache.size()).toBe(1)
-      expect(recentFeeCache.getSuggestedFee(60)).toBe(transaction2.fee())
+      expect(recentFeeCache.estimateFeeRate(60)).toBe(getFeeRate(transaction2))
     })
 
     it('should keep old transactions in the cache if its maximum size has not been reached', async () => {

--- a/ironfish/src/memPool/recentFeeCache.ts
+++ b/ironfish/src/memPool/recentFeeCache.ts
@@ -20,7 +20,7 @@ export class RecentFeeCache {
   private numOfRecentBlocks = 10
   private numOfTxSamples = 3
   private maxQueueLength: number
-  private defaultFeeRate = BigInt(2)
+  private defaultFeeRate = BigInt(1)
 
   constructor(options: {
     chain: Blockchain
@@ -151,5 +151,7 @@ export class RecentFeeCache {
 }
 
 export function getFeeRate(transaction: Transaction): bigint {
-  return transaction.fee() / BigInt(getTransactionSize(transaction.serialize()))
+  const rate = transaction.fee() / BigInt(getTransactionSize(transaction.serialize()))
+
+  return rate > 0 ? rate : BigInt(1)
 }


### PR DESCRIPTION
## Summary

changing the block size limit from a maximum number of transactions to a maximum size in bytes will prompt miners to prioritize transactions by fee rate ($ORE/byte) instead of fee.

- implements getFeeRate to caculate the fee rate for a given transaction from its fee and its size
- changes FeeEntry to FeeRateEntry such that RecentFeeCache tracks fee rates instead of fees
- changes getSugggestedFee to estimateFeeRate

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
