### PR TITLE
feat: export mnemonic (1/2)

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -37,6 +37,16 @@ export interface NativeSpendDescription {
 export const PROOF_LENGTH: number
 export const TRANSACTION_VERSION: number
 export function verifyTransactions(serializedTransactions: Array<Buffer>): boolean
+export const enum LanguageCode {
+  English = 0,
+  ChineseSimplified = 1,
+  ChineseTraditional = 2,
+  French = 3,
+  Italian = 4,
+  Japanese = 5,
+  Korean = 6,
+  Spanish = 7
+}
 export interface Key {
   spending_key: string
   incoming_view_key: string
@@ -44,6 +54,7 @@ export interface Key {
   public_address: string
 }
 export function generateKey(): Key
+export function wordsSpendingKey(privateKey: string, languageCode: LanguageCode): string
 export function generateKeyFromPrivateKey(privateKey: string): Key
 export function initializeSapling(): void
 export function isValidPublicAddress(hexAddress: string): boolean

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -246,7 +246,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_OWNER_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, GENERATOR_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, TransactionPosted, PROOF_LENGTH, TRANSACTION_VERSION, Transaction, verifyTransactions, generateKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_OWNER_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, GENERATOR_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, TransactionPosted, PROOF_LENGTH, TRANSACTION_VERSION, Transaction, verifyTransactions, LanguageCode, generateKey, wordsSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.contribute = contribute
 module.exports.verifyTransform = verifyTransform
@@ -280,7 +280,9 @@ module.exports.PROOF_LENGTH = PROOF_LENGTH
 module.exports.TRANSACTION_VERSION = TRANSACTION_VERSION
 module.exports.Transaction = Transaction
 module.exports.verifyTransactions = verifyTransactions
+module.exports.LanguageCode = LanguageCode
 module.exports.generateKey = generateKey
+module.exports.wordsSpendingKey = wordsSpendingKey
 module.exports.generateKeyFromPrivateKey = generateKeyFromPrivateKey
 module.exports.initializeSapling = initializeSapling
 module.exports.FoundBlockResult = FoundBlockResult

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -80,7 +80,7 @@ pub fn generate_key() -> Key {
 #[napi]
 pub fn words_spending_key(private_key: String, language_code: LanguageCode) -> Result<String> {
     let key = SaplingKey::from_hex(&private_key).map_err(to_napi_err)?;
-    key.words_spending_key(&language_code.into())
+    key.words_spending_key(language_code.into())
         .map_err(to_napi_err)
 }
 

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -30,7 +30,6 @@ describe('Demonstrate the Sapling API', () => {
   it('Should return phrase words from key input', () => {
     const key = generateKey()
     const words = wordsSpendingKey(key.spending_key, LanguageCode.English);
-    console.log(words)
     expect(words.split(' ').length).toEqual(24)
   })
 

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Asset, DECRYPTED_NOTE_LENGTH } from '..'
+import { Asset, DECRYPTED_NOTE_LENGTH, LanguageCode, wordsSpendingKey } from '..'
 import {
   initializeSapling,
   generateKey,
@@ -25,6 +25,13 @@ describe('Demonstrate the Sapling API', () => {
     expect(typeof key.outgoing_view_key).toBe('string')
     expect(typeof key.public_address).toBe('string')
     expect(typeof key.spending_key).toBe('string')
+  })
+
+  it('Should return phrase words from key input', () => {
+    const key = generateKey()
+    const words = wordsSpendingKey(key.spending_key, LanguageCode.English);
+    console.log(words)
+    expect(words.split(' ').length).toEqual(24)
   })
 
   it('Should generate a new public address given a spending key', () => {

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -26,6 +26,7 @@ pub enum IronfishError {
     InvalidData,
     InvalidDecryptionKey,
     InvalidDiversificationPoint,
+    InvalidEntropy,
     InvalidLanguageEncoding,
     InvalidMinersFeeTransaction,
     InvalidNonceLength,

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -197,8 +197,8 @@ impl SaplingKey {
     /// a seed. This isn't strictly necessary for private key, but view keys
     /// will need a direct mapping. The private key could still be generated
     /// using bip-32 and bip-39 if desired.
-    pub fn words_spending_key(&self, language: &Language) -> Result<String, IronfishError> {
-        let mnemonic = Mnemonic::from_entropy(&self.spending_key, *language)
+    pub fn words_spending_key(&self, language: Language) -> Result<String, IronfishError> {
+        let mnemonic = Mnemonic::from_entropy(&self.spending_key, language)
             .map_err(|_| IronfishError::InvalidEntropy)?;
         Ok(mnemonic.phrase().to_string())
     }

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -5,7 +5,8 @@
 use crate::errors::IronfishError;
 
 use super::serializing::{bytes_to_hex, hex_to_bytes, read_scalar};
-use bip39::{Language, Mnemonic};
+pub use bip39::Language;
+use bip39::Mnemonic;
 use blake2b_simd::Params as Blake2b;
 use blake2s_simd::Params as Blake2s;
 use group::GroupEncoding;
@@ -29,7 +30,9 @@ pub use view_keys::*;
 mod test;
 
 const EXPANDED_SPEND_BLAKE2_KEY: &[u8; 16] = b"Iron Fish Money ";
+
 pub const SPEND_KEY_SIZE: usize = 32;
+
 /// A single private key generates multiple other key parts that can
 /// be used to allow various forms of access to a commitment note:
 ///
@@ -194,10 +197,9 @@ impl SaplingKey {
     /// a seed. This isn't strictly necessary for private key, but view keys
     /// will need a direct mapping. The private key could still be generated
     /// using bip-32 and bip-39 if desired.
-    pub fn words_spending_key(&self, language_code: &str) -> Result<String, IronfishError> {
-        let language = Language::from_language_code(language_code)
-            .ok_or(IronfishError::InvalidLanguageEncoding)?;
-        let mnemonic = Mnemonic::from_entropy(&self.spending_key, language).unwrap();
+    pub fn words_spending_key(&self, language: &Language) -> Result<String, IronfishError> {
+        let mnemonic = Mnemonic::from_entropy(&self.spending_key, *language)
+            .map_err(|_| IronfishError::InvalidEntropy)?;
         Ok(mnemonic.phrase().to_string())
     }
 

--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -118,9 +118,9 @@ fn test_hex_conversion() {
 fn test_words_spending_key() {
     let key = SaplingKey::generate_key();
     let words = key
-        .words_spending_key(&bip39::Language::English)
+        .words_spending_key(bip39::Language::English)
         .expect("Should return words");
-    let expected_words = MnemonicType::for_key_size(&key.spending_key[..].len() * 8)
+    let expected_words = MnemonicType::for_key_size(key.spending_key.len() * 8)
         .expect("valid key size")
         .word_count();
     assert_eq!(words.split(' ').count(), expected_words);

--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -5,6 +5,7 @@
 use crate::keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE};
 
 use super::{shared_secret, PublicAddress, SaplingKey};
+use bip39::MnemonicType;
 use group::Curve;
 use jubjub::ExtendedPoint;
 
@@ -111,4 +112,16 @@ fn test_hex_conversion() {
     assert_eq!(second_address, address);
 
     assert!(PublicAddress::from_hex("invalid").is_err());
+}
+
+#[test]
+fn test_words_spending_key() {
+    let key = SaplingKey::generate_key();
+    let words = key
+        .words_spending_key(&bip39::Language::English)
+        .expect("Should return words");
+    let expected_words = MnemonicType::for_key_size(&key.spending_key[..].len() * 8)
+        .expect("valid key size")
+        .word_count();
+    assert_eq!(words.split(' ').count(), expected_words);
 }


### PR DESCRIPTION
## Summary
- Exposes Mnemonic phrase generation from the rust side into TS side. 
- Uses the `bip39` library we already have installed.
- Adds `LanguageCode` enum for usage typescript side. Sadly the support for enums is crap in napi, manual mapping is the best we can do.

### Implementation note
I considered adding the function to a new `.rs` file (ie `keys.ts`) but I saw there was a pattern for key helper functions already set up in `lib.rs` didn't want to diverge in this PR.

## Followup PR
[Next pull request will be added here. It will update the export command and call this NAPI function.](https://github.com/iron-fish/ironfish/pull/3207)

## Testing Plan
Tests
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
