### PR TITLE
feat: airdrop allocations to raw transactions

### DIFF
--- a/ironfish-cli/src/commands/airdrop/raw-transactions.ts
+++ b/ironfish-cli/src/commands/airdrop/raw-transactions.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { isValidPublicAddress } from '@ironfish/rust-nodejs'
+import { Flags } from '@oclif/core'
+import fs from 'fs/promises'
+import { IronfishCommand } from '../../command'
+import { LocalFlags } from '../../flags'
+import { parseAllocationsFile } from '../../utils/allocations'
+import { AIRDROP_NOTES_IN_BLOCK, FEE_ORE_PER_AIRDROP } from './constants'
+
+export default class AirdropRawTransactions extends IronfishCommand {
+  static aliases = ['airdrop:raw']
+  static hidden = true
+
+  static flags = {
+    ...LocalFlags,
+    account: Flags.string({
+      required: true,
+      description: 'The name of the account used to create raw transactions',
+    }),
+    allocations: Flags.string({
+      required: true,
+      description:
+        'A CSV file with the format address,amountInIron,memo containing genesis block allocations',
+    }),
+    raw: Flags.string({
+      required: false,
+      default: 'raw_transactions.txt',
+      description: 'where to output the raw transactions',
+    }),
+  }
+  async start(): Promise<void> {
+    const { flags } = await this.parse(AirdropRawTransactions)
+    const account = flags.account
+    const client = await this.sdk.connectRpc()
+
+    const csv = await fs.readFile(flags.allocations, 'utf-8')
+    const result = parseAllocationsFile(csv)
+
+    if (!result.ok) {
+      this.error(result.error)
+    }
+    const allocations = result.allocations
+
+    await fs.rm(flags.raw)
+    const fileHandle = await fs.open(flags.raw, 'a')
+
+    for (let i = 0; i < allocations.length; i += AIRDROP_NOTES_IN_BLOCK) {
+      const chunk = allocations.slice(i, i + AIRDROP_NOTES_IN_BLOCK)
+      const outputs = []
+      for (const output of chunk) {
+        if (!isValidPublicAddress(output.publicAddress)) {
+          this.warn(
+            `Invalid public address ${output.publicAddress} for user: ${output.memo}, skipping`,
+          )
+          continue
+        }
+        if (output.amountInOre < 1) {
+          this.warn(`Invalid amount ${output.amountInOre} for user: ${output.memo}, skipping`)
+          continue
+        }
+
+        outputs.push({
+          publicAddress: output.publicAddress,
+          amount: output.amountInOre.toString(),
+          memo: output.memo,
+        })
+      }
+
+      const fee = BigInt(AIRDROP_NOTES_IN_BLOCK) * FEE_ORE_PER_AIRDROP
+      const result = await client.wallet.createTransaction({
+        account,
+        outputs,
+        fee: String(fee),
+      })
+      await fs.appendFile(fileHandle, `${result.content.transaction}\n`)
+    }
+    await fileHandle.close()
+  }
+}

--- a/ironfish-cli/src/commands/airdrop/raw-transactions.ts
+++ b/ironfish-cli/src/commands/airdrop/raw-transactions.ts
@@ -45,7 +45,6 @@ export default class AirdropRawTransactions extends IronfishCommand {
 
     await fs.rm(flags.raw)
     const fileHandle = await fs.open(flags.raw, 'a')
-
     for (let i = 0; i < allocations.length; i += AIRDROP_NOTES_IN_BLOCK) {
       const chunk = allocations.slice(i, i + AIRDROP_NOTES_IN_BLOCK)
       const outputs = []
@@ -56,11 +55,6 @@ export default class AirdropRawTransactions extends IronfishCommand {
           )
           continue
         }
-        if (output.amountInOre < 1) {
-          this.warn(`Invalid amount ${output.amountInOre} for user: ${output.memo}, skipping`)
-          continue
-        }
-
         outputs.push({
           publicAddress: output.publicAddress,
           amount: output.amountInOre.toString(),
@@ -68,11 +62,10 @@ export default class AirdropRawTransactions extends IronfishCommand {
         })
       }
 
-      const fee = BigInt(AIRDROP_NOTES_IN_BLOCK) * FEE_ORE_PER_AIRDROP
-      const result = await client.wallet.createTransaction({
+      const result = await client.wallet.createTransactionAirdrop({
         account,
         outputs,
-        fee: String(fee),
+        fee: String(BigInt(AIRDROP_NOTES_IN_BLOCK) * FEE_ORE_PER_AIRDROP),
       })
       await fs.appendFile(fileHandle, `${result.content.transaction}\n`)
     }

--- a/ironfish-cli/src/commands/airdrop/split.ts
+++ b/ironfish-cli/src/commands/airdrop/split.ts
@@ -29,6 +29,7 @@ export default class AirdropSplit extends IronfishCommand {
       description: 'A serialized raw transaction for splitting originating note',
     }),
   }
