### PR TITLE
feat(ironfish): Add connection retries to wallet node

### DIFF
--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -271,7 +271,7 @@ export class IronfishSdk {
   }
 
   async walletNode(): Promise<WalletNode> {
-    let nodeClient: RpcClient
+    let nodeClient: RpcSocketClient
 
     if (this.config.get('walletNodeTcpEnabled')) {
       if (this.config.get('walletNodeTlsEnabled')) {

--- a/ironfish/src/walletNode.ts
+++ b/ironfish/src/walletNode.ts
@@ -19,9 +19,10 @@ import { Migrator } from './migrations'
 import { Database } from './migrations/migration'
 import { getNetworkDefinition } from './networkDefinition'
 import { Package } from './package'
-import { RpcClient } from './rpc'
+import { RpcSocketClient } from './rpc'
 import { RpcServer } from './rpc/server'
 import { Strategy } from './strategy'
+import { SetTimeoutToken } from './utils'
 import { Wallet, WalletDB } from './wallet'
 import { calculateWorkers, WorkerPool } from './workerPool'
 
@@ -38,10 +39,14 @@ export class WalletNode {
   rpc: RpcServer
   pkg: Package
   assetsVerifier: AssetsVerifier
+  nodeClient: RpcSocketClient
 
   started = false
   shutdownPromise: Promise<void> | null = null
   shutdownResolve: (() => void) | null = null
+
+  private nodeClientConnectionWarned: boolean
+  private nodeClientConnectionTimeout: SetTimeoutToken | null
 
   constructor({
     pkg,
@@ -54,6 +59,7 @@ export class WalletNode {
     workerPool,
     logger,
     assetsVerifier,
+    nodeClient,
   }: {
     pkg: Package
     files: FileSystem
@@ -65,6 +71,7 @@ export class WalletNode {
     workerPool: WorkerPool
     logger: Logger
     assetsVerifier: AssetsVerifier
+    nodeClient: RpcSocketClient
   }) {
     this.files = files
     this.config = config
@@ -76,10 +83,13 @@ export class WalletNode {
     this.rpc = new RpcServer(this, internal)
     this.logger = logger
     this.pkg = pkg
+    this.nodeClient = nodeClient
+    this.assetsVerifier = assetsVerifier
 
     this.migrator = new Migrator({ node: this, logger, databases: [Database.WALLET] })
 
-    this.assetsVerifier = assetsVerifier
+    this.nodeClientConnectionWarned = false
+    this.nodeClientConnectionTimeout = null
 
     this.config.onConfigChange.on((key, value) => this.onConfigChange(key, value))
   }
@@ -103,7 +113,7 @@ export class WalletNode {
     metrics?: MetricsMonitor
     files: FileSystem
     strategyClass: typeof Strategy | null
-    nodeClient: RpcClient
+    nodeClient: RpcSocketClient
   }): Promise<WalletNode> {
     logger = logger.withTag('walletnode')
     dataDir = dataDir || DEFAULT_DATA_DIR
@@ -158,7 +168,7 @@ export class WalletNode {
       assetsVerifier,
     })
 
-    const node = new WalletNode({
+    return new WalletNode({
       pkg,
       strategy,
       files,
@@ -169,9 +179,8 @@ export class WalletNode {
       workerPool,
       logger,
       assetsVerifier,
+      nodeClient,
     })
-
-    return node
   }
 
   async openDB(): Promise<void> {
@@ -218,6 +227,36 @@ export class WalletNode {
     if (this.config.get('enableAssetVerification')) {
       this.assetsVerifier.start()
     }
+
+    this.nodeClient.onClose.on(this.onDisconnectRpc)
+    await this.startConnectingRpc()
+  }
+
+  private async startConnectingRpc(): Promise<void> {
+    if (!this.started) {
+      return
+    }
+
+    const connected = await this.nodeClient.tryConnect()
+    if (!connected) {
+      if (!this.nodeClientConnectionWarned) {
+        this.logger.warn(
+          `Failed to connect to node on ${this.nodeClient.describe()}, retrying...`,
+        )
+        this.nodeClientConnectionWarned = true
+      }
+
+      this.nodeClientConnectionTimeout = setTimeout(() => void this.startConnectingRpc(), 5000)
+      return
+    }
+
+    this.nodeClientConnectionWarned = false
+    this.logger.info('Successfully connected to node')
+  }
+
+  private onDisconnectRpc = (): void => {
+    this.logger.info('Disconnected from node unexpectedly. Reconnecting.')
+    void this.startConnectingRpc()
   }
 
   async waitForShutdown(): Promise<void> {
@@ -225,6 +264,13 @@ export class WalletNode {
   }
 
   async shutdown(): Promise<void> {
+    this.nodeClient.onClose.off(this.onDisconnectRpc)
+    this.nodeClient.close()
+
+    if (this.nodeClientConnectionTimeout) {
+      clearTimeout(this.nodeClientConnectionTimeout)
+    }
+
     await Promise.allSettled([
       this.wallet.stop(),
       this.rpc.stop(),


### PR DESCRIPTION
## Summary

* Update node client to be a socket client (since this can never be a memory client anyways)
* When we start the wallet node, connect to the node client
* Set a retry logic every 5s
* Retry connection if something gets disconnected

## Testing Plan

N/A - will be tested once the start command is up

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
