### PR TITLE
fixes count of subscribed pool miners

### DIFF
--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -312,7 +312,7 @@ export class MiningPool {
           )}/s`,
         )
         this.webhooks.map((w) =>
-          w.poolSubmittedBlock(hashedHeaderHex, hashRate, this.stratum.clients.size),
+          w.poolSubmittedBlock(hashedHeaderHex, hashRate, this.stratum.subscribed),
         )
       } else {
         this.logger.info(`Block was rejected: ${result.content.reason}`)

--- a/ironfish/src/mining/stratum/stratumServer.ts
+++ b/ironfish/src/mining/stratum/stratumServer.ts
@@ -325,6 +325,11 @@ export class StratumServer {
 
     client.socket.removeAllListeners()
     client.close()
+
+    if (client.subscribed) {
+      this.subscribed--
+    }
+
     this.clients.delete(client.id)
     this.peers.removeConnectionCount(client)
   }


### PR DESCRIPTION
## Summary

the StratumServer has a property, 'subscribed', that it uses to count the number of subscribed miners.

we don't decrement that counter when a subscribed miner is disconnected because of an error. this causes the miner count in status messages to hover at an incorrect level after miner errors.

we also use the number of clients to indicate the number of miners when sending notifications for submitted blocks. this is not the right number since there may be connected clients that are only following the pool for status messages and aren't mining.

## Testing Plan

manual testing with discord hook to my own discord server. modified miner to send malformed messages.
before changes:
<img width="375" alt="image" src="https://user-images.githubusercontent.com/57735705/227645528-4e6602b7-5859-4f52-a672-2d0664f34bd8.png">
"Miners" keeps increasing after the miner idsconnects due to error

after changes:
<img width="287" alt="image" src="https://user-images.githubusercontent.com/57735705/227645592-1cb0938b-3dcd-4255-91d2-30ec9765f753.png">
"Miners" never increases from 0

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
