### PR TITLE
fixes error output in wallet rpc test

### DIFF
--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -14,6 +14,12 @@ import { ImportResponse } from './importAccount'
 describe('Route wallet/importAccount', () => {
   const routeTest = createRouteTest(true)
 
+  beforeAll(() => {
+    jest
+      .spyOn(routeTest.node.wallet, 'scanTransactions')
+      .mockImplementation(async () => Promise.resolve())
+  })
+
   it('should import a view only account that has no spending key', async () => {
     const key = generateKey()
 


### PR DESCRIPTION
## Summary

one of the importAccount RPC tests triggers a rescan after import. however, the wallet database is not open in the scope of the test, so the scan throws an error.

the test depends on the response of the RPC, which is returned before the error, so the test succeeds. the error is thrown and outputs a stack trace.

fixes the error by mocking 'scanTransactions' for all importAccount tests to no-op

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
