### PR TITLE
Only create a default account on first run

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -231,10 +231,6 @@ export default class Start extends IronfishCommand {
       await this.firstRun(node)
     }
 
-    if (!node.wallet.getDefaultAccount()) {
-      await this.setDefaultAccount(node)
-    }
-
     await node.start()
     this.node = node
 
@@ -261,6 +257,10 @@ export default class Start extends IronfishCommand {
       this.log('')
       this.log('To help improve Iron Fish, opt in to collecting telemetry by running')
       this.log(` > ironfish config:set ${ENABLE_TELEMETRY_CONFIG_KEY} true`)
+    }
+
+    if (!node.wallet.getDefaultAccount()) {
+      await this.setDefaultAccount(node)
     }
 
     this.log('')


### PR DESCRIPTION
## Summary

It's useful to run the node with no accounts to disable the wallet from scanning/decrypting notes, however the start command will always recreate accounts if you don't have one.

It's probably still useful on first run to create an account for users, but if a user chooses to remove that account, I don't think we need to create another one.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
