### PR TITLE
Remove generate public address flag from getPublicKey rpc

### DIFF
--- a/ironfish-cli/src/commands/accounts/address.ts
+++ b/ironfish-cli/src/commands/accounts/address.ts
@@ -2,12 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { IronfishCommand } from '../../command'
+import { RemoteFlags } from '../../flags'
 
 export class AddressCommand extends IronfishCommand {
   static aliases = ['accounts:publickey']
   static description = `Display your account address
 
   The address for an account is the accounts public key, see more here: https://ironfish.network/docs/whitepaper/5_account`
+
+  static flags = {
+    ...RemoteFlags,
+  }
 
   static args = [
     {

--- a/ironfish-cli/src/commands/accounts/address.ts
+++ b/ironfish-cli/src/commands/accounts/address.ts
@@ -1,24 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { RemoteFlags } from '../../flags'
 
 export class AddressCommand extends IronfishCommand {
   static aliases = ['accounts:publickey']
-  static description = `Display or regenerate your account address
+  static description = `Display your account address
 
   The address for an account is the accounts public key, see more here: https://ironfish.network/docs/whitepaper/5_account`
-
-  static flags = {
-    ...RemoteFlags,
-    generate: Flags.boolean({
-      char: 'g',
-      default: false,
-      description: 'Generate a new address',
-    }),
-  }
 
   static args = [
     {
@@ -30,14 +19,13 @@ export class AddressCommand extends IronfishCommand {
   ]
 
   async start(): Promise<void> {
-    const { args, flags } = await this.parse(AddressCommand)
+    const { args } = await this.parse(AddressCommand)
     const account = args.account as string | undefined
 
     const client = await this.sdk.connectRpc()
 
     const response = await client.getAccountPublicKey({
       account: account,
-      generate: flags.generate,
     })
 
     if (!response) {

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -44,7 +44,7 @@ export interface Key {
   public_address: string
 }
 export function generateKey(): Key
-export function generateNewPublicAddress(privateKey: string): Key
+export function generatePublicAddress(privateKey: string): Key
 export function initializeSapling(): void
 export function isValidPublicAddress(hexAddress: string): boolean
 export class BoxKeyPair {

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -44,7 +44,7 @@ export interface Key {
   public_address: string
 }
 export function generateKey(): Key
-export function generatePublicAddress(privateKey: string): Key
+export function generateKeyFromPrivateKey(privateKey: string): Key
 export function initializeSapling(): void
 export function isValidPublicAddress(hexAddress: string): boolean
 export class BoxKeyPair {

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -236,7 +236,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, GENERATOR_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, TransactionPosted, PROOF_LENGTH, TRANSACTION_VERSION, Transaction, verifyTransactions, generateKey, generatePublicAddress, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, GENERATOR_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, TransactionPosted, PROOF_LENGTH, TRANSACTION_VERSION, Transaction, verifyTransactions, generateKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.KEY_LENGTH = KEY_LENGTH
 module.exports.NONCE_LENGTH = NONCE_LENGTH
@@ -265,7 +265,7 @@ module.exports.TRANSACTION_VERSION = TRANSACTION_VERSION
 module.exports.Transaction = Transaction
 module.exports.verifyTransactions = verifyTransactions
 module.exports.generateKey = generateKey
-module.exports.generatePublicAddress = generatePublicAddress
+module.exports.generateKeyFromPrivateKey = generateKeyFromPrivateKey
 module.exports.initializeSapling = initializeSapling
 module.exports.FoundBlockResult = FoundBlockResult
 module.exports.ThreadPoolHandler = ThreadPoolHandler

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -236,7 +236,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, GENERATOR_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, TransactionPosted, PROOF_LENGTH, TRANSACTION_VERSION, Transaction, verifyTransactions, generateKey, generateNewPublicAddress, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, GENERATOR_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, TransactionPosted, PROOF_LENGTH, TRANSACTION_VERSION, Transaction, verifyTransactions, generateKey, generatePublicAddress, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.KEY_LENGTH = KEY_LENGTH
 module.exports.NONCE_LENGTH = NONCE_LENGTH
@@ -265,7 +265,7 @@ module.exports.TRANSACTION_VERSION = TRANSACTION_VERSION
 module.exports.Transaction = Transaction
 module.exports.verifyTransactions = verifyTransactions
 module.exports.generateKey = generateKey
-module.exports.generateNewPublicAddress = generateNewPublicAddress
+module.exports.generatePublicAddress = generatePublicAddress
 module.exports.initializeSapling = initializeSapling
 module.exports.FoundBlockResult = FoundBlockResult
 module.exports.ThreadPoolHandler = ThreadPoolHandler

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -45,7 +45,7 @@ pub fn generate_key() -> Key {
 }
 
 #[napi]
-pub fn generate_new_public_address(private_key: String) -> Result<Key> {
+pub fn generate_public_address(private_key: String) -> Result<Key> {
     let sapling_key = SaplingKey::from_hex(&private_key).map_err(to_napi_err)?;
 
     Ok(Key {

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -45,7 +45,7 @@ pub fn generate_key() -> Key {
 }
 
 #[napi]
-pub fn generate_public_address(private_key: String) -> Result<Key> {
+pub fn generate_key_from_private_key(private_key: String) -> Result<Key> {
     let sapling_key = SaplingKey::from_hex(&private_key).map_err(to_napi_err)?;
 
     Ok(Key {

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -6,7 +6,7 @@ import { DECRYPTED_NOTE_LENGTH } from '..'
 import {
   initializeSapling,
   generateKey,
-  generateNewPublicAddress,
+  generatePublicAddress,
   Note,
   NoteEncrypted,
   Transaction,
@@ -29,7 +29,7 @@ describe('Demonstrate the Sapling API', () => {
 
   it('Should generate a new public address given a spending key', () => {
     const key = generateKey()
-    const newKey = generateNewPublicAddress(key.spending_key)
+    const newKey = generatePublicAddress(key.spending_key)
 
     expect(key.incoming_view_key).toEqual(newKey.incoming_view_key)
     expect(key.outgoing_view_key).toEqual(newKey.outgoing_view_key)

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -6,7 +6,7 @@ import { DECRYPTED_NOTE_LENGTH } from '..'
 import {
   initializeSapling,
   generateKey,
-  generatePublicAddress,
+  generateKeyFromPrivateKey,
   Note,
   NoteEncrypted,
   Transaction,
@@ -29,7 +29,7 @@ describe('Demonstrate the Sapling API', () => {
 
   it('Should generate a new public address given a spending key', () => {
     const key = generateKey()
-    const newKey = generatePublicAddress(key.spending_key)
+    const newKey = generateKeyFromPrivateKey(key.spending_key)
 
     expect(key.incoming_view_key).toEqual(newKey.incoming_view_key)
     expect(key.outgoing_view_key).toEqual(newKey.outgoing_view_key)

--- a/ironfish/src/rpc/routes/accounts/getPublicKey.test.ts
+++ b/ironfish/src/rpc/routes/accounts/getPublicKey.test.ts
@@ -45,17 +45,4 @@ describe('Route account/getPublicKey', () => {
       publicKey: publicAddress,
     })
   })
-
-  it('should regenerate the account key', async () => {
-    const response = await routeTest.client
-      .request<any>('account/getPublicKey', {
-        account: account.name,
-        generate: true,
-      })
-      .waitForEnd()
-
-    expect(response.status).toBe(200)
-    expect(response.content.account).toEqual(account.name)
-    expect(response.content.publicAddress).not.toEqual(publicAddress)
-  })
 })

--- a/ironfish/src/rpc/routes/accounts/getPublicKey.ts
+++ b/ironfish/src/rpc/routes/accounts/getPublicKey.ts
@@ -5,13 +5,12 @@ import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
-export type GetPublicKeyRequest = { account?: string; generate?: boolean }
+export type GetPublicKeyRequest = { account?: string }
 export type GetPublicKeyResponse = { account: string; publicKey: string }
 
 export const GetPublicKeyRequestSchema: yup.ObjectSchema<GetPublicKeyRequest> = yup
   .object({
     account: yup.string().strip(true),
-    generate: yup.boolean().defined().default(false),
   })
   .defined()
 
@@ -25,12 +24,8 @@ export const GetPublicKeyResponseSchema: yup.ObjectSchema<GetPublicKeyResponse> 
 router.register<typeof GetPublicKeyRequestSchema, GetPublicKeyResponse>(
   `${ApiNamespace.account}/getPublicKey`,
   GetPublicKeyRequestSchema,
-  async (request, node): Promise<void> => {
+  (request, node): void => {
     const account = getAccount(node, request.data.account)
-
-    if (request.data.generate) {
-      await node.wallet.generateNewPublicAddress(account)
-    }
 
     request.end({
       account: account.name,

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -4,7 +4,7 @@
 
 import {
   generateKey,
-  generatePublicAddress,
+  generateKeyFromPrivateKey,
   Key,
   Note as NativeNote,
   Transaction as NativeTransaction,
@@ -92,7 +92,7 @@ describe('Demonstrate the Sapling API', () => {
 
   describe('Can transact between two accounts', () => {
     it('Can create a miner reward', () => {
-      const owner = generatePublicAddress(spenderKey.spending_key).public_address
+      const owner = generateKeyFromPrivateKey(spenderKey.spending_key).public_address
 
       minerNote = new NativeNote(owner, BigInt(42), '')
 
@@ -275,7 +275,7 @@ describe('Demonstrate the Sapling API', () => {
 
       const noteForSpender = new NativeNote(spenderKey.public_address, BigInt(10), '')
       const receiverNoteToSelf = new NativeNote(
-        generatePublicAddress(receiverKey.spending_key).public_address,
+        generateKeyFromPrivateKey(receiverKey.spending_key).public_address,
         BigInt(29),
         '',
       )

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -4,7 +4,7 @@
 
 import {
   generateKey,
-  generateNewPublicAddress,
+  generatePublicAddress,
   Key,
   Note as NativeNote,
   Transaction as NativeTransaction,
@@ -92,7 +92,7 @@ describe('Demonstrate the Sapling API', () => {
 
   describe('Can transact between two accounts', () => {
     it('Can create a miner reward', () => {
-      const owner = generateNewPublicAddress(spenderKey.spending_key).public_address
+      const owner = generatePublicAddress(spenderKey.spending_key).public_address
 
       minerNote = new NativeNote(owner, BigInt(42), '')
 
@@ -275,7 +275,7 @@ describe('Demonstrate the Sapling API', () => {
 
       const noteForSpender = new NativeNote(spenderKey.public_address, BigInt(10), '')
       const receiverNoteToSelf = new NativeNote(
-        generateNewPublicAddress(receiverKey.spending_key).public_address,
+        generatePublicAddress(receiverKey.spending_key).public_address,
         BigInt(29),
         '',
       )

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { generateKey, generateNewPublicAddress } from '@ironfish/rust-nodejs'
+import { generateKey } from '@ironfish/rust-nodejs'
 import { v4 as uuid } from 'uuid'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
@@ -1148,13 +1148,6 @@ export class Wallet {
     }
 
     return this.getAccount(this.defaultAccount)
-  }
-
-  async generateNewPublicAddress(account: Account): Promise<void> {
-    this.assertHasAccount(account)
-    const key = generateNewPublicAddress(account.spendingKey)
-    account.publicAddress = key.public_address
-    await this.walletDb.setAccount(account)
   }
 
   async getEarliestHeadHash(): Promise<Buffer | null> {

--- a/ironfish/src/workerPool/tasks/createMinersFee.ts
+++ b/ironfish/src/workerPool/tasks/createMinersFee.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { generatePublicAddress, Note, Transaction } from '@ironfish/rust-nodejs'
+import { generateKeyFromPrivateKey, Note, Transaction } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
 import { BigIntUtils } from '../../utils'
 import { WorkerMessage, WorkerMessageType } from './workerMessage'
@@ -77,7 +77,7 @@ export class CreateMinersFeeTask extends WorkerTask {
 
   execute({ amount, memo, spendKey, jobId }: CreateMinersFeeRequest): CreateMinersFeeResponse {
     // Generate a public address from the miner's spending key
-    const minerPublicAddress = generatePublicAddress(spendKey).public_address
+    const minerPublicAddress = generateKeyFromPrivateKey(spendKey).public_address
     const minerNote = new Note(minerPublicAddress, amount, memo)
 
     const transaction = new Transaction(spendKey)

--- a/ironfish/src/workerPool/tasks/createMinersFee.ts
+++ b/ironfish/src/workerPool/tasks/createMinersFee.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { generateNewPublicAddress, Note, Transaction } from '@ironfish/rust-nodejs'
+import { generatePublicAddress, Note, Transaction } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
 import { BigIntUtils } from '../../utils'
 import { WorkerMessage, WorkerMessageType } from './workerMessage'
@@ -77,7 +77,7 @@ export class CreateMinersFeeTask extends WorkerTask {
 
   execute({ amount, memo, spendKey, jobId }: CreateMinersFeeRequest): CreateMinersFeeResponse {
     // Generate a public address from the miner's spending key
-    const minerPublicAddress = generateNewPublicAddress(spendKey).public_address
+    const minerPublicAddress = generatePublicAddress(spendKey).public_address
     const minerNote = new Note(minerPublicAddress, amount, memo)
 
     const transaction = new Transaction(spendKey)


### PR DESCRIPTION
## Summary
Remove generate public address flag from getPublicKey rpc
Rename geneartePublicAddress
## Testing Plan
unit tests
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@dguenther 