### PR TITLE
adds createdAt field to Account

### DIFF
--- a/ironfish/src/migrations/data/021-add-version-to-accounts/schemaOld.ts
+++ b/ironfish/src/migrations/data/021-add-version-to-accounts/schemaOld.ts
@@ -100,6 +100,7 @@ export async function GetOldAccounts(
         ...account,
         version: 1,
         viewKey: key.viewKey,
+        createdAt: null,
         walletDb: node.wallet.walletDb,
       }),
     )

--- a/ironfish/src/migrations/data/024-unspent-notes.ts
+++ b/ironfish/src/migrations/data/024-unspent-notes.ts
@@ -31,6 +31,7 @@ export class Migration024 extends Migration {
       accounts.push(
         new Account({
           ...accountValue,
+          createdAt: null,
           walletDb: node.wallet.walletDb,
         }),
       )

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
@@ -29,6 +29,7 @@ export class Migration025 extends Migration {
       accounts.push(
         new Account({
           ...account,
+          createdAt: null,
           walletDb: node.wallet.walletDb,
         }),
       )

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -46,6 +46,7 @@ router.register<typeof ImportAccountRequestSchema, ImportResponse>(
   async (request, node): Promise<void> => {
     const accountValue = {
       id: uuid(),
+      createdAt: null,
       ...request.data.account,
     }
     const account = await node.wallet.importAccount(accountValue)

--- a/ironfish/src/testUtilities/fixtures/account.ts
+++ b/ironfish/src/testUtilities/fixtures/account.ts
@@ -32,7 +32,8 @@ export function useAccountFixture(
     },
 
     deserialize: async (accountData: AccountValue): Promise<SpendingAccount> => {
-      const account = await wallet.importAccount(accountData)
+      const createdAt = accountData.createdAt ? new Date(accountData.createdAt) : null
+      const account = await wallet.importAccount({ ...accountData, createdAt })
 
       if (accountData) {
         if (wallet.chainProcessor.hash && wallet.chainProcessor.sequence) {

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -36,6 +36,7 @@ export class Account {
   readonly outgoingViewKey: string
   readonly version: number
   publicAddress: string
+  readonly createdAt: Date | null
   readonly prefix: Buffer
   readonly prefixRange: DatabaseKeyRange
 
@@ -49,6 +50,7 @@ export class Account {
     incomingViewKey,
     outgoingViewKey,
     version,
+    createdAt,
   }: AccountValue & { walletDb: WalletDB }) {
     this.id = id
     this.name = name
@@ -65,6 +67,7 @@ export class Account {
 
     this.walletDb = walletDb
     this.version = version ?? 1
+    this.createdAt = createdAt
   }
 
   serialize(): AccountValue {
@@ -77,6 +80,7 @@ export class Account {
       incomingViewKey: this.incomingViewKey,
       outgoingViewKey: this.outgoingViewKey,
       publicAddress: this.publicAddress,
+      createdAt: this.createdAt,
     }
   }
 

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -633,6 +633,7 @@ describe('Accounts', () => {
       viewKey: account.viewKey,
       outgoingViewKey: account.outgoingViewKey,
       incomingViewKey: account.incomingViewKey,
+      createdAt: null,
     }
     const viewOnlyAccount = await viewOnlyNode.wallet.importAccount(accountValue)
 

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -553,6 +553,7 @@ describe('Accounts', () => {
         name: 'viewonly',
         version: 1,
         spendingKey: null,
+        createdAt: null,
         ...key,
       }
       const viewonlyAccount = await node.wallet.importAccount(accountValue)
@@ -572,6 +573,7 @@ describe('Accounts', () => {
         name: 'viewonly',
         version: 1,
         spendingKey: null,
+        createdAt: null,
         ...key,
       }
       await node.wallet.importAccount(accountValue)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1272,6 +1272,7 @@ export class Wallet {
       publicAddress: key.publicAddress,
       spendingKey: key.spendingKey,
       viewKey: key.viewKey,
+      createdAt: new Date(),
       walletDb: this.walletDb,
     })
 

--- a/ironfish/src/wallet/walletdb/accountValue.test.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.test.ts
@@ -18,6 +18,7 @@ describe('AccountValueEncoding', () => {
       spendingKey: key.spendingKey,
       viewKey: key.viewKey,
       version: 1,
+      createdAt: new Date(2023, 2, 28),
     }
     const buffer = encoder.serialize(value)
     const deserializedValue = encoder.deserialize(buffer)

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -19,15 +19,17 @@ export interface AccountValue {
   incomingViewKey: string
   outgoingViewKey: string
   publicAddress: string
+  createdAt: Date | null
 }
 
-export type AccountImport = Omit<AccountValue, 'id'>
+export type AccountImport = Omit<AccountValue, 'id' | 'createdAt'>
 
 export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
   serialize(value: AccountValue): Buffer {
     const bw = bufio.write(this.getSize(value))
     let flags = 0
     flags |= Number(!!value.spendingKey) << 0
+    flags |= Number(!!value.createdAt) << 1
     bw.writeU8(flags)
     bw.writeU16(value.version)
     bw.writeVarString(value.id, 'utf8')
@@ -39,6 +41,9 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
     bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
     bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
+    if (value.createdAt) {
+      bw.writeU64(value.createdAt.getTime())
+    }
 
     return bw.render()
   }
@@ -48,6 +53,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     const flags = reader.readU8()
     const version = reader.readU16()
     const hasSpendingKey = flags & (1 << 0)
+    const hasCreatedAt = flags & (1 << 1)
     const id = reader.readVarString('utf8')
     const name = reader.readVarString('utf8')
     const spendingKey = hasSpendingKey ? reader.readBytes(KEY_LENGTH).toString('hex') : null
@@ -55,6 +61,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
     const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
     const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+    const createdAt = hasCreatedAt ? new Date(reader.readU64()) : null
 
     return {
       version,
@@ -65,6 +72,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
       outgoingViewKey,
       spendingKey,
       publicAddress,
+      createdAt,
     }
   }
 
@@ -81,6 +89,9 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     size += KEY_LENGTH
     size += KEY_LENGTH
     size += PUBLIC_ADDRESS_LENGTH
+    if (value.createdAt) {
+      size += 8
+    }
 
     return size
   }


### PR DESCRIPTION
## Summary

the createdAt field or 'account birthday' will be used during account scanning to skip blocks that were created before the account was created.

adds a nullable createdAt date field. the field may be null for imported accounts. if an account is imported we cannot determine when the account was created without scanning the chain for the earliest transactions that involved that account.

theses changes do not yet support importing an account with a creation date. followup changes should add createdAt to account exports and make the field optional for imports.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
