### PR TITLE
trusted-setup: Handle client disconnects while server is verifying contributions

### DIFF
--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -11,11 +11,21 @@ import { v4 as uuid } from 'uuid'
 import { S3Utils } from '../utils'
 import { CeremonyClientMessageSchema, CeremonyServerMessage } from './schema'
 
-type CurrentContributor = {
-  state: 'STARTED' | 'UPLOADING'
-  client: CeremonyServerClient
-  actionTimeout: SetTimeoutToken
-}
+type CurrentContributor =
+  | {
+      state: 'STARTED'
+      client: CeremonyServerClient
+      actionTimeout: SetTimeoutToken
+    }
+  | {
+      state: 'UPLOADING'
+      client: CeremonyServerClient
+      actionTimeout: SetTimeoutToken
+    }
+  | {
+      state: 'VERIFYING'
+      client: CeremonyServerClient | null
+    }
 
 const ENABLE_IP_BANNING = true
 
@@ -107,7 +117,7 @@ export class CeremonyServer {
   }
 
   closeClient(client: CeremonyServerClient, error?: Error): void {
-    if (this.currentContributor?.client.id === client.id) {
+    if (this.currentContributor?.client?.id === client.id) {
       clearTimeout(this.currentContributor.actionTimeout)
       this.currentContributor = null
       void this.startNextContributor()
@@ -188,7 +198,7 @@ export class CeremonyServer {
       ENABLE_IP_BANNING &&
       (ip === undefined ||
         this.queue.find((c) => c.socket.remoteAddress === ip) !== undefined ||
-        this.currentContributor?.client.socket.remoteAddress === ip)
+        this.currentContributor?.client?.socket.remoteAddress === ip)
     ) {
       this.closeClient(client, new Error('IP address already used in this service'))
       return
@@ -249,11 +259,14 @@ export class CeremonyServer {
   }
 
   private async handleContributionComplete(client: CeremonyServerClient) {
-    if (this.currentContributor?.client.id !== client.id) {
-      throw new Error('upload-complete message sent but not the current contributor')
+    if (
+      this.currentContributor?.client?.id !== client.id ||
+      this.currentContributor.state !== 'STARTED'
+    ) {
+      throw new Error('contribution-complete message sent but not the current contributor')
     }
 
-    this.currentContributor.actionTimeout && clearTimeout(this.currentContributor.actionTimeout)
+    clearTimeout(this.currentContributor.actionTimeout)
 
     client.logger.info('Generating presigned URL')
 
@@ -266,14 +279,18 @@ export class CeremonyServer {
 
     client.logger.info('Sending back presigned URL')
 
-    this.currentContributor.actionTimeout = setTimeout(() => {
-      this.closeClient(client, new Error('Failed to complete upload in time'))
-    }, this.uploadTimeoutMs)
-
     client.send({
       method: 'initiate-upload',
       uploadLink: presignedUrl,
     })
+
+    this.currentContributor = {
+      state: 'UPLOADING',
+      actionTimeout: setTimeout(() => {
+        this.closeClient(client, new Error('Failed to complete upload in time'))
+      }, this.uploadTimeoutMs),
+      client: this.currentContributor.client,
+    }
   }
 
   private sendUpdatedLocationsToClients() {
@@ -285,11 +302,19 @@ export class CeremonyServer {
   }
 
   private async handleUploadComplete(client: CeremonyServerClient) {
-    if (this.currentContributor?.client.id !== client.id) {
+    if (
+      this.currentContributor?.client?.id !== client.id ||
+      this.currentContributor.state !== 'UPLOADING'
+    ) {
       throw new Error('upload-complete message sent but not the current contributor')
     }
 
-    this.currentContributor.actionTimeout && clearTimeout(this.currentContributor.actionTimeout)
+    clearTimeout(this.currentContributor.actionTimeout)
+
+    this.currentContributor = {
+      state: 'VERIFYING',
+      client: this.currentContributor.client,
+    }
 
     client.logger.info('Getting latest contribution from S3')
     const latestParamName = await this.getLatestParamName()

--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -118,9 +118,13 @@ export class CeremonyServer {
 
   closeClient(client: CeremonyServerClient, error?: Error): void {
     if (this.currentContributor?.client?.id === client.id) {
-      clearTimeout(this.currentContributor.actionTimeout)
-      this.currentContributor = null
-      void this.startNextContributor()
+      if (this.currentContributor.state === 'VERIFYING') {
+        this.currentContributor.client = null
+      } else {
+        clearTimeout(this.currentContributor.actionTimeout)
+        this.currentContributor = null
+        void this.startNextContributor()
+      }
     }
 
     client.close(error)
@@ -385,6 +389,7 @@ export class CeremonyServer {
     })
 
     client.logger.info(`Contribution ${nextParamNumber} complete`)
+    this.currentContributor = null
     await this.startNextContributor()
     this.sendUpdatedLocationsToClients()
   }


### PR DESCRIPTION
- Add a VERIFYING state to the trusted setup server
- WIP

## Summary

If a client disconnects while the server is verifying parameters, the server will continue with verifying + uploading the parameters, but will start the next client in the queue at the same time. We should effectively be locking around the process of verifying+uploading verified params to S3, and once a client has uploading their parameters, it's not too important whether they remain connected or not.

This PR adds an additional client state, VERIFYING, that is transitioned to once the client uploads their parameters. If the current contributor disconnects while in this state, the verification will continue.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
