### PR TITLE
Log chain db size in stats 

### DIFF
--- a/ironfish-cli/src/commands/service/stats.ts
+++ b/ironfish-cli/src/commands/service/stats.ts
@@ -10,7 +10,7 @@ import { IronfishCliPKG } from '../../package'
 import { GossipForkCounter } from '../../utils/gossipForkCounter'
 
 export default class Stats extends IronfishCommand {
-  //static hidden = true
+  static hidden = true
 
   static description = `Submits stats to telemetry API`
 

--- a/ironfish-cli/src/commands/service/stats.ts
+++ b/ironfish-cli/src/commands/service/stats.ts
@@ -10,7 +10,7 @@ import { IronfishCliPKG } from '../../package'
 import { GossipForkCounter } from '../../utils/gossipForkCounter'
 
 export default class Stats extends IronfishCommand {
-  static hidden = true
+  //static hidden = true
 
   static description = `Submits stats to telemetry API`
 
@@ -164,6 +164,7 @@ export default class Stats extends IronfishCommand {
       if (!response.content.blockchain.dbSizeBytes) {
         this.log(`chain DB size unexpected response`)
       } else {
+        const chainSize = Number(response.content.blockchain.dbSizeBytes)
         await api.submitTelemetry({
           points: [
             {
@@ -173,13 +174,15 @@ export default class Stats extends IronfishCommand {
                 {
                   name: `chain_db_size_bytes`,
                   type: 'integer',
-                  value: Number(response.content.blockchain.dbSizeBytes),
+                  value: chainSize,
                 },
               ],
               tags: [{ name: 'version', value: IronfishCliPKG.version }],
             },
           ],
         })
+
+        this.log(`Chain DB size: ${chainSize}`)
       }
 
       await PromiseUtils.sleep(delay)


### PR DESCRIPTION
## Summary
Log chain db size in stats cmd

## Testing Plan
locally run yarn start service:stats

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@danield9tqh 