### PR TITLE
chore(rust): Remove deprecated usage of `extern`

### DIFF
--- a/ironfish-rust-nodejs/build.rs
+++ b/ironfish-rust-nodejs/build.rs
@@ -1,5 +1,3 @@
-extern crate napi_build;
-
 fn main() {
     napi_build::setup();
 }

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -1,10 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
-#[macro_use]
-extern crate lazy_static;
-
 use bellman::groth16;
 use bls12_381::Bls12;
 

--- a/ironfish-rust/src/sapling_bls12.rs
+++ b/ironfish-rust/src/sapling_bls12.rs
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
 pub use bls12_381::Scalar;
+use lazy_static::lazy_static;
 use std::sync::Arc;
 
 use crate::Sapling;


### PR DESCRIPTION
## Summary
This was changed in Rust 2018. While still supported, is awkward and mostly outdated. We can use regular imports for everything, so might as well be consistent.

More info: https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html#path-and-module-system-changes

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
