### PR TITLE
Remove expect check in perf tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,16 @@
 
 ## Testing Plan
 
+## Documentation
+
+Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
+Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
+related documentation pull request for the website.
+
+```
+[ ] Yes
+```
+
 ## Breaking Change
 
 Is this a breaking change? If yes, add notes below on why this is breaking and

--- a/ironfish/src/blockchain/blockchain.test.perf.ts
+++ b/ironfish/src/blockchain/blockchain.test.perf.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /* eslint-disable no-console */
+/* eslint-disable jest/expect-expect */
 import { Asset } from '@ironfish/rust-nodejs'
 import _ from 'lodash'
 import { Assert } from '../assert'
@@ -75,103 +76,31 @@ describe('Blockchain', () => {
   it('Times Ran 5 Fork Length 1', async () => {
     const result = await runTest(testCount, 1)
     printResults(result)
-
-    const totalTestAverageTime = MathUtils.arrayAverage(result.all)
-    expect(totalTestAverageTime).toBeLessThanOrEqual(39.4)
-
-    const addBlockLinearTime = MathUtils.arrayAverage(result.add)
-    expect(addBlockLinearTime).toBeLessThanOrEqual(1)
-
-    const addBlockOnForkTime = MathUtils.arrayAverage(result.fork)
-    expect(addBlockOnForkTime).toBeLessThanOrEqual(1)
-
-    const addHeadRewindForkBlocksTime = MathUtils.arrayAverage(result.rewind)
-    expect(addHeadRewindForkBlocksTime).toBeLessThanOrEqual(36.6)
   })
 
   it('Times Ran 5 Fork Length 3', async () => {
     const result = await runTest(testCount, 3)
     printResults(result)
-
-    const totalTestAverageTime = MathUtils.arrayAverage(result.all)
-    expect(totalTestAverageTime).toBeLessThanOrEqual(274.6)
-
-    const addBlockLinearTime = MathUtils.arrayAverage(result.add)
-    expect(addBlockLinearTime).toBeLessThanOrEqual(45.3)
-
-    const addBlockOnForkTime = MathUtils.arrayAverage(result.fork)
-    expect(addBlockOnForkTime).toBeLessThanOrEqual(34.2)
-
-    const addHeadRewindForkBlocksTime = MathUtils.arrayAverage(result.rewind)
-    expect(addHeadRewindForkBlocksTime).toBeLessThanOrEqual(157.8)
   })
 
   it('Times Ran 5 Fork Length 5', async () => {
     const result = await runTest(testCount, 5)
     printResults(result)
-
-    const totalTestAverageTime = MathUtils.arrayAverage(result.all)
-    expect(totalTestAverageTime).toBeLessThanOrEqual(612.2)
-
-    const addBlockLinearTime = MathUtils.arrayAverage(result.add)
-    expect(addBlockLinearTime).toBeLessThanOrEqual(57.3)
-
-    const addBlockOnForkTime = MathUtils.arrayAverage(result.fork)
-    expect(addBlockOnForkTime).toBeLessThanOrEqual(75.1)
-
-    const addHeadRewindForkBlocksTime = MathUtils.arrayAverage(result.rewind)
-    expect(addHeadRewindForkBlocksTime).toBeLessThanOrEqual(82.6)
   })
 
   it('Times Ran 5 Fork Length 10', async () => {
     const result = await runTest(testCount, 10)
     printResults(result)
-
-    const totalTestAverageTime = MathUtils.arrayAverage(result.all)
-    expect(totalTestAverageTime).toBeLessThanOrEqual(1598.8)
-
-    const addBlockLinearTime = MathUtils.arrayAverage(result.add)
-    expect(addBlockLinearTime).toBeLessThanOrEqual(67.49)
-
-    const addBlockOnForkTime = MathUtils.arrayAverage(result.fork)
-    expect(addBlockOnForkTime).toBeLessThanOrEqual(99.64)
-
-    const addHeadRewindForkBlocksTime = MathUtils.arrayAverage(result.rewind)
-    expect(addHeadRewindForkBlocksTime).toBeLessThanOrEqual(94.6)
   })
 
   it('Times Ran 5 Fork Length 50', async () => {
     const result = await runTest(testCount, 50)
     printResults(result)
-
-    const totalTestAverageTime = MathUtils.arrayAverage(result.all)
-    expect(totalTestAverageTime).toBeLessThanOrEqual(13709.4)
-
-    const addBlockLinearTime = MathUtils.arrayAverage(result.add)
-    expect(addBlockLinearTime).toBeLessThanOrEqual(74.29)
-
-    const addBlockOnForkTime = MathUtils.arrayAverage(result.fork)
-    expect(addBlockOnForkTime).toBeLessThanOrEqual(201.62)
-
-    const addHeadRewindForkBlocksTime = MathUtils.arrayAverage(result.rewind)
-    expect(addHeadRewindForkBlocksTime).toBeLessThanOrEqual(189.0)
   })
 
   it('Times Ran 5 Fork Length 100', async () => {
     const result = await runTest(testCount, 100)
     printResults(result)
-
-    const totalTestAverageTime = MathUtils.arrayAverage(result.all)
-    expect(totalTestAverageTime).toBeLessThanOrEqual(43504.2)
-
-    const addBlockLinearTime = MathUtils.arrayAverage(result.add)
-    expect(addBlockLinearTime).toBeLessThanOrEqual(84.23)
-
-    const addBlockOnForkTime = MathUtils.arrayAverage(result.fork)
-    expect(addBlockOnForkTime).toBeLessThanOrEqual(351.67)
-
-    const addHeadRewindForkBlocksTime = MathUtils.arrayAverage(result.rewind)
-    expect(addHeadRewindForkBlocksTime).toBeLessThanOrEqual(1200.2)
   })
 
   afterEach(() => {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -968,7 +968,7 @@ export class Blockchain {
         }
 
         if (previous && !previous.hash.equals(previousBlockHash)) {
-          throw new Error('Cannot create a block with a previous header that does not match')
+          throw new HeadChangedError(`Can't create a block not attached to the chain head`)
         }
 
         target = Target.calculateTarget(
@@ -1519,4 +1519,8 @@ export class VerifyError extends Error {
     this.reason = reason
     this.score = score
   }
+}
+
+export class HeadChangedError extends Error {
+  name = this.constructor.name
 }

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -4,7 +4,7 @@
 
 import { BufferSet } from 'buffer-map'
 import { Assert } from '../assert'
-import { Blockchain } from '../blockchain'
+import { Blockchain, HeadChangedError } from '../blockchain'
 import { isExpiredSequence } from '../consensus'
 import { Event } from '../event'
 import { MemPool } from '../memPool'
@@ -66,9 +66,17 @@ export class MiningManager {
     this.chain.onConnectBlock.on(
       (block) =>
         void this.onConnectedBlock(block).catch((error) => {
-          this.node.logger.info(
-            `Error creating block template: ${ErrorUtils.renderError(error)}`,
-          )
+          if (error instanceof HeadChangedError) {
+            this.node.logger.debug(
+              `Chain head changed while creating block template for sequence ${
+                block.header.sequence + 1
+              }`,
+            )
+          } else {
+            this.node.logger.error(
+              `Error creating block template: ${ErrorUtils.renderError(error)}`,
+            )
+          }
         }),
     )
   }

--- a/ironfish/src/workerPool/tasks/workerMessages.test.perf.ts
+++ b/ironfish/src/workerPool/tasks/workerMessages.test.perf.ts
@@ -48,11 +48,7 @@ describe('WorkerMessages', () => {
     })
 
     expect(true).toBe(true)
-    const { min, max, avg } = printResults('createMinersFeeRequest', runs, segment)
-
-    expect(max).toBeLessThanOrEqual(1.191)
-    expect(min).toBeLessThanOrEqual(0.029459)
-    expect(avg).toBeLessThanOrEqual(0.06783)
+    printResults('createMinersFeeRequest', runs, segment)
   })
 
   it('decryptNotes', async () => {
@@ -94,22 +90,10 @@ describe('WorkerMessages', () => {
       }
     })
 
-    const { min, max, avg } = printResults('decryptNotes', runs, segment)
-
-    expect(max).toBeLessThanOrEqual(6.1685)
-    expect(min).toBeLessThanOrEqual(0.510597)
-    expect(avg).toBeLessThanOrEqual(0.682932)
+    printResults('decryptNotes', runs, segment)
   })
 
-  function printResults(
-    testName: string,
-    runs: number[],
-    segment: SegmentResults,
-  ): {
-    min: number
-    max: number
-    avg: number
-  } {
+  function printResults(testName: string, runs: number[], segment: SegmentResults) {
     let min = Number.MAX_SAFE_INTEGER
     let max = 0
     let total = 0
@@ -137,12 +121,6 @@ describe('WorkerMessages', () => {
           `\nAverage: ${average} milliseconds`,
       )
       console.info(BenchUtils.renderSegment(segment))
-    }
-
-    return {
-      min,
-      max,
-      avg: average,
     }
   }
 })


### PR DESCRIPTION
## Summary
Remove the expect check in perf tests

## Testing Plan
yarn test:perf

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@mat-if 