### PR TITLE
Mining pool refactors

### DIFF
--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -40,9 +40,6 @@ export class StartPool extends IronfishCommand {
       allowNo: true,
       description: 'Whether the pool should payout or not. Useful for solo miners',
     }),
-    balancePercentPayout: Flags.integer({
-      description: 'Whether the pool should payout or not. Useful for solo miners',
-    }),
     banning: Flags.boolean({
       description: 'Whether the pool should ban peers for errors or bad behavior',
       allowNo: true,
@@ -146,7 +143,6 @@ export class StartPool extends IronfishCommand {
       webhooks: webhooks,
       host: host,
       port: port,
-      balancePercentPayoutFlag: flags.balancePercentPayout,
       banning: flags.banning,
       enableTls: flags.enableTls,
       tlsOptions: tlsOptions,

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -145,11 +145,6 @@ export type ConfigOptions = {
   poolBanning: boolean
 
   /**
-   * The percent of the confirmed balance of the pool's account that it will payout
-   */
-  poolBalancePercentPayout: number
-
-  /**
    * The host that the pool is listening for miner connections on.
    */
   poolHost: string
@@ -163,16 +158,6 @@ export type ConfigOptions = {
    * The pool difficulty, which determines how often miners submit shares.
    */
   poolDifficulty: string
-
-  /**
-   * The length of time in seconds that the pool will wait between checking if it is time to make a payout.
-   */
-  poolAttemptPayoutInterval: number
-
-  /**
-   * The length of time in seconds that the pool will wait between successful payouts.
-   */
-  poolSuccessfulPayoutInterval: number
 
   /**
    * The length of time in seconds that the pool will wait between status
@@ -291,12 +276,9 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     poolName: yup.string(),
     poolAccountName: yup.string(),
     poolBanning: yup.boolean(),
-    poolBalancePercentPayout: YupUtils.isPercent,
     poolHost: yup.string().trim(),
     poolPort: YupUtils.isPort,
     poolDifficulty: yup.string(),
-    poolAttemptPayoutInterval: YupUtils.isPositiveInteger,
-    poolSuccessfulPayoutInterval: YupUtils.isPositiveInteger,
     poolStatusNotificationInterval: YupUtils.isPositiveInteger,
     poolRecentShareCutoff: YupUtils.isPositiveInteger,
     poolDiscordWebhook: yup.string(),
@@ -373,12 +355,9 @@ export class Config extends KeyStore<ConfigOptions> {
       poolName: 'Iron Fish Pool',
       poolAccountName: 'default',
       poolBanning: true,
-      poolBalancePercentPayout: 10,
       poolHost: DEFAULT_POOL_HOST,
       poolPort: DEFAULT_POOL_PORT,
       poolDifficulty: '15000000000',
-      poolAttemptPayoutInterval: 15 * 60, // 15 minutes
-      poolSuccessfulPayoutInterval: 2 * 60 * 60, // 2 hours
       poolStatusNotificationInterval: 30 * 60, // 30 minutes
       poolRecentShareCutoff: 2 * 60 * 60, // 2 hours
       poolPayoutPeriodDuration: 2 * 60 * 60, // 2 hours

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -186,6 +186,12 @@ export type ConfigOptions = {
   poolRecentShareCutoff: number
 
   /**
+   * The length of time in seconds for each payout period. This is used to
+   * calculate the number of shares and how much they earn per period.
+   */
+  poolPayoutPeriodDuration: number
+
+  /**
    * The discord webhook URL to post pool critical pool information to
    */
   poolDiscordWebhook: ''
@@ -375,6 +381,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolSuccessfulPayoutInterval: 2 * 60 * 60, // 2 hours
       poolStatusNotificationInterval: 30 * 60, // 30 minutes
       poolRecentShareCutoff: 2 * 60 * 60, // 2 hours
+      poolPayoutPeriodDuration: 2 * 60 * 60, // 2 hours
       poolDiscordWebhook: '',
       poolMaxConnectionsPerIp: 0,
       poolLarkWebhook: '',

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -8,6 +8,7 @@ import { Assert } from '../assert'
 import { Config } from '../fileStores/config'
 import { Logger } from '../logger'
 import { Target } from '../primitives/target'
+import { Transaction } from '../primitives/transaction'
 import { RpcSocketClient } from '../rpc/clients'
 import { SerializedBlockTemplate } from '../serde/BlockTemplateSerde'
 import { BigIntUtils } from '../utils/bigint'
@@ -228,6 +229,7 @@ export class MiningPool {
     const eventLoopStartTime = new Date().getTime()
 
     await this.shares.rolloverPayoutPeriod()
+    await this.updateUnconfirmedBlocks()
 
     if (this.nextPayoutAttempt <= new Date().getTime()) {
       this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
@@ -307,6 +309,12 @@ export class MiningPool {
       if (result.content.added) {
         const hashRate = await this.estimateHashRate()
         const hashedHeaderHex = hashedHeader.toString('hex')
+
+        const minersFee = new Transaction(
+          Buffer.from(blockTemplate.transactions[0], 'hex'),
+        ).fee()
+
+        await this.shares.submitBlock(blockTemplate.header.sequence, hashedHeaderHex, minersFee)
 
         this.logger.info(
           `Block ${hashedHeaderHex} submitted successfully! ${FileUtils.formatHashRate(
@@ -534,5 +542,19 @@ export class MiningPool {
     }
 
     return status
+  }
+
+  async updateUnconfirmedBlocks(): Promise<void> {
+    const unconfirmedBlocks = await this.shares.unconfirmedBlocks()
+
+    for (const block of unconfirmedBlocks) {
+      const blockInfoResp = await this.rpc.getBlockInfo({
+        hash: block.blockHash,
+        confirmations: this.config.get('confirmations'),
+      })
+
+      const { main, confirmed } = blockInfoResp.content.metadata
+      await this.shares.updateBlockStatus(block, main, confirmed)
+    }
   }
 }

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -44,9 +44,6 @@ export class MiningPool {
 
   private eventLoopTimeout: SetTimeoutToken | null
 
-  private attemptPayoutInterval: number
-  private nextPayoutAttempt: number
-
   name: string
 
   nextMiningRequestId: number
@@ -99,9 +96,6 @@ export class MiningPool {
 
     this.eventLoopTimeout = null
 
-    this.attemptPayoutInterval = this.config.get('poolAttemptPayoutInterval')
-    this.nextPayoutAttempt = new Date().getTime()
-
     this.recalculateTargetInterval = null
     this.notifyStatusInterval = null
   }
@@ -114,7 +108,6 @@ export class MiningPool {
     enablePayouts?: boolean
     host: string
     port: number
-    balancePercentPayoutFlag?: number
     banning?: boolean
     enableTls?: boolean
     tlsOptions?: tls.TlsOptions
@@ -125,7 +118,6 @@ export class MiningPool {
       logger: options.logger,
       webhooks: options.webhooks,
       enablePayouts: options.enablePayouts,
-      balancePercentPayoutFlag: options.balancePercentPayoutFlag,
     })
 
     const pool = new MiningPool({
@@ -233,12 +225,6 @@ export class MiningPool {
     await this.updateUnconfirmedBlocks()
     await this.updateUnconfirmedPayoutTransactions()
     await this.shares.createNewPayout()
-
-    // TODO: Disable old payout logic, to be removed in next PR
-    // if (this.nextPayoutAttempt <= new Date().getTime()) {
-    //   this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
-    //   await this.shares.createPayout()
-    // }
 
     const eventLoopEndTime = new Date().getTime()
     const eventLoopDuration = eventLoopEndTime - eventLoopStartTime

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -232,11 +232,13 @@ export class MiningPool {
     await this.shares.rolloverPayoutPeriod()
     await this.updateUnconfirmedBlocks()
     await this.updateUnconfirmedPayoutTransactions()
+    await this.shares.createNewPayout()
 
-    if (this.nextPayoutAttempt <= new Date().getTime()) {
-      this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
-      await this.shares.createPayout()
-    }
+    // TODO: Disable old payout logic, to be removed in next PR
+    // if (this.nextPayoutAttempt <= new Date().getTime()) {
+    //   this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
+    //   await this.shares.createPayout()
+    // }
 
     const eventLoopEndTime = new Date().getTime()
     const eventLoopDuration = eventLoopEndTime - eventLoopStartTime

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -15,6 +15,7 @@ import { BigIntUtils } from '../utils/bigint'
 import { ErrorUtils } from '../utils/error'
 import { FileUtils } from '../utils/file'
 import { SetIntervalToken, SetTimeoutToken } from '../utils/types'
+import { TransactionStatus } from '../wallet'
 import { MiningPoolShares } from './poolShares'
 import { StratumTcpAdapter, StratumTlsAdapter } from './stratum/adapters'
 import { MiningStatusMessage } from './stratum/messages'
@@ -230,6 +231,7 @@ export class MiningPool {
 
     await this.shares.rolloverPayoutPeriod()
     await this.updateUnconfirmedBlocks()
+    await this.updateUnconfirmedPayoutTransactions()
 
     if (this.nextPayoutAttempt <= new Date().getTime()) {
       this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
@@ -555,6 +557,27 @@ export class MiningPool {
 
       const { main, confirmed } = blockInfoResp.content.metadata
       await this.shares.updateBlockStatus(block, main, confirmed)
+    }
+  }
+
+  async updateUnconfirmedPayoutTransactions(): Promise<void> {
+    const unconfirmedTransactions = await this.shares.unconfirmedPayoutTransactions()
+
+    for (const transaction of unconfirmedTransactions) {
+      const transactionInfoResp = await this.rpc.getAccountTransaction({
+        hash: transaction.transactionHash,
+        confirmations: this.config.get('confirmations'),
+      })
+
+      const transactionInfo = transactionInfoResp.content.transaction
+      if (!transactionInfo) {
+        this.logger.debug(`Transaction ${transaction.transactionHash} not found.`)
+        continue
+      }
+
+      const confirmed = transactionInfo.status === TransactionStatus.CONFIRMED
+      const expired = transactionInfo.status === TransactionStatus.EXPIRED
+      await this.shares.updatePayoutTransactionStatus(transaction, confirmed, expired)
     }
   }
 }

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -227,7 +227,9 @@ export class MiningPool {
 
     const eventLoopStartTime = new Date().getTime()
 
-    if (this.nextPayoutAttempt <= eventLoopStartTime) {
+    await this.shares.rolloverPayoutPeriod()
+
+    if (this.nextPayoutAttempt <= new Date().getTime()) {
       this.nextPayoutAttempt = new Date().getTime() + this.attemptPayoutInterval * 1000
       await this.shares.createPayout()
     }

--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Assert } from '../../assert'
 import { Config } from '../../fileStores'
 import { NodeFileProvider } from '../../fileSystems'
 import { createRootLogger } from '../../logger'
@@ -32,12 +34,29 @@ describe('poolDatabase', () => {
     await db.stop()
   })
 
-  // TODO(mat): This is an example, new tests will come with the refactor PRs
-  it('newShare', async () => {
-    const address = 'fakeAddress'
-    await db.newShare(address)
+  it('payout periods', async () => {
+    const payoutPeriod0 = await db.getCurrentPayoutPeriod()
+    expect(payoutPeriod0).toBeUndefined()
 
-    const shareCount = await db.getSharesCountForPayout(address)
-    expect(shareCount).toEqual(1)
+    const now = new Date().getTime()
+    await db.rolloverPayoutPeriod(now)
+
+    const payoutPeriod1 = await db.getCurrentPayoutPeriod()
+    Assert.isNotUndefined(payoutPeriod1, 'payoutPeriod1 should exist')
+    expect(payoutPeriod1.start).toEqual(now)
+
+    const nextTimestamp = now + 10
+    await db.rolloverPayoutPeriod(nextTimestamp)
+
+    const payoutPeriod2 = await db.getCurrentPayoutPeriod()
+    Assert.isNotUndefined(payoutPeriod2, 'payoutPeriod2 should exist')
+    expect(payoutPeriod2.start).toEqual(nextTimestamp)
+
+    const period1Raw = await db['db'].get(
+      'SELECT * FROM payoutPeriod WHERE id = ?',
+      payoutPeriod1.id,
+    )
+    Assert.isNotUndefined(period1Raw, 'period1Raw should exist')
+    expect(period1Raw.end).toEqual(payoutPeriod2.start - 1)
   })
 })

--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -234,6 +234,24 @@ describe('poolDatabase', () => {
       })
     })
 
+    it('shareCountSince', async () => {
+      const address1 = 'publicAddress1'
+      const address2 = 'publicAddress2'
+
+      const before = new Date().getTime() - 10 * 1000 // 10 seconds in the past
+
+      await db.newShare(address1)
+      await db.newShare(address2)
+
+      const after = new Date().getTime() + 10 * 1000 // 10 seconds in the future
+
+      await expect(db.shareCountSince(before)).resolves.toEqual(2)
+      await expect(db.shareCountSince(after)).resolves.toEqual(0)
+
+      await expect(db.shareCountSince(before, address1)).resolves.toEqual(1)
+      await expect(db.shareCountSince(after, address1)).resolves.toEqual(0)
+    })
+
     it('marks shares paid', async () => {
       const address = 'testPublicAddress'
 

--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -377,6 +377,33 @@ describe('poolDatabase', () => {
       expect(shareCount3).toEqual(3)
     })
 
+    it('pendingShareCount', async () => {
+      const payoutPeriod = await db.getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod)
+
+      const publicAddress1 = 'publicAddress1'
+      const publicAddress2 = 'publicAddress2'
+
+      // 1 share each that is paid out
+      await db.newShare(publicAddress1)
+      await db.newShare(publicAddress2)
+
+      await db.markSharesPaid(payoutPeriod.id, 1, [publicAddress1, publicAddress2])
+
+      // 1 share each that is not paid out
+      await db.newShare(publicAddress1)
+      await db.newShare(publicAddress2)
+
+      await db.rolloverPayoutPeriod(new Date().getTime() + 100)
+
+      // 1 share each that is not paid out in another payout period
+      await db.newShare(publicAddress1)
+      await db.newShare(publicAddress2)
+
+      await expect(db.pendingShareCount()).resolves.toEqual(4)
+      await expect(db.pendingShareCount(publicAddress1)).resolves.toEqual(2)
+    })
+
     it('getPayoutReward', async () => {
       const payoutPeriod1 = await db.getCurrentPayoutPeriod()
       Assert.isNotUndefined(payoutPeriod1)

--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { LogLevel } from 'consola'
 import { Assert } from '../../assert'
 import { Config } from '../../fileStores'
 import { NodeFileProvider } from '../../fileSystems'
@@ -15,6 +16,7 @@ describe('poolDatabase', () => {
 
   beforeEach(async () => {
     const logger = createRootLogger().withTag('test')
+    logger.level = LogLevel.Silent
     const dataDir = getUniqueTestDataDir()
     const fileSystem = new NodeFileProvider()
     await fileSystem.init()

--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Config } from '../../fileStores'
+import { NodeFileProvider } from '../../fileSystems'
+import { createRootLogger } from '../../logger'
+import { getUniqueTestDataDir } from '../../testUtilities/utils'
+import { PoolDatabase } from './database'
+
+describe('poolDatabase', () => {
+  let db: PoolDatabase
+
+  beforeEach(async () => {
+    const logger = createRootLogger().withTag('test')
+    const dataDir = getUniqueTestDataDir()
+    const fileSystem = new NodeFileProvider()
+    await fileSystem.init()
+    // TODO(mat): It would be convenient if we didn't need a filesystem for Config for tests
+    const config = new Config(fileSystem, dataDir)
+
+    db = await PoolDatabase.init({
+      config,
+      logger,
+      dbPath: ':memory:',
+    })
+
+    await db.start()
+  })
+
+  afterEach(async () => {
+    await db.stop()
+  })
+
+  // TODO(mat): This is an example, new tests will come with the refactor PRs
+  it('newShare', async () => {
+    const address = 'fakeAddress'
+    await db.newShare(address)
+
+    const shareCount = await db.getSharesCountForPayout(address)
+    expect(shareCount).toEqual(1)
+  })
+})

--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -310,6 +310,20 @@ describe('poolDatabase', () => {
       expect(unpaidShares[0].payoutTransactionId).toBeNull()
     })
 
+    it('deletes unpayable shares', async () => {
+      const payoutPeriod = await db.getCurrentPayoutPeriod()
+      Assert.isNotUndefined(payoutPeriod)
+
+      await db.newShare('publicAddress1')
+
+      // Sanity check
+      await expect(db.payoutPeriodShareCount(payoutPeriod.id)).resolves.toEqual(1)
+
+      await db.deleteUnpayableShares(payoutPeriod.id)
+
+      await expect(db.payoutPeriodShareCount(payoutPeriod.id)).resolves.toEqual(0)
+    })
+
     it('payoutAddresses', async () => {
       const address1 = 'testPublicAddress1'
       const address2 = 'testPublicAddress2'

--- a/ironfish/src/mining/poolDatabase/database.ts
+++ b/ironfish/src/mining/poolDatabase/database.ts
@@ -304,6 +304,22 @@ export class PoolDatabase {
     return result.count
   }
 
+  // Returns the shares that have not been paid out independent of payout period
+  async pendingShareCount(publicAddress?: string): Promise<number> {
+    let sql = 'SELECT COUNT(*) AS count FROM payoutShare WHERE payoutTransactionId IS NULL'
+
+    if (publicAddress) {
+      sql += ' AND publicAddress = ?'
+    }
+
+    const result = await this.db.get<{ count: number }>(sql, publicAddress)
+
+    if (result === undefined) {
+      return 0
+    }
+    return result.count
+  }
+
   // Returns the total payout reward for a specific payout period
   async getPayoutReward(payoutPeriodId: number): Promise<bigint> {
     const sql = `

--- a/ironfish/src/mining/poolDatabase/database.ts
+++ b/ironfish/src/mining/poolDatabase/database.ts
@@ -216,6 +216,10 @@ export class PoolDatabase {
     )
   }
 
+  async deleteUnpayableShares(payoutPeriodId: number): Promise<void> {
+    await this.db.run('DELETE FROM payoutShare WHERE payoutPeriodId = ?', payoutPeriodId)
+  }
+
   async earliestOutstandingPayoutPeriod(): Promise<DatabasePayoutPeriod | undefined> {
     const sql = `
       SELECT * FROM payoutPeriod WHERE id = (

--- a/ironfish/src/mining/poolDatabase/database.ts
+++ b/ironfish/src/mining/poolDatabase/database.ts
@@ -23,7 +23,11 @@ export class PoolDatabase {
     this.successfulPayoutInterval = this.config.get('poolSuccessfulPayoutInterval')
   }
 
-  static async init(options: { config: Config; logger: Logger }): Promise<PoolDatabase> {
+  static async init(options: {
+    config: Config
+    logger: Logger
+    dbPath?: string
+  }): Promise<PoolDatabase> {
     const fs = new NodeFileProvider()
     await fs.init()
 
@@ -31,7 +35,7 @@ export class PoolDatabase {
     await fs.mkdir(poolFolder, { recursive: true })
 
     const db = await open({
-      filename: fs.join(poolFolder, '/database.sqlite'),
+      filename: options.dbPath || fs.join(poolFolder, '/database.sqlite'),
       driver: sqlite3.Database,
     })
 

--- a/ironfish/src/mining/poolDatabase/index.ts
+++ b/ironfish/src/mining/poolDatabase/index.ts
@@ -2,5 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export { PoolDatabase, DatabaseShare } from './database'
+export { PoolDatabase } from './database'
 export { Migrator } from './migrator'

--- a/ironfish/src/mining/poolDatabase/migrations/005-add-payout-period-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/005-add-payout-period-table.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration005 extends Migration {
+  name = '005-add-payout-period-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE payoutPeriod (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        start INTEGER NOT NULL,
+        end INTEGER
+      );
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP TABLE IF EXISTS payoutPeriod;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/006-add-block-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/006-add-block-table.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration006 extends Migration {
+  name = '006-add-block-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE block (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        blockSequence INTEGER NOT NULL,
+        blockHash TEXT NOT NULL,
+        minerReward TEXT NOT NULL,
+        confirmed BOOLEAN DEFAULT FALSE,
+        main BOOLEAN DEFAULT TRUE,
+        payoutPeriodId INTEGER NOT NULL,
+        CONSTRAINT block_fk_payoutPeriodId FOREIGN KEY (payoutPeriodId) REFERENCES payoutPeriod (id)
+      );
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP TABLE IF EXISTS block;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/007-add-payout-transaction-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/007-add-payout-transaction-table.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration007 extends Migration {
+  name = '006-add-payout-transaction-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE payoutTransaction (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        transactionHash TEXT NOT NULL,
+        confirmed BOOLEAN DEFAULT FALSE,
+        expired BOOLEAN DEFAULT FALSE,
+        payoutPeriodId INTEGER NOT NULL,
+        CONSTRAINT payoutTransaction_fk_payoutPeriodId FOREIGN KEY (payoutPeriodId) REFERENCES payoutPeriod (id)
+      );
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP TABLE IF EXISTS payoutTransaction;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/007-add-payout-transaction-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/007-add-payout-transaction-table.ts
@@ -6,7 +6,7 @@ import { Database } from 'sqlite'
 import { Migration } from '../migration'
 
 export default class Migration007 extends Migration {
-  name = '006-add-payout-transaction-table'
+  name = '007-add-payout-transaction-table'
 
   async forward(db: Database): Promise<void> {
     await db.run(`

--- a/ironfish/src/mining/poolDatabase/migrations/008-add-payout-share-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/008-add-payout-share-table.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration008 extends Migration {
+  name = '006-add-payout-share-table'
+
+  async forward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE payoutShare (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        publicAddress TEXT NOT NULL,
+        payoutPeriodId INTEGER NOT NULL,
+        payoutTransactionId INTEGER,
+        CONSTRAINT payoutShare_fk_payoutPeriodId FOREIGN KEY (payoutPeriodId) REFERENCES payoutPeriod (id)
+        CONSTRAINT payoutShare_fk_payoutTransactionId FOREIGN KEY (payoutTransactionId) REFERENCES payoutTransaction (id)
+      );
+    `)
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run('DROP TABLE IF EXISTS payoutShare;')
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/008-add-payout-share-table.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/008-add-payout-share-table.ts
@@ -6,7 +6,7 @@ import { Database } from 'sqlite'
 import { Migration } from '../migration'
 
 export default class Migration008 extends Migration {
-  name = '006-add-payout-share-table'
+  name = '008-add-payout-share-table'
 
   async forward(db: Database): Promise<void> {
     await db.run(`

--- a/ironfish/src/mining/poolDatabase/migrations/009-remove-old-tables.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/009-remove-old-tables.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Database } from 'sqlite'
+import { Migration } from '../migration'
+
+export default class Migration009 extends Migration {
+  name = '009-remove-old-tables'
+
+  async forward(db: Database): Promise<void> {
+    await db.run('DROP INDEX IF EXISTS idx_share_public_address;')
+    await db.run('DROP INDEX IF EXISTS idx_share_created_at;')
+    await db.run('DROP TABLE IF EXISTS payout;')
+    await db.run('DROP TABLE IF EXISTS share;')
+  }
+
+  async backward(db: Database): Promise<void> {
+    await db.run(`
+      CREATE TABLE payout (
+        id INTEGER PRIMARY KEY,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        succeeded BOOLEAN DEFAULT FALSE,
+        transactionHash TEXT
+      );
+    `)
+
+    await db.run(`
+      CREATE TABLE share (
+        id INTEGER PRIMARY KEY,
+        publicAddress TEXT NOT NULL,
+        createdAt INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        payoutId INTEGER,
+        CONSTRAINT share_fk_payout_id FOREIGN KEY (payoutId) REFERENCES payout (id)
+      );
+    `)
+
+    await db.run(`CREATE INDEX idx_share_created_at ON share (createdAt);`)
+    await db.run(`CREATE INDEX idx_share_public_address ON share (publicAddress);`)
+  }
+}

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -8,6 +8,7 @@ import Migration003 from './003-add-transaction-hash'
 import Migration004 from './004-add-shares-address-index'
 import Migration005 from './005-add-payout-period-table'
 import Migration006 from './006-add-block-table'
+import Migration007 from './007-add-payout-transaction-table'
 
 export const MIGRATIONS = [
   Migration001,
@@ -16,4 +17,5 @@ export const MIGRATIONS = [
   Migration004,
   Migration005,
   Migration006,
+  Migration007,
 ]

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -5,5 +5,7 @@
 import Migration001 from './001-initial'
 import Migration002 from './002-add-shares-index'
 import Migration003 from './003-add-transaction-hash'
+import Migration004 from './004-add-shares-address-index'
+import Migration005 from './005-add-payout-period-table'
 
-export const MIGRATIONS = [Migration001, Migration002, Migration003]
+export const MIGRATIONS = [Migration001, Migration002, Migration003, Migration004, Migration005]

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -9,6 +9,7 @@ import Migration004 from './004-add-shares-address-index'
 import Migration005 from './005-add-payout-period-table'
 import Migration006 from './006-add-block-table'
 import Migration007 from './007-add-payout-transaction-table'
+import Migration008 from './008-add-payout-share-table'
 
 export const MIGRATIONS = [
   Migration001,
@@ -18,4 +19,5 @@ export const MIGRATIONS = [
   Migration005,
   Migration006,
   Migration007,
+  Migration008,
 ]

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -7,5 +7,13 @@ import Migration002 from './002-add-shares-index'
 import Migration003 from './003-add-transaction-hash'
 import Migration004 from './004-add-shares-address-index'
 import Migration005 from './005-add-payout-period-table'
+import Migration006 from './006-add-block-table'
 
-export const MIGRATIONS = [Migration001, Migration002, Migration003, Migration004, Migration005]
+export const MIGRATIONS = [
+  Migration001,
+  Migration002,
+  Migration003,
+  Migration004,
+  Migration005,
+  Migration006,
+]

--- a/ironfish/src/mining/poolDatabase/migrations/index.ts
+++ b/ironfish/src/mining/poolDatabase/migrations/index.ts
@@ -10,6 +10,7 @@ import Migration005 from './005-add-payout-period-table'
 import Migration006 from './006-add-block-table'
 import Migration007 from './007-add-payout-transaction-table'
 import Migration008 from './008-add-payout-share-table'
+import Migration009 from './009-remove-old-tables'
 
 export const MIGRATIONS = [
   Migration001,
@@ -20,4 +21,5 @@ export const MIGRATIONS = [
   Migration006,
   Migration007,
   Migration008,
+  Migration009,
 ]

--- a/ironfish/src/mining/poolDatabase/migrator.ts
+++ b/ironfish/src/mining/poolDatabase/migrator.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /* eslint-disable no-console */
+import { LogLevel } from 'consola'
 import { Database } from 'sqlite'
 import { Logger } from '../../logger'
 import { Migration } from './migration'
@@ -52,17 +53,17 @@ export class Migrator {
       this.logger.info('Running migrations:')
 
       for (const migration of unapplied) {
-        process.stdout.write(`  Applying ${migration.name}...`)
+        this.write(`  Applying ${migration.name}...`)
 
         try {
           await migration.forward(this.db)
           await this.db.run(`PRAGMA user_version = ${migration.id};`)
         } catch (e) {
-          process.stdout.write(` ERROR\n`)
+          this.write(` ERROR\n`)
           console.error(e)
           throw e
         }
-        process.stdout.write(` OK\n`)
+        this.write(` OK\n`)
       }
 
       await this.db.run('COMMIT;')
@@ -72,6 +73,12 @@ export class Migrator {
         /* do nothing */
       })
       throw e
+    }
+  }
+
+  write(output: string): void {
+    if (this.logger.level >= LogLevel.Info) {
+      process.stdout.write(output)
     }
   }
 }

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Assert } from '../assert'
 import { createRootLogger } from '../logger'
 import { createRouteTest } from '../testUtilities/routeTest'
 import { MiningPoolShares } from './poolShares'
@@ -26,12 +27,35 @@ describe('poolShares', () => {
     await shares.stop()
   })
 
-  // TODO(mat): This is an example, new tests will come with the refactor PRs
-  it('submitShare', async () => {
-    const address = 'fakeAddress'
-    await shares.submitShare(address)
+  it('rolloverPayoutPeriod', async () => {
+    jest.useFakeTimers({ legacyFakeTimers: false })
 
-    const shareCount = await shares.sharesPendingPayout(address)
-    expect(shareCount).toEqual(1)
+    const now = new Date(2020, 1, 1).getTime()
+    jest.setSystemTime(now)
+
+    const payoutPeriod0 = await shares['db'].getCurrentPayoutPeriod()
+    expect(payoutPeriod0).toBeUndefined()
+
+    await shares.rolloverPayoutPeriod()
+
+    const payoutPeriod1 = await shares['db'].getCurrentPayoutPeriod()
+    Assert.isNotUndefined(payoutPeriod1, 'payoutPeriod1 should exist')
+
+    // No time has elapsed, so it will not rollover
+    await shares.rolloverPayoutPeriod()
+
+    const payoutPeriod1A = await shares['db'].getCurrentPayoutPeriod()
+    expect(payoutPeriod1A).toEqual(payoutPeriod1)
+
+    // Move the clock forward the amount of time needed to trigger a new payout rollover
+    jest.setSystemTime(now + shares.config.get('poolPayoutPeriodDuration') * 1000)
+
+    await shares.rolloverPayoutPeriod()
+
+    const payoutPeriod2 = await shares['db'].getCurrentPayoutPeriod()
+    Assert.isNotUndefined(payoutPeriod2, 'payoutPeriod2 should exist')
+    expect(payoutPeriod2.id).toEqual(payoutPeriod1.id + 1)
+
+    jest.useRealTimers()
   })
 })

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -17,7 +17,7 @@ describe('poolShares', () => {
       rpc: routeTest.client,
       config: routeTest.sdk.config,
       logger: createRootLogger().withTag('test'),
-      enablePayouts: false,
+      enablePayouts: true,
       dbPath: ':memory:',
     })
 
@@ -26,6 +26,31 @@ describe('poolShares', () => {
 
   afterEach(async () => {
     await shares.stop()
+  })
+
+  it('shareRate', async () => {
+    jest.useFakeTimers({ legacyFakeTimers: false })
+
+    const now = new Date(2020, 1, 1).getTime()
+    jest.setSystemTime(now)
+
+    await shares.rolloverPayoutPeriod()
+
+    const publicAddress1 = 'publicAddress1'
+    const publicAddress2 = 'publicAddress2'
+
+    await shares.submitShare(publicAddress1)
+    await shares.submitShare(publicAddress2)
+
+    shares['recentShareCutoff'] = 2
+
+    const shareRate = await shares.shareRate()
+    const shareRateAddress = await shares.shareRate(publicAddress1)
+
+    expect(shareRate).toEqual(1)
+    expect(shareRateAddress).toEqual(0.5)
+
+    jest.useRealTimers()
   })
 
   it('rolloverPayoutPeriod', async () => {

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { createRootLogger } from '../logger'
+import { createRouteTest } from '../testUtilities/routeTest'
+import { MiningPoolShares } from './poolShares'
+
+describe('poolShares', () => {
+  const routeTest = createRouteTest()
+  let shares: MiningPoolShares
+
+  beforeEach(async () => {
+    shares = await MiningPoolShares.init({
+      rpc: routeTest.client,
+      config: routeTest.sdk.config,
+      logger: createRootLogger().withTag('test'),
+      enablePayouts: false,
+      dbPath: ':memory:',
+    })
+
+    await shares.start()
+  })
+
+  afterEach(async () => {
+    await shares.stop()
+  })
+
+  // TODO(mat): This is an example, new tests will come with the refactor PRs
+  it('submitShare', async () => {
+    const address = 'fakeAddress'
+    await shares.submitShare(address)
+
+    const shareCount = await shares.sharesPendingPayout(address)
+    expect(shareCount).toEqual(1)
+  })
+})

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Asset } from '@ironfish/rust-nodejs'
 import { Assert } from '../assert'
 import { createRootLogger } from '../logger'
 import { createRouteTest } from '../testUtilities/routeTest'
@@ -155,5 +156,87 @@ describe('poolShares', () => {
       const outstandingPeriod2 = await shares['db'].earliestOutstandingPayoutPeriod()
       expect(outstandingPeriod2).toBeDefined()
     })
+  })
+
+  it('createNewPayout', async () => {
+    jest.useFakeTimers({ legacyFakeTimers: false })
+
+    const now = new Date(2020, 1, 1).getTime()
+    jest.setSystemTime(now)
+
+    const publicAddress1 = 'testPublicAddress1'
+    const publicAddress2 = 'testPublicAddress2'
+
+    await shares.rolloverPayoutPeriod()
+
+    const payoutPeriod1 = await shares['db'].getCurrentPayoutPeriod()
+    Assert.isNotUndefined(payoutPeriod1)
+
+    // Setup some shares to be paid out
+    await shares.submitShare(publicAddress1)
+    await shares.submitShare(publicAddress2)
+    await shares.submitShare(publicAddress2)
+
+    // Setup a block for some reward to pay out
+    await shares.submitBlock(1, 'blockHash1', BigInt(102))
+    const blocks = await shares.unconfirmedBlocks()
+    expect(blocks.length).toEqual(1)
+    await shares.updateBlockStatus(blocks[0], true, true)
+
+    // Move the clock forward the amount of time needed to trigger a new payout rollover
+    jest.setSystemTime(now + shares.config.get('poolPayoutPeriodDuration') * 1000)
+
+    // Setup some shares to not be paid out since they are in a separate period
+    await shares.rolloverPayoutPeriod()
+    const payoutPeriod2 = await shares['db'].getCurrentPayoutPeriod()
+    Assert.isNotUndefined(payoutPeriod2)
+
+    await shares.submitShare(publicAddress1)
+    await shares.submitShare(publicAddress2)
+
+    const hasBalanceSpy = jest.spyOn(shares, 'hasConfirmedBalance').mockResolvedValueOnce(true)
+    const sendTransactionSpy = jest
+      .spyOn(shares, 'sendTransaction')
+      .mockResolvedValueOnce('testTransactionHash')
+
+    // Create payout
+    await shares.createNewPayout()
+
+    // The expected reward total breakdown should be as follows:
+    // - 1 period (to simplify the calculation, we're not including any past periods)
+    // - 1 block reward of 102
+    // - Since this block was found in this period, the total reward amount is 102 * 50% = 51
+    // - 2 recipients, so we subtract the naive fee of 1 ORE per recipient to
+    //    calculate the reward per share = 49
+    // - 3 shares total, so 48 / 3 = 16 reward per share (truncate decimals because ORE is indivisable)
+    // - 16 reward per share * 3 shares + fee of 2 = 50
+    expect(hasBalanceSpy).toHaveBeenCalledWith(BigInt(50))
+    const assetId = Asset.nativeId().toString('hex')
+    expect(sendTransactionSpy).toHaveBeenCalledWith([
+      // Address 1 had 1 share, with 16 reward per share = 16 amount
+      {
+        publicAddress: publicAddress1,
+        amount: '16',
+        memo: `Iron Fish Pool payout ${payoutPeriod1.id}`,
+        assetId,
+      },
+      // Address 2 had 2 shares, with 16 reward per share = 32 amount
+      {
+        publicAddress: publicAddress2,
+        amount: '32',
+        memo: `Iron Fish Pool payout ${payoutPeriod1.id}`,
+        assetId,
+      },
+    ])
+
+    const transactions = await shares.unconfirmedPayoutTransactions()
+    expect(transactions.length).toEqual(1)
+
+    await expect(shares['db'].payoutAddresses(payoutPeriod1.id)).resolves.toEqual([])
+
+    const unpaidShares = await shares['db'].payoutAddresses(payoutPeriod2.id)
+    expect(unpaidShares.length).toEqual(2)
+
+    jest.useRealTimers()
   })
 })

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Asset } from '@ironfish/rust-nodejs'
+import { LogLevel } from 'consola'
 import { Assert } from '../assert'
 import { createRootLogger } from '../logger'
 import { createRouteTest } from '../testUtilities/routeTest'
@@ -13,10 +14,12 @@ describe('poolShares', () => {
   let shares: MiningPoolShares
 
   beforeEach(async () => {
+    const logger = createRootLogger().withTag('test')
+    logger.level = LogLevel.Silent
     shares = await MiningPoolShares.init({
       rpc: routeTest.client,
       config: routeTest.sdk.config,
-      logger: createRootLogger().withTag('test'),
+      logger,
       enablePayouts: true,
       dbPath: ':memory:',
     })

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -9,7 +9,7 @@ import { ErrorUtils } from '../utils'
 import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
 import { DatabaseShare, PoolDatabase } from './poolDatabase'
-import { DatabaseBlock } from './poolDatabase/database'
+import { DatabaseBlock, DatabasePayoutTransaction } from './poolDatabase/database'
 import { WebhookNotifier } from './webhooks'
 
 export class MiningPoolShares {
@@ -260,5 +260,21 @@ export class MiningPoolShares {
     }
 
     await this.db.updateBlockStatus(block.id, main, confirmed)
+  }
+
+  async unconfirmedPayoutTransactions(): Promise<DatabasePayoutTransaction[]> {
+    return await this.db.unconfirmedTransactions()
+  }
+
+  async updatePayoutTransactionStatus(
+    transaction: DatabasePayoutTransaction,
+    confirmed: boolean,
+    expired: boolean,
+  ): Promise<void> {
+    if (confirmed === transaction.confirmed && expired === transaction.expired) {
+      return
+    }
+
+    await this.db.updateTransactionStatus(transaction.id, confirmed, expired)
   }
 }

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -221,4 +221,19 @@ export class MiningPoolShares {
   async sharesPendingPayout(publicAddress?: string): Promise<number> {
     return await this.db.getSharesCountForPayout(publicAddress)
   }
+
+  async rolloverPayoutPeriod(): Promise<void> {
+    const payoutPeriodDuration = this.config.get('poolPayoutPeriodDuration') * 1000
+    const now = new Date().getTime()
+    const payoutPeriodCutoff = now - payoutPeriodDuration
+
+    const payoutPeriod = await this.db.getCurrentPayoutPeriod()
+
+    if (payoutPeriod && payoutPeriod.start > payoutPeriodCutoff) {
+      // Current payout period has not exceeded its duration yet
+      return
+    }
+
+    await this.db.rolloverPayoutPeriod(now)
+  }
 }

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -276,5 +276,21 @@ export class MiningPoolShares {
     }
 
     await this.db.updateTransactionStatus(transaction.id, confirmed, expired)
+
+    if (expired && !confirmed) {
+      await this.db.markSharesUnpaid(transaction.id)
+    }
+  }
+
+  // TODO: This function is a rough shell, will be filled out with logic in follow-up PR
+  async createNewPayout(): Promise<void> {
+    const payoutPeriod = await this.db.earliestOutstandingPayoutPeriod()
+
+    if (!payoutPeriod) {
+      this.logger.debug('No outstanding shares, skipping payout')
+      return
+    }
+
+    // TODO: Rest of logic will go here
   }
 }

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -9,6 +9,7 @@ import { ErrorUtils } from '../utils'
 import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
 import { DatabaseShare, PoolDatabase } from './poolDatabase'
+import { DatabaseBlock } from './poolDatabase/database'
 import { WebhookNotifier } from './webhooks'
 
 export class MiningPoolShares {
@@ -235,5 +236,29 @@ export class MiningPoolShares {
     }
 
     await this.db.rolloverPayoutPeriod(now)
+  }
+
+  async submitBlock(sequence: number, hash: string, reward: bigint): Promise<void> {
+    if (reward < 0) {
+      reward *= BigInt(-1)
+    }
+
+    await this.db.newBlock(sequence, hash, reward.toString())
+  }
+
+  async unconfirmedBlocks(): Promise<DatabaseBlock[]> {
+    return await this.db.unconfirmedBlocks()
+  }
+
+  async updateBlockStatus(
+    block: DatabaseBlock,
+    main: boolean,
+    confirmed: boolean,
+  ): Promise<void> {
+    if (main === block.main && confirmed === block.confirmed) {
+      return
+    }
+
+    await this.db.updateBlockStatus(block.id, main, confirmed)
   }
 }

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -7,9 +7,7 @@ import { Config } from '../fileStores/config'
 import { Logger } from '../logger'
 import { RpcClient } from '../rpc/clients/client'
 import { CurrencyUtils, ErrorUtils } from '../utils'
-import { BigIntUtils } from '../utils/bigint'
-import { MapUtils } from '../utils/map'
-import { DatabaseShare, PoolDatabase } from './poolDatabase'
+import { PoolDatabase } from './poolDatabase'
 import { DatabaseBlock, DatabasePayoutTransaction } from './poolDatabase/database'
 import { WebhookNotifier } from './webhooks'
 
@@ -25,8 +23,6 @@ export class MiningPoolShares {
   private poolName: string
   private recentShareCutoff: number
   private accountName: string
-  private balancePercentPayout: bigint
-  private balancePercentPayoutFlag: number | undefined
 
   private constructor(options: {
     db: PoolDatabase
@@ -35,7 +31,6 @@ export class MiningPoolShares {
     logger: Logger
     webhooks?: WebhookNotifier[]
     enablePayouts?: boolean
-    balancePercentPayoutFlag?: number
   }) {
     this.db = options.db
     this.rpc = options.rpc
@@ -47,8 +42,6 @@ export class MiningPoolShares {
     this.poolName = this.config.get('poolName')
     this.recentShareCutoff = this.config.get('poolRecentShareCutoff')
     this.accountName = this.config.get('poolAccountName')
-    this.balancePercentPayout = BigInt(this.config.get('poolBalancePercentPayout'))
-    this.balancePercentPayoutFlag = options.balancePercentPayoutFlag
   }
 
   static async init(options: {
@@ -57,7 +50,6 @@ export class MiningPoolShares {
     logger: Logger
     webhooks?: WebhookNotifier[]
     enablePayouts?: boolean
-    balancePercentPayoutFlag?: number
     dbPath?: string
   }): Promise<MiningPoolShares> {
     const db = await PoolDatabase.init({
@@ -73,7 +65,6 @@ export class MiningPoolShares {
       logger: options.logger,
       webhooks: options.webhooks,
       enablePayouts: options.enablePayouts,
-      balancePercentPayoutFlag: options.balancePercentPayoutFlag,
     })
   }
 
@@ -89,135 +80,11 @@ export class MiningPoolShares {
     await this.db.newShare(publicAddress)
   }
 
-  async createPayout(): Promise<void> {
-    if (!this.enablePayouts) {
-      return
-    }
-
-    // TODO: Make a max payout amount per transaction
-    //   - its currently possible to have a payout include so many inputs that it expires before it
-    //     gets added to the mempool. suspect this would cause issues elsewhere
-    //  As a simple stop-gap, we could probably make payout interval = every x hours OR if confirmed balance > 200 or something
-    //  OR we could combine them, every x minutes, pay 10 inputs into 1 output?
-
-    // Since timestamps have a 1 second granularity, make the cutoff 1 second ago, just to avoid potential issues
-    const shareCutoff = new Date()
-    shareCutoff.setSeconds(shareCutoff.getSeconds() - 1)
-    const timestamp = Math.floor(shareCutoff.getTime() / 1000)
-
-    // Create a payout in the DB as a form of a lock
-    const payoutId = await this.db.newPayout(timestamp)
-    if (payoutId == null) {
-      this.logger.info(
-        'Another payout may be in progress or a payout was made too recently, skipping.',
-      )
-      return
-    }
-
-    const shares = await this.db.getSharesForPayout(timestamp)
-    const shareCounts = this.sumShares(shares)
-
-    if (shareCounts.totalShares === 0) {
-      this.logger.info('No shares submitted since last payout, skipping.')
-      return
-    }
-
-    const balance = await this.rpc.getAccountBalance({ account: this.accountName })
-    const confirmedBalance = BigInt(balance.content.confirmed)
-
-    let payoutAmount: number
-    if (this.balancePercentPayoutFlag !== undefined) {
-      payoutAmount = BigIntUtils.divide(
-        confirmedBalance * BigInt(this.balancePercentPayoutFlag),
-        100n,
-      )
-    } else {
-      payoutAmount = BigIntUtils.divide(confirmedBalance, this.balancePercentPayout)
-    }
-
-    if (payoutAmount <= shareCounts.totalShares + shareCounts.shares.size) {
-      // If the pool cannot pay out at least 1 ORE per share and pay transaction fees, no payout can be made.
-      this.logger.info('Insufficient funds for payout, skipping.')
-      return
-    }
-
-    const transactionReceives = MapUtils.map(
-      shareCounts.shares,
-      (shareCount, publicAddress) => {
-        const payoutPercentage = shareCount / shareCounts.totalShares
-        const amt = Math.floor(payoutPercentage * payoutAmount)
-
-        return {
-          publicAddress,
-          amount: amt.toString(),
-          memo: `${this.poolName} payout ${shareCutoff.toUTCString()}`,
-          assetId: Asset.nativeId().toString('hex'),
-        }
-      },
-    )
-
-    try {
-      this.logger.debug(
-        `Creating payout ${payoutId}, shares: ${shareCounts.totalShares}, outputs: ${transactionReceives.length}`,
-      )
-      this.webhooks.map((w) =>
-        w.poolPayoutStarted(payoutId, transactionReceives, shareCounts.totalShares),
-      )
-
-      const transaction = await this.rpc.sendTransaction({
-        fromAccountName: this.accountName,
-        outputs: transactionReceives,
-        fee: transactionReceives.length.toString(),
-      })
-
-      await this.db.markPayoutSuccess(payoutId, timestamp, transaction.content.hash)
-
-      this.logger.debug(`Payout ${payoutId} succeeded`)
-      this.webhooks.map((w) =>
-        w.poolPayoutSuccess(
-          payoutId,
-          transaction.content.hash,
-          transactionReceives,
-          shareCounts.totalShares,
-        ),
-      )
-    } catch (e) {
-      this.logger.error(`There was an error with the transaction ${ErrorUtils.renderError(e)}`)
-      this.webhooks.map((w) => w.poolPayoutError(e))
-    }
-  }
-
-  sumShares(shares: DatabaseShare[]): { totalShares: number; shares: Map<string, number> } {
-    let totalShares = 0
-    const shareMap = new Map<string, number>()
-
-    shares.forEach((share) => {
-      const address = share.publicAddress
-      const shareCount = shareMap.get(address)
-
-      if (shareCount != null) {
-        shareMap.set(address, shareCount + 1)
-      } else {
-        shareMap.set(address, 1)
-      }
-
-      totalShares += 1
-    })
-
-    return {
-      totalShares,
-      shares: shareMap,
-    }
-  }
-
   async shareRate(publicAddress?: string): Promise<number> {
-    return (await this.recentShareCount(publicAddress)) / this.recentShareCutoff
-  }
+    const timestamp = new Date().getTime() - this.recentShareCutoff * 1000
+    const recentShareCount = await this.db.shareCountSince(timestamp, publicAddress)
 
-  private async recentShareCount(publicAddress?: string): Promise<number> {
-    const timestamp = Math.floor(new Date().getTime() / 1000) - this.recentShareCutoff
-
-    return await this.db.shareCountSince(timestamp, publicAddress)
+    return recentShareCount / this.recentShareCutoff
   }
 
   async sharesPendingPayout(publicAddress?: string): Promise<number> {
@@ -284,6 +151,10 @@ export class MiningPoolShares {
   }
 
   async createNewPayout(): Promise<void> {
+    if (!this.enablePayouts) {
+      return
+    }
+
     // Get the earliest payout the has shares that have not yet been paid out
     const payoutPeriod = await this.db.earliestOutstandingPayoutPeriod()
     if (!payoutPeriod) {

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
+import { Assert } from '../assert'
 import { Config } from '../fileStores/config'
 import { Logger } from '../logger'
 import { RpcClient } from '../rpc/clients/client'
-import { ErrorUtils } from '../utils'
+import { CurrencyUtils, ErrorUtils } from '../utils'
 import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
 import { DatabaseShare, PoolDatabase } from './poolDatabase'
@@ -282,8 +283,8 @@ export class MiningPoolShares {
     }
   }
 
-  // TODO: This function is a rough shell, will be filled out with logic in follow-up PR
   async createNewPayout(): Promise<void> {
+    // Get the earliest payout the has shares that have not yet been paid out
     const payoutPeriod = await this.db.earliestOutstandingPayoutPeriod()
 
     if (!payoutPeriod) {
@@ -291,6 +292,101 @@ export class MiningPoolShares {
       return
     }
 
-    // TODO: Rest of logic will go here
+    // Ensure all of the blocks submitted during the related periods are
+    // confirmed so that we are not sending out payouts of incorrect or changing
+    // amounts
+    const blocksConfirmed = await this.db.payoutPeriodBlocksConfirmed(payoutPeriod.id)
+    if (!blocksConfirmed) {
+      return
+    }
+
+    // Get the batch of addresses to be paid out and their associated share count
+    const payoutAddresses = await this.db.payoutAddresses(payoutPeriod.id)
+
+    // Get the total amount earned during the payout (and associated previous payouts)
+    const totalPayoutReward = await this.db.getPayoutReward(payoutPeriod.id)
+
+    // Subtract the amount of recipients since that's how we estimate a
+    // transaction fee right now. If we move to use the fee estimator, we will
+    // need to update this logic as well.
+    // It is worth noting that this leads to slightly inconsistent payout
+    // amounts, since 1 payout may have 250 recipients and another may have 5,
+    // but considering 1 block reward is 2 billion ORE, it is a trivial
+    // difference.
+    const feeAmount = BigInt(payoutAddresses.length)
+    const totalPayoutAmount = totalPayoutReward - feeAmount
+
+    // Get the total amount of shares submitted during the period
+    const totalShareCount = await this.db.payoutPeriodShareCount(payoutPeriod.id)
+
+    // Get the amount that each share earned during this period
+    // (total reward - fee) / total share count
+    const amountPerShare = totalPayoutAmount / BigInt(totalShareCount)
+
+    // The total balance required to send this payout
+    // (total shares * amount per share) + fee
+    const totalRequired = amountPerShare * BigInt(totalShareCount) + feeAmount
+
+    // Sanity assertion to make sure the pool is not overpaying
+    Assert.isTrue(
+      totalPayoutReward >= totalRequired,
+      'Payout total must be less than the total reward amount',
+    )
+
+    const hasEnoughBalance = await this.hasConfirmedBalance(totalRequired)
+    if (!hasEnoughBalance) {
+      this.logger.info('Insufficient funds for payout, skipping.')
+      return
+    }
+
+    const assetId = Asset.nativeId().toString('hex')
+    const outputs = []
+    for (const payout of payoutAddresses) {
+      const amount = amountPerShare * BigInt(payout.shareCount)
+      outputs.push({
+        publicAddress: payout.publicAddress,
+        amount: CurrencyUtils.encode(amount),
+        memo: `${this.poolName} payout ${payoutPeriod.id}`,
+        assetId,
+      })
+    }
+
+    try {
+      const transactionHash = await this.sendTransaction(outputs)
+
+      const transactionId = await this.db.newTransaction(transactionHash, payoutPeriod.id)
+      Assert.isNotUndefined(transactionId)
+
+      const addressesPaidOut = payoutAddresses.map((p) => p.publicAddress)
+      await this.db.markSharesPaid(payoutPeriod.id, transactionId, addressesPaidOut)
+    } catch (e) {
+      this.logger.error(`There was an error with the transaction ${ErrorUtils.renderError(e)}`)
+      this.webhooks.map((w) => w.poolPayoutError(e))
+    }
+  }
+
+  async hasConfirmedBalance(amount: bigint): Promise<boolean> {
+    const balance = await this.rpc.getAccountBalance({ account: this.accountName })
+    const confirmedBalance = BigInt(balance.content.confirmed)
+
+    return confirmedBalance >= amount
+  }
+
+  async sendTransaction(
+    outputs: {
+      publicAddress: string
+      amount: string
+      memo: string
+      assetId: string
+    }[],
+  ): Promise<string> {
+    const transaction = await this.rpc.sendTransaction({
+      fromAccountName: this.accountName,
+      outputs,
+      fee: outputs.length.toString(),
+      expirationDelta: this.config.get('transactionExpirationDelta'),
+    })
+
+    return transaction.content.hash
   }
 }

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -179,6 +179,12 @@ export class MiningPoolShares {
     // Get the total amount earned during the payout (and associated previous payouts)
     const totalPayoutReward = await this.db.getPayoutReward(payoutPeriod.id)
 
+    if (totalPayoutReward === 0n) {
+      // The shares in this period cannot be paid out since no reward exists
+      await this.db.deleteUnpayableShares(payoutPeriod.id)
+      return
+    }
+
     // Subtract the amount of recipients since that's how we estimate a
     // transaction fee right now. If we move to use the fee estimator, we will
     // need to update this logic as well.

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -4,7 +4,7 @@
 import { Asset } from '@ironfish/rust-nodejs'
 import { Config } from '../fileStores/config'
 import { Logger } from '../logger'
-import { RpcSocketClient } from '../rpc/clients/socketClient'
+import { RpcClient } from '../rpc/clients/client'
 import { ErrorUtils } from '../utils'
 import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
@@ -12,7 +12,7 @@ import { DatabaseShare, PoolDatabase } from './poolDatabase'
 import { WebhookNotifier } from './webhooks'
 
 export class MiningPoolShares {
-  readonly rpc: RpcSocketClient
+  readonly rpc: RpcClient
   readonly config: Config
   readonly logger: Logger
   readonly webhooks: WebhookNotifier[]
@@ -28,7 +28,7 @@ export class MiningPoolShares {
 
   private constructor(options: {
     db: PoolDatabase
-    rpc: RpcSocketClient
+    rpc: RpcClient
     config: Config
     logger: Logger
     webhooks?: WebhookNotifier[]
@@ -50,16 +50,18 @@ export class MiningPoolShares {
   }
 
   static async init(options: {
-    rpc: RpcSocketClient
+    rpc: RpcClient
     config: Config
     logger: Logger
     webhooks?: WebhookNotifier[]
     enablePayouts?: boolean
     balancePercentPayoutFlag?: number
+    dbPath?: string
   }): Promise<MiningPoolShares> {
     const db = await PoolDatabase.init({
       config: options.config,
       logger: options.logger,
+      dbPath: options.dbPath,
     })
 
     return new MiningPoolShares({

--- a/ironfish/src/mining/webhooks/webhookNotifier.ts
+++ b/ironfish/src/mining/webhooks/webhookNotifier.ts
@@ -52,20 +52,20 @@ export abstract class WebhookNotifier {
   }
 
   poolPayoutSuccess(
-    payoutId: number,
+    payoutPeriodId: number,
     transactionHashHex: string,
     outputs: { publicAddress: string; amount: string; memo: string }[],
-    totalShareCount: number,
+    shareCount: number,
   ): void {
     const total = outputs.reduce((m, c) => BigInt(c.amount) + m, BigInt(0))
 
     this.sendText(
-      `Successfully created payout of ${totalShareCount} shares to ${
+      `Successfully created payout of ${shareCount} shares to ${
         outputs.length
       } users for ${CurrencyUtils.renderIron(total, true)} in transaction ${this.renderHashHex(
         transactionHashHex,
         this.explorerTransactionsUrl,
-      )}. Transaction pending (${payoutId})`,
+      )}. Transaction pending (${payoutPeriodId})`,
     )
   }
 
@@ -76,16 +76,16 @@ export abstract class WebhookNotifier {
   }
 
   poolPayoutStarted(
-    payoutId: number,
+    payoutPeriodId: number,
     outputs: { publicAddress: string; amount: string; memo: string }[],
-    totalShareCount: number,
+    shareCount: number,
   ): void {
     const total = outputs.reduce((m, c) => BigInt(c.amount) + m, BigInt(0))
 
     this.sendText(
-      `Creating payout of ${totalShareCount} shares to ${
+      `Creating payout of ${shareCount} shares to ${
         outputs.length
-      } users for ${CurrencyUtils.renderIron(total, true)} (${payoutId})`,
+      } users for ${CurrencyUtils.renderIron(total, true)} (${payoutPeriodId})`,
     )
   }
 


### PR DESCRIPTION
## Summary

The mining pool was at risk of creating transactions larger than the block size limit. We used this opportunity to refactor the logic so that it could handle batching payouts. This had a downstream effect of letting us improve the overall reliability of the mining pool.

New config option:
- `poolPayoutPeriodDuration`

Removed config options: 
- `poolBalancePercentPayout`
- `poolAttemptPayoutInterval`
- `poolSuccessfulPayoutInterval`

The pool now operates on a stricter 'payout period' concept. Every x minutes (default: 120 or 2 hours), a new payout period is created. Any blocks found or shares submitted during this time are part of that payout period. Once a payout period ends, and all of its associated blocks are confirmed, the pool will begin paying out in batches of 250 unique public addresses per transaction.

Pool rewards are now calculated as follows: 
For payout period x, the total amount of reward for that period is:
- 50% of all block rewards earned in payout period x
- 25% of all block rewards earned in the previous payout period, x-1
- 15% of all block rewards earned in the payout period x-2
- 10% of all block rewards earned in the payout period x-3

This means that a block reward is fully paid out over 4 payout periods. This is to incentivize miners to not switch between pools, and also to help alleviate periods of bad luck when the pool has found less blocks than average.

For now, the amount paid out is not configurable. However, `--no-payouts` still works to completely disable payouts.

The pool now also checks whether the blocks it has submitted are confirmed before trying to pay out any reward earned from them, as well as checking that any payout transactions that the pool makes are confirmed as well. If a transaction expires, it will attempt to payout those shares again.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
