### PR TITLE
Remove V2_MAX_BLOCK_SIZE consensus param

### DIFF
--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -33,14 +33,6 @@ export type ConsensusParameters = {
 export class Consensus {
   readonly parameters: ConsensusParameters
 
-  /**
-   * Before upgrade V2 we didn't enforce max block size.
-   * At this block we check that the block size doesn't exceed maxBlockSizeBytes.
-   *
-   * TODO: remove this sequence check before mainnet
-   */
-  V2_MAX_BLOCK_SIZE = 0
-
   constructor(parameters: ConsensusParameters) {
     this.parameters = parameters
   }
@@ -53,6 +45,5 @@ export class Consensus {
 export class TestnetConsensus extends Consensus {
   constructor(parameters: ConsensusParameters) {
     super(parameters)
-    this.V2_MAX_BLOCK_SIZE = 255000
   }
 }

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -125,17 +125,8 @@ describe('Verifier', () => {
       })
     })
 
-    it('accepts a block with size more than maxBlockSizeBytes before V2 consensus upgrade', async () => {
+    it('rejects a block with size more than maxBlockSizeBytes', async () => {
       const block = await useMinerBlockFixture(nodeTest.chain)
-      nodeTest.chain.consensus.V2_MAX_BLOCK_SIZE = block.header.sequence + 1
-      nodeTest.chain.consensus.parameters.maxBlockSizeBytes = getBlockSize(block) - 1
-
-      expect((await nodeTest.verifier.verifyBlock(block)).valid).toBe(true)
-    })
-
-    it('rejects a block with size more than maxBlockSizeBytes after V2 consensus upgrade', async () => {
-      const block = await useMinerBlockFixture(nodeTest.chain)
-      nodeTest.chain.consensus.V2_MAX_BLOCK_SIZE = block.header.sequence
       nodeTest.chain.consensus.parameters.maxBlockSizeBytes = getBlockSize(block) - 1
 
       expect(await nodeTest.verifier.verifyBlock(block)).toMatchObject({

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -43,15 +43,8 @@ export class Verifier {
     block: Block,
     options: { verifyTarget?: boolean } = { verifyTarget: true },
   ): Promise<VerificationResult> {
-    if (
-      this.chain.consensus.isActive(
-        this.chain.consensus.V2_MAX_BLOCK_SIZE,
-        block.header.sequence,
-      )
-    ) {
-      if (getBlockSize(block) > this.chain.consensus.parameters.maxBlockSizeBytes) {
-        return { valid: false, reason: VerificationResultReason.MAX_BLOCK_SIZE_EXCEEDED }
-      }
+    if (getBlockSize(block) > this.chain.consensus.parameters.maxBlockSizeBytes) {
+      return { valid: false, reason: VerificationResultReason.MAX_BLOCK_SIZE_EXCEEDED }
     }
 
     // Verify the block header


### PR DESCRIPTION
## Summary

Removes the consensus parameter that allows for enabling/disabling the max block size, and leaves it always enabled now.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```

Breaks compatibility with node versions that support not enabling a max block size in bytes.