### PR TITLE
Reset enableTelemetry and telemetryNodeId

### DIFF
--- a/ironfish-cli/src/commands/mainnet.ts
+++ b/ironfish-cli/src/commands/mainnet.ts
@@ -71,8 +71,15 @@ export default class Mainnet extends IronfishCommand {
       this.exit(1)
     }
 
+    // Reset the telemetry config to allow people to re-opt in
+    if (this.sdk.config.isSet('enableTelemetry') && this.sdk.config.get('enableTelemetry')) {
+      this.sdk.config.clear('enableTelemetry')
+      await this.sdk.config.save()
+    }
+
     this.sdk.internal.set('networkId', 1)
     this.sdk.internal.set('isFirstRun', true)
+    this.sdk.internal.clear('telemetryNodeId')
     await this.sdk.internal.save()
 
     CliUx.ux.action.stop('Data migrated successfully.')


### PR DESCRIPTION
## Summary

Since we're resetting the node to first run, we should clear the enableTelemetry config to give users another chance to opt in to telemetry. We may as well also clear telemetryNodeId since we're changing networks too.

## Testing Plan

* [x] Start ironfish@0.1.72 in a directory, set enableTelemetry true. Run mainnet and ensure enableTelemetry in config.json is gone, and the telemetryNodeId in internal.json is gone.
* [x] Start ironfish@0.1.72 in a directory. Set enableTelemetry false. Run mainnet and ensure enableTeletry in config.json is still false, and the telemetryNodeId in internal.json is gone.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
