### PR TITLE
feat(ironfish): Add explicit payout period to mining pool

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -186,6 +186,12 @@ export type ConfigOptions = {
   poolRecentShareCutoff: number
 
   /**
+   * The length of time in seconds for each payout period. This is used to
+   * calculate the number of shares and how much they earn per period.
+   */
+  poolPayoutPeriodDuration: number
+
+  /**
    * The discord webhook URL to post pool critical pool information to
    */
   poolDiscordWebhook: ''
@@ -375,6 +381,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolSuccessfulPayoutInterval: 2 * 60 * 60, // 2 hours
       poolStatusNotificationInterval: 30 * 60, // 30 minutes
       poolRecentShareCutoff: 2 * 60 * 60, // 2 hours
+      poolPayoutPeriodDuration: 2 * 60 * 60, // 2 hours
       poolDiscordWebhook: '',
       poolMaxConnectionsPerIp: 0,
       poolLarkWebhook: '',

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -211,7 +211,9 @@ export class MiningPool {
 
     const eventLoopStartTime = new Date().getTime()
 
-    if (this.nextPayoutAttempt <= eventLoopStartTime) {
+    await this.shares.rolloverPayoutPeriod()
+
+    if (this.nextPayoutAttempt <= new Date().getTime()) {
       this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
       await this.shares.createPayout()
     }

--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Assert } from '../../assert'
 import { Config } from '../../fileStores'
 import { NodeFileProvider } from '../../fileSystems'
 import { createRootLogger } from '../../logger'
@@ -32,12 +34,29 @@ describe('poolDatabase', () => {
     await db.stop()
   })
 
-  // TODO(mat): This is an example, new tests will come with the refactor PRs
-  it('newShare', async () => {
-    const address = 'fakeAddress'
-    await db.newShare(address)
+  it('payout periods', async () => {
+    const payoutPeriod0 = await db.getCurrentPayoutPeriod()
+    expect(payoutPeriod0).toBeUndefined()
 
-    const shareCount = await db.getSharesCountForPayout(address)
-    expect(shareCount).toEqual(1)
+    const now = new Date().getTime()
+    await db.rolloverPayoutPeriod(now)
+
+    const payoutPeriod1 = await db.getCurrentPayoutPeriod()
+    Assert.isNotUndefined(payoutPeriod1, 'payoutPeriod1 should exist')
+    expect(payoutPeriod1.start).toEqual(now)
+
+    const nextTimestamp = now + 10
+    await db.rolloverPayoutPeriod(nextTimestamp)
+
+    const payoutPeriod2 = await db.getCurrentPayoutPeriod()
+    Assert.isNotUndefined(payoutPeriod2, 'payoutPeriod2 should exist')
+    expect(payoutPeriod2.start).toEqual(nextTimestamp)
+
+    const period1Raw = await db['db'].get(
+      'SELECT * FROM payoutPeriod WHERE id = ?',
+      payoutPeriod1.id,
+    )
+    Assert.isNotUndefined(period1Raw, 'period1Raw should exist')
+    expect(period1Raw.end).toEqual(payoutPeriod2.start - 1)
   })
 })

--- a/ironfish/src/mining/poolDatabase/database.ts
+++ b/ironfish/src/mining/poolDatabase/database.ts
@@ -133,6 +133,17 @@ export class PoolDatabase {
 
     return result.count
   }
+
+  async getCurrentPayoutPeriod(): Promise<DatabasePayoutPeriod | undefined> {
+    return await this.db.get<DatabasePayoutPeriod>(
+      'SELECT * FROM payoutPeriod WHERE end is null',
+    )
+  }
+
+  async rolloverPayoutPeriod(timestamp: number): Promise<void> {
+    await this.db.run('UPDATE payoutPeriod SET end = ? WHERE end IS NULL', timestamp - 1)
+    await this.db.run('INSERT INTO payoutPeriod (start) VALUES (?)', timestamp)
+  }
 }
 
 export type DatabaseShare = {
@@ -140,4 +151,12 @@ export type DatabaseShare = {
   publicAddress: string
   createdAt: Date
   payoutId: number | null
+}
+
+export type DatabasePayoutPeriod = {
+  id: number
+  // TODO(mat): Look into why this creates a string instead of a timestamp like start and end
+  createdAt: string
+  start: number
+  end: number | null
 }

--- a/ironfish/src/mining/poolDatabase/database.ts
+++ b/ironfish/src/mining/poolDatabase/database.ts
@@ -141,8 +141,10 @@ export class PoolDatabase {
   }
 
   async rolloverPayoutPeriod(timestamp: number): Promise<void> {
+    await this.db.run('BEGIN')
     await this.db.run('UPDATE payoutPeriod SET end = ? WHERE end IS NULL', timestamp - 1)
     await this.db.run('INSERT INTO payoutPeriod (start) VALUES (?)', timestamp)
+    await this.db.run('COMMIT')
   }
 }
 

--- a/ironfish/src/mining/poolDatabase/migrations/005-add-payout-period-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/005-add-payout-period-table.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration005 extends Migration {
+  name = '005-add-payout-period-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE payoutPeriod (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        start INTEGER NOT NULL,
+        end INTEGER
+      );
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP TABLE IF EXISTS payoutPeriod;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -5,5 +5,7 @@
 import Migration001 from './001-initial'
 import Migration002 from './002-add-shares-index'
 import Migration003 from './003-add-transaction-hash'
+import Migration004 from './004-add-shares-address-index'
+import Migration005 from './005-add-payout-period-table'
 
-export const MIGRATIONS = [Migration001, Migration002, Migration003]
+export const MIGRATIONS = [Migration001, Migration002, Migration003, Migration004, Migration005]

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Assert } from '../assert'
 import { createRootLogger } from '../logger'
 import { createRouteTest } from '../testUtilities/routeTest'
 import { MiningPoolShares } from './poolShares'
