### PR TITLE
adds accounts:repair command

### DIFF
--- a/ironfish-cli/src/commands/accounts/repair.ts
+++ b/ironfish-cli/src/commands/accounts/repair.ts
@@ -181,6 +181,9 @@ export default class Repair extends IronfishCommand {
     })
 
     this.log(
+      `\tRepaired ${missingNotes} nullifiers that map to notes that are not in the wallet`,
+    )
+    this.log(
       `\tRepaired ${nullifierNoteHashMismatches} nullifiers that map to notes that are not on chain`,
     )
   }

--- a/ironfish-cli/src/commands/accounts/repair.ts
+++ b/ironfish-cli/src/commands/accounts/repair.ts
@@ -7,6 +7,7 @@ import {
   Blockchain,
   CurrencyUtils,
   NodeUtils,
+  Transaction,
   Wallet,
   WalletDB,
 } from '@ironfish/sdk'
@@ -114,7 +115,13 @@ export default class Repair extends IronfishCommand {
             },
             tx,
           )
-        } else if (!spent) {
+        } else if (
+          !spent &&
+          !chain.verifier.isExpiredSequence(
+            transactionValue.transaction.expirationSequence(),
+            chain.head.sequence,
+          )
+        ) {
           unconfirmedBalance += decryptedNoteValue.note.value()
         }
       }

