### PR TITLE
feat(ifl-1233): account name optional

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -69,7 +69,7 @@ export class ImportCommand extends IronfishCommand {
       (accountName) => accountName === account.name,
     )
     // Offer the user to use a different name if a duplicate is found
-    if (duplicateAccount) {
+    if (duplicateAccount && account.name) {
       this.log()
       this.log(`Found existing account with name '${account.name}'`)
 

--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -62,4 +62,24 @@ describe('Route wallet/importAccount', () => {
       isDefaultAccount: false, // This is false because the default account is already imported in a previous test
     })
   })
+
+  it('should throw when account.name and name are not set', async () => {
+    const key = generateKey()
+    await expect(async () => {
+      await routeTest.client
+        .request<ImportResponse>('wallet/importAccount', {
+          account: {
+            viewKey: key.viewKey,
+            spendingKey: key.spendingKey,
+            publicAddress: key.publicAddress,
+            incomingViewKey: key.incomingViewKey,
+            outgoingViewKey: key.outgoingViewKey,
+            version: 1,
+            createdAt: null,
+          },
+          rescan: false,
+        })
+        .waitForEnd()
+    }).rejects.toThrow('Account name is required')
+  })
 })

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -23,8 +23,9 @@ export interface AccountValue {
   createdAt: HeadValue | null
 }
 
-export type AccountImport = Omit<AccountValue, 'id' | 'createdAt'> & {
+export type AccountImport = Omit<AccountValue, 'id' | 'createdAt' | 'name'> & {
   createdAt: { hash: string; sequence: number } | null
+  name?: string
 }
 
 export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {


### PR DESCRIPTION
## Summary
Makes `AccountImport.name` optional, this will enable encoders/decoders to use this type. Related to:
https://github.com/iron-fish/ironfish/pull/4011
## Testing Plan
unit tests
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
