### PR TITLE
feat(ironfish): mining pool tracks status of its submitted blocks

### DIFF
--- a/ironfish/src/mining/poolDatabase/migrations/006-add-block-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/006-add-block-table.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration006 extends Migration {
+  name = '006-add-block-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE block (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        blockSequence INTEGER NOT NULL,
+        blockHash TEXT NOT NULL,
+        minerReward TEXT NOT NULL,
+        confirmed BOOLEAN DEFAULT FALSE,
+        main BOOLEAN DEFAULT TRUE,
+        payoutPeriodId INTEGER NOT NULL,
+        CONSTRAINT block_fk_payoutPeriodId FOREIGN KEY (payoutPeriodId) REFERENCES payoutPeriod (id)
+      );
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP TABLE IF EXISTS block;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -7,5 +7,13 @@ import Migration002 from './002-add-shares-index'
 import Migration003 from './003-add-transaction-hash'
 import Migration004 from './004-add-shares-address-index'
 import Migration005 from './005-add-payout-period-table'
+import Migration006 from './006-add-block-table'
 
-export const MIGRATIONS = [Migration001, Migration002, Migration003, Migration004, Migration005]
+export const MIGRATIONS = [
+  Migration001,
+  Migration002,
+  Migration003,
+  Migration004,
+  Migration005,
+  Migration006,
+]

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -9,6 +9,7 @@ import { ErrorUtils } from '../utils'
 import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
 import { DatabaseShare, PoolDatabase } from './poolDatabase'
+import { DatabaseBlock } from './poolDatabase/database'
 import { WebhookNotifier } from './webhooks'
 
 export class MiningPoolShares {
@@ -235,5 +236,29 @@ export class MiningPoolShares {
     }
 
     await this.db.rolloverPayoutPeriod(now)
+  }
+
+  async submitBlock(sequence: number, hash: string, reward: bigint): Promise<void> {
+    if (reward < 0) {
+      reward *= BigInt(-1)
+    }
+
+    await this.db.newBlock(sequence, hash, reward.toString())
+  }
+
+  async unconfirmedBlocks(): Promise<DatabaseBlock[]> {
+    return await this.db.unconfirmedBlocks()
+  }
+
+  async updateBlockStatus(
+    block: DatabaseBlock,
+    main: boolean,
+    confirmed: boolean,
+  ): Promise<void> {
+    if (main === block.main && confirmed === block.confirmed) {
+      return
+    }
+
+    await this.db.updateBlockStatus(block.id, main, confirmed)
   }
 }


### PR DESCRIPTION
## Summary

**Builds on #3268** 

This introduces a new table to the mining pool database, block. The pool will insert a row every time it successfully submits a block. The event loop will check any unconfirmed blocks, and update their status accordingly. For now, that status includes whether it's on the main chain, and whether it's confirmed. This gives us the ability to track how much reward was earned within a specific timeframe.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
