### PR TITLE
Use schema result when routing requests

### DIFF
--- a/ironfish/src/rpc/routes/faucet/getFunds.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.ts
@@ -15,7 +15,7 @@ export type GetFundsResponse = { id: string }
 export const GetFundsRequestSchema: yup.ObjectSchema<GetFundsRequest> = yup
   .object({
     account: yup.string(),
-    email: yup.string().strip(true),
+    email: yup.string().trim(),
   })
   .defined()
 

--- a/ironfish/src/rpc/routes/router.test.ts
+++ b/ironfish/src/rpc/routes/router.test.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { createRouteTest } from '../../testUtilities/routeTest'
+
+describe('Router', () => {
+  const routeTest = createRouteTest()
+
+  it('should use yup schema', async () => {
+    const schema = yup.string().default('default')
+    routeTest.client.router.register('foo/bar', schema, (request) => request.end(request.data))
+
+    // should use default value from the schema
+    let response = await routeTest.client.request('foo/bar').waitForEnd()
+    expect(response.content).toBe('default')
+
+    // should not use the default value from the schema
+    response = await routeTest.client.request('foo/bar', 'bar').waitForEnd()
+    expect(response.content).toBe('bar')
+  })
+})

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -90,10 +90,11 @@ export class Router {
 
     const { handler, schema } = methodRoute
 
-    const { error } = await YupUtils.tryValidate(schema, request.data)
+    const { result, error } = await YupUtils.tryValidate(schema, request.data)
     if (error) {
       throw new ValidationError(error.message, 400)
     }
+    request.data = result
 
     Assert.isNotNull(this.server)
 

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -21,7 +21,7 @@ export type AddTransactionResponse = {
 export const AddTransactionRequestSchema: yup.ObjectSchema<AddTransactionRequest> = yup
   .object({
     transaction: yup.string().defined(),
-    broadcast: yup.boolean().optional(),
+    broadcast: yup.boolean().optional().default(true),
   })
   .defined()
 
@@ -37,10 +37,6 @@ router.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
   `${ApiNamespace.wallet}/addTransaction`,
   AddTransactionRequestSchema,
   async (request, node): Promise<void> => {
-    if (request.data.broadcast == null) {
-      request.data.broadcast = true
-    }
-
     const data = Buffer.from(request.data.transaction, 'hex')
     const transaction = new Transaction(data)
 

--- a/ironfish/src/rpc/routes/wallet/exportAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.ts
@@ -24,7 +24,7 @@ export type ExportAccountResponse = {
 
 export const ExportAccountRequestSchema: yup.ObjectSchema<ExportAccountRequest> = yup
   .object({
-    account: yup.string().strip(true),
+    account: yup.string().trim(),
     viewOnly: yup.boolean().optional().default(false),
   })
   .defined()

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -28,7 +28,7 @@ export type GetBalanceResponse = {
 
 export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup
   .object({
-    account: yup.string().strip(true),
+    account: yup.string().trim(),
     assetId: yup.string().optional(),
     confirmations: yup.number().min(0).optional(),
   })

--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -21,7 +21,7 @@ export type GetAccountNotesStreamResponse = {
 export const GetAccountNotesStreamRequestSchema: yup.ObjectSchema<GetAccountNotesStreamRequest> =
   yup
     .object({
-      account: yup.string().strip(true),
+      account: yup.string().trim(),
     })
     .defined()
 

--- a/ironfish/src/rpc/routes/wallet/getPublicKey.ts
+++ b/ironfish/src/rpc/routes/wallet/getPublicKey.ts
@@ -10,7 +10,7 @@ export type GetPublicKeyResponse = { account: string; publicKey: string }
 
 export const GetPublicKeyRequestSchema: yup.ObjectSchema<GetPublicKeyRequest> = yup
   .object({
-    account: yup.string().strip(true),
+    account: yup.string().trim(),
   })
   .defined()
 

--- a/ironfish/src/rpc/routes/wallet/getTransactions.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.test.ts
@@ -23,13 +23,10 @@ describe('Route wallet/getAccountTransactions', () => {
     await expect(node.chain).toAddBlock(block)
     await node.wallet.updateHead()
 
-    const response = routeTest.client.request<unknown, GetAccountTransactionsResponse>(
-      'wallet/getAccountTransactions',
-      {
-        account: account.name,
-        hash: block.transactions[0].hash(),
-      },
-    )
+    const response = routeTest.client.getAccountTransactionsStream({
+      account: account.name,
+      hash: block.transactions[0].hash().toString('hex'),
+    })
 
     const transactions = await AsyncUtils.materialize(response.contentStream())
     expect(transactions).toHaveLength(1)

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -45,7 +45,7 @@ export type GetAccountTransactionsResponse = {
 export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTransactionsRequest> =
   yup
     .object({
-      account: yup.string().strip(true),
+      account: yup.string().trim(),
       hash: yup.string().notRequired(),
       sequence: yup.number().min(GENESIS_BLOCK_SEQUENCE).notRequired(),
       limit: yup.number().notRequired(),

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -51,7 +51,7 @@ export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTra
       limit: yup.number().notRequired(),
       offset: yup.number().notRequired(),
       confirmations: yup.number().notRequired(),
-      boolean: yup.boolean().notRequired(),
+      notes: yup.boolean().notRequired(),
     })
     .defined()
 

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -18,7 +18,7 @@ export type PostTransactionResponse = {
 
 export const PostTransactionRequestSchema: yup.ObjectSchema<PostTransactionRequest> = yup
   .object({
-    account: yup.string().strip(true),
+    account: yup.string().trim(),
     transaction: yup.string().defined(),
     broadcast: yup.boolean().optional(),
   })


### PR DESCRIPTION
## Summary

The bug here is that the schema result is not used when routing requests. It means that any calls to default() will be ignored in the resulting request. No transformations will be made.

This fixes it so the transformed input is what is passed to the request and not the unsanitized input.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
