### PR TITLE
Fix config:edit --remote crashing

### DIFF
--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -44,7 +44,7 @@ export class EditCommand extends IronfishCommand {
     const output = JSON.stringify(response.content, undefined, '   ')
 
     const tmpDir = os.tmpdir()
-    const folderPath = await mkdtempAsync(path.join(tmpDir, '@ironfish/sdk'))
+    const folderPath = await mkdtempAsync(path.join(tmpDir, '@ironfish-sdk-'))
     const filePath = path.join(folderPath, DEFAULT_CONFIG_NAME)
 
     await writeFileAsync(filePath, output)


### PR DESCRIPTION
## Summary

This would crash because the directory passed to mkdtempdir has a 2 slash so it thinks its 2 folders that don't exist.

```
> ironfish config:edit --remote
Error: ENOENT: no such file or directory, mkdtemp '/var/folders/tn/zq9xjdyd347gzn6xbgpgdjxw0000gn/T/@ironfish/sdk-9ArQrX'
error Command failed with exit code 1.
```

## Testing Plan
Run the command

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
