### PR TITLE
feat(ironfish): Remove node from peer network

### DIFF
--- a/ironfish/src/network/blockFetcher.test.ts
+++ b/ironfish/src/network/blockFetcher.test.ts
@@ -372,7 +372,7 @@ describe('BlockFetcher', () => {
   })
 
   it('ignores new messages when the block was previously marked as an orphan', async () => {
-    const { peerNetwork, chain, node } = nodeTest
+    const { peerNetwork, chain } = nodeTest
 
     // Create an orphan block by adding 5 blocks, removing 5 blocks then adding 5 new blocks
     // We want to have an orphan that is also not ahead of the current chain
@@ -386,7 +386,7 @@ describe('BlockFetcher', () => {
       await chain.addBlock(block)
     }
 
-    const syncSpy = jest.spyOn(node.syncer, 'startSync')
+    const syncSpy = jest.spyOn(peerNetwork.syncer, 'startSync')
 
     const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 4)
 

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -350,11 +350,11 @@ async function getStatus(node: IronfishNode): Promise<GetNodeStatusResponse> {
       },
     },
     blockSyncer: {
-      status: node.syncer.state,
+      status: node.peerNetwork.syncer.state,
       syncing: {
         blockSpeed: MathUtils.round(node.chain.addSpeed.average, 2),
-        speed: MathUtils.round(node.syncer.speed.rollingRate1m, 2),
-        downloadSpeed: MathUtils.round(node.syncer.downloadSpeed.average, 2),
+        speed: MathUtils.round(node.peerNetwork.syncer.speed.rollingRate1m, 2),
+        downloadSpeed: MathUtils.round(node.peerNetwork.syncer.downloadSpeed.average, 2),
         progress: node.chain.getProgress(),
       },
     },

--- a/ironfish/src/testUtilities/mocks.ts
+++ b/ironfish/src/testUtilities/mocks.ts
@@ -78,7 +78,7 @@ export function mockMiningManager(): any {
   }
 }
 
-function mockMempool(): unknown {
+export function mockMempool(): any {
   return {
     acceptTransaction: jest.fn(),
     exists: jest.fn().mockReturnValue(false),

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -96,7 +96,7 @@ export class NodeTest {
     const chain = node.chain
     const wallet = node.wallet
     const peerNetwork = node.peerNetwork
-    const syncer = node.syncer
+    const syncer = peerNetwork.syncer
     const verifier = node.chain.verifier
     const workerPool = node.workerPool
 


### PR DESCRIPTION
## Summary

For the standalone wallet, we need to support broadcasting transactions from the peer network *without* a dependency on the node. This change removes the node out of the peer network to remove a circular dependency.

Changes:
* Moves the syncer inside the peer network to avoid circular dependency 
* Pass the mining manager, worker pool, mempool directly into peer network instead of using node properties
* *Temporarily* pass wallet callback functions to the peer network
  * Add pending transaction from new messages will be removed
  * Broadcast transactions will be referenced once a wallet node client is created (but this change needs to go in first)

## Testing Plan

Covered by unit tests. No new tests needed.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```

This code change updates the constructor of the `PeerNetwork` in our SDK, so this is a breaking change. We will need to ship a new major version release whenever this change is deployed.