### PR TITLE
Fix trusted setup error when verifying

### DIFF
--- a/ironfish-cli/src/trusted-setup/server.ts
+++ b/ironfish-cli/src/trusted-setup/server.ts
@@ -308,14 +308,12 @@ export class CeremonyServer {
         await this.handleUploadComplete(client).catch((e) => {
           client.logger.error(`Error handling upload-complete: ${ErrorUtils.renderError(e)}`)
 
-          if (this.currentContributor?.client?.id === client.id) {
-            this.currentContributor.state !== 'VERIFYING' &&
-              clearTimeout(this.currentContributor.actionTimeout)
+          this.closeClient(client)
+
+          if (this.currentContributor?.client == null) {
             this.currentContributor = null
             void this.startNextContributor()
           }
-
-          client.close(new Error(`Error verifying contribution`))
         })
       } else {
         client.logger.error(`Unknown method received: ${message}`)


### PR DESCRIPTION
## Summary
If the server encounters an error when verifying a contribution, the server can get into an unrecoverable state. Where `currentContributor.client` is null nut `currentContributor` is still defined. This means the trying to start the next contributor will not work

## Testing Plan
Local testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
