### PR TITLE
feat(ironfish): add new payout share table

### DIFF
--- a/ironfish/src/mining/poolDatabase/migrations/007-add-payout-shares-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/007-add-payout-shares-table.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration007 extends Migration {
+  name = '007-add-payout-shares-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE payoutShare (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        publicAddress TEXT NOT NULL,
+        payoutPeriodId INTEGER NOT NULL,
+        CONSTRAINT payoutShare_fk_payoutPeriodId FOREIGN KEY (payoutPeriodId) REFERENCES payoutPeriod (id)
+      );
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP TABLE IF EXISTS payoutShare;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -8,6 +8,7 @@ import Migration003 from './003-add-transaction-hash'
 import Migration004 from './004-add-shares-address-index'
 import Migration005 from './005-add-block-table'
 import Migration006 from './006-add-payout-period-table'
+import Migration007 from './007-add-payout-shares-table'
 
 export const MIGRATIONS = [
   Migration001,
@@ -16,4 +17,5 @@ export const MIGRATIONS = [
   Migration004,
   Migration005,
   Migration006,
+  Migration007,
 ]


### PR DESCRIPTION
## Summary

Builds on #3243 

This table is functionally identical to the existing one, but gives us a foreign key to payoutPeriod table, which will eventually be used to create new payout transactions. When that is done, this table will have an additional foreign key relation to a payout transaction table

The old table/logic will be removed in one complete removal PR, rather than piece-meal removal, so that we don't accidentally get anything into a broken state or miss something.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
