### PR TITLE
Use assetsVerifier on wallet for RPC calls

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -75,7 +75,7 @@ export class IronfishNode {
     privateIdentity,
     hostsStore,
     networkId,
-    verifiedAssetsCache,
+    assetsVerifier,
   }: {
     pkg: Package
     files: FileSystem
@@ -92,7 +92,7 @@ export class IronfishNode {
     privateIdentity?: PrivateIdentity
     hostsStore: HostsStore
     networkId: number
-    verifiedAssetsCache: VerifiedAssetsCacheStore
+    assetsVerifier: AssetsVerifier
   }) {
     this.files = files
     this.config = config
@@ -178,11 +178,7 @@ export class IronfishNode {
       blocksPerMessage: config.get('blocksPerMessage'),
     })
 
-    this.assetsVerifier = new AssetsVerifier({
-      apiUrl: config.get('assetVerificationApi'),
-      cache: verifiedAssetsCache,
-      logger,
-    })
+    this.assetsVerifier = assetsVerifier
 
     this.config.onConfigChange.on((key, value) => this.onConfigChange(key, value))
   }
@@ -230,6 +226,12 @@ export class IronfishNode {
 
     const verifiedAssetsCache = new VerifiedAssetsCacheStore(files, dataDir)
     await verifiedAssetsCache.load()
+
+    const assetsVerifier = new AssetsVerifier({
+      apiUrl: config.get('assetVerificationApi'),
+      cache: verifiedAssetsCache,
+      logger,
+    })
 
     let workers = config.get('nodeWorkers')
     if (workers === -1) {
@@ -303,6 +305,7 @@ export class IronfishNode {
       workerPool,
       consensus,
       nodeClient: memoryClient,
+      assetsVerifier,
     })
 
     const node = new IronfishNode({
@@ -321,7 +324,7 @@ export class IronfishNode {
       privateIdentity,
       hostsStore,
       networkId: networkDefinition.id,
-      verifiedAssetsCache,
+      assetsVerifier,
     })
 
     memoryClient.router = node.rpc.getRouter(ALL_API_NAMESPACES)

--- a/ironfish/src/rpc/routes/wallet/getAssets.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.ts
@@ -70,7 +70,7 @@ routes.register<typeof GetAssetsRequestSchema, GetAssetsResponse>(
           confirmations: request.data.confirmations,
         }),
         supply: asset.supply !== null ? CurrencyUtils.encode(asset.supply) : undefined,
-        verification: node.assetsVerifier.verify(asset.id),
+        verification: node.wallet.assetsVerifier.verify(asset.id),
       })
     }
 

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -80,7 +80,7 @@ routes.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
     request.end({
       account: account.name,
       assetId: assetId.toString('hex'),
-      assetVerification: node.assetsVerifier.verify(assetId),
+      assetVerification: node.wallet.assetsVerifier.verify(assetId),
       confirmed: balance.confirmed.toString(),
       unconfirmed: balance.unconfirmed.toString(),
       unconfirmedCount: balance.unconfirmedCount,

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -90,7 +90,7 @@ routes.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
         assetId: balance.assetId.toString('hex'),
         assetName: asset?.name.toString('hex') ?? '',
         assetCreator: asset?.creator.toString('hex') ?? '',
-        assetVerification: node.assetsVerifier.verify(balance.assetId),
+        assetVerification: node.wallet.assetsVerifier.verify(balance.assetId),
         blockHash: balance.blockHash?.toString('hex') ?? null,
         confirmed: CurrencyUtils.encode(balance.confirmed),
         sequence: balance.sequence,

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -5,6 +5,7 @@ import { Asset, generateKey, Note as NativeNote } from '@ironfish/rust-nodejs'
 import { BufferMap, BufferSet } from 'buffer-map'
 import { v4 as uuid } from 'uuid'
 import { Assert } from '../assert'
+import { AssetsVerifier } from '../assets'
 import { Blockchain } from '../blockchain'
 import { Consensus, isExpiredSequence, Verifier } from '../consensus'
 import { Event } from '../event'
@@ -84,6 +85,7 @@ export class Wallet {
   readonly nodeClient: RpcClient
   private readonly config: Config
   readonly consensus: Consensus
+  readonly assetsVerifier: AssetsVerifier
 
   protected rebroadcastAfter: number
   protected defaultAccount: string | null = null
@@ -104,6 +106,7 @@ export class Wallet {
     workerPool,
     consensus,
     nodeClient,
+    assetsVerifier,
   }: {
     chain: Blockchain
     config: Config
@@ -113,6 +116,7 @@ export class Wallet {
     workerPool: WorkerPool
     consensus: Consensus
     nodeClient: RpcClient
+    assetsVerifier: AssetsVerifier
   }) {
     this.chain = chain
     this.config = config
@@ -121,6 +125,7 @@ export class Wallet {
     this.workerPool = workerPool
     this.consensus = consensus
     this.nodeClient = nodeClient
+    this.assetsVerifier = assetsVerifier
     this.rebroadcastAfter = rebroadcastAfter ?? 10
     this.createTransactionMutex = new Mutex()
     this.eventLoopAbortController = new AbortController()


### PR DESCRIPTION
## Summary
AssetsVerfier needs to be accessible in RPC calls to a standalone wallet

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
