### PR TITLE
Parallelize downloading and adding blocks

### DIFF
--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -600,7 +600,9 @@ export class PeerNetwork {
     })
   }
 
-  async getBlockHashes(peer: Peer, start: number, limit: number): Promise<Buffer[]> {
+  async getBlockHashes(peer: Peer, start: number, limit: number): Promise<[Buffer[], number]> {
+    const begin = BenchUtils.start()
+
     const message = new GetBlockHashesRequest(start, limit)
     const response = await this.requestFrom(peer, message)
 
@@ -611,10 +613,16 @@ export class PeerNetwork {
       )
     }
 
-    return response.message.hashes
+    return [response.message.hashes, BenchUtils.end(begin)]
   }
 
-  async getBlocks(peer: Peer, start: Buffer, limit: number): Promise<SerializedBlock[]> {
+  async getBlocks(
+    peer: Peer,
+    start: Buffer,
+    limit: number,
+  ): Promise<[SerializedBlock[], number]> {
+    const begin = BenchUtils.start()
+
     const message = new GetBlocksRequest(start, limit)
     const response = await this.requestFrom(peer, message)
 
@@ -623,7 +631,7 @@ export class PeerNetwork {
       throw new Error(`Invalid GetBlocksResponse: ${displayNetworkMessageType(message.type)}`)
     }
 
-    return response.message.blocks
+    return [response.message.blocks, BenchUtils.end(begin)]
   }
 
   private async handleMessage(

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -600,7 +600,11 @@ export class PeerNetwork {
     })
   }
 
