### PR TITLE
Download snapshots data from r2

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -21,7 +21,6 @@ import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
 import { SnapshotManifest } from '../../snapshot'
 import { ProgressBar } from '../../types'
-import { S3Utils } from '../../utils'
 import { UrlUtils } from '../../utils/url'
 
 export default class Download extends IronfishCommand {
@@ -35,9 +34,7 @@ export default class Download extends IronfishCommand {
       char: 'm',
       parse: (input: string) => Promise.resolve(input.trim()),
       description: 'Manifest url to download snapshot from',
-      default: S3Utils.getDownloadUrl('ironfish-snapshots', 'manifest.json', {
-        accelerated: true,
-      }),
+      default: `https://snapshots.ironfish.network/manifest.json`,
     }),
     path: Flags.string({
       char: 'p',


### PR DESCRIPTION
## Summary
Use r2 public domain when download snapshots data
## Testing Plan
```
yajun@Yajuns-MBP ironfish-cli % yarn start chain:download
yarn run v1.22.19
$ yarn build && yarn start:js chain:download
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-d
Download 5.64 GB snapshot to update from block 41703 to 54404?
At least 11.29 GB of free disk space is required to download and unzip the snapshot file.
Are you sure? (Y)es / (N)o: y
Cleaning up snapshot file at /Users/yajun/.ironfish/temp/ironfish_snapshot_1677186168233.tar.e
✨  Done in 212.66s.
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
