### PR TITLE
adds timestamp to wallet:transaction

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -45,6 +45,7 @@ export class TransactionCommand extends IronfishCommand {
     this.log(`Transaction: ${hash}`)
     this.log(`Account: ${response.content.account}`)
     this.log(`Status: ${response.content.transaction.status}`)
+    this.log(`Timestamp: ${new Date(response.content.transaction.timestamp).toLocaleString()}`)
     this.log(`Miner Fee: ${response.content.transaction.isMinersFee ? `✔` : `x`}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(response.content.transaction.fee, true)}`)
     if (response.content.transaction.blockHash && response.content.transaction.blockSequence) {

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -21,6 +21,7 @@ export type GetAccountTransactionResponse = {
     blockSequence?: number
     notesCount: number
     spendsCount: number
+    timestamp: number
     notes: RpcAccountDecryptedNote[]
   } | null
 }
@@ -47,6 +48,7 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
           blockSequence: yup.number().optional(),
           notesCount: yup.number().defined(),
           spendsCount: yup.number().defined(),
+          timestamp: yup.number().defined(),
           notes: yup
             .array(
               yup


### PR DESCRIPTION
## Summary

adds the stored transaction timestamp to the RPC response and CLI output of the wallet:transaction command

timestamp is the time that the transaction was first seen by the wallet

## Testing Plan

<img width="627" alt="image" src="https://user-images.githubusercontent.com/57735705/212974199-6c8bf70e-a4b4-46c3-9991-71c298e73466.png">

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
