### PR TITLE
Set sender address from spender key

### DIFF
--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -65,7 +65,7 @@ impl NativeNote {
                 value_u64,
                 memo,
                 NATIVE_ASSET_GENERATOR,
-                sender_address_placeholder,
+                Some(sender_address_placeholder),
             ),
         })
     }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -121,10 +121,12 @@ impl ProposedTransaction {
 
     /// Create a proof of a new note owned by the recipient in this
     /// transaction.
-    pub fn add_output(&mut self, note: Note) {
+    pub fn add_output(&mut self, mut note: Note) {
         self.value_balances
             .subtract(&note.asset_identifier(), note.value() as i64);
 
+        // set sender address from spender key
+        note.sender = Some(self.spender_key.public_address());
         self.outputs.push(OutputBuilder::new(note));
     }
 
@@ -177,7 +179,7 @@ impl ProposedTransaction {
                     change_amount as u64, // we checked it was positive
                     "",
                     SubgroupPoint::from_bytes(asset_identifier).unwrap(),
-                    self.spender_key.public_address(),
+                    Some(self.spender_key.public_address()),
                 );
 
                 change_notes.push(change_note);

--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -98,7 +98,7 @@ impl OutputBuilder {
                 &self.note,
                 &self.value_commitment,
                 &diffie_hellman_keys,
-            )
+            )?
         };
 
         let output_proof = OutputDescription { proof, merkle_note };
@@ -222,14 +222,13 @@ mod test {
     /// set will use the hard-coded note encryption keys
     fn test_output_miners_fee() {
         let spender_key = SaplingKey::generate_key();
-        let sender_key = SaplingKey::generate_key();
 
         let note = Note::new(
             spender_key.public_address(),
             42,
             "",
             NATIVE_ASSET_GENERATOR,
-            sender_key.public_address(),
+            None,
         );
 
         let mut output = OutputBuilder::new(note);
@@ -255,7 +254,7 @@ mod test {
             42,
             "",
             NATIVE_ASSET_GENERATOR,
-            spender_key.public_address(),
+            Some(spender_key.public_address()),
         );
 
         let output = OutputBuilder::new(note);
@@ -271,6 +270,26 @@ mod test {
     }
 
     #[test]
+    fn test_output_not_miners_fee_with_empty_sender() {
+        let spender_key = SaplingKey::generate_key();
+        let receiver_key = SaplingKey::generate_key();
+
+        let note = Note::new(
+            receiver_key.public_address(),
+            42,
+            "",
+            NATIVE_ASSET_GENERATOR,
+            None,
+        );
+
+        let output = OutputBuilder::new(note);
+
+        let proof = output.build(&spender_key);
+
+        assert!(proof.is_err());
+    }
+
+    #[test]
     fn test_output_round_trip() {
         let spender_key = SaplingKey::generate_key();
         let receiver_key = SaplingKey::generate_key();
@@ -280,7 +299,7 @@ mod test {
             42,
             "",
             NATIVE_ASSET_GENERATOR,
-            spender_key.public_address(),
+            Some(spender_key.public_address()),
         );
 
         let output = OutputBuilder::new(note);

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -408,7 +408,6 @@ mod test {
     fn test_spend_round_trip() {
         let key = SaplingKey::generate_key();
         let public_address = key.public_address();
-        let sender_key = SaplingKey::generate_key();
 
         let note_randomness = random();
 
@@ -417,7 +416,7 @@ mod test {
             note_randomness,
             "",
             NATIVE_ASSET_GENERATOR,
-            sender_key.public_address(),
+            None,
         );
         let witness = make_fake_witness(&note);
 


### PR DESCRIPTION
## Summary
- Allow optional for the sender address in the Note since the sender address will be populated from spender key. No need to pass in externally
- Set sender address from spender key when building Output 
- Validation on sender address when creating Merkle note
- Validation of sender address is only on the Output side, no check on the note in Spend. If the note in spend has no sender address, it won't break
- 
## Testing Plan
unit tests
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@mat-if @jowparks 