### PR TITLE
feat(rust-nodejs): Add `note.asset_identifier()`

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -84,6 +84,8 @@ export class Note {
    * the proof in any way.
    */
   memo(): string
+  /** Asset identifier associated with this note */
+  assetIdentifier(): Buffer
   /**
    * Compute the nullifier for this note, given the private key of its owner.
    *

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -67,6 +67,12 @@ impl NativeNote {
         self.note.memo().to_string()
     }
 
+    /// Asset identifier associated with this note
+    #[napi]
+    pub fn asset_identifier(&self) -> Buffer {
+        Buffer::from(&self.note.asset_identifier()[..])
+    }
+
     /// Compute the nullifier for this note, given the private key of its owner.
     ///
     /// The nullifier is a series of bytes that is published by the note owner


### PR DESCRIPTION
## Summary

Update NAPI bindings and expose note's asset identifier 

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
