### PR TITLE
adds a migration to backfill transactionAmounts

### DIFF
--- a/ironfish/src/migrations/data/017-transaction-amounts.ts
+++ b/ironfish/src/migrations/data/017-transaction-amounts.ts
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Assert } from '../../assert'
+import { Logger } from '../../logger'
+import { IronfishNode } from '../../node'
+import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { Account } from '../../wallet'
+import { AssetBalances } from '../../wallet/assetBalances'
+import { Migration } from '../migration'
+
+export class Migration017 extends Migration {
+  path = __filename
+
+  prepare(node: IronfishNode): IDatabase {
+    return node.wallet.walletDb.db
+  }
+
+  async forward(
+    node: IronfishNode,
+    _db: IDatabase,
+    _tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const accounts = []
+
+    for await (const accountValue of node.wallet.walletDb.loadAccounts()) {
+      accounts.push(
+        new Account({
+          ...accountValue,
+          walletDb: node.wallet.walletDb,
+        }),
+      )
+    }
+
+    logger.info(
+      `Migration 017-transaction-amounts supports efficiently computing the amount of each asset that an account is able to spend`,
+    )
+    logger.info(
+      `Summing input/output amounts in transactions for ${accounts.length} accounts...`,
+    )
+
+    for (const account of accounts) {
+      logger.info(
+        ` Backfilling input/output amounts from transactions for account ${account.name}...`,
+      )
+
+      let transactions = 0
+
+      for await (const transaction of account.getTransactions()) {
+        const inputs = new AssetBalances()
+        const outputs = new AssetBalances()
+
+        for (const spend of transaction.transaction.spends) {
+          const noteHash = await account.getNoteHash(spend.nullifier)
+
+          if (!noteHash) {
+            continue
+          }
+
+          const decryptedNote = await account.getDecryptedNote(noteHash)
+
+          Assert.isNotUndefined(decryptedNote)
+
+          inputs.increment(decryptedNote.note.assetId(), decryptedNote.note.value())
+        }
+
+        for (const note of transaction.transaction.notes) {
+          const decryptedNote = await account.getDecryptedNote(note.hash())
+
+          if (!decryptedNote) {
+            continue
+          }
+
+          outputs.increment(decryptedNote.note.assetId(), decryptedNote.note.value())
+        }
+
+        await account.saveTransactionAmounts(transaction.transaction.hash(), inputs, outputs)
+        transactions++
+      }
+
+      logger.info(
+        ` Completed backfilling input/output amounts from ${transactions} transactions for account ${account.name}`,
+      )
+      logger.info('')
+    }
+  }
+
+  async backward(node: IronfishNode): Promise<void> {
+    await node.wallet.walletDb.transactionAmounts.clear()
+  }
+}

--- a/ironfish/src/migrations/data/018-transaction-amounts.ts
+++ b/ironfish/src/migrations/data/018-transaction-amounts.ts
@@ -10,7 +10,7 @@ import { Account } from '../../wallet'
 import { AssetBalances } from '../../wallet/assetBalances'
 import { Migration } from '../migration'
 
-export class Migration017 extends Migration {
+export class Migration018 extends Migration {
   path = __filename
 
   prepare(node: IronfishNode): IDatabase {

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -6,5 +6,6 @@ import { Migration014 } from './014-blockchain'
 import { Migration015 } from './015-wallet'
 import { Migration016 } from './016-sequence-to-tx'
 import { Migration017 } from './017-sequence-encoding'
+import { Migration018 } from './018-transaction-amounts'
 
-export const MIGRATIONS = [Migration014, Migration015, Migration016, Migration017]
+export const MIGRATIONS = [Migration014, Migration015, Migration016, Migration017, Migration018]

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -37,7 +37,7 @@ import {
 } from './transactionAmountsValue'
 import { TransactionValue, TransactionValueEncoding } from './transactionValue'
 
-export const VERSION_DATABASE_ACCOUNTS = 17
+export const VERSION_DATABASE_ACCOUNTS = 18
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountId: null,


### PR DESCRIPTION
## Summary

the migration iterates over the accounts in the walletDb to backfill the new transactionAmounts datastore

for each transaction in an account it
        - adds up the values of all the notes that the account spent in the
          transaction
        - adds up the values of all the notes that the account received in the
          transaction
        - adds records to the transactionAmounts store for each asset in the
          transaction that the account either spent or received

## Testing Plan

<img width="875" alt="image" src="https://user-images.githubusercontent.com/57735705/215613456-ca392ba0-7b0d-4cba-8559-ce936ff1a443.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
