### PR TITLE
feat(cli): Add asset selector for `wallet:send`

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@oclif/test": "2.1.0",
     "@types/blessed": "0.1.17",
+    "@types/inquirer": "8.2.5",
     "@types/node": "18.11.16",
     "@types/tar": "6.1.1",
     "@types/ws": "7.4.5",
@@ -67,6 +68,7 @@
     "blessed": "0.1.81",
     "blru": "0.1.6",
     "buffer-map": "0.0.7",
+    "inquirer": "8.2.5",
     "json-colorizer": "2.2.2",
     "segfault-handler": "1.3.0",
     "supports-hyperlinks": "2.2.0",

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -1,8 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils, isValidPublicAddress } from '@ironfish/sdk'
+import { Asset } from '@ironfish/rust-nodejs'
+import { BufferUtils, CurrencyUtils, isValidPublicAddress, RpcClient } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
+import inquirer from 'inquirer'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { ProgressBar } from '../../types'
@@ -63,6 +65,7 @@ export class Send extends IronfishCommand {
     const { flags } = await this.parse(Send)
     let amount = null
     let fee = null
+    let assetId = null
     let to = flags.to?.trim()
     let from = flags.account?.trim()
     const expiration = flags.expiration
@@ -78,11 +81,21 @@ export class Send extends IronfishCommand {
       this.exit(1)
     }
 
+    if (flags.assetId) {
+      assetId = flags.assetId
+    }
+
+    if (assetId === null) {
+      assetId = await this.selectAsset(client, from)
+    }
+
+    if (!assetId) {
+      assetId = Asset.nativeId().toString('hex')
+    }
+
     if (flags.amount) {
       amount = CurrencyUtils.decodeIron(flags.amount)
     }
-
-    const assetId = flags.assetId
 
     if (amount === null) {
       const response = await client.getAccountBalance({ account: from, assetId })
@@ -264,5 +277,45 @@ Find the transaction on https://explorer.ironfish.network/transaction/${
       }
       this.exit(2)
     }
+  }
+
+  async selectAsset(
+    client: RpcClient,
+    account: string | undefined,
+  ): Promise<string | undefined> {
+    const balancesResponse = await client.getAccountBalances({ account })
+    const assetOptions = []
+
+    // Get the asset name from the chain DB to populate the display choices
+    for (const { assetId } of balancesResponse.content.balances) {
+      const assetResponse = await client.getAsset({ id: assetId })
+
+      if (assetResponse.content.name) {
+        const displayName = BufferUtils.toHuman(Buffer.from(assetResponse.content.name, 'hex'))
+        assetOptions.push({
+          value: assetId,
+          name: `${assetId} (${displayName})`,
+        })
+      }
+    }
+
+    let assetId
+
+    if (balancesResponse.content.balances.length === 1) {
+      // If there's only one available asset, showing the choices is unnecessary
+      assetId = balancesResponse.content.balances[0].assetId
+    } else if (balancesResponse.content.balances.length > 1) {
+      const response: { assetId: string } = await inquirer.prompt<{ assetId: string }>([
+        {
+          name: 'assetId',
+          message: 'Select the asset you wish to send',
+          type: 'list',
+          choices: assetOptions,
+        },
+      ])
+      assetId = response.assetId
+    }
+
+    return assetId
   }
 }

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -286,6 +286,14 @@ Find the transaction on https://explorer.ironfish.network/transaction/${
     const balancesResponse = await client.getAccountBalances({ account })
     const assetOptions = []
 
+    const balances = balancesResponse.content.balances
+    if (balances.length === 0) {
+      return undefined
+    } else if (balances.length === 1) {
+      // If there's only one available asset, showing the choices is unnecessary
+      return balancesResponse.content.balances[0].assetId
+    }
+
     // Get the asset name from the chain DB to populate the display choices
     for (const { assetId } of balancesResponse.content.balances) {
       const assetResponse = await client.getAsset({ id: assetId })
@@ -299,23 +307,14 @@ Find the transaction on https://explorer.ironfish.network/transaction/${
       }
     }
 
