### PR TITLE
feat(ifl 776): size method note primitives

### DIFF
--- a/ironfish/src/primitives/__fixtures__/note.test.ts.fixture
+++ b/ironfish/src/primitives/__fixtures__/note.test.ts.fixture
@@ -37,5 +37,44 @@
         }
       ]
     }
+  ],
+  "Note byte sizes should match": [
+    {
+      "version": 2,
+      "id": "ab69e24f-1abe-471b-99b9-70ffdadbc3f4",
+      "name": "test",
+      "spendingKey": "4a45fc04e04c59fcd99b14b8d28d90c3a01e9c599430092eb68c4a984eb4bb15",
+      "viewKey": "d8fe3d69d5f4378dfdc01dc0c6dd4a182da4c02975e63892930764afd094f63880aa11b69e4e37b9eb292e1e47dd6e3c3112c69a7444122973b2b0542e9878c8",
+      "incomingViewKey": "4967fc8c1b94252eb1a6e9fa00ef2c6b35bce3fdb73a50cd5cd52f4c46f11402",
+      "outgoingViewKey": "1ca9a804cf9e3639a7062091534747ace7f5f0c9ad184d39c841f6b41de756b9",
+      "publicAddress": "8aca83c93836bf5daebc31c09c8a9320e1952b43b8535d2e9c0c7ccece2cd602",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:dpHmM+cSUt55BpyLIgD8uD3jvqRobfRpyL9z+DWGfgg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Om3x0JSzjz8ZD2sVt8YKx42j2zUCW8FoaHb88YMgCr0="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1682957249066,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQfq5tFqZY7BOFKBDPVXmM0krYfo7473Xhd1H8Jx5EGuy6DOvvGpUqajWD/UQwSbSIckPXCsCJ1AoaG1/x6BNAbzlHGTGAm+hWmNr16Njbmu1iYZLQ4qZvSaUx7u1C8kwpEzXvGQD1ac6f22Tkci7YyLrzK8iUPscSxRpHXKzL9EJ8J7M/4vm8DQ1xfi+WNQpAT61PHs/yYFJPCD1Nli1aMRO+0jaVQsVOYwLOsMZOiCQLyxrxDdHibGulCQX6HpTElhRt9mfsmagu374//djM5h1NcA+kSDrrxDPDE9njyxe9B236/HjttmOoeBTYV4xSxU0/7x1yi+cJWAHWBQaxzqvq9CIdyB8bT/AMkdYZ0lqGebFj71slsswKCJP+oM3aMSm1gdJqCUzjrtijmoT8KAU3BKzKztgg1Tf7sQ188xSjZUh31KOoSwPoGTxkejqmgUnIwm/jlqrATkiLRgX/AKhYsSmTF0iMJ9kr2z06Xhcjy4SrD5TDqWHZVNGXYwrk2RE5aluwM30hKAPbXj7FCpNt5Nyr6Y1IYKyE4Hj1sVhvKx/js2niKJIhJdU54Fvd7+hdQLpwW22MpSHDhwbZ+YzUikT6A2mymM9wUZqR5syRI2toRpbDklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw7TYsfMAgH5JUCz+QCOih0GM7qyvX3JCGWQAHL/3Xqtl359PbCzjrAVmy0XMFDuIck6Ijou7/AHn712zOIQvBCA=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/primitives/note.test.ts
+++ b/ironfish/src/primitives/note.test.ts
@@ -29,7 +29,7 @@ describe('Note', () => {
     const decrypted = encrypted.decryptNoteForOwner(account.incomingViewKey)
 
     Assert.isNotUndefined(decrypted)
-    expect(encrypted.serialize().byteLength).toBe(NoteEncrypted.size())
-    expect(decrypted.serialize().byteLength).toBe(Note.size())
+    expect(encrypted.serialize().byteLength).toBe(NoteEncrypted.size)
+    expect(decrypted.serialize().byteLength).toBe(Note.size)
   })
 })

--- a/ironfish/src/primitives/note.test.ts
+++ b/ironfish/src/primitives/note.test.ts
@@ -4,6 +4,8 @@
 import { Assert } from '../assert'
 import { useAccountFixture, useMinerBlockFixture } from '../testUtilities/fixtures'
 import { createNodeTest } from '../testUtilities/nodeTest'
