### PR TITLE
Default to 5 for blocksPerMessage which should increase sync stability

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -391,7 +391,7 @@ export class Config extends KeyStore<ConfigOptions> {
       telemetryApi: DEFAULT_TELEMETRY_API,
       accountName: DEFAULT_WALLET_NAME,
       generateNewIdentity: false,
-      blocksPerMessage: 20,
+      blocksPerMessage: 5,
       minerBatchSize: DEFAULT_MINER_BATCH_SIZE,
       poolName: DEFAULT_POOL_NAME,
       poolAccountName: DEFAULT_POOL_ACCOUNT_NAME,


### PR DESCRIPTION
## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
