### PR TITLE
Fix peer.punish not banning peers

### DIFF
--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -694,8 +694,8 @@ export class Peer {
     }
 
     this.logger.info(`Peer ${this.displayName} has been banned: ${reason || 'UNKNOWN'}`)
-    this.close(new Error(`BANNED: ${reason || 'UNKNOWN'}`))
     this.onBanned.emit()
+    this.close(new Error(`BANNED: ${reason || 'UNKNOWN'}`))
     return true
   }
 

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -36,6 +36,7 @@ import {
   WebRtcConnection,
   WebSocketConnection,
 } from './connections'
+import { BAN_SCORE } from './peer'
 import { PeerManager } from './peerManager'
 
 jest.useFakeTimers()
@@ -215,6 +216,30 @@ describe('PeerManager', () => {
     expect(peer1.state.type).toEqual('DISCONNECTED')
     expect(peer2.state.type).toEqual('DISCONNECTED')
     expect(peer3.state.type).toEqual('DISCONNECTED')
+  })
+
+  describe('banning', () => {
+    it('Should add the peer identity to PeerManager.banned when banPeer is called', () => {
+      const localPeer = mockLocalPeer()
+      const peers = new PeerManager(localPeer, mockHostsStore())
+
+      const { peer } = getConnectedPeer(peers)
+
+      peers.banPeer(peer)
+
+      expect(peers.banned.has(peer.getIdentityOrThrow())).toBe(true)
+    })
+
+    it('Should add the peer identity to PeerManager.banned when punished with BAN_SCORE.MAX', () => {
+      const localPeer = mockLocalPeer()
+      const peers = new PeerManager(localPeer, mockHostsStore())
+
+      const { peer } = getConnectedPeer(peers)
+
+      peer.punish(BAN_SCORE.MAX, 'TESTING')
+
+      expect(peers.banned.has(peer.getIdentityOrThrow())).toBe(true)
+    })
   })
 
   describe('connect', () => {


### PR DESCRIPTION
## Summary

Peer.punish was closing the connection, which triggers dispose to be run in the peerManager, which removes event handlers from the Peer's Events, before the onBanned event was emitted. So peers weren't being banned when punish was called. This swaps the order to fix the banning.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
