### PR TITLE
Try optionally checking the brew deploy ref

### DIFF
--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -11,10 +11,15 @@ jobs:
     runs-on: macos-12
 
     steps:
-      - name: Check out Git repository
+      - name: Check out Git repository with ref
         uses: actions/checkout@v3
+        if: ${{ inputs.refToBuild != '' }}
         with:
           ref: ${{ inputs.refToBuild }}
+
+      - name: Check out Git repository without ref
+        if: ${{ inputs.refToBuild == '' }}
+        uses: actions/checkout@v3
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

It doesn't look like optionally specifying a ref to check out in the Deploy Brew workflow works as expected. Going to test it again in this branch.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
