### PR TITLE
Change wallet import/export to mirror each other, and to expect blobs

### DIFF
--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -44,7 +44,7 @@ export class ExportCommand extends IronfishCommand {
     path: Flags.string({
       description: 'The path to export the account to',
       required: false,
-    })
+    }),
   }
 
   static args = [

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -41,6 +41,10 @@ export class ExportCommand extends IronfishCommand {
       default: false,
       description: 'Output the account as JSON, rather than the default bech32',
     }),
+    path: Flags.string({
+      description: 'The path to export the account to',
+      required: false,
+    })
   }
 
   static args = [
@@ -50,19 +54,13 @@ export class ExportCommand extends IronfishCommand {
       required: false,
       description: 'Name of the account to export',
     },
-    {
-      name: 'path',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
-      required: false,
-      description: 'The path to export the account to',
-    },
   ]
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(ExportCommand)
     const { color, local } = flags
     const account = args.account as string
-    const exportPath = args.path as string | undefined
+    const exportPath = flags.path
 
     const client = await this.sdk.connectRpc(local)
     const response = await client.exportAccount({ account })

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -23,10 +23,10 @@ export class ImportCommand extends IronfishCommand {
 
   static args = [
     {
-      name: 'path',
+      name: 'blob',
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
-      description: 'The path to import the account from',
+      description: 'The copy-pasted output of wallet:export',
     },
   ]
 
@@ -63,12 +63,14 @@ export class ImportCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(ImportCommand)
-    const importPath = args.path as string | undefined
+    const blob = args.blob as string | undefined
 
     const client = await this.sdk.connectRpc()
 
     let account: AccountImport | null = null
-    if (importPath) {
+    if (blob) {
+      account = await this.stringToAccountImport(blob)
+    } else if (importPath) {
       account = await this.importFile(importPath)
     } else if (process.stdin.isTTY) {
       account = await this.importTTY()

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -19,10 +19,9 @@ export class ImportCommand extends IronfishCommand {
       default: true,
       description: 'Rescan the blockchain once the account is imported',
     }),
-    importPath: Flags.string({
-      char: 'p',
+    path: Flags.string({
       description: 'the path to the file containing the account to import',
-      flagName: 'import path',
+      flagName: 'path',
     }),
   }
 
@@ -75,8 +74,8 @@ export class ImportCommand extends IronfishCommand {
     let account: AccountImport | null = null
     if (blob) {
       account = await this.stringToAccountImport(blob)
-    } else if (flags.importPath) {
-      account = await this.importFile(flags.importPath)
+    } else if (flags.path) {
+      account = await this.importFile(flags.path)
     } else if (process.stdin.isTTY) {
       account = await this.importTTY()
     } else if (!process.stdin.isTTY) {

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -19,6 +19,11 @@ export class ImportCommand extends IronfishCommand {
       default: true,
       description: 'Rescan the blockchain once the account is imported',
     }),
+    importPath: Flags.string({
+      char: 'p',
+      description: 'the path to the file containing the account to import',
+      flagName: 'import path',
+    }),
   }
 
   static args = [
@@ -70,8 +75,8 @@ export class ImportCommand extends IronfishCommand {
     let account: AccountImport | null = null
     if (blob) {
       account = await this.stringToAccountImport(blob)
-    } else if (importPath) {
-      account = await this.importFile(importPath)
+    } else if (flags.importPath) {
+      account = await this.importFile(flags.importPath)
     } else if (process.stdin.isTTY) {
       account = await this.importTTY()
     } else if (!process.stdin.isTTY) {


### PR DESCRIPTION
## Summary
This PR proposes to change the CLI `wallet:import` workflow to default to expecting a blob, such as: `ironfish wallet:import pasted_blob`, rather than what it currently expects, a path: `ironfish wallet:import /path/to/a/blob`.  Path can still be supplied with `--importPath`. If the user somehow supplies both a blob and a path, just the blob is used.

Mirroring this behavior, `wallet:export` now needs an explicit argument `--path` if you want to export to a path; it defaults to assuming you would like a blob output to console.

## Testing Plan

https://user-images.githubusercontent.com/5766842/217118129-15011ebe-d730-46d1-8fa2-c5d5fa4a22a4.mov


## Breaking Change
Not a breaking change, though users may have to update scripts if they use any, since the usage default changed.
```
[ ] Yes
[X] No
```


