### PR TITLE
feat(ci): Cache rust build on staging

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -5,7 +5,7 @@ on:
       - "ironfish-rust-nodejs/**"
       - "ironfish-zkp/**"
       - "rust-toolchain"
-      - ".github/workflows/rust_ci.yml"
+      - ".github/workflows/rust*"
   push:
     branches:
       - master
@@ -14,7 +14,7 @@ on:
       - "ironfish-rust-nodejs/**"
       - "ironfish-zkp/**"
       - "rust-toolchain"
-      - ".github/workflows/rust_ci.yml"
+      - ".github/workflows/rust*"
 
 name: Rust CI
 
@@ -44,7 +44,7 @@ jobs:
         run: ./ci/lintHeaders.sh ./ironfish-rust/src *.rs
 
       - name: Check for license headers for ironfish-rust-nodejs
-        run: ./ci/lintHeaders.sh ./ironfish-rust/src *.rs
+        run: ./ci/lintHeaders.sh ./ironfish-rust-nodejs/src *.rs
 
       # fmt
       - uses: actions-rs/cargo@v1
@@ -87,27 +87,6 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-rust
-
-  ironfish_rust_nodejs:
-    name: ironfish-rust-nodejs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          components: rustfmt, clippy
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: nodejs
-
-      - uses: actions-rs/cargo@v1
-        name: "Build NAPI bindings for the cache"
-        with:
-          command: build
-          args: --release
-
 
   ironfish_zkp:
     name: Test ironfish-zkp

--- a/.github/workflows/rust_ci_cache.yml
+++ b/.github/workflows/rust_ci_cache.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches:
+      - master
+      - staging
+    paths:
+      - "ironfish-rust/**"
+      - "ironfish-rust-nodejs/**"
+      - "ironfish-zkp/**"
+      - "rust-toolchain"
+      - ".github/workflows/rust*"
+
+name: Cache Rust build
+
+jobs:
+  build-rust-cache:
+    name: Build and cache rust code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nodejs
+
+      - name: Build NAPI bindings for the cache
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release


### PR DESCRIPTION
## Summary

Due to the limitations of cache access [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache), every PR following a change to rust code will have to rebuild until that change reaches master. If we build on every push to staging and master, we can make sure the rust cache is updated for staging as well.

## Testing Plan

Tested the trigger by adding this branch name to the branch list: https://github.com/iron-fish/ironfish/actions/runs/3690467909/jobs/6247495432

Testing a PR opened against this branch demonstrates that this will work for PRs opened against staging: https://github.com/iron-fish/ironfish/actions/runs/3696396216/jobs/6260033708

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
