### PR TITLE
Bugfix: account import TTY fallthrough

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -95,7 +95,7 @@ export class ImportCommand extends IronfishCommand {
       this.log(`Run "ironfish wallet:use ${name}" to set the account as default`)
     }
   }
-  async stringToAccountImport(data: string): Promise<AccountImport> {
+  async stringToAccountImport(data: string): Promise<AccountImport | null> {
     // try bech32 first
     const bech32 = ImportCommand.bech32ToJSON(data)
     if (bech32) {
@@ -116,17 +116,17 @@ export class ImportCommand extends IronfishCommand {
     try {
       return JSONUtils.parse<AccountImport>(data)
     } catch (e) {
-      return null as any // this will be caught in the calling function
+      return null // this will be caught in the calling function
     }
   }
 
-  async importFile(path: string): Promise<AccountImport> {
+  async importFile(path: string): Promise<AccountImport | null> {
     const resolved = this.sdk.fileSystem.resolve(path)
     const data = await this.sdk.fileSystem.readFile(resolved)
     return this.stringToAccountImport(data)
   }
 
-  async importPipe(): Promise<AccountImport> {
+  async importPipe(): Promise<AccountImport | null> {
     let data = ''
 
     const onData = (dataIn: string): void => {
@@ -151,7 +151,7 @@ export class ImportCommand extends IronfishCommand {
     })
 
     const output = await this.stringToAccountImport(userInput)
-    
+
     if (output === null) {
       CliUx.ux.error(
         'Failed to decode the account from the provided input, please continue with the manual input below',
@@ -162,7 +162,6 @@ export class ImportCommand extends IronfishCommand {
     } else {
       return output
     }
-
 
     const accountName = await CliUx.ux.prompt('Enter the account name', {
       required: true,

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -116,9 +116,7 @@ export class ImportCommand extends IronfishCommand {
     try {
       return JSONUtils.parse<AccountImport>(data)
     } catch (e) {
-      throw new Error(
-        'Could not detect a valid account format, please verify your account info input',
-      )
+      return null as any // this will be caught in the calling function
     }
   }
 
@@ -151,16 +149,20 @@ export class ImportCommand extends IronfishCommand {
     const userInput = await CliUx.ux.prompt('Paste the output of wallet:export', {
       required: true,
     })
-    try {
-      return this.stringToAccountImport(userInput)
-    } catch (e) {
+
+    const output = this.stringToAccountImport(userInput)
+    
+    if (output === null) {
       CliUx.ux.error(
         'Failed to decode the account from the provided input, please continue with the manual input below',
         {
           exit: false,
         },
       )
+    } else {
+      return output
     }
+
 
     const accountName = await CliUx.ux.prompt('Enter the account name', {
       required: true,

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -150,7 +150,7 @@ export class ImportCommand extends IronfishCommand {
       required: true,
     })
 
-    const output = this.stringToAccountImport(userInput)
+    const output = await this.stringToAccountImport(userInput)
     
     if (output === null) {
       CliUx.ux.error(


### PR DESCRIPTION
## Summary
When running interactive `wallet:import` in `ironfish-cli`, there is an intended feature that if a user doesn't have a mnemonic (or a bech blob, or a json), the CLI falls through to accepting the hex `spendingKey`. However, the `try`/`catch` meant to enable this behavior doesn't actually catch the error involved:
```
➜  ironfish-cli git:(staging) yarn start wallet:import
yarn run v1.22.19
$ yarn build && yarn start:js wallet:import
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:import
Paste the output of wallet:export: ignore this and hit enter
Error: Could not detect a valid account format, please verify your account info input
    at ImportCommand.stringToAccountImport (/Users/evan/Documents/GitHub/ironfish/ironfish-cli/src/commands/wallet/import.ts:119:13)
[...rest of trace removed by Evan]
```

This PR changes `stringToAccountImport` to return `null` rather than throwing if all parsing fails. This will still cause the CLI to exit gracefully in other cases, but allows TTY interactive fallthrough to work again. 

Discovered by @xx-134 in a comment on #3288.

## Testing Plan

https://user-images.githubusercontent.com/5766842/217003494-3033bb21-e1d9-45e5-86d7-ad6f472c2011.mov


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
