### PR TITLE
moves broadcastTransaction into RpcClient chain namespace

### DIFF
--- a/ironfish-cli/src/commands/chain/broadcast.ts
+++ b/ironfish-cli/src/commands/chain/broadcast.ts
@@ -26,7 +26,7 @@ export class BroadcastCommand extends IronfishCommand {
 
     CliUx.ux.action.start(`Broadcasting transaction`)
     const client = await this.sdk.connectRpc()
-    const response = await client.broadcastTransaction({ transaction })
+    const response = await client.chain.broadcastTransaction({ transaction })
     if (response.content) {
       CliUx.ux.action.stop(`Transaction broadcasted: ${response.content.hash}`)
     }

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -703,6 +703,15 @@ export abstract class RpcClient {
         params,
       ).waitForEnd()
     },
+
+    broadcastTransaction: (
+      params: BroadcastTransactionRequest,
+    ): Promise<RpcResponse<BroadcastTransactionResponse>> => {
+      return this.request<BroadcastTransactionResponse>(
+        `${ApiNamespace.chain}/broadcastTransaction`,
+        params,
+      ).waitForEnd()
+    },
   }
 
   config = {
@@ -739,14 +748,5 @@ export abstract class RpcClient {
         params,
       ).waitForEnd()
     },
-  }
-
-  async broadcastTransaction(
-    params: BroadcastTransactionRequest,
-  ): Promise<RpcResponse<BroadcastTransactionResponse>> {
-    return this.request<BroadcastTransactionResponse>(
-      `${ApiNamespace.chain}/broadcastTransaction`,
-      params,
-    ).waitForEnd()
   }
 }

--- a/ironfish/src/rpc/routes/chain/broadcastTransaction.test.ts
+++ b/ironfish/src/rpc/routes/chain/broadcastTransaction.test.ts
@@ -13,7 +13,7 @@ describe('Route chain/broadcastTransaction', () => {
 
     const broadcastSpy = jest.spyOn(routeTest.peerNetwork, 'broadcastTransaction')
 
-    const response = await routeTest.client.broadcastTransaction({
+    const response = await routeTest.client.chain.broadcastTransaction({
       transaction: transaction.serialize().toString('hex'),
     })
 
@@ -24,7 +24,7 @@ describe('Route chain/broadcastTransaction', () => {
 
   it("should return an error if the transaction won't deserialize", async () => {
     await expect(
-      routeTest.client.broadcastTransaction({
+      routeTest.client.chain.broadcastTransaction({
         transaction: '0xdeadbeef',
       }),
     ).rejects.toThrow('Out of bounds read')


### PR DESCRIPTION
## Summary

all other rpc routes defined on the RpcClient are found within their namespaces. only 'chain/broadcastTransaction' is used directly without its namespace.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
