### PR TITLE
Rename fee rate options

### DIFF
--- a/ironfish-cli/src/commands/fees.ts
+++ b/ironfish-cli/src/commands/fees.ts
@@ -31,7 +31,7 @@ export class FeeCommand extends IronfishCommand {
     this.log('Fee Rates ($ORE/kB)')
     this.log(`slow:    ${feeRates.content.slow || ''}`)
     this.log(`average: ${feeRates.content.average || ''}`)
-    this.log(`fast:   ${feeRates.content.fast || ''}`)
+    this.log(`fast:    ${feeRates.content.fast || ''}`)
   }
 
   async explainFeeRates(client: RpcClient): Promise<void> {

--- a/ironfish-cli/src/commands/fees.ts
+++ b/ironfish-cli/src/commands/fees.ts
@@ -51,7 +51,7 @@ export class FeeCommand extends IronfishCommand {
     this.log('The low, medium, and high rates each come from a percentile in the distribution:')
     this.log(`slow:    ${slow}th`)
     this.log(`average: ${average}th`)
-    this.log(`fast:   ${fast}th`)
+    this.log(`fast:    ${fast}th`)
     this.log('')
   }
 }

--- a/ironfish-cli/src/commands/fees.ts
+++ b/ironfish-cli/src/commands/fees.ts
@@ -29,17 +29,17 @@ export class FeeCommand extends IronfishCommand {
     const feeRates = await client.estimateFeeRates()
 
     this.log('Fee Rates ($ORE/kB)')
-    this.log(`low:    ${feeRates.content.low || ''}`)
-    this.log(`medium: ${feeRates.content.medium || ''}`)
-    this.log(`high:   ${feeRates.content.high || ''}`)
+    this.log(`slow:    ${feeRates.content.slow || ''}`)
+    this.log(`average: ${feeRates.content.average || ''}`)
+    this.log(`fast:   ${feeRates.content.fast || ''}`)
   }
 
   async explainFeeRates(client: RpcClient): Promise<void> {
     const config = await client.getConfig()
 
-    const low = config.content['feeEstimatorPercentileLow'] || '10'
-    const medium = config.content['feeEstimatorPercentileMedium'] || '20'
-    const high = config.content['feeEstimatorPercentileHigh'] || '30'
+    const slow = config.content['feeEstimatorPercentileLow'] || '10'
+    const average = config.content['feeEstimatorPercentileMedium'] || '20'
+    const fast = config.content['feeEstimatorPercentileHigh'] || '30'
     const numBlocks = config.content['feeEstimatorMaxBlockHistory'] || '10'
 
     this.log(
@@ -49,9 +49,9 @@ export class FeeCommand extends IronfishCommand {
       'The fee rate for each transaction is computed by dividing the transaction fee in $ORE by the size of the transaction in kB.\n',
     )
     this.log('The low, medium, and high rates each come from a percentile in the distribution:')
-    this.log(`low:    ${low}th`)
-    this.log(`medium: ${medium}th`)
-    this.log(`high:   ${high}th`)
+    this.log(`slow:    ${slow}th`)
+    this.log(`average: ${average}th`)
+    this.log(`fast:   ${fast}th`)
     this.log('')
   }
 }

