### PR TITLE
improve output display

### DIFF
--- a/ironfish-cli/src/commands/rpc/status.ts
+++ b/ironfish-cli/src/commands/rpc/status.ts
@@ -66,11 +66,9 @@ function renderStatus(content: GetRpcStatusResponse): string {
   for (const adapter of content.adapters) {
     const result = []
     result.push(['Clients', `${adapter.clients}`])
-    result.push(['Clients', `${adapter.clients}`])
     result.push(['Requests Pending', `${adapter.pending.length}`])
     result.push(['Routes Pending', `${adapter.pending.join(', ')}`])
-    result.push(['Inbound Traffic', `${adapter.clients}`])
-    result.push(['Outbound Traffic', `${FileUtils.formatMemorySize(adapter.inbound)}`])
+    result.push(['Inbound Traffic', `${FileUtils.formatMemorySize(adapter.inbound)}`])
     result.push(['Outbound Traffic', `${FileUtils.formatMemorySize(adapter.outbound)}`])
     result.push(['Outbound Total', `${FileUtils.formatMemorySize(adapter.writtenBytes)}`])
     result.push(['Inbound Total', `${FileUtils.formatMemorySize(adapter.readBytes)}`])

--- a/ironfish-cli/src/commands/rpc/status.ts
+++ b/ironfish-cli/src/commands/rpc/status.ts
@@ -4,6 +4,8 @@
 import { FileUtils, GetRpcStatusResponse, PromiseUtils } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import blessed from 'blessed'
+import { table } from 'table'
+import { TableUserConfig } from 'table'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -58,21 +60,36 @@ export default class Status extends IronfishCommand {
 }
 
 function renderStatus(content: GetRpcStatusResponse): string {
-  let result = `STARTED: ${String(content.started)}`
+  const resultStatus = `STARTED: ${String(content.started)}`
 
+  const output = []
   for (const adapter of content.adapters) {
-    result += `\n\n[${adapter.name}]\n`
-    result += `Clients:          ${adapter.clients}\n`
-    result += `Requests Pending: ${adapter.pending.length}\n`
-    result += `Routes Pending:   ${adapter.pending.join(', ')}\n`
-    result += `Inbound Traffic:  ${FileUtils.formatMemorySize(adapter.inbound)}/s\n`
-    result += `Outbound Traffic: ${FileUtils.formatMemorySize(adapter.outbound)}/s\n`
-    result += `Outbound Total:   ${FileUtils.formatMemorySize(adapter.writtenBytes)}\n`
-    result += `Inbound Total:    ${FileUtils.formatMemorySize(adapter.readBytes)}\n`
-    result += `RW Backlog:       ${FileUtils.formatMemorySize(
-      adapter.readableBytes,
-    )} / ${FileUtils.formatMemorySize(adapter.writableBytes)}`
+    const result = []
+    result.push(['Clients', `${adapter.clients}`])
+    result.push(['Clients', `${adapter.clients}`])
+    result.push(['Requests Pending', `${adapter.pending.length}`])
+    result.push(['Routes Pending', `${adapter.pending.join(', ')}`])
+    result.push(['Inbound Traffic', `${adapter.clients}`])
+    result.push(['Outbound Traffic', `${FileUtils.formatMemorySize(adapter.inbound)}`])
+    result.push(['Outbound Traffic', `${FileUtils.formatMemorySize(adapter.outbound)}`])
+    result.push(['Outbound Total', `${FileUtils.formatMemorySize(adapter.writtenBytes)}`])
+    result.push(['Inbound Total', `${FileUtils.formatMemorySize(adapter.readBytes)}`])
+    result.push([
+      'RW Backlog',
+      `${FileUtils.formatMemorySize(adapter.readableBytes)} / ${FileUtils.formatMemorySize(
+        adapter.writableBytes,
+      )}`,
+    ])
+
+    const config: TableUserConfig = {
+      header: {
+        alignment: 'center',
+        content: `${adapter.name}`,
+      },
+    }
+
+    output.push(table(result, config))
   }
 
-  return result
+  return `${resultStatus}\n${output.join('\n')}`
 }


### PR DESCRIPTION
## Summary
Improves the output display of rpc:status
## Testing Plan
Tested on local

## Output before
<img width="420" alt="Screenshot 2022-11-12 at 12 58 59 PM" src="https://user-images.githubusercontent.com/40714633/201462841-0f519f34-6570-4f25-9c20-8dbb850099c2.png">



## Output now
<img width="496" alt="Screenshot 2022-11-12 at 1 10 56 PM" src="https://user-images.githubusercontent.com/40714633/201463256-2506c31a-a940-415c-a4b5-0f677f6a1d2e.png">


If there are multiple adapters it will output multiple such tables

## Breaking Change
No
