### PR TITLE
fixes error message when database is ahead of node

### DIFF
--- a/ironfish/src/storage/database/errors.ts
+++ b/ironfish/src/storage/database/errors.ts
@@ -39,7 +39,7 @@ export class DatabaseVersionError extends DatabaseOpenError {
         ? `Your database needs to be upgraded (v${current} vs v${version}).\n` +
             `Run "ironfish migrations:start" or "ironfish start --upgrade"\n`
         : `Your database is newer than your node.\n` +
-            `Your database is ${version} and your node is ${current}.\n`,
+            `Your database is ${current} and your node is ${version}.\n`,
     )
 
     this.version = current


### PR DESCRIPTION
## Summary

swaps the current database version with the code database version in the error message:

```
Your database is newer than your node.
Your database is 27 and your node is 29.
```

changes to

```
Your database is newer than your node.
Your database is 29 and your node is 27.
```

## Testing Plan

manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
