### PR TITLE
Update deposit and deposit-all with new fee estimation

### DIFF
--- a/ironfish-cli/src/commands/deposit.ts
+++ b/ironfish-cli/src/commands/deposit.ts
@@ -93,9 +93,15 @@ export default class Bank extends IronfishCommand {
     if (flags.fee) {
       const [parsedFee] = BigIntUtils.tryParse(flags.fee)
 
-      if (parsedFee != null) {
-        fee = parsedFee
+      if (parsedFee == null) {
+        this.log(`Error reading the fee value, please enter a valid number.`)
+        this.exit(0)
+      } else if (parsedFee <= 0n) {
+        this.log(`The minimum fee is ${CurrencyUtils.renderIron(1n, true)}`)
+        this.exit(0)
       }
+
+      fee = parsedFee
     }
 
     const balanceResp = await this.client.getAccountBalance({ account: accountName })
@@ -123,7 +129,6 @@ export default class Bank extends IronfishCommand {
       this.client,
       this.api,
       expirationSequenceDelta,
-      fee,
       graffiti,
     )
     if (!canSend) {

--- a/ironfish-cli/src/commands/fees.ts
+++ b/ironfish-cli/src/commands/fees.ts
@@ -33,9 +33,9 @@ export class FeeCommand extends IronfishCommand {
 
       this.log(
         `Fee distribution for last ${JSON.stringify(numOfBlocks)} block\n` +
-          `percentile ${JSON.stringify(low)}: ${response.content.low || ''} ORE\n` +
-          `percentile ${JSON.stringify(medium)}: ${response.content.medium || ''} ORE\n` +
-          `percentile ${JSON.stringify(high)}: ${response.content.high || ''} ORE\n`,
+          `percentile ${JSON.stringify(low)}: ${response.content.low || ''} ORE/kb\n` +
+          `percentile ${JSON.stringify(medium)}: ${response.content.medium || ''} ORE/kb\n` +
+          `percentile ${JSON.stringify(high)}: ${response.content.high || ''} ORE/kb\n`,
       )
     } catch (error: unknown) {
       if (error instanceof Error) {

--- a/ironfish-cli/src/commands/fees.ts
+++ b/ironfish-cli/src/commands/fees.ts
@@ -1,10 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ConfigOptions } from '@ironfish/sdk'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 
-const DEFAULT_BLOCKS_TO_FETCH = 10
+const DEFAULT_NUM_OF_BLOCKS = 10
 
 export class FeeCommand extends IronfishCommand {
   static description = `Get fee distribution for most recent blocks`
@@ -13,32 +14,28 @@ export class FeeCommand extends IronfishCommand {
     ...RemoteFlags,
   }
 
-  static args = [
-    {
-      name: 'blocks',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
-      required: false,
-      description: 'Number of the latest blocks to calculate fees for',
-    },
-  ]
-
   async start(): Promise<void> {
-    const { args } = await this.parse(FeeCommand)
-    const blocks = args.blocks as number | null
-
-    const numOfBlocks = blocks || DEFAULT_BLOCKS_TO_FETCH
-
     const client = await this.sdk.connectRpc()
 
     try {
-      const response = await client.getFees({ numOfBlocks })
+      const response = await client.estimateFeeRates({})
+
+      const config = await client.getConfig({})
+
+      const configKey = 'feeEstimatorMaxBlockHistory' as keyof Partial<ConfigOptions>
+      const low =
+        config.content['feeEstimatorPercentileLow' as keyof Partial<ConfigOptions>] || '10'
+      const medium =
+        config.content['feeEstimatorPercentileMedium' as keyof Partial<ConfigOptions>] || '20'
+      const high =
+        config.content['feeEstimatorPercentileHigh' as keyof Partial<ConfigOptions>] || '30'
+      const numOfBlocks = config.content[configKey] || DEFAULT_NUM_OF_BLOCKS
 
       this.log(
-        `Fee distribution for last ${numOfBlocks} block${numOfBlocks > 1 ? 's' : ''}: (${
-          response.content.startBlock
-        } - ${response.content.endBlock})\np25: ${response.content.p25} ORE\np50: ${
-          response.content.p50
-        } ORE\np75: ${response.content.p75} ORE`,
+        `Fee distribution for last ${JSON.stringify(numOfBlocks)} block\n` +
+          `percentile ${JSON.stringify(low)}: ${response.content.low || ''} ORE\n` +
+          `percentile ${JSON.stringify(medium)}: ${response.content.medium || ''} ORE\n` +
+          `percentile ${JSON.stringify(high)}: ${response.content.high || ''} ORE\n`,
       )
     } catch (error: unknown) {
       if (error instanceof Error) {

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { CurrencyUtils, RpcClient, WebApi } from '@ironfish/sdk'
+import { RpcClient, WebApi } from '@ironfish/sdk'
 
 const REGISTER_URL = 'https://testnet.ironfish.network/signup'
 
@@ -10,7 +10,6 @@ export async function verifyCanSend(
   client: RpcClient,
   api: WebApi,
   expirationSequenceDelta: number | undefined,
-  fee: bigint,
   graffiti: string,
 ): Promise<{ canSend: boolean; errorReason: string | null }> {
   const status = await client.getNodeStatus()
@@ -56,13 +55,6 @@ export async function verifyCanSend(
     return {
       canSend: false,
       errorReason: 'Expiration sequence delta should not be above 120 blocks',
-    }
-  }
-
-  if (fee <= 0n) {
-    return {
-      canSend: false,
-      errorReason: `The minimum fee is ${CurrencyUtils.renderIron(1n, true)}`,
     }
   }
 


### PR DESCRIPTION
## Summary
Use new fee estimation for 
- deposit
- deposit-all
- fees
Use medium priority level as the fee estimation.
## Testing Plan
local
```
yarn start deposit
yarn run v1.22.19
$ yarn build && yarn start:js deposit
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run deposit
Insufficient balance: 0.00000000 IRON.  Fee (0.00000365 IRON) + minimum deposit (0.1 IRON) = total required (0.10000365 IRON)
```
```
yarn start deposit -f 0.1
yarn run v1.22.19
$ yarn build && yarn start:js deposit -f 0.1
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run deposit -f 0.1
Error reading the fee value, please enter a valid number.
```

```
yarn start fees
yarn run v1.22.19
$ yarn build && yarn start:js fees
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run fees
Fee distribution for last 10 block
percentile 10: 654 ORE
percentile 20: 654 ORE
percentile 30: 654 ORE
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
