### PR TITLE
enforces enums in wallet transaction rpc schemas

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -4,6 +4,7 @@
 import * as yup from 'yup'
 import { Note } from '../../../primitives/note'
 import { CurrencyUtils } from '../../../utils'
+import { TransactionStatus, TransactionType } from '../../../wallet'
 import { ApiNamespace, router } from '../router'
 import {
   getAssetBalanceDeltas,
@@ -22,8 +23,8 @@ export type GetAccountTransactionResponse = {
   account: string
   transaction: {
     hash: string
-    status: string
-    type: string
+    status: TransactionStatus
+    type: TransactionType
     fee: string
     blockHash?: string
     blockSequence?: number
@@ -53,8 +54,8 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
       transaction: yup
         .object({
           hash: yup.string().required(),
-          status: yup.string().defined(),
-          type: yup.string().defined(),
+          status: yup.string().oneOf(Object.values(TransactionStatus)).defined(),
+          type: yup.string().oneOf(Object.values(TransactionType)).defined(),
           fee: yup.string().defined(),
           blockHash: yup.string().optional(),
           blockSequence: yup.number().optional(),

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { IronfishNode } from '../../../node'
+import { TransactionStatus, TransactionType } from '../../../wallet'
 import { Account } from '../../../wallet/account'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { RpcRequest } from '../../request'
@@ -19,8 +20,8 @@ export type GetAccountTransactionsRequest = {
 }
 
 export type GetAccountTransactionsResponse = {
-  status: string
-  type: string
+  status: TransactionStatus
+  type: TransactionType
   hash: string
   fee: string
   notesCount: number
@@ -46,8 +47,8 @@ export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTra
 export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTransactionsResponse> =
   yup
     .object({
-      status: yup.string().defined(),
-      type: yup.string().defined(),
+      status: yup.string().oneOf(Object.values(TransactionStatus)).defined(),
+      type: yup.string().oneOf(Object.values(TransactionType)).defined(),
       hash: yup.string().defined(),
       fee: yup.string().defined(),
       notesCount: yup.number().defined(),


### PR DESCRIPTION
## Summary

the getAccountTransaction and getAccountTransactions RPC endpoints return a transaction status and a transaction type with each transaction in a response. each of these fields has a set of valid values that we define with an enum.

the response schemas, however, only specify that 'status' and 'type' are strings.

updates the response schemas to enforce that transaction status is one of the TransactionStatus enum values and that transaction type is one of the TransactionType enum values.

Proposed on Discord: https://discord.com/channels/771503434028941353/831945060777852998/1088097724907409468

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
