### PR TITLE
Remove invalid transaction from mempool

### DIFF
--- a/ironfish/src/memPool/feeEstimator.test.ts
+++ b/ironfish/src/memPool/feeEstimator.test.ts
@@ -138,7 +138,7 @@ describe('FeeEstimator', () => {
       expect(feeEstimator.size(PRIORITY_LEVELS[1])).toBe(0)
       expect(feeEstimator.size(PRIORITY_LEVELS[2])).toBe(0)
 
-      expect(node.memPool.acceptTransaction(transaction)).toBe(true)
+      expect(await node.memPool.acceptTransaction(transaction)).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
@@ -192,7 +192,7 @@ describe('FeeEstimator', () => {
         fee: 10,
       })
 
-      expect(node.memPool.acceptTransaction(transaction)).toBe(true)
+      expect(await node.memPool.acceptTransaction(transaction)).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
@@ -211,7 +211,7 @@ describe('FeeEstimator', () => {
         },
       )
 
-      expect(node.memPool.acceptTransaction(transaction2)).toBe(true)
+      expect(await node.memPool.acceptTransaction(transaction2)).toBe(true)
 
       feeEstimator.onConnectBlock(block2, node.memPool)
 
@@ -238,7 +238,7 @@ describe('FeeEstimator', () => {
         fee: 10,
       })
 
-      const result = node.memPool.acceptTransaction(transaction)
+      const result = await node.memPool.acceptTransaction(transaction)
       expect(result).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
@@ -258,7 +258,7 @@ describe('FeeEstimator', () => {
         },
       )
 
-      expect(node.memPool.acceptTransaction(transaction2)).toBe(true)
+      expect(await node.memPool.acceptTransaction(transaction2)).toBe(true)
 
       feeEstimator.onConnectBlock(block2, node.memPool)
 
@@ -282,7 +282,7 @@ describe('FeeEstimator', () => {
         fee: 10,
       })
 
-      expect(node.memPool.acceptTransaction(transaction)).toBe(true)
+      expect(await node.memPool.acceptTransaction(transaction)).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
@@ -296,7 +296,7 @@ describe('FeeEstimator', () => {
         account2,
       )
       for (const newTransaction of newTransactions) {
-        expect(node.memPool.acceptTransaction(newTransaction)).toBe(true)
+        expect(await node.memPool.acceptTransaction(newTransaction)).toBe(true)
       }
 
       feeEstimator.onConnectBlock(newBlock, node.memPool)
@@ -321,7 +321,7 @@ describe('FeeEstimator', () => {
 
       const { block, transaction } = await useBlockWithTx(node, undefined, undefined, true)
 
-      expect(node.memPool.acceptTransaction(transaction)).toBe(true)
+      expect(await node.memPool.acceptTransaction(transaction)).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
@@ -351,7 +351,7 @@ describe('FeeEstimator', () => {
         fee: 10,
       })
 
-      expect(node.memPool.acceptTransaction(transaction)).toBe(true)
+      expect(await node.memPool.acceptTransaction(transaction)).toBe(true)
 
       feeEstimator.onConnectBlock(block, node.memPool)
 
@@ -366,7 +366,7 @@ describe('FeeEstimator', () => {
         },
       )
 
-      expect(node.memPool.acceptTransaction(transaction2)).toBe(true)
+      expect(await node.memPool.acceptTransaction(transaction2)).toBe(true)
 
       feeEstimator.onConnectBlock(block2, node.memPool)
 

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -18,7 +18,7 @@ describe('MemPool', () => {
       const accountB = await useAccountFixture(wallet, 'accountB')
       const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-      memPool.acceptTransaction(transaction)
+      await memPool.acceptTransaction(transaction)
 
       expect(memPool.count()).toBe(1)
     })
@@ -37,7 +37,7 @@ describe('MemPool', () => {
       const { transaction, block } = await useBlockWithTx(node, accountA, accountB)
       const { transaction: transaction2 } = await useBlockWithTx(node, accountC, accountD)
 
-      memPool.acceptTransaction(transaction)
+      await memPool.acceptTransaction(transaction)
 
       const size = (tx: Transaction) => {
         return getTransactionSize(tx)
@@ -46,12 +46,12 @@ describe('MemPool', () => {
       expect(memPool.sizeBytes()).toBe(size(transaction))
 
       // If we accept the same transaction it should not add to the memory size
-      memPool.acceptTransaction(transaction)
+      await memPool.acceptTransaction(transaction)
 
       expect(memPool.sizeBytes()).toBe(size(transaction))
 
       // If we add another it should include that in size
-      memPool.acceptTransaction(transaction2)
+      await memPool.acceptTransaction(transaction2)
 
       expect(memPool.sizeBytes()).toBe(size(transaction) + size(transaction2))
 
@@ -122,9 +122,9 @@ describe('MemPool', () => {
       expect(getFeeRate(transactionB)).toBeGreaterThan(getFeeRate(transactionA))
       expect(getFeeRate(transactionA)).toBeGreaterThan(getFeeRate(transactionC))
 
-      memPool.acceptTransaction(transactionA)
-      memPool.acceptTransaction(transactionB)
-      memPool.acceptTransaction(transactionC)
+      await memPool.acceptTransaction(transactionA)
+      await memPool.acceptTransaction(transactionB)
+      await memPool.acceptTransaction(transactionC)
 
       const transactions = Array.from(memPool.orderedTransactions())
       expect(transactions).toEqual([transactionB, transactionA, transactionC])
@@ -141,8 +141,8 @@ describe('MemPool', () => {
       jest.spyOn(transactionA, 'fee').mockImplementationOnce(() => BigInt(1))
       jest.spyOn(transactionB, 'fee').mockImplementationOnce(() => BigInt(4))
 
-      memPool.acceptTransaction(transactionA)
-      memPool.acceptTransaction(transactionB)
+      await memPool.acceptTransaction(transactionA)
+      await memPool.acceptTransaction(transactionB)
 
       const generator = memPool.orderedTransactions()
       const result = generator.next()
@@ -167,9 +167,9 @@ describe('MemPool', () => {
         const accountB = await useAccountFixture(wallet, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-        memPool.acceptTransaction(transaction)
+        await memPool.acceptTransaction(transaction)
 
-        expect(memPool.acceptTransaction(transaction)).toBe(false)
+        expect(await memPool.acceptTransaction(transaction)).toBe(false)
       })
     })
 
@@ -187,7 +187,7 @@ describe('MemPool', () => {
           .spyOn(chain.verifier, 'isExpiredSequence')
           .mockReturnValue(true)
 
-        expect(memPool.acceptTransaction(transaction)).toBe(false)
+        expect(await memPool.acceptTransaction(transaction)).toBe(false)
         expect(isExpiredSequenceSpy).toHaveBeenCalledTimes(1)
         expect(isExpiredSequenceSpy).lastReturnedWith(true)
       })
@@ -211,9 +211,9 @@ describe('MemPool', () => {
 
         expect(transaction.getSpend(0).nullifier).toEqual(transaction2.getSpend(0).nullifier)
 
-        memPool.acceptTransaction(transaction)
+        await memPool.acceptTransaction(transaction)
 
-        expect(memPool.acceptTransaction(transaction2)).toBe(false)
+        expect(await memPool.acceptTransaction(transaction2)).toBe(false)
       })
 
       it('returns true with a higher fee', async () => {
@@ -232,9 +232,9 @@ describe('MemPool', () => {
 
         expect(transaction.getSpend(0).nullifier).toEqual(transaction2.getSpend(0).nullifier)
 
-        memPool.acceptTransaction(transaction)
+        await memPool.acceptTransaction(transaction)
 
-        expect(memPool.acceptTransaction(transaction2)).toBe(true)
+        expect(await memPool.acceptTransaction(transaction2)).toBe(true)
       })
     })
 
@@ -248,7 +248,7 @@ describe('MemPool', () => {
         const accountB = await useAccountFixture(wallet, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-        expect(memPool.acceptTransaction(transaction)).toBe(true)
+        expect(await memPool.acceptTransaction(transaction)).toBe(true)
       })
 
       it('sets the transaction hash in the mempool map and priority queue', async () => {
@@ -258,7 +258,7 @@ describe('MemPool', () => {
         const accountB = await useAccountFixture(wallet, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-        memPool.acceptTransaction(transaction)
+        await memPool.acceptTransaction(transaction)
 
         expect(memPool.exists(transaction.hash())).toBe(true)
         expect([...memPool.orderedTransactions()]).toContainEqual(transaction)
@@ -293,8 +293,8 @@ describe('MemPool', () => {
 
       expect(chain.head.sequence).toEqual(3)
 
-      memPool.acceptTransaction(transactionA)
-      memPool.acceptTransaction(transactionB)
+      await memPool.acceptTransaction(transactionA)
+      await memPool.acceptTransaction(transactionB)
       expect(memPool.exists(transactionA.hash())).toBe(true)
       expect(memPool.exists(transactionB.hash())).toBe(true)
 

--- a/ironfish/src/mining/manager.test.slow.ts
+++ b/ironfish/src/mining/manager.test.slow.ts
@@ -48,7 +48,7 @@ describe('Mining manager', () => {
     const transaction = await useTxFixture(node.wallet, account, account)
 
     expect(node.memPool.count()).toBe(0)
-    node.memPool.acceptTransaction(transaction)
+    await node.memPool.acceptTransaction(transaction)
     expect(node.memPool.count()).toBe(1)
 
     const spy = jest.spyOn(BlockTemplateSerde, 'serialize')
@@ -95,7 +95,7 @@ describe('Mining manager', () => {
     // G -> A1
     //   -> B2 -> B3
 
-    const added = nodeA.memPool.acceptTransaction(invalidTx)
+    const added = await nodeA.memPool.acceptTransaction(invalidTx)
     expect(added).toBe(true)
 
     const { blockTransactions } = await nodeA.miningManager.getNewBlockTransactions(

--- a/ironfish/src/mining/manager.test.ts
+++ b/ironfish/src/mining/manager.test.ts
@@ -68,7 +68,7 @@ describe('Mining manager', () => {
       chain.head.sequence + 2,
     )
 
-    node.memPool.acceptTransaction(transaction)
+    await node.memPool.acceptTransaction(transaction)
     chain.consensus.MAX_BLOCK_SIZE_BYTES = 0
 
     let results = (await miningManager.getNewBlockTransactions(chain.head.sequence + 1, 0))

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -87,6 +87,7 @@ export class MiningManager {
         sequence,
       )
       if (isExpired) {
+        this.memPool.deleteTransaction(transaction)
         continue
       }
 
@@ -99,6 +100,7 @@ export class MiningManager {
 
       const { valid: isValid } = await this.chain.verifier.verifyTransactionSpends(transaction)
       if (!isValid) {
+        this.memPool.deleteTransaction(transaction)
         continue
       }
 

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -59,6 +59,7 @@ export class MiningManager {
    * the sum of the associated fees.
    *
    * @param sequence The sequence of the next block to be included in the chain
+   * @param currBlockSize The initial size of the next block
    * @returns
    */
   async getNewBlockTransactions(

--- a/ironfish/src/network/blockFetcher.test.ts
+++ b/ironfish/src/network/blockFetcher.test.ts
@@ -164,7 +164,7 @@ describe('BlockFetcher', () => {
     expect(block.header.sequence - chain.head.sequence).toEqual(1)
 
     // We accept one of the the transaction in our mempool
-    node.memPool.acceptTransaction(transactions[2])
+    await node.memPool.acceptTransaction(transactions[2])
 
     // Create 5 connected peers
     const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -464,7 +464,7 @@ describe('PeerNetwork', () => {
         const accountA = await useAccountFixture(wallet, 'accountA')
         const accountB = await useAccountFixture(wallet, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
-        memPool.acceptTransaction(transaction)
+        await memPool.acceptTransaction(transaction)
 
         const { peer, sendSpy } = getConnectedPeersWithSpies(peerNetwork.peerManager, 1)[0]
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -1352,7 +1352,7 @@ export class PeerNetwork {
         return
       }
 
-      if (this.node.memPool.acceptTransaction(transaction)) {
+      if (await this.node.memPool.acceptTransaction(transaction)) {
         this.onTransactionAccepted.emit(transaction, received)
       }
 

--- a/ironfish/src/network/transactionFetcher.test.ts
+++ b/ironfish/src/network/transactionFetcher.test.ts
@@ -158,7 +158,7 @@ describe('TransactionFetcher', () => {
 
     const hash = transaction.hash()
 
-    expect(node.memPool.acceptTransaction(transaction)).toBe(true)
+    expect(await node.memPool.acceptTransaction(transaction)).toBe(true)
 
     const { peer, sendSpy } = getConnectedPeersWithSpies(peerNetwork.peerManager, 1)[0]
     const peerIdentity = peer.getIdentityOrThrow()
@@ -206,7 +206,7 @@ describe('TransactionFetcher', () => {
 
     const hash = transaction.hash()
 
-    expect(node.memPool.acceptTransaction(transaction)).toBe(true)
+    expect(await node.memPool.acceptTransaction(transaction)).toBe(true)
 
     // Get 5 peers on the most recent version
     const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)

--- a/ironfish/src/rpc/routes/mining/blockTemplateStream.test.slow.ts
+++ b/ironfish/src/rpc/routes/mining/blockTemplateStream.test.slow.ts
@@ -86,7 +86,7 @@ describe('Block template stream', () => {
     const response = routeTest.client.request('miner/blockTemplateStream')
 
     // Add the transaction to the route mempool
-    routeTest.node.memPool.acceptTransaction(tx)
+    await routeTest.node.memPool.acceptTransaction(tx)
 
     // Add both blocks to the route node
     await expect(chain).toAddBlock(block2)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -671,7 +671,7 @@ export class Wallet {
     }
 
     await this.syncTransaction(transaction, { submittedSequence: heaviestHead.sequence })
-    memPool.acceptTransaction(transaction)
+    await memPool.acceptTransaction(transaction)
     this.broadcastTransaction(transaction)
     this.onTransactionCreated.emit(transaction)
 


### PR DESCRIPTION
## Summary
There are too many invalid transactions in mempool, which actually makes some invalid blocks for double spend and slows down the `blockTemplateStream`. The mempool information like nullifiers will be cleared once restart. This PR add some verify logic with blockchain nullifiers before add a transaction to mempool, which remove invalid transactions from mempool and makes mining more efficient. 
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
