### PR TITLE
feat(ifl-1237): encodeAccount/decodeAccount generalized functions

### DIFF
--- a/ironfish/src/wallet/account/encoder/account.test.ts
+++ b/ironfish/src/wallet/account/encoder/account.test.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Assert } from '../../../assert'
+import { decodeAccount, encodeAccount } from './account'
+import { Format } from './encoder'
+
+describe('decodeAccount/encodeAccount', () => {
+  describe('when decoding/encoding', () => {
+    it('decodes arbitrary format without failure', () => {
+      const jsonString =
+        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"hash":"000000000000007e3b8229e5fa28ecf70d7a34c973dd67b87160d4e55275a907","sequence":97654}}'
+      const decoded = decodeAccount(jsonString)
+      Assert.isNotNull(decoded)
+      const encoded = encodeAccount(decoded, Format.JSON)
+      expect(encoded).toEqual(jsonString)
+    })
+    it('throws when json is not a valid account', () => {
+      const invalidJson = '{}'
+      expect(() => decodeAccount(invalidJson)).toThrow()
+    })
+  })
+})

--- a/ironfish/src/wallet/account/encoder/account.ts
+++ b/ironfish/src/wallet/account/encoder/account.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../../../assert'
+import { AccountImport } from '../../walletdb/accountValue'
+import { Bech32Encoder } from './bech32'
+import { Bech32JsonEncoder } from './bech32json'
+import { AccountDecodingOptions, AccountEncodingOptions, Format } from './encoder'
+import { JsonEncoder } from './json'
+import { MnemonicEncoder } from './mnemonic'
+import { SpendingKeyEncoder } from './spendingKey'
+
+const ENCODER_VERSIONS = [
+  JsonEncoder,
+  MnemonicEncoder,
+  SpendingKeyEncoder,
+  Bech32JsonEncoder,
+  Bech32Encoder,
+]
+
+export function encodeAccount(
+  value: AccountImport,
+  format: Format,
+  options: AccountEncodingOptions = {},
+): string {
+  switch (format) {
+    case Format.JSON:
+      return new JsonEncoder().encode(value)
+    case Format.Bech32:
+      return new Bech32Encoder().encode(value)
+    case Format.SpendingKey:
+      return new SpendingKeyEncoder().encode(value)
+    case Format.Mnemonic:
+      return new MnemonicEncoder().encode(value, options)
+    default:
+      return Assert.isUnreachable(format)
+  }
+}
+
+export function decodeAccount(
+  value: string,
+  options: AccountDecodingOptions = {},
+): AccountImport {
+  let decoded = null
+  for (const encoder of ENCODER_VERSIONS) {
+    try {
+      decoded = new encoder().decode(value, options)
+    } catch (e) {
+      continue
+    }
+    if (decoded) {
+      return decoded
+    }
+  }
+  throw new Error('Account could not be decoded')
+}

--- a/ironfish/src/wallet/account/encoder/bech32.test.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.test.ts
@@ -5,11 +5,11 @@ import { generateKey } from '@ironfish/rust-nodejs'
 import { Bech32m } from '../../../utils'
 import { AccountImport } from '../../walletdb/accountValue'
 import { ACCOUNT_SCHEMA_VERSION } from '../account'
-import { BECH32_ACCOUNT_PREFIX, Bech32AccountEncoder } from './bech32'
+import { BECH32_ACCOUNT_PREFIX, Bech32Encoder } from './bech32'
 
 describe('Bech32AccountEncoder', () => {
   const key = generateKey()
-  const encoder = new Bech32AccountEncoder()
+  const encoder = new Bech32Encoder()
 
   it('encodes the account as a bech32 string and decodes the string', () => {
     const accountImport: AccountImport = {

--- a/ironfish/src/wallet/account/encoder/bech32.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.ts
@@ -9,7 +9,7 @@ import { ACCOUNT_SCHEMA_VERSION } from '../account'
 import { AccountEncoder } from './encoder'
 
 export const BECH32_ACCOUNT_PREFIX = 'ifaccount'
-export class Bech32AccountEncoder implements AccountEncoder {
+export class Bech32Encoder implements AccountEncoder {
   VERSION = 1
 
   encode(value: AccountImport): string {

--- a/ironfish/src/wallet/account/encoder/encoder.ts
+++ b/ironfish/src/wallet/account/encoder/encoder.ts
@@ -4,6 +4,13 @@
 import { LanguageKey } from '../../../utils'
 import { AccountImport } from '../../walletdb/accountValue'
 
+export enum Format {
+  JSON = 'JSON',
+  Bech32 = 'Bech32',
+  SpendingKey = 'SpendingKey',
+  Mnemonic = 'Mnemonic',
+}
+
 export type AccountEncodingOptions = {
   language?: LanguageKey
 }

--- a/ironfish/src/wallet/account/encoder/json.ts
+++ b/ironfish/src/wallet/account/encoder/json.ts
@@ -1,19 +1,36 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { RpcAccountImport } from '../../../rpc/routes/wallet/types'
 import { validateAccount } from '../../validator'
-import { AccountImport, AccountValue } from '../../walletdb/accountValue'
+import { AccountImport } from '../../walletdb/accountValue'
 import { AccountEncoder } from './encoder'
 
 export class JsonEncoder implements AccountEncoder {
   encode(value: AccountImport): string {
-    return JSON.stringify(value)
+    let createdAt = null
+    if (value.createdAt) {
+      createdAt = {
+        hash: value.createdAt.hash.toString('hex'),
+        sequence: value.createdAt.sequence,
+      }
+    }
+    return JSON.stringify({ ...value, createdAt })
   }
 
   decode(value: string): AccountImport {
-    const account = JSON.parse(value) as AccountImport
-    // TODO: consolidate AccountImport and AccountValue createdAt types
-    validateAccount(account as AccountValue)
-    return account
+    const account = JSON.parse(value) as RpcAccountImport
+    const updatedAccount = {
+      ...account,
+      createdAt: account.createdAt
+        ? {
+            hash: Buffer.from(account.createdAt.hash, 'hex'),
+            sequence: account.createdAt.sequence,
+          }
+        : null,
+    } as AccountImport
+
+    validateAccount(updatedAccount)
+    return updatedAccount
   }
 }

--- a/ironfish/src/wallet/account/encoder/mnemonic.ts
+++ b/ironfish/src/wallet/account/encoder/mnemonic.ts
@@ -14,7 +14,7 @@ import { ACCOUNT_SCHEMA_VERSION } from '../account'
 import { AccountDecodingOptions, AccountEncoder, AccountEncodingOptions } from './encoder'
 
 export class MnemonicEncoder implements AccountEncoder {
-  encode(value: AccountImport, options?: AccountEncodingOptions): string {
+  encode(value: AccountImport, options: AccountEncodingOptions): string {
     if (!value.spendingKey) {
       throw new EncodingError('Spending key is required for mnemonic key encoder')
     }


### PR DESCRIPTION
## Summary
Adds `encodeAccount/decodeAccount` which can be used in place of the individual encoders to:
1. Always use recommended encoder from SDK
2. Try all decoders on string instead of trying each encoder
## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
