### PR TITLE
Revert "Blstrs (#3922)"

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           save-if: false
           shared-key: base
-      
+
       - name: Install Cargo tools
         run: |
           rustup component add rustfmt clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,12 +102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
-name = "bech32"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
-
-[[package]]
 name = "bellman"
 version = "0.13.1"
 source = "git+https://github.com/iron-fish/bellman?rev=1cc52ca33e6db14233f1cbc0c9c5b7c822b229ec#1cc52ca33e6db14233f1cbc0c9c5b7c822b229ec"
@@ -128,47 +122,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "bellperson"
-version = "0.24.1"
-source = "git+https://github.com/iron-fish/bellperson.git?branch=blstrs#37b9976bcd96986cbdc71ae09fc455015e3dfac0"
-dependencies = [
- "bincode",
- "blake2s_simd",
- "blstrs",
- "byteorder",
- "crossbeam-channel",
- "digest 0.10.6",
- "ec-gpu",
- "ec-gpu-gen",
- "ff 0.12.1",
- "group 0.12.1",
- "log",
- "memmap2",
- "pairing 0.22.0",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rayon",
- "rustversion",
- "serde",
- "sha2 0.10.6",
- "thiserror",
-]
-
-[[package]]
 name = "benchmarks"
 version = "0.1.0"
 dependencies = [
  "criterion",
  "ironfish",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -296,54 +254,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "blst"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a30d0edd9dd1c60ddb42b80341c7852f6f985279a5c1a83659dcb65899dec99"
-dependencies = [
- "cc",
- "glob",
- "threadpool",
- "which",
- "zeroize",
-]
-
-[[package]]
-name = "blstrs"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ecb6f3a9429706971633edf4b84f922aba9d2e3a7d71bfb450337e64ccb7df0"
-dependencies = [
- "blst",
- "byte-slice-cast",
- "ff 0.12.1",
- "group 0.12.1",
- "pairing 0.22.0",
- "rand_core 0.6.4",
- "serde",
- "subtle",
-]
-
-[[package]]
-name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-dependencies = [
- "sha2 0.9.9",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
@@ -730,34 +644,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ec-gpu"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd63582de2b59ea1aa48d7c1941b5d87618d95484397521b3acdfa0e1e9f5e45"
-
-[[package]]
-name = "ec-gpu-gen"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd09bf9d5313ad60379f70250590bccc10f7a04e2773062ac13255a37022584e"
-dependencies = [
- "bitvec",
- "crossbeam-channel",
- "ec-gpu",
- "execute",
- "ff 0.12.1",
- "group 0.12.1",
- "hex",
- "log",
- "num_cpus",
- "once_cell",
- "rayon",
- "sha2 0.10.6",
- "thiserror",
- "yastl",
-]
-
-[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,7 +661,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab579d7cf78477773b03e80bc2f89702ef02d7112c711d54ca93dcdce68533d5"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -800,51 +687,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "execute"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d9a9ea4c04632c16bc5c71a2fcc63d308481f7fc67eb1a1ce6315c44a426ae"
-dependencies = [
- "execute-command-macro",
- "execute-command-tokens",
- "generic-array",
-]
-
-[[package]]
-name = "execute-command-macro"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc65a0cf735106743f4c38c9a3671c1e734b5c2c20d21a3c93c696daa3157"
-dependencies = [
- "execute-command-macro-impl",
-]
-
-[[package]]
-name = "execute-command-macro-impl"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a9a55d1dab3b07854648d48e366f684aefe2ac78ae28cec3bf65e3cd53d9a3"
-dependencies = [
- "execute-command-tokens",
- "quote",
- "syn 2.0.18",
-]
-
-[[package]]
-name = "execute-command-tokens"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba569491c70ec8471e34aa7e9c0b9e82bb5d2464c0398442d17d3c4af814e5a"
-
-[[package]]
-name = "f4jumble"
-version = "0.1.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
-dependencies = [
- "blake2b_simd",
 ]
 
 [[package]]
@@ -875,15 +717,6 @@ checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "spin",
 ]
 
 [[package]]
@@ -1019,21 +852,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff 0.12.1",
- "rand 0.8.5",
  "rand_core 0.6.4",
- "rand_xorshift",
  "subtle",
 ]
 
@@ -1320,11 +1145,11 @@ checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 name = "ironfish"
 version = "0.1.0"
 dependencies = [
- "bellperson",
+ "bellman",
  "blake2b_simd",
  "blake2s_simd",
  "blake3",
- "blstrs",
+ "bls12_381",
  "byteorder",
  "chacha20poly1305 0.9.1",
  "crypto_box",
@@ -1332,7 +1157,7 @@ dependencies = [
  "group 0.12.1",
  "hex",
  "ironfish_zkp",
- "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
+ "jubjub",
  "lazy_static",
  "libc",
  "rand 0.8.5",
@@ -1390,13 +1215,13 @@ dependencies = [
 name = "ironfish_zkp"
 version = "0.1.0"
 dependencies = [
- "bellperson",
+ "bellman",
  "blake2s_simd",
- "blstrs",
+ "bls12_381",
  "byteorder",
  "ff 0.12.1",
  "group 0.12.1",
- "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
+ "jubjub",
  "lazy_static",
  "rand 0.8.5",
  "zcash_primitives",
@@ -1442,21 +1267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jubjub"
-version = "0.9.0"
-source = "git+https://github.com/iron-fish/jubjub.git?branch=blstrs#a1a0c2ed69eec4d5d5e87842e2a40849f7fa4633"
-dependencies = [
- "bitvec",
- "blst",
- "blstrs",
- "ff 0.12.1",
- "group 0.12.1",
- "lazy_static",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,16 +1301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,15 +1314,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memoffset"
@@ -1765,7 +1556,7 @@ dependencies = [
  "serde",
  "subtle",
  "tracing",
- "zcash_note_encryption 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_note_encryption",
 ]
 
 [[package]]
@@ -2037,15 +1828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rayon"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,7 +1858,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "group 0.12.1",
- "jubjub 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jubjub",
  "pasta_curves",
  "rand_core 0.6.4",
  "serde",
@@ -2093,7 +1875,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "digest 0.9.0",
- "jubjub 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jubjub",
  "rand_core 0.6.4",
  "serde",
  "thiserror",
@@ -2202,12 +1984,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.45.0",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
@@ -2358,15 +2134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,15 +2231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]
@@ -2800,17 +2558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,30 +2784,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
 
 [[package]]
-name = "yastl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca6c5a4d66c1a9ea261811cf4773c27343de7e5033e1b75ea3f297dc7db3c1a"
-dependencies = [
- "flume",
- "scopeguard",
-]
-
-[[package]]
-name = "zcash_address"
-version = "0.1.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
-dependencies = [
- "bech32",
- "bs58",
- "f4jumble",
- "zcash_encoding",
-]
-
-[[package]]
 name = "zcash_encoding"
 version = "0.1.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb61ea88eb539bc0ac2068e5da99411dd4978595b3d7ff6a4b1562ddc8e8710"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -3079,27 +2806,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_note_encryption"
-version = "0.1.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
-dependencies = [
- "chacha20 0.8.2",
- "chacha20poly1305 0.9.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "zcash_primitives"
 version = "0.7.0"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbb401f5dbc482b831954aaa7cba0a8fe148241db6d19fe7cebda78252ca680"
 dependencies = [
  "aes",
  "bip0039",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
- "blstrs",
+ "bls12_381",
  "byteorder",
  "chacha20poly1305 0.9.1",
  "equihash",
@@ -3108,7 +2825,7 @@ dependencies = [
  "group 0.12.1",
  "hex",
  "incrementalmerkletree",
- "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
+ "jubjub",
  "lazy_static",
  "memuse",
  "nonempty",
@@ -3117,24 +2834,24 @@ dependencies = [
  "rand_core 0.6.4",
  "sha2 0.9.9",
  "subtle",
- "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.1.0 (git+https://github.com/iron-fish/librustzcash.git?branch=blstrs)",
+ "zcash_note_encryption",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.7.1"
-source = "git+https://github.com/iron-fish/librustzcash.git?branch=blstrs#d551820030cb596eafe82226667f32b47164f91b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98bf5f6af051dd929263f279b21b9c04c1f30116c70f3c190de2566677f245ef"
 dependencies = [
- "bellperson",
+ "bellman",
  "blake2b_simd",
- "blstrs",
+ "bls12_381",
  "byteorder",
  "directories",
  "ff 0.12.1",
  "group 0.12.1",
- "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
+ "jubjub",
  "lazy_static",
  "rand_core 0.6.4",
  "redjubjub",

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -32,18 +32,18 @@ name = "ironfish"
 path = "src/lib.rs"
 
 [dependencies]
-bellperson = { git = "https://github.com/iron-fish/bellperson.git", branch = "blstrs", features = ["groth16"] }
+bellman = { version = "0.13.1" }
 blake2b_simd = "1.0.0"
 blake2s_simd = "1.0.0"
 blake3 = "1.3.1"
-blstrs = { version = "0.6.0" }
+bls12_381 = "0.7.0"
 byteorder = "1.4.3"
 chacha20poly1305 = "0.9.0"
 crypto_box = { version = "0.8", features = ["std"] }
 ff = "0.12.0"
 group = "0.12.0"
 ironfish_zkp = { version = "0.1.0", path = "../ironfish-zkp" }
-jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs" }
+jubjub = "0.9.0"
 lazy_static = "1.4.0"
 libc = "0.2.126" # sub-dependency that needs a pinned version until a new release of cpufeatures: https://github.com/RustCrypto/utils/pull/789
 rand = "0.8.5"

--- a/ironfish-rust/src/assets/asset_identifier.rs
+++ b/ironfish-rust/src/assets/asset_identifier.rs
@@ -78,7 +78,7 @@ mod test {
 
         assert_eq!(
             value_commitment_generator,
-            *NATIVE_VALUE_COMMITMENT_GENERATOR
+            NATIVE_VALUE_COMMITMENT_GENERATOR
         );
     }
 }

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -15,7 +15,8 @@ use std::string;
 /// be raised on the Javascript side.
 #[derive(Debug)]
 pub enum IronfishError {
-    BellpersonSynthesis(bellperson::SynthesisError),
+    BellmanSynthesis(bellman::SynthesisError),
+    BellmanVerification(bellman::VerificationError),
     CryptoBox(crypto_box::aead::Error),
     IllegalValue,
     InconsistentWitness,
@@ -73,9 +74,15 @@ impl From<string::FromUtf8Error> for IronfishError {
     }
 }
 
-impl From<bellperson::SynthesisError> for IronfishError {
-    fn from(e: bellperson::SynthesisError) -> IronfishError {
-        IronfishError::BellpersonSynthesis(e)
+impl From<bellman::VerificationError> for IronfishError {
+    fn from(e: bellman::VerificationError) -> IronfishError {
+        IronfishError::BellmanVerification(e)
+    }
+}
+
+impl From<bellman::SynthesisError> for IronfishError {
+    fn from(e: bellman::SynthesisError) -> IronfishError {
+        IronfishError::BellmanSynthesis(e)
     }
 }
 

--- a/ironfish-rust/src/keys/ephemeral.rs
+++ b/ironfish-rust/src/keys/ephemeral.rs
@@ -21,7 +21,7 @@ impl EphemeralKeyPair {
 
         Self {
             secret,
-            public: *PUBLIC_KEY_GENERATOR * secret,
+            public: PUBLIC_KEY_GENERATOR * secret,
         }
     }
 
@@ -44,10 +44,7 @@ mod test {
     fn test_ephemeral_key_pair() {
         let key_pair = EphemeralKeyPair::new();
 
-        assert_eq!(
-            *key_pair.public(),
-            *PUBLIC_KEY_GENERATOR * key_pair.secret()
-        );
+        assert_eq!(*key_pair.public(), PUBLIC_KEY_GENERATOR * key_pair.secret());
 
         assert_eq!(key_pair.public(), &key_pair.public);
         assert_eq!(key_pair.secret(), &key_pair.secret);

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -93,8 +93,8 @@ impl SaplingKey {
         let outgoing_viewing_key = OutgoingViewKey {
             view_key: outgoing_viewing_key,
         };
-        let authorizing_key = *SPENDING_KEY_GENERATOR * spend_authorizing_key;
-        let nullifier_deriving_key = *PROOF_GENERATION_KEY_GENERATOR * proof_authorizing_key;
+        let authorizing_key = SPENDING_KEY_GENERATOR * spend_authorizing_key;
+        let nullifier_deriving_key = PROOF_GENERATION_KEY_GENERATOR * proof_authorizing_key;
         let view_key = ViewKey {
             authorizing_key,
             nullifier_deriving_key,

--- a/ironfish-rust/src/keys/public_address.rs
+++ b/ironfish-rust/src/keys/public_address.rs
@@ -49,7 +49,7 @@ impl PublicAddress {
 
     pub fn from_view_key(view_key: &IncomingViewKey) -> PublicAddress {
         PublicAddress {
-            transmission_key: *PUBLIC_KEY_GENERATOR * view_key.view_key,
+            transmission_key: PUBLIC_KEY_GENERATOR * view_key.view_key,
         }
     }
 

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use bellperson::groth16;
-use blstrs::Bls12;
+use bellman::groth16;
+use bls12_381::Bls12;
 
 pub mod assets;
 pub mod errors;
@@ -39,7 +39,7 @@ pub use ironfish_zkp::primitives::ValueCommitment;
 // The main entry-point to the sapling API. Construct this with loaded parameters, and then call
 // methods on it to do the actual work.
 //
-// spend and output are two arithmetic circuits for use in zksnark calculations provided by bellperson.
+// spend and output are two arithmetic circuits for use in zksnark calculations provided by Bellman.
 // Though the *_params have a verifying key on them, they are not the prepared verifying keys,
 // so we store the prepared keys separately at the time of loading the params.
 //

--- a/ironfish-rust/src/merkle_note.rs
+++ b/ironfish-rust/src/merkle_note.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 use blake2b_simd::Params as Blake2b;
-use blstrs::Scalar;
+use bls12_381::Scalar;
 use ff::PrimeField;
 use group::GroupEncoding;
 use ironfish_zkp::primitives::ValueCommitment;
@@ -168,7 +168,7 @@ impl MerkleNote {
 
     pub fn write<W: io::Write>(&self, writer: &mut W) -> Result<(), IronfishError> {
         writer.write_all(&self.value_commitment.to_bytes())?;
-        writer.write_all(&self.note_commitment.to_bytes_le())?;
+        writer.write_all(&self.note_commitment.to_bytes())?;
         writer.write_all(&self.ephemeral_public_key.to_bytes())?;
         writer.write_all(&self.encrypted_note)?;
         writer.write_all(&self.note_encryption_keys)?;
@@ -281,7 +281,7 @@ mod test {
     use crate::keys::EphemeralKeyPair;
     use crate::{keys::SaplingKey, note::Note};
 
-    use blstrs::Scalar;
+    use bls12_381::Scalar;
     use ironfish_zkp::primitives::ValueCommitment;
     use rand::prelude::*;
 

--- a/ironfish-rust/src/merkle_note_hash.rs
+++ b/ironfish-rust/src/merkle_note_hash.rs
@@ -8,7 +8,7 @@ use crate::errors::IronfishError;
 /// A tree containing these values can serve as a snapshot of the entire chain.
 use super::serializing::read_scalar;
 
-use blstrs::Scalar;
+use bls12_381::Scalar;
 use ff::{PrimeField, PrimeFieldBits};
 use group::Curve;
 use ironfish_zkp::pedersen_hash::{pedersen_hash, Personalization};
@@ -39,7 +39,7 @@ impl MerkleNoteHash {
     }
 
     pub fn write<W: io::Write>(&self, writer: &mut W) -> Result<(), IronfishError> {
-        writer.write_all(&self.0.to_bytes_le())?;
+        writer.write_all(&self.0.to_bytes())?;
 
         Ok(())
     }

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -12,7 +12,7 @@ use super::{
     serializing::{aead, read_scalar},
 };
 use blake2s_simd::Params as Blake2sParams;
-use blstrs::Scalar;
+use bls12_381::Scalar;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
 use ff::{Field, PrimeField};
 use group::{Curve, GroupEncoding};
@@ -289,7 +289,7 @@ impl<'a> Note {
     pub fn nullifier(&self, view_key: &ViewKey, position: u64) -> Nullifier {
         // Compute rho = cm + position.G
         let rho = self.commitment_full_point()
-            + (*NULLIFIER_POSITION_GENERATOR * jubjub::Fr::from(position));
+            + (NULLIFIER_POSITION_GENERATOR * jubjub::Fr::from(position));
 
         // Compute nf = BLAKE2s(nk | rho)
         Nullifier::from_slice(
@@ -309,7 +309,7 @@ impl<'a> Note {
     /// in the note, including the randomness and converts them to a byte
     /// format. This hash is what gets used for the leaf nodes in a Merkle Tree.
     pub fn commitment(&self) -> [u8; 32] {
-        self.commitment_point().to_bytes_le()
+        self.commitment_point().to_bytes()
     }
 
     /// Compute the commitment of this note. This is essentially a hash of all

--- a/ironfish-rust/src/sapling_bls12.rs
+++ b/ironfish-rust/src/sapling_bls12.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-pub use blstrs::Scalar;
+pub use bls12_381::Scalar;
 use lazy_static::lazy_static;
 use std::sync::Arc;
 

--- a/ironfish-rust/src/test_util.rs
+++ b/ironfish-rust/src/test_util.rs
@@ -7,7 +7,7 @@ use super::{
     witness::{Witness, WitnessNode},
     MerkleNoteHash,
 };
-use blstrs::Scalar;
+use bls12_381::Scalar;
 use ironfish_zkp::constants::TREE_DEPTH;
 use rand::{thread_rng, Rng};
 
@@ -39,6 +39,7 @@ pub fn make_fake_witness(note: &Note) -> Witness {
 /// Currently marked for test-only compilation,
 /// but it may be useful to publish
 /// something like this in the future.
+
 pub(crate) fn auth_path_to_root_hash(
     auth_path: &[WitnessNode<Scalar>],
     child_hash: Scalar,

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -4,10 +4,9 @@
 
 use std::io;
 
-use bellperson::groth16;
-use blstrs::{Bls12, Scalar};
+use bellman::groth16;
+use bls12_381::{Bls12, Scalar};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use ff::Field;
 use group::{Curve, GroupEncoding};
 use ironfish_zkp::{
     constants::SPENDING_KEY_GENERATOR,
@@ -96,11 +95,11 @@ impl UnsignedMintDescription {
         let private_key = redjubjub::PrivateKey(spender_key.spend_authorizing_key);
         let randomized_private_key = private_key.randomize(self.public_key_randomness);
         let randomized_public_key =
-            redjubjub::PublicKey::from_private(&randomized_private_key, *SPENDING_KEY_GENERATOR);
+            redjubjub::PublicKey::from_private(&randomized_private_key, SPENDING_KEY_GENERATOR);
 
         let transaction_randomized_public_key =
             redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
-                .randomize(self.public_key_randomness, *SPENDING_KEY_GENERATOR);
+                .randomize(self.public_key_randomness, SPENDING_KEY_GENERATOR);
 
         if randomized_public_key.0 != transaction_randomized_public_key.0 {
             return Err(IronfishError::InvalidSigningKey);
@@ -113,7 +112,7 @@ impl UnsignedMintDescription {
         self.description.authorizing_signature = randomized_private_key.sign(
             &data_to_be_signed,
             &mut thread_rng(),
-            *SPENDING_KEY_GENERATOR,
+            SPENDING_KEY_GENERATOR,
         );
 
         Ok(self.description)
@@ -157,7 +156,7 @@ impl MintDescription {
         if !randomized_public_key.verify(
             &data_to_be_signed,
             &self.authorizing_signature,
-            *SPENDING_KEY_GENERATOR,
+            SPENDING_KEY_GENERATOR,
         ) {
             return Err(IronfishError::VerificationFailed);
         }
@@ -274,7 +273,7 @@ mod test {
 
         let public_key_randomness = jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
-            .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
+            .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let mint = MintBuilder::new(asset, value);
         let unsigned_mint = mint
@@ -304,7 +303,7 @@ mod test {
             .is_err());
 
         let other_randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
-            .randomize(jubjub::Fr::random(thread_rng()), *SPENDING_KEY_GENERATOR);
+            .randomize(jubjub::Fr::random(thread_rng()), SPENDING_KEY_GENERATOR);
         assert!(description
             .verify_signature(&sig_hash, &other_randomized_public_key)
             .is_err());
@@ -323,7 +322,7 @@ mod test {
 
         let public_key_randomness = jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
-            .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
+            .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let mint = MintBuilder::new(asset, value);
         let unsigned_mint = mint
@@ -399,7 +398,7 @@ mod test {
 
         let public_key_randomness = jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
-            .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
+            .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let mint = MintBuilder::new(
             Asset {

--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -10,9 +10,8 @@ use crate::{
     sapling_bls12::SAPLING,
 };
 
-use bellperson::groth16;
-use blstrs::{Bls12, Scalar};
-use ff::Field;
+use bellman::groth16;
+use bls12_381::{Bls12, Scalar};
 use group::Curve;
 use ironfish_zkp::{primitives::ValueCommitment, proofs::Output, redjubjub};
 use jubjub::ExtendedPoint;
@@ -172,7 +171,7 @@ impl OutputDescription {
         Ok(())
     }
 
-    /// Converts the values to appropriate inputs for verifying the bellperson proof.
+    /// Converts the values to appropriate inputs for verifying the bellman proof.
     /// Demonstrates knowledge of a note containing the sender's randomized public key,
     /// value_commitment, public_key, and note_commitment
     pub fn public_inputs(&self, randomized_public_key: &redjubjub::PublicKey) -> [Scalar; 7] {
@@ -238,7 +237,7 @@ mod test {
         let public_key_randomness = jubjub::Fr::random(thread_rng());
         let randomized_public_key =
             redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
-                .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
+                .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let note = Note::new(
             spender_key.public_address(),
@@ -268,7 +267,7 @@ mod test {
         let public_key_randomness = jubjub::Fr::random(thread_rng());
         let randomized_public_key =
             redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
-                .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
+                .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let note = Note::new(
             receiver_key.public_address(),
@@ -296,7 +295,7 @@ mod test {
         let public_key_randomness = jubjub::Fr::random(thread_rng());
         let randomized_public_key =
             redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
-                .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
+                .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         let note = Note::new(
             receiver_key.public_address(),

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -12,11 +12,11 @@ use crate::{
     witness::WitnessTrait,
 };
 
-use bellperson::gadgets::multipack;
-use bellperson::groth16;
-use blstrs::{Bls12, Scalar};
+use bellman::gadgets::multipack;
+use bellman::groth16;
+use bls12_381::{Bls12, Scalar};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use ff::{Field, PrimeField};
+use ff::PrimeField;
 use group::{Curve, GroupEncoding};
 use ironfish_zkp::{
     constants::SPENDING_KEY_GENERATOR,
@@ -164,11 +164,11 @@ impl UnsignedSpendDescription {
         let randomized_private_key = private_key.randomize(self.public_key_randomness);
 
         let randomized_public_key =
-            redjubjub::PublicKey::from_private(&randomized_private_key, *SPENDING_KEY_GENERATOR);
+            redjubjub::PublicKey::from_private(&randomized_private_key, SPENDING_KEY_GENERATOR);
 
         let transaction_randomized_public_key =
             redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
-                .randomize(self.public_key_randomness, *SPENDING_KEY_GENERATOR);
+                .randomize(self.public_key_randomness, SPENDING_KEY_GENERATOR);
 
         if randomized_public_key.0 != transaction_randomized_public_key.0 {
             return Err(IronfishError::InvalidSigningKey);
@@ -182,7 +182,7 @@ impl UnsignedSpendDescription {
         self.description.authorizing_signature = randomized_private_key.sign(
             &data_to_be_signed,
             &mut thread_rng(),
-            *SPENDING_KEY_GENERATOR,
+            SPENDING_KEY_GENERATOR,
         );
 
         Ok(self.description)
@@ -284,7 +284,7 @@ impl SpendDescription {
         if !randomized_public_key.verify(
             &data_to_be_signed,
             &self.authorizing_signature,
-            *SPENDING_KEY_GENERATOR,
+            SPENDING_KEY_GENERATOR,
         ) {
             return Err(IronfishError::VerificationFailed);
         }
@@ -311,7 +311,7 @@ impl SpendDescription {
         Ok(())
     }
 
-    /// Converts the values to appropriate inputs for verifying the bellperson
+    /// Converts the values to appropriate inputs for verifying the bellman
     /// proof.  Confirms the randomized_public_key, commitment_value, anchor
     /// (root hash), and nullifier attached to this [`SpendDescription`].
     pub fn public_inputs(&self, randomized_public_key: &redjubjub::PublicKey) -> [Scalar; 7] {
@@ -405,7 +405,7 @@ mod test {
 
         let public_key_randomness = jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
-            .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
+            .randomize(public_key_randomness, SPENDING_KEY_GENERATOR);
 
         // signature comes from transaction, normally
         let mut sig_hash = [0u8; 32];

--- a/ironfish-rust/src/transaction/utils.rs
+++ b/ironfish-rust/src/transaction/utils.rs
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use bellperson::groth16;
-use blstrs::Bls12;
+use bellman::groth16;
+use bls12_381::Bls12;
 
 use crate::{errors::IronfishError, sapling_bls12::SAPLING};
 
@@ -11,7 +11,7 @@ use crate::{errors::IronfishError, sapling_bls12::SAPLING};
 /// [`super::batch_verify_transactions`]
 pub(crate) fn verify_spend_proof(
     proof: &groth16::Proof<Bls12>,
-    inputs: &[blstrs::Scalar],
+    inputs: &[bls12_381::Scalar],
 ) -> Result<(), IronfishError> {
     groth16::verify_proof(&SAPLING.spend_verifying_key, proof, inputs)?;
 
@@ -23,7 +23,7 @@ pub(crate) fn verify_spend_proof(
 /// [`super::batch_verify_transactions`]
 pub(crate) fn verify_output_proof(
     proof: &groth16::Proof<Bls12>,
-    inputs: &[blstrs::Scalar],
+    inputs: &[bls12_381::Scalar],
 ) -> Result<(), IronfishError> {
     groth16::verify_proof(&SAPLING.output_verifying_key, proof, inputs)?;
 
@@ -35,7 +35,7 @@ pub(crate) fn verify_output_proof(
 /// [`super::batch_verify_transactions`]
 pub(crate) fn verify_mint_proof(
     proof: &groth16::Proof<Bls12>,
-    inputs: &[blstrs::Scalar],
+    inputs: &[bls12_381::Scalar],
 ) -> Result<(), IronfishError> {
     groth16::verify_proof(&SAPLING.mint_verifying_key, proof, inputs)?;
 

--- a/ironfish-rust/src/witness.rs
+++ b/ironfish-rust/src/witness.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use blstrs::Scalar;
+use bls12_381::Scalar;
 
 use super::MerkleNoteHash;
 use std::fmt::{self, Debug};

--- a/ironfish-zkp/Cargo.toml
+++ b/ironfish-zkp/Cargo.toml
@@ -21,14 +21,14 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bellperson = { git = "https://github.com/iron-fish/bellperson.git", branch = "blstrs", features = ["groth16"] }
+bellman = { version = "0.13.1" }
 blake2s_simd = "1.0.0"
-blstrs = { version = "0.6.0" }
+bls12_381 = "0.7.0"
 byteorder = "1.4.3"
 ff = "0.12.0"
 group = "0.12.0"
-jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs" }
+jubjub = "0.9.0"
 lazy_static = "1.4.0"
 rand = "0.8.5"
-zcash_primitives = { git = "https://github.com/iron-fish/librustzcash.git", branch = "blstrs", package = "zcash_primitives" }
-zcash_proofs = { git = "https://github.com/iron-fish/librustzcash.git", branch = "blstrs", package = "zcash_proofs" }
+zcash_primitives = "0.7.0"
+zcash_proofs = "0.7.1"

--- a/ironfish-zkp/src/bin/generate_params.rs
+++ b/ironfish-zkp/src/bin/generate_params.rs
@@ -1,5 +1,5 @@
-use bellperson::{groth16, Circuit};
-use blstrs::Bls12;
+use bellman::{groth16, Circuit};
+use bls12_381::Bls12;
 use ironfish_zkp::{
     constants::ASSET_ID_LENGTH,
     proofs::{MintAsset, Output, Spend},
@@ -12,7 +12,7 @@ const TREE_DEPTH: usize = 32;
 
 const ALLOWED_ARGUMENTS: [&str; 4] = ["all", "spend", "output", "mint"];
 
-fn generate_params(filename: &str, circuit: impl Circuit<blstrs::Scalar>) {
+fn generate_params(filename: &str, circuit: impl Circuit<bls12_381::Scalar>) {
     let full_filename = format!("{filename}.params");
 
     let rng = &mut thread_rng();

--- a/ironfish-zkp/src/circuits/mint_asset.rs
+++ b/ironfish-zkp/src/circuits/mint_asset.rs
@@ -1,4 +1,4 @@
-use bellperson::{
+use bellman::{
     gadgets::{blake2s, boolean},
     Circuit,
 };
@@ -20,11 +20,11 @@ pub struct MintAsset {
     pub public_key_randomness: Option<jubjub::Fr>,
 }
 
-impl Circuit<blstrs::Scalar> for MintAsset {
-    fn synthesize<CS: bellperson::ConstraintSystem<blstrs::Scalar>>(
+impl Circuit<bls12_381::Scalar> for MintAsset {
+    fn synthesize<CS: bellman::ConstraintSystem<bls12_381::Scalar>>(
         self,
         cs: &mut CS,
-    ) -> Result<(), bellperson::SynthesisError> {
+    ) -> Result<(), bellman::SynthesisError> {
         // Prover witnesses ak (ensures that it's on the curve)
         let ak = ecc::EdwardsPoint::witness(
             cs.namespace(|| "ak"),
@@ -117,7 +117,7 @@ impl Circuit<blstrs::Scalar> for MintAsset {
 
 #[cfg(test)]
 mod test {
-    use bellperson::{gadgets::test::TestConstraintSystem, Circuit, ConstraintSystem};
+    use bellman::{gadgets::test::TestConstraintSystem, Circuit};
     use ff::Field;
     use group::{Curve, Group};
     use jubjub::ExtendedPoint;
@@ -140,7 +140,7 @@ mod test {
             nsk: jubjub::Fr::random(&mut rng),
         };
         let incoming_view_key = proof_generation_key.to_viewing_key();
-        let public_address = *PUBLIC_KEY_GENERATOR * incoming_view_key.ivk().0;
+        let public_address = PUBLIC_KEY_GENERATOR * incoming_view_key.ivk().0;
         let public_address_point = ExtendedPoint::from(public_address).to_affine();
 
         let public_key_randomness = jubjub::Fr::random(&mut rng);

--- a/ironfish-zkp/src/circuits/output.rs
+++ b/ironfish-zkp/src/circuits/output.rs
@@ -1,6 +1,6 @@
 use ff::PrimeField;
 
-use bellperson::{gadgets::blake2s, Circuit, ConstraintSystem, SynthesisError};
+use bellman::{gadgets::blake2s, Circuit, ConstraintSystem, SynthesisError};
 
 use group::Curve;
 use jubjub::SubgroupPoint;
@@ -21,7 +21,7 @@ use crate::{
 };
 
 use super::util::expose_value_commitment;
-use bellperson::gadgets::boolean;
+use bellman::gadgets::boolean;
 
 /// This is a circuit instance inspired from ZCash's `Output` circuit in the Sapling protocol
 /// https://github.com/zcash/librustzcash/blob/main/zcash_proofs/src/circuit/sapling.rs#L57-L70
@@ -49,8 +49,8 @@ pub struct Output {
     pub ar: Option<jubjub::Fr>,
 }
 
-impl Circuit<blstrs::Scalar> for Output {
-    fn synthesize<CS: ConstraintSystem<blstrs::Scalar>>(
+impl Circuit<bls12_381::Scalar> for Output {
+    fn synthesize<CS: ConstraintSystem<bls12_381::Scalar>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {
@@ -255,7 +255,7 @@ impl Circuit<blstrs::Scalar> for Output {
 
 #[cfg(test)]
 mod test {
-    use bellperson::{gadgets::test::*, Circuit, ConstraintSystem};
+    use bellman::{gadgets::test::*, Circuit};
     use ff::Field;
     use group::{Curve, Group};
     use rand::rngs::StdRng;
@@ -269,7 +269,7 @@ mod test {
     };
 
     #[test]
-    fn test_output_circuit_with_blstrs() {
+    fn test_output_circuit_with_bls12_381() {
         // Seed a fixed rng for determinism in the test
         let mut rng = StdRng::seed_from_u64(0);
 
@@ -300,7 +300,7 @@ mod test {
 
             let viewing_key = proof_generation_key.to_viewing_key();
 
-            let payment_address = *PUBLIC_KEY_GENERATOR * viewing_key.ivk().0;
+            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0;
 
             let sender_address = payment_address;
 
@@ -340,10 +340,10 @@ mod test {
                     jubjub::ExtendedPoint::from(value_commitment.commitment()).to_affine();
 
                 let expected_epk =
-                    jubjub::ExtendedPoint::from(*PUBLIC_KEY_GENERATOR * esk).to_affine();
+                    jubjub::ExtendedPoint::from(PUBLIC_KEY_GENERATOR * esk).to_affine();
 
                 assert_eq!(cs.num_inputs(), 8);
-                assert_eq!(cs.get_input(0, "ONE"), blstrs::Scalar::one());
+                assert_eq!(cs.get_input(0, "ONE"), bls12_381::Scalar::one());
                 assert_eq!(cs.get_input(1, "rk/u/input variable"), rk.get_u());
                 assert_eq!(cs.get_input(2, "rk/v/input variable"), rk.get_v());
                 assert_eq!(

--- a/ironfish-zkp/src/circuits/spend.rs
+++ b/ironfish-zkp/src/circuits/spend.rs
@@ -1,16 +1,16 @@
-use bellperson::{Circuit, ConstraintSystem, SynthesisError};
-use ff::{Field, PrimeField};
+use bellman::{Circuit, ConstraintSystem, SynthesisError};
+use ff::PrimeField;
 use jubjub::SubgroupPoint;
 
 use crate::constants::{CRH_IVK_PERSONALIZATION, PRF_NF_PERSONALIZATION};
 use crate::{constants::proof::PUBLIC_KEY_GENERATOR, primitives::ValueCommitment};
 
 use super::util::expose_value_commitment;
-use bellperson::gadgets::blake2s;
-use bellperson::gadgets::boolean;
-use bellperson::gadgets::multipack;
-use bellperson::gadgets::num;
-use bellperson::gadgets::Assignment;
+use bellman::gadgets::blake2s;
+use bellman::gadgets::boolean;
+use bellman::gadgets::multipack;
+use bellman::gadgets::num;
+use bellman::gadgets::Assignment;
 use zcash_primitives::sapling::ProofGenerationKey;
 use zcash_proofs::{
     circuit::{ecc, pedersen_hash},
@@ -40,18 +40,18 @@ pub struct Spend {
     pub ar: Option<jubjub::Fr>,
 
     /// The authentication path of the commitment in the tree
-    pub auth_path: Vec<Option<(blstrs::Scalar, bool)>>,
+    pub auth_path: Vec<Option<(bls12_381::Scalar, bool)>>,
 
     /// The anchor; the root of the tree. If the note being
     /// spent is zero-value, this can be anything.
-    pub anchor: Option<blstrs::Scalar>,
+    pub anchor: Option<bls12_381::Scalar>,
 
     /// The sender address associated with the note
     pub sender_address: Option<SubgroupPoint>,
 }
 
-impl Circuit<blstrs::Scalar> for Spend {
-    fn synthesize<CS: ConstraintSystem<blstrs::Scalar>>(
+impl Circuit<bls12_381::Scalar> for Spend {
+    fn synthesize<CS: ConstraintSystem<bls12_381::Scalar>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {
@@ -167,7 +167,7 @@ impl Circuit<blstrs::Scalar> for Spend {
 
             // Compute the note's value as a linear combination
             // of the bits.
-            let mut coeff = blstrs::Scalar::one();
+            let mut coeff = bls12_381::Scalar::one();
             for bit in &value_bits {
                 value_num = value_num.add_bool_with_coeff(CS::one(), bit, coeff);
                 coeff = coeff.double();
@@ -293,7 +293,7 @@ impl Circuit<blstrs::Scalar> for Spend {
             cs.enforce(
                 || "conditionally enforce correct root",
                 |lc| lc + cur.get_variable() - rt.get_variable(),
-                |lc| lc + &value_num.lc(blstrs::Scalar::one()),
+                |lc| lc + &value_num.lc(bls12_381::Scalar::one()),
                 |lc| lc,
             );
 
@@ -334,9 +334,9 @@ impl Circuit<blstrs::Scalar> for Spend {
 
 #[cfg(test)]
 mod test {
-    use bellperson::{
+    use bellman::{
         gadgets::{multipack, test::*},
-        Circuit, ConstraintSystem,
+        Circuit,
     };
     use blake2s_simd::Params as Blake2sParams;
     use ff::{Field, PrimeField, PrimeFieldBits};
@@ -354,7 +354,7 @@ mod test {
     };
 
     #[test]
-    fn test_spend_circuit_with_blstrs() {
+    fn test_spend_circuit_with_bls12_381() {
         // Seed a fixed rng for determinism in the test
         let mut rng = StdRng::seed_from_u64(0);
 
@@ -364,7 +364,7 @@ mod test {
             let value_commitment = ValueCommitment {
                 value: rng.next_u64(),
                 randomness: jubjub::Fr::random(&mut rng),
-                asset_generator: (*VALUE_COMMITMENT_VALUE_GENERATOR).into(),
+                asset_generator: VALUE_COMMITMENT_VALUE_GENERATOR.into(),
             };
 
             let proof_generation_key = ProofGenerationKey {
@@ -374,11 +374,14 @@ mod test {
 
             let viewing_key = proof_generation_key.to_viewing_key();
 
-            let payment_address = *PUBLIC_KEY_GENERATOR * viewing_key.ivk().0;
+            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0;
 
             let commitment_randomness = jubjub::Fr::random(&mut rng);
             let auth_path =
-                vec![Some((blstrs::Scalar::random(&mut rng), rng.next_u32() % 2 != 0)); tree_depth];
+                vec![
+                    Some((bls12_381::Scalar::random(&mut rng), rng.next_u32() % 2 != 0));
+                    tree_depth
+                ];
             let ar = jubjub::Fr::random(&mut rng);
 
             {
@@ -387,7 +390,7 @@ mod test {
                     jubjub::ExtendedPoint::from(value_commitment.commitment()).to_affine();
                 let note = Note {
                     value: value_commitment.value,
-                    g_d: *PUBLIC_KEY_GENERATOR,
+                    g_d: PUBLIC_KEY_GENERATOR,
                     pk_d: payment_address,
                     rseed: Rseed::BeforeZip212(commitment_randomness),
                 };
@@ -421,8 +424,12 @@ mod test {
                         pedersen_hash::Personalization::MerkleTree(i),
                         lhs.iter()
                             .by_vals()
-                            .take(blstrs::Scalar::NUM_BITS as usize)
-                            .chain(rhs.iter().by_vals().take(blstrs::Scalar::NUM_BITS as usize)),
+                            .take(bls12_381::Scalar::NUM_BITS as usize)
+                            .chain(
+                                rhs.iter()
+                                    .by_vals()
+                                    .take(bls12_381::Scalar::NUM_BITS as usize),
+                            ),
                     ))
                     .to_affine()
                     .get_u();
@@ -432,7 +439,7 @@ mod test {
                     }
                 }
 
-                let rho = commitment + (*NULLIFIER_POSITION_GENERATOR * jubjub::Fr::from(position));
+                let rho = commitment + (NULLIFIER_POSITION_GENERATOR * jubjub::Fr::from(position));
 
                 // Compute nf = BLAKE2s(nk | rho)
                 let expected_nf = Nullifier::from_slice(
@@ -476,7 +483,7 @@ mod test {
                 assert_eq!(cs.get("randomization of note commitment/u3/num"), cmu);
 
                 assert_eq!(cs.num_inputs(), 8);
-                assert_eq!(cs.get_input(0, "ONE"), blstrs::Scalar::one());
+                assert_eq!(cs.get_input(0, "ONE"), bls12_381::Scalar::one());
                 assert_eq!(cs.get_input(1, "rk/u/input variable"), rk.get_u());
                 assert_eq!(cs.get_input(2, "rk/v/input variable"), rk.get_v());
                 assert_eq!(
@@ -495,7 +502,7 @@ mod test {
     }
 
     #[test]
-    fn test_spend_circuit_with_blstrs_external_test_vectors() {
+    fn test_spend_circuit_with_bls12_381_external_test_vectors() {
         // Seed a fixed rng for determinism in the test
         let mut rng = StdRng::seed_from_u64(0);
 
@@ -521,7 +528,7 @@ mod test {
             let value_commitment = ValueCommitment {
                 value: i,
                 randomness: jubjub::Fr::from(1000 * (i + 1)),
-                asset_generator: (*VALUE_COMMITMENT_VALUE_GENERATOR).into(),
+                asset_generator: VALUE_COMMITMENT_VALUE_GENERATOR.into(),
             };
 
             let proof_generation_key = ProofGenerationKey {
@@ -531,11 +538,14 @@ mod test {
 
             let viewing_key = proof_generation_key.to_viewing_key();
 
-            let payment_address = *PUBLIC_KEY_GENERATOR * viewing_key.ivk().0;
+            let payment_address = PUBLIC_KEY_GENERATOR * viewing_key.ivk().0;
 
             let commitment_randomness = jubjub::Fr::random(&mut rng);
             let auth_path =
-                vec![Some((blstrs::Scalar::random(&mut rng), rng.next_u32() % 2 != 0)); tree_depth];
+                vec![
+                    Some((bls12_381::Scalar::random(&mut rng), rng.next_u32() % 2 != 0));
+                    tree_depth
+                ];
             let ar = jubjub::Fr::random(&mut rng);
 
             {
@@ -544,11 +554,13 @@ mod test {
                     jubjub::ExtendedPoint::from(value_commitment.commitment()).to_affine();
                 assert_eq!(
                     expected_value_commitment.get_u(),
-                    blstrs::Scalar::from_str_vartime(expected_commitment_us[i as usize]).unwrap()
+                    bls12_381::Scalar::from_str_vartime(expected_commitment_us[i as usize])
+                        .unwrap()
                 );
                 assert_eq!(
                     expected_value_commitment.get_v(),
-                    blstrs::Scalar::from_str_vartime(expected_commitment_vs[i as usize]).unwrap()
+                    bls12_381::Scalar::from_str_vartime(expected_commitment_vs[i as usize])
+                        .unwrap()
                 );
 
                 let mut position = 0u64;
@@ -581,8 +593,12 @@ mod test {
                         pedersen_hash::Personalization::MerkleTree(i),
                         lhs.iter()
                             .by_vals()
-                            .take(blstrs::Scalar::NUM_BITS as usize)
-                            .chain(rhs.iter().by_vals().take(blstrs::Scalar::NUM_BITS as usize)),
+                            .take(bls12_381::Scalar::NUM_BITS as usize)
+                            .chain(
+                                rhs.iter()
+                                    .by_vals()
+                                    .take(bls12_381::Scalar::NUM_BITS as usize),
+                            ),
                     ))
                     .to_affine()
                     .get_u();
@@ -592,7 +608,7 @@ mod test {
                     }
                 }
 
-                let rho = commitment + (*NULLIFIER_POSITION_GENERATOR * jubjub::Fr::from(position));
+                let rho = commitment + (NULLIFIER_POSITION_GENERATOR * jubjub::Fr::from(position));
 
                 // Compute nf = BLAKE2s(nk | rho)
                 let expected_nf = Nullifier::from_slice(
@@ -636,7 +652,7 @@ mod test {
                 assert_eq!(cs.get("randomization of note commitment/u3/num"), cmu);
 
                 assert_eq!(cs.num_inputs(), 8);
-                assert_eq!(cs.get_input(0, "ONE"), blstrs::Scalar::one());
+                assert_eq!(cs.get_input(0, "ONE"), bls12_381::Scalar::one());
                 assert_eq!(cs.get_input(1, "rk/u/input variable"), rk.get_u());
                 assert_eq!(cs.get_input(2, "rk/v/input variable"), rk.get_v());
                 assert_eq!(

--- a/ironfish-zkp/src/circuits/util.rs
+++ b/ironfish-zkp/src/circuits/util.rs
@@ -1,4 +1,4 @@
-use bellperson::{
+use bellman::{
     gadgets::{
         blake2s,
         boolean::{self, AllocatedBit, Boolean},
@@ -57,7 +57,7 @@ pub fn expose_value_commitment<CS>(
     value_commitment: Option<ValueCommitment>,
 ) -> Result<Vec<boolean::Boolean>, SynthesisError>
 where
-    CS: ConstraintSystem<blstrs::Scalar>,
+    CS: ConstraintSystem<bls12_381::Scalar>,
 {
     // Booleanize the value into little-endian bit order
     let value_bits = boolean::u64_into_boolean_vec_le(
@@ -109,7 +109,7 @@ where
     Ok(value_bits)
 }
 
-pub fn assert_valid_asset_generator<CS: bellperson::ConstraintSystem<blstrs::Scalar>>(
+pub fn assert_valid_asset_generator<CS: bellman::ConstraintSystem<bls12_381::Scalar>>(
     mut cs: CS,
     asset_id: &[u8; ASSET_ID_LENGTH],
     asset_generator_repr: &[Boolean],

--- a/ironfish-zkp/src/constants.rs
+++ b/ironfish-zkp/src/constants.rs
@@ -1,5 +1,4 @@
 use jubjub::SubgroupPoint;
-use lazy_static::lazy_static;
 pub use zcash_primitives::constants::{
     CRH_IVK_PERSONALIZATION, GH_FIRST_BLOCK, NOTE_COMMITMENT_RANDOMNESS_GENERATOR,
     NULLIFIER_POSITION_GENERATOR, PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR,
@@ -20,41 +19,35 @@ pub const PRF_NF_PERSONALIZATION: &[u8; 8] = b"ironf_nf";
 /// BLAKE2s personalization for the value commitment generator for the value
 pub const VALUE_COMMITMENT_GENERATOR_PERSONALIZATION: &[u8; 8] = b"ironf_cv";
 
-lazy_static! {
-    pub static ref PUBLIC_KEY_GENERATOR: SubgroupPoint = SubgroupPoint::from_raw_unchecked(
-        blstrs::Scalar::from_u64s_le(&[
-            0x3edc_c85f_4d1a_44cd,
-            0x77ff_8c90_a9a0_d8f4,
-            0x0daf_03b5_47e2_022b,
-            0x6dad_65e6_2328_d37a,
-        ])
-        .unwrap(),
-        blstrs::Scalar::from_u64s_le(&[
-            0x5095_1f1f_eff0_8278,
-            0xf0b7_03d5_3a3e_dd4e,
-            0xca01_f580_9c00_eee2,
-            0x6996_932c_ece1_f4bb,
-        ])
-        .unwrap(),
-    );
-    pub static ref NATIVE_VALUE_COMMITMENT_GENERATOR: SubgroupPoint =
-        SubgroupPoint::from_raw_unchecked(
-            blstrs::Scalar::from_u64s_le(&[
-                0x94d2_7f25_df35_ab48,
-                0xd63c_001a_a39a_7991,
-                0x7398_aab3_c907_f5ab,
-                0x6623_5382_bd3b_3741,
-            ])
-            .unwrap(),
-            blstrs::Scalar::from_u64s_le(&[
-                0x6f79_906c_2a58_8644,
-                0x48e2_9b1a_efc3_a67c,
-                0x4808_b27f_848e_59b3,
-                0x074c_0767_fd99_d42f,
-            ])
-            .unwrap(),
-        );
-}
+pub const PUBLIC_KEY_GENERATOR: SubgroupPoint = SubgroupPoint::from_raw_unchecked(
+    bls12_381::Scalar::from_raw([
+        0x3edc_c85f_4d1a_44cd,
+        0x77ff_8c90_a9a0_d8f4,
+        0x0daf_03b5_47e2_022b,
+        0x6dad_65e6_2328_d37a,
+    ]),
+    bls12_381::Scalar::from_raw([
+        0x5095_1f1f_eff0_8278,
+        0xf0b7_03d5_3a3e_dd4e,
+        0xca01_f580_9c00_eee2,
+        0x6996_932c_ece1_f4bb,
+    ]),
+);
+
+pub const NATIVE_VALUE_COMMITMENT_GENERATOR: SubgroupPoint = SubgroupPoint::from_raw_unchecked(
+    bls12_381::Scalar::from_raw([
+        0x94d2_7f25_df35_ab48,
+        0xd63c_001a_a39a_7991,
+        0x7398_aab3_c907_f5ab,
+        0x6623_5382_bd3b_3741,
+    ]),
+    bls12_381::Scalar::from_raw([
+        0x6f79_906c_2a58_8644,
+        0x48e2_9b1a_efc3_a67c,
+        0x4808_b27f_848e_59b3,
+        0x074c_0767_fd99_d42f,
+    ]),
+);
 
 pub mod proof {
     use lazy_static::lazy_static;
@@ -62,6 +55,6 @@ pub mod proof {
 
     lazy_static! {
         pub static ref PUBLIC_KEY_GENERATOR: FixedGeneratorOwned =
-            generate_circuit_generator(*super::PUBLIC_KEY_GENERATOR);
+            generate_circuit_generator(super::PUBLIC_KEY_GENERATOR);
     }
 }

--- a/ironfish-zkp/src/primitives/value_commitment.rs
+++ b/ironfish-zkp/src/primitives/value_commitment.rs
@@ -24,7 +24,7 @@ impl ValueCommitment {
 
     pub fn commitment(&self) -> jubjub::SubgroupPoint {
         (self.asset_generator.clear_cofactor() * jubjub::Fr::from(self.value))
-            + (*VALUE_COMMITMENT_RANDOMNESS_GENERATOR * self.randomness)
+            + (VALUE_COMMITMENT_RANDOMNESS_GENERATOR * self.randomness)
     }
 }
 
@@ -52,9 +52,9 @@ mod test {
         assert_eq!(
             commitment.to_bytes(),
             [
-                26, 187, 102, 88, 49, 246, 207, 250, 101, 221, 173, 175, 223, 125, 32, 121, 255,
-                254, 160, 169, 214, 227, 29, 219, 84, 179, 43, 24, 186, 217, 93, 177
-            ],
+                246, 11, 253, 164, 210, 130, 169, 101, 41, 250, 51, 71, 158, 70, 62, 61, 194, 206,
+                21, 161, 234, 105, 158, 75, 142, 162, 25, 155, 101, 231, 117, 38
+            ]
         );
     }
 

--- a/ironfish-zkp/src/util.rs
+++ b/ironfish-zkp/src/util.rs
@@ -51,7 +51,7 @@ pub fn commitment_full_point(
     );
 
     // Compute final commitment
-    (*NOTE_COMMITMENT_RANDOMNESS_GENERATOR * rcm) + hash_of_contents
+    (NOTE_COMMITMENT_RANDOMNESS_GENERATOR * rcm) + hash_of_contents
 }
 
 /// This is a lightly modified group_hash function, for use with the asset identifier/generator flow
@@ -60,7 +60,7 @@ pub fn asset_hash_to_point(tag: &[u8]) -> Option<jubjub::ExtendedPoint> {
     assert_eq!(VALUE_COMMITMENT_GENERATOR_PERSONALIZATION.len(), 8);
 
     // Check to see that scalar field is 255 bits
-    assert!(blstrs::Scalar::NUM_BITS == 255);
+    assert!(bls12_381::Scalar::NUM_BITS == 255);
 
     let h = blake2s_simd::Params::new()
         .hash_length(32)


### PR DESCRIPTION
## Summary

This reverts commit 77b21e260a6444e928521edca00145bf73aa29dc.

This was working before, but something has changed such that our x86 darwin builds are not working. Testing x86 darwin locally appears to work just fine, so it's unclear what the issue is. It's possible that something in the build CI jobs has changed, a version or something, but nothing seemed immediately obvious and we don't want to hold up the release until we figure it out.

See https://github.com/iron-fish/ironfish/actions/runs/5269744219

Green build on this PR: https://github.com/iron-fish/ironfish/actions/runs/5272051494

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
