### PR TITLE
Add DatabaseIteratorOptions

### DIFF
--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -6,6 +6,7 @@ import { BatchOperation, IDatabaseBatch } from './batch'
 import { IDatabaseStore, IDatabaseStoreOptions } from './store'
 import { IDatabaseTransaction } from './transaction'
 import {
+  DatabaseIteratorOptions,
   DatabaseKeyRange,
   DatabaseOptions,
   DatabaseSchema,
@@ -158,7 +159,10 @@ export interface IDatabase {
   put(key: Readonly<Buffer>, value: Buffer): Promise<void>
 
   /* Get an [[`AsyncGenerator`]] that yields all of the key/value pairs in the IDatabase */
-  getAllIter(range?: DatabaseKeyRange): AsyncGenerator<[Buffer, Buffer]>
+  getAllIter(
+    range?: DatabaseKeyRange,
+    options?: DatabaseIteratorOptions,
+  ): AsyncGenerator<[Buffer, Buffer]>
 }
 
 export abstract class Database implements IDatabase {
@@ -193,7 +197,10 @@ export abstract class Database implements IDatabase {
 
   abstract put(key: Readonly<Buffer>, value: Buffer): Promise<void>
 
-  abstract getAllIter(range?: DatabaseKeyRange): AsyncGenerator<[Buffer, Buffer]>
+  abstract getAllIter(
+    range?: DatabaseKeyRange,
+    options?: DatabaseIteratorOptions,
+  ): AsyncGenerator<[Buffer, Buffer]>
 
   protected abstract _createStore<Schema extends DatabaseSchema>(
     options: IDatabaseStoreOptions<Schema>,

--- a/ironfish/src/storage/database/types.ts
+++ b/ironfish/src/storage/database/types.ts
@@ -11,6 +11,11 @@ export interface DatabaseKeyRange {
   lte?: Buffer
 }
 
+export interface DatabaseIteratorOptions {
+  reverse?: boolean
+  limit?: number
+}
+
 export type DatabaseKey =
   | bigint
   | number

--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -27,7 +27,7 @@ import {
   DatabaseIsOpenError,
   DatabaseVersionError,
 } from '../database/errors'
-import { DatabaseKeyRange } from '../database/types'
+import { DatabaseIteratorOptions, DatabaseKeyRange } from '../database/types'
 import { LevelupBatch } from './batch'
 import { LevelupStore } from './store'
 import { LevelupTransaction } from './transaction'
@@ -213,8 +213,11 @@ export class LevelupDatabase extends Database {
     await this.levelup.put(key, value)
   }
 
-  async *getAllIter(range?: DatabaseKeyRange): AsyncGenerator<[Buffer, Buffer]> {
-    const stream = this.levelup.createReadStream(range)
+  async *getAllIter(
+    range?: DatabaseKeyRange,
+    options?: DatabaseIteratorOptions,
+  ): AsyncGenerator<[Buffer, Buffer]> {
+    const stream = this.levelup.createReadStream({ ...range, ...options })
 
     // The return type for createReadStream is wrong
     const iter = stream as unknown as AsyncIterable<{

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -7,6 +7,7 @@ import MurmurHash3 from 'imurmurhash'
 import { Assert } from '../../assert'
 import { AsyncUtils } from '../../utils/async'
 import {
+  DatabaseIteratorOptions,
   DatabaseKeyRange,
   DatabaseSchema,
   DatabaseStore,
@@ -74,6 +75,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
   async *getAllIter(
     transaction?: IDatabaseTransaction,
     keyRange?: DatabaseKeyRange,
+    iterationOptions?: DatabaseIteratorOptions,
   ): AsyncGenerator<[SchemaKey<Schema>, SchemaValue<Schema>]> {
     if (keyRange) {
       keyRange = StorageUtils.addPrefixToRange(keyRange, this.prefixBuffer)
@@ -108,7 +110,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
       }
     }
 
-    for await (const [key, value] of this.db.getAllIter(keyRange)) {
+    for await (const [key, value] of this.db.getAllIter(keyRange, iterationOptions)) {
       if (seen.has(key)) {
         continue
       }


### PR DESCRIPTION
## Summary

Add `DatabaseIteratorOptions` to separate iteration params from key range params. Merge everything together before passing into levelup's `createReadStream`.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
