### PR TITLE
docs: documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once your environment is set up - you can run the CLI by following [these direct
 ## Structure of the repository
 
 - [ironfish](./ironfish/README.md): The library that contains the IronfishSDK and all Ironfish code written in TypeScript.
-- [ironfish-cli](./ironfish-cli/README.md): The main client for Iron Fish as of today. It is a command-line interface built on Node. More details in [our documentation](https://ironfish.network/docs/onboarding/iron-fish-tutorial).
+- [ironfish-cli](./ironfish-cli/README.md): The main client for Iron Fish as of today. It is a command-line interface built on Node. More details in [our documentation](https://ironfish.network/use/get-started/installation).
 - [ironfish-rust](./ironfish-rust/README.md): Core API for interacting with the transactions and chain and using ZKP.
 - [ironfish-rust-nodejs](./ironfish-rust-nodejs/README.md): Wrapper for `ironfish-rust` as a native NodeJS addon.
 


### PR DESCRIPTION
## Summary
Updates readme documentation URL

## Testing Plan
Check if new URL works in https://github.com/iron-fish/ironfish/blob/c14dac9b9b17356ad388bd67c47678d4319fb0ed/README.md

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
