### PR TITLE
Fix chain:asset args name

### DIFF
--- a/ironfish-cli/src/commands/chain/asset.ts
+++ b/ironfish-cli/src/commands/chain/asset.ts
@@ -10,7 +10,7 @@ export default class Asset extends IronfishCommand {
 
   static args = [
     {
-      name: 'identifier',
+      name: 'id',
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The identifier of the asset',


### PR DESCRIPTION
## Summary
Fixing bug https://github.com/iron-fish/ironfish/issues/3234. Args name should be `id`.

## Testing Plan
Run `chain:asset` and check that bug is gone

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
