### PR TITLE
Replace Payment Address with Subgroup Point in Output and Spend

### DIFF
--- a/ironfish-zkp/src/circuits/output.rs
+++ b/ironfish-zkp/src/circuits/output.rs
@@ -3,8 +3,8 @@ use group::Curve;
 
 use bellman::{Circuit, ConstraintSystem, SynthesisError};
 
-use jubjub::{SubgroupPoint, ExtendedPoint};
-use zcash_primitives::sapling::{PaymentAddress, ValueCommitment};
+use jubjub::{ExtendedPoint, SubgroupPoint};
+use zcash_primitives::sapling::ValueCommitment;
 
 use zcash_proofs::{
     circuit::{
@@ -69,8 +69,8 @@ impl Circuit<bls12_381::Scalar> for Output {
             // curve.
             let g_d = ecc::EdwardsPoint::witness(
                 cs.namespace(|| "witness g_d"),
-        Some(ExtendedPoint::from(PUBLIC_KEY_GENERATOR))
-    )?;
+                Some(ExtendedPoint::from(PUBLIC_KEY_GENERATOR)),
+            )?;
 
             // g_d is ensured to be large order. The relationship
             // between g_d and pk_d ultimately binds ivk to the
@@ -174,7 +174,7 @@ mod test {
     use group::{Curve, Group};
     use rand::{RngCore, SeedableRng};
     use rand_xorshift::XorShiftRng;
-    use zcash_primitives::sapling::{ValueCommitment, Note};
+    use zcash_primitives::sapling::{Note, ValueCommitment};
     use zcash_primitives::sapling::{ProofGenerationKey, Rseed};
 
     use crate::circuits::output::Output;
@@ -201,7 +201,7 @@ mod test {
 
             let viewing_key = proof_generation_key.to_viewing_key();
 
-            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0  ;
+            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0;
 
             let commitment_randomness = jubjub::Fr::random(&mut rng);
             let esk = jubjub::Fr::random(&mut rng);
@@ -230,16 +230,15 @@ mod test {
                     rseed: Rseed::BeforeZip212(commitment_randomness),
                     g_d: PUBLIC_KEY_GENERATOR,
                     pk_d: payment_address,
-                }).expect("should be valid")
+                })
+                .expect("should be valid")
                 .cmu();
 
                 let expected_value_commitment =
                     jubjub::ExtendedPoint::from(value_commitment.commitment()).to_affine();
 
-                let expected_epk = jubjub::ExtendedPoint::from(
-                    PUBLIC_KEY_GENERATOR * esk,
-                )
-                .to_affine();
+                let expected_epk =
+                    jubjub::ExtendedPoint::from(PUBLIC_KEY_GENERATOR * esk).to_affine();
 
                 assert_eq!(cs.num_inputs(), 6);
                 assert_eq!(cs.get_input(0, "ONE"), bls12_381::Scalar::one());

--- a/ironfish-zkp/src/circuits/output.rs
+++ b/ironfish-zkp/src/circuits/output.rs
@@ -14,23 +14,10 @@ use zcash_proofs::{
     constants::NOTE_COMMITMENT_RANDOMNESS_GENERATOR,
 };
 
+use crate::constants::PUBLIC_KEY_GENERATOR;
+
 use super::util::expose_value_commitment;
 use bellman::gadgets::boolean;
-
-pub const PUBLIC_KEY_GENERATOR: SubgroupPoint = SubgroupPoint::from_raw_unchecked(
-    bls12_381::Scalar::from_raw([
-        0x3edc_c85f_4d1a_44cd,
-        0x77ff_8c90_a9a0_d8f4,
-        0x0daf_03b5_47e2_022b,
-        0x6dad_65e6_2328_d37a,
-    ]),
-    bls12_381::Scalar::from_raw([
-        0x5095_1f1f_eff0_8278,
-        0xf0b7_03d5_3a3e_dd4e,
-        0xca01_f580_9c00_eee2,
-        0x6996_932c_ece1_f4bb,
-    ]),
-);
 
 /// This is an output circuit instance.
 pub struct Output {

--- a/ironfish-zkp/src/circuits/spend.rs
+++ b/ironfish-zkp/src/circuits/spend.rs
@@ -2,7 +2,6 @@ use bellman::{Circuit, ConstraintSystem, SynthesisError};
 use ff::PrimeField;
 use jubjub::ExtendedPoint;
 use jubjub::SubgroupPoint;
-use zcash_primitives::sapling::PaymentAddress;
 
 use crate::circuits::output::PUBLIC_KEY_GENERATOR;
 
@@ -142,7 +141,7 @@ impl Circuit<bls12_381::Scalar> for Spend {
         // Witness g_d, checking that it's on the curve.
         let g_d = ecc::EdwardsPoint::witness(
             cs.namespace(|| "witness g_d"),
-            Some(ExtendedPoint::from(PUBLIC_KEY_GENERATOR))
+            Some(ExtendedPoint::from(PUBLIC_KEY_GENERATOR)),
         )?;
 
         // Check that g_d is not small order. Technically, this check
@@ -339,7 +338,7 @@ mod test {
     use zcash_primitives::sapling::ValueCommitment;
     use zcash_primitives::sapling::{pedersen_hash, Diversifier, Note, ProofGenerationKey, Rseed};
 
-    use crate::circuits::{spend::Spend, output::PUBLIC_KEY_GENERATOR};
+    use crate::circuits::{output::PUBLIC_KEY_GENERATOR, spend::Spend};
 
     #[test]
     fn test_input_circuit_with_bls12_381() {
@@ -363,7 +362,7 @@ mod test {
 
             let viewing_key = proof_generation_key.to_viewing_key();
 
-            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0  ;
+            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0;
 
             let commitment_randomness = jubjub::Fr::random(&mut rng);
             let auth_path =
@@ -515,7 +514,7 @@ mod test {
 
             let viewing_key = proof_generation_key.to_viewing_key();
 
-            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0  ;
+            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0;
 
             let commitment_randomness = jubjub::Fr::random(&mut rng);
             let auth_path =

--- a/ironfish-zkp/src/circuits/spend.rs
+++ b/ironfish-zkp/src/circuits/spend.rs
@@ -1,5 +1,10 @@
 use bellman::{Circuit, ConstraintSystem, SynthesisError};
 use ff::PrimeField;
+use jubjub::ExtendedPoint;
+use jubjub::SubgroupPoint;
+use zcash_primitives::sapling::PaymentAddress;
+
+use crate::circuits::output::PUBLIC_KEY_GENERATOR;
 
 use super::util::expose_value_commitment;
 use bellman::gadgets::blake2s;
@@ -10,7 +15,7 @@ use bellman::gadgets::Assignment;
 use zcash_primitives::{
     constants::CRH_IVK_PERSONALIZATION,
     constants::PRF_NF_PERSONALIZATION,
-    sapling::{PaymentAddress, ProofGenerationKey, ValueCommitment},
+    sapling::{ProofGenerationKey, ValueCommitment},
 };
 use zcash_proofs::{
     circuit::{
@@ -33,7 +38,7 @@ pub struct Spend {
     pub proof_generation_key: Option<ProofGenerationKey>,
 
     /// The payment address associated with the note
-    pub payment_address: Option<PaymentAddress>,
+    pub payment_address: Option<SubgroupPoint>,
 
     /// The randomness of the note commitment
     pub commitment_randomness: Option<jubjub::Fr>,
@@ -135,14 +140,10 @@ impl Circuit<bls12_381::Scalar> for Spend {
         ivk.truncate(jubjub::Fr::CAPACITY as usize);
 
         // Witness g_d, checking that it's on the curve.
-        let g_d = {
-            ecc::EdwardsPoint::witness(
-                cs.namespace(|| "witness g_d"),
-                self.payment_address
-                    .as_ref()
-                    .and_then(|a| a.g_d().map(jubjub::ExtendedPoint::from)),
-            )?
-        };
+        let g_d = ecc::EdwardsPoint::witness(
+            cs.namespace(|| "witness g_d"),
+            Some(ExtendedPoint::from(PUBLIC_KEY_GENERATOR))
+        )?;
 
         // Check that g_d is not small order. Technically, this check
         // is already done in the Output circuit, and this proof ensures
@@ -338,7 +339,7 @@ mod test {
     use zcash_primitives::sapling::ValueCommitment;
     use zcash_primitives::sapling::{pedersen_hash, Diversifier, Note, ProofGenerationKey, Rseed};
 
-    use crate::circuits::spend::Spend;
+    use crate::circuits::{spend::Spend, output::PUBLIC_KEY_GENERATOR};
 
     #[test]
     fn test_input_circuit_with_bls12_381() {
@@ -362,22 +363,8 @@ mod test {
 
             let viewing_key = proof_generation_key.to_viewing_key();
 
-            let payment_address;
+            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0  ;
 
-            loop {
-                let diversifier = {
-                    let mut d = [0; 11];
-                    rng.fill_bytes(&mut d);
-                    Diversifier(d)
-                };
-
-                if let Some(p) = viewing_key.to_payment_address(diversifier) {
-                    payment_address = p;
-                    break;
-                }
-            }
-
-            let g_d = payment_address.diversifier().g_d().unwrap();
             let commitment_randomness = jubjub::Fr::random(&mut rng);
             let auth_path =
                 vec![
@@ -392,8 +379,8 @@ mod test {
                     jubjub::ExtendedPoint::from(value_commitment.commitment()).to_affine();
                 let note = Note {
                     value: value_commitment.value,
-                    g_d,
-                    pk_d: *payment_address.pk_d(),
+                    g_d: PUBLIC_KEY_GENERATOR,
+                    pk_d: payment_address,
                     rseed: Rseed::BeforeZip212(commitment_randomness),
                 };
 
@@ -528,22 +515,8 @@ mod test {
 
             let viewing_key = proof_generation_key.to_viewing_key();
 
-            let payment_address;
+            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0  ;
 
-            loop {
-                let diversifier = {
-                    let mut d = [0; 11];
-                    rng.fill_bytes(&mut d);
-                    Diversifier(d)
-                };
-
-                if let Some(p) = viewing_key.to_payment_address(diversifier) {
-                    payment_address = p;
-                    break;
-                }
-            }
-
-            let g_d = payment_address.diversifier().g_d().unwrap();
             let commitment_randomness = jubjub::Fr::random(&mut rng);
             let auth_path =
                 vec![
@@ -568,8 +541,8 @@ mod test {
                 );
                 let note = Note {
                     value: value_commitment.value,
-                    g_d,
-                    pk_d: *payment_address.pk_d(),
+                    g_d: PUBLIC_KEY_GENERATOR,
+                    pk_d: payment_address,
                     rseed: Rseed::BeforeZip212(commitment_randomness),
                 };
 

--- a/ironfish-zkp/src/circuits/spend.rs
+++ b/ironfish-zkp/src/circuits/spend.rs
@@ -3,7 +3,7 @@ use ff::PrimeField;
 use jubjub::ExtendedPoint;
 use jubjub::SubgroupPoint;
 
-use crate::circuits::output::PUBLIC_KEY_GENERATOR;
+use crate::constants::PUBLIC_KEY_GENERATOR;
 
 use super::util::expose_value_commitment;
 use bellman::gadgets::blake2s;
@@ -336,9 +336,9 @@ mod test {
     use rand::{RngCore, SeedableRng};
     use rand_xorshift::XorShiftRng;
     use zcash_primitives::sapling::ValueCommitment;
-    use zcash_primitives::sapling::{pedersen_hash, Diversifier, Note, ProofGenerationKey, Rseed};
+    use zcash_primitives::sapling::{pedersen_hash, Note, ProofGenerationKey, Rseed};
 
-    use crate::circuits::{output::PUBLIC_KEY_GENERATOR, spend::Spend};
+    use crate::{circuits::spend::Spend, constants::PUBLIC_KEY_GENERATOR};
 
     #[test]
     fn test_input_circuit_with_bls12_381() {

--- a/ironfish-zkp/src/constants.rs
+++ b/ironfish-zkp/src/constants.rs
@@ -28,6 +28,21 @@ pub const ASSET_KEY_GENERATOR: SubgroupPoint = SubgroupPoint::from_raw_unchecked
     ]),
 );
 
+pub const PUBLIC_KEY_GENERATOR: SubgroupPoint = SubgroupPoint::from_raw_unchecked(
+    bls12_381::Scalar::from_raw([
+        0x3edc_c85f_4d1a_44cd,
+        0x77ff_8c90_a9a0_d8f4,
+        0x0daf_03b5_47e2_022b,
+        0x6dad_65e6_2328_d37a,
+    ]),
+    bls12_381::Scalar::from_raw([
+        0x5095_1f1f_eff0_8278,
+        0xf0b7_03d5_3a3e_dd4e,
+        0xca01_f580_9c00_eee2,
+        0x6996_932c_ece1_f4bb,
+    ]),
+);
+
 pub mod proof {
     use lazy_static::lazy_static;
     use zcash_proofs::constants::{generate_circuit_generator, FixedGeneratorOwned};


### PR DESCRIPTION
## Summary
Replace Payment Address with Subgroup Point in Output and Spend
## Testing Plan
unit tests
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@mat-if @rohanjadvani 