### PR TITLE
fix(rust,zkp): Utilize portable flag for blstrs

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           save-if: false
           shared-key: base
-      
+
       - name: Install Cargo tools
         run: |
           rustup component add rustfmt clippy

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -36,7 +36,7 @@ bellperson = { git = "https://github.com/iron-fish/bellperson.git", branch = "bl
 blake2b_simd = "1.0.0"
 blake2s_simd = "1.0.0"
 blake3 = "1.3.1"
-blstrs = { version = "0.6.0" }
+blstrs = { version = "0.6.0", features = ["portable"] }
 byteorder = "1.4.3"
 chacha20poly1305 = "0.9.0"
 crypto_box = { version = "0.8", features = ["std"] }

--- a/ironfish-zkp/Cargo.toml
+++ b/ironfish-zkp/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 [dependencies]
 bellperson = { git = "https://github.com/iron-fish/bellperson.git", branch = "blstrs", features = ["groth16"] }
 blake2s_simd = "1.0.0"
-blstrs = { version = "0.6.0" }
+blstrs = { version = "0.6.0", features = ["portable"] }
 byteorder = "1.4.3"
 ff = "0.12.0"
 group = "0.12.0"


### PR DESCRIPTION
## Summary

Blstrs builds using CPU instructions that may not be present on older hardware. Github Actions hardware pool has some of this older hardware, leading to broken builds in some cases.

Rust benchmarks on a c6i.large (2vCPU, 4gb RAM)
```
asset::new
        STAGING : 142.64 µs
        PORTABLE: 97.957 µs
        BLSTRS  : 89.686 µs
asset::new_with_nonce
        STAGING : 65.369 µs
        PORTABLE: 44.218 µs
        BLSTRS  : 40.830 µs
merkle_note::decrypt_note_for_spender
        STAGING : 866.14 µs
        PORTABLE: 765.79 µs
        BLSTRS  : 700.06 µs
merkle_note::decrypt_note_for_owner
        STAGING : 788.39 µs
        PORTABLE: 719.39 µs
        BLSTRS  : 659.66 µs
sapling_key::generate_key
        STAGING : 268.66 µs
        PORTABLE: 259.10 µs
        BLSTRS  : 236.38 µs
transaction::simple
        STAGING : 9.0264 s
        PORTABLE: 8.1176 s
        BLSTRS  : 6.3045 s
transaction::all_descriptions
        STAGING : 10.753 s
        PORTABLE: 9.7014 s
        BLSTRS  : 7.5252 s
transaction::verify
        STAGING : 19.735 ms
        PORTABLE: 5.3661 ms
        BLSTRS  : 4.4110 ms
transaction::batch_verify
        STAGING : 32.953 ms
        PORTABLE: 14.664 ms
        BLSTRS  : 11.927 ms
```

## Testing Plan

Run the build CI job on the same branch with and without the portable flag to hopefully stick to the same hardware.
Failed build without portable: https://github.com/iron-fish/ironfish/actions/runs/5326947221
Passed build with portable: https://github.com/iron-fish/ironfish/actions/runs/5327211967
Passed on the final version of this PR: https://github.com/iron-fish/ironfish/actions/runs/5337567384

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
