### PR TITLE
adds db transactions to note hash index updates

### DIFF
--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -327,25 +327,29 @@ export class WalletDB {
     sequence: number | null,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
-    if (sequence) {
-      await this.sequenceToNoteHash.put([account.prefix, [sequence, noteHash]], null, tx)
-      await this.nonChainNoteHashes.del([account.prefix, noteHash], tx)
-    } else {
-      await this.nonChainNoteHashes.put([account.prefix, noteHash], null, tx)
-    }
+    await this.db.withTransaction(tx, async (tx) => {
+      if (sequence) {
+        await this.sequenceToNoteHash.put([account.prefix, [sequence, noteHash]], null, tx)
+        await this.nonChainNoteHashes.del([account.prefix, noteHash], tx)
+      } else {
+        await this.nonChainNoteHashes.put([account.prefix, noteHash], null, tx)
+      }
+    })
   }
 
   async deleteNoteHashSequence(
     account: Account,
     noteHash: Buffer,
     sequence: number | null,
-    tx: IDatabaseTransaction,
+    tx?: IDatabaseTransaction,
   ): Promise<void> {
-    await this.nonChainNoteHashes.del([account.prefix, noteHash], tx)
+    await this.db.withTransaction(tx, async (tx) => {
+      await this.nonChainNoteHashes.del([account.prefix, noteHash], tx)
 
-    if (sequence !== null) {
-      await this.sequenceToNoteHash.del([account.prefix, [sequence, noteHash]], tx)
-    }
+      if (sequence !== null) {
+        await this.sequenceToNoteHash.del([account.prefix, [sequence, noteHash]], tx)
+      }
+    })
   }
 
   /*


### PR DESCRIPTION
## Summary

setNoteHashSequence and deleteNoteHashSequence each make writes and/or deletes to multiple stores. these functions need to use database transactions to ensure that these db updates are atomic.

- adds 'withTransaction' wrapping to setNoteHashSequence to create a db transaction if one was note passed in
- changes tx argument to deleteNoteHashSequence to optional to match function signatures elsewhere in the wallet
- uses 'withTransaction' in deleteNoteHashSequence to ensure atomic changes

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
