### PR TITLE
Use confirmations when checking balance in sendTransaction

### DIFF
--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -97,7 +97,9 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
 
     // Check that the node has enough balance
     for (const [assetId, sum] of totalByAssetId) {
-      const balance = await node.wallet.getBalance(account, assetId)
+      const balance = await node.wallet.getBalance(account, assetId, {
+        confirmations: request.data.confirmations ?? undefined,
+      })
 
       if (balance.available < sum) {
         throw new ValidationError(


### PR DESCRIPTION
## Summary

I'm reasonably sure the custom confirmation range should be passed in here, since we pass it in to node.wallet.send.

I could use a review from someone familiar with the wallet code to double-check though.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
