### PR TITLE
adds context to telemetry TypeErrors

### DIFF
--- a/ironfish/src/workerPool/tasks/submitTelemetry.ts
+++ b/ironfish/src/workerPool/tasks/submitTelemetry.ts
@@ -35,20 +35,32 @@ export class SubmitTelemetryRequest extends WorkerMessage {
       bw.writeU64(fields.length)
       for (const field of fields) {
         bw.writeVarString(field.name, 'utf8')
-        bw.writeVarString(field.type, 'utf8')
-        switch (field.type) {
-          case 'string':
-            bw.writeVarString(field.value, 'utf8')
-            break
-          case 'boolean':
-            bw.writeU8(Number(field.value))
-            break
-          case 'float':
-            bw.writeDouble(field.value)
-            break
-          case 'integer':
-            bw.writeU64(field.value)
-            break
+        try {
+          bw.writeVarString(field.type, 'utf8')
+          switch (field.type) {
+            case 'string':
+              bw.writeVarString(field.value, 'utf8')
+              break
+            case 'boolean':
+              bw.writeU8(Number(field.value))
+              break
+            case 'float':
+              bw.writeDouble(field.value)
+              break
+            case 'integer':
+              bw.writeU64(Math.round(field.value))
+              break
+          }
+        } catch (e: unknown) {
+          if (e instanceof TypeError) {
+            throw new TypeError(
+              `Failed to serialize field ${field.name}: expected value of ${
+                field.type
+              } type but received ${field.value.toString()}`,
+            )
+          }
+
+          throw e
         }
       }
 


### PR DESCRIPTION
## Summary

some node runners have seen telemetry jobs failing when a telemtry attempts to serialize a field that's expected to be an integer.

rounds numeric values for integer fields.

adds additional details to error messages for TypeErrors when serializing telemetry fields.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
