### PR TITLE
chore: add multi asset address

### DIFF
--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -69,6 +69,11 @@ export class WebApi {
     this.getFundsEndpoint = options?.getFundsEndpoint || null
   }
 
+  async getMultiAssetAddress(): Promise<string> {
+    const response = await axios.get<{ address: string }>(`${this.host}/deposit/address`)
+    return response.data.address
+  }
+
   async headMultiAsset(): Promise<string | null> {
     const response = await axios
       .get<{ block_hash: string }>(`${this.host}/multi_asset/head`)


### PR DESCRIPTION
## Summary
Reuses the existing API endpoint for `deposits/address` to get the IronBank Address. We will need this once we make a CLI command for users to automatically transfer assets to IronBank

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
