### PR TITLE
Notify Slack of fixture regeneration failure

### DIFF
--- a/.github/workflows/ci-regenerate-fixtures.yml
+++ b/.github/workflows/ci-regenerate-fixtures.yml
@@ -37,3 +37,12 @@ jobs:
 
       - name: Run slow tests
         run: JEST_TIMEOUT=1000000000 yarn test:slow:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
+
+      - name: Report Status
+        if: always()
+        uses: ravsamhq/notify-slack-action@master
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.GITHUB_ACTIONS_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary
Notify slack that the CI job to run tests that regenerate fixtures has failed

## Testing Plan
Testing running the job manually

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
