### PR TITLE
removes account hasSpend method

### DIFF
--- a/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/account.test.ts.fixture
@@ -3721,5 +3721,59 @@
         }
       ]
     }
+  ],
+  "Accounts addPendingTransaction should only save transactions to accounts involved in the transaction": [
+    {
+      "version": 1,
+      "id": "b532d80b-e581-4a61-bb3a-531fd590ca2c",
+      "name": "a",
+      "spendingKey": "15bcd47611f48cc2449626304d9a06207bbb6deec1921418002a59e3ac8d53c2",
+      "viewKey": "91f2958e4337a1d12b678f56d4a2199048d5d84b325ca5f3b1dbd3c4abf5f640e0acb979830c314c781f211ca6f68c8c77000ba7e4fa7cdf2299cbd96ccac21b",
+      "incomingViewKey": "f1d9fe8822480109f6bcbb29d595d6f3dba7e396a6a09632573310d88dcb7f06",
+      "outgoingViewKey": "93a1c3e4865629efc480d8728fef97532fdcaab6ea41249238bac11ff488a049",
+      "publicAddress": "6b46e8def47e285e9d70df20cd52a816894218b2385cd40d99b1588c3d011c97",
+      "createdAt": "2023-03-22T18:45:17.951Z"
+    },
+    {
+      "version": 1,
+      "id": "dc785412-7637-456d-b191-db3e9ee2ec41",
+      "name": "b",
+      "spendingKey": "08f7d74adeedda62bc1cbf74bd1a91d4838143eb6e273ac4dec0e55fcdb0df11",
+      "viewKey": "912039eead30827067ff2c54840f440317cc982bd8ef538b6fdd473fe46995cdc5fb40e60250f8e8585ff5b7ae5a5eb0032bd76b661c09ce7fa9b822f2914470",
+      "incomingViewKey": "843322669aecc1e9850e873e703fb5786e101d10d3e02c482ee0a746a3aa0405",
+      "outgoingViewKey": "7614a34227df4536d7f5168e8aad09cbdb76054f690e030c6acd8c7506caabd8",
+      "publicAddress": "f8c36799849623cea55c6eb362aaa1c91b61ab9688a996c5ac61a68e5f2946ec",
+      "createdAt": "2023-03-22T18:45:17.962Z"
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:4ocGrsLmvh/+H7GyxtsHLom9hcxhjifMKHmPaNw1XmA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:gzH5qQblDGE8ivqOwYIddddRRkhP+RoqSVKAVmnjPhI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1679510719091,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAkyOEkI2Wwdlfs2s8+d1H2U+9MGQMH5wpj/lEQtYEV3OvTQzaEuRnYe4OoekTupST7eJWytdWFw4W4QBEZSJkk9UNKHwNKn97iR0lKZuUGfuLRiH13iGSTfb72zM6OtOxIpdp8QVXZ65kFbbiFkWtwkVIGm/Vd8Aq/Yf4s/ZE2hoILMwagFJ849SV7bXSs0JBhaZ3CyWBZZ5aDovpkbNZuwNwjwUjip9MtA3ja+Xan9WZ8mBfS+iAFEp8GXa+l0YxVUKaNqSM9Sh3kSftk6cSf3FVYhDbQtWPsfYK4ON6DV+7PP7zILB1PU0MalHip8MN3yLhW9E1jCMKkE4bB8eACihQ2uel4tSKkr5fscQaSOb5qxcwnGPUmXuyyd8BhRcMf+NZpo6rqX3EVogqATNVCY+F+VoFLTsbf7OARk5Y5ruGWBnx3AyxmD6bqPzauSCZLkkbHC7T1mR0a3+guFPvC221CHOHlCGZzqm3cPJzo68PtM2okWrtkq0WrgCbSjsmUPICsHAV64H0nr8C2VAEHkkT18/dsb1My5A7JANyLhHFAvaclzk75WZbN79wostsy8rUCwN2tNKncN1vgaf8D4+SHEqVWFhsBuFaWk8tueZOl2YqKRNahUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcQAdU15jx2fo+n2Jqr5rwuLqM623/FKQ3qdPFfXLjzh6+4bgDC9bv3H3SA3v6rZQIm3MV2twpuigfYijGFUqAQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWKJERrP4mGh/y3Z0iMksm/2EcX3o90QQ5kgNL7CH5Z6Db1IwFCuv6PjP5CtNr33BTPOBXzye4lJpPf1sJw9EtHA0K3Qt2M9j4wx5Jw9tIoCkz+TA9RGwL/o12Mf0hD8U0loAd2gDsXO+/H9y4WYaZDTPNpPzqRWsyv/sdSQ/hGIVLR87whsiv9VI+jMAoqw8kCj1JUQ2gTy9/AUcnKGOlG3vHvkKSvbaZVlZ6vAQEZaiAuerLKMvVesT2QUuST0kP4h0YBXxNL5P0unhoTcgj6UCCGimYtbM2bPUvrNyR6At4v8LYzovURAzJXgPGf8jYR954V7Z5+haC68Ev4ja3+KHBq7C5r4f/h+xssbbBy6JvYXMYY4nzCh5j2jcNV5gBAAAAJFHnIoV0LlBbBNS/NQNuPUxJzqiJNP486ylVKp2xUI9JMZ8gRR5a1rAG0USHWdfoixhNQCFnYMv44cgD9ookAJfZ9NfhQ8L5ofDlKt1hSD5nLd6s307LkeButN4Iu49AYE6y7heTfgf1XldIxERSxR2pZziWKBJ99eoAgjOcKZXVk2TAjo31NjeWdJW5x4mpIHRjX799IrnZGutbHo/TxMPlVAcqX8CHyVYouQ+mnrbkWS+bM3ndin71jWWjCkGBAt2t97k1TYamSCzbGaai85sTjmyd/rvOmSHNIL18rfVrajfL4/bF/Leq42zWSFJAJGDBIyDgppjhXyd/Xh1s9w/woO5kZisqhc/XY8V7EvqMdW8R/PizW9CnE73CszUYi9TMyJPnJ7ZoZiyUnm/SKGcOSA6GAiYTssS8g6Tcmo2RdSxNHggdJ9AjpyRyqfXXY6q4oDjmabtSPPSeE/9yVc6/KkliNMqmH+4t4obwtWeRXIQvPtqTMh4bm42q5DcwnqcZyoOQET/n9KvKIDA0rql3wtc7cU0PJqP3MepkweGhyYBai5rqC/M6NhzU1wtwjb6cyvB/kTCWGWmAKq664gqaZ34DOXFMZVljrK7gQViPdWEVeVh91Myw1lu9BUzAn3QSNpdKGXGAFVGGNiRdzdICP0yzOnB35OKasJs/rNBTXZvGQFLB69xxVhB93ECeoJO1oA8V7jVkhyMfubW0odXUM1SIuC8/gTh8DmznNb9EuBzPguQRFb2OmXfmoiebRdgana/ApSTbSvVHtmD8G6v+JZQzZQg9JUdOhf3eu77nKjql7/oMzKYvuqDWIFvkCf3hzlowCwNGqjkokX5BwCOwYeFHRMZSEN7Kg/G+MzZ/7gug9Ktoj+BnE68MMH9pkoC7w06JsqO5ToDPrazLZgBFsqLW9+UKLSVT/jeAjOUM0ZeUez6swoBQkxIpyJQ8n4fODnVa5dM8dXnJ264HJKYKheAYud3I3zv2j1gnVXofnxz0JFdTXS320QULKVBsEJe9USEDwAz8Cs/yG3xqeyBOQ5OaG5qIct25W3HDFtg5NqukBqdyeNzfXxzwQApT4A5LWyzbS5HakomUjdUFf/55dOqR4nzSmP3QCZ5leEwpOq4qLzOh+QcoHLA8DlqSnoLyFMjuJE9DN5MlFC2/NYnnCrEzun6QJC6QX6pGmbu7tJbUps7CYKTg835JRJUM13xcAqkfMev8SY7C6+4UpzMxSo9gKuZB8yxCYkrxGOO39+DKh8L9rjEHsr70+BUqvU65u0voKGc1f+bo0zfj4ZcFsYRdn4kMmAOKc0Wm/MNrcUP/hIOiMmNPxLKY8mvCHj42thk36Fsj2HZ37gIJ3Z2kqzxzAayLz7LgFzpqKIa+uqGW99Y/g1wPXdAxn5xKN582/k0wJLSlT7wGhfpxnbNDO5SQh2OMv5yCL3gyRoDwKtEHNCbgWMmdcyMeckkjrPRZfkqKg0PPgiNaojQdEbsMrwGOMA76qbNb8Oum40TuuNcsTn2G3qiur0vQYve2C+9/kzjaoqhrG6CTC8CI9l3baoHX19fdw6MnDKeEnv8Lr703RuwGAwDiLpxFYXKAA=="
+    }
   ]
 }

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -2566,60 +2566,6 @@
       ]
     }
   ],
