### PR TITLE
fixes serialization of mints with unicode

### DIFF
--- a/ironfish/src/primitives/rawTransaction.test.ts
+++ b/ironfish/src/primitives/rawTransaction.test.ts
@@ -261,4 +261,33 @@ describe('RawTransactionSerde', () => {
     expect(deserialized.spends[0].note).toEqual(raw.spends[0].note)
     expect(IsNoteWitnessEqual(deserialized.spends[0].witness, raw.spends[0].witness)).toBe(true)
   })
+
+  it('serializes and deserializes a transaction with unicode characters', () => {
+    const assetName = '吉锕涩偶讷'
+    const assetMetadata = '💪💎🚀'
+
+    const raw = new RawTransaction()
+
+    raw.mints = [
+      {
+        name: assetName,
+        metadata: assetMetadata,
+        value: 5n,
+      },
+      {
+        name: assetName,
+        metadata: assetMetadata,
+        value: 4n,
+      },
+    ]
+
+    const serialized = RawTransactionSerde.serialize(raw)
+    const deserialized = RawTransactionSerde.deserialize(serialized)
+
+    expect(deserialized.mints[0].name).toEqual(assetName)
+    expect(deserialized.mints[0].metadata).toEqual(assetMetadata)
+
+    expect(deserialized.mints[1].name).toEqual(assetName)
+    expect(deserialized.mints[1].metadata).toEqual(assetMetadata)
+  })
 })

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -248,8 +248,8 @@ export class RawTransactionSerde {
 
     size += 8 // raw.mints.length
     for (const mint of raw.mints) {
-      size += bufio.sizeVarString(mint.name)
-      size += bufio.sizeVarString(mint.metadata)
+      size += bufio.sizeVarString(mint.name, 'utf8')
+      size += bufio.sizeVarString(mint.metadata, 'utf8')
       size += AMOUNT_VALUE_LENGTH // mint.value
     }
 


### PR DESCRIPTION
## Summary

we calculate the size of raw transactions incorrectly when those transactions contain mints of assets with unicode characters in either the name or metadata: we use 'sizeVarString' with the default binary encoding, but use 'writeVarString' with utf8 encoding. this results in an out of bounds write because the binary encoding is smaller than the utf8 encoding.

fixes the out of bounds write by using the utf8 encoding when calculating size.

adds test of serialization and deserialization of a mint with unicode characters.

## Testing Plan

1. added unit test
2. minted asset 💪💎🚀

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
