### PR TITLE
Replace message type with sub-protocol and message type

### DIFF
--- a/ironfish/src/network/messageRegistry.test.ts
+++ b/ironfish/src/network/messageRegistry.test.ts
@@ -8,7 +8,7 @@ describe('messageRegistry', () => {
   describe('parseNetworkMessage', () => {
     describe('with a malformed header', () => {
       it('throws an error', () => {
-        expect(() => parseNetworkMessage(Buffer.from(''))).toThrow()
+        expect(() => parseNetworkMessage(Buffer.from(''), true)).toThrow()
       })
     })
 
@@ -28,7 +28,8 @@ describe('messageRegistry', () => {
         })
         jest.spyOn(message, 'serialize').mockImplementationOnce(() => Buffer.from('adsf'))
 
-        expect(() => parseNetworkMessage(message.serializeWithMetadata())).toThrow()
+        expect(() => parseNetworkMessage(message.serializeWithMetadata(true), true)).toThrow()
+        expect(() => parseNetworkMessage(message.serializeWithMetadata(true), true)).toThrow()
       })
     })
 
@@ -47,7 +48,7 @@ describe('messageRegistry', () => {
           subProtocols: new Map(),
         })
 
-        expect(parseNetworkMessage(message.serializeWithMetadata())).toEqual(message)
+        expect(parseNetworkMessage(message.serializeWithMetadata(true), true)).toEqual(message)
       })
     })
   })

--- a/ironfish/src/network/messageRegistry.ts
+++ b/ironfish/src/network/messageRegistry.ts
@@ -29,8 +29,11 @@ import { SignalMessage } from './messages/signal'
 import { SignalRequestMessage } from './messages/signalRequest'
 import { NetworkMessageType } from './types'
 
