### PR TITLE
Feature: accounts:delete --wait

### DIFF
--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -37,7 +37,9 @@ export class DeleteCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
+    CliUx.ux.action.start(`Deleting account '${account}'`)
     const response = await client.removeAccount({ account, confirm, wait })
+    CliUx.ux.action.stop()
 
     if (response.content.needsConfirm) {
       const value = await CliUx.ux.prompt(`Are you sure? Type ${account} to confirm`)
@@ -47,7 +49,9 @@ export class DeleteCommand extends IronfishCommand {
         this.exit(1)
       }
 
+      CliUx.ux.action.start(`Deleting account '${account}'`)
       await client.removeAccount({ account, confirm: true, wait })
+      CliUx.ux.action.stop()
     }
 
     this.log(`Account '${account}' successfully deleted.`)

--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -23,16 +23,21 @@ export class DeleteCommand extends IronfishCommand {
     confirm: Flags.boolean({
       description: 'Suppress the confirmation prompt',
     }),
+    wait: Flags.boolean({
+      description:
+        'Wait for the account to be deleted, rather than the default of marking the account for deletion then returning immediately',
+    }),
   }
 
   async start(): Promise<void> {
     const { args, flags } = await this.parse(DeleteCommand)
     const confirm = flags.confirm
+    const wait = flags.wait
     const account = args.account as string
 
     const client = await this.sdk.connectRpc()
 
-    const response = await client.removeAccount({ account, confirm })
+    const response = await client.removeAccount({ account, confirm, wait })
 
     if (response.content.needsConfirm) {
       const value = await CliUx.ux.prompt(`Are you sure? Type ${account} to confirm`)
@@ -42,7 +47,7 @@ export class DeleteCommand extends IronfishCommand {
         this.exit(1)
       }
 
-      await client.removeAccount({ account, confirm: true })
+      await client.removeAccount({ account, confirm: true, wait })
     }
 
     this.log(`Account '${account}' successfully deleted.`)

--- a/ironfish/src/rpc/routes/wallet/removeAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/removeAccount.ts
@@ -40,7 +40,7 @@ router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
     }
     await node.wallet.removeAccountByName(account.name)
     if (request.data.wait) {
-      await node.wallet.forceDeletedAccountCleanup()
+      await node.wallet.forceCleanupDeletedAccounts()
     }
     request.end({})
   },

--- a/ironfish/src/rpc/routes/wallet/removeAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/removeAccount.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
-export type RemoveAccountRequest = { account: string; confirm?: boolean, wait?: boolean }
+export type RemoveAccountRequest = { account: string; confirm?: boolean; wait?: boolean }
 export type RemoveAccountResponse = { needsConfirm?: boolean }
 
 export const RemoveAccountRequestSchema: yup.ObjectSchema<RemoveAccountRequest> = yup
@@ -40,8 +40,9 @@ router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
     }
     if (request.data.wait) {
       await node.wallet.removeAccountByNameSynchronous(account.name)
+    } else {
+      await node.wallet.removeAccountByName(account.name)
     }
-    await node.wallet.removeAccountByName(account.name)
     request.end({})
   },
 )

--- a/ironfish/src/rpc/routes/wallet/removeAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/removeAccount.ts
@@ -5,13 +5,14 @@ import * as yup from 'yup'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
-export type RemoveAccountRequest = { account: string; confirm?: boolean }
+export type RemoveAccountRequest = { account: string; confirm?: boolean, wait?: boolean }
 export type RemoveAccountResponse = { needsConfirm?: boolean }
 
 export const RemoveAccountRequestSchema: yup.ObjectSchema<RemoveAccountRequest> = yup
   .object({
     account: yup.string().defined(),
     confirm: yup.boolean().optional(),
+    wait: yup.boolean().optional(),
   })
   .defined()
 
@@ -37,7 +38,9 @@ router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
         }
       }
     }
-
+    if (request.data.wait) {
+      await node.wallet.removeAccountByNameSynchronous(account.name)
+    }
     await node.wallet.removeAccountByName(account.name)
     request.end({})
   },

