### PR TITLE
Remove IncomingPeerMessage

### DIFF
--- a/ironfish/src/network/blockFetcher.test.ts
+++ b/ironfish/src/network/blockFetcher.test.ts
@@ -131,10 +131,7 @@ describe('BlockFetcher', () => {
     const sentMessage = sentPeers[0].sendSpy.mock.calls[0][0]
     expect(sentMessage).toBeInstanceOf(GetCompactBlockRequest)
     const rpcId = (sentMessage as GetCompactBlockRequest).rpcId
-    const message = {
-      peerIdentity: sentPeer.getIdentityOrThrow(),
-      message: new GetCompactBlockResponse(block.toCompactBlock(), rpcId),
-    }
+    const message = new GetCompactBlockResponse(block.toCompactBlock(), rpcId)
 
     await expect(chain.hasBlock(block.header.hash)).resolves.toBe(false)
 

--- a/ironfish/src/network/messages/networkMessage.ts
+++ b/ironfish/src/network/messages/networkMessage.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
 import { Serializable } from '../../common/serializable'
-import { Identity } from '../identity'
 import { NetworkMessageType } from '../types'
 
 export function displayNetworkMessageType(type: NetworkMessageType): string {
@@ -33,13 +32,4 @@ export abstract class NetworkMessage implements Serializable {
     bw.writeBytes(this.serialize())
     return bw.render()
   }
-}
-
-/**
- * A message that we have received from a peer, identified by that peer's
- * identity.
- */
-export interface IncomingPeerMessage<M extends NetworkMessage> {
-  peerIdentity: Identity
-  message: M
 }

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -84,12 +84,7 @@ describe('PeerNetwork', () => {
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
       const message = new PeerListMessage([])
-      await expect(
-        peerNetwork['handleMessage'](peer, {
-          peerIdentity: peer.getIdentityOrThrow(),
-          message,
-        }),
-      ).rejects.not.toBeUndefined()
+      await expect(peerNetwork['handleMessage'](peer, message)).rejects.not.toBeUndefined()
       await peerNetwork.stop()
     })
   })
