### PR TITLE
Move IDatabaseStore functionality into IDatabase

### DIFF
--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -137,6 +137,15 @@ export interface IDatabase {
       SchemaValue<DatabaseSchema>
     >[],
   ): Promise<void>
+
+  /**
+   * Used to get a value from the database at a given key
+
+  * @param key - The key to fetch
+  *
+  * @returns resolves with the serialized value if found, or undefined if not found.
+  */
+  get(key: Readonly<Buffer>): Promise<Buffer | undefined>
 }
 
 export abstract class Database implements IDatabase {
@@ -166,6 +175,8 @@ export abstract class Database implements IDatabase {
       SchemaValue<DatabaseSchema>
     >[],
   ): Promise<void>
+
+  abstract get(key: Readonly<Buffer>): Promise<Buffer | undefined>
 
   protected abstract _createStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -156,6 +156,9 @@ export interface IDatabase {
   * @returns A promise that resolves when the operation has been executed.
   */
   put(key: Readonly<Buffer>, value: Buffer): Promise<void>
+
+  /* Get an [[`AsyncGenerator`]] that yields all of the key/value pairs in the IDatabase */
+  getAllIter(range?: DatabaseKeyRange): AsyncGenerator<[Buffer, Buffer]>
 }
 
 export abstract class Database implements IDatabase {
@@ -189,6 +192,8 @@ export abstract class Database implements IDatabase {
   abstract get(key: Readonly<Buffer>): Promise<Buffer | undefined>
 
   abstract put(key: Readonly<Buffer>, value: Buffer): Promise<void>
+
+  abstract getAllIter(range?: DatabaseKeyRange): AsyncGenerator<[Buffer, Buffer]>
 
   protected abstract _createStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -146,6 +146,16 @@ export interface IDatabase {
   * @returns resolves with the serialized value if found, or undefined if not found.
   */
   get(key: Readonly<Buffer>): Promise<Buffer | undefined>
+
+  /**
+   * Put a value into the store with the given key.
+
+  * @param key - The key to insert
+  * @param value - The value to insert
+  *
+  * @returns A promise that resolves when the operation has been executed.
+  */
+  put(key: Readonly<Buffer>, value: Buffer): Promise<void>
 }
 
 export abstract class Database implements IDatabase {
@@ -177,6 +187,8 @@ export abstract class Database implements IDatabase {
   ): Promise<void>
 
   abstract get(key: Readonly<Buffer>): Promise<Buffer | undefined>
+
+  abstract put(key: Readonly<Buffer>, value: Buffer): Promise<void>
 
   protected abstract _createStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,

--- a/ironfish/src/storage/database/types.ts
+++ b/ironfish/src/storage/database/types.ts
@@ -5,8 +5,10 @@
 import { IJsonSerializable } from '../../serde'
 
 export interface DatabaseKeyRange {
-  gte: Buffer
-  lt: Buffer
+  gt?: Buffer
+  gte?: Buffer
+  lt?: Buffer
+  lte?: Buffer
 }
 
 export type DatabaseKey =

--- a/ironfish/src/storage/database/utils.test.ts
+++ b/ironfish/src/storage/database/utils.test.ts
@@ -27,5 +27,41 @@ describe('StorageUtils', () => {
       expect(range.lt[0]).toBe(2)
       expect(range.lt[1]).toBe(5)
     })
+
+    it('should check buffer range', () => {
+      const b = (v: number) => Buffer.alloc(1, v)
+
+      // 0 <= 1 <= 2
+      expect(
+        StorageUtils.isInRange(b(1), {
+          gte: b(0),
+          lte: b(2),
+        }),
+      ).toBe(true)
+
+      // 0 < 1 < 2
+      expect(
+        StorageUtils.isInRange(b(1), {
+          gt: b(0),
+          lt: b(2),
+        }),
+      ).toBe(true)
+
+      // 0 < 0 < 2
+      expect(
+        StorageUtils.isInRange(b(0), {
+          gt: b(0),
+          lt: b(2),
+        }),
+      ).toBe(false)
+
+      // 0 < 2 < 2
+      expect(
+        StorageUtils.isInRange(b(2), {
+          gt: b(0),
+          lt: b(2),
+        }),
+      ).toBe(false)
+    })
   })
 })

