### PR TITLE
Use Cargo resolver v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "benchmarks",


### PR DESCRIPTION
## Summary

The [v2 resolver](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2) is the default for crates using the 2021 Rust edition, but it's not the default for virtual workspaces. This commit enables the v2 resolver for all our crates.

### Further details

Excerpt from [Default Cargo feature resolver](https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html):

> If you are using a [virtual workspace](https://doc.rust-lang.org/cargo/reference/workspaces.html#virtual-manifest), you will still need to explicitly set the [`resolver` field](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) in the `[workspace]` definition if you want to opt-in to the new resolver.

In fact, sometimes (but not always), when working crates I see the following warning:

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

Using the v2 resolver may result in some unneeded dependency features to being disabled at build time, which ultimately will result in faster build times and maybe smaller binaries.

## Testing Plan

Rebuild of all crates and re-run of all tests.

## Documentation

No doc change required.

## Breaking Change

Not a breaking change.