### PR TITLE
Output error message when transaction amount is not greater than 0

### DIFF
--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -5,6 +5,8 @@
 import { Asset } from '@ironfish/rust-nodejs'
 import { Assert, CurrencyUtils, RpcClient } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
+import {createRootLogger, Logger} from '@ironfish/sdk'
+
 
 export async function promptCurrency(options: {
   client: RpcClient
@@ -16,6 +18,7 @@ export async function promptCurrency(options: {
     assetId?: string
     confirmations?: number
   }
+  logger?: Logger
 }): Promise<bigint>
 
 export async function promptCurrency(options: {
@@ -28,9 +31,10 @@ export async function promptCurrency(options: {
     assetId?: string
     confirmations?: number
   }
+  logger?: Logger
 }): Promise<bigint | null> {
   let text = options.text
-
+  const logger = options.logger ?? createRootLogger()
   if (options.balance) {
     const balance = await options.client.getAccountBalance({
       assetId: options.balance.assetId ?? Asset.nativeId().toString('hex'),
@@ -57,9 +61,8 @@ export async function promptCurrency(options: {
     }
 
     Assert.isNotNull(amount)
-
     if (options.minimum != null && amount < options.minimum) {
-      console.log("Please enter an amount greater than 0")
+      logger.log("Please enter an amount greater than 0")
       continue
     }
 

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -59,6 +59,7 @@ export async function promptCurrency(options: {
     Assert.isNotNull(amount)
 
     if (options.minimum != null && amount < options.minimum) {
+      console.log("Please enter an amount greater than 0")
       continue
     }
 


### PR DESCRIPTION
## Summary
Output error message: "Please enter an amount greater than 0", when transaction amount is not greater than 0
Fixes: #3549 

## Testin
After burn:
<img width="898" alt="after-burn" src="https://user-images.githubusercontent.com/114656810/221303121-c8f7ac58-7bfa-49e5-b5d2-520817c25437.png">

After mint:
<img width="901" alt="after-mint" src="https://user-images.githubusercontent.com/114656810/221303125-e2a143ee-709e-4905-a406-dc0336cd5610.png">

After send:
<img width="898" alt="after-send" src="https://user-images.githubusercontent.com/114656810/221303127-5d6c0470-3fb3-480c-a103-fce806923797.png">
g Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ X] No
```
