### PR TITLE
updates poolMiner log message on new work

### DIFF
--- a/ironfish/src/mining/poolMiner.ts
+++ b/ironfish/src/mining/poolMiner.ts
@@ -111,7 +111,9 @@ export class MiningPoolMiner {
     Assert.isNotNull(this.graffiti)
 
     this.logger.debug(
-      `new work ${this.target.toString('hex')} ${miningRequestId} ${FileUtils.formatHashRate(
+      `new work ${header
+        .toString('hex')
+        .slice(0, 50)}... ${miningRequestId} ${FileUtils.formatHashRate(
         this.hashRate.rate1s,
       )}/s`,
     )


### PR DESCRIPTION
## Summary

the poolMiner only updates its target when it receives a 'set_target' message, and not when it receives new work from the pool.

the pool only sends 'set_target' when the miner first connects, so a pool miner uses the same target for the duration of its connection.

the miner outputs a log message with its target each time it receives new work, but this is misleading.

updates the pool miner message to output a slice of the header sent for new work, which matches the log output of the pool when it sends new work.

Closes #3839 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
