### PR TITLE
chore: upgrade ws websocket library

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -28,7 +28,6 @@
     "@types/inquirer": "8.2.5",
     "@types/node": "18.11.16",
     "@types/tar": "6.1.1",
-    "@types/ws": "7.4.5",
     "chai": "4.2.0",
     "cross-env": "7.0.3",
     "eslint-config-ironfish": "*",
@@ -77,8 +76,7 @@
     "segfault-handler": "1.3.0",
     "supports-hyperlinks": "2.2.0",
     "tar": "6.1.11",
-    "uuid": "8.3.2",
-    "ws": "7.5.1"
+    "uuid": "8.3.2"
   },
   "oclif": {
     "macos": {

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -41,7 +41,7 @@
     "sqlite": "4.0.23",
     "sqlite3": "5.0.4",
     "uuid": "8.3.2",
-    "ws": "7.5.1",
+    "ws": "8.12.1",
     "yup": "0.29.3"
   },
   "scripts": {
@@ -69,7 +69,7 @@
     "@types/mitm": "1.3.4",
     "@types/node-forge": "1.0.2",
     "@types/uuid": "^8.0.1",
-    "@types/ws": "7.4.5",
+    "@types/ws": "8.5.4",
     "@types/yup": "0.29.10",
     "@typescript-eslint/eslint-plugin": "4.28.1",
     "@typescript-eslint/parser": "4.28.1",

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -175,6 +175,7 @@ describe('PeerNetwork', () => {
       // Check that the disconnect message was serialized properly
       const args = sendSpy.mock.calls[0][0]
       expect(Buffer.isBuffer(args)).toBe(true)
+      Assert.isInstanceOf(args, Buffer)
       const message = parseNetworkMessage(args)
       expect(message.type).toEqual(NetworkMessageType.Disconnecting)
       Assert.isInstanceOf(message, DisconnectingMessage)

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -148,18 +148,12 @@ export class WebSocketConnection extends Connection {
     this.setState({ type: 'DISCONNECTED' })
 
     // Unbind event handlers, they can still fire with buffered inbound messages after
-    // the socket is closed
+    // the socket is closed. onerror is intentionally left intact, since it will
+    // trigger if a WebSocket is closed before the connection was established
     this.socket.onmessage = null
     this.socket.onclose = null
     this.socket.onopen = null
-    this.socket.onerror = null
 
-    // This can throw a "WebSocket was closed before the connection was established"
-    // error -- since we're closing the connection anyway, we can discard any error.
-    try {
-      this.socket.close()
-    } catch {
-      // Discard the errors
-    }
+    this.socket.close()
   }
 }

--- a/ironfish/src/network/webSocketServer.ts
+++ b/ironfish/src/network/webSocketServer.ts
@@ -37,5 +37,8 @@ export class WebSocketServer {
 
   close(): void {
     this.server.close()
+    for (const client of this.server.clients) {
+      client.terminate()
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4769,10 +4769,10 @@
     "@types/expect" "^1.20.4"
     "@types/node" "*"
 
-"@types/ws@7.4.5":
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.5.tgz#8ff0f7efcd8fea19f51f9dd66cb8b498d172a752"
-  integrity sha512-8mbDgtc8xpxDDem5Gwj76stBDJX35KQ3YBoayxlqUQcL5BZUthiqP/VQ4PQnLHqM4PmlbyO74t98eJpURO+gPA==
+"@types/ws@8.5.4":
+  version "8.5.4"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.4.tgz#bb10e36116d6e570dd943735f86c933c1587b8a5"
+  integrity sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==
   dependencies:
     "@types/node" "*"
 
@@ -11947,10 +11947,10 @@ write-pkg@^4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
-ws@7.5.1:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.1.tgz#44fc000d87edb1d9c53e51fbc69a0ac1f6871d66"
-  integrity sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==
+ws@8.12.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
+  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
 
 xml2js@0.4.19:
   version "0.4.19"


### PR DESCRIPTION
## Summary

- Upgrade `ws` to the latest version
- Remove the dependency from CLI since it isn't being used
- Only big change is that "WebSocket was closed before the connection was established" error no longer raises an exception, but fires an onError event in the _next tick_ (https://github.com/websockets/ws/commit/d086f4bcbbe235f12f6fa2ddba5a8ce1342dac58) which means we can't easily remove the onerror handler. If we still want to remove the handler, we will likely have to do it in a `process.nextTick` call.

If you wish to confirm that the removal of the try-catch works, adding a nice obvious log to the onerror handler when the state is disconnected. Within about 2-5 minutes, you'll see the "WebSocket was closed before the connection was established" error being logged and no exception getting raised.

## Testing Plan

Manually tested 2 nodes on this version, as well as running live on the testnet for several hours.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
