### PR TITLE
Add encoder name to DecoderFailed

### DIFF
--- a/ironfish/src/wallet/account/encoder/account.ts
+++ b/ironfish/src/wallet/account/encoder/account.ts
@@ -46,23 +46,24 @@ export function decodeAccount(
   value: string,
   options: AccountDecodingOptions = {},
 ): AccountImport {
-  let decoded = null
-  const errors: { name: string; err: Error }[] = []
+  const errors: DecodeFailed[] = []
+
   for (const encoder of ENCODER_VERSIONS) {
     try {
-      decoded = new encoder().decode(value, options)
+      const decoded = new encoder().decode(value, options)
+
+      if (decoded) {
+        return decoded
+      }
     } catch (e) {
       if (e instanceof DecodeFailed) {
-        errors.push({ name: encoder.name, err: e as Error })
-        continue
+        errors.push(e)
       } else {
         throw e
       }
     }
-    if (decoded) {
-      return decoded
-    }
   }
-  const errorString = errors.map((error) => `${error.name}: ${error.err.message}`).join('\n')
+
+  const errorString = errors.map((error) => `${error.decoder}: ${error.message}`).join('\n')
   throw new Error(`Account could not be decoded, decoder errors:\n${errorString} `)
 }

--- a/ironfish/src/wallet/account/encoder/bech32.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.ts
@@ -42,6 +42,7 @@ export class Bech32Encoder implements AccountEncoder {
     if (!hexEncoding) {
       throw new DecodeFailed(
         `Could not decode account ${value} using bech32: ${err?.message || ''}`,
+        this.constructor.name,
       )
     }
 
@@ -84,7 +85,10 @@ export class Bech32Encoder implements AccountEncoder {
       }
     } catch (e) {
       if (e instanceof EncodingError) {
-        throw new DecodeFailed(`Bufio decoding failed while using bech32 encoder: ${e.message}`)
+        throw new DecodeFailed(
+          `Bufio decoding failed while using bech32 encoder: ${e.message}`,
+          this.constructor.name,
+        )
       }
       throw e
     }

--- a/ironfish/src/wallet/account/encoder/bech32json.ts
+++ b/ironfish/src/wallet/account/encoder/bech32json.ts
@@ -16,7 +16,10 @@ export class Bech32JsonEncoder implements AccountEncoder {
   decode(value: string, options?: AccountDecodingOptions): AccountImport {
     const [decoded, err] = Bech32m.decode(value)
     if (!decoded) {
-      throw new DecodeFailed(`Invalid bech32 JSON encoding: ${err?.message || ''}`)
+      throw new DecodeFailed(
+        `Invalid bech32 JSON encoding: ${err?.message || ''}`,
+        this.constructor.name,
+      )
     }
     const accountImport = new JsonEncoder().decode(decoded)
     return {

--- a/ironfish/src/wallet/account/encoder/encoder.ts
+++ b/ironfish/src/wallet/account/encoder/encoder.ts
@@ -6,7 +6,14 @@ import { AccountImport } from '../../walletdb/accountValue'
 
 export class DecodeInvalid extends Error {}
 
-export class DecodeFailed extends Error {}
+export class DecodeFailed extends Error {
+  decoder: string
+
+  constructor(message?: string, decoder?: string) {
+    super(message)
+    this.decoder = decoder ?? ''
+  }
+}
 
 export enum AccountFormat {
   JSON = 'JSON',

--- a/ironfish/src/wallet/account/encoder/json.ts
+++ b/ironfish/src/wallet/account/encoder/json.ts
@@ -38,7 +38,7 @@ export class JsonEncoder implements AccountEncoder {
       validateAccount(accountImport)
       return accountImport
     } catch (e) {
-      throw new DecodeFailed(`Invalid JSON: ${(e as Error).message}`)
+      throw new DecodeFailed(`Invalid JSON: ${(e as Error).message}`, this.constructor.name)
     }
   }
 }

--- a/ironfish/src/wallet/account/encoder/mnemonic.ts
+++ b/ironfish/src/wallet/account/encoder/mnemonic.ts
@@ -44,7 +44,7 @@ export class MnemonicEncoder implements AccountEncoder {
       language = LanguageUtils.languageCodeToKey(code)
     }
     if (language === null) {
-      throw new DecodeFailed('Invalid mnemonic')
+      throw new DecodeFailed('Invalid mnemonic', this.constructor.name)
     }
     if (!options.name) {
       throw new DecodeInvalid('Name option is required for mnemonic key encoder')

--- a/ironfish/src/wallet/account/encoder/spendingKey.ts
+++ b/ironfish/src/wallet/account/encoder/spendingKey.ts
@@ -19,7 +19,10 @@ export class SpendingKeyEncoder implements AccountEncoder {
     try {
       key = generateKeyFromPrivateKey(spendingKey)
     } catch (e) {
-      throw new DecodeFailed(`Invalid spending key: ${(e as Error).message}`)
+      throw new DecodeFailed(
+        `Invalid spending key: ${(e as Error).message}`,
+        this.constructor.name,
+      )
     }
 
     if (!options.name) {


### PR DESCRIPTION
## Summary

I think it makes sense for the DecoderFailed error to contain the name of the decoder that it was produced from. It also makes the code a bit simpler when you are relying on accumulating errors, but need a new wrapper type because you lose the encoder name in the error.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
