### PR TITLE
Fix reset changing internal.json before confirming

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -32,9 +32,6 @@ export default class Reset extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(Reset)
 
-    this.sdk.internal.set('networkId', this.sdk.config.defaults.networkId)
-    this.sdk.internal.set('isFirstRun', true)
-    await this.sdk.internal.save()
     const chainDatabasePath = this.sdk.config.chainDatabasePath
     const hostFilePath: string = this.sdk.config.files.join(
       this.sdk.config.dataDir,
@@ -61,6 +58,10 @@ export default class Reset extends IronfishCommand {
       fsAsync.rm(chainDatabasePath, { recursive: true, force: true }),
       fsAsync.rm(hostFilePath, { recursive: true, force: true }),
     ])
+
+    this.sdk.internal.set('networkId', this.sdk.config.defaults.networkId)
+    this.sdk.internal.set('isFirstRun', true)
+    await this.sdk.internal.save()
 
     CliUx.ux.action.stop('Databases deleted successfully')
   }


### PR DESCRIPTION
## Summary

Reset should not change the `internal.json` file before the user has confirmed whether they wish to reset. Otherwise, when we switch the default network ID at mainnet, someone running `reset` who responds "No" will have their network ID out of sync with their database.

## Testing Plan

* [x] Create data directory with `--networkId 2`. Run `reset` and No on that data directory and confirm that internal.json has networkId 2.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
