### PR TITLE
feat(ironfish): use GetBlockHeaders if peer has the appropriate version

### DIFF
--- a/ironfish/src/network/version.ts
+++ b/ironfish/src/network/version.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const VERSION_PROTOCOL = 19
+export const VERSION_PROTOCOL = 20
 export const VERSION_PROTOCOL_MIN = 19
 
 export const MAX_REQUESTED_BLOCKS = 50


### PR DESCRIPTION
## Summary

**Builds on #3418** 

This allows us to use the new GetBlockHeaders message without requiring
a minimum version bump, as syncing from a peer on an older version will
default to the previously expected behavior of using GetBlockHashes.

## Testing Plan

Local testing

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
