### PR TITLE
shows all assets for each transaction in transactions list

### DIFF
--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -56,3 +56,11 @@ const timestamp = <T extends Record<string, unknown>>(options?: {
 }
 
 export const TableCols = { timestamp }
+
+export function truncateCol(value: string, maxWidth: number | null): string {
+  if (maxWidth === null || value.length <= maxWidth) {
+    return value
+  }
+
+  return value.slice(0, maxWidth - 1) + '…'
+}


### PR DESCRIPTION
## Summary

adds additional rows for each asset in a transaction beneath the native asset row.

each custom asset row displays the asset ID and the net amount of that asset in the transaction.

converts '*Count' columns to 'extended' columns that are not displayed by default.

updates getTransactions and getTransaction to include asset name in
assetBalanceDeltas with each transaction so that asset name can be displayed
with balances.
    
truncates the asset name column unless the '--extended' flag is passed to show
all columns in the table.

## Testing Plan

<img width="1519" alt="image" src="https://user-images.githubusercontent.com/57735705/214749852-de5ff419-2b88-43be-8111-9d800556a669.png">

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
