### PR TITLE
Simplify Rust error types

### DIFF
--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::fmt::Display;
+
 use ironfish_rust::PublicAddress;
 use ironfish_rust::SaplingKey;
 use napi::bindgen_prelude::*;
-use napi::Error;
 use napi_derive::napi;
 
 use ironfish_rust::mining;
@@ -14,6 +15,10 @@ use ironfish_rust::sapling_bls12;
 pub mod nacl;
 pub mod rolling_filter;
 pub mod structs;
+
+fn to_napi_err(err: impl Display) -> napi::Error {
+    Error::from_reason(err.to_string())
+}
 
 #[napi(object)]
 pub struct Key {
@@ -41,8 +46,7 @@ pub fn generate_key() -> Key {
 
 #[napi]
 pub fn generate_new_public_address(private_key: String) -> Result<Key> {
-    let sapling_key =
-        SaplingKey::from_hex(&private_key).map_err(|err| Error::from_reason(err.to_string()))?;
+    let sapling_key = SaplingKey::from_hex(&private_key).map_err(to_napi_err)?;
 
     Ok(Key {
         spending_key: sapling_key.hex_spending_key(),

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -7,6 +7,8 @@ use napi_derive::napi;
 
 use ironfish_rust::{note::Memo, Note, SaplingKey};
 
+use crate::to_napi_err;
+
 #[napi(js_name = "Note")]
 pub struct NativeNote {
     pub(crate) note: Note,
@@ -18,8 +20,7 @@ impl NativeNote {
     pub fn new(owner: String, value: BigInt, memo: String) -> Result<Self> {
         let value_u64 = value.get_u64().1;
 
-        let owner_address = ironfish_rust::PublicAddress::from_hex(&owner)
-            .map_err(|err| Error::from_reason(err.to_string()))?;
+        let owner_address = ironfish_rust::PublicAddress::from_hex(&owner).map_err(to_napi_err)?;
         Ok(NativeNote {
             note: Note::new(owner_address, value_u64, Memo::from(memo)),
         })
@@ -29,8 +30,7 @@ impl NativeNote {
     pub fn deserialize(js_bytes: JsBuffer) -> Result<Self> {
         let byte_vec = js_bytes.into_value()?;
 
-        let note =
-            Note::read(byte_vec.as_ref()).map_err(|err| Error::from_reason(err.to_string()))?;
+        let note = Note::read(byte_vec.as_ref()).map_err(to_napi_err)?;
 
         Ok(NativeNote { note })
     }
@@ -38,9 +38,7 @@ impl NativeNote {
     #[napi]
     pub fn serialize(&self) -> Result<Buffer> {
         let mut arr: Vec<u8> = vec![];
-        self.note
-            .write(&mut arr)
-            .map_err(|err| Error::from_reason(err.to_string()))?;
+        self.note.write(&mut arr).map_err(to_napi_err)?;
 
         Ok(Buffer::from(arr))
     }
@@ -69,8 +67,7 @@ impl NativeNote {
     pub fn nullifier(&self, owner_private_key: String, position: BigInt) -> Result<Buffer> {
         let position_u64 = position.get_u64().1;
 
-        let private_key = SaplingKey::from_hex(&owner_private_key)
-            .map_err(|err| Error::from_reason(err.to_string()))?;
+        let private_key = SaplingKey::from_hex(&owner_private_key).map_err(to_napi_err)?;
 
         let nullifier: &[u8] = &self.note.nullifier(&private_key, position_u64).0;
 

--- a/ironfish-rust-nodejs/src/structs/note_encrypted.rs
+++ b/ironfish-rust-nodejs/src/structs/note_encrypted.rs
@@ -11,6 +11,8 @@ use napi_derive::napi;
 
 use ironfish_rust::MerkleNote;
 
+use crate::to_napi_err;
+
 #[napi(js_name = "NoteEncrypted")]
 pub struct NativeNoteEncrypted {
     pub(crate) note: MerkleNote,
@@ -21,8 +23,7 @@ impl NativeNoteEncrypted {
     #[napi(constructor)]
     pub fn new(js_bytes: JsBuffer) -> Result<Self> {
         let bytes = js_bytes.into_value()?;
-        let note =
-            MerkleNote::read(bytes.as_ref()).map_err(|err| Error::from_reason(err.to_string()))?;
+        let note = MerkleNote::read(bytes.as_ref()).map_err(to_napi_err)?;
 
         Ok(NativeNoteEncrypted { note })
     }
@@ -30,9 +31,7 @@ impl NativeNoteEncrypted {
     #[napi]
     pub fn serialize(&self) -> Result<Buffer> {
         let mut vec: Vec<u8> = vec![];
-        self.note
-            .write(&mut vec)
-            .map_err(|err| Error::from_reason(err.to_string()))?;
+        self.note.write(&mut vec).map_err(to_napi_err)?;
 
         Ok(Buffer::from(vec))
     }
@@ -48,7 +47,7 @@ impl NativeNoteEncrypted {
         self.note
             .merkle_hash()
             .write(&mut vec)
-            .map_err(|err| Error::from_reason(err.to_string()))?;
+            .map_err(to_napi_err)?;
 
         Ok(Buffer::from(vec))
     }
@@ -60,15 +59,13 @@ impl NativeNoteEncrypted {
         let left = js_left.into_value()?;
         let right = js_right.into_value()?;
 
-        let left_hash = MerkleNoteHash::read(left.as_ref())
-            .map_err(|err| Error::from_reason(err.to_string()))?;
+        let left_hash = MerkleNoteHash::read(left.as_ref()).map_err(to_napi_err)?;
 
-        let right_hash = MerkleNoteHash::read(right.as_ref())
-            .map_err(|err| Error::from_reason(err.to_string()))?;
+        let right_hash = MerkleNoteHash::read(right.as_ref()).map_err(to_napi_err)?;
 
         let converted_depth: usize = depth
             .try_into()
-            .map_err(|_| Error::from_reason("Value could not fit in usize".to_string()))?;
+            .map_err(|_| to_napi_err("Value could not fit in usize"))?;
 
         let mut vec = Vec::with_capacity(32);
 
@@ -78,7 +75,7 @@ impl NativeNoteEncrypted {
             &right_hash.0,
         ))
         .write(&mut vec)
-        .map_err(|err| Error::from_reason(err.to_string()))?;
+        .map_err(to_napi_err)?;
 
         Ok(Buffer::from(vec))
     }
@@ -86,14 +83,13 @@ impl NativeNoteEncrypted {
     /// Returns undefined if the note was unable to be decrypted with the given key.
     #[napi]
     pub fn decrypt_note_for_owner(&self, incoming_hex_key: String) -> Result<Option<Buffer>> {
-        let incoming_view_key = IncomingViewKey::from_hex(&incoming_hex_key)
-            .map_err(|err| Error::from_reason(err.to_string()))?;
+        let incoming_view_key =
+            IncomingViewKey::from_hex(&incoming_hex_key).map_err(to_napi_err)?;
 
         Ok(match self.note.decrypt_note_for_owner(&incoming_view_key) {
             Ok(note) => {
                 let mut vec = vec![];
-                note.write(&mut vec)
-                    .map_err(|err| Error::from_reason(err.to_string()))?;
+                note.write(&mut vec).map_err(to_napi_err)?;
                 Some(Buffer::from(vec))
             }
             Err(_) => None,
@@ -103,14 +99,13 @@ impl NativeNoteEncrypted {
     /// Returns undefined if the note was unable to be decrypted with the given key.
     #[napi]
     pub fn decrypt_note_for_spender(&self, outgoing_hex_key: String) -> Result<Option<Buffer>> {
-        let outgoing_view_key = OutgoingViewKey::from_hex(&outgoing_hex_key)
-            .map_err(|err| Error::from_reason(err.to_string()))?;
+        let outgoing_view_key =
+            OutgoingViewKey::from_hex(&outgoing_hex_key).map_err(to_napi_err)?;
         Ok(
             match self.note.decrypt_note_for_spender(&outgoing_view_key) {
                 Ok(note) => {
                     let mut vec = vec![];
-                    note.write(&mut vec)
-                        .map_err(|err| Error::from_reason(err.to_string()))?;
+                    note.write(&mut vec).map_err(to_napi_err)?;
                     Some(Buffer::from(vec))
                 }
                 Err(_) => None,

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use super::errors;
+use crate::errors::IronfishError;
+
 use super::serializing::{
     bytes_to_hex, hex_to_bytes, point_to_bytes, read_scalar, scalar_to_bytes,
 };
@@ -79,7 +80,7 @@ pub struct SaplingKey {
 
 impl<'a> SaplingKey {
     /// Construct a new key from an array of bytes
-    pub fn new(spending_key: [u8; 32]) -> Result<Self, errors::SaplingKeyError> {
+    pub fn new(spending_key: [u8; 32]) -> Result<Self, IronfishError> {
         let spend_authorizing_key =
             jubjub::Fr::from_bytes_wide(&Self::convert_key(spending_key, 0));
         let proof_authorizing_key =
@@ -107,19 +108,19 @@ impl<'a> SaplingKey {
     }
 
     /// Load a new key from a Read implementation (e.g: socket, file)
-    pub fn read<R: io::Read>(reader: &mut R) -> Result<Self, errors::SaplingKeyError> {
+    pub fn read<R: io::Read>(reader: &mut R) -> Result<Self, IronfishError> {
         let mut spending_key = [0; 32];
         reader.read_exact(&mut spending_key)?;
         Self::new(spending_key)
     }
 
     /// Load a key from a string of hexadecimal digits
-    pub fn from_hex(value: &str) -> Result<Self, errors::SaplingKeyError> {
+    pub fn from_hex(value: &str) -> Result<Self, IronfishError> {
         match hex_to_bytes(value) {
-            Err(()) => Err(errors::SaplingKeyError::InvalidPaymentAddress),
+            Err(()) => Err(IronfishError::InvalidPaymentAddress),
             Ok(bytes) => {
                 if bytes.len() != 32 {
-                    Err(errors::SaplingKeyError::InvalidPaymentAddress)
+                    Err(IronfishError::InvalidPaymentAddress)
                 } else {
                     let mut byte_arr = [0; 32];
                     byte_arr.clone_from_slice(&bytes[0..32]);
@@ -130,11 +131,11 @@ impl<'a> SaplingKey {
     }
 
     /// Load a key from a string of words to be decoded into bytes.
-    pub fn from_words(language_code: &str, value: String) -> Result<Self, errors::SaplingKeyError> {
+    pub fn from_words(language_code: &str, value: String) -> Result<Self, IronfishError> {
         let language = Language::from_language_code(language_code)
-            .ok_or(errors::SaplingKeyError::InvalidLanguageEncoding)?;
+            .ok_or(IronfishError::InvalidLanguageEncoding)?;
         let mnemonic = Mnemonic::from_phrase(&value, language)
-            .map_err(|_| errors::SaplingKeyError::InvalidPaymentAddress)?;
+            .map_err(|_| IronfishError::InvalidPaymentAddress)?;
         let bytes = mnemonic.entropy();
         let mut byte_arr = [0; 32];
         byte_arr.clone_from_slice(&bytes[0..32]);
@@ -163,10 +164,7 @@ impl<'a> SaplingKey {
     ///
     /// Note: This may need to be public at some point. I'm hoping the client
     /// API would never have to deal with diversifiers, but I'm not sure, yet.
-    pub fn public_address(
-        &self,
-        diversifier: &[u8; 11],
-    ) -> Result<PublicAddress, errors::SaplingKeyError> {
+    pub fn public_address(&self, diversifier: &[u8; 11]) -> Result<PublicAddress, IronfishError> {
         PublicAddress::from_key(self, diversifier)
     }
 
@@ -209,12 +207,9 @@ impl<'a> SaplingKey {
     /// a seed. This isn't strictly necessary for private key, but view keys
     /// will need a direct mapping. The private key could still be generated
     /// using bip-32 and bip-39 if desired.
-    pub fn words_spending_key(
-        &self,
-        language_code: &str,
-    ) -> Result<String, errors::SaplingKeyError> {
+    pub fn words_spending_key(&self, language_code: &str) -> Result<String, IronfishError> {
         let language = Language::from_language_code(language_code)
-            .ok_or(errors::SaplingKeyError::InvalidLanguageEncoding)?;
+            .ok_or(IronfishError::InvalidLanguageEncoding)?;
         let mnemonic = Mnemonic::from_entropy(&self.spending_key, language).unwrap();
         Ok(mnemonic.phrase().to_string())
     }
@@ -313,7 +308,7 @@ impl<'a> SaplingKey {
     fn hash_viewing_key(
         authorizing_key: &SubgroupPoint,
         nullifier_deriving_key: &SubgroupPoint,
-    ) -> Result<jubjub::Fr, errors::SaplingKeyError> {
+    ) -> Result<jubjub::Fr, IronfishError> {
         let mut view_key_contents = [0; 64];
         view_key_contents[0..32].copy_from_slice(&authorizing_key.to_bytes());
         view_key_contents[32..64].copy_from_slice(&nullifier_deriving_key.to_bytes());
@@ -330,7 +325,7 @@ impl<'a> SaplingKey {
         // Drop the last five bits, so it can be interpreted as a scalar.
         hash_result[31] &= 0b0000_0111;
         if hash_result == [0; 32] {
-            return Err(errors::SaplingKeyError::InvalidViewingKey);
+            return Err(IronfishError::InvalidViewingKey);
         }
         let scalar = read_scalar(&hash_result[..])?;
         Ok(scalar)

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -178,16 +178,13 @@ impl<'a> SaplingKey {
     }
 
     // Write a bytes representation of this key to the provided stream
-    pub fn write<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
         let num_bytes_written = writer.write(&self.spending_key)?;
         if num_bytes_written != 32 {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Couldn't write entire key",
-            ))
-        } else {
-            Ok(())
+            return Err(IronfishError::InvalidData);
         }
+
+        Ok(())
     }
 
     /// Retrieve the private spending key

--- a/ironfish-rust/src/keys/public_address.rs
+++ b/ironfish-rust/src/keys/public_address.rs
@@ -125,8 +125,9 @@ impl PublicAddress {
     }
 
     /// Store the bytes of this public address in the given writer.
-    pub fn write<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
         writer.write_all(&self.public_address())?;
+
         Ok(())
     }
 

--- a/ironfish-rust/src/keys/view_keys.rs
+++ b/ironfish-rust/src/keys/view_keys.rs
@@ -12,9 +12,10 @@
 //! that you have spent.
 //!
 
-use super::{errors, PublicAddress};
-use crate::serializing::{
-    bytes_to_hex, hex_to_bytes, point_to_bytes, read_scalar, scalar_to_bytes,
+use super::PublicAddress;
+use crate::{
+    errors::IronfishError,
+    serializing::{bytes_to_hex, hex_to_bytes, point_to_bytes, read_scalar, scalar_to_bytes},
 };
 use bip39::{Language, Mnemonic};
 use blake2b_simd::Params as Blake2b;
@@ -35,18 +36,18 @@ pub struct IncomingViewKey {
 
 impl IncomingViewKey {
     /// load view key from a Read implementation
-    pub fn read<R: io::Read>(reader: &mut R) -> Result<Self, errors::SaplingKeyError> {
+    pub fn read<R: io::Read>(reader: &mut R) -> Result<Self, IronfishError> {
         let view_key = read_scalar(reader)?;
         Ok(IncomingViewKey { view_key })
     }
 
     /// Load a key from a string of hexadecimal digits
-    pub fn from_hex(value: &str) -> Result<Self, errors::SaplingKeyError> {
+    pub fn from_hex(value: &str) -> Result<Self, IronfishError> {
         match hex_to_bytes(value) {
-            Err(()) => Err(errors::SaplingKeyError::InvalidViewingKey),
+            Err(()) => Err(IronfishError::InvalidViewingKey),
             Ok(bytes) => {
                 if bytes.len() != 32 {
-                    Err(errors::SaplingKeyError::InvalidViewingKey)
+                    Err(IronfishError::InvalidViewingKey)
                 } else {
                     Self::read(&mut bytes[..].as_ref())
                 }
@@ -57,11 +58,11 @@ impl IncomingViewKey {
     /// Load a key from a string of words to be decoded into bytes.
     ///
     /// See https://github.com/BeanstalkNetwork/word-encoding
-    pub fn from_words(language_code: &str, value: String) -> Result<Self, errors::SaplingKeyError> {
+    pub fn from_words(language_code: &str, value: String) -> Result<Self, IronfishError> {
         let language = Language::from_language_code(language_code)
-            .ok_or(errors::SaplingKeyError::InvalidLanguageEncoding)?;
+            .ok_or(IronfishError::InvalidLanguageEncoding)?;
         let mnemonic = Mnemonic::from_phrase(&value, language)
-            .map_err(|_| errors::SaplingKeyError::InvalidPaymentAddress)?;
+            .map_err(|_| IronfishError::InvalidPaymentAddress)?;
         let bytes = mnemonic.entropy();
         let mut byte_arr = [0; 32];
         byte_arr.clone_from_slice(&bytes[0..32]);
@@ -74,9 +75,9 @@ impl IncomingViewKey {
     }
 
     /// Even more readable
-    pub fn words_key(&self, language_code: &str) -> Result<String, errors::SaplingKeyError> {
+    pub fn words_key(&self, language_code: &str) -> Result<String, IronfishError> {
         let language = Language::from_language_code(language_code)
-            .ok_or(errors::SaplingKeyError::InvalidLanguageEncoding)?;
+            .ok_or(IronfishError::InvalidLanguageEncoding)?;
         let mnemonic = Mnemonic::from_entropy(&scalar_to_bytes(&self.view_key), language).unwrap();
         Ok(mnemonic.phrase().to_string())
     }
@@ -88,10 +89,7 @@ impl IncomingViewKey {
     ///
     /// Note: This may need to be public at some point. I'm hoping the client
     /// API would never have to deal with diversifiers, but I'm not sure, yet.
-    pub fn public_address(
-        &self,
-        diversifier: &[u8; 11],
-    ) -> Result<PublicAddress, errors::SaplingKeyError> {
+    pub fn public_address(&self, diversifier: &[u8; 11]) -> Result<PublicAddress, IronfishError> {
         PublicAddress::from_view_key(self, diversifier)
     }
 
@@ -131,12 +129,12 @@ pub struct OutgoingViewKey {
 
 impl OutgoingViewKey {
     /// Load a key from a string of hexadecimal digits
-    pub fn from_hex(value: &str) -> Result<Self, errors::SaplingKeyError> {
+    pub fn from_hex(value: &str) -> Result<Self, IronfishError> {
         match hex_to_bytes(value) {
-            Err(()) => Err(errors::SaplingKeyError::InvalidViewingKey),
+            Err(()) => Err(IronfishError::InvalidViewingKey),
             Ok(bytes) => {
                 if bytes.len() != 32 {
-                    Err(errors::SaplingKeyError::InvalidViewingKey)
+                    Err(IronfishError::InvalidViewingKey)
                 } else {
                     let mut view_key = [0; 32];
                     view_key.clone_from_slice(&bytes[0..32]);
@@ -149,11 +147,11 @@ impl OutgoingViewKey {
     /// Load a key from a string of words to be decoded into bytes.
     ///
     /// See https://github.com/BeanstalkNetwork/word-encoding
-    pub fn from_words(language_code: &str, value: String) -> Result<Self, errors::SaplingKeyError> {
+    pub fn from_words(language_code: &str, value: String) -> Result<Self, IronfishError> {
         let language = Language::from_language_code(language_code)
-            .ok_or(errors::SaplingKeyError::InvalidLanguageEncoding)?;
+            .ok_or(IronfishError::InvalidLanguageEncoding)?;
         let mnemonic = Mnemonic::from_phrase(&value, language)
-            .map_err(|_| errors::SaplingKeyError::InvalidPaymentAddress)?;
+            .map_err(|_| IronfishError::InvalidPaymentAddress)?;
         let bytes = mnemonic.entropy();
         let mut view_key = [0; 32];
         view_key.clone_from_slice(&bytes[0..32]);
@@ -166,9 +164,9 @@ impl OutgoingViewKey {
     }
 
     /// Even more readable
-    pub fn words_key(&self, language_code: &str) -> Result<String, errors::SaplingKeyError> {
+    pub fn words_key(&self, language_code: &str) -> Result<String, IronfishError> {
         let language = Language::from_language_code(language_code)
-            .ok_or(errors::SaplingKeyError::InvalidLanguageEncoding)?;
+            .ok_or(IronfishError::InvalidLanguageEncoding)?;
         let mnemonic = Mnemonic::from_entropy(&self.view_key, language).unwrap();
         Ok(mnemonic.phrase().to_string())
     }

--- a/ironfish-rust/src/merkle_note.rs
+++ b/ironfish-rust/src/merkle_note.rs
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::errors::IronfishError;
+
 /// Implement a merkle note to store all the values that need to go into a merkle tree.
 /// A tree containing these values can serve as a snapshot of the entire chain.
 use super::{
-    errors,
     keys::{shared_secret, IncomingViewKey, OutgoingViewKey, PublicAddress, SaplingKey},
     note::{Note, ENCRYPTED_NOTE_SIZE},
     serializing::{aead, read_scalar},
@@ -168,7 +169,7 @@ impl MerkleNote {
     pub fn decrypt_note_for_owner(
         &self,
         owner_view_key: &IncomingViewKey,
-    ) -> Result<Note, errors::NoteError> {
+    ) -> Result<Note, IronfishError> {
         let shared_secret = owner_view_key.shared_secret(&self.ephemeral_public_key);
         let note =
             Note::from_owner_encrypted(owner_view_key, &shared_secret, &self.encrypted_note)?;
@@ -179,7 +180,7 @@ impl MerkleNote {
     pub fn decrypt_note_for_spender(
         &self,
         spender_key: &OutgoingViewKey,
-    ) -> Result<Note, errors::NoteError> {
+    ) -> Result<Note, IronfishError> {
         let encryption_key = calculate_key_for_encryption_keys(
             spender_key,
             &self.value_commitment,

--- a/ironfish-rust/src/merkle_note_hash.rs
+++ b/ironfish-rust/src/merkle_note_hash.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::errors::IronfishError;
+
 /// Implement a merkle note to store all the values that need to go into a merkle tree.
 /// A tree containing these values can serve as a snapshot of the entire chain.
 use super::serializing::read_scalar;
@@ -30,15 +32,16 @@ impl MerkleNoteHash {
         MerkleNoteHash(fr)
     }
 
-    pub fn read<R: io::Read>(reader: R) -> io::Result<MerkleNoteHash> {
-        let res = read_scalar(reader).map_err(|_| {
-            io::Error::new(io::ErrorKind::InvalidInput, "Unable to convert note hash")
-        });
-        Ok(MerkleNoteHash(res.unwrap()))
+    pub fn read<R: io::Read>(reader: R) -> Result<MerkleNoteHash, IronfishError> {
+        let res = read_scalar(reader)?;
+
+        Ok(MerkleNoteHash(res))
     }
 
-    pub fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-        writer.write_all(self.0.to_repr().as_ref())
+    pub fn write<W: io::Write>(&self, writer: &mut W) -> Result<(), IronfishError> {
+        writer.write_all(self.0.to_repr().as_ref())?;
+
+        Ok(())
     }
 
     /// Hash two child hashes together to calculate the hash of the

--- a/ironfish-rust/src/nacl.rs
+++ b/ironfish-rust/src/nacl.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::error::Error;
-
 use crypto_box::{
     aead::{generic_array::GenericArray, Aead},
     rand_core::OsRng,
@@ -37,7 +35,7 @@ pub fn box_message(
     plaintext: String,
     sender_secret_key: [u8; KEY_LENGTH],
     recipient_public_key: [u8; KEY_LENGTH],
-) -> Result<(Vec<u8>, Vec<u8>), Box<dyn Error>> {
+) -> Result<(Vec<u8>, Vec<u8>), IronfishError> {
     let mut rng = OsRng;
 
     let sender: SecretKey = SecretKey::from(sender_secret_key);
@@ -57,9 +55,9 @@ pub fn unbox_message(
     nonce: &[u8],
     sender_public_key: [u8; KEY_LENGTH],
     recipient_secret_key: [u8; KEY_LENGTH],
-) -> Result<String, Box<dyn Error>> {
+) -> Result<String, IronfishError> {
     if nonce.len() != NONCE_LENGTH {
-        return Err(Box::new(IronfishError::InvalidNonceLength));
+        return Err(IronfishError::InvalidNonceLength);
     }
 
     let nonce = GenericArray::from_slice(nonce);

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -118,11 +118,12 @@ impl<'a> Note {
     /// This should generally never be used to serialize to disk or the network.
     /// It is primarily added as a device for transmitting the note across
     /// thread boundaries.
-    pub fn write<W: io::Write>(&self, mut writer: &mut W) -> io::Result<()> {
+    pub fn write<W: io::Write>(&self, mut writer: &mut W) -> Result<(), IronfishError> {
         self.owner.write(&mut writer)?;
         writer.write_u64::<LittleEndian>(self.value)?;
         writer.write_all(self.randomness.to_repr().as_ref())?;
         writer.write_all(&self.memo.0)?;
+
         Ok(())
     }
 

--- a/ironfish-rust/src/receiving.rs
+++ b/ironfish-rust/src/receiving.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::sapling_bls12::SAPLING;
+use crate::{errors::IronfishError, sapling_bls12::SAPLING};
 
-use super::{errors, keys::SaplingKey, merkle_note::MerkleNote, note::Note};
+use super::{keys::SaplingKey, merkle_note::MerkleNote, note::Note};
 use bellman::groth16;
 use bls12_381::{Bls12, Scalar};
 use group::Curve;
@@ -35,7 +35,7 @@ impl ReceiptParams {
     pub(crate) fn new(
         spender_key: &SaplingKey,
         note: &Note,
-    ) -> Result<ReceiptParams, errors::SaplingProofError> {
+    ) -> Result<ReceiptParams, IronfishError> {
         let diffie_hellman_keys = note.owner.generate_diffie_hellman_keys();
 
         let mut buffer = [0u8; 64];
@@ -76,7 +76,7 @@ impl ReceiptParams {
     ///
     /// Verifies the proof before returning to prevent posting broken
     /// transactions.
-    pub fn post(&self) -> Result<ReceiptProof, errors::SaplingProofError> {
+    pub fn post(&self) -> Result<ReceiptProof, IronfishError> {
         let receipt_proof = ReceiptProof {
             proof: self.proof.clone(),
             merkle_note: self.merkle_note.clone(),
@@ -116,7 +116,7 @@ impl ReceiptProof {
     /// Load a ReceiptProof from a Read implementation( e.g: socket, file)
     /// This is the main entry-point when reconstructing a serialized
     /// transaction.
-    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, errors::SaplingProofError> {
+    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
         let proof = groth16::Proof::read(&mut reader)?;
         let merkle_note = MerkleNote::read(&mut reader)?;
 
@@ -130,26 +130,25 @@ impl ReceiptProof {
 
     /// Verify that the proof demonstrates knowledge that a note exists with
     /// the value_commitment, public_key, and note_commitment on this proof.
-    pub fn verify_proof(&self) -> Result<(), errors::SaplingProofError> {
+    pub fn verify_proof(&self) -> Result<(), IronfishError> {
         self.verify_value_commitment()?;
 
-        match groth16::verify_proof(
+        groth16::verify_proof(
             &SAPLING.receipt_verifying_key,
             &self.proof,
             &self.public_inputs()[..],
-        ) {
-            Ok(()) => Ok(()),
-            _ => Err(errors::SaplingProofError::VerificationFailed),
-        }
+        )?;
+
+        Ok(())
     }
 
-    pub fn verify_value_commitment(&self) -> Result<(), errors::SaplingProofError> {
+    pub fn verify_value_commitment(&self) -> Result<(), IronfishError> {
         if self.merkle_note.value_commitment.is_small_order().into()
             || ExtendedPoint::from(self.merkle_note.ephemeral_public_key)
                 .is_small_order()
                 .into()
         {
-            return Err(errors::SaplingProofError::VerificationFailed);
+            return Err(IronfishError::IsSmallOrder);
         }
 
         Ok(())

--- a/ironfish-rust/src/receiving.rs
+++ b/ironfish-rust/src/receiving.rs
@@ -91,7 +91,10 @@ impl ReceiptParams {
     /// The signature is used by the transaction to calculate the signature
     /// hash. Having this data essentially binds the note to the transaction,
     /// proving that it is actually part of that transaction.
-    pub(crate) fn serialize_signature_fields<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+    pub(crate) fn serialize_signature_fields<W: io::Write>(
+        &self,
+        mut writer: W,
+    ) -> Result<(), IronfishError> {
         self.proof.write(&mut writer)?;
         self.merkle_note.write(&mut writer)?;
         Ok(())
@@ -124,7 +127,7 @@ impl ReceiptProof {
     }
 
     /// Stow the bytes of this ReceiptProof in the given writer.
-    pub fn write<W: io::Write>(&self, writer: W) -> io::Result<()> {
+    pub fn write<W: io::Write>(&self, writer: W) -> Result<(), IronfishError> {
         self.serialize_signature_fields(writer)
     }
 
@@ -182,9 +185,13 @@ impl ReceiptProof {
     /// The signature is used by the transaction to calculate the signature
     /// hash. Having this data essentially binds the note to the transaction,
     /// proving that it is actually part of that transaction.
-    pub(crate) fn serialize_signature_fields<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+    pub(crate) fn serialize_signature_fields<W: io::Write>(
+        &self,
+        mut writer: W,
+    ) -> Result<(), IronfishError> {
         self.proof.write(&mut writer)?;
         self.merkle_note.write(&mut writer)?;
+
         Ok(())
     }
 }

--- a/ironfish-rust/src/spending.rs
+++ b/ironfish-rust/src/spending.rs
@@ -172,7 +172,10 @@ impl<'a> SpendParams {
     ///
     /// It is also used during verification, which is why there is an identical
     /// function on the SpendProof struct.
-    pub(crate) fn serialize_signature_fields<W: io::Write>(&self, writer: W) -> io::Result<()> {
+    pub(crate) fn serialize_signature_fields<W: io::Write>(
+        &self,
+        writer: W,
+    ) -> Result<(), IronfishError> {
         serialize_signature_fields(
             writer,
             &self.proof,
@@ -282,7 +285,7 @@ impl SpendProof {
     }
 
     /// Stow the bytes of this SpendProof in the given writer.
-    pub fn write<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
         self.serialize_signature_fields(&mut writer)?;
         self.authorizing_signature.write(&mut writer)?;
 
@@ -369,7 +372,10 @@ impl SpendProof {
 
     /// Serialize the fields that are needed in calculating a signature to
     /// the provided writer (probably a Blake2B writer)
-    pub(crate) fn serialize_signature_fields<W: io::Write>(&self, writer: W) -> io::Result<()> {
+    pub(crate) fn serialize_signature_fields<W: io::Write>(
+        &self,
+        writer: W,
+    ) -> Result<(), IronfishError> {
         serialize_signature_fields(
             writer,
             &self.proof,
@@ -395,13 +401,14 @@ fn serialize_signature_fields<W: io::Write>(
     root_hash: &Scalar,
     tree_size: u32,
     nullifier: &Nullifier,
-) -> io::Result<()> {
+) -> Result<(), IronfishError> {
     proof.write(&mut writer)?;
     writer.write_all(&value_commitment.to_bytes())?;
     writer.write_all(&randomized_public_key.0.to_bytes())?;
     writer.write_all(root_hash.to_repr().as_ref())?;
     writer.write_u32::<LittleEndian>(tree_size)?;
     writer.write_all(&nullifier.0)?;
+
     Ok(())
 }
 

--- a/ironfish-rust/src/spending.rs
+++ b/ironfish-rust/src/spending.rs
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::sapling_bls12::SAPLING;
+use crate::{errors::IronfishError, sapling_bls12::SAPLING};
 
 use super::{
-    errors,
     keys::SaplingKey,
     merkle_note::{position as witness_position, sapling_auth_path},
     merkle_note_hash::MerkleNoteHash,
@@ -82,11 +81,11 @@ impl<'a> SpendParams {
         spender_key: SaplingKey,
         note: &Note,
         witness: &dyn WitnessTrait,
-    ) -> Result<SpendParams, errors::SaplingProofError> {
+    ) -> Result<SpendParams, IronfishError> {
         // This is a sanity check; it would be caught in proving the circuit anyway,
         // but this gives us more information in the event of a failure
         if !witness.verify(&MerkleNoteHash::new(note.commitment_point())) {
-            return Err(errors::SaplingProofError::InconsistentWitness);
+            return Err(IronfishError::InconsistentWitness);
         }
 
         let mut buffer = [0u8; 64];
@@ -135,13 +134,13 @@ impl<'a> SpendParams {
     ///
     /// Verifies the proof before returning to prevent posting broken
     /// transactions
-    pub fn post(&self, signature_hash: &[u8; 32]) -> Result<SpendProof, errors::SaplingProofError> {
+    pub fn post(&self, signature_hash: &[u8; 32]) -> Result<SpendProof, IronfishError> {
         let private_key = redjubjub::PrivateKey(self.spender_key.spend_authorizing_key);
         let randomized_private_key = private_key.randomize(self.public_key_randomness);
         let randomized_public_key =
             redjubjub::PublicKey::from_private(&randomized_private_key, SPENDING_KEY_GENERATOR);
         if randomized_public_key.0 != self.randomized_public_key.0 {
-            return Err(errors::SaplingProofError::SigningError);
+            return Err(IronfishError::InvalidSigningKey);
         }
         let mut data_to_be_signed = [0; 64];
         data_to_be_signed[..32].copy_from_slice(&randomized_public_key.0.to_bytes());
@@ -253,14 +252,14 @@ impl SpendProof {
     /// Load a SpendProof from a Read implementation (e.g: socket, file)
     /// This is the main entry-point when reconstructing a serialized
     /// transaction.
-    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, errors::SaplingProofError> {
+    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
         let proof = groth16::Proof::read(&mut reader)?;
         let value_commitment = {
             let mut bytes = [0; 32];
             reader.read_exact(&mut bytes)?;
             let point = ExtendedPoint::from_bytes(&bytes);
             if point.is_none().into() {
-                return Err(errors::SaplingProofError::IOError);
+                return Err(IronfishError::InvalidData);
             }
             point.unwrap()
         };
@@ -304,12 +303,9 @@ impl SpendProof {
 
     /// Verify that the signature on this proof is signing the provided input
     /// with the randomized_public_key on this proof.
-    pub fn verify_signature(
-        &self,
-        signature_hash_value: &[u8; 32],
-    ) -> Result<(), errors::SaplingProofError> {
+    pub fn verify_signature(&self, signature_hash_value: &[u8; 32]) -> Result<(), IronfishError> {
         if self.randomized_public_key.0.is_small_order().into() {
-            return Err(errors::SaplingProofError::VerificationFailed);
+            return Err(IronfishError::IsSmallOrder);
         }
         let mut data_to_be_signed = [0; 64];
         data_to_be_signed[..32].copy_from_slice(&self.randomized_public_key.0.to_bytes());
@@ -320,30 +316,29 @@ impl SpendProof {
             &self.authorizing_signature,
             SPENDING_KEY_GENERATOR,
         ) {
-            Err(errors::SaplingProofError::VerificationFailed)
-        } else {
-            Ok(())
+            return Err(IronfishError::VerificationFailed);
         }
+
+        Ok(())
     }
 
     /// Verify that the bellman proof confirms the randomized_public_key,
     /// commitment_value, nullifier, and anchor attached to this SpendProof.
-    pub fn verify_proof(&self) -> Result<(), errors::SaplingProofError> {
+    pub fn verify_proof(&self) -> Result<(), IronfishError> {
         self.verify_value_commitment()?;
 
-        match groth16::verify_proof(
+        groth16::verify_proof(
             &SAPLING.spend_verifying_key,
             &self.proof,
             &self.public_inputs()[..],
-        ) {
-            Ok(()) => Ok(()),
-            _ => Err(errors::SaplingProofError::VerificationFailed),
-        }
+        )?;
+
+        Ok(())
     }
 
-    pub fn verify_value_commitment(&self) -> Result<(), errors::SaplingProofError> {
+    pub fn verify_value_commitment(&self) -> Result<(), IronfishError> {
         if self.value_commitment.is_small_order().into() {
-            return Err(errors::SaplingProofError::VerificationFailed);
+            return Err(IronfishError::IsSmallOrder);
         }
 
         Ok(())

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -385,7 +385,7 @@ impl Transaction {
 
     /// Store the bytes of this transaction in the given writer. This is used
     /// to serialize transactions to file or network
-    pub fn write<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
         writer.write_u64::<LittleEndian>(self.spends.len() as u64)?;
         writer.write_u64::<LittleEndian>(self.receipts.len() as u64)?;
         writer.write_i64::<LittleEndian>(self.transaction_fee)?;

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::sapling_bls12::SAPLING;
+use crate::{errors::IronfishError, sapling_bls12::SAPLING};
 
 use super::{
-    errors::{SaplingProofError, TransactionError},
     keys::{PublicAddress, SaplingKey},
     merkle_note::NOTE_ENCRYPTION_MINER_KEYS,
     note::{Memo, Note},
@@ -95,7 +94,7 @@ impl ProposedTransaction {
         spender_key: SaplingKey,
         note: &Note,
         witness: &dyn WitnessTrait,
-    ) -> Result<(), SaplingProofError> {
+    ) -> Result<(), IronfishError> {
         let proof = SpendParams::new(spender_key, note, witness)?;
         self.add_spend_proof(proof, note.value());
         Ok(())
@@ -115,11 +114,7 @@ impl ProposedTransaction {
 
     /// Create a proof of a new note owned by the recipient in this
     /// transaction.
-    pub fn receive(
-        &mut self,
-        spender_key: &SaplingKey,
-        note: &Note,
-    ) -> Result<(), SaplingProofError> {
+    pub fn receive(&mut self, spender_key: &SaplingKey, note: &Note) -> Result<(), IronfishError> {
         let proof = ReceiptParams::new(spender_key, note)?;
 
         self.increment_binding_signature_key(&proof.value_commitment_randomness, true);
@@ -146,11 +141,11 @@ impl ProposedTransaction {
         spender_key: &SaplingKey,
         change_goes_to: Option<PublicAddress>,
         intended_transaction_fee: u64,
-    ) -> Result<Transaction, TransactionError> {
+    ) -> Result<Transaction, IronfishError> {
         let change_amount = self.transaction_fee - intended_transaction_fee as i64;
 
         if change_amount < 0 {
-            return Err(TransactionError::InvalidBalanceError);
+            return Err(IronfishError::InvalidBalance);
         }
         if change_amount > 0 {
             // TODO: The public address generated from the spender_key if
@@ -175,9 +170,9 @@ impl ProposedTransaction {
     /// or change and therefore have a negative transaction fee. In normal use,
     /// a miner would not accept such a transaction unless it was explicitly set
     /// as the miners fee.
-    pub fn post_miners_fee(&mut self) -> Result<Transaction, TransactionError> {
+    pub fn post_miners_fee(&mut self) -> Result<Transaction, IronfishError> {
         if !self.spends.is_empty() || self.receipts.len() != 1 {
-            return Err(TransactionError::InvalidBalanceError);
+            return Err(IronfishError::InvalidMinersFeeTransaction);
         }
         // Ensure the merkle note has an identifiable encryption key
         self.receipts
@@ -190,7 +185,7 @@ impl ProposedTransaction {
     /// Super special case for generating an illegal transaction for the genesis block.
     /// Don't bother using this anywhere else, it won't pass verification.
     #[deprecated(note = "Use only in genesis block generation")]
-    pub fn post_genesis_transaction(&self) -> Result<Transaction, TransactionError> {
+    pub fn post_genesis_transaction(&self) -> Result<Transaction, IronfishError> {
         self._partial_post()
     }
 
@@ -205,7 +200,7 @@ impl ProposedTransaction {
     }
 
     // post transaction without much validation.
-    fn _partial_post(&self) -> Result<Transaction, TransactionError> {
+    fn _partial_post(&self) -> Result<Transaction, IronfishError> {
         self.check_value_consistency()?;
         let data_to_sign = self.transaction_signature_hash();
         let binding_signature = self.binding_signature()?;
@@ -267,7 +262,7 @@ impl ProposedTransaction {
     /// Note: There is some duplication of effort between this function and
     /// binding_signature below. I find the separation of concerns easier
     /// to read, but it's an easy win if we see a performance bottleneck here.
-    fn check_value_consistency(&self) -> Result<(), TransactionError> {
+    fn check_value_consistency(&self) -> Result<(), IronfishError> {
         let private_key = PrivateKey(self.binding_signature_key);
         let public_key =
             PublicKey::from_private(&private_key, VALUE_COMMITMENT_RANDOMNESS_GENERATOR);
@@ -278,7 +273,7 @@ impl ProposedTransaction {
         calculated_public_key += value_balance_point;
 
         if calculated_public_key != public_key.0 {
-            Err(TransactionError::InvalidBalanceError)
+            Err(IronfishError::InvalidBalance)
         } else {
             Ok(())
         }
@@ -288,7 +283,7 @@ impl ProposedTransaction {
     /// transaction and uses it as a private key to sign all the values
     /// that were calculated as part of the transaction. This function
     /// performs the calculation and sets the value on this struct.
-    fn binding_signature(&self) -> Result<Signature, TransactionError> {
+    fn binding_signature(&self) -> Result<Signature, IronfishError> {
         let mut data_to_be_signed = [0u8; 64];
         let private_key = PrivateKey(self.binding_signature_key);
         let public_key =
@@ -364,7 +359,7 @@ impl Transaction {
     /// Load a Transaction from a Read implementation (e.g: socket, file)
     /// This is the main entry-point when reconstructing a serialized transaction
     /// for verifying.
-    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, TransactionError> {
+    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
         let num_spends = reader.read_u64::<LittleEndian>()?;
         let num_receipts = reader.read_u64::<LittleEndian>()?;
         let transaction_fee = reader.read_i64::<LittleEndian>()?;
@@ -413,7 +408,7 @@ impl Transaction {
     ///  *  The entire transaction was signed with a binding signature
     ///     containing those proofs (and only those proofs)
     ///
-    pub fn verify(&self) -> Result<(), TransactionError> {
+    pub fn verify(&self) -> Result<(), IronfishError> {
         batch_verify_transactions(iter::once(self))
     }
 
@@ -490,7 +485,7 @@ impl Transaction {
     fn verify_binding_signature(
         &self,
         binding_verification_key: &ExtendedPoint,
-    ) -> Result<(), TransactionError> {
+    ) -> Result<(), IronfishError> {
         let mut value_balance_point = value_balance_to_point(self.transaction_fee)?;
         value_balance_point = -value_balance_point;
 
@@ -507,7 +502,7 @@ impl Transaction {
             &self.binding_signature,
             VALUE_COMMITMENT_RANDOMNESS_GENERATOR,
         ) {
-            Err(TransactionError::VerificationFailed)
+            Err(IronfishError::VerificationFailed)
         } else {
             Ok(())
         }
@@ -516,13 +511,13 @@ impl Transaction {
 
 // Convert the integer value to a point on the Jubjub curve, accounting for
 // negative values
-fn value_balance_to_point(value: i64) -> Result<ExtendedPoint, TransactionError> {
+fn value_balance_to_point(value: i64) -> Result<ExtendedPoint, IronfishError> {
     // Can only construct edwards point on positive numbers, so need to
     // add and possibly negate later
     let is_negative = value.is_negative();
     let abs = match value.checked_abs() {
         Some(a) => a as u64,
-        None => return Err(TransactionError::IllegalValueError),
+        None => return Err(IronfishError::IllegalValue),
     };
 
     let mut value_balance = VALUE_COMMITMENT_VALUE_GENERATOR * jubjub::Fr::from(abs);
@@ -536,7 +531,7 @@ fn value_balance_to_point(value: i64) -> Result<ExtendedPoint, TransactionError>
 
 pub fn batch_verify_transactions<'a>(
     transactions: impl IntoIterator<Item = &'a Transaction>,
-) -> Result<(), TransactionError> {
+) -> Result<(), IronfishError> {
     let mut spend_verifier = Verifier::<Bls12>::new();
     let mut receipt_verifier = Verifier::<Bls12>::new();
 
@@ -570,19 +565,9 @@ pub fn batch_verify_transactions<'a>(
         transaction.verify_binding_signature(&binding_verification_key)?;
     }
 
-    if spend_verifier
-        .verify(&mut OsRng, &SAPLING.spend_params.vk)
-        .is_err()
-    {
-        return Err(SaplingProofError::VerificationFailed.into());
-    }
+    spend_verifier.verify(&mut OsRng, &SAPLING.spend_params.vk)?;
 
-    if receipt_verifier
-        .verify(&mut OsRng, &SAPLING.receipt_params.vk)
-        .is_err()
-    {
-        return Err(SaplingProofError::VerificationFailed.into());
-    };
+    receipt_verifier.verify(&mut OsRng, &SAPLING.receipt_params.vk)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Simplify ironfish-rust to single error type and create a small helper for converting to napi errors

The goal here is to make it a little easier to work with errors, spending less time thinking about which type is correct. This also makes it easier to extend functionality (implement From/Into traits, etc).

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
