### PR TITLE
resets head hash if header is null in getLatestHeadHash

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1172,7 +1172,7 @@ export class Wallet {
             'hex',
           )}. This account needs to be rescanned.`,
         )
-        await this.walletDb.saveHeadHash(account, null)
+        await this.updateHeadHash(account, null)
         continue
       }
 
@@ -1202,7 +1202,7 @@ export class Wallet {
             'hex',
           )}. This account needs to be rescanned.`,
         )
-        await this.walletDb.saveHeadHash(account, null)
+        await this.updateHeadHash(account, null)
         continue
       }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1187,16 +1187,24 @@ export class Wallet {
   async getLatestHeadHash(): Promise<Buffer | null> {
     let latestHeader = null
 
-    for (const headHash of this.headHashes.values()) {
+    for (const account of this.accounts.values()) {
+      const headHash = this.headHashes.get(account.id)
+
       if (!headHash) {
         continue
       }
 
       const header = await this.chain.getHeader(headHash)
-      Assert.isNotNull(
-        header,
-        `getLatestHeadHash: No header found for ${headHash.toString('hex')}`,
-      )
+
+      if (!header) {
+        this.logger.warn(
+          `${account.displayName} has an invalid head hash ${headHash.toString(
+            'hex',
+          )}. This account needs to be rescanned.`,
+        )
+        await this.walletDb.saveHeadHash(account, null)
+        continue
+      }
 
       if (!latestHeader || latestHeader.sequence < header.sequence) {
         latestHeader = header


### PR DESCRIPTION
## Summary

if a user downloads a snapshot and an account's head hash is not in the chain, then their node cannot recover unless the account database is removed.

- changes getLatestHeadHash to behave the same way as getEarliestHeadHash and set the head hash to null if the header is not found

## Testing Plan
1. create account
2. use `ironfish repl` to set the head hash for that account to a random string
3. try to start the node

with changes applied, starting the node results in a rescan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
