### PR TITLE
adds backfill for unspentNoteHashes

### DIFF
--- a/ironfish/src/migrations/data/023-unspent-notes.ts
+++ b/ironfish/src/migrations/data/023-unspent-notes.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Logger } from '../../logger'
+import { IronfishNode } from '../../node'
+import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { Account } from '../../wallet'
+import { Migration } from '../migration'
+
+export class Migration020 extends Migration {
+  path = __filename
+
+  prepare(node: IronfishNode): IDatabase {
+    return node.wallet.walletDb.db
+  }
+
+  async forward(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const accounts = []
+
+    for await (const accountValue of node.wallet.walletDb.loadAccounts()) {
+      accounts.push(
+        new Account({
+          ...accountValue,
+          walletDb: node.wallet.walletDb,
+        }),
+      )
+    }
+
+    logger.info(`Indexing unspent notes for ${accounts.length} accounts`)
+
+    for (const account of accounts) {
+      let unspentNotes = 0
+
+      logger.info(` Indexing unspent notes for account ${account.name}`)
+      for await (const note of account.getNotes()) {
+        if (note.sequence === null || note.spent) {
+          continue
+        }
+
+        await node.wallet.walletDb.addUnspentNoteHash(account, note.hash, note)
+        unspentNotes++
+      }
+
+      logger.info(` Indexed ${unspentNotes} unspent notes for account ${account.name}`)
+    }
+  }
+
+  async backward(node: IronfishNode): Promise<void> {
+    await node.wallet.walletDb.unspentNoteHashes.clear()
+  }
+}

--- a/ironfish/src/migrations/data/023-unspent-notes.ts
+++ b/ironfish/src/migrations/data/023-unspent-notes.ts
@@ -5,6 +5,7 @@
 import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { createDB } from '../../storage/utils'
 import { Account } from '../../wallet'
 import { Migration } from '../migration'
 import { GetNewStores } from './023-unspent-notes/schemaNew'
