### PR TITLE
fixes error message from IronFlag

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -35,7 +35,7 @@ export class Burn extends IronfishCommand {
     fee: IronFlag({
       char: 'o',
       description: 'The fee amount in IRON',
-      largerThan: 0n,
+      minimum: 1n,
       flagName: 'fee',
     }),
     amount: IronFlag({

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -36,7 +36,7 @@ export class Mint extends IronfishCommand {
     fee: IronFlag({
       char: 'o',
       description: 'The fee amount in IRON',
-      largerThan: 0n,
+      minimum: 1n,
       flagName: 'fee',
     }),
     amount: IronFlag({

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -45,13 +45,13 @@ export class Send extends IronfishCommand {
     fee: IronFlag({
       char: 'o',
       description: 'The fee amount in IRON',
-      largerThan: 0n,
+      minimum: 1n,
       flagName: 'fee',
     }),
     feeRate: IronFlag({
       char: 'r',
       description: 'The fee rate amount in IRON/Kilobyte',
-      largerThan: 0n,
+      minimum: 1n,
       flagName: 'fee rate',
     }),
     memo: Flags.string({

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -127,7 +127,7 @@ remoteFlags[RpcAuthFlagKey] = RpcAuthFlag as unknown as CompletableOptionFlag
  */
 export const RemoteFlags = remoteFlags
 
-export type IronOpts = { largerThan?: bigint; flagName: string }
+export type IronOpts = { minimum?: bigint; flagName: string }
 
 export const IronFlag = Flags.custom<bigint, IronOpts>({
   parse: async (input, _ctx, opts) => parseIron(input, opts),
@@ -136,13 +136,13 @@ export const IronFlag = Flags.custom<bigint, IronOpts>({
 
 export const parseIron = (input: string, opts: IronOpts): Promise<bigint> => {
   return new Promise((resolve, reject) => {
-    const { largerThan, flagName } = opts ?? {}
+    const { minimum, flagName } = opts ?? {}
     try {
       const value = CurrencyUtils.decodeIron(input)
 
-      if (largerThan !== undefined && value <= largerThan) {
+      if (minimum !== undefined && value < minimum) {
         reject(
-          new Error(`The minimum ${flagName} is ${CurrencyUtils.renderOre(largerThan, true)}`),
+          new Error(`The minimum ${flagName} is ${CurrencyUtils.renderOre(minimum, true)}`),
         )
       }
 


### PR DESCRIPTION
## Summary

the IronFlag takes a 'largerThan' parameter but prints an error message using the 'minimum'. this results in a misleading error message. for example, when using a fee of 0 ORE:

'Error: The minimum fee is $ORE 0'

- changes 'largerThan' to 'minimum'
- changes logic to use less than instead of less than or equal to trigger error messages
- changes flag usage to use minimums of 1 ORE for fees

## Testing Plan

manual testing:

before:
<img width="594" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/e9aa1e46-eae8-4be3-a75d-5d7dfc1cd326">


after:
<img width="540" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/75df1efd-31c4-4b80-ab8d-69319551be9b">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
