### PR TITLE
adds decrypted notes to getAccountTransactions

### DIFF
--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getTransactions.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getTransactions.test.ts.fixture
@@ -2,14 +2,14 @@
   "Route wallet/getAccountTransactions streams the associated transaction for a hash": [
     {
       "version": 1,
-      "id": "e6820aae-fdb7-4f7e-ad37-4577d35d34f7",
+      "id": "199283c9-7480-4325-9ccf-668736f5a626",
       "name": "test",
-      "spendingKey": "46adeed9a5fc9854c8c757f32a865b38d6befecb817569f5078f9336bbcb2518",
-      "viewKey": "fb951df8a32c53e9b472ea2ed2f44cefd4bdb653ce54f0604d3a7ad1d3ae872f53f5fd5850583c3ad6cdcd32aff16c997379c7fce0ac1231d513edec91ba9aab",
-      "incomingViewKey": "d198e1cf3763f7344ef42f193e2117f5040bdb9b432fb289d03d0a999beb8b07",
-      "outgoingViewKey": "21818419721f891ee52a7c3a952a02ac824d4760324c515a8e24269a6ef6bb41",
-      "publicAddress": "4683eb58cde053d64008f4620c0e1b3064e245600478c15203d2dfb46cb0845e",
-      "createdAt": "2023-03-27T20:16:01.935Z"
+      "spendingKey": "7a91661c18090813fc3e4662bd7f65824467e45b388f00926558c96e036b468e",
+      "viewKey": "e8641977acf12898369f825fa747c9baa85c3c29d631e0b45699cb0d548746b68fa17a4308e2371dadb8780d3e731569bd84c837b530ce73b4ef55732cb0289f",
+      "incomingViewKey": "43475442205d2f1efd79106e842ec1c99c70dd8c0f5c0b73e7d99c36e768e506",
+      "outgoingViewKey": "0e981b1038e0715ece45f163f234b194e5f0f031b11aee204a5d63b78c51fa0d",
+      "publicAddress": "f95094748a614653a51d5526b282f54237f1cb07d539fc6f4a96ec6ffae4f888",
+      "createdAt": "2023-04-03T22:23:54.843Z"
     },
     {
       "header": {
@@ -17,15 +17,15 @@
         "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:cFGj8ut1SP8xlBXESnfcasMbc+6NfOnQdPyjNnLspzk="
+          "data": "base64:TicXyzuWfsOgGGkNdrVnw62Z+zCYRVLG51Zw8HtdgD4="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:Qg931VQjt6K+YYgJhLr4mRHFrEkXGNg2HLq2wBBmZbw="
+          "data": "base64:eWgnBJYopk+T53nZOevtXaAqPNOVflIMJ4viHmQMyu4="
         },
         "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
         "randomness": "0",
-        "timestamp": 1679948162767,
+        "timestamp": 1680560635631,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 4,
         "work": "0"
@@ -33,7 +33,7 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAkUVXL6bVAz64EgrJLj0qGJcgaH/qnBC3IllD+z3kGU+H6LKJeMHeA7YGQKght9VsFDaG5sRXvZ0ucsDEkVaO9FTjjcDB6i+XrFf/f1VzFCiQLjxB3zVF4N4USOl/h+3tJ34imK4Qpq47tR6mC3Zokj9ddvvYVB2gxAZIhka9ZzEH3/6rpS8ivSr9vQnzqYSdrLeq3YZU9RyQEBPE07SbbQfEZH0Lp7mu+FX/qjpANXm1gTIFOw8yb7uO/pK1zK+NdabHo+MvBhasE6FH55bZqSfGU/H0vQJY66bA5LqfUkbNrYRk7rGj98C1KqS03DJNIK0MxwIEhXRYEKNNxGLbF+bmxy7GUWSHoAFR+Wxg1lvUB0hxMXFNQfxOk5PgZuIrwNY6Vf0/3pEu4NnH+23g67nw8kvAoCtuw6mqvAbj1kROaoCPRcSKXMebXypy1FBqMHoomwCRugmFPGA+1yoR9bHCMytSq9ZeblyvDHn5/EoyTG+w119pDZ6ihjYDiyR6PRkZTTzAq9g0/E6U3CrqyMsSrAr4PQbZGg2OH6hZVfyfgqIOR3SsXFjcscrUVSzAywtj7tnlFskar463Ao7k7zmsVrReNOaE3M7NKcV1pZRINwi/0SYTCUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwfKRNJDYkoUAbpBbaEBUKBa9l8e7gwl2N46384PU5bqb/8tgqlmE/prQx1aKbmg0Qp5wU5qbqcJTqj/iFoVICCg=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAJDKsMv7a4q6OTCOzTBmNaRs0YqENPSNfKVE/u98pdx6veuJTsWMCtw4+Bu+9MQXK7dbsOJ+b9ctXQRwzSx9z5NweTPMq8OS0koBdmg2mbmi2wPqGLLJSCtrWoeUVT65D7ZE2EM08Yct/vBdldbs/+oi5CpCISlglHUgs4wDS8Z4TZpniC9uqHNO9oeI7mehHQd7d/2e4B3A6IgX+Qb/KoyXjpKWdjxMhsHoP77fjXAWygurtLldJFGB9s+8TrDEyGfpOl1MCN94F06E/tCA5oUNrJyIxICTPhPlN/Z+41S3crjX+iHTIrn4sgfMwj/VZFJ+UIjOVqZFYu3QOaPBxKX4dKeJ/bws8N67GZDCkRPEerabHZkLp5ph/FiOcozE2R5maV2b+cr+bG8n05jEdGL6hv6sRACn+SEjug12DXVRpmDmCc5x0oqM1K+RRiHjDgvab4LvIms6Bozxxp1y5muxyJol9tRpwNW30SdlGraMEz0iD7AaQvWR2UMK7mqD9xDGSj2WwM07et84dWKfaH/jtaa27dDcgkLh1vjdWsVe7qWzDAJ2X0MlsToS6UEjWHQM7ZzFGbvVl+cPvrOh/tn8lkp1vpCcYbWabZb6ZqmGy67Eh6gZ+WElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtECZYGrrrlxLZxtoGJSKyTfl4AI8CoRWyrvicVRRXxPGov5eceO8pp7w6qSpnoS19GusqtNBS17D2mqWH7kKBw=="
         }
       ]
     }
