### PR TITLE
adds standalone wallet config options

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -283,7 +283,7 @@ export type ConfigOptions = {
   /**
    * Enable the node's in-process wallet to scan blocks and mempool transactions
    */
-  enableWalletScanning: boolean
+  walletScanningEnabled: boolean
 
   /**
    * Enable standalone wallet process to connect to a node via IPC
@@ -418,7 +418,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     memPoolRecentlyEvictedCacheSize: yup.number().integer(),
     networkDefinitionPath: yup.string().trim(),
     incomingWebSocketWhitelist: yup.array(yup.string().trim().defined()),
-    enableWalletScanning: yup.boolean(),
+    walletScanningEnabled: yup.boolean(),
     walletNodeIpcEnabled: yup.boolean(),
     walletNodeIpcPath: yup.string(),
     walletNodeTcpEnabled: yup.boolean(),
@@ -534,7 +534,7 @@ export class Config extends KeyStore<ConfigOptions> {
       memPoolRecentlyEvictedCacheSize: 60000,
       networkDefinitionPath: files.resolve(files.join(dataDir, 'network.json')),
       incomingWebSocketWhitelist: [],
-      enableWalletScanning: true,
+      walletScanningEnabled: true,
       walletNodeIpcEnabled: true,
       walletNodeIpcPath: files.resolve(files.join(dataDir, 'ironfish.ipc')),
       walletNodeTcpEnabled: false,

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -279,6 +279,66 @@ export type ConfigOptions = {
    * Always allow incoming connections from these IPs even if the node is at maxPeers
    */
   incomingWebSocketWhitelist: string[]
+
+  /**
+   * Enable the node's in-process wallet to scan blocks and mempool transactions
+   */
+  enableWalletScanning: boolean
+
+  /**
+   * Enable standalone wallet process to connect to a node via IPC
+   */
+  walletNodeIpcEnabled: boolean
+  walletNodeIpcPath: string
+
+  /**
+   * Enable stanalone wallet process to connect to a node via TCP
+   */
+  walletNodeTcpEnabled: boolean
+  walletNodeTcpHost: string
+  walletNodeTcpPort: number
+  walletNodeTlsEnabled: boolean
+
+  /**
+   * Enable standalone wallet process to connect to a node via HTTP
+   */
+  walletNodeHttpEnabled: boolean
+  walletNodeHttpHost: string
+  walletNodeHttpPort: number
+
+  /**
+   * Enable IPC connections to a standalone wallet RPC server
+   */
+  walletEnableRpcIpc: boolean
+  walletRpcIpcPath: string
+
+  /**
+   * Enable TCP connections to a standalone wallet RPC server
+   */
+  walletEnableRpcTcp: boolean
+  walletRpcTcpHost: string
+  walletRpcTcpPort: number
+
+  /**
+   * Enable TLS for TCP connections to a standalone wallet RPC server
+   */
+  walletEnableRpcTls: boolean
+  walletTlsKeyPath: string
+  walletTlsCertPath: string
+
+  /**
+   * Enable HTTP connections to a standalone wallet RPC server
+   */
+  walletEnableRpcHttp: boolean
+  walletRpcHttpHost: string
+  walletRpcHttpPort: number
+
+  /**
+   * The number of CPU workers to use in the worker pool of a standalone wallet
+   * process. See config "nodeWorkers"
+   */
+  walletWorkers: number
+  walletWorkersMax: number
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -358,6 +418,29 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     memPoolRecentlyEvictedCacheSize: yup.number().integer(),
     networkDefinitionPath: yup.string().trim(),
     incomingWebSocketWhitelist: yup.array(yup.string().trim().defined()),
+    enableWalletScanning: yup.boolean(),
+    walletNodeIpcEnabled: yup.boolean(),
+    walletNodeIpcPath: yup.string(),
+    walletNodeTcpEnabled: yup.boolean(),
+    walletNodeTcpHost: yup.string(),
+    walletNodeTcpPort: yup.number(),
+    walletNodeTlsEnabled: yup.boolean(),
+    walletNodeHttpEnabled: yup.boolean(),
+    walletNodeHttpHost: yup.string(),
+    walletNodeHttpPort: yup.number(),
+    walletEnableRpcIpc: yup.boolean(),
+    walletRpcIpcPath: yup.string(),
+    walletEnableRpcTcp: yup.boolean(),
+    walletRpcTcpHost: yup.string(),
+    walletRpcTcpPort: yup.number(),
+    walletEnableRpcTls: yup.boolean(),
+    walletTlsKeyPath: yup.string(),
+    walletTlsCertPath: yup.string(),
+    walletEnableRpcHttp: yup.boolean(),
+    walletRpcHttpHost: yup.string(),
+    walletRpcHttpPort: yup.number(),
+    walletWorkers: yup.number(),
+    walletWorkersMax: yup.number(),
   })
   .defined()
 
@@ -451,6 +534,29 @@ export class Config extends KeyStore<ConfigOptions> {
       memPoolRecentlyEvictedCacheSize: 60000,
       networkDefinitionPath: files.resolve(files.join(dataDir, 'network.json')),
       incomingWebSocketWhitelist: [],
+      enableWalletScanning: true,
+      walletNodeIpcEnabled: true,
+      walletNodeIpcPath: files.resolve(files.join(dataDir, 'ironfish.ipc')),
+      walletNodeTcpEnabled: false,
+      walletNodeTcpHost: 'localhost',
+      walletNodeTcpPort: 8020,
+      walletNodeTlsEnabled: true,
+      walletNodeHttpEnabled: false,
+      walletNodeHttpHost: 'localhost',
+      walletNodeHttpPort: 8021,
+      walletEnableRpcIpc: true,
+      walletRpcIpcPath: files.resolve(files.join(dataDir, 'ironfish.wallet.ipc')),
+      walletEnableRpcTcp: false,
+      walletRpcTcpHost: 'localhost',
+      walletRpcTcpPort: 8022,
+      walletEnableRpcTls: true,
+      walletTlsKeyPath: files.resolve(files.join(dataDir, 'certs', 'wallet-key.pem')),
+      walletTlsCertPath: files.resolve(files.join(dataDir, 'certs', 'wallet-cert.pem')),
+      walletEnableRpcHttp: false,
+      walletRpcHttpHost: 'localhost',
+      walletRpcHttpPort: 8023,
+      walletWorkers: -1,
+      walletWorkersMax: 6,
     }
   }
 }


### PR DESCRIPTION
## Summary

running a standalone wallet requires config options for the wallet's RPC connection to a node, for the wallet's RPC server, and for the wallet's worker pool

adds config options to the Config store and sets default values:
- sets default options for wallet node RPC connections to mirror node RPC server defaults
- sets defaults for wallet RPC server to match defaults for node RPC server
- uses separate default IPC filepath for wallet RPC server
- uses separate default TLS files for wallet RPC server
- uses distinct port for each TCP and HTTP server
- uses same defaults for wallet worker pool as node worker pool

## Testing Plan

config options are defined, but not yet used

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
