### PR TITLE
feat(ironfish): Introduce new `GetBlockHeaders` network message

### DIFF
--- a/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
@@ -1324,5 +1324,455 @@
         }
       ]
     }
+  ],
+  "PeerNetwork handles requests for block headers should respond to GetBlockHeadersRequest": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:RIqunNumNtATvUUZ+4VXjidberNWzeZG5LDDk/O5dCI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZfTJDY0arUqztIsc0aJDnO1yWNgMEtoYd5ZE722NhIc="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676325609945,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA9EN6QZHMrABAp6NR+yIXSRvQMyJvsH8OVj7d23NxPcyHD3oep0d1nLQUVo8lEz6u/HH/4kpjDEL7R0n68CPwEYL+bwLSxq5FPpP/7vQsmYOMFiShhz6XBOu5g9VlieiY62Wqkl7tm8GbJxVwiWw1A5BRycePo1zkB7uQqfhA8Y8Xp7eZONvYe2GiUCSaDWb3b9QotAL2hPwaXKcv7O2/suBnImTk1iMDwv1IjgnpvqKhhnaSPo3uzc2ga0yEnLty1cNOiH+iqgP1Rydbx/JDyCaFohgTH2Mpi4MpWaQyicgiYFdlRqYAWzmflzUZ8VsDTNxB9mwhrxtlwFkhu+j8iQq+BBMOKLc+QgqlweFrKcsIvtomNoVLrvoLOrahBRAUDbGKTq6w2Xx34hIZKhpgrkPsMkAIFD24qLVT2PXKxRctBDfZ5uRc1Gr9GiYbYCn6X98lL6oozSpVALWyIfN70HKkS+oEgmBVMRy3W85nyxrxvpsFv7npgaWchwyDN6ffu2t3xlFgR21WcU1x9lJTWcXOseD4Ve3MJarTUb5hV4T1cAjQjVx/qXZtsIlrhtlKFXPcJNckjSWgzGuvzsPTxL/bRgXIKg/6efbISSGT9X63A4Launguf0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5VbvtoqqqpKKZ24+LnpwEMrtp3tPClyX2BLc2VQa1SWav9E5YARkm98bDzlkda9j22M2Oad/5ZjtdS0Db1EMDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "681163D68772F09CB6B971DF14E966F2B6BD0DCE8DAAF07D58D2ADF369898744",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:6kzjjfnKbHUmh6mAQL24L/bXyxdqLcJ32sLWoJKhc1U="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:MNkFMYlx0qa/OoAgG27pW5VBnqJO4Nfe3PjFR+TAxvI="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1676325610248,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAoC6JO2XV+ovMzUSb04Oqioj9XLoQMqWPVW5hk5G57524tA7jrD3KJhC615GdWdqDN3m2EmlRzs8uAuDUikKNXkEJfvajtyqGH1AxNj1wHZuwjKuuT6JlDuo0ZbL504MDtvHnBh/mgtekwglAMpV5XAeSeKjCAGQOvT1xtKDvigkN+JqQI+7828O4ppNbgJ33MAoDjv7PenNBg1ITLv4MOilE/uenhqU9+aKS2NcP/Y65U5gwfZeKFdR89wlZGrjXmFyFLj8rkfL3V9jW9zwHwg/mA926z5XSimQPsjjGYBc4CKRHGFgyzdIma7IQ/TQkvoOk0rVePILDgC1gc5lECYCxx5RFlWJhsDrZtJfO48RZgkRDo2mPeHIWcpmEcyBOEz9FePanTlr9Iq3sug4QY3x3/gNAS6AXiv7aSN7f2Ftb3D3ksSmnYwPfdlgqV5p09VvsDEsDf+9H1gI/sO4q5Gzcg6xkCvrR+O1X7XXh9WLDzmpW5MJN6APwcDnmq9KzVw+MyAFsTHNAOxkxZbvb+Nbvgzljpk53VwPLwlJTz9C01zVirI58l4+FIklUbXf4kA9viCw1WBRtV/YB5pZy8ffkR15gJEDfZ54lmYgnc7Ntx1kt21Pq1Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4cSVrBDbH+GL9jEu7fGfYhLwdPUAqPQ2feVs6KfeX8oN8COHBhYpDzEw0Fo61hqwWvyDp7pi4MYQNMScyRRuCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "5ACDDC347D42FEF5B93EB10D2361107AEA1D3AB65009BE961BE991D0F1CF9B3F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:KYnnsa/vp/AMeJXurHKfPwBieEkribf13qigXOyk3Qw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:O4Xa56cvBVfgubVe/8q4yxsUx3Af8FRWxV5colfDt6A="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1676325610528,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAY24X7DfF+oYGuJhhVvBvdfovbs/QP+R1HjaiIR/qPVqVQXfFu2AZZu13tEkt4JBgqYpIkTvm2TwKg8JN3jxTUksU5w6PBIHpYYq68NONF2CY1wyRWjDJFpOVKs+MLXqEBzXyo7yhGctl1JEC7ZWB0qpYjjUSwnxQkcOH+pByo64A3SA9wqsxBB8cxLYhldPR1j/dVWPVTI8ebgoGOBPZqKEsip57AQpLWY+Yl+r3seipjQSQk7I9IglFWuA4uMNiM/RzbT2KSmMToLTdQuO4vUXE5ZgZvjWbz06UiuUhhRheA+198kMfIoDj3d7aDacdE1jRyaR43ugS0uhcFOlx257Caa/8aRC0U2DzcUEA5SorhPneRaiFSLJ15YE0FhdJROoLIxWxVwYf+MNX/BrmnII1xOhU6C230EmFr7kbIfK1zlbmkVd8mjULPNbJCqvvrvWwKO0VUoaXreGizuss+ruV+fAZOberCuzZwkv9pLULMBOGmn6xGutl/NWURmp0b7zCnu/9okenyIkUoc/mNgb7P7S/1X4fTTQwn7pj9ByWWqoRvZXs44CkqUICBdd33M7sPILurpkdP6PtXFaQuYnSR2tG4xzNEM+UAapN2k6FYo1UHmHjj0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9Pxeeg6g+Rtox3jB+rgMS8jZOcMYf3nFagZnoK41DuW64Wi2wVGQ3dB3RI1anAWxbbmchhAe+0cYGO72cWuIDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "E81B109E9172FA6FC18FE08BEABFB6EDD4FC34F00C4CCE00E47D8F11F647B1E4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:YyRD+Q0XYXfgVBkBJr2A1ss3ak94THqNhlhvzxYlZGY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:IzXukrx+13gPmxyN4CSa0u95Y6NeiFEkJSHb9RGyvLI="
+        },
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
+        "randomness": "0",
+        "timestamp": 1676325610809,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAd+5ADsQoZgp4r6nQPWVI46royQ6wNpQmsBJJHJyl1Iampuarb0Z3lozmM7xq9Qx1smYsj3XCOoG76Kr0lM1N4IXh5EBTjUCNlGMlq5wFtJu2GG2CYmotl4/sWj9EGnGbbvC06SgHYP8JAb2lhM09OKfMn0seJd6zgGSFORoi9kEE4bDDaqPRpSXm2H00/+fNtn9Ba0ghu/LsUqQF9fJ9aQrZ3bo3w/cr1QjjCOm3HYavC1mFyTLMR6AGEaIyVV7HSMi1XmUWIButbVOvv5J3oY+RWE7CQjjTMyc3mjTBNHPGjpX/gVeuoL4B4ilpi+6Fq09bfsyw1wk4DquZ9/VrgIHBK9ALfJMvR6VM4nIBmyHTgnwP7chMr3pSM/98qvFToYqIzRxyg4q5RH514O551d1uBMsuNAVnM/T7geTkCW8EpS2n4Ik4zezO9XuQIQ/FPDyeqQ+eWJezZJYDj2VgcRchh0AZ56WYjTE2SyjmoUL9Du0kZO2CQH3/8xtlSFHEuZcniEjhIlEDG3K7rw2PnJk2aWKxhMy4AaMzId+cIFiRHfCKCD9Frh6Tnp2ZLplxk7D3glnl3o5VGsDj7YcFhGYFf2be55w7nWmwcbNHVFmxohAt5yQXTElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw66z5VO2NCPz4PcAEdIQXL+a9cRMSov46MQydIfUTWvDubkv3Y1LyoAmWYm1S20NGSgRbUa3cEMeLDydyHGKrCg=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork handles requests for block headers should respond to GetBlockHeadersRequest with skip": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:CY/Vg3Hp5CmdMcScOpZ/9dSS4GdMEuFgMUIXmdqoqmw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/c5IXaK8aejg4vD6xFwZyvRPhCPVV1QpzyVzafln/DY="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676325611120,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAnjFF3jqtgNOY3ZNIPqDHK7CVByphfH8QhcqyNN3uMIu37b7wECAf/5XwpahcExWUOhqQdsAB1Utt6XPkktbZgz/171d0jSXkN/AzluZCJlGIltnt+bANJ38iFDl7A+mER/ZJOBMN1eYGjIhrWIoHu8v/fKGrJyQJ3W6SvLxAYBkUl9ktZ1PCofEcYLmuNcIHACUH1xd1Fy75bEDZBifJQbd/I32I5d2p9RDUEKfd/euSYKv4Svh5wBDobcFmrjDV8WlUsDma4ND3n9+TG/a2UAkQ4NzzCkosP58MxtkPtru6eHgidBzvs9VT4z61NwefNYvqLIPt0JLNok8Akm5OAJK1sAlGJtWTVgZhLQueme/cAzgH4jmBV4b3eUUqjaIqE3B0Xk1q5ixl+VZ7kc+NUBuloDuLENRZLFN9ClsCt0ywE6ROrP95BW4pWUPG4BhzLV4HKpF/Si6Tirge3GNE/p4abNWxrKKqnK9y6tHLM/OFkj0OXNo8IOlIkH2V2XxIF67x/sKBJ7Y6dovE3U/8vDHSa5r6sUtRbTxFhh+WjV4lCIDh7E0suUIPqpRbas339vvPE0GDxfzBNg1bhAgNVSJhtnHXRxWrZvo6T+55wVy8yX6EDZjwVElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtnWX5vKBsIiWnQtPA/JqHPBiPvV+BCJ6oizeNCDZKKCECGjTtnpzud8bMcPi9dsr0bnM5AcsGwVBU8Ewyw3FBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "6BAADA2EB1864C4EBC9E27B1CA74638B866317103DFB1D37098EDFB985CC3B64",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:JgANHrxyquT4/Cj1Yr6RT5ZmZMk1EZeuLzIdshvXBzo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:MEbdTY8LbdtqeRrU+kZ1Ly/RtAUVFXUMwE9ObFWO3Bs="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1676325611416,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAsLDQxv0geZj+R2U+WYrOTI8PH1vOPLP6FvDqS4CCTZWJv/KkGyJ+J7PLHB6pw7jx4Ky8Zfegu55fv2jtp2M5CL0T3rWz36t0nknCZlmulJWD+OpyM85IrxhD049o8AbsogaGDQchb3RUSHggJXx4IDYv4zonFoXBVbSqIgLK85UM6DshnI+v8jHK0j/vZDkT4PK5YERSnuFD2wTovxFK6UXyOFGHTQcgv8gYtw2XgjiHyRa3gM3/wEBY30X8IDgnqwdTFkrwL2i/HAopjj/8oQa5M690q5DccZ5+iUntNMBeL6Bt0M54jfamtnG6XU4u5A2ry8CwfFSe/+3wTtjFlMtr4sjsB63juG7dQcBOuU7S/nt4rpj2VbKKOHTr5lwPjXY7rT7NucFguz1i6iPMClNkuoXMIvrPSVsYcV5NFzmc01iBR8Ny1NLP/aiYhArXdfpDuKCI/7mR7/CBHJnR2y9aPAWjU5MDkOpKSff8bN3EmKjuClmOEVl43qdd7SFFSBSUN6Cofs41INZqXTKFVVrBXZ4TcgmUTfd6JU+cNwxKNtEHSAUJe5GVP+RiMqnhKS9EGGi+rvJHUggtjTEW+JycDNKySOX1oHgu6O9ect+ky3xpfdYJ4Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcokU5wdGUhG5CQHogBFlcKql+FaxV3DKZRBoYZeTFsssE/o2je9ai+fYcc62xMUk5zFo5eAPUXuCVkQiUfgzDg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "130D527D673847148C95E41114D0FC31784C545E3597E8FEF0AEB01DAEB12908",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:2LkxWCrb5R8WuLa4kGlH2P9s1PQ+N2lBdmKH7hWP8z4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:j9u8jmNEOUPPwxhPD0tVC/FFh2IhpGhKB2vhtGfbzqc="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1676325611691,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAJMzIiCFtw9Jcdbe+E6qHMeQxDqxhTmnf2L9rlzkSWQCRXvGcMqyXwQgj5C9YeX5igf/L/+DhKDDNG+P/gMiDO3KnRL/52Ml5boysK2+yYrKkLxHAOwAfcuRwmMp1AKl01eEy9cuQF9YwLF9iia1RDAneO7rfVohu4WIe6nd71VwEmGyee/uv9b+ap0S3mixx6btnXXL+zmCvceXGy3PDs5c7fYOlojGW7oJyJEjps+yAy4sFBKonAsM1c2u4OIS8YzcW9d72vB+VqNnAH/WehDYIpjMAv5Agr7pDwZLdMij/M1j8sJVaJri5PLVkezRfVc+gepTWYhXThLWXVmXsJKqiFeG0X5x5yUhOX2zcGQhw462oiNLtxER1f+EOUQc6XjEV7hvSL5NyXZ/oMKz20ki0iQuEItxbEI4fx5GzlAc65LAkhUuRYJnsapC/im6a7nvvFAXKWVjbJYAY0OVcSF/u5Lr7ktAOT6HWwHDkxtAVO03+plf4nkXpBGuPkSjJCiXH3+VoHCrp5mY8YhgkWENnpI3ssgJ/a7Sj2qRAlidTxG/Xx6h9OW/0a1IpMi5JRd2qJc+SB+gGwK7wbrdNb/LhgR5OkMnqh9mPBTLKt6ox1I0B4n8vN0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwUEFYAiDpcVA63Cx341zRPNZbNVgTdF6KheCybbd4hpphCgKuqksUwvGFMgk9IrX5emr3c0yHzJaVh0R7iWk8Cg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "A65EE9F181B11306249C194391337A8F469EB135F25879833BED7840804719D1",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:X4EBcjeDWazpZHPmrXKT8h1bUqXr0DUnJLKzRMX/swg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:QNlj0NEbLMuR1gi5W6XHq/e68QitHkXP1ywJMWeEuGg="
+        },
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
+        "randomness": "0",
+        "timestamp": 1676325611972,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQ5zkFtMPSxUMPSrU1RRkknkDaS6zOQ0Ep7Bp+qFI7qSXXz90xUmxS1c71ZyNyjfDc0avOvMhq3rSDaL/yijmN+x25jnI8FWLqtTOHj0PhMOk81ybFQWIHW759X5pYjKCdIQz25WXbIQmTYbrFq+JSgfueETYjBijOUn8EiYhRigT5ZAxO9uzggdiIq25vsNFM77Ka+5t4sN0cWHqVlj9nDLW2E4GsqRhvMZsAV+h+Naq9k+vD8V5bouV7BsCCPpRoeGD9s9FtDlOJaibxYpUX1RsMTHp+iL2L1EpTZPAFPEx+vP7j15igXGO53ts1vYZczfTX6BJyi3gZQfYOERZRm7SOnnEows3ZKT/ByEcpOQjOB/+Nva9tMrmOM8ZVWIFr8dDolru3SIMzJWS5s3rkvDeXk8CNPYB37HqZ9Au45WVIZOuaKPE+n0iCCg4i1MmPFy9kPivNGbtXSYB4KhjpHGrCkOCZfec/2mKFcmDl/sjSo6sYdZDrFEV8zSMjw9tZqz3OAVF+rQG+WmH9+FPc9muDMVV/FmNGyXK4gLmgBv97BJFaRxjH1cOniwrEHEDVBomORCPMq7rDtnC7b2ve4XfLgVFB/j+URju/J/pwuStEY5VnS63Lklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvkfd8ImVVkNeK+gvr37HGut9Va4tDB0waBv+u+/aOd8QFPFMvumRThbPMZ0v+bbk2a7a7CVnbVrRVCqaZAHlDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "B2D774B1009ECF2B9AC7CEA66DB0EAE0673A4FA508933D4304C1E8471D2A96A4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:dLn0jmAQ5/NZnzR7iELkKtnX0AqZmkMOu316L+dnfzg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:NIxlIg1GNhXWNeH3bce4oUCeBTaKWC7CVqZQmyLmLHM="
+        },
+        "target": "873190827380823143577845869093025366895436057143163037218399975928398962",
+        "randomness": "0",
+        "timestamp": 1676325612243,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA6Bu5NmbLPovkelnYDnOMhMARYPwCNXp/1UKR/AZ51rSj5eMQaQH/f9ZeCuQ4CHhBCMu2hEaR1Mk8WwCvTgCg3xcw7b1/sm6Lo55RkgQ9o4WEKGfW0XcPCLE3Q/gfUo55wals1JyeDGlznRZjGNENEmihTAGjYAG3w3iG+DWBMAcZv8iyt6yrUDGYqNaSPOgI9qV3DcGuScJgyIklXsmn5YE5l2lDMnagsnirVxhw/+qV3FpXhSpKydjlZGZ50hNGvpjpS2DPD/R0HkkodqBuI8LQ8yb15cvN9A1gfB2wCokOCOSlmeA8LVAea7q1cmlYSI5GqK7Qv3Ky4x9WfFDmyj5rN6606xB7yc9Z89q0Aq7pkVx7SCb+LQsUtBwjRehtWhlguFmv2CQZr0Wcu76ZEf6hzxkJVbiVl4LmLtOMDwEDLc2pl/Kvf4OlKKZ8bBIJIiDD9+70+5DGs2v5onUVhuqFnfD1j9YVSou6IZ64eOxAAfRJTHmHEN5ZoROi7/vkHQpbEzB2r4sOkL0ypkaVdRDJCd/4K2gl3R5G0d2zl1D0y9yYOMzOvj6eHvWOS3X1S9+F5V1g75Bcg5pJ5wpChp/CXSPn+LO/lO854+5tqpLnz8B9DbQ0gElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAY8w1+9LEnMIXdJXVBO3yuWeI2UqfSp4sQkaeqDfLU4Uwyadz+YyTWItYKLbzR31Dn9VYsnuBN//I6jhTGB8BQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 7,
+        "previousBlockHash": "4F49F43ECCC9094087748A57D5CEDB05F77F08F8ECE7C45D496FD20103454C41",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:QC3190h9ygtImwy5tISZhHg8V8W5gHx3LNLo02GygmM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:1cjvr93XZ6Ik4JF7sJIDl9yrquTNYa4l9b9aRBAd7t8="
+        },
+        "target": "870669583413409794751345832897376592977547406352566801307278513052763546",
+        "randomness": "0",
+        "timestamp": 1676325612523,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAPIapfEHPe/OY2eFG02lyQG5/Jf10XscVBBY37pPaeGWr9hBMjbaO+LbnI5dniPD+yJGboTe4DKzRpidnU/v00Dn9k1GLxs4UAAbE9I4Vkc6xAcrtwoOItyhcwVV3MF9jtjUHB8HS9d8v2xL8oudukS/X9mJ6t/QS0ExyT6fp0kUUUGEic2Q3B27WGXn1aU1w6pTiwp/YD+BjWs1ziW07XqZpPu2/nsgD3PoFq+reC9CDAEVbrIcQL+3IdMdK76zMediPmoymiGyiwOkl2ieXsmv+Yghu3h3Pc3yP0jTJcBoUoXtHfMvTtB5lP5Fq1HO/YwJnIXPk8BpmvADucZVznOKInHfj5c9wrpxVrwgeacFtqXuXmEp0vaC4T0BaJXsxgbm5oEPTBC5PvjkA0XwV0WnpyJSYqDSXTCvGXgdDm1LzvwhVlxuTnQy8gHAEBxZ0p+PJyKlpoyLzZjPpm+LAVyVfUVmA8n2QWfdsPAd6l0uMIij1+pRcir/Dmv2d/N7KRsSKp4VnxqBs23TXWJRfA1SXsykxzHx00MVxBKVkj8mHYWxljKP3x1cmDSLSNB4miwNC2kwZx8xwKTv3u+MAzcxYmkd5y4tNbF1Q+Q8QIvIM6yTkxtD+PElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEboSZ1jXOoJr88oehJ3Tf5Ayub1F38uF/Ezma0lbfS0D7Jb+Wi3hqXK7Ahb7SFgPNTxuRDiVDYpOGLwLSdnrAg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 8,
+        "previousBlockHash": "7C21DD136165DC7A9BEF0E82647C56B8CD04EEF9BB9BDCD140556C976179863E",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:rrNSHbD4h/h+2nEMBCgqyem94nOpxz2bUCji0P8NwyQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:+N+E800t3X9Pt5osWPnTV6ET1P834mDTROoEdss1m20="
+        },
+        "target": "868162857165578480563002226852566487623485369674008547560712452074684573",
+        "randomness": "0",
+        "timestamp": 1676325612817,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 10,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKEHtJ+nuSWwBdmSz+C/Qv9OTEtntIzla3u9K8+8hre6lTuPloIG6fBS0Zh+XKIJ3k3H4mk7XvDrasZFL9FE+/UWdTPs++3/ZER0bkjewEBqs+ubob9Q9U3Rsukl3J7QOSyNwUlkk8zBDOGXfIrt4xe4c/ExcSxmx0nkGPUK9jeMZno0dgGHr5tnLnnX0/UuupdRVOXzqjIPw5vfcsYGwS10nrJg00m+4qhNeDwKARB23L4EXRvlFfz+n/DmX7TAFXrWnIpFJWOR1yKlLIOuw30HfN8CpnxLwjHPbpCzUUk6P4rvK4+zpdia+uHb/f/lYy9Kw77r0zrxZh3bavqAUBdh2V01dhRr1cbFAM98vnwrdr8bOGJu2/MzrCEbXUwEmNf4Ib4s7KDmIW0xrP8VNxTnTmVSGFmtUODWlutk0/e8z0DanRA/0CSn0t1QYgJ7HD8mvKOkT0BWSDHS1ogFQOOF6LCVVHBMenUtMSmRCRX9xRXazdJz1R2xMgiebGEjFH+A6fc5cOAvcDG2ynKcPMU7OEbr8v6BP2wOJ5+eNJNzoIaKIBvHNRRUlKdFyZc0rpL7NkSUbxA2+4ZX5QUTIN4iPdInEoBFzkcN359HKJ3lIXHZelsd1QUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4mYfHsp6ZQ7Es3WjZEoFEcZwFzD5ugtFTYxdUfcbTV97W0AQao/4BPhCIXsGvWswg2Y10FMPY6+GPNj4p8PZCg=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork handles requests for block headers should respond to GetBlockHeadersRequest with reverse": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:4HjH82db3xKVx2XcOGdq5AQ5zp0tR9a52FuvjExozA8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:MtpPHh1cnQnEVhuUgdU3B9V2R1I7DQpEl+4dH/u5cvI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676325613120,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAVyINRA4/9UaYFbqm5kE8FgTr3oMaGaQP6LbXFNsYzYq1Mhzn/rArl9r9Apyda8v2bWD0x3AVXaiD/l59rF/R9t3pkp2hqC/EsMCFZ+7h55ilquvbd4CnnlWqNZIBW43X+ldbjNzuCrxm04uSJ4rQiX/og8gA/MFZLT9dvxpS4VsEgepQe7xzytT/GdsXvRjx68DY02ajta21UMJdmpgaSCAiK/8p8RLpl84/qwKe8GaVa5lA4uOZXDnOK3lI8C1f75fEoVgFSQqim6HSL+KNJY3OBnwYl9oAWfitCMBZ/m+Fq30SmDldvj7hQ2r5EDukEyWgHoL1oaEsx6O72YiyIxkxYTxaOj4lVXYi1HaVPlT9/B5Ztv8GhV1LDSunJkpumfWvU1QUbe8BO+vU7curjGazudSUnKNfB13EQSdc0iZj8FN+AyB7sJUrZEd5JXAx4Izocddzx3veT/YQ36UttYm1j5dtiqoU4DvGPhTNedzIRZmFCfvJ7vNoRVJ1sf4RC1Wu/0WwLPG3+znihtQNn948y0vh4aGPURyclGBnzQ1F4frMjNIlEUbICf4BIE468MG81oxrU0mo3sDmlxTz5OsYG+ctYN09g4s/VWH7kcWShG+YDvlQHUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwibgBM/jZigMBtvQEyD5sNlpoVorOOPkEd9A84LtxPMoeR8lLBeGw/AQvKriLJOvGhO6kk0/czMJ8J40tCXeqCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "0FCFA7268BE1E80D78E7103F57CCC398174EC39A9857ED03D7CF63F3B16AC0CF",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:oIp7EtmE73he8sR6VdRHvVrgVrDLcauhW63xM4lC6Cw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:X8F9C5XNcxFqa9rDruCV8hsdTSF8HyRIQ3u39WKOhf4="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1676325613398,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAARnqE461d1EUhTrrkktCvCw1BmPejB4iAQbvKmOF+G4WS33APkwYkUvlOBTAkJrz1bzwsZc2tJn3mYvg0BZcpYKrMUjCcHRWZB3K5ZcSJaVKYY4EBEdmgQZ7EghCTrPuCXLJsqVrue2f3oEBA2MFM04a1MB/bsUqelPZop6r20vUDiZ0BGUY5qvf3mg1Q5vz7rEdgesFh0bLIUS8C5HmYIW6hIG9yFRWux8saL3/DHOCXeImi5o/m/WudriJo/8iYNDCczUn6j0bY85xXlSgiTKR8qTX+ubHbpg6GuijtlO6bBoL3YZEycJVfxoqW+AnGVRbTiQZgzT6dVzy1E5ES6nU6czDNHuY7B1xM/aDAdb8dz/rQdQ7jAnfFjkO2p88RFhu5JWtCOdiULDT9iiUHAB2mueG+uXVzFTpPWd1pjfKbqTm8x1cfUS3fCwO94KvrJGL3QCELMHMHbXmFuzo4asvtoYIpTjaqzJ8v1+1iJvgnnU+KjR0yYjE7vywKBjMmPxoJQdrW7zeaMf+7xjJq/K6sYNtkJtX/jP4EIRhz5FUSy3mH4I+8IWarWSjqhZVPy77lTcedFgq4ghKW1ogw0Th8jD7cGWOmesP+TnCvBR29Wi7llIvMMUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJ6OyXquMAzNbuLTmStmL5q2t3GkEawO+76JBE4uBc5W+sr1w5UWKVQq163xMWDEX7NlXVh7EHDys6/O/CzxECQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "AAC355D47BB23BBF812F53E536E35B8CC5BECD32BC610046EB10049B89BC79F1",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:VMlXm4pD6xNSbU3qGsR808yh3RxQYpTK4r0JcIF0CGg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/NeotLXXBJwCxeb0enHGVYj917cnWyKKJ/iX4AJmmlQ="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1676325613691,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAADtAPbvoU/VKjq3DeLt2lTVt8CvCxzyxQH2chV7QWf72sayEo4AKo0vxhhRnd9ClbAzWba4kD3qj9NOq2Opu8Rttvdc3kBG/iX90jQcyxJfiQL1lue6iu6lseWanvUe3f87tSkq4CJ1qC6QDmCdYirJ7+215j0n9sck1NSrf9EqgAlnfYNR5Lekc0XkZt4FMULeoa+iuFR2/oqw85IDmpqQjU7t40B9a/1b2uB5Ja3CaQ2M6eyE46LqXL3BSztMyVsL4T42L07aqWhSo42QMIFH1l9ZQdvi56sLMcCgkvVGfORV8PZDRtMKnG5+F+Ij69VlESYTlU+Za4X/yfEd39S8h9ZuqHoYFvYbasAIWEeIfUV0ngE0mSxVAD3BY4Z1A6cLlFQrqiQhfWY1ojHyvWBeWl16wrIxfia4TGXgJOdrDtevWmyPBM1HLl7W+Ekzb4iEAK2lNevw55Mvov690IrgiwrTEMj8G0jpK9L95yWLZKX0EbwduNniv7aubD7u0w66dqk/asKJmjJ/RejGkyb6w1IWm2wL9Nz2M5tinWGn1oe7Ws1BLYLYueY3N3RQDcPMcDj9v1DfCldoPwXZ0X0y76V+keIfuRNOKkvS2fdkBR6rKkV92mj0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDj0ibBFbLrLy/yEIEDxbZ7YCWbbCgjBh5/ABF85JLdJoBR6n1MR8cEhsGd2Xs03g2UtRnopGp7C9aGTK+HhBCQ=="
+        }
+      ]
+    }
+  ],
+  "PeerNetwork handles requests for block headers should respond to GetBlockHeadersRequest with reverse and skip": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ikH+lCwcW/To1lkwH54LeKtbyuA6Gv8/bOVCbIhcumc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:lNfm6YkuiiA1Z8YzSJwcCzDXRFQ0XyO1SFwjwXVadYs="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676325614005,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQmZvGf8jnVzIt17kXPFHZ193qmy7PVCJdXHyWeUk8OKBLl6dH3rnRSEKQyJhQgzGwhOINwXQmJ1p09mQ9DjGAnB+KY2w6hRUIBdeVvK1eEWJ2S/qVi6vOgTKtQJ/fJ/Y/6H+ET+0Y4ILf51rv5QzGZmHbSbB6QTyupIPj3pCI3kNtl3u46kOLRTJq2lFysf1l8MuP3bZi5gMa1HH+0VMye1sFN+87QhAMjUSXyEA/hOoqnIk7ygEwIM9sIAqPaQMtkK66zYmaDBa75/QMYMR8VsmksOYDFwSG1gBVyfvg7Nf8aD8Ga3s79lGbC5OKnPHrh99+98mJ58T64aTiqcsL+PnDQ7//a1j6aqREIvgolefcD3wszcvx6uq7oa8qU4Jgeg7I4XfOvEJQfza/W/BhxeFEkpmM/L3Xp7Lp3zyWxIABLhmDIHzGjSOjYDwO7AJoyoSILkx150EG/C5dIHxmA1MZcCmrDDaMLyTMmfq84Fzfb4nUiC24fT5TsUqPyT17Q/iUgGXfWbFOvrwxNqcNpGzu06JdHKhBY86V67TQM3GpNITMxDq63UtNSoLzNAgy/QopSHqaTPr6YxmCqGDbUA+B2Qp+r0t1NaS2GCxxYDENDT5tvNvQ0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw6EKGXhmMn32g5dSIvbfsQjpA0BOsuS+QL9o7LAYr40l8d1/77JfLexn2O726m2I8lPTMa7eT2LRNP7NQOpoRBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9D9BCAA157BF070B6DFEF0801DE591BD4617BC6E06C606F3B97E42F0A473C7AD",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:CVbI0xuAWLrXIbza2qFRExX0aDXoI49aOKR3qE826gY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Umtz6yU+WR06Aoy7lQIWEX/Id7PI7/aRM4U5rt4cgcc="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1676325614306,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAAfn95g4+7AAsuQ6VHV5XN+P2MHUCi49QtfeQbVMhdFuqiJA31LVMyYV9YrArOy0LanrhapBY81sNQZ97fI4WWi0N9mdCz4NiTaJOQ4H+Kb2rEZ0x6HohxDZF25qivQWucSK75Bzl4qtpG14GC09G+jXxz2ND2TYhxgySZluCZyYUsqDiySFewpV6lM0oJt2M/p1PbVt7R6jZGUY9ocuyPZae0dgLKkhYOHAAYDgK/wWNuIZufinl2pwAUKBB+W697Q+SuBEuHEwMw124mGrEoqr2rqEtuv0sCdYWM+iA/+QUaZVGIvH+eRO5+32SYy86lROEGjxqIv0jmqsmcHP/RsmDSH0FEU88yL8o7dP7gIlBhuWOIPrzptBK6dSUaABnqNsR5Ztyb/+ucs8zzTdqbP9Xsan5TgzCYje9Iu4FSq5QCOUkztaDNhX+1RbS+R+MJ4MEvEpJFL2SqYRf+UoTFWp1Tp6iC7IA32q91XnjICaMARFYFqxFNlZyc9toiez9R/IInu+cwjrCJFko6NM4plb8bGLCNrZeuVXHhol6yz5oGObwpT1h0D7DUtMsGa4Kid5sRnezLYEar/LLNHxpGWV1CNcMNeMzRvl9GZyMxBOTFAFMGFDvgElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmDxrsvL3N3iIErk68z4AsIJmCJfYxAX1Npx38AWAvZ9T9xe+B3qauxpytZPgQeBxm2RzeYWdxkpzIKfdgCxVDg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "26200F9C2E317FC52E9AFC7CFF09065ABAD8BAE89C897ABAF0A8C988DD32FD0F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:GLym8epLj4ZZzCr3lB4mk6jbutZRYv+TQaMPX5SGzQ8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:tygn1GYUllq3TDE8vUxNVaDBRTm2AszFlejicxPFHEo="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1676325614591,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA/GhYHJgsQ3LGOHG7Khk0nl2OoOQ2qIoTeVyTXOtnaY6EtbEHUA+ZDx9QrVIpzBQY82TFkNa7gmgBKauWAoYQDfb6iDAbTC1J78XpFPLu/T2Vf70TtaKdUWjgI5x5ZBFAVAirRMnjojcmrhX/UGTSKHJ+4gGYaD4sRzvY+usMCLgMc9/dBoCrYBHRcGBpwro6aQUk5TDwfHjI+CAFUBK343aD2pOf38fRhFpTjP6Cep6vsl044frbKT99mlVPsdWFM9nshnZp2bUlmIMcof6JFaDQ5kVwf6WIyfvn1EbUJ5srPN88AZNAwXItl3NsmU2Zn5OW9Pz6c81vvCmxkafALNOTkS/3Bvjo9zWkZd4GdAQQOEBLyCbR0BhURaDHaNcdwTvk1pd4lbIhBb5ArFtqqTbETQR9ZNNN4xV5nZP5gyz0LLoO/BPG2Uq2Qu5ugS8m9zOj76DTrtJUG3NBX2BezIe40c0le4m13T4StBOf9CyKpGZ5k4131ejZtcNpAfeKoonurxlD4EyV/f8rTvlDAEha93tGnV9g/LOFgocRsHB0eBhdWc7lpXHfOz5l0BzCIPj8q5kpUh2MIM8GJe5ELFsqQrfkt4FlaJBw579zRomx0DV0Bnx43Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4ZIaFqx/QhIPwpcshZbwXp639mSTihRxzGO6bQJWJuuB19wyxqKHrVJpAXzcjx06qcpOuvxkGzGQYBJN0LpUAg=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/network/messageRegistry.ts
+++ b/ironfish/src/network/messageRegistry.ts
@@ -5,6 +5,7 @@
 import { CannotSatisfyRequest } from './messages/cannotSatisfyRequest'
 import { DisconnectingMessage } from './messages/disconnecting'
 import { GetBlockHashesRequest, GetBlockHashesResponse } from './messages/getBlockHashes'
