### PR TITLE
sends buffers as buffers over wallet transaction rpc endpoints

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -48,7 +48,9 @@ export class TransactionCommand extends IronfishCommand {
     this.log(`Miner Fee: ${response.content.transaction.isMinersFee ? `✔` : `x`}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(response.content.transaction.fee, true)}`)
     if (response.content.transaction.blockHash && response.content.transaction.blockSequence) {
-      this.log(`Block Hash: ${Buffer.from(response.content.transaction.blockHash).toString('hex')}`)
+      this.log(
+        `Block Hash: ${Buffer.from(response.content.transaction.blockHash).toString('hex')}`,
+      )
       this.log(`Block Sequence: ${response.content.transaction.blockSequence}`)
     }
     this.log(`Spends Count: ${response.content.transaction.spendsCount}`)

--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils } from '@ironfish/sdk'
+import { BufferUtils, CurrencyUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -48,7 +48,7 @@ export class TransactionCommand extends IronfishCommand {
     this.log(`Miner Fee: ${response.content.transaction.isMinersFee ? `✔` : `x`}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(response.content.transaction.fee, true)}`)
     if (response.content.transaction.blockHash && response.content.transaction.blockSequence) {
-      this.log(`Block Hash: ${response.content.transaction.blockHash}`)
+      this.log(`Block Hash: ${Buffer.from(response.content.transaction.blockHash).toString('hex')}`)
       this.log(`Block Sequence: ${response.content.transaction.blockSequence}`)
     }
     this.log(`Spends Count: ${response.content.transaction.spendsCount}`)
@@ -69,9 +69,11 @@ export class TransactionCommand extends IronfishCommand {
         },
         assetName: {
           header: 'Asset Name',
+          get: (note) => BufferUtils.toHuman(Buffer.from(note.assetName)),
         },
         assetId: {
           header: 'Asset Id',
+          get: (note) => Buffer.from(note.assetId).toString('hex'),
         },
         isSpent: {
           header: 'Spent',

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -65,6 +65,7 @@ export class TransactionsCommand extends IronfishCommand {
           },
           hash: {
             header: 'Hash',
+            get: (transaction) => Buffer.from(transaction.hash).toString('hex')
           },
           isMinersFee: {
             header: 'Miner Fee',

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -65,7 +65,7 @@ export class TransactionsCommand extends IronfishCommand {
           },
           hash: {
             header: 'Hash',
-            get: (transaction) => Buffer.from(transaction.hash).toString('hex')
+            get: (transaction) => Buffer.from(transaction.hash).toString('hex'),
           },
           isMinersFee: {
             header: 'Miner Fee',

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -13,11 +13,11 @@ export type GetAccountTransactionRequest = { account?: string; hash: string }
 export type GetAccountTransactionResponse = {
   account: string
   transaction: {
-    hash: string
+    hash: Buffer
     status: string
     isMinersFee: boolean
     fee: string
-    blockHash?: string
+    blockHash?: Buffer
     blockSequence?: number
     notesCount: number
     spendsCount: number
@@ -39,11 +39,11 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
       account: yup.string().defined(),
       transaction: yup
         .object({
-          hash: yup.string().required(),
+          hash: yup.mixed<Buffer>().required(),
           status: yup.string().defined(),
           isMinersFee: yup.boolean().defined(),
           fee: yup.string().defined(),
-          blockHash: yup.string().optional(),
+          blockHash: yup.mixed<Buffer>().optional(),
           blockSequence: yup.number().optional(),
           notesCount: yup.number().defined(),
           spendsCount: yup.number().defined(),
@@ -53,8 +53,8 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
                 .object({
                   owner: yup.boolean().defined(),
                   value: yup.string().defined(),
-                  assetId: yup.string().defined(),
-                  assetName: yup.string().defined(),
+                  assetId: yup.mixed<Buffer>().defined(),
+                  assetName: yup.mixed<Buffer>().defined(),
                   sender: yup.string().defined(),
                   memo: yup.string().trim().defined(),
                   spent: yup.boolean(),
@@ -106,8 +106,8 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
         owner,
         memo: note.memo(),
         value: CurrencyUtils.encode(note.value()),
-        assetId: note.assetId().toString('hex'),
-        assetName: asset?.name.toString('utf8') || '',
+        assetId: note.assetId(),
+        assetName: asset?.name || Buffer.alloc(0),
         sender: note.sender(),
         spent: spent,
       })

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -20,7 +20,7 @@ export type GetAccountTransactionsRequest = {
 export type GetAccountTransactionsResponse = {
   creator: boolean
   status: string
-  hash: string
+  hash: Buffer
   isMinersFee: boolean
   fee: string
   notesCount: number
@@ -46,7 +46,7 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
     .object({
       creator: yup.boolean().defined(),
       status: yup.string().defined(),
-      hash: yup.string().defined(),
+      hash: yup.mixed<Buffer>().defined(),
       isMinersFee: yup.boolean().defined(),
       fee: yup.string().defined(),
       notesCount: yup.number().defined(),

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -4,10 +4,10 @@
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 
 export type RpcAccountTransaction = {
-  hash: string
+  hash: Buffer
   isMinersFee: boolean
   fee: string
-  blockHash?: string
+  blockHash?: Buffer
   blockSequence?: number
   notesCount: number
   spendsCount: number
@@ -20,8 +20,8 @@ export type RpcAccountTransaction = {
 export type RpcAccountDecryptedNote = {
   owner: boolean
   value: string
-  assetId: string
-  assetName: string
+  assetId: Buffer
+  assetName: Buffer
   memo: string
   sender: string
   spent: boolean
@@ -31,10 +31,10 @@ export function serializeRpcAccountTransaction(
   transaction: TransactionValue,
 ): RpcAccountTransaction {
   return {
-    hash: transaction.transaction.hash().toString('hex'),
+    hash: transaction.transaction.hash(),
     isMinersFee: transaction.transaction.isMinersFee(),
     fee: transaction.transaction.fee().toString(),
-    blockHash: transaction.blockHash?.toString('hex'),
+    blockHash: transaction.blockHash ?? undefined,
     blockSequence: transaction.sequence ?? undefined,
     notesCount: transaction.transaction.notes.length,
     spendsCount: transaction.transaction.spends.length,


### PR DESCRIPTION
## Summary

instead of serializing buffers like transaction hashes, block hashes, and asset ids to strings before sending them in rpc responses we can keep the data as buffers (bytes) and render them as strings on the client side.

- changes transaction hash, block hash, asset id, and asset name to buffers in getTransaction and getTransactions
- parses buffers and converts to string on client side
- uses toHuman instead of utf-8 for asset names

## Testing Plan

ran `wallet:transaction` and `wallet:transactions` locally to verify that output was unchanged

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
