### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/ironfish-phase2/Cargo.toml
+++ b/ironfish-phase2/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.2"
 authors = ["Sean Bowe <ewillbefull@gmail.com>", "Iron Fish <contact@ironfish.network> (https://ironfish.network)"]
 description = "Library for performing MPCs for creating zk-SNARK public parameters"
 homepage = "https://github.com/iron-fish/ironfish"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/iron-fish/ironfish"
 
 publish = false


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields