### PR TITLE
feat(rust): Add `partial_verify` when building spends and outputs

### DIFF
--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -104,14 +104,15 @@ impl OutputBuilder {
             )
         };
 
-        let output_proof = OutputDescription { proof, merkle_note };
+        let description = OutputDescription { proof, merkle_note };
+        description.partial_verify()?;
 
         verify_output_proof(
-            &output_proof.proof,
-            &output_proof.public_inputs(randomized_public_key),
+            &description.proof,
+            &description.public_inputs(randomized_public_key),
         )?;
 
-        Ok(output_proof)
+        Ok(description)
     }
 }
 

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -131,6 +131,7 @@ impl SpendBuilder {
             nullifier,
             authorizing_signature: blank_signature,
         };
+        description.partial_verify()?;
 
         verify_spend_proof(
             &description.proof,


### PR DESCRIPTION
## Summary

Add a `partial_verify` when building spends and output descriptions.

## Testing Plan

N/A

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
