### PR TITLE
adds pagination support to walletDb loadDecryptedNotes iterator

### DIFF
--- a/ironfish/src/utils/buffer.ts
+++ b/ironfish/src/utils/buffer.ts
@@ -29,9 +29,37 @@ function equalsNullable(a: Buffer | null | undefined, b: Buffer | null | undefin
   return a == null || b == null ? a === b : a.equals(b)
 }
 
+function maxNullable(
+  a: Buffer | null | undefined,
+  b: Buffer | null | undefined,
+): Buffer | undefined {
+  if (!a) {
+    return b ? b : undefined
+  } else if (!b) {
+    return a
+  } else {
+    return Buffer.compare(a, b) > 0 ? a : b
+  }
+}
+
+function minNullable(
+  a: Buffer | null | undefined,
+  b: Buffer | null | undefined,
+): Buffer | undefined {
+  if (!a) {
+    return b ? b : undefined
+  } else if (!b) {
+    return a
+  } else {
+    return Buffer.compare(a, b) <= 0 ? a : b
+  }
+}
+
 export const BufferUtils = {
   toHuman,
   equalsNullable,
   incrementLE,
   incrementBE,
+  maxNullable,
+  minNullable,
 }

--- a/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
+++ b/ironfish/src/wallet/walletdb/__fixtures__/walletdb.test.ts.fixture
@@ -2,53 +2,508 @@
   "WalletDB loadNoteHashesInSequenceRange loads note hashes in the provided range": [
     {
       "version": 2,
-      "id": "a7600b14-e5a2-45a9-b017-090aec98d669",
+      "id": "0ff08554-78d1-4296-93a0-c16f55a87f94",
       "name": "test",
-      "spendingKey": "a919c4c64153673b3fd76af5478a70ce88498f65a31f94c8553abcfd6797db1f",
-      "viewKey": "880ef945f43e36387873b657de3fb80f9f77343fd3430f076243e4a26913e1c93e27b90d26f1ff196fecb945421c36bccb5e3b06850dac11c6a797dd83741b28",
-      "incomingViewKey": "68e90bf6c4a9a59980f64068644bcfd61e6a39032d0dbbfb367370fa37cc8a02",
-      "outgoingViewKey": "d81e63753b71142b59e1df78a1cfe73c34b1798f399b616f57568a0aa34a19b5",
-      "publicAddress": "017d73ec21e1002ee338286aa196747b3d81a26b534f7c51fc13f70cc747f3a9",
+      "spendingKey": "df347568f5acb296c461e25db465da7f1f1bc09984ce74d3efef2ab24182c066",
+      "viewKey": "c035077cd4647c9d6c8a0252ab4a68bdd9985383f2882bad1ed88bde117e5e2cd3c2a5e3bc3897a5cd57705e5439aadd77c261f1d5a884fd5952e2b6017e5358",
+      "incomingViewKey": "07458cee0babe903a30d3bdd19651ca21f1b91ee403c55251c627f8481921c03",
+      "outgoingViewKey": "101c845203e0bdfa5573ccac8d988a9353599c982d17d7863f4fb310ce758426",
+      "publicAddress": "942007bf15c3a67bd0024dcccd70eccbeb74e3de54a7a233b239ad8e7101d1e6",
       "createdAt": null
     }
   ],
   "WalletDB loadTransactionHashesInSequenceRange loads transaction hashes in the provided range": [
     {
       "version": 2,
-      "id": "4b5d1006-4f9b-4d8f-9b1e-38293a249e8a",
+      "id": "a6221f42-49a5-4fd5-961a-5506b8bb392b",
       "name": "test",
-      "spendingKey": "a383d8e0af769ab465eaf4bcebab266405b47b6d8f845afbb23385cf49a6a859",
-      "viewKey": "d6fb3df2e63558d229540494b9943efb5895baeba3966c6bad9b3eb7024a549f0c1186d669005bb549d9f80248f7dbec95349a9938b0292e1fc43a8c1af899c6",
-      "incomingViewKey": "704a8d4927d14344790c004b144c039b6094ccfb1391428efaa6df1003553901",
-      "outgoingViewKey": "f8961bcbfde1e42074b4954f6190d2e0c1428407f18b264a6f95d8fa33ba40ff",
-      "publicAddress": "29ad362c8b74a1ce09df078f2d25394eb48b7135317b53fdd657483cf8df7b9c",
+      "spendingKey": "c510b90bb450e9a58a1fdc756c87b3afbde7d0aac25b8037880920c357abb8cc",
+      "viewKey": "929ef519c22a436f93a5165ad736c5ace2521cb8ec59f712276ab36a7db941edc81f42cad869ee7a9f39bb9fe8bcfc0870145c3c75835c1b8fc9733ceeee8488",
+      "incomingViewKey": "050b83819a5864b89f7c5d6d90e8a20ad6fb8b7c78df312a96905a42b2647405",
+      "outgoingViewKey": "bf02455082ba4f0d062692e492527e1e2f826b609373d8abd76eb2d849b55768",
+      "publicAddress": "9811e090550f599d2b5631e98ee9588877ef7ca726f7e9faef3e17f8b30dd56d",
       "createdAt": null
     }
   ],
   "WalletDB loadExpiredTransactionHashes loads transaction hashes with expiration sequences in the expired range": [
     {
       "version": 2,
-      "id": "d1ce4649-d102-4067-9979-9c4327809715",
+      "id": "eeb6c1bd-dab9-490c-8c86-722e09986dab",
       "name": "test",
-      "spendingKey": "2b11076ff19357f5cc66c3455d5bf1dafd00a1fd05d79097c566f55d427c3aaa",
-      "viewKey": "162d5040839db817859187c6237c2754772fac700fbc7b85bb3c1e3d53de62bd212f111fee131921046792334017691db0354ec89c131732cf659296d695bfbc",
-      "incomingViewKey": "df49091dd809bfe246aa5a0b1eedaea31b1ae816fc2aa98d7ec9c5f017037102",
-      "outgoingViewKey": "0b4e325f43707d467579c98356f2064750139f40fe5e7a0ffd37db68b8e7ab8b",
-      "publicAddress": "175d7f75895b6466c39501a6ce41898e1f90e4f4546bc5f123e8cfaa0c111f34",
+      "spendingKey": "8785e14042b26105518b572dd9692d431d9ebe58c8e0399876c3d270d69eee8a",
+      "viewKey": "095baba084ca410e11ba596d1dcb37096181e3628473776951124451216facbfabf055b6c5bb4202a432fd68c6a27279cbc318f7b52a2329a3760693d3fe4ea9",
+      "incomingViewKey": "8b372b5cad3d14cc4688acf473c3e249363de52407660c1ca304b1a460338303",
+      "outgoingViewKey": "752c2ae824da4cab709e2fabf53f206ccd7bc0b8e6146965e253d90f691b0ec2",
+      "publicAddress": "79910fe4b451b59e4459964af0dbd13574f65b20451277df0eec8e7a96c4e504",
       "createdAt": null
     }
   ],
   "WalletDB loadPendingTransactionHashes loads transaction hashes with expiration sequences outside the expired range": [
     {
       "version": 2,
-      "id": "da5523e8-3a62-47e6-a667-cafd810b0fe8",
+      "id": "8af08356-8e22-4948-8747-d50ca9891c6c",
       "name": "test",
-      "spendingKey": "753eafe9a680eb80fc0286a747c1456ef0bbf6fadea3a20eec16b55fec754e37",
-      "viewKey": "a637cd4dde2b5b3017cf1b55ea6623430064198d223a585f8e73dcdecad66ab5fe9b091b23ca407788ffb1310ba73f15efdbf371b379f97a431a868288522280",
-      "incomingViewKey": "8ec1957330f8e233377dced8ca8c5f1674cef27baa5414ef9c040c471874d300",
-      "outgoingViewKey": "6fb3c8d704264d9a401a9f486debf0b245e07aaac1dc018aa9979c3f9cb97181",
-      "publicAddress": "541f9aacd5657acff39eb5a933f77f72651bf5b54af1b5256fe925baf19c7de3",
+      "spendingKey": "de50c49f5b52ba0f3e2a904537c25801cf9561c4aa73ced86727f3465416f4b8",
+      "viewKey": "ad126076ae5b01d5c07ed2836f866b19145c9e8f1956f4cd7e07541526133c838694cda8fe9bfcc862928e016c932f5c1e1fc4339535d59f916eee09944cf7cb",
+      "incomingViewKey": "d962df31f8ca609f68152b5dc221961040e0d3c2d96cc5cb3eaf08380d294203",
+      "outgoingViewKey": "e6a2354a61ac6349c697a26e69c4329609c4d44f52038840f8ab9ef89acb8f45",
+      "publicAddress": "d08ea91b757e88e97cacd5ab108ac406a8aa5e5c230f1d12538092eee5d9e830",
       "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:1ckYIwhRNFf3EoN9GeS15lCb7xnUo6Y5Pu0FL2cLxzE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Spc/uqd99LkUnx9rHnbjPwAhvfHMUk6fWkDiZl/3gIY="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1682646215704,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA7PYAJWaTW1lkGi6uZKnFXlFEkPJ/pCSzGPnZKmP1k7m0JMhmJjvZPn4t8wPTO2ovCpDDlBq2iFO93U5Q3t1IDKEg1ikG6f7fN+NLi43fX6irvTl20CPA9k/ES8kmLiDE1/XU7GSwEJnTGgEYYZA1Rk26VfZBtn0V88VdIZ/EkqgAcf/TYqrydnbnjSRZgi980VfnKnYr9JzH5VO5B5EsKG9I80VGKus0XzzWHjpvdOmZT2I09T2pUPYK1hhOwegrjBuVKMYgB05kgsgaY3FxLPS+B1ugxnBjyptHjxn+h4mmaV9OYFU3rCwh7o0oPAQBzYV00QIz7FVZ0rOSh+NqnZdiv92TvPZyaqq2kmGa7lF4EzNY3NkKo23tsPbvBcwAzvccu5ZKSAJnkxqv2am0FbJ9DmJbCF+Enz1NGX5XYIpG8HoVdVxvfqTbxsfADZ82MFAt/q3kv5z6VnQZmdZoUlZTKSsT45hAWcRR+CnU/eYM/H2OZIWkHzRDPjKGDlolSpe+JpdlaMMgxAEz6Mz8t1mJgQ7R1eJsSos4jMlrMLhw1u72y0cI98IqJPhJMJ/NG0IkH3B2QF5hm4GqtnEYKTw3VICn/X2L+0+wVTQIwhu3dCSyrElC1Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwc+XG2sfbG+CUVt4chspE6CbCAqBJl+NRfNEQ2JmcERKUl05fpyiLcwVDH6GuhWRsKhxdHjZjPmHbGOsT8Z4HBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "05844FDBFF345EEB5DBB9CF4F1201A9812A65383050FA7BFBE001B782642D5A7",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:g19XKLKcdimfhXH4UdlwTywG9is9mJyrY6AvlT3A1HI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:p57hPqtCcIRriY2hwBPoxT4J8D0Sr3ToiGZ26TAfNe4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1682646334491,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAjdg8tI2Dw6jXR8l9bi3gA0V2adROdNlSHqS17NfNy6ih0SDTgezQcJHY+Ovnb3zgRX39cIYzAX5a0e1Dm0o/joE/JXVWS+S1JWmOp0580Magpcb8yvDU0SlqiWvI1q3YmSDMakTpv6cKY77KAU96Bp0xVPceigt+Kx4qon8sXhgGP1sjVVC6LsdgiMC0pPSPtERcTNSndwObYlBjMKktS3Hb5HBVi1Akg8tehJFnQYWAxanbSxBNGa/rOb/NacfFCQPL3nT7eaD3iKXwtAtj1WAiL9ZD0XD+msKIhirtYxV/A2ltP9pviw/e5Za5uazXIHCgr4zjXp5Ao80wrto/0Vg2lUwqQ5yF2Zc74H7aK7uyTIMmYJRN6WzZymiyQENaKYEOnOriHTXD9QzYFjqWhgf4NSF8sPSAmla8b5QPoFP64qJlY08YroCRV5D2NmEF3/mOF0d2nzWAX6ZxXCDLBV1rtnEkQHCzEnKxLd9DB1xRaS8TzzWqKxOvWEGoBE/dQBs+0J5XE+At25TkFD7o3ZRicGXoAQqGk2qUgVsfuxpPyskCd6EAg4W+015WKV1BqEj/deQh0moE0A1rXsy3IkjvGQrUCOp0Wpgc+tDDXx70T52R1DFx1Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8Ulg3OT7F9FisnS0uWz3bC/8hy+DiT5KVzWX0eAwNI5juNRKElr82//2jj3kS7yW1x1kv+FDzH+uIrDu+sw9Dg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "6B81E543E56C3E8D036A598509982ED4A44832F81D3126F08C01B925F91EFEEB",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:oc5tvcefBAt/ztHHG6J4nIb7EEeynoCz/digq4Gd7Q4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:rUcK40NDqhxfe4Y4QNbFUo/ujohWc77Nur5FPt0ubo0="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1682646335068,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA89NCIUXN67FGq4Hrhf0vGk0BmGhRSsR6qo+4fCTaFeWJDivuDWRX2m47fx/dsUWeCrEi2pCEqTh9CaNn8kotj+6IqYmA4a8NMia9nmF3teq0oAGxuSxl77GDpoDpGirWljOpVM6QqVsNFHl7jc8fSlibB99BMQuNBB5mXZUcO/cIcof1Oyc/CVIimQ2hqLoTp3sRweccJZc71QafcftHBIGNO0VUxOz1YRB/0Fd3FwKne3NI8qT2fBI+rn7NBSFINpO4Cn9mdghrfOAXgyC0/gFnZVaKzpT6YU2NFiUpGaJjLjELT5AcKjUBRMaauwtlLVb2tsEog2ZwVCw7JF7MOq9OO/jjg3PhzT6du5TmiDLiKpbSH6oCrmsffKDE8SxomhBWQdvH0f/UrF9jSSw8R3TLbjNHX3yH7aRzoEEUTdJQCdwZLRSpyw2sa9ZBms2YPoBzeAJEt7wHlI5Q6/aGnvtV3PCUGS0HZF+HuIqWAC9Pv6lCKL2jQ2gwrZOVg/0goa00Tpz/4lBCV3HfkErQBsd67V1ce8Yf0CXxkLmnZj78Eht/38oa/x7wPS71JbTCQYLdLrrjw3MQyYVWjOeEPO8osE+lvE2lY11NhTtCpoZFHw9R19UkQklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwkCVP2yYlXKkkmNKJ+EtHVjKT444QNpeCvW3qA3qb44c8rz6rCmr8qrvjPAibBS7Mf+U5U3+bh5KUaGa7vODeBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "4E68A0A0D3C29CC555389229D85A8180C9074CF9F4D9928E8D0FB893BD8E1B88",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ep3gNtoxjmoLU3IJzmHfEe1fUGJk17HabJ9HQFYqjw4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ju+auKjdfWMfkzrmgZdcDO/v+ItMbsLAZtuXn6qIDbM="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1682646335655,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAGfMDldDq1Epg2fV0HNCbNsKqJghVcgEz96Q6XCYzR7mP/g51bagkE7tvS38FXOMH2Av92zGdWcrBbdjWx2TyVS4DydXhIW/KP2N6DLIJy9Ovr4lPsL8C/DAm2tPZ8iTY9VhmEKHmxFdALT/1RgPYKXzgyVrIV5LzKYI3FSxVW6QSfRDvhe/MJBvAHCd2BFPyIlNd8t1McY8d7kl3c3XTxXcAIJHK1vpCDsBHBTHrXwWutM4CFsbiOPyZMSB69JAtO24wAv2RnlGQvSPnYjbpEEitb97MrNWUu5MKTxvFqtz+mGqEtxZHKseirnTkMQ8RfCrF49Bb+TuLiTAFGjLbK71ufVscb6L9e8+hbLYTxt6ugXEEV+HcvHePB/EOdJE7EFkLTtK1ys9hq9Xwq5xd7RtylvkhpaNYbEHf7Y4rGwlm4Maf2WL3aPb72XMaD2Zf3+rDc1mhAFCtfEc0QP/XP9z18c/KnTBG865TMYuJ0Qqqte24LkZxOlFoKBIrvRrX1p2axNTKNKkKKuDYYa9HdHNOgwrsqT8ITe+LEYf+ERzBtaZkhFTOVDi3jqQOONZXZYNVOyujYEvsUThvLFQ2O7WE0PDcgZVvdqhbpXv922fhbvBR/Hk8hElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwgbzFnMHfkltn10h07dkjHEnB50ZYW2tJrcbqvT0icx5G78pHfd3kjv+zKwjP1NKT3oxFc3eYAYGKowYEVRebAg=="
+        }
+      ]
+    }
+  ],
+  "WalletDB loadDecryptedNotes loads decrypted notes in a given key range": [
+    {
+      "version": 2,
+      "id": "1c40b9c1-53fc-4d5e-a4eb-14850eabc16d",
+      "name": "test",
+      "spendingKey": "efd5b29b80295e1a1371395a67a602e8e1311c85a5efbd2c2b072910edab6fad",
+      "viewKey": "62d9e6d12f12a18e705eb440e8c6b35f2ebdcb58b6da2aae1d42c1fef51dbf4ddf2f5c009d75f6bb622911ae8921c301c3cc551d06064a6c18ac98199b5e0638",
+      "incomingViewKey": "f16f5868fe24b9e6045499810d03ccfe578fedb6ddf76823710b3a1b847ac503",
+      "outgoingViewKey": "58291eaf418aaf27d4f238234e5dbe488a095a6cc9610abccdb1fa0ca3129264",
+      "publicAddress": "68789cf7b17f10476c161c3c6848b9b8f23426d5ac127be1791453dc128b894c",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:uEgAB44kJLsyOP+fxr/FiFKJgBwEq6akUGOx4dJtCDk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Dz+S7N5KoZIfCTsHXnmpqpXTevu9WP7/H0/AaeBilIc="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1682644211729,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA5eRqHIaKmP+93VpvE7Ry/6V207UxSPXHsitcMTY7rEKSO+fkSVXnkvsByoJQnsVBhFRQmnuR+Tg03Z4z3TjnDS0lYsPcBL1grMwn5fGEnM2SeEwJ+kJUI99IQnTID/SEd47RxNUR2sUug6YXcCOqJXvmhsNFcTmbQWYLNWk91nAPkxhH6sH7WhMW7qi9L6I0kLqjInxD1C0Jzo1rUqZJslW/I6iiX7aou7HOv8yIfCuzf5vqBb2zvfcHmSdJObtQBc9cQY+trADR0uZQ2NhB5sccoIc24mNsb09m7eIS57BXj4JywgXLY+VyF+8Dbk355/dzaxA/bAXFnLQRl0ZqHKw6905r9sm7Ex1XDkOEvGd++UdfDRC4Z0kjtlHA/T8n11XUreVt8UoIukzEeMe8WGtgFUv+2S2XhtaZjDAe0+SlDh9y0diaLxZHccRULdtOOsUN/e+nREYvBXdyu2M9slP9np0YdC8f0IkqxLM69bAUmDyp8TmuIcn7dL9rqELQsLktnvqmfMHpuLFPp7TDDsictW0rsQ50MkPsQzwFXUPMazNHzvHAmMvu0RYY/5cchojjZQ1QPsx4YNX/fKCrQq8AYusqa9fUNeKaje1KBoSFofTP25htF0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdEdvzBptZwVYt6/7bzp8bL5kqxJDhklOzvDjJ77S/vASnigE+yhICx9XnKdRaHtoOaYNVEuH6XNdUCkwxUE7BA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "BA7D2F10F5FB1E4BDF69586ECD65A4317CDCA7689F0D1BD8E1E626834F961666",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:/Q5+I2947QLhjfkBHtyiOW/oixIpeNhTZPZLcs3C+To="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:FcBd0mUYXAVUoW97bMjfLjf6LkffnSlbeOhVMhM2KQs="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1682644212315,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4QUM3pMUGZjEsBXOwj1bfwG5biOZYyZ/+vpv17QFY92Dy46FfN0WNZ/9Q3GrGYZUyIFIQfa1hzBhFh9f7YW3M9Iy2RZKbQUbhKHYyQYMFsqwI++IpRaPJmQXKPq0JY19A+Yf0ySY6lg+XWZN8afxiXIGWCfsqB5Erim375oFqacKfUsND991nRu/Rtk+c7DlRQUx43utFFkpXagzweURFzu/KMVGwWyprzvezGescS+wWvAB1vSjcmNFRhuacTljtwJmMxQLVRjpU64ZvaATzhQQ7+pL0rHvtN3Jj2uJ25AraHTgMRfQ5EhkrjM9XptGc1JXtRCGBvgt6l9/iujNqD8xd36mknFDH1sDQD17MfCse/ulEdtlgSHknO/POphPPFPe3P49lmGclKAE53QAxkFWs3Fm1plCMEq3LeL8VSlNWzhW+0hCRqnrLTDhlHHZhJiLzyTZrk5fw0+KUAE0tzyRBx6xSBJXQ7bwOLpajfUpawOUmHClujiGiLLADskwD8JOY6Buu2OPGl6yPHsx55dD0VMLHtdGSsySBc0exSU14vRxLN8+9y5Gjc2Sj1GQFtFTr+0GpNPFgjGuKLE9r9gCholULjTkgC4E9NUA+Z1psf3skHw8J0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1X7sIsDS8gNmO8pZSn4+PzToi9H3XLUAjmi5Io5sA6AG4bnFifEuhO2VGxzy8UD6k9WjejgF+H3VLn4nMKReBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "C4261C9952ED3D372FE4A1D5054B1FA77DB9079F445FC45A169A31704058EDF4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:GjDoQFoe7+ERRTv5qzI01dDdsi5yCs5eRf2iD1i2jwM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:aUckNnydXeL0DbE/MUhza9Xx9zsZlFj0Ui8/BOpHKLU="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1682644212892,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABz6xpLShmbkDln0zcMNm6D3pSEwgXX33U2aKtlwCM22RMsKRC9kwgqchwOazw6JtJ4sBO0WnYNgzz+Mt2ikgiPxL461GBk4AgUnlNInwag+xAqVaLVhCPcnjSOV3r/vk8cOj8nuyfpmDadSu3QCtJGMP7fZBF92y7L9ou8ewwy8HRfww4D98F0GKlbFjiYXztRRxSe0uumkWfWVgUxtwdkRE+JSt+iN5aHCMPiT1kzqTDYSqqWzoyVBNVIWZwY83jBelr1wGM5yFA8CQHx1zagqTrnkueDwnlV1pJS5SERYfg3Yz4rZUnNzCMvpiVydc8v4hwHnbgIyGzk/zdCLwQhIC1LGL+VHVIGRIHI9R9Yu2OudPSG5LLfTpubOawpgGC1PWKaoj4PIrlRiTMsgvlaQ0roi5UVZMAkq59kwWi2se7U8HkP3XlLpzKJPdor+RyR6bUJ9fL4i/6nwfqIcV42Qy5NptNpsg8r7MruXzuJ5IvAvEWXQmngzAjQn+Mc6TnHuPjHdrUPsHp44XTdJBYwgYQ47B4FFOtdrE+j4HvMFYF7sarMY1bDojUqFf2rOkN51KIXDihMlp68RxoQ2jXseezTq6LRHcwxi9pHGGkCCFphbmw88ouklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwN5+Ke1DGAzPldQKROHeqDk1xptVTPLHcT/8zSb+3EVvQhgRfUdOUmknaAEpsRRDWK6oKNGppv6NdocuNoIqJBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "FE1EB942B7CECA53E4EF865FFD3521AAC4E0C8F74CEFD4DBF04606E7BAFE2F20",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:OHPPXgO+9QXNW+EQgEEv1Nqm6IIRdVBhwdeOemCBViM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:NWNuBAHMnzPRgM6Se/CYds3Ld+ut4oVBxFSmSNUMJSQ="
+        },
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
+        "randomness": "0",
+        "timestamp": 1682644213471,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAJAGSb/bfigre8W89AzKZodxhqtxK+V0ofuy6hXcpPCaL5qXs0ZcxEoNDsS8QXReavSq1jyQqSBWYwvKrqX+zlqBko709Ki21kOtd1ThoFiuPU+f1xvs6vp0d5bSmHJZWaSjTcX9cEwSRgL4BAIJJF7xDQnXqO0cz0W/EspiWCTEWXODKtRvUunoALbar6bsVnWRBGrQQGyWdebEDSEl7MpKcjs1BDAHCjHyKcT0zaMG2d0dmKcAi61KuLxClbLilgErfgVgaiFjEFRER9fwK9uUJrR3McW+r4N7yW66LgzAxrfdVOii6sfI1HDO3Otm91WyQ1xQX165X28SuxI0oRLBscaIBMBrRoreGJAW1Aw1F2CMNzTTTlQMaNqG9VJhW4xS1VdbaxV7xVMPTgm1vUmD6LbwE1otF6mpttxxZcb2/SiG1sLV1SwJkHNlQ0wcuyCOiPqO6IXkRiHU2UtEoG+lFaoXYPe7+yV9514SZ7b9UZYFMGe5NYHFKlt2LWClnex70sr82a2pm/TJeuElw2a2btR6qZzV6sUSM5JOZRpy9YJlIc9acvO25sGfbkhDPXpkRJ0Q+GH80psAxO0RUskxuqcMximrPsh/lZ41qvY88M33KDLcQ3Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3HPF9TgB1WW+iti294hFDwlwtEcKezIUJ47oHiLUnLNn/bIQwiO/njuDYTJbY9R6LARG2+K55YE9Sgics9y0Ag=="
+        }
+      ]
+    }
+  ],
+  "WalletDB loadDecryptedNotes loads decrypted notes greater than or equal to a given key": [
+    {
+      "version": 2,
+      "id": "9298d46d-e1e2-4711-a3a2-d42e8b4f4abd",
+      "name": "test",
+      "spendingKey": "cc2d5589800009a996074bf8c8b41b2149bcb82a7a0b8aa3cdded61352c5d68a",
+      "viewKey": "8969e99d59602d35e85e83259e89f1349ddc8ecaa368ebcc981098ffacb3fbdd349254c2f1bcd750ad6affef80df5abbff1ec09c8983699237f3b7d30ec17463",
+      "incomingViewKey": "c61d5e370160a5e9cc37d3e075486adcd41305308818575795bb76bd740f8403",
+      "outgoingViewKey": "0250363128981d0dd65946a9d5bee61d62cc0804eeaf480b2470ddb53d829fee",
+      "publicAddress": "3a71ce4fe6cd8da26ff0a5e7a2b903372f2cac9ade66097a92a8292015bb27e3",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:jsxrwhSDZlK983kzg/iqoUZLClOmkGGGmH7tNZO02Ds="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:TaBuBtdXoldWC8X8KCfHw5zzagG3JH9gidWEvxmhvhM="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1682649760063,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAo3HXDC1ESmakf7RCpGEBckLIyvSKCsuvpXj7Z0uoEOmj8F1KaWwXp7L3SVkZk1ctOqXkBxluvkMFUft5sqf8IjuMk1t5yKy6uLfCThUKLbKmfFcdmC8Myv1nI05XQaUX+cVZmYd4v0U0+nW6WBsqOdiiliu2wIYd7YJ18klmQY8IbQ/M/ZibXpwsime2khD8KVOaRGaeuuGTpAI4PZxRHZk5Ramk2p1Wl98ulk8MHKm3V0bAYYwdgU62xeObOXvl9PaGa+dicpxZAwwXqmcizQmHXtcKFkx9nJRDhjxNxrmReT93XuK6t7lgzZL5wxJJRCdwRDeiEICGRwtZ+Jn81mnuLdZ/TyDln7baVqFZf4NNhN/9TEz4yAqpB37LEp5WC8bcpeWfwu4rRxtegKJE2I0bAq/LiL7ZNQ1CNJYjD+nKcaqzr8qxCCk3fgA2X84VrOipC9OrRItOlkfi99NcP9ouyOWPH7bATJ+SKzaBb8DjKyNTIt2DQuZhLHIM1RuuIhYTnvGHGTlwAp/bnY8KPT0q6UkSN2UXbYSotzf8wX4YInqpPAU46AxSHgq62fQsra+S3cF5LLyPkUEiCQQxMEqThK2HnCAi0HIowl+3lm+mt5ngPJz3p0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5Z7HpBXUOAlWtobP+0o6MWunpJqkVMA4uCVxQ1nIKTzfNhJ9nef0tEwHs2d9SDWM4w6QqxyqxZTQ5Qbsc/njAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "4E5EF99E98FCF18462D3D82820CF0241B1BDA22AF6F889B562F4719D3321B77A",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:F9jNSsGZrTymHfzC2J7MYVUa+PjO85ycbvjZeeWuuD4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:t52EBI3c52dj6eXL4GQGRY98GTFwAsA8Gpbgj3K7PtU="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1682649760631,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA9p/F+EN/BYwCTVOYdxT+wnFSutk8vt2C+1dZxQoolnCqGzsN9FP12OHdgLArO59I2NvgIKECiMXvywD5vYjwWUkdq9Nz9omv4cu3FUkBmt+Ras4vdyBEN3Nlfl+wM6bgrf+wyQjVqTOBUyE/W9No/bhL9gUt4rBV9qZLyapTt6ARdGFzfDlnRelFtpO8LBLohjIqD4jBvkE8gzl8r1s7UUIF/S2PlTVtpgFdVRUBkuGEfxeWCWLh90TQUwDbCTh5kWiQeKFmSIDcnviKBvzjtjgQRaOCv2UDZ85A1SJUlXwKqdZMOwFOIQAH3+Ov/kcsYb5zMvAcDzFbXfkaEyzem5metkvnXhofz2zWiJch8H/OVTnJq+AHRJ7sG8naFZImihGMSlZEY9WLAmbJFfSEm2DPbjWsjANgK73SwTJ1Y/CdakJhMrHbl2fPgmsE8RMD7NppPVuHuprPyzA6+H1rwUX3Gh4j8CMehxIyaqCQlDsK8sE4T3cPJRfOv1+rpTvpKWwgPH5wQ/PC4E/QuQlKyyYkoWK0E5Lzr+18jtTj72shAlBKWBC5RnC7fcsbzMIfe/5sEKJxfo80VWx8U5S0eN1Tj2XLsbRKtjUFm+tCgri2c0IyRgzJn0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwK/Z+w6SO04XERT5P/fOyWP3GRunb/Crfrmrb9Lhy9RQL5sWRDne1KBbetOgGr2eqEk5ODFa1/W0OIExenyFJCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "7428E2F1874E7AB9E6DD839363CF77AB56225C6B7B584FDB1119F3AD93821BEA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Jv3Gok4AFJSDBIYBtbOSVlsHW1QE3r3UD8UWpKYqJ2U="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:qOy26+EfuTZAOYKw9zbx8voUgGInafLItYzyPEtU+is="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1682649761240,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAD9ONDL6tP4L8+yC2hJtm6zQNZKo+b2O7pinYrskhBySqd3z2ST6y/yJgttZAyLGIn9bX2XtOF4LFfZxXAoHetUYKBAmM2HKv29ZJ8oLfRve1qsApf+QRsC9YCCNzRj/WWOmveM8TsPKr0i21W4eH6ZOb/zJh2VU5X7R8Skbt1KgNxTE56O417pxv1BezQjEW497MEbWdp4ZoYgMTeNcqM/K9SadSEi5FZxyIIm8jtN2l+Mfur5+dsyZEz8kqTT0/DXOg3wNWrdajc02knpDw8rwh40Fo2tv9vVsWvdnHKcQTbPOsEQnbbWKJGCKmgQx8sX/aM0NrGCBXSNgn2aOL3BHWi8j25LhTKz/K7fUAlBmZKdkiNlsN8kt8ZDZkr4YCXHIsRu0wrgXBA7Gv5N60h6etBIOlZd3YX59M/OXmFyZJpHKqt2GlZYAD99VjwNSyZpzYl88UTx1VUJr2z/CI6+x3eND4WDWA336mjxYAT2r7/cxCzXrK+bnBP1KW39EjObDe+bnQjZAlBPooUc+MTArNcBseLn+BItbhh8GbuB4U10qbWdLz10heGfXSXiPbz0IbNPxjW37VOiIZZwJbw/TYvhQT+vkzNRlQWjDggjExXZN4ysmfMUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwys/BAtGARBzq5rAygkiIPdNegWDadjuSSJyR27oH4kuzaiECt0QPgflIS/clUBTlHs/x4pT3WCNUj9QwHSUFDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "5D807AB327BA56CF5B43F246822458C89DFECF036872DBFEF6643C143CB26DAA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:KTKS6+VIvVdsHmui4/IDJtjB76z65fqRv2V1KCwaYjM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:4Bn4cf6QN1i7SWfExjvxDkDX8XzHf3F/sE8m9s+pjJk="
+        },
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
+        "randomness": "0",
+        "timestamp": 1682649761831,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAB/7hzVCMAm3SQsXMC+0NhSKNkVca920y+WW3PtIe+uKLHAj6go4LacMnwu6eLq0j3ciSSbYyepe4OFEYbXTrAvppJeCdkJcu3m7pC7I8Oo+KFF99KvaMOc12f+PlBBuIVKuTiCz/zMmWtxYv81BdGcAzalf5TAEnX6vOsM7Jv0AUNSDrcGbUCSjH8Ft1FPSuXOveoUGCPxGD6aaXSCZHbkXm/hDD/ytuTGyOaiCRSMmgQLj+Av/Pk7h/c6zzhvRGASYYAkn6LbE0HptkGtPOLnAC/X9yhV2ArXvz1DhwO35YI16fbym3XPLOeBaHrp5d1K6Vk6v8YN1jLfxElj5+R2EGxKiyoZDr2fEe42X2hWu3GmoxSXK9gD/O1DMXN8s/J1g6xOgNOYpOCGQY0H0ChAImH4Ekuhhe+23gmDDdM0Bm+/dxM/QISVoFGFWtBUeY20xeJ6S/8Dhq+gd34hfqf+1gVv2OjYPxO0H5FmWWrk2qxDe0eV8GmcHjAMoqm9IWiMJxJtZYQAlzaZ4vEWdbxizhJLO5sba3mAZNtda51UmZxj1CUlsHImlsInByo6w+HgIGhIANk7O+YtTebMAqJZiUt4FkKqPGhNxydtLOHM3dlmBhyf672Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwR3pbhGpac05HHzCkzutWL4dFryjyGRNGu/Om1NxfL2ZQfFMS7JAn0K/4hMxp6xACbG13yweDYVn+Z+QXKOxuDg=="
+        }
+      ]
+    }
+  ],
+  "WalletDB loadDecryptedNotes loads decrypted notes less than a given key": [
+    {
+      "version": 2,
+      "id": "937ec484-5e79-4c26-b53a-df313f59ff38",
+      "name": "test",
+      "spendingKey": "40fd5ae9bcc32b232b8c013987dc4ed2885b6a6ad9c916d4684498c6655b3981",
+      "viewKey": "8dd8438467e58bae7aaa0beef45ae6345a7a192541dc34441be3da0a5b0824585f7cc0f2a1560b9224b3f76e76ef017542378efa05d7543029c2a1348ae232bc",
+      "incomingViewKey": "73f90e38c809648774b43e0aa88fa77d3bd0837eb92f2e86193344674fdb9d02",
+      "outgoingViewKey": "b6925f88e159c81dbcf5c7268679b6cec2de231a179f4b9cc6b35d756ae1ba3d",
+      "publicAddress": "5576cbe395d9850901e8dc286df0c98f2c830b5bedf8ad81eafd803778549064",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+XvnBXVD54hH0iAV9xguvJSJvCNKwmT3KWYy/9ZcNgU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ySnDyE5RvMzeK3tRsxVEBQkzX9lWWcHkuKzbmphx1fE="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1682649762668,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAJSXDPXunlZ0+JLD5Gpxjp3zWLRc3jjN04Jm75xGbIa6mc+cpdsr660UnB05jNCMbnU2MufnvJxY9r4TIwQuZdzb1nFCMi0p7cEmPjW3rJfKSc/X/bU+KBlsIsvrOkSnEiXjkYQzt8vUpwFChP7NkNoA3atkUWHc3LATuIp2fqa8Uf3ppj7RQaLLXUOH5sGT6KYRLaW2HxMPSLBuev8ibPDcw4TQG6xVLa6JBnpZkq7yZ/e6TkVg3l7AS8R7WnD7X7LTOmN3GooPZp7ltW2eGowwtzTyUxiMgimUNXUiAbtJS7GkMN6CKR5cFbrl/fGnsivAG9xFKuRNvSta2U90W8VDYowFwr3CIkRhVRpxsUyag1LABLp9zoA+DFFWiVkhVm2oYvu90hjA61uKuC+QbFuUBqRBZopW/KO02migUEN6U8G8mIv49B/6ayLxuuD+Pb4VIbywA8AY/CZDASOurT3z9bFsYQXXClF1pKa+egXYqvU0YbKQANZyuvBao+OkK4Nzr5DSYTewrSZ3aH5Tg0xZseXfmiz2Pho31jROb0Csy61OvlNQgVw4MS2+oV/U4hbHBROl35nQP+NviTLHn1NSTT2W/AxEqTD0oTCWdUfihzGRzqMXqwUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsGM0rUBsphvWbenzT2/XvCi1b2qbj9ZR81vTAzrEfnP1gVAFf7mIeddhxJq7X34wZAJzTXqDk366b9iyc3I5Aw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "F74DD23E886EF8AF9E05973775C1B2B568E9BF86DF5FABEF7003AD611D763E7F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:HVRa4x9kH6xRgvIBw7cvjQF41YUrKjAVhxq2SmZuyhs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:rns0MHgzHI1aqDOIK9SeUsavwyGN/d8JfCy36zc5SEo="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1682649763256,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAqUCAT5UHBbMhDO5EsikJtM+ztLs3LN+dOFRzYhRd1mSmmM4b63Vk2fO0WK+YkvCN18l+wXZ8LCQOFClvZFfimhh8aRNULcoakqGe4s9zJIikqulHp+Xu9yercrTdiDFZrXuVegx6XmDMsqHRV1meZR1g3gSeDfmRQIJY6c3WfvMH4rNW45SAkmpHKZevTHk2j8vSfXg7fc6E/GQTMkdRCklXOu+u6AIaKjlswa2P1OmuaXKyDGSKJCch8+MpNsftH6ryGGIbODXoh7Rg3ifrtNZpYYkgKaXbNE2V31jYkOZ9Vib6MhyEy0JR0z+8QhQALF6w9qTYeJPY364G6ehXbxbIi31gZR2OsRsAY9s58b3uVR6PYhhI92vqXJGNsdoLntU/0WUrB9kk4036Huqc0mSOnuz2dkBkiC140R8qaoe7NttPEe0nLs8JV+YPcE5rA5GfccFAn1zYooP70MXcMIAiiwtpANm2rPk+Nd/aKDuw/YYDGlIX0YxA89r+bpn5n4MDcDB/uOljScuCooP2PXTqtan9EpUFuba6SL8/B+y0YOL8lFNk60piYM9eDGzbKAOqubl7rgZV21U10Lde8o5EWfHDIV8EoYx95HEV9vX7a+Tym6wCK0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLaP+HoXr4UpZv+nSeiwjh7wVFICSht40flE4PorY4A3HkDDNfs4Yr8jAc6fdCv7aPL1XBzNQppPueSyNj7T2BA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "21C737C17D200BBF75D86847C476269B64D6D7AB021A76BC1DB361E4E17C5EC7",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:4BdIpoQEJpHa+Ira35Pd0jS5Po9o5OuAC5iyRYrr8VE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:dCYc3DCyoZEkOIvBHHGsnA6e0A5lZ6Ccf3w7iwAXQyM="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1682649763864,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAJp+lqEzx7i6QlYmvJmfUBcqbVIq3yOKil1l38AgNm6K3X/rKsv5eawFFhJICO3YfJPkJSNqhRWR6TDNB9gIrum3xH4CRb/mTpITsmv3mQsu3+4U7twyHKaBv9RZ+A1CV3VYCf2wk1y9s/lGsgf/JDed0oJmaXzdeCVO1MBRBLpoS0YWxQfbHMG9yFn0TdknmdXX+Z96GaALi7gS6E6iNQOz4zIyjNbKky4H1boJPh0C0ADpzzerNa2osq+bDtZIHrofwyh1s+XB0atPN7KA9Fre77K6leKN9ct35LKOhj+p5GX5xEUgOBKywEZj8BK2yUxp7FnY8RpkstHmWWXsCkU228FqDha/gKIFpKoN+jUjrOiSD3UbJxJkkN/3MI09nCxReeozsJNwkCaxHLEMJtuG5lojlgjpo8V+7Wf0gAbyXDt0XxHn+bZbhdJC51j7ieGhU85j+sCa7Kx8uLWhEWYLTjFaXaGUbA2GzWxZeMfIdC3b97KCF99+VHqd4iM04bbyXv91qQ98iINzqokM2VOe21ieghL5vXe/IgosGxh+3U51OhOaJ0Um1zRJMLyEYYUPqDTyWulF0yrYwuJZJlZj+++vAj+ISyq9l7WbpHZ8QI53SK1QqM0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+KBccY0FnucX6+63g/WhLacmt2UvuudgZE2WSe4Zx5WHZxCIUFGEl3zs5S2PhWGL2CKLNaJSiiOILc08ZvBDAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "813FC47BED49EF3F46DC70E28DEE8B3DFB4889FEB7ACD0E911B0127627D426F8",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:01Xg+YEkRkGPL6x8ocjvI7siDCxLPzcgKyFGjB3+kBg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Qq/7fEnazJDBDE/2dE4InhXOSxMXYxO38BJyufm19n8="
+        },
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
+        "randomness": "0",
+        "timestamp": 1682649764449,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABWP0TatmLWUXRDbaNEClCmtOLp6zK1HNMoe2tPy4eGCvFJ/1FE8jfwtjfDe5Yw+egPrNKjpFze6BGJPR/04mxPC7Y3Hzrb5BGmpSZqJwvVeizJwsI8+QFiSmSKDK5LrdrjA/Uw2PO9B0MyQlFH1SwPckwFLfK1QDdt1LiFh9FNQUELF/cLE7+bMMFwiMXWBu4dPQK4MJIrARH8ni5zYKOBwC//VCkAaZdEkJh+xf6t2ibrpX9K0Jyy+YWVVRiH5etzxzV8PJEwOYxxkLc34gaBLpjKrxkExsizztGWElLtbYThm7/vcJnw/qRZgOfo1DNKUUPZebclCpXLmq3KQXNfZBlLDpjLPIUpXyEDbeCaIRmwgq7nrkEElapxUuYsE71JME6fiev5opzZHgYBBgbiMvQcVFbBeeaNuyszdRa2m+xlDUAR3/uY+FLTKhkC+3wu4UFTGjMRzn9fHnF2qBpLZCg+106suQD+dlmFcFkGK3gxYNSFCvo78qPzXMd0lGtA68xPjFpzknHFyfyWbJ3L/U+LZ6HadMWIbG0chy9SKjIDzCY/++LXtFPLXJBwbsvj5Qg+uOWv4Y+VHCTFwvc3lJKmwYigT+irPKrSv1YwCx4nee3Fs3cklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWyU5WhIV8QRBotzehH6bkQUyK6k0IW30aDixuqlrnioTMhF3j7DemO3FBWeJ5AgFn8vYF5GaFASWSF29avrxAg=="
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- updates loadDecryptedNotes to accept a key range (gte, lt).
- adds BufferUtils for max and min of two nullable buffers to make it easier to construct key ranges with defaults.

## Testing Plan

- adds unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
