### PR TITLE
Add private queue for trusted setup

### DIFF
--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -281,14 +281,15 @@ export class CeremonyServer {
           return
         }
 
+        client.join(parsedMessage.name)
+
         if (parsedMessage.token === this.token) {
           this.privateQueue.push(client)
+          client.send(this.getJoinedMessage(this.privateQueue.length))
         } else {
           this.queue.push(client)
+          client.send(this.getJoinedMessage(this.totalQueueLength()))
         }
-
-        client.join(parsedMessage.name)
-        client.send(this.getJoinedMessage(this.totalQueueLength()))
 
         client.logger.info(
           `(Connected) public: ${this.queue.length}, private: ${this.privateQueue.length}`,

--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -88,7 +88,8 @@ export class CeremonyServer {
 
   readonly tempDir: string
 
-  private queue: CeremonyServerClient[]
+  private queue: CeremonyServerClient[] = []
+  private privateQueue: CeremonyServerClient[] = []
 
   private currentContributor: CurrentContributor | null = null
 
@@ -117,7 +118,6 @@ export class CeremonyServer {
     enableIPBanning: boolean
   }) {
     this.logger = options.logger
-    this.queue = []
 
     this.host = options.host
     this.port = options.port
@@ -149,6 +149,10 @@ export class CeremonyServer {
     return validParams[validParams.length - 1]
   }
 
+  totalQueueLength(): number {
+    return this.queue.length + this.privateQueue.length
+  }
+
   closeClient(client: CeremonyServerClient, error?: Error, disconnect = false): void {
     if (this.currentContributor?.client?.id === client.id) {
       if (this.currentContributor.state === 'VERIFYING') {
@@ -171,7 +175,7 @@ export class CeremonyServer {
       return
     }
 
-    const nextClient = this.queue.shift()
+    const nextClient = this.privateQueue.shift() || this.queue.shift()
     if (!nextClient) {
       return
     }
@@ -224,31 +228,29 @@ export class CeremonyServer {
 
     socket.on('data', (data: Buffer) => void this.onData(client, data))
     socket.on('close', () => this.onDisconnect(client))
-    socket.on('error', (e) => this.onError(client, e))
+    socket.on('error', (e) => this.onDisconnect(client, e))
 
     const ip = socket.remoteAddress
     if (
       this.enableIPBanning &&
       (ip === undefined ||
         this.queue.find((c) => c.socket.remoteAddress === ip) !== undefined ||
+        this.privateQueue.find((c) => c.socket.remoteAddress === ip) !== undefined ||
         this.currentContributor?.client?.socket.remoteAddress === ip)
     ) {
-      this.closeClient(client, new Error('IP address already used in this service'), true)
+      this.closeClient(client, new Error('IP address already in queue'), true)
       return
     }
   }
 
-  private onDisconnect(client: CeremonyServerClient): void {
-    this.closeClient(client)
-    this.queue = this.queue.filter((c) => client.id !== c.id)
-    client.logger.info(`Disconnected (${this.queue.length} total)`)
-  }
-
-  private onError(client: CeremonyServerClient, e: Error): void {
+  private onDisconnect(client: CeremonyServerClient, e?: Error): void {
     this.closeClient(client, e)
     this.queue = this.queue.filter((c) => client.id !== c.id)
+    this.privateQueue = this.privateQueue.filter((c) => client.id !== c.id)
+
+    e && client.logger.info(`Disconnected with error: ${ErrorUtils.renderError(e)}`)
     client.logger.info(
-      `Disconnected with error '${ErrorUtils.renderError(e)}'. (${this.queue.length} total)`,
+      `(Disconnected) public: ${this.queue.length}, private: ${this.privateQueue.length}`,
     )
   }
 
@@ -279,12 +281,18 @@ export class CeremonyServer {
           return
         }
 
-        this.queue.push(client)
-        const estimate = this.queue.length * (this.contributionTimeoutMs + this.uploadTimeoutMs)
-        client.join(parsedMessage.name)
-        client.send({ method: 'joined', queueLocation: this.queue.length, estimate })
+        if (parsedMessage.token === this.token) {
+          this.privateQueue.push(client)
+        } else {
+          this.queue.push(client)
+        }
 
-        client.logger.info(`Connected ${this.queue.length} total`)
+        client.join(parsedMessage.name)
+        client.send(this.getJoinedMessage(this.totalQueueLength()))
+
+        client.logger.info(
+          `(Connected) public: ${this.queue.length}, private: ${this.privateQueue.length}`,
+        )
         void this.startNextContributor()
       } else if (parsedMessage.method === 'contribution-complete') {
         await this.handleContributionComplete(client).catch((e) => {
@@ -340,11 +348,18 @@ export class CeremonyServer {
     }
   }
 
+  private getJoinedMessage(position: number): CeremonyServerMessage {
+    const estimate = position * ((this.contributionTimeoutMs + this.uploadTimeoutMs) / 2)
+    return { method: 'joined', queueLocation: position, estimate }
+  }
+
   private sendUpdatedLocationsToClients() {
+    for (const [i, client] of this.privateQueue.entries()) {
+      client.send(this.getJoinedMessage(i + 1))
+    }
+
     for (const [i, client] of this.queue.entries()) {
-      const queueLocation = i + 1
-      const estimate = queueLocation * (this.uploadTimeoutMs + this.contributionTimeoutMs)
-      client.send({ method: 'joined', queueLocation, estimate })
+      client.send(this.getJoinedMessage(i + 1 + this.privateQueue.length))
     }
   }
 

--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -420,7 +420,6 @@ export class CeremonyServer {
 
     const metadata = {
       ...(client.name && { contributorName: encodeURIComponent(client.name) }),
-      ...(client.socket.remoteAddress && { remoteAddress: client.socket.remoteAddress }),
     }
 
     await S3Utils.uploadToBucket(


### PR DESCRIPTION
## Summary
Since we may not have time for a pre-contribution period, adding a private queue for trusted setup contributions

## Testing Plan
Testing locally running server and client

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
