### PR TITLE
refactor(rust): Add a struct for ephemeral key pairs

### DIFF
--- a/ironfish-rust/src/keys/ephemeral.rs
+++ b/ironfish-rust/src/keys/ephemeral.rs
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use ff::Field;
 use ironfish_zkp::constants::PUBLIC_KEY_GENERATOR;
 use rand::thread_rng;

--- a/ironfish-rust/src/keys/ephemeral.rs
+++ b/ironfish-rust/src/keys/ephemeral.rs
@@ -30,3 +30,20 @@ impl EphemeralKeyPair {
         &self.public
     }
 }
+
+#[cfg(test)]
+mod test {
+    use ironfish_zkp::constants::PUBLIC_KEY_GENERATOR;
+
+    use super::EphemeralKeyPair;
+
+    #[test]
+    fn test_ephemeral_key_pair() {
+        let key_pair = EphemeralKeyPair::new();
+
+        assert_eq!(*key_pair.public(), PUBLIC_KEY_GENERATOR * key_pair.secret());
+
+        assert_eq!(key_pair.public(), &key_pair.public);
+        assert_eq!(key_pair.secret(), &key_pair.secret);
+    }
+}

--- a/ironfish-rust/src/keys/ephemeral.rs
+++ b/ironfish-rust/src/keys/ephemeral.rs
@@ -1,0 +1,32 @@
+use ff::Field;
+use ironfish_zkp::constants::PUBLIC_KEY_GENERATOR;
+use rand::thread_rng;
+
+/// Diffie Hellman key exchange pair as used in note encryption.
+///
+/// This can be used according to the protocol described in
+/// [`crate::keys::shared_secret`]
+#[derive(Default)]
+pub struct EphemeralKeyPair {
+    secret: jubjub::Fr,
+    public: jubjub::SubgroupPoint,
+}
+
+impl EphemeralKeyPair {
+    pub fn new() -> Self {
+        let secret = jubjub::Fr::random(thread_rng());
+
+        Self {
+            secret,
+            public: PUBLIC_KEY_GENERATOR * secret,
+        }
+    }
+
+    pub fn secret(&self) -> &jubjub::Fr {
+        &self.secret
+    }
+
+    pub fn public(&self) -> &jubjub::SubgroupPoint {
+        &self.public
+    }
+}

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -19,6 +19,8 @@ use rand::prelude::*;
 
 use std::io;
 
+mod ephemeral;
+pub use ephemeral::EphemeralKeyPair;
 mod public_address;
 pub use public_address::*;
 mod view_keys;

--- a/ironfish-rust/src/keys/public_address.rs
+++ b/ironfish-rust/src/keys/public_address.rs
@@ -6,11 +6,9 @@ use crate::{
     errors::IronfishError,
     serializing::{bytes_to_hex, hex_to_bytes},
 };
-use ff::Field;
 use group::GroupEncoding;
 use ironfish_zkp::constants::PUBLIC_KEY_GENERATOR;
 use jubjub::SubgroupPoint;
-use rand::thread_rng;
 
 use std::{convert::TryInto, io};
 
@@ -106,22 +104,6 @@ impl PublicAddress {
         } else {
             Err(IronfishError::InvalidPaymentAddress)
         }
-    }
-
-    /// Calculate secret key and ephemeral public key for Diffie Hellman
-    /// Key exchange as used in note encryption.
-    ///
-    /// The returned values can be used according to the protocol described in
-    /// the module-level shared_secret function
-    ///
-    /// Returns a tuple of:
-    ///  *  the ephemeral secret key as a scalar FS
-    ///  *  the ephemeral public key as an edwards point
-    pub fn generate_diffie_hellman_keys(&self) -> (jubjub::Fr, SubgroupPoint) {
-        let secret_key: jubjub::Fr = jubjub::Fr::random(thread_rng());
-        let public_key = PUBLIC_KEY_GENERATOR * secret_key;
-
-        (secret_key, public_key)
     }
 }
 

--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::keys::PUBLIC_ADDRESS_SIZE;
+use crate::keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE};
 
 use super::{shared_secret, PublicAddress, SaplingKey};
 use group::Curve;
