### PR TITLE
Add balances to asset menu

### DIFF
--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -41,7 +41,7 @@ export async function selectAsset(
       const displayName = BufferUtils.toHuman(Buffer.from(assetResponse.content.name, 'hex'))
       assetOptions.push({
         value: assetId,
-        name: `${assetId} (${displayName}) - ${CurrencyUtils.renderIron(confirmed)}`,
+        name: `${assetId} (${displayName}) (${CurrencyUtils.renderIron(confirmed)})`,
       })
     }
   }

--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Asset } from '@ironfish/rust-nodejs'
-import { BufferUtils, RpcClient } from '@ironfish/sdk'
+import { BufferUtils, CurrencyUtils, RpcClient } from '@ironfish/sdk'
 import inquirer from 'inquirer'
 
 export async function selectAsset(
@@ -34,14 +34,14 @@ export async function selectAsset(
   }
 
   // Get the asset name from the chain DB to populate the display choices
-  for (const { assetId } of balances) {
+  for (const { assetId, confirmed } of balances) {
     const assetResponse = await client.getAsset({ id: assetId })
 
     if (assetResponse.content.name) {
       const displayName = BufferUtils.toHuman(Buffer.from(assetResponse.content.name, 'hex'))
       assetOptions.push({
         value: assetId,
-        name: `${assetId} (${displayName})`,
+        name: `${assetId} (${displayName}) - ${CurrencyUtils.renderIron(confirmed)}`,
       })
     }
   }


### PR DESCRIPTION
## Summary
Implementing https://github.com/iron-fish/ironfish/issues/3180. Adding confirmed balances to asset selection menu.

## Testing Plan
Run `ironfish wallet:send/burn/mint` and check balances when selecting the asset from menu

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
