### PR TITLE
Add V2 consensus upgrade for block size limit

### DIFF
--- a/ironfish/src/consensus/__fixtures__/verifier.test.ts.fixture
+++ b/ironfish/src/consensus/__fixtures__/verifier.test.ts.fixture
@@ -1180,5 +1180,69 @@
         }
       ]
     }
+  ],
+  "Verifier Block accepts a block with size more than MAX_BLOCK_SIZE_BYTES before V2 consensus upgrade": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:DVKLUlgKNunmCl4vtfVfcAnxV7Idnwu4mSamfm4CUTk="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1666030652011,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "775AAB101836545C8F809A300BC60409FFE815245446D151DD4AB54CEDAEC33B",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI8pi8cy3m7YiGRl1O5WGxv4Mn4r0jbJBs4G8JKlgSwgd5dv3nyK++r18KuSDJXtCq6LPg7/AZBo1V/D4MvQ4Nwk04iNXDtlrC1jcsLrmxT5kXnB/qqcALRMD6v5VIEQbhR/Z/DskYWJpSnA3DiZpSgk2LuyNgXC6xQSr27o04BMlGuX6WYmRnNJay72H48h0KyoU8hnvwuRDiORhzskYOZz1hZUnz/4wZtYj9ScEHJ55VG6IYQxElL2MrYvxg56Ae4fYhMS4CLkYvceW9E+oYP1DFbl2Wy9lUC1noBgd0UIdZbZbuV0jidVP3kKTgisY4vtAIkbAt88XCsUDagi5DHn92fMp6WlNTcPoQ+boTAFMf+PkrivQ02MLDRJSNeIIbEGTXt79ukfnfbvP+S3znIESM15vlM50DIFIyJE1kxfW8s9X31KX7pKxmxe/0UMpAh9gUJIvKTGR283uAY+5Sh7UBpvwiYR/4mrfxQ2gNEcPSj8GSlOd0+/bk2nVBf26oeNKEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTG/MGIB37mq+uMRAwbBJjDKUbhES6Gt3LkulbBz+JihBy1PpFrvEDM7iOrAnVoCrphaVcEwVovugkT4OfytfBA=="
+        }
+      ]
+    }
+  ],
+  "Verifier Block rejects a block with size more than MAX_BLOCK_SIZE_BYTES after V2 consensus upgrade": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:RK+87e6MhkdioxLtaV+luHz6YlAkDpulLeKZMg8r/Rk="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1666030652648,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "CB50834E81F457CDA479B056E5DAFDAA4E84B2ECD50A69A2F7288F2274817FF4",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALMZW8wsXX1aY0VI6ZovqXP/Dm4oNOI+exLqo6DUtsFvNCeSYllpPVZjRW3WXlPdQbd2B+awodB7u5To7CJtwjtt/fLrmuSdVDzNvhwY4m5/MjY2oZ2Bz3RCnACsyZr1egywf3Rl87p6IZ1EGpibMsAGwspmcWIqfRxlJVo64QISoM6fjRZIYgYIFrEPtdyE26SZN7RLVH97cb3GEObtMB1X8S1TiX1QD9LYeypGksQM3DhzFWrBaTUcO3d4w57DHo1LMjojJas+BmxM4X1xmppRedr3ErcIcpbfrXWg7ge/AxwVOX4NRjoCmsMW7FVjQO37D6FBMTKiBROGTR0EFyp4MthOdEEjVK0mD/gwvscWhTAy3RwkNfmfZcLBoYgZ7qIs7KNqxHBciBQRo0TmFch393uU5vHA5jonrqd8hj31sp5vYLXGeSG/69Y+VvRwyWnS0g8OYDbwrqMsDrYHkTsl8ZzBwzbqTBemTaFtZAtKVUFabiYBx+ljzIzxNbIpUPenIUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtot+quC8otMqCBIXOjv/Y15vbayrBuzTuRuSUxXn+lWB/Wh1gGqJeRTOFONCqZudvyCZKHU27l62+t6GhdwACQ=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -101,6 +101,6 @@ export class TestnetParameters extends ConsensusParameters {
   constructor() {
     super()
     this.V1_DOUBLE_SPEND = 204000
-    this.V2_MAX_BLOCK_SIZE = 250000
+    this.V2_MAX_BLOCK_SIZE = 252000
   }
 }

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -72,17 +72,17 @@ export const MAX_TRANSACTIONS_PER_BLOCK = 301
 
 export class ConsensusParameters {
   /**
+   * Max block size = 2 MB
+   */
+  MAX_BLOCK_SIZE_BYTES = 2000000
+
+  /**
    * Before upgrade V1 we had double spends. At this block we do a double spend
    * check to disallow it.
    *
    * TODO: remove this sequence check before mainnet
    */
   V1_DOUBLE_SPEND = 0
-
-  /**
-   * Max block size = 2 MB
-   */
-  MAX_BLOCK_SIZE_BYTES = 2000000
 
   /**
    * Before upgrade V2 we didn't enforce max block size.

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -84,6 +84,14 @@ export class ConsensusParameters {
    */
   MAX_BLOCK_SIZE_BYTES = 2000000
 
+  /**
+   * Before upgrade V2 we didn't enforce max block size.
+   * At this block we check that the block size doesn't exceed MAX_BLOCK_SIZE_BYTES.
+   *
+   * TODO: remove this sequence check before mainnet
+   */
+  V2_MAX_BLOCK_SIZE = 0
+
   isActive(upgrade: number, sequence: number): boolean {
     return sequence >= upgrade
   }
@@ -93,5 +101,6 @@ export class TestnetParameters extends ConsensusParameters {
   constructor() {
     super()
     this.V1_DOUBLE_SPEND = 204000
+    this.V2_MAX_BLOCK_SIZE = 250000
   }
 }

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -6,7 +6,8 @@ jest.mock('ws')
 
 import '../testUtilities/matchers/blockchain'
 import { Assert } from '../assert'
-import { BlockHeader, Transaction } from '../primitives'
+import { getBlockSize } from '../network/utils/serializers'
+import { BlockHeader, BlockSerde, Transaction } from '../primitives'
 import { Target } from '../primitives/target'
 import {
   createNodeTest,
@@ -127,6 +128,27 @@ describe('Verifier', () => {
       expect(await nodeTest.verifier.verifyBlock(block)).toMatchObject({
         valid: false,
         reason: VerificationResultReason.MAX_TRANSACTIONS_EXCEEDED,
+      })
+    })
+
+    it('accepts a block with size more than MAX_BLOCK_SIZE_BYTES before V2 consensus upgrade', async () => {
+      const block = await useMinerBlockFixture(nodeTest.chain)
+      block.header.sequence = nodeTest.chain.consensus.V2_MAX_BLOCK_SIZE - 1
+      nodeTest.chain.consensus.MAX_BLOCK_SIZE_BYTES =
+        getBlockSize(BlockSerde.serialize(block)) - 1
+
+      expect((await nodeTest.verifier.verifyBlock(block)).valid).toBe(true)
+    })
+
+    it('rejects a block with size more than MAX_BLOCK_SIZE_BYTES after V2 consensus upgrade', async () => {
+      const block = await useMinerBlockFixture(nodeTest.chain)
+      block.header.sequence = nodeTest.chain.consensus.V2_MAX_BLOCK_SIZE
+      nodeTest.chain.consensus.MAX_BLOCK_SIZE_BYTES =
+        getBlockSize(BlockSerde.serialize(block)) - 1
+
+      expect(await nodeTest.verifier.verifyBlock(block)).toMatchObject({
+        valid: false,
+        reason: VerificationResultReason.MAX_BLOCK_SIZE_EXCEEDED,
       })
     })
 

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -133,7 +133,7 @@ describe('Verifier', () => {
 
     it('accepts a block with size more than MAX_BLOCK_SIZE_BYTES before V2 consensus upgrade', async () => {
       const block = await useMinerBlockFixture(nodeTest.chain)
-      block.header.sequence = nodeTest.chain.consensus.V2_MAX_BLOCK_SIZE - 1
+      nodeTest.chain.consensus.V2_MAX_BLOCK_SIZE = block.header.sequence + 1
       nodeTest.chain.consensus.MAX_BLOCK_SIZE_BYTES =
         getBlockSize(BlockSerde.serialize(block)) - 1
 
@@ -142,7 +142,7 @@ describe('Verifier', () => {
 
     it('rejects a block with size more than MAX_BLOCK_SIZE_BYTES after V2 consensus upgrade', async () => {
       const block = await useMinerBlockFixture(nodeTest.chain)
-      block.header.sequence = nodeTest.chain.consensus.V2_MAX_BLOCK_SIZE
+      nodeTest.chain.consensus.V2_MAX_BLOCK_SIZE = block.header.sequence
       nodeTest.chain.consensus.MAX_BLOCK_SIZE_BYTES =
         getBlockSize(BlockSerde.serialize(block)) - 1
 

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -43,7 +43,6 @@ export class Verifier {
     block: Block,
     options: { verifyTarget?: boolean } = { verifyTarget: true },
   ): Promise<VerificationResult> {
-    // Verify the block size
     if (
       this.chain.consensus.isActive(
         this.chain.consensus.V2_MAX_BLOCK_SIZE,

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -4,7 +4,8 @@
 
 import { BufferSet } from 'buffer-map'
 import { Blockchain } from '../blockchain'
-import { Spend } from '../primitives'
+import { getBlockSize } from '../network/utils/serializers'
+import { BlockSerde, Spend } from '../primitives'
 import { Block } from '../primitives/block'
 import { BlockHeader } from '../primitives/blockheader'
 import { Target } from '../primitives/target'
@@ -42,6 +43,20 @@ export class Verifier {
     block: Block,
     options: { verifyTarget?: boolean } = { verifyTarget: true },
   ): Promise<VerificationResult> {
+    // Verify the block size
+    if (
+      this.chain.consensus.isActive(
+        this.chain.consensus.V2_MAX_BLOCK_SIZE,
+        block.header.sequence,
+      )
+    ) {
+      if (
+        getBlockSize(BlockSerde.serialize(block)) > this.chain.consensus.MAX_BLOCK_SIZE_BYTES
+      ) {
+        return { valid: false, reason: VerificationResultReason.MAX_BLOCK_SIZE_EXCEEDED }
+      }
+    }
+
     // Verify the block header
     const blockHeaderValid = this.verifyBlockHeader(block.header, options)
     if (!blockHeaderValid.valid) {
@@ -483,6 +498,7 @@ export enum VerificationResultReason {
   INVALID_TRANSACTION_FEE = 'Transaction fee is incorrect',
   INVALID_TRANSACTION_PROOF = 'Invalid transaction proof',
   INVALID_PARENT = 'Invalid_parent',
+  MAX_BLOCK_SIZE_EXCEEDED = 'Block size exceeds maximum',
   MAX_TRANSACTIONS_EXCEEDED = 'Number of transactions on block exceeds maximum',
   MINERS_FEE_EXPECTED = 'Miners fee expected',
   MINERS_FEE_MISMATCH = 'Miners fee does not match block header',


### PR DESCRIPTION
## Summary

Enforce block size limit of 2 MB.

Added a new consensus upgrade for this limit on block 252000, estimated to occur on October 31, 2022 at 12:30 pm ET. All users will need to upgrade by then.

## Testing Plan

Added tests to `verifier.test.ts` to confirm the block size limit is enforced after consensus upgrade V2.

Can also test by lowering the activation height (`V2_MAX_BLOCK_SIZE`) and max block size (`MAX_BLOCK_SIZE_BYTES`) and trying to sync - all blocks larger than max size set should be marked as invalid.

## Breaking Change

```
[X] Yes
```
