### PR TITLE
parse client messages and pass in timeouts to server script

### DIFF
--- a/ironfish-cli/src/commands/service/ceremony.ts
+++ b/ironfish-cli/src/commands/service/ceremony.ts
@@ -8,6 +8,10 @@ import { RemoteFlags } from '../../flags'
 import { CeremonyServer } from '../../trusted-setup/server'
 import { S3Utils } from '../../utils'
 
+const CONTRIBUTE_TIMEOUT_MS = 5 * 60 * 1000
+const UPLOAD_TIMEOUT_MS = 5 * 60 * 1000
+const PRESIGNED_EXPIRATION_SEC = 5 * 60
+
 export default class Ceremony extends IronfishCommand {
   static hidden = true
 
@@ -23,6 +27,21 @@ export default class Ceremony extends IronfishCommand {
       required: false,
       description: 'S3 bucket to download and upload params to',
       default: 'ironfish-contributions',
+    }),
+    contributionTimoutMs: Flags.integer({
+      required: false,
+      description: 'Allowable milliseconds for a contributor to run the contribution script',
+      default: CONTRIBUTE_TIMEOUT_MS,
+    }),
+    uploadTimoutMs: Flags.integer({
+      required: false,
+      description: 'Allowable milliseconds for a contributor to upload their new parameters',
+      default: UPLOAD_TIMEOUT_MS,
+    }),
+    presignedExpirationSec: Flags.integer({
+      required: false,
+      description: 'How many seconds the S3 pre-signed upload URL is valid for a contributor',
+      default: PRESIGNED_EXPIRATION_SEC,
     }),
   }
 
@@ -43,6 +62,9 @@ export default class Ceremony extends IronfishCommand {
       s3Bucket: flags.bucket,
       s3Client: s3Client,
       tempDir: this.sdk.config.tempDir,
+      contributionTimoutMs: flags.contributionTimoutMs,
+      uploadTimoutMs: flags.uploadTimoutMs,
+      presignedExpirationSec: flags.presignedExpirationSec,
     })
 
     await server.start()

--- a/ironfish-cli/src/commands/service/ceremony.ts
+++ b/ironfish-cli/src/commands/service/ceremony.ts
@@ -28,12 +28,12 @@ export default class Ceremony extends IronfishCommand {
       description: 'S3 bucket to download and upload params to',
       default: 'ironfish-contributions',
     }),
-    contributionTimoutMs: Flags.integer({
+    contributionTimeoutMs: Flags.integer({
       required: false,
       description: 'Allowable milliseconds for a contributor to run the contribution script',
       default: CONTRIBUTE_TIMEOUT_MS,
     }),
-    uploadTimoutMs: Flags.integer({
+    uploadTimeoutMs: Flags.integer({
       required: false,
       description: 'Allowable milliseconds for a contributor to upload their new parameters',
       default: UPLOAD_TIMEOUT_MS,
@@ -62,8 +62,8 @@ export default class Ceremony extends IronfishCommand {
       s3Bucket: flags.bucket,
       s3Client: s3Client,
       tempDir: this.sdk.config.tempDir,
-      contributionTimoutMs: flags.contributionTimoutMs,
-      uploadTimoutMs: flags.uploadTimoutMs,
+      contributionTimeoutMs: flags.contributionTimeoutMs,
+      uploadTimeoutMs: flags.uploadTimeoutMs,
       presignedExpirationSec: flags.presignedExpirationSec,
     })
 

--- a/ironfish-cli/src/trusted-setup/schema.ts
+++ b/ironfish-cli/src/trusted-setup/schema.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import * as yup from 'yup'
+
 export type CeremonyServerMessage =
   | {
       method: 'joined'
@@ -23,10 +25,12 @@ export type CeremonyServerMessage =
       contributionNumber: number
     }
 
-export type CeremonyClientMessage =
-  | {
-      method: 'contribution-complete'
-    }
-  | {
-      method: 'upload-complete'
-    }
+export type CeremonyClientMessage = {
+  method: 'contribution-complete' | 'upload-complete'
+}
+
+export const CeremonyClientMessageSchema: yup.ObjectSchema<CeremonyClientMessage> = yup
+  .object({
+    method: yup.string().oneOf(['contribution-complete', 'upload-complete']).required(),
+  })
+  .required()

--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -62,8 +62,8 @@ export class CeremonyServer {
 
   private currentContributor: CurrentContributor | null = null
 
-  readonly contributionTimoutMs: number
-  readonly uploadTimoutMs: number
+  readonly contributionTimeoutMs: number
+  readonly uploadTimeoutMs: number
   readonly presignedExpirationSec: number
 
   constructor(options: {
@@ -73,8 +73,8 @@ export class CeremonyServer {
     s3Bucket: string
     s3Client: S3Client
     tempDir: string
-    contributionTimoutMs: number
-    uploadTimoutMs: number
+    contributionTimeoutMs: number
+    uploadTimeoutMs: number
     presignedExpirationSec: number
   }) {
     this.logger = options.logger
@@ -88,8 +88,8 @@ export class CeremonyServer {
     this.s3Bucket = options.s3Bucket
     this.s3Client = options.s3Client
 
-    this.contributionTimoutMs = options.contributionTimoutMs
-    this.uploadTimoutMs = options.uploadTimoutMs
+    this.contributionTimeoutMs = options.contributionTimeoutMs
+    this.uploadTimeoutMs = options.uploadTimeoutMs
     this.presignedExpirationSec = options.presignedExpirationSec
 
     this.server = net.createServer((s) => this.onConnection(s))
@@ -127,7 +127,7 @@ export class CeremonyServer {
 
     const contributionTimeout = setTimeout(() => {
       this.closeClient(nextClient, new Error('Failed to complete contribution in time'))
-    }, this.contributionTimoutMs)
+    }, this.contributionTimeoutMs)
 
     this.currentContributor = {
       state: 'STARTED',
@@ -253,7 +253,7 @@ export class CeremonyServer {
 
     this.currentContributor.actionTimeout = setTimeout(() => {
       this.closeClient(client, new Error('Failed to complete upload in time'))
-    }, this.uploadTimoutMs)
+    }, this.uploadTimeoutMs)
 
     client.send({
       method: 'initiate-upload',


### PR DESCRIPTION
## Summary
Parsing messages from clients using yup so un-parsable messages do not crash the server. Also paramtaraizing timeouts on the server side so we can increase them if clients are having trouble uploading or contributing in the allotted time 

## Testing Plan
Tested locally

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
