### PR TITLE
WIP allows witness creation at a given tree size

### DIFF
--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -5969,24 +5969,24 @@
   "Accounts createTransaction should create transactions with spends valid after a reorg": [
     {
       "version": 2,
-      "id": "ec8564f7-f717-42b3-b08b-98c873eba3bc",
+      "id": "fcbd3064-d5c0-4532-a31e-71a7a2056e42",
       "name": "a",
-      "spendingKey": "73882782b43a9cbf53a3c36c37d6713619faaf2392b5aa8b3c7af4412d2a30f1",
-      "viewKey": "d02dea9f3000828f7736e5877ce3ef88f2ccdda58fae885ca207fbe8f9c62d489055119fd07e960ffbdb14d9a8c5501fce1144bdc4b6b9ae7df7ad26c6f23941",
-      "incomingViewKey": "44ccb3af615ec75854970e6185857c33a5caafa0d5644de9d5bbd56aac169b00",
-      "outgoingViewKey": "b1d23bd84b2f85620f0646f50ddcb3beeb8f98352b039c8aa268e37fd453f646",
-      "publicAddress": "9475c8e4293497032478e704810c15416b74999dd8e7eae9e9c7410afff38e2a",
+      "spendingKey": "eda14c428da8ca6f4b5e75f5e8a5551be13157d06f63cb48b3bb66cb13e66599",
+      "viewKey": "7dd6d4f500f1795863f7cd2d19ee3bb015aa5a1a03fafb3095eac2525ad982ca2e2cf6e76d1145f9f3a469bb29d90292719352f30bb2e7faf7120f0e9773c317",
+      "incomingViewKey": "d143158c6e768b0ec8570cb2d04395fab26bed9d04f622509335fe6d2d788003",
+      "outgoingViewKey": "7405f0ecf9d32a8779378a2c6408be05ef6ba7c4b85974f332954c964159e1e3",
+      "publicAddress": "c973581f9e214d12e2535fb0b566b566578f505a9ff64f1bbec04e7030cfa7cb",
       "createdAt": null
     },
     {
       "version": 2,
-      "id": "6b553bf6-fe1a-49e3-9207-9e15300c753e",
+      "id": "7a9503ff-4cb7-43ba-ae34-9ec98c7dfe15",
       "name": "b",
-      "spendingKey": "aa73216ce28308d3ab025293d08616432f08b63241bf7d8cc02730f0ab1f6f3b",
-      "viewKey": "55b2627ece5591879a4e9f24a20573ab0c72f265332987d392884acdb201e6bbf6ac1aa3525f8f2b78bc2af011b97714e8d6cbea93e8632d534a731756094882",
-      "incomingViewKey": "c30cba3a2aab6ab396e2243f9363dc76eb51fd1d69489db3a43adab847361504",
-      "outgoingViewKey": "d9176eb7a25f452c46483207eeba6671b004a9bfdebcdb2160af1847cc6e6997",
-      "publicAddress": "8bdd70976763c663c69049eec29ce689970867105fb347c03f3af24a2666f51d",
+      "spendingKey": "30639cd4e1c0d96363344f9ca097d311ac7a2aee503b7a58ffd6848d9753ba3b",
+      "viewKey": "5c6e8b1a2a7cd641e31fe256be8ff1e3d9a3b2ecc85fe38ded86a8563362438334bbc1fce04dd4b9ea03ac2a6562b21359f4a4e1644eccc8a57bc4c3b9f9ef98",
+      "incomingViewKey": "f68705bd1e0f2a8960aa030e04d001de004ce7864375fa66e330bd47193bac02",
+      "outgoingViewKey": "c6cdc3dba9dba6f08eca20fd5dd38d7b2843b09c9714687c1565a1e0b8cb827b",
+      "publicAddress": "d7ca857e743f54b17979153bdac8c09a7c26d5a8d7f79e4360423520e2a7098e",
       "createdAt": null
     },
     {
@@ -5995,15 +5995,15 @@
         "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:BITU3rMb3G/vLi37leUQ21b9gsEBMa4nQDXf1Wbt01w="
+          "data": "base64:NyaZgZTVJO7W1Nwt7lWPpQa4yMBL/f4V4kCpNImITBo="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:R50u9Zm5no1iDee+hhQNyBr/wgEl4m5KW3epo+1hB8U="
+          "data": "base64:dN0NcGhJ6XIoFp6VLzcspXIHXQdgkmaDEqtyWAyU69k="
         },
         "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
         "randomness": "0",
-        "timestamp": 1683317542054,
+        "timestamp": 1683330813994,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 4,
         "work": "0"
@@ -6011,25 +6011,25 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAlmjoNTXwkI7l5CSHjJrorIsSBA1eMVGc2osw7FK7FWOPFUYw0AhpR7oHQiqxZVOdvqRVIXzNwD7Zj0YR/G/9xP7kLXoTNqlNbRCmgdyjjR2jd8s2Y3KPQ7nlRHyD7QqOoP6gttKUEchPMpoAg3EB7OIwTLSRJpQNOzmAvzm1Am4ME67EKr4eDaUsW77k22G68jeLOKKDD9OoYAdKIPip89uQmwZlc1gB/wT8AAwZynWlnfJwbRK0JnSuDbQQUvqPB+vt7RDNCXuIQFaBlYltLsm8tT0bIPdmb2X9tuppFVoYM1N2F5yS5ltlR9KU/0L7ovdAIQa+F37ZgMIFulT3XOwWYWuzUjJISuAugcNh8sPjYDI/6TnXyWFU2L+yAM8B2bzMBs7Bjn2Z2docC5F3Sy75rGDHbKxi5bO7HSMVtR4evU8YkqnzNSu9iZI4YIb4tqunlgOynb4EbDD8WyNsrYfp4PY79bBpTXKNWcM/Bkl/sIstLWMokVJIySc7AehN1nhXZul43kVNXczS5XTVA7TMddL/0QoULT+4rKbq8ooW59S9xgWxAfjAU2zZMnYkWUkAMozOmKhIBP8EDzNUWQ3O0d1o2EA706OwSLxat9/AQIi5Q/zn/Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwG9OZ0L8H9bfRA4E7mwKRFzBpNoLVZkiiHDD9OgBaNNzgyvC6e/HLMTOPGDwbkoBpbbcZJE756pe9Jb2sPaHmCw=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtlpZLxo2ZiZbVQiXUMjBqscV51B6Mkb7YC6Tc9OFTiy25EzCQXhM4HRDaqv9uVe/hw5addVBZvyVltA8KsDlPy97CShb8jG5gSq+QLGj+QyYOpEmqNPbGz+WjiX1VS8kdbB0hat/iQOGEfeClLJcOtNtXmSgWV4N1H9KssKyrhQVOFvGRn2A1puPJ5HPvZ3y1gSkZAXgsa+4yRwx+Pa4P5wSW0oDsfHWNWTfUQcT6zmQAoqK6EYNqzq+Ljt7oNtf51wSuTcpaTD34W29H20WjDGOBqODlzEs8NNjqP3umsJjox5oSwl1XTaVW7FVEE7O6hfwby/KZu+is75KxmKQg976Pp1BS4Y4Wsf15DKOw+uaDISofWBp3877s16f2I1O3ye9eOoNwXYKc5eSN7bcFUSILB2Wap6TM7ZPF2zTlVsfCffwReBSm6swvmxXdRTKdH+lVTA7KlcSgHCq34Su0dYlGI25vsL0SVRhNEda4gwbcGI4RRnDcEELMYE32og9cfwGOBi1I9cGjH77KgPir9hbltbSq810gZH9faPKSulNszTVfg+DShpK+qyoSCuzIVDC6lmdxIH7WYX5Ki2+HgxBRSFEjJvLqBn2XeHtf/jSaEdIddiaIklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXAF5Z/joiWBeDozEpfxb4zRcdf4bFr50L2VH0yPyIRFj9BN+ow6giYd3eBh5KhtXOeXSW5vaOSHVJBVwILaiCQ=="
         }
       ]
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "508C9B9CACEB1AD3C16B1EB10C846B7A1027B2AA9B2B0888690C70209D8FE933",
+        "previousBlockHash": "23C2BD27A18BE4B01DF01C53F7C0BB086E84D463A8F1E9A11732D765DBAF3EBE",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:NA3kfeUDndehImVtGz9pxH+sQYOXqzxRWVLoQLlDqyY="
+          "data": "base64:IMBLY39yhZEA/BmKrOd8u0x2JqplcI95KNMnGVGvu1A="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:m0VEiCLea43USgB7EDN+69HyZQTVA6P3A4BJUM5zz3k="
+          "data": "base64:6Hpr0Wu7BUr7G4ex/QIs3YQJvZky/adGROFHarv7/lw="
         },
         "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
         "randomness": "0",
-        "timestamp": 1683317542712,
+        "timestamp": 1683330814632,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 5,
         "work": "0"
