### PR TITLE
Add WalletNode interface and connect to RPC handlers

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -59,7 +59,7 @@ export class IronfishNode {
   shutdownPromise: Promise<void> | null = null
   shutdownResolve: (() => void) | null = null
 
-  private constructor({
+  constructor({
     pkg,
     chain,
     files,
@@ -104,7 +104,7 @@ export class IronfishNode {
     this.miningManager = new MiningManager({ chain, memPool, node: this, metrics })
     this.memPool = memPool
     this.workerPool = workerPool
-    this.rpc = new RpcServer({ node: this, wallet }, internal)
+    this.rpc = new RpcServer(this, internal)
     this.logger = logger
     this.pkg = pkg
 

--- a/ironfish/src/rpc/routes/chain/broadcastTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/broadcastTransaction.ts
@@ -4,6 +4,7 @@
 
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { Transaction } from '../../../primitives'
 import { ValidationError } from '../../adapters'
 import { ApiNamespace, routes } from '../router'
@@ -35,8 +36,8 @@ export const BroadcastTransactionResponseSchema: yup.ObjectSchema<BroadcastTrans
 routes.register<typeof BroadcastTransactionRequestSchema, BroadcastTransactionResponse>(
   `${ApiNamespace.chain}/broadcastTransaction`,
   BroadcastTransactionRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     if (!node.peerNetwork.isReady) {
       throw new ValidationError('Cannot broadcast transaction. Peer network is not ready')

--- a/ironfish/src/rpc/routes/chain/estimateFeeRate.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRate.ts
@@ -4,6 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { PRIORITY_LEVELS, PriorityLevel } from '../../../memPool/feeEstimator'
+import { IronfishNode } from '../../../node'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, routes } from '../router'
 
@@ -28,8 +29,8 @@ export const EstimateFeeRateResponseSchema: yup.ObjectSchema<EstimateFeeRateResp
 routes.register<typeof EstimateFeeRateRequestSchema, EstimateFeeRateResponse>(
   `${ApiNamespace.chain}/estimateFeeRate`,
   EstimateFeeRateRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const priority = request.data?.priority ?? 'average'
     const rate = node.memPool.feeEstimator.estimateFeeRate(priority)

--- a/ironfish/src/rpc/routes/chain/estimateFeeRates.ts
+++ b/ironfish/src/rpc/routes/chain/estimateFeeRates.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, routes } from '../router'
 
@@ -28,8 +29,8 @@ export const EstimateFeeRatesResponseSchema: yup.ObjectSchema<EstimateFeeRatesRe
 routes.register<typeof EstimateFeeRatesRequestSchema, EstimateFeeRatesResponse>(
   `${ApiNamespace.chain}/estimateFeeRates`,
   EstimateFeeRatesRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const rates = node.memPool.feeEstimator.estimateFeeRates()
 

--- a/ironfish/src/rpc/routes/chain/exportChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/exportChainStream.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { BlockchainUtils } from '../../../utils/blockchain'
 import { ApiNamespace, routes } from '../router'
 
@@ -61,8 +62,8 @@ export const ExportChainStreamResponseSchema: yup.ObjectSchema<ExportChainStream
 routes.register<typeof ExportChainStreamRequestSchema, ExportChainStreamResponse>(
   `${ApiNamespace.chain}/exportChainStream`,
   ExportChainStreamRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
     Assert.isNotNull(node.chain.head, 'head')
     Assert.isNotNull(node.chain.latest, 'latest')
 

--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -5,6 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { ChainProcessor } from '../../../chainProcessor'
 import { getBlockSize, getTransactionSize } from '../../../network/utils/serializers'
+import { IronfishNode } from '../../../node'
 import { Block, BlockHeader } from '../../../primitives'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { BufferUtils, PromiseUtils } from '../../../utils'
@@ -76,8 +77,8 @@ export const FollowChainStreamResponseSchema: yup.ObjectSchema<FollowChainStream
 routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse>(
   `${ApiNamespace.chain}/followChainStream`,
   FollowChainStreamRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
     const head = request.data?.head ? Buffer.from(request.data.head, 'hex') : null
 
     const processor = new ChainProcessor({

--- a/ironfish/src/rpc/routes/chain/getAsset.ts
+++ b/ironfish/src/rpc/routes/chain/getAsset.ts
@@ -4,6 +4,7 @@
 import { ASSET_ID_LENGTH } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { CurrencyUtils } from '../../../utils'
 import { NotFoundError, ValidationError } from '../../adapters'
 import { ApiNamespace, routes } from '../router'
@@ -44,8 +45,8 @@ export const GetAssetResponse: yup.ObjectSchema<GetAssetResponse> = yup
 routes.register<typeof GetAssetRequestSchema, GetAssetResponse>(
   `${ApiNamespace.chain}/getAsset`,
   GetAssetRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const id = Buffer.from(request.data.id, 'hex')
 

--- a/ironfish/src/rpc/routes/chain/getBlock.ts
+++ b/ironfish/src/rpc/routes/chain/getBlock.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { BlockHeader } from '../../../primitives'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives/block'
 import { BufferUtils } from '../../../utils'
@@ -89,8 +90,8 @@ export const GetBlockResponseSchema: yup.ObjectSchema<GetBlockResponse> = yup
 routes.register<typeof GetBlockRequestSchema, GetBlockResponse>(
   `${ApiNamespace.chain}/getBlock`,
   GetBlockRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     let header: BlockHeader | null = null
     let error = ''

--- a/ironfish/src/rpc/routes/chain/getChainInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getChainInfo.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives/block'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { ApiNamespace, routes } from '../router'
@@ -44,8 +45,8 @@ export const GetChainInfoResponseSchema: yup.ObjectSchema<GetChainInfoResponse> 
 routes.register<typeof GetChainInfoRequestSchema, GetChainInfoResponse>(
   `${ApiNamespace.chain}/getChainInfo`,
   GetChainInfoRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     Assert.isNotNull(node.chain.genesis, 'no genesis')
 

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { ApiNamespace, routes } from '../router'
 
 interface ConsensusParameters {
@@ -35,8 +36,8 @@ export const GetConsensusParametersResponseSchema: yup.ObjectSchema<GetConsensus
 routes.register<typeof GetConsensusParametersRequestSchema, GetConsensusParametersResponse>(
   `${ApiNamespace.chain}/getConsensusParameters`,
   GetConsensusParametersRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
     Assert.isNotNull(node.chain.consensus, 'no consensus parameters')
 
     const consensusParameters = node.chain.consensus.parameters

--- a/ironfish/src/rpc/routes/chain/getDifficulty.ts
+++ b/ironfish/src/rpc/routes/chain/getDifficulty.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { ValidationError } from '../../adapters'
 import { ApiNamespace, routes } from '../router'
 
@@ -35,8 +36,8 @@ export const GetDifficultyResponseSchema: yup.ObjectSchema<GetDifficultyResponse
 routes.register<typeof GetDifficultyRequestSchema, GetDifficultyResponse>(
   `${ApiNamespace.chain}/getDifficulty`,
   GetDifficultyRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     let sequence = node.chain.head.sequence
     let block = node.chain.head

--- a/ironfish/src/rpc/routes/chain/getNetworkHashPower.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkHashPower.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { BigIntUtils } from '../../../utils'
 import { ValidationError } from '../../adapters'
 import { ApiNamespace, routes } from '../router'
@@ -38,8 +39,8 @@ export const GetNetworkHashPowerResponseSchema: yup.ObjectSchema<GetNetworkHashP
 routes.register<typeof GetNetworkHashPowerRequestSchema, GetNetworkHashPowerResponse>(
   `${ApiNamespace.chain}/getNetworkHashPower`,
   GetNetworkHashPowerRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     let blocks = request.data?.blocks ?? 120
     let sequence = request.data?.sequence ?? -1

--- a/ironfish/src/rpc/routes/chain/getNetworkInfo.ts
+++ b/ironfish/src/rpc/routes/chain/getNetworkInfo.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { ApiNamespace, routes } from '../router'
 
 export type GetNetworkInfoRequest = undefined
@@ -23,8 +24,8 @@ export const GetNetworkInfoResponseSchema: yup.ObjectSchema<GetNetworkInfoRespon
 routes.register<typeof GetNetworkInfoRequestSchema, GetNetworkInfoResponse>(
   `${ApiNamespace.chain}/getNetworkInfo`,
   GetNetworkInfoRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     request.end({
       networkId: node.internal.get('networkId'),

--- a/ironfish/src/rpc/routes/chain/getNoteWitness.ts
+++ b/ironfish/src/rpc/routes/chain/getNoteWitness.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives'
 import { ValidationError } from '../../adapters'
 import { ApiNamespace, routes } from '../router'
@@ -48,8 +49,8 @@ export const GetNoteWitnessResponseSchema: yup.ObjectSchema<GetNoteWitnessRespon
 routes.register<typeof GetNoteWitnessRequestSchema, GetNoteWitnessResponse>(
   `${ApiNamespace.chain}/getNoteWitness`,
   GetNoteWitnessRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
     const { chain } = node
 
     const confirmations = request.data.confirmations ?? node.config.get('confirmations')

--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { BlockHashSerdeInstance } from '../../../serde'
 import { CurrencyUtils } from '../../../utils'
 import { NotFoundError, ValidationError } from '../../adapters'
@@ -80,8 +81,8 @@ export const GetTransactionResponseSchema: yup.ObjectSchema<GetTransactionRespon
 routes.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
   `${ApiNamespace.chain}/getTransaction`,
   GetTransactionRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     if (!request.data.transactionHash) {
       throw new ValidationError(`Missing transaction hash`)

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -4,6 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { ChainProcessor } from '../../../chainProcessor'
+import { IronfishNode } from '../../../node'
 import { Block } from '../../../primitives/block'
 import { BlockHeader } from '../../../primitives/blockheader'
 import { CurrencyUtils } from '../../../utils'
@@ -125,8 +126,9 @@ export const GetTransactionStreamResponseSchema: yup.ObjectSchema<GetTransaction
 routes.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamResponse>(
   `${ApiNamespace.chain}/getTransactionStream`,
   GetTransactionStreamRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
+
     if (!isValidIncomingViewKey(request.data.incomingViewKey)) {
       throw new ValidationError(`incomingViewKey is not valid`)
     }

--- a/ironfish/src/rpc/routes/chain/showChain.ts
+++ b/ironfish/src/rpc/routes/chain/showChain.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { ApiNamespace, routes } from '../router'
 import { renderChain } from './utils'
 
@@ -36,8 +37,8 @@ export const ShowChainResponseSchema: yup.ObjectSchema<ShowChainResponse> = yup
 routes.register<typeof ShowChainRequestSchema, ShowChainResponse>(
   `${ApiNamespace.chain}/showChain`,
   ShowChainRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const content = await renderChain(node.chain, request.data?.start, request.data?.stop, {
       indent: '  ',

--- a/ironfish/src/rpc/routes/config/getConfig.ts
+++ b/ironfish/src/rpc/routes/config/getConfig.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
 import { ValidationError } from '../../adapters/errors'
 import { ApiNamespace, routes } from '../router'
@@ -22,9 +21,7 @@ export const GetConfigResponseSchema: yup.ObjectSchema<GetConfigResponse> = Conf
 routes.register<typeof GetConfigRequestSchema, GetConfigResponse>(
   `${ApiNamespace.config}/getConfig`,
   GetConfigRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
-
+  (request, node): void => {
     if (request.data?.name && !(request.data.name in node.config.defaults)) {
       throw new ValidationError(`No config option ${String(request.data.name)}`)
     }

--- a/ironfish/src/rpc/routes/config/setConfig.ts
+++ b/ironfish/src/rpc/routes/config/setConfig.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
 import { ApiNamespace, routes } from '../router'
 import { setUnknownConfigValue } from './uploadConfig'
@@ -22,9 +21,7 @@ export const SetConfigResponseSchema: yup.ObjectSchema<SetConfigResponse> = Conf
 routes.register<typeof SetConfigRequestSchema, SetConfigResponse>(
   `${ApiNamespace.config}/setConfig`,
   SetConfigRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     setUnknownConfigValue(node.config, request.data.name, request.data.value)
     await node.config.save()
     request.end()

--- a/ironfish/src/rpc/routes/config/unsetConfig.ts
+++ b/ironfish/src/rpc/routes/config/unsetConfig.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
 import { ApiNamespace, routes } from '../router'
 import { setUnknownConfigValue } from './uploadConfig'
@@ -22,9 +21,7 @@ export const UnsetConfigResponseSchema: yup.ObjectSchema<UnsetConfigResponse> =
 routes.register<typeof UnsetConfigRequestSchema, UnsetConfigResponse>(
   `${ApiNamespace.config}/unsetConfig`,
   UnsetConfigRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     setUnknownConfigValue(node.config, request.data.name)
     await node.config.save()
     request.end()

--- a/ironfish/src/rpc/routes/config/uploadConfig.ts
+++ b/ironfish/src/rpc/routes/config/uploadConfig.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { Config, ConfigOptions, ConfigOptionsSchema } from '../../../fileStores/config'
 import { ValidationError } from '../../adapters/errors'
 import { ApiNamespace, routes } from '../router'
@@ -20,9 +19,7 @@ export const UploadConfigResponseSchema: yup.ObjectSchema<UploadConfigResponse> 
 routes.register<typeof UploadConfigRequestSchema, UploadConfigResponse>(
   `${ApiNamespace.config}/uploadConfig`,
   UploadConfigRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     clearConfig(node.config)
 
     for (const key of Object.keys(request.data.config)) {

--- a/ironfish/src/rpc/routes/event/onGossip.ts
+++ b/ironfish/src/rpc/routes/event/onGossip.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { BlockHeader } from '../../../primitives'
 import { ApiNamespace, routes } from '../router'
 import { RpcBlockHeader, RpcBlockHeaderSchema, serializeRpcBlockHeader } from './types'
@@ -22,8 +23,8 @@ export const OnGossipResponseSchema: yup.ObjectSchema<OnGossipResponse> = yup
 routes.register<typeof OnGossipRequestSchema, OnGossipResponse>(
   `${ApiNamespace.event}/onGossip`,
   OnGossipRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     function onGossip(header: BlockHeader) {
       const serialized = serializeRpcBlockHeader(header)

--- a/ironfish/src/rpc/routes/event/onReorganizeChain.ts
+++ b/ironfish/src/rpc/routes/event/onReorganizeChain.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { BlockHeader } from '../../../primitives'
 import { ApiNamespace, routes } from '../router'
 import { RpcBlockHeader, RpcBlockHeaderSchema, serializeRpcBlockHeader } from './types'
@@ -28,8 +29,8 @@ export const OnReorganizeChainResponseSchema: yup.ObjectSchema<OnReorganizeChain
 routes.register<typeof OnReorganizeChainRequestSchema, OnReorganizeChainResponse>(
   `${ApiNamespace.event}/onReorganizeChain`,
   OnReorganizeChainRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     function onReorganizeChain(oldHead: BlockHeader, newHead: BlockHeader, fork: BlockHeader) {
       request.stream({

--- a/ironfish/src/rpc/routes/event/onTransactionGossip.ts
+++ b/ironfish/src/rpc/routes/event/onTransactionGossip.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { Transaction } from '../../../primitives'
 import { ApiNamespace, routes } from '../router'
 
@@ -26,8 +27,8 @@ export const OnTransactionGossipResponseSchema: yup.ObjectSchema<OnTransactionGo
 routes.register<typeof OnTransactionGossipRequestSchema, OnTransactionGossipResponse>(
   `${ApiNamespace.event}/onTransactionGossip`,
   OnTransactionGossipRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const onTransactionGossip = (transaction: Transaction) => {
       request.stream({

--- a/ironfish/src/rpc/routes/faucet/getFunds.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.ts
@@ -4,6 +4,7 @@
 import { AxiosError } from 'axios'
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { WebApi } from '../../../webApi'
 import { ERROR_CODES, ResponseError } from '../../adapters'
 import { ApiNamespace, routes } from '../router'
@@ -28,8 +29,8 @@ export const GetFundsResponseSchema: yup.ObjectSchema<GetFundsResponse> = yup
 routes.register<typeof GetFundsRequestSchema, GetFundsResponse>(
   `${ApiNamespace.faucet}/getFunds`,
   GetFundsRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
     // check node network id
     const networkId = node.internal.get('networkId')
 

--- a/ironfish/src/rpc/routes/mempool/acceptTransaction.ts
+++ b/ironfish/src/rpc/routes/mempool/acceptTransaction.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { Transaction } from '../../../primitives'
 import { ApiNamespace, routes } from '../router'
 
@@ -31,8 +32,8 @@ export const AcceptTransactionResponseSchema: yup.ObjectSchema<AcceptTransaction
 routes.register<typeof AcceptTransactionRequestSchema, AcceptTransactionResponse>(
   `${ApiNamespace.mempool}/acceptTransaction`,
   AcceptTransactionRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const data = Buffer.from(request.data.transaction, 'hex')
     const transaction = new Transaction(data)

--- a/ironfish/src/rpc/routes/mempool/getStatus.ts
+++ b/ironfish/src/rpc/routes/mempool/getStatus.ts
@@ -51,8 +51,8 @@ export const GetMempoolStatusResponseSchema: yup.ObjectSchema<GetMempoolStatusRe
 routes.register<typeof GetMempoolStatusRequestSchema, GetMempoolStatusResponse>(
   `${ApiNamespace.mempool}/getStatus`,
   GetMempoolStatusRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const status = getStatus(node)
 

--- a/ironfish/src/rpc/routes/mempool/getTransactions.ts
+++ b/ironfish/src/rpc/routes/mempool/getTransactions.ts
@@ -4,6 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { getFeeRate } from '../../../memPool'
+import { IronfishNode } from '../../../node'
 import { Transaction } from '../../../primitives'
 import { ApiNamespace, routes } from '../router'
 
@@ -58,8 +59,8 @@ export const MempoolTransactionResponseSchema: yup.ObjectSchema<GetMempoolTransa
 routes.register<typeof MempoolTransactionsRequestSchema, GetMempoolTransactionResponse>(
   `${ApiNamespace.mempool}/getTransactions`,
   MempoolTransactionsRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     let position = 0
     let streamed = 0

--- a/ironfish/src/rpc/routes/miner/blockTemplateStream.ts
+++ b/ironfish/src/rpc/routes/miner/blockTemplateStream.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { SerializedBlockTemplate } from '../../../serde/BlockTemplateSerde'
 import { ApiNamespace, routes } from '../router'
 
@@ -44,8 +45,8 @@ export const BlockTemplateStreamResponseSchema: yup.ObjectSchema<BlockTemplateSt
 routes.register<typeof BlockTemplateStreamRequestSchema, BlockTemplateStreamResponse>(
   `${ApiNamespace.miner}/blockTemplateStream`,
   BlockTemplateStreamRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     if (!node.chain.synced && !node.config.get('miningForce')) {
       node.logger.info(

--- a/ironfish/src/rpc/routes/miner/submitBlock.ts
+++ b/ironfish/src/rpc/routes/miner/submitBlock.ts
@@ -4,6 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { MINED_RESULT } from '../../../mining/manager'
+import { IronfishNode } from '../../../node'
 import { SerializedBlockTemplate } from '../../../serde'
 import { ApiNamespace, routes } from '../router'
 
@@ -63,8 +64,8 @@ export const SubmitBlockResponseSchema: yup.ObjectSchema<SubmitBlockResponse> = 
 routes.register<typeof SubmitBlockRequestSchema, SubmitBlockResponse>(
   `${ApiNamespace.miner}/submitBlock`,
   SubmitBlockRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const result = await node.miningManager.submitBlockTemplate(request.data)
 

--- a/ironfish/src/rpc/routes/node/getLogStream.ts
+++ b/ironfish/src/rpc/routes/node/getLogStream.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ConsolaReporterLogObject } from 'consola'
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { InterceptReporter } from '../../../logger'
 import { IJSON } from '../../../serde'
 import { ApiNamespace, routes } from '../router'
@@ -37,9 +36,7 @@ export const GetLogStreamResponseSchema: yup.ObjectSchema<GetLogStreamResponse> 
 routes.register<typeof GetLogStreamRequestSchema, GetLogStreamResponse>(
   `${ApiNamespace.node}/getLogStream`,
   GetLogStreamRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
-
+  (request, node): void => {
     const reporter = new InterceptReporter((logObj: ConsolaReporterLogObject): void => {
       request.stream({
         level: String(logObj.level),

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -255,8 +255,8 @@ export const GetStatusResponseSchema: yup.ObjectSchema<GetNodeStatusResponse> = 
 routes.register<typeof GetStatusRequestSchema, GetNodeStatusResponse>(
   `${ApiNamespace.node}/getStatus`,
   GetStatusRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const status = getStatus(node)
 

--- a/ironfish/src/rpc/routes/node/stopNode.ts
+++ b/ironfish/src/rpc/routes/node/stopNode.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { IronfishNode } from '../../../node'
 import { ApiNamespace, routes } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -20,8 +21,8 @@ export const StopNodeResponseSchema: yup.MixedSchema<StopNodeRequest> = yup
 routes.register<typeof StopNodeRequestSchema, StopNodeResponse>(
   `${ApiNamespace.node}/stopNode`,
   StopNodeRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     node.logger.withTag('stopnode').info('Shutting down')
     request.end()

--- a/ironfish/src/rpc/routes/peer/addPeer.ts
+++ b/ironfish/src/rpc/routes/peer/addPeer.ts
@@ -4,6 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { DEFAULT_WEBSOCKET_PORT } from '../../../fileStores/config'
+import { IronfishNode } from '../../../node'
 import { ApiNamespace, routes } from '../router'
 
 export type AddPeerRequest = {
@@ -34,8 +35,8 @@ export const AddPeerResponseSchema: yup.ObjectSchema<AddPeerResponse> = yup
 routes.register<typeof AddPeerRequestSchema, AddPeerResponse>(
   `${ApiNamespace.peer}/addPeer`,
   AddPeerRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const peerManager = node.peerNetwork.peerManager
     const { host, port, whitelist } = request.data

--- a/ironfish/src/rpc/routes/peer/getBannedPeers.ts
+++ b/ironfish/src/rpc/routes/peer/getBannedPeers.ts
@@ -4,6 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { PeerNetwork } from '../../../network'
+import { IronfishNode } from '../../../node'
 import { ApiNamespace, routes } from '../router'
 
 export type BannedPeerResponse = {
@@ -46,8 +47,8 @@ export const GetBannedPeersResponseSchema: yup.ObjectSchema<GetBannedPeersRespon
 routes.register<typeof GetBannedPeersRequestSchema, GetBannedPeersResponse>(
   `${ApiNamespace.peer}/getBannedPeers`,
   GetBannedPeersRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const peerNetwork = node.peerNetwork
 

--- a/ironfish/src/rpc/routes/peer/getPeer.ts
+++ b/ironfish/src/rpc/routes/peer/getPeer.ts
@@ -4,6 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { Connection, PeerNetwork } from '../../../network'
+import { IronfishNode } from '../../../node'
 import { ApiNamespace, routes } from '../router'
 import { PeerResponse } from './getPeers'
 
@@ -61,8 +62,8 @@ export const GetPeerResponseSchema: yup.ObjectSchema<GetPeerResponse> = yup
 routes.register<typeof GetPeerRequestSchema, GetPeerResponse>(
   `${ApiNamespace.peer}/getPeer`,
   GetPeerRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const peerNetwork = node.peerNetwork
 

--- a/ironfish/src/rpc/routes/peer/getPeerMessages.ts
+++ b/ironfish/src/rpc/routes/peer/getPeerMessages.ts
@@ -5,6 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { Connection, PeerNetwork } from '../../../network'
 import { NetworkMessageType } from '../../../network/types'
+import { IronfishNode } from '../../../node'
 import { IJSON } from '../../../serde'
 import { ApiNamespace, routes } from '../router'
 
@@ -61,8 +62,8 @@ export const GetPeerMessagesResponseSchema: yup.ObjectSchema<GetPeerMessagesResp
 routes.register<typeof GetPeerMessagesRequestSchema, GetPeerMessagesResponse>(
   `${ApiNamespace.peer}/getPeerMessages`,
   GetPeerMessagesRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const peerNetwork = node.peerNetwork
 

--- a/ironfish/src/rpc/routes/peer/getPeers.ts
+++ b/ironfish/src/rpc/routes/peer/getPeers.ts
@@ -5,6 +5,7 @@ import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { Connection, PeerNetwork } from '../../../network'
 import { Features } from '../../../network/peers/peerFeatures'
+import { IronfishNode } from '../../../node'
 import { ApiNamespace, routes } from '../router'
 
 type ConnectionState = Connection['state']['type'] | ''
@@ -88,8 +89,8 @@ export const GetPeersResponseSchema: yup.ObjectSchema<GetPeersResponse> = yup
 routes.register<typeof GetPeersRequestSchema, GetPeersResponse>(
   `${ApiNamespace.peer}/getPeers`,
   GetPeersRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
+  (request, node): void => {
+    Assert.isInstanceOf(node, IronfishNode)
 
     const peerNetwork = node.peerNetwork
 

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -5,7 +5,7 @@ import { Assert } from '../../assert'
 import { IronfishNode } from '../../node'
 import { YupSchema, YupSchemaResult, YupUtils } from '../../utils'
 import { StrEnumUtils } from '../../utils/enums'
-import { Wallet } from '../../wallet'
+import { WalletNode } from '../../walletNode'
 import { ERROR_CODES } from '../adapters'
 import { ResponseError, ValidationError } from '../adapters/errors'
 import { RpcRequest } from '../request'
@@ -27,7 +27,7 @@ export enum ApiNamespace {
 
 export const ALL_API_NAMESPACES = StrEnumUtils.getValues(ApiNamespace)
 
-export type RequestContext = { node?: IronfishNode; wallet?: Wallet }
+export type RequestContext = IronfishNode | WalletNode
 
 export type RouteHandler<TRequest = unknown, TResponse = unknown> = (
   request: RpcRequest<TRequest, TResponse>,
@@ -139,6 +139,12 @@ class Routes {
     }
 
     return copy
+  }
+}
+
+export function isFullNode(x: unknown, message?: string): asserts x is IronfishNode {
+  if (!(x instanceof IronfishNode)) {
+    throw new Error(message || `Expected value to be an IronfishNode but was ${typeof x}`)
   }
 }
 

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -142,10 +142,4 @@ class Routes {
   }
 }
 
-export function isFullNode(x: unknown, message?: string): asserts x is IronfishNode {
-  if (!(x instanceof IronfishNode)) {
-    throw new Error(message || `Expected value to be an IronfishNode but was ${typeof x}`)
-  }
-}
-
 export const routes = new Routes()

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { Verifier } from '../../../consensus'
 import { Transaction } from '../../../primitives'
 import { AsyncUtils } from '../../../utils'
@@ -38,9 +37,7 @@ export const AddTransactionResponseSchema: yup.ObjectSchema<AddTransactionRespon
 routes.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
   `${ApiNamespace.wallet}/addTransaction`,
   AddTransactionRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const data = Buffer.from(request.data.transaction, 'hex')
     const transaction = new Transaction(data)
 

--- a/ironfish/src/rpc/routes/wallet/burnAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.ts
@@ -48,8 +48,7 @@ export const BurnAssetResponseSchema: yup.ObjectSchema<BurnAssetResponse> = yup
 routes.register<typeof BurnAssetRequestSchema, BurnAssetResponse>(
   `${ApiNamespace.wallet}/burnAsset`,
   BurnAssetRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     const fee = CurrencyUtils.decode(request.data.fee)

--- a/ironfish/src/rpc/routes/wallet/create.ts
+++ b/ironfish/src/rpc/routes/wallet/create.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { ERROR_CODES, ValidationError } from '../../adapters'
 import { ApiNamespace, routes } from '../router'
 
@@ -31,9 +30,7 @@ export const CreateAccountResponseSchema: yup.ObjectSchema<CreateAccountResponse
 routes.register<typeof CreateAccountRequestSchema, CreateAccountResponse>(
   `${ApiNamespace.wallet}/create`,
   CreateAccountRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const name = request.data.name
 
     if (node.wallet.accountExists(name)) {

--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -102,8 +102,7 @@ export const CreateTransactionResponseSchema: yup.ObjectSchema<CreateTransaction
 routes.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse>(
   `${ApiNamespace.wallet}/createTransaction`,
   CreateTransactionRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     const params: Parameters<Wallet['createTransaction']>[0] = {

--- a/ironfish/src/rpc/routes/wallet/estimateFeeRates.ts
+++ b/ironfish/src/rpc/routes/wallet/estimateFeeRates.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Assert } from '../../../assert'
 import {
   EstimateFeeRatesRequestSchema,
   EstimateFeeRatesResponse,
@@ -11,10 +10,8 @@ import { ApiNamespace, routes } from '../router'
 routes.register<typeof EstimateFeeRatesRequestSchema, EstimateFeeRatesResponse>(
   `${ApiNamespace.wallet}/estimateFeeRates`,
   EstimateFeeRatesRequestSchema,
-  async (request, { wallet }): Promise<void> => {
-    Assert.isNotUndefined(wallet)
-
-    const rates = await wallet.nodeClient.chain.estimateFeeRates()
+  async (request, node): Promise<void> => {
+    const rates = await node.wallet.nodeClient.chain.estimateFeeRates()
 
     request.end({ ...rates.content })
   },

--- a/ironfish/src/rpc/routes/wallet/exportAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/exportAccount.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { LanguageKey, LanguageUtils } from '../../../utils'
 import { encodeAccount } from '../../../wallet/account/encoder/account'
 import { AccountFormat } from '../../../wallet/account/encoder/encoder'
@@ -38,9 +37,7 @@ export const ExportAccountResponseSchema: yup.ObjectSchema<ExportAccountResponse
 routes.register<typeof ExportAccountRequestSchema, ExportAccountResponse>(
   `${ApiNamespace.wallet}/exportAccount`,
   ExportAccountRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
-
+  (request, node): void => {
     const account = getAccount(node.wallet, request.data.account)
     const { id: _, ...accountInfo } = account.serialize()
     if (request.data.viewOnly) {

--- a/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, routes } from '../router'
 import { RpcWalletNote, RpcWalletNoteSchema } from './types'
@@ -25,9 +24,7 @@ export const GetAccountNotesStreamResponseSchema: yup.ObjectSchema<GetAccountNot
 routes.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStreamResponse>(
   `${ApiNamespace.wallet}/getAccountNotesStream`,
   GetAccountNotesStreamRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     for await (const transaction of account.getTransactionsByTime()) {

--- a/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { TransactionStatus, TransactionType } from '../../../wallet'
 import { RpcSpend, RpcSpendSchema } from '../chain'
 import { ApiNamespace, routes } from '../router'
@@ -91,9 +90,7 @@ export const GetAccountTransactionResponseSchema: yup.ObjectSchema<GetAccountTra
 routes.register<typeof GetAccountTransactionRequestSchema, GetAccountTransactionResponse>(
   `${ApiNamespace.wallet}/getAccountTransaction`,
   GetAccountTransactionRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     const transactionHash = Buffer.from(request.data.hash, 'hex')

--- a/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives'
 import { TransactionStatus, TransactionType, Wallet } from '../../../wallet'
 import { Account } from '../../../wallet/account/account'
@@ -99,9 +98,7 @@ export const GetAccountTransactionsResponseSchema: yup.ObjectSchema<GetAccountTr
 routes.register<typeof GetAccountTransactionsRequestSchema, GetAccountTransactionsResponse>(
   `${ApiNamespace.wallet}/getAccountTransactions`,
   GetAccountTransactionsRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     const headSequence = (await account.getHead())?.sequence ?? null

--- a/ironfish/src/rpc/routes/wallet/getAccounts.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccounts.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { Account } from '../../../wallet'
 import { ApiNamespace, routes } from '../router'
 
@@ -26,9 +25,7 @@ export const GetAccountsResponseSchema: yup.ObjectSchema<GetAccountsResponse> = 
 routes.register<typeof GetAccountsRequestSchema, GetAccountsResponse>(
   `${ApiNamespace.wallet}/getAccounts`,
   GetAccountsRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
-
+  (request, node): void => {
     let accounts: Account[] = []
 
     if (request.data?.default) {

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { HeadValue } from '../../../wallet/walletdb/headValue'
 import { ApiNamespace, routes } from '../router'
 
@@ -43,9 +42,7 @@ export const GetAccountStatusResponseSchema: yup.ObjectSchema<GetAccountStatusRe
 routes.register<typeof GetAccountStatusRequestSchema, GetAccountStatusResponse>(
   `${ApiNamespace.wallet}/getAccountsStatus`,
   GetAccountStatusRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const heads = new Map<string, HeadValue | null>()
     for await (const { accountId, head } of node.wallet.walletDb.loadHeads()) {
       heads.set(accountId, head)

--- a/ironfish/src/rpc/routes/wallet/getAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/getAsset.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ASSET_ID_LENGTH } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { AssetVerification } from '../../../assets'
 import { CurrencyUtils } from '../../../utils'
 import { NotFoundError, ValidationError } from '../../adapters'
@@ -57,9 +56,7 @@ export const GetWalletAssetResponse: yup.ObjectSchema<GetWalletAssetResponse> = 
 routes.register<typeof GetWalletAssetRequestSchema, GetWalletAssetResponse>(
   `${ApiNamespace.wallet}/getAsset`,
   GetWalletAssetRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     const id = Buffer.from(request.data.id, 'hex')

--- a/ironfish/src/rpc/routes/wallet/getAssets.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { AssetVerification } from '../../../assets'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, routes } from '../router'
@@ -50,9 +49,7 @@ export const GetAssetsResponseSchema: yup.ObjectSchema<GetAssetsResponse> = yup
 routes.register<typeof GetAssetsRequestSchema, GetAssetsResponse>(
   `${ApiNamespace.wallet}/getAssets`,
   GetAssetsRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     for await (const asset of account.getAssets()) {

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { AssetVerification } from '../../../assets'
 import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
@@ -61,9 +60,7 @@ export const GetBalanceResponseSchema: yup.ObjectSchema<GetBalanceResponse> = yu
 routes.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
   `${ApiNamespace.wallet}/getBalance`,
   GetBalanceRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const confirmations = request.data?.confirmations ?? node.config.get('confirmations')
 
     const account = getAccount(node.wallet, request.data?.account)

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { AssetVerification } from '../../../assets'
 import { CurrencyUtils } from '../../../utils'
 import { ApiNamespace, routes } from '../router'
@@ -73,9 +72,7 @@ export const GetBalancesResponseSchema: yup.ObjectSchema<GetBalancesResponse> = 
 routes.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
   `${ApiNamespace.wallet}/getBalances`,
   GetBalancesRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     const balances = []

--- a/ironfish/src/rpc/routes/wallet/getDefaultAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/getDefaultAccount.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { ApiNamespace, routes } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -28,9 +27,7 @@ export const GetDefaultAccountResponseSchema: yup.ObjectSchema<GetDefaultAccount
 routes.register<typeof GetDefaultAccountRequestSchema, GetDefaultAccountResponse>(
   `${ApiNamespace.wallet}/getDefaultAccount`,
   GetDefaultAccountRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
-
+  (request, node): void => {
     const account = node.wallet.getDefaultAccount()
     request.end({ account: account ? { name: account.name } : null })
   },

--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { ApiNamespace, routes } from '../router'
 import { RpcWalletNote, RpcWalletNoteSchema } from './types'
 import { getAccount, serializeRpcWalletNote } from './utils'
@@ -72,9 +71,7 @@ export const GetNotesResponseSchema: yup.ObjectSchema<GetNotesResponse> = yup
 routes.register<typeof GetNotesRequestSchema, GetNotesResponse>(
   `${ApiNamespace.wallet}/getNotes`,
   GetNotesRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
     const pageSize = request.data.pageSize ?? DEFAULT_PAGE_SIZE
     const pageCursor = request.data.pageCursor

--- a/ironfish/src/rpc/routes/wallet/getPublicKey.ts
+++ b/ironfish/src/rpc/routes/wallet/getPublicKey.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
@@ -25,9 +24,7 @@ export const GetPublicKeyResponseSchema: yup.ObjectSchema<GetPublicKeyResponse> 
 routes.register<typeof GetPublicKeyRequestSchema, GetPublicKeyResponse>(
   `${ApiNamespace.wallet}/getPublicKey`,
   GetPublicKeyRequestSchema,
-  (request, { node }): void => {
-    Assert.isNotUndefined(node)
-
+  (request, node): void => {
     const account = getAccount(node.wallet, request.data.account)
 
     request.end({

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { v4 as uuid } from 'uuid'
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { decodeAccount } from '../../../wallet/account/encoder/account'
 import { ApiNamespace, routes } from '../router'
 import { RpcAccountImport } from './types'
@@ -40,9 +39,7 @@ export const ImportAccountResponseSchema: yup.ObjectSchema<ImportResponse> = yup
 routes.register<typeof ImportAccountRequestSchema, ImportResponse>(
   `${ApiNamespace.wallet}/importAccount`,
   ImportAccountRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     let accountImport = null
     if (typeof request.data.account === 'string') {
       accountImport = decodeAccount(request.data.account, {

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -54,8 +54,7 @@ export const MintAssetResponseSchema: yup.ObjectSchema<MintAssetResponse> = yup
 routes.register<typeof MintAssetRequestSchema, MintAssetResponse>(
   `${ApiNamespace.wallet}/mintAsset`,
   MintAssetRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     const fee = CurrencyUtils.decode(request.data.fee)

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { RawTransactionSerde } from '../../../primitives/rawTransaction'
 import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
@@ -40,9 +39,7 @@ export const PostTransactionResponseSchema: yup.ObjectSchema<PostTransactionResp
 routes.register<typeof PostTransactionRequestSchema, PostTransactionResponse>(
   `${ApiNamespace.wallet}/postTransaction`,
   PostTransactionRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     const bytes = Buffer.from(request.data.transaction, 'hex')

--- a/ironfish/src/rpc/routes/wallet/remove.ts
+++ b/ironfish/src/rpc/routes/wallet/remove.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
@@ -26,9 +25,7 @@ export const RemoveAccountResponseSchema: yup.ObjectSchema<RemoveAccountResponse
 routes.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
   `${ApiNamespace.wallet}/remove`,
   RemoveAccountRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     if (!request.data.confirm) {

--- a/ironfish/src/rpc/routes/wallet/rename.ts
+++ b/ironfish/src/rpc/routes/wallet/rename.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
@@ -23,9 +22,7 @@ export const RenameAccountResponseSchema: yup.MixedSchema<RenameAccountResponse>
 routes.register<typeof RenameAccountRequestSchema, RenameAccountResponse>(
   `${ApiNamespace.wallet}/rename`,
   RenameAccountRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
     await account.setName(request.data.newName)
     request.end()

--- a/ironfish/src/rpc/routes/wallet/rescanAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/rescanAccount.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { GENESIS_BLOCK_SEQUENCE } from '../../../primitives'
 import { ValidationError } from '../../adapters/errors'
 import { ApiNamespace, routes } from '../router'
@@ -28,9 +27,7 @@ export const RescanAccountResponseSchema: yup.ObjectSchema<RescanAccountResponse
 routes.register<typeof RescanAccountRequestSchema, RescanAccountResponse>(
   `${ApiNamespace.wallet}/rescanAccount`,
   RescanAccountRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     let scan = node.wallet.scan
 
     if (scan && !request.data.follow) {

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -4,7 +4,6 @@
 import { Asset, MEMO_LENGTH } from '@ironfish/rust-nodejs'
 import { BufferMap } from 'buffer-map'
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { CurrencyUtils, YupUtils } from '../../../utils'
 import { Wallet } from '../../../wallet'
 import { NotEnoughFundsError } from '../../../wallet/errors'
@@ -67,9 +66,7 @@ export const SendTransactionResponseSchema: yup.ObjectSchema<SendTransactionResp
 routes.register<typeof SendTransactionRequestSchema, SendTransactionResponse>(
   `${ApiNamespace.wallet}/sendTransaction`,
   SendTransactionRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 
     const synced = (await node.wallet.nodeClient.node.getStatus()).content?.blockchain.synced

--- a/ironfish/src/rpc/routes/wallet/use.ts
+++ b/ironfish/src/rpc/routes/wallet/use.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
 import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
@@ -22,9 +21,7 @@ export const UseAccountResponseSchema: yup.MixedSchema<UseAccountResponse> = yup
 routes.register<typeof UseAccountRequestSchema, UseAccountResponse>(
   `${ApiNamespace.wallet}/use`,
   UseAccountRequestSchema,
-  async (request, { node }): Promise<void> => {
-    Assert.isNotUndefined(node)
-
+  async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
     await node.wallet.setDefaultAccount(account.name)
     request.end()

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -134,7 +134,7 @@ describe('IronfishSdk', () => {
         expect(client).toBeInstanceOf(RpcMemoryClient)
         const memoryClient = client as RpcMemoryClient
         Assert.isNotUndefined(memoryClient.router)
-        expect(memoryClient.router.server.context.node).toBe(node)
+        expect(memoryClient.router.server.context).toBe(node)
       })
     })
 

--- a/ironfish/src/walletNode.ts
+++ b/ironfish/src/walletNode.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { AssetsVerifier } from './assets'
+import { Config } from './fileStores'
+import { Logger } from './logger'
+import { RpcServer } from './rpc'
+import { Wallet } from './wallet/wallet'
+import { WorkerPool } from './workerPool'
+
+export type WalletNode = {
+  wallet: Wallet
+  config: Config
+  logger: Logger
+  assetsVerifier: AssetsVerifier
+  workerPool: WorkerPool
+  rpc: RpcServer
+}


### PR DESCRIPTION
## Summary
Creating a similar interface for a full node (IronfishNode) and a standalone wallet (WalletNode) makes RPC reqeust handlers much easier to manage. This allows the standalone wallet to use the `/config` `/rpc` and `/workers` RPC endpoints without changes. The full `WalletNode` will be created in a future PR.   

## Testing Plan
Unit tests + running local node

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
