### PR TITLE
refactor(ironfish): move `resolveSequenceOrHash` fn

### DIFF
--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -21,7 +21,7 @@ import { Block, CompactBlock } from '../primitives/block'
 import { BlockHash, BlockHeader } from '../primitives/blockheader'
 import { TransactionHash } from '../primitives/transaction'
 import { Telemetry } from '../telemetry'
-import { ArrayUtils, BenchUtils, HRTime } from '../utils'
+import { ArrayUtils, BenchUtils, BlockchainUtils, HRTime } from '../utils'
 import { BlockFetcher } from './blockFetcher'
 import { Identity, PrivateIdentity } from './identity'
 import { CannotSatisfyRequest } from './messages/cannotSatisfyRequest'
@@ -1013,14 +1013,6 @@ export class PeerNetwork {
     }
   }
 
-  private async resolveSequenceOrHash(start: Buffer | number): Promise<BlockHeader | null> {
-    if (Buffer.isBuffer(start)) {
-      return await this.chain.getHeader(start)
-    }
-
-    return await this.chain.getHeaderAtSequence(start)
-  }
-
   private async onGetBlockHeadersRequest(
     request: IncomingPeerMessage<GetBlockHeadersRequest>,
   ): Promise<GetBlockHeadersResponse> {
@@ -1050,7 +1042,7 @@ export class PeerNetwork {
     const skip = message.skip
     const reverse = message.reverse
 
-    const from = await this.resolveSequenceOrHash(start)
+    const from = await BlockchainUtils.blockHeaderBySequenceOrHash(this.chain, start)
     if (!from) {
       return new GetBlockHeadersResponse([], rpcId)
     }
@@ -1111,7 +1103,7 @@ export class PeerNetwork {
     const start = message.start
     const limit = message.limit
 
-    const from = await this.resolveSequenceOrHash(start)
+    const from = await BlockchainUtils.blockHeaderBySequenceOrHash(this.chain, start)
     if (!from) {
       return new GetBlockHashesResponse([], rpcId)
     }
@@ -1149,7 +1141,7 @@ export class PeerNetwork {
     const start = message.start
     const limit = message.limit
 
-    const from = await this.resolveSequenceOrHash(start)
+    const from = await BlockchainUtils.blockHeaderBySequenceOrHash(this.chain, start)
     if (!from) {
       return new GetBlocksResponse([], rpcId)
     }

--- a/ironfish/src/utils/__fixtures__/blockutil.test.ts.fixture
+++ b/ironfish/src/utils/__fixtures__/blockutil.test.ts.fixture
@@ -1,0 +1,58 @@
+{
+  "BlockchainUtils blockHeaderBySequenceOrHash gets block header by sequence": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:KzPEJPLgCnPELGMpREExQ7ROCFMiYo+ldIVpV/P1oCk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:dtKD1ObaO3NarBS8NlGysx0iGPmlFTp7H1ImMjv0FYQ="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676586569216,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABImcnr0LaejxQDHnCDKIbl40zpA5M6vyCwEZt1Otg6uvNCYUxEYrVm7P8/uukVicp41Y1OQrw1PEg5PogrXEvcv9l43vh0bgefMzkXSjpJapSeXkFu6mj2m5IErigiyIlgwPUpRrRqeEZ7wN7rRPKCoQ2Rs3DG6boEUFWUyPR2QLCGzrjcK8GWGrgbWDnf/baC7AW6+hl3V+1kTEHrVu3sdAgUp+JGAbEFl5uiIJU/S4iSKpTtHlM+xtyvZGNADWxjyqrbdoSrQAaBD0qZ7NYkcRjS9aTIBud1ESf8haKgChgBDGigNkBGCboypUmc0H0No/pzEG4zd0p6SAHeZjLv8ExNg94ubYb0hpSGnjgyBHHs+R/b2qLJR1OW2+EiMOsxtdaZrb/5WYdb7WJhhyj4Bz9ZQ1RmDiusG1XqjSjLf1CIW14pH6A4JjgQtct1kp/Lm1bSknAJD6ofTNnm3ySVWXMuYFm+oSUaYQdi+m5xe9myXAgtE489cOfTR50b784UHeYtkTxBTiC7FItRpUR3OFdVD4CoNAaqJ9y9oRd65c5KOWrN8THAD9xhzcDOH4EtvQBsrmga87gBo393ydH3QXTW+Qbe/+PUHbPCwoN164Ip7VqLWsH0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwV4lG16ZQbtsI+WIUZX52KOrV/xRx9U8cmwFXsDu0Dg3R4w7pST8MIQXiTdz8Wb4YeWs9a5KqYjc+3V2G26MXCQ=="
+        }
+      ]
+    }
+  ],
+  "BlockchainUtils blockHeaderBySequenceOrHash gets block header by hash": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:274dGQylL9VXiiiF8JddKdLctp6hkp1gya1wkBlqFFw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ma0zYPdbSOO5fJT0/xYTyUp4sG+8jmdxGbdrcYMOofg="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1676586570132,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAq/sACl1n2pCBGLIzorJ1yLIQCNrRMT9FR5LriYNuT8qjkn1cAqRdMol6jnJuE4n7vIvvcj6OvlBmSrgn09YAogJbbYbBjgHasRT6Cpewvy6q4fjEAlSbGfYgxktuccNK/4r72NWPxUd5vos0Yl6MhYaueh3NSbjykHUaYyx8MyAVSlbxJYorqlvyFBWV+JFKDquDh2sCpDuX7V/6S6d6aXAUkURkMhIvDsGTobba3JCAJvarEhYI3dkiM7mFqtltoyuaK7kSn4EqqQcx0QZWh4xQlX56vWBfWWmxD27sAAREwRK1xPXujbLjFhMq3OR1qwVH11oKf79ogJaT32nsQDQZFOZacm+oziWprEIewoZ3/ZBlWfXgj86CJvqaTg4tLSxWKn38+nK51BQLz8oiZBoBTLIgN/net7hllha+3T1bbQ9b5X0wXMyvHzHfIz7kka7zGetAzjvbR2SsPi/EsCTREctqjNB3QzGB3BxVpfEqf1b/o1TdmhO0QoeBtJ3ehNno6LqYQcA9of1KO2PaA67uIirBhKNGWxPIdsTqESanskJnhpEh4HOGLZ71axlVb0Xs+LtIevAvB6cHf7CFqrpCCva4bH5Bg3cmhFm2OWO8CHH76lxthUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCNBfpDBEjc7uzJzUKTCv+5V6ayEhDI5IErtzVKeBpBA6G7djUzmmt4UCylqZB1DOEnbDGi556J0N31gdP0HKCQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/utils/blockchain.ts
+++ b/ironfish/src/utils/blockchain.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Blockchain } from '../blockchain'
-import { Block } from '../primitives'
+import { Block, BlockHeader } from '../primitives'
 import { GENESIS_BLOCK_SEQUENCE } from '../primitives/block'
 import { isTransactionMine } from '../testUtilities/helpers/transaction'
 import { Account } from '../wallet'
