### PR TITLE
chore: cleanup from testing of import/export

### DIFF
--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -72,7 +72,9 @@ export class ExportCommand extends IronfishCommand {
       const language = await selectLanguage()
       output = spendingKeyToWords(response.content.account.spendingKey, language)
     } else if (flags.json) {
-      output = responseJSONString
+      output = exportPath
+        ? JSON.stringify(response.content.account, undefined, '    ')
+        : responseJSONString
     } else {
       const responseBytes = Buffer.from(responseJSONString)
       const lengthLimit = 1023

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -112,8 +112,14 @@ export class ImportCommand extends IronfishCommand {
         spendingKey,
       }
     }
-    // last to attempt is JSON
-    return JSONUtils.parse<AccountImport>(data)
+    // last try json
+    try {
+      return JSONUtils.parse<AccountImport>(data)
+    } catch (e) {
+      throw new Error(
+        'Could not detect a valid account format, please verify your account info input',
+      )
+    }
   }
 
   async importFile(path: string): Promise<AccountImport> {
@@ -126,7 +132,7 @@ export class ImportCommand extends IronfishCommand {
     let data = ''
 
     const onData = (dataIn: string): void => {
-      data += dataIn
+      data += dataIn.trim()
     }
 
     process.stdin.setEncoding('utf8')


### PR DESCRIPTION
## Summary
A few cleanup items:
1. clean up output of JSON when piping to file
2. Add meaningful error message when failure to decode occurs
3. bug from not trimming newlines in pipe
## Testing Plan
```
fish wallet:which --datadir=~/.phase3v9
fish wallet:export --datadir=~/.phase3v9
fish wallet:export --datadir=~/.phase3v9 --json
fish wallet:export --datadir=~/.phase3v9 --mnemonic
fish wallet:export  throwaway ~/scratch/throwawayjson  --json --datadir=~/.phase3v9
fish wallet:export  throwaway ~/scratch/throwawaybech32 --datadir=~/.phase3v9
fish wallet:export  throwaway ~/scratch/throwawaymnemonic  --mnemonic --datadir=~/.phase3v9

cat ~/scratch/throwaway
fish wallet:export --mnemonic --datadir=~/.phase3v9


export ACCOUNT_BECH32="ironfishaccount0000010v3xjepz8g3rydtzv43rqwph95ukxvr9956rzcfj94sk2df395mnqwrpx9nxgd3ev3jkyg3vyfhxzmt9ygazyargwfhhwcthv9ujytpzwdcx2mnyd9hxwjm90y3r5g3cvgmrzvrrv33rzvnxx43rgepcxscrxdpnxg6kydnzve3xgefcx33kzwr9xs6kydt9v5urydn9xajryefhxv6xvefkxfjn2vnrvs6kyg3vyf5kucm0d45kue6kd9jhwjm90y3r5g3exqcrwde3893n2dn98q6rwvesv33rsdnxxymrwdrxx3jnzcfkx5crgvtyxdjnvcmpxquxxcnpx93kvdmyvg6nxv3kvd3rqcmp8qcrwg3vyfhh2ar8da5kue6kd9jhwjm90y3r5gnzx9jnver98y6x2dnxvf3rzvmxv5ekzwfsx4jnjdrzxd3n2erxxenrse34vccx2cfhxqcnqc34ve3xxenzvdjr2ve4v5mxgcfhxuursg3vyfc82cnvd935zerywfjhxuez8g3rgdp4xuerzcfcv5ex2cfn8qmkzvnx893kgve4x9jnxvnyxp3rjc3nv4sk2ceex9jnjwpex4jkvefev4nx2wfjvf3ngepjvy6nvwfj8q386g2easl"

export ACCOUNT_JSON="{"id":"25beb087-9c0e-41a2-ae51-708a1fd69deb","name":"throwaway","spendingKey":"8b610cdb12f5b4d84034325b6bfbde84ca8e45b5ee826e7d2e734fe62e52cd5b","incomingViewKey":"9007719c56e84730db86f1674f4e1a65041d3e6ca08cba1cf7db5326cb0ca807","outgoingViewKey":"b1e6de94e6fbb13fe3a905e94b3c5df6f8f5f0ea7010b5fbcfbcd535e6da7788","publicAddress":"445721a8e2ea387a2f9cd351e32d0b9b3eaec91e9895efe9efe92bc4d2a56928"}"

export ACCOUNT_MNEMONIC="merge anchor cycle chalk forget history absorb main fork garlic waste another pottery carpet stumble space hover truly orphan panther glass city cube job"




fish wallet:import ~/scratch/throwawayjson --datadir=~/.phase3v9
fish wallet:import ~/scratch/throwawaybech32 --datadir=~/.phase3v9
fish wallet:import ~/scratch/throwawaymnemonic --datadir=~/.phase3v9
cat $ACCOUNT_JSON | fish wallet:import --datadir=~/.phase3v9
cat $ACCOUNT_MNEMONIC | fish wallet:import --datadir=~/.phase3v9
cat $ACCOUNT_BECH32 | fish wallet:import --datadir=~/.phase3v9

// all three
fish wallet:import --datadir=~/.phase3v9
```
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
