### PR TITLE
adds a simulation for fetching transactions from getAccountTransaction

### DIFF
--- a/simulator/src/simulations/getAccountTransaction.ts
+++ b/simulator/src/simulations/getAccountTransaction.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { GetAccountTransactionResponse, Logger } from '@ironfish/sdk'
+import axios from 'axios'
+import chalk from 'chalk'
+import { IRON, SECOND, sendTransaction, SimulationNode, Simulator, sleep } from '../simulator'
+
+// Author: hughy
+// Purpose: Send transactions and ensure that they're available from
+//          wallet/getAccountTransaction
+
+const RPC_HTTP_PORT = 8020
+
+export async function run(simulator: Simulator, logger: Logger): Promise<void> {
+  const receiverNode = await simulator.startNode({
+    cfg: { enableRpcHttp: true, rpcHttpHost: 'localhost', rpcHttpPort: RPC_HTTP_PORT },
+  })
+
+  for (let i = 1; i < 3; i++) {
+    const senderRpcHttpPort = RPC_HTTP_PORT + i
+    const senderNode = await simulator.startNode({
+      cfg: {
+        enableRpcHttp: true,
+        rpcHttpHost: 'localhost',
+        rpcHttpPort: senderRpcHttpPort,
+        importGenesisAccount: false,
+      },
+    })
+    void senderLoop(simulator, logger, senderNode, receiverNode, senderRpcHttpPort)
+  }
+
+  // wait for all nodes to be stopped
+  await simulator.waitForShutdown()
+
+  logger.log('nodes stopped, shutting down...')
+}
+
+async function senderLoop(
+  simulator: Simulator,
+  logger: Logger,
+  from: SimulationNode,
+  to: SimulationNode,
+  senderRpcHttpPort: number,
+) {
+  const receiverEndpoint = `http://localhost:${RPC_HTTP_PORT}/wallet/getAccountTransaction`
+  const senderEndpoint = `http://localhost:${senderRpcHttpPort}/wallet/getAccountTransaction`
+
+  from.startMiner()
+
+  while (simulator.nodes) {
+    const sendResult = await sendTransaction(from, to, 1 * IRON, 1 * IRON).catch(
+      () => undefined,
+    )
+
+    if (!sendResult) {
+      continue
+    }
+
+    const { transaction, hash } = sendResult
+    logger.log(chalk.yellow(`[SENT] ${hash}`))
+
+    void getAccountTransaction(senderEndpoint, hash)
+
+    void to.waitForTransactionConfirmation(hash, transaction.expiration()).then((block) => {
+      if (block === undefined) {
+        logger.log(chalk.red(`[FAILED] ${hash}`))
+      } else {
+        logger.log(chalk.green(`[RECEIVED] ${hash} on block ${block?.sequence}`))
+      }
+
+      void getAccountTransaction(receiverEndpoint, hash)
+    })
+
+    await sleep(1 * SECOND)
+  }
+
+  async function getAccountTransaction(endpointUrl: string, hash: string): Promise<void> {
+    const httpResponse = await axios.post<GetAccountTransactionResponse>(endpointUrl, { hash })
+
+    if (httpResponse.status !== 200) {
+      logger.log(chalk.red(`[FAILED] request to ${endpointUrl}`))
+    }
+
+    if (httpResponse.data.transaction !== null) {
+      logger.log(chalk.green(`[FOUND] transaction ${hash} at ${endpointUrl}`))
+    } else {
+      logger.log(chalk.red(`[NOT FOUND] transaction ${hash} not at ${endpointUrl}`))
+    }
+  }
+}

--- a/simulator/src/simulations/index.ts
+++ b/simulator/src/simulations/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '@ironfish/sdk'
 import { Simulator } from '../simulator'
+import * as getAccountTransaction from './getAccountTransaction'
 import * as send from './send'
 import * as stability from './stability'
 
@@ -19,4 +20,5 @@ export interface Simulation {
 export const SIMULATIONS: { [name: string]: Simulation | undefined } = {
   send,
   stability,
+  getAccountTransaction,
 }


### PR DESCRIPTION
## Summary

we have heard reports that the 'wallet/getAccountTransaction' endpoint does not always return every transaction.

this simulation creates three nodes and has two 'sender' nodes repeatedly send transactions to the 'receiver' node. for each transaction the simulation checks that the transaction can be found on the sender node and the receiver node using the 'wallet/getAccountTransaction' endpoint over HTTP.

running the simulation for ~1000 blocks did not find any transactions missing from either the sender or receiver.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
