### PR TITLE
fix(ironfish): Change asset supply truthy checks to be against null

### DIFF
--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -8,6 +8,7 @@ import { Migration016 } from './016-sequence-to-tx'
 import { Migration017 } from './017-sequence-encoding'
 import { Migration018 } from './018-backfill-wallet-assets'
 import { Migration019 } from './019-backfill-wallet-assets-from-chain'
+import { Migration020 } from './020-backfill-null-asset-supplies'
 
 export const MIGRATIONS = [
   Migration014,
@@ -16,4 +17,5 @@ export const MIGRATIONS = [
   Migration017,
   Migration018,
   Migration019,
+  Migration020,
 ]

--- a/ironfish/src/rpc/routes/wallet/getAssets.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.test.ts
@@ -55,7 +55,7 @@ describe('wallet/getAssets', () => {
         name: pendingAsset.name().toString('hex'),
         owner: account.publicAddress,
         status: AssetStatus.PENDING,
-        supply: undefined,
+        supply: BigInt(0),
       },
       {
         createdTransactionHash: mintBlock.transactions[1].hash().toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/getAssets.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.test.ts
@@ -55,7 +55,7 @@ describe('wallet/getAssets', () => {
         name: pendingAsset.name().toString('hex'),
         owner: account.publicAddress,
         status: AssetStatus.PENDING,
-        supply: BigInt(0),
+        supply: '0',
       },
       {
         createdTransactionHash: mintBlock.transactions[1].hash().toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/getAssets.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.ts
@@ -61,7 +61,7 @@ router.register<typeof GetAssetsRequestSchema, GetAssetsResponse>(
         status: await node.wallet.getAssetStatus(account, asset, {
           confirmations: request.data.confirmations,
         }),
-        supply: asset.supply ? CurrencyUtils.encode(asset.supply) : undefined,
+        supply: asset.supply !== null ? CurrencyUtils.encode(asset.supply) : undefined,
       })
     }
 

--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -609,7 +609,7 @@ describe('Accounts', () => {
         name: asset.name(),
         owner: asset.owner(),
         sequence: null,
-        supply: null,
+        supply: BigInt(0),
       })
 
       const secondMintValue = BigInt(42)
@@ -966,7 +966,7 @@ describe('Accounts', () => {
         name: asset.name(),
         owner: asset.owner(),
         sequence: null,
-        supply: null,
+        supply: BigInt(0),
       })
 
       // Expiration of the first mint will delete the record

--- a/ironfish/src/wallet/walletdb/assetValue.ts
+++ b/ironfish/src/wallet/walletdb/assetValue.ts
@@ -32,7 +32,7 @@ export class AssetValueEncoding implements IDatabaseEncoding<AssetValue> {
     let flags = 0
     flags |= Number(!!value.blockHash) << 0
     flags |= Number(!!value.sequence) << 1
-    flags |= Number(!!value.supply) << 2
+    flags |= Number(value.supply !== null) << 2
     bw.writeU8(flags)
 
     if (value.blockHash) {
@@ -43,7 +43,7 @@ export class AssetValueEncoding implements IDatabaseEncoding<AssetValue> {
       bw.writeU32(value.sequence)
     }
 
-    if (value.supply) {
+    if (value.supply !== null) {
       bw.writeVarBytes(BigIntUtils.toBytesLE(value.supply))
     }
 
@@ -98,7 +98,7 @@ export class AssetValueEncoding implements IDatabaseEncoding<AssetValue> {
       size += 4
     }
 
-    if (value.supply) {
+    if (value.supply !== null) {
       size += bufio.sizeVarBytes(BigIntUtils.toBytesLE(value.supply))
     }
 

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -34,7 +34,7 @@ import { HeadValue, NullableHeadValueEncoding } from './headValue'
 import { AccountsDBMeta, MetaValue, MetaValueEncoding } from './metaValue'
 import { TransactionValue, TransactionValueEncoding } from './transactionValue'
 
-export const VERSION_DATABASE_ACCOUNTS = 19
+export const VERSION_DATABASE_ACCOUNTS = 20
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountId: null,


### PR DESCRIPTION
## Summary

We found in the v0.1.66 release that users were running into null supply assertions crashing the wallet. This happened if an asset an account owns had 0 supply. The most common way this occurred was if a user burned their entire supply from previous mints.

Our asset value encoding was treating 0 as a nil value which later triggered that exception. 

This code change:
* Updates the encoding to properly check against null
* Adds a migration which clears assets the account owns and re-syncs from mints and burns
* Clears out assets from the original backfill in case that was failing

## Testing Plan

Ran against corrupted database and now working

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
