### PR TITLE
removes use of wallet.chain in useMinersTxFixture

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -587,7 +587,7 @@ describe('Blockchain', () => {
 
     it(`throws if the notes tree size is greater than the previous block's note tree size`, async () => {
       const account = await useAccountFixture(nodeTest.wallet)
-      const tx = await useMinersTxFixture(nodeTest.wallet, account)
+      const tx = await useMinersTxFixture(nodeTest.node, account)
       const block = await useMinerBlockFixture(nodeTest.chain)
 
       await nodeTest.chain.notes.add(tx.getNote(0))
@@ -599,7 +599,7 @@ describe('Blockchain', () => {
   })
 
   it('newBlock throws an error if the provided transactions are invalid', async () => {
-    const minersFee = await useMinersTxFixture(nodeTest.wallet)
+    const minersFee = await useMinersTxFixture(nodeTest.node)
 
     jest.spyOn(nodeTest.verifier['workerPool'], 'verifyTransactions').mockResolvedValue({
       valid: false,
@@ -748,7 +748,7 @@ describe('Blockchain', () => {
   })
 
   it('should create a block successfully', async () => {
-    const { node, chain, wallet } = await nodeTest.createSetup()
+    const { node, chain } = await nodeTest.createSetup()
 
     const accountA = await useAccountFixture(node.wallet, 'accountA')
 
@@ -757,7 +757,7 @@ describe('Blockchain', () => {
 
     await node.wallet.updateHead()
 
-    const minersFeeTx = await useMinersTxFixture(wallet, accountA, undefined, 0)
+    const minersFeeTx = await useMinersTxFixture(node, accountA, undefined, 0)
     const tx = await useTxFixture(node.wallet, accountA, accountA)
 
     const newBlock = await chain.newBlock([tx], minersFeeTx, undefined, chain.head)
@@ -771,7 +771,7 @@ describe('Blockchain', () => {
   })
 
   it('should create a block when clock is behind', async () => {
-    const { node, chain, wallet } = await nodeTest.createSetup()
+    const { node, chain } = await nodeTest.createSetup()
 
     const accountA = await useAccountFixture(node.wallet, 'accountA')
 
@@ -780,7 +780,7 @@ describe('Blockchain', () => {
 
     await node.wallet.updateHead()
 
-    const minersFeeTx = await useMinersTxFixture(wallet, accountA, undefined, 0)
+    const minersFeeTx = await useMinersTxFixture(node, accountA, undefined, 0)
     const tx = await useTxFixture(node.wallet, accountA, accountA)
 
     jest
@@ -792,7 +792,7 @@ describe('Blockchain', () => {
   })
 
   it('should create a block when clock is in the future', async () => {
-    const { node, chain, wallet } = await nodeTest.createSetup()
+    const { node, chain } = await nodeTest.createSetup()
 
     const accountA = await useAccountFixture(node.wallet, 'accountA')
 
@@ -801,7 +801,7 @@ describe('Blockchain', () => {
 
     await node.wallet.updateHead()
 
-    const minersFeeTx = await useMinersTxFixture(wallet, accountA, undefined, 0)
+    const minersFeeTx = await useMinersTxFixture(node, accountA, undefined, 0)
     const tx = await useTxFixture(node.wallet, accountA, accountA)
 
     jest
@@ -897,7 +897,7 @@ describe('Blockchain', () => {
 
     const asset = new Asset(accountA.publicAddress, 'test asset', '')
 
-    const minersFeeTx = await useMinersTxFixture(wallet, accountA, undefined, 1)
+    const minersFeeTx = await useMinersTxFixture(node, accountA, undefined, 1)
     const tx = await useTxFixture(wallet, accountA, accountA, async () => {
       return await wallet.mint(accountA, {
         fee: 0n,

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -47,7 +47,7 @@ describe('Verifier', () => {
     })
 
     it('returns false on miners transactions', async () => {
-      const tx = await useMinersTxFixture(nodeTest.wallet)
+      const tx = await useMinersTxFixture(nodeTest.node)
       const serialized = tx.serialize()
 
       const result = await nodeTest.chain.verifier.verifyNewTransaction(
@@ -205,7 +205,7 @@ describe('Verifier', () => {
     it('rejects a block with miners fee as second transaction', async () => {
       const account = await useAccountFixture(nodeTest.node.wallet, 'accountA')
       const { block } = await useBlockWithTx(nodeTest.node)
-      block.transactions[1] = await useMinersTxFixture(nodeTest.wallet, account, undefined, 0)
+      block.transactions[1] = await useMinersTxFixture(nodeTest.node, account, undefined, 0)
       block.header.transactionCommitment = transactionCommitment(block.transactions)
 
       expect(await nodeTest.verifier.verifyBlock(block)).toMatchObject({

--- a/ironfish/src/network/messages/getBlockTransactions.test.ts
+++ b/ironfish/src/network/messages/getBlockTransactions.test.ts
@@ -32,7 +32,7 @@ describe('GetBlockTransactionsResponse', () => {
 
   it('serializes the object into a buffer and deserializes to the original object', async () => {
     const { account, transaction: transactionA } = await useTxSpendsFixture(nodeTest.node)
-    const transactionB = await useMinersTxFixture(nodeTest.node.wallet, account)
+    const transactionB = await useMinersTxFixture(nodeTest.node, account)
 
     const rpcId = 0
     const blockHash = Buffer.alloc(32, 1)

--- a/ironfish/src/network/messages/getBlocks.test.ts
+++ b/ironfish/src/network/messages/getBlocks.test.ts
@@ -38,7 +38,7 @@ describe('GetBlocksResponse', () => {
 
   it('serializes the object into a buffer and deserializes to the original object', async () => {
     const { account, transaction: transactionA } = await useTxSpendsFixture(nodeTest.node)
-    const transactionB = await useMinersTxFixture(nodeTest.node.wallet, account)
+    const transactionB = await useMinersTxFixture(nodeTest.node, account)
 
     const rpcId = 0
     const message = new GetBlocksResponse(

--- a/ironfish/src/network/messages/getCompactBlock.test.ts
+++ b/ironfish/src/network/messages/getCompactBlock.test.ts
@@ -30,7 +30,7 @@ describe('GetCompactBlockResponse', () => {
 
   it('serializes the object into a buffer and deserializes to the original object', async () => {
     const { account, transaction: transactionA } = await useTxSpendsFixture(nodeTest.node)
-    const transactionB = await useMinersTxFixture(nodeTest.node.wallet, account)
+    const transactionB = await useMinersTxFixture(nodeTest.node, account)
 
     const compactBlock: CompactBlock = {
       header: new BlockHeader(

--- a/ironfish/src/network/messages/newCompactBlock.test.ts
+++ b/ironfish/src/network/messages/newCompactBlock.test.ts
@@ -37,7 +37,7 @@ describe('NewCompactBlockMessage', () => {
   // eslint-disable-next-line jest/expect-expect
   it('serializes the object into a buffer and deserializes to the original object', async () => {
     const { account, transaction: transactionA } = await useTxSpendsFixture(nodeTest.node)
-    const transactionB = await useMinersTxFixture(nodeTest.node.wallet, account)
+    const transactionB = await useMinersTxFixture(nodeTest.node, account)
 
     const compactBlock: CompactBlock = {
       header: new BlockHeader(

--- a/ironfish/src/network/messages/newTransactions.test.ts
+++ b/ironfish/src/network/messages/newTransactions.test.ts
@@ -30,7 +30,7 @@ describe('NewTransactionsMessage', () => {
   // eslint-disable-next-line jest/expect-expect
   it('serializes the object into a buffer and deserializes to the original object', async () => {
     const { account, transaction: transactionA } = await useTxSpendsFixture(nodeTest.node)
-    const transactionB = await useMinersTxFixture(nodeTest.node.wallet, account)
+    const transactionB = await useMinersTxFixture(nodeTest.node, account)
 
     const transactions = [transactionA, transactionB]
 

--- a/ironfish/src/network/messages/pooledTransactions.test.ts
+++ b/ironfish/src/network/messages/pooledTransactions.test.ts
@@ -44,7 +44,7 @@ describe('PooledTransactionsResponse', () => {
 
   it('serializes the object into a buffer and deserializes to the original object', async () => {
     const { account, transaction: transactionA } = await useTxSpendsFixture(nodeTest.node)
-    const transactionB = await useMinersTxFixture(nodeTest.node.wallet, account)
+    const transactionB = await useMinersTxFixture(nodeTest.node, account)
 
     const rpcId = 53242
     const transactions = [transactionA, transactionB]

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -193,8 +193,8 @@ describe('PeerNetwork', () => {
       const account = await useAccountFixture(node.wallet, 'accountA')
       const block = await useMinerBlockFixture(node.chain, undefined, account, node.wallet)
       const transaction1 = block.transactions[0]
-      const transaction2 = await useMinersTxFixture(node.wallet, account)
-      const transaction3 = await useMinersTxFixture(node.wallet, account)
+      const transaction2 = await useMinersTxFixture(node, account)
+      const transaction3 = await useMinersTxFixture(node, account)
 
       await expect(node.chain).toAddBlock(block)
 
@@ -273,8 +273,8 @@ describe('PeerNetwork', () => {
       const account = await useAccountFixture(node.wallet, 'accountA')
       const block = await useMinerBlockFixture(node.chain, undefined, account, node.wallet)
       const transaction1 = block.transactions[0]
-      const transaction2 = await useMinersTxFixture(node.wallet, account)
-      const transaction3 = await useMinersTxFixture(node.wallet, account)
+      const transaction2 = await useMinersTxFixture(node, account)
+      const transaction3 = await useMinersTxFixture(node, account)
 
       await expect(node.chain).toAddBlock(block)
 

--- a/ironfish/src/primitives/block.test.ts
+++ b/ironfish/src/primitives/block.test.ts
@@ -48,7 +48,7 @@ describe('Block', () => {
 
   it('check block equality', async () => {
     const account = await useAccountFixture(nodeTest.node.wallet, 'account')
-    const tx = await useMinersTxFixture(nodeTest.node.wallet, account)
+    const tx = await useMinersTxFixture(nodeTest.node, account)
     const { block: block1 } = await useBlockWithTx(nodeTest.node, account, account)
 
     // Header change

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
@@ -179,7 +179,7 @@ describe('Route wallet/sendTransaction', () => {
     routeTest.chain.synced = true
 
     const account = await useAccountFixture(routeTest.node.wallet, 'account')
-    const tx = await useMinersTxFixture(routeTest.node.wallet, account)
+    const tx = await useMinersTxFixture(routeTest.node, account)
 
     jest.spyOn(routeTest.node.wallet, 'send').mockResolvedValue(tx)
     jest.spyOn(routeTest.node.wallet, 'getBalance').mockResolvedValueOnce({
@@ -202,7 +202,7 @@ describe('Route wallet/sendTransaction', () => {
     routeTest.chain.synced = true
 
     const account = await useAccountFixture(routeTest.node.wallet, 'account_multi-output')
-    const tx = await useMinersTxFixture(routeTest.node.wallet, account)
+    const tx = await useMinersTxFixture(routeTest.node, account)
 
     jest.spyOn(routeTest.node.wallet, 'send').mockResolvedValue(tx)
     jest.spyOn(routeTest.node.wallet, 'getBalance').mockResolvedValueOnce({
@@ -222,7 +222,7 @@ describe('Route wallet/sendTransaction', () => {
 
   it('lets you configure the expiration and confirmations', async () => {
     const account = await useAccountFixture(routeTest.node.wallet, 'expiration')
-    const tx = await useMinersTxFixture(routeTest.node.wallet, account)
+    const tx = await useMinersTxFixture(routeTest.node, account)
 
     routeTest.node.peerNetwork['_isReady'] = true
     routeTest.chain.synced = true

--- a/ironfish/src/testUtilities/fixtures/transactions.ts
+++ b/ironfish/src/testUtilities/fixtures/transactions.ts
@@ -100,22 +100,22 @@ export async function useTxFixture(
 }
 
 export async function useMinersTxFixture(
-  wallet: Wallet,
+  node: IronfishNode,
   to?: Account,
   sequence?: number,
   amount = 0,
 ): Promise<Transaction> {
   if (!to) {
-    to = await useAccountFixture(wallet)
+    to = await useAccountFixture(node.wallet)
   }
 
-  return useTxFixture(wallet, to, to, () => {
+  return useTxFixture(node.wallet, to, to, () => {
     Assert.isNotUndefined(to)
     Assert.isNotNull(to.spendingKey)
 
-    return wallet.chain.strategy.createMinersFee(
+    return node.chain.strategy.createMinersFee(
       BigInt(amount),
-      sequence || wallet.chain.head.sequence + 1,
+      sequence || node.chain.head.sequence + 1,
       to.spendingKey,
     )
   })

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -816,7 +816,7 @@ describe('Accounts', () => {
       node.wallet['isStarted'] = true
 
       const account = await useAccountFixture(node.wallet)
-      const tx = await useMinersTxFixture(node.wallet, account)
+      const tx = await useMinersTxFixture(node, account)
       await node.wallet.addPendingTransaction(tx)
 
       await expect(

--- a/ironfish/src/wallet/walletdb/decryptedNoteValue.test.ts
+++ b/ironfish/src/wallet/walletdb/decryptedNoteValue.test.ts
@@ -19,7 +19,7 @@ describe('DecryptedNoteValueEncoding', () => {
       const encoder = new DecryptedNoteValueEncoding()
 
       const account = await useAccountFixture(nodeTest.wallet)
-      const transaction = await useMinersTxFixture(nodeTest.wallet, account)
+      const transaction = await useMinersTxFixture(nodeTest.node, account)
       const note = transaction.getNote(0).decryptNoteForOwner(account.incomingViewKey)
       Assert.isNotUndefined(note)
 
@@ -44,7 +44,7 @@ describe('DecryptedNoteValueEncoding', () => {
       const encoder = new DecryptedNoteValueEncoding()
 
       const account = await useAccountFixture(nodeTest.wallet)
-      const transaction = await useMinersTxFixture(nodeTest.wallet, account)
+      const transaction = await useMinersTxFixture(nodeTest.node, account)
       const note = transaction.getNote(0).decryptNoteForOwner(account.incomingViewKey)
       Assert.isNotUndefined(note)
 

--- a/ironfish/src/wallet/walletdb/transactionValue.test.ts
+++ b/ironfish/src/wallet/walletdb/transactionValue.test.ts
@@ -19,7 +19,7 @@ describe('TransactionValueEncoding', () => {
     it('serializes the object into a buffer and deserializes to the original object', async () => {
       const encoder = new TransactionValueEncoding()
 
-      const transaction = await useMinersTxFixture(nodeTest.wallet)
+      const transaction = await useMinersTxFixture(nodeTest.node)
 
       const assetBalanceDeltas = new BufferMap<bigint>()
       assetBalanceDeltas.set(Asset.nativeId(), -transaction.fee())
@@ -42,7 +42,7 @@ describe('TransactionValueEncoding', () => {
     it('serializes the object into a buffer and deserializes to the original object', async () => {
       const encoder = new TransactionValueEncoding()
 
-      const transaction = await useMinersTxFixture(nodeTest.wallet)
+      const transaction = await useMinersTxFixture(nodeTest.node)
 
       const assetBalanceDeltas = new BufferMap<bigint>()
       assetBalanceDeltas.set(Asset.nativeId(), -transaction.fee())
@@ -65,7 +65,7 @@ describe('TransactionValueEncoding', () => {
     it('serializes the object into a buffer and deserializes to the original object', async () => {
       const encoder = new TransactionValueEncoding()
 
-      const transaction = await useMinersTxFixture(nodeTest.wallet)
+      const transaction = await useMinersTxFixture(nodeTest.node)
 
       const assetBalanceDeltas = new BufferMap<bigint>()
       assetBalanceDeltas.set(Asset.nativeId(), -transaction.fee())
@@ -88,7 +88,7 @@ describe('TransactionValueEncoding', () => {
     it('serializes the object into a buffer and deserializes to the original object', async () => {
       const encoder = new TransactionValueEncoding()
 
-      const transaction = await useMinersTxFixture(nodeTest.wallet)
+      const transaction = await useMinersTxFixture(nodeTest.node)
 
       const value: TransactionValue = {
         transaction,
@@ -110,7 +110,7 @@ describe('TransactionValueEncoding', () => {
 
       const encoder = new TransactionValueEncoding()
 
-      const transaction = await useMinersTxFixture(nodeTest.wallet)
+      const transaction = await useMinersTxFixture(nodeTest.node)
 
       const assetBalanceDeltas = new BufferMap<bigint>()
 
@@ -139,7 +139,7 @@ describe('TransactionValueEncoding', () => {
     it('serializes the object into a buffer and deserializes to the original object', async () => {
       const encoder = new TransactionValueEncoding()
 
-      const transaction = await useMinersTxFixture(nodeTest.wallet)
+      const transaction = await useMinersTxFixture(nodeTest.node)
 
       const assetBalanceDeltas = new BufferMap<bigint>()
       assetBalanceDeltas.set(Asset.nativeId(), -transaction.fee())
@@ -163,7 +163,7 @@ describe('TransactionValueEncoding', () => {
     it('serializes the object into a buffer and deserializes to the original object', async () => {
       const encoder = new TransactionValueEncoding()
 
-      const transaction = await useMinersTxFixture(nodeTest.wallet)
+      const transaction = await useMinersTxFixture(nodeTest.node)
 
       const assetBalanceDeltas = new BufferMap<bigint>()
       assetBalanceDeltas.set(Asset.nativeId(), -20n)

--- a/ironfish/src/workerPool/tasks/decryptNotes.test.ts
+++ b/ironfish/src/workerPool/tasks/decryptNotes.test.ts
@@ -99,7 +99,7 @@ describe('DecryptNotesTask', () => {
   describe('execute', () => {
     it('posts the miners fee transaction', async () => {
       const account = await useAccountFixture(nodeTest.wallet)
-      const transaction = await useMinersTxFixture(nodeTest.wallet, account)
+      const transaction = await useMinersTxFixture(nodeTest.node, account)
 
       const task = new DecryptNotesTask()
       const index = 2

--- a/ironfish/src/workerPool/tasks/postTransaction.test.ts
+++ b/ironfish/src/workerPool/tasks/postTransaction.test.ts
@@ -50,7 +50,7 @@ describe('PostTransactionResponse', () => {
   const nodeTest = createNodeTest()
 
   it('serializes the object into a buffer and deserializes to the original object', async () => {
-    const transaction = await useMinersTxFixture(nodeTest.wallet)
+    const transaction = await useMinersTxFixture(nodeTest.node)
 
     const response = new PostTransactionResponse(transaction, 0)
     const serialized = serializePayloadToBuffer(response)

--- a/ironfish/src/workerPool/tasks/verifyTransactions.test.ts
+++ b/ironfish/src/workerPool/tasks/verifyTransactions.test.ts
@@ -44,7 +44,7 @@ describe('VerifyTransactionsTask', () => {
   describe('execute', () => {
     it('verifies the transaction', async () => {
       const account = await useAccountFixture(nodeTest.wallet)
-      const transaction = await useMinersTxFixture(nodeTest.wallet, account)
+      const transaction = await useMinersTxFixture(nodeTest.node, account)
 
       const task = new VerifyTransactionsTask()
       const request = new VerifyTransactionsRequest([transaction.serialize()])


### PR DESCRIPTION
## Summary

updates the fixture to take a node instead of a wallet, use the wallet and the chain from the node

updates all tests that use this fixture to pass a node instead of a wallet

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
