### PR TITLE
fix: solo miner will wait for new work after submitting

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -172,7 +172,7 @@ export class FoundBlockResult {
   constructor(randomness: string, miningRequestId: number)
 }
 export class ThreadPoolHandler {
-  constructor(threadCount: number, batchSize: number)
+  constructor(threadCount: number, batchSize: number, pauseOnSuccess: boolean)
   newWork(headerBytes: Buffer, target: Buffer, miningRequestId: number): void
   stop(): void
   pause(): void

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -74,9 +74,13 @@ pub struct ThreadPoolHandler {
 #[napi]
 impl ThreadPoolHandler {
     #[napi(constructor)]
-    pub fn new(thread_count: u32, batch_size: u32) -> Self {
+    pub fn new(thread_count: u32, batch_size: u32, pause_on_success: bool) -> Self {
         ThreadPoolHandler {
-            threadpool: mining::threadpool::ThreadPool::new(thread_count as usize, batch_size),
+            threadpool: mining::threadpool::ThreadPool::new(
+                thread_count as usize,
+                batch_size,
+                pause_on_success,
+            ),
         }
     }
 

--- a/ironfish-rust/src/mining/thread.rs
+++ b/ironfish-rust/src/mining/thread.rs
@@ -30,6 +30,7 @@ impl Thread {
         hash_rate_channel: Sender<u32>,
         pool_size: usize,
         batch_size: u32,
+        pause_on_success: bool,
     ) -> Self {
         let (work_sender, work_receiver) = mpsc::channel::<Command>();
 
@@ -43,6 +44,7 @@ impl Thread {
                     id,
                     pool_size,
                     batch_size as u64,
+                    pause_on_success,
                 )
             })
             .unwrap();
@@ -78,6 +80,7 @@ fn process_commands(
     start: u64,
     step_size: usize,
     default_batch_size: u64,
+    pause_on_success: bool,
 ) {
     let mut commands: VecDeque<Command> = VecDeque::new();
     loop {
@@ -124,6 +127,10 @@ fn process_commands(
                     if let Some(randomness) = match_found {
                         if let Err(e) = block_found_channel.send((randomness, mining_request_id)) {
                             panic!("Error sending found block: {:?}", e);
+                        }
+
+                        if pause_on_success {
+                            break;
                         }
                     }
 

--- a/ironfish-rust/src/mining/threadpool.rs
+++ b/ironfish-rust/src/mining/threadpool.rs
@@ -12,7 +12,7 @@ pub struct ThreadPool {
     mining_request_id: u32,
 }
 impl ThreadPool {
-    pub fn new(thread_count: usize, batch_size: u32) -> Self {
+    pub fn new(thread_count: usize, batch_size: u32, pause_on_success: bool) -> Self {
         let (block_found_channel, block_found_receiver) = mpsc::channel::<(u64, u32)>();
 
         let (hash_rate_channel, hash_rate_receiver) = mpsc::channel::<u32>();
@@ -25,6 +25,7 @@ impl ThreadPool {
                 hash_rate_channel.clone(),
                 thread_count,
                 batch_size,
+                pause_on_success,
             ));
         }
 

--- a/ironfish/src/mining/poolMiner.ts
+++ b/ironfish/src/mining/poolMiner.ts
@@ -48,7 +48,7 @@ export class MiningPoolMiner {
     }
 
     const threadCount = options.threadCount ?? 1
-    this.threadPool = new ThreadPoolHandler(threadCount, options.batchSize)
+    this.threadPool = new ThreadPoolHandler(threadCount, options.batchSize, false)
 
     this.stratum = new StratumClient({
       host: options.host,

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -55,7 +55,7 @@ export class MiningSoloMiner {
     this.graffiti = options.graffiti
 
     const threadCount = options.threadCount ?? 1
-    this.threadPool = new ThreadPoolHandler(threadCount, options.batchSize)
+    this.threadPool = new ThreadPoolHandler(threadCount, options.batchSize, true)
 
     this.miningRequestId = 0
     this.nextMiningRequestId = 0


### PR DESCRIPTION
## Summary

This will still submit multiple blocks in the case of having a high thread count and a very easy target, but it will be at most n submissions where n is the number of threads. This still allows the node to process and create a new block template, making it much harder for the node to get overloaded

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
