### PR TITLE
add checks on user input

### DIFF
--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -56,14 +56,8 @@ export default class Export extends IronfishCommand {
       stop: argStop,
     })
     const { start, stop } = await AsyncUtils.first(stream.contentStream())
-    if (
-      (argStart && argStart < Number(GENESIS_BLOCK_SEQUENCE)) ||
-      (argStop != null && argStop > stop)
-    ) {
-      this.error(
-        `You can can only export chain from ${Number(GENESIS_BLOCK_SEQUENCE)} -> ${stop}`,
-      )
-      this.exit(1)
+    if (argStop != null && argStop > stop) {
+      this.log(`Argument stop is greater than the chain head of the node: ${argStop} > ${stop}`)
     }
     this.log(`Exporting chain from ${start} -> ${stop} to ${exportPath}`)
     const progress = CliUx.ux.progress({


### PR DESCRIPTION
## Summary
When running chain:export command, there is no check on user inputs

Example:

If user runs chain:export 1000 20000 but chain or their node is synced till block 200
then only 200th block will be exported, without informing the user that it is not what they requested, or what they request isn't available

or If user runs: chain:export -100
Then from 1 -> last synced block will be exported, without informing the user that their input is wrong


## Testing Plan
Tested locally

## Breaking Change
No