### PR TITLE
feat(ironfish): Send block header work to API in sync

### DIFF
--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -128,6 +128,7 @@ export class WebApi {
       graffiti: block.graffiti,
       main: block.main,
       transactions: block.transactions,
+      work: block.work,
     }))
 
     const options = this.options({ 'Content-Type': 'application/json' })


### PR DESCRIPTION
## Summary

Sync over block header work for hash rate calculation

## Testing Plan

N/A

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
