### PR TITLE
migrates account createdAt from Date to HeadValue

### DIFF
--- a/ironfish/src/migrations/data/027-account-created-at-block.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Logger } from '../../logger'
+import { IronfishNode } from '../../node'
+import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { createDB } from '../../storage/utils'
+import { Account } from '../../wallet'
+import { Migration } from '../migration'
+import { GetStores } from './027-account-created-at-block/stores'
+
+export class Migration027 extends Migration {
+  path = __filename
+
+  prepare(node: IronfishNode): IDatabase {
+    return createDB({ location: node.config.walletDatabasePath })
+  }
+
+  async forward(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const stores = GetStores(db)
+
+    logger.info(`Migrating account data to store block-based creation time`)
+
+    for await (const accountValue of stores.old.accounts.getAllValuesIter(tx)) {
+      const account = new Account({
+        ...accountValue,
+        createdAt: null,
+        walletDb: node.wallet.walletDb,
+      })
+
+      logger.info(` Migrating account ${account.name}`)
+
+      await stores.new.accounts.put(account.id, account, tx)
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  async backward(): Promise<void> {}
+}

--- a/ironfish/src/migrations/data/027-account-created-at-block/new/accountValue.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block/new/accountValue.ts
@@ -87,7 +87,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
 
   getSize(value: AccountValue): number {
     let size = 0
-    size += 1
+    size += 1 // flags
     size += VERSION_LENGTH
     size += bufio.sizeVarString(value.id, 'utf8')
     size += bufio.sizeVarString(value.name, 'utf8')

--- a/ironfish/src/migrations/data/027-account-created-at-block/new/accountValue.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block/new/accountValue.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+import { HeadValue, NullableHeadValueEncoding } from './headValue'
+
+const KEY_LENGTH = 32
+export const VIEW_KEY_LENGTH = 64
+const VERSION_LENGTH = 2
+
+export interface AccountValue {
+  version: number
+  id: string
+  name: string
+  spendingKey: string | null
+  viewKey: string
+  incomingViewKey: string
+  outgoingViewKey: string
+  publicAddress: string
+  createdAt: HeadValue | null
+}
+
+export type AccountImport = Omit<AccountValue, 'id' | 'createdAt'> & {
+  createdAt: { hash: string; sequence: number } | null
+}
+
+export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
+  serialize(value: AccountValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    let flags = 0
+    flags |= Number(!!value.spendingKey) << 0
+    flags |= Number(!!value.createdAt) << 1
+    bw.writeU8(flags)
+    bw.writeU16(value.version)
+    bw.writeVarString(value.id, 'utf8')
+    bw.writeVarString(value.name, 'utf8')
+    if (value.spendingKey) {
+      bw.writeBytes(Buffer.from(value.spendingKey, 'hex'))
+    }
+    bw.writeBytes(Buffer.from(value.viewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
+
+    if (value.createdAt) {
+      const encoding = new NullableHeadValueEncoding()
+      bw.writeBytes(encoding.serialize(value.createdAt))
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): AccountValue {
+    const reader = bufio.read(buffer, true)
+    const flags = reader.readU8()
+    const version = reader.readU16()
+    const hasSpendingKey = flags & (1 << 0)
+    const hasCreatedAt = flags & (1 << 1)
+    const id = reader.readVarString('utf8')
+    const name = reader.readVarString('utf8')
+    const spendingKey = hasSpendingKey ? reader.readBytes(KEY_LENGTH).toString('hex') : null
+    const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
+    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+
+    let createdAt = null
+    if (hasCreatedAt) {
+      const encoding = new NullableHeadValueEncoding()
+      createdAt = encoding.deserialize(reader.readBytes(encoding.nonNullSize))
+    }
+
+    return {
+      version,
+      id,
+      name,
+      viewKey,
+      incomingViewKey,
+      outgoingViewKey,
+      spendingKey,
+      publicAddress,
+      createdAt,
+    }
+  }
+
+  getSize(value: AccountValue): number {
+    let size = 0
+    size += 1
+    size += VERSION_LENGTH
+    size += bufio.sizeVarString(value.id, 'utf8')
+    size += bufio.sizeVarString(value.name, 'utf8')
+    if (value.spendingKey) {
+      size += KEY_LENGTH
+    }
+    size += VIEW_KEY_LENGTH
+    size += KEY_LENGTH
+    size += KEY_LENGTH
+    size += PUBLIC_ADDRESS_LENGTH
+    if (value.createdAt) {
+      const encoding = new NullableHeadValueEncoding()
+      size += encoding.nonNullSize
+    }
+
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/027-account-created-at-block/new/headValue.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block/new/headValue.ts
@@ -10,7 +10,7 @@ export type HeadValue = {
 }
 
 export class NullableHeadValueEncoding implements IDatabaseEncoding<HeadValue | null> {
-  readonly nonNullSize = 32 + 4
+  readonly nonNullSize = 32 + 4 // 256-bit block hash + 32-bit integer
 
   serialize(value: HeadValue | null): Buffer {
     const bw = bufio.write(this.getSize(value))

--- a/ironfish/src/migrations/data/027-account-created-at-block/new/headValue.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block/new/headValue.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+export type HeadValue = {
+  hash: Buffer
+  sequence: number
+}
+
+export class NullableHeadValueEncoding implements IDatabaseEncoding<HeadValue | null> {
+  readonly nonNullSize = 32 + 4
+
+  serialize(value: HeadValue | null): Buffer {
+    const bw = bufio.write(this.getSize(value))
+
+    if (value) {
+      bw.writeHash(value.hash)
+      bw.writeU32(value.sequence)
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): HeadValue | null {
+    const reader = bufio.read(buffer, true)
+
+    if (reader.left()) {
+      const hash = reader.readHash()
+      const sequence = reader.readU32()
+      return { hash, sequence }
+    }
+
+    return null
+  }
+
+  getSize(value: HeadValue | null): number {
+    return value ? this.nonNullSize : 0
+  }
+}

--- a/ironfish/src/migrations/data/027-account-created-at-block/new/index.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block/new/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase, IDatabaseStore, StringEncoding } from '../../../../storage'
+import { AccountValue, AccountValueEncoding } from './accountValue'
+
+export function GetNewStores(db: IDatabase): {
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+} {
+  const accounts: IDatabaseStore<{ key: string; value: AccountValue }> = db.addStore(
+    {
+      name: 'a',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountValueEncoding(),
+    },
+    false,
+  )
+
+  return { accounts }
+}

--- a/ironfish/src/migrations/data/027-account-created-at-block/old/accountValue.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block/old/accountValue.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
+import bufio from 'bufio'
+import { IDatabaseEncoding } from '../../../../storage'
+
+const KEY_LENGTH = 32
+export const VIEW_KEY_LENGTH = 64
+const VERSION_LENGTH = 2
+
+export interface AccountValue {
+  version: number
+  id: string
+  name: string
+  spendingKey: string | null
+  viewKey: string
+  incomingViewKey: string
+  outgoingViewKey: string
+  publicAddress: string
+  createdAt: Date | null
+}
+
+export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
+  serialize(value: AccountValue): Buffer {
+    const bw = bufio.write(this.getSize(value))
+    let flags = 0
+    flags |= Number(!!value.spendingKey) << 0
+    flags |= Number(!!value.createdAt) << 1
+    bw.writeU8(flags)
+    bw.writeU16(value.version)
+    bw.writeVarString(value.id, 'utf8')
+    bw.writeVarString(value.name, 'utf8')
+    if (value.spendingKey) {
+      bw.writeBytes(Buffer.from(value.spendingKey, 'hex'))
+    }
+    bw.writeBytes(Buffer.from(value.viewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
+    if (value.createdAt) {
+      bw.writeU64(value.createdAt.getTime())
+    }
+
+    return bw.render()
+  }
+
+  deserialize(buffer: Buffer): AccountValue {
+    const reader = bufio.read(buffer, true)
+    const flags = reader.readU8()
+    const version = reader.readU16()
+    const hasSpendingKey = flags & (1 << 0)
+    const hasCreatedAt = flags & (1 << 1)
+    const id = reader.readVarString('utf8')
+    const name = reader.readVarString('utf8')
+    const spendingKey = hasSpendingKey ? reader.readBytes(KEY_LENGTH).toString('hex') : null
+    const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
+    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+    const createdAt = hasCreatedAt ? new Date(reader.readU64()) : null
+
+    return {
+      version,
+      id,
+      name,
+      viewKey,
+      incomingViewKey,
+      outgoingViewKey,
+      spendingKey,
+      publicAddress,
+      createdAt,
+    }
+  }
+
+  getSize(value: AccountValue): number {
+    let size = 0
+    size += 1
+    size += VERSION_LENGTH
+    size += bufio.sizeVarString(value.id, 'utf8')
+    size += bufio.sizeVarString(value.name, 'utf8')
+    if (value.spendingKey) {
+      size += KEY_LENGTH
+    }
+    size += VIEW_KEY_LENGTH
+    size += KEY_LENGTH
+    size += KEY_LENGTH
+    size += PUBLIC_ADDRESS_LENGTH
+    if (value.createdAt) {
+      size += 8
+    }
+
+    return size
+  }
+}

--- a/ironfish/src/migrations/data/027-account-created-at-block/old/index.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block/old/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase, IDatabaseStore, StringEncoding } from '../../../../storage'
+import { AccountValue, AccountValueEncoding } from './accountValue'
+
+export function GetOldStores(db: IDatabase): {
+  accounts: IDatabaseStore<{ key: string; value: AccountValue }>
+} {
+  const accounts: IDatabaseStore<{ key: string; value: AccountValue }> = db.addStore(
+    {
+      name: 'a',
+      keyEncoding: new StringEncoding(),
+      valueEncoding: new AccountValueEncoding(),
+    },
+    false,
+  )
+
+  return { accounts }
+}

--- a/ironfish/src/migrations/data/027-account-created-at-block/stores.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block/stores.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase } from '../../../storage'
+import { GetNewStores } from './new'
+import { GetOldStores } from './old'
+
+export function GetStores(db: IDatabase): {
+  old: ReturnType<typeof GetOldStores>
+  new: ReturnType<typeof GetNewStores>
+} {
+  const oldStores = GetOldStores(db)
+  const newStores = GetNewStores(db)
+
+  return { old: oldStores, new: newStores }
+}

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -15,6 +15,7 @@ import { Migration023 } from './023-wallet-optional-spending-key'
 import { Migration024 } from './024-unspent-notes'
 import { Migration025 } from './025-backfill-wallet-nullifier-to-transaction-hash'
 import { Migration026 } from './026-timestamp-to-transactions'
+import { Migration027 } from './027-account-created-at-block'
 
 export const MIGRATIONS = [
   Migration014,
@@ -30,4 +31,5 @@ export const MIGRATIONS = [
   Migration024,
   Migration025,
   Migration026,
+  Migration027,
 ]

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -88,7 +88,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
 
   getSize(value: AccountValue): number {
     let size = 0
-    size += 1
+    size += 1 // flags
     size += VERSION_LENGTH
     size += bufio.sizeVarString(value.id, 'utf8')
     size += bufio.sizeVarString(value.name, 'utf8')

--- a/ironfish/src/wallet/walletdb/headValue.ts
+++ b/ironfish/src/wallet/walletdb/headValue.ts
@@ -10,7 +10,7 @@ export type HeadValue = {
 }
 
 export class NullableHeadValueEncoding implements IDatabaseEncoding<HeadValue | null> {
-  readonly nonNullSize = 32 + 4
+  readonly nonNullSize = 32 + 4 // 256-bit block hash + 32-bit integer
 
   serialize(value: HeadValue | null): Buffer {
     const bw = bufio.write(this.getSize(value))

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -35,7 +35,7 @@ import { HeadValue, NullableHeadValueEncoding } from './headValue'
 import { AccountsDBMeta, MetaValue, MetaValueEncoding } from './metaValue'
 import { TransactionValue, TransactionValueEncoding } from './transactionValue'
 
-const VERSION_DATABASE_ACCOUNTS = 26
+const VERSION_DATABASE_ACCOUNTS = 27
 
 const getAccountsDBMetaDefaults = (): AccountsDBMeta => ({
   defaultAccountId: null,


### PR DESCRIPTION
## Summary

to support block-based account birthdays we will store the chain head (block hash and sequence) at the time the account was created.

adds migration to set createdAt to null for all existing accounts

## Testing Plan

- ran data migration and verified that createdAt was set to null with no other account data affected

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
