### PR TITLE
Fix note encoding not using CurrencyUtils

### DIFF
--- a/ironfish/src/rpc/routes/assets/mint.test.ts
+++ b/ironfish/src/rpc/routes/assets/mint.test.ts
@@ -4,6 +4,7 @@
 import { Asset } from '@ironfish/rust-nodejs'
 import { useAccountFixture, useTxFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
+import { CurrencyUtils } from '../../../utils'
 
 describe('mint', () => {
   const routeTest = createRouteTest(true)
@@ -81,8 +82,9 @@ describe('mint', () => {
         fee: '1',
         metadata: asset.metadata().toString('hex'),
         name: asset.name().toString('hex'),
-        value: value.toString(),
+        value: CurrencyUtils.encode(value),
       })
+
       expect(response.content).toEqual({
         assetIdentifier: asset.identifier().toString('hex'),
         hash: mintTransaction.hash().toString('hex'),

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -6,6 +6,7 @@ import { Assert } from '../../../assert'
 import { ChainProcessor } from '../../../chainProcessor'
 import { Block } from '../../../primitives/block'
 import { BlockHeader } from '../../../primitives/blockheader'
+import { CurrencyUtils } from '../../../utils'
 import { PromiseUtils } from '../../../utils/promise'
 import { isValidIncomingViewKey } from '../../../wallet/validator'
 import { ValidationError } from '../../adapters/errors'
@@ -116,7 +117,7 @@ router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
 
           if (decryptedNote) {
             notes.push({
-              amount: decryptedNote.value().toString(),
+              amount: CurrencyUtils.encode(decryptedNote.value()),
               memo: decryptedNote.memo(),
             })
           }

--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
@@ -55,7 +56,7 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
       const asset = await node.chain.getAssetById(note.assetIdentifier())
 
       request.stream({
-        value: note.value().toString(),
+        value: CurrencyUtils.encode(note.value()),
         assetIdentifier: note.assetIdentifier().toString('hex'),
         assetName: asset?.name.toString('utf8') || '',
         memo: note.memo(),

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Note } from '../../../primitives/note'
+import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
 import { RpcAccountDecryptedNote, serializeRpcAccountTransaction } from './types'
 import { getAccount } from './utils'
@@ -100,7 +101,7 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
       serializedNotes.push({
         owner,
         memo: note.memo(),
-        value: note.value().toString(),
+        value: CurrencyUtils.encode(note.value()),
         sender: note.sender(),
         spent: spent,
       })


### PR DESCRIPTION
## Summary

All currency encoding should be done using CurrencyUtils.encode() and CurrencyUtils.decode()

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
