### PR TITLE
Update pay cmd with fee estimate

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
-import { CurrencyUtils, isValidPublicAddress } from '@ironfish/sdk'
+import { CurrencyUtils, isValidPublicAddress, ConfigOptions } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -145,8 +144,13 @@ export class Pay extends IronfishCommand {
             },
           ],
         })
+
+        const config = await client.getConfig({})
+    
+        const feeEstimatorMaxBlockHistory = 'feeEstimatorMaxBlockHistory' as keyof Partial<ConfigOptions>
+
         suggestedFees = suggestedFees.concat(
-          `  low: ${CurrencyUtils.renderIron(response.content.low)}\n`,
+          `  low (*among ${config.content[feeEstimatorMaxBlockHistory]}% of recent transactions): ${CurrencyUtils.renderIron(response.content.low)}\n`,
         )
         suggestedFees = suggestedFees.concat(
           `  medium: ${CurrencyUtils.renderIron(response.content.medium)}\n`,

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { CurrencyUtils, EstimateFeeResponse, isValidPublicAddress } from '@ironfish/sdk'
+import { CurrencyUtils, isValidPublicAddress } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -133,21 +133,23 @@ export class Pay extends IronfishCommand {
     }
 
     if (fee == null) {
-      let suggestedFees: string = ""
+      let suggestedFees = ''
       try {
-        const response = await client.estimateFee({ 
-          fromAccountName: from, 
-          receives:  [{
-            publicAddress: to,
-            amount: CurrencyUtils.encode(amount),
-            memo: memo,
-          }]
-      })
+        const response = await client.estimateFee({
+          fromAccountName: from,
+          receives: [
+            {
+              publicAddress: to,
+              amount: CurrencyUtils.encode(amount),
+              memo: memo,
+            },
+          ],
+        })
         suggestedFees.concat(`low: ${CurrencyUtils.renderIron(response.content.low)}\n`)
         suggestedFees.concat(`medium: ${CurrencyUtils.renderIron(response.content.medium)}\n`)
         suggestedFees.concat(`high: ${CurrencyUtils.renderIron(response.content.high)}\n`)
       } catch {
-        suggestedFees = ""
+        suggestedFees = ''
       }
 
       const input = (await CliUx.ux.prompt(

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -48,10 +48,9 @@ export class Pay extends IronfishCommand {
         'The block sequence after which the transaction will be removed from the mempool. Set to 0 for no expiration.',
     }),
     priority: Flags.string({
-      default: 'medium', 
+      default: 'medium',
       char: 'p',
-      description:
-        'The priority level for transaction fee estimation.',
+      description: 'The priority level for transaction fee estimation.',
       options: ['low', 'medium', 'high'],
     }),
   }

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -145,16 +145,23 @@ export class Pay extends IronfishCommand {
             },
           ],
         })
-        suggestedFees.concat(`low: ${CurrencyUtils.renderIron(response.content.low)}\n`)
-        suggestedFees.concat(`medium: ${CurrencyUtils.renderIron(response.content.medium)}\n`)
-        suggestedFees.concat(`high: ${CurrencyUtils.renderIron(response.content.high)}\n`)
+        suggestedFees = suggestedFees.concat(
+          `  low: ${CurrencyUtils.renderIron(response.content.low)}\n`,
+        )
+        suggestedFees = suggestedFees.concat(
+          `  medium: ${CurrencyUtils.renderIron(response.content.medium)}\n`,
+        )
+        suggestedFees = suggestedFees.concat(
+          `  high: ${CurrencyUtils.renderIron(response.content.high)}\n`,
+        )
       } catch {
         suggestedFees = ''
       }
 
       const input = (await CliUx.ux.prompt(
-        `Enter the fee amount in $IRON (min: ${CurrencyUtils.renderIron(1n)} \n
-        recommended: ${suggestedFees}`,
+        `Enter the fee amount in $IRON (min: ${CurrencyUtils.renderIron(
+          1n,
+        )})\nrecommended:\n${suggestedFees}`,
         {
           required: true,
         },

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -150,7 +150,7 @@ export class Pay extends IronfishCommand {
           ],
         })
 
