### PR TITLE
moves note/spend size constants to primitives

### DIFF
--- a/ironfish/src/memPool/feeEstimator.ts
+++ b/ironfish/src/memPool/feeEstimator.ts
@@ -7,6 +7,8 @@ import { createRootLogger, Logger } from '../logger'
 import { MemPool } from '../memPool'
 import { getTransactionSize } from '../network/utils/serializers'
 import { Block, Transaction } from '../primitives'
+import { NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE } from '../primitives/noteEncrypted'
+import { SPEND_SERIALIZED_SIZE_IN_BYTE } from '../primitives/spend'
 import { Wallet } from '../wallet'
 import { Account } from '../wallet/account'
 
@@ -25,8 +27,6 @@ const PRIORITY_LEVELS_TO_PERCENTILES = new Map<PriorityLevel, Percentile>([
   ['medium', 20],
   ['high', 30],
 ])
-const SPEND_SERIALIZED_SIZE_IN_BYTE = 388
-const NOTE_SERIALIZED_SIZE_IN_BYTE = 467
 
 export class FeeEstimator {
   private queues: Map<PriorityLevel, Array<FeeRateEntry>>
@@ -149,6 +149,9 @@ export class FeeEstimator {
     }
   }
 
+  /*
+   * returns an estimated fee rate as ore/kb
+   */
   estimateFeeRate(priorityLevel: PriorityLevel): bigint {
     const queue = this.queues.get(priorityLevel)
     if (queue === undefined || queue.length < this.maxBlockHistory) {
@@ -201,7 +204,7 @@ export class FeeEstimator {
 
     size += notesToSpend.length * SPEND_SERIALIZED_SIZE_IN_BYTE
 
-    size += receives.length * NOTE_SERIALIZED_SIZE_IN_BYTE
+    size += receives.length * NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE
 
     if (estimateFeeRate) {
       const additionalAmountNeeded =

--- a/ironfish/src/primitives/noteEncrypted.ts
+++ b/ironfish/src/primitives/noteEncrypted.ts
@@ -7,6 +7,8 @@ import bufio from 'bufio'
 import { Serde } from '../serde'
 import { Note } from './note'
 
+export const NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE = 467
+
 export type NoteEncryptedHash = Buffer
 export type SerializedNoteEncryptedHash = Buffer
 export type SerializedNoteEncrypted = Buffer

--- a/ironfish/src/primitives/spend.ts
+++ b/ironfish/src/primitives/spend.ts
@@ -4,6 +4,8 @@
 
 import { Nullifier } from './nullifier'
 
+export const SPEND_SERIALIZED_SIZE_IN_BYTE = 388
+
 export interface Spend {
   nullifier: Nullifier
   commitment: Buffer


### PR DESCRIPTION
## Summary

moves constants for noteEncrypted and spend serialized byte sizes to primitives modules for NoteEncrypted and Spend.

adds documentation of return value of estimateFeeRate.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
