### PR TITLE
adds hash to response of wallet/postTransaction

### DIFF
--- a/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Transaction } from '../../../primitives'
 import { RawTransactionSerde } from '../../../primitives/rawTransaction'
 import { useAccountFixture } from '../../../testUtilities'
 import { createRawTransaction } from '../../../testUtilities/helpers/transaction'
@@ -27,8 +28,9 @@ describe('Route wallet/postTransaction', () => {
 
     expect(addSpy).toHaveBeenCalledTimes(0)
     expect(response.status).toBe(200)
-    expect(response.content.hash).toBe(expect.any(String))
     expect(response.content.transaction).toBeDefined()
+    const transaction = new Transaction(Buffer.from(response.content.transaction, 'hex'))
+    expect(response.content.hash).toBe(transaction.hash().toString('hex'))
   })
 
   it('should post a raw transaction', async () => {
@@ -47,8 +49,9 @@ describe('Route wallet/postTransaction', () => {
 
     expect(addSpy).toHaveBeenCalledTimes(1)
     expect(response.status).toBe(200)
-    expect(response.content.hash).toBeDefined()
     expect(response.content.transaction).toBeDefined()
+    const transaction = new Transaction(Buffer.from(response.content.transaction, 'hex'))
+    expect(response.content.hash).toBe(transaction.hash().toString('hex'))
   })
 
   it("should return an error if the transaction won't deserialize", async () => {

--- a/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
@@ -27,7 +27,7 @@ describe('Route wallet/postTransaction', () => {
 
     expect(addSpy).toHaveBeenCalledTimes(0)
     expect(response.status).toBe(200)
-    expect(response.content.hash).toBeDefined()
+    expect(response.content.hash).toBe(expect.any(String))
     expect(response.content.transaction).toBeDefined()
   })
 

--- a/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
@@ -27,6 +27,7 @@ describe('Route wallet/postTransaction', () => {
 
     expect(addSpy).toHaveBeenCalledTimes(0)
     expect(response.status).toBe(200)
+    expect(response.content.hash).toBeDefined()
     expect(response.content.transaction).toBeDefined()
   })
 
@@ -46,6 +47,7 @@ describe('Route wallet/postTransaction', () => {
 
     expect(addSpy).toHaveBeenCalledTimes(1)
     expect(response.status).toBe(200)
+    expect(response.content.hash).toBeDefined()
     expect(response.content.transaction).toBeDefined()
   })
 

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -13,6 +13,7 @@ export type PostTransactionRequest = {
 }
 
 export type PostTransactionResponse = {
+  hash: string
   transaction: string
 }
 
@@ -26,6 +27,7 @@ export const PostTransactionRequestSchema: yup.ObjectSchema<PostTransactionReque
 
 export const PostTransactionResponseSchema: yup.ObjectSchema<PostTransactionResponse> = yup
   .object({
+    hash: yup.string().defined(),
     transaction: yup.string().defined(),
   })
   .defined()
@@ -46,6 +48,9 @@ router.register<typeof PostTransactionRequestSchema, PostTransactionResponse>(
     })
 
     const serialized = transaction.serialize()
-    request.end({ transaction: serialized.toString('hex') })
+    request.end({
+      hash: transaction.hash().toString('hex'),
+      transaction: serialized.toString('hex'),
+    })
   },
 )


### PR DESCRIPTION
## Summary

sendTransaction includes the hash in its responses, but postTransaction does not.

a client _could_ hash the output themselves, but this adds an extra step and perhaps an extra dependency for the client.

## Testing Plan

- updates unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
