### PR TITLE
Debug log CLI error if it exists

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -74,6 +74,10 @@ export abstract class IronfishCommand extends Command {
     } catch (error: unknown) {
       if (hasUserResponseError(error)) {
         this.log(error.codeMessage)
+
+        if (error.codeStack) {
+          this.sdk.logger.debug(error.codeStack)
+        }
       } else if (error instanceof ExitError) {
         throw error
       } else if (error instanceof CLIError) {


### PR DESCRIPTION
## Summary

It's not easy to debug CLI errors from the RPC. You need to add a log here, but it's nicer if in verbose mode this automatically happens. This helped me locally, let me know if you think this is a good idea or not.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
