### PR TITLE
feat(ci): Increase timeout for cargo tarpaulin

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -81,7 +81,7 @@ jobs:
           wget -O tarpaulin.tar.gz https://github.com/xd009642/tarpaulin/releases/download/0.22.0/cargo-tarpaulin-0.22.0-travis.tar.gz
           tar -xzf tarpaulin.tar.gz
           mv cargo-tarpaulin ~/.cargo/bin/
-          cargo tarpaulin -p ironfish_rust --release --out Xml --avoid-cfg-tarpaulin --skip-clean -- --test-threads 1
+          cargo tarpaulin -p ironfish_rust --release --out Xml --avoid-cfg-tarpaulin --skip-clean --timeout 180 -- --test-threads 1
 
       # Upload code coverage to Codecov
       - name: Upload to codecov.io
@@ -110,7 +110,7 @@ jobs:
           wget -O tarpaulin.tar.gz https://github.com/xd009642/tarpaulin/releases/download/0.22.0/cargo-tarpaulin-0.22.0-travis.tar.gz
           tar -xzf tarpaulin.tar.gz
           mv cargo-tarpaulin ~/.cargo/bin/
-          cargo tarpaulin -p ironfish_zkp --release --out Xml --avoid-cfg-tarpaulin --skip-clean -- --test-threads 1
+          cargo tarpaulin -p ironfish_zkp --release --out Xml --avoid-cfg-tarpaulin --skip-clean --timeout 180 -- --test-threads 1
 
       # Upload code coverage to Codecov
       - name: Upload to codecov.io


### PR DESCRIPTION
## Summary

There appear to be occasional CI failures due to cargo tarpaulin's timeout of 60 seconds being hit. Let's try increasing this to see if it helps.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
