### PR TITLE
feat(rust): Use fallible casting so values arent silently incorrect

### DIFF
--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -5,6 +5,7 @@
 use std::error::Error;
 use std::fmt;
 use std::io;
+use std::num;
 use std::string;
 
 /// Error type to handle all errors within the code and dependency-raised
@@ -38,6 +39,7 @@ pub enum IronfishError {
     Io(io::Error),
     IsSmallOrder,
     RandomnessError,
+    TryFromInt(num::TryFromIntError),
     Utf8(string::FromUtf8Error),
     VerificationFailed,
 }
@@ -77,5 +79,11 @@ impl From<bellman::VerificationError> for IronfishError {
 impl From<bellman::SynthesisError> for IronfishError {
     fn from(e: bellman::SynthesisError) -> IronfishError {
         IronfishError::BellmanSynthesis(e)
+    }
+}
+
+impl From<num::TryFromIntError> for IronfishError {
+    fn from(e: num::TryFromIntError) -> IronfishError {
+        IronfishError::TryFromInt(e)
     }
 }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -138,7 +138,7 @@ impl ProposedTransaction {
         witness: &dyn WitnessTrait,
     ) -> Result<(), IronfishError> {
         self.value_balances
-            .add(&note.asset_id(), note.value() as i64)?;
+            .add(&note.asset_id(), note.value().try_into()?)?;
 
         self.spends.push(SpendBuilder::new(note, witness));
 
@@ -149,7 +149,7 @@ impl ProposedTransaction {
     /// transaction.
     pub fn add_output(&mut self, note: Note) -> Result<(), IronfishError> {
         self.value_balances
-            .subtract(&note.asset_id(), note.value() as i64)?;
+            .subtract(&note.asset_id(), note.value().try_into()?)?;
 
         self.outputs.push(OutputBuilder::new(note));
 
@@ -157,7 +157,7 @@ impl ProposedTransaction {
     }
 
     pub fn add_mint(&mut self, asset: Asset, value: u64) -> Result<(), IronfishError> {
-        self.value_balances.add(asset.id(), value as i64)?;
+        self.value_balances.add(asset.id(), value.try_into()?)?;
 
         self.mints.push(MintBuilder::new(asset, value));
 
@@ -165,7 +165,7 @@ impl ProposedTransaction {
     }
 
     pub fn add_burn(&mut self, asset_id: AssetIdentifier, value: u64) -> Result<(), IronfishError> {
-        self.value_balances.subtract(&asset_id, value as i64)?;
+        self.value_balances.subtract(&asset_id, value.try_into()?)?;
 
         self.burns.push(BurnBuilder::new(asset_id, value));
 
@@ -193,7 +193,7 @@ impl ProposedTransaction {
             let is_native_asset = asset_id == &NATIVE_ASSET;
 
             let change_amount = match is_native_asset {
-                true => *value - intended_transaction_fee as i64,
+                true => *value - i64::try_from(intended_transaction_fee)?,
                 false => *value,
             };
 


### PR DESCRIPTION
## Summary

Builds on #2851

The issue here is that we are indirectly enforcing a max value per description of `i64`, but allowing larger values. By using `as` to cast them, they would silently wrap, which will likely cause issues. By explicitly using `TryFrom` trait, we get checked casting.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
