### PR TITLE
adds an 'explain' flag to the fees command

### DIFF
--- a/ironfish-cli/src/commands/fees.ts
+++ b/ironfish-cli/src/commands/fees.ts
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { RpcClient } from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 
@@ -9,24 +11,47 @@ export class FeeCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
+    explain: Flags.boolean({
+      default: false,
+      description: 'Explain fee rates',
+    }),
   }
 
   async start(): Promise<void> {
+    const { flags } = await this.parse(FeeCommand)
+
     const client = await this.sdk.connectRpc()
 
-    const response = await client.estimateFeeRates()
+    if (flags.explain) {
+      await this.explainFeeRates(client)
+    }
+
+    const feeRates = await client.estimateFeeRates()
+
+    this.log('Fee Rates ($ORE/kB)')
+    this.log(`low:    ${feeRates.content.low || ''}`)
+    this.log(`medium: ${feeRates.content.medium || ''}`)
+    this.log(`high:   ${feeRates.content.high || ''}`)
+  }
+
+  async explainFeeRates(client: RpcClient): Promise<void> {
     const config = await client.getConfig()
 
     const low = config.content['feeEstimatorPercentileLow'] || '10'
     const medium = config.content['feeEstimatorPercentileMedium'] || '20'
     const high = config.content['feeEstimatorPercentileHigh'] || '30'
-    const numOfBlocks = config.content['feeEstimatorMaxBlockHistory']
+    const numBlocks = config.content['feeEstimatorMaxBlockHistory'] || '10'
 
     this.log(
-      `Fee distribution for last ${JSON.stringify(numOfBlocks)} block\n` +
-        `percentile ${JSON.stringify(low)}: ${response.content.low || ''} ORE/kb\n` +
-        `percentile ${JSON.stringify(medium)}: ${response.content.medium || ''} ORE/kb\n` +
-        `percentile ${JSON.stringify(high)}: ${response.content.high || ''} ORE/kb`,
+      `Fee rates are estimated from the distribution of transaction fees over the last ${numBlocks} blocks.\n`,
     )
+    this.log(
+      'The fee rate for each transaction is computed by dividing the transaction fee in $ORE by the size of the transaction in kB.\n',
+    )
+    this.log('The low, medium, and high rates each come from a percentile in the distribution:')
+    this.log(`low:    ${low}th`)
+    this.log(`medium: ${medium}th`)
+    this.log(`high:   ${high}th`)
+    this.log('')
   }
 }


### PR DESCRIPTION
## Summary

changes fees command to only output fee rates unless '--explain' is passed. the explain flag causes the command to also output information on how fee rates are computed and estimated.

## Testing Plan

without `--explain`:
```
Fee Rates ($ORE/kB)
low:    488
medium: 622
high:   622
```

with `--expain`:
```
Fee rates are estimated from the distribution of transaction fees over the last 10 blocks.

The fee rate for each transaction is computed by dividing the transaction fee in $ORE by the size of the transaction in kB.

The low, medium, and high rates each come from a percentile in the distribution:
low:    10th
medium: 20th
high:   30th

Fee Rates ($ORE/kB)
low:    488
medium: 622
high:   622
```


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
