### PR TITLE
Push V2 consensus upgrade (block size) to activate at block 255000

### DIFF
--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -101,6 +101,6 @@ export class TestnetParameters extends ConsensusParameters {
   constructor() {
     super()
     this.V1_DOUBLE_SPEND = 204000
-    this.V2_MAX_BLOCK_SIZE = 252000
+    this.V2_MAX_BLOCK_SIZE = 255000
   }
 }


### PR DESCRIPTION
## Summary

Added the consensus upgrade for max block limit to block 255000, estimated to occur on November 2, 2022 at 1:30 pm ET. All users will need to upgrade by then. Relevant changes are included in https://github.com/iron-fish/ironfish/pull/2378.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
