### PR TITLE
fixes database compact to use db instance

### DIFF
--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -116,12 +116,12 @@ export class LevelupDatabase extends Database {
 
   compact(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      if (this.levelup instanceof LevelDOWN) {
-        this.levelup.compactRange(
-          DATABASE_ALL_KEY_RANGE.gte,
-          DATABASE_ALL_KEY_RANGE.lt,
-          (err) => (err ? reject(err) : resolve()),
+      if (this.db instanceof LevelDOWN) {
+        this.db.compactRange(DATABASE_ALL_KEY_RANGE.gte, DATABASE_ALL_KEY_RANGE.lt, (err) =>
+          err ? reject(err) : resolve(),
         )
+      } else {
+        resolve()
       }
     })
   }


### PR DESCRIPTION
## Summary

compact attempts to call compactRange on the instance of levelup, but it is the db that will be an instance of LevelDOWN. changes the compactRange call to use the db instance.

resolves in the 'else' case of compact. process currently exits if compaction is not feasible.

## Testing Plan

tested with recent changes to service:snapshot #2360 

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
