### PR TITLE
iterates over pending transactions for rebroadcast

### DIFF
--- a/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
@@ -148,5 +148,137 @@
         }
       ]
     }
+  ],
+  "Accounts loadPendingTransactions should load pending transactions": [
+    {
+      "id": "2c49ae20-6933-4127-bc19-dcc4b05c036f",
+      "name": "accountA",
+      "spendingKey": "1d0539fd7977529efe3dfcc8bdcafc99fecd2cbca635308e2d345c374e54532b",
+      "incomingViewKey": "033862f95498bbb9551fbbf9de2fd441641551fd5c4951e534562ee8f43cc406",
+      "outgoingViewKey": "32b978ecc458dcb6b9e33a56da1fbf089eb0a3b3fecb41161bc0417aac44bc14",
+      "publicAddress": "29a645088920c8edf80248a7a3174fff77c953463f1debe3a0a2d586415cd77f1c0c4be9125e99ef20c333"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:UjA6teUm0zdhCh8kR844bY45inTXmn8q/cRV5LS2+Ww="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1667421473872,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "B6DDB1F2F69F8AC02DF4BDEC224ECF711119F97511177E76037A924AABFE334D",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIedpMd1JWayGtCt9yI88plaHHznDJQI0+R2pAT+N5ptW56+AsatH2kl4anodUzJJIPjwoqRbtuxfzLO+NPy8jwxwLJu3JFdJnJMVcpfggfXdFt36a1S/gKq0aQVopFepgRSpwYglXfFRcdRf9JKclzHXlW6yWzU4mm/GjLU297iZUMPlv31pcCguhwCngB7RKD6k6nCR0CMJMnNHDTTwX6HtHePh56JJLr3ONTy2M9CGIL/FwbwNwXYZBjBWuC+WoGiRtfqfa9pKEmM5rDnUhKFLx2GZllpuqz3fB+v+1ZuYh+anNdOsQhC59TQEnP4GmF8T7oIuuZ+t8MqulVHyQZ5iiuFV5BOM6QXyvT39/upJoSNYDt0T4775B8Vp+DMFCuVyV6Uaepo9WrL5H9qqCxzf0qWoZxO2IdhI97sKQViLQVNIcOLIxrtUQpbRexRqQtS/2rETWsdaGFFHGpejEPNW6pJIgo4DdNNbXbZSAZ6PJaVPqA1lgZ2DshJ1knYXJtXnUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQGXIOMdCs7TK234gnMt3oiM5wCIpY3j87j+Od/xuVszJktKED+rbhadTl04yddiOOGsm6SO0hyHf4zcXeECzDQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAABAAAALRx1LpYkNOWu06eSb4O0lKDXFFfVZGRt4tIb8lMSfuTxjClobOxtIRq6xpiz2AnEJHzbBOQ3wQF53sfrG7JeZqJSLohbY1ETo4z9End022RcT21Vmfev4Q5TJYwYPug0gfEn9iFah2N8rIYoNsPbKOTeYrdNbI3cH4z1Ard6eJlnuZYLIgsRvC/DhBWabIyULBxtOaxPbjHBbzz5BCcTtUdXf7B38QR8N+cmuFY05FhBm4q0Hs+zzY1lxZ4FMIuSkojPyHXTCdFAreP4w0zxFvU5GhumJk1pLdI+X7ZxI3lz9eA/bGaCSMwZLVUQP48QSDxkzTCXW2rZNzPXen0uR9SMDq15SbTN2EKHyRHzjhtjjmKdNeafyr9xFXktLb5bAQAAAAcjeIRiREeSu7nwUJgdREGhchvHZ5lAislKh9Wm/bsZAu8SmoWTakYqDK6C0bNi15qsC43rr73hTkjbr33TzIx3uPpgTh0Gs24/s/2/HGcj3iHVexZLL6v35A1h3C3yQKGpPMl2JJpeSJ1cintHVufLS0J5lS7pcMcFNB3+B4TSDLURPEkmnR+4+2z6xDqDUq0MMH+Xd69r5Bp7MjVnSt7Eu07V6TGeljJHzCQLumaDoXTb0eichOoj9j7CIpRp84I6sgMRWBjsSEgrNuq1c/mN1YEHvv95VHcjCl7q62FPaKIwkS6Y8ZuJVnRYkl3012mw5VFGsOfZYoKh8bN9qSikZMvC+OqtlVG24lduP/uBrbczTfSnk095e9nwGifRmXgyvU4tkRBgK8K5WfSDK3Jr5LJk8CdeXVRzMDlwCQpAAzbzU9W4bIwMsQsAU3G00aYsYoV3f+Su0n/TgT+mo5aRNjKjuzZRayhVf8aCnYI02FJKuIYROlD++VZWQVo1m+ZShZYDECYwa/xtiOP4toW1X8/sNi5sQ8IOUuHM/fTy2Y7DUF5HjEMzLnmxuxaTbgHtO6JhkBJ1iguOBR7eaSQiqSwBXnaHLeK7//SyAJNQldCIKHdXFRGgGoSuY9qGeAq0Azvw261IJXAAU6xJRKNZs26v7N9K4hapq8PeNxyy8V4LrI8jdJAbG/2fIOockEV7j3V0Flr7udOTERC2DRTdNfM8dpNZeQYHMiCgW6Di7gUSIe9GPH2PrR/aUTaFp2IzTv/eF1CnAbhVYvJTvHOqX8/IlDU4J6hq1nwnrxzQ0g5Q6lo6jhj7adMA8CHy6pyyMt7DJhJM0eb8L+oW/Uza4eDrnegvPOMk7T0bOPfxEPOlQ6YCJ0dQM7680ieDWLc+XyUZAmPwN3myG/5SJfe87XDgBzDZo9r7unvKaJkX8EiE4VpkGcQ13PSmcU7jkctestgCS+B1qoQ6j+zfY/EV7ovrlgnI1IjcxGwG1Oea5F9la4BFH2UcQ6hkIOxbew6jxpuWmVApqqXH+oJsQz3TIafNzImWTIXV7dCPFj6aZKsXpBsilHGvu0+HvP5gs3Kmy001KWWZdyzy/+5y3zMHDuJ01e6nzhOsZqudfPp/dTXDlXmKsWAwVBX3p9/iW/xH8yy+Ft6vB0BX5Nh1gPnT9duUvyXa5MkF0OrWC9aZo+/W/7xLxZ1/JVhOXD28k2jArxxX/UR7gv7f3kDmlkDNCyi+TW2PMfnJpjmrkDJyRx0vi3boLd/4kefmsbePGLf2G1XdW0QuS/eayxN22D23VvCndFUP4tkcxzemAjy3u4C5S9kMaDMRXSLysffZym4aBWgy5fRrncOY+oj7oR37XWsV03W8hVJ6yY2v6tXm3TxB/g+K8dh0sfUDX/jEqgrMQ6pAINiKQkLY5N8WAWKwUA/g0SXYnOW/bD3Hh+f1qNkcF8rCA=="
+    }
+  ],
+  "Accounts loadPendingTransactions should load transactions with no expiration": [
+    {
+      "id": "21701455-4bb1-4d6c-b2ba-38276f9b0017",
+      "name": "accountA",
+      "spendingKey": "ed88ff05597323eaf850cebd79fec10c53a709d93f30e3890e2e2be8b2b749a9",
+      "incomingViewKey": "9694b6ebc48d1098d676ec2247aec91a33bcd1a6d2681c9e1264d56a5735c304",
+      "outgoingViewKey": "e83af4c95215e7221dbf2df3e7df59dca17803c1ab6fe54f5fbe4424aceea518",
+      "publicAddress": "d4f745ad077c2de70032c2d7e05f96dff25b059b8fcc2ff2b6505df489683ea0e66317a4013f45418d78f2"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:k+hPWl6BayffTI16MHvJf2jQp6FVKJxefoLL9t0iCRk="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1667421963901,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "8F787A7D70EE8868339441AEAB6CBCA30D5A1CD5418EE82E8DC7070CD4DCBD1D",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALOJcttTRVpG2IHKi1uzhLKOV/ZLymQD9TQPZQVjYVbfpSksq73qdusVxt15uriFWLKiSLmM3bhWtrvYJLj9IUquKyXgqQmMTcJ7QPobXRO0WCSTUxt6iCP+5ngpHjB5TAlmhMaPRcuDbu889MJ3bSq6sr2fBat8TFj+n37kM8nAMDBFhMCvp0PNU6IGcCg5pbBb0HDJS6uzdy9RZpef1jTXlgch0aAw8dK4/11WwZZHdFzyj154xxYZadQyaCnDgtY46iPfXGp31jnNhFLmVX519+Hn3khTmff5zO+s03PAJrfpwtPXvatmso7v2d7KyUrp1JVcXYU+wmXa+x79bSoGnI6lnExH6mECekya/e2rXyxAtm9CaVl33MjEAto9csseXq3N5Qngq3l4vGMz8G/k+9kT3fMKtIJLzF/bjS8om7FJWEjmyVGyFIv145Yu7iPgXUboEzqyzZ9WQovv2J1PsSyv3BBtYf1EgSfFAA1J0R+UDC5T7YHc4VEiskd8k1HrwkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjxsU4xADsiQOwtD5RJUhME5lFXKmicKdw8+gnSbQaS6sEZIX7Dp/bcqlbwuYSnRbMAEqUzD590f0XwRKrPjPCw=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAKjbRtcFNcjUjsEiczZygj2SR0FC1BK1fp22qzGX4XtPg4RVmLYroPrtMU+7bcpmiIvLb90eTjyvNe7wVzh6dIF1B4DFvSkWvtsuBi2lUqqh3KtZXc1PWPRG3fklY2gPaxGVeFLxtRorrpcom1UMWmtSopN5HlDW7bwX4b618JxM/fkL9KXHP2IjMxBUH5ekJJiGUmm/atx5FfwkwWsu5qx3Xadd6SKgFWKoXQZGZbU5KurzRA25QFCo5j0YyYb5G/8jYs4LXnC5c/r/RvGdaNsXdA+1NjWx3cLNupRUqjXF26V+GC8n6QdKMt1cSsTZSEKO+ggl13fVHyNpoqw8UA2T6E9aXoFrJ99MjXowe8l/aNCnoVUonF5+gsv23SIJGQQAAAA1Dqo5eLxWzenwLGBTiQBFRGdD5NlFmxSoBGuhbwaDKzE0kWmdyQM5vMrF6878M7+0BD/KEwFgxSdJdyx27D2xDozWfLP3jIvoOsiZRRlWxrIIgzOxOA+Omnc05NSroAi3sZYoPo8qh+aHueYFeqFfC/XkuSwLxJRVWxeEEkNMXdi/7EglrRw5cbhS1LAsEnWKPRX/M4OJzE3TKrSnGoNk4vQB+zNHL0qHDo9xhgQ6UdjhoBx8tRw/TQfa6BWZYIkWh2MlsFWkPudT+ugI37twA9TszFuIKHir0LyKzCdg4RF0H56EY8VnK0E+2Mg6gTqiUFbT1+4ReeF0uTyUcXgwe/uY2+91VExktGFgTdOlC77Ar8u7MZtBderA5ZFOtKssN9E0GggiHyO7qfLuLcoZczL8FOrLL7tfyf5suTd3E1651icf0M5Rq+V+Sm6nFKZA8qsvTB/Qhig66xepF/JSSlFJnrjNwdNdMf9DKZG+5nGKXnUTr9/okmwrw7ZaX9HgJ0Vb3t1xNN0bfZNMT/mqPxFHeTykEC+rfGOavBipsJ33JbYwjiqIP6F3537u7fc7qCXAxxzVa8T8RiBBpo9h+XraS/wESdCT9DkXHJ8aaoMGxcGFWKL0vpoIihc2N3sdz87JmNEigX9MDXtavXSa1+maET/JTuE82WR3RLQ+FpzkN8OLlVqkj+Z1b30zey2Y9BanKyvb30Cw0SeVqRJDL6S5iFvS6rzPubIgS6ipD2r0U6ZlCGXlMIcwXmpALiJ/ErNLnzvhHIfRuGztwKpG9c5dgJa2+FrDSqmBgdMxtHBwaY6/i9qN0ccF9RXRdmn5oknxJ29UFc9irttvChkGRoWtKqo0rPKetx9HRBq7ic9WXBWT8ERbMXwqQ+7k915nL1FNPJGM209seuxrh5REiPGVG25TWceIXrX58bnvno9maYVS9R8yr0EV0o2bXCse4t5ZKTyhur4AQlEUzHO4I/PcCmG6VgW40x4iJlzBEljkUCDwJDL3ICjVhxvP8U6lBwJocOsRUw7zjNKi0rOI1VjtdzDy7lfJmzMWGqvJf8C23/7rBjoLamQX5PxkRD5bxQRipYgMwlK287gvzwAfKfpBQpdWN2KbDYquRRttU/8tlxvnQ8IAWX2QKV2tcFZ4oa7P+Ur3Mxz8VUEVKC3mXmjUHxp2eG1fXf8psJ2ucSNchZm3b9pJRVwyEHzz7aCMVhPWG2iWZLjGpTN370nibk5X1G0sJqMm1YlKSMOaOJK1mh+MUfOgCP0opjrvsspPMiGFMQyXIxRWqb+9Qgsqd1HPYM1ezGEqzfrmeukWGuZlkjppOEqXXwGL/VjboGESsHBQpJQpJY21F9eAU7vIvhZg8fDffc+MosZH3jgldcIh6ywHSmlGaCWhfXtU8BAOXjN2YM8a6dNrk4tpNKIt7Ih0hr3YLMVEaHbsNYPeKk6Sjow0Bw=="
+    }
+  ],
+  "Accounts loadPendingTransactions should not load expired transactions": [
+    {
+      "id": "0e0e024d-0d14-42ce-af9d-eb4fb9fff5aa",
+      "name": "accountA",
+      "spendingKey": "5f1950b7608f7ad4f64fc5d82c1a6ec782b861bd7a5ba879c1c5d6ec00ded144",
+      "incomingViewKey": "e58a81528165421275a13ac584dfc536a7ca188f7c4b5270b2e39eea68d06203",
+      "outgoingViewKey": "1f09a815cef62f73dfd1bbc0bd52fffc3670cc744b31e4edafc8f02c36ba52ea",
+      "publicAddress": "3669402714b3a0da60bc71253a834e886fc923f047b8e3bbd994c7fc39aa734995760ce541508afc640e01"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:BNjuWZUKCsUI9VN5AKMv9dAzZ96vJe1MTe1ZQuVVSic="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1667421966092,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "C7BD5DFF1438EDA961D92B3BE8AC82AE86287CE692852FF621344D7CE0756888",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJdz660Qr/URQ6HTDkDJ3MipfmU1hnb7ETJ0EFHt68H4wB6o9wV/ySEv6UYTHaSvUZUSkKeoth67gGytYdUDc46SAoFEq5QtrV6iLGmB7BrD6sZ9LGXHUgDYFxU4ztXRWhIN4jISEb3IbSMYuDk9FIs/xW+FapuZz4G46NO40OXbvFaJ1h/iqtPlnKpGtaVMArOZN2gxkaxgJmVhR9asvGq83Zk5ctSpXOozavjrJBjhoFX5sM+9CWegNVHnBKJy204kpiIuBTd3dJD6g9enhJZVQjlK4QsqUedjHhSE4Oun+HorTev1SmRxqthf4pd3Yg7OlZVAuN+a3vQUnIBtp0g2eO6+2in05Xkn43xTucvd4KmF7dFZ1g0rycUXjccuAJ5TFENB8vVXqAV72RSiWDPZ8hPzan0jWhETgvPCpRCY5SGQfbvo+ZVAImjwuDetCGJhto5koXCeKDSXobKqUTn/PAoU5vq18YX3mP+tsLRF04UCya57W6eTcbqXc0ygRlsK/EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqqml1j/LbHVK0OvEMEBgCNocULXkNBCKd5GDaCyoFc3pp2ev8C9vQeHwrt9Wlyr03ncyABTesxd+eOo/tX3DAA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAQAAAKDiKD5niF2XJyCCOfl1x6+vV3NfcCKCGU5JSVRVqjI502A2qiGcVckK7qMPGnFn37Canq2TBhgAylYUW+/4vsBQRWCGAiWtuOCu2mj4VWV7jl2/xK3DWdks8wNZvijfgQtuP032AsXPnjXAC+46AoFUQ1SUtbi0bCfDi3wreHI+vrbu9izefZFs5hkB0Hdmna5Ul7YNNH/r/dzzyuN7jcbnNQfSIpz0vukRhE5pUjyzlGXCvkPD5imllVJTDQQnq1IizVWqlDeFWQTUXohqjr4e60qdl62ZlJgRZzvQobNHDivY+qaPTAW6W8k9tsqjIXp2LGJhI2Sd4waiiq/znLUE2O5ZlQoKxQj1U3kAoy/10DNn3q8l7UxN7VlC5VVKJwQAAAA4lfLKEMlpx8R0DdV8yMHsQngZS1aQobl+WQiZ7MYnPDtbgvlgPOeXw7lvfFUjN/G10MqV8PJGmoVBQnJXet0rQBaoWevijz3QW7HWlgpsOnRz47cej6HkunTpdPqzQA6hD/7mXKa+YmGt6IE9itkVZPdykoPhI7hDd51Z2TL/dmNoh+PCwf6lm57D7ybSiva3jqWGu+pD5fEajdojonnEbquvCyCOYuqhgoveUQ697oeFQNrMln1wx4TDGb+lnHYT1B2RrMwGUc7/JnZuTw9lAtYTX1VuNFT7pc2M4v/g0R8CY76Ddht2cGq56ntSYd2rpNpnBADkN6+ZMqyx30emeb/skFDWj0zQVu7PBhJ9PtbbrhwaOxBT21KoNi2aBYDK6zQOF2ZaNDE2M0C7//1g0JjFm3RMkQx3KG2SkH7s1s89FqclPHg6mtYrV9x4teGM/UmNCstFkg3pjsXkKSYvT5EvEIQMrf9bySoTnDZd/B8xQdzcereIIJJVNZzSewvLJHw14EnbbxSXXij2W7AGR6w/bJFuUQb6ADQoqiIjNNYTXiL7/sXf49u0DtE5DtiXYcqRM4+l7LRaW+m0cFRgSOlBVY8xUS0evbysH4iWJRoI9iGt/nyZlrp96rBCAF88JfRCag402/opmKjsk6HRONY3Z210JxjiknTEBpg3fDO2DGfkfhdxd2a6s8GjZUv+LR0PtdMd+EqNOxuoh+ZPJmO3oJhDfjdoQX3w1OJ/mT8lPpBXFBCTWfzYmpVYm8s13kpSK1fdl5oqB+tLwNPTaYTf+MiwwY9cK16dQGeJz/PTvopqpbJh9ooH52IeI9hvpJ4z4LxQF3Cuy86Jlc/mVIIbihESexTaq56sFtWgmmcNVRl7/yRLD7YMLNEntMrWl815JLA1+xOcdoyXFXyvtmgVnuhCk/g2IKHSxd2Yd6e4W6H3xpYWB3lEk9jdgTj/QcCiZdE+67d4ce1BSAYhTjeC0l6JhyDDXlQHKkIHv/DLPSQ8kcgARfsFHWF+AhJVnzdcIf0snMdr3lYgYpczvmaU1bdK8SUOrqHi/W3OFjzQiGNBKhyoVT/AngJOQC+kclqaFeapiGvuI0JeCI5CdrE4ANkqhxT1j5im9Gbe5msRKCshD/8J4LT1ErYBUl583AbQwRSgt5B7BOIhuTdf1pMkbEsTdqwf3n1tHwX4oDRIFkZaLd9541muhp459F5bEyVrkdxDWNJb5ia4wyj7gkoN87McJkrs+5Xmo8/POnParVzNQd1/iBS+p2fqKhz8Opb0byeF//FY3IaBdikMCmfAgOIMB/LMNQMB/KyhveKnOWQGmeZam3MKI/DfnP7cAFmLK++9g2aibqO4Jxy0NDrcVqbiLHyuo3p5BjneGZG5iTfikmpeFriP2E0/LJnY90APQo9n4gmXeKHKwFbvQCcOc7NbGbDhnniMldinYjYQUOn7DQ=="
+    }
   ]
 }