@@ -24,15 +24,14 @@ fn test_key_generation_and_construction() {
 fn test_diffie_hellman_shared_key() {
     let key1: SaplingKey = SaplingKey::generate_key();
 
-    // second address has to use the same diversifier for the keys to be valid
     let address1 = key1.public_address();
-    let (secret_key, public_key) = address1.generate_diffie_hellman_keys();
-    let shared_secret1 = shared_secret(&secret_key, &address1.transmission_key, &public_key);
-    let shared_secret2 = shared_secret(
-        &key1.incoming_viewing_key.view_key,
-        &public_key,
-        &public_key,
-    );
+
+    let key_pair = EphemeralKeyPair::new();
+    let secret_key = key_pair.secret();
+    let public_key = key_pair.public();
+
+    let shared_secret1 = shared_secret(secret_key, &address1.transmission_key, public_key);
+    let shared_secret2 = shared_secret(&key1.incoming_viewing_key.view_key, public_key, public_key);
     assert_eq!(shared_secret1, shared_secret2);
 }
 

--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -10,19 +10,16 @@ use jubjub::ExtendedPoint;
 
 #[test]
 fn test_key_generation_and_construction() {
-    let key: SaplingKey = SaplingKey::generate_key();
-    let key2: SaplingKey = SaplingKey::new(key.spending_key).unwrap();
+    let key = SaplingKey::generate_key();
+    let key2 = SaplingKey::new(key.spending_key).unwrap();
     assert!(key.spending_key != [0; 32]);
     assert!(key2.spending_key == key.spending_key);
     assert!(key2.incoming_viewing_key.view_key == key.incoming_viewing_key.view_key);
-
-    // should not fail or infinite loop
-    key2.public_address();
 }
 
 #[test]
 fn test_diffie_hellman_shared_key() {
-    let key1: SaplingKey = SaplingKey::generate_key();
+    let key1 = SaplingKey::generate_key();
 
     let address1 = key1.public_address();
 
@@ -36,14 +33,47 @@ fn test_diffie_hellman_shared_key() {
 }
 
 #[test]
+fn test_diffie_hellman_shared_key_with_other_key() {
+    let key = SaplingKey::generate_key();
+    let third_party_key = SaplingKey::generate_key();
+
+    let address = key.public_address();
+    let third_party_address = third_party_key.public_address();
+
+    let key_pair = EphemeralKeyPair::new();
+    let secret_key = key_pair.secret();
+    let public_key = key_pair.public();
+
+    let shared_secret1 = shared_secret(secret_key, &address.transmission_key, public_key);
+    let shared_secret2 = shared_secret(&key.incoming_viewing_key.view_key, public_key, public_key);
+    assert_eq!(shared_secret1, shared_secret2);
+
+    let shared_secret_third_party1 = shared_secret(
+        secret_key,
+        &third_party_address.transmission_key,
+        public_key,
+    );
+    assert_ne!(shared_secret1, shared_secret_third_party1);
+    assert_ne!(shared_secret2, shared_secret_third_party1);
+
+    let shared_secret_third_party2 = shared_secret(
+        &third_party_key.incoming_viewing_key.view_key,
+        public_key,
+        public_key,
+    );
+    assert_ne!(shared_secret1, shared_secret_third_party2);
+    assert_ne!(shared_secret2, shared_secret_third_party2);
+}
+
+#[test]
 fn test_serialization() {
-    let key: SaplingKey = SaplingKey::generate_key();
+    let key = SaplingKey::generate_key();
     let mut serialized_key = [0; PUBLIC_ADDRESS_SIZE];
     key.write(&mut serialized_key[..])
         .expect("Should be able to serialize key");
     assert_ne!(serialized_key, [0; PUBLIC_ADDRESS_SIZE]);
 
-    let read_back_key: SaplingKey = SaplingKey::read(&mut serialized_key.as_ref())
+    let read_back_key = SaplingKey::read(&mut serialized_key.as_ref())
         .expect("Should be able to load key from valid bytes");
     assert_eq!(
         read_back_key.incoming_view_key().view_key,
@@ -67,11 +97,11 @@ fn test_serialization() {
 
 #[test]
 fn test_hex_conversion() {
-    let key: SaplingKey = SaplingKey::generate_key();
+    let key = SaplingKey::generate_key();
 
     let hex = key.hex_spending_key();
     assert_eq!(hex.len(), 64);
-    let second_key: SaplingKey = SaplingKey::from_hex(&hex).unwrap();
+    let second_key = SaplingKey::from_hex(&hex).unwrap();
     assert_eq!(second_key.spending_key, key.spending_key);
 
     let address = key.public_address();

--- a/ironfish-rust/src/keys/view_keys.rs
+++ b/ironfish-rust/src/keys/view_keys.rs
@@ -154,28 +154,25 @@ pub struct ViewKeys {
 /// Derive a shared secret key from a secret key and the other person's public
 /// key.
 ///
-///
 /// The shared secret point is calculated by multiplying the public and private
 /// keys. This gets converted to bytes and hashed together with the reference
 /// public key to generate the final shared secret as used in encryption.
 
 /// A Diffie Hellman key exchange might look like this:
-///  *  alice generates her DH secret key as SaplingKeys::internal_viewing_key
-///  *  alice chooses a diversifier and publishes it and the transmission key
-///     generated from it as a PublicAddress
-///      *  The transmission key becomes her DH public_key
-///  *  Bob chooses some randomness as his secret key using the
-///     generate_diffie_hellman_keys method on alice's PublicAddress
-///  *  That method calculates bob's public key as (alice diversifier * bob secret key)
+///  *  Alice generates her DH secret key as SaplingKeys::internal_viewing_key
+///  *  Alice publishes her Public key
+///      *  This becomes her DH public_key
+///  *  Bob chooses some randomness as his secret key
+///  *  Bob's public key is calculated as (PUBLIC_KEY_GENERATOR * Bob secret key)
 ///      *  This public key becomes the reference public key for both sides
-///      *  bob sends public key to Alice
-///  *  bob calculates shared secret key as (alice public key * bob secret key)
-///      *  which is (alice transmission key * bob secret key)
-///      *  maths to (alice internal viewing key * diversifier * bob secret key)
-///  *  alice calculates shared secret key as (bob public key * alice internal viewing key)
-///      *  this maths to (alice diversifier * bob secret key * alice internal viewing key)
-///  *  both alice and bob hash the shared secret key with the reference public
-///     key (bob's public key) to get the final shared secret
+///      *  Bob sends public key to Alice
+///  *  Bob calculates shared secret key as (Alice public key * Bob secret key)
+///      *  which is (Alice public key * Bob secret key)
+///      *  which is equivalent to (Alice internal viewing key * PUBLIC_KEY_GENERATOR * Bob secret key)
+///  *  Alice calculates shared secret key as (Bob public key * Alice internal viewing key)
+///      *  which is equivalent to (Alice internal viewing key * PUBLIC_KEY_GENERATOR * Bob secret key)
+///  *  both Alice and Bob hash the shared secret key with the reference public
+///     key (Bob's public key) to get the final shared secret
 ///
 /// The resulting key can be used in any symmetric cipher
 pub(crate) fn shared_secret(

--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -3,7 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    errors::IronfishError, keys::SaplingKey, merkle_note::MerkleNote, note::Note,
+    errors::IronfishError,
+    keys::{EphemeralKeyPair, SaplingKey},
+    merkle_note::MerkleNote,
+    note::Note,
     sapling_bls12::SAPLING,
 };
 
@@ -77,13 +80,13 @@ impl OutputBuilder {
         &self,
         spender_key: &SaplingKey,
     ) -> Result<OutputDescription, IronfishError> {
-        let diffie_hellman_keys = self.note.owner.generate_diffie_hellman_keys();
+        let diffie_hellman_keys = EphemeralKeyPair::new();
 
         let circuit = Output {
             value_commitment: Some(self.value_commitment.clone()),
             payment_address: Some(self.note.owner.transmission_key),
             commitment_randomness: Some(self.note.randomness),
-            esk: Some(diffie_hellman_keys.0),
+            esk: Some(*diffie_hellman_keys.secret()),
             asset_generator: Some(self.note.asset_generator().into()),
         };
 


### PR DESCRIPTION
## Summary

This creates a distinct struct to avoid having to mess around with tuples. It also removes the `generate_diffie_hellman_keys` function from the PublicAddress since it's no longer related to the PublicAddress with the removal of the diversifier

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
