### PR TITLE
Use string as block difficulty in `getBlock`, instead of Number

### DIFF
--- a/ironfish/src/rpc/routes/chain/getBlock.test.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.test.ts
@@ -56,7 +56,7 @@ describe('Route chain.getBlock', () => {
       },
       metadata: {
         size: expect.any(Number),
-        difficulty: Number(block.header.target.toDifficulty()),
+        difficulty: block.header.target.toDifficulty().toString(),
       },
     })
     expect(response.content.transactions).toHaveLength(1)

--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -35,7 +35,7 @@ interface Block {
   transactions: Array<Transaction>
   metadata: {
     size: number
-    difficulty: number
+    difficulty: string
   }
 }
 export type GetBlockResponse = Block
@@ -103,7 +103,7 @@ export const GetBlockResponseSchema: yup.ObjectSchema<GetBlockResponse> = yup
     metadata: yup
       .object({
         size: yup.number().defined(),
-        difficulty: yup.number().defined(),
+        difficulty: yup.string().defined(),
       })
       .defined(),
   })
@@ -200,7 +200,7 @@ router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
       transactions,
       metadata: {
         size: blockBuffer.byteLength,
-        difficulty: Number(block.header.target.toDifficulty()),
+        difficulty: block.header.target.toDifficulty().toString(),
       },
     })
   },


### PR DESCRIPTION
## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
