### PR TITLE
feat: move bech32 to SDK

### DIFF
--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -85,14 +85,7 @@ export class ExportCommand extends IronfishCommand {
     } else if (flags.json) {
       output = JSON.stringify(response.content.account, undefined, '    ')
     } else {
-      const [encoded, error] = Bech32m.encode(
-        JSON.stringify(response.content.account),
-        'ironfishaccount00000',
-      )
-      if (error) {
-        throw error
-      }
-      output = encoded
+      output = Bech32m.encode(JSON.stringify(response.content.account), 'ironfishaccount00000')
     }
 
     if (exportPath) {

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -4,7 +4,6 @@
 import { spendingKeyToWords } from '@ironfish/rust-nodejs'
 import { Bech32m, ErrorUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { bech32m } from 'bech32'
 import fs from 'fs'
 import jsonColorizer from 'json-colorizer'
 import path from 'path'

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { wordsToSpendingKey } from '@ironfish/rust-nodejs'
-import { AccountImport, JSONUtils, PromiseUtils } from '@ironfish/sdk'
+import { AccountImport, Bech32m, JSONUtils, PromiseUtils } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { bech32m } from 'bech32'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { LANGUAGE_VALUES } from '../../utils/language'
@@ -29,17 +28,6 @@ export class ImportCommand extends IronfishCommand {
       description: 'The path to import the account from',
     },
   ]
-
-  static bech32ToJSON(bech32: string): string | null {
-    try {
-      const decodedOutput = bech32m.decode(bech32, 1023)
-      const decodedWords = decodedOutput.words
-      const decodedBytes = bech32m.fromWords(decodedWords)
-      return Buffer.from(decodedBytes).toString()
-    } catch (e) {
-      return null
-    }
-  }
 
   static mnemonicWordsToKey(mnemonic: string): string | null {
     let spendingKey: string | null = null
@@ -97,9 +85,9 @@ export class ImportCommand extends IronfishCommand {
   }
   async stringToAccountImport(data: string): Promise<AccountImport | null> {
     // try bech32 first
-    const bech32 = ImportCommand.bech32ToJSON(data)
-    if (bech32) {
-      return JSONUtils.parse<AccountImport>(bech32)
+    const [decoded, _] = Bech32m.decode(data)
+    if (decoded) {
+      return JSONUtils.parse<AccountImport>(decoded)
     }
     // then try mnemonic
     const spendingKey = ImportCommand.mnemonicWordsToKey(data)

--- a/ironfish/src/utils/bech32m.test.ts
+++ b/ironfish/src/utils/bech32m.test.ts
@@ -4,23 +4,16 @@
 import { Bech32m } from './bech32m'
 
 describe('Bech32m Decode/Encode', () => {
-  it('succeed encoding/decoding when prefix provided', () => {
-    const output = Bech32m.encode('barbaz', 'foo')
-    expect(output[0]).toEqual('foo1vfshycnp0gv5etqu')
-    if (!output[0]) {
-      throw new Error('should return value')
-    }
-    const decoded = Bech32m.decode(output[0])
-    if (!decoded[0]) {
-      throw new Error('should have decoded')
-    }
-    expect(decoded[0]).toEqual('barbaz')
+  it('succeed encoding / decoding', () => {
+    const encoded = Bech32m.encode('barbaz', 'foo')
+    expect(encoded).toEqual('foo1vfshycnp0gv5etqu')
+
+    const [decoded] = Bech32m.decode(encoded)
+    expect(decoded).toEqual('barbaz')
   })
+
   it('returns error when failure occurs', () => {
-    const decoded = Bech32m.decode('broken')
-    if (!decoded[1]) {
-      throw new Error('should have thrown error')
-    }
-    expect(decoded[1]).toBeInstanceOf(Error)
+    const [, error] = Bech32m.decode('broken')
+    expect(error).toBeInstanceOf(Error)
   })
 })

--- a/ironfish/src/utils/bech32m.test.ts
+++ b/ironfish/src/utils/bech32m.test.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Bech32m } from './bech32m'
+
+describe('Bech32m Decode/Encode', () => {
+  it('succeed encoding/decoding when prefix provided', () => {
+    const output = Bech32m.encode('barbaz', 'foo')
+    expect(output[0]).toEqual('foo1vfshycnp0gv5etqu')
+    if (!output[0]) {
+      throw new Error('should return value')
+    }
+    const decoded = Bech32m.decode(output[0])
+    if (!decoded[0]) {
+      throw new Error('should have decoded')
+    }
+    expect(decoded[0]).toEqual('barbaz')
+  })
+  it('returns error when failure occurs', () => {
+    const decoded = Bech32m.decode('broken')
+    if (!decoded[1]) {
+      throw new Error('should have thrown error')
+    }
+    expect(decoded[1]).toBeInstanceOf(Error)
+  })
+})

--- a/ironfish/src/utils/bech32m.ts
+++ b/ironfish/src/utils/bech32m.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { bech32m } from 'bech32'
+
+// 1023 is maximum character count where the checksum will still catch errors
+function decode(bech32String: string): [string, null] | [null, Error] {
+  try {
+    const decodedOutput = bech32m.decode(bech32String, 1023)
+    const decodedBytes = bech32m.fromWords(decodedOutput.words)
+    return [Buffer.from(decodedBytes).toString(), null]
+  } catch (err) {
+    if (err instanceof Error) {
+      return [null, err]
+    }
+    throw err
+  }
+}
+
+function encode(input: string, prefix: string): [string, null] | [null, Error] {
+  if (prefix === '') {
+    return [null, Error('prefix must have defined value')]
+  }
+  if (input === '') {
+    return [null, Error('input string must have defined value')]
+  }
+  const bytes = Buffer.from(input)
+  const words = bech32m.toWords(bytes)
+  return [bech32m.encode(prefix, words, 1023), null]
+}
+
+export const Bech32m = {
+  encode,
+  decode,
+}

--- a/ironfish/src/utils/bech32m.ts
+++ b/ironfish/src/utils/bech32m.ts
@@ -2,31 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { bech32m } from 'bech32'
+import { Assert } from '../assert'
 
 // 1023 is maximum character count where the checksum will still catch errors
-function decode(bech32String: string): [string, null] | [null, Error] {
-  try {
-    const decodedOutput = bech32m.decode(bech32String, 1023)
-    const decodedBytes = bech32m.fromWords(decodedOutput.words)
-    return [Buffer.from(decodedBytes).toString(), null]
-  } catch (err) {
-    if (err instanceof Error) {
-      return [null, err]
-    }
-    throw err
+function decode(bech32String: string, limit = 1023): [string, null] | [null, Error] {
+  const decoded = bech32m.decodeUnsafe(bech32String, limit)
+
+  if (decoded === undefined) {
+    return [null, new Error(`Failed to decode`)]
   }
+
+  const bytes = bech32m.fromWordsUnsafe(decoded.words)
+
+  if (bytes === undefined) {
+    return [null, new Error(`Failed to get bytes from words`)]
+  }
+
+  const output = Buffer.from(bytes).toString('utf8')
+  return [output, null]
 }
 
-function encode(input: string, prefix: string): [string, null] | [null, Error] {
-  if (prefix === '') {
-    return [null, Error('prefix must have defined value')]
-  }
-  if (input === '') {
-    return [null, Error('input string must have defined value')]
-  }
-  const bytes = Buffer.from(input)
+function encode(input: string, prefix: string, limit = 1023): string {
+  Assert.isTruthy(prefix, `Prefix is required by bech32`)
+
+  const bytes = Buffer.from(input, 'utf8')
   const words = bech32m.toWords(bytes)
-  return [bech32m.encode(prefix, words, 1023), null]
+  const encoded = bech32m.encode(prefix, words, limit)
+
+  return encoded
 }
 
 export const Bech32m = {

--- a/ironfish/src/utils/index.ts
+++ b/ironfish/src/utils/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './array'
 export * from './async'
+export * from './bech32m'
 export * from './bench'
 export * from './bigint'
 export * from './blockchain'


### PR DESCRIPTION
## Summary
This moves the bech32 encode/decode scheme to the SDK for reuse
## Testing Plan
tests
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
