### PR TITLE
fixes little-endian encodings in walletDb

### DIFF
--- a/ironfish/src/migrations/data/017-sequence-encoding.ts
+++ b/ironfish/src/migrations/data/017-sequence-encoding.ts
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Logger } from '../../logger'
+import { IronfishNode } from '../../node'
+import {
+  BufferEncoding,
+  DatabaseSchema,
+  IDatabase,
+  IDatabaseStore,
+  IDatabaseTransaction,
+  NULL_ENCODING,
+  PrefixEncoding,
+  U32_ENCODING_BE,
+} from '../../storage'
+import { Account } from '../../wallet'
+import { Migration } from '../migration'
+
+export class Migration017 extends Migration {
+  path = __filename
+
+  prepare(node: IronfishNode): IDatabase {
+    return node.wallet.walletDb.db
+  }
+
+  async forward(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const accounts = await this.getAccounts(node)
+
+    logger.info(`Re-indexing transactions for ${accounts.length} accounts`)
+    logger.info('')
+
+    for (const account of accounts) {
+      let transactionCount = 0
+
+      logger.info(`Indexing on-chain transactions for account ${account.name}`)
+      for await (const transactionValue of account.getTransactions()) {
+        await node.wallet.walletDb.saveTransaction(
+          account,
+          transactionValue.transaction.hash(),
+          transactionValue,
+        )
+        transactionCount++
+      }
+
+      logger.info(` Indexed ${transactionCount} transactions for account ${account.name}`)
+      logger.info('')
+    }
+
+    logger.info('Clearing data from old datastores...')
+
+    const { sequenceToNoteHash, sequenceToTransactionHash, pendingTransactionHashes } =
+      this.getOldStores(db)
+
+    await sequenceToNoteHash.clear()
+    await sequenceToTransactionHash.clear()
+    await pendingTransactionHashes.clear()
+  }
+
+  async backward(node: IronfishNode, db: IDatabase): Promise<void> {
+    const accounts = await this.getAccounts(node)
+
+    const { sequenceToNoteHash, sequenceToTransactionHash, pendingTransactionHashes } =
+      this.getOldStores(db)
+
+    for (const account of accounts) {
+      for await (const transactionValue of account.getTransactions()) {
+        const transactionHash = transactionValue.transaction.hash()
+
+        for (const note of transactionValue.transaction.notes) {
+          if (transactionValue.sequence !== null) {
+            const sequence = transactionValue.sequence
+
+            const decryptedNoteValue = await account.getDecryptedNote(note.hash())
+
+            if (decryptedNoteValue === undefined) {
+              continue
+            }
+
+            await sequenceToNoteHash.put([account.prefix, [sequence, note.hash()]], null)
+            await sequenceToTransactionHash.put(
+              [account.prefix, [sequence, transactionHash]],
+              null,
+            )
+          } else {
+            const expiration = transactionValue.transaction.expiration()
+            await pendingTransactionHashes.put(
+              [account.prefix, [expiration, transactionHash]],
+              null,
+            )
+          }
+        }
+      }
+    }
+
+    await node.wallet.walletDb.sequenceToNoteHash.clear()
+    await node.wallet.walletDb.sequenceToTransactionHash.clear()
+    await node.wallet.walletDb.pendingTransactionHashes.clear()
+  }
+
+  async getAccounts(node: IronfishNode): Promise<Account[]> {
+    const accounts = []
+
+    for await (const accountValue of node.wallet.walletDb.loadAccounts()) {
+      accounts.push(
+        new Account({
+          ...accountValue,
+          walletDb: node.wallet.walletDb,
+        }),
+      )
+    }
+
+    return accounts
+  }
+
+  getOldStores(db: IDatabase): {
+    sequenceToNoteHash: IDatabaseStore<DatabaseSchema>
+    sequenceToTransactionHash: IDatabaseStore<DatabaseSchema>
+    pendingTransactionHashes: IDatabaseStore<DatabaseSchema>
+  } {
+    const sequenceToNoteHash = db.addStore({
+      name: 's',
+      keyEncoding: new PrefixEncoding(
+        new BufferEncoding(),
+        new PrefixEncoding(U32_ENCODING_BE, new BufferEncoding(), 4),
+        4,
+      ),
+      valueEncoding: NULL_ENCODING,
+    })
+
+    const sequenceToTransactionHash = db.addStore({
+      name: 'st',
+      keyEncoding: new PrefixEncoding(
+        new BufferEncoding(),
+        new PrefixEncoding(U32_ENCODING_BE, new BufferEncoding(), 4),
+        4,
+      ),
+      valueEncoding: NULL_ENCODING,
+    })
+
+    const pendingTransactionHashes = db.addStore({
+      name: 'p',
+      keyEncoding: new PrefixEncoding(
+        new BufferEncoding(),
+        new PrefixEncoding(U32_ENCODING_BE, new BufferEncoding(), 4),
+        4,
+      ),
+      valueEncoding: NULL_ENCODING,
+    })
+
+    return { sequenceToNoteHash, sequenceToTransactionHash, pendingTransactionHashes }
+  }
+}

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -5,5 +5,6 @@
 import { Migration014 } from './014-blockchain'
 import { Migration015 } from './015-wallet'
 import { Migration016 } from './016-sequence-to-tx'
