### PR TITLE
Change NotEnoughFundsError to use CurrencyUtils.renderIron

### DIFF
--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { CurrencyUtils } from "../utils"
+
 export class NotEnoughFundsError extends Error {
   name = this.constructor.name
 
   constructor(assetId: Buffer, amount: bigint, amountNeeded: bigint) {
     super()
-    this.message = `Insufficient funds: Needed ${amountNeeded.toString()} but have ${amount.toString()} for asset '${assetId.toString(
-      'hex',
-    )}'`
+    this.message = `Insufficient funds: Needed ${CurrencyUtils.renderIron(amountNeeded.toString())} but have '${CurrencyUtils.renderIron(amount, true, assetId.toString('hex',))}'`
   }
 }

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -11,6 +11,8 @@ export class NotEnoughFundsError extends Error {
     super()
     this.message = `Insufficient funds: Needed ${CurrencyUtils.renderIron(
       amountNeeded,
-    )} but have '${CurrencyUtils.renderIron(amount, true, assetId.toString('hex'))}'`
+      true,
+      assetId.toString('hex'),
+    )} but have '${CurrencyUtils.renderIron(amount)}'`
   }
 }

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -10,7 +10,7 @@ export class NotEnoughFundsError extends Error {
   constructor(assetId: Buffer, amount: bigint, amountNeeded: bigint) {
     super()
     this.message = `Insufficient funds: Needed ${CurrencyUtils.renderIron(
-      amountNeeded.toString(),
+      amountNeeded,
     )} but have '${CurrencyUtils.renderIron(amount, true, assetId.toString('hex'))}'`
   }
 }

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -9,6 +9,6 @@ export class NotEnoughFundsError extends Error {
 
   constructor(assetId: Buffer, amount: bigint, amountNeeded: bigint) {
     super()
-    this.message = `Insufficient funds: Needed ${CurrencyUtils.renderIron(amountNeeded.toString())} but have '${CurrencyUtils.renderIron(amount, true, assetId.toString('hex',))}'`
+    this.message = `Insufficient funds: Needed ${CurrencyUtils.renderIron(amountNeeded.toString())} but have '${CurrencyUtils.renderIron(amount, true, assetId.toString('hex'))}'`
   }
 }

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -2,13 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { CurrencyUtils } from "../utils"
+import { CurrencyUtils } from '../utils'
 
 export class NotEnoughFundsError extends Error {
   name = this.constructor.name
 
   constructor(assetId: Buffer, amount: bigint, amountNeeded: bigint) {
     super()
-    this.message = `Insufficient funds: Needed ${CurrencyUtils.renderIron(amountNeeded.toString())} but have '${CurrencyUtils.renderIron(amount, true, assetId.toString('hex'))}'`
+    this.message = `Insufficient funds: Needed ${CurrencyUtils.renderIron(
+      amountNeeded.toString(),
+    )} but have '${CurrencyUtils.renderIron(amount, true, assetId.toString('hex'))}'`
   }
 }


### PR DESCRIPTION
## Summary
`NotEnoughFundsError` just dumps the raw ore amounts and assetID. Use `CurrencyUtils.renderIron` instead.

## Testing Plan
`yarn test` locally detected no errors.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
