### PR TITLE
Remove the V3_DISABLE_MINING_REWARD consensus param

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -850,24 +850,4 @@ describe('Blockchain', () => {
     await expect(nodeA.chain).toAddBlock(blockA6)
     expect(nodeA.chain.head.hash.equals(blockA6.header.hash)).toBe(true)
   })
-
-  it('does not grant mining reward after V3_DISABLE_MINING_REWARD', async () => {
-    const { node } = await nodeTest.createSetup()
-    node.chain.consensus.V3_DISABLE_MINING_REWARD = 3
-    const account = await useAccountFixture(node.wallet)
-
-    const block1 = await useMinerBlockFixture(node.chain, 2, account)
-    expect(block1.minersFee.fee()).toEqual(-20n * 10n ** 8n)
-    expect(block1.minersFee.spendsLength()).toEqual(0)
-    expect(block1.minersFee.notesLength()).toEqual(1)
-    await expect(node.chain).toAddBlock(block1)
-
-    const block2 = await useMinerBlockFixture(node.chain, 3, account)
-    expect(block2.minersFee.fee()).toEqual(0n)
-    expect(block2.minersFee.spendsLength()).toEqual(0)
-    expect(block2.minersFee.notesLength()).toEqual(1)
-    await expect(node.chain).toAddBlock(block2)
-
-    await node.wallet.updateHead()
-  })
 })

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -41,11 +41,6 @@ export class Consensus {
    */
   V2_MAX_BLOCK_SIZE = 0
 
-  /**
-   * All mined blocks give 0 mining reward
-   */
-  V3_DISABLE_MINING_REWARD = Number.MAX_SAFE_INTEGER
-
   constructor(parameters: ConsensusParameters) {
     this.parameters = parameters
   }
@@ -59,6 +54,5 @@ export class TestnetConsensus extends Consensus {
   constructor(parameters: ConsensusParameters) {
     super(parameters)
     this.V2_MAX_BLOCK_SIZE = 255000
-    this.V3_DISABLE_MINING_REWARD = 279900
   }
 }

--- a/ironfish/src/strategy.test.ts
+++ b/ironfish/src/strategy.test.ts
@@ -47,10 +47,4 @@ describe('Miners reward', () => {
     const minersReward = strategy.miningReward(ironFishYearInBlocks + 1)
     expect(minersReward).toBe(19 * 10 ** 8)
   })
-
-  it('miner reward is 0 after V3 activation', () => {
-    strategy.consensus.V3_DISABLE_MINING_REWARD = 1000
-    expect(strategy.miningReward(999)).toBe(20 * 10 ** 8)
-    expect(strategy.miningReward(1005)).toBe(0)
-  })
 })

--- a/ironfish/src/strategy.ts
+++ b/ironfish/src/strategy.ts
@@ -39,10 +39,6 @@ export class Strategy {
    * @returns mining reward (in ORE) per block given the block sequence
    */
   miningReward(sequence: number): number {
-    if (this.consensus.isActive(this.consensus.V3_DISABLE_MINING_REWARD, sequence)) {
-      return 0
-    }
-
     const ironFishYearInBlocks =
       (365 * 24 * 60 * 60) / this.consensus.parameters.targetBlockTimeInSeconds
     const yearsAfterLaunch = Math.floor(Number(sequence) / ironFishYearInBlocks)


### PR DESCRIPTION
## Summary

Removes a consensus parameter we used at the end of phase 2 to disable the miner's reward.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```

Breaks compatibility with prior versions that support disabling the miner reward.