### PR TITLE
refactor(rust): Encapsulate description verification and remove unused verify_proof functions

### DIFF
--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -48,6 +48,7 @@ pub mod burns;
 pub mod mints;
 pub mod outputs;
 pub mod spends;
+mod utils;
 
 #[cfg(test)]
 mod tests;
@@ -758,7 +759,7 @@ pub fn batch_verify_transactions<'a>(
         let hash_to_verify_signature = transaction.transaction_signature_hash();
 
         for spend in transaction.spends.iter() {
-            spend.verify_not_small_order()?;
+            spend.partial_verify()?;
 
             let public_inputs = spend.public_inputs(transaction.randomized_public_key());
             spend_verifier.queue((&spend.proof, &public_inputs[..]));
@@ -772,7 +773,7 @@ pub fn batch_verify_transactions<'a>(
         }
 
         for output in transaction.outputs.iter() {
-            output.verify_not_small_order()?;
+            output.partial_verify()?;
 
             let public_inputs = output.public_inputs(transaction.randomized_public_key());
             output_verifier.queue((&output.proof, &public_inputs[..]));
@@ -781,7 +782,7 @@ pub fn batch_verify_transactions<'a>(
         }
 
         for mint in transaction.mints.iter() {
-            mint.verify_not_small_order()?;
+            mint.partial_verify()?;
 
             let public_inputs = mint.public_inputs(transaction.randomized_public_key());
             mint_verifier.queue((&mint.proof, &public_inputs[..]));

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -29,6 +29,8 @@ use jubjub::ExtendedPoint;
 use rand::thread_rng;
 use std::io;
 
+use super::utils::verify_spend_proof;
+
 /// Parameters used when constructing proof that the spender owns a note with
 /// a given value.
 ///
@@ -129,7 +131,10 @@ impl SpendBuilder {
             authorizing_signature: blank_signature,
         };
 
-        description.verify_proof(randomized_public_key)?;
+        verify_spend_proof(
+            &description.proof,
+            &description.public_inputs(randomized_public_key),
+        )?;
 
         Ok(UnsignedSpendDescription {
             public_key_randomness: *public_key_randomness,
@@ -284,25 +289,18 @@ impl SpendDescription {
         Ok(())
     }
 
-    /// Verify that the bellman proof confirms the randomized_public_key,
-    /// commitment_value, nullifier, and anchor attached to this
-    /// [`SpendDescription`].
-    pub fn verify_proof(
-        &self,
-        randomized_public_key: &redjubjub::PublicKey,
-    ) -> Result<(), IronfishError> {
+    /// A function to encapsulate any verification besides the proof itself.
+    /// This allows us to abstract away the details and make it easier to work
+    /// with. Note that this does not verify the proof, that happens in the
+    /// [`SpendBuilder`] build function as the prover, and in
+    /// [`super::batch_verify_transactions`] as the verifier.
+    pub fn partial_verify(&self) -> Result<(), IronfishError> {
         self.verify_not_small_order()?;
-
-        groth16::verify_proof(
-            &SAPLING.spend_verifying_key,
-            &self.proof,
-            &self.public_inputs(randomized_public_key)[..],
-        )?;
 
         Ok(())
     }
 
-    pub fn verify_not_small_order(&self) -> Result<(), IronfishError> {
+    fn verify_not_small_order(&self) -> Result<(), IronfishError> {
         if self.value_commitment.is_small_order().into() {
             return Err(IronfishError::IsSmallOrder);
         }
@@ -374,6 +372,7 @@ mod test {
 
     use super::{SpendBuilder, SpendDescription};
     use crate::assets::asset::NATIVE_ASSET_GENERATOR;
+    use crate::transaction::utils::verify_spend_proof;
     use crate::{keys::SaplingKey, note::Note, test_util::make_fake_witness};
     use ff::Field;
     use group::Curve;
@@ -415,8 +414,7 @@ mod test {
         let proof = unsigned_proof
             .sign(&key, &sig_hash)
             .expect("should be able to sign proof");
-        proof
-            .verify_proof(&randomized_public_key)
+        verify_spend_proof(&proof.proof, &proof.public_inputs(&randomized_public_key))
             .expect("proof should check out");
         proof
             .verify_signature(&sig_hash, &randomized_public_key)

--- a/ironfish-rust/src/transaction/utils.rs
+++ b/ironfish-rust/src/transaction/utils.rs
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use bellman::groth16;
+use bls12_381::Bls12;
+
+use crate::{errors::IronfishError, sapling_bls12::SAPLING};
+
+/// Helper function for verifying spend proof internally. Note that this is not
+/// called by verifiers as part of transaction verification. See
+/// [`super::batch_verify_transactions`]
+pub(crate) fn verify_spend_proof(
+    proof: &groth16::Proof<Bls12>,
+    inputs: &[bls12_381::Scalar],
+) -> Result<(), IronfishError> {
+    groth16::verify_proof(&SAPLING.spend_verifying_key, proof, inputs)?;
+
+    Ok(())
+}
+
+/// Helper function for verifying output proof internally. Note that this is not
+/// called by verifiers as part of transaction verification. See
+/// [`super::batch_verify_transactions`]
+pub(crate) fn verify_output_proof(
+    proof: &groth16::Proof<Bls12>,
+    inputs: &[bls12_381::Scalar],
+) -> Result<(), IronfishError> {
+    groth16::verify_proof(&SAPLING.output_verifying_key, proof, inputs)?;
+
+    Ok(())
+}
+
+/// Helper function for verifying mint proof internally. Note that this is not
+/// called by verifiers as part of transaction verification. See
+/// [`super::batch_verify_transactions`]
+pub(crate) fn verify_mint_proof(
+    proof: &groth16::Proof<Bls12>,
+    inputs: &[bls12_381::Scalar],
+) -> Result<(), IronfishError> {
+    groth16::verify_proof(&SAPLING.mint_verifying_key, proof, inputs)?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Realized this code was too easy to get wrong because it was not clear what was happening.
- Removed `verify_proof` from the descriptions since it was only being used by the builders when creating the description. Since it wasn't used when verifying a transaction, it was too easy to add logic here that wouldn't get checked. The mint had a bug because of this - generator point was not being verified.
- Encapsulate all other verification logic into one function so as to not be a leaky abstraction

I think it's time to introduce a trait for descriptions, but I want to wait until the rust changes settle a bit so I'm not creating a ton of merge conflicts

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
