### PR TITLE
Rust minor code cleanup

### DIFF
--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -5,7 +5,7 @@
 use napi::{bindgen_prelude::*, JsBuffer};
 use napi_derive::napi;
 
-use ironfish_rust::{note::Memo, Note, SaplingKey};
+use ironfish_rust::{Note, SaplingKey};
 
 use crate::to_napi_err;
 
@@ -22,7 +22,7 @@ impl NativeNote {
 
         let owner_address = ironfish_rust::PublicAddress::from_hex(&owner).map_err(to_napi_err)?;
         Ok(NativeNote {
-            note: Note::new(owner_address, value_u64, Memo::from(memo)),
+            note: Note::new(owner_address, value_u64, memo),
         })
     }
 

--- a/ironfish-rust/src/keys/public_address.rs
+++ b/ironfish-rust/src/keys/public_address.rs
@@ -6,10 +6,11 @@ use crate::{
     errors::IronfishError,
     serializing::{bytes_to_hex, hex_to_bytes, point_to_bytes},
 };
+use ff::Field;
 use group::GroupEncoding;
 use ironfish_zkp::{Diversifier, PaymentAddress};
 use jubjub::SubgroupPoint;
-use rand::{thread_rng, Rng};
+use rand::thread_rng;
 
 use std::{convert::TryInto, io};
 
