### PR TITLE
allows configuration of fee estimator percentiles

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -22,6 +22,9 @@ export const DEFAULT_EXPLORER_BLOCKS_URL = 'https://explorer.ironfish.network/bl
 export const DEFAULT_EXPLORER_TRANSACTIONS_URL =
   'https://explorer.ironfish.network/transaction/'
 export const DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY = 10
+export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_LOW = 10
+export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_MEDIUM = 20
+export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_HIGH = 30
 
 // Pool defaults
 export const DEFAULT_POOL_NAME = 'Iron Fish Pool'
@@ -238,6 +241,9 @@ export type ConfigOptions = {
   explorerTransactionsUrl: string
 
   feeEstimatorMaxBlockHistory: number
+  feeEstimatorPercentileLow: number
+  feeEstimatorPercentileMedium: number
+  feeEstimatorPercentileHigh: number
 }
 
 // Matches either an empty string, or a string that has no leading or trailing whitespace.
@@ -405,6 +411,9 @@ export class Config extends KeyStore<ConfigOptions> {
       explorerBlocksUrl: DEFAULT_EXPLORER_BLOCKS_URL,
       explorerTransactionsUrl: DEFAULT_EXPLORER_TRANSACTIONS_URL,
       feeEstimatorMaxBlockHistory: DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY,
+      feeEstimatorPercentileLow: DEFAULT_FEE_ESTIMATOR_PERCENTILE_LOW,
+      feeEstimatorPercentileMedium: DEFAULT_FEE_ESTIMATOR_PERCENTILE_MEDIUM,
+      feeEstimatorPercentileHigh: DEFAULT_FEE_ESTIMATOR_PERCENTILE_HIGH,
     }
   }
 }

--- a/ironfish/src/memPool/feeEstimator.test.ts
+++ b/ironfish/src/memPool/feeEstimator.test.ts
@@ -111,7 +111,7 @@ describe('FeeEstimator', () => {
       expect(feeEstimator.size(PRIORITY_LEVELS[1])).toBe(2)
       expect(feeEstimator.size(PRIORITY_LEVELS[2])).toBe(2)
       let queue: FeeRateEntry[] | undefined
-      Assert.isNotUndefined((queue = feeEstimator['queues'].get(PRIORITY_LEVELS[0])))
+      Assert.isNotUndefined((queue = feeEstimator['queues']['low']))
       expect(queue[0].feeRate).toEqual(getFeeRate(transaction))
       expect(queue[1].feeRate).toEqual(getFeeRate(transaction2))
     })
@@ -308,9 +308,7 @@ describe('FeeEstimator', () => {
       expect(feeEstimator.size(PRIORITY_LEVELS[2])).toBe(2)
 
       // transaction from first block is still in the cache
-      expect(feeEstimator['queues'].get(PRIORITY_LEVELS[0])?.at(0)?.blockHash).toEqualHash(
-        block.header.hash,
-      )
+      expect(feeEstimator['queues']['low'].at(0)?.blockHash).toEqualHash(block.header.hash)
     })
   })
 

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -256,6 +256,11 @@ export class IronfishNode {
     const feeEstimator = new FeeEstimator({
       wallet,
       maxBlockHistory: config.get('feeEstimatorMaxBlockHistory'),
+      percentiles: {
+        low: config.get('feeEstimatorPercentileLow'),
+        medium: config.get('feeEstimatorPercentileMedium'),
+        high: config.get('feeEstimatorPercentileHigh'),
+      },
     })
 
     const memPool = new MemPool({ chain, feeEstimator, metrics, logger })


### PR DESCRIPTION
## Summary

updates FeeEstimator to accept an object that configures the fee rate percentiles associated with low, medium, and high priority fee rates.

- adds config variables for low, medium, and high percentiles
- removes percentile constants
- updates queues to be an object with low/medium/high properties and removes checks on lookups using priority levels
- refactors method to fetch lowest fee rates from block to return sorted list instead of map

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
