### PR TITLE
[asset-security] feat: add asset owner field to chain DB

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -1077,6 +1077,7 @@ describe('Blockchain', () => {
           name: asset.name(),
           nonce: asset.nonce(),
           creator: asset.creator(),
+          owner: asset.creator(),
           supply: 10n,
         })
       })
@@ -1155,6 +1156,7 @@ describe('Blockchain', () => {
           name: asset.name(),
           nonce: asset.nonce(),
           creator: asset.creator(),
+          owner: asset.creator(),
           supply: mintValueA + mintValueB,
         })
       })

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -63,7 +63,7 @@ import {
   TransactionHashToBlockHashSchema,
 } from './schema'
 
-export const VERSION_DATABASE_CHAIN = 14
+export const VERSION_DATABASE_CHAIN = 28
 
 export class Blockchain {
   db: IDatabase
@@ -1333,6 +1333,7 @@ export class Blockchain {
           name: asset.name(),
           nonce: asset.nonce(),
           creator: asset.creator(),
+          owner: asset.creator(),
           supply: supply + value,
         },
         tx,
@@ -1361,6 +1362,7 @@ export class Blockchain {
           name: existingAsset.name,
           nonce: existingAsset.nonce,
           creator: existingAsset.creator,
+          owner: existingAsset.owner,
           supply,
         },
         tx,
@@ -1388,6 +1390,7 @@ export class Blockchain {
           name: existingAsset.name,
           nonce: existingAsset.nonce,
           creator: existingAsset.creator,
+          owner: existingAsset.owner,
           supply,
         },
         tx,
@@ -1425,6 +1428,7 @@ export class Blockchain {
             name: asset.name(),
             nonce: asset.nonce(),
             creator: asset.creator(),
+            owner: asset.creator(),
             supply,
           },
           tx,
@@ -1459,6 +1463,7 @@ export class Blockchain {
         name: Buffer.from('$IRON', 'utf8'),
         nonce: 0,
         creator: Buffer.from('Iron Fish', 'utf8'),
+        owner: Buffer.from('Iron Fish', 'utf8'),
         supply: 0n,
       }
     }

