### PR TITLE
feat(ifl-1233): create existing encoders

### DIFF
--- a/ironfish/src/typedefs/bufio.d.ts
+++ b/ironfish/src/typedefs/bufio.d.ts
@@ -92,4 +92,6 @@ declare module 'bufio' {
   export function sizeVarint(value: number): number
   export function sizeVarBytes(value: Buffer): number
   export function sizeVarString(value: string, enc: BufferEncoding): number
+
+  class EncodingError extends Error {}
 }

--- a/ironfish/src/wallet/account/encoder/bech32json.test.ts
+++ b/ironfish/src/wallet/account/encoder/bech32json.test.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Assert } from '../../../assert'
+import { Bech32JsonEncoder } from './bech32json'
+describe('Bech32JsonEncoder', () => {
+  describe('encoding/decoding', () => {
+    it('encodes the value into a AccountImport and deserializes to the original value', () => {
+      const bech32JsonString =
+        'ironfishaccount0000010v38vetjwd5k7m3z8gezcgnwv9kk2g36yfnxvenxygkzyumsv4hxg6twva9k27fz8g3rjefsxf3x2drr8yenyetzvvcrjce3v43xzvpjxuekzvr9vy6rzve5xsmrzdfs8ymnyv3jvy6kvc3cvyurwwphve3xzvryvgckzwrxvy3zcgnkd9jhwjm90y3r5g3cvscrydmzv9jnqdpkvsmnxcmxxp3x2vphv5mrqv35v3jr2de389nxyvmzvfjxxctrxgckxcnzx56xywfcx5cxvdn9x3nrswtrvsersenyvg6rjwp4xejn2v3hxgurwvr9xsunwepkx43rzdehxcurye3j8qcrjvecv5enwwfk8ymxgcnyvvmrswfcxcux2et9x4jn2vnrx9nzytpzd9hxxmmdd9hxw4nfv4m5keteygazyve58p3xgdf4x3nxzwrxx9jxxwfk8qmrzdpkvdjkgvmyxsurxce58qenyvfc8qcxvce3vymxxe3nxgenjwp3vf3rycf5x9nrjwfhxqczytpzda6hgem0d9hxw4nfv4m5keteygazyd3cx56rxcfjxpjkgctpxsen2enzxsunzdf4vsckgetxvg6nzdp3xservcecx3jr2d3hxguxzwrrx4sk2dek8yexycesxuurwdt9xd3zytpzwp6kymrfvdqkgerjv4ehxg36yg6rwvfnxg6kzc33xvmxywpcxdnx2vmyv93kve3svcerswp3x5ekzwfkxcukgep5vfsk2vmyxuekyd34xuuxyvenxuerycfnvfjryvnrygkzycmjv4shgetyg96zywnmyf5xzumgygazyvpsxqcrqvpsxqcrqvpsxqcrwefnvguryv3ev56kvcfj8pjkxe3hxpjrwcfnx33njdenv3jrvdmz8qmnzd3svs6x2df4xgmn2cfexqmjytpzwdjhzat9de3k2g368ymnvdf5047sh0ql7q'
+      const encoder = new Bech32JsonEncoder()
+      const decoded = encoder.decode(bech32JsonString)
+      Assert.isNotNull(decoded)
+      const encoded = encoder.encode(decoded)
+      expect(encoded).toEqual(bech32JsonString)
+    })
+    it('throws when bech32 decoded string is not json account', () => {
+      const invalidJson = 'ironfishaccount1qqqqqqqqc5n9p2'
+      const encoder = new Bech32JsonEncoder()
+      expect(() => encoder.decode(invalidJson)).toThrow()
+    })
+  })
+})

