### PR TITLE
Initial implementation of the AssetsVerifier system

### DIFF
--- a/ironfish/src/assets/assetsVerificationApi.test.ts
+++ b/ironfish/src/assets/assetsVerificationApi.test.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import nock from 'nock'
+import { AssetsVerificationApi } from './assetsVerificationApi'
+
+describe('Assets Verification API Client', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  afterEach(() => {
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(nock.pendingMocks()).toHaveLength(0)
+  })
+
+  describe('getVerifiedAssets', () => {
+    it('should return verified assets', async () => {
+      nock('https://test')
+        .get('/assets/verified')
+        .reply(200, {
+          data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+        })
+
+      const api = new AssetsVerificationApi({
+        url: 'https://test/assets/verified',
+      })
+      const verifiedAssets = await api.getVerifiedAssets()
+
+      expect(verifiedAssets['assetIds']).toStrictEqual(new Set(['0123', 'abcd']))
+      expect(verifiedAssets.isVerified('0123')).toBe(true)
+      expect(verifiedAssets.isVerified('abcd')).toBe(true)
+      expect(verifiedAssets.isVerified('4567')).toBe(false)
+      expect(verifiedAssets.isVerified('89ef')).toBe(false)
+    })
+
+    it('should ignore extra fields in responses', async () => {
+      nock('https://test')
+        .get('/assets/verified')
+        .reply(200, {
+          data: [
+            { identifier: '0123', extra: 'should be ignored' },
+            { identifier: 'abcd', extra: 'should be ignored' },
+          ],
+          extra: 'should be ignored',
+        })
+
+      const api = new AssetsVerificationApi({
+        url: 'https://test/assets/verified',
+      })
+      const verifiedAssets = await api.getVerifiedAssets()
+
+      expect(verifiedAssets['assetIds']).toStrictEqual(new Set(['0123', 'abcd']))
+    })
+
+    it('should refresh verified assets', async () => {
+      nock('https://test')
+        .get('/assets/verified')
+        .reply(200, {
+          data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+        })
+        .get('/assets/verified')
+        .reply(200, {
+          data: [{ identifier: '4567' }, { identifier: '0123' }],
+        })
+
+      const api = new AssetsVerificationApi({
+        url: 'https://test/assets/verified',
+      })
+      const verifiedAssets = await api.getVerifiedAssets()
+
+      expect(verifiedAssets['assetIds']).toStrictEqual(new Set(['0123', 'abcd']))
+
+      await api.refreshVerifiedAssets(verifiedAssets)
+
+      expect(verifiedAssets['assetIds']).toStrictEqual(new Set(['0123', '4567']))
+    })
+
+    it('should optimize refreshing of verified assets with If-Modified-Since', async () => {
+      const lastModified = new Date().toUTCString()
+      nock('https://test')
+        .get('/assets/verified')
+        .reply(
+          200,
+          {
+            data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+          },
+          {
+            'last-modified': lastModified,
+          },
+        )
+      nock('https://test')
+        .matchHeader('if-modified-since', lastModified)
+        .get('/assets/verified')
+        .reply(304)
+
+      const api = new AssetsVerificationApi({
+        url: 'https://test/assets/verified',
+      })
+      const verifiedAssets = await api.getVerifiedAssets()
+
+      expect(verifiedAssets['assetIds']).toStrictEqual(new Set(['0123', 'abcd']))
+
+      await api.refreshVerifiedAssets(verifiedAssets)
+
+      expect(verifiedAssets['assetIds']).toStrictEqual(new Set(['0123', 'abcd']))
+    })
+
+    it('should propagate HTTP errors', async () => {
+      nock('https://test').get('/assets/verified').reply(500)
+
+      const api = new AssetsVerificationApi({
+        url: 'https://test/assets/verified',
+      })
+      await expect(api.getVerifiedAssets()).rejects.toThrow(
+        'Request failed with status code 500',
+      )
+    })
+
+    it('should respect timeouts while establishing connections', async () => {
+      nock('https://test')
+        .get('/assets/verified')
+        .delayConnection(2000)
+        .reply(200, {
+          data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+        })
+
+      const api = new AssetsVerificationApi({
+        url: 'https://test/assets/verified',
+        timeout: 1000,
+      })
+      await expect(api.getVerifiedAssets()).rejects.toThrow('timeout of 1000ms exceeded')
+    })
+
+    it('should respect timeouts while waiting for responses', async () => {
+      nock('https://test')
+        .get('/assets/verified')
+        .delay(2000)
+        .reply(200, {
+          data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+        })
+
+      const api = new AssetsVerificationApi({
+        url: 'https://test/assets/verified',
+        timeout: 1000,
+      })
+      await expect(api.getVerifiedAssets()).rejects.toThrow('timeout of 1000ms exceeded')
+    })
+  })
+})

