### PR TITLE
Make the default pool host ipv6 compatible

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -13,7 +13,7 @@ export const DEFAULT_DISCORD_INVITE = 'https://discord.ironfish.network'
 export const DEFAULT_USE_RPC_IPC = true
 export const DEFAULT_USE_RPC_TCP = false
 export const DEFAULT_USE_RPC_TLS = true
-export const DEFAULT_POOL_HOST = '0.0.0.0'
+export const DEFAULT_POOL_HOST = '::'
 export const DEFAULT_POOL_PORT = 9034
 export const DEFAULT_NETWORK_ID = 0
 


### PR DESCRIPTION
## Summary

By default if you listen on 0.0.0.0 then the node net server won't listen on the ipv6 adapter. IF you listen on :: which is the ipv6 equivilent it will set the net server in multi adapter mode and listen on both ipv6 and ipv4. If you want ipv6 only there is an extra parameter.

Read more, https://github.com/nodejs/node/issues/9390

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
