### PR TITLE
enforces max target value in Target construction

### DIFF
--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -237,7 +237,7 @@ export class BlockHeader {
    * repeatedly.
    */
   verifyTarget(): boolean {
-    return Target.meets(new Target(this.recomputeHash()).asBigInt(), this.target)
+    return Target.meets(BigIntUtils.fromBytesBE(this.recomputeHash()), this.target)
   }
 
   equals(other: BlockHeader): boolean {

--- a/ironfish/src/primitives/target.test.ts
+++ b/ironfish/src/primitives/target.test.ts
@@ -24,6 +24,11 @@ describe('Target', () => {
     expect(() => new Target(bytes)).toThrow(`Target value exceeds max target`)
   })
 
+  it('throws when constructed with a value greater than the maximum target', () => {
+    const maxTarget = Target.maxTarget().asBigInt()
+    expect(() => new Target(maxTarget + 1n)).toThrow(`Target value exceeds max target`)
+  })
+
   it('has the correct max value', () => {
     // The minimum difficulty is 131072, which means the maximum target is 2**256 / 131072
     const maxTarget = BigInt(2) ** BigInt(256) / BigInt(Target.minDifficulty())
@@ -222,6 +227,10 @@ describe('Calculate target', () => {
 
     it('does not return values outside the 256 bit range', () => {
       expect(Target.fromDifficulty(1n).targetValue).toBeLessThanOrEqual(2n ** 256n - 1n)
+    })
+
+    it('returns the maximum target for difficulty below the minimum', () => {
+      expect(Target.fromDifficulty(Target.minDifficulty() - 1n)).toEqual(Target.maxTarget())
     })
   })
 

--- a/ironfish/src/primitives/target.test.ts
+++ b/ironfish/src/primitives/target.test.ts
@@ -24,11 +24,6 @@ describe('Target', () => {
     expect(() => new Target(bytes)).toThrow(`Target value exceeds max target`)
   })
 
-  it('throws when constructed with a value greater than the maximum target', () => {
-    const maxTarget = Target.maxTarget().asBigInt()
-    expect(() => new Target(maxTarget + 1n)).toThrow(`Target value exceeds max target`)
-  })
-
   it('has the correct max value', () => {
     // The minimum difficulty is 131072, which means the maximum target is 2**256 / 131072
     const maxTarget = BigInt(2) ** BigInt(256) / BigInt(Target.minDifficulty())

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -32,7 +32,7 @@ export class Target {
           ? BigIntUtils.fromBytesBE(targetValue)
           : BigInt(targetValue)
 
-      if (candidate > MAX_256_BIT_NUM) {
+      if (candidate > MAX_TARGET) {
         throw new Error('Target value exceeds max target')
       } else {
         this.targetValue = candidate
@@ -142,8 +142,8 @@ export class Target {
    * Converts difficulty to Target
    */
   static fromDifficulty(difficulty: bigint): Target {
-    if (difficulty <= 1n) {
-      return new Target(MAX_256_BIT_NUM)
+    if (difficulty <= Target.minDifficulty()) {
+      return Target.maxTarget()
     }
     return new Target((2n ** 256n / difficulty).valueOf())
   }

--- a/ironfish/src/primitives/target.ts
+++ b/ironfish/src/primitives/target.ts
@@ -32,7 +32,7 @@ export class Target {
           ? BigIntUtils.fromBytesBE(targetValue)
           : BigInt(targetValue)
 
-      if (candidate > MAX_TARGET) {
+      if (candidate > MAX_256_BIT_NUM) {
         throw new Error('Target value exceeds max target')
       } else {
         this.targetValue = candidate


### PR DESCRIPTION
## Summary

we define a maximum target value, but we don't enforce that a constructed Target instance is below the maximum target value.

- update fromDifficulty to return maxTarget for any difficulty >= minDifficulty
- updates blockheader to use bigint directly in verifyTarget instead of constructing Target from hash

## Testing Plan

- adds unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
