### PR TITLE
Fix wallet:transaction decrypting at most 255 notes

### DIFF
--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -33,6 +33,25 @@ describe('DecryptNotesRequest', () => {
     const deserializedRequest = DecryptNotesRequest.deserializePayload(request.jobId, buffer)
     expect(deserializedRequest).toEqual(request)
   })
+
+  it('serializes over 255 notes', () => {
+    const length = 600
+
+    const request = new DecryptNotesRequest(
+      Array.from({ length }, () => ({
+        serializedNote: Buffer.alloc(ENCRYPTED_NOTE_LENGTH, 1),
+        incomingViewKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
+        outgoingViewKey: Buffer.alloc(ACCOUNT_KEY_LENGTH, 1).toString('hex'),
+        viewKey: Buffer.alloc(VIEW_KEY_LENGTH, 1).toString('hex'),
+        currentNoteIndex: 2,
+        decryptForSpender: true,
+      })),
+      0,
+    )
+    const buffer = serializePayloadToBuffer(request)
+    const deserializedRequest = DecryptNotesRequest.deserializePayload(request.jobId, buffer)
+    expect(deserializedRequest.payloads).toHaveLength(length)
+  })
 })
 
 describe('DecryptNotesResponse', () => {
@@ -53,6 +72,24 @@ describe('DecryptNotesResponse', () => {
     const buffer = serializePayloadToBuffer(response)
     const deserializedResponse = DecryptNotesResponse.deserializePayload(response.jobId, buffer)
     expect(deserializedResponse).toEqual(response)
+  })
+
+  it('serializes over 255 notes', () => {
+    const length = 600
+
+    const request = new DecryptNotesResponse(
+      Array.from({ length }, () => ({
+        forSpender: false,
+        index: 1,
+        hash: Buffer.alloc(32, 1),
+        nullifier: Buffer.alloc(32, 1),
+        serializedNote: Buffer.alloc(DECRYPTED_NOTE_LENGTH, 1),
+      })),
+      0,
+    )
+    const buffer = serializePayloadToBuffer(request)
+    const deserializedResponse = DecryptNotesResponse.deserializePayload(request.jobId, buffer)
+    expect(deserializedResponse.notes).toHaveLength(length)
   })
 })
 

--- a/ironfish/src/workerPool/tasks/decryptNotes.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.ts
@@ -35,7 +35,6 @@ export class DecryptNotesRequest extends WorkerMessage {
   }
 
   serializePayload(bw: bufio.StaticWriter | bufio.BufferWriter): void {
-    bw.writeU8(this.payloads.length)
     for (const payload of this.payloads) {
       let flags = 0
       flags |= Number(!!payload.currentNoteIndex) << 0
@@ -57,8 +56,7 @@ export class DecryptNotesRequest extends WorkerMessage {
     const reader = bufio.read(buffer, true)
     const payloads = []
 
-    const length = reader.readU8()
-    for (let i = 0; i < length; i++) {
+    while (reader.left() > 0) {
       const flags = reader.readU8()
       const hasCurrentNoteIndex = flags & (1 << 0)
       const decryptForSpender = Boolean(flags & (1 << 1))
@@ -82,7 +80,7 @@ export class DecryptNotesRequest extends WorkerMessage {
   }
 
   getSize(): number {
-    let size = 1
+    let size = 0
     for (const payload of this.payloads) {
       size += 1
       size += ENCRYPTED_NOTE_LENGTH
@@ -106,7 +104,6 @@ export class DecryptNotesResponse extends WorkerMessage {
   }
 
   serializePayload(bw: bufio.StaticWriter | bufio.BufferWriter): void {
-    bw.writeU8(this.notes.length)
     for (const note of this.notes) {
       const hasDecryptedNote = Number(!!note)
       bw.writeU8(hasDecryptedNote)
@@ -135,8 +132,7 @@ export class DecryptNotesResponse extends WorkerMessage {
     const reader = bufio.read(buffer)
     const notes = []
 
-    const length = reader.readU8()
-    for (let i = 0; i < length; i++) {
+    while (reader.left() > 0) {
       const hasDecryptedNote = reader.readU8()
       if (!hasDecryptedNote) {
         notes.push(null)
@@ -173,7 +169,7 @@ export class DecryptNotesResponse extends WorkerMessage {
   }
 
   getSize(): number {
-    let size = 1
+    let size = 0
 
     for (const note of this.notes) {
       size += 1


### PR DESCRIPTION
## Summary

Fixes a bug where calling `wallet:transaction` or `wallet:transactions` on a transaction with more than 255 output notes would only display at most the first 255 results.

The decryptNotes task passes in the number of notes to decrypt as a u8, but bufio only bounds-checks if a number is a safe integer when writing numbers, and we don't do any verification that the number of results matches the number of inputs, so it's possible to overflow the value. In the wallet's transaction processing code, we decrypt notes in batches of 20, so this doesn't affect it. But when calling `wallet:transaction` or `wallet:transactions`, we attempt to decrypt output notes as a spender in one batch, and since transactions can have several hundred notes, this opens up the possibility for this bug.

The PR's change removes the length field from the serialized output -- since the worker pool is internal to the SDK and nothing external can connect to it, I don't think it's necessary to encode the number of notes as part of the input.

This doesn't affect a user's balance or available notes in their wallet, and transactions don't need to be rescanned or re-decrypted as a result of this change. Also, incoming/received notes are not affected by this, so this bug would only affect display of transactions where the decrypting account sent more than 255 notes.

## Testing Plan

* Added tests for including over 255 notes in a decryptNotes job.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
