### PR TITLE
feat(ironfish): new payout logic for mining pool

### DIFF
--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -216,11 +216,13 @@ export class MiningPool {
     await this.shares.rolloverPayoutPeriod()
     await this.updateUnconfirmedBlocks()
     await this.updateUnconfirmedPayoutTransactions()
+    await this.shares.createNewPayout()
 
-    if (this.nextPayoutAttempt <= new Date().getTime()) {
-      this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
-      await this.shares.createPayout()
-    }
+    // TODO: Disable old payout logic, to be removed in next PR
+    // if (this.nextPayoutAttempt <= new Date().getTime()) {
+    //   this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
+    //   await this.shares.createPayout()
+    // }
 
     const eventLoopEndTime = new Date().getTime()
     const eventLoopDuration = eventLoopEndTime - eventLoopStartTime

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -217,14 +217,14 @@ describe('poolShares', () => {
       {
         publicAddress: publicAddress1,
         amount: '16',
-        memo: 'Iron Fish Pool payout',
+        memo: `Iron Fish Pool payout ${payoutPeriod1.id}`,
         assetId,
       },
       // Address 2 had 2 shares, with 16 reward per share = 32 amount
       {
         publicAddress: publicAddress2,
         amount: '32',
-        memo: 'Iron Fish Pool payout',
+        memo: `Iron Fish Pool payout ${payoutPeriod1.id}`,
         assetId,
       },
     ])

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -384,6 +384,7 @@ export class MiningPoolShares {
       fromAccountName: this.accountName,
       outputs,
       fee: outputs.length.toString(),
+      expirationDelta: this.config.get('transactionExpirationDelta'),
     })
 
     return transaction.content.hash

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -6,7 +6,7 @@ import { Assert } from '../assert'
 import { Config } from '../fileStores/config'
 import { Logger } from '../logger'
 import { RpcClient } from '../rpc/clients/client'
-import { ErrorUtils } from '../utils'
+import { CurrencyUtils, ErrorUtils } from '../utils'
 import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
 import { DatabaseShare, PoolDatabase } from './poolDatabase'
@@ -345,8 +345,8 @@ export class MiningPoolShares {
       const amount = amountPerShare * BigInt(payout.shareCount)
       outputs.push({
         publicAddress: payout.publicAddress,
-        amount: amount.toString(),
-        memo: `${this.poolName} payout`,
+        amount: CurrencyUtils.encode(amount),
+        memo: `${this.poolName} payout ${payoutPeriod.id}`,
         assetId,
       })
     }


### PR DESCRIPTION
## Summary

**Builds on #3316** 

This introduces the core logic needed to create payouts with the new additions to the codebase. Specifically, it now knows which shares have been paid out, how much reward was earned in a payout period, whether its blocks and transactions are confirmed and whether transactions need to be undone in the database if they expire.

It lacks some of the polish of the existing payout logic, which will be moved over and tweaked as needed as we begin to remove the old logic.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
