### PR TITLE
fix(ci): ** as glob to pick up branch names with / in them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Node.js CI
 on:
   pull_request:
     branches:
-      - '*'
+      - '**'
   push:
     branches:
       - master


### PR DESCRIPTION
## Summary

[Sometimes ](https://github.com/iron-fish/ironfish/pull/3268) my PRs don't seem to trigger CI workflows. I am not entirely sure what the root cause is, but this seems like a good start

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
