### PR TITLE
adds rpc to follow mempool transaction stream

### DIFF
--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -6,6 +6,7 @@ import { BufferMap } from 'buffer-map'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { Consensus, isExpiredSequence } from '../consensus'
+import { Event } from '../event'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
 import { getTransactionSize } from '../network/utils/serializers'
@@ -59,6 +60,8 @@ export class MemPool {
   private readonly metrics: MetricsMonitor
 
   readonly feeEstimator: FeeEstimator
+
+  onAdd = new Event<[transaction: Transaction]>()
 
   constructor(options: {
     chain: Blockchain
@@ -307,6 +310,8 @@ export class MemPool {
       const evicted = this.evictTransactions()
       this.metrics.memPoolEvictions.value += evicted.length
     }
+
+    this.onAdd.emit(transaction)
 
     return true
   }

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -29,6 +29,8 @@ import {
   ExportChainStreamResponse,
   FollowChainStreamRequest,
   FollowChainStreamResponse,
+  FollowMempoolTransactionStreamRequest,
+  FollowMempoolTransactionStreamResponse,
   GetAccountNotesStreamRequest,
   GetAccountNotesStreamResponse,
   GetAccountsRequest,
@@ -361,6 +363,15 @@ export abstract class RpcClient {
     ): RpcResponse<void, GetMempoolTransactionResponse> => {
       return this.request<void, GetMempoolTransactionResponse>(
         `${ApiNamespace.mempool}/getTransactions`,
+        { ...params },
+      )
+    },
+
+    followMempoolTransactionStream: (
+      params: FollowMempoolTransactionStreamRequest,
+    ): RpcResponse<void, FollowMempoolTransactionStreamResponse> => {
+      return this.request<void, FollowMempoolTransactionStreamResponse>(
+        `${ApiNamespace.mempool}/followTransactionStream`,
         { ...params },
       )
     },

--- a/ironfish/src/rpc/routes/mempool/__fixtures__/followTransactionStream.test.ts.fixture
+++ b/ironfish/src/rpc/routes/mempool/__fixtures__/followTransactionStream.test.ts.fixture
@@ -1,0 +1,71 @@
+{
+  "Route mempool/followTransactionStream should stream transactions as they are added to the mempool": [
+    {
+      "version": 2,
+      "id": "5ed877fd-8e7c-4f39-bda5-df3ab1717f9f",
+      "name": "test",
+      "spendingKey": "07fe23a96155d4d10560b066732609c4f97196dec32791c26c15a84494bc8a31",
+      "viewKey": "e59ec701225015bc3f652f39452c90b66a3185e43f161dca0d0de35d1daa5bbb855e2bfe7a7d6ca53ce8a22455b97d5bb422c28585877ee821b8b288af7fc9c4",
+      "incomingViewKey": "abc3b374e34cab24c88fcd44c13132042c0a2dac2edbfc96973f9439c0e7e102",
+      "outgoingViewKey": "3f6e50188b95355eb5374134e0214371590301cda1da50f1a0e9b4cb49c48215",
+      "publicAddress": "abde6802e8527e63f11fb1069c5a6dfbd472c23b1d3b810b3096d5e91f72fab4",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:FfQacpOANaWVrMoKy7rAbqV/AQJw3exnM6JW9WVAWB0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:oVdLkXbXzTSkPLyxEkjzR8Ua6v0UgpgjglfsAS9f+N4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1683663005181,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAOiHMdq112BdwTHwVGiGjPDHux/jp+s7N6Y4NQY/XlVywLKTK10VW1cix7WaM1/mXx7VeOlGcRbhB997JFHAfbZkzFGmQuY4v7ZeZnkeq5QqP1OJDohylVHN+CpvLcDDG++rpS4zdm40EmOQ42d/wa1H/qFXSVnNlQ/CjjguYXUUM83e1UZ6VuHwZ/3xjr/7PwMXBc69doeRrP9MVOyOexRai4qoyL+pnhGh1HXw+qsGBCTi65P30URYr6FaJFl5ATJlzZO37yH/ASFxt/8kI3VDhUlBSoh31OGGwrLcNlySYes5vlew3GLdZABW/7KEUOkyDqO6sFKZCaJxpNy/L03fyj7+/UCHNZuVStZSPODjVyL8bQKpEgTz0ohUUUyQtLHtlHB/9GULyHG+OuHS5grjTO4AbvnipqHBEOOv6Kr1C1/XGNM+blMPxLiFw8E2dUVld9QHRBXYGq9S84oJKLPiuOyc3zWRG+2datO+MtNbzUYRVY3LCMhEygyfFJ4Bo0rHIEa35RhkD9hB7N8LazU591LG/isieZ+uq02wypUQfctgF0mmzdnqsj0MpSPi1vSOjkWhy11NrxXNOv0QzuaP8T/MkPOhTgxz562i1/EbOKQ/3Mz4J+Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwgPdWBWCAwfxYs2t8WzMVtE/vx/nMtw7zRV4JfZxuy2Op4pb5HsGcfs8R+hakzpFIcqrb8xYwvG4x2TyL019IAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "99E845D675EB6A158A1B0627AD570A37286A17496FE97EC2C08062ACBFDD596A",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:TczbSVJhiqCc5Fsw8/hFf4aHtGjAVqHONW9pW9M7cUM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:6s99axgqTUw6Oa4kCUPOKk5pr0OlwZhppFRC7dP0N8Y="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1683663008007,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAg9obXMOlZolANGDdvBUEhNm7hAo4+UL3VTpGJYzGIeKye0bn2wdsCw6KJH+fqfawEylNwU7SmDY601UvTMN+r4xb4xtU1GCCjbafk61kTsqPR/30cOl6WI1jVeO4Vwh28zcdg4KS624Skrpiun3w4iuaHiu8hCpvlzmrnJENHsAWZ8B3f7fo76C3u6OLpeKFLHlEDpazbY04C47s5itKvbbnXUBCryyKqtFISfqXAj2UrYw5h57GW7O0+piQwKQgAT3sc9JZFGK16KHYhqBHjQ29qJyPrt4VZs2doVtpeN8VmY87hqF+srfWCfajqYLSMjTkfJeOtHKuwUcNTkPXBusEpQtaALj+gVGG+EsMS9lDLklDlY1D4RHNdhvBpqdbEUzF0ViGswRXjA/jY0Ljgiy5b5i4lzPlDPkXFjIC5oegzyBP6wOfmjuzC8JvomfwfKefWiIBSFu6mPvd6w5/m0RHe7f566AOXAf0dRDx9kBM9G2J4HqylbhU9g3O4U7KJjDuhRzcKlAxGStlAifSf8+OfWWkqewWw3iiw+AN52L8Ec6ta/5DDoKB8X2l5NzbGhS0O+bLqtzJwwJkPEnive9WEWVP8w9kzYPYRqETvvV6hV5IK4YLe0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8VWtKoTyxSNM5tavE8m6TLW+TmCOLKtO1fawU2n0vr3LlqNUg5CLz2lsLQ53zYBUoxcsKcnzNJSJ3vGRTXkICA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAIfY0KYWlEnh3ksxHRSMigWPgd2V0o3rNI5WzE4Q14FKMVi3H0Hz3/haU61A+Pc/wK3X8/KDNJS5hT7irqu0hNq8mNRvW6ut/EmcUrW7LJqCqc3rf0BcxjkC0gX/sIgBvEiWNs1+yRK3dEeLUeH1V7B5BRUvUxJk7klQlz4lgyA4Ha0XCZKQ0ebwlAqVrEbngcDZQSRMp9t7+7HyyjnIRol63ISab6OlLtBc6PjvBfu+sKJe9AyMl9TppAXYTguqwYTb6I4jiwyEZrgzru8A0i+LuoqA0jDf2joEyB+6NxfDIAkdqx/d0Z7hNOT3OnYK8qYAxAlGef5aeaXb4jqAMcRX0GnKTgDWllazKCsu6wG6lfwECcN3sZzOiVvVlQFgdBAAAAIQ1J0cCgahJOkXsvhOBGzrs7fgosVlTfNsC2iaGw+UJAoKoEpoDEimHLPjv3NNLLAo8vmIrmjjUo1Fxbor08+vcPweURjm40ehjB/zvQtBKcCcpCVfcMkSI0KHegQP+C6wOTpCqmVYtIM+OVFrpQg6FbUedSsdFj4qyfQFQEL8gSQ86RHMDLEKj3N0112Rb1altNrvS4pdqLc292f9dp9bD+1Q9ufU7MWBruCT87I23Nx4NFTroUIvA6YG0AZqEURcNaIsrRqjHt/yOpJV92pgRF6Yp0Xahk8MowjH9v9f+HmECyQJ4D6i4r7qWLKO+TJQIaHNvWHktIJ4LJeQXIJrlQtOlO8J7Hj/bkgd5hNBKDpArleH+ZZwZ+u/bH69pFy88dpWsBv4caV70KimixdarOKOWWwqi7HIy/K1kRXtRceOcDYEelqBjX4NJcxdx6cctFjSP5j7HUtMwyom/ilGY7kp/cCBpToUTZvC7J+XoNf+O8zztTD8KY2id0nELyGeyAbSFIX2vHAKhiPStLimph45WNypmidkZSgbjbqVoLwvhuYIvLIKgCU4spS3OsF4eJs3isDu8FirtNYYCaEeiJ9yDEuTVZ+WLTJm327W2M59o9ZyyOz4pUbW33KfK0pEhXVZFyO86CWKkvreFVr5HjpGRlEPT+V/NOWxhgnHX9OqQT30ZvxaM4+Ve1IovjdJAuFeHYZrPTb9GgzN2OmvmCdYERtgwPsuLiZk4pqFLheTH1ae6xAvKpqtrBWwrFfYUmdcaRfLlT63QEKR3gIcfxxTbb7e8iDId4ElcQQs1QtzscFzRTjmYgStqLfRHP5WT+TAfRm73NgVOOwxdsiD6C3cMrW+5G5AgDrsIwiRPhXYTbRIScCGIXvnWrxcsuzHwJwXTpdceivUg0j4yusQXuBr1mmxB7jxoprjdZAaD0L4trkctUBcVE/QZoScnIlYAXO/vr3Co5F/IGm53wqE1YQPx4fHrUxAxGxCYAvIUiS11WB3M2wC3oinjnhp4XWupeNrDAWXpgQNyPau+JzGc3XpC69bx0/lOZvX03Xf4hTI01FZc8hvVJkC8YFdRaX6PYzqppOUomOTw/enRWsaJCMOePaYEL9rCLaFmXbaOkDbWZmNSYSxpKBiACwW3eSf3mteynbgBKRaBk9LqOd8aF9CIf5DalM1biox7sd3IJmuUtaaCNhFcjIRzRGwkl5vmj5HEa6V3ci2UhxM/QuZKK/lBAgR9nwtlO+crNhJNa6Z2hOxi5MpzREhLHRKzWV5MKNf1rqTNLBP7JcniQ9IKw2Uni5calqJ4QGFxhe/9pQ3ldS4kUtfQXdGnjyQE3etKzUxVK3B6b50YD7KbGaRK9yU2ZZfcSbDBS41a6eq2fmV+aHJ7Sccl0PEyQje8KKbmeKfwxg2tT11uNEdUq2Eg6NhwmB3i+5upV8Suv5hJpWx1rxl0sXOI8c9lCl2rVBtL2rVCroMGqoZcwYy597fRp1yTgfYWQjS9ECmcaCZppGOES0KASACYi7pQvmPbh+H1p37Dj/UySID+l7mRhQKRGa5QHoK/5nGCSfNaGjYVSZGCHafn0ysvEhEHKtkrDA=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/mempool/followTransactionStream.test.ts
+++ b/ironfish/src/rpc/routes/mempool/followTransactionStream.test.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { useBlockWithTx } from '../../../testUtilities'
+import { createRouteTest } from '../../../testUtilities/routeTest'
+
+describe('Route mempool/followTransactionStream', () => {
+  const routeTest = createRouteTest()
+
+  it('should stream transactions as they are added to the mempool', async () => {
+    const { node } = routeTest
+
+    const response = await routeTest.client
+      .request('mempool/followTransactionStream')
+      .waitForRoute()
+
+    const { transaction } = await useBlockWithTx(routeTest.node)
+
+    node.memPool.acceptTransaction(transaction)
+
+    const { value } = await response.contentStream().next()
+
+    expect(value).toMatchObject({
+      serializedTransaction: transaction.serialize().toString('hex'),
+    })
+
+    response.end()
+    expect(response.status).toEqual(200)
+  })
+})

--- a/ironfish/src/rpc/routes/mempool/followTransactionStream.ts
+++ b/ironfish/src/rpc/routes/mempool/followTransactionStream.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { Transaction } from '../../../primitives'
+import { ApiNamespace, router } from '../router'
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type FollowMempoolTransactionStreamRequest = {} | undefined
+
+export type FollowMempoolTransactionStreamResponse = {
+  serializedTransaction: string
+}
+
+export const FollowMempoolTransactionStreamRequestSchema: yup.ObjectSchema<FollowMempoolTransactionStreamRequest> =
+  yup.object({}).notRequired().default({})
+
+export const FollowMempoolTransactionStreamResponseSchema: yup.ObjectSchema<FollowMempoolTransactionStreamResponse> =
+  yup
+    .object({
+      serializedTransaction: yup.string().defined(),
+    })
+    .defined()
+
+router.register<
+  typeof FollowMempoolTransactionStreamRequestSchema,
+  FollowMempoolTransactionStreamResponse
+>(
+  `${ApiNamespace.mempool}/followTransactionStream`,
+  FollowMempoolTransactionStreamRequestSchema,
+  (request, node): void => {
+    const onAdd = (transaction: Transaction) => {
+      request.stream({
+        serializedTransaction: transaction.serialize().toString('hex'),
+      })
+    }
+
+    node.memPool.onAdd.on(onAdd)
+
+    request.onClose.on(() => {
+      node.memPool.onAdd.off(onAdd)
+    })
+  },
+)

--- a/ironfish/src/rpc/routes/mempool/index.ts
+++ b/ironfish/src/rpc/routes/mempool/index.ts
@@ -4,3 +4,4 @@
 
 export * from './getTransactions'
 export * from './getStatus'
+export * from './followTransactionStream'


### PR DESCRIPTION
## Summary

creates a mempool rpc endpoint to stream serialized transactions as they are added to the mempool.

adds an event to the mempool that emits each transaction successfully added to the mempool.

supports syncing mempool transaction to the api.

## Testing Plan

- adds unit test
- manual testing:
  - simple script to invoke the rpc endpoint using the sdk and log transactions to the console

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
