### PR TITLE
Convert some deposit-all numbers to bigints

### DIFF
--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -4,11 +4,11 @@
 
 import {
   Assert,
-  displayIronAmountWithCurrency,
+  BigIntUtils,
+  CurrencyUtils,
   ERROR_CODES,
   ironToOre,
   MINIMUM_IRON_AMOUNT,
-  oreToIron,
   PromiseUtils,
   RpcClient,
   RpcRequestError,
@@ -33,7 +33,7 @@ export default class DepositAll extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    fee: Flags.integer({
+    fee: Flags.string({
       char: 'f',
       description: `The fee amount in ORE, minimum of 1. 1 ORE is equal to ${MINIMUM_IRON_AMOUNT} IRON`,
     }),
@@ -62,14 +62,24 @@ export default class DepositAll extends IronfishCommand {
     this.client = await this.sdk.connectRpc(false, true)
     this.api = new WebApi()
 
-    let fee = flags.fee
+    let fee = null
 
-    if (fee == null || Number.isNaN(fee)) {
+    if (flags.fee) {
+      const [parsedFee] = BigIntUtils.tryParse(flags.fee)
+
+      if (parsedFee != null) {
+        fee = parsedFee
+      }
+    }
+
+    if (fee == null) {
       try {
         // fees p25 of last 100 blocks
-        fee = (await this.client.getFees({ numOfBlocks: 100 })).content.p25
+        const feeNumber = (await this.client.getFees({ numOfBlocks: 100 })).content.p25
+        // TODO: NEVER use numbers for amounts
+        fee = BigInt(feeNumber)
       } catch {
-        fee = 1
+        fee = 1n
       }
     }
 
@@ -111,7 +121,7 @@ export default class DepositAll extends IronfishCommand {
       this.client,
       this.api,
       expirationSequenceDelta,
-      fee,
+      Number(fee),
       graffiti,
     )
     if (!canSend) {
@@ -121,8 +131,7 @@ export default class DepositAll extends IronfishCommand {
     }
 
     if (!flags.confirm) {
-      const feeInIron = oreToIron(fee)
-      const displayFee = displayIronAmountWithCurrency(feeInIron, true)
+      const displayFee = CurrencyUtils.renderIron(fee, true)
 
       this.log(
         `You are about to deposit all your $IRON to the Iron Fish deposit account. Each transaction will use a fee of ${displayFee}. The memos will contain the graffiti "${graffiti}".`,
@@ -138,8 +147,9 @@ export default class DepositAll extends IronfishCommand {
     this.log('Fetching account balance...')
 
     let balanceResp = await this.client.getAccountBalance({ account: accountName })
-    let confirmedBalance = Number(balanceResp.content.confirmed)
-    let pendingBalance = Number(balanceResp.content.pending)
+    let confirmedBalance = CurrencyUtils.decode(balanceResp.content.confirmed)
+    let unconfirmedBalance = CurrencyUtils.decode(balanceResp.content.unconfirmed)
+    let pendingBalance = CurrencyUtils.decode(balanceResp.content.pending)
 
     // Console log will create display issues with Blessed
     this.logger.pauseLogs()
@@ -159,7 +169,7 @@ export default class DepositAll extends IronfishCommand {
     })
 
     const list = blessed.textbox({
-      top: 1,
+      top: 4,
       alwaysScroll: true,
       scrollable: true,
       parent: screen,
@@ -182,13 +192,13 @@ export default class DepositAll extends IronfishCommand {
       }
 
       status.setContent(
-        `Balance: Confirmed - ${displayIronAmountWithCurrency(
-          oreToIron(Number(confirmedBalance)),
-          false,
-        )}, Unconfirmed - ${displayIronAmountWithCurrency(
-          oreToIron(Number(pendingBalance)),
-          false,
-        )}`,
+        `Balance\nConfirmed:   ${CurrencyUtils.renderIron(
+          confirmedBalance,
+          true,
+        )}\nUnconfirmed: ${CurrencyUtils.renderIron(
+          unconfirmedBalance,
+          true,
+        )}\nPending:     ${CurrencyUtils.renderIron(pendingBalance, true)}`,
       )
 
       screen.append(footer)
@@ -198,17 +208,18 @@ export default class DepositAll extends IronfishCommand {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       balanceResp = await this.client.getAccountBalance({ account: accountName })
-      confirmedBalance = Number(balanceResp.content.confirmed)
-      pendingBalance = Number(balanceResp.content.pending)
+      confirmedBalance = CurrencyUtils.decode(balanceResp.content.confirmed)
+      unconfirmedBalance = CurrencyUtils.decode(balanceResp.content.unconfirmed)
+      pendingBalance = CurrencyUtils.decode(balanceResp.content.pending)
 
       // terminate condition
-      if (terminate && pendingBalance < ironToOre(IRON_TO_SEND) + fee) {
+      if (terminate && pendingBalance < BigInt(ironToOre(IRON_TO_SEND)) + BigInt(fee)) {
         screen.destroy()
         process.exit(0)
       }
 
       // send transaction
-      if (confirmedBalance > ironToOre(IRON_TO_SEND) + fee) {
+      if (confirmedBalance > BigInt(ironToOre(IRON_TO_SEND)) + BigInt(fee)) {
         try {
           const result = await this.client.sendTransaction({
             fromAccountName: accountName,
@@ -219,7 +230,7 @@ export default class DepositAll extends IronfishCommand {
                 memo: graffiti,
               },
             ],
-            fee: fee.toString(),
+            fee: CurrencyUtils.encode(fee),
             expirationSequenceDelta: expirationSequenceDelta,
           })
 

--- a/ironfish/src/utils/bigint.ts
+++ b/ironfish/src/utils/bigint.ts
@@ -112,6 +112,17 @@ function divide(a: bigint, b: bigint): number {
   return Number(div) + Number(a - div * b) / Number(b)
 }
 
+function tryParse(value: string): [bigint, null] | [null, Error] {
+  try {
+    return [BigInt(value), null]
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      return [null, e]
+    }
+    throw e
+  }
+}
+
 export const BigIntUtils = {
   toBytes,
   fromBytes,
@@ -120,4 +131,5 @@ export const BigIntUtils = {
   toBytesLE,
   max,
   divide,
+  tryParse,
 }


### PR DESCRIPTION
## Summary

I noticed some currency amounts in deposit all were in numbers that should be ore. We should _always_ take strings and parse them into bigints for ore amounts.

```
Balance
Confirmed:   $IRON 0.00021458
Unconfirmed: $IRON 0.00021458
Pending:     $IRON 0.00021458

--- Completed Transactions (0) ---
```

## Testing Plan
I ran the command manually and looked at the UI.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
