### PR TITLE
Update to Nodejs 18

### DIFF
--- a/.github/workflows/build-ironfish-rust-nodejs.yml
+++ b/.github/workflows/build-ironfish-rust-nodejs.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/setup-node@v3
         if: ${{ !matrix.settings.docker }}
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
           cache: yarn
           architecture: ${{ matrix.settings.architecture }}
 
@@ -132,11 +132,11 @@ jobs:
 
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            docker: node:16-slim
+            docker: node:18-slim
 
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            docker: node:16-alpine
+            docker: node:18-alpine
 
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
@@ -144,7 +144,7 @@ jobs:
 
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            docker: arm64v8/node:16-alpine
+            docker: arm64v8/node:18-alpine
             platform: linux/arm64/v8
 
     name: Test bindings for ${{ matrix.settings.target }}
@@ -160,7 +160,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
 
       - name: Download artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
           cache: 'yarn'
 
       - name: Install packages
@@ -50,7 +50,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
           cache: 'yarn'
 
       - name: Cache Rust
@@ -79,7 +79,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
           cache: 'yarn'
 
       - name: Cache Rust

--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
           cache: 'yarn'
 
       - name: Build Ironfish CLI

--- a/.github/workflows/deploy-npm-ironfish-cli.yml
+++ b/.github/workflows/deploy-npm-ironfish-cli.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
 

--- a/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
+++ b/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
 

--- a/.github/workflows/deploy-npm-ironfish.yml
+++ b/.github/workflows/deploy-npm-ironfish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See https://ironfish.network
 
 The following steps should only be used to install if you are planning on contributing to the Iron Fish codebase. Otherwise, we **strongly** recommend using the installation methods here: https://ironfish.network/docs/onboarding/installation-iron-fish
 
-1. Install [Node.js 16.x](https://nodejs.org/download/release/latest-v16.x/)
+1. Install [Node.js 18.x](https://nodejs.org/en/download/)
 1. Install [Rust](https://www.rust-lang.org/learn/get-started).
 1. Install [Yarn](https://classic.yarnpkg.com/en/docs/install).
 1. Windows:

--- a/ironfish-cli/Dockerfile
+++ b/ironfish-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.1-bullseye as build
+FROM node:18.12.1-bullseye as build
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN \
@@ -13,7 +13,7 @@ COPY ./ ./
 
 RUN ./ironfish-cli/scripts/build.sh
 
-FROM node:16.15.1-bullseye-slim
+FROM node:18.12.1-bullseye-slim
 EXPOSE 8020:8020
 EXPOSE 9033:9033
 VOLUME /root/.ironfish

--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -7,8 +7,8 @@ if (process.platform !== 'win32') {
   require('segfault-handler').registerHandler('segfault.log')
 }
 
-if(process.versions.node.split('.')[0] !== '16') {
-  console.log('NodeJS version ' +  process.versions.node + ' is not compatible. Must have node v16.x installed: https://nodejs.org/en/blog/release/v16.16.0')
+if(process.versions.node.split('.')[0] !== '18') {
+  console.log('NodeJS version ' +  process.versions.node + ' is not compatible. Must have node v18.x installed: https://nodejs.org/en/download/')
   process.exit(1)
 }
 

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -20,12 +20,12 @@
     "/oclif.manifest.json"
   ],
   "engines": {
-    "node": "16.x"
+    "node": "18.x"
   },
   "devDependencies": {
     "@oclif/test": "2.1.0",
     "@types/blessed": "0.1.17",
-    "@types/node": "16.11.1",
+    "@types/node": "18.11.16",
     "@types/tar": "6.1.1",
     "@types/ws": "7.4.5",
     "chai": "4.2.0",

--- a/ironfish-rust-nodejs/npm/darwin-arm64/package.json
+++ b/ironfish-rust-nodejs/npm/darwin-arm64/package.json
@@ -13,6 +13,6 @@
   ],
   "license": "MPL-2.0",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   }
 }

--- a/ironfish-rust-nodejs/npm/darwin-x64/package.json
+++ b/ironfish-rust-nodejs/npm/darwin-x64/package.json
@@ -13,6 +13,6 @@
   ],
   "license": "MPL-2.0",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   }
 }

--- a/ironfish-rust-nodejs/npm/linux-arm64-gnu/package.json
+++ b/ironfish-rust-nodejs/npm/linux-arm64-gnu/package.json
@@ -13,6 +13,6 @@
   ],
   "license": "MPL-2.0",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   }
 }

--- a/ironfish-rust-nodejs/npm/linux-arm64-musl/package.json
+++ b/ironfish-rust-nodejs/npm/linux-arm64-musl/package.json
@@ -13,6 +13,6 @@
   ],
   "license": "MPL-2.0",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   }
 }

--- a/ironfish-rust-nodejs/npm/linux-x64-gnu/package.json
+++ b/ironfish-rust-nodejs/npm/linux-x64-gnu/package.json
@@ -13,6 +13,6 @@
   ],
   "license": "MPL-2.0",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   }
 }

--- a/ironfish-rust-nodejs/npm/linux-x64-musl/package.json
+++ b/ironfish-rust-nodejs/npm/linux-x64-musl/package.json
@@ -13,6 +13,6 @@
   ],
   "license": "MPL-2.0",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   }
 }

--- a/ironfish-rust-nodejs/npm/win32-x64-msvc/package.json
+++ b/ironfish-rust-nodejs/npm/win32-x64-msvc/package.json
@@ -13,6 +13,6 @@
   ],
   "license": "MPL-2.0",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   }
 }

--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -30,7 +30,7 @@
     }
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   },
   "devDependencies": {
     "@napi-rs/cli": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4002,10 +4002,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
   integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
 
-"@types/node@16.11.1":
-  version "16.11.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.1.tgz#2e50a649a50fc403433a14f829eface1a3443e97"
-  integrity sha512-PYGcJHL9mwl1Ek3PLiYgyEKtwTMmkMw4vbiyz/ps3pfdRYLVv+SN7qHVAImrjdAXxgluDEw6Ph4lyv+m9UpRmA==
+"@types/node@18.11.16":
+  version "18.11.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.16.tgz#966cae211e970199559cfbd295888fca189e49af"
+  integrity sha512-6T7P5bDkRhqRxrQtwj7vru+bWTpelgtcETAZEUSdq0YISKz8WKdoBukQLYQQ6DFHvU9JRsbFq0JH5C51X2ZdnA==
 
 "@types/node@^15.6.1":
   version "15.14.9"


### PR DESCRIPTION
## Summary

Requires the latest LTS, Nodejs 18, when running `ironfish`.

Leaving this in draft intentionally until after the next release, since there's a good chance it'll break some of the github actions.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
