### PR TITLE
fix: remove id account export

### DIFF
--- a/ironfish/src/rpc/routes/wallet/exportAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.ts
@@ -41,6 +41,8 @@ router.register<typeof ExportAccountRequestSchema, ExportAccountResponse>(
   ExportAccountRequestSchema,
   (request, node): void => {
     const account = getAccount(node, request.data.account)
-    request.end({ account: account.serialize() })
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id, ...accountInfo } = account.serialize()
+    request.end({ account: accountInfo })
   },
 )


### PR DESCRIPTION
## Summary
Removes id from `exportAccount` RPC.
## Testing Plan
Before
```
fish wallet:export  --json --datadir=~/.phase3v9                                                                              ─╯

yarn run v1.22.19
$ yarn build && yarn start:js wallet:export --json '--datadir=~/.phase3v9'
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:export --json '--datadir=~/.phase3v9'
{
    "id": "25beb087-9c0e-41a2-ae51-708a1fd69deb",
    "name": "throwaway",
    "spendingKey": "8b610cdb12f5b4d84034325b6bfbde84ca8e45b5ee826e7d2e734fe62e52cd5b",
    "incomingViewKey": "9007719c56e84730db86f1674f4e1a65041d3e6ca08cba1cf7db5326cb0ca807",
    "outgoingViewKey": "b1e6de94e6fbb13fe3a905e94b3c5df6f8f5f0ea7010b5fbcfbcd535e6da7788",
    "publicAddress": "445721a8e2ea387a2f9cd351e32d0b9b3eaec91e9895efe9efe92bc4d2a56928"
}
✨  Done in 2.73s.
```
After
```
fish wallet:export  --json --datadir=~/.phase3v9                                                                              ─╯

yarn run v1.22.19
$ yarn build && yarn start:js wallet:export --json '--datadir=~/.phase3v9'
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:export --json '--datadir=~/.phase3v9'
{
    "name": "throwaway",
    "spendingKey": "8b610cdb12f5b4d84034325b6bfbde84ca8e45b5ee826e7d2e734fe62e52cd5b",
    "incomingViewKey": "9007719c56e84730db86f1674f4e1a65041d3e6ca08cba1cf7db5326cb0ca807",
    "outgoingViewKey": "b1e6de94e6fbb13fe3a905e94b3c5df6f8f5f0ea7010b5fbcfbcd535e6da7788",
    "publicAddress": "445721a8e2ea387a2f9cd351e32d0b9b3eaec91e9895efe9efe92bc4d2a56928"
}
✨  Done in 2.43s.
```
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
