### PR TITLE
Rename the `ironfish_rust` crate to just `ironfish`

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -81,7 +81,7 @@ jobs:
           wget -O tarpaulin.tar.gz https://github.com/xd009642/tarpaulin/releases/download/0.22.0/cargo-tarpaulin-0.22.0-travis.tar.gz
           tar -xzf tarpaulin.tar.gz
           mv cargo-tarpaulin ~/.cargo/bin/
-          cargo tarpaulin -p ironfish_rust --release --out Xml --avoid-cfg-tarpaulin --skip-clean --timeout 180 -- --test-threads 1
+          cargo tarpaulin -p ironfish --release --out Xml --avoid-cfg-tarpaulin --skip-clean --timeout 180 -- --test-threads 1
 
       # Upload code coverage to Codecov
       - name: Upload to codecov.io

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ name = "benchmarks"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "ironfish_rust",
+ "ironfish",
 ]
 
 [[package]]
@@ -811,6 +811,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironfish"
+version = "0.1.0"
+dependencies = [
+ "bellman",
+ "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
+ "bls12_381",
+ "byteorder",
+ "chacha20poly1305",
+ "crypto_box",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "ironfish_zkp",
+ "jubjub",
+ "lazy_static",
+ "libc",
+ "rand 0.8.5",
+ "tiny-bip39",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "ironfish-phase2"
 version = "0.2.2"
 dependencies = [
@@ -831,8 +854,8 @@ name = "ironfish-rust-nodejs"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "ironfish",
  "ironfish_mpc",
- "ironfish_rust",
  "napi",
  "napi-build",
  "napi-derive",
@@ -852,29 +875,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_seeder",
-]
-
-[[package]]
-name = "ironfish_rust"
-version = "0.1.0"
-dependencies = [
- "bellman",
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
- "bls12_381",
- "byteorder",
- "chacha20poly1305",
- "crypto_box",
- "ff 0.12.1",
- "group 0.12.1",
- "ironfish_zkp",
- "jubjub",
- "lazy_static",
- "libc",
- "rand 0.8.5",
- "tiny-bip39",
- "xxhash-rust",
 ]
 
 [[package]]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 criterion = "0.4"
-ironfish_rust = { path = "../ironfish-rust", features = ["benchmark"] }
+ironfish = { path = "../ironfish-rust", features = ["benchmark"] }
 
 [[bench]]
 name = "asset"

--- a/benchmarks/benches/asset.rs
+++ b/benchmarks/benches/asset.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
-use ironfish_rust::{
+use ironfish::{
     assets::asset::{Asset, METADATA_LENGTH, NAME_LENGTH},
     SaplingKey,
 };

--- a/benchmarks/benches/merkle_note.rs
+++ b/benchmarks/benches/merkle_note.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use ironfish_rust::{
+use ironfish::{
     assets::asset_identifier::NATIVE_ASSET, keys::EphemeralKeyPair, MerkleNote, Note, SaplingKey,
     ValueCommitment,
 };

--- a/benchmarks/benches/sapling_key.rs
+++ b/benchmarks/benches/sapling_key.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use ironfish_rust::SaplingKey;
+use ironfish::SaplingKey;
 
 pub fn generate_key(c: &mut Criterion) {
     c.bench_function("sapling_key::generate_key", |b| {

--- a/benchmarks/benches/transaction.rs
+++ b/benchmarks/benches/transaction.rs
@@ -1,6 +1,6 @@
 use benchmarks::{slow_config, very_slow_config};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use ironfish_rust::{
+use ironfish::{
     assets::{asset::Asset, asset_identifier::NATIVE_ASSET},
     test_util::make_fake_witness,
     transaction::batch_verify_transactions,

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 base64 = "0.13.0"
-ironfish_rust = { path = "../ironfish-rust" }
+ironfish = { path = "../ironfish-rust" }
 napi-derive = "=2.9.1"
 # Pinning this can be removed if we eventually move to the latest releases again
 napi-derive-backend = "=1.0.38"

--- a/ironfish-rust-nodejs/src/lib.rs
+++ b/ironfish-rust-nodejs/src/lib.rs
@@ -4,14 +4,14 @@
 
 use std::fmt::Display;
 
-use ironfish_rust::keys::Language;
-use ironfish_rust::PublicAddress;
-use ironfish_rust::SaplingKey;
+use ironfish::keys::Language;
+use ironfish::PublicAddress;
+use ironfish::SaplingKey;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use ironfish_rust::mining;
-use ironfish_rust::sapling_bls12;
+use ironfish::mining;
+use ironfish::sapling_bls12;
 
 pub mod mpc;
 pub mod nacl;

--- a/ironfish-rust-nodejs/src/nacl.rs
+++ b/ironfish-rust-nodejs/src/nacl.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ironfish_rust::{
+use ironfish::{
     nacl::{self, box_message, bytes_to_secret_key, new_secret_key, unbox_message},
     serializing::hex_to_bytes,
 };

--- a/ironfish-rust-nodejs/src/rolling_filter.rs
+++ b/ironfish-rust-nodejs/src/rolling_filter.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ironfish_rust::rolling_filter::RollingFilter;
+use ironfish::rolling_filter::RollingFilter;
 use napi::JsBuffer;
 use napi_derive::napi;
 

--- a/ironfish-rust-nodejs/src/signal_catcher.rs
+++ b/ironfish-rust-nodejs/src/signal_catcher.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ironfish_rust::signal_catcher::{init_signal_handler, trigger_segfault};
+use ironfish::signal_catcher::{init_signal_handler, trigger_segfault};
 use napi_derive::napi;
 
 /// # Safety

--- a/ironfish-rust-nodejs/src/structs/asset.rs
+++ b/ironfish-rust-nodejs/src/structs/asset.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ironfish_rust::{
+use ironfish::{
     assets::{
         asset::{
             Asset, ASSET_LENGTH as SERIALIZED_ASSET_LENGTH, ID_LENGTH, METADATA_LENGTH, NAME_LENGTH,

--- a/ironfish-rust-nodejs/src/structs/note.rs
+++ b/ironfish-rust-nodejs/src/structs/note.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ironfish_rust::{
+use ironfish::{
     assets::asset::ID_LENGTH as ASSET_ID_LENGTH,
     note::{AMOUNT_VALUE_SIZE, MEMO_SIZE, SCALAR_SIZE},
     ViewKey,
@@ -10,9 +10,9 @@ use ironfish_rust::{
 use napi::{bindgen_prelude::*, JsBuffer};
 use napi_derive::napi;
 
-use ironfish_rust::Note;
+use ironfish::Note;
 
-use ironfish_rust::keys::PUBLIC_ADDRESS_SIZE;
+use ironfish::keys::PUBLIC_ADDRESS_SIZE;
 
 use crate::to_napi_err;
 
@@ -59,9 +59,8 @@ impl NativeNote {
         sender: String,
     ) -> Result<Self> {
         let value_u64 = value.get_u64().1;
-        let owner_address = ironfish_rust::PublicAddress::from_hex(&owner).map_err(to_napi_err)?;
-        let sender_address =
-            ironfish_rust::PublicAddress::from_hex(&sender).map_err(to_napi_err)?;
+        let owner_address = ironfish::PublicAddress::from_hex(&owner).map_err(to_napi_err)?;
+        let sender_address = ironfish::PublicAddress::from_hex(&sender).map_err(to_napi_err)?;
 
         let buffer = asset_id.into_value()?;
         let asset_id_vec = buffer.as_ref();

--- a/ironfish-rust-nodejs/src/structs/note_encrypted.rs
+++ b/ironfish-rust-nodejs/src/structs/note_encrypted.rs
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ironfish_rust::IncomingViewKey;
-use ironfish_rust::MerkleNoteHash;
-use ironfish_rust::OutgoingViewKey;
+use ironfish::IncomingViewKey;
+use ironfish::MerkleNoteHash;
+use ironfish::OutgoingViewKey;
 use napi::bindgen_prelude::*;
 use napi::JsBuffer;
 use napi_derive::napi;
 
-use ironfish_rust::merkle_note::NOTE_ENCRYPTION_KEY_SIZE;
-use ironfish_rust::note::ENCRYPTED_NOTE_SIZE;
-use ironfish_rust::serializing::aead::MAC_SIZE;
-use ironfish_rust::MerkleNote;
+use ironfish::merkle_note::NOTE_ENCRYPTION_KEY_SIZE;
+use ironfish::note::ENCRYPTED_NOTE_SIZE;
+use ironfish::serializing::aead::MAC_SIZE;
+use ironfish::MerkleNote;
 
 use crate::to_napi_err;
 

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -5,12 +5,12 @@
 use std::cell::RefCell;
 use std::convert::TryInto;
 
-use ironfish_rust::assets::asset_identifier::AssetIdentifier;
-use ironfish_rust::transaction::{
+use ironfish::assets::asset_identifier::AssetIdentifier;
+use ironfish::transaction::{
     batch_verify_transactions, TRANSACTION_EXPIRATION_SIZE, TRANSACTION_FEE_SIZE,
     TRANSACTION_PUBLIC_KEY_SIZE, TRANSACTION_SIGNATURE_SIZE,
 };
-use ironfish_rust::{
+use ironfish::{
     MerkleNoteHash, ProposedTransaction, PublicAddress, SaplingKey, Transaction,
     TRANSACTION_VERSION as TX_VERSION,
 };
@@ -26,7 +26,7 @@ use super::note::NativeNote;
 use super::spend_proof::NativeSpendDescription;
 use super::witness::JsWitness;
 use super::{NativeAsset, ENCRYPTED_NOTE_LENGTH};
-use ironfish_rust::transaction::outputs::PROOF_SIZE;
+use ironfish::transaction::outputs::PROOF_SIZE;
 
 #[napi(js_name = "TransactionPosted")]
 pub struct NativeTransactionPosted {

--- a/ironfish-rust-nodejs/src/structs/witness.rs
+++ b/ironfish-rust-nodejs/src/structs/witness.rs
@@ -5,13 +5,13 @@
 use std::cell::RefCell;
 use std::ops::Deref;
 
-use ironfish_rust::sapling_bls12::Scalar;
-use ironfish_rust::MerkleNoteHash;
+use ironfish::sapling_bls12::Scalar;
+use ironfish::MerkleNoteHash;
 use napi::bindgen_prelude::*;
 use napi::Env;
 use napi::JsObject;
 
-use ironfish_rust::witness::{WitnessNode, WitnessTrait};
+use ironfish::witness::{WitnessNode, WitnessTrait};
 
 pub struct JsWitness {
     pub cx: RefCell<Env>,

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ironfish_rust"
+name = "ironfish"
 version = "0.1.0"
 license = "MPL-2.0"
 
@@ -13,7 +13,7 @@ workspace = true
 benchmark = []
 
 [lib]
-name = "ironfish_rust"
+name = "ironfish"
 path = "src/lib.rs"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Rename the crate in order to better follow the Rust conventions. In particular: https://rust-lang.github.io/api-guidelines/naming.html

> Crate names should not use -rs or -rust as a suffix or prefix. Every
> crate is Rust! It serves no purpose to remind users of this constantly.

## Testing Plan

Rebuilt the repository, and verified that the CLI program starts correctly.

## Documentation

N/A

## Breaking Change

Not a breaking change (yet) thanks to the fact that `ironfish_rust` is not public.