### PR TITLE
feat(ironfish,rust-nodejs): Update create transaction handler to include mints and burns

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -51,8 +51,11 @@ export class RollingFilter {
 }
 export type NativeAsset = Asset
 export class Asset {
-  constructor(jsBytes: Buffer)
+  constructor(ownerPrivateKey: string, name: string, metadata: string)
+  static nativeIdentifier(): Buffer
+  identifier(): Buffer
   serialize(): Buffer
+  static deserialize(jsBytes: Buffer): NativeAsset
 }
 export type NativeNoteEncrypted = NoteEncrypted
 export class NoteEncrypted {

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -61,6 +61,12 @@ export class Note {
     return BufferUtils.toHuman(this._memo)
   }
 
+  assetIdentifier(): Buffer {
+    const identifier = this.takeReference().assetIdentifier()
+    this.returnReference()
+    return identifier
+  }
+
   nullifier(ownerPrivateKey: string, position: bigint): Buffer {
     const buf = this.takeReference().nullifier(ownerPrivateKey, position)
     this.returnReference()

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -81,7 +81,7 @@ export class Transaction {
       // proof
       reader.seek(192)
 
-      const asset = new Asset(reader.readBytes(ASSET_LENGTH))
+      const asset = Asset.deserialize(reader.readBytes(ASSET_LENGTH))
       const value = reader.readU8()
 
       // value commitment
@@ -95,7 +95,7 @@ export class Transaction {
     })
 
     this._burns = Array.from({ length: _burnsLength }, () => {
-      const asset = new Asset(reader.readBytes(ASSET_LENGTH))
+      const asset = Asset.deserialize(reader.readBytes(ASSET_LENGTH))
       const value = reader.readU8()
 
       // value commitment

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -164,6 +164,8 @@ export class WorkerPool {
       expirationSequence,
       spendsWithSerializedNotes,
       receives,
+      [],
+      [],
     )
 
     const response = await this.execute(request).result()

--- a/ironfish/src/workerPool/tasks/__fixtures__/createTransaction.test.slow.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/createTransaction.test.slow.ts.fixture
@@ -12,5 +12,15 @@
       "type": "Buffer",
       "data": "base64:AAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbMqI/////wAAAACqGr82dmfXzfYrox11oq8DkcEbUReaHK2IlxiouR61FOlR49yF8+hef5MpSw6p6V6KcP181Q1GFXwY0x0PwfWb+Jb7d9j7xKgIslJ11NHuWTKML9as99SKI76ZRSE//n0AhpfTj0SXpRgrwrs8LPFf5Cyt7d8vnUvysy1jLLth+1DCQ9lCmMGBtOyrB3B3vC6Y6r2ABUXxNNz+RLZLtWyt2CGZ7yjV8PwSIKRuCB7g5Vdm99V2+wmZYpXcfogBK4P6OIU3cIX6lYm3QnC2OzFcZCd8T3xghMlZwt7TNIQYMi/urZSLhYvEkU+CGkGziToBg0Vbt4YGEjtiLnaTjhYWexIenb7Ce2ivt7/WGGG7HTm1jLoQwgncxe2vs8kYys3RnsN0qheXuDd96uriK+c18o8ibXgpTgIqXOPOP+n1e+MG8aAkEmOiutL6OknZzs/2KZzW7W7mq1jMcnlIa/fhHO1y/olHIDYGGstkHsa5fOXPUWcMqQgz/nQLIGUlu+Doh1udjGvp/FCJv08IBUPX4kkAa8a6uOpCZWFuc3RhbGsgbm90ZSBlbmNyeXB0aW9uIG1pbmVyIGtleTAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMJMjTeGeMXiVd1gldIg2oQpjWUG9IH4FNdAx1Ch3yx+Z+mf4tFbpAGKLRDLbK6yCNg9t1iiZIkc6LWrpIJRVbAg="
     }
+  ],
+  "CreateTransactionRequest serializes the object into a buffer and deserializes to the original object": [
+    {
+      "id": "204b77dc-878c-4f79-8c2b-99fe6a4986f4",
+      "name": "test",
+      "spendingKey": "c3c7b90f8261e4cb550a32f9b0517691a2d67d64762a99b14992ca9d271e3d4d",
+      "incomingViewKey": "2be3f34197ee7f1d74f830b4663590f6dfa5d66d362f0d65fdad8992a5ba8c02",
+      "outgoingViewKey": "01cb847a4b02cb7881cede0eefd85c4b78236387560175c46b147b019a1be3d0",
+      "publicAddress": "5394eff3e4b94bf24b75a0a4b408280b8fa98e0799d4d7db589fdb089c817c1a"
+    }
   ]
 }

--- a/ironfish/src/workerPool/tasks/createTransaction.test.slow.ts
+++ b/ironfish/src/workerPool/tasks/createTransaction.test.slow.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { TransactionPosted } from '@ironfish/rust-nodejs'
+import { Asset, TransactionPosted } from '@ironfish/rust-nodejs'
+import { BufferMap } from 'buffer-map'
 import { Assert } from '../../assert'
 import { NoteLeafEncoding } from '../../merkletree/database/leaves'
 import { NodeEncoding } from '../../merkletree/database/nodes'
@@ -57,7 +58,12 @@ async function makeStrategyTree({
 type ThenArg<T> = T extends PromiseLike<infer U> ? U : T
 
 describe('CreateTransactionRequest', () => {
-  it('serializes the object into a buffer and deserializes to the original object', () => {
+  const nodeTest = createNodeTest()
+
+  it('serializes the object into a buffer and deserializes to the original object', async () => {
+    const account = await useAccountFixture(nodeTest.wallet)
+    const mintAsset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+    const burnAsset = new Asset(account.spendingKey, 'burn-asset', 'metadata')
     const request = new CreateTransactionRequest(
       '',
       BigInt(1),
@@ -80,6 +86,18 @@ describe('CreateTransactionRequest', () => {
           publicAddress: '',
           amount: BigInt(5),
           memo: '👁️🏃🐟',
+        },
+      ],
+      [
+        {
+          asset: mintAsset,
+          value: BigInt(10),
+        },
+      ],
+      [
+        {
+          asset: burnAsset,
+          value: BigInt(2),
         },
       ],
     )
@@ -110,7 +128,13 @@ describe('CreateTransactionTask', () => {
   describe('execute', () => {
     it('creates the transaction', async () => {
       const account = await useAccountFixture(nodeTest.wallet)
+      const asset = new Asset(account.spendingKey, 'test-asset', 'fake-metadata')
+      const mintValue = BigInt(10)
+      const burnValue = BigInt(2)
+      const fee = BigInt(1)
+
       const minerTransaction = await useMinersTxFixture(nodeTest.wallet, account)
+      const balance = await account.getUnconfirmedBalance()
 
       const spendNote = minerTransaction.getNote(0).decryptNoteForOwner(account.incomingViewKey)
       Assert.isNotUndefined(spendNote)
@@ -125,7 +149,7 @@ describe('CreateTransactionTask', () => {
       const task = new CreateTransactionTask()
       const request = new CreateTransactionRequest(
         account.spendingKey,
-        BigInt(1),
+        fee,
         15,
         [
           {
@@ -136,6 +160,18 @@ describe('CreateTransactionTask', () => {
           },
         ],
         [{ publicAddress: account.publicAddress, amount: BigInt(1), memo: '' }],
+        [
+          {
+            asset,
+            value: mintValue,
+          },
+        ],
+        [
+          {
+            asset,
+            value: burnValue,
+          },
+        ],
       )
 
       const response = task.execute(request)
@@ -145,11 +181,27 @@ describe('CreateTransactionTask', () => {
         Buffer.from(response.serializedTransactionPosted),
       )
       expect(transactionPosted.verify()).toBe(true)
-      expect(transactionPosted.notesLength()).toBe(2)
-      const decryptedNote = new NoteEncrypted(transactionPosted.getNote(0)).decryptNoteForOwner(
-        account.incomingViewKey,
-      )
-      expect(decryptedNote).toBeDefined()
+      expect(transactionPosted.notesLength()).toBe(3)
+
+      const outputValuesByAssetIdentifier = new BufferMap<bigint>()
+      for (let i = 0; i < transactionPosted.notesLength(); i++) {
+        const decryptedNote = new NoteEncrypted(
+          transactionPosted.getNote(i),
+        ).decryptNoteForOwner(account.incomingViewKey)
+        Assert.isNotUndefined(decryptedNote)
+
+        const identifier = decryptedNote.assetIdentifier()
+        const value = outputValuesByAssetIdentifier.get(identifier) || BigInt(0)
+        outputValuesByAssetIdentifier.set(identifier, value + decryptedNote.value())
+      }
+
+      const nativeAssetValue = outputValuesByAssetIdentifier.get(Asset.nativeIdentifier())
+      Assert.isNotUndefined(nativeAssetValue)
+      expect(nativeAssetValue).toEqual(balance - fee)
+
+      const mintedAssetValue = outputValuesByAssetIdentifier.get(asset.identifier())
+      Assert.isNotUndefined(mintedAssetValue)
+      expect(mintedAssetValue).toEqual(mintValue - burnValue)
     })
   })
 })


### PR DESCRIPTION
## Summary

* Update the create transaction worker pool message to accept an array of mints and an array of burns
* Expose asset identifier and native asset identifier from NAPI
* Expose asset identifier associated with Note

## Testing Plan

Add unit test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
