### PR TITLE
changes rewind update wallet head

### DIFF
--- a/ironfish-cli/src/commands/chain/hardfork.ts
+++ b/ironfish-cli/src/commands/chain/hardfork.ts
@@ -180,7 +180,7 @@ export default class RepairHardFork extends IronfishCommand {
     this.log(`Rewinding your blockchain to before the hard fork.`)
 
     if (!dryRun) {
-      await rewindChainTo(this, node.chain, HARD_FORK_SEQUENCE - 1)
+      await rewindChainTo(this, node, HARD_FORK_SEQUENCE - 1)
     }
   }
 }

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -4,7 +4,6 @@
 import {
   Assert,
   Blockchain,
-  BlockHeader,
   IronfishNode,
   Meter,
   NodeUtils,

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -1,7 +1,15 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Blockchain, Meter, NodeUtils, TimeUtils } from '@ironfish/sdk'
+import {
+  Assert,
+  Blockchain,
+  IronfishNode,
+  Meter,
+  NodeUtils,
+  TimeUtils,
+  Wallet,
+} from '@ironfish/sdk'
 import { CliUx, Command } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
@@ -36,19 +44,22 @@ export default class Rewind extends IronfishCommand {
     const node = await this.sdk.node()
     await NodeUtils.waitForOpen(node)
 
-    await rewindChainTo(this, node.chain, Number(args.to), Number(args.from))
+    await rewindChainTo(this, node, Number(args.to), Number(args.from))
   }
 }
 
 export const rewindChainTo = async (
   command: Command,
-  chain: Blockchain,
+  node: IronfishNode,
   to: number,
   from?: number,
 ): Promise<void> => {
+  const chain = node.chain
+  const wallet = node.wallet
+
   const sequence = to
 
-  let fromSequence = from ? Math.max(from, chain.latest.sequence) : chain.latest.sequence
+  const fromSequence = from ? Math.max(from, chain.latest.sequence) : chain.latest.sequence
 
   const toDisconnect = fromSequence - sequence
 
@@ -60,25 +71,84 @@ export const rewindChainTo = async (
   }
 
   command.log(
-    `Chain currently has blocks up to ${fromSequence}. Rewinding ${toDisconnect} blocks to ${sequence}.`,
+    `Chain currently has blocks up to ${fromSequence}. Disconnecting ${toDisconnect} blocks to ${sequence}.`,
   )
 
-  const progressBar = CliUx.ux.progress({
-    barCompleteChar: '\u2588',
-    barIncompleteChar: '\u2591',
-    format:
-      'Rewinding chain: [{bar}] {percentage}% | {value} / {total} blocks | {speed}/s | ETA: {estimate}',
-  }) as ProgressBar
+  await disconnectBlocks(chain, toDisconnect)
 
+  await rewindWalletHead(chain, wallet, sequence)
+
+  await removeBlocks(chain, sequence, fromSequence)
+}
+
+async function disconnectBlocks(chain: Blockchain, toDisconnect: number): Promise<void> {
+  const bar = getProgressBar('Disconnecting blocks')
   const speed = new Meter()
-  speed.start()
 
-  progressBar.start(toDisconnect, 0, {
+  bar.start(toDisconnect, 0, {
     speed: '0',
     estimate: TimeUtils.renderEstimate(0, 0, 0),
   })
+  speed.start()
 
   let disconnected = 0
+
+  await chain.db.transaction(async (tx) => {
+    while (disconnected < toDisconnect) {
+      const headBlock = await chain.getBlock(chain.head, tx)
+
+      Assert.isNotNull(headBlock)
+
+      await chain.disconnect(headBlock, tx)
+
+      speed.add(1)
+      bar.update(++disconnected, {
+        speed: speed.rate1s.toFixed(2),
+        estimate: TimeUtils.renderEstimate(disconnected, toDisconnect, speed.rate1m),
+      })
+    }
+  })
+
+  bar.stop()
+  speed.stop()
+}
+
+async function rewindWalletHead(
+  chain: Blockchain,
+  wallet: Wallet,
+  sequence: number,
+): Promise<void> {
+  const walletHeadHash = await wallet.getLatestHeadHash()
+
+  if (walletHeadHash) {
+    const walletHead = await chain.getHeader(walletHeadHash)
+
+    if (walletHead && walletHead.sequence > sequence) {
+      CliUx.ux.action.start('Rewinding wallet...')
+
+      await wallet.updateHead()
+
+      CliUx.ux.action.stop()
+    }
+  }
+}
+
+async function removeBlocks(
+  chain: Blockchain,
+  sequence: number,
+  fromSequence: number,
+): Promise<void> {
+  const toDisconnect = fromSequence - sequence
+  const bar = getProgressBar('Removing blocks')
+  const speed = new Meter()
+
+  bar.start(toDisconnect, 0, {
+    speed: '0',
+    estimate: TimeUtils.renderEstimate(0, 0, 0),
+  })
+  speed.start()
+
+  let removed = 0
 
   while (fromSequence > sequence) {
     const hashes = await chain.getHashesAtSequence(fromSequence)
@@ -90,12 +160,20 @@ export const rewindChainTo = async (
     fromSequence--
 
     speed.add(1)
-    progressBar.update(++disconnected, {
+    bar.update(++removed, {
       speed: speed.rate1s.toFixed(2),
-      estimate: TimeUtils.renderEstimate(disconnected, toDisconnect, speed.rate1m),
+      estimate: TimeUtils.renderEstimate(removed, toDisconnect, speed.rate1m),
     })
   }
 
   speed.stop()
-  progressBar.stop()
+  bar.stop()
+}
+
+function getProgressBar(label: string): ProgressBar {
+  return CliUx.ux.progress({
+    barCompleteChar: '\u2588',
+    barIncompleteChar: '\u2591',
+    format: `${label}: [{bar}] {percentage}% | {value} / {total} blocks | {speed}/s | ETA: {estimate}`,
+  }) as ProgressBar
 }

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -147,7 +147,6 @@ async function rewindWalletHead(
         header = await chain.getHeaderAtSequence(--headSequence)
 
         if (header) {
-          await wallet.updateHeadHashes(header.hash)
           wallet['chainProcessor'].hash = header.hash
           wallet['chainProcessor'].sequence = header.sequence
         }

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -140,8 +140,6 @@ async function rewindWalletHead(
       let headSequence = header.sequence
       let removed = 0
 
-      const accounts = wallet.listAccounts()
-
       while (header && header.sequence > sequence) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         await wallet['chainProcessor']['remove'](header)
@@ -149,9 +147,9 @@ async function rewindWalletHead(
         header = await chain.getHeaderAtSequence(--headSequence)
 
         if (header) {
-          for (const account of accounts) {
-            await wallet.updateHeadHash(account, header.hash)
-          }
+          await wallet.updateHeadHashes(header.hash)
+          wallet['chainProcessor'].hash = header.hash
+          wallet['chainProcessor'].sequence = header.sequence
         }
 
         speed.add(1)

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -94,7 +94,7 @@ async function disconnectBlocks(chain: Blockchain, toDisconnect: number): Promis
   let disconnected = 0
 
   while (disconnected < toDisconnect) {
-    const headBlock = await chain.getBlock(chain.head, tx)
+    const headBlock = await chain.getBlock(chain.head)
 
     Assert.isNotNull(headBlock)
 


### PR DESCRIPTION
## Summary

we need to update the wallet while we rewind the chain. otherwise nodes will be forced to rescan because the wallet's head hash will not be in the chain anymore.

first disconnect blocks back to the rewind point.

next, update the wallet head, if necessary. only update the wallet head if its sequence is greater than the 'to' sequence of the rewind.

finally, remove all blocks back to the rewind point.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
