### PR TITLE
refactor(rust): move spends and outputs into transaction module

### DIFF
--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -14,10 +14,8 @@ pub mod merkle_note_hash;
 pub mod mining;
 pub mod nacl;
 pub mod note;
-pub mod outputs;
 pub mod rolling_filter;
 pub mod sapling_bls12;
-pub mod spending;
 pub mod transaction;
 pub mod util;
 pub mod witness;
@@ -26,9 +24,9 @@ pub use {
     merkle_note::MerkleNote,
     merkle_note_hash::MerkleNoteHash,
     note::Note,
-    outputs::OutputDescription,
-    spending::SpendDescription,
-    transaction::{ProposedTransaction, Transaction},
+    transaction::{
+        outputs::OutputDescription, spending::SpendDescription, ProposedTransaction, Transaction,
+    },
 };
 
 #[cfg(test)]

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -2,23 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use outputs::OutputBuilder;
+use spending::{SpendBuilder, UnsignedSpendDescription};
+use value_balances::ValueBalances;
+
 use crate::{
     assets::asset::NATIVE_ASSET,
     errors::IronfishError,
-    outputs::OutputBuilder,
-    sapling_bls12::SAPLING,
-    spending::{SpendBuilder, UnsignedSpendDescription},
-};
-
-use self::value_balances::ValueBalances;
-
-use super::{
     keys::{PublicAddress, SaplingKey},
     note::Note,
-    outputs::OutputDescription,
-    spending::SpendDescription,
+    sapling_bls12::SAPLING,
     witness::WitnessTrait,
+    OutputDescription, SpendDescription,
 };
+
 use bellman::groth16::batch::Verifier;
 use blake2b_simd::Params as Blake2b;
 use bls12_381::Bls12;
@@ -34,6 +31,8 @@ use ironfish_zkp::{
 
 use std::{io, iter, slice::Iter};
 
+pub mod outputs;
+pub mod spending;
 #[cfg(test)]
 mod tests;
 mod value_balances;

--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -2,9 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::{errors::IronfishError, sapling_bls12::SAPLING};
+use crate::{
+    errors::IronfishError, keys::SaplingKey, merkle_note::MerkleNote, note::Note,
+    sapling_bls12::SAPLING,
+};
 
-use super::{keys::SaplingKey, merkle_note::MerkleNote, note::Note};
 use bellman::groth16;
 use bls12_381::{Bls12, Scalar};
 use ff::Field;

--- a/ironfish-rust/src/transaction/spending.rs
+++ b/ironfish-rust/src/transaction/spending.rs
@@ -2,15 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::{errors::IronfishError, sapling_bls12::SAPLING};
-
-use super::{
+use crate::{
+    errors::IronfishError,
     keys::SaplingKey,
     merkle_note::{position as witness_position, sapling_auth_path},
     note::Note,
+    sapling_bls12::SAPLING,
     serializing::read_scalar,
     witness::WitnessTrait,
 };
+
 use bellman::gadgets::multipack;
 use bellman::groth16;
 use bls12_381::{Bls12, Scalar};


### PR DESCRIPTION
## Summary

Cleaning up the root level a bit, plus these just make more sense in the transaction module

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
