### PR TITLE
Add config:unset command

### DIFF
--- a/ironfish-cli/src/commands/config/unset.ts
+++ b/ironfish-cli/src/commands/config/unset.ts
@@ -5,7 +5,7 @@ import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
-export class SetCommand extends IronfishCommand {
+export class UnsetCommand extends IronfishCommand {
   static description = `Unset a value in the config and fall back to default`
 
   static args = [
@@ -28,7 +28,7 @@ export class SetCommand extends IronfishCommand {
   static examples = ['$ ironfish config:unset blockGraffiti']
 
   async start(): Promise<void> {
-    const { args, flags } = await this.parse(SetCommand)
+    const { args, flags } = await this.parse(UnsetCommand)
     const name = args.name as string
 
     const client = await this.sdk.connectRpc(flags.local)

--- a/ironfish-cli/src/commands/config/unset.ts
+++ b/ironfish-cli/src/commands/config/unset.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../../command'
+import { RemoteFlags } from '../../flags'
+
+export class SetCommand extends IronfishCommand {
+  static description = `Unset a value in the config and fall back to default`
+
+  static args = [
+    {
+      name: 'name',
+      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
+      required: true,
+      description: 'Name of the config item',
+    },
+  ]
+
+  static flags = {
+    ...RemoteFlags,
+    local: Flags.boolean({
+      default: false,
+      description: 'Dont connect to the node when updating the config',
+    }),
+  }
+
+  static examples = ['$ ironfish config:unset blockGraffiti']
+
+  async start(): Promise<void> {
+    const { args, flags } = await this.parse(SetCommand)
+    const name = args.name as string
+
+    const client = await this.sdk.connectRpc(flags.local)
+    await client.unsetConfig({ name })
+
+    this.exit(0)
+  }
+}

--- a/ironfish/src/fileStores/keyStore.ts
+++ b/ironfish/src/fileStores/keyStore.ts
@@ -96,6 +96,22 @@ export class KeyStore<TSchema extends Record<string, unknown>> {
     await this.storage.save(save)
   }
 
+  clear<T extends keyof TSchema>(key: T): void {
+    const previousValue = this.config[key]
+
+    delete this.loaded[key]
+    this.keysLoaded.delete(key)
+
+    if (Object.prototype.hasOwnProperty.call(this.overrides, key)) {
+      delete this.overrides[key]
+    }
+
+    const newValue = this.get(key)
+    if (previousValue !== newValue) {
+      this.onConfigChange.emit(key, newValue)
+    }
+  }
+
   set<T extends keyof TSchema>(key: T, value: TSchema[T]): void {
     const schema = this.schema?.fields[key]
 

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -76,6 +76,7 @@ import {
   FollowChainStreamRequest,
   FollowChainStreamResponse,
 } from '../routes/chain/followChain'
+import { UnsetConfigRequest, UnsetConfigResponse } from '../routes/config/unsetConfig'
 import { OnGossipRequest, OnGossipResponse } from '../routes/events/onGossip'
 import { GetBannedPeersRequest, GetBannedPeersResponse } from '../routes/peers/getBannedPeers'
 import { GetPeerRequest, GetPeerResponse } from '../routes/peers/getPeer'
@@ -502,6 +503,15 @@ export abstract class RpcClient {
   async setConfig(params: SetConfigRequest): Promise<RpcResponseEnded<SetConfigResponse>> {
     return this.request<SetConfigResponse>(
       `${ApiNamespace.config}/setConfig`,
+      params,
+    ).waitForEnd()
+  }
+
+  async unsetConfig(
+    params: UnsetConfigRequest,
+  ): Promise<RpcResponseEnded<UnsetConfigResponse>> {
+    return this.request<UnsetConfigResponse>(
+      `${ApiNamespace.config}/unsetConfig`,
       params,
     ).waitForEnd()
   }

--- a/ironfish/src/rpc/routes/config/index.ts
+++ b/ironfish/src/rpc/routes/config/index.ts
@@ -4,4 +4,5 @@
 
 export * from './getConfig'
 export * from './setConfig'
+export * from './unsetConfig'
 export * from './uploadConfig'

--- a/ironfish/src/rpc/routes/config/unsetConfig.test.ts
+++ b/ironfish/src/rpc/routes/config/unsetConfig.test.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createRouteTest } from '../../../testUtilities/routeTest'
+
+jest.mock('axios')
+
+describe('Route config/unsetConfig', () => {
+  const routeTest = createRouteTest()
+
+  it('should error if the config name does not exist', async () => {
+    await expect(routeTest.client.unsetConfig({ name: 'asdf' })).rejects.toThrow()
+  })
+
+  it('handles clear values values', async () => {
+    routeTest.sdk.config.set('blockGraffiti', 'bar')
+    routeTest.sdk.config.setOverride('blockGraffiti', 'foo')
+    expect(routeTest.sdk.config.get('blockGraffiti')).toEqual('foo')
+
+    await routeTest.client.unsetConfig({
+      name: 'blockGraffiti',
+    })
+
+    expect(routeTest.sdk.config.get('blockGraffiti')).toEqual('')
+  })
+})

--- a/ironfish/src/rpc/routes/config/unsetConfig.ts
+++ b/ironfish/src/rpc/routes/config/unsetConfig.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
+import { ApiNamespace, router } from '../router'
+import { setUnknownConfigValue } from './uploadConfig'
+
+export type UnsetConfigRequest = { name: string }
+export type UnsetConfigResponse = Partial<ConfigOptions>
+
+export const UnsetConfigRequestSchema: yup.ObjectSchema<UnsetConfigRequest> = yup
+  .object({
+    name: yup.string().defined(),
+  })
+  .defined()
+
+export const UnsetConfigResponseSchema: yup.ObjectSchema<UnsetConfigResponse> =
+  ConfigOptionsSchema
+
+router.register<typeof UnsetConfigRequestSchema, UnsetConfigResponse>(
+  `${ApiNamespace.config}/unsetConfig`,
+  UnsetConfigRequestSchema,
+  async (request, node): Promise<void> => {
+    setUnknownConfigValue(node.config, request.data.name)
+    await node.config.save()
+    request.end()
+  },
+)

--- a/ironfish/src/rpc/routes/config/uploadConfig.ts
+++ b/ironfish/src/rpc/routes/config/uploadConfig.ts
@@ -43,7 +43,7 @@ function clearConfig(config: Config): void {
 export function setUnknownConfigValue(
   config: Config,
   unknownKey: string,
-  unknownValue: unknown,
+  unknownValue?: unknown,
   ignoreUnknownKey = false,
 ): void {
   if (unknownKey && !(unknownKey in config.defaults)) {
@@ -66,6 +66,11 @@ export function setUnknownConfigValue(
   // Trim string values
   if (typeof sourceValue === 'string') {
     sourceValue = sourceValue.trim()
+  }
+
+  if (value === undefined) {
+    config.clear(sourceKey)
+    return
   }
 
   if (typeof sourceValue !== typeof targetValue) {


### PR DESCRIPTION
## Summary

This new command will unset a config variable

```
$ ironfish config:set blockGraffiti foo
$ ironfish config:get blockGraffiti
"foo"

$ ironfish config:unset blockGraffiti
$ ironfish config:get blockGraffiti
""
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
