### PR TITLE
fixes wallet handling of fork transactions from other wallets

### DIFF
--- a/ironfish/src/wallet/__fixtures__/wallet.test.slow.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.slow.ts.fixture
@@ -303,7 +303,7 @@
       ]
     }
   ],
-  "Accounts Undoes spends created by another node when rolling back a fork": [
+  "Accounts Keeps spends created by another node when rolling back a fork": [
     {
       "id": "6db36e74-f115-4445-b0c3-4bcc6f6fd1ec",
       "name": "testA",

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -192,7 +192,6 @@ export class Account {
         )
       }
 
-      const isRemovingTransaction = submittedSequence === null && blockHash === null
       await this.bulkUpdateDecryptedNotes(
         transactionHash,
         decryptedNotes,
@@ -200,7 +199,7 @@ export class Account {
         sequence,
         tx,
       )
-      await this.processTransactionSpends(transaction, isRemovingTransaction, tx)
+      await this.processTransactionSpends(transaction, tx)
     })
   }
 
@@ -364,7 +363,6 @@ export class Account {
 
   private async processTransactionSpends(
     transaction: Transaction,
-    isRemovingTransaction: boolean,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     for (const spend of transaction.spends) {
@@ -381,7 +379,7 @@ export class Account {
           noteHash,
           {
             ...decryptedNote,
-            spent: !isRemovingTransaction,
+            spent: true,
           },
           tx,
         )

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -801,7 +801,7 @@ describe('Accounts', () => {
     })
   })
 
-  it('Undoes spends created by another node when rolling back a fork', async () => {
+  it('Keeps spends created by another node when rolling back a fork', async () => {
     // Create a block 1 that gives account A money
     // Create a block A2 with a transaction from account A to account B
     // Create a block B2 that gives neither account money
@@ -909,13 +909,13 @@ describe('Accounts', () => {
     await nodeA.chain.addBlock(blockB3)
     await nodeA.wallet.updateHead()
 
-    // A should have its original coins
-    // B should not have the coins any more
+    // B should not have confirmed coins yet because the transaction isn't on a block
+    // A should not have confirmed coins any more because the transaction is pending
     await expect(
       nodeA.wallet.getBalance(accountA, Asset.nativeIdentifier()),
     ).resolves.toMatchObject({
-      confirmed: BigInt(2000000000),
-      pending: BigInt(3999999998),
+      confirmed: BigInt(0),
+      pending: BigInt(1999999998),
     })
     await expect(
       nodeA.wallet.getBalance(accountBNodeA, Asset.nativeIdentifier()),


### PR DESCRIPTION
## Summary

when a block is disconnected from the chain, the transactions on that block are pending: they may be included in a future block connected to the chain.

the wallet marks notes as spent when they are spent in pending transactions. when a block is disconnected, those notes are still marked as spent _unless_ the transaction was created by another wallet.

this is incorrect because the transaction is still pending even if a different wallet created it. marking the spent notes as unspent could result in the wallet creating double-spend transactions.

these changes fix this issue by only marking spent notes as unspent when a transaction expires.

- changes processTransactionSpends to only mark spends as spent, never unspent
- updates test to enforce correct handling of forked transactions from other wallets

## Testing Plan

- updates unit test

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
