### PR TITLE
feat(cli): add confirm flag/step to burn

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -35,6 +35,10 @@ export class Burn extends IronfishCommand {
       char: 'i',
       description: 'Identifier for the asset',
     }),
+    confirm: Flags.boolean({
+      default: false,
+      description: 'Confirm without asking',
+    }),
   }
 
   async start(): Promise<void> {
@@ -102,6 +106,25 @@ export class Burn extends IronfishCommand {
       )
 
       fee = CurrencyUtils.decodeIron(input)
+    }
+
+    if (!flags.confirm) {
+      this.log(`
+You are about to burn:
+${CurrencyUtils.renderIron(
+  amount,
+  true,
+  assetId,
+)} plus a transaction fee of ${CurrencyUtils.renderIron(fee, true)} with the account ${account}
+
+* This action is NOT reversible *
+`)
+
+      const confirm = await CliUx.ux.confirm('Do you confirm (Y/N)?')
+      if (!confirm) {
+        this.log('Transaction aborted.')
+        this.exit(0)
+      }
     }
 
     const bar = CliUx.ux.progress({


### PR DESCRIPTION
## Summary

without confirm flag
![image](https://user-images.githubusercontent.com/97762857/213231313-94f90d68-048c-48c3-9b0c-96829ed5655e.png)

with confirm flag
![image](https://user-images.githubusercontent.com/97762857/213231374-1cd396ff-e68c-4531-af7c-41a949ff55dc.png)


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
