### PR TITLE
Show mint asset name in human readable form

### DIFF
--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
+  BufferUtils,
   CreateTransactionRequest,
   CreateTransactionResponse,
   CurrencyUtils,
@@ -319,7 +320,7 @@ ${amountString} plus a transaction fee of ${feeString} with the account ${accoun
       const minted = transaction.mints[0]
 
       this.log(`
-Minted asset ${minted.asset.name().toString('hex')} from ${account}
+Minted asset ${BufferUtils.toHuman(minted.asset.name())} from ${account}
 Asset Identifier: ${minted.asset.id().toString('hex')}
 Value: ${CurrencyUtils.renderIron(minted.value, true, minted.asset.id().toString('hex'))}
 


### PR DESCRIPTION
## Summary
Fix https://github.com/iron-fish/ironfish/issues/3386. Show mint asset name in human readable form.

## Testing Plan
Run `wallet:mint` and check format of asset name.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
