### PR TITLE
Update cli text for transaction:watch

### DIFF
--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -38,8 +38,6 @@ export async function watchTransaction(options: {
   let prevStatus = last?.content.transaction?.status ?? 'not found'
   let currentStatus = prevStatus
 
-  CliUx.ux.action.start(`Current Status`)
-
   // If the transaction is already in the desired state, return
   if (currentStatus === waitUntil) {
     logger.log(`Transaction ${options.hash} is ${waitUntil}`)


### PR DESCRIPTION
## Summary

Fix https://github.com/iron-fish/ironfish/issues/3823. Remove unnecessary `Current status... !` from transaction:watch when status is already in desired state.

Before - 
```
wd021:~# ironfish wallet:transaction:watch abcd
Transaction abcd is confirmed
Current Status... !
```

After - 
```
wd021:~# ironfish wallet:transaction:watch abcd
Transaction abcd is confirmed
```

## Testing Plan
Run `wallet:transaction:watch` for confirmed transaction

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
