### PR TITLE
Show nicer parsing errors in promptCurrency

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -139,6 +139,7 @@ export class Burn extends IronfishCommand {
         required: true,
         text: 'Enter the amount of the custom asset to burn',
         minimum: 1n,
+        logger: this.logger,
         balance: {
           account,
           confirmations: flags.confirmations,
@@ -166,6 +167,7 @@ export class Burn extends IronfishCommand {
       raw = await selectFee({
         client,
         transaction: params,
+        logger: this.logger,
       })
     } else {
       const response = await client.createTransaction(params)

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -178,6 +178,7 @@ export class Mint extends IronfishCommand {
         required: true,
         text: 'Enter the amount',
         minimum: 1n,
+        logger: this.logger,
       })
     }
 
@@ -203,6 +204,7 @@ export class Mint extends IronfishCommand {
       raw = await selectFee({
         client,
         transaction: params,
+        logger: this.logger,
       })
     } else {
       const response = await client.createTransaction(params)

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -143,6 +143,7 @@ export class Send extends IronfishCommand {
         required: true,
         text: 'Enter the amount',
         minimum: 1n,
+        logger: this.logger,
         balance: {
           account: from,
           confirmations: flags.confirmations,
@@ -201,6 +202,7 @@ export class Send extends IronfishCommand {
       raw = await selectFee({
         client,
         transaction: params,
+        logger: this.logger,
       })
     } else {
       const response = await client.createTransaction(params)

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -8,6 +8,7 @@ import {
   CreateTransactionRequest,
   CurrencyUtils,
   ERROR_CODES,
+  Logger,
   RawTransaction,
   RawTransactionSerde,
   RpcClient,
@@ -21,6 +22,7 @@ export async function selectFee(options: {
   transaction: CreateTransactionRequest
   account?: string
   confirmations?: number
+  logger: Logger
 }): Promise<RawTransaction> {
   const feeRates = await options.client.estimateFeeRates()
 
@@ -68,6 +70,7 @@ export async function selectFee(options: {
       client: options.client,
       required: true,
       text: 'Enter the fee amount in $IRON',
+      logger: options.logger,
       balance: {
         account: options.account,
         confirmations: options.confirmations,


### PR DESCRIPTION
## Summary

This will help parse the untyped errors from bignumber and add a new function to try and display them more cleanly.

It also now logs the reason for prompt errors. 

```bash
$ fishy wallet:send

Enter the amount (balance 0.00000000): 0.000000000005
Error: fractional component exceeds 8 decimals
Enter the amount (balance 0.00000000): fisdfjgdsdsfds
Error: invalid decimal value
Enter the amount (balance 0.00000000): -4
Error: Minimum is 0.00000001
Enter the amount (balance 0.00000000): 4
Enter the public address of the recipient:
```

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
