### PR TITLE
refactor(ironfish): Move notes and nullifiers from db to blockchain

### DIFF
--- a/ironfish-cli/src/commands/chain/benchmark.ts
+++ b/ironfish-cli/src/commands/chain/benchmark.ts
@@ -136,8 +136,8 @@ export default class Benchmark extends IronfishCommand {
     if (endingHeader.noteSize === null) {
       return this.error(`Header should have a noteSize`)
     }
-    const nodeNotesHash = await node.chain.getNotesPastRoot(endingHeader.noteSize)
-    const tempNodeNotesHash = await tempNode.chain.getNotesRootHash()
+    const nodeNotesHash = await node.chain.notes.pastRoot(endingHeader.noteSize)
+    const tempNodeNotesHash = await tempNode.chain.notes.rootHash()
     if (!nodeNotesHash.equals(tempNodeNotesHash)) {
       throw new Error('/!\\ Note tree hashes were not consistent /!\\')
     }

--- a/ironfish-cli/src/commands/chain/repair.ts
+++ b/ironfish-cli/src/commands/chain/repair.ts
@@ -130,8 +130,8 @@ export default class RepairChain extends IronfishCommand {
   ): Promise<void> {
     Assert.isNotNull(node.chain.head)
 
-    const noNotes = (await node.chain.getNotesSize()) === 0
-    const noNullifiers = (await node.chain.getNullifiersSize()) === 0
+    const noNotes = (await node.chain.notes.size()) === 0
+    const noNullifiers = (await node.chain.nullifiers.size()) === 0
     const headBlock = await node.chain.getBlock(node.chain.head)
     Assert.isNotNull(headBlock)
     const treeStatus = await node.chain.verifier.verifyConnectedBlock(headBlock)
@@ -155,11 +155,11 @@ export default class RepairChain extends IronfishCommand {
     const noteSize = prev && prev.noteSize !== null ? prev.noteSize : 0
 
     CliUx.ux.action.start('Clearing notes MerkleTree')
-    await node.chain.truncateNotes(noteSize)
+    await node.chain.notes.truncate(noteSize)
     CliUx.ux.action.stop()
 
     CliUx.ux.action.start('Clearing nullifier set')
-    await node.chain.clearNullifiers()
+    await node.chain.nullifiers.clear()
 
     CliUx.ux.action.stop()
 

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -451,7 +451,7 @@ describe('Verifier', () => {
       })
 
       jest
-        .spyOn(nodeTest.chain['blockchainDb'].notes, 'getCount')
+        .spyOn(nodeTest.chain.notes, 'getCount')
         .mockImplementationOnce(() => Promise.resolve(0))
 
       expect(await nodeTest.verifier.verifyConnectedSpends(block)).toEqual({

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -259,7 +259,7 @@ export class Verifier {
         // (and spends) can eventually become valid if the chain forks to them.
         // Calculating the notes rootHash is also expensive at the time of writing, so performance test
         // before verifying the rootHash on spends.
-        if (await this.chain.nullifiers.get(spend.nullifier, tx)) {
+        if (await this.chain.nullifiers.contains(spend.nullifier, tx)) {
           return VerificationResultReason.DOUBLE_SPEND
         }
       }
@@ -335,7 +335,7 @@ export class Verifier {
           return { valid: false, reason }
         }
 
-        if (await this.chain.nullifiers.get(spend.nullifier, tx)) {
+        if (await this.chain.nullifiers.contains(spend.nullifier, tx)) {
           return { valid: false, reason: VerificationResultReason.DOUBLE_SPEND }
         }
       }
@@ -437,7 +437,7 @@ export class Verifier {
     }
 
     for (const spend of block.spends()) {
-      if (await this.chain.nullifiers.get(spend.nullifier, tx)) {
+      if (await this.chain.nullifiers.contains(spend.nullifier, tx)) {
         return { valid: false, reason: VerificationResultReason.DOUBLE_SPEND }
       }
     }

--- a/ironfish/src/genesis/addGenesisTransaction.ts
+++ b/ironfish/src/genesis/addGenesisTransaction.ts
@@ -53,7 +53,7 @@ export async function addGenesisTransaction(
         account.viewKey,
         BigInt(initialNoteIndex + noteIndex),
       )
-      if (await node.chain.hasNullifier(nullifier)) {
+      if (await node.chain.nullifiers.get(nullifier)) {
         continue
       }
 
@@ -62,7 +62,7 @@ export async function addGenesisTransaction(
         continue
       }
 
-      witness = await node.chain.getNoteWitness(initialNoteIndex + noteIndex)
+      witness = await node.chain.notes.witness(initialNoteIndex + noteIndex)
       note = decryptedNote.takeReference()
       decryptedNote.returnReference()
       break
@@ -122,11 +122,11 @@ export async function addGenesisTransaction(
   genesisBlock.transactions.push(postedTransaction)
 
   // Add the new notes to the merkle tree
-  await node.chain.addNotesBatch(postedTransaction.notes)
+  await node.chain.notes.addBatch(postedTransaction.notes)
 
   // Generate a new block header for the new genesis block
-  const noteCommitment = await node.chain.getNotesRootHash()
-  const noteSize = await node.chain.getNotesSize()
+  const noteCommitment = await node.chain.notes.rootHash()
+  const noteSize = await node.chain.notes.size()
   const newGenesisHeader = new BlockHeader(
     1,
     genesisBlock.header.previousBlockHash,

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -103,19 +103,19 @@ export async function makeGenesisBlock(
   if (postedInitialTransaction.notes.length !== 1) {
     throw new Error('Expected postedInitialTransaction to have 1 note')
   }
-  await chain.addNote(postedMinersFeeTransaction.getNote(0))
-  await chain.addNote(postedInitialTransaction.getNote(0))
+  await chain.notes.add(postedMinersFeeTransaction.getNote(0))
+  await chain.notes.add(postedInitialTransaction.getNote(0))
 
   // Construct a witness of the Transaction 1 note
   logger.info('  Constructing a witness of the note...')
-  const witness = await chain.getNoteWitness(1)
+  const witness = await chain.notes.witness(1)
   if (witness === null) {
     throw new Error('We must be able to construct a witness in order to generate a spend.')
   }
 
   // Now that we have the witness, remove the note from the tree
   logger.info('  Removing the note from the tree...')
-  await chain.truncateNotes(0)
+  await chain.notes.truncate(0)
 
   /**
    *

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -961,7 +961,7 @@ describe('PeerNetwork', () => {
         const { block, transaction } = await useBlockWithTx(node, accountA, accountB)
         const verifyNewTransactionSpy = jest.spyOn(node.chain.verifier, 'verifyNewTransaction')
 
-        await node.chain.connectBlockToNullifiers(block)
+        await node.chain.nullifiers.connectBlock(block)
 
         const acceptTransaction = jest.spyOn(node.memPool, 'acceptTransaction')
         const addPendingTransaction = jest.spyOn(node.wallet, 'addPendingTransaction')

--- a/ironfish/src/rpc/routes/chain/getNoteWitness.test.ts
+++ b/ironfish/src/rpc/routes/chain/getNoteWitness.test.ts
@@ -20,7 +20,7 @@ describe('Route chain/getNoteWitness', () => {
     const block2 = await useMinerBlockFixture(chain)
     await expect(chain).toAddBlock(block2)
 
-    const noteSize = await chain.getNotesSize()
+    const noteSize = await chain.notes.size()
 
     for (const index of Array.from(Array(noteSize).keys())) {
       const response = await routeTest.client
@@ -28,7 +28,7 @@ describe('Route chain/getNoteWitness', () => {
         .waitForEnd()
 
       const witness: Witness<NoteEncrypted, Buffer, Buffer, Buffer> | null =
-        await chain.getNoteWitness(index)
+        await chain.notes.witness(index)
       Assert.isNotNull(witness)
 
       expect(response.content.rootHash).toEqual(witness.rootHash.toString('hex'))
@@ -66,7 +66,7 @@ describe('Route chain/getNoteWitness', () => {
         .waitForEnd()
 
       const witness: Witness<NoteEncrypted, Buffer, Buffer, Buffer> | null =
-        await chain.getNoteWitness(index, noteSize)
+        await chain.notes.witness(index, noteSize)
       Assert.isNotNull(witness)
 
       expect(response.content.rootHash).toEqual(witness.rootHash.toString('hex'))

--- a/ironfish/src/rpc/routes/chain/getNoteWitness.ts
+++ b/ironfish/src/rpc/routes/chain/getNoteWitness.ts
@@ -64,7 +64,7 @@ routes.register<typeof GetNoteWitnessRequestSchema, GetNoteWitnessResponse>(
     Assert.isNotNull(maxConfirmedHeader)
     Assert.isNotNull(maxConfirmedHeader?.noteSize)
 
-    const witness = await chain.getNoteWitness(request.data.index, maxConfirmedHeader.noteSize)
+    const witness = await chain.notes.witness(request.data.index, maxConfirmedHeader.noteSize)
 
     if (witness === null) {
       throw new ValidationError(

--- a/ironfish/src/testUtilities/fixtures/blocks.ts
+++ b/ironfish/src/testUtilities/fixtures/blocks.ts
@@ -157,9 +157,9 @@ export async function useBlockWithRawTxFixture(
       notesToSpend.map(async (n) => {
         const note = n.decryptNoteForOwner(sender.incomingViewKey)
         Assert.isNotUndefined(note)
-        const treeIndex = await chain.getLeavesIndex(n.hash())
+        const treeIndex = await chain.notes.leavesIndex.get(n.hash())
         Assert.isNotUndefined(treeIndex)
-        const witness = await chain.getNoteWitness(treeIndex)
+        const witness = await chain.notes.witness(treeIndex)
         Assert.isNotNull(witness)
 
         return {

--- a/ironfish/src/testUtilities/matchers/blockchain.ts
+++ b/ironfish/src/testUtilities/matchers/blockchain.ts
@@ -58,10 +58,10 @@ async function toAddDoubleSpendBlock(
   const transactionHashMock = jest
     .spyOn(self, 'transactionHashHasBlock')
     .mockResolvedValue(false)
-  const containsMock = jest.spyOn(self, 'hasNullifier').mockResolvedValue(false)
+  const containsMock = jest.spyOn(self.nullifiers['nullifiers'], 'has').mockResolvedValue(false)
   const addNullifierMock = jest
-    .spyOn(self['blockchainDb'].nullifiers['nullifiers'], 'add')
-    .mockImplementation((...args) => self['blockchainDb'].nullifiers['nullifiers'].put(...args))
+    .spyOn(self.nullifiers['nullifiers'], 'add')
+    .mockImplementation((...args) => self.nullifiers['nullifiers'].put(...args))
 
   const result = await self.addBlock(other)
 


### PR DESCRIPTION
## Summary

Spoke with @NullSoldier and decided to keep the original pattern of notes and nullifiers directly under the blockchain.

## Testing Plan

N/A

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
