### PR TITLE
replaces 'x' with blank space in transactions cli

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -57,14 +57,14 @@ export class TransactionsCommand extends IronfishCommand {
           },
           creator: {
             header: 'Creator',
-            get: (transaction) => (transaction.creator ? `✔` : `x`),
+            get: (transaction) => (transaction.creator ? `✔` : ``),
           },
           hash: {
             header: 'Hash',
           },
           isMinersFee: {
             header: 'Miner Fee',
-            get: (transaction) => (transaction.isMinersFee ? `✔` : `x`),
+            get: (transaction) => (transaction.isMinersFee ? `✔` : ``),
           },
           fee: {
             header: 'Fee ($IRON)',


### PR DESCRIPTION
## Summary

displays a check mark in the 'Creator' and 'Miner Fee' columns if those conditions are true, but a blank space otherwise.

## Testing Plan
Before:
<img width="1234" alt="image" src="https://user-images.githubusercontent.com/57735705/212385463-b460578b-e03e-47ac-b03c-287b87613faf.png">


After:
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/57735705/212385348-22062d54-adfe-4c4a-8a34-6088a78483c1.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
