### PR TITLE
Fix default host for trusted setup

### DIFF
--- a/ironfish-cli/src/commands/ceremony.ts
+++ b/ironfish-cli/src/commands/ceremony.ts
@@ -159,8 +159,9 @@ export default class Ceremony extends IronfishCommand {
     let connected = false
     while (!connected) {
       CliUx.ux.action.start('Connecting')
-      connected = await client.start()
-      CliUx.ux.action.stop(connected ? 'done' : 'error')
+      const error = await client.start()
+      connected = error === null
+      CliUx.ux.action.stop(error ? `Error connecting: ${error}` : 'done')
 
       if (!connected) {
         this.log('Unable to connect to contribution server. Retrying in 5 seconds.')

--- a/ironfish-cli/src/commands/ceremony.ts
+++ b/ironfish-cli/src/commands/ceremony.ts
@@ -20,7 +20,7 @@ export default class Ceremony extends IronfishCommand {
     [DataDirFlagKey]: DataDirFlag,
     host: Flags.string({
       parse: (input: string) => Promise.resolve(input.trim()),
-      default: 'https://ceremony.ironfish.network',
+      default: 'ceremony.ironfish.network',
       description: 'Host address of the ceremony coordination server',
     }),
     port: Flags.integer({

--- a/ironfish-cli/src/trusted-setup/client.ts
+++ b/ironfish-cli/src/trusted-setup/client.ts
@@ -32,22 +32,19 @@ export class CeremonyClient {
     this.socket.on('data', (data) => void this.onData(data))
   }
 
-  async start(): Promise<boolean> {
+  async start(): Promise<string | null> {
     this.stopPromise = new Promise((r) => (this.stopResolve = r))
 
-    const connected = await connectSocket(this.socket, this.host, this.port)
-      .then(() => true)
-      .catch((e) => {
-        this.logger.log(ErrorUtils.renderError(e))
-        return false
-      })
+    const error = await connectSocket(this.socket, this.host, this.port)
+      .then(() => null)
+      .catch((e) => ErrorUtils.renderError(e))
 
-    if (connected) {
+    if (error === null) {
       this.socket.on('error', this.onError)
       this.socket.on('close', this.onDisconnect)
     }
 
-    return connected
+    return error
   }
 
   stop(success: boolean): void {

--- a/ironfish-cli/src/trusted-setup/client.ts
+++ b/ironfish-cli/src/trusted-setup/client.ts
@@ -37,7 +37,10 @@ export class CeremonyClient {
 
     const connected = await connectSocket(this.socket, this.host, this.port)
       .then(() => true)
-      .catch(() => false)
+      .catch((e) => {
+        this.logger.log(ErrorUtils.renderError(e))
+        return false
+      })
 
     if (connected) {
       this.socket.on('error', this.onError)


### PR DESCRIPTION
## Summary
Trusted setup does not use http so we need to remove that. Also adding some logic to display connection errors

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
