### PR TITLE
Add note.hash()

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -91,7 +91,11 @@ export class NoteEncrypted {
   constructor(jsBytes: Buffer)
   serialize(): Buffer
   equals(other: NoteEncrypted): boolean
-  merkleHash(): Buffer
+  /**
+   * The commitment hash of the note
+   * This hash is what gets used for the leaf nodes in a Merkle Tree.
+   */
+  hash(): Buffer
   /**
    * Hash two child hashes together to calculate the hash of the
    * new parent
@@ -107,6 +111,11 @@ export class Note {
   constructor(owner: string, value: bigint, memo: string, assetId: Buffer, sender: string)
   static deserialize(jsBytes: Buffer): NativeNote
   serialize(): Buffer
+  /**
+   * The commitment hash of the note
+   * This hash is what gets used for the leaf nodes in a Merkle Tree.
+   */
+  hash(): Buffer
   /** Value this note represents. */
   value(): bigint
   /**

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -99,6 +99,13 @@ impl NativeNote {
         Ok(Buffer::from(arr))
     }
 
+    /// The commitment hash of the note
+    /// This hash is what gets used for the leaf nodes in a Merkle Tree.
+    #[napi]
+    pub fn hash(&self) -> Buffer {
+        Buffer::from(&self.note.commitment()[..])
+    }
+
     /// Value this note represents.
     #[napi]
     pub fn value(&self) -> u64 {

--- a/ironfish-rust-nodejs/src/structs/note_encrypted.rs
+++ b/ironfish-rust-nodejs/src/structs/note_encrypted.rs
@@ -63,8 +63,10 @@ impl NativeNoteEncrypted {
         self.note.eq(&other.note)
     }
 
+    /// The commitment hash of the note
+    /// This hash is what gets used for the leaf nodes in a Merkle Tree.
     #[napi]
-    pub fn merkle_hash(&self) -> Result<Buffer> {
+    pub fn hash(&self) -> Result<Buffer> {
         let mut vec: Vec<u8> = Vec::with_capacity(32);
         self.note
             .merkle_hash()

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -66,7 +66,7 @@ describe('Demonstrate the Sapling API', () => {
     expect(postedTransaction.verify()).toBe(true)
 
     const encryptedNote = new NoteEncrypted(postedTransaction.getNote(0))
-    expect(encryptedNote.merkleHash().byteLength).toBe(32)
+    expect(encryptedNote.hash().byteLength).toBe(32)
     expect(encryptedNote.equals(encryptedNote)).toBe(true)
 
     const decryptedNoteBuffer = encryptedNote.decryptNoteForOwner(key.incoming_view_key)
@@ -100,7 +100,7 @@ describe('Demonstrate the Sapling API', () => {
     const decryptedNote = Note.deserialize(encryptedNote.decryptNoteForOwner(key.incoming_view_key)!)
     const newNote = new Note(recipientKey.public_address, BigInt(15), 'receive', Asset.nativeId(), minersFeeNote.owner())
 
-    let currentHash = encryptedNote.merkleHash()
+    let currentHash = encryptedNote.hash()
     let authPath = Array.from({ length: 32 }, (_, depth) => {
       const tempHash = currentHash
       const witnessNode = {

--- a/ironfish/src/primitives/__fixtures__/note.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/note.test.ts.fixture
@@ -1,0 +1,38 @@
+{
+  "Note should post": [
+    {
+      "id": "9e8fa3cc-e071-47bc-b633-4ed634d27173",
+      "name": "test",
+      "spendingKey": "a8e97ef506cd750a7d29cc849161b0c98b79cb396df7b040eca2dd5d361dc37b",
+      "incomingViewKey": "4e8f0954a08e363b04322652fb1bc4f88923c579cecabae7236fdd94a4603006",
+      "outgoingViewKey": "12a2777a88d02c9214b069a3d32f87d82bf0302ccf9281fb4f313a5c33fa16b6",
+      "publicAddress": "edddea968cb3aefdd98cfb7c79e2ac373ce996c455fb4cf1aa6bc1a8d69602ca"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Io4HVIP9JI9UEMvjfdOdiHzJnzLyZzhl2nx5PLhRbkM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:+R4nZTSiNHRzvlKTsFY60ExGnbAHAsl0GnIZktua0MM="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676308908327,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA63B1kqcM3ehyw9TxqVk91GWNRsYX81ubnsMBAIbQ7bukQBdvwx+uAIec+HJy5mup7MKXxm03J9wtSAo28E5rNe7iM1hbGaPAZU1RwFbrE3izuPfEN1fjWoyXvZHG1vzlTI3ic9j7jcD9q4lCziO6NBfuATB5Eleg3k7KBF3YzHAVVSOv34atVUMLu9zCIXz3rN3KyHr9hEiq6heXnPUK/zQCvMdQydt3No2ACsGJw8SiC2CSkqCiGvkt+6VAM5XX8xv7KEypR9b01mRPLLygVD65hKvYPVYl1ncCNa2SnBc3QnZR4RYN11+P9Yx2diIhEqLuM//0tiqICgK95X43IqJ1N32fmwZgB8F/gw04iWI5Zr6NnY2LNLiCM6bDvoc857mMKNbxWL9o+jjnVN1hxH4coAFnWyX2tc2e4HOIclOUWZU9vpdxqqZPlFauX1TI1dtIySfBbJ7bnbYWqOz1zfWYvYYVXZtXSUdfATjt4mxEPkq6bOmwjHEnRP+cJ0Z5sbTJgYTCb0KcPoVNoTNAb0bo/1QNOFoo56pIBriGlk8IgyHD49AZG36wK13sM0VHiH45YpJz3MI8rmzMtCAUdPjvuwL1hDjbxSwEX71fjxsTQ1zrTdYcTUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwb+XkBVc6Hq/HmX4DWNmWAi2IZltUKBimGIKRRWi6m96Os1Cj3iKjpwyZ0Oc1dII+bWg2o5QrIkdBxLoHLjerBg=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/primitives/note.test.ts
+++ b/ironfish/src/primitives/note.test.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../assert'
+import { useAccountFixture, useMinerBlockFixture } from '../testUtilities/fixtures'
+import { createNodeTest } from '../testUtilities/nodeTest'
+
+describe('Note', () => {
+  const nodeTest = createNodeTest()
+
+  it('should post', async () => {
+    const account = await useAccountFixture(nodeTest.wallet)
+    const block = await useMinerBlockFixture(nodeTest.chain, undefined, account)
+
+    const encrypted = block.minersFee.notes[0]
+    const decrypted = encrypted.decryptNoteForOwner(account.incomingViewKey)
+
+    Assert.isNotUndefined(decrypted)
+    expect(encrypted.hash().equals(decrypted.hash())).toBe(true)
+  })
+})

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -11,6 +11,7 @@ import {
 } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
 import { BufferUtils } from '../utils/buffer'
+import { NoteEncryptedHash } from './noteEncrypted'
 
 export class Note {
   private readonly noteSerialized: Buffer
@@ -60,6 +61,12 @@ export class Note {
       this.referenceCount = 0
       this.note = null
     }
+  }
+
+  hash(): NoteEncryptedHash {
+    const hash = this.takeReference().hash()
+    this.returnReference()
+    return hash
   }
 
   value(): bigint {


### PR DESCRIPTION
## Summary

This PR exposes the ability to get the hash from a decrypted note. It also exposes hash() in the JS side for both encrypted and decrypted notes but renaming merkle_hash() to hash().

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
