### PR TITLE
fixes genesis block transaction status

### DIFF
--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -959,10 +959,8 @@ export class Account {
     if (confirmations > 0) {
       const unconfirmedSequenceEnd = headSequence
 
-      const unconfirmedSequenceStart = Math.max(
-        unconfirmedSequenceEnd - confirmations + 1,
-        GENESIS_BLOCK_SEQUENCE,
-      )
+      const unconfirmedSequenceStart =
+        Math.max(unconfirmedSequenceEnd - confirmations, GENESIS_BLOCK_SEQUENCE) + 1
 
       for await (const transaction of this.walletDb.loadTransactionsInSequenceRange(
         this,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -16,6 +16,7 @@ import { getFee } from '../memPool/feeEstimator'
 import { NoteHasher } from '../merkletree/hasher'
 import { NoteWitness, Witness } from '../merkletree/witness'
 import { Mutex } from '../mutex'
+import { GENESIS_BLOCK_SEQUENCE } from '../primitives'
 import { BlockHeader } from '../primitives/blockheader'
 import { BurnDescription } from '../primitives/burnDescription'
 import { Note } from '../primitives/note'
@@ -1202,7 +1203,9 @@ export class Wallet {
     }
 
     if (transaction.sequence) {
-      const isConfirmed = headSequence - transaction.sequence >= confirmations
+      const isConfirmed =
+        transaction.sequence === GENESIS_BLOCK_SEQUENCE ||
+        headSequence - transaction.sequence >= confirmations
 
       return isConfirmed ? TransactionStatus.CONFIRMED : TransactionStatus.UNCONFIRMED
     } else {


### PR DESCRIPTION
## Summary

all transactions on the genesis block are confirmed.

'wallet:balance --all' shows a 'confirmed' balance of 0 for the genesis account when the chain contains only the genesis block.

fixes calculation of confirmed balance by ensuring that the range of unconfirmed sequences starts at at least 2

'wallet:transactions' shows a single 'unconfirmed' transaction for the genesis account when the chain contains only the genesis block.

fixes display of transaction status by checking if transaction has sequence equal to genesis block sequence

## Testing Plan

Before:
![image](https://user-images.githubusercontent.com/57735705/224203116-19f634a6-6783-4e47-b18b-739f763a8f38.png)

After:
![image](https://user-images.githubusercontent.com/57735705/224203241-b0e89152-3722-43d7-83d1-9e47f8810b40.png)


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
