### PR TITLE
fixes submittedSequence to be non-nullable

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -126,7 +126,7 @@ export class Account {
     const blockHash = blockHeader.hash
     const sequence = blockHeader.sequence
     const assetBalanceDeltas = new AssetBalanceDeltas()
-    let submittedSequence: number | null = null
+    let submittedSequence = sequence
     let timestamp = new Date()
 
     await this.walletDb.db.withTransaction(tx, async (tx) => {
@@ -196,7 +196,7 @@ export class Account {
   async addPendingTransaction(
     transaction: Transaction,
     decryptedNotes: Array<DecryptedNote>,
-    submittedSequence: number | null,
+    submittedSequence: number,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     const assetBalanceDeltas = new AssetBalanceDeltas()

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1037,10 +1037,6 @@ export class Wallet {
           continue
         }
 
-        if (!submittedSequence) {
-          continue
-        }
-
         // TODO: This algorithm suffers a deanonymization attack where you can
         // watch to see what transactions node continuously send out, then you can
         // know those transactions are theres. This should be randomized and made

--- a/ironfish/src/wallet/walletdb/transactionValue.test.ts
+++ b/ironfish/src/wallet/walletdb/transactionValue.test.ts
@@ -29,7 +29,7 @@ describe('TransactionValueEncoding', () => {
         timestamp: new Date(),
         blockHash: null,
         sequence: null,
-        submittedSequence: null,
+        submittedSequence: 123,
         assetBalanceDeltas,
       }
       const buffer = encoder.serialize(value)
@@ -75,7 +75,7 @@ describe('TransactionValueEncoding', () => {
         timestamp: new Date(),
         blockHash: Buffer.alloc(32, 1),
         sequence: 124,
-        submittedSequence: null,
+        submittedSequence: 123,
         assetBalanceDeltas,
       }
       const buffer = encoder.serialize(value)
@@ -95,7 +95,7 @@ describe('TransactionValueEncoding', () => {
         timestamp: new Date(),
         blockHash: Buffer.alloc(32, 1),
         sequence: 124,
-        submittedSequence: null,
+        submittedSequence: 123,
         assetBalanceDeltas: new BufferMap<bigint>(),
       }
       const buffer = encoder.serialize(value)


### PR DESCRIPTION
## Summary

in the past we only populated submittedSequence for transactions that the node created and submitted.

now we also populate submittedSequence for any transaction that is gossiped to the node.

submittedSequence should no longer be null for any transaction in the wallet.

- defaults submittedSequence to the block sequence for transactions found on blocks but not previously synced to the wallet through the mempool

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
