### PR TITLE
fix: roll up errors from decodeAccount function

### DIFF
--- a/ironfish/src/wallet/account/encoder/account.ts
+++ b/ironfish/src/wallet/account/encoder/account.ts
@@ -42,15 +42,18 @@ export function decodeAccount(
   options: AccountDecodingOptions = {},
 ): AccountImport {
   let decoded = null
+  const errors: { name: string; err: Error }[] = []
   for (const encoder of ENCODER_VERSIONS) {
     try {
       decoded = new encoder().decode(value, options)
     } catch (e) {
+      errors.push({ name: encoder.name, err: e as Error })
       continue
     }
     if (decoded) {
       return decoded
     }
   }
-  throw new Error('Account could not be decoded')
+  const errorString = errors.map((error) => `${error.name}: ${error.err.message}`).join('\n')
+  throw new Error(`Account could not be decoded, decoder errors:\n${errorString} `)
 }


### PR DESCRIPTION
## Summary
Rolls up errors from attempted decoders.

## Testing Plan
```
fish wallet:import
Paste the output of wallet:export, or your spending key: own bicycle nasty chaos type agent amateur inject cheese spare poverty charge ecology portion frame earn garden shed bulk youth patch sugar physical family
Account could not be decoded, decoder errors:
JsonEncoder: Unexpected token o in JSON at position 0
MnemonicEncoder: Name option is required for mnemonic key encoder
SpendingKeyEncoder: Name option is required for spending key encoder
Bech32JsonEncoder: Invalid bech32 JSON encoding
Bech32Encoder: Could not decode account own bicycle nasty chaos type agent amateur inject cheese spare poverty charge ecology portion frame earn garden shed bulk youth patch sugar physical family using bech32 
```
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
