### PR TITLE
allows users to set datadir using env variable

### DIFF
--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -45,6 +45,7 @@ export const ConfigFlag = Flags.string({
 export const DataDirFlag = Flags.string({
   default: DEFAULT_DATA_DIR,
   description: 'The path to the data dir',
+  env: 'IRONFISH_DATA_DIR',
 })
 
 export const DatabaseFlag = Flags.string({


### PR DESCRIPTION
## Summary

updates datadir flag to read from 'IRONFISH_DATA_DIR' env variable. allows users to set this env variable to avoid having to pass '--datadir=...' with every command if they use a non-default datadir.

datadir is somewhat unique as a flag: it can't be set in an Iron Fish config file, since the config file is in the datadir.

## Testing Plan

- set IRONFISH_DATA_DIR, ran commands to see that datadir was set
- ran commands passing --datadir to see that datadir was overridden

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
