### PR TITLE
feat(ifl-1263): support account rename decoding

### DIFF
--- a/ironfish/src/wallet/account/encoder/account.test.ts
+++ b/ironfish/src/wallet/account/encoder/account.test.ts
@@ -4,6 +4,7 @@
 
 import { Assert } from '../../../assert'
 import { decodeAccount, encodeAccount } from './account'
+import { Bech32JsonEncoder } from './bech32json'
 import { Format } from './encoder'
 
 describe('decodeAccount/encodeAccount', () => {
@@ -15,6 +16,26 @@ describe('decodeAccount/encodeAccount', () => {
       Assert.isNotNull(decoded)
       const encoded = encodeAccount(decoded, Format.JSON)
       expect(encoded).toEqual(jsonString)
+    })
+
+    it('renames account when option is passed', () => {
+      const jsonString =
+        '{"version":2,"name":"ffff","spendingKey":"9e02be4c932ebc09c1eba0273a0ea41344615097222a5fb8a8787fba0db1a8fa","viewKey":"8d027bae046d73cf0be07e6024dd5719fb3bbdcac21cbb54b9850f6e4f89cd28fdb49856e5272870e497d65b177682f280938e379696dbdc689868eee5e52c1f","incomingViewKey":"348bd554fa8f1dc9686146ced3d483c48321880fc1a6cf323981bb2a41f99700","outgoingViewKey":"68543a20edaa435fb49155d1defb5141426c84d56728a8c5ae7692bc07875e3b","publicAddress":"471325ab136b883fe3dacff0f288153a9669dd4bae3d73b6578b33722a3bd22c","createdAt":{"hash":"000000000000007e3b8229e5fa28ecf70d7a34c973dd67b87160d4e55275a907","sequence":97654}}'
+      const decoded = decodeAccount(jsonString)
+      Assert.isNotNull(decoded)
+
+      const encodedJson = encodeAccount(decoded, Format.JSON)
+      const decodedJson = decodeAccount(encodedJson, { name: 'new' })
+      expect(decodedJson.name).toEqual('new')
+
+      const encodedBech32 = encodeAccount(decoded, Format.Bech32)
+      const decodedBech32 = decodeAccount(encodedBech32, { name: 'new' })
+      expect(decodedBech32.name).toEqual('new')
+
+      const bech32Encoder = new Bech32JsonEncoder()
+      const encodedBech32Json = bech32Encoder.encode(decoded)
+      const decodedBech32Json = bech32Encoder.decode(encodedBech32Json, { name: 'new' })
+      expect(decodedBech32Json.name).toEqual('new')
     })
     it('throws when json is not a valid account', () => {
       const invalidJson = '{}'

--- a/ironfish/src/wallet/account/encoder/bech32.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.ts
@@ -6,7 +6,7 @@ import bufio from 'bufio'
 import { Bech32m } from '../../../utils'
 import { AccountImport, KEY_LENGTH, VIEW_KEY_LENGTH } from '../../walletdb/accountValue'
 import { ACCOUNT_SCHEMA_VERSION } from '../account'
-import { AccountEncoder } from './encoder'
+import { AccountDecodingOptions, AccountEncoder } from './encoder'
 
 export const BECH32_ACCOUNT_PREFIX = 'ifaccount'
 export class Bech32Encoder implements AccountEncoder {
@@ -36,7 +36,7 @@ export class Bech32Encoder implements AccountEncoder {
     return Bech32m.encode(bw.render().toString('hex'), BECH32_ACCOUNT_PREFIX)
   }
 
-  decode(value: string): AccountImport {
+  decode(value: string, options?: AccountDecodingOptions): AccountImport {
     const [hexEncoding, _] = Bech32m.decode(value)
 
     if (hexEncoding === null) {
@@ -74,7 +74,7 @@ export class Bech32Encoder implements AccountEncoder {
 
     return {
       version: ACCOUNT_SCHEMA_VERSION,
-      name,
+      name: options?.name ? options.name : name,
       viewKey,
       incomingViewKey,
       outgoingViewKey,

--- a/ironfish/src/wallet/account/encoder/bech32json.ts
+++ b/ironfish/src/wallet/account/encoder/bech32json.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Bech32m } from '../../../utils'
 import { AccountImport } from '../../walletdb/accountValue'
-import { AccountEncoder } from './encoder'
+import { AccountDecodingOptions, AccountEncoder } from './encoder'
 import { JsonEncoder } from './json'
 export class Bech32JsonEncoder implements AccountEncoder {
   /**
@@ -13,11 +13,15 @@ export class Bech32JsonEncoder implements AccountEncoder {
     return Bech32m.encode(new JsonEncoder().encode(value), 'ironfishaccount00000')
   }
 
-  decode(value: string): AccountImport {
+  decode(value: string, options?: AccountDecodingOptions): AccountImport {
     const [decoded, _] = Bech32m.decode(value)
     if (!decoded) {
       throw new Error('Invalid bech32 JSON encoding')
     }
-    return new JsonEncoder().decode(decoded)
+    const accountImport = new JsonEncoder().decode(decoded)
+    return {
+      ...accountImport,
+      name: options?.name ? options.name : accountImport.name,
+    }
   }
 }

--- a/ironfish/src/wallet/account/encoder/json.ts
+++ b/ironfish/src/wallet/account/encoder/json.ts
@@ -4,7 +4,7 @@
 import { RpcAccountImport } from '../../../rpc/routes/wallet/types'
 import { validateAccount } from '../../validator'
 import { AccountImport } from '../../walletdb/accountValue'
-import { AccountEncoder } from './encoder'
+import { AccountDecodingOptions, AccountEncoder } from './encoder'
 
 export class JsonEncoder implements AccountEncoder {
   encode(value: AccountImport): string {
@@ -18,10 +18,11 @@ export class JsonEncoder implements AccountEncoder {
     return JSON.stringify({ ...value, createdAt })
   }
 
-  decode(value: string): AccountImport {
+  decode(value: string, options?: AccountDecodingOptions): AccountImport {
     const account = JSON.parse(value) as RpcAccountImport
     const updatedAccount = {
       ...account,
+      name: options?.name ? options.name : account.name,
       createdAt: account.createdAt
         ? {
             hash: Buffer.from(account.createdAt.hash, 'hex'),
@@ -29,7 +30,6 @@ export class JsonEncoder implements AccountEncoder {
           }
         : null,
     } as AccountImport
-
     validateAccount(updatedAccount)
     return updatedAccount
   }


### PR DESCRIPTION
## Summary
If the `option->name` is passed to a `decoder`, we should rename the corresponding account in the `AccountImport`
## Testing Plan
tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
