### PR TITLE
Fix call to FeeEstimator.init() in openDB()

### DIFF
--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -83,6 +83,10 @@ export class MemPool {
     })
   }
 
+  async start(): Promise<void> {
+    await this.feeEstimator.init(this.chain)
+  }
+
   count(): number {
     return this.transactions.size
   }

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -277,7 +277,7 @@ export class IronfishNode {
       files,
       config,
       internal,
-      wallet: wallet,
+      wallet,
       metrics,
       memPool,
       workerPool,
@@ -300,7 +300,6 @@ export class IronfishNode {
     try {
       await this.chain.open()
       await this.wallet.open()
-      await this.memPool.feeEstimator.init(this.chain)
     } catch (e) {
       await this.chain.close()
       await this.wallet.close()
@@ -335,6 +334,8 @@ export class IronfishNode {
     if (this.config.get('enableRpc')) {
       await this.rpc.start()
     }
+
+    await this.memPool.start()
 
     this.telemetry.submitNodeStarted()
   }


### PR DESCRIPTION
## Summary

The function is for opening DB connections, this function does not open a database.

The fee estimator should also not take a Wallet. It won't have access to it once we split it out, and the estimator should not be wallet aware. I will fix in a future PR.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
