### PR TITLE
uses WalletNode instead of FullNode in wallet:prune

### DIFF
--- a/ironfish-cli/src/commands/wallet/prune.ts
+++ b/ironfish-cli/src/commands/wallet/prune.ts
@@ -35,7 +35,7 @@ export default class PruneCommand extends IronfishCommand {
     const { flags } = await this.parse(PruneCommand)
 
     CliUx.ux.action.start(`Opening node`)
-    const node = await this.sdk.node()
+    const node = await this.sdk.walletNode()
     await NodeUtils.waitForOpen(node)
     CliUx.ux.action.stop('Done.')
 

--- a/ironfish/src/utils/node.ts
+++ b/ironfish/src/utils/node.ts
@@ -10,7 +10,7 @@ import { PromiseUtils } from './promise'
 /**
  * Try to open the node DB's and wait until they can be opened
  */
-async function waitForOpen(node: FullNode, abort?: null | (() => boolean)): Promise<void> {
+async function waitForOpen(node: IronfishNode, abort?: null | (() => boolean)): Promise<void> {
   let logged = false
 
   while (!abort || !abort()) {


### PR DESCRIPTION
## Summary

allows standalone wallets to prune expired transactions and compact the walletDb

## Testing Plan

- manual testing with `wallet:prune`

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
