### PR TITLE
Use env vars for Influx Auth credentials

### DIFF
--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -53,5 +53,5 @@ jobs:
           INFLUX_URL: 'https://us-east-1-1.aws.cloud2.influxdata.com'
         run: |
           for f in ironfish/test-reports/*.perf.csv; do
-            influx write --bucket ironfish-telemetry-mainnet --host $INFLUX_URL --org-id $INFLUX_ORG --token $INFLUX_TOKEN --format=csv --file $f
+            influx write --bucket ironfish-telemetry-mainnet --format=csv --file $f
           done

--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           INFLUX_ORG: 'fdcfe96f6c31245a'
-          INFLUX_URL: 'https://us-east-1-1.aws.cloud2.influxdata.com'
+          INFLUX_HOST: 'https://us-east-1-1.aws.cloud2.influxdata.com'
         run: |
           for f in ironfish/test-reports/*.perf.csv; do
             influx write --bucket ironfish-telemetry-mainnet --format=csv --file $f


### PR DESCRIPTION
## Summary
Auth credential is already set in env variables. Based on the doc https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/write/#examples, no need to pass in from the cli flags.

When we pass both, it also cause the error 
```
Error: ambiguous org: use OrgId or OrgName, but not both. OrgID: fdcfe96f6c31245a, OrgName: fdcfe96f6c31245a
```
## Testing Plan
locally run  influx write --bucket ironfish-telemetry-mainnet --format=csv --file /Users/yajun/ironfish/ironfish/ironfish/test-reports/manager.test.perf.csv
gh workflow
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@danield9tqh 