@@ -41,47 +41,47 @@
   "Route wallet/getAccountTransactions throws a ValidationError for invalid sequences": [
     {
       "version": 1,
-      "id": "6501d007-44a7-450e-b8f0-d055e9db17ec",
+      "id": "879268ae-da8d-4e35-8950-0508794bd858",
       "name": "invalid-sequence",
-      "spendingKey": "5ccadae2a6e6110bab6aed559ec39c3157926131fe25e51efd437934b1eadee3",
-      "viewKey": "0ff3ac0f0578cf0f8b96ab3de8f54f3f74f43c635f4b95fa66253c6eb5d089b9d10afa510d58a5b46d8d0864d63cd8531090fd8b9ea4309b95eaf75beccab3cb",
-      "incomingViewKey": "2711cbdfa86672463795b75bac77477071815b8762c0fa243e65f446fa318a06",
-      "outgoingViewKey": "1b1356b74634482e815742aa98658aa8495defe69a1074367819e3d66a70c27a",
-      "publicAddress": "a95fdcee694e300717477a970bb516549e3c37948a5a456e4dae4ba22d29ac84",
-      "createdAt": "2023-03-27T20:22:20.665Z"
+      "spendingKey": "f59702d717e55ee9f88fbdab6394305d864c2fa4842bf11360c4101c80b71b90",
+      "viewKey": "dfd4aa0f6118b223198de278fcf0e14d2d5ad49cfa99596ff2ced87f0e014515ca96bfe4b140da83e767b48d31baef5268daafd615b89c474833a74b1814543b",
+      "incomingViewKey": "24827dedb816340e7dc51ba594141fce0433fe19381f7e1d1403edb16ba18807",
+      "outgoingViewKey": "723f4541da8081b0ec790f3203aaef9612026cc617afb4540502b81ed858d742",
+      "publicAddress": "a45e0f0f08383ad28eabac8a149e99016bcab9751299553cb9dee4b3f4c53d5e",
+      "createdAt": "2023-04-03T22:23:55.702Z"
     }
   ],
   "Route wallet/getAccountTransactions streams back transactions for a given block sequence": [
     {
       "version": 1,
-      "id": "e0f23e23-3adf-4c11-bf7c-dca8fe57b5b1",
+      "id": "3f9adf5e-e3bb-4a37-b7c8-55772defcba2",
       "name": "valid-sequence",
-      "spendingKey": "b55766d1aa6a79941b54f06748860d8cb7c2f447716a1abcc8348932e8303ff2",
-      "viewKey": "eadcd8e6b7001ca44260e339b6534bdb250848735cdb3a5bd975f2ff252a4386937f8f07402bc7dbd6ce3058b1206ccc1f3a367ab845b5e7d629f98c4c38048e",
-      "incomingViewKey": "7096c396949106cee695136e3429c4511093624a499a04ac701182ead15c8903",
-      "outgoingViewKey": "40b83f94de4c1bd9915623ce5320a310105fe3bb0df0c1ac0b26a2415d16a9f6",
-      "publicAddress": "0f6e67528f733e8a043f29862a62e6c6e880f3fbc9f8ba5e218a25475f09a568",
-      "createdAt": "2023-03-27T20:28:00.063Z"
+      "spendingKey": "ef3a2a321dc1cb9061777a4e23717d5e4d2940e922160725511f283abc8401d4",
+      "viewKey": "8b2bf2510bd44c7f1d26db96f11fcb6a64d2a90933060b5dc2bf87773e8c5caf41ba53a483f8d431aa2a11814802065158e142c3b286a52a155a2b7b174a3940",
+      "incomingViewKey": "8f22c4cdcd22803ca8a3eca74104ef1068b079e968fc45f7e0b686bd994e3504",
+      "outgoingViewKey": "1f140bf9c69be5992be0beb9c18dd25db4366f13b897b6d2c4cb94f8f569e935",
+      "publicAddress": "6eb7e718123a46dba07fae43ec344f92f77134a0e491968f1d743d0aa752d924",
+      "createdAt": "2023-04-03T22:23:55.708Z"
     },
     {
       "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADXAndxXKxlFxKHXi0W/9W0QeAVt/4pOZyjl/ENWieiCnDo4eoN/fpczM9UwWipcPskKBiHzGQlxWL0Mw+624qJRziL02bHXyjjeRlw0+qEWjrO1RoPflb1Bxh1FVktS/9GJTrxJ7MyYiFwUa8CWU1iS6YoeoUmh3fvdG5VNS5j8TeMB6SvKkjVOgY5Z9n2tA3LSDaFEHU4w2h40lniOZGFqvdXZMo7CaXKuo+KdsqCKH6t1joeAcRcGsH7vau81gDYeahvb/Qwz5fJYrWo6/9Sh0DLjJjczQTJlHaHLbjbMvpaaTzfOiUk8r1h64irRt+QIxUPMeuqvUIJJ7iYP22u8SNfV3MEGy/NKmp6Uyyebg4NrmXyucavcykZqUNVcck0MFPFhAK3fNZjvCWGe6o8F23j6gAvPS2iQQHA72lgwqZ9BNdnECeeft1tJP37nbGbYVUyyqy47rqBJylAmmnaYPsGkQJ7x2BsiotpaNi/dyGMW2misue6C1QLn08qLRXWIsN8JdMGRCWPeoez6cToZHerQ3wIz4bcR/Y0/rq6hA+6AUai9YpxCw7nu5UxdcEmOwUgaUzoIZfUpbam+vLYj0hyzsbKPgrKQypE8GPK75lTbpiOsReF6GQgFrE53rkMK278tnXjpmExV1IxQnwaGfKmJMIc4Bv4V+2un8abxeM+Gdvuq00u8XQTgzSUDSUOQEJCQ+g5pDYPptqZVnFNY3HqjYBC3TgPNUJRAvGHE1kvcpIJaBZGUfngCXjJ8soL+N+q8Pv8IjWDDjZUeo3KiHFQj35vckqycNVcrO/yfijk6XRSDRddM2LLlK5ymdrWX7aqEU/6H9BWg5vhWUSxjWjfwOILtCAI/3roG1gmSneL0iSur0WhfpUbqsFuXZcf0L8j/JKcj5uOOUr+v+Uf7dBjoKvtDBjmetF6jjwwUhqI9ktHaBwrbIi4ycVM24SXrG9xW+Hu0NMCyQ6jpGjQpUIpaXWFgSD25nUo9zPooEPymGKmLmxuiA8/vJ+LpeIYolR18JpWhhc3NldAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAAAA8jjq8G3VCfy9/AHJVx0ujh1CGz2oVGoPqPAvzOKQipLFsjoaxGnUpF7MPY6faSsoF2t4voAkoPa6NQ/KPZNUGhDeuaEb5urN+G1mAXGvNOLyAjyBGWw9S8IdBraQGKVBadb41+KZhjuzQ46wvwjCBJ5Q769rYZ6crknbDeeiHCQ=="
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgmd9SYnxFYPmx06/DqrpeovCyH9RZpaImCjmvdRHqpmXQNIbUHjTo4XXNezXYyX5T5yTk+qi5AL6NZYzY378lzUMdSnn6YJegKZvkalv31qDQm0m96cjJG7IHBPzeuJbY/pFjiU/93v7d2YecotVqTZ1gTH7qHXi9krw0c9aQ5UAuaR/sMkmBAdpLuXEa4g6QPNsRxX43dBP7C8fXIwLvXRa2E1O2/l2x9xFy4NukFWPHbzUeYlkWWdifLKsYcbGUxRA3o9JYPh+76qySIcKpUNoGHjur8G+r8oEKzrP3LWl3YWOA7uBrI/DankSj2s8k/S9iYJ9fZ1A7xXlI4laHz+Xc+rdneK6wauQA2bXd0Pg5fFs4SyXy6edpVPZOvcYlfkdmaEuPkpvfewMDX7GphZSTP5AMN2D4sE0Iid298n0uPkY02xAILJfnl5Ai7OB9kFemzP+lgYuIvB9owAU5qQTeuSAOjJMtlglzm5yDmDFaqAp2LhAaZF5psoHU2Tz9S/8WZw+vEYwGXizH9BGbTFCA9FSusNLIt0L2yMXHoQiWioQh1zETsEC484/9/KNDiDRx1oRI90mERPle9nP4NWoL9OYbK6Ivqx1DG1ly8yvWnH2Z10v9S4mv93//y0upUS86g8a24+8wx3DthA+aVNbappSULneaBk1nNQO8Z1pkoEKNywWBX26jXwx+pZW/ljU2J095Fk/P3pr/7OVOH7MKD+hNjDCjbpcRxmLeznBPN+OwHYC6hzY8bPOdVGcU/jWure82Cp7fwHPxZYDnjYWtsLgoynxmWmKuTv6hvawxGqUqVk8/cvCEVJcRhsZJE9dEBdsNa6vKJXG+A56JxGxKHCoorvcGec7nVT9siUJMhkPrAZ/IhzzEGRT7Bn9mWHSNqKoBjB+GmY0YC7t93f9tY0FNkdSgM1o+WSjRXc0yDJg9TlSyv38y302UGY6xplFGr3JcCZRG5pdOql6jNyr/L2/dAtFbrfnGBI6Rtugf65D7DRPkvdxNKDkkZaPHXQ9CqdS2SRhc3NldAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAAAAwYM4jeNQfTAUyfaxrf7bgxWHNVa0IOFL6lVx/kpmemiSukBf6q9A3BSpI51ksj1aJuxHbht1t+9uXwtpstzwEyfhrXmtz8ytoGgC+pfPTHjrT2zFZm36rw2t6xwgXloMDsOJiNjmAOCttwgLQUbjgB6a5M9Gb/pzdb+2inlKHBA=="
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "ED964164271306033EDE335A790187B1A8CFE1CB9C98EF1D3C29E4E137B36D3F",
+        "previousBlockHash": "9B9868FC62BB197C4A452C5CDDBA6BDC26B8874D2CBECE28C5E5070278713347",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:3GBQZYWT51ILz91p1VwGEuhzVbTb2gk5NCuuwmYAAVA="
+          "data": "base64:dlAA85c/EIF7jM5lZBedNQ50fvE6sANijzADza9Ks18="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:TRhE1SC9sLWsOuv2GQ4sA/F6fRwutbFAwG0oi3/q180="
+          "data": "base64:rAC1C+wvP2Kk9op1Hg8/7DjA0BJJnp2FQom6j37v3hw="
         },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
         "randomness": "0",
-        "timestamp": 1679948881317,
+        "timestamp": 1680560636864,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 6,
         "work": "0"
@@ -89,11 +89,11 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABzg9kMXIkUMO5MadBZFA3n/GCEHY1JA9AbAOouvFywujG/KtuEjIN5OKkACS+DqngjwVUt1CY+O9zRSH2l5qpc4gXbKwFVzqxwCNqKw8lNKJ3lYdDZtkjFKi9L/jyFsK0AHTsVve7KsZ9LlYqaErwu/MWXw6qZIwTYJ5sMgEIiAHARBbg9jR0RDfgkJDkD1vag4nTfwoT36OoPEVe/MCXXIXZr3e47IA/KFEExmme+WSLxndtf96oFnK1Pou5wcP1hUQuEhR/Ly1W75oReQ1mR2bT2rxqFrH6f4xGbmvFwBbare5xAXLXynJnAhsAsg0ksijV4I7VhEdxR0pIfwNGYjtLcW66GPt9GKPGu9/meKadCLPSyKGpJNSIdI9SJ9AabXu9o5S4MgYD+mbUl5PBYc+geu0ZlBU5RYtsF/gGre4hWkdbjr+UFjZn41zQs2GpUfTU8vLedrnLe5+JQ1T9Rl1Ny5DbGb2VsaflcKT5XbsZXSUnY0sTM+PrVkHI5WDLN4DB8VwS+A9vr4sQkIWpmIAst6iXOJr8LejUODjijbJV05Lv2BFWftVAAoGM0mLH2uxoJiT/Fu8yJSMuAPwdKYXj18qvdV5FDwLI9AaPj2fR7JHU6LAzElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwKyyO5I7zvsXWdbql4qDucBvGrrbqh0e5ElmH8Q13Koxco1Qq7+YghZxbktvPmNU+2frl8SZpUHfLaPNyouQ6BA=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAGNZpX1Z5owRmigJBYaF3YiGfLSenEDM8cxs0/hBFLxKz4BdMdOYzyyrhahLNN8F9rhFDNTIrHfsNqPWmqmAz6on5s6t3e0iSuOMnrGS4kYeLAmLGx/N4xME2hV36VALrDFhV3kxoUec76+PuC6wIbHRad8tBQELgainFTzmaOHcLzB6+swJQzILV98Nb7GAylDgP73p2gxxQzbNBz7Sp1GIhnmOm95k/0SMRb24iecWECCgHQiHQiLeJZsX7mrYM1xJMY31MkGU2wK5//g4KRy9R0fe0WtBimnWtrKt3FWhj975JDvKaogibIu/hHx4n79Q7j4wktZd86FkVfk6J2JdxMsdrNufNJYhiJIICYX2zlpnzqEy5lyfghkyuFFEI0JF04S/uAfFVNSXZkIssTm5jkPE6vKowKIV67/EBJlc6fhKVTlua50QmIePox22kP5/yS3SH4KKiLX/JUtNQ5g1y/vpH8wBLxrTtNx7EPOQdK34e2OPLdwVM3cIdQilG/EScUTFSOOo15C+l+V4wwt5WKqfXlZLRfsXLE5Ufgtl0pGzThpeTthvDzKjRpmjOydu5I8MxDhF3JhBXEv1dpqK7UHXKVPYjQamEkJR7suCq/wngP5F3UUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw6xxES67H4l/kF5Y8w7eOEfiWKVQGpUEdvhvnTLI44mWj9JVrZNg/z75xH4DJZUIH4W81yVoMBaJTYAHf/K4tCg=="
         },
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADXAndxXKxlFxKHXi0W/9W0QeAVt/4pOZyjl/ENWieiCnDo4eoN/fpczM9UwWipcPskKBiHzGQlxWL0Mw+624qJRziL02bHXyjjeRlw0+qEWjrO1RoPflb1Bxh1FVktS/9GJTrxJ7MyYiFwUa8CWU1iS6YoeoUmh3fvdG5VNS5j8TeMB6SvKkjVOgY5Z9n2tA3LSDaFEHU4w2h40lniOZGFqvdXZMo7CaXKuo+KdsqCKH6t1joeAcRcGsH7vau81gDYeahvb/Qwz5fJYrWo6/9Sh0DLjJjczQTJlHaHLbjbMvpaaTzfOiUk8r1h64irRt+QIxUPMeuqvUIJJ7iYP22u8SNfV3MEGy/NKmp6Uyyebg4NrmXyucavcykZqUNVcck0MFPFhAK3fNZjvCWGe6o8F23j6gAvPS2iQQHA72lgwqZ9BNdnECeeft1tJP37nbGbYVUyyqy47rqBJylAmmnaYPsGkQJ7x2BsiotpaNi/dyGMW2misue6C1QLn08qLRXWIsN8JdMGRCWPeoez6cToZHerQ3wIz4bcR/Y0/rq6hA+6AUai9YpxCw7nu5UxdcEmOwUgaUzoIZfUpbam+vLYj0hyzsbKPgrKQypE8GPK75lTbpiOsReF6GQgFrE53rkMK278tnXjpmExV1IxQnwaGfKmJMIc4Bv4V+2un8abxeM+Gdvuq00u8XQTgzSUDSUOQEJCQ+g5pDYPptqZVnFNY3HqjYBC3TgPNUJRAvGHE1kvcpIJaBZGUfngCXjJ8soL+N+q8Pv8IjWDDjZUeo3KiHFQj35vckqycNVcrO/yfijk6XRSDRddM2LLlK5ymdrWX7aqEU/6H9BWg5vhWUSxjWjfwOILtCAI/3roG1gmSneL0iSur0WhfpUbqsFuXZcf0L8j/JKcj5uOOUr+v+Uf7dBjoKvtDBjmetF6jjwwUhqI9ktHaBwrbIi4ycVM24SXrG9xW+Hu0NMCyQ6jpGjQpUIpaXWFgSD25nUo9zPooEPymGKmLmxuiA8/vJ+LpeIYolR18JpWhhc3NldAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAAAA8jjq8G3VCfy9/AHJVx0ujh1CGz2oVGoPqPAvzOKQipLFsjoaxGnUpF7MPY6faSsoF2t4voAkoPa6NQ/KPZNUGhDeuaEb5urN+G1mAXGvNOLyAjyBGWw9S8IdBraQGKVBadb41+KZhjuzQ46wvwjCBJ5Q769rYZ6crknbDeeiHCQ=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgmd9SYnxFYPmx06/DqrpeovCyH9RZpaImCjmvdRHqpmXQNIbUHjTo4XXNezXYyX5T5yTk+qi5AL6NZYzY378lzUMdSnn6YJegKZvkalv31qDQm0m96cjJG7IHBPzeuJbY/pFjiU/93v7d2YecotVqTZ1gTH7qHXi9krw0c9aQ5UAuaR/sMkmBAdpLuXEa4g6QPNsRxX43dBP7C8fXIwLvXRa2E1O2/l2x9xFy4NukFWPHbzUeYlkWWdifLKsYcbGUxRA3o9JYPh+76qySIcKpUNoGHjur8G+r8oEKzrP3LWl3YWOA7uBrI/DankSj2s8k/S9iYJ9fZ1A7xXlI4laHz+Xc+rdneK6wauQA2bXd0Pg5fFs4SyXy6edpVPZOvcYlfkdmaEuPkpvfewMDX7GphZSTP5AMN2D4sE0Iid298n0uPkY02xAILJfnl5Ai7OB9kFemzP+lgYuIvB9owAU5qQTeuSAOjJMtlglzm5yDmDFaqAp2LhAaZF5psoHU2Tz9S/8WZw+vEYwGXizH9BGbTFCA9FSusNLIt0L2yMXHoQiWioQh1zETsEC484/9/KNDiDRx1oRI90mERPle9nP4NWoL9OYbK6Ivqx1DG1ly8yvWnH2Z10v9S4mv93//y0upUS86g8a24+8wx3DthA+aVNbappSULneaBk1nNQO8Z1pkoEKNywWBX26jXwx+pZW/ljU2J095Fk/P3pr/7OVOH7MKD+hNjDCjbpcRxmLeznBPN+OwHYC6hzY8bPOdVGcU/jWure82Cp7fwHPxZYDnjYWtsLgoynxmWmKuTv6hvawxGqUqVk8/cvCEVJcRhsZJE9dEBdsNa6vKJXG+A56JxGxKHCoorvcGec7nVT9siUJMhkPrAZ/IhzzEGRT7Bn9mWHSNqKoBjB+GmY0YC7t93f9tY0FNkdSgM1o+WSjRXc0yDJg9TlSyv38y302UGY6xplFGr3JcCZRG5pdOql6jNyr/L2/dAtFbrfnGBI6Rtugf65D7DRPkvdxNKDkkZaPHXQ9CqdS2SRhc3NldAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAAAAwYM4jeNQfTAUyfaxrf7bgxWHNVa0IOFL6lVx/kpmemiSukBf6q9A3BSpI51ksj1aJuxHbht1t+9uXwtpstzwEyfhrXmtz8ytoGgC+pfPTHjrT2zFZm36rw2t6xwgXloMDsOJiNjmAOCttwgLQUbjgB6a5M9Gb/pzdb+2inlKHBA=="
         }
       ]
     }
