### PR TITLE
feat(cli): use config networkId instead of default

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -59,7 +59,7 @@ export default class Reset extends IronfishCommand {
       fsAsync.rm(hostFilePath, { recursive: true, force: true }),
     ])
 
-    this.sdk.internal.set('networkId', this.sdk.config.defaults.networkId)
+    this.sdk.internal.set('networkId', this.sdk.config.get('networkId'))
     this.sdk.internal.set('isFirstRun', true)
     await this.sdk.internal.save()
 


### PR DESCRIPTION
## Summary

Currently, there's no way to change networks with an existing datadir that I'm aware of. This at least allows us to do the following:
`ironfish config:set networkId 1`
`ironfish reset`

I think we'll need to re-visit this more in-depth.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