--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -204,6 +204,10 @@ export class LevelupDatabase extends Database {
     }
   }
 
+  async put(key: Readonly<Buffer>, value: Buffer): Promise<void> {
+    await this.levelup.put(key, value)
+  }
+
   async getVersion(): Promise<number> {
     let current = await this.metaStore.get('version')
 

--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -27,6 +27,7 @@ import {
   DatabaseIsOpenError,
   DatabaseVersionError,
 } from '../database/errors'
+import { DatabaseKeyRange } from '../database/types'
 import { LevelupBatch } from './batch'
 import { LevelupStore } from './store'
 import { LevelupTransaction } from './transaction'
@@ -125,9 +126,13 @@ export class LevelupDatabase extends Database {
   compact(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       if (this.db instanceof LevelDOWN) {
-        this.db.compactRange(DATABASE_ALL_KEY_RANGE.gte, DATABASE_ALL_KEY_RANGE.lt, (err) =>
-          err ? reject(err) : resolve(),
-        )
+        const start = DATABASE_ALL_KEY_RANGE.gte
+        const end = DATABASE_ALL_KEY_RANGE.lt
+
+        Assert.isNotUndefined(start)
+        Assert.isNotUndefined(end)
+
+        this.db.compactRange(start, end, (err) => (err ? reject(err) : resolve()))
       } else {
         resolve()
       }
@@ -206,6 +211,20 @@ export class LevelupDatabase extends Database {
 
   async put(key: Readonly<Buffer>, value: Buffer): Promise<void> {
     await this.levelup.put(key, value)
+  }
+
+  async *getAllIter(range?: DatabaseKeyRange): AsyncGenerator<[Buffer, Buffer]> {
+    const stream = this.levelup.createReadStream(range)
+
+    // The return type for createReadStream is wrong
+    const iter = stream as unknown as AsyncIterable<{
+      key: Buffer
+      value: Buffer
+    }>
+
+    for await (const { key, value } of iter) {
+      yield [key, value]
+    }
   }
 
   async getVersion(): Promise<number> {

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -20,14 +20,6 @@ import { LevelupTransaction } from './transaction'
 
 const ENABLE_TRANSACTIONS = true
 
-interface INotFoundError {
-  type: 'NotFoundError'
-}
-
-function isNotFoundError(error: unknown): error is INotFoundError {
-  return (error as INotFoundError)?.type === 'NotFoundError'
-}
-
 export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<Schema> {
   db: LevelupDatabase
 
@@ -60,21 +52,13 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
       return transaction.get(this, key)
     }
 
-    try {
-      const data = (await this.db.levelup.get(encodedKey)) as unknown
-      if (data === undefined) {
-        return undefined
-      }
-      if (!(data instanceof Buffer)) {
-        return undefined
-      }
-      return this.valueEncoding.deserialize(data)
-    } catch (error: unknown) {
-      if (isNotFoundError(error)) {
-        return undefined
-      }
-      throw error
+    const data = await this.db.get(encodedKey)
+
+    if (data === undefined) {
+      return undefined
     }
+
+    return this.valueEncoding.deserialize(data)
   }
 
   async *getAllIter(

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -189,7 +189,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     }
 
     const [encodedKey, encodedValue] = this.encode(key, value)
-    await this.db.levelup.put(encodedKey, encodedValue)
+    await this.db.put(encodedKey, encodedValue)
   }
 
   async add(
@@ -212,7 +212,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     }
 
     const [encodedKey, encodedValue] = this.encode(key, value)
-    await this.db.levelup.put(encodedKey, encodedValue)
+    await this.db.put(encodedKey, encodedValue)
   }
 
   async del(key: SchemaKey<Schema>, transaction?: IDatabaseTransaction): Promise<void> {

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import type { LevelupDatabase } from './database'
+import { BufferSet } from 'buffer-map'
 import MurmurHash3 from 'imurmurhash'
+import { Assert } from '../../assert'
 import { AsyncUtils } from '../../utils/async'
 import {
   DatabaseKeyRange,
@@ -32,6 +34,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
 
     // Hash the prefix key to ensure identical length and avoid collisions
     const prefixHash = new MurmurHash3(this.name, 1).result()
+
     this.prefixBuffer = Buffer.alloc(4)
     this.prefixBuffer.writeUInt32BE(prefixHash)
 
@@ -61,58 +64,50 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     return this.valueEncoding.deserialize(data)
   }
 
+  /* Get an [[`AsyncGenerator`]] that yields all of the key/value pairs in the IDatastore */
   async *getAllIter(
     transaction?: IDatabaseTransaction,
     keyRange?: DatabaseKeyRange,
   ): AsyncGenerator<[SchemaKey<Schema>, SchemaValue<Schema>]> {
-    const seen = new Set<string>()
+    if (keyRange) {
+      keyRange = StorageUtils.addPrefixToRange(keyRange, this.prefixBuffer)
+    } else {
+      keyRange = this.allKeysRange
+    }
 
-    if (ENABLE_TRANSACTIONS && transaction instanceof LevelupTransaction) {
+    const seen = new BufferSet()
+
+    if (ENABLE_TRANSACTIONS && transaction) {
+      Assert.isInstanceOf(transaction, LevelupTransaction)
       await transaction.acquireLock()
 
-      for (const [key, value] of transaction.cache.entries()) {
-        const keyBuffer = BUFFER_TO_STRING_ENCODING.deserialize(key)
+      for (const [keyString, value] of transaction.cache.entries()) {
+        const key = BUFFER_TO_STRING_ENCODING.deserialize(keyString)
 
-        const isFromStore = keyBuffer
-          .slice(0, this.prefixBuffer.byteLength)
-          .equals(this.prefixBuffer)
-
-        if (isFromStore) {
-          if (keyRange) {
-            const keyPostPrefix = keyBuffer.slice(this.prefixBuffer.byteLength)
-
-            const inKeyRange =
-              keyPostPrefix.compare(keyRange.gte) >= 1 && keyPostPrefix.compare(keyRange.lt) < 0
-
-            if (!inKeyRange) {
-              continue
-            }
-          }
-
-          if (value !== undefined) {
-            yield [this.decodeKey(keyBuffer), value as SchemaValue<Schema>]
-          }
-
-          seen.add(key)
+        if (!StorageUtils.hasPrefix(key, this.prefixBuffer)) {
+          continue
         }
+
+        if (!StorageUtils.isInRange(key, keyRange)) {
+          continue
+        }
+
+        seen.add(key)
+
+        if (value === undefined) {
+          continue
+        }
+
+        yield [this.decodeKey(key), value as SchemaValue<Schema>]
       }
     }
 
-    if (keyRange) {
-      keyRange = {
-        gte: Buffer.concat([this.prefixBuffer, keyRange.gte]),
-        lt: Buffer.concat([this.prefixBuffer, keyRange.lt]),
+    for await (const [key, value] of this.db.getAllIter(keyRange)) {
+      if (seen.has(key)) {
+        continue
       }
-    }
 
-    const stream = this.db.levelup.createReadStream(keyRange ?? this.allKeysRange)
-
-    for await (const pair of stream) {
-      const { key, value } = pair as unknown as { key: Buffer; value: Buffer }
-
-      if (!seen.has(BUFFER_TO_STRING_ENCODING.serialize(key))) {
-        yield [this.decodeKey(key), this.valueEncoding.deserialize(value)]
-      }
+      yield [this.decodeKey(key), this.valueEncoding.deserialize(value)]
     }
   }
 
@@ -164,10 +159,9 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     }
 
     if (keyRange) {
-      keyRange = {
-        gte: Buffer.concat([this.prefixBuffer, keyRange.gte]),
-        lt: Buffer.concat([this.prefixBuffer, keyRange.lt]),
-      }
+      keyRange = StorageUtils.addPrefixToRange(keyRange, this.prefixBuffer)
+    } else {
+      keyRange = this.allKeysRange
     }
 
     await this.db.levelup.clear(keyRange ?? this.allKeysRange)
@@ -180,6 +174,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
   ): Promise<void>
   async put(a: unknown, b: unknown, c?: unknown): Promise<void> {
     const { key, value, transaction } = parsePut<Schema>(a, b, c)
+
     if (key === undefined) {
       throw new Error('No key defined')
     }


### PR DESCRIPTION
## Summary
This is so you can use the raw KVS database behaviour on the database itself, and the store just becomes a thin wrapper over the database functionality.

## Testing Plan

Existing tests, and new tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
