### PR TITLE
refactor(rust): Define shared values in cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ members = [
     "ironfish-zkp",
 ]
 
+[workspace.package]
+authors = ["Iron Fish <contact@ironfish.network> (https://ironfish.network)"]
+edition = "2021"
+
 [patch.crates-io]
 bellman = { git = "https://github.com/iron-fish/bellman", rev = "1cc52ca33e6db14233f1cbc0c9c5b7c822b229ec" }
 napi = { git = "https://github.com/napi-rs/napi-rs", rev = "26f6c926d30de744146fe54db6a6b399e142e63c" }

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -2,7 +2,12 @@
 name = "ironfish-rust-nodejs"
 version = "0.1.0"
 license = "MPL-2.0"
-edition = "2021"
+
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
-authors = ["Iron Fish <contact@ironfish.network> (https://ironfish.network)"]
-edition = "2021"
-license = "MPL-2.0"
 name = "ironfish_rust"
 version = "0.1.0"
+license = "MPL-2.0"
+
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 
 [lib]
 name = "ironfish_rust"

--- a/ironfish-zkp/Cargo.toml
+++ b/ironfish-zkp/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "ironfish_zkp"
 version = "0.1.0"
-edition = "2021"
 license = "MIT OR Apache-2.0"
+
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Summary

Wanted to de-dupe the edition so it only needs to be updated in one place going forward. We can probably utilize more, the full list can be found here: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
