### PR TITLE
feat(ironfish): Backfill `nullifierToTransactionHash`

### DIFF
--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
@@ -40,7 +40,7 @@ export class Migration025 extends Migration {
 
     for (const account of accounts) {
       logger.info('')
-      logger.info(`  Backfilling assets for account ${account.name}`)
+      logger.info(`  Backfilling nullifier to transaction hashes for account ${account.name}`)
 
       const head = await stores.old.heads.get(account.id)
       // If the account has not scanned, we can skip the backfill

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Logger } from '../../logger'
+import { IronfishNode } from '../../node'
+import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { createDB } from '../../storage/utils'
+import { Account } from '../../wallet'
+import { Migration } from '../migration'
+import { GetStores } from './025-backfill-wallet-nullifier-to-transaction-hash/stores'
+
+export class Migration025 extends Migration {
+  path = __filename
+
+  prepare(node: IronfishNode): IDatabase {
+    return createDB({ location: node.config.walletDatabasePath })
+  }
+
+  async forward(
+    node: IronfishNode,
+    db: IDatabase,
+    _tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const accounts = []
+    const stores = GetStores(db)
+
+    for await (const account of stores.old.accounts.getAllValuesIter()) {
+      accounts.push(
+        new Account({
+          ...account,
+          walletDb: node.wallet.walletDb,
+        }),
+      )
+    }
+
+    logger.info(`Backfilling nullifier to transaction hashes for ${accounts.length} accounts`)
+
+    for (const account of accounts) {
+      logger.info('')
+      logger.info(`  Backfilling assets for account ${account.name}`)
+
+      const head = await stores.old.heads.get(account.id)
+      // If the account has not scanned, we can skip the backfill
+      if (!head) {
+        continue
+      }
+
+      let transactionCount = 0
+      for await (const { blockHash, transaction } of stores.old.transactions.getAllValuesIter(
+        undefined,
+        account.prefixRange,
+      )) {
+        // If the transaction is expired, we can skip the backfill
+        if (
+          !blockHash &&
+          transaction.expiration() !== 0 &&
+          transaction.expiration() <= head.sequence
+        ) {
+          continue
+        }
+
+        // Backfill the mappings from all transaction spends
+        for (const spend of transaction.spends) {
+          const existingNullifierToTransactionHash =
+            await stores.new.nullifierToTransactionHash.get([account.prefix, spend.nullifier])
+          // Upsert a record for connected transactions or if a mapping doesn't already exist
+          if (blockHash || !existingNullifierToTransactionHash) {
+            await stores.new.nullifierToTransactionHash.put(
+              [account.prefix, spend.nullifier],
+              transaction.hash(),
+            )
+          }
+        }
+
+        transactionCount++
+      }
+
+      const transactionsString =
+        transactionCount === 1
+          ? `${transactionCount} transaction`
+          : `${transactionCount} : transactions`
+      logger.info(`  Completed backfilling ${transactionsString} for account ${account.name}`)
+    }
+
+    logger.info('')
+  }
+
+  /**
+   * Writing a backwards migration is optional but suggested
+   */
+  async backward(
+    _node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const stores = GetStores(db)
+    logger.info('Clearing nullifierToTransactionHash')
+    await stores.new.nullifierToTransactionHash.clear(tx)
+  }
+}

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
@@ -34,7 +34,9 @@ export class Migration025 extends Migration {
       )
     }
 
