### PR TITLE
replaces unsigned transaction hashes in rpc responses

### DIFF
--- a/ironfish/src/rpc/routes/accounts/getNotes.ts
+++ b/ironfish/src/rpc/routes/accounts/getNotes.ts
@@ -49,7 +49,7 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
       request.stream({
         amount: note.value().toString(),
         memo: note.memo(),
-        transactionHash: transaction.transaction.unsignedHash().toString('hex'),
+        transactionHash: transaction.transaction.hash().toString('hex'),
         spent,
       })
     }

--- a/ironfish/src/rpc/routes/accounts/getTransaction.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransaction.ts
@@ -71,7 +71,7 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
 
     const transactionHash = Buffer.from(request.data.hash, 'hex')
 
-    const transaction = await account.getTransactionByUnsignedHash(transactionHash)
+    const transaction = await account.getTransaction(transactionHash)
 
     if (!transaction) {
       return request.end({

--- a/ironfish/src/rpc/routes/accounts/getTransactions.ts
+++ b/ironfish/src/rpc/routes/accounts/getTransactions.ts
@@ -112,7 +112,7 @@ const handleSingleTransaction = async (
 ): Promise<void> => {
   const hashBuffer = Buffer.from(hash, 'hex')
 
-  const transaction = await account.getTransactionByUnsignedHash(hashBuffer)
+  const transaction = await account.getTransaction(hashBuffer)
 
   if (transaction) {
     await streamTransaction(request, node, account, transaction)

--- a/ironfish/src/rpc/routes/accounts/types.ts
+++ b/ironfish/src/rpc/routes/accounts/types.ts
@@ -25,7 +25,7 @@ export function serializeRpcAccountTransaction(
   transaction: TransactionValue,
 ): RpcAccountTransaction {
   return {
-    hash: transaction.transaction.unsignedHash().toString('hex'),
+    hash: transaction.transaction.hash().toString('hex'),
     isMinersFee: transaction.transaction.isMinersFee(),
     fee: transaction.transaction.fee().toString(),
     blockHash: transaction.blockHash?.toString('hex'),

--- a/ironfish/src/rpc/routes/chain/followChain.ts
+++ b/ironfish/src/rpc/routes/chain/followChain.ts
@@ -116,7 +116,7 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
       const transactions = block.transactions.map((transaction) => {
         return transaction.withReference(() => {
           return {
-            hash: BlockHashSerdeInstance.serialize(transaction.unsignedHash()),
+            hash: BlockHashSerdeInstance.serialize(transaction.hash()),
             size: getTransactionSize(transaction),
             fee: Number(transaction.fee()),
             notes: [...transaction.notes()].map((note) => ({

--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -172,7 +172,7 @@ router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
 
       return {
         transaction_identifier: {
-          hash: BlockHashSerdeInstance.serialize(transaction.unsignedHash()),
+          hash: BlockHashSerdeInstance.serialize(transaction.hash()),
         },
         operations: [],
         metadata: {

--- a/ironfish/src/rpc/routes/chain/getBlockInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getBlockInfo.ts
@@ -130,7 +130,7 @@ router.register<typeof GetBlockInfoRequestSchema, GetBlockInfoResponse>(
 
       transactions.push({
         signature: tx.transactionSignature().toString('hex'),
-        hash: tx.unsignedHash().toString('hex'),
+        hash: tx.hash().toString('hex'),
         fee: fee.toString(),
         spends: tx.spendsLength(),
         notes: tx.notesLength(),

--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -58,7 +58,7 @@ router.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
       notesEncrypted: [],
     }
     block.transactions.map((transaction) => {
-      if (transaction.unsignedHash().toString('hex') === request.data.transactionHash) {
+      if (transaction.hash().toString('hex') === request.data.transactionHash) {
         const fee = transaction.fee().toString()
         const expirationSequence = transaction.expirationSequence()
         const notesCount = transaction.notesLength()

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -124,7 +124,7 @@ router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
 
         if (notes.length) {
           transactions.push({
-            hash: tx.unsignedHash().toString('hex'),
+            hash: tx.hash().toString('hex'),
             isMinersFee: tx.isMinersFee(),
             notes: notes,
           })

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.test.ts
@@ -176,7 +176,7 @@ describe('Transactions sendTransaction', () => {
     })
 
     const result = await routeTest.client.sendTransaction(TEST_PARAMS)
-    expect(result.content.hash).toEqual(tx.unsignedHash().toString('hex'))
+    expect(result.content.hash).toEqual(tx.hash().toString('hex'))
   })
 
   it('calls the pay method on the node with multiple recipient', async () => {
@@ -196,7 +196,7 @@ describe('Transactions sendTransaction', () => {
     })
 
     const result = await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
-    expect(result.content.hash).toEqual(tx.unsignedHash().toString('hex'))
+    expect(result.content.hash).toEqual(tx.hash().toString('hex'))
   })
 
   it('lets you configure the expiration', async () => {

--- a/ironfish/src/rpc/routes/transactions/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/transactions/sendTransaction.ts
@@ -138,7 +138,7 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
       request.end({
         receives: transaction.receives,
         fromAccountName: account.name,
-        hash: transactionPosted.unsignedHash().toString('hex'),
+        hash: transactionPosted.hash().toString('hex'),
       })
     } catch (e) {
       if (e instanceof NotEnoughFundsError) {

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -298,17 +298,6 @@ export class Account {
     return await this.walletDb.loadTransaction(this, hash, tx)
   }
 
-  async getTransactionByUnsignedHash(
-    unsignedHash: Buffer,
-    tx?: IDatabaseTransaction,
-  ): Promise<Readonly<TransactionValue> | undefined> {
-    for await (const transactionValue of this.getTransactions(tx)) {
-      if (unsignedHash.equals(transactionValue.transaction.unsignedHash())) {
-        return transactionValue
-      }
-    }
-  }
-
   getTransactions(tx?: IDatabaseTransaction): AsyncGenerator<Readonly<TransactionValue>> {
     return this.walletDb.loadTransactions(this, tx)
   }


### PR DESCRIPTION
## Summary

uses the signed transaction hash instead of the unsigned hash in every rpc response that returns a transaction hash.

we store transactions by signed hash in the wallet but return unsigned hashes in rpc responses. every user-facing transaction hash is currently an unsigned hash, so lookups iterate over all traansactions to find a match.

removes logic for finding transactions by unsigned hash.


NOTE: this will also have the effect of propagating signed hashes to the API instead of unsigned hashes

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