@@ -207,7 +202,6 @@ describe('PeerNetwork', () => {
       }
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -215,7 +209,7 @@ describe('PeerNetwork', () => {
       const message = new GetCompactBlockRequest(block.header.hash, rpcId)
       const response = new GetCompactBlockResponse(compactBlock, rpcId)
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy.mock.calls[0][0]).toBeInstanceOf(GetCompactBlockResponse)
       expectGetCompactBlockResponseToMatch(
@@ -234,7 +228,6 @@ describe('PeerNetwork', () => {
       }
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -242,7 +235,7 @@ describe('PeerNetwork', () => {
       const message = new GetCompactBlockRequest(node.chain.genesis.hash, rpcId)
       const response = new CannotSatisfyRequest(rpcId)
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy).toHaveBeenCalledWith(response)
     })
@@ -251,7 +244,6 @@ describe('PeerNetwork', () => {
       const { peerNetwork } = nodeTest
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -259,7 +251,7 @@ describe('PeerNetwork', () => {
       const message = new GetCompactBlockRequest(Buffer.alloc(32, 1), rpcId)
       const response = new CannotSatisfyRequest(rpcId)
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy).toHaveBeenCalledWith(response)
     })
@@ -284,7 +276,6 @@ describe('PeerNetwork', () => {
       })
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -296,7 +287,7 @@ describe('PeerNetwork', () => {
         rpcId,
       )
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy.mock.calls[0][0]).toBeInstanceOf(GetBlockTransactionsResponse)
       expectGetBlockTransactionsResponseToMatch(
@@ -315,7 +306,6 @@ describe('PeerNetwork', () => {
       }
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -323,7 +313,7 @@ describe('PeerNetwork', () => {
       const message = new GetBlockTransactionsRequest(node.chain.genesis.hash, [0], rpcId)
       const response = new CannotSatisfyRequest(rpcId)
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy).toHaveBeenCalledWith(response)
     })
@@ -332,7 +322,6 @@ describe('PeerNetwork', () => {
       const { peerNetwork } = nodeTest
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -340,7 +329,7 @@ describe('PeerNetwork', () => {
       const message = new GetBlockTransactionsRequest(Buffer.alloc(32, 1), [0, 1], rpcId)
       const response = new CannotSatisfyRequest(rpcId)
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy).toHaveBeenCalledWith(response)
     })
@@ -349,7 +338,6 @@ describe('PeerNetwork', () => {
       const { peerNetwork, node } = nodeTest
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -364,7 +352,7 @@ describe('PeerNetwork', () => {
       )
       const response = new CannotSatisfyRequest(rpcId)
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy).toHaveBeenCalledWith(response)
     })
@@ -373,7 +361,6 @@ describe('PeerNetwork', () => {
       const { peerNetwork, node } = nodeTest
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -381,7 +368,7 @@ describe('PeerNetwork', () => {
       const message = new GetBlockTransactionsRequest(node.chain.genesis.hash, [-1], rpcId)
       const response = new CannotSatisfyRequest(rpcId)
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy).toHaveBeenCalledWith(response)
     })
@@ -402,7 +389,6 @@ describe('PeerNetwork', () => {
       await expect(node.chain).toAddBlock(block5)
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -413,7 +399,7 @@ describe('PeerNetwork', () => {
         rpcId,
       )
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy.mock.calls[0][0]).toBeInstanceOf(GetBlockHeadersResponse)
       expectGetBlockHeadersResponseToMatch(
@@ -440,7 +426,6 @@ describe('PeerNetwork', () => {
       await expect(node.chain).toAddBlock(block8)
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -451,7 +436,7 @@ describe('PeerNetwork', () => {
         rpcId,
       )
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy.mock.calls[0][0]).toBeInstanceOf(GetBlockHeadersResponse)
       expectGetBlockHeadersResponseToMatch(
@@ -470,7 +455,6 @@ describe('PeerNetwork', () => {
       await expect(node.chain).toAddBlock(block4)
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -481,7 +465,7 @@ describe('PeerNetwork', () => {
         rpcId,
       )
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy.mock.calls[0][0]).toBeInstanceOf(GetBlockHeadersResponse)
       expectGetBlockHeadersResponseToMatch(
@@ -500,7 +484,6 @@ describe('PeerNetwork', () => {
       await expect(node.chain).toAddBlock(block4)
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -508,7 +491,7 @@ describe('PeerNetwork', () => {
       const message = new GetBlockHeadersRequest(4, 2, 1, true, rpcId)
       const response = new GetBlockHeadersResponse([block4.header, block2.header], rpcId)
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy.mock.calls[0][0]).toBeInstanceOf(GetBlockHeadersResponse)
       expectGetBlockHeadersResponseToMatch(
@@ -527,7 +510,6 @@ describe('PeerNetwork', () => {
       await expect(node.chain).toAddBlock(block4)
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
@@ -535,7 +517,7 @@ describe('PeerNetwork', () => {
       const message = new GetBlockHeadersRequest(block4.header.hash, 2, 1, true, rpcId)
       const response = new GetBlockHeadersResponse([block4.header, block2.header], rpcId)
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy.mock.calls[0][0]).toBeInstanceOf(GetBlockHeadersResponse)
       expectGetBlockHeadersResponseToMatch(
@@ -550,14 +532,13 @@ describe('PeerNetwork', () => {
       await expect(node.chain).toAddBlock(block2)
 
       const { peer } = getConnectedPeer(peerNetwork.peerManager)
-      const peerIdentity = peer.getIdentityOrThrow()
 
       const sendSpy = jest.spyOn(peer, 'send')
 
       const rpcId = 432
       const message = new GetBlockHeadersRequest(block2.header.hash, 5, 1, false, rpcId)
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+      await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
       expect(sendSpy.mock.calls[0][0]).toBeInstanceOf(CannotSatisfyRequest)
     })
@@ -585,7 +566,6 @@ describe('PeerNetwork', () => {
         await expect(node.chain).toAddBlock(block10)
 
         const { peer } = getConnectedPeer(peerNetwork.peerManager)
-        const peerIdentity = peer.getIdentityOrThrow()
 
         const sendSpy = jest.spyOn(peer, 'send')
 
@@ -595,7 +575,7 @@ describe('PeerNetwork', () => {
         // resulting in 7 lookups. The 8th and final lookup is block9.
         const response = new GetBlockHeadersResponse([block2.header, block9.header], rpcId)
 
-        await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+        await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
         expect(sendSpy.mock.calls[0][0]).toBeInstanceOf(GetBlockHeadersResponse)
         expectGetBlockHeadersResponseToMatch(
@@ -626,7 +606,6 @@ describe('PeerNetwork', () => {
         await expect(node.chain).toAddBlock(block10)
 
         const { peer } = getConnectedPeer(peerNetwork.peerManager)
-        const peerIdentity = peer.getIdentityOrThrow()
 
         const sendSpy = jest.spyOn(peer, 'send')
 
@@ -637,7 +616,7 @@ describe('PeerNetwork', () => {
         // since it would be the 9th lookup.
         const response = new GetBlockHeadersResponse([block2.header], rpcId)
 
-        await peerNetwork.peerManager.onMessage.emitAsync(peer, { peerIdentity, message })
+        await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
         expect(sendSpy.mock.calls[0][0]).toBeInstanceOf(GetBlockHeadersResponse)
         expectGetBlockHeadersResponseToMatch(
@@ -746,10 +725,7 @@ describe('PeerNetwork', () => {
         const message = new PooledTransactionsRequest([transaction.hash()], rpcId)
         const response = new PooledTransactionsResponse([transaction], rpcId)
 
-        peerNetwork.peerManager.onMessage.emit(peer, {
-          peerIdentity: peer.getIdentityOrThrow(),
-          message,
-        })
+        peerNetwork.peerManager.onMessage.emit(peer, message)
 
         expect(sendSpy).toHaveBeenCalledWith(response)
       })
@@ -771,10 +747,10 @@ describe('PeerNetwork', () => {
         const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
         const { peer: peerWithTransaction } = peers[0]
 
-        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
-          peerIdentity: peerWithTransaction.getIdentityOrThrow(),
-          message: new NewTransactionsMessage([transaction]),
-        })
+        await peerNetwork.peerManager.onMessage.emitAsync(
+          peerWithTransaction,
+          new NewTransactionsMessage([transaction]),
+        )
 
         for (const { sendSpy } of peers) {
           expect(sendSpy).not.toHaveBeenCalled()
@@ -799,10 +775,10 @@ describe('PeerNetwork', () => {
         const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
         const { peer: peerWithTransaction } = peers[0]
 
-        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
-          peerIdentity: peerWithTransaction.getIdentityOrThrow(),
-          message: new NewTransactionsMessage([transaction]),
-        })
+        await peerNetwork.peerManager.onMessage.emitAsync(
+          peerWithTransaction,
+          new NewTransactionsMessage([transaction]),
+        )
 
         for (const { sendSpy } of peers) {
           expect(sendSpy).not.toHaveBeenCalled()
@@ -829,10 +805,10 @@ describe('PeerNetwork', () => {
         const { peer: peerWithTransaction } = peers[0]
         const peersWithoutTransaction = peers.slice(1)
 
-        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
-          peerIdentity: peerWithTransaction.getIdentityOrThrow(),
-          message: new NewTransactionsMessage([transaction]),
-        })
+        await peerNetwork.peerManager.onMessage.emitAsync(
+          peerWithTransaction,
+          new NewTransactionsMessage([transaction]),
+        )
 
         for (const { sendSpy } of peersWithoutTransaction) {
           const transactionMessages = sendSpy.mock.calls.filter(([message]) => {
@@ -859,10 +835,10 @@ describe('PeerNetwork', () => {
         }
 
         const { peer: peerWithTransaction2 } = peers[1]
-        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction2, {
-          peerIdentity: peerWithTransaction2.getIdentityOrThrow(),
-          message: new NewTransactionsMessage([transaction]),
-        })
+        await peerNetwork.peerManager.onMessage.emitAsync(
+          peerWithTransaction2,
+          new NewTransactionsMessage([transaction]),
+        )
 
         // These functions should still only be called once
         for (const { sendSpy } of peersWithoutTransaction) {
@@ -902,10 +878,10 @@ describe('PeerNetwork', () => {
         const { peer: peerWithTransaction } = peers[0]
         const peersWithoutTransaction = peers.slice(1)
 
-        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
-          peerIdentity: peerWithTransaction.getIdentityOrThrow(),
-          message: new NewTransactionsMessage([transaction]),
-        })
+        await peerNetwork.peerManager.onMessage.emitAsync(
+          peerWithTransaction,
+          new NewTransactionsMessage([transaction]),
+        )
 
         // Peers should not be sent invalid transaction
         for (const { sendSpy } of peers) {
@@ -969,10 +945,10 @@ describe('PeerNetwork', () => {
         const { peer: peerWithTransaction } = peers[0]
         const peersWithoutTransaction = peers.slice(1)
 
-        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
-          peerIdentity: peerWithTransaction.getIdentityOrThrow(),
-          message: new NewTransactionsMessage([transaction]),
-        })
+        await peerNetwork.peerManager.onMessage.emitAsync(
+          peerWithTransaction,
+          new NewTransactionsMessage([transaction]),
+        )
 
         expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(1)
         const verificationResult = await verifyNewTransactionSpy.mock.results[0].value
@@ -1017,10 +993,10 @@ describe('PeerNetwork', () => {
         const { peer: peerWithTransaction } = peers[0]
         const peersWithoutTransaction = peers.slice(1)
 
-        await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
-          peerIdentity: peerWithTransaction.getIdentityOrThrow(),
-          message: new NewTransactionsMessage([transaction]),
-        })
+        await peerNetwork.peerManager.onMessage.emitAsync(
+          peerWithTransaction,
+          new NewTransactionsMessage([transaction]),
+        )
 
         // Peers should not be sent invalid transaction
         for (const { sendSpy } of peers) {
@@ -1132,10 +1108,10 @@ describe('PeerNetwork', () => {
       jest.spyOn(chain.verifier, 'verifyNewTransaction')
       jest.spyOn(memPool, 'acceptTransaction')
 
-      await peerNetwork.peerManager.onMessage.emitAsync(peerWithTransaction, {
-        peerIdentity: peerWithTransaction.getIdentityOrThrow(),
-        message: new NewTransactionsMessage([transaction]),
-      })
+      await peerNetwork.peerManager.onMessage.emitAsync(
+        peerWithTransaction,
+        new NewTransactionsMessage([transaction]),
+      )
 
       expect(sendSpy).not.toHaveBeenCalled()
       expect(chain.verifier.verifyNewTransaction).not.toHaveBeenCalled()

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -16,11 +16,7 @@ import {
 } from '../identity'
 import { DisconnectingMessage, DisconnectingReason } from '../messages/disconnecting'
 import { IdentifyMessage } from '../messages/identify'
-import {
-  displayNetworkMessageType,
-  IncomingPeerMessage,
-  NetworkMessage,
-} from '../messages/networkMessage'
+import { displayNetworkMessageType, NetworkMessage } from '../messages/networkMessage'
 import { PeerListMessage } from '../messages/peerList'
 import { PeerListRequestMessage } from '../messages/peerListRequest'
 import { SignalMessage } from '../messages/signal'
@@ -117,7 +113,7 @@ export class PeerManager {
    * Note that the `Peer` is the peer that sent it to us,
    * not necessarily the original source.
    */
-  readonly onMessage: Event<[Peer, IncomingPeerMessage<NetworkMessage>]> = new Event()
+  readonly onMessage: Event<[Peer, NetworkMessage]> = new Event()
 
   /**
    * Event fired when a peer enters or leaves the CONNECTED state.
@@ -876,12 +872,6 @@ export class PeerManager {
 
   /**
    * Handler fired whenever we receive any message from a peer.
-   *
-   * If it is a signal message we need to forward it to the appropriate
-   * webrtc peer.
-   *
-   * Note that the identity on IncomingPeerMessage is the identity of the
-   * peer that sent it to us, not the original source.
    */
   private handleMessage(peer: Peer, connection: Connection, message: NetworkMessage) {
     if (connection.state.type === 'WAITING_FOR_IDENTITY') {
@@ -908,7 +898,7 @@ export class PeerManager {
         peer.close()
         return
       }
-      this.onMessage.emit(peer, { peerIdentity: peer.state.identity, message: message })
+      this.onMessage.emit(peer, message)
     }
   }
 

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -7,7 +7,7 @@ import { Identity, isIdentity } from '../identity'
 import { GetBlockHeadersResponse } from '../messages/getBlockHeaders'
 import { GetBlockTransactionsResponse } from '../messages/getBlockTransactions'
 import { GetCompactBlockResponse } from '../messages/getCompactBlock'
-import { IncomingPeerMessage, NetworkMessage } from '../messages/networkMessage'
+import { NetworkMessage } from '../messages/networkMessage'
 import {
   Connection,
   ConnectionDirection,
@@ -75,17 +75,8 @@ export function getWaitingForIdentityPeer(
 }
 
 /* Used for constructing stubbed messages to send to the PeerManager.onMessage */
-export function peerMessage<T extends NetworkMessage>(
-  peer: Peer,
-  message: T,
-): [Peer, IncomingPeerMessage<T>] {
-  return [
-    peer,
-    {
-      peerIdentity: peer.getIdentityOrThrow(),
-      message,
-    },
-  ]
+export function peerMessage<T extends NetworkMessage>(peer: Peer, message: T): [Peer, T] {
+  return [peer, message]
 }
 
 /* Add new peers to the PeerManager and spy on peer.send() */

--- a/ironfish/src/network/transactionFetcher.test.ts
+++ b/ironfish/src/network/transactionFetcher.test.ts
@@ -5,16 +5,14 @@
 import { blake3 } from '@napi-rs/blake-hash'
 import { v4 as uuid } from 'uuid'
 import { IronfishNode } from '../node'
-import { TransactionHash } from '../primitives/transaction'
 import { createNodeTest, useAccountFixture, useBlockWithTx } from '../testUtilities'
-import { IncomingPeerMessage, NetworkMessage } from './messages/networkMessage'
+import { NetworkMessage } from './messages/networkMessage'
 import { NewPooledTransactionHashes } from './messages/newPooledTransactionHashes'
 import { NewTransactionsMessage } from './messages/newTransactions'
 import {
   PooledTransactionsRequest,
   PooledTransactionsResponse,
 } from './messages/pooledTransactions'
-import { Peer } from './peers/peer'
 import { getConnectedPeer, getConnectedPeersWithSpies } from './testUtilities'
 import { VERSION_PROTOCOL } from './version'
 
@@ -26,17 +24,6 @@ const getValidTransactionOnBlock = async (node: IronfishNode) => {
   const accountB = await useAccountFixture(node.wallet, 'accountB')
   const { transaction, block } = await useBlockWithTx(node, accountA, accountB)
   return { transaction, accountA, accountB, block }
-}
-
-const newHashMessage = (
-  peer: Peer,
-  hash: TransactionHash,
-): IncomingPeerMessage<NewPooledTransactionHashes> => {
-  const peerIdentity = peer.getIdentityOrThrow()
-  return {
-    peerIdentity,
-    message: new NewPooledTransactionHashes([hash]),
-  }
 }
 
 describe('TransactionFetcher', () => {
@@ -51,7 +38,10 @@ describe('TransactionFetcher', () => {
     const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
 
     for (const { peer } of peers) {
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, newHashMessage(peer, hash))
+      await peerNetwork.peerManager.onMessage.emitAsync(
+        peer,
+        new NewPooledTransactionHashes([hash]),
+      )
     }
 
     jest.runOnlyPendingTimers()
@@ -79,16 +69,15 @@ describe('TransactionFetcher', () => {
     const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
 
     for (const { peer } of peers) {
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, newHashMessage(peer, hash))
+      await peerNetwork.peerManager.onMessage.emitAsync(
+        peer,
+        new NewPooledTransactionHashes([hash]),
+      )
     }
 
     // Another peer send the full transaction
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
-    const peerIdentity = peer.getIdentityOrThrow()
-    const message = {
-      peerIdentity,
-      message: new NewTransactionsMessage([transaction]),
-    }
+    const message = new NewTransactionsMessage([transaction])
 
     await peerNetwork.peerManager.onMessage.emitAsync(peer, message)
 
@@ -113,7 +102,10 @@ describe('TransactionFetcher', () => {
     const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
 
     for (const { peer } of peers) {
-      await peerNetwork.peerManager.onMessage.emitAsync(peer, newHashMessage(peer, hash))
+      await peerNetwork.peerManager.onMessage.emitAsync(
+        peer,
+        new NewPooledTransactionHashes([hash]),
+      )
     }
 
     // We wait 500ms and then send the request for the transaction to a random peer
@@ -127,10 +119,7 @@ describe('TransactionFetcher', () => {
     const sentMessage = sentPeers[0].sendSpy.mock.calls[0][0]
     expect(sentMessage).toBeInstanceOf(PooledTransactionsRequest)
     const rpcId = (sentMessage as PooledTransactionsRequest).rpcId
-    const message = {
-      peerIdentity: sentPeer.getIdentityOrThrow(),
-      message: new PooledTransactionsResponse([transaction], rpcId),
-    }
+    const message = new PooledTransactionsResponse([transaction], rpcId)
 
     expect(node.memPool.exists(transaction.hash())).toBe(false)
 
@@ -165,7 +154,10 @@ describe('TransactionFetcher', () => {
 
     expect(peerNetwork.knowsTransaction(hash, peerIdentity)).toBe(false)
 
-    await peerNetwork.peerManager.onMessage.emitAsync(peer, newHashMessage(peer, hash))
+    await peerNetwork.peerManager.onMessage.emitAsync(
+      peer,
+      new NewPooledTransactionHashes([hash]),
+    )
 
     jest.runOnlyPendingTimers()
 
@@ -189,7 +181,10 @@ describe('TransactionFetcher', () => {
 
     expect(peerNetwork.knowsTransaction(hash, peerIdentity)).toBe(false)
 
-    await peerNetwork.peerManager.onMessage.emitAsync(peer, newHashMessage(peer, hash))
+    await peerNetwork.peerManager.onMessage.emitAsync(
+      peer,
+      new NewPooledTransactionHashes([hash]),
+    )
 
     jest.runOnlyPendingTimers()
 
@@ -219,7 +214,10 @@ describe('TransactionFetcher', () => {
     expect(peerNetwork.knowsTransaction(hash, peerIdentity)).toBe(false)
 
     // The first peer sends us the transaction hash
-    await peerNetwork.peerManager.onMessage.emitAsync(peer, newHashMessage(peer, hash))
+    await peerNetwork.peerManager.onMessage.emitAsync(
+      peer,
+      new NewPooledTransactionHashes([hash]),
+    )
 
     jest.runOnlyPendingTimers()
 
@@ -254,14 +252,20 @@ describe('TransactionFetcher', () => {
 
     // The first peer sends a hash message
     const peer1 = peers[0].peer
-    await peerNetwork.peerManager.onMessage.emitAsync(peer1, newHashMessage(peer1, hash))
+    await peerNetwork.peerManager.onMessage.emitAsync(
+      peer1,
+      new NewPooledTransactionHashes([hash]),
+    )
 
     // We wait 500ms and then send the request for the transaction to a random peer
     jest.runOnlyPendingTimers()
 
     // The second peer sends a hash message
     const peer2 = peers[1].peer
-    await peerNetwork.peerManager.onMessage.emitAsync(peer2, newHashMessage(peer2, hash))
+    await peerNetwork.peerManager.onMessage.emitAsync(
+      peer2,
+      new NewPooledTransactionHashes([hash]),
+    )
 
     // Should only send a request to one peer
     const sentPeersBefore = peers.filter(({ sendSpy }) => sendSpy.mock.calls.length > 0)
@@ -290,7 +294,7 @@ describe('TransactionFetcher', () => {
     const peer1 = peers[0].peer
     await peerNetwork.peerManager.onMessage.emitAsync(
       peer1,
-      newHashMessage(peer1, transaction.hash()),
+      new NewPooledTransactionHashes([transaction.hash()]),
     )
 
     // We wait 500ms and then send the request for the transaction to a random peer
@@ -300,7 +304,7 @@ describe('TransactionFetcher', () => {
     const peer2 = peers[1].peer
     await peerNetwork.peerManager.onMessage.emitAsync(
       peer2,
-      newHashMessage(peer2, transaction.hash()),
+      new NewPooledTransactionHashes([transaction.hash()]),
     )
 
     // Should only send a request to one peer


### PR DESCRIPTION
## Summary

This abstraction isn't really useful anymore since we pass the peer around with the message, so we can remove it and just emit the message directly.

## Testing Plan

Tests should pass.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
