### PR TITLE
Use pub keyword in for napi to fix "dead code"

### DIFF
--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -68,14 +68,12 @@ pub struct FoundBlockResult {
 }
 
 #[napi]
-struct ThreadPoolHandler {
-    #[allow(dead_code)]
+pub struct ThreadPoolHandler {
     threadpool: mining::threadpool::ThreadPool,
 }
 #[napi]
 impl ThreadPoolHandler {
     #[napi(constructor)]
-    #[allow(dead_code)]
     pub fn new(thread_count: u32, batch_size: u32) -> Self {
         ThreadPoolHandler {
             threadpool: mining::threadpool::ThreadPool::new(thread_count as usize, batch_size),
@@ -83,26 +81,22 @@ impl ThreadPoolHandler {
     }
 
     #[napi]
-    #[allow(dead_code)]
     pub fn new_work(&mut self, header_bytes: Buffer, target: Buffer, mining_request_id: u32) {
         self.threadpool
             .new_work(&header_bytes, &target, mining_request_id)
     }
 
     #[napi]
-    #[allow(dead_code)]
     pub fn stop(&self) {
         self.threadpool.stop()
     }
 
     #[napi]
-    #[allow(dead_code)]
     pub fn pause(&self) {
         self.threadpool.pause()
     }
 
     #[napi]
-    #[allow(dead_code)]
     pub fn get_found_block(&self) -> Option<FoundBlockResult> {
         if let Some(result) = self.threadpool.get_found_block() {
             return Some(FoundBlockResult {
@@ -114,13 +108,12 @@ impl ThreadPoolHandler {
     }
 
     #[napi]
-    #[allow(dead_code)]
     pub fn get_hash_rate_submission(&self) -> u32 {
         self.threadpool.get_hash_rate_submission()
     }
 }
 
 #[napi]
-fn is_valid_public_address(hex_address: String) -> bool {
+pub fn is_valid_public_address(hex_address: String) -> bool {
     PublicAddress::from_hex(&hex_address).is_ok()
 }


### PR DESCRIPTION
## Summary

I kept wondering why some of the napi code was complaining about dead code.. Would be neat if napi enforced the pub keyword more strictly like it does for `#[napi(object)]` 

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
