### PR TITLE
throws error if wallet chainProcessor head not in chain

### DIFF
--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -24,17 +24,13 @@ import { AssetStatus, ScanState } from './wallet'
 describe('Accounts', () => {
   const nodeTest = createNodeTest()
 
-  it('should reset when chain processor head does not exist in chain', async () => {
+  it('should throw an error when chain processor head does not exist in chain', async () => {
     const { node, strategy } = nodeTest
     strategy.disableMiningReward()
 
-    const resetSpy = jest.spyOn(node.wallet, 'reset').mockImplementation()
-    jest.spyOn(node.wallet, 'eventLoop').mockImplementation(() => Promise.resolve())
-
     node.wallet['chainProcessor'].hash = Buffer.from('0')
 
-    await node.wallet.start()
-    expect(resetSpy).toHaveBeenCalledTimes(1)
+    await expect(node.wallet.start()).rejects.toThrow()
   })
 
   it('should handle transaction created on fork', async () => {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -253,12 +253,11 @@ export class Wallet {
       const hasHeadBlock = await this.chainHasBlock(this.chainProcessor.hash)
 
       if (!hasHeadBlock) {
-        this.logger.error(
-          `Resetting accounts database because accounts head was not found in chain: ${this.chainProcessor.hash.toString(
+        throw new Error(
+          `Wallet has scanned to block ${this.chainProcessor.hash.toString(
             'hex',
-          )}`,
+          )}, but node's chain does not contain that block. Unable to sync from node without rescan.`,
         )
-        await this.reset()
       }
     }
 


### PR DESCRIPTION
## Summary

throws an error and prevents wallet from starting instead of automatically resetting the wallet and deleting data if the wallet's latest head hash is not in the chain

the wallet's latest head hash might not be in the node's chain if the wallet has synced past that node's chain head or if the wallet has synced on a fork that the node's chain does not have. in either case the wallet cannot sync blocks on the main chain from that node.

## Testing Plan

- updates unit test

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
