### PR TITLE
Verified assets: implement persistent caching

### DIFF
--- a/ironfish/src/assets/assetsVerifier.ts
+++ b/ironfish/src/assets/assetsVerifier.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { VerifiedAssetsCacheStore } from '../fileStores/verifiedAssets'
 import { createRootLogger, Logger } from '../logger'
 import { ErrorUtils } from '../utils'
 import { SetIntervalToken } from '../utils'
@@ -15,15 +16,25 @@ export class AssetsVerifier {
 
   private readonly logger: Logger
   private readonly api: AssetsVerificationApi
+  private readonly cache?: VerifiedAssetsCacheStore
 
   private started: boolean
   private refreshToken?: SetIntervalToken
   private verifiedAssets?: VerifiedAssets
 
-  constructor(options?: { apiUrl?: string; logger?: Logger }) {
+  constructor(options?: {
+    apiUrl?: string
+    cache?: VerifiedAssetsCacheStore
+    logger?: Logger
+  }) {
     this.logger = options?.logger ?? createRootLogger()
     this.api = new AssetsVerificationApi({ url: options?.apiUrl })
+    this.cache = options?.cache
     this.started = false
+
+    if (this.cache?.config?.apiUrl === this.api.url) {
+      this.verifiedAssets = VerifiedAssets.restore(this.cache.config)
+    }
   }
 
   start(): void {
@@ -59,14 +70,28 @@ export class AssetsVerifier {
     try {
       if (this.verifiedAssets) {
         this.logger.debug(`Refreshing list of verified assets from ${this.api.url}`)
-        await this.api.refreshVerifiedAssets(this.verifiedAssets)
+        if (await this.api.refreshVerifiedAssets(this.verifiedAssets)) {
+          await this.saveCache()
+        }
       } else {
         this.logger.debug(`Downloading list of verified assets from ${this.api.url}`)
         this.verifiedAssets = await this.api.getVerifiedAssets()
+        await this.saveCache()
       }
     } catch (error) {
       this.logger.warn(`Error while fetching verified assets: ${ErrorUtils.renderError(error)}`)
     }
+  }
+
+  private saveCache(): Promise<void> {
+    if (!this.cache) {
+      return Promise.resolve()
+    }
+    this.cache.setMany({
+      apiUrl: this.api.url,
+      ...(this.verifiedAssets ?? new VerifiedAssets()).export(),
+    })
+    return this.cache.save()
   }
 
   verify(assetId: Buffer | string): AssetVerification {

--- a/ironfish/src/fileStores/fileStore.ts
+++ b/ironfish/src/fileStores/fileStore.ts
@@ -33,7 +33,7 @@ export class FileStore<T extends Record<string, unknown>> {
 
   async save(data: PartialRecursive<T>): Promise<void> {
     const json = JSON.stringify(data, undefined, '    ')
-    await this.files.mkdir(this.dataDir, { recursive: true })
+    await this.files.mkdir(path.dirname(this.configPath), { recursive: true })
     await this.files.writeFile(this.configPath, json)
   }
 }

--- a/ironfish/src/fileStores/index.ts
+++ b/ironfish/src/fileStores/index.ts
@@ -3,5 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './config'
 export * from './fileStore'
-export * from './internal'
 export * from './hosts'
+export * from './internal'
+export * from './verifiedAssets'

--- a/ironfish/src/fileStores/keyStore.ts
+++ b/ironfish/src/fileStores/keyStore.ts
@@ -139,6 +139,13 @@ export class KeyStore<TSchema extends Record<string, unknown>> {
     }
   }
 
+  setMany(params: Partial<TSchema>): void {
+    for (const key in params) {
+      const value = params[key] as TSchema[keyof TSchema]
+      this.set(key, value)
+    }
+  }
+
   setOverride<T extends keyof TSchema>(key: T, value: TSchema[T]): void {
     const previousValue = this.config[key]
 

--- a/ironfish/src/fileStores/verifiedAssets.ts
+++ b/ironfish/src/fileStores/verifiedAssets.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import path from 'path'
+import { ExportedVerifiedAssets } from '../assets'
+import { FileSystem } from '../fileSystems'
+import { createRootLogger, Logger } from '../logger'
+import { ParseJsonError } from '../utils/json'
+import { KeyStore } from './keyStore'
+
+export type VerifiedAssetsCacheOptions = {
+  apiUrl: string
+} & ExportedVerifiedAssets
+
+export const VerifiedAssetsCacheOptionsDefaults: VerifiedAssetsCacheOptions = {
+  apiUrl: '',
+  assetIds: [],
+}
+
+export const VERIFIED_ASSETS_CACHE_FILE_NAME = path.join('cache', 'verified-assets.json')
+
+export class VerifiedAssetsCacheStore extends KeyStore<VerifiedAssetsCacheOptions> {
+  logger: Logger
+
+  constructor(files: FileSystem, dataDir: string) {
+    super(files, VERIFIED_ASSETS_CACHE_FILE_NAME, VerifiedAssetsCacheOptionsDefaults, dataDir)
+    this.logger = createRootLogger()
+  }
+
+  async load(): Promise<void> {
+    try {
+      await super.load()
+    } catch (e) {
+      if (e instanceof ParseJsonError) {
+        this.logger.debug(
+          `Error: Could not parse JSON at ${this.storage.configPath}, ignoring.`,
+        )
+      } else {
+        throw e
+      }
+    }
+  }
+}

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_DATA_DIR,
   HostsStore,
   InternalStore,
+  VerifiedAssetsCacheStore,
 } from './fileStores'
 import { FileSystem } from './fileSystems'
 import { createRootLogger, Logger } from './logger'
@@ -73,6 +74,7 @@ export class IronfishNode {
     privateIdentity,
     hostsStore,
     networkId,
+    verifiedAssetsCache,
   }: {
     pkg: Package
     files: FileSystem
@@ -89,6 +91,7 @@ export class IronfishNode {
     privateIdentity?: PrivateIdentity
     hostsStore: HostsStore
     networkId: number
+    verifiedAssetsCache: VerifiedAssetsCacheStore
   }) {
     this.files = files
     this.config = config
@@ -174,6 +177,7 @@ export class IronfishNode {
 
     this.assetsVerifier = new AssetsVerifier({
       apiUrl: config.get('assetVerificationApi'),
+      cache: verifiedAssetsCache,
       logger,
     })
 
@@ -220,6 +224,9 @@ export class IronfishNode {
 
     const hostsStore = new HostsStore(files, dataDir)
     await hostsStore.load()
+
+    const verifiedAssetsCache = new VerifiedAssetsCacheStore(files, dataDir)
+    await verifiedAssetsCache.load()
 
     let workers = config.get('nodeWorkers')
     if (workers === -1) {
@@ -308,6 +315,7 @@ export class IronfishNode {
       privateIdentity,
       hostsStore,
       networkId: networkDefinition.id,
+      verifiedAssetsCache,
     })
   }
 


### PR DESCRIPTION
## Summary

The verified assets cache is now stored in `$DATADIR/cache/verified-assets.json` (default on *nix: `~/.ironfish/cache/verified-assets.json`).

- The cache is saved only when the API returns new data.
- The cache file can be safely removed at any time. It will be rewritten at the next update from the API, or the next node restart.
- The cache file may be corrupted. In that case, the node will ignore it and move one.
  - Note though that if the cache file contains invalid data (e.g. `assetIds` is set to a number instead of an array), this may result in exceptions that will prevent the node from starting.
- Restarting the node causes the cache to be immediately revalidated, regardless of how long has passed since the last revalidation. A future PR may improve this by storing the last revalidation timestamp in the cache.
- Changing the API URL (through the `assetVerificationApi` configuration value) causes the cache to be invalidated.

## Testing Plan

Start the node and observe the cache file appearing. It should look like this:

```
{
    "apiUrl": "https://api.ironfish.network/assets?verified=true",
    "assetIds": [
        "51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c"
    ],
    "lastModified": "Wed, 05 Jul 2023 15:42:05 GMT"
}
```

Restart the node with `--verbose` and observe the "Refreshing list of verified assets ..." log message appearing. The message must say "Refreshing", not "Downloading".

## Documentation

No doc change required.

## Breaking Change

Not a breaking change.