### PR TITLE
feat: rust backtrace via anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "arrayref"
@@ -639,6 +639,7 @@ dependencies = [
 name = "ironfish_rust"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bellman",
  "blake2b_simd",
  "blake2s_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,7 @@ dependencies = [
 name = "ironfish-rust-nodejs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base64",
  "ironfish_rust",
  "napi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +53,9 @@ name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayref"
@@ -56,6 +74,21 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -536,6 +569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+
+[[package]]
 name = "group"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +801,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "napi"
 version = "2.9.0"
 source = "git+https://github.com/napi-rs/napi-rs?rev=26f6c926d30de744146fe54db6a6b399e142e63c#26f6c926d30de744146fe54db6a6b399e142e63c"
@@ -857,6 +905,15 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1164,6 +1221,12 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hash"

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -9,8 +9,6 @@ workspace = true
 [package.edition]
 workspace = true
 
-[env]
-RUST_BACKTRACE = "1"
 
 [lib]
 crate-type = ["cdylib"]
@@ -18,7 +16,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { version = "1.0.66", features = ["backtrace"] }
 base64 = "0.13.0"
 ironfish_rust = { path = "../ironfish-rust" }
 napi-derive = "2.9.0"

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -9,12 +9,16 @@ workspace = true
 [package.edition]
 workspace = true
 
+[env]
+RUST_BACKTRACE = "1"
+
 [lib]
 crate-type = ["cdylib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.66"
 base64 = "0.13.0"
 ironfish_rust = { path = "../ironfish-rust" }
 napi-derive = "2.9.0"

--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -15,7 +15,7 @@
     "build": "yarn clean && napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish --skip-gh-release",
-    "test:slow": "jest --testPathIgnorePatterns --testMatch \"**/*.test.slow.ts\"",
+    "test:slow": "RUST_BACKTRACE=1 jest --testPathIgnorePatterns --testMatch \"**/*.test.slow.ts\"",
     "clean": "rimraf target"
   },
   "napi": {

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -16,8 +16,15 @@ pub mod nacl;
 pub mod rolling_filter;
 pub mod structs;
 
-fn to_napi_err(err: impl Display) -> napi::Error {
+fn display_to_napi_err(err: impl Display) -> napi::Error {
     Error::from_reason(err.to_string())
+}
+
+fn str_to_napi_err(err_string: &str) -> napi::Error {
+    napi::Error::from_reason(err_string)
+}
+fn anyhow_to_napi_err(err: anyhow::Error) -> napi::Error {
+    napi::Error::from_reason(format!("{:?}", err))
 }
 
 #[napi(object)]
@@ -46,7 +53,7 @@ pub fn generate_key() -> Key {
 
 #[napi]
 pub fn generate_key_from_private_key(private_key: String) -> Result<Key> {
-    let sapling_key = SaplingKey::from_hex(&private_key).map_err(to_napi_err)?;
+    let sapling_key = SaplingKey::from_hex(&private_key).map_err(anyhow_to_napi_err)?;
 
     Ok(Key {
         spending_key: sapling_key.hex_spending_key(),

--- a/ironfish-rust-nodejs/src/nacl.rs
+++ b/ironfish-rust-nodejs/src/nacl.rs
@@ -9,7 +9,7 @@ use ironfish_rust::{
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::{str_to_napi_err, anyhow_to_napi_err};
+use crate::{anyhow_to_napi_err, str_to_napi_err};
 
 #[napi]
 pub const KEY_LENGTH: u32 = nacl::KEY_LENGTH as u32;
@@ -38,8 +38,7 @@ impl BoxKeyPair {
 
     #[napi(factory)]
     pub fn from_hex(secret_hex: String) -> napi::Result<BoxKeyPair> {
-        let byte_vec =
-            hex_to_bytes(&secret_hex).map_err(anyhow_to_napi_err)?;
+        let byte_vec = hex_to_bytes(&secret_hex).map_err(anyhow_to_napi_err)?;
 
         let bytes: [u8; nacl::KEY_LENGTH] = byte_vec
             .try_into()
@@ -121,10 +120,11 @@ pub fn native_unbox_message(
         .try_into()
         .map_err(|_| str_to_napi_err("Unable to convert recipient secret key"))?;
 
-    let decoded_nonce = base64::decode(nonce).map_err(|_| str_to_napi_err("Unable to decode nonce"))?;
+    let decoded_nonce =
+        base64::decode(nonce).map_err(|_| str_to_napi_err("Unable to decode nonce"))?;
 
-    let decoded_ciphertext =
-        base64::decode(boxed_message).map_err(|_| str_to_napi_err("Unable to decode boxed_message"))?;
+    let decoded_ciphertext = base64::decode(boxed_message)
+        .map_err(|_| str_to_napi_err("Unable to decode boxed_message"))?;
 
     unbox_message(&decoded_ciphertext, &decoded_nonce, sender, recipient)
         .map_err(anyhow_to_napi_err)

--- a/ironfish-rust-nodejs/src/nacl.rs
+++ b/ironfish-rust-nodejs/src/nacl.rs
@@ -9,7 +9,7 @@ use ironfish_rust::{
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::to_napi_err;
+use crate::{str_to_napi_err, anyhow_to_napi_err};
 
 #[napi]
 pub const KEY_LENGTH: u32 = nacl::KEY_LENGTH as u32;
@@ -39,11 +39,11 @@ impl BoxKeyPair {
     #[napi(factory)]
     pub fn from_hex(secret_hex: String) -> napi::Result<BoxKeyPair> {
         let byte_vec =
-            hex_to_bytes(&secret_hex).map_err(|_| to_napi_err("Unable to decode secret key"))?;
+            hex_to_bytes(&secret_hex).map_err(anyhow_to_napi_err)?;
 
         let bytes: [u8; nacl::KEY_LENGTH] = byte_vec
             .try_into()
-            .map_err(|_| to_napi_err("Unable to convert secret key"))?;
+            .map_err(|_| str_to_napi_err("Unable to convert secret key"))?;
 
         let secret_key = bytes_to_secret_key(bytes);
 
@@ -84,17 +84,17 @@ pub fn native_box_message(
     let sender: [u8; 32] = sender_secret_key
         .to_vec()
         .try_into()
-        .map_err(|_| to_napi_err("Unable to convert sender secret key"))?;
+        .map_err(|_| str_to_napi_err("Unable to convert sender secret key"))?;
 
     let decoded_recipient = base64::decode(recipient_public_key)
-        .map_err(|_| to_napi_err("Unable to decode recipient public key"))?;
+        .map_err(|_| str_to_napi_err("Unable to decode recipient public key"))?;
 
     let recipient: [u8; 32] = decoded_recipient
         .try_into()
-        .map_err(|_| to_napi_err("Unable to convert recipient public key"))?;
+        .map_err(|_| str_to_napi_err("Unable to convert recipient public key"))?;
 
     let (nonce, ciphertext) = box_message(plaintext, sender, recipient)
-        .map_err(|_| to_napi_err("Unable to box message"))?;
+        .map_err(|_| str_to_napi_err("Unable to box message"))?;
 
     Ok(BoxedMessage {
         nonce: base64::encode(nonce),
@@ -110,22 +110,22 @@ pub fn native_unbox_message(
     recipient_secret_key: Uint8Array,
 ) -> Result<String> {
     let decoded_sender = base64::decode(sender_public_key)
-        .map_err(|_| to_napi_err("Unable to decode sender public key"))?;
+        .map_err(|_| str_to_napi_err("Unable to decode sender public key"))?;
 
     let sender: [u8; 32] = decoded_sender
         .try_into()
-        .map_err(|_| to_napi_err("Unable to convert sender public key"))?;
+        .map_err(|_| str_to_napi_err("Unable to convert sender public key"))?;
 
     let recipient: [u8; 32] = recipient_secret_key
         .to_vec()
         .try_into()
-        .map_err(|_| to_napi_err("Unable to convert recipient secret key"))?;
+        .map_err(|_| str_to_napi_err("Unable to convert recipient secret key"))?;
 
-    let decoded_nonce = base64::decode(nonce).map_err(|_| to_napi_err("Unable to decode nonce"))?;
+    let decoded_nonce = base64::decode(nonce).map_err(|_| str_to_napi_err("Unable to decode nonce"))?;
 
     let decoded_ciphertext =
-        base64::decode(boxed_message).map_err(|_| to_napi_err("Unable to decode boxed_message"))?;
+        base64::decode(boxed_message).map_err(|_| str_to_napi_err("Unable to decode boxed_message"))?;
 
     unbox_message(&decoded_ciphertext, &decoded_nonce, sender, recipient)
-        .map_err(|e| to_napi_err(format!("Unable to unbox message: {}", e)))
+        .map_err(anyhow_to_napi_err)
 }

--- a/ironfish-rust-nodejs/src/structs/asset.rs
+++ b/ironfish-rust-nodejs/src/structs/asset.rs
@@ -16,7 +16,7 @@ use napi::{
 };
 use napi_derive::napi;
 
-use crate::to_napi_err;
+use crate::anyhow_to_napi_err;
 
 #[napi]
 pub const ASSET_IDENTIFIER_LENGTH: u32 = IDENTIFIER_LENGTH as u32;
@@ -42,11 +42,11 @@ pub struct NativeAsset {
 impl NativeAsset {
     #[napi(constructor)]
     pub fn new(owner_private_key: String, name: String, metadata: String) -> Result<NativeAsset> {
-        let sapling_key = SaplingKey::from_hex(&owner_private_key).map_err(to_napi_err)?;
+        let sapling_key = SaplingKey::from_hex(&owner_private_key).map_err(anyhow_to_napi_err)?;
         let owner = sapling_key.public_address();
 
         Ok(NativeAsset {
-            asset: Asset::new(owner, &name, &metadata).map_err(to_napi_err)?,
+            asset: Asset::new(owner, &name, &metadata).map_err(anyhow_to_napi_err)?,
         })
     }
 
@@ -83,7 +83,7 @@ impl NativeAsset {
     #[napi]
     pub fn serialize(&self) -> Result<Buffer> {
         let mut vec: Vec<u8> = vec![];
-        self.asset.write(&mut vec).map_err(to_napi_err)?;
+        self.asset.write(&mut vec).map_err(anyhow_to_napi_err)?;
 
         Ok(Buffer::from(vec))
     }
@@ -91,7 +91,7 @@ impl NativeAsset {
     #[napi(factory)]
     pub fn deserialize(js_bytes: JsBuffer) -> Result<Self> {
         let bytes = js_bytes.into_value()?;
-        let asset = Asset::read(bytes.as_ref()).map_err(to_napi_err)?;
+        let asset = Asset::read(bytes.as_ref()).map_err(anyhow_to_napi_err)?;
 
         Ok(NativeAsset { asset })
     }

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -15,7 +15,7 @@ use ironfish_rust::{Note, SaplingKey};
 
 use ironfish_rust::keys::PUBLIC_ADDRESS_SIZE;
 
-use crate::to_napi_err;
+use crate::anyhow_to_napi_err;
 
 #[napi]
 pub const PUBLIC_ADDRESS_LENGTH: u32 = PUBLIC_ADDRESS_SIZE as u32;
@@ -63,9 +63,9 @@ impl NativeNote {
         sender: String,
     ) -> Result<Self> {
         let value_u64 = value.get_u64().1;
-        let owner_address = ironfish_rust::PublicAddress::from_hex(&owner).map_err(to_napi_err)?;
+        let owner_address = ironfish_rust::PublicAddress::from_hex(&owner).map_err(anyhow_to_napi_err)?;
         let sender_address =
-            ironfish_rust::PublicAddress::from_hex(&sender).map_err(to_napi_err)?;
+            ironfish_rust::PublicAddress::from_hex(&sender).map_err(anyhow_to_napi_err)?;
 
         let buffer = asset_identifier.into_value()?;
         let asset_identifier_vec = buffer.as_ref();
@@ -88,7 +88,7 @@ impl NativeNote {
     pub fn deserialize(js_bytes: JsBuffer) -> Result<Self> {
         let byte_vec = js_bytes.into_value()?;
 
-        let note = Note::read(byte_vec.as_ref()).map_err(to_napi_err)?;
+        let note = Note::read(byte_vec.as_ref()).map_err(anyhow_to_napi_err)?;
 
         Ok(NativeNote { note })
     }
@@ -96,7 +96,7 @@ impl NativeNote {
     #[napi]
     pub fn serialize(&self) -> Result<Buffer> {
         let mut arr: Vec<u8> = vec![];
-        self.note.write(&mut arr).map_err(to_napi_err)?;
+        self.note.write(&mut arr).map_err(anyhow_to_napi_err)?;
 
         Ok(Buffer::from(arr))
     }
@@ -143,7 +143,7 @@ impl NativeNote {
     pub fn nullifier(&self, owner_private_key: String, position: BigInt) -> Result<Buffer> {
         let position_u64 = position.get_u64().1;
 
-        let private_key = SaplingKey::from_hex(&owner_private_key).map_err(to_napi_err)?;
+        let private_key = SaplingKey::from_hex(&owner_private_key).map_err(anyhow_to_napi_err)?;
 
         let nullifier: &[u8] = &self.note.nullifier(&private_key, position_u64).0;
 

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -63,7 +63,8 @@ impl NativeNote {
         sender: String,
     ) -> Result<Self> {
         let value_u64 = value.get_u64().1;
-        let owner_address = ironfish_rust::PublicAddress::from_hex(&owner).map_err(anyhow_to_napi_err)?;
+        let owner_address =
+            ironfish_rust::PublicAddress::from_hex(&owner).map_err(anyhow_to_napi_err)?;
         let sender_address =
             ironfish_rust::PublicAddress::from_hex(&sender).map_err(anyhow_to_napi_err)?;
 

--- a/ironfish-rust-nodejs/src/structs/note_encrypted.rs
+++ b/ironfish-rust-nodejs/src/structs/note_encrypted.rs
@@ -14,7 +14,8 @@ use ironfish_rust::note::ENCRYPTED_NOTE_SIZE;
 use ironfish_rust::serializing::aead::MAC_SIZE;
 use ironfish_rust::MerkleNote;
 
-use crate::to_napi_err;
+use crate::anyhow_to_napi_err;
+use crate::str_to_napi_err;
 
 #[napi]
 pub const NOTE_ENCRYPTION_KEY_LENGTH: u32 = NOTE_ENCRYPTION_KEY_SIZE as u32;
@@ -45,7 +46,7 @@ impl NativeNoteEncrypted {
     #[napi(constructor)]
     pub fn new(js_bytes: JsBuffer) -> Result<Self> {
         let bytes = js_bytes.into_value()?;
-        let note = MerkleNote::read(bytes.as_ref()).map_err(to_napi_err)?;
+        let note = MerkleNote::read(bytes.as_ref()).map_err(anyhow_to_napi_err)?;
 
         Ok(NativeNoteEncrypted { note })
     }
@@ -53,7 +54,7 @@ impl NativeNoteEncrypted {
     #[napi]
     pub fn serialize(&self) -> Result<Buffer> {
         let mut vec: Vec<u8> = vec![];
-        self.note.write(&mut vec).map_err(to_napi_err)?;
+        self.note.write(&mut vec).map_err(anyhow_to_napi_err)?;
 
         Ok(Buffer::from(vec))
     }
@@ -69,7 +70,7 @@ impl NativeNoteEncrypted {
         self.note
             .merkle_hash()
             .write(&mut vec)
-            .map_err(to_napi_err)?;
+            .map_err(anyhow_to_napi_err)?;
 
         Ok(Buffer::from(vec))
     }
@@ -81,13 +82,13 @@ impl NativeNoteEncrypted {
         let left = js_left.into_value()?;
         let right = js_right.into_value()?;
 
-        let left_hash = MerkleNoteHash::read(left.as_ref()).map_err(to_napi_err)?;
+        let left_hash = MerkleNoteHash::read(left.as_ref()).map_err(anyhow_to_napi_err)?;
 
-        let right_hash = MerkleNoteHash::read(right.as_ref()).map_err(to_napi_err)?;
+        let right_hash = MerkleNoteHash::read(right.as_ref()).map_err(anyhow_to_napi_err)?;
 
         let converted_depth: usize = depth
             .try_into()
-            .map_err(|_| to_napi_err("Value could not fit in usize"))?;
+            .map_err(|_| str_to_napi_err("Value could not fit in usize"))?;
 
         let mut vec = Vec::with_capacity(32);
 
@@ -97,7 +98,7 @@ impl NativeNoteEncrypted {
             &right_hash.0,
         ))
         .write(&mut vec)
-        .map_err(to_napi_err)?;
+        .map_err(anyhow_to_napi_err)?;
 
         Ok(Buffer::from(vec))
     }
@@ -106,12 +107,12 @@ impl NativeNoteEncrypted {
     #[napi]
     pub fn decrypt_note_for_owner(&self, incoming_hex_key: String) -> Result<Option<Buffer>> {
         let incoming_view_key =
-            IncomingViewKey::from_hex(&incoming_hex_key).map_err(to_napi_err)?;
+            IncomingViewKey::from_hex(&incoming_hex_key).map_err(anyhow_to_napi_err)?;
 
         Ok(match self.note.decrypt_note_for_owner(&incoming_view_key) {
             Ok(note) => {
                 let mut vec = vec![];
-                note.write(&mut vec).map_err(to_napi_err)?;
+                note.write(&mut vec).map_err(anyhow_to_napi_err)?;
                 Some(Buffer::from(vec))
             }
             Err(_) => None,
@@ -122,12 +123,12 @@ impl NativeNoteEncrypted {
     #[napi]
     pub fn decrypt_note_for_spender(&self, outgoing_hex_key: String) -> Result<Option<Buffer>> {
         let outgoing_view_key =
-            OutgoingViewKey::from_hex(&outgoing_hex_key).map_err(to_napi_err)?;
+            OutgoingViewKey::from_hex(&outgoing_hex_key).map_err(anyhow_to_napi_err)?;
         Ok(
             match self.note.decrypt_note_for_spender(&outgoing_view_key) {
                 Ok(note) => {
                     let mut vec = vec![];
-                    note.write(&mut vec).map_err(to_napi_err)?;
+                    note.write(&mut vec).map_err(anyhow_to_napi_err)?;
                     Some(Buffer::from(vec))
                 }
                 Err(_) => None,

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -17,7 +17,7 @@ use napi::{
 };
 use napi_derive::napi;
 
-use crate::{anyhow_to_napi_err, str_to_napi_err, display_to_napi_err};
+use crate::{anyhow_to_napi_err, display_to_napi_err, str_to_napi_err};
 
 use super::note::NativeNote;
 use super::spend_proof::NativeSpendDescription;
@@ -50,7 +50,9 @@ impl NativeTransactionPosted {
     #[napi]
     pub fn serialize(&self) -> Result<Buffer> {
         let mut vec: Vec<u8> = vec![];
-        self.transaction.write(&mut vec).map_err(anyhow_to_napi_err)?;
+        self.transaction
+            .write(&mut vec)
+            .map_err(anyhow_to_napi_err)?;
 
         Ok(Buffer::from(vec))
     }
@@ -83,7 +85,10 @@ impl NativeTransactionPosted {
 
         let proof = &self.transaction.outputs()[index_usize];
         let mut vec: Vec<u8> = Vec::with_capacity(ENCRYPTED_NOTE_LENGTH as usize);
-        proof.merkle_note().write(&mut vec).map_err(anyhow_to_napi_err)?;
+        proof
+            .merkle_note()
+            .write(&mut vec)
+            .map_err(anyhow_to_napi_err)?;
 
         Ok(Buffer::from(vec))
     }
@@ -218,7 +223,10 @@ impl NativeTransaction {
     /// as the miners fee.
     #[napi(js_name = "post_miners_fee")]
     pub fn post_miners_fee(&mut self) -> Result<Buffer> {
-        let transaction = self.transaction.post_miners_fee().map_err(anyhow_to_napi_err)?;
+        let transaction = self
+            .transaction
+            .post_miners_fee()
+            .map_err(anyhow_to_napi_err)?;
 
         let mut vec: Vec<u8> = vec![];
         transaction.write(&mut vec).map_err(anyhow_to_napi_err)?;
@@ -254,7 +262,9 @@ impl NativeTransaction {
             .map_err(anyhow_to_napi_err)?;
 
         let mut vec: Vec<u8> = vec![];
-        posted_transaction.write(&mut vec).map_err(anyhow_to_napi_err)?;
+        posted_transaction
+            .write(&mut vec)
+            .map_err(anyhow_to_napi_err)?;
 
         Ok(Buffer::from(vec))
     }

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -14,7 +14,7 @@ name = "ironfish_rust"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { version = "1.0.66", features = ["backtrace"] }
 bellman = { version = "0.13.1" }
 blake2b_simd = "1.0.0"
 blake2s_simd = "1.0.0"

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -14,6 +14,7 @@ name = "ironfish_rust"
 path = "src/lib.rs"
 
 [dependencies]
+anyhow = "1.0.66"
 bellman = { version = "0.13.1" }
 blake2b_simd = "1.0.0"
 blake2s_simd = "1.0.0"

--- a/ironfish-rust/src/merkle_note.rs
+++ b/ironfish-rust/src/merkle_note.rs
@@ -180,10 +180,7 @@ impl MerkleNote {
         MerkleNoteHash::new(self.note_commitment)
     }
 
-    pub fn decrypt_note_for_owner(
-        &self,
-        owner_view_key: &IncomingViewKey,
-    ) -> Result<Note, Error> {
+    pub fn decrypt_note_for_owner(&self, owner_view_key: &IncomingViewKey) -> Result<Note, Error> {
         let shared_secret = owner_view_key.shared_secret(&self.ephemeral_public_key);
         let note =
             Note::from_owner_encrypted(owner_view_key, &shared_secret, &self.encrypted_note)?;
@@ -191,10 +188,7 @@ impl MerkleNote {
         Ok(note)
     }
 
-    pub fn decrypt_note_for_spender(
-        &self,
-        spender_key: &OutgoingViewKey,
-    ) -> Result<Note, Error> {
+    pub fn decrypt_note_for_spender(&self, spender_key: &OutgoingViewKey) -> Result<Note, Error> {
         let encryption_key = calculate_key_for_encryption_keys(
             spender_key,
             &self.value_commitment,

--- a/ironfish-rust/src/merkle_note.rs
+++ b/ironfish-rust/src/merkle_note.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::{errors::IronfishError, keys::EphemeralKeyPair, serializing::read_point};
+use crate::{keys::EphemeralKeyPair, serializing::read_point};
 
 /// Implement a merkle note to store all the values that need to go into a merkle tree.
 /// A tree containing these values can serve as a snapshot of the entire chain.
@@ -14,6 +14,7 @@ use super::{
     MerkleNoteHash,
 };
 
+use anyhow::Error;
 use blake2b_simd::Params as Blake2b;
 use bls12_381::Scalar;
 use ff::PrimeField;
@@ -146,7 +147,7 @@ impl MerkleNote {
     }
 
     /// Load a MerkleNote from the given stream
-    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
+    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, Error> {
         let value_commitment = read_point(&mut reader)?;
         let note_commitment = read_scalar(&mut reader)?;
         let ephemeral_public_key = read_point(&mut reader)?;
@@ -165,7 +166,7 @@ impl MerkleNote {
         })
     }
 
-    pub fn write<W: io::Write>(&self, writer: &mut W) -> Result<(), IronfishError> {
+    pub fn write<W: io::Write>(&self, writer: &mut W) -> Result<(), Error> {
         writer.write_all(&self.value_commitment.to_bytes())?;
         writer.write_all(&self.note_commitment.to_bytes())?;
         writer.write_all(&self.ephemeral_public_key.to_bytes())?;
@@ -182,7 +183,7 @@ impl MerkleNote {
     pub fn decrypt_note_for_owner(
         &self,
         owner_view_key: &IncomingViewKey,
-    ) -> Result<Note, IronfishError> {
+    ) -> Result<Note, Error> {
         let shared_secret = owner_view_key.shared_secret(&self.ephemeral_public_key);
         let note =
             Note::from_owner_encrypted(owner_view_key, &shared_secret, &self.encrypted_note)?;
@@ -193,7 +194,7 @@ impl MerkleNote {
     pub fn decrypt_note_for_spender(
         &self,
         spender_key: &OutgoingViewKey,
-    ) -> Result<Note, IronfishError> {
+    ) -> Result<Note, Error> {
         let encryption_key = calculate_key_for_encryption_keys(
             spender_key,
             &self.value_commitment,

--- a/ironfish-rust/src/merkle_note_hash.rs
+++ b/ironfish-rust/src/merkle_note_hash.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
- use anyhow::Error;
+use anyhow::Error;
 
 /// Implement a merkle note to store all the values that need to go into a merkle tree.
 /// A tree containing these values can serve as a snapshot of the entire chain.

--- a/ironfish-rust/src/merkle_note_hash.rs
+++ b/ironfish-rust/src/merkle_note_hash.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::errors::IronfishError;
+ use anyhow::Error;
 
 /// Implement a merkle note to store all the values that need to go into a merkle tree.
 /// A tree containing these values can serve as a snapshot of the entire chain.
@@ -32,13 +32,13 @@ impl MerkleNoteHash {
         MerkleNoteHash(fr)
     }
 
-    pub fn read<R: io::Read>(reader: R) -> Result<MerkleNoteHash, IronfishError> {
+    pub fn read<R: io::Read>(reader: R) -> Result<MerkleNoteHash, Error> {
         let res = read_scalar(reader)?;
 
         Ok(MerkleNoteHash(res))
     }
 
-    pub fn write<W: io::Write>(&self, writer: &mut W) -> Result<(), IronfishError> {
+    pub fn write<W: io::Write>(&self, writer: &mut W) -> Result<(), Error> {
         writer.write_all(&self.0.to_bytes())?;
 
         Ok(())

--- a/ironfish-rust/src/nacl.rs
+++ b/ironfish-rust/src/nacl.rs
@@ -9,6 +9,7 @@ use crypto_box::{
 };
 use rand::RngCore;
 
+use anyhow::{anyhow, Error};
 use crate::errors::IronfishError;
 
 pub const KEY_LENGTH: usize = crypto_box::KEY_SIZE;
@@ -35,7 +36,7 @@ pub fn box_message(
     plaintext: String,
     sender_secret_key: [u8; KEY_LENGTH],
     recipient_public_key: [u8; KEY_LENGTH],
-) -> Result<(Vec<u8>, Vec<u8>), IronfishError> {
+) -> Result<(Vec<u8>, Vec<u8>), Error> {
     let mut rng = OsRng;
 
     let sender: SecretKey = SecretKey::from(sender_secret_key);
@@ -55,9 +56,9 @@ pub fn unbox_message(
     nonce: &[u8],
     sender_public_key: [u8; KEY_LENGTH],
     recipient_secret_key: [u8; KEY_LENGTH],
-) -> Result<String, IronfishError> {
+) -> Result<String, Error> {
     if nonce.len() != NONCE_LENGTH {
-        return Err(IronfishError::InvalidNonceLength);
+        return Err(anyhow!(IronfishError::InvalidNonceLength));
     }
 
     let nonce = GenericArray::from_slice(nonce);

--- a/ironfish-rust/src/nacl.rs
+++ b/ironfish-rust/src/nacl.rs
@@ -9,8 +9,8 @@ use crypto_box::{
 };
 use rand::RngCore;
 
-use anyhow::{anyhow, Error};
 use crate::errors::IronfishError;
+use anyhow::{anyhow, Error};
 
 pub const KEY_LENGTH: usize = crypto_box::KEY_SIZE;
 pub const NONCE_LENGTH: usize = 24;

--- a/ironfish-rust/src/serializing.rs
+++ b/ironfish-rust/src/serializing.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use anyhow::{anyhow, Error};
 use crate::errors::IronfishError;
+use anyhow::{anyhow, Error};
 
 /// Helper functions to convert pairing parts to bytes
 ///
@@ -63,8 +63,8 @@ pub fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, Error> {
 }
 
 pub mod aead {
-    use anyhow::Error;
     use crate::errors::IronfishError;
+    use anyhow::Error;
     use chacha20poly1305::aead::{AeadInPlace, NewAead};
     use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 

--- a/ironfish-rust/src/transaction/burns.rs
+++ b/ironfish-rust/src/transaction/burns.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::io;
-
+use anyhow::{anyhow, Error};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ff::Field;
 use group::GroupEncoding;
@@ -76,9 +76,9 @@ pub struct BurnDescription {
 }
 
 impl BurnDescription {
-    pub fn verify_not_small_order(&self) -> Result<(), IronfishError> {
+    pub fn verify_not_small_order(&self) -> Result<(), Error> {
         if self.value_commitment.is_small_order().into() {
-            return Err(IronfishError::IsSmallOrder);
+            return Err(anyhow!(IronfishError::IsSmallOrder));
         }
 
         Ok(())
@@ -92,7 +92,7 @@ impl BurnDescription {
     pub(crate) fn serialize_signature_fields<W: io::Write>(
         &self,
         mut writer: W,
-    ) -> Result<(), IronfishError> {
+    ) -> Result<(), Error> {
         writer.write_all(&self.asset_identifier)?;
         writer.write_u64::<LittleEndian>(self.value)?;
         writer.write_all(&self.value_commitment.to_bytes())?;
@@ -100,7 +100,7 @@ impl BurnDescription {
         Ok(())
     }
 
-    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
+    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, Error> {
         let asset_identifier = {
             let mut bytes = [0u8; ASSET_IDENTIFIER_LENGTH];
             reader.read_exact(&mut bytes)?;
@@ -117,7 +117,7 @@ impl BurnDescription {
     }
 
     /// Stow the bytes of this [`BurnDescription`] in the given writer.
-    pub fn write<W: io::Write>(&self, writer: W) -> Result<(), IronfishError> {
+    pub fn write<W: io::Write>(&self, writer: W) -> Result<(), Error> {
         self.serialize_signature_fields(writer)?;
 
         Ok(())

--- a/ironfish-rust/src/transaction/burns.rs
+++ b/ironfish-rust/src/transaction/burns.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::io;
 use anyhow::{anyhow, Error};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ff::Field;
@@ -10,6 +9,7 @@ use group::GroupEncoding;
 use ironfish_zkp::{constants::ASSET_IDENTIFIER_LENGTH, ValueCommitment};
 use jubjub::ExtendedPoint;
 use rand::thread_rng;
+use std::io;
 
 use crate::{
     assets::asset::{asset_generator_from_identifier, AssetIdentifier},

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::io;
 use anyhow::{anyhow, Error};
 use bellman::{gadgets::multipack, groth16};
 use bls12_381::{Bls12, Scalar};
@@ -17,6 +16,7 @@ use ironfish_zkp::{
 };
 use jubjub::{ExtendedPoint, Fr};
 use rand::thread_rng;
+use std::io;
 
 use crate::{
     assets::asset::{asset_generator_point, Asset},

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ff::Field;
 use anyhow::{anyhow, Error};
+use ff::Field;
 use outputs::OutputBuilder;
 use spends::{SpendBuilder, UnsignedSpendDescription};
 use value_balances::ValueBalances;

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -52,9 +52,9 @@
     "lint": "tsc -b && tsc -b tsconfig.test.json && eslint --ext .ts,.tsx,.js,.jsx src/",
     "lint:fix": "tsc -b && tsc -b tsconfig.test.json && eslint --ext .ts,.tsx,.js,.jsx src/ --fix",
     "start": "tsc -b -w",
-    "test": "tsc -b && tsc -b tsconfig.test.json && jest --testTimeout=${JEST_TIMEOUT:-5000}",
-    "test:slow": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.slow.ts\" --testTimeout=${JEST_TIMEOUT:-60000} --testPathIgnorePatterns",
-    "test:perf": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.perf.ts\" --testTimeout=${JEST_TIMEOUT:-60000} --testPathIgnorePatterns",
+    "test": "tsc -b && tsc -b tsconfig.test.json && RUST_BACKTRACE=1 jest --testTimeout=${JEST_TIMEOUT:-5000}",
+    "test:slow": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true RUST_BACKTRACE=1 jest --testMatch \"**/*.test.slow.ts\" --testTimeout=${JEST_TIMEOUT:-60000} --testPathIgnorePatterns",
+    "test:perf": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true RUST_BACKTRACE=1 jest --testMatch \"**/*.test.perf.ts\" --testTimeout=${JEST_TIMEOUT:-60000} --testPathIgnorePatterns",
     "test:coverage:html": "tsc -b tsconfig.test.json && jest --coverage --coverage-reporters html --testPathIgnorePatterns",
     "test:watch": "tsc -b tsconfig.test.json && jest --watch --coverage false",
     "fixtures:regenerate": "find . -name \"__fixtures__\" | xargs rm -rf && JEST_TIMEOUT=1000000000 yarn run test && JEST_TIMEOUT=1000000000 yarn run test:slow && JEST_TIMEOUT=1000000000 yarn run test:perf"

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -83,7 +83,7 @@ export class Transaction {
       const note = new NoteEncrypted(reader.readBytes(ENCRYPTED_NOTE_LENGTH, true))
       // TODO(joe): remove once rpk removed from proof and put on transaction
       // randomized public key
-      reader.seek(32)
+      // reader.seek(32)
       return note
     })
 


### PR DESCRIPTION
## Summary
Add anyhow library (which implements backtrace well for us)
https://github.com/dtolnay/anyhow

This is currently using install of backtrace package via `anyhow = { version = "1.0.66", features = ["backtrace"] }`

The `std` lib version enabled in anyhow is tracked by this issue:
https://github.com/dtolnay/anyhow/issues/284

Jest without `RUST_BACKTRACE=1`
```

    InvalidData

      58 |     this.referenceCount++
      59 |     if (this.noteEncrypted === null) {
    > 60 |       this.noteEncrypted = new NativeNoteEncrypted(this.noteEncryptedSerialized)
         |                            ^
      61 |     }
      62 |     return this.noteEncrypted
      63 |   }

      at NoteEncrypted.takeReference (src/primitives/noteEncrypted.ts:60:28)
      at NoteEncrypted.decryptNoteForOwner (src/primitives/noteEncrypted.ts:74:23)
      at DecryptNotesTask.execute (src/workerPool/tasks/decryptNotes.ts:226:33)
      at Object.handleRequest (src/workerPool/tasks/handlers.ts:32:18)
      at Job.execute (src/workerPool/job.ts:78:10)
      at WorkerPool.execute (src/workerPool/pool.ts:259:16)
      at WorkerPool.decryptNotes (src/workerPool/pool.ts:225:33)
      at Wallet.decryptNotesFromTransaction (src/wallet/wallet.ts:390:44)
      at Wallet.decryptNotes (src/wallet/wallet.ts:374:48)
      at Wallet.addPendingTransaction (src/wallet/wallet.ts:412:50)
      at PeerNetwork.onNewTransaction (src/network/peerNetwork.ts:1383:7)
      at PeerNetwork.handleMessage (src/network/peerNetwork.ts:615:9)
          at async Promise.all (index 0)
      at Event.emitAsync (src/event.ts:69:5)
      at Object.<anonymous> (src/network/transactionFetcher.test.ts:93:5)
```
with `RUST_BACKTRACE=1`
```
    InvalidData

    Stack backtrace:
       0: backtrace::backtrace::libunwind::trace

      91 | #[inline(always)]
      92 | pub unsafe fn trace(mut cb: &mut dyn FnMut(&super::Frame) -> bool) {
    > 93 |     uw::_Unwind_Backtrace(trace_fn, &mut cb as *mut _ as *mut _);
         |     ^
      94 |
      95 |     extern "C" fn trace_fn(
      96 |         ctx: *mut uw::_Unwind_Context,

      at ../../../.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.67/src/backtrace/libunwind.rs:93:5
            backtrace::backtrace::trace_unsynchronized
      at ../../../.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.67/src/backtrace/mod.rs:66:5
         1: backtrace::backtrace::trace
      at ../../../.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.67/src/backtrace/mod.rs:53:14
         2: anyhow::backtrace::capture::Backtrace::create
      at ../../../.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.66/src/backtrace.rs:216:13
         3: anyhow::backtrace::capture::Backtrace::capture
      at ../../../.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.66/src/backtrace.rs:204:17
         4: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
      at ../../../.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.66/src/error.rs:547:25
         5: <T as core::convert::Into<U>>::into
      at ../../../../../rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/convert/mod.rs:550:9
         6: anyhow::kind::Trait::new
      at ../../../.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.66/src/kind.rs:91:9
         7: ironfish_rust::serializing::read_point
      at ../ironfish-rust/src/serializing.rs:29:52
         8: ironfish_rust::merkle_note::MerkleNote::read
      at ../ironfish-rust/src/merkle_note.rs:151:32
      9: ironfish_rust_nodejs::structs::note_encrypted::NativeNoteEncrypted::new
      at ../ironfish-rust-nodejs/src/structs/note_encrypted.rs:49:20
      10: ironfish_rust_nodejs::structs::note_encrypted::__napi_impl_helper__NativeNoteEncrypted__3::__napi__new::{{closure}}::{{closure}}
      at ../ironfish-rust-nodejs/src/structs/note_encrypted.rs:44:1
        11: napi::bindgen_prelude::within_runtime_if_available
      at ../../../.cargo/git/checkouts/napi-rs-052f838a107f387b/26f6c92/crates/napi/src/lib.rs:174:5
      12: ironfish_rust_nodejs::structs::note_encrypted::__napi_impl_helper__NativeNoteEncrypted__3::__napi__new::{{closure}}
      at ../ironfish-rust-nodejs/src/structs/note_encrypted.rs:44:1
        13: core::result::Result<T,E>::and_then
      at ../../../../../rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/result.rs:1361:22
      14: ironfish_rust_nodejs::structs::note_encrypted::__napi_impl_helper__NativeNoteEncrypted__3::__napi__new
      at ../ironfish-rust-nodejs/src/structs/note_encrypted.rs:44:1
      at NoteEncrypted.takeReference (src/primitives/noteEncrypted.ts:60:28)
      at NoteEncrypted.decryptNoteForOwner (src/primitives/noteEncrypted.ts:74:23)
      at DecryptNotesTask.execute (src/workerPool/tasks/decryptNotes.ts:226:33)
      at Object.handleRequest (src/workerPool/tasks/handlers.ts:32:18)
      at Job.execute (src/workerPool/job.ts:78:10)
      at WorkerPool.execute (src/workerPool/pool.ts:259:16)
      at WorkerPool.decryptNotes (src/workerPool/pool.ts:225:33)
      at Wallet.decryptNotesFromTransaction (src/wallet/wallet.ts:390:44)
      at Wallet.decryptNotes (src/wallet/wallet.ts:374:48)
      at Wallet.addPendingTransaction (src/wallet/wallet.ts:412:50)
      at PeerNetwork.onNewTransaction (src/network/peerNetwork.ts:1383:7)
      at PeerNetwork.handleRpcMessage (src/network/peerNetwork.ts:688:11)
      at PeerNetwork.handleMessage (src/network/peerNetwork.ts:606:7)
          at async Promise.all (index 0)
      at Event.emitAsync (src/event.ts:69:5)
      at Object.<anonymous> (src/network/transactionFetcher.test.ts:137:5)
```
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
