### PR TITLE
Move maxSyncedAgeBlocks to config from consensus

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -8,6 +8,7 @@ import { Assert } from '../assert'
 import { Consensus } from '../consensus'
 import { VerificationResultReason, Verifier } from '../consensus/verifier'
 import { Event } from '../event'
+import { Config } from '../fileStores'
 import { FileSystem } from '../fileSystems'
 import { createRootLogger, Logger } from '../logger'
 import { MerkleTree } from '../merkletree'
@@ -84,6 +85,7 @@ export class Blockchain {
   files: FileSystem
   consensus: Consensus
   seedGenesisBlock: SerializedBlock
+  config: Config
 
   synced = false
   opened = false
@@ -174,6 +176,7 @@ export class Blockchain {
     files: FileSystem
     consensus: Consensus
     genesis: SerializedBlock
+    config: Config
   }) {
     const logger = options.logger || createRootLogger()
 
@@ -191,6 +194,7 @@ export class Blockchain {
     this.autoSeed = options.autoSeed ?? true
     this.consensus = options.consensus
     this.seedGenesisBlock = options.genesis
+    this.config = options.config
 
     // Flat Fields
     this.meta = this.db.addStore({
@@ -1352,7 +1356,7 @@ export class Blockchain {
     }
 
     const maxSyncedAgeMs =
-      this.consensus.parameters.maxSyncedAgeBlocks *
+      this.config.get('maxSyncedAgeBlocks') *
       this.consensus.parameters.targetBlockTimeInSeconds *
       1000
     if (this.head.timestamp.valueOf() < Date.now() - maxSyncedAgeMs) {

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -20,11 +20,6 @@ export type ConsensusParameters = {
   targetBlockTimeInSeconds: number
 
   /**
-   * The oldest the tip should be before we consider the chain synced
-   */
-  maxSyncedAgeBlocks: number
-
-  /**
    * The time range when difficulty and target not change
    */
   targetBucketTimeInSeconds: number

--- a/ironfish/src/defaultNetworkDefinitions.ts
+++ b/ironfish/src/defaultNetworkDefinitions.ts
@@ -48,7 +48,6 @@ export const TESTING = `{
       "allowedBlockFutureSeconds": 15,
       "genesisSupplyInIron": 42000000,
       "targetBlockTimeInSeconds": 60,
-      "maxSyncedAgeBlocks": 60,
       "targetBucketTimeInSeconds": 10,
       "maxBlockSizeBytes": 2000000
   }
@@ -63,7 +62,6 @@ export const MAINNET = `
         "allowedBlockFutureSeconds": 15,
         "genesisSupplyInIron": 42000000,
         "targetBlockTimeInSeconds": 60,
-        "maxSyncedAgeBlocks": 60,
         "targetBucketTimeInSeconds": 10,
         "maxBlockSizeBytes": 2000000
     }
@@ -115,7 +113,6 @@ export const TESTNET_PHASE_2 = `
         "allowedBlockFutureSeconds": 15,
         "genesisSupplyInIron": 42000000,
         "targetBlockTimeInSeconds": 60,
-        "maxSyncedAgeBlocks": 60,
         "targetBucketTimeInSeconds": 10,
         "maxBlockSizeBytes": 2000000
     }
@@ -165,7 +162,6 @@ export const DEV = `
         "allowedBlockFutureSeconds": 15,
         "genesisSupplyInIron": 42000000,
         "targetBlockTimeInSeconds": 60,
-        "maxSyncedAgeBlocks": 60,
         "targetBucketTimeInSeconds": 10,
         "maxBlockSizeBytes": 2000000
     }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -230,6 +230,11 @@ export type ConfigOptions = {
    * Path to a JSON file containing the network definition of a custom network
    */
   customNetwork: string
+
+  /**
+   * The oldest the tip should be before we consider the chain synced
+   */
+  maxSyncedAgeBlocks: number
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -293,6 +298,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     explorerTransactionsUrl: YupUtils.isUrl,
     networkId: yup.number().integer().min(0),
     customNetwork: yup.string().trim(),
+    maxSyncedAgeBlocks: yup.number().integer().min(0),
   })
   .defined()
 
@@ -379,6 +385,7 @@ export class Config extends KeyStore<ConfigOptions> {
       feeEstimatorPercentileHigh: 30,
       networkId: 2,
       customNetwork: '',
+      maxSyncedAgeBlocks: 60,
     }
   }
 }

--- a/ironfish/src/networkDefinition.ts
+++ b/ironfish/src/networkDefinition.ts
@@ -41,7 +41,6 @@ export const networkDefinitionSchema: yup.ObjectSchema<NetworkDefinition> = yup
         allowedBlockFutureSeconds: yup.number().integer().defined(),
         genesisSupplyInIron: yup.number().integer().defined(),
         targetBlockTimeInSeconds: yup.number().integer().defined(),
-        maxSyncedAgeBlocks: yup.number().integer().defined(),
         targetBucketTimeInSeconds: yup.number().integer().defined(),
         maxBlockSizeBytes: yup.number().integer().defined(),
       })

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -275,6 +275,7 @@ export class IronfishNode {
       files,
       consensus,
       genesis: networkDefinition.genesis,
+      config,
     })
 
     const accountDB = new WalletDB({

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.test.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.test.ts
@@ -22,9 +22,6 @@ describe('Route chain.getConsensusParameters', () => {
     expect(response.content.targetBlockTimeInSeconds).toEqual(
       routeTest.chain.consensus.parameters.targetBlockTimeInSeconds,
     )
-    expect(response.content.maxSyncedAgeBlocks).toEqual(
-      routeTest.chain.consensus.parameters.maxSyncedAgeBlocks,
-    )
     expect(response.content.targetBucketTimeInSeconds).toEqual(
       routeTest.chain.consensus.parameters.targetBucketTimeInSeconds,
     )

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
@@ -9,7 +9,6 @@ interface ConsensusParameters {
   allowedBlockFuturesSeconds: number
   genesisSupplyInIron: number
   targetBlockTimeInSeconds: number
-  maxSyncedAgeBlocks: number
   targetBucketTimeInSeconds: number
   maxBlockSizeBytes: number
 }
@@ -26,7 +25,6 @@ export const GetConsensusParametersResponseSchema: yup.ObjectSchema<GetConsensus
       allowedBlockFuturesSeconds: yup.number().defined(),
       genesisSupplyInIron: yup.number().defined(),
       targetBlockTimeInSeconds: yup.number().defined(),
-      maxSyncedAgeBlocks: yup.number().defined(),
       targetBucketTimeInSeconds: yup.number().defined(),
       maxBlockSizeBytes: yup.number().defined(),
     })
@@ -44,7 +42,6 @@ router.register<typeof GetConsensusParametersRequestSchema, GetConsensusParamete
       allowedBlockFuturesSeconds: consensusParameters.allowedBlockFutureSeconds,
       genesisSupplyInIron: consensusParameters.genesisSupplyInIron,
       targetBlockTimeInSeconds: consensusParameters.targetBlockTimeInSeconds,
-      maxSyncedAgeBlocks: consensusParameters.maxSyncedAgeBlocks,
       targetBucketTimeInSeconds: consensusParameters.targetBucketTimeInSeconds,
       maxBlockSizeBytes: consensusParameters.maxBlockSizeBytes,
     })

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -64,7 +64,6 @@ const consensusParameters: ConsensusParameters = {
   allowedBlockFutureSeconds: 15,
   genesisSupplyInIron: 42000000,
   targetBlockTimeInSeconds: 60,
-  maxSyncedAgeBlocks: 60,
   targetBucketTimeInSeconds: 10,
   maxBlockSizeBytes: 2000000,
 }

--- a/ironfish/src/strategy.test.ts
+++ b/ironfish/src/strategy.test.ts
@@ -13,7 +13,6 @@ describe('Miners reward', () => {
     allowedBlockFutureSeconds: 15,
     genesisSupplyInIron: 42000000,
     targetBlockTimeInSeconds: 60,
-    maxSyncedAgeBlocks: 60,
     targetBucketTimeInSeconds: 10,
     maxBlockSizeBytes: 2000000,
   }


### PR DESCRIPTION
## Summary

Moved `maxSyncedAgeBlocks` to config from consensus since the entire network doesn't have to agree on it.

## Testing Plan

Updated tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
