### PR TITLE
filters by sequence in getUnspentNotes at account level

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -95,8 +95,8 @@ export class Account {
   async *getUnspentNotes(
     assetId: Buffer,
     options?: {
-      minimumBlockConfirmations?: number,
-    }
+      minimumBlockConfirmations?: number
+    },
   ): AsyncGenerator<DecryptedNoteValue & { hash: Buffer }> {
     const head = await this.getHead()
     if (!head) {

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -116,7 +116,11 @@ export class Account {
         continue
       }
 
-      if (!decryptedNote.sequence || decryptedNote.sequence > maxConfirmedSequence) {
+      if (!decryptedNote.sequence) {
+        continue
+      }
+
+      if (decryptedNote.sequence > maxConfirmedSequence) {
         continue
       }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -589,24 +589,9 @@ export class Wallet {
     const minimumBlockConfirmations =
       options?.minimumBlockConfirmations ?? this.config.get('minimumBlockConfirmations')
 
-    const headSequence = await this.getAccountHeadSequence(account)
-    if (!headSequence) {
-      return
-    }
-
-    for await (const decryptedNote of account.getUnspentNotes(assetId)) {
-      if (minimumBlockConfirmations > 0) {
-        if (!decryptedNote.sequence) {
-          continue
-        }
-
-        const confirmations = headSequence - decryptedNote.sequence
-
-        if (confirmations < minimumBlockConfirmations) {
-          continue
-        }
-      }
-
+    for await (const decryptedNote of account.getUnspentNotes(assetId, {
+      minimumBlockConfirmations,
+    })) {
       yield decryptedNote
     }
   }


### PR DESCRIPTION
## Summary

the wallet getUnspentNotes method filters all unspent notes that the account level method returns by the account's head sequence.

moving this filtering down to the account level method puts all of the filtering logic for unspent notes in one place.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
