### PR TITLE
feat: encoder options for AccountEncoder type

### DIFF
--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -62,24 +62,4 @@ describe('Route wallet/importAccount', () => {
       isDefaultAccount: false, // This is false because the default account is already imported in a previous test
     })
   })
-
-  it('should throw when account.name and name are not set', async () => {
-    const key = generateKey()
-    await expect(async () => {
-      await routeTest.client
-        .request<ImportResponse>('wallet/importAccount', {
-          account: {
-            viewKey: key.viewKey,
-            spendingKey: key.spendingKey,
-            publicAddress: key.publicAddress,
-            incomingViewKey: key.incomingViewKey,
-            outgoingViewKey: key.outgoingViewKey,
-            version: 1,
-            createdAt: null,
-          },
-          rescan: false,
-        })
-        .waitForEnd()
-    }).rejects.toThrow('Account name is required')
-  })
 })

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -25,7 +25,7 @@ export const ImportAccountRequestSchema: yup.ObjectSchema<ImportAccountRequest> 
     name: yup.string().optional(),
     account: yup
       .object({
-        name: yup.string().optional(),
+        name: yup.string().defined(),
         spendingKey: yup.string().nullable().defined(),
         viewKey: yup.string().defined(),
         publicAddress: yup.string().defined(),

--- a/ironfish/src/wallet/account/encoder/encoder.ts
+++ b/ironfish/src/wallet/account/encoder/encoder.ts
@@ -1,10 +1,19 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { LanguageKey } from '../../../utils'
 import { AccountImport } from '../../walletdb/accountValue'
 
-export type AccountEncoder = {
-  encode(value: AccountImport): string
+export type AccountEncodingOptions = {
+  language?: LanguageKey
+}
 
-  decode(value: string): AccountImport | null
+export type AccountDecodingOptions = {
+  name?: string
+}
+
+export type AccountEncoder = {
+  encode(value: AccountImport, options?: AccountEncodingOptions): string
+
+  decode(value: string, options?: AccountDecodingOptions): AccountImport
 }

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -23,9 +23,8 @@ export interface AccountValue {
   createdAt: HeadValue | null
 }
 
-export type AccountImport = Omit<AccountValue, 'id' | 'createdAt' | 'name'> & {
+export type AccountImport = Omit<AccountValue, 'id' | 'createdAt'> & {
   createdAt: { hash: string; sequence: number } | null
-  name?: string
 }
 
 export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {


### PR DESCRIPTION
## Summary
Adds encoder options to encoder/decoders
## Testing Plan
tests/lint pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
