### PR TITLE
updates account createdAt if block disconnected

### DIFF
--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -4969,5 +4969,87 @@
         "sequence": 3
       }
     }
+  ],
+  "Accounts disconnectBlock should update an account createdAt field if that block is disconnected": [
+    {
+      "version": 1,
+      "id": "1f36ba0d-fc27-4e21-93ec-f74d90aee106",
+      "name": "accountA",
+      "spendingKey": "9cebffd7d3a2ab3132264fae01cdaebb8fc5f627b4cc110929452ac4cc2b9964",
+      "viewKey": "3de1429fef73ab4317333dd7836a92b4a2464b5288ea8122d8005e9180f3b8658ff8085f655156a0ff76b5d14492d844f3b40ebce32b5d5430c97438acf21bb7",
+      "incomingViewKey": "bb85b9523b8cc9e9217b8b2f5f3fc6e7785b96fd7a7ab893d8b59c209d1bde03",
+      "outgoingViewKey": "1b297c72951c07df2bb4fe11386fb6d73f2ac979d462cba9f256c836e860c3ca",
+      "publicAddress": "40de785eea94bf63bd075cdefa0b34702c0ef7a2e31595312263df2991eef5f1",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:awMq4HRaFn6KCECaPq94qd9SiDIOh6KIjuS/DuFMmTs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:oiqgr5AiMzk8cUzNo1w0JQiozrgF2vX/xV12ivcqXfE="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1679351630561,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAHU5JTNogFqZm/OR7n3ZTEJih5mDhQJgufXgP9c8tw2GpazS9YPhyt4kiDXfz36Ed7ApomkJH2Om5pZGppzj62DWB2SYig5PNlhs80Q9baEeww8ddjJh3l6+QPirqe2bJEQXwpMsEdvXuYnAypLV2/2NKHMDf4RkrKo2tUeASmmQX/fSxSKCNg+vHrQxCo35z/Mf4ULnjbEBNgiiMTd/yR0bavXUITNfSIV8PXL48cPCFc1r5WQgreYTCLecQ9ZQZjmO1OI+Lh6pD1fpnQpCEy4Z6KmA305GKTGb+kCG6vLnZ4JB1O7wqV+54UmpQ7j4WGFXwFvkeqVS4sgyPmxz6SMluG2YPopZFMBvCPZlpjfcQOwi2A9512n03ge+GKQk906ULCIIJ0LfVbicYaNXVFJJawG9EX754CJ+4nppFQ1NV0hZGhjx1+QYJfae5B72PqcYIgxFFB+PYf1dcRdLRvUKagr1TAXT6JB8FuhjguxtwMYeFW8cVf8rf7v5K/kE64FT8v++Ii0/wEHda3vUJMuVjgV1i3u6RdBqVHWCm76fFjeDtgmy7cGcDalfZhnvwq1DGA+K5v50M8P+uM00NOLj1IhOeEshHLwLhlXTYX3Qh7425WdjUnElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3ytzHcR/wlWURH2KjOIDP4x7J5irI/CBbi7lRyNV5kM7hGNFgEUEtydJUuth5wMFJwHFluqVqcLjoHHlIWRUCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "4C148AA3689680CDEFAADAAEBC91B02E4143DB6000E71CE188627BE4C301E3BB",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:dgnLZmVE7NkYTDRsM9PAeN/IeeH7M7LN1COAjOXPcCY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:sJI+uqYOW+n5rHSVhSyMc6AekEnywZn1+rWPJZIngg8="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1679351631056,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAkenm5mGoq8z5n8LTU9ljKf9PZp8abVefydbnXh0j9O2A6oqpSc4XSL1iFnEhOuqK3cNTExHMToMmKnKGlRO8sJYs3lS+X4pg1vJ2mr2v2mCNbr82lgpnTAPqBNZnNlKCBMoBe6nU+uzmJK5Qeim8Du5hrAW8OKUYC/M3wBCGoFUNWV92brkIAVdutU8hm0xerF9j2yzrqYbsqzZLPYdTwE5prAwPjBoL7AwDhA0hl323k2z2x6Msud4nyUxWUz2OZj/nyXwuIfSOPCAF4N69AO4ig+1GqFcl5sVpXdSYs2n9tz53jwgHr21ZcEty68yM0/004KcI9eJGrFTOmzVuEIQGQ5aOkCDI9mS/WcCA6O/1VrgfGqMszFMd7XmGq0IvEPuxLrgFvRWnavj3lebmjlc0RctR0je7T5mM5koUzSMXCokP8UXSXn1Y2i0rgAGPoELBe5g72j4rL5BpxAQZvSqpgEPBvLhGKXP6a3n2IZV0SpQgdfNG2YVrKSdjd7nEI46cd5xnzpmDz5wCOlsp8cVQRuNNtGrGackIat9NOOywJZOzFxEZEa1KmyMvYePNPCPKv2+dNtdU2Lpv91k1O/nJjffwJ2ms2OVWXkeDdtQQ6lXTH9khTElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwR+07yKocWqynzgGRMHK5Zn6nuDDQp23tM1UsXravWMHB7ep3BnFnakamte5pQjBeBCqOxdlSFYsuXNIrVWcBDQ=="
+        }
+      ]
+    },
+    {
+      "version": 1,
+      "id": "8288e559-46a6-4007-b9e2-0d46eb610f3f",
+      "name": "accountB",
+      "spendingKey": "229d4c739598bcb72ecd70dca9f2db6a50f76e3733374c8b67a512f9a4dd526f",
+      "viewKey": "d619ad1b3b89a182d9d0163cdafefb601b863f3e59996bd9f315648cf834003947017caa88e351ca5bbe3df04aca3ab28cae5c4734d5a9f0b6258cacdc005294",
+      "incomingViewKey": "b4afd3a3b7a42f8c04cf40da0eb7f3eab2b558e3261a43908c974d3fd3983e04",
+      "outgoingViewKey": "bcf38698a3d551b2fa91b0e3a436601668c267e1bdf7024812531a5f403d110b",
+      "publicAddress": "2211e7a06b16f8b556a186264847396dee027c77049f9467c0b8fa1bf68cdca4",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:LV6VUCfNKoyQoJ69INcaAXRFVAl9uSBBkdWbuOy6HsM="
+        },
+        "sequence": 3
+      }
+    }
   ]
 }

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -5051,5 +5051,191 @@
         "sequence": 3
       }
     }
