### PR TITLE
fix(simulator): gracefully shutdown simulator on unexpected exit

### DIFF
--- a/simulator/src/commands/start.ts
+++ b/simulator/src/commands/start.ts
@@ -10,8 +10,6 @@ import { Simulator } from '../simulator'
 export abstract class Start extends Command {
   static description = 'Start a simulation'
 
-  static simulator: Simulator
-
   static args = [
     {
       name: 'simulation',
@@ -65,13 +63,13 @@ export abstract class Start extends Command {
     // The simulator is created here because oclif catches errors so we can't throw them
     // and handle `uncaughtException` in the simulator. Having this try-catch block is a workaround
     // to ensure the simulator gracefully exits when an error occurs.
-    Start.simulator = new Simulator(logger, { persist, duration })
+    const simulator = new Simulator(logger, { persist, duration })
 
     try {
-      await simulation.run(Start.simulator, logger)
+      await simulation.run(simulator, logger)
     } catch (e) {
       logger.error(`simulation encountered ${String(e)}, shutting down...`)
-      Start.simulator.exit(1)
+      simulator.exit(1)
     }
 
     CliUx.ux.action.stop(`stop simulation ${simName}`)

--- a/simulator/src/simulations/index.ts
+++ b/simulator/src/simulations/index.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '@ironfish/sdk'
+import { Simulator } from '../simulator'
 import * as send from './send'
 import * as stability from './stability'
 
@@ -9,13 +10,7 @@ import * as stability from './stability'
  * Interface that simulations must implement to be run by the framework.
  */
 export interface Simulation {
-  run(
-    logger: Logger,
-    options?: {
-      persist?: boolean
-      duration?: number
-    },
-  ): Promise<void>
+  run(simulator: Simulator, logger: Logger): Promise<void>
 }
 
 /**

--- a/simulator/src/simulations/send.ts
+++ b/simulator/src/simulations/send.ts
@@ -9,12 +9,7 @@ import { IRON, SECOND, sendTransaction, SimulationNode, Simulator, sleep } from 
 // Author: holahula
 // Purpose: Send transactions from one node to another every 3 seconds
 
-export async function run(
-  logger: Logger,
-  options?: { persist?: boolean; duration?: number },
-): Promise<void> {
-  const simulator = new Simulator(logger, options)
-
+export async function run(simulator: Simulator, logger: Logger): Promise<void> {
   const nodes = []
   for (let i = 0; i < 2; i++) {
     nodes.push(await simulator.startNode())

--- a/simulator/src/simulations/stability.ts
+++ b/simulator/src/simulations/stability.ts
@@ -19,9 +19,7 @@ import {
 // This simulation tests the stability of the network by randomly stopping and starting nodes,
 // trying to see if nodes crash over time. The memory usage of the nodes is also monitored.
 
-export async function run(logger: Logger, options?: { persist: boolean }): Promise<void> {
-  const simulator = new Simulator(logger, options)
-
+export async function run(simulator: Simulator, logger: Logger): Promise<void> {
   const alive: Set<string> = new Set()
 
   const onExit = (event: ExitEvent): void => {

--- a/simulator/src/simulator/simulator.ts
+++ b/simulator/src/simulator/simulator.ts
@@ -69,19 +69,10 @@ export class Simulator {
       }
     }
 
-    process
-      .on('SIGINT', (event) => {
-        this.logger.log(`simulator handled ${event.toString()}`)
-        this.exit(1)
-      })
-      .on('uncaughtException', (err) => {
-        this.logger.log(`simulator handled uncaught exception: ${String(err)}`)
-        this.exit(1)
-      })
-      .on('unhandledRejection', (reason, _) => {
-        this.logger.log(`simulator handled unhandled rejection: ${String(reason)}`)
-        this.exit(1)
-      })
+    process.on('SIGINT' || 'SIGKILL', (event) => {
+      this.logger.log(`simulator handled signal ${event.toString()}`)
+      this.exit(1)
+    })
   }
 
   /**
@@ -155,7 +146,7 @@ export class Simulator {
    * Unexpected process exit handler.
    * This deletes all data directories, kills all nodes, and exits the Simulator process.
    */
-  private exit(code = 0) {
+  public exit(code = 0): void {
     this.nodes.forEach((node) => node.kill())
     this.deleteDataDirs()
     this.logger.log('exiting...')


### PR DESCRIPTION
## Summary
Attempting to hook into `process.on('uncaughtException')` in the simulator to catch exceptions before process shutdwn does not work because oclif has built-in uncaught exception handlin so the exception never propagates to this level. Thus, when unexpected errors occur in user-written simulations, the simulator is unaware of them and is unable to gracefully shutdown. This can leave running `ironfish` processes hanging in the background which affects future simulation runs. 

By wrapping the simulation execution in a try-catch block, the uncaught exceptions / unhandled rejections can be caught before they reach oclif and the simulator can gracefully shutdown before exit.

The simulator needs to be created in the `start` cmd so it can catch unexpected simulation exits. 

Closes IFL-566

## Testing Plan
Sample simulation that returns a rejected promise
```
export async function run(simulator: Simulator, logger: Logger): Promise<void> {
  const nodes = []
  for (let i = 0; i < 2; i++) {
    nodes.push(await simulator.startNode())
  }

  await rejectPromise()

  // wait for all nodes to be stopped
  await simulator.waitForShutdown()

  logger.log('nodes stopped, shutting down...')
}
```
gracefully shuts down when unexpected promise rejection reached:
```
➜  simulator git:(holahula/feat/simulator-exception-handling) sim start test
yarn run v1.22.19
$ yarn build && yarn start:js start test
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run start test
(node:4092) Error Plugin: simulator: command process not found
module: @oclif/core@1.23.1
task: toCached
plugin: simulator
root: /Users/austino/i/ironfish/simulator
See more details with DEBUG=*
(Use `node --trace-warnings ...` to show where the warning was created)
Starting node {
  cfg: `{"nodeName":"node-6c93","blockGraffiti":"node-6c93","peerPort":7001,"networkId":2,"rpcTcpHost":"localhost","rpcTcpPort":9001,"bootstrapNodes":["''"],"dataDir":"~/.ironfish-simulator/node-6c93","verbose":false,"importGenesisAccount":false}`
}
started node: node-6c93
Starting node {
  cfg: '{"nodeName":"node-4f98","blockGraffiti":"node-4f98","peerPort":7002,"networkId":2,"rpcTcpHost":"localhost","rpcTcpPort":9002,"bootstrapNodes":["localhost:7001"],"dataDir":"~/.ironfish-simulator/node-4f98","verbose":false,"importGenesisAccount":false}'
}
started node: node-4f98
simulation encountered rejected!, shutting down...
cleaning up node-6c93...
cleaning up node-4f98...
cleaning up data dirs
removing data dir: /Users/austino/.ironfish-simulator/node-6c93
removing data dir: /Users/austino/.ironfish-simulator/node-4f98
exiting...
running simulation test... done
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
[X] No
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```

Changes the `Simulation` interface from 
```
  run(logger: Logger, options?: { persist?: boolean; duration?: number }): Promise<void>
```
to
```
  run(simulator: Simulator, logger: Logger): Promise<void>
```
Anyone actively writing simulations needs to change their simulation function signature to follow the new interface definition.

This change does not break the core `Ironfish` sdk 