-        switch (flags.priority || 'medium') {
+        switch (flags.priority) {
           case 'low':
             suggestedFees = CurrencyUtils.renderIron(response.content.low)
             break

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -147,16 +147,18 @@ export class Pay extends IronfishCommand {
 
         const config = await client.getConfig({})
     
-        const feeEstimatorMaxBlockHistory = 'feeEstimatorMaxBlockHistory' as keyof Partial<ConfigOptions>
+        const low = 'feeEstimatorPercentileLow' as keyof Partial<ConfigOptions>
+        const medium = 'feeEstimatorPercentileMedium' as keyof Partial<ConfigOptions>
+        const high = 'feeEstimatorPercentileHigh' as keyof Partial<ConfigOptions>
 
         suggestedFees = suggestedFees.concat(
-          `  low (*among ${config.content[feeEstimatorMaxBlockHistory]}% of recent transactions): ${CurrencyUtils.renderIron(response.content.low)}\n`,
+          `  low (*among ${config.content[low]}% of recent transactions): ${CurrencyUtils.renderIron(response.content.low)}\n`,
         )
         suggestedFees = suggestedFees.concat(
-          `  medium: ${CurrencyUtils.renderIron(response.content.medium)}\n`,
+          `  medium (*among ${config.content[medium]}% of recent transactions): ${CurrencyUtils.renderIron(response.content.medium)}\n`,
         )
         suggestedFees = suggestedFees.concat(
-          `  high: ${CurrencyUtils.renderIron(response.content.high)}\n`,
+          `  high (*among ${config.content[high]}% of recent transactions): ${CurrencyUtils.renderIron(response.content.high)}\n`,
         )
       } catch {
         suggestedFees = ''

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils, isValidPublicAddress, ConfigOptions } from '@ironfish/sdk'
+import { ConfigOptions, CurrencyUtils, isValidPublicAddress } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -146,19 +146,25 @@ export class Pay extends IronfishCommand {
         })
 
         const config = await client.getConfig({})
-    
+
         const low = 'feeEstimatorPercentileLow' as keyof Partial<ConfigOptions>
         const medium = 'feeEstimatorPercentileMedium' as keyof Partial<ConfigOptions>
         const high = 'feeEstimatorPercentileHigh' as keyof Partial<ConfigOptions>
 
         suggestedFees = suggestedFees.concat(
-          `  low (*among ${config.content[low]}% of recent transactions): ${CurrencyUtils.renderIron(response.content.low)}\n`,
+          `  low (*among ${JSON.stringify(
+            config.content[low],
+          )}% of recent transactions): ${CurrencyUtils.renderIron(response.content.low)}\n`,
         )
         suggestedFees = suggestedFees.concat(
-          `  medium (*among ${config.content[medium]}% of recent transactions): ${CurrencyUtils.renderIron(response.content.medium)}\n`,
+          `  medium (*among ${JSON.stringify(
+            config.content[medium],
+          )}% of recent transactions): ${CurrencyUtils.renderIron(response.content.medium)}\n`,
         )
         suggestedFees = suggestedFees.concat(
-          `  high (*among ${config.content[high]}% of recent transactions): ${CurrencyUtils.renderIron(response.content.high)}\n`,
+          `  high (*among ${JSON.stringify(
+            config.content[high],
+          )}% of recent transactions): ${CurrencyUtils.renderIron(response.content.high)}\n`,
         )
       } catch {
         suggestedFees = ''

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -48,9 +48,11 @@ export class Pay extends IronfishCommand {
         'The block sequence after which the transaction will be removed from the mempool. Set to 0 for no expiration.',
     }),
     priority: Flags.string({
+      default: 'medium', 
       char: 'p',
       description:
-        'The priority level for transaction fee estimation. The possible values are low, medium and high.',
+        'The priority level for transaction fee estimation.',
+      options: ['low', 'medium', 'high'],
     }),
   }
 
