### PR TITLE
Remove graffiti from the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -37,8 +37,3 @@ body:
       label: Relevant log output
       description: Please copy and paste any relevant log output, like the command you entered and the logs leading up to the error. This will be automatically formatted into code, so no need for backticks.
       render: shell
-  - type: input
-    id: graffiti
-    attributes:
-      label: Graffiti
-      description: Please copy and paste your graffiti.


### PR DESCRIPTION
## Summary

Graffiti isn't really relevant to bug reporting anymore now that the incentivized testnet has concluded.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
