### PR TITLE
Move perf test to separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,13 +153,6 @@ jobs:
             exit 1
           fi
 
-      - name: Archive test results
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: perf-test-report
-          path: ironfish/test-reports/*.perf.csv
-
       - name: Setup InfluxDB
         uses: influxdata/influxdb-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,6 @@ on:
     branches:
       - master
 
-permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-
 jobs:
   lint:
     name: Lint
@@ -118,54 +113,3 @@ jobs:
       - name: Upload coverage
         if: github.repository == 'iron-fish/ironfish'
         run: CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} ROOT_PATH=$GITHUB_WORKSPACE/ yarn coverage:upload
-
-  testperf:
-    name: Perf Tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.12.1'
-          cache: 'yarn'
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: nodejs
-
-      - name: Install packages
-        run: yarn --non-interactive --frozen-lockfile
-
-      - name: Run perf tests
-        run: yarn test:perf:report
-
-      - name: Check for missing fixtures
-        run: |
-          if [[ $(git status | grep fixture) ]]; then
-            echo "New test fixtures have not been checked in, please check them in."
-            exit 1
-          fi
-
-      - name: Setup InfluxDB
-        uses: influxdata/influxdb-action@v3
-        with:
-          influxdb_version: 2.6.0
-          influxdb_start: false
-      
-      - name: Import to InfluxDB
-        env:
-          INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
-          INFLUX_ORG: 'fdcfe96f6c31245a'
-          INFLUX_URL: 'https://us-east-1-1.aws.cloud2.influxdata.com'
-        run: |
-          influx config create --config-name ghaction --host-url $INFLUX_URL --org $INFLUX_ORG --token $INFLUX_TOKEN --active
-          for f in ironfish/test-reports/*.perf.csv; do 
-            influx write --bucket ironfish-telemetry-mainnet --token $INFLUX_TOKEN --format=csv --file $f
-          done

--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -1,18 +1,14 @@
 name: Performance Tests
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
-      - master
       - staging
 
 permissions:
   checks: write
   contents: write
-  
+
 jobs:
   testperf:
     name: Perf Tests

--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -1,0 +1,66 @@
+name: Performance Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+      - staging
+
+permissions:
+  checks: write
+  contents: write
+  
+jobs:
+  testperf:
+    name: Perf Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.12.1'
+          cache: 'yarn'
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nodejs
+
+      - name: Install packages
+        run: yarn --non-interactive --frozen-lockfile
+
+      - name: Run perf tests
+        run: yarn test:perf:report
+
+      - name: Check for missing fixtures
+        run: |
+          if [[ $(git status | grep fixture) ]]; then
+            echo "New test fixtures have not been checked in, please check them in."
+            exit 1
+          fi
+
+      - name: Setup InfluxDB
+        uses: influxdata/influxdb-action@v3
+        with:
+          influxdb_version: 2.6.0
+          influxdb_start: false
+      
+      - name: Import to InfluxDB
+        env:
+          INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+          INFLUX_ORG: 'fdcfe96f6c31245a'
+          INFLUX_URL: 'https://us-east-1-1.aws.cloud2.influxdata.com'
+        run: |
+          influx config create --config-name ghaction --host-url $INFLUX_URL --org $INFLUX_ORG --token $INFLUX_TOKEN --active
+          for f in ironfish/test-reports/*.perf.csv; do 
+            influx write --bucket ironfish-telemetry-mainnet --token $INFLUX_TOKEN --format=csv --file $f
+          done


### PR DESCRIPTION
## Summary
Move perf test to separate workflow, so it will only trigger on :
push to staging and master
PR on master

## Testing Plan
github workflow

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@danield9tqh 