### PR TITLE
Add back print result

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -56,7 +56,7 @@
     "test": "tsc -b && tsc -b tsconfig.test.json && jest --testTimeout=${JEST_TIMEOUT:-5000}",
     "test:slow": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.slow.ts\" --testTimeout=${JEST_TIMEOUT:-60000} --testPathIgnorePatterns",
     "test:perf": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --testMatch \"**/*.test.perf.ts\" --testTimeout=${JEST_TIMEOUT:-600000} --testPathIgnorePatterns --runInBand",
-    "test:perf:report": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true jest --config jest.config.js --testMatch \"**/*.test.perf.ts\" --testTimeout=${JEST_TIMEOUT:-600000} --testPathIgnorePatterns --ci",
+    "test:perf:report": "tsc -b && tsc -b tsconfig.test.json && cross-env TEST_INIT_RUST=true GENERATE_TEST_REPORT=true jest --config jest.config.js --testMatch \"**/*.test.perf.ts\" --testTimeout=${JEST_TIMEOUT:-600000} --testPathIgnorePatterns --ci",
     "test:coverage:html": "tsc -b tsconfig.test.json && jest --coverage --coverage-reporters html --testPathIgnorePatterns",
     "test:watch": "tsc -b tsconfig.test.json && jest --watch --coverage false",
     "fixtures:regenerate": "find . -name \"__fixtures__\" | xargs rm -rf && JEST_TIMEOUT=1000000000 yarn run test && JEST_TIMEOUT=1000000000 yarn run test:slow && JEST_TIMEOUT=1000000000 yarn run test:perf"

--- a/ironfish/src/blockchain/blockchain.test.perf.ts
+++ b/ironfish/src/blockchain/blockchain.test.perf.ts
@@ -245,12 +245,28 @@ describe('Blockchain', () => {
   }
 
   function printResults(result: UnwrapPromise<ReturnType<typeof runTest>>): void {
-    console.log(
-      `Total Test Average: ${MathUtils.arrayAverage(result.all).toFixed(2)}` +
-        `,Insert blocks linear: ${MathUtils.arrayAverage(result.add).toFixed(2)}` +
-        `,Insert blocks on fork: ${MathUtils.arrayAverage(result.fork).toFixed(2)}` +
-        `,Add head rewind fork blocks: ${MathUtils.arrayAverage(result.rewind).toFixed(2)}`,
-    )
+    if (process.env.GENERATE_TEST_REPORT) {
+      console.log(
+        `Total Test Average: ${MathUtils.arrayAverage(result.all).toFixed(2)}` +
+          `,Insert blocks linear: ${MathUtils.arrayAverage(result.add).toFixed(2)}` +
+          `,Insert blocks on fork: ${MathUtils.arrayAverage(result.fork).toFixed(2)}` +
+          `,Add head rewind fork blocks: ${MathUtils.arrayAverage(result.rewind).toFixed(2)}`,
+      )
+    } else {
+      console.info(
+        `[TEST RESULTS: Times Ran: ${result.testCount}, Fork Length: ${result.forkLength}]` +
+          `\nTotal Test Average: ${MathUtils.arrayAverage(result.all).toFixed(2)}ms` +
+          `\nInsert ${result.forkLength - 1} blocks linear: ${MathUtils.arrayAverage(
+            result.add,
+          ).toFixed(2)}ms` +
+          `\nInsert ${result.forkLength - 1} blocks on fork: ${MathUtils.arrayAverage(
+            result.fork,
+          ).toFixed(2)}ms` +
+          `\nAdd head rewind fork blocks: ${MathUtils.arrayAverage(result.rewind).toFixed(
+            2,
+          )}ms`,
+      )
+    }
   }
 })
 

--- a/ironfish/src/mining/manager.test.perf.ts
+++ b/ironfish/src/mining/manager.test.perf.ts
@@ -84,7 +84,14 @@ describe('MiningManager', () => {
   }
 
   function printResults(results: Results) {
-    console.log(`Elapsed: ${results.elapsed.toLocaleString()}`)
+    if (process.env.GENERATE_TEST_REPORT) {
+      console.log(`Elapsed: ${results.elapsed.toLocaleString()}`)
+    } else {
+      console.info(
+        `[TEST RESULTS: Mempool size: ${results.mempoolSize}, Transactions count: ${results.numTransactions}]` +
+          `\nElapsed: ${results.elapsed.toLocaleString()} milliseconds`,
+      )
+    }
   }
 
   async function runTest(

--- a/ironfish/src/primitives/transaction.test.perf.ts
+++ b/ironfish/src/primitives/transaction.test.perf.ts
@@ -50,7 +50,14 @@ describe('Transaction', () => {
   }
 
   function printResults(results: Results) {
-    console.log(`Elapsed: ${results.elapsed.toLocaleString()}`)
+    if (process.env.GENERATE_TEST_REPORT) {
+      console.log(`Elapsed: ${results.elapsed.toLocaleString()}`)
+    } else {
+      console.info(
+        `[TEST RESULTS: Spends: ${results.spends}, Outputs: ${results.outputs}]` +
+          `\nElapsed: ${results.elapsed.toLocaleString()} milliseconds`,
+      )
+    }
   }
 
   async function runTest(

--- a/ironfish/src/workerPool/tasks/workerMessages.test.perf.ts
+++ b/ironfish/src/workerPool/tasks/workerMessages.test.perf.ts
@@ -120,13 +120,24 @@ describe('WorkerMessages', () => {
     }
     const average = total / runs.length
 
-    console.log(
-      `Total time: ${total},` +
-        `Fastest runtime: ${min},` +
-        `Slowest runtime: ${max},` +
-        `Average runtime: ${average},` +
-        BenchUtils.renderSegment(segment, ''),
-    )
+    if (process.env.GENERATE_TEST_REPORT) {
+      console.log(
+        `Total time: ${total},` +
+          `Fastest runtime: ${min},` +
+          `Slowest runtime: ${max},` +
+          `Average runtime: ${average},` +
+          BenchUtils.renderSegment(segment, ''),
+      )
+    } else {
+      console.info(
+        `[TEST RESULTS: Message: ${testName}, Iterations: ${TEST_ITERATIONS}]` +
+          `\nTotal elapsed: ${total} milliseconds` +
+          `\nFastest: ${min} milliseconds` +
+          `\nSlowest: ${max} milliseconds` +
+          `\nAverage: ${average} milliseconds`,
+      )
+      console.info(BenchUtils.renderSegment(segment))
+    }
 
     return {
       min,


### PR DESCRIPTION
## Summary
Only generate test report for `yarn test:perf:report`
`yarn test:perf` will print the same result as before

## Testing Plan
`yarn test:perf:report`
`yarn test:perf`
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@mat-if 