### PR TITLE
pushes version to testnet api

### DIFF
--- a/.github/workflows/push-version-to-api.yml
+++ b/.github/workflows/push-version-to-api.yml
@@ -1,5 +1,15 @@
 name: Push new version number to API
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      push_mainnet:
+        description: "mainnet"
+        type: boolean
+        default: false
+      push_testnet:
+        description: "testnet"
+        type: boolean
+        default: false
 
 jobs:
   Push:
@@ -10,8 +20,16 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Push version string to API
+      - name: Push version string to mainnet API
+        if: ${{ inputs.push_mainnet }}
         run: ./ironfish-cli/scripts/push-version.sh
         env:
           IRON_FISH_API_KEY: ${{ secrets.IRON_FISH_API_KEY }}
           IRON_FISH_API_URL: ${{ secrets.IRON_FISH_API_URL }}
+
+      - name: Push version string to testnet API
+        if: ${{ inputs.push_testnet }}
+        run: ./ironfish-cli/scripts/push-version.sh
+        env:
+          IRON_FISH_API_KEY: ${{ secrets.IRON_FISH_API_KEY_TESTNET }}
+          IRON_FISH_API_URL: ${{ secrets.IRON_FISH_API_URL_TESTNET }}


### PR DESCRIPTION
## Summary

the push-version-to-api workflow pushes the latest ironfish-cli version to the api. however, we now have two different apis for mainnet and testnet.

users are confused about the version not updating on the testnet explorer.

- adds inputs for pushing to mainnet and testnet
- optionally pushes the api version to the mainnet api, testnet api, or both

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
