### PR TITLE
implements bech32 account encoder

### DIFF
--- a/ironfish/src/typedefs/bufio.d.ts
+++ b/ironfish/src/typedefs/bufio.d.ts
@@ -92,4 +92,6 @@ declare module 'bufio' {
   export function sizeVarint(value: number): number
   export function sizeVarBytes(value: Buffer): number
   export function sizeVarString(value: string, enc: BufferEncoding): number
+
+  class EncodingError {}
 }

--- a/ironfish/src/typedefs/bufio.d.ts
+++ b/ironfish/src/typedefs/bufio.d.ts
@@ -92,6 +92,4 @@ declare module 'bufio' {
   export function sizeVarint(value: number): number
   export function sizeVarBytes(value: Buffer): number
   export function sizeVarString(value: string, enc: BufferEncoding): number
-
-  class EncodingError {}
 }

--- a/ironfish/src/wallet/account/encoder/bech32.test.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.test.ts
@@ -40,7 +40,10 @@ describe('Bech32AccountEncoder', () => {
       outgoingViewKey: key.outgoingViewKey,
       publicAddress: key.publicAddress,
       createdAt: {
-        hash: '0000000000000000000000000000000000000000000000000000000000000000',
+        hash: Buffer.from(
+          '0000000000000000000000000000000000000000000000000000000000000000',
+          'hex',
+        ),
         sequence: 1,
       },
     }
@@ -71,23 +74,19 @@ describe('Bech32AccountEncoder', () => {
     expect(decoded).toMatchObject(accountImport)
   })
 
-  it('returns null if it cannot decode the bech32 string', () => {
+  it('throws an error if it cannot decode the bech32 string', () => {
     const encoded = Bech32m.encode('incorrect serialization', BECH32_ACCOUNT_PREFIX)
 
-    const decoded = encoder.decode(encoded)
-
-    expect(decoded).toBeNull()
+    expect(() => encoder.decode(encoded)).toThrow()
   })
 
-  it('returns null when decoding non-bech32 strings', () => {
+  it('throws an error when decoding non-bech32 strings', () => {
     const encoded = 'not bech32'
 
-    const decoded = encoder.decode(encoded)
-
-    expect(decoded).toBeNull()
+    expect(() => encoder.decode(encoded)).toThrow()
   })
 
-  it('returns null when decoding if the version does not match', () => {
+  it('throws an error when decoding if the version does not match', () => {
     const accountImport: AccountImport = {
       version: ACCOUNT_SCHEMA_VERSION,
       name: 'test',
@@ -106,7 +105,6 @@ describe('Bech32AccountEncoder', () => {
 
     encoder.VERSION = 1
 
-    const decoded = encoder.decode(encoded)
-    expect(decoded).toBeNull()
+    expect(() => encoder.decode(encoded)).toThrow()
   })
 })

--- a/ironfish/src/wallet/account/encoder/bech32.test.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.test.ts
@@ -4,6 +4,7 @@
 import { generateKey } from '@ironfish/rust-nodejs'
 import { Bech32m } from '../../../utils'
 import { AccountImport } from '../../walletdb/accountValue'
+import { ACCOUNT_SCHEMA_VERSION } from '../account'
 import { BECH32_ACCOUNT_PREFIX, Bech32AccountEncoder } from './bech32'
 
 describe('Bech32AccountEncoder', () => {
@@ -12,7 +13,7 @@ describe('Bech32AccountEncoder', () => {
 
   it('encodes the account as a bech32 string and decodes the string', () => {
     const accountImport: AccountImport = {
-      version: 2,
+      version: ACCOUNT_SCHEMA_VERSION,
       name: 'test',
       spendingKey: key.spendingKey,
       viewKey: key.viewKey,
@@ -31,7 +32,7 @@ describe('Bech32AccountEncoder', () => {
 
   it('encodes and decodes accounts with non-null createdAt', () => {
     const accountImport: AccountImport = {
-      version: 2,
+      version: ACCOUNT_SCHEMA_VERSION,
       name: 'test',
       spendingKey: key.spendingKey,
       viewKey: key.viewKey,
@@ -53,7 +54,7 @@ describe('Bech32AccountEncoder', () => {
 
   it('encodes and decodes view-only accounts', () => {
     const accountImport: AccountImport = {
-      version: 2,
+      version: ACCOUNT_SCHEMA_VERSION,
       name: 'test',
       spendingKey: null,
       viewKey: key.viewKey,
@@ -83,6 +84,29 @@ describe('Bech32AccountEncoder', () => {
 
     const decoded = encoder.decode(encoded)
 
+    expect(decoded).toBeNull()
+  })
+
+  it('returns null when decoding if the version does not match', () => {
+    const accountImport: AccountImport = {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name: 'test',
+      spendingKey: null,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+    }
+
+    encoder.VERSION = 0
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BECH32_ACCOUNT_PREFIX)).toBe(true)
+
+    encoder.VERSION = 1
+
+    const decoded = encoder.decode(encoded)
     expect(decoded).toBeNull()
   })
 })

--- a/ironfish/src/wallet/account/encoder/bech32.test.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.test.ts
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { generateKey } from '@ironfish/rust-nodejs'
+import { Bech32m } from '../../../utils'
+import { AccountImport } from '../../walletdb/accountValue'
+import { BECH32_ACCOUNT_PREFIX, Bech32AccountEncoder } from './bech32'
+
+describe('Bech32AccountEncoder', () => {
+  const key = generateKey()
+  const encoder = new Bech32AccountEncoder()
+
+  it('encodes the account as a bech32 string and decodes the string', () => {
+    const accountImport: AccountImport = {
+      version: 2,
+      name: 'test',
+      spendingKey: key.spendingKey,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BECH32_ACCOUNT_PREFIX)).toBe(true)
+
+    const decoded = encoder.decode(encoded)
+    expect(decoded).toMatchObject(accountImport)
+  })
+
+  it('encodes and decodes accounts with non-null createdAt', () => {
+    const accountImport: AccountImport = {
+      version: 2,
+      name: 'test',
+      spendingKey: key.spendingKey,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: {
+        hash: '0000000000000000000000000000000000000000000000000000000000000000',
+        sequence: 1,
+      },
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BECH32_ACCOUNT_PREFIX)).toBe(true)
+
+    const decoded = encoder.decode(encoded)
+    expect(decoded).toMatchObject(accountImport)
+  })
+
+  it('encodes and decodes view-only accounts', () => {
+    const accountImport: AccountImport = {
+      version: 2,
+      name: 'test',
+      spendingKey: null,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BECH32_ACCOUNT_PREFIX)).toBe(true)
+
+    const decoded = encoder.decode(encoded)
+    expect(decoded).toMatchObject(accountImport)
+  })
+
+  it('returns null if it cannot decode the bech32 string', () => {
+    const encoded = Bech32m.encode('incorrect serialization', BECH32_ACCOUNT_PREFIX)
+
+    const decoded = encoder.decode(encoded)
+
+    expect(decoded).toBeNull()
+  })
+
+  it('returns null when decoding non-bech32 strings', () => {
+    const encoded = 'not bech32'
+
+    const decoded = encoder.decode(encoded)
+
+    expect(decoded).toBeNull()
+  })
+})

--- a/ironfish/src/wallet/account/encoder/bech32.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.ts
@@ -29,64 +29,58 @@ export class Bech32AccountEncoder implements AccountEncoder {
 
     bw.writeU8(Number(!!value.createdAt))
     if (value.createdAt) {
-      bw.writeBytes(Buffer.from(value.createdAt.hash, 'hex'))
+      bw.writeBytes(value.createdAt.hash)
       bw.writeU32(value.createdAt.sequence)
     }
 
     return Bech32m.encode(bw.render().toString('hex'), BECH32_ACCOUNT_PREFIX)
   }
 
-  decode(value: string): AccountImport | null {
+  decode(value: string): AccountImport {
     const [hexEncoding, _] = Bech32m.decode(value)
 
     if (hexEncoding === null) {
-      return null
+      throw new Error(`Could not decode account ${value} using bech32`)
     }
 
-    try {
-      const buffer = Buffer.from(hexEncoding, 'hex')
+    const buffer = Buffer.from(hexEncoding, 'hex')
 
-      const reader = bufio.read(buffer, true)
+    const reader = bufio.read(buffer, true)
 
-      const version = reader.readU16()
+    const version = reader.readU16()
 
-      if (version !== this.VERSION) {
-        return null
-      }
+    if (version !== this.VERSION) {
+      throw new Error(
+        `Encoded account version ${version} does not match encoder version ${this.VERSION}`,
+      )
+    }
 
-      const name = reader.readVarString('utf8')
-      const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
-      const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
-      const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
-      const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+    const name = reader.readVarString('utf8')
+    const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
+    const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+    const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
 
-      const hasSpendingKey = reader.readU8() === 1
-      const spendingKey = hasSpendingKey ? reader.readBytes(KEY_LENGTH).toString('hex') : null
+    const hasSpendingKey = reader.readU8() === 1
+    const spendingKey = hasSpendingKey ? reader.readBytes(KEY_LENGTH).toString('hex') : null
 
-      const hasCreatedAt = reader.readU8() === 1
-      let createdAt = null
-      if (hasCreatedAt) {
-        const hash = reader.readBytes(32).toString('hex')
-        const sequence = reader.readU32()
-        createdAt = { hash, sequence }
-      }
+    const hasCreatedAt = reader.readU8() === 1
+    let createdAt = null
+    if (hasCreatedAt) {
+      const hash = reader.readBytes(32)
+      const sequence = reader.readU32()
+      createdAt = { hash, sequence }
+    }
 
-      return {
-        version: ACCOUNT_SCHEMA_VERSION,
-        name,
-        viewKey,
-        incomingViewKey,
-        outgoingViewKey,
-        spendingKey,
-        publicAddress,
-        createdAt,
-      }
-    } catch (e: unknown) {
-      if (e instanceof bufio.EncodingError) {
-        return null
-      }
-
-      throw e
+    return {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name,
+      viewKey,
+      incomingViewKey,
+      outgoingViewKey,
+      spendingKey,
+      publicAddress,
+      createdAt,
     }
   }
 

--- a/ironfish/src/wallet/account/encoder/bech32.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.ts
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
+import bufio from 'bufio'
+import { Bech32m } from '../../../utils'
+import {
+  AccountImport,
+  KEY_LENGTH,
+  VERSION_LENGTH,
+  VIEW_KEY_LENGTH,
+} from '../../walletdb/accountValue'
+import { AccountEncoder } from './encoder'
+
+export const BECH32_ACCOUNT_PREFIX = 'ironfishaccount00000'
+
+export class Bech32AccountEncoder implements AccountEncoder {
+  encode(value: AccountImport): string {
+    const bw = bufio.write(this.getSize(value))
+    bw.writeU16(value.version)
+
+    let flags = 0
+    flags |= Number(!!value.spendingKey) << 0
+    flags |= Number(!!value.createdAt) << 1
+    bw.writeU8(flags)
+
+    bw.writeVarString(value.name, 'utf8')
+    if (value.spendingKey) {
+      bw.writeBytes(Buffer.from(value.spendingKey, 'hex'))
+    }
+    bw.writeBytes(Buffer.from(value.viewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.incomingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.outgoingViewKey, 'hex'))
+    bw.writeBytes(Buffer.from(value.publicAddress, 'hex'))
+
+    if (value.createdAt) {
+      bw.writeBytes(Buffer.from(value.createdAt.hash, 'hex'))
+      bw.writeU32(value.createdAt.sequence)
+    }
+
+    return Bech32m.encode(bw.render().toString('hex'), BECH32_ACCOUNT_PREFIX)
+  }
+
+  decode(value: string): AccountImport | null {
+    const [hexEncoding, _] = Bech32m.decode(value)
+
+    if (hexEncoding === null) {
+      return null
+    }
+
+    try {
+      const buffer = Buffer.from(hexEncoding, 'hex')
+
+      const reader = bufio.read(buffer, true)
+
+      const version = reader.readU16()
+
+      const flags = reader.readU8()
+      const hasSpendingKey = flags & (1 << 0)
+      const hasCreatedAt = flags & (1 << 1)
+
+      const name = reader.readVarString('utf8')
+      const spendingKey = hasSpendingKey ? reader.readBytes(KEY_LENGTH).toString('hex') : null
+      const viewKey = reader.readBytes(VIEW_KEY_LENGTH).toString('hex')
+      const incomingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+      const outgoingViewKey = reader.readBytes(KEY_LENGTH).toString('hex')
+      const publicAddress = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+
+      let createdAt = null
+      if (hasCreatedAt) {
+        const hash = reader.readBytes(32).toString('hex')
+        const sequence = reader.readU32()
+        createdAt = { hash, sequence }
+      }
+
+      return {
+        version,
+        name,
+        viewKey,
+        incomingViewKey,
+        outgoingViewKey,
+        spendingKey,
+        publicAddress,
+        createdAt,
+      }
+    } catch (e: unknown) {
+      if (e instanceof bufio.EncodingError) {
+        return null
+      }
+
+      throw e
+    }
+  }
+
+  getSize(value: AccountImport): number {
+    let size = 0
+    size += VERSION_LENGTH
+    size += 1 // flags
+    size += bufio.sizeVarString(value.name, 'utf8')
+    if (value.spendingKey) {
+      size += KEY_LENGTH
+    }
+    size += VIEW_KEY_LENGTH
+    size += KEY_LENGTH // incomingViewKey
+    size += KEY_LENGTH // outgoingViewKey
+    size += PUBLIC_ADDRESS_LENGTH
+    if (value.createdAt) {
+      size += 32 // block hash
+      size += 4 // block sequence
+    }
+
+    return size
+  }
+}

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -7,9 +7,9 @@ import { IDatabaseEncoding } from '../../storage'
 import { ACCOUNT_KEY_LENGTH } from '../account/account'
 import { HeadValue, NullableHeadValueEncoding } from './headValue'
 
-const KEY_LENGTH = ACCOUNT_KEY_LENGTH
+export const KEY_LENGTH = ACCOUNT_KEY_LENGTH
 export const VIEW_KEY_LENGTH = 64
-const VERSION_LENGTH = 2
+export const VERSION_LENGTH = 2
 
 export interface AccountValue {
   version: number

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -9,7 +9,7 @@ import { HeadValue, NullableHeadValueEncoding } from './headValue'
 
 export const KEY_LENGTH = ACCOUNT_KEY_LENGTH
 export const VIEW_KEY_LENGTH = 64
-export const VERSION_LENGTH = 2
+const VERSION_LENGTH = 2
 
 export interface AccountValue {
   version: number


### PR DESCRIPTION
## Summary

encodes account data as a buffer by concatenating fields together before encoding the hex string using bech32.

copies buffer encoding pattern from walletdb/accountValue

## Testing Plan

adds unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
