### PR TITLE
fix: bug transactions in multi asset syncer and 

### DIFF
--- a/ironfish-cli/src/commands/service/sync-multi-asset.ts
+++ b/ironfish-cli/src/commands/service/sync-multi-asset.ts
@@ -4,6 +4,7 @@
 import { Asset } from '@ironfish/rust-nodejs'
 import {
   ApiMultiAssetUpload,
+  BufferUtils,
   GENESIS_BLOCK_SEQUENCE,
   GetTransactionStreamResponse,
   Meter,
@@ -211,13 +212,13 @@ function serializeMultiAssets(data: GetTransactionStreamResponse): ApiMultiAsset
       for (const mint of tx.mints) {
         multiAssets.push({
           type: 'MULTI_ASSET_MINT' as MultiAssetTypes,
-          assetName: mint.assetName,
+          assetName: BufferUtils.toHuman(Buffer.from(mint.assetName, 'hex')),
         })
       }
       for (const burn of tx.burns) {
         multiAssets.push({
           type: 'MULTI_ASSET_BURN' as MultiAssetTypes,
-          assetName: burn.assetName,
+          assetName: BufferUtils.toHuman(Buffer.from(burn.assetName, 'hex')),
         })
       }
       for (const note of tx.notes) {
@@ -225,7 +226,7 @@ function serializeMultiAssets(data: GetTransactionStreamResponse): ApiMultiAsset
         if (note.assetId !== Asset.nativeId().toString('hex')) {
           multiAssets.push({
             type: 'MULTI_ASSET_TRANSFER' as MultiAssetTypes,
-            assetName: note.assetName,
+            assetName: BufferUtils.toHuman(Buffer.from(note.assetName, 'hex')),
           })
         }
       }

--- a/ironfish-cli/src/commands/service/sync-multi-asset.ts
+++ b/ironfish-cli/src/commands/service/sync-multi-asset.ts
@@ -205,7 +205,7 @@ export default class SyncMultiAsset extends IronfishCommand {
 function serializeMultiAssets(data: GetTransactionStreamResponse): ApiMultiAssetUpload {
   const txs = []
   // should not send transactions if block is disconnected
-  if (data.type !== 'connected') {
+  if (data.type === 'connected') {
     for (const tx of data.transactions) {
       const multiAssets = []
       for (const mint of tx.mints) {

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -6,7 +6,7 @@ import { Assert } from '../../../assert'
 import { ChainProcessor } from '../../../chainProcessor'
 import { Block } from '../../../primitives/block'
 import { BlockHeader } from '../../../primitives/blockheader'
-import { BufferUtils, CurrencyUtils } from '../../../utils'
+import { CurrencyUtils } from '../../../utils'
 import { PromiseUtils } from '../../../utils/promise'
 import { isValidIncomingViewKey } from '../../../wallet/validator'
 import { ValidationError } from '../../adapters/errors'
@@ -162,7 +162,7 @@ router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
               value: CurrencyUtils.encode(decryptedNote.value()),
               memo: decryptedNote.memo(),
               assetId: decryptedNote.assetId().toString('hex'),
-              assetName: assetValue ? BufferUtils.toHuman(assetValue.name) : '',
+              assetName: assetValue?.name.toString('hex') || '',
             })
           }
         }
@@ -172,7 +172,7 @@ router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
           burns.push({
             value: CurrencyUtils.encode(burn.value),
             assetId: burn.assetId.toString('hex'),
-            assetName: assetValue ? BufferUtils.toHuman(assetValue.name) : '',
+            assetName: assetValue?.name.toString('hex') || '',
           })
         }
 
@@ -180,7 +180,7 @@ router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
           mints.push({
             value: CurrencyUtils.encode(mint.value),
             assetId: mint.asset.id().toString('hex'),
-            assetName: BufferUtils.toHuman(mint.asset.name()),
+            assetName: mint.asset.name().toString('hex'),
           })
         }
 

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -6,7 +6,7 @@ import { Assert } from '../../../assert'
 import { ChainProcessor } from '../../../chainProcessor'
 import { Block } from '../../../primitives/block'
 import { BlockHeader } from '../../../primitives/blockheader'
-import { CurrencyUtils } from '../../../utils'
+import { BufferUtils, CurrencyUtils } from '../../../utils'
 import { PromiseUtils } from '../../../utils/promise'
 import { isValidIncomingViewKey } from '../../../wallet/validator'
 import { ValidationError } from '../../adapters/errors'
@@ -162,7 +162,7 @@ router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
               value: CurrencyUtils.encode(decryptedNote.value()),
               memo: decryptedNote.memo(),
               assetId: decryptedNote.assetId().toString('hex'),
-              assetName: assetValue?.name.toString('hex') || '',
+              assetName: assetValue ? BufferUtils.toHuman(assetValue.name) : '',
             })
           }
         }
