### PR TITLE
refactor(ironfish): Properly mark `notesEncrypted` as deprecated

### DIFF
--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -29,7 +29,9 @@ export type GetTransactionResponse = {
     value: string
   }[]
   blockHash: string
-  // Deprecated: use `notes` instead
+  /**
+   * @deprecated Please use `notes` instead
+   */
   notesEncrypted: string[]
 }
 


### PR DESCRIPTION
## Summary

Use JsDoc `@deprecated` to mark this field as deprecated

## Testing Plan

![image](https://user-images.githubusercontent.com/5459049/234396162-5454129b-42c6-4e3b-8323-ac47da847a32.png)

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
