### PR TITLE
refactor(ironfish,rust-nodejs): Export Napi constants for note lengths

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -18,6 +18,8 @@ export interface BoxedMessage {
 }
 export function boxMessage(plaintext: string, senderSecretKey: Uint8Array, recipientPublicKey: string): BoxedMessage
 export function unboxMessage(boxedMessage: string, nonce: string, senderPublicKey: string, recipientSecretKey: Uint8Array): string
+export const ENCRYPTED_NOTE_LENGTH: number
+export const DECRYPTED_NOTE_LENGTH: number
 export interface NativeSpendProof {
   treeSize: number
   rootHash: Buffer

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -236,7 +236,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, NoteEncrypted, Note, TransactionPosted, Transaction, verifyTransactions, generateKey, generateNewPublicAddress, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, DECRYPTED_NOTE_LENGTH, Note, TransactionPosted, Transaction, verifyTransactions, generateKey, generateNewPublicAddress, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.KEY_LENGTH = KEY_LENGTH
 module.exports.NONCE_LENGTH = NONCE_LENGTH
@@ -245,7 +245,9 @@ module.exports.randomBytes = randomBytes
 module.exports.boxMessage = boxMessage
 module.exports.unboxMessage = unboxMessage
 module.exports.RollingFilter = RollingFilter
+module.exports.ENCRYPTED_NOTE_LENGTH = ENCRYPTED_NOTE_LENGTH
 module.exports.NoteEncrypted = NoteEncrypted
+module.exports.DECRYPTED_NOTE_LENGTH = DECRYPTED_NOTE_LENGTH
 module.exports.Note = Note
 module.exports.TransactionPosted = TransactionPosted
 module.exports.Transaction = Transaction

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -9,6 +9,9 @@ use ironfish_rust::{note::Memo, Note, SaplingKey};
 
 use crate::to_napi_err;
 
+#[napi]
+pub const DECRYPTED_NOTE_LENGTH: u32 = 115;
+
 #[napi(js_name = "Note")]
 pub struct NativeNote {
     pub(crate) note: Note,

--- a/ironfish-rust-nodejs/src/structs/note_encrypted.rs
+++ b/ironfish-rust-nodejs/src/structs/note_encrypted.rs
@@ -13,6 +13,9 @@ use ironfish_rust::MerkleNote;
 
 use crate::to_napi_err;
 
+#[napi]
+pub const ENCRYPTED_NOTE_LENGTH: u32 = 275;
+
 #[napi(js_name = "NoteEncrypted")]
 pub struct NativeNoteEncrypted {
     pub(crate) note: MerkleNote,

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -15,6 +15,7 @@ use crate::to_napi_err;
 use super::note::NativeNote;
 use super::spend_proof::NativeSpendProof;
 use super::witness::JsWitness;
+use super::ENCRYPTED_NOTE_LENGTH;
 
 #[napi(js_name = "TransactionPosted")]
 pub struct NativeTransactionPosted {
@@ -67,8 +68,7 @@ impl NativeTransactionPosted {
             .map_err(|_| to_napi_err("Value out of range"))?;
 
         let proof = &self.transaction.receipts()[index_usize];
-        // Note bytes are 275
-        let mut vec: Vec<u8> = Vec::with_capacity(275);
+        let mut vec: Vec<u8> = Vec::with_capacity(ENCRYPTED_NOTE_LENGTH as usize);
         proof.merkle_note().write(&mut vec).map_err(to_napi_err)?;
 
         Ok(Buffer::from(vec))

--- a/ironfish/src/merkletree/database/leaves.ts
+++ b/ironfish/src/merkletree/database/leaves.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { IDatabaseEncoding } from '../../storage/database/types'
+import { ENCRYPTED_NOTE_LENGTH } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
 import { NoteEncrypted } from '../../primitives/noteEncrypted'
 
@@ -12,7 +13,6 @@ export interface LeafValue<T> {
   parentIndex: number
 }
 
-const NOTE_BYTES = 275
 const NULLIFIER_BYTES = 32
 
 export type NoteLeafValue = LeafValue<NoteEncrypted>
@@ -33,7 +33,7 @@ export class NoteLeafEncoding implements IDatabaseEncoding<NoteLeafValue> {
   deserialize(buffer: Buffer): NoteLeafValue {
     const reader = bufio.read(buffer, true)
 
-    const element = new NoteEncrypted(reader.readBytes(NOTE_BYTES))
+    const element = new NoteEncrypted(reader.readBytes(ENCRYPTED_NOTE_LENGTH))
     const merkleHash = reader.readHash()
     const parentIndex = reader.readU32()
 
@@ -46,7 +46,7 @@ export class NoteLeafEncoding implements IDatabaseEncoding<NoteLeafValue> {
 
   getSize(): number {
     let size = 0
-    size += NOTE_BYTES // element
+    size += ENCRYPTED_NOTE_LENGTH // element
     size += 32 // merkleHash
     size += 4 // parentIndex
     return size

--- a/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
+++ b/ironfish/src/migrations/data/013-wallet-2/new/decryptedNotes.ts
@@ -1,8 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DECRYPTED_NOTE_LENGTH } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import { Note, NOTE_LENGTH } from '../../../../primitives/note'
+import { Note } from '../../../../primitives/note'
 import { IDatabaseEncoding, IDatabaseStore } from '../../../../storage'
 
 export type DecryptedNotesStore = IDatabaseStore<{
@@ -54,7 +55,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
     const spent = Boolean(flags & (1 << 2))
 
     const accountId = reader.readVarString()
-    const serializedNote = reader.readBytes(NOTE_LENGTH)
+    const serializedNote = reader.readBytes(DECRYPTED_NOTE_LENGTH)
     const transactionHash = reader.readHash()
 
     let index = null
@@ -75,7 +76,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
   getSize(value: DecryptedNoteValue): number {
     let size = 1
     size += bufio.sizeVarString(value.accountId)
-    size += NOTE_LENGTH
+    size += DECRYPTED_NOTE_LENGTH
 
     // transaction hash
     size += 32

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -6,8 +6,6 @@ import { Note as NativeNote } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
 import { BufferUtils } from '../utils/buffer'
 
-export const NOTE_LENGTH = 43 + 8 + 32 + 32
-
 export class Note {
   private readonly noteSerialized: Buffer
   private note: NativeNote | null = null

--- a/ironfish/src/primitives/noteEncrypted.ts
+++ b/ironfish/src/primitives/noteEncrypted.ts
@@ -7,8 +7,6 @@ import bufio from 'bufio'
 import { Serde } from '../serde'
 import { Note } from './note'
 
-export const ENCRYPTED_NOTE_LENGTH = 32 + 32 + 32 + 83 + 16 + 64 + 16
-
 export type NoteEncryptedHash = Buffer
 export type SerializedNoteEncryptedHash = Buffer
 export type SerializedNoteEncrypted = Buffer

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { TransactionPosted } from '@ironfish/rust-nodejs'
+import { ENCRYPTED_NOTE_LENGTH, TransactionPosted } from '@ironfish/rust-nodejs'
 import { blake3 } from '@napi-rs/blake-hash'
 import bufio from 'bufio'
 import { NoteEncrypted } from './noteEncrypted'
@@ -63,7 +63,7 @@ export class Transaction {
       // proof
       reader.seek(192)
 
-      return new NoteEncrypted(reader.readBytes(275, true))
+      return new NoteEncrypted(reader.readBytes(ENCRYPTED_NOTE_LENGTH, true))
     })
 
     this._signature = reader.readBytes(64, true)

--- a/ironfish/src/wallet/walletdb/decryptedNoteValue.ts
+++ b/ironfish/src/wallet/walletdb/decryptedNoteValue.ts
@@ -1,8 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DECRYPTED_NOTE_LENGTH } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import { Note, NOTE_LENGTH } from '../../primitives/note'
+import { Note } from '../../primitives/note'
 import { IDatabaseEncoding } from '../../storage'
 
 export interface DecryptedNoteValue {
@@ -49,7 +50,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
     const spent = Boolean(flags & (1 << 2))
 
     const accountId = reader.readVarString()
-    const serializedNote = reader.readBytes(NOTE_LENGTH)
+    const serializedNote = reader.readBytes(DECRYPTED_NOTE_LENGTH)
     const transactionHash = reader.readHash()
 
     let index = null
@@ -70,7 +71,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
   getSize(value: DecryptedNoteValue): number {
     let size = 1
     size += bufio.sizeVarString(value.accountId)
-    size += NOTE_LENGTH
+    size += DECRYPTED_NOTE_LENGTH
 
     // transaction hash
     size += 32

--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { NOTE_LENGTH } from '../../primitives/note'
-import { ENCRYPTED_NOTE_LENGTH } from '../../primitives/noteEncrypted'
+import { DECRYPTED_NOTE_LENGTH, ENCRYPTED_NOTE_LENGTH } from '@ironfish/rust-nodejs'
 import { createNodeTest, useAccountFixture, useMinersTxFixture } from '../../testUtilities'
 import { ACCOUNT_KEY_LENGTH } from '../../wallet'
 import { DecryptNotesRequest, DecryptNotesResponse, DecryptNotesTask } from './decryptNotes'
@@ -36,7 +35,7 @@ describe('DecryptNotesResponse', () => {
           index: 1,
           hash: Buffer.alloc(32, 1),
           nullifier: Buffer.alloc(32, 1),
-          serializedNote: Buffer.alloc(NOTE_LENGTH, 1),
+          serializedNote: Buffer.alloc(DECRYPTED_NOTE_LENGTH, 1),
         },
         null,
       ],

--- a/ironfish/src/workerPool/tasks/decryptNotes.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DECRYPTED_NOTE_LENGTH, ENCRYPTED_NOTE_LENGTH } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import { NOTE_LENGTH } from '../../primitives/note'
-import { ENCRYPTED_NOTE_LENGTH, NoteEncrypted } from '../../primitives/noteEncrypted'
+import { NoteEncrypted } from '../../primitives/noteEncrypted'
 import { ACCOUNT_KEY_LENGTH } from '../../wallet'
 import { WorkerMessage, WorkerMessageType } from './workerMessage'
 import { WorkerTask } from './workerTask'
@@ -153,7 +153,7 @@ export class DecryptNotesResponse extends WorkerMessage {
       const hasNullifier = flags & (1 << 1)
       const forSpender = Boolean(flags & (1 << 2))
       const hash = reader.readHash()
-      const serializedNote = reader.readBytes(NOTE_LENGTH)
+      const serializedNote = reader.readBytes(DECRYPTED_NOTE_LENGTH)
 
       let index = null
       if (hasIndex) {
@@ -184,7 +184,7 @@ export class DecryptNotesResponse extends WorkerMessage {
       size += 1
 
       if (note) {
-        size += 1 + 32 + NOTE_LENGTH
+        size += 1 + 32 + DECRYPTED_NOTE_LENGTH
 
         if (note.index) {
           size += 4


### PR DESCRIPTION
## Summary

We re-create constants for decrypted and encrypted note lengths in our JS and Rust packages. This PR exports a Napi constant that can be shared.

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