@@ -137,7 +139,7 @@ export class Pay extends IronfishCommand {
     }
 
     if (fee == null) {
-      let suggestedFees = ''
+      let suggestedFee = ''
       try {
         const response = await client.estimateFee({
           fromAccountName: from,
@@ -152,24 +154,25 @@ export class Pay extends IronfishCommand {
 
         switch (flags.priority) {
           case 'low':
-            suggestedFees = CurrencyUtils.renderIron(response.content.low)
+            suggestedFee = CurrencyUtils.renderIron(response.content.low)
             break
           case 'high':
-            suggestedFees = CurrencyUtils.renderIron(response.content.high)
+            suggestedFee = CurrencyUtils.renderIron(response.content.high)
             break
           default:
-            suggestedFees = CurrencyUtils.renderIron(response.content.medium)
+            suggestedFee = CurrencyUtils.renderIron(response.content.medium)
         }
       } catch {
-        suggestedFees = ''
+        suggestedFee = ''
       }
 
       const input = (await CliUx.ux.prompt(
         `Enter the fee amount in $IRON (min: ${CurrencyUtils.renderIron(
           1n,
-        )})\nrecommended: ${suggestedFees}`,
+        )} recommended: ${suggestedFee})`,
         {
           required: true,
+          default: suggestedFee,
         },
       )) as string
 

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -167,7 +167,7 @@ export class Pay extends IronfishCommand {
       const input = (await CliUx.ux.prompt(
         `Enter the fee amount in $IRON (min: ${CurrencyUtils.renderIron(
           1n,
-        )})\nrecommended:${suggestedFees}`,
+        )})\nrecommended: ${suggestedFees}`,
         {
           required: true,
         },

--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -153,17 +153,17 @@ export class Pay extends IronfishCommand {
 
         suggestedFees = suggestedFees.concat(
           `  low (*among ${JSON.stringify(
-            config.content[low],
+            config.content[low] || '10', 
           )}% of recent transactions): ${CurrencyUtils.renderIron(response.content.low)}\n`,
         )
         suggestedFees = suggestedFees.concat(
           `  medium (*among ${JSON.stringify(
-            config.content[medium],
+            config.content[medium] || '20',
           )}% of recent transactions): ${CurrencyUtils.renderIron(response.content.medium)}\n`,
         )
         suggestedFees = suggestedFees.concat(
           `  high (*among ${JSON.stringify(
-            config.content[high],
+            config.content[high] || '30',
           )}% of recent transactions): ${CurrencyUtils.renderIron(response.content.high)}\n`,
         )
       } catch {


### PR DESCRIPTION
## Summary
Update account:pay command with fee estimate. 
## Testing Plan
```
yarn start accounts:pay -v -a 10 -t acc03c941600e99cb0e53d9062826071a00af58905606aaabc4afc57d9626855b58724394b1a05d0d4a742
yarn run v1.22.19
$ yarn build && yarn start:js accounts:pay -v -a 10 -t acc03c941600e99cb0e53d9062826071a00af58905606aaabc4afc57d9626855b58724394b1a05d0d4a742
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run accounts:pay -v -a 10 -t acc03c941600e99cb0e53d9062826071a00af58905606aaabc4afc57d9626855b58724394b1a05d0d4a742
Connecting to /Users/yajun/.ironfish/ironfish.ipc
Enter the fee amount in $IRON (min: 0.00000001 recommended: 0.00000365) [0.00000365]:

You are about to send:
$IRON 10.00000000 plus a transaction fee of $IRON 0.00000825 to acc03c941600e99cb0e53d9062826071a00af58905606aaabc4afc57d9626855b58724394b1a05d0d4a742 from the account default

* This action is NOT reversible *

```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@hughy 
