### PR TITLE
Require node 16

### DIFF
--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -8,7 +8,7 @@ if (process.platform !== 'win32') {
 }
 
 if(process.versions.node.split('.')[0] !== '16') {
-  console.log('Node version ' +  process.versions.node + ' is not compatible. Must have node v16.x installed. You can install using nvm: https://github.com/nvm-sh/nvm')
+  console.log('NodeJS version ' +  process.versions.node + ' is not compatible. Must have node v16.x installed. You can install using nvm: https://github.com/nvm-sh/nvm')
   process.exit(1)
 }
 

--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -7,7 +7,7 @@ if (process.platform !== 'win32') {
   require('segfault-handler').registerHandler('segfault.log')
 }
 
-if(process.versions.node.split('.')[0] === '16') {
+if(process.versions.node.split('.')[0] !== '16') {
   console.log('Node version ' +  process.versions.node + ' is not compatible. Must have node v16.x installed. You can install using nvm: https://github.com/nvm-sh/nvm')
   process.exit(1)
 }

--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -7,6 +7,11 @@ if (process.platform !== 'win32') {
   require('segfault-handler').registerHandler('segfault.log')
 }
 
+if(process.versions.node.split('.')[0] === '16') {
+  console.log('Node version ' +  process.versions.node + ' is not compatible. Must have node v16.x installed. You can install using nvm: https://github.com/nvm-sh/nvm')
+  process.exit(1)
+}
+
 require('@oclif/core').run()
 .then(require('@oclif/core/flush'))
 .catch(require('@oclif/core/handle'))

--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -8,7 +8,7 @@ if (process.platform !== 'win32') {
 }
 
 if(process.versions.node.split('.')[0] !== '16') {
-  console.log('NodeJS version ' +  process.versions.node + ' is not compatible. Must have node v16.x installed. You can install using nvm: https://github.com/nvm-sh/nvm')
+  console.log('NodeJS version ' +  process.versions.node + ' is not compatible. Must have node v16.x installed: https://nodejs.org/en/blog/release/v16.16.0')
   process.exit(1)
 }
 


### PR DESCRIPTION
## Summary
The CLI is built to run on node version 16. We have run into one [issue](https://github.com/iron-fish/ironfish/issues/2376) that arose from incompatible node version. We should require users to be using the correct node version so we do not run into these versioning errors.

## Testing Plan
Local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
