### PR TITLE
Config rules of nodeWorkersMax

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -279,7 +279,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     blockGraffiti: yup.string(),
     nodeName: yup.string(),
     nodeWorkers: yup.number().integer().min(-1),
-    nodeWorkersMax: isWholeNumber,
+    nodeWorkersMax: yup.number().integer().min(-1),
     p2pSimulateLatency: isWholeNumber,
     peerPort: isPort,
     rpcTcpHost: noWhitespaceBegEnd,


### PR DESCRIPTION
## Summary
`nodeWorkersMax = -1` is an easy way to enable all cpu cores for workerPool. Since some miners have already work with this flag for a long time, config rules running now will force them to make some changes. And most of them have no idea about physical and logic cpu cores, it's complicated to enable all cpu cores with `nodeWorkersMax = 10 or 20`. 
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
