### PR TITLE
feat(ci): Check for missing test fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,13 @@ jobs:
       - name: Run tests
         run: yarn test:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
 
+      - name: Check for missing fixtures
+        run: |
+          if [[ $(git status | grep fixture) ]]; then
+            echo "New test fixtures have not been checked in, please check them in."
+            exit 1
+          fi
+
       - name: Upload coverage
         if: github.repository == 'iron-fish/ironfish'
         run: CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} ROOT_PATH=$GITHUB_WORKSPACE/ yarn coverage:upload
@@ -97,6 +104,13 @@ jobs:
 
       - name: Run slow tests & coverage
         run: yarn test:slow:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
+
+      - name: Check for missing fixtures
+        run: |
+          if [[ $(git status | grep fixture) ]]; then
+            echo "New test fixtures have not been checked in, please check them in."
+            exit 1
+          fi
 
       - name: Run import/export account tests
         run: sudo apt-get update && sudo apt-get install -y expect && yarn build && cd ironfish-cli && yarn test:importexport
@@ -129,6 +143,13 @@ jobs:
 
       - name: Run perf tests
         run: yarn test:perf:report
+
+      - name: Check for missing fixtures
+        run: |
+          if [[ $(git status | grep fixture) ]]; then
+            echo "New test fixtures have not been checked in, please check them in."
+            exit 1
+          fi
 
       - name: Archive test results
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Summary

Currently, there is no check for fixtures when new tests are added. By checking for fixture changes during CI, we won't forget to check in the fixtures anymore.

Closes IFL-1113

## Testing Plan

CI run with a placeholder test with a missing fixture: 
https://github.com/iron-fish/ironfish/actions/runs/5323380651

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
