### PR TITLE
[WIP] Add spends to getTransaction RPCs

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -9,7 +9,7 @@ import { Account } from '../../../wallet/account'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { RpcRequest } from '../../request'
 import { ApiNamespace, router } from '../router'
-import { RpcAccountDecryptedNote } from './types'
+import { RpcAccountDecryptedNote, RpcSpend } from './types'
 import {
   getAccount,
   getAccountDecryptedNotes,
@@ -25,6 +25,7 @@ export type GetAccountTransactionsRequest = {
   offset?: number
   confirmations?: number
   notes?: boolean
+  spends?: boolean
 }
 
 export type GetAccountTransactionsResponse = {
@@ -44,6 +45,7 @@ export type GetAccountTransactionsResponse = {
   submittedSequence: number
   assetBalanceDeltas: Array<{ assetId: string; assetName: string; delta: string }>
   notes?: RpcAccountDecryptedNote[]
+  spends?: RpcSpend[]
 }
 
 export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTransactionsRequest> =
@@ -55,7 +57,8 @@ export const GetAccountTransactionsRequestSchema: yup.ObjectSchema<GetAccountTra
       limit: yup.number().notRequired(),
       offset: yup.number().notRequired(),
       confirmations: yup.number().notRequired(),
-      notes: yup.boolean().notRequired(),
+      notes: yup.boolean().notRequired().default(false),
+      spends: yup.boolean().notRequired().default(false),
     })
     .defined()
 
@@ -98,6 +101,15 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
             sender: yup.string().defined(),
             memo: yup.string().trim().defined(),
             spent: yup.boolean(),
+          })
+          .defined(),
+      ),
+      spends: yup.array(
+        yup
+          .object({
+            nullifier: yup.string().defined(),
+            commitment: yup.string().defined(),
+            size: yup.number().defined(),
           })
           .defined(),
       ),
@@ -177,6 +189,15 @@ const streamTransaction = async (
     notes = await getAccountDecryptedNotes(node, account, transaction)
   }
 
+  let spends = undefined
+  if (request.data.spends) {
+    spends = transaction.transaction.spends.map((spend) => ({
+      nullifier: spend.nullifier.toString('hex'),
+      commitment: spend.commitment.toString('hex'),
+      size: spend.size,
+    }))
+  }
+
   const status = await node.wallet.getTransactionStatus(account, transaction, options)
   const type = await node.wallet.getTransactionType(account, transaction)
 
@@ -187,6 +208,7 @@ const streamTransaction = async (
     confirmations: options.confirmations,
     type,
     notes,
+    spends,
   }
 
   request.stream(serialized)

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -32,3 +32,9 @@ export type RpcAccountDecryptedNote = {
   owner: string
   spent: boolean
 }
+
+export type RpcSpend = {
+  nullifier: string
+  commitment: string
+  size: number
+}


### PR DESCRIPTION
## Summary

This is WIP, I'm going to split this into 2 separate PRs and add tests.

This adds the spends (vin) to 2 RPCs that return transactions.

 - wallet/getAccountTransactions
 - chain/getTransaction

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
