### PR TITLE
Change semicolon to ampersand for Windows support

### DIFF
--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "artifacts": "napi artifacts",
-    "build": "yarn clean; napi build --platform --release",
+    "build": "yarn clean && napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish --skip-gh-release",
     "test:slow": "jest --testPathIgnorePatterns --testMatch \"**/*.test.slow.ts\"",


### PR DESCRIPTION
## Summary

Per [a comment by @AmberKiso](https://github.com/iron-fish/ironfish/pull/2406#issuecomment-1292879341), the semicolon doesn't work on Windows platforms, so changing this to double ampersand.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
