### PR TITLE
fixes --no-header flag in cli

### DIFF
--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -51,7 +51,7 @@ export class AssetsCommand extends IronfishCommand {
     const assetNameWidth = flags.extended
       ? MAX_ASSET_NAME_COLUMN_WIDTH
       : MIN_ASSET_NAME_COLUMN_WIDTH
-    let showHeader = true
+    let showHeader = !flags['no-header']
 
     for await (const asset of response.contentStream()) {
       CliUx.ux.table(

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -32,7 +32,7 @@ export class NotesCommand extends IronfishCommand {
 
     const response = client.getAccountNotesStream({ account })
 
-    let showHeader = true
+    let showHeader = !flags['no-header']
 
     for await (const note of response.contentStream()) {
       CliUx.ux.table(

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -59,7 +59,7 @@ export class TransactionsCommand extends IronfishCommand {
 
     const columns = this.getColumns(flags.extended)
 
-    let showHeader = true
+    let showHeader = !flags['no-header']
 
     for await (const transaction of response.contentStream()) {
       const transactionRows = this.getTransactionRows(transaction)


### PR DESCRIPTION
## Summary

in the assets, notes, and transactions commands in the wallet we accept a --no-header flag as one of the oclif table flags, but we don't handle it correctly.

uses the value of the flag to set 'showHeader' to remove the table header if a user passes --no-header.

Closes #3416

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
