### PR TITLE
Update mining transaction picking logic to use fee rate instead of fee

### DIFF
--- a/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
@@ -1530,224 +1530,6 @@
       ]
     }
   ],
-  "MemPool orderedTransactions returns transactions from the node mempool sorted by fees": [
-    {
-      "id": "8a9cf216-4a31-48be-aa59-3e1343c124b7",
-      "name": "accountA",
-      "spendingKey": "a5ab7560b37fbd8f0c1d8498cfb291e61e09336e10fc1812192a919494908f73",
-      "incomingViewKey": "f9ebf6a8a110260bf6b107324f50776afb0e824b0d8d666a65ae453cd9272901",
-      "outgoingViewKey": "bb052e05ef2abc2d333846eed684b97a521ce05d7be07765b92229f2637a800b",
-      "publicAddress": "685b93b28196dae936f3336cb9ad732993b4eb0b775fa7f531ff7515a3deade70156ca200a1580caf49d3c"
-    },
-    {
-      "id": "2d3ac778-4f96-4552-9ef6-ea5a9d5f6fe9",
-      "name": "accountB",
-      "spendingKey": "28efc1db0eefd0c28c8e7b06d3f23d8c2377bf8a3cfda60ffb4c938d6ba3be7f",
-      "incomingViewKey": "ff6d1cbe0bb219914152ab4afef24dcf93599635adf005099669759c5492ff03",
-      "outgoingViewKey": "ca5d95b3039f509a84332649dc8dbab6a931ce1df3962261e7f2a7992e318ef3",
-      "publicAddress": "94e950e543bb415d6a215a3e05df5f9ac88e81feb9a8f32e286ef9bb66726e2722d6821507da12b36d6451"
-    },
-    {
-      "id": "8747e0c2-0c7a-4607-b2e9-145ae4099b26",
-      "name": "accountC",
-      "spendingKey": "2d014f147a762708a417fe89294ea30fb7a543fafa278d7d9927b0aae0e79560",
-      "incomingViewKey": "dca5661ab238721fae9f522a505663f46eff6d58eceb0e7d35c1f4f9437a1b01",
-      "outgoingViewKey": "c649d27afd2dcf318aa8e7fe2952f275924e14e6b721606c4527485457125f2f",
-      "publicAddress": "2a5e34efc6eba0f4090d16de94d66b83758ae19f50267772edbe96b2328bc027966667e75ba56bae6da8c5"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:bYzgbm7VtU+Dag80Mt9ZquWiCCnNorr1s41Jwrq1ZQ0="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1664914104075,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "7D7DEDA3356919EDD0C363DAE9DD4A7665E966A2CEE05967E79CA6CA246AF5AE",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALHqv7lbZ/kN5FDwNlBwBo+nos2g+D5i+4JStOeWZoP28g4k0xXcS3Nvxco9AkLG3IfTF0A9Qo+lvadOtlcpu8Vq8ViDwZaWEPiS3+QWW5b7aIcm45hiGoE/UqoKg/i8VBW6zahEkc75o3Vdzb+00GSQYS+jQimVnQztodyinmsdM3zJG/xpDVqsRxT/fWyU75mSjVrlWozZU3J7XYABUbMfKmROX0H4w+3zhP/ON2pFUUhOqgx+usxewcFubpxsBXelcxNSjFnHSDiv6+l13PoFQB8ve+3LIlrlKbXOn+g+G6Kox5BdzUsO0dy/5lIa0evvPEeGEzmu0at2maiE6T++PMpPTt/kzO1CheIh0oLqnxQ11xXvL3bHm9hK9LzHlTP9oSmyZKcnK21wxAewNtT1DPRdIoBYSeQZxJm56kcV3wS+l3NCaRDDYm1qdjSaXsJ0gYVI9vcDmln2GLUVFv+qmTc2dcVuVGWhVTgIkCdhKo+Oe1rgxFfM7LiE0Wv0Lk9whUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZ+6cnwx24mKW4rHVYuL53/yC2GhQPB2QrkqS17Qwhptctb6O4+Vy2UmTtPVfrYmXdHXhyo+uJAQqzNZrFh2uBA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "7D7DEDA3356919EDD0C363DAE9DD4A7665E966A2CEE05967E79CA6CA246AF5AE",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:FNDX3JgPWamMKRpz2LvH8lwQQOszZC1u0meL7AFBCCE="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "FB542B1F41361E2FFB7CA5D97718039D2292AA4B6CCB47725951DD2C5984CBE8",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1664914105466,
-        "minersFee": "-2000000001",
-        "work": "0",
-        "hash": "69554B8DD21CAF244927F9C0F5655DBDA262031C49CAD19D5E3E29AC5A794E89",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALRj456ozdm0kS0cgzndCBfiV5h6qfF1iuKvaYkc9so78TBISjDK5WBUApHTdl9nRYD1INdDiwjDqF2KnG5D3+dqOj2iEEXVekRZWXhwmVldtG79hh4Yjtlw5yBp3Ut+tA21tlxXHsonf/MZW5KLycf2d57yPMtCgeMV6+vo6baJkcPDeODrQ+o0HVuv8YbBEpXtlAFp1G9veC4OsPWXnmExHEuw7/ypke2WqCvcupfCgJ8ktCwLMi97FEXB/Zgi5KkfUdwWRAtO/Zt3cS850/GogTunlgo2N6ewI+GyyDM9eNyntltDGqKrOT5/rk1LG17VdN5Rmznv5CnKYbHIw1zmWbHKxI5iTUUEqD4/f8dZhXYCjub69TPcgwCuFVn3Jj5sYXKf2eK2E/H+A8M0DoZlpE1M1wQn/G/dHa2COJty80MLmdoVZ9JOhrcRvo8OX/URdfzoKNL7aoAoqiFRB/XPzLiBzVCykJ0TThZvQFe2DsustT8KfAClFH7zh1H5F/Me1UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEYBINTJ1TNKbhxjySGas8XK3VAcROISqwTzeYgMFgrX6k+LOP8+/94I6skM5WM2HlLt+PEif6ZSQfES6iWlPCA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKmnKiXgwFubl6aAD+7AXl15LHvtlUnaFRW0yyh78PYDDvn9kLEIMXA41SkjtQXUsYlJtCz3hflh0MZxQxJ1fXf4U9uHqVSiy1VTf7v3/ifmc+9e9f2gaXeNegMld3/bOg+49I3T9WnnmlLs07eYHPTo9ljPSLnMFPxrjEjCKDOm8Dm2AdHF8X0TGx5SnKi1U65IuriqVM+xYZzBjTbrGgWG6ApSdQL4XsRo4dK6RBpzr8iAXT2A+mWPvIIZxvZgDnhMgz6VsTVLe+OCySWsye1rsB/oF6wfhEQeVaTTbEPYBczOn4x1+thTKdnxF4A9pS7hRo3v6LF+FGYxHLL5f+FtjOBubtW1T4NqDzQy31mq5aIIKc2iuvWzjUnCurVlDQQAAADMSHA9QpP7DkSdT378vuShJw1sd7tzvTo7o1rp+Cv7sUpFxEvJqB09MIAHxE87tAtywN86DrC5r6vNYlu0kdjQZuYargCb9GXN/zFV9By1haIiSDW2trVZHKsUo5DFVgOMIyo7WARbdFX9JOuo1a4UbYyNe7f04LYCSwQzK7J9CH3SDZQU5ggFspKcA39oHeuGy6vVSHUQVuZUOxUDYP5+70UIliazXiJNpVjtzoASuv7oY9X3sKyZQceYyFlT4AMA0gk4vGSZqW+lXNFsDn3lqv/BnPtlOUluZQnxKc66D/Gf7t3HAEt0CIpFSbdwtceJ1A3uvV9wqPxQ49yNU9tbIeirUSNYgFEebqPEHBIs42YRCFWSo+BFVTprAbvp53Q5UQTkaI9Gj4FCepMyiMf+hTh3k5gUamHI28U6lPsLoGi9f5HSQkh5rhKVMt7o8/Ku4MMF2+Qf+fWDKrzL30too/cqBNzqBMwVuwN6MmDTSt7F9vuVu5XM2G/rkRlgSHH+bOa+D/HkGOjk5z2w3USdxW0N0TYnNs5wBdm/PvPq71aTe6FV8NxSUBLJJ25oM2+FuNo9C1nQIFmWmsgnaCcEDlEzL7Z6BWHS2u/v5+Ezcex2m4gm5Ntoq6BfOnAnS9Pa2NU+64McEYPWM6Mf4f0aCzpuVE5a4eXU/DEB4/7TEuBq+aNCt8MuYjfO+zziUD2YOLy6aU0qVJhfyOnXwGiE1oHIXH4crsK4hf/Gvn7WcL5GJKB5dka5aWc4YCcFMxjbtWOw5gO24Vkw/OIfK07I2jdl1TAFaQxHDFbnbq1RFh4Vd6a+LanPy9VHutd5qEjMkvCkQgaSgS05pAwpnWYGUstu+7NWFVqYo3flVuPwGBIp+ABp2lORSzH/NBxGKs0ZP7yIQcoZ3DTaBJqsh5dhX/hkYtrmAEYVYBZRrd4QLaV0768936gAYLfJ0XpMs/3ajz2t8MnZcadFhWbQdqEPOMmfsxLdgEkzE4l6W5sRDMDzQHB26YMK9bSfe8sYJJopDhE6njtTE7DXhpEUn1URX5UdGSBrs00kqe6uzCoJxjWt7VqRYBk/Yo3hoPG3Vi8d12fTvoz7De09JdAHJiN8Jdf//3bvNAqT6gnhnjuGkXidKsD4W/I1gy5DoMDWt6yV2l7LHt61RcPpQEclHspTk1/bKG79FOc04CzzwbZp+tlCtvv4aERDYQ40IEX3bUHJZTfHk7anbyqowX6ekimptzBU+7gucpjpscdHMjIdOzJTpsw99u8ycmuoIqQ9/ElL3XIrfvwUfoHJNJIoOMd02r8ctlCWd4eTMY2DbVawMZTVMzTYs4JULKrV6f2Horh6V10c3JULpqJT82OTGt4nkc4nlZx1Z3UCXpLCGRAM4izVJtBB0EZtmrGq01OMrdqnE9Gb1VRPbxopZY9YcGkvhJg7A2hjH0H0Hk/Q9SgBjxpWIB0cDA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "7D7DEDA3356919EDD0C363DAE9DD4A7665E966A2CEE05967E79CA6CA246AF5AE",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:J/iWKsLPaXIx49NKXHmmId4yMAfetKPXo0nt30XW8mo="
-          },
-          "size": 5
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1664914105629,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "5D3643A4624C10C0998BBACFF8BD336CE1D57C230D38B34348D96BF83CE3EE13",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIsSsaD0XEu551sWqpBnNoslIhwFfpTNJ/y0WFvPURzsA1AzcEHFIod/iPlkrQShsLg4vZHk2vgGtqrvCG/86+tIX80egYKzIwSQOI/au/P2Q8HGV6dMzUfrrCXj1VVs4g9GrlqZ9V0m83I4zlxranWWUFjytyRuVQKslxXYMN7N93jZN6977VsP1zKP5oO3aZhfORQ1TVy4OmMDdtz4stm6S3eAowfnj6GvW/kNi0eBbtnO9T/8ELhIn05bjlkG03tVK93FQBsGMkkMqNFfmWUe/XVreiC27l4Js4Oo+XbGiDetypUCX9VgPUaKMDIhbsVSfI44xAhrqZujmKBsDTJjllalxxc57qIdXWUWkpVogDDCOow3WhpuhE438lxcycx+BUjAjlr5xhGFEoucBZxgO/5jz7Waj4yszVpm+2pyUe2RIfAxfy3+zpGBC/OLEXNTYuqSdKUjyuXjSJdD8IhPIdIxjysfyPI7CXjXzw5R6mHtVEu/Sl+4j+AFYWR7lbBhUEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMx2W4wgEvzbH7Qh+DNjMuqO5HaPFRexjGB9UJf2aQj9J1n/60jXCD9+M5dz6HraCL+7wdI4p4J/BZPP09aA8DA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "5D3643A4624C10C0998BBACFF8BD336CE1D57C230D38B34348D96BF83CE3EE13",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:VzOhObAOmghmDJdZA7ysMWsVoVNLTFvv1W+23nsyylY="
-          },
-          "size": 8
-        },
-        "nullifierCommitment": {
-          "commitment": "EA1A3AA15FA3B3A828D0C7BEFF927DD11D88F418C19C5792A5C64BEBDCD23047",
-          "size": 2
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1664914106947,
-        "minersFee": "-2000000001",
-        "work": "0",
-        "hash": "FCF6A225C1AB58D4CA64488A1FB5A8A1612C8EF8F10E8F52F4475B91042D5407",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIxNuO7KsyQIXIp3K1AbLbYNUOq3lvuzUaqEjdqyaAk20DTUJR4Zqr3OW5UtwdaHN7npcyRIJsdFUGGr/mfkEpbgLUd+hDsGlvvmnefv9jWLREwdO+Rf14K8mCH3ZH+/zRSenZeFKHlNtlg+o/Rp4/LnGLxYOqN64rA38gpLsBif3SEgCk1D8dQTTs/2Oi4tPqkUj4+QKEMOL6UegJzRtZ2O4QyKC/fGhK0HX4NFlw9A3epaS+Iuc9vwlGSsVs0dMPDSZ52bXjDQZm9gIiraXhMjlLZXQ6RMlDPlLC0dyOBzrbRni4/rM4rgVIh7wHlW215rgsy0JZuv3GsKL7H4xmgenIaMbrAof2Dwy7L55/Sct51w7CxEWXx0/bR4I6EEZTBQCiz34WizmL2acZUUIOmYXRPoUJZpgprvcBlaqm8WwAWYj86cFYZ0Z6jLJwq+YNC+7U4xxg1Ut3OOmEffMFGI38aHaKdAFCUcZ9/n3LTlbnObsN0aXPNUP9x8SHLROolEjEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0/Hg9NeRi5xCQQkViWNWv6jtBU9Wh09RSGYM3aSnSsmzSVDDygtNxp2GvW9xYgW+mXKLwnq0TMw+HHdRYrEEDA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAJTIFyeIRXr5TL/GADQYwAY1r6ZaZpB0Mz8XUBsPlQ1c4xKmGVBW2XNTNjieEgetIbPvK9DLx34RFD3hapU+4REcLNMkl/IQNtciuwazjc76zl6ZgwBXgcwhWpeI36oWUxbrzbqtsPWiKaVRsmkjXZifCg7eJ4VVv32vcDlmI0oGu5cFaxnRTO3ZUf8otTFrg46YJVw4yC1vTzKJhadlBS1E8tV2RaKNNTlpXGi2/impwTNd2tGMW+QelKpf600iVdP7hJbh+irhNh/R4+2dO+MrKNyJJuU9wZx+y9yqzLxraZIULEpTVSBiTGsVJScivcL3Cf6BTnk4/8ZofIBi98cn+JYqws9pcjHj00pceaYh3jIwB960o9ejSe3fRdbyagUAAADcDGIyk/74ZkNyIqWpiepO+N3+xpP4YRzjNAqFmyRpsCuyxx6gqkmqLNPmb2WWTqwkreOreSxFyFMHJvnLJDTUCrmTqCgoIb16K/W9f7zobvj2iLUERhSZLws1Gm5pJQ6EQrQCC4Renw5Ff1vnLCrl8MQJTBYNsGUmxZj1P8+Ej8mSC48DpbSu5x5XiTlKy9CIMQlu0hoiU3yVzi7LwdjrEIWRTNgY7FIn8K/+sBdr45CwWi2m0BeZc3hGr9RxV7YHGcXkE75bGIrdlH8+J9X09oTT0hJJLhEZe2hwoLLv3xxjlo7xqufl5nsAgAopdlGuYsF3qWNAsEMoJbe6khDkxkmpQaxdJ5cPD38wXYLjviaoHgZPsOKToYFHiR2KvABC6pwFkqbbpdsKMg1jKSP3G/rpYhmkQVc10xfykgZ0y7svXCnSvdOuDDsbaFJBneh719eyuxFQmsWFG9Evnh5qNHLc0hfp3updizsTrwP+ACGsznoasa6NBanl1gBxx7mZODMX3dR7aWjj3uYG/LQNfhv0Ktuf8xLfDZmN0KwQhor6h3cziO9pbGnkMnRsoz6n+BIEddEqVCcKXDH3QdUQbIFSOsPu//vHZKN6arZZtXmn+uRWYZpl0B8nqMbrMv4tYGX5QNB7+ZAzEnqcG8Sty3vnDgM27k4iOfBulciKpH58+8V3gZjHKwhtJeQhVuUM9zyKHV8WyGQfEz1X5dPPkwkcHY9JR13o+Hc2EmKVKmuTILNbi5rvo0v4/l/0uxqCmFWQ/+uUALnjeYzTBN5LbX+aa/e1Nq2ZvmrXtCtQb5yGA61brD38NCWB2y0+w4ijCq4cXaXkucRyX6uG6vRg9QmyrtlziNV3aPlkC1rqj9Sw2xKef1iYfkFIkz+JRCvOEtTTWoPKH2jAlcQt5dIHJwBbaFRThkYkRpnCA2PYb+ZEM5AqquOw3QYQTTWxW/e0FzyGC59uzdxzLG8GAQl3E5a5UqPVOYquBncRSUBd9+D40pu3jp8UHWmOwMCETLtQeaZBVcI6ViXUjp34apskgDejezOdOgkQVLW4lbUQKz+RxyC280iqOWdjVobBUqrbNlmbOw+lZLa2/0T2h7ySYRDluaYR8KYOkvWHVLy1yt7IMkF+tTdDRY8/Gb+FkuQtzpVD9snWzB5fs+Qu81+oFKeiG5nndodMU3LWuokKrz3Ep8EW16OyiXiG/pUr+peF6UKjDvOk8cRFJ8cR+MJb3/vjPGqykaQsKjIwA0inIsKsm6FXtgcfRg/l55W5kF7pZ9pyeeQKeX+lYsw8HxIv0YKZ6O6ubat2DCEv6wsUwlXDCPknqlO/XQhEnas8//hmoSkq9lt29M6tES91Rwqyj2TKaCsH5ypR4ek2LOa3Q34A5xT65U/OPahwH0wK96kklAaG6hDdTGI0OgUARSlpVZ9JijGlEAh2rzkbsTqn/0pUw6huAA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "5D3643A4624C10C0998BBACFF8BD336CE1D57C230D38B34348D96BF83CE3EE13",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:AzXIDHYwAz6RLd1jjYDFinI1qOiRQ8nYR5TQu3onLEM="
-          },
-          "size": 6
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1664914107120,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "901E101C900B2ED7551925631F73FA4B7C3E6F265AF18C1B66EF3203E7D6BB3C",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJBNgh00WShRskEuIZ1UbbnAjT5b/9AveROfERS1DhZS1yIFsHkdA0VgAdp32w4GVJRnPDUFiUOrmzDJg217dVMX2t9oIGOc5Ov48/WyaZFlqkt2n85hZAMwFURQxICpkApYoHLrPmamgUtOGlxeTY8/0G91/M4lO5B8lsqXi6CsZZF1jT9pLexV7st9nTatIbd2GVKFPXyRdt28GpAP2Jm6rmoZmo5YNHHJCyslBFdoaGgF9lkw5L6YRnMA4JAZUs9GVbmaEJTfJAPS8b0wYObUFKl/vYN//Cgu7A7MdjgNE1WgnPt+IQ8c2IvBI1kry8stEdHocXs/iCsG3aGC8VF1MpzbT4EyYazd3RCD4sYpQLz1wX4yZVLeZt6Z3ZO16yw9L30VFP1kZipjP0kbD94smKJuYD/hM8oTHa5Y2Hv91+Hfmts8gSg3uja7hZ2YH6vcr5I9+y9ofpG53fCGLNqRuXZnyamZGuth/sb+tQfCe/1H4I0UwgrWNB6Frfr/Tbf/cEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw7dFYxqbg2f8FF3ReKauCO8CYaVoUAFj0fBgPeX2iHmRZ8Mm33rgq3tjcHVEUxGZq2tR8L/4IQ1EEMWN48BUfBw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "901E101C900B2ED7551925631F73FA4B7C3E6F265AF18C1B66EF3203E7D6BB3C",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:bhe+9+jOsT/Ujn4hRKMh4p2FRcmt+g37p3z27+MPHxk="
-          },
-          "size": 9
-        },
-        "nullifierCommitment": {
-          "commitment": "504FA2DA1FAE35290D2B09186DA69478E8ED63C5C2D102EA7EA2272A609699D2",
-          "size": 2
-        },
-        "target": "12061061787010396005823540495362954933337395011119300165635986189",
-        "randomness": "0",
-        "timestamp": 1664914108421,
-        "minersFee": "-2000000001",
-        "work": "0",
-        "hash": "D5394C9F614E43AAC06F0F2BE2B4117ED60510E304C62EE8F335C75D8A069E55",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALJXt4PgP8FQVRzuFqqY5/jWHaci7Vz+zq/OnngQ3U+ccJHqBan6MAKD0M/4hsjSl5Qfm3lCOWDkT38PNHQg9o5xH8lCzYZArRZzPJGRhhfDl6Fjz5CgY/kswjbreN5SMAuz4Sdo5RhaU1PHgrmiJPRdu4k5MNH9QSswu9j0mbaX6eEim6LDSKK2Dkg8TIgtY5jLLPLHrKI8kFNdMozsP2MxwmOAkC4wIRLttMSabH+7lIyRIXk++q34o3f1H5+71LP0T/z3V6Sr/Wu5p4jNTcKG/+vfV635GRdFxd4zZhzsv8p1NGdObMA5/tyZlfwXdXNr08FJzdzHF+9MxLboqHIeQnOsPBTYS3atqNR98zeeS8cSUiB+U4/c7A9Sln3nDQ93EjQNyABdGmdq6McvrBP9SPyIZGM9QNn8VfmoInVqPoawe8O3o3bwDMaNv8SbSIHXk678cp7Rbk32L694AVnJXRc0EDD57yzhaSrzdHrJkQzYnMnvAIW4PLEWuyZ7EutVGkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMvbYdMztt93Y7XaBkJ5xSMyEQEYDdZP+eMwPfcXKXExNaIdumCWrEkKU1fWFceksYso9W+0yDPuQ9zNpIC5SCQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALjInxPe0h7rk1le5a+PUzXdcPEuk1LbI+rORDL2X2t7pBBZgFMDpvfU/f5d2ANql4+SKqoINB62JTCabX/BBRf/1GFmREbHf10gzS51QjBKPxj/X8/5DBKQJ6GOj1WqZBEMzuOFGzR+DKLxJfXnF13FFNkx//VtLNMnVLaaoZ3bQ1iwGb/q4f/hUqENOXoAWJiNduveymfMiN0Ola91czLfUhGmye3NI/OP9Op/5cWmBnJo8vfZsM/xLGyUG4CzF3wOu6asb7zXayJ4F1uSzigNCoIumps7D8SwANpOyiHdhkAgfcgss4sSQV7rgtOudyvkis1tv3LDuoufM8LOxsIDNcgMdjADPpEt3WONgMWKcjWo6JFDydhHlNC7eicsQwYAAACoItuhEzCSNhFRxnQBjG0qypVCIOkXaIlU2/4BLRcaqTULHXiDGWShry5bnUpiCGyJNPpjtYwEZiom7oWvO5c0wkCkQhTXBsnUfmNk0ruE8qtapyOaM9PWMOqVlkm1VwmmDh5qX0AJXNGZC81R4ftWAAgw9cdi9/Jt8d0NDgTYdUwmIvNozi1usxKMYV0ey/Gsm9BKdkwroyYlGNFP4TgWG6LcD30iegD4RLQTl+YfH/Ajspo0H1XPn2P/uGgXpSIAaDNIXt0XsGAzUntCs6uYXImnPUsYe9AX5RdQcMgosTP864M833Wrjd9FfkoQ9vKGySebYDsj1AtutajyVLABct1O9+JSK52iDSNNr+O1IDMf9OgyD+7U7POzO7k1McEi6+6jrM5cStVNujmS7/72b3LM5Z2mJEqbwbhL/UhqqbMRNeI/3Ztr1PtJH0sXUFsQFnlkAnMWD+rl7uaGtXo1/bopnBZe4KJ7lFwD8VqZK26PciepR0HHe3l5ZforLLB3vw4Wrc+n11L7J3cipUf9GJNs4j65j+rXWyya93Ra589k8sYuIev20Um8fOtto7+XOd40Rv5UUwCn4C9TWKzWZvjlBh9NtP7jwsENT3DGsFWuSPzBfgRZOROOkTwd9DFZusqoyGxoo3IvLQ7cynjmlQkIFHIDf8t+E9b26NJLSCzy7J2wXQt4xcJHyvEdV+KxFNb2Qz50l70Wlb3th0DY62cEIuje8185s8Vp8TBopTkzdbe2FYKbGFFrgnJ/fFEKlAc8GnNjIkGGHxn1DvU0Pr9lls2FOdDlxZlA/bTMz3EsQ7aMOMwBNj8KHy2WYHdQljMnZbJx3ryx8wxn5Zzi0r0IHFgrikHEzU8w97vNnu50gBE2uG901Juv1o+OQb33Se68iDuY6IfPynsKuEy1NvGrkCCytjytL37bcz13YchTDIMkNmPlHjJxohcGgNJy4N8E2/HllgH2dgnhpBr0BTbYHyIGDcpWUbfknnF0ut/We7ueFlBNmcKgGsxnd63n98Y+mEfKEiT92UzZMmGIhDYo1omsMKGOGASJpfvAmUw5VNsOxq+4FYOswot/VLtySE++BnHT0h4hLYtWTgmp19WYy6gMzlDfPwArY6VYUzcULYyXA7i3m/jwY51+p1XI3yg7ne0pj6FhO0/nM6WivSNQ0dvJMWSSh0pM0kAUn3TinuHwlT6QSQJzpgngq9i6kqKFx3qaOofuAbbAHqTtBxLTtihsyaENFUGAVpIoddkblbUzPwrcMrsD2LSocUYmDr+zr03GJYDciJoyQ0wdQ21ZPqIfdJk2aeJtRBcHXk9KcfA+Vh2sKS6eV8lvPbtJCqMuAaxk0kZvSoXmREp5KszTUugrrjI1ZRnrL8yhltgNyQu5BEmAxMwXWe3fPxaFx4Vr+TEyxpB6MIsoPvyJk+gavc6bHqBasl+Jlvkh7snpZPoCCQ=="
-        }
-      ]
-    }
-  ],
   "MemPool orderedTransactions does not return transactions that have been removed from the mempool": [
     {
       "id": "670ebb9c-cd30-4799-b74e-e1f7170aa234",
@@ -2052,6 +1834,224 @@
         {
           "type": "Buffer",
           "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKD47Gvwo+YWZOpzKCFKduLK9l5e9s9ezXtHrXLy5hUt7gdmuh437AVH21Zfn/iWW6Zwi1Wbzq0fYyCyq4Zm6OYGk5y5DVwrt4j+PAFe37ZoiIJ5Bx7S6VMxfCOa6O8BuRRWWhuDGfdQzMzMsyTHHrquZwzX2Ajee6gZA0nAWbonUcqZ9QjOah2bHL6bKveljrPeR0UaBy53Wi9IT/iP8RHEa0aaaOHUaZnMPQt3UlU3Qxt4XXOMA2tSHRtkGvPnmZC8muZDxs0py0DdnHD0BzQrVGG6wVGC2EAuSYnYiwEIxkz/U3ERxcDg8dD7aKU62rC6Mk1k/zX3ye489CX0jmYceCXzWHPUBfcMpgMLXTz8WPV7YraTBr86FqHK4RfTTAUAAAAYBY6qIXIoD51EHG58zcAUBgr9RZB6oEldk6I6Nh7lxMhFmzG1TOretdQvwdV3ujVxaI5IQnFiGn/EzMflPLPzLh5eT9RSmrEymdgk4+eHieLNs2T/Wdg5NkgGwTUrTwug0tOuI4gPAr78voXaDMCSc4ksgBmokDNq+fjQRkcHDnwuRcq7M3DxWV2L29YRHcqYoCUsC0DTrb6DUpLp+uzcUInOysklp0+AgsF06NIVVi3Kn4HtuHjV2a5ELUbecKARF9OIcLckjuZce3Xhf4jW9T3TEjsGYGVzuuF3tbGKvuA1szPCKhDm4np05+X3q8GFf2ojhIfqZC+ffAYeBCmeCrSOoeMdj9NUGsNlSDFfdNf5+oxiK+3Y03O7COW3v3N0Ibbl00mK15RRI8noemeZAXsATtMsldd1OqTxpSLyh3iF68/en1F2xFUZg8momGBPRHUwN8DlI3BZboLgMHRuTn5AmDMxQr0rbV/a3YtaJ1NudtuwIvoyXI8XKy1zcg24oB2ArsSl9ggCFs2VCLV10diBdRsElmwl/7zBAms5J+/aFu4r9BWSrGfVQgO1Kd8saPW4neaL4b5tvArdXjBTCNYRZVF4irYOliIFbpQnsVxXyuN8UoUj/ptU6adxUsYuoToWL0Ds1ooSgvNTjM8l48da95SNXDF13Ln09m8sa3mecw920XXG2vg77AoycFXz/T0KON2D1S61x6HsYjy0VOvTKZbZaXKmR809VYIzFu6dE5Z/3qlwTXIv2RYugpmFuZgiJLVUgY+UP5KpQ0MRfSDPhU3M9l25tEQSZ2ZlT7WG/qrf4Jrk0fmhrtSZ0t9AsnMCK6WIbKeTVRh+dLdiUgLyYYxA6cb46dgv0TES5CNd5w/MKeZ2lypQ0CV19kq00sXmIY5kGmPS60dH4rayWU1pXck1+S7PNYtZYrCKwml4ApDRU8qQ4bMxFo3LwT9nD6isByUHO3erCZRRjsEpigfFiCJ7RXrij60lBStx/1NKdr2ZmZrk0JS9B+uk2pXlxKoMNdILZGJDpN1sPTq3UYnTzEzzV5HAJM+RPkEUp1Jwi4HTOOcnXXz7jXNSigd1RUnzGxrsYMW4dOrSwPYbyGZgM6IwrG4fRktnFSWjA12GLyJQ1HNMFGAr5Q912t5XKyTBHDfAZ0LyDpSx59HRSiZEYirL2IahurQxYoSw41q3WD7+Z+DksVPxqfrtiju7+8kWEkjws6o/GWTyqhJjBUo2+6bwSrf8jCVYtN5J3y7X2R5u3VMIjGfQvovIlqLQTXXnrPNWeSRhGeTsgrcaDUAWK5OoO0afw46BULKVtnhzyGevfDMdCv7ol9XgApxuw2qRnGs0aFTP5orT7UgkSoetXS/AL7Ka5pqVE30TLxxSDka4xGVl2n+WT8KuAkzoxdgyphbinVQrPAGODlWnlffirzFTwgAuN9M5IKIqbidc2J9KCA=="
+        }
+      ]
+    }
+  ],
+  "MemPool orderedTransactions returns transactions from the node mempool sorted by fee rate": [
+    {
+      "id": "1df7b158-3ffb-44a1-927c-62f03eeaa5d3",
+      "name": "accountA",
+      "spendingKey": "00aeaa60becdfa2bd69a49f12bfc8d37a4e9e798fb352ff3503325bc520627d0",
+      "incomingViewKey": "6ad3883ee486a09577dd2eb0a86683320c51c3ac6eff4d31a0d4df8b47553a01",
+      "outgoingViewKey": "7e93338deaf233055310bd9aec5b88337de55dd3af5112931abb07f65bce7ac1",
+      "publicAddress": "ad52ba82adf7d96f4171f20aac71cde2bbb84bd88027dcf0ab4ad608401be505167ebf7ba91fc2e58ef182"
+    },
+    {
+      "id": "5d4f42ab-93ac-432e-b6c7-4f4de4a15fd6",
+      "name": "accountB",
+      "spendingKey": "4f4acdb479ea62bae82bceec4b0b51d1a1283dfde5b4252fac79505a5238bf60",
+      "incomingViewKey": "7af8d957f957e9c3e1eb37d442274cf6d602ff404c34eca346dc555eb2ea5303",
+      "outgoingViewKey": "0d659d9e0f003d44b0415ed9dfdd0df5bce6c7405322078c90b87d9c34cba34e",
+      "publicAddress": "055c0bef8d69d8ef5f737116e33e20c379c29751eb6d8e08079661aeb31847dedc3fba0746c6e7e8642b45"
+    },
+    {
+      "id": "07b7a2c5-34bd-498a-a6b3-39cbaa3cab48",
+      "name": "accountC",
+      "spendingKey": "ce6a00c0603d93814cb372910d9e9041b4d20321c5b193b19571e92a4423e4a3",
+      "incomingViewKey": "1e0839db404600464db72c0ef4f78cb0ba5dfcf3cad34b5d106f41303b137602",
+      "outgoingViewKey": "874f01c34db0eaeda480889d91bf604cb5f9a522153bb80ae3f841b7c5000b5b",
+      "publicAddress": "39522a9c433f0850f65e78b56c40d4274952a79df13ebea4afd917984ebae43f9cb0a25f2e8057f7665396"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:PqUT98OXdK/PblJzHpQshlmw1hlgRVaJg1Agrf5z2ms="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1666650751267,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "A06DF8A0E008F81D4C3B4A4256D714F8F8D19B26468020EC8DFACE9C4CEE65F3",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKy2KXkiTY1bh+AyBim7ZXh9QVFfe0726BuOz29DkFl+tX+Rw7/IvTTyE8TwCcouR5i0QcnmjM0dA9YDSjVehIxHUnAMkRz1BBdQt6lrogkuus2UqSJn0Q6+ZRpsuAo+DwNPbecxH30BHykAPOE1QaQPAh0YGicdIR9vkSrd9Q5tCgf1hfyZE+UUJzd7H5bh77MYokjsagh6G1nDcieUVGMpU7YKconQZICJF2ceACR609i16BmdJvoXqb7Gx3xf+zTdGTwz9h5NiyfLV9JdgwmV8ote8VJSutZqrVsk9mWso+VM4TMFnSGS187VtX/ktrqBNJSAMJ0XZ6lUrCA07GwfCVgwx5C2b2sVIv9fai4ZR4Chb+Ki65LW4YgX8oTqj8ZvhNWb2Ww3e0b3qUF5nayrSGcNUx5Uaoj4y1Glra19jYDlXgE/QYH5ekUotamgs08uc4sPYbttDcfSoUFRneSZ6QgUu6+A4xEs3A+hcthWqJgWIyPceicwRoa/AbSoVfMpAkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwejjIFa+K050ucIGpNPMLmxPBmLvMbDRFCDOQFWwV+2CWBHvGYAQpdGFAY/QavT3C7HLphsM1I62qOsElXquiAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A06DF8A0E008F81D4C3B4A4256D714F8F8D19B26468020EC8DFACE9C4CEE65F3",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:dBCdsYuHM7l6pDN9o/o28ytExyS0k7EdS/wo7X3ziRY="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "7D655404A5AA1EFB32B7B073F3D7A6FC6127AB41883E721A588E3DC83CCB23D6",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1666650753132,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "62DAD556F922E648E0ACBFE11A5F03B11E9CC957232C8A881BC25274363B9592",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKaHwIr0anBeDfQbeoMFAX3jPh16fM79Tte2O2LPNYe8GYRFAkyAP3VqDNhWvvuMF7aguP7B00bxX/Kh0vI+qKvpkz2oLD6LeMzrl6rL2E3uIkB1BP1QfRV3g8EvB4z2TAx4rwbVDbjKZ1OGcVO07D5/rMAX7pdSe5cf21IOfcT5sF2Rx8TJNfoDPwT/l+gc0IBCoAonR8wDwbgu9xKsxVjSOefA3p5T70C/B2sFQzPqfNqjOZuBubco2pjJLTaoOEaFN6QQUszBittMhRKSqE8suqoVkwydXHmxerhadLrzQqjnLSETtx5NZiQ42u2GuUWuqOZlHerK6o7fenFskiOPCClHQdnglPLNOcoL4XR3sZlXy8WH5OXaCUgtqhisJMi4IE7DPAh34GeVMqzvZxFMdscg/r8pJcWOAyU9GZXSAge5T/IYSBOhBuBIkq1uu6MJ/c2nlvSL4/t4JyX2xPENt+2AZtUvEzB2yDX7cI6WEyHGvu3lp8smIhkHiamR9WaWsEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxaEv+SCgzmBjqlJaPllXLdNTiN9yNRE/AzjMnBTk0+/K+bgeKzKdwU/Pj6ce31ZVI9z6Zo3F3JOWNW2dq3c2Aw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAJYcB6zjI0x3htrewFCuwchx0F3kzq9rdfWxCbdRPeTOXV1I9MWo4y2OMAT4vmUSNYb5Al0AOmznB5zDRB4xHsTn94gJSgwL17+jKDbNRWYEPeQuHoUgTrdAJIDNem5ngwgtpzYzFAQ+uH8T+F3zhQx6DBmyug7ZOqsIYZvKRMGS4+P8J4nVn3qCjVDzVyHpIqJ0nY5iUO1mEjwdQkco0d+1TUJ7q5o097rSFkBhQIgvxKir4DzjlEWSWWP8kt9H4311jxxnFnW1SFe4rsV7LTWPppcEZrRPSjckEzMGzwxyQlnsw47vjhmyReqwf+tp1ANL1S+jfuCciVRcpFqUZic+pRP3w5d0r89uUnMelCyGWbDWGWBFVomDUCCt/nPaawQAAAD5yKeYg/pc4n6A1L9oarP/E9uy0aYFflsEA/evST4dVB4J8NFD/3TOMHkrp6tyVkpE0jP6nyS3QbPOO7QBKm7ZpoUGFIWLPkv+YwvnIspRWj/ZSx/bxIA8SKfE7NdoFACQwJ25XrzSxY0mq3dqG7bRTRc9Kpr43tB9xUc1Hh3D6f6Yto9fxTt/Qa5ZNuLieTOFCt00D+tO8dk9ovuXy3Gw0wODYBQNpOA1S5580gDleC5Etzgg7bC/MjhAemoxP5YKaAI/cdsFFGAcvY/2DdvRbVgNQYyfoNrGqPI8cZP0zspzeoEZsK7nTIPr+/HQFNuKPdagVZZmUycGPaWdskZmnjM7CxJaAWESgWEiXZNOSJit917jiYDqbITPz5u/YBo++xQEBpofsORLEWvlcdO6aZDKQ4BQsSgNEJTMDI+V1igLOWt1MjzIKDPzpdUENF8ILT34vkO8+EpyvCAvCR45fNHkgBA6r88NsiLJm5YA1q4MrXdU3uHeSxAx/4aNG9QhKEN9brXSwOvQ97rPdstse8CY5BDMsZFypqiInlj4B0BMk3iEoQ3vmfohviCHXuo7hpH8/rz8KrZ6GhsKf5GPOmEAELVDeG4aKe6TMIpLnoh9TAIRoi+Z7aSRrW4g/y8fB47HryI7wdW8VuPrM2yYmkOqs7pKGdlr88hLma36Xr5kSLR5KyMwaQjPI1yUUz/lRkC1i/clBDEst/H5YZCqVIhvibfBIBUmxf2Ap6rYfinswJNayKAUF3TYiAncd6pvdiNYRz/3o6d6y8piMQ/9PR4WkK6xsxpe1mkOb2q8zZge3KwP/PTDh/NvlGGeuiLoLLkggkmngn75gQotjEnGbnUhXPaOXQcnY8dyKgMm+K9Mdg4QXajXt2BCU15qMjDziTfD+9lzAhxA4+3UTU8gwJGN13M3tG7F7zSEyXGdyIJcFa23fZNrNAwrejddvh67049Sgdf3NWYpSbc+PZ8MjmLHRsG40RjV+xC+w8agP4LuRIavO1XrhSeo1o/I3gsGgSg7KWnTvOZFx3t1kOqA3HvozpGuMTSGKNG8cwKCBH6jP5d2kWCmMdDAyKkdsJPjVAtDYvAIk4ibGn3K5z9vXW9YwLIVL4mtwrXZrXBtczKLX0+HvYBmIi6HsNswrwnxQo+oitG4sxGFFyz3SP0OiuoDozMAqgjONb9HaOhjC2rIRjCSJPS1Mf+MMkI1/TT/8FWmFFAiLveo+xPWw7qVOvT8FxuRwsC1+l9BFrPQUlMTz5CmsO5A9PYfKYFLWbBcFXjSXk/FwJiZvBZyyb124QYyMAqZtHl3x631WV/2mHCynsLE+BlQ73yM/x7jS/r/CQy86DZ4GrDgQsHSS8/qRQs9kztSpCwP//9z4VQoDkpQDCRbH8n1YaKln9Iz3MAe0/1XxUI8nRzniwH6TJI/SSe6A3pM2LWAWqcUs7uvMkOmZstfBA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A06DF8A0E008F81D4C3B4A4256D714F8F8D19B26468020EC8DFACE9C4CEE65F3",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:YCjqTWT0nZFqvU+tW60RoRSAmDKlodOUQD3bHe0sLCk="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1666650753336,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "F9017D71720B44BA4849A2ABF5D8AE6AD3024F846E9B8C6C7599D18B78B98100",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKXqRKwosazyq9ydT33SnHE+mGvsugXtkcm5O0wpXZZmJY4goDvUVhxmyNC664h7/IT/LIzXKtjxH59SvbHFCuiNVksrbyaUXc7qZ+DncytsnWeexkp6sEA/n2m/tzwLQBDyfr+TFMvsINJoi4S+pJVt4bKnXtJS1XE7kMOQEEN7bdwnaFU2QOEdqNfB0P1Q0ZCKRsah1muOpI6juVRHRiLhjnz3L2/HCB6uHnIYEo4UvELScHAy+hSdcgKisSHAP8HtDSXY02A82A8kH6YcFIbWiw1NlTDdU6WZcJtpaImbFUaxI0RhzHUVMuL0b8yugfRBUyv8/ZN59ZsWnq+sxGZ/h7VFeZPXARoviWbyshUP+g9cFHA51aBBTr2wXPi+0eth0hc9LBJVvthGiji4P3plmZXUbUAhy0x02wo0f6YIiEaR9m/Ln/8B37jJf/6bFiH9PrAUGNgKUuw4ee6ewiFy6Wm55QiU/Psa3bf6gwhFEfOsd455XY2Jow+BnjFeLgejBUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwiIxQCXoPU2gZb3axcOlvtNgYSCQFfBtt7c6Z1vHN6M7hM8s6i1K8jphYFgHgdz20Die0TO2yLHepJyS/8bXyDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "F9017D71720B44BA4849A2ABF5D8AE6AD3024F846E9B8C6C7599D18B78B98100",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:7b8s7KKmMBjeK3XW89eBUMz3tfXX25GDbZzAYoAc41A="
+          },
+          "size": 8
+        },
+        "nullifierCommitment": {
+          "commitment": "45A2AE82F6123985C515BBBA7010DAC25CD19FA11585B23E7D65DCA33BA37E48",
+          "size": 2
+        },
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "randomness": "0",
+        "timestamp": 1666650755209,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "298C6B98FDD304DA97013F4FE9D211517C13B2205DD5C548A92DEAAEF5FC6424",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAIMLk0vmj5rzeZKI8C3Fe30gV0+iwUzngcdjUQfg0SsJ3OXu8ES/jEn4KTv1//FFSbQsWfvj1B2TEttn4JhSBLTq/rm8cuV8G7t9z8BmBJol/YP+pd7CCnRti2OrK1FwAhj8gArADROHRYN0uDcn2n0fbkxomVPm7vKd65AcaN/6yCX9k/0EeLchBy1PZFd7CIC8axC3b8du0W6bEVY85OLy80MgF7INj0FWZibcOIMWmcHoFtuuiEwcQWN5MgXNjRa7Kjxy5NQnZyUjQrP64NxYzQ/POfKp6hWS0ZOc2thOclK3W+kJsdQC/4ymVqjC1llwU43hjY9kadWgko/vWAh757ilUANMMZBfuAnJAglqRXdcpEZeNL5e9rePRcnGF3c2wSTKZUCJxzu7O4N+qj+B9mfnZQYC+whLYtR76KB27nc9eJnkuw8SQvlceaEhd7pwfsyBvTYV+o4bZBI2yBctY+0RE/L5dd181+SzNklZXWBZcoRIB0XRONMDxCeU+SVx/kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMNH70IghSsPP9ZIxj9zaQxojqQ4Zuk4wy65CapfgToF2Sg9iEATWdSbzUtCSb/qK9RNZctW52e48LKzZihO5AA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAI30pmLUm6y97z7mFX6y6D9tyjPIvJJ3+mlncmRwYjvQVLH1wr3gNNUCjyBj7eH6OI3yUKJ2kHfx/q+mD+auG0uiWhtKjfdZ09StW/DYu6qaSD0mabQ0NPyEX/WUW8wV2AEjcQ8coVwcB2I1D+nzqpqIJoX+Cu7/BeF3Qn+Oko566oVwgzYUQFNvAabTi6nZiJDgOJrLJg4mRNlob/XHxMxSG5rnM4hkwq/B+B744qDR3PHAauVZQabCq5EjGxxIm3v2NzRYNcx6Qf54pcmbYbMRK7nIxfBDne92YUq5/EcQpmX797zIr5PNcG7I3Yb9SjpoEiZ1cBGeSddjeeJGHs1gKOpNZPSdkWq9T61brRGhFICYMqWh05RAPdsd7SwsKQUAAAB9IU7jIKhjD+Sn0UN7rRLuyDJeyGcOts16zwCTxatP3ZSXyc7RSNEP0Pub5fuOx0GwrjKKNktCOZI8WmjjTeOubNKGDFFOzVPpf/+53J+CLxX6L1+1CQaea2bIJDfrigmVrxblSvIRdlSh8+lyxsX/OhIW3KGQggRFoxispCHCUXzoGkFQB8aiWAveg9yQgzKrktt+Xu2QOu2/zTSgDghdLzkiAnzlb0uX263BZc6dpTkBpuEiNgtuOpm3u7fdFuIPRNY0JABfXPd2OcLngFiCTaFbgSQyO9y0Jd0fjEbC/wfXT3RX7+wKtbrX1Umfv9K4DTbDVU+AAgW/p8Mi3MijJ0dKi5G4n8iXIYWImKINjzMe3GAQFDPXd96bNnLL+uAPjvYoiqnDnEUfIC1gmhm7LdOtr9l1+doYmZawQvuPuzP4hgdhTiozwkTeyhCCkpdi1Mx18ualmybeLVtRmVgfgKsjDqNh4v2di+HLUuxjuy4PpN9o6XdQcbF1WC+xoRw3bG/qwp2J6ZZx4h1ePFFRYKV3J5ZD2et5gKliE8k+koLK7BeqgcE3cPeu0klkvqXyaqQPicZKfiPVAr1e3s+DDR9dGJPBI855wN+Im2YsgiQTapvokuduYU/MF2k0D2YxwGYQHqxCnJbYzHYspP+ndZczIjm51UFEFP7GHnrgP4lTqueXhoBg+sYXvG7EvsA6elpKCy6jx7TraIIU6SJ7T7RA0xVLBdhuL5dGgRfzMpmnO5YoO6pNnuJqaUWJxh6PUmYScfDjoR/7xdGnurGJO2BtixBtxKdazBCRwMjMevlZGrASgr4YjKIgOXfrswR9BhR1lbw+qnnpFA84IBL7ntSEpVHFmjUQYSdf/al1tcvPrBfFIFGvUcNeh2/FgLEAoA3TI1uL6EgoX2S5+1Syxb6N4s+3I5vKAgdPVeUOaBVm/KL6VXl2yEK62Rwa6qNJio3/39Ilo6NDC92x5I3/mcZDh206nHT43aiqioCGMc1XtBbNPQWVnPbBmOie7dQghhqMtYvgDrPL2KI00qQ7nVBj3ciHTqSpN+7f0xI2eU+d4knjCL3TmQt9unuJLlM/VQFOKbYa9iqgeGDJJQK29wm8U+Cr1L8tr4wazxYMFILbgU7nwDYMqJA9sygX0un9CtBmqIAv+Cw7jiN7O/KTbOR+CQmENgq5mzC7zJof/iZovULpmJLLh7VldStjuNrhDxNWFDrPC5iBnEi2+ggX5Bs2hX5lws8AHJm3GYnXxSrR6EZRYQM0tnl64+Xaf6DOE3MhnJz+Gr+3rDzHusViH50ffdjeWNjoN44YN+gzi38Z3SZioKVTNdrjXwBWxyUGCpzR96urGwWuIFfdUXa1Saj5zGKJtVeiMfPfZYIvfZAQUqMl6Zd0gSlvVzs4XY1h3H9oEUl/dKFe622ofztKYPECrcUkEKSima0I2c4yI2mtUy4ICA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "F9017D71720B44BA4849A2ABF5D8AE6AD3024F846E9B8C6C7599D18B78B98100",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:cE/18Zp3y6gEROtMmrykrfQfopHuOuoua1+lIjcUrE4="
+          },
+          "size": 6
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "randomness": "0",
+        "timestamp": 1666650755467,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "7AE778A2E8FFDC798600F1F045096DB96B590C29C666347B0E0D660D05EF87AB",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI7nDzIIqoIu/kDUN4WD7xIH4urpbSzUYTyCZbNnop1SK1jdXY8umi0JUFvXnU7aZZbnH47e/ffg5p24Sc+LI7n/U2GmsM/wUnfO9RGC/6N7aHD8BCJ3XOLqakhvCjCc9Rezb80yWPGQlu/jArL5TT7Ob2VkaD4L8FiJHzI9qD8tIW9SQ6TirHz7mBPRRvJglKkhlH9fob5jB1BDb1DLe8K8S34TvCAliA3jug2fJRSdM6fnRYrQhajeKG8DSGMEf075aieNJwZ2k8pUz7KR1HvEURdlI1/G8u6mb26s4OdNGsTUbrrghfukoYwgaKJ2RWPI6H2iv5/hcIpPACCtxSUvcf3A9xgzQ5C+KsttJwehkoLgAvQ+4Jm5YI5KfidqK7dGoQMnfs9aH/l24HMkRHi+7DbZ4x1XMJjyWWRLa4aADS+He8Apv/OXOqvWCAmURgzpSdE5vbml4CVodg/rh4+oNOb3xtsb2VdOI2S6hEiKlcqETPuQtK1qJ78UlqtKSjB3mUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw7Z1+2qNUOB3Ahd1CRlcPFZtLUMmOmJCvs+P9g+O9qsSjQ6A0tCaM4Eg5/aEcIP6kof1WvteYe9OcemhGqdgoAg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "7AE778A2E8FFDC798600F1F045096DB96B590C29C666347B0E0D660D05EF87AB",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:icZWIaiz5V1c0ca94UUoGYp/SgCKI5gZc3b2gul4Ohk="
+          },
+          "size": 9
+        },
+        "nullifierCommitment": {
+          "commitment": "4DC5E5C21DBDBFF2C232A75C46F6B0D4626BCF83C0C1A94F561D351951F7760F",
+          "size": 2
+        },
+        "target": "12072817207853498844696253586895361112250465582177476158256282062",
+        "randomness": "0",
+        "timestamp": 1666650778250,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "0E402C3AD17096441D3364E35C60400D077DE4D300BFD24B37B6887F02D4D422",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALji13r3cLurIJETVeSEJ2bH6ecsSM/8HmL4dZsOmok3F42LXt8b/d9zjOequyVBq4mkT87aTz2XjCWzJgkPQxVRIp6tKoycr95ZZgKxIfgwKANOqEnmdmEjn8iAZu3lsQ9CDK5F/e4eEELCvoOL2V+nmgAJu0Iz51wDWyKcT9K59n36eNj3zC14XZTEN6W/5qTYIiTX/bcE9orotV5ZxQ0C088qhZgO89ypE2YEyogrMcILB3VJY56PJyRypvWIJWkSdqVLQXJwn276c2nS5CqU7C8j7pSjX+SUXxQngGqOu1Gw0RuUw6uqDEfB+HRPu9TwYitlk10Yjs0FxeQfL1nHwxdMPna+Dj1sfJ7Qc6OgZtGUId6lFDjlB5Y2QJVjOu5L7l8KzNgHrzdkqBK9y21HBYe7RJ5ThzTWmNboZO2StUCCrUVyKu2sZNlK3M4VCs5gQgoY1zbIX7sS172JVfL2kh4HJi86cTRhykNb5++WZGUBxLLakQuUAXY0/kwiqSTBEEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrVIClQWmJ2aT5CgksN5UTTWot2wtOs4UZ0Z8AxapDD7Yzufii27XPd0xFWXke0bn8YmlyPlYYOBpZqi1sWpcBg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALUajI9YoAfulsvZM+kuLDAMM0hAjNxiqV9DDS+kfHnrjs8gB3JiY1eqZgpkWxOLNrcSwTjueCmUgE+l037njWjbUTd/RFzPyxInTNmyGvSYyjc43sYOBryC+lHMHT/KLQANV99/c4WOCHlU7mljgDiWy2swNn4ogKe8MHAa/yEtSJ06kb1WfL/uPqkw59Qks4d2F5hzxGvWohgZ0BxuFRkxf3W8otOq4Yv/Tzv5Q9syA+Tr2KS2HxeIMb30LxMwU6k0Mr68eummKHULyhfphmI73eUVd1he0aX+alUI+shYLPfiADSmMkDOFevg9eM69DaD9C0a4fwILnm6JtRna5BwT/XxmnfLqARE60yavKSt9B+ike466i5rX6UiNxSsTgYAAADGaQ6pf96YntFGRF2Dk34YLz2e+eHPANa+thNrvzTsdcjWf+4DYDoh9ehUCWFPesoR6cDiLRd1CTNOyufgYrJpAPU2IZrzi5/TFfruaDsCxrBT6+Ez3H+Ky7iO7HSVAwWx0k/KnUldGOGTTZgWKWVwKkYxQGIA59SrQ5l48i2sH3dhHft66kqNc+DIpeciTn62DKc0/u1o8k4GkDaf4TmFsK+Z8qK0E3BqMKeBgbRdXKhHoqfvDcOQNe6yQvSY++IALOo2WWuhcwjW4s4KldXmgzVPG8zimc7ph88z7yNS+ff7tfGUtC7zRpuvvuRuGzWM8l8B3RnNGtzXDTh9KA7z8PLDux4rnIQUi2B2YPzh99N52ZNRatfMPmINSddeWoQO6k4k5gims5fzzSv4hRF/z8BeEgrFEW4TAMRyz77nJhympdBmdJtRMNHbF94qsbMjObnVXFEIG9rI76Kz0npUUiNcYUAU0kDyBPGRhskUHqSfE0Xc/lzSdpcVn4XpD2RhZ2HyI6+qjcMnRtT0LFw2Q/0QEVrS+yUD9jE1OMvhcS/ixXGK+amSkcoSJVN6ZjtUyjq6KWngZu+vafNFvTedmZIidX1O9YYhag3FbkrVUcq4ZpUpsW4CkulOEKNcTzrTTA3eDw5ibbV/R6srRik5dC1Wy3NHln3an2bQYSWqJl3+rtr/7yWxPxCifdYxhDbDl/PRhkWrQ5PtPw0+UiWovORGaujCS9eGJwmPT4C2vWDRgpd77Usl8s1nG6YhOcSyYvgF3zv3jOx2eET7ip5OZ2JsribJJtHfFOvSDHIAJ8Csw5S0Siq84aJI2jK6CcLQ4ahTB/b6/3lYnY1SHDMDHTHtQODRlQIyzWPl183xiNxdtgByOx2ALijVpcLq4pMp+5yrT+IVKKD2u18ZBzwaoUYl8mh7DCsfc7XrnXROgpRvXqWnBdTWb8pDWqcLu1TSCh9n/tAlrEGiZNGjzVAYpkNnM5KqmxqXQpKRucFA/OK5rIk7za0FybswHk2wU5nsTUTUBxmMYoVhGwUDwLy5bXXOeV4Pe95Jr8QrDzFNIOvrZkxpER/SOekw2nA0w7df3BPxWAzcO7BQEIMZbkqz1t3qyPMC8t5gJYAmCDHmIEcbJ2A9xzlN32Nx4fG/0QL0z5es8KaS4bj2CfIsLoUy0c54sJ/AgaPEca3GSXvJ6m0WWqzGcVtsU4LCXkYKjOOqEddj9j4FgvDnqhC7wLRlxYfJyiEb8bloYV3hc7da/olJge0eWrLrifTaQrwAdPQCJnXsTMw7eiJSikFCAEznjQzyQ/a36mczW9//CX9GQwUsN+vjVy+tVbUcr08+Mm4CRydfEeUiLmCGMEOymtz6axVLhmaYGWEcHz9iHJbyaON7xXujeIC1xoaBunKRLPRr3rVFzFRlwn0TMQdoTXPCPknUpe65Ga5WzU6JVOFTTHNvHElnDg=="
         }
       ]
     }

