### PR TITLE
Tag docker deploys with Github info

### DIFF
--- a/.github/workflows/deploy-node-aws.yml
+++ b/.github/workflows/deploy-node-aws.yml
@@ -30,3 +30,5 @@ jobs:
         env:
           REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
           PACKAGE_NAME: ironfish
+          GITHUB_REF: ${GITHUB_REF}
+          GITHUB_SHA: ${GITHUB_SHA}

--- a/.github/workflows/deploy-node-github-beta.yml
+++ b/.github/workflows/deploy-node-github-beta.yml
@@ -28,3 +28,5 @@ jobs:
         env:
           REGISTRY_URL: ghcr.io/iron-fish
           PACKAGE_NAME: ironfish-beta
+          GITHUB_REF: "$GITHUB_REF"
+          GITHUB_SHA: "$GITHUB_SHA"

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -28,3 +28,5 @@ jobs:
         env:
           REGISTRY_URL: ghcr.io/iron-fish
           PACKAGE_NAME: ironfish
+          GITHUB_REF: ${GITHUB_REF}
+          GITHUB_SHA: ${GITHUB_SHA}

--- a/ironfish-cli/scripts/deploy-docker.sh
+++ b/ironfish-cli/scripts/deploy-docker.sh
@@ -12,7 +12,18 @@ if [ -z "${PACKAGE_NAME-}" ]; then
     exit 1
 fi
 
+if [ -z "${GITHUB_SHA-}" ]; then
+    echo "Set GITHUB_SHA before running deploy-docker.sh"
+    exit 1
+fi
+
+if [ -z "${GITHUB_REF-}" ]; then
+    echo "Set GITHUB_REF before running deploy-docker.sh"
+    exit 1
+fi
 
 docker tag ironfish:latest ${REGISTRY_URL}/${PACKAGE_NAME}:latest
-docker push ${REGISTRY_URL}/${PACKAGE_NAME}:latest
+docker tag ironfish:latest ${REGISTRY_URL}/${PACKAGE_NAME}:${GITHUB_REF}
+docker tag ironfish:latest ${REGISTRY_URL}/${PACKAGE_NAME}:${GITHUB_SHA}
 
+docker push --all-tags ${REGISTRY_URL}/${PACKAGE_NAME}


### PR DESCRIPTION
## Summary
When we deploy any docker images either from master or from another branch we only tag with `latest`. This can run into potential issues with production deploys if we don't always deploy from the master branch. Tagging docker images with their Github hash+branch / tag name will make our production deployments more stable

## Testing Plan
Testing by running Github action

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
