### PR TITLE
feat: replace segfault-handler

### DIFF
--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -1,18 +1,21 @@
 #!/usr/bin/env node
 
-// segfault-handler causes crashes in node-webrtc on Windows because
-// it catches all exceptions rather than only exceptions that would
-// crash the process
+// the signal handler does not support windows yet
 if (process.platform !== 'win32') {
-  require('segfault-handler').registerHandler('segfault.log')
+  require('@ironfish/rust-nodejs').initSignalHandler()
 }
 
-if(process.versions.node.split('.')[0] !== '18') {
-  console.log('NodeJS version ' +  process.versions.node + ' is not compatible. Must have Node v18 installed: https://nodejs.org/en/download/')
-  console.log('After v18 is installed, MAKE SURE TO run `npm install -g ironfish` again to install ironfish with the correct Node version')
+if (process.versions.node.split('.')[0] !== '18') {
+  console.log(
+    `NodeJS version ${process.versions.node} is not compatible. Must have Node v18 installed: https://nodejs.org/en/download/`,
+  )
+  console.log(
+    'After v18 is installed, MAKE SURE TO run `npm install -g ironfish` again to install ironfish with the correct Node version',
+  )
   process.exit(1)
 }
 
-require('@oclif/core').run()
-.then(require('@oclif/core/flush'))
-.catch(require('@oclif/core/handle'))
+require('@oclif/core')
+  .run()
+  .then(require('@oclif/core/flush'))
+  .catch(require('@oclif/core/handle'))

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -74,7 +74,6 @@
     "chalk": "4.1.2",
     "inquirer": "8.2.5",
     "json-colorizer": "2.2.2",
-    "segfault-handler": "1.3.0",
     "supports-hyperlinks": "2.2.0",
     "tar": "6.1.11",
     "uuid": "8.3.2",

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -14,6 +14,16 @@ export interface BoxedMessage {
 }
 export function boxMessage(plaintext: string, senderSecretKey: Uint8Array, recipientPublicKey: string): BoxedMessage
 export function unboxMessage(boxedMessage: string, nonce: string, senderPublicKey: string, recipientSecretKey: Uint8Array): string
+/**
+ * # Safety
+ * This is unsafe, it calls libc functions
+ */
+export function initSignalHandler(): void
+/**
+ * # Safety
+ * This is unsafe, it intentionally crashes
+ */
+export function triggerSegfault(): void
 export const ASSET_ID_LENGTH: number
 export const ASSET_METADATA_LENGTH: number
 export const ASSET_NAME_LENGTH: number

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -246,7 +246,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_OWNER_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, GENERATOR_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, TransactionPosted, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, TRANSACTION_VERSION, Transaction, verifyTransactions, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_OWNER_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, GENERATOR_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, TransactionPosted, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, TRANSACTION_VERSION, Transaction, verifyTransactions, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.contribute = contribute
 module.exports.verifyTransform = verifyTransform
@@ -257,6 +257,8 @@ module.exports.randomBytes = randomBytes
 module.exports.boxMessage = boxMessage
 module.exports.unboxMessage = unboxMessage
 module.exports.RollingFilter = RollingFilter
+module.exports.initSignalHandler = initSignalHandler
+module.exports.triggerSegfault = triggerSegfault
 module.exports.ASSET_ID_LENGTH = ASSET_ID_LENGTH
 module.exports.ASSET_METADATA_LENGTH = ASSET_METADATA_LENGTH
 module.exports.ASSET_NAME_LENGTH = ASSET_NAME_LENGTH

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -16,6 +16,7 @@ use ironfish_rust::sapling_bls12;
 pub mod mpc;
 pub mod nacl;
 pub mod rolling_filter;
+pub mod signal_catcher;
 pub mod structs;
 
 fn to_napi_err(err: impl Display) -> napi::Error {

--- a/ironfish-rust-nodejs/src/signal_catcher.rs
+++ b/ironfish-rust-nodejs/src/signal_catcher.rs
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use ironfish_rust::signal_catcher::{init_signal_handler, trigger_segfault};
+use napi_derive::napi;
+
+/// # Safety
+/// This is unsafe, it calls libc functions
+#[napi(js_name = "initSignalHandler")]
+pub unsafe fn native_init_signal_handler() {
+    init_signal_handler()
+}
+
+/// # Safety
+/// This is unsafe, it intentionally crashes
+#[napi(js_name = "triggerSegfault")]
+pub unsafe fn native_trigger_segfault() {
+    trigger_segfault()
+}

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Asset, DECRYPTED_NOTE_LENGTH, LanguageCode, spendingKeyToWords, wordsToSpendingKey } from '..'
+import { Asset, DECRYPTED_NOTE_LENGTH, initSignalHandler, LanguageCode, spendingKeyToWords, wordsToSpendingKey } from '..'
 import {
   initializeSapling,
   generateKey,
@@ -137,5 +137,11 @@ describe('Demonstrate the Sapling API', () => {
     expect(postedTransaction.hash().byteLength).toEqual(32)
     expect(postedTransaction.transactionSignature().byteLength).toEqual(64)
     expect(postedTransaction.verify()).toBe(true)
+  })
+})
+
+describe('signal catcher', () => {
+  it('should be able to initialize the handler', () => {
+    expect(() => initSignalHandler()).not.toThrow()
   })
 })

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -15,6 +15,7 @@ pub mod note;
 pub mod rolling_filter;
 pub mod sapling_bls12;
 pub mod serializing;
