### PR TITLE
sets the account birthday on block connect/disconnect

### DIFF
--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -4805,5 +4805,217 @@
         }
       ]
     }
+  ],
+  "Accounts connectBlock should not set account createdAt if the connected block is later than the current value": [
+    {
+      "version": 1,
+      "id": "2741c742-cc7d-4d90-aa30-d79928847449",
+      "name": "accountA",
+      "spendingKey": "f87c56402e80e3ee89319f9f56bd8d7da2e5adea7f5f3fb59a8573e837febe9c",
+      "viewKey": "85b2f0361f47abb91dc934ab3b910bee8cb5862f749c04aa3368813ad2f8e5da264082c2640df31d3fdc12d469b152cadabe4d02d717221def0ded677d762e65",
+      "incomingViewKey": "5e1dc2da5875fefd1a37ea5a9f420c6a8f31355fd077026b9a277af4c06ee100",
+      "outgoingViewKey": "3f64f678213e381d7dfdbfaa40f81ce828a0fef0e117cc75f0a17b8cb963aa46",
+      "publicAddress": "706a501a825c02ce858f53db77a402d226cbddbf2574123c56e90943d0f6fbca",
+      "createdAt": "2023-03-02T00:18:56.905Z"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:StOmWV+mCA5baAXSKTbQHD3dvoS6piHIxIbA4x8dIjI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:RZOtBnocI1p7vCy2Bvwam3HEaIPiN+EJg0qNCVR37Qo="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1677716337319,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAyfIkCGDjd3ugblKBjsF7IAyMwD07Vn7PM9zMgZsqfamtJASKxbJ7CXxf+HWsnAqrZCwJpv7wKusnRdb3Q2qsavgCHAymcvS7u1X7dkKy2kCUw6gINNkSGNQwIefsTA/74ERN+1IRNs+ZvQMPBZeIgj/D/NB1TUw74xeqd3c4K2MXv+2iEeagavrXuDRJT4fvAgCay/qcrJJAKQqrnBeldBg5W/g8cSKqT0X0FulVkHKl9bGFqPdIAZnwQiJOjtcTxjcYZkessNCI1U6OgSUVpZptZPD1eFUqANGJMLFJOcznuoYxlmSodhapBTTDjFnLU6VG6504C9lpBlICmNHkD5JkeTCQNsZVN/suOVWOezYzYgidWyl6y9F1JfOljrYgdoYNoApa8NGiKFhxWnthgyVXvlEfTmc8jX3jc3DktW0rOIRMITuvaXiE/R/tl1QlFlNz8bsGarLopu/zjza/FNuKoamjn7h9msfuZGrc9ozH31hr5iomrAgJXuugnQAukcG5Gme5OW1cA3NRCA6xlqyDkjqHkYES+OBcVm/1XUWKcy6AlqJaZKFkMuU31X+PMCav7ZAYCzRlOG9Xt+tz2MplylZ1l63tvm1DX73b3iiSWO2Y1WDIUklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOhyQ6Y8EUVXqFxW5Z4rPe9K9NjKabPbSsyfRQcOo6cgIn329kPVX6DqQWvJocFUupgNQ5OM+u2Q0JgadG2piAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "126AE410B1208BBDACC96106488BE03707B9B4F1E992A9CA77318C2392E5AEB2",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZrPeRqzfUVwYnyPw3lxmZYPjnhJqPTcwdlJN4R/hOC0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:M3EPaSRaSCavy+b3C9A+kmh7ELnyzW/XG/KWBOPnuDs="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1677716337864,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA3u7+KTyJzzQ5rRzKsl/ughgbyGPfpTK+NjvgrRHH7durC+fhEBeoMye8MtDqpyooG7G5vY39gWOMbTgnp/ZXDrnkj7HfSSceYBU4rcdnHHeQYLq68qB9zfPt3ocyJg/WfcCXepONb2Aa8xNXlEtCSpGazalpEcPSHe9hLG4+XNgKQ1hbZeiVIZd4OHSaXyv2qiexbaBGmhWfzJKvxiWklyXaLztu4dH8pIOVZngXqnCQi/fsN8+eYQIN7S1qcuyoSfdtiTyfZT1vhv+K1RqTQkQfdgb8UUAWnwxY/uiJAz5ShYSE/SIRMRSI2JcCLArMXUWirD4o+pRyymb1VWW2rKvgFiCX2U3Pj/6cjbv70DPnX01CmPzpswzIjyuf4jZZhq2NfLeIJvB2wbqZXdpfycjBOGrvHH3XcLYiTOukQmLQwrK3v8EYeTmVE1trUGeW9HkKeUrDLx5PIl6UVBtswAcuJXv3OTvfF7kP0rhZMAh9Y93t3PKHtdLWz50DjGjw6kOVGWxS4sWCK5YwysoNC1pcxsWwQZ9K7HkTdxg67DIzex1u3yqU5vVV+9BMT1xsxlVoOhAuNXKqciuhkbcn4Kus3Q23wr7CR2S0q0/7zoHa+DQwnerotUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaMNDCCA0SamLlF/agsHH5stVs/JzhAQr276KMFrPwyNelOZB0cc44tXUo8uYt/neHPnMtgmceVbo54p1Av5sCQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should set account createdAt to the earliest transaction timestamp": [
+    {
+      "version": 1,
+      "id": "5ab8b68a-6f38-4fb0-8651-8e311b928235",
+      "name": "accountA",
+      "spendingKey": "4e4d7194a2550c35c46a273f5fa67a5c2742cb9873b32c73dac9479c9a5bfb0b",
+      "viewKey": "89b73011114feeb7ea8a9adc931fcc2230a67caf34256d642a1f96d51d9a4ad5e24463095f6f9ffc98f9685341512a0754dd22a55f9ae1377b0bccea994a87b9",
+      "incomingViewKey": "b59626b834b5c0382b83622095e6c8518b1dcfa94f4980289f2c2f75c2e8f906",
+      "outgoingViewKey": "5befaca509be3c82fa99a1ecbcbaffd2bea00635265d7935d50d8380fb1cc9c3",
+      "publicAddress": "dab70de80e3db82eec4f6141072be483f9060dd04a67eeb9b2e2c862544c2c2c",
+      "createdAt": "2023-03-02T01:06:26.319Z"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:y8UWBsblT63UWoQO8yg/C+xLuVSbKSAQZTwUqS5+vmQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:bk5uduCSaP7uWac6oLYrr2or6H+VBYtD6GW1/8hg52Y="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1677719187107,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAhjBfsPSEvvf1YPLIkB1+MEUZAP347c/YjXxYsU5PpLeJYDU7IPxYoTYP+nPq7pFL/GjrOOo/n8P/cnfK5vnnr8wkHWeHE5WH1+eqSa5ZGqatVh3VSqZpt0isr1xC0npzJoj/6Q/Ludm7Dqz3MQskvs/zPGXykmv2u9LksV0aA1MP+MewnWFQSb41IQSFGOIFlm7JJLPsTnbemHcRZ/x5RG/I4z/aXETw6un9ikG4tjm1edBi7rYap1vu7B7Gp6RUWmOMse7LHhyCPOqfSRQE5Usk53aRRH13gJoJRdQ4X5DpICaAd2DH3W+v1b88l9Mbjyk2sZFpJWeF3UbjZ+xA45AgTT6WoJ9I5O3HIebFhs2uU/v8754mi/r3znoacG0Tf10G7nWLtSyvAb5ZOx9Fb3sBp1hT+mrbOdaGY3UAIVfeFBSyVJDkNIF7y2nUL4MOo1fD6G0Z1btI4GiGA6pHrRbW/sIsyEB7ce2AlTLPZO06mdbdq8P/ZTGTie4uD2lueKxgTSYZb5Nxl/TGBMpgZw+VZNX74wzlD48m4KaWhbSGkPZTZNVR2YqezTOVdBtf3d7pxpdn4UnI8tJS4UEBdWLmnQCix+H4y/khkxZ+XiBmK6DLsHzb9klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhXZUsZsFexSTXSvdhin4mGFM6JhAENLaQQTHYW+MiOG7MmaRVdOEG+W9C6PNm+pPAPl0qCwrnB9nZawSej5LAg=="
+        }
+      ]
+    }
+  ],
+  "Accounts disconnectBlock should set account.createdAt if the disconnected block is earlier": [
+    {
+      "version": 1,
+      "id": "07248fde-b6d0-4145-ae29-1638314a1f72",
+      "name": "accountA",
+      "spendingKey": "69573dbec41895b878a098ba7abc5842568379856f4cae391235d518fe51d664",
+      "viewKey": "6df36639ca1035cb7896847677e8f55d7fe43ece3c18a9fbbc6a89dffe30bdd52e5d7ee605da3981f33d0327ee87dd485ce599a62129e44e9ea1018cf3acd63f",
+      "incomingViewKey": "ed11763fe4ee26d1592829e59750f5485cf89f962515ce877fed6527636a7604",
+      "outgoingViewKey": "27e9004473a42e4b579777cf91f9bedef126c3463304ba6d45d43102fda02a58",
+      "publicAddress": "d430e6e9b8ed838125c1de4b1cf1fc944668b168020fd0a5d90dd3e4d47772d9",
+      "createdAt": "2023-03-02T01:49:57.802Z"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:kkdIn0LUmjpYV+xMsyvKdvrKmKnTCgFlo0RwxJ8wfBw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:GvK5vEzkqqxQ+dDxRPLYRJkHNvnYz0lMerMyB+tpof8="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1677721798559,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAWRwecSBad8+FoygTtPtYSmJuVlcST9FaMBWR1bx+Ou2l8RNnUWYfwYhK7cK1+kdIM1HAcWfuWnksQquNT6r6qWMXX+MmBZ+/2S2FqFXodymHVRCuayhi5kXvtTeRJbi4BkxWWoeQJxYBSvCjUg5ewidsa2FkipfFNneQNUOIeN0KEehIlSTC6qAGzlwIRwKVlE/BSt9mtD/748ZXkkcvYTjGW9oI3Tou5GDkBIl+idWN+xGXiWXW8gBYwZQbp7r77fy4jRhFzzS60ILF+RxQWZGwI/nj2F24Mnmu5vGUfLhx/iwOv69NOezYlCuPZeVHRJL0Wr/0Tcm4Wk+N+CszMjw50lSUjkXPbAdIOB7ikWNOEw2TiX+Ik3ItWCBsRakKQTBNoU0m9troFr1YhteEWvqfaOdGbO0Poz1X2QAViOhsvJ/Mw7zlEAdYqGB0IhnZVF+j5MNvQbH1LRezmkrfdKmxeX43s/xPYLJee98o36Rtr3Ij18ngawj0+WDEHeJS3Et5WqMKunsE+28CMxTWPE+B4hRQp7aLERUEYgH8QqNTMfgxiS4dCrVwXQngf2j5L6dcqkq38EZYXgVEFwrzfOhANZ4uR06iy0Vl1REmwdc3JueIDZkoqklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwVA/2olGUsBTaHsF5LvIhsshEef7k6HQuquC0+0rs+ERGfF8ikqJHx+u004lWs/sABbyezHot2TllRc/h6YTtAA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuEJpVqA4fOyNH/+XPGe0r3l5UCrehD01z2wvQKJ0aD6WFZabtceav7V4USi8hwRJ+J3v4TgoeJz/5ugRTsA/GXaWe5m6FNZpRC2p06lhz32BVl9iWXjL2Bm5OTltaKGfDf2QIb02jGxQ9u6IrVUnh/gLJIEWR8uG2qw/YqcrsNMWXk9voIOHjs9vrl3611lFghmnPQwr8WBA9y71IXojG3DHYpBxdu+3ccfRKRdVLeCMqP2pyPbQWcMd/fzfi2sj38sn6Os/wRTeN1J7xrIQLByFexFu3UJ5V8KWKT8MsQhUll3qfdbTfqGOoz1DOxOQd6ob8vkg2GnKvCLgTV6c0pJHSJ9C1Jo6WFfsTLMrynb6ypip0woBZaNEcMSfMHwcBAAAAK7icfUJk2DEUTxYkoB1cGpPj3l5SfpxsB6XW4PwCEcdtmzPM4IY0c/yCOp4R/EVuvmRxOb5nxf5OqofDIgAUxAfTOUW7P6QeTzE3zPu9jhDoKNel5TNoXGGyDXRSCGjCpGC7KXw0YG5WgB5c5ge+Eb8UjrzAQt48UlMp1sPuuxm/BZPwNl2mDAm89WXh/kLY4WuPSuxt17+xI6AothPId5Q6szOtLlA2lNVHeInC/V+AzEXKQEURWd4twLVZOSSQhnBRbeZd5l+7Fu+zqd8doEibbMdkWbnBVD37GTxbwthgLxqkC6kNGc/CaJYyvaKDo7rcb7u4BpqTh4j3LH6w18ozvMPFNdegUY4sqRWoSnfCtw2V1YF9b+DvQ83sZjnlVO3P9xufaxdWwtb8fIKNKEuedw9gp/94tE4Y/K0cz5lLck64CK99rmG8Te5Fv/5qJbjbREiGt8WpjUoxh5vCTc+cSDNCkVtNbr2sq3tb4bg9KJIgu8ejYADO0YWybh4kgyq+dA4VJcb4i3CEhsTpbgH7Mg7+g8Znj7i1ZjgPqEkXQi/Ou8Pjr1jjzNJws/K/YDSYMuCjPWbIan6IGR6OomYYHtqh0EW/AXqHuuBqfxlJOz+J6rZprZyaENik1W5dr5HaXlaTZKYwRJm0oIPLvH3q9GQMTO1wcwfCdHXOuyXkz1dhknC+HzqiDmaRiCko0SBFZ5tvNTyhPEx4mK+A8SMuUPtZ2LLUdg6D2i/BWyfk6NfkeuWkjSN+yJCKbe3Q9gNZCa9tv/e6bCvKhM4ZLTvVhRekRJUlW7M445EJtdj3f8CW7RO24qRhNhoLB8j2CaLOzJ6OxP0tX9JRGW/J8UvTX+SIAebAlyD2K0xN4L5MuNaDhgqtpKjHhd9uv3WrtJhzrmFaRNWgaiN7n1XTEGrhq3zmrd+r7+8bIXkRo3ANEAKM16KEi0XnRIneSwIeethCS7L2MchioRCtQ7EggrbH4L55LUtZsq2XMN6bGcSQODpQ+ZFmwiIHD2wDZ+Nknl51Ma9dw24YwiAWJNmIaBMbWyQ+UpS6UMWFy5dmq8FZZSoN9tXEftCf8sPp4lT5/iL8h4EiUp0+IFav03rND7/2FL/nIJLvIhqgs5Nv1zIHC34ngWrfIgTuKWEXd1X34rH82kSX9NEbUpvRYx43nIvLPuNNqyZEd6od+D0VACiaE5yQ5FdwCe4TJewztewTDJuRJFA6BkQe/courUFWskSESEgsgKnHY+1yu7F+jpl71UUog96NwJB7sfXK3EqBvQbYMC3bHRtMepWIf/G7txApiTfgSYayBV2XxUcBBbb0t1bb9y8ZbAbIwoAXKJ6pefwqJqF4T8dYF38PLUJqwnpTPfpJHc8s7HI9xb03ZAFjH+U4WwRRhXb/JRrrD8esZr/+VDT+xAWgxeioj1sMjbbEOU+7pxdsDNzQV8JisO4J4DsvrLces5bs217QXpcJzl8K55aEEaoany0dXCEKPKHZYhiR+cQfS4R90KvgmOHuyp5GQr/+jksEt18p1X3onQ++iySyD/E26co+ryQrdbWzxykwLY+jYIwtf8ugFi5aU03KSNFuCZENNGfilMYCg=="
+    }
+  ],
+  "Accounts disconnectBlock should not update account createdAt if the disconnected block is later": [
+    {
+      "version": 1,
+      "id": "e85f78bf-f3ae-42da-acf9-988892840229",
+      "name": "accountA",
+      "spendingKey": "4edfaec24a1e1c35a46c04d020b61816146dbb868082afe27a51596e58866d5f",
+      "viewKey": "caa4c59666416a98cc480164ce8a16acfe3fc3ae5abd71684efa84c81a2220b5a86a45c40c78d1178fa7572f2130818c8bb16a958c7b5467cc47863c8a9c94b3",
+      "incomingViewKey": "46c4d854414830bc6d4ec831c40b9b2cbb175f856115b996e158e9b06a9dd306",
+      "outgoingViewKey": "b7487f58fafa6a62b770a65eaeabc2571757bc336597fa724d5f6a28d0a363bb",
+      "publicAddress": "3cfec09d30e4004ebdd2efd592169418a3b1c418312aff3b091a7cb6fb02cb8a",
+      "createdAt": "2023-03-02T01:14:26.130Z"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:k4tnIGmssL9skKtgDJ7dbGC4K3pvJ55cBgy1E5CMcDU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:surJW5gvbKOyMoUTZt7ox5QD8WFKVLc7FPcwFJCbzNU="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1677719666628,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAhpUT4GgQjq7RNuesZbNEXVpsed3zsdf/frcEl0ubYairYgJjvq+FhGAVXnhcUR+hWDF11oNn4Grl6QNLU4GiJEE1y212Q7VJCAombNq4pP6remHm8E0DKhhlA1aFg9OJTrvuPYJWCQIEB6+v3rGVbh3KmrcAN58qtE9AOnvPlhECD7J1KRYec2NRp/7m8qQeJ9f2bDKqnexiYlbAab9aM0sGUQn9j+ZCc+BeLP2YS0mWex70c+B+FtjX+aZyck1Lv8Hvl3mMks60fxqhjuy5MLtW1YqbHSCbz2Anxd7u1uuYVU6OehR3Aj20ja18GW8z/TBhG40meXwVFqpX+T6AGayupgehWpp4VI4Ggs/LFWqyTLbEWwkVdDjAfDLccdBHtKTe+Sbw+ckC0n6O414a1O96COBhpqIvvEmPgk8hI2dTu/fAoijXaJ/xrV5x0a90qx1FT2+X8a0tUXkiCBkdnDBh32isirZ5NUD8cQSiNaP2gI0Y1PDg5RjIOsorJQRhV+ImPtiAuF87EfHsfJ/6GU2DogwHLzwCpaV0YSxDP/fgEjrvUBjAigPbeQK68r/sP2rNrcXOESEnnKoygnjuRt1tXqycb6WDCYKLnqd6BMCzwCTn5ROIAklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnKbFGSf69QdC4ynN2awj/ImPeSS09ccQdSOgHmSBaDGSemO1pFN9SZlAdT9fk1cYWYZDi0LhQPwnq6ctedhmCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "3098D0314E32B434FF35C83052F212CA022A1EA84ED2A4FB88E4596DED4BF50F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:2cumOJGyrfFOaD1RaPGempwbVO6A4kg/t062XL6Ug3M="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:gns6WfzNNEDq+j8Lo3ddfgY+vep3p7dKkPEw+0UVNzI="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1677719667128,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQ4Lf4l6gE23V6k0nl4bY9MqJNYxgn3i2a1M5eZAn9oa50Z42+jswmonqSz6xmDXazf6HC00UbnG32rzuDXvp2TTpWcKUZiN+FUguBDUAg5Onf5cdPGtBUdQIyAFsu+Ea1glpZcP+n79LQ5hQ4SyL6O/k/GpBRIbzQled/l3ak7gLieJNtI54hn5kgyI8fFNSBzswYf95S6vGSFza5CMJMZawVfIrJjm8hLSvxb55OKe5GWgH1Et5ArvWPoeuWBpmfjdf0R1E82Bws2hBW/1nI/ym/l3Tm8JF3vCGteWgr5mouobsXcxBaoQVfOnPRJPJWwhsMGHv68QuUVFz9aAMNqOHaRgdLkim4XHYRiDwLjkCsL9WKxS+U6xHFazJvXUgfjKbGnf5/Qt0p1UOf/2mKq7WjDEZ8nLHFH6DeKK/4ECkQnebxtWp3B+TAoAp3LrZgq7xTOWe0gik44zsTnhXSSh8LcXUY1icGEdE6oK8PtpW1FoYwJG5zMAN9cKhG8lqMG/elFHkizS8zcgOxdMwJ0oJQssTIXz6ijyE6+aiods6MMyNiSbkFtwhoy3JeZEzw5JIJPSEC77MFx7IjqK83qBuFku49n9uSApNxzdnbhvyDQvhbmKM/klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFZHo/3odGJBuIB2/8sTmfLsqiND+pfdxvGWkMinh5Bzdas5bdsi+8EI9B5Y6Vl9fNpk2t8aD4zFS+AuTf/NxDQ=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -36,7 +36,7 @@ export class Account {
   readonly outgoingViewKey: string
   readonly version: number
   publicAddress: string
-  readonly createdAt: Date | null
+  createdAt: Date | null
   readonly prefix: Buffer
   readonly prefixRange: DatabaseKeyRange
 
@@ -663,6 +663,10 @@ export class Account {
     tx?: IDatabaseTransaction,
   ): Promise<Readonly<TransactionValue> | undefined> {
     return await this.walletDb.loadTransaction(this, hash, tx)
+  }
+
+  async getEarliestTransactionTimestamp(tx?: IDatabaseTransaction): Promise<Date | null> {
+    return this.walletDb.getEarliestTransactionTimestamp(this, tx)
   }
 
   async getAsset(

--- a/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
@@ -50,5 +50,102 @@
       "publicAddress": "c2f98450a9a3cae438352b7a6b7ceb7c8bb4918baf62b6016984dd1a15e083eb",
       "default": false
     }
+  ],
+  "WalletDB getEarliestTransactionTimestamp should return null if the account has no transactions": [
+    {
+      "version": 1,
+      "id": "444093e9-bcc3-45e0-83fe-9a2e0e33d690",
+      "name": "test",
+      "spendingKey": "c5c624990e930a98ac16a84b4b447a30567d475723b9014ab5c6fcc580dfac96",
+      "viewKey": "ffca98770d3c1c08a343a29c61a80524666ca9a1f3987ecf12205861d936190fce9598e919c1b7e9e919a81ccfc64501c508b3e031d102052341d9baeec9bc1a",
+      "incomingViewKey": "c7794e0964abfff3051b40244b8bba176407e60fafc69d48e3520d34b8382a07",
+      "outgoingViewKey": "df7f9ed27fc4d544b5e4e863f5abf389da4be88d29c545f485de60cf1837a6b5",
+      "publicAddress": "c3f67c0fcdb4066176cd31713f7710828f09e59a3c225b9a3b15115289931833",
+      "createdAt": "2023-03-01T01:38:22.988Z"
+    }
+  ],
+  "WalletDB getEarliestTransactionTimestamp should return the timestamp of the earliest transaction for an account": [
+    {
+      "version": 1,
+      "id": "97a56cf1-c0bb-4194-ae62-002e28b9c9b0",
+      "name": "accountA",
+      "spendingKey": "cccc1fa2de861b5538ad0fabf4db09a7f5943af819d9ba373618aa9e7dfd8bd6",
+      "viewKey": "634b43b7856a9d4f6f7daecf8da4a0b2e2d665b828ab8e3b9c40fd0a9ffbc310f78cc2033e7649a96f083339d7995234373045144116fef79c310e719bb2ec21",
+      "incomingViewKey": "5aade590d1c073696093dc0e3290e6c9549526eecc16ce690a01d0100a304a07",
+      "outgoingViewKey": "94d2be565ec7dd408b013ef5302d5f90939d05d7e01625984d95dfe5989036d5",
+      "publicAddress": "7918e22d4034cea64708d92630fec73b9aa19c419f302f82352196fe0deb536d",
+      "createdAt": "2023-03-01T17:04:33.023Z"
+    },
+    {
+      "version": 1,
+      "id": "0d57bf4b-44e4-4e79-b86b-770e678a3654",
+      "name": "accountB",
+      "spendingKey": "7f355181d4f0adb54d62da05632a6e82847be153e718d51aa24540a6d2d68ecd",
+      "viewKey": "9df38b111db566c30bc616cb590af9e3e75925e6ae76159fc7fa6e34e458b32a5c2daf4f20bbf832390c3b0046c6d6f83e68b5b1b2dbd1be0d458da747673c58",
+      "incomingViewKey": "0c69477a01fe7edfd07a3dc9683d9a3e1cb64d623c4a047167dd822ea7980900",
+      "outgoingViewKey": "0469cb365381cee9bf1207eb29cefeb58b6e3b53883c292e4feff6e39f5826d5",
+      "publicAddress": "c606592974c081a7402c08be52e8eea38359cfbdca0dae8f7b9e234fe6c5cdc1",
+      "createdAt": "2023-03-01T17:04:33.026Z"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "D179D8B74987D6617267D46F4958554BA0DF02D7E5E6117DB02D6FF38FD0F6DA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:tdc4BWK8wzsU4H46DpuFffppcIjCAG6Salw17W+iAiA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:bsLuYLjZaTEUdHHVHAUvYZcyM1/Psppoqg2VSeV0Hj4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1677690273848,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAldAfk6VtQkqBtkC2iA3AKL5XI4zWI0EZ0t9hSwLmIDqwyaAYps5xc8y65hd4a4+NPUje2aXToqLk2zUvvqAANteFtcbJLuNeC7Q2EWTG34iCjnEOJfdWPbN54VRBIbfVA/brhMmodmh4BLunTiJaW497G6TQll6q/5zTry7Yh4QOwgc+Km3cayf3+DUdPXv42/4TKWKLPnGywJZIfMz+l43YRvtZlaYBUTfVWqkdxTeZoNVKnFb7M1e86za7y99H6SxlJYLEr/qdSZo9z/BmVYyws+LBZ2ZtXub8jVVrHSoX+ivYKjkri0lumlyIXgU5353oAxtD0Ujr1ZeyW1QtGsgoF3VrbqlldjfuELKB/yEfJ/shs8EGTLv8E9W5vN9YUlwI16yxPjQxUcqrdkxXbQkKb1tdC9mt6V4QHrd9Fe3uefwSsayXflpbUW/dL3Vw83JndoXxLvBxD+ivFmYEzvBBSeWqzOV7eoAnXGJZGj1ZqitN0VwRzbE1SZamgJbdsTJ9U6Kldn9HsdMCZC1UO4ysLXRPdQNbVH9mMipQbxPmTL99y/AQgvMHcHU9JFUawgabG8hgqUxchFvEW4Czn/p90s/Z1b2WZcoKD/g7BzmSXnEXw0qMEUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw86s7M9MzpLf1UPUGWerqJbvRyQzMRONQQb4IveUmN2L344rn9md9iyLgBcSl6B7900NiJjPbp/mm6WeHPC++Bw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "6DFEDB68549AED256BCA822A112812C178111E8443542AEDCFA67C847D9FF03D",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:AcY/7dxXJ7JeFnscNOo5LoNpp5XNKc3n9yzOKAj0FQE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:PLac3hKh0vfSbwgt4YC2jUnmk+FSC9b2UWQbVBHBkuw="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1677690274421,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAwPkyqyDyQrRI1MQ47cveBOYF5J+vL7nRR17ni2ombOCYFKRYNOEss1womFKqHroS7uXaB5HHpjh4yMZHMKIU3LVb7tIyY41dzWnp6kiv75uV4kSLPUGXp5A6nfM1yoGkftah0wWiopQHpyLKdPvjvfd2bebFxy3eucuk7/FbB/oHhlFrXpkPSK/8MN/7Hrtc0EPd5nyuZeSwYS+Za3x4D8EYYQDVahYMDYuIpQIUK/m0RNKMAGOr6cihqBCYXWDkyvjHMRbRHoDWK4hqsSfYui/HppSCBLZb0GKSZuP7Qe4GxvQIoXINCH2t8PdEHSaTWEZUjfqE5BiseeWkhGHv5mqsM2VRarrPb91CGq+M71aDt7BFDfQlPrSJ9z1DX2c967LFajZREFfukqoZViLKJ3Dtr/YkZCCAMU6iyA71Obys+k9dWlht4V6M+ieBHDKa5OpTLxBGN4MG5cT+6VuXU3qqCY382OktfxMKBWlzRu8Bir/XN4pfT2M9GwmEG/x176v3LTYv2+df7njMy7RmhHGb3ENOMP33eU/vVE3FUaa30kKg2mdc82BzSaKFXL/NofYiPQjDZfwX6X6nIH7K5uarSFzlTbnq7KiM7WqVQnM0ywgsgz2/lElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2wZ5nZClm64jkBCexGddSr7zAtkuBNjqjlSmtFc9D8y6TjXBNKR928rl2Ez6PC9V6A5gBpaIc7FHXVUq1OTZBQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5ZrPHRfsQb8nfYvbzDy3vmjWdY5uszBIPHFJUfruM5KSkRQ1Qc8kdHmZfEDf6bcSc3yikJP/S+IdDPa3Yp7NkKhajHrDSwOFBTfT8ZN+K/mTPcZeC5jlcVyXznJzGkhtzxwJB2tKPPgd+Iv6E/VL1ODbUGK+AyJ2thYlq3WX1YwH0xH01AdWsxQmsqSSRlOgvza5hTnKTFvad4nrBOn5UOFI9W4wRUd7npieh1FG0gSoXmXyxEkhMhfu7w08F2HoBZNtvwPk3G1UQU82kPDIZIB+GpJnzQ1Aj/MhxNZzBtGQPuXTt9PSxtQBEFtp7oIsGBf7QgF5EfrYPaWHcyGKhgHGP+3cVyeyXhZ7HDTqOS6DaaeVzSnN5/cszigI9BUBBQAAAAyFRFFnvSZK5AKqrATHxY2vG/IrcHSwBjmAWq7rTU2SlOr255eHKKUClW262mxfQJrk/CqGgEHmK8fL5ANYF2aOGayn5MBK0FcJC7lCgt/18H5Km52xgGidCSbk56i2A5cYQPyqcwvRgQJS3fhZ1X2JD0FS3uRyFIWHg81ctvYRPZh8y3ZBJ5Af6muSjZI0e65EdnNoHyvuD/41YvWrF9v1Z740s0TflX50u9U4mcxgTpniu7QOITXzWHjMZ9duFxfiL7fNBXxBFUWZz5H46KFcZFim5nywFzcV9eRi+IdkR7n1g3QDrbaLpeNmAfQ/UqE5X9HCUNfQy3ukeWdYlmompPLhBLJu6uzGemG8Ehigx+SEd3iNld0sWgy+hcsfO1GU43sI/m7/elxRLgZNt/3wFzyFf72IRnLOLw01JbPKj0H0qPRausATMc02BO+0W6CbUKlr4TCEJNisOQxhXV0+KPAxsYsvs55fRZW29bqjahlybBdyRZ471D2VV+8+L2syKJDeqHFgienwv0hJUlZN5Dht9HCHfwjfpyLSyNU4eHQ79aCMj7sFJcWGjjNVQWGD6tywvD5EnMMOBuQpsYc0CygDmq1e4UpbF9cbrlLJKN0Ume0bh7d9FEXAnTgmFPhuISwpOaxFudikef517GJKRvAhNBVJnzrgDyRRCYy7IJ2+ax8cKceFnZshErf4E2U8kB2TE3K/80hppcokeLqJD2GbDwdsyiQfz9Yqh6AuT5BY0ag87ASFYbC2eMenb4rOCe1A8uBbbR9wIr+lt9JrCf+zVNLK8BkZcasQST5KcDNTmM4n3PaBNHMUcwyyIX5qNWckO3HxTNgtLM4ypjnkH5AC4RcS5d7OJ0pqA+754QM+UuFw9wykc0oSBiCkXL2XhF8fsJCtz96EkGHzjoNasQadsxpEOzthwfDKMo7GA5M3k29hws4MMchv0y6g7BnfD2MPl7lk34LUbL4yYDX3qMRrJe1DtdDr5GscjBi9H+qUEVIFqj+MAW8jxW8ao6gg7/KSPEhE810c70fgTyK9ypaC87ljBriHquRqHLpwckjTMPk3jBJ0wTplD6O1H0Wvn51dGEkuCm+jPP5ka0rGTAxlkF2DIweW7KkhQWA2Vo3GtuRUQusDL5nNsRw1KeGOQCFTlEUJS38vxuV3sLeOSu54x8uZ/nuhTOqsNLRHZbY0+3ab/nGLUH2yfwVo6kRZzhFjA3mAOUJ8N0ZTLwuIfKb7oZJ2qKsN+gQ1BtmmXA2G1Gro9fMLHLTbR4rKZinoSytUCVUstvEE4Q3i7tGRQfT3MTFY73HxC4rmA9DTfzot2kc+PDIhrD8qhuYtukjt068Jx3/UjPUd/M7RIGrxgo6vA43z3gCyDPMohDrkbNiCCE0cCuZPDHFkB7Sl4CN/Acjy4WWZusv08rH7oKLk2W6Dj8ZJu3TXQj6k8Bvu2T9Ul2itBZzIlf6EuarStV3MqKD+QCNligpEP8pm4SiMnDWVzGcGWJw4nJckK4TFKZlM8aA6qxbFb+itUf3IDJ16aUhax4tmjck7jnlfMGXlRNGcrcXTcX8J3DeOpjmDy4HEh0lDWsQ6ZvtAR05vDg=="
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKLlmEyPvDdGcaClaHUzEjpFPlu+21mJZfiaSuxCKELqLLmvEnCTJqZm+zp0ve6jPTJtBgQdcFNeZf+6XOsyLgaPsAGZxiFclhrFdV4G2e/u5K3yGBUjNjoSaSOwR/9zaNmMp/sJ47e6vgzszwgwfWKI7i7Nucgb9qPgNjZ7g1R4PLxI7BjKLMf3LhYUTM+2+Nw5YgimQ8puWHuXGMOif+mP9TzJ3XzXpU4XXBadVrQCN3W4r+6quZ6mhnt8I95f66RAUvVgACyeDxL5hu8QfV+DQJgymQUKTUCYXMFkokSnrJy7I0ngLFucvEnqF9US6H8YHZf/Fom1rs3N3hO4LXDt7j7oIrtid3/N6UJ+OnUgQsYL7NWB6n+9shmhUq8MBBQAAAP0ADH3Uk6M7vGsoCKlkXg8NjSeXOfKzN4jangjGSGaTBNZfra/xYLkvTAvuEoTxpEerqoozh4kWMIrrHlbLdDOrQph5H7431yLwJ5MYxgrBctVi71XOKviHzFBXG2SoC6VHx2BG9CPnR4d81Oh1Sc/6IbW64O2tj/a7KyZCBALVJeV5RgNtOVLiL4DWDm9subURNM1T3S7eHGLy6/b1zY34glODfjkvzVHt2p8gKPchy7t+s9/FGwgUl5eOxxj3VBm3XVvDEonnRlNARLCPsZX9yFh4iL6bZQPN6GtkeL51Y0NEt4oMh+dG/cp46s5WGKGbtxHU9Ztqs5UTcOxqzGz8lkEkp3GePTh3YCsMKKjB6V5T4d0nbMKYqU3ShsScItJNsxrAI4y2y+150W1ks9/c8/7kYp6ESDS89GIpxNlpDcIN+gAH19mMGsxF0BRHjPyJQIC7TdQvfdRD6mqc70TLNe5kkBAgrxme8qAfC2yk41BycNlc7dvT257aiNkw7YqBH+wfLx9EVtc8UFdXezpMA71DurLx1HWBAr+YOXeSexH1fuUKXnXIvT6cCRarQGTFCHvX2GcToOGudW98J3j+kGgkvY/KP3PcbNHfQ1BlP5HM2R/20AP2UBBtJIUXiMNqFzdIVeE6ys+6GUtyGIKf00+ADp7Ma7XYjZ3g2lMS2/1PWpP27o8/k13NFfavLFr4oiGQ4M/x++kZSS0V5eLwTFMGV/SL5dX9zZoAmtJeciWuLMgiH/GuKC3SW3hJFA1DsZhguR8c0nCwLoTq6v3UzPqwfq4h0Q7hR35ya6QSknOE/oRAZl2GenSagcpy1yWQ2wUYgklB/smqo2FlRlW2KLokuUbBlZVRa5ViaskqfLIaLuT680KHb4TdeRx1sB/DBYTbRGP93mWPb/HZ8cfF3cpGjSjZBt/3qG+eC7L7Qu4aBe89zNAYHVaKN6KxEFy7UXwuuGIX2uDv3TLaDSmA9lYGE7HHGJ1aEmnDtk5qA0MiosCusk+Hu61CNis8tAz6wCvjvkEWKhLahcwQlWpe13+17naz37qRF5LV1Z/HH2ns4kQx+Y5ywFUWEZ35nVOnF6LqdAKH/Q5UIF2vIbp7xtECdMlXAqyv1jIec8Fb7o9D2ABHmyk6xp5PKxjdEBPRl7EVmx4VbOUBNBlSvTDOxPIinUOJLOHBn4zRxOJR+aEINMGuszP/yX5/M/FQnT3C2/SX6+QpJmh3t1lijjT7aCqf32zSF3sR6Ox77beZ9CIYGemAXmx0aB07I0B2yIcOSpjMEatVd9bT9snmtsj5inqHZOuuRxNfieSbJUSDfeGfEB63YQwzhhU4GQHk/s1CSc8WFVRIm7HfvYoS60YOLOD/jsTpL4PiDFWN81c3DW3YSxTPNMDNjh97OkhMJ2k302mpmdIL0IlBosAg4IzZxV32otCqsq7lK/rPJzK9hKzFmO+7+i3YFjEpPBH+vPNDBsKuQc3oeLcTlydtDbLSsOrMT5MaDdBD+CpAtQhxOjPE/VPoHAQ3YxeO9NcBqtuuAI/ZRtCjOVUepeLh/GZvWmM5GUoi3vnitAH1N5k/JnlxXYb0n2h7f7vhJQlJCg=="
+    }
   ]
 }

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1074,6 +1074,23 @@ export class WalletDB {
     }
   }
 
+  async getEarliestTransactionTimestamp(
+    account: Account,
+    tx?: IDatabaseTransaction,
+  ): Promise<Date | null> {
+    for await (const [_, timestamp] of this.timestampToTransactionHash.getAllKeysIter(
+      tx,
+      account.prefixRange,
+      {
+        ordered: true,
+      },
+    )) {
+      return new Date(timestamp)
+    }
+
+    return null
+  }
+
   async putAsset(
     account: Account,
     assetId: Buffer,


### PR DESCRIPTION
## Summary

sets the account birthday to the earliest transaction timestamp when a block is connected or disconnected if the following are all true:
- the account was involved in a transaction on the block
- the account birthday is null or the block timestamp is earlier than the account birthday

defines 'getEarliestTransactionTimestamp' methods for reading the earliest timestamp from the wallet database using the timestampToTransactionHash index.

defines wallet methods for updating the account createdAt field. updateAccount updates the account record in the wallet database and updates the entry in the wallet's cache.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
