### PR TITLE
Trim file contents when importing an account

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -127,7 +127,7 @@ export class ImportCommand extends IronfishCommand {
   async importFile(path: string): Promise<AccountImport> {
     const resolved = this.sdk.fileSystem.resolve(path)
     const data = await this.sdk.fileSystem.readFile(resolved)
-    return this.stringToAccountImport(data)
+    return this.stringToAccountImport(data.trim())
   }
 
   async importPipe(): Promise<AccountImport> {


### PR DESCRIPTION
## Summary

Many editors put new lines at the end of file, and any file with a newline that contains bech32 won't be importable.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
