### PR TITLE
addresses zero division errors in Target calculation

### DIFF
--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -237,7 +237,7 @@ export class BlockHeader {
    * repeatedly.
    */
   verifyTarget(): boolean {
-    return Target.meets(new Target(this.recomputeHash()).asBigInt(), this.target)
+    return Target.meets(BigIntUtils.fromBytesBE(this.recomputeHash()), this.target)
   }
 
   equals(other: BlockHeader): boolean {

--- a/ironfish/src/primitives/target.test.ts
+++ b/ironfish/src/primitives/target.test.ts
@@ -223,6 +223,10 @@ describe('Calculate target', () => {
     it('does not return values outside the 256 bit range', () => {
       expect(Target.fromDifficulty(1n).targetValue).toBeLessThanOrEqual(2n ** 256n - 1n)
     })
+
+    it('returns the maximum target for difficulty below the minimum', () => {
+      expect(Target.fromDifficulty(Target.minDifficulty() - 1n)).toEqual(Target.maxTarget())
+    })
   })
 
   describe('toDifficulty', () => {

--- a/ironfish/src/primitives/target.test.ts
+++ b/ironfish/src/primitives/target.test.ts
@@ -214,4 +214,20 @@ describe('Calculate target', () => {
       expect(newTarget).toEqual(maximallyDifferentTarget)
     }
   })
+
+  describe('fromDifficulty', () => {
+    it('does not divide by zero', () => {
+      expect(() => Target.fromDifficulty(0n)).not.toThrow(RangeError)
+    })
+
+    it('does not return values outside the 256 bit range', () => {
+      expect(Target.fromDifficulty(1n).targetValue).toBeLessThanOrEqual(2n ** 256n - 1n)
+    })
+  })
+
+  describe('toDifficulty', () => {
+    it('does not divide by zero', () => {
+      expect(Target.minTarget().toDifficulty).not.toThrow(RangeError)
+    })
+  })
 })

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -142,8 +142,8 @@ export class Target {
    * Converts difficulty to Target
    */
   static fromDifficulty(difficulty: bigint): Target {
-    if (difficulty <= 1n) {
-      return new Target(MAX_256_BIT_NUM)
+    if (difficulty <= Target.minDifficulty()) {
+      return Target.maxTarget()
     }
     return new Target((2n ** 256n / difficulty).valueOf())
   }

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -152,8 +152,8 @@ export class Target {
    * Return the difficulty representation as a big integer
    */
   toDifficulty(): bigint {
-    if (this.targetValue === 0n) {
-      return 2n ** 256n + 1n
+    if (this.targetValue <= 1n) {
+      return MAX_256_BIT_NUM
     }
     return 2n ** 256n / this.targetValue
   }

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -142,7 +142,7 @@ export class Target {
    * Converts difficulty to Target
    */
   static fromDifficulty(difficulty: bigint): Target {
-    if (difficulty === 1n) {
+    if (difficulty <= 1n) {
       return new Target(MAX_256_BIT_NUM)
     }
     return new Target((2n ** 256n / difficulty).valueOf())
@@ -152,6 +152,9 @@ export class Target {
    * Return the difficulty representation as a big integer
    */
   toDifficulty(): bigint {
+    if (this.targetValue === 0n) {
+      return 2n ** 256n + 1n
+    }
     return 2n ** 256n / this.targetValue
   }
 


### PR DESCRIPTION
## Summary

- fromDifficulty: division by zero when difficulty is 0
- toDifficulty: division by zero when target is 0

any difficulty value > 2**256 will give a target value of 0

note: ethereum uses the same calculation (2**256 / difficulty) for target, but some ethereum implementations (e.g., cpp-ethereum) used a 256-bit integer to store difficulty in the block header, which made a target of 0 impossible.

## Testing Plan

- adds unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
