### PR TITLE
fix(ironfish): Keep consistent iteration in block connect events

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1204,7 +1204,7 @@ export class Blockchain {
     // last note in the block.
     for (const transaction of block.transactions.slice().reverse()) {
       noteIndex -= transaction.notes.length
-      transactions.push({
+      transactions.unshift({
         transaction,
         initialNoteIndex: noteIndex,
         blockHash: header.hash,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -409,7 +409,7 @@ export class Wallet {
       await this.walletDb.db.transaction(async (tx) => {
         const transactions = await this.chain.getBlockTransactions(header)
 
-        for (const { transaction } of transactions) {
+        for (const { transaction } of transactions.slice().reverse()) {
           await account.disconnectTransaction(header, transaction, tx)
 
           if (transaction.isMinersFee()) {


### PR DESCRIPTION
## Summary

* Fetching block transactions should be in the same order as on the block object
* Disconnecting block transactions should be done in reverse order

## Testing Plan

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
