### PR TITLE
refactor(ironfish): move assembleBlockFromResponse fn

### DIFF
--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -835,33 +835,6 @@ export class PeerNetwork {
     }
   }
 
-  assembleBlockFromResponse(
-    partialTransactions: TransactionOrHash[],
-    responseTransactions: readonly Transaction[],
-  ): { ok: false } | { ok: true; transactions: Transaction[] } {
-    const transactions: Transaction[] = []
-    let currResponseIndex = 0
-
-    for (const partial of partialTransactions) {
-      if (partial.type === 'FULL') {
-        transactions.push(partial.value)
-      } else if (currResponseIndex >= responseTransactions.length) {
-        // did not respond with enough transactions
-        return { ok: false }
-      } else {
-        const next = responseTransactions[currResponseIndex]
-        if (!next.hash().equals(partial.value)) {
-          // hashes are mismatched
-          return { ok: false }
-        }
-        transactions.push(next)
-        currResponseIndex++
-      }
-    }
-
-    return { ok: true, transactions }
-  }
-
   private async onNewBlockTransactions(peer: Peer, message: GetBlockTransactionsResponse) {
     const block = this.blockFetcher.receivedBlockTransactions(message)
 


### PR DESCRIPTION
## Summary

This moves `assembleBlockFromResponse` function from the `peerNetwork` into the `blockFetcher`. It is a helper function that has no dependence on the `peerNetwork` class, and is only used by the `blockFetcher` class, we might as well have it live where it is used. The `peerNetwork` class is already pretty bloated, so this is a small step to alleviate that.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
