### PR TITLE
Reorder stats cmd

### DIFF
--- a/ironfish-cli/src/commands/service/stats.ts
+++ b/ironfish-cli/src/commands/service/stats.ts
@@ -50,8 +50,8 @@ export default class Stats extends IronfishCommand {
     await this.sdk.client.connect()
 
     // metric loops, must await last loop
-    void this.chainDBSize(api, flags.delay)
     void this.forks(api, flags.delay)
+    void this.chainDBSize(api, flags.delay)
     await this.feeRates(api, flags.delay)
   }
 


### PR DESCRIPTION
## Summary
The fork count metric stop working after calling chainDB first in the metrics loop. It stucks at line 60 `await this.sdk.client.chain.getConsensusParameters()`
The fork count start to work after the reorder.

## Testing Plan
local run service:stats

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@iron-fish/engineering 