### PR TITLE
feat(ifl-779): add getMaxTransactionBytes method to the verifier

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,16 @@
 
 ## Testing Plan
 
+## Documentation
+
+Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
+Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
+related documentation pull request for the website.
+
+```
+[ ] Yes
+```
+
 ## Breaking Change
 
 Is this a breaking change? If yes, add notes below on why this is breaking and

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,16 +2,6 @@
 
 ## Testing Plan
 
-## Documentation
-
-Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
-Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
-related documentation pull request for the website.
-
-```
-[ ] Yes
-```
-
 ## Breaking Change
 
 Is this a breaking change? If yes, add notes below on why this is breaking and

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -257,6 +257,10 @@ export class Verifier {
     return { valid: true }
   }
 
+  static getMaxTransactionBytes(maxBlockSizeBytes: number): number {
+    return maxBlockSizeBytes - getBlockWithMinersFeeSize()
+  }
+
   /**
    * Verify that a transaction created by the account can be accepted into the mempool
    * and rebroadcasted to the network.
@@ -264,7 +268,7 @@ export class Verifier {
   verifyCreatedTransaction(transaction: Transaction): VerificationResult {
     if (
       getTransactionSize(transaction) >
-      this.chain.consensus.parameters.maxBlockSizeBytes - getBlockWithMinersFeeSize()
+      Verifier.getMaxTransactionBytes(this.chain.consensus.parameters.maxBlockSizeBytes)
     ) {
       return { valid: false, reason: VerificationResultReason.MAX_TRANSACTION_SIZE_EXCEEDED }
     }


### PR DESCRIPTION
## Summary
This method takes in the consensus param as an argument (since it can vary between networks/nodes) and 


From discussion with Derek:
Joe:
Why would we need blockSize as a param for this task?
Seems like the blockSize will always be the same unless we update the concensus params (which would in turn update this method).

Derek:
since it’s configurable in the network params, we should assume that it might be different depending on the network. and in that case we need the consensus params for the node + the network the node is connected to


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
