### PR TITLE
remove magic number for padding and formatted into a table

### DIFF
--- a/ironfish-cli/src/commands/workers/status.ts
+++ b/ironfish-cli/src/commands/workers/status.ts
@@ -4,6 +4,7 @@
 import { GetWorkersStatusResponse, PromiseUtils } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import blessed from 'blessed'
+import { table } from 'table'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -63,15 +64,11 @@ function renderStatus(content: GetWorkersStatusResponse): string {
     workersStatus += ` - ${content.queued} -> ${content.executing} / ${content.capacity} - ${content.change} jobs Δ, ${content.speed} jobs/s`
   }
 
-  let status = `\n${'JOB'.padEnd(20, ' ')} | QUEUE | EXECUTE | ERROR | DONE \n`
+  const status = []
+  status.push(['JOB', 'QUEUE', 'EXECUTE', 'ERROR', 'DONE'])
   for (const job of content.jobs) {
-    status += `${job.name.padEnd(20, ' ')} | ${String(job.queue).padStart(5, ' ')} | ${String(
-      job.execute,
-    ).padStart(7, ' ')} | ${String(job.error).padStart(5, ' ')} | ${String(job.complete).padEnd(
-      6,
-      ' ',
-    )}\n`
+    status.push([job.name, job.queue, job.execute, job.error, job.complete])
   }
 
-  return `Workers: ${workersStatus}\n${status}`
+  return `Workers: ${workersStatus}\n${table(status)}`
 }


### PR DESCRIPTION
## Summary

Removes magic numbers added to pad the string, instead format the output into table which is much more readable code wise and display wise too

## Output before
<img width="650" alt="Screenshot 2022-11-12 at 11 51 14 AM" src="https://user-images.githubusercontent.com/40714633/201460568-b5794798-2379-48e5-8aca-a182ce11c43b.png">


## Output now
<img width="620" alt="Screenshot 2022-11-12 at 11 49 51 AM" src="https://user-images.githubusercontent.com/40714633/201460505-e7d350d5-a29f-4263-a1a0-5a2e1b5b251e.png">


## Testing Plan

Tested on local

## Breaking Change

No
