### PR TITLE
Downgrade node-datachannel to 0.3.5

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -36,7 +36,7 @@
     "leveldown": "5.6.0",
     "levelup": "4.4.0",
     "lodash": "4.17.21",
-    "node-datachannel": "0.3.6",
+    "node-datachannel": "0.3.5",
     "node-forge": "1.3.1",
     "parse-json": "5.2.0",
     "sqlite": "4.0.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8264,10 +8264,10 @@ node-cleanup@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
 
-node-datachannel@0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/node-datachannel/-/node-datachannel-0.3.6.tgz#1ce1167ec5324d3719bd19c92570b7d5642f06f0"
-  integrity sha512-weZD9Do1sFvAxznUETWDP/XOvge85NzKeEid0kzHyYF09p8IOYcnwg+rxkgymF3WviZXRYWxHCxjyPHIZnKkLw==
+node-datachannel@0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/node-datachannel/-/node-datachannel-0.3.5.tgz#a8ec9c99ec1d4e06aef7d6f1966129d23c30b060"
+  integrity sha512-hlNdgjTsmXS+0ZPpV+/JdCQwDPz+CWRnaC4i9jj08KyAqEWRkYV7gkNKiR0wV+E9NlbJrgcYB5GzaCwxLk6gug==
   dependencies:
     prebuild-install "^7.0.1"
 


### PR DESCRIPTION
## Summary

node-datachannel was upgraded in https://github.com/iron-fish/ironfish/pull/2263, but that version caused Windows users to build node-datachannel from source. I've filed an issue with node-datachannel here: https://github.com/murat-dogan/node-datachannel/issues/138 but since we likely have more Windows users than M1 users, I think it's a good idea to downgrade for now.

## Testing Plan

* [ ] Install this branch on a clean Windows installation and check which dependencies are required.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
