### PR TITLE
Handle note status change during getBalance

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -400,10 +400,12 @@ export class Account {
     const pending = await this.getUnconfirmedBalance(tx)
 
     let unconfirmed = pending
+    const notOnChainNotes: DecryptedNoteValue[] = []
     for await (const note of this.walletDb.loadNotesNotOnChain(this, tx)) {
       if (!note.spent) {
         pendingCount++
         unconfirmed -= note.note.value()
+        notOnChainNotes.push(note)
       }
     }
 
@@ -423,6 +425,11 @@ export class Account {
         tx,
       )) {
         if (!note.spent) {
+          if (notOnChainNotes.includes(note)) {
+            pendingCount--
+            unconfirmed += note.note.value()
+            confirmed += note.note.value()
+          }
           unconfirmedCount++
           confirmed -= note.note.value()
         }


### PR DESCRIPTION
## Summary
This PR handles note status change during `getBalance`, which should be the reason of https://github.com/iron-fish/ironfish/issues/2520 in my opinion.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
