### PR TITLE
fix: add client route for `chain/getTransaction`

### DIFF
--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -46,6 +46,8 @@ import {
   GetPeersResponse,
   GetPublicKeyRequest,
   GetPublicKeyResponse,
+  GetTransactionRequest,
+  GetTransactionResponse,
   GetTransactionStreamRequest,
   GetTransactionStreamResponse,
   GetWorkersStatusRequest,
@@ -524,6 +526,13 @@ export abstract class RpcClient {
   ): RpcResponse<void, GetTransactionStreamResponse> {
     return this.request<void, GetTransactionStreamResponse>(
       `${ApiNamespace.chain}/getTransactionStream`,
+      params,
+    )
+  }
+
+  getTransaction(params: GetTransactionRequest): RpcResponse<void, GetTransactionResponse> {
+    return this.request<void, GetTransactionResponse>(
+      `${ApiNamespace.chain}/getTransaction`,
       params,
     )
   }


### PR DESCRIPTION
## Summary
Adds a client RPC call for `chain/getTransaction`. There are docs for the RPC function on [the website](https://ironfish.network/docs/onboarding/rpc/chain#chaingettransaction) but the route is not actually exposed on the client. 

## Testing Plan
existing tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
[X] No
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
