### PR TITLE
WIP(ironfish-cli): modify old command help text 'account' to 'wallet'

### DIFF
--- a/ironfish-cli/README.md
+++ b/ironfish-cli/README.md
@@ -20,15 +20,13 @@ Run this command in the terminal:
 Interact with the node in a new terminal window:
 - `yarn start status`
    - Show your node's status
-- `yarn start accounts:balance` 
-   - Show the balance of your account, including $IRON from blocks you've mined
+- `yarn start wallet:balance` 
+   - Show the balance of your wallet, including $IRON from blocks you've mined
    - Tentative balance includes all known transactions. Spending balance includes only transactions on blocks on the main chain
 - `yarn start faucet`
    - Request a small amount of $IRON for testing payments
-- `yarn start accounts:pay`
-   - Send $IRON to another account
-- `yarn start accounts:transactions [account]`
-   - Display transactions from and to your account
+- `yarn start wallet:transactions [wallet]`
+   - Display transactions from and to your wallet
 
 ### Start a node and start mining
 Run these commands in two different terminals:

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -96,10 +96,7 @@ Congratulations! The Iron Fish Faucet just added your request to the queue!
 It will be processed within the next hour and $IRON will be sent directly to your account.
 
 Check your balance by running:
-  - ironfish accounts:balance
-
-Learn how to send a transaction by running:
-  - ironfish accounts:pay --help`,
+  - ironfish wallet:balance`,
     )
   }
 }

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -96,7 +96,10 @@ Congratulations! The Iron Fish Faucet just added your request to the queue!
 It will be processed within the next hour and $IRON will be sent directly to your account.
 
 Check your balance by running:
-  - ironfish wallet:balance`,
+  - ironfish wallet:balance
+
+Learn how to send a transaction by running:
+  - ironfish wallet:send --help`,
     )
   }
 }

--- a/ironfish-cli/src/commands/wallet/create.ts
+++ b/ironfish-cli/src/commands/wallet/create.ts
@@ -27,24 +27,24 @@ export class CreateCommand extends IronfishCommand {
     let name = args.account as string
 
     if (!name) {
-      name = await CliUx.ux.prompt('Enter the name of the account', {
+      name = await CliUx.ux.prompt('Enter the name of the wallet', {
         required: true,
       })
     }
 
     const client = await this.sdk.connectRpc()
 
-    this.log(`Creating account ${name}`)
+    this.log(`Creating wallet ${name}`)
     const result = await client.createAccount({ name })
 
     const { publicAddress, isDefaultAccount } = result.content
 
-    this.log(`Account ${name} created with public address ${publicAddress}`)
+    this.log(`Wallet ${name} created with public address ${publicAddress}`)
 
     if (isDefaultAccount) {
-      this.log(`The default account is now: ${name}`)
+      this.log(`The default wallet is now: ${name}`)
     } else {
-      this.log(`Run "ironfish accounts:use ${name}" to set the account as default`)
+      this.log(`Run "ironfish wallet:use ${name}" to set the wallet as default`)
     }
   }
 }

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -43,7 +43,7 @@ export class ImportCommand extends IronfishCommand {
     }
 
     if (account === null) {
-      this.log('No wallet to import provided')
+      this.log('No account to import provided')
       return this.exit(1)
     }
 
@@ -53,10 +53,10 @@ export class ImportCommand extends IronfishCommand {
     })
 
     const { name, isDefaultAccount } = result.content
-    this.log(`Wallet ${name} imported.`)
+    this.log(`Account ${name} imported.`)
 
     if (isDefaultAccount) {
-      this.log(`The default wallet is now: ${name}`)
+      this.log(`The default account is now: ${name}`)
     } else {
       this.log(`Run "ironfish wallet:use ${name}" to set the account as default`)
     }
