### PR TITLE
Collect locks metrics locally

### DIFF
--- a/ironfish/src/metrics/meter.ts
+++ b/ironfish/src/metrics/meter.ts
@@ -32,7 +32,7 @@ export class Meter {
   private _intervalLastMs: number | null = null
 
   constructor(options?: { maxRollingAverageSamples?: number }) {
-    this._intervalMs = 1000
+    this._intervalMs = 1
 
     this._rate1s = new EwmAverage(1000 / this._intervalMs)
     this._rate5s = new EwmAverage(5000 / this._intervalMs)

--- a/ironfish/src/metrics/meter.ts
+++ b/ironfish/src/metrics/meter.ts
@@ -32,7 +32,7 @@ export class Meter {
   private _intervalLastMs: number | null = null
 
   constructor(options?: { maxRollingAverageSamples?: number }) {
-    this._intervalMs = 1
+    this._intervalMs = 100
 
     this._rate1s = new EwmAverage(1000 / this._intervalMs)
     this._rate5s = new EwmAverage(5000 / this._intervalMs)

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -259,8 +259,8 @@ export abstract class Database implements IDatabase {
           'acquire lock',
           new Date(Date.now()).toISOString(),
           transaction.lockWaitTime.toString(),
-          transaction.lockContention.rollingRate1s.toString(),
-          transaction.lockAcquisition.rollingRate1s.toString(),
+          transaction.lockContention.rate1s.toFixed(2),
+          transaction.lockAcquisition.rate1s.toFixed(2),
           this.callerName(),
         ]
 

--- a/ironfish/src/storage/database/database.ts
+++ b/ironfish/src/storage/database/database.ts
@@ -251,8 +251,9 @@ export abstract class Database implements IDatabase {
     const caller = this.callerName('withTransaction')
 
     try {
+      await transaction.acquireLock()
+
       if (transaction instanceof LevelupTransaction) {
-        await transaction.acquireLock()
         const row: string[] = [
           '',
           'perf_test',
@@ -268,8 +269,6 @@ export abstract class Database implements IDatabase {
         appendTestReport(row, 'acquireLock.perf.csv')
 
         transaction.db.dblockUser = caller
-      } else {
-        await transaction.acquireLock()
       }
 
       const start = BenchUtils.start()

--- a/ironfish/src/storage/levelup/database.ts
+++ b/ironfish/src/storage/levelup/database.ts
@@ -9,7 +9,7 @@ import { Assert } from '../../assert'
 import { Meter } from '../../metrics/meter'
 import { Mutex, MutexUnlockFunction } from '../../mutex'
 import { IJsonSerializable } from '../../serde'
-import { appendTestReport } from '../../testUtilities'
+import { appendTestReport } from '../../testUtilities/utils'
 import {
   BatchOperation,
   Database,

--- a/ironfish/src/testUtilities/utils.ts
+++ b/ironfish/src/testUtilities/utils.ts
@@ -45,7 +45,7 @@ export function appendTestReport(row: string[], filename: string): void {
   const writeStream = createWriteStream(`${process.cwd()}/${TEST_REPORT_FOLDER}/${filename}`, {
     flags: 'a+',
   })
-  writeStream.write(row.join(',src/testUtilities/utils.ts'))
+  writeStream.write(row.join(','))
   writeStream.write('\n')
   writeStream.end()
 }

--- a/ironfish/src/testUtilities/utils.ts
+++ b/ironfish/src/testUtilities/utils.ts
@@ -4,6 +4,7 @@
 
 /* eslint-disable no-console */
 
+import { createWriteStream, existsSync, mkdirSync } from 'fs'
 import path from 'path'
 import { v4 as uuid } from 'uuid'
 
@@ -35,6 +36,18 @@ export function writeTestReport(
   }
 }
 
+export function appendTestReport(row: string[], filename: string): void {
+  if (!existsSync(`${process.cwd()}/test-report`)) {
+    mkdirSync(`${process.cwd()}/test-report`)
+  }
+
+  const writeStream = createWriteStream(`${process.cwd()}/test-reports/${filename}`, {
+    flags: 'a+',
+  })
+  writeStream.write(row.join(','))
+  writeStream.write('\n')
+  writeStream.end()
+}
 /**
  * Asserts the type of a given function as a Jest mock.
  */

--- a/ironfish/src/testUtilities/utils.ts
+++ b/ironfish/src/testUtilities/utils.ts
@@ -36,15 +36,16 @@ export function writeTestReport(
   }
 }
 
+const TEST_REPORT_FOLDER = 'test-reports'
 export function appendTestReport(row: string[], filename: string): void {
-  if (!existsSync(`${process.cwd()}/test-report`)) {
-    mkdirSync(`${process.cwd()}/test-report`)
+  if (!existsSync(`${process.cwd()}/${TEST_REPORT_FOLDER}`)) {
+    mkdirSync(`${process.cwd()}/${TEST_REPORT_FOLDER}`)
   }
 
-  const writeStream = createWriteStream(`${process.cwd()}/test-reports/${filename}`, {
+  const writeStream = createWriteStream(`${process.cwd()}/${TEST_REPORT_FOLDER}/${filename}`, {
     flags: 'a+',
   })
-  writeStream.write(row.join(','))
+  writeStream.write(row.join(',src/testUtilities/utils.ts'))
   writeStream.write('\n')
   writeStream.end()
 }


### PR DESCRIPTION
## Summary
Collect following metrics for LevelDB lock performance
- Lock waiting time
- Lock acquisitions
- Contention count
- Lock holding time

Also log the caller function and transaction size
For the caller name, the regex is search the last index of `withTransaction` in the stack trace and log the stack trace of the line below that index, this will be the function that calls `withTransaction` function

## Testing Plan
locally run and get the test report 
```
,perf_test,transactionLock,acquire lock,2023-07-01T02:05:20.645Z,0.008125,0,0,at processTicksAndRejections (node:internal/process/task_queues:95:5)
,perf_test,transactionLock,acquire lock,2023-07-01T02:05:20.652Z,0.007666,0,0,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:240:5)
,perf_test,transactionLock,acquire lock,2023-07-01T02:05:20.667Z,0.083375,0,0,at processTicksAndRejections (node:internal/process/task_queues:95:5)
,perf_test,transactionLock,acquire lock,2023-07-01T02:05:20.668Z,0.009916,0,0,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:434:7)
,perf_test,transactionLock,acquire lock,2023-07-01T02:05:20.669Z,0.003542,0,0,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:440:7)
```

```
,perf_test,transactionLock,hold lock,2023-07-01T02:05:20.647Z,1.510375,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:199:5),0
,perf_test,transactionLock,hold lock,2023-07-01T02:05:20.653Z,0.483333,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:240:5),0
,perf_test,transactionLock,hold lock,2023-07-01T02:05:20.668Z,0.132125,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:434:7),0
,perf_test,transactionLock,hold lock,2023-07-01T02:05:20.669Z,0.796792,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:440:7),0
,perf_test,transactionLock,hold lock,2023-07-01T02:05:20.672Z,0.686583,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:463:7),0
,perf_test,transactionLock,hold lock,2023-07-01T02:05:20.674Z,0.380791,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:487:7),0
,perf_test,transactionLock,hold lock,2023-07-01T02:05:20.675Z,0.182708,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:511:7),0
,perf_test,transactionLock,hold lock,2023-07-01T02:05:20.678Z,0.091375,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:537:7),1
,perf_test,transactionLock,hold lock,2023-07-01T02:05:20.680Z,0.01775,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:550:7),2
,perf_test,transactionLock,hold lock,2023-07-01T02:05:20.680Z,0.295333,at async Object.<anonymous> (/Users/yajun/ironfish/ironfish/ironfish/src/storage/database.test.ts:550:7),2
```
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@danield9tqh 