### PR TITLE
adds support for `RpcHttpAdapter` in `rpc/getStatus` route

### DIFF
--- a/ironfish/src/metrics/index.ts
+++ b/ironfish/src/metrics/index.ts
@@ -4,3 +4,4 @@
 export * from './meter'
 export * from './metricsMonitor'
 export * from './ewmAverage'
+export * from './gauge'

--- a/ironfish/src/rpc/adapters/httpAdapter.ts
+++ b/ironfish/src/rpc/adapters/httpAdapter.ts
@@ -178,9 +178,10 @@ export class RpcHttpAdapter implements IRpcAdapter {
       `Call HTTP RPC: ${request.method || 'undefined'} ${request.url || 'undefined'}`,
     )
 
-    // TODO(daniel): better way to parse method from request here
-    const url = new URL(request.url, `http://${request.headers.host || 'localhost'}`)
-    const route = url.pathname.substring(1)
+    const route = this.formatRoute(request)
+    if (route === undefined) {
+      throw new ResponseError('No route found')
+    }
 
     // TODO(daniel): clean up reading body code here a bit of possible
     let size = 0
@@ -243,5 +244,14 @@ export class RpcHttpAdapter implements IRpcAdapter {
     currRequest && this.requests.set(requestId, { ...currRequest, rpcRequest })
 
     await router.route(route, rpcRequest)
+  }
+
+  // TODO(daniel): better way to parse method from request here
+  formatRoute(request: http.IncomingMessage): string | undefined {
+    if (!request.url) {
+      return
+    }
+    const url = new URL(request.url, `http://${request.headers.host || 'localhost'}`)
+    return url.pathname.substring(1)
   }
 }

--- a/ironfish/src/rpc/routes/rpc/getStatus.ts
+++ b/ironfish/src/rpc/routes/rpc/getStatus.ts
@@ -126,13 +126,10 @@ async function getRpcStatus(node: IronfishNode): Promise<GetRpcStatusResponse> {
       formatted.writtenBytes = adapter.outboundBytes.value
 
       adapter.requests.forEach((r) => {
-        if (!r.req.url) {
-          return
+        const route = adapter.formatRoute(r.req)
+        if (route) {
+          formatted.pending.push(route)
         }
-        const url = new URL(r.req.url, `http://${r.req.headers.host || 'localhost'}`)
-        const route = url.pathname.substring(1)
-
-        formatted.pending.push(route)
       })
 
       if (adapter.server) {

--- a/ironfish/src/rpc/routes/rpc/getStatus.ts
+++ b/ironfish/src/rpc/routes/rpc/getStatus.ts
@@ -3,7 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { IronfishNode } from '../../../node'
-import { RpcIpcAdapter } from '../../adapters'
+import { PromiseUtils } from '../../../utils'
+import { RpcHttpAdapter, RpcIpcAdapter } from '../../adapters'
 import { RpcSocketAdapter } from '../../adapters/socketAdapter/socketAdapter'
 import { ApiNamespace, router } from '../router'
 
@@ -61,8 +62,8 @@ export const GetRpcStatusResponseSchema: yup.ObjectSchema<GetRpcStatusResponse> 
 router.register<typeof GetRpcStatusRequestSchema, GetRpcStatusResponse>(
   `${ApiNamespace.rpc}/getStatus`,
   GetRpcStatusRequestSchema,
-  (request, node): void => {
-    const jobs = getRpcStatus(node)
+  async (request, node): Promise<void> => {
+    const jobs = await getRpcStatus(node)
 
     if (!request.data?.stream) {
       request.end(jobs)
@@ -71,25 +72,26 @@ router.register<typeof GetRpcStatusRequestSchema, GetRpcStatusResponse>(
 
     request.stream(jobs)
 
-    const interval = setInterval(() => {
-      const jobs = getRpcStatus(node)
+    while (!request.closed) {
+      const jobs = await getRpcStatus(node)
       request.stream(jobs)
-    }, 1000)
-
-    request.onClose.on(() => {
-      clearInterval(interval)
-    })
+      await PromiseUtils.sleep(1000)
+    }
   },
 )
 
-function getRpcStatus(node: IronfishNode): GetRpcStatusResponse {
+async function getRpcStatus(node: IronfishNode): Promise<GetRpcStatusResponse> {
   const result: GetRpcStatusResponse = {
     started: node.rpc.isRunning,
     adapters: [],
   }
 
   for (const adapter of node.rpc.adapters) {
-    if (!(adapter instanceof RpcIpcAdapter) && !(adapter instanceof RpcSocketAdapter)) {
+    if (
+      !(adapter instanceof RpcIpcAdapter) &&
+      !(adapter instanceof RpcSocketAdapter) &&
+      !(adapter instanceof RpcHttpAdapter)
+    ) {
       continue
     }
 
@@ -117,6 +119,37 @@ function getRpcStatus(node: IronfishNode): GetRpcStatusResponse {
       formatted.inbound = Math.max(adapter.inboundTraffic.rate1s, 0)
       formatted.outbound = Math.max(adapter.outboundTraffic.rate1s, 0)
       formatted.clients = adapter.clients.size
+    } else if (adapter instanceof RpcHttpAdapter) {
+      formatted.inbound = Math.max(adapter.inboundTraffic.rate1s, 0)
+      formatted.outbound = Math.max(adapter.outboundTraffic.rate1s, 0)
+      formatted.readBytes = adapter.inboundBytes.value
+      formatted.writtenBytes = adapter.outboundBytes.value
+
+      adapter.requests.forEach((r) => {
+        if (!r.req.url) {
+          return
+        }
+        const url = new URL(r.req.url, `http://${r.req.headers.host || 'localhost'}`)
+        const route = url.pathname.substring(1)
+
+        formatted.pending.push(route)
+      })
+
+      if (adapter.server) {
+        const [promise, resolve] = PromiseUtils.split<number>()
+        adapter.server.getConnections((err, count) => {
+          if (err) {
+            resolve(0)
+            return
+          }
+          resolve(count)
+        })
+
+        formatted.clients = await promise
+      }
+
+      // TODO: there is no equivalent of readableLength or writableLength for HTTP.
+      // For now, readableLength and writableLength will be set to 0
     }
 
     result.adapters.push(formatted)


### PR DESCRIPTION
## Summary
This adds support for outputting `RpcHttpAdapter` status under the `rpc/getStatus` route

## Testing Plan
Output of `ironfish rpc:status -f`

```
STARTED: true

[RpcIpcAdapter]
Clients:          2
Requests Pending: 2
Routes Pending:   node/getStatus, rpc/getStatus
Inbound Traffic:  0 B/s
Outbound Traffic: 2.99 KiB/s
Outbound Total:   170.76 KiB
Inbound Total:    190 B
RW Backlog:       0 B / 0 B

[RpcHttpAdapter]
Clients:          2
Requests Pending: 2
Routes Pending:   mempool/getStatus, rpc/getStatus
Inbound Traffic:  0 B/s
Outbound Traffic: 788 B/s
Outbound Total:   23.11 KiB
Inbound Total:    66 B
RW Backlog:       0 B / 0 B
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
[X] No
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
