### PR TITLE
changes RPC serialization of asset name to use hex

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils } from '@ironfish/sdk'
+import { BufferUtils, CurrencyUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -42,6 +42,7 @@ export class NotesCommand extends IronfishCommand {
           },
           assetName: {
             header: 'Asset Name',
+            get: (row) => BufferUtils.toHuman(Buffer.from(row.assetName, 'hex')),
           },
           assetId: {
             header: 'Asset Id',

--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils, TimeUtils } from '@ironfish/sdk'
+import { BufferUtils, CurrencyUtils, TimeUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -72,6 +72,7 @@ export class TransactionCommand extends IronfishCommand {
         },
         assetName: {
           header: 'Asset Name',
+          get: (note) => BufferUtils.toHuman(Buffer.from(note.assetName, 'hex')),
         },
         assetId: {
           header: 'Asset Id',

--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -58,7 +58,7 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
       request.stream({
         value: CurrencyUtils.encode(note.value()),
         assetId: note.assetId().toString('hex'),
-        assetName: asset?.name.toString('utf8') || '',
+        assetName: asset?.name.toString('hex') || '',
         memo: note.memo(),
         sender: note.sender(),
         transactionHash: transaction.transaction.hash().toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -124,7 +124,7 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
         memo: note.memo(),
         value: CurrencyUtils.encode(note.value()),
         assetId: note.assetId().toString('hex'),
-        assetName: asset?.name.toString('utf8') || '',
+        assetName: asset?.name.toString('hex') || '',
         sender: note.sender(),
         spent: spent,
       })


### PR DESCRIPTION
## Summary

instead of serializing the asset name using utf-8 before sending over RPC serializes asset name as a hex string, like all other buffers.

uses BufferUtils.toHuman to render the asset name on the client side.

## Testing Plan

ran `wallet:notes` and `wallet:transaction` to ensure that asset name is still rendered correctly

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
