### PR TITLE
Remove limiting miner fee transactions to single note

### DIFF
--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -197,14 +197,15 @@ impl ProposedTransaction {
     /// a miner would not accept such a transaction unless it was explicitly set
     /// as the miners fee.
     pub fn post_miners_fee(&mut self) -> Result<Transaction, IronfishError> {
-        if !self.spends.is_empty() || self.outputs.len() != 1 {
+        if !self.spends.is_empty() || self.outputs.is_empty() {
             return Err(IronfishError::InvalidMinersFeeTransaction);
         }
+
         // Ensure the merkle note has an identifiable encryption key
-        self.outputs
-            .get_mut(0)
-            .ok_or(IronfishError::InvalidMinersFeeTransaction)?
-            .set_is_miners_fee();
+        for output in &mut self.outputs {
+            output.set_is_miners_fee();
+        }
+
         self._partial_post()
     }
 

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -171,7 +171,7 @@ export class Transaction {
   }
 
   isMinersFee(): boolean {
-    return this._spends.length === 0 && this._notes.length === 1 && this._fee <= 0
+    return this._spends.length === 0 && this._notes.length >= 1 && this._fee <= 0
   }
 
   /**


### PR DESCRIPTION
## Summary

Now that we have a block size limit, miners are lightly disincentivized from creating a miner's fee transaction with many notes. I don't see a reason to limit the number of notes 
in the transaction, since it allows miners additional flexibility when distributing block rewards.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```

Multi-note miners fee transactions won't verify on older code.
