### PR TITLE
Add error message when running from a windows 32-bit install

### DIFF
--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -5,6 +5,13 @@ if (process.platform !== 'win32') {
   require('@ironfish/rust-nodejs').initSignalHandler()
 }
 
+if (process.platform === 'win32' && process.arch === 'ia32') {
+  console.log(
+    `32-bit installations are not supported. You may have accidentally installed 32-bit Node.js. Please try reinstalling Node.js v18 (64-bit): https://nodejs.org/en/download/`,
+  )
+  process.exit(1)
+}
+
 if (process.versions.node.split('.')[0] !== '18') {
   console.log(
     `NodeJS version ${process.versions.node} is not compatible. Must have Node v18 installed: https://nodejs.org/en/download/`,


### PR DESCRIPTION
## Summary

This was an error that came up in slack: https://iron-fish.slack.com/archives/C02PF56HESK/p1678727391843899 I suspect some people are installing 32-bit versions by mistake.

If they do actually have 32-bit Windows computers, those would be at least 10 years old, which likely will end up struggling to run Iron Fish anyway (particularly since we recommend >4GB RAM)

## Testing Plan

* [x] Tested on a Windows computer with 32-bit Node.js installed to ensure the error popped up
* [x] Tested on a Windows computer with 64-bit Node.js installed to ensure no error appeared

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

I updated the onboarding docs to specifically call out 64-bit installs: https://ironfish.network/docs/onboarding/installation-iron-fish

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
