### PR TITLE
fix: typescript perf tests run in band, longer timeout

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -54,7 +54,7 @@
     "start": "tsc -b -w",
     "test": "tsc -b && tsc -b tsconfig.test.json && jest --testTimeout=${JEST_TIMEOUT:-5000}",
     "test:slow": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.slow.ts\" --testTimeout=${JEST_TIMEOUT:-60000} --testPathIgnorePatterns",
-    "test:perf": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.perf.ts\" --testTimeout=${JEST_TIMEOUT:-60000} --testPathIgnorePatterns",
+    "test:perf": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.perf.ts\" --testTimeout=${JEST_TIMEOUT:-600000} --testPathIgnorePatterns --runInBand",
     "test:coverage:html": "tsc -b tsconfig.test.json && jest --coverage --coverage-reporters html --testPathIgnorePatterns",
     "test:watch": "tsc -b tsconfig.test.json && jest --watch --coverage false",
     "fixtures:regenerate": "find . -name \"__fixtures__\" | xargs rm -rf && JEST_TIMEOUT=1000000000 yarn run test && JEST_TIMEOUT=1000000000 yarn run test:slow && JEST_TIMEOUT=1000000000 yarn run test:perf"


### PR DESCRIPTION
## Summary

Realized when I was trying to run them all that it was running them in multiple threads and the timeout is too short for some of the longer running perf tests

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
