### PR TITLE
Namespace all routes inside of RPCClient

### DIFF
--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -25,7 +25,7 @@ export default class ShowBlock extends IronfishCommand {
     const search = args.search as string
 
     const client = await this.sdk.connectRpc()
-    const data = await client.getBlock({ search })
+    const data = await client.chain.getBlock({ search })
 
     this.log(JSON.stringify(data.content, undefined, '  '))
   }

--- a/ironfish-cli/src/commands/chain/asset.ts
+++ b/ironfish-cli/src/commands/chain/asset.ts
@@ -27,7 +27,7 @@ export default class Asset extends IronfishCommand {
     const assetId = args.id
 
     const client = await this.sdk.connectRpc()
-    const data = await client.getAsset({ id: assetId })
+    const data = await client.chain.getAsset({ id: assetId })
 
     this.log(`Name: ${BufferUtils.toHuman(Buffer.from(data.content.name, 'hex'))}`)
     this.log(`Metadata: ${BufferUtils.toHuman(Buffer.from(data.content.metadata, 'hex'))}`)

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -49,7 +49,7 @@ export default class Export extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    const stream = client.exportChainStream({
+    const stream = client.chain.exportChainStream({
       start: args.start as number | null,
       stop: args.stop as number | null,
     })

--- a/ironfish-cli/src/commands/chain/forks.ts
+++ b/ironfish-cli/src/commands/chain/forks.ts
@@ -45,8 +45,8 @@ export default class ForksCommand extends IronfishCommand {
 
     await this.sdk.client.connect()
 
-    const targetBlockTimeInSeconds = (await this.sdk.client.getConsensusParameters()).content
-      .targetBlockTimeInSeconds
+    const targetBlockTimeInSeconds = (await this.sdk.client.chain.getConsensusParameters())
+      .content.targetBlockTimeInSeconds
 
     const counter = new GossipForkCounter(targetBlockTimeInSeconds)
     counter.start()
@@ -89,7 +89,7 @@ export default class ForksCommand extends IronfishCommand {
         continue
       }
 
-      const response = this.sdk.client.onGossipStream()
+      const response = this.sdk.client.event.onGossipStream()
 
       for await (const value of response.contentStream()) {
         counter.add(value.blockHeader)

--- a/ironfish-cli/src/commands/chain/power.ts
+++ b/ironfish-cli/src/commands/chain/power.ts
@@ -34,7 +34,7 @@ export default class Power extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    const data = await client.getNetworkHashPower({
+    const data = await client.chain.getNetworkHashPower({
       sequence: block,
       blocks: flags.history,
     })

--- a/ironfish-cli/src/commands/chain/show.ts
+++ b/ironfish-cli/src/commands/chain/show.ts
@@ -36,7 +36,7 @@ export default class Show extends IronfishCommand {
     this.log(`Getting the chain blocks...`)
     await this.sdk.client.connect()
 
-    const data = await this.sdk.client.showChain({ start, stop })
+    const data = await this.sdk.client.chain.showChain({ start, stop })
 
     data.content.content.forEach((content) => this.log(content))
   }

--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -40,7 +40,7 @@ export class EditCommand extends IronfishCommand {
     }
 
     const client = await this.sdk.connectRpc(!flags.remote)
-    const response = await client.getConfig({ user: true })
+    const response = await client.config.getConfig({ user: true })
     const output = JSON.stringify(response.content, undefined, '   ')
 
     const tmpDir = os.tmpdir()
@@ -57,7 +57,7 @@ export class EditCommand extends IronfishCommand {
     const content = await readFileAsync(filePath, { encoding: 'utf8' })
     const config = JSONUtils.parse<Record<string, unknown>>(content)
 
-    await client.uploadConfig({ config })
+    await client.config.uploadConfig({ config })
     this.log('Uploaded config successfully.')
     this.exit(0)
   }

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -46,7 +46,7 @@ export class GetCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc(flags.local)
 
-    const response = await client.getConfig({
+    const response = await client.config.getConfig({
       user: flags.user,
       name: name,
     })

--- a/ironfish-cli/src/commands/config/index.ts
+++ b/ironfish-cli/src/commands/config/index.ts
@@ -26,7 +26,7 @@ export class ShowCommand extends IronfishCommand {
     const { flags } = await this.parse(ShowCommand)
 
     const client = await this.sdk.connectRpc(flags.local)
-    const response = await client.getConfig({ user: flags.user })
+    const response = await client.config.getConfig({ user: flags.user })
 
     let output = JSON.stringify(response.content, undefined, '   ')
     if (flags.color) {

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -41,7 +41,7 @@ export class SetCommand extends IronfishCommand {
     const value = args.value as string
 
     const client = await this.sdk.connectRpc(flags.local)
-    await client.setConfig({ name, value })
+    await client.config.setConfig({ name, value })
 
     this.exit(0)
   }

--- a/ironfish-cli/src/commands/config/unset.ts
+++ b/ironfish-cli/src/commands/config/unset.ts
@@ -32,7 +32,7 @@ export class UnsetCommand extends IronfishCommand {
     const name = args.name as string
 
     const client = await this.sdk.connectRpc(flags.local)
-    await client.unsetConfig({ name })
+    await client.config.unsetConfig({ name })
 
     this.exit(0)
   }

--- a/ironfish-cli/src/commands/faucet.ts
+++ b/ironfish-cli/src/commands/faucet.ts
@@ -34,7 +34,7 @@ export class FaucetCommand extends IronfishCommand {
     }
 
     const client = await this.sdk.connectRpc()
-    const networkInfoResponse = await client.getNetworkInfo()
+    const networkInfoResponse = await client.chain.getNetworkInfo()
 
     if (networkInfoResponse.content === null || networkInfoResponse.content.networkId !== 0) {
       // not testnet
@@ -53,7 +53,7 @@ export class FaucetCommand extends IronfishCommand {
     }
 
     // Create an account if one is not set
-    const response = await client.getDefaultAccount()
+    const response = await client.wallet.getDefaultAccount()
     let accountName = response.content.account?.name
 
     if (!accountName) {
@@ -63,7 +63,7 @@ export class FaucetCommand extends IronfishCommand {
           required: false,
         })) || 'default'
 
-      await client.createAccount({ name: accountName, default: true })
+      await client.wallet.createAccount({ name: accountName, default: true })
     }
 
     CliUx.ux.action.start(
@@ -75,7 +75,7 @@ export class FaucetCommand extends IronfishCommand {
     )
 
     try {
-      await client.getFunds({
+      await client.faucet.getFunds({
         account: accountName,
         email,
       })

--- a/ironfish-cli/src/commands/fees.ts
+++ b/ironfish-cli/src/commands/fees.ts
@@ -32,7 +32,7 @@ export class FeeCommand extends IronfishCommand {
       await this.explainFeeRates(client)
     }
 
-    const feeRates = await client.estimateFeeRates()
+    const feeRates = await client.chain.estimateFeeRates()
 
     this.log('Fee Rates ($ORE/kB)')
     this.log(`slow:    ${feeRates.content.slow || ''}`)
@@ -41,7 +41,7 @@ export class FeeCommand extends IronfishCommand {
   }
 
   async explainFeeRates(client: RpcClient): Promise<void> {
-    const config = await client.getConfig()
+    const config = await client.config.getConfig()
 
     const slow =
       config.content['feeEstimatorPercentileSlow'] || DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW

--- a/ironfish-cli/src/commands/logs.ts
+++ b/ironfish-cli/src/commands/logs.ts
@@ -20,7 +20,7 @@ export default class LogsCommand extends IronfishCommand {
 
     await this.sdk.client.connect()
 
-    const response = this.sdk.client.getLogStream()
+    const response = this.sdk.client.node.getLogStream()
 
     for await (const value of response.contentStream()) {
       let parsedArgs

--- a/ironfish-cli/src/commands/mempool/status.ts
+++ b/ironfish-cli/src/commands/mempool/status.ts
@@ -25,7 +25,7 @@ export default class Status extends IronfishCommand {
 
     if (!flags.follow) {
       const client = await this.sdk.connectRpc()
-      const response = await client.getMempoolStatus()
+      const response = await client.mempool.getMempoolStatus()
       this.log(renderStatus(response.content))
       this.exit(0)
     }
@@ -49,7 +49,7 @@ export default class Status extends IronfishCommand {
         continue
       }
 
-      const response = this.sdk.client.getMempoolStatusStream()
+      const response = this.sdk.client.mempool.getMempoolStatusStream()
       for await (const value of response.contentStream()) {
         statusText.setContent(renderStatus(value))
         screen.render()

--- a/ironfish-cli/src/commands/mempool/transactions.ts
+++ b/ironfish-cli/src/commands/mempool/transactions.ts
@@ -120,7 +120,7 @@ export class TransactionsCommand extends IronfishCommand {
 
     await this.sdk.client.connect()
 
-    const response = this.sdk.client.getMempoolTransactionsStream({
+    const response = this.sdk.client.mempool.getMempoolTransactionsStream({
       limit: flags.queryLimit,
       feeRate,
       fee,

--- a/ironfish-cli/src/commands/miners/start.ts
+++ b/ironfish-cli/src/commands/miners/start.ts
@@ -73,7 +73,7 @@ export class Miner extends IronfishCommand {
 
       if (publicAddress == null) {
         const client = await this.sdk.connectRpc()
-        const publicKeyResponse = await client.getAccountPublicKey({})
+        const publicKeyResponse = await client.wallet.getAccountPublicKey()
 
         publicAddress = publicKeyResponse.content.publicKey
       }

--- a/ironfish-cli/src/commands/peers/banned.ts
+++ b/ironfish-cli/src/commands/peers/banned.ts
@@ -27,7 +27,7 @@ export class BannedCommand extends IronfishCommand {
 
     if (!flags.follow) {
       await this.sdk.client.connect()
-      const response = await this.sdk.client.getBannedPeers()
+      const response = await this.sdk.client.peer.getBannedPeers()
       this.log(renderTable(response.content))
       this.exit(0)
     }
@@ -50,7 +50,7 @@ export class BannedCommand extends IronfishCommand {
         continue
       }
 
-      const response = this.sdk.client.getBannedPeersStream()
+      const response = this.sdk.client.peer.getBannedPeersStream()
 
       for await (const value of response.contentStream()) {
         text.clearBaseLine(0)

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -56,7 +56,7 @@ export class ListCommand extends IronfishCommand {
 
     if (!flags.follow) {
       await this.sdk.client.connect()
-      const response = await this.sdk.client.getPeers()
+      const response = await this.sdk.client.peer.getPeers()
       this.log(renderTable(response.content, flags))
       this.exit(0)
     }
@@ -79,7 +79,7 @@ export class ListCommand extends IronfishCommand {
         continue
       }
 
-      const response = this.sdk.client.getPeersStream()
+      const response = this.sdk.client.peer.getPeersStream()
 
       for await (const value of response.contentStream()) {
         text.clearBaseLine(0)

--- a/ironfish-cli/src/commands/peers/show.ts
+++ b/ironfish-cli/src/commands/peers/show.ts
@@ -31,8 +31,8 @@ export class ShowCommand extends IronfishCommand {
 
     await this.sdk.client.connect()
     const [peer, messages] = await Promise.all([
-      this.sdk.client.getPeer({ identity }),
-      this.sdk.client.getPeerMessages({ identity }),
+      this.sdk.client.peer.getPeer({ identity }),
+      this.sdk.client.peer.getPeerMessages({ identity }),
     ])
 
     if (peer.content.peer === null) {

--- a/ironfish-cli/src/commands/rpc/status.ts
+++ b/ironfish-cli/src/commands/rpc/status.ts
@@ -24,7 +24,7 @@ export default class Status extends IronfishCommand {
 
     if (!flags.follow) {
       const client = await this.sdk.connectRpc()
-      const response = await client.getRpcStatus()
+      const response = await client.rpc.getRpcStatus()
       this.log(renderStatus(response.content))
       this.exit(0)
     }
@@ -48,7 +48,7 @@ export default class Status extends IronfishCommand {
         continue
       }
 
-      const response = this.sdk.client.getRpcStatusStream()
+      const response = this.sdk.client.rpc.getRpcStatusStream()
       for await (const value of response.contentStream()) {
         statusText.setContent(renderStatus(value))
         screen.render()

--- a/ironfish-cli/src/commands/service/estimate-fee-rates.ts
+++ b/ironfish-cli/src/commands/service/estimate-fee-rates.ts
@@ -60,7 +60,7 @@ export default class EstimateFees extends IronfishCommand {
         continue
       }
 
-      const response = await this.sdk.client.estimateFeeRates()
+      const response = await this.sdk.client.chain.estimateFeeRates()
 
       if (!(response.content.slow && response.content.average && response.content.fast)) {
         this.log('Unexpected response')

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -89,7 +89,7 @@ export default class Faucet extends IronfishCommand {
 
     this.log('Fetching faucet account')
 
-    const response = await client.getDefaultAccount()
+    const response = await client.wallet.getDefaultAccount()
     const account = response.content.account?.name
 
     if (!account) {
@@ -112,7 +112,7 @@ export default class Faucet extends IronfishCommand {
     speed: Meter,
     api: WebApi,
   ): Promise<void> {
-    const status = await client.getNodeStatus()
+    const status = await client.node.getStatus()
 
     if (!status.content.blockchain.synced) {
       this.log('Blockchain not synced, waiting 5s')
@@ -147,7 +147,7 @@ export default class Faucet extends IronfishCommand {
       }
     }
 
-    const response = await client.getAccountBalance({ account })
+    const response = await client.wallet.getAccountBalance({ account })
 
     if (BigInt(response.content.available) < BigInt(FAUCET_AMOUNT + FAUCET_FEE)) {
       if (!this.warnedFund) {
@@ -194,7 +194,7 @@ export default class Faucet extends IronfishCommand {
       }
     })
 
-    const tx = await client.sendTransaction({
+    const tx = await client.wallet.sendTransaction({
       account,
       outputs,
       fee: BigInt(faucetTransactions.length * FAUCET_FEE).toString(),

--- a/ironfish-cli/src/commands/service/forks.ts
+++ b/ironfish-cli/src/commands/service/forks.ts
@@ -52,8 +52,8 @@ export default class Forks extends IronfishCommand {
 
     await this.sdk.client.connect()
 
-    const targetBlockTimeInSeconds = (await this.sdk.client.getConsensusParameters()).content
-      .targetBlockTimeInSeconds
+    const targetBlockTimeInSeconds = (await this.sdk.client.chain.getConsensusParameters())
+      .content.targetBlockTimeInSeconds
 
     const counter = new GossipForkCounter(targetBlockTimeInSeconds, { delayMs: flags.delay })
     counter.start()
@@ -88,7 +88,7 @@ export default class Forks extends IronfishCommand {
         continue
       }
 
-      const response = this.sdk.client.onGossipStream()
+      const response = this.sdk.client.event.onGossipStream()
 
       for await (const value of response.contentStream()) {
         counter.add(value.blockHeader)

--- a/ironfish-cli/src/commands/service/sync-multi-asset.ts
+++ b/ironfish-cli/src/commands/service/sync-multi-asset.ts
@@ -95,7 +95,7 @@ export default class SyncMultiAsset extends IronfishCommand {
 
     let lastCountedSequence: number
     if (head) {
-      const block = await client.getBlock({ hash: head })
+      const block = await client.chain.getBlock({ hash: head })
       lastCountedSequence = block.content.block.sequence
     } else {
       lastCountedSequence = GENESIS_BLOCK_SEQUENCE
@@ -103,7 +103,7 @@ export default class SyncMultiAsset extends IronfishCommand {
 
     this.log(`Starting from block ${lastCountedSequence}: ${head || 'Genesis Block'}`)
 
-    const response = this.sdk.client.getTransactionStream({
+    const response = this.sdk.client.chain.getTransactionStream({
       incomingViewKey: viewKey,
       head: head,
     })

--- a/ironfish-cli/src/commands/service/sync.ts
+++ b/ironfish-cli/src/commands/service/sync.ts
@@ -81,7 +81,7 @@ export default class Sync extends IronfishCommand {
       this.log(`Starting from head ${head}`)
     }
 
-    const response = client.followChainStream({
+    const response = client.chain.followChainStream({
       head: head,
     })
 

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -29,7 +29,7 @@ export default class Status extends IronfishCommand {
 
     if (!flags.follow) {
       const client = await this.sdk.connectRpc()
-      const response = await client.getNodeStatus()
+      const response = await client.node.getStatus()
       this.log(renderStatus(response.content, flags.all))
       this.exit(0)
     }
@@ -61,7 +61,7 @@ export default class Status extends IronfishCommand {
         continue
       }
 
-      const response = this.sdk.client.statusStream()
+      const response = this.sdk.client.node.getStatusStream()
 
       for await (const value of response.contentStream()) {
         statusText.clearBaseLine(0)

--- a/ironfish-cli/src/commands/stop.ts
+++ b/ironfish-cli/src/commands/stop.ts
@@ -22,7 +22,7 @@ export default class StopCommand extends IronfishCommand {
 
     CliUx.ux.action.start('Asking node to shut down...')
 
-    await this.sdk.client.stopNode()
+    await this.sdk.client.node.stopNode()
 
     CliUx.ux.action.stop('done.')
   }

--- a/ironfish-cli/src/commands/wallet/accounts.ts
+++ b/ironfish-cli/src/commands/wallet/accounts.ts
@@ -21,7 +21,7 @@ export class AccountsCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    const response = await client.getAccounts({ displayName: flags.displayName })
+    const response = await client.wallet.getAccounts({ displayName: flags.displayName })
 
     if (response.content.accounts.length === 0) {
       this.log('you have no accounts')

--- a/ironfish-cli/src/commands/wallet/address.ts
+++ b/ironfish-cli/src/commands/wallet/address.ts
@@ -28,7 +28,7 @@ export class AddressCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    const response = await client.getAccountPublicKey({
+    const response = await client.wallet.getAccountPublicKey({
       account: account,
     })
 

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -41,7 +41,7 @@ export class AssetsCommand extends IronfishCommand {
     const account = args.account as string | undefined
 
     const client = await this.sdk.connectRpc()
-    const response = client.getAssets({
+    const response = client.wallet.getAssets({
       account,
     })
 

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -48,7 +48,7 @@ export class BalanceCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    const response = await client.getAccountBalance({
+    const response = await client.wallet.getAccountBalance({
       account,
       assetId: flags.assetId,
       confirmations: flags.confirmations,

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -36,7 +36,7 @@ export class BalancesCommand extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     const account = args.account as string | undefined
-    const response = await client.getAccountBalances({
+    const response = await client.wallet.getAccountBalances({
       account,
       confirmations: flags.confirmations,
     })

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -82,7 +82,7 @@ export class Burn extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     if (!flags.offline) {
-      const status = await client.getNodeStatus()
+      const status = await client.node.getStatus()
       if (!status.content.blockchain.synced) {
         this.log(
           `Your node must be synced with the Iron Fish network to send a transaction. Please try again later`,
@@ -93,7 +93,7 @@ export class Burn extends IronfishCommand {
 
     let account = flags.account
     if (!account) {
-      const response = await client.getDefaultAccount()
+      const response = await client.wallet.getDefaultAccount()
 
       if (!response.content.account) {
         this.error(
@@ -161,7 +161,7 @@ export class Burn extends IronfishCommand {
         logger: this.logger,
       })
     } else {
-      const response = await client.createTransaction(params)
+      const response = await client.wallet.createTransaction(params)
       const bytes = Buffer.from(response.content.transaction, 'hex')
       raw = RawTransactionSerde.deserialize(bytes)
     }
@@ -179,7 +179,7 @@ export class Burn extends IronfishCommand {
 
     CliUx.ux.action.start('Sending the transaction')
 
-    const response = await client.postTransaction({
+    const response = await client.wallet.postTransaction({
       transaction: RawTransactionSerde.serialize(raw).toString('hex'),
       account,
     })
@@ -189,7 +189,7 @@ export class Burn extends IronfishCommand {
 
     CliUx.ux.action.stop()
 
-    const assetResponse = await client.getAsset({ id: assetId })
+    const assetResponse = await client.chain.getAsset({ id: assetId })
     const assetName = BufferUtils.toHuman(Buffer.from(assetResponse.content.name, 'hex'))
 
     this.log(`Burned asset ${assetName} from ${account}`)

--- a/ironfish-cli/src/commands/wallet/create.ts
+++ b/ironfish-cli/src/commands/wallet/create.ts
@@ -35,7 +35,7 @@ export class CreateCommand extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     this.log(`Creating account ${name}`)
-    const result = await client.createAccount({ name })
+    const result = await client.wallet.createAccount({ name })
 
     const { publicAddress, isDefaultAccount } = result.content
 

--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -38,7 +38,7 @@ export class DeleteCommand extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     CliUx.ux.action.start(`Deleting account '${account}'`)
-    const response = await client.removeAccount({ account, confirm, wait })
+    const response = await client.wallet.removeAccount({ account, confirm, wait })
     CliUx.ux.action.stop()
 
     if (response.content.needsConfirm) {
@@ -50,7 +50,7 @@ export class DeleteCommand extends IronfishCommand {
       }
 
       CliUx.ux.action.start(`Deleting account '${account}'`)
-      await client.removeAccount({ account, confirm: true, wait })
+      await client.wallet.removeAccount({ account, confirm: true, wait })
       CliUx.ux.action.stop()
     }
 

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -71,7 +71,7 @@ export class ExportCommand extends IronfishCommand {
     }
 
     const client = await this.sdk.connectRpc(local)
-    const response = await client.exportAccount({ account: account, viewOnly: viewOnly })
+    const response = await client.wallet.exportAccount({ account: account, viewOnly: viewOnly })
     let output
 
     if (flags.mnemonic) {

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -64,7 +64,7 @@ export class ImportCommand extends IronfishCommand {
       account.createdAt = null
     }
 
-    const accountsResponse = await client.getAccounts()
+    const accountsResponse = await client.wallet.getAccounts()
     const duplicateAccount = accountsResponse.content.accounts.find(
       (accountName) => accountName === account.name,
     )
@@ -84,7 +84,7 @@ export class ImportCommand extends IronfishCommand {
     }
 
     const rescan = flags.rescan
-    const result = await client.importAccount({ account, rescan })
+    const result = await client.wallet.importAccount({ account, rescan })
 
     const { name, isDefaultAccount } = result.content
     this.log(`Account ${name} imported.`)

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -94,7 +94,7 @@ export class Mint extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     if (!flags.offline) {
-      const status = await client.getNodeStatus()
+      const status = await client.node.getStatus()
       if (!status.content.blockchain.synced) {
         this.log(
           `Your node must be synced with the Iron Fish network to send a transaction. Please try again later`,
@@ -105,7 +105,7 @@ export class Mint extends IronfishCommand {
 
     let account = flags.account
     if (!account) {
-      const response = await client.getDefaultAccount()
+      const response = await client.wallet.getDefaultAccount()
 
       if (!response.content.account) {
         this.error(
@@ -198,7 +198,7 @@ export class Mint extends IronfishCommand {
         logger: this.logger,
       })
     } else {
-      const response = await client.createTransaction(params)
+      const response = await client.wallet.createTransaction(params)
       const bytes = Buffer.from(response.content.transaction, 'hex')
       raw = RawTransactionSerde.deserialize(bytes)
     }
@@ -219,7 +219,7 @@ export class Mint extends IronfishCommand {
 
     CliUx.ux.action.start('Sending the transaction')
 
-    const response = await client.postTransaction({
+    const response = await client.wallet.postTransaction({
       transaction: RawTransactionSerde.serialize(raw).toString('hex'),
       account,
     })

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -30,7 +30,7 @@ export class NotesCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    const response = client.getAccountNotesStream({ account })
+    const response = client.wallet.getAccountNotesStream({ account })
 
     let showHeader = !flags['no-header']
 

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -67,7 +67,7 @@ export class PostCommand extends IronfishCommand {
 
     CliUx.ux.action.start(`Posting the transaction`)
 
-    const response = await client.postTransaction({
+    const response = await client.wallet.postTransaction({
       transaction,
       account: flags.account,
       broadcast: flags.broadcast,
@@ -87,7 +87,7 @@ export class PostCommand extends IronfishCommand {
 
   async confirm(client: RpcClient, raw: RawTransaction, account?: string): Promise<boolean> {
     if (!account) {
-      const response = await client.getDefaultAccount()
+      const response = await client.wallet.getDefaultAccount()
 
       if (response.content.account) {
         account = response.content.account.name

--- a/ironfish-cli/src/commands/wallet/rescan.ts
+++ b/ironfish-cli/src/commands/wallet/rescan.ts
@@ -44,7 +44,7 @@ export class RescanCommand extends IronfishCommand {
       stdout: true,
     })
 
-    const response = client.rescanAccountStream({ follow, from })
+    const response = client.wallet.rescanAccountStream({ follow, from })
 
     const speed = new Meter()
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -103,7 +103,7 @@ export class Send extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     if (!flags.offline) {
-      const status = await client.getNodeStatus()
+      const status = await client.node.getStatus()
 
       if (!status.content.blockchain.synced) {
         this.error(
@@ -144,7 +144,7 @@ export class Send extends IronfishCommand {
     }
 
     if (!from) {
-      const response = await client.getDefaultAccount()
+      const response = await client.wallet.getDefaultAccount()
 
       if (!response.content.account) {
         this.error(
@@ -196,7 +196,7 @@ export class Send extends IronfishCommand {
         logger: this.logger,
       })
     } else {
-      const response = await client.createTransaction(params)
+      const response = await client.wallet.createTransaction(params)
       const bytes = Buffer.from(response.content.transaction, 'hex')
       raw = RawTransactionSerde.deserialize(bytes)
     }
@@ -214,7 +214,7 @@ export class Send extends IronfishCommand {
 
     CliUx.ux.action.start('Sending the transaction')
 
-    const response = await client.postTransaction({
+    const response = await client.wallet.postTransaction({
       transaction: RawTransactionSerde.serialize(raw).toString('hex'),
       account: from,
     })

--- a/ironfish-cli/src/commands/wallet/status.ts
+++ b/ironfish-cli/src/commands/wallet/status.ts
@@ -19,7 +19,7 @@ export class StatusCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    const response = await client.getAccountsStatus({
+    const response = await client.wallet.getAccountsStatus({
       account: account,
     })
 

--- a/ironfish-cli/src/commands/wallet/transaction/add.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/add.ts
@@ -32,7 +32,10 @@ export class TransactionAddCommand extends IronfishCommand {
 
     CliUx.ux.action.start(`Adding transaction`)
     const client = await this.sdk.connectRpc()
-    const response = await client.addTransaction({ transaction, broadcast: flags.broadcast })
+    const response = await client.wallet.addTransaction({
+      transaction,
+      broadcast: flags.broadcast,
+    })
     CliUx.ux.action.stop()
 
     this.log(`Transaction added for accounts: ${response.content.accounts.join(', ')}`)

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -35,7 +35,7 @@ export class TransactionCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    const response = await client.getAccountTransaction({ account, hash })
+    const response = await client.wallet.getAccountTransaction({ account, hash })
 
     if (!response.content.transaction) {
       this.log(`No transaction found by hash ${hash}`)

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -66,7 +66,7 @@ export class TransactionsCommand extends IronfishCommand {
         : Format.cli
 
     const client = await this.sdk.connectRpc()
-    const response = client.getAccountTransactionsStream({
+    const response = client.wallet.getAccountTransactionsStream({
       account,
       hash: flags.hash,
       sequence: flags.sequence,

--- a/ironfish-cli/src/commands/wallet/use.ts
+++ b/ironfish-cli/src/commands/wallet/use.ts
@@ -25,7 +25,7 @@ export class UseCommand extends IronfishCommand {
     const account = args.account as string
 
     const client = await this.sdk.connectRpc()
-    await client.useAccount({ account })
+    await client.wallet.useAccount({ account })
     this.log(`The default account is now: ${account}`)
   }
 }

--- a/ironfish-cli/src/commands/wallet/which.ts
+++ b/ironfish-cli/src/commands/wallet/which.ts
@@ -29,7 +29,7 @@ export class WhichCommand extends IronfishCommand {
       content: {
         accounts: [accountName],
       },
-    } = await client.getAccounts({ default: true, displayName: flags.displayName })
+    } = await client.wallet.getAccounts({ default: true, displayName: flags.displayName })
 
     if (!accountName) {
       this.log(

--- a/ironfish-cli/src/commands/workers/status.ts
+++ b/ironfish-cli/src/commands/workers/status.ts
@@ -24,7 +24,7 @@ export default class Status extends IronfishCommand {
 
     if (!flags.follow) {
       const client = await this.sdk.connectRpc()
-      const response = await client.getWorkersStatus()
+      const response = await client.worker.getWorkersStatus()
       this.log(renderStatus(response.content))
       this.exit(0)
     }
@@ -48,7 +48,7 @@ export default class Status extends IronfishCommand {
         continue
       }
 
-      const response = this.sdk.client.getWorkersStatusStream()
+      const response = this.sdk.client.worker.getWorkersStatusStream()
       for await (const value of response.contentStream()) {
         statusText.setContent(renderStatus(value))
         screen.render()

--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -23,7 +23,7 @@ export async function selectAsset(
     }
   | undefined
 > {
-  const balancesResponse = await client.getAccountBalances({
+  const balancesResponse = await client.wallet.getAccountBalances({
     account: account,
     confirmations: options.confirmations,
   })
@@ -35,7 +35,7 @@ export async function selectAsset(
   }
 
   if (!options.showNonOwnerAsset) {
-    const accountResponse = await client.getAccountPublicKey({
+    const accountResponse = await client.wallet.getAccountPublicKey({
       account: account,
     })
 

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -34,7 +34,7 @@ export async function promptCurrency(options: {
   let text = options.text
 
   if (options.balance) {
-    const balance = await options.client.getAccountBalance({
+    const balance = await options.client.wallet.getAccountBalance({
       account: options.balance.account,
       assetId: options.balance.assetId ?? Asset.nativeId().toString('hex'),
       confirmations: options.balance.confirmations,

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -24,7 +24,7 @@ export async function selectFee(options: {
   confirmations?: number
   logger: Logger
 }): Promise<RawTransaction> {
-  const feeRates = await options.client.estimateFeeRates()
+  const feeRates = await options.client.chain.estimateFeeRates()
 
   const [slow, average, fast] = [
     await getTxWithFee(
@@ -78,7 +78,7 @@ export async function selectFee(options: {
       },
     })
 
-    const custom = await options.client.createTransaction({
+    const custom = await options.client.wallet.createTransaction({
       ...options.transaction,
       fee: CurrencyUtils.encode(fee),
     })
@@ -96,7 +96,7 @@ async function getTxWithFee(
   params: CreateTransactionRequest,
   feeRate: bigint,
 ): Promise<RawTransaction | null> {
-  const promise = client.createTransaction({
+  const promise = client.wallet.createTransaction({
     ...params,
     feeRate: CurrencyUtils.encode(feeRate),
   })

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -27,7 +27,7 @@ export async function watchTransaction(options: {
 
   let lastTime = Date.now()
 
-  let last = await options.client.getAccountTransaction({
+  let last = await options.client.wallet.getAccountTransaction({
     account: options.account,
     hash: options.hash,
     confirmations: options.confirmations,
@@ -54,7 +54,7 @@ export async function watchTransaction(options: {
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const response = await options.client.getAccountTransaction({
+    const response = await options.client.wallet.getAccountTransaction({
       account: options.account,
       hash: options.hash,
       confirmations: options.confirmations,

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -296,7 +296,7 @@ export class MiningPool {
     if (hashedHeader.compare(Buffer.from(blockTemplate.header.target, 'hex')) !== 1) {
       this.logger.debug('Valid block, submitting to node')
 
-      const result = await this.rpc.submitBlock(blockTemplate)
+      const result = await this.rpc.miner.submitBlock(blockTemplate)
 
       if (result.content.added) {
         const hashRate = await this.estimateHashRate()
@@ -369,9 +369,9 @@ export class MiningPool {
   }
 
   private async processNewBlocks() {
-    const consensusParameters = (await this.rpc.getConsensusParameters()).content
+    const consensusParameters = (await this.rpc.chain.getConsensusParameters()).content
 
-    for await (const payload of this.rpc.blockTemplateStream().contentStream()) {
+    for await (const payload of this.rpc.miner.blockTemplateStream().contentStream()) {
       Assert.isNotUndefined(payload.previousBlockInfo)
       this.restartCalculateTargetInterval(
         consensusParameters.targetBlockTimeInSeconds,
@@ -540,7 +540,7 @@ export class MiningPool {
     const unconfirmedBlocks = await this.shares.unconfirmedBlocks()
 
     for (const block of unconfirmedBlocks) {
-      const blockInfoResp = await this.rpc.getBlock({
+      const blockInfoResp = await this.rpc.chain.getBlock({
         hash: block.blockHash,
         confirmations: this.config.get('confirmations'),
       })
@@ -554,7 +554,7 @@ export class MiningPool {
     const unconfirmedTransactions = await this.shares.unconfirmedPayoutTransactions()
 
     for (const transaction of unconfirmedTransactions) {
-      const transactionInfoResp = await this.rpc.getAccountTransaction({
+      const transactionInfoResp = await this.rpc.wallet.getAccountTransaction({
         hash: transaction.transactionHash,
         confirmations: this.config.get('confirmations'),
       })

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -267,7 +267,7 @@ export class MiningPoolShares {
   }
 
   async hasAvailableBalance(amount: bigint): Promise<boolean> {
-    const balance = await this.rpc.getAccountBalance({ account: this.accountName })
+    const balance = await this.rpc.wallet.getAccountBalance({ account: this.accountName })
     const availableBalance = BigInt(balance.content.available)
 
     return availableBalance >= amount
@@ -284,7 +284,7 @@ export class MiningPoolShares {
     let account = this.accountName
 
     if (account === undefined) {
-      const defaultAccount = await this.rpc.getDefaultAccount()
+      const defaultAccount = await this.rpc.wallet.getDefaultAccount()
 
       if (!defaultAccount.content.account) {
         throw Error(
@@ -295,7 +295,7 @@ export class MiningPoolShares {
       account = defaultAccount.content.account.name
     }
 
-    const transaction = await this.rpc.sendTransaction({
+    const transaction = await this.rpc.wallet.sendTransaction({
       account,
       outputs,
       fee: outputs.length.toString(),
@@ -307,7 +307,7 @@ export class MiningPoolShares {
 
   async assertAccountExists(): Promise<void> {
     if (this.accountName) {
-      const response = await this.rpc.getAccounts()
+      const response = await this.rpc.wallet.getAccounts()
 
       const accountNames = response.content.accounts
 
@@ -317,7 +317,7 @@ export class MiningPoolShares {
         )
       }
     } else {
-      const defaultAccount = await this.rpc.getDefaultAccount()
+      const defaultAccount = await this.rpc.wallet.getDefaultAccount()
 
       if (defaultAccount.content.account === null) {
         throw Error(`Cannot send pool payouts: no account is active on the node.`)

--- a/ironfish/src/mining/soloMiner.ts
+++ b/ironfish/src/mining/soloMiner.ts
@@ -148,9 +148,9 @@ export class MiningSoloMiner {
   }
 
   private async processNewBlocks() {
-    const consensusParameters = (await this.rpc.getConsensusParameters()).content
+    const consensusParameters = (await this.rpc.chain.getConsensusParameters()).content
 
-    for await (const payload of this.rpc.blockTemplateStream().contentStream()) {
+    for await (const payload of this.rpc.miner.blockTemplateStream().contentStream()) {
       Assert.isNotUndefined(payload.previousBlockInfo)
 
       const currentHeadTarget = new Target(Buffer.from(payload.previousBlockInfo.target, 'hex'))
@@ -221,7 +221,7 @@ export class MiningSoloMiner {
     if (hashedHeader.compare(Buffer.from(blockTemplate.header.target, 'hex')) !== 1) {
       this.logger.debug('Valid block, submitting to node')
 
-      const result = await this.rpc.submitBlock(blockTemplate)
+      const result = await this.rpc.miner.submitBlock(blockTemplate)
 
       if (result.content.added) {
         this.logger.info(

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -4,25 +4,49 @@
 import { Logger } from '../../logger'
 import { RpcResponse, RpcResponseEnded } from '../response'
 import {
+  AddTransactionRequest,
+  AddTransactionResponse,
   ApiNamespace,
   BlockTemplateStreamRequest,
   BlockTemplateStreamResponse,
   BroadcastTransactionRequest,
   BroadcastTransactionResponse,
+  BurnAssetRequest,
+  BurnAssetResponse,
   CreateAccountRequest,
   CreateAccountResponse,
+  CreateTransactionRequest,
+  CreateTransactionResponse,
+  EstimateFeeRateRequest,
+  EstimateFeeRateResponse,
+  EstimateFeeRatesRequest,
+  EstimateFeeRatesResponse,
+  ExportAccountRequest,
+  ExportAccountResponse,
+  ExportChainStreamRequest,
+  ExportChainStreamResponse,
+  FollowChainStreamRequest,
+  FollowChainStreamResponse,
   GetAccountNotesStreamRequest,
   GetAccountNotesStreamResponse,
   GetAccountsRequest,
   GetAccountsResponse,
+  GetAccountStatusRequest,
+  GetAccountStatusResponse,
   GetAccountTransactionRequest,
   GetAccountTransactionResponse,
   GetAccountTransactionsRequest,
   GetAccountTransactionsResponse,
   GetAssetRequest,
   GetAssetResponse,
+  GetAssetsRequest,
+  GetAssetsResponse,
   GetBalanceRequest,
   GetBalanceResponse,
+  GetBalancesRequest,
+  GetBalancesResponse,
+  GetBannedPeersRequest,
+  GetBannedPeersResponse,
   GetBlockRequest,
   GetBlockResponse,
   GetChainInfoRequest,
@@ -38,16 +62,27 @@ import {
   GetFundsRequest,
   GetFundsResponse,
   GetLogStreamResponse,
+  GetMempoolStatusResponse,
+  GetMempoolTransactionResponse,
+  GetMempoolTransactionsRequest,
   GetNetworkHashPowerRequest,
   GetNetworkHashPowerResponse,
   GetNetworkInfoRequest,
   GetNetworkInfoResponse,
   GetNodeStatusRequest,
   GetNodeStatusResponse,
+  GetNoteWitnessRequest,
+  GetNoteWitnessResponse,
+  GetPeerMessagesRequest,
+  GetPeerMessagesResponse,
+  GetPeerRequest,
+  GetPeerResponse,
   GetPeersRequest,
   GetPeersResponse,
   GetPublicKeyRequest,
   GetPublicKeyResponse,
+  GetRpcStatusRequest,
+  GetRpcStatusResponse,
   GetTransactionRequest,
   GetTransactionResponse,
   GetTransactionStreamRequest,
@@ -56,8 +91,16 @@ import {
   GetWorkersStatusResponse,
   ImportAccountRequest,
   ImportResponse,
+  MintAssetRequest,
+  MintAssetResponse,
+  OnGossipRequest,
+  OnGossipResponse,
   PostTransactionRequest,
   PostTransactionResponse,
+  RemoveAccountRequest,
+  RemoveAccountResponse,
+  RescanAccountRequest,
+  RescanAccountResponse,
   SendTransactionRequest,
   SendTransactionResponse,
   SetConfigRequest,
@@ -67,52 +110,13 @@ import {
   StopNodeResponse,
   SubmitBlockRequest,
   SubmitBlockResponse,
+  UnsetConfigRequest,
+  UnsetConfigResponse,
   UploadConfigRequest,
   UploadConfigResponse,
   UseAccountRequest,
   UseAccountResponse,
 } from '../routes'
-import {
-  EstimateFeeRateRequest,
-  EstimateFeeRateResponse,
-} from '../routes/chain/estimateFeeRate'
-import {
-  EstimateFeeRatesRequest,
-  EstimateFeeRatesResponse,
-} from '../routes/chain/estimateFeeRates'
-import {
-  ExportChainStreamRequest,
-  ExportChainStreamResponse,
-} from '../routes/chain/exportChain'
-import {
-  FollowChainStreamRequest,
-  FollowChainStreamResponse,
-} from '../routes/chain/followChain'
-import { GetNoteWitnessRequest, GetNoteWitnessResponse } from '../routes/chain/getNoteWitness'
-import { UnsetConfigRequest, UnsetConfigResponse } from '../routes/config/unsetConfig'
-import { OnGossipRequest, OnGossipResponse } from '../routes/events/onGossip'
-import { GetMempoolTransactionResponse, GetMempoolTransactionsRequest } from '../routes/mempool'
-import { GetMempoolStatusResponse } from '../routes/mempool/getStatus'
-import { GetBannedPeersRequest, GetBannedPeersResponse } from '../routes/peers/getBannedPeers'
-import { GetPeerRequest, GetPeerResponse } from '../routes/peers/getPeer'
-import {
-  GetPeerMessagesRequest,
-  GetPeerMessagesResponse,
-} from '../routes/peers/getPeerMessages'
-import { GetRpcStatusRequest, GetRpcStatusResponse } from '../routes/rpc/getStatus'
-import { AddTransactionRequest, AddTransactionResponse } from '../routes/wallet/addTransaction'
-import { BurnAssetRequest, BurnAssetResponse } from '../routes/wallet/burnAsset'
-import {
-  CreateTransactionRequest,
-  CreateTransactionResponse,
-} from '../routes/wallet/createTransaction'
-import { ExportAccountRequest, ExportAccountResponse } from '../routes/wallet/exportAccount'
-import { GetAssetsRequest, GetAssetsResponse } from '../routes/wallet/getAssets'
-import { GetBalancesRequest, GetBalancesResponse } from '../routes/wallet/getBalances'
-import { GetAccountStatusRequest, GetAccountStatusResponse } from '../routes/wallet/getStatus'
-import { MintAssetRequest, MintAssetResponse } from '../routes/wallet/mintAsset'
-import { RemoveAccountRequest, RemoveAccountResponse } from '../routes/wallet/removeAccount'
-import { RescanAccountRequest, RescanAccountResponse } from '../routes/wallet/rescanAccount'
 
 export abstract class RpcClient {
   readonly logger: Logger
@@ -127,513 +131,553 @@ export abstract class RpcClient {
     options?: { timeoutMs?: number | null },
   ): RpcResponse<TEnd, TStream>
 
-  async getNodeStatus(
-    params: GetNodeStatusRequest = undefined,
-  ): Promise<RpcResponseEnded<GetNodeStatusResponse>> {
-    return this.request<GetNodeStatusResponse>(
-      `${ApiNamespace.node}/getStatus`,
-      params,
-    ).waitForEnd()
+  node = {
+    getStatus: (
+      params: GetNodeStatusRequest = undefined,
+    ): Promise<RpcResponseEnded<GetNodeStatusResponse>> => {
+      return this.request<GetNodeStatusResponse>(
+        `${ApiNamespace.node}/getStatus`,
+        params,
+      ).waitForEnd()
+    },
+
+    getStatusStream: (): RpcResponse<void, GetNodeStatusResponse> => {
+      return this.request<void, GetNodeStatusResponse>(`${ApiNamespace.node}/getStatus`, {
+        stream: true,
+      })
+    },
+
+    stopNode: (): Promise<RpcResponseEnded<StopNodeResponse>> => {
+      return this.request<StopNodeResponse>(`${ApiNamespace.node}/stopNode`).waitForEnd()
+    },
+
+    getLogStream: (): RpcResponse<void, GetLogStreamResponse> => {
+      return this.request<void, GetLogStreamResponse>(`${ApiNamespace.node}/getLogStream`)
+    },
   }
 
-  statusStream(): RpcResponse<void, GetNodeStatusResponse> {
-    return this.request<void, GetNodeStatusResponse>(`${ApiNamespace.node}/getStatus`, {
-      stream: true,
-    })
+  wallet = {
+    getAccounts: (
+      params: GetAccountsRequest = undefined,
+    ): Promise<RpcResponseEnded<GetAccountsResponse>> => {
+      return this.request<GetAccountsResponse>(
+        `${ApiNamespace.wallet}/getAccounts`,
+        params,
+      ).waitForEnd()
+    },
+
+    getDefaultAccount: (
+      params: GetDefaultAccountRequest = undefined,
+    ): Promise<RpcResponseEnded<GetDefaultAccountResponse>> => {
+      return this.request<GetDefaultAccountResponse>(
+        `${ApiNamespace.wallet}/getDefaultAccount`,
+        params,
+      ).waitForEnd()
+    },
+
+    createAccount: (
+      params: CreateAccountRequest,
+    ): Promise<RpcResponseEnded<CreateAccountResponse>> => {
+      return this.request<CreateAccountResponse>(
+        `${ApiNamespace.wallet}/create`,
+        params,
+      ).waitForEnd()
+    },
+    useAccount: (params: UseAccountRequest): Promise<RpcResponseEnded<UseAccountResponse>> => {
+      return this.request<UseAccountResponse>(`${ApiNamespace.wallet}/use`, params).waitForEnd()
+    },
+
+    removeAccount: (
+      params: RemoveAccountRequest,
+    ): Promise<RpcResponseEnded<RemoveAccountResponse>> => {
+      return this.request<RemoveAccountResponse>(
+        `${ApiNamespace.wallet}/remove`,
+        params,
+      ).waitForEnd()
+    },
+
+    getAccountBalances: (
+      params: GetBalancesRequest,
+    ): Promise<RpcResponseEnded<GetBalancesResponse>> => {
+      return this.request<GetBalancesResponse>(
+        `${ApiNamespace.wallet}/getBalances`,
+        params,
+      ).waitForEnd()
+    },
+
+    getAccountBalance: (
+      params: GetBalanceRequest = {},
+    ): Promise<RpcResponseEnded<GetBalanceResponse>> => {
+      return this.request<GetBalanceResponse>(
+        `${ApiNamespace.wallet}/getBalance`,
+        params,
+      ).waitForEnd()
+    },
+
+    rescanAccountStream: (
+      params: RescanAccountRequest = {},
+    ): RpcResponse<void, RescanAccountResponse> => {
+      return this.request<void, RescanAccountResponse>(
+        `${ApiNamespace.wallet}/rescanAccount`,
+        params,
+      )
+    },
+
+    exportAccount: (
+      params: ExportAccountRequest,
+    ): Promise<RpcResponseEnded<ExportAccountResponse>> => {
+      return this.request<ExportAccountResponse>(
+        `${ApiNamespace.wallet}/exportAccount`,
+        params,
+      ).waitForEnd()
+    },
+
+    importAccount: (
+      params: ImportAccountRequest,
+    ): Promise<RpcResponseEnded<ImportResponse>> => {
+      return this.request<ImportResponse>(
+        `${ApiNamespace.wallet}/importAccount`,
+        params,
+      ).waitForEnd()
+    },
+
+    getAccountPublicKey: (
+      params: GetPublicKeyRequest = {},
+    ): Promise<RpcResponseEnded<GetPublicKeyResponse>> => {
+      return this.request<GetPublicKeyResponse>(
+        `${ApiNamespace.wallet}/getPublicKey`,
+        params,
+      ).waitForEnd()
+    },
+
+    getAccountNotesStream: (
+      params: GetAccountNotesStreamRequest = {},
+    ): RpcResponse<void, GetAccountNotesStreamResponse> => {
+      return this.request<void, GetAccountNotesStreamResponse>(
+        `${ApiNamespace.wallet}/getAccountNotesStream`,
+        params,
+      )
+    },
+
+    getAccountsStatus: (
+      params: GetAccountStatusRequest,
+    ): Promise<RpcResponseEnded<GetAccountStatusResponse>> => {
+      return this.request<GetAccountStatusResponse>(
+        `${ApiNamespace.wallet}/getAccountsStatus`,
+        params,
+      ).waitForEnd()
+    },
+
+    getAccountTransaction: (
+      params: GetAccountTransactionRequest,
+    ): Promise<RpcResponseEnded<GetAccountTransactionResponse>> => {
+      return this.request<GetAccountTransactionResponse>(
+        `${ApiNamespace.wallet}/getAccountTransaction`,
+        params,
+      ).waitForEnd()
+    },
+
+    getAccountTransactionsStream: (
+      params: GetAccountTransactionsRequest,
+    ): RpcResponse<void, GetAccountTransactionsResponse> => {
+      return this.request<void, GetAccountTransactionsResponse>(
+        `${ApiNamespace.wallet}/getAccountTransactions`,
+        params,
+      )
+    },
+
+    mintAsset: (params: MintAssetRequest): Promise<RpcResponseEnded<MintAssetResponse>> => {
+      return this.request<MintAssetResponse>(
+        `${ApiNamespace.wallet}/mintAsset`,
+        params,
+      ).waitForEnd()
+    },
+
+    burnAsset: (params: BurnAssetRequest): Promise<RpcResponseEnded<BurnAssetResponse>> => {
+      return this.request<BurnAssetResponse>(
+        `${ApiNamespace.wallet}/burnAsset`,
+        params,
+      ).waitForEnd()
+    },
+
+    sendTransaction: (
+      params: SendTransactionRequest,
+    ): Promise<RpcResponseEnded<SendTransactionResponse>> => {
+      return this.request<SendTransactionResponse>(
+        `${ApiNamespace.wallet}/sendTransaction`,
+        params,
+      ).waitForEnd()
+    },
+
+    getAssets: (params: GetAssetsRequest): RpcResponse<void, GetAssetsResponse> => {
+      return this.request<void, GetAssetsResponse>(`${ApiNamespace.wallet}/getAssets`, params)
+    },
+
+    postTransaction: (
+      params: PostTransactionRequest,
+    ): Promise<RpcResponseEnded<PostTransactionResponse>> => {
+      return this.request<PostTransactionResponse>(
+        `${ApiNamespace.wallet}/postTransaction`,
+        params,
+      ).waitForEnd()
+    },
+
+    addTransaction: (
+      params: AddTransactionRequest,
+    ): Promise<RpcResponseEnded<AddTransactionResponse>> => {
+      return this.request<AddTransactionResponse>(
+        `${ApiNamespace.wallet}/addTransaction`,
+        params,
+      ).waitForEnd()
+    },
+
+    createTransaction: (
+      params: CreateTransactionRequest,
+    ): Promise<RpcResponseEnded<CreateTransactionResponse>> => {
+      return this.request<CreateTransactionResponse>(
+        `${ApiNamespace.wallet}/createTransaction`,
+        params,
+      ).waitForEnd()
+    },
   }
 
-  async stopNode(): Promise<RpcResponseEnded<StopNodeResponse>> {
-    return this.request<StopNodeResponse>(`${ApiNamespace.node}/stopNode`).waitForEnd()
+  mempool = {
+    getMempoolTransactionsStream: (
+      params: GetMempoolTransactionsRequest,
+    ): RpcResponse<void, GetMempoolTransactionResponse> => {
+      return this.request<void, GetMempoolTransactionResponse>(
+        `${ApiNamespace.mempool}/getTransactions`,
+        { ...params },
+      )
+    },
+
+    getMempoolStatus: (): Promise<RpcResponseEnded<GetMempoolStatusResponse>> => {
+      return this.request<GetMempoolStatusResponse>(
+        `${ApiNamespace.mempool}/getStatus`,
+      ).waitForEnd()
+    },
+
+    getMempoolStatusStream: (): RpcResponse<void, GetMempoolStatusResponse> => {
+      return this.request<void, GetMempoolStatusResponse>(`${ApiNamespace.mempool}/getStatus`, {
+        stream: true,
+      })
+    },
   }
 
-  getLogStream(): RpcResponse<void, GetLogStreamResponse> {
-    return this.request<void, GetLogStreamResponse>(`${ApiNamespace.node}/getLogStream`)
+  peer = {
+    getBannedPeers: (
+      params: GetBannedPeersRequest = undefined,
+    ): Promise<RpcResponseEnded<GetBannedPeersResponse>> => {
+      return this.request<GetBannedPeersResponse>(
+        `${ApiNamespace.peer}/getBannedPeers`,
+        params,
+      ).waitForEnd()
+    },
+
+    getBannedPeersStream: (
+      params: GetBannedPeersRequest = undefined,
+    ): RpcResponse<void, GetBannedPeersResponse> => {
+      return this.request<void, GetBannedPeersResponse>(`${ApiNamespace.peer}/getBannedPeers`, {
+        ...params,
+        stream: true,
+      })
+    },
+
+    getPeers: (
+      params: GetPeersRequest = undefined,
+    ): Promise<RpcResponseEnded<GetPeersResponse>> => {
+      return this.request<GetPeersResponse>(
+        `${ApiNamespace.peer}/getPeers`,
+        params,
+      ).waitForEnd()
+    },
+
+    getPeersStream: (
+      params: GetPeersRequest = undefined,
+    ): RpcResponse<void, GetPeersResponse> => {
+      return this.request<void, GetPeersResponse>(`${ApiNamespace.peer}/getPeers`, {
+        ...params,
+        stream: true,
+      })
+    },
+
+    getPeer: (params: GetPeerRequest): Promise<RpcResponseEnded<GetPeerResponse>> => {
+      return this.request<GetPeerResponse>(`${ApiNamespace.peer}/getPeer`, params).waitForEnd()
+    },
+
+    getPeerStream: (params: GetPeerRequest): RpcResponse<void, GetPeerResponse> => {
+      return this.request<void, GetPeerResponse>(`${ApiNamespace.peer}/getPeer`, {
+        ...params,
+        stream: true,
+      })
+    },
+
+    getPeerMessages: (
+      params: GetPeerMessagesRequest,
+    ): Promise<RpcResponseEnded<GetPeerMessagesResponse>> => {
+      return this.request<GetPeerMessagesResponse>(
+        `${ApiNamespace.peer}/getPeerMessages`,
+        params,
+      ).waitForEnd()
+    },
+
+    getPeerMessagesStream: (
+      params: GetPeerMessagesRequest,
+    ): RpcResponse<void, GetPeerMessagesResponse> => {
+      return this.request<void, GetPeerMessagesResponse>(
+        `${ApiNamespace.peer}/getPeerMessages`,
+        {
+          ...params,
+          stream: true,
+        },
+      )
+    },
   }
 
-  async getAccounts(
-    params: GetAccountsRequest = undefined,
-  ): Promise<RpcResponseEnded<GetAccountsResponse>> {
-    return await this.request<GetAccountsResponse>(
-      `${ApiNamespace.wallet}/getAccounts`,
-      params,
-    ).waitForEnd()
+  worker = {
+    getWorkersStatus: (
+      params: GetWorkersStatusRequest = undefined,
+    ): Promise<RpcResponseEnded<GetWorkersStatusResponse>> => {
+      return this.request<GetWorkersStatusResponse>(
+        `${ApiNamespace.worker}/getStatus`,
+        params,
+      ).waitForEnd()
+    },
+
+    getWorkersStatusStream: (
+      params: GetWorkersStatusRequest = undefined,
+    ): RpcResponse<void, GetWorkersStatusResponse> => {
+      return this.request<void, GetWorkersStatusResponse>(`${ApiNamespace.worker}/getStatus`, {
+        ...params,
+        stream: true,
+      })
+    },
   }
 
-  async getDefaultAccount(
-    params: GetDefaultAccountRequest = undefined,
-  ): Promise<RpcResponseEnded<GetDefaultAccountResponse>> {
-    return await this.request<GetDefaultAccountResponse>(
-      `${ApiNamespace.wallet}/getDefaultAccount`,
-      params,
-    ).waitForEnd()
+  rpc = {
+    getRpcStatus: (
+      params: GetRpcStatusRequest = undefined,
+    ): Promise<RpcResponseEnded<GetRpcStatusResponse>> => {
+      return this.request<GetRpcStatusResponse>(
+        `${ApiNamespace.rpc}/getStatus`,
+        params,
+      ).waitForEnd()
+    },
+
+    getRpcStatusStream: (
+      params: GetRpcStatusRequest = undefined,
+    ): RpcResponse<void, GetRpcStatusResponse> => {
+      return this.request<void, GetRpcStatusResponse>(`${ApiNamespace.rpc}/getStatus`, {
+        ...params,
+        stream: true,
+      })
+    },
   }
 
-  async createAccount(
-    params: CreateAccountRequest,
-  ): Promise<RpcResponseEnded<CreateAccountResponse>> {
-    return await this.request<CreateAccountResponse>(
-      `${ApiNamespace.wallet}/create`,
-      params,
-    ).waitForEnd()
+  event = {
+    onGossipStream: (
+      params: OnGossipRequest = undefined,
+    ): RpcResponse<void, OnGossipResponse> => {
+      return this.request<void, OnGossipResponse>(`${ApiNamespace.event}/onGossip`, params)
+    },
   }
 
-  async useAccount(params: UseAccountRequest): Promise<RpcResponseEnded<UseAccountResponse>> {
-    return await this.request<UseAccountResponse>(
-      `${ApiNamespace.wallet}/use`,
-      params,
-    ).waitForEnd()
+  miner = {
+    blockTemplateStream: (
+      params: BlockTemplateStreamRequest = undefined,
+    ): RpcResponse<void, BlockTemplateStreamResponse> => {
+      return this.request<void, BlockTemplateStreamResponse>(
+        `${ApiNamespace.miner}/blockTemplateStream`,
+        params,
+      )
+    },
+
+    submitBlock: (
+      params: SubmitBlockRequest,
+    ): Promise<RpcResponseEnded<SubmitBlockResponse>> => {
+      return this.request<SubmitBlockResponse>(
+        `${ApiNamespace.miner}/submitBlock`,
+        params,
+      ).waitForEnd()
+    },
   }
 
-  async removeAccount(
-    params: RemoveAccountRequest,
-  ): Promise<RpcResponseEnded<RemoveAccountResponse>> {
-    return await this.request<RemoveAccountResponse>(
-      `${ApiNamespace.wallet}/remove`,
-      params,
-    ).waitForEnd()
+  faucet = {
+    getFunds: (params: GetFundsRequest): Promise<RpcResponseEnded<GetFundsResponse>> => {
+      return this.request<GetFundsResponse>(
+        `${ApiNamespace.faucet}/getFunds`,
+        params,
+      ).waitForEnd()
+    },
   }
 
-  async getAccountBalances(
-    params: GetBalancesRequest,
-  ): Promise<RpcResponseEnded<GetBalancesResponse>> {
-    return this.request<GetBalancesResponse>(
-      `${ApiNamespace.wallet}/getBalances`,
-      params,
-    ).waitForEnd()
+  chain = {
+    estimateFeeRates: (
+      params?: EstimateFeeRatesRequest,
+    ): Promise<RpcResponseEnded<EstimateFeeRatesResponse>> => {
+      return this.request<EstimateFeeRatesResponse>(
+        `${ApiNamespace.chain}/estimateFeeRates`,
+        params,
+      ).waitForEnd()
+    },
+
+    estimateFeeRate: (
+      params?: EstimateFeeRateRequest,
+    ): Promise<RpcResponseEnded<EstimateFeeRateResponse>> => {
+      return this.request<EstimateFeeRateResponse>(
+        `${ApiNamespace.chain}/estimateFeeRate`,
+        params,
+      ).waitForEnd()
+    },
+
+    getChainInfo: (
+      params: GetChainInfoRequest = undefined,
+    ): Promise<RpcResponseEnded<GetChainInfoResponse>> => {
+      return this.request<GetChainInfoResponse>(
+        `${ApiNamespace.chain}/getChainInfo`,
+        params,
+      ).waitForEnd()
+    },
+
+    exportChainStream: (
+      params: ExportChainStreamRequest = undefined,
+    ): RpcResponse<void, ExportChainStreamResponse> => {
+      return this.request<void, ExportChainStreamResponse>(
+        `${ApiNamespace.chain}/exportChainStream`,
+        params,
+      )
+    },
+
+    followChainStream: (
+      params: FollowChainStreamRequest = undefined,
+    ): RpcResponse<void, FollowChainStreamResponse> => {
+      return this.request<void, FollowChainStreamResponse>(
+        `${ApiNamespace.chain}/followChainStream`,
+        params,
+      )
+    },
+
+    getBlock: (params: GetBlockRequest): Promise<RpcResponseEnded<GetBlockResponse>> => {
+      return this.request<GetBlockResponse>(
+        `${ApiNamespace.chain}/getBlock`,
+        params,
+      ).waitForEnd()
+    },
+
+    getDifficulty: (
+      params: GetDifficultyRequest = undefined,
+    ): Promise<RpcResponseEnded<GetDifficultyResponse>> => {
+      return this.request<GetDifficultyResponse>(
+        `${ApiNamespace.chain}/getDifficulty`,
+        params,
+      ).waitForEnd()
+    },
+
+    getNoteWitness: (
+      params: GetNoteWitnessRequest,
+    ): Promise<RpcResponseEnded<GetNoteWitnessResponse>> => {
+      return this.request<GetNoteWitnessResponse>(
+        `${ApiNamespace.chain}/getNoteWitness`,
+        params,
+      ).waitForEnd()
+    },
+
+    getNetworkHashPower: (
+      params: GetNetworkHashPowerRequest,
+    ): Promise<RpcResponseEnded<GetNetworkHashPowerResponse>> => {
+      return this.request<GetNetworkHashPowerResponse>(
+        `${ApiNamespace.chain}/getNetworkHashPower`,
+        params,
+      ).waitForEnd()
+    },
+
+    showChain: (
+      params: ShowChainRequest = undefined,
+    ): Promise<RpcResponseEnded<ShowChainResponse>> => {
+      return this.request<ShowChainResponse>(
+        `${ApiNamespace.chain}/showChain`,
+        params,
+      ).waitForEnd()
+    },
+
+    getTransactionStream: (
+      params: GetTransactionStreamRequest,
+    ): RpcResponse<void, GetTransactionStreamResponse> => {
+      return this.request<void, GetTransactionStreamResponse>(
+        `${ApiNamespace.chain}/getTransactionStream`,
+        params,
+      )
+    },
+
+    getTransaction: (
+      params: GetTransactionRequest,
+    ): RpcResponse<void, GetTransactionResponse> => {
+      return this.request<void, GetTransactionResponse>(
+        `${ApiNamespace.chain}/getTransaction`,
+        params,
+      )
+    },
+
+    getConsensusParameters: (
+      params: GetConsensusParametersRequest = undefined,
+    ): Promise<RpcResponseEnded<GetConsensusParametersResponse>> => {
+      return this.request<GetConsensusParametersResponse>(
+        `${ApiNamespace.chain}/getConsensusParameters`,
+        params,
+      ).waitForEnd()
+    },
+
+    getAsset: (params: GetAssetRequest): Promise<RpcResponseEnded<GetAssetResponse>> => {
+      return this.request<GetAssetResponse>(
+        `${ApiNamespace.chain}/getAsset`,
+        params,
+      ).waitForEnd()
+    },
+
+    getNetworkInfo: (
+      params?: GetNetworkInfoRequest,
+    ): Promise<RpcResponse<GetNetworkInfoResponse>> => {
+      return this.request<GetNetworkInfoResponse>(
+        `${ApiNamespace.chain}/getNetworkInfo`,
+        params,
+      ).waitForEnd()
+    },
   }
 
-  async getAccountBalance(
-    params: GetBalanceRequest = {},
-  ): Promise<RpcResponseEnded<GetBalanceResponse>> {
-    return this.request<GetBalanceResponse>(
-      `${ApiNamespace.wallet}/getBalance`,
-      params,
-    ).waitForEnd()
-  }
+  config = {
+    getConfig: (
+      params: GetConfigRequest = undefined,
+    ): Promise<RpcResponseEnded<GetConfigResponse>> => {
+      return this.request<GetConfigResponse>(
+        `${ApiNamespace.config}/getConfig`,
+        params,
+      ).waitForEnd()
+    },
 
-  rescanAccountStream(
-    params: RescanAccountRequest = {},
-  ): RpcResponse<void, RescanAccountResponse> {
-    return this.request<void, RescanAccountResponse>(
-      `${ApiNamespace.wallet}/rescanAccount`,
-      params,
-    )
-  }
+    setConfig: (params: SetConfigRequest): Promise<RpcResponseEnded<SetConfigResponse>> => {
+      return this.request<SetConfigResponse>(
+        `${ApiNamespace.config}/setConfig`,
+        params,
+      ).waitForEnd()
+    },
 
-  async exportAccount(
-    params: ExportAccountRequest,
-  ): Promise<RpcResponseEnded<ExportAccountResponse>> {
-    return this.request<ExportAccountResponse>(
-      `${ApiNamespace.wallet}/exportAccount`,
-      params,
-    ).waitForEnd()
-  }
+    unsetConfig: (
+      params: UnsetConfigRequest,
+    ): Promise<RpcResponseEnded<UnsetConfigResponse>> => {
+      return this.request<UnsetConfigResponse>(
+        `${ApiNamespace.config}/unsetConfig`,
+        params,
+      ).waitForEnd()
+    },
 
-  async importAccount(params: ImportAccountRequest): Promise<RpcResponseEnded<ImportResponse>> {
-    return this.request<ImportResponse>(
-      `${ApiNamespace.wallet}/importAccount`,
-      params,
-    ).waitForEnd()
-  }
-
-  async getAccountPublicKey(
-    params: GetPublicKeyRequest,
-  ): Promise<RpcResponseEnded<GetPublicKeyResponse>> {
-    return this.request<GetPublicKeyResponse>(
-      `${ApiNamespace.wallet}/getPublicKey`,
-      params,
-    ).waitForEnd()
-  }
-
-  getAccountNotesStream(
-    params: GetAccountNotesStreamRequest = {},
-  ): RpcResponse<void, GetAccountNotesStreamResponse> {
-    return this.request<void, GetAccountNotesStreamResponse>(
-      `${ApiNamespace.wallet}/getAccountNotesStream`,
-      params,
-    )
-  }
-
-  async getAccountsStatus(
-    params: GetAccountStatusRequest,
-  ): Promise<RpcResponseEnded<GetAccountStatusResponse>> {
-    return this.request<GetAccountStatusResponse>(
-      `${ApiNamespace.wallet}/getAccountsStatus`,
-      params,
-    ).waitForEnd()
-  }
-
-  async getAccountTransaction(
-    params: GetAccountTransactionRequest,
-  ): Promise<RpcResponseEnded<GetAccountTransactionResponse>> {
-    return await this.request<GetAccountTransactionResponse>(
-      `${ApiNamespace.wallet}/getAccountTransaction`,
-      params,
-    ).waitForEnd()
-  }
-
-  getAccountTransactionsStream(
-    params: GetAccountTransactionsRequest,
-  ): RpcResponse<void, GetAccountTransactionsResponse> {
-    return this.request<void, GetAccountTransactionsResponse>(
-      `${ApiNamespace.wallet}/getAccountTransactions`,
-      params,
-    )
-  }
-
-  getMempoolTransactionsStream(
-    params: GetMempoolTransactionsRequest,
-  ): RpcResponse<void, GetMempoolTransactionResponse> {
-    return this.request<void, GetMempoolTransactionResponse>(
-      `${ApiNamespace.mempool}/getTransactions`,
-      { ...params },
-    )
-  }
-
-  async getMempoolStatus(): Promise<RpcResponseEnded<GetMempoolStatusResponse>> {
-    return await this.request<GetMempoolStatusResponse>(
-      `${ApiNamespace.mempool}/getStatus`,
-    ).waitForEnd()
-  }
-
-  getMempoolStatusStream(): RpcResponse<void, GetMempoolStatusResponse> {
-    return this.request<void, GetMempoolStatusResponse>(`${ApiNamespace.mempool}/getStatus`, {
-      stream: true,
-    })
-  }
-
-  async getBannedPeers(
-    params: GetBannedPeersRequest = undefined,
-  ): Promise<RpcResponseEnded<GetBannedPeersResponse>> {
-    return this.request<GetBannedPeersResponse>(
-      `${ApiNamespace.peer}/getBannedPeers`,
-      params,
-    ).waitForEnd()
-  }
-
-  getBannedPeersStream(
-    params: GetBannedPeersRequest = undefined,
-  ): RpcResponse<void, GetBannedPeersResponse> {
-    return this.request<void, GetBannedPeersResponse>(`${ApiNamespace.peer}/getBannedPeers`, {
-      ...params,
-      stream: true,
-    })
-  }
-
-  async getPeers(
-    params: GetPeersRequest = undefined,
-  ): Promise<RpcResponseEnded<GetPeersResponse>> {
-    return this.request<GetPeersResponse>(`${ApiNamespace.peer}/getPeers`, params).waitForEnd()
-  }
-
-  getPeersStream(params: GetPeersRequest = undefined): RpcResponse<void, GetPeersResponse> {
-    return this.request<void, GetPeersResponse>(`${ApiNamespace.peer}/getPeers`, {
-      ...params,
-      stream: true,
-    })
-  }
-
-  async getPeer(params: GetPeerRequest): Promise<RpcResponseEnded<GetPeerResponse>> {
-    return this.request<GetPeerResponse>(`${ApiNamespace.peer}/getPeer`, params).waitForEnd()
-  }
-
-  getPeerStream(params: GetPeerRequest): RpcResponse<void, GetPeerResponse> {
-    return this.request<void, GetPeerResponse>(`${ApiNamespace.peer}/getPeer`, {
-      ...params,
-      stream: true,
-    })
-  }
-
-  async getPeerMessages(
-    params: GetPeerMessagesRequest,
-  ): Promise<RpcResponseEnded<GetPeerMessagesResponse>> {
-    return this.request<GetPeerMessagesResponse>(
-      `${ApiNamespace.peer}/getPeerMessages`,
-      params,
-    ).waitForEnd()
-  }
-
-  getPeerMessagesStream(
-    params: GetPeerMessagesRequest,
-  ): RpcResponse<void, GetPeerMessagesResponse> {
-    return this.request<void, GetPeerMessagesResponse>(`${ApiNamespace.peer}/getPeerMessages`, {
-      ...params,
-      stream: true,
-    })
-  }
-
-  async getWorkersStatus(
-    params: GetWorkersStatusRequest = undefined,
-  ): Promise<RpcResponseEnded<GetWorkersStatusResponse>> {
-    return this.request<GetWorkersStatusResponse>(
-      `${ApiNamespace.worker}/getStatus`,
-      params,
-    ).waitForEnd()
-  }
-
-  getWorkersStatusStream(
-    params: GetWorkersStatusRequest = undefined,
-  ): RpcResponse<void, GetWorkersStatusResponse> {
-    return this.request<void, GetWorkersStatusResponse>(`${ApiNamespace.worker}/getStatus`, {
-      ...params,
-      stream: true,
-    })
-  }
-
-  async getRpcStatus(
-    params: GetRpcStatusRequest = undefined,
-  ): Promise<RpcResponseEnded<GetRpcStatusResponse>> {
-    return this.request<GetRpcStatusResponse>(
-      `${ApiNamespace.rpc}/getStatus`,
-      params,
-    ).waitForEnd()
-  }
-
-  getRpcStatusStream(
-    params: GetRpcStatusRequest = undefined,
-  ): RpcResponse<void, GetRpcStatusResponse> {
-    return this.request<void, GetRpcStatusResponse>(`${ApiNamespace.rpc}/getStatus`, {
-      ...params,
-      stream: true,
-    })
-  }
-
-  onGossipStream(params: OnGossipRequest = undefined): RpcResponse<void, OnGossipResponse> {
-    return this.request<void, OnGossipResponse>(`${ApiNamespace.event}/onGossip`, params)
-  }
-
-  async mintAsset(params: MintAssetRequest): Promise<RpcResponseEnded<MintAssetResponse>> {
-    return this.request<MintAssetResponse>(
-      `${ApiNamespace.wallet}/mintAsset`,
-      params,
-    ).waitForEnd()
-  }
-
-  async burnAsset(params: BurnAssetRequest): Promise<RpcResponseEnded<BurnAssetResponse>> {
-    return this.request<BurnAssetResponse>(
-      `${ApiNamespace.wallet}/burnAsset`,
-      params,
-    ).waitForEnd()
-  }
-
-  async sendTransaction(
-    params: SendTransactionRequest,
-  ): Promise<RpcResponseEnded<SendTransactionResponse>> {
-    return this.request<SendTransactionResponse>(
-      `${ApiNamespace.wallet}/sendTransaction`,
-      params,
-    ).waitForEnd()
-  }
-
-  blockTemplateStream(
-    params: BlockTemplateStreamRequest = undefined,
-  ): RpcResponse<void, BlockTemplateStreamResponse> {
-    return this.request<void, BlockTemplateStreamResponse>(
-      `${ApiNamespace.miner}/blockTemplateStream`,
-      params,
-    )
-  }
-
-  submitBlock(params: SubmitBlockRequest): Promise<RpcResponseEnded<SubmitBlockResponse>> {
-    return this.request<SubmitBlockResponse>(
-      `${ApiNamespace.miner}/submitBlock`,
-      params,
-    ).waitForEnd()
-  }
-
-  async getFunds(params: GetFundsRequest): Promise<RpcResponseEnded<GetFundsResponse>> {
-    return this.request<GetFundsResponse>(
-      `${ApiNamespace.faucet}/getFunds`,
-      params,
-    ).waitForEnd()
-  }
-
-  async estimateFeeRates(
-    params?: EstimateFeeRatesRequest,
-  ): Promise<RpcResponseEnded<EstimateFeeRatesResponse>> {
-    return this.request<EstimateFeeRatesResponse>(
-      `${ApiNamespace.chain}/estimateFeeRates`,
-      params,
-    ).waitForEnd()
-  }
-
-  async estimateFeeRate(
-    params?: EstimateFeeRateRequest,
-  ): Promise<RpcResponseEnded<EstimateFeeRateResponse>> {
-    return this.request<EstimateFeeRateResponse>(
-      `${ApiNamespace.chain}/estimateFeeRate`,
-      params,
-    ).waitForEnd()
-  }
-
-  async getChainInfo(
-    params: GetChainInfoRequest = undefined,
-  ): Promise<RpcResponseEnded<GetChainInfoResponse>> {
-    return this.request<GetChainInfoResponse>(
-      `${ApiNamespace.chain}/getChainInfo`,
-      params,
-    ).waitForEnd()
-  }
-
-  exportChainStream(
-    params: ExportChainStreamRequest = undefined,
-  ): RpcResponse<void, ExportChainStreamResponse> {
-    return this.request<void, ExportChainStreamResponse>(
-      `${ApiNamespace.chain}/exportChainStream`,
-      params,
-    )
-  }
-
-  followChainStream(
-    params: FollowChainStreamRequest = undefined,
-  ): RpcResponse<void, FollowChainStreamResponse> {
-    return this.request<void, FollowChainStreamResponse>(
-      `${ApiNamespace.chain}/followChainStream`,
-      params,
-    )
-  }
-
-  async getBlock(params: GetBlockRequest): Promise<RpcResponseEnded<GetBlockResponse>> {
-    return this.request<GetBlockResponse>(`${ApiNamespace.chain}/getBlock`, params).waitForEnd()
-  }
-
-  async getDifficulty(
-    params: GetDifficultyRequest = undefined,
-  ): Promise<RpcResponseEnded<GetDifficultyResponse>> {
-    return this.request<GetDifficultyResponse>(
-      `${ApiNamespace.chain}/getDifficulty`,
-      params,
-    ).waitForEnd()
-  }
-
-  async getNoteWitness(
-    params: GetNoteWitnessRequest,
-  ): Promise<RpcResponseEnded<GetNoteWitnessResponse>> {
-    return this.request<GetNoteWitnessResponse>(
-      `${ApiNamespace.chain}/getNoteWitness`,
-      params,
-    ).waitForEnd()
-  }
-
-  async getNetworkHashPower(
-    params: GetNetworkHashPowerRequest,
-  ): Promise<RpcResponseEnded<GetNetworkHashPowerResponse>> {
-    return this.request<GetNetworkHashPowerResponse>(
-      `${ApiNamespace.chain}/getNetworkHashPower`,
-      params,
-    ).waitForEnd()
-  }
-
-  async showChain(
-    params: ShowChainRequest = undefined,
-  ): Promise<RpcResponseEnded<ShowChainResponse>> {
-    return this.request<ShowChainResponse>(
-      `${ApiNamespace.chain}/showChain`,
-      params,
-    ).waitForEnd()
-  }
-
-  getTransactionStream(
-    params: GetTransactionStreamRequest,
-  ): RpcResponse<void, GetTransactionStreamResponse> {
-    return this.request<void, GetTransactionStreamResponse>(
-      `${ApiNamespace.chain}/getTransactionStream`,
-      params,
-    )
-  }
-
-  getTransaction(params: GetTransactionRequest): RpcResponse<void, GetTransactionResponse> {
-    return this.request<void, GetTransactionResponse>(
-      `${ApiNamespace.chain}/getTransaction`,
-      params,
-    )
-  }
-
-  async getConfig(
-    params: GetConfigRequest = undefined,
-  ): Promise<RpcResponseEnded<GetConfigResponse>> {
-    return this.request<GetConfigResponse>(
-      `${ApiNamespace.config}/getConfig`,
-      params,
-    ).waitForEnd()
-  }
-
-  async setConfig(params: SetConfigRequest): Promise<RpcResponseEnded<SetConfigResponse>> {
-    return this.request<SetConfigResponse>(
-      `${ApiNamespace.config}/setConfig`,
-      params,
-    ).waitForEnd()
-  }
-
-  async unsetConfig(
-    params: UnsetConfigRequest,
-  ): Promise<RpcResponseEnded<UnsetConfigResponse>> {
-    return this.request<UnsetConfigResponse>(
-      `${ApiNamespace.config}/unsetConfig`,
-      params,
-    ).waitForEnd()
-  }
-
-  async uploadConfig(
-    params: UploadConfigRequest,
-  ): Promise<RpcResponseEnded<UploadConfigResponse>> {
-    return this.request<UploadConfigResponse>(
-      `${ApiNamespace.config}/uploadConfig`,
-      params,
-    ).waitForEnd()
-  }
-
-  async getConsensusParameters(
-    params: GetConsensusParametersRequest = undefined,
-  ): Promise<RpcResponseEnded<GetConsensusParametersResponse>> {
-    return this.request<GetConsensusParametersResponse>(
-      `${ApiNamespace.chain}/getConsensusParameters`,
-      params,
-    ).waitForEnd()
-  }
-
-  async getAsset(params: GetAssetRequest): Promise<RpcResponseEnded<GetAssetResponse>> {
-    return this.request<GetAssetResponse>(`${ApiNamespace.chain}/getAsset`, params).waitForEnd()
-  }
-
-  getAssets(params: GetAssetsRequest): RpcResponse<void, GetAssetsResponse> {
-    return this.request<void, GetAssetsResponse>(`${ApiNamespace.wallet}/getAssets`, params)
-  }
-
-  async postTransaction(
-    params: PostTransactionRequest,
-  ): Promise<RpcResponseEnded<PostTransactionResponse>> {
-    return this.request<PostTransactionResponse>(
-      `${ApiNamespace.wallet}/postTransaction`,
-      params,
-    ).waitForEnd()
-  }
-
-  async addTransaction(
-    params: AddTransactionRequest,
-  ): Promise<RpcResponseEnded<AddTransactionResponse>> {
-    return this.request<AddTransactionResponse>(
-      `${ApiNamespace.wallet}/addTransaction`,
-      params,
-    ).waitForEnd()
-  }
-
-  async createTransaction(
-    params: CreateTransactionRequest,
-  ): Promise<RpcResponseEnded<CreateTransactionResponse>> {
-    return this.request<CreateTransactionResponse>(
-      `${ApiNamespace.wallet}/createTransaction`,
-      params,
-    ).waitForEnd()
-  }
-
-  async getNetworkInfo(
-    params?: GetNetworkInfoRequest,
-  ): Promise<RpcResponse<GetNetworkInfoResponse>> {
-    return this.request<GetNetworkInfoResponse>(
-      `${ApiNamespace.chain}/getNetworkInfo`,
-      params,
-    ).waitForEnd()
+    uploadConfig: (
+      params: UploadConfigRequest,
+    ): Promise<RpcResponseEnded<UploadConfigResponse>> => {
+      return this.request<UploadConfigResponse>(
+        `${ApiNamespace.config}/uploadConfig`,
+        params,
+      ).waitForEnd()
+    },
   }
 
   async broadcastTransaction(

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -8,14 +8,14 @@ import { ALL_API_NAMESPACES, Router } from '../routes'
 import { RpcClient } from './client'
 
 export class RpcMemoryClient extends RpcClient {
-  node: IronfishNode
+  _node: IronfishNode
   router: Router
 
   constructor(logger: Logger, node: IronfishNode) {
     super(logger)
 
     this.router = node.rpc.getRouter(ALL_API_NAMESPACES)
-    this.node = node
+    this._node = node
   }
 
   request<TEnd = unknown, TStream = unknown>(

--- a/ironfish/src/rpc/routes/chain/estimateFeeRate.test.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRate.test.ts
@@ -11,7 +11,7 @@ describe('Route chain/estimateFeeRates', () => {
       .spyOn(routeTest.node.memPool.feeEstimator, 'estimateFeeRate')
       .mockReturnValueOnce(7n)
 
-    const response = await routeTest.client.estimateFeeRate({ priority: 'slow' })
+    const response = await routeTest.client.chain.estimateFeeRate({ priority: 'slow' })
     expect(response.content).toMatchObject({ rate: '7' })
     expect(estimateSpy).toHaveBeenCalledWith('slow')
   })
@@ -21,7 +21,7 @@ describe('Route chain/estimateFeeRates', () => {
       .spyOn(routeTest.node.memPool.feeEstimator, 'estimateFeeRate')
       .mockReturnValueOnce(1n)
 
-    await routeTest.client.estimateFeeRate()
+    await routeTest.client.chain.estimateFeeRate()
     expect(estimateSpy).toHaveBeenCalledWith('average')
   })
 })

--- a/ironfish/src/rpc/routes/chain/estimateFeeRates.test.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRates.test.ts
@@ -13,7 +13,7 @@ describe('Route chain/estimateFeeRates', () => {
       fast: 3n,
     })
 
-    const response = await routeTest.client.estimateFeeRates()
+    const response = await routeTest.client.chain.estimateFeeRates()
 
     expect(response.content).toMatchObject({
       slow: '1',

--- a/ironfish/src/rpc/routes/chain/getAsset.test.ts
+++ b/ironfish/src/rpc/routes/chain/getAsset.test.ts
@@ -15,7 +15,7 @@ describe('Route chain.getAsset', () => {
     const asset = await routeTest.node.chain.getAssetById(Asset.nativeId())
     Assert.isNotNull(asset)
 
-    const response = await routeTest.client.getAsset({
+    const response = await routeTest.client.chain.getAsset({
       id: asset.id.toString('hex'),
     })
 

--- a/ironfish/src/rpc/routes/chain/getDifficulty.test.ts
+++ b/ironfish/src/rpc/routes/chain/getDifficulty.test.ts
@@ -9,7 +9,7 @@ describe('Route chain/getDifficulty', () => {
   it('get difficulty', async () => {
     expect(routeTest.chain.head.hash.equals(routeTest.chain.genesis.hash)).toBe(true)
 
-    const response = await routeTest.client.getDifficulty()
+    const response = await routeTest.client.chain.getDifficulty()
 
     expect(response.content).toMatchObject({
       difficulty: routeTest.chain.genesis.target.toDifficulty().toString(),
@@ -21,7 +21,7 @@ describe('Route chain/getDifficulty', () => {
   it('get difficulty by sequence', async () => {
     expect(routeTest.chain.head.hash.equals(routeTest.chain.genesis.hash)).toBe(true)
 
-    const response = await routeTest.client.getDifficulty({
+    const response = await routeTest.client.chain.getDifficulty({
       sequence: routeTest.chain.genesis.sequence,
     })
 

--- a/ironfish/src/rpc/routes/chain/getNetworkHashPower.test.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkHashPower.test.ts
@@ -26,7 +26,7 @@ describe('Route chain/getNetworkHashPower', () => {
       await Promise.all([expect(routeTest.node.chain).toAddBlock(block)])
       await Promise.all([routeTest.node.wallet.updateHead()])
     }
-    const response = await routeTest.client.getNetworkHashPower({})
+    const response = await routeTest.client.chain.getNetworkHashPower({})
     expect(response.content).toEqual(
       expect.objectContaining({
         hashesPerSecond: expect.any(Number),
@@ -51,7 +51,7 @@ describe('Route chain/getNetworkHashPower', () => {
 
     const offset = -3
 
-    const response = await routeTest.client.getNetworkHashPower({
+    const response = await routeTest.client.chain.getNetworkHashPower({
       blocks: 100,
       sequence: offset,
     })
@@ -69,7 +69,7 @@ describe('Route chain/getNetworkHashPower', () => {
 
   it('should fail with a negative [blocks] value', async () => {
     await expect(
-      routeTest.client.getNetworkHashPower({
+      routeTest.client.chain.getNetworkHashPower({
         blocks: -1,
       }),
     ).rejects.toThrow(
@@ -82,7 +82,7 @@ describe('Route chain/getNetworkHashPower', () => {
   })
 
   it('should return 0 network hash power if start block == end block', async () => {
-    const response = await routeTest.client.getNetworkHashPower({
+    const response = await routeTest.client.chain.getNetworkHashPower({
       blocks: 1,
       sequence: 1,
     })

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.test.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.test.ts
@@ -38,7 +38,7 @@ describe('Route chain.getTransactionStream', () => {
     const wallet = routeTest.node.wallet
     const account = await useAccountFixture(wallet)
     const asset = new Asset(account.spendingKey, 'customasset', 'metadata')
-    const response = routeTest.client.getTransactionStream({
+    const response = routeTest.client.chain.getTransactionStream({
       incomingViewKey: account.incomingViewKey,
     })
     Assert.isInstanceOf(response, MemoryResponse)

--- a/ironfish/src/rpc/routes/config/getConfig.test.ts
+++ b/ironfish/src/rpc/routes/config/getConfig.test.ts
@@ -7,7 +7,7 @@ describe('Route config/getConfig', () => {
   const routeTest = createRouteTest()
 
   it('should error if the config name does not exist', async () => {
-    await expect(routeTest.client.getConfig({ name: 'asdf' })).rejects.toThrow()
+    await expect(routeTest.client.config.getConfig({ name: 'asdf' })).rejects.toThrow()
   })
 
   it('returns value of the requested ConfigOptions', async () => {

--- a/ironfish/src/rpc/routes/config/unsetConfig.test.ts
+++ b/ironfish/src/rpc/routes/config/unsetConfig.test.ts
@@ -9,7 +9,7 @@ describe('Route config/unsetConfig', () => {
   const routeTest = createRouteTest()
 
   it('should error if the config name does not exist', async () => {
-    await expect(routeTest.client.unsetConfig({ name: 'asdf' })).rejects.toThrow()
+    await expect(routeTest.client.config.unsetConfig({ name: 'asdf' })).rejects.toThrow()
   })
 
   it('handles clear values values', async () => {
@@ -17,7 +17,7 @@ describe('Route config/unsetConfig', () => {
     routeTest.sdk.config.setOverride('blockGraffiti', 'foo')
     expect(routeTest.sdk.config.get('blockGraffiti')).toEqual('foo')
 
-    await routeTest.client.unsetConfig({
+    await routeTest.client.config.unsetConfig({
       name: 'blockGraffiti',
     })
 

--- a/ironfish/src/rpc/routes/faucet/getFunds.test.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.test.ts
@@ -61,9 +61,9 @@ describe('Route faucet.getFunds', () => {
           },
         }
       })
-      await expect(routeTest.client.getFunds({ account: accountName, email })).rejects.toThrow(
-        RpcRequestError,
-      )
+      await expect(
+        routeTest.client.faucet.getFunds({ account: accountName, email }),
+      ).rejects.toThrow(RpcRequestError)
     })
   })
 
@@ -71,18 +71,18 @@ describe('Route faucet.getFunds', () => {
     it('throws an error', async () => {
       const apiResponse = new Error('API failure') as AxiosError
       axios.post = jest.fn().mockRejectedValueOnce(apiResponse)
-      await expect(routeTest.client.getFunds({ account: accountName, email })).rejects.toThrow(
-        'API failure',
-      )
+      await expect(
+        routeTest.client.faucet.getFunds({ account: accountName, email }),
+      ).rejects.toThrow('API failure')
     })
   })
 
   describe('should fail when non testnet node', () => {
     it('throws an error', async () => {
       routeTest.node.internal.set('networkId', 2)
-      await expect(routeTest.client.getFunds({ account: accountName, email })).rejects.toThrow(
-        'This endpoint is only available for testnet.',
-      )
+      await expect(
+        routeTest.client.faucet.getFunds({ account: accountName, email }),
+      ).rejects.toThrow('This endpoint is only available for testnet.')
     })
   })
 })

--- a/ironfish/src/rpc/routes/node/getStatus.test.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.test.ts
@@ -7,7 +7,7 @@ describe('Route node/getStatus', () => {
   const routeTest = createRouteTest()
 
   it('should get status', async () => {
-    const response = await routeTest.client.getNodeStatus()
+    const response = await routeTest.client.node.getStatus()
 
     expect(response.status).toBe(200)
 

--- a/ironfish/src/rpc/routes/node/stopNode.test.ts
+++ b/ironfish/src/rpc/routes/node/stopNode.test.ts
@@ -9,7 +9,7 @@ describe('Route node.getStatus', () => {
   it('should get status', async () => {
     routeTest.node.shutdown = jest.fn()
 
-    const response = await routeTest.client.stopNode()
+    const response = await routeTest.client.node.stopNode()
     expect(response.status).toBe(200)
     expect(response.content).toBe(undefined)
     expect(routeTest.node.shutdown).toHaveBeenCalled()

--- a/ironfish/src/rpc/routes/wallet/addTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.test.ts
@@ -15,7 +15,7 @@ describe('Route wallet/addTransaction', () => {
 
     await expect(account.hasTransaction(transaction.hash())).resolves.toBe(false)
 
-    const response = await routeTest.client.addTransaction({
+    const response = await routeTest.client.wallet.addTransaction({
       transaction: transaction.serialize().toString('hex'),
     })
 
@@ -35,7 +35,7 @@ describe('Route wallet/addTransaction', () => {
     const broadcastSpy = jest.spyOn(routeTest.wallet, 'broadcastTransaction')
 
     // Add it again
-    const response = await routeTest.client.addTransaction({
+    const response = await routeTest.client.wallet.addTransaction({
       transaction: transaction.serialize().toString('hex'),
     })
 
@@ -48,7 +48,7 @@ describe('Route wallet/addTransaction', () => {
 
   it("should return an error if the transaction won't deserialize", async () => {
     await expect(
-      routeTest.client.addTransaction({
+      routeTest.client.wallet.addTransaction({
         transaction: '0xdeadbeef',
       }),
     ).rejects.toThrow('Out of bounds read')

--- a/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
@@ -20,7 +20,7 @@ describe('burnAsset', () => {
   describe('with an invalid fee', () => {
     it('throws a validation error', async () => {
       await expect(
-        routeTest.client.burnAsset({
+        routeTest.client.wallet.burnAsset({
           account: 'account',
           assetId: '{ url: hello }',
           fee: '0',
@@ -35,7 +35,7 @@ describe('burnAsset', () => {
   describe('with an invalid value', () => {
     it('throws a validation error', async () => {
       await expect(
-        routeTest.client.burnAsset({
+        routeTest.client.wallet.burnAsset({
           account: 'account',
           assetId: '{ url: hello }',
           fee: '1',
@@ -69,7 +69,7 @@ describe('burnAsset', () => {
       })
       jest.spyOn(wallet, 'burn').mockResolvedValueOnce(burnTransaction)
 
-      const response = await routeTest.client.burnAsset({
+      const response = await routeTest.client.wallet.burnAsset({
         account: account.name,
         assetId: assetId.toString('hex'),
         fee: '1',

--- a/ironfish/src/rpc/routes/wallet/create.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/create.test.slow.ts
@@ -23,7 +23,7 @@ describe('Route wallet/create', () => {
 
     const name = uuid()
 
-    const response = await routeTest.client.createAccount({ name })
+    const response = await routeTest.client.wallet.createAccount({ name })
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
       name: name,
@@ -43,7 +43,7 @@ describe('Route wallet/create', () => {
 
     const name = uuid()
 
-    const response = await routeTest.client.createAccount({ name })
+    const response = await routeTest.client.wallet.createAccount({ name })
     expect(response.content).toMatchObject({
       name: name,
       publicAddress: expect.any(String),
@@ -59,7 +59,7 @@ describe('Route wallet/create', () => {
 
     try {
       expect.assertions(2)
-      await routeTest.client.createAccount({ name: name })
+      await routeTest.client.wallet.createAccount({ name: name })
     } catch (e: unknown) {
       if (!(e instanceof RpcRequestError)) {
         throw e
@@ -78,7 +78,7 @@ describe('Route wallet/create', () => {
 
     const name = uuid()
 
-    const response = await routeTest.client.createAccount({ name })
+    const response = await routeTest.client.wallet.createAccount({ name })
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
       name: name,

--- a/ironfish/src/rpc/routes/wallet/createTransaction.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.test.slow.ts
@@ -56,7 +56,7 @@ describe('Route wallet/createTransaction', () => {
       await Promise.all([routeTest.node.wallet.updateHead()])
     }
 
-    const response = await routeTest.client.createTransaction({
+    const response = await routeTest.client.wallet.createTransaction({
       account: 'existingAccount',
       outputs: [
         {

--- a/ironfish/src/rpc/routes/wallet/createTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.test.ts
@@ -46,7 +46,7 @@ describe('Route wallet/createTransaction', () => {
   it('throws if not enough funds', async () => {
     await useAccountFixture(routeTest.node.wallet, 'existingAccount')
 
-    await expect(routeTest.client.createTransaction(REQUEST_PARAMS)).rejects.toThrow(
+    await expect(routeTest.client.wallet.createTransaction(REQUEST_PARAMS)).rejects.toThrow(
       expect.objectContaining({
         message: expect.any(String),
         status: 400,
@@ -72,7 +72,7 @@ describe('Route wallet/createTransaction', () => {
 
       await routeTest.node.wallet.updateHead()
     }
-    const response = await routeTest.client.createTransaction(REQUEST_PARAMS)
+    const response = await routeTest.client.wallet.createTransaction(REQUEST_PARAMS)
 
     expect(response.status).toBe(200)
     expect(response.content.transaction).toBeDefined()
@@ -104,7 +104,7 @@ describe('Route wallet/createTransaction', () => {
       await routeTest.node.wallet.updateHead()
     }
 
-    const response = await routeTest.client.createTransaction(
+    const response = await routeTest.client.wallet.createTransaction(
       REQUEST_PARAMS_WITH_MULTIPLE_RECIPIENTS,
     )
 
@@ -138,7 +138,7 @@ describe('Route wallet/createTransaction', () => {
       await routeTest.node.wallet.updateHead()
     }
 
-    const response = await routeTest.client.createTransaction({
+    const response = await routeTest.client.wallet.createTransaction({
       account: 'existingAccount',
       outputs: [
         {
@@ -182,7 +182,7 @@ describe('Route wallet/createTransaction', () => {
       await routeTest.node.wallet.updateHead()
     }
 
-    const response = await routeTest.client.createTransaction({
+    const response = await routeTest.client.wallet.createTransaction({
       account: 'existingAccount',
       outputs: [
         {
@@ -227,7 +227,7 @@ describe('Route wallet/createTransaction', () => {
 
     const asset = new Asset(sender.spendingKey, 'mint-asset', 'metadata')
 
-    const response = await routeTest.client.createTransaction({
+    const response = await routeTest.client.wallet.createTransaction({
       account: 'existingAccount',
       outputs: [
         {
@@ -281,7 +281,7 @@ describe('Route wallet/createTransaction', () => {
     }
 
     await expect(
-      routeTest.client.createTransaction({
+      routeTest.client.wallet.createTransaction({
         account: 'existingAccount',
         outputs: [
           {
@@ -319,7 +319,7 @@ describe('Route wallet/createTransaction', () => {
     }
 
     await expect(
-      routeTest.client.createTransaction({
+      routeTest.client.wallet.createTransaction({
         account: 'existingAccount',
         outputs: [
           {
@@ -355,7 +355,7 @@ describe('Route wallet/createTransaction', () => {
     const asset = new Asset(sender.spendingKey, 'mint-asset', 'metadata')
 
     await expect(
-      routeTest.client.createTransaction({
+      routeTest.client.wallet.createTransaction({
         account: 'existingAccount',
         outputs: [
           {

--- a/ironfish/src/rpc/routes/wallet/getAssets.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.test.ts
@@ -44,7 +44,7 @@ describe('wallet/getAssets', () => {
       ],
     })
 
-    const response = routeTest.client.getAssets({ account: account.name })
+    const response = routeTest.client.wallet.getAssets({ account: account.name })
 
     const assets = await AsyncUtils.materialize(response.contentStream())
     expect(assets).toEqual(

--- a/ironfish/src/rpc/routes/wallet/getBalances.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.test.ts
@@ -15,7 +15,7 @@ describe('getBalances', () => {
   describe('with a missing account', () => {
     it('throws a validation error', async () => {
       await expect(
-        routeTest.client.getAccountBalances({ account: 'fake-account' }),
+        routeTest.client.wallet.getAccountBalances({ account: 'fake-account' }),
       ).rejects.toThrow('No account with name fake-account')
     })
   })
@@ -79,7 +79,7 @@ describe('getBalances', () => {
         }),
       )
 
-      const response = await routeTest.client.getAccountBalances({
+      const response = await routeTest.client.wallet.getAccountBalances({
         account: account.name,
       })
 

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -16,7 +16,7 @@ describe('mint', () => {
   describe('with an invalid fee', () => {
     it('throws a validation error', async () => {
       await expect(
-        routeTest.client.mintAsset({
+        routeTest.client.wallet.mintAsset({
           account: 'account',
           fee: '0',
           metadata: '{ url: hello }',
@@ -32,7 +32,7 @@ describe('mint', () => {
   describe('with an invalid value', () => {
     it('throws a validation error', async () => {
       await expect(
-        routeTest.client.mintAsset({
+        routeTest.client.wallet.mintAsset({
           account: 'account',
           fee: '1',
           metadata: '{ url: hello }',
@@ -74,7 +74,7 @@ describe('mint', () => {
 
       jest.spyOn(wallet, 'mint').mockResolvedValueOnce(mintTransaction)
 
-      const response = await routeTest.client.mintAsset({
+      const response = await routeTest.client.wallet.mintAsset({
         account: account.name,
         fee: '1',
         metadata: asset.metadata().toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.test.ts
@@ -19,7 +19,7 @@ describe('Route wallet/postTransaction', () => {
       from: account,
     })
 
-    const response = await routeTest.client.postTransaction({
+    const response = await routeTest.client.wallet.postTransaction({
       transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
       account: account.name,
       broadcast: false,
@@ -39,7 +39,7 @@ describe('Route wallet/postTransaction', () => {
       from: account,
     })
 
-    const response = await routeTest.client.postTransaction({
+    const response = await routeTest.client.wallet.postTransaction({
       transaction: RawTransactionSerde.serialize(rawTransaction).toString('hex'),
       account: account.name,
     })
@@ -53,7 +53,7 @@ describe('Route wallet/postTransaction', () => {
     const account = await useAccountFixture(routeTest.node.wallet, 'accountB')
 
     await expect(
-      routeTest.client.postTransaction({
+      routeTest.client.wallet.postTransaction({
         transaction: '0xdeadbeef',
         account: account.name,
       }),

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
@@ -49,7 +49,7 @@ describe('Transactions sendTransaction', () => {
 
   it('throws if account does not exist', async () => {
     await expect(
-      routeTest.client.sendTransaction({
+      routeTest.client.wallet.sendTransaction({
         ...TEST_PARAMS,
         account: 'AccountDoesNotExist',
       }),
@@ -59,7 +59,7 @@ describe('Transactions sendTransaction', () => {
   it('throws if not connected to network', async () => {
     routeTest.node.peerNetwork['_isReady'] = false
 
-    await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrow(
+    await expect(routeTest.client.wallet.sendTransaction(TEST_PARAMS)).rejects.toThrow(
       'Your node must be connected to the Iron Fish network to send a transaction',
     )
   })
@@ -68,7 +68,7 @@ describe('Transactions sendTransaction', () => {
     routeTest.node.peerNetwork['_isReady'] = true
     routeTest.chain.synced = false
 
-    await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrow(
+    await expect(routeTest.client.wallet.sendTransaction(TEST_PARAMS)).rejects.toThrow(
       'Your node must be synced with the Iron Fish network to send a transaction. Please try again later',
     )
   })
@@ -77,7 +77,7 @@ describe('Transactions sendTransaction', () => {
     routeTest.node.peerNetwork['_isReady'] = true
     routeTest.chain.synced = true
 
-    await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrow(
+    await expect(routeTest.client.wallet.sendTransaction(TEST_PARAMS)).rejects.toThrow(
       expect.objectContaining({
         message: expect.stringContaining(
           `Your balance is too low. Add funds to your account first`,
@@ -87,7 +87,7 @@ describe('Transactions sendTransaction', () => {
       }),
     )
 
-    await expect(routeTest.client.sendTransaction(TEST_PARAMS_MULTI)).rejects.toThrow(
+    await expect(routeTest.client.wallet.sendTransaction(TEST_PARAMS_MULTI)).rejects.toThrow(
       expect.objectContaining({
         message: expect.stringContaining(
           `Your balance is too low. Add funds to your account first`,
@@ -113,7 +113,7 @@ describe('Transactions sendTransaction', () => {
       sequence: null,
     })
 
-    await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrow(
+    await expect(routeTest.client.wallet.sendTransaction(TEST_PARAMS)).rejects.toThrow(
       expect.objectContaining({
         message: expect.stringContaining(
           `Your balance is too low. Add funds to your account first`,
@@ -134,7 +134,7 @@ describe('Transactions sendTransaction', () => {
       sequence: null,
     })
 
-    await expect(routeTest.client.sendTransaction(TEST_PARAMS_MULTI)).rejects.toThrow(
+    await expect(routeTest.client.wallet.sendTransaction(TEST_PARAMS_MULTI)).rejects.toThrow(
       expect.objectContaining({
         message: expect.stringContaining(
           `Your balance is too low. Add funds to your account first`,
@@ -165,7 +165,7 @@ describe('Transactions sendTransaction', () => {
       sequence: null,
     })
 
-    await expect(routeTest.client.sendTransaction(TEST_PARAMS)).rejects.toThrow(
+    await expect(routeTest.client.wallet.sendTransaction(TEST_PARAMS)).rejects.toThrow(
       expect.objectContaining({
         status: 400,
         code: ERROR_CODES.INSUFFICIENT_BALANCE,
@@ -192,7 +192,7 @@ describe('Transactions sendTransaction', () => {
       sequence: null,
     })
 
-    const result = await routeTest.client.sendTransaction(TEST_PARAMS)
+    const result = await routeTest.client.wallet.sendTransaction(TEST_PARAMS)
     expect(result.content.hash).toEqual(tx.hash().toString('hex'))
   })
 
@@ -215,7 +215,7 @@ describe('Transactions sendTransaction', () => {
       sequence: null,
     })
 
-    const result = await routeTest.client.sendTransaction(TEST_PARAMS_MULTI)
+    const result = await routeTest.client.wallet.sendTransaction(TEST_PARAMS_MULTI)
     expect(result.content.hash).toEqual(tx.hash().toString('hex'))
   })
 
@@ -239,7 +239,7 @@ describe('Transactions sendTransaction', () => {
 
     const sendSpy = jest.spyOn(routeTest.node.wallet, 'send').mockResolvedValue(tx)
 
-    await routeTest.client.sendTransaction(TEST_PARAMS)
+    await routeTest.client.wallet.sendTransaction(TEST_PARAMS)
 
     expect(sendSpy).toHaveBeenCalledWith(
       expect.anything(),
@@ -250,7 +250,7 @@ describe('Transactions sendTransaction', () => {
       undefined,
     )
 
-    await routeTest.client.sendTransaction({
+    await routeTest.client.wallet.sendTransaction({
       ...TEST_PARAMS,
       expiration: 1234,
       expirationDelta: 12345,

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -96,7 +96,7 @@ describe('IronfishSdk', () => {
 
         expect(openDb).toHaveBeenCalledTimes(1)
         expect(client).toBeInstanceOf(RpcMemoryClient)
-        expect((client as RpcMemoryClient).node).toBe(node)
+        expect((client as RpcMemoryClient)._node).toBe(node)
       })
     })
 

--- a/simulator/src/simulator/simulation-node.ts
+++ b/simulator/src/simulator/simulation-node.ts
@@ -336,7 +336,7 @@ export class SimulationNode {
    * and wait for the transaction to appear.
    */
   initializeBlockStream(startingBlockHash: string): void {
-    const blockStream = this.client
+    const blockStream = this.client.chain
       .followChainStream({ head: startingBlockHash.toString() })
       .contentStream()
 
@@ -616,7 +616,7 @@ export async function stopSimulationNode(node: {
   let msg = ''
 
   try {
-    await client.stopNode()
+    await client.node.stopNode()
   } catch (error) {
     if (error instanceof Error) {
       msg = error.message

--- a/simulator/src/simulator/utils/accounts.ts
+++ b/simulator/src/simulator/utils/accounts.ts
@@ -14,7 +14,7 @@ export async function getAccountBalance(
   node: SimulationNode,
   account: string,
 ): Promise<number> {
-  const resp = await node.client.getAccountBalance({
+  const resp = await node.client.wallet.getAccountBalance({
     account,
     assetId: Asset.nativeId().toString('hex'),
     confirmations: 0,
@@ -35,7 +35,7 @@ export async function getAccountPublicKey(
   node: SimulationNode,
   account: string,
 ): Promise<string> {
-  const resp = await node.client.getAccountPublicKey({ account })
+  const resp = await node.client.wallet.getAccountPublicKey({ account })
 
   const publicKey = resp.content.publicKey
   if (publicKey === undefined) {
@@ -49,7 +49,7 @@ export async function getAccountPublicKey(
  * Gets the default account on a node.
  */
 export async function getDefaultAccount(node: SimulationNode): Promise<string> {
-  const resp = await node.client.getDefaultAccount()
+  const resp = await node.client.wallet.getDefaultAccount()
 
   if (resp.content.account === undefined || resp.content.account?.name === undefined) {
     throw new Error('default account not found')

--- a/simulator/src/simulator/utils/chain.ts
+++ b/simulator/src/simulator/utils/chain.ts
@@ -8,7 +8,7 @@ import { SimulationNode } from '../simulation-node'
  * Gets the chain info from a node.
  */
 export async function getChainInfo(node: SimulationNode): Promise<ChainInfo> {
-  const resp = await node.client.getChainInfo()
+  const resp = await node.client.chain.getChainInfo()
 
   return resp.content
 }

--- a/simulator/src/simulator/utils/mint.ts
+++ b/simulator/src/simulator/utils/mint.ts
@@ -12,7 +12,7 @@ export async function mintAsset(
   node: SimulationNode,
   request: MintAssetRequest,
 ): Promise<MintAssetResponse> {
-  const resp = await node.client.mintAsset(request)
+  const resp = await node.client.wallet.mintAsset(request)
 
   if (resp.content === undefined) {
     throw new Error(`error minting asset`)

--- a/simulator/src/simulator/utils/status.ts
+++ b/simulator/src/simulator/utils/status.ts
@@ -11,7 +11,7 @@ import { SimulationNode } from '../simulation-node'
  * @returns status of node
  */
 export async function getNodeStatus(node: SimulationNode): Promise<GetNodeStatusResponse> {
-  const resp = await node.client.getNodeStatus()
+  const resp = await node.client.node.getStatus()
 
   return resp.content
 }

--- a/simulator/src/simulator/utils/transactions.ts
+++ b/simulator/src/simulator/utils/transactions.ts
@@ -33,7 +33,7 @@ export async function sendTransaction(
     throw new Error('invalid public key for to account')
   }
 
-  const txn = await from.client.sendTransaction({
+  const txn = await from.client.wallet.sendTransaction({
     account: fromAccount,
     outputs: [
       {


### PR DESCRIPTION
## Summary
This should make the client a bit nicer to use, because you can just look at each object there and find all the chain apis under chain. You also can now just name things in a lot simpler ways. We should start renaming routes to remove the namespace from the route if its duplicated.

```js
// Before
client.getNodeStatus()
// After
client.node.getStatus()
```

## Testing Plan
It only changes the client which should get caught in builds.

## Documentation
Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.
```
[ ] Yes
```

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
```
[x] Yes
```

Need to add a note about this in the release notes.
