### PR TITLE
Remove transaction withReference wallet

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -405,19 +405,17 @@ export class Wallet {
   ): Promise<void> {
     const initialNoteIndex = 'initialNoteIndex' in params ? params.initialNoteIndex : null
 
-    await transaction.withReference(async () => {
-      const decryptedNotesByAccountId = await this.decryptNotes(
-        transaction,
-        initialNoteIndex,
-        accounts,
-      )
+    const decryptedNotesByAccountId = await this.decryptNotes(
+      transaction,
+      initialNoteIndex,
+      accounts,
+    )
 
-      for (const [accountId, decryptedNotes] of decryptedNotesByAccountId) {
-        const account = this.accounts.get(accountId)
-        Assert.isNotUndefined(account, `syncTransaction: No account found for ${accountId}`)
-        await account.syncTransaction(transaction, decryptedNotes, params)
-      }
-    })
+    for (const [accountId, decryptedNotes] of decryptedNotesByAccountId) {
+      const account = this.accounts.get(accountId)
+      Assert.isNotUndefined(account, `syncTransaction: No account found for ${accountId}`)
+      await account.syncTransaction(transaction, decryptedNotes, params)
+    }
   }
 
   async scanTransactions(): Promise<void> {


### PR DESCRIPTION
## Summary
We make a call to [withReference](https://github.com/iron-fish/ironfish/blob/6651ab318530a7bd86aa82b83fbaf5ef8e0ebf28/ironfish/src/wallet/wallet.ts#L408) in the wallet code that is not necessary. This seems to be a relic of older code.

Deserializing the transaction into an underlying Rust Transaction struct can be slow, and in the past it was also leaking memory to keep a constructed Rust transaction object around. So the withReference function keeps track of how many references we have to a Rust object and once we don't need the reference anymore it deletes the Rust object.

previously in this wallet code we probably needed to access multiple fields on the Rust object. One of those calls was a call to `unsignedHash` on the Transaction. We [replaced unsignedHash](https://github.com/iron-fish/ironfish/pull/2069/files) with the hash function which does not access Rust code so constructing the Rust struct is no longer needed here. We can remove this reference.

## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
