### PR TITLE
Store consensus on wallet and use it for wallet/addTransaction RPC

### DIFF
--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -29,7 +29,7 @@ import {
   useTxSpendsFixture,
 } from '../testUtilities'
 import { useFixture } from '../testUtilities/fixtures/fixture'
-import { VerificationResultReason } from './verifier'
+import { VerificationResultReason, Verifier } from './verifier'
 
 describe('Verifier', () => {
   describe('Transaction', () => {
@@ -83,7 +83,7 @@ describe('Verifier', () => {
       const { transaction } = await useTxSpendsFixture(nodeTest.node)
       nodeTest.chain.consensus.parameters.maxBlockSizeBytes = getBlockWithMinersFeeSize()
 
-      const result = nodeTest.chain.verifier.verifyCreatedTransaction(transaction)
+      const result = Verifier.verifyCreatedTransaction(transaction, nodeTest.chain.consensus)
 
       expect(result).toEqual({
         reason: VerificationResultReason.MAX_TRANSACTION_SIZE_EXCEEDED,
@@ -110,7 +110,7 @@ describe('Verifier', () => {
 
       jest.spyOn(transaction.mints[0].asset, 'name').mockReturnValue(Buffer.alloc(32, 0))
 
-      const result = nodeTest.chain.verifier.verifyCreatedTransaction(transaction)
+      const result = Verifier.verifyCreatedTransaction(transaction, nodeTest.chain.consensus)
 
       expect(result).toEqual({
         reason: VerificationResultReason.INVALID_ASSET_NAME,
@@ -132,7 +132,7 @@ describe('Verifier', () => {
         burns: [{ assetId: Asset.nativeId(), value: BigInt(5) }],
       })
 
-      const result = nodeTest.chain.verifier.verifyCreatedTransaction(transaction)
+      const result = Verifier.verifyCreatedTransaction(transaction, nodeTest.chain.consensus)
 
       expect(result).toEqual({
         reason: VerificationResultReason.NATIVE_BURN,
@@ -152,7 +152,7 @@ describe('Verifier', () => {
 
       nodeTest.chain.consensus.parameters.minFee = txnFee + 1
 
-      const result = nodeTest.chain.verifier.verifyCreatedTransaction(transaction)
+      const result = Verifier.verifyCreatedTransaction(transaction, nodeTest.chain.consensus)
 
       expect(result).toEqual({
         reason: VerificationResultReason.MINIMUM_FEE_NOT_MET,

--- a/ironfish/src/memPool/memPool.ts
+++ b/ironfish/src/memPool/memPool.ts
@@ -5,7 +5,7 @@
 import { BufferMap } from 'buffer-map'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
-import { Consensus, isExpiredSequence } from '../consensus'
+import { Consensus, isExpiredSequence, Verifier } from '../consensus'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
 import { getTransactionSize } from '../network/utils/serializers'
@@ -266,7 +266,7 @@ export class MemPool {
       return false
     }
 
-    const { valid } = this.chain.verifier.verifyInternalNullifiers(transaction.spends)
+    const { valid } = Verifier.verifyInternalNullifiers(transaction.spends)
     if (!valid) {
       return false
     }

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -302,6 +302,7 @@ export class IronfishNode {
       memPool,
       database: walletDB,
       workerPool,
+      consensus,
       nodeClient: memoryClient,
     })
 

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { Verifier } from '../../../consensus'
 import { Transaction } from '../../../primitives'
 import { AsyncUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
@@ -43,7 +44,8 @@ routes.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
     const data = Buffer.from(request.data.transaction, 'hex')
     const transaction = new Transaction(data)
 
-    const verify = node.chain.verifier.verifyCreatedTransaction(transaction)
+    const verify = Verifier.verifyCreatedTransaction(transaction, node.chain.consensus)
+
     if (!verify.valid) {
       throw new ValidationError(`Invalid transaction, reason: ${String(verify.reason)}`, 400)
     }

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -44,7 +44,7 @@ routes.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
     const data = Buffer.from(request.data.transaction, 'hex')
     const transaction = new Transaction(data)
 
-    const verify = Verifier.verifyCreatedTransaction(transaction, node.chain.consensus)
+    const verify = Verifier.verifyCreatedTransaction(transaction, node.wallet.consensus)
 
     if (!verify.valid) {
       throw new ValidationError(`Invalid transaction, reason: ${String(verify.reason)}`, 400)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -86,7 +86,7 @@ export class Wallet {
   readonly memPool: MemPool
   readonly nodeClient: RpcClient
   private readonly config: Config
-  private readonly consensus: Consensus
+  readonly consensus: Consensus
 
   protected rebroadcastAfter: number
   protected defaultAccount: string | null = null

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -7,7 +7,7 @@ import { v4 as uuid } from 'uuid'
 import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { ChainProcessor } from '../chainProcessor'
-import { isExpiredSequence } from '../consensus'
+import { Consensus, isExpiredSequence, Verifier } from '../consensus'
 import { Event } from '../event'
 import { Config } from '../fileStores'
 import { createRootLogger, Logger } from '../logger'
@@ -86,6 +86,7 @@ export class Wallet {
   readonly memPool: MemPool
   readonly nodeClient: RpcClient
   private readonly config: Config
+  private readonly consensus: Consensus
 
   protected rebroadcastAfter: number
   protected defaultAccount: string | null = null
@@ -105,6 +106,7 @@ export class Wallet {
     logger = createRootLogger(),
     rebroadcastAfter,
     workerPool,
+    consensus,
     nodeClient,
   }: {
     chain: Blockchain
@@ -114,6 +116,7 @@ export class Wallet {
     logger?: Logger
     rebroadcastAfter?: number
     workerPool: WorkerPool
+    consensus: Consensus
     nodeClient: RpcClient
   }) {
     this.chain = chain
@@ -122,6 +125,7 @@ export class Wallet {
     this.memPool = memPool
     this.walletDb = database
     this.workerPool = workerPool
+    this.consensus = consensus
     this.nodeClient = nodeClient
     this.rebroadcastAfter = rebroadcastAfter ?? 10
     this.createTransactionMutex = new Mutex()
@@ -966,7 +970,8 @@ export class Wallet {
 
     const transaction = await this.workerPool.postTransaction(options.transaction, spendingKey)
 
-    const verify = this.chain.verifier.verifyCreatedTransaction(transaction)
+    const verify = Verifier.verifyCreatedTransaction(transaction, this.consensus)
+
     if (!verify.valid) {
       throw new Error(`Invalid transaction, reason: ${String(verify.reason)}`)
     }


### PR DESCRIPTION
## Summary
Standalone wallet should know whether or not its creating invalid transactions based on consensus parameters like max block size and min transaction fee. It could query this information from a full node but reasonably it seems more efficient for the wallet to store its own consensus parameters. The downside is that wallet consensus params could become out of sync due to a hardfork. This might deserve some discussion but proposing this solution because it reduces RPC calls and removes need for adding additional verifyCreatedTransaction RPC endpoint
 
## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

Makes some methods on Verifier class static
```
[X] Yes
```
