### PR TITLE
gets balance for correct account in promptCurrency

### DIFF
--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -35,6 +35,7 @@ export async function promptCurrency(options: {
 
   if (options.balance) {
     const balance = await options.client.getAccountBalance({
+      account: options.balance.account,
       assetId: options.balance.assetId ?? Asset.nativeId().toString('hex'),
       confirmations: options.balance.confirmations,
     })


### PR DESCRIPTION
## Summary

when getting the balance to use in the prompt in 'promptCurrency' we do not use the name of the account passed to the function.

this results in getting the balance for the default account, which may not be the right one.

we get the balance for the right account in the asset selector, so you can see the issue clearly when using the asset selector for a non-default account and using the amount prompt afterwards.

## Testing Plan

Before:
![image](https://user-images.githubusercontent.com/57735705/223294743-67097703-bebe-4d05-b9a6-05531b2b3a77.png)

After:
<img width="852" alt="image" src="https://user-images.githubusercontent.com/57735705/223294760-13a5cb56-dff4-44a9-a8d4-927b7923987a.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
