### PR TITLE
clears walletDb in 'mainnet' command

### DIFF
--- a/ironfish-cli/src/commands/mainnet.ts
+++ b/ironfish-cli/src/commands/mainnet.ts
@@ -82,6 +82,16 @@ export default class Mainnet extends IronfishCommand {
     this.sdk.internal.clear('telemetryNodeId')
     await this.sdk.internal.save()
 
+    // Reset walletDb stores containing chain data
+    const node = await this.sdk.node()
+    const walletDb = node.wallet.walletDb
+
+    await walletDb.db.open()
+
+    for (const store of walletDb.cacheStores) {
+      await store.clear()
+    }
+
     CliUx.ux.action.stop('Data migrated successfully.')
   }
 }


### PR DESCRIPTION
## Summary

adds changes from #3797 into 'mainnet' command.

clears old chain data from the walletdb that cannot be migrated or deleted by key following changes from network reset.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
