### PR TITLE
clears old wallet data without deserialization

### DIFF
--- a/ironfish/src/storage/database/store.ts
+++ b/ironfish/src/storage/database/store.ts
@@ -94,7 +94,11 @@ export interface IDatabaseStore<Schema extends DatabaseSchema> {
    *
    * @returns resolves when all keys have been deleted
    */
-  clear(transaction?: IDatabaseTransaction, keyRange?: DatabaseKeyRange): Promise<void>
+  clear(
+    transaction?: IDatabaseTransaction,
+    keyRange?: DatabaseKeyRange,
+    iteratorOptions?: DatabaseIteratorOptions,
+  ): Promise<void>
 
   /**
    * Used to get a value from the store at a given key

--- a/ironfish/src/storage/levelup/store.ts
+++ b/ironfish/src/storage/levelup/store.ts
@@ -192,9 +192,13 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
     return AsyncUtils.materialize(this.getAllKeysIter(transaction, keyRange, iteratorOptions))
   }
 
-  async clear(transaction?: IDatabaseTransaction, keyRange?: DatabaseKeyRange): Promise<void> {
+  async clear(
+    transaction?: IDatabaseTransaction,
+    keyRange?: DatabaseKeyRange,
+    iteratorOptions?: DatabaseIteratorOptions,
+  ): Promise<void> {
     if (transaction) {
-      for await (const key of this.getAllKeysIter(transaction, keyRange)) {
+      for await (const key of this.getAllKeysIter(transaction, keyRange, iteratorOptions)) {
         await this.del(key, transaction)
       }
       return
@@ -206,7 +210,7 @@ export class LevelupStore<Schema extends DatabaseSchema> extends DatabaseStore<S
       keyRange = this.allKeysRange
     }
 
-    await this.db.levelup.clear(keyRange ?? this.allKeysRange)
+    await this.db.levelup.clear({ ...keyRange, ...iteratorOptions })
   }
 
   async put(

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1074,14 +1074,11 @@ export class WalletDB {
       const range = StorageUtils.getPrefixKeyRange(prefix)
 
       for (const store of stores) {
-        for await (const key of store.getAllKeysIter(undefined, range)) {
-          if (signal?.aborted === true || recordsToCleanup === 0) {
-            return
-          }
-
-          await store.del(key)
-          recordsToCleanup--
+        if (signal?.aborted === true) {
+          return
         }
+
+        await store.clear(undefined, range, { limit: recordsToCleanup })
       }
 
       await this.accountIdsToCleanup.del(accountId)


### PR DESCRIPTION
## Summary

we delete old records from wallet datastores in batches in 'cleanupDeletedAccounts' to avoid blocking the node during lengthy delete operations.

however, we use 'getAllKeysIter' to iterate over keys and delete them one by one. 'getAllKeysIter' calls 'getAllIter' which iterates over keys _and_ values. during this iteration 'getAllIter' decodes the key and deserializes the value. this deserialization is problematic if the value encoding has changed.

for example, the latest network reset changed asset generation. the database fails to deserialize old transaction data because the asset identifiers in the old transactions are now invalid:

```
Error: InvalidAssetIdentifier
    at <anonymous> (/Users/hughy/Code/ironfish/ironfish/src/primitives/transaction.ts:95:27)
    at Function.from (<anonymous>)
    at Transaction (/Users/hughy/Code/ironfish/ironfish/src/primitives/transaction.ts:91:24)
    at TransactionValueEncoding.deserialize (/Users/hughy/Code/ironfish/ironfish/src/wallet/walletdb/transactionValue.ts:58:25)
```

we can solve this problem by using the levelup 'clear' method (https://github.com/Level/levelup#dbclearoptions-callback) to delete entries in a key range instead of deleting keys one by one. using 'clear' does not deserialize values.

'clear' also accepts a 'limit' option so that we can still perform deletions on batches of records.

- modifies levelup definition of clear to accept 'DatabaseIteratorOptions' and pass those options to the database
- uses clear with limit in walletdb cleanupDeletedAccounts instead of iterating over keys and deleting each key

## Testing Plan

manual testing:
1. start a node on v0.1.75
2. mint an asset
3. upgrade ironfish to v0.1.76
4. run 'ironfish reset' to reset the chain
5. start the node
  a. without changes applied, you'll run into an error during account data cleanup
  b. with changes applied the node will start and clean up old data in the background

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
