### PR TITLE
[Draft][Part 1]Remove diversifier from public address

### DIFF
--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -156,27 +156,9 @@ impl<'a> SaplingKey {
         }
     }
 
-    /// Generate a public address from the incoming viewing key, given a specific
-    /// 11 byte diversifier.
-    ///
-    /// This may fail, as not all diversifiers are created equal.
-    ///
-    /// Note: This may need to be public at some point. I'm hoping the client
-    /// API would never have to deal with diversifiers, but I'm not sure, yet.
-    pub fn public_address(
-        &self,
-        diversifier: &[u8; 11],
-    ) -> Result<PublicAddress, errors::SaplingKeyError> {
-        PublicAddress::from_key(self, diversifier)
-    }
-
-    /// Generate a public address from this key's incoming viewing key,
-    /// picking a diversifier that is guaranteed to work with it.
-    ///
-    /// This method always succeeds, retrying with a different diversifier if
-    /// one doesn't work
-    pub fn generate_public_address(&self) -> PublicAddress {
-        self.incoming_viewing_key.generate_public_address()
+    /// Generate a public address from the incoming viewing key
+    pub fn public_address(&self) -> PublicAddress {
+        PublicAddress::from_key(self)
     }
 
     // Write a bytes representation of this key to the provided stream

--- a/ironfish-rust/src/keys/public_address.rs
+++ b/ironfish-rust/src/keys/public_address.rs
@@ -12,22 +12,27 @@ use std::{convert::TryInto, io};
 
 use super::{errors, IncomingViewKey, SaplingKey};
 
-/// The address to which funds can be sent, stored as a diversifier and public
-/// transmission key. Combining a diversifier with an incoming_viewing_key allows
-/// the creation of multiple public addresses without revealing the viewing key.
-/// This allows the user to have multiple "accounts", or to even have different
-/// payment addresses per transaction.
+/// The generator for public address.
+pub const PUBLIC_KEY_GENERATOR: SubgroupPoint = SubgroupPoint::from_raw_unchecked(
+    bls12_381::Scalar::from_raw([
+        0x3af2_dbef_b96e_2571,
+        0xadf2_d038_f2fb_b820,
+        0x7043_03f1_e890_6081,
+        0x1457_a502_31cd_e2df,
+    ]),
+    bls12_381::Scalar::from_raw([
+        0x467a_f9f7_e05d_e8e7,
+        0x50df_51ea_f5a1_49d2,
+        0xdec9_0184_0f49_48cc,
+        0x54b6_d107_18df_2a7a,
+    ]),
+);
+
+/// The address to which funds can be sent, stored as a public
+/// transmission key. Using the incoming_viewing_key allows
+/// the creation of a unqiue public addresses without revealing the viewing key.
 #[derive(Clone, Copy)]
 pub struct PublicAddress {
-    /// Diversifier is a struct of 11 bytes. The array is hashed and interpreted
-    /// as an edwards point, but we have to store the diversifier independently
-    /// because the pre-hashed bytes cannot be extracted from the point.
-    pub(crate) diversifier: Diversifier,
-
-    /// The same diversifier, but represented as a point on the jubjub curve.
-    /// Often referred to as
-    /// `g_d` in the literature.
-    pub(crate) diversifier_point: SubgroupPoint,
 
     /// The transmission key is the result of combining the diversifier with the
     /// incoming viewing key (a non-reversible operation). Together, the two
@@ -36,54 +41,40 @@ pub struct PublicAddress {
 }
 
 impl PublicAddress {
-    /// Initialize a public address from its 43 byte representation.
-    pub fn new(address_bytes: &[u8; 43]) -> Result<PublicAddress, errors::SaplingKeyError> {
-        let (diversifier, diversifier_point) =
-            PublicAddress::load_diversifier(&address_bytes[..11])?;
-        let transmission_key = PublicAddress::load_transmission_key(&address_bytes[11..])?;
+    /// Initialize a public address from its 32 byte representation.
+    pub fn new(address_bytes: &[u8; 32]) -> Result<PublicAddress, errors::SaplingKeyError> {
+        let transmission_key = PublicAddress::load_transmission_key(&address_bytes[0..])?;
 
         Ok(PublicAddress {
-            diversifier,
-            diversifier_point,
             transmission_key,
         })
     }
 
     /// Load a public address from a Read implementation (e.g: socket, file)
     pub fn read<R: io::Read>(reader: &mut R) -> Result<Self, errors::SaplingKeyError> {
-        let mut address_bytes = [0; 43];
+        let mut address_bytes = [0; 32];
         reader.read_exact(&mut address_bytes)?;
         Self::new(&address_bytes)
     }
 
-    /// Initialize a public address from a sapling key and the bytes
-    /// representing a diversifier. Typically constructed from
+    /// Initialize a public address from a sapling key. Typically constructed from
     /// SaplingKey::public_address()
     pub fn from_key(
         sapling_key: &SaplingKey,
-        diversifier: &[u8; 11],
-    ) -> Result<PublicAddress, errors::SaplingKeyError> {
-        Self::from_view_key(sapling_key.incoming_view_key(), diversifier)
+    ) -> PublicAddress {
+        Self::from_view_key(sapling_key.incoming_view_key())
     }
 
     pub fn from_view_key(
         view_key: &IncomingViewKey,
-        diversifier: &[u8; 11],
-    ) -> Result<PublicAddress, errors::SaplingKeyError> {
-        let diversifier = Diversifier(*diversifier);
-        if let Some(key_part) = diversifier.g_d() {
-            Ok(PublicAddress {
-                diversifier,
-                diversifier_point: key_part,
-                transmission_key: key_part * view_key.view_key,
-            })
-        } else {
-            Err(errors::SaplingKeyError::DiversificationError)
+    ) -> PublicAddress {
+        PublicAddress {
+            transmission_key: PUBLIC_KEY_GENERATOR * view_key.view_key,
         }
     }
 
     /// Convert a String of hex values to a PublicAddress. The String must
-    /// be 86 hexadecimal characters representing the 43 bytes of an address
+    /// be 86 hexadecimal characters representing the 32 bytes of an address
     /// or it fails.
     pub fn from_hex(value: &str) -> Result<Self, errors::SaplingKeyError> {
         if value.len() != 86 {
@@ -93,11 +84,11 @@ impl PublicAddress {
         match hex_to_bytes(value) {
             Err(()) => Err(errors::SaplingKeyError::InvalidPublicAddress),
             Ok(bytes) => {
-                if bytes.len() != 43 {
+                if bytes.len() != 32 {
                     Err(errors::SaplingKeyError::InvalidPublicAddress)
                 } else {
-                    let mut byte_arr = [0; 43];
-                    byte_arr.clone_from_slice(&bytes[0..43]);
+                    let mut byte_arr = [0; 32];
+                    byte_arr.clone_from_slice(&bytes[0..32]);
                     Self::new(&byte_arr)
                 }
             }
@@ -106,10 +97,9 @@ impl PublicAddress {
 
     /// Retrieve the public address in byte form. It is comprised of the
     /// 11 byte diversifier followed by the 32 byte transmission key.
-    pub fn public_address(&self) -> [u8; 43] {
-        let mut result = [0; 43];
-        result[..11].copy_from_slice(&self.diversifier.0);
-        result[11..].copy_from_slice(
+    pub fn public_address(&self) -> [u8; 32] {
+        let mut result = [0; 32];
+        result[..32].copy_from_slice(
             &point_to_bytes(&self.transmission_key)
                 .expect("transmission key should be convertible to bytes"),
         );
@@ -125,18 +115,6 @@ impl PublicAddress {
     pub fn write<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(&self.public_address())?;
         Ok(())
-    }
-
-    pub(crate) fn load_diversifier(
-        diversifier_slice: &[u8],
-    ) -> Result<(Diversifier, SubgroupPoint), errors::SaplingKeyError> {
-        let mut diversifier_bytes = [0; 11];
-        diversifier_bytes.clone_from_slice(diversifier_slice);
-        let diversifier = Diversifier(diversifier_bytes);
-        let diversifier_point = diversifier
-            .g_d()
-            .ok_or(errors::SaplingKeyError::DiversificationError)?;
-        Ok((diversifier, diversifier_point))
     }
 
     pub(crate) fn load_transmission_key(
@@ -167,7 +145,7 @@ impl PublicAddress {
         thread_rng().fill(&mut buffer[..]);
 
         let secret_key: jubjub::Fr = jubjub::Fr::from_bytes_wide(&buffer);
-        let public_key = self.diversifier_point * secret_key;
+        let public_key = PUBLIC_KEY_GENERATOR * secret_key;
         (secret_key, public_key)
     }
 
@@ -176,7 +154,8 @@ impl PublicAddress {
     /// another because `pk_d` is not a name I want to expose in a public
     /// interface.
     pub(crate) fn sapling_payment_address(&self) -> PaymentAddress {
-        PaymentAddress::from_parts(self.diversifier, self.transmission_key)
+        let diversifier = Diversifier([0; 11]);
+        PaymentAddress::from_parts(diversifier, self.transmission_key)
             .expect("Converting PaymentAddress types shouldn't fail")
     }
 }
@@ -204,7 +183,7 @@ mod test {
 
         let bad_result = PublicAddress::from_hex(bad_address);
         assert!(bad_result.is_err());
-
+ 
         PublicAddress::from_hex(good_address).expect("returns a valid public address");
     }
 }

--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -15,7 +15,7 @@ fn test_key_generation_and_construction() {
     assert!(key2.incoming_viewing_key.view_key == key.incoming_viewing_key.view_key);
 
     // should not fail or infinite loop
-    key2.generate_public_address();
+    key2.public_address();
 }
 
 #[test]
@@ -23,7 +23,7 @@ fn test_diffie_hellman_shared_key() {
     let key1: SaplingKey = SaplingKey::generate_key();
 
     // second address has to use the same diversifier for the keys to be valid
-    let address1 = key1.generate_public_address();
+    let address1 = key1.public_address();
     let (secret_key, public_key) = address1.generate_diffie_hellman_keys();
     let shared_secret1 = shared_secret(&secret_key, &address1.transmission_key, &public_key);
     let shared_secret2 = shared_secret(
@@ -49,22 +49,15 @@ fn test_serialization() {
         key.incoming_view_key().view_key
     );
 
-    let public_address = key.generate_public_address();
-    let mut serialized_address = [0; 43];
+    let public_address = key.public_address();
+    let mut serialized_address = [0; 32];
     public_address
         .write(&mut serialized_address[..])
         .expect("should be able to serialize address");
 
     let read_back_address: PublicAddress = PublicAddress::new(&serialized_address)
         .expect("Should be able to construct address from valid bytes");
-    assert_eq!(
-        read_back_address.diversifier.0,
-        public_address.diversifier.0
-    );
-    assert_eq!(
-        ExtendedPoint::from(read_back_address.diversifier_point).to_affine(),
-        ExtendedPoint::from(public_address.diversifier_point).to_affine()
-    );
+    
     assert_eq!(
         ExtendedPoint::from(read_back_address.transmission_key).to_affine(),
         ExtendedPoint::from(public_address.transmission_key).to_affine()
@@ -80,7 +73,7 @@ fn test_hex_conversion() {
     let second_key: SaplingKey = SaplingKey::from_hex(&hex).unwrap();
     assert_eq!(second_key.spending_key, key.spending_key);
 
-    let address = key.generate_public_address();
+    let address = key.public_address();
     let hex = address.hex_public_address();
     assert_eq!(hex.len(), 86);
     let second_address = PublicAddress::from_hex(&hex).unwrap();

--- a/ironfish-rust/src/keys/view_keys.rs
+++ b/ironfish-rust/src/keys/view_keys.rs
@@ -81,37 +81,9 @@ impl IncomingViewKey {
         Ok(mnemonic.phrase().to_string())
     }
 
-    /// Generate a public address from the incoming viewing key, given a specific
-    /// 11 byte diversifier.
-    ///
-    /// This may fail, as not all diversifiers are created equal.
-    ///
-    /// Note: This may need to be public at some point. I'm hoping the client
-    /// API would never have to deal with diversifiers, but I'm not sure, yet.
-    pub fn public_address(
-        &self,
-        diversifier: &[u8; 11],
-    ) -> Result<PublicAddress, errors::SaplingKeyError> {
-        PublicAddress::from_view_key(self, diversifier)
-    }
-
-    /// Generate a public address from this key,
-    /// picking a diversifier that is guaranteed to work with it.
-    ///
-    /// This method always succeeds, retrying with a different diversifier if
-    /// one doesn't work.
-    pub fn generate_public_address(&self) -> PublicAddress {
-        let public_address;
-        loop {
-            let mut diversifier_candidate = [0u8; 11];
-            thread_rng().fill(&mut diversifier_candidate);
-
-            if let Ok(key) = self.public_address(&diversifier_candidate) {
-                public_address = key;
-                break;
-            }
-        }
-        public_address
+    /// Generate a public address from the incoming viewing key
+    pub fn public_address(&self) -> PublicAddress {
+        PublicAddress::from_view_key(self)
     }
 
     /// Calculate the shared secret key given the ephemeral public key that was

--- a/ironfish-rust/src/merkle_note.rs
+++ b/ironfish-rust/src/merkle_note.rs
@@ -286,11 +286,12 @@ mod test {
         let spender_key: SaplingKey = SaplingKey::generate_key();
         let receiver_key: SaplingKey = SaplingKey::generate_key();
         let note = Note::new(
-            receiver_key.generate_public_address(),
+            receiver_key.public_address(),
             42,
             Memo::default(),
             AssetType::default(),
         );
+
         let diffie_hellman_keys = note.owner.generate_diffie_hellman_keys();
 
         let mut buffer = [0u8; 64];
@@ -315,11 +316,12 @@ mod test {
     fn test_receipt_invalid_commitment() {
         let spender_key: SaplingKey = SaplingKey::generate_key();
         let note = Note::new(
-            spender_key.generate_public_address(),
+            spender_key.public_address(),
             42,
             Memo::default(),
             AssetType::default(),
         );
+
         let diffie_hellman_keys = note.owner.generate_diffie_hellman_keys();
 
         let mut buffer = [0u8; 64];

--- a/ironfish-rust/src/spending.rs
+++ b/ironfish-rust/src/spending.rs
@@ -432,7 +432,7 @@ mod test {
     #[test]
     fn test_spend_round_trip() {
         let key = SaplingKey::generate_key();
-        let public_address = key.generate_public_address();
+        let public_address = key.public_address();
 
         let note_randomness = random();
 

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -20,23 +20,24 @@ fn test_transaction() {
     let spender_key: SaplingKey = SaplingKey::generate_key();
     let receiver_key: SaplingKey = SaplingKey::generate_key();
     let in_note = Note::new(
-        spender_key.generate_public_address(),
+        spender_key.public_address(),
         42,
         Memo::default(),
         AssetType::default(),
     );
     let out_note = Note::new(
-        receiver_key.generate_public_address(),
+        receiver_key.public_address(),
         40,
         Memo::default(),
         AssetType::default(),
     );
     let in_note2 = Note::new(
-        spender_key.generate_public_address(),
+        spender_key.public_address(),
         18,
         Memo::default(),
         AssetType::default(),
     );
+
     let witness = make_fake_witness(&in_note);
     let _witness2 = make_fake_witness(&in_note2);
     transaction
@@ -107,7 +108,7 @@ fn test_miners_fee() {
     let mut transaction = ProposedTransaction::new();
     let receiver_key: SaplingKey = SaplingKey::generate_key();
     let out_note = Note::new(
-        receiver_key.generate_public_address(),
+        receiver_key.public_address(),
         42,
         Memo::default(),
         AssetType::default(),
@@ -115,6 +116,7 @@ fn test_miners_fee() {
     transaction
         .receive(&receiver_key, &out_note)
         .expect("It's a valid note");
+
     let posted_transaction = transaction
         .post_miners_fee()
         .expect("it is a valid miner's fee");
@@ -134,8 +136,8 @@ fn test_miners_fee() {
 fn test_transaction_signature() {
     let spender_key = SaplingKey::generate_key();
     let receiver_key = SaplingKey::generate_key();
-    let spender_address = spender_key.generate_public_address();
-    let receiver_address = receiver_key.generate_public_address();
+    let spender_address = spender_key.public_address();
+    let receiver_address = receiver_key.public_address();
 
     let mut transaction = ProposedTransaction::new();
     let in_note = Note::new(spender_address, 42, Memo::default(), AssetType::default());


### PR DESCRIPTION
## Summary
Use constant generator for g_d when generate public address
There will be another PR that is part 2. Part 2 will remove the random diversifier in the spending verification.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@leanthebean 