### PR TITLE
Move importexport tests to ironfish-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
       - name: Run slow tests & coverage
         run: yarn test:slow:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
 
-      - name: Check for account export/import regressions
-        run: sudo apt-get update && sudo apt-get install -y expect && yarn build && yarn test:importexport
+      - name: Run import/export account tests
+        run: sudo apt-get update && sudo apt-get install -y expect && yarn build && cd ironfish-cli && yarn test:importexport
 
       - name: Upload coverage
         if: github.repository == 'iron-fish/ironfish'

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -49,6 +49,7 @@
     "test": "yarn clean && tsc -b && tsc -b tsconfig.test.json && jest --passWithNoTests",
     "test:coverage:html": "tsc -b tsconfig.test.json && jest --passWithNoTests --coverage --coverage-reporters html --testPathIgnorePatterns",
     "test:watch": "tsc -b tsconfig.test.json && jest --watch --coverage false",
+    "test:importexport": "bash ./scripts/import-export-test.sh",
     "postpack": "rimraf oclif.manifest.json",
     "clean": "rimraf build",
     "prepack": "rimraf build && yarn build && oclif manifest && oclif readme",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "test:update:changed": "lerna run --since origin/master --include-dependents test -- -u",
     "test:slow": "lerna run test:slow",
     "test:slow:coverage": "lerna run test:slow --stream -- --collect-coverage --testPathIgnorePatterns",
-    "test:importexport": "bash ./ironfish-cli/scripts/import-export-test.sh",
     "typecheck": "lerna exec -- tsc --noEmit",
     "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit",
     "coverage:upload": "lerna exec '\"yarn codecov -t $CODECOV_TOKEN -f ./coverage/clover.xml -F $LERNA_PACKAGE_NAME -p $ROOT_PATH/ --disable=gcov\"'"


### PR DESCRIPTION
## Summary

This test command was in the root package, but is only related to testing one package, the ironfish-cli. In the root we only run lerna there, and have each child package have their own set of commands that they own.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
