### PR TITLE
fixes yup currency validation with min

### DIFF
--- a/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
@@ -26,7 +26,9 @@ describe('burnAsset', () => {
           fee: '0',
           value: '100',
         }),
-      ).rejects.toThrow('value must be equal to or greater than 1')
+      ).rejects.toThrow(
+        'Request failed (400) validation: value must be equal to or greater than 1',
+      )
     })
   })
 
@@ -39,7 +41,9 @@ describe('burnAsset', () => {
           fee: '1',
           value: '-1',
         }),
-      ).rejects.toThrow('value must be equal to or greater than 1')
+      ).rejects.toThrow(
+        'Request failed (400) validation: value must be equal to or greater than 1',
+      )
     })
   })
 

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -23,7 +23,9 @@ describe('mint', () => {
           name: 'fake-coin',
           value: '100',
         }),
-      ).rejects.toThrow('value must be equal to or greater than 1')
+      ).rejects.toThrow(
+        'Request failed (400) validation: value must be equal to or greater than 1',
+      )
     })
   })
 
@@ -37,7 +39,9 @@ describe('mint', () => {
           name: 'fake-coin',
           value: '-1',
         }),
-      ).rejects.toThrow('value must be equal to or greater than 1')
+      ).rejects.toThrow(
+        'Request failed (400) validation: value must be equal to or greater than 1',
+      )
     })
   })
 

--- a/ironfish/src/utils/yup.test.ts
+++ b/ironfish/src/utils/yup.test.ts
@@ -35,6 +35,7 @@ describe('YupUtils', () => {
     it('currency', () => {
       expect(YupUtils.currency().isValidSync(CurrencyUtils.encode(6n))).toBe(true)
       expect(YupUtils.currency({ min: 0n }).isValidSync(CurrencyUtils.encode(-1n))).toBe(false)
+      expect(YupUtils.currency({ min: 0n }).isValidSync('0.1')).toBe(false)
       expect(YupUtils.currency().isValidSync('hello world')).toBe(false)
       expect(YupUtils.currency().isValidSync(0.00046)).toBe(false)
     })

--- a/ironfish/src/utils/yup.ts
+++ b/ironfish/src/utils/yup.ts
@@ -23,19 +23,33 @@ export class YupUtils {
   static isUrl = yup.string().url()
 
   static currency = (options?: { min?: bigint }): yup.StringSchema => {
-    return yup.string().test('currency', `Must be encoded currency`, (val) => {
+    let schema = yup.string().test('currency', `Must be encoded currency`, (val) => {
       if (val == null) {
         return true
       }
 
       const [value] = CurrencyUtils.decodeTry(val)
-
-      if (options?.min != null) {
-        return value != null && value >= options.min
-      }
-
       return value != null
     })
+
+    if (options?.min != null) {
+      const min = options?.min
+
+      schema = schema.test(
+        'min',
+        `value must be equal to or greater than ${min.toString()}`,
+        (val) => {
+          if (val == null) {
+            return true
+          }
+
+          const [value] = CurrencyUtils.decodeTry(val)
+          return value != null && value >= min
+        },
+      )
+    }
+
+    return schema
   }
 
   static async tryValidate<S extends YupSchema>(

--- a/ironfish/src/utils/yup.ts
+++ b/ironfish/src/utils/yup.ts
@@ -23,26 +23,19 @@ export class YupUtils {
   static isUrl = yup.string().url()
 
   static currency = (options?: { min?: bigint }): yup.StringSchema => {
-    let schema = yup.string().test('currency', `Must be encoded currency`, (val) => {
+    return yup.string().test('currency', `Must be encoded currency`, (val) => {
       if (val == null) {
         return true
       }
 
       const [value] = CurrencyUtils.decodeTry(val)
+
+      if (options?.min != null) {
+        return value != null && value >= options.min
+      }
+
       return value != null
     })
-
-    if (options?.min != null) {
-      const min = options?.min
-
-      schema = schema.test(
-        `min`,
-        `value must be equal to or greater than ${min.toString()}`,
-        (val) => val == null || CurrencyUtils.decode(val) >= min,
-      )
-    }
-
-    return schema
   }
 
   static async tryValidate<S extends YupSchema>(


### PR DESCRIPTION
## Summary

when using our custom 'currency' yup schema with a minimum value we do not catch errors from 'CurrencyUtils.decode'. this results in a non-yup error during validation if the value cannot be decoded.

an error other than 'yup.ValidationError' in an RPC endpoint crashes the node.

see #3662

## Testing Plan

- updates unit test. updated unit test fails before applying changes
- manual testing
  - apply the attached diff to pass an invalid feeRate to the 'createTransaction' RPC
  - use the 'send' command, pass the invalid feeRate, and crash the node

[test.diff.txt](https://github.com/iron-fish/ironfish/files/11056890/test.diff.txt)


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
