### PR TITLE
changes burn to use new utils

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -4,19 +4,19 @@
 import {
   BufferUtils,
   CreateTransactionRequest,
-  CreateTransactionResponse,
   CurrencyUtils,
+  RawTransaction,
   RawTransactionSerde,
-  RpcResponseEnded,
   Transaction,
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import inquirer from 'inquirer'
 import { IronfishCommand } from '../../command'
-import { IronFlag, parseIron, RemoteFlags } from '../../flags'
-import { ProgressBar } from '../../types'
+import { IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
+import { promptCurrency } from '../../utils/currency'
+import { selectFee } from '../../utils/fees'
 import { doEligibilityCheck } from '../../utils/testnet'
+import { watchTransaction } from '../../utils/transaction'
 
 export class Burn extends IronfishCommand {
   static description = 'Burn tokens and decrease supply for a given asset'
@@ -73,40 +73,47 @@ export class Burn extends IronfishCommand {
       allowNo: true,
       description: 'check testnet eligibility',
     }),
+    offline: Flags.boolean({
+      default: false,
+      description: 'Allow offline transaction creation',
+    }),
+    watch: Flags.boolean({
+      default: false,
+      description: 'Wait for the transaction to be confirmed',
+    }),
   }
 
   async start(): Promise<void> {
     const { flags } = await this.parse(Burn)
-    const client = await this.sdk.connectRpc(false, true)
+    const client = await this.sdk.connectRpc()
 
     if (flags.eligibility) {
       await doEligibilityCheck(client, this.logger)
     }
 
-    const status = await client.getNodeStatus()
-    if (!status.content.blockchain.synced) {
-      this.log(
-        `Your node must be synced with the Iron Fish network to send a transaction. Please try again later`,
-      )
-      this.exit(1)
+    if (!flags.offline) {
+      const status = await client.getNodeStatus()
+      if (!status.content.blockchain.synced) {
+        this.log(
+          `Your node must be synced with the Iron Fish network to send a transaction. Please try again later`,
+        )
+        this.exit(1)
+      }
     }
 
-    let account = flags.account?.trim()
+    let account = flags.account
     if (!account) {
       const response = await client.getDefaultAccount()
-      const defaultAccount = response.content.account
 
-      if (!defaultAccount) {
+      if (!response.content.account) {
         this.error(
           `No account is currently active.
            Use ironfish wallet:create <name> to first create an account`,
         )
       }
 
-      account = defaultAccount.name
+      account = response.content.account.name
     }
-
-    const confirmations = flags.confirmations
 
     let assetId = flags.assetId
 
@@ -115,7 +122,7 @@ export class Burn extends IronfishCommand {
         action: 'burn',
         showNativeAsset: false,
         showSingleAssetChoice: true,
-        confirmations,
+        confirmations: flags.confirmations,
       })
 
       assetId = asset?.id
@@ -125,186 +132,113 @@ export class Burn extends IronfishCommand {
       this.error(`You must have a custom asset in order to burn.`)
     }
 
-    let amount
-    if (flags.amount) {
-      amount = flags.amount
-    } else {
-      const input = await CliUx.ux.prompt('Enter the amount to burn in the custom asset', {
+    let amount = flags.amount
+    if (!amount) {
+      amount = await promptCurrency({
+        client: client,
         required: true,
-      })
-
-      amount = await parseIron(input, { flagName: 'amount' }).catch((error: Error) =>
-        this.error(error.message),
-      )
-    }
-
-    let fee
-    let rawTransactionResponse: string
-    if (flags.fee) {
-      fee = CurrencyUtils.encode(flags.fee)
-      const createResponse = await client.createTransaction({
-        account,
-        outputs: [],
-        burns: [
-          {
-            assetId,
-            value: CurrencyUtils.encode(amount),
-          },
-        ],
-        fee: fee,
-        expiration: flags.expiration,
-        confirmations: confirmations,
-      })
-      rawTransactionResponse = createResponse.content.transaction
-    } else {
-      const feeRatesResponse = await client.estimateFeeRates()
-      const feeRates = [
-        feeRatesResponse.content.slow ?? '1',
-        feeRatesResponse.content.average ?? '1',
-        feeRatesResponse.content.fast ?? '1',
-      ]
-
-      const feeRateNames = Object.getOwnPropertyNames(feeRatesResponse.content)
-
-      const feeRateOptions: { value: number; name: string }[] = []
-
-      const createTransactionRequest: CreateTransactionRequest = {
-        account,
-        outputs: [],
-        burns: [
-          {
-            assetId,
-            value: CurrencyUtils.encode(amount),
-          },
-        ],
-        expiration: flags.expiration,
-        confirmations: confirmations,
-      }
-
-      const allPromises: Promise<RpcResponseEnded<CreateTransactionResponse>>[] = []
-      feeRates.forEach((feeRate) => {
-        allPromises.push(
-          client.createTransaction({
-            ...createTransactionRequest,
-            feeRate: feeRate,
-          }),
-        )
-      })
-
-      const createResponses = await Promise.all(allPromises)
-      createResponses.forEach((createResponse, index) => {
-        const rawTransactionBytes = Buffer.from(createResponse.content.transaction, 'hex')
-        const rawTransaction = RawTransactionSerde.deserialize(rawTransactionBytes)
-
-        feeRateOptions.push({
-          value: index,
-          name: `${feeRateNames[index]}: ${CurrencyUtils.renderIron(rawTransaction.fee)} IRON`,
-        })
-      })
-
-      const input: { selection: number } = await inquirer.prompt<{ selection: number }>([
-        {
-          name: 'selection',
-          message: `Select the fee you wish to use for this transaction`,
-          type: 'list',
-          choices: feeRateOptions,
+        text: 'Enter the amount of the custom asset to burn',
+        minimum: 1n,
+        balance: {
+          account,
+          confirmations: flags.confirmations,
+          assetId,
         },
-      ])
-
-      rawTransactionResponse = createResponses[input.selection].content.transaction
+      })
     }
 
-    const rawTransactionBytes = Buffer.from(rawTransactionResponse, 'hex')
-    const rawTransaction = RawTransactionSerde.deserialize(rawTransactionBytes)
+    const params: CreateTransactionRequest = {
+      account,
+      outputs: [],
+      burns: [
+        {
+          assetId,
+          value: CurrencyUtils.encode(amount),
+        },
+      ],
+      fee: flags.fee ? CurrencyUtils.encode(flags.fee) : null,
+      expiration: flags.expiration,
+      confirmations: flags.confirmations,
+    }
 
-    if (!flags.confirm) {
-      this.log(`
-You are about to burn:
-${CurrencyUtils.renderIron(
-  amount,
-  true,
-  assetId,
-)} plus a transaction fee of ${CurrencyUtils.renderIron(
-        rawTransaction.fee,
-        true,
-      )} with the account ${account}
-`)
-
-      if (!flags.rawTransaction) {
-        this.log(`* This action is NOT reversible *\n`)
-      }
-
-      const confirm = await CliUx.ux.confirm('Do you confirm (Y/N)?')
-      if (!confirm) {
-        this.log('Transaction aborted.')
-        this.exit(0)
-      }
+    let raw: RawTransaction
+    if (params.fee === null) {
+      raw = await selectFee({
+        client,
+        transaction: params,
+      })
+    } else {
+      const response = await client.createTransaction(params)
+      const bytes = Buffer.from(response.content.transaction, 'hex')
+      raw = RawTransactionSerde.deserialize(bytes)
     }
 
     if (flags.rawTransaction) {
-      this.log(`Raw transaction: ${rawTransactionResponse}`)
-      this.log(`\nRun "ironfish wallet:post" to post the raw transaction. `)
+      this.log('Raw Transaction')
+      this.log(RawTransactionSerde.serialize(raw).toString('hex'))
+      this.log(`Run "ironfish wallet:post" to post the raw transaction. `)
       this.exit(0)
     }
 
-    const bar = CliUx.ux.progress({
-      barCompleteChar: '\u2588',
-      barIncompleteChar: '\u2591',
-      format: 'Creating the transaction: [{bar}] {percentage}% | ETA: {eta}s',
-    }) as ProgressBar
-
-    bar.start()
-
-    let value = 0
-    const timer = setInterval(() => {
-      value++
-      bar.update(value)
-      if (value >= bar.getTotal()) {
-        bar.stop()
-      }
-    }, 1000)
-
-    const stopProgressBar = () => {
-      clearInterval(timer)
-      bar.update(100)
-      bar.stop()
+    if (!flags.confirm && !(await this.confirm(assetId, amount, raw.fee, account))) {
+      this.error('Transaction aborted.')
     }
 
-    let transaction
+    CliUx.ux.action.start('Sending the transaction')
 
-    try {
-      const result = await client.postTransaction({
-        transaction: rawTransactionResponse,
-        account,
-      })
+    const response = await client.postTransaction({
+      transaction: RawTransactionSerde.serialize(raw).toString('hex'),
+      account,
+    })
 
-      stopProgressBar()
+    const bytes = Buffer.from(response.content.transaction, 'hex')
+    const transaction = new Transaction(bytes)
 
-      const transactionBytes = Buffer.from(result.content.transaction, 'hex')
-      transaction = new Transaction(transactionBytes)
+    CliUx.ux.action.stop()
 
-      const assetResponse = await client.getAsset({ id: assetId })
-      const assetName = BufferUtils.toHuman(Buffer.from(assetResponse.content.name, 'hex'))
+    const assetResponse = await client.getAsset({ id: assetId })
+    const assetName = BufferUtils.toHuman(Buffer.from(assetResponse.content.name, 'hex'))
 
-      this.log(`
-Burned asset ${assetName} from ${account}
-Asset Identifier: ${assetId}
-Value: ${CurrencyUtils.renderIron(amount)}
-
-Transaction Hash: ${transaction.hash().toString('hex')}
-
-Find the transaction on https://explorer.ironfish.network/transaction/${transaction
+    this.log(`Burned asset ${assetName} from ${account}`)
+    this.log(`Asset Identifier: ${assetId}`)
+    this.log(`Amount: ${CurrencyUtils.renderIron(amount)}`)
+    this.log(`Hash: ${transaction.hash().toString('hex')}`)
+    this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
+    this.log(
+      `\nIf the transaction is mined, it will appear here https://explorer.ironfish.network/transaction/${transaction
         .hash()
-        .toString(
-          'hex',
-        )} (it can take a few minutes before the transaction appears in the Explorer)`)
-    } catch (error: unknown) {
-      stopProgressBar()
-      this.log(`An error occurred while burning the asset.`)
-      if (error instanceof Error) {
-        this.error(error.message)
-      }
-      this.exit(2)
+        .toString('hex')}`,
+    )
+
+    if (flags.watch) {
+      this.log('')
+
+      await watchTransaction({
+        client,
+        logger: this.logger,
+        account,
+        hash: transaction.hash().toString('hex'),
+      })
     }
+  }
+
+  async confirm(
+    assetId: string,
+    amount: bigint,
+    fee: bigint,
+    account: string,
+  ): Promise<boolean> {
+    this.log(
+      `You are about to burn: ${CurrencyUtils.renderIron(
+        amount,
+        true,
+        assetId,
+      )} plus a transaction fee of ${CurrencyUtils.renderIron(
+        fee,
+        true,
+      )} with the account ${account}`,
+    )
+
+    return CliUx.ux.confirm('Do you confirm (Y/N)?')
   }
 }


### PR DESCRIPTION
## Summary

updates the burn command to use new utils: promptCurrency, selectFee, watchTransaction

makes the burn command consistent with changes to send and mint

adds 'offline' and 'watch' flags to burn


## Testing Plan

ran a couple of `burn`s

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
