### PR TITLE
feat(ironfish): Query asset from account in `getAccountNotesStream`

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
@@ -39,7 +39,7 @@ router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
           break
         }
 
-        const asset = await node.chain.getAssetById(note.assetId())
+        const asset = await account.getAsset(note.assetId())
 
         request.stream({
           value: CurrencyUtils.encode(note.value()),


### PR DESCRIPTION
## Summary

The assets related to an account's notes should be present in the wallet database, so reduce chain dependency.

## Testing Plan

Covered by existing behavior

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
