### PR TITLE
uses config tempDir for backup files

### DIFF
--- a/ironfish-cli/src/commands/backup.ts
+++ b/ironfish-cli/src/commands/backup.ts
@@ -5,7 +5,6 @@ import { S3Client } from '@aws-sdk/client-s3'
 import { FileUtils, NodeUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import fsAsync from 'fs/promises'
-import os from 'os'
 import path from 'path'
 import { v4 as uuid } from 'uuid'
 import { IronfishCommand } from '../command'
@@ -85,7 +84,10 @@ export default class Backup extends IronfishCommand {
     }
 
     const source = this.sdk.config.dataDir
-    const destDir = await fsAsync.mkdtemp(path.join(os.tmpdir(), `ironfish.backup`))
+
+    const destDir = this.sdk.config.tempDir
+    await fsAsync.mkdir(destDir, { recursive: true })
+
     const destName = `node.${id}.tar.gz`
     const dest = path.join(destDir, destName)
 
@@ -131,8 +133,8 @@ export default class Backup extends IronfishCommand {
     )
     CliUx.ux.action.stop(`done`)
 
-    CliUx.ux.action.start(`Removing backup dir ${destDir}`)
-    await fsAsync.rm(destDir, { recursive: true })
+    CliUx.ux.action.start(`Removing backup file ${dest}`)
+    await fsAsync.rm(dest)
     CliUx.ux.action.stop(`done`)
   }
 }


### PR DESCRIPTION
## Summary

the backup command writes files to a temporary directory before uploading to S3. instead of generating a new directory on each command invocation we can use the tempDir specified by the config, which is located within the datadir.

the config tempDir makes backup consistent with other ironfish commands and makes the write location for backup consistent across invocations.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
