### PR TITLE
chore: refactor mnemonic return type

### DIFF
--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -80,7 +80,8 @@ pub fn generate_key() -> Key {
 #[napi]
 pub fn spending_key_to_words(private_key: String, language_code: LanguageCode) -> Result<String> {
     let key = SaplingKey::from_hex(&private_key).map_err(to_napi_err)?;
-    key.to_words(language_code.into()).map_err(to_napi_err)
+    let mnemonic = key.to_words(language_code.into()).map_err(to_napi_err)?;
+    Ok(mnemonic.into_phrase())
 }
 
 #[napi]

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -29,6 +29,7 @@ pub enum IronfishError {
     InvalidEntropy,
     InvalidLanguageEncoding,
     InvalidMinersFeeTransaction,
+    InvalidMnemonicString,
     InvalidNonceLength,
     InvalidPaymentAddress,
     InvalidPublicAddress,

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -185,16 +185,15 @@ impl SaplingKey {
     /// a seed. This isn't strictly necessary for private key, but view keys
     /// will need a direct mapping. The private key could still be generated
     /// using bip-32 and bip-39 if desired.
-    pub fn to_words(&self, language: Language) -> Result<String, IronfishError> {
-        let mnemonic = Mnemonic::from_entropy(&self.spending_key, language)
-            .map_err(|_| IronfishError::InvalidEntropy)?;
-        Ok(mnemonic.phrase().to_string())
+    pub fn to_words(&self, language: Language) -> Result<Mnemonic, IronfishError> {
+        Mnemonic::from_entropy(&self.spending_key, language)
+            .map_err(|_| IronfishError::InvalidEntropy)
     }
 
     /// Takes a bip-39 phrase as a string and turns it into a SaplingKey instance
     pub fn from_words(words: String, language: Language) -> Result<Self, IronfishError> {
         let mnemonic = Mnemonic::from_phrase(&words, language)
-            .map_err(|_| IronfishError::InvalidPaymentAddress)?;
+            .map_err(|_| IronfishError::InvalidMnemonicString)?;
         let bytes = mnemonic.entropy();
         let mut byte_arr = [0; SPEND_KEY_SIZE];
         byte_arr.clone_from_slice(&bytes[0..SPEND_KEY_SIZE]);

--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -123,9 +123,10 @@ fn test_from_and_to_words() {
 
     // Convert to words
     let key = SaplingKey::new(key_bytes).expect("Key should be created");
-    let words = key
+    let mnemonic = key
         .to_words(bip39::Language::English)
         .expect("Should return words");
+    let words = mnemonic.into_phrase();
     assert_eq!(words_for_bytes, words);
 
     // Convert from words


### PR DESCRIPTION
## Summary
Minor refactor to return mnemonic type rather than generic string
## Testing Plan
test pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
