### PR TITLE
removes extra ' character in error message

### DIFF
--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -13,7 +13,7 @@ export class NotEnoughFundsError extends Error {
       amountNeeded,
       true,
       assetId.toString('hex'),
-    )} but have '${CurrencyUtils.renderIron(
+    )} but have ${CurrencyUtils.renderIron(
       amount,
     )} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.'`
   }


### PR DESCRIPTION
## Summary

purely cosmetic change to error text

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
