### PR TITLE
Remove direct wallet dependency wallet from PeerNetwork

### DIFF
--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -887,11 +887,15 @@ describe('PeerNetwork', () => {
 
         const verifyNewTransactionSpy = jest.spyOn(node.chain.verifier, 'verifyNewTransaction')
 
-        const addPendingTransaction = jest.spyOn(node.wallet, 'addPendingTransaction')
-
         const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
         const { peer: peerWithTransaction } = peers[0]
         const peersWithoutTransaction = peers.slice(1)
+
+        // Don't sync incoming transactions to wallet since its done async and will
+        // attempt to update the wallet after the test has finished
+        peerNetwork.onTransactionGossipReceived.clear()
+        const onTransactionGossipReceivedSpy = jest.fn()
+        peerNetwork.onTransactionGossipReceived.on(onTransactionGossipReceivedSpy)
 
         await peerNetwork.peerManager.onMessage.emitAsync(
           peerWithTransaction,
@@ -912,7 +916,7 @@ describe('PeerNetwork', () => {
 
         expect(memPool.get(transaction.hash())).toBeDefined()
 
-        expect(addPendingTransaction).toHaveBeenCalledTimes(1)
+        expect(onTransactionGossipReceivedSpy).toHaveBeenCalledTimes(1)
 
         for (const { peer } of peers) {
           expect(peer.state.identity).not.toBeNull()
@@ -943,7 +947,7 @@ describe('PeerNetwork', () => {
 
         expect(memPool.get(transaction.hash())).toBeDefined()
 
-        expect(addPendingTransaction).toHaveBeenCalledTimes(1)
+        expect(onTransactionGossipReceivedSpy).toHaveBeenCalledTimes(1)
       })
 
       it('does not sync or gossip double-spent transactions', async () => {
@@ -1150,11 +1154,16 @@ describe('PeerNetwork', () => {
         await chain.removeBlock(chain.head.hash)
 
         const verifyNewTransactionSpy = jest.spyOn(node.chain.verifier, 'verifyNewTransaction')
-        const addPendingTransaction = jest.spyOn(node.wallet, 'addPendingTransaction')
 
         const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 5)
         const { peer: peerWithTransaction } = peers[0]
         const peersWithoutTransaction = peers.slice(1)
+
+        // Don't sync incoming transactions to wallet since its done async and will
+        // attempt to update the wallet after the test has finished
+        peerNetwork.onTransactionGossipReceived.clear()
+        const onTransactionGossipReceivedSpy = jest.fn()
+        peerNetwork.onTransactionGossipReceived.on(onTransactionGossipReceivedSpy)
 
         await peerNetwork.peerManager.onMessage.emitAsync(
           peerWithTransaction,
@@ -1168,7 +1177,7 @@ describe('PeerNetwork', () => {
         })
 
         expect(memPool.get(transaction.hash())).toBeDefined()
-        expect(addPendingTransaction).toHaveBeenCalledTimes(1)
+        expect(onTransactionGossipReceivedSpy).toHaveBeenCalledTimes(1)
         for (const { sendSpy } of peersWithoutTransaction) {
           const transactionMessages = sendSpy.mock.calls.filter(([message]) => {
             return (

--- a/ironfish/src/network/transactionFetcher.test.ts
+++ b/ironfish/src/network/transactionFetcher.test.ts
@@ -60,6 +60,10 @@ describe('TransactionFetcher', () => {
   it('does not send a request for a transaction if received NewTransactionsMessage from another peer within 500ms', async () => {
     const { peerNetwork, chain, node } = nodeTest
 
+    // Don't sync incoming transactions to wallet since its done async and will
+    // attempt to update the wallet after the test has finished
+    peerNetwork.onTransactionGossipReceived.clear()
+
     chain.synced = true
     const { transaction } = await getValidTransactionOnBlock(node)
 
@@ -92,6 +96,10 @@ describe('TransactionFetcher', () => {
 
   it('handles transaction response when the fetcher sends a request', async () => {
     const { peerNetwork, chain, node } = nodeTest
+
+    // Don't sync incoming transactions to wallet since its done async and will
+    // attempt to update the wallet after the test has finished
+    peerNetwork.onTransactionGossipReceived.clear()
 
     chain.synced = true
     const { transaction } = await getValidTransactionOnBlock(node)

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -158,6 +158,12 @@ export class IronfishNode {
       this.telemetry.submitBlockMined(block)
     })
 
+    this.peerNetwork.onTransactionGossipReceived.on((transaction, valid) => {
+      if (valid) {
+        void wallet.addPendingTransaction(transaction)
+      }
+    })
+
     this.peerNetwork.onTransactionAccepted.on((transaction, received) => {
       this.telemetry.submitNewTransactionSeen(transaction, received)
     })

--- a/ironfish/src/rpc/routes/event/onTransactionGossip.test.ts
+++ b/ironfish/src/rpc/routes/event/onTransactionGossip.test.ts
@@ -20,7 +20,7 @@ describe('Route event/onTransactionGossip', () => {
 
     const response = await routeTest.client.request('event/onTransactionGossip').waitForRoute()
 
-    node.peerNetwork.onTransactionGossipReceived.emit(transaction)
+    node.peerNetwork.onTransactionGossipReceived.emit(transaction, true)
 
     const { value } = await response.contentStream().next()
 


### PR DESCRIPTION
## Summary
For standalone wallet project we are adding a feature where a node can be running without running wallet. This would allow miners for example to run a mining node and not waste resources on running a wallet. For this we cannot blindly call wallet functions from the PeerNetwork assuming the wallet is started. This also provides a consistent callback function for syncing transactions to both the local wallet and any remote wallets listening to the node

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
