### PR TITLE
Fix errors when regenerating fixtures for fee estimator tests

### DIFF
--- a/ironfish/src/memPool/__fixtures__/feeEstimator.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/feeEstimator.test.ts.fixture
@@ -1,1210 +1,12 @@
 {
-  "FeeEstimator init build recent fee cache with capacity of 1": [
-    {
-      "id": "0b75b151-4f1f-48ac-b4e9-73220afeb9e6",
-      "name": "test",
-      "spendingKey": "39cbe867b7e8f2eb9ccf299dcc4c0cd35c01b542f0484ee1876d431c5956f5a4",
-      "incomingViewKey": "36bf072bb912c7194a2c2d8dd42824da53ca5c013b20642d96e915a96c6a5f05",
-      "outgoingViewKey": "e543566607485e48cc57eeeb1c27cd654c2586b9fa307a81e402f97ac36056be",
-      "publicAddress": "0845f18eccc6899f22d33235290d06574192beb2ffb7f28014db3d4f62d59004827cef43805b840a9d9467"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:BISdYCpkkwdrZlHWZ2ZhCqxI4vtd/KwljHo9uxMlekE="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665618614369,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "B77C2921D23E34E68FA5E92A1A476E2D660C7CC4B6EE5811CD867FBFE5A669BA",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK9q4JEEG9wxQsoRPC7TOX2kY3G4Ew/bsHZAnzcQdgaGTjONrl/isw2Q5wCFrUn/BqNmFt8OeIZJ9LnkIkUcU87wBrEvnZRGOpc7XmkJjFXvYM3PLXCl1ESQdI15fySiYA9vogYPve3ceSq0vNJCPyZwXhqdvOLMwapMIZO6eOAACO88yChetUKRiUOvNu31xquI5s2jVlj323yVhcbHMhxY5GSu1MYrDTIctIR0jzGea7YVHt23ETbaGgzvvNuFkGWn0AKg62UfZDwmJzjxbmwU2UmUD3rWMxD2I66nVGWYt2tu9LegMh/OLRVjLtExmsFcA00eWa58EeleBLZztxwJMaLNzx6tDd2cQne/895loPFV8OVAkQVjRpJLfRL4x5RveK7gjpoqRf5frF7NjGp51Uvon+tDaXMy8Y+UIKa0klFqXPSUB23Mtk8P6CdQNF76yzo/4nNncb+DAjmzEdeaMnMz9yYZJRbK8SQR2qw6Hvj4HIju0Bi4HaMSQjWj6CSBz0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/8vI+j6vyEz09pg1bnZMhjR1bV6CqkTZ9dKhAP5WktbYl0HhTWMiDpyiKfwbswrYZmXt8BF1J+A3ltQqmr3yAg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "B77C2921D23E34E68FA5E92A1A476E2D660C7CC4B6EE5811CD867FBFE5A669BA",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:PBmfYWvxLgR0HCiznWa4qYWZJJnZOChBPv5bTiVMfSE="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "544FFD4F36C4B42DE3F9F81663CA28CE87908D9FF0EAC256AB49FE7E30B12FBF",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665618616334,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "ABFF7C63628323CF140ED2D3A1A482B6B956336F38F300637B11D525619FBC1B",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAJWhpKrqU1pq6xzPzdHL3o/KbTPiy8NFO8c/uaPJRk7rFQyOJx+JFA2hDp5NY13sebE+7XVVVHte3q1jz0R0cgUI60b2sxm7VDYKcV0er6u4UWaEEXQ3hGz9s+qxzSTehw98UT8UBRwVF+NZ5ZRnuRiAFPlFwk13K52MXAfGUpmwXoos7QvEVkOGomxegoruzJOavITD9kKaPmeJrBiWvPWujTdAoJsYEFz/yd3eDLYudNcu9oBlQit+uEKlkT78dl76IErmeJ9JEfCsixupqR+Kc6UvbtMDE6MN3LumUskzME0GWxfk6cl4NMd/9r/afwzMp2CykeFViqHYeA00HT6s92dkLMRd3eIU+tXfzwiHYAGKRSNAjDBE8m7Cxi+GzKrfaFyArdse4OQ6gopFff+qpKb0Ainkf5irAcMgtuGS1IuTvAt+QXoVIbbtGAHuFL+b6rS4teA18vJVIo1TnxTCXG3t+vdSrpm7H3ioNIRlOb1eGLHYt9OIQzkcItdNw3ft8kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTGVnxLXVsSv5Xv8cEZdh/aK+2h/0PUwy9mV5Ldy9BSls+H+k9dfsg/6S4RZdrK13lbbYh+ho6DAsAnp6432HAw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAIQ/KwTfFDd7FcSZc8Lu5f9P8e2RwnRPoPJaUE6QO07npTBcM+Ujs0g4alP+XbXUY5XZOMdSr66P5O+Fap5KEaKlEacYd7CBNg1SGbEDlelNiHOhQllEDfimbytTOfbyFxUJHW2ZoyNrM3Ii2yBZ6oS7RcDreL97P5RK7m1yW42p2/1A7Qa/ZRmUCqeaEHoCuYKXGdUVzzdtOVCKu0eICVjWlkWsGTFppstWFlGNdq2ySsBSYwvjr1sliMyZj0jS49H2fDw5nC4OXUcce48zf9Ba+3AkWIbGSQ7w4HRAGgOg8gbgWE7X79YWz3suGSqNEiprP9ThF8sjNsMIdceermkEhJ1gKmSTB2tmUdZnZmEKrEji+138rCWMej27EyV6QQQAAACXsjccSzof0y+ev6CF9Kr+mdxhjFiL439TyFiP3x6owkDSDt9ghLDUzw+VcutohbNiumDRAhBDq1lbZyj/Yj6z/+yH5UIRi7zLg/efEfpEFRS5GeitzMQwT0xdpvrz4QSv6Oe7OS00Z1l225OmG+nF1XIEjSw5g63fI8I3xYneML1hAfJlzUfQ0KYv+LTpqZ2iTDshS/e7Mdb94MJZ947z9OtU9IoPMjGKOHprAIaJWXLwNvWgVXYhoXAIO5SViBoMw+DDlLtmokcJcyaJf38PH45CdaUvCzbLr88IOzUXADC7M4kSBY8gNhCDCeuBAgil2dH/Qnn7lZ+/kEiyeHtYqA6okEirKYfzBgnmlFvRfEgH2LJt3NH5u84bvhZVVjzeyRIQXQp/lcJ7d4uLSEeAT9qYyCK0pOrOuerFHw1YW4CWweiDfLb1fEw+MD2rANKrcEXcUjndGOo+tpWbh9AXeZZLDFBQ0HCBuPzMSdWSw1tB3OP8gBs2pDknRwLaX24QVToNkDINaHlEO5xymk237KEE1YCfgtP+0kYIfKXSzTtVs5gnc/ekgyvncVOhsTBFNdGE947cxPrt0Chzp7IyoJ/mlIGtCtVI5toB65DHfoztfnQCDUzxCTvQrtLhP2yED60uG2f14qURoWz5SEM0+qpo2dBDyJ4BXnycKaaOrWvAJ+UTyD2FOjHr3c6EfH3U5uo5CnY8T0aczt96GssWVqBItjW9kSFVA8R4bm9L2b6487Owj7YgesOD4KQCZhy9W8KXIjPze0Rvi0qffu4nQeGPFjx9004Hyhaw/pOnPkqNlYb4upgFHWtAGdmflGHY5jEef8wfHF3i1dS7UKWYRtW5SotFxskvZQc/DY1L9mQFBw2Vc8nTvr7tPuGjObUt3Nm1Pig2dT+Uk41WiyrM7Gg+sEK+XD0lLz6LNjPnsOg9crKfLGTUPoGu434NLk3wYOvRibjsXYaDQoilVyDWncZn8SJKEF0E/OKlwfPtROiOOPQ6R0+9ltur9iZOkEVfbmT36rPRMxWSkoQSjFpfzwDyaVUkB5NJNrObsYTmqeDH1m5O4hwlYvIHEfQzJUf6P23ySdxQlJ6B+BStd7KTjWoG5jvBeXOHijPS+Ia84cwtMimquxO910hzyPzuu9oBw1PFL59c0QSgFEViTYgCAcfvac86kN7s/y2rLjKVwOBnK45xZLgQhpo7ffDf7AN8YuxjR4WB/3ECEaJnJuz8DLLjcXlx59k6L7MAQTL2YvzfSjERYsXIsaFkjwAS6fyiRtzs7j4ZZ5Qkf0toyC9+9SMT5WYUnCCrMDqefG+sDwRHWHx4MPPHWYNYM3wfT85IMthEYlmhu9unMYDSkz/LSYzNu+FgO8aBO/IiD7UcUT0XHBwX/HMZ2MUWGv66cVOgMQqNwLhGRddor9ThJ5i93UnNfPFt0XfpIYsju9OaLEnw3oquBQ=="
-        }
-      ]
-    }
-  ],
-  "FeeEstimator init build recent fee cache with more than one transaction": [
-    {
-      "id": "9c01b177-103b-47f9-9ee2-6dc627ec454a",
-      "name": "test",
-      "spendingKey": "878ae09b1440bb9b81c903bed0c9c5a16dd1b12db0c713b5dfe64c60b297499e",
-      "incomingViewKey": "d5fbe8a132b075b8f1c145ccf472e9d477810bc69ae2d44330772b4a5dc04601",
-      "outgoingViewKey": "8a4b3d7045a8d66789943c7404f20c2d81ad5568e3dd4ead45dcedac3ea4dee6",
-      "publicAddress": "072d9b32fd1c46a139378892ca9eaf7da736a27ff098978964af458a2cafe17ac6ed9c61d4a780123fdd93"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:2S0VZJex2AfjCfVpLricmYdyAAt8XJ4F+QUeXEu5MWg="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665618616644,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "765360339771BA23721B2A25FB4A79154F7B4D322559189407FDB9B10B2B4FF5",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIpLotfdLURbBQ3l82a6vI/0eOolCm5ju9Z8JEjPNtqohyzOUwFzTdlV3zCICra1k6YrEAlh2DHto36e7UY0VJUec2dou/s/SmpPttb1J5klDAYz2fynk6+qi8RY6jx0hRjxzerzrbg5lp3+iTSMQYau3uFo+WTLPqyu+VkiE5AKVJsZHxJadoxHkNOJaIB7eos25PA6jnL6ztMAuNodK0NRPMI4cTrUfD/XsPLJnCEdGRU15oWZPmkBdTkTNBZYChHMUZPPWsFjtC2fnO9hlpqXNKuw0wRO5ub7ECgpIOGmeIJAaVPamByFX/xh9EV1eU+3trdRZoyYBya9nn6uu1lmDHhgsX9xDZy96P+mCnWP17V/4UW7juEL+bEOHqUQrr0nYRZApCsxwMm81uqNdIJ3RXeasAORnQTfcgUpjSFfl3uhOZ28wBJE7CaJ2tbgZBpYd/FZZFAu4fGUd/jnR4J5otZy16YPz/HeCpIZltP2Dlucvz2T3llL7nDQBdZQaXZo7EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1LnWFh5Qj099zWVlhVLLLvkTRCmrCBEa7dkJscN+P+7/iFuOmYrBb7ujjqVyQYxPuILAhGqZHe3i4drA1K3TCw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "765360339771BA23721B2A25FB4A79154F7B4D322559189407FDB9B10B2B4FF5",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:nrx5IZllMMngpMnvUj/ASl2z3+LMqbodS2MlTYkmcRA="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "D1852F00DB6989B779CD135E5A28201C9956007A917F1326B28BF605BBF82B6C",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665618618523,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "0D044F368F569B78F72011620E45229CD95ECF0EBB04DAEBE0B00A3CB5B10BB9",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAJnnDFujff5J2LW0k4Cj5OZvbIAsCwYLNnTqr/pGusnRoec+DbQ06Ux+8SMkkcjDm7KOy3QHUOvyIMIYKoFP+QDNknQy4DTMaHyh4kePBrECwDQQcT0ClIkCwOWSibjkKQrv5BxlPo3KAcXNffFZD5SbjgqBFomDDb4UEwoU5iJQTMNZeJ0hugVxPFHDxoodjojfh6tMECjzrlNzsmDz+UJDh+zu9l1byD6rOOUuAe2IswHJmLG+R8siXkwnzihnfzRr7JWr93nvMb13JN0oAmef0/TS5QVI/SGVC4jLh/ISLWDkgeJjT0MHMG5OWm50soKakZO3uwxCMfWV0QaX7Q1pFzED05UMTQSGNb/dGlu7Du4JVcFxF2yBd8TOZ/6w8BJjXsFAC/WIuoPyVC2GePc6ex60W1pf6Jg/2HPrS0IJh0FDIB4B0bwLdAWwd77ExzffvgxpPpiBGHzNmF1EfTnSUNL1NY1TIju8hXKRr/xHpHNyNDkYDXn35Qbnwnfcp6ZzjkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoK8xM/jYduIhVhmvDeU+GkWxJMHk2DgfcI7jadzRdeQkI1h+4iCbAu55wkgIPDAYqu1UP5xmIHS842UcOHLqCQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAKc8e9QmpQXlCm1UQOVgThdduks4R+2aUdLN9OyPZt+oi+DfEdBEIe0xUru4GRkbdaP/Hd7xucgg3l91TYNoEPdCOl7vHbFSSgXieEegvt7xZz1CCObdyoWm0qMoo7AXMRnaZIGUPkh0XHg2WLyKHpV+tb8SGRzjK+RwS5V6C0SkYi0sBaIwW4Athqob4hyEEIfwEVJr1J39ywxWRypo6PQgcnljkQ1kZvoTy7L88vDgQC1cHnsEyY5Blohfn56zKyTQ2voW8/Y7YR/ckAnBUaC1vJ8/+L7HYAijO8YoqZ7Sk9vATJ1izoVp5VMJCuBAMCXeWN/xcZtXE2eWlcgq9APZLRVkl7HYB+MJ9WkuuJyZh3IAC3xcngX5BR5cS7kxaAQAAAAhnA47XMBxnmGMOkjJLssco6PyKsm5g4giYLW+0GUL6u9IxgYKrtyftzlwZspFsstM78m/WIg/BSeIPOD005q54I5Byhy40IN3Ot9nTscOLKE0R9IwXWWnHF+XR6mFrwKWxbWVjnZsuZZU09yYTZ/SoVU1yQw/pnOzR8Dko6k+sU9JldjH8HiCR1oYvJFzmiOQUbRCsSgqJmcZTJ1QvYqxyqZeEuzX+nngyaSg4jN9I+FJ7l+sxnnABqyPoLAxDjEPcxelM2cyFi94gDs8assSknsvZoKNQtVwZD9Sq6hYaP1w7+tYpsX1bRQ9/bz/yJOkdDttuH6UIagO+IRgql3HzanAta4zjixnwF9jBD1H1xp2ayVrT39a16rFcri1pbhpHEl5fcbmdwcOeIx6OUrQI/kh6FX1bk+DguObg1wKHI8JSFd424+czsjWir/ORHdq8p4bNULG5rQQ41ZpMec/7ovxfw7CVzHcgJ4JWq2YRwz/hNA8w1DJVrmNiz/FKCQgRRd7UVZfWZAjRJHQQcushmWqHvOd96HZiMsB8NcDfIVjJ2O1K8efKefZzQOzf3difHLyJeEQobNmyT52/H+W+ub4YGw43XWWIOOfJE1riDC7qy9U5nnq+a/yxwoEWKG3I5mLSVvWMoIUGLszi8L3nxKYTfwRgpMxwkuZM6ld6s9ZzglkG3ZneShuXWOpSgbTFsI+l11Ss6JYqUegMp86o+AOOBBVyHOHg/ZaFgdRUhtH+qRLteprRvsOCTM0T2FZy8JTBPm3mA9aJjaIetzW7+lN9ucBa0jHqkW1FpNMjEX3BLKKXJcOVdatrInzl75fgvnWSktZ0cgepjkB7JFuTTn0tQK0Y7wfBq0/O8oV1mNAeRTDwCZhoq23/cPNY/5tql+ZZQLPNkKWjnDbjEc++Wu5vFO0TrYqoN7GndeUgQ/sFIFFykRkejIe7MH+aIXsclPSc1hDp01T0iZbmnC+KvFNPGrM2uXeQg2rTllrbSXklxEVwpydVGTjKzJyv70pINC51nTO3gHY0/dOVGV+eMBtzt4n7doRmLV792YBUHl0AT4kYClmm1oa85dAUNdIWVNrzUioycUcTAqq/y0eURHHPIdHhZpHN6BMt/3M9rOdaQ3Zt+kW3N7gnawg7pB/ZXrAuBZa80gW8gJ6zm2UrX6ZQ0izzF+TyXss/HHD1bzqTM3AGftFi3v6l9P/lnqaLt325kEz0NRxidOgV6mvPuA77/awM2M1EDF4TLn/zPS9vBcnPYV47lihRqEhrC8h9j5Sg3KWE+j4gUZNHqb//SiFCsX8L5a+jlgl6WRmGLsrf4chCDrbNtszDBKKYJ7awrzgLgJUJXb8//MS5qUzclgDIaq8ljolhoX/kpVhj6tkmLI2fagcYn9qZfJZ5tnTDtTRZpHYTpOFlrUCeY8rUYbVMus6mkkdFkqi9yEALrXrnEypCQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "0D044F368F569B78F72011620E45229CD95ECF0EBB04DAEBE0B00A3CB5B10BB9",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:U5amEOGOWJWm/t5MkmR6+dw4CzRy4jI/hjDNwGll9CA="
-          },
-          "size": 8
-        },
-        "nullifierCommitment": {
-          "commitment": "D1852F00DB6989B779CD135E5A28201C9956007A917F1326B28BF605BBF82B6C",
-          "size": 2
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1665618618751,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "E7807904D162EDDA24C744901EB6E0AC969C19BB607F861A4B0E8317DB3EB64D",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKfE+wutMnum/GQ+29GQu1kYcE8Ec18wV5h+UM8BFRM468QaMstuTcxFUUR/YITWD6LTBCdenKh1fNNT0aw4MgbdrZtFih4AYvizo1Rp6BUcEA1zIO7LIhth/F6lUoQ0YwJ6AxMf2IphxbRaAStGTMoeZS0XaheNqe8+FmSULmZ13dl+unVC7fhZx2601rE8WrU5JyJSRkcy6vsyEGkC/Xr5mHuQ+IW0fxaEU91y6BRDZe++Y6QF8+F9V8FyZ+ItVGxI+8DMQfE5kilEQXzubVGwcDSq4MC8sGRgHDZ5IB1Nf0uitnUEeN3JqY2Wp84Ngx4EUZGolyfxnZO/buZp9kkkmw7W38FJ3tekGyLJJJBKPUu6ALEpiIwwqanObPdDpx7ze1Me8jnYJwUgz0ipPdLaTaOoiJESWa6zsTXoVQHQ3Pbyf/1bdscYTQXVLKFIjlxj3fXPz/Ex9ELfhGRQW+2UA64itycPQckyGO59cIjjxcYDh6HsGy/3BK2u4Yv2azB08UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYj3do6L2QuNpH6DQlf6INl1PHFqVfVhBNVNPoScp8Lq01hzb661VgrRjGj4WNFrD8ECWIX3UyINzlHy0hVwECg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "E7807904D162EDDA24C744901EB6E0AC969C19BB607F861A4B0E8317DB3EB64D",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:Cg+V6LjhapueNCalXw1FcaqdvTt/K330qqaI3yAnRxM="
-          },
-          "size": 11
-        },
-        "nullifierCommitment": {
-          "commitment": "CDBD7E16CFE1C542FEA5949104DD37400201AE00B3F546B184D49E43F71A4BCF",
-          "size": 3
-        },
-        "target": "12061061787010396005823540495362954933337395011119300165635986189",
-        "randomness": "0",
-        "timestamp": 1665618620649,
-        "minersFee": "-2000000009",
-        "work": "0",
-        "hash": "BFF16DC54C90ABF5E4704F9881F5FE73F481C48567B5AABE746A0CB201C5B494",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAIRgra5V83rpbrCGGqURbHT9Buzb4S1SR1Foj3SDgfq6wCLBTg6Hq4UP+O05BSEwyq91pwkonyKgtgn+sxTczxCMBon3UaFwoiqDi8m9kAoz4ELta8hBoXcLju97vKVFlwwIh/6gM4/L6wOlKLsN5vg54oEauBTy4x55kBSle0I1Pi6IRAHmq13Cf/DBufqdXILBbnFJOZhitphwuELJV9JZmBKxuyWPvrbvnCm6+xn+DYTYpbpbJfCGGDvwm9uH5d4oS0v+ep7HRPQpv1JjVKS/zMTh9TDSBCOXqKW1/dyKLJUn3mwaEVqLULRBvPTgVvshda1OJ6NaUbdygxwD6QvAnHsrwOJP2bAbuB4gBmOyYaq1ohk5+QL2hVyaE1yLsz+wjk3dX9af+o6iaz0S/sNHd0cZMO6BF5fJm1wDsIm0zQu3vPby/5foVdP6NxDoHpV9KMrK1GGeHECBTEF77M//3LGzttVN+9+TL2EmPbzGHNuSizK3Z9Zy0OpAxW5uEEdC/UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCufP7iEIvf87hGXVPA3xN3MJXOZDoomBkMc/J+TNj5SWXJVa8Bp1mD7qTgyAoMbpRsKKh+wxJbA+Nt5j7owaDA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAAI99znxr9RnUg8fZVTz8KZeY+nthuY5hTWLM0t+E8ZowkmjVXx5IUSEsh5U6+8VTvJDEYeZlu1PijD5knvcvVgPx4l+NWmxGqemLXStsp31aGT0nwXJmfILXnQTeYNnFfwWKhN5KAHtVOTXRkO09EkNbMk8/KPbHnX/lb2hYGlLVUEbceQDxGreXZQwXXAZ0sKw9FT0y90KvEBOOZeJovmAas/SaDrhX4tQBF2fiJ6x6rQZbFa/B9ZwL3gQrUB5Euw6uy5nIMDIli80NY2vTAKcRASooheRmH7KI9sIK9xyBOXTxyg+T5aUEfb5dOLywaAsKHoUBKTv5y4CoiA8ECA9TlqYQ4Y5Ylab+3kySZHr53DgLNHLiMj+GMM3AaWX0IAgAAABezuVFxVPuGlSeQELgS7I597EngYyCKLVTbXx1mIsippXsQ95wF7f1a9SwSqhDnD9P9R7GywsQs/n3KVtH+XqHYpsFKQ8OkPns/mf7twCd0tYueBNMWT5X68ZhHkYxxAOxUnmiF+g9yEcY3PHQz87d5qo4dpNHrfMMFaMLi0g0mCpHKJjX2l5n57Isri3zXzenAYbuFRFdt4oUEcRrzDmy+E1clhHNcSCOA8OIlAtEi8VmWIN7pjR8iTc1qYQU3J4IUcD318bqhm1WgqBkNc28jmW6GTY5kqkaqrh+KuR7LZM49uCAJGo3Sx33rj1d7hmRjsplzJHm4r9TY+7+cjEE3076e2kD0C/n4purmNp8IwtkfFLTAh90O7w1XSHUHUdFnZE/tk1XYmbbbehC+J/70c3lf3bXMMTxCNxMvIaSgKDlCI6GcV5nafh3+dlRhoSYfis/HQMQ9TRe4q30k0dcr3cn9Vk2tE7ENQba417DLY79xxefMYEX8Mc9Rt8gr508VcuP8h5TQpEUZkKNnAi3HtJxga8C+oRY4LrCgV0AxSY9GceqIyszzUHQek6C3yNtSe7M3rangLagh243KazEYzXATF/F04SjIes2SxunripggN4fM+Q6e94q4mBpXHwL7fTv8skjRY/+PKTun5incYfFKgho1I+lR6pNyuHfAbd/z2Mbj7k7p77Vp1WoHsbdjAw1toWqhVpKQYyWQYXCxgSXb0tdBB3TvGKp4NeAgbMey6d+b02wrytVwLdQXiGTrL4zutKV3gh6QXfHsaM9m5YBfFc0ly7L38Mjqmo3g42fubUke7v9+5zhT3BnjFTMSjtvSixKi8/7P1dOWYdGlPIudr8CRwytGeZeVwsBsZ5+mQzeeLvrZUECt7HPtpcvgrY909uONyMMRZOz110NOXhSYAXpNJKCuuZX2dr6NIpZypgAWIkxKk+M9U09JjPzxoUS6qLQ6Vo2ZnzOzh12kVAA78SMzuOTi8/4r3fzUal5lDlp0PNm7or8+LW0ckrXR3B8ZKSQuNOTBnA6pEF/Oda/WDFhn3G/TJnZrhS2keQPfifsRoaZ/QQmi/yZmN7AZ07Eck7pSdtYH+7hlCM0PPZebC4nkoivHkvP5prs92/CWBtzSGglI+M9LtVVzR+eCpzXIhVluflrbNFOlzrEEbtbcVWL6JbTpvGVqd8UjNMj5uB1X3nQy/LxeRIw/3axm2tuf6SJvemCR/4KKr9wbSNUyN2/mO5ic9ZHrZ8kKYILvGfY+V4JWmueEZDE40AqtWUiqMWOgCDyKCh8eJfNlotCO/BGo9lRYEQgzQMrykT+EJm2NlL9ebHQSTic7nLEBmAsfChqXI7nSzVXgPB1PBiGIC6TuMR8Kq9YvFPkKJZmWxMKJqlpCNKyn5E5dUPf7Whkc70CEQ8VGyQjPKRgY1cKIK8gmA9h8is6+soIxOxcwJhYCA=="
-        }
-      ]
-    }
-  ],
-  "FeeEstimator add transaction to cache": [
-    {
-      "id": "0c16635b-1d89-4a53-80b6-e99053ccf40a",
-      "name": "test",
-      "spendingKey": "530bd79db6a821b9ff2560188d04dbefc7272e3489adfe289ddf93e20ec36055",
-      "incomingViewKey": "ce06bd428c7c06c6bb693870acb08bcde3f51c6c99d23d01af184ce9aed59a03",
-      "outgoingViewKey": "c55359884c3497b47af99d0a02438387d3c44f4f63da8ec9e37d3fd2b552fa23",
-      "publicAddress": "22968058a391f57721a3ca77d49e886ec1f1cf37d96fcf5a5148e7fe0307dd7d232c9729cad4c1c9ad0bc9"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:+6cNrj5xJRTu1y/gzM+928oRWUblLNyHUbKMoLLMFig="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665618621016,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "9F9C9AF153B887F9773A0BE561337B03D5C3A92D5D7F71E17702C03F1C8BC913",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIZ3PVPA8ET1ijh4FR/6Fb7IAWW3IfVkCIuu886N9EU35d3gGTVU2k0lhIqsj5Tnl6h3PBFvMLgdZZq4E5m2Z1hWA6JCp2Z3wm33rRxO+vAAa3YCfGjz5duql+3nxyy7Vg6yR9xCzxrR8hdAZybqb0aNYtQ4NHRz/pNq9hidKUIdQHZNLSvw2CQrmx3IVIY7s4o48NBTVQ6OccJpZ8h491oDVSRBPl8sqdfbTirYm7FvxqmWiTczRKFYtirIQBfuZxqVkncxJpOFt6t4ezHBwVeWq30VNPTi1JUl8l82eLIbVobLnSGxczxpK/ZMjZ7He1deBQucZ742Ya/PUEr95lzPWs9IrAgOiubMoerHITH69GMlnUFUm9iEXWhruF4lLw0DAncOXxZ3wLjl7OiQGDb2W2FqGfomzPlPs0QoYeUxVMdXaRL04K9cAEW7N73hqi+RgNuTHzAiN1O6A4bX7MM9giD9TTvJgKo9lPtbUnVCGf7tTvC4Z7MO2rfh5llgcyGlKkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhWmrMO1K0VTYqKNC1hBkVKSrVxrm/7Fj+lmbPhM4JTmcuGc9IVZ6tkuToqa6/1LTRnLYu5Qw2fRlRP0DHFElBg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "9F9C9AF153B887F9773A0BE561337B03D5C3A92D5D7F71E17702C03F1C8BC913",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:qDUsWUKyGn6vboB2ssZzDrJDGlK5jRo/c7iq21onr1k="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "B7EEFC32F6B5F17C580B07AF911D640778ECB0BC803A8E5EF5C07B91EA07C94F",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665618622993,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "C41C4FF6E1B9F22141ABE6557C901020178F4CF12F6B19F664E831EBF61F45D8",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAI9LnVPP6RXI8dzzVPl24+BZVr6FBNs4oARCppNLGStUzd5o7GXkGw2j6zZoc4zc4LShL53GNwDM7YPHXp6fR0Tu0DGqmNx2Zkbge6BoFqUBOLu7C7hAaOOtIQTRyY3s3gSUEj5XH1blZxWjfXJYXb/hpAo5TjLRQK6BSOCvWYOu75k3Ueq2K3lKu+sudJBO1KQTUhaPgVdfVyXxKEI9m3hUaoBIQ4F9nevmP874kzgX1ojqx8T5gvZvg4aU8ZZ1PK0qbRNI2jr6fAAVAl09zruo9LMa9VW6slg9IFW8xWco/IOmuv530/5HrwLIb1+txEvZnZIcOM4up8K/EyXv2W9Usgierhs2qVpjCTom7H1QZvo3KnbxVFcW2dz/tU5u5CIDOSQdwu1rtXJByhoqGENlRmt7ppzZyHgb9ObI1Oga1Y8WeqiJuRewNcUaxOnCj642dLEfAj88GpmpMg7hUh/JdBzT6XGdTgMMKLa9ONG9J36ycqc1DgfxPgZsO8r2BN7NVkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbSmNqeWfRUY259BvYt/HFA8Y/4AMdi8Artf4Pji/a4+7Y+aYUzVmxUvww30jLwQjph7OrIyzcHTsEV0DFhxTCQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAIihYzEGUqj/kd6kW6DlY7KNuxc3j3ZIKAZQXdiHppj4YKIfdCaAc7gVGNAsGK+nfqeKGXkVlpiL1rYJpK/TsX1wwQJj+7KrqPYuRPygipg56IJNAQzR826CJUOK2PJcRwhJyJSREhz5PsOwE2dpzttmfzZc0zEPVKBrE5cUp1Fhz32XUn6ujnu5Z51mccpD9o+V5Rrtsifys0/cYkLr1twhWn2V9gQRrN33PJnbQM80OjkzJpGihvHQ5+BmiUB6qx4r+VdUFn4MPwRbs439Tyixm1iECGNrfAW+3RDpIn0CBjwazx2OdPULKzUaqEZ/QJhEuG7tDQlu9LtjBgK6aq77pw2uPnElFO7XL+DMz73byhFZRuUs3IdRsoygsswWKAQAAAA9zVjMuqOc+pJgHkyMboMV5YWp1UQl0uFxNnwtQFywlZ34WGBFtrmYTO5R/r/KgEhbKMokJEc+mHtfNX6+qfDAzL/xHO/810vt2qFPx06hdqOdZ98CneyPFP7WZ24LYg2Lai5wzD9Z33vPMHRW8NUZ93XMLALdBYwf6sJiFeb30KujlGSTgDiNAUvGgHkrTwiqDQA3NII43BkidvQecuEw2eZreIejxzWyZ4PsRLNKu5OzHcQW2j4ftUMIZwgm8OUA2p2o3yScB7uUw4rp3J4blZ7GyxQTNzaO1uIwexrMFuH39s2SKBdql1ToCpC+j4eghHcim6ojrS6v2LLRr0ubuB0qPduwbgMCErFokFQPfI6uxYXfRL1JWPukxgolCOR0FQOTXrUCtkBeNeaOZ9rdGVDu5IoocnhVn4qP6+rXykk431tt/N+KLm1fPhpF6/8z281IB2OXScy99WeZDnIXamOyuUoYzOr+5d+ZvBVoYOgwBaU/Fl1JPspV47FkABnoYfO5GXRRmMduzZDkxzXrVvlGJj7i2PjOxSoLzx20w5NkTIAaF2w14oTe5/NY1Y63Cnw0868aESY0kuSYYX7M39NMd+k2ly0S2dI4FWrMcLGUM8dSmPAUBm+7yJn93w5ar/MQ8exD+ASzFYPXqaxJOm6KtbsQAZWmeQMDFX5uh+Aej493U5bElEliKgZ2XlapCESPTORMAkbRuMmQ9a8fxXmmtnnR7kwT554BCvAlVkUu+5Mqu6N/qSz5lOkYBJqnQJJmK6jzm0Dlem0QOPRrtzR4CAgdO4zhHPl5+TeTOijFxpaQD0PGXQtp0LUrgvVB4810f+M41WN8exuCgJlrIl+vDxVnRWDSPIqVZuOveac2egoH61lZuGxbINyS1VQEZBY12KNH510wxDkH7Yiwz8nbar/4upC5d/8znSaVSBUXipgGJ0z8Bm9wsEtmcG0eBD8rlDct6W4gIODZZys/95Nl7KHCFJKwAWHvCjOnjzh0XCRXfOFdoqDe+15fqUcvmlxbzq6trZmKqAz1P5ZU76wzP85/e4tRslljvIKPpCzy8V08yLTn3i48/qeVv4OSIRpWJdmDpwGZ7V2A9OadSUE6RlmFXTNxpxKPR3MhnSNWuQpmYleoVyvvhF3FweA7rqoJ1ofmm2dmqpdmZGtNXPMU/2PpZ50y6WXSCIEKRuqUz1Gz2314X0SCwrXDln4ekpgHmG+rlqUEh00qyh92U9fspWZeTLIp2/9qKFuVAFMK5+0FK4GaQUK1uKwX6fGgU15Y1/RZg6lhTOEBgLWmcnSOys/h4fCcOwOxPT7Jqd/OslQIpmoA29NTUMvjNYwReJavCHtCmQz53+ipsORnUGmNhwA+pv4wxRTyG4a06811JH/m7CxYtOoU+5jJH1T807dy1RI4qUzXTxC7oQt2/XFn6IKRlOOiDRc1SVxxbArIrGOYCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "C41C4FF6E1B9F22141ABE6557C901020178F4CF12F6B19F664E831EBF61F45D8",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:v/qkanE1JM3gmqSCbY5bW2I9UwEV62gfuJsYvEnT6Fw="
-          },
-          "size": 8
-        },
-        "nullifierCommitment": {
-          "commitment": "B7EEFC32F6B5F17C580B07AF911D640778ECB0BC803A8E5EF5C07B91EA07C94F",
-          "size": 2
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1665618623256,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "4DA00A35FC6ACC05CC7DB4A86BACAA2E58A6802DD3F005FB26F314DD76422934",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJlyb/BLZNS2mfMWmKySFbRkOuy/ZCpFHFtFLo45g/fkuq07K8LIrWlOZVOZHgH8YoGdohe/TvJ8l9y5M9s2n2NBA4mPNiiyZQqTdGz61ef3OwDAEjK/hLG4bwwFwOlRHRgCCBxj2/419gYwIRzURSbWriCkALy3KM4GyO59+mcb3rJHNvySAll+4Rvxk1JNBKyi/h4G9KKo8E6LJZfwOGZyeUE+fIj59BkRnh1wiDrKTG+L0OTZq37th9J5mOYMAS3LiAnz5n53Xiuhu9LLC+/+XpTF9zbAKiPlcxgekpzcsuT9dl90mA6YC1CyfCUqMvUjHkvrCfrb/XTKpplaumu5ER/kPgGni6lVg1qPu9vhv6r56Vxhk3TyEJLkD3ErO+qUqRA93uqDlZKe5Sn37s+2+BmiwyE+zbtdfMkkpU90InF16FTVDpKeK7nZu9nAbT7hnFy0Nx1yWyj80x1qXNH9irfwiTqJjjoHq9nUMMLHUlquBduw1ZSylmkO8D1XzFKxJEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDF3XU+VBaBonRKWSC2QhrUj6uS2Sxi/0U8eLvqMyWjlWeXF33U11eeQmcuLeUrQ8Wra8yzsgtmRtcR77prrZBg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "4DA00A35FC6ACC05CC7DB4A86BACAA2E58A6802DD3F005FB26F314DD76422934",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:J0iwjOPmKSv+KKvPW43YwmXk1N7rK0hCBGVGdBLk4FE="
-          },
-          "size": 11
-        },
-        "nullifierCommitment": {
-          "commitment": "BFF7F2947F65547FC787C80870FB4C68A1D0F925CA59A35DF2A7E1CD70679C45",
-          "size": 3
-        },
-        "target": "12061061787010396005823540495362954933337395011119300165635986189",
-        "randomness": "0",
-        "timestamp": 1665618625131,
-        "minersFee": "-2000000009",
-        "work": "0",
-        "hash": "1EAD7FE8BFD628E712122F65C25B809684876912B8F683FAFD3713B06617AF38",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAKCnmZg7XWh9ZOQZGwZaAS6pJK/lyj+sA+W0bSzeAAbx9nlPbHlz2W8ZJ337SPdt/qpysFUTheVmEnswU9QdP5Jm1c47D3rAWJGyGGCkmLWa86OPp2mROmDibVAtP2K/lgZ/mq/qMDbR9d0bHnkaQgWYKpHzVLYRxnNMkoROaPtbGJM2j0+6jeJc8jjmx+lYyapieoDBiqXfys68a7D0LvKv7fdBJhdcQJA5bRnoC5jfGiQXcFlqXYKVySiV6mWvup/Hj9u2XHJSosJVXQxBMWikStqNW7IF1hX2OV+GQ0/SxxecjRjRGIuYHKnEI9x/H+u5AJgIOqWeukGQjb7Wqz/JpcaFxMDPcSL937kfUR6URIM4RS1qWZaZlWy0fotMZ7uetscwWCUEmyJgpXVpDdf6bSxXVnCdl5Ul0TuKqp6/f740ah7xr4FhT0NGelfRPd3SbXaXez91wS5DLZ8d3xKMAPxIZdcJeKqHveyGy+iwzTmENOBkZHsEsZYXuVyeZnN/o0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw7NgEjfFxReCzl9hYphhozHvbj/jc2rBSztkQLT59KE71AZyHJGdRlytKsVMBEndbPn510FCrvQJpf+NsDXaSAA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAAKYteEhG0ojX7edbljwyk6eTOMtq6s2+BqSBs5+O/c6tJeqnULEbv4vwLyOsojuxA7L73Km9EAAgVq8x3ayj8jFccXJrzL/VDmEOLH+r8Wk/jCQT503Uq0YdbCM9DkQz9hW2q4V0ANOZy3ru7GxDCmKJdzIE5/k0VBsYiobO3cbpbqpNw4gcs7Fj8UHfyRvDjKJmLocFCDkekT0XMO3fPPxdXWuhaf7YazYBH5VyT982a3jz17t3su36FuSd3TZe0ErncKI1O4+KaV5YFzfPaq1F+ZLO1cSTQlSHNZ9aiHuETvl6AxnpdtlGjEqbimKYJb2D0TQb7PUgTopbLAUENoq/+qRqcTUkzeCapIJtjltbYj1TARXraB+4mxi8SdPoXAgAAAAIJAKfwprnNTPxoeoAZIyc9lCX4V2Rjdncpdp8xzEL10IaoyWysDcbYU4ciHmF98hsw08lH/AeZZ6XYk9lOK5Y9cYhb5M0D4cNSIGAvNjqPAvGcpMN0H9V1FAm93DWPwKjRqa8C58/aRBjn0VHtetvSNhdgsurI5L3VehC46SOL9K0vbwrkW/stwFOee+I9y2i52vPDPoHkAMKsdrNpeLybsZFkVVI/3rDwGUflr/bfAGoCIXequhT4nhTAhJNfawObKFpfe7/X/jqFISPKvKxtfTL9INHtk8G4e40xvhIImzWBXjgwvKvGXleN4bEHbuMN1J5XfUUjikVa69gMQVwE2J5ESWkidrX94d7D3blx5+EXdkLDwmW6CTxKmZTje1kdQfRecrviVc4w44O96RNsU70UIn9aaRitIUH0mu8RKNVK/zhacxyWJRuMtRPSBCUAH6mdgwED0yFstMonp4+MqiPMzF+NV4uqooEvizhcYB2tJA1uoMguRxvvSpeVwllCQg4UqMXDm3TU7iuSbk+5oTpIAE45jKr5VZRSX/FBaq/6p1zG4QlfXFaOrjLqNuNzzgzC4+wuBgR4sRIk4QdyLR8MG95GWr3ukQsQpDMX3KGXSL0VZbnghVUPcDP65ik9uplr0wsdiRmq48TcrzlONDHNsprBzayN2Q5UrG387/ZLmaLhTA9poX7X7vHTPzCLni5jPqrjgnl5zk+R9IGFSkgxYj/UtwU39yAOIuHGy2n84CfyjAWmeIQMZdOZd0eLTgwpLV4N4SUIjn4t6PqA9WkDvRtLt7NGTBuCgncwSegMIi7cOoNfv7g8mipvHN/5mgedGeDaugYW4nttTmkOQmhuH434i3McCKnbhJ1BxTbNQcdCuS+40RFbRlo+DfCVvdGAkvBEq5iW4/VR0bNnkb89rtMHNvcYyJIlIeDRgPVT6ivdu1twRqGBZwpTflzTbqpGP7/z5x/POJzk+YG7QWM2fEY5OXrB5meuORiRP242XvQt4CK+7RBo3YPE49SXJu2uY3DGxKvJFZTlPgq0uOYjoDp2nOwpuwnr+Za3E4d9mHdojLSiEusnjyTjATjAmhKL2xiYJn2n+0rZJ4qhCBJDxLbdZzL7rFS64b4jkqcLotjJ/87k4dWpvZ+5updt4r2JFE+Gitldz8xYewjj4ahZaPSXdzshrzM6Cdm6/ZXkWfljoFou2uBfvFe69dwImxF0z74QH+zWmsu1+J+llLwPHIlrc+XnEtKaj78QyY000wXLpeKP6ZRtiv3yMUP1mmQUWx9doS0hCtcszzqN2midfjgKc/ko6YxUs6aWvT3Gv5C3VNX46pMAZMuzhJu3UhqtNlEyN/iO42Mwgxg/jlgJzurFGX1C0Ye3s6TOz5pS9gZPaAKPqydtuZ5qcmBfKTXF5OEuYmOTGdRBr62eS2D5IwZkcw+jtQLVugQ0eydYFQ+Cg=="
-        }
-      ]
-    }
-  ],
-  "FeeEstimator add transaction to cache when cache is full": [
-    {
-      "id": "b67f21b8-5c1c-4504-8265-623457ac75cf",
-      "name": "test",
-      "spendingKey": "dbc7f2ff140ad8a903c3ea2c6a63d43d0e62c7e8ed8f83f8ef20c5e0c3f755a9",
-      "incomingViewKey": "526efda0c6d13d6603a407aa9e82af0c0d7f519ef89d83c5b9c1dd4d7b329006",
-      "outgoingViewKey": "4b2e5a622979e46cefe90886b7b0282fbd9fbcecb776997a7f4ec2dcac56f7fa",
-      "publicAddress": "49409ae3c9a18702c20285b5a2cf17e11bfaa400797dc9e3ebe06d1bdc6c8b6b86989272a6f6e76d0b3ef3"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:H5R8v3T6K2d8+evtZWoh//fTyeE0OmZOEPjqll7X9g4="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665618625445,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "F460B16D30303CD43EEBB4DBF2F8B7623EF4F98A507CFCBB79056FCD71D51646",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIGni+k+AbNznmrQXDT2fNOBBOelYCUPPbt9ctnQjss3GtfT5y25HOfbPQEEyaDqsIH7f+16SjXSMfiXl6MsfPTshTmiM9yaRanf1RboeWdsh5G9x3+YoEuN0wWP2JkZTRdrBFj19gEpXJyc+dSM8QB7al5DOwjRQqO+jxazwkKK6rTYiX7NK/KazyaeEo1p3Y2Ru87QQpTI+tNSAs0JqC6PaNfHtB3hSl9kLaLEvc0l9Q40Lc9WnT3WjT/bvcDcB+OiKN5gxYTVc6181RTp2VP9pGI5Z3pNjUBOPWrU9iQG1nqcU+jzZUF33u31wllsjAHCk/iGy0flDlRJ5VAf4T9yOPwqDCfTZLtR5DK9Ras+4acHGCVemJZqT3rb4KJhTVg7LAX3M9XICMYK/NCAMOESZ+D/NlVx5oPSUbXIevj4wP/Es7/5AITXSgPHuRm6D8PuQOt2q31ix+TiW0fG1fjyOuEt0OfCFESaaGwLssT3wRO4wbDf3X7Pg3Q2NJcjooGC60JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5g3d3q8eIKb/Y81n0fjGJsmhsFf4kKzHSc01odzjSpm96/sK2gPnf4KZ57Ol9oxIlGZmLMe9Ysuic4xgaHEPBA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "F460B16D30303CD43EEBB4DBF2F8B7623EF4F98A507CFCBB79056FCD71D51646",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:RQMx7Cg/J4rTB3vXHnUBlWsC0eE3aJjpO648iWQzhAc="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "AC927CD09326A21804205F7A995CBFFBF9613FD252CB9D9C1369CDD01EBE24C1",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665618627334,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "5D341B4A69114227D4D61CA8EE1A7A4EFA82775B2630D9E8D57985E86CE03BB2",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAKnl9shozzkHm3Qr/T9cgV52yZFhfUyW1lN7JA58eminQvA3vaNp/uw68TXQ4edG8qsKRdOdD/TdJxIyRB2JN82WRlhLt7SvzPtj2z9MhwDR3RFV/AAkKaGWC3Axah7fORXksCOhHmAs8bBVIfJf+URstUl/KpKJm0rdz1IJdOOtdGtNG8xLAnaLywlGUdgYJ5BliQMJ9MqY6NpxPuHadEacGVJGHEjMfxjSX6XH0YkEP47a622XKaD56URZPaCpH96W8qFQi9bivp7+5Fx+ujzQg1uBZMBvs+KceDvNi6e77oRRPMiZvFyhGwFEG49JHLO4cbpgO0eP9N7csCR27F9hnfuCO6ya+Pw7+Z+KUJ45loSbuQDxd1UmZ3nyZxRkAmaJPfRKRuj6OqDz8G9OYeiZuQbCE5mgu+aJEIsCNFrwaY7aV9Ch/IU3ha6RbR0fOPS4Gz3haIHxQBJSlQWVE/IrDymwJGLl8v0XYEEwZiniXkNCcTCUhQ5peKxJqDu1R+mkpUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwfuRghpafLQa+vPqTj8gFyMXom327kaJ06seR7I+k2esF1iYRaABx9KMyHk3OyIW25sSWagpNFCSzm5cFVYxYBw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAJCVjosdnu8Oevl+Jb4EKrpwMk2OPh1tF/5Mv3qYEvVJltV1JmVkVA09me67kpWWSbC72DYSVK6c+uyYcoVGJ4bCywO9DbYPVgpSCP8FspRI1J4H4IrmhYQsmRPWs/uJWxQM4VH9IVdWhAMeAbfK3j07B0bqXeUJGR7NBXIwhJvfMFJwO+/tGQLuzaKfbAlTh5HW8jiLEaFt1m6sl/iEVk8rNOlZS/2hEwClLPu1coYMs1RJRPSxP05NyWgC3WV66HPZl+HOoshOXg2m9YG7nCGwUM3NRjqQ813alXWoXSEpGWF8uflICwV/vgNNK/qaS0ogBlsUuvqGI0ZmLAKGV94flHy/dPorZ3z56+1laiH/99PJ4TQ6Zk4Q+OqWXtf2DgQAAACmfWqd7Oo6kTQ/QqnoPjoyXJNCniXvkuuildUd2acJpyrCxJ8awXUXPQlwBZLVNyCkwHOyH/GNiBTmzhntB9dykIXp0qkVP8Y+vVndWHEHroBOiJJwzdlZtp53ZZi7oACq98ZLamCl7f54lV8dGhMsIe1QfYlSBjKH3YPxhlsIeEsfzyeMOasHFtczN1KViMC0EY3HUrOw2bkM2ZcaBFL4v1CRuTWKhJ/w1k6/RhmI47xvW55PYUlzXhNIyEsHJIAMmUyIRlcFhaGeock2LkUexc2oNS+G6b1yqytgkP7O3sSIbBW37XxiNiBBJOanvveEKl1D4JHOKGb72FQttoU76U490kyPzm8u+/oQ9dNtPhv+ueCfPLKG1cm3J/oAlcMPcS5hJ6lc+at95xyFHR2n+KSE2VTx65HCmXdcI5MUEEuftrU6zTOF0COEYerq9LN/d2J2Rx6/ChG5S2n4MBkbxGOFeigKX+pDnOsxjNce0IWZcXQEgiL4mnL5b8TNq1/rCIflkky9zS4esauaZjxAtdSNh0ZCNG1BTAXbEgmNZgLRceCrKbinxGKVIE6A9ucLFi0OxkOq/uzwmJ8ktZlEVDZAtSdsrUyzzQB6BwTlHREDYNh7fK0M5La4MsVskXOSDmysma0Q4xvHEbRi+1f1f4kLLgI7QhYnG01obIi2EuG8zK7R2W/kGmVIuLV+2opYrH5+OiWABpJEtmkHPXhv/brtD6dK9u8elndOnszqOdDV0aYiyq/iOnar8bz1snTTkORyIOTkKdf0rTY/YTSpyUzabCGny7gMzWkdLOsdCQTcW7dDMMwdt5qeHHnPAw/8PXxv+4XB3l5m7oCwSi3Oc1NvaYwoPBC1j6NxdO9njrQ2TQBWayM9vpketqB3UckVMFD/ZNbHU1G3ZDwMbhgTNchAnkseEfRGcf/ZjXhGVvu9XbBjT4D3TT+BTzDNlHxWVM1vEbInTllRiHdgZ076Z2ZHHddNokm9PzVY+lV+z7Gww8Ir5M1NU1NhACJrZLUvfcAg0QIZgaZJ9xNCB2k+3BbDO65hMZLBovjJsVQ7SPLO79XUZ9+TGddKcj1pwrRsmi5Yuo6RC+5QvFlV6nXMGviP0Rzjcdjc+5y1mqot/73r55ujvgWn9pJULDB/+Rs6ysYaOcmF/xI9lkTSUAoqTb2Z70QiLS9QUw5NYMJdmChAUu4+WgUNcCs8RT2Kkeigdnrw9M3FF8HJfEAu12F53DX58oyyLmRl8t7Pu8Q2HvZKSj6fPxTDTDnf2fQLV82/2SvYlGIyxVmZ8+/4k5e0PyS6Q0xizqmME9HMFqHpAfNZtwYLPzrnCrBrz6OC8pQH1DGMIl971yd41WD6s14KnqJyxOhKZr0nClHqyJkeHGpWyI2IRS9/+YnFi/RftimS8GuJlzCbja3S7SJMMYVMzGJusm21vzGCkDNwDi1Txuj5suElCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "5D341B4A69114227D4D61CA8EE1A7A4EFA82775B2630D9E8D57985E86CE03BB2",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:IrBNaCDTtlsTGL0LgkSIU3vNXe4CMb7ejKf/VjlnTGo="
-          },
-          "size": 8
-        },
-        "nullifierCommitment": {
-          "commitment": "AC927CD09326A21804205F7A995CBFFBF9613FD252CB9D9C1369CDD01EBE24C1",
-          "size": 2
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1665618627578,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "61A1CA04510FC2EF2C65CB338F714B22932466FBF5759989781461EBAF8254D0",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKDO2TAxc9oh69dI1U2AQR6UqOHIr/N1TSPCResgfbx+QbigVQe55kMbouSSQYcwDIA6McJd0LIJaPY6Yeud0V91DeF0GnIzQOnKGB33Zuhp1NouOtN6BFWQYCCSYnf3fQKlAavsgE3G6vfNWL7eJmWIq9KhvNX625kQmQL53NNOckRFeDy0Ilj7aAH9xwGnCqWcTbym52pTS/uLGIba5JFmQOpN+1Awguy8aGJGDuaIDKx+jMQyuKjWNq7cBZ9mJdv4iD9o5Nuu5JPjgB5j9C75s5ohzzbhkgvNlTfKZl6AbmRJMmc07Lsi1fkyr0AG3xhhSlR3X86ESnlfzQW1DBvJN1TWNlELWXTUaDy/n8pvt8u6aRZThglXtvqsEZ7bRP9Q4N2xDJ/SILMNhAuf8W9NBKbE6/Hr8K91T3qT3/HZzTXkObEhlk49ZMfUsVmZOlKohAhmKuoieRv8Mt2Efyw2UHR0X1mQkNWcCMd94rKnTFZMgEjFMAOWafFQBeSlHge5dkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNnFSQBOPhYmjtKUd/bzkbZ2rCdNH/ZQvsxvtH/0S3FJy3K3WB5IgvLMjRaxhaJ0HJzS3mk/N3X8jecVlsB7qCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "61A1CA04510FC2EF2C65CB338F714B22932466FBF5759989781461EBAF8254D0",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:2C1k8BhE/0VQJFwGTytD5f6Pt1UTY1PI/tMu5urip2k="
-          },
-          "size": 11
-        },
-        "nullifierCommitment": {
-          "commitment": "CE00F99B6A1ED8F576CFAD38A1D228182CFAF92F5CA67F51AE4105153329BAAE",
-          "size": 3
-        },
-        "target": "12061061787010396005823540495362954933337395011119300165635986189",
-        "randomness": "0",
-        "timestamp": 1665618629456,
-        "minersFee": "-2000000001",
-        "work": "0",
-        "hash": "24FEB21507A3E3BDDA0F326B0D2256A485CCF289E52B14CD1B25641F17041D86",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAALReaAJbZ0RhQEmYKH9XxXAp7/JukDG/IV0tDyzKp/U7XkTQ2Hj+kYHPLrrkOqyKFLTzsiElHCN8w2ldn6aHLonbGG0F5OF5ThCjRn3Nn1HL4pcxwHg9FzI6Cddj4qjKDQL9OaWWPSK9+HlLi3O3piw7tdt7IDaL66DFIfoV+tADRZNr9Y/xPl7maOAOxtRfQ69CVUh7vec5K7m4zcP/UsEncIBRvqQ5sGQczAzB6x+vpF+LUxL1osnAQt1ueu8xjxGNZ0aJoGDuGuRu2mbNz+wIzYc07TezAj6tsnIFaeoWmDftTqXTqPd9ZxKn3AlI2AMWOFQSQ+ONn9DNMHeQBzmDFZhO+ubqapeLiqkNuWYBzDVFxLJ2CsTlYlprxAH5PGa4z1QJ/8TMBB9bqTFuiEzngw8kagZjNQsVmpd64yLKoHrPnbK4QVGrg66cijxqwZwA0S8TLeH1a/PC7BqAjyjNRJd8+eHvw8YgK+nHfJ5AMGf9EIsTLuZGY4KLc7NlT+hgfkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLgbjrRxQdGpiaUXArS91r8It8MHIf+uNcC0LLgIpmCp4zG1fVsteBNIOuDe1wfcZ3wqHw69B/tjmgbQ2UhWfAg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKZdVOJ337LeG7KeykR8BkxJ4AF2UQXbcZFOHwMRy+uQl8c5Fqfsjjo/7RqamJPp3a9lmOwB+mgATZRQdR4veN/FfYW9O8bZC2uzvnzvX3mM4k4YqluFD5ERXLrJgvXOIhYQwhptyJuPsXaiEACJnplFs12LF9WbVvJamN6YnR/xw37IKE24JqA3IgSMn6OC9IJeWFFHjp4R3Fe/3DJ6NhhPLPVg5Mc7Uq152x2laO0Py4ZDTeAURWpBAKL0Yh8K4ZbB76bX7RKch1HFKtiYP239seYvcCXAjFg5kQaoCnrJj02xxGYvvrflhik1nqY9T9plnUkIDAnHDK8+LHpzG6oisE1oINO2WxMYvQuCRIhTe81d7gIxvt6Mp/9WOWdMaggAAAASlWIEAwNbR8nmHQXDelcz80qNXO4Jv/lGSST7GXRsmBJ0vLReNew/iaXJRwjnBMNrB/2NhUeC3DysFE4bc93iXWadsuSivLMEVGF6gpjpLdUIQGr5MNzl8bgtrjvJjg25ziCqQ5imJ334cvT89BVr4NYEPeXzZdUUiNZxmsbeUUmV+Ff+vOS+30kCCahSqzCIDwKGpC7Uv9XWAOSdMABkzOzaIgZolEF07LPdMOMxWkHfq9hQ5yYXN+9rJIVS0dEQ+MgQPZZ0x/JmvBWX509+hCTzLcLB+aSVurZI3diMcOdvNc8kAEEzywkSBouRNVeIdf15ZX6XiTdWgPZRnuhfF3XNxoViepETaT7sudwAYjPPe5TRlvb9qPNGbDIoE74FDSSBJDRpYNuLWaMSmqglJErGEgBLNI8OQs5C0jc67wmR2I8B71Lax2mlmV8uRrWcvAD6Vzdi2KMTFADR44EvQr9gXy13bvHpd19sn5TqXNukx2ooTtaukMZqENn5+uZoYBnw7z47dy90XWvHmM91e1ZBIEGlp4Xh0S+vm7zlcPkumgfN0yBtI/VmRH7Lv8Ztyx3tC9U5Z5UNa+qsoPVW3w7BW6/G8W161E1O2h9vM009ANBqszpi8xv+tBfWnRuD/FXL6L3tXyyUbtpypJTjtkxdTICZYLnKlfiHmv+A+XyndBzc0dqFVyOO11nOO8gBP72TCPx4V8igCW9qf1FlysMVB5nHBabnnz2uVDmQrFfZ87fDUzy3A9S7fkLiWb2MKURSyOTS1qxmONMZ+nMkO5Kjkz/qnynRS8MMDXSZL96WqK5eq9fmtpKkRU7rLjQiCxREwn++SbpHwJsl2ndXRHIlPy2SZHlOM6lZx9acrL/9yBLqlTi1gnF7exncbkG0SacYRaamCGBIe5nJCiyAe80eXRSZ2tsPR9dyWTX3WwzT/IIh4n4icQ3chGyC5GlOIwYhahYRuiZZtpIWRlyjVTuSPzflm0Xp3UwrETT21S+WMWQG2kNFg79/8h3Oid7Voq57gRribmVlPqFOx+X8o43VabORCcEn4MQBfNwavj7G+JhJA9hVZ46yE7ncDnLxCUu8hOvN11HJGloJjaEo6N9p+jq0/9QHw4fFWvWBvKsuKrKAdIdlZrUmZEpXEp0HD62yFj00DbR2iFEFezSZnkcHFx3lu8i97IDJVz4xZF8uOwA+UWrKmpZsHzMMvb1q3Af3ORGoNVVFyDJCn7vU5Ld0EH6qaGtbsV471bhj63a7RVo6ZMFfztsWC1ptV1kkc4OVUuIUWLOI3fTeuvR+hwOHvRcIY2oUqLus21UTXL5sBg8cWJ8s3q/xsoPPgzzj6jaSOgKb62mwxpJsu7ZTPlsI0Gmc775HrLpWAuz5c6PNCT6Je4PlyldL3kjisgLeEcXy+ItMPjtqquM4V/6MC54GjYZiTUubT2OZE+DrTQV8MgweAw=="
-        }
-      ]
-    }
-  ],
-  "FeeEstimator should add all transactions from a block that are in the mempool": [
-    {
-      "id": "e4266669-d74b-4b8b-ab8a-c62589cd44a0",
-      "name": "test",
-      "spendingKey": "46adf69c10482a2d3f3a073819a049453216e120d20ffcc71fef9ff23dfa7040",
-      "incomingViewKey": "41c11ecc8e5dd1b17b2c0c08e59a488aebc607e1cae42f165526860710cf3906",
-      "outgoingViewKey": "d366dffeee07011e8cd798ea4ed925724bad2cb5b2c459e0ac72cec118fb9ad1",
-      "publicAddress": "0b282fb70977df058c77cf504760c9d2ba39a0809ded8c0bb1f1c1d8979c94deb4fb24036066542d5751df"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:ppZrQ/sG44h7q3r1e51HtR4Av08dtYsa72C4IKj9/h4="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665616401042,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "998798ABA8D22937D382C9E0D9C7A61806C478D6D6786CADCF720BC979F22327",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI4jBPrB1EerCCKyD0A1+bLu9xjJlCAYIqLxH2TjJlCbjDpNFZsHVkMJuOZZS48XSJg1eiWvVNqJwzh86Ypc8o98QhyVWCy/3UfcXWmV2njW+7Shyubcl7V3IEIJsLkaTgQpoWujvuQ/YXq0pMe5tpccDs64zkcmVKNM9TSvS2Dpj3t5tIUTqMT+Wb26AU5nfqoUVtFudVyd5lDDURm/3lgH450l/c04hwiQq8Bw95ro0bGwsy2c3IP4TpwdWPCbhkafjXU04uLCbjLs9Q9UNL8S6lDzR7mpJBuR55o5CK8OXrkGR2Uy87V59OW1S4ZI6AtJlC5MA7wuArUZlXJP7hlhvUfrFAqE69gkT7186Bn5/9MkQ64iX6DhBrN92Qr0GDK/esuXCpUdLoY9f/JZc48814R7phEqGQy74giwGNMiQ8QQ/O0/OikYHcfj8sLQ5p0RB7GtPPzE29yA41C5xQKAs1o2TPPo76I/Y1VdHx6+um0TMBw5nK5sO9+M1xZaOPrCMUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrRsbMyWG1/sZO/zWXcj9QSU2ueaiT/qgUr7lDrErzeWh8PLtlyr5IRtiwLDCJF2xY3yUH03OcAJmgIBPqEqjAQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "998798ABA8D22937D382C9E0D9C7A61806C478D6D6786CADCF720BC979F22327",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:uyKiPKMu3wIFoTrIF689qXaBMLRUrzN+8uUu5ajK8Bc="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "683B7A4BDE3CEFB337D5C0B9EDE830B4A93FC7725B2EBCCD13D281F1F4315FDC",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665616402977,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "7E2C0AEA55B6109B05B2C725284E56606A7D8D9CF864E86A28250BA3BFB59A10",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAKwZhGHfPpD8fUUpfClrQvXU1utf9Q4upb4KOAfEA76tTAXR6i/c2zoVybu76PQIo4HeTiNj9A0REZ5HKOm4mNc7GeIwYG2tgRgaKS5xP7PMeTVfzmJj1FopMVrRyjLexxHCtVUbaRteTx8etUC1BfFZo1r/kbJ3j+BUxZZa5qYvwNnZ7HAiSQ2S98aOlUK1zJCR2XUqaFVid/rnvg5Qmr3hmf1iunrw9bMXS68pd5ePOCtdvllFBb+7/zhrY5a9psX4vRQy/Bb7+k9n2tqEZGouH7dVFSbXkpi+Stf4pNwneRRX5XPJk+QuYCthpSVeo4/Oc1YHvdDNGh3X4HZLKGZDSlUVctwD/KoPkpafWvFNnzfC7N2li5bxSO/sosWKmTceLncG7qA//eJfBlrk9eRjqsG1TbRmXuXP4+C/1gGXWAEPJ6IxFLrKTKNQT4kn9kolfy+w0Si0kgtkIU0dkmhwPcEkoBeHuqwRlcn+NqBmJGrijObmyesi+S9ooYikQJp0Y0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw6x+qrZmXlJj39K9NdH56qjc7h9QHYrQCwl6WIIa9BuuHNeyExa1bzdFTLUpkYR2pNUZSErPuRtWrdg3V7+2lAQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAALaAG34F1QYE2cD581Tcj/xR/jPlzMNnmQQSlA73TBzA1LWZs9Y4H/D4qZVeR5FhpbJ6x5XWlSj5LEQ9ux4hE+qD8aRa5PGnBowZCNKUccf3XxKVH1ASkDb/SdYwiYTxAhj0gQ9VB88LwWqwYsga7/PaMbCxz8hCuS3LvDnVaUJGRY/GuIOgSeC7RnQzRME5D7cqeO+uOMJdPdoD64Q/FxlJI2WpBTUP7asH1yFDoB0/e8aVk77/h3Qk5h/catA6b6Vv6ROdma5K6aTkl0kX1o6VShzmKFYUNxSwZrslZj4Z2jVSoD2ATMKOYFap7aF4H89w2OncGAHcBNdWniZYWymmlmtD+wbjiHurevV7nUe1HgC/Tx21ixrvYLggqP3+HgQAAABBHpq9Li/nZ9p4y5qD5IfPe8Jx/urI3BJq8jRn8/tQENV15DIv8G5DyhnTudGfqpqkHpMhGq1W0o6ibKnIdhBgsmUoMzgFEkDYF4z8o+jcEwhNniZAIqoQFpJ6b6W2pQu2IliL+5pIkTW6a58MfmH+2hNGe/ESzZaaC3gzDFZkSjDVjRORG63t2RVsTCY5XDqNj51LArKmcKV2/TBrOxta/IVwCq1YqTy96ID66VW/IGQr3zDycD56OPbyZWPjCZERh3kOL67O2juW5edrlcL2/nsz3luNt57Bpxg2QP9xi6uycO/FxobCs9VUkeSyMciVoiGW4avFfx51MWum+sX6eaJUz8TYih850NFmRpFWjp/thHMk+Z4ibrLsq17L59sIea1Ei7Wno8yWlfkXkQmqJtu5WMPybM6SZJxpFF21rVW3CG+rn7zryMpxAdOIUPDb5eWIiAnxZGJglS/TWWo9J2FHzLH1ispKiXZ8eAWKb8ZAvfbYw8CLFj2u3RBtuWNhZWayVXmfes1RrpkpSq5Tq8cnQcEsB8TG2kr81PcDazTO+aY9go3Q+GhNXiXWt416e9sVv06H04sEWyU2JTu3WPTxGHqrnbB7FcnWfwGDxGF0z62+M/kViHzNekkh79T5Hp5X0j9YpK1gRFOpLveXkFkw4Xgl18RQO71HVvz9Iao6Wj0ZIoEyBfQj+BURgVeaPCrCK+SxXhAB+snLdysdXy4z1qMgEnqDKLomJlI2+KyWu4/WjGQ7q10WfMsJMzwYrN6opI/AVLEX1HIa5mjVjHSzOXQ+ldLcrBUrIw/huTYWdrPCy5E5MaGB4Gome4xUNZh4lZfKOLdlUImVbagpeQiRkmiEYHil6vl1XulSj8yJJgCSDlWqIH6+MqvTgAQm8ujKzF9u4Qr9DSogigTX3lP8/1K8eCMCDP8LWejsmqi78rmpKV2l7Y+qqjdi6MPtNfDhmkqWG9F5BOLZl8OYS2lBu5wJfAWiXUrporwC3IxzhrZKwa9Syakf6kvZyVcf9w4ncyrUBFLFzNMKk9G+ngwsbZzwkuA9eSakOsk5c2kLKnD9dp1S6nYGrRSg41veTnB//A5Fn0mrSbcJ3/WTnrGzxWfKT9ld4HDYRal7mpsoyXONRp7keW+f/PYMTCYe5C5Fr/x82KOvmFFLqvNWEXd18k3G6IlKvedXuxRRDguumOie+jPMxaAprxbrBZDXtV3hij/BLp4QkYIYcSrBAQTyYCySvYJJNjiHBd2ypQ/wesIpmM3DPJX8vYBQlkRJzQ3mMifehyR0TMb7rCGPEFVq6bpvJ5eefkYi0X20Yqn+yI/NZglmzxgMBuE6i04WCbsUtFIKQdCvfbOOy5wer0TIeHmjU51YkbBcfXWqv75GFJ/ysavqhWA2qmRVaK37AwhJa+Q6A8ZHaftsKMEV9Zg4p/4m8jX4/xENZQlnsEF286iUDQ=="
-        }
-      ]
-    }
-  ],
-  "FeeEstimator onConnectBlock should add all transactions from a block that are in the mempool": [
-    {
-      "id": "e0f9d95d-c267-44eb-90fe-82c83b977a5a",
-      "name": "test",
-      "spendingKey": "a658567fc022c43da6786df40737bf4d3d1a16e9a63ba0857e0073413a94e8e3",
-      "incomingViewKey": "d31356cd2a65a9237b44f39ba6c489a3215fdada2509bea102af7f4c9682aa00",
-      "outgoingViewKey": "cdff0272edbac9666728e06a7e2951ceff0b8f77c02d75e0f329dcf400ac47d5",
-      "publicAddress": "81c7e3c5cd24e3ec664fd9d509daa254f8de17ec3a109fe10b1f2ca5af4d49714ebe2160a64784efc4456f"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:czol2puJofZv5ZdQJ7Ta2azO0nEhG4jlVjLd6rQsV1s="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665619086794,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "DEB94DF75DA7060C34EB0CCA510FB367C4441FB607990AA44D4A9AA94D4CCD76",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK+BkTTpRgQlSo//hfxbAhr4AEDf4P5P3rU/Fpw5XI6KFa99RXkqFzn1Puawkr5rmIAj3ICOPkpCNzdrmQ+Now7gjzTrsOzXP/Lm6YJNvZh9iy8PKuP66KIHgpPOFpRC5A16B8SHvy7MbLDqLqghtYwKz/DEBvHX9IglxX//4dPA9V++V8cX1tZnXcYjeL+Tuqfbu8qRSKP7p2aeSU8sU//gHheb0xWVBGizpBq1U0vI8O/ZNEtcRX2Id/2lWBWTT6yQK0yWT+r7LgVV4RV3m3m5WBK5Gj1val6MT4Nt6c1Sm3QmCaU+Duv6fCyuNOb0FM/K0iV95Gaw2qoXhie2MGYqv+fNkN2t72AdXNGg2r+JSBJJ20FkM6eE3NSkXJIELXUzom8hNTKa6KPJCTz700OPKmha73WzQNKthI5LNckHpITHPcI27txfDXPIqVd1uZtaXcK8ZPnC09HMz46Vp7ETBKmA1FUt8WT4njb24Nrkt84X3AcE0hC1IF/s22jCVljCR0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqk9/CS1xwS8tzCSsdHq0bUZExAkjh5DWU+/Zx6KYfw6uGBKi2RwOzr2crJcjI0IE5me9A8qOh3VcyOFFR0ayCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "DEB94DF75DA7060C34EB0CCA510FB367C4441FB607990AA44D4A9AA94D4CCD76",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:/Up7Nk7mWSMSmNbBI4C4nhMoc4xfA9QqNKUb2J91uGo="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "C7E7F13A9113D8EC99DB7E8634202A997F5921C29757479B1087339EF521F260",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665619088750,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "171D2D493D765B69E43CCA7E67BE5E65EC0E78198D20F019F7E9548F5BA418C2",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAI70c4INERhGmSSnVYB8vveqstEU/v/7hqg/QHIq1Xy3lD9ToDZYg6ofcMzgcAfaBZGhFIcnRnAcGb7Gpnrh8lfaHeM0aCTKVPiqln1lCNnn3GvAg1VhbFyu9HacyTochwKYsh+3HLJJIP9+MgjK2A9egHv79vzn99s4xVN2xn7JqaQjjzuoI/wxSyelrA1RJ7a8cDU09dtXRzo4HBuDA6FS/+ebJ/Z39dS0V6T4vqklRkYASCibo1dy32h2fTlqBFvCyY4lvvDVvdEXVqFLFQj++P+LZ0Tz2vuxlmMH2HKZJjofByHtvw5T3XR14+Zyx0MnYRg9oXdVUa37h1nTcFHlU1oAiqSRfSRPNIc147VSPy0PteFndFvn7nImCetZYm0GHt2JbXxNeHHPqBQY1HwDTVPOab5ST0AKjbAp1AhsQ35Cu3ftPJ35jT2Rp7oQGsVnMdDTRtmON/IMcUBq/Pyh0DmaVag6BtLiVwkaysmzBRg3AZlVoZcfS7iWLbASmgiCMEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQKWWFFcYH2fSa7VYNnGs40twUWtkTbZuVY/C8gPYQJCAS8QydukcPuGx7aIq1dElu2/TDSatOrpvB2BCwVAKCw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAALY9y+3lD8pzaLABOKTEi8DN23xryJOeVfZ9uT8CqfBLixzLZcblMGrxAEqI5uKXM4hNKjHU+SW/Jt6ZwBORBLkHTFQnk/dOnE3Onym16b2B+Wh5+DmYy4zdI3+mhmeUDxIvfpU84GJXmYLsxpDY6v4X6myLm5Rj//qWohBMwvwdvFW8Hgf/3Lmkp5bBrY98rasfd+TaqFTbvqRDd6szbc4qeUmY2vBU8Ku53YXaF3oa93B8uEbcYxgdTcMd70RwGYkzcNsihh0MaYHWkaKA/XBUq3YUeJY5yRtfMhfNdphsyEpPiSaqtQOF9k+8LpHfZiCgIrW31n2T9t2JlxcA5jFzOiXam4mh9m/ll1AntNrZrM7ScSEbiOVWMt3qtCxXWwQAAADsU7EhvtJQhyg1xZUya8TQUi/uTu/HZjobkefQtHvBha9u0R0e7HSQs3DSvBDsEB74uQpLweZ8Krkj9GXv7FzJaICWiotWMN0vHew8baPoTxeEcheh+Zlll4dkDBb6ZQuXdzthabJa+Gy9ZZZB2kdPCnQ1QtS+rH0JJqb/r/YPtjLWCdXR6NB8wA8kICktnWKAr3pj2khQPa8jcA7mXhujU8rXaPMPFWzhutybepumVH833dl8IoZLm1/xDXdjWAUCP4ZsWP1n0jcJJlD6ccinjhGGkyeD3kUYa1tI9ndJHZ9S1954c/m6AMoQf2YXyISnjRIEW8UcsgH+o6C4KbsZQIm86+b4MgXMBoiwrQHg5WDpjBW9zqpxeCTEf4DyxP1NjrLAK/fYmiJscX6gbfewq7uIH1u1zYjarhPhAberAaQkvqZaZ2ie/7EYlh6bOckfPiF6l+wU22RUmiGrX8I0UsEg6gYtijuDPzIxaxwnY3HNCTRTbjR4xAbX+td2vMz/Yj6ByIoOigkwdRf8ibIOEPMNao9ZwuLeBKgH+iamRw9kJY+WUeJ08VUy6/o2gbXFWYxY/XXrTgSe3+T27mSJGP00Hbov1VTKn9Vi+TyuzYqNdYtmSNwPZE/+v7ONpB64WBbToPJIru6N5rUL8bZ8PC02GG5vk+uBRtQwcidc+P2ianRtUeGKdQbqVlSC5LSOLAXbg0/L99SSTSMCyawB21sEKYDq91K2FDDHkyiKLolbepM60fmHKGnvPI6vmuEtl9r0ZfYAKsSUkrr1cKsONnyWBzUr5NZb4JtFPsdS5ASiOoc6vJLpxPWG2ZzNt4FB4LKlPFrE9xVl30bJvST7a1qkJHRaGjt71IIVucxKWf+NEBHZSFNsSC3YybntI4r+E/FdQixXBRArdfPcG/N+c8y9+Y5yRrvugU//+wInBAhTV634V8dH16iLu1Hr3dYvawszDFM1YgDu47aM/oPjiGeZTBFZVQw3PT+lJ8s6D9jo5qpr/eJTE8CVbH2bE6Hfo4Z75oN1yJ2IJzkbESf8efE0GFn/zsV1QomML55m/TErd1ispEA2h2bj3SzYV5zs+SgiqHSTJg+RcJsLwWnDNujCrZoeGLFkuQCQv43vEay3YUWwWgWXW0NJH0Bb0tons1QoLwP+DAJkpwAPrQKPJbcd2fuvvYIEF52kXVAh0syKMBNfr1vCgvFZhz3WIDc/B87nXAhyUbtFzMLdJJPWA2pnpxmoqMKm9jy3Da0YyzUJGzu66X4NMGh5QneZlgTyx0y+uGX9h2WgUibFPh7pbTEMi5zdrS30KekyQsv6Lyg9b5Flfywrb9ua0xBfF5lXzsLDFPpNGqjJ+m4WUudevyQQRvHK4ggwC05YHVOowviPbex0R7KUKWAmXX3DEpBaElUJj8DP2eKkfgUe5+MWoVy8EHMjyYfRTLYQ959WbS8bWDXGAA=="
-        }
-      ]
-    }
-  ],
-  "FeeEstimator onConnectBlock should exclude  transactions from a block that are not in the mempool": [
-    {
-      "id": "9d269993-5990-4652-8346-b3a06dd250cc",
-      "name": "test",
-      "spendingKey": "fc3ccf8ae0350b8325960059a7c45d3bc750ddaa135707d83aee5e4a270e2d9d",
-      "incomingViewKey": "caf24766747ca2b214e5b181cb686cdd11f00c465d052216c2483ac8ae927403",
-      "outgoingViewKey": "c47c373a21ea49ff3b9605a91c8e4436236bd56eb68ee99e0fdf94afd60b491e",
-      "publicAddress": "9e6078c7c546c8dff31ec5eba2532764a651e43fa2de2cb0a911deb7893bd8215086922151bd78b5eb8065"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:Nx3vfRx+4aGjcs3rmQ+a9k8GUHhdYE/4+630WVFtVGU="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665616625756,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "1B46D80B31509E58C794F69669425316B391B1B7A1645F09E093C5A46F40847C",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALF11dYRQutUAdvjXj8634U3VRwqGjO6lWAroKhGoeMmnrrh8LA7fYmdmDNI+rdyHISgadc9czFon34KfEg54CZdH2bstw8rrYA5GznjtBhCJ1yRHfkkAwcCTcNYreJjSwIFT5I7H6m5N3+SyC0i6007M8wj70dcGKofPZsopiOCdAEwmT8i9uTxzFbD+zTn2qs83FqKKknd/gEq3sKFfMrQFJIhNgd4Psd4pTJIOu2RuqtS83p76ulxglTvI2q+5sMa7zhcDw8F+8BwinAgzYZB3VXRMLyda0pYCmtUlifBTBtM3+OBSpjbXxqNsijMJXegdPth92VRoGrWbAqxHQ//Gp1RKkpNEa4PfklRJhSXNm7HYIr/UE6VSuykg22qvLm+VWRJEQnH8vTaOZ+plWPO68H2Z3Ozk+jRzFDqnC13mXjZ8PAH37pr7CLNwRwdhCsjJZALxzYDkawC1afPJRIlM7ypsaUOhIVUPQnq0vKtzgsI5ZoG1g/a6BDtoMqEcdDs6UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwVHSBIpSxP/WTpPoxJvJuohY55IYg3c/Do9Vx6tpQyjzFqGOjCRhCwuatq0qMuqjGyi+h6s2VNM4Rfdropjo/DA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "1B46D80B31509E58C794F69669425316B391B1B7A1645F09E093C5A46F40847C",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:RE7QbLevcngA9VJzXUH5wYNvIzFRk/YSp0u6xUEf32k="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "91B49F29E96046086630B9CF4D2AC512AB613881C05D9FBE44D4E74CF09EABA7",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665616627641,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "0D61D8CB2C65117F187D7BB86903E9DE28B139560D997EDA6D77E681BFE55CCB",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAIV5dvmE8k+F3uCN7+d87Hcd+u9Bmq97R1gPwoI2cfXVEhs6kSIJbDm/O9lQs8NOx5MTqYsDRZwZf2aDGihqisVKqTNorUCbxz1jqJTROduimA8E1HkJCMM6KgZ6f9bELQE2l9+hAJu94T2l2OZwBbWK8vwfVZ97WP/BSYqGCuh4tQxVFKz4MMEQziZKe5wt95Uh2VpvvQUtup4bH/39IIoyU2uY1Bva5IwE9XXdfeFKHVK3PZv9uiTqKWsoBEW4GhG8t18tNFYwDWZb/QV5yPvYtez++4+G0sIack4ZMh5gHiiMQsPwM/baCtG3qNAO+JafQ8m2yUqU7tEp0ydi0RpFzHpGQyalCaCxd76M4zcq3aVuuHq9FBzibiFsWTpElND4tHiW5qU3ZKV4XToMbywq/taQQLX4HkH4PersJL+OSWmqLl/maaqk8Ps8/DtSf3mP+1ezgYQ2GTXrO4We/LCxGaG4HoZgUKQN5LWjvvAaypNfw8PDZEtc66sUf2qrP5btEEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyvs+zgklY5F73iJB/mVHt3N2OSyCAsRH5CkuQSvmrl3eWmDXBBGIgtzGNbuTWFI0/VOz0JzL9lZZ9Y7phHGLAw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAKk1ZmiCeUv+abujy6JfJvFPC8GwzZBkYP2aSBfHSPvzQKBQ6QiM9xYD/4liU5RagYHH4PAm5ZE8VREvP2h1kBflr6fUb0Qepme70HhO95PM/nYJ51iHEXJoNQTW2V/RLQZ5VeD6a2sYJ3cG9OWduOEee77LuHSwB72ksjFfzvvLvmKzH6Tv/uWV/DeyeA6r6YDfQuM7Q0huVzruXjllLc3wsgXAB7IHkqWU6NmpcIOK6eLhrJJfAFu1Betor3yE5Syy5v8N/vxx1JNprPp692MYDq6Amprpq9otv6vbD6G/YDJSkrDpbJqZcn/i8MQ/MkDDhaRLf/TrBWOQjEolDxE3He99HH7hoaNyzeuZD5r2TwZQeF1gT/j7rfRZUW1UZQQAAAA0tDQY7atMpWw0Ja/YGs3xNnNKPJa9RqOIixJONDVkBvHbuH0a2Lcb9UBfTs6YarkZZmbKrSrXLvrcRkWEIDov+RaOTEMCJ0xsVgQMR7g3FpL1iSwISHOkQBumWw3K+ACvElTN8fHSBuwKDMH8/2zUARlPLdUZP2gvrFwT5n7ZZaCFwwedG7J41i+pdb9xiv+vRVU5yGqeA9EWvnlJ6nJa0a0OOMYH5e14Qr0QuY9LI+8LDh17VFlM/NqXBzlAipMSRNpb2yxWakpa8tR5i2q9jJ8jdphKESWzbkyX/TxyRSTMICnaXwP34q5LpdYGvBe2ZXkzxHd/jEQvP+KfTGPEjx9LXginHGVjKFTCbnIFOFBKXB+CestO3F4Jd0on+MylCq9sBO9NN357oRMdWyHNi2ZS9X59pz07U6/zxIkrrvW5dEPVJO0GYpqvokJNgVQPzy7osWeaoJEaIMJ+quJaIJznCC3FX7b4IHEWOesj0u+UHdepc2yCiBDlxHwpqnMzACEoL2noKDqrc9lgSU+J3fswGrrfvd4mbo0I63uBCWHfKm5CqFscMCkXxgYT6BpmRy5uOmE+Yfpc1lKGES46cK9SxBSL1j8yV3d9wyRFZwHRgv8DyCBC2TuTwN6VR1geTbw1tt1rLusRmBpAc4QR/I5yLg264L1Vgqo+54Dk2xxfmgVz9wqpcjIWzF5jo2YwH8m8JMJ7ZRSJeaWEOXhrWkBBMx0qLgmNM1FI97fXmWEvGYHR0oXuaodN9UhpCEJVoJXnQWxlrJ/JKPtnnfX+Bcy8HU4OwvWPS2Zi5ZO+oCnLNYS7XcGaV9/GqpGkoxs0UAnfNpLmFA3A9S20zYKZ2veeaRaexsWv+N0gcN27WKTDnwCvEXn9F2iG2Ce1zEaqHPj8KqdwGR8j6Xx/kiCfj6zGrQzqJs6H7KcPlrXAkQlRzrAWMsmORqHJE+XqLD896dywg761wmkWmROpCvtcsEvsgLtf51dJUJMC8OonTXaBUhZLkBwlPNlCOuJj4oF4RL2OW7SBLi6wVwRpxNl+Ww4rDB1AC0i/xpJ80KpNoSYuTFWUHYgK3ybC7QDfbknohzsafgyMl1O0ioq8bsaVW15kxFyIYO5yxOKg+94Deyu3DtFJTYjEu/y6A7gLnzF2yZGG31goqMDDpkhkEhV2YP4wY75UTH7nlcLrFz4RRpRX9IG7Y32TSN1toUXfsRZYcWFqhK4kc86fH5CxsAh/nsSZjUbjQScnhuITNLb6mxjxqiR8JRmYRfujrhuF9PZ2fE9DF0/Hw9S+eFM6loXEg4zCh3c0FdFbRDNsNIMPFDlsy+ktcXkM4IrZRTfyxp9ysBOUqKI+bfHZGbbnXHvvVENn+2RhzrI8JGQqXP0bSF3e44xS7GxuCnhcEYFrrdamcNFATql3K6wu+7PNFkabf4dq1ip1rMAikhsxcBf8e/skNlteAg=="
-        }
-      ]
-    }
-  ],
-  "FeeEstimator onConnectBlock should exclude transactions from a block that are not in the mempool": [
-    {
-      "id": "fbfd53ad-8bb4-4eb2-a227-cd0e57644246",
-      "name": "test",
-      "spendingKey": "423f2f1e5180181e438b3fc0dea74d3118e5d12499ffe1d9840033be7b9ede67",
-      "incomingViewKey": "00a920bff5be20d685ed0fa8ef104c8b6599c8abda362368c8af1428d371a100",
-      "outgoingViewKey": "ab37ec8c87a244b188afbb62a66f5c5237cd3e11f796958a62066dc97ed4fcbb",
-      "publicAddress": "46176c124c6b92f2b969de64a8aa782ef4a902a41f0b5ef3aa4125468db9775f74e4dd15a26e5658092ddb"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:D/Wr8zDNJsmR7Y2WTSqWonLqUZYk2LcaNW9i2USKNgM="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665619089054,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "6637CFBE69B93511E4F5170D07B07B7C254DC00DC7013EC6D221525C688F35AB",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKWwkxNmuGKLeaeDU126mcTUv5VQbmvRPEW5H7eCwO9QBVASU0rsMeMc5/xEnPazMafUU6fPASvtOBP/kJ1fKT0cZ9dFhRlROqKhz39eGUwSKzovXno8GsMqLcaL5l2c/RQ8s+HerymLL8bdhXIQyVAU8ldcfA7IYkmFR3S47tpBE3X8pyn3XfujdW1b8sw+FoyttUaqDOGym1Hsb8Gmjn/Dq9qPBFUUSY+UhP0iH8cYYixUsgIjO0kOOXFT47sY77IsRRk4pkoasWND0l2zuzEXjX66kcTuot7LZENuF8MWOL5p6maph/yjVip2w0uV6wPhy9rh070brk16ywFZoReP7Od1isiclqf4If2wOooQUqwwC0HslDtC/aY+YeCqRPCujy5AoDrP9H3KW5AJ+u0LXNlyR6mWGaj6zv9YHJHwuqapr3f38FteXMLbAqirdASmJRa5BbtRA9Uq+cK7SvVjUNy/XxGz01E02q8EJMuTGRf7tx5ORIkDbxaaQVSo7lK++UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAP2HcuOaAcNSDRCUyZMf0GMARY1TtvG2xP4WSyYvpdjGM+FVjp1bdm/eibV+BECr7WjP5p6To7dDctltQ3DiAQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "6637CFBE69B93511E4F5170D07B07B7C254DC00DC7013EC6D221525C688F35AB",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:TdEVBfWwMrdY9Jx9o0CC+U7BSqJXfA2J8RqlCN9/Wg4="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "610B91523A551A19196CEA60684BC72AFFA3872EF11D48727337641B5AD156FE",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665619090935,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "9675902EA850D8D0619D25601416CF2DD9653F5897537FC65AA72648B7C11CC2",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAKf2++jRe2WnTiSmBWJEp60kT8cLtbW4fwmqZ9eo8Z38RAmJNGRaOufsqNax1pvy+o4SrHSZ5FVUZnf8ga8JMq5FQTtEnyo0JsqR3FtNQ/4GGKXL+varoPlmL2wxS5UhQwp6k6huc9HEwWaQcemgZPlH9Hrva9lTppjSyUHorHH+fM1uOy9myiL2ST4cPsa8voKiOPX5BZsMrF72+miaHJnjbFCeQLNttybcP9Q4xj8WtHEqMhzvWpMwi9aEfkmUbozP+upAXSCDmjatuT/VLr3mRzsNXg2fA9NH1DLvVkUQVeNKB9HVkccsnDpK4DzhzLDG5WYoz4Fe8+kqRyin5Uffeqtaymaraz409nUOfwDWlOM5LJwSBtwzCbS2qOKL78XPnxJgCKMK19x/P11KUkmEWWym56KDvsKuZ2naB2DyOSPuxMP+DrHPfO3cyCUv+GpdhZa2AA0zPWHGXXbSLDW59jR/L+Pw20wRpvsWBYW8Ifqc/LXVXVSrMEUOXlzT/T8YYUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8Rz4xCFKYkZ0wpKlKnhMWNEHGp75VZgsMYMMFzfV1Fgk2LmOKNHXeziXkv7g8plQTm4R+F4LmhDJyLbqBvOoCw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAJlZuHXJ9FLY0d1kvEMZMpAYro5tRBVvCUpixt2QBUV3X5reoMSbv8HObzpmYKNxi6ShJRtwEwf1pKGyXt2Hn/DwXFMCzJU85mRknawOyCW7pKcWT+10xeZGYuB6HlR1jhH5qqsGCBgB9uVFDQCDGZDPMP0yD2CreCGiT3LMuMEEdFja5eCaTnruu4MSIDAQz6edUppZYcybBlnh38K7ee8zhQb5oRnu12nRQyQ40Y1bbNNdiEBGkDUgaXqV6mquVAeITjCJihnufBZ0u0y4unxqA939AO7utC+jH8Fc7m3maeSkovsL+EYqxHYdx67qLhlP3GOhvMvqfr/k/6hX1SwP9avzMM0myZHtjZZNKpaicupRliTYtxo1b2LZRIo2AwQAAAAkvAiw1gGZGM5m/Y8axVF0jmutbbm5JCTggS7v40dPBYEUo8lBxYcWVYXwX/64tucKQJEjF5L2b3NF+W3Yyyu2tpforOPhEGXP/x/uBhUS1ZeHSxFFYwJblShfB/bu+gGmCH6RCjalQk/VNQx3TH/SsG73KDwAuZsw4IGwauwRWN7ErqnuTzaFHJ6WqqFJMPO0+wNq+lZ7N7kQmd3kt2mepqbWPByEOD5Ksri0YSMsXvrDKbXQsAGUZYMqZaMeOAcDeA5iynPSafdDiAqR6LETbs+70GkixGOJXlcRqXJCDHi9R554d+6NDBHWxWvZVzyg9ZeGriagCBHvfdcb5uCFn9p9Zi0DcwdcU0ypdjNAaBahFDWgQ85I8WpYAWsaVxenMmORoipCbC3itUUCCPD4Bw9yTMIJDGUNj3MJAcppBXoTIWCSm7SAqZ/8r5P27DJel9FQ9RwCSBqbLWUDOcwedbu86N29wLEVS+FEjR275mrO/QbjYx2/iH3FY7T+KXCWT9HjC+6Edj9LWNgM1OKE3eREzFINY7KZ69+UhOck7/+jiq5muCv6P4+2iVnixLh126NNQN7SsRI5A+8eVuI/HYDmOY1+6qE+RfwhdtFTBnEKnKBD0ayH8OYKs7zLSrXkND1gxTQDLhPPumwSqDa16kL6BDZwMWS+I5xEkP73Nxu48lmkpLlJxo/UsEgvHVCqzC+qPeb9x50jCNGkbEfMte5JBcILatKOiWcd6tHjCrQGsaQJYx7ketb8cilPZOcPnXIigPyr9QShhzDHz/nrJGESZzOhUFM5g+IvjBzu5DJLcKU/zP5NePD9ydaFx+HUcpxuGUohYtGR0VwDSD1sm+VEBOoFIGzvh1GbycdoG5hiXBcgmTWbyBkxOya1j1d59OjQ+Vw/gEsOrZ1QdrPFPOSHvbnHjVuVkdRljXDexPqPCaEbNsudaDKizaDQvBYLS4pZkq1VBrkEKSPiSo8vcpwWQqbuwIzi0BXzIE10bQvfCdBTJR4ETkinmm49VK1ZTjtxdFgRmANhbjeLLldSoRzbWRTQfN1SO3JLTYRLmeo9r1xmDSaDmuqY2Rhe+KV6EUs591amY9govwXCLiXBnoe7jTPowmRnPxZsSHnsTDwaVlNfQ8QNdZQlC4ZDc7JWKCaTFFhrwPh5IbV5d6TRVVbKPuiRtW9u6Ffc2h3CpCCzxJVYrM7q56UoWWiGf5GjAtuLUVMyUZ8Al7p5XcnZS7pIBWjpAzsaUYyK+SRAVo3kSTScs8zKGGPMSbM1gLSqsbyEQdsgROx+4HP1ocAVlNISrBRWNWsenSWt6YjMJW7zGYtH3nP00ZVOQHhz65DMNfS2+HDY+RYK1CwKlDafE7n8Q9pruQ5h1B+Z6zXWPf6Py27UDPktRn0n4r24oPaskiXKb0aty2BSJixgAYuVZjkB6mKCYWEC2FEhCpSaPexeDtcaCA=="
-        }
-      ]
-    }
-  ],
-  "FeeEstimator onConnectBlock should remove old transactions from the cache when its maximum size is reached": [
-    {
-      "id": "f07426d9-acba-48f0-9dd3-78ec8d8543ea",
-      "name": "test",
-      "spendingKey": "ebd6e6437e160696f0d1e374aa99ff5c75571e336617340536f3ec74b9233e74",
-      "incomingViewKey": "615dd837660492d7d1e55a8d0981b1996b5af210ccf4cb13b2d2d0821bc46b04",
-      "outgoingViewKey": "d5716293b879963fbd90769892f605ac16265c6dd711121b77cba021a56e1c85",
-      "publicAddress": "3a3ae5f25450792d1acc1ef56d8850a2c51f28165924b94dd12803c6a3db4ddd3d731a741caac7f28f0647"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:2l1SJEaziwaJ9dr1m9rglqehn85Sj2Hr+zuTSLYF3hM="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665619091230,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "B3DD40838D008CEC77FC1F7C61228C5E7CD79AD987B8EDF6C2F4D4E381FB7D4D",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIN6U3NH23hz7NznJZkDBcmjfIHToi1+/sg+uQEs93WCbPM7yMV7lUzTD10j/p8uObhdCO4wFjIpfCRpwthT2SEjhrBUXFKZOIIW16j14POYG5sh67ZCTbwwMNOtjLyhMxSyvVvUf+DT28fYdlT1yZKBrQbMdwsMu50oQm7C6lVrHvF6RBkSri0Yi6vLHXr1irIrdU/71NwRHsnCfCv2zOMvkDU1JJbwkvnIs0tQsnnS78XD/sf+IvqNckkqa9L0ImxvVpeAine6QMBw3N7Kmx7t575nWjqgkQAuIBpD0N2i6RSZynP4Jyv453yNYpfFUiWVXQGSP371PD/ckzbfunFUVsr1pan9cTjIh/PfCkWGCcVZcZHs9UVR6crYfB2cZwW9gOkJy42tne1CHLnulGiP0ier2zmRHBRarLzp20kzaRcjxOsmYyk+yfCgJIQtm4K4r64hG9z5yKdZs83LNmpOWDRP3BKoBC5qLacUGsRWeVsy6NTtGTQqgefOQmPbQZSGwEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwj6TsU9L73whadVCH2P0utMl6CUhusdfsc46S4is79zH9328UrenThpQzTTjYge/h3a/I36RPmPHwOUOU1zl1Ag=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "B3DD40838D008CEC77FC1F7C61228C5E7CD79AD987B8EDF6C2F4D4E381FB7D4D",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:z2hOvg1iYh79Y5Sau11MVuS5ITueftnW1owm692L8Tg="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "D83AD9EA86248D9F877D900CA2C3D73812830D72918208C45DEECE4602CB1226",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665619093153,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "20F21EDFB6A23FA92D11791F2C8E8A7D1CA2945B0D685935C91B3481B71C6A3A",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAKqKXBMyu6xz64SHClb43FPEst/NupmIvHV5YcZwVph5CouE/+q3rNnZOjGlu/LQcoOVrC7gtJQERJI37fqyN2vqAuVnjMuadMHwul26IlTxqF9m6Q7omUhtfBIyFs45FhNaWGsAUmwuJoUcli/+Wc6RnRtXRXWBrTKg7JQawjdgvEaE/Gh5q/4vUGpVJGMRYqqGPpsFIFCuDZLtfL1xdHd6wPbFARKP5Rlc890XzePZR/MlGJz22MuYlp88Xn43M7O2ECmIsDygSHqQWzBXOc0Sr9DqJcwY2N7pewRs1f/xONw1Op7LqmsOKgK+bpKaViJhItbi9QAWRN5MhstvdCkos1sM9DLt1nW+MHm/tE4JxDE+/HtZW9+5JJU/X7gjqcMwyolIAnLVUcvYOrKPHT6RRvOmM1j8U6isAcHUZP+o4hNBwOrttsnsHdlJW0n55mAq0m3GjByjVH0w7BeE1v/ZpSd8qeEsvqfaQNzqdbjcsNoD9M+sgOBZmIPG+5CRsRlRCUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYBLIIKi2NjRv5S/I+NeLajGuBCKwU7KOm8GqqExPgc0LSf804B5w1x8obUDHBqumIz0EuC6enHWDZ+CUkqjnAQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAKc5P6tac02SNt05ShD6+6qX6AbMtA1IkspKRxrJ1ZmE/jxR6ETJ2B5GLWvSN7DFG6GzlWaWuGi/BQgdMq4l9Dqowg2Df6tq3dR8D1HAbu6pl9keeDPEAgFTQXLTogBg3QfbOLbzrW12mA/NwiiSGTh30kKBFiZp4rl7UNGnAi0n8zpNb4BV+89wR+vbNfCuFavKI/QDTzOSSUVJu1qLmVz8JlTHgj2MiO1Wmea8iVogcgAVmMWZNN+Y82tq2TixrxmTuQS5Tkx/8hKkwbaYxA/9+16WyC+PxfVAKppDSnAWWDO+nyLL636PbDl5nRK7SGeP+7BZFmzn5a3YLCxNeELaXVIkRrOLBon12vWb2uCWp6GfzlKPYev7O5NItgXeEwQAAACkHvxdRAaEsR4J+Ft3LCoHzSgpM1dFjFrO6aADlmaTalNlO04VlHz11bhIPcp49i6R0elBuYLHX0i0hu603LjgTnAK2iQxeYPVXrm1SXZhfMaIK0j9N3AE/h23REiXewWPUsh3T9Q2AWxrO0BxCJ/BwludBdag98iajPKoD0WtBDqsRbMopkMm2IiikGi2Zm+IO2SFh61hXB5x7FILJrAjzaqfO/uBJn9vqm7vUdEdskSTNTXD/oFMudtUff/8e74UBPgQ2Xxq2i428q654T3nNTMW3KQj9RtPntL1QFx2/yhIOhdD6X7gfOFll/uwH2iRNx3rhM5WVt8u6DmJy8tVHcOd0/75v5rQko7MJV2XKMIVIOJBVXmpfJl/YoHZge0J0kwyyG88bHr0aj4/gh1u5TtEFBn+1OIyybD0uX2XCz+1v2cuCILXW0XqaknFrAH1uppAf1KqatGZgEWk1EpWo9tnjKTs22bbD+i7rbqvS3RcgXaPxrjFnmq0gJe0XYbkFjvui0OzZ1COKzlRB/lrFyL6cz0FNSbyUSJ/ltUcOvWR9pH/HdUzRH99YqQkOJHSPbCMa7yYXMrGdcp2S0K4e3RV8QDtKQScISHpuBAcQK2nbhBGjPeG4oRoC27jGGA5kVcSLZ+Y/dSlEAK12mKh6/UKdSABp72xthkkup8B6GxQb9p2AabgQkrUdpf9ci3dfhqfRcZ9rqxPbgLgDtpPvm9U4HGAUHkRd7S+0TlThyINNa08Fx2u+nmYPTDE8gh3MyfMgV3RGt3XI0VjGldJ5GZnQnKytTFi/sv+qHObp/hy2K2MD4zhQYfAHrLQD31UmaQDNAexkoyDFgHQrX46hshJagW+ycLFl9A/6PShU0Zqaghs9Xdo6Z+SPojCkoV2+FnoZDGWx2FQW2gXSsU+oIPfTwr7d5ZqDKKmR6gP7ZtaSra5RQ6SppyNFTe52YniQTSAVwxRfxZMbiAv/PpZiLY/I+FT+f2onvlcctRr90LAweKqXPqOD65VvGl2MnE1lTcpfBQOqhSRhjzMOiKvvQ7WuWJzm6IdqTbFeD4jFzJ3H5NOH4g2sOFG91Ucl3wvtWQ/LBbfgs7jCFYs61YiAjtD6T4IEdcQvQP5pfjUyNKY4CmWGX9ow5EGXbGB/Biec4BZ3h02F+T5t/N9eewk2+0SpcAOGjNHtx+i+vACeriKwk23SLAUfuM5E7/ZvIsBLkQCuX9vpPwHU8M+Tn7sjQHgL6a0Z3CMma+dO6Mr1Be7jH+ZDMDdcESI7fb/1BT7duHNgKCT0wLp3KnKX5/k9HveJknZCYAswSN0G9BDcHiJL0DybrZXpPZ/xKRQB8prCrZzGZ54oqTn/oFUtbrKt9yY5Bncp6iYTHOlkymzbkwSrfi4qSuCg5aZqhbKvCqFNmu295RKZRTC5HYALyG6gLjn3O2M1VwNUwenaTAHWRbxoChYCw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "B3DD40838D008CEC77FC1F7C61228C5E7CD79AD987B8EDF6C2F4D4E381FB7D4D",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:77rTS06SSG5qJlxignVBulq8tzSvpdMjAhUj6IDuc0c="
-          },
-          "size": 5
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665619093365,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "25D47EC3664563C738D5C6C90ACD0373861B8BAA266EE08256F477B70ED1D691",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKYUEstrSWLyaiKuzI/4CI93ZlzLfFU64JMXmAB71n4nAyKfewjPFLvV4+eTD5wLHY8X/n9I6DTwiBFIURq+525aoYj1oU9ZjZL9TAKddKKyVye6XBZGiPV72qmnZsOjRQwXjU2hj3KPQ/KK2lV5gWN6jHmtp4wZ4rip1I7S9qRbN5WaF0PD5wbLdUFkcKANzaI6dz92AS+A3eZ79CCTSwXeqg5pR0NfMN0ZED8bVYBfRDLqfTUGvbgczqnoroy7wbDWslZKqLSaD7KPX0bo3MINnUzAk6PAukdUDpxGYX1mUZfe4axsfQcWljktxA8gJMNWzzN1smbcwYBps4IsaWMK6lc2zxCuOguEkeHXlfAxbHfVZJ3RTFUUBSKCfiBXnE2z+rVl7OngdTtVs50ViD/Jun9/Iz7RgXEIkq5UnwVpHWWhkTcitJVHkX20YW5sHel1QaQkgHI0Vgr2quA9vsOL8tqZgpO/7O9PygtLsiWiF1YRAvU4dXi37r3LZI3+etOnxUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqsH97qziZmBEJN3tuMk8ek85XjGfLOPiYk1rwWM2JzZkTHw0v9dKJZvzEo/47Ga/Wc+NuANQFpmCYt++PSq2AA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "25D47EC3664563C738D5C6C90ACD0373861B8BAA266EE08256F477B70ED1D691",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:ZvyjKa+zWa5oXrrmvKY7LhAPXcz0lQg52oiAp/3PEWw="
-          },
-          "size": 8
-        },
-        "nullifierCommitment": {
-          "commitment": "C240E57330110161DF2B40EC7CEA12C8B5B4A1FD4FCEE2697B361761D8DB1CC6",
-          "size": 2
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1665619095246,
-        "minersFee": "-2000000009",
-        "work": "0",
-        "hash": "AC69F84430D9C373721C3CB158FB44D718A8C097FAC0A97ED154D1D0BCE680E2",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAILbqI226bybaKchPuOgyATG+Mp50aWIqzvpZkGfZIAOcnPV3cWvHlDq1ZSSsCT6T6I89tVMaZSF5sYLpeR/A+ICRmQL353+o+8IQAkbjCjLDsbgAunUgHmRcfOrsSMX8wMOvbNric4qBF/nmeWUKXateVcmcOuItVH8Wj23t1yPL3nuLygBI7G/vNdMX20I1q8RCj39LpnhQvQlb2ohnD9XXrQtKeEiufWziKmHSIuknBa0z9Aojx4nCZeGANJlVXq7t2+pNDRWO1ekoGUDp7Ja1dHUb7C2J1fLim1R5/as2Kqo/pDkowGpJKLcdgeOKg2iHghuIpvdOceCWsBhHBAX2+pJ3aWiIkcNAZRdTFW1rfwCnAalzrnxfds1FNoz0s6k26qvbWXvoFbnlydIrfy93z45CFbnypLfkJZ30GVy3xTIYCbRXGn6IcG6VTXz+n3HOyy2nz+8xlV2KYo63paX6+IUmOcALNpqk/FOzjL/OealwSNlr5cjFsNn183wSBtmEEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw6N3xNKnTiBbeQG86UDc4LHhvj1GC904HmUcWcYPfo+J1XQodoO1sBYvIzsjJp+qmmrvOqo7ctoQyou+1r+PRAA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAAJb9d2r7Uzcp4pZb523vq6H3I04uHGsYEIgdRU0EroZVE1+cy9rlywmYuqdyhPv4DZj6zYD1z0OyIZvLsUyrk9M6h2J937CqzLz4Gs/3Ylrs2LhLtzpItFjwfmy61wuGAhf2pUudnE+rtJ282+MzYAaajtJx5OBl1/yXCNUQoYvEpdyM7BgBzrJMDdqC1ZupA4UsEob18JH5j6EYXL8f5pSDoJAdgfllOg0VCzFNargYlT8Tb3blTYlJSosRXQoPZbOXJ3atL74u96HZctSJzsg6oOsoePKhgM2H47uq6QqyzwmwnvlRfk1t8jPCCsR48+L2uiJSyI8kFkdChWUVy1PvutNLTpJIbmomXGKCdUG6Wry3NK+l0yMCFSPogO5zRwUAAAAy8sj+Ur67x/ZcpZ5WjTOVkLxSlDZaRZ9l+lM/lV7fngw1ychsgTblaIReenFyl9IK9iF1PBdYPJlrpstxV6G6v5cupQasDxxEFMZ+t2HuPcBbsLu+89G9RxsCVBNdUQK0TOFsa/Fy05KXlI06/mQliH+srDNMFIKrMO/xvEQaqLsjWHcPa1bUoWf2R5nxyFSpVeOl26ei6P3dx60NSWArCenoEJ0OHCTiLAJ+ZurvepNKuyn+qKdy9nShd2KxTh8RjMHMdpj+uwUmUeYf1xXUMRvU50RoNScqZwgupD2GdNB6mqv9WltXuhqKrw+5TFaOwYEZNai7MjhtseFNiTsAJBPdX8QPr/nzCKJ/O+12yHhBo1Ygw4rrfJNFEgRKD1jAt7G6qXW2aLN2UbVqSpgODjMbLa9pBvaeabGQQZGoGSyLg6snLDK+OamKF30pcDOdku0oC76Jb8jzaOznzNhbr38mGimvOoGy+hLa9HQ4/7QHIkrmQ3u6DheK9PVdWT+pyJiAChm72w4M9WzmewKAn9oJQG0ymsgg7xBnGZ7XxI5IJdbqzEwUtAzQ6oPlFCQLSVeYdT7OugpQK0y2BJ4YQJmur+62H2FpXUAY+R2V1RJZLMA204kxRJ4QMJuhWvN0ogdmn1uZ8ZUqx/TfRWsdEUAo2oGkkNmJCyIPxxhZ1qrRQA4zBxjHwKti3t/cIv8re9iuUN5qZKG1Wv5ymo75Mpg3/26GP+ACGo7lpZeuZwOIeIZok/53EzFS7+oEzX1XOEuP0in891dMlBE75x2M85YJ1xyfhB0kRXT9rfQwVTV5A47cViH+i0+TGULOFcEFa/ZSmzF6EN4XjtuVc/LQ/379lxYdnqDDHD/LVFZuE3a/ZAs+SDfasg6Lq8/myf3XubdQhclRXZ4bX5lpMkcrAYbA3q4lr/jKP4DFG2M3EQsz/IVz1j1mf/wCKRtvdqSHyparg4DuriTEdwtGrGObuJr2/xvActnsR3v+81TqNnxZ2D/HsDhffzmjRqHKmgVo35np/bjdfmBoBlPm2f54IdsY4FhG8W3/8y/TiEBQWP+TCUk0xv6A3FIEnYCph1R5gA8ssD11NOSYvC6vdgYp9i2WNs1S4Dsx7o/jWkFylEZGZ6gys6RRoElgxFQ4pQ7SWDbgoPlsDFpQD2jA6wGrghOHlPaE/XA3Jp8jVnBXUNnmu9CzbUZyMwHogKAy/ysps6bW4RQrrR+JaKnNco/PuNyEYXLMNJ81jtRLf/xjtWePjzBNPDSs5AN+/Nb6zTAB+45uJodZNokCzoLyW0V+db+A3NhMAYH2Bo6irZQEXhuILHgNtyWB81be1zY/DWDvIk/OA1BLGEhHOvJ91tptal5fRYr1709QFaLexBRpMPQoPN1F8B7Hx3yOC4NkzcNDlK1mabd8fhajUXE5qvFQbCTaNl3divtklYn8hKh2/veYifv9Cg=="
-        }
-      ]
-    }
-  ],
-  "FeeEstimator onConnectBlock should keep old transactions in the cache if its maximum size is not reached": [
-    {
-      "id": "9f967d0c-4507-4242-9c1e-9e9af40fe640",
-      "name": "test",
-      "spendingKey": "c87a39113107648ac7f57ae7cecd0adc14189d595edba0580f46db3ea1e80226",
-      "incomingViewKey": "fc353b4cd0271e7cbfe5d5592313eb6fe4977d4625fb69466bb88bcd38da0703",
-      "outgoingViewKey": "2d77be72b4df399c59d0c288c6016dddd54063a05756fca4c2ecf4b6f8567d7f",
-      "publicAddress": "72e3d58bea21edd90a04de78a1c7bc4a3adf3d740f00efbf38e0954ae35d43131d7e599590b7fa0fe931af"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:mfTbET3zZzVURx8jRW96zuNav+CzI2/wtGZB+2pZUAo="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665618765562,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "DFD2C1CCF404CA0A8090F51005B93512F2513739DAC0B4E7637A42A3246FF6A2",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJOWhu2lhEPWwprepYhTsbVRM3xeFohL4SASwMB4Tks1UiEQ0HRpze/wPowdSktto4Y1bJvImGI0t3HMto2RMDOtIQO5dKx6gqVI/MuY3BkXPlEHHxbvvl0y1rIwXyMLzwKW7aj3LB/ufUAJg/yn9VHKqU+4vRP+TITQ1RIJtBZw6WwrGMQFMEgFpG8ftRJDuosibLp/+oAP85wKNzwmKheXTJ4sosP548q4eIr3O9aTGiqLCXh26hpnT5tkXgmJz1vic6deeGMr5+sY4NDDInXMgxeJuVy5Ees56pOLIXy/vrP9jLQYlT61XkPvZVDqeRSgwpoqroI/UZHaltbYgDUMiEssMA/ezcFz2PwWLdlf35r6Hlgy9mbNd8gY2VuFHuHHwUPIYdrd2FipKKWqtO6Bw7YIcZnENO+1EXDtXWr/SfRmVLcYG1fSYTY9dTEqem8O9B1XoMNyGiYC/mpgd56KY476RjPkUPWK3E7WuS0Mcy6kWzbX+wDs3N3LLwT73c7X/kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwt01gNGl9MUvt/HUIC9xeP8RgLx9o7WP+jBdX2L/JK6RCLCzBDE7DNOghDlqelE123ljGCy8TbQcyrJyuL2O9BQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "DFD2C1CCF404CA0A8090F51005B93512F2513739DAC0B4E7637A42A3246FF6A2",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:/Z5aKdkcN/guIRaw8txRdfxxMZhlXfSE+gzhpIi9umg="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "27E28D8250D8830CE63D3B1AAA0976429A853604858123C909AF6179D7ED0D1F",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665618767540,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "83BA0A67BD7948A4439FC672673282545092B9E69C996B5AC7C5E2EBDBC4B436",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAALIZI4108dFk3KYR3soEcWIgTqKUfsgfC2qko3SWToV0ji57MhRi6E9sgLbX8mF6q61iLMHwzLpUdRZ5lB/Tae1KhkvKgz929Lwnr9f4rrXdu9IWX7LY7GUu1dKMeCYpHxYtgoOE+pjPf4/R5KZ5O9ka2ZJ+W8R33ILuHYfkm0GCiCOX4hwxJRDGLyo2mM8GT44FEjTzgr8W0GUorGovyxixgOjj1qEgIn62/NEMBo6ur74I52SfW91V7D7qAacYNEHWT+I5PgFNcpPKoXEcoCEFbgdY3quFSfv6APmBOEbPo+qFn0a86mBOKPpjUx9EpAmU/oC+af4msd/u+TF02RAmCpbPPjYbDcKtPJ7ZOzbLg8LjNoFRdqpR0EimKNhmhQDboVNgyLF6PvHaPk8jXmwsx8VWnP8MrSXHC1E+3PkpE3W+/tKrNf3FirpYG15a0hea+GxW/jmmxKDf0XxazmHXcu3N7xDszwPH60bMSn7bxiMpGhivos0WzjKw+FpYmY/bKUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+gbOTverY8Icqej8v549lcuNoj2vIxsUUiBH5Wuj3p1QgcEKregcgvY7nq/ppC1kaZXWGhI9PHyJpDfwr/beCg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAKlXmNFkhHFpb4ymQH2Qay8MQ8kxCuK7xfTjgjAP04p39wBqG7CjcPlRkXdM51AVEoIeRV7VK9jBtfRA8t5Fd3c1pCcIa53HrPMuMHaD3m/FShSpELsSAMenMFjqMGvQ6xe7CclSrY9pdFxupbxhnnIgSw7BeyYJdaq/Kg+auLXHgghoXYwuIWEWgDGdrtgZ/rdJgu8dpOAXBUn5xUSrANK8K54l6eHtm0CMhEt1iusH7KQEhSvmbmec0dcHT2YRm0Z9bWELdu1u559gKVA04XzWgljJEIMwOkTKo5jH/MFzz0D5R3Lrr81qp81xONUhpvh8zhuGybX1R5PnV8T+MRaZ9NsRPfNnNVRHHyNFb3rO41q/4LMjb/C0ZkH7allQCgQAAADe8ofC21kNTqcmT2BgEP1Jtpe7+ax8jlEDHjmM7nSqV6WtEwyxbd3TcPiBEq+dWuMuLKEdk2SmiILAZvCOXl2oI7STGkn1DrvfPEWSzVpLbtkcv/SduCg7ieY564R5FAqLdl06s2vi34w12ZP0evM+z0WyPHlD7g1EQyA3jxKtEOPsJ5LrAd8GFCVnjXSF9SKyZHTtvcKLFwYk5RwfYTn/xQ3syQI5GXJXo+FcDlF7xosrzDsxzJctuQbDv+CkICIXQnf12g/23TtNvhOHKuzRDbi8GuD00zXNyjz11Ms6EGrIMToVvQeLK3+85vwVEfWgE4mOUQdfBD3CQRBjnXrXU7ZqaBraifhW8JNbqv/EwGb/heLJ7/JMzY/lvgzo6H4l5cR6VMxF4Tl6D4XJ1S2+X1k5UOXF6vDqZWsPGKZYsUbFtTbiaGJkJvVTy2Eu4/snmMwzI+/V8wnOwB7VBgZGGdYFADioM6otkcdNGxFZdNoNe8IkoEGVZwyls+5f963ay83QzgsE2nvKiU3gDmFsqCLD10M0+tot4NLbyt8Q6LdYuho8buTH83C++iW3IwFe1DrtpDEbKSeclTc5bH5TQ+3OCWDmsIJmQRmSFwxGKvwFS6xVmxm98YMPhapJWMtFhhISkFbX3rYEDoicbUbT+5+oVmfphND1yKHE9N7FxvlbQGIVdd7gekoaMmdto0Lh7K234jxd3FhRsZx1810EJQyTIL9srdFW1ggM2t8AS76KC445Pv6LB4iAcOZI3VpSe3eCFOplYQR0UsKB2Qn9SqA4uwDZnTmOcPnDQ1Ke3gjVq4RWCMK2PB/TV4iBltbF0F3E62L+FlFUKu6lk5tmbVXLgFw3VoMMK4wgtiTt1/wLPw9w7l647itqWaQRb0DxYZ8veLguRU30tUT+fFl9Gj8h2ujxRPie57QVMyYFP/KLPpc1B6CHJ5MgX/ks/ntBKuz66kIEH/EvfNHTzzjuyfscfpHgSRNoG7J1ontOkTeYRuT8I5HnBS7NUz3n4oeEahyUq9M7mAZotj4ssUY17nrOjWcQhJtSRIlRj+b+E2xb4NcPqs/dtHE/dYAHe2nJPCLwlt6lilWP+F5Ql2ZjDuQQzmj4tAxsqwfDnOEwisCu6+aLPsstvTuMJwagOGvProIAiX3hUmTyzudKYPN3LrwyZzaShsqYQANynP3UqdZDaiaXi9mmtkXvRMPcIfWDBHgLG43ZDECqzcJKzD3m40VWpwsOFqNa19i6RBCTDAR6rN2pmh7eE3NzhZOd3r1m4uLfui/tcg2aRoxzP6BFJD/gxfZ1b/xRlslWcIwO3i2R7AeEh5TBk43f3tlkAee95q1A3Za+39cNBvnvO1I9um8/nGYvM40OOZTsGQFc6S3c/9gNzxDD3EjrJ7SfGTySU02N3u0GjbHz3XZj6Tce4OSDOEj02+aieIVCGKia1n5doILlBg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "DFD2C1CCF404CA0A8090F51005B93512F2513739DAC0B4E7637A42A3246FF6A2",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:vfi52slYT/EQch8+dR1LHwNHHyW+1woyIItY+1O+/gM="
-          },
-          "size": 5
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665618767760,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "30E9182F9FF5193074FE7F8B48C66499648BE94451149BC07B5EA30EFB7C02CF",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKC/bDESThprEPernDaHf17k0UZ30J9eIIOX7EqWW9wr0uKpkuqTMVar+PrQr2yB3o+QnsGWO7se+BhFKznFS3NMSrOBEclgPzkWg+FDEkijfHTcWrzuqwAxur2i6ETBEhT/vyp/9zlpX8bawdtWN+iEW7m4S5NYFvh1u0XcsK0qSKJd2vG/0IBdksMMQsBl1qolJDtfuXuNusO2E+GvLPtGc2GZRBxBZaI+Kj71OcSsmv0ZVQQnCM3FZHQmruMjaQxH3iGPFMwbZtFhrJq/eu33AnOQYDKy08kYO5ScuRQ9M4g8wRsZvUpw4ETtKpG0KklK4lWPT1Z7pmHtjsSWVFeSd4FA3utwgiGlTxFnH+0wDe2P8oAyeWyFcw6Z6r2gwwFo8zDwJSKA8Vktwf3pIODCuRG6QEJpgIAB1J2Gha+wD64YFAkKOOYsije0PAicEL/1gzDolQ0iOGTBh2DBoJLaOktcMiShnD9SGCLRKiU4OujSD390iCJzYzwREQZUstwiN0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw818FbI37hIk9iHKwqyATBgUMXfcqK+Q2BNKyrmfmbBDJKFbso494GEZ5pQd6JAOVBvjCdLTYRPAfNeR5T3ZpAA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "30E9182F9FF5193074FE7F8B48C66499648BE94451149BC07B5EA30EFB7C02CF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:UppRj5YMTksqBq6vCfkPa5R0jHyqF/yPrG/SqUl7CRs="
-          },
-          "size": 8
-        },
-        "nullifierCommitment": {
-          "commitment": "BF0AEC4B77D25BD4D58DDF3F785AB0F123D38E3F4C8967B1223047C9B0EB2C7F",
-          "size": 2
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1665618769675,
-        "minersFee": "-2000000009",
-        "work": "0",
-        "hash": "FE63F093CADD86D5A35E1B9D599DA6FB71FF5CEAB1A70C3FF697C134BB058C77",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAKawYCrWCHdO3DsjqE8taNI6Y6vXBetbWV968laJxc5beTXrEFCEzHKqpkogbN1T07dpCm3lU1ORcKAiqnR+vlPWmkPu68rvq/Qu+qCxN/rCXyS3KWNFbj7pAx7Ej9UrMgSw2cdYHrBSPrkkcZ5vzdl9ekPIOwlpSp3lsGwfWQV4jxMcaWAN/nuLKKd87xn44JWiWQ7rQZ9V/BBjo2afXpxUGCnshH2iOSZQ36oH3iaPu/W80I7DYDyn3JVsX/telWHjwxr0ILXRaEV0dfXjytMHsuKkqAuEZr1UDSB+QUcVu8qGZ4G6NGtZOJWVYRykZJZP06uTgD0gcEHR4JiH/VQacpJC8+2301SwLr2IijTQTEk3YbI1UQw+STYIrnnI1lA0Bu+3muk06cmldAm577wQanl36sXco+qGjl5kmEEp7l7OF/1FWa9Igicx5cQAZO7PUzrrAlzrC+VoNgrJHrG2d0EheWPw+Dx3FBCbpKWSmwaBJpYhmhMVlaZDn/mF5vAkVEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxNiZ04TK/8qkPRyPq2iaOgtzOvmvUGPrBmeGttJRcWaFEPPW31Yi5m5wQ/PWD62/JrgUF/C8Q18glf1bjEx1CQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAAKDDsNaLttIQV2K9yEudQCRycay7wjtU7gqAnhKTnUvfG3FrG4ZwPNfhU4vKtTuj+IwDur/tnazAmBRQ8YW7MPa0RkRb1diBueUrjufNGXYYXPNKyz/1MaQEZKys0M1UUhG/G+KYGeyPQMiu3wK1YgyThxccpuIFfKD48dHCf6/Qjgz7Y1gk4d8KDo4Sy51154/Cv+UznV04RBvZhFP7Uc/zM0KX1708SaOJK7zRTYVr1mSzxI3KlJ+11uLod9HH6rX0W6FA1N7gR7fUYyjF8eldi1NHX6aAEYyZk0/btIJu2WNF00LmnbLzhiG6mQNCkkudm6XPQp2cmkzrsySr+FS9+LnayVhP8RByHz51HUsfA0cfJb7XCjIgi1j7U77+AwUAAABaMM3vjzRvKvCrmPZGiEWdEttczK0y8Ci0KqbpS3Gq9YPI49GfsNVlDi37zkbTfbnxe2HLzLzoJ/408sN16zPTEKltpfSZ8LDF9kQ6RdFHhmeo3lKEPURYE0TwoTFYfw2Xx1hbmIReWj+Elw3TpdKwHCmFJwb9SDndznnOMc5PoHN3QhE5v1NbZH8Qxf0lQYaqh8hSZbg6B3FDLa/dSTAYzEHzzJyhZqXcDtMY2yXj0E8V+9cvnhvqB7YL5OD37m0RcOqjnbPVhIE6o8XiJMUu8pmVY9UQYMzy14YVmBV1ZFY66CXs752Zv+P4HGyVE4+PqXAymju5vL/ortdaH985iG/2pkKiByNkeoSFykMdas/ebR7qUcNLhbXYr7GgGkXVHbJ/F1LSXnHEw1CbNH60zxpf2U3RDA8hEMRY7WbZg9xFUh/GmkFdxPAcjdBE2ZLrcU3dwZ7w6tUSTVWG2SRZPNZ27PANzj506ZbJOFRPm8nPrePI+ugA1p8oEz5Qz/CWRjMdAcn0NlS3q2BqGa6v4RTDOA2sQRG4vewRtcTxTwoiBjWKF7UV9r5+u7J6Wqnn+55JB3WlongWNf9/8wMnqH4LopKIkIc4dSqEm2otvkJC+6WYZUcuPsXdkWsWBttSrO2YLpmzTwX2KxZft1x3+AVgB3RZgE51f+6Hm6MF4a5B2mKEQ017qYCJBKurjIxLkRg8FUlpR++Wnb+jJDe9TYstHbaRCPmVQ5kNZLmC0d3LZ4QipP9xVOU0aOOUIFNfnSSComzKdJ0yESFCJ7iwrjQ2plwzT+Ty4ffRg4WNHZGKzatGwCB6N8c0nCLrkHBWYmiTUi1TugV9AySma4OC+XJX/lCWUXkTzRdDWWupHZD4VwJzB/DBjYKOAjbrDhq6cYtSsfK8c83777lQqHr63y4tGKaHzu0RcahoEsKq5UG3KLkQ5n+F2LyJ7MWgeV9oYgBTODhDNARVDpAY4GBdLQsKIcFjy50rExnn836lNAUXAw7bvbLe+5hHQ/t40FTt9vqDyXB5z4CTqlYNLDqDyySapVPV6XB1fugwr6T30TpnYoxF8FYrL914BKF9ElvWcCcYn8Nc8Y0vmUSnJ5xoS9o1YKtYBO3yVErf3KfK30cu7FeB1mf1b7LO/88CVOcoBz8XC0o3w/eruW4NoxcOUtCt3uTqySi+LhnASau32JZ03FO/v3zxNN9H9IzcV36S3f1ZH6tFc1T3QEJS2E8LsIeGb3o5UWxK52BNms/v9Ov86c6YX6Ys7H+61gwNCqLf7hyq5oSXwr23cJm7MlpqJCwMNDTeJlICkyzx4q7OPa3dAmgVj8Q0G6zlMmXBQrd+Tw0hT/k0ynPpYb4sGSiLeUXWF82WcF1WoEISyqv3iFjl46Lh8pBNWmTJSsRjjBX3NBKkP7nQ1KSxwvjg+qHeTDMePW/OhTFN9gopF6DiyaCPJG1WBA=="
-        }
-      ]
-    }
-  ],
-  "FeeEstimator onConnectBlock should keep old transactions in the cache if its maximum size has not been reached": [
-    {
-      "id": "b69e3128-ed16-4786-8ed3-59bbbf58a8b4",
-      "name": "test",
-      "spendingKey": "5ab0b79aab0599b99d50c0bd796820222dc21b9a2b558ccb35b66055c17e1088",
-      "incomingViewKey": "242780e4264fc83b4fc4126ed8fdd7f19e4ace3d4d25d492f62abfebbcd88905",
-      "outgoingViewKey": "cc8b52d6ebe357cfcf8d5ea738344448c52aa7a47a9b64001bb6d79a87638327",
-      "publicAddress": "4e498035e9a31b73b8e8b36ba1ddeb470bdd25807fc07e3567524554113b49de0475b3ae6bc59c3f7946ea"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:2ZubnxFDj2zcYu370jzg1UUXanU59oGk7f7lcbdrd00="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1665619484731,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "78DFD01BA6488C2C847ED337FCB25EB0D2FBF4D23B68CE14C8E2B52B8E765ABE",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALDD5JVVmo1wY0hnlC6UKKxbNwwaW3cKx1JOYIp0Fn0aNRjcirP9MXn31qNRbX41AKmVTiZoWLN2OoL7fgrkyYLv/EoO4nqf5t3fyoehKZ4KnoR0es3/alh2VOx9IxAfsgvOo0cVHd8a5h2hB+nsXhYMDwBVagBky6a2OHfkFGyE2Y9xAyPKEzVaOS6fr+6dwYIP38mLKJs6Qt6bm1IZt9T93N3NZtXNLqL8XzsQmrhnEPwkbiCgGmb9O+o/pYlLnnktDXTlORLQ/BH4PnfHJ9w4JetFX2nZQqf6SZWxK2owtkP2lkhzD2G1loIrkSt0jHvxxPHOhy30erin8VH+ByMFfWqDZUmqudTk6SNRr7YrEn1sC4T9V+YArsiIkZN7VuvGIF5QksfHQFbPvRpIAE0nQJvOU6HjTUMsUKLRIKycUfy2GglVnwVq4rnwvOMRk6MrFJ04JknlDp8tJ1ilvm4vW6hIz1tOMesUCVWiCnJAwrge7t1d/1R+LCztC/ed4hAczEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwv3FUhgywW4g9SkNU23XhSP/lhDsq0K0wgIEncLUeQs7HL79XH6Tf6nBl/lpraDEOMQvCglTNpayiZ/VW5PLlCw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "78DFD01BA6488C2C847ED337FCB25EB0D2FBF4D23B68CE14C8E2B52B8E765ABE",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:Je2lepHtCrCcYQU46gNifCsW8t0nNTqeSLRN40bm4yk="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "30D8BD39F3EB45452B477F7E33B139B68E6F000CB0888C21CD935BB315D14F9A",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665619486651,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "5DBFC35ED7DBFC709F1B483335F40E9C3278E93C892092AA40E64F5B98600855",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAKhZD9MGTkS6mHB7AJ0PB8/m6zUGLd6Vx3DgWdgtTCh85HWCggHIaBNhmE44Ob+ROJkLVKbRV5keOHB2Pwnl8rPmU6cS/49kHc9lSKKbwojJ0XPc8txKpRw/ddAt2XtPwBY7VwhqyWs9+U9DD1QVh7qK9v/nYERlaAHLBGEJOhwmjM0bw8bhvhbkO74tue0M56i3YSn6AbvtVZ8YR0MWjNhqTRqWU0I4CuFeqrFFXjHObKaB7lx+GW42GOU5BzbTjh/IYqeeYwki5UemrbwO7/mq4ZPmB1k8MOT5QTcMyQOEDtX2TqPTVyyEfzOLQzKvtvRnSD/DnSGaTMM0dn81KBkl5I5FsmEkxIveGIclJaDBPtY6TESRmw7vPCUmOTLHK7OXxYEGndtwj84ledJ2wNlMZX2r0mdYZvqPgYDxyQGk3buGa5BZGhln7ylYQsWlL/LUHb6/OjoF2vhTr8TYeQ+xQl519z9rSjiWczkTY33JCdQ/DpY1kga77LkHE98Wi7xhG0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5q1xswMT0jhR4ba9csWssosj0set+sEcc2jLIKB9fTehIjKy3tK3R9nuZVjt1VN+es8M8nKNFJF7f25f9NBRCg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAALQ9cccdRlpU60pOoN4l4/YJrjxL9IWiO5fOEdaAhjq/Wv/bhnv+W+82IG12ueMxFpESD7Qvfp/DzyUSiXVOdNKqpmUcZBcxulNQzFrf9yeI/64c0sxso2NltDnived2WRmxhfEcJjUIhDUDw09rVVJEhv5H0GheD8nZxokDfP7dQCLOI46opEwdhoBu+6ZWfKPmKiblHXeqFXOlKEWM6a8SeCtvfMuwQBjKXiUfxeNmYGVnaAje1EYD6hpjhXWgaw/BkWnG//4pXgMO9BTf2M9dH4HkewqIjuTg/I/Unr1Q6+uElMJjwSFXTBIKe17vZFNsXHXYJQBEVw8mD6pJyqbZm5ufEUOPbNxi7fvSPODVRRdqdTn2gaTt/uVxt2t3TQQAAADK9W4YzvgLX7WWFmL10wRi4T3gHDtPlDQNTjy0jlWhq7U1FfYX49nXjdzqv0NwCyFkV1Y1HT6LsL7NBsc1/lKvq7k+DqXbkkfSHcOotHpKrOUp/odBdCZRVppZPPYsbAiVL2N66jQ5ifXietfPM4T6f0SDj9i83YdYZr2IeY1FbKt/u+4RqJ0D43I+Ni47e0G1T7zuYP7CVyfakPECfz/qM9vJsP7KC2qfKiVg8N2H1xwxR9OJ9cce/3nURzSBNb8OH4lwMYa6do9dipGT4BWrFqR5YUrOe/mN9+/1Seudav1XAvc3CZf8JhQvgSSzwpGLYhVR78aJUkD9+P2WibIi4Q2aZ+L+oBkANrsjDXWGkN5SbBI6LZv3unpEiGaO1f/Aquo+rnmCf17jukcaskWwxK+GhoG1cIh0ZyWw0eNqg9Dj95B7QFS3K3OSa/FDHBdNky3bIIGiKnPpXLldREkpY0YMNSdXQYC2ftwMSm2Fe4rk/OOtWhPiJ8zCxoVIuoNlFDz4pqQGHJF1qYxDK0ufJuAasCBiZe6Yb9PBDVGV4XBrebclB/xmRQUSCRFokir6rcOO5y2sKLGkLDOfJh8bOTfN+3HfRlSpVfnSSHC4nzl1eu6pnmImpUjXzIl28C964e+3844U0zG6Uj6rO3EgCLDkjp9HAH836ZLNAbxKCYWNf0fa25b5QHziHiD9kbGs/TrLDxJ0wmn1WTwlkXhNtOYogg33+P4CB6cqgK36maL/WaXqVvPVeXFUZBkHsmM3FxYDx38SFD+vRYQfkwRelMT+BvrLQ3RZQLD4yTyJjJmawKMDIZpu15xF3FPyQxpowapT3oERN1axMOneJwHhuGHbNWoxw8iGVZUKnPnuXHrv+BVCE7dWYy2Tlc4ROq+iVm/Pib5iPtxOwd0oi7J9tHhV1DJvzM9WTuk1rLVvuxkVPZnucgv2iw8M7nl/F3SBf24rz58mwoCp2dWZronZBmesu3UCeXZQsW2joO/lms4biXh4isCZfdOzAvrVX+PEFHkwvcuLCVz3MwHfeqczonenwXGV8gqEjABhNBYBAul4VQenV4QXb2ESo80+S3cxlwZAXoa4YDFujAHk2ZLlN7ViyGENecUzgam3FMNs1rVKitGxIAEbt2OCRaCi1cNKlB5Ax7Pj0cZrp4EMROmKNxPMHr+7MxAPCga2XHxX5ByLwSON+epeMP+0kXiYEZ/eBHmUHL96jOo0d0Wy9jM9+8fhipKnThbyZwj87Zpmwar9qdBonTpstecv70uCgGQi/PgSa+x1NQ8VDmrb7+Vs19D9SwQybjkxX66DtoXxCAUL1RC9jz5lCwnyAZTyIT7Ri5hjL3KsNs/MX7AxHRFT35x5MMgGbdqBUx/VFIKyfyzkNrWtMHbFF1wRw6uWZtgKJFgwidW62Y5tymotd1n7BWlKuCzS5rKrB3R7CfWsil1/P+jTBQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "78DFD01BA6488C2C847ED337FCB25EB0D2FBF4D23B68CE14C8E2B52B8E765ABE",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:O19mxoYUPJsfx9NROpAxC1YosnVVk1IxwEUmC3sKnQU="
-          },
-          "size": 5
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1665619486869,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "D04D25F7A0A50F7797FCF6B876FCFA4D217113BA783E2C31E52606D8E42FE9B1",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJW3FjefXn244ENJMH8UI/7OJ9YIJh+urCDPCBLOROD/DMRNi+/lIGitz1/1r3xo8qCOUufG6j/eT5ElO54ick9vcC7JgHN2reXHtYR1KTPcxgwXWj0TWp1Wk1kliqgfBQVEvpl7XdDBiXCeeG9A0MMzqgopcwO3igehoHw7cCCk7hhO9qN2uMjhoFNONMx0nbjp/e1rp+q7GV0SWqw0IU8PYbxn6nuNu1s2Rfuoj8zjpb7Sr73eO2Vjh1l4NZ1Mi/mgrjXGFMx/bzhYJDNVgEAsbguW0fbFaUuzoGVv4ei9nXB7qBos2ui7aLXjB47CWspjxb8zc0qCV7Z6rmoWFV1PiPaLaf8ujyNtLNQ/8I5XHmDqiZejbALYYOUDm0aIINPJFahmtIrLhMHvYz3UvAZEJBSFpHOIEh7Aq5HGgGwqGxi2QcMPM5ZMDBZygH9KzsepICQzlZRdvIPTODIDCQa7lVBZSjEcgVmZtY15gNNJ7t4MYCJGdHW98mGngIcsPRh1bUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3tCWKsmW2XPTb5lcz0kltUfNA214PeO3qdOSvbURD/HmQroiZeomUOpkTp/sWXmn072s461ru80fMjsUkE2oCg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "D04D25F7A0A50F7797FCF6B876FCFA4D217113BA783E2C31E52606D8E42FE9B1",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:tM9VTnTM+oPGrG5EGGymEsZteVWhD8DgvY2be32ku0k="
-          },
-          "size": 8
-        },
-        "nullifierCommitment": {
-          "commitment": "667FB22C14F2122815FB4D0A8BD84C2A74DFE7DDF73FC1CF1AE67CCF3FA40C94",
-          "size": 2
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1665619488722,
-        "minersFee": "-2000000009",
-        "work": "0",
-        "hash": "25077A5FE4FCF24C92717703220802E5239C6A88B0B60134F04A1C6916D2F7B9",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAKNmj7uAt+gwifQwuCABZMIeGTxzv89pxOn7ne74PgS9orxUfPeAH3ruVFrfLTA/nouylFzanniJiK9/mUxczq7KoQsbJCqqx4CZyt9rn7fafqCqp985XEDVaBk0RM64kAMQpFD5adBPEC3uLT+lJInqw+LLMfwgQAAalWhnRu6NFkZ8BylTDeCBdMQgAtgvJ7jJ5hlke6ZVHp/DPOtxJF1f487L2ad5OwURdRa50qm/zA+RA68aVZElC2p/GV636nFQ9siir3GnWZ9ySgOtYQzg+DlmVrypTZHJOM2xyT+rTPLxrYnzLkY8CS6/Vfll+TwiI8+kdOmlmnBaMQgkXgZhpDKDZ6nWyYyf+tSvPpOkMIlOKeEnnP3PYU3nJubsz24CtPXvQWTU9bA94zrfJHqOSNlz+sXkFkhHFr2r3fHtGkqOEWmkl8GtEFZ1KSmcUbOL3r7C6dO8MRwJREaqi3lrqzQGpj4GZSDzoOtzMYMk7AIfk8bB+9tARAn2i2Xb5WLMNUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdS6js4rmM/OxmPSXGLqXjtoIIvY4pwdUeCfKGNP1AcxkmBqBlocJ68kxGBOdNmO9muKrAu6h1LUPYastQ/9dCw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAAJDWwpZ/oVKeeeMVuF+CqyIq1qAYkS9RZntcnyitfo6ugK3sqlIXkL0kLtpqg8mXyK3U/iU9gZjnRAY79dOXAzR1wyh2iloTk7vnrr1rcHwiVDA39Jz00ExB3PABMjvBLQ9n44dxsJESvjiw0eOZ+gllOp+LsLXxifN+0DHWYHcCDGsBAT44gRB420juQ+qkbbCxx7s0x9nM3VK5pi6gP2AgSvWt3uKqP3lI8z0gWhzFWKYKZqDQSz4AvhfzODdKxA9UYbInYr6PKIsRPQOqOTwzDh4mmWrhKCqEN+SA0GJzArmz7LPfFm+ugzdUZlDB1+3C45dIq0NlE2W4WpzAvKQ7X2bGhhQ8mx/H01E6kDELViiydVWTUjHARSYLewqdBQUAAAAetkxTrHuH14YwmZstGpT+avMAwfMfXC83ZlULXOGGhCE7q2gt+NdeilqUH/TkZZOkEXTgiIDa/Nx7bwB0KWKd154bj17yhsDhnj9HkJ77aAvEKEuWCzh69nvz3MdJIw2JB1dfelD5dl+7VA3ILvwQ5BOm0CzVQ9DvO0C6GZkae7ZPAQ0n1k4C+W0MQNbd17uyn+PkV6K6/giclGJAv7t+uoB8u//du3nJ6Ie7gK+Nk2i97+qzCEGqA7w90nzgUPoI81a2sAbPenAQH6Ff3VxAuPilbJYg9LYH0bjrlJciTiHSbwu/J6CLyoCdX8iXXPOsEvPSNp8Oq1tpCWpFGAzT0VGlTAy5LZqoiwM/FKsf4MFxxwTsQMUNf/6FxO6QZnILfIaOQtAa4AZgSCd0PCcn0MMCkbLfOIHONo6BgsM15Vt6/J5xgGJFpVBYSvsEFP4CLYMUsqSDeCGOqx56rWsKR8z/zSjs8L8I1ScEToK9v5SO/xvJKdXyb+RZ+8YGSM1N0IO0lyqAIJQI1vXh+i4KOlS3yNobnoTr1p7+wzWiUjUKFZzobhEJU92/fL1SlzzjelGUN3qrBo/3k4avhPDKo7mt1Ojt0NWWtTBvXqCvFOdWodNdh39Rj4Coyg7Osr79YyroHth85eyNCUTENNkafEnC60LQiS47F6O2chPUp58yOwacUtFmIgg5ekZaMWB8x2F52C7LlOJIne+8eOaLJX8r5w5UKnJBwgVzBtIRRNKNPK+bCCi4nT8ymJm2rqOLMokW+ukzxk6bUks0tKDHaS5ZUW9lbt+akt5xm4o1R7Hv0afI+eRWE1QXqrYSSebSse5N0dE64RaGCdTK3bM7mh/5XGyqtcJby911cfdKId0YJRWFvUNaB+1ZRQ9nov9LJSY2XBdQLrkiuokf/7nXPXUoZjSEcc/8KRNicHrYzmMeELe6TLtLi6tMo5rfnlzNy1dRPLkzXtVwZUYkHVH0Dq+ryMPXr/3U687anGHMlAnXeqKc+8ySW9l/3jSX/SNTgECfw33ogLolxdfUsJz3dWtsWeeeHj3q0FiQbRLXMJn3la6zr89yn/0ny6VKagQ640oDBt/Wn0PDI2/gKcKnE9xm7FbbUTeZYI/v4WbvzYJFPxg075IeF7SStaVnQZwEvGIJbNuqZex+5pTh4+PU/Xmwq+5Lyq/rh5n0GSGp4cSt3wg97lP+kS4jB+l3FaeI3mhGu5uiNRGlihqJuzp2q3ka7ihgeZxfryqi+/6OgrC0nRT6fbuWRV3/BiRPVJfuNU3lRpXSKfDUgEcajGKA+d0mCqvwj9Cbw2PfPd+LHROIu6js9e2oDWtZMNOSwmmAOeWBIa6Os4PzjZXuqRUeipRks8VAEew+UPwb2U6DF0Ti5WHruoWyJSUPH1H6Dlb34XsSZOYVvDzvKOkDRg0VL3sSnMToW9pLXM6oDbqdw5zb0GrRCA=="
-        }
-      ]
-    }
-  ],
   "FeeEstimator init should build recent fee cache with capacity of 1": [
     {
-      "id": "c488d89e-74e7-4887-a71d-e76746b390b3",
+      "id": "116efb88-7ab4-4748-a251-6a5cf2813c29",
       "name": "test",
-      "spendingKey": "06f1b6ab2acb3c8fa878accc126f53e2b798e5a1cddaee6abd218bab102e73fd",
-      "incomingViewKey": "0073a5c14e6801bf1a68c748f17d449add71ca54634cc43e3c4c55b9e8c0a005",
-      "outgoingViewKey": "9298b1ac4339d0e17738122030c6e0d14a7fcc8db732fa3de6b41f7a6007cdac",
-      "publicAddress": "9afe8251abc56527a5ae070c6470aec043a52d60786cf3363ba41a82f9ae8fca91b3faad3c637599ce9110"
+      "spendingKey": "b5edfaddc597fd15461baa4340bd8845a0550231c873d141d782e2f19d457bac",
+      "incomingViewKey": "f029a07165e732688d84727417aca06868c0d923f61eb0a05c2f97703cf51704",
+      "outgoingViewKey": "22acb9c5dae58dd620be19f673669cd40bbd81ab39568d9f11a841df9ea27d12",
+      "publicAddress": "3fa2266e90002af092014dc46e7ac6eae709532bbfc7783aad48b972bbee5207906921e7c61dfba93951a2"
     },
     {
       "header": {
@@ -1213,7 +15,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:Q27Y/Jj3BGCFqA3IxcJbM1kAj6LiRJNpeCrblNtKNks="
+            "data": "base64:6zlWmGpKJwB8bTHdjdi9YPcFhuYqOdYC7Tt5J9FscxA="
           },
           "size": 4
         },
@@ -1223,62 +25,62 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1665619071446,
+        "timestamp": 1668120326745,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "7345971994ADC6C380E70B9D5FE7C79ED234AC847310754C1E84371F9FC1F8B2",
+        "hash": "E6B930ED940631F04F5F80787371DAB8F37EDBA1B14BFCE834C9F1E51DBE917B",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJDMtpHNgEu1F6L69WK0+MvWmzYdGSr1AYgZdI/lgYpfBs+IZH2u4JRsDH1DjGOA0K+qplF/2bMrRaiNDYjFqTaEZeQLHjuP/ZwMO4YIuIUwyq36oUC2kyy0trERLMCIhA+sf56AJ0tXxLK1gbhwoVtFO+zbHFH/K81FqClZl8WPj0oEgdMypKE9bhGtvjWRBI+wfRGnld6jk/RqpXnaD3TVHSTDAxYmEXRY6pOwH359+4eCs7LUyltzN29rz2SsRl99XqkH4HRbNm9Rv/ZgdBh81RFG+bviHfK37FBi7B1qAh/AHsqYRf1YAWWBaEY72cvpFZ+ztX6EKC53zWhpJAm/s6+zseC15991LJ3apikblg6ajQffqGXiXVygZTbEA25drWh+TkxIJxNpo+pvloFDDq6+99iRkqhPvu5rNirSFlZ6dVM7RClfWnj7IpALGIH2bMbS3wG5L6YMxCSrlRanFAvv2iuiHn+LxHcDJ+fDzPK88Y047uDYGyLrcXVtNH1XLEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmaRcrJXEGosWxTs/AWZ9YZ5ccbu1ZBZTnZSzK4nr5L1BM+G+7YxEzgUFRQixmreYhCQXQxcsH+Y7VzKGSAjCAw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIT5d6aJE7U2YCIwTqs6BOUoOJxin7+nileeMvQLqdYPaZLsO72+UwkVtWA/dolxObUBXKELvMhZSmzwAJWeY+JLBOfJ8yS6rqdVRfEkrVC8krgvyAOnlZ0z+KvkCVeQNgCASt+OAiSV/EVj8wor1SPOXv16ZC/tZUpHBfx+wJusip1aRu7wpPYgnITV9kDM5oHDnCHlugQEhkJk77N5j4CvnFHPjqsAu2uRCrNd+ihYxa0Ev3Cw5ASFWSVcB/Yz5CG8+9rwLz3l114Dv0rUZTnpfNX7HZasrdy12CDfOt8lhUKVcafDcqTL9AB42qq+gyXHbWkpqx7JJZmzJPJBgjJwwXSyWlZ1G+v1g/Y6qx2/WMTkLDAs/A2b2AdYqBZhA1uxZJkwvEcJlvAGdradSmRysu/urL9vg2GgZzc7cXM2ZrrW1go/4RmBv8bt7huE3FbwrZml+Jaxrr1O5FnQbdkXGcQTmobiKnguWjDZQxqfxluFao+eMyKzhFKtew3Ppme5YUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwg7oPbeJfoRv18xF5tBxXrpUfTcyygw1piNWYSel3BeePyevHACKH10fQjEoIX/m/TkQf1qXlS98gD565fAAsCg=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "7345971994ADC6C380E70B9D5FE7C79ED234AC847310754C1E84371F9FC1F8B2",
+        "previousBlockHash": "E6B930ED940631F04F5F80787371DAB8F37EDBA1B14BFCE834C9F1E51DBE917B",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:xwS68aB5Y36CYlu2rR3Ne+dd0IgnaQyAkk7TxZ5JMEs="
+            "data": "base64:owVDkPz0Y6fqOATuOyGydBWoc5dEuoJnQADnRPcZnhs="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "D8848E3F4B7060F66EE3898077F4ED731379CD4FE15B436E9E9106D7BBD134AC",
+          "commitment": "1B19C8D3A9FB2D7E615298A99934F3AA9EC4F00A4656D1D90B4D8A63FDC4665E",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1665619073334,
+        "timestamp": 1668120329273,
         "minersFee": "-2000000010",
         "work": "0",
-        "hash": "AE737214D111899923CBD6ABD81AB9BE2A210853EBF29817D44F4534B718DF08",
+        "hash": "EAFA3648C6CE0596EBDDCDFC0A2F96C0D86719A6C255D9C95F429B3801022528",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAK3RlmreeKQslpOz+lMn95a/45LMOWo2YzUV6lUzsnGZ39bmCye6RoyvBkRf7vanNImvmu7CjMJD4pI9lupLqZiVX6f1U3oAh+2Avo6y9u5t2+O1hnG6cFkXtvCNgM6r+wk7qZNjOQhdJMlp0ROeiufVTNQxmB6P1AILAuWPOgsfCIEbyECITl5TZJt++PFk9oWPWz6EpGKDr9fs4Kj8klpVL10Px8J5fgyZztqEbuLiLndhO5iR8Y7bvU93sBmwsWa/8pKU+PXZBtk3Z6F/JUn1kimW6YWMUuptIsXZp5UTO1TEBgkkCM0+JxVWVZ/FFfsUVyrj8piu+vlitK1QhEJFoE+bV+iVlZHGQ1wvhy8mYOU4XD2PaTJZANUpwvy4CMBBe8r2x9+vrIJCS4Xw+vUwK8reaWaDzZI7B9e6XbXENP0DHcZ52ZlZb9hjl8GjX7pjn8QeuzCq9euFsU4+7IsyDMT73AP2apm7/NtxE1tILHMZrZdiBBkiIo8EXO7Ct6UQIUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnOXGf2wgq0CL0z9r7GjPDZewtw7COw2fralQZonV8AdB/TVxTQgo3iipy7P9AC/16VxGn/aZsB3rmOjuZP1pCQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAALaO+YZw/cO97+qOPW9M2zOB11hCHLkmYVlUhiQTC0tLlfl6xF3iuk5yllI1Ua9wA7TI0ePlk9ytqvEQVpJOVNVsThPf8sUScYgmYcIxJ+lIsARKVFjxqESV+NiP9JvDVg9e5+bBNlQWfbP6bCWKFUA8xVZlkwoCkvdbKS6cFdHtawFwb5GKpYwt2E0PO+mkiYVbqcWvY7TxZG/DON+0neGoqOXpcdvDiOaRubluuWyVvgK1V8R+BAASQfgjRf3ood3N9AFn+3rWk9f/ciDJTLw2bwtzK8/kU0eVWsnPrzuh2tlqaagYP4D8m7MfxfHbM9X2LD7wss+mOiN1kBM4vxC16VVy3Cqf0J5qRcVD0e55KevE3rBQRcDECv+XQW3wX4Ack3Lx9D8Cxdhf6IpP7Sx0/W9W3lHyIpOwOEKIXlvCDI2qoIKIhqnTMuf6AQTqhJ5doXrBiL89uQf6wjN+sTSc1xYK6XSWTWaI2x/877WIFzBKn2y7sMMEwLo5sWCMP2uj+0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwkVii0x/0vXEW7i8v/zddPet/7geYoeGiV1MqljJYTsYqEugW6iKgyat7QiEf86SIJMqtjMDU8uBQH6mpIneqBw=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAIChsdWvujAmHRJDpTobJDHqjDKBOTpH6KJwuKRu0321Zgx7PZ2Mqz4wglaDp57QoZgzJVxzNSwsKHc7enb7INIYZJNTa1piBos5m7OvyOosoB70t7ghWYirYPDLS6Cy/RbXrCzBxu+p/WMC7fCvpMxS8LHamvKC8nmn7DytjKj8pUIJ0sdRw+/IPhoO0346qIdD7FaKpjZQd9DhVA5oQlbUM4zRljUsejo0xEkLWgyzE9NTQh19oM4aOTTJfidP0hgbXPJXdlmzaSCREIj+July1z4d/RWhDBmNf5zWxX3Ut/luS9PB+XKF20mNFPmyaUs0YEWHz3wGRo5wkMdl9t1Dbtj8mPcEYIWoDcjFwlszWQCPouJEk2l4KtuU20o2SwQAAADZwWZ2AEit/AmhgnDMHXF1grhuHMuo7zBm9zqZogitKnKdVBlVsI+YQfn1VxzFiqbAhDZYBehNMzteo6C0JeTqkPwzSqn0wvJx0zLfzCXHBudkT+DNMgoJGhgXNlvl1wCnmReOPE2JZ6zzg1JE0FDA1NAhbxuk9aSURVgcTTNx9eBLniFg89/GvbB2i2SPFJqUPo11zlMtOrXkB9nORMDt+am6NbyGSrJL1mGwferUODExa3p/3txcV/71Cu76VDoAgy0ji/Maxs3OynC214h6RYSuYk6EEVZ3H+e3zLBxk068pnznpvBJWbb01rsXqoWqNJjG+oD2V8FHn24R0H/wr7quqjaQJOA5peQAnE4k3ltAs3uHy3/G0ZHM8EQJTzZdAtseOlIRMalqurA+jIXsVoonEAaSWuSV2nzl04oMHfNC1kUuoZz13RrkC/5EMTWerUKQeK2D+b4St1GRNaIokW5s52QNxGWBeaa/gLo6UKyVoVFoZKthc5zHRe9/UwS5ZILpQE2WFBc3V8/jMx5bkTRV4OjQUNu/m8NeqdgFq0Jx2DDBx//nV8qysF2Co1WNwEpCQCndci2Hk1GwMbBUOzKTTM20fIiR1y0oDBcu7fF6V1hBZx/NMZsw8+JlnxoBjkPcJI0g1P9eTyfgq4ay/Rw/JlxH6/WTqQM30kbuClWWUB5bg1OrBQeLmBTvamjsf5BHSpfZzVx5oZjUcYWPptMaOhpx4yuQz5dtXOON+dxa6K8D4PLu11nBapIaASu/W2anUJ6ODcZ/GiPrykOJue83HLVfGjjnlyU0w+hqEP4pWJXOfy6aS7ZAYc//Ll2sobm+AZqOsm7GeZp9n0V5AgN6jj7qVaPSNr4uRGObRf6/5xfkXeA6oI/ylOYJD+NgP27Qgfox+lOifzQs9DQe8S4gWK2p31BJNoOaYYlBZoH+37jQoo+PTjRehvuSw8Is457QN7Oyqq9vr7IiW09wlb+ZzWsoR+rTWIw7ofWi20SDxxF6glM3IjQnsoFw+NC80fWhKz5dNWkCKEBC+huSrCgN8iqSImuOOFHWsmMqyxpyTjQlwduu0DSANWBgOh0B2VvXm05ZLm/Lxq0Q6G3aYQt55JUuw/cjNjiLbfpavqerV64UyGSeX8lnzC7Eowfwt3DiZfEObvN4hvYG2FY4miEoEmMOqn6UycMDfOwN0Lx6dvZCKNNLx8aGyKhLwNQZq/1JBu1AjCu9LNCdp7BaNIoQwh+1j1UvVLUNhL/Ao2f7vkEgiqI4L2gru95qnnlWaeBwSGdbGcvAfIOulEZerbk/cwtlk5vm7R93Y+5n7UpTl193b8qfb2J7/7TjSoM+rpX5LI9vvByYRkEQzAf04c9TLfD0lq7ii1tfLrfEd5rutK3eiIHPRo4HZW0ULqdHVR7FE0q/XzZ4gojSKoYL77kmwsIiAQKjUxIm/b1bD3vTM/bgCw=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAITDivFpEy8T4YCCDEV/xy0SPgonHjSbzpfXWdgtcQX3EEL6yWl/D9VLlSUjxo53dK57QX4UcelC8SJn/+7SO1KxE6CPJfAVBb8NpAYYhWuXcA37kv5deGLlrXO5lUNOsAWSDEMqYdHvEa0JwpuCLgDfEiBZredqe1FMZlMz4Hr4XkXnjUQB9c4RnfkbYmcMB6bImiofn4je0wEOba46iJMAACHcsujGttKtRNsUp3vQvmbhxTiiwRwU0m5Hj2gBBgm5YkPAWNkxp8e++rqK4Ywu6TK4mQbLIIve1cPGUCEFXFt/02O133zwPx9YHX75s1qz8SSwuMoWVltbno8K5hbrOVaYakonAHxtMd2N2L1g9wWG5io51gLtO3kn0WxzEAQAAABYkBINCxChaV5dQKGgv5mmSPQpHoOT3yZoYMy8XfgK0Rv3EI3BYYaUAtjukmDAmyI42WdP9QHyTsAE/CY6C962njZGRNM+W/IqnMp/pU7xBXzAF6iE27h1wMVlYLz0Zg6xkch+4veybqlEWB3LwmzClHk2Z5cVX/xekpJDDCp2maljScIqwxaKxkKqVQP+aJO4c04qAf/qw+VJDJYLgDY7fmcV3j7u3nUdZAEWFZ5ClaUzId+q3rsK9ENXRwIpfvsMHKon0cjRxhIMDHgi3A2bLsb2Rc1WGWqp/DznpKrflb8CnQVEC6SLyP3ZrwiEKN+sDxFTwW3U4AdX/qNzesy/Rq3LOvWR4jxaQLf4iGTLjAtHhR5/bLqTmU0T7mJm7R5zgND2+B3dBC5Kdulh+yUMRB93aNhDJsE2VpmGgNFql9bmeBTMtKW1XU4cJF80t9cSRs9uU0YQP2/NLJ/WRhgIG70cclxFCgUPq6VoSB0tRHpokMFFTdCIbq6U5LplJiTebVMBMDoqNtL0vO+wdxbydKxyBVPTwbA8nuqHtnWXSlcQ7okRnoudCxOsVVVFANhOyfO6CtPtfevCTZTz4aQi8alap22Nq1CrfNU/Gzv+7MRrD6cf5VoxvL5HssUbdpjN43SNLhKEmggAfNl9Fcpty1N8gGMZnwmDnPbWrebh+YQZL8YmPZJ2n6vmHmP+6edp/at/lpblC+tyrKoD2zDlp+zq6J2h62BkklrxBbwhwJqMd7WJ/F2HiHem7uvt0itQjgZy/V7kqcfB59Kp5iZYQnSPUVMHXxgq7XPB40nlOccKM6gc8Yuhehc+RH0v4BXe9l2n6uwq8n9ta/PYRL91ISI8kChPAFYWTw5HYlTPnIDGCgDrtbq/gfs6DMLzwMuIF4az6ctsX5y1T51MBdmNk8wSxw6RyjZaKJo1umJmrThuSozN70uqu8cCBhmk25ZLx8gP/0894DgIHFDaho+zq1KJVQ8TnXY96jfCvA1V4XhgsZU+iclpA4y1JeoC3VFqFyt0tAwlMUQUML+9nYVyPAywq6xvAM3AD+T1CAkOFSnssRysul3PvVCx8gREe7dtDxvuBbBzMRgIMHRqaGKCWSS8hvBzwrdN7Op2KBm3Stdz4kQLtsE+JxNath5L3TQIc2S2Rkb9knOe+3Tz/UzsBU88asi4QhlD/1yhJN4QlXQHZYcrFjfSvk8zCmNrBFERbUE5s9iZ2W6XznXcPCA9t9tI52j57cKVOCToVKpFaP56W8rGL7EFCY9qxMeDohjRdMFT4RiIZ9TzkAkqWOj1lRjQUYou4qy5n1Gd1WiBKOVKX5eGb4w0DC7m04e9cvVdMDWb3wNRFJKyYTSIUTcEWMxOuz5bfn1H93W/O6UzT8rzJvqHbzvYctn6RPwLyjhIVhc+91I4Y7LrJiKpqmYgKNdWNdGFy1vle/0ByAKIlE7EcsAnAA=="
         }
       ]
     }
   ],
   "FeeEstimator init should build recent fee cache with more than one transaction": [
     {
-      "id": "ae97b9de-ed01-48e7-bffa-c9423b4b35ac",
+      "id": "30a1794d-3ee7-47cb-973f-839fe8fe9204",
       "name": "test",
-      "spendingKey": "88708cd80a5dc81128657384fbba6cdbcebca9a6bd341c2e33d416f792c44204",
-      "incomingViewKey": "8fb1e4ffa36c092a4602825d1c295c34585d96c445f9f2e35ac45a7fe8021d07",
-      "outgoingViewKey": "afac4f712b70374b6376c24ed697b0e9483bae23b78339884a091a53dfa75e4b",
-      "publicAddress": "2d371b7612b2c04d46c0bb9c29e08d6732adc71842f47f305307cfce4b4ed47a0b78d34aaad4f7d78a3f3e"
+      "spendingKey": "47b9ef6dc77092cbf466d7ec9d3a7b8a086fa653fcd17cc372af8d7a5a8dabba",
+      "incomingViewKey": "68db43eafcf597e1cbafa3fe6acdd3d56630dc4f82c6f24725ae9c832de67b03",
+      "outgoingViewKey": "d23ebb4906070a85a00d7f2491a9858e7a6cc6d455fe6d85456c687e6d801ef4",
+      "publicAddress": "efb3a385116c8a7c7e5cb3b6ec68da4035d39ebc345c8abc30c6fc9c7a2eae3dcb5ef01c41937a7f944a0d"
     },
     {
       "header": {
@@ -1287,7 +89,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:9Y6bGZE00c4pEuv84Exk7HRlHWRdfOEZlP6dkDHNEAI="
+            "data": "base64:K+IatZnFq3FCHo7S4/K7tjixnwHdx5t8Kjfre6R4xF4="
           },
           "size": 4
         },
@@ -1297,126 +99,126 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1665619073656,
+        "timestamp": 1668120329625,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "861522E24A2BD8A195D2E15F7D9B1B47EBCA4CC3183AE1469C1B266632643779",
+        "hash": "39FAB5FF6E6F19F5ED5D3078435EBB3FBA5395F212CF75A40D5E7C5649E411DD",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKFwZ6LH+b6/EEMHWEzSC3+Bidtn/MDK//E2XknsSOJqHYytVkSe1tFQ4epNbMvkaYwRRqqYa1sO0NnuO/lmjb5+8O+3nDaeVln/ZZYwoSgdvaa4tsk6RlPGhpyjuSi2VQ+IpZCoGuwg0KeB8Tg6u+wZCDBscdeXX39pX3u4Rl+9Hr6AYDFEAZcwBbklFRleyqi60OdANniaOCOaVj7Zy5pyZDp6V5hdjPfisYNW4SEzP3IWNQhTtbj2eyJ5nuy6EKpkxlpki83ZLPh4GtiXu63jY7Ar0YU4KhVycFmQ2R2byC/p4fdKVZjI1W+snaEDB+b/85lF5s4xNTF92pHe5QlUpHuHDWCFOzSAET0KzOZcyFjoxLDU+c2pKhdjPUJzHirzwaK4mdd22QzJ86dJfzQeDAOG4WhLV7jrLD0JiNbBjZqZOIUFbt8YvgXM9bZ4VR+2JthbDK2ecS/hKIHw53vm4BhfTfuL6SKJ2tcpGlixfCIqAjmt3ozy+dcj2p/Ni9fo4kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDwzkT9gNA3UEj0ndOlm5RltnjhCuPNFr9QDfSNumboLU+C3c9aiPuzJTvl7iyIP4CaemdSyL/2cpZt6c2bgmAQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIURU02p3e+rCRxJ61+vw/kYu2V3Em1pNUQ3QBKwcdxCgKLixD7+fG+sBnTDv2Wvqa6DJ+Jg4XkuG1gvOiTcdXlH2t4UAJrdBx12hK/snT7VVaUVk6ZTWGE2np5hef3+hA0vOLSTWJsH6tl0VLdJKU5OzocnbmfGegz74GTdIn8YNIfEH8wf650/mETqfkIhNbKVXwFUeFPrREC4ygub05f/Hr7kAVcsRFvw0wvCRUH/hbpA/1tA3Pp516XRSil0WvgbB3MN1GCUJajbl672o31N0rqw3fMsCRrwmeK1DsG9t8IT4IkPB3T0mnmuaHolX5CHu6cVgJzoDHxeIQBcvggzl6VEkEnEUYzJpXILm2RTGBPnPY4YgknwpQItFUj/z+bzdTs1sKTA6+g6MRA+dH1G/0dGa5OWb5XhOzTHmQuDACgXg9GiJ/zeRLNpmvBfY18Gn9q1h/jYsyVGTAA04y4GRYJDLasACpW6HjOx/KeMNvQOE8Z2/kStzBgtd5sqH25qg0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxt5aQaaTmG+w/HMPHqhvsLa8oL8P04mwc+nbxpnlVnCHZc8aWmZCOz0GQJa9gKgc/RvHoNuc2TRckPvYK/ByDg=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "861522E24A2BD8A195D2E15F7D9B1B47EBCA4CC3183AE1469C1B266632643779",
+        "previousBlockHash": "39FAB5FF6E6F19F5ED5D3078435EBB3FBA5395F212CF75A40D5E7C5649E411DD",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:/+oecmFDbhL+TjGSjhYmTsEtLxx5ygnA4slHUM7CESA="
+            "data": "base64:NsgVcVgEg5teg0EF/4gjGlt7MWU249zX1YETLhD07TY="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "F3CD2DBA04F1D4086EA9E17F778D169AEFF21C874685FA60CF81350E2B626A99",
+          "commitment": "BA16F0FE0A529B208A16AF65EAAABA1F0E32663A6FA01A3879DD716564F2AA78",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1665619075612,
+        "timestamp": 1668120331993,
         "minersFee": "-2000000010",
         "work": "0",
-        "hash": "E191B3F039340C87F7236814882A3A2ECD6CAB2CAD91C3C4C9A1D265B1F5E7EB",
+        "hash": "2D074FEA6C80F922CC2BA91F5D25759C28A5FA6C0FB05B8078AA2D8FA33DF8DD",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAKggGUu6x9p0WpxThnzp6AqdHYswc/A4zXcv6z0a4WrtnJrAzkjG46csRLzihFTPPIdB3czlc51IPu91bJcGNprr20/x1Lj+gzjpqI7AkEp2lAgYYqpp3z8mjmp8s+GouxZpLrH1/GR+Q4VC1bRv4Idv2jFDRM5TIa5GoFHM6ItfdGqRLybxgcZAW9oBm4hDcokS4c50zy8GLXGWQB3lZuGG2XYs8pUDQeSrSEqUARlx3efjMqzPu4WIdFpvIqXcFYZwzLjJWfW0RudHYJLM3S6VPXVHl1LcqcAClvOhMRW4OcTWmbRVmJAoLpztWHL6/8njuZAIticPkqCHtSLsdVj7dzVj2UYIfAvfX3ho6t2cBHICDt29tFWkZbKTbopc2o3IR71VQcT/7s7yfZGdqJjMVjYbyJA10H7OgcHf9I0ZF/WFtU6qFIQVUWsqnY6L++XCqwUD8LPZnTvKnMVtEpGTnQFb9haoIuA9vjOQQQFBiNIt7fdVgSs3D80Rtx+XkrHs/kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8Qe4VplOrgrJuZjrJz9E83vSFkIadfqM0OBnvlmrHjre8qHFcbS4AaxyH8En6ujN0UJV3mYODW6jm41PrcD2BQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAJUlzjaApC8MvEG3KHZ+9a6xFlRBEzTvZFXtOeP1931tQk2hgBe4uFcR1N9NzegaaY3Nl7+BO44FYaK52LLwS2b3Or87Qnt4V+l6aGAgYTFzcS3tYJZfepdtoAbOzHpoBgHq8umIfChdc4rwIhzLYJjkFXFOtG14uwal2Wb5jJriR0QmdOUIDEbxZKcZqD5Jkpdl1DrZRYLGKC6caOqpPoml2wLdfe67vOmc758Ba/AeGiIBuYv3gGdJ39W1VlLr/m5mn/O2rz8Fj13XoWCavVLVsKPDRIPyaZoWczhdNzsCru4vLyIGdFuCumJRzImj9jCChk4CjpSixtiyKOLAzjBEvWx83/F0BazGukDetbBFBWrIGwvVntIkusf5Qc3HqcpC3GxNLVyjsWJ5d0VVOFhkIVFc3tP6YFv7mBYrtXMYd3D2VvoJonEbwCPvXbB0IyfPDzzxlEvCFSCdws8StdCWEbf3AntnucSKveagR1P/3EwPYQSoRBrq9WQMm5+c2di5CEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw7ZFvlKdxHDDNP+EX1vqPmdcETxM0b2S7aqHQU6naMleBtW01HqIaYnjPxs767ppw41G47zablGQweBAKfRA9Cw=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAKP3Zs3ihySpmOrAeQVu1tLlpvzp5QgOmwKu8cdEj7AaraZqh9HiDSuxmngNBQPBULOfQLh+Co9+VBMANdmuMl5UXY0RiXd6u6Mxb8Fb5p8AOQkU1axqbrlSgG0WM/s78hR7VQEV5wUwpcnIa/eMMzi8/TPTXROCeACPf2ES+sO3imVpUr4hJ+AzS+ODClkXw4FDTewCDVqJClefFxglyLb2+aUkB7CYDZ9iBUX7UqsAdc4P47Du/WFQ2kGMsskU1Hvgc9lMKwtFFahta7qxkD+Bl14dNdUC4Mp/ec9sdimB85qgbOsfuS19uzDzBgOZzkmKpMEGvAAcSmv6paSGx031jpsZkTTRzikS6/zgTGTsdGUdZF184RmU/p2QMc0QAgQAAABu+/leKRUq+b0KdC1C1Zq5wM3kmPgrnmZ5a+Cquhs+BbmTkupObhhe5/t0GVevC2oKo/EqVwpl77vGVqLfQ+4ziNNsZIRrm82kVicF/Zj8UtlShvDqDeiocI4yR9QQdAmk3rbxG2xjXS/bBdD3j/gi5+JJiAbZ2+/2txp9PFvmGGQXyjPP2CASx4KqUbAoZRiSeBcQK0tISnZZjzxMelI1iKFa7NZESGSS1/zYF8ScD/blWy7TQLZV4I+xTvdMFyAIca/l6K7mE16e9HZBFu58+F2cCJRrfxPxxUcJVzOPkG38s4+D8hcsMZwwfvASWqmE3OBiXc9wKuea8ufjKmeVpbUU4xQWxFdGpAXVGtPaO5+KMj2PZTpPJjkT9cZ8X5W9gr0ZpcJ2mzyTfq5lxAGcG0szepFopPdSA7eoQJMXLDLP7Cnx0dO+W8dsusm5I7P25F0diCkmJzHeyJ77OSEGrG0AuKUtqLfD/p8f/pQVikngl6/u6VQItYAs9uasYu/xptzaKJAMwTaz4Gh3O6N8g70IjeC2azGV7Rff5wcfojFscpVfUMSSQ29MDr1r8eYtHKXdA/POUtCWtDQfcbS3EvwwN+GMA+C386Zz7GAr9oZz21UPw6U7A2IuGf7+ZkBCrdgyVqlJq0xC60dkIVeMuq2xEKunY78OyhG234dobqD7fyktTxXlXxT039Eez92Gu+8Dg/uPF5eTioex7YmT/R0u9BxAAuxyB3GWc5K5Zldjy6ahKCrS2fe1QdLde8bQdqomBcBh4X6qtOY2M1FT+W+JXbm+VFth5p09GIbeY0Mqw4qlIyWCDbP62nkxTKVAUTlUlRjSQ8OWZHRfEK6Yr8s+ch3cqzdfcbdcMq7/UsVwSQfIxFWHpSrAePFGAxMiW1Gn7yK9SlqjIV9+lv683pDsfTyg83JugbCF2gy7vbTiO6QLjXh7IDXVPylSvE2C4RBb31AqsNCzwfY3sfuOSoDOIlaBNZAa3oCOgxPqs+P3mVHI/s+jAVXXM2ZUA/ErfAms2EeasFBO+zmj8VuLeieAx+SduBKj6XMOl9k3XmQq0Qh4DiDLEn1ATQ0mzGm/m2lUud7GcSKuZxvyoIFSdWF0hplDady31LEchdropxsAIViNSOUv3mvlMe/WTFUcdzIJfxXIbeJxvw2NE49TWpXZeGXAi0u4BNKeF1rfrFQBJVCC87MRG6X9WduDGmGSJZ6JtY2U7dsefOt1cM7IcEcI1GrDNUimnBjQiKG89Z2UZEXJ1MxncFjx93HBJ/9zpWt1iqdiyq34/sMAUYjcqmRvX/y8EAGwx3Ch5fShh0cg7fMi8dHNNKefUWbRmk2nDU7xAMZWzJTSfTQLfMP9hfkmAq8EnbM/eMe4JmClJPKBmnqtO0o8Fb32uAwAXqX7fvP1U6DgmPLHoA/7315qYKwWUt5/ZNimCI0F/v1VlVztrT1bBQ=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAKcGVnsyL2t+cfIS1VLukoXiMGUiEkqSyTV92FE/rUEPh7OcgU9SE+cJjT63Z6xyT7i+1+RjhV4srWHuO4TtAI/9eakCvvM1rTbI7BbmkBjMn4p7xF06tjQU3UtU14bqRwVD5GLt8zCwT4VjUPeEEcgRRvFpNmwgNgUfPwDTG/biGEW/CEaBuycfEF70TP38R60S0GfKvp3AkMcK10tm1VnmxIb2YE0gEcnNkHb+GWbP1lQpkD7JhevszrZIkpvx4ADZ3Evsp3wodb8w9CubWjhCYi34KCiuCOKzk/4kCjnuvNebDwKCSoXMXO2Jlqq6yVRI2wiT+7z9xOQooeTxSVwr4hq1mcWrcUIejtLj8ru2OLGfAd3Hm3wqN+t7pHjEXgQAAACZ+s1d8W86buQTUgL5ScLGGju2dXQJBcZEzOt5/CiA6z67EsmO6vu1lt00teIEKDc+JoOLg2S8BYNTRgdMCcVpokH/AyPkInY5Li/gdq/kHtGqYvjJ5A0l295m6qAYgg2Unqb/UzwtNNI+XDzUHt2shvT3TX4i81xgTNhI+yrVD45nveIhVG7xrk8N2uQnF3O29h0Sgcgksh++dSL+rmZ1QNr0eRyYfbQ5/hX39FEcz17CmlFbO4gbpnt3Nhj1HT0GS7XTPZlz04AioKKxrzhuWThRY5OLcQNSGctk9kB8O8MvoTDQfe5JAXG7NdpfslKY+FTc8iBeHGbcHOUMc3SEfZkpTkpelR+fCLpqDCl6ozDB25+Sh2DQnOjfUOYuwfQf1glKPxBammsM+UHcEolnE5OLtraXfl74KxKG8JTWCT3mN0pqAPSaREzzKIG5BkxhV9Aoyx3PYHGMxSQMjxMOP8E8ngmIKm5GU8ktFQw4iRQtziK2cD4s8AfZiCwr/LTPxlC3PhZnbg1jqByHlBhjqXpVUF5GfATHRF6Pa4zqCZKiYzZqgpqp8/3gPSBFIS/C1c5zPlvbqf1Li5dGz5CZ30Y/fOOjML5QHA5FkybQ9GZxlptyW9endCsm1up5hkG4M7LpBrjUwpS5X7YbjB+2VwHFYgd3H638CS5JcZCDufOSwpbqqIltIc0D90/Ox/fv/kq/CbLjjwA08hQ1NWkC55m4lkLvgXpF2rlPf8Htha0DwoBZH3ZqjEPPAtm2es4nE2Kj8WlgTxAiMiU6IDR2dmoeXMndYh0nj/spXaYA8Rm/7bIaU+aPqyabjh/+us5NZ0o1YYnWIl0qyL2kvKFo/8BR9A8fAXLsn7DQ10bt6o/WKQk5pCfYCAAUoGqbmZcWsBUvecXV6vfFhdBPp0uRudnOUFJnjMRebWl2TdGMpxl7tqMkDo45O9lbnxU3ckzrUTo4DNXGn21S/SFwyTQqZhz5IC6bQBdYIDvkoSAzd3xRcEmHYdY/lA5L23K/GwXi314whVpl3vPxfk/W3ifrhM5W4z0RqhNlShUk8lujcbmgazlm+B1VCUlSTQi6VAMnqEqrzBvo1ySEqi+4zgksA1ybwYRMYnr266p28w2mH76nMz6wTs2+OsyY5aEEFCEUpMoigtyfSkIEKLVy1ZX7D9qtlKz2UrGqdtaOTO+0bH3a4/yM/CuEwKXSGBbcuhD+SURmMbycVSOzn0tgQnYiUuO+HwwTVj74VBg2KzOrH/msf0NxA+7YlpP2GgeZHHXABe6hPt1gtyrj2PQ39HvggxQ+J+tf1xVfwo7tN3hIc4TRozHdKFoOYps4H9RrrzB2LwGwgj+5a3TBncGcaMigkOKbzBnQo8d1x6QO1Jeu2jhBzdRorPcxorR1xXY4L+yU4qFhSqffGEep4u2UrGF6mzrKfuVqIwoRUEESc19ZUzWE2GYEAA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 4,
-        "previousBlockHash": "E191B3F039340C87F7236814882A3A2ECD6CAB2CAD91C3C4C9A1D265B1F5E7EB",
+        "previousBlockHash": "2D074FEA6C80F922CC2BA91F5D25759C28A5FA6C0FB05B8078AA2D8FA33DF8DD",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:/130RNIYe7A1K6zaOlhnxPCq77++bsBWOxE2doLXr2I="
+            "data": "base64:SnwdDIo10aDlUbylvE2+h/UDrKG3H5GonYsilWvI7FI="
           },
           "size": 8
         },
         "nullifierCommitment": {
-          "commitment": "F3CD2DBA04F1D4086EA9E17F778D169AEFF21C874685FA60CF81350E2B626A99",
+          "commitment": "BA16F0FE0A529B208A16AF65EAAABA1F0E32663A6FA01A3879DD716564F2AA78",
           "size": 2
         },
         "target": "12096396928958695709100635723060514718229275323289987966729581326",
         "randomness": "0",
-        "timestamp": 1665619075840,
+        "timestamp": 1668120332263,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "559B21DF7BA7180F6C94C4F47E28D6225F97D18B2932B2B63283D18893EFF4D6",
+        "hash": "9AF3E2D48BE7D7A28F3E1AA1756EBADE947D0D2D46290303F0CAE6C121386AC8",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJl7W5QZg/tfo3KpPAY5r4uf/ztHYMYrM0Hiw6dSfk0NWjaAgOuGezUA1mtFNetWTaa7ag7+e6LcM7tbmA1RoKXbA2tziF3pOP4ZS1n5Vyy0CKfQi9pfb4RJGhxKBPytsQ9grWna6fGAH1HHU3kT+9KQRp4YKVg8dH7wL9eKeuO4Q1/yLt0zZSt/M8NSB0MfS6l7BvYn3LNij5ow/yv/0+szFfZ6bgj9E23uoAfRUr6ypvY6z+Il53nnchnesdOJnk7Qw/h1DcHzofqHfSR6VcDbwbrYX/lyLDmccadbN8gkGu4e/Q7gQYnfxo5RssNhw9Hgo7wgU0XTmYx6+WZlElENchxZIpsg7t7nIs1GdJCvPPM/LuS+3uDSNiDtiLupsgjdFVQASv/tlIJsVyWzvNSGRu8Rp0eJuYDjN9SlIG2ai83XLIY48OiYdkpf1SEdOJamscCOrxc3Y3kLPn9XNHOoD0SNuOjaEXzJSCHfYp2Pjr5lpeYE6wkiUP/2VAKcJNX9lUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEhZCAsdQoRVXTHVQBuwCLUKStZVNf+Sr1xaP0WmY7sureq0VcgTLAGpXFx2LgkqbJT0KeS4uGxSdlFiXLLG+Aw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKXJan90f7VEbRVQoGhWc6ka7ybZ7izRwl21GA/0hPjwCfbeMV3oAQHuU3JwNyPNuZgj3ywHf1B+I7fzhb68wrcdENMGkI8V8QQ3TuQYaudTp2wibUNZqFATRR9aGgJQ9BY7qg19BSH3ZH9lotVwsypvZk5U6Z4CJ4q9QXYg83Rhh9gQRKys12/8vuags3LWz4PSjQczIgRW+0Sq876CbyW1MDqTE3tun3GQ8LDZmNss2cIO5rSjZ8QTwUn7aKOFXu0NQOXHfjYgx8CiEpm15DSPwyTpjcnbW/oNCrBpIzuOMEAMhuiwMn3jTtBBP9g6uS7gM7+KhpwyOw4/RU/Qymdp8+1fr5X+6sxJ6PxwQac3OWTOYqD/paM3bOVsxecRR4e1UjVYk9C+dCbLbTN5veUo7/fbNZrxrwb1E1A8VQZ0OELHLomQOevRMJZUBkF9DsZlzmuBncWl0v2x4V+4K6qv3MKlnjwDqMT/rOIQxRX2DYOFDMbChY4Q1qMgM+tb7wRRnUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0Hkxd2gF/W1tFSEQpy2DXkY/1eAjxfwqSDbnddbfLu8sHsylGtO/cQi/tmAMCvCq9u1Ew6k+tZdbKKXPLdXBCA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 5,
-        "previousBlockHash": "559B21DF7BA7180F6C94C4F47E28D6225F97D18B2932B2B63283D18893EFF4D6",
+        "previousBlockHash": "9AF3E2D48BE7D7A28F3E1AA1756EBADE947D0D2D46290303F0CAE6C121386AC8",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:fW9TIgTIuDaKSPKOR/9j9yCKG2q/ivu4Lpz1eNeDbBo="
+            "data": "base64:jLxFpZ6w31KcGiBONsloGVQAp22E4RLA1wkcenNf3WY="
           },
           "size": 11
         },
         "nullifierCommitment": {
-          "commitment": "B778F84D13F534F34C3E9930B18991686E1C5FE11EC7005316D1EE5221DAE019",
+          "commitment": "257D7942F7E94780D3D4C2D64ECD56195BC61FA532997663C59FF8F058A7D76C",
           "size": 3
         },
-        "target": "12061061787010396005823540495362954933337395011119300165635986189",
+        "target": "12102306258185349897699630071968783615464071387541038817732810713",
         "randomness": "0",
-        "timestamp": 1665619077797,
+        "timestamp": 1668120402086,
         "minersFee": "-2000000009",
         "work": "0",
-        "hash": "A4A85F8F2F14C24F2016357CFB19D58BBD9292A9D7C7DEAA3D8079F351B1362E",
+        "hash": "768339F3F604C632A0070DEC77EAE41DA2D9BAF019BDB45503ED15BCD87FCDDB",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAI1UtN8o3Vhrst2I4r8wCXcB7NPF9v5vnTUkLgMQbko1b6wmhGkwxb3rtnZqm7GDAIIlVzmC0r3KqC9hhnR06nLkbzy8mtUGsLpMNPf0E04YQ64i+JaRyk9Dw8Po+ibVFQ1QXteqLeB5GbX/s1h4XTPXw/My1BjKvhdCmaChMKQ90yMX1ntYu0S8yE8fm4tPuJJ0ooh+y5s3/ovf09AzREz+4m5WUVJPM/HTIRKMO1m8RUvaJkkQ2kup8RHJZ2EXykyj0YIulrwB7BisCo/qj6rIgd7pj7rUMkPW2hViJ/0JGoirdpOuz+tP3KL+eMcnsckSTtZEtZWIw4aDvD34hWQO+/u2SpLuYzru7Jqu3rUAzyiczN/XciUa0AAALgMK1RtUsNgZoOVhd+YfOMfIAmmA/PYc322kYAoTDBs6XSvSZ2/hdhSGnWo6gzuWqxz2FJ9fkW6KjoxwPuIt5yPascW4Db381DDcHCn66XFIf2d07/79Cq9BAKpJsTYqx+DKbokWPEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwV2uSycrk7qCcVu+0zz04/0KNVII3jAUJuSPzwQwkXOhB3xascvxwy2UPVmc0XoYF+BZvLOjfvnDBvHsDXnqmAA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAJh2hFMq0sTRtDeYMiFNphZPLkZLHsE+j4qAyQqgwku6v/QdFuEIy4zrwpfVZAgaZKTwKmLv9RO2a55947diSDsXBeUNOZ0kzxuhcIicTbqWk1/yo3UugwGeFmDG9btZHhm+yzJ+bOQXDp+l4fXMO9iP7afT6pgjJW+YDSkQjBgoQOsQZZV5J58zgEPBGoUkMKYDbNl5ZNI3ISpA0cH2rCzFrZPyEy2DlnaKIDFARAzxVE6ENNfH+Ad7gZQx0yfpVgAMQbmw48IgRaJKivcoIEfJd0IB/9wxRCQAACIGNOJj5gLVVXCLsbgBsxW0hjklSmKkz7a/4jOScyNK5X4YmkHjuET5fz7GOIM6z5ZaAUtZT6jrQm4oGJe5WFRNWBtYG5bwHJ/VknYDEqGJGZOGrUPpceSsXnmSRL2ESLH7AI9aCJ3yi/wo3tSK4tDp/QEPaBcjqRdbInfgRF53Tikf7MNkC9uEE4+hG3+T/f9Ec01SNiVH20U5ykVAlS1pVlx8qJ5maUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDU1YI/vIpm1Zl+7ghIDt39bZA6ft2cLJd9E0rfgvFkKndOBDxsU6EfBskcdg5x3efm8aViZtE7MaEVDPMGa7Cw=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAAIOzSKeQM98NZaCcXY4Oh011DSUeKRAHMmPy4PPnUga0vbG3G6S/s00beHQgpVJsGaIsYOtzdhKlOj92ZYq5t6E35PCINlxMj1XXKlGXEmONZXIGrTv2bg1RFX+7KJ6bcBYaDgbQ5Fu97VcVrcMgYFgZAOCbxBLoepakZ+6zkVfB8SkiuBj+y/qC8N+Sj/kjcJIBQKFJ5V1fSHnvQsuLE17qyTfJn1XyrrXWV4U5ViF9xxODaS0gRRVDOdUvbg23WlcbSJ9F2qZsRt1+yBQVVRu+XDkmaGoIi5jEKrJi5zckGCMiEF5HR0tCWmPsQ8kUSs2qOmjlBrTe0j0DL0SxlkP/XfRE0hh7sDUrrNo6WGfE8Krvv75uwFY7ETZ2gtevYggAAAAKl4WSuAGRzBXKPcc22bAXbKvmfHgMvSF0e7V2dO5denkwFYK02BsnrTVacdLfIbuIB+1Rv3cE4NGIO5U4kGrQ5nH9y1lvk74KKTWSy/Mf08YV6/thrimkYo34Pt+xEAiEjZoIBqSntAt5g1toAfvoY4TZJR5pCRTxn7k19MJam1Pv3x7fLg0OH3boYHLpuQmXxOrqLPzZs/GOmcIN1s06JtOt5AQ5SaJBMAkytziVIRnnRWaf2Aix32TItuiC0+gXIgSE7OskQUtw/J5gs365Vj3LyiZFMblMAkp1zWeYYVUlK8VU7ScPNRAhYRQSQoukcamtGP9EmQuMGfKwzbx4og3bv9eEpKnJHw0kCNev+MwuwSkCSzF+MrrVAkO5d1SyyAEEcQGI2TZAe8Z+oK/bNK/xwGu3RV8+HNAIIVLCPSxoouOgUI0CwgqAp4LQIUiFJyz1ZcMFAPsRBxsFOlUy315G2xZt8Iys6AtCmVv/Ij/mINv/ufliyDIkSZOcyuZiJ2r7n3lxi2pQfr0nph4HVx25+buEfk+JnConoMqjjJW2vnUcvt+UJvK7nS52ZRhTkn4Sl1tBPQCmSevVKCHsPyVLuvTVd1KbbvoO0Ncmr3hIX4tPwvbmCW4jk0MvZA/+cSfbc7M4kf0uYtZzYjK9ghdJWOx0+Mw+cOEUmxSmq+h8AjfQWiiZ3gd7u2fxfWlBR/qzjSgjoHyciM41pzVtwQ5Yj4PThXiToL3QF2E4BUKrr6BwLy0sPVnP/22zhJLoQjhh6UlJyOoIR+X9PcMdmaeL56jvEfADZIyKkiHsqVoYnalerULzkQB2jxL4AOxgQ1R1GW2m6ElIWQNs7aikDy4hluZ3EOxIpKSK2MXMmRWgpABmQV9+LpK9bTgERjUCIYhWesWzF5u9Dsn8xSwS8esK5+Sa30tHvT1D2qS9Fmctw5L3t/5kbJteQkyiZXzQMha2XZ8VkdfIIy/VJrhXNzd2xjgoKbmzMznY0CvZYuwCfjrMIRCF9Gm5OeGym1n9VjeEhPwpANrqaknK3cg+0fOEph2LZcBuJR+kiuTBBtR9twOt6s0xtbvF1f79pBxNxxrnnAqJj6iYCmAI7t51WaUpBM4B38PmbY5EzWDeXbRJoPBJdPyorxVQzBOWRvPoK5ktmjTAviTasgi9ZZFpOwJ5SUsuY1fs2pzjovxBslSYK9HzWMItm/yOL305fxF3M4yctbX5EMfygB7eNWg/2vNyIcMy+mEr1obRiF6k3VnXu5AweCXosNz8srGVWU33QQGzjy5Qov2ptOUodwwYL4XoOXMP3XJH/LcImNQQCvFXpxePQ3cHunqssxnq01DvYx/dNr6+rAWmCossFy63IPPjVJ2xc1xL82sHIXOBbUtCdJTSK43BTaY0j8kT7mcTelppAeX1FcMgF7gMovu8PUkmjqly5jmnZ+j4lQcEQNLT8gYTDA=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAAIvP+EQJPtEexzhda1eXgA8SpdapIOXip/FPHhmpwh9qTBVZGDzClSWiwFifum+kJ5YshxenxUpk9gGOOr3vvXo8pKqF2hTQYoRsnj05tpymJf7DsMu+9uGGVhJfb/iubQRJ6WwfVIhYyJqEPkeCuo+Z8ddhfKYR6LVC3sn212amhMIAdhv2ZzG/eFKy+2WEX4KA5VSFRH83hl/5qli1kZpzKPZJ4RrbZr/8tTKgNQc0kQ6n6jXWqgVnPZxQtZYvaLwm1UnDfhWNdOkXPhgqxPMWcEBP1L0mb/t+Ox1WVxWyw0+EQEqpomkIj3OS+4ZXKMcPtU1843eY45SEV8vYtEpKfB0MijXRoOVRvKW8Tb6H9QOsobcfkaidiyKVa8jsUggAAACbB/0d5vJvWOBZN/SabjZbeBhOHBUny/M12Z/L7mZuX7y2fIbvZk9R1MtLgh++XKgWOQU5ah/1VVtVb1RD1/Wt6ppGRCFLAM+TMSXUgVfuNruj2mfvhUXVeXHJu7QnBgKNpqvo04TRRFrxFy094kFzCbY3o5DGhh/IRWr+flYtbDoi9aN2BSbfg0pIIdh/Dq6vkB4SyxaHFP9YhTZKCjukmF3mj91H78SqDDEIcfJF2pBxEBaJA7VUKeNeHhaYDtAMU6aH25Ym6YyceNT3SszTUyx20fNAQ8B3kmg5QJrSLJwhpR9oGY24EhwCv4RHRr6RgHglX/qVT3JxnJWxLXrXYnU4BEkFM6ncuOHiRjvGKu1YzcfL4IwSQEmIK+9jNjznPGBYkPKpGtWt4VZOvKscDtbZ4GfuaW0GwSLjfeKSopBNihr4bMTntDlArLvnR5XsWAqYCtTNGyvRaJqojbMCBvmBIsEKTMyfcws0qKW+3RWYCitT2Gq3x57/ZlZFcyk43INNokBx7uAR8taixLDRnZM0dBWxBCqb7BCOdxn7OCbLbO6X3gWwOsC7G7bO373DGabWM+2UtkmVnD/ob3d0Sbh+H9WtoqyBNPqQwTO4CpP7IZQraOYmPzoM6DMBgHmZVCsfvJ/U0pNIgL6zhegvZ4+4vFSwwKNNTR+FrRQtEu4SiMaOo3qaJbGk1G+xx/fmpDVR3FZhukeywYmttaYjwbF43qiCGzAFgFoACVXHpMA1RLWRRYI+KN9HPVRk7eXMimswsOr0Ao3a/e/fmdvlMhJ7sf0rdLpnmeoV2x6cC/A16qFscjkxeR6WnDj3ok7u060hxgz1tixGliQPV14zpvptDezKiJDWpzHYwsk2iVzOKhnUDURSCDpitoTLCP/p6iIDLffWiPY9iWLDa2b0T8ir1cOB7DVLlmUdUmbqri1nzK4yUChJs4rNRNsdjGqu49InspQYTOXjaBI5bPvycNhDPFaT98tWHgw+BZSuCyvwfH45RH1TkloTHHHlUv/I2CxKWqjnABpwKjmKV+ai6RBpfbaUrJ1rjXbVLpU6Uyj6SjuNDzFGLJFWut7oezyEUG4fx/h0wg2BGAeLWUYwg08kmHlzsC33ULGA76IZ8DXNOXgEEYXBBB8dl86XopSMw+FP92W742Jz/wcxFSJkTFT3xit4T+tm0eAWOTni8+3JD/s0y7uZVpgAnCE7sDc8cRjtKbjlr7QMPSRB1AJsWsWcrIVhc+nSG3+HXIeCKekETP39tPaaja+HyiHpBKtAa/WxYsIeTqWQjOX3q81Uv8xPNCQW0PTkK8yQL6OLYEQGwmOwRq3QYFB/0owa4Le7ADerx6Y2l91UvMjrnT/TPPgDzZ+JbewRfS58kTmx8S2vdT9IdQKuYw5W4CtoIeYAgABY8VIsULQDB6jj0QCeSm22A3Z9WPrYT1g8r7gMoVavWDtjAw=="
         }
       ]
     }
   ],
-  "FeeEstimator addTransaction should add transactions to the cache": [
+  "FeeEstimator init should initialize with the most recent block at the end of the queue": [
     {
-      "id": "8a6e70be-755d-4282-9bde-6bfbb20a93dc",
+      "id": "373a5841-ca68-44eb-bf17-6e91cba9b6a1",
       "name": "test",
-      "spendingKey": "faf8f7ddad85cd5b908e67f9aed9e853b91bb915b0d6868a9e57b817b69cfca3",
-      "incomingViewKey": "e34fbfa2252b399a5a4ca0367719a17752d07f74bdfb61f1096e4954caa2cd01",
-      "outgoingViewKey": "730fe91803b7d3c8077d0cbb0d9b61cc385069e27b103525f2150faa72d336fd",
-      "publicAddress": "301871c363201eb9990ddc0e3a3fe76c1d2d212a8db0106a74a168b1bacd8e19fc84987e2d52e8479737bf"
+      "spendingKey": "49024ce5d70f36d2d34a2b1eb2cb3ce44e13e47e35374b7d3331e1adc93359ba",
+      "incomingViewKey": "8ef819ac6f0cc1fc62da4cf7afe37281ae3955767c1ac26cb64990d01cd50900",
+      "outgoingViewKey": "0067a96b9d8abded3e963c3ae4d7bca60006e77b3d62d300f8213c20b3166dcb",
+      "publicAddress": "43ee7b18a6a22cc291731c20b6ffddab93fd628e925e2f97f966d08fac1e194f525fc627e6dff00b01f268"
     },
     {
       "header": {
@@ -1425,7 +227,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:bMcchB60PsWplGQmSSDN0Xluzis4YF1slZwgVTOIaXI="
+            "data": "base64:u9Un0XwMbb3JwH+v7MDKQM1YLxHfDhZMyq171hxo4SE="
           },
           "size": 4
         },
@@ -1435,126 +237,96 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1665619078121,
+        "timestamp": 1668120334976,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "8C48865CCFA5BF98E361B80263F11B636F85BE691EAAD16142CCFFBCD1D9A5BA",
+        "hash": "A2340E8ECA2E4A10A49A411461E4E9B019832CA5B0EEB2DEBF00C2A2A3374552",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKLg3ZK4gOxJD8Alf3Wx+uxog0ik2gE9W6OQb9yUPjLnBSYu255+IRiZrkHFW81KW7Sb6cScZf6+Eil1YZVXNz3gZu/iR4TdSJGlnZ9Hgdc6D2YUIGIZY8FkfVlAbQbvIRFkiNhjrsubx/o4dXQUgzckd2UEw3zc5uN5BRr9MpnvoxOThWS0QytxkOKjBtEPmogG1LCIbaAmct94ubhy6j7JVD0eCWoFZe78tdUouBjHD3Qqed/mYMZKlhaf8tXsHfnOmcaRWK2UUUaYHgzl5vgC6KQdny7Kt7h4E0RwBKOPc2fi5NEsrPh9V5jaX7khL+vyvY598r57qMoLJ28kHHC6DaxGAqQVTePXhICYV+lqDMUXAtqUBEUixKGZl9kDzQJI9R0iEfyQS4rcTI5RxDDFD9Zw+JVR84ml4bot8Jni98exGGVZaeUHnElETijWijbRAGrMDIU2ez3oxbZxTc7Cglr2slF7n5269Tyj87QmV8f+lwFYUyN1JVdFz1102lqQCEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5BY7kwA5cCCD83KZykH1yduHDmAGnishyMLa6F9oNoJwylLUN5N9ZLpQRSpC1rX3N1NtYUi5TrITaPIMUg3ECw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIkCTVZ/XxYMxkgBrNFRGxxE3eQV7ekQH6gHJaFEXzCsXpAonX/CZGA03HDMaziakYoFlo1fyQhtxDPjGQu1pFGvH/ZggB/6i/gfn7RzuW0OF+86t7dmJNdvaailF0DwxBPYTpMryMqeIGq237HO0QzJwJh2TspG+DyWrk2RoI0VVDLo5E5mKlKjrEm5npA5B6jrh85rFvORvSEsOuEEROBCQV1yMvDD6FAO2sZYszJKRUgvPM5cqU3qtxkOu9e3e0u8YjqBTUYoi6aGWiRv8RC4jIhQxtg52hAyvtGimlwNaCOYrlLjLAAbbGO5DW7iCWhU08wFr4vPjJEnivmS2Rh7F3GGsS57E39UPtLnaidEmKqdjYFcmT2p4bFtTMEItAWWpqf1Osnj9inpP+6Kx61VtY9V3n8yLK7GtCr0fdhYF8WMD3jTSMws5+M1dhefk7t9OI8/nLdxqVOpdOyv6+N6nSNm8QU14yF/fk4a4A64uV8ECuOt30pBVIxZJd5gvAtUc0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwfpiMdVqquSXx0OifkJa09r3H3ofX3JvX7BcqObZKs2VO9OXbNlVRsAQRMokfhYmIKL6x+d91XAk5fPNeMEjyDQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "8C48865CCFA5BF98E361B80263F11B636F85BE691EAAD16142CCFFBCD1D9A5BA",
+        "previousBlockHash": "A2340E8ECA2E4A10A49A411461E4E9B019832CA5B0EEB2DEBF00C2A2A3374552",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:ojWKUZwziu2VS+KGJeYb8xmS/ilaz7RwGhVdGgiPTjI="
+            "data": "base64:g2FaMep9VRzqFe2L53PACUEwDFzYTEaN6V5K6wwiayo="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "8409E95EC8499AE06E9904C6C2A290225B42A5490A6843544FB66618377CAA9E",
+          "commitment": "D0D87DB88D1BCC7D4D2E60E3DDE195D57389AF277863B30B2870A462C46F22BC",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1665619080020,
+        "timestamp": 1668120337370,
         "minersFee": "-2000000010",
         "work": "0",
-        "hash": "5A1A88A1A8EDD94CB0E1DE965D0A918C3690A6C21DD511AB7BE6184DB75FC9D2",
+        "hash": "7994E49DFA8FBBF5B08903DAD377E253903C206811653F055D400786D11BA42F",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAIcTIAkSLWLBhmANJfvJMpjVkC50/FgTaVgpMGpVLHXvOtXzDsJmxf9ZdrxZkSkU7rFcOLd++HWIXknWCkEnwP0Cs7jEsPossnAYu4kBEenBShEqUGL/MrsyzQKKlZFeoAuYArKwmN1GRB8TiBz1UEB3vebj4u6DPwfOcgRiSY09+mdioUKRgtmUyLzxpjAqjqmpnHbbuBW+PK5HXS9ooVbdAnljhYn3z/McJbtD6c5fdSkUS3Do+I7hywSV8lqNKJHj4NPnzc4wvg7mTsJyTf5Z+sbST6jBgAiP9k8u5Zo63AIQppRy3GM/5Az89G7aUsdYdTN/j1KsS4t+dqicaVQr1a2YIs0mIBG9x0euZ7gnlvnuBee/h3dzFzVNRi1GwaImsG7vhMQarKgjuRvLtRPwrfA53WIK6oXxffL3d62lU+O/WxnKp5lUkFB64O04sgkkmjI02zMxWrYtHZbpJfmO5ONOSdJ9fczyot+iJaOSYkiDVmBVMBqguB1FrUAuoRYjgUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3VySwX114rLttAjyREDDcaj+9pd9R5XJBUl8YXUmgQ9M2cLP0aHw7P8QyqJW8FvP3wme3ysekrexTQeRe+CBBw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAJjsEGTbvb2BEOROIWTEFRCE/LJrxOqyMWUJQpDBh/3LJd5BBNOv0mLipkIgkL2fa6/4G3qEBMCmSEUKNBLutM1t2PRmrlgPz9qyhFaRgoC7v+9h8LV/qdk5kR7FfukQVAnXTM6B3NdLJySu/y8lcBjzqscEDD4Gn3Od1xsOibqX4sJMhtDW0IFwueGzZUrlM5KyPNuZnMpxyQ6cJM3l7N6GvbJ1s0zKihWnvKnGdQeZtMIDUPk/49bLLvMUS5mpt0lPx7qHBOGEar7ORvvG+HtdOhQI/2nR2qcelX/AJKxo+m98AegNfx0RNoFP75JEq7MmDTSeeeAOs377APdsRRKlFuGN8atrq3FR3v5gYFW9sInrS15ARHHaaDMyHmr3g1hICcPrxEEvOSeiobaqblsKzUgWlPfyKI+1/zlKqwaKd3jgx3pHOtYHCQSEuIkNUjnXXi7tH4w6v2LixkUF95zubfsJmahgGni3GM0T9h9wCHmtYGLu+JY9lm6Epk9sIJZfNEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5aKX57n6edcrIlB22qqujEPQPZVPdjG8JRjJFrzkTBi2rqpz/TZBJL90GjxWnTHgd8ILMxoRVh5kNLugO2qfDA=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAKT9wezooFauIYjjKfu6RIBeGpUIr7euA/hc3hbzrKvs6d5xUC6lPdPIwb5nHDXcn4z3C3IE0hXMX0JsPGWNPcdy/+WIUig6Lhm0Z739k52hhZJBIMjI2s4ofwKh0fK61gOuxKcWmVbaQXUTxTl4lQNvlEZD06R1nY2N1Wif/DNQ00MXjYUTsu0p/rLbOBDbbakkDq+1zeGIVZVSa2elBy6y6dHEMI2wex58ElBgd/WsNJsAm5hQiZxDIOMmnaIFhy0jo29JU1R0BMBsRQSAO9/KB9UoBEAG0QeIe8/LGuTb4D5x8CntfM3zzIIDEgrSi6mN5llnjFuI097wyuf1wEhsxxyEHrQ+xamUZCZJIM3ReW7OKzhgXWyVnCBVM4hpcgQAAADliqEeQiZPOq8osMdvjnsnXKY3UxTru5wjZc8jQZUlFaZTHP2L8bJ8Vdm/Jwj/1EB4fM7U/x29cavO902D5yCs6ZCxePofCh/iRyelb1QF1BuI5fY+5i2NvMdja3M/kAWpqE+evYZl+QPjOR5e0d+WCH7oHL1KQgcocTq6jgRXZ/+F5ZMX5j+vIZLjBle7FG6vdpmJDKnEexZ4bZGCqAlHkTpOT4FLJZQ/yQOnPbZ2rDDBkq8muO3sFNzDO0mYtJEQsty9Y8fThgT8hALP93+l1bSAsqPkyEvr7T/l49A0bGq+B/e29sM/G7Fuv9mvIouSOdGiwRihowa/SC4Z4LomwU2WDjBtpFPU4itvyJmjnlQtcQvxFXsJePC+OKqxftHailzXPtdwkc2mzteGKVD9iBnaVD8gTnnGAzhHHJn6LEnVy14upK8Z1V2NsHkYvYgAp+sYnYSXxVqNjXw3t+w9T2EDgilBSN5HDk8xS2KuRCwVTUi2aW6AXtdL1x5C048Hqs0El+LbClLXq/Kdlh/RM/Z99FkWqbkPuFuZim2R2tdG7GcfOkLoQwXuNe2Au4wyp6JmD7zpRuJ/CMnbfLU2qKo6ZM6nZWSPX/1IGBzr2KgrOjIBdeg+HoHShu0ZEJmLi9k7hx/0lWsiFQo6JW1UtTbjSE8/YYc7gFRyYQ7bTJZTm8XkZqqKAjja6Z0bV3fEVCdgun5U2A4OxRxd7yyPZB+r0PlZRZJI2dMgu8iA651uVaSmVgRz1NG8CKb8XAgc3RHsduJ9UKipcd51OF6xdI3Th9ys+T3jg3/b8zKUAI7Cr6sqaiADeEz6PB5OLrLWMMRI9KBsaFyzx5XdyMakMXlhU7PqwpAPd5UkNgD0oK00cgmKKbJyZDT2CCY3e1X6ANhXp/XylEMd8J+nZRs1D49XLZx681qvbw5Fir6lp399/bVOHwEmVZUEFXIy9jJs1NbxLdfIS0mgNqWI/sPReXY+cT1vkJJ+wd4fI07Wuz/0VVrV7/H4vW0ITfuJZ4qTKuZH9f4sX93TnDNN5FpXedAXBV6nLT6x9hS8Mr60ThjFbvIY2PpNkWU3zMxRnoEDblUkjmC/2WKzsV8NRJr7xUK8RHygbILKuWOMYr1blHiv1FNADYNP0NlXKxgdSOAdhSiqSFa0J3Yo/X3xbThJBwc2g6hoHtWdWkk9b5DSG+5jh+NgGWEeZj9DJrC9l3WViVVOLbMbFG4XIjbMFnD8YLKV8Wjsix6N2ak3GOwPt4QdEcoMU8QmRtvQSZWJq5xEc63nRqAzswuoK2pFJtCWhUyov+s68nMQOh4m+hc4ARko1Nu+BtWv7IjAxR/mF789LfLk2VOZn3+phQcsvC152kxAPqTER4yeYslGKdlWO65YnAqp5oAispJAIW9r9JkLG3jAArHD/cYEC+zCNc41uD4dD/XzOkyWm4aBGMvQHbHu/bnDCg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAALnXGTj0nouvyVu/IT07tn5NByHYJQA5+u+Spip7qmOUyd77dt4goR9sE2kZsFq3R6pfL1AKKGaVZ/0u60SmeTPjv+rCxEs0eD7K/p8lYWqNnhh/K3R02Jde5mw5rZSIFRjiSJzfCQLCvIre8+a5HbGTqcnsLFEqQdZo/5ntQHWPC/xcLub/n5PzwGoM2trKXo5pV3I8EXOwdBcV+fvtjToG63auHZm6/fOByt1CWoGemvSWvotwT7odVZ2O4yO6vWzfqqrP+XyGnIfql8RoR+pb+ehrsHNYBjgaBuVwvnlIgeQKxTG3PEoX3ya8J00JqHGa6M7GItCFaN3CgyBxGWe71SfRfAxtvcnAf6/swMpAzVgvEd8OFkzKrXvWHGjhIQQAAADMFt50EZq4vb8ExJmo+XLNb75zTNqzNewlqkv/EHGs+4k2hngwr6EsPsfjoohsn59Pvayq4ii7eJcs7k0n5h+dogqsAfTTpUuNzZFffgjfot5r+uD6AHKR6fAiQbyQOAKk5+phYST9pSQnnE85R3e21aUT3znb8bPdUJNjRMjujCL/0EkHb6q32yCgBsrhEECPUegSTgTiVjgb/DGXLvO+ZHfATSUq/kYzw812FnrP35nOT/qg6ajtsTCMUMHu69QWtKkLNQ+ULMJJvA7oM2G8CrqAKc2IJGofcd3MV0jvEweVOO3oQm9C4PCwtLuEq2yUM3spn1W1Di5bj/goQwSPnv7qps26hiTr031ul8lXbA4s2HpxF8PMzl9hLBwhosvfOLD48cVf5n9ERBisUlZX64HQhWDPsPlST3u6BXXFHvPobD1T9Xhv/n5nBzjMdMMKsckf6ShTSTOG9H490Mlb0lX4VAc8ETxvt+WDOqNuLSveb4JpErNdNi8c0Ghvb1Y2socJLgI2l/+p5qVvx1eIXI9qhQts0bp3/KOO4wxA7eNvHXH6MR9Wv7ik7gaGRycpB06R/snoBrAmvTjKDuYbyqWLxGFxpXwsQv9OpEugWVIswjippssLwLi2EM7fkGME5xwDGuU4TxNAqYwgCy7DdIPs0h/wD+AeSD98aF1kbcVJ+TQFNt3DGVTmIVsjwi0LEWFiR5AMjvhsKxdFAxikxVNUiJh5mDapzxUXT76ooAnl44z6tzSmIsUePCCFX6tP+Zza8Q/MpGHnxAMMT7nOn7wwkGQs/uZbSB8xoa5Jl7QncK/D6ambnIQFT1tqsAnquM1T683ePUzaApsVX/9NQpdyEmrqKUzPThHA/EpMYIdyYxlL7UdE+a9kNQO/RDaaTzcdPyGa6JtB3Q+K20SjKC355f3eRLpjfnueKomQ8f3xLKo+8xysyiZZmV4yshZfkWByHT1axyoIxnC1sZhQU13Kl/+pSnyj9i9h01TINcu+CnEskWtew8yWMSvB+ePgLy4fvQeF0HeznGOnU4kkSPmAlhQtEmb3GpEK6Y0YX9htHQevKpyKnYXcRouYXu57xQZ/JD2sTkFMyQdNpPEGKEnUcpoYW+kKogexQ6cz/+lUpz7boGq03994iKM6El9QAFYZEm4V0Rpg1B5S5u91/WPgatQl+QqtIhy2Fqv4pQdvJLDHB53Ph96ho309qN2wq+RgsakS/SBVL/Was5fNUBBqyv90dy/3MBp2kZXPFRYjnJ+OoliZUycNxADq8mLVYEiZNJKE6IRJcAa/ly7yDJgUIpBmrW8kN/SiiO3Eo7CYyBc+MJvpV2OUHFTS+Sb5pr1P/p/oS6I+7phc8F3vnPPFOMIx89sGpTEGn3WcxsIwvJrhg1cujXiY+qO0AlbfHexObhVcxmVckazTKRO8PooMROApvPZPOWbM82QVV0lmH1SdAg=="
         }
       ]
     },
     {
       "header": {
         "sequence": 4,
-        "previousBlockHash": "5A1A88A1A8EDD94CB0E1DE965D0A918C3690A6C21DD511AB7BE6184DB75FC9D2",
+        "previousBlockHash": "7994E49DFA8FBBF5B08903DAD377E253903C206811653F055D400786D11BA42F",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:8YPrAIcu+2p1YOXDAc/zx3XQmiuBbPjUhO7AUeOGoB8="
+            "data": "base64:Ga7MYn1ZLz0++z5Qq8fglemCWbZKV0dbF6u2SPeUkGg="
           },
-          "size": 8
+          "size": 10
         },
         "nullifierCommitment": {
-          "commitment": "8409E95EC8499AE06E9904C6C2A290225B42A5490A6843544FB66618377CAA9E",
-          "size": 2
+          "commitment": "7B46ED7676BF32969AA84E8D3DDBA3C643954968F0E43E484783A81EF50AAA30",
+          "size": 3
         },
         "target": "12096396928958695709100635723060514718229275323289987966729581326",
         "randomness": "0",
-        "timestamp": 1665619080288,
-        "minersFee": "-2000000000",
+        "timestamp": 1668120339731,
+        "minersFee": "-2000000020",
         "work": "0",
-        "hash": "E022FE60A36FB611907D1B80D65E6217E6EA74DFFB68AA12CD9E31A0733C2A40",
+        "hash": "86385D0D661F9565B1B736A0C532D96FD503C327CC60F5A199ADA65C3C76E99F",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALQLz2deUfEAP9GeVIuURnBORN7vn356mQSP4UmaoItZh2yNiuJ0AyuLuUWgq53DZ69htMxvWqXvjA6WdMxOTgPqacec1I6saDYPSDWjHTfNvDbVOjFOaDBB56B2xLtRphnHarIYRN4nk2Gp/7k7gloXWElrzTSykYh6Z1smF7zVmNMquGFwdAn+t0xzFZwPJZL1a9oqU1udDRxJbPaCAuv68uXsRpubqBdPS+btTjdV02Wbck8kbqBV0ofaZsxiuusDqlxoMvptN6iik9LnhzMJsZ3QJ+Au2IgXsn9ucNBtqhG4yF1mskuKZBGoMRyGZYMgALaPxGSqZDO8nBZPFzX2GdaB4ky0qjryWgMLFgoir9LfTTphiwOrTIC4RX8WmC80wxVNR/Q8Dvo5mFoe6w8i9oSEiprzL2sTFLGsunK/pFDA70XQKAj8Tvtw/44zDcfriolK12mwWZPPVC9KzZUxHx5qRxqmabQl5e6qli+yA9NecpYAp7h8P2VHPtkwziHaOEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZhcTv01WY17fnCCSuZwCKlMjjL5crjtArEuSHpPcfk3qkXxaWhhFhKwk+Fh0ia9HViNL1cAHhJzo7Z3IX9yRBQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "E022FE60A36FB611907D1B80D65E6217E6EA74DFFB68AA12CD9E31A0733C2A40",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:5El+MCw2FLTvIjW0wKA103xVKEDl1wdthLUl33W2bEk="
-          },
-          "size": 11
-        },
-        "nullifierCommitment": {
-          "commitment": "2CC7FEC7D57527DF27E162869F627520BD101E69D5A8424A8DE6DFA3B7282BB6",
-          "size": 3
-        },
-        "target": "12061061787010396005823540495362954933337395011119300165635986189",
-        "randomness": "0",
-        "timestamp": 1665619082196,
-        "minersFee": "-2000000009",
-        "work": "0",
-        "hash": "AC6D2931852099D48C2AE268DEF4A651A53873A968DA90BCAD46175BC5B919BB",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAJPKCkfztu6LED0ZEZoB1Rog3rzKY/MM/zPg/4q0hsScpsuiReNysSfj5ggXDNn22bU4Sc8HcJ0bGIv3qNF4/RbvVvyIvD+TAxL8/JLGmqcXCIBSayd25WTOmtx1e7Z2nQUtEKqre1k/5JenWbVgmQVa69nL/U5muSmVLBuoiOV22bhrSnKdj3UFEo11+wG+boR31TZXBUDtz7CRCeoQclT7ITnj4/5UCq4f8iL0Okg6HvDdsWrkuNahxGyPF11P5RgLDvd8oTAD0/NjROXCfe3CoOCPge05+Y+SdP4/LquxcDFSwUN+FYXFZ/yRzcdLqx/uhaNZWwZG0H9+i0PLkREwyxhhrMjhyyIojvHJlp1EJZQptiUm4+HqgYPnjtEPT6dwEOAyAOYYTWNqPqywJTFYCHWiQwnSLgW+YVAeuqHAxWZ1XRy/5d53v+6QK5LPeIfj5NFbtOXq7X6I87HeDc6pnwp/l0m67hxpaSxNTps+xri8krK+9XE92lCbZbqIo5QHS0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBTQtdHIVPMMUOnvNLVPnVB35EXaReerFCRYg2Z2eUieA8frGa3Gg1iQPvpAu7lFTBWwjLByBVvCB+ghmo80qAg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAOxryoj/////AAAAAI78YO2idwI6DsSrrVgtEblgh8vWO/DbbMurwWddRvMWlY5lvlNUbGDT358YpnhOgakzwytR4pSnr1ArZ+OVoGj3kPUm/DE7N8iKIQsb9WhjbO6f7xzBSSfQEvbXPlI8NwibfIzaB2oo3i/NhQ1SNl9C7xVJYvwUgFsmautxojgUqS1pBavyAl+JBgrTYB1SHI1VV5Ci/AlqqB6rG2KHdjSjYr9hb5fOONDskdcEzCE4rRma+3hyddoTrOc44nGc6TFXTa3CAj8sjBIKAnSHT7l//LUSeZ8TEgOBoMRIMLjxJCnCltQvCuLFdF6gwfX7bbu4qoUfFLFVw4UMVmPIMyqlZTfgaBUSOeHNNRRAMa6Can5qnjQ9gUw3xxelsxR2PvbpRRZQfgj2ay4mELRtEXhetNh98X6NrmCzEOCWC6Zg2nX1M26CB7zECIF+fbjGTE2CkkbkeZ0wbLyHFE+dYrkiVHcrMtvE6H1FXiEF1wlKrfy/9/nAHBK3PlF45HzbHE4J+kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxHwrUP72ulJqOfQ9w9EczW4K93Mtz1mJN+PM7GtGLBOfe4R58mbcx6/LMYkXZey28U2FJ41WSL7PEWyo0hCYDA=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAAIlF1x3/2vJwteJtdMDCtQaTXBPzqDqskX2VA475D/UVE00LZW9dQYEsKFA8lmwGbahkCJgMIPt5fhTkM5PqtDqIxyQuZ6LuiaT8m/ielc80NHwnuysbOY9AKeevLOyVvwao40IBgP2cX/wk5nhqnY0VUcI6rLviEkHWPwKVwpS8p4PNyl195bqWMfKzW5igka8JvVASdVVKItLpPaF9NkPqOPm/dbKOTKkJqvnP/vlFMfrJ8DJzA5Ejp/y96sAifxn97D/1WGuyeAgZ8x+cT2g5anI+DW4U1VhhcyIIZdPLwiKdk+SDL1GVW0k3EpcjMf9Dq5rdAx3YpWv0ecY9xanxg+sAhy77anVg5cMBz/PHddCaK4Fs+NSE7sBR44agHwgAAAAabfO3jOCQl9ehvkv3H3rygmPfVNlwICy1Oq/obWJRmxZ6/i+guiiwNF723kHXiHGkxLaB50N7gNSFKVi955vHk9OGcWtzCmbiuadOLT2Jl9P+sY8gveh3STl0Vs4ouwmSAfL3MRIYb6hH62vEVj4tisJH3b4Ih/lk11U3umg/NACOUkh0wA67TSb6A89s/RGol1FOU6Y7meFJTTYXJsTc8Yo71TdYn9ym9gYDf83za4tUXJ7zd5c9SLpYR0hsc9kSJX8JOmgKL154Agv2QYWSyH9QOqUw1nnlHDb3XhwZNFUUPqmzyhoWFaozxFvdJNyNp6Z6CHB0Ysx28l90y6BeYSFCjM3vxZHcfcwpr0A2iTMMKidi3ZBbMe73usQm7zK/yxFnWa7E/NZQsVD8KGI5QNuQuHqx2dFDbO/UXisegLJyO2atebzTscNC1TMeOUZPnp5yVzoH/J/Ggdppw1NF8KHLPNUfSWrEvxGd/5hIXFRTsWoFvIg2F7RLcTQJrzzdk1gaaGChfX4SZu06MJTKFiMMoxQrAGGfEsy8ZnnUqG4n95NAxR9MWp2MSipQZyYr6fjKoI65g9kGG4KZ5No7YYPvAxn0zqZef8m4yXZkvyU2ZMMpXx91yEuXlzhRHPQ6FIAnm66geOQHQvKsILVsnBQ4r3u6Cd14mZ0M1i12kAd75kJpU3DeyExeHadTbzdyLX1hzr9Iat6YQdx+/4xkrps6+hpdhLxyJ9GXkJG6JqjKDICKJvk6YykjLeAFzb5Ttd8xpM5L5/f4pycnkMFTarzCWlF31I+At8HxLrXuJirl9LO30LzbU+Kbm0ERgx27KdZfF0Ez3VbxPt+/jzSQYEYMxtSe2p+aLess3P0/MOpEMAuXCi319Onds6f2O3al8t7xQK+NEcEWZnNFwZMfhlOnOpqOjAwG68TfiCvW088DDomXWfruRzJwDCOW4W4HvZg5LYHTWeUlkocM3lVQfC8KCT8yXCQDuJchNbqU/RmaaHdlETw8491OVwfKr8AVMfPZTijnQ5nLQ5/1HIyD9sI1g72gIBygNPtOFEWvULXaR3NiFFv+IiPQYjGHMOWRVzii6Ef67yfUldfb0/QHM9EsT6KTnisFPAE63Pn7HaosmafDRwTGcBSgyDW/o0KGcctyaEJjHR6zOqd8K9ya1Ir7v1NnkbZ8evYhjcWp8TGabESygz+trNi+qXNWevoHbWNZN+Q1C+51coeg1vVQS54ZkHBGYG4pKZFuT+V6X3d58Tcv5k8QHuYqSB/rR0wb0IViN9/EIaJV4pXinWhD8d2vF23TpsXxhtj9kAP/6toccD5YujXoqdcBuAh3vdHbjrrHF3kQgs0O3MIem4Lf2JFbCIp3gZTgzTUzvlyDyYzlmZ+pgGGB3+tm0PzX3iq5ylxLYevw3uDwRjrApXd2M47NWFs1WadifelIZlnfoQ/VN8XhBg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAABQAAAAAAAAAAAAAAKkYfDqti4GU8Fo1XmXAPsfh4MneQ3jyIsCkadvuVE3brsyobe9fZLmuwrKrA728sarg+wB+/c1O9FyDkCCYNTMfWobCVupGV2E16YiWvNbEAeN/jptSWPyRnGd7cpHcmQp7b6dMKesqLy8BY+RKn6fseTQJQ14F0ntzWN4EJMK8qTAPPS1AVd3S+BQiir5IDbMBBICmy5x3xKIKq1i997CH2efYasyzBNqoJ4XCExBslR55MjRI+XzqKFioGcOVBasnps0cE88ytxZXjAdRErRq4spwQyUP4WYLmMA/fFII4IWXVghQJp4DhF5xENEEzvduHmzJN5DcmwtFMumkgLSDYVox6n1VHOoV7Yvnc8AJQTAMXNhMRo3pXkrrDCJrKgcAAACJ/Mf81JzpFpE5Sfs5x15gWqP76dzF2DTLrFdYCIczSRhViYd06NNRQnl7WtCJDq9fLd6qp0v9P04CGhJXNLQevGVeM7k3jFaXz4EjcvJBZYt/dKLfWkgJoG6N8MqTPwKGXu5GddkDFs8T9oSXPaWGA04TGdh6hfO3Px/cyLEfAFAYNIw3j+H5Hq/UNVqJU1myNlYT6NScNLAKMkFkF6GjZM2K/4yYV85rQCGDp8k6DXrSM6INrZ97S/PDohDMUIwMGacWfJzVqGpMa5LapQEteyk/wOieMWQTkizjUgzlQAm+zKfmSzWYhkXimkR2kmaRcnrHnIOrZPkrK/W99nZHsGXpVVyfNcgxgU7bwOk3CNAN6eKgfcZXVnzQccTyPMUlVjxLkyzOi0k9INiN+cOKzojRQ3ltKjSLCKyVEhcCB9EH2etZWvH93RWboCttYSBjD2DkeUM5phyM3gsxuyAQxuF9oOsES4LdlNV1DiMIhpIOQJe7efKKrR39s8sqVQdoc/3xav4aEusk14kDsv2G8B9d6qkA38ZE53vDaLVRDju2r8tzLu/m0Gmm0oU5I7ZuVneT+ObFuF5rkLvk7kyZ1P0yjgq1rD+rCtoIi9k1iC7w1KyPnGTkUJW4Kz37VqrLTFec+ScsrmwaGrFJYPirJixm8MsBiS/9jRfd1yDsJYaHv5N58Encnlc2Ng+Joqx4AjAXA7uTgliaQGO3AqN3jnXxvoXNSKatXanQUvOoE5s9OrkXpuhfMBCiz3SEoiI7YT53YanLxWwOxDdpeaaDm26HkxsOQl9ilAO2pXMzzxqRJ4lBr/5L5FHOQHdLpJRiXF6ZC31QKL5KzVJwFzoZvAOgFTBZDWHkjWbyKB2MmuTn2wgqHKhrilSoGDWfv8oefER/eDB4OBzYiHtgPMY7a4zKQAxwovLTX//eTb3Hd3Z9N7DELm9V1dpr4Thqj3xdKoq21kP6b9ppV4ymgkYUTZIfefYR/u7kJ3rmJgPFmfNtloudcLm6asLDAV1YkAr2gYBhbRDE7s70Xa6EyxA5xuaNW1WpXSXmpBtG+YZkSJM+uAqu/4RvJ6G/PplzvyIE0BrkZBFBrWNCn2PJYzmixonKp+FGRlK3eJQuExFFZN48Iwi9icgKGnKWByrphDwf+kuOxD3ibUaqFY+9byGQE2xTVeffcn54frPrRDjgknZhaKJs+KuD8hp2iKD8vH5gHOjKsWH3fMwT6fsNZKTDlkkoL10D8EQov6Eac/PJ3BaisWP13S9OzdxLb+GwlC8jXOUZNNYlbQhi8cSsYd4Om266gDSRFfq5H2OdUOFPJ8XP+XzvYwzMX73Mw0AV21CqEZJjeXJFbqKAuN4rcDbuUITxM6EVztMyf26Cy8JTHeQtUfPtRQiUA6YiXS1TSI4Xbm3k38AGRU90TpT47hyDWfIMK80VZ5P7Sukilf6b9WZF7AvxAQ=="
         }
       ]
     }
   ],
-  "FeeEstimator addTransaction should remove the oldest transaction from the cache when the cache is full": [
+  "FeeEstimator onConnectBlock should add all transactions from a block that are in the mempool": [
     {
-      "id": "19a57b1b-b060-4551-82ae-fb80d040e160",
+      "id": "24596b4e-003d-492a-8a6b-d16812fde6c8",
       "name": "test",
-      "spendingKey": "b296c433154faf9c2f479e6af0938d2cb835b04ec7f43924080135252680c36c",
-      "incomingViewKey": "8876aa6688fb69564d7b867342a49a1a16fe94d5228516dcd2c4b8287d771407",
-      "outgoingViewKey": "9014641c37ab7a4339a4677fd683c95685819082f8b8294b17a987be3999551e",
-      "publicAddress": "f22d7e4047720db6aab74816109f99441b24540f8c32d0fc1db7281672e866cd2b291250ce4850b54c2826"
+      "spendingKey": "579af1ff5518ed50d5fdc3ea954d8d30d4207fe61859503faea14fcfe9303028",
+      "incomingViewKey": "fa19e4391b1a52f49ef40b2841264bfba4c3ba3d312be86d0a3e5a518a0a4f05",
+      "outgoingViewKey": "d780d9569e1c19f2d9029a142f1251b3215e406070270658e73c88e555d5e201",
+      "publicAddress": "9af8ad6c3a6fba18de67692587a15fc4503b1861814500c79b144132438459e647fc9903fb681d5d40888a"
     },
     {
       "header": {
@@ -1563,7 +335,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:0NWuGzIYBud6Ngnku9JHzkEKWOPINHn34Ons/w0pHSk="
+            "data": "base64:fzWiNaJr/1wmmuqWB5xBXy/UC4cmUHPHD106a1t53AY="
           },
           "size": 4
         },
@@ -1573,126 +345,62 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1665619082497,
+        "timestamp": 1668120340047,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "BC873E67D9376BBDACCE5FADB006DC5F4FEC560C636A4D01023959FCA9C9F606",
+        "hash": "2EBDAF32AA71A344101889A3A03A0CADDC21EA47A722F9D9908FFED932B803FA",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI+qoIKLB3051OqOFNUB8F+xDOUFkFozfsfEYMt70KXhPlVdFIKlBL7+nf8k2yKYe4zbTkU1IApLXgWmyOjrTVj/SWP8JGCVogBdMoileLD2e4FPCLBG+m/uCI8jQKAfsBn5MKXbYEMoQdEijrQaL8EeIxeaTZD0L9yogD7weTIAs2yWfhxQJnR9XF4CjvXefY6JAINBRSWqpK9Mw1qMxMnzxYuLEmZPZf8cmiWwDM7lGj0SNQPLP0gfKumZipSW6AOWNiB9vmTH/T1ns1OnusPZLP8hhDJwK1HIwT5/j3dWgnubiv3/FiU553gouNE936t/Pl21CLRvvnbQILhPByCd85eXgC2XMqYK8668Kgw58HRY+Nkujgx8b8k8ANqgk6t1Z4rmmb7bwSI7SNwHMRRnvZTYCy2R/bPTJ/ssKoYYbuVSv7decWZol5XYgVLXr7uIJCj7SokPMmYR64jyOzaACrom2N7g0hxq+AZVF9Ky46dhqO7rNCRERQXcoK6YsTeaXkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJB0LwSNf/sHPjb95eYDhJtHcrXpmFnBIuSHSQWZRDvKTAx+KSDT+nAL5kCayoFh9ymVhAzfnXGYEQlxZIimGCQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJStXf7o4VbBvyMRxE6aQmM8TcIK27wHpiHY64fJy/3G0Q16dKVB6kmRE/wMKWY2xqA7sBXP/5JK9mQ+zQbeQduXJHj2U+E0MtODN/RhBgwIW1v5QEWccbXDy8UcNMYrfAyW7t5jUjZeW84VwuOxpPdYRw/rYkorrAeXuLjrGkVVOp9YDGZtKI7jdGaTS7+gsKSr3PQy43AdL5WzjGpDCd8JyXHfE4AaLpQGaFW4lck86TLn2DGsXGXJtjXNVf2taX/HX/27gwg7dSpFl2rKDQBAT/aaMyEftI+8WHeRcb7JUTdbVOyY3hfFsHre8QfC8CpHujuzIRVcl03gZyrPQVQqXgKiddYv00gcFKZ1lNn1whPsr6uk9Vnqb3I6U6+q7L/myAW4m1d1u0RTbcra99HQ+0QpeNxxRojnXVNEpVMkBC2H63Eqg7WbSOvO457kXOy88Q7R+Jf7lR+i6oX5lXwD0ob2qFMqzLdOlcYDXjxDpiOMri4qlqxB0V3tV7ef0V5KRkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw64ea8d8DAqD02Jjpa23FHBmbBOxVRG/mw6/Cj6elQDsiif74UlJqcLypLVbJtlNbEZvYRHSRAnQaEVN+PXo5Bw=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "BC873E67D9376BBDACCE5FADB006DC5F4FEC560C636A4D01023959FCA9C9F606",
+        "previousBlockHash": "2EBDAF32AA71A344101889A3A03A0CADDC21EA47A722F9D9908FFED932B803FA",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:WEIeNXo/NsDw8wX8OTuS5WyLLzL3YmOexkxpaVUfE1I="
+            "data": "base64:ORzMO8FEIv1QXDtnbDzl3gbkNwRRxRs4AANfDQ962mo="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "5B9AC96FF41A6BE17D0471E02BE66AA4513E4048F6792EA9D726617D583CAE03",
+          "commitment": "E0106FF10B8FDB1521F9C864641C8321510DF0F6607783754A67383121A4C581",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1665619084411,
+        "timestamp": 1668120342387,
         "minersFee": "-2000000010",
         "work": "0",
-        "hash": "A543344701A4CBABF72BC3DA9680C00641F77DCA77711BFEF8FB2198EE7A7621",
+        "hash": "5B09AD9A194A1304244C8EEAF1B75EDDF7635249300849D09EF747CB86E5E45B",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAIOHclaIN+K67tse4oa2iGyAzcMQSq7A3no7HHGWRfLrSdeAXyXMDBPmumCgmJFuNZhPnVt/MI3+TQb73oj1B2n4SJsq53jGovOdZaYicBFgk9q4gyX5lmTV6Kca7k2cDhepXhJ8GIvV43Z4jMSQGxGMWActATh4QyakvNxf4fDltQOoDbRyVIaStXSHOy9Uf7ShNQL6MmvStt8nlCCQfDLrtRxs87HtK7PiLyclk3wsI8i0SGM01Cf1VwUH/7p7p7BKnm8ZkKvu/ctaf3Kl6J/xdV8TNHuJX3FZb8rjG5SF4vNlelYyq14as+WagiLbUOW+LmpXacFIPDXm4gojH0O1HGyBwd4Dv3kiW+upSjd25XtO5ab/GKKEhohOk4j4zIxQQtRu1MTF9LHlIaC3t1ZHCq2oallMXQWdvLJZX2Z5wPCMrUNAVol7Uc8lcfo6xrzge7J1nL/BJV1QdJle3K25TiUDZjLfPMuP9CLO6PVt1JLN9aJL4umi7mbilF8CLdSai0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwi9C5CAX9I5h4NGCGh1jE+dnGCgirl6DTlP65do1LhVT9AU/DU31QDF4aPB9OlTYkBST+hvQFnxb4qJtTgMc4Bw=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAKQCLa8L5uu/MwOzoF6yku3kRXHVNWblp4CC6nVkvgK/rNV5hfol0RoH590DNPjRlao5bzuA86Cei/3i4QCNq7XQszk958s8bI9SKeM6T8rek2AlopmkL6cKzzIKddp4vwmeEtatraokqzYTi8XgaO/RldMpq1rM1v/5ZSPxsidMBIdfaIlRp/KJcbKpL2ss9KsJftZHRe+n4Ly7dnnzGXKMXfS4Z+tKCEp0yTgeXYvVQny3KTI1QQ4OBtt7VOHGEEGWR/rHx4gJpzKBApoDggbl0lsV7tUTFI1I+e7f33tbCK5RtD56c8FxAWRrJmaG7LO1JDZHuibW/MFF0su1JU7cBAOr0VtOkvz5AdRjcjpWzlM15nFc1LzKzX7AAud0vIxvEmHv2FzbAKOmtSKEfMWk2X5oFb27hgAjdS/sjaApRDRSxVapuIE6c24T5bOpRRQYtk1rRKsIIh1hqu+kaPee+uAwhd9T3/qt46xugPKGfJUJ/LrCTF5g3sj4W4ak7I5sYEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/dtJkXZGxrTYGzs2zzuP1GYeUK1b38zUiOApF4mbg9sCbB667fW5amjrLNw/wd93d/+WzidPRFInvLU79iLkAA=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAJJUTp5RemDd0DMu9UjqcKhC6lHE5viGbrL5AB6Xb9qEL4Uly8o5l0PTbDh0GUV4pLbqyby17EEn9taxDoLJ1H85n0SUyRGwGrZT0CPVUS3jLrBHuNjjahSDzgZS0Ja5gAwl6nxOB+bmYoYGI3iRZw8HmRvUZRQapmsBOBX0wsZ3VXsTtEMxYxBmjdhWJEr4wbDsU3pXbTXtfh76weMVwEdhgobQsgxITL5s6jFHVTkKZEA7TQamfh6FPLHqYvZOMDkD0iCwyQsBTYLvvZgC8y0VymSb9cycPFUsXqPSwTnYgGsbY4bBSwLaSeqRYj0Ew8WA+06cQQUt1+9WZXYdJJ/Q1a4bMhgG53o2CeS70kfOQQpY48g0effg6ez/DSkdKQQAAAByzQ8Kji2da/Fi6zYF4tkClCJHv4buXVVQIx71w772pgpqc9Q/ll4KMkdCJwdY6p7ivk3UVhp0XRSxLSEvQkthxZHTrvuCkmr2+eU7wyj3ve7ee4kwWQncznCCxvKOeQ6rcbsd6EmAfhKbNFiBp6N+y2//RtcqT2strtO9s7FNi5JddN5Tw/g/PQXCPNQFVwayNLccIKVN9ynT5gpPpvPBpA1cxUHMZsbcz4Sar5sMl8fWcHoCy6M1auJ1EKmdJREKje92chZ5d7B7QKw7R/WCAhaqTeoUT/qdfavBPYSvGPUlWsPsTXhgIyE07YB8G2mBDrhGesYphpz3pWgrW6OLFYzmHw/rUIwjzBY+VQqMFnzpLuAN/xOCZR8ZTzB0g7sAqFynzYNbk9U54XDEUUjPmHwZx0tawj4BQY7A446+subBYBT/S6O2FfeRgsv6OKvnjS8FI/O7cruvGlnRo7keDxnOlXvH8sWiaag0jcwVc35ysvvjU3TUoN7tlN5FDGjrpFnQ4yVoEhrRP0OGntNgl5zQyPqu/dN1AQM/PVUC3tofamE6qh4G/IgVqRHzTStstmCconkAqLkbgKKdUWYUpqSLXDnpzXxCJrXrN4qEzpu1zKCqo/sOl2NeWvAHQdiDa9lXRL3X1zT+4v4qFJNo/GSGa1/A1m1CL8uWQFjrAsPvpyOYENkFdEX4UR4ZnEy2mCh/B0pIoIGCKEOvA80zGysU3MfjkT5Ydie/IgWbAQ4Y2434+6954wKpbT+xWm+nU/aAcqsEko6beVZzveNLfb54HPfSdZe8W7vHnm8yT6UvYLQOg3yhpTGmXm96z1V0Qjrn4vK4H9TFEcwCyy34aMvD3eazzNy+LiT8+iqscSruLgfArm4KjhdNzl0diFSjoTkTlmHvjC2vXpo6vY5I4KoCkCAbB9sqPdnE/AWDg1r6sYoEJXG7+qcAe31jVyunqaElHYbPOC0Kigiv0rWB4Oe+Y7sO0d/o8bJ9W68APxP2oIaz8peAVh29b1Ff7nOa6bBSHyPZ7x6bUrjjPJPBXeomInKHqipYaHfA9DUThmZviwWzQXU3d0F9lil4aPc6CDuNzY9oP5Yh3zc13IfOmDAPEYQLZviOE9TdGRwpFRJq4g7KM16zl6CnSsphWmotc8fPyHWPfegBU5bNHIS0rkW2uMKcZQG520AJh5sdx0Bz+8Fq3r1kkJeEtM/QQBOC7PIgiqTIklSX8dS4SQujvNjEnRT4WNIbmJmOIssSIR3pWfFmpxBfBtM01cTyPuACAt2NjsdTW5ua/QxKZVGwXRKtlWWKPOJpY2IjaSNOlr7jjp2nLpUIBRsVRLlbAvmFiIIfDEyD+nEQD9xtP+BeXDPWo+p8y0Gyak0QDDyJK9l7xlYvVHw7zIE5AKniONKGqhxy79Ktaka0qPdB/7dhV6OaJWeEB/bxj6CGcXJtr8gnWGLfAg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "A543344701A4CBABF72BC3DA9680C00641F77DCA77711BFEF8FB2198EE7A7621",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:ygn4ap8cx3o3NURGkvhIVUgZCvs4LD1vudQQHyCE9lo="
-          },
-          "size": 8
-        },
-        "nullifierCommitment": {
-          "commitment": "5B9AC96FF41A6BE17D0471E02BE66AA4513E4048F6792EA9D726617D583CAE03",
-          "size": 2
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1665619084658,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "8FD8A074D360BFC4D1E6CA9B09520EEDEEC66D2B489743BFE6A22AEA04D5C952",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKLbKBa9C+v0crPHylwTgZNM3d6uuwnXMJC9E5303zPMGT8K7cCRz1RoLEfZrt2IZKp/bOYJHyLAy4uPH9vv8x/Fk/DXm4TPcIUnknuBzgyvLD+NkpUNe9kaiot1WEbPpQwApKJZHyjjJWHNi+7HaKtAiGVH4CiRxLDkxOhos+gUfF1dtVb+j8JQ866b7QqUzZMDwJLRB8ya/3HyRTWUzUgQdtRu2YqeyS1QjaHp39WadJl968hngtpkI8MaG02KdvBixhVn+sM0IUlF24yAn7esnSDiyOUo7xWNhnOAomclvRbC5z9EJjklDwcdWKfb2zN4NiIj0c57CyVciIc5UmSpbf8lyLeE+KAVIHOCMqwkvOgTLUDcZVcogGkfTVCpQP1jpQ5JhGhhBrxxH7NdzEO7nYvRXl7L6V0ZqPqUNySXVkAYx1AUE1G4vtIVyRGn+mlKGCs9F6xP8rVERF+Qh/2jWbfefdFu8n158cMMNo8llouOy2pd5QcWzWwxECe702HkTkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFULABGAaHt+UeHC0p5x8DQLOzacjAIUlGLCKb/YjUyMLszmx+wBCV8ItUMqwFvkC+FVrtUZQB4veuJKxEYhjCg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "8FD8A074D360BFC4D1E6CA9B09520EEDEEC66D2B489743BFE6A22AEA04D5C952",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:wMeeKoenTeefQPN4tqLST6en453dyltVuRGE+H+oKi0="
-          },
-          "size": 11
-        },
-        "nullifierCommitment": {
-          "commitment": "DA4E92B96EE6770A56684C79089FAE3DA7A6180842B228796363F560D8AFFB48",
-          "size": 3
-        },
-        "target": "12061061787010396005823540495362954933337395011119300165635986189",
-        "randomness": "0",
-        "timestamp": 1665619086522,
-        "minersFee": "-2000000001",
-        "work": "0",
-        "hash": "FE50ECD7AD002CEEE4CC12194343909FFED0E7B1288EA87FEE6657430FB76B03",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAKdB6yHpFwuVQV7S41daFeEWmvrwK9MnMQLjMUFEhnciDSYz0NTBENXv+lsMbFUG7o7+I/YT5AjvZ8N9RqNE67aWEcbaRulBVA72Y8L6Fpvx/e+fKssnaHK2Up2oej007gmlNSeoyhr6BdMsmILQNRdmVfkPmUElX8PKpC7vPZDBpOCuKQYyVkugXHnFfdXg57ehBtKOLvkO/UwX8OxARAlCFd7lhOWxgvXU2XbiNF5/83k1Wsxk3gGhNAxBCph2YSIfPFuVSMMJd04SZ0pBwn2W70Ibiz5C5yw0Vp754DORQVfTqK9H/If9e3GJNYy7U2Y+a3rWAwbH/UHO+qs8I0xatac1tGEUQDV1/NHmO9h+6/CsEMcj+AX+Ktu/hpzTI5/YEKDnRFmelEcqD3PBzkSOmi6YkU7dFkFWV2IqbLnpzt9h9NI18/7AeGc2fRqVhWwUZx/+U/bCIYTcb062Djb15vb8ho03pDsSInhG6/Qsd2dvwrZRmV2I01pgSRfC6+OoV0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDrILM3aFagQpP35rvkKjr6UdvauMitLAduSl0eJKfTPdQulkGPugSulg3rvqQgDklQYGe/kj6S89MuZJpBWaCA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAKtc+xK6U50Ai6ujhU5fntZVFNLjuyu2NyE4wAydZrMo0H5Nwx7L+W38SSsGXkK/qaKjZq8L2yBazPepVSQW+mliCn3vo7GXpA9RXD9qkYoC27mixFFcBSWhIvuT72VmRA5hg6Yi9GNuI3qkXCKrbZq0pIhzF+Va8UbVVbJO6T/AAfBDW4O9Dxc3cI4iTmkd5oB7ulrtzw5YVbA1iiRuMZUhqtZRV1MYGPalIvHzI2Qaa4tgW69s0ZOwE3pSfJolLtclFK1hsRj0R4qaWoVJg1YK/LTbX6mWu6tG/ezgUxhu/VqMz3OCn7qr/2l4iK7XYMaBokYGyjNUDeL79H54OzjKCfhqnxzHejc1REaS+EhVSBkK+zgsPW+51BAfIIT2WggAAADUI9rEKqf2Y6VQITissAUHLYKAKXjAxD31UMgf1Dk1FecxSxELBbXFSa075XqamYF/+R4ahQIApUSBmVWEidGOr6EYDfFtbspvBQ1e9ios7iZWoEawOmAiT+/teGsxEwqH+mCX5PDFGNttUTGb2zbIZXdjhzxiwpsg3t8w+tZu1+HGJuPGGNFSjnQDIrS87Y2jCPP9zjP1U055izoTdwTlwdrGxYNpYSZhBO1pEwuNcWUEcmCUfusH6iuAJZ7sg3IYdqksAGTjTdyYwTDrvHEXduGmEFOYCo0fE+i+PhSc2vaxAbdNxK4IzqbjIy283T+1jiYkMI9LFUOkb5nVO3E9wxEDHtKXByfcAcf1IzrI4ynq4bHECUUEg1fAsxcBadkKOYZviKCma85unBK7fjkT6VrnmxQyooGXNxyc8EOYihTSZtJLMBxhIIiiXu59VbGvwPOmOlWjEwW97Pt87oU5hUDPDfSLcJ6LPan2srUUkNURMkZicEn0JWqd3AMOtZbKc9R4uBHu+jql515DBnTNrziqgNBc9/8YkCpZiYaL0fS+AdTciLONq8+Lpwyy6TLeotBkXTmRajMDu+yuZsta16xeb/wrK1lbFtjLDhFJ2eYdPaXtETXdjv6nR92vbiII89RQm1xPXoM9UlJny46STViCLmn2kH6R6eepXzKkCpEJGDjx2ty663M1attpuXZQvtML42j2EP0+rOfJQQnPPI7zJRtFoVU9I564TPHZvBCO+5Si9esTSRPBVTpq/13nGjOBsSYdaKNzzKEpRrQYu+fbD+W5IGykWBJIHI4r2Rh+I4Z4FjNArlYXRGQOsVe3dk0lCTyyf+4iik2+qQmBolPgq64UeiaPg3rMI1DgZgCzmASvTd59rGzrk22zcQVb2PQAmPh3rdGZ6RlKXFL4X42JGKTt+8WUoEjfXMDbQ5hFN4Kycvg5Ou2NEvi4F+vcA79J+RlsbcGm4Ye2WDHRlmMLrKJniNVHpPD737KNXaX7fG26n5RECJbA8fw5aswBYbu05+pU9EY+hsTGqbLrsyQCiX+nwi4laRY/H86J1OilfqMiQiAADJmmO7milpy3AUbXbxTKOwQA4iRmMtznR9QCrP7EdFLOiUkXGeCENtP1UlZhaOoMjhIRS7YMcmwkbvjKuCGWvVRM67FBVSy90f6yJF4c7h4U6tRwc443UHwYgJQOLs/OxVdehr8VsJLmsGPj5adCYT910wvEBvmh458Rueyl6VE8sPE+Vs7YBcnB/kM7QDYuXJBHW0fIHuCr6ChC9dbCV/CPmIdX2GJ7P7mYnp+V5gERbaK009QTDvkSP+CHvKiHOu7BQySIuTeWGS67OSriOUJSaIitdLXpSdix2L4rJ4aH/Z/nxCgSK0rxcDX8YTF7NeKxVC6EN5IJT4vChqQyrWmjAs6Jtqi2EtoJ9ijr8Gh5vGgWxQJoDft+mr4oDg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAIzEEmPyelThuRpS7IT57ThqvnlrY5E0SR1Pe4bvzIQRFxahjt7vEqRKo4YSlmW8zqInVqaG0UvGZW4ORHbfWy4sc1WVeIU6sfWgwnmAZKurJ/ty9vSyvKI3NGOKeq087gOc27xhEaYMfpt9zWG7oxeMA0/DDHsh1Z58/eA13HGpi4/pAeWC7dK+zMLh6jXqJKsvtR1hSTly+vACi0ErfVaGEQMwBV7wwJ2lkqsOI/JNo2pieoL/a/DVuYGweEFBLwVt1+PxorvtjqLjj5QSjFK7Gc7SuIL1Q3NzMhpPFHyf+lTED9qEdscULpuuECUNMZE8NgaadNVTLrUmyUBKxFB/NaI1omv/XCaa6pYHnEFfL9QLhyZQc8cPXTprW3ncBgQAAADCRzCWf/RaJ3DxettA2vDxzmplqJDQIBDztd0ic5xfRa28ifIOD7zZ4UDzWiJhC+SvcXpIseaCga3SiX1aHlyngEDcmUF/57PZz+JDXJ/n42Cmu/qYt3xIpRl/bFwCfAeGQcTcuUWbaWvJFl1rY8GfCz7bA+PbmcztpTaFZnkNxaTceN1yanDorSdLyzW/Ijew5zw/tkAU6UICscO7tzpG8sPGRB0wHuKNf2CSHHFkD8nIhkpLyDvLgx6WHnyRECUHf5a/SrP4k1HXQKWCIndISiUZHmzs4Dvkmt2K2Wnr8anLCGbtXPM8Xwao8CXCHb2qWIyXAPpCHEA14JaK99hdschKaLfzDe8F2q9/usoHDMURaL5ZhJen/mM7msA40y8ATBlgysRMW4xydnpHj9Qh9zw9OXIC/VWkte4gHEvGppRVpqEFsAVk5EpLH28ftCSk6mMTtN6H31qcHMJmdWguUAj1Dnohld0Ee31t/9y4hT0zpd94yy8fHmXnD5XOAlVyQzis8o/Q3lOWkQmcJ7jHZJOAeedeHkCxuVQ/kgHxGqfSzcnynhd11QqMoMKLJTwuy+cAOEVtswKz/glCn7w2MAyck/oD+p/WzUDDxfIQ/oPkPyzPXtaxf3GBStrj+ny90LLdlG1rxHiAKmISuaaPEuVCdO/8dBFn9p9ithhLCTWKRKVwBvPOAQ/sxO1s+wGaDst2V9UOIpdy+F2H42U64weUGqC0VBTWjP4rpCdoE9tsQJYY8LZUIiHrxKEaXPnl6L5aFm8bJLKfBcuxJxnNNC2vUD5ai5ii95//I5pO0TYae4NKxBEuvGlohKG7VyJ7ggsi2c7iX5MxGBYB+qza08YzhDHIYxVGVq6F9OmYct9cLxGMjVVads5f4nh9C1Vq3TBv4D77GdsU8iqw01M11+UNxTpVqAJGrKL//eFss2HmaJSfHSRBOx2QcJD13B+aV94QwlMhVaqaoyMEH24mnktVwIjNKx/u2ydO5VNJ4CvQ//2G6CmKd2sNsWY1FlPzDc/huefJI3ip9fC5CGQZHyuk4X8XOmdJO44mxqOAgrlyw7mM4ovsbQn23J0NcoVP+QfiuntqAXu2/l0U9YBcovrnf7RgucCNJHxu93N/bMunGx47otC4O8TGBgfS7rThDXNhLjbu4Rcnn/0wVl53G7/KPsUTbr2Qo/lV9s0YCGZzUoRWO++BjdDFJLnb4HPwJVkT9oR5LjIfBEnxeYSvuZQ1c9hrReM9UhEtLJVM9irdxmLqsuz+Jxwid80adFagKY0uIJTjz47ko6OB4GYTbBz7kaLe8iZq5tnq9SUR37gKlnBk6+9iYi2SccZG689ZScoPhHFbk5nTvF9j2UtXoKFfY0g8DqdK1pU5nm+CGSQke14mTZkZpWkQ2SQJNkrBnRHLPdR1G3irTEPD1OO1ZzOaKq2cI7zfsGl886IFXHYTDCCPCw=="
         }
       ]
     }
   ],
-  "FeeEstimator onConnectBlock should add only add a limited number of transactions from each block": [
+  "FeeEstimator onConnectBlock should exclude transactions from a block that are not in the mempool": [
     {
-      "id": "f763b6c1-55cc-442e-b2c6-2aea5abc4cae",
+      "id": "64525522-ce63-4668-b503-1a2606075d38",
       "name": "test",
-      "spendingKey": "b88a2df4b50de70bfbb14a9ab048ecbda40c745955d29f863ffe8756030c0138",
-      "incomingViewKey": "adff0c20deb09fa1b840a1d45da1931db0b77d87441a88d8d05df2e1b60a0c06",
-      "outgoingViewKey": "45cdffab369452b8969cfba390bdd4c5c0cc3be87d679b374ae5794545d18882",
-      "publicAddress": "bbb8233ef5ec9bcd5e7af777a1ebd9a5cded4a60fa5c29d141081d7689bd00d33d360669d908d57acfafd9"
+      "spendingKey": "525e258e37cb9a2f7b9633e51a30db25a4229fd9cc1aacf05c19dc68650d4afb",
+      "incomingViewKey": "5f2b70c3eec774d71323f5e884d44045b0476a55371ca5e72e3d94f6a4dc6404",
+      "outgoingViewKey": "5b7b609d4f1ee174247e91900afd5d4e67d1686d835424c55b70511144d138ff",
+      "publicAddress": "6a2346a8f6e232ff2800f4cc1617a72be737c19f6c8f0bd6097176761cea937388b5fc480dc4bb9cd1d3c7"
     },
     {
       "header": {
@@ -1701,7 +409,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:CbYjW+A2pG9jzzW/MNOc2T5Y8aZrzcKqipo13NbswVs="
+            "data": "base64:Vy4RmRFOV+HS1dfrRGSoWDPW4ihR7EvYRgxfh5UMAwM="
           },
           "size": 4
         },
@@ -1711,61 +419,143 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1665685769233,
+        "timestamp": 1668120342715,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "211477BD8DDA72B674FFFC053C68DD3759E5033C2E2E6782BA3DF87A0FDE6830",
+        "hash": "B35A5E30E57F0242B4536B9805FB3D8A3E24F499B5FC75D771991FF422C24CBD",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJK2EQ/ncu0nhhGAb/EleDTc83t5fBXJ/YlkgNqRnYl/+zD/Wb1Q1hQhlxu0OeWotok7koS1dkV6nJ+/Ovghv1r3Mm0vTPRRH5eP5kmxHyqPF+n82Hyp1K5OcsMxG0N6hgRzAjlOwYsIDe3zrW2zbpRYqoi76f5DVBZxBhXmKUGM2fQzTIkW3pi0VUNevvll4ZNrEznOU6Kemwj9fI6xxpqdqOwyUn4z4U8+vBAEkxYfDiQJ3uYwmd/L80JVoJOgc+hu3ERkgyv47goMo7yzi+RZYIApiDHVVBkrqNz1kKE1dJ7J3ZV3NUlYcypLgnMGTgID0zgVLEClEhT2bj30bHJee0A3sEHbfHVo9XVn8k96bFdU3bDIAalom6epbXKDxE8+cIkxQUNYVKdlqLpFgMFLrqQP4tueqCOJHCTQXBr+0wLqWMAL3YCjXjSUH3CEdSrSEh95L93+GXUJj1Wmg3cbGxhjuh4Yhwds5Xcf0fOIlVcYsnNTZ+Ai4TSeJ8rizCiK10JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwfbuQlGcI4YUlNhYrZz5iGJMNxPCSjj+CRIZ9MgD5iWz+rpFbil3lHNtkBATl+iCpXN/mZ/LY4MlT2ULdpUCYBA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKtd0Z/dtOeVafTQmPa8fsdWL5NawXMfQKDMhar/in6JS0gyJqDMW0HT/+6fKWCN05ODLxJKTjT1vUvr6NXY1f2mwTCPGpZwpO7WRDNEQfLhvv0A+YjQiOqqQpd2YmmgDBLuTIfukA4dUKV5h8AHvKxk6p+j9Svk+84a6GnRmBH4aCt/c8GNLg4s8MNNjtijsJQXsoLY67s8HUu+geA3nwdlDhJM935eC5ZJw2mfbbin2ixFy8Hzxw5LE7l6OXIthSvGkjz3TJUSOdK0F3UbvksFG3Evdi3EHBcLUAWuxMTRMr7wJGz9xyTieGghXLjKSQ3a95YU2J+KmTyMu1MgtW5xbqRuq8AxnOz1KNnN5jXzs+leo7W13SosfuihAZGFLodINS2dRzIe4Sjg1yOBQ58E6kAo/znQpxVbQE4BCXeiYa60NVGezTX8qOhwjvC6mcHp9vllTm4hqzfRXl3TbtqXh4nKxgHUCSKfNCAkk3o9g+LBWeiElqs8E9Ki4GJlzO5WZUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwF97KhkVV7rgW15Sb/nxyB9i+6Fq0ZyZWeRERsYNIrKsXfuow0kErdOzFdxSqr5GA8qYe/RKm3fU8vaK8muT+Bw=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "211477BD8DDA72B674FFFC053C68DD3759E5033C2E2E6782BA3DF87A0FDE6830",
+        "previousBlockHash": "B35A5E30E57F0242B4536B9805FB3D8A3E24F499B5FC75D771991FF422C24CBD",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:jrcllojiPllrdIomn053uTMkBg7ksyoCk/MDszTN/zs="
+            "data": "base64:ynGfe4/5Ht9c9i29OaLkk4KfjSjsgzwThQkZytS02Uw="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "61BEF643DEF083FB4D2667B6F11616EBD48843D13F3E79F44AE103DB0F699FDA",
+          "commitment": "113BC3407AFB5426068EF0EA229CE5805616E2538B899FE686CAAEDA7150660B",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1665685771194,
+        "timestamp": 1668120345119,
         "minersFee": "-2000000010",
         "work": "0",
-        "hash": "81E3FA4F0488FE2EC64915043D6B5708490EAC3A2D1C033CF900CE71D65B7646",
+        "hash": "CE7EF3F413517E1EDC3924A54CB62047517860F5EFDB12FD279E573DC158BF90",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAIUju//WxF9O2p7jnoTN7OK8E+JSObI/0eaRztcVGmiekFcvOL6BG3iD11fNGLKSwI6eL8US0EsYthsbxRZub9OI8Mt0SkDXG4NepbFlJlVs/FRpvJ0SYLV77jUP142zEhI6Y1yJvaEuIwk8W1vTw/4bYq/oT8T1zzDYXECMdFk0Tnra22xP4aU4Bz1iYIImzIW7xHpAF6iYNdwtzbo/30XsAUg5olrVOrwNCxWZo7WincrysqNcCay4nFCZxGfNy0kxqu5hisK3FyF5GQSpfmYrgPX0e8gVQA6vrdUA+l2fpEbTw5kaohShGhcu2S7dVuqHcxDbx7DHbINRywi1hC6glinlIQNSJAyBcDwMNghYNeZoxMnELKMy6zTevVKjzPk42E45sVjnyljHQ0JElpTg2XREW7v28UHKFZVXpa8xbykdGI+MM9uDa2/H9YHrW0CKBWPu4rilA956B4TDehQ2puOC6Ycj/aKQd4ek6Y4qdmMOhVPGOGyBl9zzaxUlWtt6CUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxmYmkp/jS2cDLuvv2CaH+AuTsIaRzPA6z0SqjJjfECqpv4kxHaxEoZHUSH+giA353UROPmU3RanzWQa/0koQAQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAI9uGLwAl7cQEU42oTR9/UIDL3UHyWLX2BTWOvxq+a5D+dKUWIJ9cz+TWNu1fU8K4YegerHZZ/wc3TEjHG8YJfjFBwgUkctFZooxhyKwIHSv31Tsu99Ux8dkYmxg66ND6gnSoAuShSukVDKL44wPIm+GU/KDsI8HpPm4ucG+5UJT5d+a4kzEnfd8iJTDufc3AaikOY5UQkLKOB9QyW89hgz3akUztAjUSSHQkLUSFG6oP++rEUnecVRJM4lOID1FSV4d/Ddh7mRF1jVQHXx8n9kTpVQMtKVboQfOoooFlBSPPggi4gh0H9QsFh7aMe+VSJI5VKxJysMiJA9rAGLX0HHZS21KRD1FPUSuhF7W1bCqDKM65g2rMVKsni29czCYGxV6KU4++GNX3T0FHIgATiaOxNluUmwfXgmGMHMOmKB5M0NvtAJWZZik3udbp+hk3fc1TbhnFrUYVAV3U14PfbaeNz/w8o1gN8MpHGXNTKwp0iv+VnjZZ3cYrqtuTU9snN0ge0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcirI3oWB0uuMU/Plx3/MaZ4MwHzhUsNt2Cv6QALe9rO2b6zoFZRrOscA1PqlPcUwscPqmFJLx+s6ATCgpsYoCg=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAIIupsBXh/3KfRk8l0fiITzOwou/NJZJzamDWs9shtQvKoMOq4qxqa6+o7fxpdNLcbY80ZmwWZiyYGXdD8ruNGXLmsZZkAPd5hHZb1vE09kKyYXE/6nKeDnOU8OiSzk5VRND8GZBACZ+LC5Ztrv24lrpMe2bnzUx6qhbf3kfpQQNto6gWBx6+ZE825qwyigRR4BDZUFJ75rEXXu1gueJD0O5WFeZoKSQvz7T4iUutO3GfZbkm+MyRkmhTZW1iUT3hDd8L0RSrBO8//S/PQ1pWtPNtFTS3WqIh6zHkWyDNcAkz9yQl28zfgScWAMLpeQT2kj7r6hDTtpUs8r5Sc3jXRIJtiNb4Dakb2PPNb8w05zZPljxpmvNwqqKmjXc1uzBWwQAAADd0mtDL0lMMfsgUUvUhys4jA7biIetOWJ5zrkE8PMumZv392ZjvW2ecBCWy79LDfNrNABLl22ytcyejXqCRoKVWdmuVvxrMlaiEdSMY61w552/V4vnWuYQNgBeYvwPHgGJM4whhyxQIhBrkjye7z6ZZ7VVwTJ9cMraAFDukZkxrmfrAJ7NUSGFsHJH3m+8whaZADytNNRLNFmUKhhLoTTpJiLC4BvyZUK1HB1gpT2Hlw0cxzw0EetyoozWTgEVg98Cte0ZdcO6EPUw6PUw5/8qj4mesZP3eejerzKctVEFFi1K1xzqJ+zWFUtATPkqGdSCTy2zu1fgioXaDe+e4j4iuD0uFNBntm5PGCE8HB2Rj33YqLKLjuGYPga21qpeDfb/CVnHYDDAxQh5j9aq2lw9LT8yRZrEijIn+tccuWDjSfTON0+0ReviuVszEEsEO1CUsTma/NlVQpofl9TX32YLSmWB4t/7PyuRR3FJUnduL9v38zgJHtaGu1dy9zppsACVuu7GK12czCDSh3n0zyqoKhwy2fwM+Tws9ny4lDgtI0EpxFPnJsrtHmbvuNBAsN/yr1JiHouKvjz8LkbgITRbagpYc6+8qPTU4OKup3pMmnPDvYFS533EE4CQeYx7n2OT5khANynHmC/ITwV38cwcsf4qycOJma40Ruffj+eebcrzhvPF8Au72KRQ4fH2WHY8zLkb4iFtQdC/9fWv3RNUqxVVVXDyhokykjxXoBIQYfGzk64ByWyQGieQvzit6UQQfA5CJPDTnwPwNyJ2A/Ug2yaPyLUwTsdOdTzy6dvp+UVJUKLIhZehXLvdBih4oUlfwEe/WK2Yzh/x0m5mFNRLMsVJ4wKQ3EZ+HHrLGAvvbXuOoxjGgEYmXDypzvsHnS/gJv+PiVa+guT1d2tbAIbOlgNqMyswq+FJyiE2JMHeQAVip4QrzcMfcuT8KSJt3zJ8O/TL4WOuNdLxmREp5dG/1nKMuqAtrZdbpNrq3nxjgzo0t4+xVs1TgcI6E0LiFHhbETnzAQeMYPwd3aVgcNyHZfQQ9apu9GkqY8/KOe0/kGgczQgsnCMa7df6Pyer70Vjgl3h810SHl5fDCFsZj6UMFDstnUOahkuuV1fPiOdydiRkRbDfikhwlSHPeFSE7XAiaY8seH9bwy/KHTlWyI0M/NeJruA15qeI7Tj8ut3etfelH48UQ0DfZnwbuFeQvwueOHqA/waHPCL8EEUq2zx2I7xG5KooKg9JTClozVb5Pz0b2BMB99Rs4N+b93wo77iyQdH/Ug+UcFAY4cpcBFb27LN1HlJat1Isrph9J+m9IfI1Gio9OcqQyP/FCkNfAHuDodiYkkmvF4jMTKCYk3pldutwYsGU6PHGNxi4oLFlNYUMAXef3FVHrV681JcmF5BLPZB0KIadhw17VW7zQ/MO5OiVeWvmc5u7jFgt5RiLrrAkO2RAQ=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAALAWA3ii20ZC2h4loQFPWtfGgK0r8YbdgJmekwtC79XxpbrDXBqgDc5YwrOPyWNtN6Bf7E9MHwB63IvUqn1WQkLC0Z4kXJkfwpzhYEQZeSCsrb+/KWpXhQAEHjcgB4NulAtbF4yZB4v/XbZcpo1BPsHYKjYy2A8XEw/jEalDwsod5KalI+iBwrQmbukMNN8JxJDiL5Atp9Sr1ULjX9K2YTsqG8q8Pv2IWTYKVbd2nbnUx6IUk2aRq7kDQoJjDjKX2+bESQBx9xqyqCQzYG/63IF9yBgTI2PhKfDluHp7eqrlmO1OcMYJ/21oexJngJ/YfPCSA1e3MuNxJgpJ/UeJZyVXLhGZEU5X4dLV1+tEZKhYM9biKFHsS9hGDF+HlQwDAwQAAADFFJ5atxccuPlMz8cWvkm4zyjc3u6faJl3ATl/nLv8BbrSkRACr6rYiEzbIqUI+tRz48iotrfpN05INSK6iVZKt/xQm4ssx5Zjvw7ufj3nVEmDa9S8ejz+O1Mk0gJ/1g2VPSx7/Pm4G/MwHj2erFfJqw6E0x63KTOAzv6fvTuMMiC8jt/lx711dVSIEx4zQWa5MTq40+AJgx5UBp4CbsAh5awfDwxSHeFOgxOPUzrudo2jNfYpR4MpzhYJcuFP9VcItHbTPnLNNzmQHbdStV2vpajxBdKZqHrGFdtZ4EgWqHsk5QSD2X1B+SWtCeg41D6AaUmQTdWE/Wox62H2oU13+D8nOlEAjkgiMNcO6pgjtKBQ4r5rsfzv/cjHfJtNNmOuMzFLN0Dx8XGUNQYjSz8SjFoJ+dFwLa2MtbfTU/d9lE1mbdEmFwpLP88rAVAtPxFkbpHbwo54vB7/KKYwWYY/jLJrz4O9AA+gP7QWc7ePryAdCTqtXxz94sVtgiyIedLO5WM3vxi7paG4ZABb1JEw8W44NlZjxPeAz1WLpl3XVrf/YCOMIRfHbewVZFbi//TpQiDMlh1Z/nU/DA60m1CRJO1SASXyPIb5mbNmULd9P4bJV17k+gXKKgWhziQr0JxcFYPDZa9Vpa+qPrvNnif/CWeY7SYtezy0M8QZJUZqQsrZdHAf0uQ3bnOkw9dXDJWKAquAIua7CfctFjlOEDeoPJf7zkEvqJdniOVnX6TTvxV43Y+rwgdqY8eJr5inzAo3deqmCZlDr5Zm36P1XwbJOc5lq3ICjDYKsqm9yW/af8DEqak1i+033pr/oJ6a3/QW39cXQFsvJMx8u+oT0xXSV6WjccJYlOuaTcq4xfch/ZTshw6Xr4Epk1gJT2LcmXcfwiPDPD3mNK40b/RbW9xEUeWfNVfQ8aDYXtu2vNmqr0/PwaGOyrRkxEC/AoHS8Aa5jALdZHH/cLHqHahSDumvKp8qw6pX9FZ9zQ56ysOmfeM6QeRM1EGNHjqqDN04zv+tmklwPsHay1/bHb7wenNHAYaddJ26JprzP6kwzHt4ZqLnKQr5LjKS+3o9f+yYMVk5VwSNSNP+Bt/qY+F9QyGyvukPtEnSByUyXea0VUphMZ2WaA4p1yrZl/9hUNtwWRYXEzxiNMvYdGA3wBN9Rn8ROixD2TxtCr8mXWzypQZ4NTPcGX2gn+4eQkk3FEWhVTlR0+2vhKjd9tujmGIoklPRwgcDevDLpQPoT78uwUpHzsZEGo6whZPIdazKhpIlZlVyQAup8wxzeCqPxsrWUayVY85P3KZtRGdiiIxJpgcN6JxQZs5WhnpiYmkn3ne6Rz2P+QfJqVjuz1V+E9JCyFBQ91u7rSu5B/HZPrbKIol0eU/rpiq1dN0oQdxKRJaCaG+ygdrKxiRQl4CuHC/uBMcRIkzAbT6Wg6zb4iC9POWNLKzazFciBA=="
+        }
+      ]
+    }
+  ],
+  "FeeEstimator onConnectBlock should remove old transactions from the cache when its maximum size is reached": [
+    {
+      "id": "92eba409-7bb8-45d0-a8a6-0a5a2320ae40",
+      "name": "account1",
+      "spendingKey": "c945c56a47c0789fa44764aac2c30f4ae93657719950c838d8c37780463f50bd",
+      "incomingViewKey": "64766214b95a29dcb75c27b1c8ba8f1777ef7267bf4f9bacf29c4398bedba004",
+      "outgoingViewKey": "3a1ce3d346d19c1a1329b2adda454d9319593349e6ff08107ff5ea52d8cb0ac7",
+      "publicAddress": "99d18fd9299ddbbe8127d7fdee08a61d8cabc35b5dfd5ec081aa806d279e24f41408663c10db482f5e51c3"
+    },
+    {
+      "id": "60432c99-38eb-437e-9306-8f2cee857934",
+      "name": "account2",
+      "spendingKey": "05ecf1882acb745713a38765b64f8449cfaaec3d49ced3f9c7e765b0cd1146a6",
+      "incomingViewKey": "2e6e4cbd58b3ea705e40a9cffd2a13ac64671fe29fc22d8a303ad25c497d1b00",
+      "outgoingViewKey": "7b146f32bd9ad12d6fda28ff5c7e85a9e53c6d9e4def6341d4f68530f1cb8975",
+      "publicAddress": "84edf52c34b26d2029582026c6817596272e751d54393ce6941c0c0d153e98db71ce76116991fd14562109"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:IVVtPMcV+htM4yPOvWZkqTWgEoQihsjxN8zSMdcbYTo="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1668120345528,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "9865209507F9CE9BF8D5174D7C8875118462483E34965DAD3FE20276F3CFB837",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI3C0NfM9fjrGswZOcimXV4NS28P3gkXp7CpuxcS1YAuGkZrromxy3sBsiw6R+rn7oFcisS9Mp8Kfj0d/m1pUM4eV7rAl2EjQutV2n5EeBtu0QMe1nGt0ErH68vpcn3Z4gNXfsLueS6CIcO9TZTpLaGkkIJaBeFl7+VlkozvSWpyOaXQ6lxdjlZoBOp196Nh4q0atbm+biZrn9K+sbPJxeFG/Ruwt9QEDllryFkaxaP+4V/GlADud0hWStVLtmHibiTrefgdvt4eBeuxFF65IDAHtC5EC+ssA//XK8wPPMFhfCeIJurL4RwJ5crqUnQzK9bgZiIAcsmo3HtwhLLVDRfl44VNaHA997zDlA9buVjWeDgIzqhZN9U5JZTcDm6gy4RKTIwTsTwfNA60ukpN6SL/fbx4Mp1IyfC2onDoejYYQQ7fbDHE5y1aNBtl/n4bNvu4rxfts64PB4RAHeb5Rx16/RqkLyARXvnoaLLQGctCHLJubS0mWvx+EYOfvn33I1LUxkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwH3G68+dJYJTpQFwoJljPcIxgCsY7ony1ToRVZO5mPJIlU6pjCaVk/NSLbH0K+3Rdw7N9TOE+4UK1/dWSCUUdBw=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "211477BD8DDA72B674FFFC053C68DD3759E5033C2E2E6782BA3DF87A0FDE6830",
+        "previousBlockHash": "9865209507F9CE9BF8D5174D7C8875118462483E34965DAD3FE20276F3CFB837",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:APKQPmUu4HcKfJfF0I3msocs1wf9/ajIMVvAZZllrx4="
+            "data": "base64:NlnyjXLYkW18O51M5ePznOAHrING1h1JW9plb3TEFCk="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "C2E57614689BD15A4E6F424F11D151647BB50BE546F8C7A271234C7B1FB3374A",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1668120347849,
+        "minersFee": "-2000000010",
+        "work": "0",
+        "hash": "AABD06A501FD2C6DA496FC52564AB38BFC149F3751BEFAB59F178A87220E3AD9",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAJAiZV5NqmIT0FUXiPNZXpv+0iSiYKHJpiXkpFY3qvz9zEzoGjXB54CDHLelPgvYC7DROCYV8HIlxa0CS1HC7OpxVqz8pcFakQeDucxNolGC5gibMYGFxvNBkgETwc2hpwI96P+TKBzKKwVYIU8l+hfUqOkujUkX9P6MZTDjJppKnnNxURoRSXNU79lo/VynFJMun0va4vZQCRI+VjqPjyCCOgQk9j0ZpltCFGQNvOex1AWxDiXkaYZPPyzW30abG89QQdyOFmkHdrby0DGzUMEic40BVw5EV5EmOwsHsno/HqvMRefq7CqTg7vUB6APa5iWdvihXUtZkj7d8CU5SATG6MihtGz8cVhW1GwKIcNycnHwndmMqBU/GKgLM7zO4YkEnFZfAR0SvB7ywx/gfSjgpU43K34rsDvUfD16wCkbmuQR6aB8nxJ9j/GM7/gm1YNzpn/PM5ZZoY577ua5Lb7Hj+aD8J5KCPJfYp0QhfHTfbne46/2BN53tyZLPryrHoUWaEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCWo6ZM/sr04/jm01zECgvxArQGHhSJw8nuWW94IQPsKNUpdZF3fwP5RpcNFKz8x4J+Iz/ZOA+FcmjC+yaAyiAA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAJfIwA4Ny4vvPll6ll7uO5XUhDYXVic86mnRqKA2+eYNHfGlmKUNgCX9ji59+KY8zqyZfPF6tYhGQjLYRXobJ+tQCfwdykBcX4w/ivnWpzbOhUn0Rrxbh+Vt/u8SPuCf6RBIn/cOwR9Js02uO25VVeeDaEJcgqwaWyHJnFiJHvrFpUATP4zhvTPEZszqTsaXGZOe42hSawyi1cv60qNCedyK9gSMXRdOtAIWFIS/E8z61qQ7LrQztY+adX1hyQOTxiioodX3WiZT3WwbdsKpYkwv215QHUpaMSkojZq85iDuQrZTDO2qtWDgMBww0IEmeYY/wSpkStoz6JUsxoXNKqghVW08xxX6G0zjI869ZmSpNaAShCKGyPE3zNIx1xthOgQAAADUFCh1LPB4JKKrxnS+bTWCDBMW2V2+5JOV6aXtqKHymH2sPT4i2yIi4/4udIiMxxvIaRabUs/pmhfKHZf/z6cj1DeifpnyEX2sw+SoOKG9kAV3QIe6k0BSIAlpCQ+GnwSTo3zqjtkVevLBEPJuJj0VmO50Txndq7wjkdDThDiXYb3zW7YP6x4x6J43E/5+ZSOJWDcwPm9jrwjVMjW5FcV7s5CWZa83dVKn1jjOdXsd03SVCI9se+y++VWnM7+et3oCqr1+J3+S2ca31+Ux8o+xGIkl3D/AkzzzsNcvXTSY37pm/xjMnDH2WUHVo6vmMyGHKpqNF1CaSopBKtTLDdxOFV9HxIjfFVK6g0ZaAu6Y95y+J7kn1p73l45dMT6QG4gulRD3yYRJch29DFIVC0ADhaT4q3OrkOcGrtIm0p4QwwALvkJFnw5IVhKdA7t6azuPvAMMqyObZyrizzjLQeJrlXTU2ZHx9sQbXGT/dMRRQ3CkZr4bP73PGzIbYnSUWj4Gd0yXIiVOX6UpsDt6uPKsuUySFejNdAwi9K8MdW2AAVBgdDIjjNIGYM0ZL6l+sHW0CTCVaRM6gwAO5RH43AORvE0NmSLPt3jCelkn1yRyHGDgAgAxSPdnRPSn8zI3O4cQEgroLbl7cwYKlFJc5cVCK4+mtRr253Gz9epH67S5RKTQxWB9OEnKSdpwfSruO38c7R/MXg6QFY6/2Sk3sgHLWWGNjkKQWktNo/lOfyVXXtBr7KRHwZ47thL2aP9s/FTBFoXli9Gmmm0QeEoW262Rk2OUSKVkzuY5UTa9x7grTKVuE60DR11LUHUpqP8UVU0+BNpat8P1M7V7nDYLMg73984vv5eWWPLkzffvAH0mN5iYZxFXl5sAwL9g0QPV+xDnUHwsqi5ELQ2KxtK2BhsYdTGeshmCqNI49/LIXXo9dR0tT6v1eOATg55SWLXla4Noo8chxdPAHO+L67mtCPnzy0ljQoIb43CNoE1l1dHK5ntOe/Ak9nteba7jey53R8nWmRbD5EAwUL1AfX/b+mn3JHfPmDsqAYVyDw3FnLuTkAfD6dDpA/IUW+o/LyZa2cJ0mQmskoHapXiir9P01SYZUGJW9AAskQFHEdgQVcUpkKcf7AorWWIILUhNtYuA6/KWYqhzmvIhN6LZlyyrlmVcrYQm09HbnhjX/Isv8hvJAdP72AL/+r6L1+VsU3uraISWRuruQXfoBrlzgJ2YBxBa+3H0CmcLuQd7pGJnpV9jOsY+42ARBV9ovZxvrDWsYyQuZnUWQsYChB834ke9d7l4nZUy2eQyA8gJuczfxHlyHet5DofncdAy0SP0bnSigpMhcWEMEmwWoP7PgJ2RSphH/nWhjYwn3FO0UAsgr0eduwNwpMH387J0S13TSA8BNT7NN9WjdO/TgyLzsR0YFq++E707kUxiN2/T0fClu/GYFlZ/al4vDg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9865209507F9CE9BF8D5174D7C8875118462483E34965DAD3FE20276F3CFB837",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:sEvxGmhkXEGzvN4MNI/KIpMd3tkq4Qu7a/8CuMH47yc="
           },
           "size": 5
         },
@@ -1773,29 +563,321 @@
           "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
           "size": 1
         },
-        "target": "12354382898144752629410295913679595511941298634701740030879966193",
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1665686134956,
+        "timestamp": 1668120348111,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "68EC95FD89C75FD2DC8F00CBE653834833B18F85098F975418587D233DE4362C",
+        "hash": "65F80A48CBADE54CE2A37AF90A34584ED041C9F5EE84F6A6EC123CA03D9D1F52",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK48ANXQ6d3xOmJ9d2b1HyazT1HwkvCdUmm2truQJfcjhpvc5nNPBWkhlhv1/WXrS6Wxcz5nntLxRxAXHsYCBvo5DUJe2VCcC24STxmp+dexlELg4F/jAJ7EThAHvyHEugoVtAz+iPrkVD7n/f/FueyCTrnrdu6037X6XDTPlXn9aWKq4dO0NXQa59kj+UXO3ITwGW4hBaRo4ZZAsMHQUK9DwLsQTBY8V/zlL7BzJW+oi4tn7l2W+GtnY2pVlYhpf48JW3Cpw5GOF2n9Hs7DqQRTz1DEoqTHJ+GKjSX+cvAXknk1paidNmiu0nYyrcn1chV+MGi+WsQstq9cSx89okLWesYHv0b0AKKED4XGEePXnLycaXmhcrhqnm6TAvVTGSsMMQ5dUu5zRnRNIUfRptoxHIvS074XhR7YKBdcG+UsCv6vm3Ysr1sc9WvblSPnC5RqYL2aSfQGsERfGJxNo7IDUo8vLLVllGO7zz+nWKEicVAb9Aq0khg1SbRW10PYUBgOjkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8Dm+pTGJSsiLKrewuKQCRhZYfFWmRru6nKwhsFQvMdrwieYRluSfL7/kP8ZIr0iXRtDlYwoXGJxrq4CWopWgBQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIg9KHR3iX/z/hHmzi1B+lczSFif8TERaeYzINt6jbIscftpps2cgjPMSbuo48sjvLP7fZ0AaIvMsaF85tfVmkIWPLo7i/SU+uSa4jxCIVsylAqyVXeyj2iol1p9T2aiLxautq2hnAZU2e+hYGqES4K2LIkexlCiuduGbCjfo2CNAUD0CzowreHH1aZF4ryFCKP4MCtCEROHAXes+spsni40UsY/emLDPH6pFa02tN+25Z1O0aQxv60YVCaX9XgF9HO0R8cs330TClQFp/I9m5oJGK7mkYMXZsk0zEa/UBmiXAvVM0+pL4wM2uUSSni9cS7ztn75wq9mFfBWRS0USAYNj53RwNEjklXEWVAu6bwOVb2o5Z6LMNl5wiw44JpW3stgHrJJhKCDYjNXTeyl4b0avmt2e+0OCodUk6KoYbwzIC9If+ZurT4XGYu4CenF4ZlUZZY//RlA5jb5zNBcsVkdyJs/3Ygm1/hfJb10vEvS8vcmDJNqkZfR5UQuNHdfgggo3EJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwn12C6hEjJShd22eafQmvJ5iT7LIM5DXikqOFFfQFacUvgqmei/lrNvrU+PhrpFVM17WvTDw67U9AfPqBLZkEAA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 4,
-        "previousBlockHash": "68EC95FD89C75FD2DC8F00CBE653834833B18F85098F975418587D233DE4362C",
+        "previousBlockHash": "65F80A48CBADE54CE2A37AF90A34584ED041C9F5EE84F6A6EC123CA03D9D1F52",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:vmLpYJFYYsxbwWvPciV7KZZJ7Ud7MiNSP7+0ldGtDj4="
+            "data": "base64:GmSQ7r3XStUT2grtCzY1oKrU5vOK2BLXxM//aQ7MYDA="
+          },
+          "size": 8
+        },
+        "nullifierCommitment": {
+          "commitment": "21E5DED121277C485485008929AB6A54D8092DCE452B0565194E2FE1A04DCF32",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1668120404632,
+        "minersFee": "-2000000009",
+        "work": "0",
+        "hash": "7A44595FDEA33C793C21E3DA1D30FD185AFDB1836CC0DF1736ECED07D8E1B550",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAIrxTMuQ8OFCFljni2ygSp1IZJwhDzXIWbWzjnUObPw2ko9JP45+67EHIiVhy9y3DIx4Itq1wyFmXikc1kddAvE/hU2ZIUAY98XXyfriVcDjh706YyiqmoBwuXrr34BIcQYzNGmUfUxgTPE4flR6ge+5q5zUakjzkX5DWnU76r2AWQB8ShYqo2uAc5vTy1AHyKBEuSiB5mbkQfoBO/s7G0hyuh9lf5DN+hOa9Ki90AxJ4PGI+17BlOdCJg7pNXDCir7jnvIY0jv0pV4HbehmOfIe9Np6T68YHp0L311aoz8BR0Ak1y38DYUA/WYaAXGl78a6tyV5UWRCmlwvXi1kEAIa8fmiXtm6ZYc8WA34SoYxlq1nGhxTrWMB3EPorBqqWAsqPYXMx5JtkjFuLvXr92yuoSFfWkB5YhqPUfkRXRyV6sTMcQvyU9MOaTZOcmme13RArN6RVkiJ92BiVPBT+Lmj2F/G1lZhQBZmZLq2S7+MfZc/FUaButrEZn6Oi8rbHz7RTUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAPekXA0Tosm9vdxQl/mT518iMila5rXYyosvcg/YO4WLPzPueroModkESgQe1a75xQ9ocUjFR338/2ijvTDZDQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAALNdKHpLtBp1WoYpUBRyG4b3pZ4BIzEudg21SC70Nd59Edw64B1rX8D5sR6GqFvH+q9Gs2Gh5uG1urDKCZJ8A9RHsFrG2SNCvU0eDfHcQ0bvH6FQGwMNEbk7t5dZ9yWjCxK29mYYyjTeDglQclAbUUR4ZG7o7qyzozzMzA/E8MRyN6daeWfm1Oz2rWz1VXUVw447bTlzkkyS/ghUscWJke1zJ4Lf0Yg5UQrqmHVsuyO8lmqqXxWLRScJUJF9heMRPWiYI+2lwSaPHo0EmwGQD83daU7uHTvGxLHH/DWUDzjTUeU0J+I6rdtCGmm2MO9bIO6JXZAJVCK/UT8w3bW5K9ywS/EaaGRcQbO83gw0j8oikx3e2SrhC7tr/wK4wfjvJwUAAACNU5ZVro4OZ20ZrUwQH209g6bGQ6suhtuVsNUEdpJ2a+yR2YZBFgLewV2/Y/rEjgfaA5shrP5v+q/ttlAUtvWd/LlPeYlJn7rAyoybMCPTYoudVs2b9psIOwkRGDIZ6wODXxi3BJlAyXwHwmmAtRmHwsirggSPamLmO/xrSuNpgoVLkJiLxdjw1NTiUX7QwGWG+Rp657wwzd7b6+h1wbcQkKx43/1sF6Au97OR7wEmnqwYO/ITiqWTRgrZmqu/tIUIXRaq9yXdxtZHScQwvAzRQMiScD5RuCNdHpb50PEgdbMfca+Qf0QhiU6ngpkCd16RCW9jN4oJuCkdauQwDayDNfO/zMVUVulfVkmTv51QRP9XYbGUeyL+cJrA5ytho0sXTknJEuiCbnHgnx5DFOymlwD5xf3jLV4ano8TRL8j4BoQQCBAKXoaBPqAHO0TJgWQCU/cPCMCYhHXOWp7p2RT+T0laLenHh3ZqGy9hWckBNG7cL6PqStDFXNrudaxlieorql7zG+wmBf0jK+wLowNvlvzMylKwHtgAWSZtjGofxG3Q7cOdJmW0uYDbFyXG8KwoE25L6jCjtVVME+HdnIYPlRYqDwOROZNJJgQ5TdhJBux/2emo2vf473+b3N2zh6Dgj4EJ1At4vyk3OHhmbwwV+udumz4kR++7jPIgrlKKFpx96+JnKikabpT/lacigW73s2lyefrdYPNJmZhSVyxJiMldqqvEoYSiLmLbFHzH/30cZeCNwQayPXynXBOh/BxfQx6iuB98PWuFD0uyX6mE93w3v3TTHuq8GJecoVw850o14hgzO9qOKo0UJ7z2Mc3Q3+IalZQB3LqYrGnAoUZf8kTdT/y9dagAWyDx5qzMNdhhxCKHKhV7T9PhMX466Fl2cJ7UF7+N7+15HnVoj3b65Q1XzpTRhKSubKHVX5mPTKLpLipIAqDVruAvMJBkagL4Y61qD5jvaMsKNs33xuS/XE3FjK3anjUL1nZIOCR/M2vM4P7dAX15ouW84SsQ9p3O7ZaLLx3wzPRS41UPkhZfsqnyvcq2SyeIfQDrhzBcR8oFheJ6IVcBTsbexg6cgHn4SFC0gfBo1neQyZ/yM5YAMGvWIyOHqIF8p4PDNzUIS4cyQH9SmJdhyLDtc5yB2VXwQ2pk73vaqqZlXTgvf0N83VNnjcO+GRUNA6ZF43OESELixGr6yCVQdk8hHQvY3n8tOw7k2fvOW5iZnV6jPhaaYtqsNLGsNJE0tOmi13Nq5Z7TfHe3yxmGzSeTmyhe3OqaqfLG6M+/1RlU/bybaEFLmbbT0Z3fYQFJwd13tyKuhfFtaPVAuES2L1B8OFLIvcwQVwWb88VmK+PNCFLe++7BYHLcgmpLFjSFXmNt32FKK8yMgEiRuGmPB+UqpQtd3qTmLmcG5KxbP27qaZZHvfFEvb5bpmMeg+ZIN+P0Kpstj6+yO9lDg=="
+        }
+      ]
+    }
+  ],
+  "FeeEstimator onConnectBlock should keep old transactions in the cache if its maximum size has not been reached": [
+    {
+      "id": "f19d03d8-85fd-449b-ba60-ae41e3705b9b",
+      "name": "account1",
+      "spendingKey": "74ca8d17e0e33119d3be5519d4b0be83424e5d28d7b9bda4a171029410076ccd",
+      "incomingViewKey": "6c10acd1c2039d8314f1666e0fce7b711dfe8b6a7c3052a28242d1746dfcc602",
+      "outgoingViewKey": "b200d6d5ea52cddadf2c0ee4d9a5a3528c7dd187b3a841de5fcf5fbe20257107",
+      "publicAddress": "a81f1d382c6c140c6648f9274f02ae9f00e751818767340e1c10f76b30bcc46bdc3180348101621baab814"
+    },
+    {
+      "id": "d671610f-9dbf-4a55-8cd9-7e3d6bed131d",
+      "name": "account2",
+      "spendingKey": "cb488318f9456f7aa6e811889615c78b3c2ad61722f3ee2cd9815c7619922f62",
+      "incomingViewKey": "19ef2a9ac34fa8bccfb610a33628866adc9b1ae602a57e8d5546c67861c84403",
+      "outgoingViewKey": "79b055b74e92943f0460fcbaf737c5e12be770f1178cf0f5341b60d82bcdd4e7",
+      "publicAddress": "3c0832069058ce3920a40c4e49d53e11618247e9d43b9b816ed7b8e04e94599c7520494f4c61d0b6fbecda"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:wDaIuhVolBzg0SzIy/MrUlT2KTQ/0k4GKuMBMY6z6kA="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1668120350647,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "BBA0BBEF48004CFABBC3009279526FCC8D2D355FCBCE6A4D8F5743696D526905",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAK9RW0EVUkUmCWY2YbjjB0RYDTlXlNZ5568TKtDnjHZReXTnIAMvWY2sz0Rd7eZINZVUiEFu74VpxQae+c5uwTsfEkXHjWSLw9LcxYuau0myJLUHCnrKBul+NlOQyPJU6Ae+VQJExCqqCy+lOkprWONDC0g0Sk+8w+0Tpp1qoY0/d9cHa0igSJ3ts9tzxV121a3H8RnGF/opCtn0AP4kbapE2Je3yGQB9y/5JRUd+oXZdHM/Sr/TVfWADP/GIJeaN8QSm+Ij3oEa50jDU5GuFGPyARgOZ8vysIpiL2O4976x3fTy5AGel4r4tvkpe0w2JSfciyoTP+T30A1+RVClzD3NnofOsln7C0AEnxb3QnWNr12qou8VCKhW2bA9jpsJbiDIwTeOEfKq76YajsPBCLNTeJBS7KyyFgnv/qIlo5f70+25XAkS6yZZrtt2gUlG90sg5NyOIBfiumhO3UVW+UJEXPNTgTcd7t9BQ0cLO0gytPLVpg6WexzWNAvaRdGzHKJ+NUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbAw9jvQZisHG4zHhMngJebBUCwz5jrRnctvfP3ue+B4hNFF1FJRCTRaqQzeY/BBKwFKMPnA92hFTt7ucnis/Aw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "BBA0BBEF48004CFABBC3009279526FCC8D2D355FCBCE6A4D8F5743696D526905",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:+qH/4tBBByOz3jIHcCsZ37nSvqmZO6d4ZT+RkvqvXgk="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "949D5BE6F9B2EC99686E7E3625131BB19AB0A78DACAC8FA0FF32CA67D0B9A299",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1668120353001,
+        "minersFee": "-2000000010",
+        "work": "0",
+        "hash": "7F012E7BAD0F97061769044352821BF3D2F08AB7CE9B2C7D9FEC6256B302EF8D",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAJmYmdQGDjZI4Sy2fON3FHB19ujkDdP0kIMcnIonaGvEWvn+4Uv2hBsESmMTsyiu1qmkJRfltqiUPbS19CnnKZ4fgBND3nXYOnOkKdLFCgMUe1lefOdP8vsZ4JNPyE0gVQif61Qcx56a0tJ1dDslCJ2lLDGrpY3+P4Y2fCcWFFUurye+NOuKnsRRiHasyRvUF4KYYY+nCqKLi1eg8T9kuaRpdPKQrkK7Hv8sSmnSrMUduCacs1s2OyOSXZ3LXArw0jM2fUgXf9Ssno1vcUAslUmtbvBdaHhkOzdOXVof5wkHnxCV80iHALy7qU6fFaapwoxUjeGdBCmuAC2QnB9V+gUXzzdY6ve+CsfWVXJ8nDQJPp4oltQMQVUKSvYOlsPbI093sFW+jtTXefVuRpi7sT+LtYXQLJ4hn4wT+KO/DYa+smou59hKHzuiKZpfzPn2EQjoQqqNEQc0cxombB2Wqh8hFTXluAd1MPUv+GS+LA5RkpDtl6kelZWBK5rSr8o/8BCTEEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjgOhZf/0Sq9XG4O8jyr3Zp+FifBWGAHcH7GEt8J4Y4slGUyWEcAm0rWzP/rc/6mqwOVs+QOvgdfl40jkr5F/BQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAKR6FfZ69elqxDpuP3YAaY3Mb4yCYD7UUMDT9n90m6R8O9Xv7UXAt1ZFtOgS+rGjPLIEZ3LVlJYWDgUolWVQRl8iTUYgT/AqzIYzN8N5QG7XY5mN8yhQZhzA22d7tQ7KsgepQ26oExDBVeIqDuHvT4xYHnXB+I1AqqUse4hDAYCgAK9i9tfjXSdf/aOX2aa+po4bEW67bSyvFKYgl5lqljFzIol1OFbrRvTMGxIAlgChTPIcPDxnYqCEsBnhzX3BcJ626byfg1XU5mJDEz9JaK5o4EewRxOX9p5i//lSqDwKsk6Jnb5zK7CSZVU50ygoR3GTbGcJuHvpqarKs+1Ww7rANoi6FWiUHODRLMjL8ytSVPYpND/STgYq4wExjrPqQAQAAAD9ih1Gnf6KwsIQHFnkIDFlztxvtFhmN0gO0wpDmyc9dnlfZs7UdyPk7Px0dbnCFKVy3jiH6gLpI1lgPSZl5mrN8Qbx19jy4LQxYbJDzFsY4y52eWwOFAA7X2ElcBjzgQ2xUpzVQkf9+uttokaTf+kZvfT/+gAfEtPH4aV9C0dVtBAVmi49d7URlv673C6CSwqLfILGWrpQi4L8Yg9ArDyaXBgyUn/d7H2LoX1buqa2ctpntLwv83wkGdSlxh4dfskQG2mQvVjeANFKoHi7FoHRbeZXoDHQUg5W1AG2urg9zeRTRIGmvK1rB9o0aA+uUwO45PtuyXUDOvOXo62EFM4GRXjyw6XkTN/Ldi3hF2f8hd6n9VOuaCP8RVo1tYaJ5ZZ5kFrKPmU2LlQnKi90QrBOEOq9wlm8sT2N75kyQd3vs+18qQ8vbWGyly5ZhFjYgapAu0+gAXVgvcTuqxJA9B5WZAeR5NPquyPotyHw1a4/yqFQ8tXmv2FWus6El12xxFl4s09Iv9dPwoaJELLu/9UxAkTphkQH5PWOJUxkHLEKzuqp0HhjXeplGNi+2AHU2cbh1asAsnaiCxqalsB7uYaB/F4ltkTgutogYRF8E+hfgwpYipOJtyvgSH56YOo2rl4XCprjPYIdQl0XbkY7/IxglTPObCwByDBr0zbec4nhohU/uU22EmqEgEyZawJFr4D1QiOGpqpH4E26qLlIOdcPR6M1tqKukgqt9O7l87ai7PJgnJnSqCQ8OOTSJqOkamuplYCo/jsv0Jm01sX1JITFrtAvBgIaXdAiIoboq3Ph2pqci65N/VwFw8NU87+SM6N7D8K2iIeF4nVN+mhJcfcbsW6hrXHn2o3SqG83Gk3IBAZ2kQmogQ4sZj4sFnaTLbkes1MNEYLBBbCocOx3HPEuMhBUokK+vIzoTFE8RK1vskQUUKwZGUdZ0QYIBzaSJnFzzcWwDxBNdYFuJMNMXXtMsfP7wIr5kXjMpM4fN+MBl+B/xgdmmtRNj+Kkji3h55wsRxQVvbVW0TSl5i7GJFNfDMLz5zZhB5iLJZd7SVW+tHtwBmCQwfxivzofbg6mTyFILBEpX8rWcFQ51pXQEGWPDLnC1UfBVpxLdC5MDzI5tyTdJHmkb3/ZNWLJQa+2w/+jnjT9q5x0qvoQ987x05vojPcrRTKejf06WPR/NSs9cHiJzPdZqqs/ASyXbJX7ZmG/3UAv3YIKhfi8dtMieBMDbXtPtOG37svM0iXpJ8R8ZIfpuGp4rzHq6pc8wsiSK+G7BHhErpGPECsq2ZUI6T8+zkUkaULWNzN00lv8e91aHyHRlUXZqeWHUirEhfXDV1LAlItEIuVIFoC6qXWVEOfb7jGIO8c5n7KsW7V25P/ShPCSWWaWukvguVHfUWz1gQRBPxx/CgNIGy90K3mTEK1F6iG5S5tOIVCfJX3jQXxHryqT4yeCCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "BBA0BBEF48004CFABBC3009279526FCC8D2D355FCBCE6A4D8F5743696D526905",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:qL5/5Ujvh13ghro83Upq9JTGsYjsqkaUrRQqhNLc81c="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1668120353262,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "9D8400B465D05A88A925BFA96BBC7A7246FECB44836706355CF06E3BACB4E820",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAINOdd34Chfj3zXO2ur/uwX56pVJ/hRXyOF/70U8bNeUeHZAfI3nmorcMGl4ralZLqdueiRxnPcqsB2TeMqJuFL9RJOSPJQtDWJn4XR7ONXng55/VkohqgJOr/kzsXJ0SQ7+ySusnMoiECZXRRh+9ziFprbCS1KFj7YTr7cIQIEiEss8pFBdQjNMPV/xr49s47jiMbrEigu+WIHKjXyJ/YHruoL4KmTT/ZYR2XTj4FndXN19joyCoU4umwGtM2FUEe9ZYcPV7/jhZs0jz0UYhT8zOf2c2frZN0kVipy100fb9FaSJSWoZk5jNvjibfuDdHCIcLU1ZmqiStRSiC6gD1nbSUJsk+N3oQ0x5fGLt3yRVPMY0DAH3vOzkkGVLBSlyeZ+epFRyGRn3FaSpqLjmnCHSnHTJlzcpUWc2BsAQS4qSjGETJ7Q3yF6qRh7GKtzHYhlr1MkAMn0AEeIoUdB6NY0HWMseACEvjYAoIhWqd+3Y4HhlQfNnN87k9NAH9IFRd3buUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFXqV43gZzXbGDfvTogZA67ozgI8Ota9ucZpyxcletzEgvEnd6y0hZD3Rsxl/nFAcijbkDqpQI6//rXSORrslCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "9D8400B465D05A88A925BFA96BBC7A7246FECB44836706355CF06E3BACB4E820",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:2rGLkQoFMVMAHkQ/+TgmGFu4ar0MsULQIcBItlWe1lo="
+          },
+          "size": 8
+        },
+        "nullifierCommitment": {
+          "commitment": "F8C3DDFD299FB691F30C105A061751C24D06893D0C6654E17D05DAED5F5A6799",
+          "size": 2
+        },
+        "target": "12125914735029618651641478138433091614955445451606161528078635362",
+        "randomness": "0",
+        "timestamp": 1668120406842,
+        "minersFee": "-2000000009",
+        "work": "0",
+        "hash": "26E541DEC317A282D670983076C6DDFCECEC1A6AE6BBA876D1C6DB1CFF765F6A",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAKpgqQiRCIifg71LNUZA4WMwqKNPvcBOJ0hOh9vlzz17AHy3RBs24Xf0ZX0dc1LgDbV1SAJVGomzuZHWVwxkPTOLpVtjgJPWY8YEwqZF0cP019djKzhxgmws6O24kbZ/chXqDsiAhoO65T2EfqQtRbUS7lHeCGRHEPof/lAx8ONKoiBjkTg8gc0SIUsgU2tcM7lGavGAWmjnmnvoKBjEhEGvqZ69kmP/tRsXgOQHTkwzWScE1XUZPcarNdxMXylMHqKy1pWf6kt2PvU5Ngf0zrldQ+hzGueO97sw/DuhzuFusgasI2RZd0LYPHOMBjsNkpaX8mpNgzscdpJXSJPERRlfGjc22DDaYzTP8H96ZF0EaMsirk6f2IJ+CbFfNM3EWgjktKZ+830sTQjhyWcBlaF0Eb3/HImRJuFMPN1QZ+ZXuFnGtE9R6HB+MHNVAnTBtuXhw68xwVt0d2tJXkLBqUNi/Buv6mW6awIIYT2XtZIzZcljPNiXYeLY7SSD+Ggoq+HP1kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBTLTNQYdWZYEzkbs2vBcmteds1txjSoXl4eD65J6+Ym3swNwH1vd8GYbxCC6+pQxZy92BpGLjQ7VowuAlniZCg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAAKOyJBCM+Lz3WZkqQZ3rYT9AwbF/kbBvS2+ITNZwGAO6kxnqa8rdZUoqwn+KQRSPmYh/WlxhLhaaK8LNoN4HL8GRzLM8AIO+RqalqXw+p+gdy32Jma0YzWHSqWp0dEbMCA/TJfq5sUFj4QqoYISwICyJwo+5NEt3iv3/Ik4eP5gKY3Be5p5dYDzuonUZcNNFsKbLUI+czWSSb4I/mQvBaLHS5a5aHFK0AddpCaDe6rvAMRqw+Cjafr9ZG9C1Zz4NNWfdTvct0kKwgk/2oPFrC8TYCHcr8IoUNlIaWnPx+ScUhjDhpNuFti9KiGkJPG6XzA38D4bbB8vA4ffAu6khmgCovn/lSO+HXeCGujzdSmr0lMaxiOyqRpStFCqE0tzzVwUAAACVHxarNvONITvMHxVPW2LZhvg9QaansD6l89fCYtL8xcnDLVI8b2NRRTFXt9C2f8lc3YJlKQDGv0Vo5q4GoIU3Q3XAziMUVAIxF8z5j96ZGiX7LKpktVT/nPhArQKd0AWmI5yjRUqJxCp+UEcxJ5QEf0C+kQAXW9j4uTCq4+ZpBju8lrIRxVfw4d6X6mZARYWvLx1ODMdFNCibNAA1GEGAfGDqExqCxSwuziGtVP1FNnMd4RyAss6iLrk7BhuZ56EAU4KEGFInrVVsd61ohA/NSO0nPFzaJ1OqAVNTAHYyxlalsEW2Sk3Pc6oqjFBhWpyGlSpYTWNy+HrkUz/PjY2E/xn3CJGjEXxUqT9wXETbRZ7V+DCu10pZI4/wBuk1/rLrdu3bTo2uLcm77b2CrKGeHFMWzaNrPTbkHIHQPer/EmrykXjGgVVcpO9dVtKWd/8SuFkuJ78929sNw7/ZXRFANC/64I8AoyxFZsuTSjdQFgh6+riD2tWo0Xf4N79UuzleQ8zVk0VRWbSb10/dU8CFPNZd3qaWjsB4VfUp7X1qApTDUhtCgSd86O8LdlOtFSHBS7C4YnISOY5E1kiyF8lRcCQVfJ5vp7yNY+LT2daFpOu6B4eI3tkBBTj4MNghNFUdNOCM+iF4Z7gKD+ISYC5T1tpfqZQjESqma4fmuhgPZJJ3vaVJp6XDI112hZogJUkiULPZjTHZSavpgb+CFgXulrLMm890BrSB6enFBrhlPm9AbKrvoTsIwevJUNCMGojloGmtuK/F8opHVzLMJ8A9KmiQ47fhaacNWtaYsdwj0pNuqo05KiS31ZnBNXXJVNxK6m3Zs/6eyhe+W1AGtP+xc2DWpShVu99NospR0QotqE0+1A+2jmaCEY8AZh5tU0dN35aLbEl6ffCAJI8afz4y/uniQkL4uyf8mGtzQDhZsfxbtaGCPc55peT2IdUm3SKSOCscRoDOoUwEXHxQbkFV3i/TBriNao653rxhaH8AI6vKaLzOiwnsiMKuu5FY4S+tP1vIr0nKh3L04lMDKWoa/4hJHudwSLos5ECy5hG1QpO4Nectp5zS+r0xOiAGethpgVyTa2FUuR0TX9pcotmPd/7VzsWp8O2m2Qh3+SmeiPEukxfMoRwYqJDtsUml95dUiBpg5S9IyQTR1+grz/qsLIsy+jx//xZ7/wav9AT4NmRDF7+/p0mvZ8xL0c7rMvT2GHuq8XEMY0Vb+TXfrLttUsuUUllmVMJS6OdwjUYgtB+GG14ITRv96OijvPDAC++WC7z/hP4Tc/n/DzBoPF58F/B2GZgzT6gM3XQA0D51fOJAk5YclZwPd788nQK4T2doATquoYB9sGoNKMSCk9ABx7UZUHImsnBiDYx6l8AjQuioPx85SOw9DIZ1NsqFXAqbR1tHS+fSGdRQ5aMnEvywCE/t1iwoREhkorXlKykawHUkx1FiBQ=="
+        }
+      ]
+    }
+  ],
+  "FeeEstimator onConnectBlock should add only add a limited number of transactions from each block": [
+    {
+      "id": "c9f22745-150d-418c-aeb8-49f9cbda095b",
+      "name": "account1",
+      "spendingKey": "0fdd75c605dfa84eac8c7fce5d16eee68227460c34b51c55114caab5853e4a08",
+      "incomingViewKey": "dc7b2b670c9dd43e0c05794af9c0da0b6610fa8540b33c5f506f003d4754d800",
+      "outgoingViewKey": "80da8f5e2fc8d76fc880c7ca4ce15c2661a3eb3e802f0142b5dd32c0bba39ccb",
+      "publicAddress": "47759fc4d3bd5387292b621e7e08bb7180aeb9e3c3669c3ab30bf4594ed84da2e7955b09183d9291005b23"
+    },
+    {
+      "id": "595f077a-0a0e-4751-99ef-e84a130247f9",
+      "name": "account2",
+      "spendingKey": "48026d7b09afc3ca898087810b2623de0555ab3ecfee644f2c2870b136752433",
+      "incomingViewKey": "1294472dc8a42df2f98d54a1847bbc0528aaf99ba45bb8625d8a68c8e6746301",
+      "outgoingViewKey": "67e3dc69fc9160c9d525be74c67724769afc49e3ad8a95fd6de3caaee4784dfb",
+      "publicAddress": "8862482365a1115fe4c597728dd608d4d825c2259fc905d7f127275d0341ccfd0a917b64153c551040dba3"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:Rkay7I1IcseOMhEksHu+vMcdiqbRIKquRLyISiaYkko="
+          },
+          "size": 4
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12167378078913471945996581698193578003257923478462384564023044230",
+        "randomness": "0",
+        "timestamp": 1668120355882,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "CC3F4761E008AD5FD18A03DA1CFCD25D30DF633C0670FF06F08E51BB208FAD36",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKWdOLD4xzEVA+hqlYqq2obAuC4t5Pxx/mpSBiE3XhMadXniXajI1mcEjs7cHAAjW6SLUYHuGBd0TEnaITSXV51gEzeCKz0dIkHGZ6SjtueQoDMSX+JEzLdlWJaHaqKfAxnVV2W+8bf8HOhkWDUL3+cGXyanzOYOr2H9OX6o69DV87BsRCTWrN2fKRzyt2gz/bI20UD7bHI8z1bXaxGKC6afFYK2eWixR5kD1KX7Zk2SiYjcXqWNOeiGed8aw4CY83MxzM/LJ5rh0W3ZFHSsYW2XwZ9//LVldQFaa0w2PCOERq/3TDm+/60vGle/HYugLdrvBvuK2PDjFq/xEW/Us0BWTvJYPO/3fQcqbrtRMuf5KnEpdwC0OAIhxyzyOZJoqUjW0jKEXCzkurjJ2wMQjP+S5xNfUHInCrAz36l7fdH4tsW02+RMa3Bd5YNuhNBUQ8v7oqxamkcLDYk0PqyBcmLXmYHXxQRjx4PneiF3PAio/nf+wyEBIVlb+WPO6otOt0ZjYUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw7p2UtaKeBCNRHXH6Ckvp1OKmYiXrJtr3CpxEcrU6Obs2ZYVwLKoqSRtCSl897zLi++HiCdEZ2sfVA+CuWHY2Cw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "CC3F4761E008AD5FD18A03DA1CFCD25D30DF633C0670FF06F08E51BB208FAD36",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:WSDLm7MXeObJ8+YEGmN8fVMhlG0xWEgVb/W8VM+fRSo="
+          },
+          "size": 7
+        },
+        "nullifierCommitment": {
+          "commitment": "A3BD51EF82A293CF65F21F8B29F53859ACE84A8C6C87639C75833171DD72D4E1",
+          "size": 2
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1668120358247,
+        "minersFee": "-2000000010",
+        "work": "0",
+        "hash": "440F904B8A64FCEBB47ED238F19F75CA7A5F6D312F77F01D33F4515B98517EE3",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAALkGEZQAf9/tk8Dr/n+xY/RkDHVFi0UN5nxoFLXkBzs9LmUWA1XyZDHDjmjt+AcZ0q6taUTyoU8qdPhQ6NNzJavv5XPBvhOwkIkXGLmVEnLbpaejeYZ63H3HzFB5PZPxegEu+D6tqPEiP2SQCUFT+c6XfyMZGTintaIkMqwj+HT7TiE+ed7GsCCCt1CN394QyoFYnQK51Gb7hjBHccMQyJy88wD73I/OfQXyNypl+n7OZmNBVsMcAwvUqes+k5JN1/iKaPPET44wftx9GVQq6uCGK4N1+PC9gkoHN2jnvMS6mgeiCXPOCDMggxUD/y6KE8XSAdPVplkDkIP25HNINA2/Y7l4pm0SQPZkvqguGe/QUnny/cD38xTnlBAwxCmytDgj+LrO5osx/3HNz3wXhRVgQV3BBB/R+v1LQ3jBxp3X0B5Y3w9jznjqWiPOCBx+Akn/CS4Gp6+VzMMtPIVIAcFdLERXuhEHzYZOiErNjZfvFCfZi2yS1yYqwbfidbyTwzyhw0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw6CSefOf60SNR6p3pErkDER+6Yrun8RgqhdeiHy6tZ5K4FO3iwx8/mLMYk2/ylVv0c3X7qWczSTR+NPxfIxqmAA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAIm1p+5exdW8cV6HrnNncqt8NNNV43wQHN5MtUCxoS5FD0Rhx2LX/Gq6Tis7BgZqpZWMH/m+HtVs1r/vVwYjmm5YMDuA2uCyLMZlvUvnRgHyUyNfdKzVOSRKYt3oatj4mAb/XEIusO4HR4JIcvovAvSbN95pPmOWnXd9Pk4sf/p48WYucEOBYaz+ddQPk4xM04hqSfNXoPjE/yPTCHNeE7gH4OiIR5I94RxLx34w/hCmLw/czSNB5MjmSAvoMH7SWMAspYVsjGfAv4H3ZtqyAYKIZ50MNAAGQBRS6UBToHamkEOWPgHW7KUQDx+xAwn9hTfAHrf5miqq2Q0GMtPcgrxGRrLsjUhyx44yESSwe768xx2KptEgqq5EvIhKJpiSSgQAAAC+Ga9qt6pdSmKA53Gebj3WmWtOgG2lLRtJRR1tuSVvfero7xUvUlCFpTDVmoeHkqv2g78CEbBSOaVvkO+y7ISr+hYRiP8gphCXf1wu4jyUkkR89oD3pWRXB+BMrPj+fwKX2SM9QiWoakiytHTFuIkQmZNhYcvKB/fwCVkOXZ0wn0BPlmyClHHscrpp4F0vDaKQM+A+YwWqY9Lsd2yVWYAtozQ37zpU7u+mkotVaddoAdnZyZI2MQ/V+dLbAebv8q4U5ACMOtbTKfWSGYJgSzlwwauR3F+6LapjluCv2P/yRcamQCpfMPM1NCBexc+csUGX8xawDXux7lkFdFbfgwONqjsKKKk7y6GOqSmn+Tfk0eF50bU2yhyjtG89iEPksAprBI6s5Cx1o3848RsIVNsybgtiShRSwDm4cUc897z0MbF/l2SaNvcjcbBfqiJN6sJ6/6ubY1luXXYzdgbNNoFBUBIBPHTcSMGoOuT/hsgqwpF3xtX5fSUDFMfLHG/UQzRONhQqqtyNxykHiZZELAGy0aoSpmDZDVD6nwq4rOu+hH/VqIUQXUzAC704ifoc0DDjQCSeicQabi3nAtqBed3mvRuowVCl+oYcbxs6GY62zsWla25Qp5Zi5mcLBT5p6Vkd3MIW4A+Lj2hTGbv7QizMkDIh57KNSbMnFIiLAlu3VV9nzZw5Fafu+xAlLhTAz6ShQ/DPGBzwtroFHQ5yl354EVknqlD7y26MZKX0qK+GXJTOv7m/c4Nnswt/9jOHS1aTaUGvveMcJkcY1OuywuGCveLC5PXlzJJzIGUD0rdSu6ZO2bC/w58yXleu7hfUrPrpixjwN6KYnmkEW2s7Ky/I9Pu4AZk+oaW2EDmr2ZlzsEkukwJ21j5b+f5pm3EH2ktdRL/wvWP9w11/XfCG4vtGYCEva341eZVnS827WVOILDlMPZir1ge1FWFw5pGF/EoP1v50RU6PFGao0NcBHf0pdUOhH7ZNutc8RbtoIMzAPpFhumqw85Ozo/ENy221gmN3ewLXyS2K1eUWL0pEnR/M61SDkvQTgSJue28gyYXXd2L/QeZNPntjChdBMQflr8ZjPlGCbynBRV3zh1/PThc8QObUGMBkAGrlVrtpgpNXlLm7cNbVfCLcY0t7nrBXd39eZaE8kwq8zV/y77ydMLOBfC3lvmec1BLRyQDo6TI0DUCEQu76bbzc8SwakpQ5d0wG2JJWD6vrhyGEAYUPNZRq4xjy92uH1kePFGa1pxYPIVkIEhKGGCqNgu+7r7X5PcfZc189FkTN1puFSvjwuDSotEcOQbX6V23IhwHqO8ynaj88vRT7V5TS7svXZNA7D2rH7NaK+TPTiw782KsQotmXpxd5mUP46suXvNwBmuo8tTING23L7dgUQfuKM8tMBt/ShnPekmJPl6Y5Ckjmbj2qUPuAoXpp1J3lxcUxJnWc9DUcogKRAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "CC3F4761E008AD5FD18A03DA1CFCD25D30DF633C0670FF06F08E51BB208FAD36",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:12SRPUowrr4T7Ix+uyAbEIVJbGSiE2/gIuZEs/vu8WM="
+          },
+          "size": 5
+        },
+        "nullifierCommitment": {
+          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
+          "size": 1
+        },
+        "target": "12131835591833296355903882315508391652467087441833704656133504637",
+        "randomness": "0",
+        "timestamp": 1668120358477,
+        "minersFee": "-2000000000",
+        "work": "0",
+        "hash": "72C22C12E29D56B13CD0A22238FF51B2D87802580CF25099EFAEF9A05FE03C6D",
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIeXE7En42ozYmaWTote7j/2ahvhVS3b1nAl5xiZ+eZg7BBgQoXuq2qzfuQarO+Y0YKMgCwRhZb/9NlAJgYO8LaRNlCFuzIPUj8vagytiQIR3g4JMWzZwZgYcJiyERgOzgawp3kwaQKvVi3KbyXyEKWG5YYeOTwNgcAvOdKqmQp9BLdANxbF7icmBhLxz5/8RoOz24+g9tHnAL4h93DJPyNe5fFpZNSzP0PyM6EZDMhaLr6VrIxknujhWvAZMrSWKwyxbfelA/j0i3X8gAnzDHILWHlWZYy91BWWRfB3S6pR/SevEeONjKuraeLr4qvbx01LyE6wbO3+ea2onsLPY3Nk4Ar3PbvjqwPzi86mEjei+XS79WzZv9U209ZHbqI0toJvZJ1WaPm4aqd9lHyCn0lg2Q3+23s746dH6PdzaL5OlJ9HElOnrFST4tmc5tSokhPqUwMoWXBHWbroEYy4V2ViUHgwa6bkPRO5YZpgTPpoDurKZoQqIhPGUnYDYQYSAvUliUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwK/WR0eEn12cAnAc/wXAmgJVTGfF60+MC646RQuVcWCjMZJ63FDAEz/ltYNBsQlFW0JA6KgAqoUXeFOgYLHuKDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "72C22C12E29D56B13CD0A22238FF51B2D87802580CF25099EFAEF9A05FE03C6D",
+        "noteCommitment": {
+          "commitment": {
+            "type": "Buffer",
+            "data": "base64:ZN9xY8C5tZ9F5aUng73pBQ30T8Omze69FdJXZ5hBu0M="
           },
           "size": 6
         },
@@ -1803,29 +885,29 @@
           "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
           "size": 1
         },
-        "target": "12318294145767769509421591566974374586912282914839103377404749309",
+        "target": "12096396928958695709100635723060514718229275323289987966729581326",
         "randomness": "0",
-        "timestamp": 1665686135215,
+        "timestamp": 1668120358740,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "BE6A2B19678EED71E32013A2C4701687DDB01B8CD6D37CA6F9AFE396349221F4",
+        "hash": "75D2E2C22551402401B98D971B2DE104B9F09DFC13C08623FE831736BA8D2889",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKeRxLj3ZZYMeX3WFebyZGlzvgoYF6gh7lU2eefUGXY2YbRlvmQU872pI5ucPJHbl484UJYNjoNJYmjrqxyl84UG6n+qucZpWrISIzkk0De/8LnPamALJ68yVDAaCEsRVxc32m/h4+Om5FK7gUUkHB25frWJCAMZB62/o8TTpieE04TpgRRDdNcZ6QwAjuHUdLm6HtoB65RPkbiekV/WEMs63xQ2QT04H6T/8w/2lkn6f2y5tCWjh04G7btG1vYllNXL1zUq5XFBfAaO/lhmkTAMCD4sbZK2fKsS5L9YIlQC2rI6X7o2h5cCJJ7ZhQutajbuDpFjd5xyWeTke3Dl0hVg1Ysbd9mUBsRLqLN6OR93nZWi98cLl4Vrk9wM4nT8nvqBJeXOBhsP75oTZJb/NqfJTutb15A1F4Q+RRh2DPGJ0qzzOBF3lUWHLV64oz3qYiU68HuKsGZd2gp0Hrz3IAe9qHSITlrNEMmEY/ETSSiFl+yMsF6RboiYpbEMv3/e2yPbyUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwgii8Cjs/yFR+O82/8velI4kZAVxByvpVECPNbIz7dlO9F317IT9ulQad8KEePn+32re15CG8F97LrUG1G0zxDQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIeT/Wxn5Rr7eqnXopRbfPm7V/1f/frcbXOIzqdijipQSOgybmzyLkfb0vFnrsbQzJN4tA/Hv4nqcl9lxo4lS9RJ53HkiDxIlALualIe1fvGKopylb02ACCjPQO0q/vn9g3XPf/qyZCvB5tA8BnrOFDhdueaWpgDVTc3AJG5FovB6k46LxGi1f0+KxubmKZX2ZYUu+/CVozaKZMd28m8aEedOnJNdzvalAT9kSJXhhP7+fwLgh7z7rgh0mNdwp84JMd5+bTzwBFiLloWbkHihoXFTq/Tp9M8RR6kmtBShglcmZFTcTEU6t18MaFfNVWqMMUo/2f3zY2CN9vpVv03rR+I1BUCLdg4MBsgdIxAOH/pJCXEnz+Fxt7W16X/sUCGklIkZyE4wpBRx1XihDGF1cs3/z5wIoj8SndCt6XNozLBTNDf8JtWd/WPGCMZ0be8IsUrycnOYS1aLsZFKOq+gQh8WvvRqyYTcxiJCse+nr6ta3nDdaxxPpdjNPlK8pT3OjK/5kJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwG9nwcLqG69EDRJEpJOtpxraweeljar/Irg73+gLwRCPQ5KSoDBelphtlZ1ukVu6FaiGUIdGQt7o8Y5oWSzU+BQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 5,
-        "previousBlockHash": "BE6A2B19678EED71E32013A2C4701687DDB01B8CD6D37CA6F9AFE396349221F4",
+        "previousBlockHash": "75D2E2C22551402401B98D971B2DE104B9F09DFC13C08623FE831736BA8D2889",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:QZzEtraQ5Td6u1ALOyA92TvhsELZOr5S3/rpjqzSkW0="
+            "data": "base64:R1AQja9G8vmQxmQsjxhlQ5uDqyBKyl4LU9J7u7zBSwg="
           },
           "size": 7
         },
@@ -1833,72 +915,72 @@
           "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
           "size": 1
         },
-        "target": "12282310813313062149747976722345089192786856311651484691394120306",
+        "target": "12061061787010396005823540495362954933337395011119300165635986189",
         "randomness": "0",
-        "timestamp": 1665686135463,
+        "timestamp": 1668120359021,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "DB9E2B159072AB6BD378FA5CB8893B8E4305BE10A0A5246C06A923BC0B73F79E",
+        "hash": "AEF9DCA99DBA9EC2A704B657D6AEB0A473C1C312A82AF445291558F8331E59B2",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALi4iI7r0LvPeli6s/Z0/P17Imexz2eZeZXelNPqqK4ZUbYQPbzGFTN8VUmyJVPlG41uc7Hl936yFdP8V+jVeVQzu0rZj8jjdEDuCr+RnY9HEP83rqQvl7GjQpLXdQedVwE3k6KrUR78kKzroaPeHlLbbdzU9lGsJnZIOC24x11QjR06BiwuxSbV0mdvjGrACbXAKRBYb4SdyIrdAQZemBlYl6SnlhrDyIOkuuGw6rq9Jadv5WsIioye/ez8BnttAoxSD5xQZb78XPLxZdLq+eolORRPmrr+QHnKp7pxi1VZ9Lz4mZezhnpr+awyvOArUnyFyguI6x7XfuCzG1FIjWKUrKd9fwoTjWhyj9i1R7bwERV+1TGWnS3s6kr+W5r9s9Ydb20xb70XIoDzlJqaCDDGQcwXMn5dLsMVxL195d7ZacB3qme6/zA/ArX27zBOxRsy5EQZbcXMLVTqJ57NU6XE7oE5mgKu02q407/tGpz+rm2jQ07ootrKimDO+zVo/SKqlEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIDA7WfHnwPHtvwqcPS71iZ0F3AfGhL3yyG+HB84hymR89yoqfI+FUvgnC0OibKsscuIspYVj6tuDepFRzs5SBg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALSfb6dQxSFHG1yButSOk36lZdz61I4/qnrlYUZA0sGTb6dCJadkSWTIJhLEr+4IT4go5N5aqmBOru7eoehbgcHBHAyry2k4I46jYIxzca+b1rEDJaJNMzF9CA03SYrkphcCFgHJQzubleMZg+mcgZ3kJyDBW9Hk6LrgM1Ickiy4e0whb4iFE5lpDtQCvj386al+pSOFeiyaq7IPItv11At0C0LClSQz5wK+YggsyOH+wr2dmqz6Q6QzJRgKF1ettGNY6kY8weEbdx9oi4G12qZwLHOyT059owvjpoxOgmzn9pePTe7qkq3ozxEfwLy80b1Bfz3wO1mIdUgseZozTQ0Cq50nW43s9Xu52wyIXY6rPOsf353AUcGbe1YhIm5Lj4H0HB1bnVShPvmLO/mvhdvjA3zRhO7ekgytoCHUxFt/uFFYwu4N+ssvwHITIEgkHeSJwbb11XeJr/qf/csPgBXlU5whQtCmegTKCJROi3DdLZgZf+xepdPxhdprccEYQqbUsEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw44J2Ivz/qvT7ncL1fFDGEMIm+zn7VQWj3id7ytnQdjaK9f1AQNaNOPityF9QK+/8m+ypN5dgGrV8aF/0bfGjCQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 6,
-        "previousBlockHash": "DB9E2B159072AB6BD378FA5CB8893B8E4305BE10A0A5246C06A923BC0B73F79E",
+        "previousBlockHash": "AEF9DCA99DBA9EC2A704B657D6AEB0A473C1C312A82AF445291558F8331E59B2",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:sjGzx65kuhUkMeWZnPtW9xcuu4rNrr4993ck6Zuapkc="
+            "data": "base64:/zRYZKLiFmsPFAw4NnPXZypWFox98uMHqPAu96NnlS0="
           },
           "size": 14
         },
         "nullifierCommitment": {
-          "commitment": "21BDA1B28F6BD2F12EF57846EA66628099DEF0FBB2214DDB6624BD2017455E84",
+          "commitment": "0CA03C1352F09D01D290D71C8901E5DAAE166ACC9155A2F5583546A5A853389E",
           "size": 4
         },
-        "target": "12495863162274128899606552658768696777231213538144041580701845756",
+        "target": "12031687549831842593585511419700568037881029157586576151389429446",
         "randomness": "0",
-        "timestamp": 1665686545728,
+        "timestamp": 1668120365009,
         "minersFee": "-2000000003",
         "work": "0",
-        "hash": "DD3D8616F982289496F335EC01EF008964D59280AD45065B0110F73E53541F13",
+        "hash": "E5860B21B7FD9D4585A73B7A40865B16FC7E0CF86AB3F360462F13963F0F1E87",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAP1ryoj/////AAAAAKBqEyjfntEpBD7/X21AY3MAj0jkUIM3Zvy9lgEytyYE045rMz8Ri0HiJEZSHX9wmodEXuNK8ZsnCndi8txb5HkfZ5khsYlJLCd4mJJJQgheaubOSRxB74+LR7S2VaYwFRn+HaGo9tJOdoYeFDSlPs1dnE1lo6xylYxION4muVS/6w43JdjSo9p0KCMPlUYKfKVd+9DFOY2CG9pNytWyp2UcKxHN8JaSMQclGwjJUKUHUDBptUSZK7uKbWZC4QR1esXO0asAqefZnrOJQo3mr8Y3ocPzvCp0lclXbrBEZQqKEmsnVecEptJtuo00GAtSDXEaw61anaTy036qx8iBGVDk4ATe6P55z8Tde4hE0MQz0Kig1wno9VSydcAs+1FHkmjAPSNxp2AMCwTCb/kPWskZRdeTu1aGHCbuDkVLLFUuAKlYo11mvPw8xWbbV3ubQC5ma4oq5fQpplcwPkFI6MGHgXTh/IucRg28aqir9bcCm5onFsJe3mIDZExcutXfT1F/80JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0ZAAWfbsu1XXjrrFlDe/i1Ns02I8eS3pEFHex4IXVIM9i/XYyFFv6IOmL9T8mJ7TVGjOHKQCKAcq5Of6o10OCg=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP1ryoj/////AAAAAK1RqS+o9h9SwglimokVS5gNUI1qpGgMjbNAJkEczCEekrFK7rEd2erODMPaL08umZkGCL1ZUbRQxsY2R156mxx1DIkD2PFezKLifPm9EQzozkHJ75125JXGnNAZAhjauw3YKfC2zoJ17w/Dt/ihWK740kEDcgQF9L2BUyxP407mYlVrzcoMeeFU04xEXKbjj5JvEACmalHJrwgqsLG/6XE0aH2AIsQVeuncwbOo/USEsjoR8IMJrCxV2B5gAmw3ngIpKQHwqdYHHBlZfV8kPC7srXXFb3qmVEQMopeh6FhChdIXxDD91DcnXaC52KZhqZVlgTVLBrjVPF1cSn2lzwQ//ZVa86GqW7G05ySPg+/DkRwoEAmycfMR7nloUHSRgqvB5MNWH0jxs274CkvkubaP50iUjkAhlsyKSLHjIPD9iuppgLPE3FITmV57O9n+FMkauBF/gz6413QzY1jH//VIiUObLNSQ/6harXEpeJ5U0kJvh61y772ZzlvMazYp9LyMjUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwog/V4PY45oUBmYmVhhZwH7iv1IxTZsljJHIVCCkkZF0kP5QCLRsvh2sMJAL58iFEp/GyBkUk5+2M6CgOQdGGBw=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAALKf5yCZlQmHUdg8IYIvcAuU5LP7ezQf5f/LOP1ETqdnDn0ToeaAt+oxDZcL/wOnXpZ31YnIlO3EvqmdLsTQYcqdrGsk3gUUXsHYM6b/0Vn4bBjF29vC/XCcj4OM7et+FgtDoFsAQuWZErKo5NOwyhwRO+2bacDj++q23klZAOjj2oAJZEgZpbf7QQ+TaJUyqYua8yTtvc45E1cmctCYpPffCN0ZxOkzAHT6fXbPzE2FDUftEIIIiL93/OONA9ehN31kS6tqI1EuB00IrN/muLlkce7I/mKhIi+beFnupBYMgia8GPGaqoX6t4ctyCB8SbJTg5AMAzqVSeTrSkcvSfNBnMS2tpDlN3q7UAs7ID3ZO+GwQtk6vlLf+umOrNKRbQcAAADd0mtDL0lMMfsgUUvUhys4jA7biIetOWJ5zrkE8PMumShKcQxn/bDlOXDxknw0NrGx/nLLaOxOhpzZfohgZjUMaIXOCjlrWzvKy3/JIReRibS3V0H0Zsg04Zlq1dBEvAKBWnoPRyS2OLDpchtUjrsE4sFbV4YsYVzw4yF0dIfgZ4jGNRil3ZOBm1vGTwdJEzmXH58SdVpcnZCJ8R16QLUIZut/OsF0W0GNBADC3/A78josSXM81lZAuC/QO8ZH9ZkS3NTak5ILNMLrWJoVnqjh9lfRjPGhtI9zDLxJwdkouSBTUYWqGAOK8DytjHi6FmCRUQAnk+YNBHkkn2MhqYn4RUT6wL757YSiZZdphShOaEmgwCMnt8+sh7JGOsCZkwY8sDhrgf7upqvuaiEchcyyVQRQX5/wtNloJbMn1vmC3qNJvxWT5kRY9WfcnqpN59aIJ5xPtbi9ROKKrL2DfzwzgONlT99ZFQY7JrfWRVWTVDVqXkuFbXANBA2cNfBvmD33S91YJoitGHvwuFffKk+t7I1tHjvLd8MPAgSKkuGQtj/NRMjP2bnpc0BesGQT+2YobmuY0u2R07j9QZ/x5VQrVjSGBZ/mlrbhUCZcWnrPA31IMFdNrWoZSknWI+R+zgqVaYboEU2AZjTTCa0woODEeFadItKpmH0hnMrbTMuwq/589oM/Q82QZZ54F3SBlkhvpTGyDoCDlfxVUKLJE27S255Pzcp25lEdoyfUF+xk8so5L68NuvkCULlO9N0muNiUqpZpc5QnkLUtNi0xHRIcGwjfNusuum1LqnoGUXAify+buZFp3Md6VXrfX57lcFH3pZDVVY9v3AGLUCtbnRFxIIDKGHEyWihFbmnKDbO5gV1ZuRiwKzYMMy6O6lcAgWE0cWrNt3TyIbCuAKbp17HzlgQMcRcLskjXL6Jik6dnJA2QZ4OghRzagzdWYV88GJgqxpAWX4ratk+qjDmpQxf2GjoTlF5CnFvlF/FumGmwIaMn7u8hwrnlQmGeSjpR5J59LDXTTHHpqixDjSLQj9hc51CSC+W2cGdUE2xoExMuF1I0vHgBR/pDxMUYIP++MWDnYFllBFLYIx3SvRosWC27PCWXHC1Tgp9G+YQFZlb1eMtpJvapNXfRFA2mRqrUw3XznJMRezTqyF0FvAlXSuaOKMr3jCHMNpPmeqOfUUJolh0KvTlPAJJMJSGZkQ276Odv4DO93/tW4KCXczH2HHitgX5UiDmBp1YRnH8DkBcU64ZcmPYty9BYGybH3bNkb0k3TX/3MwNra7whwfqr/D1waWWZ+W0MQpCXYcNe2PzNlGBjGYNVFmZMC3T2caSEJbIH5zOLEWGKSbu65FEVsuNH0PTJSZawFuR45A5WQNVABjOOAmZjkp3EXJ9FOL7zg3nArDPbGAmZAHq9bkoqlei2JdyFTvfbf3EBTYS95xlbvSHfkKILCg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIDG3CPF8SeIN0kNmQizQeDxLr+xyBNhhCVfdhdEe/TOzHQq0J5XxrfQ0UEM5IA5R7LkjKGNXscht7IWUyuVqOrbnlltYii2MRhIr+2l9x94xIpImNayOos8yTfkE/EtKwl/ROEkZrJ0A3OZsL3ZUv9XSrYIpTtfiHrX+RQ0CH5lFwY6Y5GTnH/v4wvo/o8jQY5U7XH1ZN6USj01tfFCxqjIt+3eAnaLYe5l5jgGeKbOmSLmQJL1qk8pFwmgppYEqDA2MVsoh32Z415ka3bec1BBZqjG6frKDLZX6bEXrjyXei3BMaSjIRv/HGKZwSmANaOEhwTEmhOIZSAlepV069FHUBCNr0by+ZDGZCyPGGVDm4OrIErKXgtT0nu7vMFLCAcAAAArItVBibo3MLJX24sIWultcw+wv3jmXo6FSLic6F7iQBkfDwcQ4zkQrJIFv+UStqdhwuvI+Pz4opXQD5ANcCSXcO3dxPfZfL3pL1ExexXC7x6zu63aO1Neb7RShDN4NAql4udQRqTcoyfsMKJEA1vEGQVjvHSP2WQSFVZM/j98rF2cfRrdK1kfmbpSUOJYyjCi3dtKoVJIEq0IOLqH3a1nGqCQpL+se2HlNTYyvHeM2gIBy58Yx6PNCZU51kStuKAJPWwh2ndekWlQmwzebxN8gyZ1Y1RxViqKCr+vLQP4zBgTaUFK0KsshnmPUXLEeCSGhidR8nfr3Z+niO1FbI/T9/tkjHxXNUHLUELPNPMD+haDGwNOLxlS6H92MvNUy9Mq8ah19cdXTO6DrPmTfuXEtYu79xjJx/hyAKhkORaGmESfTDD0YQSpOYZpsey87GMagluTx/AA+lCJk9ttggwJPxQr8jtAv+8AIk5Mp7lu/3cMENrZxb5fRBlBVA08tUPOeJDtCQ3GfvfgtUw6S0eErVK+SeM/X9CEAhbbeeFNbuStiAAq9oSH2jt1hPSyrqMSCYHN+lnNLgcM8YzK3WKNa4khHcOOSHd3q3upQtuPB1URQDvl1Crrl1lEbsWrHW+NPlk0y9eAdwVjWi20Ihax2TgwHXmtUJjMSmw/dnOcuMyPiQXpurEOocLJK1XlMrTuKiR7xu8ENfc3moZckqPKxhuzxtHnj5qZQ5L7MpBeoOLd67LLk/zOR55jof6yTEFzEHdkDtRiunqZ0i2vo3e1wPZVKPrdzfr9WGnJzNIJSOfvPq3XJzNa1W+dmy0r38nh2oD1Jkh0kYV3VTRKNf8fn1Te5Z/A4tbAYImxGGr99QY9wQhv9jFXGrbSVRkQMnwd3P0x/5ie3qP60uAZ82Db9B2ugJb9lFXxQlHhqxnZvKmCrqLtVGLvVmOsPQfMfkMppT39zo9V2fHSisqiC1uSkWIycALTodG3dY05d012KZ6TXNVYwpR4EI178WqGNzkIKPL8TJd9IVjILMXxwh59xufnldZd8j1NSve4eAOFkLxKsjbE6LOzMA9geD1N2uihrGJC5shrqL+/5Wc724AP2GsQbr2r0ApLt30bqCTTb2BZRcfXERa38QCoyOsP5Cd8BaQrg5Al/hoRVmGdN+aezKZAbVYfJtRXIweiuL99DAp2T1B07dRdpp/ik5u320Bql6bJZ6ShfN0SbqLmRw8Y5IFAOJjShI2wyGYEcuHFaI60u7fXqJdCOavPO65eNfnSXyxQ+ALrML3LBLHREIbh8DKjlWotPZdoIaQWhThO8jH7CStw0tqr2GJ14lYxgUxOXpgYGxlGfmXcaLqPLCTIypHEY3jOtvaKp1+vpMaA1gO2J5ojEdzPCYdLHk552ZtlUgpVmWDk8+oxjwwXB/RpyC0TDBOqL2WhIGHrxWdDH8IAkO9rBw=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAIo5O6pQRPu/VtayIsIfD05D6A864wfw0yO1V7bO+BAUcAGHPbLIJwc+UyB1IOqe36j+sFQSNsKc/K3ZdTf++9UvHOCk4+QvszCBNlOmrfDmN39YbSNh3t7ibbsGrI1wZgY0+cx8nChJ7DbrfpTz1B16M8mwSX2HgOEMpSKJywHUCRif1iAsTAFUAVpb+259S5Da4COFCCiOa0wbH19QiRnDppvJQgjey/r2+DZp7ASAiJTPoLNvO/qxCSP1PtK4PR+wEztsvmlPSHuHOhH1LHPX2guYXAbTtoe3Ueta9qQco8SAT/xnOMkSDdQiUsCv895VKoVJTdw7ZUG+Jrbv1YdBnMS2tpDlN3q7UAs7ID3ZO+GwQtk6vlLf+umOrNKRbQcAAAAN/bYBe/m3HEgNyXolAuHCSvvQWqM3PCrZVg1EX5QaqDnx/1koUYyjk4WLo/IOWO3WSXmOKTxhX+cUFIR2uApZiGr5nzzo8YB+BJN+mzIduFYCIZph2mX2kw5b0xxAoAOgkL7viRDyUHJCeqZFJAnBOzF114Jd4lHWDQiae9pNb8XJYWRXHx1s0G7349zwbk+oMPXIYB9X83/At4TDAhfHas0CrF7DGFLArYmc5W8L+FccxVbRo9Q1mcC6bbfs40oHuFZB9sIZ4O5K2oyMO3AvUhMfbr7TrmA5JpbJ1U0Axp6VQMEsMl75SmUcgTm+aX20iN1Tf444vm3nsW/ITk0m/bZ8Kf8jiaixJzltVmAVWbWNci34RdSBvXLeIuZuk55OeDqe6sazrvs/NH/fBLZBDK3W0LIqQxtLeQqwC8DDNr4hmbo8DVX0+DdkICq1sYzYld/xvV/FYmG26AjD0LZAifQ47l6pccs0gGDx1WSLCQDf+NwT9KAbVyiDYFW9lov6pL82FV3gWAyHxlxkqpn6GrHNsgHzuxdDuS8kzct0AVbnR8zNtnyzlZ3MLHg0aLExXGgV3ZAtOe6KMzYDN4sbIWzTp7ds079DG6HSOZH9jT5rGZY3sK31ZZ8GzazkCNooAVQ5Eu1Z+CyDn36hjkTkifCBRHXHk3vrUXcOb3zU2nq6YJ3Dp++05Yy0okdLgTxwbgMqnun20cNFzdpnMr9nmq3Y2IVmCYEhlaEiwlCxl3PrA7XmT0RYvHZJffyW6WCJpR3tkRhaWqls1yq/Kh49j+Ggm8UGEK0w3O2mQTBshf0rgrEWNp/kiVVARM2w9HAMMcWoVWzIUg/pcaCnMtfutFZjhsgPg+3BhTPLK/QXPhO7zxK1rG4Eh5KyykSvnGnHCgo2+r6dNvuZNujlhpf4EYF8fUARHZRxe0bQzEkbmxUimaVUcWUWhR7yosSdkh2xNNAasXBclbgixuHJD/O9YnjRyTerCAyS3arr7zTnHmwOAr66QmDtwG4r4vUVSn5mJvsv2tCTRPjoaq0SGzxewiWJ5f9G/VqzqepUUhYxUdZo46B2db0B+ktYxS9xpZXCNjKj+5/01B0wYIoPM7XZD1UGBUwlLyQc6heHN7Z5N762Q9JVOwAZ6TwXqzDT0bOb3MospjhxILF4QH5E1xtiAvWbrNcp6tv7Zs+Fc51ueppw61qeWBarxCP67A9iiIyIEU2m8afdeByDn9dZ00odX0Ym2WfnqLnNdDWyGis3xeERL6v4gOU/KQId5PpcEcCRKzCEAdJI248iXZUqjso4wBYezb05cKKc0EGdky5uw+L2HJlXGiutms3S5DC8DCu6nToBTRTW1lMa1cdBfn882jYC8k/ggU5ygLPgRaqG/91AbFXgw86qRAvjppIA3SqHeGmKY1id2qjE1gqk9o4GiyxsoNZ3Ug7YioKH3So+OVkBEwwVCw=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAJEED2dvFdZmRp/XL+2H/W0EpphLxeb049EyRhU5qdchyyT/CrzMDSjAzUPu0IZqlK9wZK1FGm5yPTvIWa49owcGIyPm16NushlmKfdYxM9QG5xco5o0xkPd6IAX5bqKJAbygS71iGSep5gprEf75L+PYErGY06JWrJ2Q8RHaLVO2IVJfCm/+3rkRuef2QwFgqjO/S57bHPbOtgELAiclmsTQMwmUNy/wuOlM4fUN04WU8GPzeAtiLuZR2SCuZf2jwSqMTqX0SaoKvp5hywIxcPZsPs5+nPMEhMJ4Rk4pCFwS+8zDrLumTTr3Gej+L8CH4FAMxoFiiVsUPFTfMgQzJ1HUBCNr0by+ZDGZCyPGGVDm4OrIErKXgtT0nu7vMFLCAcAAABwlCMZqgWtiLED+SNPAAuFMc+9NbNsewD7sskGS0ew/FBMKcrEoWAWrPCnOe1VsJKGgUQuzOUZ0x8M+mAqwUoNvXuo3MrHaqaBKr23osYB57yz9sdp6I1ZTUqOn3msuACpEYPvgWD7P2ZCkSfAmtWmdmQdk3DXrZq8/zqjDoZzyl4BsR/di1JBGJgTt83CF32nCbqDOv4PBp8W94uiF9j3cMaGAmW+3RQLDfTtceQWHvGjSG8U/2y0mFHuC0gkyi0W9Kw3aB9xMXozQQqdrWPnYOg0XkcxPdSgSppArMrAuPC5FVwKhK0lJgKTxUqBg5a5fi99UJRy9UuwJguLN7bA0Rj9QMqfEDFdmI2W6SGBwikMzL5wk7+K9I3Z0pNIulnNBChvPm3kWajuLvcl4448z+w3s106ZwvfDJo8TvurstUHsh8j6pj508mhP6fyS9WTUfWb+UDtdnV+0BlAwLEGEqpvDm39ff9AyilbjEvPHi718l2RFkxPsX7+clJldJClQbk8NR+hlBdlJZb6LWOI5Jo9Asw39rTxYkNYi3ElW5TYLHHOFsqJIfdovAPDzfpCEY7uWl/Dh+N4yGJYjeQaPC5fUZEU/OqtPf/P9IrFZ2bqnKT03JGi29FwkzsPSHyShWwemeHKKi6fdH3a+eHmwLkcooFJYvBF4zum3P/JQTWO7x19om5PuL/rO3x9E3hPGPdOwXujc/0TH+wfgq7evi6v6JHVwXfEVSR8lxkZyZ8fl5RdscKxRT8fqS/I9nMe99q7hbEoYoiQaT4W4xY/fhArvwGe9SRUeaW29NO+cO8cjalxOSakzA1AX3mZ+kUVAj2i0gQm1qTLeeSOpXuJBZQnQJOEHAjfELHxTPTGO/mpvA+nXWDqwxF+yiaTMwmqZHmddWgtHPC3ibG7Mhpo+XGQxdEZdR/AeMbArShZlAodXpjrFaJ4eMMYo6NP8W69rpYM837T8uVElrW2lQA1p1802zzt764z4g/rEsXX5tQCNN8tAQVsPsTSzjVgBVDa2FTy78kj6vbrkjpUxhfh2Lmqjh4YPAcf/bBSC8munznE86DpeAFhQlyhRNF/g6IoVwpsAu93DNCDWAkkZ83gGRTdNElFHvyT9SDKBpI2PNGJQ04uZvU1tkNZbATx6cvQnK4+WQp1Bu9swdt1L+qUF2BF9YQzszjQjcvkro07+hvQ9zukV+RyUFNLhK1oRniRrCmRK3D/nhe30gc+AvEi3T1uj0RFdALjG7l0LM8v4XkfD3DBfWXv02GIIKWzuOlXlJ2zF4Y9EpxmA42nWI4mu0fzlC8r+k/SBIZUCost1EdJfgmauv80kawL2yk9qc1+oFQkwOUHSnVlfV6ReC5Cn00xEkeU0YQdis8t+EYM1lgC+s4s8D1RyFoOqcKGVsXrTmDzb5uW+oVnDPTC8rkXVoM8JHrRXYZDsygQGYBQt7Mdna55DQ=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAJLcWyB2i36AdKyBx4JxHsEOKbPbP59cDIK3bD6Xwo4WqztNewopFL5kN7dpEnIe+YgMHIoif9pfGsx6gq7rsTHSRsBHhkCRoHaocKhHvpMgGHKRWesFpZgLuOY9/eliqhJKIq+K38659v9ejZ2g/orVH01QcO+emXQlMP7rhgndc2x5Oo/T/Y8OWQ1/96I8SLBf4IDfrFFmT0SNbFNjckGU8Qb6t53OdVFMX4M9PB6WA6QETLzDp5VDLRUrqN9ZX4K1BDu8IYOV8L55iWkQgDGEvzhRCCIfTYTuMI01YczZb76AnoWmQn9q05HXm4Vj28MgqcYHGacNXS2DfKdutSZBnMS2tpDlN3q7UAs7ID3ZO+GwQtk6vlLf+umOrNKRbQcAAABAGQLk9Bz3KUd9iA6A9XgGuEIJIRePepnFP9OZaOv4aJGdRfz2rZUkiEuDaImuFA/yE6nRgmVm+Pxi44jU3VO2MpHw24mxM00xJoUFwhSvfDK/BMAAbtopsG6oNtzBHAiPo6llWg6hBgJoLcz5W211vda2JCe0BbN0efWuL7uLfdKl7i0vYWt7vPLXCb271rKttEZwoeeItRAxcwrD228JqBZtlrgZCilE4j82lXo+eCVAEhMsi0L+9Rd11KsXfygDHxPI6GgU1fwNzAfmicndaxwRvebPZGzYq0/93rlp7NtnNq/7bFEXqATHjoOFMViQhXKrpW3bu9SoyGsGkWgmezRLUNch3Gd/jhW//4nUghoIdH9EPb1INwLmMlAbJkrzBqFHghRbeWuUfLQ77+GgZGOlo9IaIkJLoqFqN6iI7wC3KYEFvPorWjrqbTh2SlBv25aUbGgDm+b23AWWBWk2KEIAH0KRgz4BXbhK2x6pFEpuKi2UOkGJKSbry/YE9T26McSAdyDg7GkjeNI2tLZPMrDdDNcGtYNUaWxjwDTH3Ej38T6AzgOA30+D9jno6p38SXyLvfpGBpZ9HO5kAMwRPenFmL90m+oGe09eeLWvbLQdZdmlHWq+mfEU0biX/wsVBGBQguCblmmsy4pR/r0NEvNk2hKD27OTJaSBPzsnSGoB52DCBgDNRqlR9EwsFDC23Oc2lb0o+eeU1lAJCJp1B/ShIJrlU3PJNdeYmW82q2qbUJZaE5i+GRwXBXtaS8pN7y7UlVhan1cd6jx1qqwv5WIWlPe6ZwojmHs7B31RpWpEb5X6bFgtxMXD5sOtYOj4sdqQ1PN4KvR/n5BBbQdRu5b4nvV4tNrELmHfNixECAfG2BBcPT8Yj6L7HoXoU3VpT3oTrPT/xHFHTPPF/yFHGLLO+tesLSJi52sbsbECwlI177leREYOPPlNjkM5jP/bMbUypjCJvroNr1f+y61pGfQyQJVUEFiyx+Y2pjvpGLIueu7+ozetmkXZ63ZP/PnY+vbhUtIjUkC+m7tehzAfG5dT4HfMX7Y9KVe7X3neQz7Vc1L5aAet55jKuJH/DBy9KjC7v9we/2Kn54LPjbWFLbMO7ehvFV2x9VUeDNGaAgVeN/KfO97Q3iDzl8IHRgNDjQevGiOodxTyMXqAx7Op130Y7JyZZ+Yq94LFxTUgUUY1ed0Z17RRDOBGzFeJq6Ern7mDohQSfm9PzDWXFGIEkVL3wE3X9S9zKe0wLe8U+H60I5eN1SvpJJrCKoT9DMDFS+chyXdio9ddE6TRI+vUA+pibWQpO3W21VadPlxQVWhV4JWbv2r/UINoeq4RbsrFXZV7ffLliu2XR8gx5hKs+DBFgbXetSuuQaNe5cjMzW2AwOyJitvCdDBbd5Cn+YeAmsDo5XBLex+Ah5yZLjxUTiOdGeOqmEGyqWVNlph19NeOaY9yBg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAK0bbPveRn68X++gpBzrF/bK0qnwGGSdBO4w5ptiMzt5P+qqkXv+24WZmlKd/JCKfa3foAQCcZ9CUaekf5E0iXJ0K8x6g/BfATbrSTXCneillnJPYLG43LUas90SzHWK3wNiRNRgwqlKI+QRM+xdgdt8GyKLesY/FtfLS+ASrQ2Wd5Kz9WFMnrP4sp/MiRQKGat0nX8AF68h9sj738DxJRtGL4XFFNpBT6+54heU8mPZBkxC2IWKO1mmU1nbkgf+nNUbOcWyicoWk0bChZmJE0cmC5CpnKGfConcLu9PtvbqEUhxlZFtj9Sf91CwU1ejIhDHZv1a0abp7DtFYE1D1GVHUBCNr0by+ZDGZCyPGGVDm4OrIErKXgtT0nu7vMFLCAcAAACQxfirL6i9mK5xd4O2EVUEZq3Y51nMts1anKttmQPz6tRDdb4vT4HR1l55NPcQ0ByN/07YeRubwA1A2iJE4fSQh6reuFDm2dghpujHBDWGTi2ihvnmltDNk2Dl2GQCCQupkK16dVaI+BhVskweu2qflw2ViyX4cZeqpi0ws5HbXdKOkvsRqh2Rggg40exHo62p9h2Yj5l6mvBFLvfLnqyL/5wBn9uaEFBvCP017apJAb2/K/SNq/a/H9gW2bXRfEAFxsV0UOlltXePPPkmvRz1jMcS0hLk0TKmJqewsMhsXp5JNuB/bZN0H/UHvuywS2aSTTnLOR6FqseTD2wTvZDxBfzljM/kIZyoT2LfaGe55a+VJfcm3JZb0dosC/o2sesSpWVxpYwvgQJfvireBZT1O3wcHaJODdI1VwRUjMls70MJTI5pBBFAF1DEfDmrAFLfF9nplHZ+YsfE8TVgemA21mRWuTYiv2Pj9nsu0QsbLOvLeQKgg0nzHrHlt4liTg6ll6br+5AAPh5OfCKxfa8KMQhOuq1cU2ARrIx6+bpYTGutvKzZMKKCVFkFEn571U/FoEy23RzpKXDytpiXytKYmgubFCx8eK196l6DCxCWTJ8+EjthF1gU035spNfv6LUWYt48FAiZIo2dHdFv685bNU17j8anhUm2uysCJ1j33GJSoPRwBBD1Wqwy7iUCsfiUOD0PiPTNtVHa9jJQaxfLoug5NnzT3fjNwp1rq1/DoYVVMaBaLKlsg09u86UchYsIvRsZWumKqe69aSv+xBrzPfTG+Pw4OR/Vcm9XkiXjPagdeKsDijHDCXQYua7OSV0wH7LUDxQ95W2+J6Vt3pjZGiWkyWUYXtcGLiJw8ir+nBjUbw71lTjYIYyn8TS2/GrqIvak78I2lAljvBkAh3Tzf4zjt+95JchEaV6h71t5DIn5fYzb2VZrNR29e55Fr/uXXs1LeUmFCuUvX8j1l1y6O8WbHt+AVIcR2BrjG+ozREJMTdq21MQMzDslHsxedFLmpHZCN6eJDMzTQ5N8gegQDZy61R1ErbmaJVvixALsCIzll36se3vRRN0UPNEhqaZsmDHGWpcZApu5Jkig7ymlyPM/hL+mqf1MJMj+DKeWXap+AqHfVa6TNYdNSycu3C+9Vw/Vo2qaMwOeFcO3y/0nD7MXl7J2Xp+J4v1PM8LCzt9Pl4KfRG17/0t/o7h3hSQWK+p4U7IIqDB/i9ZyCHxqRZ5UylZjw3iymf/RyJ8RXOHUwD5smS7hK8qEBDrkkj1bnxhJr4eWABk9jrZzb8+dHCXQQzuAqemcshWJGDPIuSnjNLESwXtglSFkNoDqVGhOfQbk8WPqYFKok9Chcph5MoQUUGRwwIh9MMBElQ71CMArY98VjoZBXnLWOjUiQAB1kB0jD9nufkg/+vHOiOLOIRCcSBLvkLAJ/iIlz4QjhW2KQnRpBA=="
         }
       ]
     }
   ],
   "FeeEstimator onDisconnectBlock should remove all transactions from a block from the end of the queue": [
     {
-      "id": "37dbc1a7-443a-4e82-a8d1-683d21b18bc9",
+      "id": "6db31feb-9cff-4d49-92d1-112888fdbb8d",
       "name": "test",
-      "spendingKey": "7aa8ed37f7ea6c2a82e0f95e6acb84fd66ef40e4c922460546381856de126e64",
-      "incomingViewKey": "bcd12c736f4effb8852f2dd1749bb84267201601c7a511f30e5a7423937fd107",
-      "outgoingViewKey": "c6f561805acdd222c5f3f0b40ed4d62e09de6803a2f6659fdf5b24e2e7eb81e3",
-      "publicAddress": "157bfd20a6c8ee0bde18408c65a65c231cedbaaa91ca25f63574a251c6d17f5db334c640934f03e5874b24"
+      "spendingKey": "52865ae7f4a3aaee9b5670bee40e8c16ccbe62521e2fbac28943f4dcaacd5c18",
+      "incomingViewKey": "c0ab4f479fb13336940a879c7139e52847872295cdb6b9f259275325b6ca1400",
+      "outgoingViewKey": "9cd10e5f9653a7b7cf36904958e1881b819c568deefeb591a84af86b2664f6d3",
+      "publicAddress": "8c18d69a9fd7065135bef4f64f33f8a6ee394a834b1dbec87540f3d89b8e43efdf30bf2140ed24d9322257"
     },
     {
       "header": {
@@ -1907,7 +989,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:vqsQXZN8Og2zDIW+6QKR3QP/llP3oUNjpPMQr1AfT1Q="
+            "data": "base64:0IQlOuLAc+su00wVwvWw17xQCXikN2ONj8vVCvI+WUI="
           },
           "size": 4
         },
@@ -1917,62 +999,70 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1665686767176,
+        "timestamp": 1668120365338,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "C54B52C89E9EB2BA1696CA77E511412E7FE02B5AE5EBF0DC85B3FED08B44E61C",
+        "hash": "A536C55E744C1D3AD4C34F9D3B9789CDEE87C886C1761CD55A75C853D9315067",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALSRozNYSalmJwJJu5Gfc8T2cKNMulJRMZurSUVAyEa7HPXSi+Zm+eM3ksymUU8/DbZgZscH8qfWXmEdkBYaglWgHcCJilF+MIPuilq04UrwbyFHTA9q+g+zFo1BXHL93QyJwsWZpIEW0g8zhbAauQ2BIZv5Jl9FSaqSV9lrY7v1QjbeBGslpfbUNE1KdpfVaKu8BYqQ0DIS1NzGxTB1m2KHWHB64vNf9MhzUH69o82pL+Z4iE+6CSJNset2zJI4rRJxCvDv0zYLo4dSy/ELBx7X0UsKrMYIGWBdVXxvYphHdskDk+YnoUve2rr2r997pI5h2TUGqaD5jCpt6h8BCUyGMHManwxEU7pktRzKv68XZl/+PnHvnbi/jxq0bd880FZQWFjcI+jUhYJnu827l+PabYsKaiH7RZnR+n9liWvGM6/R/NRJ2mBy8VPTec96/IiFmyFbbPgS/PGZyc7rPHw1B8koat4rbMKNV2HXCo/ZcE5gZvunfQ0Y6MEP2tTz6Av0xEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZKDWiAeE+X/lVXafChGKyhibFapIhsGWoEgNh54CziYiyB/57PhPzgIULX5VgJWNo83kRD/hP0QVDSi7gRcuBA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJc4+8a/9XWNFKZAqRdMXr51NtAJeHNe/B4ERePqaLdKOB8ITHnt7DzpVzR2NtqHCrUoJeckrAx81eKj/PraBBCl9qmvvFD/80ES+lr8qhfqXu+/YZOF1+nz725feyUNLg/e0WN5UHQCcM5utByfqBhV1ZqeJnJdE0CIcJlaAhsU7s0q1LUEDCyv0MLUi0Mf0qqjJwCTH/Av1UI7bujBBXqvhvR0xsGAg2/EpmtwCPrIV+6drJTePcCxYIB7yzgj2CRL6ewcbW7HXs7CUjnSrknozTObG042OLuRnjBhcqho13fHj7xGvImzwXtHLjbEluKyQvX5E1Cblpc03Em9s1NrlMdbUQbu3ZngGvpk5cx0sKcfihO/0oHZM5ok9/K15Fq8c0SfSiQaj7oFVKg7TX3I69bo3lxjrZR210rfTOaujgZAi5GyyBlT90PweUfVXNnyBvdtNDC20nTruhuc80Uc3Q+z0jfKcZ4hwPaVqDg4V2nGMVlmYo/Pqpl8zuBIkQv3uEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnrW0eZ84ds1ZGnny0n5VTSIX155F64TIkQR7lPQz1m0lXKlKo+97cbb/9XS+b9/0/9r/MP3FKJcUVrRE9d7GCg=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "C54B52C89E9EB2BA1696CA77E511412E7FE02B5AE5EBF0DC85B3FED08B44E61C",
+        "previousBlockHash": "A536C55E744C1D3AD4C34F9D3B9789CDEE87C886C1761CD55A75C853D9315067",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:DWwb84af4tHIM/Fu8s3KFSkBzK13QQe+pNMRtpJrzkE="
+            "data": "base64:J+WN4JD74vdRD/1nKhP61n99OZqzrDxfLkbgXsVOSlA="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "730C22860FB5824DF1E20C281C2901CABFFB8B47B79B51D4D6E7737F7A2D8F9C",
+          "commitment": "387FC3A84C41C8B31F77A3924E1ED2803D8F14EE922BDE9D50A6F345A1E7CB19",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1665686769073,
-        "minersFee": "-2000000010",
+        "timestamp": 1668120367517,
+        "minersFee": "-2000000001",
         "work": "0",
-        "hash": "7A332813FE1D4764EFCDCD380BC8416144CF4EF198E066BBE3E091A668F83352",
+        "hash": "1CFCEC67A30CF33FCD37DBA9767D38653B815BF4969396638FFC2BA2D009A232",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAI9osdtydIEHS2sQxqpenIMlwf5AjizFfnX6J1PhYNJi0L4ZhCvpBRcphdfXZCjA/pG5Fagky3jOwFx6SzSr6sR2CS/s0O5sYnTX9j0ogNaTu80D7Oo0B+yBRS1BF/mcRAHWq9/oogkKBITstL/oYc1/ZB2nnkKGUb6hvjWwPc0cco4IsCGoRVYZMewaFNfgi6O6lUW8O9arHcVhJwunjflHF89zEmkOxAolgLfRxcn0mtWXpyHs/VIgdp12AukPbWIi3FDY6UQisDPtZnvv+XZSQFiVXb+2kRvUwmm/OWi00lgDvBU/olTRs9q73gFJ3pNJHApoHhKYA3VNUmRsJSOqa+zm+8RdDMO6aGEonmGyDFYlIlVFmJVzYzvR+CLqG/yTckRi9oPK7tyQJEtpGN05R30Oqr+LAXDCLdsmr0enSa13ljB2iLzPMUbFsYsVvm4ur4zMFNFQ5eQ9FWu1RCqoB5F2IjGrmNpOolrz6rokp4jzT01PQYZsLXK2UyZpUzf+80JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwb2mwpoWkTBhXXBvh9RSZVxCPbwCBBzuByuMxiunJRm4RNq0Bx0uwyPatXHtQYD5JoJkFdbMN8J4cSQ2uv7OEDA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAP9ryoj/////AAAAAI5BnscGGA14AHXw2MxTUvyUHZhnIY/dVnGGNKl1iN1VP2eQ9wvHL+gbHZb2xJoasop3ZhZCd640Q/9GkpGvykyj0odxjepsweAnSkAcx5phWNg3KwiCWHm/eXaCLCNnqQIPQ40zxKleb/T+lCREjwWR4zGX7xEg04TZ1RSeGSDqzIF685uiSovbmvJdQ8/PHIHtFervaP1mgknsD8BAg8I6MT+sRLyxIK9PkXD2gkQwiMdO0b/Mvj2RS2kTcOdOtq7Kmz/efpU/KAtZI0/9+BNhwEaFUw8Ivz6HfC/Jv/jQMai3Uj6Sy/ygSwHVAjj9z+DtAPXaAwzTeUpCKSmEDTcl4EUf8iTz6Lob3blxAsFGDquNb3iieIZDfn4N15Ho0Rg7u759pmSZCegQ4EBtMfQHD6qo3C/zd1oaozJ0L/ND+N/62lDVxOyV85Tu4feA+cKRr4oa4AmsWFmPjquyZsA8ainhzoTVDx6hblnPtNgWpaJkXlywnTwVqdWfQkjwbJViU0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwD1HJQ+0V1SNchsxoa2N7SOaUXvorKnGOsvuwvP46QzCK5x3lYdUuCsVpD1B4CDStLtSqoy7C2plDS37nERN4CQ=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAKBV1r0lNRkNRY1dvrTHxzfKO6oJW45c+KrGhVYmd6zp8qrWMPtTflypMN0E9YKkaYX4QYWqkO/sU6BE+ywqFN7KeRMn1xC/y05C91IJMtGNC0ExRGXHWItq12IueOZuYBVr7vlyamS7X+dalhPHZjrRgQFP903H7UFiifmM6C/i9Colzn55g2Z7ZvwMCnump66OxROnFNzDXLbTqCe7eeqpPSUJtdTT76yGZL0sc5vsxmrhxNtUQl84zyqTzvrcyuTF3RQJOD0o/smSZp4zimWbuyzi+s/fVSV6bEyLHxKWc+STgitmiAr57vt66yAExXTcehqgcBBptSUfsssn0eG+qxBdk3w6DbMMhb7pApHdA/+WU/ehQ2Ok8xCvUB9PVAQAAABOSMTfudDgdq9zUeFu07yAv+wdo5txh5lmVGUkLi9lKoMMEc+GTGw3aRlPpcJlEk3ldqcRUAj+5sxI5fqg5VlGUrReWV6ilalEY/4hAxdeuQ3sJG70IzdAMeFC6jzmJQ2h1zzw6Ku+OcAiQT+hfM5xzIKphlB7ZWg+eXh1MiAna1hbo15cB5qmR28tkyegNPu4omM3hQAlbRCtinLefMiixA3qIvMc8QTxppybY0Mfkr7u1plHh8bW16LS4UXH2BYTD+W6nQGsB8SLc3jPFY4hx+kZZEj9rLDc/6NZyALg0QUee9hujH89J/75SLGuC8eH1GhEeI9RU8NUZ0kJfwzsXjK+Jq/8SsHx0nBGAQmHTf/YK5qebQ8nHs1FCWWxBAPCv5TJsXVi7Z08aoTm7I+sFyueytV/etXejSm5Okd0Nd2K19HEfygXXBUnMZLOSVvfY+fKNBUOgJL6vH0RFj0yvPGKFkK6FohOJjFrJeBpEAF+/8I/0daRUpt/1LM2qMfXy9fJ091NxJywtqckZvzetuqXYNk+Cl3mohh9WK3sshTwEDLoxd/bVGdRANXykNTGWzhtsIloZSV4ESMGyfxWel/41Ikhtn1r46ZEhgISQ7S2FoIQTbi6cQ0g8IHHh2g6KWBi8+BWiNr6c7Odj+pEI3oi+1W5/aXLPAPsULCgRgVNSF4eW1UrJ4cxvV+i6rIqvFPAOB99QaSXEUX4gWnFcPgy6R93aFmR73Fozkoc5CvaX6i4z5BXypytfZq6jATcD7TbrbfbU6WAyemuyjO2cClFNg9654pggVQbx1dWNjaQL6rabjYxB57cCJ0bn5WD0rQfIibXXqm+wnss5g6ThAc89QdG5xLYHejMS0U8hC6LyRLzP7tFmcWYASh2jeMEDKzceEJGfTjoHktPtvJRLf0NqICcUwaPDA08t//OmTzMaJcVUCa7G1WXZr4PwDd7oUXAzabdLHJNB8oEH1K4EzSK3pia4wSBkEKFnGpOZy5zsF6eDkNdJ8QUtdcxJ78po49Ahg0m3qLLpVOHZvOG+s1fcSaABaFt6TtTdV5R/PG8ez32clo7yhwaZBEdmjaN+CqV6GsylQPsBpgeFikYfE92bf7j6DyduDQ20gW1tJOAWdsULZUgaRy2MPvpNMHrdBRfKlqLI7tdnQ4OAbG9e9EuGZGFn4aA+I6dknhCM7kGWyd9PKf27a2UhwI3Vlw2jqAb615wo8hDkyHAMGp0IiAhXdV/UISTbPGxa6Ak7NDOwiFgUi4SfqUE5y/OhLLVejhJy25Ue7AQAlpHo/JkppV1en/ZcCcrAYitId//3jZkvZtG+OcmGkn8AZu41oRD/IIJZUgqNrkaBwutPg+Bqf3U3QDX4IV5b+8g6CU9n16jG1etFr3rCjsL/Qz0pk1wovyIG3Mv8i4EsPP3e0MGqGuynrnST0OsVtVAMCmJR9cJ4kzCBg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAJiBdGRxIhaqDeN3AqlfwH80wcCnOm/aor2uKNrBaToU+2QnMFjML/C4mEA15+Ks3I84/UsF37LvysES/VLdSEAKSzgtRYTxMrrftTieWaLKluQYELnk+T0SJ2W7omCjywPdT/qDK+YdseSLT3+Gs0Lovtd/F/NNQ2RgmN1fc5N31N1hL2eUIOuRFoKgQbPjs4GkSBbzhoJuKZmADiccHdPYV/9t4cA2cOO5DSi0FLkWJqdKp4u8wqLCMv/R4EefDQwbBgn+4qWucFzjpYb3QIr7bPewzrG5TRhLOgna3BwzKggQ5leeIiXPd/LFY0FiFNXGVNj3G/F+hqNNK0ja4knQhCU64sBz6y7TTBXC9bDXvFAJeKQ3Y42Py9UK8j5ZQgQAAADo5YRIBYNAxWHBt8Smu8QtM8YQ3Dxr4vbjxsnAmGkZAacMmw79d0O3SIaqW+qjJoH85wzigBR5Y3y36QssqYYp9IE+nU4r0JC/j/jHeItWRwuHTk8iHkA44nwEz8peZAeXYSFlwGAdDRS46ieQquOHO/DSpYzICnaWGy+musao2I9aqgKqrS8D0hwsvMvyfGG1aFCPiEtGG46wYLPxADdMWHTupqJctofIud4G9wxnArXMLdggPXfdVSpkgoXiTbcWjTY2rB/YC1ZmI3jlQQaIs65KxDb6dYMfYyiVAa6HgYIiN79ZtSwQyPX/aMjl9GiFexKG/yAAhdPh4I7GQVLY3UQwocC6pm0hfSBFq06znUOqDjSx2Q08QkJboBbCbAoN56hCYV6Hbb6pWZsUcfokDAxPEZBuyBIaum7nA56t1aOJwL9C2Peo/RpxvXpyOAgIXh5fG9UP5fUeHdh9z7tlPW7jlEGwc+iNTOUKR7AxdoXp0YpB632Psy+HL4wv0E/PVOeqINXUoMyvq7gXKmr0kBepLd5/RXI4qWdNx2nmjEQoe5UznAYKphWAiZDS6+xfxP6NAujNXsFLM/dRDlyS7DD/UTVsNzbY2NvU3BaQtTeRwNwz9uWie2y7qgRGVC8IAw8raX4RdtYOSNGKMws5jVMkQC2lUFNsiS4cxz8oKv7GqPTp5WDzXI6vtWej3JnCIDyhBNd3b/uhgLMY7kq6N0C2AMTVAVhUyl6tsYygxaRXEIX+LSkK+/AZ9LRjAed/q/qinIZlNXTz+pcolsRSpFJsANGMgNkOPFB9SRmNzR/pka5pJisIFo5wEO4oWabCUQRARzy18bcfZq+57isEogYGMwluC5sa1QC3u4snlh1xBRV1IzQXvO5BxZGAt7dQQE65rjcNlkcpod1FTfy3G1OIb90dNUpoSpBWEDDtjgJE2bUSUvuowAQ5mBMPrLB5WpYQKF5KGbk4WIfivqxRYCIvCRdko1Tvy8kEG6LckSv1deVvDRVjCIKqjahc5NLasgX1t0ZF8B0oIgFAaKkhM4fL01b2pPwMBfmgrkuyadSa2l44OEeXOeX7iJJxiZPQK2tRc76kOo3Hf8w+MWwTOjMruD/iz5exgUUz0Ebh3fFhP+voVa6QgSr7FNUpD4CzH6YNJSkEsZKTFi5MYGP82RiUXr70cMKDsOcGRi2xuNfIEZJy9VdyotkbBhEvVnDelF5FfROU//qUNypr14QA7J07cBy7wUhiiHv90HJZqy9eK29tUvVWTuZ9PsxnKtiY7S0qUkXCC+b5N2xBZLtVMy/bGx/F7apFCVQciaMuIzG0C7E+RaL7CVxWIOMf21PCOu1ZyJ1pVFMl7r/DLLPjVe9HeZKjgJdl2vTMfXfMakX0WKCYnGySM28tgeyERqxbazwvdSTs5aiK5Ni5AMKadRnF5ICRvfIXFg8Su4Tz+wZueFDhBg=="
         }
       ]
     }
   ],
   "FeeEstimator onDisconnectBlock should not remove transactions from the queue that did not come from the disconnected block": [
     {
-      "id": "0862af81-e82e-4e35-aa80-f4054fef74de",
-      "name": "test",
-      "spendingKey": "df2350dc69eeb49cde87a155dfa3f9b86bdcab2b64c2d7297deefa5d984b144b",
-      "incomingViewKey": "b0e60e3abddc14b8e52acb958419cc817a9a2854b4e4d1527f4ead7c97584400",
-      "outgoingViewKey": "41584bf838d272e7129f71ac0196b8ef99823f3cfbe17a50cd215e6ff3c4ef6c",
-      "publicAddress": "7910de50211c54ee60b3054d63880359639fd45f4864cf7d41f64fe5af5041dc141fa7c00eb3878fba34a2"
+      "id": "b2442712-220a-4039-a671-ccd56b37ebe9",
+      "name": "account1",
+      "spendingKey": "6efb685956c15cc4a0de30fb3dd03ac12e3c70fd9c91c3aef078297be657d3e8",
+      "incomingViewKey": "466415f28edeeb44f788c4cedaef107c23b4d3695eed815e36a66f59b52b2505",
+      "outgoingViewKey": "e85912f14887a2abd3da2683bf0d083c32444ef8a904d6d54d3505a09b1874bc",
+      "publicAddress": "dc09eacc54a16662c154a571ce1cf8e9c9248ad969d8f716cf16d06431cd8715182d6492983dc5d4890689"
+    },
+    {
+      "id": "6a8167a7-114d-4081-bfe8-e86c0e619eab",
+      "name": "account2",
+      "spendingKey": "94f23e4f5fd3820ed3273da4c054a706b7e2b5b09805866b6f01b2c203caa6b1",
+      "incomingViewKey": "86a24e9f552a277694ea8ee367c19ee0848816a9b25b14833204fb7031866a06",
+      "outgoingViewKey": "fccb8ef92486355f194b4c98765364faaf6745c79a3a02398277b15b5f81d73a",
+      "publicAddress": "83fb232327dc5a262b6c6e37726b1f8b0e08f4973eb70990525808e12b422b0a221ae1ca4bfad46a675c71"
     },
     {
       "header": {
@@ -1981,7 +1071,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:Ju9zfOB4wdwxfdDg9pB5jbD4mfWKWX4H1MKE5t4lBSY="
+            "data": "base64:KDAX443LesjgzqpYR8KOW+hM0b1j8OMo2yoYi5LX4V8="
           },
           "size": 4
         },
@@ -1991,61 +1081,61 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1665688083720,
+        "timestamp": 1668120367834,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "ABB4C955064DA17F8F2793C3D9AF15C37308C64E3D79FAC321C08E5BB0A65353",
+        "hash": "FE0C353F7C3E25440240C9ED48CBE76DD00AE2BD9E39742D2E83596CD95BA6BD",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAI6QdFk5aZtlfd43EqekwnNsa4FHG//RbUK6z89tghXlD9/osZ9mk7LqdQk3ALcAj68m+cd4Q62vUu15MU0D/IiI4sZTmyE3udyn/mUw5pR1W8gxdajbzrqDR59aLcqS7Avql54yxzx70p7xtK1Ho3jOm1ua0skzZfZLjn4gTmwBOcYXBN5px5+63WNmTfkbnoKzehm/ANvS9N813O0WU8EkQElMxiQ5ZCIEJlWaoxYjuOILB/YhvYKUA1GnUMzIyim/kdsFKIP8C85NJjuRlJWplryCE+zM993h6wq0C86GxBejYl7ALibcGnqJ5OkYg91t4A1RjFdfv1ddJOB8SQkjztr7cmIf4UHzW4vmAiDWnIWzHClNr6OR4pd+E5EMiP5NgwwsyICl8Ub/yLt082cGDs4n8ovYVOMDU928gVNc1oQ7JfaFf6f2V5KNpPDlfgavrdSxV/GhoTkRKK2E+gWusG/lwRXZEHqlugwF33hLt12u6kv0utQM/92flBpNi+mvekJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAxfuswA0Cy6CGE7zQokTWVXBCKmqPV/o1fqDqA1E317ld+8616SMiKNGLL62pCjz90aov/FiC1hd7uxvX7ykCA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAJQDGjgYNm8QhnHnCyHdHb/mMzvVBMfqiqYBb7olGuVbro+Me7B1laXzSxz1i4qGLKJdbKANdmR9Fcrb2ym/K1vfJqXKj8kfTKkfcqqKJ9cfYCNkQnF8Mnmw/ejx8hpjUwE+DaMrkyDi4w9vQdMqJJVtqJHcVBPT+xeC1Q0ufw5qO5Rx/vg4/hQRrB+qUeuylKVbvGWdTGvc7w3x8o/Hh0xys5mizNqDkXIFUvbU6y9BtX0qIvshFgcXB2bPoBZgH7SW7LYMt/ci70Obgah/oyd/9aTVCWhmQLpRNL1ZX/Bd0beKRCMjbgKZaToQG/k9KmKOz2fxuaoIaxg5wdgueR39g8poAw81BYPH/8Z7MOWC+6rlN0GrvFxr4uXNlFRETy6bTqiYYgdfs39TdHf8bRTWyfTXUDsEIA6CEDYm4hycwJq1OUK0ruKYzR5vNh2p3OQAnMBIY5aJJJJ3oB9AxGr8P3UXDXlgiHXU5H+1rbjH6bRm7SVYYxcS/Li51aRpTkYcaUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw16iN7C7qpDz65aZXV+ilpxjrbYq0bsDD4hMqpuo3CynHJOsSdyQPi64SRFawbC6agMiY/GqKcOYkiYUS0VZNDg=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "ABB4C955064DA17F8F2793C3D9AF15C37308C64E3D79FAC321C08E5BB0A65353",
+        "previousBlockHash": "FE0C353F7C3E25440240C9ED48CBE76DD00AE2BD9E39742D2E83596CD95BA6BD",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:uEwswddibX2Uozz5SS1PpXlpLj/zBsEVXTktA4/Bs2k="
+            "data": "base64:lNTD6ysgFrwyyXvRdas8qiGY8fFc43HSJV9C5ZNqZDE="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "5BA7C4F2F5C1A75BE7977C6E591FB40184152D29E7441F6D1F4B5A5FCC8DC36B",
+          "commitment": "98AC093231697238BE1E280642DF632114370F1BB1862B0CC8F70525155CA237",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1665688085633,
+        "timestamp": 1668120370216,
         "minersFee": "-2000000010",
         "work": "0",
-        "hash": "6C978BE2F15D0D73DE4105E21A68C3289E7CF3C83CD3E7F91D8C03B0F6FCC73A",
+        "hash": "B626B9FC684EAFF8F9BA82175636CD5C2EF46EB439F07916EFA1773A320838DF",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAALGi8z4dVhtEdKDcN/Z81Q4I/iweL3DYGYuQ59YJyBFxVWY5NoJs/d9NfPsFMGZRtY05b0TIDgDFN7si99IVBP2sDjD4LotNhmectsavs+qEdZanpbDUfgCd+ev7tE3mhQbolH6U/FLpwBbQ324qx25GLDi6fvcVedIvl6ExW+r9QH+31uP8wszABakS8cI27aKhXTfiNUYrmD41tjWYjGi4T6iSO12NdLl0/kuZ1iEo0cg24fv2wpW7nFxsc8RKnaE8zAa90d8XRpSBZbp3+xMH16pA+ucpSDRphn5JjWNY1K/IIwqONsV0OhXzN/I5B727Z9yTAAkLXH5oG5w00g3ZGjtp+RPMLgLyC4CInHpjPyf2xrH4PGyjX92DYftCYOW4UfmxXDepRGnChAAXBtLaHJf6WXA1FFNLbnI4ZZHv3bWzDRgf1xQLdGdejueFWeV9VIGoOVHAnQIJMfqrhP3E38ajFP67jA+frk5eF3w+MHfsc79FTx58axCKM+rHt1rmekJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwHOp394fQyzwj677hMy3v3GLhKXBOAOqIsIsZrLHLD+xaQIiujj6MO7QBtdqokfV29b/vEBCK6eep1oNZ0bkCAQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAI4RPVo3XLWPiebTVdTVQ6nAJU+cuwQpxZdkh1nnalsm/U4BaBVjLBO6R2jZ6AQHsaeSswlMFidcLtAh0Upc1oh1D6Mc4N3a8fKrAsyMYFMa5IgSG/4o5D455gRiPemx0glgf7Bcy1h35qn52jMcV6DmRnBmi/a9gkiErwK6NcXieDuskJ3KWv3JkBeAhMqqTqPjtx5yUyhIqcU2NRz18I0o9RlMc7Ni59ksjgo96+1ZnzD5TAj3M4ZHmI9AXu3IAfCWnZbuLA3ohMmCPpk7/ZnNwVuggiCE+HQgrnvVynbSC/ZM/moR7djSIZ4xVWHkeDdRJgcyz0bdl/nfSd+rkh151twZtAEPa55x1WmpwrUoNxUZwsERacuWd8mKtufIH/QtOfSVWtzZccM9LTzt0lKRb9phISYK8SZJ7hFIy7Z56EbXYn5Ul8/zQOidNzoC5iEHzMkQocWBWKEhqxuZ/7M2M+PyjMdJxn06Y63l2N3OQWpSmf1J9Dc7R0Q6yYpFtfBwHUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcOY7MD8V7H/uTd8PiQVR362oDQ6aKE0Ca5KJuam+dcCGZQ1RAXsbMQn00pZpSin/QcVUaBXOr80lVV9FH3lFCw=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAALeW4zY+hnvP/SbpJ+Ctm2ySqUGWAMPYMhHUudrmhSGshU5QcCmXoxBUh5BFkcsvtJZVAeScDfvCyLZa+TeCSLRQWzfbOZ9yAqWMZtxXh0M1kQ9O/77CXJv4NtME470qGRjDaaxZiK0bOKXMGeORr9Pt85ymwlpXMPEQZDghzhFN/KdtMvGUgln3M7KBA1bLZKyGCAbuOsXKzUYwgndmKh/eSfa06nQ3fokf581JhmApe9Av9IdsdfXBHlrVXXZhVM78XX9QtoEL4w9OJRiyW5UKNPX6e+90CRfWYA0EDQTsk9Kx/6PTbM6eA0pwKeEI1duaouPloI2zoUjQ3qMsK+0m73N84HjB3DF90OD2kHmNsPiZ9YpZfgfUwoTm3iUFJgQAAACTo6KaYDIn/Ikvvpw+Ys1HwjzMD+GaaMo21D1s9U7YswtFOt1KgXp3U5J6R+a6XlblrfDNla5XslTtR4XCbJzFkn0cUPMNz8pFVZDL9eMc4eU0147cEswIZ4dAdDCAuAqo5yC2k7zxr13/ErPjtpEF8TiMfmwN2C0gCwkZ7UUV8vY+Xn4ojBfcqE4RYz7eupm39paCTWR01BzkQWUce3EdPiej+LFOboiccqbTRRQovjOoqaZIOoLQtbz5K5HF66gYKBQu3wIeuWaSYo/iLgvssxhaOc9otsRh4JNS0pUm/VPmvOZScYPMzeX8538zXqGXWSa8S0w/1QPJ/n1dozGPUsVt57SxScYBDJItXTWb5wRgZ3Z2tobPmSk5RHsdolXEj9gRltFHHt7CdJv8w1aZmZgaVe/UyHyGZ0OSkOZgPqoYQkhYwuxkybyvOXUqkD829Gk6qmZsM2VO503yg2Eg9YHpffavS6L4bpelQfhAZHB8CsC33zukvNsp+U6U+KyTy5JEUyMdMFgMsNzkP6rHU5zJXZKDXxR9320VzpQlhHyhtN+EqN2EDLCjbVhEz9yMvc2eV65ku6b9oqJHFdUNzZtYDXQA61EDdkicCYe3pNObv9Zz42hvMqeLA2DfP88G6XrRySVJGrrXog2aZsHdHIWpISbV4p0stV6E6s8PERZGRLvsLtPup7Y9eZ1pQtEwoezBZwigZv+DC+v04OY2R5WlRyH4wG0XiUi0SSIz5MYX25NQ6imhMLLZzkJ/zMHPeVG+URoRER7TG2xa8ZGlPttRmnAaERw0IX68bw1eEC3xS5N/RbmQ+iI0TFW1pxwM9i9fMRomKSd8VzuvaLVUzzoplO3ZKBvS3+N/aAriBid+ywPfXjNCyHFsjotlcwkXKwLYOfnXLEp33E/twZ4afSrwR/UE9NA/zj0402Z66ZoJ2JViUpbu1NO81cNIFQDmFXiqWI4V2fuO7XJQniX5fFFp1E4Qt9g5JSgB102RYHuIH/mFUyVQ176x8ZCKzl5v2WCGkHh77/7tUxJy4XyNToXBoE7hqUeene5cRZMpL+Ep0nbq9zDyUmC++LMU/YfaBDTpqoEtdNSEBNOBcIr9CpEPK0zZS+SgOpUDztpXA4+zrGZmD6/xfj5LPaD+736lOE4jFHHfIb/34OzqXHh5x5j7TF0+wP5eUsdnoHIGoAyPexFoj7lB0XycvteKYpLby8frdBqoiJ9yz05BIg0xv0HVWQ8afPpX7iSf//nnzamdRd+vofzOhHBD7tWx4fy+p3r98PGuEELllXlp+jhSiW9qkOZcFmvkgceotg9uNZqdPe/HkKkPVzwLRszofL2DthcYbN7AnGeNcDzULBKPVLARL0s8GaHAwX6D64DWap4Q9xTFCCZrUmySSDnSB8EBFrJz5C/8zZKU+KaEYOpqTR7+N+tWv+w5BeP3n/kp2A+ds863AQ=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAALh9enjVyBUiuWkkPaTyjF9FO08k5yAnNK3XdpwwNKCQNVlxReBHGW1Kf1c6AFVSFq1/TcNSfbatTQwVzUio0mJwdpuQFJoEURJRpmbchINlkb4QUgj4pv1VbEhVQiNmiwWrNYMhD99Eq55D3PUYAHTYK3Og9oCVinxS8VUDXD2lhlkOdYPlnl7lTJi32MAiVKsTrIghb/LC487au/FkH2yoMHwj8OBPzkmOBMd9nzVxn4HKyneQLMIHzYOVPzEdrLyBmKXyBe9EYzA4pog9DXKHaTlmp6z4Y0/FGTjVlIotApNEc+irAHWRwmJbmbkjbXc9sdnuk1pgdNAZRKxoRosoMBfjjct6yODOqlhHwo5b6EzRvWPw4yjbKhiLktfhXwQAAAChW183dsZF9AOZxfJKhRRF3B0CtT3u8lRW9Qy2DF8lj/UQu9ESPrhfxySK1zjCVqgtcH6/qEbtKJg9c+dEj3WjSDUV1KPLUISjU3n0a5qEa9zNDDAlLVEHrgge1Qc1XACq1E20iZ1dydLpHfs3zcF7v/Rb/l3+Yo4UEPZ6tMD4n64zDxQjB5EpyT9frqLOJq+mrmG8IhPwMI50lCkI0z45FqXjdAIaWcX+Tx4JGUi9IdSA8unMDJ6mu2cXXOit+KkVe0XTj/69ZFf5Utgk+n/IgxRgUJ3biLSrGz0DBjldvoU/sNNKGJqHOjwYFWHQMfW3fcr+afG7Uy/K+fqxkncu2uN9PtiZcAiH4ImSwoPUeaAjUkpa1zd02DTx0asWagb16JAaSTIoMJgZC++J7iquh2WOAUZKB0VgiHRdIv21015GpvJ5R0SBOw3zFUOgMSqYHu8A2P38Dy3g7MrGdNAfbJEY+yjsgwF329dSmCNQbPVdAW5heaHmrS0lJaNynacmefBpmtwqgos/ncWbQF4beIOnz4QQY7sDFT9mUrgaQhtNldafBUVoguhmUGe7sTwqDInjV7zE/sDej+wdxSBekwi3RHIkCIMO2e+KgZod0QEDbPmEcI2My6CIUAzzdpO5LEuNhyN/8JBcqVDxdnxrjt85t+3y2Z7bZOAzSC6nfZuy6Emgos52rK4pQPHJr4fclDByVcbgm+8Is2/CqWtqbE64+jceA0Bz+RMKkexBW2clMZhd7YqNSg7ywsTvtaMIXdxQHSmaSMo/SFsnm2ERDqpSthe4DmvearUUZj+9yQkRDZfcTO9sRCFGiKNDXRGkVQk/cCMIrrcgPgktoac+mhwMbJm9F+dYUjD75cFmkVcr8QQVtWS5lGAPDk3AvqUH0s7npTRntfKgma80BhrQRAAlJ/UEoE8iQBWFDqYxcmDTwqc889P+To73z+zfg3s0TspOYCma2MK3vpmWQ02pubyG6TOMEOe/HCYfaclWifOtfi3zUGCQXJ8F5RgtBIkS8yqzBaiuS08zpK9ri3eMUvs+5GXd4dChqM5yn1BaMU/F1JKT30Ab2sju9LQcxGOgcC47QRx2KlVlYmVi1+hXoh15R2EM9LyA3rDCUWUKSu5Yjcs0OyUHkO8ODGy6q+H3DkRka9kLPy20/xK1WlrwRbaIIOJx2XmlmJZPKtYX6gAWLjlDEbtC3GvT9/Y7Ga1p2qCJVj+Lqyql1lG9+ve2zcfyrxvrz033tToLppdRn/E2QcyCknhbBzSoEvfU1vlDJZXQ2Gb4jf5xJWbTyCKQcYLY6VKGN3fw7V3YiJa1mSQkskdEunPQq+uwpQiau+TK5/z6n3qbTmF66SJof8cTv+P77DoaclkXM6j0BmMujxKGERKOj2rG98LnxI8Zo+jS3LZW/2xfrjeYXYa+WKhsHZOTfAtgejAjmJOCUj8XwH5Pp14pDQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "ABB4C955064DA17F8F2793C3D9AF15C37308C64E3D79FAC321C08E5BB0A65353",
+        "previousBlockHash": "FE0C353F7C3E25440240C9ED48CBE76DD00AE2BD9E39742D2E83596CD95BA6BD",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:/+JMi8Iz/Szi+n8rCIYVmvWV1f5WHDqa9vmIUgAVdhM="
+            "data": "base64:dpjsCVNCHo2zHWAPOthePTaoSE5f9y9Ky/wofKce70g="
           },
           "size": 5
         },
@@ -2055,144 +1145,62 @@
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1665688085846,
+        "timestamp": 1668120370504,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "5123C978E172FB5BA7DE733792FD17ECA03FC08CBEC11BDAD4BE38C97FF0B3FF",
+        "hash": "8B1575284E56C6C7BDE4FA2A71C54C380D7E7444FE18C20FEB30F9807B358A35",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALaMjZFIQ1bRKHJPGxEuz9+2bZdTh3yKsdXyd3qACRVhNWiBI1RAklXj7nn6shX+AaWCW61pwJPNpG/ZqTUY1m+OZsNVPkHrVe2yQ8EMlfTEU/ivFgQuYHsLkoeeZlUoLRMxI0ozZJ7N8ApJarrDCt1QQrcuM/QfdCvsgc77thgIbvdDZv/+miZeKIyLgB29BqGZZQ4e34UhtFHO7HcQmhHXjCDaB4CI/1XCqU8qou+Wr62qr4zWQZ0CbQ3LJ0mPReaDpQRhr2rJPi0Af2mPB2Y5EgXX0BU5jqu7VFASrmuzbiUmqn42W+VejJ8Wlz/wOaTRgE4fuwHfM3JBe9JnRAi3LJ/rHjXMfuOm6tNBxjn5e3w+62F0k3UL2WioUZkUlEjmuauNjefK1tyhagxa0stOhTSJ6ilBV8IqIwucylLOiHMR7SPBsCuby7B8H2gfxyGjWkLCGSuamxAj0JoCT84qNxFhSnK61X0P6uQnjfdRRNdj3S0KAOtUADtII4bEg5zdnkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwS8eosFV9YlonVTW6E6Vyq1X2qik5+QFYaRVAQQXGvGhkpux5kGUJPxseoI+batXU5JAI1XbVMX2fOPI2sj3zCA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAIU1WrPrJo7/CFrFHUwAZ44PAejEUGvJzNCAiMmPmwYsLwzYOEijxFBKuGBlEBeGoYIipCDCForTwvlM+aBIBIYSjaAvAEJuSUvkCOVR4eQ1xvWUhTrqqVcN+0sO9EY+9xYj7NffJIgTrV/Blu7NatydHCRVuWGjK9eNojFk3j6gOKEKs9Tj6tL7pZkFzn9NMK6vXjVvUDYr1Y6masXdH5viBrLnp+y6Tu0m5Pf5D0iW3BgKmjgXQKmvbabgk63JBkaw/lMJj9Nb3tPUUT/P8usBm+jRd8IoRwOO+SouRTKn9VEPNRBjfLs2ohHEEd3Ypnbd08qlpb5061C22cmRui3/XU4xfPe/xNqs57K4FASp5vnLqfQswofsHMB3U6KygqBXzAElADhjV812IjK0ITqhjVoy+PEFG8hIIo6iS3NYWmUHfDcAVygYaY18KWU5djr7L92I/ATXmdZnmSJJYGFzLDK9m6doGPM4NDc2cyq4F1NVl55g1eudzz94ilY9OPujrkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwc/vow2ckpEjR+Tz3ItXCYYaQY/xzc8mZv2soyWlbqBL+8Rl7fHc+qz88rXfPQST4p2flJO1i/oEA5TXlPJwVDA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 4,
-        "previousBlockHash": "5123C978E172FB5BA7DE733792FD17ECA03FC08CBEC11BDAD4BE38C97FF0B3FF",
+        "previousBlockHash": "8B1575284E56C6C7BDE4FA2A71C54C380D7E7444FE18C20FEB30F9807B358A35",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:/27YiR0yXNPatZLoW7Hl9ZATw2MPn6EKBJsWU9lCii4="
+            "data": "base64:IRJMSBTIHG4EiRqgN4rg+USg/xbTZiLfRpv0QOVZ4TM="
           },
           "size": 8
         },
         "nullifierCommitment": {
-          "commitment": "15F773373C57C3B65C70815FB3D0214180057F4EF1CF2E6215F1B8ADCC202D02",
+          "commitment": "3831D004E013F904BFF9DBD5DD05CAD7D7C26D7F01D79DD2DAFA0BCBE4CA9076",
           "size": 2
         },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
+        "target": "12119999654671602549574631743681858537201091223028554332475739630",
         "randomness": "0",
-        "timestamp": 1665688087700,
+        "timestamp": 1668120409460,
         "minersFee": "-2000000009",
         "work": "0",
-        "hash": "C93ECE774271527A34EAF8466EDF5A71547D7C05DF13802E381139E7DEE00A3C",
+        "hash": "E9A3D70BD8CD5630CC500743D6D2AC5856DC2333ED2F55EB606D81FCBE4D4041",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAIihOVroPr8GUEetDO4dPN8seWklhUfNugP7V/r5leRmYMN8CExa/bGigbpc9Apg96hhwAGExJ8r2eFg6QJFg5se/r3X3EDkxpFUAiAsy3v2uKK4Q5SEhpBe9JwGJwOAvxUTG9QcMRKkhOscq7hd6VFmmjOp5AnbxBifgAlDMQY0SFviQa8xzNFkgzFU4L1QK40pUN3Pexcv3ecFD9i3h4M0fGdiqm3IRaHddeitBLXnY7NmJyTNdf5EOGgKwubDJdFRM7mh9rIM2bghG55hvv5PGTgoz8BsqlCwvqc4fexkzFnhLez6m0MWC5ewhQUdso/Ile+EQvKRq1wJQiAxDVOdheKg9ORM9XNIF+COe0ht7Dt3Ptpcd2yOM9Ffgy0O3DtArMQFnCmBnuT1JkHx+j+VyiEs6LTqkPe/nNhfZCjKouTOq7GpOrT1z6V+tlREKxPqexknZqOu0NmYxW6HMsSStvTgBambdujWGdRxGRMXSsCGF0LKAUdM+iZiBroHGlwZxUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtmy5R014BwUiqFO+zaBL5HTPLpjBRQNA4hK7oAFLc+8n0SDPkpG1hT9J4b5ONf4GeWNc0AV/+6vf2O3AFqKrAQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPdryoj/////AAAAAImfK8bseBvu6XFa4PPXJ/pMWNU3j7zknl23s5v0Xo5jJorZrRE1mECDorSDFUSm97bjxgx9SkOwA/KoVvT+KBiGD+1LO3jdcz/L1gFtkK8nU2RT3f1TF2cS9BagMe+cAQxVV0f2lzAOliZTj+4IbR2o33vALz9yZRkfkYMhAyWzfmR7o238ooz8J+KYXxxoWaJNxUhZglvriYUlD0i4b5KNeewtvyjSdCipMY/mO3pVwpjFELbbg9davoXDzXz9S2FaB4NOk++zCfgQDPPZjZ4pELRFD4g+IIYfz1ITB2FP+6QhSrTAHkykjd/VjoO8nNeroSeYizhzXRQ/7P5WshFC8Qsll8nUSAnPG11T/kNfW9cJoU4eAyZ5O9iY0njzAsYPXBYdwFjOXQBfm9vwmmyqQp2OGi8HUUfs/Ma0SL6GP4Z7yJkygQ1KC3vnCgxkqiv2FL3x98WFC7EP0yva4sb/ctOjROh06JNt6QY3Fj3um+vXDAcKiSXfDI/Xn54gKdtteUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhXhgTOvQqvueHn1yPBxlpZ2aTlhqv/oxEgNm3Zxgu4n6dWM5g2h7sVx6GkIumHRBonp7IcjpWz8A6vv6v5YBDQ=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAALI/AaLW+8B9+PZh8uuv80gb6UE4ad0jtYjZ5YqqAaf3d8XuiUZtIOQCHNUcXraci4t3EB7qxPm7WpYQDLnBhuxZxFGqR+tSvIuZMp0e9Dxls+/aJs4Hl2VQ9JhzRM3/yhWXehFdu9Wj4VEiXIOjWILQqb3z7LGXxCr3H4QXEnQbbijTFc/nyjjfnZItIB8zF7goXknKjUUTEo0l6YIz/hSHQ+tHKQOXVlYmAA5AwaQWM6rqlojZkVU3O0MysbAw06dDuDDl/vBGeNjC+cevc067DU4jlXaMkqBvawRMup5Mub+X/bH9em5ZIciaVbeyict7dw/xqmSMou3Y6aBw9hT/4kyLwjP9LOL6fysIhhWa9ZXV/lYcOpr2+YhSABV2EwUAAAApKN4ws9S4TH82cYTZ/YdylQTznL0xNki9qvJ3lk+ZGyhWfLhYtiDL2S0NN8accBaILkkYC0yPKL0VVhgPgJY55mNGxA8SDBdSloU9uLKWZOqGOIzY2SQgwcvZdeCnzgiJFlVOeQqQ39RflrqFoj9+PU7t5tKqksbMmUv9KuMjA2GCCoKguw2lWr98KuBcfL6yYji846dhA8gWck2ddCIhBcoYuESQCT2aUYDEkGRy4wG5hNPzabq6w4IUhMg1OPISrqfeUNCQPBDaMpuvyT6NvEVQ4n92J2EkEseWIlTUwkj0QKe80P5UTkTAZjhFwfmuOnb6wh483GgEfHG8Nj6Cg68grDwcoBISPFH1XaxlmSxNzKAXmPM/KHB3hlqch7dFFGM/aGthBpTlYJuhb1PBmVKoIT4dYDBBbSvM9C5D2cNQjzPLAA+M4GZWxBM4HqqVTFevcqm3iaErdTd2eWph1+Ag5r8G9gC1UVN4CTgjQ8WIrPubR/zYy4B9wJaEovJcqgMlBmhz5n9UZFZeqV6geoQyNaccCoj1eQENXzxfEJQyYJV1WpLMlulhnE79b6ucV/STgAJ3AnFMageyISYl1EF9aDuEEM0JKgpfxbALXrOuP3CkSDStVTScCn7ILM73LUW8UAeRUvz2HW+k0RL5uhdQ6QOgqPSkWj3KBUrHmtjOkNts7vK1dUk+/+Nth8Yyc1ThvH0o8u7cys4R+LZ+9KC1lGLzueCfzMtV5nbzBxmXi7fUYWCJOD38PN8pIHkKIzIoQ3IPgbIyU3sYhhcVctbZ5e91ZZbLqg9qIduLGmQdW69WEcEXISP6O6UGy/V+Vgj3JB0xOXnAeG5VH5lPbwJzsMYNc9U9Oaq5HENS3bvJDwda1n3DXYp0saNICtY1OZ43rDP/tFkDeQ/ArD/1DjUvMYElOGXyelnNsaxFcXTz7YyL6/Rv2LXtMVvTkJXLnuPRcQCLx0rxBjjXsQ9cKBsXIp7Cp+iotk2y+t/LzWjLM2ahLYnVnmQN9e4vfcS2u04eG8CaSS+vtCPH6hoKNTenl6IC7YDbnDx1mi095cgzXFsKb+bU+cuL09WHMS1e7UUV7XNqMoTyRzXwQonHgrJ0bHUJ2bDxRXUQoCirUHI9rjibAsRHMbeECqYpIpHM5mM3F09guSSffTXEYGHi+5UHQmJxC65gqoTlgHEmZ/rHfNsc5+XAkwSjtIZf2D8Jn3yXEKu2/2HZueL92DYGeG0bCxF22/GNxztRtfF2R+aWCjATw4IieYJaB4H7Azcuf4aqUlDl/WxFSmVfuCL5UlLAPBmKNSHAiFv+CtzCiQ1zwEedQVqN1LNSnvACR8/UT2mlDT8iCW4AM5xzxZXcV1Jpm9NIZ2+0HDv2h+W8Ms41RV+at3o2CMmimn4bsPDZ2a5z0jG4GtVubN/uru2HkWJK6UtxsR38ZgCRmj+aJ+sgTSuPAw=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAkAAAAAAAAAAAAAAI19P23QUqXeATQmps0FNHaeTuX+OghVNEvMSOSTlEwfwY6cLmLI/3Fmrz1c5ZcCGaPRUDcXc/nui0Gk9JBJ8pLH/VWjBo0qxHCTqX0p9tOp96tHz7lzimP3N1yWJG+APQjzWoR64W4G/dQRxftEUlCrGycZ1aOCu5qAM/FmEMBGRbGMPI/Uzey99CGFYyD5OJbCV/vwbPoRTF6MkkVIr4Ts0yC5vqzRIvwQQXgGFVkeLvagwfNfatGC34tB8B5q7RH7bECwxy+Zx5LfQkMemjqLBonqBlDgfCzwUuAMhjUzP2zB6Ucc6n0IbdPNIs3WFkIPODn8E75iY03PlS2ZB1V2mOwJU0IejbMdYA862F49NqhITl/3L0rL/Ch8px7vSAUAAAAjYWUbLGFzcwQZ05PJhEhK6HrV5uet4Md37Dk0LYisrQDXdb4Oshw+SsWQ22Frn4SZBUbXCA4uB9JVG9Z+cDPIVr8dx9yq3PDNPAp7O1BQ27NxPAOca15p5+lPQRMKHwOWln5x1zpMYtPy0J1ssURdlIpifX+diJXNWTAfLRzJ5BKA+N0lGw9aOgqFEQwCcSSYo5YmmotdUUYopfsjhsU/SUyHgQ6Xkwu5Shy9EpuPkwC+fyqXIz4XjstVhWyM58wRiCoTkNri8k1vpYYq7s3nB19YgAnD1sF9P5ql3w7Y2Ku/fnNciHJMiUp4HeaQN9OlzTkevV3GNrv6FkEug3svgmmDFSgBCXwlLcIy9sBn9ql7Y4Y02NGzbrTifArnGqA3uotW/az1eX1SnwQaDdQVCUX/KNTE4dndw9ilxkPhXCExOD9etRlZx9T+b8IIfj57kZXpUEcBhpfs88K0aFAufXtZBnmxJb+aHer0uksA4FwaHHTBXb/zmSvg5N2HV1iLfYfJoC5shw4xtKlo7/CqkIJ0saaPnyw3ajIRPn3NStSqQx9KilT9F9nSvGT+YaKWRUvWUe29JSai1aKiV4hbH8q91tFj1H+yQYHg8RRk1SH4xlKK24ddd/Bh3QOOsNKPpZ61t3REN/AD7yW5oAqucBvwQlPINPzob05KFhR817ZoMQrOjo+Q65PPNL0kFzSJ2A64AertFyfB1pMaKuncWpZClJL/ik7I3+n8qnfPyLO85YAg/u4KnLOwukvThoq8l+TkfC2y9LzG7IAFefb7Iar8Dq0/5Evkm46wLexJNaWDmJDlGiA7w+wgkKilFoVSJh42RS3hmhEMB4lR0vdCJ4K+PhqZcLB+WnHlY+Er8aFjBBkBm0aD/XDK4wrVRMeNygnQfkGPxgW4CGu3l1hQpcnbHzrjxGnObrTNLywalBj3KJO3MOBfEp807jWyFFp+zndgoRjMnmeCtFvIuCaVVZGY02kp3OdpXbfLkAEdOFkHe0emAX4N6J2lrIfnK0zsHGbSHYKwBrflkE7TFCTkOuY98SXtgh/ZvV2rV0fBKFBSkS3kgffZJWxjHiAL+B+oE2EJNVIK1yDbTh+4D0RN9bIW1EmSKeqJoSXqRsuW1sAvmITPOuoI+ut4mFAz2Pp9+cyDhPnB6d59GijTd//xSLi6NlOjN4Hu8EUoqFR0gCg5+IRqPKcgHit4HXI6CUnjuujRmrAVesMVXGRAPphP2g3qwqFr92JRZiNfTYyKMw4f7rQB/EfWF0BEIsxKvF2nXWt2Z44JcwXj4S4i31P7bjY95UZBFh9XvDPDLToUVAyihnMJqCzqP9ZEYP4H9r27TR7QwcQOZpdRLennNv6Rx7uJF1WETG/kshWGuZ3+6lOOwHybG0eNnrzPxIAjg0IlTe05fzfNegk053JQqlnBAv0Rx3OiV5wppuTBQrUiWlIuhwYECA=="
         }
       ]
-    }
-  ],
-  "FeeEstimator estimateFee should get transaction size": [
-    {
-      "id": "17f692ac-6358-4191-b517-28d0cf9eafb3",
-      "name": "test",
-      "spendingKey": "3cfb02ab9d8e49ed25b29dd7826394e1b1302097e660aef73a64c173f4d0c372",
-      "incomingViewKey": "a918477b78c9bc8d3c120bc14c438f8b8ed57ce6ba38a2737d80cff341185b06",
-      "outgoingViewKey": "2cf3f88d5920227baed73751fdb2c168aad1e51f455861798c6e4f0871248df5",
-      "publicAddress": "357437fa3e25960e4abfdd31944c9bdba4b713ade84f403faff4358d4bc57a4028b73cbde26a5d7103329f"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:GNjUSUGA6RD51WPMU9ztIR0Qwl/lT8apK5h9br4FgUo="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1666740372774,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "F40E433502ED236832B6EA0503E8D06C4784F2DD1C946B8A10450BA5CC0828AD",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALZEoQLjF1MgdY7wI3lSm8KAOEWdCqxNH9w674g5T2IqfLFP8f4lyQV95Jc3nUALTZmGCSwQR39GQbYioCDCXT8Z2I3ZZQmwHvvL9KMaXP6whO247rFNyku85AOFHh1HCRF2BTmHOdNeJiRwaTV1DeTY+gRUrx67Kw04qYu1KbIua+odd7Mc6bgjGVf4v5IhlJRRh43a7hCXOSGcFTRTaKZ+VuUt/kiPeGTw8sESw1DlltgIV6QY5fDnz0mfHaFpBwqwqiw1quo4G5oYBxZppg71IS7CzRRnYYNjqy8q+wMOEoqca+ULXdQNymsvAAzaD2cwIgwjXsEr71xjwMACblsyZu2d7SqpBfp3Zmro1o9mtgiRl5/1oIM4tydGBas5KQoeH9S53lv1T6x0kLTo8wSK1DHofipSwZ30yZyUTVk+rs90k8RUlIN7ITiJJNHSejm1IgFXvDhmeqYz2mlvrOG94NJXuudHuqeWUGV6v/rSCW6c9FlFbeHPW2iu6dzY9UufXUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRS4PuVZQGQbb15Cha2flk/TaE/iWI+hl962Dzyr8ivJ6WekOEYZ+XOFB5yJJ0jLubTfQPAtHoHoYBZu+dvxwBQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "F40E433502ED236832B6EA0503E8D06C4784F2DD1C946B8A10450BA5CC0828AD",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:5YYGu5udHdCT0E/7Vp+kUMuUFAXS51wK9sEfXgHI7V8="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "5D8FAD24EEC6A87B74FA6042DF13033A84A86A489620A3336479D7FA105C552E",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1666740374086,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "B5FE90965DDB3C31E0F73F102B0D7403B68EBED30A200DC2DB19F10CCC0163FA",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAKuW1o6/2qXNLzEjKRT9ZLcLEqqkJdNM+PCrw5B1lY5JUzbF9VY1oeJ4D9oAlhdfELIGBbmuA78etii66nMCip7h63zdEaVAquHApntMBexyvWuelKaugf8P8lhV9vTyBAnACNHOd8G/3RRrR4w7TiZYjmt+9JvWJ/AAo546sJ5zYz108vRmYBNmCnSenvBdUbdTvWPN9P/shGb7EEv8hOPZ32Y0Y9EBvB4q0ocI/3vD2qObMQjQHYVsguz+hGxKQoPll+lAgd+35lAz6Hs2wMObfW/DhD9uu931mkV0RvFJoLLhn7fxsaDOLimhbFT7evZgnibrSUxDh0rEG7hFnw2I8o8ZkXOqVI6fre13qXKur7xEAZj0pXNroCCS5gWFs7CBs8paZm5UhPCKFRyY5FwOyc+aUjcsmMuyqyoGwMeRjVzVQ8CE/5xEq/pPcC61feGc4VH0KVDOGGvAYSVONbvfFUJr5oSEfQe4OlwCbJyK+qBFjE9joO1gXwvPFsm/l+cP+0JlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwgpZl+gV3+Pr2ViaRLdUL5u49zpaIBlEai/+NFdsE5Rrx6ef4ABEx6w+KZhw/rdvk/+AUQMQAuUCwH1sWDSd/DQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAImg41/DwfQJPtmZW4vfMgdru1JKov21KELlCrzs7XZs9gR9d4zvGNJmB0HzQSTM9KLPCDFSINLEaEDdzxgTzsLoOq6SLzycAVohv9MNyv3yb+M/GfWrsTy8S4cInLKAlgRlofwaI27ocZuOrx0Qz/STAJBYsw6vVRSVjWFB7PsM+9JG90PtdBUPu9eCj+zIdKChes7Uvmhe6bODw2GZN14RGAWht3WoM6dV63T74kGFbPUEkRPnnnrdfQeISYOzRxbUBND/rMQfi+/KGiNKeGVVYtOtDUe4KFlonockwkPY5ikJtaqtiET4j9uCg+4p8U1ax5cy8vAgcna8IOFdODQY2NRJQYDpEPnVY8xT3O0hHRDCX+VPxqkrmH1uvgWBSgQAAABsl0oBH4/jI2p90IBmBOZJ4oRHLUSFMvaNCeHZF1Ixyf9j/M1cax70ejYcW20h5dawnsJd3MeRz9hhWdFmbpqTdecEkS+L1yWhVW1TokVYD9+WDTM+tDtgypirvB+mwwKUuHvyUajm/dk1ihe1QLJuuK/5LbYtvyT60AKYxmu/h0XGZhwXfcXPrKjI+OWM32OBRJFDwSuGdMQddawkZGscOFiwlTbNxX0mXDUKeHk+gBhxURR4zegEzetV8j6GlbED53KRIk4BlYbwHwqQl6Ymxf2tYDfVmrRRRSw+ZIzE5280rY51g1HJ2+0O9GmOjVujreflIOKiW5j53/3JTYYYAWJNv0CpQEkkFlxXsBeBrxmVKmp1icpR5Hl4CGHB44zvI5pJ1ewnhsOTKJgjJY9RP722sFPIejfhsaXMPZWVEXhTDD2Q1JceSlZPv4tOZjaompcuf1KGLM4G7wGtCxElNM9tYFL4JPwUeLlfTQtOuEM6XaBPoxcObW+y89opPrO97MW2cJebf5Q8Ez7+yCSJ8u7z9Hwp/kx1/F/Ssu8HgdmiW0RM5Kx/UhrV3Jkws4BATFd9eDtF9xAhD1+9jdVqINlhZEEyF8ucaRqXCmgJCQg4ixZh3ApmvKx0qz9r/GBzSixQhV1UP+Fee24WRcOGRFv4sMPoTAj3//UUh9sKOOF/Re66VmOaYoNpGDNf0py1uAjIvU3dqi8TkFN+ecgN2oCOa8kcV2uVwZTbC58WXNqKZ4Yo3/zjS+98iUt987e2AXFFA7t88axzej+2NQg2LS/jr8TYHorPYS5h/Th2ruByaLEl4fVg8Dhhk0Ke6nyMwdlZ0RvXePzz+ta8w3jj37uhYD8A1vh/Be+y9wjCxZkSAhdXX4PyJEkTaLwgWwpaSex4sC7UutZXEF816GIaEfAjgfunHXL7PQihaCLCUGEVEqqJmre8PtNJa6Wc2HxGQ+CXP6WICnR4KuR2PyoI+uSyfKPkiUWHCkQawHuDrDBr5moLPd3yPDJI+tVUglmMwDtBxUHjXZDU+WqxugbN8tSXY422e+cnok28SXyzQ/GKsmkCTYKG1m/FMUrawJY8YhUkutSL0TDCAqwnprs/+t2x2sJgpwulBZ3DoNWG3donhCqu/cAGqEsLzs/lB3nu7WAre8jq3u6t+oC1/JDbMDebUqK9iWNAFV7YP+rfJd47pVkZjvFYWCl1iGuSDmzKqWJLDEzq+L06NLpL2r6qCS/s1LRN4+bgbDn1Di3OIrFyFN54wi9mgGSUdofqpgnZG9dk71ElX3dhycwGRlODDwjTyU+CSCkl7hdGT496CvO8Hto4aLgADhIIvEudOoYPitxtbIWkNlwhlOyR03Pz+AHT+NqyLZVBVjTq7hSpT53VWc8KyIiGN0D3PUU+rLSA62BuEQqWmnpb8am3DsHotbRQ/ylI/hblHBULHk0gNGx6+U2RCA=="
-        }
-      ]
-    },
-    {
-      "id": "bb72b666-0e05-4cd8-a39e-e759f6332be9",
-      "name": "accountA",
-      "spendingKey": "95932ac28303eb75a4245e5ac663d646f66d7cbe9d1e2fa640ae9d85d99f7408",
-      "incomingViewKey": "7a49fd84c1565479433cb9f11dfa1bd4c048669299ddcf88c4919a7e64b56805",
-      "outgoingViewKey": "ea4a89c6fc636f7efa3fa05beea88f245c372b8991ba9053335babe0aa1f31b2",
-      "publicAddress": "35e75649048eecf96e34f807a6411126386c02b354c89db74f44486f2e92b17a726788fd8aff7ec81511bc"
     }
   ],
   "FeeEstimator estimateFee should estimate fee for a pending transaction": [
     {
-      "id": "9adfe4cb-3ff6-40a4-8993-5b4b50a0325b",
+      "id": "f68e1a2d-0660-4beb-9f0e-35162ce46e7e",
       "name": "test",
-      "spendingKey": "383e57b0c677e45aab1611c5889bf610fa99abbf776fa9efa3079421a546c08d",
-      "incomingViewKey": "7632386cc8a87a2d070b1503a909db550ebe4808f6971cab915507d3bc0daf02",
-      "outgoingViewKey": "68eef5c8c9096de6a3801c8649d00abad6e5eabe3ff56c62052eec2c6db3e385",
-      "publicAddress": "c14d5bf0e6206d4a2db7af4d0c9cba195f109ad7c6f8683d454572b952e31da7d6c99cd2c626ec5b394931"
+      "spendingKey": "d4980f6d019d95bac58ee472ecd40c45f990876d3d1c17d1e2dc83ed5b721d72",
+      "incomingViewKey": "bb1054c4744d334b260c4118633681eb0d2ea08f00cacc6abf46b10b058d0306",
+      "outgoingViewKey": "abf9ffd47f86c6188364a5d9843195b66b7164dfb6b1ad707ba11c7e91d7e713",
+      "publicAddress": "d2338a30b37c40857800b13d2215f63f308c5939eddcc00201ed4e3650a9e67f99435f76552f74e8e2f21e"
     },
     {
       "header": {
@@ -2201,7 +1209,7 @@
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:6KqTXsblEfDE6C5FYvF7NYBbtYLuySDtfyCbxDhi6wM="
+            "data": "base64:uB6zFN3aR4ePelP4Ds1huzCrLvFJTEPme3kIgyfz9zA="
           },
           "size": 4
         },
@@ -2211,202 +1219,60 @@
         },
         "target": "12167378078913471945996581698193578003257923478462384564023044230",
         "randomness": "0",
-        "timestamp": 1666740850902,
+        "timestamp": 1668120373074,
         "minersFee": "-2000000000",
         "work": "0",
-        "hash": "84548D69B367032BF7F00FA3AEBDE21CE5434435A1D2226E984F813606FC529F",
+        "hash": "4AB5AACCD55997BF02D6961722AB8AE59C1E7DAC3CF60DA5E00CF659D30A10BF",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKLfsmaDgq3oAlzIkHJs0AeoH6J7nqZIjCZVsRE7pOKqDQm06a6xO69KHeDZ6Vzqy4zsYNHI5A2XbxZxtnB2Alk9nOUmaoSZTacAXCUc155Rm/c8uJg7Y2WSU+0sHlOsxQYa3oJcZ4cNVE7B+xbNUlFZ2Hek7EH5j00SyQ485Lc8YYR8X6S7x20rj7h/4s9AqYN2l7s0ta2Y+Xpkt+e14ngIVvjad+mL4HwWZwGtkRC8u7P2K7kI/GppG177bUUyPbeD3WFY7thBuuyeE1MMBisNX5Ic/XV06dVtSrNMNuFlrrkBzfry7vvKLLmkiwsaqrphLMofl1gSBCT4Uf46Jjxh0iJFQTcIRpHCqhnnXCYlNnmhBTKDNC72DjvpkrBVPY9l6IsBeaiAeWCppxGjgPhrHuo7BX0ShCJuPQOEqA8c+jQ+sgThyebOml/QLzBd6/loYGlF+nFpyKzJPmiwRKybjC4RY6CWksTL2vBGspW0Hljf+DOJyKVNltqXzR0IHWZN6UJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOI2mEj7dY3ZdTWmvoO5ypwvYQ25FsVka1xZwJURjsXJewMSLCRDdB05zO23fpElHXdTw4wB9gxNm+sGbsfveBA=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAALG/WWS4P14Jx1Ev20s80GmGu/NeHiqezVJrAfq5QBS8zTQmVmi+KhunKN7RN+GxxbfZQeZgUeGrmiAo/YVLbKmKMbSUTFD85ThPWFk85qdUuwbgSVs5xPSCd5GFQbatBAMbD9v8u1APqyNXKvdgaKogH7bn64/YkIRvAYOR9Q5s9Zt+2k6WYNQXTDJFW6Mora3xseuT4LaBdYH6/OM5T0TXthNxXuKXVs5y3ZyWiFS16ukmA99aL9jsT3UsiDmQLg93AOV2DV68kyZ0fr3H9fMfeVRJbmsxhZx9GaPJw6OFTXmsUgwyt43pQdn22B3lc4O5pmgXX5fWrtESoeZ1shRfqC4WK69GerTAnsfDrvFJyBGAGP8ZimwuxqNyO/I3jtD20xL8Uf52LaHWSvAp/FQVRV8Zz2K9eTMy5Hq2qRrrPZiBBYqkI/+VamJuyOFjGZ6174oKiFebZtMHWMK+Uifl1LHCS07L3kJ0p5aca3yGDY25MrH0nx8ko31a6UsNInpGSEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIe75JMsfwg58nEoaGyGa3dVUouXxjkhcrVBc9ca3kDkVIW+qr5u9Csf7wBTNl+ASJ7L4K+RiZRXRdPZa8f0KBA=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "84548D69B367032BF7F00FA3AEBDE21CE5434435A1D2226E984F813606FC529F",
+        "previousBlockHash": "4AB5AACCD55997BF02D6961722AB8AE59C1E7DAC3CF60DA5E00CF659D30A10BF",
         "noteCommitment": {
           "commitment": {
             "type": "Buffer",
-            "data": "base64:ID9uRUBeEi95B9+h/FSadOsP6YFxmsRUJF4MYlpo5XE="
+            "data": "base64:Id6AlgKgilj7onz49MH9HpT0vu1yWGfijKaMK7pleD8="
           },
           "size": 7
         },
         "nullifierCommitment": {
-          "commitment": "3C5C8ADAB479612CC044702DBB90427DD7BB131CE289B440BEAD1A44315771CB",
+          "commitment": "B9DD67FF7EDD7B50BA9E518AD7B88EA23A0812BB3A6D665C690D2A9E15E33198",
           "size": 2
         },
         "target": "12131835591833296355903882315508391652467087441833704656133504637",
         "randomness": "0",
-        "timestamp": 1666740852332,
+        "timestamp": 1668120375481,
         "minersFee": "-2000000010",
         "work": "0",
-        "hash": "9D47C75ED2BFB607B349C8EB04C6E6626D83D498C25B330B4E42212264C4E0E7",
+        "hash": "2EA428A947DBC95AA847DC5231804258FD5D07805D7C6651D47F84D7C1527B9D",
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
       },
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAImhAsEWuYCfm+CIICiBZ5zDUa+fGvt8vndmgpUdz3mMFz+sYJRNqG9n64Pd06Cvh4ef935bLEas63uy2Kj7fXTrHFWycOEkq6nyFhxcvGBQdy3EJgJ58qkx3PhxfWwrlglDbWvSjD9/nXOwDEZajHTZULXRYB6slQ48YM1Aszv5ET4v7QrCVWadjA9RIdr68I7U9xBMnRxdnp3FSs+TimX9RuOt5NQHMnL/Q4kaHgUvBFiFPlqNOf6etlBO4oWh0T68nbwLypK38CiOlyEkaKxYgk5NpyasEIkSgV21SXzY1CCO6HQ1j+L3vNYqV3A2FzZLqy0IqUvOfEYekGP1KiEja/t7nN3BAltWU1ONQvSAsM5QR/SLsPIPzJ2n4GK4jZZlvlHqZ1/4fDR0Ms9RmlD6gt9b79hqO7aFByXXfSfj2XypbysaFOvMOp24BiJAdgL7UDH0RhDZGNu+dCH0Km6L4GF1Jxja7kthLyffFaq8CBkRpEheQL/3dHyKw/UeHn49vkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwh8L7vyWK1le3QPH14OHeUcIR9vFzQwyLqWjmjJvl6XB1lslBkzsvGiSUW1a7eDn1dX86gxj1MG2dSAb93cjQCQ=="
+          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAISbgYrs/pTkd+oPzDxWUlwopmIb6uVGFOQJ8xnd6we+PFaAYPNbH9dNXF/FzC2g9KOgsoEvTdmF+bY/Qt8E3myrcjpd3vPKLFJtE63fLqwkwsrxZdmgtN4eZb6b9tyCuRZKG9jJrI5bspU/2bIHt4sQnRViZbxWtK5R/MhtruA/+5oui8EuNI/q59NdWHhciYjor5lDFDy/KkkFg1KIpOX8STmt0cDQ76O354tJIuCjk/mwBuWtSNcj12P3TCiCPS8ayXMjB3J4tb+JdxeLCdeG2004TJAKuXLn2q32eOmBxYOntM7lC7grqV8FYxUnmCtYdqBiNshm/DTT2R9YmW+NQDlMEXEWHbFiMa51j8CwRLU5AHA5f09Wi46OlTLZhtgMsXbks1uTfhO/OSFw7AZ68tmZQVTuhIOu0TlmHWGAt7lutlxJUxmkNh1xjw/8hgWPNcQ9QAznVez4WC/JrMzFB/1+mypYr7gVqncK0KP/PhrDTAVYzsOLT+wIPrIt7xd6PEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJ8MomltJbXlfANU0hI8dCKwEIPuFLtiQSY2o6imZwW6T4WjVtBelrmL0jYGfXIl/+RWj2XkrvMJzFP4YxLLwCw=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAIfz3QwFLe+MGJyCSWR3rCh1ZZJq6Xs/yu7knbtWvUOGyKhk5QnTnRbe7fIJCsPd1oDjMKPPiF9keaP90VMPScWDtQYfLm7c0YAzAgM8TgA55YgHp5aYdUq0/jixWsDpKAmuCXejPIoIfdRnEnSiGoEMt091XAS9GyBTiU7gZfZH0XGt2YVVhpfz9Ag4GmgNxLmrozAg56GxYHXZRnEa26z6YeFzO+fH9FWyKvlCLdMSf3EaErdEBeAWbg28YMZlW7vRUlzYEth3ULO9mVk4rMonwena2/Y6PCp9868hdye0XL79XEuII7+/bjXCSBu8ow247ekPZeMz4tDS6oXnjproqpNexuUR8MToLkVi8Xs1gFu1gu7JIO1/IJvEOGLrAwQAAADw99s9e9ryslrvHCcxjfNX3WXE2artHutw4GOb/5LgQbbzymFSRRyB/otYjw/MtEomAE/dw1VCC+tH0Uo0c+Zh3rjifv/QYeavOiBERZWzC7hVRwQnoCyExd/U8ko5mQSE+eD39+e/0QyZA/dGCLFR4epH1amgTv8pyCsIgJmnRyooFZQVpYLog74ChActIDWFgwrZ7/hxTDj0MUIBai2cT8eG63BmNUO9minBwDMiO7RxDktfW/xlmCuJoCmkLhABhDwXdv5w50I9ZuUkMXQG/20y82CQwvPe9JOlpZZ+3tHroanxIL0idks2ZPPo0HinnD8mOTH/Ifg1V/w0aExtKqFNOlHJVJcjQmBzel//9YlUQZZYxBZ1EnsUqlQFTgZdXExKZuI5fQayBhDSBGmMpoaCfkteHmIkTjWvG3j24sKZlA3PvVfBSMVE3RZnM3YjIS3Cg0oo6YuxWnhq7KAqZDPuzLoDor9YIwU7vA5zZqXmLS8Z6PTkG6u/7fjC5UnDBJbU3aJHk+T1xA9hiGL57DQXLUmYOdcDMH+3iwu8lJ/DrqoTargY8VMVhugulb5c0oBvhoi3oB0jSuT9lqYegnORImH3uzR3JPpeHnyfJP21Sw9yud3pZYHrE1mkUhEyi0J1N8Ep5tiILkKaQnLeAqGEutgfQR+Lmp/AbKsKxPnXR880/ZOsltlNfojdDnmIrlvMyHqGHBFylcNSAMXcVRomKKrG8uBy6V2Ke0SAUWs1fqu6nfPM6EA111EONtRIDQcQYTDALKc2PsXr7O6KBk9+I6g93XPdjgRLecvoU/ZDobfkqxQcHwucYF9XgmxIfBzh3Z4dnVVR3WGkkRYpiWZoH0Z7N0CPPnbdGj79bnNHfg+O8jsEC6ApakeQWOqJhFLnH2K3NYovkO5KM6lCuLKwnoWsVjtzrj8N4AWcQJHCoLMIn8jn5y787jOwQRGvkl+Ub8hfPFB3/mBXCk2eYUXk/kEapUtO/V1m14t1p6esHhBmtMDnOPmOmD6nokbfN8A9PzmsQDcMIyiiT+5LeL0OcNyR829wBzebckEJJAWXn23vZEwg9pqljwQG3vJxf29T4KygoVyrDELxQfmuH2O5ZiScnFPbP2fN1In18dqOFAiyP/L847ZqoRZupRsgNzUU/3+P+GjJAA/4gYjodBzJGJ8pBTnsuP12xfz1Cw2Aib1Ew7B+3z4fzMRQEQNqIB4O5trpQWkh9aasYyCoK0mz1AIPCo1QHUXaBUooMeqLv0vFPtlBHhDWRNQaBh9IblAGiKowh1DxRswrwUwqskWtXi77rxyNy9U8dayoc/bqRRcIV7BkxumP6Po07l9GFRt0ueLw+Z6/M9r8qKavqXMKdlswNBcm+lhjN43NvSu/ZgkvDO26bpYQ5XTJ2eJdxk1RT9ZmQrJufUj2xlkpTUCbjKbSwymaDOURew+gO3y4Mu+YCg=="
+          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAALb6hmvI+P4piBwn5E+Td3/Z6rA1WgY5HYVZRT2njF/N3WSe9ro4wZR2a0TWInYoWIVXTHQegnTAPY95mPSctoazIv/m2Bt1Mio1V9yg8wYtTo/S0L97bTrCqB+Ba0URzxH5Bb/+CBmArQujIrP8oRRlkuAeDvk1g1+9GyuRnYRwdR+bRGV2lN0aJFOTyAX3pLmttkcatlarkbn17mXn2vp+Em/U8EfIrmvpmBl4zNa01SiZutMIbpkAKn1hfG0pUO29qK1nXzi2duGaKMPqUXzx9rrwqfk7f3hEyV7oM/LHCrhPm/NK3VM8f/Hikuw8BwkqZh791sWWbBkGXJuJ4li4HrMU3dpHh496U/gOzWG7MKsu8UlMQ+Z7eQiDJ/P3MAQAAAC//A4L8ijun83QWChiHeSwBCPA5zjwu4AKQccv3bdmN3bp0W+81UgnlUN8y6yUS25JJ5NbdxLN+TrJylopgDWxgQ3u2tQW5JEjmX5/Z8IsiI64Cd0JPbm3lOrYPQyOaguHgMjaQ1TNN83UqHyZ2EmDW65IvA/GCF2MFh2lsqRjVmvvpbb3u+x4S3dQ3jY3KUWudgX3ROpAG99fqXx+SY2en+QT+v5LmdJV5iBURD5qYqJ/iMYTyXELSO46mF8DY44KtDsbBUAefeCpLJgEoSzn/ebCLbVhullC5qm/Eib7VjVDO/tAVKIdEyCqKO272jaYt/jVC+BQ6B/DsQlXTNmoG721jcosEUcqfXB0W8E7tle7mcdWSN8sh9JNTt50TrzFU0EMCdmN1SOsiwihhec8Y0eYPhpnK15XxEphg8YnnspFGAJoLh6Y33bTzFNJcYDdAiI/DpSKcC5uz2OukpZAmCGLRt3LebS0gmkW7YozGp/+Jrc34K0xJ3YhJV7nrCBAfZs++O+pbUrVqKuite2po2g7Hhx1dBCr6zWlE3rDKEWqV1RV3YapvAUhHC895zcXEwd2P2qYcR92AGYjRjYp/mS66pDb31jLgsRiRAI4htPyzhLzD/lvtFX3BWOzxFnvxSyUO3Fyc872b1rxRwB05wCel956wDAYy336KU7ZF3YGtsh6FEjVUjzttX0V43FE8Uh1Hfmmb88qn2ue2E39i/eXLta/yhHw7qHSSHQ2t9lGgK6zEE0HvdT2xLfh4qRgIc1mAJH/7jpGHXJYVu9m1xXipCQcNfSM1KF2V3yjoPgJBZTz+Bj2wTNwgnqijeClJIpXIq43q3ci6CFmfnDEwj93q2pENlPyc4rz7fCvwsZDtAZkwaVP4yJS3PnhOw+ul6gd1rxQcK+u5QW1aq9VFf580bnU7JJBO89UlT9h5Ki7aI9RSJfnuxUg+mVJ1/oJWx4Cq0ITPcGLlR+oriUFhFgjPFPzIkmrMWL57aXu0vaOh9G8yKhpdFmwvn3aeRREuiU/pCCNrNJkRWG3/v43Cag446W2ntHAsZ+XZOYF98oUKfi5IDpvdQBv6IxJ3MowySyHgHqheBkEXssvzNnQGplNuueM5+d14FFSKEd3T9ZKnozpcPSiDmXTifDQIjtH5qhyfFXhiY109obyzCZcfDsEosbUalutp2h6Y35AiNjucq06MHcYk7MfYG+KHocGjbsQ9l0RgFd6PaYsqVQtkEHbL0Ksu/OC3vvHdlv63UeNZR5Lorl3/h2S9sgwqiXCTpYWljbm878wEycUu5Q4T/teXHnAGAtcWFvNUBDFhhzjqcxbqJwSWSj7NMJU+ACijzvWvszMmbGX8RCMCH2y3Vs/Wd2Lg6anKHvaANNFr/yDfeoVcZrUK27t3tYkTjs70lpFcgaQYMdyso+pFKGTfQIpL4UM5mVBRX8kWg6KkXG/P303Bg=="
         }
       ]
     },
     {
-      "id": "b1e24afe-ae25-4421-8b1f-af22e7d37833",
+      "id": "be7940f6-dda6-4750-ac91-783b61cf013f",
       "name": "accountA",
-      "spendingKey": "b4afc5022596e1793d5464a357211068c99a6695ee99addca62f437b2af73376",
-      "incomingViewKey": "fdd80a3fbf31fc6b7e80694367bc1df62438d8997f7e0e63462cd1805f2eb000",
-      "outgoingViewKey": "50a82af03760a3353c6f593f320903e1c1a8cb7e0163d994392ba7a499aac23c",
-      "publicAddress": "979e9e1490bc7698d7e88997abaab507c6a9e5c7710b2a03814aa2ed30d056fee39b8722ef858168317086"
-    }
-  ],
-  "FeeEstimator init should initialize with the most recent block at the end of the queue": [
-    {
-      "id": "e69a66df-6237-484f-9195-5a2d1a7c3b3b",
-      "name": "test",
-      "spendingKey": "6cd8935ef74c4d0a1186217ec5e91f400ac23ee5e7032047fc6b2fcf06303c99",
-      "incomingViewKey": "60e4c84faa4e5387eb375513ca4bda884a5f0259b781c1171b0497370802b303",
-      "outgoingViewKey": "52330ff1d7a183306cb41164dc4f40fb3c3b698921e29477f1543b80ab59dfe1",
-      "publicAddress": "d4e7ae0e1beb7da48c7522f1c75a4cc6191f43b26e0ea835f289a2f993739805f24579ebcad86e1a9e8edc"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "69E263E931FA1A2A4B0437A8EFF79FFB7A353B6384A7AEAC9F90AC12AE4811EF",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:7yRI/p1o/YrvuAxDq4JLV3HdfQ11PkNhB1Edb8jf0k8="
-          },
-          "size": 4
-        },
-        "nullifierCommitment": {
-          "commitment": "E2484D0BF38F29EFFD63EF9D5A61202F198129862B12845182A4CA77AA557A4B",
-          "size": 1
-        },
-        "target": "12167378078913471945996581698193578003257923478462384564023044230",
-        "randomness": "0",
-        "timestamp": 1666809683244,
-        "minersFee": "-2000000000",
-        "work": "0",
-        "hash": "34CFA3428B3FF231DD20EA516FCC20781F20C192CCD176BF1ACE47767B42ECFE",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAABsyoj/////AAAAAKIfCCbB9qMqd5l0C0EBonIJm6oKbiVunwC9ln1MHitqS/Whu/aQmvO+2l7/imdstoPbTJ1y1d3Xk2u+SHcPUVuR8GI0GnmsFDXgbKf3QKXzmfvZOqr082aOt/gvbKdakw7/vlIV/zkSZvItradA8WAoUvA9x9sp3Hm2ONPTLr0MbFyTt9Fe1C0jpLxG3AXsIq+epFN4g5k0FFfIWN5o7A1tjtYCLzfiKktFGkZIgKJfbnvz6V+OGNtC9hSSqfTeplXIZDl0ZIZ6K27mMNAyZPa/XImVFqjuhLejBUtYT/yfI4LaTY0yQLloDHqUBLMshyN47haDd9REM7arJaNGzx687FgOOhF6/HUs/UVfxa6f2XVpVxvKnscg7XnpQKEDMBNg3xAv/Ri8W3YnaauF/irR53rFIkUNXJCGSkzGlHenMlLDwp1aLbHA7vTO06ky676dUMvz0d53twY4KzrxRD61VzUS8YGnBi5N5TRJjIYTIsoi56mqbRHTZjffY2ogSNh5HEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsCL2AZe1JgriqUh6LSSMt4fWy/HrtEI0aUOUb1LtK4TYiDBNzSfDMLfp6V3LJiNaNZAM1Nqy0RBvcnHVLfF0BA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "34CFA3428B3FF231DD20EA516FCC20781F20C192CCD176BF1ACE47767B42ECFE",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:oKj6HL4wwG5LbmfL4/XU6YiBwjPCUYaxqcbckI/3Wj8="
-          },
-          "size": 7
-        },
-        "nullifierCommitment": {
-          "commitment": "C81E8E95DD769CD26526B6B78C9124DEC139E5FA246C4C7553B6245852A0622C",
-          "size": 2
-        },
-        "target": "12131835591833296355903882315508391652467087441833704656133504637",
-        "randomness": "0",
-        "timestamp": 1666809685171,
-        "minersFee": "-2000000010",
-        "work": "0",
-        "hash": "DC0707DAF73ABDEEA04092BAA3E31D430D6257C8EB295372B23CDD05FA8BE5E2",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAPZryoj/////AAAAAKVih+gQiOdD4iDIRmItt8IgNQBHpRnR/M5+dIRFtY/zQW1c8HdAx/KCBPJasaDon5RaF6GogG3RvfrvBk6ZrHFd27f8t1avhPgEfLupzUd2Us5+h/ANQmGegngWEKDnyAoW+sK1PLnQ6hXVNcWMI1h3ODJEVv0XDpLlzKxhVv0MYm6U7J1FIKVICOlf9euHiaOhFlvzH9rSTxYIVtjnagzP7DWb0uURKEZabzmDzLgBiS88tDkBVJgLIjdZ/FoKQIzYbU+JiLNxcEg9ydAL9Qz8SxVD3NsrneqqLY0GVoixbj6QB9+/i9gNBul8WMDjvG1oWl+XOcA415Ot8sl+fw8/pakG3hYCRQ+hBYbXc+iE3drqSJvu8reIUzNkEjC/g09Rl0CeSQu7axyH6nKBwFglduHD/i4qbXFec0qYrUYRlFmJGC2ODzDva3ysaYYGe8mfE9DXME9BSNPAY9Nh6BFalxx59itGEw+jzWUz86jO/Lze/qQJEGxavGrNpt8DZ8bJFUJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8bMIKJ3Lbi6AT+I0y9W/+4vM5BCfhBudIUnzhoTL/MnsUcXLAO+W2hQNcNcBGCZPbNuvo0ocmyG6ArLVeLUNCg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAAAoAAAAAAAAAAAAAAJY+RJakduAXFlr+uVSDqzlmemeJU96ZdLua/CYZ2YTs+kpjGcKYCwJcPAzoT3ITJYccg7ROMShgTH6WlEG6gEHxiUofRg0Ku19V1qNYnvnEVYbQbzBmp3L/8AYN0DwUnRIpqEaCncg91+Uqqswif4uzIpHWh4mGxSjHOIfvAB86cEFgiIMRJOsh9LOJhg/Kn5R7vGey7QQT/E3q2BXO9K7DW6YM5RjAT02CuNEfC6KlTKC6n8zZaZ4j2sguI4hFDP/DH+3AMQhKoKWnLwMWwmPSpRfDBXo4D/pI19Uq5J4WddwyC4ie1MvLBVrdzqCvwxWf7eorcNejFUCWkDXLBozvJEj+nWj9iu+4DEOrgktXcd19DXU+Q2EHUR1vyN/STwQAAABBIcwhEU99g1EYnwov22ZYudfP0xdx5hIsnXIHHihck9+V8eJaJkiQ3Ra/7HF3BNzUySikT+aUDBwimlz57Cs/BHsiqneGHH7Ry42K++MPTMNLt2ywofuEl7nIZxIgQQmZG22+SExkTv48JullcFFZfnXOx8XfKdczSthurBUzD31cTjSUdkJR5yeFkjhwdAey6SMowpPxnIUPQcCo33a4mJ0qeKPH0HxXaKmvUMP3VSTsTv9gBEAwXVfR+3VLHz0HZYnQDemiKvE2XQkajr368CsR8n3fzMOjAil1koushAE3Q1nEWXWdxI8CE0Ih+YqI8EdvsnoN/YE6OlOFOKQVzagEfOmuqPp2KBQHKevxlGMzguoRGaxhivE9bndsSUEVmRRHWaHmotwY+2denDWx0sVz2DbLcPwIzxlsf7PIFGlV7k9oSiefNGHqfvM7ERhbMYqXDKiIRBZCaVOPfJdQOtiiuRoRgIS0hkemzOayl4xhBeaO7x9UhQpuv80ptl3tgGxb6XddEJDxLESqsJRNuSF79VpZV7N3uGpLtXHX8GxdSx6Mdm+YTI1ZG6YVM3o/66Fwup3GPQZkOR/z0IIoQXNPn/T6ndnLgEA1nkg0Tk1jYomUlX99EH/oxDjaABBvUO+LJVKIJSKpySXJ2rwjsIiNX6f+bRcZHPSA0DSD//TJ0SFpYqaprnVkRZbzEn1Pjaz49fi/YprYz6LDGyWW/rsFLvuiPXBaUdvtGJv7JyMHebL8g65XPkgf9E3d5l/NJ5aafgcCLnhJMUw4LxHdvQ5h74AM5QeyKvLb+gesfBk8RbFk9cH8hhDTk3gi8ZeisNSXJnV4bl99Dxa6N78ETSEX04KXwPAB+xQ2sJ6iQLAqew7r0/KlS163Xs5O7VqFsM5tPCrEXNgzURQ3h0HVL3bwg6nK8Cb8bMqLfHcqiQbND5Sfsl5G6pzCB2jqtV0WbbIARPDiPrIE20ng7oMMdJ0uu8tj1Irc22ixZVc+9n7NI9MvfnVvl9Taluz4Qzrl1KIJweDsLXCNl5Z1c2jk4aIXlXfmQ1EV9PbB1aUuZQKHpeH3WP6S59ZfKYbvCpoOISzicVqm1YqWwmyznalZTic/r0bdYDD3Pnlfz7tor6VzDyb2UIXZ62usN4VjASCNm3sQW8se0GxiymRMjhXSPnoJFz3n5h4rrjSx3sxeok9LuKgMRkUQV0UneM6wHP3Ff9PXQcgDWwF24iRMbIWqQZVSCEdmJ/FIEdHGrPFAWnGTLpPjoYhEJvJnUW2L678z8Q3gp3VEBppc5590HNTt+QCTs/SHNdCGST8FBuco8i2F9ifx6RnSlu50MICCmCAXGzLNWDCm4YFjpcbIcYbm4uy9DnI7fjGuDwqbX51klsmIc/Irir+SFoT2lqbIOI/3/Xxz7Up+W9BO9LrAA7nj0FJ4pakroldnnQ2+mXxMUHOMrzyCCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "DC0707DAF73ABDEEA04092BAA3E31D430D6257C8EB295372B23CDD05FA8BE5E2",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:Y15C9sdUgYJbiEH5FSS3ZWAgzvDyye8H74Xp/V5AFzQ="
-          },
-          "size": 10
-        },
-        "nullifierCommitment": {
-          "commitment": "F9BA4BA7B8A3EF43F2EEC1BB05609D49A5FFA16610AF62334A1A146D01C01072",
-          "size": 4
-        },
-        "target": "12096396928958695709100635723060514718229275323289987966729581326",
-        "randomness": "0",
-        "timestamp": 1666809688413,
-        "minersFee": "-2000000020",
-        "work": "0",
-        "hash": "3D44D9ED50874B864C59301112C98B9CEE5DFA9856F91EC54F2276E1430E1FF5",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAOxryoj/////AAAAAI6XlVSgp08hH4vi0ue82HBNV+c6YhmcbnEQmaF/QB4U2tI1iHcMv4Xi0O5sczN/J6MTQtCWjsIhiHuQUoAbCQM1Zl2uX5FflSlIiXWxUugrDLy3zBb2mXj75mjfbbnwaA6iXWi+uzNy+sQZNWjG9hZNE6+eIFXE34C/nfgQF/Rn6R7cCd6OppRcyhNPLGBxXZUHKDiBxhzrYiLQMWW35V1asI0ckG6acgXQ5vMC0xf1Z/3L9JaYfZEfn/14JZJ9zQdUyMC6WAMJTTrBGkpGCN96btNuedR33LQ7MnYbdsmegc09WG+bPSRuU4wDrWyx68h7NMI0szXJqnzzxvOhGl+5ypwNTQSyD0tcA/9dtoD5LoJA4PjRTFKDJkGGDjyHgYI0WnTMLmMUia/Q8/A86OcM2hDNPZ80JsuMvW4TaXhkRLQtwriEoo82RPA/Jukelt+5s7zzb2NycB7f42siA5KuTb41wgS5VHniiAqcgtlGSvCYQKqx8mnyFTCkshfRUuTIdkJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaGYmieEisBFL5AoG8IWVC1fnI/1AQLiPnJjyKK83WzECS9DAwKgZx6YkzUYtLmXIL9i7ODRR+ONzc0hSr2sBAQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AgAAAAAAAAACAAAAAAAAABQAAAAAAAAAAAAAAItAjlu55Xp4HAzUhBuj5NUias/hah/APZPMDMO+wesdoGVcKRwQRxpztkMDoYJpvriEP0oSRbDV6UquzHYMoff8WLc+DGjGMaLU9kg54oamL/divUiSlAdvPHJo+QfnSxQqsKcHDlpG1DbpNU48SE+xkATS7BKpWDumSVhM8v4s1MyjORb0TTjffRxh0IeckITWJi5ORj6VeiqMQTF3IFSLYXYwlPe3uan/FfJ88unUG2yvDJ4PHiDlQG+yQQ4d53MR/LywzekyJjIcSp0FmHLlueJ6/h8Rfhm5dP3GMrNiUzvLGcRg/oi9k3/WhM4ja/cA4j4Sh+te0SghBx4dVM+gqPocvjDAbktuZ8vj9dTpiIHCM8JRhrGpxtyQj/daPwcAAAABqxUAqp+VdBZi5N77ehPcsYvC29zBfE4pof8Q7vJdT5qs5/QLKiQkv85bRUPwyoVntLMVWpWBpthC3EQ1D1BRKpxAclYKbhAsvwmzNazJ5N/z1itdS12DHJZo/ptKJAitA2KsaKMKhqhxkG2bPmS+NN2FLd6JA4dahhnLsorLqIRbhIKsM8Jvin79gHhbo4aGcIeuHV5ZTLboQo4u/EzCrqrzS6k6RS/qrDWNHwVd2OM6t7DONefx9wHZ4u21Jo4Nh3uoc5fgUv8COPxBe736mwmcLjeVrQ4GDxnLLQBuNI9qGGxSdeM4NmxzcdBCjAW577qMgZn80JlA5W1sh9r/HVwEsUfyHC6sIkXazjH1jaccajL459LPIMlMK8Btr1Te66e67Yc8bFfMpXiNqEmzSVL/XJTO1NCE4CIdUmRY1v+rqvIsiJDxKjZXppjgxdeOqMB6tHYAFTe+hddMg7k5oKj6HL4wwG5LbmfL4/XU6YiBwjPCUYaxqcbckI/3Wj8HAAAA6ifMEjKBiL343SHQdp7CJpkQ0J+XPF/8y2bpLoLKPpL7VqCrR9mrFfQbe7UisXSZhqf/u+PbFuiohtnXOgA8EfBg+XrJAe40aM8C2AjChsuLAKpGdlmU16DubsZGWCYDgLfEQ9Ir9fbQOWO0VMOKUs68NVpwAJ0f53k/7TluwOKgYPdfyCN+YO39qX3AIK/0gzDdT9L79GHkrpLwqUyzusiPUyNYd01p+l5SsmwllI5ZhPNsBFbW0dMdaoDZH9BpAE20/FmN7t4XjkEzTgyIm4WKaOftVaDNvEsTgoZEiuRBfGZyacSnxmsn0XogUwT2jQue2rIeTFDS/ks/PqRsDnkFIDCHNp6ACRr6USznbYy49sb9EY4UOng9Dp0tGsFW+AUJPmr8ad+NDjZHzGhOgm6Wam2i2PHOQmcvsnM4vXCUQLL+l4C+bIBYY0ngNLUPJcCyWy+cg6yCRUTkfg3rL+NXzfl21e/9N8gQtRdvNaxrdlkb2o36lrYBt4dll/xhi3bZzLMQMF01fPW8awujDgknG6HbaaHx66bR//RiRfed03fNqXUN3/BOH5XAdZbYW4ooZBiEj80T4plVrZ6Y6jDX/hvFeiMErUO3WnNLyflGHfL1NX5L1HkUwv78rRmdnDzXpgoiAtK03MXn/NflILcFzBbfq/uDg58nVShtIBFiLHh2T4vuPXFqZVBFg5jea6UFhCEEuZzBzKEYBqsmkONxbyP3/6vocrQ5u2sSrYrBQ3ShKP5TPID5h2tCBdegOxxPINjQLtMNZQkA+YQcy0Zk8q+duEQzezhLqJNJIQGsW3+UemaOBbIjENO0osKSyjp8Kd5H0f548ZP0yK9tkrDzHF7lAzegjpMQl7LpteH4P+oUOdAsHdKNBrOMYPjXuFiJ6NpSH3jO+3MY6DpgDlngKVk+kp9WCuVBMLXvqLuec56YZMFDe5zs583F90FRQie/H7+4E6eETw6VbwUnSmd0zvZuWW2af7BBhXwYZlOWbnRGICHnFnQuAFbFRIayTUEWorAFS+GFl4jfmTxlHUv67M/5o3uHsZSLiTHVyK8XSlt2GcusIQ11xWWd5xq1k3UFP+dNgfK2ZpGI1CsovvbYInFEhmwHbjKIgaFg2PfjTuhTcPG7YBTqZzMgJjKgRx7Gd2LB8othgU1dAprcJ/saaOPPB4Pk4dqYCwIsxJlxh+C2q2w75z+W2WBobJ9UJlnwhFvP0f0Rqnn4c6kkuve51TJmHdvJtyRVvqVLzWZTmkKi/skoq/138P3mAcIEjNeWxSFvpCQ4UgONi2WcuMVEy1DvkB4fdzlcxD8ChmfeV2iNX4ejC/NrjP89WJxSbzAStsohVA8sPMa0KdKHlIuBuF20QQMR+CD6hoARIRQcml6OGVP5KY34y3RBJDHcPN9JUMRYFamlEWg+X2H6m0SZbP3l30q+Fv88s1TWI/i1F/OeeQk="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "5D261EE7F178C0342DFAD65C17436A9BC1F9B174973D6C6A9073E2A458DD3167",
-        "noteCommitment": {
-          "commitment": {
-            "type": "Buffer",
-            "data": "base64:qyxLuPaGDUCwuXMOyH9vmAGufYDAq7YF8YHF/wCuEhA="
-          },
-          "size": 11
-        },
-        "nullifierCommitment": {
-          "commitment": "82F054B31141C72D0533A911CCF718AF3B066971A420A147295E997CB8A457FB",
-          "size": 3
-        },
-        "target": "12061061787010396005823540495362954933337395011119300165635986189",
-        "randomness": "0",
-        "timestamp": 1666809493549,
-        "minersFee": "-2000000020",
-        "work": "0",
-        "hash": "5E5BE11FE64CCB958F93801AE202D0B9CC2394CFD8B78D3395565A4F1547E5B6",
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AAAAAAAAAAABAAAAAAAAAOxryoj/////AAAAAIXEmSES+gsF5i4uIz/0MjJvCQuRfYPL+IgIaLAk07sJa0ZfEWk4YtH3xkwo1zEiXoB758ZvR7hDyS9LQtQvlkot5l9SYJCAr/nTbv+nxpJ/Gf37hULvVVC1sPJAs5DC/wi6s/quiKI7uGdOlQq6jNiEBI9Eq74VtNXHkUpPaHc/MHEkCvckJMi9dOaTjDHjs7FA+Lx+3LfFK7N8jw6SygUnuWm7qXwVWPWUXjTr9JTgV4wA/IK/IlmsL8hD261bEvD1t6lKFUTuVYh+kDYXj5SlveQF1ldFe62CR2XwFZoadP9rLQ0//xRBZX8W9oADIT4xDh//uGDBK2UoeXLq/k0nQq4i2549cPJk6VjhbDqCp/gKufVOTnB8PxRDVHft1R4ktjiJUipOQowNabVs4OxQNDJfbhTd25w5dQGK8HdwJvLvjm3dFKnFJJOFsAv1V2DXfjLezSI7RCfDKZpyVFl6Yicq6XiCCm+J1VeM83ioqJ0myFu1r10fKT5Se/Em7ijfWEJlYW5zdGFsayBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwkNT6HnOqYUm+/zbdxnM3GBVRVNirbdDAXy5Zp1gzu93aPv1bECOEta1XhfH1+fYQ30XkpTG3yOvj7qlAzBAaAw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAACAAAAAAAAABQAAAAAAAAAAAAAAIG7yuVhBqLNxjNNM8N3nYbGwikLzxo0aAe4Ra9RRFrY0rQ7/miS8doe1AD0Vg1a4pPHd9eDEySS+md1pd639SUJG3ZoCXJ1bwtGPy4lyEycV32KdPcWl4cG0dkkncueDAk3tP/617K+yqHq4xx+NkZVh8pEq49FjxaNHUct5LrPXziEU8dSkXJ7+yfF5gEaQpQ93nC/QcnI09W9xLHgShaV70fNPb94uAVPDr+dnPP/nb7qNZKO/XVnFCCM2EcF7D/gc4u0TLfJ7OdcRN30E+DU6sR0fOzx7Y37gC1GYMMm5rTtDPJ75T/37VyE31ORXnyUcbca7waGjHcIcNB6WdZUOXZvsphzXn/BvrU8dMQ/rCFNA6bL0rBXaVEZBPr1aAgAAACcTgVjJViR8loFP8C3VS2uBKseLhR1a2lnLVbN/3NVrdX4nlPVivRgyijeChmZCZp+/eODzNT98bGKj/zv28uW/NiwQKZlju8CT21p8V19B5jL2xff8O+i3dKwhz1RhgyJY50gjKks5QPbGY597Hf99rO7pWyl9DSoTR6R2qSR3JVZK+QdfJezsjeNMqi/m4eMcwTJZpSgZOdqQ7j7dhHQc0u4O+CM7Jm32curBzo2Ut0Zd7PT1x48P0lY3+JScgQYZzox7GeEIQdar0rCwswah1hTrURmVKyoqmUnWO3esq1RGa8C6bHWTOtuf1/xJyusLtWFP6/POPfCLS04vHEZY+/wjRPvnKTqALh2A3vUnkLzeMHXpEv7KnI8IVw2LTLqZ9Kwxx5mq+DuRnLhT6Trp5Vji9sy5suu3AYbWtfEpbHVKkfTSXQbKb5EqnKWIMNblODMpVgOKz3wdYY7DnInEXamiRri3AQy04f3kZDWHFG63wYhnQHWE1RpGTMDOyRLnb4w3XpGdrXnY9Ns8u+pRxVDNeiqzacsgdoGoYMumB+2qICAsGMYlxi+TQ9ZKOT6+YJlGPVZv9RBOi9wtUBEQhSjmdHBOPLGfsuTuNhNKitksktYW4yccaSxS55dnBj/Pzjxv2BROOsm4RmwKncv0fqSgQMwqV5sVLE1ORQNohMCXv44aUEQSoW7AxcUHeW4chWl4wLaylGZQOISnxXjSkUuTii0spIXSUfT9a9OFDgEDLS7IkeZv9AKEQ/uS22irNyOoVMgClO5Z36p33qDhmBcMq6/nU56/ML1srAH3zRk6Iq7k+wdSVxBanPLcz7fdeSEJd76UXQyG07AAGxRdAL4UssRRg6KU9qocH7BmiOBoQ7FdEnNMtsBzGMPZapu9uaiV/5DAfhN2UJvZBa7O7mVbk5SXidq5soFCzMcwmXRiqHj61FX3w3jsvwoW+dH7ZVw4PNgFKjCAKcHT5nKAJlPTfuLstdZnmXEXQgH0GfU6hGxc9HLf2mLhSnpuO+khxLjWT10SE0aKLoa7XfxDY6XKKYyv416vuVGMi7DSniCRFZV2ZzaV6aOZVAR/eDCNiuVUPtvKADDZ3C/1tZC28S7WmTjif/F4DZg3+1G2tzkzjyC112q48h6XlqR4UCXGF9oT1h6bLKU8gDhbEKz9KjeGNkMq7xxTeN+2X1WbTVDZIXIN7C6Aux8fgm33FbZVsYevhorcmfem+qdVLX08TdGCoODLduHQAQhIF2jpHGIMDvsn1r1Ptevj8SuBNoF6vKd78EvVUwbyfbXMKGwWlvVS5IsI8hS9msvD9AMXxuPguBRK26bl0BNl8j6fiaRRcTfmDDkwtTNrzFlSKVZRWMtvr+rrtMWSnwQPA77WAxkfuIkA79KNVCVcIYiMc8ORo4tF8MFi0ZwdbDqLYiOOIfDiGVUdj5rB6lbxY4uNZcjapN6BQ=="
-        }
-      ]
+      "spendingKey": "c040c58b8289a2801cbf4202cdedbba7428298cdc9bbf5d8212bd48c838ac9be",
+      "incomingViewKey": "a9e54c687d82dc7bb66228cd49903fb3e313ab6ad40230a36a4cc5dde50af006",
+      "outgoingViewKey": "9f5ccf8e800989b576e8dd11eb25d7411a029c1bb70201fd5f59dd0589126348",
+      "publicAddress": "5e8785170aff71c724c4ae5a9c31ba0bca5348757a42365d417e7dbd0773ffba05deca075d65496e181ceb"
     }
   ]
 }

--- a/ironfish/src/memPool/feeEstimator.test.ts
+++ b/ironfish/src/memPool/feeEstimator.test.ts
@@ -135,7 +135,7 @@ describe('FeeEstimator', () => {
       expect(feeEstimator.size(PRIORITY_LEVELS[1])).toBe(0)
       expect(feeEstimator.size(PRIORITY_LEVELS[2])).toBe(0)
 
-      node.memPool.acceptTransaction(transaction)
+      expect(node.memPool.acceptTransaction(transaction)).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
@@ -182,15 +182,14 @@ describe('FeeEstimator', () => {
         maxBlockHistory: 1,
       })
 
-      const { account, block, transaction } = await useBlockWithTx(
-        node,
-        undefined,
-        undefined,
-        true,
-        { fee: 10 },
-      )
+      const account1 = await useAccountFixture(node.wallet, 'account1')
+      const account2 = await useAccountFixture(node.wallet, 'account2')
 
-      node.memPool.acceptTransaction(transaction)
+      const { block, transaction } = await useBlockWithTx(node, account1, account2, true, {
+        fee: 10,
+      })
+
+      expect(node.memPool.acceptTransaction(transaction)).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
@@ -201,15 +200,15 @@ describe('FeeEstimator', () => {
       const fee = Number(transaction.fee()) - 1
       const { block: block2, transaction: transaction2 } = await useBlockWithTx(
         node,
-        account,
-        account,
+        account2,
+        account1,
         true,
         {
           fee,
         },
       )
 
-      node.memPool.acceptTransaction(transaction2)
+      expect(node.memPool.acceptTransaction(transaction2)).toBe(true)
 
       feeEstimator.onConnectBlock(block2, node.memPool)
 
@@ -230,15 +229,14 @@ describe('FeeEstimator', () => {
         maxBlockHistory: 2,
       })
 
-      const { account, block, transaction } = await useBlockWithTx(
-        node,
-        undefined,
-        undefined,
-        true,
-        { fee: 10 },
-      )
+      const account1 = await useAccountFixture(node.wallet, 'account1')
+      const account2 = await useAccountFixture(node.wallet, 'account2')
+      const { block, transaction } = await useBlockWithTx(node, account1, account2, true, {
+        fee: 10,
+      })
 
-      node.memPool.acceptTransaction(transaction)
+      const result = node.memPool.acceptTransaction(transaction)
+      expect(result).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
@@ -249,15 +247,15 @@ describe('FeeEstimator', () => {
       const fee = Number(transaction.fee()) - 1
       const { block: block2, transaction: transaction2 } = await useBlockWithTx(
         node,
-        account,
-        account,
+        account2,
+        account1,
         true,
         {
           fee,
         },
       )
 
-      node.memPool.acceptTransaction(transaction2)
+      expect(node.memPool.acceptTransaction(transaction2)).toBe(true)
 
       feeEstimator.onConnectBlock(block2, node.memPool)
 
@@ -274,17 +272,14 @@ describe('FeeEstimator', () => {
         maxBlockHistory: 2,
       })
 
-      const { account, block, transaction } = await useBlockWithTx(
-        node,
-        undefined,
-        undefined,
-        true,
-        {
-          fee: 10,
-        },
-      )
+      const account1 = await useAccountFixture(node.wallet, 'account1')
+      const account2 = await useAccountFixture(node.wallet, 'account2')
 
-      node.memPool.acceptTransaction(transaction)
+      const { block, transaction } = await useBlockWithTx(node, account1, account2, true, {
+        fee: 10,
+      })
+
+      expect(node.memPool.acceptTransaction(transaction)).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
@@ -295,10 +290,10 @@ describe('FeeEstimator', () => {
       const { block: newBlock, transactions: newTransactions } = await useBlockWithTxs(
         node,
         3,
-        account,
+        account2,
       )
       for (const newTransaction of newTransactions) {
-        node.memPool.acceptTransaction(newTransaction)
+        expect(node.memPool.acceptTransaction(newTransaction)).toBe(true)
       }
 
       feeEstimator.onConnectBlock(newBlock, node.memPool)
@@ -323,7 +318,7 @@ describe('FeeEstimator', () => {
 
       const { block, transaction } = await useBlockWithTx(node, undefined, undefined, true)
 
-      node.memPool.acceptTransaction(transaction)
+      expect(node.memPool.acceptTransaction(transaction)).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
@@ -346,30 +341,29 @@ describe('FeeEstimator', () => {
         maxBlockHistory: 2,
       })
 
-      const { account, block, transaction } = await useBlockWithTx(
-        node,
-        undefined,
-        undefined,
-        true,
-        { fee: 10 },
-      )
+      const account1 = await useAccountFixture(node.wallet, 'account1')
+      const account2 = await useAccountFixture(node.wallet, 'account2')
 
-      node.memPool.acceptTransaction(transaction)
+      const { block, transaction } = await useBlockWithTx(node, account1, account2, true, {
+        fee: 10,
+      })
+
+      expect(node.memPool.acceptTransaction(transaction)).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
       const fee = Number(transaction.fee()) - 1
       const { block: block2, transaction: transaction2 } = await useBlockWithTx(
         node,
-        account,
-        account,
+        account2,
+        account1,
         true,
         {
           fee,
         },
       )
 
-      node.memPool.acceptTransaction(transaction2)
+      expect(node.memPool.acceptTransaction(transaction2)).toBe(true)
 
       feeEstimator.onConnectBlock(block2, node.memPool)
 
@@ -411,7 +405,7 @@ describe('FeeEstimator', () => {
         },
       ])
 
-      expect(fee).toBe(BigInt(6))
+      expect(fee).toBe(BigInt(9))
     })
   })
 })


### PR DESCRIPTION
## Summary

Some of the fee estimator tests were failing when regenerating the fixtures. Several of them were due to one of the transactions not being accepted into the mempool due to duplicate spends -- I addressed this by creating two separate accounts to receive/spend tokens.

Another one was due to the estimated fee changing -- I'll follow up on this to double-check the value makes sense.

## Testing Plan

Tests should pass.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
