### PR TITLE
Add a configuration value for customizing the asset verification URL

### DIFF
--- a/ironfish/src/assets/assetsVerificationApi.ts
+++ b/ironfish/src/assets/assetsVerificationApi.ts
@@ -33,7 +33,7 @@ export class AssetsVerificationApi {
   readonly url: string
 
   constructor(options?: { url?: string; timeout?: number }) {
-    this.url = options?.url ?? 'https://api.ironfish.network/assets?verified=true'
+    this.url = options?.url || 'https://api.ironfish.network/assets?verified=true'
     this.timeout = options?.timeout ?? 30 * 1000 // 30 seconds
   }
 

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -110,6 +110,7 @@ export type ConfigOptions = {
    */
   targetPeers: number
   telemetryApi: string
+  assetVerificationApi: string
 
   /**
    * When the option is true, then each invocation of start command will invoke generation of new identity.
@@ -315,6 +316,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     minPeers: YupUtils.isPositiveInteger,
     targetPeers: yup.number().integer().min(1),
     telemetryApi: yup.string(),
+    assetVerificationApi: yup.string(),
     generateNewIdentity: yup.boolean(),
     transactionExpirationDelta: YupUtils.isPositiveInteger,
     blocksPerMessage: YupUtils.isPositiveInteger,
@@ -410,6 +412,7 @@ export class Config extends KeyStore<ConfigOptions> {
       minPeers: 1,
       targetPeers: 50,
       telemetryApi: '',
+      assetVerificationApi: '',
       generateNewIdentity: false,
       blocksPerMessage: 25,
       minerBatchSize: 25000,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -172,6 +172,7 @@ export class IronfishNode {
     })
 
     this.assetsVerifier = new AssetsVerifier({
+      apiUrl: config.get('assetVerificationApi'),
       logger,
     })
 


### PR DESCRIPTION
## Summary

The new configuration parameter `assetVerificationApi` can be used to change the API URL.

Changing this configuration value requires the node to be restarted in order for the change to be picked up. This is consistent with the behavior of other similar parameters like `telemetryApi`.

## Testing Plan

Start the node and observe the default URL:

```
$ ironfish start --verbose |& grep -w verified
Downloading list of verified assets from https://api.ironfish.network/assets?verified=true
```

Change the config, restart the node, and observe the new URL:

```
$ ironfish config:set assetVerificationApi https://testnet.api.ironfish.network/assets?verified=true

$ ironfish start --verbose |& grep -w verified
Downloading list of verified assets from https://testnet.api.ironfish.network/assets?verified=true
```

## Documentation

Config doc changes required (coming soon).

## Breaking Change

Not a breaking change.