### PR TITLE
feat(ironfish): Pass memory client into wallet

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -27,6 +27,7 @@ import { IsomorphicWebSocketConstructor } from './network/types'
 import { getNetworkDefinition } from './networkDefinition'
 import { Package } from './package'
 import { Platform } from './platform'
+import { RpcMemoryClient } from './rpc'
 import { RpcServer } from './rpc/server'
 import { Strategy } from './strategy'
 import { Syncer } from './syncer'
@@ -287,15 +288,18 @@ export class IronfishNode {
       files,
     })
 
+    const memoryClient = new RpcMemoryClient(logger)
+
     const wallet = new Wallet({
       chain,
       config,
       memPool,
       database: walletDB,
       workerPool,
+      nodeClient: memoryClient,
     })
 
-    return new IronfishNode({
+    const node = new IronfishNode({
       pkg,
       chain,
       strategy,
@@ -313,6 +317,9 @@ export class IronfishNode {
       networkId: networkDefinition.id,
       verifiedAssetsCache,
     })
+    memoryClient.setNode(node)
+
+    return node
   }
 
   async openDB(): Promise<void> {

--- a/ironfish/src/rpc/clients/memoryClient.ts
+++ b/ironfish/src/rpc/clients/memoryClient.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../../assert'
 import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
 import { MemoryResponse, RpcMemoryAdapter } from '../adapters'
@@ -8,14 +9,24 @@ import { ALL_API_NAMESPACES, Router } from '../routes'
 import { RpcClient } from './client'
 
 export class RpcMemoryClient extends RpcClient {
-  _node: IronfishNode
-  router: Router
+  _node: IronfishNode | null
+  router: Router | null
 
-  constructor(logger: Logger, node: IronfishNode) {
+  constructor(logger: Logger, node?: IronfishNode) {
     super(logger)
 
-    this.router = node.rpc.getRouter(ALL_API_NAMESPACES)
+    if (node) {
+      this._node = node
+      this.router = node.rpc.getRouter(ALL_API_NAMESPACES)
+    } else {
+      this._node = null
+      this.router = null
+    }
+  }
+
+  setNode(node: IronfishNode): void {
     this._node = node
+    this.router = node.rpc.getRouter(ALL_API_NAMESPACES)
   }
 
   request<TEnd = unknown, TStream = unknown>(
@@ -25,6 +36,7 @@ export class RpcMemoryClient extends RpcClient {
       timeoutMs?: number | null
     } = {},
   ): MemoryResponse<TEnd, TStream> {
+    Assert.isNotNull(this.router)
     if (options.timeoutMs) {
       throw new Error(`MemoryAdapter does not support timeoutMs`)
     }

--- a/ironfish/src/rpc/routes/router.test.ts
+++ b/ironfish/src/rpc/routes/router.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
+import { Assert } from '../../assert'
 import { createRouteTest } from '../../testUtilities/routeTest'
 
 describe('Router', () => {
@@ -9,9 +10,9 @@ describe('Router', () => {
 
   it('should use yup schema', async () => {
     const schema = yup.string().default('default')
-    routeTest.client.router.routes.register('foo/bar', schema, (request) =>
-      request.end(request.data),
-    )
+    const router = routeTest.client.router
+    Assert.isNotNull(router)
+    router.routes.register('foo/bar', schema, (request) => request.end(request.data))
 
     // should use default value from the schema
     let response = await routeTest.client.request('foo/bar').waitForEnd()

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import os from 'os'
+import { Assert } from './assert'
 import { Config, DEFAULT_DATA_DIR } from './fileStores'
 import { NodeFileProvider } from './fileSystems'
 import { IronfishNode } from './node'
@@ -131,7 +132,9 @@ describe('IronfishSdk', () => {
 
         expect(openDb).toHaveBeenCalledTimes(1)
         expect(client).toBeInstanceOf(RpcMemoryClient)
-        expect((client as RpcMemoryClient)._node).toBe(node)
+        const memoryClient = client as RpcMemoryClient
+        Assert.isNotNull(memoryClient._node)
+        expect(memoryClient._node).toBe(node)
       })
     })
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -22,6 +22,7 @@ import { Note } from '../primitives/note'
 import { NoteEncrypted } from '../primitives/noteEncrypted'
 import { MintData, RawTransaction } from '../primitives/rawTransaction'
 import { Transaction } from '../primitives/transaction'
+import { RpcClient } from '../rpc'
 import { IDatabaseTransaction } from '../storage/database/transaction'
 import {
   AsyncUtils,
@@ -81,6 +82,7 @@ export class Wallet {
   readonly chain: Blockchain
   readonly chainProcessor: ChainProcessor
   readonly memPool: MemPool
+  readonly nodeClient: RpcClient
   private readonly config: Config
 
   protected rebroadcastAfter: number
@@ -101,6 +103,7 @@ export class Wallet {
     logger = createRootLogger(),
     rebroadcastAfter,
     workerPool,
+    nodeClient,
   }: {
     chain: Blockchain
     config: Config
@@ -109,6 +112,7 @@ export class Wallet {
     logger?: Logger
     rebroadcastAfter?: number
     workerPool: WorkerPool
+    nodeClient: RpcClient
   }) {
     this.chain = chain
     this.config = config
@@ -116,6 +120,7 @@ export class Wallet {
     this.memPool = memPool
     this.walletDb = database
     this.workerPool = workerPool
+    this.nodeClient = nodeClient
     this.rebroadcastAfter = rebroadcastAfter ?? 10
     this.createTransactionMutex = new Mutex()
     this.eventLoopAbortController = new AbortController()


### PR DESCRIPTION
## Summary

* Makes node and router nullable in memory client
* Passes memory client into wallet

## Testing Plan

Refactored null references in existing unit tests. Otherwise, covered by existing behavior.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
