### PR TITLE
Handles insufficient funds for one or more fee rates

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -3,16 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
 import {
-  CreateTransactionRequest,
   CurrencyUtils,
-  ERROR_CODES,
   isValidPublicAddress,
   RawTransactionSerde,
-  RpcRequestError,
   Transaction,
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import inquirer from 'inquirer'
 import { IronfishCommand } from '../../command'
 import { IronFlag, parseIron, RemoteFlags } from '../../flags'
 import { ProgressBar } from '../../types'
@@ -200,7 +196,7 @@ export class Send extends IronfishCommand {
 
     let rawTransactionResponse: string
     if (fee === null && feeRate === null) {
-      const foo = await selectFee({
+      const raw = await selectFee({
         client,
         account: flags.account,
         confirmations: flags.confirmations,
@@ -218,7 +214,7 @@ export class Send extends IronfishCommand {
           confirmations: confirmations,
         },
       })
-      rawTransactionResponse = RawTransactionSerde.serialize(foo).toString('hex')
+      rawTransactionResponse = RawTransactionSerde.serialize(raw).toString('hex')
     } else {
       const createResponse = await client.createTransaction({
         account: from,

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -46,11 +46,11 @@ export async function promptCurrency(options: {
     return null
   }
 
-  const [fee, error] = CurrencyUtils.decodeTry(input)
+  const [amount, error] = CurrencyUtils.decodeTry(input)
 
   if (error) {
     throw error
   }
 
-  return fee
+  return amount
 }

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Asset } from '@ironfish/rust-nodejs'
+import { CurrencyUtils, RpcClient } from '@ironfish/sdk'
+import { CliUx } from '@oclif/core'
+
+export async function promptCurrency(options: {
+  client: RpcClient
+  text: string
+  required: true
+  balance: {
+    account?: string
+    assetId?: string
+    confirmations?: number
+  }
+}): Promise<bigint>
+
+export async function promptCurrency(options: {
+  client: RpcClient
+  text: string
+  required?: boolean
+  balance: {
+    account?: string
+    assetId?: string
+    confirmations?: number
+  }
+}): Promise<bigint | null> {
+  let text = options.text
+
+  if (options.balance) {
+    const balance = await options.client.getAccountBalance({
+      assetId: options.balance.assetId ?? Asset.nativeId().toString('hex'),
+      confirmations: options.balance.confirmations,
+    })
+
+    text += ` (balance: ${CurrencyUtils.renderIron(balance.content.confirmed)})`
+  }
+
+  const input = await CliUx.ux.prompt(text, {
+    required: options.required,
+  })
+
+  if (!input) {
+    return null
+  }
+
+  const [fee, error] = CurrencyUtils.decodeTry(input)
+
+  if (error) {
+    throw error
+  }
+
+  return fee
+}

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  Assert,
+  CreateTransactionRequest,
+  CurrencyUtils,
+  ERROR_CODES,
+  RawTransaction,
+  RawTransactionSerde,
+  RpcClient,
+  RpcRequestError,
+} from '@ironfish/sdk'
+import inquirer from 'inquirer'
+
+export async function selectFee(options: {
+  client: RpcClient
+  transaction: CreateTransactionRequest
+  account?: string
+  confirmations?: number
+}): Promise<RawTransaction> {
+  const getTxWithFee = async (
+    feeRate: bigint,
+  ): Promise<{
+    transaction: RawTransaction | null
+    fee: bigint
+  }> => {
+    const promise = options.client.createTransaction({
+      ...options.transaction,
+      feeRate: CurrencyUtils.encode(feeRate),
+    })
+
+    const response = await promise.catch((e) => {
+      if (e instanceof RpcRequestError && e.code === ERROR_CODES.INSUFFICIENT_BALANCE) {
+        return null
+      } else {
+        throw e
+      }
+    })
+
+    if (response === null) {
+      return {
+        transaction: null,
+        fee: feeRate,
+      }
+    }
+
+    const bytes = Buffer.from(response.content.transaction, 'hex')
+    const raw = RawTransactionSerde.deserialize(bytes)
+
+    return {
+      transaction: raw,
+      fee: feeRate,
+    }
+  }
+
+  const feeRates = await options.client.estimateFeeRates()
+
+  const [slow, average, fast] = await Promise.all([
+    getTxWithFee(CurrencyUtils.decode(feeRates.content.slow)),
+    getTxWithFee(CurrencyUtils.decode(feeRates.content.average)),
+    getTxWithFee(CurrencyUtils.decode(feeRates.content.fast)),
+  ])
+
+  const choices: {
+    name: string
+    disabled?: string
+    value: {
+      transaction: RawTransaction | null
+      fee: bigint
+    }
+  }[] = [
+    {
+      name: 'slow',
+      disabled: 'disabled',
+      value: {
+        transaction: slow.transaction,
+        fee: slow.fee,
+      },
+    },
+  ]
+
+  const result = await inquirer.prompt<{
+    selection: {
+      transaction: RawTransaction | null
+      fee: bigint
+    }
+  }>([
+    {
+      name: 'selection',
+      message: `Select the fee you wish to use for this transaction`,
+      type: 'list',
+      choices,
+    },
+  ])
+
+  Assert.isNotNull(result.selection.transaction)
+  return result.selection.transaction
+}

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -22,65 +22,30 @@ export async function selectFee(options: {
   account?: string
   confirmations?: number
 }): Promise<RawTransaction> {
-  const getTxWithFee = async (
-    feeRate: bigint,
-  ): Promise<{
-    transaction: RawTransaction | null
-    fee: bigint | null
-  }> => {
-    const promise = options.client.createTransaction({
-      ...options.transaction,
-      feeRate: CurrencyUtils.encode(feeRate),
-    })
-
-    const response = await promise.catch((e) => {
-      if (e instanceof RpcRequestError && e.code === ERROR_CODES.INSUFFICIENT_BALANCE) {
-        return null
-      } else {
-        throw e
-      }
-    })
-
-    if (response === null) {
-      return {
-        transaction: null,
-        fee: null,
-      }
-    }
-
-    const bytes = Buffer.from(response.content.transaction, 'hex')
-    const raw = RawTransactionSerde.deserialize(bytes)
-
-    return {
-      transaction: raw,
-      fee: feeRate,
-    }
-  }
-
   const feeRates = await options.client.estimateFeeRates()
 
   const [slow, average, fast] = await Promise.all([
-    getTxWithFee(CurrencyUtils.decode(feeRates.content.slow)),
-    getTxWithFee(CurrencyUtils.decode(feeRates.content.average)),
-    getTxWithFee(CurrencyUtils.decode(feeRates.content.fast)),
+    getTxWithFee(
+      options.client,
+      options.transaction,
+      CurrencyUtils.decode(feeRates.content.slow),
+    ),
+    getTxWithFee(
+      options.client,
+      options.transaction,
+      CurrencyUtils.decode(feeRates.content.average),
+    ),
+    getTxWithFee(
+      options.client,
+      options.transaction,
+      CurrencyUtils.decode(feeRates.content.fast),
+    ),
   ])
 
-  const choices: {
-    name: string
-    disabled?: string | boolean
-    value: {
-      transaction: RawTransaction | null
-      fee: bigint
-    } | null
-  }[] = [
-    {
-      name: `Slow ${CurrencyUtils.renderIron(slow.fee)}`,
-      disabled: 'Not enough $IRON',
-      value: {
-        transaction: slow.transaction,
-        fee: slow.fee,
-      },
-    },
+  const choices = [
+    getChoiceFromTx('Slow', slow),
+    getChoiceFromTx('Average', average),
+    getChoiceFromTx('Fast', fast),
     {
       name: 'Enter your own',
       value: null,
@@ -108,7 +73,7 @@ export async function selectFee(options: {
     })
 
     const input = await CliUx.ux.prompt(
-      `Enter the fee amount in $IRON (blance: ${CurrencyUtils.renderIron(
+      `Enter the fee amount in $IRON (balance: ${CurrencyUtils.renderIron(
         response.content.confirmed,
       )})`,
       {
@@ -121,4 +86,50 @@ export async function selectFee(options: {
 
   Assert.isNotNull(result.selection.transaction)
   return result.selection.transaction
+}
+
+async function getTxWithFee(
+  client: RpcClient,
+  params: CreateTransactionRequest,
+  feeRate: bigint,
+): Promise<RawTransaction | null> {
+  const promise = client.createTransaction({
+    ...params,
+    feeRate: CurrencyUtils.encode(feeRate),
+  })
+
+  const response = await promise.catch((e) => {
+    if (e instanceof RpcRequestError && e.code === ERROR_CODES.INSUFFICIENT_BALANCE) {
+      return null
+    } else {
+      throw e
+    }
+  })
+
+  if (Math.random() < 1) {
+    return null
+  }
+
+  if (response === null) {
+    return null
+  }
+
+  const bytes = Buffer.from(response.content.transaction, 'hex')
+  const raw = RawTransactionSerde.deserialize(bytes)
+  return raw
+}
+
+function getChoiceFromTx(
+  name: string,
+  transaction: RawTransaction | null,
+): {
+  name: string
+  disabled?: string | boolean
+  value: RawTransaction | null
+} {
+  return {
+    name: `${name} ${transaction ? CurrencyUtils.renderIron(transaction.fee) : ''}`,
+    disabled: transaction ? false : 'Not enough $IRON',
+    value: transaction,
+  }
 }

--- a/ironfish/src/assert.ts
+++ b/ironfish/src/assert.ts
@@ -67,7 +67,7 @@ export class Assert {
     message?: string,
   ): asserts x is T {
     if (!(x instanceof constructor)) {
-      throw new Error(message || `Expected value to be false`)
+      throw new Error(message || `Expected value to be ${constructor.name} but was ${typeof x}`)
     }
   }
 


### PR DESCRIPTION
## Summary

we use Promise.all to parallelize createTransaction requests for all three fee rates (slow, average, fast) when neither a fee nor fee rate are specified in the send command.

however, if the sender account does not have enough funds to pay the fast fee rate, then the whole transaction fails. the user cannot select the slow fee rate even if their account has enough funds to pay that fee.

handles insufficient balance errors when creating transactions for different fee rates. inserts an 'Insufficient funds' option into the inquirer prompt and throws the error if that option is selected.

removes parallelization of the three fee rate requests to simplify error handling. Promise.allSettled is an alternative that would preserve parallelization, but makes it more difficult to distinguish the type of error when a request fails.

https://asciinema.org/a/VA4SGLM1Xklb3oI1nqwMhrMrj

## Testing Plan

Randomly throw errors in the backend to test what happens

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
