### PR TITLE
Add mempool status command

### DIFF
--- a/ironfish-cli/src/commands/mempool/status.ts
+++ b/ironfish-cli/src/commands/mempool/status.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { FileUtils, PromiseUtils } from '@ironfish/sdk'
+import { GetMempoolStatusResponse } from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
+import blessed from 'blessed'
+import { IronfishCommand } from '../../command'
+import { RemoteFlags } from '../../flags'
+
+export default class Status extends IronfishCommand {
+  static description = 'Show the status of the Mempool'
+
+  static flags = {
+    ...RemoteFlags,
+    follow: Flags.boolean({
+      char: 'f',
+      default: false,
+      description: 'Follow the status of the mempool live',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(Status)
+
+    if (!flags.follow) {
+      const client = await this.sdk.connectRpc()
+      const response = await client.getMempoolStatus()
+      this.log(renderStatus(response.content))
+      this.exit(0)
+    }
+
+    // Console log will create display issues with Blessed
+    this.logger.pauseLogs()
+
+    const screen = blessed.screen({ smartCSR: true })
+    const statusText = blessed.text()
+    screen.append(statusText)
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const connected = await this.sdk.client.tryConnect()
+
+      if (!connected) {
+        statusText.clearBaseLine(0)
+        statusText.setContent('Node: STOPPED')
+        screen.render()
+        await PromiseUtils.sleep(1000)
+        continue
+      }
+
+      const response = this.sdk.client.getMempoolStatusStream()
+      for await (const value of response.contentStream()) {
+        statusText.setContent(renderStatus(value))
+        screen.render()
+      }
+    }
+  }
+}
+
+function renderStatus(content: GetMempoolStatusResponse): string {
+  const storage = FileUtils.formatMemorySize(content.sizeBytes)
+  const maxStorage = FileUtils.formatMemorySize(content.maxSizeBytes)
+  const saturationPercentage = ((content.sizeBytes / content.maxSizeBytes) * 100).toFixed(2)
+
+  return `\
+Tx Count           ${content.size}
+Memory             ${storage} / ${maxStorage} (${saturationPercentage}%)
+Eviction Cache     ${content.recentlyEvictedCache.size} / ${content.recentlyEvictedCache.maxSize}
+Evictions          ${content.evictions}
+Head Sequence      ${content.headSequence}`
+}

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -301,7 +301,7 @@ export class MemPool {
 
     if (this.full()) {
       const evicted = this.evictTransactions()
-      this.metrics.memPoolEvictions.add(evicted.length)
+      this.metrics.memPoolEvictions.value += evicted.length
     }
 
     return true

--- a/ironfish/src/metrics/metricsMonitor.ts
+++ b/ironfish/src/metrics/metricsMonitor.ts
@@ -48,7 +48,7 @@ export class MetricsMonitor {
   readonly memPoolSizeBytes: Gauge
   readonly memPoolMaxSizeBytes: Gauge
   readonly memPoolSaturation: Gauge
-  readonly memPoolEvictions: Meter
+  readonly memPoolEvictions: Gauge
 
   readonly memPool_RecentlyEvictedCache_Size: Gauge
   readonly memPool_RecentlyEvictedCache_MaxSize: Gauge
@@ -98,7 +98,7 @@ export class MetricsMonitor {
     this.memPoolSizeBytes = new Gauge()
     this.memPoolMaxSizeBytes = new Gauge()
     this.memPoolSaturation = new Gauge()
-    this.memPoolEvictions = this.addMeter()
+    this.memPoolEvictions = new Gauge()
 
     this.memPool_RecentlyEvictedCache_Size = new Gauge()
     this.memPool_RecentlyEvictedCache_MaxSize = new Gauge()

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -85,6 +85,7 @@ import {
 import { UnsetConfigRequest, UnsetConfigResponse } from '../routes/config/unsetConfig'
 import { OnGossipRequest, OnGossipResponse } from '../routes/events/onGossip'
 import { GetMempoolTransactionResponse, GetMempoolTransactionsRequest } from '../routes/mempool'
+import { GetMempoolStatusResponse } from '../routes/mempool/getStatus'
 import { GetBannedPeersRequest, GetBannedPeersResponse } from '../routes/peers/getBannedPeers'
 import { GetPeerRequest, GetPeerResponse } from '../routes/peers/getPeer'
 import {
@@ -280,6 +281,18 @@ export abstract class RpcClient {
       `${ApiNamespace.mempool}/getTransactions`,
       { ...params },
     )
+  }
+
+  async getMempoolStatus(): Promise<RpcResponseEnded<GetMempoolStatusResponse>> {
+    return await this.request<GetMempoolStatusResponse>(
+      `${ApiNamespace.mempool}/getStatus`,
+    ).waitForEnd()
+  }
+
+  getMempoolStatusStream(): RpcResponse<void, GetMempoolStatusResponse> {
+    return this.request<void, GetMempoolStatusResponse>(`${ApiNamespace.mempool}/getStatus`, {
+      stream: true,
+    })
   }
 
   async getBannedPeers(

--- a/ironfish/src/rpc/routes/mempool/getStatus.ts
+++ b/ironfish/src/rpc/routes/mempool/getStatus.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { IronfishNode } from '../../../node'
+import { PromiseUtils } from '../../../utils'
+import { ApiNamespace, router } from '../router'
+
+export type GetMempoolStatusRequest =
+  | undefined
+  | {
+      stream?: boolean
+    }
+
+export type GetMempoolStatusResponse = {
+  size: number
+  sizeBytes: number
+  maxSizeBytes: number
+  evictions: number
+  headSequence: number
+  recentlyEvictedCache: {
+    size: number
+    maxSize: number
+  }
+}
+
+export const GetMempoolStatusRequestSchema: yup.ObjectSchema<GetMempoolStatusRequest> = yup
+  .object({
+    stream: yup.boolean().optional(),
+  })
+  .optional()
+  .default({})
+
+export const GetMempoolStatusResponseSchema: yup.ObjectSchema<GetMempoolStatusResponse> = yup
+  .object({
+    size: yup.number().defined(),
+    sizeBytes: yup.number().defined(),
+    maxSizeBytes: yup.number().defined(),
+    evictions: yup.number().defined(),
+    headSequence: yup.number().defined(),
+    recentlyEvictedCache: yup
+      .object({
+        size: yup.number().defined(),
+        maxSize: yup.number().defined(),
+      })
+      .defined(),
+  })
+  .defined()
+
+router.register<typeof GetMempoolStatusRequestSchema, GetMempoolStatusResponse>(
+  `${ApiNamespace.mempool}/getStatus`,
+  GetMempoolStatusRequestSchema,
+  async (request, node): Promise<void> => {
+    const status = getStatus(node)
+
+    if (!request.data?.stream) {
+      request.end(status)
+      return
+    }
+
+    request.stream(status)
+
+    let stream = true
+    while (stream) {
+      const status = getStatus(node)
+      request.stream(status)
+      await PromiseUtils.sleep(500)
+    }
+
+    request.onClose.on(() => {
+      stream = false
+    })
+  },
+)
+
+function getStatus(node: IronfishNode): GetMempoolStatusResponse {
+  const { memPool, metrics } = node
+
+  return {
+    size: memPool.count(),
+    sizeBytes: memPool.sizeBytes(),
+    maxSizeBytes: memPool.maxSizeBytes,
+    headSequence: memPool.head?.sequence || 0,
+    evictions: metrics.memPoolEvictions.value,
+    recentlyEvictedCache: memPool.recentlyEvictedCacheStats(),
+  }
+}

--- a/ironfish/src/rpc/routes/mempool/index.ts
+++ b/ironfish/src/rpc/routes/mempool/index.ts
@@ -3,3 +3,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export * from './getTransactions'
+export * from './getStatus'

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -315,7 +315,7 @@ function getStatus(node: IronfishNode): GetNodeStatusResponse {
       size: node.metrics.memPoolSize.value,
       sizeBytes: node.memPool.sizeBytes(),
       maxSizeBytes: node.memPool.maxSizeBytes,
-      evictions: Math.max(node.metrics.memPoolEvictions.rate5m, 0),
+      evictions: Math.max(node.metrics.memPoolEvictions.value, 0),
       recentlyEvictedCache: {
         size: node.memPool.recentlyEvictedCacheStats().size,
         maxSize: node.memPool.recentlyEvictedCacheStats().maxSize,

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -187,17 +187,17 @@ export class Telemetry {
       {
         name: 'mempool_size_bytes',
         type: 'integer',
-        value: this.metrics.memPoolSizeBytes.value,
+        value: Math.round(this.metrics.memPoolSizeBytes.value),
       },
       {
         name: 'mempool_max_size_bytes',
         type: 'integer',
-        value: this.metrics.memPoolMaxSizeBytes.value,
+        value: Math.round(this.metrics.memPoolMaxSizeBytes.value),
       },
       {
         name: 'mempool_saturation',
         type: 'integer',
-        value: this.metrics.memPoolSaturation.value,
+        value: Math.round(this.metrics.memPoolSaturation.value * 100),
       },
       {
         name: 'mempool_evictions',

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -202,7 +202,7 @@ export class Telemetry {
       {
         name: 'mempool_evictions',
         type: 'integer',
-        value: this.metrics.memPoolEvictions.rate5m,
+        value: this.metrics.memPoolEvictions.value,
       },
       {
         name: 'mempool_recently_evicted_cache_size',


### PR DESCRIPTION
## Summary
Adding a status command for the mempool to monitor the recently evicted cache. Also fixes a telemetry bug by sending number instead of a float

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
