### PR TITLE
feat: introduce WebSocketClient class to allow options parameter

### DIFF
--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { SignalData } from './connections/webRtcConnection'
-import WSWebSocket from 'ws'
 import { Event } from '../../event'
 import { HostsStore } from '../../fileStores/hosts'
 import { createRootLogger, Logger } from '../../logger'
@@ -26,6 +25,7 @@ import { PeerListMessage } from '../messages/peerList'
 import { PeerListRequestMessage } from '../messages/peerListRequest'
 import { SignalMessage } from '../messages/signal'
 import { SignalRequestMessage } from '../messages/signalRequest'
+import { IsomorphicWebSocket } from '../types'
 import { parseUrl } from '../utils'
 import { VERSION_PROTOCOL_MIN } from '../version'
 import { AddressManager } from './addressManager'
@@ -276,7 +276,7 @@ export class PeerManager {
   }
 
   createPeerFromInboundWebSocketConnection(
-    webSocket: WebSocket | WSWebSocket,
+    webSocket: IsomorphicWebSocket,
     address: string | null,
   ): Peer {
     const peer = this.getOrCreatePeer(null)
@@ -303,7 +303,7 @@ export class PeerManager {
    */
   private initWebSocketConnection(
     peer: Peer,
-    ws: WebSocket | WSWebSocket,
+    ws: IsomorphicWebSocket,
     direction: ConnectionDirection,
     hostname: string | null,
     port: number | null,

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import ws from 'ws'
 import { Assert } from '../../assert'
 import { Identity, isIdentity } from '../identity'
 import { GetBlockHeadersResponse } from '../messages/getBlockHeaders'
@@ -17,6 +16,7 @@ import {
 } from '../peers/connections'
 import { Peer } from '../peers/peer'
 import { PeerManager } from '../peers/peerManager'
+import { WebSocketClient } from '../webSocketClient'
 import { mockIdentity } from './mockIdentity'
 
 export function getConnectingPeer(
@@ -32,7 +32,7 @@ export function getConnectingPeer(
     peer = pm.getOrCreatePeer(identity ?? null)
 
     const connection = new WebSocketConnection(
-      new ws(''),
+      new WebSocketClient(''),
       ConnectionDirection.Inbound,
       peer.logger,
     )

--- a/ironfish/src/network/testUtilities/mockLocalPeer.ts
+++ b/ironfish/src/network/testUtilities/mockLocalPeer.ts
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import ws from 'ws'
 import { Blockchain } from '../../blockchain'
 import { mockChain } from '../../testUtilities/mocks'
 import { PrivateIdentity } from '../identity'
 import { LocalPeer } from '../peers/localPeer'
 import { VERSION_PROTOCOL } from '../version'
+import { WebSocketClient } from '../webSocketClient'
 import { mockPrivateIdentity } from './mockPrivateIdentity'
 
 /**
@@ -24,5 +24,5 @@ export function mockLocalPeer({
   version?: number
   chain?: Blockchain
 } = {}): LocalPeer {
-  return new LocalPeer(identity, agent, version, chain || mockChain(), ws, 0)
+  return new LocalPeer(identity, agent, version, chain || mockChain(), WebSocketClient, 0)
 }

--- a/ironfish/src/network/types.ts
+++ b/ironfish/src/network/types.ts
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import type WSWebSocket from 'ws'
 import type { ErrorEvent as WSErrorEvent } from 'ws'
+import { WebSocketClient } from './webSocketClient'
 
 export enum NetworkMessageType {
   Disconnecting = 0,
@@ -30,6 +30,6 @@ export enum NetworkMessageType {
   GetBlockHeadersResponse = 22,
 }
 
-export type IsomorphicWebSocketConstructor = typeof WebSocket | typeof WSWebSocket
-export type IsomorphicWebSocket = WebSocket | WSWebSocket
+export type IsomorphicWebSocketConstructor = typeof WebSocket | typeof WebSocketClient
+export type IsomorphicWebSocket = WebSocket | WebSocketClient
 export type IsomorphicWebSocketErrorEvent = WSErrorEvent

--- a/ironfish/src/network/webSocketClient.ts
+++ b/ironfish/src/network/webSocketClient.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import http from 'http'
+import WSWebSocket from 'ws'
+import { WEBSOCKET_OPTIONS } from './webSocketServer'
+
+/**
+ * A simple wrapper around WSWebSocket to allow passing options when being used
+ * as an IsomorphicWebSocket
+ */
+export class WebSocketClient extends WSWebSocket {
+  constructor(
+    address: string | URL,
+    protocols?: string | string[],
+    options?: WSWebSocket.ClientOptions | http.ClientRequestArgs,
+  ) {
+    const opts = {
+      ...WEBSOCKET_OPTIONS,
+      ...options,
+    }
+    super(address, protocols, opts)
+  }
+}

--- a/ironfish/src/network/webSocketServer.ts
+++ b/ironfish/src/network/webSocketServer.ts
@@ -6,12 +6,20 @@ import http from 'http'
 import WSWebSocket from 'ws'
 import { MAX_MESSAGE_SIZE } from './version'
 
+export const WEBSOCKET_OPTIONS = {
+  maxPayload: MAX_MESSAGE_SIZE,
+}
+
 export class WebSocketServer {
   // The server instance
   readonly server: WSWebSocket.Server
 
   constructor(ctor: typeof WSWebSocket.Server, port: number) {
-    this.server = new ctor({ port, maxPayload: MAX_MESSAGE_SIZE })
+    const opts = {
+      ...WEBSOCKET_OPTIONS,
+      port,
+    }
+    this.server = new ctor(opts)
   }
 
   /**

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -21,6 +21,7 @@ import { FileReporter } from './logger/reporters'
 import { MetricsMonitor } from './metrics'
 import { PrivateIdentity } from './network/identity'
 import { IsomorphicWebSocketConstructor } from './network/types'
+import { WebSocketClient } from './network/webSocketClient'
 import { IronfishNode } from './node'
 import { IronfishPKG, Package } from './package'
 import { Platform } from './platform'
@@ -182,7 +183,7 @@ export class IronfishSdk {
     autoSeed?: boolean
     privateIdentity?: PrivateIdentity
   } = {}): Promise<IronfishNode> {
-    const webSocket = (await require('ws')) as IsomorphicWebSocketConstructor
+    const webSocket = WebSocketClient as IsomorphicWebSocketConstructor
 
     const node = await IronfishNode.init({
       pkg: this.pkg,


### PR DESCRIPTION
## Summary

The issue right now is that since we have the IsomorphicWebSocket, we lack the ability to set the options parameter for the ws WebSocket. The primary issue is that any connections created this way will not receive the maxPayload option, thus allowing anyone to send a message of any size (up to the default limit set in the library which is I think 100mb). By creating this class which extends ws WebSocket and sets default options in the constructor, we can create ws WebSockets with the maxPayload option set.

## Testing Plan

Unit tests and manual testing by running a node on testnest

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
