### PR TITLE
Add ability to filter migrations by database

### DIFF
--- a/ironfish/src/migrations/data/000-template.ts
+++ b/ironfish/src/migrations/data/000-template.ts
@@ -6,11 +6,12 @@ import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetStores } from './000-template/stores'
 
 export class Migration000 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     /* replace line below with node.chain.location if applying migration to the blockchain

--- a/ironfish/src/migrations/data/014-blockchain.ts
+++ b/ironfish/src/migrations/data/014-blockchain.ts
@@ -7,10 +7,11 @@ import { IronfishNode } from '../../node'
 import { IDatabase } from '../../storage'
 import { createDB } from '../../storage/utils'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 
 export class Migration014 extends Migration {
   path = __filename
+  database = Database.BLOCKCHAIN
 
   async prepare(node: Node): Promise<IDatabase> {
     Assert.isInstanceOf(node, IronfishNode)

--- a/ironfish/src/migrations/data/015-wallet.ts
+++ b/ironfish/src/migrations/data/015-wallet.ts
@@ -5,10 +5,11 @@
 import { IDatabase } from '../../storage'
 import { createDB } from '../../storage/utils'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 
 export class Migration015 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   async prepare(node: Node): Promise<IDatabase> {
     await node.files.mkdir(node.config.walletDatabasePath, { recursive: true })

--- a/ironfish/src/migrations/data/016-sequence-to-tx.ts
+++ b/ironfish/src/migrations/data/016-sequence-to-tx.ts
@@ -5,11 +5,12 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration016 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db

--- a/ironfish/src/migrations/data/017-sequence-encoding.ts
+++ b/ironfish/src/migrations/data/017-sequence-encoding.ts
@@ -14,11 +14,12 @@ import {
   U32_ENCODING_BE,
 } from '../../storage'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration017 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db

--- a/ironfish/src/migrations/data/018-backfill-wallet-assets.ts
+++ b/ironfish/src/migrations/data/018-backfill-wallet-assets.ts
@@ -4,11 +4,12 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration018 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db

--- a/ironfish/src/migrations/data/019-backfill-wallet-assets-from-chain.ts
+++ b/ironfish/src/migrations/data/019-backfill-wallet-assets-from-chain.ts
@@ -10,11 +10,12 @@ import { BUFFER_ENCODING, IDatabase, IDatabaseStore, IDatabaseTransaction } from
 import { createDB } from '../../storage/utils'
 import { BufferUtils, Node } from '../../utils'
 import { Account } from '../../wallet'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration019 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db

--- a/ironfish/src/migrations/data/020-backfill-null-asset-supplies.ts
+++ b/ironfish/src/migrations/data/020-backfill-null-asset-supplies.ts
@@ -4,11 +4,12 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { BufferUtils, Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration020 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db

--- a/ironfish/src/migrations/data/021-add-version-to-accounts.ts
+++ b/ironfish/src/migrations/data/021-add-version-to-accounts.ts
@@ -4,12 +4,13 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetNewStores } from './021-add-version-to-accounts/schemaNew'
 import { GetOldStores } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration021 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db

--- a/ironfish/src/migrations/data/022-add-view-key-account.ts
+++ b/ironfish/src/migrations/data/022-add-view-key-account.ts
@@ -5,12 +5,13 @@ import { generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetNewStores } from './022-add-view-key-account/schemaNew'
 import { GetOldStores } from './022-add-view-key-account/schemaOld'
 
 export class Migration022 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db

--- a/ironfish/src/migrations/data/023-wallet-optional-spending-key.ts
+++ b/ironfish/src/migrations/data/023-wallet-optional-spending-key.ts
@@ -4,11 +4,12 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetStores } from './023-wallet-optional-spending-key/stores'
 
 export class Migration023 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return node.wallet.walletDb.db

--- a/ironfish/src/migrations/data/024-unspent-notes.ts
+++ b/ironfish/src/migrations/data/024-unspent-notes.ts
@@ -7,11 +7,12 @@ import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
 import { Node } from '../../utils'
 import { Account } from '../../wallet'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetStores } from './024-unspent-notes/stores'
 
 export class Migration024 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return createDB({ location: node.config.walletDatabasePath })

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
@@ -6,11 +6,12 @@ import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
 import { Node } from '../../utils'
 import { Account } from '../../wallet'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetStores } from './025-backfill-wallet-nullifier-to-transaction-hash/stores'
 
 export class Migration025 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return createDB({ location: node.config.walletDatabasePath })

--- a/ironfish/src/migrations/data/026-timestamp-to-transactions.ts
+++ b/ironfish/src/migrations/data/026-timestamp-to-transactions.ts
@@ -6,11 +6,12 @@ import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
 import { Node } from '../../utils'
 import { Account } from '../../wallet'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetStores } from './026-timestamp-to-transactions/stores'
 
 export class Migration026 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return createDB({ location: node.config.walletDatabasePath })

--- a/ironfish/src/migrations/data/027-account-created-at-block.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block.ts
@@ -5,11 +5,12 @@ import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetStores } from './027-account-created-at-block/stores'
 
 export class Migration027 extends Migration {
   path = __filename
+  database = Database.WALLET
 
   prepare(node: Node): IDatabase {
     return createDB({ location: node.config.walletDatabasePath })

--- a/ironfish/src/migrations/data/028-backfill-assets-owner.ts
+++ b/ironfish/src/migrations/data/028-backfill-assets-owner.ts
@@ -5,11 +5,12 @@ import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
 import { Node } from '../../utils'
-import { Migration } from '../migration'
+import { Database, Migration } from '../migration'
 import { GetStores } from './028-backfill-assets-owner/stores'
 
 export class Migration028 extends Migration {
   path = __filename
+  database = Database.BLOCKCHAIN
 
   prepare(node: Node): IDatabase {
     return createDB({ location: node.config.chainDatabasePath })

--- a/ironfish/src/migrations/migration.ts
+++ b/ironfish/src/migrations/migration.ts
@@ -7,9 +7,15 @@ import { Logger } from '../logger'
 import { IDatabase, IDatabaseTransaction } from '../storage'
 import { Node } from '../utils'
 
+export enum Database {
+  WALLET = 'wallet',
+  BLOCKCHAIN = 'blockchain',
+}
+
 export abstract class Migration {
   id = 0
   name = ''
+  abstract database: Database
 
   abstract path: string
 


### PR DESCRIPTION
## Summary
The standalone wallet needs the ability to not apply chain database migrations. Adding ability to filter which database migrations to apply 

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
