### PR TITLE
Verified assets: place the cache in the `temp` directory

### DIFF
--- a/ironfish/src/fileStores/verifiedAssets.ts
+++ b/ironfish/src/fileStores/verifiedAssets.ts
@@ -17,7 +17,7 @@ export const VerifiedAssetsCacheOptionsDefaults: VerifiedAssetsCacheOptions = {
   assetIds: [],
 }
 
-export const VERIFIED_ASSETS_CACHE_FILE_NAME = path.join('cache', 'verified-assets.json')
+export const VERIFIED_ASSETS_CACHE_FILE_NAME = path.join('temp', 'verified-assets.json')
 
 export class VerifiedAssetsCacheStore extends KeyStore<VerifiedAssetsCacheOptions> {
   logger: Logger


### PR DESCRIPTION
## Summary

Reuse the already-existing `temp` directory instead of creating a new `cache` directory.

## Testing Plan

Launch the node and observe the `$DATADIR/temp/verified-assets.json` file appearing.

## Documentation

No doc change required

## Breaking Change

Not a breaking change