### PR TITLE
adds config value for the maximum blocks in fee estimator history

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -21,6 +21,7 @@ export const DEFAULT_MINER_BATCH_SIZE = 25000
 export const DEFAULT_EXPLORER_BLOCKS_URL = 'https://explorer.ironfish.network/blocks/'
 export const DEFAULT_EXPLORER_TRANSACTIONS_URL =
   'https://explorer.ironfish.network/transaction/'
+export const DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY = 10
 
 // Pool defaults
 export const DEFAULT_POOL_NAME = 'Iron Fish Pool'
@@ -235,6 +236,8 @@ export type ConfigOptions = {
    * URL for viewing transaction information in a block explorer
    */
   explorerTransactionsUrl: string
+
+  feeEstimatorMaxBlockHistory: number
 }
 
 // Matches either an empty string, or a string that has no leading or trailing whitespace.
@@ -401,6 +404,7 @@ export class Config extends KeyStore<ConfigOptions> {
       jsonLogs: false,
       explorerBlocksUrl: DEFAULT_EXPLORER_BLOCKS_URL,
       explorerTransactionsUrl: DEFAULT_EXPLORER_TRANSACTIONS_URL,
+      feeEstimatorMaxBlockHistory: DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY,
     }
   }
 }

--- a/ironfish/src/memPool/feeEstimator.test.ts
+++ b/ironfish/src/memPool/feeEstimator.test.ts
@@ -25,7 +25,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 1,
+        maxBlockHistory: 1,
       })
       await feeEstimator.init(node.chain)
 
@@ -59,7 +59,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 1,
+        maxBlockHistory: 1,
       })
 
       await feeEstimator.init(node.chain)
@@ -103,7 +103,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 2,
+        maxBlockHistory: 2,
       })
       await feeEstimator.init(node.chain)
 
@@ -128,7 +128,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 1,
+        maxBlockHistory: 1,
       })
 
       expect(feeEstimator.size(PRIORITY_LEVELS[0])).toBe(0)
@@ -158,7 +158,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 1,
+        maxBlockHistory: 1,
       })
 
       expect(feeEstimator.size(PRIORITY_LEVELS[0])).toBe(0)
@@ -179,7 +179,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 1,
+        maxBlockHistory: 1,
       })
 
       const { account, block, transaction } = await useBlockWithTx(
@@ -227,7 +227,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 2,
+        maxBlockHistory: 2,
       })
 
       const { account, block, transaction } = await useBlockWithTx(
@@ -271,7 +271,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 2,
+        maxBlockHistory: 2,
       })
 
       const { account, block, transaction } = await useBlockWithTx(
@@ -320,7 +320,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 2,
+        maxBlockHistory: 2,
       })
 
       const { block, transaction } = await useBlockWithTx(node, undefined, undefined, true)
@@ -345,7 +345,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 2,
+        maxBlockHistory: 2,
       })
 
       const { account, block, transaction } = await useBlockWithTx(
@@ -400,7 +400,7 @@ describe('FeeEstimator', () => {
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
-        numOfRecentBlocks: 1,
+        maxBlockHistory: 1,
       })
       await feeEstimator.init(node.chain)
 

--- a/ironfish/src/memPool/feeEstimator.ts
+++ b/ironfish/src/memPool/feeEstimator.ts
@@ -32,13 +32,13 @@ export class FeeEstimator {
   private queues: Map<PriorityLevel, Array<FeeRateEntry>>
   private wallet: Wallet
   private readonly logger: Logger
-  private maxBlocks = 10
+  private maxBlockHistory = 10
   private defaultFeeRate = BigInt(1)
   private readonly percentiles = PRIORITY_LEVEL_PERCENTILES.map((x) => x)
 
   constructor(options: { wallet: Wallet; maxBlockHistory?: number; logger?: Logger }) {
     this.logger = options.logger || createRootLogger().withTag('recentFeeCache')
-    this.maxBlocks = options.maxBlockHistory ?? this.maxBlocks
+    this.maxBlockHistory = options.maxBlockHistory ?? this.maxBlockHistory
 
     this.queues = new Map<PriorityLevel, FeeRateEntry[]>()
     PRIORITY_LEVELS.forEach((priorityLevel) => this.queues.set(priorityLevel, []))
@@ -52,7 +52,7 @@ export class FeeEstimator {
 
     let currentBlockHash = chain.latest.hash
 
-    for (let i = 0; i < this.maxBlocks; i++) {
+    for (let i = 0; i < this.maxBlockHistory; i++) {
       const currentBlock = await chain.getBlock(currentBlockHash)
       Assert.isNotNull(currentBlock, 'No block found')
 
@@ -143,7 +143,7 @@ export class FeeEstimator {
 
   estimateFeeRate(priorityLevel: PriorityLevel): bigint {
     const queue = this.queues.get(priorityLevel)
-    if (queue === undefined || queue.length < this.maxBlocks) {
+    if (queue === undefined || queue.length < this.maxBlockHistory) {
       return this.defaultFeeRate
     }
 
@@ -214,7 +214,7 @@ export class FeeEstimator {
   }
 
   private isFull(array: FeeRateEntry[]): boolean {
-    return array.length === this.maxBlocks
+    return array.length === this.maxBlockHistory
   }
 }
 

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -253,7 +253,10 @@ export class IronfishNode {
       workerPool,
     })
 
-    const feeEstimator = new FeeEstimator({ wallet })
+    const feeEstimator = new FeeEstimator({
+      wallet,
+      maxBlockHistory: config.get('feeEstimatorMaxBlockHistory'),
+    })
 
     const memPool = new MemPool({ chain, feeEstimator, metrics, logger })
 


### PR DESCRIPTION
## Summary

allows users to configure the fee estimator.

- adds feeEstimatorMaxBlocks to config
- renames numOfRecentBlocks to maxBlockHistory to match ETH config naming
- renames recentBlockNum argument to maxBlockHistory for consistency
- reads maxBlockHistory from config when constructing fee estimator

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
