### PR TITLE
Remove use of routeTest.client.request

### DIFF
--- a/ironfish/src/rpc/routes/chain/getTransactionStream.test.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.test.ts
@@ -11,16 +11,9 @@ import {
   useMintBlockFixture,
 } from '../../../testUtilities/fixtures'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { GetTransactionStreamResponse } from './getTransactionStream'
 
 describe('Route chain.getTransactionStream', () => {
   const routeTest = createRouteTest()
-
-  it('should fail if no incoming view key is specified', async () => {
-    await expect(
-      routeTest.client.request('chain/getTransactionStream', {}).waitForEnd(),
-    ).rejects.toThrow('Request failed (400) validation: incomingViewKey is a required field')
-  })
 
   it(`should fail if block can't be found with hash`, async () => {
     const hash = BlockHashSerdeInstance.serialize(Buffer.alloc(32, 'blockhashnotfound'))
@@ -43,10 +36,9 @@ describe('Route chain.getTransactionStream', () => {
     const wallet = routeTest.node.wallet
     const account = await useAccountFixture(wallet)
     const asset = new Asset(account.spendingKey, 'customasset', 'metadata')
-    const response = routeTest.client.request<GetTransactionStreamResponse>(
-      'chain/getTransactionStream',
-      { incomingViewKey: account.incomingViewKey },
-    )
+    const response = routeTest.client.getTransactionStream({
+      incomingViewKey: account.incomingViewKey,
+    })
     await response.contentStream().next()
     // Mint so we have an existing asset
     const mintValue = BigInt(10)

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.test.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.test.ts
@@ -4,6 +4,7 @@
 
 import '../../../testUtilities/matchers'
 import { Asset } from '@ironfish/rust-nodejs'
+import { Assert } from '../../../assert'
 import { BlockHashSerdeInstance } from '../../../serde'
 import {
   useAccountFixture,
@@ -11,6 +12,7 @@ import {
   useMintBlockFixture,
 } from '../../../testUtilities/fixtures'
 import { createRouteTest } from '../../../testUtilities/routeTest'
+import { MemoryResponse } from '../../adapters'
 
 describe('Route chain.getTransactionStream', () => {
   const routeTest = createRouteTest()
@@ -39,6 +41,7 @@ describe('Route chain.getTransactionStream', () => {
     const response = routeTest.client.getTransactionStream({
       incomingViewKey: account.incomingViewKey,
     })
+    Assert.isInstanceOf(response, MemoryResponse)
     await response.contentStream().next()
     // Mint so we have an existing asset
     const mintValue = BigInt(10)
@@ -49,9 +52,10 @@ describe('Route chain.getTransactionStream', () => {
       asset,
       value: mintValue,
     })
+
     await expect(routeTest.node.chain).toAddBlock(mintBlock)
     // validate mint block
-    expect(await (await response.contentStream().next()).value).toEqual(
+    expect((await response.contentStream().next()).value).toEqual(
       expect.objectContaining({
         transactions: expect.arrayContaining([
           expect.objectContaining({
@@ -72,8 +76,9 @@ describe('Route chain.getTransactionStream', () => {
       value: mintValue,
     })
     await expect(routeTest.node.chain).toAddBlock(burnBlock)
+
     // validate burn block
-    expect(await (await response.contentStream().next()).value).toEqual(
+    expect((await response.contentStream().next()).value).toEqual(
       expect.objectContaining({
         transactions: expect.arrayContaining([
           expect.objectContaining({

--- a/ironfish/src/rpc/routes/config/getConfig.test.ts
+++ b/ironfish/src/rpc/routes/config/getConfig.test.ts
@@ -7,9 +7,7 @@ describe('Route config/getConfig', () => {
   const routeTest = createRouteTest()
 
   it('should error if the config name does not exist', async () => {
-    await expect(
-      routeTest.client.request('config/getConfig', { name: 'asdf' }).waitForEnd(),
-    ).rejects.toThrow()
+    await expect(routeTest.client.getConfig({ name: 'asdf' })).rejects.toThrow()
   })
 
   it('returns value of the requested ConfigOptions', async () => {

--- a/ironfish/src/rpc/routes/faucet/getFunds.test.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.test.ts
@@ -59,9 +59,9 @@ describe('Route faucet.getFunds', () => {
           },
         }
       })
-      await expect(
-        routeTest.client.request('faucet/getFunds', { accountName, email }).waitForEnd(),
-      ).rejects.toThrow(RpcRequestError)
+      await expect(routeTest.client.getFunds({ account: accountName, email })).rejects.toThrow(
+        RpcRequestError,
+      )
     })
   })
 
@@ -69,9 +69,9 @@ describe('Route faucet.getFunds', () => {
     it('throws an error', async () => {
       const apiResponse = new Error('API failure') as AxiosError
       axios.post = jest.fn().mockRejectedValueOnce(apiResponse)
-      await expect(
-        routeTest.client.request('faucet/getFunds', { accountName, email }).waitForEnd(),
-      ).rejects.toThrow('API failure')
+      await expect(routeTest.client.getFunds({ account: accountName, email })).rejects.toThrow(
+        'API failure',
+      )
     })
   })
 })

--- a/ironfish/src/rpc/routes/node/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.test.ts
@@ -7,7 +7,7 @@ describe('Route node/getStatus', () => {
   const routeTest = createRouteTest()
 
   it('should get status', async () => {
-    const response = await routeTest.client.request('node/getStatus').waitForEnd()
+    const response = await routeTest.client.getNodeStatus()
 
     expect(response.status).toBe(200)
 

--- a/ironfish/src/rpc/routes/node/stopNode.test.ts
+++ b/ironfish/src/rpc/routes/node/stopNode.test.ts
@@ -9,7 +9,7 @@ describe('Route node.getStatus', () => {
   it('should get status', async () => {
     routeTest.node.shutdown = jest.fn()
 
-    const response = await routeTest.client.request('node/stopNode').waitForEnd()
+    const response = await routeTest.client.stopNode()
     expect(response.status).toBe(200)
     expect(response.content).toBe(undefined)
     expect(routeTest.node.shutdown).toHaveBeenCalled()

--- a/ironfish/src/rpc/routes/wallet/create.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/create.test.slow.ts
@@ -18,7 +18,7 @@ describe('Route wallet/create', () => {
 
     const name = uuid()
 
-    const response = await routeTest.client.request<any>('wallet/create', { name }).waitForEnd()
+    const response = await routeTest.client.createAccount({ name })
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
       name: name,
@@ -38,27 +38,13 @@ describe('Route wallet/create', () => {
 
     const name = uuid()
 
-    const response = await routeTest.client.request<any>('wallet/create', { name }).waitForEnd()
+    const response = await routeTest.client.createAccount({ name })
     expect(response.content).toMatchObject({
       name: name,
       publicAddress: expect.any(String),
       isDefaultAccount: true,
     })
     expect(routeTest.node.wallet.getDefaultAccount()?.name).toBe(name)
-  })
-
-  it('should validate request', async () => {
-    try {
-      expect.assertions(3)
-      await routeTest.client.request('wallet/create').waitForEnd()
-    } catch (e: unknown) {
-      if (!(e instanceof RpcRequestError)) {
-        throw e
-      }
-      expect(e.status).toBe(400)
-      expect(e.code).toBe(ERROR_CODES.VALIDATION)
-      expect(e.message).toContain('name')
-    }
   })
 
   it('should fail if name already exists', async () => {
@@ -68,7 +54,7 @@ describe('Route wallet/create', () => {
 
     try {
       expect.assertions(2)
-      await routeTest.client.request('wallet/create', { name: name }).waitForEnd()
+      await routeTest.client.createAccount({ name: name })
     } catch (e: unknown) {
       if (!(e instanceof RpcRequestError)) {
         throw e


### PR DESCRIPTION
## Summary

We don't need to use this unless you want a raw untyped request. Most of these tests only want the typed request, and in fact typing these found some bugs in the tests.

## Testing Plan

these are changes to the tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
