### PR TITLE
feat(ironfish): mining pool tracks status of transactions its created

### DIFF
--- a/ironfish/src/mining/poolDatabase/migrations/007-add-payout-transaction-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/007-add-payout-transaction-table.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration007 extends Migration {
+  name = '006-add-payout-transaction-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE payoutTransaction (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        transactionHash TEXT NOT NULL,
+        confirmed BOOLEAN DEFAULT FALSE,
+        expired BOOLEAN DEFAULT FALSE,
+        payoutPeriodId INTEGER NOT NULL,
+        CONSTRAINT payoutTransaction_fk_payoutPeriodId FOREIGN KEY (payoutPeriodId) REFERENCES payoutPeriod (id)
+      );
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP TABLE IF EXISTS payoutTransaction;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -8,6 +8,7 @@ import Migration003 from './003-add-transaction-hash'
 import Migration004 from './004-add-shares-address-index'
 import Migration005 from './005-add-payout-period-table'
 import Migration006 from './006-add-block-table'
+import Migration007 from './007-add-payout-transaction-table'
 
 export const MIGRATIONS = [
   Migration001,
@@ -16,4 +17,5 @@ export const MIGRATIONS = [
   Migration004,
   Migration005,
   Migration006,
+  Migration007,
 ]

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -9,7 +9,7 @@ import { ErrorUtils } from '../utils'
 import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
 import { DatabaseShare, PoolDatabase } from './poolDatabase'
-import { DatabaseBlock } from './poolDatabase/database'
+import { DatabaseBlock, DatabasePayoutTransaction } from './poolDatabase/database'
 import { WebhookNotifier } from './webhooks'
 
 export class MiningPoolShares {
@@ -260,5 +260,21 @@ export class MiningPoolShares {
     }
 
     await this.db.updateBlockStatus(block.id, main, confirmed)
+  }
+
+  async unconfirmedPayoutTransactions(): Promise<DatabasePayoutTransaction[]> {
+    return await this.db.unconfirmedTransactions()
+  }
+
+  async updatePayoutTransactionStatus(
+    transaction: DatabasePayoutTransaction,
+    confirmed: boolean,
+    expired: boolean,
+  ): Promise<void> {
+    if (confirmed === transaction.confirmed && expired === transaction.expired) {
+      return
+    }
+
+    await this.db.updateTransactionStatus(transaction.id, confirmed, expired)
   }
 }


### PR DESCRIPTION
## Summary

**Builds on #3275**

This introduces a new table which allows the pool to insert a row whenever it makes a new transaction. The event loop will update the status of any unconfirmed and unexpired transactions. This allows the pool to know what transactions it has made, as well as giving it the ability to re-pay out transactions in the event of one expiring.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
