### PR TITLE
Add runtime flag for json logging

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -16,6 +16,8 @@ import { CLIError, ExitError } from '@oclif/core/lib/errors'
 import {
   ConfigFlagKey,
   DataDirFlagKey,
+  JsonLogsFlag,
+  JsonLogsFlagKey,
   RpcAuthFlagKey,
   RpcHttpHostFlagKey,
   RpcHttpPortFlagKey,
@@ -49,6 +51,7 @@ export type FLAGS =
   | typeof RpcHttpPortFlagKey
   | typeof RpcTcpTlsFlagKey
   | typeof VerboseFlagKey
+  | typeof JsonLogsFlagKey
   | typeof RpcAuthFlagKey
 
 export abstract class IronfishCommand extends Command {
@@ -165,6 +168,11 @@ export abstract class IronfishCommand extends Command {
     const verboseFlag = getFlag(flags, VerboseFlagKey)
     if (typeof verboseFlag === 'boolean' && verboseFlag !== VerboseFlag.default) {
       configOverrides.logLevel = '*:verbose'
+    }
+
+    const jsonLogsFlag = getFlag(flags, JsonLogsFlagKey)
+    if (typeof jsonLogsFlag === 'boolean' && jsonLogsFlag !== JsonLogsFlag.default) {
+      configOverrides.jsonLogs = jsonLogsFlag
     }
 
     const rpcAuthFlag = getFlag(flags, RpcAuthFlagKey)

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -12,6 +12,8 @@ import {
   ConfigFlagKey,
   DataDirFlag,
   DataDirFlagKey,
+  JsonLogsFlag,
+  JsonLogsFlagKey,
   RpcHttpHostFlag,
   RpcHttpHostFlagKey,
   RpcHttpPortFlag,
@@ -39,6 +41,7 @@ export default class Start extends IronfishCommand {
 
   static flags = {
     [VerboseFlagKey]: VerboseFlag,
+    [JsonLogsFlagKey]: JsonLogsFlag,
     [ConfigFlagKey]: ConfigFlag,
     [DataDirFlagKey]: DataDirFlag,
     [RpcUseIpcFlagKey]: { ...RpcUseIpcFlag, allowNo: true },

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -17,6 +17,7 @@ import { Flags, Interfaces } from '@oclif/core'
 type CompletableOptionFlag = Interfaces.CompletableOptionFlag<unknown>
 
 export const VerboseFlagKey = 'verbose'
+export const JsonLogsFlagKey = 'jsonLogs'
 export const ConfigFlagKey = 'config'
 export const ColorFlagKey = 'color'
 export const DataDirFlagKey = 'datadir'
@@ -34,6 +35,11 @@ export const VerboseFlag = Flags.boolean({
   char: 'v',
   default: false,
   description: 'Set logging level to verbose',
+})
+
+export const JsonLogsFlag = Flags.boolean({
+  default: false,
+  description: 'Log all lines in JSON format',
 })
 
 export const ColorFlag = Flags.boolean({
@@ -98,6 +104,7 @@ export const RpcUseHttpFlag = Flags.boolean({
 
 const localFlags: Record<string, CompletableOptionFlag> = {}
 localFlags[VerboseFlagKey] = VerboseFlag as unknown as CompletableOptionFlag
+localFlags[JsonLogsFlagKey] = JsonLogsFlag as unknown as CompletableOptionFlag
 localFlags[ConfigFlagKey] = ConfigFlag as unknown as CompletableOptionFlag
 localFlags[DataDirFlagKey] = DataDirFlag as unknown as CompletableOptionFlag
 
@@ -109,6 +116,7 @@ export const LocalFlags = localFlags
 
 const remoteFlags: Record<string, CompletableOptionFlag> = {}
 remoteFlags[VerboseFlagKey] = VerboseFlag as unknown as CompletableOptionFlag
+remoteFlags[JsonLogsFlagKey] = JsonLogsFlag as unknown as CompletableOptionFlag
 remoteFlags[ConfigFlagKey] = ConfigFlag as unknown as CompletableOptionFlag
 remoteFlags[DataDirFlagKey] = DataDirFlag as unknown as CompletableOptionFlag
 remoteFlags[RpcUseTcpFlagKey] = RpcUseTcpFlag as unknown as CompletableOptionFlag


### PR DESCRIPTION
## Summary
When programmatically starting up a node for the first time like we are doing in the simulator, a config value may not be set. This allows logging easily parable logs (with tags included) on startup without having to modify a config file first.

## Testing Plan
Tested locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
