### PR TITLE
checks for corrupt block in chain before starting

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -2,7 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BoxKeyPair } from '@ironfish/rust-nodejs'
-import { Assert, IronfishNode, NodeUtils, PrivateIdentity, PromiseUtils } from '@ironfish/sdk'
+import {
+  Assert,
+  Blockchain,
+  IronfishNode,
+  NodeUtils,
+  PrivateIdentity,
+  PromiseUtils,
+} from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import inspector from 'node:inspector'
 import { v4 as uuid } from 'uuid'
@@ -199,6 +206,8 @@ export default class Start extends IronfishCommand {
       return startDoneResolve()
     }
 
+    await this.checkCorruptBlock(node.chain)
+
     const headBlock = await node.chain.getBlock(node.chain.head)
     Assert.isNotNull(headBlock)
     const trees = await node.chain.verifier.verifyConnectedBlock(headBlock)
@@ -286,6 +295,22 @@ export default class Start extends IronfishCommand {
       networkIdentity.length > 31
     ) {
       return BoxKeyPair.fromHex(networkIdentity)
+    }
+  }
+
+  async checkCorruptBlock(chain: Blockchain): Promise<void> {
+    const corruptBlockHash = Buffer.from(
+      '00000000000006ce61057e714ede8471d15cc9d19f0ff58eee179cadf3ba1f31',
+      'hex',
+    )
+
+    const hash270446 = await chain.getHashAtSequence(270446)
+
+    if (hash270446?.equals(corruptBlockHash)) {
+      this.log(
+        'Your chain contains a corrupt block at sequence 270446 that contains a double spend. You must run `chain:repair` before starting your node.',
+      )
+      this.exit(1)
     }
   }
 }


### PR DESCRIPTION
## Summary

adds a check to the node `start` command that determines whether the chain contains the corrupt double spend block at sequence 270446. if the chain has this block the node will fail to start and the user will be prompted to run `chain:repair`.

## Testing Plan

1. Ran start with a node that does not have the corrupt block, confirmed that it starts
2. Ran start with a node that does have the corrupt block, confirmed that it exits immediately

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
