### PR TITLE
Allow Router and Server to be created without a node object

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -103,7 +103,7 @@ export class IronfishNode {
     this.miningManager = new MiningManager({ chain, memPool, node: this, metrics })
     this.memPool = memPool
     this.workerPool = workerPool
-    this.rpc = new RpcServer(this)
+    this.rpc = new RpcServer({ node: this, wallet }, internal)
     this.logger = logger
     this.pkg = pkg
 

--- a/ironfish/src/rpc/routes/chain/broadcastTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/broadcastTransaction.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { Transaction } from '../../../primitives'
 import { ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
@@ -32,7 +33,9 @@ export const BroadcastTransactionResponseSchema: yup.ObjectSchema<BroadcastTrans
 router.register<typeof BroadcastTransactionRequestSchema, BroadcastTransactionResponse>(
   `${ApiNamespace.chain}/broadcastTransaction`,
   BroadcastTransactionRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const data = Buffer.from(request.data.transaction, 'hex')
     const transaction = new Transaction(data)
 

--- a/ironfish/src/rpc/routes/chain/estimateFeeRate.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRate.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { PRIORITY_LEVELS, PriorityLevel } from '../../../memPool/feeEstimator'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
@@ -27,7 +28,9 @@ export const EstimateFeeRateResponseSchema: yup.ObjectSchema<EstimateFeeRateResp
 router.register<typeof EstimateFeeRateRequestSchema, EstimateFeeRateResponse>(
   `${ApiNamespace.chain}/estimateFeeRate`,
   EstimateFeeRateRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const priority = request.data?.priority ?? 'average'
     const rate = node.memPool.feeEstimator.estimateFeeRate(priority)
     request.end({ rate: CurrencyUtils.encode(rate) })

--- a/ironfish/src/rpc/routes/chain/estimateFeeRates.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRates.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
 
@@ -27,7 +28,9 @@ export const EstimateFeeRatesResponseSchema: yup.ObjectSchema<EstimateFeeRatesRe
 router.register<typeof EstimateFeeRatesRequestSchema, EstimateFeeRatesResponse>(
   `${ApiNamespace.chain}/estimateFeeRates`,
   EstimateFeeRatesRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const rates = node.memPool.feeEstimator.estimateFeeRates()
 
     request.end({

--- a/ironfish/src/rpc/routes/chain/exportChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/exportChainStream.ts
@@ -61,7 +61,8 @@ export const ExportChainStreamResponseSchema: yup.ObjectSchema<ExportChainStream
 router.register<typeof ExportChainStreamRequestSchema, ExportChainStreamResponse>(
   `${ApiNamespace.chain}/exportChainStream`,
   ExportChainStreamRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
     Assert.isNotNull(node.chain.head, 'head')
     Assert.isNotNull(node.chain.latest, 'latest')
 

--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -139,7 +139,8 @@ export const FollowChainStreamResponseSchema: yup.ObjectSchema<FollowChainStream
 router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse>(
   `${ApiNamespace.chain}/followChainStream`,
   FollowChainStreamRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
     const head = request.data?.head ? Buffer.from(request.data.head, 'hex') : null
 
     const processor = new ChainProcessor({

--- a/ironfish/src/rpc/routes/chain/getAsset.ts
+++ b/ironfish/src/rpc/routes/chain/getAsset.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ASSET_ID_LENGTH } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { CurrencyUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
@@ -41,7 +42,9 @@ export const GetAssetResponse: yup.ObjectSchema<GetAssetResponse> = yup
 router.register<typeof GetAssetRequestSchema, GetAssetResponse>(
   `${ApiNamespace.chain}/getAsset`,
   GetAssetRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const id = Buffer.from(request.data.id, 'hex')
 
     if (id.byteLength !== ASSET_ID_LENGTH) {

--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { BlockHeader } from '../../../primitives'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives/block'
 import { BufferUtils } from '../../../utils'
@@ -88,7 +89,9 @@ export const GetBlockResponseSchema: yup.ObjectSchema<GetBlockResponse> = yup
 router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
   `${ApiNamespace.chain}/getBlock`,
   GetBlockRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     let header: BlockHeader | null = null
     let error = ''
 

--- a/ironfish/src/rpc/routes/chain/getChainInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.ts
@@ -44,7 +44,9 @@ export const GetChainInfoResponseSchema: yup.ObjectSchema<GetChainInfoResponse> 
 router.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
   `${ApiNamespace.chain}/getChainInfo`,
   GetChainInfoRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     Assert.isNotNull(node.chain.genesis, 'no genesis')
 
     const latestHeader = node.chain.latest

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
@@ -35,7 +35,8 @@ export const GetConsensusParametersResponseSchema: yup.ObjectSchema<GetConsensus
 router.register<typeof GetConsensusParametersRequestSchema, GetConsensusParametersResponse>(
   `${ApiNamespace.chain}/getConsensusParameters`,
   GetConsensusParametersRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
     Assert.isNotNull(node.chain.consensus, 'no consensus parameters')
 
     const consensusParameters = node.chain.consensus.parameters

--- a/ironfish/src/rpc/routes/chain/getDifficulty.ts
+++ b/ironfish/src/rpc/routes/chain/getDifficulty.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
 
@@ -34,7 +35,9 @@ export const GetDifficultyResponseSchema: yup.ObjectSchema<GetDifficultyResponse
 router.register<typeof GetDifficultyRequestSchema, GetDifficultyResponse>(
   `${ApiNamespace.chain}/getDifficulty`,
   GetDifficultyRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     let sequence = node.chain.head.sequence
     let block = node.chain.head
 

--- a/ironfish/src/rpc/routes/chain/getNetworkHashPower.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkHashPower.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { BigIntUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
@@ -37,7 +38,9 @@ export const GetNetworkHashPowerResponseSchema: yup.ObjectSchema<GetNetworkHashP
 router.register<typeof GetNetworkHashPowerRequestSchema, GetNetworkHashPowerResponse>(
   `${ApiNamespace.chain}/getNetworkHashPower`,
   GetNetworkHashPowerRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     let blocks = request.data?.blocks ?? 120
     let sequence = request.data?.sequence ?? -1
 

--- a/ironfish/src/rpc/routes/chain/getNetworkInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkInfo.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ApiNamespace, router } from '../router'
 
 export type GetNetworkInfoRequest = undefined
@@ -22,7 +23,9 @@ export const GetNetworkInfoResponseSchema: yup.ObjectSchema<GetNetworkInfoRespon
 router.register<typeof GetNetworkInfoRequestSchema, GetNetworkInfoResponse>(
   `${ApiNamespace.chain}/getNetworkInfo`,
   GetNetworkInfoRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     request.end({
       networkId: node.internal.get('networkId'),
     })

--- a/ironfish/src/rpc/routes/chain/getNoteWitness.ts
+++ b/ironfish/src/rpc/routes/chain/getNoteWitness.ts
@@ -48,7 +48,8 @@ export const GetNoteWitnessResponseSchema: yup.ObjectSchema<GetNoteWitnessRespon
 router.register<typeof GetNoteWitnessRequestSchema, GetNoteWitnessResponse>(
   `${ApiNamespace.chain}/getNoteWitness`,
   GetNoteWitnessRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
     const { chain } = node
 
     const confirmations = request.data.confirmations ?? node.config.get('confirmations')

--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { CurrencyUtils } from '../../../utils'
 import { NotFoundError, ValidationError } from '../../adapters'
@@ -80,7 +81,9 @@ export const GetTransactionResponseSchema: yup.ObjectSchema<GetTransactionRespon
 router.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
   `${ApiNamespace.chain}/getTransaction`,
   GetTransactionRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     if (!request.data.transactionHash) {
       throw new ValidationError(`Missing transaction hash`)
     }

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -125,7 +125,8 @@ export const GetTransactionStreamResponseSchema: yup.ObjectSchema<GetTransaction
 router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamResponse>(
   `${ApiNamespace.chain}/getTransactionStream`,
   GetTransactionStreamRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
     if (!isValidIncomingViewKey(request.data.incomingViewKey)) {
       throw new ValidationError(`incomingViewKey is not valid`)
     }

--- a/ironfish/src/rpc/routes/chain/showChain.ts
+++ b/ironfish/src/rpc/routes/chain/showChain.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ApiNamespace, router } from '../router'
 import { renderChain } from './utils'
 
@@ -35,7 +36,9 @@ export const ShowChainResponseSchema: yup.ObjectSchema<ShowChainResponse> = yup
 router.register<typeof ShowChainRequestSchema, ShowChainResponse>(
   `${ApiNamespace.chain}/showChain`,
   ShowChainRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const content = await renderChain(node.chain, request.data?.start, request.data?.stop, {
       indent: '  ',
       work: false,

--- a/ironfish/src/rpc/routes/config/getConfig.ts
+++ b/ironfish/src/rpc/routes/config/getConfig.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
 import { ValidationError } from '../../adapters/errors'
 import { ApiNamespace, router } from '../router'
@@ -21,7 +22,9 @@ export const GetConfigResponseSchema: yup.ObjectSchema<GetConfigResponse> = Conf
 router.register<typeof GetConfigRequestSchema, GetConfigResponse>(
   `${ApiNamespace.config}/getConfig`,
   GetConfigRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     if (request.data?.name && !(request.data.name in node.config.defaults)) {
       throw new ValidationError(`No config option ${String(request.data.name)}`)
     }

--- a/ironfish/src/rpc/routes/config/setConfig.ts
+++ b/ironfish/src/rpc/routes/config/setConfig.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
 import { ApiNamespace, router } from '../router'
 import { setUnknownConfigValue } from './uploadConfig'
@@ -21,7 +22,9 @@ export const SetConfigResponseSchema: yup.ObjectSchema<SetConfigResponse> = Conf
 router.register<typeof SetConfigRequestSchema, SetConfigResponse>(
   `${ApiNamespace.config}/setConfig`,
   SetConfigRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     setUnknownConfigValue(node.config, request.data.name, request.data.value)
     await node.config.save()
     request.end()

--- a/ironfish/src/rpc/routes/config/unsetConfig.ts
+++ b/ironfish/src/rpc/routes/config/unsetConfig.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
 import { ApiNamespace, router } from '../router'
 import { setUnknownConfigValue } from './uploadConfig'
@@ -21,7 +22,9 @@ export const UnsetConfigResponseSchema: yup.ObjectSchema<UnsetConfigResponse> =
 router.register<typeof UnsetConfigRequestSchema, UnsetConfigResponse>(
   `${ApiNamespace.config}/unsetConfig`,
   UnsetConfigRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     setUnknownConfigValue(node.config, request.data.name)
     await node.config.save()
     request.end()

--- a/ironfish/src/rpc/routes/config/uploadConfig.ts
+++ b/ironfish/src/rpc/routes/config/uploadConfig.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { Config, ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
 import { ValidationError } from '../../adapters/errors'
 import { ApiNamespace, router } from '../router'
@@ -19,7 +20,9 @@ export const UploadConfigResponseSchema: yup.ObjectSchema<UploadConfigResponse> 
 router.register<typeof UploadConfigRequestSchema, UploadConfigResponse>(
   `${ApiNamespace.config}/uploadConfig`,
   UploadConfigRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     clearConfig(node.config)
 
     for (const key of Object.keys(request.data.config)) {

--- a/ironfish/src/rpc/routes/event/onGossip.ts
+++ b/ironfish/src/rpc/routes/event/onGossip.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { BlockHeader } from '../../../primitives'
 import { ApiNamespace, router } from '../router'
 import { RpcBlockHeader, RpcBlockHeaderSchema, serializeRpcBlockHeader } from './types'
@@ -21,7 +22,9 @@ export const OnGossipResponseSchema: yup.ObjectSchema<OnGossipResponse> = yup
 router.register<typeof OnGossipRequestSchema, OnGossipResponse>(
   `${ApiNamespace.event}/onGossip`,
   OnGossipRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     function onGossip(header: BlockHeader) {
       const serialized = serializeRpcBlockHeader(header)
       request.stream({ blockHeader: serialized })

--- a/ironfish/src/rpc/routes/event/onReorganizeChain.ts
+++ b/ironfish/src/rpc/routes/event/onReorganizeChain.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { BlockHeader } from '../../../primitives'
 import { ApiNamespace, router } from '../router'
 import { RpcBlockHeader, RpcBlockHeaderSchema, serializeRpcBlockHeader } from './types'
@@ -27,7 +28,9 @@ export const OnReorganizeChainResponseSchema: yup.ObjectSchema<OnReorganizeChain
 router.register<typeof OnReorganizeChainRequestSchema, OnReorganizeChainResponse>(
   `${ApiNamespace.event}/onReorganizeChain`,
   OnReorganizeChainRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     function onReorganizeChain(oldHead: BlockHeader, newHead: BlockHeader, fork: BlockHeader) {
       request.stream({
         oldHead: serializeRpcBlockHeader(oldHead),

--- a/ironfish/src/rpc/routes/event/onTransactionGossip.ts
+++ b/ironfish/src/rpc/routes/event/onTransactionGossip.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { Transaction } from '../../../primitives'
 import { ApiNamespace, router } from '../router'
 
@@ -25,7 +26,9 @@ export const OnTransactionGossipResponseSchema: yup.ObjectSchema<OnTransactionGo
 router.register<typeof OnTransactionGossipRequestSchema, OnTransactionGossipResponse>(
   `${ApiNamespace.event}/onTransactionGossip`,
   OnTransactionGossipRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const onTransactionGossip = (transaction: Transaction) => {
       request.stream({
         serializedTransaction: transaction.serialize().toString('hex'),

--- a/ironfish/src/rpc/routes/faucet/getFunds.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.ts
@@ -28,7 +28,8 @@ export const GetFundsResponseSchema: yup.ObjectSchema<GetFundsResponse> = yup
 router.register<typeof GetFundsRequestSchema, GetFundsResponse>(
   `${ApiNamespace.faucet}/getFunds`,
   GetFundsRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
     // check node network id
     const networkId = node.internal.get('networkId')
 

--- a/ironfish/src/rpc/routes/mempool/getStatus.ts
+++ b/ironfish/src/rpc/routes/mempool/getStatus.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { IronfishNode } from '../../../node'
 import { PromiseUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
@@ -50,7 +51,9 @@ export const GetMempoolStatusResponseSchema: yup.ObjectSchema<GetMempoolStatusRe
 router.register<typeof GetMempoolStatusRequestSchema, GetMempoolStatusResponse>(
   `${ApiNamespace.mempool}/getStatus`,
   GetMempoolStatusRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const status = getStatus(node)
 
     if (!request.data?.stream) {

--- a/ironfish/src/rpc/routes/mempool/getTransactions.ts
+++ b/ironfish/src/rpc/routes/mempool/getTransactions.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { getFeeRate } from '../../../memPool'
 import { Transaction } from '../../../primitives'
 import { ApiNamespace, router } from '../router'
@@ -57,7 +58,9 @@ export const MempoolTransactionResponseSchema: yup.ObjectSchema<GetMempoolTransa
 router.register<typeof MempoolTransactionsRequestSchema, GetMempoolTransactionResponse>(
   `${ApiNamespace.mempool}/getTransactions`,
   MempoolTransactionsRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     let position = 0
     let streamed = 0
 

--- a/ironfish/src/rpc/routes/miner/blockTemplateStream.ts
+++ b/ironfish/src/rpc/routes/miner/blockTemplateStream.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { SerializedBlockTemplate } from '../../../serde/BlockTemplateSerde'
 import { ApiNamespace, router } from '../router'
 
@@ -43,7 +44,9 @@ export const BlockTemplateStreamResponseSchema: yup.ObjectSchema<BlockTemplateSt
 router.register<typeof BlockTemplateStreamRequestSchema, BlockTemplateStreamResponse>(
   `${ApiNamespace.miner}/blockTemplateStream`,
   BlockTemplateStreamRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     if (!node.chain.synced && !node.config.get('miningForce')) {
       node.logger.info(
         'Miner connected while the node is syncing. Will not start mining until the node is synced',

--- a/ironfish/src/rpc/routes/miner/submitBlock.ts
+++ b/ironfish/src/rpc/routes/miner/submitBlock.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { MINED_RESULT } from '../../../mining/manager'
 import { SerializedBlockTemplate } from '../../../serde'
 import { ApiNamespace, router } from '../router'
@@ -62,7 +63,9 @@ export const SubmitBlockResponseSchema: yup.ObjectSchema<SubmitBlockResponse> = 
 router.register<typeof SubmitBlockRequestSchema, SubmitBlockResponse>(
   `${ApiNamespace.miner}/submitBlock`,
   SubmitBlockRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const result = await node.miningManager.submitBlockTemplate(request.data)
 
     request.end({

--- a/ironfish/src/rpc/routes/node/getLogStream.ts
+++ b/ironfish/src/rpc/routes/node/getLogStream.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ConsolaReporterLogObject } from 'consola'
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { InterceptReporter } from '../../../logger'
 import { IJSON } from '../../../serde'
 import { ApiNamespace, router } from '../router'
@@ -36,7 +37,9 @@ export const GetLogStreamResponseSchema: yup.ObjectSchema<GetLogStreamResponse> 
 router.register<typeof GetLogStreamRequestSchema, GetLogStreamResponse>(
   `${ApiNamespace.node}/getLogStream`,
   GetLogStreamRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const reporter = new InterceptReporter((logObj: ConsolaReporterLogObject): void => {
       request.stream({
         level: String(logObj.level),

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { getActiveReqs, isActive } from 'libuv-monitor'
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { IronfishNode } from '../../../node'
 import { MathUtils, PromiseUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
@@ -254,7 +255,9 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetNodeStatusResponse> = 
 router.register<typeof GetStatusRequestSchema, GetNodeStatusResponse>(
   `${ApiNamespace.node}/getStatus`,
   GetStatusRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const status = getStatus(node)
 
     if (!request.data?.stream) {

--- a/ironfish/src/rpc/routes/node/stopNode.ts
+++ b/ironfish/src/rpc/routes/node/stopNode.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ApiNamespace, router } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -19,7 +20,9 @@ export const StopNodeResponseSchema: yup.MixedSchema<StopNodeRequest> = yup
 router.register<typeof StopNodeRequestSchema, StopNodeResponse>(
   `${ApiNamespace.node}/stopNode`,
   StopNodeRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     node.logger.withTag('stopnode').info('Shutting down')
     request.end()
     await node.shutdown()

--- a/ironfish/src/rpc/routes/peer/addPeer.ts
+++ b/ironfish/src/rpc/routes/peer/addPeer.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { DEFAULT_WEBSOCKET_PORT } from '../../../fileStores/config'
 import { ApiNamespace, router } from '../router'
 
@@ -33,7 +34,9 @@ export const AddPeerResponseSchema: yup.ObjectSchema<AddPeerResponse> = yup
 router.register<typeof AddPeerRequestSchema, AddPeerResponse>(
   `${ApiNamespace.peer}/addPeer`,
   AddPeerRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const peerManager = node.peerNetwork.peerManager
     const { host, port, whitelist } = request.data
 

--- a/ironfish/src/rpc/routes/peer/getBannedPeers.ts
+++ b/ironfish/src/rpc/routes/peer/getBannedPeers.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { PeerNetwork } from '../../../network'
 import { ApiNamespace, router } from '../router'
 
@@ -45,7 +46,9 @@ export const GetBannedPeersResponseSchema: yup.ObjectSchema<GetBannedPeersRespon
 router.register<typeof GetBannedPeersRequestSchema, GetBannedPeersResponse>(
   `${ApiNamespace.peer}/getBannedPeers`,
   GetBannedPeersRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const peerNetwork = node.peerNetwork
 
     const peers = getPeers(peerNetwork)

--- a/ironfish/src/rpc/routes/peer/getPeer.ts
+++ b/ironfish/src/rpc/routes/peer/getPeer.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { Connection, PeerNetwork } from '../../../network'
 import { ApiNamespace, router } from '../router'
 import { PeerResponse } from './getPeers'
@@ -60,7 +61,9 @@ export const GetPeerResponseSchema: yup.ObjectSchema<GetPeerResponse> = yup
 router.register<typeof GetPeerRequestSchema, GetPeerResponse>(
   `${ApiNamespace.peer}/getPeer`,
   GetPeerRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const peerNetwork = node.peerNetwork
 
     if (!peerNetwork) {

--- a/ironfish/src/rpc/routes/peer/getPeerMessages.ts
+++ b/ironfish/src/rpc/routes/peer/getPeerMessages.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { Connection, PeerNetwork } from '../../../network'
 import { NetworkMessageType } from '../../../network/types'
 import { IJSON } from '../../../serde'
@@ -60,7 +61,9 @@ export const GetPeerMessagesResponseSchema: yup.ObjectSchema<GetPeerMessagesResp
 router.register<typeof GetPeerMessagesRequestSchema, GetPeerMessagesResponse>(
   `${ApiNamespace.peer}/getPeerMessages`,
   GetPeerMessagesRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const peerNetwork = node.peerNetwork
 
     if (!peerNetwork) {

--- a/ironfish/src/rpc/routes/peer/getPeers.ts
+++ b/ironfish/src/rpc/routes/peer/getPeers.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { Connection, PeerNetwork } from '../../../network'
 import { Features } from '../../../network/peers/peerFeatures'
 import { ApiNamespace, router } from '../router'
@@ -87,7 +88,9 @@ export const GetPeersResponseSchema: yup.ObjectSchema<GetPeersResponse> = yup
 router.register<typeof GetPeersRequestSchema, GetPeersResponse>(
   `${ApiNamespace.peer}/getPeers`,
   GetPeersRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const peerNetwork = node.peerNetwork
 
     if (!peerNetwork) {

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -5,6 +5,7 @@ import { Assert } from '../../assert'
 import { IronfishNode } from '../../node'
 import { YupSchema, YupSchemaResult, YupUtils } from '../../utils'
 import { StrEnumUtils } from '../../utils/enums'
+import { Wallet } from '../../wallet'
 import { ERROR_CODES } from '../adapters'
 import { ResponseError, ValidationError } from '../adapters/errors'
 import { RpcRequest } from '../request'
@@ -26,9 +27,11 @@ export enum ApiNamespace {
 
 export const ALL_API_NAMESPACES = StrEnumUtils.getValues(ApiNamespace)
 
+type RequestContext = { node?: IronfishNode; wallet?: Wallet }
+
 export type RouteHandler<TRequest = unknown, TResponse = unknown> = (
   request: RpcRequest<TRequest, TResponse>,
-  node: IronfishNode,
+  context: RequestContext,
 ) => Promise<void> | void
 
 export class RouteNotFoundError extends ResponseError {
@@ -50,6 +53,7 @@ export function parseRoute(
 
 export class Router {
   routes = new Map<string, Map<string, { handler: RouteHandler; schema: YupSchema }>>()
+  context: RequestContext = {}
   server: RpcServer | null = null
 
   register<TRequestSchema extends YupSchema, TResponse>(
@@ -96,10 +100,8 @@ export class Router {
     }
     request.data = result
 
-    Assert.isNotNull(this.server)
-
     try {
-      await handler(request, this.server.node)
+      await handler(request, this.context)
     } catch (e: unknown) {
       if (e instanceof ResponseError) {
         throw e

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -27,7 +27,7 @@ export enum ApiNamespace {
 
 export const ALL_API_NAMESPACES = StrEnumUtils.getValues(ApiNamespace)
 
-type RequestContext = { node?: IronfishNode; wallet?: Wallet }
+export type RequestContext = { node?: IronfishNode; wallet?: Wallet }
 
 export type RouteHandler<TRequest = unknown, TResponse = unknown> = (
   request: RpcRequest<TRequest, TResponse>,

--- a/ironfish/src/rpc/routes/rpc/getStatus.ts
+++ b/ironfish/src/rpc/routes/rpc/getStatus.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { IronfishNode } from '../../../node'
 import { PromiseUtils } from '../../../utils'
 import { RpcHttpAdapter, RpcIpcAdapter } from '../../adapters'
@@ -62,7 +63,9 @@ export const GetRpcStatusResponseSchema: yup.ObjectSchema<GetRpcStatusResponse> 
 router.register<typeof GetRpcStatusRequestSchema, GetRpcStatusResponse>(
   `${ApiNamespace.rpc}/getStatus`,
   GetRpcStatusRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const jobs = await getRpcStatus(node)
 
     if (!request.data?.stream) {

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { Transaction } from '../../../primitives'
 import { AsyncUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
@@ -36,7 +37,9 @@ export const AddTransactionResponseSchema: yup.ObjectSchema<AddTransactionRespon
 router.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
   `${ApiNamespace.wallet}/addTransaction`,
   AddTransactionRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const data = Buffer.from(request.data.transaction, 'hex')
     const transaction = new Transaction(data)
 

--- a/ironfish/src/rpc/routes/wallet/burnAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.ts
@@ -48,7 +48,8 @@ export const BurnAssetResponseSchema: yup.ObjectSchema<BurnAssetResponse> = yup
 router.register<typeof BurnAssetRequestSchema, BurnAssetResponse>(
   `${ApiNamespace.wallet}/burnAsset`,
   BurnAssetRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
     const account = getAccount(node.wallet, request.data.account)
 
     const fee = CurrencyUtils.decode(request.data.fee)

--- a/ironfish/src/rpc/routes/wallet/create.ts
+++ b/ironfish/src/rpc/routes/wallet/create.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ERROR_CODES, ValidationError } from '../../adapters'
 import { ApiNamespace, router } from '../router'
 
@@ -30,7 +31,9 @@ export const CreateAccountResponseSchema: yup.ObjectSchema<CreateAccountResponse
 router.register<typeof CreateAccountRequestSchema, CreateAccountResponse>(
   `${ApiNamespace.wallet}/create`,
   CreateAccountRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const name = request.data.name
 
     if (node.wallet.accountExists(name)) {

--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -102,7 +102,8 @@ export const CreateTransactionResponseSchema: yup.ObjectSchema<CreateTransaction
 router.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse>(
   `${ApiNamespace.wallet}/createTransaction`,
   CreateTransactionRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
     const account = getAccount(node.wallet, request.data.account)
 
     const params: Parameters<Wallet['createTransaction']>[0] = {

--- a/ironfish/src/rpc/routes/wallet/exportAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { LanguageKey, LanguageUtils } from '../../../utils'
 import { encodeAccount } from '../../../wallet/account/encoder/account'
 import { AccountFormat } from '../../../wallet/account/encoder/encoder'
@@ -37,7 +38,9 @@ export const ExportAccountResponseSchema: yup.ObjectSchema<ExportAccountResponse
 router.register<typeof ExportAccountRequestSchema, ExportAccountResponse>(
   `${ApiNamespace.wallet}/exportAccount`,
   ExportAccountRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
     const { id: _, ...accountInfo } = account.serialize()
     if (request.data.viewOnly) {

--- a/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
 import { RpcWalletNote, RpcWalletNoteSchema } from './types'
@@ -24,7 +25,9 @@ export const GetAccountNotesStreamResponseSchema: yup.ObjectSchema<GetAccountNot
 router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStreamResponse>(
   `${ApiNamespace.wallet}/getAccountNotesStream`,
   GetAccountNotesStreamRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
 
     for await (const transaction of account.getTransactionsByTime()) {

--- a/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { TransactionStatus, TransactionType } from '../../../wallet'
 import { ApiNamespace, router } from '../router'
 import { RpcSpend, RpcSpendSchema, RpcWalletNote, RpcWalletNoteSchema } from './types'
@@ -89,7 +90,9 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
 router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransactionResponse>(
   `${ApiNamespace.wallet}/getAccountTransaction`,
   GetAccountTransactionRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
 
     const transactionHash = Buffer.from(request.data.hash, 'hex')

--- a/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { IronfishNode } from '../../../node'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives'
 import { TransactionStatus, TransactionType } from '../../../wallet'
@@ -98,7 +99,9 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
 router.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactionsResponse>(
   `${ApiNamespace.wallet}/getAccountTransactions`,
   GetAccountTransactionsRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
 
     const headSequence = (await account.getHead())?.sequence ?? null

--- a/ironfish/src/rpc/routes/wallet/getAccounts.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccounts.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { Account } from '../../../wallet'
 import { ApiNamespace, router } from '../router'
 
@@ -25,7 +26,9 @@ export const GetAccountsResponseSchema: yup.ObjectSchema<GetAccountsResponse> = 
 router.register<typeof GetAccountsRequestSchema, GetAccountsResponse>(
   `${ApiNamespace.wallet}/getAccounts`,
   GetAccountsRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     let accounts: Account[] = []
 
     if (request.data?.default) {

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ApiNamespace, router } from '../router'
 
 export type GetAccountStatusRequest = { account?: string }
@@ -41,7 +42,9 @@ export const GetAccountStatusResponseSchema: yup.ObjectSchema<GetAccountStatusRe
 router.register<typeof GetAccountStatusRequestSchema, GetAccountStatusResponse>(
   `${ApiNamespace.wallet}/getAccountsStatus`,
   GetAccountStatusRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const headHashes = new Map<string, Buffer | null>()
     for await (const { accountId, head } of node.wallet.walletDb.loadHeads()) {
       headHashes.set(accountId, head?.hash ?? null)

--- a/ironfish/src/rpc/routes/wallet/getAssets.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { AssetVerification } from '../../../assets'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
@@ -49,7 +50,9 @@ export const GetAssetsResponseSchema: yup.ObjectSchema<GetAssetsResponse> = yup
 router.register<typeof GetAssetsRequestSchema, GetAssetsResponse>(
   `${ApiNamespace.wallet}/getAssets`,
   GetAssetsRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
 
     for await (const asset of account.getAssets()) {

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { AssetVerification } from '../../../assets'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
@@ -60,7 +61,9 @@ export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yu
 router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
   `${ApiNamespace.wallet}/getBalance`,
   GetBalanceRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const confirmations = request.data?.confirmations ?? node.config.get('confirmations')
 
     const account = getAccount(node.wallet, request.data?.account)

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { AssetVerification } from '../../../assets'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, router } from '../router'
@@ -72,7 +73,9 @@ export const GetBalancesResponseSchema: yup.ObjectSchema<GetBalancesResponse> = 
 router.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
   `${ApiNamespace.wallet}/getBalances`,
   GetBalancesRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
 
     const balances = []

--- a/ironfish/src/rpc/routes/wallet/getDefaultAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/getDefaultAccount.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ApiNamespace, router } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -27,7 +28,9 @@ export const GetDefaultAccountResponseSchema: yup.ObjectSchema<GetDefaultAccount
 router.register<typeof GetDefaultAccountRequestSchema, GetDefaultAccountResponse>(
   `${ApiNamespace.wallet}/getDefaultAccount`,
   GetDefaultAccountRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const account = node.wallet.getDefaultAccount()
     request.end({ account: account ? { name: account.name } : null })
   },

--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ApiNamespace, router } from '../router'
 import { RpcWalletNote, RpcWalletNoteSchema } from './types'
 import { getAccount, serializeRpcWalletNote } from './utils'
@@ -71,7 +72,9 @@ export const GetNotesResponseSchema: yup.ObjectSchema<GetNotesResponse> = yup
 router.register<typeof GetNotesRequestSchema, GetNotesResponse>(
   `${ApiNamespace.wallet}/getNotes`,
   GetNotesRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
     const pageSize = request.data.pageSize ?? DEFAULT_PAGE_SIZE
     const pageCursor = request.data.pageCursor

--- a/ironfish/src/rpc/routes/wallet/getPublicKey.ts
+++ b/ironfish/src/rpc/routes/wallet/getPublicKey.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
@@ -24,7 +25,9 @@ export const GetPublicKeyResponseSchema: yup.ObjectSchema<GetPublicKeyResponse> 
 router.register<typeof GetPublicKeyRequestSchema, GetPublicKeyResponse>(
   `${ApiNamespace.wallet}/getPublicKey`,
   GetPublicKeyRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
 
     request.end({

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { v4 as uuid } from 'uuid'
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { decodeAccount } from '../../../wallet/account/encoder/account'
 import { ApiNamespace, router } from '../router'
 import { RpcAccountImport } from './types'
@@ -39,7 +40,9 @@ export const ImportAccountResponseSchema: yup.ObjectSchema<ImportResponse> = yup
 router.register<typeof ImportAccountRequestSchema, ImportResponse>(
   `${ApiNamespace.wallet}/importAccount`,
   ImportAccountRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     let accountImport = null
     if (typeof request.data.account === 'string') {
       accountImport = decodeAccount(request.data.account, {

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -54,7 +54,8 @@ export const MintAssetResponseSchema: yup.ObjectSchema<MintAssetResponse> = yup
 router.register<typeof MintAssetRequestSchema, MintAssetResponse>(
   `${ApiNamespace.wallet}/mintAsset`,
   MintAssetRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
     const account = getAccount(node.wallet, request.data.account)
 
     const fee = CurrencyUtils.decode(request.data.fee)

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { RawTransactionSerde } from '../../../primitives/rawTransaction'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
@@ -35,7 +36,9 @@ export const PostTransactionResponseSchema: yup.ObjectSchema<PostTransactionResp
 router.register<typeof PostTransactionRequestSchema, PostTransactionResponse>(
   `${ApiNamespace.wallet}/postTransaction`,
   PostTransactionRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
 
     const bytes = Buffer.from(request.data.transaction, 'hex')

--- a/ironfish/src/rpc/routes/wallet/remove.ts
+++ b/ironfish/src/rpc/routes/wallet/remove.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
@@ -25,7 +26,9 @@ export const RemoveAccountResponseSchema: yup.ObjectSchema<RemoveAccountResponse
 router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
   `${ApiNamespace.wallet}/remove`,
   RemoveAccountRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
 
     if (!request.data.confirm) {

--- a/ironfish/src/rpc/routes/wallet/rename.ts
+++ b/ironfish/src/rpc/routes/wallet/rename.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
@@ -22,7 +23,9 @@ export const RenameAccountResponseSchema: yup.MixedSchema<RenameAccountResponse>
 router.register<typeof RenameAccountRequestSchema, RenameAccountResponse>(
   `${ApiNamespace.wallet}/rename`,
   RenameAccountRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
     await account.setName(request.data.newName)
     request.end()

--- a/ironfish/src/rpc/routes/wallet/rescanAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/rescanAccount.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives'
 import { ValidationError } from '../../adapters/errors'
 import { ApiNamespace, router } from '../router'
@@ -27,7 +28,9 @@ export const RescanAccountResponseSchema: yup.ObjectSchema<RescanAccountResponse
 router.register<typeof RescanAccountRequestSchema, RescanAccountResponse>(
   `${ApiNamespace.wallet}/rescanAccount`,
   RescanAccountRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     let scan = node.wallet.scan
 
     if (scan && !request.data.follow) {

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -4,6 +4,7 @@
 import { Asset, MEMO_LENGTH } from '@ironfish/rust-nodejs'
 import { BufferMap } from 'buffer-map'
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { CurrencyUtils, YupUtils } from '../../../utils'
 import { Wallet } from '../../../wallet'
 import { NotEnoughFundsError } from '../../../wallet/errors'
@@ -66,7 +67,9 @@ export const SendTransactionResponseSchema: yup.ObjectSchema<SendTransactionResp
 router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
   `${ApiNamespace.wallet}/sendTransaction`,
   SendTransactionRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
 
     if (!node.peerNetwork.isReady) {

--- a/ironfish/src/rpc/routes/wallet/use.ts
+++ b/ironfish/src/rpc/routes/wallet/use.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { ApiNamespace, router } from '../router'
 import { getAccount } from './utils'
 
@@ -21,7 +22,9 @@ export const UseAccountResponseSchema: yup.MixedSchema<UseAccountResponse> = yup
 router.register<typeof UseAccountRequestSchema, UseAccountResponse>(
   `${ApiNamespace.wallet}/use`,
   UseAccountRequestSchema,
-  async (request, node): Promise<void> => {
+  async (request, { node }): Promise<void> => {
+    Assert.isNotUndefined(node)
+
     const account = getAccount(node.wallet, request.data.account)
     await node.wallet.setDefaultAccount(account.name)
     request.end()

--- a/ironfish/src/rpc/routes/worker/getStatus.ts
+++ b/ironfish/src/rpc/routes/worker/getStatus.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../../assert'
 import { IronfishNode } from '../../../node'
 import { MathUtils } from '../../../utils'
 import { WorkerMessageType } from '../../../workerPool/tasks/workerMessage'
@@ -65,7 +66,9 @@ export const GetWorkersStatusResponseSchema: yup.ObjectSchema<GetWorkersStatusRe
 router.register<typeof GetWorkersStatusRequestSchema, GetWorkersStatusResponse>(
   `${ApiNamespace.worker}/getStatus`,
   GetWorkersStatusRequestSchema,
-  (request, node): void => {
+  (request, { node }): void => {
+    Assert.isNotUndefined(node)
+
     const jobs = getWorkersStatus(node)
 
     if (!request.data?.stream) {

--- a/ironfish/src/rpc/server.ts
+++ b/ironfish/src/rpc/server.ts
@@ -11,15 +11,12 @@ export class RpcServer {
   readonly node: IronfishNode
   readonly adapters: IRpcAdapter[] = []
 
-  private readonly router: Router
   private _isRunning = false
   private _startPromise: Promise<unknown> | null = null
   logger: Logger
 
   constructor(node: IronfishNode, logger: Logger = createRootLogger()) {
     this.node = node
-    this.router = router
-    this.router.server = this
     this.logger = logger.withTag('rpcserver')
   }
 
@@ -29,7 +26,10 @@ export class RpcServer {
 
   /** Creates a new router from this RpcServer with the attached routes filtered by namespaces */
   getRouter(namespaces: ApiNamespace[]): Router {
-    return this.router.filter(namespaces)
+    const newRouter = router.filter(namespaces)
+    newRouter.server = this
+    newRouter.context = { node: this.node }
+    return newRouter
   }
 
   /** Starts the RPC server and tells any attached adapters to starts serving requests to the routing layer */


### PR DESCRIPTION
## Summary
To enable the RPC layer to be re-used with a standalone wallet, it needs to be able to be intsantiated without a node. Removing direct dependency on a node object here.

## Testing Plan
Unit testing / local testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
