### PR TITLE
uses default node account in pool by default

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -148,7 +148,7 @@ export type ConfigOptions = {
   /**
    * The name of the account that the pool will use to payout from.
    */
-  poolAccountName: string
+  poolAccountName?: string
 
   /**
    * Should pool clients be banned for perceived bad behavior
@@ -316,7 +316,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     minerBatchSize: YupUtils.isPositiveInteger,
     confirmations: YupUtils.isPositiveInteger,
     poolName: yup.string(),
-    poolAccountName: yup.string(),
+    poolAccountName: yup.string().optional(),
     poolBanning: yup.boolean(),
     poolHost: yup.string().trim(),
     poolPort: YupUtils.isPort,
@@ -408,7 +408,7 @@ export class Config extends KeyStore<ConfigOptions> {
       blocksPerMessage: 25,
       minerBatchSize: 25000,
       poolName: 'Iron Fish Pool',
-      poolAccountName: 'default',
+      poolAccountName: undefined,
       poolBanning: true,
       poolHost: DEFAULT_POOL_HOST,
       poolPort: DEFAULT_POOL_PORT,

--- a/ironfish/src/mining/poolShares.test.ts
+++ b/ironfish/src/mining/poolShares.test.ts
@@ -7,6 +7,7 @@ import { LogLevel } from 'consola'
 import { Assert } from '../assert'
 import { createRootLogger } from '../logger'
 import { createRouteTest } from '../testUtilities/routeTest'
+import { Account } from '../wallet'
 import { MiningPoolShares } from './poolShares'
 
 describe('poolShares', () => {
@@ -270,5 +271,47 @@ describe('poolShares', () => {
     expect(unpaidShares.length).toEqual(2)
 
     jest.useRealTimers()
+  })
+
+  describe('sendTransaction', () => {
+    let defaultAccount: Account | null
+
+    beforeEach(() => {
+      defaultAccount = routeTest.node.wallet.getDefaultAccount()
+    })
+
+    afterEach(async () => {
+      await routeTest.node.wallet.setDefaultAccount(defaultAccount?.name ?? null)
+    })
+
+    it('throws an error if no account exists with accountName', async () => {
+      shares['accountName'] = 'fakeAccount'
+
+      const output = {
+        publicAddress: 'testPublicAddress',
+        amount: '42',
+        memo: 'for testing',
+        assetId: 'testAsset',
+      }
+
+      await expect(shares.sendTransaction([output])).rejects.toThrow(
+        new RegExp('No account with name'),
+      )
+    })
+
+    it('throws an error if node has no default account', async () => {
+      await routeTest.node.wallet.setDefaultAccount(null)
+
+      const output = {
+        publicAddress: 'testPublicAddress',
+        amount: '42',
+        memo: 'for testing',
+        assetId: 'testAsset',
+      }
+
+      await expect(shares.sendTransaction([output])).rejects.toThrow(
+        new RegExp('No account is currently active on the node'),
+      )
+    })
   })
 })


### PR DESCRIPTION
## Summary

by default the name of the account that a mining pool uses for payout transactions is hardcoded to 'default'. this poses two potential problems:

1. if the default account on the pool node is not 'default', then 'default' may not have any funds for payouts
2. 'default' may not exist on the pool node

instead of hardcoding the default value of the pool account name we can leave it unset by default. at the time of a payout the pool can then use the default account of its node.

## Testing Plan

- adds unit tests
- existing unit tests cover fetching default account from pool node via rpc

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
