### PR TITLE
fix memory client close handlers

### DIFF
--- a/ironfish/src/rpc/adapters/memoryAdapter.ts
+++ b/ironfish/src/rpc/adapters/memoryAdapter.ts
@@ -84,11 +84,6 @@ export class MemoryResponse<TEnd, TStream> extends RpcResponse<TEnd, TStream> {
     this.request.close()
   }
 
-  end(...args: Parameters<RpcRequest['end']>): ReturnType<RpcRequest['end']> {
-    Assert.isNotNull(this.request)
-    return this.request.end(args)
-  }
-
   async waitForRoute(): Promise<MemoryResponse<TEnd, TStream>> {
     if (this.routePromise) {
       await this.routePromise

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.test.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.test.ts
@@ -87,6 +87,7 @@ describe('Route chain.getTransactionStream', () => {
         ]),
       }),
     )
-    response.end()
+
+    response.close()
   })
 })

--- a/ironfish/src/rpc/routes/event/onTransactionGossip.test.ts
+++ b/ironfish/src/rpc/routes/event/onTransactionGossip.test.ts
@@ -28,7 +28,6 @@ describe('Route event/onTransactionGossip', () => {
       serializedTransaction: transaction.serialize().toString('hex'),
     })
 
-    response.end()
-    expect(response.status).toEqual(200)
+    response.close()
   })
 })

--- a/ironfish/src/rpc/routes/miner/blockTemplateStream.test.slow.ts
+++ b/ironfish/src/rpc/routes/miner/blockTemplateStream.test.slow.ts
@@ -36,9 +36,9 @@ describe('Block template stream', () => {
     await expect(chain).toAddBlock(previous)
     await flushTimeout()
 
-    response.end()
-
     expect(createNewBlockTemplateSpy).toHaveBeenCalledTimes(1)
+
+    response.close()
   })
 
   it('does not crash on expired transactions if the chain head changes rapidly', async () => {

--- a/ironfish/src/rpc/routes/node/getLogStream.test.ts
+++ b/ironfish/src/rpc/routes/node/getLogStream.test.ts
@@ -18,9 +18,6 @@ describe('Route node/getLogStream', () => {
     routeTest.node.logger.info('Hello', { foo: 2 })
     const { value } = await response.contentStream().next()
 
-    response.end()
-    expect(response.status).toBe(200)
-
     expect(value).toMatchObject({
       level: LogLevel.Info.toString(),
       tag: expect.stringContaining('ironfishnode'),
@@ -28,6 +25,8 @@ describe('Route node/getLogStream', () => {
       args: '["Hello",{"foo":2}]',
       date: expect.anything(),
     })
+
+    response.close()
   })
 
   it('should encode bigints', async () => {
@@ -41,9 +40,6 @@ describe('Route node/getLogStream', () => {
     routeTest.node.logger.info(`${BigInt(2)}`)
     const { value } = await response.contentStream().next()
 
-    response.end()
-    expect(response.status).toBe(200)
-
     expect(value).toMatchObject({
       level: LogLevel.Info.toString(),
       tag: expect.stringContaining('ironfishnode'),
@@ -51,5 +47,7 @@ describe('Route node/getLogStream', () => {
       args: '["2"]',
       date: expect.anything(),
     })
+
+    response.close()
   })
 })


### PR DESCRIPTION
## Summary

When tests are testing streaming endpoints they should close the connection at the end of the test so the node can clean up. It doesn't look like that's happening correctly currently.

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
