### PR TITLE
Fix 'Already have a WebSocket connection' message

### DIFF
--- a/ironfish/src/network/messages/peerList.ts
+++ b/ironfish/src/network/messages/peerList.ts
@@ -7,7 +7,7 @@ import { identityLength } from '../identity'
 import { NetworkMessageType } from '../types'
 import { NetworkMessage } from './networkMessage'
 
-interface Peer {
+export interface Peer {
   identity: Buffer
   name?: string
   address: string | null

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -171,6 +171,11 @@ export class Peer {
   /** how many outbound connections does the peer have */
   pendingRPC = 0
 
+  /**
+   * True if the peer is a known honest peer.
+   */
+  isWhitelisted = false
+
   shouldLogMessages = false
 
   loggedMessages: Array<LoggedMessage> = []

--- a/ironfish/src/network/peers/peerCandidates.ts
+++ b/ironfish/src/network/peers/peerCandidates.ts
@@ -1,13 +1,17 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ArrayUtils } from '../../utils/array'
+import { Identity } from '../identity'
+import { Peer as PeerListPeer } from '../messages/peerList'
 import { ConnectionRetry } from './connectionRetry'
+import { Peer } from './peer'
 
 export type PeerCandidate = {
   name?: string
   address: string | null
   port: number | null
-  neighbors: Set<string>
+  neighbors: Set<Identity>
   webRtcRetry: ConnectionRetry
   websocketRetry: ConnectionRetry
   /**
@@ -23,13 +27,68 @@ export type PeerCandidate = {
 }
 
 export class PeerCandidates {
-  map: Map<string, PeerCandidate> = new Map()
+  private readonly map: Map<Identity, PeerCandidate> = new Map()
 
-  get(identity: string): PeerCandidate | undefined {
+  get size(): number {
+    return this.map.size
+  }
+
+  addFromPeer(peer: Peer, neighbors = new Set<Identity>()): void {
+    const address = peer.getWebSocketAddress()
+    const addressPeerCandidate = this.map.get(address)
+    const newPeerCandidate = {
+      address: peer.address,
+      port: peer.port,
+      neighbors,
+      webRtcRetry: new ConnectionRetry(peer.isWhitelisted),
+      websocketRetry: new ConnectionRetry(peer.isWhitelisted),
+      localRequestedDisconnectUntil: null,
+      peerRequestedDisconnectUntil: null,
+    }
+
+    if (peer.state.identity !== null) {
+      if (addressPeerCandidate) {
+        this.map.delete(address)
+      }
+
+      if (!this.map.has(peer.state.identity)) {
+        this.map.set(peer.state.identity, addressPeerCandidate ?? newPeerCandidate)
+      }
+    } else if (!addressPeerCandidate) {
+      this.map.set(address, newPeerCandidate)
+    }
+  }
+
+  addFromPeerList(sendingPeerIdentity: Identity, peer: PeerListPeer): void {
+    const peerIdentity = peer.identity.toString('base64')
+    const peerCandidateValue = this.map.get(peerIdentity)
+
+    if (peerCandidateValue) {
+      peerCandidateValue.neighbors.add(sendingPeerIdentity)
+    } else {
+      const tempPeer = new Peer(peerIdentity)
+      tempPeer.setWebSocketAddress(peer.address, peer.port)
+      this.addFromPeer(tempPeer, new Set([sendingPeerIdentity]))
+    }
+  }
+
+  shufflePeerCandidates(): string[] {
+    return ArrayUtils.shuffle([...this.map.keys()])
+  }
+
+  get(identity: Identity): PeerCandidate | undefined {
     return this.map.get(identity)
   }
 
-  set(identity: string, value: PeerCandidate): void {
+  has(identity: Identity): boolean {
+    return this.map.has(identity)
+  }
+
+  private set(identity: Identity, value: PeerCandidate): void {
     this.map.set(identity, value)
+  }
+
+  clear(): void {
+    this.map.clear()
   }
 }

--- a/ironfish/src/network/peers/peerCandidates.ts
+++ b/ironfish/src/network/peers/peerCandidates.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ConnectionRetry } from './connectionRetry'
+
+export type PeerCandidate = {
+  name?: string
+  address: string | null
+  port: number | null
+  neighbors: Set<string>
+  webRtcRetry: ConnectionRetry
+  websocketRetry: ConnectionRetry
+  /**
+   * UTC timestamp. If set, the peer manager should not initiate connections to the
+   * Peer until after the timestamp.
+   */
+  peerRequestedDisconnectUntil: number | null
+  /**
+   * UTC timestamp. If set, the peer manager should not accept connections from the
+   * Peer until after the timestamp.
+   */
+  localRequestedDisconnectUntil: number | null
+}
+
+export class PeerCandidates {
+  map: Map<string, PeerCandidate> = new Map()
+
+  get(identity: string): PeerCandidate | undefined {
+    return this.map.get(identity)
+  }
+
+  set(identity: string, value: PeerCandidate): void {
+    this.map.set(identity, value)
+  }
+}

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -14,7 +14,6 @@ import {
   webRtcCanInitiateIdentity,
   webRtcLocalIdentity,
 } from '../testUtilities'
-import { ConnectionRetry } from './connectionRetry'
 import {
   ConnectionDirection,
   ConnectionType,
@@ -46,15 +45,7 @@ describe('connectToDisconnectedPeers', () => {
     peer.setWebSocketAddress('testuri.com', 9033)
     pm['tryDisposePeer'](peer)
 
-    pm.peerCandidates.set(peer.getWebSocketAddress(), {
-      address: 'testuri.com',
-      port: 9033,
-      neighbors: new Set(),
-      webRtcRetry: new ConnectionRetry(),
-      websocketRetry: new ConnectionRetry(),
-      localRequestedDisconnectUntil: null,
-      peerRequestedDisconnectUntil: null,
-    })
+    pm.peerCandidates.addFromPeer(peer)
 
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
     pcm.start()
@@ -72,15 +63,11 @@ describe('connectToDisconnectedPeers', () => {
     const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
     const identity = mockIdentity('peer')
-    pm.peerCandidates.set(identity, {
-      address: 'testuri.com',
-      port: 9033,
-      neighbors: new Set(),
-      webRtcRetry: new ConnectionRetry(),
-      websocketRetry: new ConnectionRetry(),
-      localRequestedDisconnectUntil: null,
-      peerRequestedDisconnectUntil: null,
-    })
+    const peer = pm.getOrCreatePeer(identity)
+    peer.setWebSocketAddress('testuri.com', 9033)
+    pm['tryDisposePeer'](peer)
+
+    pm.peerCandidates.addFromPeer(peer)
 
     // We want to test websocket only
     const retry = pm.getConnectionRetry(
@@ -106,15 +93,11 @@ describe('connectToDisconnectedPeers', () => {
     const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
 
     const identity = mockIdentity('peer')
-    peers.peerCandidates.set(identity, {
-      address: 'testuri.com',
-      port: 9033,
-      neighbors: new Set(),
-      webRtcRetry: new ConnectionRetry(),
-      websocketRetry: new ConnectionRetry(),
-      localRequestedDisconnectUntil: null,
-      peerRequestedDisconnectUntil: null,
-    })
+    const createdPeer = peers.getOrCreatePeer(identity)
+    createdPeer.setWebSocketAddress('testuri.com', 9033)
+    peers['tryDisposePeer'](createdPeer)
+
+    peers.peerCandidates.addFromPeer(createdPeer)
 
     const peerConnections = new PeerConnectionManager(peers, createRootLogger(), {
       maxPeers: 50,
@@ -141,23 +124,15 @@ describe('connectToDisconnectedPeers', () => {
     )
     const { peer: brokeringPeer } = getConnectedPeer(pm, 'brokering')
     // Link the peers
-    pm.peerCandidates.set(brokeringPeer.getIdentityOrThrow(), {
+    pm.peerCandidates.addFromPeerList(brokeringPeer.getIdentityOrThrow(), {
       address: null,
       port: null,
-      neighbors: new Set([peerIdentity]),
-      webRtcRetry: new ConnectionRetry(),
-      websocketRetry: new ConnectionRetry(),
-      localRequestedDisconnectUntil: null,
-      peerRequestedDisconnectUntil: null,
+      identity: Buffer.from(peerIdentity, 'base64'),
     })
-    pm.peerCandidates.set(peerIdentity, {
+    pm.peerCandidates.addFromPeerList(peerIdentity, {
       address: null,
       port: null,
-      neighbors: new Set([brokeringPeer.getIdentityOrThrow()]),
-      webRtcRetry: new ConnectionRetry(),
-      websocketRetry: new ConnectionRetry(),
-      localRequestedDisconnectUntil: null,
-      peerRequestedDisconnectUntil: null,
+      identity: Buffer.from(brokeringPeer.getIdentityOrThrow(), 'base64'),
     })
 
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -46,7 +46,7 @@ describe('connectToDisconnectedPeers', () => {
     peer.setWebSocketAddress('testuri.com', 9033)
     pm['tryDisposePeer'](peer)
 
-    pm.peerCandidateMap.set(peer.getWebSocketAddress(), {
+    pm.peerCandidates.set(peer.getWebSocketAddress(), {
       address: 'testuri.com',
       port: 9033,
       neighbors: new Set(),
@@ -72,7 +72,7 @@ describe('connectToDisconnectedPeers', () => {
     const pm = new PeerManager(mockLocalPeer(), mockHostsStore())
 
     const identity = mockIdentity('peer')
-    pm.peerCandidateMap.set(identity, {
+    pm.peerCandidates.set(identity, {
       address: 'testuri.com',
       port: 9033,
       neighbors: new Set(),
@@ -106,7 +106,7 @@ describe('connectToDisconnectedPeers', () => {
     const peers = new PeerManager(mockLocalPeer(), mockHostsStore())
 
     const identity = mockIdentity('peer')
-    peers.peerCandidateMap.set(identity, {
+    peers.peerCandidates.set(identity, {
       address: 'testuri.com',
       port: 9033,
       neighbors: new Set(),
@@ -141,7 +141,7 @@ describe('connectToDisconnectedPeers', () => {
     )
     const { peer: brokeringPeer } = getConnectedPeer(pm, 'brokering')
     // Link the peers
-    pm.peerCandidateMap.set(brokeringPeer.getIdentityOrThrow(), {
+    pm.peerCandidates.set(brokeringPeer.getIdentityOrThrow(), {
       address: null,
       port: null,
       neighbors: new Set([peerIdentity]),
@@ -150,7 +150,7 @@ describe('connectToDisconnectedPeers', () => {
       localRequestedDisconnectUntil: null,
       peerRequestedDisconnectUntil: null,
     })
-    pm.peerCandidateMap.set(peerIdentity, {
+    pm.peerCandidates.set(peerIdentity, {
       address: null,
       port: null,
       neighbors: new Set([brokeringPeer.getIdentityOrThrow()]),

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -4,7 +4,7 @@
 
 import type { Peer } from './peer'
 import { createRootLogger, Logger } from '../../logger'
-import { ArrayUtils, SetTimeoutToken } from '../../utils'
+import { SetTimeoutToken } from '../../utils'
 import { PeerManager } from './peerManager'
 
 /**
@@ -83,11 +83,8 @@ export class PeerConnectionManager {
     }
 
     let connectAttempts = 0
-    const shuffledPeerCandidates = ArrayUtils.shuffle([
-      ...this.peerManager.peerCandidates.keys(),
-    ])
 
-    for (const peerCandidateIdentity of shuffledPeerCandidates) {
+    for (const peerCandidateIdentity of this.peerManager.peerCandidates.shufflePeerCandidates()) {
       if (connectAttempts >= CONNECT_ATTEMPTS_MAX) {
         break
       }

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -84,7 +84,7 @@ export class PeerConnectionManager {
 
     let connectAttempts = 0
     const shuffledPeerCandidates = ArrayUtils.shuffle([
-      ...this.peerManager.peerCandidateMap.keys(),
+      ...this.peerManager.peerCandidates.keys(),
     ])
 
     for (const peerCandidateIdentity of shuffledPeerCandidates) {
@@ -93,7 +93,7 @@ export class PeerConnectionManager {
       }
 
       if (!this.peerManager.identifiedPeers.has(peerCandidateIdentity)) {
-        const val = this.peerManager.peerCandidateMap.get(peerCandidateIdentity)
+        const val = this.peerManager.peerCandidates.get(peerCandidateIdentity)
         if (val) {
           const peer = this.peerManager.getOrCreatePeer(peerCandidateIdentity)
           peer.name = val.name ?? null

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -308,7 +308,7 @@ describe('PeerManager', () => {
       const peer2 = pm.getOrCreatePeer(peer2Identity)
 
       // Link the peers
-      pm.peerCandidateMap.set(peer1Identity, {
+      pm.peerCandidates.set(peer1Identity, {
         address: null,
         port: null,
         neighbors: new Set([peer2Identity]),
@@ -317,7 +317,7 @@ describe('PeerManager', () => {
         localRequestedDisconnectUntil: null,
         peerRequestedDisconnectUntil: null,
       })
-      pm.peerCandidateMap.set(peer2Identity, {
+      pm.peerCandidates.set(peer2Identity, {
         address: null,
         port: null,
         neighbors: new Set([peer1Identity]),
@@ -355,7 +355,7 @@ describe('PeerManager', () => {
       expect(targetPeer.state.type).toEqual('DISCONNECTED')
 
       // Link the peers
-      peers.peerCandidateMap.set(brokeringPeer.getIdentityOrThrow(), {
+      peers.peerCandidates.set(brokeringPeer.getIdentityOrThrow(), {
         address: null,
         port: null,
         neighbors: new Set([targetPeer.getIdentityOrThrow()]),
@@ -364,7 +364,7 @@ describe('PeerManager', () => {
         localRequestedDisconnectUntil: null,
         peerRequestedDisconnectUntil: null,
       })
-      peers.peerCandidateMap.set(targetPeer.getIdentityOrThrow(), {
+      peers.peerCandidates.set(targetPeer.getIdentityOrThrow(), {
         address: null,
         port: null,
         neighbors: new Set([brokeringPeer.getIdentityOrThrow()]),
@@ -448,7 +448,7 @@ describe('PeerManager', () => {
       expect(targetPeer.state.type).toEqual('DISCONNECTED')
 
       // Link the peers
-      peers.peerCandidateMap.set(brokeringPeer.getIdentityOrThrow(), {
+      peers.peerCandidates.set(brokeringPeer.getIdentityOrThrow(), {
         address: null,
         port: null,
         neighbors: new Set([targetPeer.getIdentityOrThrow()]),
@@ -457,7 +457,7 @@ describe('PeerManager', () => {
         localRequestedDisconnectUntil: null,
         peerRequestedDisconnectUntil: null,
       })
-      peers.peerCandidateMap.set(targetPeer.getIdentityOrThrow(), {
+      peers.peerCandidates.set(targetPeer.getIdentityOrThrow(), {
         address: null,
         port: null,
         neighbors: new Set([brokeringPeer.getIdentityOrThrow()]),
@@ -501,7 +501,7 @@ describe('PeerManager', () => {
 
       // Set disconnectUntil and verify that we can't create a connection
       Assert.isNotNull(peer.state.identity)
-      pm.peerCandidateMap.set(peer.state.identity, {
+      pm.peerCandidates.set(peer.state.identity, {
         address: null,
         port: null,
         neighbors: new Set(),
@@ -520,7 +520,7 @@ describe('PeerManager', () => {
       peer.close()
 
       // Try websockets first
-      pm.peerCandidateMap.set(peer.getIdentityOrThrow(), {
+      pm.peerCandidates.set(peer.getIdentityOrThrow(), {
         address: null,
         port: null,
         neighbors: new Set(),
@@ -532,7 +532,7 @@ describe('PeerManager', () => {
 
       pm.connectToWebSocket(peer)
       expect(peer.state.type).toBe('CONNECTING')
-      const candidate = pm.peerCandidateMap.get(peer.getIdentityOrThrow())
+      const candidate = pm.peerCandidates.get(peer.getIdentityOrThrow())
       Assert.isNotUndefined(candidate)
       expect(candidate.peerRequestedDisconnectUntil).toBeNull()
 
@@ -937,7 +937,7 @@ describe('PeerManager', () => {
       peer.close()
       expect(peer.state).toEqual({ type: 'DISCONNECTED', identity: peerIdentity })
 
-      pm.peerCandidateMap.set(peerIdentity, {
+      pm.peerCandidates.set(peerIdentity, {
         address: null,
         port: null,
         neighbors: new Set(),
@@ -964,7 +964,7 @@ describe('PeerManager', () => {
       connection.onMessage.emit(id)
 
       const localRequestedDisconnectUntil =
-        pm.peerCandidateMap.get(peerIdentity)?.localRequestedDisconnectUntil
+        pm.peerCandidates.get(peerIdentity)?.localRequestedDisconnectUntil
       Assert.isNotUndefined(localRequestedDisconnectUntil)
       Assert.isNotNull(localRequestedDisconnectUntil)
 
@@ -1437,7 +1437,7 @@ describe('PeerManager', () => {
         },
       ])
       peer.onMessage.emit(peerList, connection)
-      expect(pm.peerCandidateMap.has(privateIdentityToIdentity(localIdentity))).toBe(false)
+      expect(pm.peerCandidates.has(privateIdentityToIdentity(localIdentity))).toBe(false)
     })
 
     it('Links peers when adding a new known peer', () => {
@@ -1450,7 +1450,7 @@ describe('PeerManager', () => {
 
       expect(pm.peers.length).toBe(1)
       expect(pm.identifiedPeers.size).toBe(1)
-      expect(pm.peerCandidateMap.get(peer.getIdentityOrThrow())).toBeUndefined()
+      expect(pm.peerCandidates.get(peer.getIdentityOrThrow())).toBeUndefined()
 
       const peerList = new PeerListMessage([
         {
@@ -1466,8 +1466,8 @@ describe('PeerManager', () => {
       expect(pm.identifiedPeers.get(peerIdentity)).toBe(peer)
       expect(pm.identifiedPeers.get(newPeerIdentity)).toBeUndefined()
 
-      expect(pm.peerCandidateMap.get(newPeerIdentity)?.neighbors.size).toBe(1)
-      expect(pm.peerCandidateMap.get(newPeerIdentity)?.neighbors.has(peerIdentity)).toBe(true)
+      expect(pm.peerCandidates.get(newPeerIdentity)?.neighbors.size).toBe(1)
+      expect(pm.peerCandidates.get(newPeerIdentity)?.neighbors.has(peerIdentity)).toBe(true)
     })
   })
 
@@ -1520,7 +1520,7 @@ describe('PeerManager', () => {
 
       expect(peer.state.type).toEqual('DISCONNECTED')
       expect(
-        pm.peerCandidateMap.get(webRtcCanInitiateIdentity())?.peerRequestedDisconnectUntil,
+        pm.peerCandidates.get(webRtcCanInitiateIdentity())?.peerRequestedDisconnectUntil,
       ).toEqual(Number.MAX_SAFE_INTEGER)
       expect(brokeringPeer.state.type).toEqual('CONNECTED')
     })
@@ -1532,7 +1532,7 @@ describe('PeerManager', () => {
       const { peer, connection } = getConnectedPeer(pm, peerIdentity)
 
       Assert.isNotNull(peer.state.identity)
-      pm.peerCandidateMap.set(peer.state.identity, {
+      pm.peerCandidates.set(peer.state.identity, {
         address: null,
         port: null,
         neighbors: new Set(),
@@ -1551,7 +1551,7 @@ describe('PeerManager', () => {
 
       connection.onMessage.emit(disconnectMessage)
 
-      const peerRequestedDisconnectUntil = pm.peerCandidateMap.get(
+      const peerRequestedDisconnectUntil = pm.peerCandidates.get(
         peer.state.identity,
       )?.peerRequestedDisconnectUntil
 

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -191,9 +191,7 @@ describe('PeerManager', () => {
       // Create a connected peer
       const { peer: connectedPeer, connection } = getConnectedPeer(peers, connectedPeerIdentity)
 
-      peers['handleMessage'](
-        connectedPeer,
-        connection,
+      connectedPeer.onMessage.emit(
         new PeerListMessage([
           {
             address: 'testuri',
@@ -201,6 +199,7 @@ describe('PeerManager', () => {
             identity: Buffer.from(peerIdentity, 'base64'),
           },
         ]),
+        connection,
       )
 
       expect(peers.peerCandidates.size).toBe(2)
@@ -1461,7 +1460,6 @@ describe('PeerManager', () => {
 
       expect(pm.peers.length).toBe(1)
       expect(pm.identifiedPeers.size).toBe(1)
-      expect(pm.peerCandidates.get(peer.getIdentityOrThrow())).toBeUndefined()
 
       const peerList = new PeerListMessage([
         {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -1536,7 +1536,7 @@ export class PeerManager {
         continue
       }
 
-      this.peerCandidates.addFromPeerList(identity, connectedPeer)
+      this.peerCandidates.addFromPeerList(peer.state.identity, connectedPeer)
     }
   }
 }

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -154,11 +154,11 @@ export function getSignalingWebRtcPeer(
 
   // We don't expect this function to be called multiple times, so make sure
   // we're not resetting pre-existing peer candidate data.
-  Assert.isFalse(pm.peerCandidateMap.has(brokeringPeerIdentity))
-  Assert.isFalse(pm.peerCandidateMap.has(peerIdentity))
+  Assert.isFalse(pm.peerCandidates.has(brokeringPeerIdentity))
+  Assert.isFalse(pm.peerCandidates.has(peerIdentity))
 
   // Link the peers
-  pm.peerCandidateMap.set(brokeringPeerIdentity, {
+  pm.peerCandidates.set(brokeringPeerIdentity, {
     address: brokeringPeer.address,
     port: brokeringPeer.port,
     neighbors: new Set([peerIdentity]),
@@ -167,7 +167,7 @@ export function getSignalingWebRtcPeer(
     peerRequestedDisconnectUntil: null,
     localRequestedDisconnectUntil: null,
   })
-  pm.peerCandidateMap.set(peerIdentity, {
+  pm.peerCandidates.set(peerIdentity, {
     address: peer.address,
     port: peer.port,
     neighbors: new Set([brokeringPeerIdentity]),

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -153,15 +153,9 @@ export function getSignalingWebRtcPeer(
 
   // We don't expect this function to be called multiple times, so make sure
   // we're not resetting pre-existing peer candidate data.
-  Assert.isFalse(pm.peerCandidates.has(brokeringPeerIdentity))
   Assert.isFalse(pm.peerCandidates.has(peerIdentity))
 
   // Link the peers
-  pm.peerCandidates.addFromPeerList(peerIdentity, {
-    address: brokeringPeer.address,
-    port: brokeringPeer.port,
-    identity: Buffer.from(brokeringPeerIdentity, 'base64'),
-  })
   pm.peerCandidates.addFromPeerList(brokeringPeerIdentity, {
     address: peer.address,
     port: peer.port,

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -8,7 +8,6 @@ import { Identity, isIdentity } from '../identity'
 import { GetBlockTransactionsResponse } from '../messages/getBlockTransactions'
 import { GetCompactBlockResponse } from '../messages/getCompactBlock'
 import { IncomingPeerMessage, NetworkMessage } from '../messages/networkMessage'
-import { ConnectionRetry } from '../peers/connectionRetry'
 import {
   Connection,
   ConnectionDirection,
@@ -158,23 +157,15 @@ export function getSignalingWebRtcPeer(
   Assert.isFalse(pm.peerCandidates.has(peerIdentity))
 
   // Link the peers
-  pm.peerCandidates.set(brokeringPeerIdentity, {
+  pm.peerCandidates.addFromPeerList(peerIdentity, {
     address: brokeringPeer.address,
     port: brokeringPeer.port,
-    neighbors: new Set([peerIdentity]),
-    webRtcRetry: new ConnectionRetry(),
-    websocketRetry: new ConnectionRetry(),
-    peerRequestedDisconnectUntil: null,
-    localRequestedDisconnectUntil: null,
+    identity: Buffer.from(brokeringPeerIdentity, 'base64'),
   })
-  pm.peerCandidates.set(peerIdentity, {
+  pm.peerCandidates.addFromPeerList(brokeringPeerIdentity, {
     address: peer.address,
     port: peer.port,
-    neighbors: new Set([brokeringPeerIdentity]),
-    webRtcRetry: new ConnectionRetry(),
-    websocketRetry: new ConnectionRetry(),
-    peerRequestedDisconnectUntil: null,
-    localRequestedDisconnectUntil: null,
+    identity: Buffer.from(peerIdentity, 'base64'),
   })
 
   // Verify peer2 is not connected


### PR DESCRIPTION
## Summary

Changes peerCandidateMap to a class called PeerCandidates, which wraps the map. This makes it easier to dedupe and merge peer candidate entries.

The underlying problem causing the 'Already have a WebSocket connection, ignoring the new one' issue is that when adding nodes whose identity we don't know (like the bootstrap node), we need to fill in a temporary identity to distinguish it. We use the address+port for this purpose. Once connected to the bootstrap node though, the peer's identity is replaced by the identity received in the Identify message. The peerCandidateMap wasn't updated, though, so it would still see the old temporary identity as a separate peer and attempt to connect to the bootstrap node again.

## Testing Plan

Added a couple tests to cover this case.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
