### PR TITLE
replaces creator and isMinersFee with transaction type

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -45,8 +45,8 @@ export class TransactionCommand extends IronfishCommand {
     this.log(`Transaction: ${hash}`)
     this.log(`Account: ${response.content.account}`)
     this.log(`Status: ${response.content.transaction.status}`)
+    this.log(`Type: ${response.content.transaction.type}`)
     this.log(`Timestamp: ${TimeUtils.renderString(response.content.transaction.timestamp)}`)
-    this.log(`Miner Fee: ${response.content.transaction.isMinersFee ? `✔` : `x`}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(response.content.transaction.fee, true)}`)
     if (response.content.transaction.blockHash && response.content.transaction.blockSequence) {
       this.log(`Block Hash: ${response.content.transaction.blockHash}`)

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -64,16 +64,12 @@ export class TransactionsCommand extends IronfishCommand {
             header: 'Status',
             minWidth: 12,
           },
-          creator: {
-            header: 'Creator',
-            get: (transaction) => (transaction.creator ? `✔` : ``),
+          type: {
+            header: 'Type',
+            minWidth: 8,
           },
           hash: {
             header: 'Hash',
-          },
-          isMinersFee: {
-            header: 'Miner Fee',
-            get: (transaction) => (transaction.isMinersFee ? `✔` : ``),
           },
           amount: {
             header: 'Amount ($IRON)',

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -15,7 +15,7 @@ export type GetAccountTransactionResponse = {
   transaction: {
     hash: string
     status: string
-    isMinersFee: boolean
+    type: string
     fee: string
     blockHash?: string
     blockSequence?: number
@@ -44,7 +44,7 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
         .object({
           hash: yup.string().required(),
           status: yup.string().defined(),
-          isMinersFee: yup.boolean().defined(),
+          type: yup.string().defined(),
           fee: yup.string().defined(),
           blockHash: yup.string().optional(),
           blockSequence: yup.number().optional(),
@@ -122,11 +122,13 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
     const serializedTransaction = serializeRpcAccountTransaction(transaction)
 
     const status = await node.wallet.getTransactionStatus(account, transaction)
+    const type = await node.wallet.getTransactionType(account, transaction)
 
     const serialized = {
       ...serializedTransaction,
       notes: serializedNotes,
       status,
+      type,
     }
 
     request.end({

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -18,10 +18,9 @@ export type GetAccountTransactionsRequest = {
 }
 
 export type GetAccountTransactionsResponse = {
-  creator: boolean
   status: string
+  type: string
   hash: string
-  isMinersFee: boolean
   fee: string
   notesCount: number
   spendsCount: number
@@ -45,10 +44,9 @@ export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTra
 export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTransactionsResponse> =
   yup
     .object({
-      creator: yup.boolean().defined(),
       status: yup.string().defined(),
+      type: yup.string().defined(),
       hash: yup.string().defined(),
-      isMinersFee: yup.boolean().defined(),
       fee: yup.string().defined(),
       notesCount: yup.number().defined(),
       spendsCount: yup.number().defined(),
@@ -125,22 +123,13 @@ const streamTransaction = async (
 ): Promise<void> => {
   const serializedTransaction = serializeRpcAccountTransaction(transaction)
 
-  let creator = false
-  for (const spend of transaction.transaction.spends) {
-    const noteHash = await account.getNoteHash(spend.nullifier)
-
-    if (noteHash) {
-      creator = true
-      break
-    }
-  }
-
   const status = await node.wallet.getTransactionStatus(account, transaction, options)
+  const type = await node.wallet.getTransactionType(account, transaction)
 
   const serialized = {
     ...serializedTransaction,
-    creator,
     status,
+    type,
   }
 
   request.stream(serialized)

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -5,7 +5,6 @@ import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 
 export type RpcAccountTransaction = {
   hash: string
-  isMinersFee: boolean
   fee: string
   blockHash?: string
   blockSequence?: number
@@ -39,7 +38,6 @@ export function serializeRpcAccountTransaction(
 
   return {
     hash: transaction.transaction.hash().toString('hex'),
-    isMinersFee: transaction.transaction.isMinersFee(),
     fee: transaction.transaction.fee().toString(),
     blockHash: transaction.blockHash?.toString('hex'),
     blockSequence: transaction.sequence ?? undefined,


### PR DESCRIPTION
## Summary

defines TransactionType as one of miner, send, or receive.

a transaction has a miner type if it is a miner's fee transaction.

a transaction is a send if any of the spent notes belong to the account.

otherwise a transaction is a receive.

- adds TransactionType and getTransactionType to wallet
- replaces creator with type in getTransactions
- adds type to getTransaction
- removes isMinersFee from both endpoints
- updates CLI for wallet:transaction and wallet:transactions

## Testing Plan

<img width="1016" alt="image" src="https://user-images.githubusercontent.com/57735705/213010554-2dc78315-61f3-4631-a474-e38305950b9b.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
