### PR TITLE
Deserialize fee as BigI64

### DIFF
--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -51,7 +51,7 @@ export class Transaction {
     const _notesLength = reader.readU64() // 8
     const _mintsLength = reader.readU64() // 8
     const _burnsLength = reader.readU64() // 8
-    this._fee = BigInt(reader.readI64()) // 8
+    this._fee = reader.readBigI64() // 8
     this._expiration = reader.readU32() // 4
     // randomized public key of sender
     // to read the value of rpk reader.readBytes(PUBLIC_ADDRESS_LENGTH, true).toString('hex')


### PR DESCRIPTION
## Summary

This shouldn't practically cause any issues, but since fee is an i64, we could run into some bounds errors if we don't use bigint for deserialization.

Fixes IFL-741

## Testing Plan

* [x] Synced first 1k blocks on mainnet

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
