### PR TITLE
Feat: import viewonly from cli

### DIFF
--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -44,6 +44,10 @@ export class ExportCommand extends IronfishCommand {
       description: 'The path to export the account to',
       required: false,
     }),
+    viewonly: Flags.boolean({
+      default: false,
+      description: 'Export an account as a view-only account',
+    }),
   }
 
   static args = [
@@ -66,7 +70,7 @@ export class ExportCommand extends IronfishCommand {
     }
 
     const client = await this.sdk.connectRpc(local)
-    const response = await client.exportAccount({ account })
+    const response = await client.exportAccount({ account, flags.viewonly })
 
     let output
 

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -64,13 +64,14 @@ export class ExportCommand extends IronfishCommand {
     const { color, local } = flags
     const account = args.account as string
     const exportPath = flags.path
+    const viewOnly = flags.viewonly
 
     if (flags.language) {
       flags.mnemonic = true
     }
 
     const client = await this.sdk.connectRpc(local)
-    const response = await client.exportAccount({ account, flags.viewonly })
+    const response = await client.exportAccount({ account: account, viewonly: viewOnly })
 
     let output
 

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -208,7 +208,7 @@ export abstract class RpcClient {
   }
 
   async exportAccount(
-    params: ExportAccountRequest = {},
+    params: ExportAccountRequest,
   ): Promise<RpcResponseEnded<ExportAccountResponse>> {
     return this.request<ExportAccountResponse>(
       `${ApiNamespace.wallet}/exportAccount`,

--- a/ironfish/src/rpc/routes/wallet/exportAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
-export type ExportAccountRequest = { account?: string }
+export type ExportAccountRequest = { account?: string; viewonly: boolean }
 export type ExportAccountResponse = {
   account: {
     name: string
@@ -19,6 +19,7 @@ export type ExportAccountResponse = {
 export const ExportAccountRequestSchema: yup.ObjectSchema<ExportAccountRequest> = yup
   .object({
     account: yup.string().strip(true),
+    viewonly: yup.boolean().defined(),
   })
   .defined()
 
@@ -43,6 +44,9 @@ router.register<typeof ExportAccountRequestSchema, ExportAccountResponse>(
     const account = getAccount(node, request.data.account)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { id, ...accountInfo } = account.serialize()
+    if (request.data.viewonly && accountInfo.spendingKey) {
+      accountInfo.spendingKey = null
+    }
     request.end({ account: accountInfo })
   },
 )


### PR DESCRIPTION
## Summary
This PR proposes to add a flag `--viewonly` to the export command, ensuring an exported account will not have its spending key exported if supplied. (Import command already supports importing viewonly accounts.)

## Testing Plan
WIP

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
