### PR TITLE
Add incoming peer whitelist by IP

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -268,6 +268,11 @@ export type ConfigOptions = {
   memPoolRecentlyEvictedCacheSize: number
 
   networkDefinitionPath: string
+
+  /**
+   * Always allow incoming connections from these IPs even if the node is at maxPeers
+   */
+  incomingWebSocketWhitelist: string[]
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -343,6 +348,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
       .min(20 * MEGABYTES),
     memPoolRecentlyEvictedCacheSize: yup.number().integer(),
     networkDefinitionPath: yup.string().trim(),
+    incomingWebSocketWhitelist: yup.array(yup.string().trim().defined()),
   })
   .defined()
 
@@ -432,6 +438,7 @@ export class Config extends KeyStore<ConfigOptions> {
       memPoolMaxSizeBytes: 60 * MEGABYTES,
       memPoolRecentlyEvictedCacheSize: 60000,
       networkDefinitionPath: files.resolve(files.join(dataDir, 'network.json')),
+      incomingWebSocketWhitelist: [],
     }
   }
 }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -102,6 +102,7 @@ export class PeerNetwork {
   private readonly networkId: number
   // optional WebSocket server, started from Node.JS
   private webSocketServer?: WebSocketServer
+  private readonly incomingWebSocketWhitelist: string[]
 
   readonly localPeer: LocalPeer
   readonly peerManager: PeerManager
@@ -169,6 +170,7 @@ export class PeerNetwork {
     node: IronfishNode
     chain: Blockchain
     hostsStore: HostsStore
+    incomingWebSocketWhitelist?: string[]
   }) {
     this.networkId = options.networkId
     this.enableSyncing = options.enableSyncing ?? true
@@ -178,6 +180,7 @@ export class PeerNetwork {
     this.metrics = options.metrics || new MetricsMonitor({ logger: this.logger })
     this.telemetry = options.telemetry
     this.bootstrapNodes = options.bootstrapNodes || []
+    this.incomingWebSocketWhitelist = options.incomingWebSocketWhitelist || []
 
     this.localPeer = new LocalPeer(
       options.identity,
@@ -279,7 +282,21 @@ export class PeerNetwork {
       this.webSocketServer.onConnection((connection, req) => {
         let address: string | null = null
 
-        if (this.peerManager.shouldRejectDisconnectedPeers()) {
+        if (req.headers['X-Forwarded-For'] && req.headers['X-Forwarded-For'][0]) {
+          address = req.headers['X-Forwarded-For'][0]
+        } else if (req.socket.remoteAddress) {
+          address = req.socket.remoteAddress
+        }
+
+        if (address) {
+          // Some times local peers connect on IPV6 incompatible addresses like
+          // '::ffff:127.0.0.1' and we don't support connecting over IPv6 right now
+          address = address.replace('::ffff:', '')
+        }
+
+        const isWhitelisted = address && this.incomingWebSocketWhitelist.includes(address)
+
+        if (this.peerManager.shouldRejectDisconnectedPeers() && !isWhitelisted) {
           this.logger.debug(
             'Disconnecting inbound websocket connection because the node has max peers',
           )
@@ -293,18 +310,6 @@ export class PeerNetwork {
           connection.send(disconnect.serializeWithMetadata())
           connection.close()
           return
-        }
-
-        if (req.headers['X-Forwarded-For'] && req.headers['X-Forwarded-For'][0]) {
-          address = req.headers['X-Forwarded-For'][0]
-        } else if (req.socket.remoteAddress) {
-          address = req.socket.remoteAddress
-        }
-
-        if (address) {
-          // Some times local peers connect on IPV6 incompatible addresses like
-          // '::ffff:127.0.0.1' and we don't support connecting over IPv6 right now
-          address = address.replace('::ffff:', '')
         }
 
         this.peerManager.createPeerFromInboundWebSocketConnection(connection, address)

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -142,6 +142,7 @@ export class IronfishNode {
       hostsStore: hostsStore,
       logger: logger,
       telemetry: this.telemetry,
+      incomingWebSocketWhitelist: config.getArray('incomingWebSocketWhitelist'),
     })
 
     this.wallet.onTransactionCreated.on((transaction) => {


### PR DESCRIPTION
## Summary
In order to bypass the maxPeers config for incoming connections a whitelist for incoming Websocket connections needs to be added.

## Testing Plan
Tested on local node

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
