### PR TITLE
Revert "optionally organizes wallet:transactions output by note"

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -37,10 +37,6 @@ export class TransactionsCommand extends IronfishCommand {
     confirmations: Flags.integer({
       description: 'Number of block confirmations needed to confirm a transaction',
     }),
-    notes: Flags.boolean({
-      default: false,
-      description: 'Include data from transaction output notes',
-    }),
   }
 
   static args = [
@@ -73,17 +69,14 @@ export class TransactionsCommand extends IronfishCommand {
       limit: flags.limit,
       offset: flags.offset,
       confirmations: flags.confirmations,
-      notes: flags.notes,
     })
 
-    const columns = this.getColumns(flags.extended, flags.notes, format)
+    const columns = this.getColumns(flags.extended, format)
 
     let showHeader = !flags['no-header']
 
     for await (const transaction of response.contentStream()) {
-      const transactionRows = flags.notes
-        ? this.getTransactionRowsByNote(transaction, format)
-        : this.getTransactionRows(transaction, format)
+      const transactionRows = this.getTransactionRows(transaction, format)
 
       CliUx.ux.table(transactionRows, columns, {
         printLine: this.log.bind(this),
@@ -151,63 +144,11 @@ export class TransactionsCommand extends IronfishCommand {
     return transactionRows
   }
 
-  getTransactionRowsByNote(
-    transaction: GetAccountTransactionsResponse,
-    format: Format,
-  ): PartialRecursive<TransactionRow>[] {
-    Assert.isNotUndefined(transaction.notes)
-    const transactionRows = []
-
-    const nativeAssetId = Asset.nativeId().toString('hex')
-
-    const notes = transaction.notes.sort((n) => (n.assetId === nativeAssetId ? -1 : 1))
-
-    const noteCount = transaction.notes.length
-
-    const feePaid = transaction.type === TransactionType.SEND ? BigInt(transaction.fee) : 0n
-
-    for (const [index, note] of notes.entries()) {
-      const amount = BigInt(note.value)
-      const assetId = note.assetId
-      const assetName = note.assetName
-      const sender = note.sender
-      const recipient = note.owner
-
-      const group = this.getRowGroup(index, noteCount, transactionRows.length)
-
-      // include full transaction details in first row or non-cli-formatted output
-      if (transactionRows.length === 0 || format !== Format.cli) {
-        transactionRows.push({
-          ...transaction,
-          group,
-          assetId,
-          assetName,
-          amount,
-          feePaid,
-          sender,
-          recipient,
-        })
-      } else {
-        transactionRows.push({
-          group,
-          assetId,
-          assetName,
-          amount,
-          sender,
-          recipient,
-        })
-      }
-    }
-
-    return transactionRows
-  }
-
   getColumns(
     extended: boolean,
-    notes: boolean,
     format: Format,
   ): CliUx.Table.table.Columns<PartialRecursive<TransactionRow>> {
-    let columns: CliUx.Table.table.Columns<PartialRecursive<TransactionRow>> = {
+    const columns: CliUx.Table.table.Columns<PartialRecursive<TransactionRow>> = {
       timestamp: TableCols.timestamp({
         streaming: true,
       }),
@@ -256,7 +197,7 @@ export class TransactionsCommand extends IronfishCommand {
       },
       ...TableCols.asset({ extended, format }),
       amount: {
-        header: 'Amount',
+        header: 'Net Amount',
         get: (row) => {
           Assert.isNotUndefined(row.amount)
           return CurrencyUtils.renderIron(row.amount)
@@ -265,20 +206,8 @@ export class TransactionsCommand extends IronfishCommand {
       },
     }
 
-    if (notes) {
-      columns = {
-        ...columns,
-        sender: {
-          header: 'Sender Address',
-        },
-        recipient: {
-          header: 'Recipient Address',
-        },
-      }
-    }
-
     if (format === Format.cli) {
-      columns = {
+      return {
         group: {
           header: '',
           minWidth: 3,
@@ -321,6 +250,4 @@ type TransactionRow = {
   burnsCount: number
   expiration: number
   submittedSequence: number
-  sender: string
-  recipient: string
 }


### PR DESCRIPTION
## Summary

This reverts commit 0be0d68a4dc1a679873155b1a0c521955681fb2e.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
