### PR TITLE
Change importexport tests to use test datadir

### DIFF
--- a/ironfish-cli/scripts/import-export-test/README
+++ b/ironfish-cli/scripts/import-export-test/README
@@ -1,0 +1,1 @@
+When ever the exported wallet format changes, the new wallet format should be included here and it will get automatically tested.


### PR DESCRIPTION
## Summary

I noticed this was failing to run because my datadir database was a later version. I see it's using my actual datadir which I have my real data in. Changing this so it does not use a users real database to perform tests, and instead uses a test datadir.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