--- a/ironfish/src/rpc/routes/wallet/removeAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/removeAccount.ts
@@ -38,10 +38,9 @@ router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
         }
       }
     }
+    await node.wallet.removeAccountByName(account.name)
     if (request.data.wait) {
-      await node.wallet.removeAccountByNameSynchronous(account.name)
-    } else {
-      await node.wallet.removeAccountByName(account.name)
+      await node.wallet.forceDeletedAccountCleanup()
     }
     request.end({})
   },

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1404,10 +1404,10 @@ export class Wallet {
       }
       // no this.walletDb.removeAccount(account, tx) - we don't want to add the account to cleanup list
       await this.walletDb.removeHead(account, tx)
-      this.accounts.delete(account.id)
       await this.walletDb.deleteAccount(account, tx)
-      this.onAccountRemoved.emit(account)
     })
+    this.accounts.delete(account.id)
+    this.onAccountRemoved.emit(account)
   }
 
   async cleanupDeletedAccounts(): Promise<void> {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1400,7 +1400,11 @@ export class Wallet {
       return
     }
 
-    await this.walletDb.cleanupDeletedAccounts(1000, this.eventLoopAbortController.signal)
+    const recordsToCleanup = 1000
+    await this.walletDb.cleanupDeletedAccounts(
+      recordsToCleanup,
+      this.eventLoopAbortController.signal,
+    )
   }
 
   get hasDefaultAccount(): boolean {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1388,7 +1388,7 @@ export class Wallet {
   }
 
   async forceDeletedAccountCleanup(): Promise<void> {
-    await this.walletDb.cleanupAllAccountsNow(this.eventLoopAbortController.signal)
+    await this.walletDb.forceDeletedAccountCleanup(this.eventLoopAbortController.signal)
   }
 
   async cleanupDeletedAccounts(): Promise<void> {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1372,15 +1372,6 @@ export class Wallet {
     await this.removeAccount(account)
   }
 
-  async removeAccountByNameSynchronous(name: string): Promise<void> {
-    const account = this.getAccountByName(name)
-    if (!account) {
-      return
-    }
-
-    await this.removeAccountSynchronous(account)
-  }
-
   async removeAccount(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.walletDb.db.withTransaction(tx, async (tx) => {
       if (account.id === this.defaultAccount) {
@@ -1396,8 +1387,7 @@ export class Wallet {
     this.onAccountRemoved.emit(account)
   }
 
-  async removeAccountSynchronous(account: Account, tx?: IDatabaseTransaction): Promise<void> {
-    await this.removeAccount(account, tx)
+  async forceDeletedAccountCleanup(): Promise<void> {
     await this.walletDb.cleanupAllAccountsNow(this.eventLoopAbortController.signal)
   }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1387,8 +1387,8 @@ export class Wallet {
     this.onAccountRemoved.emit(account)
   }
 
-  async forceDeletedAccountCleanup(): Promise<void> {
-    await this.walletDb.forceDeletedAccountCleanup(this.eventLoopAbortController.signal)
+  async forceCleanupDeletedAccounts(): Promise<void> {
+    await this.walletDb.forceCleanupDeletedAccounts(this.eventLoopAbortController.signal)
   }
 
   async cleanupDeletedAccounts(): Promise<void> {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1397,17 +1397,8 @@ export class Wallet {
   }
 
   async removeAccountSynchronous(account: Account, tx?: IDatabaseTransaction): Promise<void> {
-    await this.walletDb.db.withTransaction(tx, async (tx) => {
-      if (account.id === this.defaultAccount) {
-        await this.walletDb.setDefaultAccount(null, tx)
-        this.defaultAccount = null
-      }
-      // no this.walletDb.removeAccount(account, tx) - we don't want to add the account to cleanup list
-      await this.walletDb.removeHead(account, tx)
-      await this.walletDb.deleteAccount(account, tx)
-    })
-    this.accounts.delete(account.id)
-    this.onAccountRemoved.emit(account)
+    await this.removeAccount(account, tx)
+    await this.walletDb.deleteAccount(account, tx)
   }
 
   async cleanupDeletedAccounts(): Promise<void> {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1398,7 +1398,7 @@ export class Wallet {
 
   async removeAccountSynchronous(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.removeAccount(account, tx)
-    await this.walletDb.deleteAccount(account, tx)
+    await this.walletDb.cleanupAllAccountsNow()
   }
 
   async cleanupDeletedAccounts(): Promise<void> {
@@ -1410,7 +1410,7 @@ export class Wallet {
       return
     }
 
-    await this.walletDb.cleanupDeletedAccounts(this.eventLoopAbortController.signal)
+    await this.walletDb.cleanupDeletedAccounts(1000, this.eventLoopAbortController.signal)
   }
 
   get hasDefaultAccount(): boolean {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1372,6 +1372,16 @@ export class Wallet {
     await this.removeAccount(account)
   }
 
+  async removeAccountByNameSynchronous(name: string): Promise<void> {
+    const account = this.getAccountByName(name)
+    if (!account) {
+      return
+    }
+
+    await this.removeAccountSynchronous(account)
+  }
+  
+
   async removeAccount(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.walletDb.db.withTransaction(tx, async (tx) => {
       if (account.id === this.defaultAccount) {
@@ -1385,6 +1395,10 @@ export class Wallet {
 
     this.accounts.delete(account.id)
     this.onAccountRemoved.emit(account)
+  }
+
+  async removeAccountSynchronous(account: Account): Promise<void> {
+    await this.walletDb.deleteAccount(account)
   }
 
   async cleanupDeletedAccounts(): Promise<void> {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1380,7 +1380,6 @@ export class Wallet {
 
     await this.removeAccountSynchronous(account)
   }
-  
 
   async removeAccount(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.walletDb.db.withTransaction(tx, async (tx) => {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1396,7 +1396,8 @@ export class Wallet {
     this.onAccountRemoved.emit(account)
   }
 
-  async removeAccountSynchronous(account: Account): Promise<void> {
+  async removeAccountSynchronous(account: Account, tx?: IDatabaseTransaction): Promise<void> {
+    await this.removeAccount(account, tx)
     await this.walletDb.deleteAccount(account)
   }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1398,7 +1398,7 @@ export class Wallet {
 
   async removeAccountSynchronous(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     await this.removeAccount(account, tx)
-    await this.walletDb.cleanupAllAccountsNow()
+    await this.walletDb.cleanupAllAccountsNow(this.eventLoopAbortController.signal)
   }
 
   async cleanupDeletedAccounts(): Promise<void> {

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1044,9 +1044,7 @@ export class WalletDB {
     const range = StorageUtils.getPrefixKeyRange(prefix)
 
     for (const store of stores) {
-      for await (const key of store.getAllKeysIter(undefined, range)) {
-        await store.del(key)
-      }
+      await store.clear(tx, range)
     }
   }
 

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1023,7 +1023,7 @@ export class WalletDB {
     await this.pendingTransactionHashes.clear(tx, account.prefixRange)
   }
 
-  async cleanupAllAccountsNow(signal?: AbortSignal): Promise<void> {
+  async forceDeletedAccountCleanup(signal?: AbortSignal): Promise<void> {
     return this.cleanupDeletedAccounts(Number.MAX_SAFE_INTEGER, signal)
   }
 

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1023,7 +1023,7 @@ export class WalletDB {
     await this.pendingTransactionHashes.clear(tx, account.prefixRange)
   }
 
-  async forceDeletedAccountCleanup(signal?: AbortSignal): Promise<void> {
+  async forceCleanupDeletedAccounts(signal?: AbortSignal): Promise<void> {
     return this.cleanupDeletedAccounts(Number.MAX_SAFE_INTEGER, signal)
   }
 

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1023,34 +1023,11 @@ export class WalletDB {
     await this.pendingTransactionHashes.clear(tx, account.prefixRange)
   }
 
-  async deleteAccount(account: Account, tx?: IDatabaseTransaction): Promise<void> {
-    const stores: IDatabaseStore<{
-      key: Readonly<unknown>
-      value: unknown
-    }>[] = [
-      this.transactions,
-      this.sequenceToNoteHash,
-      this.nonChainNoteHashes,
-      this.nullifierToNoteHash,
-      this.pendingTransactionHashes,
-      this.decryptedNotes,
-      this.timestampToTransactionHash,
-      this.accounts,
-    ]
-
-    await this.clearBalance(account, tx)
-
-    const prefix = calculateAccountPrefix(account.id)
-    const range = StorageUtils.getPrefixKeyRange(prefix)
-
-    for (const store of stores) {
-      await store.clear(tx, range)
-    }
+  async cleanupAllAccountsNow(signal?: AbortSignal): Promise<void> {
+    return this.cleanupDeletedAccounts(Number.MAX_SAFE_INTEGER, signal)
   }
 
-  async cleanupDeletedAccounts(signal?: AbortSignal): Promise<void> {
-    let recordsToCleanup = 1000
-
+  async cleanupDeletedAccounts(recordsToCleanup: number, signal?: AbortSignal): Promise<void> {
     const stores: IDatabaseStore<{
       key: Readonly<unknown>
       value: unknown

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1023,7 +1023,7 @@ export class WalletDB {
     await this.pendingTransactionHashes.clear(tx, account.prefixRange)
   }
 
-  async deleteAccount(account: Account): Promise<void> {
+  async deleteAccount(account: Account, tx?: IDatabaseTransaction): Promise<void> {
     const stores: IDatabaseStore<{
       key: Readonly<unknown>
       value: unknown
@@ -1035,7 +1035,11 @@ export class WalletDB {
       this.pendingTransactionHashes,
       this.decryptedNotes,
       this.timestampToTransactionHash,
+      this.accounts,
     ]
+
+    await this.clearBalance(account, tx)
+
     const prefix = calculateAccountPrefix(account.id)
     const range = StorageUtils.getPrefixKeyRange(prefix)
 

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1023,6 +1023,29 @@ export class WalletDB {
     await this.pendingTransactionHashes.clear(tx, account.prefixRange)
   }
 
+  async deleteAccount(account: Account): Promise<void> {
+    const stores: IDatabaseStore<{
+      key: Readonly<unknown>
+      value: unknown
+    }>[] = [
+      this.transactions,
+      this.sequenceToNoteHash,
+      this.nonChainNoteHashes,
+      this.nullifierToNoteHash,
+      this.pendingTransactionHashes,
+      this.decryptedNotes,
+      this.timestampToTransactionHash,
+    ]
+    const prefix = calculateAccountPrefix(account.id)
+    const range = StorageUtils.getPrefixKeyRange(prefix)
+
+    for (const store of stores) {
+      for await (const key of store.getAllKeysIter(undefined, range)) {
+        await store.del(key)
+      }
+    }
+  }
+
   async cleanupDeletedAccounts(signal?: AbortSignal): Promise<void> {
     let recordsToCleanup = 1000
 

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1024,7 +1024,7 @@ export class WalletDB {
   }
 
   async forceCleanupDeletedAccounts(signal?: AbortSignal): Promise<void> {
-    return this.cleanupDeletedAccounts(Number.MAX_SAFE_INTEGER, signal)
+    return this.cleanupDeletedAccounts(Number.POSITIVE_INFINITY, signal)
   }
 
   async cleanupDeletedAccounts(recordsToCleanup: number, signal?: AbortSignal): Promise<void> {


### PR DESCRIPTION
## Summary
As it stands currently, `accounts:delete` only marks an account for deletion. This account is later deleted in the event loop. 

This feature proposes to add an option `--wait`. This will immediately force the cleanup code to be called. 

## Testing Plan
```
yarn start wallet:use killme
The default account is now: killme
```
```
yarn start wallet:delete --wait killme
Deleting account 'killme'... done
Account 'killme' successfully deleted.
```
```
yarn start wallet:accounts
default
```
## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
