### PR TITLE
updates poolMiner target on new work

### DIFF
--- a/ironfish/src/mining/poolMiner.ts
+++ b/ironfish/src/mining/poolMiner.ts
@@ -10,7 +10,7 @@ import { GraffitiUtils } from '../utils/graffiti'
 import { PromiseUtils } from '../utils/promise'
 import { isValidPublicAddress } from '../wallet/validator'
 import { StratumClient } from './stratum/clients/client'
-import { MINEABLE_BLOCK_HEADER_GRAFFITI_OFFSET } from './utils'
+import { MINEABLE_BLOCK_HEADER_GRAFFITI_OFFSET, minedPartialHeader } from './utils'
 
 export class MiningPoolMiner {
   readonly hashRate: Meter
@@ -109,6 +109,9 @@ export class MiningPoolMiner {
 
   newWork(miningRequestId: number, header: Buffer): void {
     Assert.isNotNull(this.graffiti)
+
+    const { target } = minedPartialHeader(header)
+    this.setTarget(target)
 
     this.logger.debug(
       `new work ${this.target.toString('hex')} ${miningRequestId} ${FileUtils.formatHashRate(


### PR DESCRIPTION
## Summary

the poolMiner only updates its target when it receives a 'set_target' message, and not when it receives new work from the pool.

the pool only sends 'set_target' when the miner first connects, so a pool miner uses the same target for the duration of its connection.

resolves #3839 

## Testing Plan

1. run a pool
2. start a pool miner in verbose mode
3. see that the 'new work' is always the same before the fix

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
