### PR TITLE
Fix rust-cache CI step to use the proper workspace target directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: nodejs
-          workspaces: ironfish-rust-nodejs
 
       - name: Install packages
         run: yarn --non-interactive --frozen-lockfile
@@ -78,7 +77,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: nodejs
-          workspaces: ironfish-rust-nodejs
 
       - name: Install packages
         run: yarn --non-interactive --frozen-lockfile

--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -14,7 +14,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: nodejs
-          workspaces: ironfish-rust-nodejs
 
       - name: Cache Ironfish CLI Build
         id: cache-ironfish-cli-build

--- a/.github/workflows/deploy-npm-ironfish-cli.yml
+++ b/.github/workflows/deploy-npm-ironfish-cli.yml
@@ -24,7 +24,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: nodejs
-          workspaces: ironfish-rust-nodejs
 
       - name: Insert Git hash into ironfish-cli/package.json as gitHash
         run: |

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -3,7 +3,7 @@ on:
     paths:
       - "ironfish-rust/**"
       - "ironfish-rust-nodejs/**"
-      - "ironfish-rust-zkp/**"
+      - "ironfish-zkp/**"
       - "rust-toolchain"
   push:
     branches:
@@ -11,7 +11,7 @@ on:
     paths:
       - "ironfish-rust/**"
       - "ironfish-rust-nodejs/**"
-      - "ironfish-rust-zkp/**"
+      - "ironfish-zkp/**"
       - "rust-toolchain"
 
 name: Rust CI

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -3,6 +3,7 @@ on:
     paths:
       - "ironfish-rust/**"
       - "ironfish-rust-nodejs/**"
+      - "ironfish-rust-zkp/**"
       - "rust-toolchain"
   push:
     branches:
@@ -10,6 +11,7 @@ on:
     paths:
       - "ironfish-rust/**"
       - "ironfish-rust-nodejs/**"
+      - "ironfish-rust-zkp/**"
       - "rust-toolchain"
 
 name: Rust CI
@@ -28,7 +30,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: base
-          workspaces: ironfish-rust
 
       # Build & Run test & Collect Code coverage
       - name: Run cargo-tarpaulin on ironfish-rust
@@ -74,7 +75,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: nodejs
-          workspaces: ironfish-rust-nodejs
 
       # Build & Run test & Collect Code coverage
       - name: Run cargo-tarpaulin on ironfish-rust-nodejs
@@ -110,16 +110,15 @@ jobs:
     name: ironfish-zkp
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           components: rustfmt, clippy
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
-          sharedKey: base
-          working-directory: ironfish-zkp
+          shared-key: zkp
 
       # Build & Run test & Collect Code coverage
       - name: Run cargo-tarpaulin on ironfish-zkp

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -5,6 +5,7 @@ on:
       - "ironfish-rust-nodejs/**"
       - "ironfish-zkp/**"
       - "rust-toolchain"
+      - ".github/workflows/rust_ci.yml"
   push:
     branches:
       - master
@@ -13,6 +14,7 @@ on:
       - "ironfish-rust-nodejs/**"
       - "ironfish-zkp/**"
       - "rust-toolchain"
+      - ".github/workflows/rust_ci.yml"
 
 name: Rust CI
 


### PR DESCRIPTION
## Summary

We no longer need to define the crates individually since rust-cache finds the parent workspace and uses it. Each individual rust job will only compile what it uses (ie `ironfish-zkp` will only compile its used dependencies), so there doesn't appear to be a need to be specific. We still key each rust job separately, so that the `ironfish-zkp` and `ironfish-rust` jobs don't contaminate the `-nodejs` job, which is the most important one that it used by most of our other CI jobs and contains the built nodejs bindings.

There may be some further optimizations to be made here. For example, running `cargo test` at the root will now run all rust tests across all workspace crates.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
