### PR TITLE
removes loops from getNewBlockTransactions

### DIFF
--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -209,6 +209,7 @@ export class MiningManager {
     // Fetch pending transactions
     const blockTransactions: Transaction[] = []
     const nullifiers = new BufferSet()
+    let totalTransactionFees = BigInt(0)
     for (const transaction of this.memPool.orderedTransactions()) {
       // Skip transactions that would cause the block to exceed the max size
       const transactionSize = getTransactionSize(transaction)
@@ -235,14 +236,8 @@ export class MiningManager {
       }
 
       currBlockSize += transactionSize
+      totalTransactionFees += transaction.fee()
       blockTransactions.push(transaction)
-    }
-
-    // Sum the transaction fees
-    let totalTransactionFees = BigInt(0)
-    const transactionFees = await Promise.all(blockTransactions.map((t) => t.fee()))
-    for (const transactionFee of transactionFees) {
-      totalTransactionFees += transactionFee
     }
 
     this.metrics.mining_newBlockTransactions.add(BenchUtils.end(startTime))


### PR DESCRIPTION
## Summary

when creating a new block template the mining manager collects a list of transactions to include in the block.

the mining manager iterates over transactions in the mempool, verifies the spends in the transactions, and tracks the total size and total fee from included transactions.

we iterate over the list of included transactions twice after collecting them: once to read the fee from the transaction and again to sum the fees.

these changes remove the extra iterations over included transactions. performance gains will be neglible.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
