### PR TITLE
Remove tree size

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -30,7 +30,6 @@ export const GENERATOR_LENGTH: number
 export const AMOUNT_VALUE_LENGTH: number
 export const DECRYPTED_NOTE_LENGTH: number
 export interface NativeSpendDescription {
-  treeSize: number
   rootHash: Buffer
   nullifier: Buffer
 }

--- a/ironfish-rust-nodejs/src/structs/spend_proof.rs
+++ b/ironfish-rust-nodejs/src/structs/spend_proof.rs
@@ -7,7 +7,6 @@ use napi_derive::napi;
 
 #[napi(object)]
 pub struct NativeSpendDescription {
-    pub tree_size: u32,
     pub root_hash: Buffer,
     pub nullifier: Buffer,
 }

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -132,7 +132,6 @@ impl NativeTransactionPosted {
         let nullifier = Buffer::from(proof.nullifier().to_vec());
 
         Ok(NativeSpendDescription {
-            tree_size: proof.tree_size(),
             root_hash: Buffer::from(root_hash),
             nullifier,
         })

--- a/ironfish-rust-nodejs/src/structs/witness.rs
+++ b/ironfish-rust-nodejs/src/structs/witness.rs
@@ -102,17 +102,4 @@ impl WitnessTrait for JsWitness {
             .unwrap()
             .0
     }
-
-    fn tree_size(&self) -> u32 {
-        let f: JsFunction = self.obj.get("treeSize").unwrap().unwrap();
-
-        let args: &[napi::JsBuffer; 0] = &[];
-
-        f.call(Some(&self.obj), args)
-            .unwrap()
-            .coerce_to_number()
-            .unwrap()
-            .get_uint32()
-            .unwrap()
-    }
 }

--- a/ironfish-rust/src/test_util.rs
+++ b/ironfish-rust/src/test_util.rs
@@ -29,7 +29,6 @@ pub(crate) fn make_fake_witness(note: &Note) -> Witness {
     Witness {
         auth_path: witness_auth_path,
         root_hash,
-        tree_size: 1400,
     }
 }
 

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -15,7 +15,6 @@ use crate::{
 use bellman::gadgets::multipack;
 use bellman::groth16;
 use bls12_381::{Bls12, Scalar};
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ff::PrimeField;
 use group::{Curve, GroupEncoding};
 use ironfish_zkp::{

--- a/ironfish-rust/src/witness.rs
+++ b/ironfish-rust/src/witness.rs
@@ -29,14 +29,11 @@ pub trait WitnessTrait {
     fn get_auth_path(&self) -> Vec<WitnessNode<Scalar>>;
 
     fn root_hash(&self) -> Scalar;
-
-    fn tree_size(&self) -> u32;
 }
 
 /// A Rust implementation of a WitnessTrait, used for testing Witness-related
 /// code within Rust.
 pub struct Witness {
-    pub tree_size: usize,
     pub root_hash: Scalar,
     pub auth_path: Vec<WitnessNode<Scalar>>,
 }
@@ -44,10 +41,10 @@ pub struct Witness {
 /// Implement partial equality, ignoring the Sapling Arc
 impl PartialEq for Witness {
     fn eq(&self, other: &Witness) -> bool {
-        self.tree_size == other.tree_size
-            && self.root_hash == other.root_hash
-            && self.auth_path == other.auth_path
+        self.root_hash == other.root_hash && 
+        self.auth_path == other.auth_path
     }
+    
 }
 
 impl WitnessTrait for Witness {
@@ -74,16 +71,11 @@ impl WitnessTrait for Witness {
     fn root_hash(&self) -> Scalar {
         self.root_hash
     }
-
-    fn tree_size(&self) -> u32 {
-        self.tree_size as u32
-    }
 }
 
 impl fmt::Debug for Witness {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "Witness {{")?;
-        writeln!(f, "    tree_size: {}", self.tree_size)?;
         writeln!(f, "    root_hash: {:?}", self.root_hash)?;
         writeln!(f, "    auth_path: {{")?;
 

--- a/ironfish-rust/src/witness.rs
+++ b/ironfish-rust/src/witness.rs
@@ -41,10 +41,8 @@ pub struct Witness {
 /// Implement partial equality, ignoring the Sapling Arc
 impl PartialEq for Witness {
     fn eq(&self, other: &Witness) -> bool {
-        self.root_hash == other.root_hash && 
-        self.auth_path == other.auth_path
+        self.root_hash == other.root_hash && self.auth_path == other.auth_path
     }
-    
 }
 
 impl WitnessTrait for Witness {


### PR DESCRIPTION
## Summary
Removing tree size from the Spend Description as it appears to no longer be necessary for any real validation. 

## Testing Plan
Relying on existing tests as this was not really used anywhere. 

## Breaking Change
Looks like it's not as it wasn't even used in db serialization