### PR TITLE
adds separate RpcAccountImport type

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -9,7 +9,7 @@ import {
   LanguageUtils,
   PromiseUtils,
 } from '@ironfish/sdk'
-import { AccountImport } from '@ironfish/sdk/src/wallet/walletdb/accountValue'
+import { RpcAccountImport } from '@ironfish/sdk/src/rpc/routes/wallet/types'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -48,9 +48,9 @@ export class ImportCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    let account: AccountImport
+    let account: RpcAccountImport
     if (blob) {
-      account = await this.stringToAccountImport(blob, flags)
+      account = await this.stringToRpcAccountImport(blob, flags)
     } else if (flags.path) {
       account = await this.importFile(flags.path, flags)
     } else if (process.stdin.isTTY) {
@@ -129,14 +129,14 @@ export class ImportCommand extends IronfishCommand {
     }
   }
 
-  async stringToAccountImport(
+  async stringToRpcAccountImport(
     data: string,
     flags: CommandFlags<typeof ImportCommand>,
-  ): Promise<AccountImport> {
+  ): Promise<RpcAccountImport> {
     // bech32 encoded json
     const [decoded, _] = Bech32m.decode(data)
     if (decoded) {
-      let data = JSONUtils.parse<AccountImport>(decoded)
+      let data = JSONUtils.parse<RpcAccountImport>(decoded)
 
       if (data.spendingKey) {
         data = {
@@ -174,7 +174,7 @@ export class ImportCommand extends IronfishCommand {
 
     // raw json
     try {
-      let json = JSONUtils.parse<AccountImport>(data)
+      let json = JSONUtils.parse<RpcAccountImport>(data)
 
       if (json.spendingKey) {
         json = {
@@ -201,13 +201,13 @@ export class ImportCommand extends IronfishCommand {
   async importFile(
     path: string,
     flags: CommandFlags<typeof ImportCommand>,
-  ): Promise<AccountImport> {
+  ): Promise<RpcAccountImport> {
     const resolved = this.sdk.fileSystem.resolve(path)
     const data = await this.sdk.fileSystem.readFile(resolved)
-    return this.stringToAccountImport(data.trim(), flags)
+    return this.stringToRpcAccountImport(data.trim(), flags)
   }
 
-  async importPipe(flags: CommandFlags<typeof ImportCommand>): Promise<AccountImport> {
+  async importPipe(flags: CommandFlags<typeof ImportCommand>): Promise<RpcAccountImport> {
     let data = ''
 
     const onData = (dataIn: string): void => {
@@ -223,10 +223,10 @@ export class ImportCommand extends IronfishCommand {
 
     process.stdin.off('data', onData)
 
-    return this.stringToAccountImport(data, flags)
+    return this.stringToRpcAccountImport(data, flags)
   }
 
-  async importTTY(flags: CommandFlags<typeof ImportCommand>): Promise<AccountImport> {
+  async importTTY(flags: CommandFlags<typeof ImportCommand>): Promise<RpcAccountImport> {
     const userInput = await CliUx.ux.prompt(
       'Paste the output of wallet:export, or your spending key',
       {
@@ -234,6 +234,6 @@ export class ImportCommand extends IronfishCommand {
       },
     )
 
-    return await this.stringToAccountImport(userInput, flags)
+    return await this.stringToRpcAccountImport(userInput, flags)
   }
 }

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -3,13 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { v4 as uuid } from 'uuid'
 import * as yup from 'yup'
-import { AccountImport } from '../../../wallet/walletdb/accountValue'
 import { ApiNamespace, router } from '../router'
+import { RpcAccountImport, RpcAccountImportSchema } from './types'
 
 export class ImportError extends Error {}
 
 export type ImportAccountRequest = {
-  account: AccountImport
+  account: RpcAccountImport
   name?: string
   rescan?: boolean
 }
@@ -23,24 +23,7 @@ export const ImportAccountRequestSchema: yup.ObjectSchema<ImportAccountRequest> 
   .object({
     rescan: yup.boolean().optional().default(true),
     name: yup.string().optional(),
-    account: yup
-      .object({
-        name: yup.string().defined(),
-        spendingKey: yup.string().nullable().defined(),
-        viewKey: yup.string().defined(),
-        publicAddress: yup.string().defined(),
-        incomingViewKey: yup.string().defined(),
-        outgoingViewKey: yup.string().defined(),
-        version: yup.number().defined(),
-        createdAt: yup
-          .object({
-            hash: yup.string().defined(),
-            sequence: yup.number().defined(),
-          })
-          .nullable()
-          .defined(),
-      })
-      .defined(),
+    account: RpcAccountImportSchema,
   })
   .defined()
 

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as yup from 'yup'
+import { AccountImport } from '../../../wallet/walletdb/accountValue'
 
 export type RpcAccountTransaction = {
   hash: string
@@ -75,5 +76,28 @@ export const RpcSpendSchema: yup.ObjectSchema<RpcSpend> = yup
     nullifier: yup.string().defined(),
     commitment: yup.string().defined(),
     size: yup.number().defined(),
+  })
+  .defined()
+
+export type RpcAccountImport = Omit<AccountImport, 'createdAt'> & {
+  createdAt: { hash: string; sequence: number } | null
+}
+
+export const RpcAccountImportSchema: yup.ObjectSchema<RpcAccountImport> = yup
+  .object({
+    name: yup.string().defined(),
+    spendingKey: yup.string().nullable().defined(),
+    viewKey: yup.string().defined(),
+    publicAddress: yup.string().defined(),
+    incomingViewKey: yup.string().defined(),
+    outgoingViewKey: yup.string().defined(),
+    version: yup.number().defined(),
+    createdAt: yup
+      .object({
+        hash: yup.string().defined(),
+        sequence: yup.number().defined(),
+      })
+      .nullable()
+      .defined(),
   })
   .defined()

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -23,8 +23,7 @@ export interface AccountValue {
   createdAt: HeadValue | null
 }
 
-export type AccountImport = Omit<AccountValue, 'id' | 'createdAt'> & {
-  createdAt: { hash: string; sequence: number } | null
+export type AccountImport = Omit<AccountValue, 'id'> & {
 }
 
 export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -23,8 +23,7 @@ export interface AccountValue {
   createdAt: HeadValue | null
 }
 
-export type AccountImport = Omit<AccountValue, 'id'> & {
-}
+export type AccountImport = Omit<AccountValue, 'id'>
 
 export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
   serialize(value: AccountValue): Buffer {


### PR DESCRIPTION
## Summary

pushes serialization of createdAt as HeadValue to the RPC; serialization of the block hash as a hex string is only needed for sending RPC responses

makes createdAt type uniform across AccountImport and AccountValue

closes IFL-1259

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
