### PR TITLE
Remove RPC Server from Router

### DIFF
--- a/ironfish/src/rpc/adapters/httpAdapter.ts
+++ b/ironfish/src/rpc/adapters/httpAdapter.ts
@@ -27,6 +27,7 @@ export type HttpRpcError = {
 export class RpcHttpAdapter implements IRpcAdapter {
   server: http.Server | null = null
   router: Router | null = null
+  rpcServer: RpcServer | null = null
 
   readonly host: string
   readonly port: number
@@ -60,8 +61,9 @@ export class RpcHttpAdapter implements IRpcAdapter {
     this.requests = new Map()
   }
 
-  attach(server: RpcServer): void | Promise<void> {
-    this.router = server.getRouter(this.namespaces)
+  attach(rpcServer: RpcServer): void | Promise<void> {
+    this.rpcServer = rpcServer
+    this.router = rpcServer.getRouter(this.namespaces)
   }
 
   start(): Promise<void> {
@@ -164,7 +166,7 @@ export class RpcHttpAdapter implements IRpcAdapter {
     response: http.ServerResponse,
     requestId: string,
   ): Promise<void> {
-    if (this.router === null || this.router.server === null) {
+    if (this.router === null || this.rpcServer === null) {
       throw new ResponseError('Tried to connect to unmounted adapter')
     }
 

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -7,7 +7,6 @@ import { StrEnumUtils } from '../../utils/enums'
 import { ERROR_CODES } from '../adapters'
 import { ResponseError, ValidationError } from '../adapters/errors'
 import { RpcRequest } from '../request'
-import { RpcServer } from '../server'
 
 export enum ApiNamespace {
   chain = 'chain',
@@ -51,11 +50,11 @@ export function parseRoute(
 
 export class Router {
   routes = new Routes()
-  server: RpcServer
+  context: RequestContext
 
-  constructor(routes: Routes, server: RpcServer) {
+  constructor(routes: Routes, context: RequestContext) {
     this.routes = routes
-    this.server = server
+    this.context = context
   }
 
   async route(route: string, request: RpcRequest): Promise<void> {
@@ -75,7 +74,7 @@ export class Router {
     request.data = result
 
     try {
-      await handler(request, this.server.context)
+      await handler(request, this.context)
     } catch (e: unknown) {
       if (e instanceof ResponseError) {
         throw e

--- a/ironfish/src/rpc/server.ts
+++ b/ironfish/src/rpc/server.ts
@@ -32,7 +32,7 @@ export class RpcServer {
 
   /** Creates a new router from this RpcServer with the attached routes filtered by namespaces */
   getRouter(namespaces: ApiNamespace[]): Router {
-    return new Router(routes.filter(namespaces), this)
+    return new Router(routes.filter(namespaces), this.context)
   }
 
   /** Starts the RPC server and tells any attached adapters to starts serving requests to the routing layer */


### PR DESCRIPTION
## Summary
The `Router` only uses the `RPCServer` for its context and so that adapters can use the Router's server. It's cleaner if we just pass the server directly to the Adapters and the context to the `Router`. This also allows us to instantiate a `Router` in the memory client without creating an `RPCServer`.

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
