### PR TITLE
reuses transaction size for different fee rates

### DIFF
--- a/ironfish/src/memPool/feeEstimator.test.ts
+++ b/ironfish/src/memPool/feeEstimator.test.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../assert'
+import { NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE } from '../primitives/noteEncrypted'
+import { SPEND_SERIALIZED_SIZE_IN_BYTE } from '../primitives/spend'
 import {
   createNodeTest,
   useAccountFixture,
@@ -388,9 +390,15 @@ describe('FeeEstimator', () => {
   describe('estimateFee', () => {
     it('should estimate fee for a pending transaction', async () => {
       const node = nodeTest.node
-      const { account, block } = await useBlockWithTx(node, undefined, undefined, true, {
-        fee: 10,
-      })
+      const { account, block, transaction } = await useBlockWithTx(
+        node,
+        undefined,
+        undefined,
+        true,
+        {
+          fee: 10,
+        },
+      )
 
       const receiver = await useAccountFixture(node.wallet, 'accountA')
 
@@ -403,15 +411,117 @@ describe('FeeEstimator', () => {
       })
       await feeEstimator.init(node.chain)
 
-      const fee = await feeEstimator.estimateFee('low', account, [
+      const receives = [
         {
           publicAddress: receiver.publicAddress,
           amount: BigInt(5),
           memo: 'test',
         },
-      ])
+      ]
 
-      expect(fee).toBe(BigInt(6))
+      const { size } = await feeEstimator['getPendingTransaction'](account, receives)
+
+      expect(size).toEqual(
+        8 +
+          8 +
+          8 +
+          4 +
+          64 +
+          SPEND_SERIALIZED_SIZE_IN_BYTE +
+          NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE,
+      )
+
+      const feeRate = getFeeRate(transaction)
+
+      const expectedFee = feeEstimator['getFee'](
+        feeRate,
+        size + NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE, // transaction size plus change note
+      )
+
+      const fee = await feeEstimator.estimateFee('low', account, receives)
+
+      expect(fee).toBe(expectedFee)
+    })
+  })
+
+  describe('getPendingTransactionFee', () => {
+    it('should not add a note if the fee is equal to the pending transaction change', () => {
+      const node = nodeTest.node
+
+      const feeEstimator = new FeeEstimator({
+        wallet: node.wallet,
+        maxBlockHistory: 1,
+      })
+
+      const pendingTransaction = { size: 1000, spenderChange: 100n }
+
+      const feeRate = 100n
+
+      const fee = feeEstimator['getPendingTransactionFee'](feeRate, pendingTransaction)
+
+      expect(fee).toEqual(pendingTransaction.spenderChange)
+    })
+
+    it('should not add a note for change if doing so would require another spend', () => {
+      const node = nodeTest.node
+
+      const feeEstimator = new FeeEstimator({
+        wallet: node.wallet,
+        maxBlockHistory: 1,
+      })
+
+      // only 1 ORE in change after fee
+      const pendingTransaction = { size: 1000, spenderChange: 101n }
+
+      const feeRate = 100n
+
+      const fee = feeEstimator['getPendingTransactionFee'](feeRate, pendingTransaction)
+
+      expect(fee).toEqual(pendingTransaction.spenderChange)
+    })
+
+    it('should add a note for change if it does not require another spend', () => {
+      const node = nodeTest.node
+
+      const feeEstimator = new FeeEstimator({
+        wallet: node.wallet,
+        maxBlockHistory: 1,
+      })
+
+      const feeRate = 100n
+
+      const expectedFee = feeEstimator['getFee'](
+        feeRate,
+        1000 + NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE,
+      )
+
+      const pendingTransaction = { size: 1000, spenderChange: expectedFee + 100n }
+
+      const fee = feeEstimator['getPendingTransactionFee'](feeRate, pendingTransaction)
+
+      expect(fee).toEqual(expectedFee)
+    })
+
+    it('should add a note for change and a spend if there is not enough change for the fee', () => {
+      const node = nodeTest.node
+
+      const feeEstimator = new FeeEstimator({
+        wallet: node.wallet,
+        maxBlockHistory: 1,
+      })
+
+      const feeRate = 100n
+
+      const expectedFee = feeEstimator['getFee'](
+        feeRate,
+        1000 + NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE + SPEND_SERIALIZED_SIZE_IN_BYTE,
+      )
+
+      const pendingTransaction = { size: 1000, spenderChange: 0n }
+
+      const fee = feeEstimator['getPendingTransactionFee'](feeRate, pendingTransaction)
+
+      expect(fee).toEqual(expectedFee)
     })
   })
 })

--- a/ironfish/src/memPool/feeEstimator.ts
+++ b/ironfish/src/memPool/feeEstimator.ts
@@ -220,10 +220,7 @@ export class FeeEstimator {
 
     const pendingFee = this.getFee(feeRate, size)
 
-    if (spenderChange === pendingFee) {
-      // sender will not receive a note with change
-      return pendingFee
-    } else if (spenderChange > pendingFee) {
+    if (spenderChange >= pendingFee) {
       // sender will receive a note with the remainder in change
       // unless that note makes the fee more expensive than the change received
       return BigIntUtils.min(

--- a/ironfish/src/rpc/routes/fees/estimateFee.ts
+++ b/ironfish/src/rpc/routes/fees/estimateFee.ts
@@ -64,14 +64,12 @@ router.register<typeof EstimateFeeRequestSchema, EstimateFeeResponse>(
 
     const feeEstimator = node.memPool.feeEstimator
 
-    const low = await feeEstimator.estimateFee('low', account, receives)
-    const medium = await feeEstimator.estimateFee('medium', account, receives)
-    const high = await feeEstimator.estimateFee('high', account, receives)
+    const fees = await feeEstimator.estimateFees(account, receives)
 
     request.end({
-      low: low.toString(),
-      medium: medium.toString(),
-      high: high.toString(),
+      low: fees.low.toString(),
+      medium: fees.medium.toString(),
+      high: fees.high.toString(),
     })
   },
 )


### PR DESCRIPTION
## Summary

estimates fees for all fee rate priority level with only one call to 'createSpends' to avoid iterating over notes multiple times.

changes 'getPendingTransactionSize' to return both the size and the spender change for a pending transaction without accounting for the fee.

implements 'getPendingTransactionFee' to use the size and spender change to determine the fee based on how big the transaction is and whether more notes or spends are needed to cover the fee and spender change.

implements 'estimateFees' to return estimates for all fee rate priority levels and updates estimateFee RPC endpoint.

accounts for additional note for spender change in transaction sizes.

## Testing Plan

Updated unit tests and ran benchmark script from #2436 . It's only *very slightly* faster than before on my node, which has very few notes.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
