### PR TITLE
adds event/onReorganizeChain RPC

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -126,6 +126,10 @@ export class Blockchain {
   onDisconnectBlock = new Event<[block: Block, tx?: IDatabaseTransaction]>()
   // When ever a block is added to a fork
   onForkBlock = new Event<[block: Block, tx?: IDatabaseTransaction]>()
+  // When ever the blockchain is reorganized
+  onReorganizeChain = new Event<
+    [oldHead: BlockHeader, newHead: BlockHeader, fork: BlockHeader]
+  >()
 
   private _head: BlockHeader | null = null
 
@@ -840,6 +844,8 @@ export class Blockchain {
         ` new: ${HashUtils.renderHash(newHead.hash)} (${newHead.sequence}),` +
         ` fork: ${HashUtils.renderHash(fork.hash)} (${fork.sequence})`,
     )
+
+    this.onReorganizeChain.emit(oldHead, newHead, fork)
   }
 
   addOrphan(header: BlockHeader): void {

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -127,9 +127,7 @@ export class Blockchain {
   // When ever a block is added to a fork
   onForkBlock = new Event<[block: Block, tx?: IDatabaseTransaction]>()
   // When ever the blockchain is reorganized
-  onReorganizeChain = new Event<
-    [oldHead: BlockHeader, newHead: BlockHeader, fork: BlockHeader]
-  >()
+  onReorganize = new Event<[oldHead: BlockHeader, newHead: BlockHeader, fork: BlockHeader]>()
 
   private _head: BlockHeader | null = null
 
@@ -845,7 +843,7 @@ export class Blockchain {
         ` fork: ${HashUtils.renderHash(fork.hash)} (${fork.sequence})`,
     )
 
-    this.onReorganizeChain.emit(oldHead, newHead, fork)
+    this.onReorganize.emit(oldHead, newHead, fork)
   }
 
   addOrphan(header: BlockHeader): void {

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -97,6 +97,8 @@ import {
   MintAssetResponse,
   OnGossipRequest,
   OnGossipResponse,
+  OnReorganizeChainRequest,
+  OnReorganizeChainResponse,
   OnTransactionGossipRequest,
   OnTransactionGossipResponse,
   PostTransactionRequest,
@@ -511,6 +513,15 @@ export abstract class RpcClient {
       params: OnGossipRequest = undefined,
     ): RpcResponse<void, OnGossipResponse> => {
       return this.request<void, OnGossipResponse>(`${ApiNamespace.event}/onGossip`, params)
+    },
+
+    onReorganizeChainStream: (
+      params: OnReorganizeChainRequest = undefined,
+    ): RpcResponse<void, OnReorganizeChainResponse> => {
+      return this.request<void, OnReorganizeChainResponse>(
+        `${ApiNamespace.event}/onReorganizeChain`,
+        params,
+      )
     },
 
     onTransactionGossipStream: (

--- a/ironfish/src/rpc/routes/event/index.ts
+++ b/ironfish/src/rpc/routes/event/index.ts
@@ -3,5 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export * from './onGossip'
+export * from './onReorganizeChain'
 export * from './onTransactionGossip'
 export { RpcBlockHeader } from './types'

--- a/ironfish/src/rpc/routes/event/onReorganizeChain.ts
+++ b/ironfish/src/rpc/routes/event/onReorganizeChain.ts
@@ -36,10 +36,10 @@ router.register<typeof OnReorganizeChainRequestSchema, OnReorganizeChainResponse
       })
     }
 
-    node.chain.onReorganizeChain.on(onReorganizeChain)
+    node.chain.onReorganize.on(onReorganizeChain)
 
     request.onClose.on(() => {
-      node.chain.onReorganizeChain.off(onReorganizeChain)
+      node.chain.onReorganize.off(onReorganizeChain)
     })
   },
 )

--- a/ironfish/src/rpc/routes/event/onReorganizeChain.ts
+++ b/ironfish/src/rpc/routes/event/onReorganizeChain.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { BlockHeader } from '../../../primitives'
+import { ApiNamespace, router } from '../router'
+import { RpcBlockHeader, RpcBlockHeaderSchema, serializeRpcBlockHeader } from './types'
+
+export type OnReorganizeChainRequest = undefined
+export type OnReorganizeChainResponse = {
+  oldHead: RpcBlockHeader
+  newHead: RpcBlockHeader
+  fork: RpcBlockHeader
+}
+export const OnReorganizeChainRequestSchema: yup.MixedSchema<OnReorganizeChainRequest> = yup
+  .mixed()
+  .oneOf([undefined] as const)
+
+export const OnReorganizeChainResponseSchema: yup.ObjectSchema<OnReorganizeChainResponse> = yup
+  .object({
+    oldHead: RpcBlockHeaderSchema,
+    newHead: RpcBlockHeaderSchema,
+    fork: RpcBlockHeaderSchema,
+  })
+  .defined()
+
+router.register<typeof OnReorganizeChainRequestSchema, OnReorganizeChainResponse>(
+  `${ApiNamespace.event}/onReorganizeChain`,
+  OnReorganizeChainRequestSchema,
+  (request, node): void => {
+    function onReorganizeChain(oldHead: BlockHeader, newHead: BlockHeader, fork: BlockHeader) {
+      request.stream({
+        oldHead: serializeRpcBlockHeader(oldHead),
+        newHead: serializeRpcBlockHeader(newHead),
+        fork: serializeRpcBlockHeader(fork),
+      })
+    }
+
+    node.chain.onReorganizeChain.on(onReorganizeChain)
+
+    request.onClose.on(() => {
+      node.chain.onReorganizeChain.off(onReorganizeChain)
+    })
+  },
+)


### PR DESCRIPTION
## Summary

streams the block headers for the old head, the new head, and header for the point of the fork: the block at which the two forks diverged

adds an event to the blockchain reorganizeChain method to emit these headers on each reorg

supports monitoring chain reorgs over time

## Testing Plan

manual testing:
- ran two nodes with two miners to create forks
- connected to RPC endpoint and logged events

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
