### PR TITLE
Handle negative balances in depositAll

### DIFF
--- a/ironfish-cli/src/commands/deposit-all.ts
+++ b/ironfish-cli/src/commands/deposit-all.ts
@@ -202,6 +202,11 @@ export default class DepositAll extends IronfishCommand {
       unconfirmedBalance = CurrencyUtils.decode(balanceResp.content.unconfirmed)
       pendingBalance = CurrencyUtils.decode(balanceResp.content.pending)
 
+      if (confirmedBalance < 0 || unconfirmedBalance < 0 || pendingBalance < 0) {
+        await PromiseUtils.sleep(30000)
+        continue
+      }
+
       if (flags.fee === undefined || fee == null) {
         try {
           const response = await this.client.estimateFee({


### PR DESCRIPTION
## Summary
There is a bug where the wallet potentially returns a negative balance. Until we fix this issue we don't want the depositAll command to be failed by it.

## Testing Plan
Local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
