### PR TITLE
feat(ironfish): introduce an event loop for mining pool

### DIFF
--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -212,8 +212,9 @@ export class MiningPool {
     const eventLoopStartTime = new Date().getTime()
 
     if (this.nextPayoutAttempt <= eventLoopStartTime) {
+      const nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
       await this.shares.createPayout()
-      this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
+      this.nextPayoutAttempt = nextPayoutAttempt
     }
 
     const eventLoopEndTime = new Date().getTime()

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -212,9 +212,8 @@ export class MiningPool {
     const eventLoopStartTime = new Date().getTime()
 
     if (this.nextPayoutAttempt <= eventLoopStartTime) {
-      const nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
+      this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
       await this.shares.createPayout()
-      this.nextPayoutAttempt = nextPayoutAttempt
     }
 
     const eventLoopEndTime = new Date().getTime()

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -21,6 +21,7 @@ import { mineableHeaderString } from './utils'
 import { WebhookNotifier } from './webhooks'
 
 const RECALCULATE_TARGET_TIMEOUT = 10000
+const EVENT_LOOP_MS = 10 * 1000
 
 export class MiningPool {
   readonly stratum: StratumServer
@@ -37,6 +38,11 @@ export class MiningPool {
   private connectWarned: boolean
   private connectTimeout: SetTimeoutToken | null
 
+  private eventLoopTimeout: SetTimeoutToken | null
+
+  private attemptPayoutInterval: number
+  private nextPayoutAttempt: number
+
   name: string
 
   nextMiningRequestId: number
@@ -49,8 +55,7 @@ export class MiningPool {
   currentHeadTimestamp: number | null
   currentHeadDifficulty: bigint | null
 
-  recalculateTargetInterval: SetIntervalToken | null
-
+  private recalculateTargetInterval: SetIntervalToken | null
   private notifyStatusInterval: SetIntervalToken | null
 
   private constructor(options: {
@@ -91,6 +96,11 @@ export class MiningPool {
     this.connectTimeout = null
     this.connectWarned = false
     this.started = false
+
+    this.eventLoopTimeout = null
+
+    this.attemptPayoutInterval = this.config.get('poolAttemptPayoutInterval')
+    this.nextPayoutAttempt = new Date().getTime()
 
     this.recalculateTargetInterval = null
     this.notifyStatusInterval = null
@@ -155,7 +165,8 @@ export class MiningPool {
       )
     }
 
-    void this.startConnectingRpc()
+    await this.startConnectingRpc()
+    void this.eventLoop()
   }
 
   async stop(): Promise<void> {
@@ -180,6 +191,10 @@ export class MiningPool {
       clearTimeout(this.connectTimeout)
     }
 
+    if (this.eventLoopTimeout) {
+      clearTimeout(this.eventLoopTimeout)
+    }
+
     if (this.recalculateTargetInterval) {
       clearInterval(this.recalculateTargetInterval)
     }
@@ -187,6 +202,25 @@ export class MiningPool {
     if (this.notifyStatusInterval) {
       clearInterval(this.notifyStatusInterval)
     }
+  }
+
+  private async eventLoop(): Promise<void> {
+    if (!this.started) {
+      return
+    }
+
+    const eventLoopStartTime = new Date().getTime()
+
+    if (this.nextPayoutAttempt <= eventLoopStartTime) {
+      await this.shares.createPayout()
+      this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
+    }
+
+    const eventLoopEndTime = new Date().getTime()
+    const eventLoopDuration = eventLoopEndTime - eventLoopStartTime
+    this.logger.debug(`Mining pool event loop took ${eventLoopDuration} milliseconds`)
+
+    this.eventLoopTimeout = setTimeout(() => void this.eventLoop(), EVENT_LOOP_MS)
   }
 
   async waitForStop(): Promise<void> {


### PR DESCRIPTION
## Summary

The goal here is to simplify the pool logic a little bit. With the coming refactors, it will be much easier if we have the main logic in one place, so it can be extended and refactored without introducing a bunch of random timeouts or intervals. This also will make it easier to read and maintain the code going forward, I hope.

One thing I want to point out: I intentionally left the existing intervals in the pool class, since they're a bit more time-sensitive. It would feel awkward if these were getting delayed because of the event loop, which I expect to be a long running function much of the time. It will eventually check for confirmed blocks, transactions, etc. on top of doing more logic around figuring out payout amounts, payout buckets, etc.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