-  "Accounts addPendingTransaction should add transactions to accounts involved in the transaction": [
-    {
-      "version": 1,
-      "id": "5cc59edf-b7a9-4c21-924d-26f25139435e",
-      "name": "a",
-      "spendingKey": "9d84f9febc7f51390657d359a21c44dff1c8cdb98a98e0db7db66e2db599bfe0",
-      "viewKey": "c42e05bf3a17642ca3aa3b73ff61e5f581b156ab8c516e11920738195a0c03115108848d9b86f468b619a88b70d8c2079c9f9d96c09e3a1c246840c619dd29b7",
-      "incomingViewKey": "c9af9ff44069d3836ad16232c29e3239dac052b6a15c60a641d7839ccebcb303",
-      "outgoingViewKey": "eb803b1de8d43b75f76a9f70a7bd3a4c479954b2bd006aee444b8604bde00774",
-      "publicAddress": "6f045687d7970c450f1e300c3c1aacc805a0b7209bb0cec2521f341f4188df38",
-      "createdAt": "2023-03-12T18:18:50.345Z"
-    },
-    {
-      "version": 1,
-      "id": "6e9d60d0-4e2e-458b-ae4e-7927497dde26",
-      "name": "b",
-      "spendingKey": "47260f9fe78449144156c8cdcd453ae2a0958bf594bf61018e46884ba3e30e48",
-      "viewKey": "1b866ea28dc2866665e5b6895b448208e3a18ef52243db78ca0c59353196b4e44d04d7cca82b6378348050e42fd84b3a6885c73c84ec0e6c94c362ead7c2cc2f",
-      "incomingViewKey": "62d17f60ec581ec32837ee65fa136a4f18b34e5bf727cf826dbc4879c4666507",
-      "outgoingViewKey": "472b2a7778566e962790c16571f825e377d0029d71cb55aef259a00c82db35df",
-      "publicAddress": "87c757a6c79731497a5eb2e4b645bd26d8ef8cf13b3172373f162973d829585b",
-      "createdAt": "2023-03-12T18:18:50.354Z"
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:2aRQUtlbSi7zeXBvWm4RE1Tnz5SoEHKssRV9c+TuzkQ="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:yEH/NKoF1PohKWGfr8HK1oXs7/VCYcHK+dx2tvqYZss="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1678645131337,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAR/GHHSOhrdqZGxIJvYxF6bAkEoEq4uonj+wtixfqupmjGfGi+gcJThiFwbBO+3W7ffjFVtE1xWIM0vmWidbDATzuiUA54RhVX0bi6OL4EUuMCthHMm+YGSBtWTlif53OslAWA/XWNd3sOBUEyzQG3BE1d4fqvVbvNP4/dwn/1OcJTsuT3eEBRtFrUZ5zhqLDmSMqWeZVEbidTcK0rdtJeFfurGfV10KBnwA/a/gXVTOZamX+YR17aJFoj0trFnIZa1umKKbZWDUwd2vvhfpIYpuhS89yqH7gKixgK+4Xt2ssV1t+hoQeYPqkuje5vOauXMO2IEsn2mcvd57vRTo3zngBMXYXAqH8r1COSSQNNVVcWz/rfPV6Mzcr2midDGJEko4ICW35/mFrVGUIbxUCrJxtJrJDTNWiTGbQv5t+BJWeMh559v0yruAjm22BSLF/B4CuZPdGt/IbvRRsdI6/PqJzLC0bgVIdo4NGP1cIOguCiRMfx5P17teWKI3Lme0lQ5C4pD1C/LjjKa+7KJvbfz735jj9Qg05R08dc4yMb99wEawl6huc8qFw6/OWgAI/QCaeejpC/nMOQy3HQi/D0SlWPxqMtHVFNyPU4Mspf5D+sFHSHGG0oUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwD0zy9bYoAO0e9epiHLv5wHJdrPMPO5pqkxyb3/YO2VPj2JFPx+Y0KxixDDoJ4WeNwYKL9YrqQKYKlRyrp2ssDA=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAvFl9TYSU0psFHNvOjc4dsbmpyFoweHpqa3LmxN9x4BaSfyygIKBL8v2GEUcOWv+g/BbdyS0mYl4EBOSbgNbsoTDQbnQDOKehVyzh3GcAfKKVbX0/h888fqFEeTGCe+4atGu4Iq6MAMFnYVLLk+4Akdh1aNA6Kw4Y/Mf3828udvMZqZWETl2jmM5oXZ+XDDtQ/vbWBB9y4JKhJ5nSVUv79oVLAmBJ9tlbAVFPqBNvxf6CTEJgoSGMQ1QO2//8exuxYmY6LZOT1PDdjE8pYDuU40nE0gav30AT+T/Hw/OtLaCLRRwp/ynbIskuRdGgjHLz5Fc/o4PiJagALselFSEzvdmkUFLZW0ou83lwb1puERNU58+UqBByrLEVfXPk7s5EBAAAAE2BY6UaVH3gMOBZqAlp44Eahuc2/DBRrBQbRqUisZhxKtU0GWhPLBfEroMPsSt7wlFdmkxF31jcWrvSKE4ORootKpQrdjgMf1St7jN4YS523QJA3jETpUQKbF3bopEdCZalvc8wt4RxefqL7m/TDMITseWejOQ+fIYRTFobMDNUGkbKZf4bf5fUgiGvN42SdaasyN71GcBX+snb6Lez89N/bnq8tmaMgUKugJsVwlF/T/kSgc2gHfjqLGSP0WKvkA+hG4XcpjLOUZPXtDwYg7hbP/P8OSm4GpegQbpi65tVIa9if+wui84hHUfU+IoNz6Wx+lIZ+aaIzyrnIUSNnH4sD/kAZDo4O/yb20X8c6Pqjq/kfdmboN5qkJeGFpRmzAVKyQVi1edk0rCi2msaFnYNzGm8GCltzyg2V/AHOxC7+Ba047a7fJNESIsyOGy8vNpEV8rMCwRrbMBhCm7CYAV7AZZV8zT3ISjbkxdYt3PempR18J9N/gjKmKtNjUiHp1rJ7JYpnWZGu66Uw2dmvDIs+/onR95zyv4/+FNk6kWxBqrzFl8WexX+8hY8LspIsiILVrw/mQo/tPzAHpgbrhGzibREzAUSn73PKeHg38t+DBlvvNFWC7uEl0qFPrOgPQnIUG/6HHpQJmqFaFfER7BOUaCf9SCR/SPRdueJ51YSQDibZKees14svBSke7ovcxGZ+ASYCpCzD8J3Da9Lg6sS8SwDOkiMafeGObYGGDa4jgc23ANMuMbJ76/bADSyUKkxziXXp7FgY5GT4qGe/guEMJfxTpElJU0Mhy8IEpd+Smq3Qg6ySRq41RcltJl+/PIsQCjgJB7TPVbp46TdJnrhScFVHCgurFtKze+V+ivQ5BZwyXY8KOKw6im02sdlSWHZBcGYRcVglfwRJ+cPPQUQGMGUDWruZtO1rTOyPGq0KtbNzFj8O+MJVeM1mJKmWZQdB2Cdat2lO0JCDh4pHtyPOMWl5ZtSvnXzGVBiQ5zu0ddHzACireSUekfDkSsAfwKYhQHr6k9qlRkrcsd1DT8lXGiXXqUWAl+I93tHyj2TdbsUrlq9fbd+uRy28Q2L1uVQTqW61nUMoFe7lc+bhKDw6nJQ/jEw6gpOajSCsMVV15GJyyoRwJbsM/qNX9Z2ZpKz7AYR9Ngz+udMttNIAvTOV54gvEQdIPRCbgfzBfWL4OuEmv0yx8s2Cp/Yzt6synh/9yYmyGmWsNMnFLxWF7OpIDiBTmeJbjLyetQU3uZ1tcYOuzNrRgRsG2HFUQPn5WS26Zo6LSLdzCePXY4wzYh6gf01dvSz/dz9CFjQkfbv8B7ejfw3TEGKvVOWQ95fZ6clZ9pBQQODxPKPkgIpWyM/imybQRQ2EeRqszmyeCO+WnX08r2rl4HEdhyzLJKstE82j15DeKwK/JNWNwABy37gf9Yp11h+DB4LcCksLHIaQ3EuP32DqxHDggpe42M4NW/qsh0Y9UkAw9UcW7PusLt/J3WMBVi5tBDUIGQtraAa/c4dPxSaWSHBwBGR5Fp75cdJBAUeAAhpcGSuq8RuJjLEa7r/OugbdMaJS4umqjvn6uzf0vElebTaAcX5mfKaBA=="
-    }
-  ],
   "Accounts addPendingTransaction should not decrypt notes for accounts that have already seen the transaction": [
     {
       "version": 1,

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -193,6 +193,11 @@ export class Account {
         await this.walletDb.deleteUnspentNoteHash(this, spentNoteHash, spentNote, tx)
       }
 
+      // account did not receive or spend
+      if (assetBalanceDeltas.size === 0) {
+        return
+      }
+
       transactionValue = {
         transaction,
         blockHash,
@@ -507,6 +512,11 @@ export class Account {
         await this.walletDb.deleteUnspentNoteHash(this, spentNoteHash, spentNote, tx)
       }
 
+      // account did not receive or spend
+      if (assetBalanceDeltas.size === 0) {
+        return
+      }
+
       const transactionValue = {
         transaction,
         blockHash: null,
@@ -666,16 +676,6 @@ export class Account {
 
   async hasPendingTransaction(hash: Buffer, tx?: IDatabaseTransaction): Promise<boolean> {
     return this.walletDb.hasPendingTransaction(this, hash, tx)
-  }
-
-  async hasSpend(transaction: Transaction, tx?: IDatabaseTransaction): Promise<boolean> {
-    for (const spend of transaction.spends) {
-      if ((await this.getNoteHash(spend.nullifier, tx)) !== undefined) {
-        return true
-      }
-    }
-
-    return false
   }
 
   getTransactions(tx?: IDatabaseTransaction): AsyncGenerator<Readonly<TransactionValue>> {

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -1343,28 +1343,6 @@ describe('Accounts', () => {
   })
 
   describe('addPendingTransaction', () => {
-    it('should add transactions to accounts involved in the transaction', async () => {
-      const { node } = await nodeTest.createSetup()
-
-      const accountA = await useAccountFixture(node.wallet, 'a')
-      const accountB = await useAccountFixture(node.wallet, 'b')
-
-      const blockA1 = await useMinerBlockFixture(node.chain, undefined, accountA, node.wallet)
-      await expect(node.chain).toAddBlock(blockA1)
-      await node.wallet.updateHead()
-
-      const addSpyA = jest.spyOn(accountA, 'addPendingTransaction')
-      const addSpyB = jest.spyOn(accountB, 'addPendingTransaction')
-
-      await useTxFixture(node.wallet, accountA, accountA)
-
-      // tx added to accountA
-      expect(addSpyA).toHaveBeenCalledTimes(1)
-
-      // tx not added to accountB
-      expect(addSpyB).toHaveBeenCalledTimes(0)
-    })
-
     it('should not decrypt notes for accounts that have already seen the transaction', async () => {
       const { node } = await nodeTest.createSetup()
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -410,10 +410,6 @@ export class Wallet {
 
           const decryptedNotes = decryptedNotesByAccountId.get(account.id) ?? []
 
-          if (decryptedNotes.length === 0 && !(await account.hasSpend(transaction))) {
-            continue
-          }
-
           const transactionDeltas = await account.connectTransaction(
             blockHeader,
             transaction,
@@ -527,10 +523,6 @@ export class Wallet {
 
     for (const account of accounts) {
       const decryptedNotes = decryptedNotesByAccountId.get(account.id) ?? []
-
-      if (decryptedNotes.length === 0 && !(await account.hasSpend(transaction))) {
-        continue
-      }
 
       await account.addPendingTransaction(transaction, decryptedNotes, this.chain.head.sequence)
       await this.upsertAssetsFromDecryptedNotes(account, decryptedNotes)


### PR DESCRIPTION
## Summary

when adding a transaction to the wallet we use 'hasSpend' to iterate over all spends in the transaction to see whether the account spent any notes in the transaction before using 'addPendingTransaction' or 'connectTransaction'.

however, both of those methods _also_ iterate over all spends in the transaction. this can result in unnecessary, duplicative iteration over spends.

there is another drawback to the way we currently use 'hasSpend': the account 'addPendingTransaction' and 'connectTransaction' methods depend on the caller not to call them with any account and transaction where the account was not involved in the transaction. this is a bug waiting to happen.

- removes 'hasSpend' method
- does not check 'hasSpend' at wallet level before adding transaction to account
- updates account 'addPendingTransaction' and 'connectTransaction' methods to return early if the account did not receive or spend any notes in the transaction

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
