### PR TITLE
Verified assets: add support for `file:///` URIs as the source of verified assets

### DIFF
--- a/ironfish/src/assets/assetsVerificationApi.test.ts
+++ b/ironfish/src/assets/assetsVerificationApi.test.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import fs from 'fs'
 import nock from 'nock'
 import { AssetsVerificationApi } from './assetsVerificationApi'
 
@@ -145,6 +146,21 @@ describe('Assets Verification API Client', () => {
         timeout: 1000,
       })
       await expect(api.getVerifiedAssets()).rejects.toThrow('timeout of 1000ms exceeded')
+    })
+
+    it('supports file:// URIs', async () => {
+      const contents = JSON.stringify({
+        data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+      })
+      const readFileSpy = jest.spyOn(fs.promises, 'readFile').mockResolvedValue(contents)
+
+      const api = new AssetsVerificationApi({
+        url: 'file:///some/where',
+      })
+      const verifiedAssets = await api.getVerifiedAssets()
+
+      expect(verifiedAssets['assetIds']).toStrictEqual(new Set(['0123', 'abcd']))
+      expect(readFileSpy).toHaveBeenCalledWith('/some/where', { encoding: 'utf8' })
     })
   })
 })

--- a/ironfish/src/assets/assetsVerificationApi.ts
+++ b/ironfish/src/assets/assetsVerificationApi.ts
@@ -1,7 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import axios, { AxiosError } from 'axios'
+import axios, { AxiosAdapter, AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
+import { readFile } from 'node:fs/promises'
+import url, { URL } from 'url'
 
 type GetVerifiedAssetsResponse = {
   data: Array<{ identifier: string }>
@@ -56,12 +58,14 @@ export type ExportedVerifiedAssets = {
 
 export class AssetsVerificationApi {
   private readonly timeout: number
+  private readonly adapter?: AxiosAdapter
 
   readonly url: string
 
   constructor(options?: { url?: string; timeout?: number }) {
     this.url = options?.url || 'https://api.ironfish.network/assets?verified=true'
     this.timeout = options?.timeout ?? 30 * 1000 // 30 seconds
+    this.adapter = isFileUrl(this.url) ? axiosFileAdapter : axios.defaults.adapter
   }
 
   async getVerifiedAssets(): Promise<VerifiedAssets> {
@@ -83,6 +87,7 @@ export class AssetsVerificationApi {
       .get<GetVerifiedAssetsResponse>(this.url, {
         headers: headers,
         timeout: this.timeout,
+        adapter: this.adapter,
       })
       .then(
         (response: {
@@ -104,4 +109,29 @@ export class AssetsVerificationApi {
         throw error
       })
   }
+}
+
+const isFileUrl = (url: string): boolean => {
+  const parsedUrl = new URL(url)
+  return parsedUrl.protocol === 'file:'
+}
+
+const axiosFileAdapter = (
+  config: AxiosRequestConfig,
+): Promise<AxiosResponse<GetVerifiedAssetsResponse>> => {
+  if (!config.url) {
+    return Promise.reject(new Error('url is undefined'))
+  }
+
+  const path = url.fileURLToPath(config.url)
+
+  return readFile(path, { encoding: 'utf8' })
+    .then(JSON.parse)
+    .then((data: GetVerifiedAssetsResponse) => ({
+      data,
+      status: 0,
+      statusText: '',
+      headers: {},
+      config: config,
+    }))
 }


### PR DESCRIPTION
## Summary

People can now use local files as their source for verified asset information.

## Testing Plan

```
$ cat <<EOF > /tmp/assets.json
{
  "data": [ {"identifier": "51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c"} ]
}
EOF

$ ironfish config:set assetVerificationApi file:///tmp/assets.json

$ ironfish start

$ ironfish wallet:balances
```

## Documentation

No doc change required

## Breaking Change

Not a breaking change