### PR TITLE
Fix ASCII encoding errors

### DIFF
--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -120,8 +120,8 @@ export class RawTransactionSerde {
 
     bw.writeU64(raw.mints.length)
     for (const mint of raw.mints) {
-      bw.writeVarString(mint.name)
-      bw.writeVarString(mint.metadata)
+      bw.writeVarString(mint.name, 'utf8')
+      bw.writeVarString(mint.metadata, 'utf8')
       bw.writeBigU64(mint.value)
     }
 
@@ -172,8 +172,8 @@ export class RawTransactionSerde {
 
     const mintsLength = reader.readU64()
     for (let i = 0; i < mintsLength; i++) {
-      const name = reader.readVarString()
-      const metadata = reader.readVarString()
+      const name = reader.readVarString('utf8')
+      const metadata = reader.readVarString('utf8')
       const value = reader.readBigU64()
       raw.mints.push({ name, metadata, value })
     }

--- a/ironfish/src/testUtilities/helpers/merkletree.ts
+++ b/ironfish/src/testUtilities/helpers/merkletree.ts
@@ -19,7 +19,7 @@ class StructureLeafEncoding implements IDatabaseEncoding<StructureLeafValue> {
   serialize(value: StructureLeafValue): Buffer {
     const bw = bufio.write()
 
-    bw.writeVarString(value.merkleHash)
+    bw.writeVarString(value.merkleHash, 'utf8')
     bw.writeU32(value.parentIndex)
 
     return bw.render()
@@ -28,7 +28,7 @@ class StructureLeafEncoding implements IDatabaseEncoding<StructureLeafValue> {
   deserialize(buffer: Buffer): StructureLeafValue {
     const bw = bufio.read(buffer, true)
 
-    const merkleHash = bw.readVarString()
+    const merkleHash = bw.readVarString('utf8')
     const parentIndex = bw.readU32()
 
     return {
@@ -42,7 +42,7 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
   serialize(value: NodeValue<string>): Buffer {
     const bw = bufio.write()
 
-    bw.writeVarString(value.hashOfSibling)
+    bw.writeVarString(value.hashOfSibling, 'utf8')
 
     if (value.side === Side.Left) {
       bw.writeU8(0)
@@ -58,7 +58,7 @@ class StructureNodeEncoding implements IDatabaseEncoding<NodeValue<string>> {
   deserialize(buffer: Buffer): NodeValue<string> {
     const reader = bufio.read(buffer, true)
 
-    const hashOfSibling = reader.readVarString()
+    const hashOfSibling = reader.readVarString('utf8')
 
     const sideNumber = reader.readU8()
     const side = sideNumber === 0 ? Side.Left : Side.Right

--- a/ironfish/src/typedefs/bufio.d.ts
+++ b/ironfish/src/typedefs/bufio.d.ts
@@ -20,8 +20,8 @@ declare module 'bufio' {
     writeBigU256(value: bigint): StaticWriter
     writeBigU256BE(value: bigint): StaticWriter
     writeVarint(value: number): StaticWriter
-    writeString(value: string, enc?: BufferEncoding | null): StaticWriter
-    writeVarString(value: string, enc?: BufferEncoding | null): StaticWriter
+    writeString(value: string, enc: BufferEncoding | null): StaticWriter
+    writeVarString(value: string, enc: BufferEncoding | null): StaticWriter
     writeVarBytes(value: Buffer): StaticWriter
     writeBytes(value: Buffer): StaticWriter
     writeHash(value: Buffer | string): StaticWriter
@@ -77,8 +77,8 @@ declare module 'bufio' {
     readDoubleBE(): number
     readDouble(): number
     readVarint(): number
-    readString(size: number, enc?: BufferEncoding | null): string
-    readVarString(enc?: BufferEncoding | null, limit?: number): string
+    readString(size: number, enc: BufferEncoding | null): string
+    readVarString(enc: BufferEncoding | null, limit?: number): string
     readBytes(size: number, zeroCopy?: boolean): Buffer
     readVarBytes(): Buffer
 

--- a/ironfish/src/wallet/walletdb/decryptedNoteValue.ts
+++ b/ironfish/src/wallet/walletdb/decryptedNoteValue.ts
@@ -32,7 +32,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
     flags |= Number(!!sequence) << 4
     bw.writeU8(flags)
 
-    bw.writeVarString(accountId)
+    bw.writeVarString(accountId, 'utf8')
     bw.writeBytes(note.serialize())
     bw.writeHash(transactionHash)
 
@@ -62,7 +62,7 @@ export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNo
     const hasBlockHash = flags & (1 << 3)
     const hasSequence = flags & (1 << 4)
 
-    const accountId = reader.readVarString()
+    const accountId = reader.readVarString('utf8')
     const serializedNote = reader.readBytes(DECRYPTED_NOTE_LENGTH)
     const transactionHash = reader.readHash()
 

--- a/ironfish/src/workerPool/tasks/sleep.ts
+++ b/ironfish/src/workerPool/tasks/sleep.ts
@@ -21,14 +21,14 @@ export class SleepRequest extends WorkerMessage {
   serialize(): Buffer {
     const bw = bufio.write(this.getSize())
     bw.writeDouble(this.sleep)
-    bw.writeVarString(this.error)
+    bw.writeVarString(this.error, 'utf8')
     return bw.render()
   }
 
   static deserialize(jobId: number, buffer: Buffer): SleepRequest {
     const reader = bufio.read(buffer, true)
     const sleep = reader.readDouble()
-    const error = reader.readVarString()
+    const error = reader.readVarString('utf8')
     return new SleepRequest(sleep, error, jobId)
   }
 

--- a/ironfish/src/workerPool/tasks/submitTelemetry.ts
+++ b/ironfish/src/workerPool/tasks/submitTelemetry.ts
@@ -25,17 +25,17 @@ export class SubmitTelemetryRequest extends WorkerMessage {
     bw.writeU64(this.points.length)
 
     for (const point of this.points) {
-      bw.writeVarString(point.measurement)
-      bw.writeVarString(point.timestamp.toISOString())
+      bw.writeVarString(point.measurement, 'utf8')
+      bw.writeVarString(point.timestamp.toISOString(), 'utf8')
 
       const { fields } = point
       bw.writeU64(fields.length)
       for (const field of fields) {
-        bw.writeVarString(field.name)
-        bw.writeVarString(field.type)
+        bw.writeVarString(field.name, 'utf8')
+        bw.writeVarString(field.type, 'utf8')
         switch (field.type) {
           case 'string':
-            bw.writeVarString(field.value)
+            bw.writeVarString(field.value, 'utf8')
             break
           case 'boolean':
             bw.writeU8(Number(field.value))
@@ -53,8 +53,8 @@ export class SubmitTelemetryRequest extends WorkerMessage {
       if (tags) {
         bw.writeU64(tags.length)
         for (const tag of tags) {
-          bw.writeVarString(tag.name)
-          bw.writeVarString(tag.value)
+          bw.writeVarString(tag.name, 'utf8')
+          bw.writeVarString(tag.value, 'utf8')
         }
       }
     }
@@ -67,17 +67,17 @@ export class SubmitTelemetryRequest extends WorkerMessage {
     const pointsLength = reader.readU64()
     const points = []
     for (let i = 0; i < pointsLength; i++) {
-      const measurement = reader.readVarString()
-      const timestamp = new Date(reader.readVarString())
+      const measurement = reader.readVarString('utf8')
+      const timestamp = new Date(reader.readVarString('utf8'))
 
       const fieldsLength = reader.readU64()
       const fields = []
       for (let j = 0; j < fieldsLength; j++) {
-        const name = reader.readVarString()
-        const type = reader.readVarString()
+        const name = reader.readVarString('utf8')
+        const type = reader.readVarString('utf8')
         switch (type) {
           case 'string': {
-            const value = reader.readVarString()
+            const value = reader.readVarString('utf8')
             fields.push({ name, type, value })
             break
           }
@@ -106,8 +106,8 @@ export class SubmitTelemetryRequest extends WorkerMessage {
         const tagsLength = reader.readU64()
         tags = []
         for (let k = 0; k < tagsLength; k++) {
-          const name = reader.readVarString()
-          const value = reader.readVarString()
+          const name = reader.readVarString('utf8')
+          const value = reader.readVarString('utf8')
           tags.push({ name, value })
         }
       }


### PR DESCRIPTION
## Summary

There are many places where we write convert UTF8 to ascii that could be
causing problems. The default encoding to bufio is 'binary', which is an
alias to 'latin-1' which is effectively ASCII. This will change our
types to force users to specify the encoding to avoid issues like this.
I also changed our encodings over to use UTF-8.

This also fixes minting supply being broken.

## Testing Plan

Run existing tests, the change is a TS that will cause compiler errors if someone does not specify this.

## Breaking Change

It's not a breaking change because existing ASCII will still be decoded as single byte characters which is part of the UTF8 spec.

```
[ ] Yes
```
