### PR TITLE
fixes account import with account birthdays

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -57,6 +57,10 @@ export class ImportCommand extends IronfishCommand {
       account.version = ACCOUNT_SCHEMA_VERSION as number
     }
 
+    if (!account.createdAt) {
+      account.createdAt = null
+    }
+
     const rescan = flags.rescan
     const result = await client.importAccount({ account, rescan })
     const { name, isDefaultAccount } = result.content
@@ -122,7 +126,7 @@ export class ImportCommand extends IronfishCommand {
         required: true,
       })
       const key = generateKeyFromPrivateKey(spendingKey)
-      return { name, version: ACCOUNT_SCHEMA_VERSION, ...key }
+      return { name, version: ACCOUNT_SCHEMA_VERSION, createdAt: null, ...key }
     }
 
     // raw json

--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -23,6 +23,7 @@ describe('Route wallet/importAccount', () => {
           incomingViewKey: key.incomingViewKey,
           outgoingViewKey: key.outgoingViewKey,
           version: 1,
+          createdAt: null,
         },
         rescan: false,
       })
@@ -49,6 +50,7 @@ describe('Route wallet/importAccount', () => {
           incomingViewKey: key.incomingViewKey,
           outgoingViewKey: key.outgoingViewKey,
           version: 1,
+          createdAt: null,
         },
         rescan: false,
       })

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -28,6 +28,7 @@ export const ImportAccountRequestSchema: yup.ObjectSchema<ImportAccountRequest> 
         incomingViewKey: yup.string().defined(),
         outgoingViewKey: yup.string().defined(),
         version: yup.number().defined(),
+        createdAt: yup.date().nullable().defined(),
       })
       .defined(),
   })
@@ -46,7 +47,6 @@ router.register<typeof ImportAccountRequestSchema, ImportResponse>(
   async (request, node): Promise<void> => {
     const accountValue = {
       id: uuid(),
-      createdAt: null,
       ...request.data.account,
     }
     const account = await node.wallet.importAccount(accountValue)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1320,6 +1320,7 @@ export class Wallet {
 
     const account = new Account({
       ...accountValue,
+      createdAt: accountValue.createdAt ? new Date(accountValue.createdAt) : null,
       walletDb: this.walletDb,
     })
 

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -22,7 +22,7 @@ export interface AccountValue {
   createdAt: Date | null
 }
 
-export type AccountImport = Omit<AccountValue, 'id' | 'createdAt'>
+export type AccountImport = Omit<AccountValue, 'id'>
 
 export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
   serialize(value: AccountValue): Buffer {


### PR DESCRIPTION
## Summary

import accounts fails following the addition of account birthdays with 'value.createdAt.getTime is not a function' because we do not parse any 'createdAt' into a date.

adds 'createdAt' to the required RPC fields in importAccount and ensures that the field is included in requests to importAccount.

## Testing Plan

manually tested various export/import conditions with and without the createdAt field:
- bech32
- json
- spendingKey
- mnemonic
- viewonly

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
