### PR TITLE
Add browse CLI command

### DIFF
--- a/ironfish-cli/src/commands/browse.ts
+++ b/ironfish-cli/src/commands/browse.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Platform } from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../command'
+import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey } from '../flags'
+import { PlatformUtils } from '../utils'
+
+export class BrowseCommand extends IronfishCommand {
+  static description = `Browse to your data directory`
+
+  static flags = {
+    [ConfigFlagKey]: ConfigFlag,
+    [DataDirFlagKey]: DataDirFlag,
+    cd: Flags.boolean({
+      default: false,
+      description: 'print the directory where the data directory is',
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(BrowseCommand)
+
+    const dataDir = this.sdk.fileSystem.resolve(this.sdk.dataDir)
+
+    if (flags.cd) {
+      this.log(dataDir)
+      this.exit(0)
+    }
+
+    this.log('Browsing to ' + dataDir)
+    const launched = PlatformUtils.browse(dataDir)
+
+    if (!launched) {
+      this.error(`Could not browse to ${dataDir} on ${Platform.getName()}`)
+    }
+  }
+}

--- a/ironfish-cli/src/utils/index.ts
+++ b/ironfish-cli/src/utils/index.ts
@@ -1,8 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export * from './asset'
 export * from './editor'
+export * from './platform'
 export * from './rpc'
 export * from './s3'
 export * from './tar'

--- a/ironfish-cli/src/utils/platform.ts
+++ b/ironfish-cli/src/utils/platform.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Platform } from '@ironfish/sdk'
+import { spawn } from 'child_process'
+
+/**
+ * Opens a resolved path in the OS specific explorer for a relevant path
+ * On mac it uses finder, on windows it uses explorer.
+ * @param dir The path or file to browse to
+ * @returns false if the OS explorer could not be detected
+ */
+export function browse(dir: string): boolean {
+  const platform = Platform.getName()
+
+  switch (platform) {
+    case 'win32':
+      spawn('explorer', [dir])
+      break
+    case 'darwin':
+      spawn('open', [dir])
+      break
+    default:
+      return false
+  }
+
+  return true
+}
+
+export const PlatformUtils = {
+  browse,
+}

--- a/ironfish/src/platform.ts
+++ b/ironfish/src/platform.ts
@@ -23,6 +23,14 @@ const getRuntime = ():
   return { type: 'unknown', runtime: 'unknown' }
 }
 
+const getName = (): NodeJS.Platform | 'unknown' => {
+  if (typeof process === 'object' && process && process.platform) {
+    return process.platform
+  }
+
+  return 'unknown'
+}
+
 /**
  * Returns a user agent that combines the name and version components
  *
@@ -34,4 +42,4 @@ const getAgent = (pkg: Package): string => {
   return `${pkg.name}/${pkg.version}/${pkg.git.slice(0, 8)}`
 }
 
-export const Platform = { getAgent, getRuntime }
+export const Platform = { getAgent, getRuntime, getName }


### PR DESCRIPTION
## Summary

This new command will attempt to open your data dir in your gui file explorer. The purpose is to make it easier to discover where your config and data directory is. I added support for the 2 systems I know what the finder process is. Others can submit PR's to add support for their environment.

## Testing Plan

Run `ironfish browse` on your platform.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

https://github.com/iron-fish/website/pull/468

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
