### PR TITLE
feat: masp transaction syncer

### DIFF
--- a/ironfish-cli/src/commands/service/sync-masp-transactions.ts
+++ b/ironfish-cli/src/commands/service/sync-masp-transactions.ts
@@ -1,11 +1,24 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { MaspTransactionTypes, PromiseUtils, WebApi } from '@ironfish/sdk'
+import {
+  ApiMaspUpload,
+  Assert,
+  GetTransactionStreamResponse,
+  MaspTransactionTypes,
+  Meter,
+  PromiseUtils,
+  TimeUtils,
+  WebApi,
+} from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { v4 as uuid } from 'uuid'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+
+const RAW_MAX_UPLOAD = Number(process.env.MAX_UPLOAD)
+const MAX_UPLOAD = isNaN(RAW_MAX_UPLOAD) ? 1000 : RAW_MAX_UPLOAD
+const NEAR_SYNC_THRESHOLD = 5
 
 export default class SyncMaspTransactions extends IronfishCommand {
   static aliases = ['service:syncMaspTransactions']
@@ -33,15 +46,12 @@ export default class SyncMaspTransactions extends IronfishCommand {
       required: false,
       description: 'API host token to authenticate with',
     }),
+    mock: Flags.boolean({
+      allowNo: true,
+      default: false,
+      description: 'Send fake data to the API',
+    }),
   }
-
-  static args = [
-    {
-      name: 'head',
-      required: false,
-      description: 'The block hash to start following at',
-    },
-  ]
 
   async start(): Promise<void> {
     const { flags } = await this.parse(SyncMaspTransactions)
@@ -63,12 +73,87 @@ export default class SyncMaspTransactions extends IronfishCommand {
       this.exit(1)
     }
 
-    this.log('Watching with view key: ', flags.viewKey)
-    this.log('Connecting to node...')
-
     const api = new WebApi({ host: apiHost, token: apiToken })
 
-    const sendRandom = async () => {
+    if (flags.mock) {
+      await this.syncRandom(api)
+    } else {
+      await this.syncChain(api, flags.viewKey)
+    }
+  }
+
+  async syncChain(api: WebApi, viewKey: string): Promise<void> {
+    this.log('Watching with view key: ', viewKey)
+
+    this.log('Connecting to node...')
+    const client = await this.sdk.connectRpc()
+
+    this.log(`Fetching head from ${api.host}`)
+    const head = await api.headMaspTransactions()
+    this.log(`Starting from ${head || 'Genesis Block'}`)
+
+    let lastCountedSequence = 0
+
+    if (head) {
+      this.log(`Starting from head ${head}`)
+      const blockInfo = await client.getBlockInfo({ hash: head })
+      lastCountedSequence = blockInfo.content.block.sequence
+    }
+
+    const response = this.sdk.client.getTransactionStream({
+      incomingViewKey: viewKey,
+      head: head,
+    })
+
+    const speed = new Meter()
+    speed.start()
+
+    const buffer = new Array<GetTransactionStreamResponse>()
+
+    async function commit(): Promise<void> {
+      const serialized = buffer.map(serializeMasp)
+      buffer.length = 0
+      await api.uploadMaspTransactions(serialized)
+    }
+
+    for await (const content of response.contentStream()) {
+      buffer.push(content)
+      speed.add(content.block.sequence - lastCountedSequence)
+      lastCountedSequence = content.block.sequence
+
+      // We're almost done syncing if we are within NEAR_SYNC_THRESHOLD sequence to the HEAD
+      const finishing =
+        Math.abs(content.head.sequence - content.block.sequence) < NEAR_SYNC_THRESHOLD
+
+      // Should we commit the current batch?
+      let txLength = 0
+      for (const block of buffer) {
+        txLength += block.transactions.length
+      }
+      const committing = txLength >= MAX_UPLOAD || finishing
+
+      this.log(
+        `${content.type}: ${content.block.hash} - ${content.block.sequence}${
+          committing
+            ? ' - ' +
+              TimeUtils.renderEstimate(
+                content.block.sequence,
+                content.head.sequence,
+                speed.rate5m,
+              )
+            : ''
+        }`,
+      )
+
+      if (committing) {
+        await commit()
+      }
+    }
+  }
+
+  async syncRandom(api: WebApi): Promise<void> {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
       const headHash = (await api.headMaspTransactions()) || ''
 
       const choices: MaspTransactionTypes[] = ['MASP_MINT', 'MASP_BURN', 'MASP_TRANSFER']
@@ -110,9 +195,17 @@ export default class SyncMaspTransactions extends IronfishCommand {
       }
       await PromiseUtils.sleep(10000)
     }
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      await sendRandom()
-    }
+  }
+}
+
+function serializeMasp(data: GetTransactionStreamResponse): ApiMaspUpload {
+  return {
+    ...data,
+    transactions: data.transactions.map((tx) => ({
+      ...tx,
+      hash: tx.hash,
+      type: 'MASP_TRANSFER',
+      assetName: 'STUBBED',
+    })),
   }
 }

--- a/ironfish-cli/src/commands/service/sync-masp-transactions.ts
+++ b/ironfish-cli/src/commands/service/sync-masp-transactions.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
   ApiMaspUpload,
-  Assert,
   GENESIS_BLOCK_SEQUENCE,
   GetTransactionStreamResponse,
   MaspTransactionTypes,

--- a/ironfish-cli/src/commands/service/sync-masp-transactions.ts
+++ b/ironfish-cli/src/commands/service/sync-masp-transactions.ts
@@ -4,6 +4,7 @@
 import {
   ApiMaspUpload,
   Assert,
+  GENESIS_BLOCK_SEQUENCE,
   GetTransactionStreamResponse,
   MaspTransactionTypes,
   Meter,
@@ -90,15 +91,16 @@ export default class SyncMaspTransactions extends IronfishCommand {
 
     this.log(`Fetching head from ${api.host}`)
     const head = await api.headMaspTransactions()
-    this.log(`Starting from ${head || 'Genesis Block'}`)
 
-    let lastCountedSequence = 0
-
+    let lastCountedSequence: number
     if (head) {
-      this.log(`Starting from head ${head}`)
       const blockInfo = await client.getBlockInfo({ hash: head })
       lastCountedSequence = blockInfo.content.block.sequence
+    } else {
+      lastCountedSequence = GENESIS_BLOCK_SEQUENCE
     }
+
+    this.log(`Starting from block ${lastCountedSequence}: ${head || 'Genesis Block'}`)
 
     const response = this.sdk.client.getTransactionStream({
       incomingViewKey: viewKey,


### PR DESCRIPTION
## Summary
Creates a base syncer, then split the two syncers (masp, and deposit) into separate commands.

The MASP command serialization is currently stubbed out until we update the `primitives` to handle multi-asset.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
