### PR TITLE
Remove async init from node filesystem

### DIFF
--- a/ironfish/src/fileStores/fileStore.test.ts
+++ b/ironfish/src/fileStores/fileStore.test.ts
@@ -8,7 +8,7 @@ import { FileStore } from './fileStore'
 describe('FileStore', () => {
   it('should load file store', async () => {
     const dir = getUniqueTestDataDir()
-    const files = await new NodeFileProvider().init()
+    const files = new NodeFileProvider()
 
     const store = new FileStore<{ foo: string }>(files, 'test', dir)
     await store.save({ foo: 'hello' })

--- a/ironfish/src/fileStores/keyStore.test.ts
+++ b/ironfish/src/fileStores/keyStore.test.ts
@@ -9,7 +9,7 @@ import { KeyStore } from './keyStore'
 describe('KeyStore', () => {
   it('should load file store', async () => {
     const dir = getUniqueTestDataDir()
-    const files = await new NodeFileProvider().init()
+    const files = new NodeFileProvider()
 
     const store = new KeyStore<{ foo: string }>(files, 'store', { foo: 'bar' }, dir)
 
@@ -24,7 +24,7 @@ describe('KeyStore', () => {
 
   it('should validate schema in load', async () => {
     const dir = getUniqueTestDataDir()
-    const files = await new NodeFileProvider().init()
+    const files = new NodeFileProvider()
 
     const schema = yup
       .object({
@@ -42,7 +42,7 @@ describe('KeyStore', () => {
 
   it('should use schema result in load', async () => {
     const dir = getUniqueTestDataDir()
-    const files = await new NodeFileProvider().init()
+    const files = new NodeFileProvider()
 
     const schema = yup
       .object({
@@ -61,9 +61,9 @@ describe('KeyStore', () => {
     expect(store2.get('foo')).toEqual('hello')
   })
 
-  it('should validate schema in set', async () => {
+  it('should validate schema in set', () => {
     const dir = getUniqueTestDataDir()
-    const files = await new NodeFileProvider().init()
+    const files = new NodeFileProvider()
 
     const schema = yup
       .object({
@@ -78,9 +78,9 @@ describe('KeyStore', () => {
     )
   })
 
-  it('should use schema result in set', async () => {
+  it('should use schema result in set', () => {
     const dir = getUniqueTestDataDir()
-    const files = await new NodeFileProvider().init()
+    const files = new NodeFileProvider()
 
     const schema = yup
       .object({
@@ -96,7 +96,7 @@ describe('KeyStore', () => {
 
   it('isSet should return false when default config used', async () => {
     const dir = getUniqueTestDataDir()
-    const files = await new NodeFileProvider().init()
+    const files = new NodeFileProvider()
 
     // Not set
     let store = new KeyStore<{ foo: string }>(files, 'store', { foo: '' }, dir)
@@ -116,7 +116,7 @@ describe('KeyStore', () => {
 
   it('should save when put matches default', async () => {
     const dir = getUniqueTestDataDir()
-    const files = await new NodeFileProvider().init()
+    const files = new NodeFileProvider()
 
     let store = new KeyStore<{ foo: string }>(files, 'store', { foo: 'default' }, dir)
     expect(store.isSet('foo')).toBe(false)

--- a/ironfish/src/fileSystems/fileSystem.ts
+++ b/ironfish/src/fileSystems/fileSystem.ts
@@ -4,7 +4,6 @@
 import type fs from 'fs'
 
 export abstract class FileSystem {
-  abstract init(): Promise<FileSystem>
   abstract access(path: fs.PathLike, mode?: number | undefined): Promise<void>
   abstract writeFile(
     path: string,

--- a/ironfish/src/logger/reporters/file.ts
+++ b/ironfish/src/logger/reporters/file.ts
@@ -5,24 +5,19 @@
 // The reporter intentionally logs to the console, so disable the lint
 /* eslint-disable no-console */
 
-import type fs from 'fs'
 import { ConsolaReporterLogObject } from 'consola'
-import { Assert } from '../../assert'
-import { NodeFileProvider } from '../../fileSystems'
+import fs from 'fs'
 import { TextReporter } from './text'
 
 export class FileReporter extends TextReporter {
-  fs: NonNullable<NodeFileProvider['fsSync']>
   stream: fs.WriteStream
 
-  constructor(fs: NodeFileProvider, path: string) {
+  constructor(path: string) {
     super()
 
     this.colorEnabled = false
 
-    Assert.isNotNull(fs.fsSync)
-    this.fs = fs.fsSync
-    this.stream = this.fs.createWriteStream(path, { flags: 'a' })
+    this.stream = fs.createWriteStream(path, { flags: 'a' })
   }
 
   logText(logObj: ConsolaReporterLogObject, args: unknown[]): void {

--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -19,7 +19,6 @@ describe('poolDatabase', () => {
     logger.level = LogLevel.Silent
     const dataDir = getUniqueTestDataDir()
     const fileSystem = new NodeFileProvider()
-    await fileSystem.init()
     // TODO(mat): It would be convenient if we didn't need a filesystem for Config for tests
     const config = new Config(fileSystem, dataDir)
 

--- a/ironfish/src/mining/poolDatabase/database.ts
+++ b/ironfish/src/mining/poolDatabase/database.ts
@@ -27,7 +27,6 @@ export class PoolDatabase {
     dbPath?: string
   }): Promise<PoolDatabase> {
     const fs = new NodeFileProvider()
-    await fs.init()
 
     const poolFolder = fs.join(options.config.dataDir, '/pool')
     await fs.mkdir(poolFolder, { recursive: true })

--- a/ironfish/src/network/testUtilities/mockHostsStore.ts
+++ b/ironfish/src/network/testUtilities/mockHostsStore.ts
@@ -11,19 +11,6 @@ import { PeerAddress } from '../peers/peerAddress'
  */
 
 class MockFileSystem extends FileSystem {
-  fsSync: typeof import('fs') | null = null
-  fs: typeof import('fs').promises | null = null
-  path: typeof import('path') | null = null
-  os: typeof import('os') | null = null
-
-  async init(): Promise<FileSystem> {
-    this.fsSync = await import('fs')
-    this.path = await import('path')
-    this.os = await import('os')
-    this.fs = this.fsSync.promises
-    return this
-  }
-
   // eslint-disable-next-line @typescript-eslint/require-await
   async access(): Promise<void> {
     throw new Error('File does not exist')

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -24,7 +24,6 @@ describe('IronfishSdk', () => {
       const dataDir = os.tmpdir()
 
       const fileSystem = new NodeFileProvider()
-      await fileSystem.init()
 
       const sdk = await IronfishSdk.init({
         configName: 'foo.config.json',
@@ -50,7 +49,6 @@ describe('IronfishSdk', () => {
 
     it('should create a node', async () => {
       const fileSystem = new NodeFileProvider()
-      await fileSystem.init()
 
       const sdk = await IronfishSdk.init({
         configName: 'foo.config.json',
@@ -68,7 +66,6 @@ describe('IronfishSdk', () => {
 
     it('should initialize an SDK with the default dataDir if none is passed in', async () => {
       const fileSystem = new NodeFileProvider()
-      await fileSystem.init()
 
       const sdk = await IronfishSdk.init({
         configName: 'foo.config.json',

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -96,7 +96,6 @@ export class IronfishSdk {
     if (!fileSystem) {
       if (runtime.type === 'node') {
         fileSystem = new NodeFileProvider()
-        await fileSystem.init()
       } else {
         throw new Error(`No default fileSystem for ${String(runtime)}`)
       }
@@ -135,9 +134,9 @@ export class IronfishSdk {
 
     const logFile = config.get('enableLogFile')
 
-    if (logFile && fileSystem instanceof NodeFileProvider && fileSystem.path) {
-      const path = fileSystem.path.join(config.dataDir, 'ironfish.log')
-      const fileLogger = new FileReporter(fileSystem, path)
+    if (logFile && fileSystem instanceof NodeFileProvider) {
+      const path = fileSystem.join(config.dataDir, 'ironfish.log')
+      const fileLogger = new FileReporter(path)
       logger.addReporter(fileLogger)
     }
 


### PR DESCRIPTION
## Summary
This seems like just legacy code of awaiting imports so removing it and using default node libraries.

## Testing Plan
Running unit tests and running node. Also tested out outputting logs to a file

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