--- a/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
@@ -2055,5 +2055,87 @@
         }
       ]
     }
+  ],
+  "MemPool acceptTransaction with size larger than the max transaction size returns false": [
+    {
+      "id": "720595c9-f63e-4b3b-a34e-7227c2d81645",
+      "name": "accountA",
+      "spendingKey": "a5584530958a73b0360bc2bf2aa7f1ee2ed12273976002c0a8f4e602f59791a2",
+      "incomingViewKey": "f5be01d49d2463a5cc937981d6488a7483b785dbab47eab7ac3be53e0076ac07",
+      "outgoingViewKey": "be6790d872cbbfe658f7dab1107e9c63436c05dffe7eba86f15b218b3fcdcc22",
+      "publicAddress": "361f2a32d9d8a8f98a5ad5b7f271aa7dbfada1a930c4b9b7326e3370db33ceec9cad0e46f71e964172fa6b"
+    },
+    {
+      "id": "ed63e72c-9414-4d6d-a099-86c6e09ffc98",
+      "name": "accountB",
+      "spendingKey": "a422e8d85df0fe6a7d8d3c53edef85bc879ce2b0f37b03309391eb87a4ad2b2a",
+      "incomingViewKey": "3f9f456bb7c56e882a4a93fbfeecc4bbdae4a47a63557ef4a030b16a8fda2404",
+      "outgoingViewKey": "667b62de4217626f5b0357f6b04122c15245671fc8a59d98cb08f65da8a21cbe",
+      "publicAddress": "6d16608ef18d6e3c2f3bc2107519ec7919040275e13fcff7fdedc477a501ddac5b718dc1549e4d26a59e84"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:cx+GI0RJXDWczqm/g7e/YKyzwUM3XSq0tS07P2vIt1c="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1666711885067,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "4645E68FB06E701A18DDFDA8C3F620CEA8F68AC00D70F140DF16AE4A3B4CE8F3",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJjCFsJikOVOvg8QJkAnuY3CgdIssNzsgXCUBV5L8FeOgsAC2tPT/1jdpueOeIQ7JKVlq+R5O+GblMbuAJm0cVmH8kiJs2ziUAABEC15iXZw+ONONVcwBybKxiC3332ZGwaj+ug5EBj66uIkXOSvKJzC9ztlltZAKV+MzKuR7v3r7ph3NX6AMcie0mXz7qKfhYPe3GkrLr4Zx5rn/4Y6/XjF2w47nWuKwbPq7eTCZecNIvvQODqGmLtZBB+Tvg7otPEEovMGrtoSJ2FcvSX6ORJ13EkooiRl583pJdH1g0eBfaXqokCDJmNfokK9SEZUEvFGBLb8ldMe3r8B5CIUeksoLvHw8FrKVJszAF+BhMemlHuwvd9lu3fn93xdKkaYWB0tgP+g46YG2XjeOQtsl3jj3Z3jfBXSgtMF0maTSWrGGIkJ5fSjSrEvTnOb3zWI/6XBxJR8OdMfp9wb05dYG+/2rjq+19IP4HpjplX9YfAsXWrGpmdyiXeCK2e3M5uNm37VLEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwPs7+oUdBC95fAZ94ID/OdloxJha6mugxid62+4ZLyXEoNYJWzZf+wHQjXBqITsQUdN2yIKXR0UIWhDJ4eybEDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "4645E68FB06E701A18DDFDA8C3F620CEA8F68AC00D70F140DF16AE4A3B4CE8F3",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:XJVlodJk9ZG/9i9Vaju8FttQydFL5P2bItDnhfRZTQE="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "492D768F9A11A923BFDE2B3920DEBDE04D870BAC12219FF1E7D417180EB6EE08",
+          "size": 2
+        },
+        "target": "12173322083836338232381095783090484055304812721852659705310015914",
+        "randomness": "0",
+        "timestamp": 1666711954970,
+        "minersFee": "-2000000001",
+        "work": "0",
+        "hash": "4DBB99D314E138602FB72120187B8695AAAB58EBC3E6F54F5D2158D13CCB4A27",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALEWxLUFb1+5ju55A3afssDWY0cw+skwtz1khm9YZbASyKMBmOPVKbABrw6p+d6xRLQv6qFtpbns9MSN66W/4KHDWEtTYLIARVi0/0QRHIu8ldCTY9jfPbuc1jpEZ5PoaQH//JcdhLAeyCgAX/MVAlZhC4wP1p0WB8jjynfr+a+nRJ+Xw5GAfeD2x/WmzEceYIN2uEW6LGf7yjr8MpM4SSTx6fo5pn33fzkP4lqIeGcrr3M0BgBGjOgOutHLkjzF7kQdTOqU/rTRstsoAGi2S35w1wZ0NOCLALntzVtjUzGmgDQ5uQJpq3a1NqelJ/Ng6IqRimdl08bTSZ6bA43q0z1yOLNmEmgezgbM+ULwt6BHEiWIFsYjTzuJJml+KOwjmtzKU3Y9XdRsO9G7IhBI4jc5YgmLnK4B4YZkAS7wAEddSyPCPHF70ohezHvZjooHVlrHjnNnAEDWF+CddeZSx4BqkkES/TK5j/tN3cnJ9GNmoPBYXH+eUc0IzOag8B53x5/XlEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxRd9c49dqkGoUi5iNkzTq/MleSnW5nQDBLcnqhoD3JXw2LgBf4ML8DLpsev+Wgm2+W8srT3FNEiU8SJlOB44DQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKO0gNuRBMDhpN9Pbd6HBzccuXGV9h4ipCxm5eZbbadYjvzxgAjfectTnG+JZoYvnYbJp8K4bMF3UmVq+4gGGw/Zn5XlVl56ePmVH3mK9/k2Gye4FyB/YdWocnwhjHYrgAKPwquzmOFAc8pNznCCKHpXjbEH1AR4MPYray1iFUzEncSWiAk4zWsvf3PLkXDfP4Eal/+zEm6FpqdSKIVHuDJSThtl/FTG8xPaY1SROB0EOGmXsZ5qF9B3f9EWhLZjfthRabqHglhFMIY5g6gejEjBQx+Ucf2A2Ia80xQctiBdOUIuix8NEyzZm7EkpphZ9U/uSZT8FDfO0/M3kP7UjyRzH4YjRElcNZzOqb+Dt79grLPBQzddKrS1LTs/a8i3VwQAAABmojUynCR5cSzILcFf54W/7fEA6XwXrYa3xnxTgvOzgYTyxmkQKlrBZEMic3eSZ8HYhKzuXqiED+rODGprxCCGbppv9ElEX7DRtFSUYy17f2GZXB8uUzDYXgLmgXQDsAqTqkuOjaoqKRuhXcyX+zn/PWuEShl1nmnP/5J/1NAcjjHBungShfZH9OmI4uf7MmugLMS6y9+HwRGhuMYcUhjdmjqDqHz/GMuPst2Y8cZl5szlKHet9LIGD8is/k32bVIJf85zM2kA4TPC6mku4Ydn4THg1gz7vjQoo0yZO2Wyq6ZiVC3seCqyhMrA8WL4sRmY/nBwSwMh3etF1XiPpbWiCXQTYqgJOvyMGiHJR3p1/HIo7uhNFIyLzJVjDZsIHskdJk5Paw1I9UzP6zoIrE6f6vWNrVifI/EDpQUjzTkdRJS5o7Xtn0neg3hEe1TTHjeFQmQrNiw6b1SBWnPB5aRifDBhvo+z+uZKen4LquH8sMUhHHh1xHZkCaqf6tSlusFU8m/9JJHsdCdewezYcvgvXcGYFKIUPV/TvTtcXSxpuUDB4thSdbadbwjBqB462ZtZDD+RytHQEuzz6mT4yiZ2ktjex5YKuoMAF8LIrP8L8q9vxlx1znvu7iR6yL124dFKcbqmWOICPbBzhXOLYvVhqTfpX3gGB+/uOMNr2BC3b/7plHDCpTshHtwPVWMWZsvLAsDKrxqIJwihP0pYDGkV8A2ewjCDm1/Lc5T/w7q+fovz05T2RzL67nHwnZq+a2YP4lGOFmff62u0kpppJLV0FTQ+aK25go7Cw+hbeT3DbLdWZZQCf5OAauXe/eu9F9V8MNKGch+M3z0DXsv8IiXJIZs88CgYAClHnueyKIiUlqDdDAbS4gBKfhIfCgJl+WxDb72p4XdvGo9kCFBAkGry6Vvh/mjR8PDyfoDDyQuWyiUaPaGQkfe4GVVRJYEJUmKc44usYtWMopHe/PwWPidZaZzozfyEhrKmbWGhDtweL4VCyOhwdeThEPsw6En0DWo3O2RQW+2lW8xfCVY7jDm7s0soQIJcSFB6IUk+DoSrr6caB4Vy3DuqXpe+BLGhodGuqgpSudZaV8zHa5B+SS5cMScNIycSuDmFIvTQaIavwjwQUiHD1UKE7oncU4HqQCk+HilZz9oyVL7q+mif9/PVT78U7Oj+5N6oOyLobka0HCJxr+T7SfB0Lh2gRJmdKg1Cjfc2TWGCYnoKJp72TrABc/pcxY9cdBsb9q8P60efbDbnEGbCTfCo1qNjjnGZcQa8/LUXkDg+31T5BjTGrC1BgpOTPAySiCBCKrSBL5BR+8U7x8UvC57WP4dylU1mLpWSbxL4q1RiXP3AWafgCAYcM3sPWIH4X8Ghq07FVy42hSc3a9mWg/dgjN4E404XoOibSL/7vR4JWxVmnaaojKeaMjncin2OOOgZMWyYQ6fogc2faCFBAw=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../assert'
-import { getEmptyBlockSize, getTransactionSize } from '../network/utils/serializers'
+import { getBlockWithMinersFeeSize, getTransactionSize } from '../network/utils/serializers'
 import { Transaction } from '../primitives'
 import { createNodeTest, useAccountFixture, useBlockWithTx } from '../testUtilities'
 import { getFeeRate } from './feeEstimator'
@@ -167,7 +167,7 @@ describe('MemPool', () => {
         const accountB = await useAccountFixture(wallet, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-        chain.consensus.MAX_BLOCK_SIZE_BYTES = getEmptyBlockSize()
+        chain.consensus.MAX_BLOCK_SIZE_BYTES = getBlockWithMinersFeeSize()
         expect(memPool.acceptTransaction(transaction)).toBe(false)
       })
     })

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../assert'
-import { getTransactionSize } from '../network/utils/serializers'
+import { getBlockHeaderSize, getTransactionSize } from '../network/utils/serializers'
 import { Transaction } from '../primitives'
 import { createNodeTest, useAccountFixture, useBlockWithTx } from '../testUtilities'
 
