### PR TITLE
getBlock route returns on-chain block of the specified index

### DIFF
--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -133,10 +133,7 @@ router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
     // Given that a chain reorg event might cause the specific block
     // at that sequence can be set to a different one
     if (!hashBuffer && sequence) {
-      const hashBuffers = await node.chain.getHashesAtSequence(sequence)
-      if (Array.isArray(hashBuffers) && hashBuffers.length > 0) {
-        hashBuffer = hashBuffers[0]
-      }
+      hashBuffer = await node.chain.getHashAtSequence(sequence)
     }
 
     if (!hashBuffer) {


### PR DESCRIPTION
## Summary
`getBlock` returns a random block of the specified `index` (height), this pr proposes to return the only one on-chain block, which is the same as `getBlockInfo` route does now. So that `getBlockWithIndex` and `getBlockInfoWithSequence` return the block with same `hash`.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
