### PR TITLE
Set SDK node compatability to >=16

### DIFF
--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -30,7 +30,7 @@
     }
   },
   "engines": {
-    "node": "18.x"
+    "node": ">=16"
   },
   "devDependencies": {
     "@napi-rs/cli": "2.14.3",

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -16,6 +16,9 @@
     "build/**/*.d.ts.map",
     "build/**/*.json"
   ],
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@ethersproject/bignumber": "5.7.0",
     "@fast-csv/format": "4.3.5",


### PR DESCRIPTION
## Summary

We use node version 18, but our node-app is stuck using version 16. This just formalizes what we already know. We need to support at least version 16 for now in our rust and SDK package.

## Testing Plan

Run tests on Github CI.