### PR TITLE
feat(ironfish): Add asset awareness when checking amounts needed for spends

### DIFF
--- a/ironfish/src/memPool/feeEstimator.test.ts
+++ b/ironfish/src/memPool/feeEstimator.test.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
 import { Assert } from '../assert'
 import { getBlockSize } from '../network/utils/serializers'
 import { Block, Transaction } from '../primitives'
@@ -434,7 +435,9 @@ describe('FeeEstimator', () => {
       await node.wallet.updateHead()
 
       // account1 should have only one note -- change from its transaction to account2
-      const account1Notes = await AsyncUtils.materialize(account1.getUnspentNotes())
+      const account1Notes = await AsyncUtils.materialize(
+        account1.getUnspentNotes(Asset.nativeIdentifier()),
+      )
       expect(account1Notes.length).toEqual(1)
 
       const feeEstimator = new FeeEstimator({

--- a/ironfish/src/memPool/feeEstimator.ts
+++ b/ironfish/src/memPool/feeEstimator.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { createRootLogger, Logger } from '../logger'
@@ -239,9 +240,13 @@ export class FeeEstimator {
 
     const amountNeeded = receives.reduce((acc, receive) => acc + receive.amount, BigInt(0))
 
-    const { amount, notesToSpend } = await this.wallet.createSpends(sender, amountNeeded)
+    const { amount, notes } = await this.wallet.createSpendsForAsset(
+      sender,
+      Asset.nativeIdentifier(),
+      amountNeeded,
+    )
 
-    size += notesToSpend.length * SPEND_SERIALIZED_SIZE_IN_BYTE
+    size += notes.length * SPEND_SERIALIZED_SIZE_IN_BYTE
 
     size += receives.length * NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE
 

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -2090,5 +2090,73 @@
         }
       ]
     }
+  ],
+  "Accounts createSpendsForAsset returns spendable notes for a provided asset identifier": [
+    {
+      "id": "486b48ab-17c4-4b68-88ba-314a8d975446",
+      "name": "test",
+      "spendingKey": "b81ce50a2bee4e615427de6b113fc2e143a850d25a1fdcdaa874cfce29653a6e",
+      "incomingViewKey": "26fb80a9b73179b887a9c2a988a0561af692d7d715b21ccc59ac07de65795d06",
+      "outgoingViewKey": "c3b664a6a99b2352b4ff2f728eab844b25eab3f63425c1a6bd0041ab2c067592",
+      "publicAddress": "d2722237a46b0c89f4217fd82fb3508560b54f00af1bdd58bee6f18d5282124e"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "6C308A881324EEA084ACA232C3C71446F4D1A1DEC5998C7E2F1FC0CAD99C3F3D",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:49hvC1yiQp6lpH7Sg+ILfVVNRaDqbwT2OTvb1/jqLRQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Yi4exPxBjwwK097pfDQHPGRV3jU/Q5Qx+7o5t+m8q7s="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1670969425503,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0",
+        "nullifierSize": 1
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgwhBpB4pCQbuGyemOYF5KHvWD7Nt4ZTVPPLSAgfiW7F/WBCizxYuTTFJGjrCpY2ouagPsefSG2sa1td6hvN3hyZstCyrPJNEvuFkmalSNshf3uN/5QBnl6qbJN4m7Es3EHr8zYXlBaerdDAzIozUOGKanej9omcBTpmZzCnMVZ/QA9dgoOMJBE/UELa87GnNlUhoH4KW6TCb7KsbfatNtnM2rzJINqvdxrMGUZ+grV9kj9Vb8LCS4m0XcPRrDax95IdNmptLeTBYFB6bXg5LyYuoT8KcbkpEG3wmUQE84HKnqJVEeIKOVmWAqlXA3zWiMe2Swg2Rs8pYE7oBudOQAC9sgKp4/tX+38j1lzZe0hbjIzw6UyK3FB7l2F5Ifj9cCWzNAXS46mGDvkJWl4dmjRE4xmxImJGahpzXwDc9u8UcOHaY467VcBYMS0T5OD8m+GYHGyLEYYfIKxnd2F3QHYJZIxwZ0RZ8iS5wmQBuxaXIVDxzh0KhQJuk/bpkV+T1Fp7LHCD+vGmC/IIFq85o/GFGii2cu1KMhRvAFDWams4Q8aDu49hoQ64TgkO9rixutJJ7KxF9iz9Jcm9uIEZpc2ggbm90ZSBlbmNyeXB0aW9uIG1pbmVyIGtleTAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMK7+gPrLE4oyUMAqxEFjQrS55PKxVV+1SCKHhcZP4FQF2tw8NMACmtroQMFHzd0B8jbcfFDp+nFlkBAXhbO8wAk="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A75EE3972CB93D6DFA931772DAAFDEB23CB7F50ABD6B504B73DD4A16603EFD69",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:2AM4nO+ChYFy07khbsX3NMH/Ay1DDkpLice2CQWVEW4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:L7pRBoOJreLaTUlaEHnWIrNhNZuBeC6OpsZKUWmd6nM="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1670969427549,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0",
+        "nullifierSize": 2
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAmbNCkqVHOORcaCkHD0aO7Mv0wyfGkrxjaUWpJPiIe7+5oVYz9P40OymoKgo/QfrzuWl9Q0zGse8mhMGUibdMmgFdh0hMb6XiKrldNxprmPDE7ckyepfakkZaPeSGpVfJFWsmyU4QA7rED1Jt+7vzBG/z2NYdR1Zxwhf+apYmWp4n8mqnF+J10RM+SnlChMDkuAPt5gg61v81HFiRk4qbxwxsi2Ci9auByn4yyg6RiAbQdApz8Oh2h+kdQ0eAy8EhdMihvD2xS08P21Pyr6/87AoiEbnIBHrznKKURu2hHE//5NtcqcZVaWPZTVM4xr7wDXqsOKNJ8vlR32F3SDODHHRegLgOOqB3rSOmTDGwe4msy84aiq8LxbAGO4fsaomEmP/dA5H0oE7M/Ns98VbX/OKbKeZHxKLqmtBxY1BWKsbz1N25ZxNBR1yIMi8oVGQI7WlYmbQCXxNYruuxk0SubttIJrb4Ozz2LRHwbE4c5BCuxuQPJjLTmwqU7QscrQGMVvT1taUgK+9tDvSHCY/7GX2Y6FdAVBWvI1FFUYBqvoMj6DANkNsxn71lwLM8OtF7cBBbuOb8c7RJcm9uIEZpc2ggbm90ZSBlbmNyeXB0aW9uIG1pbmVyIGtleTAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDVRP+LmoJtf3GnljcL3/umb6df1yJjjcTs5sciQvHzhyae/UMyIXHfhYuDx4Cu+UwOHSs2l2RTbTD8kM/serAE="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtU7D8OhwYLaDkccybl9tg5sBtRCjpDAWriY1IpTZ1qih0PxKAVZZFYWd+7LPsTiulftC2Uzv8PlG1JI7KQExEvGdOtZQ7R0SVuM1wbv80Wq8uy1iOGqaSd51yqL/MlobB9Vv3TNcvSm7z8B+OJop6MpkpgdJamWlXmBXJxz2Ok7g9DNuJiwc+uRgleYvT/Entqf4tCzYyLIx0mLZPaAr0l18Rmw9DSOs+/g0WLbCdS3Cif+4VJM49Jtxz6+rLc4E6WiO/CvwukZKhSE60OBjyV+aTDDx2+1leS+O917FUeqIURaQQ7NomBgFR9JRXlpn3rYWs55aOuNnbeP9kEPUPePYbwtcokKepaR+0oPiC31VTUWg6m8E9jk729f46i0UBAAAAJVoj9B2Td/+uTrfGC4LoUvbtwQWb1TDVVRCRXZCcnKF56PApQfNnuFy+ZXYhqrDppAGoJgfYs6yU4ihJ4IyYM4GxkVPrwn18+CBZWOoIFIop5nQSXyamHtujNew/67iCIx/p9pQeoJ10kCz/iVSoM1v3uAVfxeD/0f0+qp3uJKO/A8Pua+D0GMiR/T6gEINSK02AYJM177eMjIe8Qn8RBk3/zKcu1yH3eXE71Lu+gStELg+ETpgQeEURZdRmi1CPxb3XCpb0cRneUD+1KIjLbJ6GKGnOUo8x3X93DJqarHwW+a1uHiGaBwSVtXn+944F4UEL3SaOtjTLFLdms2Ak5WeWRNvmYq4egvSCKMrypIvQYUebQdeihvYnaU8l2zBhUu/ooSke4POpViBtyicZzIMwkr8kQ/mxdTRBO2ngRjD+nDWsQnkHuQFtp85gHRmkOG4ykzpsZdXPW8jOUGTz2fRjg0aYQQ9Nzj0+USAESiWjEh4/UTFnQtsYsYSfb/CszPlOtwfc3EoYZsocloo2J8BZKp2gEPsrExZE+ZVBJOKOO69W4jtvsv3/BWSDcCl9dL88Hrw3Y4fusZu6sOPp2+aOSReYPtBEVq4Lk+c+a6Pnsppgk0zepW1aWBPKJZHFBqY38d6PwGjxPyzOrzGwjOQNf9Ow5LaPyoKnTP11XNd3w3bdUofP73dKtGeDNjjMCsJEiCLujIZ/vAaVVuOkFD11MFI96GM6dWegkKDO76AZBKaOKgxkiy+djrHl0FwAtodPC83/SDOUT+4/3EqZH92mtxzHpkDWEuL3ZWpTu0CthpDThK/c0uWCfgR4sNbOc08/TEDWk9CrEM/Z5FrmqMETyn5TE0oTNtJCg5WClVBZhDVBpbMzhqY8uFRveZkrnNGtIZtB9WkXmTc5ZVRMv/FvvPGwwXu+Y8LyhsUSazDvIM7WKd0b4APQZvsjKCmKF5syWArwXfibGuYci3ljX5MDuP2F6hqb5YTlPPleESi8PadfA5PK3SVeU+5uPz+W+t9nFZhudwZDFL5c10H8ra9Ogz5A50bAwAmKE9yvdilJqOH7d8l5JoJNTJiqJUCOn9TChqYkH33RQ+IhF3Gds1lVXfrB9bQRge2qh2fE9/cl01FTRVhCkyhhft4Exe/TqIbgRkaNAIo0FsMe4id9J8Yf6vxQ7kYLB1o24zaXyHpATIjRYDgsrA0V4Urc0APzTKXSctKmLTlbOlQK7xji/5ozv5mAHHnGgPG8/2S/UHJbaxvHBAf00mRzvVEYSgETiqr99nzRqG4SqSEan+ZdXGoZeCTjP3Kjr443l6gp7JsNbseSmJFTh1M47r1GUFzDLeNPp15hB0U72jRv3AJXKFs5I0y1SRFYNY0gocAK5AU4IS3UlPt96ZcLU6lGpdawfSedFk+rmgl96aT8ixYj2mAetvrg3A4HNT12EZDeb7cuBMRGbw9E0WzqeQam5Ow9W4/VQz2e9bUP49QSy2obKlq07fYFVisUnZ0uPV76VQWlZU6w0aeoPXQlTM/HEmsg0fgHpNUkV5AiKtaURSeb/QPmWddi8Wm5DkXePCH4aHJqSkWc32ffo9w36HvL9SeVdvLnA+TVMhjLYq5MCTeEH5QZW01NmjTU6qFmCV58dMREftze+91e0utB3UZQ8igy61ar84QlGLiTGp6nQIbfxhhHKxHZaDcYSKyOyWCly1ylhT30wezz8UYvgOsC1KQ0Nc5oX2nB2+tvJNf5+6KyTBZKq+4FNBgtRRRfcT3xJaqLaR4mDDgpf6qY9lYOFZmpkg8YLYzOKIYvwpuEmldHI9taW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCgAAAAAAAADXmU8lSsvjl3J7c/lalyHvVcWQqjGkjT/0DmPnKFOM6zp9XYiA0jhLMN3DcI4rF6NCme/RMorSmtx9Foe/thyLj/InzpLs9bLD7jPzkS+JOJ9BUYkqStzZ2e833fk2CwQEL+Z8NdU8RAjl5PwJFABWBOC7Mw0TFMEeonXNWRmVCibyJvaxUP25yZIY4myhaazmU30QLJID3eFKEYcx/POYyGslb2fzxQpw1y8Lqz9NgCI72rU4sh4sjRj830ZoFAI="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1,7 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { generateKey } from '@ironfish/rust-nodejs'
+import { Asset, generateKey } from '@ironfish/rust-nodejs'
+import { BufferMap } from 'buffer-map'
 import { v4 as uuid } from 'uuid'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
@@ -610,6 +611,7 @@ export class Wallet {
 
   private async *getUnspentNotes(
     account: Account,
+    assetIdentifier: Buffer,
     options?: {
       minimumBlockConfirmations?: number
     },
@@ -622,7 +624,7 @@ export class Wallet {
       return
     }
 
-    for await (const decryptedNote of account.getUnspentNotes()) {
+    for await (const decryptedNote of account.getUnspentNotes(assetIdentifier)) {
       if (minimumBlockConfirmations > 0) {
         const transaction = await account.getTransaction(decryptedNote.transactionHash)
 
@@ -717,16 +719,8 @@ export class Wallet {
         throw new Error('Your account must finish scanning before sending a transaction.')
       }
 
-      const amountNeeded =
-        receives.reduce((acc, receive) => acc + receive.amount, BigInt(0)) + transactionFee
-
-      const { amount, notesToSpend } = await this.createSpends(sender, amountNeeded)
-
-      if (amount < amountNeeded) {
-        throw new NotEnoughFundsError(
-          `Insufficient funds: Needed ${amountNeeded.toString()} but have ${amount.toString()}`,
-        )
-      }
+      const amountsNeeded = this.buildAmountsNeeded(receives, burns, transactionFee)
+      const notesToSpend = await this.createSpends(sender, amountsNeeded)
 
       return this.workerPool.createTransaction(
         sender.spendingKey,
@@ -747,15 +741,66 @@ export class Wallet {
     }
   }
 
-  async createSpends(
-    sender: Account,
-    amountNeeded: bigint,
-  ): Promise<{ amount: bigint; notesToSpend: Array<{ note: Note; witness: NoteWitness }> }> {
-    let amount = BigInt(0)
+  private buildAmountsNeeded(
+    receives: {
+      publicAddress: string
+      amount: bigint
+      memo: string
+      assetIdentifier: Buffer
+    }[],
+    burns: { asset: Asset; value: bigint }[],
+    fee: bigint,
+  ): BufferMap<bigint> {
+    const amountsNeeded = new BufferMap<bigint>()
 
+    amountsNeeded.set(Asset.nativeIdentifier(), fee)
+    for (const { amount, assetIdentifier } of receives) {
+      const currentAmount = amountsNeeded.get(assetIdentifier) ?? BigInt(0)
+      amountsNeeded.set(assetIdentifier, amount + currentAmount)
+    }
+
+    for (const { asset, value } of burns) {
+      const assetIdentifier = asset.identifier()
+      const currentAmount = amountsNeeded.get(assetIdentifier) ?? BigInt(0)
+      amountsNeeded.set(assetIdentifier, value + currentAmount)
+    }
+
+    return amountsNeeded
+  }
+
+  private async createSpends(
+    sender: Account,
+    amountsNeeded: BufferMap<bigint>,
+  ): Promise<Array<{ note: Note; witness: NoteWitness }>> {
     const notesToSpend: Array<{ note: Note; witness: NoteWitness }> = []
 
-    for await (const unspentNote of this.getUnspentNotes(sender)) {
+    for (const [assetIdentifier, amountNeeded] of amountsNeeded.entries()) {
+      const { amount, notes } = await this.createSpendsForAsset(
+        sender,
+        assetIdentifier,
+        amountNeeded,
+      )
+      if (amount < amountNeeded) {
+        throw new NotEnoughFundsError(
+          `Insufficient funds: Needed ${amountNeeded.toString()} but have ${amount.toString()}`,
+        )
+      }
+
+      notesToSpend.push(...notes)
+    }
+
+    return notesToSpend
+  }
+
+  async createSpendsForAsset(
+    sender: Account,
+    assetIdentifier: Buffer,
+    amountNeeded: bigint,
+  ): Promise<{ amount: bigint; notes: Array<{ note: Note; witness: NoteWitness }> }> {
+    let amount = BigInt(0)
+    const notes: Array<{ note: Note; witness: NoteWitness }> = []
+
+    for await (const unspentNote of this.getUnspentNotes(sender, assetIdentifier)) {
       if (unspentNote.note.value() <= BigInt(0)) {
         continue
       }
@@ -782,7 +827,7 @@ export class Wallet {
       )
 
       // Otherwise, push the note into the list of notes to spend
-      notesToSpend.push({ note: unspentNote.note, witness: witness })
+      notes.push({ note: unspentNote.note, witness })
       amount += unspentNote.note.value()
 
       if (amount >= amountNeeded) {
@@ -790,10 +835,7 @@ export class Wallet {
       }
     }
 
-    return {
-      amount,
-      notesToSpend,
-    }
+    return { amount, notes }
   }
 
   /**


### PR DESCRIPTION
## Summary

Currently the wallet only uses the native asset and checks values across all notes when given a payload for transaction `receives`. Since this is now asset aware, we need to check amounts needed for each given asset type. This code change builds aggregate amounts keyed by asset identifier and fetches unspent notes with matching identifiers.

## Testing Plan

Added unit test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
