### PR TITLE
feat(cli,ironfish): Log warning if errors happen during broadcast

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -191,6 +191,16 @@ export class Burn extends IronfishCommand {
 
     CliUx.ux.action.stop()
 
+    if (response.content.accepted === false) {
+      this.warn(
+        `Transaction '${transaction.hash().toString('hex')}' was not accepted into the mempool`,
+      )
+    }
+
+    if (response.content.broadcasted === false) {
+      this.warn(`Transaction '${transaction.hash().toString('hex')}' failed to broadcast`)
+    }
+
     const assetResponse = await client.wallet.getAsset({
       account,
       id: assetId,

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -233,6 +233,16 @@ export class Mint extends IronfishCommand {
 
     const minted = transaction.mints[0]
 
+    if (response.content.accepted === false) {
+      this.warn(
+        `Transaction '${transaction.hash().toString('hex')}' was not accepted into the mempool`,
+      )
+    }
+
+    if (response.content.broadcasted === false) {
+      this.warn(`Transaction '${transaction.hash().toString('hex')}' failed to broadcast`)
+    }
+
     this.log(`Minted asset ${BufferUtils.toHuman(minted.asset.name())} from ${account}`)
     this.log(`Asset Identifier: ${minted.asset.id().toString('hex')}`)
     this.log(

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -78,13 +78,13 @@ export class PostCommand extends IronfishCommand {
     const posted = new Transaction(Buffer.from(response.content.transaction, 'hex'))
 
     if (response.content.accepted === false) {
-      this.log(
+      this.warn(
         `Transaction '${posted.hash().toString('hex')}' was not accepted into the mempool`,
       )
     }
 
     if (response.content.broadcasted === false) {
-      this.log(`Transaction '${posted.hash().toString('hex')}' failed to broadcast`)
+      this.warn(`Transaction '${posted.hash().toString('hex')}' failed to broadcast`)
     }
 
     this.log(`Posted transaction with hash ${posted.hash().toString('hex')}\n`)

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -77,6 +77,16 @@ export class PostCommand extends IronfishCommand {
 
     const posted = new Transaction(Buffer.from(response.content.transaction, 'hex'))
 
+    if (response.content.accepted === false) {
+      this.log(
+        `Transaction '${posted.hash().toString('hex')}' was not accepted into the mempool`,
+      )
+    }
+
+    if (response.content.broadcasted === false) {
+      this.log(`Transaction '${posted.hash().toString('hex')}' failed to broadcast`)
+    }
+
     this.log(`Posted transaction with hash ${posted.hash().toString('hex')}\n`)
     this.log(response.content.transaction)
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -229,6 +229,16 @@ export class Send extends IronfishCommand {
 
     CliUx.ux.action.stop()
 
+    if (response.content.accepted === false) {
+      this.warn(
+        `Transaction '${transaction.hash().toString('hex')}' was not accepted into the mempool`,
+      )
+    }
+
+    if (response.content.broadcasted === false) {
+      this.warn(`Transaction '${transaction.hash().toString('hex')}' failed to broadcast`)
+    }
+
     this.log(`Sent ${CurrencyUtils.renderIron(amount, true, assetId)} to ${to} from ${from}`)
     this.log(`Hash: ${transaction.hash().toString('hex')}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)

--- a/ironfish/src/primitives/transaction.test.slow.ts
+++ b/ironfish/src/primitives/transaction.test.slow.ts
@@ -107,7 +107,7 @@ describe('Accounts', () => {
       expiration: 0,
     })
 
-    const transaction = await nodeA.wallet.post({
+    const { transaction } = await nodeA.wallet.post({
       transaction: raw,
       account: accountA,
     })

--- a/ironfish/src/rpc/routes/wallet/createTransaction.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.test.slow.ts
@@ -36,10 +36,11 @@ describe('Route wallet/createTransaction', () => {
             expiration: 0,
           })
 
-          return routeTest.node.wallet.post({
+          const { transaction } = await routeTest.node.wallet.post({
             transaction: raw,
             account: sender,
           })
+          return transaction
         },
       )
 

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -66,10 +66,11 @@ describe('Route wallet/mintAsset', () => {
           fee: 0n,
           expiration: 0,
         })
-        return wallet.post({
+        const { transaction } = await wallet.post({
           transaction: raw,
           account,
         })
+        return transaction
       })
 
       jest.spyOn(wallet, 'mint').mockResolvedValueOnce(mintTransaction)

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -14,6 +14,8 @@ export type PostTransactionRequest = {
 }
 
 export type PostTransactionResponse = {
+  accepted?: boolean
+  broadcasted?: boolean
   hash: string
   transaction: string
 }
@@ -28,6 +30,8 @@ export const PostTransactionRequestSchema: yup.ObjectSchema<PostTransactionReque
 
 export const PostTransactionResponseSchema: yup.ObjectSchema<PostTransactionResponse> = yup
   .object({
+    accepted: yup.bool().optional(),
+    broadcasted: yup.bool().optional(),
     hash: yup.string().defined(),
     transaction: yup.string().defined(),
   })
@@ -44,7 +48,7 @@ routes.register<typeof PostTransactionRequestSchema, PostTransactionResponse>(
     const bytes = Buffer.from(request.data.transaction, 'hex')
     const raw = RawTransactionSerde.deserialize(bytes)
 
-    const transaction = await node.wallet.post({
+    const { accepted, broadcasted, transaction } = await node.wallet.post({
       transaction: raw,
       account,
       broadcast: request.data.broadcast,
@@ -52,6 +56,8 @@ routes.register<typeof PostTransactionRequestSchema, PostTransactionResponse>(
 
     const serialized = transaction.serialize()
     request.end({
+      accepted,
+      broadcasted,
       hash: transaction.hash().toString('hex'),
       transaction: serialized.toString('hex'),
     })

--- a/ironfish/src/wallet/wallet.test.slow.ts
+++ b/ironfish/src/wallet/wallet.test.slow.ts
@@ -512,7 +512,7 @@ describe('Accounts', () => {
         expiration: 0,
       })
 
-      const transaction = await nodeA.wallet.post({
+      const { transaction } = await nodeA.wallet.post({
         transaction: raw,
         account: accountA,
       })
@@ -743,7 +743,7 @@ describe('Accounts', () => {
           expiration: 0,
         })
 
-        const transaction = await nodeA.wallet.post({
+        const { transaction } = await nodeA.wallet.post({
           transaction: raw,
           account: accountA,
         })
@@ -856,7 +856,7 @@ describe('Accounts', () => {
           expiration: 0,
         })
 
-        const transaction = await nodeB.wallet.post({
+        const { transaction } = await nodeA.wallet.post({
           transaction: raw,
           account: accountANodeB,
         })


### PR DESCRIPTION
## Summary

* If `broadcast` is set to true in posting, return if the transaction was accepted into the mempool and broadcasted successfully
* Log out messages in CLI if either the transaction was not accepted or broadcasted

## Testing Plan

Unit tests and running CLI

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

TODO @rohanjadvani 

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
