### PR TITLE
fix(ci): dont build windows binary with zig

### DIFF
--- a/.github/workflows/build-ironfish-rust-nodejs.yml
+++ b/.github/workflows/build-ironfish-rust-nodejs.yml
@@ -62,7 +62,7 @@ jobs:
         working-directory: ./ironfish-rust-nodejs
 
       - name: Build
-        run: yarn build --zig ${{ matrix.settings.target == 'x86_64-unknown-linux-gnu' && '--zig-abi-suffix=2.17' || ''}} --target ${{ matrix.settings.target }}
+        run: yarn build ${{ matrix.settings.target != 'x86_64-pc-windows-msvc' && '--zig' || '' }} ${{ matrix.settings.target == 'x86_64-unknown-linux-gnu' && '--zig-abi-suffix=2.17' || ''}} --target ${{ matrix.settings.target }}
         working-directory: ./ironfish-rust-nodejs
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary

Problem: https://github.com/iron-fish/ironfish/actions/runs/3963411310/jobs/6791201687

Green test run: https://github.com/iron-fish/ironfish/actions/runs/3963638104/jobs/6791695422

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
