### PR TITLE
Switch R2 to use prod endpoint

### DIFF
--- a/ironfish-cli/src/commands/ceremony/service.ts
+++ b/ironfish-cli/src/commands/ceremony/service.ts
@@ -26,7 +26,7 @@ export default class CeremonyService extends IronfishCommand {
       char: 'b',
       parse: (input: string) => Promise.resolve(input.trim()),
       required: false,
-      description: 'S3 bucket to download and upload params to',
+      description: 'S3/R2 bucket to download and upload params to',
       default: 'ironfish-contributions',
     }),
     downloadPrefix: Flags.string({
@@ -34,8 +34,7 @@ export default class CeremonyService extends IronfishCommand {
       parse: (input: string) => Promise.resolve(input.trim()),
       required: false,
       description: 'Prefix for contribution download URLs',
-      // TODO: update this to non-dev endpoint to avoid rate limiting
-      default: 'https://pub-6a239e04e140459087cf392ffc3245b1.r2.dev',
+      default: 'https://contributions.ironfish.network',
     }),
     contributionTimeoutMs: Flags.integer({
       required: false,
@@ -49,7 +48,8 @@ export default class CeremonyService extends IronfishCommand {
     }),
     presignedExpirationSec: Flags.integer({
       required: false,
-      description: 'How many seconds the S3 pre-signed upload URL is valid for a contributor',
+      description:
+        'How many seconds the S3/R2 pre-signed upload URL is valid for a contributor',
       default: PRESIGNED_EXPIRATION_SEC,
     }),
     startDate: Flags.integer({


### PR DESCRIPTION
## Summary
Switching to a production endpoint that does not have inherent rate limiting

## Testing Plan
Local testing of contributions

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
