### PR TITLE
adds chain state fields to balances datastore

### DIFF
--- a/ironfish/src/primitives/rawTransaction.test.ts
+++ b/ironfish/src/primitives/rawTransaction.test.ts
@@ -32,7 +32,7 @@ describe('RawTransaction', () => {
     )
     await expect(nodeTest.chain).toAddBlock(block)
     await nodeTest.wallet.updateHead()
-    const balance = await account.getUnconfirmedBalance(Asset.nativeIdentifier())
+    const { balance } = await account.getUnconfirmedBalance(Asset.nativeIdentifier())
 
     const burn = {
       assetIdentifier: Asset.nativeIdentifier(),

--- a/ironfish/src/primitives/rawTransaction.test.ts
+++ b/ironfish/src/primitives/rawTransaction.test.ts
@@ -32,7 +32,7 @@ describe('RawTransaction', () => {
     )
     await expect(nodeTest.chain).toAddBlock(block)
     await nodeTest.wallet.updateHead()
-    const { balance } = await account.getUnconfirmedBalance(Asset.nativeIdentifier())
+    const { unconfirmed } = await account.getUnconfirmedBalance(Asset.nativeIdentifier())
 
     const burn = {
       assetIdentifier: Asset.nativeIdentifier(),
@@ -77,7 +77,7 @@ describe('RawTransaction', () => {
 
     const nativeValue = valuesByAsset.get(Asset.nativeIdentifier())
     Assert.isNotUndefined(nativeValue)
-    expect(nativeValue).toEqual(balance - raw.fee - mint.value - 1n)
+    expect(nativeValue).toEqual(unconfirmed - raw.fee - mint.value - 1n)
 
     const mintedValue = valuesByAsset.get(asset.identifier())
     Assert.isNotUndefined(mintedValue)

--- a/ironfish/src/rpc/routes/wallet/removeAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/removeAccount.ts
@@ -41,8 +41,8 @@ router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
     if (!request.data.confirm) {
       const balances = await account.getUnconfirmedBalances()
 
-      for (const [_, { balance }] of balances) {
-        if (balance !== BigInt(0)) {
+      for (const [_, { unconfirmed }] of balances) {
+        if (unconfirmed !== BigInt(0)) {
           request.end({ needsConfirm: true })
           return
         }

--- a/ironfish/src/rpc/routes/wallet/removeAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/removeAccount.ts
@@ -41,7 +41,7 @@ router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
     if (!request.data.confirm) {
       const balances = await account.getUnconfirmedBalances()
 
-      for (const [_, balance] of balances) {
+      for (const [_, { balance }] of balances) {
         if (balance !== BigInt(0)) {
           request.end({ needsConfirm: true })
           return

--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -203,13 +203,13 @@ describe('Accounts', () => {
 
       const account = await useAccountFixture(node.wallet, 'account')
       const nativeBalance = {
-        balance: BigInt(1),
+        unconfirmed: BigInt(1),
         blockHash: null,
         sequence: null,
       }
       const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
       const mintedAssetBalance = {
-        balance: BigInt(7),
+        unconfirmed: BigInt(7),
         blockHash: null,
         sequence: null,
       }

--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -11,6 +11,7 @@ import {
   useTxFixture,
 } from '../testUtilities'
 import { AsyncUtils } from '../utils/async'
+import { BalanceValue } from './walletdb/balanceValue'
 
 describe('Accounts', () => {
   const nodeTest = createNodeTest()
@@ -201,15 +202,23 @@ describe('Accounts', () => {
       const { node } = nodeTest
 
       const account = await useAccountFixture(node.wallet, 'account')
-      const nativeBalance = BigInt(1)
+      const nativeBalance = {
+        balance: BigInt(1),
+        blockHash: null,
+        sequence: null,
+      }
       const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
-      const mintedAssetBalance = BigInt(7)
+      const mintedAssetBalance = {
+        balance: BigInt(7),
+        blockHash: null,
+        sequence: null,
+      }
 
       await account.saveUnconfirmedBalance(Asset.nativeIdentifier(), nativeBalance)
       await account.saveUnconfirmedBalance(asset.identifier(), mintedAssetBalance)
 
       const balances = await account.getUnconfirmedBalances()
-      const expectedBalances = new BufferMap<bigint>([
+      const expectedBalances = new BufferMap<BalanceValue>([
         [Asset.nativeIdentifier(), nativeBalance],
         [asset.identifier(), mintedAssetBalance],
       ])
@@ -445,7 +454,7 @@ describe('Accounts', () => {
       }
 
       // disconnect transaction
-      await accountA.disconnectTransaction(transaction)
+      await accountA.disconnectTransaction(block3.header, transaction)
 
       for (const note of transaction.notes) {
         const decryptedNote = await accountA.getDecryptedNote(note.merkleHash())
@@ -499,7 +508,7 @@ describe('Accounts', () => {
       }
 
       // disconnect transaction
-      await accountA.disconnectTransaction(transaction)
+      await accountA.disconnectTransaction(block3.header, transaction)
 
       for (const spend of transaction.spends) {
         const spentNoteHash = await accountA.getNoteHash(spend.nullifier)
@@ -539,7 +548,7 @@ describe('Accounts', () => {
       expect(pendingHashEntry).toBeUndefined()
 
       // disconnect transaction
-      await accountA.disconnectTransaction(transaction)
+      await accountA.disconnectTransaction(block3.header, transaction)
 
       pendingHashEntry = await accountA['walletDb'].pendingTransactionHashes.get([
         accountA.prefix,

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -456,7 +456,7 @@ export class Account {
   }> {
     let unconfirmedCount = 0
 
-    const { balance: unconfirmed } = await this.getUnconfirmedBalance(assetIdentifier, tx)
+    const { unconfirmed } = await this.getUnconfirmedBalance(assetIdentifier, tx)
 
     let confirmed = unconfirmed
     if (minimumBlockConfirmations > 0) {
@@ -522,7 +522,7 @@ export class Account {
         this,
         assetIdentifier,
         {
-          balance: currentUnconfirmedBalance.balance + balanceDelta,
+          unconfirmed: currentUnconfirmedBalance.unconfirmed + balanceDelta,
           blockHash,
           sequence,
         },

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -1088,7 +1088,7 @@ describe('Accounts', () => {
       await node.wallet.updateHead()
 
       const balanceBefore = await accountA.getUnconfirmedBalance(Asset.nativeIdentifier())
-      expect(balanceBefore.balance).toEqual(2000000000n)
+      expect(balanceBefore.unconfirmed).toEqual(2000000000n)
 
       const { block: blockA2 } = await useBlockWithTx(node, accountA, accountB, false)
       await expect(node.chain).toAddBlock(blockA2)
@@ -1096,7 +1096,7 @@ describe('Accounts', () => {
       await node.wallet.connectBlock(blockA2.header, [accountA, accountB])
 
       const balanceAfter = await accountA.getUnconfirmedBalance(Asset.nativeIdentifier())
-      expect(balanceAfter.balance).toEqual(1999999998n)
+      expect(balanceAfter.unconfirmed).toEqual(1999999998n)
     })
   })
 
@@ -1176,7 +1176,7 @@ describe('Accounts', () => {
       await node.wallet.updateHead()
 
       const balanceBefore = await accountA.getUnconfirmedBalance(Asset.nativeIdentifier())
-      expect(balanceBefore.balance).toEqual(2000000000n)
+      expect(balanceBefore.unconfirmed).toEqual(2000000000n)
 
       const { block: blockA2 } = await useBlockWithTx(node, accountA, accountB, false)
       await expect(node.chain).toAddBlock(blockA2)
@@ -1184,7 +1184,7 @@ describe('Accounts', () => {
       await node.wallet.updateHead()
 
       const balanceAfterConnect = await accountA.getUnconfirmedBalance(Asset.nativeIdentifier())
-      expect(balanceAfterConnect.balance).toEqual(1999999998n)
+      expect(balanceAfterConnect.unconfirmed).toEqual(1999999998n)
 
       await node.chain.db.transaction(async (tx) => {
         await node.chain.disconnect(blockA2, tx)
@@ -1195,7 +1195,7 @@ describe('Accounts', () => {
       const balanceAfterDisconnect = await accountA.getUnconfirmedBalance(
         Asset.nativeIdentifier(),
       )
-      expect(balanceAfterDisconnect.balance).toEqual(2000000000n)
+      expect(balanceAfterDisconnect.unconfirmed).toEqual(2000000000n)
     })
   })
 })

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -1088,7 +1088,7 @@ describe('Accounts', () => {
       await node.wallet.updateHead()
 
       const balanceBefore = await accountA.getUnconfirmedBalance(Asset.nativeIdentifier())
-      expect(balanceBefore).toEqual(2000000000n)
+      expect(balanceBefore.balance).toEqual(2000000000n)
 
       const { block: blockA2 } = await useBlockWithTx(node, accountA, accountB, false)
       await expect(node.chain).toAddBlock(blockA2)
@@ -1096,7 +1096,7 @@ describe('Accounts', () => {
       await node.wallet.connectBlock(blockA2.header, [accountA, accountB])
 
       const balanceAfter = await accountA.getUnconfirmedBalance(Asset.nativeIdentifier())
-      expect(balanceAfter).toEqual(1999999998n)
+      expect(balanceAfter.balance).toEqual(1999999998n)
     })
   })
 
@@ -1176,7 +1176,7 @@ describe('Accounts', () => {
       await node.wallet.updateHead()
 
       const balanceBefore = await accountA.getUnconfirmedBalance(Asset.nativeIdentifier())
-      expect(balanceBefore).toEqual(2000000000n)
+      expect(balanceBefore.balance).toEqual(2000000000n)
 
       const { block: blockA2 } = await useBlockWithTx(node, accountA, accountB, false)
       await expect(node.chain).toAddBlock(blockA2)
@@ -1184,7 +1184,7 @@ describe('Accounts', () => {
       await node.wallet.updateHead()
 
       const balanceAfterConnect = await accountA.getUnconfirmedBalance(Asset.nativeIdentifier())
-      expect(balanceAfterConnect).toEqual(1999999998n)
+      expect(balanceAfterConnect.balance).toEqual(1999999998n)
 
       await node.chain.db.transaction(async (tx) => {
         await node.chain.disconnect(blockA2, tx)
@@ -1195,7 +1195,7 @@ describe('Accounts', () => {
       const balanceAfterDisconnect = await accountA.getUnconfirmedBalance(
         Asset.nativeIdentifier(),
       )
-      expect(balanceAfterDisconnect).toEqual(2000000000n)
+      expect(balanceAfterDisconnect.balance).toEqual(2000000000n)
     })
   })
 })

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -432,7 +432,7 @@ export class Wallet {
     for (const account of accounts) {
       await this.walletDb.db.transaction(async (tx) => {
         for await (const { transaction } of this.chain.iterateBlockTransactions(header)) {
-          await account.disconnectTransaction(transaction, tx)
+          await account.disconnectTransaction(header, transaction, tx)
         }
 
         await this.updateHeadHash(account, header.previousBlockHash, tx)

--- a/ironfish/src/wallet/walletdb/__fixtures__/balanceValue.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/balanceValue.test.ts.fixture
@@ -1,0 +1,30 @@
+{
+  "BalanceValueEncoding with all fields defined serializes the object into a buffer and deserializes to the original object": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:BtXrlQrSx77ALa9nCiCxO+MMKkRqg3kO0gYLEp2bJCM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/TOL6Ie6D1ooqmdr3ZqlvIzpHSnJqt0usPlG3dzdomQ="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1671576478657,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAlDhxwugGoILLsEoGS1LvSIce7ctD9JZPrMpMMOvBgcCtofjR2k08gtjQl2G2X8S4I8dVR5DXPRAoXgTKShEUCRhjvdyc47BANbozLMMTxfaFGe71C7ZQFplKqTSkKfhriCJxJU5bu/iWzbBJK9lQ57Df+cOQfljg05iiDxQbiuEIc/GA21LwhXyz4LPANsX7yWdlIwZo1VteHt+ItVAcMr2aLVC4SRr2rcvIVg0/T6WVZaVsyccyA1WUDY6DusQYtluvBN8EWsYMJzZmovFzWEo+huQzaoAj7gaLDFC+RNtCENO3FbrfBy21dNVt3goSXoTLN1LMWeFWjXq7Havzlm3nH3lPTHMImzcDNkfhGoVS1niD0UVRkVM0vMOfWlQzeKocP4FF6j5OtGAxRTEHiST5ASX8I9iQGFlk0eV3ee0Cow2tnm0or2/fPGTyzuvj7XhDDV7JN6gtGcIqdG+MY1Uh6TDLskuoH2oHttlKUfDryvAXPFsq/yHIHJaQcWN8ifgTUEK7TClIO1w26ePProJigti1XKryb1i7S47mPDPhbtYzHzBFPMpX4aKmVdqnlVcfzO2UWm3nhHE0m9Ezm/OEZYw6izUhs3q189zSzmgoYDNL8/tDcklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoNkyA5lOZCC0MMCT2uWjkoKYa7Zx98PWajey8HDq++7oo9w2TNNiHyEuZ6kUETNJyzNwE6YD85xGk1R3URT8BQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/wallet/walletdb/balanceValue.test.ts
+++ b/ironfish/src/wallet/walletdb/balanceValue.test.ts
@@ -9,7 +9,7 @@ describe('BalanceValueEncoding', () => {
   const nodeTest = createNodeTest()
 
   function expectBalanceValueToMatch(a: BalanceValue, b: BalanceValue): void {
-    expect(a.balance).toEqual(b.balance)
+    expect(a.unconfirmed).toEqual(b.unconfirmed)
     expect(BufferUtils.equalsNullable(a.blockHash, b.blockHash)).toBe(true)
     expect(a.sequence).toEqual(b.sequence)
   }
@@ -19,7 +19,7 @@ describe('BalanceValueEncoding', () => {
       const encoder = new BalanceValueEncoding()
 
       const balanceValue = {
-        balance: 0n,
+        unconfirmed: 0n,
         blockHash: null,
         sequence: null,
       }
@@ -38,7 +38,7 @@ describe('BalanceValueEncoding', () => {
       const encoder = new BalanceValueEncoding()
 
       const balanceValue = {
-        balance: 0n,
+        unconfirmed: 0n,
         blockHash: block.header.hash,
         sequence: block.header.sequence,
       }

--- a/ironfish/src/wallet/walletdb/balanceValue.test.ts
+++ b/ironfish/src/wallet/walletdb/balanceValue.test.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createNodeTest, useMinerBlockFixture } from '../../testUtilities'
+import { BufferUtils } from '../../utils/buffer'
+import { BalanceValue, BalanceValueEncoding } from './balanceValue'
+
+describe('BalanceValueEncoding', () => {
+  const nodeTest = createNodeTest()
+
+  function expectBalanceValueToMatch(a: BalanceValue, b: BalanceValue): void {
+    expect(a.balance).toEqual(b.balance)
+    expect(BufferUtils.equalsNullable(a.blockHash, b.blockHash)).toBe(true)
+    expect(a.sequence).toEqual(b.sequence)
+  }
+
+  describe('with a null block hash and sequence', () => {
+    it('serializes the object into a buffer and deserializes to the original object', () => {
+      const encoder = new BalanceValueEncoding()
+
+      const balanceValue = {
+        balance: 0n,
+        blockHash: null,
+        sequence: null,
+      }
+
+      const buffer = encoder.serialize(balanceValue)
+      const deserializedValue = encoder.deserialize(buffer)
+      expectBalanceValueToMatch(deserializedValue, balanceValue)
+    })
+  })
+
+  describe('with all fields defined', () => {
+    it('serializes the object into a buffer and deserializes to the original object', async () => {
+      const { node } = nodeTest
+      const block = await useMinerBlockFixture(node.chain)
+
+      const encoder = new BalanceValueEncoding()
+
+      const balanceValue = {
+        balance: 0n,
+        blockHash: block.header.hash,
+        sequence: block.header.sequence,
+      }
+
+      const buffer = encoder.serialize(balanceValue)
+      const deserializedValue = encoder.deserialize(buffer)
+      expectBalanceValueToMatch(deserializedValue, balanceValue)
+    })
+  })
+})

--- a/ironfish/src/wallet/walletdb/balanceValue.ts
+++ b/ironfish/src/wallet/walletdb/balanceValue.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../storage'
+
+export interface BalanceValue {
+  balance: bigint
+  blockHash: Buffer | null
+  sequence: number | null
+}
+
+export class BalanceValueEncoding implements IDatabaseEncoding<BalanceValue> {
+  serialize(value: BalanceValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    bw.writeBigU64(value.balance)
+
+    let flags = 0
+    flags |= Number(!!value.blockHash) << 0
+    flags |= Number(!!value.sequence) << 1
+    bw.writeU8(flags)
+
+    if (value.blockHash) {
+      bw.writeHash(value.blockHash)
+    }
+
+    if (value.sequence) {
+      bw.writeU32(value.sequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): BalanceValue {
+    const reader = bufio.read(buffer, true)
+    const value = reader.readBigU64()
+
+    const flags = reader.readU8()
+    const hasBlockHash = flags & (1 << 0)
+    const hasSequence = flags & (1 << 1)
+
+    let blockHash = null
+    if (hasBlockHash) {
+      blockHash = reader.readHash()
+    }
+
+    let sequence = null
+    if (hasSequence) {
+      sequence = reader.readU32()
+    }
+
+    return {
+      balance: value,
+      blockHash,
+      sequence,
+    }
+  }
+
+  getSize(value: BalanceValue): number {
+    let size = 0
+    size += 8 // value
+    size += 1 // flags
+
+    if (value.blockHash) {
+      size += 32
+    }
+
+    if (value.sequence) {
+      size += 4
+    }
+
+    return size
+  }
+}

--- a/ironfish/src/wallet/walletdb/balanceValue.ts
+++ b/ironfish/src/wallet/walletdb/balanceValue.ts
@@ -5,7 +5,7 @@ import bufio from 'bufio'
 import { IDatabaseEncoding } from '../../storage'
 
 export interface BalanceValue {
-  balance: bigint
+  unconfirmed: bigint
   blockHash: Buffer | null
   sequence: number | null
 }
@@ -13,7 +13,7 @@ export interface BalanceValue {
 export class BalanceValueEncoding implements IDatabaseEncoding<BalanceValue> {
   serialize(value: BalanceValue): Buffer {
     const bw = bufio.write(this.getSize(value))
-    bw.writeBigU64(value.balance)
+    bw.writeBigU64(value.unconfirmed)
 
     let flags = 0
     flags |= Number(!!value.blockHash) << 0
@@ -50,7 +50,7 @@ export class BalanceValueEncoding implements IDatabaseEncoding<BalanceValue> {
     }
 
     return {
-      balance: value,
+      unconfirmed: value,
       blockHash,
       sequence,
     }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -222,7 +222,7 @@ export class WalletDB {
           account,
           Asset.nativeIdentifier(),
           {
-            balance: BigInt(0),
+            unconfirmed: BigInt(0),
             blockHash: null,
             sequence: null,
           },
@@ -640,7 +640,7 @@ export class WalletDB {
 
     return (
       unconfirmedBalance ?? {
-        balance: BigInt(0),
+        unconfirmed: BigInt(0),
         blockHash: null,
         sequence: null,
       }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -10,7 +10,6 @@ import { NoteEncryptedHash } from '../../primitives/noteEncrypted'
 import { Nullifier } from '../../primitives/nullifier'
 import { TransactionHash } from '../../primitives/transaction'
 import {
-  BigIntLEEncoding,
   BUFFER_ENCODING,
   BufferEncoding,
   IDatabase,
@@ -28,6 +27,7 @@ import { createDB } from '../../storage/utils'
 import { WorkerPool } from '../../workerPool'
 import { Account, calculateAccountPrefix } from '../account'
 import { AccountValue, AccountValueEncoding } from './accountValue'
+import { BalanceValue, BalanceValueEncoding } from './balanceValue'
 import { DecryptedNoteValue, DecryptedNoteValueEncoding } from './decryptedNoteValue'
 import { AccountsDBMeta, MetaValue, MetaValueEncoding } from './metaValue'
 import { TransactionValue, TransactionValueEncoding } from './transactionValue'
@@ -58,7 +58,7 @@ export class WalletDB {
 
   balances: IDatabaseStore<{
     key: [Account['prefix'], Buffer]
-    value: bigint
+    value: BalanceValue
   }>
 
   decryptedNotes: IDatabaseStore<{
@@ -139,7 +139,7 @@ export class WalletDB {
     this.balances = this.db.addStore({
       name: 'b',
       keyEncoding: new PrefixEncoding(new BufferEncoding(), new BufferEncoding(), 4),
-      valueEncoding: new BigIntLEEncoding(),
+      valueEncoding: new BalanceValueEncoding(),
     })
 
     this.decryptedNotes = this.db.addStore({
@@ -218,7 +218,16 @@ export class WalletDB {
         tx,
       )
       if (nativeUnconfirmedBalance === undefined) {
-        await this.saveUnconfirmedBalance(account, Asset.nativeIdentifier(), BigInt(0), tx)
+        await this.saveUnconfirmedBalance(
+          account,
+          Asset.nativeIdentifier(),
+          {
+            balance: BigInt(0),
+            blockHash: null,
+            sequence: null,
+          },
+          tx,
+        )
       }
     })
   }
@@ -626,15 +635,22 @@ export class WalletDB {
     account: Account,
     assetIdentifier: Buffer,
     tx?: IDatabaseTransaction,
-  ): Promise<bigint> {
+  ): Promise<BalanceValue> {
     const unconfirmedBalance = await this.balances.get([account.prefix, assetIdentifier], tx)
-    return unconfirmedBalance ?? BigInt(0)
+
+    return (
+      unconfirmedBalance ?? {
+        balance: BigInt(0),
+        blockHash: null,
+        sequence: null,
+      }
+    )
   }
 
   async *getUnconfirmedBalances(
     account: Account,
     tx?: IDatabaseTransaction,
-  ): AsyncGenerator<{ assetIdentifier: Buffer; balance: bigint }> {
+  ): AsyncGenerator<{ assetIdentifier: Buffer; balance: BalanceValue }> {
     for await (const [[_, assetIdentifier], balance] of this.balances.getAllIter(
       tx,
       account.prefixRange,
@@ -646,7 +662,7 @@ export class WalletDB {
   async saveUnconfirmedBalance(
     account: Account,
     assetIdentifier: Buffer,
-    balance: bigint,
+    balance: BalanceValue,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.balances.put([account.prefix, assetIdentifier], balance, tx)


### PR DESCRIPTION
## Summary

instead of storing only a bigint with the asset balance as the value in the balances store, stores an object containing the balance and the block hash and sequence of the most recent balance update.

now that we only update the balance when blocks are connected and disconnected from the chain the stored balance value corresponds to a specific chain state. storing this chain state alongside the balance will allow us to inform users of what chain state their balance reflects. a number of users were confused by balances while accounts were scanning during phase 2: their transactions would be on the chain, but the transaction wouldn't be reflected in their account balance because the account was behind the chain.

- defines BalanceValue type to include balance, blockHash, and sequence
- replaces value in balances datastore with BalanceValue
- propagates BalanceValue through all reads/writes on balances store

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