+import { Migration017 } from './017-sequence-encoding'
 
-export const MIGRATIONS = [Migration014, Migration015, Migration016]
+export const MIGRATIONS = [Migration014, Migration015, Migration016, Migration017]

--- a/ironfish/src/storage/database/encoding.ts
+++ b/ironfish/src/storage/database/encoding.ts
@@ -31,6 +31,18 @@ export class U32Encoding implements IDatabaseEncoding<number> {
   }
 }
 
+export class U32EncodingBE implements IDatabaseEncoding<number> {
+  serialize(value: number): Buffer {
+    const buffer = Buffer.alloc(4)
+    buffer.writeUInt32BE(value)
+    return buffer
+  }
+
+  deserialize(buffer: Buffer): number {
+    return buffer.readUInt32BE()
+  }
+}
+
 export class NullEncoding implements IDatabaseEncoding<null> {
   static EMPTY_BUFFER = Buffer.alloc(0)
 
@@ -185,5 +197,6 @@ export class BufferToStringEncoding {
 
 export const BUFFER_ENCODING = new BufferEncoding()
 export const U32_ENCODING = new U32Encoding()
+export const U32_ENCODING_BE = new U32EncodingBE()
 export const NULL_ENCODING = new NullEncoding()
 export const U64_ENCODING = new U64Encoding()

--- a/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
@@ -1,0 +1,42 @@
+{
+  "WalletDB loadNoteHashesInSequenceRange loads note hashes in the provided range": [
+    {
+      "id": "0e7b38bc-ec81-4684-810c-b9db2ee892cd",
+      "name": "test",
+      "spendingKey": "fa5efee37ae37d91f39fc1359a4c208c34f56b61171704a5946a647223b500f6",
+      "incomingViewKey": "2fd48d0953832e120e510330c26456d01c3df230b4bbeec463f508ac2c864006",
+      "outgoingViewKey": "73438b606fc5af0e08bb2c9ce81a4a138f369f71eaa53e7790c2a6150caeac04",
+      "publicAddress": "55daa782b5c2dc29646d3ae5f0d2d3c7c99ee590e7ebdf7a3fdacc6e547fac0c"
+    }
+  ],
+  "WalletDB loadTransactionHashesInSequenceRange loads transaction hashes in the provided range": [
+    {
+      "id": "c2272829-4379-4b5e-98f7-6c4eb112fb58",
+      "name": "test",
+      "spendingKey": "a63b2a839960581373b8b4cc63b995c32e28ffdc0005a5aca96000fbcc9358be",
+      "incomingViewKey": "c5472c7f2f230ed048d908ff90385e3a9556bffda82500aa84d6e2fd90209107",
+      "outgoingViewKey": "b9be459a2e35da5a72c3e5a788dcb3fa1ce62194710979d6ffa5b09966f394a1",
+      "publicAddress": "5126fac26340d8454b64de51fa96e94641a4196321663206f8e172ecfe6eb2ba"
+    }
+  ],
+  "WalletDB loadExpiredTransactionHashes loads transaction hashes with expiration sequences in the expired range": [
+    {
+      "id": "effa5cd0-e5a6-40c4-bd1f-264e2dfc61b9",
+      "name": "test",
+      "spendingKey": "f93d51183d1366d5014e82a3c418f8d52fdd56fd8a0b5b88e8539990f0de885a",
+      "incomingViewKey": "9c3d9dbc3759509d1056b1243f6ee768539455d265e0446d5bb220d662ccf601",
+      "outgoingViewKey": "1fe8cc66325238e7afaecd556e51bf2c7a041775f18ebc016b30eebfac45be71",
+      "publicAddress": "90f6ba51e618293d2773eff1bb6f7055a4f97208c41586ce02548694d24809ab"
+    }
+  ],
+  "WalletDB loadPendingTransactionHashes loads transaction hashes with expiration sequences outside the expired range": [
+    {
+      "id": "b433e112-2ecd-4a26-80f2-f09e6b7951ca",
+      "name": "test",
+      "spendingKey": "a84e7384f5ccf7051102dbb0006f82bbda6fa5bc85786109cbb7d86e88a55faf",
+      "incomingViewKey": "7c9369a0638824a59aa4da319defe0fe1db3aed1f3e50be3664a0ab1d980f505",
+      "outgoingViewKey": "f086aa2880af2409f1d46e5acf853929f780d1d85ef5729c2279c73c7b44b3b8",
+      "publicAddress": "898d6f68973b0892caf2e4d539bc87beff7422d48234a23ef77d939d46e17ae4"
+    }
+  ]
+}

--- a/ironfish/src/wallet/walletdb/walletdb.test.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.test.ts
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createNodeTest, useAccountFixture } from '../../testUtilities'
+import { AsyncUtils } from '../../utils'
+
+describe('WalletDB', () => {
+  const nodeTest = createNodeTest()
+
+  describe('loadNoteHashesInSequenceRange', () => {
+    it('loads note hashes in the provided range', async () => {
+      const { node } = await nodeTest.createSetup()
+
+      const walletDb = node.wallet.walletDb
+
+      const account = await useAccountFixture(node.wallet)
+
+      await walletDb.sequenceToNoteHash.put(
+        [account.prefix, [1, Buffer.from('1', 'hex')]],
+        null,
+      )
+      await walletDb.sequenceToNoteHash.put(
+        [account.prefix, [10, Buffer.from('10', 'hex')]],
+        null,
+      )
+      await walletDb.sequenceToNoteHash.put(
+        [account.prefix, [100, Buffer.from('100', 'hex')]],
+        null,
+      )
+      await walletDb.sequenceToNoteHash.put(
+        [account.prefix, [1000, Buffer.from('1000', 'hex')]],
+        null,
+      )
+      await walletDb.sequenceToNoteHash.put(
+        [account.prefix, [10000, Buffer.from('10000', 'hex')]],
+        null,
+      )
+
+      const noteHashes = await AsyncUtils.materialize(
+        walletDb.loadNoteHashesInSequenceRange(account, 2, 9999),
+      )
+
+      expect(noteHashes).toHaveLength(3)
+      expect(noteHashes[0]).toEqualBuffer(Buffer.from('10', 'hex'))
+      expect(noteHashes[1]).toEqualBuffer(Buffer.from('100', 'hex'))
+      expect(noteHashes[2]).toEqualBuffer(Buffer.from('1000', 'hex'))
+    })
+  })
+
+  describe('loadTransactionHashesInSequenceRange', () => {
+    it('loads transaction hashes in the provided range', async () => {
+      const { node } = await nodeTest.createSetup()
+
+      const walletDb = node.wallet.walletDb
+
+      const account = await useAccountFixture(node.wallet)
+
+      await walletDb.sequenceToTransactionHash.put(
+        [account.prefix, [2, Buffer.from('2', 'hex')]],
+        null,
+      )
+      await walletDb.sequenceToTransactionHash.put(
+        [account.prefix, [20, Buffer.from('20', 'hex')]],
+        null,
+      )
+      await walletDb.sequenceToTransactionHash.put(
+        [account.prefix, [200, Buffer.from('200', 'hex')]],
+        null,
+      )
+      await walletDb.sequenceToTransactionHash.put(
+        [account.prefix, [2000, Buffer.from('2000', 'hex')]],
+        null,
+      )
+      await walletDb.sequenceToTransactionHash.put(
+        [account.prefix, [20000, Buffer.from('20000', 'hex')]],
+        null,
+      )
+
+      const transactionHashes = await AsyncUtils.materialize(
+        walletDb.loadTransactionHashesInSequenceRange(account, 2, 9999),
+      )
+
+      expect(transactionHashes).toHaveLength(4)
+      expect(transactionHashes[0]).toEqualBuffer(Buffer.from('2', 'hex'))
+      expect(transactionHashes[1]).toEqualBuffer(Buffer.from('20', 'hex'))
+      expect(transactionHashes[2]).toEqualBuffer(Buffer.from('200', 'hex'))
+      expect(transactionHashes[3]).toEqualBuffer(Buffer.from('2000', 'hex'))
+    })
+  })
+
+  describe('loadExpiredTransactionHashes', () => {
+    it('loads transaction hashes with expiration sequences in the expired range', async () => {
+      const { node } = await nodeTest.createSetup()
+
+      const walletDb = node.wallet.walletDb
+
+      const account = await useAccountFixture(node.wallet)
+
+      // expiration of 0 never expires
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [0, Buffer.from('0', 'hex')]],
+        null,
+      )
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [3, Buffer.from('3', 'hex')]],
+        null,
+      )
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [30, Buffer.from('30', 'hex')]],
+        null,
+      )
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [300, Buffer.from('300', 'hex')]],
+        null,
+      )
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [3000, Buffer.from('3000', 'hex')]],
+        null,
+      )
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [30000, Buffer.from('30000', 'hex')]],
+        null,
+      )
+
+      const transactionHashes = await AsyncUtils.materialize(
+        walletDb.loadExpiredTransactionHashes(account, 3000),
+      )
+
+      expect(transactionHashes).toHaveLength(4)
+      expect(transactionHashes[0]).toEqualBuffer(Buffer.from('3', 'hex'))
+      expect(transactionHashes[1]).toEqualBuffer(Buffer.from('30', 'hex'))
+      expect(transactionHashes[2]).toEqualBuffer(Buffer.from('300', 'hex'))
+      expect(transactionHashes[3]).toEqualBuffer(Buffer.from('3000', 'hex'))
+    })
+  })
+
+  describe('loadPendingTransactionHashes', () => {
+    it('loads transaction hashes with expiration sequences outside the expired range', async () => {
+      const { node } = await nodeTest.createSetup()
+
+      const walletDb = node.wallet.walletDb
+
+      const account = await useAccountFixture(node.wallet)
+
+      // expiration of 0 never expires
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [0, Buffer.from('0', 'hex')]],
+        null,
+      )
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [4, Buffer.from('4', 'hex')]],
+        null,
+      )
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [40, Buffer.from('40', 'hex')]],
+        null,
+      )
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [400, Buffer.from('400', 'hex')]],
+        null,
+      )
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [4000, Buffer.from('4000', 'hex')]],
+        null,
+      )
+      await walletDb.pendingTransactionHashes.put(
+        [account.prefix, [40000, Buffer.from('40000', 'hex')]],
+        null,
+      )
+
+      const transactionHashes = await AsyncUtils.materialize(
+        walletDb.loadPendingTransactionHashes(account, 4000),
+      )
+
+      expect(transactionHashes).toHaveLength(2)
+      expect(transactionHashes[0]).toEqualBuffer(Buffer.from('0', 'hex'))
+      expect(transactionHashes[1]).toEqualBuffer(Buffer.from('40000', 'hex'))
+    })
+  })
+})


### PR DESCRIPTION
## Summary

we store sequences in several walletDb datastores: sequenceToNoteHash, sequenceToTransactionHash, and pendingTransactionHashes

we use little-endian encodings in the keys for each of these stores. the problem is that we rely on iterating over the keys of these stores *in order* so that we can load keys using sequence ranges. we cannot use little-endian encodings for this kind of ordering; we need to use big-endian encoding instead.

- adds UInt32EncodingBE for big-endian encoding of Uint32 values
- replaces datastores using little-endian encodings with new ones using big-endian encodings
- adds data migration to replace the old stores with the new stores
- adds tests of WalletDB methods that rely on ordered iteration

## Testing Plan

- Added unit tests, ran on old datastores to confirm the issue
- Ran migration on local node, tested balance computations with different confirmation values

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
