### PR TITLE
Add config for setting latest tag

### DIFF
--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -66,7 +66,7 @@ jobs:
       # Used if we are deploying a new version (e.g. v1.1)
       # This is only executed when deploying a new release to mainnet
       - name: Deploy Node Image to Github:{version}
-        if: ${{ inputs.github_tag_mainnet && GITHUB_REF_TYPE == 'tag'}}
+        if: ${{ inputs.github_tag_mainnet && github.event.ref_type == 'tag'}}
         run: ./ironfish-cli/scripts/deploy-docker.sh
         env:
           REGISTRY_URL: ghcr.io/iron-fish

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -1,5 +1,27 @@
 name: Deploy Node Image to Github
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      github_tag_mainnet:
+        description: 'Github:mainnet'
+        type: boolean
+        default: false
+      github_tag_testnet:
+        description: 'Github:testnet'
+        type: boolean
+        default: false
+      aws_tag_mainnet:
+        description: 'AWS:mainnet'
+        type: boolean
+        default: false
+      aws_tag_testnet:
+        description: 'AWS:testnet'
+        type: boolean
+        default: false
+      aws_tag_git_sha:
+        description: 'AWS:{GIT_SHA}'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -23,10 +45,62 @@ jobs:
       - name: Build Node Image
         run: ./ironfish-cli/scripts/build-docker.sh
 
-      - name: Deploy Node Image to Github
+      - name: Deploy Node Image to Github:mainnet
+        if: ${{ inputs.github_tag_mainnet }}
         run: ./ironfish-cli/scripts/deploy-docker.sh
         env:
           REGISTRY_URL: ghcr.io/iron-fish
           PACKAGE_NAME: ironfish
