### PR TITLE
updates wallet:notes table formatting

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -36,7 +36,7 @@ export class NotesCommand extends IronfishCommand {
 
     for await (const note of response.contentStream()) {
       CliUx.ux.table(
-        [{ ...note, assetName: BufferUtils.toHuman(Buffer.from(note.assetName, 'hex')) }],
+        [note],
         {
           memo: {
             header: 'Memo',
@@ -49,12 +49,6 @@ export class NotesCommand extends IronfishCommand {
           transactionHash: {
             header: 'From Transaction',
           },
-          ...TableCols.asset({ extended: flags.extended }),
-          value: {
-            header: 'Amount',
-            get: (row) => CurrencyUtils.renderIron(row.value),
-            minWidth: 16,
-          },
           isSpent: {
             header: 'Spent',
             get: (row) => {
@@ -64,6 +58,12 @@ export class NotesCommand extends IronfishCommand {
                 return row.spent ? `✔` : ``
               }
             },
+          },
+          ...TableCols.asset({ extended: flags.extended }),
+          value: {
+            header: 'Amount',
+            get: (row) => CurrencyUtils.renderIron(row.value),
+            minWidth: 16,
           },
         },
         { ...flags, 'no-header': !showHeader },

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { CurrencyUtils } from '@ironfish/sdk'
+import { BufferUtils, CurrencyUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -36,7 +36,7 @@ export class NotesCommand extends IronfishCommand {
 
     for await (const note of response.contentStream()) {
       CliUx.ux.table(
-        [note],
+        [{ ...note, assetName: BufferUtils.toHuman(Buffer.from(note.assetName, 'hex')) }],
         {
           memo: {
             header: 'Memo',

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BufferUtils, CurrencyUtils } from '@ironfish/sdk'
+import { CurrencyUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -1,16 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BufferUtils, CurrencyUtils } from '@ironfish/sdk'
+import { CurrencyUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { TableCols } from '../../utils/table'
 
 export class NotesCommand extends IronfishCommand {
   static description = `Display the account notes`
 
   static flags = {
     ...RemoteFlags,
+    ...CliUx.ux.table.flags(),
   }
 
   static args = [
@@ -23,7 +25,7 @@ export class NotesCommand extends IronfishCommand {
   ]
 
   async start(): Promise<void> {
-    const { args } = await this.parse(NotesCommand)
+    const { flags, args } = await this.parse(NotesCommand)
     const account = args.account as string | undefined
 
     const client = await this.sdk.connectRpc()
@@ -36,17 +38,6 @@ export class NotesCommand extends IronfishCommand {
       CliUx.ux.table(
         [note],
         {
-          value: {
-            header: 'Amount',
-            get: (row) => CurrencyUtils.renderIron(row.value),
-          },
-          assetName: {
-            header: 'Asset Name',
-            get: (row) => BufferUtils.toHuman(Buffer.from(row.assetName, 'hex')),
-          },
-          assetId: {
-            header: 'Asset Id',
-          },
           memo: {
             header: 'Memo',
             // Maximum memo length is 32 bytes
@@ -58,18 +49,24 @@ export class NotesCommand extends IronfishCommand {
           transactionHash: {
             header: 'From Transaction',
           },
+          ...TableCols.asset({ extended: flags.extended }),
+          value: {
+            header: 'Amount',
+            get: (row) => CurrencyUtils.renderIron(row.value),
+            minWidth: 16,
+          },
           isSpent: {
             header: 'Spent',
             get: (row) => {
               if (row.spent === undefined) {
                 return '-'
               } else {
-                return row.spent ? `✔` : `x`
+                return row.spent ? `✔` : ``
               }
             },
           },
         },
-        { 'no-header': !showHeader },
+        { ...flags, 'no-header': !showHeader },
       )
       showHeader = false
     }

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -4,7 +4,6 @@
 import { Asset } from '@ironfish/rust-nodejs'
 import {
   Assert,
-  BufferUtils,
   CurrencyUtils,
   GetAccountTransactionsResponse,
   PartialRecursive,
@@ -105,7 +104,7 @@ export class TransactionsCommand extends IronfishCommand {
         ...transaction,
         group: isGroup ? '┏' : '',
         assetId: nativeAssetId,
-        assetName: '$IRON',
+        assetName: Buffer.from('$IRON').toString('hex'),
         amount,
         feePaid,
       })
@@ -126,7 +125,7 @@ export class TransactionsCommand extends IronfishCommand {
           ...transaction,
           group: assetCount === 2 ? '' : '┏',
           assetId,
-          assetName: BufferUtils.toHuman(Buffer.from(assetName, 'hex')),
+          assetName,
           amount: BigInt(delta),
           feePaid,
         })
@@ -134,7 +133,7 @@ export class TransactionsCommand extends IronfishCommand {
         transactionRows.push({
           group: index === assetCount - 1 ? '┗' : '┣',
           assetId,
-          assetName: BufferUtils.toHuman(Buffer.from(assetName, 'hex')),
+          assetName,
           amount: BigInt(delta),
         })
       }

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -126,7 +126,7 @@ export class TransactionsCommand extends IronfishCommand {
           ...transaction,
           group: assetCount === 2 ? '' : '┏',
           assetId,
-          assetName,
+          assetName: BufferUtils.toHuman(Buffer.from(assetName, 'hex')),
           amount: BigInt(delta),
           feePaid,
         })

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -102,7 +102,7 @@ const asset = <T extends Record<string, unknown>>(options?: {
   }
 }
 
-function truncateCol(value: string, maxWidth: number | null): string {
+export function truncateCol(value: string, maxWidth: number | null): string {
   if (maxWidth === null || value.length <= maxWidth) {
     return value
   }

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { TimeUtils } from '@ironfish/sdk'
+import { ASSET_NAME_LENGTH } from '@ironfish/rust-nodejs'
+import { Assert, BufferUtils, TimeUtils } from '@ironfish/sdk'
 import { table } from '@oclif/core/lib/cli-ux/styled/table'
 
 /**
@@ -16,6 +17,9 @@ import { table } from '@oclif/core/lib/cli-ux/styled/table'
 const MAX_TIMESTAMP_LENGTH = TimeUtils.renderString(
   new Date(2024, 11, 25, 23, 59, 59).getTime(),
 ).length
+
+const MAX_ASSET_NAME_COLUMN_WIDTH = ASSET_NAME_LENGTH + 1
+const MIN_ASSET_NAME_COLUMN_WIDTH = ASSET_NAME_LENGTH / 2 + 1
 
 const timestamp = <T extends Record<string, unknown>>(options?: {
   streaming?: boolean
@@ -55,12 +59,53 @@ const timestamp = <T extends Record<string, unknown>>(options?: {
   }
 }
 
-export const TableCols = { timestamp }
+const asset = <T extends Record<string, unknown>>(options?: {
+  extended?: boolean
+}): Partial<Record<string, table.Column<T>>> => {
+  if (options?.extended) {
+    return {
+      assetId: {
+        header: 'Asset ID',
+        get: (row) => row['assetId'],
+        minWidth: MAX_ASSET_NAME_COLUMN_WIDTH,
+        extended: true,
+      },
+      assetName: {
+        header: 'Asset Name',
+        get: (row) => {
+          Assert.isString(row.assetName)
+          const assetName = BufferUtils.toHuman(Buffer.from(row.assetName, 'hex'))
+          return truncateCol(assetName, MAX_ASSET_NAME_COLUMN_WIDTH)
+        },
+        minWidth: MAX_ASSET_NAME_COLUMN_WIDTH,
+        extended: true,
+      },
+    }
+  } else {
+    return {
+      asset: {
+        header: 'Asset',
+        get: (row) => {
+          Assert.isString(row.assetName)
+          Assert.isString(row.assetId)
+          let assetName = BufferUtils.toHuman(Buffer.from(row.assetName, 'hex'))
+          assetName = truncateCol(assetName, MIN_ASSET_NAME_COLUMN_WIDTH)
+          const text = assetName.padEnd(MIN_ASSET_NAME_COLUMN_WIDTH, ' ')
+          return `${text} (${row.assetId.slice(0, 5)})`
+        },
+        minWidth: MIN_ASSET_NAME_COLUMN_WIDTH,
+        extended: false,
+      },
+    }
+  }
+}
 
-export function truncateCol(value: string, maxWidth: number | null): string {
+function truncateCol(value: string, maxWidth: number | null): string {
   if (maxWidth === null || value.length <= maxWidth) {
     return value
   }
 
   return value.slice(0, maxWidth - 1) + '…'
 }
+
+export const TableCols = { timestamp, asset }

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -88,8 +88,7 @@ const asset = <T extends Record<string, unknown>>(options?: {
         get: (row) => {
           Assert.isString(row.assetName)
           Assert.isString(row.assetId)
-          let assetName = BufferUtils.toHuman(Buffer.from(row.assetName, 'hex'))
-          assetName = truncateCol(assetName, MIN_ASSET_NAME_COLUMN_WIDTH)
+          const assetName = truncateCol(row.assetName, MIN_ASSET_NAME_COLUMN_WIDTH)
           const text = assetName.padEnd(MIN_ASSET_NAME_COLUMN_WIDTH, ' ')
           return `${text} (${row.assetId.slice(0, 5)})`
         },

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -88,7 +88,10 @@ const asset = <T extends Record<string, unknown>>(options?: {
         get: (row) => {
           Assert.isString(row.assetName)
           Assert.isString(row.assetId)
-          const assetName = truncateCol(row.assetName, MIN_ASSET_NAME_COLUMN_WIDTH)
+          const assetName = truncateCol(
+            BufferUtils.toHuman(Buffer.from(row.assetName, 'hex')),
+            MIN_ASSET_NAME_COLUMN_WIDTH,
+          )
           const text = assetName.padEnd(MIN_ASSET_NAME_COLUMN_WIDTH, ' ')
           return `${text} (${row.assetId.slice(0, 5)})`
         },


### PR DESCRIPTION
## Summary

uses the same column formatting for 'Asset', 'Asset Name', and 'Asset ID' columns as wallet:transactions

moves logic for constructing asset column(s) to utils

replaces 'x' for unspent notes with '' in Spent column

reorders columns so that amount appears right after asset name

## Testing Plan

<img width="1528" alt="image" src="https://user-images.githubusercontent.com/57735705/216464933-c50d2c73-91ad-410f-9232-a97219cd91a0.png">

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
