### PR TITLE
feat(ifl-405): update metrics flush interval to one hour

### DIFF
--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -19,7 +19,7 @@ import { Metric } from './interfaces/metric'
 import { Tag } from './interfaces/tag'
 
 export class Telemetry {
-  private readonly FLUSH_INTERVAL = 5 * 60 * 1000 // 5 minutes
+  private readonly FLUSH_INTERVAL = 60 * 60 * 1000 // 60 minutes
   private readonly MAX_POINTS_TO_SUBMIT = 1000
   private readonly MAX_RETRIES = 5
   private readonly METRICS_INTERVAL = 5 * 60 * 1000 // 5 minutes


### PR DESCRIPTION
## Summary
Collects metrics every 5 minutes, but flushes only once per hour. This should reduce API burden but keep our metrics granular.
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
