### PR TITLE
feat(ironfish): add new share concept to mining pool

### DIFF
--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -189,4 +189,168 @@ describe('poolDatabase', () => {
     expect(transactions.length).toEqual(1)
     expect(transactions[0].id).toEqual(transaction3Id)
   })
+
+  describe('shares', () => {
+    beforeEach(async () => {
+      await db.rolloverPayoutPeriod(new Date().getTime())
+    })
+
+    const getShares = () => {
+      return db['db'].all('SELECT * FROM payoutShare')
+    }
+
+    it('inserts new shares', async () => {
+      const address1 = 'testPublicAddress1'
+      const address2 = 'testPublicAddress2'
+
+      const payoutPeriod1 = await db.getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod1)
+
+      await db.newShare(address1)
+      await db.newShare(address1)
+
+      await db.rolloverPayoutPeriod(new Date().getTime() + 1_000_000)
+      const payoutPeriod2 = await db.getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod2)
+
+      await db.newShare(address2)
+
+      const shares = await getShares()
+      expect(shares.length).toEqual(3)
+      expect(shares[0]).toMatchObject({
+        publicAddress: address1,
+        payoutTransactionId: null,
+        payoutPeriodId: payoutPeriod1.id,
+      })
+      expect(shares[1]).toMatchObject({
+        publicAddress: address1,
+        payoutTransactionId: null,
+        payoutPeriodId: payoutPeriod1.id,
+      })
+      expect(shares[2]).toMatchObject({
+        publicAddress: address2,
+        payoutTransactionId: null,
+        payoutPeriodId: payoutPeriod2.id,
+      })
+    })
+
+    it('marks shares paid', async () => {
+      const address = 'testPublicAddress'
+
+      const payoutPeriod1 = await db.getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod1)
+
+      await db.newShare(address)
+
+      await db.rolloverPayoutPeriod(new Date().getTime() + 1_000_000)
+
+      const payoutPeriod2 = await db.getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod2)
+
+      await db.newShare(address)
+
+      const transactionId = await db.newTransaction('txHash1', payoutPeriod1.id)
+      Assert.isNotUndefined(transactionId)
+
+      await db.markSharesPaid(payoutPeriod1.id, transactionId)
+
+      const shares = await getShares()
+      expect(shares.length).toEqual(2)
+      expect(shares[0]).toMatchObject({
+        payoutPeriodId: payoutPeriod1.id,
+        payoutTransactionId: transactionId,
+      })
+      expect(shares[1]).toMatchObject({
+        payoutPeriodId: payoutPeriod2.id,
+        payoutTransactionId: null,
+      })
+    })
+
+    it('marks shares unpaid', async () => {
+      const address = 'testPublicAddress'
+
+      const payoutPeriod1 = await db.getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod1)
+
+      await db.newShare(address)
+
+      const transactionId = await db.newTransaction('txHash1', payoutPeriod1.id)
+      Assert.isNotUndefined(transactionId)
+
+      await db.markSharesPaid(payoutPeriod1.id, transactionId)
+
+      const paidShares = await getShares()
+      expect(paidShares.length).toEqual(1)
+      expect(paidShares[0].payoutTransactionId).toEqual(transactionId)
+
+      await db.markSharesUnpaid(transactionId)
+
+      const unpaidShares = await getShares()
+      expect(unpaidShares.length).toEqual(1)
+      expect(unpaidShares[0].payoutTransactionId).toBeNull()
+    })
+
+    it('payoutAddresses', async () => {
+      const address1 = 'testPublicAddress1'
+      const address2 = 'testPublicAddress2'
+      const address3 = 'testPublicAddress3'
+
+      const payoutPeriod1 = await db.getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod1)
+
+      // Address 1: 2 shares
+      await db.newShare(address1)
+      await db.newShare(address1)
+      // Address 2: 3  shares
+      await db.newShare(address2)
+      await db.newShare(address2)
+      await db.newShare(address2)
+      // Address 3: 0 shares
+
+      await db.rolloverPayoutPeriod(new Date().getTime() + 100)
+
+      await db.newShare(address1)
+      await db.newShare(address2)
+      await db.newShare(address3)
+
+      const addresses = await db.payoutAddresses(payoutPeriod1.id)
+      expect(addresses.length).toEqual(2)
+      expect(addresses[0]).toMatchObject({
+        publicAddress: address1,
+        shareCount: 2,
+      })
+      expect(addresses[1]).toMatchObject({
+        publicAddress: address2,
+        shareCount: 3,
+      })
+    })
+
+    it('earliestOutstandingPayoutPeriod', async () => {
+      const address = 'testPublicAddress'
+
+      const payoutPeriod1 = await db.getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod1)
+
+      await db.newShare(address)
+
+      await db.rolloverPayoutPeriod(new Date().getTime() + 100)
+
+      await db.newShare(address)
+
+      const payoutPeriod2 = await db.getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod2)
+
+      await db.rolloverPayoutPeriod(new Date().getTime() + 200)
+
+      const earliest1 = await db.earliestOutstandingPayoutPeriod()
+      Assert.isNotUndefined(earliest1)
+      expect(earliest1.id).toEqual(payoutPeriod1.id)
+
+      await db.markSharesPaid(payoutPeriod1.id, 1)
+
+      const earliest2 = await db.earliestOutstandingPayoutPeriod()
+      Assert.isNotUndefined(earliest2)
+      expect(earliest2.id).toEqual(payoutPeriod2.id)
+    })
+  })
 })

