### PR TITLE
Make STUN servers configurable

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -29,7 +29,6 @@ export type ConfigOptions = {
   bootstrapNodes: string[]
   /**
    * STUN servers to use for inititating WebRTC connections.
-   * TODO: Use our own STUN servers
    */
   p2pStunServers: string[]
   databaseMigrate: boolean

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -31,7 +31,7 @@ export type ConfigOptions = {
    * STUN servers to use for inititating WebRTC connections.
    * TODO: Use our own STUN servers
    */
-  stunServers: string[]
+  p2pStunServers: string[]
   databaseMigrate: boolean
   editor: string
   enableListenP2P: boolean
@@ -283,7 +283,7 @@ export type ConfigOptions = {
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
   .object({
     bootstrapNodes: yup.array().of(yup.string().defined()),
-    stunServers: yup.array().of(yup.string().defined()),
+    p2pStunServers: yup.array().of(yup.string().defined()),
     databaseMigrate: yup.boolean(),
     editor: yup.string().trim(),
     enableListenP2P: yup.boolean(),
@@ -380,7 +380,7 @@ export class Config extends KeyStore<ConfigOptions> {
   static GetDefaults(files: FileSystem, dataDir: string): ConfigOptions {
     return {
       bootstrapNodes: [],
-      stunServers: ['stun:stun.l.google.com:19302', 'stun:global.stun.twilio.com:3478'],
+      p2pStunServers: ['stun:stun.l.google.com:19302', 'stun:global.stun.twilio.com:3478'],
       databaseMigrate: false,
       transactionExpirationDelta: 15,
       editor: '',

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -27,6 +27,11 @@ const MEGABYTES = 1000 * 1000
 
 export type ConfigOptions = {
   bootstrapNodes: string[]
+  /**
+   * STUN servers to use for inititating WebRTC connections.
+   * TODO: Use our own STUN servers
+   */
+  stunServers: string[]
   databaseMigrate: boolean
   editor: string
   enableListenP2P: boolean
@@ -278,6 +283,7 @@ export type ConfigOptions = {
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
   .object({
     bootstrapNodes: yup.array().of(yup.string().defined()),
+    stunServers: yup.array().of(yup.string().defined()),
     databaseMigrate: yup.boolean(),
     editor: yup.string().trim(),
     enableListenP2P: yup.boolean(),
@@ -374,6 +380,7 @@ export class Config extends KeyStore<ConfigOptions> {
   static GetDefaults(files: FileSystem, dataDir: string): ConfigOptions {
     return {
       bootstrapNodes: [],
+      stunServers: ['stun:stun.l.google.com:19302', 'stun:global.stun.twilio.com:3478'],
       databaseMigrate: false,
       transactionExpirationDelta: 15,
       editor: '',

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -158,6 +158,7 @@ export class PeerNetwork {
     listen?: boolean
     port?: number
     bootstrapNodes?: string[]
+    stunServers: string[]
     name?: string | null
     maxPeers?: number
     minPeers?: number
@@ -204,6 +205,7 @@ export class PeerNetwork {
     this.peerManager = new PeerManager(
       this.localPeer,
       options.hostsStore,
+      options.stunServers,
       this.logger,
       this.metrics,
       maxPeers,

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -158,7 +158,7 @@ export class PeerNetwork {
     listen?: boolean
     port?: number
     bootstrapNodes?: string[]
-    stunServers: string[]
+    stunServers?: string[]
     name?: string | null
     maxPeers?: number
     minPeers?: number
@@ -205,12 +205,12 @@ export class PeerNetwork {
     this.peerManager = new PeerManager(
       this.localPeer,
       options.hostsStore,
-      options.stunServers,
       this.logger,
       this.metrics,
       maxPeers,
       targetPeers,
       logPeerMessages,
+      options.stunServers,
     )
     this.peerManager.onMessage.on((peer, message) => this.handleMessage(peer, message))
     this.peerManager.onConnectedPeersChanged.on(() => {

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -58,6 +58,7 @@ export class WebRtcConnection extends Connection {
   constructor(
     initiator: boolean,
     logger: Logger,
+    stunServers: string[],
     metrics?: MetricsMonitor,
     options: { simulateLatency?: number } = {},
   ) {
@@ -73,9 +74,8 @@ export class WebRtcConnection extends Connection {
       this.addLatencyWrapper()
     }
 
-    // TODO: Use our own STUN servers
     this.peer = new nodeDataChannel.PeerConnection('peer', {
-      iceServers: ['stun:stun.l.google.com:19302', 'stun:global.stun.twilio.com:3478'],
+      iceServers: stunServers,
       maxMessageSize: MAX_MESSAGE_SIZE,
     })
 

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -59,7 +59,7 @@ export class WebRtcConnection extends Connection {
     initiator: boolean,
     logger: Logger,
     metrics?: MetricsMonitor,
-    options: { simulateLatency?: number; stunServers: string[] } = { stunServers: [] },
+    options: { simulateLatency?: number; stunServers?: string[] } = {},
   ) {
     super(
       ConnectionType.WebRtc,
@@ -74,7 +74,7 @@ export class WebRtcConnection extends Connection {
     }
 
     this.peer = new nodeDataChannel.PeerConnection('peer', {
-      iceServers: options.stunServers,
+      iceServers: options.stunServers ?? [],
       maxMessageSize: MAX_MESSAGE_SIZE,
     })
 

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -58,9 +58,8 @@ export class WebRtcConnection extends Connection {
   constructor(
     initiator: boolean,
     logger: Logger,
-    stunServers: string[],
     metrics?: MetricsMonitor,
-    options: { simulateLatency?: number } = {},
+    options: { simulateLatency?: number; stunServers: string[] } = { stunServers: [] },
   ) {
     super(
       ConnectionType.WebRtc,
@@ -75,7 +74,7 @@ export class WebRtcConnection extends Connection {
     }
 
     this.peer = new nodeDataChannel.PeerConnection('peer', {
-      iceServers: stunServers,
+      iceServers: options.stunServers,
       maxMessageSize: MAX_MESSAGE_SIZE,
     })
 

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -329,15 +329,10 @@ export class PeerManager {
    * @param initiator Set to true if we are initiating a connection with `peer`
    */
   private initWebRtcConnection(peer: Peer, initiator: boolean): WebRtcConnection {
-    const connection = new WebRtcConnection(
-      initiator,
-      this.logger,
-      this.stunServers,
-      this.metrics,
-      {
-        simulateLatency: this.localPeer.simulateLatency,
-      },
-    )
+    const connection = new WebRtcConnection(initiator, this.logger, this.metrics, {
+      simulateLatency: this.localPeer.simulateLatency,
+      stunServers: this.stunServers,
+    })
 
     connection.onSignal.on((data) => {
       let errorMessage

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -143,12 +143,12 @@ export class PeerManager {
   constructor(
     localPeer: LocalPeer,
     hostsStore: HostsStore,
-    stunServers: string[],
     logger: Logger = createRootLogger(),
     metrics?: MetricsMonitor,
     maxPeers = 10000,
     targetPeers = 50,
     logPeerMessages = false,
+    stunServers: string[] = [],
   ) {
     this.stunServers = stunServers
     this.logger = logger.withTag('peermanager')

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -138,7 +138,7 @@ export class IronfishNode {
       logPeerMessages: config.get('logPeerMessages'),
       simulateLatency: config.get('p2pSimulateLatency'),
       bootstrapNodes: config.getArray('bootstrapNodes'),
-      stunServers: config.getArray('stunServers'),
+      stunServers: config.getArray('p2pStunServers'),
       webSocket: webSocket,
       node: this,
       chain: chain,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -138,6 +138,7 @@ export class IronfishNode {
       logPeerMessages: config.get('logPeerMessages'),
       simulateLatency: config.get('p2pSimulateLatency'),
       bootstrapNodes: config.getArray('bootstrapNodes'),
+      stunServers: config.getArray('stunServers'),
       webSocket: webSocket,
       node: this,
       chain: chain,


### PR DESCRIPTION
## Summary
We currently use Twilio and Google as STUN servers to facilitate WebRTC. If users are not confortable with this we should give them the option to use another server (possibly in the future a team run server). Making this configurable for now

## Testing Plan
Tested locally + unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