-    let assetId
-
-    if (balancesResponse.content.balances.length === 1) {
-      // If there's only one available asset, showing the choices is unnecessary
-      assetId = balancesResponse.content.balances[0].assetId
-    } else if (balancesResponse.content.balances.length > 1) {
-      const response: { assetId: string } = await inquirer.prompt<{ assetId: string }>([
-        {
-          name: 'assetId',
-          message: 'Select the asset you wish to send',
-          type: 'list',
-          choices: assetOptions,
-        },
-      ])
-      assetId = response.assetId
-    }
-
-    return assetId
+    const response: { assetId: string } = await inquirer.prompt<{ assetId: string }>([
+      {
+        name: 'assetId',
+        message: 'Select the asset you wish to send',
+        type: 'list',
+        choices: assetOptions,
+      },
+    ])
+    return response.assetId
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3908,6 +3908,13 @@
   resolved "https://registry.yarnpkg.com/@types/imurmurhash/-/imurmurhash-0.1.1.tgz#9dd1135b18af3191e29f0a6ae14cc18b200003ea"
   integrity sha512-ThbETc7uxx6rIpNP0fE3bqrSSIeBWPrFY4TzY4WFsvdQYWinub+PLZV/9nT3zicRJJPWbmHqJIsHZHeh5Ad+Ug==
 
+"@types/inquirer@8.2.5":
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-8.2.5.tgz#c508423bcc11126db278170ab07347783ac2300c"
+  integrity sha512-QXlzybid60YtAwfgG3cpykptRYUx2KomzNutMlWsQC64J/WG/gQSl+P4w7A21sGN0VIxRVava4rgnT7FQmFCdg==
+  dependencies:
+    "@types/through" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -4055,6 +4062,13 @@
   integrity sha512-8mto3YZfVpqB1CHMaYz1TUYIQfZFbh/QbEq5Hsn6D0ilCfqRVCdalmc89B7vi3jhl9UYIk+dWDABShNfOkv5HA==
   dependencies:
     "@types/minipass" "*"
+    "@types/node" "*"
+
+"@types/through@*":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.30.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
+  integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
+  dependencies:
     "@types/node" "*"
 
 "@types/uuid@^8.0.1":
@@ -6752,7 +6766,7 @@ grouped-queue@^2.0.0:
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
-  integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+  integrity sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==
 
 handlebars@4.7.7, handlebars@^4.7.6:
   version "4.7.7"
@@ -7040,30 +7054,10 @@ init-package-json@^3.0.2:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^4.0.0"
 
-inquirer@^8.0.0:
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.1.tgz#e00022e3e8930a92662f760f020686530a84671d"
-  integrity sha512-pxhBaw9cyTFMjwKtkjePWDhvwzvrNGAw7En4hottzlPvz80GZaMZthdDU35aA6/f5FRZf3uhE057q8w1DE3V2g==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^4.1.1"
-    cli-cursor "^3.1.0"
-    cli-width "^3.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.21"
-    mute-stream "0.0.8"
-    ora "^5.4.1"
-    run-async "^2.4.0"
-    rxjs "^7.5.5"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    through "^2.3.6"
-
-inquirer@^8.2.4:
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.4.tgz#ddbfe86ca2f67649a67daa6f1051c128f684f0b4"
-  integrity sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==
+inquirer@8.2.5, inquirer@^8.0.0, inquirer@^8.2.4:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
+  integrity sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==
   dependencies:
     ansi-escapes "^4.2.1"
     chalk "^4.1.1"


### PR DESCRIPTION
## Summary

Per the [oclif docs](https://oclif.io/docs/prompting#inquirer), they recommend the `inquirer` lib for this. We also had it installed already as a transitive dependency.

Since we're adding this new functionality: we should use this `inquirer` selector any time we have a known, finite list of things to select from. It's a huge improvement over making the user go look up the information out-of-band and then look up the flag to pass into the CLI.

![Screen Recording 2023-01-13 at 10 30 31 AM](https://user-images.githubusercontent.com/97762857/212385733-435082c2-4027-4553-abc8-2e5c03975b1c.gif)

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
