### PR TITLE
Add the 'expiration' field to transactions returned by followChainStream

### DIFF
--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -35,6 +35,7 @@ export type FollowChainStreamResponse = {
       hash: string
       size: number
       fee: number
+      expiration: number
       notes: Array<{ commitment: string }>
       spends: Array<{ nullifier: string }>
       mints: Array<{
@@ -84,6 +85,7 @@ export const FollowChainStreamResponseSchema: yup.ObjectSchema<FollowChainStream
                 hash: yup.string().defined(),
                 size: yup.number().defined(),
                 fee: yup.number().defined(),
+                expiration: yup.number().defined(),
                 notes: yup
                   .array(
                     yup
@@ -153,6 +155,7 @@ router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
             hash: BlockHashSerdeInstance.serialize(transaction.hash()),
             size: getTransactionSize(transaction),
             fee: Number(transaction.fee()),
+            expiration: transaction.expiration(),
             notes: transaction.notes.map((note) => ({
               commitment: note.hash().toString('hex'),
             })),


### PR DESCRIPTION
## Summary

This change exposes the expiration information of transactions in the output of `chain/followChainStream`. This new field is always present, even with the expiration is set to 0.

## Testing Plan

Checked the output of `curl -s http://127.0.0.1:8021/chain/followChainStream` and verified that the `expiration` field is present and contains an integer value.

## Documentation

https://github.com/iron-fish/website/pull/457

## Breaking Change

No, because this only adds a new field; it does not alter/delete existing fields.