### PR TITLE
avoids deleting wallet in reset command

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -32,23 +32,9 @@ export default class Reset extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(Reset)
 
-    let confirmed = flags.confirm
-
-    const warningMessage =
-      `\n/!\\ WARNING: This will permanently delete your wallets. You can back them up by loading the previous version of ironfish and running ironfish export. /!\\\n` +
-      '\nHave you read the warning? (Y)es / (N)o'
-
-    confirmed = flags.confirm || (await CliUx.ux.confirm(warningMessage))
-
-    if (!confirmed) {
-      this.log('Reset aborted.')
-      this.exit(0)
-    }
-
     this.sdk.internal.set('networkId', this.sdk.config.defaults.networkId)
     this.sdk.internal.set('isFirstRun', true)
     await this.sdk.internal.save()
-    const walletDatabasePath = this.sdk.config.walletDatabasePath
     const chainDatabasePath = this.sdk.config.chainDatabasePath
     const hostFilePath: string = this.sdk.config.files.join(
       this.sdk.config.dataDir,
@@ -57,12 +43,12 @@ export default class Reset extends IronfishCommand {
 
     const message =
       '\nYou are about to destroy your node databases. The following directories and files will be deleted:\n' +
-      `\nWallet: ${walletDatabasePath}` +
       `\nBlockchain: ${chainDatabasePath}` +
       `\nHosts: ${hostFilePath}` +
+      '\nYour wallet, accounts, and keys will NOT be deleted.' +
       `\n\nAre you sure? (Y)es / (N)o`
 
-    confirmed = flags.confirm || (await CliUx.ux.confirm(message))
+    const confirmed = flags.confirm || (await CliUx.ux.confirm(message))
 
     if (!confirmed) {
       this.log('Reset aborted.')
@@ -72,7 +58,6 @@ export default class Reset extends IronfishCommand {
     CliUx.ux.action.start('Deleting databases...')
 
     await Promise.all([
-      fsAsync.rm(walletDatabasePath, { recursive: true, force: true }),
       fsAsync.rm(chainDatabasePath, { recursive: true, force: true }),
       fsAsync.rm(hostFilePath, { recursive: true, force: true }),
     ])

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -42,7 +42,7 @@ export default class Reset extends IronfishCommand {
     )
 
     const message =
-      '\nYou are about to destroy your node databases. The following directories and files will be deleted:\n' +
+      '\nYou are about to destroy your local copy of the blockchain. The following directories and files will be deleted:\n' +
       `\nBlockchain: ${chainDatabasePath}` +
       `\nHosts: ${hostFilePath}` +
       '\nYour wallet, accounts, and keys will NOT be deleted.' +


### PR DESCRIPTION
## Summary

we likely do NOT want to delete users' accounts and keys after mainnet launch.

removes deletion of wallet database from 'reset' command. when the user starts a node on a new network after running reset, the wallet will automatically reset because the account heads will not be on the same chain as the network.

## Testing Plan

- manual testing

1. verify that node databases are on the wrong network
![image](https://user-images.githubusercontent.com/57735705/224442050-48b34c4a-29b5-48ad-b611-2d5f9afa47d8.png)

2. run `reset`
![image](https://user-images.githubusercontent.com/57735705/224442121-44da422c-6249-429c-a878-aa44e88c9216.png)

3. verify that accounts are still there
![image](https://user-images.githubusercontent.com/57735705/224442193-e859c85e-3cee-4152-9584-601d7cac5817.png)

4. verify that wallet is reset once node starts successfully
![image](https://user-images.githubusercontent.com/57735705/224442290-0b24d34a-4bb1-4df8-ae31-1ad3de8c02a1.png)


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
