### PR TITLE
print table for miners:pools:status

### DIFF
--- a/ironfish-cli/src/commands/miners/pools/status.ts
+++ b/ironfish-cli/src/commands/miners/pools/status.ts
@@ -108,7 +108,7 @@ export class PoolStatus extends IronfishCommand {
         alignment: 'center',
         content: `Status of mining pool: ${status.name}`,
       },
-      columns: [{ alignment: 'left', width: 100 }],
+      columns: [{ alignment: 'left', width: 110 }],
     }
 
     result.push(['Miners', `${status.clients}`])
@@ -124,7 +124,7 @@ export class PoolStatus extends IronfishCommand {
           alignment: 'center',
           content: `Mining status for address: ${status.addressStatus.publicAddress}`,
         },
-        columns: [{ alignment: 'left', width: 100 }],
+        columns: [{ alignment: 'left', width: 110 }],
       }
 
       result = []

--- a/ironfish-cli/src/commands/miners/pools/status.ts
+++ b/ironfish-cli/src/commands/miners/pools/status.ts
@@ -108,6 +108,7 @@ export class PoolStatus extends IronfishCommand {
         alignment: 'center',
         content: `Status of mining pool: ${status.name}`,
       },
+      columns: [{ alignment: 'left', width: 100 }],
     }
 
     result.push(['Miners', `${status.clients}`])
@@ -123,6 +124,7 @@ export class PoolStatus extends IronfishCommand {
           alignment: 'center',
           content: `Mining status for address: ${status.addressStatus.publicAddress}`,
         },
+        columns: [{ alignment: 'left', width: 100 }],
       }
 
       result = []

--- a/ironfish-cli/src/commands/miners/pools/status.ts
+++ b/ironfish-cli/src/commands/miners/pools/status.ts
@@ -13,6 +13,8 @@ import {
 } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import blessed from 'blessed'
+import { table } from 'table'
+import { TableUserConfig } from 'table'
 import dns from 'dns'
 import { IronfishCommand } from '../../../command'
 
@@ -99,23 +101,26 @@ export class PoolStatus extends IronfishCommand {
   }
 
   renderStatus(status: MiningStatusMessage): string {
-    let result = ''
-    result += `Status of mining pool '${status.name}':\n`
-    result += `Miners:                ${status.miners}\n`
-    result += `Hashrate:              ${FileUtils.formatHashRate(status.hashRate)}\n`
-    result += `Shares pending payout: ${status.sharesPending}\n`
-    result += `Clients:               ${status.clients}\n`
-    result += `Bans:                  ${status.bans}\n`
+    const output = []
+    let result = []
+    result.push(['Status of mining pool', `${status.name}`])
+    result.push(['Miners', `${status.clients}`])
+    result.push(['Hashrate', `${FileUtils.formatHashRate(status.hashRate)}`])
+    result.push(['Shares pending payout', `${status.sharesPending}`])
+    result.push(['Clients', `${status.clients}`])
+    result.push(['Bans', `${status.bans}`])
+    output.push(table(result))
 
     if (status.addressStatus) {
-      result += `\nMining status for address '${status.addressStatus.publicAddress}':\n`
-      result += `Number of miners:      ${status.addressStatus.miners}\n`
-      result += `Connected miners:      ${status.addressStatus.connectedMiners.join(', ')}\n`
-      result += `Hashrate:              ${FileUtils.formatHashRate(
-        status.addressStatus.hashRate,
-      )}\n`
-      result += `Shares pending payout: ${status.addressStatus.sharesPending}`
+      result = []
+      result.push(['Mining status for address', `${status.addressStatus.publicAddress}`])
+      result.push(['Number of miners', `${status.addressStatus.miners}`])
+      result.push(['Connected miners', `${status.addressStatus.connectedMiners.join(', ')}`])
+      result.push(['Hashrate', `${FileUtils.formatHashRate(status.addressStatus.hashRate)}`])
+      result.push(['Shares pending payout', `${status.addressStatus.sharesPending}`])
+      output.push(table(result))
     }
-    return result
+
+    return output.join('\n')
   }
 }

