### PR TITLE
Move chain db size out of telemetry class and into stats cmd

### DIFF
--- a/ironfish-cli/src/commands/service/stats.ts
+++ b/ironfish-cli/src/commands/service/stats.ts
@@ -50,7 +50,7 @@ export default class Stats extends IronfishCommand {
     await this.sdk.client.connect()
 
     // metric loops, must await last loop
-    await this.chainDBSize(api, flags.delay)
+    void this.chainDBSize(api, flags.delay)
     void this.forks(api, flags.delay)
     await this.feeRates(api, flags.delay)
   }
@@ -159,9 +159,9 @@ export default class Stats extends IronfishCommand {
         continue
       }
 
-      const response = await this.sdk.client.chain.getChainInfo()
+      const response = await this.sdk.client.node.getStatus()
 
-      if (!response.content.chainDBSizeBytes) {
+      if (!response.content.blockchain.dbSizeBytes) {
         this.log(`chain DB size unexpected response`)
       } else {
         await api.submitTelemetry({
@@ -173,7 +173,7 @@ export default class Stats extends IronfishCommand {
                 {
                   name: `chain_db_size_bytes`,
                   type: 'integer',
-                  value: Number(response.content.chainDBSizeBytes),
+                  value: Number(response.content.blockchain.dbSizeBytes),
                 },
               ],
               tags: [{ name: 'version', value: IronfishCliPKG.version }],

--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -102,8 +102,6 @@ describe('Blockchain', () => {
     expect((await chain.getHashAtSequence(2))?.equals(headerA1.hash)).toBe(true)
     expect((await chain.getHashAtSequence(3))?.equals(headerB2.hash)).toBe(true)
     expect((await chain.getHashAtSequence(4))?.equals(headerB3.hash)).toBe(true)
-
-    expect(await chain.db.size()).toBeGreaterThan(0)
   })
 
   it('iterate', async () => {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -354,8 +354,6 @@ export class Blockchain {
     if (this._head) {
       this.updateSynced()
     }
-
-    this.metrics.chain_databaseSize.value = await this.db.size()
   }
 
   async close(): Promise<void> {
@@ -407,8 +405,6 @@ export class Blockchain {
         const connectResult = await this.connect(block, previous, tx)
 
         this.resolveOrphans(block)
-
-        this.metrics.chain_databaseSize.value = await this.db.size()
 
         return connectResult
       })
@@ -1163,8 +1159,6 @@ export class Blockchain {
         this.latest = this.head
         await this.meta.put('latest', this.head.hash, tx)
       }
-
-      this.metrics.chain_databaseSize.value = await this.db.size()
     })
   }
 

--- a/ironfish/src/rpc/routes/chain/getChainInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.ts
@@ -14,7 +14,6 @@ export interface ChainInfo {
   genesisBlockIdentifier: BlockIdentifier
   oldestBlockIdentifier: BlockIdentifier
   currentBlockTimestamp: number
-  chainDBSizeBytes: number
 }
 
 export type GetChainInfoRequest = Record<string, never> | undefined
@@ -36,7 +35,6 @@ export const GetChainInfoResponseSchema: yup.ObjectSchema<GetChainInfoResponse> 
       .object({ index: yup.string().defined(), hash: yup.string().defined() })
       .defined(),
     currentBlockTimestamp: yup.number().defined(),
-    chainDBSizeBytes: yup.number().defined(),
   })
   .defined()
 
@@ -46,7 +44,7 @@ export const GetChainInfoResponseSchema: yup.ObjectSchema<GetChainInfoResponse> 
 router.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
   `${ApiNamespace.chain}/getChainInfo`,
   GetChainInfoRequestSchema,
-  async (request, node): Promise<void> => {
+  (request, node): void => {
     Assert.isNotNull(node.chain.genesis, 'no genesis')
 
     const latestHeader = node.chain.latest
@@ -70,14 +68,11 @@ router.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
     genesisBlockIdentifier.index = GENESIS_BLOCK_SEQUENCE.toString()
     genesisBlockIdentifier.hash = BlockHashSerdeInstance.serialize(node.chain.genesis.hash)
 
-    const chainDBSizeBytes = await node.chain.db.size()
-
     request.end({
       currentBlockIdentifier,
       oldestBlockIdentifier,
       genesisBlockIdentifier,
       currentBlockTimestamp,
-      chainDBSizeBytes,
     })
   },
 )

--- a/ironfish/src/telemetry/telemetry.ts
+++ b/ironfish/src/telemetry/telemetry.ts
@@ -234,11 +234,6 @@ export class Telemetry {
         type: 'integer',
         value: this.chain.head.sequence,
       },
-      {
-        name: 'chain_database_size',
-        type: 'integer',
-        value: this.metrics.chain_databaseSize.value,
-      },
     ]
 
     for (const [messageType, meter] of this.metrics.p2p_InboundTrafficByMessage) {


### PR DESCRIPTION
## Summary
Move chain db size to stats cmd
Add chain db size to node getStatus response
Remove chain db size from telemetry class and blockchain class

## Testing Plan
locally run `yarn start service:stats` 
log chain db size to console
```
yajun@Yajuns-MBP ironfish-cli % yarn start service:stats
yarn run v1.22.19
$ yarn build && yarn start:js service:stats
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run service:stats
module: @oclif/core@1.23.1
task: toCached
plugin: ironfish
root: /Users/yajun/ironfish/ironfish/ironfish-cli
See more details with DEBUG=*
(Use `node --trace-warnings ...` to show where the warning was created)
chain DB size 3486947512
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@dguenther 