### PR TITLE
removes miners fee transactions from forked blocks

### DIFF
--- a/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
@@ -766,5 +766,77 @@
         }
       ]
     }
+  ],
+  "Accounts removeTransaction should delete transaction record from the database": [
+    {
+      "id": "c6b68316-2fde-4e17-b39a-3976bb5ccc94",
+      "name": "accountA",
+      "spendingKey": "695d9b5cc5e396e5a67ab23a6e4e5f0935d04a5c5359a4e9fe4cf585d18b4d51",
+      "incomingViewKey": "612ab80f8dd8713c23662edc58d3aadab63c7237a7712b8c1c1a3755b2221805",
+      "outgoingViewKey": "937094470814c7dff07be1e48a25404439f2d1108255c54313e2a9f7188bf6ce",
+      "publicAddress": "e6c3e999f6fd5c4b0f6f0a3d7dfbdc0081c5ab37e673dd42571e56950c0f0e6a"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:XzCkpp810jSwqSNAHqqn5SZqbvxhPeQp4SU0AY7exlA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/C1tPmOKOBFvEvaPX2tXqTrVv5yWSexDSoiq3PQuNds="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1673288291824,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4jRXY/OFD9B12pF+sp6apQfjKXlYd/MP4RR12dVdnVuEPxV/ihLMKlOLB0PYT7d2bM3bvFurTVXFRLbbYCeAI/XuWP/8/qRXR84KfL4DpXmNiOGyK6jfoSlSrA2R+Ki6kI9hWROmjk8BmoFdd3aTfbVz02q7UHWZ5Soo3+/DMpkHBROGqy8OmpBolTsZiTBdKOifEFVdZYva2/JHa57iJph3WWR4iQddCWzEAnTLArSYMuoNdHMS8XOC7ygzWnUd6HnPWF9mESvG2fwGifsZR0ESOBsp2QMHvYl1cn6XitRvGLXrZvoQ8HrCVXPUO63FE+FeqKT38upXzMdz/qNkaeSFgc+w6LohAtm+tnBIizJ0oTkGHjFl6K14OTXNvE5oxkpcJNxnJpgpOzeWxR0DTWbBuiF0EgLXsgNjO2JpDo/7c8YMWLJeglQYMqCzY9FWiNCtp5XsOq78dRpV3cFiXCwYZ4vMKAX8nzf4BXGdRVZKMIZQXdMru3Pn4OLDi4Ug5FF6MdS/hGLGXFezKLVkYm1hFO6if3Ba2DLwRElHMZ9G3uWzZvUbH+58IUBBkyINmZ2CI/4DpGoCfMEMYmzPvfJ9yWNu1pk/2DJ5wF2UfnCLXkV4TA19Wklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrylBRGbeBy0xPIsiHEG1FgAMXHU4OrJ7LrpKHqtiU4tvGdiPLWCpKW3rugdqXAjNdRVws3IYJnHGXplSI5KjBg=="
+        }
+      ]
+    }
+  ],
+  "Accounts removeTransaction should delete output note records from the database": [
+    {
+      "id": "a2d7f004-35f1-4d4b-adf6-0f15f02accbc",
+      "name": "accountA",
+      "spendingKey": "d1d714234169b2dc63081e5b8733d84a95eb54555071b07784797a55b66ba2f3",
+      "incomingViewKey": "d9531eb70f54bd8242b92a862e336e80bcee2e51cd19d43e4f8af0b265a4d403",
+      "outgoingViewKey": "08eddfccdda526fb53f4efbd5cbefd36033567bb2248afd51b54b09a0179ff0a",
+      "publicAddress": "abdf5c63258e22abdb7497bd3366d7043e4eb3ce674bb66a2757b6758a6299cd"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:lGE6bPhFfMgpO3rPQ9+8hXKuXzlOrNvs0O2wcaALk0Y="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:JIagA2UJYEqNyWf1LqiJTa2ILCN9lScvStPE9JU6ZM0="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1673288672007,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQVUvrkC+PkUhArcBGsbHTTgSjRyfC9iXGXgMSiPZIJWyiNtcEOhkn4Iau4DDblEXVhTgdgY65Tm6I3epe1r4AVUCIlRgiTJHa+J/M55T83WpKCTMDIt353mZhqnzRmOhcRjYxELXcte7MoWlk2ZA+ETLQuASN+b2Cuq6SSo9YYIEN9ZTi6dqv5Nhpv7qjBzgALD359ZGXC8s6V+Cs1yV2ALmKRgxyecsZmIB/6Q8O3W25pEWNku7Iv0FC63tBSogyhCzYafT3TZo7Kr45NRBrOXfAz4DLcp79o1oV3xXIDM2m+3YAAS4SEd7c3jQBo0MqGkpecRxJoJEeCuMmhseFHKkWsh05zH8AxpxYqbzAIZAmzpfJIqnJ+onxjqkkolNsVEPkPwwYwP5ZqTXQEJ8a+jmXqzZGxhDLtvQnGVz2D8RBu58bkqtdlCWuE1oEEnatX4zN79MoikF9nJ8vCg7xiXCBsdezAFjqNmxC3nUldQuQGmvS4IOgJ3ECumG5oo8XysuHn3hPSRphjmWDoGz1zdPEmQ+V2J4gjnKN0BKw/SJaaf+du4rX7dN6UQ6E1BE3h67uiyRz6oDUKCEiQFS30fCWQhKkq0HvkZe+beRlPl5Pqnb53c5gUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBV5B6RSi/rzcBFnTKsdzKOR/lZJcTvp4jkMeWBH8ZGBC+gDYZF/lP3HNB6XMhIPNpd4VS2cvNj1Z9t3Djt13Cw=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
@@ -767,14 +767,14 @@
       ]
     }
   ],
