### PR TITLE
feat(ironfish): mining pool tracks status of blocks its submitted

### DIFF
--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -7,6 +7,7 @@ import { Assert } from '../assert'
 import { Config } from '../fileStores/config'
 import { Logger } from '../logger'
 import { Target } from '../primitives/target'
+import { Transaction } from '../primitives/transaction'
 import { RpcSocketClient } from '../rpc/clients'
 import { SerializedBlockTemplate } from '../serde/BlockTemplateSerde'
 import { BigIntUtils } from '../utils/bigint'
@@ -211,7 +212,9 @@ export class MiningPool {
 
     const eventLoopStartTime = new Date().getTime()
 
-    if (this.nextPayoutAttempt <= eventLoopStartTime) {
+    await this.updateUnconfirmedBlocks()
+
+    if (this.nextPayoutAttempt <= new Date().getTime()) {
       this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
       await this.shares.createPayout()
     }
@@ -290,11 +293,18 @@ export class MiningPool {
         const hashRate = await this.estimateHashRate()
         const hashedHeaderHex = hashedHeader.toString('hex')
 
+        const minersFee = new Transaction(
+          Buffer.from(blockTemplate.transactions[0], 'hex'),
+        ).fee()
+
+        await this.shares.submitBlock(blockTemplate.header.sequence, hashedHeaderHex, minersFee)
+
         this.logger.info(
           `Block ${hashedHeaderHex} submitted successfully! ${FileUtils.formatHashRate(
             hashRate,
           )}/s`,
         )
+
         this.webhooks.map((w) =>
           w.poolSubmittedBlock(hashedHeaderHex, hashRate, this.stratum.clients.size),
         )
@@ -516,5 +526,19 @@ export class MiningPool {
     }
 
     return status
+  }
+
+  async updateUnconfirmedBlocks(): Promise<void> {
+    const unconfirmedBlocks = await this.shares.unconfirmedBlocks()
+
+    for (const block of unconfirmedBlocks) {
+      const blockInfoResp = await this.rpc.getBlockInfo({
+        hash: block.blockHash,
+        confirmations: this.config.get('confirmations'),
+      })
+
+      const { main, confirmed } = blockInfoResp.content.metadata
+      await this.shares.updateBlockStatus(block, main, confirmed)
+    }
   }
 }

--- a/ironfish/src/mining/poolDatabase/migrations/005-add-block-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/005-add-block-table.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration005 extends Migration {
+  name = '005-add-block-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE block (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        blockSequence INTEGER NOT NULL,
+        blockHash TEXT NOT NULL,
+        minerReward TEXT NOT NULL,
+        confirmed BOOLEAN DEFAULT FALSE,
+        main BOOLEAN DEFAULT TRUE
+      );
+     `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP TABLE IF EXISTS block;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -5,5 +5,7 @@
 import Migration001 from './001-initial'
 import Migration002 from './002-add-shares-index'
 import Migration003 from './003-add-transaction-hash'
+import Migration004 from './004-add-shares-address-index'
+import Migration005 from './005-add-block-table'
 
-export const MIGRATIONS = [Migration001, Migration002, Migration003]
+export const MIGRATIONS = [Migration001, Migration002, Migration003, Migration004, Migration005]

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -9,6 +9,7 @@ import { ErrorUtils } from '../utils'
 import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
 import { DatabaseShare, PoolDatabase } from './poolDatabase'
+import { DatabaseBlock } from './poolDatabase/database'
 import { WebhookNotifier } from './webhooks'
 
 export class MiningPoolShares {
@@ -83,6 +84,14 @@ export class MiningPoolShares {
 
   async submitShare(publicAddress: string): Promise<void> {
     await this.db.newShare(publicAddress)
+  }
+
+  async submitBlock(sequence: number, hash: string, reward: bigint): Promise<void> {
+    if (reward < 0) {
+      reward *= BigInt(-1)
+    }
+
+    await this.db.newBlock(sequence, hash, reward.toString())
   }
 
   async createPayout(): Promise<void> {
@@ -218,5 +227,21 @@ export class MiningPoolShares {
 
   async sharesPendingPayout(publicAddress?: string): Promise<number> {
     return await this.db.getSharesCountForPayout(publicAddress)
+  }
+
+  async unconfirmedBlocks(): Promise<DatabaseBlock[]> {
+    return await this.db.unconfirmedBlocks()
+  }
+
+  async updateBlockStatus(
+    block: DatabaseBlock,
+    main: boolean,
+    confirmed: boolean,
+  ): Promise<void> {
+    if (main === block.main && confirmed === block.confirmed) {
+      return
+    }
+
+    await this.db.updateBlockStatus(block.id, main, confirmed)
   }
 }


### PR DESCRIPTION
## Summary

**DO NOT MERGE**

This introduces a new table to the mining pool database, block. The pool will insert a row every time it successfully submits a block. The event loop will check any unconfirmed blocks, and update their status accordingly. For now, that status includes whether it's on the main chain, and whether it's confirmed. This gives us the ability to track how much reward was earned within a specific timeframe.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
