### PR TITLE
feature(simulator): add support for running arbitrary ironfish cli commands

### DIFF
--- a/simulator/src/simulator/simulation-node.ts
+++ b/simulator/src/simulator/simulation-node.ts
@@ -13,7 +13,8 @@ import {
   RpcTcpClient,
   YupUtils,
 } from '@ironfish/sdk'
-import { ChildProcessWithoutNullStreams, spawn } from 'child_process'
+import { ChildProcessWithoutNullStreams, exec, ExecException, spawn } from 'child_process'
+import { promisify } from 'util'
 import {
   defaultOnError,
   defaultOnExit,
@@ -320,7 +321,6 @@ export class SimulationNode {
 
     return success
   }
-
   /**
    * Initializes a block stream for a node. Each node should only have 1 block stream
    * because currently the stream RPC  cannot be closed. The `onBlock` event will emit
@@ -381,7 +381,8 @@ export class SimulationNode {
   }
 
   /**
-   * Starts the node process and attaches listeners to it.
+   * Starts the node process and attaches listeners to it. The ironfish
+   * process is is spawned from `ironfish/node_modules/.bin/ironfish`.
    *
    * @param args The arguments to pass to the node process. These arguments follow
    * the same format as the CLI.
@@ -508,6 +509,58 @@ export class SimulationNode {
     this.onBlock.clear()
     this.onLog.clear()
     this.onError.clear()
+  }
+
+  /**
+   * Executes a cli command command via `child_process.exec()` synchronously and returns the stdout and stderr.
+   * If you need the command to be asynchronous, use `executeCliCommandAsync` instead.
+   *
+   * @param args The ironfish cli arguments to execute
+   * @param callback The callback to execute when the command is complete
+   */
+  executeCliCommand(
+    args: string[],
+    callback?: (err: ExecException | null, stdout: string, stderr: string) => void,
+  ): void {
+    args.push('--datadir', this.config.dataDir)
+    this.logger.log(`executing cli command: ${rootCmd} ${args.join(' ')}`)
+    exec(rootCmd + ' ' + args.join(' '), callback)
+  }
+
+  /**
+   * Executes a cli command command via `child_process.exec()` asynchronously and returns the stdout and stderr.
+   * Async behaviour is achieved by wrapping the `child_process.exec()` function in a promise. This function
+   * should be used if you need to execute a command and wait for it to complete before continuing.
+   *
+   * If the command fails, the error is thrown. Arguments should be passed in as an array
+   * and will be concatened with spaces when the command is executed. The datadir is
+   * automatically added to based on the node.
+   *
+   * ```ts
+   * try {
+   *  const { stdout, stderr } = await node.executeCliCommandAsync(['status'])
+   * } catch (e) {
+   *  const error = e as ExecException
+   *  // handle error
+   * }
+   *```
+   *
+   * @param args The ironfish cli arguments to execute
+   * @returns The stdout and stderr of the command
+   */
+  async executeCliCommandAsync(args: string[]): Promise<{ stdout: string; stderr: string }> {
+    const execWithPromise = promisify(exec)
+
+    args.push('--datadir', this.config.dataDir)
+
+    this.logger.log(`executing async cli command: ${rootCmd} ${args.join(' ')}`)
+
+    try {
+      return await execWithPromise(rootCmd + ' ' + args.join(' '))
+    } catch (e) {
+      const error = e as ExecException
+      throw error
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Adds support for running arbitrary ironfish cli commands in simulator simulations.

## Testing Plan
Demo simulation:
```js
export async function run(
  logger: Logger,
  options?: { persist?: boolean; duration?: number },
): Promise<void> {
  const simulator = new Simulator(logger, options)

  const nodes = []
  for (let i = 0; i < 2; i++) {
    nodes.push(await simulator.startNode())
  }

 const { stdout, stderr } = await nodes[0].executeCliCommandAsync('status', ['--all'])
  logger.log(`stdout: ${stdout}`)
  logger.log(`stderr: ${stderr}`)

  nodes[1].executeCliCommand('status', ['--all'], {
    onLog: (data) => {
      logger.log(data)
    },
    onError: (err, stderr) => {
      logger.error(`error: stderr: ${stderr}, ${err.message}, code: ${err.code || 'unknown'}`)
    },
  })

  // wait for all nodes to be stopped
  await simulator.waitForShutdown()

  logger.log('nodes stopped, shutting down...')
}
```
prints
```log
executing async cli command: ironfish status --all --datadir ~/.ironfish-simulator/node-e409
stdout: Version              0.1.74 @ src
Node                 STARTED
Node Name            node-e409
Block Graffiti       node-e409
Memory               Heap: 56.55 MiB -> 90.25 MiB / 3.98 GiB (1.4%), RSS: 529.29 MiB (3.2%), Free: 60.84 MiB (99.6%)
CPU                  Cores: 12, Current: 0.1%, Rolling Avg: 9.1%
P2P Network          CONNECTED - In: 0 B/s, Out: 0 B/s, peers 1
Mining               STARTED - 0 miners, 0 mined, get txs: 0ms, block: 0ms, template: 0ms
Mem Pool             Count: 0 tx, Bytes: 0 B / 57.22 MiB (0.00%), Evictions: 0
Syncer               IDLE - 50.40 blocks added/sec, progress: 0.00%
Blockchain           ad35193fa159cfd7440a3dfdfbe7acb720cb4a44a441ab933071e2b9ef5de90b (1), Since HEAD: 555h 6m (NOT SYNCED)
Accounts             ad35193fa159cfd7440a3dfdfbe7acb720cb4a44a441ab933071e2b9ef5de90b (1)
Telemetry            STOPPED
Workers              STARTED - 0 -> 0 / 6 - 0 jobs Δ, 0 jobs/s

stderr:
executing cli command: ironfish status --all --datadir ~/.ironfish-simulator/node-2765
simulator waiting for shutdown...
Version              0.1.74 @ src
Node                 STARTED
Node Name            node-2765
Block Graffiti       node-2765
Memory               Heap: 56.42 MiB -> 90.00 MiB / 3.99 GiB (1.4%), RSS: 539.37 MiB (3.3%), Free: 141.71 MiB (99.1%)
CPU                  Cores: 12, Current: 2.3%, Rolling Avg: 1.2%
P2P Network          CONNECTED - In: 0 B/s, Out: 0 B/s, peers 1
Mining               STARTED - 0 miners, 0 mined, get txs: 0ms, block: 0ms, template: 0ms
Mem Pool             Count: 0 tx, Bytes: 0 B / 57.22 MiB (0.00%), Evictions: 0
Syncer               IDLE - 54.61 blocks added/sec, progress: 0.00%
Blockchain           ad35193fa159cfd7440a3dfdfbe7acb720cb4a44a441ab933071e2b9ef5de90b (1), Since HEAD: 555h 6m (NOT SYNCED)
Accounts             ad35193fa159cfd7440a3dfdfbe7acb720cb4a44a441ab933071e2b9ef5de90b (1)
Telemetry            STOPPED
Workers              STARTED - 0 -> 0 / 6 - 0 jobs Δ, 0 jobs/s
```
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