@@ -167,11 +168,9 @@ impl PublicAddress {
     ///  *  the ephemeral secret key as a scalar FS
     ///  *  the ephemeral public key as an edwards point
     pub fn generate_diffie_hellman_keys(&self) -> (jubjub::Fr, SubgroupPoint) {
-        let mut buffer = [0u8; 64];
-        thread_rng().fill(&mut buffer[..]);
-
-        let secret_key: jubjub::Fr = jubjub::Fr::from_bytes_wide(&buffer);
+        let secret_key: jubjub::Fr = jubjub::Fr::random(thread_rng());
         let public_key = self.diversifier_point * secret_key;
+
         (secret_key, public_key)
     }
 

--- a/ironfish-rust/src/merkle_note.rs
+++ b/ironfish-rust/src/merkle_note.rs
@@ -257,9 +257,10 @@ mod test {
     };
 
     use bls12_381::Scalar;
+    use ff::Field;
     use ironfish_zkp::ValueCommitment;
     use rand::prelude::*;
-    use rand::{thread_rng, Rng};
+    use rand::thread_rng;
 
     #[test]
     fn test_view_key_encryption() {
@@ -268,10 +269,7 @@ mod test {
         let note = Note::new(receiver_key.generate_public_address(), 42, Memo::default());
         let diffie_hellman_keys = note.owner.generate_diffie_hellman_keys();
 
-        let mut buffer = [0u8; 64];
-        thread_rng().fill(&mut buffer[..]);
-
-        let value_commitment_randomness: jubjub::Fr = jubjub::Fr::from_bytes_wide(&buffer);
+        let value_commitment_randomness: jubjub::Fr = jubjub::Fr::random(thread_rng());
 
         let value_commitment = ValueCommitment {
             value: note.value,
@@ -294,10 +292,7 @@ mod test {
         let note = Note::new(spender_key.generate_public_address(), 42, Memo::default());
         let diffie_hellman_keys = note.owner.generate_diffie_hellman_keys();
 
-        let mut buffer = [0u8; 64];
-        thread_rng().fill(&mut buffer[..]);
-
-        let value_commitment_randomness: jubjub::Fr = jubjub::Fr::from_bytes_wide(&buffer);
+        let value_commitment_randomness: jubjub::Fr = jubjub::Fr::random(thread_rng());
 
         let value_commitment = ValueCommitment {
             value: note.value,

--- a/ironfish-rust/src/merkle_note.rs
+++ b/ironfish-rust/src/merkle_note.rs
@@ -251,10 +251,7 @@ fn calculate_key_for_encryption_keys(
 #[cfg(test)]
 mod test {
     use super::MerkleNote;
-    use crate::{
-        keys::SaplingKey,
-        note::{Memo, Note},
-    };
+    use crate::{keys::SaplingKey, note::Note};
 
     use bls12_381::Scalar;
     use ff::Field;
@@ -266,7 +263,7 @@ mod test {
     fn test_view_key_encryption() {
         let spender_key: SaplingKey = SaplingKey::generate_key();
         let receiver_key: SaplingKey = SaplingKey::generate_key();
-        let note = Note::new(receiver_key.generate_public_address(), 42, Memo::default());
+        let note = Note::new(receiver_key.generate_public_address(), 42, "");
         let diffie_hellman_keys = note.owner.generate_diffie_hellman_keys();
 
         let value_commitment_randomness: jubjub::Fr = jubjub::Fr::random(thread_rng());
@@ -289,7 +286,7 @@ mod test {
     #[test]
     fn test_receipt_invalid_commitment() {
         let spender_key: SaplingKey = SaplingKey::generate_key();
-        let note = Note::new(spender_key.generate_public_address(), 42, Memo::default());
+        let note = Note::new(spender_key.generate_public_address(), 42, "");
         let diffie_hellman_keys = note.owner.generate_diffie_hellman_keys();
 
         let value_commitment_randomness: jubjub::Fr = jubjub::Fr::random(thread_rng());

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -79,14 +79,14 @@ pub struct Note {
 
 impl<'a> Note {
     /// Construct a new Note.
-    pub fn new(owner: PublicAddress, value: u64, memo: Memo) -> Self {
+    pub fn new(owner: PublicAddress, value: u64, memo: impl Into<Memo>) -> Self {
         let randomness: jubjub::Fr = jubjub::Fr::random(thread_rng());
 
         Self {
             owner,
             value,
             randomness,
-            memo,
+            memo: memo.into(),
         }
     }
 
@@ -291,7 +291,7 @@ mod test {
     fn test_plaintext_serialization() {
         let owner_key: SaplingKey = SaplingKey::generate_key();
         let public_address = owner_key.generate_public_address();
-        let note = Note::new(public_address, 42, "serialize me".into());
+        let note = Note::new(public_address, 42, "serialize me");
         let mut serialized = Vec::new();
         note.write(&mut serialized)
             .expect("Should serialize cleanly");
@@ -316,7 +316,7 @@ mod test {
         let (dh_secret, dh_public) = public_address.generate_diffie_hellman_keys();
         let public_shared_secret =
             shared_secret(&dh_secret, &public_address.transmission_key, &dh_public);
-        let note = Note::new(public_address, 42, Memo::default());
+        let note = Note::new(public_address, 42, "");
         let encryption_result = note.encrypt(&public_shared_secret);
 
         let private_shared_secret = owner_key.incoming_view_key().shared_secret(&dh_public);

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -10,10 +10,10 @@ use super::{
 };
 use bls12_381::Scalar;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
-use ff::PrimeField;
+use ff::{Field, PrimeField};
 use ironfish_zkp::{Nullifier, Rseed, SaplingNote};
 use jubjub::SubgroupPoint;
-use rand::{thread_rng, Rng};
+use rand::thread_rng;
 
 use std::{fmt, io, io::Read};
 
@@ -80,10 +80,7 @@ pub struct Note {
 impl<'a> Note {
     /// Construct a new Note.
     pub fn new(owner: PublicAddress, value: u64, memo: Memo) -> Self {
-        let mut buffer = [0u8; 64];
-        thread_rng().fill(&mut buffer[..]);
-
-        let randomness: jubjub::Fr = jubjub::Fr::from_bytes_wide(&buffer);
+        let randomness: jubjub::Fr = jubjub::Fr::random(thread_rng());
 
         Self {
             owner,

--- a/ironfish-rust/src/receiving.rs
+++ b/ironfish-rust/src/receiving.rs
@@ -197,10 +197,7 @@ impl ReceiptProof {
 #[cfg(test)]
 mod test {
     use super::{ReceiptParams, ReceiptProof};
-    use crate::{
-        keys::SaplingKey,
-        note::{Memo, Note},
-    };
+    use crate::{keys::SaplingKey, note::Note};
     use ff::PrimeField;
     use group::Curve;
     use jubjub::ExtendedPoint;
@@ -208,7 +205,7 @@ mod test {
     #[test]
     fn test_receipt_round_trip() {
         let spender_key: SaplingKey = SaplingKey::generate_key();
-        let note = Note::new(spender_key.generate_public_address(), 42, Memo::default());
+        let note = Note::new(spender_key.generate_public_address(), 42, "");
 
         let receipt = ReceiptParams::new(&spender_key, &note)
             .expect("should be able to create receipt proof");

--- a/ironfish-rust/src/receiving.rs
+++ b/ironfish-rust/src/receiving.rs
@@ -7,11 +7,12 @@ use crate::{errors::IronfishError, sapling_bls12::SAPLING};
 use super::{keys::SaplingKey, merkle_note::MerkleNote, note::Note};
 use bellman::groth16;
 use bls12_381::{Bls12, Scalar};
+use ff::Field;
 use group::Curve;
 use ironfish_zkp::proofs::Output;
 use ironfish_zkp::ValueCommitment;
 use jubjub::ExtendedPoint;
-use rand::{rngs::OsRng, thread_rng, Rng};
+use rand::{rngs::OsRng, thread_rng};
 
 use std::io;
 
@@ -38,10 +39,7 @@ impl ReceiptParams {
     ) -> Result<ReceiptParams, IronfishError> {
         let diffie_hellman_keys = note.owner.generate_diffie_hellman_keys();
 
-        let mut buffer = [0u8; 64];
-        thread_rng().fill(&mut buffer[..]);
-
-        let value_commitment_randomness: jubjub::Fr = jubjub::Fr::from_bytes_wide(&buffer);
+        let value_commitment_randomness: jubjub::Fr = jubjub::Fr::random(thread_rng());
 
         let value_commitment = ValueCommitment {
             value: note.value,

--- a/ironfish-rust/src/spending.rs
+++ b/ironfish-rust/src/spending.rs
@@ -16,13 +16,13 @@ use bellman::gadgets::multipack;
 use bellman::groth16;
 use bls12_381::{Bls12, Scalar};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use ff::PrimeField;
+use ff::{Field, PrimeField};
 use group::{Curve, GroupEncoding};
 use ironfish_zkp::constants::SPENDING_KEY_GENERATOR;
 use ironfish_zkp::proofs::Spend;
 use ironfish_zkp::{redjubjub, Nullifier, ValueCommitment};
 use jubjub::ExtendedPoint;
-use rand::{rngs::OsRng, thread_rng, Rng};
+use rand::{rngs::OsRng, thread_rng};
 use std::io;
 
 /// Parameters used when constructing proof that the spender owns a note with
@@ -86,17 +86,12 @@ impl<'a> SpendParams {
             return Err(IronfishError::InconsistentWitness);
         }
 
-        let mut buffer = [0u8; 64];
-        thread_rng().fill(&mut buffer[..]);
-
         let value_commitment = ValueCommitment {
             value: note.value,
-            randomness: jubjub::Fr::from_bytes_wide(&buffer),
+            randomness: jubjub::Fr::random(thread_rng()),
         };
 
-        let mut buffer = [0u8; 64];
-        thread_rng().fill(&mut buffer[..]);
-        let public_key_randomness = jubjub::Fr::from_bytes_wide(&buffer);
+        let public_key_randomness = jubjub::Fr::random(thread_rng());
 
         let proof_generation_key = spender_key.sapling_proof_generation_key();
 

--- a/ironfish-rust/src/spending.rs
+++ b/ironfish-rust/src/spending.rs
@@ -405,11 +405,7 @@ fn serialize_signature_fields<W: io::Write>(
 #[cfg(test)]
 mod test {
     use super::{SpendParams, SpendProof};
-    use crate::{
-        keys::SaplingKey,
-        note::{Memo, Note},
-        test_util::make_fake_witness,
-    };
+    use crate::{keys::SaplingKey, note::Note, test_util::make_fake_witness};
     use group::Curve;
     use rand::prelude::*;
     use rand::{thread_rng, Rng};
@@ -421,7 +417,7 @@ mod test {
 
         let note_randomness = random();
 
-        let note = Note::new(public_address, note_randomness, Memo::default());
+        let note = Note::new(public_address, note_randomness, "");
         let witness = make_fake_witness(&note);
 
         let spend =

--- a/ironfish-rust/src/spending.rs
+++ b/ironfish-rust/src/spending.rs
@@ -253,11 +253,8 @@ impl SpendProof {
         let value_commitment = {
             let mut bytes = [0; 32];
             reader.read_exact(&mut bytes)?;
-            let point = ExtendedPoint::from_bytes(&bytes);
-            if point.is_none().into() {
-                return Err(IronfishError::InvalidData);
-            }
-            point.unwrap()
+
+            Option::from(ExtendedPoint::from_bytes(&bytes)).ok_or(IronfishError::InvalidData)?
         };
         let randomized_public_key = redjubjub::PublicKey::read(&mut reader)?;
         let root_hash = read_scalar(&mut reader)?;

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -7,7 +7,7 @@ use crate::{errors::IronfishError, sapling_bls12::SAPLING};
 use super::{
     keys::{PublicAddress, SaplingKey},
     merkle_note::NOTE_ENCRYPTION_MINER_KEYS,
-    note::{Memo, Note},
+    note::Note,
     receiving::{ReceiptParams, ReceiptProof},
     spending::{SpendParams, SpendProof},
     witness::WitnessTrait,
@@ -148,7 +148,7 @@ impl ProposedTransaction {
             let change_note = Note::new(
                 change_address,
                 change_amount as u64, // we checked it was positive
-                Memo::default(),
+                "",
             );
             self.receive(&change_note)?;
         }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -408,11 +408,6 @@ impl Transaction {
         self.expiration_sequence
     }
 
-    /// Set the sequence to expire the transaction from the mempool.
-    pub fn set_expiration_sequence(&mut self, expiration_sequence: u32) {
-        self.expiration_sequence = expiration_sequence;
-    }
-
     /// Calculate a hash of the transaction data. This hash was signed by the
     /// private keys when the transaction was constructed, and will now be
     /// reconstructed to verify the signature.

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -5,9 +5,7 @@
 #[cfg(test)]
 use super::{ProposedTransaction, Transaction};
 use crate::{
-    keys::SaplingKey,
-    merkle_note::NOTE_ENCRYPTION_MINER_KEYS,
-    note::{Memo, Note},
+    keys::SaplingKey, merkle_note::NOTE_ENCRYPTION_MINER_KEYS, note::Note,
     test_util::make_fake_witness,
 };
 
@@ -17,9 +15,9 @@ use ironfish_zkp::redjubjub::Signature;
 fn test_transaction() {
     let spender_key: SaplingKey = SaplingKey::generate_key();
     let receiver_key: SaplingKey = SaplingKey::generate_key();
-    let in_note = Note::new(spender_key.generate_public_address(), 42, Memo::default());
-    let out_note = Note::new(receiver_key.generate_public_address(), 40, Memo::default());
-    let in_note2 = Note::new(spender_key.generate_public_address(), 18, Memo::default());
+    let in_note = Note::new(spender_key.generate_public_address(), 42, "");
+    let out_note = Note::new(receiver_key.generate_public_address(), 40, "");
+    let in_note2 = Note::new(spender_key.generate_public_address(), 18, "");
     let witness = make_fake_witness(&in_note);
     let _witness2 = make_fake_witness(&in_note2);
 
@@ -90,7 +88,7 @@ fn test_transaction() {
 #[test]
 fn test_miners_fee() {
     let receiver_key: SaplingKey = SaplingKey::generate_key();
-    let out_note = Note::new(receiver_key.generate_public_address(), 42, Memo::default());
+    let out_note = Note::new(receiver_key.generate_public_address(), 42, "");
     let mut transaction = ProposedTransaction::new(receiver_key);
     transaction.receive(&out_note).expect("It's a valid note");
     let posted_transaction = transaction
@@ -116,8 +114,8 @@ fn test_transaction_signature() {
     let receiver_address = receiver_key.generate_public_address();
 
     let mut transaction = ProposedTransaction::new(spender_key);
-    let in_note = Note::new(spender_address, 42, Memo::default());
-    let out_note = Note::new(receiver_address, 41, Memo::default());
+    let in_note = Note::new(spender_address, 42, "");
+    let out_note = Note::new(receiver_address, 41, "");
     let witness = make_fake_witness(&in_note);
 
     transaction


### PR DESCRIPTION
## Summary

Felt like overkill to open a PR for each one of these, so here's a cleanup PR. Might be easiest to review the individual commits

- [Remove verbose add/sub operations for transaction balance](https://github.com/iron-fish/ironfish/commit/0f0025d20fcd13d0b7756b41a897642626e5dd29)
- [Remove expiration_sequence setter on posted Transaction](https://github.com/iron-fish/ironfish/commit/53a4ba0f14b9f98004a0572e563e1e2f90962879)
- [Simplify some math operations in Transactions](https://github.com/iron-fish/ironfish/commit/2c3e6127e493fe2f4af32917f169555666cd4aa7)
- [Use jubjub::Fr::random](https://github.com/iron-fish/ironfish/commit/798c4b4587fe579e5e30b309d66e013bb273a754)
- [Cleanup CtOption unwrap](https://github.com/iron-fish/ironfish/commit/350ad9f92496bcac14a7d27fb0d2b0231961328e)
- [Use `Into<Memo>` for Note constructor](https://github.com/iron-fish/ironfish/pull/2398/commits/0723146cb64afe199bbcc1714b3d745c57771d1d)

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
