### PR TITLE
Make remote call to node to see if its synced enough to create a tranaction

### DIFF
--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -72,13 +72,18 @@ routes.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
 
     const account = getAccount(node.wallet, request.data.account)
 
-    if (!node.peerNetwork.isReady) {
-      throw new ValidationError(
-        `Your node must be connected to the Iron Fish network to send a transaction`,
-      )
-    }
+    const chainInfo = await node.wallet.nodeClient.chain.getChainInfo()
+    const headHash = chainInfo.content.oldestBlockIdentifier.hash
+    const headBlock = await node.wallet.nodeClient.chain.getBlock({ hash: headHash })
 
-    if (!node.chain.synced) {
+    const maxSyncedAgeMs =
+      node.wallet.config.get('maxSyncedAgeBlocks') *
+      node.wallet.consensus.parameters.targetBlockTimeInSeconds *
+      1000
+
+    const isSynced = headBlock.content.block.timestamp.valueOf() >= Date.now() - maxSyncedAgeMs
+
+    if (!isSynced) {
       throw new ValidationError(
         `Your node must be synced with the Iron Fish network to send a transaction. Please try again later`,
       )

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -72,18 +72,9 @@ routes.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
 
     const account = getAccount(node.wallet, request.data.account)
 
-    const chainInfo = await node.wallet.nodeClient.chain.getChainInfo()
-    const headHash = chainInfo.content.oldestBlockIdentifier.hash
-    const headBlock = await node.wallet.nodeClient.chain.getBlock({ hash: headHash })
+    const synced = (await node.wallet.nodeClient.node.getStatus()).content?.blockchain.synced
 
-    const maxSyncedAgeMs =
-      node.wallet.config.get('maxSyncedAgeBlocks') *
-      node.wallet.consensus.parameters.targetBlockTimeInSeconds *
-      1000
-
-    const isSynced = headBlock.content.block.timestamp.valueOf() >= Date.now() - maxSyncedAgeMs
-
-    if (!isSynced) {
+    if (!synced) {
       throw new ValidationError(
         `Your node must be synced with the Iron Fish network to send a transaction. Please try again later`,
       )

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -82,7 +82,7 @@ export class Wallet {
   readonly chain: Blockchain
   readonly chainProcessor: RemoteChainProcessor
   readonly nodeClient: RpcClient
-  readonly config: Config
+  private readonly config: Config
   readonly consensus: Consensus
 
   protected rebroadcastAfter: number

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -82,7 +82,7 @@ export class Wallet {
   readonly chain: Blockchain
   readonly chainProcessor: RemoteChainProcessor
   readonly nodeClient: RpcClient
-  private readonly config: Config
+  readonly config: Config
   readonly consensus: Consensus
 
   protected rebroadcastAfter: number


### PR DESCRIPTION
## Summary
This makes 2 changes
1) No longer check whether the remote not is connected to the peer network before attempting to send a transaction. 
   - Removing this check because the wallet can attempt rebroadcasting a transaction asynchronously so the node doesn't need to have peers for the transaction to eventually succeed
2) Checking the remote node to see if its head is synced instead of assuming there will always be a local node

## Testing Plan
Unit tests + local testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
