### PR TITLE
refactor(ironfish): do not quit transaction:watch if the transaction is not found

### DIFF
--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -35,7 +35,7 @@ export async function watchTransaction(options: {
 
   const startTime = lastTime
 
-  let prevStatus = last?.content.transaction?.status ?? TransactionStatus.NOT_FOUND
+  let prevStatus = last?.content.transaction?.status ?? 'not found'
   let currentStatus = prevStatus
 
   CliUx.ux.action.start(`Current Status`)
@@ -60,12 +60,9 @@ export async function watchTransaction(options: {
       confirmations: options.confirmations,
     })
 
-    currentStatus = response?.content.transaction?.status ?? TransactionStatus.NOT_FOUND
+    currentStatus = response?.content.transaction?.status ?? 'not found'
 
-    if (
-      prevStatus !== TransactionStatus.NOT_FOUND &&
-      currentStatus === TransactionStatus.NOT_FOUND
-    ) {
+    if (prevStatus !== 'not found' && currentStatus === 'not found') {
       CliUx.ux.action.stop(`Transaction ${options.hash} deleted while watching it.`)
       break
     }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -54,7 +54,6 @@ export enum AssetStatus {
 }
 
 export enum TransactionStatus {
-  NOT_FOUND = 'not found',
   CONFIRMED = 'confirmed',
   EXPIRED = 'expired',
   PENDING = 'pending',

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -54,6 +54,7 @@ export enum AssetStatus {
 }
 
 export enum TransactionStatus {
+  NOT_FOUND = 'not found',
   CONFIRMED = 'confirmed',
   EXPIRED = 'expired',
   PENDING = 'pending',


### PR DESCRIPTION
## Summary
`ironfish wallet:transactions:watch` no longer quits if the transaction is not found. The `NOT_FOUND` state has been added as a `TransactionStatus` and is now integrated into the watch status loop 


Closes IFL-413

## Testing Plan
Successful watch:
```
➜  ironfish git:(holahula/fix/transaction-watch-404) ✗ fish wallet:send -d ~/.ironfish-simulator/node-e050 --watch
yarn run v1.22.19
$ yarn build && yarn start:js wallet:send -d /Users/austino/.ironfish-simulator/node-e050 --watch
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:send -d /Users/austino/.ironfish-simulator/node-e050 --watch
Enter the amount (balance 48405.00000000): 1
Enter the public address of the recipient: beb858a08898867fa7917c45f4ff6c5c67cb590dc654204330b0b69cc647ef1f
? Select the fee you wish to use for this transaction Enter a custom fee
Enter the fee amount in $IRON (balance 48405.00000000): 1
You are about to send a transaction: $IRON 1.00000000 plus a transaction fee of $IRON 1.00000000 to beb858a08898867fa7917c45f4ff6c5c67cb590dc654204330b0b69cc647ef1f from the account default
Do you confirm (Y/N)?: Y
Sending the transaction... done
Sent $IRON 1.00000000 to beb858a08898867fa7917c45f4ff6c5c67cb590dc654204330b0b69cc647ef1f from default
Hash: 7e9ae0a153e0b6bc8375c67ee5be8f62f6a715144461656ab76b676b098a2fc4
Fee: $IRON 1.00000000

If the transaction is mined, it will appear here https://explorer.ironfish.network/transaction/7e9ae0a153e0b6bc8375c67ee5be8f62f6a715144461656ab76b676b098a2fc4

{"level":2,"tag":"wallet:send","date":"2023-04-05T17:07:23.987Z","message":"Watching transaction 7e9ae0a153e0b6bc8375c67ee5be8f62f6a715144461656ab76b676b098a2fc4"}
Current Status... pending -> unconfirmed: 20s
Current Status... unconfirmed -> confirmed: 10s
Current Status... done after 30s
✨  Done in 53.00s.
```

If txn not found, then `watchTransaction()` loop forever
```
➜  ironfish git:(holahula/fix/transaction-watch-404) ✗ fish wallet:transaction:watch abc -d ~/.ironfish-simulator/node-75d5
yarn run v1.22.19
$ yarn build && yarn start:js wallet:transaction:watch abc -d /Users/austino/.ironfish-simulator/node-75d5
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:transaction:watch abc -d /Users/austino/.ironfish-simulator/node-75d5
{"level":2,"tag":"wallet:transaction:watch","date":"2023-04-05T17:11:56.931Z","message":"Watching transaction abc"}
Current Status... ⢿ not found 20s
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
