### PR TITLE
fixes usage of oclif table sort flag

### DIFF
--- a/ironfish-cli/src/commands/mempool/transactions.ts
+++ b/ironfish-cli/src/commands/mempool/transactions.ts
@@ -7,7 +7,7 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { CommandFlags } from '../../types'
 
-const tableFlags = CliUx.ux.table.flags()
+const { sort: _, ...tableFlags } = CliUx.ux.table.flags()
 
 const parseMinMax = (input: string): MinMax | undefined => {
   if (input.split(':').length === 1) {

--- a/ironfish-cli/src/commands/peers/banned.ts
+++ b/ironfish-cli/src/commands/peers/banned.ts
@@ -7,7 +7,7 @@ import blessed from 'blessed'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 
-const tableFlags = CliUx.ux.table.flags()
+const { sort, ...tableFlags } = CliUx.ux.table.flags()
 
 export class BannedCommand extends IronfishCommand {
   static description = `List all banned peers`
@@ -15,6 +15,10 @@ export class BannedCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     ...tableFlags,
+    sort: {
+      ...sort,
+      exclusive: ['follow'],
+    },
     follow: Flags.boolean({
       char: 'f',
       default: false,
@@ -30,10 +34,6 @@ export class BannedCommand extends IronfishCommand {
       const response = await this.sdk.client.peer.getBannedPeers()
       this.log(renderTable(response.content))
       this.exit(0)
-    }
-
-    if (flags.sort !== undefined) {
-      this.log('The `sort` flag is not supported when using the `follow` flag.')
     }
 
     // Console log will create display issues with Blessed

--- a/ironfish-cli/src/commands/peers/banned.ts
+++ b/ironfish-cli/src/commands/peers/banned.ts
@@ -32,6 +32,10 @@ export class BannedCommand extends IronfishCommand {
       this.exit(0)
     }
 
+    if (flags.sort !== undefined) {
+      this.log('The `sort` flag is not supported when using the `follow` flag.')
+    }
+
     // Console log will create display issues with Blessed
     this.logger.pauseLogs()
 

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -11,12 +11,17 @@ import { CommandFlags } from '../../types'
 type GetPeerResponsePeer = GetPeersResponse['peers'][0]
 
 const STATE_COLUMN_HEADER = 'STATE'
+const { sort, ...tableFlags } = CliUx.ux.table.flags()
 export class ListCommand extends IronfishCommand {
   static description = `List all connected peers`
 
   static flags = {
     ...RemoteFlags,
-    ...CliUx.ux.table.flags(),
+    ...tableFlags,
+    sort: {
+      ...sort,
+      exclusive: ['follow'],
+    },
     follow: Flags.boolean({
       char: 'f',
       default: false,
@@ -61,10 +66,6 @@ export class ListCommand extends IronfishCommand {
       const response = await this.sdk.client.peer.getPeers()
       this.log(renderTable(response.content, flags))
       this.exit(0)
-    }
-
-    if (flags.sort !== undefined) {
-      this.log('The `sort` flag is not supported when using the `follow` flag.')
     }
 
     // Console log will create display issues with Blessed

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -11,15 +11,12 @@ import { CommandFlags } from '../../types'
 type GetPeerResponsePeer = GetPeersResponse['peers'][0]
 
 const STATE_COLUMN_HEADER = 'STATE'
-const tableFlags = CliUx.ux.table.flags()
-tableFlags.sort.default = STATE_COLUMN_HEADER
-
 export class ListCommand extends IronfishCommand {
   static description = `List all connected peers`
 
   static flags = {
     ...RemoteFlags,
-    ...tableFlags,
+    ...CliUx.ux.table.flags(),
     follow: Flags.boolean({
       char: 'f',
       default: false,
@@ -58,10 +55,16 @@ export class ListCommand extends IronfishCommand {
     const { flags } = await this.parse(ListCommand)
 
     if (!flags.follow) {
+      flags.sort = flags.sort ?? STATE_COLUMN_HEADER
+
       await this.sdk.client.connect()
       const response = await this.sdk.client.peer.getPeers()
       this.log(renderTable(response.content, flags))
       this.exit(0)
+    }
+
+    if (flags.sort !== undefined) {
+      this.log('The `sort` flag is not supported when using the `follow` flag.')
     }
 
     // Console log will create display issues with Blessed

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -12,6 +12,7 @@ type GetPeerResponsePeer = GetPeersResponse['peers'][0]
 
 const STATE_COLUMN_HEADER = 'STATE'
 const { sort, ...tableFlags } = CliUx.ux.table.flags()
+
 export class ListCommand extends IronfishCommand {
   static description = `List all connected peers`
 

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -19,12 +19,14 @@ const MIN_ASSET_METADATA_COLUMN_WIDTH = ASSET_METADATA_LENGTH / 2 + 1
 const MAX_ASSET_NAME_COLUMN_WIDTH = ASSET_NAME_LENGTH + 1
 const MIN_ASSET_NAME_COLUMN_WIDTH = ASSET_NAME_LENGTH / 2 + 1
 
+const { ...tableFlags } = CliUx.ux.table.flags()
+
 export class AssetsCommand extends IronfishCommand {
   static description = `Display the wallet's assets`
 
   static flags = {
     ...RemoteFlags,
-    ...CliUx.ux.table.flags(),
+    ...tableFlags,
   }
 
   static args = [

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -7,12 +7,13 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { TableCols } from '../../utils/table'
 
+const { sort: _, ...tableFlags } = CliUx.ux.table.flags()
 export class NotesCommand extends IronfishCommand {
   static description = `Display the account notes`
 
   static flags = {
     ...RemoteFlags,
-    ...CliUx.ux.table.flags(),
+    ...tableFlags,
   }
 
   static args = [

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -14,12 +14,13 @@ import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
 import { Format, TableCols } from '../../utils/table'
 
+const { sort: _, ...tableFlags } = CliUx.ux.table.flags()
 export class TransactionsCommand extends IronfishCommand {
   static description = `Display the account transactions`
 
   static flags = {
     ...RemoteFlags,
-    ...CliUx.ux.table.flags(),
+    ...tableFlags,
     hash: Flags.string({
       char: 't',
       description: 'Transaction hash to get details for',


### PR DESCRIPTION
## Summary

in many of our CLI command that use oclif tables we include the 'sort' flag. however, if we are displaying streamed responses in a table then the sort flag doesn't work because each response is a separate table.

- removes 'sort' flag from commands where it can't be used
- adds message if 'sort' is used along with 'follow' and can't be supported in peers commands
- removes default setting of 'STATE' for sort in peers command: the table flags are global, so this was being applied to every command that includes the sort flag

Relates to #3944

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
