### PR TITLE
Add global lerna test:slow command

### DIFF
--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -59,12 +59,12 @@ describe('Demonstrate the Sapling API', () => {
 
     const decryptedNoteBuffer = encryptedNote.decryptNoteForOwner(key.incoming_view_key)
     expect(decryptedNoteBuffer).toBeInstanceOf(Buffer)
-    expect(decryptedNoteBuffer.byteLength).toBe(115)
+    expect(decryptedNoteBuffer!.byteLength).toBe(115)
 
     const decryptedSpenderNote = encryptedNote.decryptNoteForSpender(key.outgoing_view_key)
     expect(decryptedSpenderNote).toBe(null)
 
-    const decryptedNote = Note.deserialize(decryptedNoteBuffer)
+    const decryptedNote = Note.deserialize(decryptedNoteBuffer!)
 
     // Null characters are included in the memo string
     expect(decryptedNote.memo().replace(/\0/g, '')).toEqual('test')
@@ -85,7 +85,7 @@ describe('Demonstrate the Sapling API', () => {
     const transaction = new Transaction()
     transaction.setExpirationSequence(10)
     const encryptedNote = new NoteEncrypted(postedMinersFeeTransaction.getNote(0))
-    const decryptedNote = Note.deserialize(encryptedNote.decryptNoteForOwner(key.incoming_view_key))
+    const decryptedNote = Note.deserialize(encryptedNote.decryptNoteForOwner(key.incoming_view_key)!)
     const newNote = new Note(recipientKey.public_address, BigInt(15), 'receive')
 
     let currentHash = encryptedNote.merkleHash()

--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "test:changed": "lerna run --since origin/master --include-dependents test",
     "test:update": "lerna run test -- -u",
     "test:update:changed": "lerna run --since origin/master --include-dependents test -- -u",
-    "test:slow:coverage": "lerna run test:slow --stream -- --collect-coverage  --testPathIgnorePatterns",
+    "test:slow": "lerna run test:slow",
+    "test:slow:coverage": "lerna run test:slow --stream -- --collect-coverage --testPathIgnorePatterns",
     "typecheck": "lerna exec -- tsc --noEmit",
     "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit",
-    "coverage:upload": " lerna exec '\"yarn codecov -t $CODECOV_TOKEN -f ./coverage/clover.xml -F $LERNA_PACKAGE_NAME -p $ROOT_PATH/ --disable=gcov\"'"
+    "coverage:upload": "lerna exec '\"yarn codecov -t $CODECOV_TOKEN -f ./coverage/clover.xml -F $LERNA_PACKAGE_NAME -p $ROOT_PATH/ --disable=gcov\"'"
   },
   "devDependencies": {
     "@types/jest": "26.0.23",


### PR DESCRIPTION
## Summary

(Re-)introduce project wide `test:slow` command, since I've been using it a lot more often while working between the nodejs and rust codebases.

Also did a little lint cleanup in the nodejs tests.

Next steps I want to take are to introduce proper lint rules/command for -nodejs folder, as well as begin properly testing more of the NAPI bindings via JS tests, so this PR is kind of step 1 of that process.

I also wouldn't mind a `test:all` command at some point but don't feel like dedicating the time to figuring that out yet.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