@@ -44,4 +44,16 @@ export function isBlockMine(block: Block, account: Account): boolean {
   return isTransactionMine(block.minersFee, account)
 }
 
-export const BlockchainUtils = { isBlockMine, getBlockRange }
+// Returns the block header at the given sequence or hash
+async function blockHeaderBySequenceOrHash(
+  chain: Blockchain,
+  start: Buffer | number,
+): Promise<BlockHeader | null> {
+  if (Buffer.isBuffer(start)) {
+    return await chain.getHeader(start)
+  }
+
+  return await chain.getHeaderAtSequence(start)
+}
+
+export const BlockchainUtils = { isBlockMine, getBlockRange, blockHeaderBySequenceOrHash }

--- a/ironfish/src/utils/blockutil.test.ts
+++ b/ironfish/src/utils/blockutil.test.ts
@@ -1,91 +1,124 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { useMinerBlockFixture } from '../testUtilities'
 import { createNodeTest } from '../testUtilities/nodeTest'
-import { getBlockRange } from './blockchain'
+import { BlockchainUtils, getBlockRange } from './blockchain'
 
-// Strategy for testing:
-// Consider a line of numbers to pick for the input parameters
-// <-----N1---N2----0G---P1---P2---H---X1---X2----->
-// N1, N2 are negative (count backward from height)
-// G is the genesis block (1)
-// P1 and P2 are positive numbers in the range of blocks
-// H is the height of the chain
-// X1 and X2 exceed the height of the chain
-describe('getBlockRange', () => {
-  const nodeTest = createNodeTest()
+describe('BlockchainUtils', () => {
+  // Strategy for testing:
+  // Consider a line of numbers to pick for the input parameters
+  // <-----N1---N2----0G---P1---P2---H---X1---X2----->
+  // N1, N2 are negative (count backward from height)
+  // G is the genesis block (1)
+  // P1 and P2 are positive numbers in the range of blocks
+  // H is the height of the chain
+  // X1 and X2 exceed the height of the chain
+  describe('getBlockRange', () => {
+    const nodeTest = createNodeTest()
 
-  it.each([
-    // P1, P2 cases
-    [{ start: 9000, stop: 900 }, 9000, 9000],
-    [{ start: 900, stop: 9000 }, 900, 9000],
+    it.each([
+      // P1, P2 cases
+      [{ start: 9000, stop: 900 }, 9000, 9000],
+      [{ start: 900, stop: 9000 }, 900, 9000],
 
-    // N1, N2 cases
-    [{ start: -9000, stop: -8000 }, 1000, 2000],
-    [{ start: -8000, stop: -9000 }, 2000, 2000],
+      // N1, N2 cases
+      [{ start: -9000, stop: -8000 }, 1000, 2000],
+      [{ start: -8000, stop: -9000 }, 2000, 2000],
 
-    // N, P cases
-    [{ start: -9000, stop: 3000 }, 1000, 3000],
-    [{ start: 3000, stop: -9000 }, 3000, 3000],
-    [{ start: 1000, stop: -7000 }, 1000, 3000],
-    [{ start: -7000, stop: 1000 }, 3000, 3000],
+      // N, P cases
+      [{ start: -9000, stop: 3000 }, 1000, 3000],
+      [{ start: 3000, stop: -9000 }, 3000, 3000],
+      [{ start: 1000, stop: -7000 }, 1000, 3000],
+      [{ start: -7000, stop: 1000 }, 3000, 3000],
 
-    // N, 0 cases
-    [{ start: -9000, stop: 0 }, 1000, 10000],
-    [{ start: 0, stop: -9000 }, 1, 1000],
+      // N, 0 cases
+      [{ start: -9000, stop: 0 }, 1000, 10000],
+      [{ start: 0, stop: -9000 }, 1, 1000],
 
-    // P, 0 cases
-    [{ start: 40, stop: 0 }, 40, 10000],
-    [{ start: 0, stop: 40 }, 1, 40],
+      // P, 0 cases
+      [{ start: 40, stop: 0 }, 40, 10000],
+      [{ start: 0, stop: 40 }, 1, 40],
 
-    // H, 0 cases
-    [{ start: 10000, stop: 0 }, 10000, 10000],
-    [{ start: 0, stop: 10000 }, 1, 10000],
+      // H, 0 cases
+      [{ start: 10000, stop: 0 }, 10000, 10000],
+      [{ start: 0, stop: 10000 }, 1, 10000],
 
-    // P, H cases
-    [{ start: 100, stop: 10000 }, 100, 10000],
-    [{ start: 10000, stop: 100 }, 10000, 10000],
+      // P, H cases
+      [{ start: 100, stop: 10000 }, 100, 10000],
+      [{ start: 10000, stop: 100 }, 10000, 10000],
 
-    // X1, X2 cases
-    [{ start: 11000, stop: 12000 }, 10000, 10000],
-    [{ start: 12000, stop: 11000 }, 10000, 10000],
+      // X1, X2 cases
+      [{ start: 11000, stop: 12000 }, 10000, 10000],
+      [{ start: 12000, stop: 11000 }, 10000, 10000],
 
-    // N, H cases
-    [{ start: -9000, stop: 10000 }, 1000, 10000],
-    [{ start: 10000, stop: -9000 }, 10000, 10000],
+      // N, H cases
+      [{ start: -9000, stop: 10000 }, 1000, 10000],
+      [{ start: 10000, stop: -9000 }, 10000, 10000],
 
-    // N1, N2 cases: |N1| > H
-    [{ start: -17000, stop: -8000 }, 1, 2000],
-    [{ start: -8000, stop: -17000 }, 2000, 2000],
+      // N1, N2 cases: |N1| > H
+      [{ start: -17000, stop: -8000 }, 1, 2000],
+      [{ start: -8000, stop: -17000 }, 2000, 2000],
 
-    // N1, N2 cases: |N1| > H, |N2| > H
-    [{ start: -17000, stop: -18000 }, 1, 1],
-    [{ start: -18000, stop: -17000 }, 1, 1],
+      // N1, N2 cases: |N1| > H, |N2| > H
+      [{ start: -17000, stop: -18000 }, 1, 1],
+      [{ start: -18000, stop: -17000 }, 1, 1],
 
-    // Fractional cases
-    [{ start: 3.14, stop: 6.28 }, 3, 6],
-    [{ start: 6.28, stop: 3.14 }, 6, 6],
-  ])('%o returns %d %d', (param, expectedStart, expectedStop) => {
-    nodeTest.chain.latest.sequence = 10000
+      // Fractional cases
+      [{ start: 3.14, stop: 6.28 }, 3, 6],
+      [{ start: 6.28, stop: 3.14 }, 6, 6],
+    ])('%o returns %d %d', (param, expectedStart, expectedStop) => {
+      nodeTest.chain.latest.sequence = 10000
 
-    const { start, stop } = getBlockRange(nodeTest.chain, param)
-    expect(start).toEqual(expectedStart)
-    expect(stop).toEqual(expectedStop)
+      const { start, stop } = getBlockRange(nodeTest.chain, param)
+      expect(start).toEqual(expectedStart)
+      expect(stop).toEqual(expectedStop)
+    })
+
+    it('{ start: null, stop: 6000 } returns 1 6000', () => {
+      nodeTest.chain.latest.sequence = 10000
+
+      const { start, stop } = getBlockRange(nodeTest.chain, { start: null, stop: 6000 })
+      expect(start).toEqual(1)
+      expect(stop).toEqual(6000)
+    })
+
+    it('{ start: 6000, stop: null } returns 6000 10000', () => {
+      nodeTest.chain.latest.sequence = 10000
+
+      const { start, stop } = getBlockRange(nodeTest.chain, { start: 6000, stop: null })
+      expect(start).toEqual(6000)
+      expect(stop).toEqual(10000)
+    })
   })
 
-  it('{ start: null, stop: 6000 } returns 1 6000', () => {
-    nodeTest.chain.latest.sequence = 10000
+  describe('blockHeaderBySequenceOrHash', () => {
+    const nodeTest = createNodeTest()
 
-    const { start, stop } = getBlockRange(nodeTest.chain, { start: null, stop: 6000 })
-    expect(start).toEqual(1)
-    expect(stop).toEqual(6000)
-  })
+    it('gets block header by sequence', async () => {
+      const { chain } = nodeTest.node
+      const block2 = await useMinerBlockFixture(chain)
+      await expect(chain).toAddBlock(block2)
 
-  it('{ start: 6000, stop: null } returns 6000 10000', () => {
-    nodeTest.chain.latest.sequence = 10000
+      await expect(
+        BlockchainUtils.blockHeaderBySequenceOrHash(chain, block2.header.sequence),
+      ).resolves.toMatchObject({
+        sequence: block2.header.sequence,
+        hash: block2.header.hash,
+      })
+    })
 
-    const { start, stop } = getBlockRange(nodeTest.chain, { start: 6000, stop: null })
-    expect(start).toEqual(6000)
-    expect(stop).toEqual(10000)
+    it('gets block header by hash', async () => {
+      const { chain } = nodeTest.node
+      const block2 = await useMinerBlockFixture(chain)
+      await expect(chain).toAddBlock(block2)
+
+      await expect(
+        BlockchainUtils.blockHeaderBySequenceOrHash(chain, block2.header.hash),
+      ).resolves.toMatchObject({
+        sequence: block2.header.sequence,
+        hash: block2.header.hash,
+      })
+    })
   })
 })


### PR DESCRIPTION
## Summary

Move and rename this function out of `PeerNetwork` class. It is really a blockchain utility function, so moving it to `BlockchainUtils` makes sense.

## Testing Plan

Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
