### PR TITLE
Return nullifier in rpc notes responses

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -68,6 +68,16 @@ export class NotesCommand extends IronfishCommand {
             get: (row) => CurrencyUtils.renderIron(row.value),
             minWidth: 16,
           },
+          nullifier: {
+            header: 'Nullifier',
+            get: (row) => {
+              if (row.nullifier === null) {
+                return '-'
+              } else {
+                return row.nullifier
+              }
+            },
+          },
         },
         { ...flags, 'no-header': !showHeader },
       )

--- a/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
@@ -18,6 +18,7 @@ export type GetAccountNotesStreamResponse = {
   transactionHash: string
   index: number | null
   spent: boolean | undefined
+  nullifier: string | null
 }
 
 export const GetAccountNotesStreamRequestSchema: yup.ObjectSchema<GetAccountNotesStreamRequest> =
@@ -39,6 +40,7 @@ export const GetAccountNotesStreamResponseSchema: yup.ObjectSchema<GetAccountNot
       transactionHash: yup.string().defined(),
       index: yup.number(),
       spent: yup.boolean(),
+      nullifier: yup.string(),
     })
     .defined()
 
@@ -55,7 +57,7 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
 
       const notes = await account.getTransactionNotes(transaction.transaction)
 
-      for (const { note, spent, index } of notes) {
+      for (const { note, spent, index, nullifier } of notes) {
         if (request.closed) {
           break
         }
@@ -72,6 +74,7 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
           transactionHash: transaction.transaction.hash().toString('hex'),
           index,
           spent,
+          nullifier: nullifier?.toString('hex') || null,
         })
       }
     }


### PR DESCRIPTION
## Summary
Return note nullifier value in the response of wallet/getAccountNotesStream

## Testing Plan
```
yarn start wallet:notes
yarn run v1.22.19
$ yarn build && yarn start:js wallet:notes
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:notes
module: @oclif/core@1.23.1
task: toCached
plugin: ironfish
root: /Users/yajun/ironfish/ironfish/ironfish-cli
See more details with DEBUG=*
(Use `node --trace-warnings ...` to show where the warning was created)
 Memo                             Sender Note Hash From Transaction Spent Asset ID                                                Asset Name                       Amount          Nullifier
 ──────────────────────────────── ────── ───────── ──────────────── ───── ─────────────────────────────────────────────────────── ──────────────────────────────── ─────────────── ─────────
                                  829f0… 2d8065e2… c108441d0cf4071…       51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a5… $IRON                            248.64118285    3e09e5ab…
                                  829f0… 52334d4e… e255c3a09f55488… ✔     51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a5… $IRON                            265.45145393    d749301f…
```
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@hughy 