### PR TITLE
Add feeRate to RPC Wallet/sendTransaction

### DIFF
--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
@@ -244,9 +244,7 @@ describe('Route wallet/sendTransaction', () => {
 
     Assert.isNotUndefined(sendSpy.mock.lastCall)
 
-    expect(sendSpy.mock.lastCall[0]).toMatchObject({
-      expirationDelta: undefined,
-    })
+    expect(sendSpy.mock.lastCall[0].expirationDelta).toBeUndefined()
 
     await routeTest.client.wallet.sendTransaction({
       ...TEST_PARAMS,

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -5,6 +5,7 @@ import { Asset, MEMO_LENGTH } from '@ironfish/rust-nodejs'
 import { BufferMap } from 'buffer-map'
 import * as yup from 'yup'
 import { CurrencyUtils, YupUtils } from '../../../utils'
+import { Wallet } from '../../../wallet'
 import { NotEnoughFundsError } from '../../../wallet/errors'
 import { ERROR_CODES, ValidationError } from '../../adapters/errors'
 import { ApiNamespace, router } from '../router'
@@ -18,7 +19,8 @@ export type SendTransactionRequest = {
     memo: string
     assetId?: string
   }[]
-  fee: string
+  fee?: string
+  feeRate?: string
   expiration?: number | null
   expirationDelta?: number | null
   confirmations?: number | null
@@ -45,7 +47,8 @@ export const SendTransactionRequestSchema: yup.ObjectSchema<SendTransactionReque
           .defined(),
       )
       .defined(),
-    fee: YupUtils.currency({ min: 1n }).defined(),
+    fee: YupUtils.currency({ min: 1n }).optional(),
+    feeRate: YupUtils.currency({ min: 1n }).optional(),
     expiration: yup.number().nullable().optional(),
     expirationDelta: yup.number().nullable().optional(),
     confirmations: yup.number().nullable().optional(),
@@ -85,14 +88,28 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
       assetId: output.assetId ? Buffer.from(output.assetId, 'hex') : Asset.nativeId(),
     }))
 
-    const fee = CurrencyUtils.decode(request.data.fee)
+    const params: Parameters<Wallet['send']>[0] = {
+      account,
+      outputs,
+      expiration: request.data.expiration ?? undefined,
+      expirationDelta: request.data.expirationDelta ?? undefined,
+      confirmations: request.data.confirmations ?? undefined,
+    }
 
     const totalByAssetId = new BufferMap<bigint>()
-    totalByAssetId.set(Asset.nativeId(), fee)
 
     for (const { assetId, amount } of outputs) {
       const sum = totalByAssetId.get(assetId) ?? 0n
       totalByAssetId.set(assetId, sum + amount)
+    }
+
+    if (request.data.fee) {
+      params.fee = CurrencyUtils.decode(request.data.fee)
+      totalByAssetId.set(Asset.nativeId(), params.fee)
+    }
+
+    if (request.data.feeRate) {
+      params.feeRate = CurrencyUtils.decode(request.data.feeRate)
     }
 
     // Check that the node has enough balance
@@ -111,14 +128,7 @@ router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
     }
 
     try {
-      const transaction = await node.wallet.send({
-        account,
-        outputs,
-        fee,
-        expirationDelta: request.data.expirationDelta ?? undefined,
-        expiration: request.data.expiration ?? undefined,
-        confirmations: request.data.confirmations ?? undefined,
-      })
+      const transaction = await node.wallet.send(params)
 
       request.end({
         account: account.name,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -757,7 +757,8 @@ export class Wallet {
       memo: string
       assetId: Buffer
     }[]
-    fee: bigint
+    fee?: bigint
+    feeRate?: bigint
     expirationDelta?: number
     expiration?: number
     confirmations?: number
@@ -766,6 +767,7 @@ export class Wallet {
       account: options.account,
       outputs: options.outputs,
       fee: options.fee,
+      feeRate: options.feeRate,
       expirationDelta: options.expirationDelta,
       expiration: options.expiration ?? undefined,
       confirmations: options.confirmations ?? undefined,


### PR DESCRIPTION
## Summary

This RPC did not support passing feeRate to this RPC. I restructured it so it's now supported.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```