### PR TITLE
Add better support for streaming endpoints in HTTP

### DIFF
--- a/ironfish/src/rpc/adapters/httpAdapter.ts
+++ b/ironfish/src/rpc/adapters/httpAdapter.ts
@@ -11,6 +11,7 @@ import { ApiNamespace, Router } from '../routes'
 import { RpcServer } from '../server'
 import { IRpcAdapter } from './adapter'
 import { ERROR_CODES, ResponseError } from './errors'
+import { MESSAGE_DELIMITER } from './socketAdapter'
 
 const MEGABYTES = 1000 * 1000
 const MAX_REQUEST_SIZE = 5 * MEGABYTES
@@ -202,16 +203,16 @@ export class RpcHttpAdapter implements IRpcAdapter {
       route,
       (status: number, data?: unknown) => {
         response.statusCode = status
-        const delimeter = chunkStreamed ? ',' : ''
+        const delimeter = chunkStreamed ? MESSAGE_DELIMITER : ''
         response.end(delimeter + JSON.stringify({ status, data }))
         this.cleanUpRequest(requestId)
       },
       (data: unknown) => {
         // TODO: Most HTTP clients don't parse `Transfer-Encoding: chunked` by chunk
         // they wait until all chunks have been received and combine them. This will
-        // stream a ',' delimitated list of JSON objects but is still probably not
+        // stream a delimitated list of JSON objects but is still probably not
         // ideal as a response. We could find some better way to stream
-        const delimeter = chunkStreamed ? ',' : ''
+        const delimeter = chunkStreamed ? MESSAGE_DELIMITER : ''
         response.write(delimeter + JSON.stringify({ data }))
         chunkStreamed = true
       },


### PR DESCRIPTION
## Summary
This PR fixes a bug where the `'Content-Type', 'application/json'` header was not set correctly before streaming a response.

It also slightly modifies streaming behavior. Some endpoints were streaming responses but we did not include a delimiter in the response. A delimiter was implicitly added because of the ` Transfer-Encoding: chunked` header but that delimiter doesn't show up in the final response of many HTTP clients because they just concatenate all the chunks together into one final response once the last chunk is received. This PR also adds a delimiter `\f` to the response so it can be easily separated into the individually streamed chunks.

If only one chunk is streamed by the response the delimiter is omitted.


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
