### PR TITLE
rebroadcasts on block connect

### DIFF
--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -99,7 +99,7 @@ describe('Accounts', () => {
     nodeA.wallet['rebroadcastAfter'] = 1
     nodeA.wallet['isStarted'] = true
     nodeA.chain['synced'] = true
-    await nodeA.wallet.rebroadcastTransactions()
+    await nodeA.wallet.rebroadcastTransactions(nodeA.chain.head.sequence)
     expect(broadcastSpy).toHaveBeenCalledTimes(0)
 
     // It should now be planned to be processed at head + 1
@@ -1298,7 +1298,7 @@ describe('Accounts', () => {
 
       const broadcastSpy = jest.spyOn(node.wallet, 'broadcastTransaction')
 
-      await node.wallet.rebroadcastTransactions()
+      await node.wallet.rebroadcastTransactions(node.chain.head.sequence)
 
       expect(broadcastSpy).toHaveBeenCalledTimes(0)
     })


### PR DESCRIPTION
## Summary

moves rebroadcastTransactions out of the wallet eventLoop and into the chain processor onAdd handler

passes the block sequence to rebroadcastTransactions to avoid reading from the chain

leaves transaction verification in for now pending changes to use broadcastTransaction RPC for broadcasting from wallet

## Testing Plan

- updates unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
