### PR TITLE
Fix error message when chain head changes

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -968,7 +968,7 @@ export class Blockchain {
         }
 
         if (previous && !previous.hash.equals(previousBlockHash)) {
-          throw new Error('Cannot create a block with a previous header that does not match')
+          throw new BlockCreationError(BlockCreationErrorReason.HEAD_CHANGED)
         }
 
         target = Target.calculateTarget(
@@ -1518,5 +1518,19 @@ export class VerifyError extends Error {
 
     this.reason = reason
     this.score = score
+  }
+}
+
+export enum BlockCreationErrorReason {
+  HEAD_CHANGED = 'HEAD_CHANGED',
+}
+
+export class BlockCreationError extends Error {
+  name = this.constructor.name
+  reason: BlockCreationErrorReason
+
+  constructor(reason: BlockCreationErrorReason) {
+    super()
+    this.reason = reason
   }
 }

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -968,7 +968,7 @@ export class Blockchain {
         }
 
         if (previous && !previous.hash.equals(previousBlockHash)) {
-          throw new HeadChangedError()
+          throw new HeadChangedError(`Can't create a block not attached to the chain head`)
         }
 
         target = Target.calculateTarget(

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -968,7 +968,7 @@ export class Blockchain {
         }
 
         if (previous && !previous.hash.equals(previousBlockHash)) {
-          throw new BlockCreationError(BlockCreationErrorReason.HEAD_CHANGED)
+          throw new HeadChangedError()
         }
 
         target = Target.calculateTarget(
@@ -1521,16 +1521,6 @@ export class VerifyError extends Error {
   }
 }
 
-export enum BlockCreationErrorReason {
-  HEAD_CHANGED = 'HEAD_CHANGED',
-}
-
-export class BlockCreationError extends Error {
+export class HeadChangedError extends Error {
   name = this.constructor.name
-  reason: BlockCreationErrorReason
-
-  constructor(reason: BlockCreationErrorReason) {
-    super()
-    this.reason = reason
-  }
 }

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -68,7 +68,7 @@ export class MiningManager {
         void this.onConnectedBlock(block).catch((error) => {
           if (error instanceof HeadChangedError) {
             this.node.logger.debug(
-              `Chain head changed while creating block template for seqeunce ${
+              `Chain head changed while creating block template for sequence ${
                 block.header.sequence + 1
               }`,
             )

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -4,7 +4,7 @@
 
 import { BufferSet } from 'buffer-map'
 import { Assert } from '../assert'
-import { Blockchain, BlockCreationError, BlockCreationErrorReason } from '../blockchain'
+import { Blockchain, HeadChangedError } from '../blockchain'
 import { isExpiredSequence } from '../consensus'
 import { Event } from '../event'
 import { MemPool } from '../memPool'
@@ -66,12 +66,8 @@ export class MiningManager {
     this.chain.onConnectBlock.on(
       (block) =>
         void this.onConnectedBlock(block).catch((error) => {
-          const headChanged =
-            error instanceof BlockCreationError &&
-            error.reason === BlockCreationErrorReason.HEAD_CHANGED
-
-          if (headChanged) {
-            this.node.logger.info(
+          if (error instanceof HeadChangedError) {
+            this.node.logger.debug(
               `Chain head changed while creating block template for seqeunce ${
                 block.header.sequence + 1
               }`,


### PR DESCRIPTION
## Summary
Miners are getting the error message `Error creating block template: Cannot create a block with a previous header that does not match` when the head changes during a template creation. This is sometimes expected behavior so when it is we don't want to surface this error to users

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
