### PR TITLE
Remove rust cache step in perf test workflow

### DIFF
--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -27,11 +27,6 @@ jobs:
           node-version: '18.12.1'
           cache: 'yarn'
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: nodejs
-
       - name: Install packages
         run: yarn --non-interactive --frozen-lockfile
 


### PR DESCRIPTION
## Summary
The workflow is stuck at post rust cache step 
https://github.com/iron-fish/ironfish/actions/runs/5425262695/jobs/9865787228
At rust cache step, it has
```
... Restoring cache ...
No cache found.
```
It seems this step is not needed to run on mac mini.


## Testing Plan
gh workflow
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@mat-if 