### PR TITLE
reverses blocks when setting up fee estimator

### DIFF
--- a/ironfish/src/memPool/__fixtures__/feeEstimator.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/feeEstimator.test.ts.fixture
@@ -1,5 +1,5 @@
 {
-  "FeeEstimator setUpCache build recent fee cache with capacity of 1": [
+  "FeeEstimator init build recent fee cache with capacity of 1": [
     {
       "id": "0b75b151-4f1f-48ac-b4e9-73220afeb9e6",
       "name": "test",
@@ -73,7 +73,7 @@
       ]
     }
   ],
-  "FeeEstimator setUpCache build recent fee cache with more than one transaction": [
+  "FeeEstimator init build recent fee cache with more than one transaction": [
     {
       "id": "9c01b177-103b-47f9-9ee2-6dc627ec454a",
       "name": "test",
@@ -1197,7 +1197,7 @@
       ]
     }
   ],
-  "FeeEstimator setUp should build recent fee cache with capacity of 1": [
+  "FeeEstimator init should build recent fee cache with capacity of 1": [
     {
       "id": "c488d89e-74e7-4887-a71d-e76746b390b3",
       "name": "test",
@@ -1271,7 +1271,7 @@
       ]
     }
   ],
-  "FeeEstimator setUp should build recent fee cache with more than one transaction": [
+  "FeeEstimator init should build recent fee cache with more than one transaction": [
     {
       "id": "ae97b9de-ed01-48e7-bffa-c9423b4b35ac",
       "name": "test",
@@ -2265,6 +2265,148 @@
       "incomingViewKey": "fdd80a3fbf31fc6b7e80694367bc1df62438d8997f7e0e63462cd1805f2eb000",
       "outgoingViewKey": "50a82af03760a3353c6f593f320903e1c1a8cb7e0163d994392ba7a499aac23c",
       "publicAddress": "979e9e1490bc7698d7e88997abaab507c6a9e5c7710b2a03814aa2ed30d056fee39b8722ef858168317086"
+    }
+  ],
+  "FeeEstimator init should initialize with the most recent block at the end of the queue": [
+    {
+      "id": "e69a66df-6237-484f-9195-5a2d1a7c3b3b",
+      "name": "test",
+      "spendingKey": "6cd8935ef74c4d0a1186217ec5e91f400ac23ee5e7032047fc6b2fcf06303c99",
+      "incomingViewKey": "60e4c84faa4e5387eb375513ca4bda884a5f0259b781c1171b0497370802b303",
+      "outgoingViewKey": "52330ff1d7a183306cb41164dc4f40fb3c3b698921e29477f1543b80ab59dfe1",
+      "publicAddress": "d4e7ae0e1beb7da48c7522f1c75a4cc6191f43b26e0ea835f289a2f993739805f24579ebcad86e1a9e8edc"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:7yRI/p1o/YrvuAxDq4JLV3HdfQ11PkNhB1Edb8jf0k8="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1666809683244,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "34CFA3428B3FF231DD20EA516FCC20781F20C192CCD176BF1ACE47767B42ECFE",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKIfCCbB9qMqd5l0C0EBonIJm6oKbiVunwC9ln1MHitqS/Whu/aQmvO+2l7/imdstoPbTJ1y1d3Xk2u+SHcPUVuR8GI0GnmsFDXgbKf3QKXzmfvZOqr082aOt/gvbKdakw7/vlIV/zkSZvItradA8WAoUvA9x9sp3Hm2ONPTLr0MbFyTt9Fe1C0jpLxG3AXsIq+epFN4g5k0FFfIWN5o7A1tjtYCLzfiKktFGkZIgKJfbnvz6V+OGNtC9hSSqfTeplXIZDl0ZIZ6K27mMNAyZPa/XImVFqjuhLejBUtYT/yfI4LaTY0yQLloDHqUBLMshyN47haDd9REM7arJaNGzx687FgOOhF6/HUs/UVfxa6f2XVpVxvKnscg7XnpQKEDMBNg3xAv/Ri8W3YnaauF/irR53rFIkUNXJCGSkzGlHenMlLDwp1aLbHA7vTO06ky676dUMvz0d53twY4KzrxRD61VzUS8YGnBi5N5TRJjIYTIsoi56mqbRHTZjffY2ogSNh5HEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsCL2AZe1JgriqUh6LSSMt4fWy/HrtEI0aUOUb1LtK4TYiDBNzSfDMLfp6V3LJiNaNZAM1Nqy0RBvcnHVLfF0BA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "34CFA3428B3FF231DD20EA516FCC20781F20C192CCD176BF1ACE47767B42ECFE",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:oKj6HL4wwG5LbmfL4/XU6YiBwjPCUYaxqcbckI/3Wj8="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "C81E8E95DD769CD26526B6B78C9124DEC139E5FA246C4C7553B6245852A0622C",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1666809685171,
+        "minersFee": "-2000000010",
+        "work": "0",
+        "hash": "DC0707DAF73ABDEEA04092BAA3E31D430D6257C8EB295372B23CDD05FA8BE5E2",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAKVih+gQiOdD4iDIRmItt8IgNQBHpRnR/M5+dIRFtY/zQW1c8HdAx/KCBPJasaDon5RaF6GogG3RvfrvBk6ZrHFd27f8t1avhPgEfLupzUd2Us5+h/ANQmGegngWEKDnyAoW+sK1PLnQ6hXVNcWMI1h3ODJEVv0XDpLlzKxhVv0MYm6U7J1FIKVICOlf9euHiaOhFlvzH9rSTxYIVtjnagzP7DWb0uURKEZabzmDzLgBiS88tDkBVJgLIjdZ/FoKQIzYbU+JiLNxcEg9ydAL9Qz8SxVD3NsrneqqLY0GVoixbj6QB9+/i9gNBul8WMDjvG1oWl+XOcA415Ot8sl+fw8/pakG3hYCRQ+hBYbXc+iE3drqSJvu8reIUzNkEjC/g09Rl0CeSQu7axyH6nKBwFglduHD/i4qbXFec0qYrUYRlFmJGC2ODzDva3ysaYYGe8mfE9DXME9BSNPAY9Nh6BFalxx59itGEw+jzWUz86jO/Lze/qQJEGxavGrNpt8DZ8bJFUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8bMIKJ3Lbi6AT+I0y9W/+4vM5BCfhBudIUnzhoTL/MnsUcXLAO+W2hQNcNcBGCZPbNuvo0ocmyG6ArLVeLUNCg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAJY+RJakduAXFlr+uVSDqzlmemeJU96ZdLua/CYZ2YTs+kpjGcKYCwJcPAzoT3ITJYccg7ROMShgTH6WlEG6gEHxiUofRg0Ku19V1qNYnvnEVYbQbzBmp3L/8AYN0DwUnRIpqEaCncg91+Uqqswif4uzIpHWh4mGxSjHOIfvAB86cEFgiIMRJOsh9LOJhg/Kn5R7vGey7QQT/E3q2BXO9K7DW6YM5RjAT02CuNEfC6KlTKC6n8zZaZ4j2sguI4hFDP/DH+3AMQhKoKWnLwMWwmPSpRfDBXo4D/pI19Uq5J4WddwyC4ie1MvLBVrdzqCvwxWf7eorcNejFUCWkDXLBozvJEj+nWj9iu+4DEOrgktXcd19DXU+Q2EHUR1vyN/STwQAAABBIcwhEU99g1EYnwov22ZYudfP0xdx5hIsnXIHHihck9+V8eJaJkiQ3Ra/7HF3BNzUySikT+aUDBwimlz57Cs/BHsiqneGHH7Ry42K++MPTMNLt2ywofuEl7nIZxIgQQmZG22+SExkTv48JullcFFZfnXOx8XfKdczSthurBUzD31cTjSUdkJR5yeFkjhwdAey6SMowpPxnIUPQcCo33a4mJ0qeKPH0HxXaKmvUMP3VSTsTv9gBEAwXVfR+3VLHz0HZYnQDemiKvE2XQkajr368CsR8n3fzMOjAil1koushAE3Q1nEWXWdxI8CE0Ih+YqI8EdvsnoN/YE6OlOFOKQVzagEfOmuqPp2KBQHKevxlGMzguoRGaxhivE9bndsSUEVmRRHWaHmotwY+2denDWx0sVz2DbLcPwIzxlsf7PIFGlV7k9oSiefNGHqfvM7ERhbMYqXDKiIRBZCaVOPfJdQOtiiuRoRgIS0hkemzOayl4xhBeaO7x9UhQpuv80ptl3tgGxb6XddEJDxLESqsJRNuSF79VpZV7N3uGpLtXHX8GxdSx6Mdm+YTI1ZG6YVM3o/66Fwup3GPQZkOR/z0IIoQXNPn/T6ndnLgEA1nkg0Tk1jYomUlX99EH/oxDjaABBvUO+LJVKIJSKpySXJ2rwjsIiNX6f+bRcZHPSA0DSD//TJ0SFpYqaprnVkRZbzEn1Pjaz49fi/YprYz6LDGyWW/rsFLvuiPXBaUdvtGJv7JyMHebL8g65XPkgf9E3d5l/NJ5aafgcCLnhJMUw4LxHdvQ5h74AM5QeyKvLb+gesfBk8RbFk9cH8hhDTk3gi8ZeisNSXJnV4bl99Dxa6N78ETSEX04KXwPAB+xQ2sJ6iQLAqew7r0/KlS163Xs5O7VqFsM5tPCrEXNgzURQ3h0HVL3bwg6nK8Cb8bMqLfHcqiQbND5Sfsl5G6pzCB2jqtV0WbbIARPDiPrIE20ng7oMMdJ0uu8tj1Irc22ixZVc+9n7NI9MvfnVvl9Taluz4Qzrl1KIJweDsLXCNl5Z1c2jk4aIXlXfmQ1EV9PbB1aUuZQKHpeH3WP6S59ZfKYbvCpoOISzicVqm1YqWwmyznalZTic/r0bdYDD3Pnlfz7tor6VzDyb2UIXZ62usN4VjASCNm3sQW8se0GxiymRMjhXSPnoJFz3n5h4rrjSx3sxeok9LuKgMRkUQV0UneM6wHP3Ff9PXQcgDWwF24iRMbIWqQZVSCEdmJ/FIEdHGrPFAWnGTLpPjoYhEJvJnUW2L678z8Q3gp3VEBppc5590HNTt+QCTs/SHNdCGST8FBuco8i2F9ifx6RnSlu50MICCmCAXGzLNWDCm4YFjpcbIcYbm4uy9DnI7fjGuDwqbX51klsmIc/Irir+SFoT2lqbIOI/3/Xxz7Up+W9BO9LrAA7nj0FJ4pakroldnnQ2+mXxMUHOMrzyCCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "DC0707DAF73ABDEEA04092BAA3E31D430D6257C8EB295372B23CDD05FA8BE5E2",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:Y15C9sdUgYJbiEH5FSS3ZWAgzvDyye8H74Xp/V5AFzQ="
+          },
+          "size": 10
+        },
+        "nullifierCommitment": {
+          "commitment": "F9BA4BA7B8A3EF43F2EEC1BB05609D49A5FFA16610AF62334A1A146D01C01072",
+          "size": 4
+        },
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "randomness": "0",
+        "timestamp": 1666809688413,
+        "minersFee": "-2000000020",
+        "work": "0",
+        "hash": "3D44D9ED50874B864C59301112C98B9CEE5DFA9856F91EC54F2276E1430E1FF5",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAOxryoj/////AAAAAI6XlVSgp08hH4vi0ue82HBNV+c6YhmcbnEQmaF/QB4U2tI1iHcMv4Xi0O5sczN/J6MTQtCWjsIhiHuQUoAbCQM1Zl2uX5FflSlIiXWxUugrDLy3zBb2mXj75mjfbbnwaA6iXWi+uzNy+sQZNWjG9hZNE6+eIFXE34C/nfgQF/Rn6R7cCd6OppRcyhNPLGBxXZUHKDiBxhzrYiLQMWW35V1asI0ckG6acgXQ5vMC0xf1Z/3L9JaYfZEfn/14JZJ9zQdUyMC6WAMJTTrBGkpGCN96btNuedR33LQ7MnYbdsmegc09WG+bPSRuU4wDrWyx68h7NMI0szXJqnzzxvOhGl+5ypwNTQSyD0tcA/9dtoD5LoJA4PjRTFKDJkGGDjyHgYI0WnTMLmMUia/Q8/A86OcM2hDNPZ80JsuMvW4TaXhkRLQtwriEoo82RPA/Jukelt+5s7zzb2NycB7f42siA5KuTb41wgS5VHniiAqcgtlGSvCYQKqx8mnyFTCkshfRUuTIdkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaGYmieEisBFL5AoG8IWVC1fnI/1AQLiPnJjyKK83WzECS9DAwKgZx6YkzUYtLmXIL9i7ODRR+ONzc0hSr2sBAQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AgAAAAAAAAACAAAAAAAAABQAAAAAAAAAAAAAAItAjlu55Xp4HAzUhBuj5NUias/hah/APZPMDMO+wesdoGVcKRwQRxpztkMDoYJpvriEP0oSRbDV6UquzHYMoff8WLc+DGjGMaLU9kg54oamL/divUiSlAdvPHJo+QfnSxQqsKcHDlpG1DbpNU48SE+xkATS7BKpWDumSVhM8v4s1MyjORb0TTjffRxh0IeckITWJi5ORj6VeiqMQTF3IFSLYXYwlPe3uan/FfJ88unUG2yvDJ4PHiDlQG+yQQ4d53MR/LywzekyJjIcSp0FmHLlueJ6/h8Rfhm5dP3GMrNiUzvLGcRg/oi9k3/WhM4ja/cA4j4Sh+te0SghBx4dVM+gqPocvjDAbktuZ8vj9dTpiIHCM8JRhrGpxtyQj/daPwcAAAABqxUAqp+VdBZi5N77ehPcsYvC29zBfE4pof8Q7vJdT5qs5/QLKiQkv85bRUPwyoVntLMVWpWBpthC3EQ1D1BRKpxAclYKbhAsvwmzNazJ5N/z1itdS12DHJZo/ptKJAitA2KsaKMKhqhxkG2bPmS+NN2FLd6JA4dahhnLsorLqIRbhIKsM8Jvin79gHhbo4aGcIeuHV5ZTLboQo4u/EzCrqrzS6k6RS/qrDWNHwVd2OM6t7DONefx9wHZ4u21Jo4Nh3uoc5fgUv8COPxBe736mwmcLjeVrQ4GDxnLLQBuNI9qGGxSdeM4NmxzcdBCjAW577qMgZn80JlA5W1sh9r/HVwEsUfyHC6sIkXazjH1jaccajL459LPIMlMK8Btr1Te66e67Yc8bFfMpXiNqEmzSVL/XJTO1NCE4CIdUmRY1v+rqvIsiJDxKjZXppjgxdeOqMB6tHYAFTe+hddMg7k5oKj6HL4wwG5LbmfL4/XU6YiBwjPCUYaxqcbckI/3Wj8HAAAA6ifMEjKBiL343SHQdp7CJpkQ0J+XPF/8y2bpLoLKPpL7VqCrR9mrFfQbe7UisXSZhqf/u+PbFuiohtnXOgA8EfBg+XrJAe40aM8C2AjChsuLAKpGdlmU16DubsZGWCYDgLfEQ9Ir9fbQOWO0VMOKUs68NVpwAJ0f53k/7TluwOKgYPdfyCN+YO39qX3AIK/0gzDdT9L79GHkrpLwqUyzusiPUyNYd01p+l5SsmwllI5ZhPNsBFbW0dMdaoDZH9BpAE20/FmN7t4XjkEzTgyIm4WKaOftVaDNvEsTgoZEiuRBfGZyacSnxmsn0XogUwT2jQue2rIeTFDS/ks/PqRsDnkFIDCHNp6ACRr6USznbYy49sb9EY4UOng9Dp0tGsFW+AUJPmr8ad+NDjZHzGhOgm6Wam2i2PHOQmcvsnM4vXCUQLL+l4C+bIBYY0ngNLUPJcCyWy+cg6yCRUTkfg3rL+NXzfl21e/9N8gQtRdvNaxrdlkb2o36lrYBt4dll/xhi3bZzLMQMF01fPW8awujDgknG6HbaaHx66bR//RiRfed03fNqXUN3/BOH5XAdZbYW4ooZBiEj80T4plVrZ6Y6jDX/hvFeiMErUO3WnNLyflGHfL1NX5L1HkUwv78rRmdnDzXpgoiAtK03MXn/NflILcFzBbfq/uDg58nVShtIBFiLHh2T4vuPXFqZVBFg5jea6UFhCEEuZzBzKEYBqsmkONxbyP3/6vocrQ5u2sSrYrBQ3ShKP5TPID5h2tCBdegOxxPINjQLtMNZQkA+YQcy0Zk8q+duEQzezhLqJNJIQGsW3+UemaOBbIjENO0osKSyjp8Kd5H0f548ZP0yK9tkrDzHF7lAzegjpMQl7LpteH4P+oUOdAsHdKNBrOMYPjXuFiJ6NpSH3jO+3MY6DpgDlngKVk+kp9WCuVBMLXvqLuec56YZMFDe5zs583F90FRQie/H7+4E6eETw6VbwUnSmd0zvZuWW2af7BBhXwYZlOWbnRGICHnFnQuAFbFRIayTUEWorAFS+GFl4jfmTxlHUv67M/5o3uHsZSLiTHVyK8XSlt2GcusIQ11xWWd5xq1k3UFP+dNgfK2ZpGI1CsovvbYInFEhmwHbjKIgaFg2PfjTuhTcPG7YBTqZzMgJjKgRx7Gd2LB8othgU1dAprcJ/saaOPPB4Pk4dqYCwIsxJlxh+C2q2w75z+W2WBobJ9UJlnwhFvP0f0Rqnn4c6kkuve51TJmHdvJtyRVvqVLzWZTmkKi/skoq/138P3mAcIEjNeWxSFvpCQ4UgONi2WcuMVEy1DvkB4fdzlcxD8ChmfeV2iNX4ejC/NrjP89WJxSbzAStsohVA8sPMa0KdKHlIuBuF20QQMR+CD6hoARIRQcml6OGVP5KY34y3RBJDHcPN9JUMRYFamlEWg+X2H6m0SZbP3l30q+Fv88s1TWI/i1F/OeeQk="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "5D261EE7F178C0342DFAD65C17436A9BC1F9B174973D6C6A9073E2A458DD3167",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:qyxLuPaGDUCwuXMOyH9vmAGufYDAq7YF8YHF/wCuEhA="
+          },
+          "size": 11
+        },
+        "nullifierCommitment": {
+          "commitment": "82F054B31141C72D0533A911CCF718AF3B066971A420A147295E997CB8A457FB",
+          "size": 3
+        },
+        "target": "12061061787010396005823540495362954933337395011119300165635986189",
+        "randomness": "0",
+        "timestamp": 1666809493549,
+        "minersFee": "-2000000020",
+        "work": "0",
+        "hash": "5E5BE11FE64CCB958F93801AE202D0B9CC2394CFD8B78D3395565A4F1547E5B6",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAOxryoj/////AAAAAIXEmSES+gsF5i4uIz/0MjJvCQuRfYPL+IgIaLAk07sJa0ZfEWk4YtH3xkwo1zEiXoB758ZvR7hDyS9LQtQvlkot5l9SYJCAr/nTbv+nxpJ/Gf37hULvVVC1sPJAs5DC/wi6s/quiKI7uGdOlQq6jNiEBI9Eq74VtNXHkUpPaHc/MHEkCvckJMi9dOaTjDHjs7FA+Lx+3LfFK7N8jw6SygUnuWm7qXwVWPWUXjTr9JTgV4wA/IK/IlmsL8hD261bEvD1t6lKFUTuVYh+kDYXj5SlveQF1ldFe62CR2XwFZoadP9rLQ0//xRBZX8W9oADIT4xDh//uGDBK2UoeXLq/k0nQq4i2549cPJk6VjhbDqCp/gKufVOTnB8PxRDVHft1R4ktjiJUipOQowNabVs4OxQNDJfbhTd25w5dQGK8HdwJvLvjm3dFKnFJJOFsAv1V2DXfjLezSI7RCfDKZpyVFl6Yicq6XiCCm+J1VeM83ioqJ0myFu1r10fKT5Se/Em7ijfWEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwkNT6HnOqYUm+/zbdxnM3GBVRVNirbdDAXy5Zp1gzu93aPv1bECOEta1XhfH1+fYQ30XkpTG3yOvj7qlAzBAaAw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAABQAAAAAAAAAAAAAAIG7yuVhBqLNxjNNM8N3nYbGwikLzxo0aAe4Ra9RRFrY0rQ7/miS8doe1AD0Vg1a4pPHd9eDEySS+md1pd639SUJG3ZoCXJ1bwtGPy4lyEycV32KdPcWl4cG0dkkncueDAk3tP/617K+yqHq4xx+NkZVh8pEq49FjxaNHUct5LrPXziEU8dSkXJ7+yfF5gEaQpQ93nC/QcnI09W9xLHgShaV70fNPb94uAVPDr+dnPP/nb7qNZKO/XVnFCCM2EcF7D/gc4u0TLfJ7OdcRN30E+DU6sR0fOzx7Y37gC1GYMMm5rTtDPJ75T/37VyE31ORXnyUcbca7waGjHcIcNB6WdZUOXZvsphzXn/BvrU8dMQ/rCFNA6bL0rBXaVEZBPr1aAgAAACcTgVjJViR8loFP8C3VS2uBKseLhR1a2lnLVbN/3NVrdX4nlPVivRgyijeChmZCZp+/eODzNT98bGKj/zv28uW/NiwQKZlju8CT21p8V19B5jL2xff8O+i3dKwhz1RhgyJY50gjKks5QPbGY597Hf99rO7pWyl9DSoTR6R2qSR3JVZK+QdfJezsjeNMqi/m4eMcwTJZpSgZOdqQ7j7dhHQc0u4O+CM7Jm32curBzo2Ut0Zd7PT1x48P0lY3+JScgQYZzox7GeEIQdar0rCwswah1hTrURmVKyoqmUnWO3esq1RGa8C6bHWTOtuf1/xJyusLtWFP6/POPfCLS04vHEZY+/wjRPvnKTqALh2A3vUnkLzeMHXpEv7KnI8IVw2LTLqZ9Kwxx5mq+DuRnLhT6Trp5Vji9sy5suu3AYbWtfEpbHVKkfTSXQbKb5EqnKWIMNblODMpVgOKz3wdYY7DnInEXamiRri3AQy04f3kZDWHFG63wYhnQHWE1RpGTMDOyRLnb4w3XpGdrXnY9Ns8u+pRxVDNeiqzacsgdoGoYMumB+2qICAsGMYlxi+TQ9ZKOT6+YJlGPVZv9RBOi9wtUBEQhSjmdHBOPLGfsuTuNhNKitksktYW4yccaSxS55dnBj/Pzjxv2BROOsm4RmwKncv0fqSgQMwqV5sVLE1ORQNohMCXv44aUEQSoW7AxcUHeW4chWl4wLaylGZQOISnxXjSkUuTii0spIXSUfT9a9OFDgEDLS7IkeZv9AKEQ/uS22irNyOoVMgClO5Z36p33qDhmBcMq6/nU56/ML1srAH3zRk6Iq7k+wdSVxBanPLcz7fdeSEJd76UXQyG07AAGxRdAL4UssRRg6KU9qocH7BmiOBoQ7FdEnNMtsBzGMPZapu9uaiV/5DAfhN2UJvZBa7O7mVbk5SXidq5soFCzMcwmXRiqHj61FX3w3jsvwoW+dH7ZVw4PNgFKjCAKcHT5nKAJlPTfuLstdZnmXEXQgH0GfU6hGxc9HLf2mLhSnpuO+khxLjWT10SE0aKLoa7XfxDY6XKKYyv416vuVGMi7DSniCRFZV2ZzaV6aOZVAR/eDCNiuVUPtvKADDZ3C/1tZC28S7WmTjif/F4DZg3+1G2tzkzjyC112q48h6XlqR4UCXGF9oT1h6bLKU8gDhbEKz9KjeGNkMq7xxTeN+2X1WbTVDZIXIN7C6Aux8fgm33FbZVsYevhorcmfem+qdVLX08TdGCoODLduHQAQhIF2jpHGIMDvsn1r1Ptevj8SuBNoF6vKd78EvVUwbyfbXMKGwWlvVS5IsI8hS9msvD9AMXxuPguBRK26bl0BNl8j6fiaRRcTfmDDkwtTNrzFlSKVZRWMtvr+rrtMWSnwQPA77WAxkfuIkA79KNVCVcIYiMc8ORo4tF8MFi0ZwdbDqLYiOOIfDiGVUdj5rB6lbxY4uNZcjapN6BQ=="
+        }
+      ]
     }
   ]
 }

