### PR TITLE
avoids logging unparsed buffers in error message

### DIFF
--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -147,7 +147,7 @@ export class WebRtcConnection extends Connection {
       try {
         message = parseNetworkMessage(bufferData)
       } catch (error) {
-        this.logger.warn(`Unable to parse webrtc message ${data.toString()}`)
+        this.logger.warn(`Unable to parse webrtc message`)
         this.close(error)
         return
       }

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -99,8 +99,8 @@ export class WebSocketConnection extends Connection {
         // TODO: any socket that sends invalid messages should probably
         // be punished with some kind of "downgrade" event. This should
         // probably happen at a higher layer of abstraction
-        const message = 'error parsing message'
-        this.logger.warn(`${message} ${event.data.toString()}`)
+        const message = 'Error parsing message'
+        this.logger.warn(message)
         this.close(new NetworkError(message))
         return
       }


### PR DESCRIPTION
## Summary

nodes sending now-unsupported message types produce parsing errors. the parsing error message includes a stringified buffer:

```
error parsing messageK9j�KG4x,ç7�k������n����b�çi��� . . .
```

removes the event data from the error message to avoid logging the unparsed buffer.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