-    logger.info(`Backfilling nullifier to transaction hashes for ${accounts.length} accounts`)
+    const accountsString =
+      accounts.length === 1 ? `${accounts.length} account` : `${accounts.length} accounts`
+    logger.info(`Backfilling nullifier to transaction hashes for ${accountsString}`)
 
     for (const account of accounts) {
       logger.info('')
@@ -79,7 +81,7 @@ export class Migration025 extends Migration {
       const transactionsString =
         transactionCount === 1
           ? `${transactionCount} transaction`
-          : `${transactionCount} : transactions`
+          : `${transactionCount} transactions`
       logger.info(`  Completed backfilling ${transactionsString} for account ${account.name}`)
     }
 

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/new/index.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/new/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { BufferEncoding, IDatabase, IDatabaseStore, PrefixEncoding } from '../../../../storage'
+
+export function GetNewStores(db: IDatabase): {
+  nullifierToTransactionHash: IDatabaseStore<{
+    key: [Buffer, Buffer]
+    value: Buffer
+  }>
+} {
+  const nullifierToTransactionHash: IDatabaseStore<{ key: [Buffer, Buffer]; value: Buffer }> =
+    db.addStore({
+      name: 'nt',
+      keyEncoding: new PrefixEncoding(new BufferEncoding(), new BufferEncoding(), 4),
+      valueEncoding: new BufferEncoding(),
+    })
+
+  return { nullifierToTransactionHash }
+}

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/old/accountValue.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/old/accountValue.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+const KEY_LENGTH = 32
+export const VIEW_KEY_LENGTH = 64
+const VERSION_LENGTH = 2
+
+export interface AccountValue {
+  version: number
+  id: string
+  name: string
+  spendingKey: string | null
+  viewKey: string
+  incomingViewKey: string
+  outgoingViewKey: string
+  publicAddress: string
+}
+
+export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
+  serialize(value: AccountValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    let flags = 0
+    flags |= Number(!!value.spendingKey) << 0
+    bw.writeU8(flags)
+    bw.writeU16(value.version)
+    bw.writeVarString(value.id, 'utf8')
+    bw.writeVarString(value.name, 'utf8')
+    if (value.spendingKey) {
+      bw.writeBytes(Buffer.from(value.spendingKey, 'hex'))
+    }
+    bw.writeBytes(Buffer.from(value.viewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): AccountValue {
+    const reader = bufio.read(buffer, true)
+    const flags = reader.readU8()
+    const version = reader.readU16()
+    const hasSpendingKey = flags & (1 << 0)
+    const id = reader.readVarString('utf8')
+    const name = reader.readVarString('utf8')
+    const spendingKey = hasSpendingKey ? reader.readBytes(KEY_LENGTH).toString('hex') : null
+    const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
+    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+
+    return {
+      version,
+      id,
+      name,
+      viewKey,
+      incomingViewKey,
+      outgoingViewKey,
+      spendingKey,
+      publicAddress,
+    }
+  }
+
+  getSize(value: AccountValue): number {
+    let size = 0
+    size += 1
+    size += VERSION_LENGTH
+    size += bufio.sizeVarString(value.id, 'utf8')
+    size += bufio.sizeVarString(value.name, 'utf8')
+    if (value.spendingKey) {
+      size += KEY_LENGTH
+    }
+    size += VIEW_KEY_LENGTH
+    size += KEY_LENGTH
+    size += KEY_LENGTH
+    size += PUBLIC_ADDRESS_LENGTH
+
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/old/headValue.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/old/headValue.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export type HeadValue = {
+  hash: Buffer
+  sequence: number
+}
+
+export class NullableHeadValueEncoding implements IDatabaseEncoding<HeadValue | null> {
+  serialize(value: HeadValue | null): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    if (value) {
+      bw.writeHash(value.hash)
+      bw.writeU32(value.sequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): HeadValue | null {
+    const reader = bufio.read(buffer, true)
+
+    if (reader.left()) {
+      const hash = reader.readHash()
+      const sequence = reader.readU32()
+      return { hash, sequence }
+    }
+
+    return null
+  }
+
+  getSize(value: HeadValue | null): number {
+    if (!value) {
+      return 0
+    }
+
+    return 32 + 4
+  }
+}

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/old/index.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/old/index.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  BufferEncoding,
+  IDatabase,
+  IDatabaseStore,
+  PrefixEncoding,
+  StringEncoding,
+} from '../../../../storage'
+import { AccountValue, AccountValueEncoding } from './accountValue'
+import { HeadValue, NullableHeadValueEncoding } from './headValue'
+import { TransactionValue, TransactionValueEncoding } from './transactionValue'
+
+export function GetOldStores(db: IDatabase): {
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+  heads: IDatabaseStore<{ key: string; value: HeadValue | null }>
+  transactions: IDatabaseStore<{ key: [Buffer, Buffer]; value: TransactionValue }>
+} {
+  const accounts: IDatabaseStore<{ key: string; value: AccountValue }> = db.addStore({
+    name: 'a',
+    keyEncoding: new StringEncoding(),
+    valueEncoding: new AccountValueEncoding(),
+  })
+
+  const heads: IDatabaseStore<{
+    key: string
+    value: HeadValue | null
+  }> = db.addStore({
+    name: 'h',
+    keyEncoding: new StringEncoding(),
+    valueEncoding: new NullableHeadValueEncoding(),
+  })
+
+  const transactions: IDatabaseStore<{
+    key: [Buffer, Buffer]
+    value: TransactionValue
+  }> = db.addStore({
+    name: 't',
+    keyEncoding: new PrefixEncoding(new BufferEncoding(), new BufferEncoding(), 4),
+    valueEncoding: new TransactionValueEncoding(),
+  })
+
+  return { accounts, heads, transactions }
+}

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/old/transactionValue.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/old/transactionValue.ts
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { IDatabaseEncoding } from '../../../../storage/database/types'
+import { BufferMap } from 'buffer-map'
+import bufio from 'bufio'
+import { Transaction } from '../../../../primitives'
+
+const ASSET_ID_LENGTH = 32
+
+export interface TransactionValue {
+  transaction: Transaction
+  timestamp: Date
+  // These fields are populated once the transaction is on the main chain
+  blockHash: Buffer | null
+  sequence: number | null
+  // This is populated when we create a transaction to track when we should
+  // rebroadcast. This can be null if we created it on another node, or the
+  // transaction was created for us by another person.
+  submittedSequence: number
+  assetBalanceDeltas: BufferMap<bigint>
+}
+
+export class TransactionValueEncoding implements IDatabaseEncoding<TransactionValue> {
+  serialize(value: TransactionValue): Buffer {
+    const { transaction, blockHash, sequence, submittedSequence, timestamp } = value
+
+    const bw = bufio.write(this.getSize(value))
+    bw.writeVarBytes(transaction.serialize())
+    bw.writeU64(timestamp.getTime())
+
+    let flags = 0
+    flags |= Number(!!blockHash) << 0
+    flags |= Number(!!sequence) << 1
+    bw.writeU8(flags)
+
+    if (blockHash) {
+      bw.writeHash(blockHash)
+    }
+    if (sequence) {
+      bw.writeU32(sequence)
+    }
+
+    bw.writeU32(submittedSequence)
+
+    const assetCount = value.assetBalanceDeltas.size
+    bw.writeU32(assetCount)
+
+    for (const [assetId, balanceDelta] of value.assetBalanceDeltas) {
+      bw.writeHash(assetId)
+      bw.writeBigI64(balanceDelta)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): TransactionValue {
+    const reader = bufio.read(buffer, true)
+    const transaction = new Transaction(reader.readVarBytes())
+    const timestamp = new Date(reader.readU64())
+
+    const flags = reader.readU8()
+    const hasBlockHash = flags & (1 << 0)
+    const hasSequence = flags & (1 << 1)
+
+    let blockHash = null
+    if (hasBlockHash) {
+      blockHash = reader.readHash()
+    }
+
+    let sequence = null
+    if (hasSequence) {
+      sequence = reader.readU32()
+    }
+
+    const submittedSequence = reader.readU32()
+
+    const assetBalanceDeltas = new BufferMap<bigint>()
+    const assetCount = reader.readU32()
+
+    for (let i = 0; i < assetCount; i++) {
+      const assetId = reader.readHash()
+      const balanceDelta = reader.readBigI64()
+      assetBalanceDeltas.set(assetId, balanceDelta)
+    }
+
+    return {
+      transaction,
+      blockHash,
+      submittedSequence,
+      sequence,
+      timestamp,
+      assetBalanceDeltas,
+    }
+  }
+
+  getSize(value: TransactionValue): number {
+    let size = bufio.sizeVarBytes(value.transaction.serialize())
+    size += 8
+    size += 1
+    if (value.blockHash) {
+      size += 32
+    }
+    if (value.sequence) {
+      size += 4
+    }
+    size += 4
+    size += 4
+    size += value.assetBalanceDeltas.size * (ASSET_ID_LENGTH + 8)
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/stores.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash/stores.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase } from '../../../storage'
+import { GetNewStores } from './new'
+import { GetOldStores } from './old'
+
+export function GetStores(db: IDatabase): {
+  old: ReturnType<typeof GetOldStores>
+  new: ReturnType<typeof GetNewStores>
+} {
+  const oldStores = GetOldStores(db)
+  const newStores = GetNewStores(db)
+
+  return { old: oldStores, new: newStores }
+}

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -12,6 +12,7 @@ import { Migration020 } from './020-backfill-null-asset-supplies'
 import { Migration021 } from './021-add-version-to-accounts'
 import { Migration022 } from './022-add-view-key-account'
 import { Migration023 } from './023-wallet-optional-spending-key'
+import { Migration025 } from './025-backfill-wallet-nullifier-to-transaction-hash'
 
 export const MIGRATIONS = [
   Migration014,
@@ -24,4 +25,5 @@ export const MIGRATIONS = [
   Migration021,
   Migration022,
   Migration023,
+  Migration025,
 ]

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -34,7 +34,7 @@ import { HeadValue, NullableHeadValueEncoding } from './headValue'
 import { AccountsDBMeta, MetaValue, MetaValueEncoding } from './metaValue'
 import { TransactionValue, TransactionValueEncoding } from './transactionValue'
 
-const VERSION_DATABASE_ACCOUNTS = 23
+const VERSION_DATABASE_ACCOUNTS = 25
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountId: null,


### PR DESCRIPTION
## Summary

For all accounts, load the transactions and backfill nullifier -> transaction hash from the database. If an account has not scanned or has no head, skip the backfill. If a transaction has expired, skip the backfill.

## Testing Plan

Manually run migration

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
