### PR TITLE
adds transactionAmounts datastore to walletDb

### DIFF
--- a/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
@@ -1314,5 +1314,131 @@
         }
       ]
     }
+  ],
+  "Accounts addPendingTransaction should add transaction amounts to transactionAmounts": [
+    {
+      "id": "6dddbe84-d076-43ff-ae87-65bf300da218",
+      "name": "accountA",
+      "spendingKey": "4f1ce64021128f548eea6f0fb85f39999b9de2aa7b5d0a61b526ebaba4f9aaf1",
+      "incomingViewKey": "802a46fc9b844dcb2318489502445b6d37f73946591d7fa5615c4967e8815b04",
+      "outgoingViewKey": "cab361555efa70f487d0c3effa6baf8ec7e5e305bbb371aae91311bf0329b4ad",
+      "publicAddress": "71a86cedeb462dada6f8da959d557da93c941b194a03be2229aef6ea2f9096b7"
+    },
+    {
+      "id": "5da20aed-7693-43cb-8442-78d8b1fd2a12",
+      "name": "accountB",
+      "spendingKey": "97b01eca376537598ddea19d053abccbbd6e4f2f79f7c9ab14a0c05ada8dd66e",
+      "incomingViewKey": "4e34c4dec8125501a9d11d4e6fcc07157f7092f72e247326b4c588b8d995c005",
+      "outgoingViewKey": "1c6e4bca8b232e7b0ae5d6f7057474e830216e48cff72b2fae16f647e46b1d08",
+      "publicAddress": "f5b38d77ce6f8f74a4cda92798725230b0836939210f567f8983a55d0303a8c1"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+vcxGalDt4gtVMZgdMEprk0fTMTpx0c55AwRVUwWD2Q="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZY+YvdH30RtAMtC4ax5CLUtL60V4fdBnbO1fkxiKTCk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1675203306973,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAv7aUPNRllhwtkXVMqt7nvtuF64U6J0raay4hyIqBAaKSNFctV1xaxIJD4yo8Tdye8R6uVrLoom2TfBISUcbWNo9a4mtWYa1HIXWldRe65G2OdSiv7/cWSEEWLEaCMYKlXmCt1VWT1XsqH8ozwhvdJqv24rOtZCLwHnhQmse81TIRetkNiYMXawP6yvnNXCsQCXkKhW1yNwehkScUA6rBEJIA46vMG6hjcyPuEQi5/9urdTAGKShyGvSJHgt0vtOvMw+jjzJrsQpv+F17TgFA7X+98fZxYjKpyxRk/nGUlDN58nhyu3+zW5aFlt2AjTUoih5Zf4abFpO9FqaN+uqdvbvj5TFM2mHnlT7QqZwxtr9MGlWuAi3sy8qOjvpe9owX6FgDfzMY1Jfu3QGWLEr6iBfDlW20yfnUDGo9eWU5dofzE/ZbI/FwYnTdXO6cTs36EWTE6dry3n+P6+UlBNrVjaAzZE0s/eTLefjfjJINnrOz8iwQAdrsF78+6mkXzIYnImkCXBTBiQnGgig90LoN5mv2q7WdZFV1vQW5CoAr2UX6FA3A7nHrpMyXf33l0m7DyKuSuAWtoZ2NmsppMpFfxZ8HXKVSadqia3UNC0smNiHm15e/BAJWPUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMwpIsi1P7WmVRVKth3gqymZrzPNxy3TVvi6Bg2ncIg1xsDTzSwHNGGrAlQaHvwcCvE94msjon1+wPoIvAc/ZBQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJ21YzMWsHV5A8jS0lHuX/1bpwsZ7g9NDyNceCQJW3dGzJY5oJz7iFi1t5up96vYsA02OATpV/l2bzG/Tiw9i/ApTmqzC1FNndeDkgTnXKsaNJsapwwKalTmXBBdVSGkHM0avnFa40Rlgsgiu0BwnwgZEAUTLYnhYdB4FN24oiGoULVAuaDdcAwKhCxVmzEzrkp6DszbxIFoj4ZeMfhGi0N5O4TXl+HwENSzV8g5aAX+pZTlFXu0HP19vdUniyR1V7Z72gqhtzdXd5RIrUX6AyUs6hgJ6/96yJDTGudSSGmTQ51Jx0AfjCkIMm2WHZvNyRiPt2/LDebvud8T8Wj7nwPr3MRmpQ7eILVTGYHTBKa5NH0zE6cdHOeQMEVVMFg9kBAAAAArxiSos1+17Kp8zX0ycYRhkAi7jyh/5nMHQQFguQBwybq6lewWuaXTzBy6/3FK+APcmKIZV+YIQzX6VyLOcpmplT/Lrme04QlexQrzwO8Cr3t/uCdh08O8lx9caeuqLDKKO2clz5LVvQ3icwossEmj53/dbvAm4xO8haWlZ1DmMb1wlbMFEhH6fmQcwt2hQSKTIhA/lehYKBFhBuvEaMwX1U/Nk0BzEAQ66kOkMnOBJE3ocC+KGzRYUE+FoQrmLeRcckoShOKfZV1VEjUHkNFfYS6JiJ/yXYdVme+n/Kg3naeEgOh0j7swPdXgMLgCspbHmxr2ZPKQMJeaSvH5fqbREx2LvFWUih7eYt0dfXPquutCqwgvnEsohKaZOZpN8gfEOKDKt2eRlD3IrcnhAOJXqQBAeSsdSgSRpsmmnAbkQF2dTdNyHzCIkNyG9A7OCicp4YFcy0KGja/T0OQoQjBgJ0+1XeK1LkW6m+jomDtAWqrr0xoRYOqLz0/2CEBMr7+/vvNbmFOOCwIupTMiAm0fEDJojcgiDHxZjPpDdzupGBatNO9gjYXgFE59O4va8mI110Yww2mpkfimFRpUHPMy4/QjKICDoVIR35cIe/Qo9j+CeVkB+yqrTiHw8m6wJp6PdWrdJo51GuC4Ba8XmW4ACLK+jv0nlpY2+CjKMANCWNAmT4s48dlE+fDKWVtxh9MUsXucRIoLY7q9zn9lFavrr6lAV+3HQCcA72mn9QS0Q7932jtjKLVke5hiIUhRkeoBJSGrwNSBNxX2PnajmuXyZfv60GlDewPiehmV2QKtmA4zbM8/faL6tz0ojfB2bpr8CIOHC6qQ4gwjDcVvl+02d7tpxQkbKR9a5dyzD06Fx/6Te0jrnOfqLgKKdz+f/SB0zUy5D1KJynDMeMKeG4xVCLl9PIK2EkR3VbFcnozuSPmBvtv3vQq8LQtj8omg+9sVF+UW8nHThB9TilnrOgV7KsfvRqY7UEyt+SnCtNv7BlRw9etyWXH2ALObn4vNX6zRNTEwnuJRTDCuT6KodLcIvBqgUc1nMS/IT8q+pb05wbq0Ho2+zuS2OH6DcVdgMD9yKakHbxC13Lden3zNUgIvlyS/csgACwD/1KECfKGm9Rq/g6IRZkxbJdE+mfMQxodivi28OriQu9nZ8J0ZkV4pMXl9Few/xRPL6tf/yBEuM9i4phn6/m2dl7jzse+umVP8pkhuTKj+MN3LtFE9aEIjIZ06u3PIDKJ0twxAwDtEvhrH08ovkyCXg73/ylD4KDxLK05WzSeIoE++X/h3+GFq5dj2Z/j+GF3fMF4NYid/uaeHaQq0ocsT1LYUAxUw3wX3i21HLaXrVt/9QzM8Yf7AT8sGbR3eWCLeo/kmp9zL5RcvlmU7DVz4WJUUaugyRBp9PA5uQF5ZNlkbDsWz1gZlPCq/PYH4R0xbd5nTZbCo6GAbW9GJQ/GFbxvsqjB84lwB44Y6zHV8k/sIppemXRdleOT3eX7ymVRFxeUkkj5Dqx3UTNeSQkq/NTNhU+II6AXHIcngAJZxZzUxLHtel6933NK0Ci9K7EY/M46N+K2dr6jxLnzG7BZqrdu+/ncdnBw=="
+    }
+  ],
+  "Accounts connectTransaction should add transaction amounts to transactionAmounts": [
+    {
+      "id": "6d8ddedf-9ab4-48a6-9335-edfd19239743",
+      "name": "accountA",
+      "spendingKey": "50448fccdc3a743a50a566792eb1591182bc444ab090f4f09cf9a3d7d2d57950",
+      "incomingViewKey": "ce3ed08ff82935173e47de3c32043d1a265879a9d3170446a5f2bd669b291f05",
+      "outgoingViewKey": "f79cee39797e70585c62183f862231bb3ad9ef8de05a251cd1de73aaae2562c0",
+      "publicAddress": "58a631f599534e9672bec245174f8768baa06c5e243e4c0444c80e65b147b3ac"
+    },
+    {
+      "id": "368cbed6-7936-4ac6-9cf8-9a1db084bf7c",
+      "name": "accountB",
+      "spendingKey": "93032e0569775287ea815840bddaa64243769a33db883a2b8ee347d3f4d0870e",
+      "incomingViewKey": "d3586ad34d480b8d4253e88d0657942386b37bc047e8e12755b735c1e96b3d00",
+      "outgoingViewKey": "29992b3d7248bec28e93a77b1f63c020e60930ce5afac002fc7936f55afb1683",
+      "publicAddress": "da5f381345e3e6c9a63ddb9ade8fd4b26dc0d2032ce429d12256ab24d24698f1"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:UyWrJp924qAs8LM3Xin7TTco7d/k/nupW89x1PaRZ2k="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:9qDvoElQSP8mFMFR79EJs+iujTAXjj4DjRb1CEeyvG0="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1675203310319,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAA4o745k0m0CWqPALQKDt8uw1JwkaB8pSO6TEcW/Hy92Y0oGyl6/dEqjKXWXLkov+jpULPBaVQcXibUO4/cZfCFtkv5xUVOniSifNJjcbCTqNQcQGyisMtqsXGvDnkmY7QnzfAtPglAh1oG1GPY/oWPVL/7ERKNQYH+dBXMAxQa4ZbroBNR/nZW+UqzWvotWdwgzduZGbMcmn8n5NJSuFpCaqvq3LjvoVknF4Q7pIE5q1QYlACryGFwH+/BaPZN2+yNnePqucd4PG+pKu9fM3r7tL31zwfoVvO1aYjX3Kr+811fFI+mseICtO9J/EjpCt4tDaGrxgeEQ3QO+DlEcruTxu5MJiwmGY96YgiEw13TLpdJ72kAon7gN4OzzpK1FrT+WwUk/wR79d1629HEskxvrJ+8ozBmjTl/x/n1CXr0JjkCz2CgDixZdK8tXPFfBRoQvIK+jYzGWgEbLyfLUbq9Nfh/WquS7Hra9lOhgOv/ouQOpchMWLob8VKhku4aPsVP/BMMq+OWJjU2eBFKVFRzYsW2yhAkdl0cMXPoBXQrUBji+88U/MjV0JH4qzJ17LfCjsfWMMes/pS3NS9/es1utdZCI7TUW/n7pMlDps+cEEp1LRGxiPuUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQQuIa6MVtWhMidxnlmduAVuWX0OIVtSZLydxtPJudw1phFbNFyKfe4dXqMI7t5rLO5KKHn89bDhWurFO4c5iDA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGz2w0W6cIwHloH+xDe5yPkzJ/hIDP2zPGY/9zRVwCAKwdz4MTofLrNftfpHCG8qo9hkmp+TEX6Upu4OzH4Ngy97oMSSM42GVxutAAA7b4aqm+h95z5sjeHVg2c0auAWC2zgJwfIqL96uVBUVyeg5PvdmGlLoFtUesb49tbOFLwURDdBQclP83WP2m8LAwUpkoV7FR6dDiCiax2sGqSY8GiLjG9NsMEN8AO+K6ij2S+u1lhtF2xovpmmVTn5TX0rYDtz2cQ3eh8mWL2jJgWcB2aLd+Dql/+EKn3Ww4Ejmhbr2+F/RXJP25W2X97l/yCvUYqJnsheCE4sf7eROwCjGF1MlqyafduKgLPCzN14p+003KO3f5P57qVvPcdT2kWdpBAAAAIF1BcL/pgZKwRtCjToBtjjsfFvqECBlGFiA7onFZw26YsPzcb95YTKV9doWmksH87WSblk61OMBQAkG4qxaScmW63TWuGYP6TlgNozF5h5EXj4mDngXNddQu7+nFUDBB6tjb+Wdfl1Rv1RC7aWGPSMN1EfPWZlqGNZzY5dtP2CGRf3NIyjgXsAf0IvfHLNQS5C9Kmyhyuvxz5Zh+yteV4tgTNxO6/2MozN2GshW3Go6uc/zGfyIBc4RUi3H8OjgmA7Ul7qJcsOHg5SY8Wy39lQB/b4Obz/dDD4S8dxqxthp384elGlcnFG51Dg3E/8/+awz6weXI+EBgPzc2G/Mfn4idCsmG1cuZboY53hEqiVzCUHOb2g7Iq6+FVZzb2dJfzLDVbO3e5uyTnrI9WDI9eWRGdaz5wleYCFsvbYS06s7HOEuQf3FhzKIVt0i5I+ehewc9hMfRrBCcA6ORjp0gRZJxn2IkjVTPBz7RvDaj52lKaoKvW3FoAW5bKM0JXCUFB7f5rqqeGfCtBSKfJi0r0uIRsu8jaNEIKyoL3FFu5WKz7xDwXllIr83OSxjYEaiGbU+3jyasZoq6kCVsC5GpzwWzjt1LB452Pz8A3kMMvq3XcpGKE/TRcPZkHUvtnUrMB8B/0READSnhW50pb2bmp6zVH4sVRPwULzQg5Bn20vTdZfXI4115ZVbdbjWdRMN5YkahgPBcMFbpmIWrrKjwrHKiwGBwCV2nSy5BYJLV/+h6nxzww4wEjfmZ/SXtJA1/h/vJQwJ/venIhXFJbb8RExTCfWWJEHdAHuFKiRzNSdq6XrXfNnQdvuKCGkHNQqHy50JDsGvcvOAcHGwDXu1w2euZ3uDHFmmJsCe1EfSy/ZjTcfY0faEDIqhbkvPeSdQVf+PRoW6SVtOp9cisNw5wODbQyJut6W9uz6W/FHlSVr56r0RhDFuI3sFnHZ8fscdR6B4TFEedupBkm777tz4/mDalxD/Wnw2H+mHXy7yhuSLIfh/zX6EE+OAu+bzuU9xX2icS+i6L4kSCO82GBaPAmCgRIoUHANLG1vGkT6S/WHBnYCrkyNVTmyRGwfX3Eol6M9ORTXUyiP+oWcVrPz4XAbf/KkxzzmER2GCWUClKhPibWti9Bjc+FIvxSaehDE20A527MZ7A4pl4DEUlZRs4ia2OPOWeaAuOG01SEpMW1xweF846M2JE2Ke0s9WmTbM3CYu1ADQ+WszYLt+4RI/aehtm9ZLuUP1MK6UuDW3pHQK+v/LMYDHTOtfUuBpYTGXg0Fgvj5iLACwbMZAOa0yFIA2yzj+GeEvDCkEVUXZ/k5IXDW7+W5hWQa8pzeYY7WmfPXRZApVymObo5bDmzQFSvEItKt+P7QKSgRuzZG/WnoN1vvGLO4VmbPBieTb4+w7Vz5oEFs3fzmGwcZw6KtNqnoW+Gwqkp4x5BtgXttSnI2vwo+moxUBYjAcbQbslktp75m8hAtM2L1LkqysDe6TcfCt80aXEAV5ALNSczYgATc96QiKrJTyf+tw16AwCbs52JyzrqqezQaukeNoH7Z1ZEMV3FEAB0+t/yGSaHfIR5y/HnPAkdIqR6cEELYv8ChEAw=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "464CE6E3CAD539A7AD2ABAA0FC9A8922C7EB67D821CCFE030CA66EB729DFAA1D",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Ve+7G5oSCFj8gHPyNyjrKIz0ZLFGwiiJy84BFKddC1E="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:rgnwxkMb/5gKaRl0/RfMlHzA8emoarXuug5XS/hL+nI="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1675203312970,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAF9JzNL293qH9eDSe5MTuz6XqumrIHuPXHHFyMDdbWaWlRN9iYC8LckDXy5RAa2Fv2bFMQ56jPk8attZe1yXCTUm8750xSHriaNgJS2kDs/Crcj1JEcVArZ8yEsldc52FgCiMfpzodVIdtv6m0j6xq/+8EaCh+5M7R5n28n9vQWoTGxOJTKiWOm1HQI0xivUZnxW+/8rRb7ge2NANYR9YBSGcBfnan0TGulAnd7d9wSqy93mMIsdlPhuC/KWPYzTXkSiiZqaKV+ll3vZWnMlHH5iBSnF8WnZUbEyfEiwjqwwb9G1O00jucXEKRj+w4WQ2maS7rDQxdmsULZCB2k61DaMnbmcQTFbFe1up23gQHnwj1q7VocS6gDMueuFz5f1qJyDMwCpuOK4k9bmqhco8mMotLpv+xsavDTTTyvQKZQv6KMWvYfoEBg3WmeONZQY8Dd9gw1VOzzfdCJV/zzHHvZLikn3KGcdttzTFqi891SBv3c7AKIkNwT1LSzGkFgo6L4VPvDfm0y6xdLPYT6N+7zMeVZ3e4I+Syqjd1pzUbtiLSd1gdtxUfHAjuA7MqghtBVnyxkg22zTWkv8K0l84jTHYRtRJIGGnk53lbmJijLSGhRv2EZqKR0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRP4hzV6uWUjcYNg8tp9WPkUDxmRfBKcQ/P+RfacR/Ax1FezDoFSAD4PNP/PU4jUPa4XTHWr7Zax1FY+SO9IGBA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGz2w0W6cIwHloH+xDe5yPkzJ/hIDP2zPGY/9zRVwCAKwdz4MTofLrNftfpHCG8qo9hkmp+TEX6Upu4OzH4Ngy97oMSSM42GVxutAAA7b4aqm+h95z5sjeHVg2c0auAWC2zgJwfIqL96uVBUVyeg5PvdmGlLoFtUesb49tbOFLwURDdBQclP83WP2m8LAwUpkoV7FR6dDiCiax2sGqSY8GiLjG9NsMEN8AO+K6ij2S+u1lhtF2xovpmmVTn5TX0rYDtz2cQ3eh8mWL2jJgWcB2aLd+Dql/+EKn3Ww4Ejmhbr2+F/RXJP25W2X97l/yCvUYqJnsheCE4sf7eROwCjGF1MlqyafduKgLPCzN14p+003KO3f5P57qVvPcdT2kWdpBAAAAIF1BcL/pgZKwRtCjToBtjjsfFvqECBlGFiA7onFZw26YsPzcb95YTKV9doWmksH87WSblk61OMBQAkG4qxaScmW63TWuGYP6TlgNozF5h5EXj4mDngXNddQu7+nFUDBB6tjb+Wdfl1Rv1RC7aWGPSMN1EfPWZlqGNZzY5dtP2CGRf3NIyjgXsAf0IvfHLNQS5C9Kmyhyuvxz5Zh+yteV4tgTNxO6/2MozN2GshW3Go6uc/zGfyIBc4RUi3H8OjgmA7Ul7qJcsOHg5SY8Wy39lQB/b4Obz/dDD4S8dxqxthp384elGlcnFG51Dg3E/8/+awz6weXI+EBgPzc2G/Mfn4idCsmG1cuZboY53hEqiVzCUHOb2g7Iq6+FVZzb2dJfzLDVbO3e5uyTnrI9WDI9eWRGdaz5wleYCFsvbYS06s7HOEuQf3FhzKIVt0i5I+ehewc9hMfRrBCcA6ORjp0gRZJxn2IkjVTPBz7RvDaj52lKaoKvW3FoAW5bKM0JXCUFB7f5rqqeGfCtBSKfJi0r0uIRsu8jaNEIKyoL3FFu5WKz7xDwXllIr83OSxjYEaiGbU+3jyasZoq6kCVsC5GpzwWzjt1LB452Pz8A3kMMvq3XcpGKE/TRcPZkHUvtnUrMB8B/0READSnhW50pb2bmp6zVH4sVRPwULzQg5Bn20vTdZfXI4115ZVbdbjWdRMN5YkahgPBcMFbpmIWrrKjwrHKiwGBwCV2nSy5BYJLV/+h6nxzww4wEjfmZ/SXtJA1/h/vJQwJ/venIhXFJbb8RExTCfWWJEHdAHuFKiRzNSdq6XrXfNnQdvuKCGkHNQqHy50JDsGvcvOAcHGwDXu1w2euZ3uDHFmmJsCe1EfSy/ZjTcfY0faEDIqhbkvPeSdQVf+PRoW6SVtOp9cisNw5wODbQyJut6W9uz6W/FHlSVr56r0RhDFuI3sFnHZ8fscdR6B4TFEedupBkm777tz4/mDalxD/Wnw2H+mHXy7yhuSLIfh/zX6EE+OAu+bzuU9xX2icS+i6L4kSCO82GBaPAmCgRIoUHANLG1vGkT6S/WHBnYCrkyNVTmyRGwfX3Eol6M9ORTXUyiP+oWcVrPz4XAbf/KkxzzmER2GCWUClKhPibWti9Bjc+FIvxSaehDE20A527MZ7A4pl4DEUlZRs4ia2OPOWeaAuOG01SEpMW1xweF846M2JE2Ke0s9WmTbM3CYu1ADQ+WszYLt+4RI/aehtm9ZLuUP1MK6UuDW3pHQK+v/LMYDHTOtfUuBpYTGXg0Fgvj5iLACwbMZAOa0yFIA2yzj+GeEvDCkEVUXZ/k5IXDW7+W5hWQa8pzeYY7WmfPXRZApVymObo5bDmzQFSvEItKt+P7QKSgRuzZG/WnoN1vvGLO4VmbPBieTb4+w7Vz5oEFs3fzmGwcZw6KtNqnoW+Gwqkp4x5BtgXttSnI2vwo+moxUBYjAcbQbslktp75m8hAtM2L1LkqysDe6TcfCt80aXEAV5ALNSczYgATc96QiKrJTyf+tw16AwCbs52JyzrqqezQaukeNoH7Z1ZEMV3FEAB0+t/yGSaHfIR5y/HnPAkdIqR6cEELYv8ChEAw=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BufferMap } from 'buffer-map'
+import { BufferMap, BufferSet } from 'buffer-map'
 import MurmurHash3 from 'imurmurhash'
 import { Assert } from '../assert'
 import { BlockHeader, Transaction } from '../primitives'
@@ -15,6 +15,7 @@ import { AccountValue } from './walletdb/accountValue'
 import { BalanceValue } from './walletdb/balanceValue'
 import { DecryptedNoteValue } from './walletdb/decryptedNoteValue'
 import { HeadValue } from './walletdb/headValue'
+import { TransactionAmountsValue } from './walletdb/transactionAmountsValue'
 import { TransactionValue } from './walletdb/transactionValue'
 import { WalletDB } from './walletdb/walletdb'
 
@@ -136,6 +137,8 @@ export class Account {
     const blockHash = blockHeader.hash
     const sequence = blockHeader.sequence
     const assetBalanceDeltas = new AssetBalances()
+    const inputs = new AssetBalances()
+    const outputs = new AssetBalances()
     let submittedSequence = sequence
     let timestamp = new Date()
 
@@ -165,6 +168,7 @@ export class Account {
         }
 
         assetBalanceDeltas.increment(note.note.assetId(), note.note.value())
+        outputs.increment(note.note.assetId(), note.note.value())
 
         await this.walletDb.saveDecryptedNote(this, decryptedNote.hash, note, tx)
       }
@@ -180,6 +184,7 @@ export class Account {
         Assert.isNotUndefined(note)
 
         assetBalanceDeltas.increment(note.note.assetId(), -note.note.value())
+        inputs.increment(note.note.assetId(), note.note.value())
 
         const spentNote = { ...note, spent: true }
         await this.walletDb.saveDecryptedNote(this, spentNoteHash, spentNote, tx)
@@ -198,6 +203,7 @@ export class Account {
         },
         tx,
       )
+      await this.saveTransactionAmounts(transaction.hash(), inputs, outputs, tx)
     })
 
     return assetBalanceDeltas
