### PR TITLE
Fix checking result of proof verification and add tests

### DIFF
--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -355,6 +355,13 @@ mod test {
 
         let other_randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
             .randomize(jubjub::Fr::random(thread_rng()), *SPENDING_KEY_GENERATOR);
+
+        assert!(verify_mint_proof(
+            &description.proof,
+            &description.public_inputs(&other_randomized_public_key),
+        )
+        .is_err());
+
         assert!(description
             .verify_signature(&sig_hash, &other_randomized_public_key)
             .is_err());

--- a/ironfish-rust/src/transaction/utils.rs
+++ b/ironfish-rust/src/transaction/utils.rs
@@ -13,7 +13,9 @@ pub(crate) fn verify_spend_proof(
     proof: &groth16::Proof<Bls12>,
     inputs: &[blstrs::Scalar],
 ) -> Result<(), IronfishError> {
-    groth16::verify_proof(&SAPLING.spend_verifying_key, proof, inputs)?;
+    if !groth16::verify_proof(&SAPLING.spend_verifying_key, proof, inputs)? {
+        return Err(IronfishError::VerificationFailed);
+    }
 
     Ok(())
 }
@@ -25,7 +27,9 @@ pub(crate) fn verify_output_proof(
     proof: &groth16::Proof<Bls12>,
     inputs: &[blstrs::Scalar],
 ) -> Result<(), IronfishError> {
-    groth16::verify_proof(&SAPLING.output_verifying_key, proof, inputs)?;
+    if !groth16::verify_proof(&SAPLING.output_verifying_key, proof, inputs)? {
+        return Err(IronfishError::VerificationFailed);
+    }
 
     Ok(())
 }
@@ -37,7 +41,9 @@ pub(crate) fn verify_mint_proof(
     proof: &groth16::Proof<Bls12>,
     inputs: &[blstrs::Scalar],
 ) -> Result<(), IronfishError> {
-    groth16::verify_proof(&SAPLING.mint_verifying_key, proof, inputs)?;
+    if !groth16::verify_proof(&SAPLING.mint_verifying_key, proof, inputs)? {
+        return Err(IronfishError::VerificationFailed);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

When switching from bellman to bellperson, the batch verification function changed. Previously, the proof verification would return a 
`Result` with `Err` in every error case and `Ok(())` otherwise, but now it returns `Err` in some error cases and `Ok(bool)` in cases where the proof 
can't be verified with the given proof verification key. This PR fixes this check and adds tests to verify the change.

## Testing Plan

Adds additional Rust tests and verifies that the tests failed before and pass with this change.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
