### PR TITLE
Add peer identity to status command

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -113,8 +113,6 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
     telemetryStatus += ` - ${content.telemetry.submitted} <- ${content.telemetry.pending} pending`
   }
 
-  const nodeName = `${content.node.nodeName}`
-
   const blockGraffiti = `${content.miningDirector.blockGraffiti}`
 
   const network =
@@ -202,7 +200,8 @@ function renderStatus(content: GetNodeStatusResponse, debugOutput: boolean): str
   return `\
 Version              ${content.node.version} @ ${content.node.git}
 Node                 ${nodeStatus}
-Node Name            ${nodeName}
+Node Name            ${content.node.nodeName}
+Peer ID              ${content.peerNetwork.publicIdentity}
 Block Graffiti       ${blockGraffiti}
 Network              ${network}
 Memory               ${memoryStatus}

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -74,6 +74,7 @@ export type GetNodeStatusResponse = {
     isReady: boolean
     inboundTraffic: number
     outboundTraffic: number
+    publicIdentity: string
   }
   telemetry: {
     status: 'started' | 'stopped'
@@ -180,6 +181,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetNodeStatusResponse> = 
         isReady: yup.boolean().defined(),
         inboundTraffic: yup.number().defined(),
         outboundTraffic: yup.number().defined(),
+        publicIdentity: yup.string().defined(),
       })
       .defined(),
     blockSyncer: yup
@@ -276,6 +278,7 @@ function getStatus(node: IronfishNode): GetNodeStatusResponse {
       isReady: node.peerNetwork.isReady,
       inboundTraffic: Math.max(node.metrics.p2p_InboundTraffic.rate1s, 0),
       outboundTraffic: Math.max(node.metrics.p2p_OutboundTraffic.rate1s, 0),
+      publicIdentity: node.peerNetwork.localPeer.publicIdentity,
     },
     blockchain: {
       synced: node.chain.synced,


### PR DESCRIPTION
## Summary
Peer ID isn't available through any RPC endpoint or CLI command currently. Exposing that here

## Testing Plan
Local testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

https://github.com/iron-fish/website/pull/442

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
