### PR TITLE
Add asset name to wallet:burn confirmation

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
+  BufferUtils,
   CreateTransactionRequest,
   CreateTransactionResponse,
   CurrencyUtils,
@@ -270,8 +271,12 @@ ${CurrencyUtils.renderIron(
       const transactionBytes = Buffer.from(result.content.transaction, 'hex')
       transaction = new Transaction(transactionBytes)
 
+      const assetResponse = await client.getAsset({ id: assetId })
+      const assetName = BufferUtils.toHuman(Buffer.from(assetResponse.content.name, 'hex'))
+
       this.log(`
-Burned asset ${assetId} from ${account}
+Burned asset ${assetName} from ${account}
+Asset Identifier: ${assetId}
 Value: ${CurrencyUtils.renderIron(amount)}
 
 Transaction Hash: ${transaction.hash().toString('hex')}

--- a/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
@@ -8,7 +8,7 @@ import {
   usePostTxFixture,
 } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { CurrencyUtils } from '../../../utils'
+import { BufferUtils, CurrencyUtils } from '../../../utils'
 
 describe('burnAsset', () => {
   const routeTest = createRouteTest(true)
@@ -87,6 +87,7 @@ describe('burnAsset', () => {
 
       expect(response.content).toEqual({
         assetId: asset.id().toString('hex'),
+        name: BufferUtils.toHuman(asset.name()),
         hash: burnTransaction.hash().toString('hex'),
         value: burnTransaction.burns[0].value.toString(),
       })

--- a/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
@@ -8,7 +8,7 @@ import {
   usePostTxFixture,
 } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { BufferUtils, CurrencyUtils } from '../../../utils'
+import { CurrencyUtils } from '../../../utils'
 
 describe('burnAsset', () => {
   const routeTest = createRouteTest(true)
@@ -87,7 +87,7 @@ describe('burnAsset', () => {
 
       expect(response.content).toEqual({
         assetId: asset.id().toString('hex'),
-        name: BufferUtils.toHuman(asset.name()),
+        name: asset.name().toString('hex'),
         hash: burnTransaction.hash().toString('hex'),
         value: burnTransaction.burns[0].value.toString(),
       })

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -90,7 +90,7 @@ describe('mint', () => {
       expect(response.content).toEqual({
         assetId: asset.id().toString('hex'),
         hash: mintTransaction.hash().toString('hex'),
-        name: asset.name().toString('utf8'),
+        name: asset.name().toString('hex'),
         value: mintTransaction.mints[0].value.toString(),
       })
     })

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -105,7 +105,7 @@ router.register<typeof MintAssetRequestSchema, MintAssetResponse>(
     request.end({
       assetId: mint.asset.id().toString('hex'),
       hash: transaction.hash().toString('hex'),
-      name: mint.asset.name().toString('utf8'),
+      name: mint.asset.name().toString('hex'),
       value: mint.value.toString(),
     })
   },


### PR DESCRIPTION
## Summary
Implementing https://github.com/iron-fish/ironfish/issues/3191. Burning asset now shows asset name and id in transaction confirmation, in the same way that minting asset does.

## Testing Plan
Run `ironfish wallet:burn` and see that asset name shows in the transaction confirmation

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