@@ -6037,29 +6037,29 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAHj0ItvTnrFQ1Z4aVD/iK6ktagiJecRY9OourG3Q3K7usMfY99Eyaj+hOgk/eXZ8S5c58Y2X936yPCMEt1p/KAjetiGNtgquX7SXTyIuxq72A3OHn1g6O8A+zlnxl1GAZFMw7IBUTA40GjRfmVe93SwxfS8jDHkgICVSRfN0ik98TrB3x0WSf5R3TZwZoauenVi7G92/8tBfvops6rmWM5TQa38THsOi3f0jiEmJCgb2AppYWU8/YoeDy19TPYNH1EM27DvHojmXJSFbKAbsCZ7GexElCP1d2NMd+lDEyc8wS0RznXXWpWz8+unGXq5WIMw1PJ2zAZRGvUxSkt0pY4e+9J2SxDy/EMuVfrAYohEVPTNKJHt1bA0OGfZt0XrFGDGIv7WxobzcAG5kwQXVzTykQ1pRvVTlKJVmfW7oHVJu4HzKqSbvkUvwMZRW9IqhZZtu2j+SfSTpyxW/UOFLl50AlogeIcGBUPS1jpdgbN+eQeG19Jd4aOg0PHgRFfGIvaVqSTywhwrgxMCJWhhKfjvPH27ZuesRN++OiYGteRPgbTY5cQPtnCoxjowop5ve8ON8xAmMMEK/v6fM8Mdki2SwPAaI8piBKYmnmNQ+y/+hsPUVAOVVlL0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSHw5zj0ElnA3wXj8nupJbq4e6Q/QGpG8DhYbnnVwrEfsU7sR4k6nKJN+nhpqvdSvfzEYoXne/QmvkuS33SEjAw=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAj7Dgz53bMPtl3jnreH7DNkdHdaN1HOZyIu8adcopJu62xp+4HH3hiHHeLezEpJy0bLialVzdjmvCg5gxqzkVWvIq2cJeObYCriCcZS00fgOSM7NhpG4bJDynBC2rSe1skAImFn7LUXdIEHQ66Br/8AjfS2z66eJYLSjqyHLIIWUQE1/pa8ESSFRgb3G3rV39voeDKXK0e/0UJo1cvRrt7mhjKZCTnVDzOlR5+/38QQCoQIraDYahvpKib+0T4X6WhHtjm6fUp+v80/jLBC/l8axnzMKv7nWx0r2n8/cn+0u7wmNThGr1yIgG4JVStaNrBNzfkEK0mJy6UlV59qoW0Oweemo4uwOFdMSTCjUy0666OpYrMV/HUTkHiiffrTZR9ydpZ4sKX3ev/CykBp7ZwrNT5Q9QpBowOMLLObHgoNbRSHCNZm6pH09J7Y41FXOCaELkGGujSP2XDpYA9HLzBu9zxLskU8wOuXGkSDjLSvbQlsW3lmwRdPL4b2Q3GfoLhhMk0PY3REkTtPqNHWQKS+INcHkFo2sar0U+DKG7m8JGANp9Dkt9VWduF8a2AAM1j4TzziA6ypw43LpOwjXYc+qrkvuuL9nlRD/c334ZC3FGqeWvsA7UBUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAws4PJBG2hm4g+UN+txEkJUDCF2Q/y5TNT94T1eHX6k7bkAiq1loM/mgQtgO+GKO1Kparg09SjU3M9KmITFLw2Bg=="
         }
       ]
     },
     {
       "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP15JZYGMJoUUap6S84bIsN8rOVAQdyQAYG6JO+7XGlOuvecPsKGjshVIcHQSfDGGRPdmwvqWH12EjhjXRLOe4CZtfCMEKMewH3jX2VNA0Xynjl1gvflrRwNxurBYe32L3SFK5ut3pj51vYwkEqAZmJ47lpt5EEbn16Vim6AAHgsVOqC3tD2bu7EtEGBqV84muyZQWDp4o+88H3wwPHVsI0zim0SvehPRaTvjuDvDSFStNM5boPITyPr0GfjDiMppxltGbN3TFu9te4iuJce31Dwg24MtMf2Qx9bdyFEENCge+ukqs/TUnOiAIIMllfpb9pics6cgkUoUtsOfGhSvETQN5H3lA53XoSJlbRs/acR/rEGDl6s8UVlS6EC5Q6smBQAAAM5m5tEUrLu1ITDYkXxEPTKjHrvIvyms4trC6uMOr3P+0XIlfjF+20mUw63I9A5N2A9Eqw+6aYc+bXc6dgVGTzaZMs7dGZJVe4HRqowq4gfZKOjyO3+uyec6ODOhsC64B7ftog03i7zhh7X301mCCJhDNn75Av5pShNcHSpax+fOYkX9dcHClkR68l1yfBPXY5ARhM0GCMcFcReMH9XzYvddlLVxKSsk/gcHQ5jnvwjHG4xY9Hnvy9uwjVJusPYx8gq8ZykdU/zU0BrN4Iu3ncGIllA6uncw/qSNljhW3EcGuk+4HJ/Y8RwestsqXG3UfINz29XQyS6Fm7FLuBWgbww7g+FqyoEYG3ELJszvQ+l/M894Oce7rF6Sxl//0fCPapS2Xxc4lAAlnkGFWbm7GrZsDkJMcPoS8lAXL/BUvHAslxrO4EW6l4bheu04B5YkGth+Fa/2ldK6+BABUJecQgiX1hbK8L4nIrc9HkfJxtXwpZ0Bx7aGpCx5aSRK/bCJlEdGQ/NmsWr+4IXbAeC3qqpMytQyf5GF6Bpw+SZvjh4644DkriBeIm0LrLkemb8qHtH2WMeBPkR+/aucujPh8RspcQx/3imRjeAN9qoyv3/hPcmGClgdeFw5vEABPgEkNjOTutj8TFMo1VxDnWwJ7S4hpHQblG+EX8R1WiWMhLVu0jNgrVhXVMQAgPyvZIy0Uy/k+0u4Mkd+j9ze6kqa+PTYxxtBMQnZr5Iwkr9jijv1F1UrbDa0CdEAv+6ojo9n9XCv50hQZ2Tw+j4v5arpty+hFSH74WP4CGK8L+CL1BYbNfj2f5d1dlqqSD5uEp8RgufRTOX01U/tWsQknBFLJAEmhavHmltGu7bK53r1zOgujVSx5eRGDyWlXC9cCsVYsdu79BcMchLZL8SEpjHLUQ9UTk2RJ2AOfhUvDkuAH8YiMjVjaJt8ZGMJgAAcByG+dz4SPBCE20bpSduUnWUPMidObo3QOfSkl+ndFpQEg0uVu7WsY6znl6KCIM4Fw+dnYjNtqxPUNPoOH3K5h3s4PZyV2earthGOrurqmg8um0opViTRIcsJykHQMbCcfAEna49RhelqQeIPaud0wLPuyTkqQCX7Q6efoGchaOU4j9G0g3Y68tIB6Ld7hJ+YNSvO0FI/1kizegQebwAn8MtWWW3vpX8nqIPthzNzsK8J+o4nayHdd7HJTpVyPR/PUbhTQ95T2EU95Cj7ax9qHZZCWwxPwmZQEA7Zqnks0Mm7ZxMjwcWZrlCCig6YkU76r8PXV5GTStl0JS9rUpF4c8SrLCNSHqoJrJFfOx70TBgNCxh4aialQTwzI96CAiWTXO7aSSWqV2Yrp2ViMeBpQIzwAQVCG6tt42Bbmo0vxE9DsZpwCWu3JMStJxf+Npfd3s7qcG7P6wUZRZukRgDOQ2OUq6gqzfQQh51TT+dwF2MTtotN6U79kltCSCa5t4FHr1eaabEtCazoNgi2EPp5s2xW0pYymIikyV2EqPXJaT2Sni6DtgwJbCeYvG4zd/Px2XD1rJuBU77JDIXmrSrKdlxRrNBIUGjwtj5Z90murjpPZgPOHwtRLpsFc+ZBjyQYez0XCw=="
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAglleiLn5ID0BvjxJEC8cGkni+3hJKGHAMcVMOoMRG72pVR25U8RRFutu7Bi/HaPnRHjSPQ559v//Yw4yahdEkwNHfuJ8hhUw9bs0d8wrmlG5CgvokfetwiISD7DdvQX33RQUDzsxSecvx63GPj0DEz3obfs5RYxhrRkihVRJZqQDWrokPqhdXwIlidDGkMP3yR7OBKS6AYONyhrPyWj91OIIDwr72njGDrAg0+xh+hqWej5lJcwQWXYT9+KNbiqGaOoOJdsXArXhqQHfuCg3hHonuuP0Ijhch04Re2mYlKAVjS1jU+NNJmQlR8j+sF/RtoZIjd/6Zc51pf1XF/+hGzcmmYGU1STu1tTcLe5Vj6UGuMjAS/3+FeJAqTSJiEwaBAAAAINTLXG2UbyjUMST4wiEyaQad7NwXQWu32xAzQVJfxT7/2zLRGnZQEaBBVuAR47xFH6H65VS8lISO1alwpv1McEjNx4k+fvGVdfwxw+xjTYiAE4EuSeyQ2URnp6mAlBPAKIBvL+fXa2PARyq4GJhJWlNvv6N00/WSfj/gzdGTGn9X1BvMFdg9GtBkIyvtD7Ui48kputQEzEtdBTjiXydmGZ6wnSCjHdURVcshNIghTckglv4AroreAvPdaSYlGYgLBUzULigm0gYB53ryem3511z24R+7RbXGpXfrTDseJSwaoocJZorP3p9pJr7RbAscYU1cyOgzXuLFnBY2OiJpwx8GCqWtHNQGh9Rqn1cAl9OSxWHqKZ8GxwFPrj0ZUpiwYlNb8BGOyUOaZxHaA8Zaaq5POXRuQ3/DnxWXln8NU815H4jXkR9tbfzGcjTy96gwLgzX1vctq1S1ttxKMWXaiplstUmUPez7jaoI8KpnMUXRo1xfWDA5EAE17AzixeM4u0LEIrDpaQkCFmb3Wzk8JJBLwgDQIDkJg/l3jdVxJX9i15Dq1MjYjUH4yzNbAf/grRjR4556OStRZ96KGk1XGFGJ6cyL5eclpHRPC3Q18HDLpev+453kimsYTzx/YnfcKj7NEuNmB6WlD48szQpIZ0F9ri5G/z84qirvcwKHVdIknlks2Bb69rEN+OHW/Jkv0i9Z2LkZ2OqewnUMk3aEaKeNufP9iyiMxijrgAW7fWJyxHK2CmDNqxQTd8CqUOO7a+w/FmcYXCbphKAiDEFSeL9uIBCqb/yeY902UXGjjRL0n7KIDj28HumoI1im93WJPEi9g5a7lBSfchT1Qp6DpuCVgR3wldqHrNImc//ylIsUfoc7EAUK72u5REOVvQkG0VLLXOcvhZGIeos4Omqj6TbJdrmf8J2I1A+TadKy38MZA/oYrSkGZENiM4o65inXFN8pagDmyf4Qkd2A1rofRUeUvT7O6V85KX7RtrXtPnDLk8jWu3dFNOwT/wsVw9lXqLiB/AmmQQi0Zyauzu98WcOzx0x101UL3mTauNxcRsVehcEqyFlwCl+67UwJn/hFZbS1Yp5aSGfhppmVJMMJ7hKp6kbwJyStkAyeHLi+lV6jl1lRvEdc6hmsK4wiz1ElauNkkLxN6BBi/+MZqSq6Uxfqpna+ZI3lBEsxbSwwkexJKiS35Yh75y+KoKR4tTtrmJ9QKnKDpP2LRiyhqKReLNk9Q4lrtQcDl94t/P0C4ugEUXowfdWnFHe1LGiW6BjG2JFdvV88Vyqqv0l91P3NWbND1acva6iyvlHyK/eYRV0yAfl8Pj1IoqgqmL0lu6cLSpEr08NObGo+HJvHURhqmqAqAArpjLuBnDadYIfYsV2jWWtNLM7QwYnAqancECJOgswE0V1gEa28w3SlxhX0HHLlBHT/a6zspcigz/MARhAm/EpXhA012ETRBYmpdiK95bIC3Z3AEtdT9V4gLIsskmrRbH5/cdN9KvMrpbXSgB4nwKQmQ8MBM6wKsa5sumg61jH2tolai3K2/Coh513kPEzF8rSwTDxMq1sEvWHg9LcEfJuasRPRd6NqxsVncQpAw=="
     },
     {
       "header": {
         "sequence": 3,
-        "previousBlockHash": "508C9B9CACEB1AD3C16B1EB10C846B7A1027B2AA9B2B0888690C70209D8FE933",
+        "previousBlockHash": "23C2BD27A18BE4B01DF01C53F7C0BB086E84D463A8F1E9A11732D765DBAF3EBE",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:edK0xJ1TVfBP8WA6iZL/Ux+kBFWbXVVqYIJnVH3fW1Q="
+          "data": "base64:b47NUd9ymBELH2bLq8DAzqc4Ff0qhX6ZmR5R+XsrrSk="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:/uuV4kQVJzoI/xgS1e0SF+r06+UYTbjMmpf72YX1W44="
+          "data": "base64:UzQ+lI7S1pheS9n3IOGDrf3r4Q5o2MgyW39NbFH+Dh8="
         },
         "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
         "randomness": "0",
-        "timestamp": 1683317545792,
+        "timestamp": 1683330817445,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 5,
         "work": "0"
@@ -6067,25 +6067,25 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAd7g3RsSf8JZCmqYp+oymZq7EfsgYdOskoT4E+eZtK+qU1x0OunQSHjqtDeulrKRKjTkxdQD/WCEbSI/egyJUON3kPymRccFcii9qLtqnpXewgmXcUkp5wRi0V/pNHnxYYorFIabTWSw+VAdWymtx+I4TZyt/nUPJ7WNK5AnbqQ0FPo4r4ikD/dk8edSJoa1UT6rmVQkw8qpIA8ZqDPv2BGScfbCAkZTRRv6VS9wg2IyJ+k4/wO2Bp2stDXN8yTQKpywwHR47mBOIWvwZV/kLDqouljXUuzNN0LYoGHwblsiStg+N44md9ziTlXS4vaNx2lITsEwfCrKFRmt3/LkuPdaDRnykOfmSoyJQnQLraX1XHJs994PEULYahevDB+hJtqztAIHVGd+uylpqZ1H26BlxmYp5n4fIUgiL8Fl/D7fJJ4gb1KabUpKBkj8/T8JTwReg2b5HRiSCkAAsYw62fQrQF1a09OKjlGiHhoMH+7Vq8DIRKH9MSBvI5qi2cSF0Q/adIR0G8+MSxxCJmIIyjGVKcsV5MQEWlQ3pzIpL2i5V+e5FyXED3enMVPsU3a5bcMXIIUFQvsd1lHguL8tV9C6mUQBWC5UoCx5JGQIqlSyYkyH2/imkXklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvGixdKf6TsOekTuhS/FXRkIo0q5mTuvG7LO90VzYOgWIUdpyIFLsm09eehzN/9RidtbG7WSVl5OrUO/myjgwBw=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAUIHVgfuaAdmjxFBsp7F/gzItAzVsnAQf26LxqNZRVhqVzqLMvqF563i+jzn+9xpgDknfM4KNllJmSkrZeYy+QheMOkNQngP8adw1jiGkeTG4dSdJyYXBnQIOhXd0W5LQBbaQyxA6nolzhXJTJduLk1O2rOS5UZ8jJjVv6ob0Iv4SFiHVUaacUwS3IsU94Ms3h82VJPtf0z1K0aQCFCtOFpjfkhlGyBN7CWLdySJTehyY5WpjgIKAL3yv8J/AV57yHNJPQjPvLkVgBhh3i/9PDfyXwkrDVyExyQueIQV2JHxdj0sRucxXyuk0K32AJAed8DkaPkWc/cNkdT44nskW7yCMWEyYaOamm6Kr1xyAfg0nIsoo/tWh0GveNQDvmbJqc2BSDotue9ZvUfbdfSrht+qlSRd1F9u4DRkbmKZIfVrkrXZYNYrwewGi6bQpjGGlRQ9FMrThwe6WAwHeLunlJIQHASPXBZYm2BNbg1iK2XS4BXA4HA55l9IRjA82JOHMCf1jdv6j4N9t07seKtdYXnpYaQupq6QfrY1c3Sz/vEmhp+YuQL+LnoTtPzS81KrQuH1YPprR+f796zDAro3/ArBoUZ0m/sWJOJLhAO/5hFCNFxC7DZFO5Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwk25Pj59jz8gJqJ9rfy43BIQH9J1H7Dz+dPWTy4nYy41iN+R926IX7ElVLRF2mkCdKzrYcYExq1F0nRTb1vgaAg=="
         }
       ]
     },
     {
       "header": {
         "sequence": 4,
-        "previousBlockHash": "DD71ED9D2436747BF9EFB36037FEA50374A030C6C61930BB09E238A6E16266E6",
+        "previousBlockHash": "3FA4972FE6BEBE1F107E80809F0B696935B4CB374708831B49B8C3104F6E72DE",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:E7nMe62sjyk3tGIryFTLWvnnrZlkwL9htUqPCFkt720="
+          "data": "base64:e2y375DHxWByJ0eENZdlNW/P9j4O8b0GK9V192n+SkE="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:BAftMxv0KXMJCzJSpKXpVm//b1jEKRUyv5KIrhBZbck="
+          "data": "base64:BobTQslcNBtYGLVF5wBcZKAx8KpLxrVX8kEk+kFTHgc="
         },
-        "target": "879558286015102359500873427691175770640419791152471469672593461411590982",
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
         "randomness": "0",
-        "timestamp": 1683317577230,
+        "timestamp": 1683330818058,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 6,
         "work": "0"
@@ -6093,7 +6093,281 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcBf4JWUdGhaKpxkErJEds2C8RKSDA75Cq4iK51apHmyQ69UovOhb0tHl+nSTHkcUvhwism8m2jgi4GWhKjEe1D+D+kVcq89Nybx+F1NIg2GM5xy00JEiD81AIWFQ2OE4FhKfJj/YB/A/ZzDoCNIbRfoliZcuyLKBxMMiOPLax+sFYJyIJmIrvYMv/7xg5uxSbEhLd3TboeDAZFvhhsRSxXEW28mFANvHpVr7LymL+6GH8IRx7k4Vov4QpB4P87TO7G2euV+2AGfssFt7phi06nScYgUVmgAZY2wMapVD9Ysp+GRrbE2TpUXP6gbmlxSjH7nsLkWFvgOYMHUrUCC8uJDlsd3UQRnCDLRW9osl8MEPqyFK3yc0HiSu7QAITvRLvrjL9judNX+EI3UVMu8beVu1gSCrGbJ8R32Hlfa8BTreY8lC/kTEFRw11Dwjc9cFLCBvSQ7j6OeXPaOQVJXAS2gWhs8lUnuSP20zS1T3PeRSqYj53QFyFseDN54za0DCVcTX0PyNJ7QK4OYRiokBN91gQcILzx4/dm7O7mRpIv1x5OiXou7aLhWwMTXd4lvlwN/XRDBIC9q0Eva4qBaf1p2I4E+czKRj60n4en2nZs8e6rWBC4rjIElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYgHx59Gd19p4qlk7d2+hi1UMYLs6z+18zaiLMzJheGwqHRz0GgTumm2Zo46NYkKGY3gIe0u7inTCvzsi7mT7Cw=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAd+e9hPmOtS2sfg3qyzRcqHSYJ1f8RsREp1+C3tvEzi2HqpT2acxV+bR69fewC8gEJi0YrVxnN98RpT1KofC5WMQcGbbH0NUPWQAX9sWuYVmyrcRIe0/Yif7hlh3cEDyHV1BKaX/cF0ytBpxy4PqahZz3qwuaSHeKExAyQwneLw8Mp76C5p9JTdvLXQRq4bAaqHZJN/NlR5xQ82UeKk+9/8qCpfFssb0yzCFNSkGLVYWvRyy821vtrD9WFXlxfATMqFyJCpgtKGa2kPzIJEOpW1QohMh81HczWu4qv/HTt/mpvlIvWbJGniBVD1jB61pXHw0kH4ooKel9xK3PfpVkHcdBygA/AZ1lpFZ+0R5izNbuNZ83xV1qxXVzXjfWHwsMCnLYFhPzHEVKGnbCmUXGy/m9cXpZl1aUNxnuFhLnimxAAqa3cBhIzs2jOqJpeLY+c/ZTyMmT7p++WDbBjZUTEUj/laVrScXc9oJfQgAtjYRRxgu7FeX7tk9tyExW49lnI0Rw/hCwpS9vV66wwV7VN4fXXtET8Mxiua5cbpFTYY2F3uykhoBgzhJCkM/v5ChGVhz7WGF+NhBJUxr5phZDYQI3issBTzOtMICn6QRFh/uNs0rhq+hlR0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTw3yG4l3ZuNFrW0HPHLVI3DMP2xWcdAU7riQxVj/hkdop2xOBoZvPKIorUeC8p1KCkaZnLpPt7nEgZZocc0ABA=="
+        }
+      ]
+    }
+  ],
+  "Accounts createTransaction should create transactions with spends valid after a longer reorg": [
+    {
+      "version": 2,
+      "id": "9405dee8-d139-4fff-9a9e-fa59dc226ad6",
+      "name": "a",
+      "spendingKey": "724f10983b610394793b8ff8afc26d86856f33d272cceea2121bf5b9c9e40af8",
+      "viewKey": "efa6d7fb3607191785963519ee5cd5b25e68b5aaef3b4c14757508017905018c0ca7ba5311d66f7f50ff5df6cb3dd7006f7a39d15efe1d033f616f84a1655ca0",
+      "incomingViewKey": "cf6114f21a3d3a204a89b5082ea3fa4de4c9d478cb531bb8168bee0ddeb3a501",
+      "outgoingViewKey": "475b6070679f25c2c2ac00217dbe4c39a595f13ac8a863ee3b8d4f1f75652093",
+      "publicAddress": "31713e9d9892c2aa6c0d35d1871adfce1dbf81c08006ec2e4a669f585f91e28e",
+      "createdAt": null
+    },
+    {
+      "version": 2,
+      "id": "eb2d8674-3f1e-422b-bd9f-82ef6f48ae77",
+      "name": "b",
+      "spendingKey": "e24c6a324405df0893d54a8d3dda67f7ed13fcd5bf4b1e4d8b94a84c85659786",
+      "viewKey": "64930770cf14812eb04575be06037bec2a1ba1784bbb622f8520da34e49d24d8939c95fce864b476a7bc9edcb56d02c8d92bcb7c71478281625a85e45718d92d",
+      "incomingViewKey": "b7e41d892c0fe9834431f38e5c54e5075318ab4f92929090886f174502357900",
+      "outgoingViewKey": "d1102ee9dd2c512d4a0a8f065aa4d5e71afae90876e2e3e27b74acb6bd2641e2",
+      "publicAddress": "c3ee1abdbcc00b8fa9e2152c3a8ed957a27bac642cf0cc149b04cda6018c09c9",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:v66AV84wSgt4aaqIgg4j5qyCtBXz/ZyANjzza+fxtGM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:+a2Nftc9aXZXRF1r+rENBtHC22Aa9jI0Ezxtfs+cjxY="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1683334009162,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAALUUEzjZqhfOF86+VMwA8MR84r3n/boU57bkGAcxrTqCoMqzKCCQA1CHl0eAusiSzBtMDQy58TjTObdDxhfJsYZDSYNauGwQGw1oS7gmZguSMVYeOfLreZ7e0qxef+x0nG9FenCPKIJrQ9i67hUpcS0FtlVM2JTCZe0mAqhA2TwgEcgpzgcgGcqDO2bJRY22hgxVSGEk4avFzicv2haEhaVu1oPQwdARs4xnjN7Qw68mjPomqIpOJT2tK/Za068mD43OzIPfTQG3RzdCTfQtKpqGvfNUuBSzQVH6UxjIxijbnlufQh8RFyi1rANJkr24y4cJREOKbi1JzkYclQV418QhjJNqEJLs4A6K9OcdxtTN15Lq7EdoZkx4Gt5/tWQME8Tfa5rj86XO45oesubDv45WVvmqI4YnQBtpDrfjwF6y2RCWiQzP6qjM4A6MQH1DoDWmW/zVVaQ1oJfYvpuwVDFT2X3pyGOS2vSJPOPAKH4I94xLFouaZoH/0bjNd8K2HHfbjnk+rbOvuLt2KGqbHnKrDv3B5nsEWXC/JmyxpS8WVUoF46i7S/+RddMVZocGjgchqb83wUDzDKMosA79ZeioX2DfB+VgiO5E2uUHUxU3q5a9IFHAQr0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqiTFSmge0fTOfsV7+AhvVaL4eiEVhHyeFbDczrGzasZEJo2GHSHeTIwwJ76kmLOdtVF4apRH5+hhWX5Z2GFEBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "C33BA9ACC3F2F7F3FDD4AB7B25537BA0C0AAB4A2E7E72C3465118ED9C360F8B3",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:yZFlyk/oFwAHTiV1X4/zbvVaCdWtQnN9tnCKbVPrbGI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:UMohcs5HymTtVXWT6R2Xndgx81iljffE3J1usx2p8+Y="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1683334009808,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAlpvPhac3IvNh8z+whF+JqVi9fouv2cNk5+gFoprF6panTPmYm6NfbN3gkqwnrvpFlj+f4CvnUw/c3oPMvSEMII0JEwspsYg+n4dfeLSf66WTpqfcu7gQtRM6qjK4L+a9/9A7/0Fwq6o+OvpqH2ybmnf9IDuZ2bhIJtLlrMnoGvsEbkxfXG2cLgITgeRrU+RkYLscesqsewFKUT1IFsF+do2QGmz8dkAS2YZrWdRq+LWl8E/1T7u6Q4aNt2e8xMG4Ds65186xAtGAXpRvKltfKljb5dDCYIDTuBu2Pwhe+xmq3La/7DXQWl7nQLzP+09Hjk6FTZiEg/0633dT4HvSwHTI0Kfx/S6BKum4w3vSp1kFPy4amid/9LR+CmNY1iBOe0kMbFeGRXBcRSrtMvRu6OL4tqTVm0/oeGrPyzUfetdExY525b4IE+ygxCS+aDyoZdO1PuzJJBrpkSbL5G1P1ZubleU0OZPAOix/Kcza2AsITxXXZ+2gWSkOAoZhN5Kt4dWDrCqNhQP8RuX7OhJUdzRjD6QaQh2yS0IzgOcnuYpMLfYxVYeuTFfv0RqURFBTMhExGOr/QwLgVlHMpa+f1c1aZr5AeDf09wwbyPAhlx+sCoeDHjyjxklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwciBjbvOYHsyKBMpHycN/eeylqBA8n5V/CMudcqN2w6oWI38hOZSk1VS8GDCiqC27LCggsoKjDGaubsLlHxuEBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "5E4E1D175C71D2357EEC19A2CD4276D09DDE040A174D28C4C0B4E7C4E700EC3C",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:NQ5K9iyJerDv27cxRcRyrpBzRaNVXHJekTigESbiZAI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ukTTaZFMJXPZxL5i8fABHuowupDxHJJ0ba84wuCvopw="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1683334010399,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAL8c6K0eZyjgO+fNlXjHMsjkul5wadLULBhufm+MJx8iiVTr+A/ajIVifJ0UCuxcTGOoNZsaAic/QYaf+v/CG6hKoczSXJiEnL926wZ26kZGopyk7wCo8hydak6o/WM/wVQfBdNhnj6qpnI9NbsTVdTMS4JoKASQqTGGZCcYra3YIInQioJuG2WiDGuXnG2PXt97PYcWV/BWxQcys2RaSAlYI9rArieuimlcpLQ/ijmC1Dy1JPgGJVS5qeWW28Uk01VXVPYosfOaJckReazNpNSRp6J7ugAUalrIuktAXqiaV+pK8fHPdmOzTPlEYMmeeyzHrNsQO+kdwod7/lsY5PERlanDhr34tXgVXs7WZp9zOGOIlN7f5NtoKF47DPCU4wgKZTtXz3dD3Dnfq4DxCja2oGqpei71UjfgL+YapnbRsRjAUgZVxEEuKDV9w0piAnV6BPoo19uevgnYtjvPkWGv0A/4YeqSQBAmVvr4ZzDuF6yZPQSA8eJDdD3EGapMRBcwGm++YTLKtem1NerskpU1LCUUTZFp9Xb9A2UlUSKCCWgBZp4Rs+d324N2rqiskNx3f9n1LqXPxkrrl9Yjs+UJOKilLE8FtZ8OjEjGDS1HEBgImkm5wyElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoo+MbmiR7R8xThuORFT3j7sxWZkDJ77c3WrX0JQrITXoHqETWPqBXeuMs1t5KpUbLhAqbQ9Z5W31QCRMyb+pDA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhy1wVMKNhfA5L1Hg3BpN9kA1XiKydQj2o/2MrNLJpcCZgT8kisTx/Y1L6ShHbDKnGwKhE7gq9nYX2WBPNbOy/72GkNInXajZ6c8FibN2PYCujARNtM51QipPV4SQcV5oq468BJsQlKOyigXFnmBnEHIGArkUbEm0v/auLv3+b/oH2mAvsSFNTPbBd3nhw8TEAA6r0yBZAP+OY6yRPiUVww03Yk1T0t2lpt2icWy2ite0KPc2kHCm4hLXbt9Q2yDLMnyDKB1+pIqsLtbPX1UAKRiTPYMXVgArYtyJ+vsh8B+Zm3zExy2Iiyw+kQo5KyrzuGQbdiQk8sBrO1/eOCyX0r+ugFfOMEoLeGmqiIIOI+asgrQV8/2cgDY882vn8bRjBAAAAOlRIGbqsuTOk7u6+1w/RjWFh+X2j2gB3873mCbx45Tx2HIOTasCjxijEPYywwJEl1M/bke6weGoDgAMEtnaLGbvchWoh/YFwARsJ5hD7ewZvzNu29vC3Ha7QbjAVh3kCpLgSv2iSMSK/zeCrpubiFBwD2a3cvunZovbhMU4eGSQk6PjqZraZZ/ZZS8cEKDmKrHfIVca9OQNMtPfpisMgeP47va4bch5FuA19MGIie+Lk1Tv9g7LlUWvv4pBNPc2jxg8dYK1dQfvTTkuBlkrV2ZDX1TvJP6ZEobhqELstWeBqMgBsrzy6vob7Xh6TKi4z6GlZIUbWZljXdGUimdVTPWWtaiy/yxvCTWi9D+ZKb7b90OlT5L73o1NY0deY2ZxVWERfIqsxIcMQD/xEOpO0+OFgYH6LXQxtAZQOjwZMg0jqaalehThIWS3ZUvFlAQpRl3p3OuA2LrVmYQ4ZoYq4Ek4rleOBlZ3ZYK90UKs/r1T7ylsxMC6CU7m2AWqN4/Wpw947efiyFCvwYwSrdsIq/yjvWCR1nBmt5dk1TY/VObdsFjGhjFDxdHU3vEHbE4/+nx0h3Yj/yr+4fMv902V6/H6e+32D8CzYCMfs5kQzgvIParigpNcupomsxGRL/QAelARABPRYKq5u841TNO3tVty8GMvIZJ/RNr4S1jn1ezm69QZTk29IBSIdSz3C1wydRNUGMWEGkQ7/JJiLkh7iXUoUgQeqYg7vSVeKFIckj2//EZ0973JakuSrt5Dvk9kCZF+zACc1gNPeuCURVcb+7AUdswQOzCWg+lij1+ftFwlvJpUlpfymE+rF/bJYMYf95sC4v22IpgwQ9zCnFZwTYAZEMU2SgKZt0tbUspPBf/LA9ykVgp06rCAwLhmaXjHy5x4glDQkZaQak5bE7Z7GmurJQMwYoaR3DerzHpEpBu4qhQV9FPKMaYG56YA+WmZm9l2jaMPs3vR5PvW0VtOHP8oU0Dk6rAg6VUgt91QByrPQGYNM/mQqBW4WCziTo7NtQYloZo1QHGIxghAbiD+dqSbZaBCPgV0f5QRZPGSbrl4WF/niGpSJ0SlPa0D9a0K9uKeV9AnLLKldQIjcKClNUd+bJESzFzdAg+Rgxb7VJfHNGlRetLc4oZKeh4zNoaR2a1aiisF/ys4Lbawibsi6BDgWPF84FKJsKEmIjddQ7XK7lbYHhXfEUULjjCv9Izvn3kCg0sXQHV7h/Hbdb2BZlC0tElJV5PKqHHRZLS42931GuUUJy6WpFKg/N/zlYAlQ+1xxAKo7Yve2yybfiyn8mbf+KGgiBrGcOvXkVmM/GovUXJ/70bWTi26VJmMBUGHHd1j7wcDyz0QWeJjd7RfqVt702ZbzP0OC7vArVjczHelVrhPv6FuFIR05tTN2UdNuLZITptrMMiWY/USRyPyHEaIupTXwWCMjbj6V5VgD/5bvD0AKbd1Kxdh8HsN0lXdgezNWXeBmyLJu/VvmXZiNiz5AKSU87n3hxC9xUcFtUyXhN3tzAmU8gS+nXSBz8sUjrKRsb7t8R5WZMwtZ9GkcRUmi1Ysb3TkrcsxeoO/jdQeJk6PA3+0g7tberT1jdoDBw=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "C33BA9ACC3F2F7F3FDD4AB7B25537BA0C0AAB4A2E7E72C3465118ED9C360F8B3",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:lzikKOLbIcMvhGcTlekF3nxEOsi47ggrT/ERn6duBTo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:jUZcooym3mMatwdD34fywXMLP/pXgc4SVfiYgQ8O33k="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1683334013233,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAIu+4xRJIF2AT9Kjq4VP1ITX4tljjXUw0akaF+E/njbWsZzp3WJL/T0NJrqCm9Yv8e7OuuUllEkFapobuZzQYVN8p3C/9Ap3aKA8IAEb+QGS30/i8SBk7LerwnIKi+CCVA3KbUqVeWSZJND6rLXXzATo9oo35+ivVHM9ff05MxbwJmMFevBcKjsh9L74SqJzY79ZrkYhDJT3htLDwPPityL5UCFv4tA9epm5fmDFDUNW3hNzbjHSpzz8Haqt0PODPj+ogiV+8O3dBTb2CM2kn9PvXZ6vW/wSOU4tLtrZEDgIpHHEUzHVuxtsWda/4SAPNOzuCQTqq9Zpc64Cz0OlZwaTjIx4St0DYR7j4UKcBecFhovPusDChuyDcjHp/vOcareuVGlX3/n+DEVWpBCrXq/usKCTqwoeVaN/59SPgPGy6nB3H4TR0ws3nJAMHKO1kxgj8DyWlcj6POp7w2bv1FYtYdVEvYAHS4fXWZcEBi09GfINsAK5z96F5uDVeeNv0QpGjdlx6YrXaaqi+2RMAa2iyqwx/t2/bXI+bbhwE+JA0ML2POcQ8ctS9zG3K5vK0e/2KiOd4/l1BUyUEJZGnt1ctog6DDFNGi+KQFwJRqi9+F9Y9KAqMBElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdMoWlUYPF2OeIbFk4T3FS3iopwX+bAMbNI5LZniuwNFhIVC6tjCZ/CMJ2W1DL+4xjLcfyBQA44jCzUCFvj0WDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "D3D27A8E60B0B7949F1FFDFBF7B5E7C9407D00C99B7CD220E00CBF08143F88DF",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:nB/Wt9cCG7uBVDI5FRcyj6Ru1C6GSB3Fz0+aDQ8y0Dg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:NHZH3Y5nhnFN+Dv0N9W2uRzoRngPOFZ78qr4hMuMdkk="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1683334016033,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAqYLu2NQVJMXHBrwowHMlIsu5jnGG9MYGSlrFshYuJ9SW4ozWcbAs6wjCRhYPn7WAflYlZppl7LUat/OVqC9a7QKfJc59f5BlZWTW7oOZfPesj3p3rGLNi1yBLZ13+jndc8JPKlEs5wmWwPPlZ2+WrA34wbCPFyo39+CYkNJcQu8HDC5OLLmUaN7O32raAevhblVPZNlrGvPiqZLG4N6cVtt4l7uVHT1rEixISekoEhimQbuBb1j4F7rakSr7QvSWI/ynzoIByNLlNEp01ZhYzNDeY6RHPW73ofgBH0YV6VQzlb2U15vLJ59zKaGUa1Qt21V4LiG6ZyF439XBZG+2ggjl9OzBRHZcmfmnZQdBYmrShJDM+L4xBJL7va1cR5M9EPx83saFIJBp89skAIEcg6TjKInzt7RlOh5P5uCIsFExIriaAVTz/LcSPHAnkQtt1GNe5u+oPkbMrkZDcarrrfcHFkiE5Lj+Xe5dMm3A2wp6Bsw0mbqGpeAkoRg5yGlWuNDb3BxZniCatlig06cGQppC7DyvPWRsh95jjuQFXSyxz/3zVsw3lNx5OmlYY60Nj7XvrbQef/K6P6GXfimp6956rHqdAvoQvzLlgfgzAK9hejfsZUV+gklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqnz0YCByYoGC39yw3+0wcRZ0du+17pHVdi2Kkuk6+VQpl8fnPWjDKsuoZiveuzfhh+8u6QjdL0V5rGVs+eZ5Bg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAIOKcfsKRxfGhMkKPdBwEqwq0AXPw3ou5Vvw6fhENebSZ4vZmqDEpnTlG3QIbFzVWBFThCjAkBqyAjXNfQZZ4HLO7lcUbDFSYOKA352+uMh+Iy/FPN+ay9f8KJ12vIhNWtIoMSZzAL+iPsVrlhpHSDB5BH9ZL/n5kfB7toCAdLdsCq9xxMlOF+rseqjHZwtXfi8tJaFxWgOitxlZLzrZxPPp1vb17SHW1MYGoSLA34JiP858nfIqip+wLN0bK8PHapNoIItDildrWbPjvcJMyYMSXy3kBDzib7+DGUOQ2n6vFjOzKD8bj/FgamAf4vlI5GBDYVu6kjSvSfDFmAA6Khpc4pCji2yHDL4RnE5XpBd58RDrIuO4IK0/xEZ+nbgU6BQAAAMQmurDWINrMfJ3VoqF4FGrDncL6UnDB8WVDAy/hZ3tUzEHPd1qO0NAVYFY4u/rkTnEhTqilv3eH0fac/DbbhNq8rYQBPHzD3tIi0GwR5xe6oX0RuOn7B2CMiR56tOD4BZkh//GVpw70HNt6Otm2RAmYsXwXMRtlkjCCsas+MQ/PlHMTrgufOGFCZ+ncSsCHk5SuTWMOvQSSzS9f04M3vj2VflANGf6wGA364JK8jjsHPJAmUfzKK3wVwIs1egmdfwxdjO1y9UvYMN3wvFPWdXwCn9NqQsBKDs4i66nP4mucC763urpt9eBIlGfW0iQQqZK7fOe4b8qmQUzN6Cnhbz5VqikfYRsNz0nDSw/7t771+RKuq+Yu2dXX5MejBeO3UA67sapWCDYE7u6XZ1QHnvHptxtIvn+zi9tXIU6ZhH9kQoAgKWadSVHC+/zl500Pw+O5jC1M9tWUpQSfOfoFnzuLZu0RyM9EwepmE2fTVOKnF+XI0WODu/z16nmrlGMAX/51cTND0LD8fL3sLAkGcw203gM/kOCoWN1Ps/v/3NuNvdcIy2QAObaNnv6d6O7cAl8jZKdaeV544Uu4uO3QfBILCauOl/aetP7BIfs4ypSmCKR9hTnsvLXemdxNnGPtjJq7aTwQ+328OEPhhUesTeIYvnEOb7YMQZhzrFW1KN+6PcrjnWeVI3EOY9e/rpE92umGzi3SzKMPIv0IQMZZMZQhfF0Dp1ol1mB7QKvxTeQvS7FmCm0AH6bmwyYevN2azPcy7GYthKgghXfDMDo9BB58SqU44WJJEE7PB+Ha0+uJTKaiKchdZzyLyuy3RPWLOtlUmWMXO5U+cJI8pmyhVA0/BcLFtX9fDcyxCafF83n/C8pfAEthRTaZFLwr6RKcXZIMuoMRvJGK6Xjg0SEE+IBnrd5R/uqDwtHT6MRWR28OoCEuZ2MXaK0GB55wUUz7jb1DbmzVeqsl9/wpYk5+4hL5RyfKLiPMIuYT8OO2SbTxdS7fNG9dZfCxMydbUAGbwnUXSyTcJciqDvyoKE2IoE529xpVwl81yQU9l694A+RHKEhZhtdU1IaB6oB/wCZj2v8mg23QenAO1M46H3cDlIOIqKHTByGjCH/O6HJQM0RLbK18ZCpFoY8zSTky6GMv9qZxl7li/w4Gkae7KB1S61TBtbgBji8TIiTqha/vn15m5zg3yZ24C4X854ePqj7CxCMWBBvgn70qt29MYbZwew5tTLRTCdO1iRY2z7Nzd+JE9pBGq9OfSaBt+8+EW1B9gWhOCMxsUVc3t3hFWbUSRchzVLvcRPous4hrcKT1SNeluhCifelZDrKjLV4kGe/i4BmOcpTyxVXxtrUKZC/h4T7zpWedjOnPyKXfGJAr+ahroIsKxJtUF74Nc6/+w2swMOBnBVUZZumidXx3fC80PUvXBuZqZUbZs1T/M8QnNyQG4/4QbxRCN7ifoTsFaomxefFQ0++NLardX5XCyZIrZxL7QUQ0iyeYMdfbxyz9AFqPQpJiBCAHpYS2rYbAMFSczKnQFifwdNLMd2WzscSCNYEO4AMvXbUrQwrZ0F9LfJtgKZyiDLNMfmaduwc+5xelAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "F2C3C6C109816DD3FC05AD0F7000B246EB791D2E0845E6505F59A5B2FA0CA42C",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Ecpzwop07NQWNaCrbl6qX4rlcBb1LJvaWRiEaKxHLmU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:5prtwsipUZk8X+Pbj51FZxkcE8vPBtJLfqDn9sGT+I4="
+        },
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
+        "randomness": "0",
+        "timestamp": 1683334016733,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA0rMWxxI6y9BXQXw7Clb6ymIEnOkUcpEnMvKlb9/51DuQTO1G4OOTh43ksu4oipGNeTy/Q/EA7wBaYWdQo7V2yvYB7fa7tpWNVHCHIlkme7K3DtlI8ER3FdGyQzubUN54mLAUBm+IzgycgsQ+qaJZUlwOagFGT/1sr2j3RYJ+I0UX35EmWy9JBwK+saSwLfyi7Lyks03QmkUCa5wLBaaHUD6YF1XltRWCXYoQ8XLrTKi0FqptjLbk12wttmMSXVBhaeo2KtP7okywEI42F9WjOu0Cp1EPsWzg8+j121xL33j3cGNPU/TVgT1Th1g4th6C2vnVu+Nr+Emd7pWSRcc1YJ128ctrJmBBzbwuNCfhP3zQHMtEc8cpmqW6PePbjxk2W9aJ6hL7erE35v4rkypPfBabuBWQXZDBlT8wDFTLuMywWMllA/CwlZqqyj+wKCTixLDuQTHk7YKwVm2n4cWkHD5FJXkK6DxEBQ3Tnc8hqNheHRzw0UeYDXyoButRMTLO6EuSfb04V2+YHi/ETwLjqzgJSdKQXrsbvliu4eAtD6ek3tjHSq1maBqjpL2McKmH9TTSnnCkYS4XqVH3juHWgylTIvBVh6fb0j22wg18ai5UPYbGtAgcpUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEZJ3/9C/LBeDlNCeYL1vHkN0DwYB1JM000MvJ0dfhcXYFJViOOpj1SSDGtIAA00vxp283qfyTY4Sngi5W8sHDg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "5D98A1E7B7E8ABF46CF926AF553FB81F915F0172F11B4202BC6AC81DBF975E47",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:8UthkvF4CsrVBvBKe37rXSjJ9xuDBcws0h7+hCjitF8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:UWUKvzSuOGjK3vRmI1gZ/5zWE/6ja6k3kmyCaZmU5zA="
+        },
+        "target": "873190827380823143577845869093025366895436057143163037218399975928398962",
+        "randomness": "0",
+        "timestamp": 1683334020700,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 12,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAAcyVh5BKK3IOEBcjPlBPENTF5+ExwAHc4K1raa9HZjy5IJsVSLyhfk2C9Qy8cPA+/IwVxOSg/R3siJHImXBwJMEPbly7MJqZ1xnzqAbHKKmx8HP+tIIlHFi75qfAeqBtP9X1xJ2056zhgYeCQJG0BSgxqO9O8h7N7D2z2AQD3RsISo/2bk7e0Zt+ycHMCWUWJ8bNvac+fxOjtIcck6shUmyj9jvq4D3iuph+EnNYXIyEEdvkqg21erVzikyrJOWsEa+KbDH3rMMEjkuVLGNrlL372AQztMtrvtOwe0LPnBPz5Ucorm09uowBx/798xfPgJjcNXSqhT/tTkBBnW/Eg+s3Ig1ojdeXyMC5dpGIA05KN3D4rPNwTxg5T3xOb/NI/efm5bWoEjG2XhiyS96BdjR/bHWjWJ6IZy7UAO1LNqXq6IcOq7ouTupf5Jd43YNhY/Py5aUIlJDthv9fsFuVsAL0NyizCU/fhrLBo9CeKyNYq+7/RIhP6pLRyNqFKi+wI/MIZ/Trf9lzZUQJMTEHrpcmtvbm8+cYXYbD89DLo+Uzy2+zYEQzUN8s9qRbaoFnkq+v5mRxe22e4LwTbR538jYlIAtSkLh8CQxTA0JaPpxJf+roP/vEi0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwte9QcV9R6ROA+IzUjn4M2ccLkSwISi+r1D+ZbC9Mag2TiC0hmNh4UCuYDr/TH70SYxzlI49u5cR6p4EZzVLSCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQIAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAObYGx0BiwBd0NFtKDe0wPRH1Pl7G8kkw7x68Grx5u5mRm1a5r1gdR8dLMgL161gZXzKW7oQuz7JeoyBBGyR5/lNNlH8oj1sJGCh+qk/BGn+YZWLc2PoWKnG8dehnTFzVe7btLz0qEbBNyqlyhnXwMGzLDyw0hrbi1Aj5yJ4LlQEGc6nT6H7seJJDliiOR1RBRW72nwv7OadqI9zoLCqs32vRHNoAWp4xz9t/IywTesGZJwXabOij0gOZIRJ6IgLjvYc2U7q923QqYQW68ryGWCEE4MPrE3OlQFsmvKuio7e/RJhJuEhaKcB9DsmSAvDWEGYbfIzE1SXUbnkLxTTzuRHKc8KKdOzUFjWgq25eql+K5XAW9Syb2lkYhGisRy5lCQAAAEoT3KgixoSb0mNwVimFCZZPb8dJiSpZbMpmE8cd5zehI2hsBDGVXtSay37cFTC1c7kAZuKCLs2HbPyIHL3oaww/v1csKrLxVBX1SqJVx9DdsL7ngRIUtKoX2cC3tU3OBqOg0U89g+OxvbKPSi+B9rV3d95LpG8Ni7icDmM3sGcZRbNVFU5/UDmKoIulhC+8b5nMk+m2+S4CkvXsMPBDOQM+Ebn9YA25UJpHYkK7kjMl3ao7LFPgzLt+tJGmeZeIaghQ9IKqgFcL9tPTmvz+c87Yxh7P3X6y8hg0Y6lyM+DxEXr+tcQ3DD4hJYpTHtpafq5P3PpcV+j37WsI509LozChRVIRiDGRNNpk/qYoWmc0FglJwCRuc4e3ehcIVbwMhS67DNPZg7y738lMW+W5rugBa3WvKa24cqNSTiTAv1naEcpzwop07NQWNaCrbl6qX4rlcBb1LJvaWRiEaKxHLmUJAAAAD4L2wOQex2X01+KU36/JxaNGVnYQ5wK4AVRenlX/tQ1OSfxOQXtMnc5zjJwk5HLwiIrBJzoyo3YdhmeDsqttP4T8vFEUhj7190/SIlc0Wrfqx0iT0rEGufD0Q4k6h1sEkBldXoy809kOYzWKlM+ZpibvIu4W1aTeUc8N6SertJuj/B4Bnd8qcUES0DPQAtbMkLta55aY4qyXngg66FDTKxgt9N2MvJpQVae/UBfx4E3myMU+PK9xt1pTiT8d0UKQDdiymPkDmiRMUqCcTzqQVLWyi4JoUXgHSqKZ8NTS+XtJjvUcHfF6A0dUH756PIELsLk3B9wt0+8La0AzeDIu6dnIPImejMWACm9X7IqCgeBuhvYNwmTxF4HBwI2iLz/bfcxFu/Du/0COK+RBqdPPtoNayQiTH7UtHaQz8zh2Sws/m+BTI+ElfM88epOg30JQIXVn1ZA2xdlFI5LkMtEnbDEqVcAEDOJB1T2q4Fs21yjhMg6jFqFkYZ3TnqGcyK45Mt3jng/qhzHi5Wt44k2iBWZmP4SuywbqFOeUlwZXpAZMAOBl/gJ0YpfH2KN/KRY1Ej8HRk7NDue2ejmNZnBK9FOCaKO0xfxwV7kqCBFQzzlclcIGGmwMyKE9eiE/pZG2Vqu+Huy2WnJQysv8rpUSWZ1jwwiJbjWq4Lr3lmA2UJCjENGiPz3avQjmgkOigrQHBlEAd2jbVV+0Ob4y/yOk0ig7h5mN7nb9J1dWjReoL25cm+MKo+s0j4Zzq7ZnQJndPL4kg3B8tgsXzOJWsDpEstZ+sQm1WalZ7exa9M/n2pSmG/tpj5hFbKam8VxRL55Szme9JIVW2SNYkg6UAzMh+EYI+Pv530SQvT+lu7reUFdjQna4ja7n+bEvW5HWZkIy0RlK6fbg/5mdFvcrf0DlmUa9aXMi8x1q+Z+nM6gH8AQLt7dM02RE+RF86Celmb/bAYiFOadr4gQFwwm0R7HfjnZ347C1z17HcXOIR3KMXaAw5yYDh+Kpo5YzBYOMHelyM+uaARGezIAD6/fHoY3ohQLs3arrHcxbgM2TFWMrC4TAya+euK6gpmX1lONvuuDcf0fhbxmy5zA8fYzdE4t0x15D+jTw3j+9JOiX/fbJmYSE/Bg9oJ8vWAanTTapPzV0f52+Wcnrvjzs+4P5ceRdEHPA3iDdSZwIX2EcO80fX24bR5q9DH6AlstrPjel3FbHBFvhlp1feDow8Ypgz+gFt8zzy55EHfTMTn1PwI/6jcKcvSHFAzrfzJv30AMp8oK7tbp2sGPp1QWWgmUNA9IzXPrA75ZDvJKw43H7OsPO7McifH4HLPaq4kmOaPOQ79/68kivzWQWScEfLi8bVWjuZcSHvM3BpUGZVEi1PCN8Xqw2ZMVGSRluAbiYeCtiC232Ql0Pgfj5Venyf+QyXS/XqP+RMBItnvtF2hv7vNOI+IaByamU65iVYLRBsVXk0CImcJUDdJd7vEs1JC6r4jjncceIpEGEYS5HWErxPFupfZhT2MuWX06aWzexPEfoJdVKuxYBX9+X8scdqwIFE6jvT/PlVH2gNvhSKMZX7trn4DAipo43XPsQ6Lginnq39nsC"
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 7,
+        "previousBlockHash": "F8107812848C9230B2AB0FFA9D2FDB6BFCEFDC1ACC67B6DB442CD342489C676F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:k3PoL/4zGzXDRC3k6PoPczich2MsAVs7AsD+Ug1DxHE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:21/IiXVYK2MumKAUlb9g++Jb+8f7pty2vi+kIHKU9bU="
+        },
+        "target": "870669583413409794751345832897376592977547406352566801307278513052763546",
+        "randomness": "0",
+        "timestamp": 1683334021397,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 13,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA8VNBLO1Y5Dy4BxI85d9ttuaqX+VnfJaf9XmA+BB4BkinNbFqx5b+18/j3/LKNuxPiBUxig3MP290lUvP+xxhtEZz/N/puPLK/W3RCI4ym/exLYcDOgZh+5Mp6CmQBedg4EtwbeGYzwwf4Ev9DV1YA9kZGQ4LYV4YqoNDf/NhSg0M783MRJNGfwCmbeeWTmx1alRtdnuac8boMswAQ9ElBDAA+oeXgjupuNWxbCfXo9K5M6GNWr9J5klxZJflYOZAeyEmrAZOR8tfpIrb4G5/pG57KZBr4snk1gdFw17b7abP9fhvBdCjS3MRNtPMDCSnejFVjcSZPGMEpZ5fkMUSALwnGvoNucZlBCT/4knEExfw3Lmf/2KxiOUDufE4G5hAcmUAuBWtaUfg8Zneaj4KPNakDYnU07qc6yLUjOUXCiU6YGTPrrzRW0heu3PHhIhXF0y+Zj4/Z/G5FqCtzOidG+ME4FCAXBLZSJBR4myirTE4liiePmBdLu5SWcogBzoXmOwos9Krv7+3qoMIVKcx1smvsFZFqxak4exo3UvA98APwQ6yEymVYn7DXlaqdCUYnmYglnaN5NIKkiytyih6Dg3ztzTpcti415tTHexfVLQt1H8QJItQNElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcTcLZABg88ymHP+NkQJ3n9vIAS8X0DorrEe9jfBx2IVTLaOIsiXyuUyaYegUzsOaq/sU4Vh5eHMu87Nw65FoAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 8,
+        "previousBlockHash": "1180A55634910F880699D0B710CEEEA5FAEA2AF8B23E6FF14308EAB4E58F0CA9",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:y1Pq/uJoToqvRU1aBfoOU4rEV0DCbPmfOOIUn8i1H10="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:y2JnRg6FXQCMJXrwUXAhGRwOmgzRjHFxQEu2JQM/t2k="
+        },
+        "target": "868162857165578480563002226852566487623485369674008547560712452074684573",
+        "randomness": "0",
+        "timestamp": 1683334024231,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 16,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAABh24GT0Ha2AKu+bcgzNIVDe5dtea/Q/6BrS+tpFNUgOkhSFMJQCunx3XXyYS7zyZbhJalTtUX5U5HX6oxbh/63vXusq7cGN2oXOAz8WJ4WWlaycAFCM0WCPESDH6vS/2e+DlK4SWVoRRy9rlfelX2/JVAmoKmiCR+Zp/eSwCaKgNIuv+lxLuJWAQd2LAvijIM30AGLl8/b/xsJElksbHMhu6KZWVQ0iSeIYC1qHYAPyx/jtom/bYZk+Dnaajsgfjoh03lpwEH4sE/biNi+Unc09eaZvCErYFSUFhAPcTnxaGWrrUZZueVpbeL+RToX7UEzmwyf7D2InshFkgu0+aHbNxkDl2/Cy2i05MCCY5gyN9nkzZAV6gPoky3ayOH41tZZwJjtAY3UAQayqaKExj6l6FmlwtCPrAn5x1zWQZIKFLW7abK3+JXS/+/1VPM4EN8g52eDxCY3iXbrILsYy/iCDxSIDdETgGGWnY2xbjlN8MjvoSKJxAEiN+kWAD8ENvT8p7eS0aHHoEh2A7c+Wzbhdi/bo86XsXMkT702Jl3nA1UKS6U8UM/44arvCPoz45Gv+xMfxZudk+Sk4L+segcLUYHuYzmJnU8XpWXQ6C5DRnmPyFhtq7o0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwPy6uCNt8YZQwF/6kKoHcL/0AMvKyZjtyatleBxOMHx+UUI8c1L2nAsvwDphS12HovYcbGsllZHZFka0rEFeMCA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAQUDI+b+2UAbnxQOfrSSGan7PjfxjdDpMBs5aHqmi2FW1Q0SYAZja/MGt/SrVogHTrLFpbHsj62mVgYme6Bzb+5R2IWN/LNU9jk91H0MPGeCtEBvjEup0co2pKA2rsiCP6Zwzc8txnC4fHq6DSduaZ8vpojqHP6gGSJLL/6b9eXsOeYOnoAcH83PtZvwkGDO/8p2LGuMKtYXSM2GXb0uhGipxJmG1MhFBXE/GQ7hwt+WN98Go3soKpEzSGl97arzU5dImJDoaT3GTuo2BVHREfJFFapbtk24VccEhrRKZWQTM37QLoQVQjofwczT2wIeRZVQb/58Mipj2vRh7ycMFEJNz6C/+Mxs1w0Qt5Oj6D3M4nIdjLAFbOwLA/lINQ8RxDQAAAMELR95VBD+eDrQvba2qWTzyjwpnL2cx13lz5m9ckzthuLGFJ1pdkTxAWU/K2UkdKh4OPQ31PYS9YqtujeTGaryYkekMFavn51T2Rzmvvyb3omV7rTogocJ1PvkAYSnbBqnmbSfGle/vJRJNTQbSQt88pJltdi5vh0bgwDxd4X1zxCOYNHVRSRu4TeYSAEUQKZjimQIK4aDuLftzhw3NvSxAZ5QYuZKjRIBUO5r7nNgDnPJTeID7S4xhccx24n6X3QSkC+d/x1TRGb79VIDqSc5BL3agDFi/zcSYDUk5cuSHt+gaALENY68hk1jnT7367apFX9X5zZe8PUgAca0rnNAy+AqyMR7xrrkZa5K2/E127qsvD5aOhEFhosMgAFfeQ0wBdGr5u5x8sRVI0CchV1rY/XFtNeVe6g14lVicvvjoXa+Ezh43MRVIGlUPCdNm5zw9DnyF6gxBWGxoCZAqxGzJf4StxjH8wJjF475FB5qrtfuHlcZm0PD1da8U+cszN3qvtfjJoU7Dkco2YTus3VYf4BKbGOQ396M+q1b2qozd4MHyxAAhx28E98dQBa1/R/xGLQWyfY55+f994DZOCiPLzJOL6XmYmWAjqdr7Mgidl/6+/qZMF/mgmGq135QDM0nizVwaCOWy5hCV07X1HjTf80QxrY4JdXgW/7vrtf8WPZ0Y7DivP92ryFNOS8P6sfg9z2boA/YQWUiIS/hq0WglOZqcYeHIrZc4TGVmw1lTn8WFp4YpA5NXd6G8+CCmLYc7jYJotTgVRrDQxnCco6Xqw8nkPkc7LiP/8f4esZu3xfrhX8qsGduy53iJJH6aSdkgD3fEdAxRXgD0oKfycFFzZeKWKiwoDS88LtbL0jmNLx0oPHHziYCl3SjkjZtXX6Zfotagge7W0p9QUhTDQPcmhEqJDBEoCC60GG9DezDUUxensmPSPIUXbqMtB6xOTV20q29LWCoKGH4MemGAPwwNPCHxwC8RUVAoTvM1KZoNRah/0Fc4fUi4iUVAbKBSYaAUOf/MNduQWJPwiBqrPJ8TSncMCMwVM49AFIpPRDNRBdRmRT7TUdE17Ug4i/x4jhXPy1JHupPN18aodUu0iaAEyX0XAB3pEGZfHtwuHFHbBeSmnMdCrEmE0SimOH7RT4ta/QzWs7QB07fFOaTHXUPj0eyMl8UibRq3XRALblldewZfrEkeCmJwVl2HgpkLfzuyY+0sNmmU60bUSFiSE2nRTclb1g2eB9rQbIxOFYpKiTY11IRYJ63wtQIx5hybq8SstBIjRrynsYShr7u4NHcfxI7aBEX597zjeCbR7+XHRfrCnMWHOvNcty5i/LwbB6j3C+kQsvl9sHFb6qOyl92mKXNsd9+b+p+NDhJstkfLGGXp9y9tZ9IcaV4KhF/txWkXdq3fMuVUsN+kVWN1gSuqAT2kUNevz26FKDK85L5+vnnUKMVlN5+p6hZ1R+NUpH47UMn/hFwwSq0SN4XT4YrjPhAhxIraFGfsRkCYK7TnaUTHMFcvQ9yMC03Q8WyJ5efpPG12vcoWq3PWiJKPKeO6MWka0EiM4BfoUN6LIS6wxczY1Wfa2JR7EIYQ/HqNAA=="
         }
       ]
     }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -868,6 +868,16 @@ export class Wallet {
 
     const confirmations = options.confirmations ?? this.config.get('confirmations')
 
+    const maxConfirmedSequence = Math.max(
+      heaviestHead.sequence - confirmations,
+      GENESIS_BLOCK_SEQUENCE,
+    )
+    const maxConfirmedHeader = await this.chain.getHeaderAtSequence(maxConfirmedSequence)
+
+    Assert.isNotNull(maxConfirmedHeader)
+
+    const notesTreeSize = maxConfirmedHeader.noteSize ?? 0
+
     const expirationDelta =
       options.expirationDelta ?? this.config.get('transactionExpirationDelta')
 
@@ -925,6 +935,7 @@ export class Wallet {
         account: options.account,
         notes: options.notes,
         confirmations: confirmations,
+        notesTreeSize: notesTreeSize,
       })
 
       if (options.feeRate) {
@@ -935,6 +946,7 @@ export class Wallet {
           account: options.account,
           notes: options.notes,
           confirmations: confirmations,
+          notesTreeSize: notesTreeSize,
         })
       }
 
