### PR TITLE
feat(ironfish): Check nullifier -> transaction hash befor marking notes as unspent

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -725,23 +725,23 @@ export class Account {
             'nullifierToNote mappings must have a corresponding decryptedNote',
           )
 
-          await this.walletDb.saveDecryptedNote(
-            this,
-            noteHash,
-            {
-              ...decryptedNote,
-              spent: false,
-            },
-            tx,
-          )
-
           const existingTransactionHash = await this.walletDb.getTransactionHashFromNullifier(
             this,
             spend.nullifier,
             tx,
           )
+          // Remove the nullifier to transaction hash mapping and mark the note as unspent
           if (existingTransactionHash && existingTransactionHash.equals(transaction.hash())) {
             await this.walletDb.deleteNullifierToTransactionHash(this, spend.nullifier, tx)
+            await this.walletDb.saveDecryptedNote(
+              this,
+              noteHash,
+              {
+                ...decryptedNote,
+                spent: false,
+              },
+              tx,
+            )
           }
         }
       }


### PR DESCRIPTION
## Summary

When we expire transactions, we can now check the nullifier -> transaction hash mapping to ensure notes are properly marked as unspent. 

It is possible that we can mark a note as spent from expiration and a pending transaction still exists for the account to spend the same note without an associated nullifier -> transaction hash mapping. 

## Testing Plan

Unit tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
