### PR TITLE
refactor(rust): s/`GENERATOR_SIZE`/`MEMO_SIZE` when encrypting note

### DIFF
--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -243,8 +243,8 @@ impl<'a> Note {
         );
         index += AMOUNT_VALUE_SIZE;
 
-        bytes_to_encrypt[index..(index + GENERATOR_SIZE)].copy_from_slice(&self.memo.0[..]);
-        index += GENERATOR_SIZE;
+        bytes_to_encrypt[index..(index + MEMO_SIZE)].copy_from_slice(&self.memo.0[..]);
+        index += MEMO_SIZE;
 
         bytes_to_encrypt[index..].copy_from_slice(&self.asset_generator.to_bytes());
         let mut encrypted_bytes = [0; ENCRYPTED_NOTE_SIZE + aead::MAC_SIZE];


### PR DESCRIPTION
## Summary

This technically works since both constants have the same value, but refactor to use the accurate memo variable.

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
