### PR TITLE
feat(ironfish): Query account instead of chain when burning asset

### DIFF
--- a/ironfish/src/rpc/routes/wallet/burnAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.ts
@@ -55,8 +55,8 @@ router.register<typeof BurnAssetRequestSchema, BurnAssetResponse>(
     const value = CurrencyUtils.decode(request.data.value)
 
     const assetId = Buffer.from(request.data.assetId, 'hex')
-    const asset = await node.chain.getAssetById(assetId)
-    Assert.isNotNull(asset)
+    const asset = await account.getAsset(assetId)
+    Assert.isNotUndefined(asset)
 
     const transaction = await node.wallet.burn(
       account,


### PR DESCRIPTION
## Summary

If an account is burning an asset, it should have the asset in its database. This reduces dependency on the chain.

## Testing Plan

Covered by existing behavior

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
