### PR TITLE
Swap wordsToSpendingKey for spendingKeyToWords

### DIFF
--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { wordsSpendingKey } from '@ironfish/rust-nodejs'
+import { spendingKeyToWords } from '@ironfish/rust-nodejs'
 import { ErrorUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs'
@@ -57,10 +57,13 @@ export class ExportCommand extends IronfishCommand {
     const response = await client.exportAccount({ account })
     let output
     if (flags.language) {
-      output = wordsSpendingKey(response.content.account.spendingKey, LANGUAGES[flags.language])
+      output = spendingKeyToWords(
+        response.content.account.spendingKey,
+        LANGUAGES[flags.language],
+      )
     } else if (flags.mnemonic) {
       const language = await selectLanguage()
-      output = wordsSpendingKey(response.content.account.spendingKey, language)
+      output = spendingKeyToWords(response.content.account.spendingKey, language)
     } else {
       output = JSON.stringify(response.content.account, undefined, '   ')
     }


### PR DESCRIPTION
## Summary

This was a misnamed function causing lints on staging to fail after merging #3218 and #3207 separately. Also, since this is exporting, I think it should be taking a spending key and outputting words, rather than taking words and outputting a spending key.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
