### PR TITLE
Add annotation to test report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,5 +174,5 @@ jobs:
         run: |
           influx config create --config-name ghaction --host-url $INFLUX_URL --org $INFLUX_ORG --token $INFLUX_TOKEN --active
           for f in ironfish/test-reports/*.perf.csv; do 
-            influx write --bucket ironfish-telemetry-mainnet --format=csv --file $f
+            influx write --bucket ironfish-telemetry-mainnet --token INFLUX_TOKEN --format=csv --file $f
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,8 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -157,3 +159,9 @@ jobs:
         with:
           name: perf-test-report
           path: ironfish/test-reports/*.perf.csv
+
+      - name: Setup InfluxDB
+        uses: influxdata/influxdb-action@v3
+        with:
+          influxdb_version: 2.6.0
+          influxdb_start: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,5 +174,5 @@ jobs:
         run: |
           influx config create --config-name ghaction --host-url $INFLUX_URL --org $INFLUX_ORG --token $INFLUX_TOKEN --active
           for f in ironfish/test-reports/*.perf.csv; do 
-            influx write --token $INFLUX_TOKEN --bucket ironfish-telemetry-mainnet --format=csv --file $f
+            influx write --bucket ironfish-telemetry-mainnet --format=csv --file $f
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,5 +174,5 @@ jobs:
         run: |
           influx config create --config-name ghaction --host-url $INFLUX_URL --org $INFLUX_ORG --token $INFLUX_TOKEN --active
           for f in ironfish/test-reports/*.perf.csv; do 
-            influx write --bucket ironfish-telemetry-mainnet --token INFLUX_TOKEN --format=csv --file $f
+            influx write --bucket ironfish-telemetry-mainnet --token $INFLUX_TOKEN --format=csv --file $f
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,3 +165,14 @@ jobs:
         with:
           influxdb_version: 2.6.0
           influxdb_start: false
+      
+      - name: Import to InfluxDB
+        env:
+          INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+          INFLUX_ORG: 'fdcfe96f6c31245a'
+          INFLUX_URL: 'https://us-east-1-1.aws.cloud2.influxdata.com'
+        run: |
+          influx config create --config-name ghaction --host-url $INFLUX_URL --org $INFLUX_ORG --token $INFLUX_TOKEN --active
+          for f in ironfish/test-reports/*.perf.csv; do 
+            influx write --token $INFLUX_TOKEN --bucket ironfish-telemetry-mainnet --format=csv --file $f
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # testing
 **/coverage
 testdbs
+**/test-reports
 
 # production
 **/build

--- a/ironfish/jest.setup.env.js
+++ b/ironfish/jest.setup.env.js
@@ -35,5 +35,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   consola.pause()
-  global.console = require('console')
+  if (!process.env.GENERATE_TEST_REPORT) {
+    global.console = require('console')
+  }
 })

