### PR TITLE
fix(ci): Base branch check should update to green if base changes

### DIFF
--- a/.github/workflows/check-pr-branch.yml
+++ b/.github/workflows/check-pr-branch.yml
@@ -4,14 +4,13 @@ on:
   pull_request:
     types: ['*']
     branches:
-      - 'master'
+      - '**'
 
 jobs:
-  check-branch-keyword:
-    name: Check Base Branch And Override Keyword
+  check:
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ !contains(github.event.pull_request.title, 'master') }}
+      - if: ${{ contains(github.event.pull_request.base.ref, 'master') && !contains(github.event.pull_request.title, 'master') }}
         run: |
           echo 'Pull request has "master" base branch without the override keyword "master" in the PR Title'
           echo 'This pull request probably meant to target "staging"'


### PR DESCRIPTION
## Summary

This wasn't changing back to green when the base branch changes because it would only run if the base branch is main. Therefore, we'll need to run it on all PRs, and check if the branch is master alongside the keyword in the job if-expression.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
