### PR TITLE
renames minimumBlockConfirmations to confirmations

### DIFF
--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -51,7 +51,7 @@ export class BalanceCommand extends IronfishCommand {
     const response = await client.getAccountBalance({
       account,
       assetId: flags.assetId,
-      minimumBlockConfirmations: flags.confirmations,
+      confirmations: flags.confirmations,
     })
     const assetId = response.content.assetId
 
@@ -99,7 +99,7 @@ export class BalanceCommand extends IronfishCommand {
     this.log(
       `${response.unconfirmedCount} notes worth ${CurrencyUtils.renderIron(
         unconfirmedDelta,
-      )} are on the chain within ${response.minimumBlockConfirmations.toString()} blocks of the head`,
+      )} are on the chain within ${response.confirmations.toString()} blocks of the head`,
     )
     this.log(`Unconfirmed: ${CurrencyUtils.renderIron(unconfirmed, true, assetId)}`)
   }

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -42,7 +42,7 @@ export class BalancesCommand extends IronfishCommand {
     const account = args.account as string | undefined
     const response = await client.getAccountBalances({
       account,
-      minimumBlockConfirmations: flags.confirmations,
+      confirmations: flags.confirmations,
     })
     this.log(`Account: ${response.content.account}`)
 

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -126,7 +126,7 @@ export type ConfigOptions = {
    * The minimum number of block confirmations needed when computing account
    * balance.
    */
-  minimumBlockConfirmations: number
+  confirmations: number
 
   /**
    * The name that the pool will use in block graffiti and transaction memo.
@@ -280,7 +280,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     transactionExpirationDelta: YupUtils.isPositiveInteger,
     blocksPerMessage: YupUtils.isPositiveInteger,
     minerBatchSize: YupUtils.isPositiveInteger,
-    minimumBlockConfirmations: YupUtils.isPositiveInteger,
+    confirmations: YupUtils.isPositiveInteger,
     poolName: yup.string(),
     poolAccountName: yup.string(),
     poolBanning: yup.boolean(),
@@ -356,7 +356,7 @@ export class Config extends KeyStore<ConfigOptions> {
       tlsKeyPath: files.resolve(files.join(dataDir, 'certs', 'node-key.pem')),
       tlsCertPath: files.resolve(files.join(dataDir, 'certs', 'node-cert.pem')),
       maxPeers: 50,
-      minimumBlockConfirmations: 2,
+      confirmations: 2,
       minPeers: 1,
       targetPeers: 50,
       telemetryApi: 'https://api.ironfish.network/telemetry',

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -9,7 +9,7 @@ import { getAccount } from './utils'
 export type GetBalanceRequest = {
   account?: string
   assetId?: string
-  minimumBlockConfirmations?: number
+  confirmations?: number
 }
 
 export type GetBalanceResponse = {
@@ -18,7 +18,7 @@ export type GetBalanceResponse = {
   confirmed: string
   unconfirmed: string
   unconfirmedCount: number
-  minimumBlockConfirmations: number
+  confirmations: number
   blockHash: string | null
   sequence: number | null
 }
@@ -27,7 +27,7 @@ export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
   .object({
     account: yup.string().strip(true),
     assetId: yup.string().optional(),
-    minimumBlockConfirmations: yup.number().min(0).optional(),
+    confirmations: yup.number().min(0).optional(),
   })
   .defined()
 
@@ -38,7 +38,7 @@ export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yu
     unconfirmed: yup.string().defined(),
     unconfirmedCount: yup.number().defined(),
     confirmed: yup.string().defined(),
-    minimumBlockConfirmations: yup.number().defined(),
+    confirmations: yup.number().defined(),
     blockHash: yup.string().nullable(true).defined(),
     sequence: yup.number().nullable(true).defined(),
   })
@@ -48,10 +48,7 @@ router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
   `${ApiNamespace.wallet}/getBalance`,
   GetBalanceRequestSchema,
   async (request, node): Promise<void> => {
-    const minimumBlockConfirmations = Math.max(
-      request.data.minimumBlockConfirmations ?? node.config.get('minimumBlockConfirmations'),
-      0,
-    )
+    const confirmations = request.data.confirmations ?? node.config.get('confirmations')
 
     const account = getAccount(node, request.data.account)
 
@@ -61,7 +58,7 @@ router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
     }
 
     const balance = await node.wallet.getBalance(account, assetId, {
-      minimumBlockConfirmations,
+      confirmations,
     })
 
     request.end({
@@ -70,7 +67,7 @@ router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
       confirmed: balance.confirmed.toString(),
       unconfirmed: balance.unconfirmed.toString(),
       unconfirmedCount: balance.unconfirmedCount,
-      minimumBlockConfirmations,
+      confirmations: confirmations,
       blockHash: balance.blockHash?.toString('hex') ?? null,
       sequence: balance.sequence,
     })

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -7,7 +7,7 @@ import { getAccount } from './utils'
 
 export interface GetBalancesRequest {
   account?: string
-  minimumBlockConfirmations?: number
+  confirmations?: number
 }
 
 export interface GetBalancesResponse {
@@ -25,7 +25,7 @@ export interface GetBalancesResponse {
 export const GetBalancesRequestSchema: yup.ObjectSchema<GetBalancesRequest> = yup
   .object({
     account: yup.string().optional(),
-    minimumBlockConfirmations: yup.number().min(0).optional(),
+    confirmations: yup.number().min(0).optional(),
   })
   .defined()
 
@@ -65,7 +65,7 @@ router.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
       sequence,
       unconfirmed,
       unconfirmedCount,
-    } of node.wallet.getBalances(account, request.data.minimumBlockConfirmations)) {
+    } of node.wallet.getBalances(account, request.data.confirmations)) {
       if (request.closed) {
         return
       }

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -78,7 +78,7 @@ export class NodeTest {
     sdk.config.setOverride('networkId', 0)
     sdk.config.setOverride('enableListenP2P', false)
     sdk.config.setOverride('enableTelemetry', false)
-    sdk.config.setOverride('minimumBlockConfirmations', 0)
+    sdk.config.setOverride('confirmations', 0)
 
     // Allow tests to override default settings
     if (options?.config) {

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -97,7 +97,7 @@ export class Account {
   async *getUnspentNotes(
     assetId: Buffer,
     options?: {
-      minimumBlockConfirmations?: number
+      confirmations?: number
     },
   ): AsyncGenerator<DecryptedNoteValue & { hash: Buffer }> {
     const head = await this.getHead()
@@ -105,9 +105,9 @@ export class Account {
       return
     }
 
-    const minimumBlockConfirmations = options?.minimumBlockConfirmations ?? 0
+    const confirmations = options?.confirmations ?? 0
 
-    const maxConfirmedSequence = head.sequence - minimumBlockConfirmations
+    const maxConfirmedSequence = head.sequence - confirmations
 
     for await (const decryptedNote of this.getNotes()) {
       if (!decryptedNote.note.assetId().equals(assetId)) {
@@ -474,7 +474,7 @@ export class Account {
   }
 
   async *getBalances(
-    minimumBlockConfirmations: number,
+    confirmations: number,
     tx?: IDatabaseTransaction,
   ): AsyncGenerator<{
     assetId: Buffer
@@ -494,7 +494,7 @@ export class Account {
         await this.calculateUnconfirmedCountAndConfirmedBalance(
           head.sequence,
           assetId,
-          minimumBlockConfirmations,
+          confirmations,
           balance.unconfirmed,
           tx,
         )
@@ -517,7 +517,7 @@ export class Account {
    */
   async getBalance(
     assetId: Buffer,
-    minimumBlockConfirmations: number,
+    confirmations: number,
     tx?: IDatabaseTransaction,
   ): Promise<{
     unconfirmed: bigint
@@ -543,7 +543,7 @@ export class Account {
       await this.calculateUnconfirmedCountAndConfirmedBalance(
         head.sequence,
         assetId,
-        minimumBlockConfirmations,
+        confirmations,
         balance.unconfirmed,
         tx,
       )
@@ -560,18 +560,18 @@ export class Account {
   private async calculateUnconfirmedCountAndConfirmedBalance(
     headSequence: number,
     assetId: Buffer,
-    minimumBlockConfirmations: number,
+    confirmations: number,
     unconfirmed: bigint,
     tx?: IDatabaseTransaction,
   ): Promise<{ confirmed: bigint; unconfirmedCount: number }> {
     let unconfirmedCount = 0
 
     let confirmed = unconfirmed
-    if (minimumBlockConfirmations > 0) {
+    if (confirmations > 0) {
       const unconfirmedSequenceEnd = headSequence
 
       const unconfirmedSequenceStart = Math.max(
-        unconfirmedSequenceEnd - minimumBlockConfirmations + 1,
+        unconfirmedSequenceEnd - confirmations + 1,
         GENESIS_BLOCK_SEQUENCE,
       )
 

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -143,9 +143,9 @@ describe('Accounts', () => {
     const notesNotOnChainA = await AsyncUtils.materialize(
       accountA['walletDb'].loadNotesNotOnChain(accountA),
     )
-    // set minimumBlockConfirmations so that balance considers confirmations
+    // set confirmations so that balance considers confirmations
     const balanceA = await nodeA.wallet.getBalance(accountA, Asset.nativeId(), {
-      minimumBlockConfirmations: 2,
+      confirmations: 2,
     })
 
     expect(balanceA.confirmed).toBeGreaterThanOrEqual(0n)
@@ -417,7 +417,7 @@ describe('Accounts', () => {
   describe('getBalance', () => {
     it('returns balances for unspent notes with minimum confirmations on the main chain', async () => {
       const { node: nodeA } = await nodeTest.createSetup({
-        config: { minimumBlockConfirmations: 2 },
+        config: { confirmations: 2 },
       })
       const { node: nodeB } = await nodeTest.createSetup()
       const accountA = await useAccountFixture(nodeA.wallet, 'accountA')

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -525,7 +525,7 @@ export class Wallet {
 
   async *getBalances(
     account: Account,
-    minimumBlockConfirmations?: number,
+    confirmations?: number,
   ): AsyncGenerator<{
     assetId: Buffer
     unconfirmed: bigint
@@ -534,12 +534,11 @@ export class Wallet {
     blockHash: Buffer | null
     sequence: number | null
   }> {
-    minimumBlockConfirmations =
-      minimumBlockConfirmations ?? this.config.get('minimumBlockConfirmations')
+    confirmations = confirmations ?? this.config.get('confirmations')
 
     this.assertHasAccount(account)
 
-    for await (const balance of account.getBalances(minimumBlockConfirmations)) {
+    for await (const balance of account.getBalances(confirmations)) {
       yield balance
     }
   }
@@ -547,7 +546,7 @@ export class Wallet {
   async getBalance(
     account: Account,
     assetId: Buffer,
-    options?: { minimumBlockConfirmations?: number },
+    options?: { confirmations?: number },
   ): Promise<{
     unconfirmedCount: number
     unconfirmed: bigint
@@ -555,26 +554,24 @@ export class Wallet {
     blockHash: Buffer | null
     sequence: number | null
   }> {
-    const minimumBlockConfirmations =
-      options?.minimumBlockConfirmations ?? this.config.get('minimumBlockConfirmations')
+    const confirmations = options?.confirmations ?? this.config.get('confirmations')
 
     this.assertHasAccount(account)
 
-    return account.getBalance(assetId, minimumBlockConfirmations)
+    return account.getBalance(assetId, confirmations)
   }
 
   private async *getUnspentNotes(
     account: Account,
     assetId: Buffer,
     options?: {
-      minimumBlockConfirmations?: number
+      confirmations?: number
     },
   ): AsyncGenerator<DecryptedNoteValue & { hash: Buffer }> {
-    const minimumBlockConfirmations =
-      options?.minimumBlockConfirmations ?? this.config.get('minimumBlockConfirmations')
+    const confirmations = options?.confirmations ?? this.config.get('confirmations')
 
     for await (const decryptedNote of account.getUnspentNotes(assetId, {
-      minimumBlockConfirmations,
+      confirmations,
     })) {
       yield decryptedNote
     }
@@ -1070,12 +1067,11 @@ export class Wallet {
     transaction: TransactionValue,
     options?: {
       headSequence?: number | null
-      minimumBlockConfirmations?: number
+      confirmations?: number
     },
     tx?: IDatabaseTransaction,
   ): Promise<TransactionStatus> {
-    const minimumBlockConfirmations =
-      options?.minimumBlockConfirmations ?? this.config.get('minimumBlockConfirmations')
+    const confirmations = options?.confirmations ?? this.config.get('confirmations')
 
     const headSequence =
       options?.headSequence ?? (await this.getAccountHeadSequence(account, tx))
@@ -1085,7 +1081,7 @@ export class Wallet {
     }
 
     if (transaction.sequence) {
-      const isConfirmed = headSequence - transaction.sequence >= minimumBlockConfirmations
+      const isConfirmed = headSequence - transaction.sequence >= confirmations
 
       return isConfirmed ? TransactionStatus.CONFIRMED : TransactionStatus.UNCONFIRMED
     } else {


### PR DESCRIPTION
## Summary

confirmations is a well-known concept in crypto.

the 'confirmations' name is much more concise and still expresses what the variable represents.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