+import { GetBlockHeadersRequest, GetBlockHeadersResponse } from './messages/getBlockHeaders'
 import { GetBlocksRequest, GetBlocksResponse } from './messages/getBlocks'
 import {
   GetBlockTransactionsRequest,
@@ -83,6 +84,10 @@ const parseRpcNetworkMessage = (
       return GetCompactBlockRequest.deserialize(body, rpcId)
     case NetworkMessageType.GetCompactBlockResponse:
       return GetCompactBlockResponse.deserialize(body, rpcId)
+    case NetworkMessageType.GetBlockHeadersRequest:
+      return GetBlockHeadersRequest.deserialize(body, rpcId)
+    case NetworkMessageType.GetBlockHeadersResponse:
+      return GetBlockHeadersResponse.deserialize(body, rpcId)
     default:
       throw new Error(`Unknown RPC network message type: ${type}`)
   }

--- a/ironfish/src/network/messages/__fixtures__/getBlockHeaders.test.ts.fixture
+++ b/ironfish/src/network/messages/__fixtures__/getBlockHeaders.test.ts.fixture
@@ -1,0 +1,110 @@
+{
+  "GetBlockHeadersResponse serializes the object into a buffer and deserializes to the original object": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:BCtBfMP/skq71PETYlxXxm0dq9VoL3muPjQpozTyfgE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:3T039xk7I0BT8gt5QzW0+8okUhHfWQLX/vL3rtgD69Q="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676313126608,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1egmBgkkqNHc4UmiF58aB8LNByWr++3x/52jivAvUhaC/fZ0Yxwn3sR+Kj73uiSbhZv6fmwpBd8Sw7J5/po9oXU19qQpiYDwWWA+Xq8PjbOCjsh2btvG7llSlJBme3ICuhGhxgN3hX4ODBpmYmhAufwDYxtEyq82MVOhGk1wBdAN96Ndc7HDAwXnrAwEW6nsw1ggJ0k5PW4/k8SQZQnfEKhUyYT7GkbkbV+pTljjDWaulcQv9ip/9nH8csPvdIPm/DWaXJdwFMyY4El7dIRGdiMlSwmSK2VqZ1klQMg5GrB/+fvKnhQQgLFZ6ZnvAifJWuVDUe+cOlA6oBLD7ky1AYxpS8WVmFpvhaJNa0fpG3HOnhvrYZY5DLv2zoky/zYa2jOCyt6DxSE22+f/n7SmwHmZ+rZVVBK77RMg02BasCbVksHoww929j9A+V+pjETyjSx/Pwh3H1QFD8/v7zyV7uPfdZMQD4O0FieqH6cOXAcSoacYvcqHiu53NyLFkioXLOZqkk3xbOmWm90qSQH/1oBCl51lkoYQEwh4aPW1WN9Z+SidpRqYBTPgdiLipDPSqPVUm2xrYRYwPm6H++Bdhg2gGCGYnmeOMQtjlD10V11l0YTcp3YPdklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwd/bDxDj3vlDYuEfnJzdxWyh9HZHAPLBRDYdQssBjD0X93YdriM3qcRi2GZi27ca4ss248sGLQocB1BK0TQi/AA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ssOjjeK+j8GW2G5JbRGxKi1F4gZTD7pbwVOCHJoY7Sk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:AdF0iy65u+AzW1wRqkSZm7j8ayLSojl6UN9pzt+7id4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676313126896,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA/Hyg4kaK0A9UZ7jlxueS2g10dn65Av5UryiXPf8sCJ+tKmC5t/dVoiscOqfvbvVYPWEhBeevey5qe1e1aBrW7VNTphhIuXNARFceVsF3HF6oj96ncaNkL1b19N1KF7uVXTFV8jpIKH+SASR/UEjWCiunjTeexGB/kagZg799t1UQ4S7zX4AtZnitvRfryx838xBkr+U3VadYDx4Frp1jKigGd3cnbhXZ8G0PmlgBJMuo6pS3fmWoL/zp8NgF8PlQCRFD8outq6MjO3wvzIfgvTciQvkTTeWbMc0HOteToKh3SNIQSBO2reB5l6u0JM0ojwhTRjspL3pMVu7gtBkb0lviiXk8Cp7FWxMR2k9KxMZG6zyRXEMB8/JXT7Ixe7Fzb1oMPyLo9LjAw7bBF2l+/DWIPUfVs+mhulnUY19JdkdHMdRb22Fa1drMGrdT2odZzNiC9swQT+c9PWuQrUm9TgHLXcbdgaCMze+XCaMoU9VnUCerz4vQYyshgp9SR6uIxtaupo76z5hGC8lUvubcEXMOuFn4Z76ATt8LrGmkZWJyo5urgdluA8P1vNPVecV5gvXno2hAKd0LnQHdRWDgxobEORErGq+2YtTTrEnSZ9v16uEYRYSo8Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrZPms/ty/jx50fFsh+yPyDwvFeiOlpOQLL3DZFx+OEAtCiGc+gBpNRAIrtF/ItU4X8mMO7nw5wKOk6XLA5h/Aw=="
+        }
+      ]
+    }
+  ],
+  "GetBlockHeadersResponse throws if the given length does not match the number of hashes": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:vreARwgeIDL0iJUK3KSxm7TgdyhFCC5jZCMrUxIpPiU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:neYh0TXTqT4/5zldCz5yPxDitLyATh9ao70KqivUxCA="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676313127208,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAoL+N1CfYxnqsJL7zc/xoTrMQppWjH8gLjGQOYwvq/ruZEkKd9KxfW1qgVX+4T62bDVFzixwvcT9EsWhhOkiq8lDz+N05UuUq1DlhnO4HtVi2RdIqbLl2xiurySFZLcsxSBZYhQlXgE6U1WM3Kzh8aEmiVlZFwKJm2/D+25NPU5YIcXvGyCUhlIRwTTPdlrzH+0vPf8crQgpM5108HdFNtCNLChMpY/rlWDU+L5O6XFOrKma9cKuqLNalCe35Vb5tsNqLP/k/XTqrYkBachKMCw7JsYP9xcLmDrsRLbO+ZmFDHX/PeQlhj5zvw3bsTkHYVNx6ofHOqaA3/L4cLfizQSINpvUvuIqV3eRqeeGGiwq3EXzleUbHL5IG6JSi4mwkwfDdGvE0EXY3BPVWiwYxJXVF4wTIMcK3eBvhN8XB2BlbMz7ZQhicFlCn+YvIOhxJlU2pSRdstL8oLLNezjft6OGcG2sBqjmH1J/YrDLHeTFOpRXSxViDINjnvwq67rFdzVrDmkzRNnaHvPrUW74AS9vO2ffLy+r5984JxhLAYpmwshc8+xA27fgoV01EliM6aD6PTyF4NiacD6Gg2iPyv+sIEz+EYrwoDSSSt9ucEIRaa4mntCpfBUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnd2ft+05imPSAivoKDTu6xOxVsSOOhqNanvS1wiuTmGa69cWyGl6dR9eHOWpxkE6XaTL3DcKGsIF4xh/JrpTAg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:9dTzfhdu7VRWF3HrIXhM12CwWsxeevDW/gd5eViPlDU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:vFDY4nHca+eqLsCVR5egKKE8wGj/GkDeSGebhmqbcKg="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676313127505,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA6JbW9PkeYJrgJl7mh9OAcg1o85gnLClx39sKZIHYWcC0aDXm22l/Ti4aKROnQ3wNvmpvWHExn4BhO1c+5molqbxRmHrGhuSpSGlAJc8asnmRZeY8v3G9hKlzIy99Hg0EKIgG+MS4Ivt2IGWwtoxZVI5MD9Do7WgLjpEfCRxC2SURsPr8KHhpdosQ/7sVRUCzJG59w+AVHyVVdX02zlW2QYvMGluJN9VQ7gv0qO+zJLyUFH4fSoD+z6AfPPjoAbRz6ayyrxmRZG/riU+egf5zP41AbDrsHwMiyfdM7i4yY4/hvFZPF2IYwBVe/ruv/pszUrAXCAYlok7b76p/Y9MRG/UymEk19BYzaLkWFEpvONw3dtGDAQbRwlu1aRqFkaciHbXARZENcH/zg7qwne0x0O2x8e6H3yzioIG3EJBzbh4pEyV3e4tDHT0wRRRtn2HfFvGBVGxTU6+aFeKTObe1MmyXe5VJYnFCJMjAToSrZ+pDk85wp7DC7bn31FE8XtCczSxm+4h7xopXYk7Lb3BvBH2jw35LS0tW/L5WT70LYrTtrGqz2h34x+pWBfOXC3EUrepgk6+GcU/RSxP5oHKYePj9Sq4MRMzY94NG6b5UH7LkuvcGIcwct0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtYDrNZ8yjybYLGJLanUid4Wa23ekxEVay3vB8hbdyI+e+MTBfYqKD9MRdNRtdR7kAkrzFQaCBlc2ExOiuegECg=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/network/messages/getBlockHeaders.test.ts
+++ b/ironfish/src/network/messages/getBlockHeaders.test.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createNodeTest, useMinerBlockFixture } from '../../testUtilities'
+import { expectGetBlockHeadersResponseToMatch } from '../testUtilities'
+import { GetBlockHeadersRequest, GetBlockHeadersResponse } from './getBlockHeaders'
+
+describe('GetBlockHeadersRequest', () => {
+  it('serializes the object into a buffer and deserializes to the original object', () => {
+    const rpcId = 0
+    const message = new GetBlockHeadersRequest(1, 10, 0, false, rpcId)
+    const buffer = message.serialize()
+    const deserializedMessage = GetBlockHeadersRequest.deserialize(buffer, rpcId)
+    expect(deserializedMessage).toEqual(message)
+  })
+})
+
+describe('GetBlockHeadersResponse', () => {
+  const nodeTest = createNodeTest()
+
+  it('serializes the object into a buffer and deserializes to the original object', async () => {
+    const block1 = await useMinerBlockFixture(nodeTest.chain, 1)
+    const block2 = await useMinerBlockFixture(nodeTest.chain, 2)
+
+    const rpcId = 0
+    const message = new GetBlockHeadersResponse([block1.header, block2.header], rpcId)
+    const buffer = message.serialize()
+    const deserializedMessage = GetBlockHeadersResponse.deserialize(buffer, rpcId)
+    expectGetBlockHeadersResponseToMatch(deserializedMessage, message)
+  })
+
+  it('throws if the given length does not match the number of hashes', async () => {
+    const block1 = await useMinerBlockFixture(nodeTest.chain, 1)
+    const block2 = await useMinerBlockFixture(nodeTest.chain, 2)
+
+    const rpcId = 0
+    const message = new GetBlockHeadersResponse([block1.header, block2.header], rpcId)
+    const buffer = message.serialize()
+    buffer.writeUInt16LE(3, 0)
+    expect(() => GetBlockHeadersResponse.deserialize(buffer, rpcId)).toThrow()
+  })
+})

