### PR TITLE
updates sync service to submit transaction gossip to api

### DIFF
--- a/ironfish-cli/src/commands/service/sync.ts
+++ b/ironfish-cli/src/commands/service/sync.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { FollowChainStreamResponse, Meter, TimeUtils, WebApi } from '@ironfish/sdk'
+import { FollowChainStreamResponse, Meter, TimeUtils, Transaction, WebApi } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -12,7 +12,7 @@ export default class Sync extends IronfishCommand {
   static hidden = true
 
   static description = `
-    Upload blocks to an HTTP API using IronfishApi
+    Upload blocks and mempool transactions to an HTTP API using IronfishApi
   `
 
   static flags = {
@@ -33,7 +33,7 @@ export default class Sync extends IronfishCommand {
       char: 'm',
       required: false,
       default: isNaN(Number(process.env.MAX_UPLOAD)) ? 20 : Number(process.env.MAX_UPLOAD),
-      description: 'The max number of blocks to sync in once batch',
+      description: 'The max number of blocks or transactions to sync in one batch',
     }),
   }
 
@@ -53,7 +53,7 @@ export default class Sync extends IronfishCommand {
 
     if (!apiHost) {
       this.log(
-        `No api host found to upload blocks to. You must set IRONFISH_API_HOST env variable or pass --endpoint flag.`,
+        `No api host found to upload blocks and transactions to. You must set IRONFISH_API_HOST env variable or pass --endpoint flag.`,
       )
       this.exit(1)
     }
@@ -67,13 +67,19 @@ export default class Sync extends IronfishCommand {
 
     this.log('Connecting to node...')
 
-    const client = await this.sdk.connectRpc()
-
     const api = new WebApi({ host: apiHost, token: apiToken })
 
-    let head = args.head as string | null
+    const head = args.head as string | null
+
+    void this.syncTransactionGossip(api, flags.maxUpload)
+    await this.syncBlocks(api, head, flags.maxUpload)
+  }
+
+  async syncBlocks(api: WebApi, head: string | null, maxUpload: number): Promise<void> {
+    const client = await this.sdk.connectRpc()
+
     if (!head) {
-      this.log(`Fetching head from ${apiHost}`)
+      this.log(`Fetching head from ${api.host}`)
       head = await api.headBlocks()
     }
 
@@ -104,7 +110,7 @@ export default class Sync extends IronfishCommand {
         Math.abs(content.head.sequence - content.block.sequence) < NEAR_SYNC_THRESHOLD
 
       // Should we commit the current batch?
-      const committing = buffer.length === flags.maxUpload || finishing
+      const committing = buffer.length === maxUpload || finishing
 
       this.log(
         `${content.type}: ${content.block.hash} - ${content.block.sequence}${
@@ -120,6 +126,29 @@ export default class Sync extends IronfishCommand {
       )
 
       if (committing) {
+        await commit()
+      }
+    }
+
+    await commit()
+  }
+
+  async syncTransactionGossip(api: WebApi, maxUpload: number): Promise<void> {
+    const client = await this.sdk.connectRpc()
+
+    const response = client.event.onTransactionGossipStream({})
+
+    const buffer = new Array<Transaction>()
+
+    async function commit(): Promise<void> {
+      await api.transactions(buffer)
+      buffer.length = 0
+    }
+
+    for await (const content of response.contentStream()) {
+      buffer.push(new Transaction(Buffer.from(content.serializedTransaction, 'hex')))
+
+      if (buffer.length === maxUpload) {
         await commit()
       }
     }

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -3,8 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import axios, { AxiosError, AxiosRequestConfig } from 'axios'
+import { getTransactionSize } from './network/utils/serializers'
+import { Transaction } from './primitives'
 import { FollowChainStreamResponse } from './rpc/routes/chain/followChainStream'
+import { BlockHashSerdeInstance } from './serde'
 import { Metric } from './telemetry'
+import { BufferUtils } from './utils'
 import { HasOwnProperty, UnwrapPromise } from './utils/types'
 
 type FaucetTransaction = {
@@ -134,6 +138,41 @@ export class WebApi {
     const options = this.options({ 'Content-Type': 'application/json' })
 
     await axios.post(`${this.host}/blocks`, { blocks: serialized }, options)
+  }
+
+  async transactions(transactions: Transaction[]): Promise<void> {
+    this.requireToken()
+
+    const serialized = []
+
+    for (const transaction of transactions) {
+      serialized.push({
+        hash: BlockHashSerdeInstance.serialize(transaction.hash()),
+        size: getTransactionSize(transaction),
+        fee: Number(transaction.fee()),
+        notes: transaction.notes.map((note) => ({
+          commitment: note.hash().toString('hex'),
+        })),
+        spends: transaction.spends.map((spend) => ({
+          nullifier: spend.nullifier.toString('hex'),
+        })),
+        mints: transaction.mints.map((mint) => ({
+          id: mint.asset.id().toString('hex'),
+          metadata: BufferUtils.toHuman(mint.asset.metadata()),
+          name: BufferUtils.toHuman(mint.asset.name()),
+          owner: mint.asset.owner().toString('hex'),
+          value: mint.value.toString(),
+        })),
+        burns: transaction.burns.map((burn) => ({
+          id: burn.assetId.toString('hex'),
+          value: burn.value.toString(),
+        })),
+      })
+    }
+
+    const options = this.options({ 'Content-Type': 'application/json' })
+
+    await axios.post(`${this.host}/transactions`, { transactions: serialized }, options)
   }
 
   async getFunds(data: { email?: string; public_key: string }): Promise<{

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -167,6 +167,7 @@ export class WebApi {
           id: burn.assetId.toString('hex'),
           value: burn.value.toString(),
         })),
+        expiration: transaction.expiration(),
       })
     }
 


### PR DESCRIPTION
## Summary

moves 'syncBlocks' to a separate method

defines 'syncTransactionGossip' method to invoke the 'event/onTransactionGossip' RPC and submit transactions to the API

updates 'sync' to run both of these methods in coroutines

updates 'webApi' with a 'transactions' method. matches transaction serialization with serialization from 'followChainStream' for transactions submitted to API with blocks.

## Testing Plan

manual testing: ran syncer locally and synced transaction to testnet api: 5c1fa0c851957d46585addf64567fb6ab93f980d23d0d698a6ab49cfc2eb7e1b

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
