### PR TITLE
Check network version on chaindownload

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -77,8 +77,10 @@ export default class Download extends IronfishCommand {
       if (networkId === 0) {
         // testnet
         manifestUrl = Download.defaultTestnetManifestUrl
-      } else {
+      } else if (networkId === 1) {
         manifestUrl = Download.defaultMainnetManifestUrl
+      } else {
+        this.log(`Manifest url for the snapshots are not available for network ID ${networkId}`)
       }
     }
 

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -70,7 +70,7 @@ export default class Download extends IronfishCommand {
 
     const networkId = node.internal.get('networkId')
 
-    let manifestUrl
+    let manifestUrl = ''
     if (flags.manifestUrl) {
       manifestUrl = flags.manifestUrl
     } else {
@@ -81,6 +81,7 @@ export default class Download extends IronfishCommand {
         manifestUrl = Download.defaultMainnetManifestUrl
       } else {
         this.log(`Manifest url for the snapshots are not available for network ID ${networkId}`)
+        this.exit(1)
       }
     }
 
@@ -89,7 +90,7 @@ export default class Download extends IronfishCommand {
     if (flags.path) {
       snapshotPath = this.sdk.fileSystem.resolve(flags.path)
     } else {
-      if (!manifestUrl) {
+      if (!manifestUrl || manifestUrl === '') {
         this.log(`Cannot download snapshot without manifest URL`)
         this.exit(1)
       }

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -28,13 +28,15 @@ export default class Download extends IronfishCommand {
 
   static description = `Download and import a chain snapshot`
 
+  static defaultMainnetManifestUrl = `https://snapshots.ironfish.network/manifest.json`
+  static defaultTestnetManifestUrl = `https://testnet.snapshots.ironfish.network/manifest.json`
+
   static flags = {
     ...LocalFlags,
     manifestUrl: Flags.string({
       char: 'm',
       parse: (input: string) => Promise.resolve(input.trim()),
       description: 'Manifest url to download snapshot from',
-      default: `https://snapshots.ironfish.network/manifest.json`,
     }),
     path: Flags.string({
       char: 'p',
@@ -68,10 +70,16 @@ export default class Download extends IronfishCommand {
 
     const networkId = node.internal.get('networkId')
 
-    let manifestUrl = flags.manifestUrl
-    if (networkId === 0) {
-      // testnet
-      manifestUrl = `https://testnet.snapshots.ironfish.network/manifest.json`
+    let manifestUrl
+    if (flags.manifestUrl) {
+      manifestUrl = flags.manifestUrl
+    } else {
+      if (networkId === 0) {
+        // testnet
+        manifestUrl = Download.defaultTestnetManifestUrl
+      } else {
+        manifestUrl = Download.defaultMainnetManifestUrl
+      }
     }
 
     let snapshotPath


### PR DESCRIPTION
## Summary
Check network Id in chain:download cli. Download testnet snapshot if the network Id is 0.

## Testing Plan
local 
```
yajun@Yajuns-MBP ironfish-cli % yarn start chain:download --datadir=~/testnet/.ironfish
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run chain:download '--datadir=~/testnet/.ironfish'
root: /Users/yajun/ironfish/ironfish/ironfish-cli
See more details with DEBUG=*
(Use `node --trace-warnings ...` to show where the warning was created)
Download 16.98 MB snapshot to update from block 4348 to 9700? 
At least 33.97 MB of free disk space is required to download and unzip the snapshot file.
Are you sure? (Y)es / (N)o: Y
Downloading snapshot from https://testnet.snapshots.ironfish.network/ironfish_snapshot_1682953324920.tar.gz to /Users/yajun/testnet/.ironfish/temp/ironfish_snapshot_1682953324920.tar.gz
Downloading snapshot: [████████████████████████████████████████] 100% | 16.98 MB / 16.98 MB | 0 B/s | ETA: N/A
Unzipping snapshot: [████████████████████████████████████████] 100% | 16 / 16 entries | 0.00/s | ETA: N/A
Removing existing chain data at /Users/yajun/testnet/.ironfish/databases/chain before importing snapshot... done
Moving snapshot files from /Users/yajun/testnet/.ironfish/temp/snapshot to /Users/yajun/testnet/.ironfish/databases/chain... done
Cleaning up snapshot file at /Users/yajun/testnet/.ironfish/temp/ironfish_snapshot_1682953324920.tar.gz... done
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@iron-fish/engineering 