--- a/ironfish/src/network/messages/getBlockHeaders.ts
+++ b/ironfish/src/network/messages/getBlockHeaders.ts
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import bufio from 'bufio'
+import { BlockHeader } from '../../primitives'
+import { NetworkMessageType } from '../types'
+import { getBlockHeaderSize, readBlockHeader, writeBlockHeader } from '../utils/serializers'
+import { Direction, RpcNetworkMessage } from './rpcNetworkMessage'
+
+export class GetBlockHeadersRequest extends RpcNetworkMessage {
+  readonly start: number
+  readonly limit: number
+  readonly skip: number
+  readonly reverse: boolean
+
+  constructor(start: number, limit: number, skip: number, reverse: boolean, rpcId?: number) {
+    super(NetworkMessageType.GetBlockHeadersRequest, Direction.Request, rpcId)
+    this.start = start
+    this.limit = limit
+    this.skip = skip
+    this.reverse = reverse
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+    bw.writeU32(this.start)
+    bw.writeU16(this.limit)
+    bw.writeU16(this.skip)
+    bw.writeU8(Number(this.reverse))
+    return bw.render()
+  }
+
+  static deserialize(buffer: Buffer, rpcId: number): GetBlockHeadersRequest {
+    const reader = bufio.read(buffer, true)
+    const start = reader.readU32()
+    const limit = reader.readU16()
+    const skip = reader.readU16()
+    const reverse = Boolean(reader.readU8())
+    return new GetBlockHeadersRequest(start, limit, skip, reverse, rpcId)
+  }
+
+  getSize(): number {
+    let size = 0
+    size += 4 // start
+    size += 2 // limit
+    size += 2 // skip
+    size += 1 // reverse
+    return size
+  }
+}
+
+export class GetBlockHeadersResponse extends RpcNetworkMessage {
+  readonly headers: BlockHeader[]
+
+  constructor(headers: BlockHeader[], rpcId: number) {
+    super(NetworkMessageType.GetBlockHeadersResponse, Direction.Response, rpcId)
+    this.headers = headers
+  }
+
+  serialize(): Buffer {
+    const bw = bufio.write(this.getSize())
+
+    bw.writeU16(this.headers.length)
+
+    for (const header of this.headers) {
+      writeBlockHeader(bw, header)
+    }
+
+    return bw.render()
+  }
+
+  static deserialize(buffer: Buffer, rpcId: number): GetBlockHeadersResponse {
+    const reader = bufio.read(buffer, true)
+    const headers = []
+
+    const headersLength = reader.readU16()
+    for (let i = 0; i < headersLength; i++) {
+      const header = readBlockHeader(reader)
+      headers.push(header)
+    }
+
+    return new GetBlockHeadersResponse(headers, rpcId)
+  }
+
+  getSize(): number {
+    let size = 0
+    size += 2 // headers length
+    size += getBlockHeaderSize() * this.headers.length
+
+    return size
+  }
+}

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -5,6 +5,7 @@
 import ws from 'ws'
 import { Assert } from '../../assert'
 import { Identity, isIdentity } from '../identity'
