### PR TITLE
verifies block template after streaming

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -1009,7 +1009,7 @@ export class Blockchain {
       )
 
       const block = new Block(header, transactions)
-      if (!previousBlockHash.equals(GENESIS_BLOCK_PREVIOUS) && verifyBlock) {
+      if (verifyBlock && !previousBlockHash.equals(GENESIS_BLOCK_PREVIOUS)) {
         // since we're creating a block that hasn't been mined yet, don't
         // verify target because it'll always fail target check here
         const verification = await this.verifier.verifyBlock(block, { verifyTarget: false })

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -923,10 +923,10 @@ export class Blockchain {
   /**
    * Create a new block on the chain.
    *
-   * Excluding the randomness, the new block is guaranteed to be valid with
-   * the current state of the chain. If the chain's head does not change,
-   * then the new block can be added to the chain, once its randomness is
-   * set to something that meets the target of the chain.
+   * When 'verifyBlock' is set, excluding the randomness, the new block is guaranteed
+   * to be valid with the current state of the chain. If the chain's head does
+   * not change, then the new block can be added to the chain, once its
+   * randomness is set to something that meets the target of the chain.
    *
    * After calling this function, the chain itself remains unchanged. No notes
    * or nullifiers have been added to the tree, and no blocks have been added
@@ -937,6 +937,7 @@ export class Blockchain {
     minersFee: Transaction,
     graffiti?: Buffer,
     previous?: BlockHeader,
+    verifyBlock = true,
   ): Promise<Block> {
     const transactions = [minersFee, ...userTransactions]
 
@@ -1008,7 +1009,7 @@ export class Blockchain {
       )
 
       const block = new Block(header, transactions)
-      if (!previousBlockHash.equals(GENESIS_BLOCK_PREVIOUS)) {
+      if (!previousBlockHash.equals(GENESIS_BLOCK_PREVIOUS) && verifyBlock) {
         // since we're creating a block that hasn't been mined yet, don't
         // verify target because it'll always fail target check here
         const verification = await this.verifier.verifyBlock(block, { verifyTarget: false })

--- a/ironfish/src/mining/__fixtures__/manager.test.slow.ts.fixture
+++ b/ironfish/src/mining/__fixtures__/manager.test.slow.ts.fixture
@@ -636,5 +636,87 @@
         }
       ]
     }
+  ],
+  "Mining manager create block template should skip block verification for empty blocks": [
+    {
+      "version": 2,
+      "id": "2677fdac-32a8-4a0a-9612-1078ea2efeb3",
+      "name": "account",
+      "spendingKey": "1040f5323bc340f5a1d3701e0661dfb365a18d7a5ac635f422069bf0123a0ac6",
+      "viewKey": "4387d3a5fb1704d2cad4defff5208c68d30e7e5f4693770534d44400b2deed87feb975ec42f32b41fc57f1ac0c5f5f08de0b5134e10008d2c84fa2a839d677cd",
+      "incomingViewKey": "ed83ec811155f9282985f636ea88f18417fe376556e3543962f0d994ba5fd507",
+      "outgoingViewKey": "39b8c88e5d4015d73182cbfe3c90a44a2f5e82d7890ea24d99556441fcffcabd",
+      "publicAddress": "b66640d0e84156215d5c4151362fd092046379fca0f83fc55421641e4dc74eb2",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:M0RC/BIH2ogMcNG2fft9kz3QjVERu/4vcuSOR6Xt4mU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:btQ+OWbB8OD8HD/QO6gS0bV/RHn1VhIqernPNML1G3Y="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1686763003092,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA8FpIjaFoivSyL3fBIpuBURqIPh2K3GLBzFhbDp2FtFqnL81zZU9FUeaiXrigwS+BIqoDInAu5HjV2yBrVLQKc99gYz9tFuFvrn6GFqvXvCSrJiD0eUab7CHPUeVtcvvqNOUUiKUXW1I84+c820dLjx1ifA2zHJ4EXd2oHRUTfY0SPxY3SJtHf2QA5x/S9vE5dTbRjkJnItq33Y5mHr407O7VfFDRQNvPK1LDWOLQjMOLUbRTRe32BSws2+QWK4t7pEpr921RLh98kLKqlyAs+KMzZf0yHJM5H+qrJkI8wuM8m5xd14LsjwT6bq+URgBzHUCJxiHLljl8vsqSJ1ro7mUT4QuFOdg/6KJCGQYUthIXeBD3F50Pv/86EVwNgm1IDAFkc29MkPR89ZH9BZlz03Q7wdiQH3t62aVo0h1nOhsUC+ql5KzWyiDdEiKVwbePDo1ocv2B96zN/5yKDBvCDAS3g9CRoDLoVaMk+UXhK71FecUF1XNDN8tIJQRLyFFswuSqQ7SQpXvNPrkkWK3k+FjQgmSFyoAbWUm9zPrwo0nGUhogl2/Ci05ro5ORBpikfu9vLza3DF8rdZTT3A4X/RBryZ+Us5O16TwGXOnTzDmCBBwS++dkyElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwpsz52UOiuJhpyX6mWDWL89qwzSAWQ4G1DgUHsdhK7ovbw549bdz1AplzqhC0SXAXaRXjH/ND7/F50XrG5XqfBw=="
+        }
+      ]
+    }
+  ],
+  "Mining manager create block template should re-send the empty template if verification fails for the full template": [
+    {
+      "version": 2,
+      "id": "154c6285-de72-4e1b-be27-6797dff13c0c",
+      "name": "test",
+      "spendingKey": "2ee75c625bca9e1d9b2de0852102a18bf91c9b9f7fec02584412092d508dfded",
+      "viewKey": "f52e92a5e1f0a5f90a49f83d3b2d7aace17813c1b78356a0ee692230a26d09c4af956fb7efa02ba758dda4481fedb6399b72528700ddb9898849efb658b7066e",
+      "incomingViewKey": "4b1699bff079d47d0939e394b578cd34d4960a4fb4a3041a98da208f4c66f607",
+      "outgoingViewKey": "bd2c0d1b0cf8ed90697f75706fc9b897f701dcf596206f563a279cde62c8cbc4",
+      "publicAddress": "52195a9f0f7edd603655055308a93748d1ed4bf1a596805ff6df2fb3e0070b49",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:m5NMeu+//tfoe2BSTYFDfMNCmn4hKZwHiQnXwyXdeRg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:5ho9NjTodYNkWihsBT1RYB4/csqlFztamVh98IXf4qk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1686763604251,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAglLu97sOyR1o3paXV1gh7uWDkSlH08OlVxYAOHx1rU2VAhiVhA8gPdt10IbRDMvIsfRR8KCIDERoo7oKbMnswGA/PsSTH2oPQEh0hUBOlL+OStFeSJog54CFnjAtkIS3hhGN7HMF9oobalnf8Iyf1S+eRqUeTj6LdAW3qlWKFMoZ/XeTmUi/psVoXbZywi9grBRHBCu9dwVO3gZbvCJNR+kpNKwk20jFIkvPixtR/lmhGLpKo5FwqphgrXhqhdT7snTFqP3oyEG52fnGRoweu8urLZMXGzYZoIsUXDy/gKFcCsNRaEYGbcksPq0ZjpD72rudKh3HbPwP6G1PGN1kXJT5iQxKmYlxsm3lHIesBMuoyp3fNQf4w9l0fgySDXcOmKrgec67uZlvoAuM8gTzGfRX/H6c6a7FUphXTShM+BF+IzCWMKshHfo+3J6mi1SKY7YnkuOzHs9qYqW5SNWAfAIqkj+HvcBcQ3bgInl9mziprAlW626uSEyBWxc0l1n/4at7fDiqssdZG48Ezyc/inT/cffcjTOD82btfa2nbRV5VQbPheQ4wOL8gbehwuH1v7HNnIgK6H9Z2XQJT6zaWyUX6Q0hH3fE4QqIWCE2rx57D6uQflaxFklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvJEAPa1Iis+qoV23W8QpaIY8Lcu8ViQwl8jxe+uIQSHHDa3qQi5jneBSwoHmxKhnlmpseLxHbMIxxfm3oe7pDA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAI/CLmbaJjYak8PTNpV1r/v8VL1B/+Jo/b2/MmghcBjGR59eNzwBkUWzHaY/Cg4ZyLCgWLJDvHe7d+H3eg+EjTQ32hdE7eAgM5gM06B6ZrR24BLHA5isORqtc1nAnZQyYPo6YzRypykL1dFo4Vqq4K/F0Zo4YTosOyDUASd2h+jYKGqgjBokJtCNiqOOakf4JAbS9lVLw1cuZzM9yyhZbldME6gMqy49F1ckjB08k9hCV0zs+TbgM7n7wuk0cSeKJQyOlOf6NsQhfSrW5VjJm49QITF4av7+leFJAErouYpoF/ThY24px8CAMBdzUKdoJZE4pZRjfchNB8saHy0YtuZuTTHrvv/7X6HtgUk2BQ3zDQpp+ISmcB4kJ18Ml3XkYBAAAADi7mUaUqwLsNXCGMytkOHvl+d4dGHjQxmZmfMG+zXiXZZLW4U1P1qT9L6naRsY1/ymxZiC0FMZducDJGcDhvN8O/DOU+MafN8EZreHCX5Fkq2IjBc9vodmQZTR1T24XAaDdE8/dS7LxzA2qkWX9g79snH/RxpEyuQYKXT0/I0D+CX9iqo/Rv1bMVJYpNOuq54iVbxWTGn9An9s8MNmTfMQhariSPWA9Fsi5phzPz9OVpM75QThpjXdqf9v81+AfGQ7va3fYL5/bNCK1BYX8dQweSy7M0ZgDq/nJG2wMnK9oxXpO9ankpQkUsSyqEwYmtqzdQfXa9ckTpdTTKyyLQhuv7RgI/F30n4rLMFdqzOXaGiEwLUz1mWx8TXpIfQ2SgoH57mJHgVKER9sH0vDGrijKGDDlyjQnb3fEuRhmXsTKxQapwyvGuCKY2UVeZm4ZcnhwhJIhdeLL2oi0Uc4GSFu+oHnhnr44b8a6VWxIZKpoAu90s7Jin1Gie1czWnEboByvwV35ufh2C2aSTj+qQwFrlA9rrOvMp9EroiYQjPvRS3iMIHFPGIucCH9G8c8lWAgc1Yv463xxNBQVX6+FVW1OgpJ/2yCdIBCAbFe5T3/K2adE9hK9H/gWsSqlw59WK3DI9PJVrnN0F5dVBP1HUNdve9FODiza1POJKOvSv8iQlo5qUzKKqPzxkuK80ORP3ZSRFsznVayY7I1oEATC/XvR0R7w+Q9f2BK7mOjxzzY7Nigq7/1QAKGOeUfZHIqzdqcTiSG01rBAjLQ4WQkT+DN1eUZfnWiOsaiPEgj2su70zVdSCssbOaujJF5hQDSkanWoktGE0W9noiJHnm46gJOaqPYZtxoCA/NsSkPzVc6oouQOOFWgVtyJD+IR+IPwfIPEo7ptV7XBYkFxW7+gdWoYMJe5IMsJKIlsrjTZ7mePEPxzyc/t0UsITsAN99TxD2G1wwK5kXdN+yhO4sJJpAleFJ7AGT0lCMXVIBhD4wfndpHL8cuB/6+1ZFBG+C1CbINUPbsFPQn5/1lETE7bCvOFQqIPOcHtY354hLcWiFfncuL1mFxisrVLSpBjmE0nU1wxPQPIcOd9DcH0dY/iTIz58c8+YT1s3i1RAh2UrBCZreskkRJzG6Mi/d8MvteXQDtCgHBFQENZ2u5OHnBF/hg6tmK7MF3ePvlUONWU1kBXPqz6vln1psp2XsPQIW3bEtdwB+CPdvqfYysDSuCdr72e6s+xwwv3Rc6+zhF0uS6liZPfcplv4a6bXFIZUgQpgg2di5DSMkGp/dojpIYbOqAGEbqYe1Krp+C/OaFiyq0pxM8VBqPv6bUG5bwFB8+NQCG7x1P79N6SQtWM7BY41H/pwt0Jy2OMEEpsHhVazhckzxcMZVrP1f0scknPE21jHN4HBFHxsBZLdj2fC4GD11M2ESRfYjbOuoqJLRFUWSah2gJBY2PIEh1Uqrj9aIWNG8h2TNwcBSGp53tRwKoNHs0qkN26DO+Iwnyt8jfvyjf2Qe6EjsaA5ar2B8eV32CECys3xDqPAMBiNweeCjrFN7oV+0bImsmC5PURSVBGmb8AOoOmXRdxrDJjyRm6WbgACQ=="
+    }
   ]
 }

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -180,6 +180,18 @@ export class MiningManager {
       const template = await this.createNewBlockTemplate(currentBlock, account)
       this.metrics.mining_newBlockTemplate.add(BenchUtils.end(connectedAt))
       this.streamBlockTemplate(currentBlock, template)
+
+      const block = BlockTemplateSerde.deserialize(template)
+      const verification = await this.chain.verifier.verifyBlock(block, {
+        verifyTarget: false,
+      })
+
+      if (!verification.valid) {
+        // Abort working on invalid block template and re-send empty block
+        this.streamBlockTemplate(currentBlock, emptyTemplate)
+
+        throw new Error(verification.reason)
+      }
     }
   }
 
@@ -301,6 +313,7 @@ export class MiningManager {
       minersFee,
       GraffitiUtils.fromString(this.node.config.get('blockGraffiti')),
       currentBlock.header,
+      false,
     )
 
     Assert.isEqual(


### PR DESCRIPTION
## Summary

optimistically sends new block templates to connected clients (miners and pools) before block verification.

we currently verify a block before sending the template out. however, if the block verification fails, then the node will crash.

block verification takes time, and miners could be mining on an old template or an empty template while verification runs. instead, we can send out the template(s) as quickly as possible and verify afterwards.

- makes block verification optional in newBlock
- does not verify block for empty block template
- verifies 'full' template after sending it out to clients
- re-sends empty template if verification of full template fails

## Testing Plan

- adds unit tests
- performance testing, time from block connect to template stream:
  - staging: ~13-18ms for empty, ~1200-1600ms for full
  - feature: ~7-8ms for empty, ~900-1200ms for full

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