+  ],
+  "Accounts disconnectBlock should reset createdAt to the fork point on a fork": [
+    {
+      "version": 1,
+      "id": "6e712e95-46bd-4026-a178-896fe1dd57a5",
+      "name": "a1",
+      "spendingKey": "dc10b050f2c7d6de1e24cf35ec8d27524b731e5c80131b52312171734f599e9e",
+      "viewKey": "9043401e021c40c1feec966ae54345069d2b3ccd4fc8d34ea58f9413c5040c89ab23e0eeacd5fd82c79e2ac3895ffb8bfe3d8f174cd1340622cf7e5a13ac2a9a",
+      "incomingViewKey": "39285d75e9ed569ad75948188d552cb0284eacb0d4dcccc0b1d9509f16b83b02",
+      "outgoingViewKey": "69b6168fb8ca41f012ee9effcfda844c89bc8b7df327ca20e063ceef6e43972e",
+      "publicAddress": "8b8678f9337f9501a2299dc753fa5de4e8a1abd9d98c83274c2ac36842ce2603",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Bu0ujodyyXIKhuukE256+UM+M3tYtSjJX+qAQA5GYU4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:TIPxsQ3385RgEXfLgsMtBW5Mrq/muO5DEhNaS0U0X6A="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1679690507527,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAozMpuZlaaCooD5uu1S+JlHm+8BDkix2LRKophLPvUyWHuQMC3PB0tlOdVjdR0cVoqxH5kK0UjNtvOTSFSqyoBe5rQZhan+7Ow8zh1WGq2JOqit+nPeDqKdqqOcsIQ2wEWouh8u4937xhiQYNkzibWveVxXA85n5+uTO2nyCSV4IMm0pTJCIUlypMVZVcideFcOXF6LGyfW3GkOv6UlYFYYVuO9Hq422HJupgCzOTTn+pjw63EKix342VeYU6h5mzNvOXK9pjOEkOHAwOJglGX6RH08dQk5qIRllUObmwfney0WNFQm/OCx/62tIcNZd9OFKjZuL9zK8IT8tTpWroXeVdihxQ1E8jVw5iheUtqE7ysv96P3V8u6mN9dB9FT1b3fJUSFDHiRutGebURiWxN57+1U0mbEpFd6vX1aXFikbQzjnYRov89f/oXJt2IzakopJEtPZONK5aIHfFudYtEBSsf2rrS95NO+Ol/eFTD1ahhDyQ2kQoY3BIaq0TKVnWZcfxEzqTNMjyfU5IqeL0aYICFoOqyB8+EFDbCVlQS2W2VxjBciVJc0CkpKqRdDQ7tk9LC/6bokOiM0kFqT7Ql1WqzwrtqBzHai/Lws6ePjPx9i5X3V8nXElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwE+UX3k3AJs2BMCrwk9fbkObVwFbZ1lah9qi1aT8nnU2wrG0orm+GKJkSCUVlh/NG3Oca94rg/qSRZzIMXT/2Bw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "51E73A884A70F42B1E5EB91566BA5E763D4551763E1CCACFD39C8090D5BBED77",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:1msLCQe4un1T7i9H/ZDDbJqW2jcs7vZimhV8sBFmy1o="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:dNZU/HzJMSemA6pHhrF0m6MaaWeuGXV06L4ynfQ2k8Q="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1679690508030,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAjnMQikmK8EkmzaNiEhtK4+/9bvPWz+VrGWMinxwU+hKE/IodsvpR1xtb5ki3ANCaUhhBwkiRuQWQuLV6e2iZB4E3XMzrY9Qs+YCcDVe8Yx+FigoNUzIh3uQq1NhkgnMxFVf0M/9lfs4X/Ijqi+6qwLX8b5/Rv/Y/fgPldWGH+IMMMiEw3UQIbP8BL/pm8reLf36l6eLM2Z1PY8HLtDdfLQFjwMsTrUMq7bGdo/vniAGWNMi0uiYbwYob0ElDrxjC8PNoqIX2/9Jax+yNpjx3e6xqvuThr/C0DLFfdsFpj0DehGDFsefF/IcivMBu7ob0hXvQoh0S/ySbl8NXWudxtHSz8wyg9CgSDVMnL52tbTcTiruoRS4+7MKhLkunoANTUKBAsqTRiau+1h/muirfElBY9pqj+s9yt5jYdPFheGiQUlVOjI+2ck39MXV3XG80yEuLUiiGMS7DRI66Z5cShAsuxOot1CgGDBG2xGp+Q1vZA38hs2+J8VZPqDSxop/QKacgMAKbz122JvdAYkoVnApDGMENincyarXAuifjley06qExEvYVu+EfbFj4Gae3iiKRDiQ8phmdOgTU4iSZoDXWEWyZebwPK4hnJXoa53BUSK+9VpzxL0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwpcz6WqL0UPkCn0YfxH2Jo12xAEWccubqVTh9LK7F5BUXdGte2HGwynxoOULGdrW/eFmLqI3xTZz4rqOd3WtPCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "1C3CF8A7E8F2B211B58711D7BD1CA89DB1C582654F02454F08D32F71EB6025C3",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:r5AYjbgEjX7Bvc1Acy59MQ+f2rzCrRBjAKj2Dhmr30k="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:o1cgZvyVDl9iaGtDZMw04gmVOM4etoe1DIS0bl3ZPb8="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1679690508501,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgbBqPUqqqPg6La6M/bS/cdAII+um23Q2T3MGbYWAI+22fRjaaZ3SrYQLEVktv7vZ3zXItdIs3OP7N9gu2jwzDNvk2npUjDzCfpD6jNzu/ZK5wB0uRf4boI8HUtvRSYoXEkJHkzGtpP8x8so6zQPAR7dfoOMnahpallyXN556vDsPJ0hzqdJczjLhO59kxXXy0BlTkvPkeLcXXpH7kx3dDkM5+nnYlV1FMaUMUfr4XOSKjVwsXGZDtgSh7p+iOyiIu4pGKustg727nfz8prPZWpxSjX4BrdDmAom+Ag4r+dwNWDlP73f0FZj9jDcBX7MPE5eXil57L/F9gvnMAZWPO9tytBuGyLsi3qBQWQkal6T8wDDDi2g6dNyv+yK5X4U30348+OwLdhbfcMl8kwS9dNnlQqDuY3lHIj8AoS4lHUOM66fj/mhuSIqDYMmsDFrkcXhw2Hjm3t9bwLeVvCYZG/iwQFCHmfr9a2xgh21GNdM+ig5aGyTtnx6LKtTp1VhWHyC0nic0dACH5a0X2YAArdQoJkfwPnAuxjospRu5dkTUzv1fPRytIXY09jG2vUyzpJT31Neez2lEn/iPaKwhedARDWOClHCZTsEQzD+JJn1Wm5gO46kQtElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnUxqCyeAFd9Gw/61gxGa0rJnLGHnW5ZcgMnUPUNi+14TbTwf3ZWuaV4Do0PB9Nt2vBJMW57sWb52s1DPrEOOBg=="
+        }
+      ]
+    },
+    {
+      "version": 1,
+      "id": "e7a00388-ee20-4dff-8b2c-cee55d94df09",
+      "name": "a2",
+      "spendingKey": "55c646918efbb6227411d7f7ac85e026aa61a6343ac965ad75b8568f1b21bd62",
+      "viewKey": "6f25b498285d550f9291a2ef444bb9f3dca2d7ad4ec7b4f34df1cad477f56821b4639e1e052eb4aec9ed40d911ecb429f4390f3535056a5f28d63882a6770967",
+      "incomingViewKey": "fdcc3db1f426447066042cb6d5d5dbdac94dde532694f2b3267dee0e4d686c07",
+      "outgoingViewKey": "6f894666fc2d8f72dddffa50fea440ecfe72da19e85d0ea439889ae999413ca3",
+      "publicAddress": "fe77c26a1d00ac5b5ba56d3af31f36bd3e62a35cd3a07bbe26ab4d8a81b22e69",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:Jrx5VQzCMOGL4O/F5QkaLvDgTER/osyB02euuD9xIC8="
+        },
+        "sequence": 4
+      }
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "51E73A884A70F42B1E5EB91566BA5E763D4551763E1CCACFD39C8090D5BBED77",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:vpYsI2aJPB9LKMYviqqpa8FgWI03G+c0ntXFaBVqFnA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:E7t8lO9hxzmCPlEuc7jhbhTEsuWFpnMwb39suviSkQo="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1679690508958,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAhqAjsktXfV15pB0MrcEAtmUAnD2+CdOjhl1t0DL0eieo/V/n4ruQCMGuwu2dLgMuZrQ4xvMxHIMikOWB9QqQ7F8wYcp5I9vYx/zktPSbLNmV2BGwO3ci10JQtSbUWuZ25wK8/kF2PQ4bTpEixTWoS4GVJcPG5T0iTmIwME0CfdAHiacN7UeU8r3KB5fw8hNffQsVcOTKUzztuifXKP0G/IsO9WzNy+eKmTkpkKpvdluqZ0DXhRdtdRZ+eSgWYuTS3Zrj09ZoYQqgrVqzwJ4T+NZ18/Wd5KMyWM0yXuvuHPTeI9rAYREfxotsndP+HGz9iW/RfXeppF8DCBmGnFzobR6c5t8B5xLkj98JbJOt+Ud842cwibQX9GosGSKXbGBCQQ2JmptlujX8Q6e2+Ko+HqXUVTXfz/Ba8SrBHf2oXAxF/FXSoSkoFtEcVYJsrAg4WQu/QHqQyImokemdzCTIAmyzaO15K8YPZzQxgqZOIw8T4+BxKblACXqylIYeMjUYTGqggduaDT99dpyO8Wy/rEnRBM+C++I7f5CTKGmXxOzYJsj6KZYH/lYkL/BXSCfNhhT7a9sI+g+yi7qaVCKohjz6Br8+butQIlisMrH2KUhy3vvtdx6cnUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/kjzwFLbPer8hlo82Ze8Fa+IOvV7CdRWcOGug7xnDbVQkfp01sWvqw75mONNml9/P2WGsUeXouid4yveIlshAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "2EB71D120D46723D9BFC254F4D61B73DEF78696371F6BDEF3014D4557EA26AD3",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:N0say69MN0y1z8QPNJb9bhPROXl07p/KFiiuY8BlJWo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ndgqD2e8YG22l7MwRu6NaX2rXgg2PrF/xbncFa8X21g="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1679690509416,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAeU4UROM20A/cL6VIEyMSiPRAlt+ajy8aS4VgnemNXxyrr/HQ5oJxBPFa05pleSfbuYLuSpWLZyVrDJ139omtqmoZEZZ5rkrjhA+ogMpM1F2grgkLvbIC73Yam7fuONgUIEl3q0HebNqMHfY2EMLabpVqF02148b5HZRQpmPwUhoUSm6jzXe8GiikUrpo2ubyvy3PVASi14xtArtZgEPb6hOJacU7jH4v6LMbZdztvMyFVsvv0cnRQIR5eNYN6RqS8C74NN7eAoa6pFrJB0CH+m7aMMmoD53kdZ33m+ygWBSYUsC+cdyVaJe2regNDKkrdtFbcipUeNWispCJQxXsE/iMScQlok+ef0ma55c9Caa+YM3Zaj8h/Y0s/Hlenc9PCoxfT2WlkstMSmLliOX3cvQhiOV8Km1Q4PomNXEw3TeLreqeign4loQAVeIRAwJUKpW2Gn4yOU0mVUacCdjIt7zimz/iOirTA6lBHEm0+0A7KlzH0YC8GBgakPh6iDEf3a5U7NB7j8RxLotFt5aE+0pzHvsCk9BGMfFJEuQR0Dy01+SKW9XsJcnrOFFXPPk/suL7omnmnmyOqMzrX5ovpOXqdpTFjoXWCZg/cT1nud/edpcbBnZjxUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqeOhjEoUNr/4aN94AmiT7NUZAFZODF9f7Qq50si1qLof8LCktSRQ/gGD0XXXCOhljpRa9DMfXskYmK3kzOPPAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "61EA0C13F7AB44DC22F9480D426D5BB3BE854FF8144EF48C9F453C0E8D5095B9",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Kcd00QsnoFFa3ldgUlsyULttckcquBl7c4KTSdcyh2U="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:UO0IyVbEy49hMPA0E1TYI6mvvUTxK7Sz98lZhhfoHLI="
+        },
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
+        "randomness": "0",
+        "timestamp": 1679690509869,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAP2xq4q4T1u3e8a9pRNjDL4Yclt4bBt4mQbuE4A5BAWaztY6mmZ0dzKGpp7NANK6EjDMVYrZt8sOl+8x06pVt9ODlbDvGl3mnhkatm8q75j2ApcVfk2ciGFPPVuJCvDCp1ekwV+0OknpHSPWrOpFTdCR5V+1SCKRR5waqkSGW8XwYymzVP3vBqKR8OYrLH4ZVJKBehp1UZj6BtpIZko+nkNM8HC0tCCW5cLB1sdpS+pG1AuoI55VWhVNCT/OGx01p0LQuywhlU+XhqpYy1st+H0L69SVXDA0+luXIJVpZJIL3xZgJxfHQwMmWv2+3zbLmPxQoVuVdwDDlbPcv6ZlK8pJ5o7ng0wv5hzCo+SS56aAOQdGC3FtcOnym2rQuhN4mEnYC3ttjrFsqTpj+142J1ZtuQt4f5r1nk1Rsp2qTIJPIroFFJ1JcP8Er4m/BN+52i53gbywLhcxcoFnY8HaqAY5gWxqgmigJ3WYdJUFc12mTyxTe6/AeBtsP1vZtyKyA2aIjb2sEQvhKMs1w+mB40c7Uehu/AfRXeXizT1mYll+/o4UdccAd7CUwGC9ozSkStjCpL9phcw0/Nt817JhaTHOtx5NkHz7NV7PPNrPyL8S15meiWdSbL0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw11woLx9u3MdIOzg15sWbonjQloVuwTHsT/vmcuCYoK0oQ10nb+O8Mzn9SXMUdjZ7B8kkCC1RH88sfxxDQUV3DA=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -36,7 +36,7 @@ export class Account {
   readonly outgoingViewKey: string
   readonly version: number
   publicAddress: string
-  readonly createdAt: HeadValue | null
+  createdAt: HeadValue | null
   readonly prefix: Buffer
   readonly prefixRange: DatabaseKeyRange
 
@@ -1112,6 +1112,12 @@ export class Account {
 
   async updateHead(head: HeadValue | null, tx?: IDatabaseTransaction): Promise<void> {
     await this.walletDb.saveHead(this, head, tx)
+  }
+
+  async updateCreatedAt(createdAt: HeadValue | null, tx?: IDatabaseTransaction): Promise<void> {
+    this.createdAt = createdAt
+
+    await this.walletDb.setAccount(this, tx)
   }
 
   async getTransactionNotes(

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -498,6 +498,13 @@ export class Wallet {
           { hash: header.previousBlockHash, sequence: header.sequence - 1 },
           tx,
         )
+
+        if (account.createdAt?.hash.equals(header.hash)) {
+          await account.updateCreatedAt(
+            { hash: header.previousBlockHash, sequence: header.sequence - 1 },
+            tx,
+          )
+        }
       })
     }
   }


### PR DESCRIPTION
## Summary

when using block-based account birthdays we need to ensure that the account birthday always refers to a block in the main chain.

on a block disconnect checks whether the account's createdAt field refers to the disconnected block. if it does, updates the account's createdAt field to the previous block. this ensures that createdAt refers to a block in the main chain at the end of a re-org.

- defines updateAccount to update the account stored in the walletDb and in the wallet's in-memory cache
- adds conditional update at the end of disconnectBlock

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