--- a/ironfish/src/assets/assetsVerificationApi.ts
+++ b/ironfish/src/assets/assetsVerificationApi.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import axios, { AxiosError } from 'axios'
+
+type GetVerifiedAssetsResponse = {
+  data: Array<{ identifier: string }>
+}
+
+type GetVerifiedAssetsRequestHeaders = {
+  'if-modified-since'?: string
+}
+
+type GetVerifiedAssetsResponseHeaders = {
+  'last-modified'?: string
+}
+
+export class VerifiedAssets {
+  private readonly assetIds: Set<string> = new Set()
+  private lastModified?: string
+
+  isVerified(assetId: Buffer | string): boolean {
+    if (!(typeof assetId === 'string')) {
+      assetId = assetId.toString('hex')
+    }
+    return this.assetIds.has(assetId)
+  }
+}
+
+export class AssetsVerificationApi {
+  private readonly url: string
+  private readonly timeout: number
+
+  constructor(options?: { url?: string; timeout?: number }) {
+    this.url = options?.url ?? 'https://api.ironfish.network/assets?verified=true'
+    this.timeout = options?.timeout ?? 30 * 1000 // 30 seconds
+  }
+
+  async getVerifiedAssets(): Promise<VerifiedAssets> {
+    const verifiedAssets = new VerifiedAssets()
+    await this.refreshVerifiedAssets(verifiedAssets)
+    return verifiedAssets
+  }
+
+  refreshVerifiedAssets(verifiedAssets: VerifiedAssets): Promise<void> {
+    const headers: GetVerifiedAssetsRequestHeaders = {}
+    if (verifiedAssets['lastModified']) {
+      headers['if-modified-since'] = verifiedAssets['lastModified']
+    }
+    return axios
+      .get<GetVerifiedAssetsResponse>(this.url, {
+        headers: headers,
+        timeout: this.timeout,
+      })
+      .then(
+        (response: {
+          data: GetVerifiedAssetsResponse
+          headers: GetVerifiedAssetsResponseHeaders
+        }) => {
+          verifiedAssets['assetIds'].clear()
+          response.data.data.forEach(({ identifier }) => {
+            return verifiedAssets['assetIds'].add(identifier)
+          })
+          verifiedAssets['lastModified'] = response.headers['last-modified']
+        },
+      )
+      .catch((error: AxiosError) => {
+        if (error.response?.status === 304) {
+          return
+        }
+        throw error
+      })
+  }
+}

