### PR TITLE
Fix mempool transaction expiry bug

### DIFF
--- a/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
@@ -1622,5 +1622,165 @@
         }
       ]
     }
+  ],
+  "MemPool when a block is connected with a transaction in the mempool removes expired transactions from the mempool even if there are 0 expiration transactions": [
+    {
+      "version": 1,
+      "id": "33674959-e0fd-48c6-878a-365b965fd7c1",
+      "name": "accountA",
+      "spendingKey": "c5ba00a84dfcf9404c0c5984e384a677d262b454ed18bb30327b6e50ddd3757f",
+      "viewKey": "e071587418be87af1c8bcb370a4c3f087b1676e6b90d0941feadd1987fe8e89cb087a2cedf2938a31f3e108d8ee67aec5a9d2523de807ab9c5f940bbd43bcc88",
+      "incomingViewKey": "bdcda32828e29995776286ca28b28007bd4b4d03dabcae4e6f12ecc707e5eb00",
+      "outgoingViewKey": "21e1c852068e6b100e3006f9906b5a3e87e4aa6f642127102c38d2a70cffea84",
+      "publicAddress": "7934d3462aad043e32e16c0e58d5c9d2875a30c7a13b977cd22d4eb81ac0ab45"
+    },
+    {
+      "version": 1,
+      "id": "f80acc7d-b1de-400f-b6d9-0d6cce58d038",
+      "name": "accountB",
+      "spendingKey": "3e65efb6a4bdeb72ec5a8e2abe2e31dfc54a250cc447a5d37880430930288ff2",
+      "viewKey": "67426b4d03d67d9bbfa7bd752ae90ef0ea5b74f5e69d244af1ae6ef992193402301b4863de19bbf3b0f14c2bd9d5eead18cf45b9fefdf2dd3090671a489568e8",
+      "incomingViewKey": "db3dd0a4d0ef50a8ba8f68433dc951018d881281b9d32df7bc8b7b0af3735b07",
+      "outgoingViewKey": "bcfe5610ba1cbb2d2d9015dfc346545cf5de21fb7a06db24a768f10447d88d2f",
+      "publicAddress": "cf868ec6fd56d68190d7e9d9339658e652b69a85d89418e187dc9531e425ef12"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Y38UaSmcu0XwXhqTdJe8uLSjwS9+u4vFV8nn2EApOEE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:vzWTBRcRyFa+iSxcAeZcOyqeb3K2ALYZbtP/hyrirl4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1677200593214,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAd6FC/LtGGzJ9x/wlZ/yYqD1GLnriViWlLYTuu2rK/EGtQvwkCZjKiRlg7u7dyFRJMHq5hwF19wBZMLgQuS7V9Aetxey6PK5CfYsdkuyuJSqJLH5KCnbPCGfdpc2BYiOt6jKeAdhLXOX/sntwF8aXNbJDJlcEunXdY2c8+zcqINoV5DCiWpON+tAR08Y/P2zVPl7jAkuJHocFb9osnX/qA2FknSBddm/rsRgvqQ/35b6xtlX6l+aZ9rNQeWB0pK8nxwVCNN3wchObmaNaiqnz6EqzI0fR/5eXy/hmz/a2gHAjeVSg/nbT2ml2VK+Kiy3NSdyt3uiUO1KXtUX11n9VK+d5kV4gruQf0BJS8wilKdiau3lZyq1ZZjZXXl2zZYs3Ms6bhyb/9gWdXR5tH44II3371h9sIgRBT9gsEcepqZuWf4uY8Gb1byF/dRwBkDRAqjdkcH97ZmtYav67C1L1R8W3BpfXBg1x8yQ3OjzywU9Vribb1H2wIWq+4qrCOeyWBljYkc5yvTh1D3dItMnioBmfPrXo3Ox0gvHzu0usfjagHe4c0ZPALlv7fmbMGDuYw+SeFx+lIIv70jn7qbovAva97Pii+D1ejgC5WTKQYLgji1MPCbIfnklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwVEKjRb2Rx1vkJNlQbPjrQScan6mI0iFnXb9RNPeNEEEHoafHLjwzOgab0ETX7+SbuHvzbzW75Ojazkb1hpwsBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "7D329D7FE26C6A5535C176F455DA70C84EA741B4382F5EE06B756FD2E4C07C4F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZAU6fOMALV5quy3mpD/qi7IzNEAf/Bk/L5NhLC7Rk2A="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:4gXNhL9jF6Nc0cnGaf7L+4TeWOR27LMnDqIibk2qaT8="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1677200595162,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAaVWwRWEdUmZbQYpk+79YNI/r9DZJi5+awil8FLC1PoKAZnnbup7XVFWobXaMfZz2GiLxuRrPl+tzoUOLbDXu8ClQbrSjhYHW1C165viS/5yFGmw5DirrZFqIhAf0pUiYZ60/wyX83QX3kv2U5oXlPRVp+zJd2hKk1ONjMvfU22cCp/jDcMOXmzVL0Z9deNAddUGPKD+OyZT8Pk7gutPm29253DEAJ83bKe52H8jGNuuJf3pUk6ZxLB3QyQb4Zh6CoyCHTnzbAjJVo5tjSGbxUcVaPNM96HN17Qspmy4BcxGacxJnlL6gtWaJWy/+Wf3GjnYlHt0kHaqjO3yHB+v7v1YS6j9DPAKMcWa+jqJ7ufk9SJe0wWgeHuP/2c2Fmf4Dsv/6rBnPaaZ6PQfRVtsCDqgVzCueJZqInyOJrnZuDqe6JgFZ4nkp4pAPkIYMjHdBpAbrrYj/lWZQF5qF4zwJoHhSlWZqPnJwexPjqzbXo7NDztGtbEtJj7Kguf0itHd14oTGhcLHoYNE5mBtoI22NCnrpJwmuJae+CLEKP5KwT/6CwMjxAIoj8RBL23mSBfgJfMwOCDO7iAIvm79I+yPag6yvqHRj5gXswFNX8momK45eU0HvR7hQElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwn3T1YjEVb+UCTkH++K+3cYFScP8GERZLzT+ejo+cMsbitu4Px2ZY5qRbZJQIO5RPgpHMhtHQIoKtJDHTwHBFCw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAEAAAAV84n8gK29UxCRvB6CMev8+bX0dvGfw/jCvGHoGnzKcWTkpQhaZIKQ7JIOxYvnXvvLP5o5TKeGdhjh8iuIQaGos7iiyZQGI91i0USQXsKyKGCnEbk7HC9wVsX7q9Zc6c6OHwXuZM0bizDQmhITdSuAi8GIob2R7ow9JU9u2smJhAW1CH/AGJS/y6akXFmAIcKi1Qf8hcs81IEj/bmA9tJCmODzuOodG8NbJC1fJYmYxCMBwTH59pffHhVdKFEInDpJQ2cWudKn0Cz/b6rn/7cXhuVS0l8Mnt6P38A4rrzvGh6jsZUIbiBewDm3BRCS9DCJ4i99qRbKsRgyJZKZEW+kWN/FGkpnLtF8F4ak3SXvLi0o8EvfruLxVfJ59hAKThBBAAAAA4v3AVbUEgFRvo4BMpVXY9OIVwd3wHWONZIyH4m6owpydJ14+Py8/6XpTdFJLv7ZnDuUXK9JzLQrJRSQhRDtc3oldDY/dh0bImvgYIZZ0uiKzLQ1DkHXQvH96ER9jQTAosWqr6ipJU6ZETikgcjhvm2ktZNc/O6n9x7k+Qb53ogr0hFEVp7svm2zY789i7Ec4YpgbtZw1N89kSfsXfZCHR+Hkhk+yypJn8gOfYUxJOci/FZy6p6Py29NpFS4tqMjhXrCyrmWN4by3a2H8tABPDkWclkM2sVtGGQev423YC4baP2COcg3eb4EavIzlH9TYlOE9voWbaFb3P0gjPRYitSRga+9UeGQR3QyybabVTsbt8QqHiNwsK9O9ZYFEyh8u+85YppH49JRutRbR8V1zneb2r2XKhGt5m7REKO+9shTWDEwV/jUxOuZgYNHvSlvFxJdsKccyCi3czINWzE6UtFSnMUDXNvswpIlAzS/chKLrCJSLajl5/FaKBUl7n8AI+gOBAlLc5Kz4NKh5xi/6kspCMTm8sA1yK8l2z9oicothF//KGZlmULYpZGQifOfbmvZY9t8IZSaiXC1k0igK/r259XhjNDFki2/lezJjKdnjTm9DGASaAYisA1SWIl5D9x8qw8SqPmGS5g6Sf2uZOTtptWPuhwW0E1KgAwHNqeaWmGmQ1ZV/nZ72qDl/9uH1MYaNBTVHuSEQ6oSAfz9jTnZgvOJofn8CIycnW3cfn6ZCXRshG0TP9+uCBEeizicTRFNZKaMbo+Za3X7HgA/0RRyK83w3MSEDh+wyJjUFAb/XFS9SPfA9CDmPinYp1KptxBIs4vcJBtr5trTXNMY3+mjDMMByzKTzVSFsCV8RDOLuCSKrqRi+mCvnA9ZvQ94fuf55zEXIeeor1+cs5g/XsR1GUj22+4apTTzjyjqKgWVVXkVj89wMMXB8bPYqI4VoVNO1h4qLCfXRoQVnMF8c9+wCLq4EXxIvNjKW59ioHK2ODbz2kjm36H05aJqlwovpeNlhcFM9bDS7yX6/xEZPzDJCVzF9y5U6Um8lZe3i8qiZl7WKikQFDYh7UWTAGhVC5Or+MYYxapC7Dl6YHbs2/JSx9VP5rlb+/A5t2lWcsHMwpcAsdJ/iBvsJ7GwxrFpPSYWTo+NlxaNkwaSyR5x4XAMNZ/VEBWapq3aU7bh19us10vk3c6+lJXwD0H5i0B2nJ96wd6k9qP6YoFDaK0ZZAN642JW5OaKbiK4BuDt55NlRFC3aJYuOuQjNXlD1jXJnFptzXX901KSWQEj6F5Ig9g9FselEql53BA5rsV61PnqUAeuUSE0AjQqN8KqTMcS3U5OlZqAZV3cIj337pCMF96QH4FckEPVfyQs6XltgRqXSzZfnaF4vtrdWoD4GYdoDzFC86vJyh5yEopgcUJvz0KmNav7BTdS3JSyv+mzRl2HQ1+h2zssbRMW9xWKL6wGvmcIwovfcfcyo+cCLPjPY1yELpDrAfK5rg0tZ0L3Y+kNXj0NX8KropyMoJ+acM9C2ss4kX36PCBRgfxqPgkd+1jfF26VgLkooAoXiBGAGWTqs7Yb92TlPZ8oT/a2CrUAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "7D329D7FE26C6A5535C176F455DA70C84EA741B4382F5EE06B756FD2E4C07C4F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:HPw+0p/MeoEl8F0AUFRm4hVlqZS8hm3rVCiPmLrHdkg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:MOxLVnFXwMyybxTl/Xr6QuBT9YgtUVofnVCZLrRrHE8="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1677200595497,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAHbE4NQwi1TB349W1Dfuo42vSCUwpqgBKbdEu1sqITgyv0hEoXMwsIUViIantjlZMA7IAJTvNcjUKO9/JiTNnYFZVWOoX/u9Cu1fDGN7zdEeSYhSnoYLiPIUoDPYJTq6HZg3Zu8u7svEoObpv1kVLnSloOuy5ac21b8WeLJXlSigLUZFJ0nkfxL7zl9RPO14kDfrawWe49eV5S1HGwv+7Kh9GDkBTyZj/idSqCko7HY2jN+E1phPYP2ou+jnUCx/57Phv26OmI6QExZvW0r0a+RfyQnmEMkovmoAUoqd07y9Y39n9gOb8Oo40p8pIF7u3B8wwEu4/u0gDyAAsWBPjM9HyUnjN/wmqrAfixdG7J/EGi5TP73MlQXvNb8ZtruUL7V27k9c0gD6Hd2Q9NOYPGW7nfn5o9u9aYaxyNEwowylI32f8MD6A8Q/wol40Qse80vO9FQxYSoB54rfk36EbB6congBwcuBXJUJaGRAr7z0Bmpcc7T8eDx7f0rU/wSp50Z5ew4zO2WOEFviUMw1WDYVyi8MMFzfcHt598ZOU/21aX4tWWpZQg7zBCZx8AMahDNaMc6K1Rq3IcKcq60vmdNCnsQwwHAycK47HQ4o2H6KGbQqczPxqYklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIkmB3+4HJWIKHP+BU23VsQ4CDlp617E1l+keAqUOyiFihuyfBJRU13VWt0nlNh0BEqooRUKv3yhjlDl9vy//Bw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "C09CC258DA20CCA62CADE6EB4EFE14B95DD51EFDEEDC27FA19F773B8521B1781",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:cePfVThZzSYtxl+lXAxWVilccnZCBDJIAstU49yfz0g="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZxOgxbGpUZ0+KdUQ0HusDMdMgV/XOYoKcylqU0hoFsM="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1677200597130,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAA7FgssQ6oQgxoTTHcOZ1/uPKbr9AjEE2h877Nw8Tl2r+t3mZPQVkdSj4gSD5W4wDk6MyrCg323tx45nzGggyzqjaggW4ORZLjvLMj4F1FrN21qG9XJzLnjH07o5K/ceZTqRcDyCCLnBYZAIk7JWzj24WI+0n1MVJEQENOCDubwRAR7geig4rQNdZgSU6NCrJrFFu6WbP+1s9Xc72mW3pxIz5qiq/UoAtPQ5GgPoOMlLCXG9qZ9HZHCcrsCkkvYwK9kXjdCwI/dtDibKTyGjnUwNa65EsNGS9POCnULHXz4Vv8QxU7nknYKKQlu2dnoVWF5Gf+XPou43mL7piAwnnIbBKB7DQev9vb0eFPy9fbMQ9nmUdezSkdV0IbQoj27zYrwHtfvD1iJZXTACrlEY0xzkZPUQgDHoWhxumLIxMO4Snq7zX7TI1/gSVzRNzj6+Bt21NLM+cPG1p3eKRn7QpbG6E/r69g9wydeZOKyDVzy06zT3H9mGit+Pk7a7rjGBKuPGL357Q+g8NDyDj6PFqoqc9SZqEfN8KJY0LsHb6lw8vyMyZh2TCz6fjmBQzOuk9Pxrah8WluVLDuiIs095HMrDyq5NxbEdSOXolNXgPe0Fy0G8lc2PtttElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXl7oE9WjEm6Cd7Ozzwl4Dvfq0I61oCK7a6/k+TuxBGQ4UxOzSN1CGoCkN502SOGpc30CPJvok8QkZcaogzWiAA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAARjGc6rWEpvX3shD90H+o8wVizKz74utJODvZ0j2xKnG2NhY/hKJciUZKD2XvrolGnW3zc02Y2wt5qMXcrgLKdOmwA85tUNaDdY1YMvQn5iSOR+6+psb/EwtZrKWTVOJncDvtzlh5wsEAhpvhQIq55/U6rsdyeOuFX5Thn27XNvIEqKyCe9HP4WaIkLEi6DHdDPVssMCg6+Ow2yafSnNga8H0j+sMkyg6ixT3WiEcoH2RmVvcLiMrCLfiQl40bLIduW9zw7zEKZEzs+wX1PzDvdZrQ2EKj8w1fMoo0A6IFwGCsuVKzWkWa6ZwOUqCd5eMNULfX4N9F/s5ucn5Iqezmhz8PtKfzHqBJfBdAFBUZuIVZamUvIZt61Qoj5i6x3ZIBQAAAPw+cRE7ph7TGt6d/s/3TgNhkwM6JHYS9SvX/7S5hq7FeeunwKZbhI6Rg+E+G8YE+959OuB1/77Cu7kLHSoW3Dbt64T3+TVGjggCeJlzppe+XVi9aD05w96/TUh8MShVAri5VTfY8ymxi9UFXD+2PRfl4DVds9TufzadL1VAkpi/XPnC+7VPF/ehKnI0iguYh47NF/szo0m0utZeC2f0iMw6mBEjlW1bcrBJ/vjBQXgqvEAa4pRS+ZFeY6oUMeNuigk7Ntq6F0p15phLOCLnCp5Ka7HVkvzT2CQtNRGBYezTJVZfim9Uxf2JXa0Xi5hV45YrJn7mb+rKTD+KkFqdkn+EugbuF7nFoBkQB/s+/5doaj9LJxkBFRTX2s5S/bt16E1bdBz7ccMIOBndzEDWZWAKrU6dA1NM/eL15Y3+7Hbpxhxp2IT9ywrogTHTmBv+NtJcPO+sN+ossD1uS98ZHWQVDlgyFhLGdT2ksdLrhmOClrl9kPmKmWq59QgvXCNRuCnOclq/wCtichrKPZFm11dbK5Fo0oKtm+jwemldWFPFI9TNB0fECI2H2wxwMv/wL3jZIG7/eCz9+oMidvAnXYNG4sOPQQkoEcdb4KaSA2nbjoURxxgNy5UWfaCQUGIwDTYse64xbf3wNRw1pygtXovNwoae40DVTQf3Ed4Uz2T44PVjkNtkvRybfPZ3q26IhQPk5PNlvMr2zRZ/1obNSFFk6TkJMHyDpGAqi+6t3YvFkZOICJ23rnyQmmyzVLwTis8rJapeayQlK9tJOg0ZWdZcFqZhUO6OpeMNTLLgT6q+FSxBgdr/9kWYGOa98o7SgfOBbxTyLblFUdNBTq43d9fWIsjln36fCbyeOLU+tHVi/oKOQ62N7DmpvdaZxvE+Eniam32L/WGYcHko0UJZEKmOKbcApOzY+fjT3sc4FUw4WqIRYXlPYAIEmSOREyzJI4oOgtS2WPOnZjl+Q7i7RGwLPgcitgqcDSdIT+loydplkGAtRo0KR/mRdt0Ch8/47gBVgHZI2WuxefWvAYbKzXNATjc2qB7yNxllNzae4+GBgJDREqclsP2KP4C110Xl8DYFtk6X75HdcPoKU0DJ87cyt2tceSto4HnEnZFNixg+dmw9SYTIZRH0rhdwemUQVOM0QqNaJGgeRjStiZWW+Zl+IF2kdeUI1BjtPd9MJpddc0Et4xW34TjRexq5RY2GVXuEQDvSVX7+JLQ7Lx75xaIlZbDnq3Sg0lrz/P6ihuzUhcpB/6vOztJdoTpM8gXLTst3GFkPzm81VSCGj6InHcOm5usjPgxXLBAr9jjIBC0hh03TxzudhFOsIxjDA0aqUV7I4QWuojG1/qbFzdk5Q4N4jKE43NO9igRbbOnTiGikno5IKCoa5305KQQjn6KWfB0F4EpoKJ1k6K7SP24eHN4ev5jfPi1moo0ySLIVOawbgwPH5LrTiG+mTQ+qI2cI4c/mEn/0mSBU2W8Ou1NVJJ2GR3FItESi6xSc/CdlFNIonG1HmeibKxzTxaYuYOYWzJVIjxlmMSB75Th4dnxvjGGcqjEQNS2Zis+rTc57x6hsEvIeZKFIgVFnFCdwMQOsCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "C09CC258DA20CCA62CADE6EB4EFE14B95DD51EFDEEDC27FA19F773B8521B1781",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:0Zp6p1G6Q74sVeR4mqg/1ByjjJtO4OEEjWwz3hvXW3M="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:EQTIevr6Rti6aQYh7JO6MnpsryTzZjlc5TDk1StazSo="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1677200597427,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcKaM9bPUTem+SnwRsDiSDhXJRJw6fajgZASJmiKMY1iNluaLe2J5aDwGf/Ig76MV0CD+PIuz37VdexBaH8WoMGF5sGkkXUbR0JkKhqwDx6G19v15N0G01rVWaU7Z82OmDKXuzgWQGNNFRF5vnmYiJsdMZa9Ro0aHm7333IWg+eIIDIfdstGYJamOYbIv65xFnrqOn4OSOgzcOsvB/NW7Pbd+KH6evJKkE/tSVAgBP7ez8x+LHU1w9Ovw7OURrbTPOAI+q93fYwSbi0DOtObvV+KEE7u3pihXcDhhXJd54xIM0CARWPcb9Bf+cqdabfJzoyklgpxbZUpIyRS/Dk5BHIZ4kfNOjNu4L+4cgjMe8cO4aGKIl5FRxqxaD2dDMl1rB7fx1tPxi1MlCSTlvpPRopLdE3QQ6/mWAkSmDSDxRpxmQwj8QBfXUmahSMFgM1fALRG4CWh7/0RSZHeTOlfV6ZdgJHaLC7h2DmoXKLwWVRtXXMit5oTakT2r8hBgsyv5XZpdzAV6vl0INMBkm6uYqxoJBEDBGuSgbBxccpurrujfzUxs9AyECUqts/P2t36VQpOJzt4dgK/zj9WXeWZLp1Rtd0L8Z/VDxcNBa++C/LGn4Ldj5mgUsklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4rYFoznRGBEvytSrBA4x6MUnbfDVy6bpdItLEdVtjLrhyjXBh0gGivDmbS/PwiyTpgGtR2F0cYzjuTqD6q7SBg=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -63,7 +63,7 @@ export class MemPool {
     )
 
     this.expirationQueue = new PriorityQueue<ExpirationMempoolEntry>(
-      (t1, t2) => t1.expiration < t2.expiration,
+      (t1, t2) => (t1.expiration === 0 ? false : t1.expiration < t2.expiration),
       (t) => t.hash.toString('hex'),
     )
 

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -63,7 +63,7 @@ export class MemPool {
     )
 
     this.expirationQueue = new PriorityQueue<ExpirationMempoolEntry>(
-      (t1, t2) => (t1.expiration === 0 ? false : t1.expiration < t2.expiration),
+      (t1, t2) => t1.expiration < t2.expiration,
       (t) => t.hash.toString('hex'),
     )
 
@@ -240,7 +240,10 @@ export class MemPool {
     }
 
     this.queue.add({ hash, feeRate: getFeeRate(transaction) })
-    this.expirationQueue.add({ expiration: transaction.expiration(), hash })
+    // 0 expiration transactions cannot expire so don't add them to the expiration queue
+    if (transaction.expiration() > 0) {
+      this.expirationQueue.add({ expiration: transaction.expiration(), hash })
+    }
     this.metrics.memPoolSize.value = this.count()
     return true
   }


### PR DESCRIPTION
## Summary
We keep a PriorityQueue of transactions to expire when a new block is connected. They are ordered by lowest expiration sequence. However we also use an expiration sequence of `0` to indicate a transaction that never expires. These 0 expiration transactions were going to the top of the queue and when checking to see if the next transaction should be expired it would look at a 0 expiration and say that the transaction does not need to be expired. This was blocking other transactions that actually did need to be expired.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
