### PR TITLE
Update node-datachannel to 0.4.0

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -36,7 +36,7 @@
     "leveldown": "5.6.0",
     "levelup": "4.4.0",
     "lodash": "4.17.21",
-    "node-datachannel": "0.3.5",
+    "node-datachannel": "0.4.0",
     "node-forge": "1.3.1",
     "parse-json": "5.2.0",
     "sqlite": "4.0.23",

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -262,9 +262,9 @@ export class WebRtcConnection extends Connection {
     this.datachannel?.close()
 
     try {
-      this.peer.close()
+      this.peer.destroy()
     } catch (e) {
-      // peer.close() may throw "It seems peer-connection is closed" if the
+      // peer.destroy() may throw "It seems peer-connection is closed" if the
       // peer connection has been disposed already
     }
     this.datachannel = null

--- a/yarn.lock
+++ b/yarn.lock
@@ -8264,10 +8264,10 @@ node-cleanup@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
 
-node-datachannel@0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/node-datachannel/-/node-datachannel-0.3.5.tgz#a8ec9c99ec1d4e06aef7d6f1966129d23c30b060"
-  integrity sha512-hlNdgjTsmXS+0ZPpV+/JdCQwDPz+CWRnaC4i9jj08KyAqEWRkYV7gkNKiR0wV+E9NlbJrgcYB5GzaCwxLk6gug==
+node-datachannel@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/node-datachannel/-/node-datachannel-0.4.0.tgz#cd237cbc121221f5f6342cbf2226120dda6dc52f"
+  integrity sha512-4ljypzRaWfM7bLtd4fpQaE4u+bAg5d8wPADycY60RfaZLoxVjcHk+Hsg+gtyyxNIeG6Cdtp3iDN+DUGAAjeVuw==
   dependencies:
     prebuild-install "^7.0.1"
 


### PR DESCRIPTION
## Summary

The broken Windows prebuilt binaries were fixed in this commit: https://github.com/murat-dogan/node-datachannel/commit/d087a7a5868d326e85ff4e08f465ce896e2845cc If someone on Windows has attempted to install this version, the older, nonworking version will be cached. But previously we had shipped 0.3.6, so none of our users should have installed 0.4.0.

As with 0.3.6, this has the benefit of adding support for prebuilt binaries on M1 machines (not requiring OpenSSL + cmake to be installed)

Also switched from calling `peer.close()` to `peer.destroy()`, since it also handles cleaning up callbacks. I ran this overnight to ensure it didn't crash.

## Testing Plan

* [x] Run `yarn` from root on an M1 machine without cmake installed and make sure it installs
* [x] Run `yarn` from root on a Windows machine without cmake installed and make sure it installs

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