--- a/ironfish/src/wallet/account/encoder/bech32json.ts
+++ b/ironfish/src/wallet/account/encoder/bech32json.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { EncodingError } from 'bufio'
+import { Bech32m } from '../../../utils'
+import { AccountImport } from '../../walletdb/accountValue'
+import { AccountEncoder } from './encoder'
+export class Bech32JsonEncoder implements AccountEncoder {
+  /**
+   * @deprecated Bech32 JSON encoding is deprecated. Use the newest version of the Bech32JSONEncoder.
+   */
+  encode(value: AccountImport): string {
+    return Bech32m.encode(JSON.stringify(value), 'ironfishaccount00000')
+  }
+
+  decode(value: string): AccountImport {
+    const [decoded, _] = Bech32m.decode(value)
+    if (!decoded) {
+      throw new EncodingError('Invalid bech32 JSON encoding')
+    }
+    return JSON.parse(decoded) as AccountImport
+  }
+}

--- a/ironfish/src/wallet/account/encoder/json.test.ts
+++ b/ironfish/src/wallet/account/encoder/json.test.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Assert } from '../../../assert'
+import { JsonEncoder } from './json'
+describe('JsonEncoder', () => {
+  describe('encoding/decoding', () => {
+    it('encodes the value into a AccountImport and deserializes to the original value', () => {
+      const jsonString =
+        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"hash":"000000000000007e3b8229e5fa28ecf70d7a34c973dd67b87160d4e55275a907","sequence":97654}}'
+      const encoder = new JsonEncoder()
+      const decoded = encoder.decode(jsonString)
+      Assert.isNotNull(decoded)
+      const encoded = encoder.encode(decoded)
+      expect(encoded).toEqual(jsonString)
+    })
+    it('throws when json is not a valid account', () => {
+      const invalidJson = '{}'
+      const encoder = new JsonEncoder()
+      expect(() => encoder.decode(invalidJson)).toThrow()
+    })
+  })
+})

--- a/ironfish/src/wallet/account/encoder/json.ts
+++ b/ironfish/src/wallet/account/encoder/json.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { validateAccount } from '../../validator'
+import { AccountImport, AccountValue } from '../../walletdb/accountValue'
+import { AccountEncoder } from './encoder'
+
+export class JsonEncoder implements AccountEncoder {
+  encode(value: AccountImport): string {
+    return JSON.stringify(value)
+  }
+
+  decode(value: string): AccountImport {
+    const account = JSON.parse(value) as AccountImport
+    // TODO: consolidate AccountImport and AccountValue createdAt types
+    validateAccount(account as AccountValue)
+    return account
+  }
+}

--- a/ironfish/src/wallet/account/encoder/mnemonic.test.ts
+++ b/ironfish/src/wallet/account/encoder/mnemonic.test.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Assert } from '../../../assert'
+import { MnemonicEncoder } from './mnemonic'
+
+describe('MnemonicEncoder', () => {
+  describe('encoding/decoding', () => {
+    it('encodes the value into a AccountImport and deserializes to the original value', () => {
+      const mnemonic =
+        'own bicycle nasty chaos type agent amateur inject cheese spare poverty charge ecology portion frame earn garden shed bulk youth patch sugar physical family'
+      const encoder = new MnemonicEncoder()
+      const decoded = encoder.decode(mnemonic, { name: 'foo' })
+      Assert.isNotNull(decoded)
+      const encoded = encoder.encode(decoded, { language: 'English' })
+      expect(encoded).toEqual(mnemonic)
+    })
+    it('should throw with invalid mnemonic', () => {
+      const mnemonic = 'invalid mnemonic'
+      const encoder = new MnemonicEncoder()
+      expect(() => encoder.decode(mnemonic, { name: 'foo' })).toThrow()
+    })
+  })
+})

