### PR TITLE
uses available balance when creating transactions

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -114,7 +114,9 @@ export class Send extends IronfishCommand {
       const response = await client.getAccountBalance({ account: from, assetId })
 
       const input = await CliUx.ux.prompt(
-        `Enter the amount (balance: ${CurrencyUtils.renderIron(response.content.confirmed)})`,
+        `Enter the amount (available balance: ${CurrencyUtils.renderIron(
+          response.content.available,
+        )})`,
         {
           required: true,
         },


### PR DESCRIPTION
## Summary

changes the 'send' command to display the available balance of the selected asset when inputting the amount to send

updates createTransaction to check the available balance instead of confirmed when checking if the account has sufficient funds

changes insufficient funds error message to explain the available balance and any unconfirmed or pending transactions

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
