### PR TITLE
fix(ci): Re-add NAPI build for the rust cache

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -88,6 +88,27 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-rust
 
+  ironfish_rust_nodejs:
+    name: ironfish-rust-nodejs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nodejs
+
+      - uses: actions-rs/cargo@v1
+        name: "Build NAPI bindings for the cache"
+        with:
+          command: build
+          args: --release
+
+
   ironfish_zkp:
     name: Test ironfish-zkp
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

I removed the `-nodejs` workflow yesterday without thinking about how this no longer caches the NAPI bindings for other CI runs.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
