### PR TITLE
Verified assets: use the new `/verified/assets` API endpoint

### DIFF
--- a/ironfish/src/assets/assetsVerificationApi.test.ts
+++ b/ironfish/src/assets/assetsVerificationApi.test.ts
@@ -20,7 +20,7 @@ describe('Assets Verification API Client', () => {
       nock('https://test')
         .get('/assets/verified')
         .reply(200, {
-          data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+          assets: [{ identifier: '0123' }, { identifier: 'abcd' }],
         })
 
       const api = new AssetsVerificationApi({
@@ -39,7 +39,7 @@ describe('Assets Verification API Client', () => {
       nock('https://test')
         .get('/assets/verified')
         .reply(200, {
-          data: [
+          assets: [
             { identifier: '0123', extra: 'should be ignored' },
             { identifier: 'abcd', extra: 'should be ignored' },
           ],
@@ -58,11 +58,11 @@ describe('Assets Verification API Client', () => {
       nock('https://test')
         .get('/assets/verified')
         .reply(200, {
-          data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+          assets: [{ identifier: '0123' }, { identifier: 'abcd' }],
         })
         .get('/assets/verified')
         .reply(200, {
-          data: [{ identifier: '4567' }, { identifier: '0123' }],
+          assets: [{ identifier: '4567' }, { identifier: '0123' }],
         })
 
       const api = new AssetsVerificationApi({
@@ -84,7 +84,7 @@ describe('Assets Verification API Client', () => {
         .reply(
           200,
           {
-            data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+            assets: [{ identifier: '0123' }, { identifier: 'abcd' }],
           },
           {
             'last-modified': lastModified,
@@ -123,7 +123,7 @@ describe('Assets Verification API Client', () => {
         .get('/assets/verified')
         .delayConnection(2000)
         .reply(200, {
-          data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+          assets: [{ identifier: '0123' }, { identifier: 'abcd' }],
         })
 
       const api = new AssetsVerificationApi({
@@ -138,7 +138,7 @@ describe('Assets Verification API Client', () => {
         .get('/assets/verified')
         .delay(2000)
         .reply(200, {
-          data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+          assets: [{ identifier: '0123' }, { identifier: 'abcd' }],
         })
 
       const api = new AssetsVerificationApi({
@@ -150,7 +150,7 @@ describe('Assets Verification API Client', () => {
 
     it('supports file:// URIs', async () => {
       const contents = JSON.stringify({
-        data: [{ identifier: '0123' }, { identifier: 'abcd' }],
+        assets: [{ identifier: '0123' }, { identifier: 'abcd' }],
       })
       const readFileSpy = jest.spyOn(fs.promises, 'readFile').mockResolvedValue(contents)
 

--- a/ironfish/src/assets/assetsVerificationApi.ts
+++ b/ironfish/src/assets/assetsVerificationApi.ts
@@ -6,7 +6,7 @@ import { readFile } from 'node:fs/promises'
 import url, { URL } from 'url'
 
 type GetVerifiedAssetsResponse = {
-  data: Array<{ identifier: string }>
+  assets: Array<{ identifier: string }>
 }
 
 type GetVerifiedAssetsRequestHeaders = {
@@ -63,7 +63,7 @@ export class AssetsVerificationApi {
   readonly url: string
 
   constructor(options?: { url?: string; timeout?: number }) {
-    this.url = options?.url || 'https://api.ironfish.network/assets?verified=true'
+    this.url = options?.url || 'https://api.ironfish.network/assets/verified'
     this.timeout = options?.timeout ?? 30 * 1000 // 30 seconds
     this.adapter = isFileUrl(this.url) ? axiosFileAdapter : axios.defaults.adapter
   }
@@ -95,7 +95,7 @@ export class AssetsVerificationApi {
           headers: GetVerifiedAssetsResponseHeaders
         }) => {
           verifiedAssets['assetIds'].clear()
-          response.data.data.forEach(({ identifier }) => {
+          response.data.assets.forEach(({ identifier }) => {
             return verifiedAssets['assetIds'].add(identifier)
           })
           verifiedAssets['lastModified'] = response.headers['last-modified']

--- a/ironfish/src/assets/assetsVerifier.test.ts
+++ b/ironfish/src/assets/assetsVerifier.test.ts
@@ -38,15 +38,15 @@ describe('AssetsVerifier', () => {
     nock('https://test')
       .get('/assets/verified')
       .reply(200, {
-        data: [{ identifier: '0123' }],
+        assets: [{ identifier: '0123' }],
       })
       .get('/assets/verified')
       .reply(200, {
-        data: [{ identifier: '4567' }],
+        assets: [{ identifier: '4567' }],
       })
       .get('/assets/verified')
       .reply(200, {
-        data: [{ identifier: '89ab' }],
+        assets: [{ identifier: '89ab' }],
       })
 
     const assetsVerifier = new AssetsVerifier({
@@ -87,7 +87,7 @@ describe('AssetsVerifier', () => {
     nock('https://test')
       .get('/assets/verified')
       .reply(200, {
-        data: [{ identifier: '0123' }],
+        assets: [{ identifier: '0123' }],
       })
 
     const assetsVerifier = new AssetsVerifier({
@@ -110,7 +110,7 @@ describe('AssetsVerifier', () => {
       .reply(
         200,
         {
-          data: [{ identifier: '0123' }],
+          assets: [{ identifier: '0123' }],
         },
         { 'last-modified': 'some-date' },
       )
@@ -168,7 +168,7 @@ describe('AssetsVerifier', () => {
       nock('https://test')
         .get('/assets/verified')
         .reply(200, {
-          data: [{ identifier: '0123' }],
+          assets: [{ identifier: '0123' }],
         })
 
       const assetsVerifier = new AssetsVerifier({
@@ -186,7 +186,7 @@ describe('AssetsVerifier', () => {
       nock('https://test')
         .get('/assets/verified')
         .reply(200, {
-          data: [{ identifier: '0123' }],
+          assets: [{ identifier: '0123' }],
         })
 
       const assetsVerifier = new AssetsVerifier({
@@ -204,7 +204,7 @@ describe('AssetsVerifier', () => {
       nock('https://test')
         .get('/assets/verified')
         .reply(200, {
-          data: [{ identifier: '0123' }],
+          assets: [{ identifier: '0123' }],
         })
         .get('/assets/verified')
         .reply(500)
@@ -236,7 +236,7 @@ describe('AssetsVerifier', () => {
       nock('https://test')
         .get('/assets/verified')
         .reply(200, {
-          data: [{ identifier: '0123' }],
+          assets: [{ identifier: '0123' }],
         })
 
       const assetsVerifier = new AssetsVerifier({
@@ -270,7 +270,7 @@ describe('AssetsVerifier', () => {
       nock('https://test')
         .get('/assets/verified')
         .reply(200, {
-          data: [{ identifier: '4567' }],
+          assets: [{ identifier: '4567' }],
         })
 
       const assetsVerifier = new AssetsVerifier({
@@ -299,7 +299,7 @@ describe('AssetsVerifier', () => {
       nock('https://bar.test')
         .get('/assets/verified')
         .reply(200, {
-          data: [{ identifier: '4567' }],
+          assets: [{ identifier: '4567' }],
         })
 
       const assetsVerifier = new AssetsVerifier({
@@ -327,13 +327,13 @@ describe('AssetsVerifier', () => {
       nock('https://test')
         .get('/assets/verified')
         .reply(200, {
-          data: [{ identifier: '0123' }],
+          assets: [{ identifier: '0123' }],
         })
         .get('/assets/verified')
         .reply(
           200,
           {
-            data: [{ identifier: '4567' }],
+            assets: [{ identifier: '4567' }],
           },
           { 'last-modified': 'some-date' },
         )


### PR DESCRIPTION
## Summary

Change the assets verifier to use the new API endpoint introduced by https://github.com/iron-fish/ironfish-api/pull/1572.

## Testing Plan

```
$ # if running the api locally
$ ironfish config:set assetVerificationApi http://localhost:8003/assets/verified
$ ironfish start --verbose |& grep asset
```

Observe the endpoint being properly queried without errors.

## Documentation

No doc change required

## Breaking Change

Not a breaking change