### PR TITLE
displays balance head hash and sequence in CLI

### DIFF
--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, GetBalanceResponse } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
-import { resolve } from 'path'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { CurrencyUtils, GetBalanceResponse } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
+import { resolve } from 'path'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
@@ -84,8 +85,12 @@ export class BalanceCommand extends IronfishCommand {
     const unconfirmedDelta = unconfirmed - confirmed
 
     this.log(`Account: ${response.account}`)
-    this.log(`Head Hash: ${response.blockHash || 'NULL'}`)
-    this.log(`Head Sequence: ${response.sequence || 'NULL'}`)
+
+    this.log(
+      `Your balance is calculated from transactions on the chain through block ${
+        response.blockHash ?? 'NULL'
+      } at sequence ${response.sequence ?? 'NULL'}`,
+    )
     this.log('')
 
     this.log(`Your balance is made of notes on the chain that are safe to spend`)

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -62,6 +62,8 @@ export class BalanceCommand extends IronfishCommand {
 
     if (flags.all) {
       this.log(`Account: ${response.content.account}`)
+      this.log(`Head Hash: ${response.content.blockHash || 'NULL'}`)
+      this.log(`Head Sequence: ${response.content.sequence || 'NULL'}`)
       this.log(
         `Balance:     ${CurrencyUtils.renderIron(response.content.confirmed, true, assetId)}`,
       )
@@ -72,6 +74,8 @@ export class BalanceCommand extends IronfishCommand {
     }
 
     this.log(`Account: ${response.content.account}`)
+    this.log(`Head Hash: ${response.content.blockHash || 'NULL'}`)
+    this.log(`Head Sequence: ${response.content.sequence || 'NULL'}`)
     this.log(`Balance: ${CurrencyUtils.renderIron(response.content.confirmed, true, assetId)}`)
   }
 
@@ -82,6 +86,8 @@ export class BalanceCommand extends IronfishCommand {
     const unconfirmedDelta = unconfirmed - confirmed
 
     this.log(`Account: ${response.account}`)
+    this.log(`Head Hash: ${response.blockHash || 'NULL'}`)
+    this.log(`Head Sequence: ${response.sequence || 'NULL'}`)
     this.log('')
 
     this.log(`Your balance is made of notes on the chain that are safe to spend`)

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -74,8 +74,6 @@ export class BalanceCommand extends IronfishCommand {
     }
 
     this.log(`Account: ${response.content.account}`)
-    this.log(`Head Hash: ${response.content.blockHash || 'NULL'}`)
-    this.log(`Head Sequence: ${response.content.sequence || 'NULL'}`)
     this.log(`Balance: ${CurrencyUtils.renderIron(response.content.confirmed, true, assetId)}`)
   }
 

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -19,6 +19,8 @@ export type GetBalanceResponse = {
   unconfirmed: string
   unconfirmedCount: number
   minimumBlockConfirmations: number
+  blockHash: string | null
+  sequence: number | null
 }
 
 export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
@@ -36,6 +38,8 @@ export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yu
     unconfirmedCount: yup.number().defined(),
     confirmed: yup.string().defined(),
     minimumBlockConfirmations: yup.number().defined(),
+    blockHash: yup.string().nullable(true).defined(),
+    sequence: yup.number().nullable(true).defined(),
   })
   .defined()
 
@@ -66,6 +70,8 @@ router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
       unconfirmed: balance.unconfirmed.toString(),
       unconfirmedCount: balance.unconfirmedCount,
       minimumBlockConfirmations,