-  async getBlockHashes(peer: Peer, start: number, limit: number): Promise<[Buffer[], number]> {
+  async getBlockHashes(
+    peer: Peer,
+    start: number,
+    limit: number,
+  ): Promise<{ hashes: Buffer[]; time: number }> {
     const begin = BenchUtils.start()
 
     const message = new GetBlockHashesRequest(start, limit)
@@ -613,14 +617,14 @@ export class PeerNetwork {
       )
     }
 
-    return [response.message.hashes, BenchUtils.end(begin)]
+    return { hashes: response.message.hashes, time: BenchUtils.end(begin) }
   }
 
   async getBlocks(
     peer: Peer,
     start: Buffer,
     limit: number,
-  ): Promise<[SerializedBlock[], number]> {
+  ): Promise<{ blocks: SerializedBlock[]; time: number }> {
     const begin = BenchUtils.start()
 
     const message = new GetBlocksRequest(start, limit)
@@ -631,7 +635,7 @@ export class PeerNetwork {
       throw new Error(`Invalid GetBlocksResponse: ${displayNetworkMessageType(message.type)}`)
     }
 
-    return [response.message.blocks, BenchUtils.end(begin)]
+    return { blocks: response.message.blocks, time: BenchUtils.end(begin) }
   }
 
   private async handleMessage(

--- a/ironfish/src/syncer.test.ts
+++ b/ironfish/src/syncer.test.ts
@@ -178,7 +178,7 @@ describe('Syncer', () => {
     expect(getBlocksSpy).toHaveBeenNthCalledWith(4, peer, blockA3.header.hash, 2)
   })
 
-  it.only('should ban peers that send empty responses', async () => {
+  it('should ban peers that send empty responses', async () => {
     const { strategy, chain, peerNetwork, syncer } = nodeTest
 
     strategy.disableMiningReward()

--- a/ironfish/src/syncer.test.ts
+++ b/ironfish/src/syncer.test.ts
@@ -158,15 +158,26 @@ describe('Syncer', () => {
     const getBlocksSpy = jest
       .spyOn(peerNetwork, 'getBlocks')
       .mockImplementationOnce(() =>
-        Promise.resolve([[BlockSerde.serialize(genesis), BlockSerde.serialize(blockA1)], 100]),
+        Promise.resolve({
+          blocks: [BlockSerde.serialize(genesis), BlockSerde.serialize(blockA1)],
+          time: 100,
+        }),
       )
       .mockImplementationOnce(() =>
-        Promise.resolve([[BlockSerde.serialize(blockA1), BlockSerde.serialize(blockA2)], 100]),
+        Promise.resolve({
+          blocks: [BlockSerde.serialize(blockA1), BlockSerde.serialize(blockA2)],
+          time: 100,
+        }),
       )
       .mockImplementationOnce(() =>
-        Promise.resolve([[BlockSerde.serialize(blockA2), BlockSerde.serialize(blockA3)], 100]),
+        Promise.resolve({
+          blocks: [BlockSerde.serialize(blockA2), BlockSerde.serialize(blockA3)],
+          time: 100,
+        }),
       )
-      .mockImplementationOnce(() => Promise.resolve([[BlockSerde.serialize(blockA3)], 100]))
+      .mockImplementationOnce(() =>
+        Promise.resolve({ blocks: [BlockSerde.serialize(blockA3)], time: 100 }),
+      )
 
     syncer.loader = peer
     await syncer.syncBlocks(peer, genesis.header.hash, genesis.header.sequence)
@@ -193,7 +204,7 @@ describe('Syncer', () => {
 
     const getBlocksSpy = jest
       .spyOn(peerNetwork, 'getBlocks')
-      .mockImplementation(() => Promise.resolve([[], 100]))
+      .mockImplementation(() => Promise.resolve({ blocks: [], time: 100 }))
     const peerPunished = jest.spyOn(peer, 'punish')
 
     syncer.loader = peer

--- a/ironfish/src/syncer.test.ts
+++ b/ironfish/src/syncer.test.ts
@@ -158,15 +158,15 @@ describe('Syncer', () => {
     const getBlocksSpy = jest
       .spyOn(peerNetwork, 'getBlocks')
       .mockImplementationOnce(() =>
-        Promise.resolve([BlockSerde.serialize(genesis), BlockSerde.serialize(blockA1)]),
+        Promise.resolve([[BlockSerde.serialize(genesis), BlockSerde.serialize(blockA1)], 100]),
       )
       .mockImplementationOnce(() =>
-        Promise.resolve([BlockSerde.serialize(blockA1), BlockSerde.serialize(blockA2)]),
+        Promise.resolve([[BlockSerde.serialize(blockA1), BlockSerde.serialize(blockA2)], 100]),
       )
       .mockImplementationOnce(() =>
-        Promise.resolve([BlockSerde.serialize(blockA2), BlockSerde.serialize(blockA3)]),
+        Promise.resolve([[BlockSerde.serialize(blockA2), BlockSerde.serialize(blockA3)], 100]),
       )
-      .mockImplementationOnce(() => Promise.resolve([BlockSerde.serialize(blockA3)]))
+      .mockImplementationOnce(() => Promise.resolve([[BlockSerde.serialize(blockA3)], 100]))
 
     syncer.loader = peer
     await syncer.syncBlocks(peer, genesis.header.hash, genesis.header.sequence)
@@ -178,7 +178,7 @@ describe('Syncer', () => {
     expect(getBlocksSpy).toHaveBeenNthCalledWith(4, peer, blockA3.header.hash, 2)
   })
 
-  it('should ban peers that send empty responses', async () => {
+  it.only('should ban peers that send empty responses', async () => {
     const { strategy, chain, peerNetwork, syncer } = nodeTest
 
     strategy.disableMiningReward()
@@ -193,7 +193,7 @@ describe('Syncer', () => {
 
     const getBlocksSpy = jest
       .spyOn(peerNetwork, 'getBlocks')
-      .mockImplementation(() => Promise.resolve([]))
+      .mockImplementation(() => Promise.resolve([[], 100]))
     const peerPunished = jest.spyOn(peer, 'punish')
 
     syncer.loader = peer

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -13,7 +13,7 @@ import { BAN_SCORE, PeerState } from './network/peers/peer'
 import { Block, BlockSerde, SerializedBlock } from './primitives/block'
 import { BlockHeader } from './primitives/blockheader'
 import { Telemetry } from './telemetry'
-import { BenchUtils, ErrorUtils, HashUtils, MathUtils, SetTimeoutToken } from './utils'
+import { ErrorUtils, HashUtils, MathUtils, SetTimeoutToken } from './utils'
 import { ArrayUtils } from './utils/array'
 
 const SYNCER_TICK_MS = 10 * 1000

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -341,16 +341,14 @@ export class Syncer {
     }
   }
 
-  async syncBlocks(peer: Peer, head: Buffer | null, sequence: number): Promise<void> {
+  async syncBlocks(peer: Peer, head: Buffer, sequence: number): Promise<void> {
     this.abort(peer)
 
     let count = 0
     let skipped = 0
     let blocksPromise: Promise<[SerializedBlock[], number]> = Promise.resolve([[], 0])
 
-    if (head) {
-      blocksPromise = this.peerNetwork.getBlocks(peer, head, this.blocksPerMessage + 1)
-    }
+    blocksPromise = this.peerNetwork.getBlocks(peer, head, this.blocksPerMessage + 1)
 
     while (head) {
       this.logger.info(

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -258,7 +258,7 @@ export class Syncer {
       requests++
 
       const needle = start - i * 2
-      const [hashes, _] = await this.peerNetwork.getBlockHashes(peer, needle, 1)
+      const { hashes } = await this.peerNetwork.getBlockHashes(peer, needle, 1)
       if (!hashes.length) {
         continue
       }
@@ -300,7 +300,7 @@ export class Syncer {
       requests++
 
       const needle = Math.floor((lower + upper) / 2)
-      const [hashes, time] = await this.peerNetwork.getBlockHashes(peer, needle, 1)
+      const { hashes, time } = await this.peerNetwork.getBlockHashes(peer, needle, 1)
       const remote = hashes.length === 1 ? hashes[0] : null
 
       const { found, local } = await hasHash(remote)
@@ -346,7 +346,10 @@ export class Syncer {
 
     let count = 0
     let skipped = 0
-    let blocksPromise: Promise<[SerializedBlock[], number]> = Promise.resolve([[], 0])
+    let blocksPromise: Promise<{ blocks: SerializedBlock[]; time: number }> = Promise.resolve({
+      blocks: [],
+      time: 0,
+    })
 
     blocksPromise = this.peerNetwork.getBlocks(peer, head, this.blocksPerMessage + 1)
 
@@ -357,7 +360,10 @@ export class Syncer {
         )} (${sequence}) from ${peer.displayName}`,
       )
 
-      const [[headBlock, ...blocks], time]: [SerializedBlock[], number] = await blocksPromise
+      const {
+        blocks: [headBlock, ...blocks],
+        time,
+      } = await blocksPromise
 
       if (!headBlock) {
         peer.punish(BAN_SCORE.MAX, 'empty GetBlocks message')

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -346,20 +346,16 @@ export class Syncer {
 
     let count = 0
     let skipped = 0
-    let blocksPromise: Promise<{ blocks: SerializedBlock[]; time: number }> = Promise.resolve({
-      blocks: [],
-      time: 0,
-    })
 
-    blocksPromise = this.peerNetwork.getBlocks(peer, head, this.blocksPerMessage + 1)
+    this.logger.info(
+      `Requesting ${this.blocksPerMessage} blocks starting at ${HashUtils.renderHash(
+        head,
+      )} (${sequence}) from ${peer.displayName}`,
+    )
+
+    let blocksPromise = this.peerNetwork.getBlocks(peer, head, this.blocksPerMessage + 1)
 
     while (head) {
-      this.logger.info(
-        `Requesting ${this.blocksPerMessage} blocks starting at ${HashUtils.renderHash(
-          head,
-        )} (${sequence}) from ${peer.displayName}`,
-      )
-
       const {
         blocks: [headBlock, ...blocks],
         time,
@@ -376,6 +372,12 @@ export class Syncer {
       if (blocks.length >= this.blocksPerMessage) {
         const lastBlock = blocks.at(-1) || headBlock
         const block = BlockSerde.deserialize(lastBlock)
+
+        this.logger.info(
+          `Requesting ${this.blocksPerMessage} blocks starting at ${HashUtils.renderHash(
+            head,
+          )} (${sequence}) from ${peer.displayName}`,
+        )
 
         blocksPromise = this.peerNetwork.getBlocks(
           peer,


### PR DESCRIPTION
## Summary
Currently we sequentially download a group of blocks (20) and then add them to the chain. If we parallelize this we can start adding blocks while we are downloading the next group of blocks from peers. After some improvements to addBlock such as caching pastRoot and batch adding notes to the merkle tree addBlock time has improved a lot. Now the limitation seems to be more around downloading blocks. We're seeing download speeds anywhere from 0.5 - 20 blocks per second depending on the peer and connection. We are seeing add block times of ~1-2 blocks/s. If we parallelize these we could potentially double syncing speed. 

## Testing Plan
Local testing and unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
