### PR TITLE
chore: remove snake case key

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -99,7 +99,7 @@ export class ImportCommand extends IronfishCommand {
 
   static verifySpendingKey(spendingKey: string): string | null {
     try {
-      return generateKeyFromPrivateKey(spendingKey)?.spending_key
+      return generateKeyFromPrivateKey(spendingKey)?.spendingKey
     } catch (e) {
       return null
     }

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -52,11 +52,11 @@ export const enum LanguageCode {
   Spanish = 7
 }
 export interface Key {
-  spending_key: string
-  view_key: string
-  incoming_view_key: string
-  outgoing_view_key: string
-  public_address: string
+  spendingKey: string
+  viewKey: string
+  incomingViewKey: string
+  outgoingViewKey: string
+  publicAddress: string
 }
 export function generateKey(): Key
 export function spendingKeyToWords(privateKey: string, languageCode: LanguageCode): string

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -55,15 +55,10 @@ impl From<LanguageCode> for Language {
 
 #[napi(object)]
 pub struct Key {
-    #[napi(js_name = "spending_key")]
     pub spending_key: String,
-    #[napi(js_name = "view_key")]
     pub view_key: String,
-    #[napi(js_name = "incoming_view_key")]
     pub incoming_view_key: String,
-    #[napi(js_name = "outgoing_view_key")]
     pub outgoing_view_key: String,
-    #[napi(js_name = "public_address")]
     pub public_address: String,
 }
 

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -21,17 +21,17 @@ describe('Demonstrate the Sapling API', () => {
 
   it('Should generate a key', () => {
     const key = generateKey()
-    expect(typeof key.incoming_view_key).toBe('string')
-    expect(typeof key.outgoing_view_key).toBe('string')
-    expect(typeof key.public_address).toBe('string')
-    expect(typeof key.spending_key).toBe('string')
+    expect(typeof key.incomingViewKey).toBe('string')
+    expect(typeof key.outgoingViewKey).toBe('string')
+    expect(typeof key.publicAddress).toBe('string')
+    expect(typeof key.spendingKey).toBe('string')
   })
 
   it('Should be able to convert hex key to words, and reverse', () => {
     const hexKey = 'd56b241ca965b3997485ccf06421740c1d61163922ad1c02ee69fbe09253daf7'
     const hexKeyWords = 'step float already fan forest smile spirit ridge vacant canal fringe blouse stock mention tonight fiber bright blast omit water ankle clarify hint turn'
     const key = generateKeyFromPrivateKey(hexKey)
-    const words = spendingKeyToWords(key.spending_key, LanguageCode.English);
+    const words = spendingKeyToWords(key.spendingKey, LanguageCode.English);
     expect(words).toEqual(hexKeyWords)
 
     const hexKeyGenerated = wordsToSpendingKey(words, LanguageCode.English);
@@ -42,24 +42,24 @@ describe('Demonstrate the Sapling API', () => {
     const hexSpendingKey = 'd96dc74bbca05dffb14a5631024588364b0cc9f583b5c11908b6ea98a2b778f7'
     const key = generateKeyFromPrivateKey(hexSpendingKey)
     // concatenated bytes of authorizing_key and nullifier_deriving_key
-    expect(key.view_key).toEqual('498b5103a72c41237c3f2bca96f20100f5a3a8a17c6b8366a485fd16e8931a5d2ff2eb8f991032c815414ff0ae2d8bc3ea3b56bffc481db3f28e800050244463')
+    expect(key.viewKey).toEqual('498b5103a72c41237c3f2bca96f20100f5a3a8a17c6b8366a485fd16e8931a5d2ff2eb8f991032c815414ff0ae2d8bc3ea3b56bffc481db3f28e800050244463')
   })
 
   it('Should generate a new public address given a spending key', () => {
     const key = generateKey()
-    const newKey = generateKeyFromPrivateKey(key.spending_key)
+    const newKey = generateKeyFromPrivateKey(key.spendingKey)
 
-    expect(key.incoming_view_key).toEqual(newKey.incoming_view_key)
-    expect(key.outgoing_view_key).toEqual(newKey.outgoing_view_key)
-    expect(typeof newKey.public_address).toBe('string')
-    expect(key.spending_key).toEqual(newKey.spending_key)
+    expect(key.incomingViewKey).toEqual(newKey.incomingViewKey)
+    expect(key.outgoingViewKey).toEqual(newKey.outgoingViewKey)
+    expect(typeof newKey.publicAddress).toBe('string')
+    expect(key.spendingKey).toEqual(newKey.spendingKey)
   })
 
   it(`Should create a miner's fee transaction`, () => {
     const key = generateKey()
 
-    const transaction = new Transaction(key.spending_key)
-    const note = new Note(key.public_address, BigInt(20), 'test', Asset.nativeId(), key.public_address)
+    const transaction = new Transaction(key.spendingKey)
+    const note = new Note(key.publicAddress, BigInt(20), 'test', Asset.nativeId(), key.publicAddress)
     transaction.output(note)
 
     const serializedPostedTransaction = transaction.post_miners_fee()
@@ -76,11 +76,11 @@ describe('Demonstrate the Sapling API', () => {
     expect(encryptedNote.hash().byteLength).toBe(32)
     expect(encryptedNote.equals(encryptedNote)).toBe(true)
 
-    const decryptedNoteBuffer = encryptedNote.decryptNoteForOwner(key.incoming_view_key)
+    const decryptedNoteBuffer = encryptedNote.decryptNoteForOwner(key.incomingViewKey)
     expect(decryptedNoteBuffer).toBeInstanceOf(Buffer)
     expect(decryptedNoteBuffer!.byteLength).toBe(DECRYPTED_NOTE_LENGTH)
 
-    const decryptedSpenderNote = encryptedNote.decryptNoteForSpender(key.outgoing_view_key)
+    const decryptedSpenderNote = encryptedNote.decryptNoteForSpender(key.outgoingViewKey)
     expect(decryptedSpenderNote).toBe(null)
 
     const decryptedNote = Note.deserialize(decryptedNoteBuffer!)
@@ -88,24 +88,24 @@ describe('Demonstrate the Sapling API', () => {
     // Null characters are included in the memo string
     expect(decryptedNote.memo().replace(/\0/g, '')).toEqual('test')
     expect(decryptedNote.value()).toEqual(BigInt(20))
-    expect(decryptedNote.nullifier(key.view_key, BigInt(0)).byteLength).toBeGreaterThan(BigInt(0))
+    expect(decryptedNote.nullifier(key.viewKey, BigInt(0)).byteLength).toBeGreaterThan(BigInt(0))
   })
 
   it(`Should create a standard transaction`, () => {
     const key = generateKey()
     const recipientKey = generateKey()
 
-    const minersFeeTransaction = new Transaction(key.spending_key)
-    const minersFeeNote = new Note(key.public_address, BigInt(20), 'miner', Asset.nativeId(), key.public_address)
+    const minersFeeTransaction = new Transaction(key.spendingKey)
+    const minersFeeNote = new Note(key.publicAddress, BigInt(20), 'miner', Asset.nativeId(), key.publicAddress)
     minersFeeTransaction.output(minersFeeNote)
 
     const postedMinersFeeTransaction = new TransactionPosted(minersFeeTransaction.post_miners_fee())
 
-    const transaction = new Transaction(key.spending_key)
+    const transaction = new Transaction(key.spendingKey)
     transaction.setExpiration(10)
     const encryptedNote = new NoteEncrypted(postedMinersFeeTransaction.getNote(0))
-    const decryptedNote = Note.deserialize(encryptedNote.decryptNoteForOwner(key.incoming_view_key)!)
-    const newNote = new Note(recipientKey.public_address, BigInt(15), 'receive', Asset.nativeId(), minersFeeNote.owner())
+    const decryptedNote = Note.deserialize(encryptedNote.decryptNoteForOwner(key.incomingViewKey)!)
+    const newNote = new Note(recipientKey.publicAddress, BigInt(15), 'receive', Asset.nativeId(), minersFeeNote.owner())
 
     let currentHash = encryptedNote.hash()
     let authPath = Array.from({ length: 32 }, (_, depth) => {
@@ -128,7 +128,7 @@ describe('Demonstrate the Sapling API', () => {
     transaction.spend(decryptedNote, witness)
     transaction.output(newNote)
 
-    const postedTransaction = new TransactionPosted(transaction.post(key.public_address, BigInt(5)))
+    const postedTransaction = new TransactionPosted(transaction.post(key.publicAddress, BigInt(5)))
 
     expect(postedTransaction.expiration()).toEqual(10)
     expect(postedTransaction.fee()).toEqual(BigInt(5))

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -1430,7 +1430,7 @@ describe('Blockchain', () => {
 
           return node.chain.newBlock(
             [burnTransaction, spendTransaction],
-            await node.strategy.createMinersFee(fee, 3, generateKey().spending_key),
+            await node.strategy.createMinersFee(fee, 3, generateKey().spendingKey),
           )
         })
 

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -182,7 +182,7 @@ describe('Verifier', () => {
         () => {
           const key = generateKey()
           const reward = nodeTest.strategy.miningReward(minersBlock.header.sequence)
-          const owner = key.public_address
+          const owner = key.publicAddress
           const minerNote1 = new NativeNote(
             owner,
             BigInt(reward / 2),
@@ -197,7 +197,7 @@ describe('Verifier', () => {
             Asset.nativeId(),
             owner,
           )
-          const transaction = new NativeTransaction(key.spending_key)
+          const transaction = new NativeTransaction(key.spendingKey)
           transaction.output(minerNote1)
           transaction.output(minerNote2)
           return new Transaction(transaction._postMinersFeeUnchecked())

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -31,7 +31,7 @@ describe('Read genesis block', () => {
     const minersfee = await nodeTest.strategy.createMinersFee(
       BigInt(0),
       nodeTest.chain.head.sequence + 1,
-      generateKey().spending_key,
+      generateKey().spendingKey,
     )
     const newBlock = await nodeTest.chain.newBlock([], minersfee)
     expect(newBlock).toBeTruthy()
@@ -106,7 +106,7 @@ describe('Create genesis block', () => {
     const minersfee = await strategy.createMinersFee(
       BigInt(0),
       block.header.sequence + 1,
-      generateKey().spending_key,
+      generateKey().spendingKey,
     )
     const additionalBlock = await chain.newBlock([], minersfee)
     expect(additionalBlock).toBeTruthy()
@@ -144,7 +144,7 @@ describe('Create genesis block', () => {
     const newMinersfee = await strategy.createMinersFee(
       BigInt(0),
       deserializedBlock.header.sequence + 1,
-      generateKey().spending_key,
+      generateKey().spendingKey,
     )
     const newBlock = await newChain.newBlock([], newMinersfee)
     expect(newBlock).toBeTruthy()

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -54,11 +54,11 @@ export async function makeGenesisBlock(
   const genesisKey = generateKey()
   // Create a genesis note granting the genesisKey allocationSum coins.
   const genesisNote = new NativeNote(
-    genesisKey.public_address,
+    genesisKey.publicAddress,
     allocationSum,
     '',
     Asset.nativeId(),
-    genesisKey.public_address,
+    genesisKey.publicAddress,
   )
 
   // Create a miner's fee transaction for the block.
@@ -70,14 +70,14 @@ export async function makeGenesisBlock(
   logger.info(`Generating a miner's fee transaction for the block...`)
   const minersFeeKey = generateKey()
   const note = new NativeNote(
-    minersFeeKey.public_address,
+    minersFeeKey.publicAddress,
     BigInt(0),
     '',
     Asset.nativeId(),
-    minersFeeKey.public_address,
+    minersFeeKey.publicAddress,
   )
 
-  const minersFeeTransaction = new NativeTransaction(minersFeeKey.spending_key)
+  const minersFeeTransaction = new NativeTransaction(minersFeeKey.spendingKey)
   minersFeeTransaction.output(note)
   const postedMinersFeeTransaction = new Transaction(minersFeeTransaction.post_miners_fee())
 
@@ -88,7 +88,7 @@ export async function makeGenesisBlock(
    *
    */
   logger.info(`Generating an initial transaction with ${allocationSumInIron} coins...`)
-  const initialTransaction = new NativeTransaction(genesisKey.spending_key)
+  const initialTransaction = new NativeTransaction(genesisKey.spendingKey)
 
   logger.info('  Generating the output...')
   initialTransaction.output(genesisNote)
@@ -124,7 +124,7 @@ export async function makeGenesisBlock(
    *
    */
   logger.info('Generating a transaction for distributing allocations...')
-  const transaction = new NativeTransaction(genesisKey.spending_key)
+  const transaction = new NativeTransaction(genesisKey.spendingKey)
   logger.info(`  Generating a spend for ${allocationSumInIron} coins...`)
   transaction.spend(genesisNote, witness)
 

--- a/ironfish/src/migrations/data/022-add-view-key-account.ts
+++ b/ironfish/src/migrations/data/022-add-view-key-account.ts
@@ -34,7 +34,7 @@ export class Migration022 extends Migration {
 
       const migrated = {
         ...account,
-        viewKey: key.view_key,
+        viewKey: key.viewKey,
       }
 
       await stores.new.accounts.put(account.id, migrated, tx)

--- a/ironfish/src/primitives/rawTransaction.test.ts
+++ b/ironfish/src/primitives/rawTransaction.test.ts
@@ -186,7 +186,7 @@ describe('RawTransactionSerde', () => {
 
     const note = new Note(
       new NativeNote(
-        generateKey().public_address,
+        generateKey().publicAddress,
         5n,
         'memo',
         asset.id(),

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -93,11 +93,11 @@ describe('Demonstrate the Sapling API', () => {
 
   describe('Can transact between two accounts', () => {
     it('Can create a miner reward', () => {
-      const owner = generateKeyFromPrivateKey(spenderKey.spending_key).public_address
+      const owner = generateKeyFromPrivateKey(spenderKey.spendingKey).publicAddress
 
       minerNote = new NativeNote(owner, BigInt(42), '', Asset.nativeId(), owner)
 
-      const transaction = new NativeTransaction(spenderKey.spending_key)
+      const transaction = new NativeTransaction(spenderKey.spendingKey)
       transaction.output(minerNote)
       minerTransaction = new NativeTransactionPosted(transaction.post_miners_fee())
       expect(minerTransaction).toBeTruthy()
@@ -123,7 +123,7 @@ describe('Demonstrate the Sapling API', () => {
     })
 
     it('Can create a simple transaction', () => {
-      transaction = new NativeTransaction(spenderKey.spending_key)
+      transaction = new NativeTransaction(spenderKey.spendingKey)
       expect(transaction).toBeTruthy()
     })
 
@@ -137,7 +137,7 @@ describe('Demonstrate the Sapling API', () => {
       // Add an output to the transaction
       receiverKey = generateKey()
       const outputNote = new NativeNote(
-        receiverKey.public_address,
+        receiverKey.publicAddress,
         BigInt(40),
         '',
         Asset.nativeId(),
@@ -175,7 +175,7 @@ describe('Demonstrate the Sapling API', () => {
         workerPool,
         consensus: new TestnetConsensus(consensusParameters),
       })
-      const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spending_key)
+      const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spendingKey)
 
       expect(minersFee['transactionPosted']).toBeNull()
       expect(await workerPool.verify(minersFee, { verifyFees: false })).toEqual({ valid: true })
@@ -189,7 +189,7 @@ describe('Demonstrate the Sapling API', () => {
         consensus: new TestnetConsensus(consensusParameters),
       })
 
-      const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spending_key)
+      const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spendingKey)
 
       await minersFee.withReference(async () => {
         expect(minersFee['transactionPosted']).not.toBeNull()
@@ -212,7 +212,7 @@ describe('Demonstrate the Sapling API', () => {
         workerPool: new WorkerPool(),
         consensus: new TestnetConsensus(consensusParameters),
       })
-      const minersFee = await strategy.createMinersFee(BigInt(0), 0, key.spending_key)
+      const minersFee = await strategy.createMinersFee(BigInt(0), 0, key.spendingKey)
 
       expect(minersFee['transactionPosted']).toBeNull()
 
@@ -223,7 +223,7 @@ describe('Demonstrate the Sapling API', () => {
       }
 
       expect(note['noteEncrypted']).toBeNull()
-      const decryptedNote = note.decryptNoteForOwner(key.incoming_view_key)
+      const decryptedNote = note.decryptNoteForOwner(key.incomingViewKey)
       expect(decryptedNote).toBeDefined()
       expect(note['noteEncrypted']).toBeNull()
 
@@ -249,7 +249,7 @@ describe('Demonstrate the Sapling API', () => {
       expect(leaf.merkleHash.equals(latestNote.hash())).toBe(true)
 
       // We should be able to decrypt the note as owned by the receiver
-      const decryptedNote = latestNote.decryptNoteForOwner(receiverKey.incoming_view_key)
+      const decryptedNote = latestNote.decryptNoteForOwner(receiverKey.incomingViewKey)
       expect(decryptedNote).toBeTruthy()
       if (!decryptedNote) {
         throw new Error('DecryptedNote should be truthy')
@@ -257,17 +257,17 @@ describe('Demonstrate the Sapling API', () => {
       receiverNote = decryptedNote
 
       // If we can decrypt a note as owned by the receiver, the spender should not be able to decrypt it as owned
-      expect(latestNote.decryptNoteForOwner(spenderKey.incoming_view_key)).toBeUndefined()
+      expect(latestNote.decryptNoteForOwner(spenderKey.incomingViewKey)).toBeUndefined()
 
       // Nor should the receiver be able to decrypt it as spent
-      expect(latestNote.decryptNoteForSpender(receiverKey.outgoing_view_key)).toBeUndefined()
+      expect(latestNote.decryptNoteForSpender(receiverKey.outgoingViewKey)).toBeUndefined()
 
       // However, the spender should be able to decrypt it as spent
-      expect(latestNote.decryptNoteForSpender(spenderKey.outgoing_view_key)).toBeTruthy()
+      expect(latestNote.decryptNoteForSpender(spenderKey.outgoingViewKey)).toBeTruthy()
     })
 
     it('Can create and post a transaction', async () => {
-      transaction = new NativeTransaction(receiverKey.spending_key)
+      transaction = new NativeTransaction(receiverKey.spendingKey)
 
       const witness = await tree.witness(receiverWitnessIndex)
       if (witness === null) {
@@ -280,9 +280,9 @@ describe('Demonstrate the Sapling API', () => {
       transaction.spend(note, witness)
       receiverNote.returnReference()
 
-      const receiverAddress = receiverKey.public_address
+      const receiverAddress = receiverKey.publicAddress
       const noteForSpender = new NativeNote(
-        spenderKey.public_address,
+        spenderKey.publicAddress,
         BigInt(10),
         '',
         Asset.nativeId(),

--- a/ironfish/src/testUtilities/fixtures/blocks.ts
+++ b/ironfish/src/testUtilities/fixtures/blocks.ts
@@ -72,7 +72,7 @@ export async function useMinerBlockFixture(
   addTransactionsTo?: Wallet,
   transactions: Transaction[] = [],
 ): Promise<Block> {
-  const spendingKey = account ? account.spendingKey : generateKey().spending_key
+  const spendingKey = account ? account.spendingKey : generateKey().spendingKey
   const transactionFees = transactions.reduce((a, t) => a + t.fee(), BigInt(0))
 
   return await useBlockFixture(
@@ -261,7 +261,7 @@ export async function useBlockWithTx(
 
     return node.chain.newBlock(
       [transaction],
-      await node.strategy.createMinersFee(transaction.fee(), 3, generateKey().spending_key),
+      await node.strategy.createMinersFee(transaction.fee(), 3, generateKey().spendingKey),
     )
   })
 
@@ -328,7 +328,7 @@ export async function useBlockWithTxs(
 
     return node.chain.newBlock(
       transactions,
-      await node.strategy.createMinersFee(transactionFees, 3, generateKey().spending_key),
+      await node.strategy.createMinersFee(transactionFees, 3, generateKey().spendingKey),
     )
   })
 

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -109,7 +109,7 @@ describe('Accounts', () => {
       account,
       [
         {
-          publicAddress: generateKey().public_address,
+          publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
           memo: '',
           assetId: Asset.nativeId(),
@@ -124,7 +124,7 @@ describe('Accounts', () => {
     const minersfee2 = await strategy.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
-      generateKey().spending_key,
+      generateKey().spendingKey,
     )
     const newBlock2 = await chain.newBlock([transaction], minersfee2)
     const addResult2 = await chain.addBlock(newBlock2)
@@ -177,7 +177,7 @@ describe('Accounts', () => {
       account,
       [
         {
-          publicAddress: generateKey().public_address,
+          publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
           memo: '',
           assetId: Asset.nativeId(),
@@ -195,7 +195,7 @@ describe('Accounts', () => {
     const minersfee2 = await strategy.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
-      generateKey().spending_key,
+      generateKey().spendingKey,
     )
     const newBlock2 = await chain.newBlock([transaction], minersfee2)
     const addResult2 = await chain.addBlock(newBlock2)
@@ -247,19 +247,19 @@ describe('Accounts', () => {
       account,
       [
         {
-          publicAddress: generateKey().public_address,
+          publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
           memo: 'recipient 1',
           assetId: Asset.nativeId(),
         },
         {
-          publicAddress: generateKey().public_address,
+          publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
           memo: 'recipient 2',
           assetId: Asset.nativeId(),
         },
         {
-          publicAddress: generateKey().public_address,
+          publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
           memo: 'recipient 3',
           assetId: Asset.nativeId(),
@@ -277,7 +277,7 @@ describe('Accounts', () => {
     const minersfee2 = await strategy.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
-      generateKey().spending_key,
+      generateKey().spendingKey,
     )
     const newBlock2 = await chain.newBlock([transaction], minersfee2)
     const addResult2 = await chain.addBlock(newBlock2)
@@ -301,7 +301,7 @@ describe('Accounts', () => {
         account,
         [
           {
-            publicAddress: generateKey().public_address,
+            publicAddress: generateKey().publicAddress,
             amount: BigInt(2),
             memo: '',
             assetId: Asset.nativeId(),
@@ -356,7 +356,7 @@ describe('Accounts', () => {
       account,
       [
         {
-          publicAddress: generateKey().public_address,
+          publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
           memo: '',
           assetId: Asset.nativeId(),
@@ -383,7 +383,7 @@ describe('Accounts', () => {
     const minersfee2 = await strategy.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
-      generateKey().spending_key,
+      generateKey().spendingKey,
     )
     const newBlock2 = await chain.newBlock([], minersfee2)
     const addResult2 = await chain.addBlock(newBlock2)
@@ -442,7 +442,7 @@ describe('Accounts', () => {
       account,
       [
         {
-          publicAddress: generateKey().public_address,
+          publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
           memo: '',
           assetId: Asset.nativeId(),
@@ -466,7 +466,7 @@ describe('Accounts', () => {
     const minersfee2 = await strategy.createMinersFee(
       transaction.fee(),
       newBlock.header.sequence + 1,
-      generateKey().spending_key,
+      generateKey().spendingKey,
     )
     const newBlock2 = await chain.newBlock([], minersfee2)
     const addResult2 = await chain.addBlock(newBlock2)
@@ -522,7 +522,7 @@ describe('Accounts', () => {
       // Create block 2
       return nodeA.chain.newBlock(
         [transaction],
-        await nodeA.strategy.createMinersFee(transaction.fee(), 3, generateKey().spending_key),
+        await nodeA.strategy.createMinersFee(transaction.fee(), 3, generateKey().spendingKey),
       )
     })
 
@@ -665,7 +665,7 @@ describe('Accounts', () => {
         // Create block A2
         return nodeA.chain.newBlock(
           [transaction],
-          await nodeA.strategy.createMinersFee(BigInt(0), 3, generateKey().spending_key),
+          await nodeA.strategy.createMinersFee(BigInt(0), 3, generateKey().spendingKey),
         )
       },
       nodeA.wallet,
@@ -778,7 +778,7 @@ describe('Accounts', () => {
         // Create block A2
         return nodeA.chain.newBlock(
           [transaction],
-          await nodeA.strategy.createMinersFee(BigInt(0), 3, generateKey().spending_key),
+          await nodeA.strategy.createMinersFee(BigInt(0), 3, generateKey().spendingKey),
         )
       },
       nodeB.wallet,
@@ -791,7 +791,7 @@ describe('Accounts', () => {
     const blockB2 = await useBlockFixture(nodeB.chain, async () =>
       nodeB.chain.newBlock(
         [],
-        await nodeB.strategy.createMinersFee(BigInt(0), 3, generateKey().spending_key),
+        await nodeB.strategy.createMinersFee(BigInt(0), 3, generateKey().spendingKey),
       ),
     )
     addedBlock = await nodeB.chain.addBlock(blockB2)
@@ -801,7 +801,7 @@ describe('Accounts', () => {
     const blockB3 = await useBlockFixture(nodeB.chain, async () =>
       nodeB.chain.newBlock(
         [],
-        await nodeB.strategy.createMinersFee(BigInt(0), 4, generateKey().spending_key),
+        await nodeB.strategy.createMinersFee(BigInt(0), 4, generateKey().spendingKey),
       ),
     )
     addedBlock = await nodeB.chain.addBlock(blockB3)

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -1065,7 +1065,7 @@ describe('Accounts', () => {
 
         const mintBlock = await node.chain.newBlock(
           [transaction],
-          await node.strategy.createMinersFee(transaction.fee(), 4, generateKey().spending_key),
+          await node.strategy.createMinersFee(transaction.fee(), 4, generateKey().spendingKey),
         )
         await expect(node.chain).toAddBlock(mintBlock)
         await node.wallet.updateHead()
@@ -1230,7 +1230,7 @@ describe('Accounts', () => {
 
         return node.chain.newBlock(
           [transaction],
-          await node.strategy.createMinersFee(transaction.fee(), 3, generateKey().spending_key),
+          await node.strategy.createMinersFee(transaction.fee(), 3, generateKey().spendingKey),
         )
       })
       await expect(node.chain).toAddBlock(blockB)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1269,11 +1269,11 @@ export class Wallet {
       version: ACCOUNT_SCHEMA_VERSION,
       id: uuid(),
       name,
-      incomingViewKey: key.incoming_view_key,
-      outgoingViewKey: key.outgoing_view_key,
-      publicAddress: key.public_address,
-      spendingKey: key.spending_key,
-      viewKey: key.view_key,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      spendingKey: key.spendingKey,
+      viewKey: key.viewKey,
       walletDb: this.walletDb,
     })
 
@@ -1317,10 +1317,10 @@ export class Wallet {
       ...toImport,
       version: ACCOUNT_SCHEMA_VERSION,
       id: uuid(),
-      viewKey: key.view_key,
-      incomingViewKey: key.incoming_view_key,
-      outgoingViewKey: key.outgoing_view_key,
-      publicAddress: key.public_address,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
     }
 
     validateAccount(accountValue)

--- a/ironfish/src/wallet/walletdb/accountValue.test.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.test.ts
@@ -12,11 +12,11 @@ describe('AccountValueEncoding', () => {
     const value: AccountValue = {
       id: 'id',
       name: 'foobar👁️🏃🐟',
-      incomingViewKey: key.incoming_view_key,
-      outgoingViewKey: key.outgoing_view_key,
-      publicAddress: key.public_address,
-      spendingKey: key.spending_key,
-      viewKey: key.view_key,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      spendingKey: key.spendingKey,
+      viewKey: key.viewKey,
       version: 1,
     }
     const buffer = encoder.serialize(value)

--- a/ironfish/src/workerPool/job.test.slow.ts
+++ b/ironfish/src/workerPool/job.test.slow.ts
@@ -16,7 +16,7 @@ describe('Worker Pool', () => {
     expect(workerPool.workers.length).toBe(1)
     expect(workerPool.completed).toBe(0)
 
-    const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spending_key)
+    const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spendingKey)
     expect(minersFee.serialize()).toBeInstanceOf(Buffer)
 
     expect(workerPool.completed).toBe(1)

--- a/ironfish/src/workerPool/tasks/createMinersFee.ts
+++ b/ironfish/src/workerPool/tasks/createMinersFee.ts
@@ -77,7 +77,7 @@ export class CreateMinersFeeTask extends WorkerTask {
 
   execute({ amount, memo, spendKey, jobId }: CreateMinersFeeRequest): CreateMinersFeeResponse {
     // Generate a public address from the miner's spending key
-    const minerPublicAddress = generateKeyFromPrivateKey(spendKey).public_address
+    const minerPublicAddress = generateKeyFromPrivateKey(spendKey).publicAddress
     const minerNote = new Note(
       minerPublicAddress,
       amount,


### PR DESCRIPTION
## Summary
Refactor NAPI nodejs representation of `Key` to use default variable name export (instead of camel case).
## Testing Plan
tests pass
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
