### PR TITLE
makes notes from wallet RPCs uniform

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -80,10 +80,6 @@ export class TransactionCommand extends IronfishCommand {
         memo: {
           header: 'Memo',
         },
-        isOwner: {
-          header: 'Owner',
-          get: (note) => (note.isOwner ? `✔` : `x`),
-        },
         owner: {
           header: 'Owner Address',
           get: (note) => note.owner,

--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountNotesStream.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountNotesStream.test.ts.fixture
@@ -1,0 +1,71 @@
+{
+  "Route wallet/getAccountNotesStream streams notes for an account": [
+    {
+      "version": 2,
+      "id": "a9e26894-90b9-43e4-ab78-56c249ceafbf",
+      "name": "test",
+      "spendingKey": "ab6d29746f22afbe94791a234bfa4be2e02eb7e669029a5bbbd98aa3c89d7f80",
+      "viewKey": "1db8f7d857cfdb49ffdaa2f7492c4f8a1eb39560f7e3245a7213c84299e83267e81b0830ed30c1531da572b748a0cf97345e770a481288951fc578d70da7bf27",
+      "incomingViewKey": "593a8410c2fc30d8cbff43ee41bd1e1496c260f54f5524c941ef6422282d9806",
+      "outgoingViewKey": "ff9885a6a5c51cf6cca35aa0d34bc2367bc7f047a2c8daaa6cb48bebedffa6cf",
+      "publicAddress": "f937cae424771036d9954ff6a4758899907ccc953a27e33d5e8831e57e0663bd",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:cNulTAMcbjKETjslg/11g+GoQg1HTlpAXC82OL7Bl0o="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:9ZbgdlJdDdmdQbdHpVGmW3TwU3d5WBBqiV+PVsKJ3Uo="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1683152080446,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA2R+wdGK5MXrYTGi7SIYDEWkVpKMy7feKiTZM1c2/z4aq4kZnCpKWBYQVCbVZsgFDb0c7SW1dT+Vm2HnAn03DMMXYGWlLF2tW3/0RZL+5xT2LaXmqC0D9+HZYOy3jKccgkd+PfuJyAJIiNdc/JyezdE18AoJ0UZ4mwLpe47jqhqYZQXGweyvoEikj/QwOwg/LWf0P3QtlIc1uRUTEP4wAertkcRp3PyW9C1mRvNF6zWmWOSpOVHQbHcEnjkfIIwLaf/utcMuEFTJUvr5i6y+iQ8AzDW6nJhRCn58hPxUfSa0/qbj52v3l8QyuSZ9k0AtExg1kj5q83MGNzdtTUaCPcE88TM2fej+PVZRfbYMlLJNET90MV0CXx1FWMrcrhLoMV1hMRvYH9zF7eLB4WRLpGqrxUbUHNlhqobVar86iOM+zEaDV8ogKG7SnqJJZrbkLF6wGWsPxnYFZfxNm9RpgvUCCJgofgYRgxQ19McA3ig8pXur6J1Z9HKDS7QHn6Tu6UOLSW43T6qUqicDwwVWK7nysRZlWjbpFfj3gFF3mkNPwPNj3aWOtKjRCFcj4vMWVP09ktK6tWAc87msilQC48w5ZsulfedZg6CuujRAeppZJwGDIamDaiklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw7vdOShDBve3zbEbVIVlr23u+YsdXfILByQN8m7JSVTFuxpsRBArucaRi8RJfI2/Sbj6XVOI+SUc7JwQ5vDfXCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "5E467B65E4D4356236B3AE300FF67E36742B67A08166E209F0DA2530FAAF7489",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:F2ys/j26ErO4om1/XgOopcn0yb6dAkmBX+Q71RxonBA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:rNW771BxUwit4YlVrejDTAM84sybBZkCtNioTFGVOyc="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1683152083475,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAarlPU9jRyYzvkePTqTqh5Ke9WeLC1b4bzL2+XMiwb5esb0wxmZlKl0kKO04zxSu8mKlmJD/F3I31iQr+lYIomMINQNdvuCpy3h2Bp6l+Kr2xaFkcKgArI/ycgeuM/Utg4Q/SB8wNxe0kvpI9jZDznSZxyegswXEJ49x4QypIR8QTE9nYvaTeFrHwDhdBbszhA+pB+v/HoXvQuV/h2tam4Xyi1n7qEwe6uBLVu2SxipqmIVAN2sx1IlRBJuQG6BTW4otjap+2kND6p5i1tqtIfgqfhi7GlR/7StgDKdmAy6ayXm4pku+wJKjJ/xP/WaVzHYRtWk20M2ax9yUe5DPBV8YwnTV4ZQU/2ZlcE4X7vGWss2080hLfMnuDV00uNjkG7wqXaDq9l8f5H+ZN/k7IUZVMkBXKQa0dR1Q95CN0J/Bwh47yRmo652xuNVIcJdOfpKIdSyORaM5s+BgbTXeng8s6rAMoP6WS3C9x+HzQa8TWWbnnaFx9GhsNwPMlrkCYO41QKSIxeLhkxDta1jEGaPiT/Rwe4j+KjtIB9FGlAGSFDCGWPqsfUYB38dfvOkTezBNzdUlFjGWcwG0HoeFEfLqvXYaHLN7xh/CzzUVsXBG2SXt4wgIOu0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOQaRvoI1IpuXtiYVbf67G0POjB6rT6vdEXM0tXVrEjG6giJTBxNSYJmBw5PjE0WLbrPTBrO3AcMVyY1Tl4k7Ag=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAtpOr5duYn8AfIgP8yEq57EbewWvft8hLBtE9BSJP9N+1vxs0+hDPkaKecxBQnofdgU1VRMYWmDDWbQkWV/syzMT+mhOZN7//gP6OUiBnCTaiBpZDd8Rmav1KRDF6BJgrTN0zhMYIKRnYnzhZ0xUE4uf4BaIIFQo7hrVQ4TMlugkU97GhJdPljo7BfPcssVw1T7WqhedR3hfZNbJIgX+NUuBD8zT1aUDtH6f7twnUcGuPNtvbpDh/BFRv/QL/ihQ8sO+rcd1qXURDzaTQyOR104ws+8p83ykE7MQ0b9XPRA+UiYrsIIbJXTDifXgvmc82VH4WGqayvn/4UaE+W1afZXDbpUwDHG4yhE47JYP9dYPhqEINR05aQFwvNji+wZdKBAAAAEiUH7AklA6FV67XljwyOLxnTv2utoN5nuDj3SO+6xl0XzsWX6aQJ98tJ1r9xfnlMhRH7reaOyAcFSYd/dvZzplmpGAxmZuV+3x3e6dx99R+wHSBOvmgVNBQoNhfzmx1CYMI6Bu8uBzFssjqm9aBudvBPybP80w4sg/80tqWfTgo7S0ZsgGp61W6snuqw/KgGrZxRNeK2fRi4i43tr2kwluvRyDRx8O9mBemyypIEy9gWpUt/Ba611PzIN/gU11QdgEaixrCKqAYM7APC9HTEv+OYZO4H7ZuxTLfQTLU3a7cvqZLw95fjcMMQrcLkkcVt7VeB2xppLxY2BUU2hreo393UMmBaWcCAAw01uvb6bVAuPCxaQXkX0rJH7VboFGwdoPVB4rBVdPAgK8s9ytkvioTlIZHpHBfZYqXaGba2OuBz8GaqLTewdaWM1fCfvVfAC4t5fWI67HEY//yUepizjUIcDbr4Ss0HLchY2iluYevCZ+msnb30dbSe4ZwuuX1nKKIQJga4KbwfglLpM+C/7r8CxgIuTpFD3YUx8xh4DcYFe9ALjw3YJob+inJLmnf43tHoxi6MeRfwZj98o0T/qeOnb2XqPaTjVYuBTaCyt1zm4cm70o0WP27FlX+lwArAsxJnXHEWDHNQB2EzDFOO+P9HHcmLNDtngL2sxA2kM8KmaHIDzp1COfkyeaFmnqW1Gc1jY/wQKXd10PK33bXx39eKGvBUotGE9Vr+3tiVNrVCmWgCX5lBqEQ4FSKNGHJClauaP+Zutj05KQe3Emo3gix6yixKcjq7SmPyJewCb6l/5gCFXQp46aCzLud8DSX4vOeW5NoNFqPXCbjvsnKTOlhZeWD4IBGi5C7Q9I228ety1o8sx8cJzymyCMECtkAbBDo4JSySd5CcY5/qyfZTJDFg6h/Tzzhquh/+52RIjSGy77EhYsp+HMFppsQxWLYC5Ak0mXlRHsMuV7iNG2UcpYl3RGFYWJ8d5k6LFVaIxTMNozg5GKbCUuhlllYQMVsSGzPNzhay+oRGPk48SAA6lV+dQ2nsTP9b5Imx8Ii1xvZLT09Z0d5TxYek1Vcyz20Lts53hdluvmFHMk797ixFEyerdbMFTE0zjmVqiM7enbrwUAsc3jooV9cXU2P6lULV86V+WrgmpgkVVqHa9nDoNuo6I/lE5t0UTASeWU8e7w1EHvewe+7M3L3NYIKid+AC9T91ek05/k4k2Kj89HDuJ8KCKOm5qIApHu928xiTeB4q9VYH48PHD7O+xkefo2Y07vxhzU8AILj28/MKIMSK+YjJp+Z6O161MpXw3yspi/7ozy4IZgUfHRKh8iSK/GLM54NwHM6YqnxQ7XR0X+81L0aG2IPjgZeVoxEZ8cb9xh9bM2x7iFBW952UID93OdMt5hLxQj52J4+4o9BIE/mHdXxuARNDfskAeOYsZab037GrUm+91l/rgtvwPmNAEW3t4vADCCyvzkw9gCRqFnUefE9gIXbq7y5ka2zCCHrtdwjjKqDuXIEQDwZtXw5HnHPKIHCVYxj+6yAoHr3Xtd7hA9Lk0keFgKIrsKNf39T+g9aYMya9yLJdmigNf05I7fRCQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/wallet/getAccountNotesStream.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountNotesStream.test.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { BufferMap } from 'buffer-map'
+import { Assert } from '../../../assert'
+import { useAccountFixture, useBlockWithTx } from '../../../testUtilities'
+import { createRouteTest } from '../../../testUtilities/routeTest'
+import { AsyncUtils, CurrencyUtils } from '../../../utils'
+import { DecryptedNoteValue } from '../../../wallet/walletdb/decryptedNoteValue'
+
+describe('Route wallet/getAccountNotesStream', () => {
+  const routeTest = createRouteTest(true)
+
+  it('streams notes for an account', async () => {
+    const node = routeTest.node
+    const account = await useAccountFixture(node.wallet)
+
+    const { previous, block, transaction } = await useBlockWithTx(node, account, account)
+    await expect(node.chain).toAddBlock(block)
+    await node.wallet.updateHead()
+
+    const response = routeTest.client.wallet.getAccountNotesStream({
+      account: account.name,
+    })
+
+    const expectedNotesByHash: BufferMap<DecryptedNoteValue> =
+      new BufferMap<DecryptedNoteValue>()
+
+    // account will have notes from previous, the block used to fund the
+    // transaction, and from the transaction
+    for (const note of [...previous.transactions[0].notes, ...transaction.notes]) {
+      const decryptedNote = await account.getDecryptedNote(note.hash())
+
+      Assert.isNotUndefined(decryptedNote)
+
+      expectedNotesByHash.set(note.hash(), decryptedNote)
+    }
+
+    const notes = await AsyncUtils.materialize(response.contentStream())
+    expect(notes).toHaveLength(expectedNotesByHash.size)
+
+    for (const note of notes) {
+      const expectedNote = expectedNotesByHash.get(Buffer.from(note.noteHash, 'hex'))
+
+      Assert.isNotUndefined(expectedNote)
+
+      expect(note.value).toEqual(CurrencyUtils.encode(expectedNote.note.value()))
+      expect(note.assetId).toEqual(expectedNote.note.assetId().toString('hex'))
+      expect(note.memo).toEqual(expectedNote.note.memo())
+      expect(note.sender).toEqual(expectedNote.note.sender())
+      expect(note.owner).toEqual(expectedNote.note.owner())
+      expect(note.noteHash).toEqual(expectedNote.note.hash().toString('hex'))
+      expect(note.transactionHash).toEqual(expectedNote.transactionHash.toString('hex'))
+      expect(note.index).toEqual(expectedNote.index)
+      expect(note.nullifier).toEqual(expectedNote.nullifier?.toString('hex'))
+      expect(note.spent).toEqual(expectedNote.spent)
+      expect(note.isOwner).toBe(true)
+      expect(note.hash).toEqual(expectedNote.note.hash().toString('hex'))
+    }
+  })
+})

--- a/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
@@ -4,22 +4,12 @@
 import * as yup from 'yup'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
+import { RpcWalletNote, RpcWalletNoteSchema } from './types'
 import { getAccount } from './utils'
 
 export type GetAccountNotesStreamRequest = { account?: string }
 
-export type GetAccountNotesStreamResponse = {
-  value: string
-  assetId: string
-  assetName: string
-  memo: string
-  sender: string
-  noteHash: string
-  transactionHash: string
-  index: number | null
-  spent: boolean | undefined
-  nullifier: string | null
-}
+export type GetAccountNotesStreamResponse = RpcWalletNote
 
 export const GetAccountNotesStreamRequestSchema: yup.ObjectSchema<GetAccountNotesStreamRequest> =
   yup
@@ -29,20 +19,7 @@ export const GetAccountNotesStreamRequestSchema: yup.ObjectSchema<GetAccountNote
     .defined()
 
 export const GetAccountNotesStreamResponseSchema: yup.ObjectSchema<GetAccountNotesStreamResponse> =
-  yup
-    .object({
-      value: yup.string().defined(),
-      assetId: yup.string().defined(),
-      assetName: yup.string().defined(),
-      memo: yup.string().trim().defined(),
-      sender: yup.string().defined(),
-      noteHash: yup.string().defined(),
-      transactionHash: yup.string().defined(),
-      index: yup.number(),
-      spent: yup.boolean(),
-      nullifier: yup.string(),
-    })
-    .defined()
+  RpcWalletNoteSchema
 
 router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStreamResponse>(
   `${ApiNamespace.wallet}/getAccountNotesStream`,
@@ -68,13 +45,16 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
           value: CurrencyUtils.encode(note.value()),
           assetId: note.assetId().toString('hex'),
           assetName: asset?.name.toString('hex') || '',
-          noteHash: note.hash().toString('hex'),
           memo: note.memo(),
           sender: note.sender(),
+          owner: note.owner(),
+          noteHash: note.hash().toString('hex'),
           transactionHash: transaction.transaction.hash().toString('hex'),
           index,
           spent,
           nullifier: nullifier?.toString('hex') || null,
+          isOwner: true,
+          hash: note.hash().toString('hex'),
         })
       }
     }

--- a/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { TransactionStatus, TransactionType } from '../../../wallet'
 import { ApiNamespace, router } from '../router'
-import { RpcAccountDecryptedNote, RpcSpend, RpcSpendSchema } from './types'
+import { RpcSpend, RpcSpendSchema, RpcWalletNote, RpcWalletNoteSchema } from './types'
 import {
   getAccount,
   getAccountDecryptedNotes,
@@ -35,7 +35,7 @@ export type GetAccountTransactionResponse = {
     timestamp: number
     submittedSequence: number
     assetBalanceDeltas: Array<{ assetId: string; assetName: string; delta: string }>
-    notes: RpcAccountDecryptedNote[]
+    notes: RpcWalletNote[]
     spends: RpcSpend[]
   } | null
 }
@@ -79,23 +79,7 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
                 .defined(),
             )
             .defined(),
-          notes: yup
-            .array(
-              yup
-                .object({
-                  isOwner: yup.boolean().defined(),
-                  owner: yup.string().defined(),
-                  value: yup.string().defined(),
-                  assetId: yup.string().defined(),
-                  assetName: yup.string().defined(),
-                  sender: yup.string().defined(),
-                  memo: yup.string().trim().defined(),
-                  spent: yup.boolean(),
-                  hash: yup.string().defined(),
-                })
-                .defined(),
-            )
-            .defined(),
+          notes: yup.array(RpcWalletNoteSchema).defined(),
           spends: yup.array(RpcSpendSchema).defined(),
         })
         .defined(),

