### PR TITLE
handles errors sending jobs to worker threads

### DIFF
--- a/ironfish/src/workerPool/job.test.slow.ts
+++ b/ironfish/src/workerPool/job.test.slow.ts
@@ -49,6 +49,16 @@ describe('Worker Pool', () => {
 
       expect(workerPool.workers.length).toBe(1)
 
+      class ErrorWorkerMessage extends WorkerMessage {
+        serializePayload(): void {
+          throw new Error('Always throw an error during serialization.')
+        }
+
+        getSize(): number {
+          return 0
+        }
+      }
+
       const worker = workerPool.workers[0]
       const message = new ErrorWorkerMessage(WorkerMessageType.JobError)
       const job = new Job(message)
@@ -59,16 +69,7 @@ describe('Worker Pool', () => {
 
       expect(job.status).toEqual('error')
       expect(worker.jobs.size).toEqual(0)
+      expect(worker.canTakeJobs).toBe(true)
     })
   })
 })
-
-class ErrorWorkerMessage extends WorkerMessage {
-  serializePayload(): void {
-    throw new Error('Always throw an error during serialization.')
-  }
-
-  getSize(): number {
-    return 0
-  }
-}

--- a/ironfish/src/workerPool/pool.ts
+++ b/ironfish/src/workerPool/pool.ts
@@ -242,7 +242,7 @@ export class WorkerPool {
       return job
     }
 
-    worker.execute(job)
+    job.execute(worker)
     return job
   }
 
@@ -261,7 +261,7 @@ export class WorkerPool {
       return
     }
 
-    worker.execute(job)
+    job.execute(worker)
   }
 
   private jobEnded = (): void => {

--- a/ironfish/src/workerPool/worker.ts
+++ b/ironfish/src/workerPool/worker.ts
@@ -59,11 +59,6 @@ export class Worker {
     }
   }
 
-  execute(job: Job): void {
-    this.jobs.set(job.id, job)
-    job.execute(this)
-  }
-
   send(message: WorkerMessage): void {
     if (this.thread) {
       this.thread.postMessage(message.serialize())


### PR DESCRIPTION
## Summary

the worker pool tracks the state of a job by assigning it a status and by assigning it to a worker. that assignment, placing the job in the worker's jobs map, occurs before sending the job to the worker. the job's status is also set to 'executing' before sending the job to the worker thread.

if an error occurs in sending the job to the worker, such as when serializing the job, then we do not reset these statuses: the job is left in an 'executing' state even though it is not executing, and the worker keeps the job in its map even though it never received it.

at this point the worker pool will not assign any more jobs to that worker.

- catches errors from 'worker.send' and sets the job status to 'error'
- moves assignment of the job to the worker's data structures to 'job.execute' and only assigns the job if it was successfully sent to the worker thread.
- removes 'worker.execute' since it only calls 'job.execute'

## Testing Plan

- adds unit test
- manual testing:
  - changed telemetry to include bad data that won't serialize: float value in integer field
  - changed telemetry to flush very every second
  - set telemetry to write to a local API host
  - ran the node with telemetry enabled
  - used 'workers:status' to see telemetry jobs getting stuck and other jobs filling the queue once all workers were stuck

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
