### PR TITLE
reads head sequence at account level in balance methods

### DIFF
--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -139,7 +139,7 @@ describe('Accounts', () => {
       AsyncUtils.materialize(node.wallet.walletDb.loadNoteHashesNotOnChain(account)),
     ).resolves.toHaveLength(1)
 
-    await expect(account.getBalance(1, Asset.nativeId(), 1)).resolves.toMatchObject({
+    await expect(account.getBalance(Asset.nativeId(), 1)).resolves.toMatchObject({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })
@@ -152,7 +152,7 @@ describe('Accounts', () => {
       AsyncUtils.materialize(node.wallet.walletDb.loadNoteHashesNotOnChain(account)),
     ).resolves.toHaveLength(0)
 
-    await expect(account.getBalance(1, Asset.nativeId(), 1)).resolves.toMatchObject({
+    await expect(account.getBalance(Asset.nativeId(), 1)).resolves.toMatchObject({
       confirmed: BigInt(0),
       unconfirmed: BigInt(0),
     })

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -511,8 +511,8 @@ export class Account {
     const head = await this.getHead()
     if (!head) {
       return {
-        unconfirmed: BigInt(0),
-        confirmed: BigInt(0),
+        unconfirmed: 0n,
+        confirmed: 0n,
         unconfirmedCount: 0,
         blockHash: null,
         sequence: null,

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -456,7 +456,6 @@ export class Account {
   }
 
   async *getBalances(
-    headSequence: number,
     minimumBlockConfirmations: number,
     tx?: IDatabaseTransaction,
   ): AsyncGenerator<{
@@ -467,14 +466,19 @@ export class Account {
     blockHash: Buffer | null
     sequence: number | null
   }> {
+    const head = await this.getHead()
+    if (!head) {
+      return
+    }
+
     for await (const { assetId, balance } of this.walletDb.getUnconfirmedBalances(this, tx)) {
       const { unconfirmed, blockHash, sequence } = balance
       const { confirmed, unconfirmedCount } =
         await this.calculateUnconfirmedCountAndConfirmedBalance(
-          headSequence,
+          head.sequence,
           assetId,
           minimumBlockConfirmations,
-          unconfirmed,
+          balance.unconfirmed,
           tx,
         )
       yield {
@@ -494,7 +498,6 @@ export class Account {
    * confirmed: confirmed balance minus notes in unconfirmed range
    */
   async getBalance(
-    headSequence: number,
     assetId: Buffer,
     minimumBlockConfirmations: number,
     tx?: IDatabaseTransaction,
@@ -505,10 +508,21 @@ export class Account {
     blockHash: Buffer | null
     sequence: number | null
   }> {
+    const head = await this.getHead()
+    if (!head) {
+      return {
+        unconfirmed: BigInt(0),
+        confirmed: BigInt(0),
+        unconfirmedCount: 0,
+        blockHash: null,
+        sequence: null,
+      }
+    }
+
     const { unconfirmed, blockHash, sequence } = await this.getUnconfirmedBalance(assetId, tx)
     const { confirmed, unconfirmedCount } =
       await this.calculateUnconfirmedCountAndConfirmedBalance(
-        headSequence,
+        head.sequence,
         assetId,
         minimumBlockConfirmations,
         unconfirmed,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -534,12 +534,8 @@ export class Wallet {
     )
 
     this.assertHasAccount(account)
-    const headSequence = await this.getAccountHeadSequence(account)
-    if (!headSequence) {
-      return
-    }
 
-    for await (const balance of account.getBalances(headSequence, minimumBlockConfirmations)) {
+    for await (const balance of account.getBalances(minimumBlockConfirmations)) {
       yield balance
     }
   }
@@ -560,23 +556,9 @@ export class Wallet {
       0,
     )
 
-    return await this.walletDb.db.transaction(async (tx) => {
-      this.assertHasAccount(account)
+    this.assertHasAccount(account)
 
-      const headSequence = await this.getAccountHeadSequence(account, tx)
-
-      if (!headSequence) {
-        return {
-          unconfirmed: BigInt(0),
-          confirmed: BigInt(0),
-          unconfirmedCount: 0,
-          blockHash: null,
-          sequence: null,
-        }
-      }
-
-      return account.getBalance(headSequence, assetId, minimumBlockConfirmations, tx)
-    })
+    return account.getBalance(assetId, minimumBlockConfirmations)
   }
 
   private async *getUnspentNotes(


### PR DESCRIPTION
## Summary

reading the account head at the wallet level is unnecessary since its only use there is to be passed down to the account.

- updates getBalance and getBalances to read account head in the account-level methods
- removes unnecessary db transaction in getBalance

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