--- a/ironfish-cli/src/commands/accounts/repair.ts
+++ b/ironfish-cli/src/commands/accounts/repair.ts
@@ -1,0 +1,229 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  Account,
+  Assert,
+  Blockchain,
+  BufferUtils,
+  CurrencyUtils,
+  NodeUtils,
+  Wallet,
+  WalletDB,
+} from '@ironfish/sdk'
+import { IronfishCommand } from '../../command'
+import { LocalFlags } from '../../flags'
+
+export default class Repair extends IronfishCommand {
+  static hidden = false
+
+  static description = `Repairs wallet database stores`
+
+  static flags = {
+    ...LocalFlags,
+  }
+
+  static args = [
+    {
+      name: 'account',
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
+      required: false,
+      description: 'Name of the account to repair the database for',
+    },
+  ]
+
+  async start(): Promise<void> {
+    const { args } = await this.parse(Repair)
+
+    const node = await this.sdk.node()
+    await NodeUtils.waitForOpen(node)
+
+    const account = this.loadAccount(node.wallet, args.account)
+
+    this.log(`Repairing wallet for account ${account.name}`)
+
+    this.log('Repairing decryptedNotes and balance')
+    await this.repairDecryptedNotes(account, node.wallet.walletDb, node.chain)
+
+    this.log('Repairing nullifierToNote')
+    await this.repairNullifierToNoteHash(account, node.wallet.walletDb)
+
+    this.log('Repairing sequenceToNoteHash')
+    await this.repairSequenceToNoteHash(account, node.wallet.walletDb)
+  }
+
+  private loadAccount(wallet: Wallet, accountName: string | undefined): Account {
+    if (accountName) {
+      const account = wallet.getAccountByName(accountName)
+      if (account) {
+        return account
+      }
+      throw new Error(`No account with name ${accountName}`)
+    }
+
+    const defaultAccount = wallet.getDefaultAccount()
+    if (defaultAccount) {
+      return defaultAccount
+    }
+
+    throw new Error('Could not find an account to repair.')
+  }
+
+  private async repairDecryptedNotes(
+    account: Account,
+    walletDb: WalletDB,
+    chain: Blockchain,
+  ): Promise<void> {
+    let unconfirmedBalance = 0n
+
+    let noteUnspentMismatches = 0
+    let nullifierNoteHashMismatches = 0
+
+    await walletDb.db.transaction(async (tx) => {
+      for await (const decryptedNoteValue of account.getNotes()) {
+        const transactionValue = await account.getTransaction(
+          decryptedNoteValue.transactionHash,
+          tx,
+        )
+
+        Assert.isNotUndefined(
+          transactionValue,
+          'Account has a note but is missing the transaction that it received the note from. Account must be rescanned',
+        )
+
+        await walletDb.setNoteHashSequence(
+          account,
+          decryptedNoteValue.hash,
+          transactionValue.sequence,
+          tx,
+        )
+
+        if (!decryptedNoteValue.nullifier) {
+          if (transactionValue.sequence) {
+            throw new Error(
+              'Transaction marked as on chain, but note missing nullifier. Account must be rescanned.',
+            )
+          }
+
+          continue
+        }
+
+        const spent = await chain.nullifiers.contains(decryptedNoteValue.nullifier)
+
+        if (spent && !decryptedNoteValue.spent) {
+          noteUnspentMismatches++
+
+          await walletDb.saveDecryptedNote(
+            account,
+            decryptedNoteValue.hash,
+            {
+              ...decryptedNoteValue,
+              spent,
+            },
+            tx,
+          )
+        } else if (!spent) {
+          unconfirmedBalance += decryptedNoteValue.note.value()
+        }
+
+        const nullifierNoteHash = await account.getNoteHash(decryptedNoteValue.nullifier)
+
+        if (!nullifierNoteHash || !nullifierNoteHash.equals(decryptedNoteValue.hash)) {
+          nullifierNoteHashMismatches++
+
+          await walletDb.saveNullifierNoteHash(
+            account,
+            decryptedNoteValue.nullifier,
+            decryptedNoteValue.hash,
+            tx,
+          )
+        }
+      }
+
+      this.log(
+        `\tSaving new unconfirmed balance: ${CurrencyUtils.renderIron(
+          unconfirmedBalance,
+          true,
+        )}`,
+      )
+      await walletDb.saveUnconfirmedBalance(account, unconfirmedBalance, tx)
+    })
+
+    this.log(
+      `\tRepaired ${noteUnspentMismatches} decrypted notes incorrectly marked as unspent`,
+    )
+    this.log(
+      `\tRepaired ${nullifierNoteHashMismatches} nullifiers mapped to an incorrect note hash`,
+    )
+  }
+
+  private async repairNullifierToNoteHash(account: Account, walletDb: WalletDB): Promise<void> {
+    let missingNotes = 0
+    let nullifierNoteHashMismatches = 0
+
+    await walletDb.db.transaction(async (tx) => {
+      for await (const [[, nullifier], noteHash] of walletDb.nullifierToNoteHash.getAllIter(
+        tx,
+        account.prefixRange,
+      )) {
+        const decryptedNoteValue = await account.getDecryptedNote(noteHash, tx)
+
+        if (!decryptedNoteValue) {
+          missingNotes++
+
+          await walletDb.deleteNullifier(account, nullifier, tx)
+        } else if (!BufferUtils.equalsNullable(nullifier, decryptedNoteValue.nullifier)) {
+          nullifierNoteHashMismatches++
+
+          await walletDb.deleteNullifier(account, nullifier, tx)
+        }
+      }
+    })
+
+    this.log(
+      `\tRepaired ${nullifierNoteHashMismatches} nullifiers that map to notes that are not on chain`,
+    )
+  }
+
+  private async repairSequenceToNoteHash(account: Account, walletDb: WalletDB): Promise<void> {
+    let sequenceMismatches = 0
+    let missingNotes = 0
+
+    await walletDb.db.transaction(async (tx) => {
+      for await (const [, [sequence, noteHash]] of walletDb.sequenceToNoteHash.getAllKeysIter(
+        tx,
+        account.prefixRange,
+      )) {
+        const decryptedNoteValue = await account.getDecryptedNote(noteHash)
+
+        if (!decryptedNoteValue) {
+          missingNotes++
+
+          await walletDb.sequenceToNoteHash.del([account.prefix, [sequence, noteHash]], tx)
+        } else {
+          const transactionValue = await account.getTransaction(
+            decryptedNoteValue.transactionHash,
+          )
+
+          Assert.isNotUndefined(
+            transactionValue,
+            'Account has a note but is missing the transaction that it received the note from. Account must be rescanned.',
+          )
+
+          if (transactionValue.sequence !== sequence) {
+            sequenceMismatches++
+
+            await walletDb.sequenceToNoteHash.del([account.prefix, [sequence, noteHash]], tx)
+
+            await walletDb.setNoteHashSequence(account, noteHash, transactionValue.sequence, tx)
+          }
+        }
+      }
+    })
+
+    this.log(`\tRepaired ${missingNotes} sequenceToNoteHash mappings with missing notes`)
+    this.log(
+      `\tRepaired ${sequenceMismatches} sequenceToNoteHash mappings with incorrect sequences`,
+    )
+  }
+}

--- a/ironfish-cli/src/commands/accounts/repair.ts
+++ b/ironfish-cli/src/commands/accounts/repair.ts
@@ -7,7 +7,6 @@ import {
   Blockchain,
   CurrencyUtils,
   NodeUtils,
-  Transaction,
   Wallet,
   WalletDB,
 } from '@ironfish/sdk'


### PR DESCRIPTION
## Summary

adds a cli command intended to fix balance and note indexing issues in the wallet without the need for a full rescan/reset of the wallet.

repairs the balance by recomputing it from 0 and adding all unspent notes. uses the chain to determine if each note has been spent and changes to spent if the note is marked as unspent

repairs sequenceToNoteHashes by ensuring that all notes that are on chain have the sequence of the transaction that created the note. any sequence to note hash mapping that does not have a note is removed.

repairs nonChainNoteHashes by removing any note hashes for notes that are on chain.

repairs nullifierToNoteHash by removing any nullifier that maps to a note that is not in the wallet or maps to a note that is not on the chain.

https://coda.io/d/Engineering-Specs_dMnayiE39lL/accounts-repair_suPC4#_lueQX

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
