### PR TITLE
feat: add support for `PostTransaction` in `workers:status`

### DIFF
--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -54,6 +54,7 @@ export class WorkerPool {
     [WorkerMessageType.CreateMinersFee, { complete: 0, error: 0, queue: 0, execute: 0 }],
     [WorkerMessageType.DecryptNotes, { complete: 0, error: 0, queue: 0, execute: 0 }],
     [WorkerMessageType.JobAborted, { complete: 0, error: 0, queue: 0, execute: 0 }],
+    [WorkerMessageType.PostTransaction, { complete: 0, error: 0, queue: 0, execute: 0 }],
     [WorkerMessageType.Sleep, { complete: 0, error: 0, queue: 0, execute: 0 }],
     [WorkerMessageType.SubmitTelemetry, { complete: 0, error: 0, queue: 0, execute: 0 }],
     [WorkerMessageType.VerifyTransaction, { complete: 0, error: 0, queue: 0, execute: 0 }],


### PR DESCRIPTION
## Summary
`PostTransaction` was missing in `workers:status` in everywhere but display, this adds support for it

Closes IFL-649

## Testing Plan
```
Workers: STARTED - 0 -> 1 / 6 - -0.08 jobs Δ, 12.68 jobs/s

JOB                  | QUEUE | EXECUTE | ERROR | DONE
CreateMinersFee      |     0 |       0 |     0 | 37
DecryptNotes         |     0 |       0 |     0 | 99
PostTransaction      |     0 |       1 |     0 | 6
SubmitTelemetry      |     0 |       0 |     0 | 0
VerifyTransaction    |     0 |       0 |     0 | 0
VerifyTransactions   |     0 |       0 |     0 | 109
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