--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -252,7 +252,7 @@ describe('poolDatabase', () => {
       const transactionId = await db.newTransaction('txHash1', payoutPeriod1.id)
       Assert.isNotUndefined(transactionId)
 
-      await db.markSharesPaid(payoutPeriod1.id, transactionId)
+      await db.markSharesPaid(payoutPeriod1.id, transactionId, [address])
 
       const shares = await getShares()
       expect(shares.length).toEqual(2)
@@ -277,7 +277,7 @@ describe('poolDatabase', () => {
       const transactionId = await db.newTransaction('txHash1', payoutPeriod1.id)
       Assert.isNotUndefined(transactionId)
 
-      await db.markSharesPaid(payoutPeriod1.id, transactionId)
+      await db.markSharesPaid(payoutPeriod1.id, transactionId, [address])
 
       const paidShares = await getShares()
       expect(paidShares.length).toEqual(1)
@@ -346,7 +346,7 @@ describe('poolDatabase', () => {
       Assert.isNotUndefined(earliest1)
       expect(earliest1.id).toEqual(payoutPeriod1.id)
 
-      await db.markSharesPaid(payoutPeriod1.id, 1)
+      await db.markSharesPaid(payoutPeriod1.id, 1, [address])
 
       const earliest2 = await db.earliestOutstandingPayoutPeriod()
       Assert.isNotUndefined(earliest2)

--- a/ironfish/src/mining/poolDatabase/migrations/008-add-payout-share-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/008-add-payout-share-table.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration008 extends Migration {
+  name = '006-add-payout-share-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE payoutShare (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        publicAddress TEXT NOT NULL,
+        payoutPeriodId INTEGER NOT NULL,
+        payoutTransactionId INTEGER,
+        CONSTRAINT payoutShare_fk_payoutPeriodId FOREIGN KEY (payoutPeriodId) REFERENCES payoutPeriod (id)
+        CONSTRAINT payoutShare_fk_payoutTransactionId FOREIGN KEY (payoutTransactionId) REFERENCES payoutTransaction (id)
+      );
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP TABLE IF EXISTS payoutShare;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -9,6 +9,7 @@ import Migration004 from './004-add-shares-address-index'
 import Migration005 from './005-add-payout-period-table'
 import Migration006 from './006-add-block-table'
 import Migration007 from './007-add-payout-transaction-table'
+import Migration008 from './008-add-payout-share-table'
 
 export const MIGRATIONS = [
   Migration001,
@@ -18,4 +19,5 @@ export const MIGRATIONS = [
   Migration005,
   Migration006,
   Migration007,
+  Migration008,
 ]

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -98,32 +98,60 @@ describe('poolShares', () => {
     })
   })
 
-  it('transactions', async () => {
-    await shares.rolloverPayoutPeriod()
+  describe('transactions', () => {
+    beforeEach(async () => {
+      await shares.rolloverPayoutPeriod()
+    })
 
-    const payoutPeriod = await shares['db'].getCurrentPayoutPeriod()
-    Assert.isNotUndefined(payoutPeriod)
+    it('expected flow', async () => {
+      const payoutPeriod = await shares['db'].getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod)
 
-    await shares['db'].newTransaction('hash1', payoutPeriod.id)
-    await shares['db'].newTransaction('hash2', payoutPeriod.id)
+      await shares['db'].newTransaction('hash1', payoutPeriod.id)
+      await shares['db'].newTransaction('hash2', payoutPeriod.id)
 
-    const unconfirmedTransactions1 = await shares.unconfirmedPayoutTransactions()
-    expect(unconfirmedTransactions1.length).toEqual(2)
+      const unconfirmedTransactions1 = await shares.unconfirmedPayoutTransactions()
+      expect(unconfirmedTransactions1.length).toEqual(2)
 
-    // This should be a no-op
-    await shares.updatePayoutTransactionStatus(unconfirmedTransactions1[0], false, false)
+      // This should be a no-op
+      await shares.updatePayoutTransactionStatus(unconfirmedTransactions1[0], false, false)
 
-    const unconfirmedTransactions2 = await shares.unconfirmedPayoutTransactions()
-    expect(unconfirmedTransactions2.length).toEqual(2)
+      const unconfirmedTransactions2 = await shares.unconfirmedPayoutTransactions()
+      expect(unconfirmedTransactions2.length).toEqual(2)
 
-    await shares.updatePayoutTransactionStatus(unconfirmedTransactions1[0], true, false)
+      await shares.updatePayoutTransactionStatus(unconfirmedTransactions1[0], true, false)
 
-    const unconfirmedTransactions3 = await shares.unconfirmedPayoutTransactions()
-    expect(unconfirmedTransactions3.length).toEqual(1)
+      const unconfirmedTransactions3 = await shares.unconfirmedPayoutTransactions()
+      expect(unconfirmedTransactions3.length).toEqual(1)
 
-    await shares.updatePayoutTransactionStatus(unconfirmedTransactions1[1], false, true)
+      await shares.updatePayoutTransactionStatus(unconfirmedTransactions1[1], false, true)
 
-    const unconfirmedTransactions4 = await shares.unconfirmedPayoutTransactions()
-    expect(unconfirmedTransactions4.length).toEqual(0)
+      const unconfirmedTransactions4 = await shares.unconfirmedPayoutTransactions()
+      expect(unconfirmedTransactions4.length).toEqual(0)
+    })
+
+    it('expired transactions should mark shares unpaid', async () => {
+      const payoutPeriod = await shares['db'].getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod)
+
+      await shares['db'].newShare('testPublicAddress')
+      const transactionId = await shares['db'].newTransaction('hash1', payoutPeriod.id)
+      Assert.isNotUndefined(transactionId)
+      await shares['db'].markSharesPaid(payoutPeriod.id, transactionId)
+
+      // All shares paid out, so there should be no outstanding payout periods
+      const outstandingPeriod1 = await shares['db'].earliestOutstandingPayoutPeriod()
+      expect(outstandingPeriod1).toBeUndefined()
+
+      const unconfirmedTransactions = await shares.unconfirmedPayoutTransactions()
+      expect(unconfirmedTransactions.length).toEqual(1)
+
+      // Mark transaction expired
+      await shares.updatePayoutTransactionStatus(unconfirmedTransactions[0], false, true)
+
+      // Share has been marked unpaid, so the payout period should be outstanding again
+      const outstandingPeriod2 = await shares['db'].earliestOutstandingPayoutPeriod()
+      expect(outstandingPeriod2).toBeDefined()
+    })
   })
 })

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -134,10 +134,12 @@ describe('poolShares', () => {
       const payoutPeriod = await shares['db'].getCurrentPayoutPeriod()
       Assert.isNotUndefined(payoutPeriod)
 
-      await shares['db'].newShare('testPublicAddress')
+      const address = 'testPublicAddress'
+
+      await shares['db'].newShare(address)
       const transactionId = await shares['db'].newTransaction('hash1', payoutPeriod.id)
       Assert.isNotUndefined(transactionId)
-      await shares['db'].markSharesPaid(payoutPeriod.id, transactionId)
+      await shares['db'].markSharesPaid(payoutPeriod.id, transactionId, [address])
 
       // All shares paid out, so there should be no outstanding payout periods
       const outstandingPeriod1 = await shares['db'].earliestOutstandingPayoutPeriod()

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -276,5 +276,21 @@ export class MiningPoolShares {
     }
 
     await this.db.updateTransactionStatus(transaction.id, confirmed, expired)
+
+    if (expired && !confirmed) {
+      await this.db.markSharesUnpaid(transaction.id)
+    }
+  }
+
+  // TODO: This function is a rough shell, will be filled out with logic in follow-up PR
+  async createNewPayout(): Promise<void> {
+    const payoutPeriod = await this.db.earliestOutstandingPayoutPeriod()
+
+    if (!payoutPeriod) {
+      this.logger.debug('No outstanding shares, skipping payout')
+      return
+    }
+
+    // TODO: Rest of logic will go here
   }
 }


### PR DESCRIPTION
## Summary

**Builds on #3285** 

This is functionally very similar to the existing shares. The only differences are that it is associated to a payout period and a payout transaction. This way, we know which payout period it belongs to, and which transaction it belongs to. This also allows us to make sure that a share is paid out again in the event of a payout transaction expiring.

The old logic/table will be removed in a follow-up commit that removes all of the old stuff in one change, to minimize disruption to the existing pool and make it easier to transition to the new logic.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