--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../assert'
-import { createNodeTest, useAccountFixture, useMinerBlockFixture } from '../testUtilities'
+import {
+  createNodeTest,
+  useAccountFixture,
+  useMinerBlockFixture,
+  useTxFixture,
+} from '../testUtilities'
 import { AsyncUtils } from '../utils/async'
 
 describe('Accounts', () => {
@@ -128,5 +133,64 @@ describe('Accounts', () => {
 
     // record of expired transaction is preserved
     await expect(account.getTransaction(tx.hash())).resolves.toBeDefined()
+  })
+
+  describe('loadPendingTransactions', () => {
+    it('should load pending transactions', async () => {
+      const { node } = nodeTest
+
+      const account = await useAccountFixture(node.wallet, 'accountA')
+
+      const block1 = await useMinerBlockFixture(node.chain, undefined, account, node.wallet)
+      await node.chain.addBlock(block1)
+      await node.wallet.updateHead()
+
+      // create pending transaction
+      await useTxFixture(node.wallet, account, account, undefined, undefined, 4)
+
+      const pendingTransactions = await AsyncUtils.materialize(
+        account.getPendingTransactions(node.chain.head.sequence),
+      )
+
+      expect(pendingTransactions.length).toEqual(1)
+    })
+
+    it('should load transactions with no expiration', async () => {
+      const { node } = nodeTest
+
+      const account = await useAccountFixture(node.wallet, 'accountA')
+
+      const block1 = await useMinerBlockFixture(node.chain, undefined, account, node.wallet)
+      await node.chain.addBlock(block1)
+      await node.wallet.updateHead()
+
+      // create transaction with no expiration
+      await useTxFixture(node.wallet, account, account)
+
+      const pendingTransactions = await AsyncUtils.materialize(
+        account.getPendingTransactions(node.chain.head.sequence),
+      )
+
+      expect(pendingTransactions.length).toEqual(1)
+    })
+
+    it('should not load expired transactions', async () => {
+      const { node } = nodeTest
+
+      const account = await useAccountFixture(node.wallet, 'accountA')
+
+      const block1 = await useMinerBlockFixture(node.chain, undefined, account, node.wallet)
+      await node.chain.addBlock(block1)
+      await node.wallet.updateHead()
+
+      // create expired transaction
+      await useTxFixture(node.wallet, account, account, undefined, undefined, 1)
+
+      const pendingTransactions = await AsyncUtils.materialize(
+        account.getPendingTransactions(node.chain.head.sequence),
+      )
+
+      expect(pendingTransactions.length).toEqual(0)
+    })
   })
 })

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -316,6 +316,13 @@ export class Account {
     return this.walletDb.loadTransactions(this, tx)
   }
 
