### PR TITLE
Replace bigint casting with bigint literal

### DIFF
--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -59,13 +59,13 @@ describe('Demonstrate the Sapling API', () => {
     const key = generateKey()
 
     const transaction = new Transaction(key.spendingKey)
-    const note = new Note(key.publicAddress, BigInt(20), 'test', Asset.nativeId(), key.publicAddress)
+    const note = new Note(key.publicAddress, 20n, 'test', Asset.nativeId(), key.publicAddress)
     transaction.output(note)
 
     const serializedPostedTransaction = transaction.post_miners_fee()
     const postedTransaction = new TransactionPosted(serializedPostedTransaction)
 
-    expect(postedTransaction.fee()).toEqual(BigInt(-20))
+    expect(postedTransaction.fee()).toEqual(-20n)
     expect(postedTransaction.notesLength()).toBe(1)
     expect(postedTransaction.spendsLength()).toBe(0)
     expect(postedTransaction.hash().byteLength).toBe(32)
@@ -87,8 +87,8 @@ describe('Demonstrate the Sapling API', () => {
 
     // Null characters are included in the memo string
     expect(decryptedNote.memo().replace(/\0/g, '')).toEqual('test')
-    expect(decryptedNote.value()).toEqual(BigInt(20))
-    expect(decryptedNote.nullifier(key.viewKey, BigInt(0)).byteLength).toBeGreaterThan(BigInt(0))
+    expect(decryptedNote.value()).toEqual(20n)
+    expect(decryptedNote.nullifier(key.viewKey, 0n).byteLength).toBeGreaterThan(0n)
   })
 
   it(`Should create a standard transaction`, () => {
@@ -96,7 +96,7 @@ describe('Demonstrate the Sapling API', () => {
     const recipientKey = generateKey()
 
     const minersFeeTransaction = new Transaction(key.spendingKey)
-    const minersFeeNote = new Note(key.publicAddress, BigInt(20), 'miner', Asset.nativeId(), key.publicAddress)
+    const minersFeeNote = new Note(key.publicAddress, 20n, 'miner', Asset.nativeId(), key.publicAddress)
     minersFeeTransaction.output(minersFeeNote)
 
     const postedMinersFeeTransaction = new TransactionPosted(minersFeeTransaction.post_miners_fee())
@@ -105,7 +105,7 @@ describe('Demonstrate the Sapling API', () => {
     transaction.setExpiration(10)
     const encryptedNote = new NoteEncrypted(postedMinersFeeTransaction.getNote(0))
     const decryptedNote = Note.deserialize(encryptedNote.decryptNoteForOwner(key.incomingViewKey)!)
-    const newNote = new Note(recipientKey.publicAddress, BigInt(15), 'receive', Asset.nativeId(), minersFeeNote.owner())
+    const newNote = new Note(recipientKey.publicAddress, 15n, 'receive', Asset.nativeId(), minersFeeNote.owner())
 
     let currentHash = encryptedNote.hash()
     let authPath = Array.from({ length: 32 }, (_, depth) => {
@@ -128,10 +128,10 @@ describe('Demonstrate the Sapling API', () => {
     transaction.spend(decryptedNote, witness)
     transaction.output(newNote)
 
-    const postedTransaction = new TransactionPosted(transaction.post(key.publicAddress, BigInt(5)))
+    const postedTransaction = new TransactionPosted(transaction.post(key.publicAddress, 5n))
 
     expect(postedTransaction.expiration()).toEqual(10)
-    expect(postedTransaction.fee()).toEqual(BigInt(5))
+    expect(postedTransaction.fee()).toEqual(5n)
     expect(postedTransaction.notesLength()).toEqual(1)
     expect(postedTransaction.spendsLength()).toEqual(1)
     expect(postedTransaction.hash().byteLength).toEqual(32)

--- a/ironfish-rust-nodejs/tsconfig.json
+++ b/ironfish-rust-nodejs/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../config/tsconfig.base.json"
+}
+  

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -113,7 +113,7 @@ export class Verifier {
     }
 
     // Sum the total transaction fees
-    let totalTransactionFees = BigInt(0)
+    let totalTransactionFees = 0n
     for (const transaction of otherTransactions) {
       const transactionFee = transaction.fee()
       if (transactionFee < 0) {
@@ -133,10 +133,7 @@ export class Verifier {
     // minersFee should be (negative) miningReward + totalTransactionFees
     const miningReward = this.chain.strategy.miningReward(block.header.sequence)
 
-    if (
-      minersFeeTransaction.fee() !==
-      BigInt(-1) * (BigInt(miningReward) + totalTransactionFees)
-    ) {
+    if (minersFeeTransaction.fee() !== -1n * (BigInt(miningReward) + totalTransactionFees)) {
       return { valid: false, reason: VerificationResultReason.INVALID_MINERS_FEE }
     }
 

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -7,28 +7,25 @@ import { BigIntUtils } from '../utils/bigint'
 /**
  *  Minimum difficulty, which is equivalent to maximum target
  */
-const MIN_DIFFICULTY = BigInt(131072)
+const MIN_DIFFICULTY = 131072n
 
 /**
  * Maximum target, which is equivalent of minimum difficulty of 131072
  * target == 2**256 / difficulty
  */
-const MAX_TARGET = BigInt(
-  '883423532389192164791648750371459257913741948437809479060803100646309888',
-)
+const MAX_TARGET = 883423532389192164791648750371459257913741948437809479060803100646309888n
 
 /**
  *  Maximum number to represent a 256 bit number, which is 2**256 - 1
  */
-const MAX_256_BIT_NUM = BigInt(
-  '115792089237316195423570985008687907853269984665640564039457584007913129639935',
-)
+const MAX_256_BIT_NUM =
+  115792089237316195423570985008687907853269984665640564039457584007913129639935n
 
 export class Target {
   targetValue: bigint
   constructor(targetValue: bigint | Buffer | string | number | undefined = undefined) {
     if (targetValue === undefined) {
-      this.targetValue = BigInt(0)
+      this.targetValue = 0n
     } else {
       const candidate =
         targetValue instanceof Buffer
@@ -128,7 +125,7 @@ export class Target {
     bucket = Math.min(bucket, 99)
 
     const difficulty =
-      previousBlockDifficulty - (previousBlockDifficulty / BigInt(2048)) * BigInt(bucket)
+      previousBlockDifficulty - (previousBlockDifficulty / 2048n) * BigInt(bucket)
 
     return BigIntUtils.max(difficulty, Target.minDifficulty())
   }
@@ -145,17 +142,17 @@ export class Target {
    * Converts difficulty to Target
    */
   static fromDifficulty(difficulty: bigint): Target {
-    if (difficulty === BigInt(1)) {
+    if (difficulty === 1n) {
       return new Target(MAX_256_BIT_NUM)
     }
-    return new Target((BigInt(2) ** BigInt(256) / BigInt(difficulty)).valueOf())
+    return new Target((2n ** 256n / difficulty).valueOf())
   }
 
   /**
    * Return the difficulty representation as a big integer
    */
   toDifficulty(): bigint {
-    return BigInt(2) ** BigInt(256) / this.targetValue
+    return 2n ** 256n / this.targetValue
   }
 
   /**

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -96,7 +96,7 @@ describe('Demonstrate the Sapling API', () => {
     it('Can create a miner reward', () => {
       const owner = generateKeyFromPrivateKey(spenderKey.spendingKey).publicAddress
 
-      minerNote = new NativeNote(owner, BigInt(42), '', Asset.nativeId(), owner)
+      minerNote = new NativeNote(owner, 42n, '', Asset.nativeId(), owner)
 
       const transaction = new NativeTransaction(spenderKey.spendingKey)
       transaction.output(minerNote)
@@ -139,14 +139,14 @@ describe('Demonstrate the Sapling API', () => {
       receiverKey = generateKey()
       const outputNote = new NativeNote(
         receiverKey.publicAddress,
-        BigInt(40),
+        40n,
         '',
         Asset.nativeId(),
         minerNote.owner(),
       )
       transaction.output(outputNote)
 
-      publicTransaction = new NativeTransactionPosted(transaction.post(null, BigInt(0)))
+      publicTransaction = new NativeTransactionPosted(transaction.post(null, 0n))
       expect(publicTransaction).toBeTruthy()
     })
 
@@ -176,7 +176,7 @@ describe('Demonstrate the Sapling API', () => {
         workerPool,
         consensus: new TestnetConsensus(consensusParameters),
       })
-      const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spendingKey)
+      const minersFee = await strategy.createMinersFee(0n, 0, generateKey().spendingKey)
 
       expect(minersFee['transactionPosted']).toBeNull()
       expect(await workerPool.verify(minersFee, { verifyFees: false })).toEqual({ valid: true })
@@ -190,7 +190,7 @@ describe('Demonstrate the Sapling API', () => {
         consensus: new TestnetConsensus(consensusParameters),
       })
 
-      const minersFee = await strategy.createMinersFee(BigInt(0), 0, generateKey().spendingKey)
+      const minersFee = await strategy.createMinersFee(0n, 0, generateKey().spendingKey)
 
       await minersFee.withReference(async () => {
         expect(minersFee['transactionPosted']).not.toBeNull()
@@ -213,7 +213,7 @@ describe('Demonstrate the Sapling API', () => {
         workerPool: new WorkerPool(),
         consensus: new TestnetConsensus(consensusParameters),
       })
-      const minersFee = await strategy.createMinersFee(BigInt(0), 0, key.spendingKey)
+      const minersFee = await strategy.createMinersFee(0, 0, key.spendingKey)
 
       expect(minersFee['transactionPosted']).toBeNull()
 
@@ -233,7 +233,7 @@ describe('Demonstrate the Sapling API', () => {
       }
 
       expect(decryptedNote['note']).toBeNull()
-      expect(decryptedNote.value()).toBe(BigInt(2000000000))
+      expect(decryptedNote.value()).toBe(2000000000n)
       expect(decryptedNote['note']).toBeNull()
     })
   })
@@ -284,14 +284,14 @@ describe('Demonstrate the Sapling API', () => {
       const receiverAddress = receiverKey.publicAddress
       const noteForSpender = new NativeNote(
         spenderKey.publicAddress,
-        BigInt(10),
+        10n,
         '',
         Asset.nativeId(),
         receiverAddress,
       )
       const receiverNoteToSelf = new NativeNote(
         receiverAddress,
-        BigInt(29),
+        29n,
         '',
         Asset.nativeId(),
         receiverAddress,
@@ -300,9 +300,7 @@ describe('Demonstrate the Sapling API', () => {
       transaction.output(noteForSpender)
       transaction.output(receiverNoteToSelf)
 
-      const postedTransaction = new NativeTransactionPosted(
-        transaction.post(undefined, BigInt(1)),
-      )
+      const postedTransaction = new NativeTransactionPosted(transaction.post(undefined, 1n))
       expect(postedTransaction).toBeTruthy()
       expect(postedTransaction.verify()).toBeTruthy()
     })

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -213,7 +213,7 @@ describe('Demonstrate the Sapling API', () => {
         workerPool: new WorkerPool(),
         consensus: new TestnetConsensus(consensusParameters),
       })
-      const minersFee = await strategy.createMinersFee(0, 0, key.spendingKey)
+      const minersFee = await strategy.createMinersFee(0n, 0, key.spendingKey)
 
       expect(minersFee['transactionPosted']).toBeNull()
 

--- a/ironfish/src/syncer.test.ts
+++ b/ironfish/src/syncer.test.ts
@@ -33,13 +33,13 @@ describe('Syncer', () => {
     expect(startSyncSpy).not.toHaveBeenCalled()
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
-    peer.work = BigInt(0)
+    peer.work = 0n
 
     // Peer does not have more work
     syncer.findPeer()
     expect(startSyncSpy).not.toHaveBeenCalled()
 
-    peer.work = chain.head.work + BigInt(1)
+    peer.work = chain.head.work + 1n
 
     // Peer should have more work than us now
     syncer.findPeer()
@@ -50,7 +50,7 @@ describe('Syncer', () => {
     const { peerNetwork, syncer } = nodeTest
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
-    peer.work = BigInt(1)
+    peer.work = 1n
     peer.sequence = 1
     peer.head = Buffer.from('')
 
@@ -76,7 +76,7 @@ describe('Syncer', () => {
     const { peerNetwork, syncer } = nodeTest
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
-    peer.work = BigInt(1)
+    peer.work = 1n
     peer.sequence = 1
     peer.head = Buffer.from('')
 
@@ -106,7 +106,7 @@ describe('Syncer', () => {
     const { peerNetwork, syncer } = nodeTest
 
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
-    peer.work = BigInt(1)
+    peer.work = 1n
     peer.sequence = 1
     peer.head = Buffer.from('')
 
@@ -156,7 +156,7 @@ describe('Syncer', () => {
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
     peer.sequence = blockA4.header.sequence
     peer.head = blockA4.header.hash
-    peer.work = BigInt(10)
+    peer.work = 10n
 
     const getBlocksSpy = jest
       .spyOn(peerNetwork, 'getBlocks')
@@ -203,7 +203,7 @@ describe('Syncer', () => {
     const { peer } = getConnectedPeer(peerNetwork.peerManager)
     peer.sequence = 2
     peer.head = Buffer.alloc(32, 1)
-    peer.work = BigInt(10)
+    peer.work = 10n
 
     const getBlocksSpy = jest
       .spyOn(peerNetwork, 'getBlocks')

--- a/ironfish/src/testUtilities/helpers/blockchain.ts
+++ b/ironfish/src/testUtilities/helpers/blockchain.ts
@@ -6,5 +6,5 @@ import '../matchers/blockchain'
 import { Target } from '../../primitives/target'
 
 export function acceptsAllTarget(): Target {
-  return new Target(BigInt(2) ** BigInt(256) - BigInt(1))
+  return new Target(2n ** 256n - 1n)
 }

--- a/ironfish/src/utils/bigint.ts
+++ b/ironfish/src/utils/bigint.ts
@@ -44,7 +44,7 @@ function min(a: bigint, b: bigint): bigint {
  */
 function fromBytesBE(bytes: Buffer): bigint {
   if (bytes.length === 0) {
-    return BigInt(0)
+    return 0n
   }
 
   const hex: string[] = []

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -281,7 +281,7 @@ export class Account {
       const existingAsset = await this.walletDb.getAsset(this, asset.id(), tx)
 
       let createdTransactionHash = transaction.hash()
-      let supply = BigInt(0)
+      let supply = 0n
 
       // Adjust supply if this transaction is connected on a block.
       if (blockHash && sequence) {
@@ -336,7 +336,7 @@ export class Account {
       Assert.isNotNull(existingAsset.supply, 'Supply should be non-null for asset')
 
       const supply = existingAsset.supply - value
-      Assert.isTrue(supply >= BigInt(0), 'Invalid burn value')
+      Assert.isTrue(supply >= 0n, 'Invalid burn value')
 
       await this.walletDb.putAsset(
         this,
@@ -412,7 +412,7 @@ export class Account {
 
       const existingSupply = existingAsset.supply
       const supply = existingSupply - value
-      Assert.isTrue(supply >= BigInt(0))
+      Assert.isTrue(supply >= 0n)
 
       let blockHash = existingAsset.blockHash
       let sequence = existingAsset.sequence

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -928,12 +928,12 @@ export class Wallet {
     amountsNeeded.set(Asset.nativeId(), options.fee)
 
     for (const output of raw.outputs) {
-      const currentAmount = amountsNeeded.get(output.note.assetId()) ?? BigInt(0)
+      const currentAmount = amountsNeeded.get(output.note.assetId()) ?? 0n
       amountsNeeded.set(output.note.assetId(), currentAmount + output.note.value())
     }
 
     for (const burn of raw.burns) {
-      const currentAmount = amountsNeeded.get(burn.assetId) ?? BigInt(0)
+      const currentAmount = amountsNeeded.get(burn.assetId) ?? 0n
       amountsNeeded.set(burn.assetId, currentAmount + burn.value)
     }
 
@@ -971,7 +971,7 @@ export class Wallet {
     amountNeeded: bigint,
     confirmations: number,
   ): Promise<{ amount: bigint; notes: Array<{ note: Note; witness: NoteWitness }> }> {
-    let amount = BigInt(0)
+    let amount = 0n
     const notes: Array<{ note: Note; witness: NoteWitness }> = []
 
     const head = await sender.getHead()
@@ -980,7 +980,7 @@ export class Wallet {
     }
 
     for await (const unspentNote of this.getUnspentNotes(sender, assetId)) {
-      if (unspentNote.note.value() <= BigInt(0)) {
+      if (unspentNote.note.value() <= 0n) {
         continue
       }
 

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -289,7 +289,7 @@ export class WalletDB {
           account,
           Asset.nativeId(),
           {
-            unconfirmed: BigInt(0),
+            unconfirmed: 0n,
             blockHash: null,
             sequence: null,
           },
@@ -879,7 +879,7 @@ export class WalletDB {
 
     return (
       unconfirmedBalance ?? {
-        unconfirmed: BigInt(0),
+        unconfirmed: 0n,
         blockHash: null,
         sequence: null,
       }

--- a/ironfish/src/workerPool/tasks/decryptNotes.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.ts
@@ -228,7 +228,7 @@ export class DecryptNotesTask extends WorkerTask {
 
       // Try decrypting the note as the owner
       const receivedNote = note.decryptNoteForOwner(incomingViewKey)
-      if (receivedNote && receivedNote.value() !== BigInt(0)) {
+      if (receivedNote && receivedNote.value() !== 0n) {
         decryptedNotes.push({
           index: currentNoteIndex,
           forSpender: false,
@@ -245,7 +245,7 @@ export class DecryptNotesTask extends WorkerTask {
       if (decryptForSpender) {
         // Try decrypting the note as the spender
         const spentNote = note.decryptNoteForSpender(outgoingViewKey)
-        if (spentNote && spentNote.value() !== BigInt(0)) {
+        if (spentNote && spentNote.value() !== 0n) {
           decryptedNotes.push({
             index: currentNoteIndex,
             forSpender: true,


### PR DESCRIPTION
## Summary

There's no reason to wrap bigints in the bigint type. You can just use literals. This only replaces some places.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
