### PR TITLE
adding information to readme about cli docs on the website

### DIFF
--- a/ironfish-cli/README.md
+++ b/ironfish-cli/README.md
@@ -101,3 +101,26 @@ yarn start start --datadir ~/.ironfish2 --port 9034 --bootstrap ws://localhost:9
 # in tab 4
 yarn start miners:start --datadir ~/.ironfish2
 ```
+
+**Running a Development Node**
+
+```bash
+# in tab 1
+yarn start start --networkId=2 --datadir ~/.ironfish-dev 
+
+# in tab 2
+yarn start miners:start --datadir ~/.ironfish-dev
+
+# in tab 3, to check the status of the node
+yarn start status --datadir ~/.ironfish-dev 
+
+# in tab 3, to check the wallet balance
+yarn start wallet:balance --datadir ~/.ironfish-dev 
+```
+
+[More information on local mining and testing](https://ironfish.network/developers/documentation/integration_local)
+
+
+## Documentation
+
+[CLI Commands](https://ironfish.network/use/get-started/cli-commands)


### PR DESCRIPTION
## Summary

README update for the CLI commands. As a new dev on the team, I thought it would be useful to have documentation to the CLI linked here. Also, making it clear that you can run the same commands on a different network (devnet) was helpful. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
