### PR TITLE
Remove mempool dependency in wallet/addTransaction

### DIFF
--- a/ironfish/src/rpc/routes/wallet/addTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.test.ts
@@ -32,7 +32,10 @@ describe('Route wallet/addTransaction', () => {
     await routeTest.wallet.addPendingTransaction(transaction)
     await expect(account.hasTransaction(transaction.hash())).resolves.toBe(true)
 
-    const broadcastSpy = jest.spyOn(routeTest.wallet, 'broadcastTransaction')
+    const broadcastSpy = jest.spyOn(routeTest.peerNetwork, 'broadcastTransaction')
+    const mempoolAddSpy = jest.spyOn(routeTest.node.memPool, 'acceptTransaction')
+
+    jest.spyOn(routeTest.peerNetwork, 'isReady', 'get').mockImplementationOnce(() => true)
 
     // Add it again
     const response = await routeTest.client.wallet.addTransaction({
@@ -44,6 +47,7 @@ describe('Route wallet/addTransaction', () => {
     expect(response.content.accepted).toBe(true)
     expect(response.content.hash).toBe(transaction.hash().toString('hex'))
     expect(broadcastSpy).toHaveBeenCalled()
+    expect(mempoolAddSpy).toHaveBeenCalled()
   })
 
   it("should return an error if the transaction won't deserialize", async () => {

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -62,10 +62,10 @@ routes.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
       )
     }
 
-    const accepted = node.memPool.acceptTransaction(transaction)
-
+    let accepted = false
     if (request.data.broadcast) {
-      await node.wallet.broadcastTransaction(transaction)
+      const result = await node.wallet.broadcastTransaction(transaction)
+      accepted = result.accepted
     }
 
     request.end({


### PR DESCRIPTION
## Summary
The RPC call to chain/broadcastTransaction already adds the transaction to the mempool. This was added in https://github.com/iron-fish/ironfish/pull/4105 and https://github.com/iron-fish/ironfish/pull/4099. 

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
