### PR TITLE
Separate global routes from Router

### DIFF
--- a/ironfish/src/rpc/adapters/ipcAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/ipcAdapter.test.ts
@@ -57,7 +57,7 @@ describe('IpcAdapter', () => {
   })
 
   it('should send and receive message', async () => {
-    ipc.router?.register('foo/bar', yup.string(), (request) => {
+    ipc.router?.routes.register('foo/bar', yup.string(), (request) => {
       request.end(request.data)
     })
 
@@ -69,7 +69,7 @@ describe('IpcAdapter', () => {
   })
 
   it('should stream message', async () => {
-    ipc.router?.register('foo/bar', yup.object({}), (request) => {
+    ipc.router?.routes.register('foo/bar', yup.object({}), (request) => {
       request.stream('hello 1')
       request.stream('hello 2')
       request.end()
@@ -89,7 +89,7 @@ describe('IpcAdapter', () => {
   it('should not crash on disconnect while streaming', async () => {
     const [waitPromise, waitResolve] = PromiseUtils.split<void>()
 
-    ipc.router?.register('foo/bar', yup.object({}), async () => {
+    ipc.router?.routes.register('foo/bar', yup.object({}), async () => {
       await waitPromise
     })
 
@@ -106,7 +106,7 @@ describe('IpcAdapter', () => {
   })
 
   it('should handle errors', async () => {
-    ipc.router?.register('foo/bar', yup.object({}), () => {
+    ipc.router?.routes.register('foo/bar', yup.object({}), () => {
       throw new ValidationError('hello error', 402, 'hello-error' as ERROR_CODES)
     })
 
@@ -129,7 +129,7 @@ describe('IpcAdapter', () => {
     // But send this instead
     const body = undefined
 
-    ipc.router?.register('foo/bar', schema, (res) => res.end())
+    ipc.router?.routes.register('foo/bar', schema, (res) => res.end())
 
     await ipc.start()
     await client.connect()

--- a/ironfish/src/rpc/adapters/tcpAdapter.test.ts
+++ b/ironfish/src/rpc/adapters/tcpAdapter.test.ts
@@ -64,7 +64,7 @@ describe('TcpAdapter', () => {
     Assert.isNotUndefined(tcp)
     Assert.isNotNull(tcp.router)
 
-    tcp.router.register('foo/bar', yup.string(), (request) => {
+    tcp.router.routes.register('foo/bar', yup.string(), (request) => {
       request.end(request.data)
     })
 
@@ -79,7 +79,7 @@ describe('TcpAdapter', () => {
     Assert.isNotUndefined(tcp)
     Assert.isNotNull(tcp?.router)
 
-    tcp.router.register('foo/bar', yup.object({}), (request) => {
+    tcp.router.routes.register('foo/bar', yup.object({}), (request) => {
       request.stream('hello 1')
       request.stream('hello 2')
       request.end()
@@ -100,7 +100,7 @@ describe('TcpAdapter', () => {
     Assert.isNotUndefined(tcp)
     Assert.isNotNull(tcp?.router)
 
-    tcp.router.register('foo/bar', yup.object({}), () => {
+    tcp.router.routes.register('foo/bar', yup.object({}), () => {
       throw new ValidationError('hello error', 402, 'hello-error' as ERROR_CODES)
     })
 
@@ -126,7 +126,7 @@ describe('TcpAdapter', () => {
     // But send this instead
     const body = undefined
 
-    tcp.router.register('foo/bar', schema, (res) => res.end())
+    tcp.router.routes.register('foo/bar', schema, (res) => res.end())
 
     client = new RpcTcpClient('localhost', 0)
     await client.connect()
@@ -147,7 +147,7 @@ describe('TcpAdapter', () => {
 
     Assert.isNotNull(tcp.router)
 
-    tcp.router.register('foo/bar', yup.string(), (request) => {
+    tcp.router.routes.register('foo/bar', yup.string(), (request) => {
       request.end(request.data)
     })
 
@@ -164,7 +164,7 @@ describe('TcpAdapter', () => {
 
     Assert.isNotNull(tcp.router)
 
-    tcp.router.register('foo/bar', yup.string(), (request) => {
+    tcp.router.routes.register('foo/bar', yup.string(), (request) => {
       request.end(request.data)
     })
 
@@ -188,7 +188,7 @@ describe('TcpAdapter', () => {
 
     Assert.isNotNull(tcp.router)
 
-    tcp.router.register('foo/bar', yup.string(), (request) => {
+    tcp.router.routes.register('foo/bar', yup.string(), (request) => {
       request.end(request.data)
     })
 

--- a/ironfish/src/rpc/clients/memoryClient.test.ts
+++ b/ironfish/src/rpc/clients/memoryClient.test.ts
@@ -21,7 +21,7 @@ describe('MemoryClient', () => {
     const client = new RpcMemoryClient(createRootLogger(), await sdk.node())
 
     const allowedNamespaces = ALL_API_NAMESPACES
-    const loadedNamespaces = [...(client.router?.routes.keys() || [])]
+    const loadedNamespaces = [...(client.router?.routes.routes.keys() || [])]
     expect([...allowedNamespaces.values()].sort()).toMatchObject(loadedNamespaces.sort())
   })
 })

--- a/ironfish/src/rpc/routes/chain/broadcastTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/broadcastTransaction.ts
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { Transaction } from '../../../primitives'
 import { ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type BroadcastTransactionRequest = {
   transaction: string
@@ -30,7 +30,7 @@ export const BroadcastTransactionResponseSchema: yup.ObjectSchema<BroadcastTrans
     })
     .defined()
 
-router.register<typeof BroadcastTransactionRequestSchema, BroadcastTransactionResponse>(
+routes.register<typeof BroadcastTransactionRequestSchema, BroadcastTransactionResponse>(
   `${ApiNamespace.chain}/broadcastTransaction`,
   BroadcastTransactionRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/chain/estimateFeeRate.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRate.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { PRIORITY_LEVELS, PriorityLevel } from '../../../memPool/feeEstimator'
 import { CurrencyUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type EstimateFeeRateRequest = { priority?: PriorityLevel } | undefined
 
@@ -25,7 +25,7 @@ export const EstimateFeeRateResponseSchema: yup.ObjectSchema<EstimateFeeRateResp
   })
   .defined()
 
-router.register<typeof EstimateFeeRateRequestSchema, EstimateFeeRateResponse>(
+routes.register<typeof EstimateFeeRateRequestSchema, EstimateFeeRateResponse>(
   `${ApiNamespace.chain}/estimateFeeRate`,
   EstimateFeeRateRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/chain/estimateFeeRates.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRates.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { CurrencyUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type EstimateFeeRatesRequest = undefined
 export type EstimateFeeRatesResponse = {
@@ -25,7 +25,7 @@ export const EstimateFeeRatesResponseSchema: yup.ObjectSchema<EstimateFeeRatesRe
   })
   .defined()
 
-router.register<typeof EstimateFeeRatesRequestSchema, EstimateFeeRatesResponse>(
+routes.register<typeof EstimateFeeRatesRequestSchema, EstimateFeeRatesResponse>(
   `${ApiNamespace.chain}/estimateFeeRates`,
   EstimateFeeRatesRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/chain/exportChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/exportChainStream.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { BlockchainUtils } from '../../../utils/blockchain'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type ExportChainStreamRequest =
   | {
@@ -58,7 +58,7 @@ export const ExportChainStreamResponseSchema: yup.ObjectSchema<ExportChainStream
   })
   .defined()
 
-router.register<typeof ExportChainStreamRequestSchema, ExportChainStreamResponse>(
+routes.register<typeof ExportChainStreamRequestSchema, ExportChainStreamResponse>(
   `${ApiNamespace.chain}/exportChainStream`,
   ExportChainStreamRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -8,7 +8,7 @@ import { getBlockSize, getTransactionSize } from '../../../network/utils/seriali
 import { Block, BlockHeader } from '../../../primitives'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { BufferUtils, PromiseUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type FollowChainStreamRequest =
   | {
@@ -136,7 +136,7 @@ export const FollowChainStreamResponseSchema: yup.ObjectSchema<FollowChainStream
   })
   .defined()
 
-router.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse>(
+routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse>(
   `${ApiNamespace.chain}/followChainStream`,
   FollowChainStreamRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/chain/getAsset.ts
+++ b/ironfish/src/rpc/routes/chain/getAsset.ts
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { CurrencyUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetAssetRequest = {
   id: string
@@ -39,7 +39,7 @@ export const GetAssetResponse: yup.ObjectSchema<GetAssetResponse> = yup
   })
   .defined()
 
-router.register<typeof GetAssetRequestSchema, GetAssetResponse>(
+routes.register<typeof GetAssetRequestSchema, GetAssetResponse>(
   `${ApiNamespace.chain}/getAsset`,
   GetAssetRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -7,7 +7,7 @@ import { BlockHeader } from '../../../primitives'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives/block'
 import { BufferUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetBlockRequest = {
   search?: string
@@ -86,7 +86,7 @@ export const GetBlockResponseSchema: yup.ObjectSchema<GetBlockResponse> = yup
   })
   .defined()
 
-router.register<typeof GetBlockRequestSchema, GetBlockResponse>(
+routes.register<typeof GetBlockRequestSchema, GetBlockResponse>(
   `${ApiNamespace.chain}/getBlock`,
   GetBlockRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/chain/getChainInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives/block'
 import { BlockHashSerdeInstance } from '../../../serde'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type BlockIdentifier = { index: string; hash: string }
 
@@ -41,7 +41,7 @@ export const GetChainInfoResponseSchema: yup.ObjectSchema<GetChainInfoResponse> 
 /**
  * Get current, heaviest and genesis block identifiers
  */
-router.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
+routes.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
   `${ApiNamespace.chain}/getChainInfo`,
   GetChainInfoRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 interface ConsensusParameters {
   allowedBlockFuturesSeconds: number
@@ -32,7 +32,7 @@ export const GetConsensusParametersResponseSchema: yup.ObjectSchema<GetConsensus
     })
     .defined()
 
-router.register<typeof GetConsensusParametersRequestSchema, GetConsensusParametersResponse>(
+routes.register<typeof GetConsensusParametersRequestSchema, GetConsensusParametersResponse>(
   `${ApiNamespace.chain}/getConsensusParameters`,
   GetConsensusParametersRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/chain/getDifficulty.ts
+++ b/ironfish/src/rpc/routes/chain/getDifficulty.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetDifficultyRequest =
   | {
@@ -32,7 +32,7 @@ export const GetDifficultyResponseSchema: yup.ObjectSchema<GetDifficultyResponse
   })
   .defined()
 
-router.register<typeof GetDifficultyRequestSchema, GetDifficultyResponse>(
+routes.register<typeof GetDifficultyRequestSchema, GetDifficultyResponse>(
   `${ApiNamespace.chain}/getDifficulty`,
   GetDifficultyRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/chain/getNetworkHashPower.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkHashPower.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { BigIntUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetNetworkHashPowerRequest = {
   blocks?: number | null // number of blocks to look back
@@ -35,7 +35,7 @@ export const GetNetworkHashPowerResponseSchema: yup.ObjectSchema<GetNetworkHashP
     })
     .defined()
 
-router.register<typeof GetNetworkHashPowerRequestSchema, GetNetworkHashPowerResponse>(
+routes.register<typeof GetNetworkHashPowerRequestSchema, GetNetworkHashPowerResponse>(
   `${ApiNamespace.chain}/getNetworkHashPower`,
   GetNetworkHashPowerRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/chain/getNetworkInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkInfo.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetNetworkInfoRequest = undefined
 export type GetNetworkInfoResponse = {
@@ -20,7 +20,7 @@ export const GetNetworkInfoResponseSchema: yup.ObjectSchema<GetNetworkInfoRespon
   })
   .defined()
 
-router.register<typeof GetNetworkInfoRequestSchema, GetNetworkInfoResponse>(
+routes.register<typeof GetNetworkInfoRequestSchema, GetNetworkInfoResponse>(
   `${ApiNamespace.chain}/getNetworkInfo`,
   GetNetworkInfoRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/chain/getNoteWitness.ts
+++ b/ironfish/src/rpc/routes/chain/getNoteWitness.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives'
 import { ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetNoteWitnessRequest = {
   index: number
@@ -45,7 +45,7 @@ export const GetNoteWitnessResponseSchema: yup.ObjectSchema<GetNoteWitnessRespon
   })
   .defined()
 
-router.register<typeof GetNoteWitnessRequestSchema, GetNoteWitnessResponse>(
+routes.register<typeof GetNoteWitnessRequestSchema, GetNoteWitnessResponse>(
   `${ApiNamespace.chain}/getNoteWitness`,
   GetNoteWitnessRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -6,7 +6,7 @@ import { Assert } from '../../../assert'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { CurrencyUtils } from '../../../utils'
 import { NotFoundError, ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { RpcSpend, RpcSpendSchema } from '../wallet/types'
 import { RpcNote, RpcNoteSchema } from './types'
 
@@ -78,7 +78,7 @@ export const GetTransactionResponseSchema: yup.ObjectSchema<GetTransactionRespon
   })
   .defined()
 
-router.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
+routes.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
   `${ApiNamespace.chain}/getTransaction`,
   GetTransactionRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -10,7 +10,7 @@ import { CurrencyUtils } from '../../../utils'
 import { PromiseUtils } from '../../../utils/promise'
 import { isValidIncomingViewKey } from '../../../wallet/validator'
 import { ValidationError } from '../../adapters/errors'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 interface Note {
   assetId: string
@@ -122,7 +122,7 @@ export const GetTransactionStreamResponseSchema: yup.ObjectSchema<GetTransaction
     })
     .defined()
 
-router.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamResponse>(
+routes.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamResponse>(
   `${ApiNamespace.chain}/getTransactionStream`,
   GetTransactionStreamRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/chain/isValidPublicAddress.ts
+++ b/ironfish/src/rpc/routes/chain/isValidPublicAddress.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { isValidPublicAddress } from '../../../wallet/validator'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type IsValidPublicAddressRequest = {
   address: string
@@ -27,7 +27,7 @@ export const IsValidPublicAddressResponseSchema: yup.ObjectSchema<IsValidPublicA
     })
     .defined()
 
-router.register<typeof IsValidPublicAddressRequestSchema, IsValidPublicAddressResponse>(
+routes.register<typeof IsValidPublicAddressRequestSchema, IsValidPublicAddressResponse>(
   `${ApiNamespace.chain}/isValidPublicAddress`,
   IsValidPublicAddressRequestSchema,
   (request): void => {

--- a/ironfish/src/rpc/routes/chain/showChain.ts
+++ b/ironfish/src/rpc/routes/chain/showChain.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { renderChain } from './utils'
 
 export type ShowChainRequest =
@@ -33,7 +33,7 @@ export const ShowChainResponseSchema: yup.ObjectSchema<ShowChainResponse> = yup
 /**
  * Render the chain as ani ASCII graph of the block chain
  */
-router.register<typeof ShowChainRequestSchema, ShowChainResponse>(
+routes.register<typeof ShowChainRequestSchema, ShowChainResponse>(
   `${ApiNamespace.chain}/showChain`,
   ShowChainRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/config/getConfig.ts
+++ b/ironfish/src/rpc/routes/config/getConfig.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
 import { ValidationError } from '../../adapters/errors'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetConfigRequest = { user?: boolean; name?: string } | undefined
 export type GetConfigResponse = Partial<ConfigOptions>
@@ -19,7 +19,7 @@ export const GetConfigRequestSchema: yup.ObjectSchema<GetConfigRequest> = yup
 
 export const GetConfigResponseSchema: yup.ObjectSchema<GetConfigResponse> = ConfigOptionsSchema
 
-router.register<typeof GetConfigRequestSchema, GetConfigResponse>(
+routes.register<typeof GetConfigRequestSchema, GetConfigResponse>(
   `${ApiNamespace.config}/getConfig`,
   GetConfigRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/config/setConfig.ts
+++ b/ironfish/src/rpc/routes/config/setConfig.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { setUnknownConfigValue } from './uploadConfig'
 
 export type SetConfigRequest = { name: string; value: unknown }
@@ -19,7 +19,7 @@ export const SetConfigRequestSchema: yup.ObjectSchema<SetConfigRequest> = yup
 
 export const SetConfigResponseSchema: yup.ObjectSchema<SetConfigResponse> = ConfigOptionsSchema
 
-router.register<typeof SetConfigRequestSchema, SetConfigResponse>(
+routes.register<typeof SetConfigRequestSchema, SetConfigResponse>(
   `${ApiNamespace.config}/setConfig`,
   SetConfigRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/config/unsetConfig.ts
+++ b/ironfish/src/rpc/routes/config/unsetConfig.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { setUnknownConfigValue } from './uploadConfig'
 
 export type UnsetConfigRequest = { name: string }
@@ -19,7 +19,7 @@ export const UnsetConfigRequestSchema: yup.ObjectSchema<UnsetConfigRequest> = yu
 export const UnsetConfigResponseSchema: yup.ObjectSchema<UnsetConfigResponse> =
   ConfigOptionsSchema
 
-router.register<typeof UnsetConfigRequestSchema, UnsetConfigResponse>(
+routes.register<typeof UnsetConfigRequestSchema, UnsetConfigResponse>(
   `${ApiNamespace.config}/unsetConfig`,
   UnsetConfigRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/config/uploadConfig.ts
+++ b/ironfish/src/rpc/routes/config/uploadConfig.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { Config, ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
 import { ValidationError } from '../../adapters/errors'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type UploadConfigRequest = { config: Record<string, unknown> }
 export type UploadConfigResponse = Partial<ConfigOptions>
@@ -17,7 +17,7 @@ export const UploadConfigRequestSchema: yup.ObjectSchema<UploadConfigRequest> = 
 export const UploadConfigResponseSchema: yup.ObjectSchema<UploadConfigResponse> =
   ConfigOptionsSchema
 
-router.register<typeof UploadConfigRequestSchema, UploadConfigResponse>(
+routes.register<typeof UploadConfigRequestSchema, UploadConfigResponse>(
   `${ApiNamespace.config}/uploadConfig`,
   UploadConfigRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/event/onGossip.ts
+++ b/ironfish/src/rpc/routes/event/onGossip.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { BlockHeader } from '../../../primitives'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { RpcBlockHeader, RpcBlockHeaderSchema, serializeRpcBlockHeader } from './types'
 
 export type OnGossipRequest = undefined
@@ -19,7 +19,7 @@ export const OnGossipResponseSchema: yup.ObjectSchema<OnGossipResponse> = yup
   })
   .defined()
 
-router.register<typeof OnGossipRequestSchema, OnGossipResponse>(
+routes.register<typeof OnGossipRequestSchema, OnGossipResponse>(
   `${ApiNamespace.event}/onGossip`,
   OnGossipRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/event/onReorganizeChain.ts
+++ b/ironfish/src/rpc/routes/event/onReorganizeChain.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { BlockHeader } from '../../../primitives'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { RpcBlockHeader, RpcBlockHeaderSchema, serializeRpcBlockHeader } from './types'
 
 export type OnReorganizeChainRequest = undefined
@@ -25,7 +25,7 @@ export const OnReorganizeChainResponseSchema: yup.ObjectSchema<OnReorganizeChain
   })
   .defined()
 
-router.register<typeof OnReorganizeChainRequestSchema, OnReorganizeChainResponse>(
+routes.register<typeof OnReorganizeChainRequestSchema, OnReorganizeChainResponse>(
   `${ApiNamespace.event}/onReorganizeChain`,
   OnReorganizeChainRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/event/onTransactionGossip.ts
+++ b/ironfish/src/rpc/routes/event/onTransactionGossip.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { Transaction } from '../../../primitives'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type OnTransactionGossipRequest = {} | undefined
@@ -23,7 +23,7 @@ export const OnTransactionGossipResponseSchema: yup.ObjectSchema<OnTransactionGo
     })
     .defined()
 
-router.register<typeof OnTransactionGossipRequestSchema, OnTransactionGossipResponse>(
+routes.register<typeof OnTransactionGossipRequestSchema, OnTransactionGossipResponse>(
   `${ApiNamespace.event}/onTransactionGossip`,
   OnTransactionGossipRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/faucet/getFunds.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.ts
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { WebApi } from '../../../webApi'
 import { ERROR_CODES, ResponseError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from '../wallet/utils'
 
 export type GetFundsRequest = { account?: string; email?: string }
@@ -25,7 +25,7 @@ export const GetFundsResponseSchema: yup.ObjectSchema<GetFundsResponse> = yup
   })
   .defined()
 
-router.register<typeof GetFundsRequestSchema, GetFundsResponse>(
+routes.register<typeof GetFundsRequestSchema, GetFundsResponse>(
   `${ApiNamespace.faucet}/getFunds`,
   GetFundsRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/mempool/getStatus.ts
+++ b/ironfish/src/rpc/routes/mempool/getStatus.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { IronfishNode } from '../../../node'
 import { PromiseUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetMempoolStatusRequest =
   | undefined
@@ -48,7 +48,7 @@ export const GetMempoolStatusResponseSchema: yup.ObjectSchema<GetMempoolStatusRe
   })
   .defined()
 
-router.register<typeof GetMempoolStatusRequestSchema, GetMempoolStatusResponse>(
+routes.register<typeof GetMempoolStatusRequestSchema, GetMempoolStatusResponse>(
   `${ApiNamespace.mempool}/getStatus`,
   GetMempoolStatusRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/mempool/getTransactions.ts
+++ b/ironfish/src/rpc/routes/mempool/getTransactions.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { getFeeRate } from '../../../memPool'
 import { Transaction } from '../../../primitives'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type MinMax = {
   min?: number
@@ -55,7 +55,7 @@ export const MempoolTransactionResponseSchema: yup.ObjectSchema<GetMempoolTransa
     })
     .defined()
 
-router.register<typeof MempoolTransactionsRequestSchema, GetMempoolTransactionResponse>(
+routes.register<typeof MempoolTransactionsRequestSchema, GetMempoolTransactionResponse>(
   `${ApiNamespace.mempool}/getTransactions`,
   MempoolTransactionsRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/miner/blockTemplateStream.ts
+++ b/ironfish/src/rpc/routes/miner/blockTemplateStream.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { SerializedBlockTemplate } from '../../../serde/BlockTemplateSerde'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type BlockTemplateStreamRequest = Record<string, never> | undefined
 export type BlockTemplateStreamResponse = SerializedBlockTemplate
@@ -41,7 +41,7 @@ export const BlockTemplateStreamResponseSchema: yup.ObjectSchema<BlockTemplateSt
     .required()
     .defined()
 
-router.register<typeof BlockTemplateStreamRequestSchema, BlockTemplateStreamResponse>(
+routes.register<typeof BlockTemplateStreamRequestSchema, BlockTemplateStreamResponse>(
   `${ApiNamespace.miner}/blockTemplateStream`,
   BlockTemplateStreamRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/miner/submitBlock.ts
+++ b/ironfish/src/rpc/routes/miner/submitBlock.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { MINED_RESULT } from '../../../mining/manager'
 import { SerializedBlockTemplate } from '../../../serde'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type SubmitBlockRequest = SerializedBlockTemplate
 
@@ -60,7 +60,7 @@ export const SubmitBlockResponseSchema: yup.ObjectSchema<SubmitBlockResponse> = 
   })
   .defined()
 
-router.register<typeof SubmitBlockRequestSchema, SubmitBlockResponse>(
+routes.register<typeof SubmitBlockRequestSchema, SubmitBlockResponse>(
   `${ApiNamespace.miner}/submitBlock`,
   SubmitBlockRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/node/getLogStream.ts
+++ b/ironfish/src/rpc/routes/node/getLogStream.ts
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { InterceptReporter } from '../../../logger'
 import { IJSON } from '../../../serde'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type GetLogStreamRequest = {} | undefined
@@ -34,7 +34,7 @@ export const GetLogStreamResponseSchema: yup.ObjectSchema<GetLogStreamResponse> 
   })
   .defined()
 
-router.register<typeof GetLogStreamRequestSchema, GetLogStreamResponse>(
+routes.register<typeof GetLogStreamRequestSchema, GetLogStreamResponse>(
   `${ApiNamespace.node}/getLogStream`,
   GetLogStreamRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { IronfishNode } from '../../../node'
 import { MathUtils, PromiseUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetNodeStatusRequest =
   | undefined
@@ -252,7 +252,7 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetNodeStatusResponse> = 
   })
   .defined()
 
-router.register<typeof GetStatusRequestSchema, GetNodeStatusResponse>(
+routes.register<typeof GetStatusRequestSchema, GetNodeStatusResponse>(
   `${ApiNamespace.node}/getStatus`,
   GetStatusRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/node/stopNode.ts
+++ b/ironfish/src/rpc/routes/node/stopNode.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type StopNodeRequest = undefined
@@ -17,7 +17,7 @@ export const StopNodeResponseSchema: yup.MixedSchema<StopNodeRequest> = yup
   .mixed()
   .oneOf([undefined] as const)
 
-router.register<typeof StopNodeRequestSchema, StopNodeResponse>(
+routes.register<typeof StopNodeRequestSchema, StopNodeResponse>(
   `${ApiNamespace.node}/stopNode`,
   StopNodeRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/peer/addPeer.ts
+++ b/ironfish/src/rpc/routes/peer/addPeer.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { DEFAULT_WEBSOCKET_PORT } from '../../../fileStores/config'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type AddPeerRequest = {
   host: string
@@ -31,7 +31,7 @@ export const AddPeerResponseSchema: yup.ObjectSchema<AddPeerResponse> = yup
   })
   .defined()
 
-router.register<typeof AddPeerRequestSchema, AddPeerResponse>(
+routes.register<typeof AddPeerRequestSchema, AddPeerResponse>(
   `${ApiNamespace.peer}/addPeer`,
   AddPeerRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/peer/getBannedPeers.ts
+++ b/ironfish/src/rpc/routes/peer/getBannedPeers.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { PeerNetwork } from '../../../network'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type BannedPeerResponse = {
   identity: string
@@ -43,7 +43,7 @@ export const GetBannedPeersResponseSchema: yup.ObjectSchema<GetBannedPeersRespon
   })
   .defined()
 
-router.register<typeof GetBannedPeersRequestSchema, GetBannedPeersResponse>(
+routes.register<typeof GetBannedPeersRequestSchema, GetBannedPeersResponse>(
   `${ApiNamespace.peer}/getBannedPeers`,
   GetBannedPeersRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/peer/getPeer.ts
+++ b/ironfish/src/rpc/routes/peer/getPeer.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { Connection, PeerNetwork } from '../../../network'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { PeerResponse } from './getPeers'
 
 type ConnectionState = Connection['state']['type'] | ''
@@ -58,7 +58,7 @@ export const GetPeerResponseSchema: yup.ObjectSchema<GetPeerResponse> = yup
   })
   .defined()
 
-router.register<typeof GetPeerRequestSchema, GetPeerResponse>(
+routes.register<typeof GetPeerRequestSchema, GetPeerResponse>(
   `${ApiNamespace.peer}/getPeer`,
   GetPeerRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/peer/getPeerMessages.ts
+++ b/ironfish/src/rpc/routes/peer/getPeerMessages.ts
@@ -6,7 +6,7 @@ import { Assert } from '../../../assert'
 import { Connection, PeerNetwork } from '../../../network'
 import { NetworkMessageType } from '../../../network/types'
 import { IJSON } from '../../../serde'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 type PeerMessage = {
   brokeringPeerDisplayName?: string
@@ -58,7 +58,7 @@ export const GetPeerMessagesResponseSchema: yup.ObjectSchema<GetPeerMessagesResp
   })
   .defined()
 
-router.register<typeof GetPeerMessagesRequestSchema, GetPeerMessagesResponse>(
+routes.register<typeof GetPeerMessagesRequestSchema, GetPeerMessagesResponse>(
   `${ApiNamespace.peer}/getPeerMessages`,
   GetPeerMessagesRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/peer/getPeers.ts
+++ b/ironfish/src/rpc/routes/peer/getPeers.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { Connection, PeerNetwork } from '../../../network'
 import { Features } from '../../../network/peers/peerFeatures'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 type ConnectionState = Connection['state']['type'] | ''
 
@@ -85,7 +85,7 @@ export const GetPeersResponseSchema: yup.ObjectSchema<GetPeersResponse> = yup
   })
   .defined()
 
-router.register<typeof GetPeersRequestSchema, GetPeersResponse>(
+routes.register<typeof GetPeersRequestSchema, GetPeersResponse>(
   `${ApiNamespace.peer}/getPeers`,
   GetPeersRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/router.test.ts
+++ b/ironfish/src/rpc/routes/router.test.ts
@@ -9,7 +9,9 @@ describe('Router', () => {
 
   it('should use yup schema', async () => {
     const schema = yup.string().default('default')
-    routeTest.client.router.register('foo/bar', schema, (request) => request.end(request.data))
+    routeTest.client.router.routes.register('foo/bar', schema, (request) =>
+      request.end(request.data),
+    )
 
     // should use default value from the schema
     let response = await routeTest.client.request('foo/bar').waitForEnd()

--- a/ironfish/src/rpc/routes/rpc/getStatus.ts
+++ b/ironfish/src/rpc/routes/rpc/getStatus.ts
@@ -7,7 +7,7 @@ import { IronfishNode } from '../../../node'
 import { PromiseUtils } from '../../../utils'
 import { RpcHttpAdapter, RpcIpcAdapter } from '../../adapters'
 import { RpcSocketAdapter } from '../../adapters/socketAdapter/socketAdapter'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetRpcStatusRequest =
   | undefined
@@ -60,7 +60,7 @@ export const GetRpcStatusResponseSchema: yup.ObjectSchema<GetRpcStatusResponse> 
   })
   .defined()
 
-router.register<typeof GetRpcStatusRequestSchema, GetRpcStatusResponse>(
+routes.register<typeof GetRpcStatusRequestSchema, GetRpcStatusResponse>(
   `${ApiNamespace.rpc}/getStatus`,
   GetRpcStatusRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -6,7 +6,7 @@ import { Assert } from '../../../assert'
 import { Transaction } from '../../../primitives'
 import { AsyncUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type AddTransactionRequest = {
   transaction: string
@@ -34,7 +34,7 @@ export const AddTransactionResponseSchema: yup.ObjectSchema<AddTransactionRespon
   })
   .defined()
 
-router.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
+routes.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
   `${ApiNamespace.wallet}/addTransaction`,
   AddTransactionRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/burnAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { CurrencyUtils, YupUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export interface BurnAssetRequest {
@@ -45,7 +45,7 @@ export const BurnAssetResponseSchema: yup.ObjectSchema<BurnAssetResponse> = yup
   })
   .defined()
 
-router.register<typeof BurnAssetRequestSchema, BurnAssetResponse>(
+routes.register<typeof BurnAssetRequestSchema, BurnAssetResponse>(
   `${ApiNamespace.wallet}/burnAsset`,
   BurnAssetRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/create.ts
+++ b/ironfish/src/rpc/routes/wallet/create.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { ERROR_CODES, ValidationError } from '../../adapters'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type CreateAccountRequest = { name: string; default?: boolean }
 export type CreateAccountResponse = {
@@ -28,7 +28,7 @@ export const CreateAccountResponseSchema: yup.ObjectSchema<CreateAccountResponse
   })
   .defined()
 
-router.register<typeof CreateAccountRequestSchema, CreateAccountResponse>(
+routes.register<typeof CreateAccountRequestSchema, CreateAccountResponse>(
   `${ApiNamespace.wallet}/create`,
   CreateAccountRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -14,7 +14,7 @@ import { CurrencyUtils, YupUtils } from '../../../utils'
 import { Wallet } from '../../../wallet'
 import { NotEnoughFundsError } from '../../../wallet/errors'
 import { ERROR_CODES, ValidationError } from '../../adapters/errors'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type CreateTransactionRequest = {
@@ -99,7 +99,7 @@ export const CreateTransactionResponseSchema: yup.ObjectSchema<CreateTransaction
   })
   .defined()
 
-router.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse>(
+routes.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse>(
   `${ApiNamespace.wallet}/createTransaction`,
   CreateTransactionRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/exportAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.ts
@@ -6,7 +6,7 @@ import { Assert } from '../../../assert'
 import { LanguageKey, LanguageUtils } from '../../../utils'
 import { encodeAccount } from '../../../wallet/account/encoder/account'
 import { AccountFormat } from '../../../wallet/account/encoder/encoder'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { RpcAccountImport } from './types'
 import { getAccount } from './utils'
 
@@ -35,7 +35,7 @@ export const ExportAccountResponseSchema: yup.ObjectSchema<ExportAccountResponse
   })
   .defined()
 
-router.register<typeof ExportAccountRequestSchema, ExportAccountResponse>(
+routes.register<typeof ExportAccountRequestSchema, ExportAccountResponse>(
   `${ApiNamespace.wallet}/exportAccount`,
   ExportAccountRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { CurrencyUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { RpcWalletNote, RpcWalletNoteSchema } from './types'
 import { getAccount } from './utils'
 
@@ -22,7 +22,7 @@ export const GetAccountNotesStreamRequestSchema: yup.ObjectSchema<GetAccountNote
 export const GetAccountNotesStreamResponseSchema: yup.ObjectSchema<GetAccountNotesStreamResponse> =
   RpcWalletNoteSchema
 
-router.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStreamResponse>(
+routes.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStreamResponse>(
   `${ApiNamespace.wallet}/getAccountNotesStream`,
   GetAccountNotesStreamRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { TransactionStatus, TransactionType } from '../../../wallet'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { RpcSpend, RpcSpendSchema, RpcWalletNote, RpcWalletNoteSchema } from './types'
 import {
   getAccount,
@@ -87,7 +87,7 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
     })
     .defined()
 
-router.register<typeof GetAccountTransactionRequestSchema, GetAccountTransactionResponse>(
+routes.register<typeof GetAccountTransactionRequestSchema, GetAccountTransactionResponse>(
   `${ApiNamespace.wallet}/getAccountTransaction`,
   GetAccountTransactionRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
@@ -9,7 +9,7 @@ import { TransactionStatus, TransactionType } from '../../../wallet'
 import { Account } from '../../../wallet/account/account'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { RpcRequest } from '../../request'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { RpcSpend, RpcSpendSchema, RpcWalletNote, RpcWalletNoteSchema } from './types'
 import {
   getAccount,
@@ -96,7 +96,7 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
     })
     .defined()
 
-router.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactionsResponse>(
+routes.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactionsResponse>(
   `${ApiNamespace.wallet}/getAccountTransactions`,
   GetAccountTransactionsRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/getAccounts.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccounts.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { Account } from '../../../wallet'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type GetAccountsRequest = { default?: boolean; displayName?: boolean } | undefined
@@ -23,7 +23,7 @@ export const GetAccountsResponseSchema: yup.ObjectSchema<GetAccountsResponse> = 
   })
   .defined()
 
-router.register<typeof GetAccountsRequestSchema, GetAccountsResponse>(
+routes.register<typeof GetAccountsRequestSchema, GetAccountsResponse>(
   `${ApiNamespace.wallet}/getAccounts`,
   GetAccountsRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetAccountStatusRequest = { account?: string }
 
@@ -39,7 +39,7 @@ export const GetAccountStatusResponseSchema: yup.ObjectSchema<GetAccountStatusRe
   })
   .defined()
 
-router.register<typeof GetAccountStatusRequestSchema, GetAccountStatusResponse>(
+routes.register<typeof GetAccountStatusRequestSchema, GetAccountStatusResponse>(
   `${ApiNamespace.wallet}/getAccountsStatus`,
   GetAccountStatusRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/getAssets.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { AssetVerification } from '../../../assets'
 import { CurrencyUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type GetAssetsRequest = {
@@ -47,7 +47,7 @@ export const GetAssetsResponseSchema: yup.ObjectSchema<GetAssetsResponse> = yup
   })
   .defined()
 
-router.register<typeof GetAssetsRequestSchema, GetAssetsResponse>(
+routes.register<typeof GetAssetsRequestSchema, GetAssetsResponse>(
   `${ApiNamespace.wallet}/getAssets`,
   GetAssetsRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -5,7 +5,7 @@ import { Asset } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { AssetVerification } from '../../../assets'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type GetBalanceRequest =
@@ -58,7 +58,7 @@ export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yu
   })
   .defined()
 
-router.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
+routes.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
   `${ApiNamespace.wallet}/getBalance`,
   GetBalanceRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { AssetVerification } from '../../../assets'
 import { CurrencyUtils } from '../../../utils'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export interface GetBalancesRequest {
@@ -70,7 +70,7 @@ export const GetBalancesResponseSchema: yup.ObjectSchema<GetBalancesResponse> = 
   })
   .defined()
 
-router.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
+routes.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
   `${ApiNamespace.wallet}/getBalances`,
   GetBalancesRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/getDefaultAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/getDefaultAccount.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type GetDefaultAccountRequest = {} | undefined
@@ -25,7 +25,7 @@ export const GetDefaultAccountResponseSchema: yup.ObjectSchema<GetDefaultAccount
   })
   .defined()
 
-router.register<typeof GetDefaultAccountRequestSchema, GetDefaultAccountResponse>(
+routes.register<typeof GetDefaultAccountRequestSchema, GetDefaultAccountResponse>(
   `${ApiNamespace.wallet}/getDefaultAccount`,
   GetDefaultAccountRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { RpcWalletNote, RpcWalletNoteSchema } from './types'
 import { getAccount, serializeRpcWalletNote } from './utils'
 
@@ -69,7 +69,7 @@ export const GetNotesResponseSchema: yup.ObjectSchema<GetNotesResponse> = yup
   })
   .defined()
 
-router.register<typeof GetNotesRequestSchema, GetNotesResponse>(
+routes.register<typeof GetNotesRequestSchema, GetNotesResponse>(
   `${ApiNamespace.wallet}/getNotes`,
   GetNotesRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/getPublicKey.ts
+++ b/ironfish/src/rpc/routes/wallet/getPublicKey.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type GetPublicKeyRequest = { account?: string }
@@ -22,7 +22,7 @@ export const GetPublicKeyResponseSchema: yup.ObjectSchema<GetPublicKeyResponse> 
   })
   .defined()
 
-router.register<typeof GetPublicKeyRequestSchema, GetPublicKeyResponse>(
+routes.register<typeof GetPublicKeyRequestSchema, GetPublicKeyResponse>(
   `${ApiNamespace.wallet}/getPublicKey`,
   GetPublicKeyRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -5,7 +5,7 @@ import { v4 as uuid } from 'uuid'
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { decodeAccount } from '../../../wallet/account/encoder/account'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { RpcAccountImport } from './types'
 import { deserializeRpcAccountImport } from './utils'
 
@@ -37,7 +37,7 @@ export const ImportAccountResponseSchema: yup.ObjectSchema<ImportResponse> = yup
   })
   .defined()
 
-router.register<typeof ImportAccountRequestSchema, ImportResponse>(
+routes.register<typeof ImportAccountRequestSchema, ImportResponse>(
   `${ApiNamespace.wallet}/importAccount`,
   ImportAccountRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { CurrencyUtils, YupUtils } from '../../../utils'
 import { MintAssetOptions } from '../../../wallet/interfaces/mintAssetOptions'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export interface MintAssetRequest {
@@ -51,7 +51,7 @@ export const MintAssetResponseSchema: yup.ObjectSchema<MintAssetResponse> = yup
   })
   .defined()
 
-router.register<typeof MintAssetRequestSchema, MintAssetResponse>(
+routes.register<typeof MintAssetRequestSchema, MintAssetResponse>(
   `${ApiNamespace.wallet}/mintAsset`,
   MintAssetRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -4,7 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { RawTransactionSerde } from '../../../primitives/rawTransaction'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type PostTransactionRequest = {
@@ -33,7 +33,7 @@ export const PostTransactionResponseSchema: yup.ObjectSchema<PostTransactionResp
   })
   .defined()
 
-router.register<typeof PostTransactionRequestSchema, PostTransactionResponse>(
+routes.register<typeof PostTransactionRequestSchema, PostTransactionResponse>(
   `${ApiNamespace.wallet}/postTransaction`,
   PostTransactionRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/remove.ts
+++ b/ironfish/src/rpc/routes/wallet/remove.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type RemoveAccountRequest = { account: string; confirm?: boolean; wait?: boolean }
@@ -23,7 +23,7 @@ export const RemoveAccountResponseSchema: yup.ObjectSchema<RemoveAccountResponse
   })
   .defined()
 
-router.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
+routes.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
   `${ApiNamespace.wallet}/remove`,
   RemoveAccountRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/rename.ts
+++ b/ironfish/src/rpc/routes/wallet/rename.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type RenameAccountRequest = { account: string; newName: string }
@@ -20,7 +20,7 @@ export const RenameAccountResponseSchema: yup.MixedSchema<RenameAccountResponse>
   .mixed()
   .oneOf([undefined] as const)
 
-router.register<typeof RenameAccountRequestSchema, RenameAccountResponse>(
+routes.register<typeof RenameAccountRequestSchema, RenameAccountResponse>(
   `${ApiNamespace.wallet}/rename`,
   RenameAccountRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/rescanAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/rescanAccount.ts
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives'
 import { ValidationError } from '../../adapters/errors'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type RescanAccountRequest = { follow?: boolean; from?: number }
 export type RescanAccountResponse = { sequence: number; startedAt: number; endSequence: number }
@@ -25,7 +25,7 @@ export const RescanAccountResponseSchema: yup.ObjectSchema<RescanAccountResponse
   })
   .defined()
 
-router.register<typeof RescanAccountRequestSchema, RescanAccountResponse>(
+routes.register<typeof RescanAccountRequestSchema, RescanAccountResponse>(
   `${ApiNamespace.wallet}/rescanAccount`,
   RescanAccountRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -9,7 +9,7 @@ import { CurrencyUtils, YupUtils } from '../../../utils'
 import { Wallet } from '../../../wallet'
 import { NotEnoughFundsError } from '../../../wallet/errors'
 import { ERROR_CODES, ValidationError } from '../../adapters/errors'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type SendTransactionRequest = {
@@ -64,7 +64,7 @@ export const SendTransactionResponseSchema: yup.ObjectSchema<SendTransactionResp
   })
   .defined()
 
-router.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
+routes.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
   `${ApiNamespace.wallet}/sendTransaction`,
   SendTransactionRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/wallet/use.ts
+++ b/ironfish/src/rpc/routes/wallet/use.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type UseAccountRequest = { account: string }
@@ -19,7 +19,7 @@ export const UseAccountResponseSchema: yup.MixedSchema<UseAccountResponse> = yup
   .mixed()
   .oneOf([undefined] as const)
 
-router.register<typeof UseAccountRequestSchema, UseAccountResponse>(
+routes.register<typeof UseAccountRequestSchema, UseAccountResponse>(
   `${ApiNamespace.wallet}/use`,
   UseAccountRequestSchema,
   async (request, { node }): Promise<void> => {

--- a/ironfish/src/rpc/routes/worker/getStatus.ts
+++ b/ironfish/src/rpc/routes/worker/getStatus.ts
@@ -6,7 +6,7 @@ import { Assert } from '../../../assert'
 import { IronfishNode } from '../../../node'
 import { MathUtils } from '../../../utils'
 import { WorkerMessageType } from '../../../workerPool/tasks/workerMessage'
-import { ApiNamespace, router } from '../router'
+import { ApiNamespace, routes } from '../router'
 
 export type GetWorkersStatusRequest =
   | undefined
@@ -63,7 +63,7 @@ export const GetWorkersStatusResponseSchema: yup.ObjectSchema<GetWorkersStatusRe
   })
   .defined()
 
-router.register<typeof GetWorkersStatusRequestSchema, GetWorkersStatusResponse>(
+routes.register<typeof GetWorkersStatusRequestSchema, GetWorkersStatusResponse>(
   `${ApiNamespace.worker}/getStatus`,
   GetWorkersStatusRequestSchema,
   (request, { node }): void => {

--- a/ironfish/src/rpc/server.ts
+++ b/ironfish/src/rpc/server.ts
@@ -5,7 +5,7 @@
 import { InternalStore } from '../fileStores'
 import { createRootLogger, Logger } from '../logger'
 import { IRpcAdapter } from './adapters'
-import { ApiNamespace, RequestContext, Router, router } from './routes'
+import { ApiNamespace, RequestContext, Router, routes } from './routes'
 
 export class RpcServer {
   readonly internal: InternalStore
@@ -32,10 +32,7 @@ export class RpcServer {
 
   /** Creates a new router from this RpcServer with the attached routes filtered by namespaces */
   getRouter(namespaces: ApiNamespace[]): Router {
-    const newRouter = router.filter(namespaces)
-    newRouter.server = this
-    newRouter.context = this.context
-    return newRouter
+    return new Router(routes.filter(namespaces), this)
   }
 
   /** Starts the RPC server and tells any attached adapters to starts serving requests to the routing layer */


### PR DESCRIPTION
## Summary
We register routes globally but don't necesarily want a global Router object. The Router has a reference to the Server which should not be on a global object

## Testing Plan
Unit tests / local testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
