### PR TITLE
trusted-setup: Send correct queue location

### DIFF
--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -170,7 +170,7 @@ export class CeremonyServer {
   private onConnection(socket: net.Socket): void {
     const client = new CeremonyServerClient({ socket, id: uuid(), logger: this.logger })
     this.queue.push(client)
-    client.send({ method: 'joined', queueLocation: this.queue.length })
+    client.send({ method: 'joined', queueLocation: this.queue.length - 1 })
 
     socket.on('data', (data: Buffer) => void this.onData(client, data))
     socket.on('close', () => this.onDisconnect(client))


### PR DESCRIPTION
## Summary

In the other place we send queueLocation, we treat "0" as the currently contributing client. This aligns the queueLocation to be the same.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
