### PR TITLE
feat(cli): add a confirm flag/step to mint

### DIFF
--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -47,6 +47,10 @@ export class Mint extends IronfishCommand {
       description: 'Name for the asset',
       required: false,
     }),
+    confirm: Flags.boolean({
+      default: false,
+      description: 'Confirm without asking',
+    }),
   }
 
   async start(): Promise<void> {
@@ -136,6 +140,26 @@ export class Mint extends IronfishCommand {
       )
 
       fee = CurrencyUtils.decodeIron(input)
+    }
+
+    if (!flags.confirm) {
+      const nameString = name ? `Name: ${name}` : ''
+      const metadataString = metadata ? `Metadata: ${metadata}` : ''
+      const includeTicker = !!assetId
+      const amountString = CurrencyUtils.renderIron(amount, includeTicker, assetId)
+      const feeString = CurrencyUtils.renderIron(fee, true)
+      this.log(`
+You are about to mint ${nameString} ${metadataString}
+${amountString} plus a transaction fee of ${feeString} with the account ${account}
+
+* This action is NOT reversible *
+`)
+
+      const confirm = await CliUx.ux.confirm('Do you confirm (Y/N)?')
+      if (!confirm) {
+        this.log('Transaction aborted.')
+        this.exit(0)
+      }
     }
 
     const bar = CliUx.ux.progress({


### PR DESCRIPTION
## Summary

new asset without confirm flag
![image](https://user-images.githubusercontent.com/97762857/213229115-ca53cd06-580f-4928-9902-d9ab26bfe3c8.png)

existing asset without confirm flag
![image](https://user-images.githubusercontent.com/97762857/213229217-82f3ba6a-579b-4b19-ad60-bf9a18d10d74.png)

with confirm flag
![image](https://user-images.githubusercontent.com/97762857/213229355-95a01e81-42a5-4f84-91ef-663bb9038930.png)



## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
