### PR TITLE
fixes webApi URL for /deposits/address

### DIFF
--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -70,7 +70,7 @@ export class WebApi {
   }
 
   async getMultiAssetAddress(): Promise<string> {
-    const response = await axios.get<{ address: string }>(`${this.host}/deposit/address`)
+    const response = await axios.get<{ address: string }>(`${this.host}/deposits/address`)
     return response.data.address
   }
 


### PR DESCRIPTION
## Summary

adds a missing 's': `deposit` -> `deposits`

## Testing Plan

https://api.ironfish.network/deposits/address

vs.

https://api.ironfish.network/deposit/address

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
