### PR TITLE
Separate telemetry by endpoint

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -403,7 +403,7 @@ export class Config extends KeyStore<ConfigOptions> {
       confirmations: 2,
       minPeers: 1,
       targetPeers: 50,
-      telemetryApi: 'https://api.ironfish.network/telemetry',
+      telemetryApi: '',
       generateNewIdentity: false,
       blocksPerMessage: 25,
       minerBatchSize: 25000,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -113,14 +113,12 @@ export class IronfishNode {
       metrics,
       workerPool,
       localPeerIdentity: privateIdentityToIdentity(identity),
-      defaultTags: [
-        { name: 'version', value: pkg.version },
-        { name: 'networkId', value: networkId.toString() },
-      ],
+      defaultTags: [{ name: 'version', value: pkg.version }],
       defaultFields: [
         { name: 'node_id', type: 'string', value: internal.get('telemetryNodeId') },
         { name: 'session_id', type: 'string', value: uuid() },
       ],
+      networkId,
     })
 
     this.peerNetwork = new PeerNetwork({

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -78,11 +78,6 @@ describe('IronfishSdk', () => {
       const sdk = await IronfishSdk.init({
         configName: 'foo.config.json',
         fileSystem: fileSystem,
-        configOverrides: {
-          // TODO: It should be possible to test on the default network (mainnet)
-          // once the genesis block has been added.
-          networkId: 2,
-        },
       })
 
       const expectedDir = fileSystem.resolve(DEFAULT_DATA_DIR)

--- a/ironfish/src/telemetry/telemetry.test.ts
+++ b/ironfish/src/telemetry/telemetry.test.ts
@@ -28,6 +28,7 @@ describe('Telemetry', () => {
 
   beforeEach(() => {
     telemetry = new Telemetry({
+      networkId: 2,
       chain: mockChain(),
       workerPool: mockWorkerPool(),
       config: mockConfig({ blockGraffiti: mockGraffiti }),
@@ -55,6 +56,7 @@ describe('Telemetry', () => {
     describe('when disabled', () => {
       it('does nothing', () => {
         const disabledTelemetry = new Telemetry({
+          networkId: 2,
           chain: mockChain(),
           workerPool: mockWorkerPool(),
           config: mockConfig({ blockGraffiti: mockGraffiti }),
@@ -136,6 +138,7 @@ describe('Telemetry', () => {
       expect(submitTelemetry).toHaveBeenCalledWith(
         points.slice(0, telemetry['MAX_POINTS_TO_SUBMIT']),
         GraffitiUtils.fromString(mockGraffiti),
+        'https://api.ironfish.network',
       )
       expect(telemetry['points']).toEqual(points.slice(telemetry['MAX_POINTS_TO_SUBMIT']))
       expect(telemetry['points']).toHaveLength(

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -32,6 +32,7 @@ export class Telemetry {
   private readonly metrics: MetricsMonitor | null
   private readonly workerPool: WorkerPool
   private readonly localPeerIdentity: Identity
+  private readonly apiHost: string
 
   private started: boolean
   private flushInterval: SetIntervalToken | null
@@ -49,6 +50,7 @@ export class Telemetry {
     localPeerIdentity: Identity
     defaultFields?: Field[]
     defaultTags?: Tag[]
+    networkId: number
   }) {
     this.chain = options.chain
     this.workerPool = options.workerPool
@@ -56,6 +58,7 @@ export class Telemetry {
     this.logger = options.logger ?? createRootLogger()
     this.metrics = options.metrics ?? null
     this.defaultTags = options.defaultTags ?? []
+    this.defaultTags.push({ name: 'networkId', value: options.networkId.toString() })
     this.defaultFields = options.defaultFields ?? []
     this.localPeerIdentity = options.localPeerIdentity
 
@@ -65,6 +68,13 @@ export class Telemetry {
     this.retries = 0
     this._submitted = 0
     this.started = false
+
+    this.apiHost = this.config.get('telemetryApi')
+    if (!this.apiHost && options.networkId === 0) {
+      this.apiHost = 'https://testnet.api.ironfish.network'
+    } else if (!this.apiHost) {
+      this.apiHost = 'https://api.ironfish.network'
+    }
   }
 
   get pending(): number {
@@ -330,7 +340,7 @@ export class Telemetry {
 
     try {
       const graffiti = GraffitiUtils.fromString(this.config.get('blockGraffiti'))
-      await this.workerPool.submitTelemetry(points, graffiti)
+      await this.workerPool.submitTelemetry(points, graffiti, this.apiHost)
       this.logger.debug(`Submitted ${points.length} telemetry points`)
       this.retries = 0
       this._submitted += points.length

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -32,7 +32,7 @@ export class Telemetry {
   private readonly metrics: MetricsMonitor | null
   private readonly workerPool: WorkerPool
   private readonly localPeerIdentity: Identity
-  private readonly apiHost: string
+  private readonly apiUrl: string
 
   private started: boolean
   private flushInterval: SetIntervalToken | null
@@ -69,11 +69,11 @@ export class Telemetry {
     this._submitted = 0
     this.started = false
 
-    this.apiHost = this.config.get('telemetryApi')
-    if (!this.apiHost && options.networkId === 0) {
-      this.apiHost = 'https://testnet.api.ironfish.network'
-    } else if (!this.apiHost) {
-      this.apiHost = 'https://api.ironfish.network'
+    this.apiUrl = this.config.get('telemetryApi')
+    if (!this.apiUrl && options.networkId === 0) {
+      this.apiUrl = 'https://testnet.api.ironfish.network'
+    } else if (!this.apiUrl) {
+      this.apiUrl = 'https://api.ironfish.network'
     }
   }
 
@@ -340,7 +340,7 @@ export class Telemetry {
 
     try {
       const graffiti = GraffitiUtils.fromString(this.config.get('blockGraffiti'))
-      await this.workerPool.submitTelemetry(points, graffiti, this.apiHost)
+      await this.workerPool.submitTelemetry(points, graffiti, this.apiUrl)
       this.logger.debug(`Submitted ${points.length} telemetry points`)
       this.retries = 0
       this._submitted += points.length

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -208,8 +208,8 @@ export class WorkerPool {
     return job
   }
 
-  async submitTelemetry(points: Metric[], graffiti: Buffer): Promise<void> {
-    const request = new SubmitTelemetryRequest(points, graffiti)
+  async submitTelemetry(points: Metric[], graffiti: Buffer, apiHost: string): Promise<void> {
+    const request = new SubmitTelemetryRequest(points, graffiti, apiHost)
 
     await this.execute(request).result()
   }


### PR DESCRIPTION
## Summary
Send telemetry to the correct API endpoint depending on the network id

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
