### PR TITLE
feat(cli,ironfish): Create a CLI helper to create a config client

### DIFF
--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -10,6 +10,7 @@ import { promisify } from 'util'
 import { IronfishCommand } from '../../command'
 import { ConfigFlag, ConfigFlagKey, DataDirFlag, DataDirFlagKey } from '../../flags'
 import { launchEditor } from '../../utils'
+import { connectRpcConfig } from '../../utils/clients'
 
 const mkdtempAsync = promisify(mkdtemp)
 const writeFileAsync = promisify(writeFile)
@@ -39,7 +40,7 @@ export class EditCommand extends IronfishCommand {
       this.exit(code || undefined)
     }
 
-    const client = await this.sdk.connectRpcConfig(!flags.remote)
+    const client = await connectRpcConfig(this.sdk, !flags.remote)
     const response = await client.config.getConfig({ user: true })
     const output = JSON.stringify(response.content, undefined, '   ')
 

--- a/ironfish-cli/src/commands/config/edit.ts
+++ b/ironfish-cli/src/commands/config/edit.ts
@@ -39,7 +39,7 @@ export class EditCommand extends IronfishCommand {
       this.exit(code || undefined)
     }
 
-    const client = await this.sdk.connectRpc(!flags.remote)
+    const client = await this.sdk.connectRpcConfig(!flags.remote)
     const response = await client.config.getConfig({ user: true })
     const output = JSON.stringify(response.content, undefined, '   ')
 

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -6,6 +6,7 @@ import { Flags } from '@oclif/core'
 import jsonColorizer from 'json-colorizer'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { connectRpcConfig } from '../../utils/clients'
 
 export class GetCommand extends IronfishCommand {
   static description = `Print out one config value`
@@ -44,7 +45,7 @@ export class GetCommand extends IronfishCommand {
     const { args, flags } = await this.parse(GetCommand)
     const name = (args.name as string).trim()
 
-    const client = await this.sdk.connectRpcConfig(flags.local)
+    const client = await connectRpcConfig(this.sdk, flags.local)
 
     const response = await client.config.getConfig({
       user: flags.user,

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -44,7 +44,7 @@ export class GetCommand extends IronfishCommand {
     const { args, flags } = await this.parse(GetCommand)
     const name = (args.name as string).trim()
 
-    const client = await this.sdk.connectRpc(flags.local)
+    const client = await this.sdk.connectRpcConfig(flags.local)
 
     const response = await client.config.getConfig({
       user: flags.user,

--- a/ironfish-cli/src/commands/config/index.ts
+++ b/ironfish-cli/src/commands/config/index.ts
@@ -25,7 +25,7 @@ export class ShowCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(ShowCommand)
 
-    const client = await this.sdk.connectRpc(flags.local)
+    const client = await this.sdk.connectRpcConfig(flags.local)
     const response = await client.config.getConfig({ user: flags.user })
 
     let output = JSON.stringify(response.content, undefined, '   ')

--- a/ironfish-cli/src/commands/config/index.ts
+++ b/ironfish-cli/src/commands/config/index.ts
@@ -6,6 +6,7 @@ import jsonColorizer from 'json-colorizer'
 import { IronfishCommand } from '../../command'
 import { ColorFlag, ColorFlagKey } from '../../flags'
 import { RemoteFlags } from '../../flags'
+import { connectRpcConfig } from '../../utils/clients'
 
 export class ShowCommand extends IronfishCommand {
   static description = `Print out the entire config`
@@ -25,7 +26,7 @@ export class ShowCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(ShowCommand)
 
-    const client = await this.sdk.connectRpcConfig(flags.local)
+    const client = await connectRpcConfig(this.sdk, flags.local)
     const response = await client.config.getConfig({ user: flags.user })
 
     let output = JSON.stringify(response.content, undefined, '   ')

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -4,6 +4,7 @@
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { connectRpcConfig } from '../../utils/clients'
 
 export class SetCommand extends IronfishCommand {
   static description = `Set a value in the config`
@@ -40,7 +41,7 @@ export class SetCommand extends IronfishCommand {
     const name = args.name as string
     const value = args.value as string
 
-    const client = await this.sdk.connectRpcConfig(flags.local)
+    const client = await connectRpcConfig(this.sdk, flags.local)
     await client.config.setConfig({ name, value })
 
     this.exit(0)

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -40,7 +40,7 @@ export class SetCommand extends IronfishCommand {
     const name = args.name as string
     const value = args.value as string
 
-    const client = await this.sdk.connectRpc(flags.local)
+    const client = await this.sdk.connectRpcConfig(flags.local)
     await client.config.setConfig({ name, value })
 
     this.exit(0)

--- a/ironfish-cli/src/commands/config/unset.ts
+++ b/ironfish-cli/src/commands/config/unset.ts
@@ -4,6 +4,7 @@
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
+import { connectRpcConfig } from '../../utils/clients'
 
 export class UnsetCommand extends IronfishCommand {
   static description = `Unset a value in the config and fall back to default`
@@ -31,7 +32,7 @@ export class UnsetCommand extends IronfishCommand {
     const { args, flags } = await this.parse(UnsetCommand)
     const name = args.name as string
 
-    const client = await this.sdk.connectRpcConfig(flags.local)
+    const client = await connectRpcConfig(this.sdk, flags.local)
     await client.config.unsetConfig({ name })
 
     this.exit(0)

--- a/ironfish-cli/src/commands/config/unset.ts
+++ b/ironfish-cli/src/commands/config/unset.ts
@@ -31,7 +31,7 @@ export class UnsetCommand extends IronfishCommand {
     const { args, flags } = await this.parse(UnsetCommand)
     const name = args.name as string
 
-    const client = await this.sdk.connectRpc(flags.local)
+    const client = await this.sdk.connectRpcConfig(flags.local)
     await client.config.unsetConfig({ name })
 
     this.exit(0)

--- a/ironfish-cli/src/utils/clients.ts
+++ b/ironfish-cli/src/utils/clients.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { ApiNamespace, IronfishSdk, RpcClient, RpcMemoryClient } from '@ironfish/sdk'
+
+export async function connectRpcConfig(
+  sdk: IronfishSdk,
+  forceLocal = false,
+  forceRemote = false,
+): Promise<Pick<RpcClient, 'config'>> {
+  forceRemote = forceRemote || sdk.config.get('enableRpcTcp')
+
+  if (!forceLocal) {
+    if (forceRemote) {
+      await sdk.client.connect()
+      return sdk.client
+    }
+
+    const connected = await sdk.client.tryConnect()
+    if (connected) {
+      return sdk.client
+    }
+  }
+
+  // This connection uses a wallet node since that is the most granular type
+  // of node available. This can be refactored in the future if needed.
+  const node = await sdk.walletNode()
+  const clientMemory = new RpcMemoryClient(
+    sdk.logger,
+    node.rpc.getRouter([ApiNamespace.config]),
+  )
+  return clientMemory
+}

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -246,34 +246,6 @@ export class IronfishSdk {
     return node
   }
 
-  async connectRpcConfig(
-    forceLocal = false,
-    forceRemote = false,
-  ): Promise<Pick<RpcClient, 'config'>> {
-    forceRemote = forceRemote || this.config.get('enableRpcTcp')
-
-    if (!forceLocal) {
-      if (forceRemote) {
-        await this.client.connect()
-        return this.client
-      }
-
-      const connected = await this.client.tryConnect()
-      if (connected) {
-        return this.client
-      }
-    }
-
-    // This connection uses a wallet node since that is the most granular type
-    // of node available. This can be refactored in the future if needed.
-    const node = await this.walletNode()
-    const clientMemory = new RpcMemoryClient(
-      this.logger,
-      node.rpc.getRouter([ApiNamespace.config]),
-    )
-    return clientMemory
-  }
-
   async connectRpc(forceLocal = false, forceRemote = false): Promise<RpcClient> {
     forceRemote = forceRemote || this.config.get('enableRpcTcp')
 

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -246,6 +246,34 @@ export class IronfishSdk {
     return node
   }
 
+  async connectRpcConfig(
+    forceLocal = false,
+    forceRemote = false,
+  ): Promise<Pick<RpcClient, 'config'>> {
+    forceRemote = forceRemote || this.config.get('enableRpcTcp')
+
+    if (!forceLocal) {
+      if (forceRemote) {
+        await this.client.connect()
+        return this.client
+      }
+
+      const connected = await this.client.tryConnect()
+      if (connected) {
+        return this.client
+      }
+    }
+
+    // This connection uses a wallet node since that is the most granular type
+    // of node available. This can be refactored in the future if needed.
+    const node = await this.walletNode()
+    const clientMemory = new RpcMemoryClient(
+      this.logger,
+      node.rpc.getRouter([ApiNamespace.config]),
+    )
+    return clientMemory
+  }
+
   async connectRpc(forceLocal = false, forceRemote = false): Promise<RpcClient> {
     forceRemote = forceRemote || this.config.get('enableRpcTcp')
 


### PR DESCRIPTION
## Summary

The CLI commands under the config namespace can be run for both a standalone wallet and full node. This code change creates a client wrapper that does not open the database and uses a wallet node to instantiate an RPC client.

Some considerations as part of this change:
* We can create a parent `IronfishNode` class which the `FullNode` and `WalletNode` inherit from, and that can be used in this call. This design seems like a convenience rather than getting a benefit of a lot of shared logic (outside of just storing properties). This would also need some updates to the migration system and potentially refactoring how arguments are passed into the RPC.
* We can use the existing `connectRpc` and add some arguments. This can be a future improvement as there's probably a way to leverage generics with the RpcClient and namespaces, but the goal of this is to get something working. We will come back and investigate it.

## Testing Plan

Ran CLI commands under config namespace

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