@@ -26,12 +27,35 @@ describe('poolShares', () => {
     await shares.stop()
   })
 
-  // TODO(mat): This is an example, new tests will come with the refactor PRs
-  it('submitShare', async () => {
-    const address = 'fakeAddress'
-    await shares.submitShare(address)
+  it('rolloverPayoutPeriod', async () => {
+    jest.useFakeTimers({ legacyFakeTimers: false })
 
-    const shareCount = await shares.sharesPendingPayout(address)
-    expect(shareCount).toEqual(1)
+    const now = new Date(2020, 1, 1).getTime()
+    jest.setSystemTime(now)
+
+    const payoutPeriod0 = await shares['db'].getCurrentPayoutPeriod()
+    expect(payoutPeriod0).toBeUndefined()
+
+    await shares.rolloverPayoutPeriod()
+
+    const payoutPeriod1 = await shares['db'].getCurrentPayoutPeriod()
+    Assert.isNotUndefined(payoutPeriod1, 'payoutPeriod1 should exist')
+
+    // No time has elapsed, so it will not rollover
+    await shares.rolloverPayoutPeriod()
+
+    const payoutPeriod1A = await shares['db'].getCurrentPayoutPeriod()
+    expect(payoutPeriod1A).toEqual(payoutPeriod1)
+
+    // Move the clock forward the amount of time needed to trigger a new payout rollover
+    jest.setSystemTime(now + shares.config.get('poolPayoutPeriodDuration') * 1000)
+
+    await shares.rolloverPayoutPeriod()
+
+    const payoutPeriod2 = await shares['db'].getCurrentPayoutPeriod()
+    Assert.isNotUndefined(payoutPeriod2, 'payoutPeriod2 should exist')
+    expect(payoutPeriod2.id).toEqual(payoutPeriod1.id + 1)
+
+    jest.useRealTimers()
   })
 })

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -221,4 +221,19 @@ export class MiningPoolShares {
   async sharesPendingPayout(publicAddress?: string): Promise<number> {
     return await this.db.getSharesCountForPayout(publicAddress)
   }
+
+  async rolloverPayoutPeriod(): Promise<void> {
+    const payoutPeriodDuration = this.config.get('poolPayoutPeriodDuration') * 1000
+    const now = new Date().getTime()
+    const payoutPeriodCutoff = now - payoutPeriodDuration
+
+    const payoutPeriod = await this.db.getCurrentPayoutPeriod()
+
+    if (payoutPeriod && payoutPeriod.start > payoutPeriodCutoff) {
+      // Current payout period has not exceeded its duration yet
+      return
+    }
+
+    await this.db.rolloverPayoutPeriod(now)
+  }
 }


### PR DESCRIPTION
## Summary

This adds a "payout period" with a fixed duration, such that any blocks or shares found during that time will be tied to that period. This will allow the pool to calculate the exact amount to payout each share in a deterministic fashion. Materializing explicit rows instead of relying on timestamps allows the code to be a bit more explicit and easier to reason about.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
