### PR TITLE
feat: SaplingKey.view_key update (PR 2)

### DIFF
--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE};
+use crate::{
+    keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE},
+    ViewKey,
+};
 
 use super::{shared_secret, PublicAddress, SaplingKey};
 use group::Curve;
@@ -133,4 +136,21 @@ fn test_from_and_to_words() {
     let key =
         SaplingKey::from_words(words, bip39::Language::English).expect("key should be created");
     assert_eq!(key.spending_key, key_bytes);
+}
+
+#[test]
+fn test_view_key() {
+    let key =
+        SaplingKey::from_hex("d96dc74bbca05dffb14a5631024588364b0cc9f583b5c11908b6ea98a2b778f7")
+            .expect("Key should be generated");
+    let view_key = key.view_key();
+    let view_key_hex = view_key.hex_key();
+    assert_eq!(view_key_hex, "498b5103a72c41237c3f2bca96f20100f5a3a8a17c6b8366a485fd16e8931a5d2ff2eb8f991032c815414ff0ae2d8bc3ea3b56bffc481db3f28e800050244463");
+
+    let recreated_key = ViewKey::from_hex(&view_key_hex).expect("Key should be created from hex");
+    assert_eq!(view_key.authorizing_key, recreated_key.authorizing_key);
+    assert_eq!(
+        view_key.nullifier_deriving_key,
+        recreated_key.nullifier_deriving_key
+    );
 }

--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::{
-    keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE},
-    ViewKey,
-};
+use crate::keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE};
 
 use super::{shared_secret, PublicAddress, SaplingKey};
 use group::Curve;
@@ -136,21 +133,4 @@ fn test_from_and_to_words() {
     let key =
         SaplingKey::from_words(words, bip39::Language::English).expect("key should be created");
     assert_eq!(key.spending_key, key_bytes);
-}
-
-#[test]
-fn test_view_key() {
-    let key =
-        SaplingKey::from_hex("d96dc74bbca05dffb14a5631024588364b0cc9f583b5c11908b6ea98a2b778f7")
-            .expect("Key should be generated");
-    let view_key = key.view_key();
-    let view_key_hex = view_key.hex_key();
-    assert_eq!(view_key_hex, "498b5103a72c41237c3f2bca96f20100f5a3a8a17c6b8366a485fd16e8931a5d2ff2eb8f991032c815414ff0ae2d8bc3ea3b56bffc481db3f28e800050244463");
-
-    let recreated_key = ViewKey::from_hex(&view_key_hex).expect("Key should be created from hex");
-    assert_eq!(view_key.authorizing_key, recreated_key.authorizing_key);
-    assert_eq!(
-        view_key.nullifier_deriving_key,
-        recreated_key.nullifier_deriving_key
-    );
 }

--- a/ironfish-rust/src/keys/view_keys.rs
+++ b/ironfish-rust/src/keys/view_keys.rs
@@ -97,7 +97,13 @@ impl IncomingViewKey {
 /// Referred to as `ViewingKey` in the literature.
 #[derive(Clone)]
 pub struct ViewKey {
+    /// Part of the full viewing key. Generally referred to as
+    /// `ak` in the literature. Derived from spend_authorizing_key using scalar
+    /// multiplication in Sapling. Used to construct incoming viewing key.
     pub authorizing_key: jubjub::SubgroupPoint,
+    /// Part of the full viewing key. Generally referred to as
+    /// `nk` in the literature. Derived from proof_authorizing_key using scalar
+    /// multiplication. Used to construct incoming viewing key.
     pub nullifier_deriving_key: jubjub::SubgroupPoint,
 }
 
@@ -244,15 +250,14 @@ mod test {
             "d96dc74bbca05dffb14a5631024588364b0cc9f583b5c11908b6ea98a2b778f7",
         )
         .expect("Key should be generated");
-        let view_key = key.view_key();
-        let view_key_hex = view_key.hex_key();
+        let view_key_hex = key.view_key.hex_key();
         assert_eq!(view_key_hex, "498b5103a72c41237c3f2bca96f20100f5a3a8a17c6b8366a485fd16e8931a5d2ff2eb8f991032c815414ff0ae2d8bc3ea3b56bffc481db3f28e800050244463");
 
         let recreated_key =
             ViewKey::from_hex(&view_key_hex).expect("Key should be created from hex");
-        assert_eq!(view_key.authorizing_key, recreated_key.authorizing_key);
+        assert_eq!(key.view_key.authorizing_key, recreated_key.authorizing_key);
         assert_eq!(
-            view_key.nullifier_deriving_key,
+            key.view_key.nullifier_deriving_key,
             recreated_key.nullifier_deriving_key
         );
     }

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -298,7 +298,7 @@ impl<'a> Note {
                 .hash_length(32)
                 .personal(PRF_NF_PERSONALIZATION)
                 .to_state()
