### PR TITLE
Fix_#2966-corrected-account-command-to-wallet

### DIFF
--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -96,10 +96,10 @@ Congratulations! The Iron Fish Faucet just added your request to the queue!
 It will be processed within the next hour and $IRON will be sent directly to your account.
 
 Check your balance by running:
-  - ironfish accounts:balance
+  - ironfish wallet:balance
 
 Learn how to send a transaction by running:
-  - ironfish accounts:pay --help`,
+  - ironfish wallet:send --help`,
     )
   }
 }

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -21,6 +21,6 @@ export function getAccount(node: IronfishNode, name?: string): Account {
 
   throw new ValidationError(
     `No account is currently active.\n\n` +
-      `Use ironfish accounts:create <name> to first create an account`,
+      `Use ironfish wallet:create <name> to first create an account`,
   )
 }


### PR DESCRIPTION
## Summary
This is a bug fix for `ironfish faucet` command.
Proposed commands are fixed to correct: from `ironfish accounts` to `ironfish wallet`

## Testing Plan
Successful run of `ironfish faucet` command is needed to check if the suggested commands are correct

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] No, it's not. Cosmetic change
```
