### PR TITLE
Remove CurrencyUtils.isValid*()

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -75,10 +75,6 @@ export class Pay extends IronfishCommand {
     }
 
     if (flags.amount) {
-      if (!CurrencyUtils.isValidIron(flags.amount)) {
-        this.error(`A valid amount is required`)
-      }
-
       amount = CurrencyUtils.decodeIron(flags.amount)
     }
 
@@ -94,17 +90,10 @@ export class Pay extends IronfishCommand {
         },
       )) as string
 
-      if (!CurrencyUtils.isValidIron(input)) {
-        this.error(`A valid amount is required`)
-      }
-
       amount = CurrencyUtils.decodeIron(input)
     }
 
     if (flags.fee) {
-      if (!CurrencyUtils.isValidIron(flags.fee)) {
-        this.error(`A valid fee is required`)
-      }
       fee = CurrencyUtils.decodeIron(flags.fee)
     }
 
@@ -174,10 +163,6 @@ export class Pay extends IronfishCommand {
           default: suggestedFee,
         },
       )) as string
-
-      if (!CurrencyUtils.isValidIron(input)) {
-        this.error(`A valid amount is required`)
-      }
 
       fee = CurrencyUtils.decodeIron(input)
     }

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -109,7 +109,7 @@ describe('Transactions sendTransaction', () => {
     await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrowError(
       expect.objectContaining({
         message: expect.stringContaining(
-          'Please wait a few seconds for your balance to update and try again',
+          'Your balance is too low. Add funds to your account first',
         ),
         status: 400,
         code: ERROR_CODES.INSUFFICIENT_BALANCE,
@@ -127,7 +127,7 @@ describe('Transactions sendTransaction', () => {
     await expect(routeTest.client.sendTransaction(TEST_PARAMS_MULTI)).rejects.toThrowError(
       expect.objectContaining({
         message: expect.stringContaining(
-          'Please wait a few seconds for your balance to update and try again',
+          'Your balance is too low. Add funds to your account first',
         ),
         status: 400,
         code: ERROR_CODES.INSUFFICIENT_BALANCE,

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { ArrayUtils, CurrencyUtils } from '../../../utils'
+import { CurrencyUtils } from '../../../utils'
 import { NotEnoughFundsError } from '../../../wallet/errors'
 import { ERROR_CODES, ValidationError } from '../../adapters/errors'
 import { ApiNamespace, router } from '../router'

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { CurrencyUtils } from '../../../utils'
+import { ArrayUtils, CurrencyUtils } from '../../../utils'
 import { NotEnoughFundsError } from '../../../wallet/errors'
 import { ERROR_CODES, ValidationError } from '../../adapters/errors'
 import { ApiNamespace, router } from '../router'
@@ -92,52 +92,37 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
       )
     }
 
-    // Check whether amount and fee are valid or not
-    if (!CurrencyUtils.isValidOre(transaction.fee)) {
-      throw new ValidationError(
-        `Invalid transaction fee, ${transaction.fee}`,
-        undefined,
-        ERROR_CODES.VALIDATION,
-      )
-    }
-    let sum = BigInt(transaction.fee)
-    transaction.receives.map((receive) => {
-      if (!CurrencyUtils.isValidOre(receive.amount)) {
-        throw new ValidationError(
-          `Invalid transaction amount, ${receive.amount}`,
-          undefined,
-          ERROR_CODES.VALIDATION,
-        )
+    const receives = transaction.receives.map((receive) => {
+      return {
+        publicAddress: receive.publicAddress,
+        amount: CurrencyUtils.decode(receive.amount),
+        memo: receive.memo,
       }
-      sum += BigInt(receive.amount)
     })
+
+    const fee = CurrencyUtils.decode(transaction.fee)
+    const sum = receives.reduce((m, c) => m + c.amount, fee)
+
+    if (fee < 1n) {
+      throw new ValidationError(`Invalid transaction fee, ${transaction.fee}`)
+    }
+
+    for (const receive of receives) {
+      if (receive.amount < 0) {
+        throw new ValidationError(`Invalid transaction amount, ${receive.amount}`)
+      }
+    }
 
     // Check that the node account is updated
     const balance = await node.wallet.getBalance(account)
 
-    if (balance.confirmed < sum && balance.unconfirmed < sum) {
-      throw new ValidationError(
-        `Your balance is too low. Add funds to your account first`,
-        undefined,
-        ERROR_CODES.INSUFFICIENT_BALANCE,
-      )
-    }
-
     if (balance.confirmed < sum) {
       throw new ValidationError(
-        `Please wait a few seconds for your balance to update and try again`,
+        'Your balance is too low. Add funds to your account first',
         undefined,
         ERROR_CODES.INSUFFICIENT_BALANCE,
       )
     }
-
-    const receives = transaction.receives.map((receive) => {
-      return {
-        publicAddress: receive.publicAddress,
-        amount: BigInt(receive.amount),
-        memo: receive.memo,
-      }
-    })
 
     try {
       const transactionPosted = await node.wallet.pay(

--- a/ironfish/src/utils/currency.test.ts
+++ b/ironfish/src/utils/currency.test.ts
@@ -59,11 +59,4 @@ describe('CurrencyUtils', () => {
     expect(CurrencyUtils.renderOre(100000000n)).toEqual('100000000')
     expect(CurrencyUtils.renderOre(1n, true)).toEqual('$ORE 1')
   })
-
-  test('isValidIronAmount returns the right value', () => {
-    expect(CurrencyUtils.isValidIron('0.0000000000001')).toBe(false)
-    expect(CurrencyUtils.isValidIron('100000000000000000000000000')).toBe(false)
-    expect(CurrencyUtils.isValidIron('0.00000001')).toBe(true)
-    expect(CurrencyUtils.isValidIron('10.000001')).toBe(true)
-  })
 })

--- a/ironfish/src/utils/currency.ts
+++ b/ironfish/src/utils/currency.ts
@@ -69,24 +69,6 @@ export class CurrencyUtils {
 
     return ore
   }
-
-  static isValidIron(amount: string): boolean {
-    try {
-      const ore = this.decodeIron(amount)
-      return this.isValidOre(this.encode(ore))
-    } catch (e) {
-      return false
-    }
-  }
-
-  static isValidOre(amount: string): boolean {
-    try {
-      const ore = this.decode(amount)
-      return ore >= MINIMUM_ORE_AMOUNT && ore <= MAXIMUM_ORE_AMOUNT
-    } catch (e) {
-      return false
-    }
-  }
 }
 
 export const ORE_TO_IRON = 100000000


### PR DESCRIPTION
## Summary

These have nothing to do with our currency. They have everything to do with user input validation that is more like isValidFee(). Let's keep our currency conversion code separate from our user input. If any input should be done in CurrencyUtils it's to ensure the values are within valid ranges.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
