### PR TITLE
feat(cli,ironfish): Offer name change on duplicate name during import

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -2,11 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { generateKeyFromPrivateKey, wordsToSpendingKey } from '@ironfish/rust-nodejs'
-import { ACCOUNT_SCHEMA_VERSION, Bech32m, JSONUtils, PromiseUtils } from '@ironfish/sdk'
+import {
+  ACCOUNT_SCHEMA_VERSION,
+  Bech32m,
+  ERROR_CODES,
+  ImportResponse,
+  JSONUtils,
+  PromiseUtils,
+  RpcResponseEnded,
+} from '@ironfish/sdk'
 import { AccountImport } from '@ironfish/sdk/src/wallet/walletdb/accountValue'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { hasUserResponseError } from '../../utils'
 import { LANGUAGE_VALUES } from '../../utils/language'
 
 export class ImportCommand extends IronfishCommand {
@@ -62,7 +71,30 @@ export class ImportCommand extends IronfishCommand {
     }
 
     const rescan = flags.rescan
-    const result = await client.importAccount({ account, rescan })
+
+    let result: RpcResponseEnded<ImportResponse>
+    try {
+      result = await client.importAccount({ account, rescan })
+    } catch (error: unknown) {
+      // Offer the user to use a different name if a duplicate is found
+      if (hasUserResponseError(error) && error.code === ERROR_CODES.ACCOUNT_EXISTS) {
+        this.log()
+        this.log(`Found existing account with name '${account.name}'`)
+
+        const name = await CliUx.ux.prompt('Enter a different name for the account', {
+          required: true,
+        })
+        if (name === account.name) {
+          this.error(`Entered the same name: '${name}'`)
+        }
+
+        account.name = name
+        result = await client.importAccount({ account, rescan })
+      } else {
+        throw error
+      }
+    }
+
     const { name, isDefaultAccount } = result.content
     this.log(`Account ${name} imported.`)
 

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -4,7 +4,6 @@
 import { v4 as uuid } from 'uuid'
 import * as yup from 'yup'
 import { AccountImport } from '../../../wallet/walletdb/accountValue'
-import { ERROR_CODES, ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
 
 export type ImportAccountRequest = {
@@ -50,15 +49,6 @@ router.register<typeof ImportAccountRequestSchema, ImportResponse>(
       id: uuid(),
       ...request.data.account,
     }
-
-    if (node.wallet.accountExists(request.data.account.name)) {
-      throw new ValidationError(
-        `There is already an account with the name ${request.data.account.name}`,
-        400,
-        ERROR_CODES.ACCOUNT_EXISTS,
-      )
-    }
-
     const account = await node.wallet.importAccount(accountValue)
 
     if (request.data.rescan) {

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -4,6 +4,7 @@
 import { v4 as uuid } from 'uuid'
 import * as yup from 'yup'
 import { AccountImport } from '../../../wallet/walletdb/accountValue'
+import { ERROR_CODES, ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
 
 export type ImportAccountRequest = {
@@ -49,6 +50,15 @@ router.register<typeof ImportAccountRequestSchema, ImportResponse>(
       id: uuid(),
       ...request.data.account,
     }
+
+    if (node.wallet.accountExists(request.data.account.name)) {
+      throw new ValidationError(
+        `There is already an account with the name ${request.data.account.name}`,
+        400,
+        ERROR_CODES.ACCOUNT_EXISTS,
+      )
+    }
+
     const account = await node.wallet.importAccount(accountValue)
 
     if (request.data.rescan) {


### PR DESCRIPTION
## Summary

If you import your default account (which has the name default) into a new wallet / data directory (and that database already has a default account), you will encounter an error that shows a duplicate name error. This is not a great UX, and it'd be nice to offer the user a chance to rename the account during the import.

* In the RPC request, throw a validation error if the account name already exists
* In the CLI check for a validation error and error code. If the code is account exists, prompt for a different name.
* If the same name is provided, error out

## Testing Plan

Existing behavior

https://user-images.githubusercontent.com/5459049/223557261-07949a5d-1ce6-4d21-8a38-8125cb188390.mp4

New behavior for same name

https://user-images.githubusercontent.com/5459049/223557529-aa1167d9-7966-46ae-b712-5d5f19c7d082.mp4

New behavior for new name

https://user-images.githubusercontent.com/5459049/223557809-ed0210c3-02e0-4d94-9fc9-6b75d461a79e.mp4

New behavior with an existing error

https://user-images.githubusercontent.com/5459049/223557981-e4ff50db-3ab4-4d79-b92c-4352aa564eb8.mp4

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