--- a/ironfish/src/wallet/account/encoder/mnemonic.ts
+++ b/ironfish/src/wallet/account/encoder/mnemonic.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  generateKeyFromPrivateKey,
+  LanguageCode,
+  spendingKeyToWords,
+  wordsToSpendingKey,
+} from '@ironfish/rust-nodejs'
+import { EncodingError } from 'bufio'
+import { LanguageUtils } from '../../../utils'
+import { AccountImport } from '../../walletdb/accountValue'
+import { ACCOUNT_SCHEMA_VERSION } from '../account'
+import { AccountDecodingOptions, AccountEncoder, AccountEncodingOptions } from './encoder'
+
+export class MnemonicEncoder implements AccountEncoder {
+  encode(value: AccountImport, options?: AccountEncodingOptions): string {
+    if (!value.spendingKey) {
+      throw new EncodingError('Spending key is required for mnemonic key encoder')
+    }
+
+    return spendingKeyToWords(
+      value.spendingKey,
+      options?.language
+        ? LanguageUtils.LANGUAGES[options.language]
+        : LanguageUtils.inferLanguageCode() || LanguageCode.English,
+    )
+  }
+
+  decode(value: string, options: AccountDecodingOptions): AccountImport {
+    if (!options.name) {
+      throw new EncodingError('Name option is required for mnemonic key encoder')
+    }
+    let spendingKey = ''
+    let language = null
+    for (const code of Object.values(LanguageUtils.LANGUAGES)) {
+      try {
+        spendingKey = wordsToSpendingKey(value, code)
+      } catch (e) {
+        continue
+      }
+      language = LanguageUtils.languageCodeToKey(code)
+    }
+    if (language === null) {
+      throw new EncodingError('Invalid mnemonic')
+    }
+    const key = generateKeyFromPrivateKey(spendingKey)
+    return {
+      name: options.name,
+      spendingKey: spendingKey,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+      version: ACCOUNT_SCHEMA_VERSION,
+    }
+  }
+}

--- a/ironfish/src/wallet/account/encoder/spendingKey.test.ts
+++ b/ironfish/src/wallet/account/encoder/spendingKey.test.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Assert } from '../../../assert'
+import { SpendingKeyEncoder } from './spendingKey'
+
+describe('SpendingKeyEncoder', () => {
+  describe('encoding/decoding', () => {
+    it('encodes the value into a AccountImport and deserializes to the original value', () => {
+      const spendingKey = '9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa'
+      const encoder = new SpendingKeyEncoder()
+      const decoded = encoder.decode(spendingKey, { name: 'foo' })
+      Assert.isNotNull(decoded)
+      const encoded = encoder.encode(decoded)
+      expect(encoded).toEqual(spendingKey)
+    })
+    it('should throw with invalid spending key', () => {
+      const invalidSpendingKey = 'foo'
+      const encoder = new SpendingKeyEncoder()
+      expect(() => encoder.decode(invalidSpendingKey, { name: 'key' })).toThrow()
+    })
+  })
+})

--- a/ironfish/src/wallet/account/encoder/spendingKey.ts
+++ b/ironfish/src/wallet/account/encoder/spendingKey.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
+import { EncodingError } from 'bufio'
+import { AccountImport } from '../../walletdb/accountValue'
+import { ACCOUNT_SCHEMA_VERSION } from '../account'
+import { AccountDecodingOptions, AccountEncoder } from './encoder'
+
+export class SpendingKeyEncoder implements AccountEncoder {
+  encode(value: AccountImport): string {
+    if (!value.spendingKey) {
+      throw new EncodingError('Spending key is required for spending key encoder')
+    }
+    return value.spendingKey
+  }
+
+  decode(spendingKey: string, options: AccountDecodingOptions): AccountImport {
+    if (!options.name) {
+      throw new EncodingError('Name option is required for spending key encoder')
+    }
+    const key = generateKeyFromPrivateKey(spendingKey)
+    return {
+      name: options.name,
+      spendingKey: spendingKey,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+      version: ACCOUNT_SCHEMA_VERSION,
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `Encoder`s for the existing account export types:
- spendingKey
- mnemonic
- JSON
- Bech32m JSON

These encoders throw instead of return null as this removes opinion about what should be done with returned encoder value. 

These will be used when we update the CLI code to import these encoders, rather than containing the code explicitly.

## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
