### PR TITLE
increases precision of fee calculation

### DIFF
--- a/ironfish/src/memPool/feeEstimator.test.ts
+++ b/ironfish/src/memPool/feeEstimator.test.ts
@@ -397,6 +397,7 @@ describe('FeeEstimator', () => {
       const receiver = await useAccountFixture(node.wallet, 'accountA')
 
       await node.chain.addBlock(block)
+      await node.wallet.updateHead()
 
       const feeEstimator = new FeeEstimator({
         wallet: node.wallet,
@@ -412,7 +413,7 @@ describe('FeeEstimator', () => {
         },
       ])
 
-      expect(fee).toBe(BigInt(7))
+      expect(fee).toBe(BigInt(6))
     })
   })
 })

--- a/ironfish/src/memPool/feeEstimator.ts
+++ b/ironfish/src/memPool/feeEstimator.ts
@@ -183,7 +183,7 @@ export class FeeEstimator {
       receives,
       estimateFeeRate,
     )
-    return estimateFeeRate * BigInt(estimateTransactionSize)
+    return this.getFee(estimateFeeRate, estimateTransactionSize)
   }
 
   private async getPendingTransactionSize(
@@ -208,7 +208,7 @@ export class FeeEstimator {
 
     if (estimateFeeRate) {
       const additionalAmountNeeded =
-        estimateFeeRate * BigInt(Math.ceil(size / 1000)) - (amount - amountNeeded)
+        this.getFee(estimateFeeRate, size) - (amount - amountNeeded)
 
       if (additionalAmountNeeded > 0) {
         const { notesToSpend: additionalNotesToSpend } = await this.wallet.createSpends(
@@ -221,11 +221,17 @@ export class FeeEstimator {
       }
     }
 
-    return Math.ceil(size / 1000)
+    return size
   }
 
   private isFull(array: FeeRateEntry[]): boolean {
     return array.length === this.maxBlockHistory
+  }
+
+  private getFee(feeRate: bigint, transactionSize: number): bigint {
+    const fee = (feeRate * BigInt(transactionSize)) / BigInt(1000)
+
+    return fee > BigInt(0) ? fee : BigInt(1)
   }
 }
 


### PR DESCRIPTION
## Summary

defers division by 1000 in conversion from (bytes * ore/kb) to ore. rounding transaction size before computing fee leads to imprecise fee calculation.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
