### PR TITLE
rpc: mint details in chain/getTransaction

### DIFF
--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -24,6 +24,8 @@ export type GetTransactionResponse = {
   mints: {
     assetId: string
     value: string
+    name: string
+    metadata: string
   }[]
   burns: {
     assetId: string
@@ -60,6 +62,8 @@ export const GetTransactionResponseSchema: yup.ObjectSchema<GetTransactionRespon
           .object({
             assetId: yup.string().defined(),
             value: yup.string().defined(),
+            name: yup.string().defined(),
+            metadata: yup.string().defined(),
           })
           .defined(),
       )
@@ -136,6 +140,8 @@ routes.register<typeof GetTransactionRequestSchema, GetTransactionResponse>(
       mints: transaction.mints.map((mint) => ({
         assetId: mint.asset.id().toString('hex'),
         value: CurrencyUtils.encode(mint.value),
+        name: mint.asset.name().toString('hex'),
+        metadata: mint.asset.metadata().toString('hex'),
       })),
       burns: transaction.burns.map((burn) => ({
         assetId: burn.assetId.toString('hex'),


### PR DESCRIPTION
## Summary
Add asset `name` and `metadata` in mint part of `chain/getTransaction` response.
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