+  getPendingTransactions(
+    headSequence: number,
+    tx?: IDatabaseTransaction,
+  ): AsyncGenerator<TransactionValue> {
+    return this.walletDb.loadPendingTransactions(this, headSequence, tx)
+  }
+
   getExpiredTransactions(
     headSequence: number,
     tx?: IDatabaseTransaction,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -839,7 +839,7 @@ export class Wallet {
         return
       }
 
-      for await (const transactionInfo of account.getTransactions()) {
+      for await (const transactionInfo of account.getPendingTransactions(head.sequence)) {
         if (this.eventLoopAbortController.signal.aborted) {
           return
         }
@@ -849,16 +849,6 @@ export class Wallet {
 
         // Skip transactions that are already added to a block
         if (blockHash) {
-          continue
-        }
-
-        // Skip expired transactions
-        if (
-          this.chain.verifier.isExpiredSequence(
-            transaction.expirationSequence(),
-            this.chain.head.sequence,
-          )
-        ) {
           continue
         }
 


### PR DESCRIPTION
## Summary

limits the wallet to iterate only over pending transactions in rebroadcastTransactions.

- implements loadPendingTransactions to yield transactions with expiration sequence equal to 0 or greater than the given head sequence
- removes check on expired transactions in rebroadcastTransactions
- updates tests

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
