### PR TITLE
returns undefined for missing nullifierToNoteHash

### DIFF
--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -326,7 +326,7 @@ describe('Accounts', () => {
       for (const spend of transaction.spends) {
         const spentNoteHash = await accountA.getNoteHash(spend.nullifier)
 
-        Assert.isNotNull(spentNoteHash)
+        Assert.isNotUndefined(spentNoteHash)
 
         const spentNote = await accountA.getDecryptedNote(spentNoteHash)
 
@@ -428,7 +428,7 @@ describe('Accounts', () => {
       for (const spend of transaction.spends) {
         const spentNoteHash = await accountA.getNoteHash(spend.nullifier)
 
-        Assert.isNotNull(spentNoteHash)
+        Assert.isNotUndefined(spentNoteHash)
 
         const spentNote = await accountA.getDecryptedNote(spentNoteHash)
 
@@ -798,7 +798,7 @@ describe('Accounts', () => {
       for (const spend of transaction.spends) {
         const spentNoteHash = await accountA.getNoteHash(spend.nullifier)
 
-        Assert.isNotNull(spentNoteHash)
+        Assert.isNotUndefined(spentNoteHash)
 
         const spentNote = await accountA.getDecryptedNote(spentNoteHash)
 
@@ -813,7 +813,7 @@ describe('Accounts', () => {
       for (const spend of transaction.spends) {
         const spentNoteHash = await accountA.getNoteHash(spend.nullifier)
 
-        Assert.isNotNull(spentNoteHash)
+        Assert.isNotUndefined(spentNoteHash)
 
         const spentNote = await accountA.getDecryptedNote(spentNoteHash)
 
@@ -1135,7 +1135,7 @@ describe('Accounts', () => {
       expect(notes.length).toEqual(0)
 
       // nullifierToNoteHash entry removed
-      await expect(accountA.getNoteHash(nullifier)).resolves.toBeNull()
+      await expect(accountA.getNoteHash(nullifier)).resolves.toBeUndefined()
 
       // the note is not stored in sequenceToNoteHash or nonChainNoteHashes
       await expect(accountHasSequenceToNoteHash(accountA, 2, noteHash)).resolves.toBe(false)

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -629,8 +629,8 @@ export class Account {
     })
   }
 
-  async getNoteHash(nullifier: Buffer, tx?: IDatabaseTransaction): Promise<Buffer | null> {
-    return await this.walletDb.loadNoteHash(this, nullifier, tx)
+  async getNoteHash(nullifier: Buffer, tx?: IDatabaseTransaction): Promise<Buffer | undefined> {
+    return this.walletDb.loadNoteHash(this, nullifier, tx)
   }
 
   async getTransaction(
@@ -657,7 +657,7 @@ export class Account {
 
   async hasSpend(transaction: Transaction, tx?: IDatabaseTransaction): Promise<boolean> {
     for (const spend of transaction.spends) {
-      if ((await this.getNoteHash(spend.nullifier, tx)) !== null) {
+      if ((await this.getNoteHash(spend.nullifier, tx)) !== undefined) {
         return true
       }
     }

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -243,8 +243,8 @@ describe('Accounts', () => {
     const forkSpendNullifier = forkSpendTx.spends[0].nullifier
     const forkSpendNoteHash = await accountA.getNoteHash(forkSpendNullifier)
 
-    // nullifier should be non-null
-    Assert.isNotNull(forkSpendNoteHash)
+    // nullifier should be defined
+    Assert.isNotUndefined(forkSpendNoteHash)
 
     // re-org
     await expect(nodeA.chain).toAddBlock(blockB1)
@@ -258,7 +258,7 @@ describe('Accounts', () => {
     expect(forkSpendNote?.nullifier).toBeNull()
 
     // nullifier should have been removed from nullifierToNote
-    expect(await accountA.getNoteHash(forkSpendNullifier)).toBeNull()
+    expect(await accountA.getNoteHash(forkSpendNullifier)).toBeUndefined()
   })
 
   describe('scanTransactions', () => {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1249,7 +1249,7 @@ export class Wallet {
     let send = false
 
     for (const spend of transaction.transaction.spends) {
-      if ((await account.getNoteHash(spend.nullifier, tx)) !== null) {
+      if ((await account.getNoteHash(spend.nullifier, tx)) !== undefined) {
         send = true
         break
       }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -506,9 +506,8 @@ export class WalletDB {
     account: Account,
     nullifier: Buffer,
     tx?: IDatabaseTransaction,
-  ): Promise<Buffer | null> {
-    const noteHash = await this.nullifierToNoteHash.get([account.prefix, nullifier], tx)
-    return noteHash || null
+  ): Promise<Buffer | undefined> {
+    return this.nullifierToNoteHash.get([account.prefix, nullifier], tx)
   }
 
   async saveNullifierNoteHash(


### PR DESCRIPTION
## Summary

when loading values from nullifierToNoteHash we convert the return value from undefined to null if the key is not found in the datastore. we do not do this for any other datastore in the walletDb.

returns undefined when key is not found in the datastore to be consistent with other stores in the walletDb.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