--- a/ironfish-cli/src/commands/service/estimate-fee-rates.ts
+++ b/ironfish-cli/src/commands/service/estimate-fee-rates.ts
@@ -62,12 +62,12 @@ export default class EstimateFees extends IronfishCommand {
 
       const response = await this.sdk.client.estimateFeeRates()
 
-      if (!(response.content.low && response.content.medium && response.content.high)) {
+      if (!(response.content.slow && response.content.average && response.content.fast)) {
         this.log('Unexpected response')
       } else {
-        const feeRateLow = Number(CurrencyUtils.decode(response.content.low))
-        const feeRateMedium = Number(CurrencyUtils.decode(response.content.medium))
-        const feeRateHigh = Number(CurrencyUtils.decode(response.content.high))
+        const feeRateSlow = Number(CurrencyUtils.decode(response.content.slow))
+        const feeRateAverage = Number(CurrencyUtils.decode(response.content.average))
+        const feeRateFast = Number(CurrencyUtils.decode(response.content.fast))
 
         await api.submitTelemetry({
           points: [
@@ -76,19 +76,19 @@ export default class EstimateFees extends IronfishCommand {
               timestamp: new Date(),
               fields: [
                 {
-                  name: `fee_rate_low`,
+                  name: `fee_rate_slow`,
                   type: 'integer',
-                  value: feeRateLow,
+                  value: feeRateSlow,
                 },
                 {
-                  name: `fee_rate_medium`,
+                  name: `fee_rate_average`,
                   type: 'integer',
-                  value: feeRateMedium,
+                  value: feeRateAverage,
                 },
                 {
-                  name: `fee_rate_high`,
+                  name: `fee_rate_fast`,
                   type: 'integer',
-                  value: feeRateHigh,
+                  value: feeRateFast,
                 },
               ],
               tags: [{ name: 'version', value: IronfishCliPKG.version }],

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -145,11 +145,11 @@ export class Burn extends IronfishCommand {
       rawTransactionResponse = createResponse.content.transaction
     } else {
       const feeRatesResponse = await client.estimateFeeRates()
-      const feeRates = new Set([
-        feeRatesResponse.content.low ?? '1',
-        feeRatesResponse.content.medium ?? '1',
-        feeRatesResponse.content.high ?? '1',
-      ])
+      const feeRates = [
+        feeRatesResponse.content.slow ?? '1',
+        feeRatesResponse.content.average ?? '1',
+        feeRatesResponse.content.fast ?? '1',
+      ]
 
       const feeRateNames = Object.getOwnPropertyNames(feeRatesResponse.content)
 

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -190,11 +190,11 @@ export class Mint extends IronfishCommand {
       rawTransactionResponse = createResponse.content.transaction
     } else {
       const feeRatesResponse = await client.estimateFeeRates()
-      const feeRates = new Set([
-        feeRatesResponse.content.low ?? '1',
-        feeRatesResponse.content.medium ?? '1',
-        feeRatesResponse.content.high ?? '1',
-      ])
+      const feeRates = [
+        feeRatesResponse.content.slow ?? '1',
+        feeRatesResponse.content.average ?? '1',
+        feeRatesResponse.content.fast ?? '1',
+      ]
 
       const feeRateNames = Object.getOwnPropertyNames(feeRatesResponse.content)
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -188,11 +188,11 @@ export class Send extends IronfishCommand {
     let rawTransactionResponse: string
     if (fee === null && feeRate === null) {
       const feeRatesResponse = await client.estimateFeeRates()
-      const feeRates = new Set([
-        feeRatesResponse.content.low ?? '1',
-        feeRatesResponse.content.medium ?? '1',
-        feeRatesResponse.content.high ?? '1',
-      ])
+      const feeRates = [
+        feeRatesResponse.content.slow ?? '1',
+        feeRatesResponse.content.average ?? '1',
+        feeRatesResponse.content.fast ?? '1',
+      ]
 
       const feeRateNames = Object.getOwnPropertyNames(feeRatesResponse.content)
 

--- a/ironfish/src/rpc/routes/chain/estimateFeeRates.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRates.ts
@@ -7,9 +7,9 @@ import { ApiNamespace, router } from '../router'
 
 export type EstimateFeeRatesRequest = { priority?: PriorityLevel } | undefined
 export type EstimateFeeRatesResponse = {
-  low?: string
-  medium?: string
-  high?: string
+  slow?: string
+  average?: string
+  fast?: string
 }
 
 export const EstimateFeeRatesRequestSchema: yup.ObjectSchema<EstimateFeeRatesRequest> = yup
@@ -20,9 +20,9 @@ export const EstimateFeeRatesRequestSchema: yup.ObjectSchema<EstimateFeeRatesReq
 
 export const EstimateFeeRatesResponseSchema: yup.ObjectSchema<EstimateFeeRatesResponse> = yup
   .object({
-    low: yup.string(),
-    medium: yup.string(),
-    high: yup.string(),
+    slow: yup.string(),
+    average: yup.string(),
+    fast: yup.string(),
   })
   .defined()
 
@@ -44,9 +44,9 @@ router.register<typeof EstimateFeeRatesRequestSchema, EstimateFeeRatesResponse>(
       const feeRates = feeEstimator.estimateFeeRates()
 
       request.end({
-        low: feeRates.low > 0 ? feeRates.low.toString() : '1',
-        medium: feeRates.medium > 0 ? feeRates.medium.toString() : '1',
-        high: feeRates.high > 0 ? feeRates.high.toString() : '1',
+        slow: feeRates.low > 0 ? feeRates.low.toString() : '1',
+        average: feeRates.medium > 0 ? feeRates.medium.toString() : '1',
+        fast: feeRates.high > 0 ? feeRates.high.toString() : '1',
       })
     }
   },


### PR DESCRIPTION

## Summary
Rename fee rate options
Always display three options

## Testing Plan
local
```
yarn start wallet:send --rawTransaction -t dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca
yarn run v1.22.19
$ yarn build && yarn start:js wallet:send --rawTransaction -t dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:send --rawTransaction -t dfc2679369551e64e3950e06a88e68466e813c63b100283520045925adbe59ca
? Select the asset you wish to send d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6
($IRON) (0.00000005)
Enter the amount (balance: 0.00000005): 0.00000001
? Select the fee you wish to use for this transaction (Use arrow keys)
❯ slow: 0.00000001 IRON
  average: 0.00000001 IRON
  fast: 0.00000001 IRON
```
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
