### PR TITLE
feat(cli): rename wallet:remove to wallet:delete

### DIFF
--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -6,8 +6,8 @@ import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
-export class RemoveCommand extends IronfishCommand {
-  static description = `Permanently remove an account`
+export class DeleteCommand extends IronfishCommand {
+  static description = `Permanently delete an account`
 
   static args = [
     {
@@ -26,7 +26,7 @@ export class RemoveCommand extends IronfishCommand {
   }
 
   async start(): Promise<void> {
-    const { args, flags } = await this.parse(RemoveCommand)
+    const { args, flags } = await this.parse(DeleteCommand)
     const confirm = flags.confirm
     const name = args.account as string
 
@@ -45,6 +45,6 @@ export class RemoveCommand extends IronfishCommand {
       await client.removeAccount({ name, confirm: true })
     }
 
-    this.log(`Account '${name}' successfully removed.`)
+    this.log(`Account '${name}' successfully deleted.`)
   }
 }


### PR DESCRIPTION
## Summary
Renamed the `wallet:remove` command to `wallet:delete`

## Testing Plan
### Command renamed 
```
➜  ironfish-cli git:(austin/cli-rename-remove-cmd) yarn start wallet
yarn run v1.22.19
$ yarn build && yarn start:js wallet
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet
List all the accounts on the node

USAGE
  $ ironfish wallet:COMMAND

COMMANDS
  wallet:accounts      List all the accounts on the node
  wallet:address       Display your account address
  wallet:balance       Display the account balance
  wallet:balances      Display the account's balances for all assets
  wallet:burn          Burn tokens and decrease supply for a given asset
  wallet:create        Create a new account for sending and receiving coins
  wallet:delete        Permanently delete an account <--
  wallet:export        Export an account
  wallet:import        Import an account
  wallet:mint          Mint tokens and increase supply for a given asset
  wallet:notes         Display the account notes
  wallet:repair        Repairs wallet database stores
  wallet:rescan        Rescan the blockchain for transaction
  wallet:send          Send coins to another account
  wallet:status        Get status of an account
  wallet:transaction   Display an account transaction
  wallet:transactions  Display the account transactions
  wallet:use           Change the default account used by all commands
  wallet:which         Show the account currently used.
 ```

### Command functionality preserved
```
➜  ironfish-cli git:(austin/cli-rename-remove-cmd) yarn start wallet:create
yarn run v1.22.19
$ yarn build && yarn start:js wallet:create
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:create
Enter the name of the account: test-cli-rename
Creating account test-cli-rename
Account test-cli-rename created with public address 799a8c1b1a40e8940d9e14eed3fb2840f26e492c7aeb286ced12f4dfa9891eba
The default account is now: test-cli-rename
✨  Done in 4.22s.

➜  ironfish-cli git:(austin/cli-rename-remove-cmd) yarn start wallet:which
yarn run v1.22.19
$ yarn build && yarn start:js wallet:which
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:which
test-cli-rename
✨  Done in 1.23s.

➜  ironfish-cli git:(austin/cli-rename-remove-cmd) yarn start wallet:delete test-cli-rename
yarn run v1.22.19
$ yarn build && yarn start:js wallet:delete test-cli-rename
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:delete test-cli-rename
Account 'test-cli-rename' successfully deleted.
✨  Done in 1.28s.

➜  ironfish-cli git:(austin/cli-rename-remove-cmd) yarn start wallet:which
yarn run v1.22.19
$ yarn build && yarn start:js wallet:which
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:which
There is currently no account being used.
 * Create an account: "ironfish wallet:create"
 * List all accounts: "ironfish wallet:accounts"
 * Use an existing account: "ironfish wallet:use <name>"
✨  Done in 1.22s.
```
  
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

[ ] Yes
[X] No
```
