### PR TITLE
Change promptCurrency to accept iron not ore

### DIFF
--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -50,13 +50,7 @@ export async function promptCurrency(options: {
       return null
     }
 
-    const [amount, error] = CurrencyUtils.decodeTry(input)
-
-    if (error) {
-      throw error
-    }
-
-    Assert.isNotNull(amount)
+    const amount = CurrencyUtils.decodeIron(input)
 
     if (options.minimum != null && amount < options.minimum) {
       continue

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Asset } from '@ironfish/rust-nodejs'
-import { Assert, CurrencyUtils, RpcClient } from '@ironfish/sdk'
+import { CurrencyUtils, RpcClient } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 
 export async function promptCurrency(options: {

--- a/ironfish/src/utils/currency.ts
+++ b/ironfish/src/utils/currency.ts
@@ -18,7 +18,7 @@ export class CurrencyUtils {
   }
 
   /**
-   * Parses iron as ore
+   * Parses iron into ore
    */
   static decodeIron(amount: string | number): bigint {
     return parseFixed(amount.toString(), 8).toBigInt()


### PR DESCRIPTION
## Summary

Users were typing iron in here, but this prompt accepted ore. Changes this to accept and decode iron now.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
