### PR TITLE
Pin macos-11 for CI builds

### DIFF
--- a/.github/workflows/build-ironfish-rust-nodejs.yml
+++ b/.github/workflows/build-ironfish-rust-nodejs.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-11
             target: x86_64-apple-darwin
             architecture: x64
             build: |
@@ -39,7 +39,7 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:749e81d2fa2fdcda2732e284069fdd8469702da007eb6088df426cdb813b3ecc
             build: cd ironfish-rust-nodejs && yarn build && strip *.node
 
-          - host: macos-latest
+          - host: macos-11
             target: aarch64-apple-darwin
             build: |
               cd ironfish-rust-nodejs
@@ -124,7 +124,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-11
             target: x86_64-apple-darwin
 
           - host: windows-latest


### PR DESCRIPTION
## Summary

6 hours ago, macos-latest was changed to point to macos-12 instead of 11: https://github.com/actions/runner-images/releases/tag/macOS-11%2F20221018.1

We got lucky to discover this now and not during a release period by chance because I happened to break our CI job. What a coincidence.

We'll probably want to figure out why 12 is breaking eventually, but this will at least unblock us until that time.

Before: https://github.com/iron-fish/ironfish/actions/runs/3292592939
After: https://github.com/iron-fish/ironfish/actions/runs/3292697171

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
