### PR TITLE
Fix account status display

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -164,9 +164,17 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
 
   let accountStatus
   if (content.accounts.scanning === undefined) {
-    accountStatus = `${content.accounts.head.hash} (${content.accounts.head.sequence})`
+    accountStatus = `${content.accounts.head.hash}`
+
+    if (content.accounts.head.sequence !== -1) {
+      accountStatus += ` (${content.accounts.head.sequence})`
+    }
   } else {
-    accountStatus = `SCANNING - ${content.accounts.scanning.sequence} / ${content.accounts.scanning.endSequence}`
+    accountStatus = `SCANNING`
+
+    if (content.accounts.scanning.sequence !== -1) {
+      accountStatus += ` - ${content.accounts.scanning.sequence} / ${content.accounts.scanning.endSequence}`
+    }
   }
 
   const cores = `Cores: ${content.cpu.cores}`


### PR DESCRIPTION
## Summary
From https://github.com/iron-fish/ironfish/issues/2186. Account status and scanning output shows `-1`. Hiding this now.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
