### PR TITLE
Fix bech32 import for accounts without view key

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -84,7 +84,7 @@ export class ImportCommand extends IronfishCommand {
       }
     }
     CliUx.ux.error(
-      `Detected mnemonic input, but the import failed. 
+      `Detected mnemonic input, but the import failed.
       Please verify the input text or use a different method to import wallet`,
     )
   }
@@ -101,7 +101,16 @@ export class ImportCommand extends IronfishCommand {
     // bech32 encoded json
     const [decoded, _] = Bech32m.decode(data)
     if (decoded) {
-      return JSONUtils.parse<AccountImport>(decoded)
+      let data = JSONUtils.parse<AccountImport>(decoded)
+
+      if (data.spendingKey) {
+        data = {
+          ...data,
+          ...generateKeyFromPrivateKey(data.spendingKey),
+        }
+      }
+
+      return data
     }
 
     // mnemonic or explicit spending key


### PR DESCRIPTION
## Summary

This is breaking import of bech32 accounts without a view key. Those keys will fail YUP validation during import.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