--- a/ironfish/src/assets/assetsVerifier.test.ts
+++ b/ironfish/src/assets/assetsVerifier.test.ts
@@ -1,0 +1,258 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import nock from 'nock'
+import { AssetsVerifier } from './assetsVerifier'
+
+/* eslint-disable jest/no-standalone-expect */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('AssetsVerifier', () => {
+  jest.useFakeTimers()
+
+  const waitForRefreshToFinish = async (refreshSpy: jest.SpyInstance) => {
+    for (const result of refreshSpy.mock.results) {
+      await result.value
+    }
+  }
+
+  beforeEach(() => {
+    nock.cleanAll()
+    jest.clearAllTimers()
+  })
+
+  afterEach(() => {
+    expect(nock.pendingMocks()).toHaveLength(0)
+  })
+
+  it('does not refresh when not started', () => {
+    const assetsVerifier = new AssetsVerifier()
+    const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
+
+    jest.runOnlyPendingTimers()
+    expect(refresh).toHaveBeenCalledTimes(0)
+  })
+
+  it('periodically refreshes once started', async () => {
+    nock('https://test')
+      .get('/assets/verified')
+      .reply(200, {
+        data: [{ identifier: '0123' }],
+      })
+      .get('/assets/verified')
+      .reply(200, {
+        data: [{ identifier: '4567' }],
+      })
+      .get('/assets/verified')
+      .reply(200, {
+        data: [{ identifier: '89ab' }],
+      })
+
+    const assetsVerifier = new AssetsVerifier({
+      apiUrl: 'https://test/assets/verified',
+    })
+    const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
+
+    expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'unknown' })
+    expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unknown' })
+    expect(assetsVerifier.verify('89ab')).toStrictEqual({ status: 'unknown' })
+
+    assetsVerifier.start()
+    expect(refresh).toHaveBeenCalledTimes(1)
+    await waitForRefreshToFinish(refresh)
+
+    expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'verified' })
+    expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unverified' })
+    expect(assetsVerifier.verify('89ab')).toStrictEqual({ status: 'unverified' })
+
+    jest.runOnlyPendingTimers()
+    expect(refresh).toHaveBeenCalledTimes(2)
+    await waitForRefreshToFinish(refresh)
+
+    expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'unverified' })
+    expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'verified' })
+    expect(assetsVerifier.verify('89ab')).toStrictEqual({ status: 'unverified' })
+
+    jest.runOnlyPendingTimers()
+    expect(refresh).toHaveBeenCalledTimes(3)
+    await waitForRefreshToFinish(refresh)
+
+    expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'unverified' })
+    expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unverified' })
+    expect(assetsVerifier.verify('89ab')).toStrictEqual({ status: 'verified' })
+  })
+
+  it('does not do any refresh after being stopped', async () => {
+    nock('https://test')
+      .get('/assets/verified')
+      .reply(200, {
+        data: [{ identifier: '0123' }],
+      })
+
+    const assetsVerifier = new AssetsVerifier({
+      apiUrl: 'https://test/assets/verified',
+    })
+    const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
+
+    assetsVerifier.start()
+    expect(refresh).toHaveBeenCalledTimes(1)
+    await waitForRefreshToFinish(refresh)
+
+    assetsVerifier.stop()
+    jest.runOnlyPendingTimers()
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves cache after being stopped', async () => {
+    nock('https://test')
+      .get('/assets/verified')
+      .reply(
+        200,
+        {
+          data: [{ identifier: '0123' }],
+        },
+        { 'last-modified': 'some-date' },
+      )
+    nock('https://test')
+      .matchHeader('if-modified-since', 'some-date')
+      .get('/assets/verified')
+      .reply(304)
+
+    const assetsVerifier = new AssetsVerifier({
+      apiUrl: 'https://test/assets/verified',
+    })
+    const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
+
+    assetsVerifier.start()
+    expect(refresh).toHaveBeenCalledTimes(1)
+    await waitForRefreshToFinish(refresh)
+
+    assetsVerifier.stop()
+    jest.runOnlyPendingTimers()
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    assetsVerifier.start()
+    expect(refresh).toHaveBeenCalledTimes(2)
+    await waitForRefreshToFinish(refresh)
+  })
+
+  describe('verify', () => {
+    it("returns 'unknown' when not started", () => {
+      const assetsVerifier = new AssetsVerifier()
+
+      expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'unknown' })
+      expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unknown' })
+    })
+
+    it("returns 'unknown' after being stopped", async () => {
+      nock('https://test')
+        .get('/assets/verified')
+        .reply(200, {
+          data: [{ identifier: '0123' }],
+        })
+
+      const assetsVerifier = new AssetsVerifier({
+        apiUrl: 'https://test/assets/verified',
+      })
+      const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
+
+      assetsVerifier.start()
+      await waitForRefreshToFinish(refresh)
+
+      expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'verified' })
+      expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unverified' })
+
+      assetsVerifier.stop()
+
+      expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'unknown' })
+      expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unknown' })
+    })
+
+    it("returns 'unknown' when the API is unreachable", async () => {
+      nock('https://test').get('/assets/verified').reply(500)
+
+      const assetsVerifier = new AssetsVerifier({
+        apiUrl: 'https://test/assets/verified',
+      })
+      const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
+      const error = jest.spyOn(assetsVerifier['logger'], 'error')
+
+      assetsVerifier.start()
+      await waitForRefreshToFinish(refresh)
+
+      expect(error).toHaveBeenCalledWith(
+        'Error while fetching verified assets: Request failed with status code 500',
+      )
+      expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'unknown' })
+      expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unknown' })
+    })
+
+    it("returns 'verified' when the API lists the given asset", async () => {
+      nock('https://test')
+        .get('/assets/verified')
+        .reply(200, {
+          data: [{ identifier: '0123' }],
+        })
+
+      const assetsVerifier = new AssetsVerifier({
+        apiUrl: 'https://test/assets/verified',
+      })
+      const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
+
+      assetsVerifier.start()
+      await waitForRefreshToFinish(refresh)
+
+      expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'verified' })
+    })
+
+    it("returns 'unverified' when the API does not list the asset", async () => {
+      nock('https://test')
+        .get('/assets/verified')
+        .reply(200, {
+          data: [{ identifier: '0123' }],
+        })
+
+      const assetsVerifier = new AssetsVerifier({
+        apiUrl: 'https://test/assets/verified',
+      })
+      const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
+
+      assetsVerifier.start()
+      await waitForRefreshToFinish(refresh)
+
+      expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unverified' })
+    })
+
+    it('uses the cache when the API is unreachable', async () => {
+      nock('https://test')
+        .get('/assets/verified')
+        .reply(200, {
+          data: [{ identifier: '0123' }],
+        })
+        .get('/assets/verified')
+        .reply(500)
+
+      const assetsVerifier = new AssetsVerifier({
+        apiUrl: 'https://test/assets/verified',
+      })
+      const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
+      const error = jest.spyOn(assetsVerifier['logger'], 'error')
+
+      assetsVerifier.start()
+      await waitForRefreshToFinish(refresh)
+
+      expect(error).not.toHaveBeenCalled()
+      expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'verified' })
+      expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unverified' })
+
+      jest.runOnlyPendingTimers()
+      await waitForRefreshToFinish(refresh)
+
+      expect(error).toHaveBeenCalledWith(
+        'Error while fetching verified assets: Request failed with status code 500',
+      )
+      expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'verified' })
+      expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unverified' })
+    })
+  })
+})

