### PR TITLE
feat(ironfish): Add explicit payout period to mining pool

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -186,6 +186,12 @@ export type ConfigOptions = {
   poolRecentShareCutoff: number
 
   /**
+   * The length of time in seconds for each payout period. This is used to
+   * calculate the number of shares and how much they earn per period.
+   */
+  poolPayoutPeriodDuration: number
+
+  /**
    * The discord webhook URL to post pool critical pool information to
    */
   poolDiscordWebhook: ''
@@ -375,6 +381,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolSuccessfulPayoutInterval: 2 * 60 * 60, // 2 hours
       poolStatusNotificationInterval: 30 * 60, // 30 minutes
       poolRecentShareCutoff: 2 * 60 * 60, // 2 hours
+      poolPayoutPeriodDuration: 2 * 60 * 60, // 2 hours
       poolDiscordWebhook: '',
       poolMaxConnectionsPerIp: 0,
       poolLarkWebhook: '',

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -212,6 +212,7 @@ export class MiningPool {
 
     const eventLoopStartTime = new Date().getTime()
 
+    await this.shares.rolloverPayoutPeriod()
     await this.updateUnconfirmedBlocks()
 
     if (this.nextPayoutAttempt <= new Date().getTime()) {

--- a/ironfish/src/mining/poolDatabase/migrations/006-add-payout-period-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/006-add-payout-period-table.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration006 extends Migration {
+  name = '006-add-payout-period-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE payoutPeriod (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        start INTEGER NOT NULL,
+        end INTEGER
+      );
+    `)
+
+    await db.run(`
+      ALTER TABLE block ADD payoutPeriodId INTEGER NOT NULL REFERENCES payoutPeriodId (id);
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run(`ALTER TABLE block DROP COLUMN payoutPeriodId;`)
+    await db.run('DROP TABLE IF EXISTS payoutPeriod;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -7,5 +7,13 @@ import Migration002 from './002-add-shares-index'
 import Migration003 from './003-add-transaction-hash'
 import Migration004 from './004-add-shares-address-index'
 import Migration005 from './005-add-block-table'
+import Migration006 from './006-add-payout-period-table'
 
-export const MIGRATIONS = [Migration001, Migration002, Migration003, Migration004, Migration005]
+export const MIGRATIONS = [
+  Migration001,
+  Migration002,
+  Migration003,
+  Migration004,
+  Migration005,
+  Migration006,
+]

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -244,4 +244,19 @@ export class MiningPoolShares {
 
     await this.db.updateBlockStatus(block.id, main, confirmed)
   }
+
+  async rolloverPayoutPeriod(): Promise<void> {
+    const payoutPeriodDuration = this.config.get('poolPayoutPeriodDuration') * 1000
+    const now = new Date().getTime()
+    const payoutPeriodCutoff = now - payoutPeriodDuration
+
+    const payoutPeriod = await this.db.getCurrentPayoutPeriod()
+
+    if (payoutPeriod && payoutPeriod.start > payoutPeriodCutoff) {
+      // Current payout period has not exceeded its duration yet
+      return
+    }
+
+    await this.db.rolloverPayoutPeriod(now)
+  }
 }


### PR DESCRIPTION
## Summary

Builds on #3216 

This adds a "payout period" with a fixed length, such that any blocks or shares found during that time will be tied to that bucket. This will allow the pool to calculate the exact amount to payout each share in a deterministic fashion.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
