### PR TITLE
Filter out non-owner assets from mint screen

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -121,6 +121,7 @@ export class Burn extends IronfishCommand {
       const asset = await selectAsset(client, account, {
         action: 'burn',
         showNativeAsset: false,
+        showNonOwnerAsset: true,
         showSingleAssetChoice: true,
         confirmations: flags.confirmations,
       })

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -160,8 +160,8 @@ export class Mint extends IronfishCommand {
       const asset = await selectAsset(client, account, {
         action: 'mint',
         showNativeAsset: false,
+        showNonOwnerAsset: false,
         showSingleAssetChoice: true,
-        showAssetOwnerOnly: true,
         confirmations: flags.confirmations,
       })
 

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -161,6 +161,7 @@ export class Mint extends IronfishCommand {
         action: 'mint',
         showNativeAsset: false,
         showSingleAssetChoice: true,
+        showAssetOwnerOnly: true,
         confirmations: flags.confirmations,
       })
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -126,6 +126,7 @@ export class Send extends IronfishCommand {
       const asset = await selectAsset(client, from, {
         action: 'send',
         showNativeAsset: true,
+        showNonOwnerAsset: true,
         showSingleAssetChoice: false,
         confirmations: flags.confirmations,
       })

--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -13,6 +13,7 @@ export async function selectAsset(
     action: string
     showNativeAsset: boolean
     showSingleAssetChoice: boolean
+    showAssetOwnerOnly?: boolean
     confirmations?: number
   },
 ): Promise<
@@ -25,6 +26,7 @@ export async function selectAsset(
   const balancesResponse = await client.getAccountBalances({
     account: account,
     confirmations: options.confirmations,
+    ownerOnly: options.showAssetOwnerOnly,
   })
 
   let balances = balancesResponse.content.balances

--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -12,7 +12,7 @@ export async function selectAsset(
   options: {
     action: string
     showNativeAsset: boolean
-    showNonOwnerAsset?: boolean
+    showNonOwnerAsset: boolean
     showSingleAssetChoice: boolean
     confirmations?: number
   },

--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -12,8 +12,8 @@ export async function selectAsset(
   options: {
     action: string
     showNativeAsset: boolean
+    showNonOwnerAsset?: boolean
     showSingleAssetChoice: boolean
-    showAssetOwnerOnly?: boolean
     confirmations?: number
   },
 ): Promise<
@@ -26,13 +26,20 @@ export async function selectAsset(
   const balancesResponse = await client.getAccountBalances({
     account: account,
     confirmations: options.confirmations,
-    ownerOnly: options.showAssetOwnerOnly,
   })
 
   let balances = balancesResponse.content.balances
 
   if (!options.showNativeAsset) {
     balances = balances.filter((b) => b.assetId !== Asset.nativeId().toString('hex'))
+  }
+
+  if (!options.showNonOwnerAsset) {
+    const accountResponse = await client.getAccountPublicKey({
+      account: account,
+    })
+
+    balances = balances.filter((b) => b.assetOwner === accountResponse.content.publicKey)
   }
 
   if (balances.length === 0) {

--- a/ironfish/src/rpc/routes/wallet/getBalances.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.test.ts
@@ -32,6 +32,7 @@ describe('getBalances', () => {
         {
           assetId,
           assetName: asset.name(),
+          assetOwner: asset.owner(),
           confirmed: BigInt(8),
           unconfirmed: BigInt(8),
           pending: BigInt(8),
@@ -44,6 +45,7 @@ describe('getBalances', () => {
         {
           assetId: Asset.nativeId(),
           assetName: Buffer.from('$IRON', 'utf8'),
+          assetOwner: Buffer.from('Iron Fish', 'utf8'),
           confirmed: BigInt(2000000000),
           unconfirmed: BigInt(2000000000),
           pending: BigInt(2000000000),
@@ -87,6 +89,7 @@ describe('getBalances', () => {
           ...mockBalance,
           assetId: mockBalance.assetId.toString('hex'),
           assetName: mockBalance.assetName.toString('hex'),
+          assetOwner: mockBalance.assetOwner.toString('hex'),
           confirmed: mockBalance.confirmed.toString(),
           unconfirmed: mockBalance.unconfirmed.toString(),
           pending: mockBalance.pending.toString(),

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -9,6 +9,7 @@ import { getAccount } from './utils'
 export interface GetBalancesRequest {
   account?: string
   confirmations?: number
+  ownerOnly?: boolean
 }
 
 export interface GetBalancesResponse {
@@ -31,6 +32,7 @@ export const GetBalancesRequestSchema: yup.ObjectSchema<GetBalancesRequest> = yu
   .object({
     account: yup.string().optional(),
     confirmations: yup.number().min(0).optional(),
+    ownerOnly: yup.boolean().optional(),
   })
   .defined()
 
@@ -73,6 +75,10 @@ router.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
       }
 
       const asset = await account.getAsset(balance.assetId)
+
+      if (request.data.ownerOnly && asset?.owner.toString('hex') !== account.publicAddress) {
+        continue
+      }
 
       balances.push({
         assetId: balance.assetId.toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -9,7 +9,6 @@ import { getAccount } from './utils'
 export interface GetBalancesRequest {
   account?: string
   confirmations?: number
-  ownerOnly?: boolean
 }
 
 export interface GetBalancesResponse {
@@ -17,6 +16,7 @@ export interface GetBalancesResponse {
   balances: {
     assetId: string
     assetName: string
+    assetOwner: string
     confirmed: string
     unconfirmed: string
     unconfirmedCount: number
@@ -32,7 +32,6 @@ export const GetBalancesRequestSchema: yup.ObjectSchema<GetBalancesRequest> = yu
   .object({
     account: yup.string().optional(),
     confirmations: yup.number().min(0).optional(),
-    ownerOnly: yup.boolean().optional(),
   })
   .defined()
 
@@ -47,6 +46,7 @@ export const GetBalancesResponseSchema: yup.ObjectSchema<GetBalancesResponse> = 
           .shape({
             assetId: yup.string().defined(),
             assetName: yup.string().defined(),
+            assetOwner: yup.string().defined(),
             unconfirmed: yup.string().defined(),
             unconfirmedCount: yup.number().defined(),
             pending: yup.string().defined(),
@@ -76,13 +76,10 @@ router.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
 
       const asset = await account.getAsset(balance.assetId)
 
-      if (request.data.ownerOnly && asset?.owner.toString('hex') !== account.publicAddress) {
-        continue
-      }
-
       balances.push({
         assetId: balance.assetId.toString('hex'),
         assetName: asset?.name.toString('hex') ?? '',
+        assetOwner: asset?.owner.toString('hex') ?? '',
         blockHash: balance.blockHash?.toString('hex') ?? null,
         confirmed: CurrencyUtils.encode(balance.confirmed),
         sequence: balance.sequence,


### PR DESCRIPTION
## Summary
Fix https://github.com/iron-fish/ironfish/issues/3477. `wallet:mint` should filter out non-owner assets. Adding `ownerOnly` flag to GetBalancesRequest rpc.

## Testing Plan
Run `ironfish wallet:mint` and see that non-owner assets no longer appear rom select screen. Run `ironfish wallet:send/burn` and confirm it still shows all assets.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
