### PR TITLE
add name to trusted setup submissions

### DIFF
--- a/ironfish-cli/src/commands/ceremony.ts
+++ b/ironfish-cli/src/commands/ceremony.ts
@@ -11,7 +11,6 @@ import { pipeline } from 'stream/promises'
 import { IronfishCommand } from '../command'
 import { DataDirFlag, DataDirFlagKey, VerboseFlag, VerboseFlagKey } from '../flags'
 import { CeremonyClient } from '../trusted-setup/client'
-import { nameIsValid } from '../trusted-setup/schema'
 
 export default class Ceremony extends IronfishCommand {
   static description = 'Contribute randomness to the Iron Fish trusted setup'
@@ -52,15 +51,10 @@ export default class Ceremony extends IronfishCommand {
     )
     randomness = randomness.length ? randomness : null
 
-    let name = 'anonymous'
-    do {
-      // Prompt for graffiti / name
-      const nameInput = await CliUx.ux.prompt(
-        `\nIf you'd like to associate a name with this contribution, type it here, then press Enter. Name must only include letters, numbers and spaces and be less than 30 characters. To accept the default, just press Enter (anonymous)`,
-        { required: false },
-      )
-      name = nameInput.length ? nameInput.trim() : name
-    } while (!nameIsValid(name))
+    const name = await CliUx.ux.prompt(
+      `If you'd like to associate a name with this contribution, type it here, then press Enter. Otherwise, to contribute anonymously, just press Enter`,
+      { required: false },
+    )
 
     // Create the client and bind events
     const client = new CeremonyClient({

--- a/ironfish-cli/src/trusted-setup/client.ts
+++ b/ironfish-cli/src/trusted-setup/client.ts
@@ -63,7 +63,7 @@ export class CeremonyClient {
     this.send({ method: 'contribution-complete' })
   }
 
-  join(name?: string): void {
+  join(name: string): void {
     this.send({ method: 'join', name })
   }
 

--- a/ironfish-cli/src/trusted-setup/client.ts
+++ b/ironfish-cli/src/trusted-setup/client.ts
@@ -63,6 +63,10 @@ export class CeremonyClient {
     this.send({ method: 'contribution-complete' })
   }
 
+  join(name?: string): void {
+    this.send({ method: 'join', name })
+  }
+
   uploadComplete(): void {
     this.send({ method: 'upload-complete' })
   }

--- a/ironfish-cli/src/trusted-setup/schema.ts
+++ b/ironfish-cli/src/trusted-setup/schema.ts
@@ -29,24 +29,11 @@ export type CeremonyServerMessage =
 export type CeremonyClientMessage = {
   method: 'contribution-complete' | 'upload-complete' | 'join'
   name?: string // only used on join
-  password?: string // only used on join
 }
-
-const nameRegexes = [/^[ a-zA-Z0-9]+$/, /^[^ ].*/, /.*[^ ]$/]
 
 export const CeremonyClientMessageSchema: yup.ObjectSchema<CeremonyClientMessage> = yup
   .object({
     method: yup.string().oneOf(['contribution-complete', 'upload-complete', 'join']).required(),
-    name: yup
-      .string()
-      .max(30)
-      .matches(nameRegexes[0]) // all characters must be alphanumeric or space
-      .matches(nameRegexes[1]) // first character cannot be a space
-      .matches(nameRegexes[2]), // last character cannot be a space
-    password: yup.string(),
+    name: yup.string(),
   })
   .required()
-
-export const nameIsValid = (name: string): boolean => {
-  return !nameRegexes.map((r) => r.test(name)).includes(false) && name.length <= 30
-}

--- a/ironfish-cli/src/trusted-setup/schema.ts
+++ b/ironfish-cli/src/trusted-setup/schema.ts
@@ -27,11 +27,26 @@ export type CeremonyServerMessage =
     }
 
 export type CeremonyClientMessage = {
-  method: 'contribution-complete' | 'upload-complete'
+  method: 'contribution-complete' | 'upload-complete' | 'join'
+  name?: string // only used on join
+  password?: string // only used on join
 }
+
+const nameRegexes = [/^[ a-zA-Z0-9]+$/, /^[^ ].*/, /.*[^ ]$/]
 
 export const CeremonyClientMessageSchema: yup.ObjectSchema<CeremonyClientMessage> = yup
   .object({
-    method: yup.string().oneOf(['contribution-complete', 'upload-complete']).required(),
+    method: yup.string().oneOf(['contribution-complete', 'upload-complete', 'join']).required(),
+    name: yup
+      .string()
+      .max(30)
+      .matches(nameRegexes[0]) // all characters must be alphanumeric or space
+      .matches(nameRegexes[1]) // first character cannot be a space
+      .matches(nameRegexes[2]), // last character cannot be a space
+    password: yup.string(),
   })
   .required()
+
+export const nameIsValid = (name: string): boolean => {
+  return !nameRegexes.map((r) => r.test(name)).includes(false) && name.length <= 30
+}

--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -116,7 +116,7 @@ export class CeremonyServer {
     const paramFileNames = await S3Utils.getBucketObjects(this.s3Client, this.s3Bucket)
     const validParams = paramFileNames
       .slice(0)
-      .filter((fileName) => /^params_\d{5}.*$/.test(fileName))
+      .filter((fileName) => /^params_\d{5}$/.test(fileName))
     validParams.sort()
     return validParams[validParams.length - 1]
   }
@@ -345,8 +345,7 @@ export class CeremonyServer {
     const hash = await verifyTransform(oldParamsDownloadPath, newParamsDownloadPath)
 
     client.logger.info(`Uploading verified contribution`)
-    const nameSuffix = client.name === undefined ? '' : `_${client.name.split(' ').join('_')}`
-    const destFile = 'params_' + nextParamNumber.toString().padStart(5, '0') + nameSuffix
+    const destFile = 'params_' + nextParamNumber.toString().padStart(5, '0')
     await S3Utils.uploadToBucket(
       this.s3Client,
       newParamsDownloadPath,
@@ -354,6 +353,7 @@ export class CeremonyServer {
       this.s3Bucket,
       destFile,
       client.logger,
+      client.name ? { contributorName: encodeURIComponent(client.name) } : undefined,
     )
 
     client.logger.info(`Cleaning up local files`)

--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -24,6 +24,9 @@ class CeremonyServerClient {
   socket: net.Socket
   connected: boolean
   logger: Logger
+  private _joined?: {
+    name?: string
+  }
 
   constructor(options: { socket: net.Socket; id: string; logger: Logger }) {
     this.id = options.id
@@ -34,6 +37,18 @@ class CeremonyServerClient {
 
   send(message: CeremonyServerMessage): void {
     this.socket.write(JSON.stringify(message) + '\n')
+  }
+
+  join(name?: string) {
+    this._joined = { name }
+  }
+
+  get joined(): boolean {
+    return this._joined !== undefined
+  }
+
+  get name(): string | undefined {
+    return this._joined?.name
   }
 
   close(error?: Error): void {
@@ -101,7 +116,7 @@ export class CeremonyServer {
     const paramFileNames = await S3Utils.getBucketObjects(this.s3Client, this.s3Bucket)
     const validParams = paramFileNames
       .slice(0)
-      .filter((fileName) => /^params_\d{4}$/.exec(fileName)?.length === 1)
+      .filter((fileName) => /^params_\d{5}.*$/.test(fileName))
     validParams.sort()
     return validParams[validParams.length - 1]
   }
@@ -193,13 +208,6 @@ export class CeremonyServer {
       this.closeClient(client, new Error('IP address already used in this service'))
       return
     }
-
-    this.queue.push(client)
-    const estimate = this.queue.length * (this.contributionTimeoutMs + this.uploadTimeoutMs)
-    client.send({ method: 'joined', queueLocation: this.queue.length, estimate })
-
-    client.logger.info(`Connected ${this.queue.length} total`)
-    void this.startNextContributor()
   }
 
   private onDisconnect(client: CeremonyServerClient): void {
@@ -230,7 +238,15 @@ export class CeremonyServer {
 
     client.logger.info(`Message Received: ${parsedMessage.method}`)
 
-    if (parsedMessage.method === 'contribution-complete') {
+    if (parsedMessage.method === 'join' && !client.joined) {
+      this.queue.push(client)
+      const estimate = this.queue.length * (this.contributionTimeoutMs + this.uploadTimeoutMs)
+      client.join(parsedMessage.name)
+      client.send({ method: 'joined', queueLocation: this.queue.length, estimate })
+
+      client.logger.info(`Connected ${this.queue.length} total`)
+      void this.startNextContributor()
+    } else if (parsedMessage.method === 'contribution-complete') {
       await this.handleContributionComplete(client).catch((e) => {
         client.logger.error(
           `Error handling contribution-complete: ${ErrorUtils.renderError(e)}`,
@@ -329,7 +345,8 @@ export class CeremonyServer {
     const hash = await verifyTransform(oldParamsDownloadPath, newParamsDownloadPath)
 
     client.logger.info(`Uploading verified contribution`)
-    const destFile = 'params_' + nextParamNumber.toString().padStart(4, '0')
+    const nameSuffix = client.name === undefined ? '' : `_${client.name.split(' ').join('_')}`
+    const destFile = 'params_' + nextParamNumber.toString().padStart(5, '0') + nameSuffix
     await S3Utils.uploadToBucket(
       this.s3Client,
       newParamsDownloadPath,

--- a/ironfish-cli/src/utils/s3.ts
+++ b/ironfish-cli/src/utils/s3.ts
@@ -49,6 +49,7 @@ export async function uploadToBucket(
   bucket: string,
   keyName: string,
   logger?: Logger,
+  metadata?: Record<string, string>,
 ): Promise<void> {
   const fileHandle = await fsAsync.open(filePath, 'r')
 
@@ -68,6 +69,7 @@ export async function uploadToBucket(
     Bucket: bucket,
     Key: keyName,
     ContentType: contentType,
+    Metadata: metadata,
   }
 
   const uploadId = await s3


### PR DESCRIPTION
## Summary
For later usage we want to give the user the option to add a name to their contribution. This is in case we want to publicly display the contributions later on.

## Testing Plan
Local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