@@ -210,6 +216,8 @@ export class Account {
     tx?: IDatabaseTransaction,
   ): Promise<void> {
     const assetBalanceDeltas = new AssetBalances()
+    const inputs = new AssetBalances()
+    const outputs = new AssetBalances()
 
     await this.walletDb.db.withTransaction(tx, async (tx) => {
       if (await this.hasTransaction(transaction.hash(), tx)) {
@@ -233,6 +241,7 @@ export class Account {
         }
 
         assetBalanceDeltas.increment(note.note.assetId(), note.note.value())
+        outputs.increment(note.note.assetId(), note.note.value())
 
         await this.walletDb.saveDecryptedNote(this, decryptedNote.hash, note, tx)
       }
@@ -248,6 +257,7 @@ export class Account {
         Assert.isNotUndefined(note)
 
         assetBalanceDeltas.increment(note.note.assetId(), -note.note.value())
+        inputs.increment(note.note.assetId(), note.note.value())
 
         const spentNote = { ...note, spent: true }
         await this.walletDb.saveDecryptedNote(this, spentNoteHash, spentNote, tx)
@@ -266,6 +276,7 @@ export class Account {
         },
         tx,
       )
+      await this.saveTransactionAmounts(transaction.hash(), inputs, outputs, tx)
     })
   }
 