@@ -101,30 +101,30 @@
   "Route wallet/getAccountTransactions streams back all transactions by default": [
     {
       "version": 1,
-      "id": "79438f9b-8b37-4ff6-a8fe-9db20974f82c",
+      "id": "40127008-47a2-4bb4-bf2d-ffc21eab37cd",
       "name": "default-stream",
-      "spendingKey": "208609ffb91991c207309dc455b3ba19a245d26af86f144cd30df12a1524039c",
-      "viewKey": "6f4bfd8852d2aedf812b08ddaf21fc6f1500cedefe3702bb67179f83479ce2b4ee032ea34c02e4245a351a7dae5f5199e526de5f2c9c4021ef875b1de5d6c0d4",
-      "incomingViewKey": "b004932248a2a8ee629ecc832fdb0eb91bfcbb6414c686309b3807dd39fc5803",
-      "outgoingViewKey": "bfe7b58879035b50397d0d924b7a9bb31cda087ae2e2bbdba1aa90adfb4f3400",
-      "publicAddress": "77cb8adcd0defbd757d45ef7d44e311f9109e170fa7fa18f83e5c3d0c06b5f23",
-      "createdAt": "2023-03-27T20:29:58.639Z"
+      "spendingKey": "0089cff3f15570f2e32c28331c17c8d092b15eacc378f10e0786822d4484f301",
+      "viewKey": "e3b7bc84ec604c2e4b192e3218e34ed3e7f5dd26e5d0f4e25a83cb17906c4def6eb6c7f5c30274bc9ea74c7049e4ad43607e3faa5a5919c042782bd0d30fff1b",
+      "incomingViewKey": "46ee0b578b53e31f58d80369f62f834f3cb473c21e3db23af3d3ed7a3502e407",
+      "outgoingViewKey": "8db71317dca40044da355e4aedfd6c111dadab64211d64df0e69fa7c058e24e0",
+      "publicAddress": "5c785353de81f2f6cccedff9496abb2ccde75b23350918e8daee2e20188b9356",
+      "createdAt": "2023-04-03T22:23:56.943Z"
     },
     {
       "header": {
         "sequence": 4,
-        "previousBlockHash": "E730EB645A3B6D4058AFC653049FDCD3D8C80063C25586C8B941856FD34D8B41",
+        "previousBlockHash": "C7E6D0BD80A502B6B7C57CD4E083B2585AEC4226984259249303B7389CA54AC3",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:aEBhNjfhS1hh49pWgKfk4orRWf+kF+G7Exnm92Rvf00="
+          "data": "base64:poX9V78VGGQFc/eGudeaap2Ffgoqgstb9TsA0X3Q1w8="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:qdKhvfpoY7xN/dQBUHawvS2CsFnF5eTu1bCxU03cjJU="
+          "data": "base64:I/vBA5Kq4ZLXb7EB93LKJdm1x7eIOuS/v6DmXYWttXc="
         },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
         "randomness": "0",
-        "timestamp": 1679948999135,
+        "timestamp": 1680560637337,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 7,
         "work": "0"
@@ -132,25 +132,25 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAEyLBvMmf0QG3qRI0IktY4rYoyb66AWLyW5/mqJuzhoeSx1idi2iB3YZXK2AuL6CuKQbdvqWg8EpAU0hh0YFg5GfSFT463X7qKj479SfciKOVlbK0R+AbVWbXWPzGmdqy7/PVpeFQHNkB8/w7J/kxK29uX7qjZV2mk+QSRfsnDdwVPC0+Vhfl7FiUF5C7LpZHW0VkwxoK9rWWf6G6rARqQuO+KH40FzULFjZ1TcPGUyqTqOPfwfAbnQ8pLm7k6cCNf8ivUWeKg/aLDQchLtFXf/B2/rtfMO1bNLnqQpMA2X8kx/0tuO5wgPkWhKrukxkiIsSxFaGCmYW49TWt6suONpo4EpzU/OOMUzavEPRso+0YBgOaLaQiBLTTw0jdRbMhu1C/JZ4Is+l0LEdC508NPh/9i+ejFrkO+HebTuKgJOuVIX5WRIRV2Z4eQfeE76Fdhne5zD0G4puCxhXqTEAjQBC7HcXgk7vQTqMgeeCLrT6WK4JhzVYrmmIr1j//xqlVPH89x8xAkEJBpfwWo/PgxvJ9rIaNienLQHv3A8cXn4d04xGZlsV6jz8PFlUGN3tv3aj9fIJtWp8WtyKMpAVBz9Q/DavMpZxGrBmxwjYCXzzBWb9E7Rkv9klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQPxsFqBJBgbjXfFHPeSzFJVMOR/I2miJwdMkTKo73Ygcdd4lQKI0qip+UM1ODkeLPiCIbJEW36fV859h1HwGAw=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAOjWgL+N4dswKqimV8uJkaewMmEnwQxyF3IS9Y7AV0MCgcG/U1oF01OkUyK8PceUlqzQJXcF66TlY3JwshjyBjNgrOxiqV9sHqpgREwb9EZ+FxNh+8RD/5GpIpYInK2dxpAEUbk0gaqTMJ6Zd4mMDzAqBIwHZtSKA+U7BTgCf2sAMgblAArPyQbBiKCK9Le2+iaCAuD6+AOnCCgM3dC1sfuAWszPLddlVya88Bu5LVcexI4ISapeKWPzO+x88RvrJpCifgon5D39TL190gAJx/BqG6a1HosJqI+xiHzu6w3hHZzSCgqTjnfO0CUdJ06eBr1bk0R9LRIJlym2mvp7MicY8WpDQkP5thMey1PV942n63zPwWrYPzxUNG94nOqgM8pAn/Yvq05hLyTuDa4qJUaWfG2L/MrLOlfaEB3VA/wVDk5fe36RfAXcTFeZVN8zcq6A4n0NFIarnwap/UwEKfca64JYizzfaJFfsqd0hHZLujSAbT4aPCsVWLFSrRC0ywh8KuCs7j5vZNnOysPwQgUrfZslmNVdH4Rfto+gd4h0CbsCEftQ3qm21ySVvI2AFf6iy4+EFXRjFjhVZZoqEcJ4rUQbqmb2BsSJkGB9JdfBZn8SAkAhQXklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwr2O9dpGe2w0o99V4XZ6ZlrJHCo7ZyF5RSw5HBKdv/dqvmMxswKh4yiYmU4M8PNlb4mhTWKTgqOtfk/HjnEg1Cw=="
         }
       ]
     },
     {
       "header": {
         "sequence": 5,
-        "previousBlockHash": "7DE275461320743CCC04FC0374BA437AFA5D3F88C2D990B2724041796A6965A3",
+        "previousBlockHash": "D6DFE43FC9CF6FE90518A2D8AF303C7DE233DDFF74EF397358B3CD0E5AB24279",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:jPMxqB1ne8nbdwlOof4213y68cVbeadrHXLWTM0yqT4="
+          "data": "base64:6PhnNQnbDR2yN3gN1mJOYyr5vGaqalEcwAI8+hgnVEg="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:8ilAjY9/6qE+r1BjAINsNPT1S5SvhSYplVQsLT1uPCI="
+          "data": "base64:GPpJUZHcW1gssGjjC72JJ4jCxBxfoCTxKpU+907zEs0="
         },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
         "randomness": "0",
-        "timestamp": 1679948999649,
+        "timestamp": 1680560637793,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 8,
         "work": "0"
@@ -158,7 +158,46 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAa6pyyUvMAWXtIqt0xd17vhKSD6f06ADh7EaLy1EhILqN5ewMcgX5uu2uo7BJ3TwYHMayj8/5zdXgJn0eva8oNP6FDDnoRHAanKvwILB7SU+HZ4WJcsAKcF2pUBLACSjZBPWoIGUctyLoOUwJfVUup+ABDKIFjR2JeNc1zEorBzsNMZk7w6X4/O1p4yUzoP1ke/1PPsyvf0BnoDRhxliwc2iLoFN65aV26+jX1b1yheGicTpuxy5JxT1h+q/eAnBgWVGZfNHr3XfQfi4LSuir2NE7FwV21ECU+l5DrS4n88MWyhYYchYlHlq2yxXZnYiBh/5RArsEyZy5Hn6GNG+qrETd+DpYq1EliYyoafev+FX8roMPs0AeUmjMKD62RhkGqS2knPi1p5XG6MJ3DDtIGm8SAEesDNLlJ/sYbzjvf9HbsNWGNFzxBNtbtbs623drhRsduALr9PUbXdCh7StNFcNCLAef9vKr79uudE4S+5nP2UkJrW3wOg5tLMwh1GPYDlMWWqhyILLp2RpWpV7WYmRctREdl1QozhuocQhtS05o8PukcMl1I+cMSh4IYMHeSUoaaD2bE+GHH7XcPT6fKni7+EEgEtYWtQ46sVD9jCbRHulheNUpZUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2R2UwFLgtsGH3Rbwh5nNMkey0Lgab4OTkGzWI+Nz+cDL/TkSdnYFuTD14PRMMKREA0Wn6wRIt3g4GrmvlGQ/CA=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZHKWAL4c+dBD6YwibHBbxldpaqUddBztu3kvSxFxuguEiCEi+Wyd1AMxEcR1L3gYLHTIlNQ12SLQpgIAk1EpFeo4TZksEAMAE/LmXOSIo3Szp6tkuygxlnZBuLYP+mdv9vgzFoY7aQJ+D7DPjn70uhj7exqa/CRW2Iwk21CUEAcZvqSfUcDDZiMiXhIGRbWwByi+fyykJea/dkQrxUhO3UIbj4A6/2GYmOBuBjJgoGuXYA2ORaV7dSjRANaqnPB37R+lTVRIi8wCvw3qE5YVEOv1QofWaUJOcwD5L6HxPpo3gwCcesei+7HvDpd7jIfBFof/BjfuKA2Q8uO9lWETXF387rhCzKT48oArs0QnLsWz2M47ACJrhqq7Nf2TglASwZ1V+rjJawVpWL9Cxis+xl1oPRctRd8hZFFbSFjQqLs91mRa0hnDxDUw0CiUxAK3cXyZs4+UnjYwQtXqc8farjzaiPZqPZNQWZyC49qKZPfs2pTIc4dSeVzo14Y53oGU+vFC46tLpQBGb9AtmaAnDfh7Rp/WXtd4BSU0TNaVVt0VoAo1vi3l6+m5tA406xLaMkgn+xfS/pMXMSrC1QcIJHRG8NUqv3lj3nCR1YvwW8XqvGxTV1ahlklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsxrWvI5PWMcfUPVZPdnedIhIuc2PA4SATFt+6yeGwOiGAs89ysLSDRrpcV8XRnRNrGNiSk6BawTUcs7TbXKaAQ=="
+        }
+      ]
+    }
+  ],
+  "Route wallet/getAccountTransactions optionally streams transactions with decrypted notes": [
+    {
+      "version": 1,
+      "id": "0480fad5-8ed4-4b05-8f06-3915353f9065",
+      "name": "with-notes",
+      "spendingKey": "5a66452e2dda3d342f22fa8a9e2e978eaaeb077feec475eaab16ec02a2dccf52",
+      "viewKey": "783fe59a6ab3d9df6a58d9f01bfdfc17dc8e4f368569a076cd673f1287536709017c043338ab8326a60d4a7773f06f10da220f8d8100f3de89ee8805b1335fd7",
+      "incomingViewKey": "450b8916c24118d5a55d45787b17706249e702bb32564d38889b9889cad42904",
+      "outgoingViewKey": "afb663bbf2a322f4440abd76861d32f5f7161aa26fd8824b9cc2c0e33b0a457b",
+      "publicAddress": "1d457473598d6dfc4156d8b91171272582476d6d9462bd0803e88bc57ccec599",
+      "createdAt": "2023-04-03T22:23:57.852Z"
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "07BECC4C55D874BC93E7B14BCAF6EDCD5FF176C4E52EF0838B0F00832FA2B3BD",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:juHW9vzxZRnTqHhSdU4P0NA7CrkeT5DFohBIL/nCrz8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:PkQDWlYwDXoVk+XPzOwj/8kBE763pm75MD21ueHpaTk="
+        },
+        "target": "873190827380823143577845869093025366895436057143163037218399975928398962",
+        "randomness": "0",
+        "timestamp": 1680560638241,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAu3syMDkUIXUzjuLiVkev6RwdOPRrrtOyp/j0Ln1+R4WBt8jdAU9mmXULuBzYfN5q/5t1VnTEd0tSKPKwyUUstitYr2iq28slcls6+Rhyv/KnPI8L/EAThXTkoBhTVQ2J1SdzabKnSTtipSb1qhrBjUCL8IQPAjCD079F52bWLAkJQ/ZoMO/druM7VLIw74YabY/c4zyd95lxT3ii4ZGYl3orKd49hcxo5OXQeCEgNM2t3VlOYV8ifJdYxgsZpOoQZ7zHfajUOFXpp3KgX8J/5UA3zG5FhgugwG9uXfYIDrqGLSpCAGgmDbMjYv0tr3aGRUSxE7YPLuaogATogrufEdrhUdEXt+3EFzNXPU8scgyn0M+zH6FD1pJcHwvdqq8xhypRmAUqiAE8DiuzxThJjc5a1FLNC9nXl4aIeX799bel+Ggu1W0wyQOK0v97LnZc4vbXdcfNSqb3s0VJLDEn9ycHutCTbhepYko/CpW+vs2/w/fBOL2n/f3iXPyw0BSrhQdgtmZ6WLCJsIr82aCUc6AZT1n/4xCTk+jgCt9S90c/wABasC3/XmSIt1bobpdL/BpdFA3bnIV3D6vLuZlV/TPXJsaFmrb8sdClkxe6cf2ofrJLQjcHSklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQ1mZMFzkQ4E3CnQkJKRlO8XZZh/fRYbu9+SDTDZ+ah69s22PJ06zww4YX0SsHZAvL2CsmsB0FACqj14mRGjpCA=="
         }
       ]
     }

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Note } from '../../../primitives/note'
-import { CurrencyUtils } from '../../../utils'
 import { TransactionStatus, TransactionType } from '../../../wallet'
 import { ApiNamespace, router } from '../router'
 import {
+  getAccountDecryptedNotes,
   getAssetBalanceDeltas,
   RpcAccountDecryptedNote,
   serializeRpcAccountTransaction,
@@ -113,39 +112,11 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
       })
     }
 
