### PR TITLE
feat(ironfish): add a recently evicted cache to the mempool

### DIFF
--- a/ironfish/src/memPool/__fixtures__/recentlyEvictedCache.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/recentlyEvictedCache.test.ts.fixture
@@ -1,0 +1,336 @@
+{
+  "RecentlyEvictedCache should not exceed maximum capacity": [
+    {
+      "version": 1,
+      "id": "537eb451-2fab-4b3f-874a-bf2a1e9e9128",
+      "name": "accountA",
+      "spendingKey": "2a8495969d2ad7446cfc1866eb9c9f8a0a0ce296309f839c2f67428a6a3757e5",
+      "viewKey": "501f1b796d92a99312755f8313e8f581f2196c583810f8ffa66c628f61c49ee9245912584b4a9140d443b7ee630b45f627a1e07711f353a8a8ebba66f788d22c",
+      "incomingViewKey": "b32c1e805403c8098783e546112a011ee0266712167d5327195560771b066103",
+      "outgoingViewKey": "8d1dd71e3298371738cd0adcd5fc8bfa40335448ee50a1869f0c925a2e5b087f",
+      "publicAddress": "caca21d53c475a64bfb585904e812ad46a0101e8058cac2158f7540dcefd1c11"
+    },
+    {
+      "version": 1,
+      "id": "fa9d7c09-35bf-4cc9-a516-4ca38597e483",
+      "name": "accountB",
+      "spendingKey": "b6216b9e5ac663e8ae1faf658ca1219bba5b0bca05cb7deb65861a9f2f2f952a",
+      "viewKey": "fb652c985c0ca32a52230dd52c0216b8c32a9d06fc782d7dc25cdf4985193fca10b218380d926374a2365f2cc80d19a957022b3165442d049220299bf71a6eee",
+      "incomingViewKey": "475b9aae2855624d0e30bef03d18d396841174bd65470dfe067f5e4abd162300",
+      "outgoingViewKey": "1c67cf6ea63cb08b0e7d37d5afa79bc7e1e660d16a89c20bc8cf30b45fb8b3b6",
+      "publicAddress": "2f8d8fb34935cc48e95166df2c209f01ea2df012977f7e6389ac0f461ff6e4ec"
+    },
+    {
+      "version": 1,
+      "id": "aaa7e247-e386-4b02-a8a3-3367e318065b",
+      "name": "accountC",
+      "spendingKey": "84baa4f4ec097e1681cecdc16054add48d9a77d5c77d6065ba03fce47b7abab0",
+      "viewKey": "d8343a12e68b06f11814ff57e019c27b7c1afa6f6cb41da88712581474107866bc95a88cbafc70af1520210e54e276a23c4e24d5d812e22d5675c3bf782267b5",
+      "incomingViewKey": "38156674976349006fb25eb68ff3e56477b5a9d18462792ad7ea0f7bb4d7ac04",
+      "outgoingViewKey": "c9619b7d1acd0dd2e614aa981c77cc6fa0b301059b812a22ff0aa4ec798de618",
+      "publicAddress": "70ba6a43a7374ac7a38bb78b24760ba2d976ffb160991749045a7e240ed999f2"
+    },
+    {
+      "version": 1,
+      "id": "3d917279-e849-4838-be77-2dc33d2133ce",
+      "name": "accountD",
+      "spendingKey": "3afc72d7860a5ff3584fa96ab18da96358110b3b97f708624468d46cbddfefaa",
+      "viewKey": "6b1ad144b7c7d03e309d53b122a1b21926ba5712a1929c82338c6c892035542cac154f871b72a1d7bcbebaa8844740316ce052f07b0b5ef1f9bc1fc09bebd8ad",
+      "incomingViewKey": "6cbb67744c3da1c89790b85d68d5fad302ae81e3bc619cb372574580ce8d4200",
+      "outgoingViewKey": "e78641092660346234e73321007129b2971921cfe6a6132931654831351f8068",
+      "publicAddress": "1c973d12b8fa4cddb0d91aa1c75e0fb2b034ecad44c14f47ec4949827fdd5e0f"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:XQ4kmNuI3ywU7jNPPJpGiv8U6tbTdEhD4oBFI/ehQC8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:SwLUaw+TgKs0NxO3z0UxFqlLqyoRf79AOB9ZbzSDPDo="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1677013875249,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAg20KvO5TiZcIXl2m6Inulle2hK6AWvjdVfwM6T1Ipt6hn662mcse8tVHmTQHJlr39tLdcbCn7RVGS6GsgWlsNS3jVLUOWy8/T81sRf4Z3M20i0T+gzkue58f12Fzpt1DVMCiU7sSw/gXPqDC+lFA4Xul6wCShswKE+EWtIvONzcTJK8wBXhhNnFNjBwf3S/QsjbECZ+nOK0z6RyN9lGCojoM0quGV2T2HZf6bqOSU7WEmwToPiX+eBuPzGTHHUFu2I9CQrPTS/ZlK/wLM56rEYckPhu7Tb5zCfrS//W/pPYjVeqPmtgJ3e0tfUPIM+FrpUzz5bctpjdKBObA37KL0ns+M5dl121eITCYIXvwR5YtYifPuozAPSkIAm61ZFsV6jnoRtnTGxucqsHKcpFk3SwPf3bYQ1zBn7v2Ogd8GgegQEUuzBZhEV+ZvfA4PJarf2gUGB24jfNI/+Odw+6TGPMWjZtRxOQe125dlVNSkTgv3kfpnSXGtd6RWMvaLY2p1p7hztFW4/EEdNGapzQrIOc/SQ7vZvScnzPU17Ab6/AxypeOhF+LWXTetmI23q80QOC+tDie09Ger59HYQ3T91+iUaboMhsaXw8VDZHf1wMoep4Lx4uwyklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxq3qVb/l1OpJiBH5f2vhBZJdoWID+Ysnt2rj4F2JTGh3tP55gq3glPCVZtxIwMHsjIaGMrFPuTGhBXhkfFf2Cg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "C77D18DA4C155AD8DE3236D4E6920940650FF525CBDE5AF36CF2A86BE71E2028",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:WpQQv1LX+5SxCPZfGzQtkJSnHcqz8yURcn8Q78GaRwk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:LO9/s7+9MbWSAFUOipMKVyDSibWDPkPdDOq2IYKjAA4="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1677013878433,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAN9OEvQnzPsSjjTwOaB7f88A9Bi0OxOF7gOTOuDOyG2GEl3jG/KEZu9e1J7nEfw5c3kWkDUvQszR4UnsznJz5tSfTkMDH4VURc//cHUzrSXi5CTJSFlaZr6C8hHVsZcFdnZ8G48lpwO4Jh/wqP+RwGJFmQm0R4muVz7dNU3EDnBMZIHNG28ETwrR9jxq7zQWD2oPNDBsO9zhChzXgJkXOeHzwpfNuWAZ71El+0e2udcG0nFpPyF9fTMAuvlvZDhTWEnpR8oTd1jVMBegf85OhUyAPHMrD6ylaYbTHmzb30y0zBcgswO8GdfG6w5qMjFbMFZznBzkVV+uzQ4MFvRnrb70YPDJCGhrOftp4h5ec04ASxWnZ2ZfBSdJEI+yQbEA2g05P7eASP0XXVrzrcEDK/Zn7xQb+nB5A7p8DnI+tIJ2ND0q0KbhEgBVZH4nNtF3xkMuxqG2RpJs40OiVoDzL+4+/rwBmwXbyt6ksxhe4iMaMAPZljnNtFwPxaW3QlR3giEh7czsu7qgItQ5mP/62uMR/m1wndR8srerlzyDhCbpngx/6ORgAcWwXPOFQgGAJ3sTHteF70B8einJYivMh3bOZ6U4jFLcafpwaZmmzIlIjTqmASfRm3Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQcbKHkOkOBzW8zX+81KXOqtPOJKUiAijHsz5Qb8m+47BSljXd2lo7yzCeb1F7DEadREHjN/l0XeskjicdQdcDQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAm34BnqgubMEcXIztA7/DV3IO5rWfvolYtFtzFDs6tPOIH3mXXaSx45G4w1VtLVPhvsMhftELY43hqe2KjnaiGcMGk3qAMGj4CCab+qNdnZSEXJU+HOMxu2CFb6SMuaNydZh+Vb4/nWQvqqafYo8kwMVaJSy19His5I4R5REzdWsFk8JjKk359r8eYUNSrpSe8e8UxzrKqrBKGEYARKk+sJTZY0TgdSuTXa3lulkUoyODw7dQWjIAGLzfeEntdqjXEPEvd0nyUc730jb/IWrBKMQVgmq7ZGJlzGcqWD2vBk2EqnLuYYLjSn2qgO6NvOGurt0eaGcqprNYZWS8nJRX4V0OJJjbiN8sFO4zTzyaRor/FOrW03RIQ+KARSP3oUAvBAAAAOs4FKUClWcZGUpyWPAtiYF2DBtQhh8+1U3cNJE7HnEtbPTbxzXPvzBGMP0lLoQSL2iAC5YKN5TLXzxPFGLrJWZfwKxGeBaffAJniGtzgxONUCCTLADE8cJYPBGiQJygCKUcV6vTDuP8NQUGAaSqGLf+sopWteGX05z9Wy+TAi/NxJYaFJXOlWsxspZM3laTRK0TWcTO9dcNNtyM0HuTMYIiBmereHLbk3SnuD6bPyo8KowTi89emOYu77/Sspfadhcf7qnxTNoNOZFT7cmaavy3HSGf2qAdqWwB1JojgWSW9pRzcM6SQUkZ9n0OJ9KYbqCIbMRHz2+/Okc6TOfE/rj2Nj8YZf1lellECq7zOlfeG+BVFHu/4bwnhhVlHysZHdJnm9MNWfDUH1qc1xYKTcALWQkbaaGfEliSWChWMwtftmD3kA91rpyFdl7pHlor8GtOBcovNywMzcKKCO2brTTtzrUXEBBxBfKTriyi646HwgFgVPLRjrDgzEj5QfFqKivlkbOgjC4QEN5ZzjaC78ONoSn+TVfGO/rV8CGy7OeAG+GHk+R1Bk05TX6mdIvz7Ta1J41rjid6MjqP1+rERLy6xl6ebDtX/DZPoavd96dqAvqViCoBlboUJC0Jfjw6BTwEl+opoEvOPR2OAZUVDlBONU7LsvmZdq5eHhlcitBjD3opKZCYIM6sKiDMq6A+LvtVYm1qtClEoii//aDBWXIIZuw74z7JbMNFHXq+NZLjYbIlK0KBp57IWcSmSkUO9HAOx70TtBROiqcizJXU5AbnEhhVev0Et/GRhm1PoVeVWheFvGfuhAiWprgj5JYHorhSNkyqCUXvfZaotCUYDwCYvPjC6ImWYmsLILSQUqTVhTltRJvCUPmCX4vXgnv0c9M/dmYhPBSRlNbLlrED2Y3XpJ3IMkrI0jEpb6L5mYF/HcfVn182qDoEel2eU+uOVJr7hbOc2UuTgroBprxL1AC2UDkdxBglIBZhOorV1HFj7mBILYM/jre4Gv2eeZBi9JDgtAjhyLXOsHkLklrsdXb56T4TkS3SYmczQSzAHqNOMAv858Vm8QrNYzxJd2ucuxrhV4BTASDz3EFqIIoukW1GDs/xRdK8Lw2eTT7GpYlueo148LCXWPTuBkDLSad1V1j1GsfRMV8Ibn4FGImXZRCKKoI51Sj1VqEVe5NlI85wUT3+UcKzhpbL16ntg4OCGXbSYxdPYXurPamoH/KNKOLmDCBLQKrZJgzeU01FGNmrYcxE6KrKeic5oixlWOv/7p992Hli+4IY9KEoXEjrO2o4eLrGD5IwhAP4r203iNPSf5MNIN9zbm+gQ7P2GEN6NeFCLQqzoBjoDFqglkebA0lTezBgPPzbrfERpO6zf0BAVHbju0wn56pp0S0Aq/sKiU9YheNPZThJ1SACTZCpHfHvzvA5H+1SiJs2NQnYOxCN/vwRGNLgiUyaUew9WPsh7scZfJCMAMYWQI//3pYi/ozs2z/bqciwv29it0/dM5hRSlGhpVRE/+34i2VPTZj9ABSTKq6zw8tTmqCa87mKVQ3mGHoD+kspRSfsxUM1/R11RrMD5Ayld7MZg/I2LNjPAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "C77D18DA4C155AD8DE3236D4E6920940650FF525CBDE5AF36CF2A86BE71E2028",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:yzZ9QMntzzJhVKlEFwU5n+To01bU51uvTCRvJf1x7gM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:WV8U+r+V2yh8NIvzqdaZdeCltbYb4cZUtRda9RClmQE="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1677013879037,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAnGI0W50gQhk8aZbJsSBbj48VRPYvl31xBNnmF0JbTBWzJs4G3XoaquZ0OGw96Tce69OiPg5+v/Pl9puhLucvleHfyoqxgNU8bfcK9mnagfmumpstJR1fNisOHpd9JD/FvcSqGH1qF5RcCkexc5PCDQFU75lfuPK0mtglQOXDBCET/X2pwJR3PsPCu9c6cdbfvv4cdro4TjQGYUWobEotoqYUjv26NF2M7FiU9GkudCOSgiQq7UXnTWP98Z/iWDKh/zvUwt2I02gWPvwvw75BW9GBCxPUEx8YKIu17U5tc6jb1hBKu5n1J8Z2L5EZxNRHD1NhIt36Jg8s7ueYzTPac4qJ7cBXFzGu8EP6x8nt7c9Fm13dHW9koGIwODBIJDckbNXAe7sorqXQltQu4mqK6EoLZHo8g94hX/reKP6lum80y/ZKnFkV/j2JlSQ/W7K8jrEE2biiXRhVm4l8wsgAcvdxxq5FKa8xKei45Q5TQzgD85C26Eh6IJaHmxlkh0YhOzX6EXEZnY4wDwlK4w75050KHzqiSNi1F6OfzS913IIcbdv/k1L6lWRM7jGzIt3j6Zc+tw21PXFBPlMX3UFCQ5NIbeb1eL8T9+VVI43uian430tJA9HLMklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2Rdws8Yu9GPugSsVSs1WUsR8qks6kh92HJa2LYBCnqKqbQFO8Y+htDmFvJM+gtxeh10NHl7Gr076sQx0RFf4Cg=="
+        }
+      ]
+    }
+  ],
+  "RecentlyEvictedCache lol should not exceed maximum capacity": [
+    {
+      "version": 1,
+      "id": "310ce753-509d-4076-bd73-34f53bfe3584",
+      "name": "accountA",
+      "spendingKey": "f766533188ccdba4879351f1e6df97b50c22f08b428754867be867944d188168",
+      "viewKey": "ac98e65c82ac61510c991c255fd1dbea06d77ecc49f81143ec39675cbe2ec60534bf532af3da74858678a08f8ff57be2867b514011643a921b770a0299323ccc",
+      "incomingViewKey": "72006862c8fa6792c507c2ee205428cc0c27bf787323e86618028f03fa1aa906",
+      "outgoingViewKey": "05ea0b643126719b147b2a0e7dc16e9f9d08cc8cfc3ca8025bd81604768dc1de",
+      "publicAddress": "d4b56714362a5f3a71b36187535783e456117633aaf0bc1d196c2902c6c83fd7"
+    },
+    {
+      "version": 1,
+      "id": "5b60e45d-3be2-4c0d-ab6e-12b807b9c8ef",
+      "name": "accountB",
+      "spendingKey": "d17eeea26ba859109e077aa3286c2d5357e04acabaab818d706516d14c8d424b",
+      "viewKey": "1d2d33a2fb42dc8a4492cd8ec563843be45b94f93579b4992d6d45e8f9d74dcee08082c0f42dbf1551b8e4cd643dad34904114ebd19abb1c311e65842de0e7bb",
+      "incomingViewKey": "2956912d1efebdc8c86fb08cb0c3ec966302e853b063364758b53fbd542a4d02",
+      "outgoingViewKey": "f7b0de659284741a1bc75f296e3d12f8b80f8f255352348535a41d423f9c894f",
+      "publicAddress": "c2f592741c0d785dbe4fd74bced611601d666ceba7d9de61eaa674d7b875bf8e"
+    },
+    {
+      "version": 1,
+      "id": "954b1abe-5e4e-47d1-bdf6-1aaa6d59eada",
+      "name": "accountC",
+      "spendingKey": "6f983941b18a5e7e5b389059d3c2629db7257d097f88fff93d62d05bd98a59e7",
+      "viewKey": "920bab308e7db699924ef45af43f6b11556412973f8da1c0a5ae22f946c2d5db2c28112c066419edf946234c4791c7a0b5d6f14f5a1c430bbeac1ddcbbef0f8a",
+      "incomingViewKey": "eab29d2688e7c4bc7ec24baa2422b68f44e293511dd6be806d12b73b136d5500",
+      "outgoingViewKey": "0cfd28d067ef0c43b50cf53416b36f72dd219a5474ae3474ac8e6bc1ab072507",
+      "publicAddress": "59308f7cd59fd9db8ebec81fb1a4ecac28222317bb2d1f8b5d29f1c3346fc41a"
+    },
+    {
+      "version": 1,
+      "id": "167c2330-783f-40ef-a37d-f2cf1f7daf78",
+      "name": "accountD",
+      "spendingKey": "0f1e48887fa514edf51c2273ce7d2236071e27421a8d6ae620bf2c4973c770fe",
+      "viewKey": "40412fbd0d3511a9c145b88e0f7f188f00ad2f47288a2e5fd978bc8be44b8920c3f5447f01c33650b2e6076d1e13af4cdeb76df111d58b855ee64d4ef9f13b0e",
+      "incomingViewKey": "d9285fbc15a531ad5a1840926eceeead22c76045d1a7e1c97613ff56f50a0704",
+      "outgoingViewKey": "232ae9277751a0d94d2eab59b01ea25eac08cc015c8d76354981b1e95e6f44f4",
+      "publicAddress": "fbfc6678986ae397220fa27dc0e21ac0e7e06f6fa56dbd30b42b5e69788ecd0c"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:i2VYamkQJNNhrxAYQeJ+hNVGG7jiLbHXnUM9wgxQUXI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:s2gBP6PnQRWdtnXZnNDs9Mk6YjRFYIkTiBmAP6DtYTw="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1677014188833,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAxkaEcRCzXUBMRQBUZYDdYYFGichsOs+c5w3wom7tcO+jpxHEEM2syz22ZX64FBBheZxfSB0kMTTbsIWJWtopwToXj8Awz5xRRbtWIGXO8YiQP1xcFSEWWPRj5fe52HPK6zzxnsPzOxZy6tBlJ/OBVRhrQpecpFcYf3RcYdamAmkYtP0Zw+KU+fHeD6LTdKsbSRbAGk4ny3xOJ6Y4RjeFOGigmVB6Usr1WV7MmSY4QMWQG45Zar6NP9uz5WahzUAPwRoos2tK7kdthht8Ypp6SWXYwc+mAKaVXNx9yedF3q/nJaWGUVP6Psrm7BMSPNHhTdeIbOMHM6VNE7ZAb6r150HNtXGBg03lAzzmmNWcqhgDbLSYkv/iVFw0y1vKyqJJpYq7mL+ma/5H2FRPYXBJY38fCG0MWAaq5cZ6mooylY7yw1/jRJ9QAkf8GwliPa0tCWb+zusYCF4usPkK8tDJMx/pdBgN2YJVBs1NeegfO6DDdzHa/Bs5pObFp/0m7D5nqvb0AJH1cvcC6C/gKo89wQIovkNAtLdlzuxHEVeidosV24A24QOSEbrhdrB3b5ZDZayX3D8jD25NDhPKPvuTUn450ugWdnP2v8mV1bd8jHg6us0j5N07s0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwj818VDZ3lbX4Ql6CPrzNXtEQV91WZO7bbYVEK45f2JSqTVl/ewqfZsbSSjG5KwdYScEyfjcGJ2kA8D3rlS8VBQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A911E6ACE2BC4E55EC80B119505B3DA0200B42CBB5B1FC39D01591C4FCA00AE4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:8/RBZWk0KZMbPPjDMpcqnIdVZOx/Q/XaHM7VFM/RMwo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:gu627DNc2Vb5u337TPWdyvyN1QhLyTQZBuZ6IcFO/4U="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1677014192357,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAsgMEUtDmyL1HS0iqWUtyoea0W0rk8ebbzDMhIL6YPHGF8IIo9Fp854XnHrselZHTNtt7bDrLnvDZg5nx6OFaxM+jpuhwLJ9tB+oTBOw0e+mMG6HCMJfG6VAV9SXzHW39jHUs9p/awvy+lE/CQPol0gxuetPP8amusC94Ot4TFCUPFl/h0i6ERTUdRVoBh/QJiRgaXcnBs7eoBDgYV8CLDSqjSDRIJJy0cEGW4t4Tji6Q6z8ykGwTpYlVKGXqfrrxvcMJA4QfaRocM/N8M0bjso1vpwlyLP42KhHHU46BMR8De64QIM6roT2b+WEeyeJgsTM8Dzh0vHGSUZn+ZMfG3UsGv0zLIfjKL0c41Gdo3LhOltLWc4aj8CHIo2Z/jP5o2u9Bw4BrpMWXABfgP9Cdg5yHpjAkAkILyhh6dtG6ryXTAHbnNUaOOb1kuCcQSNZvleGPzIyGa6qmf8EpwOOqQXD71Jg59gPHura7VLPER3SlErvPka0Sp38qrOLqNflVEFc3V0oJ7zoKe5auNLweDD4WZX1fyzFjVNMVEififcnQ5ZotadSUV4Gt4TruCzMWl5Nb6JFkE7zR+opyD+hcFqUaP2s6VyX/1ThbkQIzxIGBwm8kh+ceyElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhDPn/7mdPLF9LYfUaZU4Ex2b99nJiiXLxGP/uCUCLFRQeouXyDI5ABWAiT7IcWRPzd9eAahkDNV3KPjPAF3cCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA35lcYW0rN1Lp3RXRwfek2rpyy72kj0gM4SZ1ATMq12+xVI8m6pK9XpWq/gFhkyKclOeDqqW9bPwfMIScvBL32k+TFtSNX3FwTwBgWpS0OjalHOe5m4MkBhz11ypy29OoBXHBRYwdi5Dkjqf5eyxa9/QmbPDfGO/FHNWNhQ7LoUkHMOrrWurJU9Fvs2WHgx/COIdKJURRS1GNTeJOb4HXT4nNDPJG5vbvurVzuRWc5SWnXxkPFPnJ5OQz2BbOtMZVLvbN4pIjP53Ix6OKaP5fb7DrXX5xy7Ou18mZKL6nwiddTDHCNYPr4KZmxPsL6SYwYnoaMwd43qCUq1XSuT54QItlWGppECTTYa8QGEHifoTVRhu44i2x151DPcIMUFFyBAAAACUu5z1elik2QBjrg7IDVAcsRmfePDxIxFh9vAebuDqPFyP25f/e457i9FacuEa6hoO1tAgxJ5G6Xdh4E30pTq+KZAsiOXi4bSgZ0REEeFtOy0cIzJMP0dF/kALTv/zaBadHvW6CkPFRJH0PIbn4nC8eezJr4Y+WyofGNrRuHj/ivQqZJF7Imzg5AV6pyWJvNZUVh3xgUuoUjXfl4O/AmAsF3r5kZN/IlK3Qpz2mre5H7XYy35veJwUW4+JhDnSlnRkPkupQ6+3W33ezk9LeKkHaUN7YoiZbgGQn8c+FFFa91FOxX0Kl1KOa2X9Q2dF2irleC4MSSU0rpseUXYWOQrQPoEjfHZOuuTUvtofpwnGVmeu1eE52vljIK7e4ZQQRKHRG8p5n94r1gZkGpSkEFaqEiPsL/fQpC8OpE7umzVrIC/sbVso/EXd97hRP0WTZbMAV4gKoKJE4j/N9GcmVOyFsz78Zo9hFvpxXBrQ8jOmDUUiGo/pFKWTn2VL/qErxK01/M/nE/ab3ieUDtWdpXCgScvoVbuVTgtxRk+SA9fj6UEx/KXoAkUlhPgGqHV6C6WyDSsoKBqlHBc5QgKlsUwG6KrVScayuQiIbpGEaM+NcMYfAMuKuA6OObhxADU7kq9ZkYxa4Mg8fJlLgPq0xYWtFKin7Dt6n/TtOpzw8OkM93dSJFHSS9p2ivpd6QsQeSynFFbG+mrHxYEGzaXPbcBtifXwfOIIbV7RhHSmf1sZ6UgvyRv5RcouxSHW+wkjg/dvk95V7BgiEQSUqenOtNM1yYBuZn3oMfhipTicATqpO4qMVIpCbXlKn7kQJYcSiJ8tlhUFmtHS660QoA1AhEE/F8klv96zXa47kBB7TQ1RMH2x7VW/RPieUcNINqTmrMBvpehVw5pyeg9ou4a4kwJOF5nd1GX/ya4bmFZWd/p8QODLLW9gNBSkGRqg0JA7pg2xKYoGxGSexYBliLU/j0av5P88IlUwR//bO9eVQwYIteyaW1IHyMCyx0Ix9vQPB9utGwg3tnmAR2MT69nxZ+L2xT2tUg6bP22VGjWFnJxXuNtyFvNbHbeWKa3MJJJAAsvB7NnKDMfzxAiCW2hb5Y/ScAakC0KmgLFJCcDBCC1m+QrVvK11qnzh6g4nPFEuQPp2D7n+xtJlv28s5CdjL2Hd9nFfLAsZw2vVA5cyklmlCdJ/NhMT3HJkEkNj0WmqcrcFCZ/vSFmreDrA1T4tiiyEKDoUlrLE9VMPu5bjdThQvAlyzdnzHCPtxbcFr+WK04mi/fZEbu4v0rr7aJqHc3JFHwLmzaphUkihbY9CO6iq1qXA2ZA+WI7ZOIx0TNvM63lPaM/XNcO2ZEq0ic7I/eYDtJvuO7R5WXwFcZ4HTRmGLl+ey3dOgqHD8Smy4iHdWQA6eO+ZrL7BzPcq4khbDh93RwgDgENYoGeNoduRJ/kvjA6cL7An4MsVEkAI8E9lyXLUP/cPtah7nNY3CjzVIiYzioNiZPePKn0iHzuiMe1Mi0LE5FiYMT81gIG8msxTozS6SK+V9WcXc+yWnMDPb3F6IPs3t/ZR1rv5n0lef1F0dgYq+UhU9A1i8hUaOBAcsCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A911E6ACE2BC4E55EC80B119505B3DA0200B42CBB5B1FC39D01591C4FCA00AE4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:x+4yVIJAGytL5n6jdzn8MrbrsswC6koOEvqcmFvjMjk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:djLsrHnJl50lne1B7PEX9HQ7Y/SgDmb6GtGkeDoCm9A="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1677014830814,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAO6bOStmRFkots0Zk5mnDA2fnGSDW9fKXBAMc+b1jdEu19RERw1ZA3K5d0WW/yFNe2AO8CbhpuMb4xawzwlVTE+9BE5gaCZiZB+/JKImO9m2RshpiipXI3Z8uPDqfy2i9DrJAUi9i7aelyOp3eM50OlW3ydFSDDhqphb0XVT5Pq8Jg4Cu+aXla41RTRSLc7uvUcDQ37zxfwCLnWW612F23fwGUqNDoJlD2MTkGr2q8SCLGCslYNBMPPf/qQIWBLLKaUGyIPdhOAQVhOWlFfi1ejvt3Ej7IgkO2CImPuH+N5xEooO3vHU0lyJ3vhxu5yo8KivZGLvok3l1twAqLDjOuIsOu2VQosyv0Y7ZMwzYJH+AByZ9HNwmnDJi5REDbe1aciaEXeOzGikpdY/m839bI/54mF95AlW4UGwD99fIiiw4hg7X0mhuFsYFltNU7jyXivPhuQDedCDG8dgzTcQwEI6+lkTsqD2HjZcsBltHmbrKHayOS4MOHovheC9adkNaKj4+FrW2B1k9HDJEE1mtTj3NwFnXhh/fM4iTJYQ0MtMKHY9zP1Hq+LVWtR1abXTObtsWy0i1BYB+6jK4TSl4vLDHoj2ifF0uCXFRJxrXHLcUwK9W4FWcJElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4ywtAntNyZghtJs5VBN4BBFNyLK+K5mk7HtQq15QNzduDMfqcBZwbUy5I2KgIMY9DrSKQxMjUU4qJkWynqynCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "6A78903D698D0AA50121BCBD4A15C828FAD9A9E1E5A1BDAEE9C969C28C3E9FFF",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:b2g1eqLOOMIZw8CVHKWoA7EjsF2awxRNKJHWkN0PXzc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:kArR5fGN5FBoeU0c+N+ARe6qwm7yuUGmAkDxZXGkHvI="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1677014832186,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAqhkTHzaAgSmICLXxL5A4B4tJHb0yMuZEh9Jo1gYO5JONQkWSudI+aLFu+GJ6jKvgnFWXmla6gBmrlm2WZDmtRUAfbk9/ILaeIR5/q3afnaSRwGbH6zOzy7O0bk8ErskUfloNhi7MAlrKMq4ddXplWN7BDI+606OGzEKbJYLGZWwH6MMYZVoolv5ymJeZB1Iyj9yvHJ5f/z/FN4Y2sQdeLGfAVeoRuDI9+pJaahMLn92TUltbrerUhMawSny8PrYeY9ZNe5Dn1Zn5BN02gNaXj7hU1Q7B01dT2hT+APJbXIIEnHzGiMhs1nZDuI47BzpFq+Myq+pk2CVKCbddngIArzyWJfSNnJdi1IQiZXI9jZYlYVPlaeD142zNpM7Lq+BOVYiNUsKhm5DS3lNjpFhkcYm1AgS789RAPCTDfP9WnAFkxZH7AuDW96oguwjy7FrTiZGV3sT3NNB9WmeIiXg8FCSXMnDs1ovXr4g13C+flGRwcwfMhZDgjcmtZtFe2PsLqmUEQHpB1jSAQe2ul9JKIUZNwFAmXis0Vl3efaE51KxbFeL4/kAxvdrRx3F7tJ3s4Gx8xvAkJHhWeR2PhY9Bp0UPr4D+rjCaR5P9mq60ofrP9s/tJJHEwElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw88Bw8vHVG7Jt+fEy7rNiMsI69+FzmUqfZNrSzhx/YOic/HUphFC1w7xexqKAkQd83Hkue1Gf6ZEnM4VYzsl0AA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAfZnjCt0KqClfAju4heeJliZ4Q6RK+Z7b8EQkNGt3gmSSgtORBl5RpBuPCLiAEF5S+SniKM+qcfE6FV4VkhNs6jfkCGJElh0zvO1tQxkD+ZiKQS/30Oa/IEDvptP/AeSJo4aqmC/KOjyfQKVvyyWFwvfeWWC4XBMPcyRXiYucQCUFzd6esrweqluUYYf6Jiux6yVXlwb+lu+cxAie7CatbR+Wb952ARmtobn2f7Vh8daOrpMIjIMWbtV+ziF+bBmyi5guUwo0SapjIWE40plgR1AVH+I5U87GJc8BuOaXQV+m5FRvou8VcUa0bl9yHLEEFrJgtbmYplsN8IhAfKjCIsfuMlSCQBsrS+Z+o3c5/DK267LMAupKDhL6nJhb4zI5BQAAAFFh1yD6JqVFvgJX4RqxnzAsJhw0mOy5ybrhL6PhrAODzkhP8CZUVpSon+Jeyu5WIX9BA0SjPPC0cchcSkxJLKHggWwGqvKUHpvCeVTBSClRxLQdJVXkv/93kNRwwZDADLH+Xv2FU+YO7xDX3zkd1F6RN4Z/Dnb0ULmtOUet41bgm8pN+DB1bW9iW/R5n/W2m4dMf8aEOjZz76JaeMBC9ua+USumvfk7Z3x4q2+RJvaTd94BSvaXIPuxT/QTyc1e0w/PoP9P+E2cYdoa9PHnwO3Ib9Amo5Nb4vxmYxHIcGnBYD7/WqlwSbqCL1+/GMoDJq7BXfTgzSsJ732pMMthSdpN+0Yhh2xti5VrhzxC4VKEh2oH0DXR+NieQwM9f6ao6pj4Tk1Px+b3od45HLDxWeIDCHj1SssyE63G7skNcRM5SynUbMrw9fBoueq8qwmqqj45hzhpBMdHGRHwZsusfWrTrvLnC4aWSxk6gTk9cVPHlz1n/nGMsbOkO16aVxE0DCUto3Q/RiGkMRfR01L4HEb0K9982iKItMriMXT7pcaQMMN3zy0dNKbB4CTuhvgYc4n8U+rvKzS0VZFnPNogWxD8Y3uFxU4TwnH+g34DefRg+Q9jkWxUJsge52PFS+UOE3ZTQPvlr3lD63ZY36ySthhyboYOkEu6iSEoJNtnXZiHhs8H+8Gq0htgVCfWoCfnAVsTcfm5DWKFAHnmS+4BLajxTP93pLa/jH27tByy2WltfuYikGUo5UokHfuPb/d5QUOOSwSKbXSwh3wTdURLM5NwNhnLF+3OGHGmv3I8sjeKaL+MqdK1MQGVk+7i5NkUkYDrQm2IF8UHzwSJI08VSe/9od0Di3vs0QE07x+SAkpQ0ir+gpw52kiUHIKAh8Ey4TjzFWGLeQ5zDe120Vfj1JC4OC3MhqS8bnBxWqkkVOKHnq9gRIv3EcUHlDzRAgMp5rTxLM/fZ2GW3EHwbPfDOYKtZhr0vubIWQPjxSCbEYJCjGFGzQBHKVWqa6qo5KwUgD0UzF5PKVYND1084bAj/QE7Hr2G03c12+vmT7bPtcSPc60aFTFqhEnIHfFjTfxiMfFi7xzIEtQKHaXiR1QGoTw0PvbamN0WrkIWMvKGVInsCS65PcEF4Ch3BGL3LBM/bU+ApyEG3SUxqBHh8AMQgAsPCERtFT5kdD875lk+5Y5DKOV+JZ7Gq/D4Xdi6fw0Oo9HujbneooY1KOs5XlHdXttbM4020d6C1devwBRIX4wrvWi0IaXNfUjhN1ux5Jtpy7uGd/AYF7GAvl4DKjGHi+v5isV6t7dIS39nNeBgtKBpcscUibV8/JH5IAXsDsI/wK+umZJ7pKAVT9SYEQroVzeit4fZuBZqq2Z5xCEc4UFF8qVecFA3T4d9TI55wx99Yp8YUUj353QNwElFBupInXARKFKVzHoeZJ7OHSP5FEZ44mblfJ6G7y5LSefB8/aNWcbOr2p+TcgxgnzHwI+gRwEdxEu7fl/yfPj34teF+LDaCTew20MlsfjKh4JEI5oYxzwGWzLqrAMGOo/TEmOI7MsAMvO58+vcoWvMsR1XkfyiZEXrIyGfVoDSfyh5EbYDCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "6A78903D698D0AA50121BCBD4A15C828FAD9A9E1E5A1BDAEE9C969C28C3E9FFF",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:U2PCBDrOxpF8QBUd5SzZVaSjvr+hq598clxBxSg1XA4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:OO+bz5BnhwLAEezOBTbUzSN0R/o7XFHAB3Ag7s6AmuY="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1677014832419,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAYaY6LQMbE2GYypuNcZYzcE2jprDryHPiik8Fgl71+1eRmXGE+H8T7qZEU7X+wURMnze+vSnKZp/gnc+FTDfw+bMGKIjOb2XhrRWTxvaPh3SYu+G5KH/6mf0NttaBLr+4gWuOyNuyDa2NutCvf/qs6R6jJptCLM2h0875zVOPa6YWj/DrMcKlM13UjLlh2JcFqU9LFhniTq07bjWUg6GaGQV0vIpU6Hd2aeK0BH8onDyqmCCQ6zSvT8W9sDgVaKmTKL9M6pviyekRBap8rOXiOtd6LXavhYtl3w/fTpUcc6ZsweSbeU4SxxThnEJWLIxMcvAYtHavswvogxD150f0A9S7nw9mJ0hgdRhP32T+vSdd/Gmev7YpWuHVh/4AS7Bpw5aVHuT0rSpj4Bm8AVXnZgt8lxDeeUg0a0qLSfwOqWESl/BsSbWd/6Lu0Fgthpp3JL7dHFSairHxxIVgU604/ey3ofZ/DFYPqj/HhNsvE5q8lyiDbB6VifMVHE9RzEmv0hV41MIvdPqFUfwdSe+gXAmcDwemvfMI66fMjBmWovRc5Livp7cdJqMjy8Hgk4yInpaI+123y47IeLe2hcQbhCsMBtCjY6uAkgsyu/PBbl8U0tS5pR+L10lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwVL5p0vZTaKwEBxrBWfMuhyK0v4SQr5CG2rzF8k4KpFCmhrOY4RjIgS2KgRrtCwypzbVeHPM9AaB02/IM6XwPBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "3DF9B164D86EA8C4929B4C4A022FC65057D9E30C680724833A120AFF78A1FCEB",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:m/EMTlhRPSLPLLgnsFcHOiWz3B3MVxkBDgG9zmh9NQM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:wiGBJqRNuelrFihZaR2tPuAKg8/ppC+DHL31D5LoVfc="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1677014833766,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAcD6Dz63UK4K8v5s7TY6NigGvVusJg3CNDXr/Dhnxh5u3KiAgqMCH5U9nbYQmhhKd8QmsAAX6N1KMmXeLJZtIPQjyIT3IX9Whg2WrXVabjVmjhLVS2Ar209kWcAm+WX6lOurt7aXAbQ8bsx3eCPT94BvpjY89Wphdi0PMJx1QlysT2YKTZRthFPX7QsmjblEoVkjHhnD5OynXpQkAWZlHhyZRRdCYeYmrmDVArJp7VL2XEknXbDu+aLEm/F5qVARIlInPAdB9Rd3rAN7phadfgr2qsjw7WtAjpJrMFAFuIh5kvYoXa9i4IAaZi17t9pkewRjO3FoXr+8Sr2iI/iAjA4/y129CFlJeQQSQP38Y1l82UHxi2IJ4mMmxoCjHC4s3k/ER2aQmWJMG6Xrlddbuxf32hbX/fkzGV+12ryvNzFkhn1sV3r8JiFrH9dpo6ieUUizkBXkaZpka6WsS/TNuVqSX+fI7eW9pfcYHx0PlOmW364zk7Gq71+v+2QOAerpDEFa8YEvzlAQDL9mFQb4UQTQSefdlQ6BWP/hmLAfx8ULIS3aG/SFF0nBi4KIgrOL4tklnReVdp4NtO1Adw4MBtUwLTdof0w9MlRGEFbkXt7xHsjwPxID3jklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZE7AsUyvhqj8lXpNAjVAiXFWUp3jCGRysNHaZXY4mnER/yGk0F5BlhTmt3F+ZmmF6w2G/6zetAZ98PX/7IagBA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAATbslL7sHvZ8lBF3NgSNumfbPB/5Zg3P/PI3SUROGuxOviOiHe7pP6IwuMGNIzbmIpwHwUuGgsWkpCTvSD9C5eVtb8wYLd0w/m9CH+FPOjaSFyNIUlQ4RkUFhLWUEZa80dkNGouI/ywU4mgS/X4XI2Z4fzgIaaQxwWFYGeEyygIYDiZzaOvolZgD3FW1LvV2tXqgYgTzXgmYYqZI5dMSTBZR88dSt2WPRsmOfMvKmG0COj/WCPVkH9wyHHSdQ9+q9flMWfahDTeYG5k9wDEolFHpaTDGW0rIP8NXN+nAyn/IatJAyNBgP4Y03Anza3XEBdJ8s9DC48YvXwQA5G1zqRlNjwgQ6zsaRfEAVHeUs2VWko76/oauffHJcQcUoNVwOBgAAABUcO1JWIn26ZqELDfP+hl8g+jofSR81CMTRVTQcquX4QQln7BcNdF6/rfA77nfpNLPj20bgIeYAivBS8xxNA00ZB/cm0tKtXQk6iR3Qmse5v8Ss/XVJIXR5lTwniqiIB6QOX9aCiD3nxP2eGRRzPIpLAzMqpWepZ5JFOIpoOUa6XB6YFlIK2zY5x/eW4N/2lLD7gSxTvwwgirPkKFTY7pdxKU2gR9JujZV6wGuC+F1sWcBDNSK2g4bkKkj8MYdppAVNaJm5OSnkNZpCS/ysadwtqHUNkPKRIPDjZaO2qsVhMOJrWCv7Aei/RjWx47D9B41uZ0DM/NeV6gSycxJD/nT2/KxhV5wnN5rgkCw1RJSINfiANet3E6LapqX+Cpaa74zap9ap/NdRdoOB3gzRFye5zxihVrdOIeNbtx9sOBpIgMCjaAgXC1eLaoqdagiKelQ6b3f6JGys5MZr3dwlexNkhiaT6te66UI77aTy8TlePIImigfJwFDnlPN/Cd5jYI13vux2e6gda12PwPRJ6fVI70Lj5HFwbGnY3DVoAlZ9vlm2yZ/K006q29DcP0N8x7sRpLy2DMFghZ3J51vsdd5BehzNZPa36GhZkH60Fq1t/zqww3/zfk5n96ogKA0uiERNHRX5nHIeTkJre6K+Fo1w+zYaWN2D30GVnVp7zeN9BhRHPDNAMFAhA2xUU0giX/QJG0hsdaEjLl6kBqfWmmxiAsdy9acAbowYifoleM3KCCHlsla6kCpz8tEbLhLqIMfIk/AfrN5KfsUvpxVNByYTmt2zvfpCbm1i1aopzfIG2iwa54Fdcve0esDEfASCsEcpTRMh11LvtyxOlIKZ1kBSBhAKK+BcG73E18ZNyw7AkTbX0mRFylK5cFXE0Ibm66CIKJUqF+URCo9+9xekZwQcbXhSCmbYYfIPMCPkdGh425slsZZ0N/kJYhGp6TNuVS5s+OPEm1gvilj264jWeZ76oKBoXx/PvADoHMXJl1GdHJWRX9tLmjijs0rVnEE5YiKtJ0wJIQaFqiajuPPtSezpR+R2pIObSEyJdqs2PHDYaBpE6Xyq9glv7qD/wmGD/yJR3XfBMaTQMKnQq9KRzhoNOkG1Kp3FiejOEeJLVggbUImD5PMsjBxByRb0Dk+Dc7kvBGin/o4sy6TySldk0tvW6IUeE4tAACsizm2og8hPp7Z0gDC8BtE0Zh8bDGLD8NEdBqTe1lCClYPvj472wKYWm6m5xdaeqjcUQUFrd7Q4u3H0mLP/jD2GTHOFB5oi4x8PHOawOBG7QuPrRZXVwmSrwVMpc+hZZdLIas85hOn4Dhll2SObanpazJjwItwI08IMhf6uqzd5eK5rdZ0v3J5aa6RCOTf6wqeiVob7jVeY7op5NLQHp+obhHA5tqy48tg79O/QxCtIVa6Etdx5E9/qC3o3HMXvZ1sx9HZEyP5vaZ0YTe6Qc87eCdjNSo5oNUxJemsgj8bo/kSwTJJL9/sr3XkmfB6fX9HTuydXEIjzPqWCBlaI8vll08fK5K5mPBAvEequnHQIJTKze5V7fiqGvJL/pT9QFyFN24lVaXfsmlM5kbY3uP/OTBe7k+/OBQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -204,7 +204,7 @@ export class MemPool {
       this.logger.debug(`Deleted ${deletedTransactions} transactions`)
     }
     this.head = block.header
-    this.recentlyEvictedCache.onConnectBlock(this.head.sequence)
+    this.recentlyEvictedCache.flush(this.head.sequence)
   }
 
   async onDisconnectBlock(block: Block): Promise<void> {

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -89,6 +89,7 @@ export class MemPool {
     this.recentlyEvictedCache = new RecentlyEvictedCache({
       logger: this.logger,
       capacity: 50000,
+      maxAge: 10,
     })
   }
 
@@ -203,7 +204,7 @@ export class MemPool {
       this.logger.debug(`Deleted ${deletedTransactions} transactions`)
     }
     this.head = block.header
-    this.recentlyEvictedCache.flush(this.head.sequence)
+    this.recentlyEvictedCache.onConnectBlock(this.head.sequence)
   }
 
   async onDisconnectBlock(block: Block): Promise<void> {

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -89,7 +89,6 @@ export class MemPool {
     this.recentlyEvictedCache = new RecentlyEvictedCache({
       logger: this.logger,
       capacity: 50000,
-      maxAge: 10,
     })
   }
 

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -88,8 +88,7 @@ export class MemPool {
 
     this.recentlyEvictedCache = new RecentlyEvictedCache({
       logger: this.logger,
-      capacity: 1000,
-      maxJailTime: 1000,
+      capacity: 50000,
     })
   }
 

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -87,8 +87,9 @@ export class MemPool {
     })
 
     this.recentlyEvictedCache = new RecentlyEvictedCache({
-      metrics: this.metrics,
       logger: this.logger,
+      capacity: 1000,
+      maxJailTime: 1000,
     })
   }
 