+pub mod signal_catcher;
 pub mod transaction;
 pub mod util;
 pub mod witness;

--- a/ironfish-rust/src/signal_catcher.rs
+++ b/ironfish-rust/src/signal_catcher.rs
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+extern "C" {
+    // This is present in libc on unix, but not on linux
+    fn backtrace_symbols_fd(buffer: *const *mut libc::c_void, size: libc::c_int, fd: libc::c_int);
+}
+
+/// # Safety
+/// This is unsafe, it calls libc functions
+#[cfg(all(unix, target_env = "musl"))]
+unsafe fn display_trace() {
+    libc::exit(libc::EXIT_FAILURE);
+}
+
+/// # Safety
+/// This is unsafe, it calls libc functions
+#[cfg(all(unix, not(target_env = "musl")))]
+unsafe fn display_trace() {
+    const MAX_FRAMES: usize = 256;
+    static mut STACK_TRACE: [*mut libc::c_void; MAX_FRAMES] = [std::ptr::null_mut(); MAX_FRAMES];
+    let depth = libc::backtrace(STACK_TRACE.as_mut_ptr(), MAX_FRAMES as i32);
+    backtrace_symbols_fd(STACK_TRACE.as_ptr(), depth, 2);
+    libc::exit(libc::EXIT_FAILURE);
+}
+
+/// # Safety
+/// This is unsafe, it calls libc functions
+#[cfg(unix)]
+pub unsafe fn init_signal_handler() {
+    libc::signal(libc::SIGSEGV, display_trace as usize);
+    libc::signal(libc::SIGTRAP, display_trace as usize);
+}
+
+/// # Safety
+/// This is unsafe, it calls libc functions
+#[cfg(not(unix))]
+pub unsafe fn init_signal_handler() {
+    return;
+}
+
+/// # Safety
+/// This is unsafe, it intentionally crashes
+pub unsafe fn trigger_segfault() {
+    std::ptr::null_mut::<i32>().write(42);
+}

--- a/ironfish-rust/src/signal_catcher.rs
+++ b/ironfish-rust/src/signal_catcher.rs
@@ -30,7 +30,10 @@ unsafe fn display_trace() {
 #[cfg(unix)]
 pub unsafe fn init_signal_handler() {
     libc::signal(libc::SIGSEGV, display_trace as usize);
+    // Rust in release mode will throw one of these in place of a SIGSEGV, not
+    // sure why it differs based on system
     libc::signal(libc::SIGTRAP, display_trace as usize);
+    libc::signal(libc::SIGILL, display_trace as usize);
 }
 
 /// # Safety

--- a/yarn.lock
+++ b/yarn.lock
@@ -5386,13 +5386,6 @@ binaryextensions@^4.15.0, binaryextensions@^4.16.0:
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-4.18.0.tgz#22aeada2d14de062c60e8ca59a504a5636a76ceb"
   integrity sha512-PQu3Kyv9dM4FnwB7XGj1+HucW+ShvJzJqjuw1JkKVs1mWdwOKVcRjOi+pV9X52A0tNvrPCsPkbFFQb+wE1EAXw==
 
-bindings@^1.2.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
-
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -6975,11 +6968,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filelist@^1.0.1:
   version "1.0.2"
@@ -9263,11 +9251,6 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.14.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
-  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
-
 napi-build-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
@@ -10705,14 +10688,6 @@ scoped-regex@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-2.1.0.tgz#7b9be845d81fd9d21d1ec97c61a0b7cf86d2015f"
   integrity sha512-g3WxHrqSWCZHGHlSrF51VXFdjImhwvH8ZO/pryFH56Qi0cDsZfylQa/t0jCzVQFNbNvM00HfHjkDPEuarKDSWQ==
-
-segfault-handler@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/segfault-handler/-/segfault-handler-1.3.0.tgz#054bc847832fa14f218ba6a79e42877501c8870e"
-  integrity sha512-p7kVHo+4uoYkr0jmIiTBthwV5L2qmWtben/KDunDZ834mbos+tY+iO0//HpAJpOFSQZZ+wxKWuRo4DxV02B7Lg==
-  dependencies:
-    bindings "^1.2.1"
-    nan "^2.14.0"
 
 "semver@2 || 3 || 4 || 5", "semver@>= 5 < 6", semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"


### PR DESCRIPTION
## Summary

segfault-handler is a useful library, but requires a lot of extra
dependencies for our users since it compiles binaries on installation.
We can replace this with some napi rust functions that give us most of
what we need. This can later be extended to cover all the cases we want
it to, or split out into its own package.

### TODOs
- [x] Ensure this catches SEGFAULTs triggered by other code.
  - [x] Catches NAPI segfaults
  - [x] Catches an unrelated C/C++ NAPI module segfault? See https://github.com/iron-fish/ironfish/tree/mat/segfault-testing for more

    - https://user-images.githubusercontent.com/97762857/222219291-74da43c8-8f09-4130-bdd4-3615ae863e34.png

- [x] Ensure catching SIGTRAPs won't cause unintended issues (have ran a node on testnet for a couple hours)
- [x] Clean up the code
- [x] Actually remove segfault-handler dependency
- [x] Get better backtraces by using libc's backtrace instead of Rust.

## Testing Plan

Manually tested:
- Windows: only needed to install nodejs, yarn, rust. Built and started a node
- NixOS: Ran in a pure shell with only nodejs, yarn, rust. Built and started a node
- M1 Mac: Started and ran a node on testnet for several hours

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
