### PR TITLE
refactor(ironfish): Check for backfill before opening db in migration 19

### DIFF
--- a/ironfish/src/migrations/data/000-template.ts
+++ b/ironfish/src/migrations/data/000-template.ts
@@ -3,16 +3,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 import { GetStores } from './000-template/stores'
 
 export class Migration000 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     /* replace line below with node.chain.location if applying migration to the blockchain
      * database
      */
@@ -20,7 +20,7 @@ export class Migration000 extends Migration {
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -53,7 +53,7 @@ export class Migration000 extends Migration {
    * Writing a backwards migration is optional but suggested
    */
   async backward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/014-blockchain.ts
+++ b/ironfish/src/migrations/data/014-blockchain.ts
@@ -2,15 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Assert } from '../../assert'
 import { IronfishNode } from '../../node'
 import { IDatabase } from '../../storage'
 import { createDB } from '../../storage/utils'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 
 export class Migration014 extends Migration {
   path = __filename
 
-  async prepare(node: IronfishNode): Promise<IDatabase> {
+  async prepare(node: Node): Promise<IDatabase> {
+    Assert.isInstanceOf(node, IronfishNode)
     await node.files.mkdir(node.chain.location, { recursive: true })
     return createDB({ location: node.chain.location })
   }

--- a/ironfish/src/migrations/data/015-wallet.ts
+++ b/ironfish/src/migrations/data/015-wallet.ts
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { IronfishNode } from '../../node'
 import { IDatabase } from '../../storage'
 import { createDB } from '../../storage/utils'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 
 export class Migration015 extends Migration {
   path = __filename
 
-  async prepare(node: IronfishNode): Promise<IDatabase> {
+  async prepare(node: Node): Promise<IDatabase> {
     await node.files.mkdir(node.config.walletDatabasePath, { recursive: true })
     return createDB({ location: node.config.walletDatabasePath })
   }

--- a/ironfish/src/migrations/data/016-sequence-to-tx.ts
+++ b/ironfish/src/migrations/data/016-sequence-to-tx.ts
@@ -3,20 +3,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration016 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -49,7 +49,7 @@ export class Migration016 extends Migration {
     }
   }
 
-  async backward(node: IronfishNode): Promise<void> {
+  async backward(node: Node): Promise<void> {
     await node.wallet.walletDb.sequenceToTransactionHash.clear()
   }
 }

--- a/ironfish/src/migrations/data/017-sequence-encoding.ts
+++ b/ironfish/src/migrations/data/017-sequence-encoding.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import {
   BufferEncoding,
   DatabaseSchema,
@@ -14,18 +13,19 @@ import {
   PrefixEncoding,
   U32_ENCODING_BE,
 } from '../../storage'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration017 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -62,7 +62,7 @@ export class Migration017 extends Migration {
     await pendingTransactionHashes.clear()
   }
 
-  async backward(node: IronfishNode, db: IDatabase): Promise<void> {
+  async backward(node: Node, db: IDatabase): Promise<void> {
     const accounts = await GetOldAccounts(node, db)
 
     const { sequenceToNoteHash, sequenceToTransactionHash, pendingTransactionHashes } =

--- a/ironfish/src/migrations/data/018-backfill-wallet-assets.ts
+++ b/ironfish/src/migrations/data/018-backfill-wallet-assets.ts
@@ -2,20 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration018 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     _db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -49,7 +49,7 @@ export class Migration018 extends Migration {
     logger.info('')
   }
 
-  async backward(node: IronfishNode): Promise<void> {
+  async backward(node: Node): Promise<void> {
     await node.wallet.walletDb.assets.clear()
   }
 }

--- a/ironfish/src/migrations/data/019-backfill-wallet-assets-from-chain.ts
+++ b/ironfish/src/migrations/data/019-backfill-wallet-assets-from-chain.ts
@@ -8,7 +8,7 @@ import { Logger } from '../../logger'
 import { IronfishNode } from '../../node'
 import { BUFFER_ENCODING, IDatabase, IDatabaseStore, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { BufferUtils } from '../../utils'
+import { BufferUtils, Node } from '../../utils'
 import { Account } from '../../wallet'
 import { Migration } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
@@ -16,12 +16,12 @@ import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 export class Migration019 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     _db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -49,6 +49,7 @@ export class Migration019 extends Migration {
     }
 
     if (assetsToBackfill.length) {
+      Assert.isInstanceOf(node, IronfishNode)
       const chainDb = createDB({ location: node.config.chainDatabasePath })
       await chainDb.open()
 

--- a/ironfish/src/migrations/data/020-backfill-null-asset-supplies.ts
+++ b/ironfish/src/migrations/data/020-backfill-null-asset-supplies.ts
@@ -2,21 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
-import { BufferUtils } from '../../utils'
+import { BufferUtils, Node } from '../../utils'
 import { Migration } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration020 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     _db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/021-add-version-to-accounts.ts
+++ b/ironfish/src/migrations/data/021-add-version-to-accounts.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 import { GetNewStores } from './021-add-version-to-accounts/schemaNew'
 import { GetOldStores } from './021-add-version-to-accounts/schemaOld'
@@ -11,12 +11,12 @@ import { GetOldStores } from './021-add-version-to-accounts/schemaOld'
 export class Migration021 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -41,7 +41,7 @@ export class Migration021 extends Migration {
   }
 
   async backward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/021-add-version-to-accounts/schemaOld.ts
+++ b/ironfish/src/migrations/data/021-add-version-to-accounts/schemaOld.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { generateKeyFromPrivateKey, PUBLIC_ADDRESS_LENGTH } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import { IronfishNode } from '../../../node'
 import {
   IDatabase,
   IDatabaseEncoding,
@@ -11,6 +10,7 @@ import {
   IDatabaseTransaction,
   StringEncoding,
 } from '../../../storage'
+import { Node } from '../../../utils'
 import { Account } from '../../../wallet'
 
 const KEY_LENGTH = 32
@@ -85,7 +85,7 @@ export function GetOldStores(db: IDatabase): {
 }
 
 export async function GetOldAccounts(
-  node: IronfishNode,
+  node: Node,
   db: IDatabase,
   tx?: IDatabaseTransaction,
 ): Promise<Account[]> {

--- a/ironfish/src/migrations/data/022-add-view-key-account.ts
+++ b/ironfish/src/migrations/data/022-add-view-key-account.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 import { GetNewStores } from './022-add-view-key-account/schemaNew'
 import { GetOldStores } from './022-add-view-key-account/schemaOld'
@@ -12,12 +12,12 @@ import { GetOldStores } from './022-add-view-key-account/schemaOld'
 export class Migration022 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -44,7 +44,7 @@ export class Migration022 extends Migration {
   }
 
   async backward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/023-wallet-optional-spending-key.ts
+++ b/ironfish/src/migrations/data/023-wallet-optional-spending-key.ts
@@ -2,20 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 import { GetStores } from './023-wallet-optional-spending-key/stores'
 
 export class Migration023 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db
   }
 
   async forward(
-    _node: IronfishNode,
+    _node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -29,7 +29,7 @@ export class Migration023 extends Migration {
   }
 
   backward(
-    _node: IronfishNode,
+    _node: Node,
     _db: IDatabase,
     _tx: IDatabaseTransaction | undefined,
     _logger: Logger,

--- a/ironfish/src/migrations/data/024-unspent-notes.ts
+++ b/ironfish/src/migrations/data/024-unspent-notes.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
+import { Node } from '../../utils'
 import { Account } from '../../wallet'
 import { Migration } from '../migration'
 import { GetStores } from './024-unspent-notes/stores'
@@ -13,12 +13,12 @@ import { GetStores } from './024-unspent-notes/stores'
 export class Migration024 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return createDB({ location: node.config.walletDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -65,7 +65,7 @@ export class Migration024 extends Migration {
     }
   }
 
-  async backward(node: IronfishNode, db: IDatabase): Promise<void> {
+  async backward(node: Node, db: IDatabase): Promise<void> {
     const stores = GetStores(db)
 
     await stores.new.unspentNoteHashes.clear()

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
+import { Node } from '../../utils'
 import { Account } from '../../wallet'
 import { Migration } from '../migration'
 import { GetStores } from './025-backfill-wallet-nullifier-to-transaction-hash/stores'
@@ -12,12 +12,12 @@ import { GetStores } from './025-backfill-wallet-nullifier-to-transaction-hash/s
 export class Migration025 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return createDB({ location: node.config.walletDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     _tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -90,7 +90,7 @@ export class Migration025 extends Migration {
   }
 
   async backward(
-    _node: IronfishNode,
+    _node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/026-timestamp-to-transactions.ts
+++ b/ironfish/src/migrations/data/026-timestamp-to-transactions.ts
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
+import { Node } from '../../utils'
 import { Account } from '../../wallet'
 import { Migration } from '../migration'
 import { GetStores } from './026-timestamp-to-transactions/stores'
@@ -12,12 +12,12 @@ import { GetStores } from './026-timestamp-to-transactions/stores'
 export class Migration026 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return createDB({ location: node.config.walletDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     _tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -67,7 +67,7 @@ export class Migration026 extends Migration {
     logger.info('')
   }
 
-  async backward(node: IronfishNode, db: IDatabase): Promise<void> {
+  async backward(node: Node, db: IDatabase): Promise<void> {
     const accounts = []
     const stores = GetStores(db)
 

--- a/ironfish/src/migrations/data/027-account-created-at-block.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block.ts
@@ -2,21 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 import { GetStores } from './027-account-created-at-block/stores'
 
 export class Migration027 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return createDB({ location: node.config.walletDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -33,7 +33,7 @@ export class Migration027 extends Migration {
   }
 
   async backward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/028-backfill-assets-owner.ts
+++ b/ironfish/src/migrations/data/028-backfill-assets-owner.ts
@@ -2,21 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
-import { IronfishNode } from '../../node'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
+import { Node } from '../../utils'
 import { Migration } from '../migration'
 import { GetStores } from './028-backfill-assets-owner/stores'
 
 export class Migration028 extends Migration {
   path = __filename
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(node: Node): IDatabase {
     return createDB({ location: node.config.chainDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -39,7 +39,7 @@ export class Migration028 extends Migration {
   }
 
   async backward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/migration.ts
+++ b/ironfish/src/migrations/migration.ts
@@ -4,8 +4,8 @@
 
 import { FileSystem } from '../fileSystems'
 import { Logger } from '../logger'
-import { IronfishNode } from '../node'
 import { IDatabase, IDatabaseTransaction } from '../storage'
+import { Node } from '../utils'
 
 export abstract class Migration {
   id = 0
@@ -24,10 +24,10 @@ export abstract class Migration {
     return this
   }
 
-  abstract prepare(node: IronfishNode): Promise<IDatabase> | IDatabase
+  abstract prepare(node: Node): Promise<IDatabase> | IDatabase
 
   abstract forward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -35,7 +35,7 @@ export abstract class Migration {
   ): Promise<void>
 
   abstract backward(
-    node: IronfishNode,
+    node: Node,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/migrator.ts
+++ b/ironfish/src/migrations/migrator.ts
@@ -6,18 +6,18 @@
 import { LogLevel } from 'consola'
 import { Assert } from '../assert'
 import { Logger } from '../logger'
-import { IronfishNode } from '../node'
 import { IDatabaseTransaction } from '../storage/database/transaction'
+import { Node } from '../utils'
 import { ErrorUtils } from '../utils/error'
 import { MIGRATIONS } from './data'
 import { Migration } from './migration'
 
 export class Migrator {
-  readonly node: IronfishNode
+  readonly node: Node
   readonly logger: Logger
   readonly migrations: Migration[]
 
-  constructor(options: { node: IronfishNode; logger: Logger }) {
+  constructor(options: { node: Node; logger: Logger }) {
     this.node = options.node
     this.logger = options.logger.withTag('migrator')
 

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -2,10 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../../assert'
-import { IronfishNode } from '../../node'
-import { YupSchema, YupSchemaResult, YupUtils } from '../../utils'
+import { Node, YupSchema, YupSchemaResult, YupUtils } from '../../utils'
 import { StrEnumUtils } from '../../utils/enums'
-import { WalletNode } from '../../walletNode'
 import { ERROR_CODES } from '../adapters'
 import { ResponseError, ValidationError } from '../adapters/errors'
 import { RpcRequest } from '../request'
@@ -27,7 +25,7 @@ export enum ApiNamespace {
 
 export const ALL_API_NAMESPACES = StrEnumUtils.getValues(ApiNamespace)
 
-export type RequestContext = IronfishNode | WalletNode
+export type RequestContext = Node
 
 export type RouteHandler<TRequest = unknown, TResponse = unknown> = (
   request: RpcRequest<TRequest, TResponse>,

--- a/ironfish/src/utils/node.ts
+++ b/ironfish/src/utils/node.ts
@@ -4,6 +4,7 @@
 
 import { IronfishNode } from '../node'
 import { DatabaseIsLockedError } from '../storage/database/errors'
+import { WalletNode } from '../walletNode'
 import { PromiseUtils } from './promise'
 
 /**
@@ -35,3 +36,5 @@ async function waitForOpen(node: IronfishNode, abort?: null | (() => boolean)): 
 }
 
 export const NodeUtils = { waitForOpen }
+
+export type Node = IronfishNode | WalletNode

--- a/ironfish/src/walletNode.ts
+++ b/ironfish/src/walletNode.ts
@@ -4,6 +4,7 @@
 
 import { AssetsVerifier } from './assets'
 import { Config } from './fileStores'
+import { FileSystem } from './fileSystems'
 import { Logger } from './logger'
 import { RpcServer } from './rpc'
 import { Wallet } from './wallet/wallet'
@@ -16,4 +17,5 @@ export type WalletNode = {
   assetsVerifier: AssetsVerifier
   workerPool: WorkerPool
   rpc: RpcServer
+  files: FileSystem
 }


### PR DESCRIPTION
## Summary

This migration specifically depends on both the wallet and chain database. We want:
* This migration to run only for full nodes (node running with the wallet)
* This migration to not crash for standalone wallets
* This migration to not create a chain db file directory on a new standalone wallet start

## Testing Plan

Run migrations on existing and new data directories

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
