### PR TITLE
feat(ifl 418): split cli command

### DIFF
--- a/ironfish-cli/src/commands/chain/genesisadd.ts
+++ b/ironfish-cli/src/commands/chain/genesisadd.ts
@@ -1,19 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { MEMO_LENGTH } from '@ironfish/rust-nodejs'
 import {
   addGenesisTransaction,
   BlockSerde,
   CurrencyUtils,
   GenesisBlockAllocation,
   IJSON,
-  isValidPublicAddress,
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs/promises'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
+import { parseAllocationsFile } from '../../utils/allocations'
 
 export default class GenesisAddCommand extends IronfishCommand {
   static hidden = true
@@ -144,60 +143,4 @@ const getDuplicates = (allocations: readonly GenesisBlockAllocation[]): string[]
   }
 
   return [...duplicateSet]
-}
-
-const parseAllocationsFile = (
-  fileContent: string,
-): { ok: true; allocations: GenesisBlockAllocation[] } | { ok: false; error: string } => {
-  const allocations: GenesisBlockAllocation[] = []
-
-  let lineNum = 0
-  for (const line of fileContent.split(/[\r\n]+/)) {
-    lineNum++
-    if (line.trim().length === 0) {
-      continue
-    }
-
-    const [address, amountInIron, memo, ...rest] = line.split(',').map((v) => v.trim())
-
-    if (rest.length > 0) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) contains more than 3 values.`,
-      }
-    }
-
-    // Check address length
-    if (!isValidPublicAddress(address)) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) has an invalid public address.`,
-      }
-    }
-
-    // Check amount is positive and decodes as $IRON
-    const amountInOre = CurrencyUtils.decodeIron(amountInIron)
-    if (amountInOre < 0) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) contains a negative $IRON amount.`,
-      }
-    }
-
-    // Check memo length
-    if (Buffer.from(memo).byteLength > MEMO_LENGTH) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) contains a memo with byte length > ${MEMO_LENGTH}.`,
-      }
-    }
-
-    allocations.push({
-      publicAddress: address,
-      amountInOre: amountInOre,
-      memo: memo,
-    })
-  }
-
-  return { ok: true, allocations }
 }

--- a/ironfish-cli/src/commands/chain/genesisblock.ts
+++ b/ironfish-cli/src/commands/chain/genesisblock.ts
@@ -1,14 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { MEMO_LENGTH } from '@ironfish/rust-nodejs'
 import {
   BlockSerde,
   CurrencyUtils,
   GenesisBlockAllocation,
   GenesisBlockInfo,
   IJSON,
-  isValidPublicAddress,
   makeGenesisBlock,
   Target,
 } from '@ironfish/sdk'
@@ -16,6 +14,7 @@ import { CliUx, Flags } from '@oclif/core'
 import fs from 'fs/promises'
 import { IronfishCommand } from '../../command'
 import { LocalFlags } from '../../flags'
+import { parseAllocationsFile } from '../../utils/allocations'
 
 export default class GenesisBlockCommand extends IronfishCommand {
   static description = 'Create and serialize a genesis block'
@@ -199,60 +198,4 @@ const getDuplicates = (allocations: readonly GenesisBlockAllocation[]): string[]
   }
 
   return [...duplicateSet]