+import { Note } from './note'
+import { NoteEncrypted } from './noteEncrypted'
 
 describe('Note', () => {
   const nodeTest = createNodeTest()
@@ -17,5 +19,17 @@ describe('Note', () => {
 
     Assert.isNotUndefined(decrypted)
     expect(encrypted.hash().equals(decrypted.hash())).toBe(true)
+  })
+
+  it('byte sizes should match', async () => {
+    const account = await useAccountFixture(nodeTest.wallet)
+    const block = await useMinerBlockFixture(nodeTest.chain, undefined, account)
+
+    const encrypted = block.minersFee.notes[0]
+    const decrypted = encrypted.decryptNoteForOwner(account.incomingViewKey)
+
+    Assert.isNotUndefined(decrypted)
+    expect(encrypted.serialize().byteLength).toBe(NoteEncrypted.size())
+    expect(decrypted.serialize().byteLength).toBe(Note.size())
   })
 })

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -43,16 +43,13 @@ export class Note {
     this._sender = reader.readBytes(PUBLIC_ADDRESS_LENGTH, true).toString('hex')
   }
 
-  static size(): number {
-    return (
-      PUBLIC_ADDRESS_LENGTH +
-      ASSET_ID_LENGTH +
-      8 + // VALUE
-      RANDOMNESS_LENGTH +
-      MEMO_LENGTH +
-      PUBLIC_ADDRESS_LENGTH
-    )
-  }
+  static size =
+    PUBLIC_ADDRESS_LENGTH +
+    ASSET_ID_LENGTH +
+    8 + // VALUE
+    RANDOMNESS_LENGTH +
+    MEMO_LENGTH +
+    PUBLIC_ADDRESS_LENGTH
 
   serialize(): Buffer {
     return this.noteSerialized

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -43,6 +43,17 @@ export class Note {
     this._sender = reader.readBytes(PUBLIC_ADDRESS_LENGTH, true).toString('hex')
   }
 
+  static size(): number {
+    return (
+      PUBLIC_ADDRESS_LENGTH +
+      ASSET_ID_LENGTH +
+      8 +
+      RANDOMNESS_LENGTH +
+      MEMO_LENGTH +
+      PUBLIC_ADDRESS_LENGTH
+    )
+  }
+
   serialize(): Buffer {
     return this.noteSerialized
   }

--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -47,7 +47,7 @@ export class Note {
     return (
       PUBLIC_ADDRESS_LENGTH +
       ASSET_ID_LENGTH +
-      8 +
+      8 + // VALUE
       RANDOMNESS_LENGTH +
       MEMO_LENGTH +
       PUBLIC_ADDRESS_LENGTH

--- a/ironfish/src/primitives/noteEncrypted.ts
+++ b/ironfish/src/primitives/noteEncrypted.ts
@@ -44,7 +44,12 @@ export class NoteEncrypted {
   }
 
   static size(): number {
-    return 32 + 32 + 32 + ENCRYPTED_NOTE_PLAINTEXT_LENGTH + NOTE_ENCRYPTION_KEY_LENGTH
+    return
+        32 + // value commitment
+        32 + // note commitment
+        32 + // ephemeral public key
+        ENCRYPTED_NOTE_PLAINTEXT_LENGTH +
+        NOTE_ENCRYPTION_KEY_LENGTH
   }
 
   serialize(): Buffer {

--- a/ironfish/src/primitives/noteEncrypted.ts
+++ b/ironfish/src/primitives/noteEncrypted.ts
@@ -3,17 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import {
-  ENCRYPTED_NOTE_LENGTH,
   ENCRYPTED_NOTE_PLAINTEXT_LENGTH,
   NOTE_ENCRYPTION_KEY_LENGTH,
   NoteEncrypted as NativeNoteEncrypted,
-  PROOF_LENGTH,
 } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
 import { Serde } from '../serde'
 import { Note } from './note'
-
-export const NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE = PROOF_LENGTH + ENCRYPTED_NOTE_LENGTH
 
 export type NoteEncryptedHash = Buffer
 export type SerializedNoteEncryptedHash = Buffer
@@ -45,9 +41,10 @@ export class NoteEncrypted {
 
     // note encryption keys
     reader.seek(NOTE_ENCRYPTION_KEY_LENGTH)
+  }
 
-    // total serialized size: 192 (proof from transaction)
-    // + 32 + 32 + 32 + 104 + 16 + 64 + 16 = 488 bytes
+  static size(): number {
+    return 32 + 32 + 32 + ENCRYPTED_NOTE_PLAINTEXT_LENGTH + NOTE_ENCRYPTION_KEY_LENGTH
   }
 
   serialize(): Buffer {

--- a/ironfish/src/primitives/noteEncrypted.ts
+++ b/ironfish/src/primitives/noteEncrypted.ts
@@ -43,14 +43,12 @@ export class NoteEncrypted {
     reader.seek(NOTE_ENCRYPTION_KEY_LENGTH)
   }
 
-  static size(): number {
-    return
-        32 + // value commitment
-        32 + // note commitment
-        32 + // ephemeral public key
-        ENCRYPTED_NOTE_PLAINTEXT_LENGTH +
-        NOTE_ENCRYPTION_KEY_LENGTH
-  }
+  static size =
+    32 + // value commitment
+    32 + // note commitment
+    32 + // ephemeral public key
+    ENCRYPTED_NOTE_PLAINTEXT_LENGTH +
+    NOTE_ENCRYPTION_KEY_LENGTH
 
   serialize(): Buffer {
     return this.noteEncryptedSerialized

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -22,12 +22,7 @@ import { CurrencyUtils } from '../utils/currency'
 import { AssetBalances } from '../wallet/assetBalances'
 import { BurnDescription } from './burnDescription'
 import { Note } from './note'
-import {
-  NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE,
-  NoteEncrypted,
-  NoteEncryptedHash,
-  SerializedNoteEncryptedHash,
-} from './noteEncrypted'
+import { NoteEncrypted, NoteEncryptedHash, SerializedNoteEncryptedHash } from './noteEncrypted'
 import { SPEND_SERIALIZED_SIZE_IN_BYTE } from './spend'
 import { Transaction } from './transaction'
 
@@ -69,7 +64,7 @@ export class RawTransaction {
     size += TRANSACTION_EXPIRATION_LENGTH // expiration
     size += TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH // public key randomness
     size += this.spends.length * SPEND_SERIALIZED_SIZE_IN_BYTE
-    size += this.outputs.length * NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE
+    size += this.outputs.length * (PROOF_LENGTH + NoteEncrypted.size())
     size +=
       this.mints.length *
       (PROOF_LENGTH + ASSET_LENGTH + AMOUNT_VALUE_LENGTH + TRANSACTION_SIGNATURE_LENGTH)
@@ -93,7 +88,7 @@ export class RawTransaction {
     }
     for (const [, value] of assetTotals) {
       if (value !== 0n) {
-        size += NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE
+        size += PROOF_LENGTH + NoteEncrypted.size()
       }
     }
     return size

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -64,7 +64,7 @@ export class RawTransaction {
     size += TRANSACTION_EXPIRATION_LENGTH // expiration
     size += TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH // public key randomness
     size += this.spends.length * SPEND_SERIALIZED_SIZE_IN_BYTE
-    size += this.outputs.length * (PROOF_LENGTH + NoteEncrypted.size())
+    size += this.outputs.length * (PROOF_LENGTH + NoteEncrypted.size)
     size +=
       this.mints.length *
       (PROOF_LENGTH + ASSET_LENGTH + AMOUNT_VALUE_LENGTH + TRANSACTION_SIGNATURE_LENGTH)
@@ -88,7 +88,7 @@ export class RawTransaction {
     }
     for (const [, value] of assetTotals) {
       if (value !== 0n) {
-        size += PROOF_LENGTH + NoteEncrypted.size()
+        size += PROOF_LENGTH + NoteEncrypted.size
       }
     }
     return size


### PR DESCRIPTION
## Summary
- Adding size methods for Note/NoteEncrypted primitives
- Add test to make sure these stay up to date

### Reason for addition
Our constants were becoming stale rather quickly (e.g. `NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE`), so this pattern attempts to do two things. 
1. Tightly couple the size via a static method to our objects (rather than an unrelated constant)
2. Add a test that verifies this always stays up to date. It is currently possible to update the serialized size of these objects (rust side) without updating these methods. Now if these values change, the tests will break.


## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
