### PR TITLE
feat(ironfish): Add missing note hashes from RPC responses

### DIFF
--- a/ironfish/src/rpc/routes/chain/getTransaction.test.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.test.ts
@@ -19,9 +19,14 @@ describe('Route chain/getTransaction', () => {
     const transaction = block2.transactions[0]
 
     const notesEncrypted: string[] = []
+    const notes: { hash: string; serialized: string }[] = []
 
     for (const note of transaction.notes) {
       notesEncrypted.push(note.serialize().toString('hex'))
+      notes.push({
+        hash: note.hash().toString('hex'),
+        serialized: note.serialize().toString('hex'),
+      })
     }
 
     const response = await routeTest.client
@@ -39,6 +44,7 @@ describe('Route chain/getTransaction', () => {
       notesEncrypted,
       mints: [],
       burns: [],
+      notes,
     })
   })
 
@@ -51,9 +57,14 @@ describe('Route chain/getTransaction', () => {
     const transaction = block2.transactions[0]
 
     const notesEncrypted: string[] = []
+    const notes: { hash: string; serialized: string }[] = []
 
     for (const note of transaction.notes) {
       notesEncrypted.push(note.serialize().toString('hex'))
+      notes.push({
+        hash: note.hash().toString('hex'),
+        serialized: note.serialize().toString('hex'),
+      })
     }
 
     const response = await routeTest.client
@@ -72,6 +83,7 @@ describe('Route chain/getTransaction', () => {
       notesEncrypted,
       mints: [],
       burns: [],
+      notes,
     })
   })
 

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -15,6 +15,7 @@ import { ApiNamespace, router } from '../router'
 interface Note {
   assetId: string
   assetName: string
+  hash: string
   value: string
   memo: string
 }
@@ -42,6 +43,7 @@ const NoteSchema = yup
   .shape({
     assetId: yup.string().required(),
     assetName: yup.string().required(),
+    hash: yup.string().required(),
     value: yup.string().required(),
     memo: yup.string().required(),
   })
@@ -163,6 +165,7 @@ router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
               memo: decryptedNote.memo(),
               assetId: decryptedNote.assetId().toString('hex'),
               assetName: assetValue?.name.toString('hex') || '',
+              hash: decryptedNote.hash().toString('hex'),
             })
           }
         }

--- a/ironfish/src/rpc/routes/wallet/getTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransaction.ts
@@ -90,6 +90,7 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
                   sender: yup.string().defined(),
                   memo: yup.string().trim().defined(),
                   spent: yup.boolean(),
+                  hash: yup.string().defined(),
                 })
                 .defined(),
             )

--- a/ironfish/src/rpc/routes/wallet/getTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getTransactions.ts
@@ -98,6 +98,7 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
             sender: yup.string().defined(),
             memo: yup.string().trim().defined(),
             spent: yup.boolean(),
+            hash: yup.string().defined(),
           })
           .defined(),
       ),

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -31,6 +31,7 @@ export type RpcAccountDecryptedNote = {
   sender: string
   owner: string
   spent: boolean
+  hash: string
 }
 
 export type RpcSpend = {

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -104,6 +104,7 @@ export async function getAccountDecryptedNotes(
       assetName: asset?.name.toString('hex') || '',
       sender: note.sender(),
       spent: spent,
+      hash: note.hash().toString('hex'),
     })
   }
 


### PR DESCRIPTION
## Summary

We don't return note hashes in several RPC responses where other fields from the note are returned. Add the hash where appropriate.

## Testing Plan

Updated existing unit tests.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

https://github.com/iron-fish/website/pull/398

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
