### PR TITLE
feat(rust-nodejs): Add `transaction.mint` and `transaction.burn`

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -114,6 +114,10 @@ export class Transaction {
   receive(note: Note): void
   /** Spend the note owned by spender_hex_key at the given witness location. */
   spend(note: Note, witness: object): void
+  /** Mint a new asset with a given value as part of this transaction. */
+  mint(asset: Asset, value: bigint): void
+  /** Burn some supply of a given asset and value as part of this transaction. */
+  burn(asset: Asset, value: bigint): void
   /**
    * Special case for posting a miners fee transaction. Miner fee transactions
    * are unique in that they generate currency. They do not have any spends

--- a/ironfish-rust-nodejs/src/structs/asset.rs
+++ b/ironfish-rust-nodejs/src/structs/asset.rs
@@ -16,7 +16,7 @@ pub const NATIVE_ASSET_LENGTH: u32 = ASSET_LENGTH as u32;
 
 #[napi(js_name = "Asset")]
 pub struct NativeAsset {
-    asset: Asset,
+    pub(crate) asset: Asset,
 }
 
 #[napi]

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -18,7 +18,7 @@ use crate::to_napi_err;
 use super::note::NativeNote;
 use super::spend_proof::NativeSpendDescription;
 use super::witness::JsWitness;
-use super::ENCRYPTED_NOTE_LENGTH;
+use super::{NativeAsset, ENCRYPTED_NOTE_LENGTH};
 
 #[napi(js_name = "TransactionPosted")]
 pub struct NativeTransactionPosted {
@@ -171,6 +171,20 @@ impl NativeTransaction {
         };
 
         self.transaction.add_spend(note.note.clone(), &w);
+    }
+
+    /// Mint a new asset with a given value as part of this transaction.
+    #[napi]
+    pub fn mint(&mut self, asset: &NativeAsset, value: BigInt) {
+        let value_u64 = value.get_u64().1;
+        self.transaction.add_mint(asset.asset, value_u64)
+    }
+
+    /// Burn some supply of a given asset and value as part of this transaction.
+    #[napi]
+    pub fn burn(&mut self, asset: &NativeAsset, value: BigInt) {
+        let value_u64 = value.get_u64().1;
+        self.transaction.add_burn(asset.asset, value_u64)
     }
 
     /// Special case for posting a miners fee transaction. Miner fee transactions


### PR DESCRIPTION
## Summary

Expose NAPI methods to mint and burn assets so we can update these descriptions when building a transaction.

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
