### PR TITLE
Add support for iterating database entries by key order

### DIFF
--- a/ironfish/src/storage/database/store.ts
+++ b/ironfish/src/storage/database/store.ts
@@ -5,6 +5,7 @@
 import { UnwrapPromise } from '../../utils/types'
 import { IDatabaseTransaction } from './transaction'
 import {
+  DatabaseIteratorOptions,
   DatabaseKeyRange,
   DatabaseSchema,
   IDatabaseEncoding,
@@ -51,35 +52,41 @@ export interface IDatabaseStore<Schema extends DatabaseSchema> {
   getAll(
     transaction?: IDatabaseTransaction,
     keyRange?: DatabaseKeyRange,
+    iteratorOptions?: DatabaseIteratorOptions,
   ): Promise<Array<[SchemaKey<Schema>, SchemaValue<Schema>]>>
 
   /* Get an [[`AsyncGenerator`]] that yields all of the key/value pairs in the IDatastore */
   getAllIter(
     transaction?: IDatabaseTransaction,
     keyRange?: DatabaseKeyRange,
+    iteratorOptions?: DatabaseIteratorOptions,
   ): AsyncGenerator<[SchemaKey<Schema>, SchemaValue<Schema>]>
 
   /* Get an [[`AsyncGenerator`]] that yields all of the values in the IDatastore */
   getAllValuesIter(
     transaction?: IDatabaseTransaction,
     keyRange?: DatabaseKeyRange,
+    iteratorOptions?: DatabaseIteratorOptions,
   ): AsyncGenerator<SchemaValue<Schema>>
   /* Get all of the values in the IDatastore */
   getAllValues(
     transaction?: IDatabaseTransaction,
     keyRange?: DatabaseKeyRange,
+    iteratorOptions?: DatabaseIteratorOptions,
   ): Promise<Array<SchemaValue<Schema>>>
 
   /* Get an [[`AsyncGenerator`]] that yields all of the keys in the IDatastore */
   getAllKeysIter(
     transaction?: IDatabaseTransaction,
     keyRange?: DatabaseKeyRange,
+    iteratorOptions?: DatabaseIteratorOptions,
   ): AsyncGenerator<SchemaKey<Schema>>
 
   /* Get all of the keys in the IDatastore */
   getAllKeys(
     transaction?: IDatabaseTransaction,
     keyRange?: DatabaseKeyRange,
+    iteratorOptions?: DatabaseIteratorOptions,
   ): Promise<Array<SchemaKey<Schema>>>
 
   /**
@@ -183,11 +190,13 @@ export abstract class DatabaseStore<Schema extends DatabaseSchema>
   abstract getAllIter(
     transaction?: IDatabaseTransaction,
     keyRange?: DatabaseKeyRange,
+    iteratorOptions?: DatabaseIteratorOptions,
   ): AsyncGenerator<[SchemaKey<Schema>, SchemaValue<Schema>]>
 
   abstract getAll(
     transaction?: IDatabaseTransaction,
     keyRange?: DatabaseKeyRange,
+    iteratorOptions?: DatabaseIteratorOptions,
   ): Promise<Array<[SchemaKey<Schema>, SchemaValue<Schema>]>>
 
   abstract getAllValuesIter(

--- a/ironfish/src/storage/database/types.ts
+++ b/ironfish/src/storage/database/types.ts
@@ -14,6 +14,7 @@ export interface DatabaseKeyRange {
 export interface DatabaseIteratorOptions {
   reverse?: boolean
   limit?: number
+  ordered?: boolean
 }
 
 export type DatabaseKey =


### PR DESCRIPTION
## Summary

Add support for iterating database entries by key order (levelDB default iteration is by sorted key order but our transaction cache didn't support this)

## Testing Plan

Added tests in `database.test.ts`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