--- a/ironfish/jest.setup.env.js
+++ b/ironfish/jest.setup.env.js
@@ -35,4 +35,5 @@ beforeAll(() => {
 
 beforeEach(() => {
   consola.pause()
+  global.console = require('console')
 })

--- a/ironfish/jest.setup.env.js
+++ b/ironfish/jest.setup.env.js
@@ -35,7 +35,4 @@ beforeAll(() => {
 
 beforeEach(() => {
   consola.pause()
-  if (!process.env.GENERATE_TEST_REPORT) {
-    global.console = require('console')
-  }
 })

--- a/ironfish/src/blockchain/blockchain.test.perf.ts
+++ b/ironfish/src/blockchain/blockchain.test.perf.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* eslint-disable no-console */
 /* eslint-disable jest/expect-expect */
+
 import { Asset } from '@ironfish/rust-nodejs'
 import _ from 'lodash'
 import { Assert } from '../assert'
@@ -14,6 +14,7 @@ import {
   useAccountFixture,
   useBlockWithTx,
   useMinerBlockFixture,
+  writeTestReport,
 } from '../testUtilities'
 import { MathUtils, UnwrapPromise } from '../utils'
 
@@ -174,28 +175,30 @@ describe('Blockchain', () => {
   }
 
   function printResults(result: UnwrapPromise<ReturnType<typeof runTest>>): void {
-    if (process.env.GENERATE_TEST_REPORT) {
-      console.log(
-        `Total Test Average: ${MathUtils.arrayAverage(result.all).toFixed(2)}` +
-          `,Insert blocks linear: ${MathUtils.arrayAverage(result.add).toFixed(2)}` +
-          `,Insert blocks on fork: ${MathUtils.arrayAverage(result.fork).toFixed(2)}` +
-          `,Add head rewind fork blocks: ${MathUtils.arrayAverage(result.rewind).toFixed(2)}`,
-      )
-    } else {
-      console.info(
-        `[TEST RESULTS: Times Ran: ${result.testCount}, Fork Length: ${result.forkLength}]` +
-          `\nTotal Test Average: ${MathUtils.arrayAverage(result.all).toFixed(2)}ms` +
-          `\nInsert ${result.forkLength - 1} blocks linear: ${MathUtils.arrayAverage(
-            result.add,
-          ).toFixed(2)}ms` +
-          `\nInsert ${result.forkLength - 1} blocks on fork: ${MathUtils.arrayAverage(
-            result.fork,
-          ).toFixed(2)}ms` +
-          `\nAdd head rewind fork blocks: ${MathUtils.arrayAverage(result.rewind).toFixed(
-            2,
-          )}ms`,
-      )
-    }
+    writeTestReport(
+      new Map([
+        ['TotalTestAverage', `${MathUtils.arrayAverage(result.all).toFixed(2)}`],
+        ['InsertBlocksLinear', `${MathUtils.arrayAverage(result.add).toFixed(2)}`],
+        ['InsertBlocksOnFork', `${MathUtils.arrayAverage(result.fork).toFixed(2)}`],
+        ['AddHeadRewindForkBlocks', `${MathUtils.arrayAverage(result.rewind).toFixed(2)}`],
+      ]),
+      new Map([
+        ['Total Test Average', `${MathUtils.arrayAverage(result.all).toFixed(2)}ms`],
+        [
+          `Insert ${result.forkLength - 1} blocks linear`,
+          `${MathUtils.arrayAverage(result.add).toFixed(2)}ms`,
+        ],
+        [
+          `Insert ${result.forkLength - 1} blocks on fork`,
+          `${MathUtils.arrayAverage(result.fork).toFixed(2)}ms`,
+        ],
+        [
+          'Add head rewind fork blocks',
+          `${MathUtils.arrayAverage(result.rewind).toFixed(2)}ms`,
+        ],
+      ]),
+      `Times Ran: ${result.testCount}, Fork Length: ${result.forkLength}`,
+    )
   }
 })
 

--- a/ironfish/src/mining/manager.test.perf.ts
+++ b/ironfish/src/mining/manager.test.perf.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* eslint-disable no-console */
 import { Asset } from '@ironfish/rust-nodejs'
 import { Assert } from '../assert'
 import { Block, Transaction } from '../primitives'
@@ -11,6 +10,7 @@ import {
   useAccountFixture,
   useMinerBlockFixture,
   useTxFixture,
+  writeTestReport,
 } from '../testUtilities'
 import { createRawTransaction } from '../testUtilities/helpers/transaction'
 import { BenchUtils } from '../utils'
@@ -84,14 +84,11 @@ describe('MiningManager', () => {
   }
 
   function printResults(results: Results) {
-    if (process.env.GENERATE_TEST_REPORT) {
-      console.log(`Elapsed: ${results.elapsed.toLocaleString()}`)
-    } else {
-      console.info(
-        `[TEST RESULTS: Mempool size: ${results.mempoolSize}, Transactions count: ${results.numTransactions}]` +
-          `\nElapsed: ${results.elapsed.toLocaleString()} milliseconds`,
-      )
-    }
+    writeTestReport(
+      new Map([['elapsed', `${results.elapsed}`]]),
+      new Map([['Elapsed', `${results.elapsed.toLocaleString()} milliseconds`]]),
+      `Mempool size: ${results.mempoolSize}, Transactions count: ${results.numTransactions}`,
+    )
   }
 
   async function runTest(

--- a/ironfish/src/primitives/transaction.test.perf.ts
+++ b/ironfish/src/primitives/transaction.test.perf.ts
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* eslint-disable no-console */
 import { Asset } from '@ironfish/rust-nodejs'
 import { Assert } from '../assert'
+import { writeTestReport } from '../testUtilities'
 import { useAccountFixture, useMinerBlockFixture } from '../testUtilities/fixtures'
 import { createRawTransaction } from '../testUtilities/helpers/transaction'
 import { createNodeTest } from '../testUtilities/nodeTest'
@@ -50,14 +50,11 @@ describe('Transaction', () => {
   }
 
   function printResults(results: Results) {
-    if (process.env.GENERATE_TEST_REPORT) {
-      console.log(`Elapsed: ${results.elapsed.toLocaleString()}`)
-    } else {
-      console.info(
-        `[TEST RESULTS: Spends: ${results.spends}, Outputs: ${results.outputs}]` +
-          `\nElapsed: ${results.elapsed.toLocaleString()} milliseconds`,
-      )
-    }
+    writeTestReport(
+      new Map([['elapsed', `${results.elapsed}`]]),
+      new Map([['Elapsed', `${results.elapsed.toLocaleString()} milliseconds`]]),
+      `Spends: ${results.spends}, Outputs: ${results.outputs}`,
+    )
   }
 
   async function runTest(

--- a/ironfish/src/testReporter/testReporter.ts
+++ b/ironfish/src/testReporter/testReporter.ts
@@ -66,8 +66,7 @@ export default class TestReporter implements CustomReporter {
         const entry = input.split(':')
         const value = entry[1]
         if (value) {
-          const trim = value.replace(/[^\d.-]/g, '')
-          if (trim.includes('.')) {
+          if (value.includes('.')) {
             datatypeHeader = datatypeHeader.concat(',double')
           } else {
             datatypeHeader = datatypeHeader.concat(',long')

--- a/ironfish/src/testReporter/testReporter.ts
+++ b/ironfish/src/testReporter/testReporter.ts
@@ -57,7 +57,7 @@ export default class TestReporter implements CustomReporter {
     const consoleOutputs = testResult.console?.filter((output) => output.type === 'log')
 
     // annotation headers for influx data
-    let datatypeHeader = '#datatype,measurement,field,field,time'
+    let datatypeHeader = '#datatype,measurement,string,string'
     let groupHeader = '#group,false,false,false'
     let defaultHeader = '#default,,,'
     if (consoleOutputs && consoleOutputs[0]) {
@@ -78,20 +78,19 @@ export default class TestReporter implements CustomReporter {
       })
     }
 
-    writeStream.write(datatypeHeader + '\n')
-    writeStream.write(groupHeader + '\n')
-    writeStream.write(defaultHeader + '\n')
+    writeStream.write(datatypeHeader + ',time\n')
+    writeStream.write(groupHeader + ',false\n')
+    writeStream.write(defaultHeader + ',\n')
 
     const stream = format({ headers: true })
     stream.pipe(writeStream)
 
     testResult.testResults.forEach((result, i) => {
       const row: Record<string, string> = {
+        '': '',
         measurement: 'perf-test',
         file: testFileName.split('.')[0],
         name: result.title,
-        duration: String(result.duration),
-        time: String(Date.now()),
       }
 
       if (consoleOutputs && consoleOutputs[i]) {
@@ -105,6 +104,8 @@ export default class TestReporter implements CustomReporter {
           }
         })
       }
+      row['timestamp'] = String(Date.now())
+
       stream.write(row)
     })
     writeStream.end()

--- a/ironfish/src/testReporter/testReporter.ts
+++ b/ironfish/src/testReporter/testReporter.ts
@@ -72,7 +72,7 @@ export default class TestReporter implements CustomReporter {
           } else {
             datatypeHeader = datatypeHeader.concat(',long')
           }
-          groupHeader = groupHeader.concat(',true')
+          groupHeader = groupHeader.concat(',false')
           defaultHeader = defaultHeader.concat(',')
         }
       })
@@ -105,10 +105,10 @@ export default class TestReporter implements CustomReporter {
           const value = entry[1]
           if (key && value) {
             if (!isValueSet) {
-              row['_value'] = value.replace(/[^\d.-]/g, '')
+              row['_value'] = value
               isValueSet = true
             } else {
-              row[key.trim().replace(/\s/g, '').toLowerCase()] = value.replace(/[^\d.-]/g, '')
+              row[key.trim().replace(/\s/g, '').toLowerCase()] = value
             }
           }
         })

--- a/ironfish/src/testReporter/testReporter.ts
+++ b/ironfish/src/testReporter/testReporter.ts
@@ -57,9 +57,9 @@ export default class TestReporter implements CustomReporter {
     const consoleOutputs = testResult.console?.filter((output) => output.type === 'log')
 
     // annotation headers for influx data
-    let datatypeHeader = '#datatype,string,long,string,string,string,dateTime:RFC3339'
-    let groupHeader = '#group,false,false,true,true,true,false'
-    let defaultHeader = '#default,_result,,,,,'
+    let datatypeHeader = '#datatype,measurement,tag,tag,dateTime:RFC3339'
+    let groupHeader = '#group,true,true,true,false'
+    let defaultHeader = '#default,,,,'
     if (consoleOutputs && consoleOutputs[0]) {
       const entries = consoleOutputs[0].message.split(',')
       entries.forEach((input) => {
@@ -87,29 +87,19 @@ export default class TestReporter implements CustomReporter {
     testResult.testResults.forEach((result, i) => {
       const row: Record<string, string> = {
         '': '',
-        result: '_result',
-        table: '0',
         _measurement: 'perf_test',
         testsuite: testFileName.split('.')[0],
-        _field: result.title,
+        testname: result.title,
         _time: new Date(Date.now()).toISOString(),
       }
 
       if (consoleOutputs && consoleOutputs[i]) {
         const entries = consoleOutputs[i].message.split(',')
-        let isValueSet = false
         entries.forEach((input) => {
           const entry = input.split(':')
           const key = entry[0]
           const value = entry[1]
-          if (key && value) {
-            if (!isValueSet) {
-              row['_value'] = value
-              isValueSet = true
-            } else {
-              row[key.trim().replace(/\s/g, '').toLowerCase()] = value
-            }
-          }
+          row[key.trim().replace(/\s/g, '').toLowerCase()] = value
         })
       }
       stream.write(row)

--- a/ironfish/src/testReporter/testReporter.ts
+++ b/ironfish/src/testReporter/testReporter.ts
@@ -72,7 +72,7 @@ export default class TestReporter implements CustomReporter {
           } else {
             datatypeHeader = datatypeHeader.concat(',long')
           }
-          groupHeader = groupHeader.concat(',false')
+          groupHeader = groupHeader.concat(',true')
           defaultHeader = defaultHeader.concat(',')
         }
       })

--- a/ironfish/src/testUtilities/utils.ts
+++ b/ironfish/src/testUtilities/utils.ts
@@ -27,7 +27,7 @@ export function writeTestReport(
 ): void {
   if (process.env.GENERATE_TEST_REPORT) {
     let row = ''
-    csvReport.forEach((v, k) => (row = row.concat(`${k}: ${v},`)))
+    csvReport.forEach((v, k) => (row = row.concat(`${k}:${v},`)))
     console.log(row.substring(0, row.length - 1))
   } else {
     console.info(`[TEST RESULTS: ${testName}]`)

--- a/ironfish/src/testUtilities/utils.ts
+++ b/ironfish/src/testUtilities/utils.ts
@@ -1,6 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* eslint-disable no-console */
+
 import path from 'path'
 import { v4 as uuid } from 'uuid'
 
@@ -15,6 +18,21 @@ export function getCurrentTestPath(): string {
 
 export function getUniqueTestDataDir(): string {
   return path.join(TEST_DATA_DIR, uuid())
+}
+
+export function writeTestReport(
+  csvReport: Map<string, string>,
+  consoleReport: Map<string, string>,
+  testName: string,
+): void {
+  if (process.env.GENERATE_TEST_REPORT) {
+    let row = ''
+    csvReport.forEach((v, k) => (row = row.concat(`${k}: ${v},`)))
+    console.log(row.substring(0, row.length - 1))
+  } else {
+    console.info(`[TEST RESULTS: ${testName}]`)
+    consoleReport.forEach((v, k) => console.info(`${k}: ${v}`))
+  }
 }
 
 /**

--- a/ironfish/src/utils/bench.ts
+++ b/ironfish/src/utils/bench.ts
@@ -96,7 +96,7 @@ function endSegment(start: Segment): SegmentResults {
 function renderSegment(segment: SegmentResults, title = 'Benchmark', delimiter = ', '): string {
   const result = []
 
-  result.push(`Time: ${TimeUtils.renderSpan(segment.time)}`)
+  result.push(`Timespan: ${TimeUtils.renderSpan(segment.time)}`)
   result.push(`Heap: ${FileUtils.formatMemorySize(segment.heap)}`)
   result.push(`RSS: ${FileUtils.formatMemorySize(segment.rss)}`)
   result.push(`Mem: ${FileUtils.formatMemorySize(segment.mem)}`)

--- a/ironfish/src/workerPool/tasks/workerMessages.test.perf.ts
+++ b/ironfish/src/workerPool/tasks/workerMessages.test.perf.ts
@@ -5,7 +5,12 @@
 /* eslint-disable no-console */
 
 import { Assert } from '../../assert'
-import { createNodeTest, useAccountFixture, useBlockWithTxs } from '../../testUtilities'
+import {
+  createNodeTest,
+  useAccountFixture,
+  useBlockWithTxs,
+  writeTestReport,
+} from '../../testUtilities'
 import { BenchUtils, CurrencyUtils, PromiseUtils, SegmentResults } from '../../utils'
 import { Account } from '../../wallet'
 import { CreateMinersFeeRequest } from './createMinersFee'
@@ -104,23 +109,25 @@ describe('WorkerMessages', () => {
     }
     const average = total / runs.length
 
-    if (process.env.GENERATE_TEST_REPORT) {
-      console.log(
-        `Total time: ${total},` +
-          `Fastest runtime: ${min},` +
-          `Slowest runtime: ${max},` +
-          `Average runtime: ${average},` +
-          BenchUtils.renderSegment(segment, ''),
-      )
-    } else {
-      console.info(
-        `[TEST RESULTS: Message: ${testName}, Iterations: ${TEST_ITERATIONS}]` +
-          `\nTotal elapsed: ${total} milliseconds` +
-          `\nFastest: ${min} milliseconds` +
-          `\nSlowest: ${max} milliseconds` +
-          `\nAverage: ${average} milliseconds`,
-      )
-      console.info(BenchUtils.renderSegment(segment))
-    }
+    writeTestReport(
+      new Map([
+        ['elapsed', `${total}`],
+        ['fastestruntime', `${min}`],
+        ['slowestruntime', `${max}`],
+        ['averageruntime', `${average}`],
+        ['timespan', `${segment.time}`],
+        ['rss', `${segment.rss}`],
+        ['mem', `${segment.mem}`],
+        ['heap', `${segment.heap}`],
+      ]),
+      new Map([
+        ['Total elapsed', `${total} milliseconds`],
+        ['Fastest runtime', `${min} milliseconds`],
+        ['Slowest runtime', `${max} milliseconds`],
+        ['Average runtime', `${average} milliseconds`],
+      ]),
+      `Message: ${testName}, Iterations: ${TEST_ITERATIONS}`,
+    )
+    console.info(BenchUtils.renderSegment(segment))
   }
 })


### PR DESCRIPTION
## Summary
- Add influx csv annotation to test report, this makes the data format compatible with influx rules, see https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/?_gl=1*9jmu3q*_ga*MTI2Nzk0MjkwMS4xNjg0ODc2Mjc1*_ga_CNWQ54SDD8*MTY4NzgwMjQ3Ny42MC4xLjE2ODc4MDg0NTEuNTMuMC4w
- Add influx set up in github CI, upload test reports to Influx
- Wrap the console log in perf test in a util function 
- Jest test reporter makes the console log in verbose form, set global console before each test in jest config

## Testing Plan
yarn test:perf
yarn test:perf:report

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@danield9tqh @mat-if 