### PR TITLE
send correct queue location

### DIFF
--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -277,7 +277,7 @@ export class CeremonyServer {
 
   private sendUpdatedLocationsToClients() {
     for (const [i, client] of this.queue.entries()) {
-      client.send({ method: 'joined', queueLocation: i })
+      client.send({ method: 'joined', queueLocation: i + 1 })
     }
   }
 


### PR DESCRIPTION
## Summary
We were sending 0 indexed queue locations but we want to send 1 indexed

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
