### PR TITLE
fix(test): Remove hard-coded test timeout override

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -1250,7 +1250,7 @@ describe('Blockchain', () => {
           createdTransactionHash: blockA.transactions[1].hash(),
           supply: mintValueA + mintValueB - burnValueD,
         })
-      }, 10000)
+      })
     })
 
     describe('when an asset is minted on a fork', () => {


### PR DESCRIPTION
## Summary

This causes issues when we are, for example, regenerating test fixtures. We can override them via the CLI now, but the hardcoded one as a test argument take ultimate precedence.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
