### PR TITLE
Fix IP flag on trusted setup server

### DIFF
--- a/ironfish-cli/src/commands/service/ceremony.ts
+++ b/ironfish-cli/src/commands/service/ceremony.ts
@@ -52,9 +52,10 @@ export default class Ceremony extends IronfishCommand {
     token: Flags.string({
       required: true,
     }),
-    enableIPBanning: Flags.boolean({
+    skipIPCheck: Flags.boolean({
       required: false,
-      default: true,
+      description: 'Pass this flag if you want to skip checking for duplicate IPs',
+      default: false,
     }),
   }
 
@@ -80,7 +81,7 @@ export default class Ceremony extends IronfishCommand {
       presignedExpirationSec: flags.presignedExpirationSec,
       startDate: flags.startDate,
       token: flags.token,
-      enableIPBanning: flags.enableIPBanning,
+      enableIPBanning: !flags.skipIPCheck,
     })
 
     await server.start()


### PR DESCRIPTION
## Summary
The boolean flags are passed with `--flag` and do not accept an input. If the flag is passed, the result is true and if not the result is false. The current flag has a default of true which is confusing because if it's not passed then it should be false but it instead defaults to true

## Testing Plan
Local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