-  "Accounts removeTransaction should delete transaction record from the database": [
+  "Accounts deleteTransaction should delete transaction record from the database": [
     {
-      "id": "c6b68316-2fde-4e17-b39a-3976bb5ccc94",
+      "id": "d1b43950-d53e-4186-b254-3e4e89c4da32",
       "name": "accountA",
-      "spendingKey": "695d9b5cc5e396e5a67ab23a6e4e5f0935d04a5c5359a4e9fe4cf585d18b4d51",
-      "incomingViewKey": "612ab80f8dd8713c23662edc58d3aadab63c7237a7712b8c1c1a3755b2221805",
-      "outgoingViewKey": "937094470814c7dff07be1e48a25404439f2d1108255c54313e2a9f7188bf6ce",
-      "publicAddress": "e6c3e999f6fd5c4b0f6f0a3d7dfbdc0081c5ab37e673dd42571e56950c0f0e6a"
+      "spendingKey": "c4f74644befbef0c5b0cffc47bd8d016f62dc9405f32e24bdb2ed314a5aa49c1",
+      "incomingViewKey": "875aa90fad4d509024cd0ee88f1875718e1dcfe90237b7d3257cb46e8fa92801",
+      "outgoingViewKey": "7f91d6135afed4ed2e1be7c2c3567455a4b6104474308fd757b9742dfb6085e6",
+      "publicAddress": "2f50b42415bbdbe47df26b79ec700429cf466499b7813314043d97c9b3509eba"
     },
     {
       "header": {
@@ -782,15 +782,15 @@
         "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:XzCkpp810jSwqSNAHqqn5SZqbvxhPeQp4SU0AY7exlA="
+          "data": "base64:vEgxsr/PJEv+7DwMDgzb8CN2HCAdPq47jgDJlmXyrzw="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:/C1tPmOKOBFvEvaPX2tXqTrVv5yWSexDSoiq3PQuNds="
+          "data": "base64:xE5fmq8DK9Dj289igaoG+RvbCPXDKm8I6wyA1L8/lA4="
         },
         "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
         "randomness": "0",
-        "timestamp": 1673288291824,
+        "timestamp": 1673303455645,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 4,
         "work": "0"
@@ -798,19 +798,19 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4jRXY/OFD9B12pF+sp6apQfjKXlYd/MP4RR12dVdnVuEPxV/ihLMKlOLB0PYT7d2bM3bvFurTVXFRLbbYCeAI/XuWP/8/qRXR84KfL4DpXmNiOGyK6jfoSlSrA2R+Ki6kI9hWROmjk8BmoFdd3aTfbVz02q7UHWZ5Soo3+/DMpkHBROGqy8OmpBolTsZiTBdKOifEFVdZYva2/JHa57iJph3WWR4iQddCWzEAnTLArSYMuoNdHMS8XOC7ygzWnUd6HnPWF9mESvG2fwGifsZR0ESOBsp2QMHvYl1cn6XitRvGLXrZvoQ8HrCVXPUO63FE+FeqKT38upXzMdz/qNkaeSFgc+w6LohAtm+tnBIizJ0oTkGHjFl6K14OTXNvE5oxkpcJNxnJpgpOzeWxR0DTWbBuiF0EgLXsgNjO2JpDo/7c8YMWLJeglQYMqCzY9FWiNCtp5XsOq78dRpV3cFiXCwYZ4vMKAX8nzf4BXGdRVZKMIZQXdMru3Pn4OLDi4Ug5FF6MdS/hGLGXFezKLVkYm1hFO6if3Ba2DLwRElHMZ9G3uWzZvUbH+58IUBBkyINmZ2CI/4DpGoCfMEMYmzPvfJ9yWNu1pk/2DJ5wF2UfnCLXkV4TA19Wklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrylBRGbeBy0xPIsiHEG1FgAMXHU4OrJ7LrpKHqtiU4tvGdiPLWCpKW3rugdqXAjNdRVws3IYJnHGXplSI5KjBg=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAqc0sDeXshWUnk1w3pPBe4FXrEy3yKAsu7zjVlCHmb0qiIbFES/q05cB75P1ISuxmi6gCA1UHyK3l86wRyaA3F7uhIhz249ms1x5i3vpK22qQ70e8mG+e40X2DAR/T5pf0vZ/H8z43ps3h0zMpjS2QTGCqvdQ73yohe48X/1nZC0UVoI9/EP3Lr1QgEh5tcj2CWX3jy2vKZ96BzkOiYLwGBNYgo2Oc9OtRC/0CkTI0tCmHEUsqKzsSnSn7Prfp3Ci+Mm1q3Ra+S2e6laN1rBi/DEZU5QKuf/s6uj9sdNkQG5TFdJAb0K9nrfXHsB5ji7zYKZ+LamdsqSQ3JCGLjd/UuEPDHqC6xdX+nsJp7FRKm6R1zNKlGPbRCADNxIRAq9GG3qOQAXovH2v2dy0Opwm0EFvmmNi9Kzx2WCG6C70jT/QSo/taM+6wlVzTiBBZWRXdC5vpIla6yX2S5iYuyADLWayDritWXghAQXD5K10nF5G8g+5yNcJfG6R6BmA5PG13fiNa1cJbfN7y/fFI7hvJis6I1Yp0DZVR0JHDiI3ciec8AwZ/0Q93/rWlCIDWVbJU62qJ+PKVAhslE7u0cy11ueEkYxAxd8Sw4N0Gmpsko1TcBPcaFfglklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqlHvYlyw/WrFHNQz6yRh5Bs3qGwAIzpU35MawWsqvj26aw44OdBTH81iqjphAcq/Pdmjwxbc5b6u1t0RlSk2DA=="
         }
       ]
     }
   ],
