### PR TITLE
Remove unused mempool and onCreateTransaction from Wallet

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -299,7 +299,6 @@ export class IronfishNode {
     const wallet = new Wallet({
       chain,
       config,
-      memPool,
       database: walletDB,
       workerPool,
       consensus,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -72,7 +72,6 @@ export enum TransactionType {
 export class Wallet {
   readonly onAccountImported = new Event<[account: Account]>()
   readonly onAccountRemoved = new Event<[account: Account]>()
-  readonly onTransactionCreated = new Event<[transaction: Transaction]>()
 
   scan: ScanState | null = null
   updateHeadState: ScanState | null = null
@@ -83,7 +82,6 @@ export class Wallet {
   readonly workerPool: WorkerPool
   readonly chain: Blockchain
   readonly chainProcessor: ChainProcessor
-  readonly memPool: MemPool
   readonly nodeClient: RpcClient
   private readonly config: Config
   readonly consensus: Consensus
@@ -122,7 +120,6 @@ export class Wallet {
     this.chain = chain
     this.config = config
     this.logger = logger.withTag('accounts')
-    this.memPool = memPool
     this.walletDb = database
     this.workerPool = workerPool
     this.consensus = consensus
@@ -978,9 +975,7 @@ export class Wallet {
 
     if (broadcast) {
       await this.addPendingTransaction(transaction)
-      this.memPool.acceptTransaction(transaction)
       await this.broadcastTransaction(transaction)
-      this.onTransactionCreated.emit(transaction)
     }
 
     return transaction

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -11,7 +11,6 @@ import { Consensus, isExpiredSequence, Verifier } from '../consensus'
 import { Event } from '../event'
 import { Config } from '../fileStores'
 import { createRootLogger, Logger } from '../logger'
-import { MemPool } from '../memPool'
 import { getFee } from '../memPool/feeEstimator'
 import { NoteHasher } from '../merkletree'
 import { Side } from '../merkletree/merkletree'
@@ -99,7 +98,6 @@ export class Wallet {
   constructor({
     chain,
     config,
-    memPool,
     database,
     logger = createRootLogger(),
     rebroadcastAfter,
@@ -110,7 +108,6 @@ export class Wallet {
     chain: Blockchain
     config: Config
     database: WalletDB
-    memPool: MemPool
     logger?: Logger
     rebroadcastAfter?: number
     workerPool: WorkerPool


### PR DESCRIPTION
## Summary
Transaction is already added to the mempool as part of `broadcastTransaction` and the onTransactionCreated callback is not used anywhere currently

## Testing Plan
Unit tests + simulation tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
