### PR TITLE
Clean up unnecessary wallet properties

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -296,7 +296,6 @@ export class FullNode {
       workerPool,
       consensus,
       nodeClient: memoryClient,
-      assetsVerifier,
     })
 
     const node = new FullNode({

--- a/ironfish/src/rpc/routes/wallet/addTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/addTransaction.ts
@@ -41,7 +41,7 @@ routes.register<typeof AddTransactionRequestSchema, AddTransactionResponse>(
     const data = Buffer.from(request.data.transaction, 'hex')
     const transaction = new Transaction(data)
 
-    const verify = Verifier.verifyCreatedTransaction(transaction, node.wallet.consensus)
+    const verify = Verifier.verifyCreatedTransaction(transaction, node.strategy.consensus)
 
     if (!verify.valid) {
       throw new ValidationError(`Invalid transaction, reason: ${String(verify.reason)}`, 400)

--- a/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts
@@ -108,7 +108,7 @@ routes.register<typeof GetAccountTransactionRequestSchema, GetAccountTransaction
 
     const assetBalanceDeltas = await getAssetBalanceDeltas(account, transaction)
 
-    const notes = await getAccountDecryptedNotes(node.wallet.workerPool, account, transaction)
+    const notes = await getAccountDecryptedNotes(node.workerPool, account, transaction)
 
     const spends = transaction.transaction.spends.map((spend) => ({
       nullifier: spend.nullifier.toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/getAssets.ts
+++ b/ironfish/src/rpc/routes/wallet/getAssets.ts
@@ -67,7 +67,7 @@ routes.register<typeof GetAssetsRequestSchema, GetAssetsResponse>(
           confirmations: request.data.confirmations,
         }),
         supply: asset.supply !== null ? CurrencyUtils.encode(asset.supply) : undefined,
-        verification: node.wallet.assetsVerifier.verify(asset.id),
+        verification: node.assetsVerifier.verify(asset.id),
       })
     }
 

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -77,7 +77,7 @@ routes.register<typeof GetBalanceRequestSchema, GetBalanceResponse>(
     request.end({
       account: account.name,
       assetId: assetId.toString('hex'),
-      assetVerification: node.wallet.assetsVerifier.verify(assetId),
+      assetVerification: node.assetsVerifier.verify(assetId),
       confirmed: balance.confirmed.toString(),
       unconfirmed: balance.unconfirmed.toString(),
       unconfirmedCount: balance.unconfirmedCount,

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -87,7 +87,7 @@ routes.register<typeof GetBalancesRequestSchema, GetBalancesResponse>(
         assetId: balance.assetId.toString('hex'),
         assetName: asset?.name.toString('hex') ?? '',
         assetCreator: asset?.creator.toString('hex') ?? '',
-        assetVerification: node.wallet.assetsVerifier.verify(balance.assetId),
+        assetVerification: node.assetsVerifier.verify(balance.assetId),
         blockHash: balance.blockHash?.toString('hex') ?? null,
         confirmed: CurrencyUtils.encode(balance.confirmed),
         sequence: balance.sequence,

--- a/ironfish/src/rpc/routes/wallet/rescanAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/rescanAccount.ts
@@ -65,7 +65,7 @@ routes.register<typeof RescanAccountRequestSchema, RescanAccountResponse>(
       scan = node.wallet.scan
 
       if (!scan) {
-        node.wallet.logger.warn(`Attempted to start accounts scan but one did not start.`)
+        node.logger.warn(`Attempted to start accounts scan but one did not start.`)
       }
     }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -5,7 +5,6 @@ import { Asset, generateKey, Note as NativeNote } from '@ironfish/rust-nodejs'
 import { BufferMap, BufferSet } from 'buffer-map'
 import { v4 as uuid } from 'uuid'
 import { Assert } from '../assert'
-import { AssetsVerifier } from '../assets'
 import { Consensus, isExpiredSequence, Verifier } from '../consensus'
 import { Event } from '../event'
 import { Config } from '../fileStores'
@@ -77,13 +76,12 @@ export class Wallet {
 
   protected readonly accounts = new Map<string, Account>()
   readonly walletDb: WalletDB
-  readonly logger: Logger
+  private readonly logger: Logger
   readonly workerPool: WorkerPool
   readonly chainProcessor: RemoteChainProcessor
   readonly nodeClient: RpcClient
   private readonly config: Config
-  readonly consensus: Consensus
-  readonly assetsVerifier: AssetsVerifier
+  private readonly consensus: Consensus
 
   protected rebroadcastAfter: number
   protected defaultAccount: string | null = null
@@ -103,7 +101,6 @@ export class Wallet {
     workerPool,
     consensus,
     nodeClient,
-    assetsVerifier,
   }: {
     config: Config
     database: WalletDB
@@ -112,7 +109,6 @@ export class Wallet {
     workerPool: WorkerPool
     consensus: Consensus
     nodeClient: RpcClient
-    assetsVerifier: AssetsVerifier
   }) {
     this.config = config
     this.logger = logger.withTag('accounts')
@@ -120,7 +116,6 @@ export class Wallet {
     this.workerPool = workerPool
     this.consensus = consensus
     this.nodeClient = nodeClient
-    this.assetsVerifier = assetsVerifier
     this.rebroadcastAfter = rebroadcastAfter ?? 10
     this.createTransactionMutex = new Mutex()
     this.eventLoopAbortController = new AbortController()

--- a/ironfish/src/walletNode.ts
+++ b/ironfish/src/walletNode.ts
@@ -155,7 +155,6 @@ export class WalletNode {
       workerPool,
       consensus,
       nodeClient,
-      assetsVerifier,
     })
 
     const node = new WalletNode({


### PR DESCRIPTION
## Summary
This PR reverts some recent changes that passed down propertes like `assetsVerifier` to the `Wallet` simply so they could be accessed in RPC handlers. Now that we have the concept of a `WalletNode` these propoerties make more sense to live at the node level and not the `Wallet` since they are not being used internally in the `Wallet`

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
