### PR TITLE
fixes rescanning wallet without --reset

### DIFF
--- a/ironfish-cli/src/commands/wallet/rescan.ts
+++ b/ironfish-cli/src/commands/wallet/rescan.ts
@@ -10,7 +10,7 @@ import { ProgressBar } from '../../types'
 import { hasUserResponseError } from '../../utils'
 
 export class RescanCommand extends IronfishCommand {
-  static description = `Rescan the blockchain for transaction`
+  static description = `Rescan the blockchain for transactions. Clears wallet disk caches before rescanning.`
 
   static flags = {
     ...RemoteFlags,
@@ -19,11 +19,6 @@ export class RescanCommand extends IronfishCommand {
       default: true,
       description: 'Follow the rescan live, or attach to an already running rescan',
       allowNo: true,
-    }),
-    reset: Flags.boolean({
-      default: false,
-      description:
-        'Clear the in-memory and disk caches before rescanning. Note that this removes all pending transactions',
     }),
     local: Flags.boolean({
       default: false,
@@ -37,14 +32,10 @@ export class RescanCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(RescanCommand)
-    const { follow, reset, local, from } = flags
+    const { follow, local, from } = flags
 
     if (local && !follow) {
       this.error('You cannot pass both --local and --no-follow')
-    }
-
-    if (from && !reset) {
-      this.error('When passing --from, you must also pass --reset.')
     }
 
     const client = await this.sdk.connectRpc(local)
@@ -53,7 +44,7 @@ export class RescanCommand extends IronfishCommand {
       stdout: true,
     })
 
-    const response = client.rescanAccountStream({ reset, follow, from })
+    const response = client.rescanAccountStream({ follow, from })
 
     const speed = new Meter()
 

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/rescanAccount.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/rescanAccount.test.ts.fixture
@@ -1,0 +1,30 @@
+{
+  "wallet/rescanAccount sets account head to one before the request.from sequence": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:q3Sg5nq5F4FBDGLBQA82adp4zfSm46kPFbJUlcSDmAk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:maskm0r6USIh55DSh6onTCysP+MEpqPV0OYLIXgDy5g="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1678897392755,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA9spIe9qq9XCnvXKM0mvzp6x81rA1rFKBY7C5UOsSdiOXc6SZeTXwV9RuWmzGZ56WmcQercJu3bMpHzN1TksuEAHV3GufHIgUaCIX++5VCtqvkztByn+s+faxBiJYo0hwOlmFkt0LV7Q4vKW5s8x+/pk+yicC03fVO/nMfsOfGL8DRg4+vKzg4l8iML3l+1elt9DxYyOWdihkpHtI/Bv4gTHMEyNhm5+H9MuOT5nwr2GWcSue36x/P4sXuKNGfJkUE8T0nhFzUDTRt1awmTUkbfUWuQ5pEhrrJofq3BRbHeci3dvUqhAP/do1gENe9+wv1fyQerLLFnkjd4I9pF1VGcLzUWNgltKH4GUBAuVEGFoevB8+iXtaqkOOcE5mMtInro+vJ6oq9jJWBZCbkvaRe9bM/MEh9W39Odc59cvRGN0CYrrTqRcyjEZbKvI7g0HFpVmQ7sKL4/j0ncNcmdRWBooqo8hBP4gMoGk7w7YkiiUVfVpSXCOZsnffo8qXQ/DhP3fACZt3mEaCzr9CqhJD5XFQ1CwewYkfADYyEJDG2GLp2w8VRh3niDlOVWnJCMmgEos/uXt1lfnpW+0/udyykx8aXssLWpPEniWEALNoE5ZFNhpTSJHkJUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwel9yFFdsdl1imMjiy6n8Ai6eSAP5QiSx3otK5gvWhpSfIarTiu0HNUY0Fwt+gcwiCFE4raymoKjb7BdUCyS8Bw=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -577,7 +577,7 @@ export class Wallet {
     }
 
     this.logger.info(
-      `Scan starting from earliest found account head hash: ${beginHash.toString('hex')}`,
+      `Scan starting from block ${beginHash.toString('hex')} (${beginHeader.sequence})`,
     )
 
     // Go through every transaction in the chain and add notes that we can decrypt


### PR DESCRIPTION
## Summary

the logic of 'connectBlock' filters any account that does not have its 'head' equal to the previous block. this means that if we don't reset account heads during rescan nothing will happen.

this is also true of rescanning using the '--from' flag. this flag lets users start the rescan at a particular sequence. however, if we don't set account heads to that sequence then scanning won't do anything.

- removes the 'reset' option and always resets accounts
- throws an error if the 'from' sequence is not in the chain or the header at that sequence is not on the main chain
- sets account heads equal to the block header before the from sequence if it is not the genesis block

## Testing Plan

- updated unit tests
- manual testing

before:
![image](https://user-images.githubusercontent.com/57735705/225383115-0c15dbc6-feca-4217-a882-57d3941ca37f.png)
Finishes scanning almost immediately and then hits an error

after:
![image](https://user-images.githubusercontent.com/57735705/225382456-59aeaff5-6169-49a2-9d6c-6f30c555fa20.png)


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
