### PR TITLE
fixes walletdb migrations that rely on old accounts

### DIFF
--- a/ironfish/src/migrations/data/016-sequence-to-tx.ts
+++ b/ironfish/src/migrations/data/016-sequence-to-tx.ts
@@ -5,8 +5,8 @@
 import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
-import { Account } from '../../wallet'
 import { Migration } from '../migration'
+import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration016 extends Migration {
   path = __filename
@@ -21,16 +21,7 @@ export class Migration016 extends Migration {
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
   ): Promise<void> {
-    const accounts = []
-
-    for await (const accountValue of node.wallet.walletDb.loadAccounts()) {
-      accounts.push(
-        new Account({
-          ...accountValue,
-          walletDb: node.wallet.walletDb,
-        }),
-      )
-    }
+    const accounts = await GetOldAccounts(node, db, tx)
 
     logger.info(`Indexing on-chain transactions for ${accounts.length} accounts`)
 

--- a/ironfish/src/migrations/data/018-backfill-wallet-assets.ts
+++ b/ironfish/src/migrations/data/018-backfill-wallet-assets.ts
@@ -4,8 +4,8 @@
 import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
-import { Account } from '../../wallet'
 import { Migration } from '../migration'
+import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration018 extends Migration {
   path = __filename
@@ -24,15 +24,7 @@ export class Migration018 extends Migration {
     // running this migration
     await node.wallet.walletDb.assets.clear()
 
-    const accounts = []
-    for await (const accountValue of node.wallet.walletDb.loadAccounts(tx)) {
-      accounts.push(
-        new Account({
-          ...accountValue,
-          walletDb: node.wallet.walletDb,
-        }),
-      )
-    }
+    const accounts = await GetOldAccounts(node, _db, tx)
 
     logger.info(`Backfilling assets for ${accounts.length} accounts`)
 

--- a/ironfish/src/migrations/data/019-backfill-wallet-assets-from-chain.ts
+++ b/ironfish/src/migrations/data/019-backfill-wallet-assets-from-chain.ts
@@ -9,8 +9,8 @@ import { IronfishNode } from '../../node'
 import { BUFFER_ENCODING, IDatabase, IDatabaseStore, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
 import { BufferUtils } from '../../utils'
-import { Account } from '../../wallet'
 import { Migration } from '../migration'
+import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration019 extends Migration {
   path = __filename
@@ -34,15 +34,7 @@ export class Migration019 extends Migration {
       valueEncoding: new AssetValueEncoding(),
     })
 
-    const accounts = []
-    for await (const accountValue of node.wallet.walletDb.loadAccounts(tx)) {
-      accounts.push(
-        new Account({
-          ...accountValue,
-          walletDb: node.wallet.walletDb,
-        }),
-      )
-    }
+    const accounts = await GetOldAccounts(node, _db, tx)
 
     logger.info(`Backfilling assets for ${accounts.length} accounts`)
 

--- a/ironfish/src/migrations/data/020-backfill-null-asset-supplies.ts
+++ b/ironfish/src/migrations/data/020-backfill-null-asset-supplies.ts
@@ -5,8 +5,8 @@ import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { BufferUtils } from '../../utils'
-import { Account } from '../../wallet'
 import { Migration } from '../migration'
+import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration020 extends Migration {
   path = __filename
@@ -21,15 +21,7 @@ export class Migration020 extends Migration {
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
   ): Promise<void> {
-    const accounts = []
-    for await (const accountValue of node.wallet.walletDb.loadAccounts(tx)) {
-      accounts.push(
-        new Account({
-          ...accountValue,
-          walletDb: node.wallet.walletDb,
-        }),
-      )
-    }
+    const accounts = await GetOldAccounts(node, _db, tx)
 
     logger.info(`Backfilling assets for ${accounts.length} accounts`)
 

--- a/ironfish/src/migrations/data/021-add-version-to-accounts/schemaOld.ts
+++ b/ironfish/src/migrations/data/021-add-version-to-accounts/schemaOld.ts
@@ -1,9 +1,17 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
+import { generateKeyFromPrivateKey, PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import { IDatabase, IDatabaseEncoding, IDatabaseStore, StringEncoding } from '../../../storage'
+import { IronfishNode } from '../../../node'
+import {
+  IDatabase,
+  IDatabaseEncoding,
+  IDatabaseStore,
+  IDatabaseTransaction,
+  StringEncoding,
+} from '../../../storage'
+import { Account } from '../../../wallet'
 
 const KEY_LENGTH = 32
 
@@ -74,4 +82,28 @@ export function GetOldStores(db: IDatabase): {
   )
 
   return { accounts }
+}
+
+export async function GetOldAccounts(
+  node: IronfishNode,
+  db: IDatabase,
+  tx?: IDatabaseTransaction,
+): Promise<Account[]> {
+  const accounts = []
+  const oldStores = GetOldStores(db)
+
+  for await (const account of oldStores.accounts.getAllValuesIter(tx)) {
+    const key = generateKeyFromPrivateKey(account.spendingKey)
+
+    accounts.push(
+      new Account({
+        ...account,
+        version: undefined,
+        viewKey: key.viewKey,
+        walletDb: node.wallet.walletDb,
+      }),
+    )
+  }
+
+  return accounts
 }


### PR DESCRIPTION
## Summary

we've recently made changes to the way that accounts are stored in the walletdb. it's possible that a user may have a database that needs to apply migrations that rely on the old AccountValue encoding before applying the migration to the new encoding.

this results in an encoding error when an older migration (pre-021) attempts to read from the accounts store, which has not yet been migrated.

adds a function, GetOldAccounts, to simplify reading accounts from the old accounts store in older migrations. uses this function for loading accounts in all migrations before Migration021.

## Testing Plan

Running migrations before changes:
<img width="912" alt="image" src="https://user-images.githubusercontent.com/57735705/220196723-faf4de75-cefc-41a9-94b0-368b9a3499fc.png">

Running migrations after changes:
<img width="376" alt="image" src="https://user-images.githubusercontent.com/57735705/220196789-c6d8aba6-296b-4c32-ab9a-3efd35b639d1.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