-          GITHUB_REF: ${GITHUB_REF_NAME}
-          GITHUB_SHA: ${GITHUB_SHA}
+          TAG: mainnet
+
+      # If we are deploying a new public release to mainnet
+      # also update the docker registry :latest tag for hygiene
+      - name: Deploy Node Image to Github:latest
+        if: ${{ inputs.github_tag_mainnet }}
+        run: ./ironfish-cli/scripts/deploy-docker.sh
+        env:
+          REGISTRY_URL: ghcr.io/iron-fish
+          PACKAGE_NAME: ironfish
+          TAG: latest
+
+      # Used if we are deploying a new version (e.g. v1.1)
+      # This is only executed when deploying a new release to mainnet
+      - name: Deploy Node Image to Github:{version}
+        if: ${{ inputs.github_tag_mainnet && GITHUB_REF_TYPE == 'tag'}}
+        run: ./ironfish-cli/scripts/deploy-docker.sh
+        env:
+          REGISTRY_URL: ghcr.io/iron-fish
+          PACKAGE_NAME: ironfish
+          TAG: ${GITHUB_REF_NAME}
+
+      - name: Deploy Node Image to Github:testnet
+        if: ${{ inputs.github_tag_testnet }}
+        run: ./ironfish-cli/scripts/deploy-docker.sh
+        env:
+          REGISTRY_URL: ghcr.io/iron-fish
+          PACKAGE_NAME: ironfish
+          TAG: testnet
+
+      - name: Deploy Node Image to AWS:mainnet
+        if: ${{ inputs.github_tag_mainnet }}
+        run: ./ironfish-cli/scripts/deploy-docker.sh
+        env:
+          REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
+          PACKAGE_NAME: ironfish
+          TAG: mainnet
+
+      - name: Deploy Node Image to AWS:testnet
+        if: ${{ inputs.github_tag_testnet }}
+        run: ./ironfish-cli/scripts/deploy-docker.sh
+        env:
+          REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
+          PACKAGE_NAME: ironfish
+          TAG: testnet
+
+      - name: Deploy Node Image to AWS:{GITHUB_SHA}
+        if: ${{ inputs.aws_tag_git_sha }}
+        run: ./ironfish-cli/scripts/deploy-docker.sh
+        env:
+          REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
+          PACKAGE_NAME: ironfish
+          TAG: ${GITHUB_SHA}

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -42,6 +42,18 @@ jobs:
           GITHUB_USER: ${{ secrets.BREW_GITHUB_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to AWS Registry
+        run: aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $AWS_REGISTRY_URL
+        env:
+          AWS_REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
+
       - name: Build Node Image
         run: ./ironfish-cli/scripts/build-docker.sh
 
@@ -65,7 +77,7 @@ jobs:
 
       # Used if we are deploying a new version (e.g. v1.1)
       # This is only executed when deploying a new release to mainnet
-      - name: Deploy Node Image to Github:{version}
+      - name: Deploy Node Image to Github:${{ github.ref_name }}
         if: ${{ inputs.github_tag_mainnet && github.event.ref_type == 'tag'}}
         run: ./ironfish-cli/scripts/deploy-docker.sh
         env:
@@ -80,18 +92,6 @@ jobs:
           REGISTRY_URL: ghcr.io/iron-fish
           PACKAGE_NAME: ironfish
           TAG: testnet
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Login to AWS Registry
-        run: aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $AWS_REGISTRY_URL
-        env:
-          AWS_REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
 
       - name: Deploy Node Image to AWS:mainnet
         if: ${{ inputs.aws_tag_mainnet }}
@@ -113,7 +113,7 @@ jobs:
 
       # Used if we are deploying a new version (e.g. v1.1)
       # This is only executed when deploying a new release to mainnet
-      - name: Deploy Node Image to AWS:{version}
+      - name: Deploy Node Image to AWS:${{ github.ref_name }}
         if: ${{ inputs.aws_tag_mainnet && github.event.ref_type == 'tag'}}
         run: ./ironfish-cli/scripts/deploy-docker.sh
         env:

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -81,6 +81,18 @@ jobs:
           PACKAGE_NAME: ironfish
           TAG: testnet
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to AWS Registry
+        run: aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $AWS_REGISTRY_URL
+        env:
+          AWS_REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
+
       - name: Deploy Node Image to AWS:mainnet
         if: ${{ inputs.aws_tag_mainnet }}
         run: ./ironfish-cli/scripts/deploy-docker.sh

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -82,7 +82,7 @@ jobs:
           TAG: testnet
 
       - name: Deploy Node Image to AWS:mainnet
-        if: ${{ inputs.github_tag_mainnet }}
+        if: ${{ inputs.aws_tag_mainnet }}
         run: ./ironfish-cli/scripts/deploy-docker.sh
         env:
           REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
@@ -90,7 +90,7 @@ jobs:
           TAG: mainnet
 
       - name: Deploy Node Image to AWS:testnet
-        if: ${{ inputs.github_tag_testnet }}
+        if: ${{ inputs.aws_tag_testnet }}
         run: ./ironfish-cli/scripts/deploy-docker.sh
         env:
           REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -109,10 +109,10 @@ jobs:
           PACKAGE_NAME: ironfish
           TAG: testnet
 
-      - name: Deploy Node Image to AWS:{GITHUB_SHA}
+      - name: Deploy Node Image to AWS:${{ github.sha }}
         if: ${{ inputs.aws_tag_git_sha }}
         run: ./ironfish-cli/scripts/deploy-docker.sh
         env:
           REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
           PACKAGE_NAME: ironfish
-          TAG: ${GITHUB_SHA}
+          TAG: ${{ github.sha }}

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -101,6 +101,26 @@ jobs:
           PACKAGE_NAME: ironfish
           TAG: mainnet
 
+      # If we are deploying a new public release to mainnet
+      # also update the docker registry :latest tag for hygiene
+      - name: Deploy Node Image to AWS:latest
+        if: ${{ inputs.aws_tag_mainnet }}
+        run: ./ironfish-cli/scripts/deploy-docker.sh
+        env:
+          REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
+          PACKAGE_NAME: ironfish
+          TAG: latest
+
+      # Used if we are deploying a new version (e.g. v1.1)
+      # This is only executed when deploying a new release to mainnet
+      - name: Deploy Node Image to AWS:{version}
+        if: ${{ inputs.aws_tag_mainnet && github.event.ref_type == 'tag'}}
+        run: ./ironfish-cli/scripts/deploy-docker.sh
+        env:
+          REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
+          PACKAGE_NAME: ironfish
+          TAG: ${GITHUB_REF_NAME}
+
       - name: Deploy Node Image to AWS:testnet
         if: ${{ inputs.aws_tag_testnet }}
         run: ./ironfish-cli/scripts/deploy-docker.sh

--- a/.github/workflows/deploy-node-github.yml
+++ b/.github/workflows/deploy-node-github.yml
@@ -59,80 +59,62 @@ jobs:
 
       - name: Deploy Node Image to Github:mainnet
         if: ${{ inputs.github_tag_mainnet }}
-        run: ./ironfish-cli/scripts/deploy-docker.sh
-        env:
-          REGISTRY_URL: ghcr.io/iron-fish
-          PACKAGE_NAME: ironfish
-          TAG: mainnet
+        run: |
+          docker tag ironfish ghcr.io/iron-fish/ironfish:mainnet
+          docker push ghcr.io/iron-fish/ironfish:mainnet
 
       # If we are deploying a new public release to mainnet
       # also update the docker registry :latest tag for hygiene
       - name: Deploy Node Image to Github:latest
         if: ${{ inputs.github_tag_mainnet }}
-        run: ./ironfish-cli/scripts/deploy-docker.sh
-        env:
-          REGISTRY_URL: ghcr.io/iron-fish
-          PACKAGE_NAME: ironfish
-          TAG: latest
+        run: |
+          docker tag ironfish ghcr.io/iron-fish/ironfish:latest
+          docker push ghcr.io/iron-fish/ironfish:latest
 
       # Used if we are deploying a new version (e.g. v1.1)
       # This is only executed when deploying a new release to mainnet
       - name: Deploy Node Image to Github:${{ github.ref_name }}
         if: ${{ inputs.github_tag_mainnet && github.event.ref_type == 'tag'}}
-        run: ./ironfish-cli/scripts/deploy-docker.sh
-        env:
-          REGISTRY_URL: ghcr.io/iron-fish
-          PACKAGE_NAME: ironfish
-          TAG: ${GITHUB_REF_NAME}
+        run: |
+          docker tag ironfish ghcr.io/iron-fish/ironfish:${{ github.ref_name }}
+          docker push ghcr.io/iron-fish/ironfish:${{ github.ref_name }}
 
       - name: Deploy Node Image to Github:testnet
         if: ${{ inputs.github_tag_testnet }}
-        run: ./ironfish-cli/scripts/deploy-docker.sh
-        env:
-          REGISTRY_URL: ghcr.io/iron-fish
-          PACKAGE_NAME: ironfish
-          TAG: testnet
+        run: |
+          docker tag ironfish ghcr.io/iron-fish/ironfish:testnet
+          docker push ghcr.io/iron-fish/ironfish:testnet
 
       - name: Deploy Node Image to AWS:mainnet
         if: ${{ inputs.aws_tag_mainnet }}
-        run: ./ironfish-cli/scripts/deploy-docker.sh
-        env:
-          REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
-          PACKAGE_NAME: ironfish
-          TAG: mainnet
+        run: |
+          docker tag ironfish ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:mainnet
+          docker push ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:mainnet
 
       # If we are deploying a new public release to mainnet
       # also update the docker registry :latest tag for hygiene
       - name: Deploy Node Image to AWS:latest
         if: ${{ inputs.aws_tag_mainnet }}
-        run: ./ironfish-cli/scripts/deploy-docker.sh
-        env:
-          REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
-          PACKAGE_NAME: ironfish
-          TAG: latest
+        run: |
+          docker tag ironfish ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:latest
+          docker push ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:latest
 
       # Used if we are deploying a new version (e.g. v1.1)
       # This is only executed when deploying a new release to mainnet
       - name: Deploy Node Image to AWS:${{ github.ref_name }}
         if: ${{ inputs.aws_tag_mainnet && github.event.ref_type == 'tag'}}
-        run: ./ironfish-cli/scripts/deploy-docker.sh
-        env:
-          REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
-          PACKAGE_NAME: ironfish
-          TAG: ${GITHUB_REF_NAME}
+        run: |
+          docker tag ironfish ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}
+          docker push ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}
 
       - name: Deploy Node Image to AWS:testnet
         if: ${{ inputs.aws_tag_testnet }}
