### PR TITLE
fix: use exec instead of spawn for complex cli commands

### DIFF
--- a/simulator/src/simulator/utils/accounts.ts
+++ b/simulator/src/simulator/utils/accounts.ts
@@ -71,7 +71,8 @@ export async function importAccount(
   account: string,
   rescan?: boolean,
 ): Promise<void> {
-  await node.executeCliCommand('wallet:import', [account])
+  await node.executeCliCommandWithExec('wallet:import', [account])
+
   if (rescan) {
     await node.client.wallet.rescanAccountStream().waitForEnd()
   }


### PR DESCRIPTION
## Summary
`child_process.spawn()` cannot handle stringified JSON arguments. Importing the genesis block converts the genesis account into a string which needs `child_process.exec()` to run. 

This was broken by #3840, so `executeCliCommandAsync()` was re-added and renamed to `executeCliCommandWithExec()` with a disclaimer as to when to use this one. 

## Testing Plan
Soon

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
