### PR TITLE
Batch merkle tree adds when constructing a new block

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -933,14 +933,19 @@ export class Blockchain {
         target = Target.calculateTarget(timestamp, heaviestHead.timestamp, heaviestHead.target)
       }
 
+      const blockNotes = []
+      const blockNullifiers = []
       for (const transaction of transactions) {
         for (const note of transaction.notes()) {
-          await this.notes.add(note, tx)
+          blockNotes.push(note)
         }
         for (const spend of transaction.spends()) {
-          await this.nullifiers.add(spend.nullifier, tx)
+          blockNullifiers.push(spend.nullifier)
         }
       }
+
+      await this.notes.addBatch(blockNotes, tx)
+      await this.nullifiers.addBatch(blockNullifiers, tx)
 
       const noteCommitment = {
         commitment: await this.notes.rootHash(tx),


### PR DESCRIPTION
## Summary

Adding the notes and nullifiers to the merkle tree as a batch will speed up block construction a bit, especially with the larger block size.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
