### PR TITLE
Parallelize verify transactions

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -403,7 +403,7 @@ describe('Blockchain', () => {
     // Should not add blockB3
     const { isAdded, reason } = await node.chain.addBlock(blockB3)
     expect(isAdded).toBe(false)
-    expect(reason).toBe(VerificationResultReason.NOTE_COMMITMENT_SIZE)
+    expect(reason).toBe(VerificationResultReason.NOTE_COMMITMENT)
 
     expect(node.chain.head?.hash).toEqualBuffer(blockB2.header.hash)
     const result = await node.chain.verifier.verifyConnectedBlock(blockB2)

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -656,8 +656,11 @@ export class Blockchain {
     prev: BlockHeader | null,
     tx: IDatabaseTransaction,
   ): Promise<void> {
-    const { valid, reason } = await this.verifier.verifyBlockAdd(block, prev)
+    const verifyBlockAdd = this.verifier.verifyBlockAdd(block, prev)
 
+    await this.saveBlock(block, prev, true, tx)
+
+    const { valid, reason } = await verifyBlockAdd
     if (!valid) {
       Assert.isNotUndefined(reason)
 
@@ -672,7 +675,6 @@ export class Blockchain {
       throw new VerifyError(reason, BAN_SCORE.MAX)
     }
 
-    await this.saveBlock(block, prev, true, tx)
     await tx.update()
     this.notes.pastRootTxCommitted(tx)
     await this.onForkBlock.emitAsync(block, tx)


### PR DESCRIPTION
## Summary
When we add blocks we verify transactions and update the Merkle tree sequentially. We could see speedup if we parallelize these two operations

## Testing Plan
Unit tests and local testing of syncing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
