### PR TITLE
Update balance.ts

### DIFF
--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -56,7 +56,7 @@ export class BalanceCommand extends IronfishCommand {
     const assetId = response.content.assetId
 
     if (flags.explain) {
-      this.explainBalance(response.content, assetId)
+      this.explainBalance(response.content)
       return
     }
 


### PR DESCRIPTION
In the explainBalance() function, the parameter assetId is not used. This can be removed because the value of assetId can be obtained from response.content.assetId.

## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
