### PR TITLE
displays transactions sent to own address in wallet:transactions

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -120,7 +120,8 @@ export class TransactionsCommand extends IronfishCommand {
         }
 
         // exclude the native asset in cli output if no amount was sent/received
-        if (format === Format.cli && amount === 0n) {
+        // and it was not the only asset exchanged
+        if (format === Format.cli && amount === 0n && assetCount > 1) {
           assetCount -= 1
           continue
         }


### PR DESCRIPTION
## Summary

we exclude IRON from the transactions list in a given transaction if the delta was zero. however, if an account sends a transaction in IRON to its own address then this transaction is omitted from the list completely.

to fix this we can ensure that we only exclude a row for IRON if it is not the only asset in the transaction.

## Testing Plan

manual testing:
1. send a transaction from an account to the account's own address in IRON
2. use 'ironfish wallet:transactions' to ensure that the transaction is displayed

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
