### PR TITLE
removes unused isLinear from findFork return value

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -342,29 +342,23 @@ describe('Blockchain', () => {
     await expect(chain).toAddBlock(blockC4)
     await expect(chain).toAddBlock(blockD4)
 
-    const { fork: fork1, isLinear: isLinear1 } = await chain.findFork(blockA1, blockA1)
+    const fork1 = await chain.findFork(blockA1, blockA1)
     expect(fork1?.hash.equals(blockA1.header.hash)).toBe(true)
-    expect(isLinear1).toBe(true)
 
-    const { fork: fork2, isLinear: isLinear2 } = await chain.findFork(blockA1, blockA2)
+    const fork2 = await chain.findFork(blockA1, blockA2)
     expect(fork2?.hash.equals(blockA1.header.hash)).toBe(true)
-    expect(isLinear2).toBe(true)
 
-    const { fork: fork3, isLinear: isLinear3 } = await chain.findFork(blockA2, blockB2)
+    const fork3 = await chain.findFork(blockA2, blockB2)
     expect(fork3?.hash.equals(blockA1.header.hash)).toBe(true)
-    expect(isLinear3).toBe(false)
 
-    const { fork: fork4, isLinear: isLinear4 } = await chain.findFork(genesis, blockD4)
+    const fork4 = await chain.findFork(genesis, blockD4)
     expect(fork4?.hash.equals(genesis.hash)).toBe(true)
-    expect(isLinear4).toBe(true)
 
-    const { fork: fork5, isLinear: isLinear5 } = await chain.findFork(blockB3, blockD4)
+    const fork5 = await chain.findFork(blockB3, blockD4)
     expect(fork5?.hash.equals(blockB2.header.hash)).toBe(true)
-    expect(isLinear5).toBe(false)
 
-    const { fork: fork6, isLinear: isLinear6 } = await chain.findFork(blockC4, blockD4)
+    const fork6 = await chain.findFork(blockC4, blockD4)
     expect(fork6?.hash.equals(blockC3.header.hash)).toBe(true)
-    expect(isLinear6).toBe(false)
   })
 
   it('abort reorg after verify error', async () => {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -437,18 +437,13 @@ export class Blockchain {
     headerA: BlockHeader | Block,
     headerB: BlockHeader | Block,
     tx?: IDatabaseTransaction,
-  ): Promise<{
-    fork: BlockHeader
-    isLinear: boolean
-  }> {
+  ): Promise<BlockHeader> {
     if (headerA instanceof Block) {
       headerA = headerA.header
     }
     if (headerB instanceof Block) {
       headerB = headerB.header
     }
-
-    let linear = true
 
     let [base, fork] =
       headerA.sequence < headerB.sequence ? [headerA, headerB] : [headerB, headerA]
@@ -465,14 +460,12 @@ export class Blockchain {
         break
       }
 
-      linear = false
-
       const prev = await this.getPrevious(base, tx)
       Assert.isNotNull(prev)
       base = prev
     }
 
-    return { fork: base, isLinear: linear }
+    return base
   }
 
   /**
@@ -806,8 +799,7 @@ export class Blockchain {
     Assert.isNotNull(oldHead, 'No genesis block with fork')
 
     // Step 0: Find the fork between the two heads
-    const { fork } = await this.findFork(oldHead, newHead, tx)
-    Assert.isNotNull(fork, 'No fork found')
+    const fork = await this.findFork(oldHead, newHead, tx)
 
     // Step 2: Collect all the blocks from the old head to the fork
     const removeIter = this.iterateFrom(oldHead, fork, tx)

--- a/ironfish/src/chainProcessor.ts
+++ b/ironfish/src/chainProcessor.ts
@@ -73,7 +73,7 @@ export class ChainProcessor {
       `Chain processor head not found in chain: ${this.hash.toString('hex')}`,
     )
 
-    const { fork } = await this.chain.findFork(head, chainHead)
+    const fork = await this.chain.findFork(head, chainHead)
 
     // All cases can be handled by rewinding to the fork point
     // and then fast-forwarding to the destination. In cases where `head` and `chainHead`


### PR DESCRIPTION
## Summary

we used to use the `isLinear` value while updating the `chainProcessor`, but after #2586 it is no longer used.

- changes findFork to only return a BlockHeader
- updates uses of findFork
- removes assertion that findFork return value is non-null in reorganizeChain because it cannot be null

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
