### PR TITLE
Update brew workflow to macos-12

### DIFF
--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -1,5 +1,9 @@
 name: Deploy Brew Tap Release
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      refToBuild:
+        type: string
 
 jobs:
   Deploy:
@@ -9,18 +13,13 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.refToBuild }}
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: nodejs
-
-      - name: Cache Ironfish CLI Build
-        id: cache-ironfish-cli-build
-        uses: actions/cache@v3
-        with:
-          path: ironfish-cli/build.cli/ironfish-cli.tar.gz
-          key: ${{ github.sha }}
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -29,7 +28,6 @@ jobs:
           cache: 'yarn'
 
       - name: Build Ironfish CLI
-        if: steps.cache-ironfish-cli-build.outputs.cache-hit != 'true'
         run: ./ironfish-cli/scripts/build.sh
 
       - name: Deploy Ironfish CLI Brew

--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 jobs:
   Deploy:
     name: Deploy
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
## Summary

Homebrew deploys aren't working because the Github action is running on a 
deprecated version of MacOS.

Fixes IFL-935

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
