### PR TITLE
Add confirmations and account to mint,burn,send fee selector

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -158,6 +158,8 @@ export class Burn extends IronfishCommand {
       raw = await selectFee({
         client,
         transaction: params,
+        account: account,
+        confirmations: flags.confirmations,
         logger: this.logger,
       })
     } else {

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -195,6 +195,8 @@ export class Mint extends IronfishCommand {
       raw = await selectFee({
         client,
         transaction: params,
+        account: account,
+        confirmations: flags.confirmations,
         logger: this.logger,
       })
     } else {

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -199,6 +199,7 @@ export class Send extends IronfishCommand {
         client,
         transaction: params,
         account: from,
+        confirmations: flags.confirmations,
         logger: this.logger,
       })
     } else {


### PR DESCRIPTION
## Summary

If users manually pass in an account or confirmations value, we should pass that along to the custom fee selector.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
