### PR TITLE
feat(ifl-774): asset constructor use public address

### DIFF
--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -87,7 +87,7 @@ export class RollingFilter {
 }
 export type NativeAsset = Asset
 export class Asset {
-  constructor(ownerPrivateKey: string, name: string, metadata: string)
+  constructor(ownerPublicAddress: string, name: string, metadata: string)
   metadata(): Buffer
   name(): Buffer
   nonce(): number

--- a/ironfish-rust-nodejs/src/structs/asset.rs
+++ b/ironfish-rust-nodejs/src/structs/asset.rs
@@ -10,7 +10,7 @@ use ironfish_rust::{
         asset_identifier::NATIVE_ASSET,
     },
     keys::PUBLIC_ADDRESS_SIZE,
-    SaplingKey,
+    PublicAddress,
 };
 use napi::{
     bindgen_prelude::{Buffer, Result},
@@ -43,12 +43,15 @@ pub struct NativeAsset {
 #[napi]
 impl NativeAsset {
     #[napi(constructor)]
-    pub fn new(owner_private_key: String, name: String, metadata: String) -> Result<NativeAsset> {
-        let sapling_key = SaplingKey::from_hex(&owner_private_key).map_err(to_napi_err)?;
-        let owner = sapling_key.public_address();
+    pub fn new(
+        owner_public_address: String,
+        name: String,
+        metadata: String,
+    ) -> Result<NativeAsset> {
+        let public_address = PublicAddress::from_hex(&owner_public_address).map_err(to_napi_err)?;
 
         Ok(NativeAsset {
-            asset: Asset::new(owner, &name, &metadata).map_err(to_napi_err)?,
+            asset: Asset::new(public_address, &name, &metadata).map_err(to_napi_err)?,
         })
     }
 

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -924,7 +924,7 @@ describe('Blockchain', () => {
         const { node } = await nodeTest.createSetup()
         const account = await useAccountFixture(node.wallet)
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
         const mintData = {
           name: asset.name().toString('utf8'),
           metadata: asset.metadata().toString('utf8'),
@@ -963,7 +963,7 @@ describe('Blockchain', () => {
         const wallet = node.wallet
         const account = await useAccountFixture(wallet)
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
 
         // Mint so we have an existing asset
         const mintValue = BigInt(10)
@@ -999,7 +999,7 @@ describe('Blockchain', () => {
         const wallet = node.wallet
         const account = await useAccountFixture(wallet)
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
 
         const mintValueA = BigInt(10)
         const blockA = await useMintBlockFixture({
@@ -1041,7 +1041,7 @@ describe('Blockchain', () => {
         const wallet = node.wallet
         const account = await useAccountFixture(wallet)
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
         const value = BigInt(10)
 
         const block = await useMintBlockFixture({
@@ -1066,7 +1066,7 @@ describe('Blockchain', () => {
         const wallet = node.wallet
         const account = await useAccountFixture(wallet)
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
 
         const mintValueA = BigInt(10)
         const blockA = await useMintBlockFixture({
@@ -1103,7 +1103,7 @@ describe('Blockchain', () => {
         const wallet = node.wallet
         const account = await useAccountFixture(wallet)
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
 
         const mintValue = BigInt(10)
         const blockA = await useMintBlockFixture({
@@ -1135,7 +1135,7 @@ describe('Blockchain', () => {
         const wallet = node.wallet
         const account = await useAccountFixture(wallet)
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
         const assetId = asset.id()
 
         const mintValue = BigInt(10)
@@ -1171,7 +1171,7 @@ describe('Blockchain', () => {
         const wallet = node.wallet
         const account = await useAccountFixture(wallet)
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
         const assetId = asset.id()
 
         const mintValue = BigInt(10)
@@ -1209,7 +1209,7 @@ describe('Blockchain', () => {
         const wallet = node.wallet
         const account = await useAccountFixture(wallet)
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
         const assetId = asset.id()
 
         // 1. Mint 10
@@ -1321,7 +1321,7 @@ describe('Blockchain', () => {
         const accountA = await useAccountFixture(nodeA.wallet, 'accountA')
         const accountB = await useAccountFixture(nodeB.wallet, 'accountB')
 
-        const asset = new Asset(accountA.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(accountA.publicAddress, 'mint-asset', 'metadata')
         const mintValue = BigInt(10)
         const assetId = asset.id()
 
@@ -1369,7 +1369,7 @@ describe('Blockchain', () => {
         const { node } = await nodeTest.createSetup()
         const account = await useAccountFixture(node.wallet)
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
         const mintValue = BigInt(10)
         const assetId = asset.id()
 

--- a/ironfish/src/blockchain/database/assetValue.test.ts
+++ b/ironfish/src/blockchain/database/assetValue.test.ts
@@ -10,7 +10,7 @@ describe('AssetValueEncoding', () => {
 
   it('serializes the value into a buffer and deserializes to the original value', async () => {
     const account = await useAccountFixture(nodeTest.wallet)
-    const asset = new Asset(account.spendingKey, 'asset', 'metadata')
+    const asset = new Asset(account.publicAddress, 'asset', 'metadata')
     const encoder = new AssetValueEncoding()
 
     const value: AssetValue = {

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -74,7 +74,7 @@ describe('Verifier', () => {
 
     it('returns false on transactions containing invalid mints', async () => {
       const account = await useAccountFixture(nodeTest.node.wallet)
-      const asset = new Asset(account.spendingKey, 'testcoin', '')
+      const asset = new Asset(account.publicAddress, 'testcoin', '')
       const mintData = {
         name: asset.name().toString('utf8'),
         metadata: asset.metadata().toString('utf8'),
@@ -289,7 +289,7 @@ describe('Verifier', () => {
 
     it('rejects a block with an invalid mint', async () => {
       const account = await useAccountFixture(nodeTest.node.wallet)
-      const asset = new Asset(account.spendingKey, 'testcoin', '')
+      const asset = new Asset(account.publicAddress, 'testcoin', '')
 
       const block = await useMintBlockFixture({
         node: nodeTest.node,
@@ -310,7 +310,7 @@ describe('Verifier', () => {
 
     it('rejects a block with an invalid burn', async () => {
       const account = await useAccountFixture(nodeTest.node.wallet)
-      const asset = new Asset(account.spendingKey, 'testcoin', '')
+      const asset = new Asset(account.publicAddress, 'testcoin', '')
 
       const blockA = await useMinerBlockFixture(nodeTest.chain, 2, account)
       await expect(nodeTest.node.chain).toAddBlock(blockA)

--- a/ironfish/src/primitives/rawTransaction.test.ts
+++ b/ironfish/src/primitives/rawTransaction.test.ts
@@ -23,7 +23,7 @@ describe('RawTransaction', () => {
 
   it('should post', async () => {
     const account = await useAccountFixture(nodeTest.wallet)
-    const asset = new Asset(account.spendingKey, 'test', '')
+    const asset = new Asset(account.publicAddress, 'test', '')
 
     const block = await useMinerBlockFixture(
       nodeTest.chain,
@@ -88,7 +88,7 @@ describe('RawTransaction', () => {
 
   it('should throw an error if the max mint value is exceeded', async () => {
     const account = await useAccountFixture(nodeTest.wallet)
-    const asset = new Asset(account.spendingKey, 'test', '')
+    const asset = new Asset(account.publicAddress, 'test', '')
     const assetName = asset.name().toString('utf8')
 
     const block = await useMinerBlockFixture(
@@ -125,7 +125,7 @@ describe('RawTransaction', () => {
   it('should throw an error if the max burn value is exceeded', async () => {
     const node = nodeTest.node
     const account = await useAccountFixture(nodeTest.wallet)
-    const asset = new Asset(account.spendingKey, 'test', '')
+    const asset = new Asset(account.publicAddress, 'test', '')
 
     const block = await useMinerBlockFixture(
       nodeTest.chain,
@@ -180,7 +180,7 @@ describe('RawTransactionSerde', () => {
 
   it('serializes and deserializes a block', async () => {
     const account = await useAccountFixture(nodeTest.wallet)
-    const asset = new Asset(account.spendingKey, 'asset', 'metadata')
+    const asset = new Asset(account.publicAddress, 'asset', 'metadata')
     const assetName = 'asset'
     const assetMetadata = 'metadata'
 

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -5,6 +5,7 @@
 import {
   AMOUNT_VALUE_LENGTH,
   ASSET_LENGTH,
+  generateKeyFromPrivateKey,
   Transaction as NativeTransaction,
   TRANSACTION_EXPIRATION_LENGTH,
   TRANSACTION_FEE_LENGTH,
@@ -69,7 +70,6 @@ export class RawTransaction {
 
   post(spendingKey: string): Transaction {
     const builder = new NativeTransaction(spendingKey)
-
     for (const spend of this.spends) {
       builder.spend(spend.note.takeReference(), spend.witness)
       spend.note.returnReference()
@@ -88,8 +88,8 @@ export class RawTransaction {
           )} exceededs maximum ${CurrencyUtils.renderIron(MAX_MINT_OR_BURN_VALUE)}. `,
         )
       }
-
-      const asset = new Asset(spendingKey, mint.name, mint.metadata)
+      const key = generateKeyFromPrivateKey(spendingKey)
+      const asset = new Asset(key.publicAddress, mint.name, mint.metadata)
 
       builder.mint(asset, mint.value)
     }

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.test.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.test.ts
@@ -37,7 +37,7 @@ describe('Route chain.getTransactionStream', () => {
   it('returns expected mints and burns', async () => {
     const wallet = routeTest.node.wallet
     const account = await useAccountFixture(wallet)
-    const asset = new Asset(account.spendingKey, 'customasset', 'metadata')
+    const asset = new Asset(account.publicAddress, 'customasset', 'metadata')
     const response = routeTest.client.chain.getTransactionStream({
       incomingViewKey: account.incomingViewKey,
     })

--- a/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
@@ -53,7 +53,7 @@ describe('Route wallet/burnAsset', () => {
       const wallet = node.wallet
       const account = await useAccountFixture(wallet)
 
-      const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
       const assetId = asset.id()
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({ node, account, asset, value, sequence: 3 })

--- a/ironfish/src/rpc/routes/wallet/createTransaction.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.test.slow.ts
@@ -15,7 +15,7 @@ describe('Route wallet/createTransaction', () => {
     routeTest.node.peerNetwork['_isReady'] = true
     routeTest.chain.synced = true
 
-    const asset = new Asset(sender.spendingKey, 'new-asset', 'metadata')
+    const asset = new Asset(sender.publicAddress, 'new-asset', 'metadata')
     const mintData = {
       name: asset.name().toString('utf8'),
       metadata: asset.metadata().toString('utf8'),

--- a/ironfish/src/rpc/routes/wallet/createTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.test.ts
@@ -226,7 +226,7 @@ describe('Route wallet/createTransaction', () => {
       await routeTest.node.wallet.updateHead()
     }
 
-    const asset = new Asset(sender.spendingKey, 'mint-asset', 'metadata')
+    const asset = new Asset(sender.publicAddress, 'mint-asset', 'metadata')
 
     const response = await routeTest.client.wallet.createTransaction({
       account: 'existingAccount',
@@ -266,7 +266,7 @@ describe('Route wallet/createTransaction', () => {
   it('throw error when create transaction to mint unknown asset', async () => {
     const sender = await useAccountFixture(routeTest.node.wallet, 'existingAccount')
 
-    const asset = new Asset(sender.spendingKey, 'unknown-asset', 'metadata')
+    const asset = new Asset(sender.publicAddress, 'unknown-asset', 'metadata')
 
     for (let i = 0; i < 3; ++i) {
       const block = await useMinerBlockFixture(
@@ -353,7 +353,7 @@ describe('Route wallet/createTransaction', () => {
     await expect(routeTest.node.chain).toAddBlock(block)
     await routeTest.node.wallet.updateHead()
 
-    const asset = new Asset(sender.spendingKey, 'mint-asset', 'metadata')
+    const asset = new Asset(sender.publicAddress, 'mint-asset', 'metadata')
 
     await expect(
       routeTest.client.wallet.createTransaction({

--- a/ironfish/src/rpc/routes/wallet/getAccountTransactions.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransactions.test.ts
@@ -54,7 +54,7 @@ describe('Route wallet/getAccountTransactions', () => {
     const node = routeTest.node
     const account = await useAccountFixture(node.wallet, 'valid-sequence')
 
-    const asset = new Asset(account.spendingKey, 'asset', 'metadata')
+    const asset = new Asset(account.publicAddress, 'asset', 'metadata')
     const mint = await usePostTxFixture({
       node: node,
       wallet: node.wallet,

--- a/ironfish/src/rpc/routes/wallet/getAssets.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.test.ts
@@ -24,13 +24,13 @@ describe('Route wallet/getAssets', () => {
     const minerBlock = await useMinerBlockFixture(node.chain, undefined, account)
     await expect(node.chain).toAddBlock(minerBlock)
 
-    const asset = new Asset(account.spendingKey, 'account-asset', 'metadata')
+    const asset = new Asset(account.publicAddress, 'account-asset', 'metadata')
     const value = BigInt(10)
     const mintBlock = await useMintBlockFixture({ node, account, asset, value })
     await expect(node.chain).toAddBlock(mintBlock)
     await node.wallet.updateHead()
 
-    const pendingAsset = new Asset(account.spendingKey, 'pending', 'metadata')
+    const pendingAsset = new Asset(account.publicAddress, 'pending', 'metadata')
     const pendingMint = await usePostTxFixture({
       node,
       wallet: node.wallet,

--- a/ironfish/src/rpc/routes/wallet/getBalances.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.test.ts
@@ -25,7 +25,7 @@ describe('Route wallet/getBalances', () => {
       const node = routeTest.node
       const wallet = node.wallet
       const account = await useAccountFixture(wallet)
-      const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
       const assetId = asset.id()
 
       const mockBalances = [

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -51,7 +51,7 @@ describe('Route wallet/mintAsset', () => {
       const wallet = node.wallet
       const account = await useAccountFixture(wallet)
 
-      const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
       const mintData = {
         name: asset.name().toString('utf8'),
         metadata: asset.metadata().toString('utf8'),

--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -258,7 +258,7 @@ describe('Accounts', () => {
         blockHash: null,
         sequence: null,
       }
-      const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
       const mintedAssetBalance = {
         unconfirmed: BigInt(7),
         blockHash: null,
@@ -681,7 +681,7 @@ describe('Accounts', () => {
       await node.chain.addBlock(block2)
       await node.wallet.updateHead()
 
-      const asset = new Asset(accountA.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'mint-asset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,
@@ -711,7 +711,7 @@ describe('Accounts', () => {
     it('should overwrite pending asset fields from a connected mint description', async () => {
       const { node } = nodeTest
       const account = await useAccountFixture(node.wallet)
-      const asset = new Asset(account.spendingKey, 'testcoin', 'metadata')
+      const asset = new Asset(account.publicAddress, 'testcoin', 'metadata')
 
       const minerBlock = await useMinerBlockFixture(node.chain, undefined, account, node.wallet)
       await node.chain.addBlock(minerBlock)
@@ -776,7 +776,7 @@ describe('Accounts', () => {
       await node.chain.addBlock(block2)
       await node.wallet.updateHead()
 
-      const asset = new Asset(accountA.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'mint-asset', 'metadata')
       const mintValue = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,
@@ -1145,7 +1145,7 @@ describe('Accounts', () => {
       await node.chain.addBlock(block2)
       await node.wallet.updateHead()
 
-      const asset = new Asset(accountA.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'mint-asset', 'metadata')
       const firstMintValue = BigInt(10)
       const firstMintBlock = await useMintBlockFixture({
         node,
@@ -1231,7 +1231,7 @@ describe('Accounts', () => {
       await node.chain.addBlock(block2)
       await node.wallet.updateHead()
 
-      const asset = new Asset(accountA.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'mint-asset', 'metadata')
       const mintValue = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,
@@ -1433,7 +1433,7 @@ describe('Accounts', () => {
       await node.chain.addBlock(block2)
       await node.wallet.updateHead()
 
-      const asset = new Asset(accountA.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'mint-asset', 'metadata')
 
       const mintTx = await usePostTxFixture({
         node,
@@ -1566,7 +1566,7 @@ describe('Accounts', () => {
         unconfirmed: 2000000000n,
       })
 
-      const asset = new Asset(accountA.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'mint-asset', 'metadata')
 
       const block3 = await useMintBlockFixture({
         node,
@@ -1814,7 +1814,7 @@ describe('Accounts', () => {
 
       await useTxFixture(node.wallet, accountA, accountB)
 
-      const asset = new Asset(accountA.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'mint-asset', 'metadata')
 
       await useMintBlockFixture({
         node,
@@ -1847,7 +1847,7 @@ describe('Accounts', () => {
         unconfirmed: 2000000000n,
       })
 
-      const asset = new Asset(accountA.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'mint-asset', 'metadata')
 
       const block3 = await useMintBlockFixture({
         node,
@@ -2033,7 +2033,7 @@ describe('Accounts', () => {
       await node.chain.addBlock(block2)
       await node.wallet.updateHead()
 
-      const asset = new Asset(accountA.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'mint-asset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -416,7 +416,7 @@ describe('Accounts', () => {
       await expect(node.chain).toAddBlock(mined)
       await node.wallet.updateHead()
 
-      const asset = new Asset(account.spendingKey, 'fakeasset', 'metadata')
+      const asset = new Asset(account.publicAddress, 'fakeasset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,
@@ -1292,7 +1292,7 @@ describe('Accounts', () => {
         await expect(node.chain).toAddBlock(mined)
         await node.wallet.updateHead()
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
 
         const mintValueA = BigInt(2)
         const mintBlockA = await useMintBlockFixture({
@@ -1339,7 +1339,7 @@ describe('Accounts', () => {
         await expect(node.chain).toAddBlock(mined)
         await node.wallet.updateHead()
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
         const mintValue = BigInt(10)
         const mintData = {
           name: asset.name().toString('utf8'),
@@ -1366,7 +1366,7 @@ describe('Accounts', () => {
         await expect(node.chain).toAddBlock(mined)
         await node.wallet.updateHead()
 
-        const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+        const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
         const value = BigInt(10)
         const mintBlock = await useMintBlockFixture({
           node,
@@ -1396,7 +1396,7 @@ describe('Accounts', () => {
       await expect(node.chain).toAddBlock(mined)
       await node.wallet.updateHead()
 
-      const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({ node, account, asset, value, sequence: 3 })
       await expect(node.chain).toAddBlock(mintBlock)
@@ -1421,7 +1421,7 @@ describe('Accounts', () => {
       await expect(node.chain).toAddBlock(mined)
       await node.wallet.updateHead()
 
-      const asset = new Asset(account.spendingKey, 'mint-asset', 'metadata')
+      const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({ node, account, asset, value, sequence: 3 })
       await expect(node.chain).toAddBlock(mintBlock)
@@ -1697,7 +1697,7 @@ describe('Accounts', () => {
         unconfirmed: 2000000000n,
       })
 
-      const asset = new Asset(accountA.spendingKey, 'fakeasset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'fakeasset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,
@@ -1751,7 +1751,7 @@ describe('Accounts', () => {
       await expect(node.chain).toAddBlock(minerBlock)
       await node.wallet.updateHead()
 
-      const asset = new Asset(accountA.spendingKey, 'fakeasset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'fakeasset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,
@@ -1946,7 +1946,7 @@ describe('Accounts', () => {
       await expect(node.chain).toAddBlock(mined)
       await node.wallet.updateHead()
 
-      const asset = new Asset(account.spendingKey, 'asset', 'metadata')
+      const asset = new Asset(account.publicAddress, 'asset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,
@@ -2212,7 +2212,7 @@ describe('Accounts', () => {
         unconfirmed: 2000000000n,
       })
 
-      const asset = new Asset(accountA.spendingKey, 'fakeasset', 'metadata')
+      const asset = new Asset(accountA.publicAddress, 'fakeasset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,
@@ -2496,7 +2496,7 @@ describe('Accounts', () => {
       await expect(node.chain).toAddBlock(blockA1)
       await node.wallet.updateHead()
 
-      const asset = new Asset(account.spendingKey, 'fakeasset', 'metadata')
+      const asset = new Asset(account.publicAddress, 'fakeasset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,
@@ -2530,7 +2530,7 @@ describe('Accounts', () => {
       await expect(node.chain).toAddBlock(blockA1)
       await node.wallet.updateHead()
 
-      const asset = new Asset(account.spendingKey, 'fakeasset', 'metadata')
+      const asset = new Asset(account.publicAddress, 'fakeasset', 'metadata')
       const value = BigInt(10)
       const mintBlock = await useMintBlockFixture({
         node,

--- a/ironfish/src/wallet/walletdb/assetValue.test.ts
+++ b/ironfish/src/wallet/walletdb/assetValue.test.ts
@@ -10,7 +10,7 @@ describe('AssetValueEncoding', () => {
 
   it('serializes the value into a buffer and deserializes to the original value', async () => {
     const account = await useAccountFixture(nodeTest.wallet)
-    const asset = new Asset(account.spendingKey, 'asset', 'metadata')
+    const asset = new Asset(account.publicAddress, 'asset', 'metadata')
     const encoder = new AssetValueEncoding()
 
     const value: AssetValue = {

--- a/ironfish/src/wallet/walletdb/transactionValue.test.ts
+++ b/ironfish/src/wallet/walletdb/transactionValue.test.ts
@@ -115,7 +115,7 @@ describe('TransactionValueEncoding', () => {
       const assetBalanceDeltas = new BufferMap<bigint>()
 
       const accountA = await useAccountFixture(wallet, 'accountA')
-      const testAsset = new Asset(accountA.spendingKey, 'test-asset', 'test-asset-metadata')
+      const testAsset = new Asset(accountA.publicAddress, 'test-asset', 'test-asset-metadata')
 
       assetBalanceDeltas.set(Asset.nativeId(), -transaction.fee())
       assetBalanceDeltas.set(testAsset.id(), 1n)


### PR DESCRIPTION
## Summary
The signature for `Asset` constructor was taking spending key, but it immediately converted it to public address in napi method. Having this take the public address instead allows us to calculate `RawTransaction` size deterministically _without_ the spending key. Which means we can calculate size of a transaction with a view only wallet.
## Testing Plan
Tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Any user of the ecosystem that is constructing an `Asset` manually will break. I think it is unlikely anyone is doing this yet.

```
[x] Yes
```
