### PR TITLE
Clarify db version error when db is newer

### DIFF
--- a/ironfish/src/storage/database/errors.ts
+++ b/ironfish/src/storage/database/errors.ts
@@ -33,13 +33,16 @@ export class DatabaseVersionError extends DatabaseOpenError {
   readonly version: number
   readonly expected: number
 
-  constructor(version: number, expected: number) {
+  constructor(current: number, version: number) {
     super(
-      `Your database needs to be upgraded (v${version} vs v${expected}).\n` +
-        `Run "ironfish migrations:start" or "ironfish start --upgrade"\n`,
+      current <= version
+        ? `Your database needs to be upgraded (v${current} vs v${version}).\n` +
+            `Run "ironfish migrations:start" or "ironfish start --upgrade"\n`
+        : `Your database is newer than your node.\n` +
+            `Your database is ${version} and your node is ${current}.\n`,
     )
 
-    this.version = version
-    this.expected = expected
+    this.version = current
+    this.expected = version
   }
 }


### PR DESCRIPTION
## Summary

When the DB is newer than your current software, the error is not very clear. It will still tell you to upgrade which is confusing. Now it will give you a better message.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
