### PR TITLE
Add subprotocols to identify message

### DIFF
--- a/ironfish/src/network/messageRegistry.test.ts
+++ b/ironfish/src/network/messageRegistry.test.ts
@@ -24,6 +24,7 @@ describe('messageRegistry', () => {
           work: BigInt(0),
           networkId: 0,
           genesisBlockHash: Buffer.alloc(32, 0),
+          subProtocols: new Map(),
         })
         jest.spyOn(message, 'serialize').mockImplementationOnce(() => Buffer.from('adsf'))
 
@@ -43,6 +44,7 @@ describe('messageRegistry', () => {
           work: BigInt(0),
           networkId: 0,
           genesisBlockHash: Buffer.alloc(32, 0),
+          subProtocols: new Map(),
         })
 
         expect(parseNetworkMessage(message.serializeWithMetadata())).toEqual(message)

--- a/ironfish/src/network/messages/identify.test.ts
+++ b/ironfish/src/network/messages/identify.test.ts
@@ -17,6 +17,7 @@ describe('IdentifyMessage', () => {
       work: BigInt('123'),
       networkId: 0,
       genesisBlockHash: Buffer.alloc(32, 0),
+      subProtocols: new Map(),
     })
 
     const buffer = message.serialize()

--- a/ironfish/src/network/peers/connections/webRtcConnection.test.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.test.ts
@@ -21,6 +21,7 @@ describe('WebRtcConnection', () => {
           work: BigInt(0),
           networkId: 0,
           genesisBlockHash: Buffer.alloc(32, 0),
+          subProtocols: new Map(),
         })
         expect(connection.send(message)).toBe(false)
         connection.close()
@@ -46,6 +47,7 @@ describe('WebRtcConnection', () => {
           work: BigInt(0),
           networkId: 0,
           genesisBlockHash: Buffer.alloc(32, 0),
+          subProtocols: new Map(),
         })
 
         expect(connection.send(message)).toBe(true)

--- a/ironfish/src/network/peers/connections/webSocketConnection.test.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.test.ts
@@ -34,6 +34,7 @@ describe('WebSocketConnection', () => {
           work: BigInt(0),
           networkId: 0,
           genesisBlockHash: Buffer.alloc(32, 0),
+          subProtocols: new Map(),
         })
 
         expect(connection.send(message)).toBe(true)

--- a/ironfish/src/network/peers/localPeer.ts
+++ b/ironfish/src/network/peers/localPeer.ts
@@ -71,6 +71,7 @@ export class LocalPeer {
       work: this.chain.head.work,
       networkId: this.networkId,
       genesisBlockHash: this.chain.genesis.hash,
+      subProtocols: new Map(),
     })
   }
 

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -74,6 +74,7 @@ describe('PeerManager', () => {
       work: BigInt(0),
       networkId: localPeer.networkId,
       genesisBlockHash: localPeer.chain.genesis.hash,
+      subProtocols: new Map(),
     })
 
     // Identify peerOut
@@ -760,6 +761,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        subProtocols: new Map(),
       })
       peer.onMessage.emit(identify, connection)
 
@@ -795,6 +797,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        subProtocols: new Map(),
       })
       peer.onMessage.emit(identify, connection)
 
@@ -821,6 +824,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        subProtocols: new Map(),
       })
       peer.onMessage.emit(identify, connection)
       expect(closeSpy).toHaveBeenCalled()
@@ -847,6 +851,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        subProtocols: new Map(),
       })
       connection.onMessage.emit(identify)
 
@@ -881,6 +886,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        subProtocols: new Map(),
       })
       connection.onMessage.emit(identify)
 
@@ -921,6 +927,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        subProtocols: new Map(),
       })
       connection.onMessage.emit(identify)
 
@@ -970,6 +977,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        subProtocols: new Map(),
       })
       connection.onMessage.emit(id)
 
@@ -1010,6 +1018,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId + 1,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        subProtocols: new Map(),
       })
       peer.onMessage.emit(identify, connection)
 
@@ -1037,6 +1046,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: Buffer.alloc(32, 1),
+        subProtocols: new Map(),
       })
       Assert.isFalse(identify.genesisBlockHash.equals(localPeer.chain.genesis.hash))
       peer.onMessage.emit(identify, connection)

--- a/ironfish/src/network/version.ts
+++ b/ironfish/src/network/version.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const VERSION_PROTOCOL = 20
+export const VERSION_PROTOCOL = 21
 export const VERSION_PROTOCOL_MIN = 19
 
 export const MAX_REQUESTED_BLOCKS = 50


### PR DESCRIPTION
## Summary

Adds supported sub-protocols to the identify message. This will allow nodes to indicate which sub-protocols they support in the identify message, as well as allowing independent development of sub-protocol versions. Sub-protocols contain an ID and a version.

## Testing Plan

Tested 0.1.68 connecting to this branch to ensure it doesn't break backward compatibility in the Identify message.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
