### PR TITLE
fix(ironfish): Check for transactions with duplicate nullifiers earlier

### DIFF
--- a/ironfish/src/blockchain/__fixtures__/blockchain.test.ts.fixture
+++ b/ironfish/src/blockchain/__fixtures__/blockchain.test.ts.fixture
@@ -3190,86 +3190,6 @@
       ]
     }
   ],
-  "Blockchain asset updates rejects double spend transactions": [
-    {
-      "version": 2,
-      "id": "fbf05765-f889-4602-bb19-92206ed3b9cb",
-      "name": "accountA",
-      "spendingKey": "d88c16dbd419c83ca3099a4e1b7e309b6cd279e5edc9cb6ffbe264569a4efef4",
-      "viewKey": "8c6a0d222e5c40cfdc6748d957fdd2d750a9098f2698f397afc8f7211cadcae4de315fbfc96eb21acbbeaba51178cb70eb8f00debedae6b964ab0dae0143a824",
-      "incomingViewKey": "db9e5a28c553dc5cd1548e9629c972f207e2ed88ea423c8f73ae2b61994e3404",
-      "outgoingViewKey": "1dd84f03a4b59b81685680653671d13b72e7ed90a3d55be4f28fcfdeec4a4a54",
-      "publicAddress": "67b9176aee1ba5163fc71fe7b88080287f2f263a233a28e058fa3cd75ffcc889",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "9a82a4c7-e7cb-4f12-8e94-4f6692882199",
-      "name": "accountB",
-      "spendingKey": "26f6481edbf187f89194cfab81bc761e7ffb29071678914cd5e7f4786c3f4d7a",
-      "viewKey": "441c36d5372913ec1221952a59e8d7bb60b2250b87357c8f0c1dea64c579c3a9e10d503efa5fad0169429a417f867052e9a8174ad6ac50ed4466db805f9b7429",
-      "incomingViewKey": "ad9f00b1be2c20051f4a3cd3366af2d5215c66e98f58bb0d6e22eee9caa51407",
-      "outgoingViewKey": "adcbb75c7ba10e6b20a87f01ca92bc97cf163f2f3415e00bc7f09169ea00bf4c",
-      "publicAddress": "d6c1a868afa11f4877698a9ba62fccd43129ca8686d97360576776405f4c2802",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:+KOv6t6mE21hjs3W/du9Ch0zBKrWn2GyZ80H6iyo+SA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:47kB4u1C188xxsaATdzCSdLmphHRNYIiP3oFaVngKkg="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1681340290258,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4LAmcXXVrEqp8lUt52ZSL7Br5eT8Z2OMCUY89mvEvsyxIRgj+0mfrveewqSay//b5RYh6MZKiZP30wROkMZ4nh3wXWaTgPa7wPBrasv51WiD7JPoGwxMOMrOcMhM4ObBxBJGgBtl/OFAFTdWevQd8wKgvvHhQa0Te9FO0c/V/ZMVrslxkJOm3zkCMgTwWrIbb/OOhzn6h4VMUGl5yHOglEnfAS59KKKK0ba+OyiT23KHcF11/Ymry3EO7WywLaBLAGT3HVCf2/EIUfFr6gGFJ94IaT0ybt4C2SwDciBshzgmQL/3e4rQnbrj/wzNYd6sCsLSTMwht0KTSTN16jYJD1qKlk4nKsb8ODQ6hMY9+OUwLiNeqcuxjb9lWfN5nd5eVItZo4KjdEDAkCSc18GVcZuRXcCSs/54qjtDSDaTJiiMMBgpXwHg4AkBSUOKYrsFpJX1eE6VztO27MmVol6/qlmySsYAYkMYkLr0zTnMkMuEHPBQg8g8DIov/2DiKl4uKCTRo5DklPHupgDKFU6NICY3kX0dJJ3getLl3UR+DOTetuI6ONVOtmy2cYCaepnAk5YcKUHLxxViGeNZA1UKtpEV1lbFkphUI0h7ocGWNvb7xNsZRTf+U0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwko2CRL/U1z8Kg/BP9cdSgxs6zHbVDI7IntLQpHJ0xOjs8OlwUzWop7UUkAA5ngeL9qwqGwNwI4FqK6/gmtBABw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "F668FA2573F84FA3749B747260307069ACB3939818BB27BACF785A9F0913D4E6",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:1MsvLinys1w8jiGd2zjYGF+76IkSoX8f1C2OYguJbUY="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:vwtzzTgXrUL5lOAz0HQW76EtN1mjW5duhFZ7nC/N+SA="
-        },
-        "target": "881271989446208257911980828427057262643615932976441214377264856368067535",
-        "randomness": "0",
-        "timestamp": 1681340298236,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAkszhP2P9Yy/XOkufcFvqNutLKns66YBQvfkOfMVJklmJ/ixFlFt5Z0od9lSpYu1tYBzeRtbJbbzI5yZE8lt249eqLIKBmBrEjHo2oQrRBKOqgFRCKPj6nGSonw+4soG7YrcdHdvkCpN4XF0Nh7K5TgXUF66rM/7jhB3AXEfWSyANVTP9tcq+NsJoGiWLoTIekgNq7YXbhQu8raMQD6aWfNpZnbtwt1uR/mYHVNQxPvezjmKq29+7CFZpBTRi97kazdGUScQhtlLOao6ou0Dz1nLBEEbAKj9kAYGjDiVafuNVZNlrHShvpxUy59gmpe7Z3AWS+EviW4DfJ9fEBLw/tFpYrWEylrHm2DI17IbM0YA4FSYnSFU/9Rjwd57bRGBz7udJjauhsnu0lnfIAo0iYhAlpfMOJOicZyilqX5YetE9BZDJA+G+YFJEpjLqQdsfuMNPReJ+ZRxZOxeNyKe4LqTBKRgehMfRgXoOQtF4JPphXJduaP6IYk33LcQvtv1LDEXo092raF+jbi5AirtPSqurdBNKNekJbEqgpSCkp4EEpeCmxOLsE/1Hq1jAZASJGSPMbsNXI8f1R42cZBZAdq4XSK1Y1yygWGEJolIgiaWjvTa+8bWbT0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxPWP5gz8mEXzXQ1dqz11GvL8wapYpV0QgBveswssgdw9bVuqWNpbUUJ/tBSrMOxuSOf7J26IqZNhUgdK2kJQDg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAyVvegxbgp16w3ILVn6iUuOfPMe0rgk51MmeM0sO8+AiP/dLae4vDsXEn+g+oMi4iemG18yq56eYKjDNAyu1NN2U68IKBw8qp7PEClfVcLU2iBH3AWxDSmeVesaMijCYZ6JjwMge0B1s38B8g69SlEvJwf2BlkPTwExuXiDqp6sIAScYFA4LGMPc68d6qqjVR4jAq6yZV7CN1vYSO7J8h365B8o5vUwUj5ybBqc0MwXuRWptwJxblJcMPpR5NuEVfG+S9yIRAecI+G/b1AaDZ11lrosh1YJHfMgINLBiTr15lQz/gHEeTNknYGlcnVDZ2gX8ufAnXjAk310BYVafvmPijr+rephNtYY7N1v3bvQodMwSq1p9hsmfNB+osqPkgBAAAAACQLJi2/67ePzVSX+hwLVQ9MLQSYtYbjSsVfqOVnc3BX+D+Tsub0DIJHoo2uN2xsam8lAP2tKp45gHa48nT9u4fBfL5ctCe081lJvexR86UgxLTpQik+4MDw5DBE0h9A5Y1FeUDxevKODefeYXZfwlNUPcwGuL0Eoj1Q9W0De38NbisMIJaXSVwqFq4cy1TiKtkvvHmOXreqBGSeKejHxyNtpGoPwIXR1dakGmJ1xVl6WIZAAbfpgoe/NnrOpVy0xf4zhnqxwqk7fq5x4JvxGD2Eos6AINu9IVglUm5lT/+pMxBJNFs2dSco3izlYOFgal+SOAAEL6WGu37sgvrEsLPgW9XJnLe2YXL/AHCkpNZOfPlnq/y+9i4TrhBgVQoib8V3Wi5W0HpnA2siPiPR1TzIJPfxPD6URp4X6lUXG5H9NkUuTn13sJbnVDFm4JvXIFkQXDD6Tl4d9d/k7de+2yxBRYCq71UgSAxcqEVT2lAFMiZd5LildmwU+sS59W+kZ3wMzkKS9HY4xUCfV683V9LNzVt0vmOLrc/Z8c9GnrVhgzhzVdNKriMmSdfZE7DEjwCf3QfsnNu1SkUkW0FTIgCv4MozGy0Zwg3CMSg8Z98yhIK26VOHKm0AhDGf5lA/niqjYppxMYOEEIA3nnw/W2J5HqKi9Xo6E+IOd85rzoqLbsO+Impq1NMqRfarimiqxYSZqUIja64HrAig+Z1VJZ3pbP8cwh+GJTopU3IvLcBLsE2hzV4WU7WiNzka3dmO0HL1LDjaevRQ1sGnal2R1hqZGjrECYG/XmS1zpra5FEVPWi0hzYhY+K/PZu+e3sMAIg3XOYObNLecHSkGu26c0JttNc059HgQGuBPFA9Yl3cLdsqskJRn+T2p7DAfi36FiK+71BPlc9gTjK/knml4S3LU6lsBEmIpF6eXXe8FhiIR8y6bNMty8EpxER4PKCIb3ANWMU9IS71/IVScPBZqyKADv4blJxO2D0hv6hUj6P5Bs3Y1sc1EuK0QtJgW2QlzwcyA9MYJn47k7d62c9PxOf3giQDKZhf+qtO+CDpzRinCPxM6nh6oFZxXSl86ibaf3NuAEHAwbCcNaPxj7fJwqfcTUppd+gZvtb4LoRCecN6bT8cReC0xVw5zcltqdPm/SGuMD9IvxInSmkqWWeA4DPZ1FalzgsaTsDVx5xTGr0e9wa3Hdg2xDfELCq5N7+cTBT42fh1dwlRaQq2i4Wt4B8Yv36LDP8YI0U2Lp/VypQ3ojbECI47lXwwu6HlbGL2DcZIBfJ6+LRk54DA5sdpHfmfyQWEsY91xVmC5CkLEalFDsOEAO3vQQKlpRt3ghFQSU1tXER9hejbpr5Sd8d/lVIeeMLWD/MwmL6q86GWLV5OLVwn2KIRsI9IQTYMYqKRqj2zeapopKFl2ZsEPobDdZUQXL5pGR46gkaNzbvWYW241Np/THsVolbeDjwPb0gnJVOpe+kP9YZy3VrALWJJ4BnNSAwRRkxc54EyQgED054c6LY9HgNqBRsQ+HB3KOouAlsUCJmYuk5gMdOBuPxstWyNHr72oY4lWZLs7pyGfJf/Unr57HNzNqknB3yMjJuCg=="
-        }
-      ]
-    }
-  ],
   "Blockchain transactionHashToBlockHash should insert records when a block is connected to the main chain": [
     {
       "header": {
@@ -3525,6 +3445,189 @@
         {
           "type": "Buffer",
           "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcwWL1IgDirNdQpEcvYqJtvYzrkjbZ2Q508ZeXVKmyIyKIzpEDT98tgo7SFAcNz7VAe32/S5PGNmwc8NJiFgn4mIrUfVSZjAM6A7ik+KKlfa4NyIpf2IkASANwwYbcYaEeCsQPxar7uREa+dh0Nr0KTF4xZc76p3GmaT2HkpwPRwSj5G8YdLqkNERirJ94V9FiVaewcYkO43Sp3y39JCnbyFg/ibanQqHcPSdoy+pvsKnu3p27c9j67cWtHi/M1OC/8JowlBX23+3erCzKp6ZvPUbbx9k8N3OXG4rbDENILpK9Ji57RZg/3oGdpc2vKKwSrL63K4j78s+/HcfC68JGr1TSqQNQilMyWPYUy0Dvp2L/lbrHH/AF0luz3oYDKxaNxe2lb3gXA/TZ1V/7In0hrOxXmIn6lRAhR4g5UJ87I6Ws2q3Whes1OaoLh4T0U2GUbxNjZDX/0ynxd1j3Z/UBi3iW09ZivrtQknADj+LGrNXTGsCvfsVvxhwh3+sqLaSkTyBs8uO1dyrsn/KQCIuyzh476ejrUWD0eaUBWnBi9y1mJYFQRHdGxipgPRBMqD6YIUYdR+zNx7cM58TiZ5IuTZ2/4LA7omD9CoNYiIIUD9kdp2pVIgdlElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnuRrVvgGhlzUxqPSEwKXJrDDQDklqXBxYJ8XbVYH1LJ4A9ei8VVUSQtRbWh7Oir0GHOBxmLS/A6tnAkbil0UCA=="
+        }
+      ]
+    }
+  ],
+  "Blockchain rejects transactions with internal double spends": [
+    {
+      "version": 2,
+      "id": "1779cead-badc-43c5-a350-2d4afffea1bf",
+      "name": "accountA",
+      "spendingKey": "927883d076018a891339c7ce1800414c1bf3fc98bbc83e1ac22d31df1358dfec",
+      "viewKey": "ac714d15b88902614eca67ef16fb201a898cc6fb84947ad57fd95318732b81b8f6cecb3769733a0578182161b9b6e151d726d6eef5f26e431734aba0e58425a2",
+      "incomingViewKey": "5ab3cd68093ffc5fefad626000c3523924a7e79dde59270ad5dddb0682b2ab03",
+      "outgoingViewKey": "3ddc2754a8ff9a436303ad8b0a1fc95af0f90b89ff0563bf96d1ce789639ea36",
+      "publicAddress": "4906bcc8254a9d331c394eed716d6aeecd343547a4d4d15b6fa99f04bbd27e2b",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:cgBoe9hBtwuEa9LvYukDAqPO0qS2yrvWPqH+ulkX4G0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:PUtJ8gHWrpaBlsIm+LchrSlw2vePVFxiSMIdl77U3Uk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1683239656667,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAxiooVX8ae10CWvLwVy9A9ALrOP+DWIHk9Tr+CsaCiRGqjzS7wCckzIHSLNvNMIsI9+TeEVbwghy85o3d23UUZxgpdCu/KqA0RdZ67Rz52k+gL/j4CN0PpITf3gcg7RPHbH2brItNKDsIDp3PofDtCtNUwurl5br+Z9m+icBpZ9gNGmXQR6LkK2rZl/MbbwBdZbeyg7DyKSu/bhZQULpsfbvBjnEDExVVoZjmSscn3nWwU8rAGk1bQmjTkvSLaYGtPijiecpvGDPAMESjgX2snG9VA0D4rpUWL1nExj3YZDNLqS2jLxb4jHzXxm5MAA7XqlkpZi4Qr6lypwmgeDLiLKflo431r5z0rf4ydYNEuXKk4cqTgfduYZMPzxEL+WRONVr+ke9I3Fkvm9FHzpazURdbcqQ11eWNXjCuZov2WeFu4K5ERelA5iMWo/QitWcQGJSeD6zj17FdN5WBtg3R4XGUSLZpRQHUrurX4zLvxRckksitMwyLqjPFxAHFew+hCARAzb/IXfwYVGxOYUW0AI0ZpneCg0loW97kHIDLZhDBXQUeULiuIAJejQxPXbn/E8//mMxvrsCMagAsSYx5jiwVkR+OqJW3qtMUrSReHqNloYbLubIZPElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTGcuDwY6Jn1nrDj7FoiW3qFuzRPcj8DEp/Ha0+MpF5JVgd8CcQc3d+ekadB3ZCdreaUQbsYri1HraeAEdBcdAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "E03E6F2D7551DAAEAEA896E56B08CB2F4107888D0429F07D08E646B66F119CED",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:6GZwdnG/u8ZBIKY5ftlO5lye+xeGCsknZ/5e7WjZrEo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:NmUSoq59tgmKab/OE5O73v6cqNmHD/ZkIJGl48Slon4="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1683239658658,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAnZ9HmBTl0TSChWVseHyf15WOsBpWELDY7JrtMMoI0zax/0lP7iB8bI+Jb0cJdoyTg+JkEXAAVKchqD1V1IpYDsvCo1MqgpTtwWSq2/0pMwyrWmRaUDkp7TtF3tE6FgvjaH0ppu/hpgkYRgkamvx4T5rR6LShhHltDXGK59UB8nUWxaA8ocSaqjh29PbTyM8WMsE7Xqj9/Lp1SH3adLMOI0IdvsUUWL5+l7K5XaRZxQKPzGsl+dGh1E2mgIMaHTuPAwj2mV90kuUQ/M8lNijRasmqWzyPFkpu3TphQbgw9AoxhMXgMQDEdmGyIxQz1+oLcaGSKIunFfZgWDEoWMc9iyRAlbEAi4nCzky4Rs09UlwUVjvHmXy1PEtsa5RhSachGOSCwt0V1D89MF1wIUC5e5+A4w/2HcXUAMw7i9I3jNPqFAEAtVSFruWI7/EQKpUqq/eli+I+Yzou4fXAWt5Lt+paFtFOG1DZjMOxrmtGBksef64fUV0NsjSn59rwyw1LL4iIIFMA1hswZTPat28g2o8AaMToy0GbvzszLPdhYaYMEXQeHOZCmcev0KlTIpSmlriVTT2xAQg9kysXGMuqcLWiu3hVOdkyCcl1nMS22TmpLOf4N5Ranklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvCVhQe+HBSBsPhN7c/G9aBaAOBRQhVkgkEUWp4zMc/EP0jyjS8eotRr13iBuSPHri1yMXADvweNVrGK97y2jBA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAH+hyyuWAy0OhLpqr6DB3EOstMb8KsUFOQVztjgzy21KE8KBvXTBG/5psCrnxwS9uAbJd933a7wKhDPKQQZR8ib77fs5rHtwRB+4mLm5+D4KBJx1zyfKXvmXPwvPonmi0X6dNL8PalGDmNu9dmfpXCPPbXVhVUZ6mgoYznUDe1twIBYJiDLwAl+zrolHwceN3c1NRtXSO676Tt5GcSkaMLmPXiqxHmsYmP7VrTmUKaC+4laKuKaTcE+34s7YJlnlJX+92Ww6o4+L0+bupASg2fRyr9TcYmwDhxa1bNsC2vCBSEoEkxhUDW/kZazqEEK5N0T9/yBuTN3DyToOsn3RNH3IAaHvYQbcLhGvS72LpAwKjztKktsq71j6h/rpZF+BtBAAAAG9qoeIKo6u5qNPQdu2rVzyc9CC2CWwWVm6GK0nWmCt6F43d/LrcehwIInktJMiya1Fqv/DFWghVYMnKqGppgsYCklSN73zklt9MXGX+L4ntZoKTRPdAbYRpjw4I4XiNDJZeVgYnM3M+3xuG13P3uc/Nk/nLDK5dKxTGAL87DcS5pftYmLEhXSkoQrb31ZuQRKb4zujJpcsExvlyzdq6QCcrP6GFl8pqda4cTrzzppgYJk9m+Mhf0UwKLc+6vSKEuRPxUBKth7Hriie4zpEUXtMHunE9OwHE1yPKJe0CXtMyDabgiwQ+5dLym6Ga9ul0/rlvEfycYsKXuI0FTsd1g3IyYi5UPRsVnT9UwXyOKc0TvlVoCRSqlKA3pXzi4r8KxdwB6NQX+aY96cDGR05wLXKfHRekCio8VOX8Th80G+IIIvYAB3jQyGDx7Qh6wZ1zlkHgeO+JsE8j/qkgfdo4DnIJn1eDbM+pOzA1xf5REst1g223M7Ah3uivxhyP6uvGFeO5zMipha+OP+MK8bHaMiuA09OfYfHah5k7lmcUI52j7s3pCZ8nLwcAdOggv3heLGYbKkBPz5w+hToNE20oOhkCkGgZynYJWsCcrWzU3bERbNAsCkVGqLw4fn+x/X1BTqO9gLEP4KjORQTbWb7cxwcPEfTWLg1eVfjwrkVDRblqbEOeuM81Dwi23xJu1uYv1WCa8DGtobW8FvQi6EMFn4M7ifN+6FtcldbGq7xTtlOOLr+TQAaDtIaeDKF84g0Qv3cu5cQ0jshTOdsSMYH2XoNydi0tso3Cg0zQr+o54OdCMLChpi4qjvOH098wEA2o8XObVXyz7EGu7HoDvh8H773JPNe3V68WW16K2pPZW9LXVrsBMdJeu3KNPAUAk6fBbE7f4YGLMY1Ul0SRmN1U7U7Hm5PA/G41ZyLPN7RykM+bNfFCDauZos8N5Q14QjmyP0xzB7jh3yp4mOi9NfGBq1rp2/7VdI5pRd1m9ppOIK+wk/oCyIBGQZiFf1NbaRfe8+pGqO4Nuhq7Y4D6fS4QZmtQQ1yBcBFjwgUKkoDLzbvqlK0ZLdd/oFiusxr2Y8EatBf14CE6wmlGL1MbdqxpZtBW/qfbGS6Sy7iVl55Gkz2QxakD5j77dv3ZeloXXI6cVV7O3PcG7G5jsPls2t1dcHFGneG18llYK9/cYkM+/UIokllj1Am4+VwFghGI30WixDPZQTFgXQAcWOQw2141pjJifd65dn0It6dUyafnpMyeuWtXV7w8JRoNx5V0/9tgCA0dcnYkCqXpDjd1IlcdC3yKtJ9ohiJGpKjKtxfjQHxXZZQFytk+aZVBMtM9a0M1JROgTWiADIGETVOxc2+kHhfbkOzwSrlSF2RFDMds72MQYuP8unHEACtBbt91V67DNUHCU842Zy4xjEsfYiqCEGpRzGIJzRSx6jpNKFecYna19RT7CBLhxjHKtplFh4WKxNRZZNLSp5Cu/FTBRhqhqKCStWnjAhmR2gSH/sTgVXtDKTl+d4ywuHzc+ZINMmH7Q3UvBR/jbjwYKdWLX0EhrPCZKkRiRRExjromNA34AHC5TrPacmboWWPKA4im+LcZDg=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQIAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAUU1fMweepJ7CKRqOFHeSY6WedyCN67Nz7gmrrXGWbCuoEaC1qO0Xz0clQMuUERYPX6Dr+gnx2D5oSuS12IN/+KeHrfZvkjc9YThTXX87d5G3Me60+siUYE+qNUiaFRhlEjg+UMJl1kYUGSc7NMCnEJRJq1nq2ncuhASaerC/iLwK2d3/6+Z69r+LLN2nS4OKtvBxEEe/CZDaYH41m+7elJdtnR9Gnemh0iA346jNckyR2juY0IAD+rTNPvpVpb27ObhA+xF2s18ukBObRLIHXBuF89svKSsTEYrCkYppDPgBfkFYBlUfopWmDEM3K/pc8LF/KQUr1Mcq5tmxIFSjA+hmcHZxv7vGQSCmOX7ZTuZcnvsXhgrJJ2f+Xu1o2axKBwAAADPI8NfDXbtyZEUKB5ykQm9iPop2Phl/mM+vSMSxz3m+qzqxfyR6VjBzWDT4Rq9eVkG/xkueiXkAL0ZQPEJMIu9MbKyAuJmwhKafFNmg2KTx0o6/RtRrL7HrGRuqym/iBJNFzfw7XZmqPJ77u8Jo1F+xtpqsx+eyBxcLEV/vfWzkxcBIs512Tf6oqlsqOXel2bICOsAplc8nH109JYPi8F1q9zHkUtRJaWp+7k6C42yyJPTHnitlwK3EHuDAXRJeXgl59n+n1h2nZTqZseo3Q9Qp++zKFgBufijvYtowVoNmltiHmtJRwsOk2jWCe9tn8qAS6RR/ERjql3RIt7qtZ+//2g8pB3G+AxXXh81vP6u2xucnZDhHCHgCVLdMuCm9yHqzdJ1zoIVYXGw9XIDOxbu9NLFdaH45YLvsO+ICmepJ6GZwdnG/u8ZBIKY5ftlO5lye+xeGCsknZ/5e7WjZrEoHAAAAM8jw18Ndu3JkRQoHnKRCb2I+inY+GX+Yz69IxLHPeb56CvdPj67xvlLqwCGzFgZetKkM3xfOlj6svUIbbeflVJzRuSElZvR1xtSuBzGSlu5OmF06UILJ1Ct6wgyXlEwGp/Sqlm9z3HYjPVtz2pgNg57SISfT/7PG+OGJu5e1iFVzRJSt4kkPvq633kBavavRjJULr+mYg550PU8Tsb8MZUg1L3ecL2KK4k2vrvVUO4aeMymBWyeaIM8ssiiJGHBPBG3cn2uayB1vKJD7hLGpJhYk2V9dmBLEny8W1KcaZwZOSbQUI62ny+82evCGsfXKtBL6LeS3Bc9vgQblpfGJIQ+pmmyiuSdH72o6MYpTHHWZSAi6kXkmU5FPGdYE3+65Qa78hQaUPiwKNxGq889sGf/me02r2NLZv7IHmL8eI8H0lsAEaa8FviXeYe8Ek/oPCu51IwJ1u8hs7xTh001WDh4iQdMLu44l1DKchXZM9UEoJDFYslekmaSbi85yScRumGHrHmPRIWV+PrhKYMrDGvOiA23NOztwJY0FLeM3AZN5YRu31ymehEbpA4wuX8HTsJODelPqckL4fDrao7i1mnRSR/vT0N1VJYzEMHE8GTwEcccEKQ4sRfIed5TMCwann+umKUgSG9siQWpAdCM6Pr51nWPL0jxWQQd02UNaIY8wCXs/quJe8HCdIPOXafTi3bGggkVSolrRWNG4wibnvWmWS7pMlcm1JEI9Rwo56/zTBh5fi/1p0TgiXvAyvFwgqs3jD09lKwDkgrT4NOQY2iWJSyvHlKa1FPDQr6801Ww2VOCnk3LE9jXIGl+k9oKUk0Kf5d/zzSVnklAn7NdEKXF804PuJUniGospQPi7uDm6/fmglu4Pfj8xtdoWTP8CAHlEazJAXAc="
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "E2C6A2A1DDACDDB1DAB277D99D781C1850C7C7D41E7302D6CDDF2770B429BBBB",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:C8p8wopGYz2RdZ8qLOL0bJUzfgJ4GpNCPHgbhj6cU0U="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:VFal9/lTSCdJkwiFC5mSDPyFYyASssfSGjvBlNFa4KI="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1683239660924,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAnieI7ADCzUsFkNJOOqSTKPuZThgwhg+D182ZIDyGADmnqYoiF9x8O51i2+1IT5X2FEEJg+FBtbWjyGMqt12OnAfjqKyLQpara9ExWhm277i1dX/8NpArWwdjVq9zvdZEbYrT1wCYDxj3CcgwmvYZSZlJ68numun/yeNFTe9yjKgPFp9q81nuahZkRJJuSTncVlBWeqoJy4Bw8KrvwOjlJyGw2hVkcre2xo5G3DA/GnS5NG9RBjbOKkZExgYLt8AO7UN/QdDdobMEQ/GhefvXGC+0+o3g23Miegg2BMV5MfqWCJm2KakhDu5lN0+pYyU/CEMPY5qQvdgReHhuqzT5y1Rxg3WS7u6QGbL9hjHK0SgZVGl5ntcatRzAKvRG2zNCfnK34Y4V/ZOIzZywp97O6EGzgfNr7fmNtdfjaTY9qZW0fsbvFPVtIwa9mzfyd8xbrHdkT/y4CbzgELZkZZn/3odxJoUyCUeh1SlsmSPGi/IgxeSAY4TpUg7jk2N6VmXRW0WS/2AEHb+qQnz5TBva21pafh6aoGA/32Xlbi+q/Oh+6BqEmnghJDKsSA82l66TwYCWcw18EcG3VlQlNweVAH0wHIZqEGYvzZlHJJncT0DlxWB27OkqUUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTN6PjfjPfXcyfyFUST4Jki/0f5Wdfrwqt1qvI/7FqTenjeS+aN+9t46WxhTHxClDc2ruhmcycR7rqfE4UfMGDg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQIAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAUU1fMweepJ7CKRqOFHeSY6WedyCN67Nz7gmrrXGWbCuoEaC1qO0Xz0clQMuUERYPX6Dr+gnx2D5oSuS12IN/+KeHrfZvkjc9YThTXX87d5G3Me60+siUYE+qNUiaFRhlEjg+UMJl1kYUGSc7NMCnEJRJq1nq2ncuhASaerC/iLwK2d3/6+Z69r+LLN2nS4OKtvBxEEe/CZDaYH41m+7elJdtnR9Gnemh0iA346jNckyR2juY0IAD+rTNPvpVpb27ObhA+xF2s18ukBObRLIHXBuF89svKSsTEYrCkYppDPgBfkFYBlUfopWmDEM3K/pc8LF/KQUr1Mcq5tmxIFSjA+hmcHZxv7vGQSCmOX7ZTuZcnvsXhgrJJ2f+Xu1o2axKBwAAADPI8NfDXbtyZEUKB5ykQm9iPop2Phl/mM+vSMSxz3m+qzqxfyR6VjBzWDT4Rq9eVkG/xkueiXkAL0ZQPEJMIu9MbKyAuJmwhKafFNmg2KTx0o6/RtRrL7HrGRuqym/iBJNFzfw7XZmqPJ77u8Jo1F+xtpqsx+eyBxcLEV/vfWzkxcBIs512Tf6oqlsqOXel2bICOsAplc8nH109JYPi8F1q9zHkUtRJaWp+7k6C42yyJPTHnitlwK3EHuDAXRJeXgl59n+n1h2nZTqZseo3Q9Qp++zKFgBufijvYtowVoNmltiHmtJRwsOk2jWCe9tn8qAS6RR/ERjql3RIt7qtZ+//2g8pB3G+AxXXh81vP6u2xucnZDhHCHgCVLdMuCm9yHqzdJ1zoIVYXGw9XIDOxbu9NLFdaH45YLvsO+ICmepJ6GZwdnG/u8ZBIKY5ftlO5lye+xeGCsknZ/5e7WjZrEoHAAAAM8jw18Ndu3JkRQoHnKRCb2I+inY+GX+Yz69IxLHPeb56CvdPj67xvlLqwCGzFgZetKkM3xfOlj6svUIbbeflVJzRuSElZvR1xtSuBzGSlu5OmF06UILJ1Ct6wgyXlEwGp/Sqlm9z3HYjPVtz2pgNg57SISfT/7PG+OGJu5e1iFVzRJSt4kkPvq633kBavavRjJULr+mYg550PU8Tsb8MZUg1L3ecL2KK4k2vrvVUO4aeMymBWyeaIM8ssiiJGHBPBG3cn2uayB1vKJD7hLGpJhYk2V9dmBLEny8W1KcaZwZOSbQUI62ny+82evCGsfXKtBL6LeS3Bc9vgQblpfGJIQ+pmmyiuSdH72o6MYpTHHWZSAi6kXkmU5FPGdYE3+65Qa78hQaUPiwKNxGq889sGf/me02r2NLZv7IHmL8eI8H0lsAEaa8FviXeYe8Ek/oPCu51IwJ1u8hs7xTh001WDh4iQdMLu44l1DKchXZM9UEoJDFYslekmaSbi85yScRumGHrHmPRIWV+PrhKYMrDGvOiA23NOztwJY0FLeM3AZN5YRu31ymehEbpA4wuX8HTsJODelPqckL4fDrao7i1mnRSR/vT0N1VJYzEMHE8GTwEcccEKQ4sRfIed5TMCwann+umKUgSG9siQWpAdCM6Pr51nWPL0jxWQQd02UNaIY8wCXs/quJe8HCdIPOXafTi3bGggkVSolrRWNG4wibnvWmWS7pMlcm1JEI9Rwo56/zTBh5fi/1p0TgiXvAyvFwgqs3jD09lKwDkgrT4NOQY2iWJSyvHlKa1FPDQr6801Ww2VOCnk3LE9jXIGl+k9oKUk0Kf5d/zzSVnklAn7NdEKXF804PuJUniGospQPi7uDm6/fmglu4Pfj8xtdoWTP8CAHlEazJAXAc="
+        }
+      ]
+    }
+  ],
+  "Blockchain asset updates rejects 0-fee transactions": [
+    {
+      "version": 2,
+      "id": "65556c50-c12e-4bb6-8bb8-dbbc5969d425",
+      "name": "accountA",
+      "spendingKey": "dc4398312deaa49ecbb148d830d8671cdf8f5a6a23aa808045f2cf442b1ca4cc",
+      "viewKey": "df9c3e2139123c3ce8b765a8932642a37b0b9503150fbd786306dfdaefec101637a7b701e823f8c59afaf9403cad526d6866b652115846b59c323e0df9ecb41f",
+      "incomingViewKey": "26b1dbf559139239fe44a1f2be3cc76238f649158e3bc0b85131ba87560cd201",
+      "outgoingViewKey": "cd296bb19863e58260d49ffa0d0c22815ba775d83bd45c756d0e650e5b0f7082",
+      "publicAddress": "4967b9bc47427ff6261721c50107e29fbc30fcc9b0cf0adc42e68413b1f55c9f",
+      "createdAt": null
+    },
+    {
+      "version": 2,
+      "id": "520433c4-347b-48bb-aa17-ccd92ae7425f",
+      "name": "accountB",
+      "spendingKey": "7c14b79996ca4d8e9d85363eb2e319ff371ff7f8c1c01a6b170a922a6e9855f3",
+      "viewKey": "a95c3efe41c1d2ae1d64e7e934886aece73d89a7efe7a7e879502e1667d4bf0821be16cc9f0aee8ee43e47b385c7a7fe7970fbd995aecd3cc92d04d7202b0fa3",
+      "incomingViewKey": "109867ed19f45293721bbcf5830d6836ce64008b48459278603e8445e6034100",
+      "outgoingViewKey": "ad6e0654c40804fe9c9e28739f913c9893ddc55aa7e093f2b609f83d3d31b873",
+      "publicAddress": "6f0f2b7d8b8fc881a25c032f3741c5cc68fb64d8de84cb2db37251213f109eac",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:frAiGp0OBBed1goIq6KiMQ1V9hpZct8vhRBPxUxh4BI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:rNK5Skwgidpn+h3mW6XNxDafQDvz+KZb6rqnsGe6Z2M="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1683243988342,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQnUQaqYaYW5Cj546kjorjNge5gLFKEzaDSbj+6pSlhiWKsmZheLCJip5hiRdpqIRS0yLBSkaZzmx/ag5cZVgXwGig+NO1dNwrHHAQIRf/piCVpAs8tRTGHLSWDC/D6ZadAO1nW4JayQaqkZsvLxW8I+W1R5iK+gdjPuDu4QNwGAPDX10LsMmO4feVa+3c0M++TghapOOXciQqqoIduZgDEsmPjq68VDFMVAPzxxTYeCFd81IV0WR548+jbR3E1a3sS6dC0WOCHxK1K3w/iovGh+e0N0fU/LLPZtTyEynxbpv3rNDLMCZsDyP5r7fd5+NEhjvjGNlg6kJ+VTwpd+OzkDTRSVsiqmH8cCalpZRWb7iH7Joh8+LXGB6Rc1fllxk0jPO3f9y4+fjwpyIj/dpod2XH8b7W9H5r83okeZfYNMllOGCqjJi9cl/WIzKYxurrbIPObHXXjzBCbcxMpFm92phUOiDxl3ruQu26PC0v5TBARTPCbM4YhWiUI1ufbAXAlgDLNTx83FA7o3ZcqYhgircwMDuQxpM3J6Eslj770rMvn4U6QIORVYIr6/pHYHIj2cQRJmzUoyR9aLNaStNhQaOeFJHKWmHsGrAaTah7ytQ5tLkgxQf4Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBJLLOkYVj9aCK4/31JxZz2fsL3W5mszgUWFWgs0m8cvxiKQhIKnV6uR7eVZFy06f6pnTkz/Z4OpY/nPv33UmCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "E52EF8AB3FC61BF776D9D60572E9C5E1E66A83ECA12B279A33631EA9192D6F6C",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:HDiZ8LvMzAotYraDmwOwFRQsQAHXPiWebOrlEbp19QU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:vvOJ2qGud2KFtMqPlDQ32O1G18P1yKqOvXE1egM43RM="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1683243990407,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA9Yi8XFFCSjKTD+QDq3sp1fMgBOrYo9knVeEfRgVebZqV10RlJKSzg7Cmwe7lNpgpsdq2DgcqKM2fQR7LhYFOx6wjb+KHUBkLd4NcpE95FdmYJ/6XKuTax3EhRbAZfxFSiSFg1ZxqVxsYLm7HGZ0lxWJ06bjhCiO8z3nCRej3maQRqW06XsqbPOWVsrz4QEKswHOTY6Nh6LShyvlA0+nKaPpOpwP1zLdByMSM91NRJYKr5bRERmf7tstHU8dzhQ80dCrrIME3gi2ABiaIURreWkTe05mLeq2rU5Qh08SX8P8NVPTLLTmll4OBibP9yO7mcej4D0bQaMiIUcqxSG/sam7YzOcOZOqQ7fNelPqX/o8LnPSBOHUSkED3Wk1G7+BWorHG3vv0v0gbXmfGHlyEL73ZpOCOYcKrsdeYr5cNmc3F+ARcMcyTmP98Gg9Rukn0cK41ol+VqU8wz0HkI1PGkHBnYv09fIo7PAaPY2RN2P+9vFFTCVDX0RNYG2WSBipW+wk0ju8S56KhCZTZKiJMNGyj/9TU0FAFJE6f/6s1FXNE7uEfKU8g6L5AvhVt8B46pJxypJ8rniFcAQmbsdAAl1eSqXV7is+Y7zIyyFXE6h3ryglvGaWF40lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoXwxoNoF6h34mPC00orXI2p5JLDjBe/n0PPPX0Uf/h66Y5OYmYTFzGFpG4gDMNCH2nOkF8XnDME2UdEnL/41DA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7UqjiqwCGgTyjUQtkJPU9ciB8P6D1buei7OFEyXlVzyV42JT3XJ67h1zbrx1XzAmq1QL6D62KywXwRWoBzU8yecvKo0ek4D4JD7N/gMBDpiAAOuoFF7QFnX2KPT6hTrajQf+YIz+gWKqphUEq7SaHEAYnwqfK3w8XAN+53NkNPQZFD/iSo3Eaqigl306kGRM13fbfluQJxLh3napikt9j7n1oOK2cP3oT7uW/mUDqvOBcIOJ4rD8coTYX55L/mJyWWDANV2M1ttxqD+gjNm+KROUoW4Ag+coDO5qJb1AIHLrMayLOxgvB/ZkixIC8acnU8ihW0mirnSmq3TeJp/+2H6wIhqdDgQXndYKCKuiojENVfYaWXLfL4UQT8VMYeASBAAAAOlIgNxLmnrvJyIXrugFceYos8ItkFnVckgUu3nKf/+ig0OsQbUwmHEYR9OKXVNeVM1d6IEOPieco0rJPbiSKPJxDRH5svGnwTWjvHRr1ivVxplbQhtPrKDHcg9ggT0OCohdAxoRRpcj14sRD8Rhxiq3mGAa7Y3eMSiHx9mKAtuo/J0uEBtyqGBja4V6t426RqoPZVEYfFJTon4CG0SrVnWFBmy594UxvYtXCN0pttym/YOZXr99MKoaZXofpvAO+AYqP2AELsiYeckOviFoIBkz6JoRINJX+K1nOkEMDFHm9HjMUETEgx2PZbkIPYUsuLQvtOyXyXmUGauCDzTevq/Obloqv7fu3CCjpzmsswtTg6LXJvSRLW6Acj4XflDkGN7XOiv7JKBKaBXk0mNipxLpbYmkssheWCvOoraPjPNZatfjcfOt9GEJJ4FXx/mFt1Ou0JF2eF2iYRaP0Ydu2m0wWxU7Gbr6RxRl6Tk7XQw8bphA6TFIx5jdGAN+hJZcm/2o5jOZrw6Yqv9uGCd//+GU7TFFBvZyKLABXWq2nNF3xb5UMp+aX/n9eMrOBTQSzag1IYZ22064lcUJp5AtAkm36jKRX+NjHRNYJncSh4YKZWW3YK/nTTh2ZnjZG0xb0Yj4LJFGxiqVwxWVHcmw7KB/pdqVZ4fWUeHEkDg90/uRJhLXU1WtUcZFiN7jkYAb93783T8Q6yfATTaC6zWD8N5P//DY19w2vFdKUrkFPOsDmL87fq5IPd4WfXAnvukyRy/BcWVxRosgH7QaaIhcsXQwZg8iKDZ8upCo8OEBwx1oiB+3dfd2/BCWfq5cj8s8OjqKYdSN6rPRWl3h7iM1S5xtIV0p2PjkOovS6SCDWZ636V9M0MMwMjKgUkAfdl06VGkOOaDVVoKdHgaGlIcAt/Yojcq0UotboNA0su1OHG1LkrC3+3aHTsQYmqlwpIhaXQwbts/HRtepp2TKVEgtd1GL6/r/lU+edaM3UNlb5USQLAHjh+BqDfmsg8z/K2yKhPKKUaOzIqjvWXoZzBD+Fl+7wDf4DIpOra227tMUDkbI97IRR1S8KLjjy3r+F0CtZcNaIqMqzc+/nbg0gsdy8AaPGrRBCCC5w+jx70eEdvnap1jG8U4b2uQatdslDIdzq81aNr2CQQRMGSA4FroGdqQ8Xdq2f41cIP253Br+hkx+6VbHp/dQ29JMcdTMJjX2/dCvxA63zeqHonNx5YwSJVwh7zOQ1usv+nAmZF2/UopezCME1nLE8Kku0F2zv90xedY7Iw0Dt3VEtO8iM91wI0gnKWBZ0ZMamLWR3cr+jvowoKKfTy87I43WVakHH6TX+VUxZPaXfHez0FEM60HTmng6UT03eyfZWQY5Q/d2DN86vyfvzd1KvG4pgpqLVIn+wsmXMI/lRqSCGPKzNmvb9DuMx3piunF4ljVROArFtWykzsdFx9MkNQJiiOoUGrqREwnVsTbAiFzaSCEP6H0HF2K+kQETN98LIwpG+IjnftEtbCVtMAWAmkDBZg0w30bEt2jpRVufldW+6SJObBpcVTolZCTi6lSd7/WNVP97skB81RegA+dO6CiVwpOVsqGEBQ=="
         }
       ]
     }

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -788,13 +788,49 @@ describe('Blockchain', () => {
     await node.wallet.updateHead()
     const tx = await useTxFixture(node.wallet, accountA, accountB)
 
-    // Spend the transaaction for the first time
+    // Spend the transaction for the first time
     const block3 = await useMinerBlockFixture(node.chain, undefined, undefined, undefined, [tx])
     await expect(node.chain).toAddBlock(block3)
 
     // Spend the transaction a second time
     const block4 = await useMinerBlockFixture(node.chain, undefined, undefined, undefined, [tx])
     await expect(node.chain.addBlock(block4)).resolves.toMatchObject({
+      isAdded: false,
+      reason: VerificationResultReason.DOUBLE_SPEND,
+    })
+  })
+
+  it('rejects transactions with internal double spends', async () => {
+    const { node, chain, wallet } = await nodeTest.createSetup()
+
+    const accountA = await useAccountFixture(wallet, 'accountA')
+    const { block, transaction } = await useBlockWithTx(
+      node,
+      accountA,
+      accountA,
+      true,
+      undefined,
+    )
+    await expect(chain).toAddBlock(block)
+    await node.wallet.updateHead()
+
+    const note = transaction.getNote(1).decryptNoteForOwner(accountA.incomingViewKey)
+    Assert.isNotUndefined(note)
+    const noteHash = note.hash()
+
+    const tx = await useTxFixture(wallet, accountA, accountA, async () => {
+      const raw = await wallet.createTransaction({
+        account: accountA,
+        notes: [noteHash, noteHash],
+        fee: 0n,
+      })
+      return await wallet.workerPool.postTransaction(raw, accountA.spendingKey)
+    })
+
+    const invalidBlock = await useMinerBlockFixture(chain, undefined, undefined, undefined, [
+      tx,
+    ])
+    await expect(chain.addBlock(invalidBlock)).resolves.toMatchObject({
       isAdded: false,
       reason: VerificationResultReason.DOUBLE_SPEND,
     })
@@ -1443,7 +1479,9 @@ describe('Blockchain', () => {
       })
     })
 
