### PR TITLE
feat(ironfish): Allow the pool migrations to be silenced during tests

### DIFF
--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { LogLevel } from 'consola'
 import { Assert } from '../../assert'
 import { Config } from '../../fileStores'
 import { NodeFileProvider } from '../../fileSystems'
@@ -15,6 +16,7 @@ describe('poolDatabase', () => {
 
   beforeEach(async () => {
     const logger = createRootLogger().withTag('test')
+    logger.level = LogLevel.Silent
     const dataDir = getUniqueTestDataDir()
     const fileSystem = new NodeFileProvider()
     await fileSystem.init()

--- a/ironfish/src/mining/poolDatabase/migrator.ts
+++ b/ironfish/src/mining/poolDatabase/migrator.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /* eslint-disable no-console */
+import { LogLevel } from 'consola'
 import { Database } from 'sqlite'
 import { Logger } from '../../logger'
 import { Migration } from './migration'
@@ -52,17 +53,17 @@ export class Migrator {
       this.logger.info('Running migrations:')
 
       for (const migration of unapplied) {
-        process.stdout.write(`  Applying ${migration.name}...`)
+        this.write(`  Applying ${migration.name}...`)
 
         try {
           await migration.forward(this.db)
           await this.db.run(`PRAGMA user_version = ${migration.id};`)
         } catch (e) {
-          process.stdout.write(` ERROR\n`)
+          this.write(` ERROR\n`)
           console.error(e)
           throw e
         }
-        process.stdout.write(` OK\n`)
+        this.write(` OK\n`)
       }
 
       await this.db.run('COMMIT;')
@@ -72,6 +73,12 @@ export class Migrator {
         /* do nothing */
       })
       throw e
+    }
+  }
+
+  write(output: string): void {
+    if (this.logger.level >= LogLevel.Info) {
+      process.stdout.write(output)
     }
   }
 }

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Asset } from '@ironfish/rust-nodejs'
+import { LogLevel } from 'consola'
 import { Assert } from '../assert'
 import { createRootLogger } from '../logger'
 import { createRouteTest } from '../testUtilities/routeTest'
@@ -13,10 +14,12 @@ describe('poolShares', () => {
   let shares: MiningPoolShares
 
   beforeEach(async () => {
+    const logger = createRootLogger().withTag('test')
+    logger.level = LogLevel.Silent
     shares = await MiningPoolShares.init({
       rpc: routeTest.client,
       config: routeTest.sdk.config,
-      logger: createRootLogger().withTag('test'),
+      logger,
       enablePayouts: true,
       dbPath: ':memory:',
     })


### PR DESCRIPTION
## Summary

Doesn't depend on any of the open mining pool PRs

Normal output is unaffected:
![image](https://user-images.githubusercontent.com/97762857/217592191-87eb6391-e797-4303-a55d-ed8f17439af8.png)

Tests don't spam a billion lines:
![image](https://user-images.githubusercontent.com/97762857/217592265-5f850896-7c55-4c07-bd77-f4a85ceed01c.png)

For reference, this is what it looked like before, which was already broken in its own way:
![image](https://user-images.githubusercontent.com/97762857/217592834-b9c34df0-c677-4a0d-9f24-f8fca5de0a90.png)


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
