### PR TITLE
fixes lint errors from rpc client namespaces

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getTransactions.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.test.ts
@@ -23,7 +23,7 @@ describe('Route wallet/getAccountTransactions', () => {
     await expect(node.chain).toAddBlock(block)
     await node.wallet.updateHead()
 
-    const response = routeTest.client.getAccountTransactionsStream({
+    const response = routeTest.client.wallet.getAccountTransactionsStream({
       account: account.name,
       hash: block.transactions[0].hash().toString('hex'),
     })

--- a/simulator/src/simulator/utils/accounts.ts
+++ b/simulator/src/simulator/utils/accounts.ts
@@ -73,6 +73,6 @@ export async function importAccount(
 ): Promise<void> {
   await node.executeCliCommandAsync('wallet:import', [account])
   if (rescan) {
-    await node.client.rescanAccountStream().waitForEnd()
+    await node.client.wallet.rescanAccountStream().waitForEnd()
   }
 }


### PR DESCRIPTION
## Summary

merging several PRs to staging without rebase introduced lint errors where RPC client methods were not accessed within their recently-added namespaces.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
