### PR TITLE
feat: create ironfish binary

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,10 +1,9 @@
 name: Build @ironfish binaries
 
 on:
-  push:
-    branches: [ '*' ]
-  pull_request:
-    branches: [ '*' ]
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -12,28 +11,41 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          # - host: ubuntu-20.04
-          #   target: x86_64-apple-darwin
+          - host: macos-latest
+            arch: x86_64
+            system: apple
 
-          # - host: windows-latest
-          #   target: x86_64-pc-windows-msvc
+          - host: windows-latest
+            arch: x86_64
+            system: windows
+
+          # requires 20.04 because ironfish depends on openssl 1.1.1, new ubuntu only allows 3.x
+          - host: ubuntu-20.04
+            arch: x86_64
+            system: linux
+          
+          - host: [self-hosted, macOS, ARM64]
+            arch: arm64
+            system: apple
+
+          # currently no way to build arm64
+          # - host: ubuntu-20.04
+          #   arch: aarch64
+          #   system: linux
+          
 
           # - host: ubuntu-20.04
           #   target: aarch64-apple-darwin
 
-          # requires 20.04 because ironfish depends on openssl 1.1.1, new ubuntu only allows 3.x
-          - host: ubuntu-20.04
-            target: x86_64-unknown-linux-musl
-
-          - host: ubuntu-20.04
-            target: aarch64-unknown-linux-gnu
-
-          - host: ubuntu-20.04
-            target: aarch64-unknown-linux-musl
-
-    name: Build ${{ matrix.settings.target }}
+    name: Build ${{ matrix.settings.system }} ${{ matrix.settings.arch }}
     runs-on: ${{ matrix.settings.host }}
     steps:
+
+      - name: clean selfhosted node_modules
+        if: matrix.settings.system == 'apple' && matrix.settings.arch == 'arm64'
+        run: |
+          cd $GITHUB_WORKSPACE
+          find . -name . -o -prune -exec rm -rf -- {} +
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -47,14 +59,36 @@ jobs:
         run: npm install ironfish caxa@3.0.1
 
       - name: caxa package
-        run: npx caxa --input . --output ${{ matrix.settings.target != 'x86_64-pc-windows-msvc' && 'ironfish' || 'ironfish.exe' }} -- "{{caxa}}/node_modules/.bin/node" "--enable-source-maps" "{{caxa}}/node_modules/.bin/ironfish"
+        id: caxa
+        run: |
+          npx caxa --uncompression-message "Running the CLI for the first time may take a while, please wait..." --input . --output "${{ matrix.settings.system != 'windows' && 'ironfish' || 'ironfish.exe' }}" -- "{{caxa}}/node_modules/.bin/node" "--enable-source-maps" "{{caxa}}/node_modules/ironfish/bin/run"
+          echo "RELEASE_NAME=ironfish-${{ matrix.settings.system }}-${{ matrix.settings.arch }}-${{ github.event.release.tag_name }}.zip"
+      
+      - name: set paths
+        id: set_paths
+        shell: bash
+        run: |
+          echo "zip=ironfish-${{ matrix.settings.system }}-${{ matrix.settings.arch }}-${{ github.event.release.tag_name }}.zip" >> $GITHUB_OUTPUT
+          echo "binary=${{ matrix.settings.system != 'windows' && 'ironfish' || 'ironfish.exe' }}" >> $GITHUB_OUTPUT
 
-      - name: Tar files
-        run: tar -cvf ironfish.tar ironfish
+      - name: chmod binary
+        if: matrix.settings.system != 'windows'
+        run: chmod +x ${{ steps.set_paths.outputs.binary }}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: Zip binary
+        uses: thedoctor0/zip-release@0.7.1
         with:
-          name: binary-${{ matrix.settings.target }}
-          path: ironfish.tar
-          if-no-files-found: error
+          type: 'zip'
+          filename: ${{ steps.set_paths.outputs.zip }}
+          path: ${{ steps.set_paths.outputs.binary }}
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: "${{ github.event.release.upload_url }}?name=${{ steps.set_paths.outputs.zip }}"
+          asset_path: ${{ steps.set_paths.outputs.zip }}
+          asset_name: ${{ steps.set_paths.outputs.zip }}
+          asset_content_type: application/zip

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,0 +1,60 @@
+name: Build @ironfish binaries
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          # - host: ubuntu-20.04
+          #   target: x86_64-apple-darwin
+
+          # - host: windows-latest
+          #   target: x86_64-pc-windows-msvc
+
+          # - host: ubuntu-20.04
+          #   target: aarch64-apple-darwin
+
+          # requires 20.04 because ironfish depends on openssl 1.1.1, new ubuntu only allows 3.x
+          - host: ubuntu-20.04
+            target: x86_64-unknown-linux-musl
+
+          - host: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+
+          - host: ubuntu-20.04
+            target: aarch64-unknown-linux-musl
+
+    name: Build ${{ matrix.settings.target }}
+    runs-on: ${{ matrix.settings.host }}
+    steps:
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.12.1'
+
+      - name: npm init
+        run: npm init -y
+      
+      - name: install dependencies
+        run: npm install ironfish caxa@3.0.1
+
+      - name: caxa package
+        run: npx caxa --input . --output ${{ matrix.settings.target != 'x86_64-pc-windows-msvc' && 'ironfish' || 'ironfish.exe' }} -- "{{caxa}}/node_modules/.bin/node" "--enable-source-maps" "{{caxa}}/node_modules/.bin/ironfish"
+
+      - name: Tar files
+        run: tar -cvf ironfish.tar ironfish
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: binary-${{ matrix.settings.target }}
+          path: ironfish.tar
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
Uses `caxa` library to package `ironfish` cli into single executable binary.

Currently codesigning is not functional because of the way that caxa packages files onto the end of the `go` generated binary.

Testing artifact upload url was done by hardcoding this URL:
`# upload_url: https://uploads.github.com/repos/iron-fish/ironfish/releases/111185314/assets?name=${{ steps.set_paths.outputs.zip }}`
## Testing Plan
Tested locally with `act` 
https://github.com/nektos/act
Used command:
`act --artifact-server-path /tmp/artifacts --container-architecture linux/amd64 -W .github/workflows/publish-binaries.yml`


Tested binary on local machines:

Linux
```
blue@blue-Standard-PC-Q35-ICH9-2009:~/Downloads$ wget https://release.ironfish.network/0.1.76/linux_amd64/ironfish
--2023-04-17 15:42:27--  https://release.ironfish.network/0.1.76/linux_amd64/ironfish
Resolving release.ironfish.network (release.ironfish.network)... 104.26.14.240, 104.26.15.240, 172.67.68.233, ...
Connecting to release.ironfish.network (release.ironfish.network)|104.26.14.240|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 246686774 (235M)
Saving to: ‘ironfish.1’

ironfish.1          100%[===================>] 235.26M  44.4MB/s    in 5.5s    

2023-04-17 15:42:33 (42.9 MB/s) - ‘ironfish.1’ saved [246686774/246686774]

blue@blue-Standard-PC-Q35-ICH9-2009:~/Downloads$ chmod 777 ironfish
blue@blue-Standard-PC-Q35-ICH9-2009:~/Downloads$ ./ironfish wallet:create
Enter the name of the account: foo
Creating account foo
Account foo created with public address 33b4321f449300ab1284562a098e9ea222d284fb7d7a6757bee3e72f11c20b6e
The default account is now: foo
```

Windows
```
PS C:\Users\jowpa> wget https://release.ironfish.network/0.1.76/windows_x86_64/ironfish.exe -OutFile ironfish.exe
PS C:\Users\jowpa> .\ironfish.exe wallet:create
Enter the name of the account:
Enter the name of the account: asd
Creating account asd
Account asd created with public address de48da790cb6f1f43767bfd3b386ea7281cb6c87276e66d49591d3826720e938

Run "ironfish wallet:use asd" to set the account as defaulthere or scroll down to learn more
```

macOS
```

```
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
