### PR TITLE
fixes oclif custom timestamp column width

### DIFF
--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -32,7 +32,7 @@ const timestamp = <T extends Record<string, unknown>>(options?: {
 
   // We should only use estimated minWidth if you are streaming
   let minWidth
-  if (!streaming && options?.minWidth === undefined) {
+  if (streaming && options?.minWidth === undefined) {
     minWidth = MAX_TIMESTAMP_LENGTH
   } else {
     minWidth = options?.minWidth


### PR DESCRIPTION
## Summary

uses estimated maximum width when streaming

## Testing Plan

Before:
<img width="706" alt="image" src="https://user-images.githubusercontent.com/57735705/214716606-78212ab8-2082-45fd-b34c-4c165f5f4e52.png">

After:
<img width="551" alt="image" src="https://user-images.githubusercontent.com/57735705/214716708-39105bcc-0b08-4a85-af5f-1069952c11ad.png">



## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
