### PR TITLE
adds blockHash and sequence to decryptedNoteValue

### DIFF
--- a/ironfish/src/migrations/data/014-note-sequence.ts
+++ b/ironfish/src/migrations/data/014-note-sequence.ts
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Logger } from '../../logger'
+import { IronfishNode } from '../../node'
+import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { BenchUtils } from '../../utils'
+import { Account, WalletDB } from '../../wallet'
+import { DecryptedNoteValue } from '../../wallet/walletdb/decryptedNoteValue'
+import { Migration } from '../migration'
+
+export class Migration014 extends Migration {
+  path = __filename
+
+  prepare(node: IronfishNode): IDatabase {
+    return node.wallet.walletDb.db
+  }
+
+  async forward(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    await this.migrate(node, db, tx, logger, true)
+  }
+
+  async backward(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    await this.migrate(node, db, tx, logger, false)
+  }
+
+  private async migrate(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+    forward: boolean,
+  ): Promise<void> {
+    const start = BenchUtils.startSegment()
+
+    if (forward) {
+      logger.debug('Adding chain state data to decryptedNotes...')
+    } else {
+      logger.debug('Removing chain state data from decryptedNotes...')
+    }
+
+    const walletDb = node.wallet.walletDb
+
+    for await (const accountValue of walletDb.loadAccounts(tx)) {
+      const account = new Account({ ...accountValue, walletDb: walletDb })
+
+      logger.debug(`Migrating decrypted notes for account ${account.name}...`)
+
+      let notesMigrated = 0
+      await db.withTransaction(tx, async (tx) => {
+        for await (const decryptedNote of walletDb.loadDecryptedNotes(account, tx)) {
+          if (forward) {
+            await this.migrateNoteForward(walletDb, account, decryptedNote, tx, logger)
+          } else {
+            await this.migrateNoteBackward(walletDb, account, decryptedNote, tx)
+          }
+          notesMigrated++
+        }
+      })
+
+      logger.debug(`\tMigrated ${notesMigrated} decrypted notes for account ${account.name}`)
+    }
+
+    const end = BenchUtils.endSegment(start)
+
+    logger.debug(BenchUtils.renderSegment(end))
+  }
+
+  private async migrateNoteForward(
+    walletDb: WalletDB,
+    account: Account,
+    decryptedNote: DecryptedNoteValue & { hash: Buffer },
+    tx: IDatabaseTransaction,
+    logger: Logger,
+  ): Promise<void> {
+    const transactionHash = decryptedNote.transactionHash
+    const noteHash = decryptedNote.hash
+
+    let blockHash: Buffer | null = null
+    let sequence: number | null = null
+
+    await walletDb.db.withTransaction(tx, async (tx) => {
+      const transaction = await walletDb.loadTransaction(account, transactionHash, tx)
+
+      if (transaction === undefined) {
+        logger.warn(`Transaction data missing for note ${noteHash.toString('hex')}`)
+      } else {
+        blockHash = transaction.blockHash
+        sequence = transaction.sequence
+      }
+
+      const newDecryptedNote: Readonly<DecryptedNoteValue> = {
+        ...decryptedNote,
+        blockHash,
+        sequence,
+      }
+
+      await walletDb.saveDecryptedNote(account, noteHash, newDecryptedNote, tx)
+    })
+  }
+
+  private async migrateNoteBackward(
+    walletDb: WalletDB,
+    account: Account,
+    decryptedNote: DecryptedNoteValue & { hash: Buffer },
+    tx: IDatabaseTransaction,
+  ): Promise<void> {
+    const noteHash = decryptedNote.hash
+
+    await walletDb.db.withTransaction(tx, async (tx) => {
+      const oldDecryptedNote: Readonly<DecryptedNoteValue> = {
+        ...decryptedNote,
+        blockHash: null,
+        sequence: null,
+      }
+
+      await walletDb.saveDecryptedNote(account, noteHash, oldDecryptedNote, tx)
+    })
+  }
+}

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -6,5 +6,6 @@ import { Migration010 } from './010-blockchain'
 import { Migration011 } from './011-accounts'
 import { Migration012 } from './012-indexer'
 import { Migration013 } from './013-wallet-2'
+import { Migration014 } from './014-note-sequence'
 
-export const MIGRATIONS = [Migration010, Migration011, Migration012, Migration013]
+export const MIGRATIONS = [Migration010, Migration011, Migration012, Migration013, Migration014]

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -217,6 +217,8 @@ export class Account {
             note: new Note(decryptedNote.serializedNote),
             spent: false,
             transactionHash,
+            blockHash: null,
+            sequence: null,
           },
           tx,
         )

--- a/ironfish/src/wallet/walletdb/decryptedNoteValue.test.ts
+++ b/ironfish/src/wallet/walletdb/decryptedNoteValue.test.ts
@@ -30,6 +30,8 @@ describe('DecryptedNoteValueEncoding', () => {
         spent: false,
         note,
         transactionHash: Buffer.alloc(32, 1),
+        blockHash: null,
+        sequence: null,
       }
       const buffer = encoder.serialize(value)
       const deserializedValue = encoder.deserialize(buffer)
@@ -53,6 +55,8 @@ describe('DecryptedNoteValueEncoding', () => {
         nullifier: Buffer.alloc(32, 1),
         note,
         transactionHash: Buffer.alloc(32, 1),
+        blockHash: Buffer.alloc(32, 1),
+        sequence: 1,
       }
       const buffer = encoder.serialize(value)
       const deserializedValue = encoder.deserialize(buffer)

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -30,7 +30,7 @@ import { DecryptedNoteValue, DecryptedNoteValueEncoding } from './decryptedNoteV
 import { AccountsDBMeta, MetaValue, MetaValueEncoding } from './metaValue'
 import { TransactionValue, TransactionValueEncoding } from './transactionValue'
 
-export const VERSION_DATABASE_ACCOUNTS = 13
+export const VERSION_DATABASE_ACCOUNTS = 14
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountId: null,


### PR DESCRIPTION
## Summary

adds chain state fields to decryptedNotes store and implements data migration to populate these fields.

~~migration does not (yet) remove sequenceToNoteHash or nonChainNoteHashes stores. subsequent changes will modify wallet code to cease using these stores and then, finally, remove them.~~ Computing the balance will be much less efficient without sequenceToNoteHash and nonChainNoteHashes, but having chain state in decryptedNotes will make it easier to keep them in sync

## Testing Plan

```
[11:05:31.374] Applying 1 migrations:
[11:05:31.377]   014-note-sequence
[11:05:31.377] 
[11:05:31.377] Running 014-note-sequence...
[11:05:31.447] Adding chain state data to decryptedNotes...
[11:05:31.452] Migrating decrypted notes for account test...
[11:05:31.453] 	Migrated 0 decrypted notes for account test
[11:05:31.454] Migrating decrypted notes for account default...
[11:05:31.465] 	Migrated 7 decrypted notes for account default
[11:05:31.532] Benchmark - Time: 86.8829ms, Heap: 325.78 KiB, RSS: 1.87 MiB, Mem: 2.19 MiB
[11:05:31.533] Successfully applied 1 migrations
✨  Done in 5.85s.
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```

Requires data migration.
