### PR TITLE
feat: owner address to transaction cli

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction.ts
+++ b/ironfish-cli/src/commands/wallet/transaction.ts
@@ -62,10 +62,6 @@ export class TransactionCommand extends IronfishCommand {
       this.log(`---Notes---\n`)
 
       CliUx.ux.table(response.content.transaction.notes, {
-        owner: {
-          header: 'Owner',
-          get: (note) => (note.owner ? `✔` : `x`),
-        },
         amount: {
           header: 'Amount',
           get: (note) => CurrencyUtils.renderIron(note.value),
@@ -83,6 +79,14 @@ export class TransactionCommand extends IronfishCommand {
         },
         memo: {
           header: 'Memo',
+        },
+        isOwner: {
+          header: 'Owner',
+          get: (note) => (note.isOwner ? `✔` : `x`),
+        },
+        owner: {
+          header: 'Owner Address',
+          get: (note) => note.owner,
         },
       })
     }

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -21,14 +21,14 @@ export class Note {
   private readonly _memo: Buffer
   private readonly _assetId: Buffer
   private readonly _sender: string
+  private readonly _owner: string
 
   constructor(noteSerialized: Buffer) {
     this.noteSerialized = noteSerialized
 
     const reader = bufio.read(this.noteSerialized, true)
 
-    // skip owner public address
-    reader.seek(PUBLIC_ADDRESS_LENGTH)
+    this._owner = reader.readBytes(PUBLIC_ADDRESS_LENGTH, true).toString('hex')
 
     this._assetId = reader.readBytes(ASSET_ID_LENGTH, true)
 
@@ -64,6 +64,10 @@ export class Note {
 
   value(): bigint {
     return this._value
+  }
+
+  owner(): string {
+    return this._owner
   }
 
   sender(): string {

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -58,7 +58,8 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
             .array(
               yup
                 .object({
-                  owner: yup.boolean().defined(),
+                  isOwner: yup.boolean().defined(),
+                  owner: yup.string().defined(),
                   value: yup.string().defined(),
                   assetId: yup.string().defined(),
                   assetName: yup.string().defined(),
@@ -111,7 +112,7 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
       const noteHash = decryptedNote.hash
       const decryptedNoteForOwner = await account.getDecryptedNote(noteHash)
 
-      const owner = !!decryptedNoteForOwner
+      const isOwner = !!decryptedNoteForOwner
       const spent = decryptedNoteForOwner ? decryptedNoteForOwner.spent : false
       const note = decryptedNoteForOwner
         ? decryptedNoteForOwner.note
@@ -120,7 +121,8 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
       const asset = await node.chain.getAssetById(note.assetId())
 
       serializedNotes.push({
-        owner,
+        isOwner,
+        owner: note.owner(),
         memo: note.memo(),
         value: CurrencyUtils.encode(note.value()),
         assetId: note.assetId().toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -18,12 +18,13 @@ export type RpcAccountTransaction = {
 }
 
 export type RpcAccountDecryptedNote = {
-  owner: boolean
+  isOwner: boolean
   value: string
   assetId: string
   assetName: string
   memo: string
   sender: string
+  owner: string
   spent: boolean
 }
 


### PR DESCRIPTION
## Summary
Add owner address to output of the `wallet:transaction` cli command
## Testing Plan
```
fish wallet:transaction d14bfaf495231252fa6ca01a299435e7453ba10e08e393df3ee6a953e560276a --datadir="~/.phase3v9"                                                                                              ─╯
yarn run v1.22.19
$ yarn build && yarn start:js wallet:transaction d14bfaf495231252fa6ca01a299435e7453ba10e08e393df3ee6a953e560276a '--datadir=~/.phase3v9'
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:transaction d14bfaf495231252fa6ca01a299435e7453ba10e08e393df3ee6a953e560276a '--datadir=~/.phase3v9'
Transaction: d14bfaf495231252fa6ca01a299435e7453ba10e08e393df3ee6a953e560276a
Account: default
Status: confirmed
Type: send
Timestamp: 1/19/2023 9:25:34 AM PST
Fee: $IRON 0.00001000
Block Hash: 00000000006538a4e1e197d283aeb0d55f88dffd7ec56022e547409026290c9a
Block Sequence: 3609
Notes Count: 2
Spends Count: 1
Mints Count: 0
Burns Count: 0
Sender: 5f54ffd127b3949dbedd926d29c2550bf10790da7a879f211712fb85cb19e733
---Notes---

 Owner Amount        Asset Name Asset Id                                                         Spent Memo Owner Address
 ───── ───────────── ────────── ──────────────────────────────────────────────────────────────── ───── ──── ────────────────────────────────────────────────────────────────
 x     0.00010000    $IRON      d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6 x          2700a7a95da373358c8c52ed6ad939442d4a7d261962f86b8f874fda6af5b56e
 ✔     9999.99944799 $IRON      d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6 x          5f54ffd127b3949dbedd926d29c2550bf10790da7a879f211712fb85cb19e733
---Asset Balance Deltas---

 Asset ID                                                         Balance Change
 ──────────────────────────────────────────────────────────────── ──────────────
 d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6 -11000
✨  Done in 3.54s.
```
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
The output of this RPC will rename `owner->isOwner` to make room for the new `owner` address. Not sure if we will need to notify pools