-  "Accounts removeTransaction should delete output note records from the database": [
+  "Accounts deleteTransaction should delete output note records from the database": [
     {
-      "id": "a2d7f004-35f1-4d4b-adf6-0f15f02accbc",
+      "id": "fa2f9f5a-50c3-45b5-8a06-c50a67d7c255",
       "name": "accountA",
-      "spendingKey": "d1d714234169b2dc63081e5b8733d84a95eb54555071b07784797a55b66ba2f3",
-      "incomingViewKey": "d9531eb70f54bd8242b92a862e336e80bcee2e51cd19d43e4f8af0b265a4d403",
-      "outgoingViewKey": "08eddfccdda526fb53f4efbd5cbefd36033567bb2248afd51b54b09a0179ff0a",
-      "publicAddress": "abdf5c63258e22abdb7497bd3366d7043e4eb3ce674bb66a2757b6758a6299cd"
+      "spendingKey": "9ae54ba844cdc8593e2e05db373acff4ccf11e7be1e4f970bba4d75291206abb",
+      "incomingViewKey": "fbb4488a7b883a0701488b910db149ff33eefd49914dba90bbb7a4af27227406",
+      "outgoingViewKey": "17b879dff25cc2182214da998733b579c450e7598b2c468e1d1d798643026830",
+      "publicAddress": "d7da5249ad1c3d30734100ec7f12f00fb569a4c35096a082deb2a75351e5a737"
     },
     {
       "header": {
@@ -818,15 +818,15 @@
         "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:lGE6bPhFfMgpO3rPQ9+8hXKuXzlOrNvs0O2wcaALk0Y="
+          "data": "base64:BZPEkz4yxugdKNs4fwZowv4i93YmLcU/3Z+En1088GA="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:JIagA2UJYEqNyWf1LqiJTa2ILCN9lScvStPE9JU6ZM0="
+          "data": "base64:fX22iftDDPmLfVSeS/u5vFe97H1ENDaPbDpu0mUGnAs="
         },
         "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
         "randomness": "0",
-        "timestamp": 1673288672007,
+        "timestamp": 1673303456475,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 4,
         "work": "0"
@@ -834,7 +834,7 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQVUvrkC+PkUhArcBGsbHTTgSjRyfC9iXGXgMSiPZIJWyiNtcEOhkn4Iau4DDblEXVhTgdgY65Tm6I3epe1r4AVUCIlRgiTJHa+J/M55T83WpKCTMDIt353mZhqnzRmOhcRjYxELXcte7MoWlk2ZA+ETLQuASN+b2Cuq6SSo9YYIEN9ZTi6dqv5Nhpv7qjBzgALD359ZGXC8s6V+Cs1yV2ALmKRgxyecsZmIB/6Q8O3W25pEWNku7Iv0FC63tBSogyhCzYafT3TZo7Kr45NRBrOXfAz4DLcp79o1oV3xXIDM2m+3YAAS4SEd7c3jQBo0MqGkpecRxJoJEeCuMmhseFHKkWsh05zH8AxpxYqbzAIZAmzpfJIqnJ+onxjqkkolNsVEPkPwwYwP5ZqTXQEJ8a+jmXqzZGxhDLtvQnGVz2D8RBu58bkqtdlCWuE1oEEnatX4zN79MoikF9nJ8vCg7xiXCBsdezAFjqNmxC3nUldQuQGmvS4IOgJ3ECumG5oo8XysuHn3hPSRphjmWDoGz1zdPEmQ+V2J4gjnKN0BKw/SJaaf+du4rX7dN6UQ6E1BE3h67uiyRz6oDUKCEiQFS30fCWQhKkq0HvkZe+beRlPl5Pqnb53c5gUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBV5B6RSi/rzcBFnTKsdzKOR/lZJcTvp4jkMeWBH8ZGBC+gDYZF/lP3HNB6XMhIPNpd4VS2cvNj1Z9t3Djt13Cw=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA6QzjIY9HgijCxhC6nIhQ4/OniXUige/5HvCvl4HE5E+kjvej71ZBvBcD8jz0ITkqm+KcaKPDi44JSDsi+eqN5MdT3PaRLzY3bByka9oFOoqhcIDvUpd0pbzQn7drj2ALLI0YIu70FO7JXt3w23RsRm/eHv684g++dxGRkUxe+WgPN4OTtFsXj4CEN8o4mJiV2h8B4ENzSQPTmb8nH/n0wxi0jDFERvPvyvxsdt8eSf6ntcslCAAgefQwoqXZHKDoqB2yTWQFTdyRERMElRwWl3xzzgS/P++7UjZ/02jnVbkEmRn3XhR0H7RSkqeyMalU4amA2mLS+HN4sG3j2/8xywocte1mrQaQXPjQd4xQ26I6TmVDuDf47Vkab6/kCpYEDxXG64/MJPTh7A0FZD/ZS+8nxyhpJK6hJVNRJZcFY0EXE1LsrN5cr8xYA/tBr+NbCLRBj+hXU7Z/kXQ//QdXpqRYzXE6Iwrx4C0/7vhQKhue7lHsbR0TLqOB9/0P94vaUD7ioeJs04hYTSzc54epEzvLKBSE3BWzBejZUlxurCPLyhbSBLbArC+fkuGIr3W7TlXz7FAnjuVHkFXhTSDE8tNpPEB7X8an8AHIDoLUb1jcHjjOn3u9oUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwgjYC4Jtff5YrqdAWCJVm9V5Bkr29/JB8yiLnnUPjGwpfAiqkseY//vb3tZJIaPkybKQsWc4tDxe1q5xsUV3eDA=="
         }
       ]
     }

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -3280,5 +3280,41 @@
         }
       ]
     }
