### PR TITLE
test: Add an improved benchmark util for typescript

### DIFF
--- a/ironfish/src/utils/math.ts
+++ b/ironfish/src/utils/math.ts
@@ -14,6 +14,22 @@ function arrayAverage(values: number[]): number {
   return total / values.length
 }
 
+function arrayMedian(values: number[], isSorted = false): number {
+  if (values.length === 0) {
+    return 0
+  }
+
+  // TODO(mat): We can use values.toSorted() when we set NodeJS min version to 20
+  const sorted = isSorted ? values : [...values].sort()
+
+  const half = Math.floor(sorted.length / 2)
+  if (sorted.length % 2) {
+    return sorted[half]
+  }
+
+  return sorted[half - 1] + values[half] / 2
+}
+
 function arraySum(values: number[]): number {
   if (values.length === 0) {
     return 0
@@ -56,4 +72,13 @@ function min<T extends number | bigint>(a: T, b: T): T {
   return a > b ? b : a
 }
 
-export const MathUtils = { arrayAverage, arraySum, round, roundBy, min, max, floor }
+export const MathUtils = {
+  arrayAverage,
+  arrayMedian,
+  arraySum,
+  round,
+  roundBy,
+  min,
+  max,
+  floor,
+}


### PR DESCRIPTION


## Summary

This function does a few things:
- Has a configurable warm-up period, to settle V8 hot-path optimizations and whatever else
- Has a configurable number of iterations which is used to collect aggregate information
- Calculates the min, max, avg, median across the iterations. Does not include the warm-up iterations
- Renders the aggregate stats

Example usage:
``` typescript
      const results = await BenchUtils.withSegmentIterations(10, 100, async () => {
        const _x = await tsPool.decryptNotes(payload)
      })

      const title = `[DecryptNotes: workers: ${test.workers}, notes: ${
        test.notes
      }, canDecrypt: ${test.canDecrypt.toString()}]`
      console.log(BenchUtils.renderSegmentAggregate(results, title))
```

Example output:
```
[DecryptNotes: workers: 1, notes: 5, canDecrypt: true]
Iterations: 100
Time: min: 0.0463ms, avg: 0.0668ms, median: 0.0808ms, max 0.3325ms
Heap: min: 12.28 KiB, avg: 12.39 KiB, median: 18.50 KiB, max 15.26 KiB
Rss: min: 0 B, avg: 983 B, median: 0 B, max 16.00 KiB
Mem: min: 12.28 KiB, avg: 13.35 KiB, median: 18.50 KiB, max 30.57 KiB
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