-        run: ./ironfish-cli/scripts/deploy-docker.sh
-        env:
-          REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
-          PACKAGE_NAME: ironfish
-          TAG: testnet
+        run: |
+          docker tag ironfish ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:testnet
+          docker push ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:testnet
 
       - name: Deploy Node Image to AWS:${{ github.sha }}
         if: ${{ inputs.aws_tag_git_sha }}
-        run: ./ironfish-cli/scripts/deploy-docker.sh
-        env:
-          REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
-          PACKAGE_NAME: ironfish
-          TAG: ${{ github.sha }}
+        run: |
+          docker tag ironfish ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.sha }}
+          docker push ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.sha }}

--- a/ironfish-cli/scripts/deploy-docker.sh
+++ b/ironfish-cli/scripts/deploy-docker.sh
@@ -12,18 +12,10 @@ if [ -z "${PACKAGE_NAME-}" ]; then
     exit 1
 fi
 
-if [ -z "${GITHUB_SHA-}" ]; then
-    echo "Set GITHUB_SHA before running deploy-docker.sh"
+if [ -z "${TAG-}" ]; then
+    echo "Set TAG before running deploy-docker.sh"
     exit 1
 fi
 
-if [ -z "${GITHUB_REF-}" ]; then
-    echo "Set GITHUB_REF before running deploy-docker.sh"
-    exit 1
-fi
-
-docker tag ironfish:latest ${REGISTRY_URL}/${PACKAGE_NAME}:latest
-docker tag ironfish:latest ${REGISTRY_URL}/${PACKAGE_NAME}:${GITHUB_REF}
-docker tag ironfish:latest ${REGISTRY_URL}/${PACKAGE_NAME}:${GITHUB_SHA}
-
-docker push --all-tags ${REGISTRY_URL}/${PACKAGE_NAME}
+docker tag ironfish:latest ${REGISTRY_URL}/${PACKAGE_NAME}:${TAG}
+docker push ${REGISTRY_URL}/${PACKAGE_NAME}:${TAG}


### PR DESCRIPTION
## Summary
Docker latest tag is used as the default tag when pulling a docker image and we only want to do this during a release, not if we are deploying specific versions.

## Testing Plan
Tested deploy locally + in github actions

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