@@ -978,6 +990,7 @@ export class Wallet {
       account: Account
       notes?: Buffer[]
       confirmations: number
+      notesTreeSize: number
     },
   ): Promise<void> {
     const needed = this.buildAmountsNeeded(raw, { fee: raw.fee })
@@ -993,7 +1006,7 @@ export class Wallet {
         }`,
       )
 
-      const witness = await this.getNoteWitness(decryptedNote)
+      const witness = await this.getNoteWitness(decryptedNote, options.notesTreeSize)
 
       const assetId = decryptedNote.note.assetId()
 
@@ -1023,6 +1036,7 @@ export class Wallet {
         assetAmountSpent,
         assetNotesSpent,
         options.confirmations,
+        options.notesTreeSize,
       )
 
       if (amountSpent < assetAmountNeeded) {
@@ -1033,6 +1047,7 @@ export class Wallet {
 
   async getNoteWitness(
     note: DecryptedNoteValue,
+    treeSize: number,
   ): Promise<Witness<NoteEncrypted, Buffer, Buffer, Buffer>> {
     Assert.isNotNull(
       note.index,
@@ -1041,7 +1056,7 @@ export class Wallet {
         .toString('hex')} is missing an index and cannot be spent.`,
     )
 
-    const witness = await this.chain.notes.witness(note.index)
+    const witness = await this.chain.notes.witness(note.index, treeSize)
 
     Assert.isNotNull(
       witness,
@@ -1081,6 +1096,7 @@ export class Wallet {
     amountSpent: bigint,
     notesSpent: BufferSet,
     confirmations: number,
+    notesTreeSize: number,
   ): Promise<bigint> {
     for await (const unspentNote of sender.getUnspentNotes(assetId, {
       confirmations,
@@ -1089,7 +1105,7 @@ export class Wallet {
         continue
       }
 
-      const witness = await this.getNoteWitness(unspentNote)
+      const witness = await this.getNoteWitness(unspentNote, notesTreeSize)
 
       amountSpent += unspentNote.note.value()
 


### PR DESCRIPTION
## Summary

supports creating spends with a confirmation range. if a spend is created with the chain head at some block A and the chain reorgs to block B, then the spends created at block A will be invalid because the commitment won't match the root hash of the notes tree at that note size.

using the note tree size from a confirmed block instead of the current chain head will reduce the likelihood that a reorg will render a spend invalid.

## Testing Plan

- updates unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
