### PR TITLE
chore: remove codecov cli

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -32,10 +32,6 @@ flags:
     paths:
       - ironfish-rust
     carryforward: true
-  ironfish-cli:
-    paths:
-      - ironfish-cli
-    carryforward: true
   ironfish:
     paths:
       - ironfish


### PR DESCRIPTION
## Summary
We are not writing tests currently for `ironfish-cli` so this is conflating our actual code coverage reports. Removing this, we can revert this change if we start writing tests again for cli.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
