### PR TITLE
refactor: remove unused blockchain util fn

### DIFF
--- a/ironfish/src/utils/blockchain.ts
+++ b/ironfish/src/utils/blockchain.ts
@@ -3,10 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Blockchain } from '../blockchain'
-import { Block, BlockHeader } from '../primitives'
+import { BlockHeader } from '../primitives'
 import { GENESIS_BLOCK_SEQUENCE } from '../primitives/block'
-import { isTransactionMine } from '../testUtilities/helpers/transaction'
-import { Account } from '../wallet'
 
 export function getBlockRange(
   chain: Blockchain,
@@ -40,10 +38,6 @@ export function getBlockRange(
   return { start, stop }
 }
 
-export function isBlockMine(block: Block, account: Account): boolean {
-  return isTransactionMine(block.minersFee, account)
-}
-
 // Returns the block header at the given sequence or hash
 async function blockHeaderBySequenceOrHash(
   chain: Blockchain,
@@ -56,4 +50,4 @@ async function blockHeaderBySequenceOrHash(
   return await chain.getHeaderAtSequence(start)
 }
 
-export const BlockchainUtils = { isBlockMine, getBlockRange, blockHeaderBySequenceOrHash }
+export const BlockchainUtils = { getBlockRange, blockHeaderBySequenceOrHash }


### PR DESCRIPTION
## Summary

`isBlockMine` was a wrapper around a test utility function. It doesn't seem like a great idea to expose test utility functions as "normal" code path functions. Given that, and that the function was unused, removing it seems like a decent option.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