+
   async start(): Promise<void> {
     const { flags } = await this.parse(AirdropSplit)
     const account = flags.account
@@ -40,7 +41,7 @@ export default class AirdropSplit extends IronfishCommand {
       this.error(result.error)
     }
     const client = await this.sdk.connectRpc()
-    const publicKey = (await client.getAccountPublicKey({ account })).content.publicKey
+    const publicKey = (await client.wallet.getAccountPublicKey({ account })).content.publicKey
     const allocations = result.allocations
 
     const outputs = []
@@ -57,7 +58,7 @@ export default class AirdropSplit extends IronfishCommand {
         memo: '',
       })
     }
-    const transaction = await client.createTransaction({
+    const transaction = await client.wallet.createTransaction({
       account,
       outputs,
       // uses dust from flooring airdrop

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -339,6 +339,15 @@ export abstract class RpcClient {
         params,
       ).waitForEnd()
     },
+
+    createTransactionAirdrop: (
+      params: CreateTransactionRequest,
+    ): Promise<RpcResponseEnded<CreateTransactionResponse>> => {
+      return this.request<CreateTransactionResponse>(
+        `${ApiNamespace.wallet}/createTransactionAirdrop`,
+        params,
+      ).waitForEnd()
+    },
   }
 
   mempool = {

--- a/ironfish/src/rpc/routes/wallet/createTransactionAirdrop.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransactionAirdrop.ts
@@ -1,0 +1,204 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
+import * as yup from 'yup'
+import { Assert } from '../../../assert'
+import { RawTransactionSerde } from '../../../primitives/rawTransaction'
+import { CurrencyUtils, YupUtils } from '../../../utils'
+import { Wallet } from '../../../wallet'
+import { NotEnoughFundsError } from '../../../wallet/errors'
+import { ERROR_CODES, ValidationError } from '../../adapters/errors'
+import { ApiNamespace, router } from '../router'
+import { getAccount } from './utils'
+
+export type CreateTransactionRequest = {
+  account: string
+  outputs: {
+    publicAddress: string
+    amount: string
+    memo: string
+    assetId?: string
+  }[]
+  mints?: {
+    assetId?: string
+    name?: string
+    metadata?: string
+    value: string
+  }[]
+  burns?: {
+    assetId: string
+    value: string
+  }[]
+  fee?: string | null
+  feeRate?: string | null
+  expiration?: number
+  expirationDelta?: number
+  confirmations?: number
+}
+
+export type CreateTransactionResponse = {
+  transaction: string
+}
+
+export const CreateTransactionRequestSchema: yup.ObjectSchema<CreateTransactionRequest> = yup
+  .object({
+    account: yup.string().defined(),
+    outputs: yup
+      .array(
+        yup
+          .object({
+            publicAddress: yup.string().defined(),
+            amount: YupUtils.currency({ min: 1n }).defined(),
+            memo: yup.string().defined(),
+            assetId: yup.string().optional(),
+          })
+          .defined(),
+      )
+      .defined(),
+    mints: yup
+      .array(
+        yup
+          .object({
+            assetId: yup.string().optional(),
+            name: yup.string().optional(),
+            metadata: yup.string().optional(),
+            value: YupUtils.currency({ min: 1n }).defined(),
+          })
+          .defined(),
+      )
+      .optional(),
+    burns: yup
+      .array(
+        yup
+          .object({
+            assetId: yup.string().defined(),
+            value: YupUtils.currency({ min: 1n }).defined(),
+          })
+          .defined(),
+      )
+      .optional(),
+    fee: YupUtils.currency({ min: 1n }).nullable().optional(),
+    feeRate: YupUtils.currency({ min: 1n }).nullable().optional(),
+    expiration: yup.number().optional(),
+    expirationDelta: yup.number().optional(),
+    confirmations: yup.number().optional(),
+  })
+  .defined()
+
+export const CreateTransactionResponseSchema: yup.ObjectSchema<CreateTransactionResponse> = yup
+  .object({
+    transaction: yup.string().defined(),
+  })
+  .defined()
+
+router.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse>(
+  `${ApiNamespace.wallet}/createTransactionAirdrop`,
+  CreateTransactionRequestSchema,
+  async (request, node): Promise<void> => {
+    const account = getAccount(node, request.data.account)
+
+    const params: Parameters<Wallet['createTransaction']>[0] = {
+      account: account,
+      confirmations: request.data.confirmations,
+      expiration: request.data.expiration,
+      expirationDelta: request.data.expirationDelta,
+    }
+
+    if (request.data.outputs) {
+      params.outputs = []
+
+      for (const output of request.data.outputs) {
+        params.outputs.push({
+          publicAddress: output.publicAddress,
+          amount: CurrencyUtils.decode(output.amount),
+          memo: output.memo,
+          assetId: output.assetId ? Buffer.from(output.assetId, 'hex') : Asset.nativeId(),
+        })
+      }
+    }
+
+    if (request.data.mints) {
+      params.mints = []
+
+      for (const mint of request.data.mints) {
+        if (mint.assetId == null && mint.name == null) {
+          throw new ValidationError('Must provide name or identifier to mint')
+        }
+
+        let name = mint.name
+        let metadata = mint.metadata ?? ''
+
+        if (mint.assetId) {
+          const assetId = Buffer.from(mint.assetId, 'hex')
+          const asset = await account.getAsset(assetId)
+
+          if (!asset) {
+            throw new ValidationError(`Error minting: Asset ${mint.assetId} not found.`)
+          }
+
+          name = asset.name.toString('utf8')
+          metadata = asset.metadata.toString('utf8')
+        }
+
+        Assert.isNotUndefined(name)
+        Assert.isNotUndefined(metadata)
+
+        params.mints.push({
+          name,
+          metadata,
+          value: CurrencyUtils.decode(mint.value),
+        })
+      }
+    }
+
+    if (request.data.burns) {
+      params.burns = []
+
+      for (const burn of request.data.burns) {
+        params.burns.push({
+          assetId: burn.assetId ? Buffer.from(burn.assetId, 'hex') : Asset.nativeId(),
+          value: CurrencyUtils.decode(burn.value),
+        })
+      }
+    }
+
+    if (request.data.fee) {
+      params.fee = CurrencyUtils.decode(request.data.fee)
+    } else if (request.data.feeRate) {
+      params.feeRate = CurrencyUtils.decode(request.data.feeRate)
+    } else {
+      params.feeRate = node.memPool.feeEstimator.estimateFeeRate('average')
+    }
+
+    try {
+      const transaction = await node.wallet.createTransaction(params)
+      for (const spend of transaction.spends) {
+        const decryptedNote = await account.getDecryptedNote(spend.note.hash())
+        Assert.isNotUndefined(
+          decryptedNote,
+          'Decrypted note that we are marking as spent was null.',
+        )
+        await node.wallet.walletDb.deleteUnspentNoteHash(
+          account,
+          spend.note.hash(),
+          decryptedNote,
+        )
+        await node.wallet.walletDb.saveDecryptedNote(account, spend.note.hash(), {
+          ...decryptedNote,
+          spent: true,
+        })
+      }
+      const serialized = RawTransactionSerde.serialize(transaction)
+
+      request.end({
+        transaction: serialized.toString('hex'),
+      })
+    } catch (e) {
+      if (e instanceof NotEnoughFundsError) {
+        throw new ValidationError(e.message, 400, ERROR_CODES.INSUFFICIENT_BALANCE)
+      }
+      throw e
+    }
+  },
+)


### PR DESCRIPTION
## Summary
Takes input allocations generated [from export](https://coda.io/d/_dMnayiE39lL/Airdrop_su_t8#_luHf9), bundles them based on max output notes per transaction, and writes them to file.
## Testing Plan
test in simulator
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
