### PR TITLE
chore: move AccountImport to accountImport RPC and use AccountValue in account.ts

### DIFF
--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -1,9 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
+import { v4 as uuid } from 'uuid'
 import * as yup from 'yup'
-import { AccountImport } from '../../../wallet/account'
 import { ApiNamespace, router } from '../router'
+
+export type AccountImport = { name: string; spendingKey: string; version: number }
 
 export type ImportAccountRequest = {
   account: AccountImport
@@ -39,7 +42,12 @@ router.register<typeof ImportAccountRequestSchema, ImportAccountResponse>(
   `${ApiNamespace.wallet}/importAccount`,
   ImportAccountRequestSchema,
   async (request, node): Promise<void> => {
-    const account = await node.wallet.importAccount(request.data.account)
+    const accountValue = {
+      id: uuid(),
+      ...request.data.account,
+      ...generateKeyFromPrivateKey(request.data.account.spendingKey),
+    }
+    const account = await node.wallet.importAccount(accountValue)
 
     if (request.data.rescan) {
       void node.wallet.scanTransactions()

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -24,8 +24,6 @@ export const ACCOUNT_KEY_LENGTH = 32
 
 export const ACCOUNT_SCHEMA_VERSION = 1
 
-export type AccountImport = { name: string; spendingKey: string; version: number }
-
 export class Account {
   private readonly walletDb: WalletDB
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -36,7 +36,7 @@ import {
 } from '../utils'
 import { WorkerPool } from '../workerPool'
 import { DecryptedNote, DecryptNoteOptions } from '../workerPool/tasks/decryptNotes'
-import { Account, ACCOUNT_SCHEMA_VERSION, AccountImport } from './account'
+import { Account, ACCOUNT_SCHEMA_VERSION } from './account'
 import { AssetBalances } from './assetBalances'
 import { NotEnoughFundsError } from './errors'
 import { MintAssetOptions } from './interfaces/mintAssetOptions'
@@ -1302,7 +1302,7 @@ export class Wallet {
     }
   }
 
-  async importAccount(toImport: AccountImport): Promise<Account> {
+  async importAccount(toImport: AccountValue): Promise<Account> {
     if (toImport.name && this.getAccountByName(toImport.name)) {
       throw new Error(`Account already exists with the name ${toImport.name}`)
     }


### PR DESCRIPTION
## Summary
This `AccountImport` type doesn't belong in the codebase. We already have a serialized version of account as `AccountValue`, all our code is mostly compatible with this.
## Testing Plan
tests pass and CLI works:
```
fish wallet:import  --datadir=~/.irfrefactorImport

Paste the output of wallet:export: ironfishaccount0000010v38vetjwd5k7m3z8gcjcgnwv9kk2g36yfjx2enpw4k8gg3vyfehqetwv35kue6tv4ujyw3zv4snzcfjvcckxvmyx9jrqcfnxyunqdryxuun2e33x5mnwdtrv4nrwwf4vcunycm9vg6nydpexqcx2dfevdjkgdmpvvmx2df4xqcnjvez9s38v6t9wa9k27fz8g3rzdecxvcnqetzx9snjefjxvmnjcmp89nrwcfcvverjve5v4snxdfcv5urxe35v56rwcehvsmnvcnyve3xxdrrxpnrvcenxqurgwpsx5crvcnzvenrqv3svymnvvpkxs6rxvfkxd3kgepnxuuk2cty8pjk2vekv93kyvfe8q6xvdn9x5cx2veexsekvvfhv33rwenxx56xxcmpygkzy6twvdhk66twvatxjethfdjhjg36ygersctzxe3ngefjxdsnverxvdnxxe34xf3xvdmyxy6rvdtrx5cngdm9vsunzefsx56xxvt9v5urydtrvesnywtrv9nxgerrxyergvp3ygkzymm4w3nk76twvatxjethfdjhjg36ygmnzdp4xgcrqcekxd3r2dp3xscxvvmxxf3nvwrrxycxvwfex33n2etxvcexzef5x4skzdfkvs6rjvmpvc6rwctzxuunyvryvyunzceeygkzyur4vfkxjc6pv3j8yetnwv3r5g3nxv6nxcnrxuurvctxvdjrwcfexscx2d34vyun2desxdsk2ctzvg6rjve38q6nqdfnxccr2vnrxy6nwd3cvg6nwefhxqun2dphxdnrxgnawr96mu
Account already exists with the name default
```
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
