### PR TITLE
Fix request closing early

### DIFF
--- a/ironfish/src/rpc/adapters/httpAdapter.ts
+++ b/ironfish/src/rpc/adapters/httpAdapter.ts
@@ -78,7 +78,7 @@ export class RpcHttpAdapter implements IRpcAdapter {
           const requestId = uuid()
 
           const waitForClose = new Promise<void>((resolve) => {
-            req.on('close', () => {
+            res.on('close', () => {
               this.cleanUpRequest(requestId)
               resolve()
             })


### PR DESCRIPTION
## Summary
Fixing a bug where the request close callback happens immediately. `req` object represents data coming from the client so once the client has streamed it's request 'close' event will be emitted. We want to wait until the client disconnects or the request is completed. This would be on the `res.on('close')` event. The response stream is separate from the request stream.

## Testing Plan
Tested locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
