### PR TITLE
implements 'get' on database in storage layer

### DIFF
--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -137,6 +137,15 @@ export interface IDatabase {
       SchemaValue<DatabaseSchema>
     >[],
   ): Promise<void>
+
+  /**
+   * Used to get a value from the database at a given key
+
+  * @param key - The key to fetch
+  *
+  * @returns resolves with the serialized value if found, or undefined if not found.
+  */
+  get(key: Readonly<SchemaKey<DatabaseSchema>>): Promise<Buffer | undefined>
 }
 
 export abstract class Database implements IDatabase {
@@ -166,6 +175,8 @@ export abstract class Database implements IDatabase {
       SchemaValue<DatabaseSchema>
     >[],
   ): Promise<void>
+
+  abstract get(key: Readonly<SchemaKey<DatabaseSchema>>): Promise<Buffer | undefined>
 
   protected abstract _createStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -145,7 +145,7 @@ export interface IDatabase {
   *
   * @returns resolves with the serialized value if found, or undefined if not found.
   */
-  get(key: Readonly<SchemaKey<DatabaseSchema>>): Promise<Buffer | undefined>
+  get(key: Readonly<Buffer>): Promise<Buffer | undefined>
 }
 
 export abstract class Database implements IDatabase {
@@ -176,7 +176,7 @@ export abstract class Database implements IDatabase {
     >[],
   ): Promise<void>
 
-  abstract get(key: Readonly<SchemaKey<DatabaseSchema>>): Promise<Buffer | undefined>
+  abstract get(key: Readonly<Buffer>): Promise<Buffer | undefined>
 
   protected abstract _createStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,

--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -31,6 +31,14 @@ import { LevelupBatch } from './batch'
 import { LevelupStore } from './store'
 import { LevelupTransaction } from './transaction'
 
+interface INotFoundError {
+  type: 'NotFoundError'
+}
+
+function isNotFoundError(error: unknown): error is INotFoundError {
+  return (error as INotFoundError)?.type === 'NotFoundError'
+}
+
 type MetaSchema = {
   key: string
   value: IJsonSerializable
@@ -176,6 +184,24 @@ export class LevelupDatabase extends Database {
     }
 
     return batch.commit()
+  }
+
+  async get(key: Readonly<SchemaKey<DatabaseSchema>>): Promise<Buffer | undefined> {
+    try {
+      const data = (await this.levelup.get(key)) as unknown
+
+      if (!(data instanceof Buffer)) {
+        return undefined
+      }
+
+      return data
+    } catch (error: unknown) {
+      if (isNotFoundError(error)) {
+        return undefined
+      }
+
+      throw error
+    }
   }
 
   async getVersion(): Promise<number> {

--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -186,7 +186,7 @@ export class LevelupDatabase extends Database {
     return batch.commit()
   }
 
-  async get(key: Readonly<SchemaKey<DatabaseSchema>>): Promise<Buffer | undefined> {
+  async get(key: Readonly<Buffer>): Promise<Buffer | undefined> {
     try {
       const data = (await this.levelup.get(key)) as unknown
 

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -20,14 +20,6 @@ import { LevelupTransaction } from './transaction'
 
 const ENABLE_TRANSACTIONS = true
 
-interface INotFoundError {
-  type: 'NotFoundError'
-}
-
-function isNotFoundError(error: unknown): error is INotFoundError {
-  return (error as INotFoundError)?.type === 'NotFoundError'
-}
-
 export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<Schema> {
   db: LevelupDatabase
 
@@ -60,21 +52,13 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
       return transaction.get(this, key)
     }
 
-    try {
-      const data = (await this.db.levelup.get(encodedKey)) as unknown
-      if (data === undefined) {
-        return undefined
-      }
-      if (!(data instanceof Buffer)) {
-        return undefined
-      }
-      return this.valueEncoding.deserialize(data)
-    } catch (error: unknown) {
-      if (isNotFoundError(error)) {
-        return undefined
-      }
-      throw error
+    const data = await this.db.get(encodedKey)
+
+    if (data === undefined) {
+      return undefined
     }
+
+    return this.valueEncoding.deserialize(data)
   }
 
   async *getAllIter(


### PR DESCRIPTION
## Summary

the current implementation of the storage layer uses stores to interact with the database.

implements 'get' on the database to retrieve serialized values

changes the store implementation of get to be a wrapper around db.get that encodes the key and deserializes the value

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
