### PR TITLE
Updated GH Actions to not use NodeJS 12

### DIFF
--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Ironfish CLI Build
         id: cache-ironfish-cli-build
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ironfish-cli/build.cli/ironfish-cli.tar.gz
           key: ${{ github.sha }}

--- a/.github/workflows/deploy-node-docker-image.yml
+++ b/.github/workflows/deploy-node-docker-image.yml
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
+++ b/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm install --no-workspaces
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: ironfish-rust-nodejs/artifacts
 

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -83,7 +83,7 @@ jobs:
 
       # Upload code coverage to Codecov
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-rust
@@ -109,7 +109,7 @@ jobs:
 
       # Upload code coverage to Codecov
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: ironfish-zkp


### PR DESCRIPTION
## Summary
NodeJS 12 is being [deprecated in Github actions soon](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). Upgrading our dependencies that use it to not use NodeJS 12 anymore

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