-    const notesByAccount = await node.wallet.decryptNotes(transaction.transaction, null, true, [
-      account,
-    ])
-    const notes = notesByAccount.get(account.id) ?? []
-
-    const serializedNotes: RpcAccountDecryptedNote[] = []
-    for await (const decryptedNote of notes) {
-      const noteHash = decryptedNote.hash
-      const decryptedNoteForOwner = await account.getDecryptedNote(noteHash)
-
-      const isOwner = !!decryptedNoteForOwner
-      const spent = decryptedNoteForOwner ? decryptedNoteForOwner.spent : false
-      const note = decryptedNoteForOwner
-        ? decryptedNoteForOwner.note
-        : new Note(decryptedNote.serializedNote)
-
-      const asset = await node.chain.getAssetById(note.assetId())
-
-      serializedNotes.push({
-        isOwner,
-        owner: note.owner(),
-        memo: note.memo(),
-        value: CurrencyUtils.encode(note.value()),
-        assetId: note.assetId().toString('hex'),
-        assetName: asset?.name.toString('hex') || '',
-        sender: note.sender(),
-        spent: spent,
-      })
-    }
-
     const serializedTransaction = serializeRpcAccountTransaction(transaction)
 
     const assetBalanceDeltas = await getAssetBalanceDeltas(node, transaction)
