### PR TITLE
Change post() to be postTransaction() with args

### DIFF
--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -27,9 +27,9 @@ export class PostCommand extends IronfishCommand {
       default: false,
       description: 'Confirm without asking',
     }),
-    offline: Flags.boolean({
-      default: false,
-      description: 'Post transaction offline',
+    broadcast: Flags.boolean({
+      default: true,
+      description: 'Broadcast the transaction after posting',
     }),
   }
 
@@ -97,7 +97,7 @@ export class PostCommand extends IronfishCommand {
     const response = await client.postTransaction({
       transaction,
       account: flags.account,
-      offline: flags.offline,
+      broadcast: flags.broadcast,
     })
 
     stopProgressBar()

--- a/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
@@ -22,7 +22,7 @@ describe('Route wallet/postTransaction', () => {
     const response = await routeTest.client.postTransaction({
       transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
       account: account.name,
-      offline: true,
+      broadcast: true,
     })
 
     expect(addSpy).toHaveBeenCalledTimes(0)

--- a/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
@@ -10,19 +10,19 @@ import { createRouteTest } from '../../../testUtilities/routeTest'
 describe('Route wallet/postTransaction', () => {
   const routeTest = createRouteTest(true)
 
-  it('should post a raw transaction offline', async () => {
+  it('should post a raw transaction and not broadcast', async () => {
     const account = await useAccountFixture(routeTest.node.wallet, 'accountA')
     const addSpy = jest.spyOn(routeTest.node.wallet, 'addPendingTransaction')
 
-    const options = {
+    const rawTransaction = await createRawTransaction({
       wallet: routeTest.node.wallet,
       from: account,
-    }
-    const rawTransaction = await createRawTransaction(options)
+    })
+
     const response = await routeTest.client.postTransaction({
       transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
       account: account.name,
-      broadcast: true,
+      broadcast: false,
     })
 
     expect(addSpy).toHaveBeenCalledTimes(0)
@@ -30,15 +30,15 @@ describe('Route wallet/postTransaction', () => {
     expect(response.content.transaction).toBeDefined()
   })
 
-  it('should accept a valid raw transaction', async () => {
+  it('should post a raw transaction', async () => {
     const account = await useAccountFixture(routeTest.node.wallet, 'existingAccount')
     const addSpy = jest.spyOn(routeTest.node.wallet, 'addPendingTransaction')
 
-    const options = {
+    const rawTransaction = await createRawTransaction({
       wallet: routeTest.node.wallet,
       from: account,
-    }
-    const rawTransaction = await createRawTransaction(options)
+    })
+
     const response = await routeTest.client.postTransaction({
       transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
       account: account.name,

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -39,13 +39,13 @@ router.register<typeof PostTransactionRequestSchema, PostTransactionResponse>(
     const bytes = Buffer.from(request.data.transaction, 'hex')
     const raw = RawTransactionSerde.deserialize(bytes)
 
-    const postedTransaction = await node.wallet.post({
+    const transaction = await node.wallet.post({
       transaction: raw,
       account,
       broadcast: request.data.broadcast,
     })
 
-    const serialized = postedTransaction.serialize()
+    const serialized = transaction.serialize()
     request.end({ transaction: serialized.toString('hex') })
   },
 )

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -868,27 +868,26 @@ export class Wallet {
     transaction: RawTransaction
     spendingKey?: string
     account?: Account
+    broadcast?: boolean
   }): Promise<Transaction> {
     const spendingKey = options.account?.spendingKey ?? options.spendingKey
     Assert.isTruthy(spendingKey, `Spending key is required to post transaction`)
 
-    const transaction = await this.postTransaction(options.transaction, spendingKey)
+    const transaction = await this.workerPool.postTransaction(options.transaction, spendingKey)
 
     const verify = this.chain.verifier.verifyCreatedTransaction(transaction)
     if (!verify.valid) {
       throw new Error(`Invalid transaction, reason: ${String(verify.reason)}`)
     }
 
-    await this.addPendingTransaction(transaction)
-    this.memPool.acceptTransaction(transaction)
-    this.broadcastTransaction(transaction)
-    this.onTransactionCreated.emit(transaction)
+    if (options.broadcast) {
+      await this.addPendingTransaction(transaction)
+      this.memPool.acceptTransaction(transaction)
+      this.broadcastTransaction(transaction)
+      this.onTransactionCreated.emit(transaction)
+    }
 
     return transaction
-  }
-
-  async postTransaction(raw: RawTransaction, spendingKey: string): Promise<Transaction> {
-    return await this.workerPool.postTransaction(raw, spendingKey)
   }
 
   async fund(

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -870,6 +870,8 @@ export class Wallet {
     account?: Account
     broadcast?: boolean
   }): Promise<Transaction> {
+    const broadcast = options.broadcast ?? true
+
     const spendingKey = options.account?.spendingKey ?? options.spendingKey
     Assert.isTruthy(spendingKey, `Spending key is required to post transaction`)
 
@@ -880,7 +882,7 @@ export class Wallet {
       throw new Error(`Invalid transaction, reason: ${String(verify.reason)}`)
     }
 
-    if (options.broadcast) {
+    if (broadcast) {
       await this.addPendingTransaction(transaction)
       this.memPool.acceptTransaction(transaction)
       this.broadcastTransaction(transaction)


### PR DESCRIPTION
## Summary

It's unclear why there are 2 post functions in the wallet SDK. This combines them and adds an argument for the previous functionality.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
