### PR TITLE
Bump min network version to 22

### DIFF
--- a/ironfish/src/network/version.ts
+++ b/ironfish/src/network/version.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const VERSION_PROTOCOL = 21
-export const VERSION_PROTOCOL_MIN = 19
+export const VERSION_PROTOCOL = 22
+export const VERSION_PROTOCOL_MIN = 22
 
 export const MAX_REQUESTED_HEADERS = 1024
 export const MAX_HEADER_LOOKUPS = MAX_REQUESTED_HEADERS * 2


### PR DESCRIPTION
## Summary

We've had this sitting in the mainnet branch for a while, but since we're doing a network reset on staging, we can deploy this with the network reset.

We changed the IDs for some messages a while ago without updating the network version, but everything has mostly worked because we also reset the genesis block several times.

This resets us to the same min + protocol version to give us a consistent version for mainnet launch.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```
