### PR TITLE
feat: Take 'reverse' parameter as option in loadTransactionsByTime

### DIFF
--- a/ironfish/src/wallet/account.test.ts
+++ b/ironfish/src/wallet/account.test.ts
@@ -2138,6 +2138,24 @@ describe('Accounts', () => {
 
       expect(accountBTx[0].transaction.hash()).toEqualHash(sortedHashes[0])
       expect(accountBTx[1].transaction.hash()).toEqualHash(sortedHashes[1])
+
+      // It also allows us to return transactions in chronological order
+      // getTransactionsByTime returns transactions in reverse order by time, hash
+      const accountATxChronological = await AsyncUtils.materialize(
+        accountA.getTransactionsByTime(undefined, { reverse: false }),
+      )
+      const accountBTxChronological = await AsyncUtils.materialize(
+        accountB.getTransactionsByTime(undefined, { reverse: false }),
+      )
+
+      // 3 block rewards plus 2 outgoing transactions
+      expect(accountATxChronological).toHaveLength(5)
+
+      // tx1 and tx2 will have the same timestamp for accountB, so ordering should be reverse by hash
+      const sortedHashesChron = [tx1.hash(), tx2.hash()].sort()
+
+      expect(accountBTxChronological[0].transaction.hash()).toEqualHash(sortedHashesChron[0])
+      expect(accountBTxChronological[1].transaction.hash()).toEqualHash(sortedHashesChron[1])
     })
   })
 

--- a/ironfish/src/wallet/account.ts
+++ b/ironfish/src/wallet/account.ts
@@ -694,8 +694,11 @@ export class Account {
     return this.walletDb.loadTransactions(this, range, tx)
   }
 
-  getTransactionsByTime(tx?: IDatabaseTransaction): AsyncGenerator<Readonly<TransactionValue>> {
-    return this.walletDb.loadTransactionsByTime(this, tx)
+  getTransactionsByTime(
+    tx?: IDatabaseTransaction,
+    options?: { reverse?: boolean },
+  ): AsyncGenerator<Readonly<TransactionValue>> {
+    return this.walletDb.loadTransactionsByTime(this, tx, options)
   }
 
   async *getTransactionsBySequence(

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1106,13 +1106,16 @@ export class WalletDB {
   async *loadTransactionsByTime(
     account: Account,
     tx?: IDatabaseTransaction,
+    options?: {
+      reverse?: boolean
+    },
   ): AsyncGenerator<TransactionValue> {
     for await (const [, [, transactionHash]] of this.timestampToTransactionHash.getAllKeysIter(
       tx,
       account.prefixRange,
       {
         ordered: true,
-        reverse: true,
+        reverse: options?.reverse ?? true,
       },
     )) {
       const transaction = await this.loadTransaction(account, transactionHash, tx)


### PR DESCRIPTION
## Summary

Makes it possible for consumer to request transactions ordered by time in chronological order by passing `{reverse: false}`.

## Testing Plan

Added `{ reverse: false }` case to `getTransactionsByTime` test in `account.test.ts`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
