### PR TITLE
makes blockHash optional in chain/getTransaction requests

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1049,7 +1049,7 @@ export class Blockchain {
     return hash || null
   }
 
-  async getHashByTransactionHash(
+  async getBlockHashByTransactionHash(
     transactionHash: TransactionHash,
     tx?: IDatabaseTransaction,
   ): Promise<BlockHash | null> {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -41,7 +41,7 @@ import {
   SerializedNoteEncryptedHash,
 } from '../primitives/noteEncrypted'
 import { Target } from '../primitives/target'
-import { Transaction } from '../primitives/transaction'
+import { Transaction, TransactionHash } from '../primitives/transaction'
 import {
   BUFFER_ENCODING,
   IDatabase,
@@ -1046,6 +1046,14 @@ export class Blockchain {
     tx?: IDatabaseTransaction,
   ): Promise<BlockHash | null> {
     const hash = await this.sequenceToHash.get(sequence, tx)
+    return hash || null
+  }
+
+  async getHashByTransactionHash(
+    transactionHash: TransactionHash,
+    tx?: IDatabaseTransaction,
+  ): Promise<BlockHash | null> {
+    const hash = await this.transactionHashToBlockHash.get(transactionHash, tx)
     return hash || null
   }
 

--- a/ironfish/src/rpc/routes/chain/__fixtures__/getTransaction.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getTransaction.test.ts.fixture
@@ -1,0 +1,58 @@
+{
+  "Route chain/getTransaction returns transaction by transaction hash only": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:3tpgTHvlvct/1r6327Mrqk6jEkxd6ADQ6MF1yKVfhiI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:f4Pz3iFCrnpHqHfBXrwsJZNKbUGFUfOlKqzevF2ylec="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1680814924744,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA28YXwWJZ6RibN7/kpIBEakgjIBj3gdcADLnhvLJKylOzAZjtumLrMTDhPDEJhF+eWxFB+bJ4TktEtSok5wP0R6exAsNdtXsVuqi8W4QSp2SqGCGIA5zDBlblyilTED0tevT3nK1WU/fpHICCf2p+wsbD5tCj9ZqtE8Wvz5DWyh0JUPysadf6EZYbr5z0HBrwdinbsl6Z5TAqwgGwEuti2qTsyCJKl5tvFykCTFqxif6CtzxdvLpsgILdQqCmvnNOJ1Y0jYsHdBEwInWelWiXGFibKcj6mPnn0/xpGJKjmG5/pI7ONVvWfIEcddXO/ElbOvatVa97gZQ9sC8qOoKlJUJzHGQW/HTOyFojq9xmoK9KfjfK4P25MfStymMje3JLVZZdvm7mlKEEn0f8n34ep/t2uz/LNY3+z75yCBXzQlFHZ3tnoy4kAE4tF/Ls+X+p5+z1LDxAqajVB9FEWyTksAhJdhrh3X1Hu+8tMPRffYpwA/NwO8NI7n/UdtXaAxwe0kbLsl5bL9Sf3USVeLnqGe4sx4w+cRUEM9RTAFWDlZTHWP+a4Gz/6rpJazGtYUGNAvSG01wGff0BddnOCSqAYqIqF5P0/CWoH6FITBrqyO54UNtsr2vtlklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGpu9n2jvuJD0aj32bI0VcsvXR1Yk8z9KTpf+5BxFGkEXgxgkXRQG+qs7kfyuEmzYmKGHiTlAmcYGHuP4GTYLDA=="
+        }
+      ]
+    }
+  ],
+  "Route chain/getTransaction returns transaction by block hash and transaction hash": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:yn11mTfYPldXY1rLPMX+1shY0RqUzIldSDfWzy4261c="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:svXyxEk0j6vfN1v0sIXyU4yArxPBJzCMilE5FrkVeuA="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1680814925310,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAg3dZPGxxpHVoiHc2VOR/dHJJASrEIICmnubJThbCMByiWpeAr9ca4y4kkbeZSt2YrcW3Sx6EWR0pIzsHVeODEgxgWbR1rCuCjWoUsMTiLHqnoEu+YkVtV0tiJtUl3zLUpPrsaE8dfszrv+i/x5RfsWlP1pOCiHidbhKkWX7itgkUCJnZQjtcwT3ANcKWudyRsGPxDckkOGKCo/ApXq93YIFr3akmaWKM+kHX47K5CUi1go/s0RJ/X2YbCr0IsUEP326TyupAFzZR3FyMfLadcCGhv9nrxITlDd9Tq8aqq7GaeRH2+/uON1kyWalFLFCICTY40loVK7PIrkwmWLVXHTaIWC6bbyU80IUdTld8DZrSsJmHd4+PXGqbs9QJ4SEUmPm0gNn8LNu2G2bVjw8lFrk8Jgm3bJZhArJAF+KdpWeiRztcUVKVpYOAVFgFbZ6NDseXGZZhA2sqT1GbRKOrtSiNgqjM4sft4uA9AQjYioAGPm8yzBnb3eSKCxVbg6yhhOulxUN2kwWOTOqrBa0w24bW7ibtEvg6wy9amuJpf/Lrha578EvEn74fuoCndLkO4qGxPg+WFhC2AaIVhcjAU8V1u0phNb5wmlhbZGno808H4ziQ/D+yQ0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwuBQhvrNZVaZGkedqIYdloNlGTA4YRZcFs1Dgh67citB+7abuXxZAPZswRCg2QogfjOiAMw6gDE6xcM1Fo89bCQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/chain/getTransaction.test.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.test.ts
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { useMinerBlockFixture } from '../../../testUtilities'
+import { createRouteTest } from '../../../testUtilities/routeTest'
+import { CurrencyUtils } from '../../../utils'
+import { ERROR_CODES } from '../../adapters'
+import { RpcRequestError } from '../../clients'
+import { GetTransactionResponse } from './getTransaction'
+
+describe('Route chain/getTransaction', () => {
+  const routeTest = createRouteTest()
+
+  it('returns transaction by transaction hash only', async () => {
+    const { chain } = routeTest
+
+    const block2 = await useMinerBlockFixture(chain)
+    await expect(chain).toAddBlock(block2)
+
+    const transaction = block2.transactions[0]
+
+    const notesEncrypted: string[] = []
+
+    for (const note of transaction.notes) {
+      notesEncrypted.push(note.serialize().toString('hex'))
+    }
+
+    const response = await routeTest.client
+      .request<GetTransactionResponse>('chain/getTransaction', {
+        transactionHash: transaction.hash().toString('hex'),
+      })
+      .waitForEnd()
+
+    expect(response.content).toMatchObject({
+      fee: CurrencyUtils.encode(transaction.fee()),
+      expiration: transaction.expiration(),
+      notesCount: 1,
+      spendsCount: 0,
+      signature: transaction.transactionSignature().toString('hex'),
+      notesEncrypted,
+      mints: [],
+      burns: [],
+    })
+  })
+
+  it('returns transaction by block hash and transaction hash', async () => {
+    const { chain } = routeTest
+
+    const block2 = await useMinerBlockFixture(chain)
+    await expect(chain).toAddBlock(block2)
+
+    const transaction = block2.transactions[0]
+
+    const notesEncrypted: string[] = []
+
+    for (const note of transaction.notes) {
+      notesEncrypted.push(note.serialize().toString('hex'))
+    }
+
+    const response = await routeTest.client
+      .request<GetTransactionResponse>('chain/getTransaction', {
+        blockHash: block2.header.hash.toString('hex'),
+        transactionHash: transaction.hash().toString('hex'),
+      })
+      .waitForEnd()
+
+    expect(response.content).toMatchObject({
+      fee: CurrencyUtils.encode(transaction.fee()),
+      expiration: transaction.expiration(),
+      notesCount: 1,
+      spendsCount: 0,
+      signature: transaction.transactionSignature().toString('hex'),
+      notesEncrypted,
+      mints: [],
+      burns: [],
+    })
+  })
+
+  it('throws an error if no transaction hash is provided', async () => {
+    await expect(
+      async () =>
+        await routeTest.client
+          .request<GetTransactionResponse>('chain/getTransaction', {})
+          .waitForEnd(),
+    ).rejects.toThrow(RpcRequestError)
+  })
+
+  it('throws an error if no block is found', async () => {
+    await expect(
+      async () =>
+        await routeTest.client
+          .request<GetTransactionResponse>('chain/getTransaction', {
+            transactionHash: 'deadbeef',
+            blockHash: 'deadbeef',
+          })
+          .waitForEnd(),
+    ).rejects.toThrow(RpcRequestError)
+  })
+
+  it('throws an error if transaction does not have a block hash', async () => {
+    await expect(
+      async () =>
+        await routeTest.client
+          .request<GetTransactionResponse>('chain/getTransaction', {
+            transactionHash: 'deadbeef',
+          })
+          .waitForEnd(),
+    ).rejects.toThrow(RpcRequestError)
+  })
+})

