### PR TITLE
Check validity of coin/fee input numbers

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils } from '@ironfish/sdk'
+import { CurrencyUtils, MAXIMUM_ORE_AMOUNT, MINIMUM_ORE_AMOUNT } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -84,18 +84,37 @@ export class Burn extends IronfishCommand {
 
     let amount
     if (flags.amount) {
-      amount = CurrencyUtils.decodeIron(flags.amount)
+      try {
+        amount = CurrencyUtils.decodeIron(flags.amount)
+      } catch {
+        amount = new Error()
+      }
     } else {
       const input = await CliUx.ux.prompt('Enter the amount to burn in the custom asset', {
         required: true,
       })
+      try {
+        amount = CurrencyUtils.decodeIron(input)
+      } catch {
+        amount = new Error()
+      }
+    }
 
-      amount = CurrencyUtils.decodeIron(input)
+    if (
+      typeof amount !== 'bigint' ||
+      amount < MINIMUM_ORE_AMOUNT ||
+      amount > MAXIMUM_ORE_AMOUNT
+    ) {
+      this.error(`The amount of coins is not a valid number.`)
     }
 
     let fee
     if (flags.fee) {
-      fee = CurrencyUtils.decodeIron(flags.fee)
+      try {
+        fee = CurrencyUtils.decodeIron(flags.fee)
+      } catch {
+        fee = new Error()
+      }
     } else {
       const input = await CliUx.ux.prompt(
         `Enter the fee amount in $IRON (min: ${CurrencyUtils.renderIron(1n)})`,
@@ -105,7 +124,15 @@ export class Burn extends IronfishCommand {
         },
       )
 
-      fee = CurrencyUtils.decodeIron(input)
+      try {
+        fee = CurrencyUtils.decodeIron(input)
+      } catch {
+        fee = new Error()
+      }
+    }
+
+    if (typeof fee !== 'bigint' || fee < MINIMUM_ORE_AMOUNT || fee > MAXIMUM_ORE_AMOUNT) {
+      this.error(`The fee amount is not a valid number.`)
     }
 
     if (!flags.confirm) {

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils } from '@ironfish/sdk'
+import { CurrencyUtils, MAXIMUM_ORE_AMOUNT, MINIMUM_ORE_AMOUNT } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -118,18 +118,38 @@ export class Mint extends IronfishCommand {
 
     let amount
     if (flags.amount) {
-      amount = CurrencyUtils.decodeIron(flags.amount)
+      try {
+        amount = CurrencyUtils.decodeIron(flags.amount)
+      } catch {
+        amount = new Error()
+      }
     } else {
       const input = await CliUx.ux.prompt('Enter the amount to mint in the custom asset', {
         required: true,
       })
 
-      amount = CurrencyUtils.decodeIron(input)
+      try {
+        amount = CurrencyUtils.decodeIron(input)
+      } catch {
+        amount = new Error()
+      }
+    }
+
+    if (
+      typeof amount !== 'bigint' ||
+      amount < MINIMUM_ORE_AMOUNT ||
+      amount > MAXIMUM_ORE_AMOUNT
+    ) {
+      this.error(`The amount of coins is not a valid number.`)
     }
 
     let fee
     if (flags.fee) {
-      fee = CurrencyUtils.decodeIron(flags.fee)
+      try {
+        fee = CurrencyUtils.decodeIron(flags.fee)
+      } catch {
+        fee = new Error()
+      }
     } else {
       const input = await CliUx.ux.prompt(
         `Enter the fee amount in $IRON (min: ${CurrencyUtils.renderIron(1n)})`,
@@ -139,7 +159,15 @@ export class Mint extends IronfishCommand {
         },
       )
 
-      fee = CurrencyUtils.decodeIron(input)
+      try {
+        fee = CurrencyUtils.decodeIron(input)
+      } catch {
+        fee = new Error()
+      }
+    }
+
+    if (typeof fee !== 'bigint' || fee < MINIMUM_ORE_AMOUNT || fee > MAXIMUM_ORE_AMOUNT) {
+      this.error(`The fee amount is not a valid number.`)
     }
 
     if (!flags.confirm) {

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -106,7 +106,11 @@ export class Send extends IronfishCommand {
     }
 
     if (flags.amount) {
-      amount = CurrencyUtils.decodeIron(flags.amount)
+      try {
+        amount = CurrencyUtils.decodeIron(flags.amount)
+      } catch {
+        amount = new Error()
+      }
     }
 
     if (amount === null) {
@@ -119,7 +123,19 @@ export class Send extends IronfishCommand {
         },
       )
 
-      amount = CurrencyUtils.decodeIron(input)
+      try {
+        amount = CurrencyUtils.decodeIron(input)
+      } catch {
+        amount = new Error()
+      }
+    }
+
+    if (
+      typeof amount !== 'bigint' ||
+      amount < MINIMUM_ORE_AMOUNT ||
+      amount > MAXIMUM_ORE_AMOUNT
+    ) {
+      this.error(`The amount of coins is not a valid number.`)
     }
 
     if (flags.fee !== undefined) {

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -7,6 +7,8 @@ import {
   CreateTransactionResponse,
   CurrencyUtils,
   isValidPublicAddress,
+  MAXIMUM_ORE_AMOUNT,
+  MINIMUM_ORE_AMOUNT,
   RawTransactionSerde,
   RpcResponseEnded,
   Transaction,

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -8,6 +8,8 @@ import {
   DEFAULT_USE_RPC_IPC,
   DEFAULT_USE_RPC_TCP,
   DEFAULT_USE_RPC_TLS,
+  MAXIMUM_ORE_AMOUNT,
+  MINIMUM_ORE_AMOUNT,
 } from '@ironfish/sdk'
 import { Flags, Interfaces } from '@oclif/core'
 
@@ -111,14 +113,23 @@ export const IronFlag = Flags.custom<bigint, IronOpts>({
   char: 'i',
 })
 
-const parseIron = (input: string, opts: IronOpts): Promise<bigint> => {
+export const parseIron = (input: string, opts: IronOpts): Promise<bigint> => {
   return new Promise((resolve, reject) => {
     const { largerThan, flagName } = opts ?? {}
-    const value = CurrencyUtils.decodeIron(input)
-    if (largerThan !== undefined && value <= largerThan) {
-      reject(new Error(`The minimum ${flagName} is ${CurrencyUtils.renderOre(1n, true)}`))
-    }
+    try {
+      const value = CurrencyUtils.decodeIron(input)
 
-    resolve(value)
+      if (largerThan !== undefined && value <= largerThan) {
+        reject(new Error(`The minimum ${flagName} is ${CurrencyUtils.renderOre(1n, true)}`))
+      }
+
+      if (value < MINIMUM_ORE_AMOUNT || value > MAXIMUM_ORE_AMOUNT) {
+        reject(new Error(`The number inputted for ${flagName} is invalid.`))
+      }
+
+      resolve(value)
+    } catch {
+      reject(new Error(`The number inputted for ${flagName} is invalid.`))
+    }
   })
 }

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -120,7 +120,9 @@ export const parseIron = (input: string, opts: IronOpts): Promise<bigint> => {
       const value = CurrencyUtils.decodeIron(input)
 
       if (largerThan !== undefined && value <= largerThan) {
-        reject(new Error(`The minimum ${flagName} is ${CurrencyUtils.renderOre(1n, true)}`))
+        reject(
+          new Error(`The minimum ${flagName} is ${CurrencyUtils.renderOre(largerThan, true)}`),
+        )
       }
 
       if (value < MINIMUM_ORE_AMOUNT || value > MAXIMUM_ORE_AMOUNT) {


### PR DESCRIPTION
## Summary

There have been a number of issues raised relating to overflow/underflow of coin amounts people are inputting. See https://github.com/iron-fish/ironfish/issues/2984, https://github.com/iron-fish/ironfish/issues/3043, https://github.com/iron-fish/ironfish/issues/3066. 

This task is aimed at improving input checks by 
1) catching underflow errors from `decodeIron` that result in https://github.com/iron-fish/ironfish/issues/3066
2) checking fee/coin inputs are within the valid range of **MINIMUM_ORE_AMOUNT** to **MAXIMUM_ORE_AMOUNT**

## Testing Plan
test `wallet:send/mint/burn` commands with fee and coin inputs that are outside the valid range

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