--- a/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
@@ -9,7 +9,7 @@ import { Account } from '../../../wallet/account'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { RpcRequest } from '../../request'
 import { ApiNamespace, router } from '../router'
-import { RpcAccountDecryptedNote, RpcSpend, RpcSpendSchema } from './types'
+import { RpcSpend, RpcSpendSchema, RpcWalletNote, RpcWalletNoteSchema } from './types'
 import {
   getAccount,
   getAccountDecryptedNotes,
@@ -44,7 +44,7 @@ export type GetAccountTransactionsResponse = {
   timestamp: number
   submittedSequence: number
   assetBalanceDeltas: Array<{ assetId: string; assetName: string; delta: string }>
-  notes?: RpcAccountDecryptedNote[]
+  notes?: RpcWalletNote[]
   spends?: RpcSpend[]
 }
 
@@ -90,21 +90,7 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
             .defined(),
         )
         .defined(),
-      notes: yup.array(
-        yup
-          .object({
-            isOwner: yup.boolean().defined(),
-            owner: yup.string().defined(),
-            value: yup.string().defined(),
-            assetId: yup.string().defined(),
-            assetName: yup.string().defined(),
-            sender: yup.string().defined(),
-            memo: yup.string().trim().defined(),
-            spent: yup.boolean(),
-            hash: yup.string().defined(),
-          })
-          .defined(),
-      ),
+      notes: yup.array(RpcWalletNoteSchema).defined(),
       spends: yup.array(RpcSpendSchema).defined(),
     })
     .defined()

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -24,17 +24,45 @@ export type RcpAccountAssetBalanceDelta = {
   delta: string
 }
 
