### PR TITLE
CI checks for yarn.lock changes manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,16 @@ jobs:
           cache: 'yarn'
 
       - name: Install packages
-        run: yarn --non-interactive --frozen-lockfile --ignore-scripts
+        run: yarn --non-interactive --ignore-scripts
+
+      # Necessary since `--frozen-lockfile` does not work properly in yarn 1.x.
+      # https://github.com/yarnpkg/yarn/issues/5840
+      - name: Check for lockfile changes
+        run: |
+          if [[ $(git status | grep yarn.lock) ]]; then
+            echo "yarn.lock has outstanding updates, please check them in."
+            exit 1
+          fi
 
       - name: Lint
         run: yarn lint

--- a/yarn.lock
+++ b/yarn.lock
@@ -6782,7 +6782,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.7.6:
+handlebars@4.7.7, handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -8986,7 +8986,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^8.0.0:
+node-notifier@8.0.1, node-notifier@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
   integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==


### PR DESCRIPTION
## Summary

Needed because --frozen-lockfile is broken in yarn 1.x. We can probably go back to using --frozen-lockfile if we upgrade to yarn 2.x

Fail with outsanding yarn.lock changes: https://github.com/iron-fish/ironfish/actions/runs/3633233416/jobs/6130008284
Pass with no outstanding yarn.lock changes: https://github.com/iron-fish/ironfish/actions/runs/3633244719/jobs/6130032328

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
