### PR TITLE
[Deploy Node Image GW] support GitHub image from sha

### DIFF
--- a/.github/workflows/deploy-node-docker-image.yml
+++ b/.github/workflows/deploy-node-docker-image.yml
@@ -10,6 +10,10 @@ on:
         description: 'GitHub:testnet'
         type: boolean
         default: false
+      github_tag_git_sha:
+        description: 'GitHub:{GIT_SHA}'
+        type: boolean
+        default: false
       aws_tag_mainnet:
         description: 'AWS:mainnet'
         type: boolean
@@ -83,6 +87,12 @@ jobs:
         run: |
           docker tag ironfish ghcr.io/iron-fish/ironfish:testnet
           docker push ghcr.io/iron-fish/ironfish:testnet
+      
+      - name: Deploy Node Image to GitHub:${{ github.sha }}
+        if: ${{ inputs.github_tag_git_sha }}
+        run: |
+          docker tag ironfish ghcr.io/iron-fish/ironfish:${{ github.sha }}
+          docker push ghcr.io/iron-fish/ironfish:${{ github.sha }}
 
       - name: Deploy Node Image to AWS:mainnet
         if: ${{ inputs.aws_tag_mainnet }}


### PR DESCRIPTION
## Summary
support GitHub image from sha
## Testing Plan
run GW
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@dguenther @iron-fish/engineering 