### PR TITLE
adds confirmations to chain/getNoteWitness

### DIFF
--- a/ironfish/src/rpc/routes/chain/__fixtures__/getNoteWitness.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/getNoteWitness.test.ts.fixture
@@ -52,5 +52,59 @@
         }
       ]
     }
+  ],
+  "Route chain/getNoteWitness gets note witness for each confirmed note using a confirmation range": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZIUnyshltZynUI4at3BwP21KNuwMOJF8unERlvm7vV0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:xRbilhqg36sxbOHspocfQPPPsMFO+xfcJRKxAbXQzcs="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1683935610513,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA7OybsE8ACeFowXfNTjNbXoXvZOARpyfZbxtqWAmbF7CthjV2mEHBQUC49Els326cFfGrpjVp+aouhj2O8APoViVr7Vn0Gt7eZ237DlO2BL+I5oYQpYjAt+MWYQasUirnCWpRP+DwbJ7c/gtTK4kKd5wmJUucHENbnhWmHe5WJE8YBBLHjEBD8KyLTTedRnpBX2pGd3GoTdbyjhkvNB7lyoNiZ8VmlN0+goLdZUokj3iBZlFSM+qShuO0ESLR3lybkn8cMYKHQR2Y8qoPGQoUm2I42YcdRZZz/ney0cM+1xPcMJsXdBSEjc3gkpZdVY0VH1PW8dxnRDmxhoJeflMGt8ADwnU0oyREhY+7hQcpzxoj2uhgDGjpKr5wP0CpzIcT6SFQVZ4IgBoMTdpWy0hJgvSgKJeWEfh1QubNhndqnnM8q7mTl3R6tRraG7iIgwBU6DFnnv7H5gKtn8E9uA6GDA/sn5clmsXXgdclQGiuTv2/KhPK6B16pKLTu+QJDAAir69x+i3IImPxD24OpcBW2C6by98SYuqok9fcTAyNOyPfL8nhuSCS6Oh4TQrt/bTtU9DUzsZJJ2C3z6KarTbuDgRUblL3xiMHaEU5H58DOWnuotEFrHG3sklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhIFfvyUnuMQJShgEjJ0ZLqzkCXzYvAMTTcUjtQRnviEmImM2a9iDpaaqDA1objZCztOPoZ4EYFPaJC9BPbWvBQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "FEDE54F466277B855DED2DFC3FDD5957A99816B4F8EF0E5688269EA66C3AA438",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:qYxoAE+nzWNtUSxhFV+fX17mxww2sO080BRxLiBWLks="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:jWXO/Fw2rQKgyjPznHH7Orls3nB9Phe0dlu62dsQfY8="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1683935611113,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAreXvFfeZc3wUoxU3C9V3vjJrMwi7YMhf/tnEqGhOScihlvDtoNKmxeRd3PvPWyhjSd7teh/lbDMWDFluNHB8HqG+cGd9EnPqS1+hKrpzASWqITnf7MT7NDkz+r9v75pKotTvqPN4k8Escgy6nh8Ne6eFFOwC4roMib+u6Tn4jbYFq2eCw/dN+2vi7dccbMk9pHX2lFzKLNg3D5NkhlX7lbz+5v1+moAhr5JpI5iXLqGKsRWVYvZuK0Ns/gVvEkotC5X8B/0+4phTw18NhTtEezAlteMXhrEKvygynu6Vkzy4/qgg6Od2ZC+qIoYbuPnbWuoKjqCqRnZFMogm4dLGhS1nCIohe+9UmdehvHssATZ0e6etmpHT7bnMlZKqtelt68nZ5sFJkkdSOyLU+zLcYdMqCv1HmrSEKncxx42+8GUBAslrKtQIzcHtXdHBHJERUBevvdmJMMDzLKO/RBCpza+dqhNQDdd6cOlTIr/3qn3MyBHUn9KapKJXBS7noIA22Kd38k04jSzfHtMeowr7Z3RlYEkZIrT53MPr/AiOZOpChc1MroyhUqmvljtiepEsilslFv+XwFSSuqNPkQobQDcc2yrKuvi34liykX/ALVDb+OyiHtrcw0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8j7xwH0KbuIwBs7tgJt44UCyDQQyG/lPJ2olRvL59g9KqsDjQ674eVQryMAX2KPyWiqLWWHPaWbJrzImvQ8NBA=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/rpc/routes/chain/getNoteWitness.test.ts
+++ b/ironfish/src/rpc/routes/chain/getNoteWitness.test.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../../../assert'
+import { Witness } from '../../../merkletree'
+import { NoteEncrypted } from '../../../primitives/noteEncrypted'
 import { useMinerBlockFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { GetNoteWitnessResponse } from './getNoteWitness'
@@ -39,6 +41,56 @@ describe('Route chain/getNoteWitness', () => {
       })
 
       expect(response.content.authPath).toEqual(expectedAuthPath)
+    }
+  })
+
+  it('gets note witness for each confirmed note using a confirmation range', async () => {
+    const { chain } = routeTest
+    await chain.open()
+
+    const block1 = await useMinerBlockFixture(chain)
+    await expect(chain).toAddBlock(block1)
+    const block2 = await useMinerBlockFixture(chain)
+    await expect(chain).toAddBlock(block2)
+
+    const noteSize = block1.header.noteSize
+
+    Assert.isNotNull(noteSize)
+
+    const confirmations = 1
+
+    for (let index = 0; index < noteSize; index++) {
+      const response = await routeTest.client
+        .request<GetNoteWitnessResponse>('chain/getNoteWitness', { index, confirmations })
+        .waitForEnd()
+
+      const witness: Witness<NoteEncrypted, Buffer, Buffer, Buffer> | null =
+        await chain.notes.witness(index, noteSize)
+      Assert.isNotNull(witness)
+
+      expect(response.content.rootHash).toEqual(witness.rootHash.toString('hex'))
+      expect(response.content.treeSize).toEqual(witness.treeSize())
+
+      const expectedAuthPath = witness.authenticationPath.map((step) => {
+        return {
+          side: step.side,
+          hashOfSibling: step.hashOfSibling.toString('hex'),
+        }
+      })
+
+      expect(response.content.authPath).toEqual(expectedAuthPath)
+    }
+
+    const block2NoteSize = block2.header.noteSize
+    Assert.isNotNull(block2NoteSize)
+
+    // Notes on block2 are not confirmed
+    for (let index = noteSize; index < block2NoteSize; index++) {
+      await expect(() =>
+        routeTest.client
+          .request<GetNoteWitnessResponse>('chain/getNoteWitness', { index, confirmations })
+          .waitForEnd(),
+      ).rejects.toThrow(`No confirmed notes exist with index ${index}`)
     }
   })
 })

--- a/ironfish/src/rpc/routes/chain/getNoteWitness.ts
+++ b/ironfish/src/rpc/routes/chain/getNoteWitness.ts
@@ -65,7 +65,9 @@ router.register<typeof GetNoteWitnessRequestSchema, GetNoteWitnessResponse>(
     const witness = await chain.notes.witness(request.data.index, maxConfirmedHeader.noteSize)
 
     if (witness === null) {
-      throw new ValidationError(`No confirmed notes exist with index ${request.data.index}`)
+      throw new ValidationError(
+        `No confirmed notes exist with index ${request.data.index} in tree of size ${maxConfirmedHeader.noteSize}`,
+      )
     }
 
     const authPath = witness.authenticationPath.map((step) => {


### PR DESCRIPTION
## Summary

the merkle tree now supports creating witnesses at past tree sizes. this allows us to create witnesses using a confirmation range.

adds a confirmations request parameter to the chain/getNoteWitness rpc. use confirmations to determine the confirmed tree size before creating a witness for the note at that tree size.

Closes IFL-880, IFL-881

## Testing Plan

- adds unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
