### PR TITLE
changes chain:rewind to remove blocks

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1069,12 +1069,12 @@ export class Blockchain {
 
   async removeBlock(hash: Buffer): Promise<void> {
     await this.db.transaction(async (tx) => {
-      this.logger.info(`Deleting block ${hash.toString('hex')}`)
+      this.logger.debug(`Deleting block ${hash.toString('hex')}`)
 
       const exists = await this.hasBlock(hash, tx)
 
       if (!exists) {
-        this.logger.warn(`No block exists at ${hash.toString('hex')}`)
+        this.logger.debug(`No block exists at ${hash.toString('hex')}`)
         return
       }
 


### PR DESCRIPTION
## Summary

rewind needs to remove blocks from the database: otherwise, when the node starts syncing again it rejects the blocks it receives from its peers as database duplicates.

removes all blocks at each sequence (including those on forks) one sequence at a time.

## Testing Plan

- rewound chain
- started node, and confirmed that it started adding blocks again

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
