### PR TITLE
RPC endpoint to output hex of a raw unsigned txn

### DIFF
--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.test.ts
@@ -25,7 +25,7 @@ describe('Route wallet/createRawTransaction', () => {
     expect(response.content.transaction).toBeDefined()
   })
 
-  it("should return an error if ????", async () => {
+  it('should return an error if ????', async () => {
     //TODO what are good negative cases?
   })
 })

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.test.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { v4 as uuid } from 'uuid'
+import { RawTransactionSerde } from '../../../primitives/rawTransaction'
+import { createRawTransaction } from '../../../testUtilities/helpers/transaction'
+import { createRouteTest } from '../../../testUtilities/routeTest'
+
+describe('Route wallet/createRawTransaction', () => {
+  const routeTest = createRouteTest(true)
+
+  it('should generate a valid raw transaction', async () => {
+    const account = await routeTest.node.wallet.createAccount(uuid(), true)
+    const options = {
+      wallet: routeTest.node.wallet,
+      from: account,
+    }
+    const rawTransaction = await createRawTransaction(options)
+    const response = await routeTest.client.postTransaction({
+      transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.content.transaction).toBeDefined()
+  })
+
+  it("should return an error if ????", async () => {
+    //TODO what are good negative cases?
+  })
+})

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
@@ -108,33 +108,33 @@ router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionRe
       }
     })
 
