### PR TITLE
clears walletdb datastores during reset

### DIFF
--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1060,13 +1060,17 @@ export class WalletDB {
       key: Readonly<unknown>
       value: unknown
     }>[] = [
-      this.transactions,
+      this.decryptedNotes,
+      this.nullifierToNoteHash,
       this.sequenceToNoteHash,
       this.nonChainNoteHashes,
-      this.nullifierToNoteHash,
+      this.transactions,
+      this.sequenceToTransactionHash,
       this.pendingTransactionHashes,
-      this.decryptedNotes,
       this.timestampToTransactionHash,
+      this.assets,
+      this.nullifierToTransactionHash,
+      this.unspentNoteHashes,
     ]
 
     for (const [accountId] of await this.accountIdsToCleanup.getAll()) {


### PR DESCRIPTION
## Summary

following a network reset the walletdb may have data that is incompatible with database schemas. for instance, if asset identifiers in transactions or notes change, then any datastores that encode that data must be migrated or cleared.

we avoid deleting the walletdb during 'reset' so that we do not delete user keys. however, the node will fail to start if it needs to apply migrations on incompatible data or even if it needs to deserialize incompatible data in the course of deleting it.

to resolve this we can use 'clear' on each walletdb datastore during the 'reset' command. clear will delete all keys within a range without deserializing the values.

note that clear soft-deletes data that is cleanup up later during database compactions rather than deleting immediately.

- clears each walletdb datastore, except accounts and meta, during 'reset'
- adds missing datastores to cleanupDeletedAccounts

## Testing Plan

manual testing:
1. start with wallet on earlier version before network reset (e.g., v0.1.70)
2. upgrade to v0.1.76
3. run `ironfish reset`
4. start the node

tested with pool account from phase 3 (~10k transactions and ~10k notes) and resetting wallet data using these changes took less than 10s.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
