### PR TITLE
Change chain:power to follow the new CLI ux guide

### DIFF
--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -30,14 +30,13 @@ export default class Power extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(Power)
-    const history = flags.history as number | null | undefined
     const block = args.block as number | null | undefined
 
     const client = await this.sdk.connectRpc()
 
     const data = await client.getNetworkHashPower({
       sequence: block,
-      blocks: history,
+      blocks: flags.history,
     })
 
     const formattedHashesPerSecond = FileUtils.formatHashRate(data.content.hashesPerSecond)

--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -2,50 +2,48 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { FileUtils } from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
 import { parseNumber } from '../../args'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 
 export default class Power extends IronfishCommand {
-  static description = "Show the network's hash power (hash/s)"
+  static description = "Show the network's hash power per second"
 
   static flags = {
     ...LocalFlags,
+    history: Flags.integer({
+      required: false,
+      description:
+        'The number of blocks to look back to calculate the network hashes per second',
+    }),
   }
 
   static args = [
     {
-      name: 'blocks',
+      name: 'block',
       parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
       required: false,
-      description:
-        'The number of blocks to look back to calculate the power. This value must be > 0',
-    },
-    {
-      name: 'sequence',
-      parse: (input: string): Promise<number | null> => Promise.resolve(parseNumber(input)),
-      required: false,
-      description: 'The sequence of the latest block from when to estimate network speed ',
+      description: 'The sequence of the block to estimate network speed for',
     },
   ]
 
   async start(): Promise<void> {
-    const { args } = await this.parse(Power)
-    const inputBlocks = args.blocks as number | null | undefined
-    const inputSequence = args.sequence as number | null | undefined
+    const { flags, args } = await this.parse(Power)
+    const history = flags.history as number | null | undefined
+    const block = args.block as number | null | undefined
 
-    await this.sdk.client.connect()
+    const client = await this.sdk.connectRpc()
 
-    const data = await this.sdk.client.getNetworkHashPower({
-      blocks: inputBlocks,
-      sequence: inputSequence,
+    const data = await client.getNetworkHashPower({
+      sequence: block,
+      blocks: history,
     })
 
-    const { hashesPerSecond, blocks, sequence } = data.content
-    const formattedHashesPerSecond = FileUtils.formatHashRate(hashesPerSecond)
+    const formattedHashesPerSecond = FileUtils.formatHashRate(data.content.hashesPerSecond)
 
     this.log(
-      `The network power for block ${sequence} was ${formattedHashesPerSecond} averaged over ${blocks} previous blocks.`,
+      `The network power for block ${data.content.sequence} was ${formattedHashesPerSecond} averaged over ${data.content.blocks} previous blocks.`,
     )
   }
 }


### PR DESCRIPTION
## Summary

```bash
$ ironfish chain:power 5432 --history 10
```

> The network power for block 43814 was 83.93 GH averaged over 10 previous blocks.

https://github.com/iron-fish/ironfish/pull/3445

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
