### PR TITLE
Remove topic overrides

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -89,26 +89,7 @@
       "@oclif/plugin-help",
       "@oclif/plugin-not-found"
     ],
-    "topics": {
-      "accounts": {
-        "description": "Create and delete accounts"
-      },
-      "chain": {
-        "description": "Manage the blockchain"
-      },
-      "config": {
-        "description": "Show and edit the node configuration"
-      },
-      "faucet": {
-        "description": "Get coins to start using Iron Fish"
-      },
-      "miners": {
-        "description": "Manage an Iron Fish miner"
-      },
-      "peers": {
-        "description": "Manage the peers connected to this node"
-      }
-    }
+    "topics": {}
   },
   "bin": {
     "ironfish": "./bin/run"


### PR DESCRIPTION
## Summary

These are only used to override topic descriptions as described here https://oclif.io/docs/topics

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
