### PR TITLE
Try fixing memory usage of CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.13.0'
+          node-version: '16.10.0'
           cache: 'yarn'
 
       - name: Cache Rust


### PR DESCRIPTION
## Summary

Testing some ideas for fixing memory usage of CI tests.

Haven't debugged into it to see whether it could be an issue with our own tests, but the Jest repo has plenty of examples of Jest memory leaking, and v29 seems to fix some memory-leak-related issues, so testing out some different versions.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
