### PR TITLE
Remove contained from merkle tree

### DIFF
--- a/ironfish/src/merkletree/merkletree.test.ts
+++ b/ironfish/src/merkletree/merkletree.test.ts
@@ -446,7 +446,6 @@ describe('Merkle tree', function () {
       await tree.truncate(i)
 
       expect(await tree.contains(element)).toBe(false)
-      expect(await tree.contained(element, elementSize)).toBe(false)
 
       // check that the rest of the elements are still there
       for (let j = 0; j < i; j++) {

--- a/ironfish/src/merkletree/merkletree.ts
+++ b/ironfish/src/merkletree/merkletree.ts
@@ -575,21 +575,13 @@ export class MerkleTree<
   }
 
   /**
-   * Check if the tree contained the given element when it was the given size.
-   */
-  async contained(value: E, pastSize: number, tx?: IDatabaseTransaction): Promise<boolean> {
-    return this.db.withTransaction(tx, async (tx) => {
-      const elementIndex = await this.leavesIndex.get(this.hasher.merkleHash(value), tx)
-
-      return elementIndex !== undefined && elementIndex < pastSize
-    })
-  }
-
-  /**
    * Check if the tree currently contains the given element.
    */
   async contains(value: E, tx?: IDatabaseTransaction): Promise<boolean> {
-    return await this.contained(value, await this.size(tx), tx)
+    const currSize = await this.size(tx)
+    const elementIndex = await this.leavesIndex.get(this.hasher.merkleHash(value), tx)
+
+    return elementIndex !== undefined && elementIndex < currSize
   }
 
   /**


### PR DESCRIPTION
## Summary
We used this on the nullifier merkle tree but removed the nullifiers in [this PR](https://github.com/iron-fish/ironfish/pull/2722). 

## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