--- a/ironfish/src/rpc/routes/chain/getTransaction.test.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.test.ts
@@ -4,7 +4,6 @@
 import { useMinerBlockFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { CurrencyUtils } from '../../../utils'
-import { ERROR_CODES } from '../../adapters'
 import { RpcRequestError } from '../../clients'
 import { GetTransactionResponse } from './getTransaction'
 

--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -7,7 +7,7 @@ import { CurrencyUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
 
-export type GetTransactionRequest = { blockHash: string; transactionHash: string }
+export type GetTransactionRequest = { transactionHash: string; blockHash?: string }
 
 export type GetTransactionResponse = {
   fee: string
@@ -27,8 +27,8 @@ export type GetTransactionResponse = {
 }
 export const GetTransactionRequestSchema: yup.ObjectSchema<GetTransactionRequest> = yup
   .object({
-    blockHash: yup.string().defined(),
     transactionHash: yup.string().defined(),
+    blockHash: yup.string(),
   })
   .defined()
 
@@ -67,10 +67,21 @@ router.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
   `${ApiNamespace.chain}/getTransaction`,
   GetTransactionRequestSchema,
   async (request, node): Promise<void> => {
-    if (!request.data.blockHash || !request.data.transactionHash) {
-      throw new ValidationError(`Missing block hash or transaction hash`)
+    if (!request.data.transactionHash) {
+      throw new ValidationError(`Missing transaction hash`)
     }
-    const hashBuffer = BlockHashSerdeInstance.deserialize(request.data.blockHash)
+
+    const hashBuffer = request.data.blockHash
+      ? BlockHashSerdeInstance.deserialize(request.data.blockHash)
+      : await node.chain.getHashByTransactionHash(
+          Buffer.from(request.data.transactionHash, 'hex'),
+        )
+
+    if (!hashBuffer) {
+      throw new ValidationError(
+        `No block hash found for transaction hash ${request.data.transactionHash}`,
+      )
+    }
 
     const block = await node.chain.getBlock(hashBuffer)
     if (!block) {

--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -73,7 +73,7 @@ router.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
 
     const hashBuffer = request.data.blockHash
       ? BlockHashSerdeInstance.deserialize(request.data.blockHash)
-      : await node.chain.getHashByTransactionHash(
+      : await node.chain.getBlockHashByTransactionHash(
           Buffer.from(request.data.transactionHash, 'hex'),
         )
 


### PR DESCRIPTION
## Summary

after adding an index from transaction hash to block hash in #3761 we no longer need to include a block hash in requests to chain/getTransaction. instead we can use the index to look up the hash of the block on the main chain that includes that transaction, if any.

- defines 'getHashByTransactionHash' to look up a block hash in 'transactionHashToBlockHash'
- changes 'blockHash' to an optional request parameter

## Testing Plan

- adds route tests for chain/getTransaction

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```
https://github.com/iron-fish/website/pull/359

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
