### PR TITLE
Made config:get return non json by default

### DIFF
--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -33,6 +33,11 @@ export class GetCommand extends IronfishCommand {
       allowNo: true,
       description: 'Should colorize the output',
     }),
+    json: Flags.boolean({
+      default: false,
+      allowNo: true,
+      description: 'Output the config value as json',
+    }),
   }
 
   async start(): Promise<void> {
@@ -51,9 +56,16 @@ export class GetCommand extends IronfishCommand {
       this.exit(0)
     }
 
-    let output = JSON.stringify(response.content[key], undefined, '   ')
-    if (flags.color) {
-      output = jsonColorizer(output)
+    let output = ''
+
+    if (flags.json) {
+      output = JSON.stringify(response.content[key], undefined, '   ')
+
+      if (flags.color) {
+        output = jsonColorizer(output)
+      }
+    } else {
+      output = String(response.content[key])
     }
 
     this.log(output)


### PR DESCRIPTION
## Summary

Now `ironfish config:get` does not output json by default

```bash
$ ironfish config:get blockGraffiti
JASON💪💎🚀

$ ironfish config:get blockGraffiti --json
"JASON💪💎🚀"
```

```
$ ironfish config:get miningForce
false

$ ironfish config:get miningForce --json
false
```
```
$ ironfish config:get bootstrapNodes
test.bn1.ironfish.network,foo.ironfish.network

$ ironfish config:get bootstrapNodes --json
[
   "test.bn1.ironfish.network",
   "foo.ironfish.network"
]
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
