### PR TITLE
Make logs for importexport tests simpler

### DIFF
--- a/ironfish-cli/scripts/import-export-test.sh
+++ b/ironfish-cli/scripts/import-export-test.sh
@@ -1,16 +1,20 @@
-#!/bin/bash
-
-set -e # exit immediately if anything returns with non-zero exit code
-
-# Change working directory to the script's directory
+#!/usr/bin/env bash
+set -euo pipefail
 cd "$(dirname "$0")"
 
+ENABLE_LOGS=0
 DATA_DIR="../testdbs/importexport"
-rm -rf $DATA_DIR
+TIMEFORMAT='Success in %3lR'
 
 if ! command -v expect &> /dev/null; then
     echo "expect is not installed but is required"
     exit 1
+fi
+
+if [[ $ENABLE_LOGS -eq 1 ]] ; then
+    exec 3>&1
+else
+    exec 3>/dev/null
 fi
 
 # check if import was successful
@@ -18,22 +22,21 @@ function check_import_success() {
     local account_name=$1
     ACCOUNTS_OUTPUT=$(../bin/ironfish wallet:accounts -d $DATA_DIR)
 
-    if echo "$ACCOUNTS_OUTPUT" | grep -q "$account_name"; then
-        echo "Import successful for $account_name"
-    else
+    if ! echo "$ACCOUNTS_OUTPUT" | grep -q "$account_name"; then
         echo "Import failed for $account_name"
         exit 1
     fi
 }
 
 # check if deletion was successful
-function check_delete_success() {
+function delete_account() {
     local account_name=$1
+
+    ../bin/ironfish wallet:delete -d $DATA_DIR $account_name &> /dev/null
+
     ACCOUNTS_OUTPUT=$(../bin/ironfish wallet:accounts -d $DATA_DIR)
 
-    if ! echo "$ACCOUNTS_OUTPUT" | grep -q "$account_name"; then
-        echo "Deletion successful for $account_name"
-    else
+    if echo "$ACCOUNTS_OUTPUT" | grep -q "$account_name"; then
         echo "Deletion failed for $account_name"
         exit 1
     fi
@@ -52,10 +55,9 @@ function check_error() {
 function import_account_interactively() {
     local account_name="$1"
     local file_contents="$2"
-    echo "Testing interactive import."
 
     expect -c "
-        spawn ../bin/ironfish wallet:import -d $DATA_DIR
+        spawn ../bin/ironfish wallet:import -d $DATA_DIR --name $account_name
         expect \"Paste the output of wallet:export, or your spending key:\"
         send {${file_contents}}
         send \"\r\"
@@ -63,35 +65,25 @@ function import_account_interactively() {
             \"Paste the output of wallet:export, or your spending key:\" {
                 exp_continue
             }
-            \"Enter a new account name:\" {
-                send \"$account_name\\r\"
-                exp_continue
-            }
             \"Account $account_name imported\" {
                 # Success, do nothing
             }
             eof
         }
-    "
+    " >&3
+
     check_error "Import failed for $account_name"
     check_import_success "$ACCOUNT_NAME"
-    ../bin/ironfish wallet:delete $ACCOUNT_NAME -d $DATA_DIR
-    check_error "Deletion failed for $account_name"
-    check_delete_success "$ACCOUNT_NAME"
 }
 
 
 function import_account_by_pipe() {
-    echo "Testing import by pipe."
     local account_name="$1"
     local test_file="$2"
+
     expect -c "
-        spawn sh -c \"cat $test_file | ../bin/ironfish wallet:import -d $DATA_DIR\"
+        spawn sh -c \"cat $test_file | ../bin/ironfish wallet:import -d $DATA_DIR --name $account_name\"
         expect {
-            \"Enter a new account name:\" {
-                send \"$account_name\\r\"
-                exp_continue
-            }
             \"Account $account_name imported\" {
                 set output \$expect_out(buffer)
                 exp_continue
@@ -101,28 +93,19 @@ function import_account_by_pipe() {
             }
         }
         puts \$output
-    "
+    " >&3
+
     check_error "Import failed for $account_name"
     check_import_success "$account_name"
-    ../bin/ironfish wallet:delete $account_name -d $DATA_DIR
-    check_error "Deletion failed for $account_name"
-    check_delete_success "$account_name"
 }
-
-
-
 
 function import_account_by_path() {
-    echo "Testing import by path."
     local account_name="$1"
     local test_file="$2"
+
     expect -c "
-        spawn ../bin/ironfish wallet:import --path $test_file -d $DATA_DIR
+        spawn ../bin/ironfish wallet:import --path $test_file -d $DATA_DIR --name $account_name
         expect {
-            \"Enter a new account name:\" {
-                send \"$account_name\\r\"
-                exp_continue
-            }
             \"Account $account_name imported\" {
                 set output \$expect_out(buffer)
             }
@@ -131,26 +114,31 @@ function import_account_by_path() {
             }
         }
         puts \$output
-    "
+    " >&3
+
     check_error "Import failed for $account_name"
     check_import_success "$account_name"
-    ../bin/ironfish wallet:delete $account_name -d $DATA_DIR
-    check_error "Deletion failed for $account_name"
-    check_delete_success "$account_name"
 }
 
-TEST_FIXTURE_LOCATION='./import-export-test/'
-for TEST_FILE in "${TEST_FIXTURE_LOCATION}"*.txt
+rm -rf $DATA_DIR
+
+for TEST_FILE in ./import-export-test/*.txt
     do
     FILENAME=$(basename -- "$TEST_FILE")
     ACCOUNT_NAME="${FILENAME%.*}"
     FILE_CONTENTS=$(cat "$TEST_FILE")
 
-    import_account_interactively "$ACCOUNT_NAME" "$FILE_CONTENTS"
-    import_account_by_path "$ACCOUNT_NAME" "$TEST_FILE"
-    # Skip import_account_by_pipe if the filename contains "mnemonic"
     if [[ "$FILENAME" != *"mnemonic"* ]]; then
-        import_account_by_pipe "$ACCOUNT_NAME" "$TEST_FILE"
+        echo "Running import by pipe:  $TEST_FILE"
+        time import_account_by_pipe "$ACCOUNT_NAME" "$TEST_FILE"
+        delete_account "$ACCOUNT_NAME"
     fi
+
+    echo "Running import by input: $TEST_FILE"
+    time import_account_interactively "$ACCOUNT_NAME" "$FILE_CONTENTS"
+    delete_account "$ACCOUNT_NAME"
+
+    echo "Running import by path:  $TEST_FILE"
+    time import_account_by_path "$ACCOUNT_NAME" "$TEST_FILE"
 done
 


### PR DESCRIPTION
## Summary

I had a hard time scanning the logs of this to see what it was doing. I simplified the logs and added two new things.

 - Remove extraneous success logs
 - Only log when each test is starting
 - Don't delete the last test account created for perf boost
 - Print out the time each test takes
 - Add ENABLE_LOGS variable to show ironfish logs to help debugging

```
Running import by pipe:  ./import-export-test/0p1p65_blob.txt
Success in 0m1.838s
Running import by input: ./import-export-test/0p1p65_blob.txt
Success in 0m1.636s
Running import by path:  ./import-export-test/0p1p65_blob.txt
Success in 0m1.643s
Running import by pipe:  ./import-export-test/0p1p65_json.txt
Success in 0m1.761s
Running import by input: ./import-export-test/0p1p65_json.txt
Success in 0m1.633s
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