+import { GetBlockHeadersResponse } from '../messages/getBlockHeaders'
 import { GetBlockTransactionsResponse } from '../messages/getBlockTransactions'
 import { GetCompactBlockResponse } from '../messages/getCompactBlock'
 import { IncomingPeerMessage, NetworkMessage } from '../messages/networkMessage'
@@ -247,4 +248,18 @@ export function expectGetBlockTransactionsResponseToMatch(
   })
 
   expect({ ...a, transactions: undefined }).toMatchObject({ ...b, transactions: undefined })
+}
+
+export function expectGetBlockHeadersResponseToMatch(
+  a: GetBlockHeadersResponse,
+  b: GetBlockHeadersResponse,
+): void {
+  expect(a.headers.length).toEqual(b.headers.length)
+  a.headers.forEach((headerA, headerIndexA) => {
+    const headerB = b.headers[headerIndexA]
+
+    expect(headerA.hash).toEqual(headerB.hash)
+  })
+
+  expect({ ...a, headers: undefined }).toMatchObject({ ...b, headers: undefined })
 }

--- a/ironfish/src/network/types.ts
+++ b/ironfish/src/network/types.ts
@@ -26,6 +26,8 @@ export enum NetworkMessageType {
   GetBlockTransactionsResponse = 18,
   GetCompactBlockRequest = 19,
   GetCompactBlockResponse = 20,
+  GetBlockHeadersRequest = 21,
+  GetBlockHeadersResponse = 22,
 }
 
 export type IsomorphicWebSocketConstructor = typeof WebSocket | typeof WSWebSocket


### PR DESCRIPTION
## Summary

This message will replace `GetBlockHashes` as the message used for syncing in a follow-up change. It also includes a `skip` and `reverse` flag, for more flexible future usage.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
