### PR TITLE
remove node dependencies in get transactions rpc

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
@@ -111,7 +111,7 @@ routes.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
 
     const assetBalanceDeltas = await getAssetBalanceDeltas(account, transaction)
 
-    const notes = await getAccountDecryptedNotes(node, account, transaction)
+    const notes = await getAccountDecryptedNotes(node.workerPool, account, transaction)
 
     const spends = transaction.transaction.spends.map((spend) => ({
       nullifier: spend.nullifier.toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
@@ -111,7 +111,7 @@ routes.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
 
     const assetBalanceDeltas = await getAssetBalanceDeltas(account, transaction)
 
-    const notes = await getAccountDecryptedNotes(node.workerPool, account, transaction)
+    const notes = await getAccountDecryptedNotes(node.wallet.workerPool, account, transaction)
 
     const spends = transaction.transaction.spends.map((spend) => ({
       nullifier: spend.nullifier.toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { IronfishNode } from '../../../node'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives'
 import { TransactionStatus, TransactionType, Wallet } from '../../../wallet'
 import { Account } from '../../../wallet/account/account'

--- a/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
@@ -169,7 +169,7 @@ const streamTransaction = async (
 
   let notes = undefined
   if (request.data.notes) {
-    notes = await getAccountDecryptedNotes(node, account, transaction)
+    notes = await getAccountDecryptedNotes(node.workerPool, account, transaction)
   }
 
   let spends = undefined

--- a/ironfish/src/rpc/routes/wallet/utils.test.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.test.ts
@@ -64,11 +64,19 @@ describe('Accounts utils', () => {
       Assert.isNotUndefined(transactionValue)
 
       // accountA should have both notes since it sent the transaction
-      const accountANotes = await getAccountDecryptedNotes(node, accountA, transactionValue)
+      const accountANotes = await getAccountDecryptedNotes(
+        node.workerPool,
+        accountA,
+        transactionValue,
+      )
       expect(accountANotes.length).toEqual(2)
 
       // accountB should only have one note since it received the transaction
-      const accountBNotes = await getAccountDecryptedNotes(node, accountB, transactionValue)
+      const accountBNotes = await getAccountDecryptedNotes(
+        node.workerPool,
+        accountB,
+        transactionValue,
+      )
       expect(accountBNotes.length).toEqual(1)
     })
     it('should not decrypt notes that the account did not send and did not receive', async () => {
@@ -88,7 +96,11 @@ describe('Accounts utils', () => {
       const decryptSpy = jest.spyOn(node.workerPool, 'decryptNotes')
 
       // accountB should only have one note since it received the transaction
-      const accountBNotes = await getAccountDecryptedNotes(node, accountB, transactionValue)
+      const accountBNotes = await getAccountDecryptedNotes(
+        node.workerPool,
+        accountB,
+        transactionValue,
+      )
       expect(accountBNotes.length).toEqual(1)
 
       // accountB did not send the transaction and has already decrypted the

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { IronfishNode } from '../../../node'
 import { Note } from '../../../primitives'
 import { CurrencyUtils } from '../../../utils'
 import { Account, Wallet } from '../../../wallet'
@@ -9,6 +8,7 @@ import { AccountImport } from '../../../wallet/walletdb/accountValue'
 import { AssetValue } from '../../../wallet/walletdb/assetValue'
 import { DecryptedNoteValue } from '../../../wallet/walletdb/decryptedNoteValue'
 import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
+import { WorkerPool } from '../../../workerPool'
 import { ValidationError } from '../../adapters'
 import {
   RcpAccountAssetBalanceDelta,
@@ -88,7 +88,7 @@ export async function getAssetBalanceDeltas(
 }
 
 export async function getTransactionNotes(
-  node: IronfishNode,
+  workerPool: WorkerPool,
   account: Account,
   transaction: TransactionValue,
 ): Promise<Array<DecryptedNoteValue>> {
@@ -124,7 +124,7 @@ export async function getTransactionNotes(
   }
 
   if (accountHasSpend && decryptNotesPayloads.length > 0) {
-    const decryptedSends = await node.workerPool.decryptNotes(decryptNotesPayloads)
+    const decryptedSends = await workerPool.decryptNotes(decryptNotesPayloads)
 
     for (const note of decryptedSends) {
       if (note === null) {
@@ -148,11 +148,11 @@ export async function getTransactionNotes(
 }
 
 export async function getAccountDecryptedNotes(
-  node: IronfishNode,
+  workerPool: WorkerPool,
   account: Account,
   transaction: TransactionValue,
 ): Promise<RpcWalletNote[]> {
-  const notes = await getTransactionNotes(node, account, transaction)
+  const notes = await getTransactionNotes(workerPool, account, transaction)
 
   const serializedNotes: RpcWalletNote[] = []
 


### PR DESCRIPTION
## Summary
An incremental improvement towards not using the node inside wallet RPC calls

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
