### PR TITLE
Add the ability to watch a transaction status

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -17,6 +17,7 @@ import { IronfishCommand } from '../../command'
 import { IronFlag, parseIron, RemoteFlags } from '../../flags'
 import { ProgressBar } from '../../types'
 import { selectAsset } from '../../utils/asset'
+import { watchTransaction } from '../../utils/transaction'
 
 export class Send extends IronfishCommand {
   static description = `Send coins to another account`
@@ -61,6 +62,10 @@ export class Send extends IronfishCommand {
     confirm: Flags.boolean({
       default: false,
       description: 'Confirm without asking',
+    }),
+    watch: Flags.boolean({
+      default: false,
+      description: 'Wait for the transaction to be confirmed',
     }),
     expiration: Flags.integer({
       char: 'e',
@@ -292,6 +297,8 @@ ${CurrencyUtils.renderIron(
       bar.stop()
     }
 
+    let transaction
+
     try {
       const result = await client.postTransaction({
         transaction: rawTransactionResponse,
@@ -300,7 +307,7 @@ ${CurrencyUtils.renderIron(
       stopProgressBar()
 
       const transactionBytes = Buffer.from(result.content.transaction, 'hex')
-      const transaction = new Transaction(transactionBytes)
+      transaction = new Transaction(transactionBytes)
 
       this.log(`
 Sending ${CurrencyUtils.renderIron(amount, true, assetId)} to ${to} from ${from}
@@ -319,6 +326,11 @@ Find the transaction on https://explorer.ironfish.network/transaction/${transact
         this.error(error.message)
       }
       this.exit(2)
+    }
+
+    if (flags.watch && transaction) {
+      this.log('')
+      await watchTransaction(client, this.logger, from, transaction.hash().toString('hex'))
     }
   }
 }

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -330,7 +330,13 @@ Find the transaction on https://explorer.ironfish.network/transaction/${transact
 
     if (flags.watch && transaction) {
       this.log('')
-      await watchTransaction(client, this.logger, from, transaction.hash().toString('hex'))
+
+      await watchTransaction({
+        client,
+        logger: this.logger,
+        account: from,
+        hash: transaction.hash().toString('hex'),
+      })
     }
   }
 }

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { BufferUtils, CurrencyUtils, TimeUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
-import { IronfishCommand } from '../../command'
-import { RemoteFlags } from '../../flags'
+import { IronfishCommand } from '../../../command'
+import { RemoteFlags } from '../../../flags'
 
 export class TransactionCommand extends IronfishCommand {
   static description = `Display an account transaction`

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../../../command'
+import { RemoteFlags } from '../../../flags'
+import { watchTransaction } from '../../../utils/transaction'
+
+export class WatchTxCommand extends IronfishCommand {
+  static description = `Display an account transaction`
+
+  static flags = {
+    ...RemoteFlags,
+    confirmations: Flags.integer({
+      required: false,
+      description: 'Minimum number of blocks confirmations for a transaction',
+    }),
+  }
+
+  static args = [
+    {
+      name: 'hash',
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
+      required: true,
+      description: 'Hash of the transaction',
+    },
+    {
+      name: 'account',
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
+      required: false,
+      description: 'Name of the account',
+    },
+  ]
+
+  async start(): Promise<void> {
+    const { flags, args } = await this.parse(WatchTxCommand)
+    const hash = args.hash as string
+    const account = args.account as string | undefined
+
+    const client = await this.sdk.connectRpc()
+    await watchTransaction(client, this.logger, account, hash, flags.confirmations)
+  }
+}

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -38,6 +38,13 @@ export class WatchTxCommand extends IronfishCommand {
     const account = args.account as string | undefined
 
     const client = await this.sdk.connectRpc()
-    await watchTransaction(client, this.logger, account, hash, flags.confirmations)
+
+    await watchTransaction({
+      client,
+      logger: this.logger,
+      account,
+      hash,
+      confirmations: flags.confirmations,
+    })
   }
 }

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  Assert,
+  Logger,
+  PromiseUtils,
+  RpcClient,
+  TimeUtils,
+  TransactionStatus,
+} from '@ironfish/sdk'
+import { CliUx } from '@oclif/core'
+
+export async function watchTransaction(
+  client: RpcClient,
+  logger: Logger,
+  account: string | undefined,
+  hash: string,
+  confirmations?: number,
+  waitUntil: TransactionStatus = TransactionStatus.CONFIRMED,
+): Promise<void> {
+  let last = await client.getAccountTransaction({ account, hash })
+  let lastTime = Date.now()
+
+  if (last.content.transaction == null) {
+    logger.log(`Tried to watch tranaction ${hash} but it's missing.`)
+    return
+  }
+
+  if (last.content.transaction.status === waitUntil) {
+    logger.log(
+      `Transaction ${last.content.transaction.hash} is ${last.content.transaction.status}`,
+    )
+    return
+  }
+
+  logger.log(`Watching transaction ${last.content.transaction.hash}`)
+
+  CliUx.ux.action.start(`Watching`)
+  CliUx.ux.action.status = last.content.transaction.status
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    Assert.isNotNull(last.content.transaction)
+
+    const response = await client.getAccountTransaction({ account, hash, confirmations })
+
+    if (response.content.transaction == null) {
+      CliUx.ux.action.stop(`Transaction ${hash} deleted while watching it.`)
+      return
+    }
+
+    if (response.content.transaction.status === last.content.transaction.status) {
+      await PromiseUtils.sleep(2000)
+      continue
+    }
+
+    const now = Date.now()
+    const duration = now - lastTime
+    lastTime = now
+
+    CliUx.ux.action.stop(
+      `${last.content.transaction.status} -> ${
+        response.content.transaction.status
+      }: ${TimeUtils.renderSpan(duration)}`,
+    )
+
+    last = response
+
+    CliUx.ux.action.start(`Watching`)
+    CliUx.ux.action.status = response.content.transaction.status
+
+    if (response.content.transaction.status === waitUntil) {
+      CliUx.ux.action.stop()
+      return
+    }
+  }
+}

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -12,7 +12,11 @@ import {
 } from './types'
 import { getAccount } from './utils'
 
-export type GetAccountTransactionRequest = { account?: string; hash: string }
+export type GetAccountTransactionRequest = {
+  hash: string
+  account?: string
+  confirmations?: number
+}
 
 export type GetAccountTransactionResponse = {
   account: string
@@ -36,8 +40,9 @@ export type GetAccountTransactionResponse = {
 export const GetAccountTransactionRequestSchema: yup.ObjectSchema<GetAccountTransactionRequest> =
   yup
     .object({
-      account: yup.string().strip(true),
+      account: yup.string(),
       hash: yup.string().defined(),
+      confirmations: yup.string(),
     })
     .defined()
 
@@ -141,7 +146,10 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
 
     const assetBalanceDeltas = await getAssetBalanceDeltas(node, transaction)
 
-    const status = await node.wallet.getTransactionStatus(account, transaction)
+    const status = await node.wallet.getTransactionStatus(account, transaction, {
+      confirmations: request.data.confirmations,
+    })
+
     const type = await node.wallet.getTransactionType(account, transaction)
 
     const serialized = {


### PR DESCRIPTION
## Summary

https://asciinema.org/a/aV8PobDK15767HElhB7yMKez3

You can now pass --watch to send or use the new command wallet:transaction:watch

## Testing Plan
Run `ironfish wallet:transaction:watch` or `ironfish wallet:send --watch`

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
