### PR TITLE
Prepare rust crates' metadata for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ members = [
 [workspace.package]
 authors = ["Iron Fish <contact@ironfish.network> (https://ironfish.network)"]
 edition = "2021"
+homepage = "https://ironfish.network/"
+repository = "https://github.com/iron-fish/ironfish"
 
 [patch.crates-io]
 bellman = { git = "https://github.com/iron-fish/bellman", rev = "1cc52ca33e6db14233f1cbc0c9c5b7c822b229ec" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -9,6 +9,12 @@ workspace = true
 [package.edition]
 workspace = true
 
+[package.homepage]
+workspace = true
+
+[package.repository]
+workspace = true
+
 [dependencies]
 criterion = "0.4"
 ironfish_rust = { path = "../ironfish-rust", features = ["benchmark"] }

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -3,10 +3,19 @@ name = "ironfish-rust-nodejs"
 version = "0.1.0"
 license = "MPL-2.0"
 
+description = "Node.js addon for interacting with transactions on the Iron Fish chain"
+keywords = ["iron-fish", "cryptocurrency", "blockchain"]
+
 [package.authors]
 workspace = true
 
 [package.edition]
+workspace = true
+
+[package.homepage]
+workspace = true
+
+[package.repository]
 workspace = true
 
 [lib]

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -3,10 +3,19 @@ name = "ironfish_rust"
 version = "0.1.0"
 license = "MPL-2.0"
 
+description = "Rust crate for interacting with transactions on the Iron Fish chain"
+keywords = ["iron-fish", "cryptocurrency", "blockchain"]
+
 [package.authors]
 workspace = true
 
 [package.edition]
+workspace = true
+
+[package.homepage]
+workspace = true
+
+[package.repository]
 workspace = true
 
 [features]

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -36,7 +36,7 @@ chacha20poly1305 = "0.9.0"
 crypto_box = { version = "0.7.2", features = ["std"] }
 ff = "0.12.0"
 group = "0.12.0"
-ironfish_zkp = { path = "../ironfish-zkp" }
+ironfish_zkp = { version = "0.1.0", path = "../ironfish-zkp" }
 jubjub = "0.9.0"
 lazy_static = "1.4.0"
 libc = "0.2.126" # sub-dependency that needs a pinned version until a new release of cpufeatures: https://github.com/RustCrypto/utils/pull/789 

--- a/ironfish-zkp/Cargo.toml
+++ b/ironfish-zkp/Cargo.toml
@@ -3,10 +3,19 @@ name = "ironfish_zkp"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
+description = "Sapling API and zero-knowledge proving mechanism for the Iron Fish node"
+keywords = ["iron-fish", "sapling", "zero-knowledge"]
+
 [package.authors]
 workspace = true
 
 [package.edition]
+workspace = true
+
+[package.homepage]
+workspace = true
+
+[package.repository]
 workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Summary

Added description, keywords, and links to the crates that will be published to crates.io (plus a few more crates for consistency).

Also added a version number to the `ironfish-rust` -> `ironfish-zpk` dependency: this version number will be required in order to publish `ironfish-rust` to crates.io.

## Testing Plan

Ran `cargo publish --dry-run` for `ironfish-zkp`, and inspected the resulting `.crate` files. Relevant output:

```
[package]
edition = "2021"
name = "ironfish_zkp"
version = "0.1.0"
authors = ["Iron Fish <contact@ironfish.network> (https://ironfish.network)"]
description = "Sapling API and zero-knowledge proving mechanism for the Iron Fish node"
homepage = "https://ironfish.network/"
readme = "README.md"
keywords = [
    "iron-fish",
    "sapling",
    "zero-knowledge",
]
license = "MIT OR Apache-2.0"
repository = "https://github.com/iron-fish/ironfish"
resolver = "1"
```

It is not possible at the moment to run `cargo publish --dry-run` for `ironfish-rust` because `ironfish-zkp` needs to be published first.

## Documentation

N/A

## Breaking Change

Not a breaking change