### PR TITLE
fixes silent failures in chain:download

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -86,10 +86,12 @@ export default class Download extends IronfishCommand {
       }
 
       const fileSize = FileUtils.formatFileSize(manifest.file_size)
+      const spaceRequired = FileUtils.formatFileSize(manifest.file_size * 2)
 
       if (!flags.confirm) {
         const confirm = await CliUx.ux.confirm(
-          `Download ${fileSize} snapshot to update from block ${node.chain.head.sequence} to ${manifest.block_sequence}?` +
+          `Download ${fileSize} snapshot to update from block ${node.chain.head.sequence} to ${manifest.block_sequence}? ` +
+            `At least ${spaceRequired} of free disk space is required to download and unzip the snapshot file.` +
             `\nAre you sure? (Y)es / (N)o`,
         )
 
@@ -282,6 +284,7 @@ export default class Download extends IronfishCommand {
       file: source,
       C: dest,
       strip: 1,
+      strict: true,
       onentry: (_) => {
         speed.add(1)
         progressBar.update(++extracted, {

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -91,7 +91,7 @@ export default class Download extends IronfishCommand {
       if (!flags.confirm) {
         const confirm = await CliUx.ux.confirm(
           `Download ${fileSize} snapshot to update from block ${node.chain.head.sequence} to ${manifest.block_sequence}? ` +
-            `At least ${spaceRequired} of free disk space is required to download and unzip the snapshot file.` +
+            `\nAt least ${spaceRequired} of free disk space is required to download and unzip the snapshot file.` +
             `\nAre you sure? (Y)es / (N)o`,
         )
 


### PR DESCRIPTION
## Summary

uses 'strict' mode during unzip to treat errors as failures (including ENOSPC errors). warns users that downloading and unzipping will require 2x the size of the snapshot in free disk space.

## Testing Plan

- Filled the disk of my AWS node instance, then tried to unzip another snapshot 😈 

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/57735705/198741366-8c5e129d-604d-4771-975a-084f55a005f4.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
