### PR TITLE
WIP: Add ability to fund transaction externally

### DIFF
--- a/ironfish/src/wallet/walletdb/decryptedNoteValue.ts
+++ b/ironfish/src/wallet/walletdb/decryptedNoteValue.ts
@@ -18,6 +18,8 @@ export interface DecryptedNoteValue {
   sequence: number | null
 }
 
+export type DecryptedNoteValueAndHash = DecryptedNoteValue & { hash: Buffer }
+
 export class DecryptedNoteValueEncoding implements IDatabaseEncoding<DecryptedNoteValue> {
   serialize(value: DecryptedNoteValue): Buffer {
     const { accountId, nullifier, index, note, spent, transactionHash, blockHash, sequence } =


### PR DESCRIPTION
## Summary

This adds the ability to pass the notes you want to use to fund a transaction into wallet.createTransaction()

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
