### PR TITLE
implements 'put' on database in storage layer

### DIFF
--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -146,6 +146,16 @@ export interface IDatabase {
   * @returns resolves with the serialized value if found, or undefined if not found.
   */
   get(key: Readonly<Buffer>): Promise<Buffer | undefined>
+
+  /**
+   * Put a value into the store with the given key.
+
+  * @param key - The key to insert
+  * @param value - The value to insert
+  *
+  * @returns A promise that resolves when the operation has been executed.
+  */
+  put(key: Readonly<Buffer>, value: Buffer): Promise<void>
 }
 
 export abstract class Database implements IDatabase {
@@ -177,6 +187,8 @@ export abstract class Database implements IDatabase {
   ): Promise<void>
 
   abstract get(key: Readonly<Buffer>): Promise<Buffer | undefined>
+
+  abstract put(key: Readonly<Buffer>, value: Buffer): Promise<void>
 
   protected abstract _createStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,

--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -204,6 +204,10 @@ export class LevelupDatabase extends Database {
     }
   }
 
+  async put(key: Readonly<Buffer>, value: Buffer): Promise<void> {
+    await this.levelup.put(key, value)
+  }
+
   async getVersion(): Promise<number> {
     let current = await this.metaStore.get('version')
 

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -189,7 +189,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     }
 
     const [encodedKey, encodedValue] = this.encode(key, value)
-    await this.db.levelup.put(encodedKey, encodedValue)
+    await this.db.put(encodedKey, encodedValue)
   }
 
   async add(
@@ -212,7 +212,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     }
 
     const [encodedKey, encodedValue] = this.encode(key, value)
-    await this.db.levelup.put(encodedKey, encodedValue)
+    await this.db.put(encodedKey, encodedValue)
   }
 
   async del(key: SchemaKey<Schema>, transaction?: IDatabaseTransaction): Promise<void> {


### PR DESCRIPTION
## Summary

having 'put' implemented on the database ensures that we can write to a database without needed to write through a database store.

changes the store implementation to utilize db.put

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
