### PR TITLE
Update httpAdapter: no requirement that a caller use POST

### DIFF
--- a/ironfish/src/rpc/adapters/httpAdapter.ts
+++ b/ironfish/src/rpc/adapters/httpAdapter.ts
@@ -166,14 +166,6 @@ export class RpcHttpAdapter implements IRpcAdapter {
     const url = new URL(request.url, `http://${request.headers.host || 'localhost'}`)
     const route = url.pathname.substring(1)
 
-    if (request.method !== 'POST') {
-      throw new ResponseError(
-        `Route does not exist, Did you mean to use POST?`,
-        ERROR_CODES.ROUTE_NOT_FOUND,
-        404,
-      )
-    }
-
     // TODO(daniel): clean up reading body code here a bit of possible
     let size = 0
     const data: Buffer[] = []


### PR DESCRIPTION
## Summary
This PR just removes the restriction that http rpc callers use `POST`.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
