### PR TITLE
Show timezones for all CLI timestamps

### DIFF
--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { GetPeerMessagesResponse, GetPeerResponse } from '@ironfish/sdk'
+import { GetPeerMessagesResponse, GetPeerResponse, TimeUtils } from '@ironfish/sdk'
 import colors from 'colors/safe'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -57,7 +57,7 @@ export class ShowCommand extends IronfishCommand {
   }
 
   renderMessage(message: GetPeerMessagesResponseMessages): string {
-    const time = new Date(message.timestamp).toLocaleTimeString()
+    const time = TimeUtils.renderTime(message.timestamp)
     const direction = colors.yellow(message.direction === 'send' ? 'SEND' : 'RECV')
     const type = message.brokeringPeerDisplayName
       ? `(broker: ${message.brokeringPeerDisplayName}) ${message.type}`

--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils } from '@ironfish/sdk'
+import { CurrencyUtils, TimeUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -45,7 +45,7 @@ export class TransactionCommand extends IronfishCommand {
     this.log(`Transaction: ${hash}`)
     this.log(`Account: ${response.content.account}`)
     this.log(`Status: ${response.content.transaction.status}`)
-    this.log(`Timestamp: ${new Date(response.content.transaction.timestamp).toLocaleString()}`)
+    this.log(`Timestamp: ${TimeUtils.renderString(response.content.transaction.timestamp)}`)
     this.log(`Miner Fee: ${response.content.transaction.isMinersFee ? `✔` : `x`}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(response.content.transaction.fee, true)}`)
     if (response.content.transaction.blockHash && response.content.transaction.blockSequence) {

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils } from '@ironfish/sdk'
+import { CurrencyUtils, TimeUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -53,7 +53,7 @@ export class TransactionsCommand extends IronfishCommand {
         {
           timestamp: {
             header: 'Timestamp',
-            get: (transaction) => new Date(transaction.timestamp).toLocaleString(),
+            get: (transaction) => TimeUtils.renderDate(transaction.timestamp),
           },
           status: {
             header: 'Status',

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -53,7 +53,7 @@ export class TransactionsCommand extends IronfishCommand {
         {
           timestamp: {
             header: 'Timestamp',
-            get: (transaction) => TimeUtils.renderDate(transaction.timestamp),
+            get: (transaction) => TimeUtils.renderString(transaction.timestamp),
           },
           status: {
             header: 'Status',

--- a/ironfish/src/utils/time.ts
+++ b/ironfish/src/utils/time.ts
@@ -90,4 +90,32 @@ const renderSpan = (
   return parts.join(' ')
 }
 
-export const TimeUtils = { renderEstimate, renderSpan }
+/**
+ * Render a timestamp in human formatting for the users local timezone
+ */
+const renderString = (timestamp: number): string => {
+  const date = new Date(timestamp).toLocaleDateString(undefined)
+  const time = new Date(timestamp).toLocaleTimeString(undefined, { timeZoneName: 'short' })
+  return `${date} ${time}`
+}
+
+/**
+ * Render a timestamp's date in human formatting for the users local timezone
+ */
+const renderDate = (timestamp: number): string => {
+  const date = new Date(timestamp).toLocaleDateString(undefined)
+  const timezone = getTimezoneCode()
+  return `${date} ${timezone}`
+}
+
+/**
+ * Render a timestamp's time in human formatting for the users local timezone
+ */
+const renderTime = (timestamp: number): string => {
+  return new Date(timestamp).toLocaleTimeString(undefined, { timeZoneName: 'short' })
+}
+
+const getTimezoneCode = (): string => {
+  return new Date().toLocaleTimeString('en-us', { timeZoneName: 'short' }).split(' ')[2]
+}
+export const TimeUtils = { renderEstimate, renderSpan, renderString, renderDate, renderTime }

--- a/ironfish/src/utils/time.ts
+++ b/ironfish/src/utils/time.ts
@@ -102,20 +102,33 @@ const renderString = (timestamp: number): string => {
 /**
  * Render a timestamp's date in human formatting for the users local timezone
  */
-const renderDate = (timestamp: number): string => {
-  const date = new Date(timestamp).toLocaleDateString(undefined)
-  const timezone = getTimezoneCode()
+const renderDate = (timestamp: number, locale?: string): string => {
+  const date = new Date(timestamp).toLocaleDateString(locale)
+  const timezone = getTimezoneCode(locale)
   return `${date} ${timezone}`
 }
 
 /**
  * Render a timestamp's time in human formatting for the users local timezone
  */
-const renderTime = (timestamp: number): string => {
-  return new Date(timestamp).toLocaleTimeString(undefined, { timeZoneName: 'short' })
+const renderTime = (timestamp: number, locale?: string): string => {
+  return new Date(timestamp).toLocaleTimeString(locale, { timeZoneName: 'short' })
 }
 
-const getTimezoneCode = (): string => {
-  return new Date().toLocaleTimeString('en-us', { timeZoneName: 'short' }).split(' ')[2]
+/**
+ * Get the timezone code such as EST, PDT
+ */
+const getTimezoneCode = (locale?: string): string => {
+  const date = new Date().toLocaleTimeString(locale, { timeZoneName: 'short' })
+  const parts = date.split(' ')
+  return parts[parts.length - 1] ?? ''
 }
-export const TimeUtils = { renderEstimate, renderSpan, renderString, renderDate, renderTime }
+
+export const TimeUtils = {
+  renderEstimate,
+  renderSpan,
+  renderString,
+  renderDate,
+  renderTime,
+  getTimezoneCode,
+}


### PR DESCRIPTION
## Summary

This adds a way to consistently render time in a human format across all of our CLI tools, and includes it in the SDK so other people can use our same time format.

**TimeUtils.renderDate()**
```bash
 Timestamp     Hash                                                            
 ───────────── ────────────────────────────────────────────────────────────────
 1/13/2023 EST 662fc308dc6ac9eb0a17595a2b107dc9574e2e3b8942bed19a5081c97086a072
```

**TimeUtils.renderTime()**
```bash
Timestamp      Hash                                                            
────────────── ────────────────────────────────────────────────────────────────
2:49:11 PM EST 662fc308dc6ac9eb0a17595a2b107dc9574e2e3b8942bed19a5081c97086a072
```

**TimeUtils.renderString()**
```bash
 Timestamp                Hash                                                            
 ──────────────────────── ────────────────────────────────────────────────────────────────
 1/13/2023 2:49:11 PM EST 662fc308dc6ac9eb0a17595a2b107dc9574e2e3b8942bed19a5081c97086a072
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
