### PR TITLE
feat: airdrop split command

### DIFF
--- a/ironfish-cli/src/commands/airdrop/constants.ts
+++ b/ironfish-cli/src/commands/airdrop/constants.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export const AIRDROP_NOTES_IN_BLOCK = 600
+export const FEE_ORE_PER_AIRDROP = 10n

--- a/ironfish-cli/src/commands/airdrop/split.ts
+++ b/ironfish-cli/src/commands/airdrop/split.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Flags } from '@oclif/core'
+import fs from 'fs/promises'
+import { IronfishCommand } from '../../command'
+import { LocalFlags } from '../../flags'
+import { parseAllocationsFile } from '../../utils/allocations'
+import { AIRDROP_NOTES_IN_BLOCK, FEE_ORE_PER_AIRDROP } from './constants'
+
+export default class AirdropSplit extends IronfishCommand {
+  static aliases = ['airdrop:split']
+  static hidden = true
+
+  static flags = {
+    ...LocalFlags,
+    account: Flags.string({
+      required: true,
+      description: 'The name of the account to use for sending airdrop',
+    }),
+    allocations: Flags.string({
+      required: true,
+      description:
+        'A CSV file with the format address,amountInOre,memo containing airdrop allocations',
+    }),
+    output: Flags.string({
+      required: false,
+      default: 'split_transaction.txt',
+      description: 'A serialized raw transaction for splitting originating note',
+    }),
+  }
+  async start(): Promise<void> {
+    const { flags } = await this.parse(AirdropSplit)
+    const account = flags.account
+
+    const csv = await fs.readFile(flags.allocations, 'utf-8')
+    const result = parseAllocationsFile(csv)
+
+    if (!result.ok) {
+      this.error(result.error)
+    }
+    const client = await this.sdk.connectRpc()
+    const publicKey = (await client.getAccountPublicKey({ account })).content.publicKey
+    const allocations = result.allocations
+
+    const outputs = []
+    for (let i = 0; i < allocations.length; i += AIRDROP_NOTES_IN_BLOCK) {
+      const chunk = allocations.slice(i, i + AIRDROP_NOTES_IN_BLOCK)
+      const ore = chunk.reduce(
+        (reduceMemo, { amountInOre }) => amountInOre + reduceMemo,
+        // base fee for the airdrop notes
+        BigInt(AIRDROP_NOTES_IN_BLOCK) * FEE_ORE_PER_AIRDROP,
+      )
+      outputs.push({
+        publicAddress: publicKey,
+        amount: ore.toString(),
+        memo: '',
+      })
+    }
+    const transaction = await client.createTransaction({
+      account,
+      outputs,
+      // uses dust from flooring airdrop
+      fee: '10',
+    })
+    await fs.writeFile(flags.output, transaction.content.transaction)
+  }
+}

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -1,14 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { MEMO_LENGTH } from '@ironfish/rust-nodejs'
 import {
   BlockSerde,
   CurrencyUtils,
   GenesisBlockAllocation,
   GenesisBlockInfo,
   IJSON,
-  isValidPublicAddress,
   makeGenesisBlock,
   Target,
 } from '@ironfish/sdk'
@@ -16,6 +14,7 @@ import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs/promises'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
+import { parseAllocationsFile } from '../../utils/allocations'
 
 export default class GenesisBlockCommand extends IronfishCommand {
   static description = 'Create and serialize a genesis block'
@@ -199,60 +198,4 @@ const getDuplicates = (allocations: readonly GenesisBlockAllocation[]): string[]
   }
 
   return [...duplicateSet]
-}
-
-const parseAllocationsFile = (
-  fileContent: string,
-): { ok: true; allocations: GenesisBlockAllocation[] } | { ok: false; error: string } => {
-  const allocations: GenesisBlockAllocation[] = []
-
-  let lineNum = 0
-  for (const line of fileContent.split(/[\r\n]+/)) {
-    lineNum++
-    if (line.trim().length === 0) {
-      continue
-    }
-
-    const [address, amountInIron, memo, ...rest] = line.split(',').map((v) => v.trim())
-
-    if (rest.length > 0) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) contains more than 3 values.`,
-      }
-    }
-
-    // Check address length
-    if (!isValidPublicAddress(address)) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) has an invalid public address.`,
-      }
-    }
-
-    // Check amount is positive and decodes as $IRON
-    const amountInOre = CurrencyUtils.decodeIron(amountInIron)
-    if (amountInOre < 0) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) contains a negative $IRON amount.`,
-      }
-    }
-
-    // Check memo length
-    if (Buffer.from(memo).byteLength > MEMO_LENGTH) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) contains a memo with byte length > ${MEMO_LENGTH}.`,
-      }
-    }
-
-    allocations.push({
-      publicAddress: address,
-      amountInOre: amountInOre,
-      memo: memo,
-    })
-  }
-
-  return { ok: true, allocations }
 }

--- a/ironfish-cli/src/utils/allocations.ts
+++ b/ironfish-cli/src/utils/allocations.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { MEMO_LENGTH } from '@ironfish/rust-nodejs'
+import { CurrencyUtils, GenesisBlockAllocation, isValidPublicAddress } from '@ironfish/sdk'
+
+export const parseAllocationsFile = (
+  fileContent: string,
+): { ok: true; allocations: GenesisBlockAllocation[] } | { ok: false; error: string } => {
+  const allocations: GenesisBlockAllocation[] = []
+
+  let lineNum = 0
+  for (const line of fileContent.split(/[\r\n]+/)) {
+    lineNum++
+    if (line.trim().length === 0) {
+      continue
+    }
+
+    const [address, amountInIron, memo, ...rest] = line.split(',').map((v) => v.trim())
+
+    if (rest.length > 0) {
+      return {
+        ok: false,
+        error: `Line ${lineNum}: (${line}) contains more than 3 values.`,
+      }
+    }
+
+    // Check address length
+    if (!isValidPublicAddress(address)) {
+      return {
+        ok: false,
+        error: `Line ${lineNum}: (${line}) has an invalid public address.`,
+      }
+    }
+
+    // Check amount is positive and decodes as $IRON
+    const amountInOre = CurrencyUtils.decodeIron(amountInIron)
+    if (amountInOre < 0) {
+      return {
+        ok: false,
+        error: `Line ${lineNum}: (${line}) contains a negative $IRON amount.`,
+      }
+    }
+
+    // Check memo length
+    if (Buffer.from(memo).byteLength > MEMO_LENGTH) {
+      return {
+        ok: false,
+        error: `Line ${lineNum}: (${line}) contains a memo with byte length > ${MEMO_LENGTH}.`,
+      }
+    }
+
+    allocations.push({
+      publicAddress: address,
+      amountInOre: amountInOre,
+      memo: memo,
+    })
+  }
+
+  return { ok: true, allocations }
+}


### PR DESCRIPTION
## Summary
Adds split command so that we can have pre-split notes for airdrop. Each airdrop transaction will contain all the ORE required for `AIRDROP_NOTES_IN_BLOCK` * FEE (10 ORE) plus the payouts for that transaction.
## Testing Plan
test in simulator

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
