### PR TITLE
syncs pending transactions from event/onTransactionGossip

### DIFF
--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -158,12 +158,6 @@ export class FullNode {
       this.telemetry.submitBlockMined(block)
     })
 
-    this.peerNetwork.onTransactionGossipReceived.on((transaction, valid) => {
-      if (valid) {
-        void wallet.addPendingTransaction(transaction)
-      }
-    })
-
     this.peerNetwork.onTransactionAccepted.on((transaction, received) => {
       this.telemetry.submitNewTransactionSeen(transaction, received)
     })


### PR DESCRIPTION
## Summary

uses the wallet nodeClient to connect to the event/onTransactionGossip RPC to sync pending transactions from the node to the wallet

runs syncTransactionGossip in a coroutine on each eventLoop iteration to handle failures and disconnects in the stream

adds a boolean isSyncingTransactionGossip to avoid concurrent syncing streams

removes event-based sync from peerNetwork

## Testing Plan

- manual testing
- simulator testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
