### PR TITLE
feat: ViewKey rust nodejs (PR 4)

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -53,6 +53,7 @@ export const enum LanguageCode {
 }
 export interface Key {
   spending_key: string
+  view_key: string
   incoming_view_key: string
   outgoing_view_key: string
   public_address: string

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -57,6 +57,8 @@ impl From<LanguageCode> for Language {
 pub struct Key {
     #[napi(js_name = "spending_key")]
     pub spending_key: String,
+    #[napi(js_name = "view_key")]
+    pub view_key: String,
     #[napi(js_name = "incoming_view_key")]
     pub incoming_view_key: String,
     #[napi(js_name = "outgoing_view_key")]
@@ -71,6 +73,7 @@ pub fn generate_key() -> Key {
 
     Key {
         spending_key: sapling_key.hex_spending_key(),
+        view_key: sapling_key.view_key().hex_key(),
         incoming_view_key: sapling_key.incoming_view_key().hex_key(),
         outgoing_view_key: sapling_key.outgoing_view_key().hex_key(),
         public_address: sapling_key.public_address().hex_public_address(),
@@ -96,6 +99,7 @@ pub fn generate_key_from_private_key(private_key: String) -> Result<Key> {
 
     Ok(Key {
         spending_key: sapling_key.hex_spending_key(),
+        view_key: sapling_key.view_key().hex_key(),
         incoming_view_key: sapling_key.incoming_view_key().hex_key(),
         outgoing_view_key: sapling_key.outgoing_view_key().hex_key(),
         public_address: sapling_key.public_address().hex_public_address(),

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -38,6 +38,13 @@ describe('Demonstrate the Sapling API', () => {
     expect(hexKeyGenerated).toEqual(hexKey)
   })
 
+  it('ViewKey concatenated key should be generated from spending key deterministically', () => {
+    const hexSpendingKey = 'd96dc74bbca05dffb14a5631024588364b0cc9f583b5c11908b6ea98a2b778f7'
+    const key = generateKeyFromPrivateKey(hexSpendingKey)
+    // concatenated bytes of authorizing_key and nullifier_deriving_key
+    expect(key.view_key).toEqual('498b5103a72c41237c3f2bca96f20100f5a3a8a17c6b8366a485fd16e8931a5d2ff2eb8f991032c815414ff0ae2d8bc3ea3b56bffc481db3f28e800050244463')
+  })
+
   it('Should generate a new public address given a spending key', () => {
     const key = generateKey()
     const newKey = generateKeyFromPrivateKey(key.spending_key)

--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE};
+use crate::{
+    keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE},
+    ViewKey,
+};
 
 use super::{shared_secret, PublicAddress, SaplingKey};
 use group::Curve;
@@ -133,4 +136,21 @@ fn test_from_and_to_words() {
     let key =
         SaplingKey::from_words(words, bip39::Language::English).expect("key should be created");
     assert_eq!(key.spending_key, key_bytes);
+}
+
+#[test]
+fn test_view_key() {
+    let key =
+        SaplingKey::from_hex("d96dc74bbca05dffb14a5631024588364b0cc9f583b5c11908b6ea98a2b778f7")
+            .expect("Key should be generated");
+    let view_key = key.view_key();
+    let view_key_hex = view_key.hex_key();
+    assert_eq!(view_key_hex, "498b5103a72c41237c3f2bca96f20100f5a3a8a17c6b8366a485fd16e8931a5d2ff2eb8f991032c815414ff0ae2d8bc3ea3b56bffc481db3f28e800050244463");
+
+    let recreated_key = ViewKey::from_hex(&view_key_hex).expect("Key should be created from hex");
+    assert_eq!(view_key.authorizing_key, recreated_key.authorizing_key);
+    assert_eq!(
+        view_key.nullifier_deriving_key,
+        recreated_key.nullifier_deriving_key
+    );
 }

--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::{
-    keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE},
-    ViewKey,
-};
+use crate::keys::{ephemeral::EphemeralKeyPair, PUBLIC_ADDRESS_SIZE};
 
 use super::{shared_secret, PublicAddress, SaplingKey};
 use group::Curve;
@@ -136,21 +133,4 @@ fn test_from_and_to_words() {
     let key =
         SaplingKey::from_words(words, bip39::Language::English).expect("key should be created");
     assert_eq!(key.spending_key, key_bytes);
-}
-
-#[test]
-fn test_view_key() {
-    let key =
-        SaplingKey::from_hex("d96dc74bbca05dffb14a5631024588364b0cc9f583b5c11908b6ea98a2b778f7")
-            .expect("Key should be generated");
-    let view_key = key.view_key();
-    let view_key_hex = view_key.hex_key();
-    assert_eq!(view_key_hex, "498b5103a72c41237c3f2bca96f20100f5a3a8a17c6b8366a485fd16e8931a5d2ff2eb8f991032c815414ff0ae2d8bc3ea3b56bffc481db3f28e800050244463");
-
-    let recreated_key = ViewKey::from_hex(&view_key_hex).expect("Key should be created from hex");
-    assert_eq!(view_key.authorizing_key, recreated_key.authorizing_key);
-    assert_eq!(
-        view_key.nullifier_deriving_key,
-        recreated_key.nullifier_deriving_key
-    );
 }


### PR DESCRIPTION
## Summary
Updates the NAPI bindings in the `ironfish-rust-nodejs` package for usage in typescript

What was originally:
```
export interface Key {
  spending_key: string
  incoming_view_key: string
  outgoing_view_key: string
  public_address: string
}
```
will now be:
```
export interface Key {
  spending_key: string
  view_key: string
  incoming_view_key: string
  outgoing_view_key: string
  public_address: string
}
```

We can leave `incoming_view_key` returned for convenience or we can clean up at end of project, I don't have a strong preference.

PR 3 here: https://github.com/iron-fish/ironfish/pull/3433

## Testing Plan
Tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
