### PR TITLE
adds --offset option to transactions list

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -31,6 +31,9 @@ export class TransactionsCommand extends IronfishCommand {
     limit: Flags.integer({
       description: 'Number of latest transactions to get details for',
     }),
+    offset: Flags.integer({
+      description: 'Number of latest transactions to skip',
+    }),
     confirmations: Flags.integer({
       description: 'Number of block confirmations needed to confirm a transaction',
     }),
@@ -54,6 +57,7 @@ export class TransactionsCommand extends IronfishCommand {
       account,
       hash: flags.hash,
       limit: flags.limit,
+      offset: flags.offset,
       confirmations: flags.confirmations,
     })
 

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -14,6 +14,7 @@ export type GetAccountTransactionsRequest = {
   account?: string
   hash?: string
   limit?: number
+  offset?: number
   confirmations?: number
 }
 
@@ -37,6 +38,7 @@ export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTra
       account: yup.string().strip(true),
       hash: yup.string().notRequired(),
       limit: yup.number().notRequired(),
+      offset: yup.number().notRequired(),
       confirmations: yup.number().notRequired(),
     })
     .defined()
@@ -94,10 +96,16 @@ router.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactio
     }
 
     let count = 0
+    let offset = 0
 
     for await (const transaction of account.getTransactionsByTime()) {
       if (request.closed) {
         break
+      }
+
+      if (request.data.offset && offset < request.data.offset) {
+        offset++
+        continue
       }
 
       if (request.data.limit && count === request.data.limit) {


### PR DESCRIPTION
## Summary

for an account with many transactions using 'ironfish wallet:transactions' may output a huge list of transactions

we have added '--limit' to support printing out a limited number of recent transactions instead of all of them.

however, we don't have any way of paginating through transactions, so if you want to see the 101st you need to view at least 101 transactions. this adds '--offset' to skip transactions when listing

## Testing Plan

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/57735705/216674857-9d2e3657-0aa7-447a-87a3-5bef7b39cefd.png">

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
