### PR TITLE
Add raw tx flag to wallet:send

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -276,9 +276,10 @@ ${CurrencyUtils.renderIron(
         rawTransaction.fee,
         true,
       )} to ${to} from the account ${from}
-
-* This action is NOT reversible *
 `)
+      if (!flags.rawTransaction) {
+        this.log(`* This action is NOT reversible *\n`)
+      }
 
       const confirm = await CliUx.ux.confirm('Do you confirm (Y/N)?')
       if (!confirm) {

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -267,7 +267,7 @@ export class Send extends IronfishCommand {
 
     if (!flags.confirm) {
       this.log(`
-You are about to send:
+You are about to create a transaction:
 ${CurrencyUtils.renderIron(
   amount,
   true,
@@ -289,6 +289,7 @@ ${CurrencyUtils.renderIron(
 
     if (flags.rawTransaction) {
       this.log(`Raw transaction: ${rawTransactionResponse}`)
+      this.log(`\nRun "ironfish wallet:post" to post the raw transaction. `)
       this.exit(0)
     }
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -82,6 +82,11 @@ export class Send extends IronfishCommand {
       char: 'i',
       description: 'The identifier for the asset to use when sending',
     }),
+    rawTransaction: Flags.boolean({
+      default: false,
+      description:
+        'Return raw transaction. Use it to create a transaction but not post to the network',
+    }),
   }
 
   async start(): Promise<void> {
@@ -280,6 +285,11 @@ ${CurrencyUtils.renderIron(
         this.log('Transaction aborted.')
         this.exit(0)
       }
+    }
+
+    if (flags.rawTransaction) {
+      this.log(`Raw transaction: ${rawTransactionResponse}`)
+      this.exit(0)
     }
 
     // Run the progress bar for about 2 minutes


### PR DESCRIPTION
## Summary

## Testing Plan
```
yajun@Yajuns-MacBook-Pro ironfish-cli % yarn start wallet:send --rawTransaction -o 0.00000001 -t "dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca" -a 0.00000001
yarn run v1.22.19
$ yarn build && yarn start:js wallet:send --rawTransaction -o 0.00000001 -t dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca -a 0.00000001
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:send --rawTransaction -o 0.00000001 -t dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca -a 0.00000001
? Select the asset you wish to send d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6 ($IRON)

You are about to send:
$IRON 0.00000001 plus a transaction fee of $IRON 0.00000001 to dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca from the account default

* This action is NOT reversible *

Do you confirm (Y/N)?: Y
Raw transaction: 01000000000000000100000000000000a8e83eba78f07ddc4c214763d88b9fb17643e4a43329d8179ba73fa33d840b36b2d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac60500000000000000e057a9b835fdbe4598208bcd302dce44db7d0950f59ff81bb5803083709b490a46617563657420666f722032393732310000000000000000000000000000000010fc9e32e36ec5a2d2e51eb3aceb55c5d2c4733b409f8ab0d0f48b0fd21936d737fe13000000000020179f2684440a7189dd41562660a34e308cf82ca0700d0189cc8e1be410bb7f52200000000000000001209a7ea8d7ca4f076a90cac0c091babbd7a434e52d2ec38de12d1746c882fd186001201d4341b2032bbdf8847173e4b993e5e3b9c32c6c64be8be5145b4c8fd2e0b5330120496fae4c4a5de9359755a17e4d8813a9dfe0671a5ce9ac2fd92d991bbc1c42040020906b34eddf96a58387842161049d9af9fc88008dffc97196a3ae799b9517f66101204c9727d5d1f408017890c0e62a566cb18a52433bfedeebf82a0d53c46421cf46012038ab0dbffd0e1556119b6cd94f34dfb7ad850d44263661275a0e390876f440510020b52084b85189c9fa047c33b1d6988075489c41e1abf9e3469f2e72a1f189033c0020faaa8f8cb8c0e9352c5586ba0906f5b4cd55cc7a1caecc1c8ebb33264d6dac330120c767df4b1d6b5f110b16184672a41a2a1d9c3eb3b91732e030b763c0c62fe73e0120f81d27b8732e8849c8d318064b32e67bddb3f6c3669aa14f05974d2f420d7754012021abf704699ec2a932957dd554bedcd6ec43f87af00daa6f311df6aadfaa0f2b0020bf6ec1daa04efd94a3b0dd27a6c3f23bf2d42485bd264139a22f23c63f299b270020face1187176214415b5972f25a0d9c3cdd609de207a2d38722a5ca5230a1871401209d53d690d578ea94f81c28d55f639fc23b0a4f40ce89fb22e278b11afce688110020eb6ccec8991cc67954e45c111014b299de4ece1d5b5483cec44813e2dd452e0f002079f6a11830bd559b6a090b9c602b28fae2a3472ba30d5cc47872d975d27bcc6300209d53f1e407ddbaf37c6c21f521136ba71ae029ae7b7314fba8432de8e9b5471c01202d308f53abcf48934260c675aa7a0fc1e0281a3b393dc4a961602efbe31f9d390020a3fd69952e5242ec957d8ac38ca56d2f6940d5d6c9cbcac9df9aa11f1891aa430020dceb6371fe20504a9bf08195b2a7f509fd18b39cc894469f29fe9ebecdd8da490020243f6ce4bb5ecc0b70b7004e9cf9f859b37548717e643d02c04c54ed88038e260020ef583cb761c5d3d0beadb8e73d63c812c54fa97ed15ae5d98d9ad30402d52f4c0020c829bd2e729b4ec211a2bd1ec7d9f21a7643cd36c90b87b97dddb333e771fe35002007fe95259f6bd03cafe4b44ad7207f2e5f0739ab7670bda49b3f6b68b735c25a002097e0d46448b7209bbe56bf8519fa50a3f3c9a9764860b6e2c264f893686dc05600205c9c824431848bae632f5c683d531649f6047ce61c0c34976f765877ec5cff0d00206b8621f9b97a3a1ecd9f1aa9d945f15620657f10c1404e7eb1ed023126fdfa2b0020672ad6289f64bf4555eb64f7eff15a3d158248fafe1b198b9f4c8726aac5c83b00203a953e35da9231ee618a112cdcbb4b3ba7c7a1eb965251daffe78e92ce2d5f4100200cda44c9f91a754cd9e489c42e4f3e7536692c10df5b9c8c060f1c33b6d4386a002083a02581590b543daa8dc28d3c8db6179bfdac435d9fb2587342e5fa369895730020ffabc0bb308f70287252580a8e640674db245a2e75f443535619fca3ae72106c0100000000000000a8dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59cad7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac60100000000000000242396b9a7cebbcaa3e9d9020718f83f0b13a54632940cc7006cbc0579ba05060000000000000000000000000000000000000000000000000000000000000000e83eba78f07ddc4c214763d88b9fb17643e4a43329d8179ba73fa33d840b36b20000000000000000000000000000000001195f000000000000
✨  Done in 22.50s.
```

```
yajun@Yajuns-MacBook-Pro ironfish-cli % yarn start wallet:send -o 0.00000001 -t "dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca" -a 0.00000001
yarn run v1.22.19
$ yarn build && yarn start:js wallet:send -o 0.00000001 -t dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca -a 0.00000001
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:send -o 0.00000001 -t dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca -a 0.00000001
? Select the asset you wish to send d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6 ($IRON)

You are about to send:
$IRON 0.00000001 plus a transaction fee of $IRON 0.00000001 to dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca from the account default

* This action is NOT reversible *

Do you confirm (Y/N)?: Y
Creating the transaction: [████████████████████████████████████████] 100% | ETA: 0s

Sending $IRON 0.00000001 to dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca from default
Transaction Hash: 44e605919fce81379004b61845a1bc916b5df924631ca4a8bca66c49e68fc89b
Transaction fee: $IRON 0.00000001

Find the transaction on https://explorer.ironfish.network/transaction/44e605919fce81379004b61845a1bc916b5df924631ca4a8bca66c49e68fc89b (it can take a few minutes before the transaction appears in the Explorer)
✨  Done in 20.55s.
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
