### PR TITLE
fix: bug in multi asset syncer

### DIFF
--- a/ironfish-cli/src/commands/service/sync-multi-asset.ts
+++ b/ironfish-cli/src/commands/service/sync-multi-asset.ts
@@ -106,7 +106,6 @@ export default class SyncMultiAsset extends IronfishCommand {
       incomingViewKey: viewKey,
       head: head,
     })
-
     const speed = new Meter()
     speed.start()
 
@@ -158,7 +157,11 @@ export default class SyncMultiAsset extends IronfishCommand {
     while (true) {
       const headHash = (await api.headMaspTransactions()) || ''
 
-      const choices: MultiAssetTypes[] = ['MASP_MINT', 'MASP_BURN', 'MASP_TRANSFER']
+      const choices: MultiAssetTypes[] = [
+        'MULTI_ASSET_TRANSFER',
+        'MULTI_ASSET_BURN',
+        'MULTI_ASSET_TRANSFER',
+      ]
       const choice = choices[Math.floor(Math.random() * choices.length)]
       const connectedblockHash = uuid()
       await api.uploadMaspTransactions([

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -15,8 +15,12 @@ type FaucetTransaction = {
   completed_at: string | null
 }
 
-export const MaspTransactionTypes = ['MASP_TRANSFER', 'MASP_BURN', 'MASP_MINT']
-export type MultiAssetTypes = typeof MaspTransactionTypes[number]
+export const MultiAsssetTransactionTypes = [
+  'MULTI_ASSET_TRANSFER',
+  'MULTI_ASSET_BURN',
+  'MULTI_ASSET_MINT',
+]
+export type MultiAssetTypes = typeof MultiAsssetTransactionTypes[number]
 
 export type ApiMultiAssetUpload = {
   type: 'connected' | 'disconnected' | 'fork'


### PR DESCRIPTION
## Summary
Rename multi-asset variables to match changes to API from `masp`->`multi-asset`
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
