### PR TITLE
removes wallet transaction verification during rebroadcast

### DIFF
--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -100,7 +100,6 @@ describe('Accounts', () => {
     nodeA.wallet['isStarted'] = true
     nodeA.chain['synced'] = true
     await nodeA.wallet.rebroadcastTransactions(nodeA.chain.head.sequence)
-    expect(broadcastSpy).toHaveBeenCalledTimes(0)
 
     // It should now be planned to be processed at head + 1
     invalidTxEntry = await accountA.getTransaction(invalidTx.hash())

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1178,13 +1178,7 @@ export class Wallet {
           continue
         }
 
-        let isValid = true
         await this.walletDb.db.transaction(async (tx) => {
-          const verify = await this.chain.verifier.verifyTransactionAdd(transaction)
-
-          // We still update this even if it's not valid to prevent constantly
-          // reprocessing valid transaction every block. Give them a few blocks to
-          // try to become valid.
           await this.walletDb.saveTransaction(
             account,
             transactionHash,
@@ -1194,20 +1188,8 @@ export class Wallet {
             },
             tx,
           )
-
-          if (!verify.valid) {
-            isValid = false
-            this.logger.debug(
-              `Ignoring invalid transaction during rebroadcast ${transactionHash.toString(
-                'hex',
-              )}, reason ${String(verify.reason)} seq: ${sequence}`,
-            )
-          }
         })
 
-        if (!isValid) {
-          continue
-        }
         await this.broadcastTransaction(transaction)
       }
     }


### PR DESCRIPTION
## Summary

the wallet depends on the chain for verifying transactions before rebroadcasting them. however, the chain/broadcastTransaction RPC verifies transactions during rebroadcast on the node

removes chain dependency from the wallet by removing wallet-side transaction verification during rebroadcast

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
