### PR TITLE
Remove array.at(0) function in PriorityQueue

### DIFF
--- a/ironfish/src/memPool/priorityQueue.ts
+++ b/ironfish/src/memPool/priorityQueue.ts
@@ -64,7 +64,7 @@ export class PriorityQueue<T> {
    * Look at the highest priority item in the queue without removing it
    */
   peek(): T | undefined {
-    return this._items.at(0)
+    return this._items[0]
   }
 
   /**


### PR DESCRIPTION
## Summary
We were getting reports of [issues](https://github.com/iron-fish/ironfish/issues/2376) with using the `.at` function on arrays so changing this to just index into the array directly. It looks like `.at()` is supported in [NodeJS 16 and onward](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at#browser_compatibility) so best guess is that these clients were running older node version but will try to confirm that. Either way it would be nice for it to work with older node versions anyway.

## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
