### PR TITLE
fixes nullifierToNote before repairing expired transactions

### DIFF
--- a/ironfish-cli/src/commands/accounts/repair.ts
+++ b/ironfish-cli/src/commands/accounts/repair.ts
@@ -42,14 +42,14 @@ export default class Repair extends IronfishCommand {
 
     this.log(`Repairing wallet for account ${account.name}`)
 
+    this.log('Repairing nullifierToNote')
+    await this.repairNullifierToNoteHash(account, node.wallet.walletDb)
+
     this.log('Repairing expired transactions')
     await this.repairTransactions(account, node.wallet.walletDb, node.chain)
 
     this.log('Repairing balance')
     await this.repairBalance(account, node.wallet.walletDb, node.chain)
-
-    this.log('Repairing nullifierToNote')
-    await this.repairNullifierToNoteHash(account, node.wallet.walletDb)
 
     this.log('Repairing sequenceToNoteHash')
     await this.repairSequenceToNoteHash(account, node.wallet.walletDb)
@@ -99,7 +99,9 @@ export default class Repair extends IronfishCommand {
       }
     }
 
-    this.log(`Repaired ${unexpiredTransactions} expired transactions stuck in unexpired state.`)
+    this.log(
+      `\tRepaired ${unexpiredTransactions} expired transactions stuck in unexpired state.`,
+    )
   }
 
   private async repairBalance(


### PR DESCRIPTION
## Summary

expiring transactions may not work because of the `nullifierToNote` error that the `repairNullifierToNoteHash` function resolves.

reorders the repair functions so that nullifiers are fixed before expired transactions.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
