### PR TITLE
Update CLI import prompt

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -150,9 +150,12 @@ export class ImportCommand extends IronfishCommand {
   }
 
   async importTTY(): Promise<AccountImport> {
-    const userInput = await CliUx.ux.prompt('Paste the output of wallet:export', {
-      required: true,
-    })
+    const userInput = await CliUx.ux.prompt(
+      'Paste the output of wallet:export, or your spending key',
+      {
+        required: true,
+      },
+    )
 
     return await this.stringToAccountImport(userInput)
   }

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -30,7 +30,7 @@ export class ImportCommand extends IronfishCommand {
       name: 'blob',
       parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
-      description: 'The copy-pasted output of wallet:export',
+      description: 'The copy-pasted output of wallet:export; or, a raw spending key',
     },
   ]
 


### PR DESCRIPTION
## Summary
`wallet:import` doesn't just accept the output of `wallet:export`, it'll also accept a raw spending key. Update the prompt to reflect this.

## Testing Plan
Cosmetic prompt change, just leaning on unit tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
