### PR TITLE
Add PeerNetwork checks for updated mempool

### DIFF
--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -142,16 +142,16 @@ export class MemPool {
   }
 
   /**
-   * @returns true if the transacition is either in the mempool or in the
+   * @returns true if the transaction is either in the mempool or in the
    * recently evicted cache. This does NOT indicate whether the full transaction
-   * is stored in the mempool or not
+   * is stored in the mempool
    */
   exists(hash: TransactionHash): boolean {
     return this.transactions.has(hash) || this.recentlyEvicted(hash)
   }
 
   /*
-   * Returns a transaction if the transaction with that hash exists in the mempool
+   * Returns a transaction if a full transaction with that hash exists in the mempool
    * Otherwise, returns undefined
    */
   get(hash: TransactionHash): Transaction | undefined {

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -838,7 +838,7 @@ describe('PeerNetwork', () => {
 
         expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(1)
 
-        expect(memPool.exists(transaction.hash())).toBe(true)
+        expect(memPool.get(transaction.hash())).toBeDefined()
 
         expect(addPendingTransaction).toHaveBeenCalledTimes(1)
 
@@ -869,7 +869,7 @@ describe('PeerNetwork', () => {
 
         expect(verifyNewTransactionSpy).toHaveBeenCalledTimes(1)
 
-        expect(memPool.exists(transaction.hash())).toBe(true)
+        expect(memPool.get(transaction.hash())).toBeDefined()
 
         expect(addPendingTransaction).toHaveBeenCalledTimes(1)
       })
@@ -1033,7 +1033,7 @@ describe('PeerNetwork', () => {
           valid: true,
         })
 
-        expect(memPool.exists(transaction.hash())).toBe(true)
+        expect(memPool.get(transaction.hash())).toBeDefined()
         expect(addPendingTransaction).toHaveBeenCalledTimes(1)
         for (const { sendSpy } of peersWithoutTransaction) {
           const transactionMessages = sendSpy.mock.calls.filter(([message]) => {

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -899,6 +899,14 @@ export class PeerNetwork {
         continue
       }
 
+      // Recently evicted means the transaction is relatively low feeRate
+      // mempool + wallet have already processed it. It could stil be download
+      // and forward to other peers but since it is a low feeRate and
+      // other peer mempools are likely at capacity, just drop it
+      if (this.node.memPool.recentlyEvicted(hash)) {
+        continue
+      }
+
       // If the transaction is already in the mempool we don't need to request
       // the full transaction. Just broadcast it
       const transaction = this.node.memPool.get(hash)
@@ -1334,6 +1342,7 @@ export class PeerNetwork {
       return
     }
 
+    // TODO(daniel): Could combine with double spend check in verifyNewTransaction
     if (this.recentlyAddedToChain.has(hash)) {
       this.transactionFetcher.removeTransaction(hash)
       return

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -126,8 +126,7 @@ export class PeerNetwork {
   private readonly transactionFetcher: TransactionFetcher
 
   // A cache that keeps track of transactions that are a part of recently confirmed blocks
-  // TODO(daniel): Consider replacing this with a nullifier check. This would filter out transactions
-  // that have overlapping nullifiers in the chain so we don't process those invalid transactions
+  // This is useful for filtering out downloading of transaction hashes that were recently added
   private readonly recentlyAddedToChain: LRU<TransactionHash, boolean> = new LRU<
     TransactionHash,
     boolean
@@ -135,7 +134,7 @@ export class PeerNetwork {
 
   // A cache that keeps track of which peers have seen which transactions. This allows
   // us to not send the same transaction to a peer more than once. TODO(daniel): We want to
-  // change this to use an RLU cache so that we don't get false positives
+  // change this to use an LRU cache so that we don't get false positives
   private readonly knownTransactionFilter: RollingFilter = new RollingFilter(
     GOSSIP_FILTER_SIZE * 50,
     GOSSIP_FILTER_FP_RATE,
@@ -1342,7 +1341,8 @@ export class PeerNetwork {
       return
     }
 
-    // TODO(daniel): Could combine with double spend check in verifyNewTransaction
+    // TODO(daniel): This is used to quickly filter double spend transactions and save on
+    // verification. Could be combined with double spend check in verifyNewTransaction
     if (this.recentlyAddedToChain.has(hash)) {
       this.transactionFetcher.removeTransaction(hash)
       return

--- a/ironfish/src/network/transactionFetcher.test.ts
+++ b/ironfish/src/network/transactionFetcher.test.ts
@@ -125,7 +125,7 @@ describe('TransactionFetcher', () => {
 
     await peerNetwork.peerManager.onMessage.emitAsync(sentPeer, message)
 
-    expect(node.memPool.exists(transaction.hash())).toBe(true)
+    expect(node.memPool.get(transaction.hash())).toBeDefined()
 
     // The timeout for the original request ends. This should not affect anything
     // since we've already received the response


### PR DESCRIPTION
## Summary
After adding max size to the mempool and adding a recently evicted cache we need to change transaction gossip logic to account for not all transactions being in the mempool.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
