### PR TITLE
allows docker deploy with version tags only

### DIFF
--- a/.github/workflows/deploy-node-docker-image.yml
+++ b/.github/workflows/deploy-node-docker-image.yml
@@ -72,9 +72,8 @@ jobs:
           docker push ghcr.io/iron-fish/ironfish:latest
 
       # Used if we are deploying a new version (e.g. v1.1)
-      # This is only executed when deploying a new release to mainnet
       - name: Deploy Node Image to GitHub:${{ github.ref_name }}
-        if: ${{ inputs.github_tag_mainnet && github.event.ref_type == 'tag'}}
+        if: ${{ github.ref_type == 'tag'}}
         run: |
           docker tag ironfish ghcr.io/iron-fish/ironfish:${{ github.ref_name }}
           docker push ghcr.io/iron-fish/ironfish:${{ github.ref_name }}


### PR DESCRIPTION
## Summary

we recently added the ability to deploy docker images tagged with the version tag (e.g., v0.1.76)

however, the workflow currently only deploys these tags if we are also deploying to and overwriting the 'latest' tag. this prevents us from deploying a tag from an earlier version, like v0.1.75, without overwriting the 'latest' image from the current version

we also use the 'github.event' context to determine if we're deploying a tag. this is incorrect since the only event that can trigger this workflow is 'workflow_dispatch', which does not have a 'ref_type' parameter, so `github.event.ref_type == 'tag'` will never be true.  instead we can use 'github.ref_type' which will refer to the branch or tag that the workflow was triggered from.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