+
+    const notes = await getAccountDecryptedNotes(node, account, transaction)
 
     const status = await node.wallet.getTransactionStatus(account, transaction, {
       confirmations: request.data.confirmations,
@@ -156,7 +127,7 @@ router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
     const serialized = {
       ...serializedTransaction,
       assetBalanceDeltas,
-      notes: serializedNotes,
+      notes,
       status,
       type,
     }

--- a/ironfish/src/rpc/routes/wallet/getTransactions.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
+import { Assert } from '../../../assert'
 import {
   useAccountFixture,
   useMinerBlockFixture,
@@ -115,5 +116,30 @@ describe('Route wallet/getAccountTransactions', () => {
 
     const transactions = await AsyncUtils.materialize(response.contentStream())
     expect(transactions).toHaveLength(2)
+  })
+
+  it('optionally streams transactions with decrypted notes', async () => {
+    const node = routeTest.node
+    const account = await useAccountFixture(node.wallet, 'with-notes')
+
+    const blockA = await useMinerBlockFixture(node.chain, undefined, account, node.wallet)
+    await expect(node.chain).toAddBlock(blockA)
+    await node.wallet.updateHead()
+
+    const response = routeTest.client.request<unknown, GetAccountTransactionsResponse>(
+      'wallet/getAccountTransactions',
+      {
+        account: account.name,
+        notes: true,
+      },
+    )
+
+    const transactions = await AsyncUtils.materialize(response.contentStream())
+    expect(transactions).toHaveLength(1)
+
+    const responseTransaction = transactions[0]
+    Assert.isNotUndefined(responseTransaction.notes)
+
+    expect(responseTransaction.notes).toHaveLength(1)
   })
 })

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -9,7 +9,12 @@ import { Account } from '../../../wallet/account'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { RpcRequest } from '../../request'
 import { ApiNamespace, router } from '../router'
-import { getAssetBalanceDeltas, serializeRpcAccountTransaction } from './types'
+import {
+  getAccountDecryptedNotes,
+  getAssetBalanceDeltas,
+  RpcAccountDecryptedNote,
+  serializeRpcAccountTransaction,
+} from './types'
 import { getAccount } from './utils'
 
 export type GetAccountTransactionsRequest = {
@@ -19,6 +24,7 @@ export type GetAccountTransactionsRequest = {
   limit?: number
   offset?: number
   confirmations?: number
+  notes?: boolean
 }
 
 export type GetAccountTransactionsResponse = {
@@ -33,6 +39,7 @@ export type GetAccountTransactionsResponse = {
   expiration: number
   timestamp: number
   assetBalanceDeltas: Array<{ assetId: string; assetName: string; delta: string }>
+  notes?: RpcAccountDecryptedNote[]
 }
 
 export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTransactionsRequest> =
@@ -44,6 +51,7 @@ export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTra
       limit: yup.number().notRequired(),
       offset: yup.number().notRequired(),
       confirmations: yup.number().notRequired(),
+      boolean: yup.boolean().notRequired(),
     })
     .defined()
 
@@ -71,6 +79,20 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
             .defined(),
         )
         .defined(),
