### PR TITLE
Improve precision in fee rate calculation

### DIFF
--- a/ironfish/src/memPool/feeEstimator.test.ts
+++ b/ironfish/src/memPool/feeEstimator.test.ts
@@ -412,7 +412,7 @@ describe('FeeEstimator', () => {
         },
       ])
 
-      expect(fee).toBe(BigInt(10))
+      expect(fee).toBe(BigInt(7))
     })
   })
 })

--- a/ironfish/src/memPool/feeEstimator.ts
+++ b/ironfish/src/memPool/feeEstimator.ts
@@ -227,8 +227,8 @@ export class FeeEstimator {
 }
 
 export function getFeeRate(transaction: Transaction): bigint {
-  const transactionSizeKb = getTransactionSize(transaction.serialize()) / 1000
-  const rate = transaction.fee() / BigInt(Math.round(transactionSizeKb))
+  const rate =
+    (transaction.fee() * BigInt(1000)) / BigInt(getTransactionSize(transaction.serialize()))
 
   return rate > 0 ? rate : BigInt(1)
 }


### PR DESCRIPTION
## Summary

Change the fee rate calculation in `getFeeRate()` to improve precision by eliminating rounding during the bytes to kb conversion.

## Testing Plan

Updated tests in `feeEstimator.test.ts`.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
