### PR TITLE
fix(cli): Fix typo. Fake address should be 64 characters, not 63

### DIFF
--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -217,7 +217,7 @@ export default class Faucet extends IronfishCommand {
     for (const invalidFaucetTransactions of faucetTransactions) {
       await api.completeFaucetTransaction(
         invalidFaucetTransactions.id,
-        '000000000000000000000000000000000000000000000000000000000000000',
+        '0000000000000000000000000000000000000000000000000000000000000000',
       )
     }
   }


### PR DESCRIPTION

## Summary

This probably wouldn't cause any issues, but just in case


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
