### PR TITLE
feat(rust): use `checked_add` for `ValueBalance`

### DIFF
--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -169,19 +169,27 @@ impl NativeTransaction {
 
     /// Create a proof of a new note owned by the recipient in this transaction.
     #[napi]
-    pub fn receive(&mut self, note: &NativeNote) {
-        self.transaction.add_output(note.note.clone());
+    pub fn receive(&mut self, note: &NativeNote) -> Result<()> {
+        self.transaction
+            .add_output(note.note.clone())
+            .map_err(to_napi_err)?;
+
+        Ok(())
     }
 
     /// Spend the note owned by spender_hex_key at the given witness location.
     #[napi]
-    pub fn spend(&mut self, env: Env, note: &NativeNote, witness: Object) {
+    pub fn spend(&mut self, env: Env, note: &NativeNote, witness: Object) -> Result<()> {
         let w = JsWitness {
             cx: RefCell::new(env),
             obj: witness,
         };
 
-        self.transaction.add_spend(note.note.clone(), &w);
+        self.transaction
+            .add_spend(note.note.clone(), &w)
+            .map_err(to_napi_err)?;
+
+        Ok(())
     }
 
     /// return the sender of the transaction
@@ -192,9 +200,13 @@ impl NativeTransaction {
 
     /// Mint a new asset with a given value as part of this transaction.
     #[napi]
-    pub fn mint(&mut self, asset: &NativeAsset, value: BigInt) {
+    pub fn mint(&mut self, asset: &NativeAsset, value: BigInt) -> Result<()> {
         let value_u64 = value.get_u64().1;
-        self.transaction.add_mint(asset.asset, value_u64)
+        self.transaction
+            .add_mint(asset.asset, value_u64)
+            .map_err(to_napi_err)?;
+
+        Ok(())
     }
 
     /// Burn some supply of a given asset and value as part of this transaction.
@@ -206,7 +218,9 @@ impl NativeTransaction {
             .try_into()
             .map_err(to_napi_err)?;
         let value_u64 = value.get_u64().1;
-        self.transaction.add_burn(asset_identifier, value_u64);
+        self.transaction
+            .add_burn(asset_identifier, value_u64)
+            .map_err(to_napi_err)?;
 
         Ok(())
     }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -133,33 +133,49 @@ impl ProposedTransaction {
     }
 
     /// Spend the note owned by spender_key at the given witness location.
-    pub fn add_spend(&mut self, note: Note, witness: &dyn WitnessTrait) {
+    pub fn add_spend(
+        &mut self,
+        note: Note,
+        witness: &dyn WitnessTrait,
+    ) -> Result<(), IronfishError> {
         self.value_balances
-            .add(&note.asset_identifier(), note.value() as i64);
+            .add(&note.asset_identifier(), note.value() as i64)?;
 
         self.spends.push(SpendBuilder::new(note, witness));
+
+        Ok(())
     }
 
     /// Create a proof of a new note owned by the recipient in this
     /// transaction.
-    pub fn add_output(&mut self, note: Note) {
+    pub fn add_output(&mut self, note: Note) -> Result<(), IronfishError> {
         self.value_balances
-            .subtract(&note.asset_identifier(), note.value() as i64);
+            .subtract(&note.asset_identifier(), note.value() as i64)?;
 
         self.outputs.push(OutputBuilder::new(note));
+
+        Ok(())
     }
 
-    pub fn add_mint(&mut self, asset: Asset, value: u64) {
-        self.value_balances.add(asset.identifier(), value as i64);
+    pub fn add_mint(&mut self, asset: Asset, value: u64) -> Result<(), IronfishError> {
+        self.value_balances.add(asset.identifier(), value as i64)?;
 
         self.mints.push(MintBuilder::new(asset, value));
+
+        Ok(())
     }
 
-    pub fn add_burn(&mut self, asset_identifier: AssetIdentifier, value: u64) {
+    pub fn add_burn(
+        &mut self,
+        asset_identifier: AssetIdentifier,
+        value: u64,
+    ) -> Result<(), IronfishError> {
         self.value_balances
-            .subtract(&asset_identifier, value as i64);
+            .subtract(&asset_identifier, value as i64)?;
 
         self.burns.push(BurnBuilder::new(asset_identifier, value));
+
+        Ok(())
     }
 
     /// Post the transaction. This performs a bit of validation, and signs
@@ -206,7 +222,7 @@ impl ProposedTransaction {
         }
 
         for change_note in change_notes {
-            self.add_output(change_note);
+            self.add_output(change_note)?;
         }
 
         self._partial_post()

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -59,23 +59,23 @@ fn test_transaction() {
     let mut transaction = ProposedTransaction::new(spender_key);
 
     // Spend
-    transaction.add_spend(in_note, &witness);
+    transaction.add_spend(in_note, &witness).unwrap();
     assert_eq!(transaction.spends.len(), 1);
 
     // Output
-    transaction.add_output(out_note);
+    transaction.add_output(out_note).unwrap();
     assert_eq!(transaction.outputs.len(), 1);
 
     // Mint 5 tokens
-    transaction.add_mint(asset, mint_value);
+    transaction.add_mint(asset, mint_value).unwrap();
     assert_eq!(transaction.mints.len(), 1);
 
     // Output 2 minted tokens to receiver
-    transaction.add_output(mint_out_note);
+    transaction.add_output(mint_out_note).unwrap();
     assert_eq!(transaction.outputs.len(), 2);
 
     // Burn 2 tokens, leaving 1 token left to be put into a change note
-    transaction.add_burn(asset.identifier, burn_value);
+    transaction.add_burn(asset.identifier, burn_value).unwrap();
     assert_eq!(transaction.burns.len(), 1);
 
     let public_transaction = transaction
@@ -155,9 +155,9 @@ fn test_transaction_simple() {
     let witness = make_fake_witness(&in_note);
 
     let mut transaction = ProposedTransaction::new(spender_key);
-    transaction.add_spend(in_note, &witness);
+    transaction.add_spend(in_note, &witness).unwrap();
     assert_eq!(transaction.spends.len(), 1);
-    transaction.add_output(out_note);
+    transaction.add_output(out_note).unwrap();
     assert_eq!(transaction.outputs.len(), 1);
 
     let public_transaction = transaction
@@ -193,7 +193,7 @@ fn test_miners_fee() {
         spender_key.public_address(),
     );
     let mut transaction = ProposedTransaction::new(spender_key);
-    transaction.add_output(out_note);
+    transaction.add_output(out_note).unwrap();
     let posted_transaction = transaction
         .post_miners_fee()
         .expect("it is a valid miner's fee");
@@ -234,9 +234,9 @@ fn test_transaction_signature() {
     );
     let witness = make_fake_witness(&in_note);
 
-    transaction.add_spend(in_note, &witness);
+    transaction.add_spend(in_note, &witness).unwrap();
 
-    transaction.add_output(out_note);
+    transaction.add_output(out_note).unwrap();
 
     transaction.set_expiration(1337);
 
@@ -278,8 +278,8 @@ fn test_transaction_created_with_version_1() {
     let witness = make_fake_witness(&in_note);
 
     let mut transaction = ProposedTransaction::new(spender_key);
-    transaction.add_spend(in_note, &witness);
-    transaction.add_output(out_note);
+    transaction.add_spend(in_note, &witness).unwrap();
+    transaction.add_output(out_note).unwrap();
 
     assert_eq!(transaction.version, 1);
 
@@ -318,8 +318,8 @@ fn test_transaction_version_is_checked() {
     let witness = make_fake_witness(&in_note);
 
     let mut transaction = ProposedTransaction::new(spender_key);
-    transaction.add_spend(in_note, &witness);
-    transaction.add_output(out_note);
+    transaction.add_spend(in_note, &witness).unwrap();
+    transaction.add_output(out_note).unwrap();
 
     transaction.version = 2;
 

--- a/ironfish-rust/src/transaction/value_balances.rs
+++ b/ironfish-rust/src/transaction/value_balances.rs
@@ -3,7 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::collections::{hash_map, HashMap};
 
-use crate::assets::asset::{AssetIdentifier, NATIVE_ASSET};
+use crate::{
+    assets::asset::{AssetIdentifier, NATIVE_ASSET},
+    errors::IronfishError,
+};
 
 pub struct ValueBalances {
     values: HashMap<AssetIdentifier, i64>,
@@ -18,14 +21,34 @@ impl ValueBalances {
         ValueBalances { values: hash_map }
     }
 
-    pub fn add(&mut self, asset_identifier: &AssetIdentifier, value: i64) {
+    pub fn add(
+        &mut self,
+        asset_identifier: &AssetIdentifier,
+        value: i64,
+    ) -> Result<(), IronfishError> {
         let current_value = self.values.entry(*asset_identifier).or_insert(0);
-        *current_value += value
+        let new_value = current_value
+            .checked_add(value)
+            .ok_or(IronfishError::InvalidBalance)?;
+
+        *current_value = new_value;
+
+        Ok(())
     }
 
-    pub fn subtract(&mut self, asset_identifier: &AssetIdentifier, value: i64) {
+    pub fn subtract(
+        &mut self,
+        asset_identifier: &AssetIdentifier,
+        value: i64,
+    ) -> Result<(), IronfishError> {
         let current_value = self.values.entry(*asset_identifier).or_insert(0);
-        *current_value -= value
+        let new_value = current_value
+            .checked_sub(value)
+            .ok_or(IronfishError::InvalidBalance)?;
+
+        *current_value = new_value;
+
+        Ok(())
     }
 
     pub fn iter(&self) -> hash_map::Iter<AssetIdentifier, i64> {
@@ -57,8 +80,8 @@ mod test {
     fn test_value_balances_fee() {
         let mut vb = ValueBalances::new();
 
-        vb.add(&NATIVE_ASSET, 5);
-        vb.subtract(&NATIVE_ASSET, 2);
+        vb.add(&NATIVE_ASSET, 5).unwrap();
+        vb.subtract(&NATIVE_ASSET, 2).unwrap();
 
         assert_eq!(*vb.fee(), 3);
     }
@@ -67,19 +90,45 @@ mod test {
     fn test_value_balances_multiple_assets() {
         let mut vb = ValueBalances::new();
 
-        let asset_two = [1u8; 32];
-        let asset_three = [2u8; 32];
+        let asset_one = [1u8; 32];
+        let asset_two = [2u8; 32];
 
-        vb.add(&NATIVE_ASSET, 5);
-        vb.subtract(&NATIVE_ASSET, 3);
+        vb.add(&NATIVE_ASSET, 5).unwrap();
+        vb.subtract(&NATIVE_ASSET, 3).unwrap();
 
-        vb.add(&asset_two, 6);
-        vb.subtract(&asset_two, 2);
+        vb.add(&asset_one, 6).unwrap();
+        vb.subtract(&asset_one, 2).unwrap();
 
-        vb.subtract(&asset_three, 10);
+        vb.subtract(&asset_two, 10).unwrap();
 
         assert_eq!(*vb.fee(), 2);
-        assert_eq!(*vb.values.get(&asset_two).unwrap(), 4);
-        assert_eq!(*vb.values.get(&asset_three).unwrap(), -10);
+        assert_eq!(*vb.values.get(&asset_one).unwrap(), 4);
+        assert_eq!(*vb.values.get(&asset_two).unwrap(), -10);
+    }
+
+    #[test]
+    fn test_value_balances_checks_overflows_add() {
+        let mut vb = ValueBalances::new();
+
+        let asset = [1u8; 32];
+
+        // First value add - does not overflow
+        vb.add(&asset, i64::MAX - 1).unwrap();
+
+        // Second value add - overflows
+        assert!(vb.add(&asset, 100).is_err());
+    }
+
+    #[test]
+    fn test_value_balances_checks_overflows_sub() {
+        let mut vb = ValueBalances::new();
+
+        let asset = [1u8; 32];
+
+        // First value sub - does not overflow
+        vb.subtract(&asset, i64::MAX - 1).unwrap();
+
+        // Second value sub - overflows
+        assert!(vb.subtract(&asset, 100).is_err());
     }
 }


### PR DESCRIPTION
## Summary

Right now, its possible to add enough value to a transaction via mints
or spends such that it would overflow the `i64` type in the
`ValueBalance` struct. By using `checked_add`, we get some cleaner error
handling around this logic. Note that this doesn't functionally change
much, it's just more explicit error handling.

As a future improvement, we could use an
arbitrarily large value type for `ValueBalance` like `i128`, and change
the logic on `Transaction::post` to loop over the values and create
multiple change notes, allowing value transfers of greater than
`u64::MAX`, if we ever needed to.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
