### PR TITLE
Remove post_genesis_transaction

### DIFF
--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -208,13 +208,6 @@ impl ProposedTransaction {
         self._partial_post()
     }
 
-    /// Super special case for generating an illegal transaction for the genesis block.
-    /// Don't bother using this anywhere else, it won't pass verification.
-    #[deprecated(note = "Use only in genesis block generation")]
-    pub fn post_genesis_transaction(&self) -> Result<Transaction, IronfishError> {
-        self._partial_post()
-    }
-
     /// Get the expiration sequence for this transaction
     pub fn expiration_sequence(&self) -> u32 {
         self.expiration_sequence


### PR DESCRIPTION
## Summary

This isn't used as part of generating the genesis block any more, so we can remove it.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
