### PR TITLE
Cache pastRoot function in merkle tree

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -644,8 +644,8 @@ export class Blockchain {
     Assert.isNotNull(prev)
 
     await this.saveConnect(block, prev, tx)
-    this.notes.pastRootTxCommited(tx)
     await tx.update()
+    this.notes.pastRootTxCommited(tx)
 
     this.head = block.header
     await this.onConnectBlock.emitAsync(block, tx)

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -644,6 +644,7 @@ export class Blockchain {
     Assert.isNotNull(prev)
 
     await this.saveConnect(block, prev, tx)
+    this.notes.pastRootTxCommited(tx)
     await tx.update()
 
     this.head = block.header

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -645,7 +645,7 @@ export class Blockchain {
 
     await this.saveConnect(block, prev, tx)
     await tx.update()
-    this.notes.pastRootTxCommited(tx)
+    this.notes.pastRootTxCommitted(tx)
 
     this.head = block.header
     await this.onConnectBlock.emitAsync(block, tx)
@@ -1274,7 +1274,7 @@ export class Blockchain {
     }
 
     await tx.update()
-    this.notes.pastRootTxCommited(tx)
+    this.notes.pastRootTxCommitted(tx)
   }
 
   private updateSynced(): void {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1273,6 +1273,7 @@ export class Blockchain {
     }
 
     await tx.update()
+    this.notes.pastRootTxCommited(tx)
   }
 
   private updateSynced(): void {

--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -515,7 +515,7 @@ export class MerkleTree<
     return this.pastRootCache.get(pastSize)
   }
 
-  pastRootTxCommited(tx: IDatabaseTransaction): void {
+  pastRootTxCommitted(tx: IDatabaseTransaction): void {
     if (tx instanceof LevelupTransaction) {
       const local = this.transactionPastRootCache.get(tx.id)
       for (const [pastSize, hash] of local?.entries() || []) {

--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import LRU from 'blru'
 import { Assert } from '../assert'
 import { JsonSerializable } from '../serde'
 import {
@@ -10,6 +11,7 @@ import {
   IDatabaseEncoding,
   IDatabaseStore,
   IDatabaseTransaction,
+  LevelupTransaction,
   SchemaValue,
   StringEncoding,
   U32_ENCODING,
@@ -41,6 +43,12 @@ export class MerkleTree<
   readonly leaves: IDatabaseStore<LeavesSchema<E, H>>
   readonly leavesIndex: IDatabaseStore<LeavesIndexSchema<H>>
   readonly nodes: IDatabaseStore<NodesSchema<H>>
+
+  private readonly globalPastRootCache: LRU<number, H> = new LRU<number, H>(300 * 60)
+  private readonly localPastRootCache: LRU<number, Map<number, H>> = new LRU<
+    number,
+    Map<number, H>
+  >(5)
 
   constructor({
     hasher,
@@ -405,6 +413,7 @@ export class MerkleTree<
    * grows.
    */
   async truncate(pastSize: number, tx?: IDatabaseTransaction): Promise<void> {
+    this.invalidatePastRootCache(pastSize, tx)
     return await this.db.withTransaction(tx, async (tx) => {
       const oldSize = await this.getCount('Leaves', tx)
 
@@ -469,6 +478,53 @@ export class MerkleTree<
     })
   }
 
+  // Invalidate and pastSize entries greater than maxSize
+  private invalidatePastRootCache(maxSize: number, tx?: IDatabaseTransaction): void {
+    if (tx instanceof LevelupTransaction) {
+      const local = this.localPastRootCache.get(tx.id)
+      for (const pastSize of local?.keys() || []) {
+        if (pastSize > maxSize) {
+          local?.delete(pastSize)
+        }
+      }
+    }
+
+    for (const pastSize of this.globalPastRootCache.keys()) {
+      if (pastSize > maxSize) {
+        this.globalPastRootCache.remove(pastSize)
+      }
+    }
+  }
+
+  private setPastRootCache(pastSize: number, hash: H, tx: IDatabaseTransaction): void {
+    if (tx instanceof LevelupTransaction) {
+      const cache = this.localPastRootCache.get(tx.id) || new Map<number, H>()
+      cache.set(pastSize, hash)
+      this.localPastRootCache.set(tx.id, cache)
+    }
+  }
+
+  private getPastRootCache(pastSize: number, tx?: IDatabaseTransaction): H | null {
+    if (tx instanceof LevelupTransaction) {
+      const local = this.localPastRootCache.get(tx.id)
+      const localResult = local && local.get(pastSize)
+
+      return localResult || this.globalPastRootCache.get(pastSize)
+    }
+
+    return this.globalPastRootCache.get(pastSize)
+  }
+
+  pastRootTxCommited(tx: IDatabaseTransaction): void {
+    if (tx instanceof LevelupTransaction) {
+      const local = this.localPastRootCache.get(tx.id)
+      for (const [pastSize, hash] of local?.entries() || []) {
+        this.globalPastRootCache.set(pastSize, hash)
+      }
+      this.localPastRootCache.remove(tx.id)
+    }
+  }
+
   /**
    * Calculate what the root hash was at the time the tree contained
    * `pastSize` elements. Throws an error if the tree is empty,
@@ -481,6 +537,11 @@ export class MerkleTree<
 
       if (leafCount === 0 || pastSize > leafCount || pastSize === 0) {
         throw new Error(`Unable to get past size ${pastSize} for tree with ${leafCount} nodes`)
+      }
+
+      const cached = this.getPastRootCache(pastSize, tx)
+      if (cached) {
+        return Promise.resolve(cached)
       }
 
       const rootDepth = depthAtLeafCount(pastSize)
@@ -527,6 +588,7 @@ export class MerkleTree<
         currentHash = this.hasher.combineHash(depth, currentHash, currentHash)
       }
 
+      this.setPastRootCache(pastSize, currentHash, tx)
       return currentHash
     })
   }


### PR DESCRIPTION
## Summary
When validating transactions, the validator loops through every spend in the transaction and compares the spend’s commitment to the note tree’s hash at the spend’s tree size. To do this, it recalculates the root hash of the note tree at the spend’s tree size. Since our transaction creation uses block-aligned tree sizes for spend commitments, there should be a clustering of common tree sizes in spends. Adding a cache here should greatly reduce the amount of rehashing needed in the merkle tree when adding a block.

## Testing Plan
Local testing and unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
