### PR TITLE
implements RemoteChainProcessor

### DIFF
--- a/ironfish/src/wallet/__fixtures__/remoteChainProcessor.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/remoteChainProcessor.test.ts.fixture
@@ -1,0 +1,242 @@
+{
+  "RemoteChainProcessor processes chain": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:6WbymdbshCr+42rrV2Mq5KFsCmqxQeGGm7zrVkv4vW4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:bo7PxIN5dsQvspYuKPg4dAglKeYjOCNYuz+rdAmMk6A="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1689888736169,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA2URUorQBThtISlX6sz/uPEFM9lG9kzBzw5p/2PBmUoCM8NDhmlkOT7t5idFAIEjTtXx8galipwlf9+D8Xxw6rFppuvFUIBE4HYUOGIrY/g2TIQCn9CVmNClFO+nI8Y8GEvWz0xI9sMZK5kuXhHAAuQFffhwkZ/qq3DlbajxGMyAJ9yOHWrdTgCKIkb5MTm4/JWRTMC0K7fH7jZhmiXxXhKK6qmzUaHHeK+RtzdPqszCMW38j+/pgTdEgsku7lwiVojn/3JgN6WMhhIRLex/y2pOnhUPJZ6aeoTI6IB5doYbc+rZj1/X113nlrnwbyUomBc7A7O+4XqQv3rTdRq+bHP2yC6IA1FXgjXSkCC4bpnf6NNn73JxI4W6xNTPN20o3T+IHHriaF2nf3CCpbLBLmNVjyZ1MTcmUrARALulWdDr/irU36Y5Lj5dm226a+5j24ut+oGeX0sjl+vnp86HsnV/3S4DFlUQufuv3CNdcEcBoFZig+Y3k/gZH4uTUJdHfsVU2zoDSnCH3udhWzN4gKL7mROIPptog/9gZy/g2N465vJD+tMIceIkEHx6yh4naNcaRC4omUXTHEaLnh+C71maNc18OvR72nSmPjhD6jnxBfa2IFnLYvUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJVu18jtKriHCxpFLKCx6rxAmVHHQH6vpnfSSWjE2xVQWnJ6G9K1IwZZqXcsAJfVXpkjtQRE1n/pWOmABVj9xAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "D4D355AE3DFBE997FA832CFD67A47C01E7B9804EE01D7750426855A51C92A6BB",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Hw6a6BdckDfQTCs42iXAtGJDeJExbIk+dRGbVfBCmhk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:wg95n08qxAw5ihuAj0ngcEjrHfSLahjxc/ZhZVWg8OU="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1689888736716,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAozXbnTOFKKejGtmlcfJy/ct304OXW+owS2GI6sAvFBCCOQm0HcXhCDQqragWs61Eyj0RareMTsaFaxM7FeymACWwMjY9vXawdL/wk2HdFDOYZ/xAkrQ083RRVqt52cxLe4itszdwD9GVCYhK8rTqD3j5ihImCO5FBYIqellGtpgWusTqTYyqeTNO4TCQpMkuvvFA1s0hidl6KdYV5E0r1TK+GoLsa6WvY+PxExRn/vWoElqb6I9z7p0qBoC1oQlguDebGTfyK4tTMKoiCJewOCwn1oQukmp+0YKUjhpSm1GbGuLCaI5c6efP35XR0ctCzqVK1bWFP949d45h9fLEC2AmzYD8/S+68Pr99IbiT2MGEk1ArLK0mpU+CmhqijsyTGHH5Xh6WVd1OymFgGT9EQGTYAS2FbSyjGiNXHFys+Nv2aIntlkICyhOmzsgoKWo6OEtMzJ0CLfnpURP5RiaIJh6KLfwR7h+O0kfOAcfkl6r4g1fCKkMbV/hegFFHRo+3oTumjQRfeP83KdpJNp31YpfumHh5XzXQp81KoUntDxbgw4Epj9S1YRAM1TgDLOs/cn4d036tAZ1/+YbB5HwskvVZVDKAlYid0+iuAEkXkl6RugzXI4LUklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwPNg1hhscBgaCyswlwp/L5TNOwObNtqRPHsTscW/0FBBB43EBk1STc2csN6mDrVck/Mc3+/gltoYTNYyKmxxBAg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "7002D146164FEF0C94E979B4DA074AC6F82C28DB1BE5531C7E07BE5E4CA4A63F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:60AW2cT3jIw4ZhGjEZTP66x6mvrpS1g4YoSFCz4p4Ss="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:4SGtm/cjmQGPb3wXOHc1bozb8c6irqnXSld3BLNiKGg="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1689888737369,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKcgGMEP4Vs+jOjNqocMwBtHGEHETryQbUwcf19gYl4qhTWczoHmpm0AfpBhn0aHnsMB09Mt3hcw2kHRI2AvzjbpMcU+oLuspCug7THdhcJ+k4ChTG72hQLZIhl4qtFuJ/Q6iWc3nvoamrPADJJlYr84mRzMiIrDd7M3WxHmDZYQNRzS125zvJKAjTXpWmKQO1qNhdey4fKw8If9URckKz+rfNyvB1gI3lcthtye+9yq43EgBl6wvJ8dpOrDJ3b7hqD/oA60mUj01cFP1lAxL8IH6QSK7NM5kD/ggS9JaqG+lw9OIr7Q1AyrfMVDpPlZLlnSH+wH7TEyyl9tupG8frT9/A+4zM8Mutewv2If6HCjqHAkColU1GXmob1fOG2caik2Kxbfx0gngM0tj35VNgzE0WUTJ1GNG0F/OvMyPHtfUpV43pbS8BC9QLXDAThwH6sm7ChLH5HobLBYmrd8m0tx7h/fP7NLdtqz7qiukO0B5wwj7utC+eeVLqHZ9hWdO9qqxT0qttOwR2L8OSMD37GYKkQac1t4tOr5Ng9Awo/nt7UkfuRJIbT8y2GdUkElz9E3CtBvtZOTKmtHZ9n7JQRwjtNFH0V/s24eHeBJIvXUyCJB8KOK9gUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwuIF13UBhp7AB4ytWzNuVUH22bXkFWYrJNfen32uYDwoRBNc0kZ4fjFrhBwNKJYRT8k6WGHs73ZDQLRYyQJK/AQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:NtKMCI7cubBUiXNiN2qCt0c3fiH6nl+yXKurmGhHZx8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:GPZKt1PVdr8VbC9MZ4a8yZvwIGljtai4KmjKjB3UcmU="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1689888737942,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAadTEG+WFsKNRux1jjOgrTekZFJuxAokGswYTkGsOuqmKg3CGPkxMTuFhjPNs1ld1itzQ2MQRIJphhkMfEwsJfxzAMwyJSIHnInG7PUTjz7KZjlJkd94Hcy2EkFiXpG/jMWxiRJL34UV6tf+hi3E8qdoHlrinyF7+V50pQvC5wNMGUm3LCeUghV615EN4woS+vftpBBXDBcU7G/v14cG/KaYdQW1h8i3tKVRQHj+49NqR/NHNGwSXY78A5y8a0/g6JCh9AviPQXpv7W57i/f8ICV796RXu3dz/Kas3b+5SSbUIzK8JSmxINCXy1jMx2NgHfKqNbCPj+tLDSANlLNlypBPvmusPGJwvyoVuErFdxPTKZLHC2vCRRlcsBAo+ThoLNc3jPvmLmsCwgG5Pm7t8dMfG4JxB6+COra1uhYQLuEeH+P4fMiNagl8sY0017nUn180gTXsfRrqtXeIAJUDM5oXV1MXzB/XcNm92ZLMRcMzTn72FkCn0AWB7dRH7BcaKgLBEFBGKiQ2P5WEuIwffmGAOTl3P2HGZBKU0jw31USJsehSXLX2UNAP/FdBZcfmH9Q5UmkF3bMvyLiEoyUbOFAI5gAc2IWsyxw+RMtA1MC4prypxQGSNklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw7m/x+k7uZvgEasGOn2YAwZywsXCzm6lU/Kfzx5Aq8GKVlolGPwqFqlhq3M0UswpC0UZ0hgoZdD1jCP7BRKnACA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "1083CD34B24A621D5997233BAC7DBD33CD1B886004E136751DD81D9FFA660E0D",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Goe19Q5Ock5U+kdphC3LOdQX4Gswa9qA2RwOZp8ZilM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:2G3BRXM0C3Hat1FQ2vVMFr2ttV5PGrM7odKz372cC9c="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1689888738490,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAW3BjsEiv8QQkvYmeru9HQ2c0M8YEsZ+58mLmg2a77L6I00sj1AKdE+8qbzSiCQsoBgd8Tyau/salLlJcTwdZYXgw+LBrzQSGKNCOIQbWABqqZ9ajgn3EKMv3bznZ97CZPCWQCM3l/HDsxHWh9ZlUZ2JsnNjbJJ4v7eAi5i0B4KAV63GeNMgzta+hPPJ2EkBzAo2nZ2F5ILVPuhklszoZhLoxQbL4neHIRqNd3FfMTkyK8X5YFVNh8qZka/T2LLssEuikJ4IQhYcePxnwAaQRzJgYtUG9/C11lhaW9d+mSI/KdSN+n88L/GhBVsvgfidFk++UzVHdzXB94bgd58J6SEEDhnf/JmzRNnvKUfgy/YAI3bMvTFR/8z+QVC2bKjsv3OuP4jM4gvZ6uWPWioF2xW/BfF7CfiKiBJYj4PmC02Bx4qPflcRHMBQN9bV9eju6q8/C+LLwcksL06t3A8NCK/0MZnx3u+EGYpgejYJhGGM95u15JwMPqvxBUUBzHfu6YYhYBykzJRXAR0SWJr7NqIqZZ29dXmhM7RssUIUaf5icKf5KkhrTVdjj+iSvitR+MAvLGgVAZanz/FPnH91zWGtA+qajBFESOyB9iKU6vwWcYAE3nFrXpElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGErQdFP6gQGFHZogo7fygI7kR47J/KRnU78M2wamJ7QkHKsajYG68TtDhyoJ83+2yijn/3KRrUYcPFfiaSkSDA=="
+        }
+      ]
+    }
+  ],
+  "RemoteChainProcessor handles rewinding": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:PqI0hS9fIEAo/bmtDCyVPa93dicLaaqkcj5DGPYM5ik="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:5NKXI1RtQ0O0ba6MqYRvQjv+0S/+ckQ+ErzJ6wbbFd4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1689888739257,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcAmPFO3TAdWrzFY6HcY9jIFfSCwVmnCoV+/zvIAkoeiNTW5h/rYSi5xK/72R2z4X9EdoMl79Tb3tTlwQAJr/xJju5Lnbc3jzrSsFthZ8hPyQoAGD1ttwDo5TB7yFlJHqq7zjlNEayEoSiigtQGFqUERzKLc22xZmMexiluD+0RgUFO7PzRtV3GGDv/LykRqVAex82z8st83U339z4pbBjAzJMXu8arqtYO39n4Np8Q2gZpYKRknU0KbCiJxHrpA+xZJ+dLC8WgZNKOb8Gq9kYF5jWrh+N6KuMJP7wTl4OVhAGGN9xH+jmJpyxydgra5p8onVLLEZ8VkaVc7W4V19403BYuuMPdCdizkr/Gmh5J6/p7POHY5qGh6Wuo/rjBIk6o8+YHbPW7Yz2UocFEUJ4W/RveNONi25FAq2tNY4ZZIwOF5apD30mPDmRBAkgjN0SjDLQBUNhcSpDAe+ryavSfYemYvQa7q8gNAYQfCDGvUccqCih2sUVQYMBuoGJUGDp6HnwJE/k6C6InhlInn+fp9e60aNQq9vvFwka0wz4Kiufx65GDbAb1e/Bc8BYClzmyb3R6+59zFD8txBbLKaNAhSKzyCbTLV9+kRyNdHWpUXrtz0L3+5LUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwTGUXFLeVTVdmVg1cpgdfcUxaVuyQE4Ls/0QjGlxf2Zq1ZotOtgmn94gQOB47K5Fgb4bCG44XJzafQqJliNkfCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "42FED161E9FC5CFBEE6A11428A225AAD28EC8FB5BBA06BCE18C0B1053F949A31",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:caWYdZzKwyWp3/U4y8gDOHsqoLPEKsrPzZBnobnrJhU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:FYYWJvF6PZADtPyMxfz4SsvuBgWReBFC6RHtyqxustU="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1689888739877,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAeiqILWInePHn4WClwMZkgdRIjkhfFB5zEOeddeQq7Ei3zOlqbDN16XrT1H7lPIKSYF9bhaqvssNN6+4Pv0OYLNlFjc5fQ4pbnYri9v8ODeeMXJ+S+ix+E1xym0j187pPuvs84e/nqChoduGgYS5+Byt1ir93nIvQUU1cvmf6poEVLQ2Y5V1GMo66tx+0kZBLdFqTHyqU5FgwWCXJDtL2qcJHLvPf0DO1dgN+NrpiicGWADLeLelquuY2q6DywnjeVgUDa0Kx2Xc+GRrHTSsjwXgPwEkL2qkmDxNIAGcaCXBPpvDdGgT1/YlOmhcdsRc0iFjGLiDJFHHZNGTGuiZ7AUO96HWQoIB/rBQArs0ocSA8/nd5zPuwhtDnIaNVLd89gtibieVw6UOKw3gZUjTrq9X0FGuClz4XYS2WxSLhsJ4mK4jZR/NqF66dsItII2jijMXS2F3ijn7t1YBWENJ1tt80MZF32v5LEzMr0ArBhBsRstOsuFat4vBRszLdtoU69qczmB5Ti3smiuT1L0u8N38Tedi5EGGlDdlbiguI8ZXEIWxY5tQnq6OWJ3mFNURYyWz1GAs7vOoxYA2imOUpkCieSBxFmSZQ66ZVZdDXKdIV7HEhMucK6Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw88B1VmMrPLE508z5a0RHV0tsPJ3zwX2Q00nF2rkwJYxPMkRxWP2CXJZMGrM8TbbffQiaEh0OqwtSuKEEgUzuCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "A7A05E01B72E8C2BD9B4B03FB1EE79D53C432DCF66572316D6E5D192CF836282",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:zAjG5VCv9NeNwQvXc+JY1se57cBACcSO9vimv4CR/SQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:EIRwX3DO+Eol7MVEokg8TNE49uRTLPspi1kIf1yum1A="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1689888740411,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAqc9xY3qwiyvQM3SDLj0UmJces0uAiyfy1oaIjCUeak+TOgMnPgCaxQG0/4QFJFwYXJNBr7p+W51MNCm/NEEVeUWCivcSiiB0prLHvOmQqyWy2Y3RXcEJjcV6lQnakH4gW4RTItMcbegsoxee46s/h/hQL00e2Tr5yFdoBIeaK8UXURVsU6kwT0NqU16ynl7fOKpwfez4RvGuudrDfP/ZEQD6FUIGFjheWf0WtFbGw+GDQLClP1Uyr0YiHjmMgswxM/BttYMAuPH91u8s7rxKvFs1NG5+aZGyiG7e7PbzVM0tV/Y9gPxTtRK8Wn/TcQprde6TsAQg/+L0YFyjklL84NEm9dTk7YA0ZsRdq6Ob0wOD9WprC0udOU38JPshRcNiw7KPJGAsDjin1rt+seJzuNtx0Eq2PGPlXnjZtfZLByQOxp4cyjZCp4tn7zE/57Drv3Oz+ozZ6llbGWPqelrFkrOZM+FAMZGCBEHdxn/ThHN3clxafeB/A4j+0eUUt7orwVCPfjM8tmGgi7SF9dL9SLPzyt1PRaq26X8ZbQMD/Lu5TuGgRjwucg+PlTAkkA6q8VjIkq+YF/OS3NjcSBsck0BW5voRahch57kE0rxk2z5mzWd+1WYQCElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwKJ47cPWDRVWxNQl30plx8B5BOZP7f044nT42xqLZfEncnZ8pm/j/yONG8Y0n174pezXpNqbUKC+llw3VkYOJCg=="
+        }
+      ]
+    }
+  ],
+  "RemoteChainProcessor cancels updates when abort signal is triggered": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:2Z0BhcZPSfbvc4+dFFMoXNw0cWZ1/6k373dnnkwVWGE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:XOiH3DlH2uBQLaINJJxedSb+m/xJZYTjOtVqWTZe6ec="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1689888741216,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAUCP0FIQbe6JWwv4sNpsV3vBHN4YCDT/yM5OpLz4ZAG2u7vb1qXBMkbqmtq/wALBCQnCKuERFDmUiYz5tyL0CWR7prT982pb86GHlmvZoToGO8oy1Ji9Zg6JCVkeDGU7BoOxNuVB149bM4PVlTwzZtaLyF6WI+jYT3DRlgz5G++kYUtjOSamXZJn6LZdyf89+xIHzrnxHOzCQiPquFSpNgF468BLEoSJlQIz+R4PALGKBQy9ZAIZmCH6XslQR1yOgDHreQItnIX6D3Kau616G26KKMr9OUzPqtoNzNesOUT/sLYJbeJBT3eJSRJ/4ErnqXvqGDWrltDhj1vX614d8vBuIN82IbuPt+2hug5hGx7/UwvWPCjgMyrze99R7/rFi1PpYk0GOfT081Uk91Qr6oKZWZ2FVirWQnfSbqeHAA5+wthVvzPvjdcyglAsL1l7CoWa2hMIHfacOnXVhfYQ2hYdyhyz6jBkcNXhNtumaxwIo3JLfuCGQ30h8xT8i/0uOjX/JWxa4E1orfw58iLoYCU6nWMSapf913jw5ZbZESEYWCrTsvzk7fn7E5bvpWYpaMxeeUPjb4WW/bljkayHMlk6if0rj2xkpvEDAuxO88mDt1NUHkX7kuElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwl5c0tF4NmwONHpmKx0X+4Hmi8vjsB4OKUvS3CLFyTsPr863uxek+F2Mi5uwEDnNrO07QPg/C5xngq0JS3WzACw=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -5,7 +5,7 @@ import { Asset } from '@ironfish/rust-nodejs'
 import { BufferMap } from 'buffer-map'
 import MurmurHash3 from 'imurmurhash'
 import { Assert } from '../../assert'