--- a/ironfish/src/blockchain/database/assetValue.test.ts
+++ b/ironfish/src/blockchain/database/assetValue.test.ts
@@ -20,6 +20,7 @@ describe('AssetValueEncoding', () => {
       name: asset.name(),
       nonce: asset.nonce(),
       creator: asset.creator(),
+      owner: asset.creator(),
       supply: BigInt(100),
     }
     const buffer = encoder.serialize(value)

--- a/ironfish/src/blockchain/database/blockchaindb.ts
+++ b/ironfish/src/blockchain/database/blockchaindb.ts
@@ -24,7 +24,7 @@ import { HeaderEncoding, HeaderValue } from './headers'
 import { SequenceToHashesValueEncoding } from './sequenceToHashes'
 import { TransactionsValue, TransactionsValueEncoding } from './transactions'
 
-export const VERSION_DATABASE_CHAIN = 14
+export const VERSION_DATABASE_CHAIN = 28
 
 export class BlockchainDB {
   db: IDatabase

--- a/ironfish/src/migrations/data/023-wallet-optional-spending-key.ts
+++ b/ironfish/src/migrations/data/023-wallet-optional-spending-key.ts
@@ -6,6 +6,7 @@ import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { Migration } from '../migration'
 import { GetStores } from './023-wallet-optional-spending-key/stores'
+
 export class Migration023 extends Migration {
   path = __filename
 

--- a/ironfish/src/migrations/data/028-backfill-assets-owner.ts
+++ b/ironfish/src/migrations/data/028-backfill-assets-owner.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Logger } from '../../logger'
+import { IronfishNode } from '../../node'
+import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { createDB } from '../../storage/utils'
+import { Migration } from '../migration'
+import { GetStores } from './028-backfill-assets-owner/stores'
+
+export class Migration028 extends Migration {
+  path = __filename
+
+  prepare(node: IronfishNode): IDatabase {
+    return createDB({ location: node.config.chainDatabasePath })
+  }
+
+  async forward(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const stores = GetStores(db)
+
+    logger.info(`Migrating asset data to store owner`)
+
+    for await (const assetValue of stores.old.assets.getAllValuesIter(tx)) {
+      const assetName = assetValue.name.toString('utf8')
+      const assetIdSlice = assetValue.id.toString('hex').substring(0, 10)
+      logger.info(` Migrating asset ${assetIdSlice}... (${assetName})`)
+
+      await stores.new.assets.put(
+        assetValue.id,
+        { ...assetValue, owner: assetValue.creator },
+        tx,
+      )
+    }
+  }
+
+  async backward(
+    node: IronfishNode,
+    db: IDatabase,
+    tx: IDatabaseTransaction | undefined,
+    logger: Logger,
+  ): Promise<void> {
+    const stores = GetStores(db)
+
+    logger.info(`Reverting migration of asset data to store owner`)
+
+    for await (const assetValue of stores.new.assets.getAllValuesIter(tx)) {
+      const assetName = assetValue.name.toString('utf8')
+      const assetIdSlice = assetValue.id.toString('hex').substring(0, 10)
+      logger.info(` Reverting migration for asset ${assetIdSlice} (${assetName})`)
+
+      const { owner: _, ...oldAssetValue } = assetValue
+
+      await stores.old.assets.put(assetValue.id, { ...oldAssetValue }, tx)
+    }
+  }
+}

--- a/ironfish/src/migrations/data/028-backfill-assets-owner/new/assetValue.ts
+++ b/ironfish/src/migrations/data/028-backfill-assets-owner/new/assetValue.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import type { IDatabaseEncoding } from '../../storage/database/types'
 import {
   ASSET_ID_LENGTH,
   ASSET_METADATA_LENGTH,
@@ -9,7 +8,8 @@ import {
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import { BigIntUtils } from '../../utils'
+import { IDatabaseEncoding } from '../../../../storage'
+import { BigIntUtils } from '../../../../utils'
 
 export interface AssetValue {
   createdTransactionHash: Buffer

--- a/ironfish/src/migrations/data/028-backfill-assets-owner/new/index.ts
+++ b/ironfish/src/migrations/data/028-backfill-assets-owner/new/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { BUFFER_ENCODING, IDatabase, IDatabaseStore } from '../../../../storage'
+import { AssetValue, AssetValueEncoding } from './assetValue'
+
+export function GetNewStores(db: IDatabase): {
+  assets: IDatabaseStore<{ key: Buffer; value: AssetValue }>
+} {
+  const assets: IDatabaseStore<{ key: Buffer; value: AssetValue }> = db.addStore(
+    {
+      name: 'bA',
+      keyEncoding: BUFFER_ENCODING,
+      valueEncoding: new AssetValueEncoding(),
+    },
+    false,
+  )
+
+  return { assets }
+}

--- a/ironfish/src/migrations/data/028-backfill-assets-owner/old/assetValue.ts
+++ b/ironfish/src/migrations/data/028-backfill-assets-owner/old/assetValue.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import type { IDatabaseEncoding } from '../../storage/database/types'
 import {
   ASSET_ID_LENGTH,
   ASSET_METADATA_LENGTH,
@@ -9,7 +8,8 @@ import {
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import { BigIntUtils } from '../../utils'
+import { IDatabaseEncoding } from '../../../../storage'
+import { BigIntUtils } from '../../../../utils'
 
 export interface AssetValue {
   createdTransactionHash: Buffer
@@ -18,7 +18,6 @@ export interface AssetValue {
   name: Buffer
   nonce: number
   creator: Buffer
-  owner: Buffer
   supply: bigint
 }
 
@@ -31,7 +30,6 @@ export class AssetValueEncoding implements IDatabaseEncoding<AssetValue> {
     bw.writeBytes(value.name)
     bw.writeU8(value.nonce)
     bw.writeBytes(value.creator)
-    bw.writeBytes(value.owner)
     bw.writeVarBytes(BigIntUtils.toBytesLE(value.supply))
     return bw.render()
   }
@@ -44,9 +42,8 @@ export class AssetValueEncoding implements IDatabaseEncoding<AssetValue> {
     const name = reader.readBytes(ASSET_NAME_LENGTH)
     const nonce = reader.readU8()
     const creator = reader.readBytes(PUBLIC_ADDRESS_LENGTH)
-    const owner = reader.readBytes(PUBLIC_ADDRESS_LENGTH)
     const supply = BigIntUtils.fromBytesLE(reader.readVarBytes())
-    return { createdTransactionHash, id, metadata, name, nonce, creator, owner, supply }
+    return { createdTransactionHash, id, metadata, name, nonce, creator, supply }
   }
 
   getSize(value: AssetValue): number {
@@ -57,7 +54,6 @@ export class AssetValueEncoding implements IDatabaseEncoding<AssetValue> {
     size += ASSET_NAME_LENGTH // name
     size += 1 // nonce
     size += PUBLIC_ADDRESS_LENGTH // creator
-    size += PUBLIC_ADDRESS_LENGTH // owner
     size += bufio.sizeVarBytes(BigIntUtils.toBytesLE(value.supply)) // supply
     return size
   }

--- a/ironfish/src/migrations/data/028-backfill-assets-owner/old/index.ts
+++ b/ironfish/src/migrations/data/028-backfill-assets-owner/old/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { BUFFER_ENCODING, IDatabase, IDatabaseStore } from '../../../../storage'
+import { AssetValue, AssetValueEncoding } from './assetValue'
+
+export function GetOldStores(db: IDatabase): {
+  assets: IDatabaseStore<{ key: Buffer; value: AssetValue }>
+} {
+  const assets: IDatabaseStore<{ key: Buffer; value: AssetValue }> = db.addStore(
+    {
+      name: 'bA',
+      keyEncoding: BUFFER_ENCODING,
+      valueEncoding: new AssetValueEncoding(),
+    },
+    false,
+  )
+
+  return { assets }
+}

--- a/ironfish/src/migrations/data/028-backfill-assets-owner/stores.ts
+++ b/ironfish/src/migrations/data/028-backfill-assets-owner/stores.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { IDatabase } from '../../../storage'
+import { GetNewStores } from './new'
+import { GetOldStores } from './old'
+
+export function GetStores(db: IDatabase): {
+  old: ReturnType<typeof GetOldStores>
+  new: ReturnType<typeof GetNewStores>
+} {
+  const oldStores = GetOldStores(db)
+  const newStores = GetNewStores(db)
+
+  return { old: oldStores, new: newStores }
+}

--- a/ironfish/src/migrations/data/index.ts
+++ b/ironfish/src/migrations/data/index.ts
@@ -16,6 +16,7 @@ import { Migration024 } from './024-unspent-notes'
 import { Migration025 } from './025-backfill-wallet-nullifier-to-transaction-hash'
 import { Migration026 } from './026-timestamp-to-transactions'
 import { Migration027 } from './027-account-created-at-block'
+import { Migration028 } from './028-backfill-assets-owner'
 
 export const MIGRATIONS = [
   Migration014,
@@ -32,4 +33,5 @@ export const MIGRATIONS = [
   Migration025,
   Migration026,
   Migration027,
+  Migration028,
 ]


### PR DESCRIPTION
## Summary

**Relies on #4075**

This adds an owner field to the asset DB alongside the now-renamed creator field. This is to store the current owner of an asset, whenever that changes, so we have the current owner and can verify the proof properly with the correct owner.

Closes IFL-1325

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
