### PR TITLE
Change V3_DISABLE_MINING_REWARD to 279900

### DIFF
--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -102,6 +102,6 @@ export class TestnetParameters extends ConsensusParameters {
     super()
     this.V1_DOUBLE_SPEND = 204000
     this.V2_MAX_BLOCK_SIZE = 255000
-    this.V3_DISABLE_MINING_REWARD = 278500
+    this.V3_DISABLE_MINING_REWARD = 279900
   }
 }


### PR DESCRIPTION
## Summary

2809 blocks from now: Mon Nov 21 2022 15:33:23 GMT-0500 (Eastern Standard Time) at block 279900 

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
