### PR TITLE
delegates headHashes datastore to account

### DIFF
--- a/ironfish/src/primitives/transaction.test.slow.ts
+++ b/ironfish/src/primitives/transaction.test.slow.ts
@@ -63,7 +63,7 @@ describe('Accounts', () => {
     Assert.isNotNull(headhash)
     // Modify the headhash
     headhash[0] = 0
-    await nodeA.wallet.updateHeadHash(accountA, headhash)
+    await accountA.updateHeadHash(headhash)
 
     const response = nodeA.wallet.createTransaction(
       accountA,

--- a/ironfish/src/testUtilities/fixtures/account.ts
+++ b/ironfish/src/testUtilities/fixtures/account.ts
@@ -20,7 +20,7 @@ export function useAccountFixture(
 
     deserialize: async (accountData: AccountValue): Promise<Account> => {
       const account = await wallet.importAccount(accountData)
-      await wallet.updateHeadHash(account, wallet.chainProcessor.hash)
+      await account.updateHeadHash(wallet.chainProcessor.hash)
       return account
     },
   })

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -82,6 +82,7 @@ export class Account {
     await this.walletDb.clearNonChainNoteHashes(this, tx)
     await this.walletDb.clearPendingTransactionHashes(this, tx)
     await this.walletDb.clearBalance(this, tx)
+    await this.updateHeadHash(null, tx)
   }
 
   async *getNotes(): AsyncGenerator<DecryptedNoteValue & { hash: Buffer }> {
@@ -546,6 +547,10 @@ export class Account {
 
   async getHeadHash(tx?: IDatabaseTransaction): Promise<Buffer | null> {
     return this.walletDb.getHeadHash(this, tx)
+  }
+
+  async updateHeadHash(headHash: Buffer | null, tx?: IDatabaseTransaction): Promise<void> {
+    await this.walletDb.saveHeadHash(this, headHash, tx)
   }
 
   async getTransactionNotes(


### PR DESCRIPTION
## Summary

most datastores in the wallet are keyed by account and managed by the account. headHashes is an exception in that the wallet writes to the datastore and uses an in-memory cache of values.

- removes in-memory headHashes cache
- removes wallet methods for writing to headHashes
- removes update of head hashes on wallet close (head hashes should only be updated when a block is connected or disconnected)
- defines updateHeadHash on the account instead of the wallet

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
