### PR TITLE
changes NotEnoughFundsError messages

### DIFF
--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
@@ -158,7 +158,6 @@ describe('Transactions sendTransaction', () => {
 
     await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrow(
       expect.objectContaining({
-        message: expect.stringContaining('Your balance changed while creating a transaction.'),
         status: 400,
         code: ERROR_CODES.INSUFFICIENT_BALANCE,
       }),

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -159,7 +159,7 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
     } catch (e) {
       if (e instanceof NotEnoughFundsError) {
         throw new ValidationError(
-          `Your balance changed while creating a transaction.`,
+          `Not enough unspent notes available to fund the transaction. Please wait for any pending transactions to be confirmed.`,
           400,
           ERROR_CODES.INSUFFICIENT_BALANCE,
         )

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -13,6 +13,8 @@ export class NotEnoughFundsError extends Error {
       amountNeeded,
       true,
       assetId.toString('hex'),
-    )} but have '${CurrencyUtils.renderIron(amount)}'`
+    )} but have '${CurrencyUtils.renderIron(
+      amount,
+    )} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.'`
   }
 }


### PR DESCRIPTION
## Summary

removes message indicating that 'balance changed' since we no longer store pending balances.

NotEnoughFundsError when sending a transaction is now likely to occur if not enough notes are available to spend because of pending or unconfirmed transactions.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
