### PR TITLE
adds IRON amount to wallet:transactions output

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -49,14 +49,9 @@ export class TransactionsCommand extends IronfishCommand {
     let showHeader = true
 
     for await (const transaction of response.contentStream()) {
-      let ironDelta = '0'
-
-      for (const { assetId, delta } of transaction.assetBalanceDeltas) {
-        if (assetId === Asset.nativeId().toString('hex')) {
-          ironDelta = delta
-          break
-        }
-      }
+      const ironDelta = transaction.assetBalanceDeltas.find(
+        (d) => d.assetId === Asset.nativeId().toString('hex'),
+      )
 
       CliUx.ux.table(
         [transaction],
@@ -82,7 +77,7 @@ export class TransactionsCommand extends IronfishCommand {
           },
           amount: {
             header: 'Amount ($IRON)',
-            get: (_) => CurrencyUtils.renderIron(ironDelta),
+            get: (_) => (ironDelta ? CurrencyUtils.renderIron(ironDelta.delta) : '0'),
             minWidth: 20,
           },
           fee: {

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
 import { CurrencyUtils, TimeUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
@@ -48,6 +49,11 @@ export class TransactionsCommand extends IronfishCommand {
     let showHeader = true
 
     for await (const transaction of response.contentStream()) {
+      const assetBalanceDeltas: Map<string, string> = new Map(
+        Object.entries(JSON.parse(transaction.assetBalanceDeltas)),
+      )
+      const amount = assetBalanceDeltas.get(Asset.nativeId().toString('hex')) ?? '0'
+
       CliUx.ux.table(
         [transaction],
         {
@@ -69,6 +75,11 @@ export class TransactionsCommand extends IronfishCommand {
           isMinersFee: {
             header: 'Miner Fee',
             get: (transaction) => (transaction.isMinersFee ? `✔` : ``),
+          },
+          amount: {
+            header: 'Amount ($IRON)',
+            get: (_) => CurrencyUtils.renderIron(amount),
+            minWidth: 20,
           },
           fee: {
             header: 'Fee ($IRON)',

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -49,10 +49,14 @@ export class TransactionsCommand extends IronfishCommand {
     let showHeader = true
 
     for await (const transaction of response.contentStream()) {
-      const assetBalanceDeltas: Map<string, string> = new Map(
-        Object.entries(JSON.parse(transaction.assetBalanceDeltas)),
-      )
-      const amount = assetBalanceDeltas.get(Asset.nativeId().toString('hex')) ?? '0'
+      let ironDelta = '0'
+
+      for (const { assetId, delta } of transaction.assetBalanceDeltas) {
+        if (assetId === Asset.nativeId().toString('hex')) {
+          ironDelta = delta
+          break
+        }
+      }
 
       CliUx.ux.table(
         [transaction],
@@ -78,7 +82,7 @@ export class TransactionsCommand extends IronfishCommand {
           },
           amount: {
             header: 'Amount ($IRON)',
-            get: (_) => CurrencyUtils.renderIron(amount),
+            get: (_) => CurrencyUtils.renderIron(ironDelta),
             minWidth: 20,
           },
           fee: {

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -29,6 +29,7 @@ export type GetAccountTransactionsResponse = {
   burnsCount: number
   expiration: number
   timestamp: number
+  assetBalanceDeltas: string
 }
 
 export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTransactionsRequest> =
@@ -55,6 +56,7 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
       burnsCount: yup.number().defined(),
       expiration: yup.number().defined(),
       timestamp: yup.number().defined(),
+      assetBalanceDeltas: yup.string().defined(),
     })
     .defined()
 

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -29,7 +29,7 @@ export type GetAccountTransactionsResponse = {
   burnsCount: number
   expiration: number
   timestamp: number
-  assetBalanceDeltas: string
+  assetBalanceDeltas: Array<{ assetId: string; delta: string }>
 }
 
 export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTransactionsRequest> =
@@ -56,7 +56,16 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
       burnsCount: yup.number().defined(),
       expiration: yup.number().defined(),
       timestamp: yup.number().defined(),
-      assetBalanceDeltas: yup.string().defined(),
+      assetBalanceDeltas: yup
+        .array(
+          yup
+            .object({
+              assetId: yup.string().defined(),
+              delta: yup.string().defined(),
+            })
+            .defined(),
+        )
+        .defined(),
     })
     .defined()
 

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -15,7 +15,7 @@ export type RpcAccountTransaction = {
   burnsCount: number
   expiration: number
   timestamp: number
-  assetBalanceDeltas: string
+  assetBalanceDeltas: Array<{ assetId: string; delta: string }>
 }
 
 export type RpcAccountDecryptedNote = {
@@ -31,13 +31,11 @@ export type RpcAccountDecryptedNote = {
 export function serializeRpcAccountTransaction(
   transaction: TransactionValue,
 ): RpcAccountTransaction {
-  const assetBalanceDeltas: Map<string, string> = new Map<string, string>()
+  const assetBalanceDeltas: Array<{ assetId: string; delta: string }> = []
 
   for (const [assetId, balance] of transaction.assetBalanceDeltas.entries()) {
-    assetBalanceDeltas.set(assetId.toString('hex'), balance.toString())
+    assetBalanceDeltas.push({ assetId: assetId.toString('hex'), delta: balance.toString() })
   }
-
-  const assetBalanceDeltasJSON = JSON.stringify(Object.fromEntries(assetBalanceDeltas))
 
   return {
     hash: transaction.transaction.hash().toString('hex'),
@@ -51,6 +49,6 @@ export function serializeRpcAccountTransaction(
     burnsCount: transaction.transaction.burns.length,
     expiration: transaction.transaction.expiration(),
     timestamp: transaction.timestamp.getTime(),
-    assetBalanceDeltas: assetBalanceDeltasJSON,
+    assetBalanceDeltas,
   }
 }

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -15,6 +15,7 @@ export type RpcAccountTransaction = {
   burnsCount: number
   expiration: number
   timestamp: number
+  assetBalanceDeltas: string
 }
 
 export type RpcAccountDecryptedNote = {
@@ -30,6 +31,14 @@ export type RpcAccountDecryptedNote = {
 export function serializeRpcAccountTransaction(
   transaction: TransactionValue,
 ): RpcAccountTransaction {
+  const assetBalanceDeltas: Map<string, string> = new Map<string, string>()
+
+  for (const [assetId, balance] of transaction.assetBalanceDeltas.entries()) {
+    assetBalanceDeltas.set(assetId.toString('hex'), balance.toString())
+  }
+
+  const assetBalanceDeltasJSON = JSON.stringify(Object.fromEntries(assetBalanceDeltas))
+
   return {
     hash: transaction.transaction.hash().toString('hex'),
     isMinersFee: transaction.transaction.isMinersFee(),
@@ -42,5 +51,6 @@ export function serializeRpcAccountTransaction(
     burnsCount: transaction.transaction.burns.length,
     expiration: transaction.transaction.expiration(),
     timestamp: transaction.timestamp.getTime(),
+    assetBalanceDeltas: assetBalanceDeltasJSON,
   }
 }


### PR DESCRIPTION
## Summary

the transactionValue stored in the walletDb now includes a mapping from assetId to the balance delta for that account and asset in the transaction. this allows us to return transaction amounts in our RPC responses and display them in the CLI.

serializes assetBalanceDeltas as a JSON string because yup does not support map types.

only includes the balance delta for IRON in the CLI output table. we can show balance deltas for all assets in a transaction more easily in the output for a single transaction in wallet:transaction

## Testing Plan

<img width="1287" alt="image" src="https://user-images.githubusercontent.com/57735705/212208375-a04b07e0-a7a7-4775-a96d-152edc2810c3.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
