### PR TITLE
excludes fee paid from amount in transactions list

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -75,12 +75,12 @@ export class TransactionsCommand extends IronfishCommand {
           },
           amount: {
             header: 'Net Amount ($IRON)',
-            get: (row) => (row.amount > 0 ? CurrencyUtils.renderIron(row.amount) : ''),
+            get: (row) => (row.amount !== 0n ? CurrencyUtils.renderIron(row.amount) : ''),
             minWidth: 20,
           },
           feePaid: {
             header: 'Fee Paid ($IRON)',
-            get: (row) => (row.feePaid > 0 ? CurrencyUtils.renderIron(row.feePaid) : ''),
+            get: (row) => (row.feePaid !== 0n ? CurrencyUtils.renderIron(row.feePaid) : ''),
             minWidth: 20,
           },
           notesCount: {

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
-import { CurrencyUtils } from '@ironfish/sdk'
+import {
+  CurrencyUtils,
+  GetAccountTransactionsResponse,
+  TransactionType,
+} from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -50,12 +54,10 @@ export class TransactionsCommand extends IronfishCommand {
     let showHeader = true
 
     for await (const transaction of response.contentStream()) {
-      const ironDelta = transaction.assetBalanceDeltas.find(
-        (d) => d.assetId === Asset.nativeId().toString('hex'),
-      )
+      const transactionRow = this.getTransactionRow(transaction)
 
       CliUx.ux.table(
-        [transaction],
+        [transactionRow],
         {
           timestamp: TableCols.timestamp({
             streaming: true,
@@ -72,13 +74,13 @@ export class TransactionsCommand extends IronfishCommand {
             header: 'Hash',
           },
           amount: {
-            header: 'Amount ($IRON)',
-            get: (_) => (ironDelta ? CurrencyUtils.renderIron(ironDelta.delta) : '0'),
+            header: 'Net Amount ($IRON)',
+            get: (row) => (row.amount > 0 ? CurrencyUtils.renderIron(row.amount) : ''),
             minWidth: 20,
           },
-          fee: {
-            header: 'Fee ($IRON)',
-            get: (transaction) => CurrencyUtils.renderIron(transaction.fee),
+          feePaid: {
+            header: 'Fee Paid ($IRON)',
+            get: (row) => (row.feePaid > 0 ? CurrencyUtils.renderIron(row.feePaid) : ''),
             minWidth: 20,
           },
           notesCount: {
@@ -111,4 +113,42 @@ export class TransactionsCommand extends IronfishCommand {
       showHeader = false
     }
   }
+
+  getTransactionRow(transaction: GetAccountTransactionsResponse): TransactionRow {
+    const assetId = Asset.nativeId().toString('hex')
+
+    const nativeAssetBalanceDelta = transaction.assetBalanceDeltas.find(
+      (d) => d.assetId === assetId,
+    )
+
+    let amount = BigInt(nativeAssetBalanceDelta?.delta ?? '0')
+
+    let feePaid = BigInt(transaction.fee)
+
+    if (transaction.type !== TransactionType.SEND) {
+      feePaid = 0n
+    } else {
+      amount += feePaid
+    }
+
+    return {
+      ...transaction,
+      amount,
+      feePaid,
+    }
+  }
+}
+
+type TransactionRow = {
+  timestamp: number
+  status: string
+  type: string
+  hash: string
+  amount: bigint
+  feePaid: bigint
+  notesCount: number
+  spendsCount: number
+  mintsCount: number
+  burnsCount: number
+  expiration: number
 }

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -2,11 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
-import {
-  CurrencyUtils,
-  GetAccountTransactionsResponse,
-  TransactionType,
-} from '@ironfish/sdk'
+import { CurrencyUtils, GetAccountTransactionsResponse, TransactionType } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'


### PR DESCRIPTION
## Summary

uses transaction type to determine whether to do fee correction on IRON amount in transaction.

renames 'Fee ($IRON)' column to 'Fee Paid ($IRON)' and only displays the fee if the account paid the transaction fee.

renames 'Amount ($IRON)' column to 'Net Amount ($IRON)' and only displays non-zero values.

defines type for TransactionRow and defines separate function for constructing the row from the transaction response.

## Testing Plan

Before:
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/57735705/213333434-b7e9243a-0f03-4243-8930-8cdef5d45264.png">


After:
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/57735705/213333372-1a05c03c-5a38-43ee-8578-426d421cb212.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
