### PR TITLE
Display asset deltas when calling wallet:transaction

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -91,6 +91,6 @@ export class TransactionCommand extends IronfishCommand {
     )
     assetBalanceDeltas.forEach((delta: string, assetId: string) => {
       this.log(`Delta is ${delta} for asset ${assetId}`)
-    });
+    })
   }
 }

--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -86,11 +86,16 @@ export class TransactionCommand extends IronfishCommand {
       })
     }
 
-    const assetBalanceDeltas: Map<string, string> = new Map(
-      Object.entries(JSON.parse(response.content.transaction.assetBalanceDeltas)),
-    )
-    assetBalanceDeltas.forEach((delta: string, assetId: string) => {
-      this.log(`Delta is ${delta} for asset ${assetId}`)
-    })
+    if (response.content.transaction.assetBalanceDeltas.length > 0) {
+      this.log(`---Asset Balance Deltas---\n`)
+      CliUx.ux.table(response.content.transaction.assetBalanceDeltas, {
+        assetId: {
+          header: 'Asset ID',
+        },
+        delta: {
+          header: 'Delta',
+        },
+      })
+    }
   }
 }

--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -85,5 +85,12 @@ export class TransactionCommand extends IronfishCommand {
         },
       })
     }
+
+    const assetBalanceDeltas: Map<string, string> = new Map(
+      Object.entries(JSON.parse(response.content.transaction.assetBalanceDeltas)),
+    )
+    assetBalanceDeltas.forEach((delta: string, assetId: string) => {
+      this.log(`Delta is ${delta} for asset ${assetId}`)
+    });
   }
 }

--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -93,7 +93,7 @@ export class TransactionCommand extends IronfishCommand {
           header: 'Asset ID',
         },
         delta: {
-          header: 'Delta',
+          header: 'Balance Change',
         },
       })
     }

--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -86,7 +86,7 @@ export class TransactionCommand extends IronfishCommand {
       })
     }
 
-    if (response.content.transaction.assetBalanceDeltas.length > 0) {
+    if (response.content.transaction.assetBalanceDeltas) {
       this.log(`---Asset Balance Deltas---\n`)
       CliUx.ux.table(response.content.transaction.assetBalanceDeltas, {
         assetId: {

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -83,7 +83,7 @@ export class TransactionsCommand extends IronfishCommand {
           },
           amount: {
             header: 'Amount ($IRON)',
-            get: (_) => CurrencyUtils.renderIron(amount),
+            get: (_) => CurrencyUtils.renderIron(ironDelta),
             minWidth: 20,
           },
           fee: {

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -83,7 +83,7 @@ export class TransactionsCommand extends IronfishCommand {
           },
           amount: {
             header: 'Amount ($IRON)',
-            get: (_) => CurrencyUtils.renderIron(ironDelta),
+            get: (_) => (ironDelta ? CurrencyUtils.renderIron(ironDelta.delta) : '0'),
             minWidth: 20,
           },
           fee: {

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -81,11 +81,6 @@ export class TransactionsCommand extends IronfishCommand {
             get: (_) => (ironDelta ? CurrencyUtils.renderIron(ironDelta.delta) : '0'),
             minWidth: 20,
           },
-          amount: {
-            header: 'Amount ($IRON)',
-            get: (_) => (ironDelta ? CurrencyUtils.renderIron(ironDelta.delta) : '0'),
-            minWidth: 20,
-          },
           fee: {
             header: 'Fee ($IRON)',
             get: (transaction) => CurrencyUtils.renderIron(transaction.fee),

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -76,11 +76,6 @@ export class TransactionsCommand extends IronfishCommand {
             get: (_) => (ironDelta ? CurrencyUtils.renderIron(ironDelta.delta) : '0'),
             minWidth: 20,
           },
-          amount: {
-            header: 'Amount ($IRON)',
-            get: (_) => (ironDelta ? CurrencyUtils.renderIron(ironDelta.delta) : '0'),
-            minWidth: 20,
-          },
           fee: {
             header: 'Fee ($IRON)',
             get: (transaction) => CurrencyUtils.renderIron(transaction.fee),

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -81,6 +81,11 @@ export class TransactionsCommand extends IronfishCommand {
             get: (_) => CurrencyUtils.renderIron(amount),
             minWidth: 20,
           },
+          amount: {
+            header: 'Amount ($IRON)',
+            get: (_) => CurrencyUtils.renderIron(amount),
+            minWidth: 20,
+          },
           fee: {
             header: 'Fee ($IRON)',
             get: (transaction) => CurrencyUtils.renderIron(transaction.fee),

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -76,6 +76,11 @@ export class TransactionsCommand extends IronfishCommand {
             get: (_) => (ironDelta ? CurrencyUtils.renderIron(ironDelta.delta) : '0'),
             minWidth: 20,
           },
+          amount: {
+            header: 'Amount ($IRON)',
+            get: (_) => CurrencyUtils.renderIron(amount),
+            minWidth: 20,
+          },
           fee: {
             header: 'Fee ($IRON)',
             get: (transaction) => CurrencyUtils.renderIron(transaction.fee),

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -78,7 +78,7 @@ export class TransactionsCommand extends IronfishCommand {
           },
           amount: {
             header: 'Amount ($IRON)',
-            get: (_) => CurrencyUtils.renderIron(amount),
+            get: (_) => (ironDelta ? CurrencyUtils.renderIron(ironDelta.delta) : '0'),
             minWidth: 20,
           },
           amount: {

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -25,6 +25,7 @@ export type GetAccountTransactionResponse = {
     burnsCount: number
     timestamp: number
     notes: RpcAccountDecryptedNote[]
+    assetBalanceDeltas: string
   } | null
 }
 
@@ -68,6 +69,7 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
                 .defined(),
             )
             .defined(),
+          assetBalanceDeltas: yup.string().defined(),
         })
         .defined(),
     })

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -25,7 +25,7 @@ export type GetAccountTransactionResponse = {
     burnsCount: number
     timestamp: number
     notes: RpcAccountDecryptedNote[]
-    assetBalanceDeltas: string
+    assetBalanceDeltas: Array<{ assetId: string; delta: string }>
   } | null
 }
 
@@ -69,7 +69,16 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
                 .defined(),
             )
             .defined(),
-          assetBalanceDeltas: yup.string().defined(),
+          assetBalanceDeltas: yup
+            .array(
+              yup
+                .object({
+                  assetId: yup.string().defined(),
+                  delta: yup.string().defined(),
+                })
+                .defined(),
+            )
+            .defined(),
         })
         .defined(),
     })


### PR DESCRIPTION
## Summary
Builds off of #2907 to dump all asset deltas when inspecting a single transaction.
Looking for input as to whether this is correct & whether this is the desired UX. 

## Testing
<img width="815" alt="Screen Shot 2023-01-17 at 4 04 16 PM" src="https://user-images.githubusercontent.com/5766842/213012099-b8f3febf-344b-4d9d-b1d6-0865fdeef2d9.png">
 Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
