### PR TITLE
Create a timestamp column

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -57,7 +57,9 @@ export class TransactionsCommand extends IronfishCommand {
       CliUx.ux.table(
         [transaction],
         {
-          timestamp: TableCols.timestamp(),
+          timestamp: TableCols.timestamp({
+            streaming: true,
+          }),
           status: {
             header: 'Status',
             minWidth: 12,

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
-import { CurrencyUtils, TimeUtils } from '@ironfish/sdk'
+import { CurrencyUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { TableCols } from '../../utils/table'
 
 export class TransactionsCommand extends IronfishCommand {
   static description = `Display the account transactions`
@@ -56,10 +57,7 @@ export class TransactionsCommand extends IronfishCommand {
       CliUx.ux.table(
         [transaction],
         {
-          timestamp: {
-            header: 'Timestamp',
-            get: (transaction) => TimeUtils.renderString(transaction.timestamp),
-          },
+          timestamp: TableCols.timestamp(),
           status: {
             header: 'Status',
             minWidth: 12,

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -18,6 +18,7 @@ const MAX_TIMESTAMP_LENGTH = TimeUtils.renderString(
 ).length
 
 const timestamp = <T extends Record<string, unknown>>(options?: {
+  streaming?: boolean
   header?: string
   field?: string
   get?: (row: Record<string, unknown>) => string
@@ -25,7 +26,17 @@ const timestamp = <T extends Record<string, unknown>>(options?: {
 }): Partial<table.Column<T>> => {
   const header = options?.header ?? 'Timestamp'
   const field = options?.field ?? 'timestamp'
-  const minWidth = options?.minWidth ?? MAX_TIMESTAMP_LENGTH
+
+  // Are you rendering one row at a time by a streaming response?
+  const streaming = options?.streaming ?? false
+
+  // We should only use estimated minWidth if you are streaming
+  let minWidth
+  if (!streaming && options?.minWidth === undefined) {
+    minWidth = MAX_TIMESTAMP_LENGTH
+  } else {
+    minWidth = options?.minWidth
+  }
 
   const get =
     options?.get ??

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -7,6 +7,11 @@ import { table } from '@oclif/core/lib/cli-ux/styled/table'
 
 /**
  * Estimated max length of the longest TimeUtils.renderTime()
+ *
+ * I chose a date where all time components in en-us have 2 digits
+ * this will be wrong in some cases but it's a decent heuristic.
+ *
+ * 12/25/2024 11:59:59 PM EST
  */
 const MAX_TIMESTAMP_LENGTH = TimeUtils.renderString(
   new Date(2024, 11, 25, 23, 59, 59).getTime(),

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { TimeUtils } from '@ironfish/sdk'
+import { table } from '@oclif/core/lib/cli-ux/styled/table'
+
+/**
+ * Estimated max length of the longest TimeUtils.renderTime()
+ */
+const MAX_TIMESTAMP_LENGTH = TimeUtils.renderString(
+  new Date(2024, 11, 25, 23, 59, 59).getTime(),
+).length
+
+const timestamp = <T extends Record<string, unknown>>(options?: {
+  header?: string
+  field?: string
+  get?: (row: Record<string, unknown>) => string
+  minWidth?: number
+}): Partial<table.Column<T>> => {
+  const header = options?.header ?? 'Timestamp'
+  const field = options?.field ?? 'timestamp'
+  const minWidth = options?.minWidth ?? MAX_TIMESTAMP_LENGTH
+
+  const get =
+    options?.get ??
+    ((row: Record<string, unknown>) => {
+      const value = row[field]
+      if (!value) {
+        return ''
+      }
+      return TimeUtils.renderString(Number(value))
+    })
+
+  return {
+    header,
+    get,
+    minWidth,
+  }
+}
+
+export const TableCols = { timestamp }


### PR DESCRIPTION
This will help render timestamp columsn better, by not having to re-guess the length of a timestamp column everywhere. This is particularly good for streaming tables.

## Summary
Before
```
 Timestamp                Status      Type    Hash                                                             Amount ($IRON)      Fee ($IRON)         Notes Spends Mints Burns Expiration
 ──────────────────────── ─────────── ─────── ──────────────────────────────────────────────────────────────── ─────────────────── ─────────────────── ───── ────── ───── ───── ──────────
 1/19/2023 8:50:23 PM EST confirmed   receive 1b4d7e3775f7f9f3746cc1913bae0108ba65030918105b4597e663dfb1ad4a76 0.22877871          0.00000121          122   12     0     0     3536
 1/18/2023 11:32:24 PM EST confirmed   send    5701785ade32456ec1cbd342a032fc1e82b21758cc0269edf8feda0e76917639 -0.00000501         0.00000001          2     1      0     0     2557
```

After
```
 Timestamp                 Status      Type    Hash                                                             Amount ($IRON)      Fee ($IRON)         Notes Spends Mints Burns Expiration
 ───────────────────────── ─────────── ─────── ──────────────────────────────────────────────────────────────── ─────────────────── ─────────────────── ───── ────── ───── ───── ──────────
 1/19/2023 7:04:36 AM EST  confirmed   receive 1016eb2c02257996a0f4f95e461a5017e2847085561722ddda8d77bbdf3e46f1 0.39033044          0.00000103          104   12     0     0     3249
 1/18/2023 11:32:24 PM EST confirmed   send    5701785ade32456ec1cbd342a032fc1e82b21758cc0269edf8feda0e76917639 -0.00000501         0.00000001          2     1      0     0     2557
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