+  ],
+  "Accounts disconnectBlock should remove minersFee transactions": [
+    {
+      "id": "db8d460b-3413-4db2-8800-6f2a64eb4333",
+      "name": "a",
+      "spendingKey": "75b53aee98e8689c77704665daacc75bf988ede52de53be80f4ca40d698b74b4",
+      "incomingViewKey": "38fcb711c2866b67fbf18ddb5d352e33fbfcc6e57ce63dccc7eea072af720604",
+      "outgoingViewKey": "3f78248d49f74108843457c949ea71a7dba284040265621d115eead303c42949",
+      "publicAddress": "288e521a2daf6e961bb50ba883c1a00b1d9c97798650e715f6957276161549a1"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:3O9FtgcQTg8Nd4VEgD/tF/eWpgdsvbLq2ViCi/fI12w="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:IdI9lmW0Ui+ZA5LnTpuBTdoalKihCsbowoEaKxEsRyI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1673299698789,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAXsVQ51fKPHFGOk+v9zgy+lobn2jIr+h6SYQl3yp6P2SR9GdjeYwQWnFIL7VG6VXdlXW0cYZZEnAH/KsxPDumScWMWulZAtLNJBjMaqubQQu0p7+dzOBqhMh2XMpWKoIGgoAIsnSLbFXO0bguaVbLepHs+nJMPx2/T1gpg16kFOQBhQwBqQy0a2nlPD/lBwGxwY5EWvdSgjafgAd1wcFWpm4OBNgFirLH4HKlUBYl7AirlUDahk5UVj1BF++7QLgAeHZ79Zq46H5lDIhfeAKsRnhpj4ceCp0khCyFFny+f8sqXxfUvMzYGlStcL8Y9TbC/qtBSyXzl0OA3c6P1fYzUv3uBHiGwIILi0KU4iP+SwHK/JJ1fglu8UT5iXKwQ/5Y4ltjN9CxwPc7EwFqGHR8LvtthSiY+47uLtZ0s/qgzCNpZVZAXXkdG16l7fQDzqli+ExdXjiXoTIDqnWoStkUEbDLlTk3Jm5Onp5PfxpXnO6Cg5fORL/HO9sfUWND965Q6MCWJKnhOFowNwqJhQjsGhyBwEBWBa6NLJcx7C0CL74XLm7S/YIBliRmipgb2ivlb1ylHu0+r7PmaquOc8WjbKThOxV8eXl5MIzpUPQzv7ybLHL/euW4fUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwiLSGa93frNwZ+hTjsLAHsfIo5uRXKnnt43I6PCEQ0ZCV1mjDvo49BGfR2Yw8TnF0Vu28Y//f0E4KueyF7k0/DQ=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -582,7 +582,7 @@ describe('Accounts', () => {
     })
   })
 