+      notes: yup.array(
+        yup
+          .object({
+            isOwner: yup.boolean().defined(),
+            owner: yup.string().defined(),
+            value: yup.string().defined(),
+            assetId: yup.string().defined(),
+            assetName: yup.string().defined(),
+            sender: yup.string().defined(),
+            memo: yup.string().trim().defined(),
+            spent: yup.boolean(),
+          })
+          .defined(),
+      ),
     })
     .defined()
 
@@ -142,6 +164,11 @@ const streamTransaction = async (
 
   const assetBalanceDeltas = await getAssetBalanceDeltas(node, transaction)
 
+  let notes = undefined
+  if (request.data.notes) {
+    notes = await getAccountDecryptedNotes(node, account, transaction)
+  }
+
   const status = await node.wallet.getTransactionStatus(account, transaction, options)
   const type = await node.wallet.getTransactionType(account, transaction)
 
@@ -150,6 +177,7 @@ const streamTransaction = async (
     assetBalanceDeltas,
     status,
     type,
+    notes,
   }
 
   request.stream(serialized)


### PR DESCRIPTION
## Summary

optionally decrypts transaction output notes and includes them in the response from getAccountTransactions with each transaction.

adding the decrypted notes will support adding both sender address and recipient address to the output of `wallet:transactions`: each note includes both the sender address and the 'owner' address, which is the recipient address.

## Testing Plan

- adds unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
