### PR TITLE
Pass oclif table flags into peers table

### DIFF
--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -6,16 +6,20 @@ import { CliUx, Flags } from '@oclif/core'
 import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { CommandFlags } from '../../types'
 
 type GetPeerResponsePeer = GetPeersResponse['peers'][0]
 
 const STATE_COLUMN_HEADER = 'STATE'
+const tableFlags = CliUx.ux.table.flags()
+tableFlags.sort.default = STATE_COLUMN_HEADER
 
 export class ListCommand extends IronfishCommand {
   static description = `List all connected peers`
 
   static flags = {
     ...RemoteFlags,
+    ...tableFlags,
     follow: Flags.boolean({
       char: 'f',
       default: false,
@@ -24,16 +28,6 @@ export class ListCommand extends IronfishCommand {
     all: Flags.boolean({
       default: false,
       description: 'Show all peers, not just connected peers',
-    }),
-    extended: Flags.boolean({
-      char: 'e',
-      default: false,
-      description: 'Display all information',
-    }),
-    sort: Flags.string({
-      char: 'o',
-      default: STATE_COLUMN_HEADER,
-      description: 'Sort by column header',
     }),
     agents: Flags.boolean({
       char: 'a',
@@ -94,14 +88,7 @@ export class ListCommand extends IronfishCommand {
 
 function renderTable(
   content: GetPeersResponse,
-  flags: {
-    extended: boolean
-    names: boolean
-    all: boolean
-    sort: string
-    agents: boolean
-    sequence: boolean
-  },
+  flags: CommandFlags<typeof ListCommand>,
 ): string {
   let columns: CliUx.Table.table.Columns<GetPeerResponsePeer> = {
     identity: {
@@ -201,8 +188,7 @@ function renderTable(
 
   CliUx.ux.table(peers, columns, {
     printLine: (line) => (result += `${String(line)}\n`),
-    extended: flags.extended,
-    sort: flags.sort,
+    ...flags,
   })
 
   return result

--- a/ironfish-cli/src/types.ts
+++ b/ironfish-cli/src/types.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Interfaces } from '@oclif/core'
+
 export interface ProgressBar {
   progress: VoidFunction
   getTotal(): number
@@ -13,3 +15,7 @@ export interface ProgressBar {
   increment(delta?: number, payload?: Record<string, unknown>): void
   increment(payload?: Record<string, unknown>): void
 }
+
+export type CommandFlags<T> = T extends Interfaces.Input<infer TFlags, infer GFlags>
+  ? Interfaces.ParserOutput<TFlags, GFlags>['flags']
+  : never


### PR DESCRIPTION
## Summary

Need this for all oclif table features like --no-truncate

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