-  describe('removeTransaction', () => {
+  describe('deleteTransaction', () => {
     it('should delete transaction record from the database', async () => {
       const { node } = nodeTest
 
@@ -600,8 +600,8 @@ describe('Accounts', () => {
       // transaction is not marked as pending
       await expect(accountA.hasPendingTransaction(transaction.hash())).resolves.toEqual(false)
 
-      // remove the transaction
-      await accountA.removeTransaction(transaction)
+      // delete the transaction
+      await accountA.deleteTransaction(transaction)
 
       // record removed from accountA
       await expect(accountA.getTransaction(transaction.hash())).resolves.toBeUndefined()
@@ -638,8 +638,8 @@ describe('Accounts', () => {
       // but not nonChainNoteHashes
       await expect(accountHasNonChainNoteHash(accountA, noteHash)).resolves.toBe(false)
 
-      // remove the transaction
-      await accountA.removeTransaction(transaction)
+      // delete the transaction
+      await accountA.deleteTransaction(transaction)
 
       // accountA has no notes for the transaction
       notes = await accountA.getTransactionNotes(transaction)

--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -11,10 +11,33 @@ import {
   useTxFixture,
 } from '../testUtilities'
 import { AsyncUtils } from '../utils/async'
+import { Account } from './account'
 import { BalanceValue } from './walletdb/balanceValue'
 
 describe('Accounts', () => {
   const nodeTest = createNodeTest()
+
+  async function accountHasSequenceToNoteHash(
+    account: Account,
+    sequence: number,
+    noteHash: Buffer,
+  ): Promise<boolean> {
+    const entry = await account['walletDb'].sequenceToNoteHash.get([
+      account.prefix,
+      [sequence, noteHash],
+    ])
+
+    return entry !== undefined
+  }
+
+  async function accountHasNonChainNoteHash(
+    account: Account,
+    noteHash: Buffer,
+  ): Promise<boolean> {
+    const entry = await account['walletDb'].nonChainNoteHashes.get([account.prefix, noteHash])
+
+    return entry !== undefined
+  }
 
   it('should store notes at sequence', async () => {
     const { node } = nodeTest
@@ -556,6 +579,81 @@ describe('Accounts', () => {
       ])
 
       expect(pendingHashEntry).toBeDefined()
+    })
+  })
+
+  describe('removeTransaction', () => {
+    it('should delete transaction record from the database', async () => {
+      const { node } = nodeTest
+
+      const accountA = await useAccountFixture(node.wallet, 'accountA')
+
+      const block2 = await useMinerBlockFixture(node.chain, undefined, accountA, node.wallet)
+      await node.chain.addBlock(block2)
+      await node.wallet.updateHead()
+
+      const transaction = block2.transactions[0]
+
+      // accountA has the transaction
+      await expect(accountA.getTransaction(transaction.hash())).resolves.toBeDefined()
+
+      // transaction is not marked as pending
+      await expect(accountA.hasPendingTransaction(transaction.hash())).resolves.toEqual(false)
+
+      // remove the transaction
+      await accountA.removeTransaction(transaction)
+
+      // record removed from accountA
+      await expect(accountA.getTransaction(transaction.hash())).resolves.toBeUndefined()
+    })
+
+    it('should delete output note records from the database', async () => {
+      const { node } = nodeTest
+
+      const accountA = await useAccountFixture(node.wallet, 'accountA')
+
+      const block2 = await useMinerBlockFixture(node.chain, undefined, accountA, node.wallet)
+      await node.chain.addBlock(block2)
+      await node.wallet.updateHead()
+
+      const transaction = block2.transactions[0]
+
+      // accountA has one note for the transaction
+      let notes = await accountA.getTransactionNotes(transaction)
+
+      expect(notes.length).toEqual(1)
+
+      const noteHash = notes[0].hash
+
+      // the note has a nullifier stored in nullifierToNoteHashes
+      const nullifier = notes[0].nullifier
+
+      Assert.isNotNull(nullifier)
+
+      await expect(accountA.getNoteHash(nullifier)).resolves.toEqual(noteHash)
+
+      // the note is stored in sequenceToNoteHash
+      await expect(accountHasSequenceToNoteHash(accountA, 2, noteHash)).resolves.toBe(true)
+
+      // but not nonChainNoteHashes
+      await expect(accountHasNonChainNoteHash(accountA, noteHash)).resolves.toBe(false)
+
+      // remove the transaction
+      await accountA.removeTransaction(transaction)
+
+      // accountA has no notes for the transaction
+      notes = await accountA.getTransactionNotes(transaction)
+
+      expect(notes.length).toEqual(0)
+
+      // nullifierToNoteHash entry removed
+      await expect(accountA.getNoteHash(nullifier)).resolves.toBeNull()
+
+      // the note is not stored in sequenceToNoteHash or nonChainNoteHashes
+      await expect(accountHasSequenceToNoteHash(accountA, 2, noteHash)).resolves.toBe(false)
+
+      // but not nonChainNoteHashes
+      await expect(accountHasNonChainNoteHash(accountA, noteHash)).resolves.toBe(false)
     })
   })
 })

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -342,12 +342,13 @@ export class Account {
     })
   }
 
-  async removeTransaction(transaction: Transaction, tx?: IDatabaseTransaction): Promise<void> {
+  async deleteTransaction(transaction: Transaction, tx?: IDatabaseTransaction): Promise<void> {
     await this.walletDb.db.withTransaction(tx, async (tx) => {
       if (!(await this.hasTransaction(transaction.hash(), tx))) {
         return
       }
 
+      // expiring transaction deletes output notes and sets spent notes to unspent
       await this.expireTransaction(transaction, tx)
       await this.walletDb.deleteTransaction(this, transaction.hash(), tx)
     })

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -342,20 +342,34 @@ export class Account {
     })
   }
 
+  async removeTransaction(transaction: Transaction, tx?: IDatabaseTransaction): Promise<void> {
+    await this.walletDb.db.withTransaction(tx, async (tx) => {
+      if (!(await this.hasTransaction(transaction.hash(), tx))) {
+        return
+      }
+
+      await this.expireTransaction(transaction, tx)
+      await this.walletDb.deleteTransaction(this, transaction.hash(), tx)
+    })
+  }
+
   private async deleteDecryptedNote(
     noteHash: Buffer,
-    transactionHash: Buffer,
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     await this.walletDb.db.withTransaction(tx, async (tx) => {
-      const existingNote = await this.getDecryptedNote(noteHash, tx)
+      const decryptedNote = await this.getDecryptedNote(noteHash, tx)
 
-      if (existingNote) {
-        await this.walletDb.deleteDecryptedNote(this, noteHash, tx)
+      if (!decryptedNote) {
+        return
       }
 
-      const record = await this.getTransaction(transactionHash, tx)
-      await this.walletDb.deleteNoteHashSequence(this, noteHash, record?.sequence ?? null, tx)
+      await this.walletDb.deleteDecryptedNote(this, noteHash, tx)
+      await this.walletDb.deleteNoteHashSequence(this, noteHash, decryptedNote.sequence, tx)
+
+      if (decryptedNote.nullifier) {
+        await this.walletDb.deleteNullifier(this, decryptedNote.nullifier, tx)
+      }
     })
   }
 
@@ -405,16 +419,7 @@ export class Account {
 
     await this.walletDb.db.withTransaction(tx, async (tx) => {
       for (const note of transaction.notes) {
-        const noteHash = note.merkleHash()
-        const decryptedNote = await this.getDecryptedNote(noteHash, tx)
-
-        if (decryptedNote) {
-          await this.deleteDecryptedNote(noteHash, transactionHash, tx)
-
-          if (decryptedNote.nullifier) {
-            await this.walletDb.deleteNullifier(this, decryptedNote.nullifier, tx)
-          }
-        }
+        await this.deleteDecryptedNote(note.merkleHash(), tx)
       }
 
       for (const spend of transaction.spends) {

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -149,7 +149,7 @@ describe('Accounts', () => {
 
     expect(balanceA.confirmed).toBeGreaterThanOrEqual(0n)
     expect(notesOnChainA.length).toEqual(0)
-    expect(notesNotOnChainA.length).toEqual(2)
+    expect(notesNotOnChainA.length).toEqual(1)
     expect(balanceA.confirmed).toBeGreaterThanOrEqual(0n)
   })
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -407,7 +407,7 @@ export class Wallet {
           await account.disconnectTransaction(header, transaction, tx)
 
           if (transaction.isMinersFee()) {
-            await account.removeTransaction(transaction, tx)
+            await account.deleteTransaction(transaction, tx)
           }
         }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -405,6 +405,10 @@ export class Wallet {
       await this.walletDb.db.transaction(async (tx) => {
         for await (const { transaction } of this.chain.iterateBlockTransactions(header)) {
           await account.disconnectTransaction(header, transaction, tx)
+
+          if (transaction.isMinersFee()) {
+            await account.removeTransaction(transaction, tx)
+          }
         }
 
         await account.updateHeadHash(header.previousBlockHash, tx)


### PR DESCRIPTION
## Summary

minersFee transactions have no expiration so they will remain in a pending state forever unless removed. there is no need to persist the minersFee transactions form a fork in the wallet: if they are added to the main chain again in a re-org then we will re-sync them.

- defines removeTransaction to execute the same logic as expireTransaction, but deletes the transaction from the database
- cleans up some unnecessary code in expireTransaction and deleteDecryptedNote

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
