### PR TITLE
Change Buffer to JsBuffer in verifyTransactions

### DIFF
--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -271,15 +271,16 @@ impl NativeTransaction {
 }
 
 #[napi]
-pub fn verify_transactions(serialized_transactions: Vec<Buffer>) -> bool {
+pub fn verify_transactions(serialized_transactions: Vec<JsBuffer>) -> Result<bool> {
     let mut transactions: Vec<Transaction> = vec![];
 
     for tx_bytes in serialized_transactions {
-        match Transaction::read(&mut tx_bytes.as_ref()) {
+        let buf = tx_bytes.into_value()?;
+        match Transaction::read(buf.as_ref()) {
             Ok(tx) => transactions.push(tx),
-            Err(_) => return false,
+            Err(_) => return Ok(false),
         }
     }
 
-    batch_verify_transactions(transactions.iter()).is_ok()
+    Ok(batch_verify_transactions(transactions.iter()).is_ok())
 }


### PR DESCRIPTION
## Summary

We occasionally see segfaults coming from allocating a new reference to a buffer
in verifyTransactions. I wasn't able to easily reproduce this, but in other places
we use JsBuffer instead of Buffer, so trying that here as well.

## Testing Plan

Tests should pass.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
