### PR TITLE
fix(ironfish): align default network id for internal and config

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -15,6 +15,7 @@ export const DEFAULT_USE_RPC_TCP = false
 export const DEFAULT_USE_RPC_TLS = true
 export const DEFAULT_POOL_HOST = '0.0.0.0'
 export const DEFAULT_POOL_PORT = 9034
+export const DEFAULT_NETWORK_ID = 0
 
 export type ConfigOptions = {
   bootstrapNodes: string[]
@@ -384,7 +385,7 @@ export class Config extends KeyStore<ConfigOptions> {
       feeEstimatorPercentileLow: 10,
       feeEstimatorPercentileMedium: 20,
       feeEstimatorPercentileHigh: 30,
-      networkId: 2,
+      networkId: DEFAULT_NETWORK_ID,
       customNetwork: '',
       maxSyncedAgeBlocks: 60,
       networkDefinitionPath: files.resolve(files.join(dataDir, 'network.json')),

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FileSystem } from '../fileSystems'
+import { DEFAULT_NETWORK_ID } from './config'
 import { KeyStore } from './keyStore'
 
 export type InternalOptions = {
@@ -17,7 +18,7 @@ export const InternalOptionsDefaults: InternalOptions = {
   networkIdentity: '',
   telemetryNodeId: '',
   rpcAuthToken: '',
-  networkId: 0,
+  networkId: DEFAULT_NETWORK_ID,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {


### PR DESCRIPTION
## Summary

Since these got out of alignment, we couldn't actually override the config to use the dev network

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