@@ -203,7 +204,7 @@ export class MemPool {
       this.logger.debug(`Deleted ${deletedTransactions} transactions`)
     }
     this.head = block.header
-    this.recentlyEvictedCache.setSequence(this.chain.head.sequence) // todo: is this right
+    this.recentlyEvictedCache.flush(this.head.sequence)
   }
 
   async onDisconnectBlock(block: Block): Promise<void> {

--- a/ironfish/src/memPool/priorityQueueTestHelpers.ts
+++ b/ironfish/src/memPool/priorityQueueTestHelpers.ts
@@ -14,7 +14,7 @@ export interface Queue<T> {
 }
 
 // Create a very simple queue implementation that is slow but adds and removes
-// elements in a predicatable fashion. Used to test the moer complicated queue
+// elements in a predicatable fashion. Used to test the more complicated queue
 // implementation against
 export class SimpleQueue<T> implements Queue<T> {
   private _map: { [key: string]: T } = {}

--- a/ironfish/src/memPool/recentlyEvictedCache.test.ts
+++ b/ironfish/src/memPool/recentlyEvictedCache.test.ts
@@ -1,0 +1,3 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/ironfish/src/memPool/recentlyEvictedCache.test.ts
+++ b/ironfish/src/memPool/recentlyEvictedCache.test.ts
@@ -19,6 +19,7 @@ describe('RecentlyEvictedCache', () => {
       feeRate: BigInt(i),
       sequence: i,
       hashAsString: hash.toString('hex'),
+      maxAge: 5,
     }
   })
 
@@ -30,6 +31,8 @@ describe('RecentlyEvictedCache', () => {
     87, 80, 73, 72, 52, 42, 19, 61, 34, 20, 49, 22, 15, 96, 14, 9, 43, 39, 33, 10,
   ]
 
+  const randomAges = [12, 13, 15, 17, 11, 1, 8, 14, 16, 3, 5, 7, 9, 18, 10, 4, 2, 20, 19, 6]
+
   const randomTransactions = [...new Array(20)].map((_, i) => {
     const hash = randomBytes(32)
     return {
@@ -37,6 +40,7 @@ describe('RecentlyEvictedCache', () => {
       feeRate: BigInt(randomFeeRates[i]),
       sequence: randomSequences[i],
       hashAsString: hash.toString('hex'),
+      maxAge: randomAges[i],
     }
   })
 
@@ -45,11 +49,10 @@ describe('RecentlyEvictedCache', () => {
       const testCache = new RecentlyEvictedCache({
         capacity: 10,
         logger,
-        maxAge: 5,
       })
 
-      for (const transaction of orderedTransactions) {
-        testCache.add(transaction.hash, transaction.feeRate, transaction.sequence)
+      for (const { hash, feeRate, sequence, maxAge } of orderedTransactions) {
+        testCache.add(hash, feeRate, sequence, maxAge)
       }
 
       expect(testCache.size()).toEqual(10)
@@ -58,7 +61,6 @@ describe('RecentlyEvictedCache', () => {
     it('should evict the proper transaction when full and a new transaction comes in [ORDERED]', () => {
       const testCache = new RecentlyEvictedCache({
         capacity: 2,
-        maxAge: 5,
         logger,
       })
 
@@ -66,11 +68,13 @@ describe('RecentlyEvictedCache', () => {
         orderedTransactions[5].hash,
         orderedTransactions[5].feeRate,
         orderedTransactions[5].sequence,
+        orderedTransactions[5].maxAge,
       )
       testCache.add(
         orderedTransactions[7].hash,
         orderedTransactions[7].feeRate,
         orderedTransactions[7].sequence,
+        orderedTransactions[7].maxAge,
       )
       // cache: fees = [5, 7]
 
@@ -79,6 +83,7 @@ describe('RecentlyEvictedCache', () => {
         orderedTransactions[6].hash,
         orderedTransactions[6].feeRate,
         orderedTransactions[6].sequence,
+        orderedTransactions[6].maxAge,
       )
       expect(testCache.has(orderedTransactions[7].hashAsString)).toEqual(false)
       expect(testCache.has(orderedTransactions[5].hashAsString)).toEqual(true)
@@ -90,6 +95,7 @@ describe('RecentlyEvictedCache', () => {
         orderedTransactions[4].hash,
         orderedTransactions[4].feeRate,
         orderedTransactions[4].sequence,
+        orderedTransactions[4].maxAge,
       )
       expect(testCache.has(orderedTransactions[6].hashAsString)).toEqual(false)
       expect(testCache.has(orderedTransactions[5].hashAsString)).toEqual(true)
@@ -101,6 +107,7 @@ describe('RecentlyEvictedCache', () => {
         orderedTransactions[10].hash,
         orderedTransactions[10].feeRate,
         orderedTransactions[10].sequence,
+        orderedTransactions[10].maxAge,
       )
       expect(testCache.has(orderedTransactions[10].hashAsString)).toEqual(false)
       expect(testCache.has(orderedTransactions[4].hashAsString)).toEqual(true)
@@ -111,13 +118,12 @@ describe('RecentlyEvictedCache', () => {
       const testCache = new RecentlyEvictedCache({
         capacity: 5,
         logger,
-        maxAge: 5,
       })
 
       const added: typeof randomTransactions = []
-      for (const { hash, feeRate, sequence, hashAsString } of randomTransactions) {
-        testCache.add(hash, feeRate, sequence)
-        added.push({ hash, feeRate, sequence, hashAsString })
+      for (const { hash, feeRate, sequence, hashAsString, maxAge } of randomTransactions) {
+        testCache.add(hash, feeRate, sequence, maxAge)
+        added.push({ hash, feeRate, sequence, hashAsString, maxAge })
         expect(testCache.size()).toEqual(Math.min(added.length, 5))
 
         const expected = added.sort((t1, t2) => Number(t1.feeRate - t2.feeRate)).slice(0, 5)
@@ -131,15 +137,13 @@ describe('RecentlyEvictedCache', () => {
 
   describe('flush', () => {
     it('should flush transactions beyond the max age when a new block connects [ORDERED]', () => {
-      const maxAge = 5
       const testCache = new RecentlyEvictedCache({
         logger,
         capacity: 20,
-        maxAge: maxAge,
       })
 
-      for (const { hash, feeRate, sequence } of orderedTransactions) {
-        testCache.add(hash, feeRate, sequence)
+      for (const { hash, feeRate, sequence, maxAge } of orderedTransactions) {
+        testCache.add(hash, feeRate, sequence, maxAge)
       }
 
       expect(testCache.size()).toEqual(20)
@@ -153,7 +157,7 @@ describe('RecentlyEvictedCache', () => {
 
       // only txns with expiration sequences after the min sequence should remain in the cache
       const expected = orderedTransactions.filter(
-        ({ sequence }) => sequence > minSequence - maxAge,
+        ({ sequence, maxAge }) => sequence > minSequence - maxAge,
       )
 
       const notExpected = orderedTransactions.filter((t) => !expected.includes(t))
@@ -168,19 +172,20 @@ describe('RecentlyEvictedCache', () => {
     })
 
     it('should flush transactions beyond the max age when a new block connects [RANDOM]', () => {
-      const maxAge = 10
       const testCache = new RecentlyEvictedCache({
         logger,
         capacity: 5,
-        maxAge: maxAge,
       })
 
       const added: typeof randomTransactions = []
 
       // add the first 10 elements
-      for (const { hash, feeRate, sequence, hashAsString } of randomTransactions.slice(0, 10)) {
-        testCache.add(hash, feeRate, sequence)
-        added.push({ hash, feeRate, sequence, hashAsString })
+      for (const { hash, feeRate, sequence, hashAsString, maxAge } of randomTransactions.slice(
+        0,
+        10,
+      )) {
+        testCache.add(hash, feeRate, sequence, maxAge)
+        added.push({ hash, feeRate, sequence, hashAsString, maxAge })
       }
 
       /**
@@ -194,7 +199,7 @@ describe('RecentlyEvictedCache', () => {
       let expected = added
         .sort((t1, t2) => Number(t1.feeRate - t2.feeRate))
         .slice(0, 5)
-        .filter(({ sequence }) => sequence > minSequence - maxAge)
+        .filter(({ sequence, maxAge }) => sequence > minSequence - maxAge)
 
       let notExpected = added.filter((t) => !expected.includes(t))
 
@@ -207,9 +212,11 @@ describe('RecentlyEvictedCache', () => {
       }
 
       // add the next 10 elements
-      for (const { hash, feeRate, sequence, hashAsString } of randomTransactions.slice(10)) {
-        testCache.add(hash, feeRate, sequence)
-        added.push({ hash, feeRate, sequence, hashAsString })
+      for (const { hash, feeRate, sequence, hashAsString, maxAge } of randomTransactions.slice(
+        10,
+      )) {
+        testCache.add(hash, feeRate, sequence, maxAge)
+        added.push({ hash, feeRate, sequence, hashAsString, maxAge })
       }
 
       testCache.flush(minSequence)
@@ -217,7 +224,7 @@ describe('RecentlyEvictedCache', () => {
       expected = added
         .sort((t1, t2) => Number(t1.feeRate - t2.feeRate))
         .slice(0, 5)
-        .filter(({ sequence }) => sequence > minSequence - maxAge)
+        .filter(({ sequence, maxAge }) => sequence > minSequence - maxAge)
 
       notExpected = added.filter((t) => !expected.includes(t))
 

--- a/ironfish/src/memPool/recentlyEvictedCache.test.ts
+++ b/ironfish/src/memPool/recentlyEvictedCache.test.ts
@@ -1,3 +1,135 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { randomBytes } from 'crypto'
+import { mockLogger } from '../testUtilities/mocks'
+import { PriorityQueue } from './priorityQueue'
+import { RecentlyEvictedCache } from './recentlyEvictedCache'
+
+function* consume<T>(queue: PriorityQueue<T>): Generator<T, void, unknown> {
+  const clone = queue.clone()
+
+  while (clone.size() > 0) {
+    const item = clone.poll()
+
+    if (item === undefined) {
+      continue
+    }
+
+    yield item
+  }
+}
+
+describe('RecentlyEvictedCache', () => {
+  describe('add', () => {
+    // transactions[i] has fee rate = i and sequence = i
+    const transactions = [...new Array(21)].map((_, i) => {
+      const hash = randomBytes(32)
+      return { hash: hash, feeRate: BigInt(i), sequence: i, hashAsString: hash.toString('hex') }
+    })
+
+    it('should not exceed maximum capacity', () => {
+      const testCache = new RecentlyEvictedCache({
+        logger: mockLogger(),
+        capacity: 10,
+        maxJailTime: 10,
+      })
+
+      for (const transaction of transactions) {
+        testCache.add(transaction.hash, transaction.feeRate, transaction.sequence)
+      }
+
+      expect(testCache.size()).toEqual(10)
+    })
+
+    it('should evict proper txn when full and new txn comes in', () => {
+      const testCache = new RecentlyEvictedCache({
+        logger: mockLogger(),
+        capacity: 2,
+        maxJailTime: 10,
+      })
+
+      testCache.add(transactions[5].hash, transactions[5].feeRate, transactions[5].sequence)
+      testCache.add(transactions[7].hash, transactions[7].feeRate, transactions[7].sequence)
+      // cache: fees = [5, 7]
+
+      // adding feeRate = 6 should evict feeRate = 7
+      testCache.add(transactions[6].hash, transactions[6].feeRate, transactions[6].sequence)
+      expect(testCache.has(transactions[7].hashAsString)).toEqual(false)
+      expect(testCache.has(transactions[5].hashAsString)).toEqual(true)
+      expect(testCache.has(transactions[6].hashAsString)).toEqual(true)
+
+      // cache: fees = [5, 6]
+      // adding feeRate = 4 should evict feeRate = 6
+      testCache.add(transactions[4].hash, transactions[4].feeRate, transactions[4].sequence)
+      expect(testCache.has(transactions[6].hashAsString)).toEqual(false)
+      expect(testCache.has(transactions[5].hashAsString)).toEqual(true)
+      expect(testCache.has(transactions[4].hashAsString)).toEqual(true)
+
+      // cache: fees = [4, 5]
+      // adding feeRate = 10 should not evict anything
+      testCache.add(transactions[10].hash, transactions[10].feeRate, transactions[10].sequence)
+      expect(testCache.has(transactions[10].hashAsString)).toEqual(false)
+      expect(testCache.has(transactions[4].hashAsString)).toEqual(true)
+      expect(testCache.has(transactions[5].hashAsString)).toEqual(true)
+    })
+  })
+
+  describe('flush', () => {
+    // transactions[i] has fee rate [i]
+    const transactions = [...new Array(10)].map((_, i) => {
+      const hash = randomBytes(32)
+      return { hash: hash, feeRate: BigInt(i), sequence: i, hashAsString: hash.toString('hex') }
+    })
+    it('should flush if new block connects that pushes out old transactions', () => {
+      const testCache = new RecentlyEvictedCache({
+        logger: mockLogger(),
+        capacity: 20,
+        maxJailTime: 5,
+      })
+
+      for (let i = 0; i < transactions.length; ++i) {
+        testCache.add(transactions[i].hash, transactions[i].feeRate, transactions[i].sequence)
+      }
+      expect(testCache.size()).toEqual(10)
+      let clone = testCache['evictionQueue'].clone()
+      while (clone.size()) {
+        const next = clone.poll()
+        next && console.log(next.hash.toString('hex'), next.feeRate)
+      }
+      // remove all transactions with sequence + max jail time < 5
+      testCache.flush(10)
+      clone = testCache['evictionQueue'].clone()
+      while (clone.size()) {
+        const next = clone.poll()
+        next && console.log(next.hash.toString('hex'), next.feeRate)
+      }
+      expect(testCache.size()).toEqual(4)
+    })
+  })
+
+  describe('helper methods', () => {
+    it('has', () => {
+      expect(true).toEqual(true)
+    })
+    it('isEmpty', () => {
+      expect(true).toEqual(true)
+    })
+    it('isFull', () => {
+      expect(true).toEqual(true)
+    })
+    it('size', () => {
+      expect(true).toEqual(true)
+    })
+  })
+
+  /*
+  add
+  - don't go over max capacity
+  - should evict proper txn when full and new txn comes in
+  flush
+  - should flush if new block connects that pushes out old transactions
+  helper methods
+  */
+})

--- a/ironfish/src/memPool/recentlyEvictedCache.ts
+++ b/ironfish/src/memPool/recentlyEvictedCache.ts
@@ -1,0 +1,225 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { BufferMap } from 'buffer-map'
+import { Assert } from '../assert'
+import { createRootLogger, Logger } from '../logger'
+import { MetricsMonitor } from '../metrics'
+import { getTransactionSize } from '../network/utils/serializers'
+import { Transaction, TransactionHash } from '../primitives/transaction'
+import { PriorityQueue } from './priorityQueue'
+
+interface EvictionEntry {
+  hash: TransactionHash
+  feeRate: bigint
+}
+
+interface ExpirationEntry {
+  hash: TransactionHash
+  expiration: number
+}
+
+export class RecentlyEvictedCache {
+  private readonly metrics: MetricsMonitor
+  private readonly logger?: Logger
+
+  private readonly capacity: number = 1000 // TODO: fix this default initialization
+
+  private readonly transactions = new BufferMap<Transaction>()
+  /**
+   * Keep track of number of bytes stored in the transaction map
+   * */
+  private transactionsBytes = 0
+
+  private readonly maxJailTime: number = 10 // TODO: fix -> this is max duration txns exist in cache
+
+  private currentSequence = 0
+
+  /**
+   * A priority queue of transactions to evict from this cache when full.
+   *
+   * Transactions are evicted in order of `feeRate` descending because
+   * they are most likely to be re-included into the mempool
+   */
+  private readonly evictionQueue: PriorityQueue<EvictionEntry>
+
+  private readonly expirationQueue: PriorityQueue<ExpirationEntry>
+
+  /**
+   * Creates a new cache to track transactions that have recently been evicted.
+   * Transactions are routinely evicted from the cache after the `maxJailTime`.
+   * When full, transactions are evicted in order of `feeRate` descending to
+   * make room for the new transaction.
+   * @param options
+   */
+  constructor(options: { metrics: MetricsMonitor; logger?: Logger }) {
+    const logger = options.logger || createRootLogger()
+
+    this.metrics = options.metrics
+    this.logger = logger.withTag('RecentlyEvictedCache')
+
+    this.evictionQueue = new PriorityQueue<EvictionEntry>(
+      (t1, t2) => t1.feeRate > t2.feeRate,
+      (t) => t.hash.toString('hex'),
+    )
+
+    this.expirationQueue = new PriorityQueue<ExpirationEntry>(
+      (t1, t2) => t1.expiration < t2.expiration,
+      (t) => t.hash.toString('hex'),
+    )
+  }
+
+  private remove(hash: TransactionHash): Transaction | void {
+    const transactionToRemove = this.get(hash)
+
+    if (!transactionToRemove) {
+      return
+    }
+
+    this.transactions.delete(hash)
+
+    this.transactionsBytes -= getTransactionSize(transactionToRemove)
+
+    return transactionToRemove
+  }
+
+  /**
+   * Removes the transaction with the highest fee rate from the cache.
+   *
+   * If the transaction cache and eviction queue are out of sync, this method
+   * lazily pops from the eviction queue until it finds a transaction that is
+   * present in the cache
+   *
+   * @returns the transaction that was evicted, or undefined if the cache is empty
+   */
+  private poll(): Transaction | void {
+    let hashToRemove: Buffer | undefined
+
+    while (!this.isEmpty() && this.evictionQueue.size() > 0) {
+      const toEvict = this.evictionQueue.poll()
+
+      Assert.isNotUndefined(toEvict)
+
+      // lazy deletion
+      if (!this.has(toEvict.hash)) {
+        continue
+      }
+
+      hashToRemove = toEvict.hash
+      break
+    }
+
+    if (!hashToRemove) {
+      return
+    }
+
+    return this.remove(hashToRemove)
+  }
+
+  count(): number {
+    return this.transactions.size
+  }
+
+  isFull(): boolean {
+    return this.count() === this.capacity
+  }
+
+  isEmpty(): boolean {
+    return this.count() === 0
+  }
+
+  /**
+   * Adds a new transaction to the recently evicted cache.
+   * If the cache is full, the transaction with the highest fee rate will be evicted.
+   *
+   */
+  add(transaction: Transaction): void {
+    const hash = transaction.hash()
+
+    if (this.has(hash)) {
+      return
+    }
+
+    if (this.isFull()) {
+      this.poll()
+    }
+
+    this.transactions.set(hash, transaction)
+    this.evictionQueue.add({
+      hash,
+      feeRate: transaction.fee(),
+    })
+
+    this.expirationQueue.add({
+      hash,
+      expiration: this.currentSequence + this.maxJailTime,
+    })
+
+    this.transactionsBytes += getTransactionSize(transaction)
+
+    return
+  }
+
+  get(hash: TransactionHash): Transaction | undefined {
+    return this.transactions.get(hash)
+  }
+
+  has(hash: TransactionHash): boolean {
+    return this.transactions.has(hash)
+  }
+
+  /**
+   * Sets the latest sequence. This will flush the cache of any transactions that have expired
+   */
+  setSequence(sequence: number): void {
+    this.currentSequence = sequence
+    this.flush()
+  }
+
+  /**
+   * Flushes the cache of any transactions that have exceeded the maximum jail time.
+   * These transactions are now eligable for re-entry into the mempool.
+   */
+  private flush(): void {
+    let flushCount = 0
+    while (!this.isEmpty() && this.expirationQueue.size() > 0) {
+      let toFlush = this.expirationQueue.peek()
+      if (!toFlush || toFlush.expiration > this.currentSequence) {
+        break
+      }
+
+      toFlush = this.expirationQueue.poll()
+      Assert.isNotUndefined(toFlush)
+
+      if (!this.has(toFlush.hash)) {
+        continue
+      }
+
+      this.remove(toFlush.hash)
+      flushCount++
+    }
+
+    this.logger?.info(
+      `Flushed ${flushCount} transactions from RecentlyEvictedCache after block ${this.currentSequence} added`,
+    )
+
+    return
+  }
+
+  /**
+   * Clears the cache and helper queues. The cache will be reset to the intiail state.
+   */
+  clear(): void {
+    this.transactions.clear()
+    this.transactionsBytes = 0
+
+    // TODO: is there an easier way to clear these 2 pqs?
+    while (this.evictionQueue.size() > 0) {
+      this.evictionQueue.poll()
+    }
+
+    while (this.expirationQueue.size() > 0) {
+      this.expirationQueue.poll()
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a new `RecentlyEvictedCache` to the mempool. 

A later PR will introduce a maximum capacity to the mempool. When the mempool is full, it is possible for transactions to be evicted to make room for more appealing ones. These evicted transactions will be added to this new cache to prevent immediate re-submission into the mempool. As transaction validation is expensive, it does not make sense to validate a transaction, _t_,  if it is known that _t_ will not make it into the mempool (as it was recently evicted). 

The `RecentlyEvictedCache` has a maximum capacity determined by the upstream maximum capacity of the mempool. Transactions can only be removed from this cache in the two following ways:

1. The cache is full and a new transaction is added. The transaction with the highest `feeRate` (fee/byte) will be removed as this has the highest chance to be re-introduced into the mempool
2. A new block is added. Transactions that have spent longer than their `maxAge` in the cache will be removed. This is to prevent transactions from never being re-added to the mempool because they were stuck indefinitely in the cache 

## Testing Plan
See included unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
