### PR TITLE
compacts chain db before creating snapshot

### DIFF
--- a/ironfish-cli/src/commands/service/snapshot.ts
+++ b/ironfish-cli/src/commands/service/snapshot.ts
@@ -67,6 +67,10 @@ export default class CreateSnapshot extends IronfishCommand {
     const node = await this.sdk.node()
     await NodeUtils.waitForOpen(node)
 
+    CliUx.ux.action.start(`Compacting chain database`)
+    await node.chain.db.compact()
+    CliUx.ux.action.stop()
+
     const chainDatabasePath = this.sdk.fileSystem.resolve(this.sdk.config.chainDatabasePath)
 
     const timestamp = Date.now()


### PR DESCRIPTION
## Summary

service:snapshot is failing sporadically with ENOENT errors. what seems to be happening is that between the start of the 'tar.create' and the end of it, files are removed from the database. LevelDB compaction may be running in the background and merging recent chain database changes.

manually execute database compaction prior to zipping the database to try to prevent compaction during the zip process.

## Testing Plan

The error that this aims to address is very difficult to reproduce. Local testing of creating snapshots verifies that the compaction doesn't adversely affect snapshot creation, but can't confirm that the ENOENT issue is fully resolved.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
