### PR TITLE
Don't save latest until transaction commit

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -701,6 +701,11 @@ export class Blockchain {
 
     await tx.update()
     this.notes.pastRootTxCommitted(tx)
+
+    if (!this.hasGenesisBlock || isBlockLater(block.header, this.latest)) {
+      this.latest = block.header
+    }
+
     await this.onForkBlock.emitAsync(block, tx)
 
     this.logger.warn(
@@ -756,6 +761,10 @@ export class Blockchain {
 
     await tx.update()
     this.notes.pastRootTxCommitted(tx)
+
+    if (!this.hasGenesisBlock || isBlockLater(block.header, this.latest)) {
+      this.latest = block.header
+    }
 
     this.head = block.header
 
@@ -1311,7 +1320,6 @@ export class Blockchain {
     }
 
     if (!this.hasGenesisBlock || isBlockLater(block.header, this.latest)) {
-      this.latest = block.header
       await this.meta.put('latest', hash, tx)
     }
   }


### PR DESCRIPTION
## Summary
A while back a change was made to do block database updates and block verification in parallel. This works because saving the block is done within an atomic transaction and if block verification later fails then the transaction can be rolled back. There are a few in-memory updates however that are not done within the database transaction and would not be rolled back such as updating the `chain.head` and `chain.latest` in memory objects. This PR fixes a potential bug where chain.latest can be updated outside of a database transaction. 

## Testing Plan
Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
