### PR TITLE
refactor(rust): Remove unnecessary to-bytes functions, add read_point function

### DIFF
--- a/ironfish-rust/src/assets/asset.rs
+++ b/ironfish-rust/src/assets/asset.rs
@@ -1,7 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use crate::{errors::IronfishError, keys::AssetPublicKey, util::str_to_array};
+use crate::{
+    errors::IronfishError, keys::AssetPublicKey, serializing::read_point, util::str_to_array,
+};
 use bellman::gadgets::multipack;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use group::GroupEncoding;
@@ -130,12 +132,7 @@ impl Asset {
     }
 
     pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
-        let owner = {
-            let mut buf = [0; OWNER_LENGTH];
-            reader.read_exact(&mut buf)?;
-
-            Option::from(AssetPublicKey::from_bytes(&buf)).ok_or(IronfishError::IllegalValue)?
-        };
+        let owner = read_point(&mut reader)?;
 
         let mut name = [0; NAME_LENGTH];
         reader.read_exact(&mut name[..])?;

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -4,9 +4,7 @@
 
 use crate::errors::IronfishError;
 
-use super::serializing::{
-    bytes_to_hex, hex_to_bytes, point_to_bytes, read_scalar, scalar_to_bytes,
-};
+use super::serializing::{bytes_to_hex, hex_to_bytes, read_scalar};
 use bip39::{Language, Mnemonic};
 use blake2b_simd::Params as Blake2b;
 use blake2s_simd::Params as Blake2s;
@@ -242,32 +240,6 @@ impl SaplingKey {
             incoming: self.incoming_view_key().clone(),
             outgoing: self.outgoing_view_key().clone(),
         }
-    }
-
-    #[deprecated(note = "I'm not aware that this ever needs to be publicly visible")]
-    /// Retrieve the spend authorizing key
-    pub fn spend_authorizing_key(&self) -> [u8; 32] {
-        scalar_to_bytes(&self.spend_authorizing_key)
-    }
-
-    #[deprecated(note = "I'm not aware that this ever needs to be publicly visible")]
-    /// Retrieve the byte representation of the proof authorizing key
-    pub fn proof_authorizing_key(&self) -> [u8; 32] {
-        scalar_to_bytes(&self.proof_authorizing_key)
-    }
-
-    #[deprecated(note = "I'm not aware that this ever needs to be publicly visible")]
-    /// Retrieve the byte representation of the authorizing key
-    pub fn authorizing_key(&self) -> [u8; 32] {
-        point_to_bytes(&self.authorizing_key)
-            .expect("authorizing key should be convertible to bytes")
-    }
-
-    #[deprecated(note = "I'm not aware that this ever needs to be publicly visible")]
-    /// Retrieve the byte representation of the nullifier_deriving_key
-    pub fn nullifier_deriving_key(&self) -> [u8; 32] {
-        point_to_bytes(&self.nullifier_deriving_key)
-            .expect("nullifier deriving key should be convertible to bytes")
     }
 
     /// Adapter to convert this key to a viewing key for use in sapling

--- a/ironfish-rust/src/merkle_note_hash.rs
+++ b/ironfish-rust/src/merkle_note_hash.rs
@@ -39,7 +39,7 @@ impl MerkleNoteHash {
     }
 
     pub fn write<W: io::Write>(&self, writer: &mut W) -> Result<(), IronfishError> {
-        writer.write_all(self.0.to_repr().as_ref())?;
+        writer.write_all(&self.0.to_bytes())?;
 
         Ok(())
     }

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -22,6 +22,7 @@ use crate::{
     assets::asset::{asset_generator_point, Asset},
     errors::IronfishError,
     sapling_bls12::SAPLING,
+    serializing::read_point,
     SaplingKey,
 };
 
@@ -253,18 +254,9 @@ impl MintDescription {
     pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
         let proof = groth16::Proof::read(&mut reader)?;
         let asset = Asset::read(&mut reader)?;
-
         let value = reader.read_u64::<LittleEndian>()?;
-
-        let value_commitment = {
-            let mut bytes = [0; 32];
-            reader.read_exact(&mut bytes)?;
-
-            Option::from(ExtendedPoint::from_bytes(&bytes)).ok_or(IronfishError::InvalidData)?
-        };
-
+        let value_commitment = read_point(&mut reader)?;
         let randomized_public_key = redjubjub::PublicKey::read(&mut reader)?;
-
         let authorizing_signature = redjubjub::Signature::read(&mut reader)?;
 
         Ok(MintDescription {

--- a/ironfish-rust/src/transaction/spending.rs
+++ b/ironfish-rust/src/transaction/spending.rs
@@ -8,7 +8,7 @@ use crate::{
     merkle_note::{position as witness_position, sapling_auth_path},
     note::Note,
     sapling_bls12::SAPLING,
-    serializing::read_scalar,
+    serializing::{read_point, read_scalar},
     witness::WitnessTrait,
 };
 
@@ -250,12 +250,7 @@ impl SpendDescription {
     /// transaction.
     pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
         let proof = groth16::Proof::read(&mut reader)?;
-        let value_commitment = {
-            let mut bytes = [0; 32];
-            reader.read_exact(&mut bytes)?;
-
-            Option::from(ExtendedPoint::from_bytes(&bytes)).ok_or(IronfishError::InvalidData)?
-        };
+        let value_commitment = read_point(&mut reader)?;
         let randomized_public_key = redjubjub::PublicKey::read(&mut reader)?;
         let root_hash = read_scalar(&mut reader)?;
         let tree_size = reader.read_u32::<LittleEndian>()?;


### PR DESCRIPTION
## Summary

We don't need the extra functions to convert to bytes, so removed those. Added a read_point function since that is a helper worth having. Cleaned up read/write functions so theyre more uniform and utilize the new read_point function properly

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
