### PR TITLE
Check mints and burns in miner fee transactions

### DIFF
--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -217,7 +217,11 @@ impl ProposedTransaction {
     /// a miner would not accept such a transaction unless it was explicitly set
     /// as the miners fee.
     pub fn post_miners_fee(&mut self) -> Result<Transaction, IronfishError> {
-        if !self.spends.is_empty() || self.outputs.len() != 1 {
+        if !self.spends.is_empty()
+            || self.outputs.len() != 1
+            || !self.mints.is_empty()
+            || !self.burns.is_empty()
+        {
             return Err(IronfishError::InvalidMinersFeeTransaction);
         }
         // Ensure the merkle note has an identifiable encryption key

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -164,7 +164,13 @@ export class Transaction {
   }
 
   isMinersFee(): boolean {
-    return this.spends.length === 0 && this.notes.length === 1 && this._fee <= 0
+    return (
+      this.spends.length === 0 &&
+      this.notes.length === 1 &&
+      this.mints.length === 0 &&
+      this.burns.length === 0 &&
+      this._fee <= 0
+    )
   }
 
   getNote(index: number): NoteEncrypted {


### PR DESCRIPTION
## Summary

I'm not sure it's actually possible for mints or burns to be non-empty if we're already verifying that spends are empty and outputs are one. Perhaps in the case where the miner 
reward is 0, someone could mint an asset rather than creating a 0-value output. I don't think there are any negatives to explicitly checking that there are no mints/burns, 
though.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
