### PR TITLE
adds asset name, id to notes in wallet:transaction output

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -64,8 +64,14 @@ export class TransactionCommand extends IronfishCommand {
           get: (note) => (note.owner ? `✔` : `x`),
         },
         amount: {
-          header: 'Amount ($IRON)',
+          header: 'Amount',
           get: (note) => CurrencyUtils.renderIron(note.value),
+        },
+        assetName: {
+          header: 'Asset Name',
+        },
+        assetId: {
+          header: 'Asset Id',
         },
         isSpent: {
           header: 'Spent',

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -53,6 +53,8 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
                 .object({
                   owner: yup.boolean().defined(),
                   value: yup.string().defined(),
+                  assetId: yup.string().defined(),
+                  assetName: yup.string().defined(),
                   sender: yup.string().defined(),
                   memo: yup.string().trim().defined(),
                   spent: yup.boolean(),
@@ -98,10 +100,14 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
         ? decryptedNoteForOwner.note
         : new Note(decryptedNote.serializedNote)
 
+      const asset = await node.chain.getAssetById(note.assetId())
+
       serializedNotes.push({
         owner,
         memo: note.memo(),
         value: CurrencyUtils.encode(note.value()),
+        assetId: note.assetId().toString('hex'),
+        assetName: asset?.name.toString('utf8') || '',
         sender: note.sender(),
         spent: spent,
       })

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -20,6 +20,8 @@ export type RpcAccountTransaction = {
 export type RpcAccountDecryptedNote = {
   owner: boolean
   value: string
+  assetId: string
+  assetName: string
   memo: string
   sender: string
   spent: boolean


### PR DESCRIPTION
## Summary

updates the table of output notes to include the asset name and id for each note.

## Testing Plan

<img width="752" alt="image" src="https://user-images.githubusercontent.com/57735705/212434414-cb237f4f-515d-46c8-ba43-edc550943c1c.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
