### PR TITLE
feat(rust): Add value balances by asset identifier to Transaction

### DIFF
--- a/ironfish-rust/src/assets/asset.rs
+++ b/ironfish-rust/src/assets/asset.rs
@@ -14,6 +14,11 @@ use std::slice::from_ref;
 #[allow(dead_code)]
 pub type AssetIdentifier = [u8; ASSET_IDENTIFIER_LENGTH];
 
+pub const NATIVE_ASSET: AssetIdentifier = [
+    63, 153, 26, 142, 149, 219, 17, 209, 253, 181, 149, 15, 213, 51, 143, 78, 12, 60, 164, 140, 4,
+    112, 88, 247, 113, 83, 236, 214, 242, 91, 103, 175,
+];
+
 /// Describes all the fields necessary for creating and transacting with an
 /// asset on the Iron Fish network
 #[allow(dead_code)]

--- a/ironfish-rust/src/assets/asset.rs
+++ b/ironfish-rust/src/assets/asset.rs
@@ -15,8 +15,8 @@ use std::slice::from_ref;
 pub type AssetIdentifier = [u8; ASSET_IDENTIFIER_LENGTH];
 
 pub const NATIVE_ASSET: AssetIdentifier = [
-    63, 153, 26, 142, 149, 219, 17, 209, 253, 181, 149, 15, 213, 51, 143, 78, 12, 60, 164, 140, 4,
-    112, 88, 247, 113, 83, 236, 214, 242, 91, 103, 175,
+    215, 200, 103, 6, 245, 129, 122, 167, 24, 205, 28, 250, 208, 50, 51, 188, 214, 74, 119, 137,
+    253, 148, 34, 211, 177, 122, 246, 130, 58, 126, 106, 198,
 ];
 
 /// Describes all the fields necessary for creating and transacting with an
