### PR TITLE
feat(ifl-934): agent to telemetry tags

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -113,7 +113,10 @@ export class IronfishNode {
       metrics,
       workerPool,
       localPeerIdentity: privateIdentityToIdentity(identity),
-      defaultTags: [{ name: 'version', value: pkg.version }],
+      defaultTags: [
+        { name: 'version', value: pkg.version },
+        { name: 'agent', value: Platform.getAgent(pkg) },
+      ],
       defaultFields: [
         { name: 'node_id', type: 'string', value: internal.get('telemetryNodeId') },
         { name: 'session_id', type: 'string', value: uuid() },

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -40,6 +40,29 @@ describe('IronfishSdk', () => {
       expect(sdk.config.storage.configPath).toContain('foo.config.json')
     })
 
+    it('should initialize an SDK/node with correct agent tag', async () => {
+      const dataDir = os.tmpdir()
+
+      const fileSystem = new NodeFileProvider()
+      await fileSystem.init()
+
+      const sdk = await IronfishSdk.init({
+        pkg: { name: 'node-app', license: 'MIT', version: '1.0.0', git: 'foo' },
+        configName: 'foo.config.json',
+        dataDir: dataDir,
+        fileSystem: fileSystem,
+      })
+
+      const node = await sdk.node()
+
+      expect(node.telemetry['defaultTags']).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'agent', value: 'node-app/1.0.0/foo' }),
+        ]),
+      )
+      expect(sdk.config.storage.configPath).toContain('foo.config.json')
+    })
+
     it('should detect platform defaults', async () => {
       const sdk = await IronfishSdk.init({ dataDir: os.tmpdir() })
       const runtime = Platform.getRuntime()


### PR DESCRIPTION
## Summary
Adds agent to telemetry tags so we can differentiate node app
## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
