### PR TITLE
Make account rpc parameter uniform and use getAccount()

### DIFF
--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -70,7 +70,7 @@ export class FaucetCommand extends IronfishCommand {
 
     try {
       await client.getFunds({
-        accountName,
+        account: accountName,
         email,
       })
     } catch (error: unknown) {

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -133,7 +133,7 @@ export class Burn extends IronfishCommand {
     if (flags.fee) {
       fee = CurrencyUtils.encode(flags.fee)
       const createResponse = await client.createTransaction({
-        sender: account,
+        account,
         outputs: [],
         burns: [
           {
@@ -159,7 +159,7 @@ export class Burn extends IronfishCommand {
       const feeRateOptions: { value: number; name: string }[] = []
 
       const createTransactionRequest: CreateTransactionRequest = {
-        sender: account,
+        account,
         outputs: [],
         burns: [
           {
@@ -265,7 +265,7 @@ ${CurrencyUtils.renderIron(
     try {
       const result = await client.postTransaction({
         transaction: rawTransactionResponse,
-        sender: account,
+        account,
       })
 
       stopProgressBar()

--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -28,23 +28,23 @@ export class DeleteCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { args, flags } = await this.parse(DeleteCommand)
     const confirm = flags.confirm
-    const name = args.account as string
+    const account = args.account as string
 
     const client = await this.sdk.connectRpc()
 
-    const response = await client.removeAccount({ name, confirm })
+    const response = await client.removeAccount({ account, confirm })
 
     if (response.content.needsConfirm) {
-      const value = await CliUx.ux.prompt(`Are you sure? Type ${name} to confirm`)
+      const value = await CliUx.ux.prompt(`Are you sure? Type ${account} to confirm`)
 
-      if (value !== name) {
-        this.log(`Aborting: ${value} did not match ${name}`)
+      if (value !== account) {
+        this.log(`Aborting: ${value} did not match ${account}`)
         this.exit(1)
       }
 
-      await client.removeAccount({ name, confirm: true })
+      await client.removeAccount({ account, confirm: true })
     }
 
-    this.log(`Account '${name}' successfully deleted.`)
+    this.log(`Account '${account}' successfully deleted.`)
   }
 }

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -176,7 +176,7 @@ export class Mint extends IronfishCommand {
       fee = flags.fee
 
       const createResponse = await client.createTransaction({
-        sender: account,
+        account,
         outputs: [],
         mints: [
           {
@@ -204,7 +204,7 @@ export class Mint extends IronfishCommand {
       const feeRateOptions: { value: number; name: string }[] = []
 
       const createTransactionRequest: CreateTransactionRequest = {
-        sender: account,
+        account,
         outputs: [],
         mints: [
           {
@@ -309,7 +309,7 @@ ${amountString} plus a transaction fee of ${feeString} with the account ${accoun
     try {
       const result = await client.postTransaction({
         transaction: rawTransactionResponse,
-        sender: account,
+        account,
       })
 
       stopProgressBar()

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -96,7 +96,7 @@ export class PostCommand extends IronfishCommand {
 
     const response = await client.postTransaction({
       transaction,
-      sender: flags.account,
+      account: flags.account,
       offline: flags.offline,
     })
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -201,7 +201,7 @@ export class Send extends IronfishCommand {
       const feeRateOptions: { value: number; name: string }[] = []
 
       const createTransactionRequest: CreateTransactionRequest = {
-        sender: from,
+        account: from,
         outputs: [
           {
             publicAddress: to,
@@ -247,7 +247,7 @@ export class Send extends IronfishCommand {
       rawTransactionResponse = createResponses[input.selection].content.transaction
     } else {
       const createResponse = await client.createTransaction({
-        sender: from,
+        account: from,
         outputs: [
           {
             publicAddress: to,
@@ -326,7 +326,7 @@ ${CurrencyUtils.renderIron(
     try {
       const result = await client.postTransaction({
         transaction: rawTransactionResponse,
-        sender: from,
+        account: from,
       })
 
       stopProgressBar()

--- a/ironfish-cli/src/commands/wallet/use.ts
+++ b/ironfish-cli/src/commands/wallet/use.ts
@@ -22,10 +22,10 @@ export class UseCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { args } = await this.parse(UseCommand)
-    const name = args.account as string
+    const account = args.account as string
 
     const client = await this.sdk.connectRpc()
-    await client.useAccount({ name })
-    this.log(`The default account is now: ${name}`)
+    await client.useAccount({ account })
+    this.log(`The default account is now: ${account}`)
   }
 }

--- a/ironfish/src/rpc/routes/faucet/getFunds.test.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.test.ts
@@ -10,82 +10,68 @@ jest.mock('axios')
 describe('Route faucet.getFunds', () => {
   const routeTest = createRouteTest()
 
-  describe('if the account does not exist in the DB', () => {
-    it('should fail', async () => {
-      await expect(
-        routeTest.client
-          .request('faucet/getFunds', { accountName: 'test-notfound' })
-          .waitForEnd(),
-      ).rejects.toThrow('Account test-notfound could not be found')
+  let accountName = 'test' + Math.random().toString()
+  const email = 'test@test.com'
+  let publicAddress = ''
+
+  beforeEach(async () => {
+    accountName = 'test' + Math.random().toString()
+    const account = await routeTest.node.wallet.createAccount(accountName, true)
+    publicAddress = account.publicAddress
+  })
+
+  describe('when the API request succeeds', () => {
+    it('returns a 200 status code', async () => {
+      routeTest.node.config.set('getFundsApi', 'foo.com')
+
+      axios.post = jest.fn().mockImplementationOnce(() => Promise.resolve({ data: { id: 5 } }))
+
+      const response = await routeTest.client
+        .request('faucet/getFunds', {
+          accountName,
+          email,
+        })
+        .waitForEnd()
+
+      // Response gives back string for ID
+      expect(response).toMatchObject({ status: 200, content: { id: '5' } })
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'foo.com',
+        {
+          email,
+          public_key: publicAddress,
+        },
+        expect.anything(),
+      )
     })
   })
 
-  describe('With a default account and the db', () => {
-    let accountName = 'test' + Math.random().toString()
-    const email = 'test@test.com'
-    let publicAddress = ''
-
-    beforeEach(async () => {
-      accountName = 'test' + Math.random().toString()
-      const account = await routeTest.node.wallet.createAccount(accountName, true)
-      publicAddress = account.publicAddress
-    })
-
-    describe('when the API request succeeds', () => {
-      it('returns a 200 status code', async () => {
-        routeTest.node.config.set('getFundsApi', 'foo.com')
-
-        axios.post = jest
-          .fn()
-          .mockImplementationOnce(() => Promise.resolve({ data: { id: 5 } }))
-
-        const response = await routeTest.client
-          .request('faucet/getFunds', {
-            accountName,
-            email,
-          })
-          .waitForEnd()
-
-        // Response gives back string for ID
-        expect(response).toMatchObject({ status: 200, content: { id: '5' } })
-
-        expect(axios.post).toHaveBeenCalledWith(
-          'foo.com',
-          {
-            email,
-            public_key: publicAddress,
-          },
-          expect.anything(),
-        )
-      })
-    })
-
-    describe('when too many faucet requests have been made', () => {
-      it('throws an error', async () => {
-        axios.post = jest.fn().mockImplementationOnce(() => {
-          throw {
-            response: {
-              data: {
-                code: 'faucet_max_requests_reached',
-                message: 'Too many faucet requests',
-              },
+  describe('when too many faucet requests have been made', () => {
+    it('throws an error', async () => {
+      axios.post = jest.fn().mockImplementationOnce(() => {
+        throw {
+          response: {
+            data: {
+              code: 'faucet_max_requests_reached',
+              message: 'Too many faucet requests',
             },
-          }
-        })
-        await expect(
-          routeTest.client.request('faucet/getFunds', { accountName, email }).waitForEnd(),
-        ).rejects.toThrow(RpcRequestError)
+          },
+        }
       })
+      await expect(
+        routeTest.client.request('faucet/getFunds', { accountName, email }).waitForEnd(),
+      ).rejects.toThrow(RpcRequestError)
     })
+  })
 
-    describe('when the API request fails', () => {
-      it('throws an error', async () => {
-        const apiResponse = new Error('API failure') as AxiosError
-        axios.post = jest.fn().mockRejectedValueOnce(apiResponse)
-        await expect(
-          routeTest.client.request('faucet/getFunds', { accountName, email }).waitForEnd(),
-        ).rejects.toThrow('API failure')
-      })
+  describe('when the API request fails', () => {
+    it('throws an error', async () => {
+      const apiResponse = new Error('API failure') as AxiosError
+      axios.post = jest.fn().mockRejectedValueOnce(apiResponse)
+      await expect(
+        routeTest.client.request('faucet/getFunds', { accountName, email }).waitForEnd(),
+      ).rejects.toThrow('API failure')
     })
   })
 })

--- a/ironfish/src/rpc/routes/faucet/getFunds.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.ts
@@ -5,15 +5,16 @@ import { AxiosError } from 'axios'
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { WebApi } from '../../../webApi'
-import { ERROR_CODES, ResponseError, ValidationError } from '../../adapters'
+import { ERROR_CODES, ResponseError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
+import { getAccount } from '../wallet/utils'
 
-export type GetFundsRequest = { accountName: string; email?: string }
+export type GetFundsRequest = { account?: string; email?: string }
 export type GetFundsResponse = { id: string }
 
 export const GetFundsRequestSchema: yup.ObjectSchema<GetFundsRequest> = yup
   .object({
-    accountName: yup.string().required(),
+    account: yup.string(),
     email: yup.string().strip(true),
   })
   .defined()
@@ -28,10 +29,7 @@ router.register<typeof GetFundsRequestSchema, GetFundsResponse>(
   `${ApiNamespace.faucet}/getFunds`,
   GetFundsRequestSchema,
   async (request, node): Promise<void> => {
-    const account = node.wallet.getAccountByName(request.data.accountName)
-    if (!account) {
-      throw new ValidationError(`Account ${request.data.accountName} could not be found`)
-    }
+    const account = getAccount(node, request.data.account)
 
     const api = new WebApi({
       getFundsEndpoint: node.config.get('getFundsApi'),

--- a/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
@@ -17,19 +17,6 @@ describe('burnAsset', () => {
     await routeTest.node.wallet.createAccount('account', true)
   })
 
-  describe('with no default account', () => {
-    it('throws a validation error', async () => {
-      await expect(
-        routeTest.client.burnAsset({
-          account: 'fake-account',
-          assetId: '{ url: hello }',
-          fee: '1',
-          value: '1',
-        }),
-      ).rejects.toThrow('No account found with name fake-account')
-    })
-  })
-
   describe('with an invalid fee', () => {
     it('throws a validation error', async () => {
       await expect(

--- a/ironfish/src/rpc/routes/wallet/burnAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.ts
@@ -4,8 +4,8 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { CurrencyUtils, YupUtils } from '../../../utils'
-import { ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
+import { getAccount } from './utils'
 
 export interface BurnAssetRequest {
   account: string
@@ -49,10 +49,7 @@ router.register<typeof BurnAssetRequestSchema, BurnAssetResponse>(
   `${ApiNamespace.wallet}/burnAsset`,
   BurnAssetRequestSchema,
   async (request, node): Promise<void> => {
-    const account = node.wallet.getAccountByName(request.data.account)
-    if (!account) {
-      throw new ValidationError(`No account found with name ${request.data.account}`)
-    }
+    const account = getAccount(node, request.data.account)
 
     const fee = CurrencyUtils.decode(request.data.fee)
     const value = CurrencyUtils.decode(request.data.value)

--- a/ironfish/src/rpc/routes/wallet/createTransaction.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.test.slow.ts
@@ -56,7 +56,7 @@ describe('Route wallet/createTransaction', () => {
     }
 
     const response = await routeTest.client.createTransaction({
-      sender: 'existingAccount',
+      account: 'existingAccount',
       outputs: [
         {
           publicAddress: '0d804ea639b2547d1cd612682bf99f7cad7aad6d59fd5457f61272defcd4bf5b',

--- a/ironfish/src/rpc/routes/wallet/createTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.test.ts
@@ -10,7 +10,7 @@ import { Account } from '../../../wallet'
 import { ERROR_CODES } from '../../adapters/errors'
 
 const REQUEST_PARAMS = {
-  sender: 'existingAccount',
+  account: 'existingAccount',
   outputs: [
     {
       publicAddress: '0d804ea639b2547d1cd612682bf99f7cad7aad6d59fd5457f61272defcd4bf5b',
@@ -23,7 +23,7 @@ const REQUEST_PARAMS = {
 }
 
 const REQUEST_PARAMS_WITH_MULTIPLE_RECIPIENTS = {
-  sender: 'existingAccount',
+  account: 'existingAccount',
   outputs: [
     {
       publicAddress: '0d804ea639b2547d1cd612682bf99f7cad7aad6d59fd5457f61272defcd4bf5b',
@@ -168,7 +168,7 @@ describe('Route wallet/createTransaction', () => {
     }
 
     const response = await routeTest.client.createTransaction({
-      sender: 'existingAccount',
+      account: 'existingAccount',
       outputs: [
         {
           publicAddress: '0d804ea639b2547d1cd612682bf99f7cad7aad6d59fd5457f61272defcd4bf5b',
@@ -213,7 +213,7 @@ describe('Route wallet/createTransaction', () => {
     }
 
     const response = await routeTest.client.createTransaction({
-      sender: 'existingAccount',
+      account: 'existingAccount',
       outputs: [
         {
           publicAddress: '0d804ea639b2547d1cd612682bf99f7cad7aad6d59fd5457f61272defcd4bf5b',
@@ -259,7 +259,7 @@ describe('Route wallet/createTransaction', () => {
     const asset = new Asset(sender.spendingKey, 'mint-asset', 'metadata')
 
     const response = await routeTest.client.createTransaction({
-      sender: 'existingAccount',
+      account: 'existingAccount',
       outputs: [
         {
           publicAddress: '0d804ea639b2547d1cd612682bf99f7cad7aad6d59fd5457f61272defcd4bf5b',
@@ -314,7 +314,7 @@ describe('Route wallet/createTransaction', () => {
 
     await expect(
       routeTest.client.createTransaction({
-        sender: 'existingAccount',
+        account: 'existingAccount',
         outputs: [
           {
             publicAddress: '0d804ea639b2547d1cd612682bf99f7cad7aad6d59fd5457f61272defcd4bf5b',
@@ -355,7 +355,7 @@ describe('Route wallet/createTransaction', () => {
 
     await expect(
       routeTest.client.createTransaction({
-        sender: 'existingAccount',
+        account: 'existingAccount',
         outputs: [
           {
             publicAddress: '0d804ea639b2547d1cd612682bf99f7cad7aad6d59fd5457f61272defcd4bf5b',
@@ -392,7 +392,7 @@ describe('Route wallet/createTransaction', () => {
 
     await expect(
       routeTest.client.createTransaction({
-        sender: 'existingAccount',
+        account: 'existingAccount',
         outputs: [
           {
             publicAddress: '0d804ea639b2547d1cd612682bf99f7cad7aad6d59fd5457f61272defcd4bf5b',

--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -10,9 +10,10 @@ import { CurrencyUtils, YupUtils } from '../../../utils'
 import { NotEnoughFundsError } from '../../../wallet/errors'
 import { ERROR_CODES, ValidationError } from '../../adapters/errors'
 import { ApiNamespace, router } from '../router'
+import { getAccount } from './utils'
 
 export type CreateTransactionRequest = {
-  sender: string
+  account: string
   outputs: {
     publicAddress: string
     amount: string
@@ -42,7 +43,7 @@ export type CreateTransactionResponse = {
 
 export const CreateTransactionRequestSchema: yup.ObjectSchema<CreateTransactionRequest> = yup
   .object({
-    sender: yup.string().defined(),
+    account: yup.string().defined(),
     outputs: yup
       .array(
         yup
@@ -97,11 +98,7 @@ router.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse
   async (request, node): Promise<void> => {
     const data = request.data
 
-    const account = node.wallet.getAccountByName(data.sender)
-
-    if (!account) {
-      throw new ValidationError(`No account found with name ${data.sender}`)
-    }
+    const account = getAccount(node, request.data.account)
 
     // The node must be connected to the network first
     if (!node.peerNetwork.isReady) {

--- a/ironfish/src/rpc/routes/wallet/exportAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.ts
@@ -41,8 +41,7 @@ router.register<typeof ExportAccountRequestSchema, ExportAccountResponse>(
   ExportAccountRequestSchema,
   (request, node): void => {
     const account = getAccount(node, request.data.account)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { id, ...accountInfo } = account.serialize()
+    const { id: _, ...accountInfo } = account.serialize()
     request.end({ account: accountInfo })
   },
 )

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -13,20 +13,6 @@ describe('mint', () => {
     await routeTest.node.wallet.createAccount('account', true)
   })
 
-  describe('with no default account', () => {
-    it('throws a validation error', async () => {
-      await expect(
-        routeTest.client.mintAsset({
-          account: 'fake-account',
-          fee: '1',
-          metadata: '{ url: hello }',
-          name: 'fake-coin',
-          value: '1',
-        }),
-      ).rejects.toThrow('No account found with name fake-account')
-    })
-  })
-
   describe('with an invalid fee', () => {
     it('throws a validation error', async () => {
       await expect(

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -5,8 +5,8 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { CurrencyUtils, YupUtils } from '../../../utils'
 import { MintAssetOptions } from '../../../wallet/interfaces/mintAssetOptions'
-import { ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
+import { getAccount } from './utils'
 
 export interface MintAssetRequest {
   account: string
@@ -54,10 +54,7 @@ router.register<typeof MintAssetRequestSchema, MintAssetResponse>(
   `${ApiNamespace.wallet}/mintAsset`,
   MintAssetRequestSchema,
   async (request, node): Promise<void> => {
-    const account = node.wallet.getAccountByName(request.data.account)
-    if (!account) {
-      throw new ValidationError(`No account found with name ${request.data.account}`)
-    }
+    const account = getAccount(node, request.data.account)
 
     const fee = CurrencyUtils.decode(request.data.fee)
     const value = CurrencyUtils.decode(request.data.value)

--- a/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
@@ -21,7 +21,7 @@ describe('Route wallet/postTransaction', () => {
     const rawTransaction = await createRawTransaction(options)
     const response = await routeTest.client.postTransaction({
       transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
-      sender: account.name,
+      account: account.name,
       offline: true,
     })
 
@@ -41,7 +41,7 @@ describe('Route wallet/postTransaction', () => {
     const rawTransaction = await createRawTransaction(options)
     const response = await routeTest.client.postTransaction({
       transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
-      sender: account.name,
+      account: account.name,
     })
 
     expect(addSpy).toHaveBeenCalledTimes(1)
@@ -55,7 +55,7 @@ describe('Route wallet/postTransaction', () => {
     await expect(
       routeTest.client.postTransaction({
         transaction: '0xdeadbeef',
-        sender: account.name,
+        account: account.name,
       }),
     ).rejects.toThrow('Out of bounds read (offset=0).')
   })

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -8,7 +8,7 @@ import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
 export type PostTransactionRequest = {
-  sender?: string
+  account?: string
   transaction: string
   offline?: boolean
 }
@@ -19,7 +19,7 @@ export type PostTransactionResponse = {
 
 export const PostTransactionRequestSchema: yup.ObjectSchema<PostTransactionRequest> = yup
   .object({
-    sender: yup.string().strip(true),
+    account: yup.string().strip(true),
     transaction: yup.string().defined(),
     offline: yup.boolean().optional(),
   })
@@ -35,7 +35,7 @@ router.register<typeof PostTransactionRequestSchema, PostTransactionResponse>(
   `${ApiNamespace.wallet}/postTransaction`,
   PostTransactionRequestSchema,
   async (request, node): Promise<void> => {
-    const account = getAccount(node, request.data.sender)
+    const account = getAccount(node, request.data.account)
 
     const rawTransactionBytes = Buffer.from(request.data.transaction, 'hex')
     const rawTransaction = RawTransactionSerde.deserialize(rawTransactionBytes)

--- a/ironfish/src/rpc/routes/wallet/removeAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/removeAccount.ts
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
+import { getAccount } from './utils'
 
-export type RemoveAccountRequest = { name: string; confirm?: boolean }
+export type RemoveAccountRequest = { account: string; confirm?: boolean }
 export type RemoveAccountResponse = { needsConfirm?: boolean }
 
 export const RemoveAccountRequestSchema: yup.ObjectSchema<RemoveAccountRequest> = yup
   .object({
-    name: yup.string().defined(),
+    account: yup.string().defined(),
     confirm: yup.boolean().optional(),
   })
   .defined()
@@ -25,24 +25,13 @@ router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
   `${ApiNamespace.wallet}/remove`,
   RemoveAccountRequestSchema,
   async (request, node): Promise<void> => {
-    const name = request.data.name
-    const account = node.wallet.getAccountByName(name)
-
-    if (!account) {
-      throw new ValidationError(
-        `There is no account with the name ${name}. Options are:\n` +
-          node.wallet
-            .listAccounts()
-            .map((a) => a.name)
-            .join('\n'),
-      )
-    }
+    const account = getAccount(node, request.data.account)
 
     if (!request.data.confirm) {
       const balances = await account.getUnconfirmedBalances()
 
       for (const [_, { unconfirmed }] of balances) {
-        if (unconfirmed !== BigInt(0)) {
+        if (unconfirmed !== 0n) {
           request.end({ needsConfirm: true })
           return
         }

--- a/ironfish/src/rpc/routes/wallet/useAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/useAccount.ts
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
+import { getAccount } from './utils'
 
-export type UseAccountRequest = { name: string }
+export type UseAccountRequest = { account: string }
 export type UseAccountResponse = undefined
 
 export const UseAccountRequestSchema: yup.ObjectSchema<UseAccountRequest> = yup
   .object({
-    name: yup.string().defined(),
+    account: yup.string().defined(),
   })
   .defined()
 
@@ -22,19 +22,7 @@ router.register<typeof UseAccountRequestSchema, UseAccountResponse>(
   `${ApiNamespace.wallet}/use`,
   UseAccountRequestSchema,
   async (request, node): Promise<void> => {
-    const name = request.data.name
-    const account = node.wallet.getAccountByName(name)
-
-    if (!account) {
-      throw new ValidationError(
-        `There is no account with the name ${name}. Options are:\n` +
-          node.wallet
-            .listAccounts()
-            .map((a) => a.name)
-            .join('\n'),
-      )
-    }
-
+    const account = getAccount(node, request.data.account)
     await node.wallet.setDefaultAccount(account.name)
     request.end()
   },


### PR DESCRIPTION
## Summary

This standardizes on the name "account" for passing in an account as the context for all wallet operations.

We also weren't using getAccount() everywhere.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
