### PR TITLE
refactors scanTransaction to use RemoteChainProcessor

### DIFF
--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -361,9 +361,9 @@ describe('Accounts', () => {
       const block2 = await useMinerBlockFixture(chain)
       await expect(chain).toAddBlock(block2)
 
-      // Should only scan up to the current processor head block1
+      // Should update the chain processor to block2
       await wallet.scanTransactions()
-      expect(wallet['chainProcessor']['hash']?.equals(block1.header.hash)).toBe(true)
+      expect(wallet['chainProcessor']['hash']?.equals(block2.header.hash)).toBe(true)
 
       // Now with a reset chain processor should go to end of chain
       await wallet.reset()


### PR DESCRIPTION
## Summary

removes chain.iterateBlockHeaders in scanTransactions and replaces with an instance of RemoteChainProcessor

preserves 'locking' logic of existing implementation so that only one scanTransactions or updateHead call can run at a time

reads current chain head using getChainInfo at start of scan so that ScanState can track progress towards an end sequence

always updates the chainProcessor hash and sequence to those of the processor used for scanning after a scan finishes. this is because the scan will go to the current head of the remote node, which may be further than the chain processor

## Testing Plan

- updates unit tests
- manual testing:
  - ran `wallet:rescan` and checked balances before and after

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
