### PR TITLE
Key store validate

### DIFF
--- a/ironfish/src/fileStores/keyStore.ts
+++ b/ironfish/src/fileStores/keyStore.ts
@@ -97,6 +97,18 @@ export class KeyStore<TSchema extends Record<string, unknown>> {
   }
 
   set<T extends keyof TSchema>(key: T, value: TSchema[T]): void {
+    const schema = this.schema?.fields[key]
+
+    if (schema) {
+      const { error, result } = YupUtils.tryValidateSync(schema, value)
+
+      if (error) {
+        throw error
+      }
+
+      value = result as TSchema[T]
+    }
+
     const previousValue = this.config[key]
 
     Object.assign(this.loaded, { [key]: value })

--- a/ironfish/src/utils/yup.ts
+++ b/ironfish/src/utils/yup.ts
@@ -11,6 +11,10 @@ export type YupSchemaResult<S extends yup.Schema<unknown, unknown>> = UnwrapProm
   ReturnType<S['validate']>
 >
 
+export type YupSchemaResultSync<S extends yup.Schema<unknown, unknown>> = ReturnType<
+  S['validate']
+>
+
 export class YupUtils {
   static async tryValidate<S extends YupSchema>(
     schema: S,
@@ -30,6 +34,32 @@ export class YupUtils {
     try {
       const result = await schema.validate(value, options)
       return { result: result as YupSchemaResult<S>, error: null }
+    } catch (e) {
+      if (e instanceof yup.ValidationError) {
+        return { result: null, error: e }
+      }
+      throw e
+    }
+  }
+
+  static tryValidateSync<S extends YupSchema>(
+    schema: S,
+    value: unknown,
+    options?: yup.ValidateOptions<unknown>,
+  ):
+    | { result: YupSchemaResultSync<S>; error: null }
+    | { result: null; error: yup.ValidationError } {
+    if (!options) {
+      options = { stripUnknown: true }
+    }
+
+    if (options.stripUnknown === undefined) {
+      options.stripUnknown = true
+    }
+
+    try {
+      const result = schema.validateSync(value, options) as YupSchemaResultSync<S>
+      return { result: result, error: null }
     } catch (e) {
       if (e instanceof yup.ValidationError) {
         return { result: null, error: e }


### PR DESCRIPTION
## Summary

This adds validation to KeyStore.set(). Before, validation was unidirectional. Now it'll check the value against the schema going in. This also adds tests to validate this new behaviour.

## Testing Plan

Added tests and used `ironfish config:set` command, and edited the config to test.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