--- a/ironfish/src/assets/assetsVerifier.ts
+++ b/ironfish/src/assets/assetsVerifier.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createRootLogger, Logger } from '../logger'
+import { ErrorUtils } from '../utils'
+import { SetIntervalToken } from '../utils'
+import { AssetsVerificationApi, VerifiedAssets } from './assetsVerificationApi'
+
+export type AssetVerification = {
+  status: 'verified' | 'unverified' | 'unknown'
+}
+
+export class AssetsVerifier {
+  private readonly REFRESH_INTERVAL = 6 * 60 * 60 * 1000 // 6 hours
+
+  private readonly logger: Logger
+  private readonly api: AssetsVerificationApi
+
+  private started: boolean
+  private refreshToken?: SetIntervalToken
+  private verifiedAssets?: VerifiedAssets
+
+  constructor(options?: { apiUrl?: string; logger?: Logger }) {
+    this.logger = options?.logger ?? createRootLogger()
+    this.api = new AssetsVerificationApi({ url: options?.apiUrl })
+    this.started = false
+  }
+
+  start(): void {
+    if (this.started) {
+      return
+    }
+
+    this.started = true
+    void this.refreshLoop()
+  }
+
+  stop(): void {
+    if (!this.started) {
+      return
+    }
+
+    this.started = false
+
+    if (this.refreshToken) {
+      clearTimeout(this.refreshToken)
+    }
+  }
+
+  private async refreshLoop(): Promise<void> {
+    await this.refresh()
+
+    this.refreshToken = setTimeout(() => {
+      void this.refreshLoop()
+    }, this.REFRESH_INTERVAL)
+  }
+
+  private async refresh(): Promise<void> {
+    try {
+      if (this.verifiedAssets) {
+        await this.api.refreshVerifiedAssets(this.verifiedAssets)
+      } else {
+        this.verifiedAssets = await this.api.getVerifiedAssets()
+      }
+    } catch (error) {
+      this.logger.error(
+        `Error while fetching verified assets: ${ErrorUtils.renderError(error)}`,
+      )
+    }
+  }
+
+  verify(assetId: Buffer | string): AssetVerification {
+    if (!this.started || !this.verifiedAssets) {
+      return { status: 'unknown' }
+    } else if (this.verifiedAssets.isVerified(assetId)) {
+      return { status: 'verified' }
+    } else {
+      return { status: 'unverified' }
+    }
+  }
+}

