### PR TITLE
Fix block download speed calculation

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -367,7 +367,7 @@ export class Syncer {
       )
 
       const elapsedSeconds = BenchUtils.end(start) / 1000
-      this.downloadSpeed.add(blocks.length + 1 / elapsedSeconds)
+      this.downloadSpeed.add((blocks.length + 1) / elapsedSeconds)
 
       if (!headBlock) {
         peer.punish(BAN_SCORE.MAX, 'empty GetBlocks message')


### PR DESCRIPTION
## Summary

The block download speed was missing parentheses, so it was calculating (blocks.length) + (1 / elapsedSeconds) rather than (blocks.length + 1) / elapsedSeconds.

This should give us a more accurate view of the block download speed.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
