### PR TITLE
Add the `transferOwnershipTo` field to MintDescription

### DIFF
--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -44,7 +44,7 @@ pub const TRANSACTION_EXPIRATION_LENGTH: u32 = TRANSACTION_EXPIRATION_SIZE as u3
 pub const TRANSACTION_FEE_LENGTH: u32 = TRANSACTION_FEE_SIZE as u32;
 
 #[napi]
-pub const TRANSACTION_VERSION: u8 = TX_VERSION;
+pub const TRANSACTION_VERSION: u8 = TX_VERSION.as_u8();
 
 #[napi(js_name = "TransactionPosted")]
 pub struct NativeTransactionPosted {

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -17,7 +17,10 @@ use ironfish_zkp::{
 use jubjub::ExtendedPoint;
 use rand::thread_rng;
 
-use crate::{assets::asset::Asset, errors::IronfishError, sapling_bls12::SAPLING, SaplingKey};
+use crate::{
+    assets::asset::Asset, errors::IronfishError, sapling_bls12::SAPLING,
+    transaction::TransactionVersion, PublicAddress, SaplingKey,
+};
 
 use super::utils::verify_mint_proof;
 
@@ -27,13 +30,26 @@ pub struct MintBuilder {
     /// Asset to be minted
     pub asset: Asset,
 
-    /// Amount of asset to mint
+    /// Amount of asset to mint. May be zero
     pub value: u64,
+
+    /// Address of the account that will be authorized to perform future
+    /// mints/burns for this asset after this transaction is executed
+    pub transfer_ownership_to: Option<PublicAddress>,
 }
 
 impl MintBuilder {
     pub fn new(asset: Asset, value: u64) -> Self {
-        Self { asset, value }
+        Self {
+            asset,
+            value,
+            transfer_ownership_to: None,
+        }
+    }
+
+    pub fn transfer_ownership_to(&mut self, owner: PublicAddress) -> &mut Self {
+        self.transfer_ownership_to = Some(owner);
+        self
     }
 
     pub fn build(
@@ -58,6 +74,7 @@ impl MintBuilder {
             proof,
             asset: self.asset,
             value: self.value,
+            transfer_ownership_to: self.transfer_ownership_to,
             authorizing_signature: blank_signature,
         };
         mint_description.partial_verify()?;
@@ -130,8 +147,12 @@ pub struct MintDescription {
     /// Asset which is being minted
     pub asset: Asset,
 
-    /// Amount of asset to mint
+    /// Amount of asset to mint. May be zero
     pub value: u64,
+
+    /// Address of the account that will be authorized to perform future
+    /// mints/burns for this asset after this transaction is executed
+    pub transfer_ownership_to: Option<PublicAddress>,
 
     /// Signature of the creator authorizing the mint action. This value is
     /// calculated after the transaction is signed since the value is dependent
@@ -213,31 +234,59 @@ impl MintDescription {
     pub(crate) fn serialize_signature_fields<W: io::Write>(
         &self,
         mut writer: W,
+        version: TransactionVersion,
     ) -> Result<(), IronfishError> {
         self.proof.write(&mut writer)?;
         self.asset.write(&mut writer)?;
         writer.write_u64::<LittleEndian>(self.value)?;
+        if version.has_mint_transfer_ownership_to() {
+            if let Some(ref transfer_ownership_to) = self.transfer_ownership_to {
+                writer.write_u8(1)?;
+                transfer_ownership_to.write(&mut writer)?;
+            } else {
+                writer.write_u8(0)?;
+            }
+        } else if self.transfer_ownership_to.is_some() {
+            return Err(IronfishError::InvalidTransactionVersion);
+        }
 
         Ok(())
     }
 
-    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
+    pub fn read<R: io::Read>(
+        mut reader: R,
+        version: TransactionVersion,
+    ) -> Result<Self, IronfishError> {
         let proof = groth16::Proof::read(&mut reader)?;
         let asset = Asset::read(&mut reader)?;
         let value = reader.read_u64::<LittleEndian>()?;
+        let transfer_ownership_to = if version.has_mint_transfer_ownership_to() {
+            if reader.read_u8()? != 0 {
+                Some(PublicAddress::read(&mut reader)?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         let authorizing_signature = redjubjub::Signature::read(&mut reader)?;
 
         Ok(MintDescription {
             proof,
             asset,
             value,
+            transfer_ownership_to,
             authorizing_signature,
         })
     }
 
     /// Stow the bytes of this [`MintDescription`] in the given writer.
-    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
-        self.serialize_signature_fields(&mut writer)?;
+    pub fn write<W: io::Write>(
+        &self,
+        mut writer: W,
+        version: TransactionVersion,
+    ) -> Result<(), IronfishError> {
+        self.serialize_signature_fields(&mut writer, version)?;
         self.authorizing_signature.write(&mut writer)?;
 
         Ok(())
@@ -255,8 +304,9 @@ mod test {
         transaction::{
             mints::{MintBuilder, MintDescription},
             utils::verify_mint_proof,
+            TransactionVersion,
         },
-        SaplingKey,
+        PublicAddress, SaplingKey,
     };
 
     #[test]
@@ -311,7 +361,7 @@ mod test {
     }
 
     #[test]
-    fn test_mint_description_serialization() {
+    fn test_mint_description_serialization_v1() {
         let key = SaplingKey::generate_key();
         let creator = key.public_address();
         let name = "name";
@@ -320,21 +370,66 @@ mod test {
         let asset = Asset::new(creator, name, metadata).unwrap();
 
         let value = 5;
+        let mint = MintBuilder::new(asset, value);
 
+        test_mint_description_serialization(TransactionVersion::V1, &key, &mint);
+    }
+
+    #[test]
+    fn test_mint_description_serialization_v2_without_transfer() {
+        let key = SaplingKey::generate_key();
+        let creator = key.public_address();
+        let name = "name";
+        let metadata = "{ 'token_identifier': '0x123' }";
+
+        let asset = Asset::new(creator, name, metadata).unwrap();
+
+        let value = 5;
+        let mint = MintBuilder::new(asset, value);
+        assert_eq!(mint.transfer_ownership_to, None);
+
+        test_mint_description_serialization(TransactionVersion::V2, &key, &mint);
+    }
+
+    #[test]
+    fn test_mint_description_serialization_v2_with_transfer() {
+        let key = SaplingKey::generate_key();
+        let creator = key.public_address();
+        let name = "name";
+        let metadata = "{ 'token_identifier': '0x123' }";
+
+        let asset = Asset::new(creator, name, metadata).unwrap();
+
+        let value = 5;
+        let mut mint = MintBuilder::new(asset, value);
+        mint.transfer_ownership_to(
+            PublicAddress::from_hex(
+                "8a4685307f159e95418a0dd3d38a3245f488c1baf64bc914f53486efd370c563",
+            )
+            .unwrap(),
+        );
+
+        test_mint_description_serialization(TransactionVersion::V2, &key, &mint);
+    }
+
+    fn test_mint_description_serialization(
+        version: TransactionVersion,
+        key: &SaplingKey,
+        mint: &MintBuilder,
+    ) {
         let public_key_randomness = jubjub::Fr::random(thread_rng());
         let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
-        let mint = MintBuilder::new(asset, value);
         let unsigned_mint = mint
-            .build(&key, &public_key_randomness, &randomized_public_key)
+            .build(key, &public_key_randomness, &randomized_public_key)
             .expect("should build valid mint description");
 
         // Signature comes from the transaction, normally
         let sig_hash = [0u8; 32];
 
         let description = unsigned_mint
-            .sign(&key, &sig_hash)
+            .sign(key, &sig_hash)
             .expect("should be able to sign proof");
 
         verify_mint_proof(
@@ -345,10 +440,10 @@ mod test {
 
         let mut serialized_description = vec![];
         description
-            .write(&mut serialized_description)
+            .write(&mut serialized_description, version)
             .expect("should be able to serialize description");
 
-        let deserialized_description = MintDescription::read(&serialized_description[..])
+        let deserialized_description = MintDescription::read(&serialized_description[..], version)
             .expect("should be able to deserialize valid description");
 
         // Proof
@@ -358,7 +453,17 @@ mod test {
 
         // Value
         assert_eq!(description.value, deserialized_description.value);
-        assert_eq!(description.value, value);
+        assert_eq!(description.value, mint.value);
+
+        // Ownership transfer
+        assert_eq!(
+            description.transfer_ownership_to,
+            deserialized_description.transfer_ownership_to
+        );
+        assert_eq!(
+            description.transfer_ownership_to,
+            mint.transfer_ownership_to
+        );
 
         // Signature
         // Instantiated with different data just to ensure this test actually does what we expect
@@ -380,7 +485,7 @@ mod test {
         // Re-serialize for one final sanity check
         let mut reserialized_description = vec![];
         deserialized_description
-            .write(&mut reserialized_description)
+            .write(&mut reserialized_description, version)
             .expect("should be able to serialize proof again");
         assert_eq!(serialized_description, reserialized_description);
     }

--- a/ironfish-rust/src/transaction/version.rs
+++ b/ironfish-rust/src/transaction/version.rs
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::errors::IronfishError;
+use byteorder::{ReadBytesExt, WriteBytesExt};
+use std::io;
+
+/// The serialization version used by a [`Transaction`](crate::Transaction).
+///
+/// When converting a [`Transaction`](crate::Transaction) to/from bytes, the serialization version
+/// specifies which serialization to use, and which transaction features to enable.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub enum TransactionVersion {
+    /// Initial version used at mainnet launch.
+    V1,
+    /// Adds the `transfer_ownership_to` field of
+    /// [`MintDescription`](crate::transaction::mints::MintDescription).
+    V2,
+}
+
+impl TransactionVersion {
+    pub const fn as_u8(self) -> u8 {
+        match self {
+            Self::V1 => 1,
+            Self::V2 => 2,
+        }
+    }
+
+    pub const fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::V1),
+            2 => Some(Self::V2),
+            _ => None,
+        }
+    }
+
+    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
+        writer.write_u8((*self).into())?;
+        Ok(())
+    }
+
+    pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
+        Self::try_from(reader.read_u8()?)
+    }
+
+    /// Returns `true` if this [`TransactionVersion`] supports the `transfer_ownership_to` field of
+    /// [`MintDescription`](crate::transaction::mints::MintDescription).
+    pub fn has_mint_transfer_ownership_to(self) -> bool {
+        self >= Self::V2
+    }
+}
+
+impl TryFrom<u8> for TransactionVersion {
+    type Error = IronfishError;
+
+    #[inline]
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Self::from_u8(value).ok_or(IronfishError::InvalidTransactionVersion)
+    }
+}
+
+impl From<TransactionVersion> for u8 {
+    #[inline]
+    fn from(version: TransactionVersion) -> u8 {
+        version.as_u8()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TransactionVersion;
+    use super::TransactionVersion::*;
+
+    #[test]
+    fn test_ordering() {
+        assert!(V1 == V1);
+        assert!(V2 == V2);
+
+        assert!(V1 < V2);
+        assert!(V1 <= V2);
+
+        assert!(V2 > V1);
+        assert!(V2 >= V1);
+
+        assert!(V1 <= V1);
+        assert!(V1 >= V1);
+
+        assert!(V2 <= V2);
+        assert!(V2 >= V2);
+    }
+
+    #[test]
+    fn test_as_u8() {
+        assert_eq!(V1.as_u8(), 1);
+        assert_eq!(V2.as_u8(), 2);
+    }
+
+    #[test]
+    fn test_from_u8() {
+        assert_eq!(TransactionVersion::from_u8(0), None);
+        assert_eq!(TransactionVersion::from_u8(1), Some(V1));
+        assert_eq!(TransactionVersion::from_u8(2), Some(V2));
+        for i in 3..=255 {
+            assert_eq!(TransactionVersion::from_u8(i), None);
+        }
+    }
+}

--- a/ironfish/src/primitives/mintDescription.ts
+++ b/ironfish/src/primitives/mintDescription.ts
@@ -6,4 +6,5 @@ import { Asset } from '@ironfish/rust-nodejs'
 export interface MintDescription {
   asset: Asset
   value: bigint
+  transferOwnershipTo: string | null
 }

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -1396,7 +1396,9 @@ describe('Accounts', () => {
           mints: [mintData],
         })
 
-        expect(transaction.mints).toEqual([{ asset: asset, value: mintValue }])
+        expect(transaction.mints).toEqual([
+          { asset: asset, value: mintValue, transferOwnershipTo: null },
+        ])
       })
 
       it('adds balance for the asset from the wallet', async () => {


### PR DESCRIPTION
## Summary

This PR introduces a new transaction serialization version: V2. When this new version is used, `MintDescription` gets a new optional field: `transferOwnershipTo`, which will be used to allow transferring the minting permission to an arbitrary account.

## Testing Plan

Unit tests

## Documentation

No doc changes needed yet as this is a purely internal change (not exposed through RPC).

## Breaking Change

This change is backward compatible, but using the new transaction version will introduce a hard fork in the network.