### PR TITLE
uses node client to broadcast transactions

### DIFF
--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -1264,6 +1264,8 @@ describe('PeerNetwork', () => {
           peer.version = VERSION_PROTOCOL
         }
 
+        jest.spyOn(peerNetwork, 'isReady', 'get').mockReturnValue(true)
+
         const accountA = await useAccountFixture(wallet, 'accountA')
         const accountB = await useAccountFixture(wallet, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -1268,7 +1268,7 @@ describe('PeerNetwork', () => {
         const accountB = await useAccountFixture(wallet, 'accountB')
         const { transaction } = await useBlockWithTx(node, accountA, accountB)
 
-        await wallet.onBroadcastTransaction.emitAsync(transaction)
+        await wallet.broadcastTransaction(transaction)
 
         const sentHash = peers.filter(({ sendSpy }) => {
           return (

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -256,10 +256,6 @@ export class PeerNetwork {
       this.broadcastBlock(block)
       this.broadcastBlockHash(block.header)
     })
-
-    this.node.wallet.onBroadcastTransaction.on((transaction) => {
-      this.broadcastTransaction(transaction)
-    })
   }
 
   start(): void {

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -65,7 +65,7 @@ routes.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
     const accepted = node.memPool.acceptTransaction(transaction)
 
     if (request.data.broadcast) {
-      node.wallet.broadcastTransaction(transaction)
+      await node.wallet.broadcastTransaction(transaction)
     }
 
     request.end({

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -29,6 +29,7 @@ import { IDatabaseTransaction } from '../storage/database/transaction'
 import {
   AsyncUtils,
   BufferUtils,
+  ErrorUtils,
   PromiseResolve,
   PromiseUtils,
   SetTimeoutToken,
@@ -1140,7 +1141,11 @@ export class Wallet {
 
       return { accepted: response.content.accepted, broadcasted: true }
     } catch (e: unknown) {
-      this.logger.warn(`Failed to broadcast transaction ${transaction.hash().toString('hex')}`)
+      this.logger.warn(
+        `Failed to broadcast transaction ${transaction
+          .hash()
+          .toString('hex')}: ${ErrorUtils.renderError(e)}`,
+      )
 
       return { accepted: false, broadcasted: false }
     }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1129,10 +1129,21 @@ export class Wallet {
     return amountSpent
   }
 
-  async broadcastTransaction(transaction: Transaction): Promise<void> {
-    await this.nodeClient.chain.broadcastTransaction({
-      transaction: transaction.serialize().toString('hex'),
-    })
+  async broadcastTransaction(
+    transaction: Transaction,
+  ): Promise<{ accepted: boolean; broadcasted: boolean }> {
+    try {
+      const response = await this.nodeClient.chain.broadcastTransaction({
+        transaction: transaction.serialize().toString('hex'),
+      })
+      Assert.isNotNull(response.content)
+
+      return { accepted: response.content.accepted, broadcasted: true }
+    } catch (e: unknown) {
+      this.logger.warn(`Failed to broadcast transaction ${transaction.hash().toString('hex')}`)
+
+      return { accepted: false, broadcasted: false }
+    }
   }
 
   async rebroadcastTransactions(sequence: number): Promise<void> {


### PR DESCRIPTION
## Summary

removes onBroadcastTransaction event from wallet and uses node client and chain/broadcastTransaction RPC to broadcast transactions from the wallet during transaction creation, rebroadcast, and wallet/addTransaction

## Testing Plan

updates unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
