### PR TITLE
feat(rust,zkp): Move asset id check from circuit to consensus

### DIFF
--- a/ironfish-rust/src/assets/asset.rs
+++ b/ironfish-rust/src/assets/asset.rs
@@ -19,7 +19,7 @@ pub const ID_LENGTH: usize = ASSET_ID_LENGTH;
 
 /// Describes all the fields necessary for creating and transacting with an
 /// asset on the Iron Fish network
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Asset {
     /// Name of the asset
     pub(crate) name: [u8; NAME_LENGTH],
@@ -57,7 +57,7 @@ impl Asset {
         }
     }
 
-    fn new_with_nonce(
+    pub fn new_with_nonce(
         owner: PublicAddress,
         name: [u8; NAME_LENGTH],
         metadata: [u8; METADATA_LENGTH],

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -4,7 +4,7 @@
 
 use std::io;
 
-use bellman::{gadgets::multipack, groth16};
+use bellman::groth16;
 use bls12_381::{Bls12, Scalar};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use group::{Curve, GroupEncoding};
@@ -13,6 +13,7 @@ use ironfish_zkp::{
     proofs::MintAsset,
     redjubjub::{self, Signature},
 };
+use jubjub::ExtendedPoint;
 use rand::thread_rng;
 
 use crate::{assets::asset::Asset, errors::IronfishError, sapling_bls12::SAPLING, SaplingKey};
@@ -41,9 +42,6 @@ impl MintBuilder {
         randomized_public_key: &redjubjub::PublicKey,
     ) -> Result<UnsignedMintDescription, IronfishError> {
         let circuit = MintAsset {
-            name: self.asset.name,
-            metadata: self.asset.metadata,
-            nonce: self.asset.nonce,
             proof_generation_key: Some(spender_key.sapling_proof_generation_key()),
             public_key_randomness: Some(*public_key_randomness),
         };
@@ -61,6 +59,7 @@ impl MintBuilder {
             value: self.value,
             authorizing_signature: blank_signature,
         };
+        mint_description.partial_verify()?;
 
         verify_mint_proof(
             &mint_description.proof,
@@ -172,12 +171,37 @@ impl MintDescription {
         public_inputs[0] = randomized_public_key_point.get_u();
         public_inputs[1] = randomized_public_key_point.get_v();
 
-        let asset_id_bits = multipack::bytes_to_bits_le(self.asset.id().as_bytes());
-        let asset_id_inputs = multipack::compute_multipacking(&asset_id_bits);
-        public_inputs[2] = asset_id_inputs[0];
-        public_inputs[3] = asset_id_inputs[1];
+        let owner_public_address_point =
+            ExtendedPoint::from(self.asset.owner.transmission_key).to_affine();
+        public_inputs[2] = owner_public_address_point.get_u();
+        public_inputs[3] = owner_public_address_point.get_v();
 
         public_inputs
+    }
+
+    /// A function to encapsulate any verification besides the proof itself.
+    /// This allows us to abstract away the details and make it easier to work
+    /// with. Note that this does not verify the proof, that happens in the
+    /// [`MintBuilder`] build function as the prover, and in
+    /// [`super::batch_verify_transactions`] as the verifier.
+    pub fn partial_verify(&self) -> Result<(), IronfishError> {
+        self.verify_valid_asset()?;
+
+        Ok(())
+    }
+
+    fn verify_valid_asset(&self) -> Result<(), IronfishError> {
+        let asset = Asset::new_with_nonce(
+            self.asset.owner,
+            self.asset.name,
+            self.asset.metadata,
+            self.asset.nonce,
+        )?;
+        if asset.id != self.asset.id {
+            return Err(IronfishError::InvalidAssetIdentifier);
+        }
+
+        Ok(())
     }
 
     /// Write the signature of this proof to the provided writer.
@@ -358,5 +382,36 @@ mod test {
             .write(&mut reserialized_description)
             .expect("should be able to serialize proof again");
         assert_eq!(serialized_description, reserialized_description);
+    }
+
+    #[test]
+    fn test_mint_invalid_id() {
+        let key = SaplingKey::generate_key();
+        let owner = key.public_address();
+        let name = "name";
+        let metadata = "{ 'token_identifier': '0x123' }";
+
+        let asset = Asset::new(owner, name, metadata).unwrap();
+        let fake_asset = Asset::new(owner, name, "").unwrap();
+
+        let value = 5;
+
+        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
+            .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
+
+        let mint = MintBuilder::new(
+            Asset {
+                id: fake_asset.id,
+                metadata: asset.metadata,
+                name: asset.name,
+                nonce: asset.nonce,
+                owner: asset.owner,
+            },
+            value,
+        );
+
+        let unsigned_mint = mint.build(&key, &public_key_randomness, &randomized_public_key);
+        assert!(unsigned_mint.is_err());
     }
 }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -817,6 +817,8 @@ pub fn batch_verify_transactions<'a>(
         }
 
         for mint in transaction.mints.iter() {
+            mint.partial_verify()?;
+
             let public_inputs = mint.public_inputs(transaction.randomized_public_key());
             mint_verifier.queue((&mint.proof, &public_inputs[..]));
 

--- a/ironfish-zkp/src/bin/generate_params.rs
+++ b/ironfish-zkp/src/bin/generate_params.rs
@@ -80,9 +80,6 @@ fn main() {
         generate_params(
             "sapling-mint",
             MintAsset {
-                name: [0u8; 32],
-                metadata: [0u8; 77],
-                nonce: 0,
                 proof_generation_key: None,
                 public_key_randomness: None,
             },

--- a/ironfish-zkp/src/circuits/util.rs
+++ b/ironfish-zkp/src/circuits/util.rs
@@ -16,35 +16,6 @@ use crate::{
     primitives::ValueCommitment,
 };
 
-pub fn asset_id_preimage<CS: bellman::ConstraintSystem<bls12_381::Scalar>>(
-    cs: &mut CS,
-    name: &[u8; 32],
-    metadata: &[u8; 77],
-    nonce: &u8,
-    owner_public_key: &EdwardsPoint,
-) -> Result<Vec<boolean::Boolean>, SynthesisError> {
-    let mut combined_preimage = vec![];
-
-    combined_preimage
-        .extend(owner_public_key.repr(cs.namespace(|| "booleanize owner_public_key"))?);
-
-    let name_bits = slice_into_boolean_vec_le(cs.namespace(|| "booleanize name"), Some(name), 32)?;
-    combined_preimage.extend(name_bits);
-
-    let metadata_bits =
-        slice_into_boolean_vec_le(cs.namespace(|| "booleanize metadata"), Some(metadata), 77)?;
-    combined_preimage.extend(metadata_bits);
-
-    let nonce_bits = slice_into_boolean_vec_le(
-        cs.namespace(|| "booleanize nonce"),
-        Some(std::slice::from_ref(nonce)),
-        1,
-    )?;
-    combined_preimage.extend(nonce_bits);
-
-    Ok(combined_preimage)
-}
-
 pub fn slice_into_boolean_vec_le<Scalar: PrimeField, CS: ConstraintSystem<Scalar>>(
     mut cs: CS,
     value: Option<&[u8]>,


### PR DESCRIPTION
## Summary

Since the metadata, name, nonce, and owner are public, we can move the identifier verification into consensus (and also reduce our constraints for the circuit).

## Testing Plan

Unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```

This is going in the network reset branch.
