### PR TITLE
Fix KeyStore not saving value if matching default

### DIFF
--- a/ironfish/src/fileStores/keyStore.test.ts
+++ b/ironfish/src/fileStores/keyStore.test.ts
@@ -114,14 +114,19 @@ describe('KeyStore', () => {
     expect(store.isSet('foo')).toBe(true)
   })
 
-  it('should save when put', async () => {
+  it('should save when put matches default', async () => {
     const dir = getUniqueTestDataDir()
     const files = await new NodeFileProvider().init()
 
-    const store = new KeyStore<{ foo: string }>(files, 'store', { foo: 'default' }, dir)
+    let store = new KeyStore<{ foo: string }>(files, 'store', { foo: 'default' }, dir)
     expect(store.isSet('foo')).toBe(false)
 
     store.set('foo', 'default')
     expect(store.isSet('foo')).toBe(true)
+
+    await store.save()
+    store = new KeyStore<{ foo: string }>(files, 'store', { foo: '' }, dir)
+    await store.load()
+    expect(store.get('foo')).toEqual('default')
   })
 })

--- a/ironfish/src/fileStores/keyStore.test.ts
+++ b/ironfish/src/fileStores/keyStore.test.ts
@@ -113,4 +113,15 @@ describe('KeyStore', () => {
     await store.load()
     expect(store.isSet('foo')).toBe(true)
   })
+
+  it('should save when put', async () => {
+    const dir = getUniqueTestDataDir()
+    const files = await new NodeFileProvider().init()
+
+    const store = new KeyStore<{ foo: string }>(files, 'store', { foo: 'default' }, dir)
+    expect(store.isSet('foo')).toBe(false)
+
+    store.set('foo', 'default')
+    expect(store.isSet('foo')).toBe(true)
+  })
 })

--- a/ironfish/src/fileStores/keyStore.ts
+++ b/ironfish/src/fileStores/keyStore.ts
@@ -112,6 +112,7 @@ export class KeyStore<TSchema extends Record<string, unknown>> {
     const previousValue = this.config[key]
 
     Object.assign(this.loaded, { [key]: value })
+    this.keysLoaded.add(key)
 
     if (Object.prototype.hasOwnProperty.call(this.overrides, key)) {
       delete this.overrides[key]


### PR DESCRIPTION
## Summary

There is a bug here where if we load all the keys, we add them to a set to keep track of those keys. That set is used to determine which keys get saved when we call keyStore.save(). It's also used by keyStore.isSet(). Since we don't add the key to the set when we call keyStore.put(), if it matches the default value it's dropped, and isSet() will always return false.

## Testing Plan

Added a new test case to reproduce this bug.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
