### PR TITLE
Add lint and lint:fix to ironfish-rust

### DIFF
--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -15,8 +15,8 @@
     "build": "yarn clean && napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish --skip-gh-release",
-    "lint": "cargo fmt --all --check",
-    "lint:fix": "cargo fmt --all",
+    "lint": "cargo fmt --all --check && cargo clippy --all-targets -- -D warnings",
+    "lint:fix": "cargo fmt --all && cargo clippy --all-targets -- -D warnings --fix",
     "test:slow": "jest --testPathIgnorePatterns --testMatch \"**/*.test.slow.ts\"",
     "clean": "rimraf target"
   },

--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -16,7 +16,7 @@
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish --skip-gh-release",
     "lint": "cargo fmt --all --check && cargo clippy --all-targets -- -D warnings",
-    "lint:fix": "cargo fmt --all && cargo clippy --all-targets -- -D warnings --fix",
+    "lint:fix": "cargo fmt --all && cargo clippy --all-targets --fix --allow-dirty --allow-staged -- -D warnings",
     "test:slow": "jest --testPathIgnorePatterns --testMatch \"**/*.test.slow.ts\"",
     "clean": "rimraf target"
   },

--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -15,6 +15,8 @@
     "build": "yarn clean && napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish --skip-gh-release",
+    "lint": "cargo fmt --all --check",
+    "lint:fix": "cargo fmt --all",
     "test:slow": "jest --testPathIgnorePatterns --testMatch \"**/*.test.slow.ts\"",
     "clean": "rimraf target"
   },


### PR DESCRIPTION
## Summary

This allows `yarn lint:fix` at the root to work via lerna.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
