### PR TITLE
feat(ironfish): add influx support for tracking the duration required to create new block templates

### DIFF
--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -19,10 +19,10 @@ import { Metric } from './interfaces/metric'
 import { Tag } from './interfaces/tag'
 
 export class Telemetry {
-  private readonly FLUSH_INTERVAL = 5 * 60 * 1000
+  private readonly FLUSH_INTERVAL = 5 * 60 * 1000 // 5 minutes
   private readonly MAX_POINTS_TO_SUBMIT = 1000
   private readonly MAX_RETRIES = 5
-  private readonly METRICS_INTERVAL = 5 * 60 * 1000
+  private readonly METRICS_INTERVAL = 5 * 60 * 1000 // 5 minutes
 
   private readonly chain: Blockchain
   private readonly config: Config
@@ -189,6 +189,11 @@ export class Telemetry {
         type: 'integer',
         value: this.chain.head.sequence,
       },
+      {
+        name: 'create_new_block_template_duration',
+        type: 'float',
+        value: this.metrics.mining_newBlockTemplate.rate5m,
+      }
     ]
 
     for (const [messageType, meter] of this.metrics.p2p_InboundTrafficByMessage) {
@@ -225,6 +230,14 @@ export class Telemetry {
           value: meter.avg,
         })
       }
+    }
+
+    if (this.metrics.mining_newBlockTemplate._average.sampleCount() >= 10) {
+      fields.push({
+        name: 'create_new_block_template_duration',
+        type: 'float',
+        value: this.metrics.mining_newBlockTemplate.rate5m,
+      })
     }
 
     this.submit({
@@ -283,7 +296,7 @@ export class Telemetry {
 
     if (points.length === 0) {
       return
-    }
+    } 
 
     try {
       const graffiti = GraffitiUtils.fromString(this.config.get('blockGraffiti'))

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -193,7 +193,7 @@ export class Telemetry {
         name: 'create_new_block_template_duration',
         type: 'float',
         value: this.metrics.mining_newBlockTemplate.rate5m,
-      }
+      },
     ]
 
     for (const [messageType, meter] of this.metrics.p2p_InboundTrafficByMessage) {
@@ -296,7 +296,7 @@ export class Telemetry {
 
     if (points.length === 0) {
       return
-    } 
+    }
 
     try {
       const graffiti = GraffitiUtils.fromString(this.config.get('blockGraffiti'))

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -189,11 +189,6 @@ export class Telemetry {
         type: 'integer',
         value: this.chain.head.sequence,
       },
-      {
-        name: 'create_new_block_template_duration',
-        type: 'float',
-        value: this.metrics.mining_newBlockTemplate.rate5m,
-      },
     ]
 
     for (const [messageType, meter] of this.metrics.p2p_InboundTrafficByMessage) {


### PR DESCRIPTION
## Summary
Add Influx support for tracking the duration required to create new block templates. [This accompanying PR](https://github.com/iron-fish/ironfish-api/pull/1194) in the `ironfish-api` repo adds the measurement `create_new_block_template_duration` to the Influx telemetry whitelist. 

## Testing Plan
- Builds successfully locally
```
➜  ironfish-cli git:(holahula/feat/influx-block-template-support) yarn start start
yarn run v1.22.19
$ yarn build && yarn start:js start
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run start


::::::::::          :::::::::::::::::
::::::::::::       :::::::::::::::::::
:::::::::::::     :::::::::::::::::::::
::::::::::::::   ::::::::::::::::::::::::
 ::::::::::::: ::::::::::        :::::::::
   :::::::::::::::::::::          ::::::::::
   :::::::::::::::::::::          :::::::::
 ::::::::::::: ::::::::::        :::::::::
::::::::::::::   ::::::::::::::::::::::::
:::::::::::::     :::::::::::::::::::::
::::::::::::       :::::::::::::::::::
::::::::::           ::::::::::::::::

Version       0.1.63 @ src
Node Name     NONE
Graffiti      NONE
Peer Identity SD+CsCbl/txW7+sLKz9GJKg/KaimySeVw7/D/DaHCw4=
Peer Agent    ironfish/0.1.63/src
Peer Port     9033
Bootstrap     test.bn1.ironfish.network
Inspector     ws://127.0.0.1:57478/530032a9-2be7-4894-a6d4-b5272e539b8c

WebSocket server started at :::9033
Connected to the Iron Fish network
```
- Telemetry data is being populated 
```
,,0,2023-01-27T15:58:25.014310947Z,2023-01-27T16:13:25.014310947Z,2023-01-27T16:08:00Z,0,create_new_block_template_duration,node_stats,true,0.1.63
```
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
