### PR TITLE
improves output of stop command

### DIFF
--- a/ironfish-cli/src/commands/stop.ts
+++ b/ironfish-cli/src/commands/stop.ts
@@ -1,7 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { IronfishNode, RpcConnectionError } from '@ironfish/sdk'
+import { IronfishNode } from '@ironfish/sdk'
+import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../command'
 import { RemoteFlags } from '../flags'
 
@@ -17,13 +18,12 @@ export default class StopCommand extends IronfishCommand {
   async start(): Promise<void> {
     await this.parse(StopCommand)
 
-    await this.sdk.client.connect().catch((e) => {
-      if (e instanceof RpcConnectionError) {
-        this.exit(0)
-      }
-      throw e
-    })
+    await this.sdk.client.connect()
+
+    CliUx.ux.action.start('Asking node to shut down...')
 
     await this.sdk.client.stopNode()
+
+    CliUx.ux.action.stop('done.')
   }
 }

--- a/ironfish/src/rpc/routes/node/stopNode.ts
+++ b/ironfish/src/rpc/routes/node/stopNode.ts
@@ -21,7 +21,7 @@ router.register<typeof StopNodeRequestSchema, StopNodeResponse>(
   StopNodeRequestSchema,
   async (request, node): Promise<void> => {
     node.logger.withTag('stopnode').info('Shutting down')
-    await node.shutdown()
     request.end()
+    await node.shutdown()
   },
 )


### PR DESCRIPTION
## Summary

the 'stopNode' RPC shuts down the node before returning a response, so the cli client receives an error from the lost connection. IronfishCommand handles RPC connection errors and outputs 'Cannot connect to your node, start your node first.'. this is confusing both because we were able to connect to the node and because we successfully stopped it.

the stop command also silences RPC connection errors, so nothing is output if the node is already stopped when stop is run.

- returns a response from stopNode before shutting down the node
- removes error handling from 'client.connect' in stop command since the IronfishCommand abstract class handles these errors
- adds output to 'stop' command indicating that it asks the node to shut down

## Testing Plan

manual testing:
- start a node
- use 'ironfish stop' to stop the node
- use 'ironfish stop' to try to stop the node again once it has shut down

Before:
![image](https://user-images.githubusercontent.com/57735705/224457742-eb3c9e23-94e3-44f6-98f9-4879ce93d4f8.png)

After:
![image](https://user-images.githubusercontent.com/57735705/224457799-8151da51-6a93-49de-a7e9-e72aa96619b4.png)


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
