### PR TITLE
fix(test): add a significant timeout for add genesis transaction tests

### DIFF
--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -316,5 +316,5 @@ describe('addGenesisTransaction', () => {
       block.header.transactionCommitment,
     )
     expect(deserializedBlock.transactions.length).toEqual(block.transactions.length)
-  })
+  }, 600000)
 })


### PR DESCRIPTION
## Summary

Ideally, we would not need to rely on hard-coded timeouts, since that messes with our `JEST_TIMEOUT` env var functionality. Using fixtures would require adding new, very specific fixtures and ultimately I think this logic is delicate enough that I'd prefer not to use fixtures.

Closes IFL-772

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
