### PR TITLE
Refactor out seed genesis block from addBlock

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -732,17 +732,6 @@ describe('Blockchain', () => {
     })
   })
 
-  it('reject block with null previous hash', async () => {
-    const { node } = await nodeTest.createSetup()
-    const block = await useMinerBlockFixture(node.chain)
-
-    const result = await node.chain.verifier.verifyBlockAdd(block, null)
-    expect(result).toMatchObject({
-      valid: false,
-      reason: VerificationResultReason.PREV_HASH_NULL,
-    })
-  })
-
   it('reject block with hash not matching previous hash', async () => {
     const { node } = await nodeTest.createSetup()
 

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -351,36 +351,6 @@ export class Blockchain {
     await this.db.close()
   }
 
-  async addGenesisBlock(genesis: Block): Promise<{
-    isAdded: boolean
-    reason: VerificationResultReason | null
-  }> {
-    try {
-      return await this.db.transaction(async (tx) => {
-        const work = genesis.header.target.toDifficulty()
-        genesis.header.work = BigInt(0) + work
-
-        const isFork = !this.isEmpty && !isBlockHeavier(genesis.header, this.head)
-        Assert.isFalse(isFork)
-
-        await this.saveBlock(genesis, null, false, tx)
-        this.head = genesis.header
-        this.genesis = genesis.header
-
-        await this.onConnectBlock.emitAsync(genesis, tx)
-
-        this.updateSynced()
-
-        return { isAdded: true, reason: null }
-      })
-    } catch (e) {
-      if (e instanceof VerifyError) {
-        return { isAdded: false, reason: e.reason }
-      }
-      throw e
-    }
-  }
-
   async addBlock(block: Block): Promise<{
     isAdded: boolean
     isFork: boolean | null

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -12,11 +12,7 @@ import { Target } from '../primitives/target'
 import { Transaction } from '../primitives/transaction'
 import { IDatabaseTransaction } from '../storage'
 import { WorkerPool } from '../workerPool'
-import {
-  ALLOWED_BLOCK_FUTURE_SECONDS,
-  GENESIS_BLOCK_SEQUENCE,
-  MAX_TRANSACTIONS_PER_BLOCK,
-} from './consensus'
+import { ALLOWED_BLOCK_FUTURE_SECONDS, MAX_TRANSACTIONS_PER_BLOCK } from './consensus'
 
 export class Verifier {
   chain: Blockchain
@@ -301,15 +297,7 @@ export class Verifier {
   }
 
   // TODO: Rename to verifyBlock but merge verifyBlock into this
-  async verifyBlockAdd(block: Block, prev: BlockHeader | null): Promise<VerificationResult> {
-    if (block.header.sequence === GENESIS_BLOCK_SEQUENCE) {
-      return { valid: true }
-    }
-
-    if (!prev) {
-      return { valid: false, reason: VerificationResultReason.PREV_HASH_NULL }
-    }
-
+  async verifyBlockAdd(block: Block, prev: BlockHeader): Promise<VerificationResult> {
     const { notes, nullifiers } = block.counts()
 
     if (block.header.noteCommitment.size !== prev.noteCommitment.size + notes) {


### PR DESCRIPTION
## Summary
Refactor out seeding the genesis block from other add block operations. We have a lot of genesis block specific logic in addBlock that unnecessarily complicates things. Factoring this out into its own function

## Testing Plan
Unit tests and ran a new chain locally for the first ~1000 blocks. Restarted the node and ran again from 1000 - 1200, no errors.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
