### PR TITLE
Use `performance.now()` instead of `Date.now()` for performance measurements

### DIFF
--- a/ironfish/src/metrics/meter.ts
+++ b/ironfish/src/metrics/meter.ts
@@ -129,7 +129,7 @@ export class Meter {
   }
 
   private update(): void {
-    const now = Date.now()
+    const now = performance.now()
 
     if (this._intervalLastMs === null) {
       this._intervalLastMs = now


### PR DESCRIPTION
## Summary

`Date` does not use a monotonic clock and it may jump in the past, or in the future. At such, it's not a good candidate for measuring performance. This PR switches from using `Date` to using `performance`, which has the following advantages:

- **`performance.now()` is a monotonic clock**: it cannot travel in the past, and it is not subject to system adjustments
- `Date.now()` has millisecond precision and resolution, `performance.now()` has microsecond resolution, and high precision depending on the platform
- Both `Date.now()` and `peformance.now()` return a timestamp in milliseconds; the difference is that `Date.now()` is an integer, `performance.now()` is a floating-point number (and this is ok because the code that uses the timestamp does floating-point arithmetic on it, so no code needs to change)

## Testing Plan

Launch `status -f` and verify that the numbers still make sense.

## Documentation

No doc change required.

## Breaking Change

Not a breaking change.