### PR TITLE
fix: add missing config fields to yup config validator

### DIFF
--- a/ironfish-cli/src/commands/fees.ts
+++ b/ironfish-cli/src/commands/fees.ts
@@ -1,7 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { RpcClient } from '@ironfish/sdk'
+import {
+  DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY,
+  DEFAULT_FEE_ESTIMATOR_PERCENTILE_AVERAGE,
+  DEFAULT_FEE_ESTIMATOR_PERCENTILE_FAST,
+  DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW,
+  RpcClient,
+} from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
@@ -37,10 +43,15 @@ export class FeeCommand extends IronfishCommand {
   async explainFeeRates(client: RpcClient): Promise<void> {
     const config = await client.getConfig()
 
-    const slow = config.content['feeEstimatorPercentileSlow'] || '10'
-    const average = config.content['feeEstimatorPercentileAverage'] || '20'
-    const fast = config.content['feeEstimatorPercentileFast'] || '30'
-    const numBlocks = config.content['feeEstimatorMaxBlockHistory'] || '10'
+    const slow =
+      config.content['feeEstimatorPercentileSlow'] || DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW
+    const average =
+      config.content['feeEstimatorPercentileAverage'] ||
+      DEFAULT_FEE_ESTIMATOR_PERCENTILE_AVERAGE
+    const fast =
+      config.content['feeEstimatorPercentileFast'] || DEFAULT_FEE_ESTIMATOR_PERCENTILE_FAST
+    const numBlocks =
+      config.content['feeEstimatorMaxBlockHistory'] || DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY
 
     this.log(
       `Fee rates are estimated from the distribution of transaction fees over the last ${numBlocks} blocks.\n`,

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -16,6 +16,10 @@ export const DEFAULT_USE_RPC_TLS = true
 export const DEFAULT_POOL_HOST = '::'
 export const DEFAULT_POOL_PORT = 9034
 export const DEFAULT_NETWORK_ID = 0
+export const DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY = 10
+export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW = 10
+export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_AVERAGE = 20
+export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_FAST = 30
 
 export type ConfigOptions = {
   bootstrapNodes: string[]
@@ -208,9 +212,25 @@ export type ConfigOptions = {
    */
   explorerTransactionsUrl: string
 
+  /**
+   * How many blocks back from the head of the chain to use to calculate the fee
+   * estimate
+   */
   feeEstimatorMaxBlockHistory: number
+
+  /**
+   * The percentile to use as an estimate for a slow transaction
+   */
   feeEstimatorPercentileSlow: number
+
+  /**
+   * The percentile to use as an estimate for an average transaction
+   */
   feeEstimatorPercentileAverage: number
+
+  /**
+   * The percentile to use as an estimate for a fast transaction
+   */
   feeEstimatorPercentileFast: number
 
   /**
@@ -281,12 +301,17 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     poolDifficulty: yup.string(),
     poolStatusNotificationInterval: YupUtils.isPositiveInteger,
     poolRecentShareCutoff: YupUtils.isPositiveInteger,
+    poolPayoutPeriodDuration: YupUtils.isPositiveInteger,
     poolDiscordWebhook: yup.string(),
     poolMaxConnectionsPerIp: YupUtils.isPositiveInteger,
     poolLarkWebhook: yup.string(),
     jsonLogs: yup.boolean(),
     explorerBlocksUrl: YupUtils.isUrl,
     explorerTransactionsUrl: YupUtils.isUrl,
+    feeEstimatorMaxBlockHistory: YupUtils.isPositiveInteger,
+    feeEstimatorPercentileSlow: YupUtils.isPositiveInteger,
+    feeEstimatorPercentileAverage: YupUtils.isPositiveInteger,
+    feeEstimatorPercentileFast: YupUtils.isPositiveInteger,
     networkId: yup.number().integer().min(0),
     customNetwork: yup.string().trim(),
     maxSyncedAgeBlocks: yup.number().integer().min(0),
@@ -367,10 +392,10 @@ export class Config extends KeyStore<ConfigOptions> {
       jsonLogs: false,
       explorerBlocksUrl: 'https://explorer.ironfish.network/blocks/',
       explorerTransactionsUrl: 'https://explorer.ironfish.network/transaction/',
-      feeEstimatorMaxBlockHistory: 10,
-      feeEstimatorPercentileSlow: 10,
-      feeEstimatorPercentileAverage: 20,
-      feeEstimatorPercentileFast: 30,
+      feeEstimatorMaxBlockHistory: DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY,
+      feeEstimatorPercentileSlow: DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW,
+      feeEstimatorPercentileAverage: DEFAULT_FEE_ESTIMATOR_PERCENTILE_AVERAGE,
+      feeEstimatorPercentileFast: DEFAULT_FEE_ESTIMATOR_PERCENTILE_FAST,
       networkId: DEFAULT_NETWORK_ID,
       customNetwork: '',
       maxSyncedAgeBlocks: 60,


### PR DESCRIPTION
## Summary

Small cleanup to add some missing keys to our yup config validator

Manually tested:
![image](https://user-images.githubusercontent.com/97762857/220770583-66585bb5-7b17-40c2-8782-986f62418347.png)


## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
