### PR TITLE
starts scanTransactions after account creation

### DIFF
--- a/ironfish/src/rpc/routes/wallet/create.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/create.test.slow.ts
@@ -14,9 +14,11 @@ describe('Route wallet/create', () => {
   jest.setTimeout(15000)
   const routeTest = createRouteTest()
 
-  it('should create an account', async () => {
+  beforeEach(() => {
     jest.spyOn(routeTest.node.wallet, 'scanTransactions').mockReturnValue(Promise.resolve())
+  })
 
+  it('should create an account', async () => {
     await routeTest.node.wallet.createAccount('existingAccount', true)
 
     const name = uuid()
@@ -37,8 +39,6 @@ describe('Route wallet/create', () => {
   })
 
   it('should set the account as default', async () => {
-    jest.spyOn(routeTest.node.wallet, 'scanTransactions').mockReturnValue(Promise.resolve())
-
     await routeTest.node.wallet.setDefaultAccount(null)
 
     const name = uuid()
@@ -53,8 +53,6 @@ describe('Route wallet/create', () => {
   })
 
   it('should fail if name already exists', async () => {
-    jest.spyOn(routeTest.node.wallet, 'scanTransactions').mockReturnValue(Promise.resolve())
-
     const name = uuid()
 
     await routeTest.node.wallet.createAccount(name)

--- a/ironfish/src/rpc/routes/wallet/create.ts
+++ b/ironfish/src/rpc/routes/wallet/create.ts
@@ -42,6 +42,7 @@ router.register<typeof CreateAccountRequestSchema, CreateAccountResponse>(
     }
 
     const account = await node.wallet.createAccount(name)
+    void node.wallet.scanTransactions()
 
     let isDefaultAccount = false
     if (!node.wallet.hasDefaultAccount || request.data.default) {


### PR DESCRIPTION
## Summary

if a node is online and syncing at the time of account creation it's possible to for an account head to be set to a block that is behind the wallet's chainProcessor.

if the account's head is behind the chain processor then the wallet will not scan any transactions for the account until the node is restarted.

runs scanTransactions after creating an account in the 'create' RPC so that a newly created account will be synced with the chainProcessor if it is behind. this matches the logic in the 'importAccount' RPC.

## Testing Plan

manual testing:
- start a new node so that the node is syncing
- create a new account
- use 'wallet:status' to see the the new account's head is moving forward with the default account

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
