### PR TITLE
Allow loading genesis block allocations from CSV

### DIFF
--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -43,7 +43,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
     allocations: Flags.string({
       required: false,
       description:
-        'A CSV file with the format address,amount,memo containing genesis block allocations',
+        'A CSV file with the format address,amountInIron,memo containing genesis block allocations',
       exclusive: ['account', 'memo'],
     }),
     genesisSupplyInIron: Flags.string({
@@ -146,7 +146,7 @@ const parseAllocationsFile = (
       continue
     }
 
-    const [address, amount, memo, ...rest] = line.split(',').map((v) => v.trim())
+    const [address, amountInIron, memo, ...rest] = line.split(',').map((v) => v.trim())
 
     if (rest.length > 0) {
       return {
@@ -164,7 +164,7 @@ const parseAllocationsFile = (
     }
 
     // Check amount is positive and decodes as $IRON
-    const amountInOre = CurrencyUtils.decodeIron(amount)
+    const amountInOre = CurrencyUtils.decodeIron(amountInIron)
     if (amountInOre < 0) {
       return {
         ok: false,

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -46,10 +46,10 @@ export default class GenesisBlockCommand extends IronfishCommand {
         'A CSV file with the format address,amountInIron,memo containing genesis block allocations',
       exclusive: ['account', 'memo'],
     }),
-    genesisSupplyInIron: Flags.integer({
+    genesisSupplyInIron: Flags.string({
       char: 'g',
       required: true,
-      default: 42000000,
+      default: '42000000',
       description: 'The amount of coins in the genesis block',
     }),
   }

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -29,7 +29,6 @@ export default class GenesisBlockCommand extends IronfishCommand {
       required: false,
       default: 'IronFishGenesisAccount',
       description: 'The name of the account to use for keys to assign the genesis block to',
-      exclusive: ['allocations'],
     }),
     difficulty: Flags.string({
       default: Target.minDifficulty().toString(),
@@ -40,7 +39,6 @@ export default class GenesisBlockCommand extends IronfishCommand {
       required: false,
       default: 'Genesis Block',
       description: 'The memo of the block',
-      exclusive: ['allocations'],
     }),
     allocations: Flags.string({
       required: false,
@@ -92,7 +90,9 @@ export default class GenesisBlockCommand extends IronfishCommand {
 
       if (totalSupply !== expectedSupply) {
         this.error(
-          `Allocations file contains ${totalSupply} $IRON, but --genesisSupplyInIron expects ${flags.genesisSupplyInIron}} $IRON.`,
+          `Allocations file contains ${CurrencyUtils.encodeIron(
+            totalSupply,
+          )} $IRON, but --genesisSupplyInIron expects ${flags.genesisSupplyInIron} $IRON.`,
         )
       }
 
@@ -151,7 +151,7 @@ const parseAllocationsFile = (
     if (rest.length > 0) {
       return {
         ok: false,
-        error: `Error on line ${lineNum}: (${line}) contains more than 3 values.`,
+        error: `Line ${lineNum}: (${line}) contains more than 3 values.`,
       }
     }
 
@@ -159,7 +159,7 @@ const parseAllocationsFile = (
     if (!isValidPublicAddress(address)) {
       return {
         ok: false,
-        error: `Error on line ${lineNum}: (${line}) has an invalid public address.`,
+        error: `Line ${lineNum}: (${line}) has an invalid public address.`,
       }
     }
 
@@ -168,7 +168,7 @@ const parseAllocationsFile = (
     if (amountInOre < 0) {
       return {
         ok: false,
-        error: `Error on line ${lineNum}: (${line}) contains a negative $IRON amount.`,
+        error: `Line ${lineNum}: (${line}) contains a negative $IRON amount.`,
       }
     }
 
@@ -176,7 +176,7 @@ const parseAllocationsFile = (
     if (Buffer.from(memo).byteLength > MEMO_LENGTH) {
       return {
         ok: false,
-        error: `Error on line ${lineNum}: (${line}) contains a memo with byte length > ${MEMO_LENGTH}.`,
+        error: `Line ${lineNum}: (${line}) contains a memo with byte length > ${MEMO_LENGTH}.`,
       }
     }
 

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -163,7 +163,7 @@ const parseAllocationsFile = (
       }
     }
 
-    // Check amount is a bigint
+    // Check amount is positive and decodes as $IRON
     const amountInOre = CurrencyUtils.decodeIron(amount)
     if (amountInOre < 0) {
       return {

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -66,18 +66,18 @@ describe('Create genesis block', () => {
     const account = await node.wallet.createAccount('test', true)
     const info = {
       timestamp: Date.now(),
-      memo: 'test',
       target: Target.maxTarget(),
       allocations: [
         {
           amount: amountNumber,
           publicAddress: account.publicAddress,
+          memo: 'test',
         },
       ],
     }
 
     // Build the genesis block itself
-    const { block } = await makeGenesisBlock(chain, info, account, node.logger)
+    const { block } = await makeGenesisBlock(chain, info, node.logger)
 
     // Check some parameters on it to make sure they match what's expected.
     expect(block.header.timestamp.valueOf()).toEqual(info.timestamp)

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -7,7 +7,7 @@ import { Target } from '../primitives/target'
 import { IJSON } from '../serde'
 import { createNodeTest } from '../testUtilities'
 import { acceptsAllTarget } from '../testUtilities/helpers/blockchain'
-import { makeGenesisBlock } from './makeGenesisBlock'
+import { GenesisBlockInfo, makeGenesisBlock } from './makeGenesisBlock'
 
 describe('Read genesis block', () => {
   const nodeTest = createNodeTest()
@@ -64,12 +64,12 @@ describe('Create genesis block', () => {
 
     // Construct parameters for the genesis block
     const account = await node.wallet.createAccount('test', true)
-    const info = {
+    const info: GenesisBlockInfo = {
       timestamp: Date.now(),
       target: Target.maxTarget(),
       allocations: [
         {
-          amount: amountNumber,
+          amountInOre: amountNumber,
           publicAddress: account.publicAddress,
           memo: 'test',
         },

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import type { Account } from '../wallet'
 import {
   generateKey,
   Note as NativeNote,


### PR DESCRIPTION
## Summary

The genesis block command doesn't currently allow for more than a single recipient for the genesis coins. This adds support for loading a batch of allocations from a CSV file.

## Testing Plan

* [x] Test some invalid inputs manually to make sure the command handles them.
* [x] Test allocating tokens to multiple addresses and make sure the tokens show up in `accounts:balance --all`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
