### PR TITLE
feat(ironfish): Add `nonce` to `chain/getAsset`

### DIFF
--- a/ironfish/src/rpc/routes/chain/getAsset.test.ts
+++ b/ironfish/src/rpc/routes/chain/getAsset.test.ts
@@ -21,6 +21,7 @@ describe('Route chain.getAsset', () => {
 
     expect(response.content.id).toEqual(asset.id.toString('hex'))
     expect(response.content.metadata).toBe(asset.metadata.toString('hex'))
+    expect(response.content.nonce).toBe(asset.nonce)
     expect(response.content.owner).toBe(asset.owner.toString('hex'))
     expect(response.content.supply).toBe(CurrencyUtils.encode(asset.supply))
     expect(response.content.createdTransactionHash).toBe(

--- a/ironfish/src/rpc/routes/chain/getAsset.ts
+++ b/ironfish/src/rpc/routes/chain/getAsset.ts
@@ -17,6 +17,7 @@ export type GetAssetResponse = {
   id: string
   metadata: string
   name: string
+  nonce: number
   owner: string
   supply: string
 }
@@ -34,6 +35,7 @@ export const GetAssetResponse: yup.ObjectSchema<GetAssetResponse> = yup
     id: yup.string().defined(),
     metadata: yup.string().defined(),
     name: yup.string().defined(),
+    nonce: yup.number().defined(),
     owner: yup.string().defined(),
     supply: yup.string().defined(),
   })
@@ -64,6 +66,7 @@ routes.register<typeof GetAssetRequestSchema, GetAssetResponse>(
       id: asset.id.toString('hex'),
       metadata: asset.metadata.toString('hex'),
       name: asset.name.toString('hex'),
+      nonce: asset.nonce,
       owner: asset.owner.toString('hex'),
       supply: CurrencyUtils.encode(asset.supply),
     })


### PR DESCRIPTION
## Summary

We need this field to be returned from the node client in the wallet.

## Testing Plan

Unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
