### PR TITLE
refactor(rust): Remove redundant hex crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,6 @@ name = "ironfish-rust-nodejs"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
- "hex 0.4.3",
  "ironfish_rust",
  "napi",
  "napi-build",

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -16,7 +16,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 base64 = "0.13.0"
-hex = "0.4.3"
 ironfish_rust = { path = "../ironfish-rust" }
 napi-derive = "2.9.0"
 

--- a/ironfish-rust-nodejs/src/nacl.rs
+++ b/ironfish-rust-nodejs/src/nacl.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ironfish_rust::nacl::{self, box_message, bytes_to_secret_key, new_secret_key, unbox_message};
+use ironfish_rust::{
+    nacl::{self, box_message, bytes_to_secret_key, new_secret_key, unbox_message},
+    serializing::hex_to_bytes,
+};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
@@ -36,7 +39,7 @@ impl BoxKeyPair {
     #[napi(factory)]
     pub fn from_hex(secret_hex: String) -> napi::Result<BoxKeyPair> {
         let byte_vec =
-            hex::decode(secret_hex).map_err(|_| to_napi_err("Unable to decode secret key"))?;
+            hex_to_bytes(&secret_hex).map_err(|_| to_napi_err("Unable to decode secret key"))?;
 
         let bytes: [u8; nacl::KEY_LENGTH] = byte_vec
             .try_into()

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -135,7 +135,7 @@ impl SaplingKey {
     /// Load a key from a string of hexadecimal digits
     pub fn from_hex(value: &str) -> Result<Self, IronfishError> {
         match hex_to_bytes(value) {
-            Err(()) => Err(IronfishError::InvalidPaymentAddress),
+            Err(_) => Err(IronfishError::InvalidPaymentAddress),
             Ok(bytes) => {
                 if bytes.len() != 32 {
                     Err(IronfishError::InvalidPaymentAddress)

--- a/ironfish-rust/src/keys/public_address.rs
+++ b/ironfish-rust/src/keys/public_address.rs
@@ -64,7 +64,7 @@ impl PublicAddress {
         }
 
         match hex_to_bytes(value) {
-            Err(()) => Err(IronfishError::InvalidPublicAddress),
+            Err(_) => Err(IronfishError::InvalidPublicAddress),
             Ok(bytes) => {
                 if bytes.len() != PUBLIC_ADDRESS_SIZE {
                     Err(IronfishError::InvalidPublicAddress)

--- a/ironfish-rust/src/keys/view_keys.rs
+++ b/ironfish-rust/src/keys/view_keys.rs
@@ -43,7 +43,7 @@ impl IncomingViewKey {
     /// Load a key from a string of hexadecimal digits
     pub fn from_hex(value: &str) -> Result<Self, IronfishError> {
         match hex_to_bytes(value) {
-            Err(()) => Err(IronfishError::InvalidViewingKey),
+            Err(_) => Err(IronfishError::InvalidViewingKey),
             Ok(bytes) => {
                 if bytes.len() != 32 {
                     Err(IronfishError::InvalidViewingKey)
@@ -105,7 +105,7 @@ impl OutgoingViewKey {
     /// Load a key from a string of hexadecimal digits
     pub fn from_hex(value: &str) -> Result<Self, IronfishError> {
         match hex_to_bytes(value) {
-            Err(()) => Err(IronfishError::InvalidViewingKey),
+            Err(_) => Err(IronfishError::InvalidViewingKey),
             Ok(bytes) => {
                 if bytes.len() != 32 {
                     Err(IronfishError::InvalidViewingKey)

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -4,8 +4,6 @@
 use bellman::groth16;
 use bls12_381::Bls12;
 
-mod serializing;
-
 pub mod assets;
 pub mod errors;
 pub mod keys;
@@ -16,6 +14,7 @@ pub mod nacl;
 pub mod note;
 pub mod rolling_filter;
 pub mod sapling_bls12;
+pub mod serializing;
 pub mod transaction;
 pub mod util;
 pub mod witness;

--- a/ironfish-rust/src/serializing.rs
+++ b/ironfish-rust/src/serializing.rs
@@ -44,7 +44,7 @@ pub(crate) fn read_scalar<F: PrimeField, R: io::Read>(mut reader: R) -> Result<F
 }
 
 /// Output the bytes as a hexadecimal String
-pub(crate) fn bytes_to_hex(bytes: &[u8]) -> String {
+pub fn bytes_to_hex(bytes: &[u8]) -> String {
     bytes
         .iter()
         .map(|b| format!("{:02x}", b))
@@ -53,12 +53,12 @@ pub(crate) fn bytes_to_hex(bytes: &[u8]) -> String {
 }
 
 /// Output the hexadecimal String as bytes
-pub(crate) fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, ()> {
+pub fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, IronfishError> {
     let mut bite_iterator = hex.as_bytes().iter().map(|b| match b {
         b'0'..=b'9' => Ok(b - b'0'),
         b'a'..=b'f' => Ok(b - b'a' + 10),
         b'A'..=b'F' => Ok(b - b'A' + 10),
-        _ => Err(()),
+        _ => Err(IronfishError::InvalidData),
     });
     let mut bytes = Vec::new();
     let mut high = bite_iterator.next();
@@ -67,7 +67,7 @@ pub(crate) fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, ()> {
         match (high, low) {
             (Some(Ok(h)), Some(Ok(l))) => bytes.push(h << 4 | l),
             (None, None) => break,
-            _ => return Err(()),
+            _ => return Err(IronfishError::InvalidData),
         }
         high = bite_iterator.next();
         low = bite_iterator.next();


### PR DESCRIPTION
## Summary

Since we already have these functions, we can skip using the crate. It's not a huge win since the package is still used in some sub-dependencies, but one less thing to worry about later (version conflicts, etc).

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