-                .update(&private_key.sapling_viewing_key().nk.to_bytes())
+                .update(&private_key.view_key.nullifier_deriving_key.to_bytes())
                 .update(&rho.to_bytes())
                 .finalize()
                 .as_bytes(),

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -98,7 +98,7 @@ impl UnsignedMintDescription {
             redjubjub::PublicKey::from_private(&randomized_private_key, SPENDING_KEY_GENERATOR);
 
         let transaction_randomized_public_key =
-            redjubjub::PublicKey(spender_key.authorizing_key.into())
+            redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
                 .randomize(self.public_key_randomness, SPENDING_KEY_GENERATOR);
 
         if randomized_public_key.0 != transaction_randomized_public_key.0 {
@@ -247,7 +247,7 @@ mod test {
         let value = 5;
 
         let public_key_randomness = jubjub::Fr::random(thread_rng());
-        let randomized_public_key = redjubjub::PublicKey(key.authorizing_key.into())
+        let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let mint = MintBuilder::new(asset, value);
@@ -277,7 +277,7 @@ mod test {
             .verify_signature(&other_sig_hash, &randomized_public_key)
             .is_err());
 
-        let other_randomized_public_key = redjubjub::PublicKey(key.authorizing_key.into())
+        let other_randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(jubjub::Fr::random(thread_rng()), SPENDING_KEY_GENERATOR);
         assert!(description
             .verify_signature(&sig_hash, &other_randomized_public_key)
@@ -296,7 +296,7 @@ mod test {
         let value = 5;
 
         let public_key_randomness = jubjub::Fr::random(thread_rng());
-        let randomized_public_key = redjubjub::PublicKey(key.authorizing_key.into())
+        let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let mint = MintBuilder::new(asset, value);

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -262,8 +262,9 @@ impl ProposedTransaction {
         // The public key after randomization has been applied. This is used
         // during signature verification. Referred to as `rk` in the literature
         // Calculated from the authorizing key and the public_key_randomness.
-        let randomized_public_key = redjubjub::PublicKey(self.spender_key.authorizing_key.into())
-            .randomize(self.public_key_randomness, SPENDING_KEY_GENERATOR);
+        let randomized_public_key =
+            redjubjub::PublicKey(self.spender_key.view_key.authorizing_key.into())
+                .randomize(self.public_key_randomness, SPENDING_KEY_GENERATOR);
 
         // Build descriptions
         let mut unsigned_spends = Vec::with_capacity(self.spends.len());
@@ -365,8 +366,9 @@ impl ProposedTransaction {
             .write_i64::<LittleEndian>(*self.value_balances.fee())
             .unwrap();
 
-        let randomized_public_key = redjubjub::PublicKey(self.spender_key.authorizing_key.into())
-            .randomize(self.public_key_randomness, SPENDING_KEY_GENERATOR);
+        let randomized_public_key =
+            redjubjub::PublicKey(self.spender_key.view_key.authorizing_key.into())
+                .randomize(self.public_key_randomness, SPENDING_KEY_GENERATOR);
 
         hasher
             .write_all(&randomized_public_key.0.to_bytes())

--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -234,8 +234,9 @@ mod test {
     fn test_output_miners_fee() {
         let spender_key = SaplingKey::generate_key();
         let public_key_randomness = jubjub::Fr::random(thread_rng());
-        let randomized_public_key = redjubjub::PublicKey(spender_key.authorizing_key.into())
-            .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
+        let randomized_public_key =
+            redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
+                .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let note = Note::new(
             spender_key.public_address(),
@@ -263,8 +264,9 @@ mod test {
         let spender_key = SaplingKey::generate_key();
         let receiver_key = SaplingKey::generate_key();
         let public_key_randomness = jubjub::Fr::random(thread_rng());
-        let randomized_public_key = redjubjub::PublicKey(spender_key.authorizing_key.into())
-            .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
+        let randomized_public_key =
+            redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
+                .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let note = Note::new(
             receiver_key.public_address(),
@@ -290,8 +292,9 @@ mod test {
         let spender_key = SaplingKey::generate_key();
         let receiver_key = SaplingKey::generate_key();
         let public_key_randomness = jubjub::Fr::random(thread_rng());
-        let randomized_public_key = redjubjub::PublicKey(spender_key.authorizing_key.into())
-            .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
+        let randomized_public_key =
+            redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
+                .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let note = Note::new(
             receiver_key.public_address(),

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -165,7 +165,7 @@ impl UnsignedSpendDescription {
             redjubjub::PublicKey::from_private(&randomized_private_key, SPENDING_KEY_GENERATOR);
 
         let transaction_randomized_public_key =
-            redjubjub::PublicKey(spender_key.authorizing_key.into())
+            redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
                 .randomize(self.public_key_randomness, SPENDING_KEY_GENERATOR);
 
         if randomized_public_key.0 != transaction_randomized_public_key.0 {
@@ -402,7 +402,7 @@ mod test {
         let spend = SpendBuilder::new(note, &witness);
 
         let public_key_randomness = jubjub::Fr::random(thread_rng());
-        let randomized_public_key = redjubjub::PublicKey(key.authorizing_key.into())
+        let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         // signature comes from transaction, normally


### PR DESCRIPTION
## Summary
Updates the `SaplingKey` struct to contain the `ViewKey` struct instead of the `authorizing_key` and `nullifier_deriving_key` components.
Lots of reference changes from `SaplingKey.authorizing_key` to `SaplingKey.view_key.authorizing_key`.

Part 1 here https://github.com/iron-fish/ironfish/pull/3423
Part 3 here https://github.com/iron-fish/ironfish/pull/3433
Part 4 here https://github.com/iron-fish/ironfish/pull/3436
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
