### PR TITLE
Close trusted setup command

### DIFF
--- a/ironfish-cli/src/commands/ceremony.ts
+++ b/ironfish-cli/src/commands/ceremony.ts
@@ -47,6 +47,12 @@ export default class Ceremony extends IronfishCommand {
     let refreshEtaInterval: NodeJS.Timeout | null = null
     let etaDate: Date | null = null
 
+    // Trusted setup has ended so just
+    this.log(
+      `The trusted setup ceremony was completed on Mar 3, 2023. For more information on the trusted setup process and its completion please read https://setup.ironfish.network.`,
+    )
+    this.exit(0)
+
     // Prompt for randomness
     let randomness: string | null = await CliUx.ux.prompt(
       `If you'd like to contribute your own randomness to the ceremony, type it here, then press Enter. For more information on where this should come from and its importance, please read https://setup.ironfish.network. If you'd like the command to generate some randomness for you, just press Enter`,

--- a/ironfish-cli/src/commands/ceremony.ts
+++ b/ironfish-cli/src/commands/ceremony.ts
@@ -47,7 +47,8 @@ export default class Ceremony extends IronfishCommand {
     let refreshEtaInterval: NodeJS.Timeout | null = null
     let etaDate: Date | null = null
 
-    // Trusted setup has ended so just
+    // Trusted setup has ended but this command may still be needed in case of future
+    // setups / network upgrades. So for now, just exit the command with some information
     this.log(
       `The trusted setup ceremony was completed on Mar 3, 2023. For more information on the trusted setup process and its completion please read https://setup.ironfish.network.`,
     )


### PR DESCRIPTION
## Summary
Giving some more information for users who try to run the `ironfish ceremony` command by telling them the ceremony is complete. We may still need this command in case of future setups / network upgrades. So for now, just exit the command with some information

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
