### PR TITLE
fix negative sequence

### DIFF
--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -23,10 +23,12 @@ export default class ShowBlock extends IronfishCommand {
   async start(): Promise<void> {
     const { args } = await this.parse(ShowBlock)
     const search = args.search as string
-
-    const client = await this.sdk.connectRpc()
-    const data = await client.getBlockInfo({ search })
-
-    this.log(JSON.stringify(data.content, undefined, '  '))
+    if (parseInt(search) < 1) {
+      this.log(`Sequence can't be negative: ${search}`)
+    } else {
+      const client = await this.sdk.connectRpc()
+      const data = await client.getBlockInfo({ search })
+      this.log(JSON.stringify(data.content, undefined, '  '))
+    }
   }
 }

--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -23,8 +23,8 @@ export default class ShowBlock extends IronfishCommand {
   async start(): Promise<void> {
     const { args } = await this.parse(ShowBlock)
     const search = args.search as string
-    if (parseInt(search) < 1) {
-      this.log(`Sequence can't be negative: ${search}`)
+    if (parseInt(search) < 0) {
+      this.log(`Sequence can't be less than 1: ${search}`)
     } else {
       const client = await this.sdk.connectRpc()
       const data = await client.getBlockInfo({ search })


### PR DESCRIPTION
## Summary
`ironfish blocks:show 0`
displays nothing
`ironfish blocks:show [anything negative]`
display the block with sequence 1

## Testing Plan
I have setup the repo in local and have tested locally with:
`yarn start blocks:show [any negative number]`

## Breaking Change
No

## Side Note
1. Correct me if I am wrong but negative sequence aren't possible right ? 
2. Also I know this seems like a small PR but the amount of time it took me to setup repo in local and to resolve all errors so that I can was huge, requesting you to consider that while allocating points