### PR TITLE
Add a configuration value for enabling/disabling the asset verification system

### DIFF
--- a/ironfish-cli/src/commands/debug.ts
+++ b/ironfish-cli/src/commands/debug.ts
@@ -60,6 +60,7 @@ export default class Debug extends IronfishCommand {
     const heapTotal = FileUtils.formatMemorySize(getHeapStatistics().total_available_size)
 
     const telemetryEnabled = this.sdk.config.get('enableTelemetry').toString()
+    const assetVerificationEnabled = this.sdk.config.get('enableAssetVerification').toString()
 
     const nodeName = this.sdk.config.get('nodeName').toString()
     const blockGraffiti = this.sdk.config.get('blockGraffiti').toString()
@@ -84,6 +85,7 @@ export default class Debug extends IronfishCommand {
       ['ironfish in PATH', `${cmdInPath.toString()}`],
       ['Garbage Collector Exposed', `${String(!!global.gc)}`],
       ['Telemetry enabled', `${telemetryEnabled}`],
+      ['Asset Verification enabled', `${assetVerificationEnabled}`],
       ['Node name', `${nodeName}`],
       ['Block graffiti', `${blockGraffiti}`],
     ])

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -39,6 +39,7 @@ export type ConfigOptions = {
   enableSyncing: boolean
   enableTelemetry: boolean
   enableMetrics: boolean
+  enableAssetVerification: boolean
   getFundsApi: string
   ipcPath: string
   /**
@@ -290,6 +291,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     enableSyncing: yup.boolean(),
     enableTelemetry: yup.boolean(),
     enableMetrics: yup.boolean(),
+    enableAssetVerification: yup.boolean(),
     getFundsApi: yup.string(),
     ipcPath: yup.string().trim(),
     miningForce: yup.boolean(),
@@ -387,6 +389,7 @@ export class Config extends KeyStore<ConfigOptions> {
       enableSyncing: true,
       enableTelemetry: false,
       enableMetrics: true,
+      enableAssetVerification: true,
       getFundsApi: 'https://testnet.api.ironfish.network/faucet_transactions',
       ipcPath: files.resolve(files.join(dataDir, 'ironfish.ipc')),
       logLevel: '*:info',

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -357,7 +357,9 @@ export class IronfishNode {
 
     await this.memPool.start()
 
-    this.assetsVerifier.start()
+    if (this.config.get('enableAssetVerification')) {
+      this.assetsVerifier.start()
+    }
 
     this.telemetry.submitNodeStarted()
   }
@@ -423,6 +425,14 @@ export class IronfishNode {
           await this.rpc.start()
         } else {
           await this.rpc.stop()
+        }
+        break
+      }
+      case 'enableAssetVerification': {
+        if (newValue) {
+          this.assetsVerifier.start()
+        } else {
+          this.assetsVerifier.stop()
         }
         break
       }

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -78,6 +78,7 @@ export class NodeTest {
     sdk.config.setOverride('networkId', 2)
     sdk.config.setOverride('enableListenP2P', false)
     sdk.config.setOverride('enableTelemetry', false)
+    sdk.config.setOverride('enableAssetVerification', false)
     sdk.config.setOverride('confirmations', 0)
 
     // Allow tests to override default settings


### PR DESCRIPTION
## Summary

Users can now enable or disable the verified assets feature by setting `enableAssetVerification`. By default, this is `true`.

## Testing Plan

Observe that:
- when `enableAssetVerification` is `true` (default), the RPC endpoints return either "verified" or "unverified"
- when `enableAssetVerification` is `true` (default), the RPC endpoints return "unknown"

Also check the output of `ironfish debug`.

```
$ ironfish start --rpc.http

$ ironfish start debug
Asset Verification enabled       true

$ curl -s http://localhost:8021/wallet/getBalance | jq
{
    "assetVerification": {
      "status": "unverified"
    },
}

$ ironfish config:set enableAssetVerification false

$ ironfish debug
Asset Verification enabled       false

$ curl -s http://localhost:8021/wallet/getBalance | jq
{
    "assetVerification": {
      "status": "unknown"
    },
}
```

## Documentation

Config doc changes required (coming soon).

## Breaking Change

Not a breaking change.