### PR TITLE
Fix Windows chain:download by closing DB before deleting

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -237,9 +237,11 @@ export default class Download extends IronfishCommand {
     const chainDatabasePath = this.sdk.fileSystem.resolve(this.sdk.config.chainDatabasePath)
 
     // chainDatabasePath must be empty before unzipping snapshot
+    // chain DB must be closed before deleting it (fixes an error on Windows)
     CliUx.ux.action.start(
       `Removing existing chain data at ${chainDatabasePath} before importing snapshot`,
     )
+    await node.closeDB()
     await fsAsync.rm(chainDatabasePath, { recursive: true, force: true, maxRetries: 10 })
     CliUx.ux.action.stop('done')
 


### PR DESCRIPTION
## Summary

chain:download on Windows was erroring out with the following error:

```
Error: EBUSY: resource busy or locked, unlink 'C:\Users\dguen\.ironfish\databases\chain\000015.ldb'
Removing existing chain data at C:\Users\dguen\.ironfish\databases\chain before importing snapshot... !
```

This change fixes the error by closing the DB before deleting it.

Fixes IFL-827
Fixes #3843

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
