### PR TITLE
adds markSpent parameter to createTransaction RPC

### DIFF
--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -35,6 +35,7 @@ export type CreateTransactionRequest = {
   expiration?: number
   expirationDelta?: number
   confirmations?: number
+  markSpent?: boolean
 }
 
 export type CreateTransactionResponse = {
@@ -56,6 +57,7 @@ export const CreateTransactionRequestSchema: yup.ObjectSchema<CreateTransactionR
           .defined(),
       )
       .defined(),
+    notes: yup.array(yup.string().defined()).notRequired(),
     mints: yup
       .array(
         yup
@@ -83,6 +85,7 @@ export const CreateTransactionRequestSchema: yup.ObjectSchema<CreateTransactionR
     expiration: yup.number().optional(),
     expirationDelta: yup.number().optional(),
     confirmations: yup.number().optional(),
+    markSpent: yup.boolean().optional(),
   })
   .defined()
 
@@ -103,6 +106,7 @@ router.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse
       confirmations: request.data.confirmations,
       expiration: request.data.expiration,
       expirationDelta: request.data.expirationDelta,
+      markSpent: request.data.markSpent,
     }
 
     if (request.data.outputs) {

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -5735,5 +5735,83 @@
         }
       ]
     }
+  ],
+  "Accounts createTransaction should mark notes as spent if markSpent is true": [
+    {
+      "version": 2,
+      "id": "135af27e-e918-4510-b6c2-904254e647d6",
+      "name": "a",
+      "spendingKey": "a79e85b12a5c2d42eaab11c3792ff12fe06c542f6d9d8cf3743498099321f463",
+      "viewKey": "8e9fb3fc40d1798db0f777ba8248647ca9c5308a768dff8e721ab874c25f572a56d5e02d7373f4d0e3a8a6d2e092a6f30e674db6a5e772be4b94eb8c5e3d9a27",
+      "incomingViewKey": "c113ff01bd765b6e1eb8e35cedd3d5801499c81165eac655268a1466cd071402",
+      "outgoingViewKey": "71cb0117f40becd5e7e201e2bcb32ffcb0202eb5cc43ae38ab22d03baa693a79",
+      "publicAddress": "daab55a937a7eedcedf1a9d440ee9ce25f2b2450f69f8ad8646b806fbff2e7b8",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:NNuW485SVO3BflbUxsETDBPPfO59J6MvQKAH9sRydkw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:88jAr4ayqGQDQz8Mln1HUhvcFXxLbgZtn2NPa1Oj9VU="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1681336862049,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABTSMoyEafgq75W46rIBOkyUlBAj3qOz7z/FOgTbQb9aYahN39CqN3lbs3SDghOzRNw66WYCNipv+Ddzbs4u9dvKKV00+eJ4F2b33RJWRkBexYqs7FS4P8gKWR/p84HTZE86uuckLYQ47lZFuXOeaHQB005mNgqIK+TOTYeCtZFsHOyxcnjFXLf3sIsu4ExD0h9od5+xfDvzEAPWfYCo4ftdj64GTRkOAM6XGKdW5y96Kzw7qw7a7pQM5cu855S0bVBjrV4U86Somj35PFyY4v4zjuTaN7nrKWc6vR0RKeN1tm3Z1fqlon23XQvUynK7nArFIcxzGKHi1DPRjFg/hPJMWpijRRQ3oWuOCrMGzVffqPmAUtpAVPUuxa6dd8SszUDhiWtzHiPSWso54rZi7k4d6wR82Tw/QDxqoHIIU4gErl7fKt93nLSY1/cl1jZHUn4csGB3nTdkbKItS72HDPMMM/91IbnuX7/QQu7r+rsf7u4YVXsAmqJCnPKd5XL8L+xbzQ0cGsnDfdskObQA65i0sRe2oOXNbf7IN6xUhDQThI+8c3B/0crpOfv77RL5hnbZzWzFx8nbMFzJtNokRAYjG2ARPIsbXOXgxRwmh3MIqeabSV6drnklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLsRru7Bjw25Asp8q+fzvr+e1O+62xGhFGvtMGiRwHTTRJ0KiIJvCDF5MeqfYs4Bq2zG06UUAx/jK78DHV8KTCw=="
+        }
+      ]
+    }
+  ],
+  "Accounts createTransaction should not mark notes as spent if markSpent is false": [
+    {
+      "version": 2,
+      "id": "9df907b0-356d-4b59-902d-296b8aeba7c6",
+      "name": "a",
+      "spendingKey": "148ae8a2db6c9053b27e4b9b7601b8b71d7d0f31f20f33ee218ab48d20dab307",
+      "viewKey": "ba66574a9959533458bb9cbc968c38c5f42ba37debac8cbc11d5b267e5eb67bc27067bf44ad6225f8bae38f2442f02e7c2206b90a584fc7b4675444b8985b954",
+      "incomingViewKey": "ca9fcf2f0116c6bb1b6e80eb738ac417b4cc1cb4e622500bb29354ec633f1903",
+      "outgoingViewKey": "889cb150d3e6c1a4211f78f9483603492152f040ff12c3750bcaf619d839f300",
+      "publicAddress": "2e32956881ae13ecced7dee52e5a111f18a89ac5f0cdf17d5b47cc42409d2b0f",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:BVy5B/+vTGiU4jIo28mi53kPQUEpQbaXgq5hIL8CzSk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:K7M71bh6M1ckyY693ToT8muthayZ+GuR6bYr0Xj01Oo="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1681337112547,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAbstlIl86+TJfGpML/D73J9pVuTbdUYFhM+4e+DrSIr2qL/94zoiTYqrk7/cN9kraxO26LagPneIAMPty2LQUxjM4JYs0qQz8Gx0wAfZA0QGgk4aD0d9UDNURxKXCd9xsCIMgk69+jq+hNYHbvQ5e0i0lwkWslMufmpJsaMVEiIEXkRILZlG6n5RVyLAoY+hdu17XYd6H2x0/tv+rqkQWrJ8y2mmBOUDP4OnvY5iWbYqTsF0mhSTVoYMOMlNFbToBLSEDVYzgEbiKAhP5m7dLNOmVvXknCVvDXUR+giq6XImudRL35MWdnZh0fKjsVYZlJzODLTlZdFWrNi5GWvYptxSoqx/pOOCGS/Qdk//MgxqLVVhADbdZ+WIB8RyR8d8Tu3ih970O2oZWrjSSbHFXO5AwItgmbdYrNl0WbU2KB1Vi78eljINI/3Y0MQl9YG5KRBSrmLGogiiSCfRDcwWdFWofKOZe4nzoK4FEEltBpEmCe8s5bqhCyRA3/EFFW9wmJ60FE+L+upaE2RtmfjrwRHYfEZwHhG+zIxL4b9Rytw0ejCa4oLgLdmh4+AeVtBi2bc6RuQkzMUc3mck1+rvcGePqxUoVnrSfWCkXxuJgZh7KSFoPcUl0+0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwKnUfAZrzB+Yq28iGDpzN/dkZIp1qirvDa+JK7xHZza0zCxJjhYVkju9DZt7xF+89xgaOP+XrO0OJRy501rh5Dg=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -5739,30 +5739,30 @@
   "Accounts createTransaction should mark notes as spent if markSpent is true": [
     {
       "version": 2,
-      "id": "135af27e-e918-4510-b6c2-904254e647d6",
+      "id": "f6db8da9-7ea5-4405-8478-e0f19858ee4f",
       "name": "a",
-      "spendingKey": "a79e85b12a5c2d42eaab11c3792ff12fe06c542f6d9d8cf3743498099321f463",
-      "viewKey": "8e9fb3fc40d1798db0f777ba8248647ca9c5308a768dff8e721ab874c25f572a56d5e02d7373f4d0e3a8a6d2e092a6f30e674db6a5e772be4b94eb8c5e3d9a27",
-      "incomingViewKey": "c113ff01bd765b6e1eb8e35cedd3d5801499c81165eac655268a1466cd071402",
-      "outgoingViewKey": "71cb0117f40becd5e7e201e2bcb32ffcb0202eb5cc43ae38ab22d03baa693a79",
-      "publicAddress": "daab55a937a7eedcedf1a9d440ee9ce25f2b2450f69f8ad8646b806fbff2e7b8",
+      "spendingKey": "0fdde61ff616cf5c43b7fd82615d120971d61cb6cacb85f9d554fe0d241baa33",
+      "viewKey": "32e21a5dec048ad77292a57541a22225c953622e70719be3894ac1d0d8f129c8f36406741b5ba8f2e19248e89d8216b6c74ac54adb88c0f54dfb5f164fa23c05",
+      "incomingViewKey": "91bb121b42909bc32902b472451ab221ef14ad7793018d8a49ff3b9fad3deb05",
+      "outgoingViewKey": "7089a67031f106f76f13e63dd140972af0f9dc36a30d9d7784751805e12bab22",
+      "publicAddress": "dcec188f896e92e27bdc08f445fdc55e00649a5fe8d4f1bd59932ba3e0116e68",
       "createdAt": null
     },
     {
       "header": {
         "sequence": 2,
-        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
+        "previousBlockHash": "1FBEADD0044107F31E8F8C5CE6FA9DF2BAA2DFCAE659FB92C594662A6DC4C2A7",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:NNuW485SVO3BflbUxsETDBPPfO59J6MvQKAH9sRydkw="
+          "data": "base64:2yrY9EFgXcLTSpC0m5ZTkBJCrfgjfHxX5kmfxr0442w="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:88jAr4ayqGQDQz8Mln1HUhvcFXxLbgZtn2NPa1Oj9VU="
+          "data": "base64:xpwrXNZJwDZJC9FT7GLM6EurGCaBTL+tvBUFld/2Lr8="
         },
         "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
         "randomness": "0",
-        "timestamp": 1681336862049,
+        "timestamp": 1681339692978,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 4,
         "work": "0"
@@ -5770,7 +5770,7 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABTSMoyEafgq75W46rIBOkyUlBAj3qOz7z/FOgTbQb9aYahN39CqN3lbs3SDghOzRNw66WYCNipv+Ddzbs4u9dvKKV00+eJ4F2b33RJWRkBexYqs7FS4P8gKWR/p84HTZE86uuckLYQ47lZFuXOeaHQB005mNgqIK+TOTYeCtZFsHOyxcnjFXLf3sIsu4ExD0h9od5+xfDvzEAPWfYCo4ftdj64GTRkOAM6XGKdW5y96Kzw7qw7a7pQM5cu855S0bVBjrV4U86Somj35PFyY4v4zjuTaN7nrKWc6vR0RKeN1tm3Z1fqlon23XQvUynK7nArFIcxzGKHi1DPRjFg/hPJMWpijRRQ3oWuOCrMGzVffqPmAUtpAVPUuxa6dd8SszUDhiWtzHiPSWso54rZi7k4d6wR82Tw/QDxqoHIIU4gErl7fKt93nLSY1/cl1jZHUn4csGB3nTdkbKItS72HDPMMM/91IbnuX7/QQu7r+rsf7u4YVXsAmqJCnPKd5XL8L+xbzQ0cGsnDfdskObQA65i0sRe2oOXNbf7IN6xUhDQThI+8c3B/0crpOfv77RL5hnbZzWzFx8nbMFzJtNokRAYjG2ARPIsbXOXgxRwmh3MIqeabSV6drnklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLsRru7Bjw25Asp8q+fzvr+e1O+62xGhFGvtMGiRwHTTRJ0KiIJvCDF5MeqfYs4Bq2zG06UUAx/jK78DHV8KTCw=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA7CBl3Kt1B5WfA4FyHn1AqnT5zIXS98ZDlbU9nyhhpTKJWGDMlTtiGjdtbq0F+/+IqxUl1uOU9AW0WGWLf0WITwdkSA767ChuCz9LInAZ2J6C+niUZCcRdNGtV/WmwzfODOL6g0njAun1bLQpszWAxlUH0JrEmrk4vNncJb/L4E8TDqrDRwUZKnpWyOPRes6z7sm5Gp9adW3sl9gXqTV6dKp6aIDlRMhxXJnAm+02YM+ISmQSSs6yvWyWCSdCEfntdEhtS6M80245e5TIjUzi5ulZqUsdTcvvJ5/p5qqLjzFTwePR1rrin07Zw8S4/CA13Op4uvx1sP3Z93NfhBPFMFvyHKS1O0OPbwBmCI52JiWV83FNmwTgLM+EC4jLsOMR8e4n4VDve+TJkSFG9SZPDMsm2uFpQjnKm5eZbvCu726NDH9m0UGMFLhIjQxBNaJxBEs2JQsbKouHl3YMoHgs4+QJ4kXDnHRuu7KrxyOymbKbXMGwZFR3RsRCKLJn/A9iLmBqqNHKSIzJecf+C8/81o6Ke2Uy5DURbOn55pC9vI1yEaavvZCKVYPVkAWj47EVwJFOyQ3jQjACMWe8gdOOaFwq6iAsM33DBbJw+7ZowD3sISsv8/aUhklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwkRLx0R92eQV45DQkIOXWvzjy2+pv4E/Jk4dwzXEBLt8qQwbZb3Mqxv1veUWBZ9lfpUuG4TNFQYr1EWc5cFWmBQ=="
         }
       ]
     }
@@ -5778,30 +5778,30 @@
   "Accounts createTransaction should not mark notes as spent if markSpent is false": [
     {
       "version": 2,
-      "id": "9df907b0-356d-4b59-902d-296b8aeba7c6",
+      "id": "47b92dfc-1da0-4650-b0f3-4afe61c78a7b",
       "name": "a",
-      "spendingKey": "148ae8a2db6c9053b27e4b9b7601b8b71d7d0f31f20f33ee218ab48d20dab307",
-      "viewKey": "ba66574a9959533458bb9cbc968c38c5f42ba37debac8cbc11d5b267e5eb67bc27067bf44ad6225f8bae38f2442f02e7c2206b90a584fc7b4675444b8985b954",
-      "incomingViewKey": "ca9fcf2f0116c6bb1b6e80eb738ac417b4cc1cb4e622500bb29354ec633f1903",
-      "outgoingViewKey": "889cb150d3e6c1a4211f78f9483603492152f040ff12c3750bcaf619d839f300",
-      "publicAddress": "2e32956881ae13ecced7dee52e5a111f18a89ac5f0cdf17d5b47cc42409d2b0f",
+      "spendingKey": "296244fdb2418eb0f8ed41b431d1c037f9624bc5a7a609164622284b4ee427a8",
+      "viewKey": "88bfa10acea9d4a0452516d1117069ce9ed3008eabff7bb1da4f5dbb99eaf881610936e379350a88ce552d2bb2f522ec038efd926a56a1d2f72c13bfb8c962ac",
+      "incomingViewKey": "b5ed3dceb8726ed74b961d0df2f3c881d3713011355113f996e0765e5d98fa07",
+      "outgoingViewKey": "1fecae50b69d30c5d89f87936cceed782b51d3b96d080bba332dfb7eb7ef8556",
+      "publicAddress": "30df6dd65fe27679bc9a19b00194fcd986aca29f0709f378fb3b3d283228a5c8",
       "createdAt": null
     },
     {
       "header": {
         "sequence": 2,
-        "previousBlockHash": "AD35193FA159CFD7440A3DFDFBE7ACB720CB4A44A441AB933071E2B9EF5DE90B",
+        "previousBlockHash": "1FBEADD0044107F31E8F8C5CE6FA9DF2BAA2DFCAE659FB92C594662A6DC4C2A7",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:BVy5B/+vTGiU4jIo28mi53kPQUEpQbaXgq5hIL8CzSk="
+          "data": "base64:6ohvBp9cBBXNOU8I65vGqnFUw7rjXiUGEofNeufnYgM="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:K7M71bh6M1ckyY693ToT8muthayZ+GuR6bYr0Xj01Oo="
+          "data": "base64:UEp6n/e9eu8DEAItZ1zq/E+Ml3/6Mco4Jj1WnWfSUX0="
         },
         "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
         "randomness": "0",
-        "timestamp": 1681337112547,
+        "timestamp": 1681339692276,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 4,
         "work": "0"
@@ -5809,7 +5809,7 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAbstlIl86+TJfGpML/D73J9pVuTbdUYFhM+4e+DrSIr2qL/94zoiTYqrk7/cN9kraxO26LagPneIAMPty2LQUxjM4JYs0qQz8Gx0wAfZA0QGgk4aD0d9UDNURxKXCd9xsCIMgk69+jq+hNYHbvQ5e0i0lwkWslMufmpJsaMVEiIEXkRILZlG6n5RVyLAoY+hdu17XYd6H2x0/tv+rqkQWrJ8y2mmBOUDP4OnvY5iWbYqTsF0mhSTVoYMOMlNFbToBLSEDVYzgEbiKAhP5m7dLNOmVvXknCVvDXUR+giq6XImudRL35MWdnZh0fKjsVYZlJzODLTlZdFWrNi5GWvYptxSoqx/pOOCGS/Qdk//MgxqLVVhADbdZ+WIB8RyR8d8Tu3ih970O2oZWrjSSbHFXO5AwItgmbdYrNl0WbU2KB1Vi78eljINI/3Y0MQl9YG5KRBSrmLGogiiSCfRDcwWdFWofKOZe4nzoK4FEEltBpEmCe8s5bqhCyRA3/EFFW9wmJ60FE+L+upaE2RtmfjrwRHYfEZwHhG+zIxL4b9Rytw0ejCa4oLgLdmh4+AeVtBi2bc6RuQkzMUc3mck1+rvcGePqxUoVnrSfWCkXxuJgZh7KSFoPcUl0+0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwKnUfAZrzB+Yq28iGDpzN/dkZIp1qirvDa+JK7xHZza0zCxJjhYVkju9DZt7xF+89xgaOP+XrO0OJRy501rh5Dg=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAGMQEPOrOVMI844g1hHe+zbHbXkXJkql/84gs01fs7wKwOPSvaje52jc8ZSsA+tMSEnOxhp2KYpWO0KzQrtZj7vhaJUqdr+zlOS+6DuSIgyKpFdvkp5EgUDtxjV9KBGZyJAFy1RaE6u76R+z3A07E3N6XsyEOU1XIyMEi9glfPCEDSJ/somfhU0GQQ+ME3Q3Q/KFouffkS1ZJS2KK/CU5we/7XyGuq7JNiorWXcF5nPa1NDJSwY7IOzvivOwxCK/fvbtldL1unpYD78BCO57v55EUuiiQWqrf98Ww+Wsf14Pp3XLyKLatGEwLmgTstEJFc/Ikv1KkiFrvujFPBVDDsBS53+lrCXKQueV93r+eE0lPwDF403YIDUeLX50AUMcjI8muNVVrAL1n5WmsRpU8r6YnNlsr8gGM65e4Nm36g4zx3WZCfItFOjl1lZG+o03p4n2ra+T506byyQ6XoDPjoTIwrdajvCuW9B6/7m72keCdJ/bSEzdnoSvRWKZggCmEtuh/jAuIRyUOj4EDvFR0uRp96NZTUtNO3hX670+KSmjxaKLx5sWtVDWPm6CyYZ9w0se3plj+T0ldOfXHdplsNnlxi7AID3DHcjWS5RTl8whvfu2KGdIQgUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwk4A9M/Q8RQSwHqI2BHLQcIMXAbChIkDfw69M3yBKjhQszX5XscxSr68DcUugA8hCymIeGAvNfQVv1Jb9KklRBg=="
         }
       ]
     }

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -968,6 +968,14 @@ describe('Accounts', () => {
       Assert.isNotUndefined(decryptedNote)
 
       expect(decryptedNote.spent).toBeFalsy()
+
+      const unspentNotes = await AsyncUtils.materialize(
+        accountA.getUnspentNotes(Asset.nativeId()),
+      )
+
+      expect(
+        unspentNotes.find((note) => note.note.hash().equals(decryptedNote.note.hash())),
+      ).toBeTruthy()
     })
 
     it('should mark notes as spent if markSpent is true', async () => {
@@ -1010,6 +1018,14 @@ describe('Accounts', () => {
       Assert.isNotUndefined(decryptedNote)
 
       expect(decryptedNote.spent).toBeTruthy()
+
+      const unspentNotes = await AsyncUtils.materialize(
+        accountA.getUnspentNotes(Asset.nativeId()),
+      )
+
+      expect(
+        unspentNotes.find((note) => note.note.hash().equals(decryptedNote.note.hash())),
+      ).toBeFalsy()
     })
   })
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -947,6 +947,13 @@ export class Wallet {
 
             Assert.isNotUndefined(decryptedNote)
 
+            await this.walletDb.deleteUnspentNoteHash(
+              options.account,
+              spend.note.hash(),
+              decryptedNote,
+              tx,
+            )
+
             await this.walletDb.saveDecryptedNote(
               options.account,
               spend.note.hash(),


### PR DESCRIPTION
## Summary

optionally marks notes used in creating a transaction as spent. this is useful for creating multiple raw transactions in succession without spending the same note(s) in more than one transaction.

we have an example of this use case in the airdrop: we need to create many raw transactions and then post them separately before broadcasting to the network.

## Testing Plan

- added unit tests
- manual testing
  - observed notes using 'wallet:notes'
  - created raw transaction with 'markSpent' set to true by modifying send command
  - confirmed that notes were marked as spent

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
