### PR TITLE
Fix mining pool init

### DIFF
--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -114,11 +114,11 @@ export class StartPool extends IronfishCommand {
     }
 
     this.pool = await MiningPool.init({
+      rpc,
       config: this.sdk.config,
       logger: this.logger,
-      rpc,
-      enablePayouts: flags.payouts,
       webhooks: webhooks,
+      enablePayouts: flags.payouts,
       host: host,
       port: port,
       balancePercentPayoutFlag: flags.balancePercentPayout,


### PR DESCRIPTION
## Summary
Fix incorrect parameters order in `ironfish-cli/src/commands/miners/pools/start` and `ironfish/src/mining/pool.ts`.
https://github.com/iron-fish/ironfish/blob/staging/ironfish-cli/src/commands/miners/pools/start.ts
<img width="451" alt="image" src="https://user-images.githubusercontent.com/82858858/213094326-217fec7b-7efb-440a-a35d-fd08f669f8db.png">
https://github.com/iron-fish/ironfish/blob/staging/ironfish/src/mining/pool.ts
<img width="395" alt="image" src="https://user-images.githubusercontent.com/82858858/213094426-23e3d243-d71f-4dab-9c92-873b312843d0.png">

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