-import { BlockHeader, Transaction } from '../../primitives'
+import { Transaction } from '../../primitives'
 import { GENESIS_BLOCK_SEQUENCE } from '../../primitives/block'
 import { Note } from '../../primitives/note'
 import { DatabaseKeyRange, IDatabaseTransaction } from '../../storage'
@@ -13,6 +13,7 @@ import { StorageUtils } from '../../storage/database/utils'
 import { WithNonNull } from '../../utils'
 import { DecryptedNote } from '../../workerPool/tasks/decryptNotes'
 import { AssetBalances } from '../assetBalances'
+import { WalletBlockHeader } from '../remoteChainProcessor'
 import { AccountValue } from '../walletdb/accountValue'
 import { AssetValue } from '../walletdb/assetValue'
 import { BalanceValue } from '../walletdb/balanceValue'
@@ -141,7 +142,7 @@ export class Account {
   }
 
   async connectTransaction(
-    blockHeader: BlockHeader,
+    blockHeader: WalletBlockHeader,
     transaction: Transaction,
     decryptedNotes: Array<DecryptedNote>,
     tx?: IDatabaseTransaction,
@@ -426,7 +427,7 @@ export class Account {
   }
 
   private async deleteDisconnectedMintsFromAssetsStore(
-    blockHeader: BlockHeader,
+    blockHeader: WalletBlockHeader,
     transaction: Transaction,
     tx: IDatabaseTransaction,
   ): Promise<void> {
@@ -559,7 +560,7 @@ export class Account {
   }
 
   async disconnectTransaction(
-    blockHeader: BlockHeader,
+    blockHeader: WalletBlockHeader,
     transaction: Transaction,
     tx?: IDatabaseTransaction,
   ): Promise<AssetBalances> {

--- a/ironfish/src/wallet/remoteChainProcessor.test.ts
+++ b/ironfish/src/wallet/remoteChainProcessor.test.ts
@@ -15,7 +15,7 @@ describe('RemoteChainProcessor', () => {
       hash: blockHeader.hash,
       previousBlockHash: blockHeader.previousBlockHash,
       sequence: blockHeader.sequence,
-      timestamp: blockHeader.timestamp
+      timestamp: blockHeader.timestamp,
     }
   }
 

--- a/ironfish/src/wallet/remoteChainProcessor.test.ts
+++ b/ironfish/src/wallet/remoteChainProcessor.test.ts
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { BlockHeader } from '../primitives'
+import { ALL_API_NAMESPACES, RpcMemoryClient } from '../rpc'
+import { createNodeTest, useMinerBlockFixture } from '../testUtilities'
+import { RemoteChainProcessor, WalletBlockHeader } from './remoteChainProcessor'
+
+describe('RemoteChainProcessor', () => {
+  const nodeTest = createNodeTest()
+
+  function getWalletBlockHeader(blockHeader: BlockHeader): WalletBlockHeader {
+    return {
+      hash: blockHeader.hash,
+      previousBlockHash: blockHeader.previousBlockHash,
+      sequence: blockHeader.sequence,
+      timestamp: blockHeader.timestamp
+    }
+  }
+
+  it('processes chain', async () => {
+    const { node, chain } = nodeTest
+
+    const { node: nodeA } = await nodeTest.createSetup()
+    const { node: nodeB } = await nodeTest.createSetup()
+
+    const blockA1 = await useMinerBlockFixture(nodeA.chain)
+    await expect(nodeA.chain).toAddBlock(blockA1)
+    const blockA2 = await useMinerBlockFixture(nodeA.chain)
+    await expect(nodeA.chain).toAddBlock(blockA2)
+    const blockA3 = await useMinerBlockFixture(nodeA.chain)
+    await expect(nodeA.chain).toAddBlock(blockA3)
+
+    const blockB1 = await useMinerBlockFixture(nodeB.chain)
+    await expect(nodeB.chain).toAddBlock(blockB1)
+    const blockB2 = await useMinerBlockFixture(nodeB.chain)
+    await expect(nodeB.chain).toAddBlock(blockB2)
+
+    const client = new RpcMemoryClient(nodeA.logger, node.rpc.getRouter(ALL_API_NAMESPACES))
+
+    const processor = new RemoteChainProcessor({
+      logger: nodeA.logger,
+      head: chain.genesis.hash,
+      nodeClient: client,
+    })
+
+    const onEvent: jest.Mock<void, [WalletBlockHeader, 'add' | 'remove']> = jest.fn()
+    processor.onAdd.on((block) => onEvent(block.header, 'add'))
+    processor.onRemove.on((block) => onEvent(block.header, 'remove'))
+
+    await processor.update()
+    expect(onEvent).toHaveBeenCalledTimes(0)
+
+    // G -> A1
+    await expect(chain).toAddBlock(blockA1)
+
+    await processor.update()
+    expect(processor.hash?.equals(blockA1.header.hash)).toBe(true)
+    expect(onEvent).toHaveBeenNthCalledWith(1, getWalletBlockHeader(blockA1.header), 'add')
+    expect(onEvent).toHaveBeenCalledTimes(1)
+
+    // G -> A1
+    //   -> B1 -> B2
+    await expect(chain).toAddBlock(blockB1)
+    await expect(chain).toAddBlock(blockB2)
+
+    await processor.update()
+    expect(processor.hash?.equals(blockB2.header.hash)).toBe(true)
+    expect(onEvent).toHaveBeenNthCalledWith(2, getWalletBlockHeader(blockA1.header), 'remove')
+    expect(onEvent).toHaveBeenNthCalledWith(3, getWalletBlockHeader(blockB1.header), 'add')
+    expect(onEvent).toHaveBeenNthCalledWith(4, getWalletBlockHeader(blockB2.header), 'add')
+    expect(onEvent).toHaveBeenCalledTimes(4)
+
+    // G -> A1 -> A2 -> A3
+    //   -> B1 -> B2
+    await expect(chain).toAddBlock(blockA2)
+    await expect(chain).toAddBlock(blockA3)
+
+    await processor.update()
+    expect(processor.hash?.equals(blockA3.header.hash)).toBe(true)
+    expect(onEvent).toHaveBeenNthCalledWith(5, getWalletBlockHeader(blockB2.header), 'remove')
+    expect(onEvent).toHaveBeenNthCalledWith(6, getWalletBlockHeader(blockB1.header), 'remove')
+    expect(onEvent).toHaveBeenNthCalledWith(7, getWalletBlockHeader(blockA1.header), 'add')
+    expect(onEvent).toHaveBeenNthCalledWith(8, getWalletBlockHeader(blockA2.header), 'add')
+    expect(onEvent).toHaveBeenNthCalledWith(9, getWalletBlockHeader(blockA3.header), 'add')
+    expect(onEvent).toHaveBeenCalledTimes(9)
+  })
+
+  it('handles rewinding', async () => {
+    const { node } = await nodeTest.createSetup()
+    const chain = node.chain
+
+    const client = new RpcMemoryClient(node.logger, node.rpc.getRouter(ALL_API_NAMESPACES))
+
+    const processor = new RemoteChainProcessor({
+      logger: node.logger,
+      head: chain.genesis.hash,
+      nodeClient: client,
+    })
+
+    const onEvent: jest.Mock<void, [WalletBlockHeader, 'add' | 'remove']> = jest.fn()
+    processor.onAdd.on((block) => onEvent(block.header, 'add'))
+    processor.onRemove.on((block) => onEvent(block.header, 'remove'))
+
+    await processor.update()
+    expect(onEvent).toHaveBeenCalledTimes(0)
+
+    // G -> A1 -> A2 -> A3
+    const blockA1 = await useMinerBlockFixture(chain)
+    await expect(chain).toAddBlock(blockA1)
+    const blockA2 = await useMinerBlockFixture(chain)
+    await expect(chain).toAddBlock(blockA2)
+    const blockA3 = await useMinerBlockFixture(chain)
+    await expect(chain).toAddBlock(blockA3)
+
+    await processor.update()
+    expect(processor.hash?.equals(blockA3.header.hash)).toBe(true)
+
+    await chain.db.transaction(async (tx) => {
+      await chain.disconnect(blockA3, tx)
+      await chain.disconnect(blockA2, tx)
+    })
+
+    expect(chain.head.hash).toEqual(blockA1.header.hash)
+
+    await processor.update()
+    expect(processor.hash?.equals(blockA1.header.hash)).toBe(true)
+    expect(onEvent).toHaveBeenNthCalledWith(4, getWalletBlockHeader(blockA3.header), 'remove')
+    expect(onEvent).toHaveBeenNthCalledWith(5, getWalletBlockHeader(blockA2.header), 'remove')
+  })
+
+  it('cancels updates when abort signal is triggered', async () => {
+    const { node } = await nodeTest.createSetup()
+    const chain = node.chain
+
+    const client = new RpcMemoryClient(node.logger, node.rpc.getRouter(ALL_API_NAMESPACES))
+
+    const processor = new RemoteChainProcessor({
+      logger: node.logger,
+      head: chain.genesis.hash,
+      nodeClient: client,
+    })
+
+    const blockA1 = await useMinerBlockFixture(chain)
+
+    await expect(chain).toAddBlock(blockA1)
+    expect(chain.head.hash).toEqual(blockA1.header.hash)
+
+    const ac = new AbortController()
+
+    const updatePromise = processor.update({ signal: ac.signal })
+
+    // abort should trigger before any blocks have been loaded
+    ac.abort()
+
+    const result = await updatePromise
+
+    expect(result.hashChanged).toEqual(false)
+    expect(processor.hash).toEqual(chain.genesis.hash)
+  })
+})

--- a/ironfish/src/wallet/remoteChainProcessor.ts
+++ b/ironfish/src/wallet/remoteChainProcessor.ts
@@ -89,7 +89,7 @@ export class RemoteChainProcessor {
     Assert.isNotNull(response.block.noteSize)
     let initialNoteIndex = response.block.noteSize
 
-    for (const rpcTransaction of response.block.transactions.reverse()) {
+    for (const rpcTransaction of response.block.transactions.slice().reverse()) {
       Assert.isNotUndefined(rpcTransaction.serialized)
       const transaction = new Transaction(Buffer.from(rpcTransaction.serialized, 'hex'))
       initialNoteIndex -= transaction.notes.length
@@ -100,6 +100,6 @@ export class RemoteChainProcessor {
       })
     }
 
-    return transactions.reverse()
+    return transactions.slice().reverse()
   }
 }

--- a/ironfish/src/wallet/remoteChainProcessor.ts
+++ b/ironfish/src/wallet/remoteChainProcessor.ts
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Assert } from '../assert'
+import { Event } from '../event'
+import { Logger } from '../logger'
+import { Transaction } from '../primitives'
+import { FollowChainStreamResponse, RpcClient } from '../rpc'
+import { BufferUtils } from '../utils'
+
+export type WalletBlockHeader = {
+  hash: Buffer
+  previousBlockHash: Buffer
+  sequence: number
+  timestamp: Date
+}
+
+export type WalletBlockTransaction = {
+  transaction: Transaction
+  initialNoteIndex: number
+}
+
+export class RemoteChainProcessor {
+  hash: Buffer | null = null
+  sequence: number | null = null
+  logger: Logger
+  nodeClient: RpcClient
+
+  onAdd = new Event<[{ header: WalletBlockHeader; transactions: WalletBlockTransaction[] }]>()
+  onRemove = new Event<
+    [{ header: WalletBlockHeader; transactions: WalletBlockTransaction[] }]
+  >()
+
+  constructor(options: { logger: Logger; nodeClient: RpcClient; head: Buffer | null }) {
+    this.logger = options.logger
+    this.nodeClient = options.nodeClient
+    this.hash = options.head
+  }
+
+  async update({ signal }: { signal?: AbortSignal } = {}): Promise<{ hashChanged: boolean }> {
+    const chainStream = this.nodeClient.chain.followChainStream({
+      head: this.hash?.toString('hex') ?? null,
+      serialized: true,
+      wait: false,
+    })
+
+    const oldHash = this.hash
+
+    for await (const content of chainStream.contentStream()) {
+      if (signal?.aborted) {
+        return { hashChanged: !BufferUtils.equalsNullable(this.hash, oldHash) }
+      }
+
+      const { type, block } = content
+
+      if (type === 'fork') {
+        continue
+      }
+
+      const blockHeader: WalletBlockHeader = {
+        hash: Buffer.from(block.hash, 'hex'),
+        previousBlockHash: Buffer.from(block.previous, 'hex'),
+        sequence: block.sequence,
+        timestamp: new Date(block.timestamp),
+      }
+
+      const blockTransactions = this.getBlockTransactions(content)
+
+      if (type === 'connected') {
+        this.hash = blockHeader.hash
+        this.sequence = blockHeader.sequence
+        await this.onAdd.emitAsync({ header: blockHeader, transactions: blockTransactions })
+      } else if (type === 'disconnected') {
+        this.hash = blockHeader.previousBlockHash
+        this.sequence = blockHeader.sequence - 1
+        await this.onRemove.emitAsync({
+          header: blockHeader,
+          transactions: blockTransactions,
+        })
+      }
+    }
+
+    return { hashChanged: !BufferUtils.equalsNullable(this.hash, oldHash) }
+  }
+
+  getBlockTransactions(response: FollowChainStreamResponse): WalletBlockTransaction[] {
+    const transactions = []
+
+    Assert.isNotNull(response.block.noteSize)
+    let initialNoteIndex = response.block.noteSize
+
+    for (const rpcTransaction of response.block.transactions.reverse()) {
+      Assert.isNotUndefined(rpcTransaction.serialized)
+      const transaction = new Transaction(Buffer.from(rpcTransaction.serialized, 'hex'))
+      initialNoteIndex -= transaction.notes.length
+
+      transactions.push({
+        transaction,
+        initialNoteIndex,
+      })
+    }
+
+    return transactions.reverse()
+  }
+}

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -65,7 +65,6 @@ describe('Accounts', () => {
     const invalidTx = await useTxFixture(nodeA.wallet, accountA, accountB)
     expect(broadcastSpy).toHaveBeenCalledTimes(0)
 
-    await nodeA.wallet.updateHead()
     await expect(accountA.hasPendingTransaction(invalidTx.hash())).resolves.toBeTruthy()
 
     await expect(nodeA.chain).toAddBlock(blockB1)
@@ -1556,7 +1555,8 @@ describe('Accounts', () => {
       const { block: blockA2, transaction } = await useBlockWithTx(node, accountA, accountB)
       await expect(node.chain).toAddBlock(blockA2)
 
-      await node.wallet.connectBlock(blockA2.header)
+      const transactions = await node.chain.getBlockTransactions(blockA2.header)
+      await node.wallet.connectBlock(blockA2.header, transactions)
 
       const transactionValue = await accountA.getTransaction(transaction.hash())
 
@@ -1578,7 +1578,8 @@ describe('Accounts', () => {
       const { block: blockA2 } = await useBlockWithTx(node, accountA, accountB)
       await expect(node.chain).toAddBlock(blockA2)
 
-      await node.wallet.connectBlock(blockA2.header)
+      const transactions = await node.chain.getBlockTransactions(blockA2.header)
+      await node.wallet.connectBlock(blockA2.header, transactions)
 
       const accountAHead = await accountA.getHead()
 
@@ -1601,7 +1602,8 @@ describe('Accounts', () => {
       const { block: blockA2 } = await useBlockWithTx(node, accountA, accountB, false)
       await expect(node.chain).toAddBlock(blockA2)
 
-      await node.wallet.connectBlock(blockA2.header)
+      const transactions = await node.chain.getBlockTransactions(blockA2.header)
+      await node.wallet.connectBlock(blockA2.header, transactions)
 
       const balanceAfter = await accountA.getUnconfirmedBalance(Asset.nativeId())
       expect(balanceAfter.unconfirmed).toEqual(1999999998n)
@@ -1619,13 +1621,14 @@ describe('Accounts', () => {
       const blockA2 = await useMinerBlockFixture(node.chain, undefined, accountA, node.wallet)
       await expect(node.chain).toAddBlock(blockA2)
 
-      await node.wallet.connectBlock(blockA2.header)
+      const transactions = await node.chain.getBlockTransactions(blockA2.header)
+      await node.wallet.connectBlock(blockA2.header, transactions)
 
       let accountAHead = await accountA.getHead()
       expect(accountAHead?.hash).toEqualHash(blockA2.header.hash)
 
-      // Try to connect A1 again
-      await node.wallet.connectBlock(blockA1.header)
+      // Try to connect A2 again
+      await node.wallet.connectBlock(blockA1.header, transactions)
 
       // accountA head hash should be unchanged
       accountAHead = await accountA.getHead()
@@ -1644,15 +1647,17 @@ describe('Accounts', () => {
       const blockA2 = await useMinerBlockFixture(node.chain, undefined, accountA, node.wallet)
       await expect(node.chain).toAddBlock(blockA2)
 
-      await node.wallet.connectBlock(blockA2.header)
+      const transactionsA2 = await node.chain.getBlockTransactions(blockA2.header)
+      await node.wallet.connectBlock(blockA2.header, transactionsA2)
 
       let accountAHead = await accountA.getHead()
       expect(accountAHead?.hash).toEqualHash(blockA2.header.hash)
 
       const updateHeadSpy = jest.spyOn(accountA, 'updateHead')
 
-      // Try to connect A2 again
-      await node.wallet.connectBlock(blockA1.header)
+      // Try to connect A1 again
+      const transactionsA1 = await node.chain.getBlockTransactions(blockA1.header)
+      await node.wallet.connectBlock(blockA1.header, transactionsA1)
 
       expect(updateHeadSpy).not.toHaveBeenCalled()
 
@@ -1680,7 +1685,8 @@ describe('Accounts', () => {
       const updateHeadSpy = jest.spyOn(accountA, 'updateHead')
 
       // Try to connect A3
-      await node.wallet.connectBlock(blockA3.header)
+      const transactionsA3 = await node.chain.getBlockTransactions(blockA3.header)
+      await node.wallet.connectBlock(blockA3.header, transactionsA3)
 
       expect(updateHeadSpy).not.toHaveBeenCalled()
 
@@ -1967,12 +1973,14 @@ describe('Accounts', () => {
       accountA = nodeA.wallet.getAccountByName('a')
       Assert.isNotNull(accountA)
 
-      await nodeA.wallet.connectBlock(nodeA.chain.genesis)
+      const transactions = await nodeA.chain.getBlockTransactions(nodeA.chain.genesis)
+      await nodeA.wallet.connectBlock(nodeA.chain.genesis, transactions)
 
       const decryptSpy = jest.spyOn(nodeA.wallet, 'decryptNotes')
 
       // reconnect block2
-      await nodeA.wallet.connectBlock(block2.header)
+      const transactions2 = await nodeA.chain.getBlockTransactions(block2.header)
+      await nodeA.wallet.connectBlock(block2.header, transactions2)
 
       // see that decryption was skipped for accountB
       expect(decryptSpy).toHaveBeenCalledTimes(1)
@@ -2135,7 +2143,8 @@ describe('Accounts', () => {
       expect(accountAHead?.hash).toEqualHash(blockA2.header.hash)
 
       // Try to disconnect blockA1
-      await node.wallet.disconnectBlock(blockA1.header)
+      const transactions = await node.chain.getBlockTransactions(blockA1.header)
+      await node.wallet.disconnectBlock(blockA1.header, transactions)
 
       // Verify accountA head hash unchanged
       accountAHead = await accountA.getHead()
@@ -2152,6 +2161,7 @@ describe('Accounts', () => {
       await node.wallet.updateHead()
 
       const blockA2 = await useMinerBlockFixture(node.chain, undefined, accountA, node.wallet)
+      await node.chain.addBlock(blockA2)
 
       let accountAHead = await accountA.getHead()
       expect(accountAHead?.hash).toEqualHash(blockA1.header.hash)
@@ -2159,7 +2169,8 @@ describe('Accounts', () => {
       const updateHeadSpy = jest.spyOn(accountA, 'updateHead')
 
       // Try to disconnect blockA2
-      await node.wallet.disconnectBlock(blockA2.header)
+      const transactions = await node.chain.getBlockTransactions(blockA2.header)
+      await node.wallet.disconnectBlock(blockA2.header, transactions)
 
       expect(updateHeadSpy).not.toHaveBeenCalled()
 
@@ -2185,7 +2196,8 @@ describe('Accounts', () => {
       await expect(accountA.hasTransaction(transaction.hash())).resolves.toEqual(true)
 
       // disconnect blockA1
-      await node.wallet.disconnectBlock(blockA1.header)
+      const transactions = await node.chain.getBlockTransactions(blockA1.header)
+      await node.wallet.disconnectBlock(blockA1.header, transactions)
 
       await expect(accountA.hasTransaction(transaction.hash())).resolves.toEqual(false)
     })
@@ -2226,7 +2238,8 @@ describe('Accounts', () => {
         unconfirmed: 2000000000n,
       })
 
-      await node.wallet.disconnectBlock(blockA2.header)
+      const transactions = await node.chain.getBlockTransactions(blockA2.header)
+      await node.wallet.disconnectBlock(blockA2.header, transactions)
 
       await expect(accountA.getUnconfirmedBalance(Asset.nativeId())).resolves.toMatchObject({
         blockHash: blockA1.header.hash,
@@ -2293,7 +2306,8 @@ describe('Accounts', () => {
         unconfirmed: value,
       })
 
-      await node.wallet.disconnectBlock(blockA3.header)
+      const transactions = await node.chain.getBlockTransactions(blockA3.header)
+      await node.wallet.disconnectBlock(blockA3.header, transactions)
 
       await expect(accountA.getUnconfirmedBalance(Asset.nativeId())).resolves.toMatchObject({
         blockHash: mintBlock.header.hash,
@@ -2329,7 +2343,8 @@ describe('Accounts', () => {
       expect(accountB.createdAt?.sequence).toEqual(block3.header.sequence)
 
       // disconnect block3 so that accountB's createdAt is updated
-      await node.wallet.disconnectBlock(block3.header)
+      const transactions = await node.chain.getBlockTransactions(block3.header)
+      await node.wallet.disconnectBlock(block3.header, transactions)
 
       // accountB.createdAt should now reference block2, the previous block from block3
       expect(accountB.createdAt?.hash).toEqualHash(block2.header.hash)


### PR DESCRIPTION
## Summary

the standalone wallet will depend on a remote node running a ChainProcessor and sending block events over the chain/followChainStream RPC

the RemoteChainProcessor mimics the behavior of the ChainProcessor but uses chain/getChainInfo and chain/followChainStream to update

update uses chain/followChainStream to stream block events _until_ it reaches the head of the remote chain from the initial call

the onAdd and onRemove Events on the RemoteChainProcessor emit transaction data in addition to the block header since transaction data arrives in the RPC response with the block data

updates wallet methods and tests to accommodate the change in event interface

defines WalletBlockHeader and WalletBlockTransaction types to represent the data required from the RemoteChainProcessor to sync transactions to the wallet

NOTE:
adds optional parameter to chain/followChainStream to end the stream once the chainProcessor reaches the head of the chain (one call to 'update'). this supports the RemoteChainProcessor using the same update logic as the ChainProcessor

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
