### PR TITLE
parallelizes checking each account for pending transaction

### DIFF
--- a/ironfish/src/utils/async.ts
+++ b/ironfish/src/utils/async.ts
@@ -48,4 +48,13 @@ export class AsyncUtils {
 
     return undefined
   }
+
+  static async filter<T>(
+    array: Array<T>,
+    predicate: (item: T) => Promise<boolean>,
+  ): Promise<Array<T>> {
+    const include = await Promise.all(array.map(predicate))
+
+    return array.filter((_, index) => include[index])
+  }
 }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -18,7 +18,13 @@ import { MintDescription } from '../primitives/mintDescription'
 import { Note } from '../primitives/note'
 import { Transaction } from '../primitives/transaction'
 import { IDatabaseTransaction } from '../storage/database/transaction'
-import { BufferUtils, PromiseResolve, PromiseUtils, SetTimeoutToken } from '../utils'
+import {
+  AsyncUtils,
+  BufferUtils,
+  PromiseResolve,
+  PromiseUtils,
+  SetTimeoutToken,
+} from '../utils'
 import { WorkerPool } from '../workerPool'
 import { DecryptedNote, DecryptNoteOptions } from '../workerPool/tasks/decryptNotes'
 import { Account } from './account'
@@ -398,7 +404,8 @@ export class Wallet {
   }
 
   async addPendingTransaction(transaction: Transaction): Promise<void> {
-    const accounts = await this.filterAccountsAsync(
+    const accounts = await AsyncUtils.filter(
+      this.listAccounts(),
       async (account) => !(await account.hasTransaction(transaction.hash())),
     )
 
@@ -1125,16 +1132,6 @@ export class Wallet {
 
   listAccounts(): Account[] {
     return Array.from(this.accounts.values())
-  }
-
-  async filterAccountsAsync(
-    predicate: (account: Account) => Promise<boolean>,
-  ): Promise<Account[]> {
-    const accounts = this.listAccounts()
-
-    const includeAccount = await Promise.all(accounts.map(predicate))
-
-    return accounts.filter((_, index) => includeAccount[index])
   }
 
   accountExists(name: string): boolean {


### PR DESCRIPTION
## Summary

followup to #2695 

defines 'filterAccountsAsync' method to parallelize filtering accounts in the wallet based on an asynchronous function.

checks whether each account has already synced a transaction before calling addPendingTransaction. parallelizes these db checks.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
