### PR TITLE
moves wallet rpc util functions from types to utils

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -4,12 +4,13 @@
 import * as yup from 'yup'
 import { TransactionStatus, TransactionType } from '../../../wallet'
 import { ApiNamespace, router } from '../router'
+import { RpcAccountDecryptedNote } from './types'
 import {
+  getAccount,
+  getAccountDecryptedNotes,
   getAssetBalanceDeltas,
-  RpcAccountDecryptedNote,
   serializeRpcAccountTransaction,
-} from './types'
-import { getAccount, getAccountDecryptedNotes } from './utils'
+} from './utils'
 
 export type GetAccountTransactionRequest = {
   hash: string

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -9,12 +9,13 @@ import { Account } from '../../../wallet/account'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { RpcRequest } from '../../request'
 import { ApiNamespace, router } from '../router'
+import { RpcAccountDecryptedNote } from './types'
 import {
+  getAccount,
+  getAccountDecryptedNotes,
   getAssetBalanceDeltas,
-  RpcAccountDecryptedNote,
   serializeRpcAccountTransaction,
-} from './types'
-import { getAccount, getAccountDecryptedNotes } from './utils'
+} from './utils'
 
 export type GetAccountTransactionsRequest = {
   account?: string

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -1,8 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { IronfishNode } from '../../../node'
-import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 
 export type RpcAccountTransaction = {
   hash: string
@@ -15,7 +13,6 @@ export type RpcAccountTransaction = {
   burnsCount: number
   expiration: number
   timestamp: number
-  submittedSequence: number
 }
 
 export type RcpAccountAssetBalanceDelta = {
@@ -33,44 +30,4 @@ export type RpcAccountDecryptedNote = {
   sender: string
   owner: string
   spent: boolean
-}
-
-export function serializeRpcAccountTransaction(
-  transaction: TransactionValue,
-): RpcAccountTransaction {
-  return {
-    hash: transaction.transaction.hash().toString('hex'),
-    fee: transaction.transaction.fee().toString(),
-    blockHash: transaction.blockHash?.toString('hex'),
-    blockSequence: transaction.sequence ?? undefined,
-    notesCount: transaction.transaction.notes.length,
-    spendsCount: transaction.transaction.spends.length,
-    mintsCount: transaction.transaction.mints.length,
-    burnsCount: transaction.transaction.burns.length,
-    expiration: transaction.transaction.expiration(),
-    timestamp: transaction.timestamp.getTime(),
-    submittedSequence: transaction.submittedSequence,
-  }
-}
-
-export async function getAssetBalanceDeltas(
-  node: IronfishNode,
-  transaction: TransactionValue,
-): Promise<RcpAccountAssetBalanceDelta[]> {
-  const assetBalanceDeltas = new Array<RcpAccountAssetBalanceDelta>()
-
-  for (const [assetId, delta] of transaction.assetBalanceDeltas.entries()) {
-    // TODO: update to use wallet assets store
-    const asset = await node.chain.getAssetById(assetId)
-
-    const assetName = asset?.name.toString('hex') ?? ''
-
-    assetBalanceDeltas.push({
-      assetId: assetId.toString('hex'),
-      assetName,
-      delta: delta.toString(),
-    })
-  }
-
-  return assetBalanceDeltas
 }


### PR DESCRIPTION
## Summary

we have a couple of functions defined in the 'types' module. functions like these may fit better in 'utils' than in 'types'

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
