### PR TITLE
Spend authorizing key should never be 0

### DIFF
--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -82,6 +82,11 @@ impl<'a> SaplingKey {
     pub fn new(spending_key: [u8; 32]) -> Result<Self, IronfishError> {
         let spend_authorizing_key =
             jubjub::Fr::from_bytes_wide(&Self::convert_key(spending_key, 0));
+
+        if spend_authorizing_key == jubjub::Fr::zero() {
+            return Err(IronfishError::IllegalValue);
+        }
+
         let proof_authorizing_key =
             jubjub::Fr::from_bytes_wide(&Self::convert_key(spending_key, 1));
         let mut outgoing_viewing_key = [0; 32];


### PR DESCRIPTION
## Summary

Per the [Sapling spec](https://github.com/zcash/zips/blob/main/protocol/sapling.pdf), on page 32, if the spend authorizing key is zero, the key should be thrown away and a new one regenerated.

I suspect we'll never actually hit this error, but it's probably possible.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