@@ -172,7 +172,7 @@ router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
           burns.push({
             value: CurrencyUtils.encode(burn.value),
             assetId: burn.assetId.toString('hex'),
-            assetName: assetValue?.name.toString('hex') || '',
+            assetName: assetValue ? BufferUtils.toHuman(assetValue.name) : '',
           })
         }
 
@@ -180,7 +180,7 @@ router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
           mints.push({
             value: CurrencyUtils.encode(mint.value),
             assetId: mint.asset.id().toString('hex'),
-            assetName: mint.asset.name().toString('hex'),
+            assetName: BufferUtils.toHuman(mint.asset.name()),
           })
         }
 


### PR DESCRIPTION
## Summary
1. Fixes bug in transaction syncer command. The condition should be reverse. Identified this bug by checking logs of `multi-asset-syncer` running in AWS after adding some multi asset transactions/blocks.

2. Decoding error was occurring in `getTransactionStream`, fixed that as well.

## Testing Plan

Tested in production by:
1. Created mint/burns with commands:
```
yarn run ironfish wallet:mint -a 100000 -f default -o 1 -n jowparks -m "minting on chain"
yarn run ironfish wallet:burn -i "8b03915814798e708ad6a3093ba2f283dcca537670b82e83d30a55077d3b4595" -a 1000 -f default -o 1
```
1. Updating database head to rescan chain with:
```
UPDATE multi_asset_head SET block_hash = 'd179d8b74987d6617267d46f4958554ba0df02d7e5e6117db02d6ff38fd0f6da' WHERE id = '1';
```
1. `yarn build && yarn`
1. Rescanning with multi asset syncer locally with command
```
yarn run ironfish service:syncMultiAsset --endpoint=https://api.ironfish.network --token=<token> --viewKey <viewkey> -v --datadir=~/.multiasset
```

Output looked reasonable.
1. Checked db for entries:
```
SELECT * FROM MULTI_ASSET;
```
returns
```
  3 | 2023-01-10 21:42:31.373 | 2023-01-10 22:04:39.69  | 0:
 id |       created_at        |       updated_at        |                         transaction_hash                         |                            block_hash                            | asset_name |       type       | block_sequence | network_version | main
----+-------------------------+-------------------------+------------------------------------------------------------------+------------------------------------------------------------------+------------+------------------+----------------+-----------------+------
  1 | 2023-01-10 21:42:17.956 | 2023-01-10 22:04:31.746 | f4f24a5f421cb71a6f21fa43adf4f3f67db8d66e5c92a38a017e083976a1e543 | 00000306d35387536f1c770af0be8cd158fc269852f759ddd30509b4105f2c46 | jowparks   | MULTI_ASSET_MINT |             42 |               4 | t
  2 | 2023-01-10 21:42:19.458 | 2023-01-10 22:04:32.61  | 56cabcc37eb17e41584919991ddaf0bd7528fe30057129cd57d2d898c72f145f | 00000252af9faa9722ef37ea8476fca9bf48aa0776474c2edc20e8bebba61417 | jowparks   | MULTI_ASSET_BURN |             61 |               4 | t
  3 | 2023-01-10 21:42:31.373 | 2023-01-10 22:04:39.69  | 0:
```
<img width="1092" alt="Screen Shot 2023-01-10 at 2 13 36 PM" src="https://user-images.githubusercontent.com/26990067/211673557-372482ee-c4e2-4a89-8760-ccae6f95b394.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
