### PR TITLE
Fix client disconnect on error

### DIFF
--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -245,7 +245,7 @@ export class CeremonyServer {
 
   private onError(client: CeremonyServerClient, e: Error): void {
     this.closeClient(client, e)
-    this.queue = this.queue.filter((c) => client.id === c.id)
+    this.queue = this.queue.filter((c) => client.id !== c.id)
     client.logger.info(
       `Disconnected with error '${ErrorUtils.renderError(e)}'. (${this.queue.length} total)`,
     )


### PR DESCRIPTION
## Summary
When a client disconnected because of an error it was clearing the queue

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
