### PR TITLE
fix: libc reference failing in android

### DIFF
--- a/ironfish-rust/src/signal_catcher.rs
+++ b/ironfish-rust/src/signal_catcher.rs
@@ -9,7 +9,7 @@ extern "C" {
 
 /// # Safety
 /// This is unsafe, it calls libc functions
-#[cfg(all(unix, target_env = "musl"))]
+#[cfg(any(all(unix, target_env = "musl"), target_os = "android"))]
 unsafe fn display_trace() {
     libc::exit(libc::EXIT_FAILURE);
 }


### PR DESCRIPTION
## Summary
This was the only failure in cargo build, excluding android os as well.

## Testing Plan
tests pass

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
