### PR TITLE
feat(ironfish): Add identifier to asset info store

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -901,6 +901,7 @@ describe('Blockchain', () => {
         const mintedAsset = await node.chain.assets.get(asset.identifier())
         expect(mintedAsset).toEqual({
           createdTransactionHash: mintTransaction.hash(),
+          identifier: asset.identifier(),
           metadata: asset.metadata(),
           name: asset.name(),
           nonce: asset.nonce(),
@@ -959,6 +960,7 @@ describe('Blockchain', () => {
         const mintedAsset = await node.chain.assets.get(asset.identifier())
         expect(mintedAsset).toEqual({
           createdTransactionHash: mintTransactionA.hash(),
+          identifier: asset.identifier(),
           metadata: asset.metadata(),
           name: asset.name(),
           nonce: asset.nonce(),

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1333,6 +1333,7 @@ export class Blockchain {
         assetIdentifier,
         {
           createdTransactionHash,
+          identifier: assetIdentifier,
           metadata: asset.metadata(),
           name: asset.name(),
           nonce: asset.nonce(),
@@ -1360,6 +1361,7 @@ export class Blockchain {
         assetIdentifier,
         {
           createdTransactionHash: existingAsset.createdTransactionHash,
+          identifier: existingAsset.identifier,
           metadata: existingAsset.metadata,
           name: existingAsset.name,
           nonce: existingAsset.nonce,
@@ -1386,6 +1388,7 @@ export class Blockchain {
         assetIdentifier,
         {
           createdTransactionHash: existingAsset.createdTransactionHash,
+          identifier: existingAsset.identifier,
           metadata: existingAsset.metadata,
           name: existingAsset.name,
           nonce: existingAsset.nonce,
@@ -1422,6 +1425,7 @@ export class Blockchain {
           assetIdentifier,
           {
             createdTransactionHash: existingAsset.createdTransactionHash,
+            identifier: asset.identifier(),
             metadata: asset.metadata(),
             name: asset.name(),
             nonce: asset.nonce(),

--- a/ironfish/src/blockchain/database/assets.test.ts
+++ b/ironfish/src/blockchain/database/assets.test.ts
@@ -15,6 +15,7 @@ describe('AssetsValueEncoding', () => {
 
     const value: AssetsValue = {
       createdTransactionHash: Buffer.alloc(32, 0),
+      identifier: asset.identifier(),
       metadata: asset.metadata(),
       name: asset.name(),
       nonce: asset.nonce(),

--- a/ironfish/src/blockchain/database/assets.ts
+++ b/ironfish/src/blockchain/database/assets.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import type { IDatabaseEncoding } from '../../storage/database/types'
 import {
+  ASSET_IDENTIFIER_LENGTH,
   ASSET_METADATA_LENGTH,
   ASSET_NAME_LENGTH,
   ASSET_OWNER_LENGTH,
@@ -13,6 +14,7 @@ import { BigIntUtils } from '../../utils'
 
 export interface AssetsValue {
   createdTransactionHash: Buffer
+  identifier: Buffer
   metadata: Buffer
   name: Buffer
   nonce: number
@@ -24,6 +26,7 @@ export class AssetsValueEncoding implements IDatabaseEncoding<AssetsValue> {
   serialize(value: AssetsValue): Buffer {
     const bw = bufio.write(this.getSize(value))
     bw.writeHash(value.createdTransactionHash)
+    bw.writeHash(value.identifier)
     bw.writeBytes(value.metadata)
     bw.writeBytes(value.name)
     bw.writeU8(value.nonce)
@@ -35,17 +38,19 @@ export class AssetsValueEncoding implements IDatabaseEncoding<AssetsValue> {
   deserialize(buffer: Buffer): AssetsValue {
     const reader = bufio.read(buffer, true)
     const createdTransactionHash = reader.readHash()
+    const identifier = reader.readBytes(ASSET_IDENTIFIER_LENGTH)
     const metadata = reader.readBytes(ASSET_METADATA_LENGTH)
     const name = reader.readBytes(ASSET_NAME_LENGTH)
     const nonce = reader.readU8()
     const owner = reader.readBytes(ASSET_OWNER_LENGTH)
     const supply = BigIntUtils.fromBytesLE(reader.readVarBytes())
-    return { createdTransactionHash, metadata, name, nonce, owner, supply }
+    return { createdTransactionHash, identifier, metadata, name, nonce, owner, supply }
   }
 
   getSize(value: AssetsValue): number {
     let size = 0
     size += 32 // createdTransactionHash
+    size += ASSET_IDENTIFIER_LENGTH // identifier
     size += ASSET_METADATA_LENGTH // metadata
     size += ASSET_NAME_LENGTH // name
     size += 1 // nonce


### PR DESCRIPTION
## Summary

Add the identifier to the asset store for developer convenience. We could generally get it from the key, but the extra 32 bytes is fairly negligble as far as storage goes.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
