### PR TITLE
Fix Github Action warnings

### DIFF
--- a/.github/workflows/build-ironfish-rust-nodejs.yml
+++ b/.github/workflows/build-ironfish-rust-nodejs.yml
@@ -71,10 +71,10 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         if: ${{ !matrix.settings.docker }}
         with:
           node-version: '16.13.0'
@@ -151,14 +151,14 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU for Docker
         if: ${{ matrix.settings.docker }}
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.13.0'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,10 @@ jobs:
           cache: 'yarn'
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           shared-key: nodejs
-          working-directory: ironfish-rust-nodejs
+          workspaces: ironfish-rust-nodejs
 
       - name: Install packages
         run: yarn --non-interactive --frozen-lockfile
@@ -75,10 +75,10 @@ jobs:
           cache: 'yarn'
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           shared-key: nodejs
-          working-directory: ironfish-rust-nodejs
+          workspaces: ironfish-rust-nodejs
 
       - name: Install packages
         run: yarn --non-interactive --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.13.0'
           cache: 'yarn'
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.13.0'
           cache: 'yarn'
@@ -47,7 +47,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v1
         with:
-          sharedKey: nodejs
+          shared-key: nodejs
           working-directory: ironfish-rust-nodejs
 
       - name: Install packages
@@ -66,10 +66,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.13.0'
           cache: 'yarn'
@@ -77,7 +77,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v1
         with:
-          sharedKey: nodejs
+          shared-key: nodejs
           working-directory: ironfish-rust-nodejs
 
       - name: Install packages

--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -8,13 +8,13 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
-          sharedKey: nodejs
-          working-directory: ironfish-rust-nodejs
+          shared-key: nodejs
+          workspaces: ironfish-rust-nodejs
 
       - name: Cache Ironfish CLI Build
         id: cache-ironfish-cli-build
@@ -24,7 +24,7 @@ jobs:
           key: ${{ github.sha }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.13.0'
           cache: 'yarn'

--- a/.github/workflows/deploy-node-aws.yml
+++ b/.github/workflows/deploy-node-aws.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy-node-github-beta.yml
+++ b/.github/workflows/deploy-node-github-beta.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to Github Registry
         run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_USER} --password-stdin ghcr.io

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to Github Registry
         run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_USER} --password-stdin ghcr.io

--- a/.github/workflows/deploy-npm-ironfish-cli.yml
+++ b/.github/workflows/deploy-npm-ironfish-cli.yml
@@ -21,10 +21,10 @@ jobs:
           cache: yarn
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
-          sharedKey: nodejs
-          working-directory: ironfish-rust-nodejs
+          shared-key: nodejs
+          workspaces: ironfish-rust-nodejs
 
       - name: Insert Git hash into ironfish-cli/package.json as gitHash
         run: |

--- a/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
+++ b/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
@@ -21,10 +21,10 @@ jobs:
         working-directory: ./ironfish-rust-nodejs
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.13.0'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/push-version-to-api.yml
+++ b/.github/workflows/push-version-to-api.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Push version string to API
         run: ./ironfish-cli/scripts/push-version.sh

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -19,16 +19,16 @@ jobs:
     name: ironfish-rust
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           components: rustfmt, clippy
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
-          sharedKey: base
-          working-directory: ironfish-rust
+          shared-key: base
+          workspaces: ironfish-rust
 
       - name: Check for license headers
         run: ./ci/lintHeaders.sh ./ironfish-rust/src *.rs
@@ -65,16 +65,16 @@ jobs:
     name: ironfish-rust-nodejs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           components: rustfmt, clippy
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
-          sharedKey: nodejs
-          working-directory: ironfish-rust-nodejs
+          shared-key: nodejs
+          workspaces: ironfish-rust-nodejs
 
       - name: Check for license headers
         run: ./ci/lintHeaders.sh ./ironfish-rust-nodejs/src *.rs


### PR DESCRIPTION
## Summary

Github shows a warning that Node.js 12 actions are deprecated (See this CI job for an example): https://github.com/iron-fish/ironfish/actions/runs/3277372608

This updates the actions to newer, supported versions.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
