### PR TITLE
fixes remaining confirmed balance checks

### DIFF
--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -167,7 +167,7 @@ export default class Faucet extends IronfishCommand {
     this.warnedFund = false
 
     const maxPossibleRecipients = Math.min(
-      Number(BigInt(response.content.confirmed) / BigInt(FAUCET_AMOUNT + FAUCET_FEE)),
+      Number(BigInt(response.content.available) / BigInt(FAUCET_AMOUNT + FAUCET_FEE)),
       MAX_RECIPIENTS_PER_TRANSACTION,
     )
 

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -37,7 +37,7 @@ export async function promptCurrency(options: {
       confirmations: options.balance.confirmations,
     })
 
-    text += ` (balance ${CurrencyUtils.renderIron(balance.content.confirmed)})`
+    text += ` (balance ${CurrencyUtils.renderIron(balance.content.available)})`
   }
 
   // eslint-disable-next-line no-constant-condition

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -226,7 +226,7 @@ describe('poolShares', () => {
     await shares.submitShare(publicAddress1)
     await shares.submitShare(publicAddress2)
 
-    const hasBalanceSpy = jest.spyOn(shares, 'hasConfirmedBalance').mockResolvedValueOnce(true)
+    const hasBalanceSpy = jest.spyOn(shares, 'hasAvailableBalance').mockResolvedValueOnce(true)
     const sendTransactionSpy = jest
       .spyOn(shares, 'sendTransaction')
       .mockResolvedValueOnce('testTransactionHash')

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -212,7 +212,7 @@ export class MiningPoolShares {
       'Payout total must be less than or equal to the total reward amount',
     )
 
-    const hasEnoughBalance = await this.hasConfirmedBalance(totalRequired)
+    const hasEnoughBalance = await this.hasAvailableBalance(totalRequired)
     if (!hasEnoughBalance) {
       this.logger.info('Insufficient funds for payout, skipping.')
       return
@@ -262,11 +262,11 @@ export class MiningPoolShares {
     }
   }
 
-  async hasConfirmedBalance(amount: bigint): Promise<boolean> {
+  async hasAvailableBalance(amount: bigint): Promise<boolean> {
     const balance = await this.rpc.getAccountBalance({ account: this.accountName })
-    const confirmedBalance = BigInt(balance.content.confirmed)
+    const availableBalance = BigInt(balance.content.available)
 
-    return confirmedBalance >= amount
+    return availableBalance >= amount
   }
 
   async sendTransaction(

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
@@ -98,7 +98,7 @@ describe('Transactions sendTransaction', () => {
     )
   })
 
-  it('throws if the confirmed balance is too low', async () => {
+  it('throws if the available balance is too low', async () => {
     routeTest.node.peerNetwork['_isReady'] = true
     routeTest.chain.synced = true
 

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -99,7 +99,7 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
     for (const [assetId, sum] of totalByAssetId) {
       const balance = await node.wallet.getBalance(account, assetId)
 
-      if (balance.confirmed < sum) {
+      if (balance.available < sum) {
         throw new ValidationError(
           `Your balance is too low. Add funds to your account first`,
           undefined,


### PR DESCRIPTION
## Summary

checks available balance to see if an account has enough funds to send a transaction instead of confirmed balance.

available balance is the sum of all unspent note values and more accurately accounts for whether the account can send the transaction.

changes confirmed balance references in the following places:
- poolShares
- sendTransaction RPC
- promptCurrency
- faucet

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
