### PR TITLE
feat(ironfish): Move databases to migrator constructor

### DIFF
--- a/ironfish/src/migrations/migrator.ts
+++ b/ironfish/src/migrations/migrator.ts
@@ -16,10 +16,12 @@ export class Migrator {
   readonly node: IronfishNode
   readonly logger: Logger
   readonly migrations: Migration[]
+  readonly whitelistedDBs: Database[]
 
-  constructor(options: { node: IronfishNode; logger: Logger }) {
+  constructor(options: { node: IronfishNode; logger: Logger; databases?: Database[] }) {
     this.node = options.node
     this.logger = options.logger.withTag('migrator')
+    this.whitelistedDBs = options?.databases ?? StrEnumUtils.getValues(Database)
 
     this.migrations = MIGRATIONS.map((m) => {
       return new m().init(options.node.files)
@@ -31,7 +33,7 @@ export class Migrator {
    */
   async isInitial(): Promise<boolean> {
     for (const migration of this.migrations) {
-      if (await this.isEmpty(migration)) {
+      if (this.whitelistedDBs.includes(migration.database) && (await this.isEmpty(migration))) {
         return true
       }
     }
@@ -71,6 +73,10 @@ export class Migrator {
     const migrations = this.migrations.slice().reverse()
 
     for (const migration of migrations) {
+      if (!this.whitelistedDBs.includes(migration.database)) {
+        continue
+      }
+
       const applied = await this.isApplied(migration)
 
       if (applied) {
@@ -105,9 +111,7 @@ export class Migrator {
     quiet?: boolean
     quietNoop?: boolean
     dryRun?: boolean
-    databases?: Database[]
   }): Promise<void> {
-    const whitelistedDBs = options?.databases ?? StrEnumUtils.getValues(Database)
     const dryRun = options?.dryRun ?? false
     const logger = this.logger.create({})
 
@@ -123,7 +127,7 @@ export class Migrator {
 
     const unapplied = status
       .filter(([, applied]) => !applied)
-      .filter(([migration]) => whitelistedDBs.includes(migration.database))
+      .filter(([migration]) => this.whitelistedDBs.includes(migration.database))
       .map(([migration]) => migration)
 
     if (unapplied.length === 0) {
@@ -180,6 +184,10 @@ export class Migrator {
     this.logger.info('Checking migrations:')
 
     for (const migration of this.migrations) {
+      if (!this.whitelistedDBs.includes(migration.database)) {
+        continue
+      }
+
       process.stdout.write(`  Checking ${migration.name.slice(0, 35)}...`.padEnd(50, ' '))
 
       try {

--- a/ironfish/src/migrations/migrator.ts
+++ b/ironfish/src/migrations/migrator.ts
@@ -25,8 +25,8 @@ export class Migrator {
     this.migrations = MIGRATIONS.map((m) => {
       return new m().init(options.node.files)
     })
-      .sort((a, b) => a.id - b.id)
       .filter((migration) => whitelistedDBs.includes(migration.database))
+      .sort((a, b) => a.id - b.id)
   }
 
   /**

--- a/ironfish/src/walletNode.ts
+++ b/ironfish/src/walletNode.ts
@@ -77,7 +77,7 @@ export class WalletNode {
     this.logger = logger
     this.pkg = pkg
 
-    this.migrator = new Migrator({ node: this, logger })
+    this.migrator = new Migrator({ node: this, logger, databases: [Database.WALLET] })
 
     this.assetsVerifier = assetsVerifier
 
@@ -182,7 +182,6 @@ export class WalletNode {
       await this.migrator.migrate({
         quiet: !migrate,
         quietNoop: true,
-        databases: [Database.WALLET],
       })
     }
 


### PR DESCRIPTION
## Summary

When checking if migrations have been applied or reverting, we can save some work by storing the databases on the migrator. This should never change throughout use of the migrator.

## Testing Plan

N/A

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