@@ -14,7 +15,7 @@ export class Migration023 extends Migration {
   path = __filename
 
   prepare(node: IronfishNode): IDatabase {
-    return node.wallet.walletDb.db
+    return createDB({ location: node.config.walletDatabasePath })
   }
 
   async forward(

--- a/ironfish/src/migrations/data/023-unspent-notes.ts
+++ b/ironfish/src/migrations/data/023-unspent-notes.ts
@@ -8,7 +8,7 @@ import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { Account } from '../../wallet'
 import { Migration } from '../migration'
 
-export class Migration020 extends Migration {
+export class Migration023 extends Migration {
   path = __filename
 
   prepare(node: IronfishNode): IDatabase {

--- a/ironfish/src/migrations/data/023-unspent-notes/schemaNew.ts
+++ b/ironfish/src/migrations/data/023-unspent-notes/schemaNew.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  BigU64BEEncoding,
+  BufferEncoding,
+  IDatabase,
+  IDatabaseStore,
+  NULL_ENCODING,
+  PrefixEncoding,
+  U32_ENCODING_BE,
+} from '../../../storage'
+import { Account } from '../../../wallet'
+
+export function GetNewStores(db: IDatabase): {
+  unspentNoteHashes: IDatabaseStore<{
+    key: [Account['prefix'], [Buffer, [number, [bigint, Buffer]]]]
+    value: null
+  }>
+} {
+  const unspentNoteHashes: IDatabaseStore<{
+    key: [Account['prefix'], [Buffer, [number, [bigint, Buffer]]]]
+    value: null
+  }> = db.addStore({
+    name: 'un',
+    keyEncoding: new PrefixEncoding(
+      new BufferEncoding(), // account prefix
+      new PrefixEncoding(
+        new BufferEncoding(), // asset ID
+        new PrefixEncoding(
+          U32_ENCODING_BE, // sequence
+          new PrefixEncoding(
+            new BigU64BEEncoding(), // value
+            new BufferEncoding(), // note hash
+            8,
+          ),
+          4,
+        ),
+        32,
+      ),
+      4,
+    ),
+    valueEncoding: NULL_ENCODING,
+  })
+
+  return { unspentNoteHashes }
+}

--- a/ironfish/src/migrations/data/023-unspent-notes/schemaOld.ts
+++ b/ironfish/src/migrations/data/023-unspent-notes/schemaOld.ts
@@ -1,0 +1,234 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
+import { DECRYPTED_NOTE_LENGTH } from '@ironfish/rust-nodejs'
+import bufio from 'bufio'
+import { Note } from '../../../primitives/note'
+import { NoteEncryptedHash } from '../../../primitives/noteEncrypted'
+import {
+  BufferEncoding,
+  IDatabase,
+  IDatabaseEncoding,
+  IDatabaseStore,
+  PrefixEncoding,
+  StringEncoding,
+} from '../../../storage'
+import { Account } from '../../../wallet'
+
+const KEY_LENGTH = 32
+const VIEW_KEY_LENGTH = 64
+const VERSION_LENGTH = 2
+
+export interface AccountValue {
+  version: number
+  id: string
+  name: string
+  spendingKey: string
+  viewKey: string
+  incomingViewKey: string
+  outgoingViewKey: string
+  publicAddress: string
+}
+
+export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
+  serialize(value: AccountValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    bw.writeU16(value.version)
+    bw.writeVarString(value.id, 'utf8')
+    bw.writeVarString(value.name, 'utf8')
+    bw.writeBytes(Buffer.from(value.spendingKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.viewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): AccountValue {
+    const reader = bufio.read(buffer, true)
+    const version = reader.readU16()
+    const id = reader.readVarString('utf8')
+    const name = reader.readVarString('utf8')
+    const spendingKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
+    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+
+    return {
+      version,
+      id,
+      name,
+      spendingKey,
+      viewKey,
+      incomingViewKey,
+      outgoingViewKey,
+      publicAddress,
+    }
+  }
+
+  getSize(value: AccountValue): number {
+    let size = 0
+    size += VERSION_LENGTH
+    size += bufio.sizeVarString(value.id, 'utf8')
+    size += bufio.sizeVarString(value.name, 'utf8')
+    size += KEY_LENGTH
+    size += VIEW_KEY_LENGTH
+    size += KEY_LENGTH
+    size += KEY_LENGTH
+    size += PUBLIC_ADDRESS_LENGTH
+
+    return size
+  }
+}
+
+export interface DecryptedNoteValue {
+  accountId: string
+  note: Note
+  spent: boolean
+  transactionHash: Buffer
+  // These fields are populated once the note's transaction is on the main chain
+  index: number | null
+  nullifier: Buffer | null
+  blockHash: Buffer | null
+  sequence: number | null
+}
+
+export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNoteValue> {
+  serialize(value: DecryptedNoteValue): Buffer {
+    const { accountId, nullifier, index, note, spent, transactionHash, blockHash, sequence } =
+      value
+    const bw = bufio.write(this.getSize(value))
+
+    let flags = 0
+    flags |= Number(!!index) << 0
+    flags |= Number(!!nullifier) << 1
+    flags |= Number(spent) << 2
+    flags |= Number(!!blockHash) << 3
+    flags |= Number(!!sequence) << 4
+    bw.writeU8(flags)
+
+    bw.writeVarString(accountId, 'utf8')
+    bw.writeBytes(note.serialize())
+    bw.writeHash(transactionHash)
+
+    if (index) {
+      bw.writeU32(index)
+    }
+    if (nullifier) {
+      bw.writeHash(nullifier)
+    }
+    if (blockHash) {
+      bw.writeHash(blockHash)
+    }
+    if (sequence) {
+      bw.writeU32(sequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): DecryptedNoteValue {
+    const reader = bufio.read(buffer, true)
+
+    const flags = reader.readU8()
+    const hasIndex = flags & (1 << 0)
+    const hasNullifier = flags & (1 << 1)
+    const spent = Boolean(flags & (1 << 2))
+    const hasBlockHash = flags & (1 << 3)
+    const hasSequence = flags & (1 << 4)
+
+    const accountId = reader.readVarString('utf8')
+    const serializedNote = reader.readBytes(DECRYPTED_NOTE_LENGTH)
+    const transactionHash = reader.readHash()
+
+    let index = null
+    if (hasIndex) {
+      index = reader.readU32()
+    }
+
+    let nullifier = null
+    if (hasNullifier) {
+      nullifier = reader.readHash()
+    }
+
+    let blockHash = null
+    if (hasBlockHash) {
+      blockHash = reader.readHash()
+    }
+
+    let sequence = null
+    if (hasSequence) {
+      sequence = reader.readU32()
+    }
+
+    const note = new Note(serializedNote)
+
+    return {
+      accountId,
+      index,
+      nullifier,
+      note,
+      spent,
+      transactionHash,
+      blockHash,
+      sequence,
+    }
+  }
+
+  getSize(value: DecryptedNoteValue): number {
+    let size = 1
+    size += bufio.sizeVarString(value.accountId)
+    size += DECRYPTED_NOTE_LENGTH
+
+    // transaction hash
+    size += 32
+
+    if (value.index) {
+      size += 4
+    }
+
+    if (value.nullifier) {
+      size += 32
+    }
+
+    if (value.blockHash) {
+      size += 32
+    }
+
+    if (value.sequence) {
+      size += 4
+    }
+
+    return size
+  }
+}
+
+export function GetOldStores(db: IDatabase): {
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+  decryptedNotes: IDatabaseStore<{
+    key: [Account['prefix'], NoteEncryptedHash]
+    value: DecryptedNoteValue
+  }>
+} {
+  const accounts: IDatabaseStore<{ key: string; value: AccountValue }> = db.addStore(
+    {
+      name: 'a',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountValueEncoding(),
+    },
+    false,
+  )
+
+  const decryptedNotes: IDatabaseStore<{
+    key: [Account['prefix'], NoteEncryptedHash]
+    value: DecryptedNoteValue
+  }> = db.addStore({
+    name: 'd',
+    keyEncoding: new PrefixEncoding(new BufferEncoding(), new BufferEncoding(), 4),
+    valueEncoding: new DecryptedNoteValueEncoding(),
+  })
+
+  return { accounts, decryptedNotes }
+}

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -11,6 +11,7 @@ import { Migration019 } from './019-backfill-wallet-assets-from-chain'
 import { Migration020 } from './020-backfill-null-asset-supplies'
 import { Migration021 } from './021-add-version-to-accounts'
 import { Migration022 } from './022-add-view-key-account'
+import { Migration023 } from './023-unspent-notes'
 
 export const MIGRATIONS = [
   Migration014,
@@ -22,4 +23,5 @@ export const MIGRATIONS = [
   Migration020,
   Migration021,
   Migration022,
+  Migration023,
 ]

--- a/ironfish/src/storage/database/encoding.ts
+++ b/ironfish/src/storage/database/encoding.ts
@@ -172,7 +172,7 @@ export class BigIntLEEncoding implements IDatabaseEncoding<BigInt> {
   }
 }
 
-export class BigIntBEEncoding implements IDatabaseEncoding<BigInt> {
+export class BigU64BEEncoding implements IDatabaseEncoding<BigInt> {
   serialize(value: bigint): Buffer {
     const buffer = bufio.write(8)
     buffer.writeBigU64BE(value)

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -11,7 +11,7 @@ import { NoteEncryptedHash } from '../../primitives/noteEncrypted'
 import { Nullifier } from '../../primitives/nullifier'
 import { TransactionHash } from '../../primitives/transaction'
 import {
-  BigIntBEEncoding,
+  BigU64BEEncoding,
   BUFFER_ENCODING,
   BufferEncoding,
   IDatabase,
@@ -241,7 +241,7 @@ export class WalletDB {
           new PrefixEncoding(
             U32_ENCODING_BE, // sequence
             new PrefixEncoding(
-              new BigIntBEEncoding(), // value
+              new BigU64BEEncoding(), // value
               new BufferEncoding(), // note hash
               8,
             ),

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -35,7 +35,7 @@ import { HeadValue, NullableHeadValueEncoding } from './headValue'
 import { AccountsDBMeta, MetaValue, MetaValueEncoding } from './metaValue'
 import { TransactionValue, TransactionValueEncoding } from './transactionValue'
 
-const VERSION_DATABASE_ACCOUNTS = 22
+const VERSION_DATABASE_ACCOUNTS = 23
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountId: null,


### PR DESCRIPTION
## Summary

iterates over all notes for each account

if a note is on the chain and has not been spent the migration adds an entry to the unspentNoteHashes datastore

Depends on #3349 

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