-}
-
-const parseAllocationsFile = (
-  fileContent: string,
-): { ok: true; allocations: GenesisBlockAllocation[] } | { ok: false; error: string } => {
-  const allocations: GenesisBlockAllocation[] = []
-
-  let lineNum = 0
-  for (const line of fileContent.split(/[\r\n]+/)) {
-    lineNum++
-    if (line.trim().length === 0) {
-      continue
-    }
-
-    const [address, amountInIron, memo, ...rest] = line.split(',').map((v) => v.trim())
-
-    if (rest.length > 0) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) contains more than 3 values.`,
-      }
-    }
-
-    // Check address length
-    if (!isValidPublicAddress(address)) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) has an invalid public address.`,
-      }
-    }
-
-    // Check amount is positive and decodes as $IRON
-    const amountInOre = CurrencyUtils.decodeIron(amountInIron)
-    if (amountInOre < 0) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) contains a negative $IRON amount.`,
-      }
-    }
-
-    // Check memo length
-    if (Buffer.from(memo).byteLength > MEMO_LENGTH) {
-      return {
-        ok: false,
-        error: `Line ${lineNum}: (${line}) contains a memo with byte length > ${MEMO_LENGTH}.`,
-      }
-    }
-
-    allocations.push({
-      publicAddress: address,
-      amountInOre: amountInOre,
-      memo: memo,
-    })
-  }
-
-  return { ok: true, allocations }
 }

--- a/ironfish-cli/src/commands/wallet/split.ts
+++ b/ironfish-cli/src/commands/wallet/split.ts
@@ -1,0 +1,242 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
+import {
+  Assert,
+  CreateTransactionRequest,
+  CurrencyUtils,
+  RawTransaction,
+  RawTransactionSerde,
+  Transaction,
+} from '@ironfish/sdk'
+import { CliUx, Flags } from '@oclif/core'
+import fs from 'fs/promises'
+import { IronfishCommand } from '../../command'
+import { IronFlag, LocalFlags } from '../../flags'
+import { selectAsset } from '../../utils'
+import { parseAllocationsFile } from '../../utils/allocations'
+import { selectFee } from '../../utils/fees'
+import { watchTransaction } from '../../utils/transaction'
+
+export default class Split extends IronfishCommand {
+  static aliases = ['wallet:split']
+  static hidden = true
+
+  static flags = {
+    ...LocalFlags,
+    allocations: Flags.string({
+      required: true,
+      description:
+        'A CSV file with the format publicAddress,amountInOre,memo containing airdrop allocations',
+    }),
+    account: Flags.string({
+      required: false,
+      description: 'The name of the account to use for creating split notes',
+    }),
+    output: Flags.string({
+      required: false,
+      default: 'split_transaction.txt',
+      description: 'A serialized raw transaction for splitting originating note',
+    }),
+    fee: IronFlag({
+      char: 'o',
+      description: 'The fee amount in IRON',
+      largerThan: 0n,
+      flagName: 'fee',
+    }),
+    feeRate: IronFlag({
+      char: 'r',
+      description: 'The fee rate amount in IRON/Kilobyte',
+      largerThan: 0n,
+      flagName: 'fee rate',
+    }),
+    confirm: Flags.boolean({
+      default: false,
+      description: 'Confirm without asking',
+    }),
+    watch: Flags.boolean({
+      default: false,
+      description: 'Wait for the transaction to be confirmed',
+    }),
+    expiration: Flags.integer({
+      char: 'e',
+      description:
+        'The block sequence after which the transaction will be removed from the mempool. Set to 0 for no expiration.',
+    }),
+    confirmations: Flags.integer({
+      char: 'c',
+      description:
+        'Minimum number of block confirmations needed to include a note. Set to 0 to include all blocks.',
+      required: false,
+    }),
+    assetId: Flags.string({
+      char: 'i',
+      description: 'The identifier for the asset to use when sending',
+    }),
+    rawTransaction: Flags.boolean({
+      default: false,
+      description:
+        'Return raw transaction. Use it to create a transaction but not post to the network',
+    }),
+    offline: Flags.boolean({
+      default: false,
+      description: 'Allow offline transaction creation',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(Split)
+    let account = flags.account
+    let assetId = flags.assetId
+    let from = flags.account?.trim()
+    const client = await this.sdk.connectRpc()
+
+    if (!account) {
+      const response = await client.wallet.getDefaultAccount()
+
+      if (response.content.account) {
+        account = response.content.account.name
+      }
+    }
+    Assert.isNotUndefined(account)
+
+    const csv = await fs.readFile(flags.allocations, 'utf-8')
+    const result = parseAllocationsFile(csv)
+    if (!result.ok) {
+      throw new Error(result.error)
+    }
+
+    if (!flags.offline) {
+      const status = await client.node.getStatus()
+
+      if (!status.content.blockchain.synced) {
+        this.error(
+          `Your node must be synced with the Iron Fish network to send a transaction. Please try again later`,
+        )
+      }
+    }
+
+    if (assetId == null) {
+      const asset = await selectAsset(client, from, {
+        action: 'send',
+        showNativeAsset: true,
+        showNonOwnerAsset: true,
+        showSingleAssetChoice: false,
+        confirmations: flags.confirmations,
+      })
+
+      assetId = asset?.id
+
+      if (!assetId) {
+        assetId = Asset.nativeId().toString('hex')
+      }
+    }
+
+    if (!from) {
+      const response = await client.wallet.getDefaultAccount()
+
+      if (!response.content.account) {
+        this.error(
+          `No account is currently active.
+           Use ironfish wallet:create <name> to first create an account`,
+        )
+      }
+
+      from = response.content.account.name
+    }
+
+    if (flags.expiration !== undefined && flags.expiration < 0) {
+      this.log('Expiration sequence must be non-negative')
+      this.exit(1)
+    }
+
+    const outputs = []
+    let amount = 0n
+    for (const allocation of result.allocations) {
+      amount += allocation.amountInOre
+      outputs.push({
+        publicAddress: allocation.publicAddress,
+        amount: allocation.amountInOre.toString(),
+        memo: allocation.memo,
+      })
+    }
+
+    const params: CreateTransactionRequest = {
+      account,
+      outputs,
+      fee: flags.fee ? CurrencyUtils.encode(flags.fee) : null,
+      feeRate: flags.feeRate ? CurrencyUtils.encode(flags.feeRate) : null,
+      expiration: flags.expiration,
+      confirmations: flags.confirmations,
+    }
+
+    let raw: RawTransaction
+    if (params.fee === null && params.feeRate === null) {
+      raw = await selectFee({
+        client,
+        transaction: params,
+        logger: this.logger,
+      })
+    } else {
+      const response = await client.wallet.createTransaction(params)
+      const bytes = Buffer.from(response.content.transaction, 'hex')
+      raw = RawTransactionSerde.deserialize(bytes)
+    }
+
+    if (flags.rawTransaction) {
+      this.log('Raw Transaction')
+      this.log(RawTransactionSerde.serialize(raw).toString('hex'))
+      this.log(`Run "ironfish wallet:post" to post the raw transaction. `)
+      this.exit(0)
+    }
+
+    if (!flags.confirm && !(await this.confirm(assetId, amount, raw.fee))) {
+      this.error('Transaction aborted.')
+    }
+
+    CliUx.ux.action.start('Sending the transaction')
+
+    const response = await client.wallet.postTransaction({
+      transaction: RawTransactionSerde.serialize(raw).toString('hex'),
+      account: from,
+    })
+
+    const bytes = Buffer.from(response.content.transaction, 'hex')
+    const transaction = new Transaction(bytes)
+
+    CliUx.ux.action.stop()
+
+    this.log(`Sent ${CurrencyUtils.renderIron(amount, true, assetId)}`)
+    this.log(`Hash: ${transaction.hash().toString('hex')}`)
+    this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
+    this.log(
+      `\nIf the transaction is mined, it will appear here https://explorer.ironfish.network/transaction/${transaction
+        .hash()
+        .toString('hex')}`,
+    )
+
+    if (flags.watch) {
+      this.log('')
+
+      await watchTransaction({
+        client,
+        logger: this.logger,
+        account: from,
+        hash: transaction.hash().toString('hex'),
+      })
+    }
+  }
+
+  async confirm(assetId: string, amount: bigint, fee: bigint): Promise<boolean> {
+    this.log(
+      `You are about to send a transaction: ${CurrencyUtils.renderIron(
+        amount,
+        true,
+        assetId,
+      )} plus a transaction fee of ${CurrencyUtils.renderIron(fee, true)}`,
+    )
+
+    return await CliUx.ux.confirm('Do you confirm (Y/N)?')
+  }
+}

--- a/ironfish-cli/src/utils/allocations.ts
+++ b/ironfish-cli/src/utils/allocations.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { MEMO_LENGTH } from '@ironfish/rust-nodejs'
+import { CurrencyUtils, GenesisBlockAllocation, isValidPublicAddress } from '@ironfish/sdk'
+
+export const parseAllocationsFile = (
+  fileContent: string,
+): { ok: true; allocations: GenesisBlockAllocation[] } | { ok: false; error: string } => {
+  const allocations: GenesisBlockAllocation[] = []
+
+  let lineNum = 0
+  for (const line of fileContent.split(/[\r\n]+/)) {
+    lineNum++
+    if (line.trim().length === 0) {
+      continue
+    }
+
+    const [address, amountInIron, memo, ...rest] = line.split(',').map((v) => v.trim())
+
+    if (rest.length > 0) {
+      return {
+        ok: false,
+        error: `Line ${lineNum}: (${line}) contains more than 3 values.`,
+      }
+    }
+
+    // Check address length
+    if (!isValidPublicAddress(address)) {
+      return {
+        ok: false,
+        error: `Line ${lineNum}: (${line}) has an invalid public address.`,
+      }
+    }
+
+    // Check amount is positive and decodes as $IRON
+    const amountInOre = CurrencyUtils.decodeIron(amountInIron)
+    if (amountInOre < 0) {
+      return {
+        ok: false,
+        error: `Line ${lineNum}: (${line}) contains a negative $IRON amount.`,
+      }
+    }
+
+    // Check memo length
+    if (Buffer.from(memo).byteLength > MEMO_LENGTH) {
+      return {
+        ok: false,
+        error: `Line ${lineNum}: (${line}) contains a memo with byte length > ${MEMO_LENGTH}.`,
+      }
+    }
+
+    allocations.push({
+      publicAddress: address,
+      amountInOre: amountInOre,
+      memo: memo,
+    })
+  }
+
+  return { ok: true, allocations }
+}


### PR DESCRIPTION
## Summary
This adds split command to cli. This has parity with the split command used in airdrop. Allows either to create a raw transaction, or to post to network directly.
## Testing Plan
TODO: Manual testing on testnet
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
