### PR TITLE
feat(cli): Add network name to status. uses id as fallback

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -1,7 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { FileUtils, GetNodeStatusResponse, PromiseUtils, TimeUtils } from '@ironfish/sdk'
+import {
+  defaultNetworkName,
+  FileUtils,
+  GetNodeStatusResponse,
+  PromiseUtils,
+  TimeUtils,
+} from '@ironfish/sdk'
 import { Assert } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import blessed from 'blessed'
@@ -111,6 +117,9 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
 
   const blockGraffiti = `${content.miningDirector.blockGraffiti}`
 
+  const network =
+    defaultNetworkName(content.node.networkId) || content.node.networkId.toString()
+
   const peerNetworkStatus = `${
     content.peerNetwork.isReady ? 'CONNECTED' : 'WAITING'
   } - In: ${FileUtils.formatFileSize(
@@ -195,6 +204,7 @@ Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
 Node Name            ${nodeName}
 Block Graffiti       ${blockGraffiti}
+Network              ${network}
 Memory               ${memoryStatus}
 CPU                  ${cpuStatus}
 P2P Network          ${peerNetworkStatus}

--- a/ironfish/src/defaultNetworkDefinitions.ts
+++ b/ironfish/src/defaultNetworkDefinitions.ts
@@ -6,6 +6,17 @@ export function isDefaultNetworkId(networkId: number): boolean {
   return networkId <= 100
 }
 
+export function defaultNetworkName(networkId: number): string | undefined {
+  switch (networkId) {
+    case 0:
+      return 'Testnet'
+    case 1:
+      return 'Mainnet'
+    case 2:
+      return 'Dev'
+  }
+}
+
 /**
  * This account (IronFishGenesisAccount) can be imported to access the funds in the genesis block.
  *

--- a/ironfish/src/index.ts
+++ b/ironfish/src/index.ts
@@ -5,7 +5,11 @@ export * from './wallet'
 export * from './assert'
 export * from './blockchain'
 export * from './consensus'
-export { DEV_GENESIS_ACCOUNT } from './defaultNetworkDefinitions'
+export {
+  DEV_GENESIS_ACCOUNT,
+  defaultNetworkName,
+  isDefaultNetworkId,
+} from './defaultNetworkDefinitions'
 export * from './chainProcessor'
 export * from './event'
 export * from './fileStores'

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -18,6 +18,7 @@ export type GetNodeStatusResponse = {
     version: string
     git: string
     nodeName: string
+    networkId: number
   }
   cpu: {
     cores: number
@@ -116,6 +117,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetNodeStatusResponse> = 
         version: yup.string().defined(),
         git: yup.string().defined(),
         nodeName: yup.string().defined(),
+        networkId: yup.number().defined(),
       })
       .defined(),
     cpu: yup
@@ -289,6 +291,7 @@ function getStatus(node: IronfishNode): GetNodeStatusResponse {
       version: node.pkg.version,
       git: node.pkg.git,
       nodeName: node.config.get('nodeName'),
+      networkId: node.internal.get('networkId'),
     },
     cpu: {
       cores: node.metrics.cpuCores,


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/97762857/233493857-c23a4281-46cf-410c-901a-1047de13ffe7.png)

Closes IFL-678

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