@@ -110,7 +110,7 @@ describe('MemPool', () => {
         accountA,
         accountB,
       )
-      const transactionB = block.transactions[0]
+      const transactionB = block.minersFee
       const { transaction: transactionC } = await useBlockWithTx(node, accountC, accountA)
 
       const transactionASize = getTransactionSize(transactionA.serialize())
@@ -170,7 +170,7 @@ describe('MemPool', () => {
         const accountB = await useAccountFixture(wallet, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-        chain.consensus.MAX_BLOCK_SIZE_BYTES = 0
+        chain.consensus.MAX_BLOCK_SIZE_BYTES = getBlockHeaderSize() + 562 + 2
         expect(memPool.acceptTransaction(transaction)).toBe(false)
       })
     })

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../assert'
-import { getBlockHeaderSize, getTransactionSize } from '../network/utils/serializers'
+import { getEmptyBlockSize, getTransactionSize } from '../network/utils/serializers'
 import { Transaction } from '../primitives'
 import { createNodeTest, useAccountFixture, useBlockWithTx } from '../testUtilities'
 
@@ -170,7 +170,7 @@ describe('MemPool', () => {
         const accountB = await useAccountFixture(wallet, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-        chain.consensus.MAX_BLOCK_SIZE_BYTES = getBlockHeaderSize() + 562 + 2
+        chain.consensus.MAX_BLOCK_SIZE_BYTES = getEmptyBlockSize()
         expect(memPool.acceptTransaction(transaction)).toBe(false)
       })
     })

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -160,6 +160,21 @@ describe('MemPool', () => {
   })
 
   describe('acceptTransaction', () => {
+    describe('with size larger than the max transaction size', () => {
+      const nodeTest = createNodeTest()
+
+      it('returns false', async () => {
+        const { node } = nodeTest
+        const { chain, wallet, memPool } = node
+        const accountA = await useAccountFixture(wallet, 'accountA')
+        const accountB = await useAccountFixture(wallet, 'accountB')
+        const { transaction } = await useBlockWithTx(node, accountA, accountB)
+
+        chain.consensus.MAX_BLOCK_SIZE_BYTES = 0
+        expect(memPool.acceptTransaction(transaction)).toBe(false)
+      })
+    })
+
     describe('with an existing hash in the mempool', () => {
       const nodeTest = createNodeTest()
 

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -7,7 +7,7 @@ import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
-import { getTransactionSize } from '../network/utils/serializers'
+import { getBlockHeaderSize, getTransactionSize } from '../network/utils/serializers'
 import { Block, BlockHeader } from '../primitives'
 import { Transaction, TransactionHash } from '../primitives/transaction'
 import { FeeEstimator, getFeeRate } from './feeEstimator'
@@ -131,7 +131,7 @@ export class MemPool {
 
     if (
       getTransactionSize(transaction.serialize()) >
-      this.chain.consensus.MAX_BLOCK_SIZE_BYTES - 562 - 2
+      this.chain.consensus.MAX_BLOCK_SIZE_BYTES - getBlockHeaderSize() - 562 - 2
     ) {
       this.logger.debug(`Invalid transaction '${hash}': larger than max transaction size`)
       return false

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -7,7 +7,7 @@ import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
-import { getEmptyBlockSize, getTransactionSize } from '../network/utils/serializers'
+import { getBlockWithMinersFeeSize, getTransactionSize } from '../network/utils/serializers'
 import { Block, BlockHeader } from '../primitives'
 import { Transaction, TransactionHash } from '../primitives/transaction'
 import { FeeEstimator, getFeeRate } from './feeEstimator'
@@ -131,7 +131,7 @@ export class MemPool {
 
     if (
       getTransactionSize(transaction.serialize()) >
-      this.chain.consensus.MAX_BLOCK_SIZE_BYTES - getEmptyBlockSize()
+      this.chain.consensus.MAX_BLOCK_SIZE_BYTES - getBlockWithMinersFeeSize()
     ) {
       this.logger.debug(`Invalid transaction '${hash}': larger than max transaction size`)
       return false

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -7,7 +7,7 @@ import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
-import { getBlockHeaderSize, getTransactionSize } from '../network/utils/serializers'
+import { getEmptyBlockSize, getTransactionSize } from '../network/utils/serializers'
 import { Block, BlockHeader } from '../primitives'
 import { Transaction, TransactionHash } from '../primitives/transaction'
 import { FeeEstimator, getFeeRate } from './feeEstimator'
@@ -131,7 +131,7 @@ export class MemPool {
 
     if (
       getTransactionSize(transaction.serialize()) >
-      this.chain.consensus.MAX_BLOCK_SIZE_BYTES - getBlockHeaderSize() - 562 - 2
+      this.chain.consensus.MAX_BLOCK_SIZE_BYTES - getEmptyBlockSize()
     ) {
       this.logger.debug(`Invalid transaction '${hash}': larger than max transaction size`)
       return false

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -10,13 +10,12 @@ import { MetricsMonitor } from '../metrics'
 import { getTransactionSize } from '../network/utils/serializers'
 import { Block, BlockHeader } from '../primitives'
 import { Transaction, TransactionHash } from '../primitives/transaction'
-import { FeeEstimator } from './feeEstimator'
+import { FeeEstimator, getFeeRate } from './feeEstimator'
 import { PriorityQueue } from './priorityQueue'
 
 interface MempoolEntry {
-  fee: bigint
   hash: TransactionHash
-  sizeKb: number
+  feeRate: bigint
 }
 
 interface ExpirationMempoolEntry {
@@ -53,12 +52,11 @@ export class MemPool {
 
     this.queue = new PriorityQueue<MempoolEntry>(
       (firstTransaction, secondTransaction) => {
-        const firstTransactionFeeRate = this.getFeeRate(firstTransaction)
-        const secondTransactionFeeRate = this.getFeeRate(secondTransaction)
-        if (firstTransactionFeeRate === secondTransactionFeeRate) {
-          return firstTransaction.hash.compare(secondTransaction.hash) > 0
+        if (firstTransaction.feeRate !== secondTransaction.feeRate) {
+          return firstTransaction.feeRate > secondTransaction.feeRate
         }
-        return firstTransactionFeeRate > secondTransactionFeeRate
+
+        return firstTransaction.hash.compare(secondTransaction.hash) > 0
       },
       (t) => t.hash.toString('hex'),
     )
@@ -97,12 +95,6 @@ export class MemPool {
     return this.transactions.has(hash)
   }
 
-  getFeeRate(mempoolEntry: MempoolEntry): bigint {
-    const rate = mempoolEntry.fee / BigInt(Math.round(mempoolEntry.sizeKb))
-
-    return rate > 0 ? rate : BigInt(1)
-  }
-
   /*
    * Returns a transaction if the transaction with that hash exists in the mempool
    * Otherwise, returns undefined
@@ -136,6 +128,14 @@ export class MemPool {
   acceptTransaction(transaction: Transaction): boolean {
     const hash = transaction.hash().toString('hex')
     const sequence = transaction.expirationSequence()
+
+    if (
+      getTransactionSize(transaction.serialize()) >
+      this.chain.consensus.MAX_BLOCK_SIZE_BYTES - 562 - 2
+    ) {
+      this.logger.debug(`Invalid transaction '${hash}': larger than max transaction size`)
+      return false
+    }
 
     if (this.exists(transaction.hash())) {
       return false
@@ -241,8 +241,7 @@ export class MemPool {
 
     this.transactions.set(hash, transaction)
 
-    const size = getTransactionSize(transaction.serialize())
-    this.transactionsBytes += size
+    this.transactionsBytes += getTransactionSize(transaction.serialize())
 
     for (const spend of transaction.spends()) {
       if (!this.nullifiers.has(spend.nullifier)) {
@@ -250,7 +249,7 @@ export class MemPool {
       }
     }
 
-    this.queue.add({ fee: transaction.fee(), hash, sizeKb: size / 1000 })
+    this.queue.add({ hash, feeRate: getFeeRate(transaction) })
     this.expirationQueue.add({ expirationSequence: transaction.expirationSequence(), hash })
     this.metrics.memPoolSize.value = this.count()
     return true

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -105,9 +105,6 @@ export class MiningManager {
       }
 
       const transactionSize = getTransactionSize(transaction.serialize())
-      if (transactionSize > this.chain.consensus.MAX_BLOCK_SIZE_BYTES) {
-        continue
-      }
 
       // Stop adding transactions when the addition would cause the block to exceed the max size
       if (currBlockSize + transactionSize > this.chain.consensus.MAX_BLOCK_SIZE_BYTES) {

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -11,7 +11,7 @@ import { MemPool } from '../memPool'
 import { MetricsMonitor } from '../metrics'
 import {
   getBlockSize,
-  getEmptyBlockSize,
+  getBlockWithMinersFeeSize,
   getTransactionSize,
   MINERS_FEE_TRANSACTION_SIZE_BYTES,
 } from '../network/utils/serializers'
@@ -145,7 +145,7 @@ export class MiningManager {
 
     const newBlockSequence = currentBlock.header.sequence + 1
 
-    const currBlockSize = getEmptyBlockSize()
+    const currBlockSize = getBlockWithMinersFeeSize()
 
     const { totalFees, blockTransactions, newBlockSize } = await this.getNewBlockTransactions(
       newBlockSequence,

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -104,8 +104,12 @@ export class MiningManager {
         nullifiers.add(spend.nullifier)
       }
 
-      // Stop adding transactions when the addition would cause the block to exceed the max size
       const transactionSize = getTransactionSize(transaction.serialize())
+      if (transactionSize > this.chain.consensus.MAX_BLOCK_SIZE_BYTES) {
+        continue
+      }
+
+      // Stop adding transactions when the addition would cause the block to exceed the max size
       if (currBlockSize + transactionSize > this.chain.consensus.MAX_BLOCK_SIZE_BYTES) {
         break
       }

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -10,9 +10,10 @@ import { Event } from '../event'
 import { MemPool } from '../memPool'
 import { MetricsMonitor } from '../metrics'
 import {
-  getBlockHeaderSize,
   getBlockSize,
+  getEmptyBlockSize,
   getTransactionSize,
+  MINERS_FEE_TRANSACTION_SIZE_BYTES,
 } from '../network/utils/serializers'
 import { IronfishNode } from '../node'
 import { Block, BlockSerde } from '../primitives/block'
@@ -80,6 +81,12 @@ export class MiningManager {
         break
       }
 
+      // Skip transactions that would cause the block to exceed the max size
+      const transactionSize = getTransactionSize(transaction.serialize())
+      if (currBlockSize + transactionSize > this.chain.consensus.MAX_BLOCK_SIZE_BYTES) {
+        continue
+      }
+
       const isExpired = this.chain.verifier.isExpiredSequence(
         transaction.expirationSequence(),
         sequence,
@@ -104,14 +111,7 @@ export class MiningManager {
         nullifiers.add(spend.nullifier)
       }
 
-      const transactionSize = getTransactionSize(transaction.serialize())
-
-      // Stop adding transactions when the addition would cause the block to exceed the max size
-      if (currBlockSize + transactionSize > this.chain.consensus.MAX_BLOCK_SIZE_BYTES) {
-        break
-      }
       currBlockSize += transactionSize
-
       blockTransactions.push(transaction)
     }
 
@@ -144,12 +144,8 @@ export class MiningManager {
     Assert.isNotNull(account, 'Cannot mine without an account')
 
     const newBlockSequence = currentBlock.header.sequence + 1
-    const newBlockHeaderSize = getBlockHeaderSize()
-    const newBlockMinersFeeTransactionSize = 562
-    const newBlockTransactionsLengthSize = 2
 
-    const currBlockSize =
-      newBlockHeaderSize + newBlockMinersFeeTransactionSize + newBlockTransactionsLengthSize
+    const currBlockSize = getEmptyBlockSize()
 
     const { totalFees, blockTransactions, newBlockSize } = await this.getNewBlockTransactions(
       newBlockSequence,
@@ -166,7 +162,7 @@ export class MiningManager {
       `Constructed miner's reward transaction for account ${account.displayName}, block sequence ${newBlockSequence}`,
     )
     Assert.isEqual(
-      newBlockMinersFeeTransactionSize,
+      MINERS_FEE_TRANSACTION_SIZE_BYTES,
       getTransactionSize(minersFee.serialize()),
       "Incorrect miner's fee transaction size used during block creation",
     )

--- a/ironfish/src/network/utils/serializers.ts
+++ b/ironfish/src/network/utils/serializers.ts
@@ -13,6 +13,10 @@ import { SerializedTransaction } from '../../primitives/transaction'
 import { GraffitiSerdeInstance } from '../../serde/serdeInstances'
 import { BigIntUtils } from '../../utils/bigint'
 
+export const MINERS_FEE_TRANSACTION_SIZE_BYTES = 562
+
+const BLOCK_TRANSACTIONS_LENGTH_BYTES = 2
+
 export function writeBlockHeader(
   bw: bufio.StaticWriter | bufio.BufferWriter,
   header: SerializedBlockHeader,
@@ -114,12 +118,18 @@ export function readBlock(reader: bufio.BufferReader): SerializedBlock {
 export function getBlockSize(block: SerializedBlock): number {
   let size = getBlockHeaderSize()
 
-  size += 2 // transactions length
+  size += BLOCK_TRANSACTIONS_LENGTH_BYTES
   for (const transaction of block.transactions) {
     size += getTransactionSize(transaction)
   }
 
   return size
+}
+
+export function getEmptyBlockSize(): number {
+  return (
+    getBlockHeaderSize() + BLOCK_TRANSACTIONS_LENGTH_BYTES + MINERS_FEE_TRANSACTION_SIZE_BYTES
+  )
 }
 
 export function writeCompactBlock(

--- a/ironfish/src/network/utils/serializers.ts
+++ b/ironfish/src/network/utils/serializers.ts
@@ -126,7 +126,7 @@ export function getBlockSize(block: SerializedBlock): number {
   return size
 }
 
-export function getEmptyBlockSize(): number {
+export function getBlockWithMinersFeeSize(): number {
   return (
     getBlockHeaderSize() + BLOCK_TRANSACTIONS_LENGTH_BYTES + MINERS_FEE_TRANSACTION_SIZE_BYTES
   )


### PR DESCRIPTION
## Summary

- Update mining manager to skip transactions that are larger than max block size
- Update mempool to order transactions by highest fee rate (ore/KB) instead of just fee

## Testing Plan

Updated `orderedTransactions` test in `memPool.test.ts`.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
