### PR TITLE
supports mnemonic and spending key import without name

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -52,35 +52,25 @@ export class ImportCommand extends IronfishCommand {
       CliUx.ux.error(`Invalid import type`)
     }
 
-    const accountsResponse = await client.wallet.getAccounts()
-    const duplicateAccount = accountsResponse.content.accounts.find(
-      (accountName) => accountName === flags.name,
-    )
-    // Offer the user to use a different name if a duplicate is found
-    if (duplicateAccount && flags.name) {
+    if (!flags.name) {
       this.log()
-      this.log(`Found existing account with name '${flags.name}'`)
 
-      const name = await CliUx.ux.prompt('Enter a different name for the account', {
-        required: true,
+      flags.name = await CliUx.ux.prompt('Enter a name for the account (or leave blank)', {
+        required: false,
       })
-      if (name === flags.name) {
-        this.error(`Entered the same name: '${name}'`)
-      }
-
-      flags.name = name
     }
 
     const rescan = flags.rescan
     const result = await client.wallet.importAccount({ account, rescan, name: flags.name })
 
     const { name, isDefaultAccount } = result.content
-    this.log(`Account ${name} imported.`)
+    this.log(`Account imported with name ${name}`)
 
     if (isDefaultAccount) {
       this.log(`The default account is now: ${name}`)
     } else {
       this.log(`Run "ironfish wallet:use ${name}" to set the account as default`)
+      this.log(`Use "ironfish wallet:rename ${name} [new-name]" to rename the account`)
     }
   }
 

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -41,16 +41,21 @@ router.register<typeof ImportAccountRequestSchema, ImportResponse>(
   ImportAccountRequestSchema,
   async (request, node): Promise<void> => {
     let accountImport = null
+    const id = uuid()
     if (typeof request.data.account === 'string') {
       accountImport = decodeAccount(request.data.account, {
-        name: request.data.name,
+        name: request.data.name ? request.data.name : id,
       })
     } else {
       accountImport = deserializeRpcAccountImport(request.data.account)
     }
 
+    if (request.data.name) {
+      accountImport.name = request.data.name
+    }
+
     const account = await node.wallet.importAccount({
-      id: uuid(),
+      id,
       ...accountImport,
     })
 

--- a/ironfish/src/wallet/account/encoder/bech32.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.ts
@@ -6,7 +6,7 @@ import bufio from 'bufio'
 import { Bech32m } from '../../../utils'
 import { AccountImport, KEY_LENGTH, VIEW_KEY_LENGTH } from '../../walletdb/accountValue'
 import { ACCOUNT_SCHEMA_VERSION } from '../account'
-import { AccountDecodingOptions, AccountEncoder } from './encoder'
+import { AccountEncoder } from './encoder'
 
 export const BECH32_ACCOUNT_PREFIX = 'ifaccount'
 export class Bech32Encoder implements AccountEncoder {
@@ -36,7 +36,7 @@ export class Bech32Encoder implements AccountEncoder {
     return Bech32m.encode(bw.render().toString('hex'), BECH32_ACCOUNT_PREFIX)
   }
 
-  decode(value: string, options?: AccountDecodingOptions): AccountImport {
+  decode(value: string): AccountImport {
     const [hexEncoding, _] = Bech32m.decode(value)
 
     if (hexEncoding === null) {
@@ -74,7 +74,7 @@ export class Bech32Encoder implements AccountEncoder {
 
     return {
       version: ACCOUNT_SCHEMA_VERSION,
-      name: options?.name ? options.name : name,
+      name,
       viewKey,
       incomingViewKey,
       outgoingViewKey,

--- a/ironfish/src/wallet/account/encoder/json.ts
+++ b/ironfish/src/wallet/account/encoder/json.ts
@@ -4,7 +4,7 @@
 import { RpcAccountImport } from '../../../rpc/routes/wallet/types'
 import { validateAccount } from '../../validator'
 import { AccountImport } from '../../walletdb/accountValue'
-import { AccountDecodingOptions, AccountEncoder } from './encoder'
+import { AccountEncoder } from './encoder'
 
 export class JsonEncoder implements AccountEncoder {
   encode(value: AccountImport): string {
@@ -18,7 +18,7 @@ export class JsonEncoder implements AccountEncoder {
     return JSON.stringify({ ...value, createdAt })
   }
 
-  decode(value: string, options?: AccountDecodingOptions): AccountImport {
+  decode(value: string): AccountImport {
     const account = JSON.parse(value) as RpcAccountImport
 
     if (account.createdAt && !account.createdAt.hash) {
@@ -27,7 +27,6 @@ export class JsonEncoder implements AccountEncoder {
 
     const updatedAccount = {
       ...account,
-      name: options?.name ? options.name : account.name,
       createdAt: account.createdAt
         ? {
             hash: Buffer.from(account.createdAt.hash, 'hex'),


### PR DESCRIPTION
## Summary

mnemonic and spending key account export data does not include an account name, so users need to provide a name or the import will fail.

we currently fail on these imports because we don't decode the import data in the cli

- prompts user to enter an account name if they did not use the --name flag, allows users to not enter name
- if no name is provided, use the uuid for the account as its name to try to decode it as a mnemonic phrase or spending key
- print instructions on renaming account

## Testing Plan

manual testing:
```
hughy@Hughs-MacBook-Pro ironfish % fish wallet:export test --mnemonic                                                                                                                                          
yarn run v1.22.18
$ yarn build && yarn start:js wallet:export test --mnemonic
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:export test --mnemonic
artwork convince waste fence always lava labor foster join have math below year resource invest hover frozen season hair punch clinic smooth light milk
✨  Done in 2.40s.
hughy@Hughs-MacBook-Pro ironfish % fish wallet:delete test                                                                                                                                                     
yarn run v1.22.18
$ yarn build && yarn start:js wallet:delete test
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:delete test
Deleting account 'test'... done
Account 'test' successfully deleted.
✨  Done in 2.50s.
hughy@Hughs-MacBook-Pro ironfish % fish wallet:import "artwork convince waste fence always lava labor foster join have math below year resource invest hover frozen season hair punch clinic smooth light milk"
yarn run v1.22.18
$ yarn build && yarn start:js wallet:import 'artwork convince waste fence always lava labor foster join have math below year resource invest hover frozen season hair punch clinic smooth light milk'
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:import 'artwork convince waste fence always lava labor foster join have math below year resource invest hover frozen season hair punch clinic smooth light milk'

Enter a name for the account (or leave blank): 
Account imported with name d7952751-fa86-430f-8ddb-248b3db145f6
Run "ironfish wallet:use d7952751-fa86-430f-8ddb-248b3db145f6" to set the account as default
Use "ironfish wallet:rename d7952751-fa86-430f-8ddb-248b3db145f6 [new-name]" to rename the account
✨  Done in 3.44s.
hughy@Hughs-MacBook-Pro ironfish % fish wallet:rename d7952751-fa86-430f-8ddb-248b3db145f6 test
yarn run v1.22.18
$ yarn build && yarn start:js wallet:rename d7952751-fa86-430f-8ddb-248b3db145f6 test
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run wallet:rename d7952751-fa86-430f-8ddb-248b3db145f6 test
Account d7952751-fa86-430f-8ddb-248b3db145f6 renamed to test
✨  Done in 2.39s.
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
