### PR TITLE
feat(ifl-934): runtime config variable (SDK vs CLI vs NodeApp)

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -118,7 +118,7 @@ export abstract class IronfishCommand extends Command {
     const dataDirFlag = getFlag(flags, DataDirFlagKey)
     const configFlag = getFlag(flags, ConfigFlagKey)
 
-    const configOverrides: Partial<ConfigOptions> = {}
+    const configOverrides: Partial<ConfigOptions> = { runtime: 'CLI' }
     const internalOverrides: Partial<InternalOptions> = {}
 
     const rpcConnectIpcFlag = getFlag(flags, RpcUseIpcFlagKey)

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -273,6 +273,11 @@ export type ConfigOptions = {
    * Always allow incoming connections from these IPs even if the node is at maxPeers
    */
   incomingWebSocketWhitelist: string[]
+
+  /**
+   * From where is the ironfish node started, currently either from CLI, Node App, or SDK directly
+   */
+  runtime: string
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -349,6 +354,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     memPoolRecentlyEvictedCacheSize: yup.number().integer(),
     networkDefinitionPath: yup.string().trim(),
     incomingWebSocketWhitelist: yup.array(yup.string().trim().defined()),
+    runtime: yup.string().trim(),
   })
   .defined()
 
@@ -439,6 +445,7 @@ export class Config extends KeyStore<ConfigOptions> {
       memPoolRecentlyEvictedCacheSize: 60000,
       networkDefinitionPath: files.resolve(files.join(dataDir, 'network.json')),
       incomingWebSocketWhitelist: [],
+      runtime: 'SDK',
     }
   }
 }

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -113,7 +113,10 @@ export class IronfishNode {
       metrics,
       workerPool,
       localPeerIdentity: privateIdentityToIdentity(identity),
-      defaultTags: [{ name: 'version', value: pkg.version }],
+      defaultTags: [
+        { name: 'version', value: pkg.version },
+        { name: 'runtime', value: config.get('runtime') },
+      ],
       defaultFields: [
         { name: 'node_id', type: 'string', value: internal.get('telemetryNodeId') },
         { name: 'session_id', type: 'string', value: uuid() },


### PR DESCRIPTION
## Summary
This adds a configuration variable for the node so we can tell how the if node is running. Currently we have 3 ways, sdk directly, cli, and soon the node app.
## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
