### PR TITLE
feat: detect language mnemonic export

### DIFF
--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -10,7 +10,13 @@ import jsonColorizer from 'json-colorizer'
 import path from 'path'
 import { IronfishCommand } from '../../command'
 import { ColorFlag, ColorFlagKey, RemoteFlags } from '../../flags'
-import { LANGUAGE_KEYS, LANGUAGES, selectLanguage } from '../../utils/language'
+import {
+  inferLanguageCode,
+  LANGUAGE_KEYS,
+  languageCodeToKey,
+  LANGUAGES,
+  selectLanguage,
+} from '../../utils/language'
 
 export class ExportCommand extends IronfishCommand {
   static description = `Export an account`
@@ -69,8 +75,14 @@ export class ExportCommand extends IronfishCommand {
         LANGUAGES[flags.language],
       )
     } else if (flags.mnemonic) {
-      const language = await selectLanguage()
-      output = spendingKeyToWords(response.content.account.spendingKey, language)
+      let languageCode = inferLanguageCode()
+      if (languageCode !== null) {
+        CliUx.ux.info(`Detected Language as '${languageCodeToKey(languageCode)}', exporting:`)
+      } else {
+        CliUx.ux.info(`Could not detect your language, please select language for export`)
+        languageCode = await selectLanguage()
+      }
+      output = spendingKeyToWords(response.content.account.spendingKey, languageCode)
     } else if (flags.json) {
       output = exportPath
         ? JSON.stringify(response.content.account, undefined, '    ')

--- a/ironfish-cli/src/utils/language.ts
+++ b/ironfish-cli/src/utils/language.ts
@@ -16,10 +16,22 @@ export const LANGUAGES = {
   Spanish: LanguageCode.Spanish,
 } as const
 
+type LanguageCodeKey = keyof typeof LANGUAGE_CODES
 type LanguageKey = keyof typeof LANGUAGES
 
 export const LANGUAGE_KEYS = Object.keys(LANGUAGES) as Array<LanguageKey>
 export const LANGUAGE_VALUES = Object.values(LANGUAGES) as Array<LanguageCode>
+
+const LANGUAGE_CODES = {
+  en: LanguageCode.English,
+  fr: LanguageCode.French,
+  it: LanguageCode.Italian,
+  ja: LanguageCode.Japanese,
+  ko: LanguageCode.Korean,
+  es: LanguageCode.Spanish,
+}
+const CHINESE_TRADITIONAL_CODES = ['zh-cht', 'zh-hant', 'zh-hk', 'zh-mo', 'zh-tw']
+const CHINESE_SIMPLIFIED_CODES = ['zh', 'zh-chs', 'zh-hans', 'zh-cn', 'zh-sg']
 
 export async function selectLanguage(): Promise<LanguageCode> {
   const response = await inquirer.prompt<{
@@ -33,4 +45,27 @@ export async function selectLanguage(): Promise<LanguageCode> {
     },
   ])
   return LANGUAGES[response.language]
+}
+
+export function inferLanguageCode(): LanguageCode | null {
+  const languageCode = Intl.DateTimeFormat().resolvedOptions().locale
+  if (languageCode.toLowerCase() in CHINESE_SIMPLIFIED_CODES) {
+    return LanguageCode.ChineseSimplified
+  }
+  if (languageCode.toLowerCase() in CHINESE_TRADITIONAL_CODES) {
+    return LanguageCode.ChineseTraditional
+  }
+  const simpleCode = languageCode?.split('-')[0].toLowerCase()
+  if (simpleCode && simpleCode in LANGUAGE_CODES) {
+    return LANGUAGE_CODES[simpleCode as LanguageCodeKey]
+  }
+  return null
+}
+
+export function languageCodeToKey(code: LanguageCode): LanguageKey {
+  const key = Object.entries(LANGUAGES).find(([_, value]) => value === code)?.[0]
+  if (key) {
+    return key as LanguageKey
+  }
+  throw new Error(`No language key found for language code: ${code}`)
 }


### PR DESCRIPTION
## Summary
Detects language based on canonical env vars in shell for language codes
## Testing Plan

https://user-images.githubusercontent.com/26990067/216724561-8c00df9b-fe94-4a6c-aa1b-ecb77fa4bc57.mov


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
