### PR TITLE
Prevent accidental publishing of crates that are not meant to be publ…

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -3,6 +3,8 @@ name = "benchmarks"
 version = "0.1.0"
 license = "MPL-2.0"
 
+publish = false
+
 [package.authors]
 workspace = true
 

--- a/ironfish-mpc/Cargo.toml
+++ b/ironfish-mpc/Cargo.toml
@@ -3,6 +3,8 @@ name = "ironfish_mpc"
 version = "0.2.0"
 authors = ["Sean Bowe <ewillbefull@gmail.com>", "Iron Fish <contact@ironfish.network> (https://ironfish.network)"]
 
+publish = false
+
 [package.edition]
 workspace = true
 

--- a/ironfish-phase2/Cargo.toml
+++ b/ironfish-phase2/Cargo.toml
@@ -7,6 +7,8 @@ homepage = "https://github.com/iron-fish/ironfish"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/iron-fish/ironfish"
 
+publish = false
+
 [package.edition]
 workspace = true
 

--- a/ironfish-rust-nodejs/Cargo.toml
+++ b/ironfish-rust-nodejs/Cargo.toml
@@ -6,6 +6,8 @@ license = "MPL-2.0"
 description = "Node.js addon for interacting with transactions on the Iron Fish chain"
 keywords = ["iron-fish", "cryptocurrency", "blockchain"]
 
+publish = false
+
 [package.authors]
 workspace = true
 


### PR DESCRIPTION
## Summary

Added `publish = false` to internal crates that are not meant to be published, to prevent accidental publishing.

The only crates that don't have `publish = false` are `ironfish` and `ironfish_zkp`.

## Testing Plan

`cargo publish --dry-run -p benchmarks` (and similar for other crates) should fail with:

```
error: `benchmarks` cannot be published.
`package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
```

## Documentation

N/A

## Breaking Change

N/A