### PR TITLE
Remove unneeded toString() in explain balance

### DIFF
--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -99,7 +99,7 @@ export class BalanceCommand extends IronfishCommand {
     this.log(
       `${response.unconfirmedCount} notes worth ${CurrencyUtils.renderIron(
         unconfirmedDelta,
-      )} are on the chain within ${response.confirmations.toString()} blocks of the head`,
+      )} are on the chain within ${response.confirmations} blocks of the head`,
     )
     this.log(`Unconfirmed: ${CurrencyUtils.renderIron(unconfirmed, true, assetId)}`)
   }


### PR DESCRIPTION
## Summary

Just saw this when tracking down a crash, though I'm not sure if this is related.

This caused this crash because the node probably wasn't updated. Either way we may not need this.

```
TypeError: Cannot read properties of undefined (reading 'toString')
    at BalanceCommand.explainBalance (D:\repos\ironfish\ironfish-cli\src\commands\accounts\balance.ts:85:71)
    at BalanceCommand.start (D:\repos\ironfish\ironfish-cli\src\commands\accounts\balance.ts:53:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at BalanceCommand.run (D:\repos\ironfish\ironfish-cli\src\command.ts:73:7)
    at async BalanceCommand._run (D:\repos\ironfish\ironfish-cli\node_modules\@oclif\core\lib\command.js:80:22)
    at async Config.runCommand (D:\repos\ironfish\ironfish-cli\node_modules\@oclif\core\lib\config\config.js:272:25)
    at async Object.run (D:\repos\ironfish\ironfish-cli\node_modules\@oclif\core\lib\main.js:74:5)
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
