### PR TITLE
Move IDatabaseStore.getAllIter() to IDatabase

### DIFF
--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -6,7 +6,6 @@ import { BatchOperation, IDatabaseBatch } from './batch'
 import { IDatabaseStore, IDatabaseStoreOptions } from './store'
 import { IDatabaseTransaction } from './transaction'
 import {
-  DatabaseIterOptions,
   DatabaseKeyRange,
   DatabaseOptions,
   DatabaseSchema,
@@ -159,7 +158,7 @@ export interface IDatabase {
   put(key: Readonly<Buffer>, value: Buffer): Promise<void>
 
   /* Get an [[`AsyncGenerator`]] that yields all of the key/value pairs in the IDatabase */
-  getAllIter(options?: DatabaseIterOptions): AsyncGenerator<[Buffer, Buffer]>
+  getAllIter(range?: DatabaseKeyRange): AsyncGenerator<[Buffer, Buffer]>
 }
 
 export abstract class Database implements IDatabase {
@@ -194,7 +193,7 @@ export abstract class Database implements IDatabase {
 
   abstract put(key: Readonly<Buffer>, value: Buffer): Promise<void>
 
-  abstract getAllIter(options?: DatabaseIterOptions): AsyncGenerator<[Buffer, Buffer]>
+  abstract getAllIter(range?: DatabaseKeyRange): AsyncGenerator<[Buffer, Buffer]>
 
   protected abstract _createStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -6,6 +6,7 @@ import { BatchOperation, IDatabaseBatch } from './batch'
 import { IDatabaseStore, IDatabaseStoreOptions } from './store'
 import { IDatabaseTransaction } from './transaction'
 import {
+  DatabaseIterOptions,
   DatabaseKeyRange,
   DatabaseOptions,
   DatabaseSchema,
@@ -156,6 +157,9 @@ export interface IDatabase {
   * @returns A promise that resolves when the operation has been executed.
   */
   put(key: Readonly<Buffer>, value: Buffer): Promise<void>
+
+  /* Get an [[`AsyncGenerator`]] that yields all of the key/value pairs in the IDatabase */
+  getAllIter(options?: DatabaseIterOptions): AsyncGenerator<[Buffer, Buffer]>
 }
 
 export abstract class Database implements IDatabase {
@@ -189,6 +193,8 @@ export abstract class Database implements IDatabase {
   abstract get(key: Readonly<Buffer>): Promise<Buffer | undefined>
 
   abstract put(key: Readonly<Buffer>, value: Buffer): Promise<void>
+
+  abstract getAllIter(options?: DatabaseIterOptions): AsyncGenerator<[Buffer, Buffer]>
 
   protected abstract _createStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,

--- a/ironfish/src/storage/database/types.ts
+++ b/ironfish/src/storage/database/types.ts
@@ -4,16 +4,11 @@
 
 import { IJsonSerializable } from '../../serde'
 
-export interface DatabaseIterOptions {
+export interface DatabaseKeyRange {
   gt?: Buffer
   gte?: Buffer
   lt?: Buffer
   lte?: Buffer
-}
-
-export interface DatabaseKeyRange {
-  gte: Buffer
-  lt: Buffer
 }
 
 export type DatabaseKey =

--- a/ironfish/src/storage/database/types.ts
+++ b/ironfish/src/storage/database/types.ts
@@ -4,6 +4,13 @@
 
 import { IJsonSerializable } from '../../serde'
 
+export interface DatabaseIterOptions {
+  gt?: Buffer
+  gte?: Buffer
+  lt?: Buffer
+  lte?: Buffer
+}
+
 export interface DatabaseKeyRange {
   gte: Buffer
   lt: Buffer

--- a/ironfish/src/storage/database/utils.test.ts
+++ b/ironfish/src/storage/database/utils.test.ts
@@ -27,5 +27,41 @@ describe('StorageUtils', () => {
       expect(range.lt[0]).toBe(2)
       expect(range.lt[1]).toBe(5)
     })
+
+    it('should check buffer range', () => {
+      const b = (v: number) => Buffer.alloc(1, v)
+
+      // 0 <= 1 <= 2
+      expect(
+        StorageUtils.isInRange(b(1), {
+          gte: b(0),
+          lte: b(2),
+        }),
+      ).toBe(true)
+
+      // 0 < 1 < 2
+      expect(
+        StorageUtils.isInRange(b(1), {
+          gt: b(0),
+          lt: b(2),
+        }),
+      ).toBe(true)
+
+      // 0 < 0 < 2
+      expect(
+        StorageUtils.isInRange(b(0), {
+          gt: b(0),
+          lt: b(2),
+        }),
+      ).toBe(false)
+
+      // 0 < 2 < 2
+      expect(
+        StorageUtils.isInRange(b(2), {
+          gt: b(0),
+          lt: b(2),
+        }),
+      ).toBe(false)
+    })
   })
 })

--- a/ironfish/src/storage/database/utils.ts
+++ b/ironfish/src/storage/database/utils.ts
@@ -4,7 +4,7 @@
 
 import { Assert } from '../../assert'
 import { BufferUtils } from '../../utils'
-import { DatabaseKeyRange } from './types'
+import { DatabaseIterOptions, DatabaseKeyRange } from './types'
 
 /**
  * In non relational KV stores, to emulate 'startswith' you often need
@@ -44,4 +44,31 @@ export function getPrefixesKeyRange(
   return { gte, lt }
 }
 
-export const StorageUtils = { getPrefixKeyRange, getPrefixesKeyRange }
+/**
+ * Return true if the buffer matches the key ranges in DatabaseIterOptions
+ */
+function isInRange(buffer: Buffer, range: DatabaseIterOptions): boolean {
+  if (range.gt && range.gt.compare(buffer) >= 0) {
+    return false
+  }
+
+  if (range.gte && range.gte.compare(buffer) > 0) {
+    return false
+  }
+
+  if (range.lt && range.lt.compare(buffer) <= 0) {
+    return false
+  }
+
+  if (range.lte && range.lte.compare(buffer) < 0) {
+    return false
+  }
+
+  return true
+}
+
+function hasPrefix(buffer: Buffer, prefix: Buffer): boolean {
+  return buffer.slice(0, prefix.byteLength).equals(prefix)
+}
+
+export const StorageUtils = { getPrefixKeyRange, getPrefixesKeyRange, hasPrefix, isInRange }

--- a/ironfish/src/storage/database/utils.ts
+++ b/ironfish/src/storage/database/utils.ts
@@ -4,7 +4,7 @@
 
 import { Assert } from '../../assert'
 import { BufferUtils } from '../../utils'
-import { DatabaseIterOptions, DatabaseKeyRange } from './types'
+import { DatabaseKeyRange } from './types'
 
 /**
  * In non relational KV stores, to emulate 'startswith' you often need
@@ -13,7 +13,7 @@ import { DatabaseIterOptions, DatabaseKeyRange } from './types'
  * you would query "gte('App') && lte('App' + 'ff')" Which would return
  * 'Apple' and 'Application'
  */
-export function getPrefixKeyRange(prefix: Buffer): DatabaseKeyRange {
+export function getPrefixKeyRange(prefix: Buffer): { gte: Buffer; lt: Buffer } {
   const gte = Buffer.alloc(prefix.byteLength)
   const lt = Buffer.alloc(prefix.byteLength)
 
@@ -29,7 +29,7 @@ export function getPrefixKeyRange(prefix: Buffer): DatabaseKeyRange {
 export function getPrefixesKeyRange(
   start: Readonly<Buffer>,
   end: Readonly<Buffer>,
-): DatabaseKeyRange {
+): { gte: Buffer; lt: Buffer } {
   Assert.isEqual(start.byteLength, end.byteLength, `Start and end must have equal byte length`)
 
   const gte = Buffer.alloc(start.byteLength)
@@ -45,9 +45,36 @@ export function getPrefixesKeyRange(
 }
 
 /**
- * Return true if the buffer matches the key ranges in DatabaseIterOptions
+ * Used to prepend a prefix to each key range condition
+ *
+ * Useful when you want to limit a range even further to a prefix
  */
-function isInRange(buffer: Buffer, range: DatabaseIterOptions): boolean {
+export function addPrefixToRange(range: DatabaseKeyRange, prefix: Buffer): DatabaseKeyRange {
+  const prefixed: DatabaseKeyRange = {}
+
+  if (range.gt) {
+    prefixed.gt = Buffer.concat([prefix, range.gt])
+  }
+
+  if (range.gte) {
+    prefixed.gte = Buffer.concat([prefix, range.gte])
+  }
+
+  if (range.lt) {
+    prefixed.lt = Buffer.concat([prefix, range.lt])
+  }
+
+  if (range.lte) {
+    prefixed.lte = Buffer.concat([prefix, range.lte])
+  }
+
+  return prefixed
+}
+
+/**
+ * Return true if the buffer matches the key ranges
+ */
+function isInRange(buffer: Buffer, range: DatabaseKeyRange): boolean {
   if (range.gt && range.gt.compare(buffer) >= 0) {
     return false
   }
@@ -71,4 +98,10 @@ function hasPrefix(buffer: Buffer, prefix: Buffer): boolean {
   return buffer.slice(0, prefix.byteLength).equals(prefix)
 }
 
-export const StorageUtils = { getPrefixKeyRange, getPrefixesKeyRange, hasPrefix, isInRange }
+export const StorageUtils = {
+  addPrefixToRange,
+  getPrefixKeyRange,
+  getPrefixesKeyRange,
+  hasPrefix,
+  isInRange,
+}

--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -27,6 +27,7 @@ import {
   DatabaseIsOpenError,
   DatabaseVersionError,
 } from '../database/errors'
+import { DatabaseIterOptions } from '../database/types'
 import { LevelupBatch } from './batch'
 import { LevelupStore } from './store'
 import { LevelupTransaction } from './transaction'
@@ -206,6 +207,20 @@ export class LevelupDatabase extends Database {
 
   async put(key: Readonly<Buffer>, value: Buffer): Promise<void> {
     await this.levelup.put(key, value)
+  }
+
+  async *getAllIter(options?: DatabaseIterOptions): AsyncGenerator<[Buffer, Buffer]> {
+    const stream = this.levelup.createReadStream(options)
+
+    // The return type for createReadStream is wrong
+    const iter = stream as unknown as AsyncIterable<{
+      key: Buffer
+      value: Buffer
+    }>
+
+    for await (const { key, value } of iter) {
+      yield [key, value]
+    }
   }
 
   async getVersion(): Promise<number> {

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -70,10 +70,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     keyRange?: DatabaseKeyRange,
   ): AsyncGenerator<[SchemaKey<Schema>, SchemaValue<Schema>]> {
     if (keyRange) {
-      keyRange = {
-        gte: Buffer.concat([this.prefixBuffer, keyRange.gte]),
-        lt: Buffer.concat([this.prefixBuffer, keyRange.lt]),
-      }
+      keyRange = StorageUtils.addPrefixToRange(keyRange, this.prefixBuffer)
     } else {
       keyRange = this.allKeysRange
     }
@@ -162,10 +159,9 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     }
 
     if (keyRange) {
-      keyRange = {
-        gte: Buffer.concat([this.prefixBuffer, keyRange.gte]),
-        lt: Buffer.concat([this.prefixBuffer, keyRange.lt]),
-      }
+      keyRange = StorageUtils.addPrefixToRange(keyRange, this.prefixBuffer)
+    } else {
+      keyRange = this.allKeysRange
     }
 
     await this.db.levelup.clear(keyRange ?? this.allKeysRange)


### PR DESCRIPTION
## Summary

This moves core underlying DB iterator into the DB itself from the store.

## Testing Plan

Added tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
