### PR TITLE
updates export CLI for RPC changes

### DIFF
--- a/ironfish/src/wallet/account/index.ts
+++ b/ironfish/src/wallet/account/index.ts
@@ -2,7 +2,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './account'
-export * from './wallet'
-export { AccountValue } from './walletdb/accountValue'
-export * from './validator'
-export * from './walletdb/walletdb'
+export { Format } from './encoder/encoder'

--- a/ironfish/src/wallet/index.ts
+++ b/ironfish/src/wallet/index.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 export * from './account/account'
+export { Format } from './account/encoder/encoder'
 export * from './wallet'
 export { AccountValue } from './walletdb/accountValue'
 export * from './validator'


### PR DESCRIPTION
## Summary

removes account encoding logic from export CLI and uses the exportAccount RPC to encode accounts in the desired format instead

## Testing Plan
manual testing:
```
hughy@Hughs-MacBook-Pro ironfish % fish wallet:export test
yarn run v1.22.18
$ yarn build && yarn start:js wallet:export test
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:export test
ifaccount1xqcnqvpsxsmngd34xuenwdry8qukyepsxu6rgdpkx5erzwrzvyerjvtpvgexgwfkxqukvvmzv5exyce5x56nzvmpxyek2drzvyurxc3ex93rgvfexesnxdtx8qmr2dtxvvuk2d35x5crxwfhxg6n2vnzxc6rwctpv5crswfnvvmnjdfkxp3rgve5v3nrxc3j8ymrgde4xguxywtzv3nrgvphxfjrjcm9xsmnvdekx9nxxefhvyerwetzvc6nxerpvyuxzde4893kgdtzvc6rzdnpvgmrxvf4xy6nzv3sxesnxce4x5mkycf3vvcxxdfexe3rjdpsxpjrqcenvsurxvt9x5ukzcfh8qcrvdrrxg6kvde5vvexzcf4x93xgdr9xa3rsenr8y6r2vtzxfnx2vfhv4jnsv33x5exvd33xpjrzdmxv33kxdrpxsenwcesxgmrjetpxqenxe33xycrswpnxvenwwp5v9jrxdrpxcekzceexgcrgdejxvmnyetxv5ersctpxe3nvwp3xyerxcesxycxgv34vcekgetpvyurqdecve3rje33xfjnqdecxfjrxd3jxscxzdnxv4nrve33vsmkydenx4jxywp5x4snzdfkv5exyvee89jnqd35xqcqxytppa
✨  Done in 2.71s.
hughy@Hughs-MacBook-Pro ironfish % fish wallet:export test --mnemonic
yarn run v1.22.18
$ yarn build && yarn start:js wallet:export test --mnemonic
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:export test --mnemonic
artwork convince waste fence always lava labor foster join have math below year resource invest hover frozen season hair punch clinic smooth light milk
✨  Done in 2.67s.
hughy@Hughs-MacBook-Pro ironfish % fish wallet:export test --language=Korean
yarn run v1.22.18
$ yarn build && yarn start:js wallet:export test --language=Korean
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:export test --language=Korean
계속 대답 형수 부끄러움 거액 신용 식생활 비판 시금치 성공 어른 광고 흔적 저번 스웨터 속도 사람 조용히 선풍기 임금 다방 진짜 씨름 여권
✨  Done in 2.71s.
hughy@Hughs-MacBook-Pro ironfish % fish wallet:export test --json           
yarn run v1.22.18
$ yarn build && yarn start:js wallet:export test --json
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:export test --json
{"version":1,"name":"test","spendingKey":"0d25f3deaa8078fb9f12e0782d36240a6fef6f1d7b735db845a156e2b399e064","viewKey":"d89bd0744465218ba291ab2d9609f3be2bc45513a13e4ba83b91b4196a35f8655fc9e64503972552b647aae0893c79560b434df3b29647528b9bdf4072d9ce47","incomingViewKey":"6761fce7a27ebf53daa8a759cd5bf416ab6315151206a3c557ba1c0c596b9400","outgoingViewKey":"d0c3d831e59aa78064c25f74c2aa51bd4e7b8fc9451b2fe17ee82152f610d17f","publicAddress":"dcc4a437c0269ea033f11088333784ad34a63ac920472372efe28aa6c681123c","createdAt":null}
✨  Done in 2.55s.
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