-    let mints: MintDescription[] = []
+    const mints: MintDescription[] = []
     if (options.mints) {
-      mints = options.mints.map((mint) => { // TODO this is incorrect way of populating mints
+      options.mints.map((mint) => { 
         let assetId = Asset.nativeId()
         if (mint.assetId) {
           assetId = Buffer.from(mint.assetId, 'hex')
         }
-  
-        return {
+        //TODO how to get from AssetID to Asset?
+        mints.push({
           asset: assetId,
           value: CurrencyUtils.decode(mint.value),
-        }
+        })
       })
     }
 
-    let burns: BurnDescription[] = []
+    const burns: BurnDescription[] = []
     if (options.burns) {
-      burns = options.burns.map((burn) => { // TODO this is incorrect way of populating burns
+      options.burns.map((burn) => { // TODO this is incorrect way of populating burns
         let assetId = Asset.nativeId()
         if (burn.assetId) {
           assetId = Buffer.from(burn.assetId, 'hex')
         }
-  
-        return {
+        //TODO how to get from AssetID to Asset?
+        burns.push({
           asset: assetId,
           value: CurrencyUtils.decode(burn.value),
-        }
+        })
       })
     }
     

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
@@ -5,17 +5,62 @@ import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
 
 export type CreateRawTransactionRequest = { 
-  options: string  // TODO change fields to match the request
+  fromAccountName: string
+  receives: {
+    publicAddress: string
+    amount: string
+    memo: string
+    assetId?: string
+  }[]
+  mints?: {
+    assetId: string
+    value: string
+  }[]
+  burns?: {
+    assetId: string
+    value: string
+  }[]
+  fee: string
+  expiration?: number | null
+  expirationDelta?: number | null
 }
 
 export type CreateRawTransactionResponse = {
   transaction: string
 }
 
-// TODO fixme
 export const CreateRawTransactionRequestSchema: yup.ObjectSchema<CreateRawTransactionRequest> = yup
   .object({
-    options: yup.string().defined(),
+    fromAccountName: yup.string().defined(),
+    receives: yup
+      .array(
+        yup
+          .object({
+            publicAddress: yup.string().defined(),
+            amount: yup.string().defined(),
+            memo: yup.string().defined(),
+            assetId: yup.string().optional(),
+          })
+          .defined(),
+      )
+      .defined(),
+    mints: yup
+      .array(
+        yup.object({
+          assetId: yup.string().defined(),
+          value: yup.string().defined(),
+        }).defined(),
+      ).optional(),
+    burns: yup
+      .array(
+        yup.object({
+          assetId: yup.string().defined(),
+          value: yup.string().defined(),
+        }).defined(),
+      ).optional(),
+    fee: yup.string().defined(),
+    expiration: yup.number().nullable().optional(),
+    expirationDelta: yup.number().nullable().optional(),
   })
   .defined()
 
@@ -29,27 +74,6 @@ router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionRe
   `${ApiNamespace.wallet}/createRawTransaction`,
   CreateRawTransactionRequestSchema,
   async (request, node): Promise<void> => {
-    // const rawTransactionBytes = Buffer.from(request.data.transaction, 'hex')
-    // const rawTransaction = RawTransactionSerde.deserialize(rawTransactionBytes)
-    // const postedTransaction = await node.wallet.postTransaction(rawTransaction)
-    // const postedTransactionBytes = postedTransaction.serialize()
-
-    // request.end({ transaction: postedTransactionBytes.toString('hex') })
-    // wallet.createTransaction takes:
-    // sender: Account, // this'll be a stringified public key
-    // receives: {
-    //   publicAddress: string 
-    //   amount: string // becomes bigint
-    //   memo: string
-    //   assetId: string  
-    // }[],
-    // mints: MintDescription[], // value will be string -> bigint, asset will be string ID. see burnAsset and mintAsset
-    // burns: BurnDescription[],
-    // fee: string, // becomes bigint
-    // expiration: number,
-
-    // maybe start with a version that just supplies [] and [] for mints and burns
-    // and then add the ability to specify them later
     // const transaction = await node.wallet.createTransaction(request.options.sender, request.options.receives, request.options.fee, request.options.expiration)
     // const transactionBytes = transaction.serialize()
     // request.end({ transaction: transactionBytes.toString('hex') })

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
@@ -7,6 +7,8 @@ import { CurrencyUtils } from '../../../utils'
 import { RawTransactionSerde } from '../../../primitives/rawTransaction'
 import { ApiNamespace, router } from '../router'
 import { ValidationError } from '../../adapters/errors'
+import { BurnDescription } from '../../../primitives/burnDescription'
+import { MintDescription } from '../../../primitives/mintDescription'
 
 export type CreateRawTransactionRequest = {
   fromAccountName: string
@@ -108,10 +110,36 @@ router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionRe
       }
     })
 
-    // TODO MINTS
-    const mints = []
-    const burns = []
-    // TODO BURNS
+    let mints: MintDescription[] = []
+    if (options.mints) {
+      mints = options.mints.map((mint) => { // TODO this is incorrect way of populating mints
+        let assetId = Asset.nativeId()
+        if (mint.assetId) {
+          assetId = Buffer.from(mint.assetId, 'hex')
+        }
+  
+        return {
+          asset: assetId,
+          value: CurrencyUtils.decode(mint.value),
+        }
+      })
+    }
+
+    let burns: BurnDescription[] = []
+    if (options.burns) {
+      burns = options.burns.map((burn) => { // TODO this is incorrect way of populating burns
+        let assetId = Asset.nativeId()
+        if (burn.assetId) {
+          assetId = Buffer.from(burn.assetId, 'hex')
+        }
+  
+        return {
+          asset: assetId,
+          value: CurrencyUtils.decode(burn.value),
+        }
+      })
+    }
+    
 
     const fee = CurrencyUtils.decode(options.fee)
     if (fee < 1n) {

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
@@ -28,7 +28,6 @@ export type CreateRawTransactionRequest = {
   }[]
   fee: string
   expiration?: number | null
-  expirationDelta?: number | null
 }
 
 export type CreateRawTransactionResponse = {
@@ -73,7 +72,6 @@ export const CreateRawTransactionRequestSchema: yup.ObjectSchema<CreateRawTransa
         .optional(),
       fee: yup.string().defined(),
       expiration: yup.number().nullable().optional(),
-      expirationDelta: yup.number().nullable().optional(),
     })
     .defined()
 

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
@@ -125,7 +125,7 @@ router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionRe
 
     const burns: BurnDescription[] = []
     if (options.burns) {
-      options.burns.map((burn) => { // TODO this is incorrect way of populating burns
+      options.burns.map((burn) => {
         let assetId = Asset.nativeId()
         if (burn.assetId) {
           assetId = Buffer.from(burn.assetId, 'hex')
@@ -143,7 +143,7 @@ router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionRe
     if (fee < 1n) {
       throw new ValidationError(`Invalid transaction fee, ${options.fee}`)
     }
-    
+
     const expiration = options.expiration ?? 0 // TODO is 0 the good default?
 
     const transaction = await node.wallet.createTransaction(

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { RawTransactionSerde } from '../../../primitives/rawTransaction'
+import { ApiNamespace, router } from '../router'
+
+export type CreateRawTransactionRequest = { transaction: string }
+
+export type CreateRawTransactionResponse = {
+  transaction: string
+}
+
+export const CreateRawTransactionRequestSchema: yup.ObjectSchema<CreateRawTransactionRequest> = yup
+  .object({
+    transaction: yup.string().defined(),
+  })
+  .defined()
+
+export const CreateRawTransactionResponseSchema: yup.ObjectSchema<CreateRawTransactionResponse> = yup
+  .object({
+    transaction: yup.string().defined(),
+  })
+  .defined()
+
+router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionResponse>(
+  `${ApiNamespace.wallet}/createRawTransaction`,
+  CreateRawTransactionRequestSchema,
+  async (request, node): Promise<void> => {
+    const rawTransactionBytes = Buffer.from(request.data.transaction, 'hex')
+    const rawTransaction = RawTransactionSerde.deserialize(rawTransactionBytes)
+    const postedTransaction = await node.wallet.postTransaction(rawTransaction)
+    const postedTransactionBytes = postedTransaction.serialize()
+
+    request.end({ transaction: postedTransactionBytes.toString('hex') })
+  },
+)

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
 
-export type CreateRawTransactionRequest = { 
+export type CreateRawTransactionRequest = {
   fromAccountName: string
   receives: {
     publicAddress: string
@@ -29,46 +29,54 @@ export type CreateRawTransactionResponse = {
   transaction: string
 }
 
-export const CreateRawTransactionRequestSchema: yup.ObjectSchema<CreateRawTransactionRequest> = yup
-  .object({
-    fromAccountName: yup.string().defined(),
-    receives: yup
-      .array(
-        yup
-          .object({
-            publicAddress: yup.string().defined(),
-            amount: yup.string().defined(),
-            memo: yup.string().defined(),
-            assetId: yup.string().optional(),
-          })
-          .defined(),
-      )
-      .defined(),
-    mints: yup
-      .array(
-        yup.object({
-          assetId: yup.string().defined(),
-          value: yup.string().defined(),
-        }).defined(),
-      ).optional(),
-    burns: yup
-      .array(
-        yup.object({
-          assetId: yup.string().defined(),
-          value: yup.string().defined(),
-        }).defined(),
-      ).optional(),
-    fee: yup.string().defined(),
-    expiration: yup.number().nullable().optional(),
-    expirationDelta: yup.number().nullable().optional(),
-  })
-  .defined()
+export const CreateRawTransactionRequestSchema: yup.ObjectSchema<CreateRawTransactionRequest> =
+  yup
+    .object({
+      fromAccountName: yup.string().defined(),
+      receives: yup
+        .array(
+          yup
+            .object({
+              publicAddress: yup.string().defined(),
+              amount: yup.string().defined(),
+              memo: yup.string().defined(),
+              assetId: yup.string().optional(),
+            })
+            .defined(),
+        )
+        .defined(),
+      mints: yup
+        .array(
+          yup
+            .object({
+              assetId: yup.string().defined(),
+              value: yup.string().defined(),
+            })
+            .defined(),
+        )
+        .optional(),
+      burns: yup
+        .array(
+          yup
+            .object({
+              assetId: yup.string().defined(),
+              value: yup.string().defined(),
+            })
+            .defined(),
+        )
+        .optional(),
+      fee: yup.string().defined(),
+      expiration: yup.number().nullable().optional(),
+      expirationDelta: yup.number().nullable().optional(),
+    })
+    .defined()
 
-export const CreateRawTransactionResponseSchema: yup.ObjectSchema<CreateRawTransactionResponse> = yup
-  .object({
-    transaction: yup.string().defined(),
-  })
-  .defined()
+export const CreateRawTransactionResponseSchema: yup.ObjectSchema<CreateRawTransactionResponse> =
+  yup
+    .object({
+      transaction: yup.string().defined(),
+    })
+    .defined()
 
 router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionResponse>(
   `${ApiNamespace.wallet}/createRawTransaction`,

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
@@ -39,13 +39,13 @@ router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionRe
     // sender: Account, // this'll be a stringified public key
     // receives: {
     //   publicAddress: string 
-    //   amount: bigint
+    //   amount: string // becomes bigint
     //   memo: string
-    //   assetId: Buffer
+    //   assetId: string  
     // }[],
-    // mints: MintDescription[],
+    // mints: MintDescription[], // value will be string -> bigint, asset will be string ID. see burnAsset and mintAsset
     // burns: BurnDescription[],
-    // fee: bigint,
+    // fee: string, // becomes bigint
     // expiration: number,
 
     // maybe start with a version that just supplies [] and [] for mints and burns

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
@@ -2,18 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { RawTransactionSerde } from '../../../primitives/rawTransaction'
 import { ApiNamespace, router } from '../router'
 
-export type CreateRawTransactionRequest = { transaction: string }
+export type CreateRawTransactionRequest = { 
+  options: string  // TODO change fields to match the request
+}
 
 export type CreateRawTransactionResponse = {
   transaction: string
 }
 
+// TODO fixme
 export const CreateRawTransactionRequestSchema: yup.ObjectSchema<CreateRawTransactionRequest> = yup
   .object({
-    transaction: yup.string().defined(),
+    options: yup.string().defined(),
   })
   .defined()
 
@@ -27,11 +29,29 @@ router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionRe
   `${ApiNamespace.wallet}/createRawTransaction`,
   CreateRawTransactionRequestSchema,
   async (request, node): Promise<void> => {
-    const rawTransactionBytes = Buffer.from(request.data.transaction, 'hex')
-    const rawTransaction = RawTransactionSerde.deserialize(rawTransactionBytes)
-    const postedTransaction = await node.wallet.postTransaction(rawTransaction)
-    const postedTransactionBytes = postedTransaction.serialize()
+    // const rawTransactionBytes = Buffer.from(request.data.transaction, 'hex')
+    // const rawTransaction = RawTransactionSerde.deserialize(rawTransactionBytes)
+    // const postedTransaction = await node.wallet.postTransaction(rawTransaction)
+    // const postedTransactionBytes = postedTransaction.serialize()
 
-    request.end({ transaction: postedTransactionBytes.toString('hex') })
+    // request.end({ transaction: postedTransactionBytes.toString('hex') })
+    // wallet.createTransaction takes:
+    // sender: Account, // this'll be a stringified public key
+    // receives: {
+    //   publicAddress: string 
+    //   amount: bigint
+    //   memo: string
+    //   assetId: Buffer
+    // }[],
+    // mints: MintDescription[],
+    // burns: BurnDescription[],
+    // fee: bigint,
+    // expiration: number,
+
+    // maybe start with a version that just supplies [] and [] for mints and burns
+    // and then add the ability to specify them later
+    // const transaction = await node.wallet.createTransaction(request.options.sender, request.options.receives, request.options.fee, request.options.expiration)
+    // const transactionBytes = transaction.serialize()
+    // request.end({ transaction: transactionBytes.toString('hex') })
   },
 )

--- a/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createRawTransaction.ts
@@ -143,6 +143,8 @@ router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionRe
     if (fee < 1n) {
       throw new ValidationError(`Invalid transaction fee, ${options.fee}`)
     }
+    
+    const expiration = options.expiration ?? 0 // TODO is 0 the good default?
 
     const transaction = await node.wallet.createTransaction(
       account,
@@ -150,7 +152,7 @@ router.register<typeof CreateRawTransactionRequestSchema, CreateRawTransactionRe
       mints,
       burns,
       fee,
-      options.expiration, // TODO this is incorrect way of passing expiration
+      expiration,
     )
     const transactionBytes = RawTransactionSerde.serialize(transaction)
     request.end({ transaction: transactionBytes.toString('hex') })

--- a/ironfish/src/rpc/routes/wallet/index.ts
+++ b/ironfish/src/rpc/routes/wallet/index.ts
@@ -4,6 +4,7 @@
 
 export * from './burnAsset'
 export * from './create'
+export * from './createRawTransaction'
 export * from './exportAccount'
 export * from './getAccounts'
 export * from './getBalance'

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -13,13 +13,13 @@ export type PostTransactionResponse = {
 
 export const PostTransactionRequestSchema: yup.ObjectSchema<PostTransactionRequest> = yup
   .object({
-    transaction: yup.string().defined(),
+    transaction: yup.string().required(),
   })
   .defined()
 
 export const PostTransactionResponseSchema: yup.ObjectSchema<PostTransactionResponse> = yup
   .object({
-    transaction: yup.string().defined(),
+    transaction: yup.string().required(),
   })
   .defined()
 

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -13,13 +13,13 @@ export type PostTransactionResponse = {
 
 export const PostTransactionRequestSchema: yup.ObjectSchema<PostTransactionRequest> = yup
   .object({
-    transaction: yup.string().required(),
+    transaction: yup.string().defined(),
   })
   .defined()
 
 export const PostTransactionResponseSchema: yup.ObjectSchema<PostTransactionResponse> = yup
   .object({
-    transaction: yup.string().required(),
+    transaction: yup.string().defined(),
   })
   .defined()
 


### PR DESCRIPTION
## Summary
As a companion to #2838, add an rpc endpoint for generating the hex of a raw unsigned txn. Proposed implementation is based on `createTransaction` in `ironfish/src/wallet/wallet.ts`. 

## Testing Plan
Unit tests in progress. Plan is to submit the same options to the wallet txn creation and the rpc, and compare output hex. Open to suggestions for negative tests and edge cases.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```

### See Also 
#2869 
