### PR TITLE
Remove withReference from followChainStream

### DIFF
--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -86,36 +86,34 @@ routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
 
     const send = (block: Block, type: 'connected' | 'disconnected' | 'fork') => {
       const transactions = block.transactions.map((transaction) => {
-        return transaction.withReference(() => {
-          return {
-            ...(request.data?.serialized
-              ? { serialized: transaction.serialize().toString('hex') }
-              : {}),
-            hash: BlockHashSerdeInstance.serialize(transaction.hash()),
-            size: getTransactionSize(transaction),
-            fee: Number(transaction.fee()),
-            expiration: transaction.expiration(),
-            notes: transaction.notes.map((note) => ({
-              commitment: note.hash().toString('hex'),
-            })),
-            spends: transaction.spends.map((spend) => ({
-              nullifier: spend.nullifier.toString('hex'),
-              commitment: spend.commitment.toString('hex'),
-              size: spend.size,
-            })),
-            mints: transaction.mints.map((mint) => ({
-              id: mint.asset.id().toString('hex'),
-              metadata: BufferUtils.toHuman(mint.asset.metadata()),
-              name: BufferUtils.toHuman(mint.asset.name()),
-              creator: mint.asset.creator().toString('hex'),
-              value: mint.value.toString(),
-            })),
-            burns: transaction.burns.map((burn) => ({
-              id: burn.assetId.toString('hex'),
-              value: burn.value.toString(),
-            })),
-          }
-        })
+        return {
+          ...(request.data?.serialized
+            ? { serialized: transaction.serialize().toString('hex') }
+            : {}),
+          hash: BlockHashSerdeInstance.serialize(transaction.hash()),
+          size: getTransactionSize(transaction),
+          fee: Number(transaction.fee()),
+          expiration: transaction.expiration(),
+          notes: transaction.notes.map((note) => ({
+            commitment: note.hash().toString('hex'),
+          })),
+          spends: transaction.spends.map((spend) => ({
+            nullifier: spend.nullifier.toString('hex'),
+            commitment: spend.commitment.toString('hex'),
+            size: spend.size,
+          })),
+          mints: transaction.mints.map((mint) => ({
+            id: mint.asset.id().toString('hex'),
+            metadata: BufferUtils.toHuman(mint.asset.metadata()),
+            name: BufferUtils.toHuman(mint.asset.name()),
+            creator: mint.asset.creator().toString('hex'),
+            value: mint.value.toString(),
+          })),
+          burns: transaction.burns.map((burn) => ({
+            id: burn.assetId.toString('hex'),
+            value: burn.value.toString(),
+          })),
+        }
       })
 
       request.stream({

--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -85,36 +85,34 @@ routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
     })
 
     const send = (block: Block, type: 'connected' | 'disconnected' | 'fork') => {
-      const transactions = block.transactions.map((transaction) => {
-        return {
-          ...(request.data?.serialized
-            ? { serialized: transaction.serialize().toString('hex') }
-            : {}),
-          hash: BlockHashSerdeInstance.serialize(transaction.hash()),
-          size: getTransactionSize(transaction),
-          fee: Number(transaction.fee()),
-          expiration: transaction.expiration(),
-          notes: transaction.notes.map((note) => ({
-            commitment: note.hash().toString('hex'),
-          })),
-          spends: transaction.spends.map((spend) => ({
-            nullifier: spend.nullifier.toString('hex'),
-            commitment: spend.commitment.toString('hex'),
-            size: spend.size,
-          })),
-          mints: transaction.mints.map((mint) => ({
-            id: mint.asset.id().toString('hex'),
-            metadata: BufferUtils.toHuman(mint.asset.metadata()),
-            name: BufferUtils.toHuman(mint.asset.name()),
-            creator: mint.asset.creator().toString('hex'),
-            value: mint.value.toString(),
-          })),
-          burns: transaction.burns.map((burn) => ({
-            id: burn.assetId.toString('hex'),
-            value: burn.value.toString(),
-          })),
-        }
-      })
+      const transactions = block.transactions.map((transaction) => ({
+        ...(request.data?.serialized
+          ? { serialized: transaction.serialize().toString('hex') }
+          : {}),
+        hash: BlockHashSerdeInstance.serialize(transaction.hash()),
+        size: getTransactionSize(transaction),
+        fee: Number(transaction.fee()),
+        expiration: transaction.expiration(),
+        notes: transaction.notes.map((note) => ({
+          commitment: note.hash().toString('hex'),
+        })),
+        spends: transaction.spends.map((spend) => ({
+          nullifier: spend.nullifier.toString('hex'),
+          commitment: spend.commitment.toString('hex'),
+          size: spend.size,
+        })),
+        mints: transaction.mints.map((mint) => ({
+          id: mint.asset.id().toString('hex'),
+          metadata: BufferUtils.toHuman(mint.asset.metadata()),
+          name: BufferUtils.toHuman(mint.asset.name()),
+          creator: mint.asset.creator().toString('hex'),
+          value: mint.value.toString(),
+        })),
+        burns: transaction.burns.map((burn) => ({
+          id: burn.assetId.toString('hex'),
+          value: burn.value.toString(),
+        })),
+      }))
 
       request.stream({
         type: type,


### PR DESCRIPTION
## Summary

The only field in the Transaction primitive that uses the Rust Transaction is `unsignedHash`, and we no longer return that in followChainStream, so we don't have any need to create a Rust transaction when creating block responses for the chain stream. This improves block processing time by roughly 30% (Tested by scanning first 4000 blocks of skynet).

## Testing Plan

Tests should pass, and also modified `service:sync` to run against the local chain to verify performance changes.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
