### PR TITLE
Change Wallet.send() to accept an object

### DIFF
--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
@@ -7,6 +7,7 @@ import { useAccountFixture, useMinersTxFixture } from '../../../testUtilities/fi
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { NotEnoughFundsError } from '../../../wallet/errors'
 import { ERROR_CODES } from '../../adapters'
+import { Assert } from '../../../assert'
 
 const TEST_PARAMS = {
   account: 'existingAccount',
@@ -241,14 +242,11 @@ describe('Route wallet/sendTransaction', () => {
 
     await routeTest.client.wallet.sendTransaction(TEST_PARAMS)
 
-    expect(sendSpy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-      routeTest.node.config.get('transactionExpirationDelta'),
-      undefined,
-      undefined,
-    )
+    Assert.isNotUndefined(sendSpy.mock.lastCall)
+
+    expect(sendSpy.mock.lastCall[0]).toMatchObject({
+      expirationDelta: undefined,
+    })
 
     await routeTest.client.wallet.sendTransaction({
       ...TEST_PARAMS,
@@ -257,13 +255,10 @@ describe('Route wallet/sendTransaction', () => {
       confirmations: 10,
     })
 
-    expect(sendSpy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-      12345,
-      1234,
-      10,
-    )
+    expect(sendSpy.mock.lastCall[0]).toMatchObject({
+      expiration: 1234,
+      expirationDelta: 12345,
+      confirmations: 10,
+    })
   })
 })

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
@@ -3,11 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Asset } from '@ironfish/rust-nodejs'
+import { Assert } from '../../../assert'
 import { useAccountFixture, useMinersTxFixture } from '../../../testUtilities/fixtures'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { NotEnoughFundsError } from '../../../wallet/errors'
 import { ERROR_CODES } from '../../adapters'
-import { Assert } from '../../../assert'
 
 const TEST_PARAMS = {
   account: 'existingAccount',

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -110,18 +110,14 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
       }
     }
 
