### PR TITLE
Use bigint to calc currency to avoid float precision problem

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -2,15 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import {
-  displayIronAmount,
-  displayIronAmountWithCurrency,
-  ironToOre,
-  isValidIronAmount,
-  isValidPublicAddress,
-  MINIMUM_IRON_AMOUNT,
-  oreToIron,
-} from '@ironfish/sdk'
+import { CurrencyUtils, isValidPublicAddress } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -60,8 +52,8 @@ export class Pay extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(Pay)
-    let amount = flags.amount
-    let fee = flags.fee
+    let amount = null
+    let fee = null
     let to = flags.to?.trim()
     let from = flags.account?.trim()
     const expirationSequence = flags.expirationSequence
@@ -70,7 +62,6 @@ export class Pay extends IronfishCommand {
     const client = await this.sdk.connectRpc(false, true)
 
     const status = await client.getNodeStatus()
-
     if (!status.content.blockchain.synced) {
       this.log(
         `Your node must be synced with the Iron Fish network to send a transaction. Please try again later`,
@@ -78,54 +69,67 @@ export class Pay extends IronfishCommand {
       this.exit(1)
     }
 
-    if (amount == null || Number.isNaN(amount)) {
+    if (flags.amount) {
+      if (!CurrencyUtils.isValidIron(flags.amount)) {
+        this.error(`A valid amount is required`)
+      }
+
+      amount = CurrencyUtils.decodeIron(flags.amount)
+    }
+
+    if (amount === null) {
       const response = await client.getAccountBalance({ account: from })
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const input: string = await CliUx.ux.prompt(
-        `Enter the amount in $IRON (balance available: ${displayIronAmountWithCurrency(
-          oreToIron(response.content.confirmed),
-          false,
+      const input = (await CliUx.ux.prompt(
+        `Enter the amount in $IRON (balance: ${CurrencyUtils.renderIron(
+          response.content.confirmed,
         )})`,
         {
           required: true,
         },
-      )
+      )) as string
 
-      if (Number.isNaN(input)) {
+      if (!CurrencyUtils.isValidIron(input)) {
         this.error(`A valid amount is required`)
       }
 
-      amount = input
+      amount = CurrencyUtils.decodeIron(input)
     }
 
-    if (fee == null || Number.isNaN(fee)) {
-      let dynamicFee: string | null
+    if (flags.fee) {
+      if (!CurrencyUtils.isValidIron(flags.fee)) {
+        this.error(`A valid fee is required`)
+      }
+      fee = CurrencyUtils.decodeIron(flags.fee)
+    }
 
+    if (fee == null) {
+      let dynamicFee: bigint | null
       try {
-        // fees p25 of last 100 blocks
-        dynamicFee = displayIronAmount(
-          oreToIron((await client.getFees({ numOfBlocks: 100 })).content.p25),
-        )
+        const response = await client.getFees({ numOfBlocks: 100 })
+        dynamicFee = CurrencyUtils.decode(response.content.p25.toString())
       } catch {
         dynamicFee = null
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const input: string = await CliUx.ux.prompt(
-        `Enter the fee amount in $IRON (min: 0.00000001${
-          dynamicFee ? `, dynamic: ${dynamicFee}` : ''
+      const input = (await CliUx.ux.prompt(
+        `Enter the fee amount in $IRON (min: ${CurrencyUtils.renderIron(1n)}${
+          dynamicFee ? `, recommended: ${dynamicFee}` : ''
         })`,
         {
           required: true,
         },
-      )
+      )) as string
 
-      if (Number.isNaN(input)) {
-        this.error(`A valid fee amount is required`)
+      if (!CurrencyUtils.isValidIron(input)) {
+        this.error(`A valid amount is required`)
       }
 
-      fee = input
+      fee = CurrencyUtils.decodeIron(input)
+    }
+
+    if (fee < 1n) {
+      this.error(`The minimum fee is ${CurrencyUtils.renderOre(1n, true)}`)
     }
 
     if (!to) {
@@ -152,26 +156,6 @@ export class Pay extends IronfishCommand {
       from = defaultAccount.name
     }
 
-    if (amount === undefined || !isValidIronAmount(amount)) {
-      this.log(
-        `The minimum transaction amount is ${displayIronAmountWithCurrency(
-          MINIMUM_IRON_AMOUNT,
-          false,
-        )}.`,
-      )
-      this.exit(0)
-    }
-
-    if (fee === undefined || !isValidIronAmount(fee)) {
-      this.log(
-        `The minimum fee amount is ${displayIronAmountWithCurrency(
-          MINIMUM_IRON_AMOUNT,
-          false,
-        )}.`,
-      )
-      this.exit(0)
-    }
-
     if (!isValidPublicAddress(to)) {
       this.log(`A valid public address is required`)
       this.exit(1)
@@ -185,10 +169,7 @@ export class Pay extends IronfishCommand {
     if (!flags.confirm) {
       this.log(`
 You are about to send:
-${displayIronAmountWithCurrency(
-  amount,
-  true,
-)} plus a transaction fee of ${displayIronAmountWithCurrency(
+${CurrencyUtils.renderIron(amount, true)} plus a transaction fee of ${CurrencyUtils.renderIron(
         fee,
         true,
       )} to ${to} from the account ${from}
@@ -234,11 +215,11 @@ ${displayIronAmountWithCurrency(
         receives: [
           {
             publicAddress: to,
-            amount: ironToOre(amount).toString(),
+            amount: CurrencyUtils.encode(amount),
             memo: memo,
           },
         ],
-        fee: ironToOre(fee).toString(),
+        fee: CurrencyUtils.encode(fee),
         expirationSequence,
       })
 
@@ -247,11 +228,11 @@ ${displayIronAmountWithCurrency(
       const transaction = result.content
       const recipients = transaction.receives.map((receive) => receive.publicAddress).join(', ')
       this.log(`
-Sending ${displayIronAmountWithCurrency(amount, true)} to ${recipients} from ${
+Sending ${CurrencyUtils.renderIron(amount, true)} to ${recipients} from ${
         transaction.fromAccountName
       }
 Transaction Hash: ${transaction.hash}
-Transaction fee: ${displayIronAmountWithCurrency(fee, true)}
+Transaction fee: ${CurrencyUtils.renderIron(fee, true)}
 
 Find the transaction on https://explorer.ironfish.network/transaction/${
         transaction.hash

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import {
+  displayIronAmount,
   displayIronAmountWithCurrency,
   ironToOre,
   isValidIronAmount,
@@ -103,7 +104,9 @@ export class Pay extends IronfishCommand {
 
       try {
         // fees p25 of last 100 blocks
-        dynamicFee = oreToIron((await client.getFees({ numOfBlocks: 100 })).content.p25)
+        dynamicFee = displayIronAmount(
+          oreToIron((await client.getFees({ numOfBlocks: 100 })).content.p25),
+        )
       } catch {
         dynamicFee = null
       }

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -3,10 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
   BlockSerde,
+  CurrencyUtils,
   GENESIS_SUPPLY_IN_IRON,
   GenesisBlockInfo,
   IJSON,
-  ironToOre,
   makeGenesisBlock,
   Target,
 } from '@ironfish/sdk'
@@ -79,7 +79,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
       allocations: [
         {
           publicAddress: account.publicAddress,
-          amount: ironToOre(GENESIS_SUPPLY_IN_IRON),
+          amount: CurrencyUtils.decodeIron(GENESIS_SUPPLY_IN_IRON),
         },
       ],
     }

--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -7,7 +7,6 @@ import {
   BigIntUtils,
   CurrencyUtils,
   ERROR_CODES,
-  ironToOre,
   MINIMUM_IRON_AMOUNT,
   PromiseUtils,
   RpcClient,
@@ -212,7 +211,7 @@ export default class DepositAll extends IronfishCommand {
       unconfirmedBalance = CurrencyUtils.decode(balanceResp.content.unconfirmed)
       pendingBalance = CurrencyUtils.decode(balanceResp.content.pending)
 
-      const sendOres = ironToOre(IRON_TO_SEND) + BigInt(fee)
+      const sendOres = CurrencyUtils.decodeIron(IRON_TO_SEND) + fee
 
       // terminate condition
       if (terminate && pendingBalance < sendOres) {
@@ -228,7 +227,7 @@ export default class DepositAll extends IronfishCommand {
             receives: [
               {
                 publicAddress: bankDepositAddress,
-                amount: ironToOre(IRON_TO_SEND).toString(),
+                amount: CurrencyUtils.encode(CurrencyUtils.decodeIron(IRON_TO_SEND)),
                 memo: graffiti,
               },
             ],

--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -212,14 +212,16 @@ export default class DepositAll extends IronfishCommand {
       unconfirmedBalance = CurrencyUtils.decode(balanceResp.content.unconfirmed)
       pendingBalance = CurrencyUtils.decode(balanceResp.content.pending)
 
+      const sendOres = ironToOre(IRON_TO_SEND) + BigInt(fee)
+
       // terminate condition
-      if (terminate && pendingBalance < BigInt(ironToOre(IRON_TO_SEND)) + BigInt(fee)) {
+      if (terminate && pendingBalance < sendOres) {
         screen.destroy()
         process.exit(0)
       }
 
       // send transaction
-      if (confirmedBalance > BigInt(ironToOre(IRON_TO_SEND)) + BigInt(fee)) {
+      if (confirmedBalance > sendOres) {
         try {
           const result = await this.client.sendTransaction({
             fromAccountName: accountName,

--- a/ironfish-cli/src/commands/deposit.ts
+++ b/ironfish-cli/src/commands/deposit.ts
@@ -111,9 +111,8 @@ export default class Bank extends IronfishCommand {
     }
 
     const balanceResp = await this.client.getAccountBalance({ account: accountName })
-    const confirmedBalance = Number(balanceResp.content.confirmed)
-    const requiredBalance = ironToOre(IRON_TO_SEND) + fee
-
+    const confirmedBalance = BigInt(balanceResp.content.confirmed)
+    const requiredBalance = ironToOre(IRON_TO_SEND) + BigInt(fee)
     if (confirmedBalance < requiredBalance) {
       this.log(`Insufficient balance: ${confirmedBalance}. Required: ${requiredBalance}`)
       this.exit(1)

--- a/ironfish-cli/src/commands/deposit.ts
+++ b/ironfish-cli/src/commands/deposit.ts
@@ -4,10 +4,9 @@
 
 import {
   Assert,
-  displayIronAmountWithCurrency,
-  ironToOre,
+  BigIntUtils,
+  CurrencyUtils,
   MINIMUM_IRON_AMOUNT,
-  oreToIron,
   RpcClient,
   WebApi,
 } from '@ironfish/sdk'
@@ -28,7 +27,7 @@ export default class Bank extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    fee: Flags.integer({
+    fee: Flags.string({
       char: 'f',
       description: `The fee amount in ORE, minimum of 1. 1 ORE is equal to ${MINIMUM_IRON_AMOUNT} IRON`,
     }),
@@ -53,14 +52,24 @@ export default class Bank extends IronfishCommand {
     this.client = await this.sdk.connectRpc(false, true)
     this.api = new WebApi()
 
-    let fee = flags.fee
+    let fee = null
 
-    if (fee == null || Number.isNaN(fee)) {
+    if (flags.fee) {
+      const [parsedFee] = BigIntUtils.tryParse(flags.fee)
+
+      if (parsedFee != null) {
+        fee = parsedFee
+      }
+    }
+
+    if (fee == null) {
       try {
         // fees p25 of last 100 blocks
-        fee = (await this.client.getFees({ numOfBlocks: 100 })).content.p25
+        const feeNumber = (await this.client.getFees({ numOfBlocks: 100 })).content.p25
+        // TODO: NEVER use numbers for amounts
+        fee = BigInt(feeNumber)
       } catch {
-        fee = 1
+        fee = 1n
       }
     }
 
@@ -101,7 +110,7 @@ export default class Bank extends IronfishCommand {
       this.client,
       this.api,
       expirationSequenceDelta,
-      fee,
+      Number(fee),
       graffiti,
     )
     if (!canSend) {
@@ -112,7 +121,7 @@ export default class Bank extends IronfishCommand {
 
     const balanceResp = await this.client.getAccountBalance({ account: accountName })
     const confirmedBalance = BigInt(balanceResp.content.confirmed)
-    const requiredBalance = ironToOre(IRON_TO_SEND) + BigInt(fee)
+    const requiredBalance = CurrencyUtils.decodeIron(IRON_TO_SEND) + BigInt(fee)
     if (confirmedBalance < requiredBalance) {
       this.log(`Insufficient balance: ${confirmedBalance}. Required: ${requiredBalance}`)
       this.exit(1)
@@ -120,13 +129,10 @@ export default class Bank extends IronfishCommand {
 
     const newBalance = confirmedBalance - requiredBalance
 
-    const displayConfirmedBalance = displayIronAmountWithCurrency(
-      oreToIron(confirmedBalance),
-      true,
-    )
-    const displayAmount = displayIronAmountWithCurrency(IRON_TO_SEND, true)
-    const displayFee = displayIronAmountWithCurrency(oreToIron(fee), true)
-    const displayNewBalance = displayIronAmountWithCurrency(oreToIron(newBalance), true)
+    const displayConfirmedBalance = CurrencyUtils.renderIron(confirmedBalance, true)
+    const displayAmount = CurrencyUtils.renderIron(CurrencyUtils.decodeIron(IRON_TO_SEND), true)
+    const displayFee = CurrencyUtils.renderIron(fee, true)
+    const displayNewBalance = CurrencyUtils.renderIron(newBalance, true)
 
     if (!flags.confirm) {
       this.log(`
@@ -177,7 +183,7 @@ The memo will contain the graffiti "${graffiti}".
         receives: [
           {
             publicAddress: bankDepositAddress,
-            amount: ironToOre(IRON_TO_SEND).toString(),
+            amount: CurrencyUtils.decodeIron(IRON_TO_SEND).toString(),
             memo: graffiti,
           },
         ],
@@ -197,7 +203,7 @@ Transaction fee: ${displayFee}
 
 New Balance: ${displayNewBalance}
 
-Find the transaction on https://explorer.ironfish.network/transaction/${transaction.hash} 
+Find the transaction on https://explorer.ironfish.network/transaction/${transaction.hash}
 (it can take a few minutes before the transaction appears in the Explorer)`)
     } catch (error: unknown) {
       stopProgressBar()

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -4,11 +4,9 @@
 import {
   Assert,
   AsyncUtils,
-  displayIronAmount,
+  CurrencyUtils,
   GENESIS_BLOCK_SEQUENCE,
-  MathUtils,
   Meter,
-  oreToIron,
   TimeUtils,
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
@@ -114,7 +112,7 @@ export class MinedCommand extends IronfishCommand {
 
   logLineForMinedBlock(block: {
     hash: string
-    minersFee: number
+    minersFee: string
     sequence: number
     main: boolean
     account: string
@@ -122,7 +120,7 @@ export class MinedCommand extends IronfishCommand {
     readline.clearLine(process.stdout, -1)
     readline.cursorTo(process.stdout, 0)
 
-    const amount = displayIronAmount(oreToIron(block.minersFee), 2)
+    const amount = CurrencyUtils.renderIron(block.minersFee, true)
 
     const link = linkText(
       `https://explorer.ironfish.network/blocks/${block.hash}`,

--- a/ironfish-cli/src/commands/miners/mined.ts
+++ b/ironfish-cli/src/commands/miners/mined.ts
@@ -4,6 +4,7 @@
 import {
   Assert,
   AsyncUtils,
+  displayIronAmount,
   GENESIS_BLOCK_SEQUENCE,
   MathUtils,
   Meter,
@@ -121,7 +122,7 @@ export class MinedCommand extends IronfishCommand {
     readline.clearLine(process.stdout, -1)
     readline.cursorTo(process.stdout, 0)
 
-    const amount = MathUtils.round(oreToIron(block.minersFee), 2)
+    const amount = displayIronAmount(oreToIron(block.minersFee), 2)
 
     const link = linkText(
       `https://explorer.ironfish.network/blocks/${block.hash}`,

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -4,7 +4,7 @@
 
 import {
   displayIronAmountWithCurrency,
-  isValidAmount,
+  isValidIronAmount,
   MINIMUM_IRON_AMOUNT,
   RpcClient,
   WebApi,
@@ -65,7 +65,7 @@ export async function verifyCanSend(
     }
   }
 
-  if (!isValidAmount(fee)) {
+  if (!isValidIronAmount(fee)) {
     return {
       canSend: false,
       errorReason: `The minimum fee is ${displayIronAmountWithCurrency(

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -2,13 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import {
-  displayIronAmountWithCurrency,
-  isValidIronAmount,
-  MINIMUM_IRON_AMOUNT,
-  RpcClient,
-  WebApi,
-} from '@ironfish/sdk'
+import { CurrencyUtils, RpcClient, WebApi } from '@ironfish/sdk'
 
 const REGISTER_URL = 'https://testnet.ironfish.network/signup'
 
@@ -65,13 +59,10 @@ export async function verifyCanSend(
     }
   }
 
-  if (!isValidIronAmount(fee)) {
+  if (fee <= 0n) {
     return {
       canSend: false,
-      errorReason: `The minimum fee is ${displayIronAmountWithCurrency(
-        MINIMUM_IRON_AMOUNT,
-        false,
-      )}`,
+      errorReason: `The minimum fee is ${CurrencyUtils.renderIron(1n, true)}`,
     }
   }
 

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -18,7 +18,6 @@
   ],
   "dependencies": {
     "@ethersproject/bignumber": "5.7.0",
-    "@ethersproject/units": "5.7.0",
     "@ironfish/rust-nodejs": "0.1.14",
     "@napi-rs/blake-hash": "1.3.1",
     "axios": "0.21.4",

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -17,6 +17,8 @@
     "build/**/*.json"
   ],
   "dependencies": {
+    "@ethersproject/bignumber": "5.7.0",
+    "@ethersproject/units": "5.7.0",
     "@ironfish/rust-nodejs": "0.1.14",
     "@napi-rs/blake-hash": "1.3.1",
     "axios": "0.21.4",

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -59,7 +59,7 @@ describe('Create genesis block', () => {
     const node = nodeTest.node
     const chain = nodeTest.chain
 
-    const amountNumber = 5
+    const amountNumber = 5n
     const amountBigint = BigInt(amountNumber)
 
     // Construct parameters for the genesis block

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -21,7 +21,7 @@ export type GenesisBlockInfo = {
   target: Target
   allocations: {
     publicAddress: string
-    amount: number
+    amount: bigint
   }[]
 }
 
@@ -41,7 +41,7 @@ export async function makeGenesisBlock(
     throw new Error('Database must be empty to create a genesis block.')
   }
   // Sum the allocations to get the total number of coins
-  const allocationSum = info.allocations.reduce((sum, cur) => sum + cur.amount, 0)
+  const allocationSum = info.allocations.reduce((sum, cur) => sum + cur.amount, 0n)
 
   // Track all of the transactions that will be added to the genesis block
   const transactionList = []
@@ -50,11 +50,7 @@ export async function makeGenesisBlock(
   // It should end up with 0 coins.
   const genesisKey = generateKey()
   // Create a genesis note granting the genesisKey allocationSum coins.
-  const genesisNote = new NativeNote(
-    genesisKey.public_address,
-    BigInt(allocationSum),
-    info.memo,
-  )
+  const genesisNote = new NativeNote(genesisKey.public_address, allocationSum, info.memo)
 
   // Create a miner's fee transaction for the block.
   // Since the block itself generates coins and we don't want the miner account to gain

--- a/ironfish/src/mining/webhooks/webhookNotifier.ts
+++ b/ironfish/src/mining/webhooks/webhookNotifier.ts
@@ -4,7 +4,7 @@
 
 import Axios, { AxiosInstance } from 'axios'
 import { createRootLogger, Logger } from '../../logger'
-import { displayIronAmountWithCurrency, ErrorUtils, oreToIron } from '../../utils'
+import { CurrencyUtils, ErrorUtils } from '../../utils'
 import { FileUtils } from '../../utils/file'
 
 export abstract class WebhookNotifier {
@@ -62,10 +62,7 @@ export abstract class WebhookNotifier {
     this.sendText(
       `Successfully created payout of ${totalShareCount} shares to ${
         receives.length
-      } users for ${displayIronAmountWithCurrency(
-        oreToIron(total),
-        false,
-      )} in transaction ${this.renderHashHex(
+      } users for ${CurrencyUtils.renderIron(total, true)} in transaction ${this.renderHashHex(
         transactionHashHex,
         this.explorerTransactionsUrl,
       )}. Transaction pending (${payoutId})`,
@@ -88,7 +85,7 @@ export abstract class WebhookNotifier {
     this.sendText(
       `Creating payout of ${totalShareCount} shares to ${
         receives.length
-      } users for ${displayIronAmountWithCurrency(oreToIron(total), false)}(${payoutId})`,
+      } users for ${CurrencyUtils.renderIron(total, true)} (${payoutId})`,
     )
   }
 

--- a/ironfish/src/mining/webhooks/webhookNotifier.ts
+++ b/ironfish/src/mining/webhooks/webhookNotifier.ts
@@ -63,7 +63,7 @@ export abstract class WebhookNotifier {
       `Successfully created payout of ${totalShareCount} shares to ${
         receives.length
       } users for ${displayIronAmountWithCurrency(
-        Number(oreToIron(Number(total.toString()))),
+        oreToIron(total),
         false,
       )} in transaction ${this.renderHashHex(
         transactionHashHex,
@@ -88,10 +88,7 @@ export abstract class WebhookNotifier {
     this.sendText(
       `Creating payout of ${totalShareCount} shares to ${
         receives.length
-      } users for ${displayIronAmountWithCurrency(
-        Number(oreToIron(Number(total.toString()))),
-        false,
-      )}(${payoutId})`,
+      } users for ${displayIronAmountWithCurrency(oreToIron(total), false)}(${payoutId})`,
     )
   }
 

--- a/ironfish/src/rpc/routes/mining/exportMined.ts
+++ b/ironfish/src/rpc/routes/mining/exportMined.ts
@@ -21,7 +21,7 @@ export type ExportMinedStreamResponse = {
   sequence?: number
   block?: {
     hash: string
-    minersFee: number
+    minersFee: string
     sequence: number
     main: boolean
     account: string
@@ -45,7 +45,7 @@ export const ExportMinedStreamResponseSchema: yup.ObjectSchema<ExportMinedStream
     block: yup
       .object({
         hash: yup.string().defined(),
-        minersFee: yup.number().defined(),
+        minersFee: yup.string().defined(),
         sequence: yup.number().defined(),
         main: yup.boolean().defined(),
         account: yup.string().defined(),
@@ -65,7 +65,14 @@ router.register<typeof ExportMinedStreamRequestSchema, ExportMinedStreamResponse
 
     if (blockHash) {
       const block = await node.minedBlocksIndexer.getMinedBlock(Buffer.from(blockHash, 'hex'))
-      request.stream({ block })
+      const serialized = block
+        ? {
+            ...block,
+            minersFee: block.minersFee.toString(),
+          }
+        : undefined
+
+      request.stream({ block: serialized })
       request.end()
     }
 
@@ -89,7 +96,10 @@ router.register<typeof ExportMinedStreamRequestSchema, ExportMinedStreamResponse
         start,
         stop,
         sequence: block.sequence,
-        block,
+        block: {
+          ...block,
+          minersFee: block.minersFee.toString(),
+        },
       })
     }
 

--- a/ironfish/src/utils/currency.test.ts
+++ b/ironfish/src/utils/currency.test.ts
@@ -1,7 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { displayIronAmountWithCurrency, ironToOre, isValidAmount, oreToIron } from './currency'
+import {
+  displayIronAmountWithCurrency,
+  ironToOre,
+  isValidIronAmount,
+  oreToIron,
+} from './currency'
 
 describe('Currency utils', () => {
   test('displayIronAmountWithCurrency returns the right string', () => {
@@ -12,40 +17,38 @@ describe('Currency utils', () => {
       })
     }
 
-    expect(displayIronAmountWithCurrency(0.00000002, true)).toEqual(
-      `$IRON ${displayLocale('0.00000002', 8)} ($ORE ${displayLocale('2', 0)})`,
+    expect(displayIronAmountWithCurrency('0.00000002', true)).toEqual(
+      `$IRON 0.00000002 ($ORE ${displayLocale('2', 0)})`,
     )
-    expect(displayIronAmountWithCurrency(0.0000001, true)).toEqual(
-      `$IRON ${displayLocale('0.00000010', 8)} ($ORE ${displayLocale('10', 0)})`,
+    expect(displayIronAmountWithCurrency('0.0000001', true)).toEqual(
+      `$IRON 0.00000010 ($ORE ${displayLocale('10', 0)})`,
     )
     expect(displayIronAmountWithCurrency(0, true)).toEqual(
-      `$IRON ${displayLocale('0.00000000', 8)} ($ORE ${displayLocale('0', 0)})`,
+      `$IRON 0.00000000 ($ORE ${displayLocale('0', 0)})`,
     )
     expect(displayIronAmountWithCurrency(1, true)).toEqual(
-      `$IRON ${displayLocale('1.00000000', 8)} ($ORE ${displayLocale('100000000', 0)})`,
+      `$IRON 1.00000000 ($ORE ${displayLocale('100000000', 0)})`,
     )
     expect(displayIronAmountWithCurrency(100, true)).toEqual(
-      `$IRON ${displayLocale('100.00000000', 8)} ($ORE ${displayLocale('10000000000', 0)})`,
+      `$IRON 100.00000000 ($ORE ${displayLocale('10000000000', 0)})`,
     )
-    expect(displayIronAmountWithCurrency(100, false)).toEqual(
-      `$IRON ${displayLocale('100.00000000', 8)}`,
-    )
+    expect(displayIronAmountWithCurrency(100, false)).toEqual(`$IRON 100.00000000`)
   })
 
-  test('isValidAmount returns the right value', () => {
-    expect(isValidAmount(0.0000000000001)).toBe(false)
-    expect(isValidAmount(100000000000000000000000000)).toBe(false)
-    expect(isValidAmount(0.00000001)).toBe(true)
-    expect(isValidAmount(10.000001)).toBe(true)
+  test('isValidIronAmount returns the right value', () => {
+    expect(isValidIronAmount('0.0000000000001')).toBe(false)
+    expect(isValidIronAmount('100000000000000000000000000')).toBe(false)
+    expect(isValidIronAmount('0.00000001')).toBe(true)
+    expect(isValidIronAmount('10.000001')).toBe(true)
   })
 
   test('oreToIron returns the right value', () => {
-    expect(oreToIron(2394)).toBe(0.00002394)
-    expect(oreToIron(999)).toBe(0.00000999)
+    expect(oreToIron(2394)).toBe('0.00002394')
+    expect(oreToIron(999)).toBe('0.00000999')
   })
 
   test('ironToOre returns the right value', () => {
-    expect(ironToOre(0.00002394)).toBe(2394)
-    expect(ironToOre(0.00000999)).toBe(999)
+    expect(ironToOre('0.00002394')).toBe(2394n)
+    expect(ironToOre('0.00000999')).toBe(999n)
   })
 })

--- a/ironfish/src/utils/currency.test.ts
+++ b/ironfish/src/utils/currency.test.ts
@@ -1,54 +1,69 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import {
-  displayIronAmountWithCurrency,
-  ironToOre,
-  isValidIronAmount,
-  oreToIron,
-} from './currency'
+import { CurrencyUtils } from './currency'
 
-describe('Currency utils', () => {
-  test('displayIronAmountWithCurrency returns the right string', () => {
-    const displayLocale = (value: string, decimals: number) => {
-      return parseFloat(value).toLocaleString(undefined, {
-        minimumFractionDigits: decimals,
-        maximumFractionDigits: decimals,
-      })
-    }
+describe('CurrencyUtils', () => {
+  it('encode', () => {
+    expect(CurrencyUtils.encode(0n)).toEqual('0')
+    expect(CurrencyUtils.encode(1n)).toEqual('1')
+    expect(CurrencyUtils.encode(100n)).toEqual('100')
+    expect(CurrencyUtils.encode(10000n)).toEqual('10000')
+    expect(CurrencyUtils.encode(100000000n)).toEqual('100000000')
+  })
 
-    expect(displayIronAmountWithCurrency('0.00000002', true)).toEqual(
-      `$IRON 0.00000002 ($ORE ${displayLocale('2', 0)})`,
-    )
-    expect(displayIronAmountWithCurrency('0.0000001', true)).toEqual(
-      `$IRON 0.00000010 ($ORE ${displayLocale('10', 0)})`,
-    )
-    expect(displayIronAmountWithCurrency(0, true)).toEqual(
-      `$IRON 0.00000000 ($ORE ${displayLocale('0', 0)})`,
-    )
-    expect(displayIronAmountWithCurrency(1, true)).toEqual(
-      `$IRON 1.00000000 ($ORE ${displayLocale('100000000', 0)})`,
-    )
-    expect(displayIronAmountWithCurrency(100, true)).toEqual(
-      `$IRON 100.00000000 ($ORE ${displayLocale('10000000000', 0)})`,
-    )
-    expect(displayIronAmountWithCurrency(100, false)).toEqual(`$IRON 100.00000000`)
+  it('decode', () => {
+    expect(CurrencyUtils.decode('0')).toEqual(0n)
+    expect(CurrencyUtils.decode('1')).toEqual(1n)
+    expect(CurrencyUtils.decode('100')).toEqual(100n)
+    expect(CurrencyUtils.decode('10000')).toEqual(10000n)
+    expect(CurrencyUtils.decode('100000000')).toEqual(100000000n)
+  })
+
+  it('encodeIron', () => {
+    expect(CurrencyUtils.encodeIron(0n)).toEqual('0.0')
+    expect(CurrencyUtils.encodeIron(1n)).toEqual('0.00000001')
+    expect(CurrencyUtils.encodeIron(100n)).toEqual('0.000001')
+    expect(CurrencyUtils.encodeIron(10000n)).toEqual('0.0001')
+    expect(CurrencyUtils.encodeIron(100000000n)).toEqual('1.0')
+
+    expect(CurrencyUtils.encodeIron(2394n)).toBe('0.00002394')
+    expect(CurrencyUtils.encodeIron(999n)).toBe('0.00000999')
+  })
+
+  it('decodeIron', () => {
+    expect(CurrencyUtils.decodeIron('0.0')).toEqual(0n)
+    expect(CurrencyUtils.decodeIron('0.00000001')).toEqual(1n)
+    expect(CurrencyUtils.decodeIron('0.000001')).toEqual(100n)
+    expect(CurrencyUtils.decodeIron('0.0001')).toEqual(10000n)
+    expect(CurrencyUtils.decodeIron('1.0')).toEqual(100000000n)
+
+    expect(CurrencyUtils.decodeIron('0.00002394')).toBe(2394n)
+    expect(CurrencyUtils.decodeIron('0.00000999')).toBe(999n)
+  })
+
+  it('renderIron', () => {
+    expect(CurrencyUtils.renderIron(0n)).toEqual('0.00000000')
+    expect(CurrencyUtils.renderIron(1n)).toEqual('0.00000001')
+    expect(CurrencyUtils.renderIron(100n)).toEqual('0.00000100')
+    expect(CurrencyUtils.renderIron(10000n)).toEqual('0.00010000')
+    expect(CurrencyUtils.renderIron(100000000n)).toEqual('1.00000000')
+    expect(CurrencyUtils.renderIron(1n, true)).toEqual('$IRON 0.00000001')
+  })
+
+  it('renderOre', () => {
+    expect(CurrencyUtils.renderOre(0n)).toEqual('0')
+    expect(CurrencyUtils.renderOre(1n)).toEqual('1')
+    expect(CurrencyUtils.renderOre(100n)).toEqual('100')
+    expect(CurrencyUtils.renderOre(10000n)).toEqual('10000')
+    expect(CurrencyUtils.renderOre(100000000n)).toEqual('100000000')
+    expect(CurrencyUtils.renderOre(1n, true)).toEqual('$ORE 1')
   })
 
   test('isValidIronAmount returns the right value', () => {
-    expect(isValidIronAmount('0.0000000000001')).toBe(false)
-    expect(isValidIronAmount('100000000000000000000000000')).toBe(false)
-    expect(isValidIronAmount('0.00000001')).toBe(true)
-    expect(isValidIronAmount('10.000001')).toBe(true)
-  })
-
-  test('oreToIron returns the right value', () => {
-    expect(oreToIron(2394)).toBe('0.00002394')
-    expect(oreToIron(999)).toBe('0.00000999')
-  })
-
-  test('ironToOre returns the right value', () => {
-    expect(ironToOre('0.00002394')).toBe(2394n)
-    expect(ironToOre('0.00000999')).toBe(999n)
+    expect(CurrencyUtils.isValidIron('0.0000000000001')).toBe(false)
+    expect(CurrencyUtils.isValidIron('100000000000000000000000000')).toBe(false)
+    expect(CurrencyUtils.isValidIron('0.00000001')).toBe(true)
+    expect(CurrencyUtils.isValidIron('10.000001')).toBe(true)
   })
 })

--- a/ironfish/src/utils/currency.ts
+++ b/ironfish/src/utils/currency.ts
@@ -2,146 +2,105 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { BigNumberish, formatFixed, parseFixed } from '@ethersproject/bignumber'
-import { commify } from '@ethersproject/units'
+import { formatFixed, parseFixed } from '@ethersproject/bignumber'
+import { ErrorUtils } from './error'
+import { FixedNumberUtils } from './fixedNumber'
 
-const ORE_TICKER = '$ORE'
-const IRON_TICKER = '$IRON'
-const ORE_TO_IRON = 100000000n
-const DECIMALS = ORE_TO_IRON.toString().length - 1
-export const MINIMUM_IRON_AMOUNT = '0.00000001'
-export const MAXIMUM_IRON_AMOUNT = 18446744000000000000n
-export const MINIMUM_ORE_AMOUNT = 1n
-export const MAXIMUM_ORE_AMOUNT = parseFixed(
-  MAXIMUM_IRON_AMOUNT.toString(),
-  DECIMALS,
-).toBigInt()
+export class CurrencyUtils {
+  static locale?: string
 
-export const isValidIronAmount = (amount: string | number | undefined): boolean => {
-  if (amount === undefined) {
-    return false
+  /**
+   * Serializes ore as iron with up to 8 decimal places
+   */
+  static encodeIron(amount: bigint): string {
+    return formatFixed(amount, 8)
   }
-  try {
-    const ore = ironToOre(amount)
-    return ore >= MINIMUM_ORE_AMOUNT && ore <= MAXIMUM_ORE_AMOUNT
-  } catch (e) {
-    return false
+
+  /**
+   * Parses iron as ore
+   */
+  static decodeIron(amount: string | number): bigint {
+    return parseFixed(amount.toString(), 8).toBigInt()
   }
-}
 
-export const ironToOre = (amount: string | number): bigint => {
-  return parseFixed(amount.toString(), DECIMALS).toBigInt()
-}
-
-export const oreToIron = (amount: BigNumberish): string => {
-  return formatFixed(amount, DECIMALS)
-}
-
-export const displayIronAmount = (amount: string, decimals?: number): string => {
-  let formattedDecimals = DECIMALS
-  if (decimals !== undefined && Number.isInteger(decimals) && decimals >= 0) {
-    formattedDecimals = Math.min(decimals, DECIMALS)
+  /**
+   * Deseialize ore back into bigint
+   */
+  static decode(amount: string): bigint {
+    return BigInt(amount)
   }
-  const commifyAmount = commify(amount)
-  const index = commifyAmount.indexOf('.')
-  if (index >= 0) {
-    const currDecimals = commifyAmount.length - 1 - index
-    if (currDecimals < formattedDecimals) {
-      const diffDecimals = formattedDecimals - currDecimals
-      let suffix = ''
-      for (let i = 0; i < diffDecimals; i++) {
-        suffix += '0'
-      }
-      return `${commifyAmount}${suffix}`
-    } else if (currDecimals > formattedDecimals) {
-      return commifyAmount.slice(0, index + 1 + formattedDecimals)
+
+  /**
+   * Serialize ore into a string
+   */
+  static encode(amount: bigint): string {
+    return amount.toString()
+  }
+
+  /*
+   * Renders ore as iron for human readable purposes
+   */
+  static renderIron(amount: bigint | string, ticker = false): string {
+    if (typeof amount === 'string') {
+      amount = this.decode(amount)
+    }
+
+    const iron = FixedNumberUtils.render(amount, 8)
+
+    if (ticker) {
+      return `$IRON ${iron}`
+    }
+
+    return iron
+  }
+
+  /*
+   * Renders ore for human readable purposes
+   */
+  static renderOre(amount: bigint | string, ticker = false): string {
+    if (typeof amount === 'string') {
+      amount = this.decode(amount)
+    }
+
+    const ore = amount.toString()
+
+    if (ticker) {
+      return `$ORE ${ore}`
+    }
+
+    return ore
+  }
+
+  /*
+   * Renders ore as either ore or iron for human readable purposes
+   */
+  static render(amount: bigint | string, ticker = false, ore = false): string {
+    if (typeof amount === 'string') {
+      amount = this.decode(amount)
+    }
+
+    if (ore) {
+      return this.renderOre(amount, ticker)
     } else {
-      return commifyAmount
+      return this.renderIron(amount, ticker)
     }
   }
-  let suffix = ''
-  for (let i = 0; i < formattedDecimals; i++) {
-    suffix += '0'
-  }
-  return `${commifyAmount}.${suffix}`
-}
 
-export const displayOreAmount = (amount: bigint): string => {
-  return amount.toLocaleString(undefined, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  })
-}
-
-/*
- * Return a string with the format $IRON X.XXXXXXXX ($ORE X^8)
- */
-export const displayIronAmountWithCurrency = (
-  amount: string | number,
-  displayOre: boolean,
-): string => {
-  let iron = `${IRON_TICKER} ${displayIronAmount(amount.toString())}`
-
-  if (displayOre) {
-    const oreAmount = ironToOre(amount)
-    iron += ` (${ORE_TICKER} ${displayOreAmount(oreAmount)})`
-  }
-
-  return iron
-}
-
-function decode(amount: string): bigint {
-  return BigInt(amount)
-}
-
-function encode(amount: bigint): string {
-  return amount.toString()
-}
-
-function renderIron(amount: bigint | string, ticker = false): string {
-  if (typeof amount === 'string') {
-    amount = decode(amount)
-  }
-
-  const iron = displayIronAmount(oreToIron(amount))
-
-  if (ticker) {
-    return `$IRON ${iron}`
-  }
-
-  return iron
-}
-
-function renderOre(amount: bigint | string, ticker = false): string {
-  if (typeof amount === 'string') {
-    amount = decode(amount)
-  }
-
-  const ore = displayOreAmount(amount)
-
-  if (ticker) {
-    return `$ORE ${ore}`
-  }
-
-  return ore
-}
-
-function render(amount: bigint | string, ticker = false, ore = false): string {
-  if (typeof amount === 'string') {
-    amount = decode(amount)
-  }
-
-  if (ore) {
-    return renderOre(amount, ticker)
-  } else {
-    return renderIron(amount, ticker)
+  static isValidIron(amount: string): boolean {
+    try {
+      const ore = this.decodeIron(amount)
+      return ore >= MINIMUM_ORE_AMOUNT && ore <= MAXIMUM_ORE_AMOUNT
+    } catch (e) {
+      if (ErrorUtils.isNodeError(e) && e.code === 'NUMERIC_FAULT') {
+        return false
+      }
+      throw e
+    }
   }
 }
 
-export const CurrencyUtils = {
-  encode,
-  decode,
-  renderIron,
-  renderOre,
-  render,
-}
+export const ORE_TO_IRON = 100000000
+export const MINIMUM_ORE_AMOUNT = 0n
+export const MAXIMUM_ORE_AMOUNT = 2n ** 64n
+export const MINIMUM_IRON_AMOUNT = CurrencyUtils.renderIron(MINIMUM_ORE_AMOUNT)
+export const MAXIMUM_IRON_AMOUNT = CurrencyUtils.renderIron(MAXIMUM_ORE_AMOUNT)

--- a/ironfish/src/utils/fixedNumber.test.ts
+++ b/ironfish/src/utils/fixedNumber.test.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { FixedNumberUtils } from './fixedNumber'
+
+describe('FixedNumberUtils', () => {
+  it('render', () => {
+    expect(FixedNumberUtils.render(1n, 0)).toEqual('1')
+    expect(FixedNumberUtils.render(1n, 2)).toEqual('1.00')
+    expect(FixedNumberUtils.render(1n, 8)).toEqual('1.00000000')
+  })
+})

--- a/ironfish/src/utils/fixedNumber.test.ts
+++ b/ironfish/src/utils/fixedNumber.test.ts
@@ -6,7 +6,8 @@ import { FixedNumberUtils } from './fixedNumber'
 describe('FixedNumberUtils', () => {
   it('render', () => {
     expect(FixedNumberUtils.render(1n, 0)).toEqual('1')
-    expect(FixedNumberUtils.render(1n, 2)).toEqual('1.00')
-    expect(FixedNumberUtils.render(1n, 8)).toEqual('1.00000000')
+    expect(FixedNumberUtils.render(1n, 1)).toEqual('0.1')
+    expect(FixedNumberUtils.render(1n, 4)).toEqual('0.0001')
+    expect(FixedNumberUtils.render(1n, 8)).toEqual('0.00000001')
   })
 })

--- a/ironfish/src/utils/fixedNumber.ts
+++ b/ironfish/src/utils/fixedNumber.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { formatFixed } from '@ethersproject/bignumber'
+
+export class FixedNumberUtils {
+  static render(amount: bigint | number, decimals: number): string {
+    const value = formatFixed(amount, decimals)
+
+    const index = value.indexOf('.')
+    const currDecimals = value.length - 1 - index
+
+    if (currDecimals < decimals) {
+      const diffDecimals = decimals - currDecimals
+      let suffix = ''
+      for (let i = 0; i < diffDecimals; i++) {
+        suffix += '0'
+      }
+
+      return `${value}${suffix}`
+    }
+
+    if (currDecimals > decimals) {
+      return value.slice(0, index + 1 + decimals)
+    }
+
+    return value
+  }
+}

--- a/ironfish/src/utils/fixedNumber.ts
+++ b/ironfish/src/utils/fixedNumber.ts
@@ -7,6 +7,10 @@ export class FixedNumberUtils {
   static render(amount: bigint | number, decimals: number): string {
     const value = formatFixed(amount, decimals)
 
+    if (decimals === 0) {
+      return value
+    }
+
     const index = value.indexOf('.')
     const currDecimals = value.length - 1 - index
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,6 +1209,43 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmmirror.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
+  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    bn.js "^5.2.1"
+
+"@ethersproject/bytes@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmmirror.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
+  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/constants@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmmirror.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
+  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+
+"@ethersproject/logger@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmmirror.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
+  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
+
+"@ethersproject/units@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmmirror.com/@ethersproject/units/-/units-5.7.0.tgz#637b563d7e14f42deeee39245275d477aae1d8b1"
+  integrity sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
 "@gar/promisify@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
@@ -3836,6 +3873,11 @@ blru@0.1.6:
   dependencies:
     bsert "~0.0.10"
 
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.npmmirror.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
+
 bowser@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
@@ -6122,9 +6164,9 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@4.7.7, handlebars@^4.7.6:
+handlebars@^4.7.6:
   version "4.7.7"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  resolved "https://registry.npmmirror.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
     minimist "^1.2.5"
@@ -8347,9 +8389,9 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@8.0.1, node-notifier@^8.0.0:
+node-notifier@^8.0.0:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
+  resolved "https://registry.npmmirror.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
   integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
   dependencies:
     growly "^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,7 +1209,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.7.0":
+"@ethersproject/bignumber@5.7.0":
   version "5.7.0"
   resolved "https://registry.npmmirror.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
   integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
@@ -1225,26 +1225,10 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/constants@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmmirror.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
-  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
-  dependencies:
-    "@ethersproject/bignumber" "^5.7.0"
-
 "@ethersproject/logger@^5.7.0":
   version "5.7.0"
   resolved "https://registry.npmmirror.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
-
-"@ethersproject/units@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmmirror.com/@ethersproject/units/-/units-5.7.0.tgz#637b563d7e14f42deeee39245275d477aae1d8b1"
-  integrity sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==
-  dependencies:
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
 
 "@gar/promisify@^1.0.1":
   version "1.1.2"
@@ -6164,9 +6148,9 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.7.6:
+handlebars@4.7.7, handlebars@^4.7.6:
   version "4.7.7"
-  resolved "https://registry.npmmirror.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
     minimist "^1.2.5"
@@ -8389,9 +8373,9 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^8.0.0:
+node-notifier@8.0.1, node-notifier@^8.0.0:
   version "8.0.1"
-  resolved "https://registry.npmmirror.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
   integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
   dependencies:
     growly "^1.3.0"


### PR DESCRIPTION
## Summary
https://github.com/iron-fish/ironfish/issues/2363 This issue isn't resolved completely.
[There is a problem with the precision of the floating point number in javascript.](https://stackoverflow.com/questions/11695618/dealing-with-float-precision-in-javascript)
But **our code use number to calc the ores & iron, this is unsafe**. 

So I use bigint to represent ores, use string to represent iron, and convert every currency calc to ores calc to avoid the precision problem.

To convert between ore and iron, I use the @ethersproject/bignumber, this is an excellent project for Ethereum, and it's bignumber matches our needs.

And the MAXIMUM_IRON_AMOUNT is way beyond the Number.MAX_SAFE_INTEGER(Such as 9007199254740991 in chrome), so I convert it to the bigint


## Testing Plan

## Breaking Change



```
[] Yes

```