--- a/ironfish/src/assets/index.ts
+++ b/ironfish/src/assets/index.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export * from './assetsVerifier'
+export * from './assetsVerificationApi'

--- a/ironfish/src/index.ts
+++ b/ironfish/src/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './wallet'
 export * from './assert'
+export * from './assets'
 export * from './blockchain'
 export * from './consensus'
 export {

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -4,6 +4,7 @@
 import { BoxKeyPair } from '@ironfish/rust-nodejs'
 import os from 'os'
 import { v4 as uuid } from 'uuid'
+import { AssetsVerifier } from './assets'
 import { Blockchain } from './blockchain'
 import { TestnetConsensus } from './consensus'
 import {
@@ -50,6 +51,7 @@ export class IronfishNode {
   syncer: Syncer
   pkg: Package
   telemetry: Telemetry
+  assetsVerifier: AssetsVerifier
 
   started = false
   shutdownPromise: Promise<void> | null = null
@@ -167,6 +169,10 @@ export class IronfishNode {
       telemetry: this.telemetry,
       peerNetwork: this.peerNetwork,
       blocksPerMessage: config.get('blocksPerMessage'),
+    })
+
+    this.assetsVerifier = new AssetsVerifier({
+      logger,
     })
 
     this.config.onConfigChange.on((key, value) => this.onConfigChange(key, value))
@@ -351,6 +357,8 @@ export class IronfishNode {
 
     await this.memPool.start()
 
+    this.assetsVerifier.start()
+
     this.telemetry.submitNodeStarted()
   }
 
@@ -364,6 +372,7 @@ export class IronfishNode {
       this.syncer.stop(),
       this.peerNetwork.stop(),
       this.rpc.stop(),
+      this.assetsVerifier.stop(),
       this.telemetry.stop(),
       this.metrics.stop(),
     ])


### PR DESCRIPTION
## Summary

This is a new system that periodically pulls information about verified assets. The main class is `AssetsVerifier`, which can be used like this:

```typescript
const assetsVerifier = new AssetsVerifier(...options)
assetsVerifier.start() // fetch assets verification information and refresh them every 6 hours
assetsVerifier.verify(assetId) // returns one of:
                               // - { status: 'unknown' }
                               // - { status: 'verified' }
                               // - { status: 'unverified' }
```

For now this system is always enabled in the node, and cannot be configured or turned off. These features will come in future pull requests, together with support for persistent caching, local lists, better error handling with retries, and more.

## Testing Plan

- Unit tests
- Start the node and verify that the new system is running and refreshing itself at a regular interval

## Documentation

Documentation about what is a "verified asset" will be written in the future.

## Breaking Change

Not a breaking change.