### PR TITLE
Fix GitHub branch ref

### DIFF
--- a/.github/workflows/deploy-node-aws.yml
+++ b/.github/workflows/deploy-node-aws.yml
@@ -30,5 +30,5 @@ jobs:
         env:
           REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
           PACKAGE_NAME: ironfish
-          GITHUB_REF: ${GITHUB_REF##*/}
+          GITHUB_REF: ${GITHUB_REF_NAME}
           GITHUB_SHA: ${GITHUB_SHA}

--- a/.github/workflows/deploy-node-aws.yml
+++ b/.github/workflows/deploy-node-aws.yml
@@ -30,5 +30,5 @@ jobs:
         env:
           REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
           PACKAGE_NAME: ironfish
-          GITHUB_REF: ${GITHUB_REF}
+          GITHUB_REF: ${GITHUB_REF##*/}
           GITHUB_SHA: ${GITHUB_SHA}

--- a/.github/workflows/deploy-node-github-beta.yml
+++ b/.github/workflows/deploy-node-github-beta.yml
@@ -28,5 +28,5 @@ jobs:
         env:
           REGISTRY_URL: ghcr.io/iron-fish
           PACKAGE_NAME: ironfish-beta
-          GITHUB_REF: "$GITHUB_REF"
+          GITHUB_REF: ${GITHUB_REF##*/}
           GITHUB_SHA: "$GITHUB_SHA"

--- a/.github/workflows/deploy-node-github-beta.yml
+++ b/.github/workflows/deploy-node-github-beta.yml
@@ -28,5 +28,5 @@ jobs:
         env:
           REGISTRY_URL: ghcr.io/iron-fish
           PACKAGE_NAME: ironfish-beta
-          GITHUB_REF: ${GITHUB_REF##*/}
+          GITHUB_REF: ${GITHUB_REF_NAME}
           GITHUB_SHA: "$GITHUB_SHA"

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -28,5 +28,5 @@ jobs:
         env:
           REGISTRY_URL: ghcr.io/iron-fish
           PACKAGE_NAME: ironfish
-          GITHUB_REF: ${GITHUB_REF##*/}
+          GITHUB_REF: ${GITHUB_REF_NAME}
           GITHUB_SHA: ${GITHUB_SHA}

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -28,5 +28,5 @@ jobs:
         env:
           REGISTRY_URL: ghcr.io/iron-fish
           PACKAGE_NAME: ironfish
-          GITHUB_REF: ${GITHUB_REF}
+          GITHUB_REF: ${GITHUB_REF##*/}
           GITHUB_SHA: ${GITHUB_SHA}


### PR DESCRIPTION
## Summary
`GITHUB_REF` is not exactly the branch name so extracting it here

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
