### PR TITLE
Fix checking for duplicates in genesis block code

### DIFF
--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -137,7 +137,7 @@ export default class GenesisBlockCommand extends IronfishCommand {
     const columns: CliUx.Table.table.Columns<GenesisBlockAllocation> = {
       identity: {
         header: 'ADDRESS',
-        get: (row: GenesisBlockAllocation) => row.publicAddress,
+        get: (row: GenesisBlockAllocation) => row.publicAddress.toString('hex'),
       },
       amount: {
         header: 'AMOUNT ($IRON)',
@@ -188,13 +188,13 @@ export default class GenesisBlockCommand extends IronfishCommand {
 
 const getDuplicates = (allocations: readonly GenesisBlockAllocation[]): string[] => {
   const duplicateSet = new Set<string>()
-  const nonDuplicateSet = new Set()
+  const nonDuplicateSet = new Set<string>()
 
   for (const alloc of allocations) {
-    if (nonDuplicateSet.has(alloc.publicAddress)) {
+    if (nonDuplicateSet.has(alloc.publicAddress.toString('hex'))) {
       duplicateSet.add(alloc.publicAddress.toString('hex'))
     } else {
-      nonDuplicateSet.add(alloc.publicAddress)
+      nonDuplicateSet.add(alloc.publicAddress.toString('hex'))
     }
   }
 

--- a/ironfish/src/wallet/validator.test.ts
+++ b/ironfish/src/wallet/validator.test.ts
@@ -40,6 +40,11 @@ describe('account-validator tests', () => {
     expect(isValidPublicAddress(Buffer.from(INVALID_PUBLIC_ADDRESS, 'hex'))).toBe(false)
   })
 
+  test('public address with non valid length (too short) should return false', () => {
+    const INVALID_PUBLIC_ADDRESS = 'e877d6903692094b67d889c483d09ad2f8'
+    expect(isValidPublicAddress(Buffer.from(INVALID_PUBLIC_ADDRESS, 'hex'))).toBe(false)
+  })
+
   test('public address that is not a valid public address should return false', () => {
     const INVALID_PUBLIC_ADDRESS =
       'e877d6903692094b67d889c483d09ad2f8438efc8f01c82e1ec3b2ccd1798ceca48216546dbae48c685f50'


### PR DESCRIPTION
## Summary
Checking for duplicates on genesis command was not working correctly

## Testing Plan
Local testing with CSV file

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
