### PR TITLE
fixes transactionValue to use signed bigints in balance deltas

### DIFF
--- a/ironfish/src/typedefs/bufio.d.ts
+++ b/ironfish/src/typedefs/bufio.d.ts
@@ -13,6 +13,7 @@ declare module 'bufio' {
     writeU64(value: number): StaticWriter
     writeI64(value: number): StaticWriter
     writeBigU64(value: bigint): StaticWriter
+    writeBigI64(value: bigint): StaticWriter
     writeBigU64BE(value: bigint): StaticWriter
     writeBigU128(value: bigint): StaticWriter
     writeBigU128BE(value: bigint): StaticWriter
@@ -43,6 +44,7 @@ declare module 'bufio' {
     writeBigU256(value: bigint): BufferWriter
     writeBigU256BE(value: bigint): BufferWriter
     writeI64(value: number): BufferWriter
+    writeBigI64(value: bigint): BufferWriter
     writeVarint(value: number): BufferWriter
     writeString(value: string, enc?: BufferEncoding | null): BufferWriter
     writeVarString(value: string, enc?: BufferEncoding | null): BufferWriter
@@ -69,6 +71,7 @@ declare module 'bufio' {
     readBigU256(): bigint
     readBigU256BE(): bigint
     readI64(): number
+    readBigI64(): bigint
     readFloat(): number
     readFloatBE(): number
     readDoubleBE(): number

--- a/ironfish/src/wallet/walletdb/__fixtures__/transactionValue.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/transactionValue.test.ts.fixture
@@ -90,5 +90,19 @@
       "outgoingViewKey": "a6c2a21fb2c3258de10d4a64295bb02f41a4095349947e59643a0792c58974eb",
       "publicAddress": "3211906ae1b270bb5e14fd24c5c093d0460bd9842543d0409904b2f1f20ec338"
     }
+  ],
+  "TransactionValueEncoding with negative balance delta serializes the object into a buffer and deserializes to the original object": [
+    {
+      "id": "ee67735b-e469-462d-80dc-9ffdb861532c",
+      "name": "test",
+      "spendingKey": "a84798c1725da860dbe9bff93c883b58575a869377ae97e4d3e82b7175b10cc8",
+      "incomingViewKey": "016f422b886ad6b328773b64a0f0cefcb7e17b008724c284b5c4af5f3c1f2003",
+      "outgoingViewKey": "8bd19637e534954d395e69cda14e3bf3bab56d35db01b394bafe2b20bef7ce99",
+      "publicAddress": "a16247aba5f6722aba220af99020afc7fb4e4aaf2931a2ea6cdca4e68b6c1872"
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA5poaMVMNOXODazKrvE32RbzBg/F4ynfWjwn+x7oygj2DCk3RzcbMyXzJUHNu/H3S1TAh328wMV3n8oiiSWbBnytftGkN3yyFGX3VEHpzobmpwZtz2xlerD1FoUSoyIy//sWMl9vWPcxD6LmpZPOLLkU3ath8xPTdj4PcDan1YC4IKWeS0AwH2a4AzkYCnC4urt3mRdJTdMCFARgoD0Qw2Lg3jRlEzqnFKkYvPZBCEG6gUynT17TbhW36oSWytwRxNtqoXJdIzJbujwMGJH5GPI5FXLOe8G+2Vd5QIMTe3UJfMEvz8sHOCSpRoSKoaqZo53EEDfGU/wLoLPgqR7rfzq5E+xrHui7b6bgi7Jy8ttYBZ9sHzGr6g1gox4FvJ6sQ2blwsDS7z7D0ohjQY3Zqan9LWePBtZyT2v2TzRdK5Gp/cy2YSM9C0v9bAb9a/TiZkXjV/B1PgxXx34rA1E2808NZ+V3gp5FILFRhSghlsnToewSsMvnAfVzRiStTvfjoBtpFe2Sn+dqyFKIgAqRjnZqm8nX0Shu8/nsF8gChBpwb7NRhF6NC8k9FDOsKgo0h2QQGpdWNmlUJX5trIPUx/j2qTHnvwqd/s94ekzSrc4AtVRuh65YP3Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwE57O4ksq7ZFLihuWS2BFejrCD4njEY+bjiPkjk0gWxBsFuLBhsKpGY6hdQCSKpUkHjWDUHX11viZeuxMz2k2Bw=="
+    }
   ]
 }

--- a/ironfish/src/wallet/walletdb/transactionValue.test.ts
+++ b/ironfish/src/wallet/walletdb/transactionValue.test.ts
@@ -158,4 +158,28 @@ describe('TransactionValueEncoding', () => {
       expectTransactionValueToMatch(deserializedValue, value)
     })
   })
+
+  describe('with negative balance delta', () => {
+    it('serializes the object into a buffer and deserializes to the original object', async () => {
+      const encoder = new TransactionValueEncoding()
+
+      const transaction = await useMinersTxFixture(nodeTest.wallet)
+
+      const assetBalanceDeltas = new BufferMap<bigint>()
+      assetBalanceDeltas.set(Asset.nativeId(), -20n)
+
+      const value: TransactionValue = {
+        transaction,
+        timestamp: new Date(),
+        blockHash: Buffer.alloc(32, 1),
+        sequence: 124,
+        submittedSequence: 123,
+        assetBalanceDeltas,
+      }
+
+      const buffer = encoder.serialize(value)
+      const deserializedValue = encoder.deserialize(buffer)
+      expectTransactionValueToMatch(deserializedValue, value)
+    })
+  })
 })

--- a/ironfish/src/wallet/walletdb/transactionValue.ts
+++ b/ironfish/src/wallet/walletdb/transactionValue.ts
@@ -47,7 +47,7 @@ export class TransactionValueEncoding implements IDatabaseEncoding<TransactionVa
 
     for (const [assetId, balanceDelta] of value.assetBalanceDeltas) {
       bw.writeHash(assetId)
-      bw.writeBigU64(balanceDelta)
+      bw.writeBigI64(balanceDelta)
     }
 
     return bw.render()
@@ -79,7 +79,7 @@ export class TransactionValueEncoding implements IDatabaseEncoding<TransactionVa
 
     for (let i = 0; i < assetCount; i++) {
       const assetId = reader.readHash()
-      const balanceDelta = reader.readBigU64()
+      const balanceDelta = reader.readBigI64()
       assetBalanceDeltas.set(assetId, balanceDelta)
     }
 


### PR DESCRIPTION
## Summary

balance delta will be negative for any outgoing transaction

adds ReadBigI64/WriteBigI64 to bufio types to support reading negative bigint values

adds test of serialization and deserialization of negative balance delta

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
