### PR TITLE
Allow empty strings in the `--memo` argument of `wallet:send`

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -57,7 +57,6 @@ export class Send extends IronfishCommand {
     memo: Flags.string({
       char: 'm',
       description: 'The memo of transaction',
-      default: '',
     }),
     confirm: Flags.boolean({
       default: false,
@@ -99,7 +98,6 @@ export class Send extends IronfishCommand {
     let assetId = flags.assetId
     let to = flags.to?.trim()
     let from = flags.account?.trim()
-    let memo = flags.memo?.trim()
 
     const client = await this.sdk.connectRpc()
 
@@ -163,9 +161,9 @@ export class Send extends IronfishCommand {
       })
     }
 
-    if (!memo) {
-      memo = await CliUx.ux.prompt('Enter the memo (or leave blank)', { required: false })
-    }
+    const memo =
+      flags.memo?.trim() ??
+      (await CliUx.ux.prompt('Enter the memo (or leave blank)', { required: false }))
 
     if (!isValidPublicAddress(to)) {
       this.log(`A valid public address is required`)


### PR DESCRIPTION
No longer prompt for a memo if `--memo ''` is specified on the command line.

## Summary

Previously, running `wallet:send --memo ''` would prompt for a memo interactively. With this change, the tool instead accepts an empty memo and moves on without any interactive prompt.

## Testing Plan

Before this change:

*   No `--memo` argument provided: prompt displayed
    ```
    $ yarn start wallet:send --amount 0.00000001 --fee 0.00000001 --to ...
    Enter the memo (or leave blank): 
    ...
    ```

*   Empty argument to `--memo`: **prompt displayed**
    ```
    $ yarn start wallet:send --amount 0.00000001 --fee 0.00000001 --to ... --memo ''
    ...
    ```

After this change:

*   No `--memo` argument provided: prompt displayed
    ```
    $ yarn start wallet:send --amount 0.00000001 --fee 0.00000001 --to ...
    Enter the memo (or leave blank): 
    ...
    ```

*   Empty argument to `--memo`: **prompt not displayed**
    ```
    $ yarn start wallet:send --amount 0.00000001 --fee 0.00000001 --to 00000070b161aa5c25f62fcac296273418e6ac81d98ab5a4421e6bdf02000000 --memo ''
    ...
    ```

## Documentation

No docs change required.

## Breaking Change

Not a breaking change.