### PR TITLE
Verified assets: use the persisted cache when the node is not running

### DIFF
--- a/ironfish/src/assets/assetsVerifier.ts
+++ b/ironfish/src/assets/assetsVerifier.ts
@@ -95,9 +95,11 @@ export class AssetsVerifier {
   }
 
   verify(assetId: Buffer | string): AssetVerification {
-    if (!this.started || !this.verifiedAssets) {
+    if (!this.verifiedAssets) {
       return { status: 'unknown' }
-    } else if (this.verifiedAssets.isVerified(assetId)) {
+    }
+
+    if (this.verifiedAssets.isVerified(assetId)) {
       return { status: 'verified' }
     } else {
       return { status: 'unverified' }


### PR DESCRIPTION
## Summary

When the command line client is running but not connected to any node, use the persisted cache (if present) to get and display verified assets information.

## Testing Plan

- Start the node so that it can fetch the verified assets information and write the cache to disk (this requires https://github.com/iron-fish/ironfish/pull/4020)
- Stop the node
- Run `ironfish wallet:balances`, or similar commands

Expected behavior: verified assets should appear as green with a checkmark.

## Documentation

No doc change needed.

## Breaking Change

Not a breaking change.