### PR TITLE
feat: use view key for nullifier

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -139,7 +139,7 @@ export class Note {
    * only at the time the note is spent. This key is collected in a massive
    * 'nullifier set', preventing double-spend.
    */
-  nullifier(ownerPrivateKey: string, position: bigint): Buffer
+  nullifier(ownerViewKey: string, position: bigint): Buffer
 }
 export type NativeTransactionPosted = TransactionPosted
 export class TransactionPosted {

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -5,11 +5,12 @@
 use ironfish_rust::{
     assets::asset::{asset_generator_from_id, ID_LENGTH as ASSET_ID_LENGTH},
     note::{AMOUNT_VALUE_SIZE, GENERATOR_SIZE, MEMO_SIZE, SCALAR_SIZE},
+    ViewKey,
 };
 use napi::{bindgen_prelude::*, JsBuffer};
 use napi_derive::napi;
 
-use ironfish_rust::{Note, SaplingKey};
+use ironfish_rust::Note;
 
 use ironfish_rust::keys::PUBLIC_ADDRESS_SIZE;
 
@@ -145,12 +146,12 @@ impl NativeNote {
     /// only at the time the note is spent. This key is collected in a massive
     /// 'nullifier set', preventing double-spend.
     #[napi]
-    pub fn nullifier(&self, owner_private_key: String, position: BigInt) -> Result<Buffer> {
+    pub fn nullifier(&self, owner_view_key: String, position: BigInt) -> Result<Buffer> {
         let position_u64 = position.get_u64().1;
 
-        let private_key = SaplingKey::from_hex(&owner_private_key).map_err(to_napi_err)?;
+        let view_key = ViewKey::from_hex(&owner_view_key).map_err(to_napi_err)?;
 
-        let nullifier: &[u8] = &self.note.nullifier(private_key.view_key(), position_u64).0;
+        let nullifier: &[u8] = &self.note.nullifier(&view_key, position_u64).0;
 
         Ok(Buffer::from(nullifier))
     }

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -88,7 +88,7 @@ describe('Demonstrate the Sapling API', () => {
     // Null characters are included in the memo string
     expect(decryptedNote.memo().replace(/\0/g, '')).toEqual('test')
     expect(decryptedNote.value()).toEqual(BigInt(20))
-    expect(decryptedNote.nullifier(key.spending_key, BigInt(0)).byteLength).toBeGreaterThan(BigInt(0))
+    expect(decryptedNote.nullifier(key.view_key, BigInt(0)).byteLength).toBeGreaterThan(BigInt(0))
   })
 
   it(`Should create a standard transaction`, () => {

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -89,8 +89,8 @@ export class Note {
     return this._assetId
   }
 
-  nullifier(ownerPrivateKey: string, position: bigint): Buffer {
-    const buf = this.takeReference().nullifier(ownerPrivateKey, position)
+  nullifier(ownerViewKey: string, position: bigint): Buffer {
+    const buf = this.takeReference().nullifier(ownerViewKey, position)
     this.returnReference()
     return buf
   }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -326,7 +326,7 @@ export class Wallet {
           serializedNote: note.serialize(),
           incomingViewKey: account.incomingViewKey,
           outgoingViewKey: account.outgoingViewKey,
-          spendingKey: account.spendingKey,
+          viewKey: account.viewKey,
           currentNoteIndex,
           decryptForSpender,
         })

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -6,7 +6,7 @@ import bufio from 'bufio'
 import { IDatabaseEncoding } from '../../storage'
 
 const KEY_LENGTH = 32
-const VIEW_KEY_LENGTH = 64
+export const VIEW_KEY_LENGTH = 64
 const VERSION_LENGTH = 2
 
 export interface AccountValue {

--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -10,6 +10,7 @@ import {
   useTxFixture,
 } from '../../testUtilities'
 import { ACCOUNT_KEY_LENGTH } from '../../wallet'
+import { VIEW_KEY_LENGTH } from '../../wallet/walletdb/accountValue'
 import { DecryptNotesRequest, DecryptNotesResponse, DecryptNotesTask } from './decryptNotes'
 
 describe('DecryptNotesRequest', () => {
@@ -20,7 +21,7 @@ describe('DecryptNotesRequest', () => {
           serializedNote: Buffer.alloc(ENCRYPTED_NOTE_LENGTH, 1),
           incomingViewKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
           outgoingViewKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
-          spendingKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
+          viewKey: Buffer.alloc(VIEW_KEY_LENGTH, 1).toString('hex'),
           currentNoteIndex: 2,
           decryptForSpender: true,
         },
@@ -69,7 +70,7 @@ describe('DecryptNotesTask', () => {
           serializedNote: transaction.getNote(0).serialize(),
           incomingViewKey: account.incomingViewKey,
           outgoingViewKey: account.outgoingViewKey,
-          spendingKey: account.spendingKey,
+          viewKey: account.viewKey,
           currentNoteIndex: 2,
           decryptForSpender: true,
         },
@@ -106,7 +107,7 @@ describe('DecryptNotesTask', () => {
           serializedNote: transaction.getNote(0).serialize(),
           incomingViewKey: accountA.incomingViewKey,
           outgoingViewKey: accountA.outgoingViewKey,
-          spendingKey: accountA.spendingKey,
+          viewKey: accountA.viewKey,
           currentNoteIndex: 3,
           decryptForSpender: true,
         },
@@ -130,7 +131,7 @@ describe('DecryptNotesTask', () => {
           serializedNote: transaction.getNote(0).serialize(),
           incomingViewKey: accountA.incomingViewKey,
           outgoingViewKey: accountA.outgoingViewKey,
-          spendingKey: accountA.spendingKey,
+          viewKey: accountA.viewKey,
           currentNoteIndex: 3,
           decryptForSpender: false,
         },


### PR DESCRIPTION
## Summary
We only need the `nullifier_deriving_key` for verifying the nullifier, not the `spend_key`.  These changes are a result of the identification of view only wallet incompatibility from this PR review comment:
https://github.com/iron-fish/ironfish/pull/3335#discussion_r1103230014

TODO:
add links to previous PR in series and rename
## Testing Plan
Tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
