### PR TITLE
[Prototype] Cloudflare R2 snapshots upload and download

### DIFF
--- a/ironfish-cli/src/commands/service/snapshot.ts
+++ b/ironfish-cli/src/commands/service/snapshot.ts
@@ -47,6 +47,11 @@ export default class CreateSnapshot extends IronfishCommand {
       required: false,
       description: 'Webhook to notify on successful snapshot upload',
     }),
+    r2: Flags.boolean({
+      default: false,
+      allowNo: true,
+      description: 'Upload the snapshot to Cloudflare R2.',
+    }),
   }
 
   async start(): Promise<void> {
@@ -99,7 +104,19 @@ export default class CreateSnapshot extends IronfishCommand {
       const snapshotBaseName = path.basename(SNAPSHOT_FILE_NAME, '.tar.gz')
       const snapshotKeyName = `${snapshotBaseName}_${timestamp}.tar.gz`
 
-      const s3 = new S3Client({})
+      let s3: S3Client
+      if (flags.r2) {
+        s3 = new S3Client({
+          region: 'auto',
+          endpoint: `https://098597f948037fe5f5ad128211603f63.r2.cloudflarestorage.com`,
+          credentials: {
+            accessKeyId: '1403b039cc8e4a36e64da704843447ca',
+            secretAccessKey: 'e46487a0edf8927b6b61702a83c0abc9036bbc42b4505179512756936f2ea792',
+          },
+        })
+      } else {
+        s3 = new S3Client({})
+      }
 
       CliUx.ux.action.start(`Uploading to ${bucket}`)
       await S3Utils.uploadToBucket(


### PR DESCRIPTION
## Summary
This is a prototype for Cloudflare R2 object storage for snapshots data.
I use r2 dev domain for public access of the bucket
also I hardcode the API access token since its my personal account R2 service
## Testing Plan
To view the manifest json 
https://pub-d424ac269bd64bfdb705403d70d31eae.r2.dev/manifest.json

To upload snapshots
Run `yarn start createsnapshot --upload --r2` -- need to enable your local cli to run create snapshot in service folder
```
yarn start wallet:snapshot --upload
yarn run v1.22.19
$ yarn build && yarn start:js wallet:snapshot --upload
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:snapshot --upload
Compacting chain database... done
Zipping
    SRC /Users/yajun/.ironfish/databases/chain
    DST /Users/yajun/.ironfish/temp/ironfish_snapshot.tar.gz

Zipping /Users/yajun/.ironfish/databases/chain... done (3.95 GB)
Creating checksum for /Users/yajun/.ironfish/temp/ironfish_snapshot.tar.gz... done (cdc9aa19ed97cf659657c9153939330b62dc8ffbed6bedc872fd5f05b2dedde6)
Uploading to ironfish-snapshots... done
Uploading latest snapshot information to ironfish-snapshots... done
Snapshot upload complete. Uploaded the following manifest:
{
  "block_sequence": 41703,
  "checksum": "cdc9aa19ed97cf659657c9153939330b62dc8ffbed6bedc872fd5f05b2dedde6",
  "file_name": "ironfish_snapshot_1676666044141.tar.gz",
  "file_size": 3954306861,
  "timestamp": 1676666044141,
  "database_version": 14
}
✨  Done in 549.92s.
```

To download snapshots
Run `yarn start chain:download -m "https://pub-d424ac269bd64bfdb705403d70d31eae.r2.dev/manifest.json" `
```
yarn run v1.22.19
$ yarn build && yarn start:js chain:download -m https://pub-d424ac269bd64bfdb705403d70d31eae.r2.dev/manifest.json
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run chain:download -m https://pub-d424ac269bd64bfdb705403d70d31eae.r2.dev/manifest.json
Download 3.95 GB snapshot to update from block 41703 to 41703?
At least 7.90 GB of free disk space is required to download and unzip the snapshot file.
Are you sure? (Y)es / (N)o: Y
Downloading snapshot from https://pub-d424ac269bd64bfdb705403d70d31eae.r2.dev/ironfish_snapshot_1676666044141.tar.gz to /Users/yajun/.ironfish/temp/ironfish_snapshot_1676666044141.tar.gz
Downloading snapshot: [████████████████████████████████████████] 100% | 3.95 GB / 3.95 GB | 2n
Unzipping snapshot: [████████████████████████████████████████] 100% | 1911 / 1911 entries | 9n
Removing existing chain data at /Users/yajun/.ironfish/databases/chain before importing snapshot... done
Moving snapshot files from /Users/yajun/.ironfish/temp/snapshot to /Users/yajun/.ironfish/databases/chain... done
Cleaning up snapshot file at /Users/yajun/.ironfish/temp/ironfish_snapshot_1676666044141.tar.gz... done
✨  Done in 248.66s.
```
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
