### PR TITLE
Validate config file options (`ConfigOptions`)

### DIFF
--- a/ironfish/src/fileStores/config.test.ts
+++ b/ironfish/src/fileStores/config.test.ts
@@ -2,20 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { mockFileSystem } from '../network/testUtilities/mockHostsStore'
 import {
-  ConfigOptionsSchema,
-  isWholeNumber,
-  isPort,
-  isPercent,
-  noWhitespaceBegEnd,
-  isUrl,
   Config,
+  ConfigOptionsSchema,
   DEFAULT_EXPLORER_BLOCKS_URL,
+  isPercent,
+  isPort,
+  isUrl,
+  isWholeNumber,
+  noWhitespaceBegEnd,
 } from './config'
 
-import { mockFileSystem } from '../network/testUtilities/mockHostsStore'
-
-function valid(schema: any, obj: any) {
+function valid(schema: yup.ObjectSchema, obj: unknown) {
   return schema.isValidSync(obj)
 }
 
@@ -40,7 +39,7 @@ describe('ConfigOptionsSchema::numbers', () => {
     .defined()
 
   {
-    let obj = {
+    const obj = {
       int1: 0,
       int2: 42,
     }
@@ -49,55 +48,55 @@ describe('ConfigOptionsSchema::numbers', () => {
     })
   }
   {
-    let obj = { int1: false }
+    const obj = { int1: false }
     it('boolIsNotInteger', () => {
       expect(valid(schema, obj)).toBe(false)
     })
   }
   {
-    let obj = { int1: 4.2 }
+    const obj = { int1: 4.2 }
     it('floatIsNotInteger', () => {
       expect(valid(schema, obj)).toBe(false)
     })
   }
   {
-    let obj = { int1: -1 }
+    const obj = { int1: -1 }
     it('isNotPosInteger', () => {
       expect(valid(schema, obj)).toBe(false)
     })
   }
   {
-    let obj = { port1: 1, port2: 65535 }
+    const obj = { port1: 1, port2: 65535 }
     it('isPortRange', () => {
       expect(valid(schema, obj)).toBe(true)
     })
   }
   {
-    let obj = { port1: -1 }
+    const obj = { port1: -1 }
     it('isNotPort', () => {
       expect(valid(schema, obj)).toBe(false)
     })
   }
   {
-    let obj = { percent: 0 }
+    const obj = { percent: 0 }
     it('isPercentLow', () => {
       expect(valid(schema, obj)).toBe(true)
     })
   }
   {
-    let obj = { percent: 100 }
+    const obj = { percent: 100 }
     it('isPercentHigh', () => {
       expect(valid(schema, obj)).toBe(true)
     })
   }
   {
-    let obj = { percent: '10%' }
+    const obj = { percent: '10%' }
     it('stringIsNotPercent', () => {
       expect(valid(schema, obj)).toBe(false)
     })
   }
   {
-    let obj = { percent: 101 }
+    const obj = { percent: 101 }
     it('outOfRangePercent', () => {
       expect(valid(schema, obj)).toBe(false)
     })
@@ -121,7 +120,7 @@ describe('ConfigOptionsSchema::strings', () => {
     .defined()
 
   {
-    let obj = {
+    const obj = {
       s1: '/usr/bin/nvim',
       s2: String.raw`C:\ironfish\is best`,
     }
@@ -130,7 +129,7 @@ describe('ConfigOptionsSchema::strings', () => {
     })
   }
   {
-    let obj = {
+    const obj = {
       s1: ' /usr/bin/nvim',
     }
     it('isNotPathLeadingWhitespace', () => {
@@ -138,7 +137,7 @@ describe('ConfigOptionsSchema::strings', () => {
     })
   }
   {
-    let obj = {
+    const obj = {
       s1: '/usr/bin/nvim   ',
     }
     it('isNotPathTrailingWhitspace', () => {
@@ -146,7 +145,7 @@ describe('ConfigOptionsSchema::strings', () => {
     })
   }
   {
-    let obj = {
+    const obj = {
       url1: DEFAULT_EXPLORER_BLOCKS_URL,
     }
     it('isUrl', () => {
@@ -154,7 +153,7 @@ describe('ConfigOptionsSchema::strings', () => {
     })
   }
   {
-    let obj = {
+    const obj = {
       url1: '192.168.1.0',
     }
     it('ipIsNotUrl', () => {
@@ -165,7 +164,7 @@ describe('ConfigOptionsSchema::strings', () => {
 
 // Tests the default config options against the schema
 describe('ConfigOptionsSchema', () => {
-  let configOptions = Config.GetDefaults(mockFileSystem(), 'foo')
+  const configOptions = Config.GetDefaults(mockFileSystem(), 'foo')
 
   it('ConfigDefaults', () => {
     expect(valid(ConfigOptionsSchema, configOptions)).toBe(true)

--- a/ironfish/src/fileStores/config.test.ts
+++ b/ironfish/src/fileStores/config.test.ts
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import {
+  ConfigOptionsSchema,
+  isWholeNumber,
+  isPort,
+  isPercent,
+  noWhitespaceBegEnd,
+  isUrl,
+  Config,
+  DEFAULT_EXPLORER_BLOCKS_URL,
+} from './config'
+
+import { mockFileSystem } from '../network/testUtilities/mockHostsStore'
+
+function valid(schema: any, obj: any) {
+  return schema.isValidSync(obj)
+}
+
+// Tests the number validations in the config schema
+describe('ConfigOptionsSchema::numbers', () => {
+  type Config = {
+    int1: number
+    int2: number
+    port1: number
+    port2: number
+    percent: number
+  }
+
+  const schema: yup.ObjectSchema<Partial<Config>> = yup
+    .object({
+      int1: isWholeNumber,
+      int2: isWholeNumber,
+      port1: isPort,
+      port2: isPort,
+      percent: isPercent,
+    })
+    .defined()
+
+  {
+    let obj = {
+      int1: 0,
+      int2: 42,
+    }
+    it('isWholeNumber', () => {
+      expect(valid(schema, obj)).toBe(true)
+    })
+  }
+  {
+    let obj = { int1: false }
+    it('boolIsNotInteger', () => {
+      expect(valid(schema, obj)).toBe(false)
+    })
+  }
+  {
+    let obj = { int1: 4.2 }
+    it('floatIsNotInteger', () => {
+      expect(valid(schema, obj)).toBe(false)
+    })
+  }
+  {
+    let obj = { int1: -1 }
+    it('isNotPosInteger', () => {
+      expect(valid(schema, obj)).toBe(false)
+    })
+  }
+  {
+    let obj = { port1: 1, port2: 65535 }
+    it('isPortRange', () => {
+      expect(valid(schema, obj)).toBe(true)
+    })
+  }
+  {
+    let obj = { port1: -1 }
+    it('isNotPort', () => {
+      expect(valid(schema, obj)).toBe(false)
+    })
+  }
+  {
+    let obj = { percent: 0 }
+    it('isPercentLow', () => {
+      expect(valid(schema, obj)).toBe(true)
+    })
+  }
+  {
+    let obj = { percent: 100 }
+    it('isPercentHigh', () => {
+      expect(valid(schema, obj)).toBe(true)
+    })
+  }
+  {
+    let obj = { percent: '10%' }
+    it('stringIsNotPercent', () => {
+      expect(valid(schema, obj)).toBe(false)
+    })
+  }
+  {
+    let obj = { percent: 101 }
+    it('outOfRangePercent', () => {
+      expect(valid(schema, obj)).toBe(false)
+    })
+  }
+})
+
+// Tests the string validations in the config schema
+describe('ConfigOptionsSchema::strings', () => {
+  type Config = {
+    s1: string
+    s2: string
+    url1: string
+  }
+
+  const schema: yup.ObjectSchema<Partial<Config>> = yup
+    .object({
+      s1: noWhitespaceBegEnd,
+      s2: noWhitespaceBegEnd,
+      url1: isUrl,
+    })
+    .defined()
+
+  {
+    let obj = {
+      s1: '/usr/bin/nvim',
+      s2: String.raw`C:\ironfish\is best`,
+    }
+    it('isPath', () => {
+      expect(valid(schema, obj)).toBe(true)
+    })
+  }
+  {
+    let obj = {
+      s1: ' /usr/bin/nvim',
+    }
+    it('isNotPathLeadingWhitespace', () => {
+      expect(valid(schema, obj)).toBe(false)
+    })
+  }
+  {
+    let obj = {
+      s1: '/usr/bin/nvim   ',
+    }
+    it('isNotPathTrailingWhitspace', () => {
+      expect(valid(schema, obj)).toBe(false)
+    })
+  }
+  {
+    let obj = {
+      url1: DEFAULT_EXPLORER_BLOCKS_URL,
+    }
+    it('isUrl', () => {
+      expect(valid(schema, obj)).toBe(true)
+    })
+  }
+  {
+    let obj = {
+      url1: '192.168.1.0',
+    }
+    it('ipIsNotUrl', () => {
+      expect(valid(schema, obj)).toBe(false)
+    })
+  }
+})
+
+// Tests the default config options against the schema
+describe('ConfigOptionsSchema', () => {
+  let configOptions = Config.GetDefaults(mockFileSystem(), 'foo')
+
+  it('ConfigDefaults', () => {
+    expect(valid(ConfigOptionsSchema, configOptions)).toBe(true)
+  })
+})

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -240,10 +240,6 @@ export type ConfigOptions = {
 // Matches either an empty string, or a string that has no leading or trailing whitespace.
 const reNoWhitespaceBegEnd = /^[^\s]+(\s+[^\s]+)*$|^$/
 
-// config validation error messages
-const cfgErrMsgPathWhiteSpace = 'Path should not contain leading or trailing whitespace.'
-const cfgErrMsgURL = 'Invalid URL.'
-
 // config number value validators
 export const isWholeNumber = yup.number().integer().min(0)
 export const isPort = yup.number().integer().min(1).max(65535)
@@ -252,8 +248,9 @@ export const isPercent = yup.number().min(0).max(100)
 // config string value validators
 export const noWhitespaceBegEnd = yup
   .string()
-  .matches(reNoWhitespaceBegEnd, cfgErrMsgPathWhiteSpace)
-export const isUrl = yup.string().url(cfgErrMsgURL)
+  .matches(reNoWhitespaceBegEnd, 'Path should not contain leading or trailing whitespace.')
+
+export const isUrl = yup.string().url('Invalid URL')
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
   .object({

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -216,7 +216,6 @@ export type ConfigOptions = {
   poolMaxConnectionsPerIp: number
 
   /**
-
    * The lark webhook URL to post pool critical pool information to
    */
   poolLarkWebhook: ''
@@ -238,9 +237,86 @@ export type ConfigOptions = {
   explorerTransactionsUrl: string
 }
 
+// Matches either an empty string, or a string that has no leading or trailing whitespace.
+const reNoWhitespaceBegEnd = /^[^\s]+(\s+[^\s]+)*$|^$/
+
+// config validation error messages
+const cfgErrMsgPathWhiteSpace = 'Path should not contain leading or trailing whitespace.'
+const cfgErrMsgURL = 'Invalid URL.'
+
+// config number value validators
+export const isWholeNumber = yup.number().integer().min(0)
+export const isPort = yup.number().integer().min(1).max(65535)
+export const isPercent = yup.number().min(0).max(100)
+
+// config string value validators
+export const noWhitespaceBegEnd = yup
+  .string()
+  .matches(reNoWhitespaceBegEnd, cfgErrMsgPathWhiteSpace)
+export const isUrl = yup.string().url(cfgErrMsgURL)
+
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
-  .object()
-  .shape({})
+  .object({
+    bootstrapNodes: yup.array().of(yup.string().defined()),
+    databaseName: yup.string(),
+    databaseMigrate: yup.boolean(),
+    editor: noWhitespaceBegEnd,
+    enableListenP2P: yup.boolean(),
+    enableLogFile: yup.boolean(),
+    enableRpc: yup.boolean(),
+    enableRpcIpc: yup.boolean(),
+    enableRpcTcp: yup.boolean(),
+    enableRpcTls: yup.boolean(),
+    enableSyncing: yup.boolean(),
+    enableTelemetry: yup.boolean(),
+    enableMetrics: yup.boolean(),
+    getFundsApi: yup.string(),
+    ipcPath: noWhitespaceBegEnd,
+    miningForce: yup.boolean(),
+    logPeerMessages: yup.boolean(),
+    // validated separately by logLevelParser
+    logLevel: yup.string(),
+    // not applying a regex pattern to avoid getting out of sync with logic
+    // to parse logPrefix
+    logPrefix: yup.string(),
+    blockGraffiti: yup.string(),
+    nodeName: yup.string(),
+    nodeWorkers: yup.number().integer().min(-1),
+    nodeWorkersMax: isWholeNumber,
+    p2pSimulateLatency: isWholeNumber,
+    peerPort: isPort,
+    rpcTcpHost: noWhitespaceBegEnd,
+    rpcTcpPort: isPort,
+    tlsKeyPath: noWhitespaceBegEnd,
+    tlsCertPath: noWhitespaceBegEnd,
+    maxPeers: isWholeNumber,
+    minPeers: isWholeNumber,
+    targetPeers: yup.number().integer().min(1),
+    telemetryApi: yup.string(),
+    accountName: yup.string(),
+    generateNewIdentity: yup.boolean(),
+    defaultTransactionExpirationSequenceDelta: isWholeNumber,
+    blocksPerMessage: isWholeNumber,
+    minerBatchSize: isWholeNumber,
+    minimumBlockConfirmations: isWholeNumber,
+    poolName: yup.string(),
+    poolAccountName: yup.string(),
+    poolBanning: yup.boolean(),
+    poolBalancePercentPayout: isPercent,
+    poolHost: noWhitespaceBegEnd,
+    poolPort: isPort,
+    poolDifficulty: yup.string(),
+    poolAttemptPayoutInterval: isWholeNumber,
+    poolSuccessfulPayoutInterval: isWholeNumber,
+    poolStatusNotificationInterval: isWholeNumber,
+    poolRecentShareCutoff: isWholeNumber,
+    poolDiscordWebhook: yup.string(),
+    poolMaxConnectionsPerIp: isWholeNumber,
+    poolLarkWebhook: yup.string(),
+    jsonLogs: yup.boolean(),
+    explorerBlocksUrl: isUrl,
+    explorerTransactionsUrl: isUrl,
+  })
   .defined()
 
 export class Config extends KeyStore<ConfigOptions> {


### PR DESCRIPTION
## Summary

Fixes: https://github.com/iron-fish/ironfish/issues/1924

Adds additional validations to `ConfigOptions` by means of the `yup` API.

## Testing Plan

Added unit tests for configuration schema validations, and applying the default config against the schema.

## Breaking Change

No

## Graffiti

null
