### PR TITLE
Improve logging in the assets verifier system

### DIFF
--- a/ironfish/src/assets/assetsVerificationApi.ts
+++ b/ironfish/src/assets/assetsVerificationApi.ts
@@ -28,8 +28,9 @@ export class VerifiedAssets {
 }
 
 export class AssetsVerificationApi {
-  private readonly url: string
   private readonly timeout: number
+
+  readonly url: string
 
   constructor(options?: { url?: string; timeout?: number }) {
     this.url = options?.url ?? 'https://api.ironfish.network/assets?verified=true'

--- a/ironfish/src/assets/assetsVerifier.test.ts
+++ b/ironfish/src/assets/assetsVerifier.test.ts
@@ -175,12 +175,12 @@ describe('AssetsVerifier', () => {
         apiUrl: 'https://test/assets/verified',
       })
       const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
-      const error = jest.spyOn(assetsVerifier['logger'], 'error')
+      const warn = jest.spyOn(assetsVerifier['logger'], 'warn')
 
       assetsVerifier.start()
       await waitForRefreshToFinish(refresh)
 
-      expect(error).toHaveBeenCalledWith(
+      expect(warn).toHaveBeenCalledWith(
         'Error while fetching verified assets: Request failed with status code 500',
       )
       expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'unknown' })
@@ -236,19 +236,19 @@ describe('AssetsVerifier', () => {
         apiUrl: 'https://test/assets/verified',
       })
       const refresh = jest.spyOn(assetsVerifier as any, 'refresh')
-      const error = jest.spyOn(assetsVerifier['logger'], 'error')
+      const warn = jest.spyOn(assetsVerifier['logger'], 'warn')
 
       assetsVerifier.start()
       await waitForRefreshToFinish(refresh)
 
-      expect(error).not.toHaveBeenCalled()
+      expect(warn).not.toHaveBeenCalled()
       expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'verified' })
       expect(assetsVerifier.verify('4567')).toStrictEqual({ status: 'unverified' })
 
       jest.runOnlyPendingTimers()
       await waitForRefreshToFinish(refresh)
 
-      expect(error).toHaveBeenCalledWith(
+      expect(warn).toHaveBeenCalledWith(
         'Error while fetching verified assets: Request failed with status code 500',
       )
       expect(assetsVerifier.verify('0123')).toStrictEqual({ status: 'verified' })

--- a/ironfish/src/assets/assetsVerifier.ts
+++ b/ironfish/src/assets/assetsVerifier.ts
@@ -58,14 +58,14 @@ export class AssetsVerifier {
   private async refresh(): Promise<void> {
     try {
       if (this.verifiedAssets) {
+        this.logger.debug(`Refreshing list of verified assets from ${this.api.url}`)
         await this.api.refreshVerifiedAssets(this.verifiedAssets)
       } else {
+        this.logger.debug(`Downloading list of verified assets from ${this.api.url}`)
         this.verifiedAssets = await this.api.getVerifiedAssets()
       }
     } catch (error) {
-      this.logger.error(
-        `Error while fetching verified assets: ${ErrorUtils.renderError(error)}`,
-      )
+      this.logger.warn(`Error while fetching verified assets: ${ErrorUtils.renderError(error)}`)
     }
   }
 


### PR DESCRIPTION
## Summary

Changed the error to a warning (suggested by @NullSoldier on https://github.com/iron-fish/ironfish/pull/3993), and added two debug statements to know when the list is getting fetched.

## Testing Plan

- start the node with `--verbose` and observe the "downloading"/"refreshing" messages appearing in the logs
- cause the API to be unreachable and observe the warning

## Documentation

No doc change required.

## Breaking Change

Not a breaking change.