### PR TITLE
feat(ironfish): Remove `AsyncGenerator` return type from `iterateBlockTransactions`

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1177,10 +1177,10 @@ export class Blockchain {
     }
   }
 
-  async *iterateBlockTransactions(
+  async iterateBlockTransactions(
     header: BlockHeader,
     tx?: IDatabaseTransaction,
-  ): AsyncGenerator<
+  ): Promise<
     {
       transaction: Transaction
       initialNoteIndex: number
@@ -1188,34 +1188,34 @@ export class Blockchain {
       blockHash: Buffer
       previousBlockHash: Buffer
       timestamp: Date
-    },
-    void,
-    unknown
+    }[]
   > {
     const block = await this.getBlock(header, tx)
-
     if (!block) {
-      return
+      return []
     }
 
     Assert.isNotNull(header.noteSize)
     let noteIndex = header.noteSize
 
+    const transactions = []
     // Transactions should be handled in reverse order because
     // header.noteCommitment is the size of the tree after the
     // last note in the block.
     for (const transaction of block.transactions.slice().reverse()) {
       noteIndex -= transaction.notes.length
-
-      yield {
+      // Maintain original order of transactions from block
+      transactions.unshift({
         transaction,
         initialNoteIndex: noteIndex,
         blockHash: header.hash,
         sequence: header.sequence,
         previousBlockHash: header.previousBlockHash,
         timestamp: header.timestamp,
-      }
+      })
     }
+
+    return transactions
   }
 
   async saveConnect(

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1177,7 +1177,7 @@ export class Blockchain {
     }
   }
 
-  async iterateBlockTransactions(
+  async getBlockTransactions(
     header: BlockHeader,
     tx?: IDatabaseTransaction,
   ): Promise<
@@ -1204,8 +1204,7 @@ export class Blockchain {
     // last note in the block.
     for (const transaction of block.transactions.slice().reverse()) {
       noteIndex -= transaction.notes.length
-      // Maintain original order of transactions from block
-      transactions.unshift({
+      transactions.push({
         transaction,
         initialNoteIndex: noteIndex,
         blockHash: header.hash,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -365,10 +365,10 @@ export class Wallet {
       }
     })
 
-    const transactions = await this.chain.iterateBlockTransactions(blockHeader)
-
     for (const account of accounts) {
       await this.walletDb.db.transaction(async (tx) => {
+        const transactions = await this.chain.iterateBlockTransactions(blockHeader)
+
         for (const { transaction, initialNoteIndex } of transactions) {
           if (scan && scan.isAborted) {
             scan.signalComplete()
@@ -405,11 +405,11 @@ export class Wallet {
       return BufferUtils.equalsNullable(accountHead?.hash ?? null, header.hash)
     })
 
-    const transactions = await this.chain.iterateBlockTransactions(header)
-
     for (const account of accounts) {
       await this.walletDb.db.transaction(async (tx) => {
-        for await (const { transaction } of transactions) {
+        const transactions = await this.chain.iterateBlockTransactions(header)
+
+        for (const { transaction } of transactions) {
           await account.disconnectTransaction(header, transaction, tx)
 
           if (transaction.isMinersFee()) {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -367,7 +367,7 @@ export class Wallet {
 
     for (const account of accounts) {
       await this.walletDb.db.transaction(async (tx) => {
-        const transactions = await this.chain.iterateBlockTransactions(blockHeader)
+        const transactions = await this.chain.getBlockTransactions(blockHeader)
 
         for (const { transaction, initialNoteIndex } of transactions) {
           if (scan && scan.isAborted) {
@@ -407,7 +407,7 @@ export class Wallet {
 
     for (const account of accounts) {
       await this.walletDb.db.transaction(async (tx) => {
-        const transactions = await this.chain.iterateBlockTransactions(header)
+        const transactions = await this.chain.getBlockTransactions(header)
 
         for (const { transaction } of transactions) {
           await account.disconnectTransaction(header, transaction, tx)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -365,12 +365,11 @@ export class Wallet {
       }
     })
 
+    const transactions = await this.chain.iterateBlockTransactions(blockHeader)
+
     for (const account of accounts) {
       await this.walletDb.db.transaction(async (tx) => {
-        for await (const {
-          transaction,
-          initialNoteIndex,
-        } of this.chain.iterateBlockTransactions(blockHeader)) {
+        for (const { transaction, initialNoteIndex } of transactions) {
           if (scan && scan.isAborted) {
             scan.signalComplete()
             this.scan = null
@@ -406,9 +405,11 @@ export class Wallet {
       return BufferUtils.equalsNullable(accountHead?.hash ?? null, header.hash)
     })
 
+    const transactions = await this.chain.iterateBlockTransactions(header)
+
     for (const account of accounts) {
       await this.walletDb.db.transaction(async (tx) => {
-        for await (const { transaction } of this.chain.iterateBlockTransactions(header)) {
+        for await (const { transaction } of transactions) {
           await account.disconnectTransaction(header, transaction, tx)
 
           if (transaction.isMinersFee()) {


### PR DESCRIPTION
## Summary

I'm thinking of replacing the AsyncGenerator return type to a regular array for iterateBlockTransaction in the blockchain here. It doesn't seem like we need a generator because there's no async operation for each transaction, and this would give the caller control over order of transactions.

## Testing Plan

Covered by existing unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
