### PR TITLE
Remove creating influx config in GH Workflow

### DIFF
--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -47,12 +47,7 @@ jobs:
 
       - name: Import to InfluxDB
         if: contains(github.event_name, 'push')
-        env:
-          INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
-          INFLUX_ORG: 'fdcfe96f6c31245a'
-          INFLUX_URL: 'https://us-east-1-1.aws.cloud2.influxdata.com'
         run: |
-          influx config create --config-name ghaction --host-url $INFLUX_URL --org $INFLUX_ORG --token $INFLUX_TOKEN --active
           for f in ironfish/test-reports/*.perf.csv; do
-            influx write --bucket ironfish-telemetry-mainnet --token $INFLUX_TOKEN --format=csv --file $f
+            influx write --bucket ironfish-telemetry-mainnet -c ghaction --format=csv --file $f
           done

--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -47,7 +47,11 @@ jobs:
 
       - name: Import to InfluxDB
         if: contains(github.event_name, 'push')
+        env:
+          INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+          INFLUX_ORG: 'fdcfe96f6c31245a'
+          INFLUX_URL: 'https://us-east-1-1.aws.cloud2.influxdata.com'
         run: |
           for f in ironfish/test-reports/*.perf.csv; do
-            influx write --bucket ironfish-telemetry-mainnet -c ghaction --format=csv --file $f
+            influx write --bucket ironfish-telemetry-mainnet --host $INFLUX_URL --org-id $INFLUX_ORG --token $INFLUX_TOKEN --format=csv --file $f
           done


### PR DESCRIPTION
## Summary
The influx config only need to be created once since its running on the same machine. Remove that command in Github workflow
Solving the error in GH workflow https://github.com/iron-fish/ironfish/actions/runs/5409999241/jobs/9830857314
`Error: failed to create config "ghaction": config "ghaction" already exists` 
## Testing Plan
Run GH workflow
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@mat-if @danield9tqh 