### PR TITLE
Add Features field to Identify message

### DIFF
--- a/ironfish/src/network/messageRegistry.test.ts
+++ b/ironfish/src/network/messageRegistry.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { parseNetworkMessage } from './messageRegistry'
 import { IdentifyMessage } from './messages/identify'
+import { defaultFeatures } from './peers/peerFeatures'
 
 describe('messageRegistry', () => {
   describe('parseNetworkMessage', () => {
@@ -24,6 +25,7 @@ describe('messageRegistry', () => {
           work: BigInt(0),
           networkId: 0,
           genesisBlockHash: Buffer.alloc(32, 0),
+          features: defaultFeatures(),
         })
         jest.spyOn(message, 'serialize').mockImplementationOnce(() => Buffer.from('adsf'))
 
@@ -43,6 +45,7 @@ describe('messageRegistry', () => {
           work: BigInt(0),
           networkId: 0,
           genesisBlockHash: Buffer.alloc(32, 0),
+          features: defaultFeatures(),
         })
 
         expect(parseNetworkMessage(message.serializeWithMetadata())).toEqual(message)

--- a/ironfish/src/network/messages/identify.test.ts
+++ b/ironfish/src/network/messages/identify.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { identityLength } from '../identity'
+import { defaultFeatures } from '../peers/peerFeatures'
 import { IdentifyMessage } from './identify'
 
 describe('IdentifyMessage', () => {
@@ -17,6 +18,7 @@ describe('IdentifyMessage', () => {
       work: BigInt('123'),
       networkId: 0,
       genesisBlockHash: Buffer.alloc(32, 0),
+      features: defaultFeatures(),
     })
 
     const buffer = message.serialize()

--- a/ironfish/src/network/messages/identify.ts
+++ b/ironfish/src/network/messages/identify.ts
@@ -128,6 +128,7 @@ export class IdentifyMessage extends NetworkMessage {
     size += bufio.sizeVarBytes(BigIntUtils.toBytesLE(this.work))
     size += 2 // network ID
     size += 32 // genesis block hash
+    size += 4 // features
     return size
   }
 }

--- a/ironfish/src/network/messages/identify.ts
+++ b/ironfish/src/network/messages/identify.ts
@@ -76,7 +76,7 @@ export class IdentifyMessage extends NetworkMessage {
     bw.writeHash(this.genesisBlockHash)
 
     let flags = 0
-    flags |= Number(this.features.enableSyncing) << 0
+    flags |= Number(this.features.syncing) << 0
     bw.writeU32(flags)
 
     return bw.render()
@@ -98,7 +98,7 @@ export class IdentifyMessage extends NetworkMessage {
     const features = defaultFeatures()
     if (version >= FEATURES_MIN_VERSION) {
       const flags = reader.readU32()
-      features.enableSyncing = Boolean(flags & (1 << 0))
+      features.syncing = Boolean(flags & (1 << 0))
     }
 
     return new IdentifyMessage({

--- a/ironfish/src/network/messages/identify.ts
+++ b/ironfish/src/network/messages/identify.ts
@@ -4,6 +4,7 @@
 import bufio from 'bufio'
 import { BigIntUtils } from '../../utils/bigint'
 import { Identity, identityLength } from '../identity'
+import { defaultFeatures, Features, FEATURES_MIN_VERSION } from '../peers/peerFeatures'
 import { NetworkMessageType } from '../types'
 import { NetworkMessage } from './networkMessage'
 
@@ -18,6 +19,7 @@ interface CreateIdentifyMessageOptions {
   work: bigint
   networkId: number
   genesisBlockHash: Buffer
+  features: Features
 }
 
 export class IdentifyMessage extends NetworkMessage {
@@ -31,6 +33,7 @@ export class IdentifyMessage extends NetworkMessage {
   readonly work: bigint
   readonly networkId: number
   readonly genesisBlockHash: Buffer
+  readonly features: Features
 
   constructor({
     agent,
@@ -43,6 +46,7 @@ export class IdentifyMessage extends NetworkMessage {
     work,
     networkId,
     genesisBlockHash,
+    features,
   }: CreateIdentifyMessageOptions) {
     super(NetworkMessageType.Identify)
     this.agent = agent
@@ -55,6 +59,7 @@ export class IdentifyMessage extends NetworkMessage {
     this.work = work
     this.networkId = networkId
     this.genesisBlockHash = genesisBlockHash
+    this.features = features
   }
 
   serialize(): Buffer {
@@ -69,6 +74,11 @@ export class IdentifyMessage extends NetworkMessage {
     bw.writeVarBytes(BigIntUtils.toBytesLE(this.work))
     bw.writeU16(this.networkId)
     bw.writeHash(this.genesisBlockHash)
+
+    let flags = 0
+    flags |= Number(this.features.enableSyncing) << 0
+    bw.writeU32(flags)
+
     return bw.render()
   }
 
@@ -84,6 +94,13 @@ export class IdentifyMessage extends NetworkMessage {
     const work = BigIntUtils.fromBytesLE(reader.readVarBytes())
     const networkId = reader.readU16()
     const genesisBlockHash = reader.readHash()
+
+    const features = defaultFeatures()
+    if (version >= FEATURES_MIN_VERSION) {
+      const flags = reader.readU32()
+      features.enableSyncing = Boolean(flags & (1 << 0))
+    }
+
     return new IdentifyMessage({
       agent,
       head,
@@ -95,6 +112,7 @@ export class IdentifyMessage extends NetworkMessage {
       work,
       networkId,
       genesisBlockHash,
+      features,
     })
   }
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -61,6 +61,7 @@ import {
 import { LocalPeer } from './peers/localPeer'
 import { BAN_SCORE, KnownBlockHashesValue, Peer } from './peers/peer'
 import { PeerConnectionManager } from './peers/peerConnectionManager'
+import { FEATURES_MIN_VERSION } from './peers/peerFeatures'
 import { PeerManager } from './peers/peerManager'
 import { TransactionFetcher } from './transactionFetcher'
 import { IsomorphicWebSocketConstructor } from './types'
@@ -190,6 +191,7 @@ export class PeerNetwork {
       options.chain,
       options.webSocket,
       options.networkId,
+      this.enableSyncing,
     )
 
     this.localPeer.port = options.port === undefined ? null : options.port
@@ -457,7 +459,11 @@ export class PeerNetwork {
 
   private *connectedPeersWithoutTransaction(hash: TransactionHash): Generator<Peer> {
     for (const p of this.peerManager.identifiedPeers.values()) {
-      if (p.state.type === 'CONNECTED' && !this.knowsTransaction(hash, p.state.identity)) {
+      if (
+        p.state.type === 'CONNECTED' &&
+        p.features?.enableSyncing &&
+        !this.knowsTransaction(hash, p.state.identity)
+      ) {
         yield p
       }
     }
@@ -465,7 +471,11 @@ export class PeerNetwork {
 
   private *connectedPeersWithoutBlock(hash: BlockHash): Generator<Peer> {
     for (const p of this.peerManager.identifiedPeers.values()) {
-      if (p.state.type === 'CONNECTED' && !p.knownBlockHashes.has(hash)) {
+      if (
+        p.state.type === 'CONNECTED' &&
+        p.features?.enableSyncing &&
+        !p.knownBlockHashes.has(hash)
+      ) {
         yield p
       }
     }
@@ -630,6 +640,15 @@ export class PeerNetwork {
     incomingMessage: IncomingPeerMessage<NetworkMessage>,
   ): Promise<void> {
     const { message } = incomingMessage
+
+    if (
+      !this.localPeer.enableSyncing &&
+      peer.version !== null &&
+      peer.version >= FEATURES_MIN_VERSION
+    ) {
+      peer.punish(BAN_SCORE.MAX)
+      return
+    }
 
     if (message instanceof RpcNetworkMessage) {
       await this.handleRpcMessage(peer, message)

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -461,7 +461,7 @@ export class PeerNetwork {
     for (const p of this.peerManager.identifiedPeers.values()) {
       if (
         p.state.type === 'CONNECTED' &&
-        p.features?.enableSyncing &&
+        p.features?.syncing &&
         !this.knowsTransaction(hash, p.state.identity)
       ) {
         yield p
@@ -473,7 +473,7 @@ export class PeerNetwork {
     for (const p of this.peerManager.identifiedPeers.values()) {
       if (
         p.state.type === 'CONNECTED' &&
-        p.features?.enableSyncing &&
+        p.features?.syncing &&
         !p.knownBlockHashes.has(hash)
       ) {
         yield p

--- a/ironfish/src/network/peers/connections/webRtcConnection.test.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.test.ts
@@ -4,6 +4,7 @@
 import { Assert } from '../../../assert'
 import { createRootLogger } from '../../../logger'
 import { IdentifyMessage } from '../../messages/identify'
+import { defaultFeatures } from '../peerFeatures'
 import { WebRtcConnection } from './webRtcConnection'
 
 describe('WebRtcConnection', () => {
@@ -21,6 +22,7 @@ describe('WebRtcConnection', () => {
           work: BigInt(0),
           networkId: 0,
           genesisBlockHash: Buffer.alloc(32, 0),
+          features: defaultFeatures(),
         })
         expect(connection.send(message)).toBe(false)
         connection.close()
@@ -46,6 +48,7 @@ describe('WebRtcConnection', () => {
           work: BigInt(0),
           networkId: 0,
           genesisBlockHash: Buffer.alloc(32, 0),
+          features: defaultFeatures(),
         })
 
         expect(connection.send(message)).toBe(true)

--- a/ironfish/src/network/peers/connections/webSocketConnection.test.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.test.ts
@@ -4,6 +4,7 @@
 import ws from 'ws'
 import { createRootLogger } from '../../../logger'
 import { IdentifyMessage } from '../../messages/identify'
+import { defaultFeatures } from '../peerFeatures'
 import { ConnectionDirection } from './connection'
 import { WebSocketConnection } from './webSocketConnection'
 
@@ -34,6 +35,7 @@ describe('WebSocketConnection', () => {
           work: BigInt(0),
           networkId: 0,
           genesisBlockHash: Buffer.alloc(32, 0),
+          features: defaultFeatures(),
         })
 
         expect(connection.send(message)).toBe(true)

--- a/ironfish/src/network/peers/localPeer.ts
+++ b/ironfish/src/network/peers/localPeer.ts
@@ -26,6 +26,8 @@ export class LocalPeer {
   readonly webSocket: IsomorphicWebSocketConstructor
   // the unique ID number of the network
   readonly networkId: number
+  // true if the peer supports syncing and gossip messages
+  readonly enableSyncing: boolean
 
   // optional port the local peer is listening on
   port: number | null
@@ -41,6 +43,7 @@ export class LocalPeer {
     chain: Blockchain,
     webSocket: IsomorphicWebSocketConstructor,
     networkId: number,
+    enableSyncing: boolean,
   ) {
     this.privateIdentity = identity
     this.publicIdentity = privateIdentityToIdentity(identity)
@@ -48,6 +51,7 @@ export class LocalPeer {
     this.agent = agent
     this.version = version
     this.networkId = networkId
+    this.enableSyncing = enableSyncing
 
     this.webSocket = webSocket
     this.port = null
@@ -71,6 +75,9 @@ export class LocalPeer {
       work: this.chain.head.work,
       networkId: this.networkId,
       genesisBlockHash: this.chain.genesis.hash,
+      features: {
+        enableSyncing: this.enableSyncing,
+      },
     })
   }
 

--- a/ironfish/src/network/peers/localPeer.ts
+++ b/ironfish/src/network/peers/localPeer.ts
@@ -76,7 +76,7 @@ export class LocalPeer {
       networkId: this.networkId,
       genesisBlockHash: this.chain.genesis.hash,
       features: {
-        enableSyncing: this.enableSyncing,
+        syncing: this.enableSyncing,
       },
     })
   }

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -14,6 +14,7 @@ import { displayNetworkMessageType, NetworkMessage } from '../messages/networkMe
 import { NetworkMessageType } from '../types'
 import { NetworkError, WebRtcConnection, WebSocketConnection } from './connections'
 import { Connection, ConnectionType } from './connections/connection'
+import { Features } from './peerFeatures'
 
 export enum BAN_SCORE {
   NO = 0,
@@ -135,6 +136,11 @@ export class Peer {
    * The peer's genesis block hash
    */
   genesisBlockHash: Buffer | null = null
+
+  /**
+   * Features supported by the peer
+   */
+  features: Features | null = null
 
   /**
    * The loggable name of the peer. For a more specific value,

--- a/ironfish/src/network/peers/peerFeatures.ts
+++ b/ironfish/src/network/peers/peerFeatures.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export const FEATURES_MIN_VERSION = 21
+
+export interface Features {
+  enableSyncing: boolean
+}
+
+export const defaultFeatures = (): Features => ({
+  enableSyncing: true,
+})

--- a/ironfish/src/network/peers/peerFeatures.ts
+++ b/ironfish/src/network/peers/peerFeatures.ts
@@ -5,9 +5,9 @@
 export const FEATURES_MIN_VERSION = 21
 
 export interface Features {
-  enableSyncing: boolean
+  syncing: boolean
 }
 
 export const defaultFeatures = (): Features => ({
-  enableSyncing: true,
+  syncing: true,
 })

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -35,6 +35,7 @@ import {
   WebSocketConnection,
 } from './connections'
 import { BAN_SCORE } from './peer'
+import { defaultFeatures } from './peerFeatures'
 import { PeerManager } from './peerManager'
 
 jest.useFakeTimers()
@@ -74,6 +75,7 @@ describe('PeerManager', () => {
       work: BigInt(0),
       networkId: localPeer.networkId,
       genesisBlockHash: localPeer.chain.genesis.hash,
+      features: defaultFeatures(),
     })
 
     // Identify peerOut
@@ -760,6 +762,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        features: defaultFeatures(),
       })
       peer.onMessage.emit(identify, connection)
 
@@ -795,6 +798,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        features: defaultFeatures(),
       })
       peer.onMessage.emit(identify, connection)
 
@@ -821,6 +825,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        features: defaultFeatures(),
       })
       peer.onMessage.emit(identify, connection)
       expect(closeSpy).toHaveBeenCalled()
@@ -847,6 +852,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        features: defaultFeatures(),
       })
       connection.onMessage.emit(identify)
 
@@ -881,6 +887,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        features: defaultFeatures(),
       })
       connection.onMessage.emit(identify)
 
@@ -921,6 +928,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        features: defaultFeatures(),
       })
       connection.onMessage.emit(identify)
 
@@ -970,6 +978,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        features: defaultFeatures(),
       })
       connection.onMessage.emit(id)
 
@@ -1010,6 +1019,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId + 1,
         genesisBlockHash: localPeer.chain.genesis.hash,
+        features: defaultFeatures(),
       })
       peer.onMessage.emit(identify, connection)
 
@@ -1037,6 +1047,7 @@ describe('PeerManager', () => {
         work: BigInt(0),
         networkId: localPeer.networkId,
         genesisBlockHash: Buffer.alloc(32, 1),
+        features: defaultFeatures(),
       })
       Assert.isFalse(identify.genesisBlockHash.equals(localPeer.chain.genesis.hash))
       peer.onMessage.emit(identify, connection)

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -1231,6 +1231,7 @@ export class PeerManager {
     peer.work = message.work
     peer.networkId = message.networkId
     peer.genesisBlockHash = message.genesisBlockHash
+    peer.features = message.features
 
     // If we've told the peer to stay disconnected, repeat
     // the disconnection time before closing the connection

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -15,6 +15,7 @@ import {
   WebSocketConnection,
 } from '../peers/connections'
 import { Peer } from '../peers/peer'
+import { defaultFeatures } from '../peers/peerFeatures'
 import { PeerManager } from '../peers/peerManager'
 import { WebSocketClient } from '../webSocketClient'
 import { mockIdentity } from './mockIdentity'
@@ -118,6 +119,8 @@ export function getConnectedPeer(
   }
 
   connection.setState({ type: 'CONNECTED', identity })
+
+  peer.features = defaultFeatures()
 
   return { peer, connection: connection }
 }

--- a/ironfish/src/network/testUtilities/mockLocalPeer.ts
+++ b/ironfish/src/network/testUtilities/mockLocalPeer.ts
@@ -24,5 +24,5 @@ export function mockLocalPeer({
   version?: number
   chain?: Blockchain
 } = {}): LocalPeer {
-  return new LocalPeer(identity, agent, version, chain || mockChain(), WebSocketClient, 0)
+  return new LocalPeer(identity, agent, version, chain || mockChain(), WebSocketClient, 0, true)
 }

--- a/ironfish/src/network/version.ts
+++ b/ironfish/src/network/version.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const VERSION_PROTOCOL = 20
+export const VERSION_PROTOCOL = 21
 export const VERSION_PROTOCOL_MIN = 19
 
 export const MAX_REQUESTED_BLOCKS = 50

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -122,7 +122,7 @@ export class Syncer {
     // Find all allowed peers that have more work than we have
     const peers = this.peerNetwork.peerManager
       .getConnectedPeers()
-      .filter((peer) => peer.features?.enableSyncing && peer.work && peer.work > head.work)
+      .filter((peer) => peer.features?.syncing && peer.work && peer.work > head.work)
 
     // Get a random peer with higher work. We do this to encourage
     // peer diversity so the highest work peer isn't overwhelmed

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -122,7 +122,7 @@ export class Syncer {
     // Find all allowed peers that have more work than we have
     const peers = this.peerNetwork.peerManager
       .getConnectedPeers()
-      .filter((peer) => peer.work && peer.work > head.work)
+      .filter((peer) => peer.features?.enableSyncing && peer.work && peer.work > head.work)
 
     // Get a random peer with higher work. We do this to encourage
     // peer diversity so the highest work peer isn't overwhelmed


### PR DESCRIPTION
## Summary

Adds a features field to the Identify message. For now, it allows for broadcasting to other peers whether your node supports syncing.

## Testing Plan

* [x] Can sync from 0.1.69 to this branch
* [x] Can sync from this branch to this branch
* [x] Does not gossip from this branch to this branch (with enableSyncing false)

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