+      blockHash: balance.blockHash?.toString('hex') ?? null,
+      sequence: balance.sequence,
     })
   },
 )

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
@@ -106,6 +106,8 @@ describe('Transactions sendTransaction', () => {
       unconfirmed: BigInt(11),
       confirmed: BigInt(0),
       unconfirmedCount: 0,
+      blockHash: null,
+      sequence: null,
     })
 
     await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrow(
@@ -122,6 +124,8 @@ describe('Transactions sendTransaction', () => {
       unconfirmed: BigInt(21),
       confirmed: BigInt(0),
       unconfirmedCount: 0,
+      blockHash: null,
+      sequence: null,
     })
 
     await expect(routeTest.client.sendTransaction(TEST_PARAMS_MULTI)).rejects.toThrow(
@@ -148,6 +152,8 @@ describe('Transactions sendTransaction', () => {
       unconfirmed: BigInt(11),
       confirmed: BigInt(11),
       unconfirmedCount: 0,
+      blockHash: null,
+      sequence: null,
     })
 
     await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrow(
@@ -171,6 +177,8 @@ describe('Transactions sendTransaction', () => {
       unconfirmed: BigInt(11),
       confirmed: BigInt(11),
       unconfirmedCount: 0,
+      blockHash: null,
+      sequence: null,
     })
 
     const result = await routeTest.client.sendTransaction(TEST_PARAMS)
@@ -189,6 +197,8 @@ describe('Transactions sendTransaction', () => {
       unconfirmed: BigInt(21),
       confirmed: BigInt(21),
       unconfirmedCount: 0,
+      blockHash: null,
+      sequence: null,
     })
 
     const result = await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
@@ -206,6 +216,8 @@ describe('Transactions sendTransaction', () => {
       unconfirmed: BigInt(100000),
       confirmed: BigInt(100000),
       unconfirmedCount: 0,
+      blockHash: null,
+      sequence: null,
     })
 
     const sendSpy = jest.spyOn(routeTest.node.wallet, 'send').mockResolvedValue(tx)

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -461,10 +461,12 @@ export class Account {
     unconfirmed: bigint
     unconfirmedCount: number
     confirmed: bigint
+    blockHash: Buffer | null
+    sequence: number | null
   }> {
     let unconfirmedCount = 0
 
-    const { unconfirmed } = await this.getUnconfirmedBalance(assetId, tx)
+    const { unconfirmed, blockHash, sequence } = await this.getUnconfirmedBalance(assetId, tx)
 
     let confirmed = unconfirmed
     if (minimumBlockConfirmations > 0) {
@@ -496,6 +498,8 @@ export class Account {
       unconfirmed,
       unconfirmedCount,
       confirmed,
+      blockHash,
+      sequence,
     }
   }
 

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -979,7 +979,7 @@ describe('Accounts', () => {
       await expect(node.chain).toAddBlock(burnBlock)
       await node.wallet.updateHead()
 
-      expect(await node.wallet.getBalance(account, asset.id())).toEqual({
+      expect(await node.wallet.getBalance(account, asset.id())).toMatchObject({
         unconfirmed: BigInt(8),
         unconfirmedCount: 0,
         confirmed: BigInt(8),

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -591,6 +591,8 @@ export class Wallet {
     unconfirmedCount: number
     unconfirmed: bigint
     confirmed: bigint
+    blockHash: Buffer | null
+    sequence: number | null
   }> {
     const minimumBlockConfirmations = Math.max(
       options?.minimumBlockConfirmations ?? this.config.get('minimumBlockConfirmations'),
@@ -607,6 +609,8 @@ export class Wallet {
           unconfirmed: BigInt(0),
           confirmed: BigInt(0),
           unconfirmedCount: 0,
+          blockHash: null,
+          sequence: null,
         }
       }
 


### PR DESCRIPTION
## Summary

the account balance now includes chain state information (blockHash and sequence). includes this chain state in the balance CLI output so that it's clearer where on the chain the balance is reflective of.

## Testing Plan

<img width="549" alt="image" src="https://user-images.githubusercontent.com/57735705/210895875-0b3dc05b-1d40-4bbf-9d81-7e45b73d07b2.png">

<img width="584" alt="image" src="https://user-images.githubusercontent.com/57735705/210895953-78bac3d4-ee90-4d72-b311-1cfe018e1f3f.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
