### PR TITLE
fixes wallet scan failures

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -149,10 +149,6 @@ export class Wallet {
       return false
     }
 
-    if (this.chainProcessor.hash === null) {
-      return true
-    }
-
     for (const account of this.accounts.values()) {
       if (!(await this.isAccountUpToDate(account))) {
         return true
@@ -444,11 +440,6 @@ export class Wallet {
       return
     }
 
-    if (!(await this.shouldRescan())) {
-      this.logger.info('Skipping Scan, all accounts up to date.')
-      return
-    }
-
     const scan = new ScanState()
     this.scan = scan
 
@@ -478,7 +469,7 @@ export class Wallet {
     scan.sequence = beginHeader.sequence
     scan.endSequence = endHeader.sequence
 
-    if (scan.isAborted) {
+    if (scan.isAborted || beginHash.equals(endHash)) {
       scan.signalComplete()
       this.scan = null
       return


### PR DESCRIPTION
## Summary

we should not automatically start a scan if the chainProcessor hash is null - if there are no accounts to scan then we should not scan. instead we can rely on the other check on 'isAccountUpToDate' in 'shouldRescan'.

- removes check on chainProcessor.hash in shouldRescan
- replaces extra call to shouldRescan in scanTransactions with early termination if beginHash is equal to endHash

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
