### PR TITLE
Add instructions to upgrading Node version

### DIFF
--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -8,7 +8,8 @@ if (process.platform !== 'win32') {
 }
 
 if(process.versions.node.split('.')[0] !== '18') {
-  console.log('NodeJS version ' +  process.versions.node + ' is not compatible. Must have node v18.x installed: https://nodejs.org/en/download/')
+  console.log('NodeJS version ' +  process.versions.node + ' is not compatible. Must have Node v18 installed: https://nodejs.org/en/download/')
+  console.log('After v18 is installed, MAKE SURE TO run `npm install -g ironfish` again to install ironfish with the correct Node version')
   process.exit(1)
 }
 

--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -30,7 +30,7 @@
     }
   },
   "engines": {
-    "node": ">= 18"
+    "node": "18.x"
   },
   "devDependencies": {
     "@napi-rs/cli": "2.14.1",


### PR DESCRIPTION
## Summary
When users are told to upgrade to Node v18 they will also need to reinstall the `ironfish` package. This adds a message with those instructions. 

## Testing Plan
Tested locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
