### PR TITLE
Remove ability to customize database names

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -15,8 +15,6 @@ import { Command, Config } from '@oclif/core'
 import { CLIError, ExitError } from '@oclif/core/lib/errors'
 import {
   ConfigFlagKey,
-  DatabaseFlag,
-  DatabaseFlagKey,
   DataDirFlagKey,
   RpcAuthFlagKey,
   RpcTcpHostFlagKey,
@@ -37,7 +35,6 @@ export type SIGNALS = 'SIGTERM' | 'SIGINT' | 'SIGUSR2'
 
 export type FLAGS =
   | typeof DataDirFlagKey
-  | typeof DatabaseFlagKey
   | typeof ConfigFlagKey
   | typeof RpcUseIpcFlagKey
   | typeof RpcUseTcpFlagKey
@@ -110,11 +107,6 @@ export abstract class IronfishCommand extends Command {
 
     const configOverrides: Partial<ConfigOptions> = {}
     const internalOverrides: Partial<InternalOptions> = {}
-
-    const databaseNameFlag = getFlag(flags, DatabaseFlagKey)
-    if (typeof databaseNameFlag === 'string' && databaseNameFlag !== DatabaseFlag.default) {
-      configOverrides.databaseName = databaseNameFlag
-    }
 
     const rpcConnectIpcFlag = getFlag(flags, RpcUseIpcFlagKey)
     if (typeof rpcConnectIpcFlag === 'boolean' && rpcConnectIpcFlag !== RpcUseIpcFlag.default) {

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -58,9 +58,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
 
     if (!node.chain.isEmpty) {
       this.log(
-        `The database ${node.config.get(
-          'databaseName',
-        )} must be empty to create a genesis block.`,
+        `The database ${node.config.chainDatabasePath} must be empty to create a genesis block.`,
       )
       this.exit(0)
     }

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -8,8 +8,6 @@ import { IronfishCommand } from '../command'
 import {
   ConfigFlag,
   ConfigFlagKey,
-  DatabaseFlag,
-  DatabaseFlagKey,
   DataDirFlag,
   DataDirFlagKey,
   VerboseFlag,
@@ -23,7 +21,6 @@ export default class Reset extends IronfishCommand {
     [VerboseFlagKey]: VerboseFlag,
     [ConfigFlagKey]: ConfigFlag,
     [DataDirFlagKey]: DataDirFlag,
-    [DatabaseFlagKey]: DatabaseFlag,
     confirm: Flags.boolean({
       default: false,
       description: 'Confirm without asking',

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -17,8 +17,6 @@ import { IronfishCommand, SIGNALS } from '../command'
 import {
   ConfigFlag,
   ConfigFlagKey,
-  DatabaseFlag,
-  DatabaseFlagKey,
   DataDirFlag,
   DataDirFlagKey,
   RpcTcpHostFlag,
@@ -46,7 +44,6 @@ export default class Start extends IronfishCommand {
     [VerboseFlagKey]: VerboseFlag,
     [ConfigFlagKey]: ConfigFlag,
     [DataDirFlagKey]: DataDirFlag,
-    [DatabaseFlagKey]: DatabaseFlag,
     [RpcUseIpcFlagKey]: { ...RpcUseIpcFlag, allowNo: true },
     [RpcUseTcpFlagKey]: { ...RpcUseTcpFlag, allowNo: true },
     [RpcTcpTlsFlagKey]: RpcTcpTlsFlag,

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -4,7 +4,6 @@
 import {
   DEFAULT_CONFIG_NAME,
   DEFAULT_DATA_DIR,
-  DEFAULT_DATABASE_NAME,
   DEFAULT_USE_RPC_IPC,
   DEFAULT_USE_RPC_TCP,
   DEFAULT_USE_RPC_TLS,
@@ -17,7 +16,6 @@ export const VerboseFlagKey = 'verbose'
 export const ConfigFlagKey = 'config'
 export const ColorFlagKey = 'color'
 export const DataDirFlagKey = 'datadir'
-export const DatabaseFlagKey = 'database'
 export const RpcUseIpcFlagKey = 'rpc.ipc'
 export const RpcUseTcpFlagKey = 'rpc.tcp'
 export const RpcTcpHostFlagKey = 'rpc.tcp.host'
@@ -46,12 +44,6 @@ export const DataDirFlag = Flags.string({
   default: DEFAULT_DATA_DIR,
   description: 'The path to the data dir',
   env: 'IRONFISH_DATA_DIR',
-})
-
-export const DatabaseFlag = Flags.string({
-  char: 'd',
-  default: DEFAULT_DATABASE_NAME,
-  description: 'The name of the database to use',
 })
 
 export const RpcUseIpcFlag = Flags.boolean({
@@ -86,7 +78,6 @@ const localFlags: Record<string, CompletableOptionFlag> = {}
 localFlags[VerboseFlagKey] = VerboseFlag as unknown as CompletableOptionFlag
 localFlags[ConfigFlagKey] = ConfigFlag as unknown as CompletableOptionFlag
 localFlags[DataDirFlagKey] = DataDirFlag as unknown as CompletableOptionFlag
-localFlags[DatabaseFlagKey] = DatabaseFlag as unknown as CompletableOptionFlag
 
 /**
  * These flags should usually be used on any command that starts a node,

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -7,10 +7,7 @@ import { YupUtils } from '../utils'
 import { KeyStore } from './keyStore'
 
 export const DEFAULT_CONFIG_NAME = 'config.json'
-export const DEFAULT_DATABASE_NAME = 'chain'
-export const DEFAULT_INDEX_DATABASE_NAME = 'mined'
 export const DEFAULT_DATA_DIR = '~/.ironfish'
-export const DEFAULT_WALLET_NAME = 'wallet'
 export const DEFAULT_WEBSOCKET_PORT = 9033
 export const DEFAULT_GET_FUNDS_API = 'https://api.ironfish.network/faucet_transactions'
 export const DEFAULT_TELEMETRY_API = 'https://api.ironfish.network/telemetry'
@@ -41,8 +38,6 @@ export const DEFAULT_POOL_RECENT_SHARE_CUTOFF = 2 * 60 * 60 // 2 hours
 
 export type ConfigOptions = {
   bootstrapNodes: string[]
-  databaseName: string
-  indexDatabaseName: string
   databaseMigrate: boolean
   editor: string
   enableListenP2P: boolean
@@ -123,7 +118,6 @@ export type ConfigOptions = {
    */
   targetPeers: number
   telemetryApi: string
-  accountName: string
 
   /**
    * When the option is true, then each invocation of start command will invoke generation of new identity.
@@ -261,8 +255,6 @@ export type ConfigOptions = {
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
   .object({
     bootstrapNodes: yup.array().of(yup.string().defined()),
-    databaseName: yup.string(),
-    indexDatabaseName: yup.string(),
     databaseMigrate: yup.boolean(),
     editor: yup.string().trim(),
     enableListenP2P: yup.boolean(),
@@ -297,7 +289,6 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     minPeers: YupUtils.isPositiveInteger,
     targetPeers: yup.number().integer().min(1),
     telemetryApi: yup.string(),
-    accountName: yup.string(),
     generateNewIdentity: yup.boolean(),
     defaultTransactionExpirationSequenceDelta: YupUtils.isPositiveInteger,
     blocksPerMessage: YupUtils.isPositiveInteger,
@@ -337,15 +328,15 @@ export class Config extends KeyStore<ConfigOptions> {
   }
 
   get chainDatabasePath(): string {
-    return this.files.join(this.storage.dataDir, 'databases', this.get('databaseName'))
+    return this.files.join(this.storage.dataDir, 'databases', 'chain')
   }
 
   get accountDatabasePath(): string {
-    return this.files.join(this.storage.dataDir, 'databases', this.get('accountName'))
+    return this.files.join(this.storage.dataDir, 'databases', 'wallet')
   }
 
   get indexDatabasePath(): string {
-    return this.files.join(this.storage.dataDir, 'databases', this.get('indexDatabaseName'))
+    return this.files.join(this.storage.dataDir, 'databases', 'mined')
   }
 
   get tempDir(): string {
@@ -362,8 +353,6 @@ export class Config extends KeyStore<ConfigOptions> {
   static GetDefaults(files: FileSystem, dataDir: string): ConfigOptions {
     return {
       bootstrapNodes: [],
-      databaseName: DEFAULT_DATABASE_NAME,
-      indexDatabaseName: DEFAULT_INDEX_DATABASE_NAME,
       databaseMigrate: false,
       defaultTransactionExpirationSequenceDelta: 15,
       editor: '',
@@ -397,7 +386,6 @@ export class Config extends KeyStore<ConfigOptions> {
       minPeers: 1,
       targetPeers: 50,
       telemetryApi: DEFAULT_TELEMETRY_API,
-      accountName: DEFAULT_WALLET_NAME,
       generateNewIdentity: false,
       blocksPerMessage: 5,
       minerBatchSize: DEFAULT_MINER_BATCH_SIZE,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -182,7 +182,6 @@ export class IronfishNode {
 
   static async init({
     pkg: pkg,
-    databaseName,
     dataDir,
     config,
     internal,
@@ -199,7 +198,6 @@ export class IronfishNode {
     config?: Config
     internal?: InternalStore
     autoSeed?: boolean
-    databaseName?: string
     logger?: Logger
     metrics?: MetricsMonitor
     files: FileSystem
@@ -222,10 +220,6 @@ export class IronfishNode {
 
     const hostsStore = new HostsStore(files, dataDir)
     await hostsStore.load()
-
-    if (databaseName) {
-      config.setOverride('databaseName', databaseName)
-    }
 
     let workers = config.get('nodeWorkers')
     if (workers === -1) {

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -58,13 +58,12 @@ describe('IronfishSdk', () => {
         fileSystem: fileSystem,
       })
 
-      const node = await sdk.node({ databaseName: 'foo' })
+      const node = await sdk.node()
 
       expect(node).toBeInstanceOf(IronfishNode)
       expect(node.files).toBe(fileSystem)
       expect(node.config).toBe(sdk.config)
       expect(node.wallet).toBeInstanceOf(Wallet)
-      expect(node.config.get('databaseName')).toBe('foo')
     })
 
     it('should initialize an SDK with the default dataDir if none is passed in', async () => {
@@ -80,7 +79,7 @@ describe('IronfishSdk', () => {
       expect(sdk.config.dataDir).toBe(expectedDir)
       expect(sdk.config.storage.dataDir).toBe(expectedDir)
 
-      const node = await sdk.node({ databaseName: 'foo' })
+      const node = await sdk.node()
       expect(node.config).toBe(sdk.config)
     })
   })

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -176,11 +176,9 @@ export class IronfishSdk {
   }
 
   async node({
-    databaseName,
     autoSeed,
     privateIdentity,
   }: {
-    databaseName?: string
     autoSeed?: boolean
     privateIdentity?: PrivateIdentity
   } = {}): Promise<IronfishNode> {
@@ -191,7 +189,6 @@ export class IronfishSdk {
       config: this.config,
       internal: this.internal,
       files: this.fileSystem,
-      databaseName: databaseName,
       autoSeed: autoSeed,
       logger: this.logger,
       metrics: this.metrics,


### PR DESCRIPTION
## Summary

We don't need this functionality, and as new DB's were added it wasn't added for the other DB's as flags and other places.

## Testing Plan

Ran the node

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
