### PR TITLE
conditionally formats cli transactions output

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -78,7 +78,7 @@ export class TransactionsCommand extends IronfishCommand {
 
   getTransactionRows(
     transaction: GetAccountTransactionsResponse,
-    formatted = true,
+    formatted: boolean,
   ): PartialRecursive<TransactionRow>[] {
     const nativeAssetId = Asset.nativeId().toString('hex')
 

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -61,14 +61,15 @@ const timestamp = <T extends Record<string, unknown>>(options?: {
 
 const asset = <T extends Record<string, unknown>>(options?: {
   extended?: boolean
+  formatted?: boolean
 }): Partial<Record<string, table.Column<T>>> => {
-  if (options?.extended) {
+  if (options?.extended || options?.formatted === false) {
     return {
       assetId: {
         header: 'Asset ID',
         get: (row) => row['assetId'],
         minWidth: MAX_ASSET_NAME_COLUMN_WIDTH,
-        extended: true,
+        extended: options.formatted ?? true,
       },
       assetName: {
         header: 'Asset Name',
@@ -78,7 +79,7 @@ const asset = <T extends Record<string, unknown>>(options?: {
           return truncateCol(assetName, MAX_ASSET_NAME_COLUMN_WIDTH)
         },
         minWidth: MAX_ASSET_NAME_COLUMN_WIDTH,
-        extended: true,
+        extended: options.formatted ?? true,
       },
     }
   } else {

--- a/ironfish-cli/src/utils/table.ts
+++ b/ironfish-cli/src/utils/table.ts
@@ -61,15 +61,15 @@ const timestamp = <T extends Record<string, unknown>>(options?: {
 
 const asset = <T extends Record<string, unknown>>(options?: {
   extended?: boolean
-  formatted?: boolean
+  format?: Format
 }): Partial<Record<string, table.Column<T>>> => {
-  if (options?.extended || options?.formatted === false) {
+  if (options?.extended || options?.format !== Format.cli) {
     return {
       assetId: {
         header: 'Asset ID',
         get: (row) => row['assetId'],
         minWidth: MAX_ASSET_NAME_COLUMN_WIDTH,
-        extended: options.formatted ?? true,
+        extended: options?.extended ?? false,
       },
       assetName: {
         header: 'Asset Name',
@@ -79,7 +79,7 @@ const asset = <T extends Record<string, unknown>>(options?: {
           return truncateCol(assetName, MAX_ASSET_NAME_COLUMN_WIDTH)
         },
         minWidth: MAX_ASSET_NAME_COLUMN_WIDTH,
-        extended: options.formatted ?? true,
+        extended: options?.extended ?? false,
       },
     }
   } else {
@@ -122,6 +122,13 @@ function truncateCol(value: string, maxWidth: number | null): string {
   }
 
   return value.slice(0, maxWidth - 1) + '…'
+}
+
+export enum Format {
+  cli = 'cli',
+  csv = 'csv',
+  json = 'json',
+  yaml = 'yaml',
 }
 
 export const TableCols = { timestamp, asset, fixedWidth }


### PR DESCRIPTION
## Summary

we've added a lot of logic to the 'wallet:transactions' command to format the table to make it easier to read in the CLI. however, this formatting logic removes data from the table that might be useful when outputting transaction data with the '--csv' or '--output' flags.

- refactors logic for assigning 'group' string to table rows for the same transaction into 'getRowGroup' method
- only includes the 'group' column in output if formatting the table for the CLI
- includes all transaction details (hash, fee, assetId, assetName, etc.) in each row if using '--csv' or '--output' flags

## Testing Plan

Manual testing:

I modified the `send` command to send multiple outputs in a single transaction to test formatting with multiple assets.

- Table output:
![image](https://user-images.githubusercontent.com/57735705/228379617-721e01fa-b988-46d0-83c7-6b27e9230847.png)

- CSV output:
```
Timestamp,Status,Type,Hash,Expiration,Fee Paid ($IRON),Asset ID,Asset Name,Net Amount
3/28/2023 3:07:03 PM PDT,confirmed,send,ab0bbc4bc6b3c0fbcfd759a02f6ec2855454cc222060fb9c45678622ced04410,35325,0.00000001,d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6,$IRON,-0.00000001
3/28/2023 3:07:03 PM PDT,confirmed,send,ab0bbc4bc6b3c0fbcfd759a02f6ec2855454cc222060fb9c45678622ced04410,35325,0.00000001,2d293899b8e7c0a79d80d3f9c02fbe67fe1a06b6ba363dcddd2cc0c4940d5214,abcdefghijklmnopqrstuvwxyz012345,-1.23456789
3/28/2023 3:07:03 PM PDT,confirmed,send,ab0bbc4bc6b3c0fbcfd759a02f6ec2855454cc222060fb9c45678622ced04410,35325,0.00000001,89457ddefaab4d02ba8e1363248549662790c6cb4518406b55ea9d797f1befb5,hughy-if,-0.00000042
3/28/2023 2:53:35 PM PDT,confirmed,send,8ca51a12977524aba1e6291b2c88e82a348d48aa55ed44ce89141dd83cf2e35b,35310,0.00000001,d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6,$IRON,-0.00000001
3/28/2023 2:53:35 PM PDT,confirmed,send,8ca51a12977524aba1e6291b2c88e82a348d48aa55ed44ce89141dd83cf2e35b,35310,0.00000001,89457ddefaab4d02ba8e1363248549662790c6cb4518406b55ea9d797f1befb5,hughy-if,-0.00000042
3/28/2023 2:47:59 PM PDT,confirmed,send,e9bffe6136a41cdf8b96567746a862ee7eb58da661d99f48b10edc4ea7dee4d3,35300,0.00000001,d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6,$IRON,0.00000000
3/28/2023 2:47:59 PM PDT,confirmed,send,e9bffe6136a41cdf8b96567746a862ee7eb58da661d99f48b10edc4ea7dee4d3,35300,0.00000001,2d293899b8e7c0a79d80d3f9c02fbe67fe1a06b6ba363dcddd2cc0c4940d5214,abcdefghijklmnopqrstuvwxyz012345,123456789.00000000
3/28/2023 2:39:26 PM PDT,expired,send,f7571421b0981a40e9267267607d2384236b38099cf889ad4560ee0251249d52,35282,0.00000001,d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6,$IRON,-0.00000001
3/28/2023 2:39:26 PM PDT,expired,send,f7571421b0981a40e9267267607d2384236b38099cf889ad4560ee0251249d52,35282,0.00000001,89457ddefaab4d02ba8e1363248549662790c6cb4518406b55ea9d797f1befb5,hughy-if,-0.00000042
3/28/2023 2:24:28 PM PDT,confirmed,send,ec444ec72ba1d5f13fc1b434ff3c4a8fa635ac63dac9bf3c656fc9c5f7c12b5a,35277,0.00000001,d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6,$IRON,0.00000000
3/28/2023 2:24:28 PM PDT,confirmed,send,ec444ec72ba1d5f13fc1b434ff3c4a8fa635ac63dac9bf3c656fc9c5f7c12b5a,35277,0.00000001,89457ddefaab4d02ba8e1363248549662790c6cb4518406b55ea9d797f1befb5,hughy-if,42.00000000
3/28/2023 2:23:48 PM PDT,confirmed,send,60724c7bd60ef2e8598e4bdae9f0552d7e3581e930230ec5ba73961637dd252c,35276,0.00000001,d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6,$IRON,-0.00000001
3/24/2023 1:38:54 PM PDT,confirmed,receive,4d520099c75ea5901d3f09a4d7236c32ae9ff2362ce750c74660563c4354b0dc,29156,,d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6,$IRON,0.00000005
3/24/2023 12:21:45 PM PDT,confirmed,receive,527c7716a375c45dac05b724d323202461217be0c67473cf2ce74f13911e5227,29071,,d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6,$IRON,0.00000005
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
