### PR TITLE
fix config validator

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -259,7 +259,7 @@ export const noWhitespaceBegEnd = yup
   .string()
   .matches(reNoWhitespaceBegEnd, 'Path should not contain leading or trailing whitespace.')
 
-export const isUrl = yup.string().url('Invalid URL')
+export const isUrl = yup.string().url()
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
   .object({


### PR DESCRIPTION
## Summary

Remove custom error message to show config key

Yup automatically gives an appropriate error message with key name and error message, if a custom error message is defined - it will become our responsibility to add the key name in that custom error message.

Here a custom error message was defined without a key name, so in case on error in key value. We were just getting:

`Error: Invalid URL` -> with no idea which key it is for

Removing the custom message which automatically fix the issue
`Error: explorerBlocksUrl must be a valid URL
`
## Testing Plan

Tested on local

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

No
