### PR TITLE
feat: accept transactions response update

### DIFF
--- a/ironfish/src/rpc/routes/wallet/addTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.test.ts
@@ -41,6 +41,8 @@ describe('Route wallet/addTransaction', () => {
 
     expect(response.status).toBe(200)
     expect(response.content.accounts[0]).toBe(account.name)
+    expect(response.content.accepted).toBe(true)
+    expect(response.content.hash).toBe(transaction.hash().toString('hex'))
     expect(broadcastSpy).toHaveBeenCalled()
   })
 

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -14,6 +14,8 @@ export type AddTransactionRequest = {
 
 export type AddTransactionResponse = {
   accounts: string[]
+  hash: string
+  accepted: boolean
 }
 
 export const AddTransactionRequestSchema: yup.ObjectSchema<AddTransactionRequest> = yup
@@ -26,6 +28,8 @@ export const AddTransactionRequestSchema: yup.ObjectSchema<AddTransactionRequest
 export const AddTransactionResponseSchema: yup.ObjectSchema<AddTransactionResponse> = yup
   .object({
     accounts: yup.array(yup.string().defined()).defined(),
+    hash: yup.string().defined(),
+    accepted: yup.boolean().defined(),
   })
   .defined()
 
@@ -57,7 +61,7 @@ router.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
       )
     }
 
-    node.memPool.acceptTransaction(transaction)
+    const accepted = node.memPool.acceptTransaction(transaction)
 
     if (request.data.broadcast) {
       node.wallet.broadcastTransaction(transaction)
@@ -65,6 +69,8 @@ router.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
 
     request.end({
       accounts: accounts.map((a) => a.name),
+      hash: transaction.hash().toString('hex'),
+      accepted,
     })
   },
 )


### PR DESCRIPTION
## Summary
Currently we have no info returned from RPC about the transaction that was added, this adds both if the transaction was accepted and what the hash is.
## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