-export type RpcAccountDecryptedNote = {
-  isOwner: boolean
+export type RpcWalletNote = {
   value: string
   assetId: string
   assetName: string
   memo: string
   sender: string
   owner: string
+  noteHash: string
+  transactionHash: string
+  index: number | null
+  nullifier: string | null
   spent: boolean
+  /**
+   * @deprecated Please use `owner` address instead
+   */
+  isOwner: boolean
+  /**
+   * @deprecated Please use `noteHash` instead
+   */
   hash: string
 }
+
+export const RpcWalletNoteSchema: yup.ObjectSchema<RpcWalletNote> = yup
+  .object({
+    value: yup.string().defined(),
+    assetId: yup.string().defined(),
+    assetName: yup.string().defined(),
+    memo: yup.string().defined(),
+    sender: yup.string().defined(),
+    owner: yup.string().defined(),
+    noteHash: yup.string().defined(),
+    transactionHash: yup.string().defined(),
+    index: yup.number(),
+    nullifier: yup.string(),
+    spent: yup.boolean().defined(),
+    isOwner: yup.boolean().defined(),
+    hash: yup.string().defined(),
+  })
+  .defined()
 
 export type RpcSpend = {
   nullifier: string

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -8,11 +8,7 @@ import { Account } from '../../../wallet'
 import { DecryptedNoteValue } from '../../../wallet/walletdb/decryptedNoteValue'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { ValidationError } from '../../adapters'
-import {
-  RcpAccountAssetBalanceDelta,
-  RpcAccountDecryptedNote,
-  RpcAccountTransaction,
-} from './types'
+import { RcpAccountAssetBalanceDelta, RpcAccountTransaction, RpcWalletNote } from './types'
 
 export function getAccount(node: IronfishNode, name?: string): Account {
   if (name) {
@@ -138,24 +134,31 @@ export async function getAccountDecryptedNotes(
   node: IronfishNode,
   account: Account,
   transaction: TransactionValue,
-): Promise<RpcAccountDecryptedNote[]> {
+): Promise<RpcWalletNote[]> {
   const notes = await getTransactionNotes(node, account, transaction)
 
-  const serializedNotes: RpcAccountDecryptedNote[] = []
+  const serializedNotes: RpcWalletNote[] = []
+
   for await (const decryptedNote of notes) {
-    const isOwner = decryptedNote.note.owner() === account.publicAddress
     const asset = await node.chain.getAssetById(decryptedNote.note.assetId())
     const note = decryptedNote.note
 
+    const index = decryptedNote.index ?? null
+    const nullifier = decryptedNote.nullifier
+
     serializedNotes.push({
-      isOwner,
-      owner: note.owner(),
-      memo: note.memo(),
       value: CurrencyUtils.encode(note.value()),
       assetId: note.assetId().toString('hex'),
       assetName: asset?.name.toString('hex') || '',
+      memo: note.memo(),
       sender: note.sender(),
+      owner: note.owner(),
+      noteHash: note.hash().toString('hex'),
+      transactionHash: transaction.transaction.hash().toString('hex'),
+      index,
+      nullifier: nullifier?.toString('hex') ?? null,
       spent: decryptedNote.spent,
+      isOwner: note.owner() === account.publicAddress,
       hash: note.hash().toString('hex'),
     })
   }

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -143,9 +143,6 @@ export async function getAccountDecryptedNotes(
     const asset = await node.chain.getAssetById(decryptedNote.note.assetId())
     const note = decryptedNote.note
 
-    const index = decryptedNote.index ?? null
-    const nullifier = decryptedNote.nullifier
-
     serializedNotes.push({
       value: CurrencyUtils.encode(note.value()),
       assetId: note.assetId().toString('hex'),
@@ -155,8 +152,8 @@ export async function getAccountDecryptedNotes(
       owner: note.owner(),
       noteHash: note.hash().toString('hex'),
       transactionHash: transaction.transaction.hash().toString('hex'),
-      index,
-      nullifier: nullifier?.toString('hex') ?? null,
+      index: decryptedNote.index ?? null,
+      nullifier: decryptedNote.nullifier?.toString('hex') ?? null,
       spent: decryptedNote.spent,
       isOwner: note.owner() === account.publicAddress,
       hash: note.hash().toString('hex'),


### PR DESCRIPTION
## Summary

defines a single RpcWalletNote type and schema, reuses across three wallet endpoints that return note data.

adds owner, index, nullifier, noteHash, and transactionHash fields to notes returned in transaction endpoints for consistency.

marks 'hash' field as deprecated. transaction endpoints used 'hash' and notes endpoint uses 'noteHash'.

marks 'isOwner' field as deprecated. this isn't very useful if the note contains the owner address. if clients need to compare the owner address to the public address for an account this is better done on the client side than the rpc.

## Testing Plan

existing unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
