### PR TITLE
Display features in the peers list

### DIFF
--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -45,6 +45,10 @@ export class ListCommand extends IronfishCommand {
       description: 'Display node names',
       hidden: true,
     }),
+    features: Flags.boolean({
+      default: false,
+      description: 'Display features that the peers have enabled',
+    }),
   }
 
   async start(): Promise<void> {
@@ -125,6 +129,26 @@ function renderTable(
       minWidth: 2,
       get: (row: GetPeerResponsePeer) => {
         return row.sequence || '-'
+      },
+    }
+  }
+
+  if (flags.features) {
+    columns['features'] = {
+      header: 'FEATURES',
+      minWidth: 2,
+      get: (row: GetPeerResponsePeer) => {
+        if (!row.features) {
+          return ''
+        }
+
+        return Object.entries(row.features)
+          .map(([k, v]) => {
+            return v ? k : null
+          })
+          .filter(Boolean)
+          .sort()
+          .join(',')
       },
     }
   }

--- a/ironfish/src/rpc/routes/peers/getPeer.ts
+++ b/ironfish/src/rpc/routes/peers/getPeer.ts
@@ -46,6 +46,12 @@ export const GetPeerResponseSchema: yup.ObjectSchema<GetPeerResponse> = yup
         connectionWebRTCError: yup.string().defined(),
         networkId: yup.number().nullable().defined(),
         genesisBlockHash: yup.string().nullable().defined(),
+        features: yup
+          .object({
+            syncing: yup.boolean().defined(),
+          })
+          .nullable()
+          .defined(),
       })
       .defined(),
   })
@@ -129,6 +135,7 @@ function getPeer(network: PeerNetwork, identity: string): PeerResponse | null {
         connectionWebRTCError: connectionWebRTCError,
         networkId: peer.networkId,
         genesisBlockHash: peer.genesisBlockHash?.toString('hex') || null,
+        features: peer.features,
       }
     }
   }

--- a/ironfish/src/rpc/routes/peers/getPeers.ts
+++ b/ironfish/src/rpc/routes/peers/getPeers.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Connection, PeerNetwork } from '../../../network'
+import { Features } from '../../../network/peers/peerFeatures'
 import { ApiNamespace, router } from '../router'
 
 type ConnectionState = Connection['state']['type'] | ''
@@ -26,6 +27,7 @@ export type PeerResponse = {
   connectionWebRTCError: string
   networkId: number | null
   genesisBlockHash: string | null
+  features: Features | null
 }
 
 export type GetPeersRequest =
@@ -69,6 +71,12 @@ export const GetPeersResponseSchema: yup.ObjectSchema<GetPeersResponse> = yup
             connectionWebRTCError: yup.string().defined(),
             networkId: yup.number().nullable().defined(),
             genesisBlockHash: yup.string().nullable().defined(),
+            features: yup
+              .object({
+                syncing: yup.boolean().defined(),
+              })
+              .nullable()
+              .defined(),
           })
           .defined(),
       )
@@ -155,6 +163,7 @@ function getPeers(network: PeerNetwork): PeerResponse[] {
       connectionWebRTCError: connectionWebRTCError,
       networkId: peer.networkId,
       genesisBlockHash: peer.genesisBlockHash?.toString('hex') || null,
+      features: peer.features,
     })
   }
 


### PR DESCRIPTION
## Summary

#3551 added features to the Identify message. This PR adds a `--features` flag to the `peers` command that displays what features a node has advertised in its Identify message.

## Testing Plan

Ran the command on a node with the syncing feature enabled and disabled to check that it appears (and doesn't) in the FEATURES column.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
