### PR TITLE
Make remote call for account status

### DIFF
--- a/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountsStatus.test.ts.fixture
+++ b/ironfish/src/rpc/routes/wallet/__fixtures__/getAccountsStatus.test.ts.fixture
@@ -1,0 +1,30 @@
+{
+  "Route wallet/getAccountsStatus should return account head and sequence": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ioqznmMOWI2n5298ffUx8MOPlp/igcIzPYBx5kViQxI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:fbUHQ/jNjZuGtn3cmjWjWqyabSdq2NPIhU/6Zalcj/I="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1690490722330,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAANsHwi2rxfoVqOVPYcMqYZwaHN4bu3dTVtcPaBugThBm4Rwt2dp942Ki9jBhA2bfJCrGUwJm2dOi4Xp3hSIiFk4X8nrZO5RvFAqPEey3TmMuNdtY93qyOXaZZqx5HOyIR50QtZwFX3kB1qifqTkkySHglNbHKyojPY0oWKOIHaB8EMbEIHcXYP/R4VrD1Nd5ANtBT1lEmlfiXyD/VAmo/2hvZsIklGQi61PCz7+k4rvuVZYH6pAMHgdhT24o5uYDJQlnxmSOAoLFeJ5yW/J5cqQ9c2tbPovIPm/7xFuVgEKnCCNU+t9qpPxkE7mtV7CH5oB+HTQjJvT0+1DdLshyBWi+6vvCRpvkAK+BAbqO7l8NGe8gLbAHNtaXzf/7UvSgvScfM+5GAoSwQf13y3pdcytfYm19qfcoqCdLTltL1t6WgySJLLdfiuUH6OZcXjPUafsqeGcx8WIe1D10czIbmrx+qAFLi2dh8suNa6x8s4CxrG8fM2YCG+RoV2Qs2VJztq+/4hu2hTfziEzsmrdTAUNhbTmnqC6Xasljq5Ax+DKZc3ZokwzoeeQV4fqDNfQ5t1rxYGZCgzwCP+AkI3Uc56UEZYY4K1OoidzI6asa8bUf9zJZMYFbqXUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIwO570HftHyxSijrCF6HAM31PQKqybx/eK37Sw2t/K4PjsTsjgoNRq/pCkHZgAk+uJncWFgXO6gV1yLsIJ3ICw=="
+        }
+      ]
+    }
+  ]
+}

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
@@ -54,17 +54,13 @@ routes.register<typeof GetAccountStatusRequestSchema, GetAccountStatusResponse>(
     const accountsInfo: GetAccountStatusResponse['accounts'] = []
     for (const account of node.wallet.listAccounts()) {
       const head = heads.get(account.id)
-      const blockResponse = head?.hash
-        ? await node.wallet.nodeClient.chain.getBlock({
-            hash: head.hash.toString('hex'),
-          })
-        : null
+      const headInChain = head?.hash ? await node.wallet.chainHasBlock(head.hash) : false
 
       accountsInfo.push({
         name: account.name,
         id: account.id,
         headHash: head?.hash.toString('hex') || 'NULL',
-        headInChain: !!blockResponse?.content.block,
+        headInChain,
         sequence: head?.sequence || 'NULL',
       })
     }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1586,7 +1586,7 @@ export class Wallet {
     }
   }
 
-  private async chainHasBlock(hash: Buffer): Promise<boolean> {
+  async chainHasBlock(hash: Buffer): Promise<boolean> {
     try {
       await this.nodeClient.chain.getBlock({ hash: hash.toString('hex') })
       return true


### PR DESCRIPTION
## Summary
For `wallet/getAccountsStatus` command we return whether the node contains the account head or not. Moving this call to use a node client in the case of a standalone wallet

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
