### PR TITLE
feat(ironfish): Return note indices in getNotes

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -15,6 +15,7 @@ export type GetAccountNotesStreamResponse = {
   memo: string
   sender: string
   transactionHash: string
+  index: number | null
   spent: boolean | undefined
 }
 
@@ -34,6 +35,7 @@ export const GetAccountNotesStreamResponseSchema: yup.ObjectSchema<GetAccountNot
       memo: yup.string().trim().defined(),
       sender: yup.string().defined(),
       transactionHash: yup.string().defined(),
+      index: yup.number(),
       spent: yup.boolean(),
     })
     .defined()
@@ -51,7 +53,7 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
 
       const notes = await account.getTransactionNotes(transaction.transaction)
 
-      for (const { note, spent } of notes) {
+      for (const { note, spent, index } of notes) {
         if (request.closed) {
           break
         }
@@ -65,6 +67,7 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
           memo: note.memo(),
           sender: note.sender(),
           transactionHash: transaction.transaction.hash().toString('hex'),
+          index,
           spent,
         })
       }


### PR DESCRIPTION
## Summary

We should return the note indices from the decrypted notes in the wallet for ease of use by developers.

## Testing Plan

N/A

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

TODO: Will add

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