-    it('rejects double spend transactions', async () => {
+    // This is a canary test to ensure we are enforcing a minimum fee to ensure
+    // validity of mints. Can be refactored/removed once IFL-851 is completed.
+    it('rejects 0-fee transactions', async () => {
       const { node, chain } = await nodeTest.createSetup()
 
       const accountA = await useAccountFixture(node.wallet, 'accountA')

--- a/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
+++ b/ironfish/src/memPool/__fixtures__/memPool.test.ts.fixture
@@ -3548,5 +3548,78 @@
         }
       ]
     }
+  ],
+  "MemPool acceptTransaction with a transaction that internally double spends returns false": [
+    {
+      "version": 2,
+      "id": "3b418865-4d31-4f66-9a4b-830b9a6cb256",
+      "name": "accountA",
+      "spendingKey": "b2aa6add50e9b795a1a12f12e7baf736e2fd42c6646390dc71bbaae64d7ee63e",
+      "viewKey": "60626e283abbca12cdfb46de7a5c665cdc72d884afad964feb65c11a8bccd972601a0a9de29f7c60012baa7bb94c5d83c56f24916b4cf0214c3751926b4d2729",
+      "incomingViewKey": "12fed95496652aef773de657022e014b63dc92031adab2ccec9a1aae7bf0f803",
+      "outgoingViewKey": "1c24ae99ccf1e0d3b6a4a7647887f15bb79286760fe841f674858ad62a273f01",
+      "publicAddress": "f52d5ec31c0662d9a026e214a7844f213a589c51baa473f292f95623ed039be8",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:VNyfjhU8ecy4kIyUL4kiZOSsn+9oDsdA/w1Q0kmI0QI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:5tjA8Z8S63hF+sfYDAFX5M1Ij6+q6Vl6+xXReMVhwr0="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1683237246424,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABJ14LCfpMVmuBSz3/kgOHiv3HEyEjgXBipBxblPMCrOXVZieg/ZptGX+tKF9UQBtVT8zsop2pIqcLGmTCeCnAJxfmJUAVD24lTUuV40CvK+Q3cgpdGPYJx3/1rltvxwlcrrMSg+4WfTK+OWORy1Rh/+CnldXBHcBb37Dh7C/AmAGmEeaEMaGRaJodtoceFaMhVdha7tV6Dbnvmjil5KHedbnzwfnKTtmdUHpQhnru5eDmLh9WYw+R3hIiEQ7wGdc3OqZ4xUN7UykL7W/pQhxkSnkOpDDN1idwoI/lmwStWvKoUC6f858AVKLIdHF5+QhmHjiovxb3VPnvtHB7qWOqDzDeugvyZ0ycXWw7LK2Is/8YT3bu2WINHjWwpo8Vlk3mXHDrThF5F7CXg+AwnpGFH+cwq25Vm8Lz64trPoWF7MpbkPcRQOQXPujNOJLnJl7rpFsla9o4Gc3+ypeotVgwWeAgXPPl4OrQ9Moy/Xflz32M8EZqyqWTx7wHQYa9IicjCzYycA89mJJJQLPp1TUy8VFEgud8h0vTxuavKSkAxg21cQjWRFU25AnYiHRcZf22FnQU0A0y9D5xIv7tHrn92i/Nqdfh/rllJPtHRgPpGc+bBIMPyzdoUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLi//Nsrkahr7QwlFzFzJbnWmTttSs4QyWubD05hUrjZKgwAC0ghVWmfrhumowahsVZe02DZBQ9PypgJNHM/UDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "031AC8697E1AA856137F879DDB95BE8A3955FD297F4CD6DCE0769997C142D21D",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:JOuvCYfhmYWDw3Hd5BQ2FLTlx4tqGOvAUIfdbLWyKjs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:5Nv6KPqL/FzlIkTW/R9hru5qVd+F8pEmslyFzh5yLUc="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1683237249012,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAPGZYgBcq2yaI3Q3ouYriS0C+OIOrKnOkSjj+8HeW7kaSOKLsatDIQaYkLqByvUsxjgBwFvjIByXPmzhu7kwz/In5NSvucTNFIMO5LBZBFEWMC7IpCj9wcliRc+5pPQSr6+/fppzgzl0yLeHQeUna1hRqIqPxhHyG/BBFylQcWsgBVzlBriLDn3T+VYyUS3veDK2i3SZkfqpVHt7N26Mf0ZUGoAtVSV08QqxiVphUhSKkHsh2IsWZ4NnQpcj77Hidf/uWHTRRJSSmUxx4OkcvDYTkAul73nocXOwtAxov6SkVEKfDTA9IPBQeDN6f2f9MiAlAEPYAcwOuf+pC9WsztqbdbssfWeQCQSkbHmG7lSgZl+6uKx8boMIK0ikIXXFj6osSJMvPLDx5++S8hLu+EiiWWgx+qaPFi1TPHfCXXXMovEMN7jssEMASHJdhnndxtSCZzR7VWty/r7E5atDmQsjKHuwgFcYa9qgbkFYTsBfvVuxLRE1TIjKwB8JezeDTNMzww5kMjZMkzgk41WDAaYi4aDxvucUz+BY3i4jNVpooaj9kNfMVPbc9WdB4fsXuwN6FMcDwbfk/GaaTpYXZr6Hd8lmcquGA2RH1JmGFjmI7Ch1/xaeXnElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwlV4Y3JT+eEnR/4pAZpOuNZdY0+Le4yZTGOhAxDa7J67MAGBDat023D6guTssuoESoJay5wvJC119m/4WjSh6DQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAALIk0O6iH47O3rQI+fQatWjAWIWgYKcRQ2dhanGZ5a2eh6MRpJL7oHNqn0EqePTSt+0BV0keBG25FQZWA1uViG6hJmjbgSc16ffQjrLWY9DeoDg4xhwCV1ohwwBCkVw/QaKUziI4lKMPtePM+caBsKwrHWnPftnoorF7VhGelLxUE7IXE1sMHPVS8wDhn2t4185XSxdtsHre/w4knhqnFQCehFa3MSzbAvgHVhiTyfV+2MpG9NiTTIcH0NWmJYg0wk7vYXr+EoS+9YH3Tb5doIn4OTds8uhrdgQ6/XrzxNXmUucCisIVrrhDJ+JZGo+HPjfZ/9X3qVMVcBJD+4wX0JlTcn44VPHnMuJCMlC+JImTkrJ/vaA7HQP8NUNJJiNECBAAAAGdG/+/I2wHCiFwgvVAJ/xMHe3LyLbG3E+fjOds9AXBkc9ie4TUU82cayRPQYpw2+VmXa9cNn7frpUPbZhJ6w2pZak5fE+HlJstj9tpg2e+dCcW1qi4sTt2Yzvmd1vBaAbPMcYjGZGbXPFi1XCEtoJ7jVfvwkAT/IRIndFabLh2uXkRb38NnKJpJFgiMQBCDRq4mZgckwBzf6UfrYdhxidWHrj9aMjwNp7e3Ps4ZwUY56VQg34pgpIciFNJUrPO3PRAsqORg9yZfF0gYnXljMo1PCMbs8szXwrqAhciRivyxQR7hGSKbV0BqwHGBcavRSJcoweZ/OrEIxdMECDP3ZJ+LEAroBRsX5TvhVoN0zdSVrBOxdfAiB2NlYd1Wi2r9tnZGRSL/MoG2G9lCda1MPbMTKtIWAxowdpRYH9bD+iYceFDhvHfwqHXuKL9y1QYBWyz7GFAYia/nYYq/ulpq+EPmx970eRsidJpdqhnUnxaLf2n76jmjPlEnO42HQg6kAW3gudY8ho+g4OD4iRStkPpWobrDscCHw/ufgeJ1GGQq7Zh2Dz5x4SPWEa4BBUnzaMskDmikhAB3CozJO6nAb1qki2Np0F9tUw9xbVdqH4dxHayX/Y+2T03D05NYJZDPxaGxSL3LZQbOCDxBMttzAle0MT+1iaOlhC7siLoN4uatc7AagzaLoSkruXiYUGrcY2gGQXv3sWmVdzr09AOynfGjk0BMFvR/TBxGAe0GHa4kzgh4eStJ3run5b9l7BmwfKVthp/SgPsbCDanHdVhPE4fgscfbfa7YEU6MjFzLaVPb7tVanK1RSuAszUpHz2qX8dX6aO6bi1rbqE+r07HPRIy1YDw9AxGAs5IH+/sWuBQDfcifju4K2ePYA2iDHacjrwACJM8jX5cVNZVya1AaFTy6n1ZgOwxZ9NP11QkwQJV4NypJYhJvX0GtKx6LIhFu2wKIVC4TgwDr81Iwp/t6Tyw19TcMgg79w5qQdHPw18c1nX2xgKMwxGHseHTsyd32ceBrXNR3UpqsT6TIJSew9shMKpxa2wGuZZcKXJRK0Hnu40ndOx7zvoosUM7x7o21p+9dKCH83h+i3y6TqJsoxlS8gMu90yuY1UfszTsYRfawVRRMRNSyCRCKYBU5mzXPrihTctSQ9ZTS3K+Cvk5J6u2LcNIbNa9nzG5SQOmBpgAhTB2GVuR8GBw3RyzbG2oIDL07jj9oN6+UnqVDA7z9rLo1DkHUToacqk8mTGmZyw/yX9Y6J40HVsIp7vxiJl6ZI7VSFpM917RZ6/9NvBDIXaIr3Rca8Chu2Rz02tDgGsOU/Va78mYs84duJXans3xIv4PoRUDlKZgEJKJFvHbtAt7Nr72gqbMpJ174gSDBNwSlYjQ4PNxudeDErguV7dTQvAzKf6qccW/8sFW5PIBPVKKIEhOVdZNABSJdVZNwWG0W4HC1DBbzJq9tq497VDw9wXlb/UE8poZdnosz6s/wUwo/vCaBEbSPnNphS72JCRo/xoHj9ChEodfrzQb9+YmASH86G41zT3DJRUE0wRFh4FFtI4/lVmtcO16DoJwfY8NyPXWGqytb2klM7FNT4i8AA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQIAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAc3eReY3bH+pfPs1dywBCrSlcKvz4OrneluICBl5JTSKHqJCW5G5JwwEdk6Ude7fIkLbCr6vQ0Z4uIkfD1rFNyiE8ULtIY7bWiznrKTIhUaZdDO1VC3X2gCl2EiusUKxnEB1NSDARy8kbf5+7z94Jc4bK3gpzPVAwfFBDVJO+64FozcfCJ/1R4gCbdQrLkHjlDm5V8AUA5iF/IkfWl1f3xH9skFcXwtbxAgKsaw0S/WUgy1fHaa2sBGty0rmMcaqd/bztBJ7BElldl5D9ab43QzJ5cOUG5AUd27oeXbW3R8fxU/OzaXDsLhVkWya2mOddlVXC2yH3rO6lXxKw8i2EyTrrwmH4ZmFg8Nx3eQUNhS05ceLahjrwFCH3Wy1sio7BwAAAMuu4jRYa/UntooIDPBAdsOKhB8KjO6tB/yslMfbK8M8mBmkHA0J/FMOj6rGfnWQdvcWjiiNKB9709XLoivFv0qlyGopYLb7mbry2WZaRXboiovl/5AH+iAyAQaOXWbrAZWGawt9xQIStpN78wz7SAb52Xx9wR+kt195v7a6cMTOw924PfwsWPmDREIeiMKTfZdTiPh2TYOgV2jwcsSaRRBoav2zCmYNpcISaMOzul2OO6ZZrJp9UhksrQiaHXCETxGQe1O5kA5b8KLB3+z+lUe83EdbNpmhj6W5WM8QIKz/8LAScMdA3GkvHdPJ2NIBrbaSHae5LjlUDx9LxfOtuPiOOdxB7UKvIOCwolAoIefitM2tkZnQ914XAxtpt2vAAyTFqWYGGo94dTvdguINnfdHSFXTh5sjvYNQQbcWP2xTJOuvCYfhmYWDw3Hd5BQ2FLTlx4tqGOvAUIfdbLWyKjsHAAAAy67iNFhr9Se2iggM8EB2w4qEHwqM7q0H/KyUx9srwzxB7mb24+9UNzBZVFQciiSB0OyB3YQzywpdairzWkefpYDIq+N5ck/loLfIEaIej6PoUOyHZzZ782pAAdA7+QsNpfyOfNFTLCj9d8tPWoCbeRiKeTx0ulXyQK39XkCv0+ddaMuk3y58QvcuLwkC84+6rWByBfIkTDRVI2eIVo/mP1epMMDM8XIkAMBHk+g/uOv95qggxFr/Htx4owJKFixxEbNEYXKXjgQpsU+iYrmrJQFMk9nspDZNSiXb/8rosgJVV7STlka8hzrcwryC/8yzpyuHctD+9bUcgqa/yKGH6b+MkFa5hslg5SmVCdtJsn8NGIXl//KEcorihjiRlIg27MWd5NX8kPta6bz5cofzO9DmHIQIUcueJGhq7TvnfYDUS8lcFufEx3twhi42VF9w3NgT9W3WbBEEBZ9k4LJdBb1z8yQ4UGaHDHqoy4aPv93khRvmCwrzGLv4zmyFEK82IZzGkIvFCSXzY77HGFKSoxoUm1VScFt6AUl2yh9wduI3Bx8J0wAdnJqN2tH/hK+JsRmOa6Fq2LyhN2HMfqWfEQZrB2hDXVT2wF288NBvWfoLxYzwKhSxsIjBGdGDPBo81YwcRvms+ca7LSXWJfFs0f09New+mrrvSJjLsVexv8mFCtebVjM7kURMjMxRs2e4+agsFt97Psq7PrmaLZk7VzMTdQ2JezVJpz3CvgVnbe6Mhf7ApGjTcDDq1yfnSPQAHvyYfpYhBij7GzXuNjtHzIIyH+MWfIzBol4QRk1PEjCn2pxeX3dkUBEDxc47A0lTqgCCrlQG/AD8imaOJ/fXuLNQvwO00ZnR2IGfXH38CmwIhqHtGE7lXKl6gxYbw5whAhAGhg24bAg="
+    }
   ]
 }

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -266,6 +266,10 @@ export class MemPool {
       return false
     }
 