-    if (!request.data.expirationDelta) {
-      request.data.expirationDelta = node.config.get('transactionExpirationDelta')
-    }
-
     try {
       const transaction = await node.wallet.send({
         account,
         outputs,
         fee,
-        expirationDelta: request.data.expirationDelta,
-        expiration: request.data.expiration,
-        confirmations: request.data.confirmations,
+        expirationDelta: request.data.expirationDelta ?? undefined,
+        expiration: request.data.expiration ?? undefined,
+        confirmations: request.data.confirmations ?? undefined,
       })
 
       request.end({

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -110,15 +110,19 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
       }
     }
 
+    if (!request.data.expirationDelta) {
+      request.data.expirationDelta = node.config.get('transactionExpirationDelta')
+    }
+
     try {
-      const transaction = await node.wallet.send(
+      const transaction = await node.wallet.send({
         account,
         outputs,
         fee,
-        request.data.expirationDelta ?? node.config.get('transactionExpirationDelta'),
-        request.data.expiration,
-        request.data.confirmations,
-      )
+        expirationDelta: request.data.expirationDelta,
+        expiration: request.data.expiration,
+        confirmations: request.data.confirmations,
+      })
 
       request.end({
         account: account.name,

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -105,9 +105,9 @@ describe('Accounts', () => {
     })
 
     // Spend the balance
-    const transaction = await node.wallet.send(
+    const transaction = await node.wallet.send({
       account,
-      [
+      outputs: [
         {
           publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
@@ -115,10 +115,10 @@ describe('Accounts', () => {
           assetId: Asset.nativeId(),
         },
       ],
-      BigInt(0),
-      node.config.get('transactionExpirationDelta'),
-      0,
-    )
+      fee: BigInt(0),
+      expirationDelta: node.config.get('transactionExpirationDelta'),
+      expiration: 0,
+    })
 
     // Create a block with a miner's fee
     const minersfee2 = await strategy.createMinersFee(
@@ -173,9 +173,9 @@ describe('Accounts', () => {
     })
 
     // Spend the balance
-    const transaction = await node.wallet.send(
+    const transaction = await node.wallet.send({
       account,
-      [
+      outputs: [
         {
           publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
@@ -183,9 +183,9 @@ describe('Accounts', () => {
           assetId: Asset.nativeId(),
         },
       ],
-      BigInt(0),
-      node.config.get('transactionExpirationDelta'),
-    )
+      fee: BigInt(0),
+      expirationDelta: node.config.get('transactionExpirationDelta'),
+    })
 
     expect(transaction.expiration()).toBe(
       node.chain.head.sequence + node.config.get('transactionExpirationDelta'),
@@ -243,9 +243,9 @@ describe('Accounts', () => {
       unconfirmed: BigInt(2000000000),
     })
 
-    const transaction = await node.wallet.send(
+    const transaction = await node.wallet.send({
       account,
-      [
+      outputs: [
         {
           publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
@@ -265,9 +265,9 @@ describe('Accounts', () => {
           assetId: Asset.nativeId(),
         },
       ],
-      BigInt(0),
-      node.config.get('transactionExpirationDelta'),
-    )
+      fee: BigInt(0),
+      expirationDelta: node.config.get('transactionExpirationDelta'),
+    })
 
     expect(transaction.expiration()).toBe(
       node.chain.head.sequence + node.config.get('transactionExpirationDelta'),
@@ -297,9 +297,9 @@ describe('Accounts', () => {
 
     // Spend the balance with an invalid expiration
     await expect(
-      node.wallet.send(
+      node.wallet.send({
         account,
-        [
+        outputs: [
           {
             publicAddress: generateKey().publicAddress,
             amount: BigInt(2),
@@ -307,10 +307,10 @@ describe('Accounts', () => {
             assetId: Asset.nativeId(),
           },
         ],
-        BigInt(0),
-        node.config.get('transactionExpirationDelta'),
-        1,
-      ),
+        fee: BigInt(0),
+        expirationDelta: node.config.get('transactionExpirationDelta'),
+        expiration: 1,
+      }),
     ).rejects.toThrow(Error)
   })
 
@@ -352,9 +352,9 @@ describe('Accounts', () => {
     })
 
     // Spend the balance, setting expiry soon
-    const transaction = await node.wallet.send(
+    const transaction = await node.wallet.send({
       account,
-      [
+      outputs: [
         {
           publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
@@ -362,9 +362,9 @@ describe('Accounts', () => {
           assetId: Asset.nativeId(),
         },
       ],
-      BigInt(0),
-      1,
-    )
+      fee: BigInt(0),
+      expirationDelta: 1,
+    })
 
     // Transaction should be pending
     await expect(node.wallet.getBalance(account, Asset.nativeId())).resolves.toMatchObject({
@@ -438,9 +438,9 @@ describe('Accounts', () => {
     })
 
     // Spend the balance, setting expiry soon
-    const transaction = await node.wallet.send(
+    const transaction = await node.wallet.send({
       account,
-      [
+      outputs: [
         {
           publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
@@ -448,9 +448,9 @@ describe('Accounts', () => {
           assetId: Asset.nativeId(),
         },
       ],
-      BigInt(0),
-      1,
-    )
+      fee: BigInt(0),
+      expirationDelta: 1,
+    })
 
     // Transaction should be unconfirmed
     await expect(account.hasPendingTransaction(transaction.hash())).resolves.toBeTruthy()
@@ -660,9 +660,9 @@ describe('Accounts', () => {
     })
 
     // Spend the balance
-    const transaction = await node.wallet.send(
+    const transaction = await node.wallet.send({
       account,
-      [
+      outputs: [
         {
           publicAddress: generateKey().publicAddress,
           amount: BigInt(2),
@@ -670,10 +670,10 @@ describe('Accounts', () => {
           assetId: Asset.nativeId(),
         },
       ],
-      BigInt(0),
-      node.config.get('transactionExpirationDelta'),
-      0,
-    )
+      fee: BigInt(0),
+      expirationDelta: node.config.get('transactionExpirationDelta'),
+      expiration: 0,
+    })
 
     // Create a block with a miner's fee
     const minersfee2 = await strategy.createMinersFee(

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -749,31 +749,31 @@ export class Wallet {
     }
   }
 
-  async send(
-    account: Account,
+  async send(options: {
+    account: Account
     outputs: {
       publicAddress: string
       amount: bigint
       memo: string
       assetId: Buffer
-    }[],
-    fee: bigint,
-    expirationDelta: number,
-    expiration?: number | null,
-    confirmations?: number | null,
-  ): Promise<Transaction> {
+    }[]
+    fee: bigint
+    expirationDelta?: number
+    expiration?: number
+    confirmations?: number
+  }): Promise<Transaction> {
     const raw = await this.createTransaction({
-      account,
-      outputs,
-      fee,
-      expirationDelta,
-      expiration: expiration ?? undefined,
-      confirmations: confirmations ?? undefined,
+      account: options.account,
+      outputs: options.outputs,
+      fee: options.fee,
+      expirationDelta: options.expirationDelta,
+      expiration: options.expiration ?? undefined,
+      confirmations: options.confirmations ?? undefined,
     })
 
     return this.post({
       transaction: raw,
-      account,
+      account: options.account,
     })
   }
 


### PR DESCRIPTION
## Summary

This brings it inline with our other APIs, and makes it more extensible. This is in preparation for adding another argument to this function too. It also makes it more backwards compatible for consumers of the SDK, because adding new parameters won't break existing users.

## Testing Plan

Just a type change, so we only need to run tests.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```

Anyone using the SDK that was calling Wallet.send() will need to update their callsites.
