### PR TITLE
Register chain routes in common place

### DIFF
--- a/ironfish-cli/src/commands/service/sync.ts
+++ b/ironfish-cli/src/commands/service/sync.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
-  FollowChainStreamResponse,
+  FollowChainStream,
   Meter,
   RpcClient,
   TimeUtils,
@@ -106,7 +106,7 @@ export default class Sync extends IronfishCommand {
     const speed = new Meter()
     speed.start()
 
-    const buffer = new Array<FollowChainStreamResponse>()
+    const buffer = new Array<FollowChainStream.Response>()
 
     async function commit(): Promise<void> {
       await api.blocks(buffer)

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -11,24 +11,19 @@ import {
   ApiNamespace,
   BlockTemplateStreamRequest,
   BlockTemplateStreamResponse,
-  BroadcastTransactionRequest,
-  BroadcastTransactionResponse,
+  BroadcastTransaction,
   BurnAssetRequest,
   BurnAssetResponse,
   CreateAccountRequest,
   CreateAccountResponse,
   CreateTransactionRequest,
   CreateTransactionResponse,
-  EstimateFeeRateRequest,
-  EstimateFeeRateResponse,
-  EstimateFeeRatesRequest,
-  EstimateFeeRatesResponse,
+  EstimateFeeRate,
+  EstimateFeeRates,
   ExportAccountRequest,
   ExportAccountResponse,
-  ExportChainStreamRequest,
-  ExportChainStreamResponse,
-  FollowChainStreamRequest,
-  FollowChainStreamResponse,
+  ExportChainStream,
+  FollowChainStream,
   GetAccountNotesStreamRequest,
   GetAccountNotesStreamResponse,
   GetAccountsRequest,
@@ -39,8 +34,7 @@ import {
   GetAccountTransactionResponse,
   GetAccountTransactionsRequest,
   GetAccountTransactionsResponse,
-  GetAssetRequest,
-  GetAssetResponse,
+  GetAsset,
   GetAssetsRequest,
   GetAssetsResponse,
   GetBalanceRequest,
@@ -49,32 +43,25 @@ import {
   GetBalancesResponse,
   GetBannedPeersRequest,
   GetBannedPeersResponse,
-  GetBlockRequest,
-  GetBlockResponse,
-  GetChainInfoRequest,
-  GetChainInfoResponse,
+  GetBlock,
+  GetChainInfo,
   GetConfigRequest,
   GetConfigResponse,
-  GetConsensusParametersRequest,
-  GetConsensusParametersResponse,
+  GetConsensusParameters,
   GetDefaultAccountRequest,
   GetDefaultAccountResponse,
-  GetDifficultyRequest,
-  GetDifficultyResponse,
+  GetDifficulty,
   GetFundsRequest,
   GetFundsResponse,
   GetLogStreamResponse,
   GetMempoolStatusResponse,
   GetMempoolTransactionResponse,
   GetMempoolTransactionsRequest,
-  GetNetworkHashPowerRequest,
-  GetNetworkHashPowerResponse,
-  GetNetworkInfoRequest,
-  GetNetworkInfoResponse,
+  GetNetworkHashPower,
+  GetNetworkInfo,
   GetNodeStatusRequest,
   GetNodeStatusResponse,
-  GetNoteWitnessRequest,
-  GetNoteWitnessResponse,
+  GetNoteWitness,
   GetPeerMessagesRequest,
   GetPeerMessagesResponse,
   GetPeerRequest,
@@ -85,14 +72,13 @@ import {
   GetPublicKeyResponse,
   GetRpcStatusRequest,
   GetRpcStatusResponse,
-  GetTransactionRequest,
-  GetTransactionResponse,
-  GetTransactionStreamRequest,
-  GetTransactionStreamResponse,
+  GetTransaction,
+  GetTransactionStream,
   GetWorkersStatusRequest,
   GetWorkersStatusResponse,
   ImportAccountRequest,
   ImportResponse,
+  IsValidPublicAddress,
   MintAssetRequest,
   MintAssetResponse,
   OnGossipRequest,
@@ -113,8 +99,7 @@ import {
   SendTransactionResponse,
   SetConfigRequest,
   SetConfigResponse,
-  ShowChainRequest,
-  ShowChainResponse,
+  ShowChain,
   StopNodeResponse,
   SubmitBlockRequest,
   SubmitBlockResponse,
@@ -125,10 +110,6 @@ import {
   UseAccountRequest,
   UseAccountResponse,
 } from '../routes'
-import {
-  IsValidPublicAddressRequest,
-  IsValidPublicAddressResponse,
-} from '../routes/chain/isValidPublicAddress'
 import { GetNotesRequest, GetNotesResponse } from '../routes/wallet/getNotes'
 
 export abstract class RpcClient {
@@ -565,149 +546,149 @@ export abstract class RpcClient {
 
   chain = {
     estimateFeeRates: (
-      params?: EstimateFeeRatesRequest,
-    ): Promise<RpcResponseEnded<EstimateFeeRatesResponse>> => {
-      return this.request<EstimateFeeRatesResponse>(
+      params?: EstimateFeeRates.Request,
+    ): Promise<RpcResponseEnded<EstimateFeeRates.Response>> => {
+      return this.request<EstimateFeeRates.Response>(
         `${ApiNamespace.chain}/estimateFeeRates`,
         params,
       ).waitForEnd()
     },
 
     estimateFeeRate: (
-      params?: EstimateFeeRateRequest,
-    ): Promise<RpcResponseEnded<EstimateFeeRateResponse>> => {
-      return this.request<EstimateFeeRateResponse>(
+      params?: EstimateFeeRate.Request,
+    ): Promise<RpcResponseEnded<EstimateFeeRate.Response>> => {
+      return this.request<EstimateFeeRate.Response>(
         `${ApiNamespace.chain}/estimateFeeRate`,
         params,
       ).waitForEnd()
     },
 
     getChainInfo: (
-      params: GetChainInfoRequest = undefined,
-    ): Promise<RpcResponseEnded<GetChainInfoResponse>> => {
-      return this.request<GetChainInfoResponse>(
+      params: GetChainInfo.Request = undefined,
+    ): Promise<RpcResponseEnded<GetChainInfo.Response>> => {
+      return this.request<GetChainInfo.Response>(
         `${ApiNamespace.chain}/getChainInfo`,
         params,
       ).waitForEnd()
     },
 
     exportChainStream: (
-      params: ExportChainStreamRequest = undefined,
-    ): RpcResponse<void, ExportChainStreamResponse> => {
-      return this.request<void, ExportChainStreamResponse>(
+      params: ExportChainStream.Request = undefined,
+    ): RpcResponse<void, ExportChainStream.Response> => {
+      return this.request<void, ExportChainStream.Response>(
         `${ApiNamespace.chain}/exportChainStream`,
         params,
       )
     },
 
     followChainStream: (
-      params: FollowChainStreamRequest = undefined,
-    ): RpcResponse<void, FollowChainStreamResponse> => {
-      return this.request<void, FollowChainStreamResponse>(
+      params: FollowChainStream.Request = undefined,
+    ): RpcResponse<void, FollowChainStream.Response> => {
+      return this.request<void, FollowChainStream.Response>(
         `${ApiNamespace.chain}/followChainStream`,
         params,
       )
     },
 
-    getBlock: (params: GetBlockRequest): Promise<RpcResponseEnded<GetBlockResponse>> => {
-      return this.request<GetBlockResponse>(
+    getBlock: (params: GetBlock.Request): Promise<RpcResponseEnded<GetBlock.Response>> => {
+      return this.request<GetBlock.Response>(
         `${ApiNamespace.chain}/getBlock`,
         params,
       ).waitForEnd()
     },
 
     getDifficulty: (
-      params: GetDifficultyRequest = undefined,
-    ): Promise<RpcResponseEnded<GetDifficultyResponse>> => {
-      return this.request<GetDifficultyResponse>(
+      params: GetDifficulty.Request = undefined,
+    ): Promise<RpcResponseEnded<GetDifficulty.Response>> => {
+      return this.request<GetDifficulty.Response>(
         `${ApiNamespace.chain}/getDifficulty`,
         params,
       ).waitForEnd()
     },
 
     getNoteWitness: (
-      params: GetNoteWitnessRequest,
-    ): Promise<RpcResponseEnded<GetNoteWitnessResponse>> => {
-      return this.request<GetNoteWitnessResponse>(
+      params: GetNoteWitness.Request,
+    ): Promise<RpcResponseEnded<GetNoteWitness.Response>> => {
+      return this.request<GetNoteWitness.Response>(
         `${ApiNamespace.chain}/getNoteWitness`,
         params,
       ).waitForEnd()
     },
 
     getNetworkHashPower: (
-      params: GetNetworkHashPowerRequest,
-    ): Promise<RpcResponseEnded<GetNetworkHashPowerResponse>> => {
-      return this.request<GetNetworkHashPowerResponse>(
+      params: GetNetworkHashPower.Request,
+    ): Promise<RpcResponseEnded<GetNetworkHashPower.Response>> => {
+      return this.request<GetNetworkHashPower.Response>(
         `${ApiNamespace.chain}/getNetworkHashPower`,
         params,
       ).waitForEnd()
     },
 
     showChain: (
-      params: ShowChainRequest = undefined,
-    ): Promise<RpcResponseEnded<ShowChainResponse>> => {
-      return this.request<ShowChainResponse>(
+      params: ShowChain.Request = undefined,
+    ): Promise<RpcResponseEnded<ShowChain.Response>> => {
+      return this.request<ShowChain.Response>(
         `${ApiNamespace.chain}/showChain`,
         params,
       ).waitForEnd()
     },
 
     getTransactionStream: (
-      params: GetTransactionStreamRequest,
-    ): RpcResponse<void, GetTransactionStreamResponse> => {
-      return this.request<void, GetTransactionStreamResponse>(
+      params: GetTransactionStream.Request,
+    ): RpcResponse<void, GetTransactionStream.Response> => {
+      return this.request<void, GetTransactionStream.Response>(
         `${ApiNamespace.chain}/getTransactionStream`,
         params,
       )
     },
 
     getTransaction: (
-      params: GetTransactionRequest,
-    ): RpcResponse<void, GetTransactionResponse> => {
-      return this.request<void, GetTransactionResponse>(
+      params: GetTransaction.Request,
+    ): RpcResponse<void, GetTransaction.Response> => {
+      return this.request<void, GetTransaction.Response>(
         `${ApiNamespace.chain}/getTransaction`,
         params,
       )
     },
 
     getConsensusParameters: (
-      params: GetConsensusParametersRequest = undefined,
-    ): Promise<RpcResponseEnded<GetConsensusParametersResponse>> => {
-      return this.request<GetConsensusParametersResponse>(
+      params: GetConsensusParameters.Request = undefined,
+    ): Promise<RpcResponseEnded<GetConsensusParameters.Response>> => {
+      return this.request<GetConsensusParameters.Response>(
         `${ApiNamespace.chain}/getConsensusParameters`,
         params,
       ).waitForEnd()
     },
 
-    getAsset: (params: GetAssetRequest): Promise<RpcResponseEnded<GetAssetResponse>> => {
-      return this.request<GetAssetResponse>(
+    getAsset: (params: GetAsset.Request): Promise<RpcResponseEnded<GetAsset.Response>> => {
+      return this.request<GetAsset.Response>(
         `${ApiNamespace.chain}/getAsset`,
         params,
       ).waitForEnd()
     },
 
     getNetworkInfo: (
-      params?: GetNetworkInfoRequest,
-    ): Promise<RpcResponse<GetNetworkInfoResponse>> => {
-      return this.request<GetNetworkInfoResponse>(
+      params?: GetNetworkInfo.Request,
+    ): Promise<RpcResponse<GetNetworkInfo.Response>> => {
+      return this.request<GetNetworkInfo.Response>(
         `${ApiNamespace.chain}/getNetworkInfo`,
         params,
       ).waitForEnd()
     },
 
     isValidPublicAddress: (
-      params: IsValidPublicAddressRequest,
-    ): Promise<RpcResponse<IsValidPublicAddressResponse>> => {
-      return this.request<IsValidPublicAddressResponse>(
+      params: IsValidPublicAddress.Request,
+    ): Promise<RpcResponse<IsValidPublicAddress.Response>> => {
+      return this.request<IsValidPublicAddress.Response>(
         `${ApiNamespace.chain}/isValidPublicAddress`,
         params,
       ).waitForEnd()
     },
 
     broadcastTransaction: (
-      params: BroadcastTransactionRequest,
-    ): Promise<RpcResponse<BroadcastTransactionResponse>> => {
-      return this.request<BroadcastTransactionResponse>(
+      params: BroadcastTransaction.Request,
+    ): Promise<RpcResponse<BroadcastTransaction.Response>> => {
+      return this.request<BroadcastTransaction.Response>(
         `${ApiNamespace.chain}/broadcastTransaction`,
         params,
       ).waitForEnd()

--- a/ironfish/src/rpc/routes/chain/estimateFeeRate.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRate.ts
@@ -3,33 +3,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { PRIORITY_LEVELS, PriorityLevel } from '../../../memPool/feeEstimator'
+import { IronfishNode } from '../../../node'
 import { CurrencyUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { RpcRequest } from '../../request'
 
-export type EstimateFeeRateRequest = { priority?: PriorityLevel } | undefined
+export type Request = { priority?: PriorityLevel } | undefined
 
-export type EstimateFeeRateResponse = {
+export type Response = {
   rate: string
 }
 
-export const EstimateFeeRateRequestSchema: yup.ObjectSchema<EstimateFeeRateRequest> = yup
+export const RequestSchema: yup.ObjectSchema<Request> = yup
   .object({
     priority: yup.string().oneOf(PRIORITY_LEVELS),
   })
   .optional()
 
-export const EstimateFeeRateResponseSchema: yup.ObjectSchema<EstimateFeeRateResponse> = yup
+export const ResponseSchema: yup.ObjectSchema<Response> = yup
   .object({
     rate: yup.string(),
   })
   .defined()
 
-router.register<typeof EstimateFeeRateRequestSchema, EstimateFeeRateResponse>(
-  `${ApiNamespace.chain}/estimateFeeRate`,
-  EstimateFeeRateRequestSchema,
-  (request, node): void => {
-    const priority = request.data?.priority ?? 'average'
-    const rate = node.memPool.feeEstimator.estimateFeeRate(priority)
-    request.end({ rate: CurrencyUtils.encode(rate) })
-  },
-)
+export const route = 'estimateFeeRate'
+export const handle = (request: RpcRequest<Request, Response>, node: IronfishNode): void => {
+  const priority = request.data?.priority ?? 'average'
+  const rate = node.memPool.feeEstimator.estimateFeeRate(priority)
+  request.end({ rate: CurrencyUtils.encode(rate) })
+}

--- a/ironfish/src/rpc/routes/chain/estimateFeeRates.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRates.ts
@@ -2,21 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { IronfishNode } from '../../../node'
 import { CurrencyUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { RpcRequest } from '../../request'
 
-export type EstimateFeeRatesRequest = undefined
-export type EstimateFeeRatesResponse = {
+export type Request = undefined
+export type Response = {
   slow: string
   average: string
   fast: string
 }
 
-export const EstimateFeeRatesRequestSchema: yup.MixedSchema<EstimateFeeRatesRequest> = yup
-  .mixed()
-  .oneOf([undefined] as const)
+export const RequestSchema: yup.MixedSchema<Request> = yup.mixed().oneOf([undefined] as const)
 
-export const EstimateFeeRatesResponseSchema: yup.ObjectSchema<EstimateFeeRatesResponse> = yup
+export const ResponseSchema: yup.ObjectSchema<Response> = yup
   .object({
     slow: yup.string().defined(),
     average: yup.string().defined(),
@@ -24,16 +23,13 @@ export const EstimateFeeRatesResponseSchema: yup.ObjectSchema<EstimateFeeRatesRe
   })
   .defined()
 
-router.register<typeof EstimateFeeRatesRequestSchema, EstimateFeeRatesResponse>(
-  `${ApiNamespace.chain}/estimateFeeRates`,
-  EstimateFeeRatesRequestSchema,
-  (request, node): void => {
-    const rates = node.memPool.feeEstimator.estimateFeeRates()
+export const route = 'estimateFeeRates'
+export const handle = (request: RpcRequest<Request, Response>, node: IronfishNode): void => {
+  const rates = node.memPool.feeEstimator.estimateFeeRates()
 
-    request.end({
-      slow: CurrencyUtils.encode(rates.slow),
-      average: CurrencyUtils.encode(rates.average),
-      fast: CurrencyUtils.encode(rates.fast),
-    })
-  },
-)
+  request.end({
+    slow: CurrencyUtils.encode(rates.slow),
+    average: CurrencyUtils.encode(rates.average),
+    fast: CurrencyUtils.encode(rates.fast),
+  })
+}

--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -5,18 +5,19 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { ChainProcessor } from '../../../chainProcessor'
 import { getBlockSize, getTransactionSize } from '../../../network/utils/serializers'
+import { IronfishNode } from '../../../node'
 import { Block, BlockHeader } from '../../../primitives'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { BufferUtils, PromiseUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { RpcRequest } from '../../request'
 
-export type FollowChainStreamRequest =
+export type Request =
   | {
       head?: string | null
     }
   | undefined
 
-export type FollowChainStreamResponse = {
+export type Response = {
   type: 'connected' | 'disconnected' | 'fork'
   head: {
     sequence: number
@@ -53,13 +54,13 @@ export type FollowChainStreamResponse = {
   }
 }
 
-export const FollowChainStreamRequestSchema: yup.ObjectSchema<FollowChainStreamRequest> = yup
+export const RequestSchema: yup.ObjectSchema<Request> = yup
   .object({
     head: yup.string().nullable().optional(),
   })
   .optional()
 
-export const FollowChainStreamResponseSchema: yup.ObjectSchema<FollowChainStreamResponse> = yup
+export const ResponseSchema: yup.ObjectSchema<Response> = yup
   .object({
     type: yup.string().oneOf(['connected', 'disconnected', 'fork']).defined(),
     head: yup
@@ -136,100 +137,100 @@ export const FollowChainStreamResponseSchema: yup.ObjectSchema<FollowChainStream
   })
   .defined()
 
-router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse>(
-  `${ApiNamespace.chain}/followChainStream`,
-  FollowChainStreamRequestSchema,
-  async (request, node): Promise<void> => {
-    const head = request.data?.head ? Buffer.from(request.data.head, 'hex') : null
+export const route = 'followChainStream'
+export const handle = async (
+  request: RpcRequest<Request, Response>,
+  node: IronfishNode,
+): Promise<void> => {
+  const head = request.data?.head ? Buffer.from(request.data.head, 'hex') : null
 
-    const processor = new ChainProcessor({
-      chain: node.chain,
-      logger: node.logger,
-      head: head,
+  const processor = new ChainProcessor({
+    chain: node.chain,
+    logger: node.logger,
+    head: head,
+  })
+
+  const send = (block: Block, type: 'connected' | 'disconnected' | 'fork') => {
+    const transactions = block.transactions.map((transaction) => {
+      return transaction.withReference(() => {
+        return {
+          hash: BlockHashSerdeInstance.serialize(transaction.hash()),
+          size: getTransactionSize(transaction),
+          fee: Number(transaction.fee()),
+          expiration: transaction.expiration(),
+          notes: transaction.notes.map((note) => ({
+            commitment: note.hash().toString('hex'),
+          })),
+          spends: transaction.spends.map((spend) => ({
+            nullifier: spend.nullifier.toString('hex'),
+          })),
+          mints: transaction.mints.map((mint) => ({
+            id: mint.asset.id().toString('hex'),
+            metadata: BufferUtils.toHuman(mint.asset.metadata()),
+            name: BufferUtils.toHuman(mint.asset.name()),
+            owner: mint.asset.owner().toString('hex'),
+            value: mint.value.toString(),
+          })),
+          burns: transaction.burns.map((burn) => ({
+            id: burn.assetId.toString('hex'),
+            value: burn.value.toString(),
+          })),
+        }
+      })
     })
 
-    const send = (block: Block, type: 'connected' | 'disconnected' | 'fork') => {
-      const transactions = block.transactions.map((transaction) => {
-        return transaction.withReference(() => {
-          return {
-            hash: BlockHashSerdeInstance.serialize(transaction.hash()),
-            size: getTransactionSize(transaction),
-            fee: Number(transaction.fee()),
-            expiration: transaction.expiration(),
-            notes: transaction.notes.map((note) => ({
-              commitment: note.hash().toString('hex'),
-            })),
-            spends: transaction.spends.map((spend) => ({
-              nullifier: spend.nullifier.toString('hex'),
-            })),
-            mints: transaction.mints.map((mint) => ({
-              id: mint.asset.id().toString('hex'),
-              metadata: BufferUtils.toHuman(mint.asset.metadata()),
-              name: BufferUtils.toHuman(mint.asset.name()),
-              owner: mint.asset.owner().toString('hex'),
-              value: mint.value.toString(),
-            })),
-            burns: transaction.burns.map((burn) => ({
-              id: burn.assetId.toString('hex'),
-              value: burn.value.toString(),
-            })),
-          }
-        })
-      })
-
-      request.stream({
-        type: type,
-        head: {
-          sequence: node.chain.head.sequence,
-        },
-        block: {
-          hash: block.header.hash.toString('hex'),
-          sequence: block.header.sequence,
-          previous: block.header.previousBlockHash.toString('hex'),
-          graffiti: BufferUtils.toHuman(block.header.graffiti),
-          size: getBlockSize(block),
-          work: block.header.work.toString(),
-          main: type === 'connected',
-          timestamp: block.header.timestamp.valueOf(),
-          difficulty: block.header.target.toDifficulty().toString(),
-          transactions,
-        },
-      })
-    }
-
-    const onAdd = async (header: BlockHeader) => {
-      const block = await node.chain.getBlock(header)
-      Assert.isNotNull(block)
-      send(block, 'connected')
-    }
-
-    const onRemove = async (header: BlockHeader) => {
-      const block = await node.chain.getBlock(header)
-      Assert.isNotNull(block)
-      send(block, 'disconnected')
-    }
-
-    const onFork = (block: Block) => {
-      send(block, 'fork')
-    }
-
-    processor.onAdd.on(onAdd)
-    processor.onRemove.on(onRemove)
-    node.chain.onForkBlock.on(onFork)
-    const abortController = new AbortController()
-
-    request.onClose.on(() => {
-      abortController.abort()
-      processor.onAdd.off(onAdd)
-      processor.onRemove.off(onRemove)
-      node.chain.onForkBlock.off(onFork)
+    request.stream({
+      type: type,
+      head: {
+        sequence: node.chain.head.sequence,
+      },
+      block: {
+        hash: block.header.hash.toString('hex'),
+        sequence: block.header.sequence,
+        previous: block.header.previousBlockHash.toString('hex'),
+        graffiti: BufferUtils.toHuman(block.header.graffiti),
+        size: getBlockSize(block),
+        work: block.header.work.toString(),
+        main: type === 'connected',
+        timestamp: block.header.timestamp.valueOf(),
+        difficulty: block.header.target.toDifficulty().toString(),
+        transactions,
+      },
     })
+  }
 
-    while (!request.closed) {
-      await processor.update({ signal: abortController.signal })
-      await PromiseUtils.sleep(1000)
-    }
+  const onAdd = async (header: BlockHeader) => {
+    const block = await node.chain.getBlock(header)
+    Assert.isNotNull(block)
+    send(block, 'connected')
+  }
 
-    request.end()
-  },
-)
+  const onRemove = async (header: BlockHeader) => {
+    const block = await node.chain.getBlock(header)
+    Assert.isNotNull(block)
+    send(block, 'disconnected')
+  }
+
+  const onFork = (block: Block) => {
+    send(block, 'fork')
+  }
+
+  processor.onAdd.on(onAdd)
+  processor.onRemove.on(onRemove)
+  node.chain.onForkBlock.on(onFork)
+  const abortController = new AbortController()
+
+  request.onClose.on(() => {
+    abortController.abort()
+    processor.onAdd.off(onAdd)
+    processor.onRemove.off(onRemove)
+    node.chain.onForkBlock.off(onFork)
+  })
+
+  while (!request.closed) {
+    await processor.update({ signal: abortController.signal })
+    await PromiseUtils.sleep(1000)
+  }
+
+  request.end()
+}

--- a/ironfish/src/rpc/routes/chain/getBlock.test.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.test.ts
@@ -5,7 +5,7 @@ import { useBlockWithTx, useMinerBlockFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { ERROR_CODES } from '../../adapters'
 import { RpcRequestError } from '../../clients/errors'
-import { GetBlockResponse } from './getBlock'
+import { Response as GetBlockResponse } from './getBlock'
 
 describe('Route chain/getBlock', () => {
   const routeTest = createRouteTest()

--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -2,20 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { IronfishNode } from '../../../node'
 import { BlockHeader } from '../../../primitives'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives/block'
 import { BufferUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { RpcRequest } from '../../request'
 
-export type GetBlockRequest = {
+export type Request = {
   search?: string
   hash?: string
   sequence?: number
   confirmations?: number
 }
 
-export type GetBlockResponse = {
+export type Response = {
   block: {
     graffiti: string
     difficulty: string
@@ -39,7 +40,7 @@ export type GetBlockResponse = {
   }
 }
 
-export const GetBlockRequestSchema: yup.ObjectSchema<GetBlockRequest> = yup
+export const RequestSchema: yup.ObjectSchema<Request> = yup
   .object()
   .shape({
     search: yup.string(),
@@ -49,7 +50,7 @@ export const GetBlockRequestSchema: yup.ObjectSchema<GetBlockRequest> = yup
   })
   .defined()
 
-export const GetBlockResponseSchema: yup.ObjectSchema<GetBlockResponse> = yup
+export const ResponseSchema: yup.ObjectSchema<Response> = yup
   .object({
     block: yup
       .object({
@@ -85,91 +86,91 @@ export const GetBlockResponseSchema: yup.ObjectSchema<GetBlockResponse> = yup
   })
   .defined()
 
-router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
-  `${ApiNamespace.chain}/getBlock`,
-  GetBlockRequestSchema,
-  async (request, node): Promise<void> => {
-    let header: BlockHeader | null = null
-    let error = ''
+export const route = 'getBlock'
+export const handle = async (
+  request: RpcRequest<Request, Response>,
+  node: IronfishNode,
+): Promise<void> => {
+  let header: BlockHeader | null = null
+  let error = ''
 
-    const confirmations = request.data.confirmations ?? node.config.get('confirmations')
+  const confirmations = request.data.confirmations ?? node.config.get('confirmations')
 
-    if (request.data.search) {
-      const search = request.data.search.trim()
-      const num = Number(search)
+  if (request.data.search) {
+    const search = request.data.search.trim()
+    const num = Number(search)
 
-      if (Number.isInteger(num)) {
-        request.data.sequence = num
-      } else {
-        request.data.hash = search
-      }
+    if (Number.isInteger(num)) {
+      request.data.sequence = num
+    } else {
+      request.data.hash = search
     }
+  }
 
-    // Use negative numbers to start from the head of the chain
-    if (request.data.sequence && request.data.sequence < 0) {
-      request.data.sequence = Math.max(
-        node.chain.head.sequence + request.data.sequence + 1,
-        GENESIS_BLOCK_SEQUENCE,
-      )
-    }
+  // Use negative numbers to start from the head of the chain
+  if (request.data.sequence && request.data.sequence < 0) {
+    request.data.sequence = Math.max(
+      node.chain.head.sequence + request.data.sequence + 1,
+      GENESIS_BLOCK_SEQUENCE,
+    )
+  }
 
-    if (request.data.hash) {
-      const hash = Buffer.from(request.data.hash, 'hex')
-      header = await node.chain.getHeader(hash)
-      error = `No block found with hash ${request.data.hash}`
-    }
+  if (request.data.hash) {
+    const hash = Buffer.from(request.data.hash, 'hex')
+    header = await node.chain.getHeader(hash)
+    error = `No block found with hash ${request.data.hash}`
+  }
 
-    if (request.data.sequence && !header) {
-      header = await node.chain.getHeaderAtSequence(request.data.sequence)
-      error = `No block found with sequence ${request.data.sequence}`
-    }
+  if (request.data.sequence && !header) {
+    header = await node.chain.getHeaderAtSequence(request.data.sequence)
+    error = `No block found with sequence ${request.data.sequence}`
+  }
 
-    if (!header) {
-      throw new ValidationError(error)
-    }
+  if (!header) {
+    throw new ValidationError(error)
+  }
 
-    if (header.noteSize === null) {
-      throw new ValidationError('Block header was saved to database without a note size')
-    }
+  if (header.noteSize === null) {
+    throw new ValidationError('Block header was saved to database without a note size')
+  }
 
-    const block = await node.chain.getBlock(header)
-    if (!block) {
-      throw new ValidationError(`No block with header ${header.hash.toString('hex')}`)
-    }
+  const block = await node.chain.getBlock(header)
+  if (!block) {
+    throw new ValidationError(`No block with header ${header.hash.toString('hex')}`)
+  }
 
-    const transactions: GetBlockResponse['block']['transactions'] = []
+  const transactions: Response['block']['transactions'] = []
 
-    for (const tx of block.transactions) {
-      const fee = tx.fee()
+  for (const tx of block.transactions) {
+    const fee = tx.fee()
 
-      transactions.push({
-        signature: tx.transactionSignature().toString('hex'),
-        hash: tx.hash().toString('hex'),
-        fee: fee.toString(),
-        spends: tx.spends.length,
-        notes: tx.notes.length,
-      })
-    }
-
-    const main = await node.chain.isHeadChain(header)
-    const confirmed = node.chain.head.sequence - header.sequence >= confirmations
-
-    request.end({
-      block: {
-        graffiti: BufferUtils.toHuman(header.graffiti),
-        difficulty: header.target.toDifficulty().toString(),
-        hash: header.hash.toString('hex'),
-        previousBlockHash: header.previousBlockHash.toString('hex'),
-        sequence: Number(header.sequence),
-        timestamp: header.timestamp.valueOf(),
-        noteSize: header.noteSize,
-        noteCommitment: header.noteCommitment.toString('hex'),
-        transactions: transactions,
-      },
-      metadata: {
-        main: main,
-        confirmed: confirmed,
-      },
+    transactions.push({
+      signature: tx.transactionSignature().toString('hex'),
+      hash: tx.hash().toString('hex'),
+      fee: fee.toString(),
+      spends: tx.spends.length,
+      notes: tx.notes.length,
     })
-  },
-)
+  }
+
+  const main = await node.chain.isHeadChain(header)
+  const confirmed = node.chain.head.sequence - header.sequence >= confirmations
+
+  request.end({
+    block: {
+      graffiti: BufferUtils.toHuman(header.graffiti),
+      difficulty: header.target.toDifficulty().toString(),
+      hash: header.hash.toString('hex'),
+      previousBlockHash: header.previousBlockHash.toString('hex'),
+      sequence: Number(header.sequence),
+      timestamp: header.timestamp.valueOf(),
+      noteSize: header.noteSize,
+      noteCommitment: header.noteCommitment.toString('hex'),
+      transactions: transactions,
+    },
+    metadata: {
+      main: main,
+      confirmed: confirmed,
+    },
+  })
+}

--- a/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { GetChainInfoResponse } from './getChainInfo'
+import { Response as GetChainInfoResponse } from './getChainInfo'
 
 describe('Route chain.getChainInfo', () => {
   const routeTest = createRouteTest()

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.test.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { GetConsensusParametersResponse } from './getConsensusParameters'
+import { Response as GetConsensusParametersResponse } from './getConsensusParameters'
 
 describe('Route chain.getConsensusParameters', () => {
   const routeTest = createRouteTest()

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
@@ -3,7 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { IronfishNode } from '../../../node'
+import { RpcRequest } from '../../request'
 
 interface ConsensusParameters {
   allowedBlockFuturesSeconds: number
@@ -14,39 +15,34 @@ interface ConsensusParameters {
   minFee: number
 }
 
-export type GetConsensusParametersRequest = Record<string, never> | undefined
-export type GetConsensusParametersResponse = ConsensusParameters
+export type Request = Record<string, never> | undefined
+export type Response = ConsensusParameters
 
-export const GetConsensusParametersRequestSchema: yup.MixedSchema<GetConsensusParametersRequest> =
-  yup.mixed().oneOf([undefined] as const)
+export const RequestSchema: yup.MixedSchema<Request> = yup.mixed().oneOf([undefined] as const)
 
-export const GetConsensusParametersResponseSchema: yup.ObjectSchema<GetConsensusParametersResponse> =
-  yup
-    .object({
-      allowedBlockFuturesSeconds: yup.number().defined(),
-      genesisSupplyInIron: yup.number().defined(),
-      targetBlockTimeInSeconds: yup.number().defined(),
-      targetBucketTimeInSeconds: yup.number().defined(),
-      maxBlockSizeBytes: yup.number().defined(),
-      minFee: yup.number().defined(),
-    })
-    .defined()
+export const ResponseSchema: yup.ObjectSchema<Response> = yup
+  .object({
+    allowedBlockFuturesSeconds: yup.number().defined(),
+    genesisSupplyInIron: yup.number().defined(),
+    targetBlockTimeInSeconds: yup.number().defined(),
+    targetBucketTimeInSeconds: yup.number().defined(),
+    maxBlockSizeBytes: yup.number().defined(),
+    minFee: yup.number().defined(),
+  })
+  .defined()
 
-router.register<typeof GetConsensusParametersRequestSchema, GetConsensusParametersResponse>(
-  `${ApiNamespace.chain}/getConsensusParameters`,
-  GetConsensusParametersRequestSchema,
-  (request, node): void => {
-    Assert.isNotNull(node.chain.consensus, 'no consensus parameters')
+export const route = 'getConsensusParameters'
+export const handle = (request: RpcRequest<Request, Response>, node: IronfishNode): void => {
+  Assert.isNotNull(node.chain.consensus, 'no consensus parameters')
 
-    const consensusParameters = node.chain.consensus.parameters
+  const consensusParameters = node.chain.consensus.parameters
 
-    request.end({
-      allowedBlockFuturesSeconds: consensusParameters.allowedBlockFutureSeconds,
-      genesisSupplyInIron: consensusParameters.genesisSupplyInIron,
-      targetBlockTimeInSeconds: consensusParameters.targetBlockTimeInSeconds,
-      targetBucketTimeInSeconds: consensusParameters.targetBucketTimeInSeconds,
-      maxBlockSizeBytes: consensusParameters.maxBlockSizeBytes,
-      minFee: consensusParameters.minFee,
-    })
-  },
-)
+  request.end({
+    allowedBlockFuturesSeconds: consensusParameters.allowedBlockFutureSeconds,
+    genesisSupplyInIron: consensusParameters.genesisSupplyInIron,
+    targetBlockTimeInSeconds: consensusParameters.targetBlockTimeInSeconds,
+    targetBucketTimeInSeconds: consensusParameters.targetBucketTimeInSeconds,
+    maxBlockSizeBytes: consensusParameters.maxBlockSizeBytes,
+    minFee: consensusParameters.minFee,
+  })
+}

--- a/ironfish/src/rpc/routes/chain/getDifficulty.ts
+++ b/ironfish/src/rpc/routes/chain/getDifficulty.ts
@@ -2,28 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { IronfishNode } from '../../../node'
 import { ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { RpcRequest } from '../../request'
 
-export type GetDifficultyRequest =
+export type Request =
   | {
       sequence?: number | null
     }
   | undefined
 
-export type GetDifficultyResponse = {
+export type Response = {
   sequence: number
   hash: string
   difficulty: string
 }
 
-export const GetDifficultyRequestSchema: yup.ObjectSchema<GetDifficultyRequest> = yup
+export const RequestSchema: yup.ObjectSchema<Request> = yup
   .object({
     sequence: yup.number().nullable().optional(),
   })
   .defined()
 
-export const GetDifficultyResponseSchema: yup.ObjectSchema<GetDifficultyResponse> = yup
+export const ResponseSchema: yup.ObjectSchema<Response> = yup
   .object({
     sequence: yup.number().defined(),
     hash: yup.string().defined(),
@@ -31,26 +32,26 @@ export const GetDifficultyResponseSchema: yup.ObjectSchema<GetDifficultyResponse
   })
   .defined()
 
-router.register<typeof GetDifficultyRequestSchema, GetDifficultyResponse>(
-  `${ApiNamespace.chain}/getDifficulty`,
-  GetDifficultyRequestSchema,
-  async (request, node): Promise<void> => {
-    let sequence = node.chain.head.sequence
-    let block = node.chain.head
+export const route = 'getDifficulty'
+export const handle = async (
+  request: RpcRequest<Request, Response>,
+  node: IronfishNode,
+): Promise<void> => {
+  let sequence = node.chain.head.sequence
+  let block = node.chain.head
 
-    if (request.data?.sequence) {
-      const sequenceBlock = await node.chain.getHeaderAtSequence(request.data.sequence)
-      if (!sequenceBlock) {
-        throw new ValidationError(`No block found at sequence ${request.data.sequence}`)
-      }
-      sequence = sequenceBlock.sequence
-      block = sequenceBlock
+  if (request.data?.sequence) {
+    const sequenceBlock = await node.chain.getHeaderAtSequence(request.data.sequence)
+    if (!sequenceBlock) {
+      throw new ValidationError(`No block found at sequence ${request.data.sequence}`)
     }
+    sequence = sequenceBlock.sequence
+    block = sequenceBlock
+  }
 
-    request.end({
-      sequence,
-      hash: block.hash.toString('hex'),
-      difficulty: block.target.toDifficulty().toString(),
-    })
-  },
-)
+  request.end({
+    sequence,
+    hash: block.hash.toString('hex'),
+    difficulty: block.target.toDifficulty().toString(),
+  })
+}

--- a/ironfish/src/rpc/routes/chain/getNetworkInfo.test.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkInfo.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { GetNetworkInfoResponse } from './getNetworkInfo'
+import { Response as GetNetworkInfoResponse } from './getNetworkInfo'
 
 describe('Route chain.getNetworkInfo', () => {
   const routeTest = createRouteTest()

--- a/ironfish/src/rpc/routes/chain/getNetworkInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkInfo.ts
@@ -2,29 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { ApiNamespace, router } from '../router'
+import { IronfishNode } from '../../../node'
+import { RpcRequest } from '../../request'
 
-export type GetNetworkInfoRequest = undefined
-export type GetNetworkInfoResponse = {
+export type Request = undefined
+export type Response = {
   networkId: number
 }
 
-export const GetNetworkInfoRequestSchema: yup.MixedSchema<GetNetworkInfoRequest> = yup
-  .mixed()
-  .oneOf([undefined] as const)
+export const RequestSchema: yup.MixedSchema<Request> = yup.mixed().oneOf([undefined] as const)
 
-export const GetNetworkInfoResponseSchema: yup.ObjectSchema<GetNetworkInfoResponse> = yup
+export const GetNetworkInfoResponseSchema: yup.ObjectSchema<Response> = yup
   .object({
     networkId: yup.number().defined(),
   })
   .defined()
 
-router.register<typeof GetNetworkInfoRequestSchema, GetNetworkInfoResponse>(
-  `${ApiNamespace.chain}/getNetworkInfo`,
-  GetNetworkInfoRequestSchema,
-  (request, node): void => {
-    request.end({
-      networkId: node.internal.get('networkId'),
-    })
-  },
-)
+export const route = 'getNetworkInfo'
+export const handle = (request: RpcRequest<Request, Response>, node: IronfishNode): void => {
+  request.end({
+    networkId: node.internal.get('networkId'),
+  })
+}

--- a/ironfish/src/rpc/routes/chain/getNoteWitness.test.ts
+++ b/ironfish/src/rpc/routes/chain/getNoteWitness.test.ts
@@ -6,7 +6,7 @@ import { Witness } from '../../../merkletree'
 import { NoteEncrypted } from '../../../primitives/noteEncrypted'
 import { useMinerBlockFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { GetNoteWitnessResponse } from './getNoteWitness'
+import { Response as GetNoteWitnessResponse } from './getNoteWitness'
 
 describe('Route chain/getNoteWitness', () => {
   const routeTest = createRouteTest()

--- a/ironfish/src/rpc/routes/chain/getTransaction.test.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.test.ts
@@ -6,7 +6,7 @@ import { createRouteTest } from '../../../testUtilities/routeTest'
 import { CurrencyUtils } from '../../../utils'
 import { RpcRequestError } from '../../clients'
 import { RpcSpend } from '../wallet/types'
-import { GetTransactionResponse } from './getTransaction'
+import { Response as GetTransactionResponse } from './getTransaction'
 
 describe('Route chain/getTransaction', () => {
   const routeTest = createRouteTest()

--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -2,16 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { IronfishNode } from '../../../node'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { CurrencyUtils } from '../../../utils'
 import { NotFoundError, ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { RpcRequest } from '../../request'
 import { RpcSpend, RpcSpendSchema } from '../wallet/types'
 import { RpcNote, RpcNoteSchema } from './types'
 
-export type GetTransactionRequest = { transactionHash: string; blockHash?: string }
+export type Request = { transactionHash: string; blockHash?: string }
 
-export type GetTransactionResponse = {
+export type Response = {
   fee: string
   expiration: number
   noteSize: number
@@ -35,14 +36,14 @@ export type GetTransactionResponse = {
   notesEncrypted: string[]
 }
 
-export const GetTransactionRequestSchema: yup.ObjectSchema<GetTransactionRequest> = yup
+export const RequestSchema: yup.ObjectSchema<Request> = yup
   .object({
     transactionHash: yup.string().defined(),
     blockHash: yup.string(),
   })
   .defined()
 
-export const GetTransactionResponseSchema: yup.ObjectSchema<GetTransactionResponse> = yup
+export const ResponseSchema: yup.ObjectSchema<Response> = yup
   .object({
     fee: yup.string().defined(),
     expiration: yup.number().defined(),
@@ -77,75 +78,71 @@ export const GetTransactionResponseSchema: yup.ObjectSchema<GetTransactionRespon
   })
   .defined()
 
-router.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
-  `${ApiNamespace.chain}/getTransaction`,
-  GetTransactionRequestSchema,
-  async (request, node): Promise<void> => {
-    if (!request.data.transactionHash) {
-      throw new ValidationError(`Missing transaction hash`)
-    }
+export const route = 'getTransaction'
+export const handle = async (
+  request: RpcRequest<Request, Response>,
+  node: IronfishNode,
+): Promise<void> => {
+  if (!request.data.transactionHash) {
+    throw new ValidationError(`Missing transaction hash`)
+  }
 
-    const transactionHashBuffer = Buffer.from(request.data.transactionHash, 'hex')
+  const transactionHashBuffer = Buffer.from(request.data.transactionHash, 'hex')
 
-    const blockHashBuffer = request.data.blockHash
-      ? BlockHashSerdeInstance.deserialize(request.data.blockHash)
-      : await node.chain.getBlockHashByTransactionHash(transactionHashBuffer)
+  const blockHashBuffer = request.data.blockHash
+    ? BlockHashSerdeInstance.deserialize(request.data.blockHash)
+    : await node.chain.getBlockHashByTransactionHash(transactionHashBuffer)
 
-    if (!blockHashBuffer) {
-      throw new NotFoundError(
-        `No block hash found for transaction hash ${request.data.transactionHash}`,
-      )
-    }
-
-    const blockHeader = await node.chain.getHeader(blockHashBuffer)
-    if (!blockHeader) {
-      throw new NotFoundError(
-        `No block found for block hash ${blockHashBuffer.toString('hex')}`,
-      )
-    }
-
-    const transactions = await node.chain.getBlockTransactions(blockHeader)
-
-    const foundTransaction = transactions.find(({ transaction }) =>
-      transaction.hash().equals(transactionHashBuffer),
+  if (!blockHashBuffer) {
+    throw new NotFoundError(
+      `No block hash found for transaction hash ${request.data.transactionHash}`,
     )
+  }
 
-    if (!foundTransaction) {
-      throw new NotFoundError(
-        `Transaction not found on block ${blockHashBuffer.toString('hex')}`,
-      )
-    }
+  const blockHeader = await node.chain.getHeader(blockHashBuffer)
+  if (!blockHeader) {
+    throw new NotFoundError(`No block found for block hash ${blockHashBuffer.toString('hex')}`)
+  }
 
-    const { transaction, initialNoteIndex } = foundTransaction
+  const transactions = await node.chain.getBlockTransactions(blockHeader)
 
-    const rawTransaction: GetTransactionResponse = {
-      fee: transaction.fee().toString(),
-      expiration: transaction.expiration(),
-      noteSize: initialNoteIndex + transaction.notes.length,
-      notesCount: transaction.notes.length,
-      spendsCount: transaction.spends.length,
-      signature: transaction.transactionSignature().toString('hex'),
-      notesEncrypted: transaction.notes.map((note) => note.serialize().toString('hex')),
-      notes: transaction.notes.map((note) => ({
-        hash: note.hash().toString('hex'),
-        serialized: note.serialize().toString('hex'),
-      })),
-      mints: transaction.mints.map((mint) => ({
-        assetId: mint.asset.id().toString('hex'),
-        value: CurrencyUtils.encode(mint.value),
-      })),
-      burns: transaction.burns.map((burn) => ({
-        assetId: burn.assetId.toString('hex'),
-        value: CurrencyUtils.encode(burn.value),
-      })),
-      spends: transaction.spends.map((spend) => ({
-        nullifier: spend.nullifier.toString('hex'),
-        commitment: spend.commitment.toString('hex'),
-        size: spend.size,
-      })),
-      blockHash: blockHashBuffer.toString('hex'),
-    }
+  const foundTransaction = transactions.find(({ transaction }) =>
+    transaction.hash().equals(transactionHashBuffer),
+  )
 
-    request.end(rawTransaction)
-  },
-)
+  if (!foundTransaction) {
+    throw new NotFoundError(`Transaction not found on block ${blockHashBuffer.toString('hex')}`)
+  }
+
+  const { transaction, initialNoteIndex } = foundTransaction
+
+  const rawTransaction: Response = {
+    fee: transaction.fee().toString(),
+    expiration: transaction.expiration(),
+    noteSize: initialNoteIndex + transaction.notes.length,
+    notesCount: transaction.notes.length,
+    spendsCount: transaction.spends.length,
+    signature: transaction.transactionSignature().toString('hex'),
+    notesEncrypted: transaction.notes.map((note) => note.serialize().toString('hex')),
+    notes: transaction.notes.map((note) => ({
+      hash: note.hash().toString('hex'),
+      serialized: note.serialize().toString('hex'),
+    })),
+    mints: transaction.mints.map((mint) => ({
+      assetId: mint.asset.id().toString('hex'),
+      value: CurrencyUtils.encode(mint.value),
+    })),
+    burns: transaction.burns.map((burn) => ({
+      assetId: burn.assetId.toString('hex'),
+      value: CurrencyUtils.encode(burn.value),
+    })),
+    spends: transaction.spends.map((spend) => ({
+      nullifier: spend.nullifier.toString('hex'),
+      commitment: spend.commitment.toString('hex'),
+      size: spend.size,
+    })),
+    blockHash: blockHashBuffer.toString('hex'),
+  }
+
+  request.end(rawTransaction)
+}

--- a/ironfish/src/rpc/routes/chain/index.ts
+++ b/ironfish/src/rpc/routes/chain/index.ts
@@ -2,21 +2,41 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export * from './broadcastTransaction'
-export * from './estimateFeeRate'
-export * from './estimateFeeRates'
-export * from './exportChainStream'
-export * from './followChainStream'
-export * from './getBlock'
-export * from './getChainInfo'
-export * from './getDifficulty'
-export * from './getNetworkHashPower'
-export * from './getTransaction'
-export * from './getTransactionStream'
-export * from './showChain'
-export * from './getConsensusParameters'
-export * from './getAsset'
-export * from './getNetworkInfo'
-export * from './getNoteWitness'
-export * from './isValidPublicAddress'
-export * from './types'
+import { ApiNamespace, router } from '../router'
+export * as BroadcastTransaction from './broadcastTransaction'
+export * as EstimateFeeRate from './estimateFeeRate'
+export * as EstimateFeeRates from './estimateFeeRates'
+export * as ExportChainStream from './exportChainStream'
+export * as FollowChainStream from './followChainStream'
+export * as GetAsset from './getAsset'
+export * as GetBlock from './getBlock'
+export * as GetChainInfo from './getChainInfo'
+export * as GetConsensusParameters from './getConsensusParameters'
+export * as GetDifficulty from './getDifficulty'
+export * as GetNetworkHashPower from './getNetworkHashPower'
+export * as GetNetworkInfo from './getNetworkInfo'
+export * as GetNoteWitness from './getNoteWitness'
+export * as GetTransaction from './getTransaction'
+export * as GetTransactionStream from './getTransactionStream'
+export * as IsValidPublicAddress from './isValidPublicAddress'
+export * as ShowChain from './showChain'
+
+import * as Routes from './'
+
+router.registerRouteFile(Routes.BroadcastTransaction, ApiNamespace.chain)
+router.registerRouteFile(Routes.EstimateFeeRate, ApiNamespace.chain)
+router.registerRouteFile(Routes.EstimateFeeRates, ApiNamespace.chain)
+router.registerRouteFile(Routes.ExportChainStream, ApiNamespace.chain)
+router.registerRouteFile(Routes.FollowChainStream, ApiNamespace.chain)
+router.registerRouteFile(Routes.GetBlock, ApiNamespace.chain)
+router.registerRouteFile(Routes.GetChainInfo, ApiNamespace.chain)
+router.registerRouteFile(Routes.GetDifficulty, ApiNamespace.chain)
+router.registerRouteFile(Routes.GetNetworkHashPower, ApiNamespace.chain)
+router.registerRouteFile(Routes.GetTransaction, ApiNamespace.chain)
+router.registerRouteFile(Routes.GetTransactionStream, ApiNamespace.chain)
+router.registerRouteFile(Routes.ShowChain, ApiNamespace.chain)
+router.registerRouteFile(Routes.GetConsensusParameters, ApiNamespace.chain)
+router.registerRouteFile(Routes.GetAsset, ApiNamespace.chain)
+router.registerRouteFile(Routes.GetNetworkInfo, ApiNamespace.chain)
+router.registerRouteFile(Routes.GetNoteWitness, ApiNamespace.chain)
+router.registerRouteFile(Routes.IsValidPublicAddress, ApiNamespace.chain)

--- a/ironfish/src/rpc/routes/chain/isValidPublicAddress.ts
+++ b/ironfish/src/rpc/routes/chain/isValidPublicAddress.ts
@@ -3,36 +3,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { isValidPublicAddress } from '../../../wallet/validator'
-import { ApiNamespace, router } from '../router'
+import { RpcRequest } from '../../request'
 
-export type IsValidPublicAddressRequest = {
+export type Request = {
   address: string
 }
 
-export type IsValidPublicAddressResponse = {
+export type Response = {
   valid: boolean
 }
 
-export const IsValidPublicAddressRequestSchema: yup.ObjectSchema<IsValidPublicAddressRequest> =
-  yup
-    .object({
-      address: yup.string().defined(),
-    })
-    .defined()
+export const route = 'isValidPublicAddress'
+export const RequestSchema: yup.ObjectSchema<Request> = yup
+  .object({
+    address: yup.string().defined(),
+  })
+  .defined()
 
-export const IsValidPublicAddressResponseSchema: yup.ObjectSchema<IsValidPublicAddressResponse> =
-  yup
-    .object({
-      valid: yup.boolean().defined(),
-    })
-    .defined()
+export const ResponseSchema: yup.ObjectSchema<Response> = yup
+  .object({
+    valid: yup.boolean().defined(),
+  })
+  .defined()
 
-router.register<typeof IsValidPublicAddressRequestSchema, IsValidPublicAddressResponse>(
-  `${ApiNamespace.chain}/isValidPublicAddress`,
-  IsValidPublicAddressRequestSchema,
-  (request): void => {
-    request.end({
-      valid: isValidPublicAddress(request.data.address),
-    })
-  },
-)
+export const handle = (request: RpcRequest<Request, Response>): void => {
+  request.end({
+    valid: isValidPublicAddress(request.data.address),
+  })
+}

--- a/ironfish/src/rpc/routes/chain/showChain.ts
+++ b/ironfish/src/rpc/routes/chain/showChain.ts
@@ -2,45 +2,43 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { ApiNamespace, router } from '../router'
+import { IronfishNode } from '../../../node'
+import { RpcRequest } from '../../request'
 import { renderChain } from './utils'
 
-export type ShowChainRequest =
+export type Request =
   | {
       start?: number | null
       stop?: number | null
     }
   | undefined
 
-export type ShowChainResponse = {
+export type Response = {
   content: string[]
 }
 
-export const ShowChainRequestSchema: yup.ObjectSchema<ShowChainRequest> = yup
+export const RequestSchema: yup.ObjectSchema<Request> = yup
   .object({
     start: yup.number().nullable().optional(),
     stop: yup.number().nullable().optional(),
   })
   .optional()
 
-export const ShowChainResponseSchema: yup.ObjectSchema<ShowChainResponse> = yup
+export const ResponseSchema: yup.ObjectSchema<Response> = yup
   .object({
     content: yup.array(yup.string().defined()).defined(),
   })
   .defined()
 
-/**
- * Render the chain as ani ASCII graph of the block chain
- */
-router.register<typeof ShowChainRequestSchema, ShowChainResponse>(
-  `${ApiNamespace.chain}/showChain`,
-  ShowChainRequestSchema,
-  async (request, node): Promise<void> => {
-    const content = await renderChain(node.chain, request.data?.start, request.data?.stop, {
-      indent: '  ',
-      work: false,
-    })
+export const route = 'showChain'
+export const handle = async (
+  request: RpcRequest<Request, Response>,
+  node: IronfishNode,
+): Promise<void> => {
+  const content = await renderChain(node.chain, request.data?.start, request.data?.stop, {
+    indent: '  ',
+    work: false,
+  })
 
-    request.end({ content })
-  },
-)
+  request.end({ content })
+}

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -48,9 +48,23 @@ export function parseRoute(
   return [n, m]
 }
 
+export type RouteFile<TRequest, TResponse> = {
+  handle: RouteHandler<YupSchemaResult<YupSchema<TRequest>>, TResponse>
+  RequestSchema: YupSchema<TRequest>
+  route: string
+}
+
 export class Router {
   routes = new Map<string, Map<string, { handler: RouteHandler; schema: YupSchema }>>()
   server: RpcServer | null = null
+
+  registerRouteFile<TRequest, TResponse>(
+    routeFile: RouteFile<TRequest, TResponse>,
+    namespace: string,
+  ): void {
+    const { route, RequestSchema, handle } = routeFile
+    this.register(`${namespace}/${route}`, RequestSchema, handle)
+  }
 
   register<TRequestSchema extends YupSchema, TResponse>(
     route: string,

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -5,7 +5,7 @@
 import axios, { AxiosError, AxiosRequestConfig } from 'axios'
 import { getTransactionSize } from './network/utils/serializers'
 import { Transaction } from './primitives'
-import { FollowChainStreamResponse } from './rpc/routes/chain/followChainStream'
+import { FollowChainStream } from './rpc/routes'
 import { BlockHashSerdeInstance } from './serde'
 import { Metric } from './telemetry'
 import { BufferUtils } from './utils'
@@ -118,7 +118,7 @@ export class WebApi {
     await axios.post(`${this.host}/multi_asset`, { operations: multiAssets }, options)
   }
 
-  async blocks(blocks: FollowChainStreamResponse[]): Promise<void> {
+  async blocks(blocks: FollowChainStream.Response[]): Promise<void> {
     this.requireToken()
 
     const serialized = blocks.map(({ type, block }) => ({

--- a/simulator/src/simulator/simulation-node.ts
+++ b/simulator/src/simulator/simulation-node.ts
@@ -7,7 +7,7 @@ import {
   createRootLogger,
   DEV_GENESIS_ACCOUNT,
   Event,
-  FollowChainStreamResponse,
+  FollowChainStream,
   Logger,
   NodeFileProvider,
   PromiseUtils,
@@ -112,7 +112,7 @@ export class SimulationNode {
   /**
    *  @event Emits when new blocks are added to the chain
    */
-  onBlock: Event<[FollowChainStreamResponse]> = new Event()
+  onBlock: Event<[FollowChainStream.Response]> = new Event()
 
   /**
    * The last error encountered by the node. This is useful for debugging
@@ -387,9 +387,9 @@ export class SimulationNode {
   async waitForTransactionConfirmation(
     transactionHash: string,
     expirationSequence?: number,
-  ): Promise<FollowChainStreamResponse['block'] | undefined> {
+  ): Promise<FollowChainStream.Response['block'] | undefined> {
     return new Promise((resolve) => {
-      const checkBlock = (resp: FollowChainStreamResponse) => {
+      const checkBlock = (resp: FollowChainStream.Response) => {
         const hasTransation = resp.block.transactions.find(
           (t) => t.hash.toLowerCase() === transactionHash,
         )


### PR DESCRIPTION
## Summary
Refactoring the `/chain` routes to export handler functions. This is one step towards allowing wallet route handlers to run without a node. Future PRs for other routes to come.

## Testing Plan
Unit testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change
This does change SDK exports which we'll have to mention. Adding that to the draft release notes 

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
