### PR TITLE
Call forceCleanupDeletedAccounts at end of wallet:prune

### DIFF
--- a/ironfish-cli/src/commands/wallet/prune.ts
+++ b/ironfish-cli/src/commands/wallet/prune.ts
@@ -71,6 +71,10 @@ export default class PruneCommand extends IronfishCommand {
       CliUx.ux.action.stop()
     }
 
+    CliUx.ux.action.start(`Cleaning up deleted accounts`)
+    await node.wallet.forceCleanupDeletedAccounts()
+    CliUx.ux.action.stop()
+
     await node.closeDB()
   }
 }

--- a/ironfish-cli/src/commands/wallet/prune.ts
+++ b/ironfish-cli/src/commands/wallet/prune.ts
@@ -65,15 +65,15 @@ export default class PruneCommand extends IronfishCommand {
       }
     }
 
+    CliUx.ux.action.start(`Cleaning up deleted accounts`)
+    await node.wallet.forceCleanupDeletedAccounts()
+    CliUx.ux.action.stop()
+
     if (flags.compact) {
       CliUx.ux.action.start(`Compacting wallet database`)
       await node.wallet.walletDb.db.compact()
       CliUx.ux.action.stop()
     }
-
-    CliUx.ux.action.start(`Cleaning up deleted accounts`)
-    await node.wallet.forceCleanupDeletedAccounts()
-    CliUx.ux.action.stop()
 
     await node.closeDB()
   }


### PR DESCRIPTION
## Summary
> `wallet:prune` is a command to reduce the side of the wallet database by removing old data from the wallet and compacting the wallet database. We currently remove expired transactions and compact the database, but we don't clean up deleted accounts, so we should call forceCleanupDeletedAccounts as well.

## Testing Plan
Ran `wallet:prune` without incident.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
[X] No
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
