### PR TITLE
Fix JSON import for accounts without a view key

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -118,7 +118,16 @@ export class ImportCommand extends IronfishCommand {
 
     // raw json
     try {
-      return JSONUtils.parse<AccountImport>(data)
+      let json = JSONUtils.parse<AccountImport>(data)
+
+      if (json.spendingKey) {
+        json = {
+          ...json,
+          ...generateKeyFromPrivateKey(json.spendingKey),
+        }
+      }
+
+      return json
     } catch (e) {
       CliUx.ux.error(`Import failed for the given input: ${data}`)
     }


### PR DESCRIPTION
## Summary

This is breaking import of json accounts without a view key. Those keys will fail YUP validation during import.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
