### PR TITLE
feat(zkp): Add quick script to regenerate params

### DIFF
--- a/ironfish-zkp/src/bin/generate_params.rs
+++ b/ironfish-zkp/src/bin/generate_params.rs
@@ -1,0 +1,71 @@
+use bellman::{groth16, Circuit};
+use bls12_381::Bls12;
+use ironfish_zkp::proofs::{Output, Spend};
+use rand::thread_rng;
+
+use std::{env, fs::File};
+
+const TREE_DEPTH: usize = 32;
+
+const ALLOWED_ARGUMENTS: [&str; 3] = ["all", "spend", "output"];
+
+fn generate_params(filename: &str, circuit: impl Circuit<bls12_381::Scalar>) {
+    let full_filename = format!("{filename}.params");
+
+    let rng = &mut thread_rng();
+
+    println!("Creating params at {full_filename}");
+    let groth_params = groth16::generate_random_parameters::<Bls12, _, _>(circuit, rng).unwrap();
+
+    let mut buffer = File::create(full_filename).unwrap();
+    groth_params.write(&mut buffer).unwrap();
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 2 {
+        println!(
+            "You must provide a circuit choice. Valid choices: {:?}",
+            ALLOWED_ARGUMENTS
+        );
+        return;
+    }
+
+    let circuit = &args[1].to_lowercase()[..];
+
+    if !ALLOWED_ARGUMENTS.contains(&circuit) {
+        println!(
+            "Invalid choice {:?}. Valid choices: {:?}",
+            circuit, ALLOWED_ARGUMENTS
+        );
+        return;
+    }
+
+    if circuit == "all" || circuit == "spend" {
+        generate_params(
+            "sapling-spend",
+            Spend {
+                value_commitment: None,
+                proof_generation_key: None,
+                payment_address: None,
+                commitment_randomness: None,
+                ar: None,
+                auth_path: vec![None; TREE_DEPTH],
+                anchor: None,
+            },
+        );
+    }
+
+    if circuit == "all" || circuit == "output" {
+        generate_params(
+            "sapling-output",
+            Output {
+                value_commitment: None,
+                payment_address: None,
+                commitment_randomness: None,
+                esk: None,
+            },
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Run `cargo run --release --bin generate_params <circuit>` where `<circuit>` is one of `all`, `spend`, or `output`

Still requires manually moving the params files into params folder for now

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
