### PR TITLE
feat(ci): add ability to run the perf tests on demand

### DIFF
--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -1,6 +1,7 @@
 name: Performance Tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - staging
@@ -45,18 +46,20 @@ jobs:
           fi
 
       - name: Setup InfluxDB
+        if: contains(github.event_name, 'push')
         uses: influxdata/influxdb-action@v3
         with:
           influxdb_version: 2.6.0
           influxdb_start: false
-      
+
       - name: Import to InfluxDB
+        if: contains(github.event_name, 'push')
         env:
           INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           INFLUX_ORG: 'fdcfe96f6c31245a'
           INFLUX_URL: 'https://us-east-1-1.aws.cloud2.influxdata.com'
         run: |
           influx config create --config-name ghaction --host-url $INFLUX_URL --org $INFLUX_ORG --token $INFLUX_TOKEN --active
-          for f in ironfish/test-reports/*.perf.csv; do 
+          for f in ironfish/test-reports/*.perf.csv; do
             influx write --bucket ironfish-telemetry-mainnet --token $INFLUX_TOKEN --format=csv --file $f
           done


### PR DESCRIPTION
## Summary

Adds the ability to run the github action on demand, so we can run it on branches prior to merging to staging. Also disables uploading the data to influx if they are ran this way.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
