### PR TITLE
adds close method on RpcResponse

### DIFF
--- a/ironfish/src/rpc/response.ts
+++ b/ironfish/src/rpc/response.ts
@@ -43,6 +43,14 @@ export class RpcResponse<TEnd = unknown, TStream = unknown> {
     return this as RpcResponseEnded<TEnd>
   }
 
+  close(): void {
+    this.stream.close()
+
+    if (this.timeout) {
+      clearTimeout(this.timeout)
+    }
+  }
+
   /*
    * Returns a generator of stream results. If a disconnect error occurs during
    * the streaming request it just causes the generator to end, the error is


### PR DESCRIPTION
## Summary

MemoryResponse has a 'close' method that can be used to close a stream before the end of the stream. this is necessary for the MemoryResponse because the stream won't end early even if the caller stops processing responses

for RpcResponse streams the stream ends when the server ends the stream or the client disconnects

adding 'close' to RpcResponse gives the same interface as MemoryResponse for early termination of streams

this is useful in the standalone wallet where the wallet will use streaming endpoints (e.g., chain/followChainStream) using either a MemoryClient or an RpcClient

## Testing Plan

manual testing:
- added a `response.close()` call to the `sync` command and verified that it stops the stream early

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
