### PR TITLE
Remove BlockHeaderSerde.equals and BlockSerde.equals

### DIFF
--- a/ironfish/src/primitives/block.test.ts
+++ b/ironfish/src/primitives/block.test.ts
@@ -39,7 +39,7 @@ describe('Block', () => {
     expect(serialized).toMatchObject({ header: { timestamp: expect.any(Number) } })
 
     const deserialized = BlockSerde.deserialize(serialized)
-    expect(BlockSerde.equals(deserialized, block)).toBe(true)
+    expect(block.equals(deserialized)).toBe(true)
   })
 
   it('throws when deserializing invalid block', () => {

--- a/ironfish/src/primitives/block.ts
+++ b/ironfish/src/primitives/block.ts
@@ -116,7 +116,7 @@ export type SerializedCounts = { notes: number; nullifiers: number }
 
 export class BlockSerde {
   static equals(block1: Block, block2: Block): boolean {
-    if (!BlockHeaderSerde.equals(block1.header, block2.header)) {
+    if (!block1.header.equals(block2.header)) {
       return false
     }
 

--- a/ironfish/src/primitives/block.ts
+++ b/ironfish/src/primitives/block.ts
@@ -68,7 +68,25 @@ export class Block {
   }
 
   equals(block: Block): boolean {
-    return block === this || BlockSerde.equals(this, block)
+    if (block === this) {
+      return true
+    }
+
+    if (!this.header.equals(block.header)) {
+      return false
+    }
+
+    if (this.transactions.length !== block.transactions.length) {
+      return false
+    }
+
+    for (const [transaction1, transaction2] of zip(this.transactions, block.transactions)) {
+      if (!transaction1 || !transaction2 || !transaction1.equals(transaction2)) {
+        return false
+      }
+    }
+
+    return true
   }
 
   get minersFee(): Transaction {
@@ -115,24 +133,6 @@ export type SerializedBlock = {
 export type SerializedCounts = { notes: number; nullifiers: number }
 
 export class BlockSerde {
-  static equals(block1: Block, block2: Block): boolean {
-    if (!block1.header.equals(block2.header)) {
-      return false
-    }
-
-    if (block1.transactions.length !== block2.transactions.length) {
-      return false
-    }
-
-    for (const [transaction1, transaction2] of zip(block1.transactions, block2.transactions)) {
-      if (!transaction1 || !transaction2 || !transaction1.equals(transaction2)) {
-        return false
-      }
-    }
-
-    return true
-  }
-
   static serialize(block: Block): SerializedBlock {
     return {
       header: BlockHeaderSerde.serialize(block.header),

--- a/ironfish/src/primitives/blockheader.test.ts
+++ b/ironfish/src/primitives/blockheader.test.ts
@@ -91,9 +91,7 @@ describe('transactionMerkleRoot', () => {
   })
 })
 
-describe('BlockHeaderSerde', () => {
-  const serde = BlockHeaderSerde
-
+describe('BlockHeader', () => {
   it('checks equal block headers', () => {
     const header1 = new BlockHeader(
       5,
@@ -119,56 +117,66 @@ describe('BlockHeaderSerde', () => {
       Buffer.alloc(32),
     )
 
-    expect(serde.equals(header1, header2)).toBe(true)
+    expect(header1.equals(header2)).toBe(true)
 
     // sequence
     header2.sequence = 6
-    expect(serde.equals(header1, header2)).toBe(false)
+    expect(header1.equals(header2)).toBe(false)
     header2.sequence = header1.sequence
-    expect(serde.equals(header1, header2)).toBe(true)
+    expect(header1.equals(header2)).toBe(true)
 
     // note commitment
     header2.noteCommitment = Buffer.alloc(32, 'not  header')
-    expect(serde.equals(header1, header2)).toBe(false)
+    expect(header1.equals(header2)).toBe(false)
     header2.noteCommitment = header1.noteCommitment
-    expect(serde.equals(header1, header2)).toBe(true)
+    expect(header1.equals(header2)).toBe(true)
+
+    // note size
+    header2.noteSize = 7
+    expect(header1.equals(header2)).toBe(false)
+    header2.noteSize = header1.noteSize
+    expect(header1.equals(header2)).toBe(true)
 
     // nullifier commitment
     header2.nullifierCommitment.commitment = Buffer.alloc(32, 'not  header')
-    expect(serde.equals(header1, header2)).toBe(false)
+    expect(header1.equals(header2)).toBe(false)
     header2.nullifierCommitment.commitment = header1.nullifierCommitment.commitment
-    expect(serde.equals(header1, header2)).toBe(true)
+    expect(header1.equals(header2)).toBe(true)
 
     // nullifier size
     header2.nullifierCommitment.size = 7
-    expect(serde.equals(header1, header2)).toBe(false)
+    expect(header1.equals(header2)).toBe(false)
     header2.nullifierCommitment.size = header1.nullifierCommitment.size
-    expect(serde.equals(header1, header2)).toBe(true)
+    expect(header1.equals(header2)).toBe(true)
 
     // target
     header2.target = new Target(10)
-    expect(serde.equals(header1, header2)).toBe(false)
+    expect(header1.equals(header2)).toBe(false)
     header2.target = header1.target
-    expect(serde.equals(header1, header2)).toBe(true)
+    expect(header1.equals(header2)).toBe(true)
 
     // randomness
     header2.randomness = BigInt(19)
-    expect(serde.equals(header1, header2)).toBe(false)
+    expect(header1.equals(header2)).toBe(false)
     header2.randomness = header1.randomness
-    expect(serde.equals(header1, header2)).toBe(true)
+    expect(header1.equals(header2)).toBe(true)
 
     // timestamp
     header2.timestamp = new Date(1000)
-    expect(serde.equals(header1, header2)).toBe(false)
+    expect(header1.equals(header2)).toBe(false)
     header2.timestamp = header1.timestamp
-    expect(serde.equals(header1, header2)).toBe(true)
+    expect(header1.equals(header2)).toBe(true)
 
     // graffiti
     header2.graffiti = Buffer.alloc(32, 'a')
-    expect(serde.equals(header1, header2)).toBe(false)
+    expect(header1.equals(header2)).toBe(false)
     header2.graffiti = header1.graffiti
-    expect(serde.equals(header1, header2)).toBe(true)
+    expect(header1.equals(header2)).toBe(true)
   })
+})
+
+describe('BlockHeaderSerde', () => {
+  const serde = BlockHeaderSerde
 
   it('serializes and deserializes a block header', () => {
     const header = new BlockHeader(
@@ -185,7 +193,7 @@ describe('BlockHeaderSerde', () => {
 
     const serialized = serde.serialize(header)
     const deserialized = serde.deserialize(serialized)
-    expect(serde.equals(header, deserialized)).toBe(true)
+    expect(header.equals(deserialized)).toBe(true)
   })
 
   it('checks block is later than', () => {

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -253,7 +253,9 @@ export class BlockHeader {
 
   equals(other: BlockHeader): boolean {
     return (
-      this.noteSize === other.noteSize && this.recomputeHash().equals(other.recomputeHash())
+      this.noteSize === other.noteSize &&
+      this.work === other.work &&
+      this.recomputeHash().equals(other.recomputeHash())
     )
   }
 }

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -238,6 +238,7 @@ export class BlockHeader {
     this.hash = hash
     return hash
   }
+
   /**
    * Check whether the hash of this block is less than the target stored
    * within the block header. This is the primary proof of work function.
@@ -248,6 +249,12 @@ export class BlockHeader {
    */
   verifyTarget(): boolean {
     return Target.meets(new Target(this.recomputeHash()).asBigInt(), this.target)
+  }
+
+  equals(other: BlockHeader): boolean {
+    return (
+      this.noteSize === other.noteSize && this.recomputeHash().equals(other.recomputeHash())
+    )
   }
 }
 
@@ -270,23 +277,6 @@ export type SerializedBlockHeader = {
 }
 
 export class BlockHeaderSerde {
-  static equals(element1: BlockHeader, element2: BlockHeader): boolean {
-    return (
-      element1.sequence === element2.sequence &&
-      element1.noteCommitment.equals(element2.noteCommitment) &&
-      NullifierSerdeInstance.equals(
-        element1.nullifierCommitment.commitment,
-        element2.nullifierCommitment.commitment,
-      ) &&
-      element1.nullifierCommitment.size === element2.nullifierCommitment.size &&
-      element1.transactionCommitment.equals(element2.transactionCommitment) &&
-      element1.target.equals(element2.target) &&
-      element1.randomness === element2.randomness &&
-      element1.timestamp.getTime() === element2.timestamp.getTime() &&
-      element1.graffiti.equals(element2.graffiti)
-    )
-  }
-
   static serialize(header: BlockHeader): SerializedBlockHeader {
     const serialized = {
       sequence: header.sequence,

--- a/ironfish/src/testUtilities/matchers/blockchain.ts
+++ b/ironfish/src/testUtilities/matchers/blockchain.ts
@@ -4,7 +4,7 @@
 
 import diff from 'jest-diff'
 import { Blockchain } from '../../blockchain'
-import { Block, BlockSerde } from '../../primitives/block'
+import { Block } from '../../primitives/block'
 import { BlockHash } from '../../primitives/blockheader'
 import { Nullifier } from '../../primitives/nullifier'
 import { makeError, makeResult } from './utils'
@@ -40,16 +40,6 @@ function toEqualNullifier(self: Nullifier, other: Nullifier): jest.CustomMatcher
   return makeError(error, `Expected two serde elements to match, but they didn't`)
 }
 
-function toEqualBlock(self: Block, other: Block): jest.CustomMatcherResult {
-  let error: string | null = null
-
-  if (!BlockSerde.equals(self, other)) {
-    error = `Blocks do not match:\n\nDifference:\n\n${String(diff(self, other))}`
-  }
-
-  return makeError(error, `Expected two blocks to match, but they didn't`)
-}
-
 async function toAddBlock(self: Blockchain, other: Block): Promise<jest.CustomMatcherResult> {
   const result = await self.addBlock(other)
 
@@ -63,7 +53,6 @@ async function toAddBlock(self: Blockchain, other: Block): Promise<jest.CustomMa
 expect.extend({
   toEqualHash: toEqualHash,
   toEqualNullifier: toEqualNullifier,
-  toEqualBlock: toEqualBlock,
   toAddBlock: toAddBlock,
 })
 
@@ -72,7 +61,6 @@ declare global {
     interface Matchers<R> {
       toEqualNullifier(other: Nullifier): R
       toEqualHash(other: BlockHash | null | undefined): R
-      toEqualBlock(block: Block): Promise<R>
       toAddBlock(block: Block): Promise<R>
     }
   }


### PR DESCRIPTION
## Summary
`BlockHeaderSerde.equals()` and `BlockHeader.equals()` are only used in tests. We also don't need to be checking every field in the block header because we can re-use the hash for that.

## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
