### PR TITLE
Separate mainnet + testnet telemetry

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -113,7 +113,10 @@ export class IronfishNode {
       metrics,
       workerPool,
       localPeerIdentity: privateIdentityToIdentity(identity),
-      defaultTags: [{ name: 'version', value: pkg.version }],
+      defaultTags: [
+        { name: 'version', value: pkg.version },
+        { name: 'networkId', value: networkId.toString() },
+      ],
       defaultFields: [
         { name: 'node_id', type: 'string', value: internal.get('telemetryNodeId') },
         { name: 'session_id', type: 'string', value: uuid() },


### PR DESCRIPTION
## Summary
Add a telemetry tag to separate mainnet and testnet telemetry

## Testing Plan
Tested by running node locally and verifying payload sent to telemetry endpoint

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
