### PR TITLE
refactor(nodejs,rust): `ProposedTransaction.transaction_fee` -> `ProposedTransaction.value_balance`

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -126,7 +126,7 @@ export class Transaction {
    * wouldn't accept a transaction that takes money away from them.
    *
    * sum(spends) - sum(outputs) - intended_transaction_fee - change = 0
-   * aka: self.transaction_fee - intended_transaction_fee - change = 0
+   * aka: self.value_balance - intended_transaction_fee - change = 0
    */
   post(changeGoesTo: string | undefined | null, intendedTransactionFee: bigint): Buffer
   setExpirationSequence(expirationSequence: number): void

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -111,7 +111,7 @@ impl NativeTransactionPosted {
 
     #[napi]
     pub fn fee(&self) -> i64n {
-        i64n(self.transaction.transaction_fee())
+        i64n(self.transaction.fee())
     }
 
     #[napi]

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -193,7 +193,7 @@ impl NativeTransaction {
     /// wouldn't accept a transaction that takes money away from them.
     ///
     /// sum(spends) - sum(outputs) - intended_transaction_fee - change = 0
-    /// aka: self.transaction_fee - intended_transaction_fee - change = 0
+    /// aka: self.value_balance - intended_transaction_fee - change = 0
     #[napi]
     pub fn post(
         &mut self,

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -53,7 +53,7 @@ fn test_transaction() {
     public_transaction
         .verify()
         .expect("Should be able to verify transaction");
-    assert_eq!(public_transaction.transaction_fee(), 1);
+    assert_eq!(public_transaction.fee(), 1);
 
     // A change note was created
     assert_eq!(public_transaction.outputs.len(), 2);
@@ -66,10 +66,7 @@ fn test_transaction() {
     let read_back_transaction: Transaction =
         Transaction::read(&mut serialized_transaction[..].as_ref())
             .expect("should be able to deserialize valid transaction");
-    assert_eq!(
-        public_transaction.transaction_fee,
-        read_back_transaction.transaction_fee
-    );
+    assert_eq!(public_transaction.fee, read_back_transaction.fee);
     assert_eq!(
         public_transaction.spends.len(),
         read_back_transaction.spends.len()
@@ -94,7 +91,7 @@ fn test_miners_fee() {
     let posted_transaction = transaction
         .post_miners_fee()
         .expect("it is a valid miner's fee");
-    assert_eq!(posted_transaction.transaction_fee, -42);
+    assert_eq!(posted_transaction.fee, -42);
     assert_eq!(
         posted_transaction
             .iter_outputs()


### PR DESCRIPTION
## Summary

Refactor the `transaction_fee` field because it's not accurate

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
