### PR TITLE
Catch error in parallel transaction verification

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -656,7 +656,9 @@ export class Blockchain {
     prev: BlockHeader | null,
     tx: IDatabaseTransaction,
   ): Promise<void> {
-    const verifyBlockAdd = this.verifier.verifyBlockAdd(block, prev)
+    const verifyBlockAdd = this.verifier.verifyBlockAdd(block, prev).catch((_) => {
+      return { valid: false, reason: VerificationResultReason.ERROR }
+    })
 
     await this.saveBlock(block, prev, true, tx)
 
@@ -710,7 +712,9 @@ export class Blockchain {
       await this.reorganizeChain(prev, tx)
     }
 
-    const verifyBlock = this.verifier.verifyBlockAdd(block, prev)
+    const verifyBlock = this.verifier.verifyBlockAdd(block, prev).catch((_) => {
+      return { valid: false, reason: VerificationResultReason.ERROR }
+    })
 
     await this.saveBlock(block, prev, false, tx)
 


### PR DESCRIPTION
## Summary
If for some reason an error is throw when calling `verifyBlockAdd` we want to handle that. Without the `catch` the error would be thrown in an unhandled promise and crash the node

## Testing Plan
Unit tests and local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
