### PR TITLE
defines reusable fixedWidth column

### DIFF
--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -7,7 +7,7 @@ import {
   ASSET_NAME_LENGTH,
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
-import { BufferUtils, GetAssetsResponse } from '@ironfish/sdk'
+import { BufferUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -57,7 +57,7 @@ export class AssetsCommand extends IronfishCommand {
       CliUx.ux.table(
         [asset],
         {
-          name: TableCols.fixedWidth<GetAssetsResponse>({
+          name: TableCols.fixedWidth({
             header: 'Name',
             width: assetNameWidth,
             get: (row) => BufferUtils.toHuman(Buffer.from(row.name, 'hex')),
@@ -66,7 +66,7 @@ export class AssetsCommand extends IronfishCommand {
             header: 'ID',
             minWidth: ASSET_ID_LENGTH + 1,
           },
-          metadata: TableCols.fixedWidth<GetAssetsResponse>({
+          metadata: TableCols.fixedWidth({
             header: 'Metadata',
             width: assetMetadataWidth,
             get: (row) => BufferUtils.toHuman(Buffer.from(row.metadata, 'hex')),

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -7,11 +7,11 @@ import {
   ASSET_NAME_LENGTH,
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
-import { BufferUtils } from '@ironfish/sdk'
+import { BufferUtils, GetAssetsResponse } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
-import { truncateCol } from '../../utils/table'
+import { TableCols } from '../../utils/table'
 
 const MAX_ASSET_METADATA_COLUMN_WIDTH = ASSET_METADATA_LENGTH + 1
 const MIN_ASSET_METADATA_COLUMN_WIDTH = ASSET_METADATA_LENGTH / 2 + 1
@@ -57,25 +57,20 @@ export class AssetsCommand extends IronfishCommand {
       CliUx.ux.table(
         [asset],
         {
-          name: {
+          name: TableCols.fixedWidth<GetAssetsResponse>({
             header: 'Name',
-            minWidth: assetNameWidth,
-            get: (row) =>
-              truncateCol(BufferUtils.toHuman(Buffer.from(row.name, 'hex')), assetNameWidth),
-          },
+            width: assetNameWidth,
+            get: (row) => BufferUtils.toHuman(Buffer.from(row.name, 'hex')),
+          }),
           id: {
             header: 'ID',
             minWidth: ASSET_ID_LENGTH + 1,
           },
-          metadata: {
+          metadata: TableCols.fixedWidth<GetAssetsResponse>({
             header: 'Metadata',
-            minWidth: assetMetadataWidth,
-            get: (row) =>
-              truncateCol(
-                BufferUtils.toHuman(Buffer.from(row.metadata, 'hex')),
-                assetMetadataWidth,
-              ),
-          },
+            width: assetMetadataWidth,
+            get: (row) => BufferUtils.toHuman(Buffer.from(row.metadata, 'hex')),
+          }),
           status: {
             header: 'Status',
             minWidth: 12,

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -102,7 +102,20 @@ const asset = <T extends Record<string, unknown>>(options?: {
   }
 }
 
-export function truncateCol(value: string, maxWidth: number | null): string {
+const fixedWidth = <T extends Record<string, unknown>>(options: {
+  width: number
+  get: (row: T) => string
+  header?: string
+  extended?: boolean
+}): Partial<table.Column<T>> => {
+  return {
+    ...options,
+    get: (row) => truncateCol(options.get(row), options.width),
+    minWidth: options.width,
+  }
+}
+
+function truncateCol(value: string, maxWidth: number | null): string {
   if (maxWidth === null || value.length <= maxWidth) {
     return value
   }
@@ -110,4 +123,4 @@ export function truncateCol(value: string, maxWidth: number | null): string {
   return value.slice(0, maxWidth - 1) + '…'
 }
 
-export const TableCols = { timestamp, asset }
+export const TableCols = { timestamp, asset, fixedWidth }


### PR DESCRIPTION
## Summary

encapsulates logic for creating an oclif table column with fixed width. creates a column with minWidth set to the width and truncates the value returned by 'get' to the specified width

uses fixedWidth column in wallet:assets command

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