--- a/ironfish-cli/src/commands/miners/pools/status.ts
+++ b/ironfish-cli/src/commands/miners/pools/status.ts
@@ -15,6 +15,7 @@ import { Flags } from '@oclif/core'
 import blessed from 'blessed'
 import dns from 'dns'
 import { table } from 'table'
+import { TableUserConfig } from 'table'
 import { IronfishCommand } from '../../../command'
 
 export class PoolStatus extends IronfishCommand {
@@ -102,22 +103,36 @@ export class PoolStatus extends IronfishCommand {
   renderStatus(status: MiningStatusMessage): string {
     const output = []
     let result = []
+    const config: TableUserConfig = {
+      header: {
+        alignment: 'center',
+        content: `Status of mining pool: ${status.name}`,
+      },
+    }
+
     result.push(['Status of mining pool', `${status.name}`])
     result.push(['Miners', `${status.clients}`])
     result.push(['Hashrate', `${FileUtils.formatHashRate(status.hashRate)}`])
     result.push(['Shares pending payout', `${status.sharesPending}`])
     result.push(['Clients', `${status.clients}`])
     result.push(['Bans', `${status.bans}`])
-    output.push(table(result))
+    output.push(table(result, config))
 
     if (status.addressStatus) {
+      const config: TableUserConfig = {
+        header: {
+          alignment: 'center',
+          content: `Mining status for address: ${status.addressStatus.publicAddress}`,
+        },
+      }
+
       result = []
       result.push(['Mining status for address', `${status.addressStatus.publicAddress}`])
       result.push(['Number of miners', `${status.addressStatus.miners}`])
       result.push(['Connected miners', `${status.addressStatus.connectedMiners.join(', ')}`])
       result.push(['Hashrate', `${FileUtils.formatHashRate(status.addressStatus.hashRate)}`])
       result.push(['Shares pending payout', `${status.addressStatus.sharesPending}`])
-      output.push(table(result))
+      output.push(table(result, config))
     }
 
     return output.join('\n')

--- a/ironfish-cli/src/commands/miners/pools/status.ts
+++ b/ironfish-cli/src/commands/miners/pools/status.ts
@@ -110,7 +110,6 @@ export class PoolStatus extends IronfishCommand {
       },
     }
 
-    result.push(['Status of mining pool', `${status.name}`])
     result.push(['Miners', `${status.clients}`])
     result.push(['Hashrate', `${FileUtils.formatHashRate(status.hashRate)}`])
     result.push(['Shares pending payout', `${status.sharesPending}`])
@@ -127,7 +126,6 @@ export class PoolStatus extends IronfishCommand {
       }
 
       result = []
-      result.push(['Mining status for address', `${status.addressStatus.publicAddress}`])
       result.push(['Number of miners', `${status.addressStatus.miners}`])
       result.push(['Connected miners', `${status.addressStatus.connectedMiners.join(', ')}`])
       result.push(['Hashrate', `${FileUtils.formatHashRate(status.addressStatus.hashRate)}`])

--- a/ironfish-cli/src/commands/miners/pools/status.ts
+++ b/ironfish-cli/src/commands/miners/pools/status.ts
@@ -13,9 +13,8 @@ import {
 } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import blessed from 'blessed'
-import { table } from 'table'
-import { TableUserConfig } from 'table'
 import dns from 'dns'
+import { table } from 'table'
 import { IronfishCommand } from '../../../command'
 
 export class PoolStatus extends IronfishCommand {


### PR DESCRIPTION
## Summary
Enhance printing output for yarn start miners:pools:status

## Output before
<img width="1501" alt="Screenshot 2022-11-12 at 1 34 32 PM" src="https://user-images.githubusercontent.com/40714633/201464910-9059aa15-a4dc-4a2c-879a-c3f40a502dcc.png">


## Output now
<img width="1399" alt="Screenshot 2022-11-12 at 2 01 17 PM" src="https://user-images.githubusercontent.com/40714633/201465750-6edc88a1-b1dd-4c99-8d48-224493f00f72.png">



## Testing Plan
Tested on local

## Breaking Change

No

## PS:
It took me a long time to setup the local environment and get everything running in local to test the changes, please accept atleast one of my PRs as a big one.