### PR TITLE
feat: adds support to configure the max rolling avg samples for meters

### DIFF
--- a/ironfish/src/metrics/meter.ts
+++ b/ironfish/src/metrics/meter.ts
@@ -5,6 +5,13 @@ import { SetIntervalToken } from '../utils'
 import { EwmAverage } from './ewmAverage'
 import { RollingAverage } from './rollingAverage'
 
+export type newMeterOptions = {
+  /**
+   * The maximum number of samples to keep in the rolling average
+   */
+  maxRollingAverageSamples?: number
+}
+
 /**
  * A metric type useful for recording metered things like
  *  * blocks per second
@@ -31,7 +38,7 @@ export class Meter {
   private _intervalMs: number
   private _intervalLastMs: number | null = null
 
-  constructor() {
+  constructor(options?: newMeterOptions) {
     this._intervalMs = 1000
 
     this._rate1s = new EwmAverage(1000 / this._intervalMs)
@@ -39,7 +46,9 @@ export class Meter {
     this._rate1m = new EwmAverage((1 * 60 * 1000) / this._intervalMs)
     this._rate5m = new EwmAverage((5 * 60 * 1000) / this._intervalMs)
 
-    this._average = new RollingAverage(1000)
+    const numSamples = options?.maxRollingAverageSamples ?? 1000
+
+    this._average = new RollingAverage(numSamples)
 
     this._rollingRate1s = new RollingAverage(1000 / this._intervalMs)
     this._rollingRate5s = new RollingAverage(5000 / this._intervalMs)

--- a/ironfish/src/metrics/meter.ts
+++ b/ironfish/src/metrics/meter.ts
@@ -5,13 +5,6 @@ import { SetIntervalToken } from '../utils'
 import { EwmAverage } from './ewmAverage'
 import { RollingAverage } from './rollingAverage'
 
-export type newMeterOptions = {
-  /**
-   * The maximum number of samples to keep in the rolling average
-   */
-  maxRollingAverageSamples?: number
-}
-
 /**
  * A metric type useful for recording metered things like
  *  * blocks per second
@@ -38,7 +31,7 @@ export class Meter {
   private _intervalMs: number
   private _intervalLastMs: number | null = null
 
-  constructor(options?: newMeterOptions) {
+  constructor(options?: { maxRollingAverageSamples?: number }) {
     this._intervalMs = 1000
 
     this._rate1s = new EwmAverage(1000 / this._intervalMs)

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -10,7 +10,7 @@ import { NetworkMessageType } from '../network/types'
 import { NumberEnumUtils, SetIntervalToken } from '../utils'
 import { CPUMeter } from './cpuMeter'
 import { Gauge } from './gauge'
-import { Meter } from './meter'
+import { Meter, newMeterOptions } from './meter'
 
 export class MetricsMonitor {
   private _started = false
@@ -56,7 +56,7 @@ export class MetricsMonitor {
 
     this.mining_newBlockTemplate = this.addMeter()
     this.chain_newBlock = this.addMeter()
-    this.mining_newBlockTransactions = this.addMeter()
+    this.mining_newBlockTransactions = this.addMeter({ maxRollingAverageSamples: 100 })
 
     this.p2p_InboundTraffic = this.addMeter()
     this.p2p_InboundTraffic_WS = this.addMeter()
@@ -111,8 +111,8 @@ export class MetricsMonitor {
     }
   }
 
-  addMeter(): Meter {
-    const meter = new Meter()
+  addMeter(options?: newMeterOptions): Meter {
+    const meter = new Meter(options)
     this._meters.push(meter)
     if (this._started) {
       meter.start()

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -10,7 +10,7 @@ import { NetworkMessageType } from '../network/types'
 import { NumberEnumUtils, SetIntervalToken } from '../utils'
 import { CPUMeter } from './cpuMeter'
 import { Gauge } from './gauge'
-import { Meter, newMeterOptions } from './meter'
+import { Meter } from './meter'
 
 export class MetricsMonitor {
   private _started = false
@@ -111,7 +111,7 @@ export class MetricsMonitor {
     }
   }
 
-  addMeter(options?: newMeterOptions): Meter {
+  addMeter(options?: { maxRollingAverageSamples?: number }): Meter {
     const meter = new Meter(options)
     this._meters.push(meter)
     if (this._started) {

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -231,7 +231,7 @@ export class Telemetry {
       fields.push({
         name: 'create_new_block_template_duration',
         type: 'float',
-        value: this.metrics.mining_newBlockTemplate.rate5m,
+        value: this.metrics.mining_newBlockTemplate.avg,
       })
     }
 


### PR DESCRIPTION
## Summary
Adds support to configure the max # of samples tracked in a `meter.rollling_avg`

Using `rate5m` is causing issues with the telemetry graphs for `create_new_block_template` as the inclusion of 0 values when new block templates are not being created are skewing the results. Switching to `avg` so sample are only added when new block templates are being created. Max # of values tracking in the rolling avg is set to `100`

## Testing Plan
existing tests

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
