### PR TITLE
fix(ironfish): Add missing `tx` argument in `getDecryptedNote` calls

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -118,7 +118,7 @@ export class Account {
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.walletDb.db.withTransaction(tx, async (tx) => {
-      const existingNote = await this.getDecryptedNote(noteHash)
+      const existingNote = await this.getDecryptedNote(noteHash, tx)
 
       if (!existingNote || existingNote.spent !== note.spent) {
         const value = note.note.value()
@@ -242,7 +242,7 @@ export class Account {
       const noteHash = await this.getNoteHash(spend.nullifier)
 
       if (noteHash) {
-        const decryptedNote = await this.getDecryptedNote(noteHash)
+        const decryptedNote = await this.getDecryptedNote(noteHash, tx)
         Assert.isNotUndefined(
           decryptedNote,
           'nullifierToNote mappings must have a corresponding decryptedNote',
@@ -266,7 +266,7 @@ export class Account {
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.walletDb.db.withTransaction(tx, async (tx) => {
-      const existingNote = await this.getDecryptedNote(noteHash)
+      const existingNote = await this.getDecryptedNote(noteHash, tx)
 
       if (existingNote) {
         const note = existingNote.note
@@ -322,7 +322,7 @@ export class Account {
     await this.walletDb.db.withTransaction(tx, async (tx) => {
       for (const note of transaction.notes()) {
         const noteHash = note.merkleHash()
-        const decryptedNote = await this.getDecryptedNote(noteHash)
+        const decryptedNote = await this.getDecryptedNote(noteHash, tx)
 
         if (decryptedNote) {
           await this.deleteDecryptedNote(noteHash, transactionHash, tx)
@@ -337,7 +337,7 @@ export class Account {
         const noteHash = await this.getNoteHash(spend.nullifier)
 
         if (noteHash) {
-          const decryptedNote = await this.getDecryptedNote(noteHash)
+          const decryptedNote = await this.getDecryptedNote(noteHash, tx)
           Assert.isNotUndefined(
             decryptedNote,
             'nullifierToNote mappings must have a corresponding decryptedNote',


### PR DESCRIPTION
## Summary

Adds the missing `IDatabaseTransaction` argument when calling `getDecryptedNote` in the Account

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
