### PR TITLE
fixes scanTransactions to update ScanState after every block

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -417,7 +417,6 @@ export class Wallet {
           assetBalanceDeltas.update(transactionDeltas)
 
           await this.upsertAssetsFromDecryptedNotes(account, decryptedNotes, blockHeader, tx)
-          scan?.signal(blockHeader.sequence)
         }
 
         await account.updateUnconfirmedBalances(
@@ -588,6 +587,7 @@ export class Wallet {
       false,
     )) {
       await this.connectBlock(blockHeader, scan)
+      scan.signal(blockHeader.sequence)
     }
 
     if (this.chainProcessor.hash === null) {


### PR DESCRIPTION
## Summary

scan state is updated with 'scan.signal'. we currently call 'scan.signal' within the logic of 'connectBlock' after scanning a transaction for an account. the result of this is that we only update the scan state for a sequence if some account in the wallet has a transaction at that sequence. the impact of this is that the output of `wallet:rescan' does not update as the scan progresses through the chain.

updates the scan state within 'scanTransactions' after each call to 'connectBlock' so that the scan state reflects that the block has been connected for all accounts.

## Testing Plan

- manual testing

before:
![image](https://user-images.githubusercontent.com/57735705/224119656-69fcecb3-cb07-4279-80ef-46af8600d0e6.png)

after:
![image](https://user-images.githubusercontent.com/57735705/224119745-7ed1c13a-91a5-4a69-a6b9-c992f86d237b.png)


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
