### PR TITLE
Split out createTransaction() from postTansction()

### DIFF
--- a/ironfish/src/merkletree/witness.ts
+++ b/ironfish/src/merkletree/witness.ts
@@ -74,3 +74,35 @@ export type NoteWitness = Witness<
   SerializedNoteEncrypted,
   SerializedNoteEncryptedHash
 >
+
+export function IsNoteWitnessEqual(a: NoteWitness, b: NoteWitness): boolean {
+  if (a.treeSize() !== b.treeSize()) {
+    return false
+  }
+
+  if (!a.rootHash.equals(b.rootHash)) {
+    return false
+  }
+
+  const otherAuth = b.authPath()
+  const thisAuth = a.authPath()
+
+  if (thisAuth.length !== otherAuth.length) {
+    return false
+  }
+
+  for (let i = 0; i < thisAuth.length; i++) {
+    const thisNode = thisAuth[i]
+    const otherNode = otherAuth[i]
+
+    const equals =
+      thisNode.side() === otherNode.side() &&
+      thisNode.hashOfSibling().equals(otherNode.hashOfSibling())
+
+    if (!equals) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/ironfish/src/primitives/__fixtures__/rawTransaction.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/rawTransaction.test.ts.fixture
@@ -1,0 +1,12 @@
+{
+  "RawTransaction RawTransactionSerde serializes and deserializes a block": [
+    {
+      "id": "cc67aa95-2ab1-4807-bfb1-11cce4e20aa8",
+      "name": "test",
+      "spendingKey": "e3ede65034055e16301a0c49bef9d1a55a851e4243318c7f751d204364859d94",
+      "incomingViewKey": "1b0bd62149c3142aa81b125aec2ef66c848d8cbb8cd0e822c41dff1923c12601",
+      "outgoingViewKey": "96fd8d9afc2215f6360ce8220a82742b4f26f10c49a248659c9756e10790f712",
+      "publicAddress": "ca7ff12aa2c251c7192a22078d2dea60c0c6a8be6024fb7921af0684156f05a9"
+    }
+  ]
+}

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -87,8 +87,4 @@ export class Note {
   equals(other: Note): boolean {
     return this.noteSerialized.equals(other.noteSerialized)
   }
-
-  static fromNative(note: NativeNote): Note {
-    return new Note(note.serialize())
-  }
 }

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -87,4 +87,8 @@ export class Note {
   equals(other: Note): boolean {
     return this.noteSerialized.equals(other.noteSerialized)
   }
+
+  static fromNative(note: NativeNote): Note {
+    return new Note(note.serialize())
+  }
 }

--- a/ironfish/src/primitives/rawTransaction.test.ts
+++ b/ironfish/src/primitives/rawTransaction.test.ts
@@ -76,6 +76,7 @@ describe('RawTransaction', () => {
         fee: raw.fee,
       })
 
+      expect(RawTransactionSerde.serialize(deserialized).equals(serialized)).toBe(true)
       expect(deserialized.receives[0].note).toEqual(raw.receives[0].note)
       expect(deserialized.burns[0].assetIdentifier).toEqual(asset.identifier())
       expect(deserialized.burns[0].value).toEqual(5n)

--- a/ironfish/src/primitives/rawTransaction.test.ts
+++ b/ironfish/src/primitives/rawTransaction.test.ts
@@ -19,14 +19,14 @@ describe('RawTransaction', () => {
       const account = await useAccountFixture(nodeTest.wallet)
       const asset = new Asset(account.spendingKey, 'asset', 'metadata')
 
-      const note = Note.fromNative(
+      const note = new Note(
         new NativeNote(
           generateKey().public_address,
           5n,
           'memo',
           asset.identifier(),
           account.publicAddress,
-        ),
+        ).serialize(),
       )
 
       const witness = new Witness(

--- a/ironfish/src/primitives/rawTransaction.test.ts
+++ b/ironfish/src/primitives/rawTransaction.test.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset, generateKey, Note as NativeNote } from '@ironfish/rust-nodejs'
+import { Witness } from '../merkletree'
+import { NoteHasher } from '../merkletree/hasher'
+import { Side } from '../merkletree/merkletree'
+import { IsNoteWitnessEqual } from '../merkletree/witness'
+import { useAccountFixture } from '../testUtilities/fixtures'
+import { createNodeTest } from '../testUtilities/nodeTest'
+import { Note } from './note'
+import { RawTransaction, RawTransactionSerde } from './rawTransaction'
+
+describe('RawTransaction', () => {
+  const nodeTest = createNodeTest()
+
+  describe('RawTransactionSerde', () => {
+    it('serializes and deserializes a block', async () => {
+      const account = await useAccountFixture(nodeTest.wallet)
+      const asset = new Asset(account.spendingKey, 'asset', 'metadata')
+
+      const note = Note.fromNative(
+        new NativeNote(
+          generateKey().public_address,
+          5n,
+          'memo',
+          asset.identifier(),
+          account.publicAddress,
+        ),
+      )
+
+      const witness = new Witness(
+        0,
+        Buffer.alloc(32, 1),
+        [
+          { side: Side.Left, hashOfSibling: Buffer.alloc(32, 1) },
+          { side: Side.Right, hashOfSibling: Buffer.alloc(32, 2) },
+          { side: Side.Left, hashOfSibling: Buffer.alloc(32, 3) },
+        ],
+        new NoteHasher(),
+      )
+
+      const raw = new RawTransaction()
+      raw.spendingKey = account.spendingKey
+      raw.expirationSequence = 60
+      raw.fee = 1337n
+
+      raw.mints = [
+        {
+          asset: asset,
+          value: 5n,
+        },
+      ]
+
+      raw.burns = [
+        {
+          assetIdentifier: asset.identifier(),
+          value: 5n,
+        },
+      ]
+
+      raw.receives = [
+        {
+          note: note,
+        },
+      ]
+
+      raw.spends = [{ note, witness }]
+
+      const serialized = RawTransactionSerde.serialize(raw)
+      const deserialized = RawTransactionSerde.deserialize(serialized)
+
+      expect(deserialized).toMatchObject({
+        spendingKey: raw.spendingKey,
+        expirationSequence: raw.expirationSequence,
+        fee: raw.fee,
+      })
+
+      expect(deserialized.receives[0].note).toEqual(raw.receives[0].note)
+      expect(deserialized.burns[0].assetIdentifier).toEqual(asset.identifier())
+      expect(deserialized.burns[0].value).toEqual(5n)
+      expect(deserialized.mints[0].asset.serialize()).toEqual(asset.serialize())
+      expect(deserialized.mints[0].value).toEqual(5n)
+      expect(deserialized.spends[0].note).toEqual(raw.spends[0].note)
+      expect(IsNoteWitnessEqual(deserialized.spends[0].witness, raw.spends[0].witness)).toBe(
+        true,
+      )
+    })
+  })
+})

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -1,0 +1,219 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Transaction as NativeTransaction } from '@ironfish/rust-nodejs'
+import { Asset, ASSET_IDENTIFIER_LENGTH, ASSET_LENGTH } from '@ironfish/rust-nodejs'
+import bufio from 'bufio'
+import { Witness } from '../merkletree'
+import { NoteHasher } from '../merkletree/hasher'
+import { Side } from '../merkletree/merkletree'
+import { BurnDescription } from './burnDescription'
+import { MintDescription } from './mintDescription'
+import { Note } from './note'
+import { NoteEncrypted, NoteEncryptedHash, SerializedNoteEncryptedHash } from './noteEncrypted'
+import { Transaction } from './transaction'
+
+// Needed for constructing a witness when creating transactions
+const noteHasher = new NoteHasher()
+
+export class RawTransaction {
+  spendingKey = ''
+  expirationSequence: number | null = null
+  fee = 0n
+  mints: MintDescription[] = []
+  burns: BurnDescription[] = []
+  receives: { note: Note }[] = []
+
+  spends: {
+    note: Note
+    witness: Witness<
+      NoteEncrypted,
+      NoteEncryptedHash,
+      NoteEncryptedHash,
+      SerializedNoteEncryptedHash
+    >
+  }[] = []
+
+  post(): Transaction {
+    const builder = new NativeTransaction(this.spendingKey)
+
+    for (const spend of this.spends) {
+      builder.spend(spend.note.takeReference(), spend.witness)
+      spend.note.returnReference()
+    }
+
+    for (const receive of this.receives) {
+      builder.receive(receive.note.takeReference())
+      receive.note.returnReference()
+    }
+
+    for (const mint of this.mints) {
+      builder.mint(mint.asset, mint.value)
+    }
+
+    for (const burn of this.burns) {
+      builder.burn(burn.assetIdentifier, burn.value)
+    }
+
+    if (this.expirationSequence !== null) {
+      builder.setExpirationSequence(this.expirationSequence)
+    }
+
+    const serialized = builder.post(null, this.fee)
+    const posted = new Transaction(serialized)
+
+    return posted
+  }
+}
+
+export class RawTransactionSerde {
+  static serialize(raw: RawTransaction): Buffer {
+    const bw = bufio.write(this.getSize(raw))
+
+    bw.writeVarString(raw.spendingKey)
+    bw.writeBigU64(raw.fee)
+
+    bw.writeU64(raw.spends.length)
+    for (const spend of raw.spends) {
+      bw.writeVarBytes(spend.note.serialize())
+
+      bw.writeU64(spend.witness.treeSize())
+      bw.writeVarBytes(spend.witness.rootHash)
+      bw.writeU64(spend.witness.authPath().length)
+      for (const step of spend.witness.authPath()) {
+        switch (step.side()) {
+          case Side.Left:
+            bw.writeU8(0)
+            break
+          case Side.Right:
+            bw.writeU8(1)
+            break
+        }
+        bw.writeVarBytes(step.hashOfSibling())
+      }
+    }
+
+    bw.writeU64(raw.receives.length)
+    for (const receive of raw.receives) {
+      bw.writeVarBytes(receive.note.serialize())
+    }
+
+    bw.writeU64(raw.mints.length)
+    for (const mint of raw.mints) {
+      bw.writeBytes(mint.asset.serialize())
+      bw.writeBigU64(mint.value)
+    }
+
+    bw.writeU64(raw.burns.length)
+    for (const burn of raw.burns) {
+      bw.writeBytes(burn.assetIdentifier)
+      bw.writeBigU64(burn.value)
+    }
+
+    bw.writeU8(Number(raw.expirationSequence != null))
+    if (raw.expirationSequence != null) {
+      bw.writeU64(raw.expirationSequence)
+    }
+
+    return bw.render()
+  }
+
+  static deserialize(buffer: Buffer): RawTransaction {
+    const reader = bufio.read(buffer, true)
+
+    const raw = new RawTransaction()
+    raw.spendingKey = reader.readVarString()
+    raw.fee = reader.readBigU64()
+
+    const spendsLength = reader.readU64()
+    for (let i = 0; i < spendsLength; i++) {
+      const note = new Note(reader.readVarBytes())
+
+      const treeSize = reader.readU64()
+      const rootHash = reader.readVarBytes()
+      const authPathLength = reader.readU64()
+      const authPath = []
+      for (let j = 0; j < authPathLength; j++) {
+        const side = reader.readU8() ? Side.Right : Side.Left
+        const hashOfSibling = reader.readVarBytes()
+        authPath.push({ side, hashOfSibling })
+      }
+
+      const witness = new Witness(treeSize, rootHash, authPath, noteHasher)
+
+      raw.spends.push({ note, witness })
+    }
+
+    const receivesLength = reader.readU64()
+    for (let i = 0; i < receivesLength; i++) {
+      const note = new Note(reader.readVarBytes())
+      raw.receives.push({ note })
+    }
+
+    const mintsLength = reader.readU64()
+    for (let i = 0; i < mintsLength; i++) {
+      const asset = Asset.deserialize(reader.readBytes(ASSET_LENGTH))
+      const value = reader.readBigU64()
+      raw.mints.push({ asset, value })
+    }
+
+    const burnsLength = reader.readU64()
+    for (let i = 0; i < burnsLength; i++) {
+      const assetIdentifier = reader.readBytes(ASSET_IDENTIFIER_LENGTH)
+      const value = reader.readBigU64()
+      raw.burns.push({ assetIdentifier, value })
+    }
+
+    const hasExpiration = reader.readU8()
+    if (hasExpiration) {
+      raw.expirationSequence = reader.readU64()
+    }
+
+    return raw
+  }
+
+  static getSize(raw: RawTransaction): number {
+    let size = 0
+
+    size += bufio.sizeVarString(raw.spendingKey)
+    size += 8 // raw.fee
+
+    size += 8 // raw.spends.length
+    for (const spend of raw.spends) {
+      size += bufio.sizeVarBytes(spend.note.serialize())
+
+      size += 8 // spend.witness.treeSize()
+      size += bufio.sizeVarBytes(spend.witness.rootHash)
+      size += 8 // spend.witness.authPath.length
+      for (const step of spend.witness.authPath()) {
+        size += 1 // step.side()
+        size += bufio.sizeVarBytes(step.hashOfSibling())
+      }
+    }
+
+    size += 8 // raw.receives.length
+    for (const receive of raw.receives) {
+      size += bufio.sizeVarBytes(receive.note.serialize())
+    }
+
+    size += 8 // raw.mints.length
+    for (const _ of raw.mints) {
+      size += ASSET_LENGTH // mint.asset
+      size += 8 // mint.value
+    }
+
+    size += 8 // raw.burns.length
+    for (const _ of raw.burns) {
+      size += ASSET_IDENTIFIER_LENGTH // burn.assetIdentifier
+      size += 8 // burn.value
+    }
+
+    size += 1 // has expiration sequence
+    if (raw.expirationSequence != null) {
+      size += 8 // raw.expirationSequence
+    }
+
+    return size
+  }
+}

--- a/ironfish/src/primitives/transaction.test.slow.ts
+++ b/ironfish/src/primitives/transaction.test.slow.ts
@@ -99,7 +99,7 @@ describe('Accounts', () => {
     await nodeA.chain.addBlock(block1)
     await nodeA.wallet.updateHead()
 
-    const transaction = await nodeA.wallet.createTransaction(
+    const raw = await nodeA.wallet.createTransaction(
       accountA,
       [
         {
@@ -114,6 +114,9 @@ describe('Accounts', () => {
       BigInt(1),
       0,
     )
+
+    const transaction = await nodeA.wallet.postTransaction(raw)
+
     expect(transaction.isMinersFee()).toBe(false)
   })
 })

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -571,7 +571,7 @@ describe('Accounts', () => {
 
     const block2 = await useBlockFixture(nodeA.chain, async () => {
       // Generate a transaction from account A to account B
-      const transaction = await nodeA.wallet.createTransaction(
+      const raw = await nodeA.wallet.createTransaction(
         accountA,
         [
           {
@@ -586,6 +586,8 @@ describe('Accounts', () => {
         BigInt(1),
         0,
       )
+
+      const transaction = await nodeA.wallet.postTransaction(raw)
 
       // Create block 2
       return nodeA.chain.newBlock(
@@ -719,7 +721,7 @@ describe('Accounts', () => {
       nodeA.chain,
       async () => {
         // Generate a transaction from account A to account B
-        const transaction = await nodeA.wallet.createTransaction(
+        const raw = await nodeA.wallet.createTransaction(
           accountA,
           [
             {
@@ -734,6 +736,8 @@ describe('Accounts', () => {
           BigInt(0),
           0,
         )
+
+        const transaction = await nodeA.wallet.postTransaction(raw)
 
         // Create block A2
         return nodeA.chain.newBlock(
@@ -833,7 +837,7 @@ describe('Accounts', () => {
       nodeB.chain,
       async () => {
         // Generate a transaction from account A to account B
-        const transaction = await nodeB.wallet.createTransaction(
+        const raw = await nodeB.wallet.createTransaction(
           accountANodeB,
           [
             {
@@ -848,6 +852,8 @@ describe('Accounts', () => {
           BigInt(0),
           0,
         )
+
+        const transaction = await nodeB.wallet.postTransaction(raw)
 
         // Create block A2
         return nodeA.chain.newBlock(

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -1069,7 +1069,7 @@ describe('Accounts', () => {
       const mintValue = BigInt(10)
       // Mint some coins
       const blockB = await useBlockFixture(node.chain, async () => {
-        const transaction = await node.wallet.createTransaction(
+        const raw = await node.wallet.createTransaction(
           account,
           [],
           [{ asset, value: mintValue }],
@@ -1077,6 +1077,8 @@ describe('Accounts', () => {
           BigInt(0),
           0,
         )
+
+        const transaction = await node.wallet.postTransaction(raw)
 
         return node.chain.newBlock(
           [transaction],

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -745,7 +745,7 @@ export class Wallet {
     }[],
     mints: MintDescription[],
     burns: BurnDescription[],
-    transactionFee: bigint,
+    fee: bigint,
     expirationSequence: number,
   ): Promise<RawTransaction> {
     const unlock = await this.createTransactionMutex.lock()
@@ -762,6 +762,7 @@ export class Wallet {
       raw.expirationSequence = expirationSequence
       raw.mints = mints
       raw.burns = burns
+      raw.fee = fee
 
       for (const receive of receives) {
         const note = new NativeNote(
@@ -769,14 +770,14 @@ export class Wallet {
           receive.amount,
           receive.memo,
           receive.assetIdentifier,
-          sender.spendingKey,
+          sender.publicAddress,
         )
 
         raw.receives.push({ note: new Note(note.serialize()) })
       }
 
       await this.fund(raw, {
-        fee: transactionFee,
+        fee: fee,
         account: sender,
       })
 

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -10,6 +10,7 @@ import { Meter, MetricsMonitor } from '../metrics'
 import { BurnDescription } from '../primitives/burnDescription'
 import { MintDescription } from '../primitives/mintDescription'
 import { Note } from '../primitives/note'
+import { RawTransaction } from '../primitives/rawTransaction'
 import { Transaction } from '../primitives/transaction'
 import { Metric } from '../telemetry/interfaces/metric'
 import { WorkerMessageStats } from './interfaces/workerMessageStats'
@@ -23,6 +24,7 @@ import {
   DecryptNotesRequest,
   DecryptNotesResponse,
 } from './tasks/decryptNotes'
+import { PostTransactionRequest, PostTransactionResponse } from './tasks/postTransaction'
 import { SleepRequest } from './tasks/sleep'
 import { SubmitTelemetryRequest } from './tasks/submitTelemetry'
 import {
@@ -184,6 +186,18 @@ export class WorkerPool {
     }
 
     return new Transaction(Buffer.from(response.serializedTransactionPosted))
+  }
+
+  async postTransaction(transaction: RawTransaction): Promise<Transaction> {
+    const request = new PostTransactionRequest(transaction)
+
+    const response = await this.execute(request).result()
+
+    if (!(response instanceof PostTransactionResponse)) {
+      throw new Error('Invalid response')
+    }
+
+    return response.transaction
   }
 
   async verify(

--- a/ironfish/src/workerPool/tasks/__fixtures__/postTransaction.test.ts.fixture
+++ b/ironfish/src/workerPool/tasks/__fixtures__/postTransaction.test.ts.fixture
@@ -1,0 +1,38 @@
+{
+  "PostTransactionRequest serializes the object into a buffer and deserializes to the original object": [
+    {
+      "id": "808dda3c-ac8b-4ac3-8117-b7f5f5d3332d",
+      "name": "test",
+      "spendingKey": "cd6bf00b2b4c42278140a523eaa4746469b0f96183dac6393c9a6f89ea1c41d9",
+      "incomingViewKey": "9133409e9cf9da9e7a7ab80fd86e66ca0d332898a58bc0005135f9f1890c4300",
+      "outgoingViewKey": "b325675bcc00ea23ac2419e9c8e87511d7052b457e6991086405a1b268996d82",
+      "publicAddress": "f8c367c9e23e16ec0d6b97ce793946d10a823445557759ce7cfb1f456d3f8001"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZCjKaaarasFNqdZyXlBICxp5FfzMrtp19yGPc7T5ClA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ImXVtzM/apU8eZ/j3qIKR6zfOxMON7w73ftr/p3OnUg="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1671326904795,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtVCkTJ8NtbyQ3e+aepnYah8nQ4LbL6cvUi5wDv7WbOaEprxi24p9UydEVn/LFZ+xhboDIiAaqBv515hbuqgGLEvgEwCGJo2l/3YLqMk4N9uShKFGfCG0z9Yn+FoP7NvgrIzM5/gx/X8qtnriu56Aet9IEwTs8SwmFdtqNy1rT04AzbYmDdl1gwgy62ZHgVYQi3mz2oDCRA9vXkAhG4Ox2GG0Gcha49MEbJeSDwM4N1W3grk4fgyD5rrLdk+QCOvn2bCEHGdQDR1JcEQkf31eLg8ffAMBMIXAMzk2ly/s+fRTE/KxOprOTo4XBnzUPL89N7ijkEyNrKCau7kOw4CojkXNrWkOmcz/3ihWOYSYlUG+aQsZ9SewDa/a8G6VCDJz8qk0MSNTrHsNoQptfch1stJoXRMjgwtGCZ/dfJkrbOnoSJEU6Ke2CxTbHKD5c1gZTh6eNHaib/TcBmxeuG94UsvtB2klEdN9v6tizEA31SLR40oXHhYgE0uyMltFC4JuTEvsWba2hfn+87zNIUesEbdC3ow/IC7FrQjO2w9HsO8PuJqSxP1Jaequun28O3t9YrWMHid0R8fnq4jhXu9k+8u/x6q4gSUDKVPNYsZFlqajwx9QoOziX0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwtqCcIOZwnkPbEo+lcrKh+iB0019zo3240jKCc+/LtDVuMS8jJT3VqOiyMVNN3VhtfA1d7W2/N0HTts8dd0WAQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/workerPool/tasks/handlers.ts
+++ b/ironfish/src/workerPool/tasks/handlers.ts
@@ -5,6 +5,7 @@ import { Job } from '../job'
 import { CreateMinersFeeTask } from './createMinersFee'
 import { CreateTransactionTask } from './createTransaction'
 import { DecryptNotesTask } from './decryptNotes'
+import { PostTransactionTask } from './postTransaction'
 import { SleepTask } from './sleep'
 import { SubmitTelemetryTask } from './submitTelemetry'
 import { VerifyTransactionTask } from './verifyTransaction'
@@ -15,6 +16,7 @@ import { WorkerTask } from './workerTask'
 export const handlers: Record<WorkerMessageType, WorkerTask | undefined> = {
   [WorkerMessageType.CreateMinersFee]: CreateMinersFeeTask.getInstance(),
   [WorkerMessageType.CreateTransaction]: CreateTransactionTask.getInstance(),
+  [WorkerMessageType.PostTransaction]: PostTransactionTask.getInstance(),
   [WorkerMessageType.DecryptNotes]: DecryptNotesTask.getInstance(),
   [WorkerMessageType.JobAborted]: undefined,
   [WorkerMessageType.JobError]: undefined,

--- a/ironfish/src/workerPool/tasks/postTransaction.ts
+++ b/ironfish/src/workerPool/tasks/postTransaction.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import bufio from 'bufio'
+import { Transaction } from '../../primitives'
+import { RawTransaction, RawTransactionSerde } from '../../primitives/rawTransaction'
+import { WorkerMessage, WorkerMessageType } from './workerMessage'
+import { WorkerTask } from './workerTask'
+
+export class PostTransactionRequest extends WorkerMessage {
+  readonly transaction: RawTransaction
+
+  constructor(transaction: RawTransaction, jobId?: number) {
+    super(WorkerMessageType.PostTransaction, jobId)
+    this.transaction = transaction
+  }
+
+  serialize(): Buffer {
+    return RawTransactionSerde.serialize(this.transaction)
+  }
+
+  static deserialize(jobId: number, buffer: Buffer): PostTransactionRequest {
+    const raw = RawTransactionSerde.deserialize(buffer)
+    return new PostTransactionRequest(raw, jobId)
+  }
+
+  getSize(): number {
+    return RawTransactionSerde.getSize(this.transaction)
+  }
+}
+
+export class PostTransactionResponse extends WorkerMessage {
+  readonly transaction: Transaction
+
+  constructor(transaction: Transaction, jobId: number) {
+    super(WorkerMessageType.CreateTransaction, jobId)
+    this.transaction = transaction
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+    bw.writeVarBytes(this.transaction.serialize())
+    return bw.render()
+  }
+
+  static deserialize(jobId: number, buffer: Buffer): PostTransactionResponse {
+    const reader = bufio.read(buffer, true)
+    const transaction = new Transaction(reader.readVarBytes())
+    return new PostTransactionResponse(transaction, jobId)
+  }
+
+  getSize(): number {
+    return bufio.sizeVarBytes(this.transaction.serialize())
+  }
+}
+
+export class PostTransactionTask extends WorkerTask {
+  private static instance: PostTransactionTask | undefined
+
+  static getInstance(): PostTransactionTask {
+    if (!PostTransactionTask.instance) {
+      PostTransactionTask.instance = new PostTransactionTask()
+    }
+
+    return PostTransactionTask.instance
+  }
+
+  execute(request: PostTransactionRequest): PostTransactionResponse {
+    const posted = request.transaction.post()
+    return new PostTransactionResponse(posted, request.jobId)
+  }
+}

--- a/ironfish/src/workerPool/tasks/workerMessage.ts
+++ b/ironfish/src/workerPool/tasks/workerMessage.ts
@@ -15,6 +15,7 @@ export enum WorkerMessageType {
   SubmitTelemetry = 6,
   VerifyTransaction = 7,
   VerifyTransactions = 8,
+  PostTransaction = 9,
 }
 
 export abstract class WorkerMessage implements Serializable {

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -14,6 +14,7 @@ import { CreateTransactionRequest, CreateTransactionResponse } from './tasks/cre
 import { DecryptNotesRequest, DecryptNotesResponse } from './tasks/decryptNotes'
 import { JobAbortedError, JobAbortedMessage } from './tasks/jobAbort'
 import { JobError, JobErrorMessage } from './tasks/jobError'
+import { PostTransactionRequest, PostTransactionResponse } from './tasks/postTransaction'
 import { SleepRequest, SleepResponse } from './tasks/sleep'
 import { SubmitTelemetryRequest, SubmitTelemetryResponse } from './tasks/submitTelemetry'
 import { VerifyTransactionRequest, VerifyTransactionResponse } from './tasks/verifyTransaction'
@@ -237,6 +238,8 @@ export class Worker {
         return CreateMinersFeeRequest.deserialize(jobId, request)
       case WorkerMessageType.CreateTransaction:
         return CreateTransactionRequest.deserialize(jobId, request)
+      case WorkerMessageType.PostTransaction:
+        return PostTransactionRequest.deserialize(jobId, request)
       case WorkerMessageType.DecryptNotes:
         return DecryptNotesRequest.deserialize(jobId, request)
       case WorkerMessageType.JobAborted:
@@ -264,6 +267,8 @@ export class Worker {
         return CreateMinersFeeResponse.deserialize(jobId, response)
       case WorkerMessageType.CreateTransaction:
         return CreateTransactionResponse.deserialize(jobId, response)
+      case WorkerMessageType.PostTransaction:
+        return PostTransactionResponse.deserialize(jobId, response)
       case WorkerMessageType.DecryptNotes:
         return DecryptNotesResponse.deserialize(jobId, response)
       case WorkerMessageType.JobAborted:


### PR DESCRIPTION
## Summary

This will make it so we can create a transaction, and post it separately. To do this a new model is being created called RawTransaction which is returned by wallet.createTransaction().

- Add Wallet.createTransaction() => RawTransaction
- Add Wallet.postTransaction(rawTransaction) => Transaction
- Add WorkerPool.postTransaction(rawTransaction) => Transaction

Remaining work after this PR merges in another PR
 - Remove wallet from fee estimator
 - Add test for WorkerPool.postTransaction()
 - Add test for wallet.createTransaction()

## Testing Plan

Write new RawTransaction serializer test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
