### PR TITLE
feat(ci): Add a lint check for PRs against master

### DIFF
--- a/.github/workflows/check-pr-branch.yml
+++ b/.github/workflows/check-pr-branch.yml
@@ -1,4 +1,4 @@
-name: Disallow Pull Requests to Master Branch
+name: Pull Requests should target Staging branch
 
 on:
   pull_request:

--- a/.github/workflows/check-pr-branch.yml
+++ b/.github/workflows/check-pr-branch.yml
@@ -1,0 +1,18 @@
+name: Disallow Pull Requests to Master Branch
+
+on:
+  pull_request:
+    types: ['*']
+    branches:
+      - 'master'
+
+jobs:
+  check-branch-keyword:
+    name: Check Base Branch And Override Keyword
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ !contains(github.event.pull_request.title, 'master') }}
+        run: |
+          echo 'Pull request has "master" base branch without the override keyword "master" in the PR Title'
+          echo 'This pull request probably meant to target "staging"'
+          exit 1


### PR DESCRIPTION
## Summary

This will fail if the PR has a base branch of master and does not contain the word master in the PR title. This still allows release PRs and other emergency PRs, while creating a quick and easy check to make sure PRs aren't accidentally going into master.

I wanted the override keyword to be "MASTER", but the github actions expressions treat strings as case-insensitive, so good enough for now.

## Testing Plan

Tested this on a small repo: https://github.com/mat-if/libuv-playground/actions/workflows/testing.yml

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
