### PR TITLE
Remove outdated comments in ironfish-rust

### DIFF
--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -51,11 +51,9 @@ pub struct Sapling {
 }
 
 impl Sapling {
-    /// Initialize a Sapling instance and prepare for proving. Load the parameters from a config file
+    /// Initialize a Sapling instance and prepare for proving. Load the parameters from files
     /// at a known location (`./sapling_params`, for now).
     pub fn load() -> Self {
-        // TODO: We'll need to build our own parameters using a trusted set up at some point.
-        // These params were borrowed from zcash
         let spend_bytes = include_bytes!("sapling_params/sapling-spend.params");
         let output_bytes = include_bytes!("sapling_params/sapling-output.params");
         let mint_bytes = include_bytes!("sapling_params/sapling-mint.params");


### PR DESCRIPTION
## Summary

We've done a trusted setup, so these comments are no longer necessary.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
