### PR TITLE
chore: test bootstrap node definition and TESTING -> TESTNET rename

### DIFF
--- a/ironfish/src/defaultNetworkDefinitions.ts
+++ b/ironfish/src/defaultNetworkDefinitions.ts
@@ -40,9 +40,9 @@ const DEV_GENESIS = `{
   ]
 }`
 
-export const TESTING = `{
+export const TESTNET = `{
   "id": 0,
-  "bootstrapNodes": [],
+  "bootstrapNodes": ["test.bn1.ironfish.network"],
   "genesis": ${DEV_GENESIS},
   "consensus": {
       "allowedBlockFutureSeconds": 15,

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -17,7 +17,7 @@ export const InternalOptionsDefaults: InternalOptions = {
   networkIdentity: '',
   telemetryNodeId: '',
   rpcAuthToken: '',
-  networkId: 2,
+  networkId: 0,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {

--- a/ironfish/src/networkDefinition.ts
+++ b/ironfish/src/networkDefinition.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { ConsensusParameters } from './consensus'
-import { DEV, isDefaultNetworkId, MAINNET, TESTING } from './defaultNetworkDefinitions'
+import { DEV, isDefaultNetworkId, MAINNET, TESTNET } from './defaultNetworkDefinitions'
 import { Config, InternalStore } from './fileStores'
 import { FileSystem } from './fileSystems'
 import { SerializedBlock } from './primitives/block'
@@ -75,7 +75,7 @@ export async function getNetworkDefinition(
       : internal.get('networkId')
 
     if (networkId === 0) {
-      networkDefinitionJSON = TESTING
+      networkDefinitionJSON = TESTNET
     } else if (networkId === 1) {
       networkDefinitionJSON = MAINNET
     } else if (networkId === 2) {


### PR DESCRIPTION
## Summary
No default bootstrap node currently set for our network defintion. Adding here

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
