### PR TITLE
refactor: expose last rebroadcast time in wallet/getTransaction

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -187,6 +187,9 @@ export class TransactionsCommand extends IronfishCommand {
       expiration: {
         header: 'Expiration',
       },
+      submittedSequence: {
+        header: 'Submitted Sequence',
+      },
       feePaid: {
         header: 'Fee Paid ($IRON)',
         get: (row) =>
@@ -246,4 +249,5 @@ type TransactionRow = {
   mintsCount: number
   burnsCount: number
   expiration: number
+  submittedSequence: number
 }

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -15,6 +15,7 @@ export type RpcAccountTransaction = {
   burnsCount: number
   expiration: number
   timestamp: number
+  submittedSequence: number
 }
 
 export type RcpAccountAssetBalanceDelta = {
@@ -48,6 +49,7 @@ export function serializeRpcAccountTransaction(
     burnsCount: transaction.transaction.burns.length,
     expiration: transaction.transaction.expiration(),
     timestamp: transaction.timestamp.getTime(),
+    submittedSequence: transaction.submittedSequence,
   }
 }
 


### PR DESCRIPTION
## Summary
Exposes the last rebroadcast time in `wallet/getTransaction`. The field is named `submittedSequence` in the `TransactionValue` interface so the naming convention was kept. 

## Testing Plan
Existing tests

```
➜  ironfish git:(holahula/feat/expose-rebroadcast-time) ✗ fish wallet:transactions -d ~/.ironfish-simulator/node-b1f0 --limit 5 -t ccc358844370ab9f77dd1b1ef9b1beafceddb3c23a933b950315f4602afbb604 -x
yarn run v1.22.19
$ yarn build && yarn start:js wallet:transactions -d /Users/austino/.ironfish-simulator/node-b1f0 --limit 5 -t ccc358844370ab9f77dd1b1ef9b1beafceddb3c23a933b950315f4602afbb604 -x
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:transactions -d /Users/austino/.ironfish-simulator/node-b1f0 --limit 5 -t ccc358844370ab9f77dd1b1ef9b1beafceddb3c23a933b950315f4602afbb604 -x
    Timestamp                   Status      Type    Hash                            Notes Spends Mints Burns Expiration Submitted Sequence Fee Paid ($IRON) Asset ID                         Asset Name                       Net Amount
 ── ─────────────────────────── ─────────── ─────── ─────────────────────────────── ───── ────── ───── ───── ────────── ────────────────── ──────────────── ──────────────────────────────── ──────────────────────────────── ───────────────
    4/3/2023 5:15:50 p.m. EDT   pending     send    ccc358844370ab9f77dd1b1ef9b1be… 2     1      0     0     40         29                 1.00000000       d7c86706f5817aa718cd1cfad03233b… $IRON                            -1.00000000
✨  Done in 3.52s.
```

Log message from `wallet/getTransactions/getAccountTransactions`
```
{
  transaction: Transaction {
    transactionPosted: null,
    referenceCount: 0,
    transactionPostedSerialized: <Buffer 01 01 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 e1 f5 05 00 00 00 00 28 00 00 00 a2 01 47 41 0f ... 1487 more bytes>,
    _version: 1,
    _fee: 100000000n,
    _expiration: 40,
    spends: [ [Object] ],
    notes: [ [NoteEncrypted], [NoteEncrypted] ],
    mints: [],
    burns: [],
    _signature: <Buffer 0b b1 ed 40 94 de 0f 4a 20 61 32 d3 67 4d 01 3c ff 4e 34 f3 98 4e fa df 03 a7 1a 9d 03 43 bf ce ac 14 85 41 d7 f1 4c 78 f6 06 1c 63 81 c1 05 b1 4b 83 ... 14 more bytes>
  },
  blockHash: null,
  submittedSequence: 29,
  sequence: null,
  timestamp: 2023-04-03T21:15:50.508Z,
  assetBalanceDeltas: Map(1) {
    'd7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6' => -200000000n
  }
}
```
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
[X] No
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
