### PR TITLE
wallet prune

### DIFF
--- a/ironfish-cli/src/commands/wallet/prune.ts
+++ b/ironfish-cli/src/commands/wallet/prune.ts
@@ -35,7 +35,6 @@ export default class PruneCommand extends IronfishCommand {
       CliUx.ux.action.stop()
     }
 
-    await node.wallet.walletDb.close()
-    await node.wallet.close()
+    await node.closeDB()
   }
 }

--- a/ironfish-cli/src/commands/wallet/prune.ts
+++ b/ironfish-cli/src/commands/wallet/prune.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { NodeUtils } from '@ironfish/sdk'
+import { CliUx, Flags } from '@oclif/core'
+import { IronfishCommand } from '../../command'
+import { LocalFlags } from '../../flags'
+
+export default class PruneCommand extends IronfishCommand {
+  static description = 'Removes expired transactions from the wallet'
+
+  static hidden = false
+
+  static flags = {
+    ...LocalFlags,
+    compact: Flags.boolean({
+      char: 'c',
+      default: true,
+      allowNo: true,
+      description: 'Compact the database',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(PruneCommand)
+
+    CliUx.ux.action.start(`Opening node`)
+    const node = await this.sdk.node()
+    await NodeUtils.waitForOpen(node)
+    await node.wallet.open()
+    await node.wallet.walletDb.open()
+    CliUx.ux.action.stop('Done.')
+
+    if (flags.compact) {
+      CliUx.ux.action.start(`Compacting wallet database`)
+      await node.wallet.walletDb.db.compact()
+      CliUx.ux.action.stop()
+    }
+
+    await node.wallet.walletDb.close()
+    await node.wallet.close()
+  }
+}

--- a/ironfish-cli/src/commands/wallet/prune.ts
+++ b/ironfish-cli/src/commands/wallet/prune.ts
@@ -27,8 +27,6 @@ export default class PruneCommand extends IronfishCommand {
     CliUx.ux.action.start(`Opening node`)
     const node = await this.sdk.node()
     await NodeUtils.waitForOpen(node)
-    await node.wallet.open()
-    await node.wallet.walletDb.open()
     CliUx.ux.action.stop('Done.')
 
     if (flags.compact) {


### PR DESCRIPTION
## Summary
Wallet prune command to remove expired transactions.
This PR only calls wallet db compact().
Removing expired tx will be a separate PR

## Testing Plan
locally run `yarn start wallet:prune`
```
yarn start wallet:prune
yarn run v1.22.19
$ yarn build && yarn start:js wallet:prune
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:prune
Opening node... Done.
Compacting wallet database... done
✨  Done in 1.15s.
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