--- a/ironfish/src/memPool/feeEstimator.test.ts
+++ b/ironfish/src/memPool/feeEstimator.test.ts
@@ -13,7 +13,7 @@ import { FeeEstimator, getFeeRate } from './feeEstimator'
 describe('FeeEstimator', () => {
   const nodeTest = createNodeTest()
 
-  describe('setUp', () => {
+  describe('init', () => {
     it('should build recent fee cache with capacity of 1', async () => {
       const node = nodeTest.node
 
@@ -28,7 +28,7 @@ describe('FeeEstimator', () => {
         recentBlocksNum: 1,
         txSampleSize: 1,
       })
-      await feeEstimator.setUp()
+      await feeEstimator.init(node.chain)
 
       expect(feeEstimator.estimateFeeRate(60)).toBe(getFeeRate(transaction))
     })
@@ -61,10 +61,50 @@ describe('FeeEstimator', () => {
         recentBlocksNum: 1,
         txSampleSize: 1,
       })
-      await feeEstimator.setUp()
+      await feeEstimator.init(node.chain)
 
       expect(feeEstimator.size()).toBe(1)
       expect(feeEstimator.estimateFeeRate(60)).toBe(getFeeRate(transaction2))
+    })
+
+    it('should initialize with the most recent block at the end of the queue', async () => {
+      const node = nodeTest.node
+      const { account, block, transaction } = await useBlockWithTx(
+        node,
+        undefined,
+        undefined,
+        true,
+        {
+          fee: 10,
+        },
+      )
+
+      await node.chain.addBlock(block)
+      await node.wallet.updateHead()
+
+      const { block: block2, transaction: transaction2 } = await useBlockWithTx(
+        node,
+        account,
+        account,
+        false,
+        {
+          fee: 20,
+        },
+      )
+
+      await node.chain.addBlock(block2)
+      await node.wallet.updateHead()
+
+      const feeEstimator = new FeeEstimator({
+        wallet: node.wallet,
+        recentBlocksNum: 2,
+        txSampleSize: 1,
+      })
+      await feeEstimator.init(node.chain)
+
+      expect(feeEstimator.size()).toBe(2)
+      expect(feeEstimator['queue'][0].feeRate).toEqual(getFeeRate(transaction))
+      expect(feeEstimator['queue'][1].feeRate).toEqual(getFeeRate(transaction2))
     })
   })
 
@@ -327,7 +367,7 @@ describe('FeeEstimator', () => {
         recentBlocksNum: 1,
         txSampleSize: 1,
       })
-      await feeEstimator.setUp()
+      await feeEstimator.init(node.chain)
 
       const fee = await feeEstimator.estimateFee(20, account, [
         {

--- a/ironfish/src/memPool/feeEstimator.ts
+++ b/ironfish/src/memPool/feeEstimator.ts
@@ -62,6 +62,10 @@ export class FeeEstimator {
         this.queue.push({ feeRate: getFeeRate(transaction), blockHash: currentBlockHash })
       }
 
+      if (currentBlockHash.equals(chain.genesis.hash)) {
+        break
+      }
+
       currentBlockHash = currentBlock.header.previousBlockHash
     }
 

--- a/ironfish/src/memPool/feeEstimator.ts
+++ b/ironfish/src/memPool/feeEstimator.ts
@@ -44,6 +44,10 @@ export class FeeEstimator {
   }
 
   async init(chain: Blockchain): Promise<void> {
+    if (chain.isEmpty) {
+      return
+    }
+
     let currentBlockHash = chain.latest.hash
 
     for (let i = 0; i < this.numOfRecentBlocks; i++) {

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -38,7 +38,7 @@ export class MemPool {
   private readonly logger: Logger
   private readonly metrics: MetricsMonitor
 
-  private readonly feeEstimator: FeeEstimator
+  readonly feeEstimator: FeeEstimator
 
   constructor(options: {
     chain: Blockchain

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -318,6 +318,8 @@ export class IronfishNode {
     // so we should start it as soon as possible
     this.workerPool.start()
 
+    await this.memPool.feeEstimator.init(this.chain)
+
     if (this.config.get('enableTelemetry')) {
       this.telemetry.start()
     }

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -296,6 +296,7 @@ export class IronfishNode {
       await this.chain.open()
       await this.wallet.open()
       await this.minedBlocksIndexer.open()
+      await this.memPool.feeEstimator.init(this.chain)
     } catch (e) {
       await this.chain.close()
       await this.wallet.close()
@@ -317,8 +318,6 @@ export class IronfishNode {
     // Work in the worker pool happens concurrently,
     // so we should start it as soon as possible
     this.workerPool.start()
-
-    await this.memPool.feeEstimator.init(this.chain)
 
     if (this.config.get('enableTelemetry')) {
       this.telemetry.start()


### PR DESCRIPTION
## Summary

when initializing the fee estimator we use transactions from recent blocks without filtering transactions using the mempool. these blocks should be added to the queue such that the most recent block is at the end of the queue rather than the beginning.

- reverses queue when initializing fee estimator
- changes 'setUp' to 'init' to match other modules in the codebase
- makes chain a parameter of init instead of a property of the fee estimator since the chain is only used during init
- calls init within node.start

## Testing Plan

adds unit test to cover initialization with multiple blocks

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
