### PR TITLE
trusted-setup: Fix server IP banning

### DIFF
--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -17,6 +17,8 @@ type CurrentContributor = {
   actionTimeout: SetTimeoutToken
 }
 
+const ENABLE_IP_BANNING = true
+
 class CeremonyServerClient {
   id: string
   socket: net.Socket
@@ -177,19 +179,23 @@ export class CeremonyServer {
   private onConnection(socket: net.Socket): void {
     const client = new CeremonyServerClient({ socket, id: uuid(), logger: this.logger })
 
+    socket.on('data', (data: Buffer) => void this.onData(client, data))
+    socket.on('close', () => this.onDisconnect(client))
+    socket.on('error', (e) => this.onError(client, e))
+
     const ip = socket.remoteAddress
-    const matching = this.queue.filter((c) => c.socket.remoteAddress === ip)
-    if (ip === undefined || matching.length > 0) {
-      client.close(new Error('IP address already used in this service'))
+    if (
+      ENABLE_IP_BANNING &&
+      (ip === undefined ||
+        this.queue.find((c) => c.socket.remoteAddress === ip) !== undefined ||
+        this.currentContributor?.client.socket.remoteAddress === ip)
+    ) {
+      this.closeClient(client, new Error('IP address already used in this service'))
       return
     }
 
     this.queue.push(client)
     client.send({ method: 'joined', queueLocation: this.queue.length })
-
-    socket.on('data', (data: Buffer) => void this.onData(client, data))
-    socket.on('close', () => this.onDisconnect(client))
-    socket.on('error', (e) => this.onError(client, e))
 
     client.logger.info(`Connected ${this.queue.length} total`)
     void this.startNextContributor()


### PR DESCRIPTION
## Summary

The server would crash when banning users by IP because it hadn't bound the error handlers yet.

Also, the server didn't check if the current contributor has the same IP as the newly connected client.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
