### PR TITLE
Simplify re-gossip logic for transactions

### DIFF
--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -403,6 +403,11 @@ export class PeerNetwork {
     }
   }
 
+  /**
+   * Send out the transaction only to peers that have not yet heard about it.
+   * The full transaction will be sent to a subset of sqrt(num_peers)
+   * and the rest of the peers will receive the transaction hash
+   */
   private broadcastTransaction(transaction: Transaction): void {
     const hash = transaction.hash()
 
@@ -960,9 +965,10 @@ export class PeerNetwork {
     for (const hash of message.hashes) {
       peer.state.identity && this.markKnowsTransaction(hash, peer.state.identity)
 
-      // If the transaction is already in the mempool the only thing we have to do is broadcast
+      // If the transaction is already in the mempool we don't need to request
+      // the full transaction. Just broadcast it
       const transaction = this.node.memPool.get(hash)
-      if (transaction && !this.alreadyHaveTransaction(hash)) {
+      if (transaction) {
         this.broadcastTransaction(transaction)
       } else {
         this.transactionFetcher.hashReceived(hash, peer)


### PR DESCRIPTION
## Summary
This call to `alreadyHaveTransaction` is unnecessary here.
1. If the transaction is in the mempool that means that it can't have been included in a recent block. So `this.recentlyAddedToChain.has(hash)` is automatically false
2. We've already checked if it's in the mempool so `this.node.memPool.exists(hash)` is automatically true
3. That leaves the `alreadyHaveTransaction` check to be `!(false || true && !peersToSendTo))` which simplifies to `peersToSendTo`
4. We already only send to peers who haven't yet received the transaction in `peersToSendTo` so checking `peersToSendTo` is redundant

Also changing a nested if statement to an early return


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
