### PR TITLE
Remove element field from merkle tree leaves

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -12,7 +12,7 @@ import { Config } from '../fileStores'
 import { FileSystem } from '../fileSystems'
 import { createRootLogger, Logger } from '../logger'
 import { MerkleTree } from '../merkletree'
-import { NoteLeafEncoding, NullifierLeafEncoding } from '../merkletree/database/leaves'
+import { LeafEncoding } from '../merkletree/database/leaves'
 import { NodeEncoding } from '../merkletree/database/nodes'
 import { NoteHasher } from '../merkletree/hasher'
 import { MetricsMonitor } from '../metrics'
@@ -247,7 +247,7 @@ export class Blockchain {
     this.notes = new MerkleTree({
       hasher: new NoteHasher(),
       leafIndexKeyEncoding: BUFFER_ENCODING,
-      leafEncoding: new NoteLeafEncoding(),
+      leafEncoding: new LeafEncoding(),
       nodeEncoding: new NodeEncoding(),
       db: this.db,
       name: 'n',
@@ -258,7 +258,7 @@ export class Blockchain {
     this.nullifiers = new MerkleTree({
       hasher: new NullifierHasher(),
       leafIndexKeyEncoding: BUFFER_ENCODING,
-      leafEncoding: new NullifierLeafEncoding(),
+      leafEncoding: new LeafEncoding(),
       nodeEncoding: new NodeEncoding(),
       db: this.db,
       name: 'u',

--- a/ironfish/src/merkletree/database/leaves.test.ts
+++ b/ironfish/src/merkletree/database/leaves.test.ts
@@ -1,45 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { generateKey, Note, Transaction, TransactionPosted } from '@ironfish/rust-nodejs'
-import { NoteEncrypted } from '../../primitives/noteEncrypted'
-import { NoteLeafEncoding, NullifierLeafEncoding } from './leaves'
+import { LeafEncoding } from './leaves'
 
-describe('NoteLeafEncoding', () => {
+describe('LeafEncoding', () => {
   it('serializes the object into a buffer and deserializes to the original object', () => {
-    const encoding = new NoteLeafEncoding()
-    const key = generateKey()
-    const note = new Note(key.public_address, 10n, '')
-    const tx = new Transaction(key.spending_key)
-    tx.receive(note)
-    const buf = tx.post_miners_fee()
-    const txp = new TransactionPosted(buf)
-    const noteEncrypted = new NoteEncrypted(txp.getNote(0))
-
-    const noteLeafValue = {
-      element: noteEncrypted,
+    const encoding = new LeafEncoding()
+    const leafValue = {
       merkleHash: Buffer.alloc(32, 'hashOfSibling'),
       parentIndex: 14,
     } as const
 
-    const buffer = encoding.serialize(noteLeafValue)
+    const buffer = encoding.serialize(leafValue)
     const deserializedMessage = encoding.deserialize(buffer)
-    expect(deserializedMessage).toEqual(noteLeafValue)
-  })
-})
-
-describe('NullifierLeafEncoding', () => {
-  it('serializes the object into a buffer and deserializes to the original object', () => {
-    const encoding = new NullifierLeafEncoding()
-
-    const nullifierLeafValue = {
-      element: Buffer.alloc(32, 'element'),
-      merkleHash: Buffer.alloc(32, 'hashOfSibling'),
-      parentIndex: 14,
-    } as const
-
-    const buffer = encoding.serialize(nullifierLeafValue)
-    const deserializedMessage = encoding.deserialize(buffer)
-    expect(deserializedMessage).toEqual(nullifierLeafValue)
+    expect(deserializedMessage).toEqual(leafValue)
   })
 })

--- a/ironfish/src/merkletree/database/leaves.ts
+++ b/ironfish/src/merkletree/database/leaves.ts
@@ -3,42 +3,30 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { IDatabaseEncoding } from '../../storage/database/types'
-import { ENCRYPTED_NOTE_LENGTH } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import { NoteEncrypted } from '../../primitives/noteEncrypted'
 
-export interface LeafValue<T> {
-  element: T
+export interface LeafValue {
   merkleHash: Buffer
   parentIndex: number
 }
 
-const NULLIFIER_BYTES = 32
-
-export type NoteLeafValue = LeafValue<NoteEncrypted>
-
-export type NullifierLeafValue = LeafValue<Buffer>
-
-export class NoteLeafEncoding implements IDatabaseEncoding<NoteLeafValue> {
-  serialize(value: NoteLeafValue): Buffer {
+export class LeafEncoding implements IDatabaseEncoding<LeafValue> {
+  serialize(value: LeafValue): Buffer {
     const bw = bufio.write(this.getSize())
 
-    bw.writeBytes(value.element.serialize())
     bw.writeHash(value.merkleHash)
     bw.writeU32(value.parentIndex)
 
     return bw.render()
   }
 
-  deserialize(buffer: Buffer): NoteLeafValue {
+  deserialize(buffer: Buffer): LeafValue {
     const reader = bufio.read(buffer, true)
 
-    const element = new NoteEncrypted(reader.readBytes(ENCRYPTED_NOTE_LENGTH))
     const merkleHash = reader.readHash()
     const parentIndex = reader.readU32()
 
     return {
-      element,
       merkleHash,
       parentIndex,
     }
@@ -46,41 +34,6 @@ export class NoteLeafEncoding implements IDatabaseEncoding<NoteLeafValue> {
 
   getSize(): number {
     let size = 0
-    size += ENCRYPTED_NOTE_LENGTH // element
-    size += 32 // merkleHash
-    size += 4 // parentIndex
-    return size
-  }
-}
-
-export class NullifierLeafEncoding implements IDatabaseEncoding<NullifierLeafValue> {
-  serialize(value: NullifierLeafValue): Buffer {
-    const bw = bufio.write(this.getSize())
-
-    bw.writeBytes(value.element)
-    bw.writeHash(value.merkleHash)
-    bw.writeU32(value.parentIndex)
-
-    return bw.render()
-  }
-
-  deserialize(buffer: Buffer): NullifierLeafValue {
-    const reader = bufio.read(buffer, true)
-
-    const element = reader.readBytes(NULLIFIER_BYTES)
-    const merkleHash = reader.readHash()
-    const parentIndex = reader.readU32()
-
-    return {
-      element,
-      merkleHash,
-      parentIndex,
-    }
-  }
-
-  getSize(): number {
-    let size = 0
-    size += NULLIFIER_BYTES // element
     size += 32 // merkleHash
     size += 4 // parentIndex
     return size

--- a/ironfish/src/merkletree/merkletree.test.ts
+++ b/ironfish/src/merkletree/merkletree.test.ts
@@ -40,14 +40,11 @@ describe('Merkle tree', function () {
     await tree2.add('B')
 
     expect(await tree1.size()).toBe(1)
-    expect(await tree1.get(0)).toBe('a')
     expect(await tree1.rootHash()).toBe(
       '<<<<a|a-0>|<a|a-0>-1>|<<a|a-0>|<a|a-0>-1>-2>|<<<a|a-0>|<a|a-0>-1>|<<a|a-0>|<a|a-0>-1>-2>-3>',
     )
 
     expect(await tree2.size()).toBe(2)
-    expect(await tree2.get(0)).toBe('A')
-    expect(await tree2.get(1)).toBe('B')
     expect(await tree2.rootHash()).toBe(
       '<<<<A|B-0>|<A|B-0>-1>|<<A|B-0>|<A|B-0>-1>-2>|<<<A|B-0>|<A|B-0>-1>|<<A|B-0>|<A|B-0>-1>-2>-3>',
     )
@@ -285,17 +282,6 @@ describe('Merkle tree', function () {
 
     await expect(tree).toMatchTree(await makeTree({ leaves: 'axy' }))
     await expect(tree.size()).resolves.toBe(3)
-  })
-
-  it('iterates over leaves', async () => {
-    const tree = await makeTree({ leaves: 'abcd' })
-
-    let leaves = ''
-    for await (const leaf of tree.getLeaves()) {
-      leaves += leaf
-    }
-
-    expect(leaves).toBe('abcd')
   })
 
   it('calculates past and current root hashes correctly', async () => {
@@ -646,18 +632,6 @@ describe('Merkle tree', function () {
       }
       expect(witness.rootHash).toEqual(rootHash)
     }
-  })
-
-  it("throws an error when getting a position that doesn't exist", async () => {
-    const tree = await makeTree()
-    await expect(() => tree.get(99)).rejects.toThrowError(
-      `No leaf found in tree ${tree.name} at index 99`,
-    )
-
-    await tree.add('1')
-    await expect(() => tree.get(99)).rejects.toThrowError(
-      `No leaf found in tree ${tree.name} at index 99`,
-    )
   })
 
   it('calculates correct depths', () => {

--- a/ironfish/src/merkletree/schema.ts
+++ b/ironfish/src/merkletree/schema.ts
@@ -12,10 +12,9 @@ interface CounterEntry<T extends string> extends DatabaseSchema {
 
 export type CounterSchema = CounterEntry<'Leaves'> | CounterEntry<'Nodes'>
 
-export interface LeavesSchema<E, H> extends DatabaseSchema {
+export interface LeavesSchema<H> extends DatabaseSchema {
   key: LeafIndex
   value: {
-    element: E
     merkleHash: H
     parentIndex: NodeIndex
   }

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
 import {
   generateKey,
   generateKeyFromPrivateKey,
@@ -12,7 +11,7 @@ import {
 } from '@ironfish/rust-nodejs'
 import { ConsensusParameters, TestnetConsensus } from './consensus'
 import { MerkleTree } from './merkletree'
-import { NoteLeafEncoding } from './merkletree/database/leaves'
+import { LeafEncoding } from './merkletree/database/leaves'
 import { NodeEncoding } from './merkletree/database/nodes'
 import { NoteHasher } from './merkletree/hasher'
 import { Note } from './primitives/note'
@@ -43,7 +42,7 @@ async function makeStrategyTree({
   const tree = new MerkleTree({
     hasher: new NoteHasher(),
     leafIndexKeyEncoding: BUFFER_ENCODING,
-    leafEncoding: new NoteLeafEncoding(),
+    leafEncoding: new LeafEncoding(),
     nodeEncoding: new NodeEncoding(),
     db: database,
     name: name,
@@ -239,7 +238,9 @@ describe('Demonstrate the Sapling API', () => {
 
     it('Decrypts and fails to decrypt notes', async () => {
       // Get the note we added in the previous example
-      const latestNote = await tree.get(receiverWitnessIndex)
+      const leaf = await tree.getLeaf(receiverWitnessIndex)
+      const latestNote = new NoteEncrypted(publicTransaction.getNote(0))
+      expect(leaf.merkleHash.equals(latestNote.merkleHash())).toBe(true)
 
       // We should be able to decrypt the note as owned by the receiver
       const decryptedNote = latestNote.decryptNoteForOwner(receiverKey.incoming_view_key)

--- a/ironfish/src/testUtilities/helpers/merkletree.ts
+++ b/ironfish/src/testUtilities/helpers/merkletree.ts
@@ -11,7 +11,6 @@ import { IDatabase, IDatabaseEncoding, StringEncoding } from '../../storage'
 import { createTestDB } from '../helpers/storage'
 
 type StructureLeafValue = {
-  element: string
   merkleHash: string
   parentIndex: number
 }
@@ -20,7 +19,6 @@ class StructureLeafEncoding implements IDatabaseEncoding<StructureLeafValue> {
   serialize(value: StructureLeafValue): Buffer {
     const bw = bufio.write()
 
-    bw.writeVarString(value.element)
     bw.writeVarString(value.merkleHash)
     bw.writeU32(value.parentIndex)
 
@@ -30,12 +28,10 @@ class StructureLeafEncoding implements IDatabaseEncoding<StructureLeafValue> {
   deserialize(buffer: Buffer): StructureLeafValue {
     const bw = bufio.read(buffer, true)
 
-    const element = bw.readVarString()
     const merkleHash = bw.readVarString()
     const parentIndex = bw.readU32()
 
     return {
-      element,
       merkleHash,
       parentIndex,
     }

--- a/ironfish/src/testUtilities/matchers/merkletree.ts
+++ b/ironfish/src/testUtilities/matchers/merkletree.ts
@@ -40,9 +40,7 @@ expect.extend({
 
       const leaf = await tree.getLeaf(i)
 
-      if (leaf.element !== characters[i]) {
-        error = `expected element ${i} to be ${characters[i]}, but it is ${leaf.element}`
-      } else if (leaf.merkleHash !== characters[i]) {
+      if (leaf.merkleHash !== characters[i]) {
         error = `expected element ${i} to have hash ${characters[i]}, but it is ${leaf.merkleHash}`
       } else if (leaf.parentIndex !== parents[i]) {
         error = `expected element ${i} to have parent ${parents[i]}, but it is ${leaf.parentIndex}`

--- a/ironfish/src/workerPool/tasks/createTransaction.test.slow.ts
+++ b/ironfish/src/workerPool/tasks/createTransaction.test.slow.ts
@@ -5,7 +5,7 @@
 import { Asset, TransactionPosted } from '@ironfish/rust-nodejs'
 import { BufferMap } from 'buffer-map'
 import { Assert } from '../../assert'
-import { NoteLeafEncoding } from '../../merkletree/database/leaves'
+import { LeafEncoding } from '../../merkletree/database/leaves'
 import { NodeEncoding } from '../../merkletree/database/nodes'
 import { NoteHasher } from '../../merkletree/hasher'
 import { MerkleTree, Side } from '../../merkletree/merkletree'
@@ -40,7 +40,7 @@ async function makeStrategyTree({
   const tree = new MerkleTree({
     hasher: new NoteHasher(),
     leafIndexKeyEncoding: BUFFER_ENCODING,
-    leafEncoding: new NoteLeafEncoding(),
+    leafEncoding: new LeafEncoding(),
     nodeEncoding: new NodeEncoding(),
     db: database,
     name: name,


### PR DESCRIPTION
## Summary

Removes the element field from merkle tree leaves, since we only use it for tests. This should save a minimum of 328MB per 1000 blocks, assuming that all 1000 blocks only have a miners transaction.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