-export const parseNetworkMessage = (buffer: Buffer): NetworkMessage => {
-  const { type, remaining: body } = NetworkMessage.deserializeType(buffer)
+export const parseNetworkMessage = (
+  buffer: Buffer,
+  supportsSubprotocols: boolean,
+): NetworkMessage => {
+  const { type, remaining: body } = NetworkMessage.deserializeType(buffer, supportsSubprotocols)
 
   if (isRpcNetworkMessageType(type)) {
     return parseRpcNetworkMessage(type, body)

--- a/ironfish/src/network/messages/identify.ts
+++ b/ironfish/src/network/messages/identify.ts
@@ -7,7 +7,7 @@ import { Identity, identityLength } from '../identity'
 import { NetworkMessageType } from '../types'
 import { NetworkMessage } from './networkMessage'
 
-const SUB_PROTOCOLS_MIN_VERSION = 21
+export const SUB_PROTOCOLS_MIN_VERSION = 21
 
 interface CreateIdentifyMessageOptions {
   agent: string

--- a/ironfish/src/network/messages/networkMessage.ts
+++ b/ironfish/src/network/messages/networkMessage.ts
@@ -4,10 +4,154 @@
 import bufio from 'bufio'
 import { Serializable } from '../../common/serializable'
 import { Identity } from '../identity'
-import { NetworkMessageType } from '../types'
+import {
+  InternalSubProtocolMessageType,
+  NetworkMessageType,
+  PeerDiscoverySubProtocolMessageType,
+  SubProtocolType,
+  SyncSubProtocolMessageType,
+} from '../types'
 
 export function displayNetworkMessageType(type: NetworkMessageType): string {
   return `${NetworkMessageType[type]} (${type})`
+}
+
+const protocolAndTypeToType: Record<number, Record<number, NetworkMessageType>> = {
+  [SubProtocolType.Internal]: {
+    [InternalSubProtocolMessageType.Identify]: NetworkMessageType.Identify,
+    [InternalSubProtocolMessageType.Disconnecting]: NetworkMessageType.Disconnecting,
+    [InternalSubProtocolMessageType.SignalRequest]: NetworkMessageType.SignalRequest,
+    [InternalSubProtocolMessageType.Signal]: NetworkMessageType.Signal,
+  },
+  [SubProtocolType.PeerDiscovery]: {
+    [PeerDiscoverySubProtocolMessageType.PeerListRequest]: NetworkMessageType.PeerListRequest,
+    [PeerDiscoverySubProtocolMessageType.PeerList]: NetworkMessageType.PeerList,
+  },
+  [SubProtocolType.Sync]: {
+    [SyncSubProtocolMessageType.CannotSatisfyRequest]: NetworkMessageType.CannotSatisfyRequest,
+    [SyncSubProtocolMessageType.GetBlockHashesRequest]:
+      NetworkMessageType.GetBlockHashesRequest,
+    [SyncSubProtocolMessageType.GetBlockHashesResponse]:
+      NetworkMessageType.GetBlockHashesResponse,
+    [SyncSubProtocolMessageType.GetBlocksRequest]: NetworkMessageType.GetBlocksRequest,
+    [SyncSubProtocolMessageType.GetBlocksResponse]: NetworkMessageType.GetBlocksResponse,
+    [SyncSubProtocolMessageType.PooledTransactionsRequest]:
+      NetworkMessageType.PooledTransactionsRequest,
+    [SyncSubProtocolMessageType.PooledTransactionsResponse]:
+      NetworkMessageType.PooledTransactionsResponse,
+    [SyncSubProtocolMessageType.NewPooledTransactionHashes]:
+      NetworkMessageType.NewPooledTransactionHashes,
+    [SyncSubProtocolMessageType.NewTransactions]: NetworkMessageType.NewTransactions,
+    [SyncSubProtocolMessageType.NewBlockHashes]: NetworkMessageType.NewBlockHashes,
+    [SyncSubProtocolMessageType.NewCompactBlock]: NetworkMessageType.NewCompactBlock,
+    [SyncSubProtocolMessageType.GetBlockTransactionsRequest]:
+      NetworkMessageType.GetBlockTransactionsRequest,
+    [SyncSubProtocolMessageType.GetBlockTransactionsResponse]:
+      NetworkMessageType.GetBlockTransactionsResponse,
+    [SyncSubProtocolMessageType.GetCompactBlockRequest]:
+      NetworkMessageType.GetCompactBlockRequest,
+    [SyncSubProtocolMessageType.GetCompactBlockResponse]:
+      NetworkMessageType.GetCompactBlockResponse,
+    [SyncSubProtocolMessageType.GetBlockHeadersRequest]:
+      NetworkMessageType.GetBlockHeadersRequest,
+    [SyncSubProtocolMessageType.GetBlockHeadersResponse]:
+      NetworkMessageType.GetBlockHeadersResponse,
+  },
+}
+
+const typeToProtocolAndType: Record<NetworkMessageType, { protocol: number; type: number }> = {
+  [NetworkMessageType.Disconnecting]: {
+    protocol: SubProtocolType.Internal,
+    type: InternalSubProtocolMessageType.Disconnecting,
+  },
+  [NetworkMessageType.CannotSatisfyRequest]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.CannotSatisfyRequest,
+  },
+  [NetworkMessageType.GetBlockHashesRequest]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.GetBlockHashesRequest,
+  },
+  [NetworkMessageType.GetBlockHashesResponse]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.GetBlockHashesResponse,
+  },
+  [NetworkMessageType.GetBlocksRequest]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.GetBlocksRequest,
+  },
+  [NetworkMessageType.GetBlocksResponse]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.GetBlocksResponse,
+  },
+  [NetworkMessageType.Identify]: {
+    protocol: SubProtocolType.Internal,
+    type: InternalSubProtocolMessageType.Identify,
+  },
+  [NetworkMessageType.PeerList]: {
+    protocol: SubProtocolType.PeerDiscovery,
+    type: PeerDiscoverySubProtocolMessageType.PeerList,
+  },
+  [NetworkMessageType.PeerListRequest]: {
+    protocol: SubProtocolType.PeerDiscovery,
+    type: PeerDiscoverySubProtocolMessageType.PeerListRequest,
+  },
+  [NetworkMessageType.Signal]: {
+    protocol: SubProtocolType.Internal,
+    type: InternalSubProtocolMessageType.Signal,
+  },
+  [NetworkMessageType.SignalRequest]: {
+    protocol: SubProtocolType.Internal,
+    type: InternalSubProtocolMessageType.SignalRequest,
+  },
+  [NetworkMessageType.PooledTransactionsRequest]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.PooledTransactionsRequest,
+  },
+  [NetworkMessageType.PooledTransactionsResponse]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.PooledTransactionsResponse,
+  },
+  [NetworkMessageType.NewPooledTransactionHashes]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.NewPooledTransactionHashes,
+  },
+  [NetworkMessageType.NewTransactions]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.NewTransactions,
+  },
+  [NetworkMessageType.NewBlockHashes]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.NewBlockHashes,
+  },
+  [NetworkMessageType.NewCompactBlock]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.NewCompactBlock,
+  },
+  [NetworkMessageType.GetBlockTransactionsRequest]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.GetBlockTransactionsRequest,
+  },
+  [NetworkMessageType.GetBlockTransactionsResponse]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.GetBlockTransactionsResponse,
+  },
+  [NetworkMessageType.GetCompactBlockRequest]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.GetCompactBlockRequest,
+  },
+  [NetworkMessageType.GetCompactBlockResponse]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.GetCompactBlockResponse,
+  },
+  [NetworkMessageType.GetBlockHeadersRequest]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.GetBlockHeadersRequest,
+  },
+  [NetworkMessageType.GetBlockHeadersResponse]: {
+    protocol: SubProtocolType.Sync,
+    type: SyncSubProtocolMessageType.GetBlockHeadersResponse,
+  },
 }
 
 export abstract class NetworkMessage implements Serializable {
@@ -20,16 +164,32 @@ export abstract class NetworkMessage implements Serializable {
   abstract serialize(): Buffer
   abstract getSize(): number
 
-  static deserializeType(buffer: Buffer): { type: NetworkMessageType; remaining: Buffer } {
+  static deserializeType(
+    buffer: Buffer,
+    supportsSubprotocols: boolean,
+  ): { type: NetworkMessageType; remaining: Buffer } {
     const br = bufio.read(buffer, true)
-    const type = br.readU8()
+    let type
+    if (!supportsSubprotocols) {
+      type = br.readU8()
+    } else {
+      const protocol = br.readU8()
+      const protocolType = br.readU8()
+      type = protocolAndTypeToType[protocol][protocolType]
+    }
     return { type, remaining: br.readBytes(br.left()) }
   }
 
-  serializeWithMetadata(): Buffer {
-    const headerSize = 1
+  serializeWithMetadata(supportsSubprotocols: boolean): Buffer {
+    const headerSize = supportsSubprotocols ? 2 : 1
     const bw = bufio.write(headerSize + this.getSize())
-    bw.writeU8(this.type)
+    if (!supportsSubprotocols) {
+      bw.writeU8(this.type)
+    } else {
+      const { protocol, type } = typeToProtocolAndType[this.type]
+      bw.writeU8(protocol)
+      bw.writeU8(type)
+    }
     bw.writeBytes(this.serialize())
     return bw.render()
   }

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -175,7 +175,7 @@ describe('PeerNetwork', () => {
       // Check that the disconnect message was serialized properly
       const args = sendSpy.mock.calls[0][0]
       expect(Buffer.isBuffer(args)).toBe(true)
-      const message = parseNetworkMessage(args)
+      const message = parseNetworkMessage(args, false)
       expect(message.type).toEqual(NetworkMessageType.Disconnecting)
       Assert.isInstanceOf(message, DisconnectingMessage)
       expect(message.reason).toEqual(DisconnectingReason.Congested)

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -292,7 +292,7 @@ export class PeerNetwork {
             reason: DisconnectingReason.Congested,
             sourceIdentity: this.localPeer.publicIdentity,
           })
-          connection.send(disconnect.serializeWithMetadata())
+          connection.send(disconnect.serializeWithMetadata(false))
           connection.close()
           return
         }

--- a/ironfish/src/network/peers/connections/connection.ts
+++ b/ironfish/src/network/peers/connections/connection.ts
@@ -35,7 +35,7 @@ type ConnectionState =
   /* A WebRTC-exclusive state that requires an identity */
   | { type: 'SIGNALING' }
   | { type: 'WAITING_FOR_IDENTITY' }
-  | { type: 'CONNECTED'; identity: Identity }
+  | { type: 'CONNECTED'; identity: Identity; supportsSubprotocols: boolean }
 
 /**
  * Model any connection that can send and receive messages.
@@ -76,6 +76,10 @@ export abstract class Connection {
     const name =
       this.state.type === 'CONNECTED' ? this.state.identity.slice(0, 7) : 'unidentified'
     return `${this.type} ${name}`
+  }
+
+  get supportsSubprotocols(): boolean {
+    return this.state.type === 'CONNECTED' ? this.state.supportsSubprotocols : false
   }
 
   /**

--- a/ironfish/src/network/peers/connections/webRtcConnection.test.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.test.ts
@@ -51,7 +51,7 @@ describe('WebRtcConnection', () => {
         })
 
         expect(connection.send(message)).toBe(true)
-        expect(sendMessageBinary).toHaveBeenCalledWith(message.serializeWithMetadata())
+        expect(sendMessageBinary).toHaveBeenCalledWith(message.serializeWithMetadata(false))
         connection.close()
       })
     })

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -144,7 +144,7 @@ export class WebRtcConnection extends Connection {
 
       let message
       try {
-        message = parseNetworkMessage(bufferData)
+        message = parseNetworkMessage(bufferData, this.supportsSubprotocols)
       } catch (error) {
         this.logger.warn(`Unable to parse webrtc message`)
         this.close(error)
@@ -216,7 +216,7 @@ export class WebRtcConnection extends Connection {
       return false
     }
 
-    const data = message.serializeWithMetadata()
+    const data = message.serializeWithMetadata(this.supportsSubprotocols)
     try {
       this.datachannel.sendMessageBinary(data)
     } catch (e) {

--- a/ironfish/src/network/peers/connections/webSocketConnection.test.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.test.ts
@@ -38,7 +38,7 @@ describe('WebSocketConnection', () => {
         })
 
         expect(connection.send(message)).toBe(true)
-        expect(send).toHaveBeenCalledWith(message.serializeWithMetadata())
+        expect(send).toHaveBeenCalledWith(message.serializeWithMetadata(false))
         connection.close()
       })
     })

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -88,7 +88,7 @@ export class WebSocketConnection extends Connection {
       let message
 
       try {
-        message = parseNetworkMessage(event.data)
+        message = parseNetworkMessage(event.data, this.supportsSubprotocols)
 
         this.metrics?.p2p_InboundTrafficByMessage.get(message.type)?.add(event.data.byteLength)
       } catch (error) {
@@ -122,7 +122,7 @@ export class WebSocketConnection extends Connection {
       )
     }
 
-    const data = message.serializeWithMetadata()
+    const data = message.serializeWithMetadata(this.supportsSubprotocols)
     this.socket.send(data)
 
     const byteCount = data.byteLength

--- a/ironfish/src/network/peers/peer.test.ts
+++ b/ironfish/src/network/peers/peer.test.ts
@@ -103,7 +103,11 @@ it('Times out WebRTC handshake', () => {
   expect(connection.state.type).toEqual('WAITING_FOR_IDENTITY')
   peer.setWebRtcConnection(connection)
   expect(peer.state.type).toEqual('CONNECTING')
-  connection.setState({ type: 'CONNECTED', identity: mockIdentity('peer') })
+  connection.setState({
+    type: 'CONNECTED',
+    identity: mockIdentity('peer'),
+    supportsSubprotocols: true,
+  })
   jest.runOnlyPendingTimers()
   expect(connection.state.type).toEqual('CONNECTED')
   expect(peer.state.type).toEqual('CONNECTED')
@@ -117,7 +121,11 @@ describe('Handles WebRTC message send failure', () => {
     const peer = new Peer(null)
 
     // Time out requesting signaling
-    connection.setState({ type: 'CONNECTED', identity: mockIdentity('peer') })
+    connection.setState({
+      type: 'CONNECTED',
+      identity: mockIdentity('peer'),
+      supportsSubprotocols: true,
+    })
     peer.setWebRtcConnection(connection)
     if (!connection['datachannel']) {
       throw new Error('Should have datachannel')
@@ -144,8 +152,16 @@ describe('Handles WebRTC message send failure', () => {
     const peer = new Peer(null)
 
     // Time out requesting signaling
-    wsConnection.setState({ type: 'CONNECTED', identity: mockIdentity('peer') })
-    wrtcConnection.setState({ type: 'CONNECTED', identity: mockIdentity('peer') })
+    wsConnection.setState({
+      type: 'CONNECTED',
+      identity: mockIdentity('peer'),
+      supportsSubprotocols: true,
+    })
+    wrtcConnection.setState({
+      type: 'CONNECTED',
+      identity: mockIdentity('peer'),
+      supportsSubprotocols: true,
+    })
     peer.setWebRtcConnection(wrtcConnection)
     peer.setWebSocketConnection(wsConnection)
 
@@ -204,7 +220,7 @@ it('Transitions to CONNECTED when a connection receives an identity', () => {
     connections: { webSocket: connection },
   })
 
-  connection.setState({ type: 'CONNECTED', identity })
+  connection.setState({ type: 'CONNECTED', identity, supportsSubprotocols: true })
 
   expect(peer.state).toEqual({
     type: 'CONNECTED',
@@ -224,6 +240,7 @@ it('Transitions to CONNECTED when adding a connection with state CONNECTED', () 
   connection.setState({
     type: 'CONNECTED',
     identity,
+    supportsSubprotocols: true,
   })
 
   peer.setWebSocketConnection(connection)
@@ -250,7 +267,7 @@ it('Stays in CONNECTED when adding an additional connection', () => {
     connections: { webSocket: connection },
   })
 
-  connection.setState({ type: 'CONNECTED', identity })
+  connection.setState({ type: 'CONNECTED', identity, supportsSubprotocols: true })
 
   // Add in an additional connection
   const wrtcConnection = new WebRtcConnection(true, createRootLogger())
@@ -276,12 +293,12 @@ describe('Stays in CONNECTED when one connection disconnects', () => {
       createRootLogger(),
     )
     peer.setWebSocketConnection(connection)
-    connection.setState({ type: 'CONNECTED', identity })
+    connection.setState({ type: 'CONNECTED', identity, supportsSubprotocols: true })
 
     // Add a CONNECTED WebRTC connection
     const wrtcConnection = new WebRtcConnection(true, createRootLogger())
     peer.setWebRtcConnection(wrtcConnection)
-    wrtcConnection.setState({ type: 'CONNECTED', identity })
+    wrtcConnection.setState({ type: 'CONNECTED', identity, supportsSubprotocols: true })
 
     expect(peer.state.type).toBe('CONNECTED')
 
@@ -305,12 +322,12 @@ describe('Stays in CONNECTED when one connection disconnects', () => {
       createRootLogger(),
     )
     peer.setWebSocketConnection(connection)
-    connection.setState({ type: 'CONNECTED', identity })
+    connection.setState({ type: 'CONNECTED', identity, supportsSubprotocols: true })
 
     // Add a CONNECTED WebRTC connection
     const wrtcConnection = new WebRtcConnection(true, createRootLogger())
     peer.setWebRtcConnection(wrtcConnection)
-    wrtcConnection.setState({ type: 'CONNECTED', identity })
+    wrtcConnection.setState({ type: 'CONNECTED', identity, supportsSubprotocols: true })
 
     expect(peer.state.type).toBe('CONNECTED')
 
@@ -336,6 +353,7 @@ describe('punish', () => {
     connection.setState({
       type: 'CONNECTED',
       identity,
+      supportsSubprotocols: true,
     })
 
     peer.setWebSocketConnection(connection)

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -164,6 +164,7 @@ describe('maintainOneConnectionPerPeer', () => {
     peer.state.connections.webSocket?.setState({
       type: 'CONNECTED',
       identity: identity,
+      supportsSubprotocols: true,
     })
 
     pm.connectToWebRTC(peer)
@@ -213,6 +214,7 @@ describe('maintainOneConnectionPerPeer', () => {
     peer.state.connections.webSocket?.setState({
       type: 'CONNECTED',
       identity: identity,
+      supportsSubprotocols: true,
     })
 
     pm.connectToWebRTC(peer)
@@ -223,6 +225,7 @@ describe('maintainOneConnectionPerPeer', () => {
     peer.state.connections.webRtc.setState({
       type: 'CONNECTED',
       identity: identity,
+      supportsSubprotocols: true,
     })
 
     expect(peer.state).toEqual({
@@ -264,6 +267,7 @@ describe('attemptToEstablishWebRtcConnectionsToWSPeers', () => {
     peer.state.connections.webSocket?.setState({
       type: 'CONNECTED',
       identity: identity,
+      supportsSubprotocols: true,
     })
 
     expect(peer.state).toEqual({

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -172,7 +172,11 @@ describe('PeerManager', () => {
       const connection = peer.state.connections.webSocket
       Assert.isNotUndefined(connection)
 
-      connection.setState({ type: 'CONNECTED', identity: peerIdentity })
+      connection.setState({
+        type: 'CONNECTED',
+        identity: peerIdentity,
+        supportsSubprotocols: true,
+      })
 
       expect(peers.peerCandidates.size).toBe(1)
       const pc = peers.peerCandidates.get(peerIdentity)
@@ -620,6 +624,7 @@ describe('PeerManager', () => {
       webRtcConnection.setState({
         type: 'CONNECTED',
         identity: peerIdentity,
+        supportsSubprotocols: true,
       })
       expect(closeSpy).toHaveBeenCalledTimes(1)
 
@@ -642,6 +647,7 @@ describe('PeerManager', () => {
       unidentifiedConnection.setState({
         type: 'CONNECTED',
         identity: peerIdentity,
+        supportsSubprotocols: true,
       })
 
       expect(pm.peers.length).toBe(2)
@@ -704,6 +710,7 @@ describe('PeerManager', () => {
       unidentifiedConnection.setState({
         type: 'CONNECTED',
         identity: peerIdentity,
+        supportsSubprotocols: true,
       })
 
       expect(pm.peers.length).toBe(1)

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -15,7 +15,7 @@ import {
   isIdentity,
 } from '../identity'
 import { DisconnectingMessage, DisconnectingReason } from '../messages/disconnecting'
-import { IdentifyMessage } from '../messages/identify'
+import { IdentifyMessage, SUB_PROTOCOLS_MIN_VERSION } from '../messages/identify'
 import {
   displayNetworkMessageType,
   IncomingPeerMessage,
@@ -1255,7 +1255,11 @@ export class PeerManager {
     }
 
     // Identity has been successfully validated, update the peer's state
-    connection.setState({ type: 'CONNECTED', identity: identity })
+    connection.setState({
+      type: 'CONNECTED',
+      identity: identity,
+      supportsSubprotocols: message.version >= SUB_PROTOCOLS_MIN_VERSION,
+    })
   }
 
   /**

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -117,7 +117,7 @@ export function getConnectedPeer(
     identity = mockIdentity(identity)
   }
 
-  connection.setState({ type: 'CONNECTED', identity })
+  connection.setState({ type: 'CONNECTED', identity, supportsSubprotocols: true })
 
   return { peer, connection: connection }
 }

--- a/ironfish/src/network/types.ts
+++ b/ironfish/src/network/types.ts
@@ -4,6 +4,44 @@
 import type { ErrorEvent as WSErrorEvent } from 'ws'
 import { WebSocketClient } from './webSocketClient'
 
+export enum SubProtocolType {
+  Internal = 0,
+  PeerDiscovery = 1,
+  Sync = 2,
+}
+
+export enum InternalSubProtocolMessageType {
+  Identify = 0,
+  Disconnecting = 1,
+  SignalRequest = 2,
+  Signal = 2,
+}
+
+export enum PeerDiscoverySubProtocolMessageType {
+  PeerListRequest = 0,
+  PeerList = 1,
+}
+
+export enum SyncSubProtocolMessageType {
+  CannotSatisfyRequest = 0,
+  GetBlockHashesRequest = 1,
+  GetBlockHashesResponse = 2,
+  GetBlocksRequest = 3,
+  GetBlocksResponse = 4,
+  PooledTransactionsRequest = 5,
+  PooledTransactionsResponse = 6,
+  NewPooledTransactionHashes = 7,
+  NewTransactions = 8,
+  NewBlockHashes = 9,
+  NewCompactBlock = 10,
+  GetBlockTransactionsRequest = 11,
+  GetBlockTransactionsResponse = 12,
+  GetCompactBlockRequest = 13,
+  GetCompactBlockResponse = 14,
+  GetBlockHeadersRequest = 15,
+  GetBlockHeadersResponse = 16,
+}
+
 export enum NetworkMessageType {
   Disconnecting = 0,
   CannotSatisfyRequest = 1,


### PR DESCRIPTION
## Summary

Given we'll be restructuring messages to be part of various sub-protocols, it would be helpful to include the sub-protocol ID along with the message ID in the network message header. At the cost of an additional byte per message, this will allow us to have independent message IDs per-protocol -- when using a single global message ID, the messages from different sub-protocols can be mixed (for example, messages from sync might be 1 and 2, then messages from peer discovery might be 3 and 4, followed by messages from sync at 5 and 6).

It'll be nice to have this backward-compatible to test on the testnet prior to mainnet launch. So in this branch, if we detect a node on a newer network version, we'll send both the sub-protocol and message ID, otherwise for older nodes, we'll just send the old message ID. We'll plan to make a breaking change to remove this code and add sub-protocol + message ID to the Identify message prior to mainnet.

## Testing Plan

Tested this with two nodes on this branch connecting to each other to check that sub-protocols and message types are sent, and tested connecting to 0.1.68 to check that only message types (and not sub-protocols) are sent.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
