### PR TITLE
Record CPU information during GitHub CI runs

### DIFF
--- a/.github/workflows/build-ironfish-rust-nodejs.yml
+++ b/.github/workflows/build-ironfish-rust-nodejs.yml
@@ -39,6 +39,12 @@ jobs:
     name: Build ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
     steps:
+      - name: Record CPU information
+        run: |
+          ${{ contains(matrix.settings.host, 'ubuntu-') && 'cat /proc/cpuinfo' || '' }}
+          ${{ contains(matrix.settings.host, 'macos-') && 'sysctl -a | grep machdep.cpu' || '' }}
+          ${{ contains(matrix.settings.host, 'windows-') && 'Get-WmiObject -Class Win32_Processor -ComputerName.' || '' }}
+
       - name: Check out Git repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
## Summary

GitHub CI runs now include a step to print CPU features before running the builds. This is useful because, as we have seen, the GitHub fleet uses a mix of CPUs in their fleet, and those features may be auto-detected by some build scripts and result in different build artifacts.

This works for Linux, MacOS and Windows. I couldn't find a way to make Windows print all the features, but we have the model, which can be used to guess what features may be available at build time.

## Testing Plan

Test run: https://github.com/iron-fish/ironfish/actions/runs/5339615241

Note the new "Record CPU information" step at the beginning of each build.

Example outputs (truncated):
*   Linux:
    ```
    ▸ Run cat /proc/cpuinfo
    processor   : 0
    vendor_id   : GenuineIntel
    cpu family  : 6
    model       : 79
    model name  : Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
    ...
    flags       : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase bmi1 hle avx2 smep bmi2 erms invpcid rtm rdseed adx smap xsaveopt md_clear
    ...
    ```

*   MacOS:
    ```
    ▸ Run sysctl -a | grep machdep.cpu
    ...
    machdep.cpu.brand_string: Intel(R) Xeon(R) CPU E5-1650 v2 @ 3.50GHz
    ...
    machdep.cpu.features: FPU VME DE PSE TSC MSR PAE MCE CX8 APIC SEP MTRR PGE MCA CMOV PAT PSE36 CLFSH MMX FXSR SSE SSE2 SS HTT SSE3 PCLMULQDQ MON VMX SSSE3 CX16 SSE4.1 SSE4.2 x2APIC POPCNT AES VMM PCID XSAVE OSXSAVE TSCTMR AVX1.0 RDRAND F16C
    machdep.cpu.leaf7_features: RDWRFSGS TSC_THREAD_OFFSET SMEP ERMS MDCLEAR IBRS STIBP L1DF ACAPMSR SSBD
    machdep.cpu.extfeatures: SYSCALL XD EM64T LAHF RDTSCP TSCI
    ...
    ```
    
*   Windows:
    ```
    ▸ Run Get-WmiObject -Class Win32_Processor -ComputerName.
    Caption           : Intel64 Family 6 Model 79 Stepping 1
    DeviceID          : CPU0
    Manufacturer      : GenuineIntel
    MaxClockSpeed     : 2295
    Name              : Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
    SocketDesignation : None
    ```

## Documentation

No doc change needed

## Breaking Change

Not a breaking change