### PR TITLE
adds short timezones, eg 'PST', to timestamp output

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -45,7 +45,11 @@ export class TransactionCommand extends IronfishCommand {
     this.log(`Transaction: ${hash}`)
     this.log(`Account: ${response.content.account}`)
     this.log(`Status: ${response.content.transaction.status}`)
-    this.log(`Timestamp: ${new Date(response.content.transaction.timestamp).toLocaleString()}`)
+    this.log(
+      `Timestamp: ${new Date(response.content.transaction.timestamp).toLocaleString(undefined, {
+        timeZoneName: 'short',
+      })}`,
+    )
     this.log(`Miner Fee: ${response.content.transaction.isMinersFee ? `✔` : `x`}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(response.content.transaction.fee, true)}`)
     if (response.content.transaction.blockHash && response.content.transaction.blockSequence) {

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -53,7 +53,10 @@ export class TransactionsCommand extends IronfishCommand {
         {
           timestamp: {
             header: 'Timestamp',
-            get: (transaction) => new Date(transaction.timestamp).toLocaleString(),
+            get: (transaction) =>
+              new Date(transaction.timestamp).toLocaleString(undefined, {
+                timeZoneName: 'short',
+              }),
           },
           status: {
             header: 'Status',


### PR DESCRIPTION
## Summary

transaction CLI output includes the localized timezone, but doesn't indicate what timezone the timestamp is in.

uses short format, e.g., 'PST' or 'GMT-8'.

## Testing Plan

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/57735705/212980231-18679e3f-8a2b-4c03-9d4b-d8a16239b3a3.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
