### PR TITLE
Make wallet:import handle wallets from version 71

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -134,6 +134,10 @@ export class ImportCommand extends IronfishCommand {
         }
       }
 
+      if (typeof data.createdAt === 'string') {
+        data.createdAt = null
+      }
+
       return data
     }
 
@@ -158,6 +162,10 @@ export class ImportCommand extends IronfishCommand {
           ...json,
           ...generateKeyFromPrivateKey(json.spendingKey),
         }
+      }
+
+      if (typeof json.createdAt === 'string') {
+        json.createdAt = null
       }
 
       return json


### PR DESCRIPTION
## Summary

It was expecting an object for createdAt, but it used to be a ISO timestamp.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
