### PR TITLE
Revove default flag on AccountFixture

### DIFF
--- a/ironfish/src/mining/manager.test.slow.ts
+++ b/ironfish/src/mining/manager.test.slow.ts
@@ -18,7 +18,8 @@ describe('Mining manager', () => {
   it('creates a new block template', async () => {
     const { chain, miningManager } = nodeTest.node
 
-    const account = await useAccountFixture(nodeTest.node.wallet, 'account', true)
+    const account = await useAccountFixture(nodeTest.node.wallet, 'account')
+    await nodeTest.node.wallet.setDefaultAccount(account.name)
 
     const block = await useMinerBlockFixture(chain, 2)
     await expect(chain).toAddBlock(block)
@@ -39,7 +40,8 @@ describe('Mining manager', () => {
     const { node, chain } = nodeTest
     const { miningManager } = node
 
-    const account = await useAccountFixture(nodeTest.node.wallet, 'account', true)
+    const account = await useAccountFixture(nodeTest.node.wallet, 'account')
+    await nodeTest.node.wallet.setDefaultAccount(account.name)
 
     const previous = await useMinerBlockFixture(chain, 2, account, node.wallet)
     await expect(chain).toAddBlock(previous)

--- a/ironfish/src/rpc/routes/mining/blockTemplateStream.test.slow.ts
+++ b/ironfish/src/rpc/routes/mining/blockTemplateStream.test.slow.ts
@@ -47,7 +47,8 @@ describe('Block template stream', () => {
     const { chain } = routeTest.node
     routeTest.node.config.set('miningForce', true)
 
-    const account = await useAccountFixture(node.wallet, 'testAccount', true)
+    const account = await useAccountFixture(node.wallet, 'testAccount')
+    await node.wallet.setDefaultAccount(account.name)
 
     // Create another node
     const nodeTest = createNodeTest()

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -38,7 +38,7 @@ describe('Accounts', () => {
     const node = nodeTest.node
     const chain = nodeTest.chain
 
-    const account = await useAccountFixture(node.wallet, 'test', true)
+    const account = await useAccountFixture(node.wallet, 'test')
     await node.wallet.updateHead()
 
     // Initial balance should be 0
@@ -76,7 +76,7 @@ describe('Accounts', () => {
     const node = nodeTest.node
     const chain = nodeTest.chain
 
-    const account = await useAccountFixture(node.wallet, 'test', true)
+    const account = await useAccountFixture(node.wallet, 'test')
 
     // Initial balance should be 0
     await expect(node.wallet.getBalance(account, Asset.nativeId())).resolves.toMatchObject({
@@ -144,7 +144,7 @@ describe('Accounts', () => {
     const node = nodeTest.node
     const chain = nodeTest.chain
 
-    const account = await useAccountFixture(node.wallet, 'test', true)
+    const account = await useAccountFixture(node.wallet, 'test')
 
     // Initial balance should be 0
     await expect(node.wallet.getBalance(account, Asset.nativeId())).resolves.toMatchObject({
@@ -215,7 +215,7 @@ describe('Accounts', () => {
     const node = nodeTest.node
     const chain = nodeTest.chain
 
-    const account = await useAccountFixture(node.wallet, 'test', true)
+    const account = await useAccountFixture(node.wallet, 'test')
 
     // Initial balance should be 0
     await expect(node.wallet.getBalance(account, Asset.nativeId())).resolves.toMatchObject({
@@ -293,7 +293,7 @@ describe('Accounts', () => {
 
   it('throws a ValidationError with an invalid expiration sequence', async () => {
     const node = nodeTest.node
-    const account = await useAccountFixture(node.wallet, 'test', true)
+    const account = await useAccountFixture(node.wallet, 'test')
 
     // Spend the balance with an invalid expiration
     await expect(
@@ -320,7 +320,7 @@ describe('Accounts', () => {
     const node = nodeTest.node
     const chain = nodeTest.chain
 
-    const account = await useAccountFixture(node.wallet, 'test', true)
+    const account = await useAccountFixture(node.wallet, 'test')
 
     // Mock that accounts is started for the purposes of the test
     node.wallet['isStarted'] = true
@@ -407,7 +407,7 @@ describe('Accounts', () => {
     // // Mock that accounts is started for the purposes of the test
     node.wallet['isStarted'] = true
 
-    const account = await useAccountFixture(node.wallet, 'test', true)
+    const account = await useAccountFixture(node.wallet, 'test')
 
     // Create a second account
     await node.wallet.createAccount('test2')


### PR DESCRIPTION
## Summary

We don't need this except for 1-2 places so we can just set the account as default.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