@@ -129,9 +129,12 @@ impl Asset {
 
 #[cfg(test)]
 mod test {
+    use group::GroupEncoding;
+    use ironfish_zkp::constants::VALUE_COMMITMENT_VALUE_GENERATOR;
+
     use crate::{util::str_to_array, PublicAddress, SaplingKey};
 
-    use super::Asset;
+    use super::{Asset, NATIVE_ASSET};
 
     #[test]
     fn test_new_with_nonce() {
@@ -177,5 +180,12 @@ mod test {
         assert_eq!(asset.name, str_to_array(name));
         assert_eq!(asset.chain, str_to_array(chain));
         assert_eq!(asset.network, str_to_array(network));
+    }
+
+    #[test]
+    fn test_native_asset_identifier() {
+        // Native asset uses the original value commitment generator, no
+        // particular reason other than it is easier to think about this way.
+        assert_eq!(NATIVE_ASSET, VALUE_COMMITMENT_VALUE_GENERATOR.to_bytes());
     }
 }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -32,10 +32,7 @@ use ironfish_zkp::{
     redjubjub::{PrivateKey, PublicKey, Signature},
 };
 
-use std::{
-    io, iter,
-    slice::Iter,
-};
+use std::{io, iter, slice::Iter};
 
 #[cfg(test)]
 mod tests;

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -3,11 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::{
+    assets::asset::{AssetIdentifier, NATIVE_ASSET},
     errors::IronfishError,
     outputs::OutputBuilder,
     sapling_bls12::SAPLING,
     spending::{SpendBuilder, UnsignedSpendDescription},
 };
+
+use self::value_balances::ValueBalances;
 
 use super::{
     keys::{PublicAddress, SaplingKey},
@@ -29,10 +32,15 @@ use ironfish_zkp::{
     redjubjub::{PrivateKey, PublicKey, Signature},
 };
 
-use std::{io, iter, slice::Iter};
+use std::{
+    collections::{hash_map, HashMap},
+    io, iter,
+    slice::Iter,
+};
 
 #[cfg(test)]
 mod tests;
+mod value_balances;
 
 const SIGNATURE_HASH_PERSONALIZATION: &[u8; 8] = b"Bnsighsh";
 const TRANSACTION_SIGNATURE_VERSION: &[u8; 1] = &[0];
@@ -57,7 +65,7 @@ pub struct ProposedTransaction {
 
     /// The balance of all the spends minus all the outputs. The difference
     /// is the fee paid to the miner for mining the transaction.
-    value_balance: i64,
+    value_balances: ValueBalances,
 
     /// This is the sequence in the chain the transaction will expire at and be
     /// removed from the mempool. A value of 0 indicates the transaction will
@@ -77,7 +85,7 @@ impl ProposedTransaction {
         ProposedTransaction {
             spends: vec![],
             outputs: vec![],
-            value_balance: 0,
+            value_balances: ValueBalances::default(),
             expiration_sequence: 0,
             spender_key,
         }
@@ -85,7 +93,7 @@ impl ProposedTransaction {
 
     /// Spend the note owned by spender_key at the given witness location.
     pub fn add_spend(&mut self, note: Note, witness: &dyn WitnessTrait) {
-        self.value_balance += note.value() as i64;
+        self.value_balances.add(&NATIVE_ASSET, note.value() as i64);
 
         self.spends.push(SpendBuilder::new(note, witness));
     }
@@ -93,7 +101,8 @@ impl ProposedTransaction {
     /// Create a proof of a new note owned by the recipient in this
     /// transaction.
     pub fn add_output(&mut self, note: Note) {
-        self.value_balance -= note.value as i64;
+        self.value_balances
+            .subtract(&NATIVE_ASSET, note.value() as i64);
 
         self.outputs.push(OutputBuilder::new(note));
     }
@@ -113,26 +122,41 @@ impl ProposedTransaction {
         change_goes_to: Option<PublicAddress>,
         intended_transaction_fee: u64,
     ) -> Result<Transaction, IronfishError> {
-        let change_amount = self.value_balance - intended_transaction_fee as i64;
+        let mut change_notes = vec![];
 
-        if change_amount < 0 {
-            return Err(IronfishError::InvalidBalance);
+        for (asset_identifier, value) in self.value_balances.iter() {
+            let is_native_asset = asset_identifier == &NATIVE_ASSET;
+
+            let change_amount = match is_native_asset {
+                true => *value - intended_transaction_fee as i64,
+                false => *value,
+            };
+
+            if change_amount < 0 {
+                return Err(IronfishError::InvalidBalance);
+            }
+            if change_amount > 0 {
+                // TODO: The public address generated from the spender_key if
+                // change_goes_to is None should probably be associated with a
+                // known diversifier (eg: that used on other notes?)
+                // But we haven't worked out why determinacy in public addresses
+                // would be useful yet.
+                let change_address =
+                    change_goes_to.unwrap_or_else(|| self.spender_key.generate_public_address());
+                let change_note = Note::new(
+                    change_address,
+                    change_amount as u64, // we checked it was positive
+                    "",
+                );
+
+                change_notes.push(change_note);
+            }
         }
-        if change_amount > 0 {
-            // TODO: The public address generated from the spender_key if
-            // change_goes_to is None should probably be associated with a
-            // known diversifier (eg: that used on other notes?)
-            // But we haven't worked out why determinacy in public addresses
-            // would be useful yet.
-            let change_address =
-                change_goes_to.unwrap_or_else(|| self.spender_key.generate_public_address());
-            let change_note = Note::new(
-                change_address,
-                change_amount as u64, // we checked it was positive
-                "",
-            );
+
+        for change_note in change_notes {
             self.add_output(change_note);
         }
+
         self._partial_post()
     }
 
@@ -199,7 +223,7 @@ impl ProposedTransaction {
 
         Ok(Transaction {
             expiration_sequence: self.expiration_sequence,
-            fee: self.value_balance,
+            fee: *self.value_balances.fee(),
             spends: spend_descriptions,
             outputs: output_descriptions,
             binding_signature,
@@ -226,7 +250,7 @@ impl ProposedTransaction {
             .write_u32::<LittleEndian>(self.expiration_sequence)
             .unwrap();
         hasher
-            .write_i64::<LittleEndian>(self.value_balance)
+            .write_i64::<LittleEndian>(*self.value_balances.fee())
             .unwrap();
         for spend in spends {
             spend
@@ -291,7 +315,7 @@ impl ProposedTransaction {
         check_value_consistency(
             &public_key,
             &binding_verification_key,
-            self.value_balance as i64,
+            *self.value_balances.fee(),
         )?;
 
         Ok((private_key, public_key))

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -123,6 +123,11 @@ impl ProposedTransaction {
         for (asset_identifier, value) in self.value_balances.iter() {
             let is_native_asset = asset_identifier == &NATIVE_ASSET;
 
+            // TODO: Remove this once we actually allow custom assets
+            if !is_native_asset {
+                return Err(IronfishError::InvalidBalance);
+            }
+
             let change_amount = match is_native_asset {
                 true => *value - intended_transaction_fee as i64,
                 false => *value,

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -81,7 +81,7 @@ impl ProposedTransaction {
         ProposedTransaction {
             spends: vec![],
             outputs: vec![],
-            value_balances: ValueBalances::default(),
+            value_balances: ValueBalances::new(),
             expiration_sequence: 0,
             spender_key,
         }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    assets::asset::{AssetIdentifier, NATIVE_ASSET},
+    assets::asset::NATIVE_ASSET,
     errors::IronfishError,
     outputs::OutputBuilder,
     sapling_bls12::SAPLING,
@@ -33,7 +33,6 @@ use ironfish_zkp::{
 };
 
 use std::{
-    collections::{hash_map, HashMap},
     io, iter,
     slice::Iter,
 };

--- a/ironfish-rust/src/transaction/value_balances.rs
+++ b/ironfish-rust/src/transaction/value_balances.rs
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::collections::{hash_map, HashMap};
 
 use crate::assets::asset::{AssetIdentifier, NATIVE_ASSET};

--- a/ironfish-rust/src/transaction/value_balances.rs
+++ b/ironfish-rust/src/transaction/value_balances.rs
@@ -10,6 +10,14 @@ pub struct ValueBalances {
 }
 
 impl ValueBalances {
+    pub fn new() -> Self {
+        let mut hash_map = HashMap::default();
+
+        hash_map.insert(NATIVE_ASSET, 0);
+
+        ValueBalances { values: hash_map }
+    }
+
     pub fn add(&mut self, asset_identifier: &AssetIdentifier, value: i64) {
         let current_value = self.values.entry(*asset_identifier).or_insert(0);
         *current_value += value
@@ -29,12 +37,49 @@ impl ValueBalances {
     }
 }
 
-impl Default for ValueBalances {
-    fn default() -> Self {
-        let mut hash_map = HashMap::default();
+#[cfg(test)]
+mod test {
+    use crate::assets::asset::NATIVE_ASSET;
 
-        hash_map.insert(NATIVE_ASSET, 0);
+    use super::ValueBalances;
 
-        ValueBalances { values: hash_map }
+    #[test]
+    fn test_value_balances_has_native_asset() {
+        let vb = ValueBalances::new();
+
+        let native_asset_value = vb.values.get(&NATIVE_ASSET);
+
+        assert!(native_asset_value.is_some());
+        assert_eq!(*native_asset_value.unwrap(), 0);
+    }
+
+    #[test]
+    fn test_value_balances_fee() {
+        let mut vb = ValueBalances::new();
+
+        vb.add(&NATIVE_ASSET, 5);
+        vb.subtract(&NATIVE_ASSET, 2);
+
+        assert_eq!(*vb.fee(), 3);
+    }
+
+    #[test]
+    fn test_value_balances_multiple_assets() {
+        let mut vb = ValueBalances::new();
+
+        let asset_two = [1u8; 32];
+        let asset_three = [2u8; 32];
+
+        vb.add(&NATIVE_ASSET, 5);
+        vb.subtract(&NATIVE_ASSET, 3);
+
+        vb.add(&asset_two, 6);
+        vb.subtract(&asset_two, 2);
+
+        vb.subtract(&asset_three, 10);
+
+        assert_eq!(*vb.fee(), 2);
+        assert_eq!(*vb.values.get(&asset_two).unwrap(), 4);
+        assert_eq!(*vb.values.get(&asset_three).unwrap(), -10);
     }
 }

--- a/ironfish-rust/src/transaction/value_balances.rs
+++ b/ironfish-rust/src/transaction/value_balances.rs
@@ -1,0 +1,37 @@
+use std::collections::{hash_map, HashMap};
+
+use crate::assets::asset::{AssetIdentifier, NATIVE_ASSET};
+
+pub struct ValueBalances {
+    values: HashMap<AssetIdentifier, i64>,
+}
+
+impl ValueBalances {
+    pub fn add(&mut self, asset_identifier: &AssetIdentifier, value: i64) {
+        let current_value = self.values.entry(*asset_identifier).or_insert(0);
+        *current_value += value
+    }
+
+    pub fn subtract(&mut self, asset_identifier: &AssetIdentifier, value: i64) {
+        let current_value = self.values.entry(*asset_identifier).or_insert(0);
+        *current_value -= value
+    }
+
+    pub fn iter(&self) -> hash_map::Iter<AssetIdentifier, i64> {
+        self.values.iter()
+    }
+
+    pub fn fee(&self) -> &i64 {
+        self.values.get(&NATIVE_ASSET).unwrap()
+    }
+}
+
+impl Default for ValueBalances {
+    fn default() -> Self {
+        let mut hash_map = HashMap::default();
+
+        hash_map.insert(NATIVE_ASSET, 0);
+
+        ValueBalances { values: hash_map }
+    }
+}

--- a/ironfish-zkp/src/circuits/mint_asset.rs
+++ b/ironfish-zkp/src/circuits/mint_asset.rs
@@ -152,9 +152,8 @@ mod test {
 
     use bellman::{
         gadgets::{multipack, test::TestConstraintSystem},
-        groth16, Circuit,
+        Circuit,
     };
-    use bls12_381::Bls12;
     use ff::Field;
     use group::{Group, GroupEncoding};
     use rand::{rngs::StdRng, SeedableRng};


### PR DESCRIPTION
## Summary

We will soon need to check balances per asset as we add mints and burns. This code change adds a new data structure for value balances with a temporary hard-coded identifier for the native asset.

## Testing Plan

Existing unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
