### PR TITLE
feat(cli): reset CLI command takes networkId flag and only modifies if given

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -43,10 +43,13 @@ export default class Reset extends IronfishCommand {
       HOST_FILE_NAME,
     )
 
+    const existingId = this.sdk.internal.get('networkId')
+
     let networkIdMessage = ''
-    if (flags.networkId != null) {
-      const existingId = this.sdk.internal.get('networkId')
+    if (flags.networkId != null && flags.networkId !== existingId) {
       networkIdMessage = `\n\nThe network ID will be changed from ${existingId} to the new value of ${flags.networkId}`
+    } else {
+      networkIdMessage = `\n\nThe network ID will stay unchanged as ${existingId}`
     }
 
     const message =
@@ -71,7 +74,7 @@ export default class Reset extends IronfishCommand {
       fsAsync.rm(hostFilePath, { recursive: true, force: true }),
     ])
 
-    if (flags.networkId != null) {
+    if (flags.networkId != null && flags.networkId !== existingId) {
       this.sdk.internal.set('networkId', flags.networkId)
     }
     this.sdk.internal.set('isFirstRun', true)

--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -21,6 +21,11 @@ export default class Reset extends IronfishCommand {
     [VerboseFlagKey]: VerboseFlag,
     [ConfigFlagKey]: ConfigFlag,
     [DataDirFlagKey]: DataDirFlag,
+    networkId: Flags.integer({
+      char: 'i',
+      default: undefined,
+      description: 'Network ID of an official Iron Fish network to connect to',
+    }),
     confirm: Flags.boolean({
       default: false,
       description: 'Confirm without asking',
@@ -38,11 +43,18 @@ export default class Reset extends IronfishCommand {
       HOST_FILE_NAME,
     )
 
+    let networkIdMessage = ''
+    if (flags.networkId != null) {
+      const existingId = this.sdk.internal.get('networkId')
+      networkIdMessage = `\n\nThe network ID will be changed from ${existingId} to the new value of ${flags.networkId}`
+    }
+
     const message =
       '\nYou are about to destroy your local copy of the blockchain. The following directories and files will be deleted:\n' +
       `\nBlockchain: ${chainDatabasePath}` +
       `\nHosts: ${hostFilePath}` +
       '\nYour wallet, accounts, and keys will NOT be deleted.' +
+      networkIdMessage +
       `\n\nAre you sure? (Y)es / (N)o`
 
     const confirmed = flags.confirm || (await CliUx.ux.confirm(message))
@@ -59,7 +71,9 @@ export default class Reset extends IronfishCommand {
       fsAsync.rm(hostFilePath, { recursive: true, force: true }),
     ])
 
-    this.sdk.internal.set('networkId', this.sdk.config.defaults.networkId)
+    if (flags.networkId != null) {
+      this.sdk.internal.set('networkId', flags.networkId)
+    }
     this.sdk.internal.set('isFirstRun', true)
     await this.sdk.internal.save()
 


### PR DESCRIPTION
## Summary

Currently, there is no way to modify your network ID unless you manually edit the internal.json file. Combined with the usage of reset changing slightly to work more like a soft reset to allow changing between networks or just reset chain data, it makes sense to only optionally re-write the network ID if passed via flag. Otherwise, leave it unmodified

## Testing Plan

![image](https://user-images.githubusercontent.com/97762857/227600567-ade995ff-03f9-401a-8c3c-625a80848fc0.png)

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
