### PR TITLE
adds service command to send fee rate estimates to telemetry

### DIFF
--- a/ironfish-cli/src/commands/service/estimate-fee-rates.ts
+++ b/ironfish-cli/src/commands/service/estimate-fee-rates.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { CurrencyUtils, PromiseUtils } from '@ironfish/sdk'
+import { WebApi } from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../../command'
+import { RemoteFlags } from '../../flags'
+import { IronfishCliPKG } from '../../package'
+
+export default class EstimateFees extends IronfishCommand {
+  static hidden = true
+
+  static description = `
+     Meaures fee rate estimates and submits them to telemetry API
+   `
+
+  static flags = {
+    ...RemoteFlags,
+    endpoint: Flags.string({
+      char: 'e',
+      parse: (input: string) => Promise.resolve(input.trim()),
+      required: false,
+      description: 'API host to sync to',
+    }),
+    token: Flags.string({
+      char: 't',
+      parse: (input: string) => Promise.resolve(input.trim()),
+      required: false,
+      description: 'API host token to authenticate with',
+    }),
+    delay: Flags.integer({
+      char: 'd',
+      required: false,
+      default: 60000,
+      description: 'Delay (in ms) to wait before uploading fee rate estimates',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(EstimateFees)
+
+    const apiHost = (
+      flags.endpoint ||
+      process.env.IRONFISH_API_HOST ||
+      'https://api.ironfish.network'
+    ).trim()
+
+    const apiToken = (flags.token || process.env.IRONFISH_API_TOKEN || '').trim()
+
+    const api = new WebApi({ host: apiHost, token: apiToken })
+
+    let connected = false
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      connected = await this.sdk.client.tryConnect()
+
+      if (!connected) {
+        await PromiseUtils.sleep(1000)
+        continue
+      }
+
+      const response = await this.sdk.client.estimateFeeRates({})
+
+      const feeRateLow = Number(CurrencyUtils.decode(response.content.low ?? '1'))
+      const feeRateMedium = Number(CurrencyUtils.decode(response.content.medium ?? '1'))
+      const feeRateHigh = Number(CurrencyUtils.decode(response.content.high ?? '1'))
+
+      await api.submitTelemetry({
+        points: [
+          {
+            measurement: 'fee_rate_estimate',
+            timestamp: new Date(),
+            fields: [
+              {
+                name: `fee_rate_low`,
+                type: 'integer',
+                value: feeRateLow,
+              },
+              {
+                name: `fee_rate_medium`,
+                type: 'integer',
+                value: feeRateMedium,
+              },
+              {
+                name: `fee_rate_high`,
+                type: 'integer',
+                value: feeRateHigh,
+              },
+            ],
+            tags: [{ name: 'version', value: IronfishCliPKG.version }],
+          },
+        ],
+      })
+
+      await PromiseUtils.sleep(flags.delay)
+    }
+  }
+}

--- a/ironfish-cli/src/commands/service/estimate-fee-rates.ts
+++ b/ironfish-cli/src/commands/service/estimate-fee-rates.ts
@@ -12,7 +12,7 @@ export default class EstimateFees extends IronfishCommand {
   static hidden = true
 
   static description = `
-     Meaures fee rate estimates and submits them to telemetry API
+     Measures fee rate estimates and submits them to telemetry API
    `
 
   static flags = {

--- a/ironfish-cli/src/commands/service/estimate-fee-rates.ts
+++ b/ironfish-cli/src/commands/service/estimate-fee-rates.ts
@@ -63,36 +63,40 @@ export default class EstimateFees extends IronfishCommand {
 
       const response = await this.sdk.client.estimateFeeRates({})
 
-      const feeRateLow = Number(CurrencyUtils.decode(response.content.low ?? '1'))
-      const feeRateMedium = Number(CurrencyUtils.decode(response.content.medium ?? '1'))
-      const feeRateHigh = Number(CurrencyUtils.decode(response.content.high ?? '1'))
+      if (!(response.content.low && response.content.medium && response.content.high)) {
+        this.log('Unexpected response from fees/estimateFeeRates')
+      } else {
+        const feeRateLow = Number(CurrencyUtils.decode(response.content.low))
+        const feeRateMedium = Number(CurrencyUtils.decode(response.content.medium))
+        const feeRateHigh = Number(CurrencyUtils.decode(response.content.high))
 
-      await api.submitTelemetry({
-        points: [
-          {
-            measurement: 'fee_rate_estimate',
-            timestamp: new Date(),
-            fields: [
-              {
-                name: `fee_rate_low`,
-                type: 'integer',
-                value: feeRateLow,
-              },
-              {
-                name: `fee_rate_medium`,
-                type: 'integer',
-                value: feeRateMedium,
-              },
-              {
-                name: `fee_rate_high`,
-                type: 'integer',
-                value: feeRateHigh,
-              },
-            ],
-            tags: [{ name: 'version', value: IronfishCliPKG.version }],
-          },
-        ],
-      })
+        await api.submitTelemetry({
+          points: [
+            {
+              measurement: 'fee_rate_estimate',
+              timestamp: new Date(),
+              fields: [
+                {
+                  name: `fee_rate_low`,
+                  type: 'integer',
+                  value: feeRateLow,
+                },
+                {
+                  name: `fee_rate_medium`,
+                  type: 'integer',
+                  value: feeRateMedium,
+                },
+                {
+                  name: `fee_rate_high`,
+                  type: 'integer',
+                  value: feeRateHigh,
+                },
+              ],
+              tags: [{ name: 'version', value: IronfishCliPKG.version }],
+            },
+          ],
+        })
+      }
 
       await PromiseUtils.sleep(flags.delay)
     }


### PR DESCRIPTION
## Summary

periodically fetches fee rate estimates from the estimateFeeRate RPC and submits them to telemetry.

- converts fee rate to iron/kb in order to submit float value instead of bigint

- fetches low, medium, high fee rates from rpc

## Testing Plan

tested with local node, logging estimates instead of submitting to telemetry

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
