### PR TITLE
removes extra block verification on submitted blocks

### DIFF
--- a/ironfish/src/mining/manager.test.slow.ts
+++ b/ironfish/src/mining/manager.test.slow.ts
@@ -269,7 +269,7 @@ describe('Mining manager', () => {
         .mockResolvedValue({ valid: false, reason: VerificationResultReason.INVALID_TARGET })
 
       await expect(miningManager.submitBlockTemplate(template)).resolves.toBe(
-        MINED_RESULT.INVALID_BLOCK,
+        MINED_RESULT.ADD_FAILED,
       )
     })
 

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -29,7 +29,6 @@ import { MinersFeeCache } from './minersFeeCache'
 export enum MINED_RESULT {
   UNKNOWN_REQUEST = 'UNKNOWN_REQUEST',
   CHAIN_CHANGED = 'CHAIN_CHANGED',
-  INVALID_BLOCK = 'INVALID_BLOCK',
   ADD_FAILED = 'ADD_FAILED',
   FORK = 'FORK',
   SUCCESS = 'SUCCESS',
@@ -378,15 +377,6 @@ export class MiningManager {
 
         return MINED_RESULT.CHAIN_CHANGED
       }
-    }
-
-    const validation = await this.node.chain.verifier.verifyBlock(block)
-
-    if (!validation.valid) {
-      this.node.logger.info(
-        `Discarding invalid mined block ${blockDisplay} ${validation.reason || 'undefined'}`,
-      )
-      return MINED_RESULT.INVALID_BLOCK
     }
 
     const { isAdded, reason, isFork } = await this.node.chain.addBlock(block)


### PR DESCRIPTION
## Summary

submitBlockTemplate calls verifyBlock and returns INVALID_BLOCK if verification fails. if verification succeeds, then submitBlockTemplate calls addBlock.

addBlock also calls verifyBlock (by way of connect, addHeadToChain, and verifyBlockAdd), so the first verification call is unnecessary.

removes the first block verification and the INVALID_BLOCK result.

## Testing Plan

- update existing unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
