### PR TITLE
Remove influx set up step in Github workflow

### DIFF
--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -45,13 +45,6 @@ jobs:
             exit 1
           fi
 
-      - name: Setup InfluxDB
-        if: contains(github.event_name, 'push')
-        uses: influxdata/influxdb-action@v3
-        with:
-          influxdb_version: 2.6.0
-          influxdb_start: false
-
       - name: Import to InfluxDB
         if: contains(github.event_name, 'push')
         env:


### PR DESCRIPTION
## Summary
Perf test workflow stuck at influxdb set up step after changed to run on mac mini. 
Initial error is 
```
/Users/ironfish/actions-runner/_work/_actions/influxdata/influxdb-action/v3/install-influxdb.sh: line 12: wget: command not found
tar: Error opening archive: Failed to open 'influxdb2-2.6.0-linux-amd64.tar.gz'
```
After installing wget on the mac mini, it still stuck on the same step without any error
see https://github.com/iron-fish/ironfish/actions/runs/5405690415/jobs/9821580327
I manually installed influx cli on the mac mini, so we can remove this step in the github workflow


## Testing Plan
run it in the github action
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@mat-if @danield9tqh 