### PR TITLE
Add char flag datadir

### DIFF
--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -168,7 +168,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
     }
 
     // Exit if dry run, otherwise confirm
-    if (flags.dryRun) {
+    if (flags.dry) {
       this.exit(0)
     } else {
       const result = await CliUx.ux.confirm('\nCreate the genesis block? (y)es / (n)o')

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -52,7 +52,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
       default: '42000000',
       description: 'The amount of coins in the genesis block',
     }),
-    dryRun: Flags.boolean({
+    dry: Flags.boolean({
       default: false,
       description: 'Display genesis block allocations without creating the genesis block',
     }),

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -53,7 +53,6 @@ export default class GenesisBlockCommand extends IronfishCommand {
       description: 'The amount of coins in the genesis block',
     }),
     dryRun: Flags.boolean({
-      char: 'd',
       default: false,
       description: 'Display genesis block allocations without creating the genesis block',
     }),

--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -22,7 +22,6 @@ export class StartPool extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     discord: Flags.string({
-      char: 'd',
       description: 'A discord webhook URL to send critical information to',
     }),
     lark: Flags.string({

--- a/ironfish-cli/src/commands/service/estimate-fee-rates.ts
+++ b/ironfish-cli/src/commands/service/estimate-fee-rates.ts
@@ -30,7 +30,6 @@ export default class EstimateFees extends IronfishCommand {
       description: 'API host token to authenticate with',
     }),
     delay: Flags.integer({
-      char: 'd',
       required: false,
       default: 60000,
       description: 'Delay (in ms) to wait before uploading fee rate estimates',

--- a/ironfish-cli/src/commands/service/forks.ts
+++ b/ironfish-cli/src/commands/service/forks.ts
@@ -31,7 +31,6 @@ export default class Forks extends IronfishCommand {
       description: 'API host token to authenticate with',
     }),
     delay: Flags.integer({
-      char: 'd',
       required: false,
       default: 60000,
       description: 'Delay (in ms) to wait before uploading fork count',

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -42,6 +42,7 @@ export const ConfigFlag = Flags.string({
 })
 
 export const DataDirFlag = Flags.string({
+  char: 'd',
   default: DEFAULT_DATA_DIR,
   description: 'The path to the data dir',
   env: 'IRONFISH_DATA_DIR',


### PR DESCRIPTION
## Summary
Add a character shortcut for the --datadir flag since it's used often in development. Remove other -d flags because they are not used often

## Testing Plan
local testing. Also checked terraform to see that we are [not using -d flag](https://github.com/iron-fish/terraform/blob/1e667c6984b1827e8e7bc5f41bd94294acac7667/modules/pool/main.tf#L36)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
