### PR TITLE
Fix submittedSequence in connectTransaction

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -182,8 +182,14 @@ export class Account {
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     const balanceDeltas = new AssetBalanceDeltas()
+    let submittedSequence: number | null = null
 
     await this.walletDb.db.withTransaction(tx, async (tx) => {
+      const transactionValue = await this.getTransaction(transaction.hash(), tx)
+      if (transactionValue) {
+        submittedSequence = transactionValue.submittedSequence
+      }
+
       for (const decryptedNote of decryptedNotes) {
         if (decryptedNote.forSpender) {
           continue
@@ -230,7 +236,7 @@ export class Account {
           transaction,
           blockHash: blockHeader.hash,
           sequence: blockHeader.sequence,
-          submittedSequence: blockHeader.sequence,
+          submittedSequence,
         },
         tx,
       )


### PR DESCRIPTION
## Summary

Get `submittedSequence` from the existing, stored `transactionValue` if it exists, otherwise set it to `null`. This change is needed because `submittedSequence` should be the sequence when the transaction was submitted and not the block's sequence.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