+    const { valid } = this.chain.verifier.verifyInternalNullifiers(transaction.spends)
+    if (!valid) {
+      return false
+    }
     // Don't allow transactions with duplicate nullifiers
     // TODO(daniel): Don't delete transactions if we aren't going to add the transaction anyway
     for (const spend of transaction.spends) {

--- a/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
+++ b/ironfish/src/network/__fixtures__/peerNetwork.test.ts.fixture
@@ -2792,5 +2792,78 @@
         }
       ]
     }
+  ],
+  "PeerNetwork when enable syncing is true handles new transactions does not sync or gossip internally-double-spent transactions": [
+    {
+      "version": 2,
+      "id": "b9ec599a-a03e-4e39-a598-984852e0bc0c",
+      "name": "accountA",
+      "spendingKey": "742bc5639b2f026e4734b9a33bd3451e0d5cb07dfd1373d9819348be520f2318",
+      "viewKey": "15e29dbb2f723b54a384ea3f8e6874ac4d65d077a1438042c53ea16b0287a5e42c3a5cb47afddcf6ef73d4c2ef8f5acc397214b1ccccbcdb6d22f2afee918233",
+      "incomingViewKey": "5abe28055f5a690ff6d278b53a08c1a0cbdb7f3f865ef8ba6dfe214cc554c801",
+      "outgoingViewKey": "982bfe6bcb1afcad0d652aaa8a29add28fe501b1adc234ef6ddbd52696dd33bc",
+      "publicAddress": "a0c03307f1197125ba88d3ec79339d0577aa2d4abf097eef9fa6be88b2b1444f",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+0QN0jKzEo3gjey0Vb8GUiABLNZpfRfUNRqDKc1c7So="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Nmp2JRKsKqxZd2qJJXP/M5QNaIRvDDuur+IoyxHI9LI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1683242485604,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAdGLLcZ3eDQ+xKm8z3miEAQakYy/J5+RrnNz1mDeamQCV/46SmLm7meLuynvlUYVO6iuFzuIPpxPz1OxJA3JgthZ96YA0rCwxaNje8Dc/IF+zBg4A+atd4bIxbmJRPV47i6AjfLxns4YvzVz+NHmGkSp7HXqxde5FoOKVA+4lxtkTCTSQaJ6SzJbsynJdlkd7y9Qr+GeWdMyM3s8etrNM1bS6gJ0nVbKckR8m95GrODunRgE1fB0kfumGApxji69RBzv5HAMnMB7Bq0jVCeeQN2mOPSD5PUuOSTHWQval2YMPmd5YqBha2vjH7TErcU+RuzmOtbPIFKJfNYXsAAlP5u/09Q9x3o0Nb8cFvLLCf3K3IoRI0D0lL/uikTibJ8xGtA4y08D0/T0YS9j6bo1TP3ryVlMotI3opGR0KuQnx8i9IReVi58Q8LsxhI6dG5qqfpVbEuqp56S5Tqd56kewxjSyvt8cHWqxLB2xzuqv/k2iIIn9VXTvAICarn370d8nIZLOPZRrrWFeCeIk7H3U12LNlr1JJJnNc7Uuli30LXpKK6eXzcizBifrbPL+n7hhezZ3EI9VRcofwEXUIvhqmi3bwu82v2ZhDKGP6FygPVyj7+1PiGciMElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwUg68ymJ5Vi5hm2igT5HdOdeF2aVeV9Hr0FdAB76bSoZqH4vBC7vRW4JokVKPuHPHojPdjTUX7lAB7ySnl1ThBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "E3C837CE8C3C6D46D908E65690DF634161E7551836088989D75AC932C1B84F8C",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:IyNqhr9jQ8a/hwxWyheIqQjQcQRPQdwCGC1TLvuPiQA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:uNB6n969zgFajuNPJnpPDYPR7Zn7KGmslbN79fjbWRc="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1683242487806,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAA0+AiYa1Wq0Hjt5e2BewCCNMMQPBbBwREgSgEocuRewyyGlgObA8KmI0Rh9q0MA7q1jn8TVU6Vp+jpTTVjyOu3lM4Dapjb4DtVMJOQkEvOE+S1VdVhlwxSozmoC1Xs3R5uX1V/rgWw5mjrzIWxtpEVuigg9q8MVZ66VDnWQd5LkYVn+L6fq3seDVWLVRX/Tbx51hJoYafPcTUGSVXnkPGuesXBkBfK99vpNStDObwvJaZP3ARZL0L3wY29gz0e6CFUh9AdpjSP1IQuvaogPbi1hWklgBI8f/K7VxUjwaJB9wvI35Ece3+zXhMMv8tcXIiQzzXcAWza4F+sCpueBdZx92ila4FWrxRxAD8KgymxAKhRREgz1/Ftu71lc6sam4Q4ehPAGuWlq65JYt8/gj3XjdOA6YUC5tiMk9Oxa/LRDABy8S0K5IhJ7B8teXNHMjNa+XIPgoCNejNZn4AN817z8nSEbkrNXEUTafWGuuzNMtXTO6kd1VyTJ4H1WpIeTfBeXHVdom11AHmvq11ruuDDDQ2WzHLh6YvECYP7k1uDXA5Eq0ITe020fLJucmBo5GEqMP86t1nDFkaDXPvE70qr9bsY6oij4uMiIMpOo2Yltlg3uftzWWJaElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9sKneftJgzXTt2kphQuPVdaf/uZut+zE5rJFU+61upl8oide+I/f+SM4q1liL+QOH8DiIQWXd4y+iSakVzvyAg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAqjga4weq1kc61SQP5JOhQMLwK5xkvlSbnbSyaqlh2GikXBHz2AbjVvofoISeb/TXRAnjZaQo49NIvnb7ldH0HVl+3mq5pqxf7/mYT2ksrVukcDUr9sv1LHDD+xo7nOADEbf0+L/EXIerdn++C6IxbeGOlLywDnecPZKRKv9xUUQW0RsE4ogbY8I21cQpQCSy62RAqw9YeeoPFDhMSxWn4sjikmui4qSb4mpe1YVke3GEfh+BiMopbKOiBGXEIilpzZY2O3vlRV2RiaRIIidWJYK+u1jlo3P3k1JaSNWptTVmjtxFcRN4Jy8fXqUtpaEbHG9YB8uZSxz65suu939CiftEDdIysxKN4I3stFW/BlIgASzWaX0X1DUagynNXO0qBAAAAEop0FNbQ8QKwMigLSMvM8LC7vQJ0pFiqPy5+GTyf6RXuMlLuVqOJSAH4MLQMi6TPB+1o0wJCVOcSGov6JJ2f0rbJ/iVjX9GQ9bCsw08/1LV2deLYFtMuvE/Z020yt5CBKIwWPKiBsb2JIpdam+//jyosWu4o5owFqLIkM0aHEbKsfvSif2yaP8URCnMMMxgUJCSBuS+VrXrJ8fYyDprxG0IMqf7MaQcFts5nR24e3LWPEv6gDl44o1ApOOQvsPKlg3XrZcld1dNLFYB5kOGhQ0m/w9RuEtziKLRbMGYXtHOy3kWplWO/Vr+7DehvUm5krHq208AMkmjaXl0uQL9k9HUdmugNxGSwLMUUw9Vs5VdDlHOU3lTBWbd9+zlVMJZmdnuLS+/k6ZU7uvkvIVWtCUUw3Giw1Ld/3uPmXpMe6CRd+xtRfzVm6u1Gcym3WZOugT96RgTl40dY1Ho8w4bfCcVN1aUGBuw+Ic3sFMijhoks1LjXrmtwwIvU+KpPvUBFlEILS/wwVQhM2vjAxlMqeTlQ/MKMjstrhljMYN1ZP3Gs10cKyZdBHSejddR8/bWrFQzH3RX9IxNDK3XgMoP9x4IXNzqRr17D91k55ESy1z4yiuyhlqByIeSyHohrbUEg2bnTNnxXhlE9pgpHGYM9FKxGxMnYewpSdDH4u/p2WXym6zc8dcCP2WSwhPropoTby2PgcprrGCe5Vy0KJeaIw1ZYKreaKws00bIaBI3QyaMwReZHJZLWDpht/lo7OuuWWg+q1wd4s7rcRdrM6Q4xXwyjV6C345zQTFgkFGZVZnr6DTxEap+qGyQWHw3vcyD8U6expmTOWasTjyKADanpYwN4JapVMzzK31IxEoSQlMiC8ThHToSKQWHsWorQM4hNfJwEcciNY1UW50TzGJE/AjtigP1PDsCXGAb/zysEDWa15/dBq3aJyAD2YLFqEFkhFo40K1oJK0dQEyggFUbv2zFraAfyo7LYCjE+z9zCVZnd2PoHydGLc+uQR5FvuCddk4ywyWx7Pbwxs9W4JNxY4PtC+eZC2a2ERu5Q6zpRIRpXimtpve5to6qPzPJlTw1WZOWUInYY/+feSIOuqp2yOzWhsseZaGMqWtlVxF9myNumrKuCYuzT1bIleGiEMPURfvatTe8stdpkF+tQRNqc1F3NT0lrvFP+W+inBnlGaGRyKk2TK2MMMHf132XYwfh5KrlObeGtIJ9ZX8X2Y39aOEK/gGNxZVmjB8cz92H9a78qJiSeaHYBFD41z6+3NlzDSI2zpdjqAAdLSs0VxI9/Dzblzot7d+A5qandI1CaH8xxzH5RYBdFV6vr1eXT9i95WaQYQ5pVko0tEqMTGHj4ZpdlCiZRZH2Dlbw872RN9YiBKEo1Inh1rGQKjXkcSBxClIIZtzPSMxQa3bVlgUIKbjdtCp6ran6JX+54U6ztjn97B7Nuq39o6Aq/sF3sc2Ipe2gB3uGmyejJW8bUHTqhWZQcywWETQpqP5LKJMrYlFRBdHgmpBdoHkW+JHxO/Mt68g/PDLrS6GHFiHMGZXHglb5mTp+6A3+UQhG2XAVotzaxRTISRI/ee2/kyvXxa3XCQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQIAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAzKe7xU+sbKkvaY+yf6QRYK9r2HZ6JhvWXtj35gKVoci0+2cPiBqC6uKzfJV6kx4bEZGaEZS+wlp2PsA794Y6mUARSchYtNuX/MOokdzqj3SmasnNTJuDSLgchBzMeThiaN/sxb3Kwh0hzLvsO6HTX4J9MHJyR5WHhIeane833K8FuALk2G6ewDnWsZE2r3cJUpKTRuahcvUV56YW4gz5OKKX5HxphGyxjayaMeMpfIG3YpDrBkyAfY5kZHIHG8B4FMqCeWaGZ/IxUtqwCcduLqfRrlpVcbBHibWKUrQdPtgrGsNbbByQhURuurXJFEcx+u76kSpHg/S/ea6t2zpLASMjaoa/Y0PGv4cMVsoXiKkI0HEET0HcAhgtUy77j4kABwAAAAJl97LYyc44jNJn+4X1S/fXW8t+qU8uphqjJ/Hye+BC1O6JGzbCcPGC3cJfM++WgNCaizG+k0vIdPktFe7PZFVsSf/l3rDHaA52N/Q4jC9G0C2loPM/P+juzjTBzqObCoKW29/jmhlkD9AnxC8EwiZhJdOZqP1xvXNBfsMGe4vEBKXLHKFEo7GKbBlqxytKAYJlO0E1CnFlijjm4RNCeJsiyjWx12e664kaeDge23gKbLuqnNtjBJ/bdKblf/DjyQ9j/xRcZYL4+T9YwY6RKTrqvQ33sU+9ROyp96CBcGnFZnkDFXnAp/S0Um9i+m9DX4Pwg3oUwwvab7Mu8rTiOzytcRi100Yhkg0ZxV157CZ+4Gd0Rq0YdurMSn0TSbVy34lglkOX4ieBIWRJVFeJnoScpkDLJ0Xh5Zt1sGSIM/6JIyNqhr9jQ8a/hwxWyheIqQjQcQRPQdwCGC1TLvuPiQAHAAAAAmX3stjJzjiM0mf7hfVL99dby36pTy6mGqMn8fJ74EKBKAqB2sDM05lK3fs3JY7QI0uzPxYeij+gK9vnl6AUWmojb/Ukr9/U4BRPvE+zNKfcoBCSwCRgkHHh9H0UEMwAkcKC91Y4L6Ysy3YYUsi1QqpRuIIPgY3s1zJGybkUIic/QztY0SnUL3cgHD70NvOCimb3WPtnvtUMKhfE3Dndv41tCx3d07Hv1gilbRCl4EjtZnpYH3uytr8SLdDma9kTFmqhm1XAJl3DaE9ebw4hSXvfJWnOsOUprHgOUk5Pc0uclelYc07X7M9eFYyZzcigjuzj5EYu6q2pWq6eITNA9JPQl/TkFLIEQdD1yWRhhKFx60pZOn74UoaXsNQEInVvFDSsquv1YqzOA4u5kpiMGtDASg3HZQ62vUTHtFy0mNK9+KHaE0JxQgWQMYcskk+2UQS5tR5LNTY1uKlp8PqScW6LBVDjTtTWRKKy4ru/+JHxfHAphGoOU3LAuQKbWcLR7wgRG1nbH770dUcoBncJwPpbNQz/3OIeENSQRtUmUk3DLBL4BA2oLPKUzXFXCl0o5x/x9+zYl/IVEYmkceitHurP85mN6APN8tpCR6xpzaXNc9ta2/Htv1eRKNRssSTea0g7pTjlpRrk+DIMUcdeQHnfbpOgCQhsVkS0qYDmdmMznluYFAWXCciWWqDMZvZtQpSy+KDfrCDDl9q5G2Evc3XJHbNWax1PmEr1D2ohB4eY+ZHJ7tpO9rG9BsXBFg8yKZtO5EKAD+R5hOtoXZcVD8Z4m1YWE+J+DN+Ey0OOeUkXRETJAW8Bo08BJghWt0XbDwspl8q4Ef/RfyDgpZOvR+250VRY/ISriKHWy/O1wpFpqh1YOxV0/0c0PMur2i9ps974J8lOsQw="
+    }
   ]
 }


### PR DESCRIPTION
## Summary

While it is not possible to double spend in this way due to checking for this when adding a block to the chain, this kind of transaction could cause issues for miners by getting them to create invalid blocks. By checking for this on gossip and when adding a transaction to the mempool, we remove that possibility.

It is not necessary to check this in all of the places that we are, but it is a relatively cheap check, so if we re-introduce the flaw in one place in the future, it will still get caught.

Closes IFL-848

## Testing Plan

Unit tests for the mempool, blockchain and verifier 

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
