### PR TITLE
adds mints count and burns count to wallet:transaction

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -52,8 +52,10 @@ export class TransactionCommand extends IronfishCommand {
       this.log(`Block Hash: ${response.content.transaction.blockHash}`)
       this.log(`Block Sequence: ${response.content.transaction.blockSequence}`)
     }
-    this.log(`Spends Count: ${response.content.transaction.spendsCount}`)
     this.log(`Notes Count: ${response.content.transaction.notesCount}`)
+    this.log(`Spends Count: ${response.content.transaction.spendsCount}`)
+    this.log(`Mints Count: ${response.content.transaction.mintsCount}`)
+    this.log(`Burns Count: ${response.content.transaction.burnsCount}`)
     this.log(`Sender: ${response.content.transaction.notes[0].sender}`)
 
     if (response.content.transaction.notes.length > 0) {

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -21,6 +21,8 @@ export type GetAccountTransactionResponse = {
     blockSequence?: number
     notesCount: number
     spendsCount: number
+    mintsCount: number
+    burnsCount: number
     timestamp: number
     notes: RpcAccountDecryptedNote[]
   } | null
@@ -48,6 +50,8 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
           blockSequence: yup.number().optional(),
           notesCount: yup.number().defined(),
           spendsCount: yup.number().defined(),
+          mintsCount: yup.number().defined(),
+          burnsCount: yup.number().defined(),
           timestamp: yup.number().defined(),
           notes: yup
             .array(


### PR DESCRIPTION
## Summary

adds mintsCount and burnsCount to getTransaction RPC response and wallet:transactions CLI output

reorders notesCount and spendsCount to be consistent with ordering in wallet:transactions

## Testing Plan
<img width="760" alt="image" src="https://user-images.githubusercontent.com/57735705/212976346-41ab6d1a-c2df-4551-8cdd-b14894d09e57.png">

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
