### PR TITLE
fix: networkId defaults set upon run of reset command

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -45,6 +45,9 @@ export default class Reset extends IronfishCommand {
       this.exit(0)
     }
 
+    this.sdk.internal.set('networkId', this.sdk.config.defaults.networkId)
+    this.sdk.internal.set('isFirstRun', true)
+    await this.sdk.internal.save()
     const walletDatabasePath = this.sdk.config.walletDatabasePath
     const chainDatabasePath = this.sdk.config.chainDatabasePath
     const hostFilePath: string = this.sdk.config.files.join(


### PR DESCRIPTION
## Summary
use of `reset` command will now change `networkId` to its default value
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
