### PR TITLE
Skip processing the chain if accounts is empty

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -134,7 +134,7 @@ export class Wallet {
   }
 
   async updateHead(): Promise<void> {
-    if (this.scan || this.updateHeadState) {
+    if (this.scan || this.updateHeadState || this.accounts.size === 0) {
       return
     }
 


### PR DESCRIPTION
## Summary

If we don't have any accounts, we should be able to stop the wallet from doing some chain processing.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
