### PR TITLE
Make metadata an optional field in minting, else default to empty string

### DIFF
--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -82,11 +82,11 @@ router.register<typeof MintAssetRequestSchema, MintAssetResponse>(
     } else {
       Assert.isNotUndefined(
         request.data.name,
-        'Must provide metadata and name or identifier to mint',
+        'Must provide name or identifier to mint',
       )
 
       const metadata: string = request.data.metadata ?? ''
-      
+
       options = {
         expiration: request.data.expiration,
         fee,

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -80,10 +80,7 @@ router.register<typeof MintAssetRequestSchema, MintAssetResponse>(
         value,
       }
     } else {
-      Assert.isNotUndefined(
-        request.data.name,
-        'Must provide name or identifier to mint',
-      )
+      Assert.isNotUndefined(request.data.name, 'Must provide name or identifier to mint')
 
       const metadata: string = request.data.metadata ?? ''
 

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -81,18 +81,16 @@ router.register<typeof MintAssetRequestSchema, MintAssetResponse>(
       }
     } else {
       Assert.isNotUndefined(
-        request.data.metadata,
-        'Must provide metadata and name or identifier to mint',
-      )
-      Assert.isNotUndefined(
         request.data.name,
         'Must provide metadata and name or identifier to mint',
       )
 
+      const metadata: string = request.data.metadata ?? ''
+      
       options = {
         expiration: request.data.expiration,
         fee,
-        metadata: request.data.metadata,
+        metadata: metadata,
         name: request.data.name,
         transactionExpirationDelta,
         value,


### PR DESCRIPTION
## Summary
This PR proposes to change the wallet:mint rpc endpoint to allow empty metadata arguments. If no metadata is provided, the rpc endpoint will use an empty string.

## Testing Plan
Open to suggestions. `yarn test` passes but this behavior isn't explicitly tested.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
