### PR TITLE
Return error codes for RPC errors

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -85,6 +85,8 @@ export abstract class IronfishCommand extends Command {
         if (error.codeStack) {
           this.sdk.logger.debug(error.codeStack)
         }
+
+        this.exit(1)
       } else if (error instanceof ExitError) {
         throw error
       } else if (error instanceof CLIError) {


### PR DESCRIPTION
## Summary
I noticed that when ever an RPC error occurs the exit code is still 0. For these, we should be returning non zero exit codes. I'm not sure if there is an oclif bug reason for this to not do this but I think we should do this until we find a reason not to.

## Notes

```
[ ] Requires documentation updates
[ ] Has breaking changes
```

### Testing Plan