### PR TITLE
fix(cli): Avoid prompt in mint if metadata or name provided

### DIFF
--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -78,28 +78,31 @@ export class Mint extends IronfishCommand {
     let assetId = flags.assetId
     let metadata = flags.metadata
     let name = flags.name
-    // We need at least one of asset id or metadata / name
-    if (!(assetId || (metadata && name))) {
-      const mintNewAsset = await CliUx.ux.confirm('Do you want to create a new asset (Y/N)?')
 
-      if (mintNewAsset) {
-        if (!name) {
-          name = await CliUx.ux.prompt('Enter the name for the new asset', {
-            required: true,
-          })
-        }
+    // We can assume the prompt can be skipped if at least one of metadata or
+    // name is provided
+    let isMintingNewAsset = Boolean(metadata || name)
+    if (!assetId && !metadata && !name) {
+      isMintingNewAsset = await CliUx.ux.confirm('Do you want to create a new asset (Y/N)?')
+    }
 
-        if (!metadata) {
-          metadata = await CliUx.ux.prompt('Enter metadata for the new asset', {
-            default: '',
-            required: false,
-          })
-        }
-      } else {
-        assetId = await CliUx.ux.prompt('Enter the Asset Identifier to mint supply for', {
+    if (isMintingNewAsset) {
+      if (!name) {
+        name = await CliUx.ux.prompt('Enter the name for the new asset', {
           required: true,
         })
       }
+
+      if (!metadata) {
+        metadata = await CliUx.ux.prompt('Enter metadata for the new asset', {
+          default: '',
+          required: false,
+        })
+      }
+    } else if (!assetId) {
+      assetId = await CliUx.ux.prompt('Enter the Asset Identifier to mint supply for', {
+        required: true,
+      })
     }
 
     let amount

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -101,11 +101,9 @@ export class Mint extends IronfishCommand {
         })
       }
     } else if (!assetId) {
-      if (assetId == null) {
-        assetId = await selectAsset(client, account, false)
-      }
+      assetId = await selectAsset(client, account, false)
 
-      if (assetId == null) {
+      if (!assetId) {
         this.error(`You must have an existing asset. Try creating a new one.`)
       }
     }


### PR DESCRIPTION
## Summary

Avoid prompt if a new asset can be inferred from the flags

## Testing Plan

Using graffiti:
```sh
rohan@x13-nixos ~/g/i/ironfish-cli (refactor/rohan/mint-interactive)> f wallet:mint --name=$(f config:get blockGraffiti)
yarn run v1.22.19
$ yarn build && yarn start:js wallet:mint '--name=yarn run v1.22.19' '--name=$ yarn build && yarn start:js config:get blockGraffiti' '--name=$ tsc -b' '--name=$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run config:get blockGraffiti' '--name="rohanjadvani"' '--name=Done in 3.13s.'
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:mint '--name=yarn run v1.22.19' '--name=$ yarn build && yarn start:js config:get blockGraffiti' '--name=$ tsc -b' '--name=$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run config:get blockGraffiti' '--name="rohanjadvani"' '--name=Done in 3.13s.'
Enter metadata for the new asset:
Enter the amount to mint in the custom asset: 12
Enter the fee amount in $IRON (min: 0.00000001): 0.00000001
Creating the transaction: [████████████████████████████████████████] 100% | ETA: 0s

Minted asset Done in 3.13s. from default
Asset Identifier: 26a80dd32e2b8b647fab5ca88a41b9df981b4e02644e6e218d5cfb56699b0c49
Value: 12.00000000

Transaction Hash: 77c42086029b9c471ce1fd38ba69c6e5156e2088c2ba15320a5ffc6b4efa3ee5
```

Using name:

https://user-images.githubusercontent.com/5459049/213060713-84c7b203-b920-47ad-9c79-298c081e48d2.mp4

Using ID:

https://user-images.githubusercontent.com/5459049/213060714-141e7ed9-f2ce-4839-8e7a-3ad59003e5f8.mp4


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