@@ -361,18 +372,20 @@ export class Account {
   ): Promise<void> {
     const assetIds = new BufferSet([...inputAmounts.keys(), ...outputAmounts.keys()])
 
-    for (const assetId of assetIds) {
-      const input = inputAmounts.get(assetId) ?? 0n
-      const output = outputAmounts.get(assetId) ?? 0n
+    await this.walletDb.db.withTransaction(tx, async (tx) => {
+      for (const assetId of assetIds) {
+        const input = inputAmounts.get(assetId) ?? 0n
+        const output = outputAmounts.get(assetId) ?? 0n
 
-      await this.walletDb.putTransactionAmounts(
-        this,
-        transactionHash,
-        assetId,
-        { input, output },
-        tx,
-      )
-    }
+        await this.walletDb.putTransactionAmounts(
+          this,
+          transactionHash,
+          assetId,
+          { input, output },
+          tx,
+        )
+      }
+    })
   }
 
   async deleteTransaction(transaction: Transaction, tx?: IDatabaseTransaction): Promise<void> {
@@ -456,6 +469,14 @@ export class Account {
     tx?: IDatabaseTransaction,
   ): AsyncGenerator<TransactionValue> {
     return this.walletDb.loadExpiredTransactions(this, headSequence, tx)
+  }
+
+  getTransactionAmounts(
+    transactionHash: Buffer,
+    assetId: Buffer,
+    tx?: IDatabaseTransaction,
+  ): Promise<TransactionAmountsValue | undefined> {
+    return this.walletDb.getTransactionAmounts(this, transactionHash, assetId, tx)
   }
 
   async expireTransaction(transaction: Transaction, tx?: IDatabaseTransaction): Promise<void> {

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -353,6 +353,28 @@ export class Account {
     return assetBalanceDeltas
   }
 
+  async saveTransactionAmounts(
+    transactionHash: Buffer,
+    inputAmounts: AssetBalances,
+    outputAmounts: AssetBalances,
+    tx?: IDatabaseTransaction,
+  ): Promise<void> {
+    const assetIds = new BufferSet([...inputAmounts.keys(), ...outputAmounts.keys()])
+
+    for (const assetId of assetIds) {
+      const input = inputAmounts.get(assetId) ?? 0n
+      const output = outputAmounts.get(assetId) ?? 0n
+
+      await this.walletDb.putTransactionAmounts(
+        this,
+        transactionHash,
+        assetId,
+        { input, output },
+        tx,
+      )
+    }
+  }
+
   async deleteTransaction(transaction: Transaction, tx?: IDatabaseTransaction): Promise<void> {
     await this.walletDb.db.withTransaction(tx, async (tx) => {
       if (!(await this.hasTransaction(transaction.hash(), tx))) {

--- a/ironfish/src/wallet/walletdb/transactionAmountsValue.test.ts
+++ b/ironfish/src/wallet/walletdb/transactionAmountsValue.test.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  TransactionAmountsValue,
+  TransactionAmountsValueEncoding,
+} from './transactionAmountsValue'
+
+describe('TransactionAmountsValueEncoding', () => {
+  function expectTransactionAmountsValueToMatch(
+    a: TransactionAmountsValue,
+    b: TransactionAmountsValue,
+  ): void {
+    expect(a.input).toEqual(b.input)
+    expect(a.output).toEqual(b.output)
+  }
+
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const encoder = new TransactionAmountsValueEncoding()
+
+    const amountsValue = {
+      input: 1n,
+      output: 0n,
+    }
+
+    const buffer = encoder.serialize(amountsValue)
+    const deserializedValue = encoder.deserialize(buffer)
+    expectTransactionAmountsValueToMatch(deserializedValue, amountsValue)
+  })
+})

--- a/ironfish/src/wallet/walletdb/transactionAmountsValue.ts
+++ b/ironfish/src/wallet/walletdb/transactionAmountsValue.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../storage'
+
+export interface TransactionAmountsValue {
+  input: bigint
+  output: bigint
+}
+
+export class TransactionAmountsValueEncoding
+  implements IDatabaseEncoding<TransactionAmountsValue>
+{
+  serialize(value: TransactionAmountsValue): Buffer {
+    const bw = bufio.write(16)
+
+    bw.writeBigU64(value.input)
+    bw.writeBigU64(value.output)
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): TransactionAmountsValue {
+    const reader = bufio.read(buffer, true)
+
+    const input = reader.readBigU64()
+    const output = reader.readBigU64()
+
+    return { input, output }
+  }
+}

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -37,7 +37,7 @@ import {
 } from './transactionAmountsValue'
 import { TransactionValue, TransactionValueEncoding } from './transactionValue'
 
-export const VERSION_DATABASE_ACCOUNTS = 17
+export const VERSION_DATABASE_ACCOUNTS = 16
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountId: null,
@@ -191,7 +191,7 @@ export class WalletDB {
     })
 
     this.transactions = this.db.addStore({
-      name: 'tx',
+      name: 't',
       keyEncoding: new PrefixEncoding(new BufferEncoding(), new BufferEncoding(), 4),
       valueEncoding: new TransactionValueEncoding(),
     })
@@ -200,7 +200,7 @@ export class WalletDB {
       name: 'ta',
       keyEncoding: new PrefixEncoding(
         new BufferEncoding(),
-        new PrefixEncoding(new BufferEncoding(), new BufferEncoding(), 4),
+        new PrefixEncoding(new BufferEncoding(), new BufferEncoding(), 32),
         4,
       ),
       valueEncoding: new TransactionAmountsValueEncoding(),


### PR DESCRIPTION
## Summary

the transactions datastore includes a field 'assetBalanceDeltas' on each record that stores a mapping from asset ID to the net amount or balance delta for that asset in the transaction.

however, there are some cases, such as computing the amount of an asset that an account has available to spend, where it is useful to separate the amount that the account input into the transaction from the amount that the account received output from the transaction.

the transactionAmounts datastore stores the input and output amounts for each account, transaction hash, and asset id.

this datastore will allow us to efficiently compute the 'available' or 'spendable' balance by reading the amount spent in a transaction without iterating over a transaction's spends and looking up decrypted notes for those spends in the walletDb.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
