### PR TITLE
removes unnecessary note decryption in wallet transaction RPCs

### DIFF
--- a/ironfish/src/rpc/routes/wallet/__fixtures__/utils.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/utils.test.ts.fixture
@@ -1,0 +1,162 @@
+{
+  "Accounts utils getAccountDecryptedNotes returns notes that an account received or sent in a transaction": [
+    {
+      "version": 2,
+      "id": "b30828e7-3188-457e-a01f-7d102bda2611",
+      "name": "a",
+      "spendingKey": "9e1e9d060c22a57f5d8be762bce88a627e5db2b6f8f624c93c74b79eb40df685",
+      "viewKey": "fdec021fa69a44f3cfc44827d5adf49436eaed20b0110ccacfdc2a74f831a60d910e0742eb745705fb03554bf9ef0624ab8fa1965eb407a4c336c2d8b29358a1",
+      "incomingViewKey": "cd2bcf234a656b09ce64644adb73dca7266584e62f56459f73dce019cf9f8104",
+      "outgoingViewKey": "7e47a7fec16d245426ec30ce309aba3fc9b624643448ea0cf87ddec1a8400978",
+      "publicAddress": "babceef2e85e0c1d036979c203431ae3a7a1edb612caa0dc445bb34a1813970f",
+      "createdAt": null
+    },
+    {
+      "version": 2,
+      "id": "9a46035c-a2cb-47c9-984c-66cd702ba4f8",
+      "name": "b",
+      "spendingKey": "de9fb47dcdd1dd7638e2cd8484a79338e14159c2901c2447bbed7bfe908c7061",
+      "viewKey": "79aab8d5b69157eb466ea5c0d7b889cb117f25bdaa730d2fb7b54b14eb207c1aa677c3bdf5638e6591249d422dd276ab837a0445afedfde0c84e0b9f1e502e9a",
+      "incomingViewKey": "4953448d6c57cb0b11bb78a09744b43bbc044e3f43885f41dad1d5b9056d0b06",
+      "outgoingViewKey": "2d8dba3133dcff381275eb6407485f1b75873d5e2d5e43d677f1702bad481d34",
+      "publicAddress": "2c339783227e4fbf2f69d5cee6fc1aa03a7c658f112e4059d8c4ff509f877a15",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:SC+SprXGhWfjFcAbStaJtjRe/d5aBjFAWzk5a0rWN24="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:dxbmMzW7KJ8iIykrHCmbVI88qLQDw4bQ/PUSnJ+0+Kw="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1682984578505,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4MQMCVAgl0u1nC5fUtRpjr672VBdncX7BGqOvgaBSRGkacBVsNC2PhK0zlxrvKaq0czzzdUwSR/do4u+jWEsbIjrEp/Ayt2u309qpW+8V+myBHYcD0EzuLXQeu5hM0Q3IFFSQDX9Q2AWqReWjCtdbqR35fmO4CsIbZsCejEL/ocMHM72aPRF/gGFpkNJaGy3PcYlf7A4b/ie8Bm9EMQbgVqV2dSgPS673u4jFipmHaCQPcd0rbPFnmbh6vbWb7O4Tf5BwnuzHiRCWymnHpopKjsJtda0Bsbab2wqp9mfo0woA3QJBOtr+wfVymF4eVqEhh2ZJUAUrwFGlX7gGF1AKf6lEQNT8DWZEtXQkUcOcnE4Zzq6UUrxP8sULZ1MOWwCxHPPqHF62AxLV0yMG+veWQfF6VtXbbH3yoUpfL4ODuZ8rNernJge41E+IGnpoXgu2KoiMJrFYbChm7Cjg/83BhcjpAl6NZiDQ5qfeTfpKEFl/Qzg/cXD1vOhgl6HRNFZXzm+TTz1MveObQQX6A3tUvPSAsCjinjVSKvvN4Kw/TwAs9NBgyuiH6T5/3OdDhzP9JNE8EtJcFVuBxDnR4v18wUSyhc0B3wMwxWx1LHr4hvdL9K7lrsItElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFJNzqFq5QcAm8aBwJInPV4HJSLnpSVWhjgb4FC8hpEUQ382+42ZtR1KKUPpgwRYDSaT5nRZPyREvi/jdTkFwAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "0D27A3B0248DC8ABFF753F3AAD490AD70ED639EB58B254AA1D8A8076F5FA8892",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Lr6hl+PNzaX8nk0cuJQbiwYO1Hzm5NUwXmADZkt9uC8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:KkIeTCNUdMUSwZln5R59ui5AikQzWBKnhcVqTE2OZco="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1682984581554,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAecot3QwECyMxGyUE3wJVtS1oRCfQosLVJNr/ikZDURqOTm7CbZ3osj4cSGFSXedkr5/SmnwIxCURGhr+aRUBamVJN0JmdQI85DPl8EYBq6+t6bkbVUBMRp1q4ZsUSc7D47kd3RW9bsFekGY8Cc2qmCE3yfmsxhGMRTG3nPd9oLcEhEomjYA8lQIDAuvSdhEAE07IrBATu5hKlKF8RFbSW/3pED1O7YuUzv0G+lXV7wiCR/gl8Q5QkrDsH95E9Ot78zUKqgBllwJ948MUGtaxehBCTsJBMKXiCA97rXzLcatckGx8bUp/a8mI/fI3CsiyuFfK+azxwSEuC1X84MhiSq1gxXYk0svsfFuc8pHc1/763IKYB2WWCvb1DomS6jFrYx5nIRuo52Y1vKuh/9Edd7K1rLeG2PqxQy1vr0mxKxfRirXhznjH9kA8jew+3+18gpYG4FsjYpfZDQx/ktMc5BuF8UYEsOu59zOZ3sb8iHWp5jSDhXzeMV7rzMPSdBNKhyLo3bu/PaxEQUNFHgDcDtQOZ6dVvcXjem+CIshr9KwJ/LAI/BNjUtjzGcFqX5mfIKwhVlpW1HWgdvuHYo5NOZpsP3vaAq2I0EZmcl0HG6CyMe4DgTMdQElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxUowZLYOIMBBEZo9+0uxYtpgqQWEKSfPRabid6gumqOSZ6Yt1KlPtganzRjRXsZS5Ayx4Oy0/3MonQXfQxW4Aw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAgVfV/ajx0FqrXEnagjX3rp7a4qs4cR2Vb+2vktPSKBah+KGw4dcw534U0NPdhPMd8u9u15KtNK17PEe/WJ/ig1eKaRv9Rh+KuR+PSvg7PASsX+8Ud3VOHKjw5aWceIlIe3B3Rw0or5uNSwG+B8fLdDW4ObIFuh35sVDKn/YuJU4JuJAZK5oFTw5xl5QsMEkjmKH+kxKvrWpUhNCpw5XMcWD1jvKviB0rH2r8tnxrq6+UBaJRu/URIhyOYgY0+pFWoVPRub7vrzMy9WdTfQYA12hg94dbHiIGp0AI0lS++tz3T6s0iMIAQVap2pgwsP7XUuVw5SGqOk9jXNGhzL+gvEgvkqa1xoVn4xXAG0rWibY0Xv3eWgYxQFs5OWtK1jduBAAAADwUQ3JRMaVx4ZTjs8LkaWmvbl2OvgTp93GNf+VLM/tPe5jFMj1sZbKmWqhT2m1aQHUFBpXNk/x+ZH74Fm20j8RyYOmdHpyqaX/O7oPgDKPrWL1adlcIHVuhadPsK9qPAq68Hrd3BClwG2BtlPoHB+E0/t12pb5xvBskvGVzC28aHPXXjNBQlTDYu4Exb0kTrqFPkwuLeLk0N2PDx5GfB80iY2QtDADO2QtEGMMokKsvkEPA28M4XStLy2ROqNkX8hFXIDmv4NnI16PFLQQSvuycAFeRoi4pqMB2KMcXc1AusN0X/ldF42vOiCp1cw2ng67xjXQLQoS8Jc7/zlNLxAWjyQntinaIMMeGb381FYuGTlbGzEn0Ie2lgSrrk7GP4AcPbcJsGEy8usZRwINkWQgdlcIPdL+cCd/eWnGOqQlgYbq+kltpl788ewa6iq+2qXG8iTjh9Wd64dG57tz3WQ0bm0UHlAMB/R6eeKMnGLSq4k4J2uZVpwLbYhpGheNmhvd/OzzqwTOcp9ag06/hUojsKDUdZHNcYhqHTZp16JxOwECYnJbpfaM5gC/HzHTNEf1pq4HANXheTIBtkDAovFvx51+3gud7TClloHU/+ocSTqb5mq8P9v4WYPSQA9Fwqb2KaY5AWK+rJ3L1YqtuCOgzuOPubHFPZXlPTescdnzUwiikbXk7n6cyFYWYjei+OeoSAFuW03iIi7ygcc3yzPw0KEr3XYxcUN5QDA9OxyPoA3PxMEoirm0lkfCVkX/3c7tNnN10adNLmVjjOYwVesnKRIVwSk0QILpW8TW8I22Gby7YLn4tskajEaDhijL3da1zIlJYAP6/+FWyDxWp9WqrqJi/X/WUzv+sH9OoK+yOqMrOx+FXqrGklTaFdyzp41feb+s1UMGy49kY/ZjhwGIg2uCJRvtcs+4WfbJncVjYvSaiQ481smMUOdUdNdeN110a4DLaHMFlNAS67+TBMXZnj+/z+XK52hYc6PL6hrhBB1eTSp7Ftju1rTfHZejgtra7Lya5p709l8QFiA2e7y7Zxpc8iLP2hYFtCnc9v2Tu4x95iMwH1LMVRx/FDl0WSOl3iQ4DDFeQuqXgjTfXLqSoTOVJD8DEm8MXxpXes8qYOMVQbyDpE5MyCEhWrs7LeIkV0QPHTN1keDkWvjq2KIe5p22sd5exf5jakV47BmlOUkp0VSUK5UsAZo4oQG097MN9FudaazrdHMDMB9hbioK+CeHT2diSWrAlDO4UPia3DTVk/UR1ldMpJiwlcSFw1SJ2JElrHQE0FUMv8z7TtLVSNUo33PiQ+CDbPu6LbTgxDR/y6U5Xe03qfQQCMYbqlox6eissNldkqIf8v4tTt/PHNsBEVHSGACWyXlO2lN52XQWsmp5yNBaJ/jAeYZjM0CJjPasfm4yL3/L1reAi/na8dloP8FekAlukwEV4J0FUIo554v7nfzT9dBK5+QuP5wV4pz6B+QGcTvUUYI4LuwwlOifbf+2b2lhaLHf3eWirdvkFb5xmAz/zO5TG/cmvak6S8rP2nTcYG75n5r3EAQO/kHytuxdcICnWOklezkAOUpmKbaE4QNzDk/K3ufLDDQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts utils getAccountDecryptedNotes should not decrypt notes that the account did not send and did not receive": [
+    {
+      "version": 2,
+      "id": "c89fd22c-a9a9-40fb-abcc-74413ef86965",
+      "name": "a",
+      "spendingKey": "c826424551343ac36ad0b7af882862ba225d474c49839e91d901d471fbad5905",
+      "viewKey": "62901c6c1ba8ba5c094355a2c307873feded666e00f9ac9f11bb2b3d93b74344f7c477b2629d5efc8c63a44242fabcda713e767f1980cb5055905800ab3c4fe8",
+      "incomingViewKey": "848ba6378471794abeebdfa2f5efb3471ee8d868c8da322ba5f2e8bc38dfa702",
+      "outgoingViewKey": "ce81cf04ac2f8fe4fbcec65410ff1c7d0b00165911868d85fc1206354d81e0d5",
+      "publicAddress": "e8a7357013fb6a0965345dbcf76cdb56be9acb120dc2ea699dfcd16da7276bb7",
+      "createdAt": null
+    },
+    {
+      "version": 2,
+      "id": "42091407-b1a5-4224-aa2f-77fa701381d4",
+      "name": "b",
+      "spendingKey": "4e231e1cf25ec96f7335d38b39b2cb6adc3ce7801dbea3a98f45b1561cd31f76",
+      "viewKey": "50bb7336028b0e0a22453e54d68e2fed507eab96f11ae5ab3403acc22f89e0e416b159f210981cd112bcb72d1068a59d4ac5913057cd8189231e056613ab265c",
+      "incomingViewKey": "369c55b4c37fff67ee987630f0e64289f2d550b95794395de14131c492965606",
+      "outgoingViewKey": "fd0d62bd1108e2b50d08761b87a20be23c2584ea57f19321aa6b09f7d533dbf9",
+      "publicAddress": "5e5ee368d525b911e93006efab98bf37f1835b83384587074066432926ca8cda",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:XhMUE+5ylma+3HO2rOtHUw2wSeOb3brbsq5IrC7RHzk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:WTnPnxxuG1H+saJR82D8UuQmsn+5BLK2JXUNASRNZp4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1682984913783,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAARo/ANJIpR0iT+EpJWSul5Oq2jatvDIWUOaiokBtEhGyhNdsqkfjhlmh9T9123CxFCUZWJJNCMQpcwE37VwsqCBY1LQP/z5A+ctwqqS4NEliQwt2XM8MkeE6ZXTSwZnpuzj6tzwtUYewMuYAjgtkZEHHC943qE6iA+FX73lMgtI8PrxPYBmUFZBdxhiLUJIpA1RkZzbQLR7/9iqjPfWXRW3m7UGhvTuNPIh0MlA7D3nGFt2LBxZcIazJ8RjwrEgfP61C9yp+/IyAs4Z5snZQMCGrhro9ukh+db8/kXDT6k1NaaoNc5GDGzoZnBmU5JLL8a+8eUQm0p5FAee9PA0UK1vm/hxaOtjZbop0JjNRlCUd0EpkCz3Tu4ehmyQtdza1HEKrb/pmDNgNuQVbSD2n4WnDYcKlBJ+rblclYIuQzO8a5v4W7MaGEHhj310UoCqbaNE2yaCtacgre2YRkDsTeMaghJeoNXIgM85SPwp8JinlFxWD7z71QEId7aoaTv6muvVQSTK4Lc2mU0Q0YJ+xIKR6zi3ZF2FFd5c32rhhkTSC3/7jz3MyYRxsAWhIJhfinv2c/6KIyIyTNAChQgErBuo6LThxZDShsFm0lYJjC+/PBGqiBhj4kx0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxn8G8OHJ6qmB7QaBFlTK9IPePGNmN8GjR2qFNAH86ewDzy2Kih3jqZF5BeaoVXq3HlIyv8C/4Cua7TL7Hob3Bw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "4628F22180E2AA599A68B54CBED87E654483056CC6E2FD185579AE3716E3E519",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:N1/cJZ28PbXJFY44hIrfyzXtkHUWZcKUdfy1G267hy8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:fzjkLfgSRxz11FbfudMotsfZ6tUJGFPCcA5LVJ8DlLY="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1682984916682,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAEfk4LPQkqDs6ZJBsR2dP18pJEicInXZRSFMDkNXoSVKzZBkS0YAiK17+JniIXqIBYW7m6LAwtJ4oo7cr0bGYprfhN1mMpFbJJ5dSArcCRz2rr5FdCZwhbhGCEVdcMyk561RjJ9wx18DDEWblLQd5HmetvFrBefDAETvnKuDRYr4Sv8ucxl0vZ9AqSkQf5CutBCP9ple03U8HbyDe7tSkvLIXt7v8/ANjCLjqp9ttXdWnucEnV8ocXSbecBRnLunQO/3AdqIAfcCyFRks/fy0yE4wlDuFdOfSJSrPrH9dHR/reODKXtKhC7Pvb4j7qQLnmpiPl1T8UyUnZ3iyFxLmjRrtVGo55xao86UvR9xWNNekXBVWFWeeyn0njtvnoDcMdOAUT2rDjWbnAc5cwrSj82OvQJPsFNu2kOygacR3Rw7EaIMtJ8HomfbixR8VHBfbkQAb4ubAzVi8GjDGWkDLFQB76uT7D+v7JmHFRP4tpLMbyvK+Je2LMJ2bOfMXZW7PRsuUFjeiOFNUzjwi6kYEysiNBiKOr+tiCv+X28PdJNCcn9Jh1xSrxpER3rThIY6Ks8LAXFr0ynleYbEu1mGdMPBXtQBsC1MjqzZnmW14kQ9+AfWlm8Y94klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwuHfPD0bHs4bO5qXTCEO1wH270xlLIXUM7+H1KuxV7ljudwaa25LIUimkjQo+w76RhN5/OgjdYs5Zdi/B6CIKDg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAASNoW3kYKBERSAMmk9bZEUkekwOv8sYX99zJK2GSRdY+Cla6GKlX1hyaoi3JY48QFvsH3r5Nrlv9LJ/Hc0L21H9Hr4X0LBDwHRa7jclrpdJaKvaCS5BV8gaC80YIVss+LhitKbsZj9POSdUt4flHWXPSXyo9sdv4tSRoWOIzx674Ca8fmS/4rOfuwIm5AbQKV1XdoLocSn46hIoS0PIDJ4hG8Q31XjQZ7a/I7QsZvw9iDSxqsEEfPQRSjrtz0svxlIAIANv5F7qcpyfs2NmaGiIqX9b7xE5YDuwA/j/K80opItOAJ+N5Wetuofv+gZQGLhB8gXmVEbZGxB6FntmLxx14TFBPucpZmvtxztqzrR1MNsEnjm92627KuSKwu0R85BAAAAKocqicgotMVh++CAOcqYrI+/EqAF+FIdoulXLu99cQaGGC6N4ifDmadhKtoUhxyTqPpsrZW5CdyqNQJdlxoeOkrEzyUFoAs0yIDQDi4e3KaAgva92IhaThfcqhqzUbxA4SQ2naTSLWftfQ44BfgEy250bJQ2KouiMbyuHmfQmo1rfQyC29jt0L9KVyh2jjmTI+26/Eeobmb+Xoj84ImdJcBqCcQUDCH3DkSSQPQ4Lsg8CO9nnnGAyH0UoGOf8F08gnHZ03aIgWDtKENzHXiIyFRTO5c0Z6Dt1M5TwtVfLXfxHnE0g8FTt+mfUyU+8O9UqA+cKsi2zPZUXBp0CBzIerzRqao9+LSbAfueVPXqQr6GXrjoADwTZk1uSg3zHI1qJYndqX8OWhCNjvlkglaLifIlf/ajpClulKNvwDKMBaRAIQO4HkYPQVVkZVpL1G7l283MQonHPV0seQRarOBEyTo7EF6Ev17MzStgXeYj6T7OaoNRd8zRlyB7MRPg5ystOs6yN7iogky2yWAITBB4yHX1khxG/8emfNHQ+YgHTvE++A9JNQ013Rf76RXdnA/roQZ1Bv/+RUrzgZd37stlb3ryLSUE3ac0d6q1zn9t2NTufXeopsNff68hF7mCC5cRFBUkkab5Z/Zrn5U2xhzOEzw9tGm0YYd9JXyDORbNS0RX6b6aSxZqWr3Q2AYc9FUOR6T+KZODp4/juBgrYy3A9bXrDkkvSTv4W0vAEvRR/AJLfJDIPvjaA3BxaGPjtttqCo9EJUSJo3rR6XlUyGUEHdwtHORBTSp14cl8Lzo++h719XGsRncAoCHIpZ9g3w8Uo2jsemHsYcGrV7k9e3YoDmu3KSvKXrWom9IApCzl5MBa+q4BULu5360csrxmEUlpkzi2H5SFpHxxGd+/blQyQL//gVlpH6MTsC2C5k37wmH0/vMYNxz3OsNw6cmDjjVkJZuT5XoGMX8+zGmKB2zNMk7aR5Sk57ooOdzcN5VqNzfHxtpgO1R41iNswjYASGI4Fac5cdzs2Hf1HBuyKPQmdAaDNggfWAjDJsJcq7DxyeUHycNmTz7sz2PSwraySAlL0KfGdukVmexhoqQjDlZGHkQZxoHJz3UylbKbzcxBJjCy2aHvKlGAo1KuuMb+vBD66cjExb2Lq5fOnlsIjRCYm/wR/qyMUyLwba6KOdkiEqYo3eA2Ge3j+tTOZLrYc2BDtuAdGObF3edbtsyldgbOjm/PuV3g1edrysm+AZrwPFJi/VXlDCN+zkkLwlH3SRiCaT7OwSEDP8sG08yr4ls+NW3DQR+Vt2vnssr+HZlhJHiIcPI9iMSSbPefTX/Lly4d2tvczK0KvZgiZ8OLtXLcmd7o6PcIXmIr13zX6zpRQEclQMo0xgjX15PvNVjPEs/iW/3UVlEhMg90IF2vciChsRgWD20tUZmPj5LWixRhK2zFw6JjnzWO4B6HdZYoGzT/q973PH5MxqzGmrxfq+iUeKGFWfvi8SA0TcNXYZgD2Nsq3lBcXnIsGIjUAksizc8S4UPq1koPJHm6eu4lrPhrjcl5MtG6sgy2GjJT1Zx0k1dyuyKuRTGzygFNoxPW2csDg=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -5,6 +5,7 @@ import { IronfishNode } from '../../../node'
 import { Note } from '../../../primitives'
 import { CurrencyUtils } from '../../../utils'
 import { Account } from '../../../wallet'
+import { DecryptedNoteValue } from '../../../wallet/walletdb/decryptedNoteValue'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { ValidationError } from '../../adapters'
 import {
@@ -72,28 +73,79 @@ export async function getAssetBalanceDeltas(
 
   return assetBalanceDeltas
 }
+
+export async function getTransactionNotes(
+  node: IronfishNode,
+  account: Account,
+  transaction: TransactionValue,
+): Promise<Array<DecryptedNoteValue>> {
+  const notes = []
+  const decryptNotesPayloads = []
+
+  let accountHasSpend = false
+  for (const spend of transaction.transaction.spends) {
+    const noteHash = await account.getNoteHash(spend.nullifier)
+
+    if (noteHash !== undefined) {
+      accountHasSpend = true
+      break
+    }
+  }
+
+  for (const note of transaction.transaction.notes) {
+    const decryptedNote = await account.getDecryptedNote(note.hash())
+
+    if (decryptedNote) {
+      notes.push(decryptedNote)
+      continue
+    }
+
+    decryptNotesPayloads.push({
+      serializedNote: note.serialize(),
+      incomingViewKey: account.incomingViewKey,
+      outgoingViewKey: account.outgoingViewKey,
+      viewKey: account.viewKey,
+      currentNoteIndex: null,
+      decryptForSpender: true,
+    })
+  }
+
+  if (accountHasSpend && decryptNotesPayloads.length > 0) {
+    const decryptedSends = await node.workerPool.decryptNotes(decryptNotesPayloads)
+
+    for (const note of decryptedSends) {
+      if (note === null) {
+        continue
+      }
+
+      notes.push({
+        accountId: '',
+        note: new Note(note.serializedNote),
+        index: null,
+        nullifier: null,
+        transactionHash: transaction.transaction.hash(),
+        spent: false,
+        blockHash: transaction.blockHash,
+        sequence: transaction.sequence,
+      })
+    }
+  }
+
+  return notes
+}
+
 export async function getAccountDecryptedNotes(
   node: IronfishNode,
   account: Account,
   transaction: TransactionValue,
 ): Promise<RpcAccountDecryptedNote[]> {
-  const notesByAccount = await node.wallet.decryptNotes(transaction.transaction, null, true, [
-    account,
-  ])
-  const notes = notesByAccount.get(account.id) ?? []
+  const notes = await getTransactionNotes(node, account, transaction)
 
   const serializedNotes: RpcAccountDecryptedNote[] = []
   for await (const decryptedNote of notes) {
-    const noteHash = decryptedNote.hash
-    const decryptedNoteForOwner = await account.getDecryptedNote(noteHash)
-
-    const isOwner = !!decryptedNoteForOwner
-    const spent = decryptedNoteForOwner ? decryptedNoteForOwner.spent : false
-    const note = decryptedNoteForOwner
-      ? decryptedNoteForOwner.note
-      : new Note(decryptedNote.serializedNote)
-
-    const asset = await node.chain.getAssetById(note.assetId())
+    const isOwner = decryptedNote.note.owner() === account.publicAddress
+    const asset = await node.chain.getAssetById(decryptedNote.note.assetId())
+    const note = decryptedNote.note
 
     serializedNotes.push({
       isOwner,
@@ -103,7 +155,7 @@ export async function getAccountDecryptedNotes(
       assetId: note.assetId().toString('hex'),
       assetName: asset?.name.toString('hex') || '',
       sender: note.sender(),
-      spent: spent,
+      spent: decryptedNote.spent,
       hash: note.hash().toString('hex'),
     })
   }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -375,7 +375,7 @@ export class Wallet {
     return decryptedNotesByAccountId
   }
 
-  private async decryptNotesFromTransaction(
+  async decryptNotesFromTransaction(
     decryptNotesPayloads: Array<DecryptNoteOptions>,
   ): Promise<Array<DecryptedNote>> {
     const decryptedNotes = []


### PR DESCRIPTION
## Summary

the wallet/getAccountTransaction and wallet/getAccountTransactions RPC endpoints decrypt notes from the transaction so that we can return data for any output notes that an account sent to another address in the transaction.

we have to do this decryption because the walletDb doesn't store decrypted notes that an account doesn't own.

however, this decryption is applied to all notes in the transaction. we don't need to decrypt any notes that we already store in decrypted form in the walletdb (i.e., notes the account owns). we also don't need to try to decrypt any other output notes if the account was not the sender of the transaction since we won't be able to decrypt them.

avoids unnecessary decryption and adds unit tests.

## Testing Plan

adds unit tests
manual testing: compared output of `ironfish wallet:transaction` for a sent transaction before and after changes

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
