### PR TITLE
moves isExpiredSequence off of Verifier

### DIFF
--- a/ironfish-cli/src/commands/wallet/repair.ts
+++ b/ironfish-cli/src/commands/wallet/repair.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Account, Assert, Blockchain, NodeUtils, Wallet, WalletDB } from '@ironfish/sdk'
+import { Account, Assert, Blockchain, isExpiredSequence, NodeUtils, Wallet, WalletDB } from '@ironfish/sdk'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
@@ -76,8 +76,7 @@ export default class Repair extends IronfishCommand {
       const transactionHash = transactionValue.transaction.hash()
 
       const isExpired =
-        !transactionValue.sequence &&
-        chain.verifier.isExpiredSequence(expiration, chain.head.sequence)
+        !transactionValue.sequence && isExpiredSequence(expiration, chain.head.sequence)
 
       const pendingTransactionHash = await walletDb.pendingTransactionHashes.get([
         account.prefix,

--- a/ironfish-cli/src/commands/wallet/repair.ts
+++ b/ironfish-cli/src/commands/wallet/repair.ts
@@ -1,7 +1,15 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Account, Assert, Blockchain, isExpiredSequence, NodeUtils, Wallet, WalletDB } from '@ironfish/sdk'
+import {
+  Account,
+  Assert,
+  Blockchain,
+  isExpiredSequence,
+  NodeUtils,
+  Wallet,
+  WalletDB,
+} from '@ironfish/sdk'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 

--- a/ironfish/src/consensus/utils.ts
+++ b/ironfish/src/consensus/utils.ts
@@ -2,6 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export * from './consensus'
-export * from './utils'
-export * from './verifier'
+export function isExpiredSequence(expiration: number, sequence: number): boolean {
+  return expiration !== 0 && expiration <= sequence
+}

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -21,6 +21,7 @@ import { Transaction } from '../primitives/transaction'
 import { IDatabaseTransaction } from '../storage'
 import { BufferUtils } from '../utils/buffer'
 import { WorkerPool } from '../workerPool'
+import { isExpiredSequence } from './utils'
 
 export class Verifier {
   chain: Blockchain
@@ -68,7 +69,7 @@ export class Verifier {
     let transactionBatch = []
     let runningNotesCount = 0
     for (const [idx, tx] of block.transactions.entries()) {
-      if (this.isExpiredSequence(tx.expiration(), block.header.sequence)) {
+      if (isExpiredSequence(tx.expiration(), block.header.sequence)) {
         return {
           valid: false,
           reason: VerificationResultReason.TRANSACTION_EXPIRED,
@@ -310,10 +311,6 @@ export class Verifier {
 
     validity = await this.workerPool.verify(transaction)
     return validity
-  }
-
-  isExpiredSequence(expiration: number, sequence: number): boolean {
-    return expiration !== 0 && expiration <= sequence
   }
 
   /**

--- a/ironfish/src/memPool/memPool.test.ts
+++ b/ironfish/src/memPool/memPool.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../assert'
+import * as ConsensusUtils from '../consensus/utils'
 import { getTransactionSize } from '../network/utils/serializers'
 import { Transaction } from '../primitives'
 import { createNodeTest, useAccountFixture, useBlockWithTx } from '../testUtilities'
@@ -176,15 +177,17 @@ describe('MemPool', () => {
     describe('with an expired sequence', () => {
       const nodeTest = createNodeTest()
 
+      afterEach(() => jest.restoreAllMocks())
+
       it('returns false', async () => {
         const { node } = nodeTest
-        const { wallet, chain, memPool } = node
+        const { wallet, memPool } = node
         const accountA = await useAccountFixture(wallet, 'accountA')
         const accountB = await useAccountFixture(wallet, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
         const isExpiredSequenceSpy = jest
-          .spyOn(chain.verifier, 'isExpiredSequence')
+          .spyOn(ConsensusUtils, 'isExpiredSequence')
           .mockReturnValue(true)
 
         expect(memPool.acceptTransaction(transaction)).toBe(false)

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -5,6 +5,7 @@
 import { BufferSet } from 'buffer-map'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
+import { isExpiredSequence } from '../consensus'
 import { Event } from '../event'
 import { MemPool } from '../memPool'
 import { MetricsMonitor } from '../metrics'
@@ -81,11 +82,7 @@ export class MiningManager {
         continue
       }
 
-      const isExpired = this.chain.verifier.isExpiredSequence(
-        transaction.expiration(),
-        sequence,
-      )
-      if (isExpired) {
+      if (isExpiredSequence(transaction.expiration(), sequence)) {
         continue
       }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -7,6 +7,7 @@ import { v4 as uuid } from 'uuid'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { ChainProcessor } from '../chainProcessor'
+import { isExpiredSequence } from '../consensus'
 import { Event } from '../event'
 import { Config } from '../fileStores'
 import { createRootLogger, Logger } from '../logger'
@@ -598,7 +599,7 @@ export class Wallet {
 
     expiration = expiration ?? heaviestHead.sequence + transactionExpirationDelta
 
-    if (this.chain.verifier.isExpiredSequence(expiration, this.chain.head.sequence)) {
+    if (isExpiredSequence(expiration, this.chain.head.sequence)) {
       throw new Error('Invalid expiration sequence for transaction')
     }
 
@@ -638,7 +639,7 @@ export class Wallet {
 
     const expiration =
       options.expiration ?? heaviestHead.sequence + options.transactionExpirationDelta
-    if (this.chain.verifier.isExpiredSequence(expiration, this.chain.head.sequence)) {
+    if (isExpiredSequence(expiration, this.chain.head.sequence)) {
       throw new Error('Invalid expiration sequence for transaction')
     }
 
@@ -703,7 +704,7 @@ export class Wallet {
     }
 
     expiration = expiration ?? heaviestHead.sequence + transactionExpirationDelta
-    if (this.chain.verifier.isExpiredSequence(expiration, this.chain.head.sequence)) {
+    if (isExpiredSequence(expiration, this.chain.head.sequence)) {
       throw new Error('Invalid expiration sequence for transaction')
     }
 
@@ -1087,10 +1088,7 @@ export class Wallet {
 
       return isConfirmed ? TransactionStatus.CONFIRMED : TransactionStatus.UNCONFIRMED
     } else {
-      const isExpired = this.chain.verifier.isExpiredSequence(
-        transaction.transaction.expiration(),
-        headSequence,
-      )
+      const isExpired = isExpiredSequence(transaction.transaction.expiration(), headSequence)
 
       return isExpired ? TransactionStatus.EXPIRED : TransactionStatus.PENDING
     }


### PR DESCRIPTION
## Summary

the logic of isExpiredSequence is very simple and is independent of any other state (i.e., it doesn't depend on the chain)

since this method is currently defined on the Verifier class it has a dependeny on the chain.

the wallet uses isExpiredSequence in several places. moving isExpiredSequence into a utils module removes a source of chain dependence in the wallet

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