@@ -88,11 +88,11 @@ export class ImportCommand extends IronfishCommand {
   }
 
   async importTTY(): Promise<AccountImport> {
-    const accountName = await CliUx.ux.prompt('Enter the wallet name', {
+    const accountName = await CliUx.ux.prompt('Enter the account name', {
       required: true,
     })
 
-    const spendingKey = await CliUx.ux.prompt('Enter the wallet spending key', {
+    const spendingKey = await CliUx.ux.prompt('Enter the account spending key', {
       required: true,
     })
 

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -43,7 +43,7 @@ export class ImportCommand extends IronfishCommand {
     }
 
     if (account === null) {
-      this.log('No account to import provided')
+      this.log('No wallet to import provided')
       return this.exit(1)
     }
 
@@ -53,12 +53,12 @@ export class ImportCommand extends IronfishCommand {
     })
 
     const { name, isDefaultAccount } = result.content
-    this.log(`Account ${name} imported.`)
+    this.log(`Wallet ${name} imported.`)
 
     if (isDefaultAccount) {
-      this.log(`The default account is now: ${name}`)
+      this.log(`The default wallet is now: ${name}`)
     } else {
-      this.log(`Run "ironfish accounts:use ${name}" to set the account as default`)
+      this.log(`Run "ironfish wallet:use ${name}" to set the account as default`)
     }
   }
 
@@ -88,11 +88,11 @@ export class ImportCommand extends IronfishCommand {
   }
 
   async importTTY(): Promise<AccountImport> {
-    const accountName = await CliUx.ux.prompt('Enter the account name', {
+    const accountName = await CliUx.ux.prompt('Enter the wallet name', {
       required: true,
     })
 
-    const spendingKey = await CliUx.ux.prompt('Enter the account spending key', {
+    const spendingKey = await CliUx.ux.prompt('Enter the wallet spending key', {
       required: true,
     })
 

--- a/ironfish-cli/src/commands/wallet/repair.ts
+++ b/ironfish-cli/src/commands/wallet/repair.ts
@@ -13,7 +13,7 @@ import {
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
-const RESCAN_MESSAGE = 'Account must be rescanned using `accounts:rescan --reset`.'
+const RESCAN_MESSAGE = 'Account must be rescanned using `wallet:rescan --reset`.'
 export default class Repair extends IronfishCommand {
   static hidden = false
 

--- a/ironfish-cli/src/commands/wallet/which.ts
+++ b/ironfish-cli/src/commands/wallet/which.ts
@@ -6,11 +6,11 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class WhichCommand extends IronfishCommand {
-  static description = `Show the account currently used.
+  static description = `Show the wallet currently used.
 
-  By default all commands will use this account when deciding what
-  keys to use. If no account is specified as the default, you must
-  specify the account in the command using --account <name>`
+  By default all commands will use this wallet when deciding what
+  keys to use. If no wallet is specified as the default, you must
+  specify the wallet in the command using --account <name>`
 
   static flags = {
     ...RemoteFlags,
@@ -33,10 +33,10 @@ export class WhichCommand extends IronfishCommand {
 
     if (!accountName) {
       this.log(
-        'There is currently no account being used.\n' +
-          ' * Create an account: "ironfish accounts:create"\n' +
-          ' * List all accounts: "ironfish accounts:list"\n' +
-          ' * Use an existing account: "ironfish accounts:use <name>"',
+        'There is currently no wallet being used.\n' +
+          ' * Create an wallet: "ironfish wallet:create"\n' +
+          ' * List all wallets: "ironfish wallet:list"\n' +
+          ' * Use an existing wallet: "ironfish wallet:use <name>"',
       )
       this.exit(0)
     }

--- a/ironfish-cli/src/commands/wallet/which.ts
+++ b/ironfish-cli/src/commands/wallet/which.ts
@@ -6,11 +6,11 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
 export class WhichCommand extends IronfishCommand {
-  static description = `Show the wallet currently used.
+  static description = `Show the account currently used.
 
-  By default all commands will use this wallet when deciding what
-  keys to use. If no wallet is specified as the default, you must
-  specify the wallet in the command using --account <name>`
+  By default all commands will use this account when deciding what
+  keys to use. If no account is specified as the default, you must
+  specify the account in the command using --account <name>`
 
   static flags = {
     ...RemoteFlags,
@@ -34,7 +34,7 @@ export class WhichCommand extends IronfishCommand {
     if (!accountName) {
       this.log(
         'There is currently no wallet being used.\n' +
-          ' * Create an wallet: "ironfish wallet:create"\n' +
+          ' * Create an account: "ironfish wallet:create"\n' +
           ' * List all wallets: "ironfish wallet:list"\n' +
           ' * Use an existing wallet: "ironfish wallet:use <name>"',
       )


### PR DESCRIPTION
## Summary

Currently, we see that the ironfish:accounts command has been changed to ironfish:wallet .
However, some ironfish:wallet sub-commands still tell you to use the ironfish:accounts command in the help.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
