### PR TITLE
adds bech32 to dependencies for @ironfish/sdk

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -21,6 +21,7 @@
     "@ironfish/rust-nodejs": "0.1.27",
     "@napi-rs/blake-hash": "1.3.3",
     "axios": "0.21.4",
+    "bech32": "2.0.0",
     "blru": "0.1.6",
     "buffer": "6.0.3",
     "buffer-json": "2.0.0",


### PR DESCRIPTION
## Summary

`yarn add bech32`

after installing @ironfish/sdk, bech32 module cannot be found (e.g., https://discord.com/channels/771503434028941353/831945060777852998/1082211129796874311)

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
