### PR TITLE
feat(cli): Improve usability when selecting asset

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -67,7 +67,11 @@ export class Burn extends IronfishCommand {
     let assetId = flags.assetId
 
     if (assetId == null) {
-      assetId = await selectAsset(client, account, false)
+      assetId = await selectAsset(client, account, {
+        action: 'burn',
+        showNativeAsset: false,
+        showSingleAssetChoice: true,
+      })
     }
 
     if (assetId == null) {

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -101,7 +101,11 @@ export class Mint extends IronfishCommand {
         })
       }
     } else if (!assetId) {
-      assetId = await selectAsset(client, account, false)
+      assetId = await selectAsset(client, account, {
+        action: 'mint',
+        showNativeAsset: false,
+        showSingleAssetChoice: true,
+      })
 
       if (!assetId) {
         this.error(`You must have an existing asset. Try creating a new one.`)

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -82,7 +82,11 @@ export class Send extends IronfishCommand {
     }
 
     if (assetId == null) {
-      assetId = await selectAsset(client, from)
+      assetId = await selectAsset(client, from, {
+        action: 'send',
+        showNativeAsset: true,
+        showSingleAssetChoice: false,
+      })
     }
 
     if (!assetId) {

--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -9,14 +9,18 @@ import inquirer from 'inquirer'
 export async function selectAsset(
   client: RpcClient,
   account: string | undefined,
-  showNativeAsset = true,
+  options: {
+    action: string
+    showNativeAsset: boolean
+    showSingleAssetChoice: boolean
+  },
 ): Promise<string | undefined> {
   const balancesResponse = await client.getAccountBalances({ account })
   const assetOptions = []
 
   let balances = balancesResponse.content.balances
 
-  if (!showNativeAsset) {
+  if (!options.showNativeAsset) {
     balances = balances.filter(
       (balance) => balance.assetId !== Asset.nativeId().toString('hex'),
     )
@@ -24,7 +28,7 @@ export async function selectAsset(
 
   if (balances.length === 0) {
     return undefined
-  } else if (balances.length === 1) {
+  } else if (balances.length === 1 && !options.showSingleAssetChoice) {
     // If there's only one available asset, showing the choices is unnecessary
     return balances[0].assetId
   }
@@ -45,7 +49,7 @@ export async function selectAsset(
   const response: { assetId: string } = await inquirer.prompt<{ assetId: string }>([
     {
       name: 'assetId',
-      message: 'Select the asset you wish to send',
+      message: `Select the asset you wish to ${options.action}`,
       type: 'list',
       choices: assetOptions,
     },


### PR DESCRIPTION
## Summary

* Show single asset options in mint / burn so it's clear which asset is being operated on
* Add action to improve message

## Testing Plan

```sh
rohan@x13-nixos ~/g/i/ironfish-cli (feat/rohan/show-single-balance)> f wallet:mint
yarn run v1.22.19
$ yarn build && yarn start:js wallet:mint
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:mint
Do you want to create a new asset (Y/N)?: N
? Select the asset you wish to mint 618c098d8d008c9f78f6155947014901a019d9ec17160dc0f0d1bb1c764b29b4 (rohancoin)
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
