### PR TITLE
feat(cli,ironfish): Add SDK method to connect to wallet rpc client

### DIFF
--- a/ironfish-cli/src/commands/rpc/status.ts
+++ b/ironfish-cli/src/commands/rpc/status.ts
@@ -23,7 +23,7 @@ export default class Status extends IronfishCommand {
     const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
-      const client = await this.sdk.connectRpc()
+      const client = await this.sdk.connectWalletRpc()
       const response = await client.rpc.getRpcStatus()
       this.log(renderStatus(response.content))
       this.exit(0)

--- a/ironfish-cli/src/commands/wallet/accounts.ts
+++ b/ironfish-cli/src/commands/wallet/accounts.ts
@@ -19,7 +19,7 @@ export class AccountsCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(AccountsCommand)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     const response = await client.wallet.getAccounts({ displayName: flags.displayName })
 

--- a/ironfish-cli/src/commands/wallet/address.ts
+++ b/ironfish-cli/src/commands/wallet/address.ts
@@ -26,7 +26,7 @@ export class AddressCommand extends IronfishCommand {
     const { args } = await this.parse(AddressCommand)
     const account = args.account as string | undefined
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     const response = await client.wallet.getAccountPublicKey({
       account: account,

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -43,7 +43,7 @@ export class AssetsCommand extends IronfishCommand {
     const { flags, args } = await this.parse(AssetsCommand)
     const account = args.account as string | undefined
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
     const response = client.wallet.getAssets({
       account,
     })

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -47,7 +47,7 @@ export class BalanceCommand extends IronfishCommand {
     const { flags, args } = await this.parse(BalanceCommand)
     const account = args.account as string | undefined
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     const response = await client.wallet.getAccountBalance({
       account,

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -34,7 +34,7 @@ export class BalancesCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags, args } = await this.parse(BalancesCommand)
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     const account = args.account as string | undefined
     const response = await client.wallet.getAccountBalances({

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -79,7 +79,7 @@ export class Burn extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(Burn)
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     if (!flags.offline) {
       const status = await client.wallet.getNodeStatus()

--- a/ironfish-cli/src/commands/wallet/create.ts
+++ b/ironfish-cli/src/commands/wallet/create.ts
@@ -32,7 +32,7 @@ export class CreateCommand extends IronfishCommand {
       })
     }
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     this.log(`Creating account ${name}`)
     const result = await client.wallet.createAccount({ name })

--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -35,7 +35,7 @@ export class DeleteCommand extends IronfishCommand {
     const wait = flags.wait
     const account = args.account as string
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     CliUx.ux.action.start(`Deleting account '${account}'`)
     const response = await client.wallet.removeAccount({ account, confirm, wait })

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -68,7 +68,7 @@ export class ExportCommand extends IronfishCommand {
       ? AccountFormat.JSON
       : AccountFormat.Bech32
 
-    const client = await this.sdk.connectRpc(local)
+    const client = await this.sdk.connectWalletRpc(local)
     const response = await client.wallet.exportAccount({
       account,
       viewOnly,

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -37,7 +37,7 @@ export class ImportCommand extends IronfishCommand {
     const { flags, args } = await this.parse(ImportCommand)
     const blob = args.blob as string | undefined
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     let account: string
     if (blob) {

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -91,7 +91,7 @@ export class Mint extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(Mint)
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     if (!flags.offline) {
       const status = await client.wallet.getNodeStatus()

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -29,7 +29,7 @@ export class NotesCommand extends IronfishCommand {
     const { flags, args } = await this.parse(NotesCommand)
     const account = args.account as string | undefined
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     const response = client.wallet.getAccountNotesStream({ account })
 

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -55,7 +55,7 @@ export class PostCommand extends IronfishCommand {
     const serialized = Buffer.from(transaction, 'hex')
     const raw = RawTransactionSerde.deserialize(serialized)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     if (!flags.confirm) {
       const confirm = await this.confirm(client, raw, flags.account)
@@ -95,7 +95,11 @@ export class PostCommand extends IronfishCommand {
     }
   }
 
-  async confirm(client: RpcClient, raw: RawTransaction, account?: string): Promise<boolean> {
+  async confirm(
+    client: Pick<RpcClient, 'wallet'>,
+    raw: RawTransaction,
+    account?: string,
+  ): Promise<boolean> {
     if (!account) {
       const response = await client.wallet.getDefaultAccount()
 

--- a/ironfish-cli/src/commands/wallet/rename.ts
+++ b/ironfish-cli/src/commands/wallet/rename.ts
@@ -31,7 +31,7 @@ export class RenameCommand extends IronfishCommand {
     const account = args.account as string
     const newName = args['new-name'] as string
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
     await client.wallet.renameAccount({ account, newName })
     this.log(`Account ${account} renamed to ${newName}`)
   }

--- a/ironfish-cli/src/commands/wallet/rescan.ts
+++ b/ironfish-cli/src/commands/wallet/rescan.ts
@@ -38,7 +38,7 @@ export class RescanCommand extends IronfishCommand {
       this.error('You cannot pass both --local and --no-follow')
     }
 
-    const client = await this.sdk.connectRpc(local)
+    const client = await this.sdk.connectWalletRpc()
 
     CliUx.ux.action.start('Asking node to start scanning', undefined, {
       stdout: true,

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -99,7 +99,7 @@ export class Send extends IronfishCommand {
     let to = flags.to?.trim()
     let from = flags.account?.trim()
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     if (!flags.offline) {
       const status = await client.wallet.getNodeStatus()

--- a/ironfish-cli/src/commands/wallet/status.ts
+++ b/ironfish-cli/src/commands/wallet/status.ts
@@ -17,7 +17,7 @@ export class StatusCommand extends IronfishCommand {
     const { args, flags } = await this.parse(StatusCommand)
     const account = args.account as string | undefined
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     const response = await client.wallet.getAccountsStatus({
       account: account,

--- a/ironfish-cli/src/commands/wallet/transaction/add.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/add.ts
@@ -31,7 +31,7 @@ export class TransactionAddCommand extends IronfishCommand {
     const transaction = args.transaction as string
 
     CliUx.ux.action.start(`Adding transaction`)
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
     const response = await client.wallet.addTransaction({
       transaction,
       broadcast: flags.broadcast,

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -33,7 +33,7 @@ export class TransactionCommand extends IronfishCommand {
     const hash = args.hash as string
     const account = args.account as string | undefined
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     const response = await client.wallet.getAccountTransaction({ account, hash })
 

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -37,7 +37,7 @@ export class WatchTxCommand extends IronfishCommand {
     const hash = args.hash as string
     const account = args.account as string | undefined
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     await watchTransaction({
       client,

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -66,7 +66,7 @@ export class TransactionsCommand extends IronfishCommand {
         ? Format.yaml
         : Format.cli
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
     const response = client.wallet.getAccountTransactionsStream({
       account,
       hash: flags.hash,

--- a/ironfish-cli/src/commands/wallet/use.ts
+++ b/ironfish-cli/src/commands/wallet/use.ts
@@ -24,7 +24,7 @@ export class UseCommand extends IronfishCommand {
     const { args } = await this.parse(UseCommand)
     const account = args.account as string
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
     await client.wallet.useAccount({ account })
     this.log(`The default account is now: ${account}`)
   }

--- a/ironfish-cli/src/commands/wallet/which.ts
+++ b/ironfish-cli/src/commands/wallet/which.ts
@@ -23,7 +23,7 @@ export class WhichCommand extends IronfishCommand {
   async start(): Promise<void> {
     const { flags } = await this.parse(WhichCommand)
 
-    const client = await this.sdk.connectRpc()
+    const client = await this.sdk.connectWalletRpc()
 
     const {
       content: {

--- a/ironfish-cli/src/commands/workers/status.ts
+++ b/ironfish-cli/src/commands/workers/status.ts
@@ -23,7 +23,7 @@ export default class Status extends IronfishCommand {
     const { flags } = await this.parse(Status)
 
     if (!flags.follow) {
-      const client = await this.sdk.connectRpc()
+      const client = await this.sdk.connectWalletRpc()
       const response = await client.worker.getWorkersStatus()
       this.log(renderStatus(response.content))
       this.exit(0)

--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -70,7 +70,7 @@ export function compareAssets(
 }
 
 export async function selectAsset(
-  client: RpcClient,
+  client: Pick<RpcClient, 'wallet'>,
   account: string | undefined,
   options: {
     action: string

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -7,7 +7,7 @@ import { Assert, CurrencyUtils, Logger, RpcClient } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 
 export async function promptCurrency(options: {
-  client: RpcClient
+  client: Pick<RpcClient, 'wallet'>
   text: string
   logger: Logger
   required: true
@@ -20,7 +20,7 @@ export async function promptCurrency(options: {
 }): Promise<bigint>
 
 export async function promptCurrency(options: {
-  client: RpcClient
+  client: Pick<RpcClient, 'wallet'>
   text: string
   logger: Logger
   required?: boolean

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -18,7 +18,7 @@ import inquirer from 'inquirer'
 import { promptCurrency } from './currency'
 
 export async function selectFee(options: {
-  client: RpcClient
+  client: Pick<RpcClient, 'wallet'>
   transaction: CreateTransactionRequest
   account?: string
   confirmations?: number
@@ -92,7 +92,7 @@ export async function selectFee(options: {
 }
 
 async function getTxWithFee(
-  client: RpcClient,
+  client: Pick<RpcClient, 'wallet'>,
   params: CreateTransactionRequest,
   feeRate: bigint,
 ): Promise<RawTransaction | null> {

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -13,7 +13,7 @@ import {
 import { CliUx } from '@oclif/core'
 
 export async function watchTransaction(options: {
-  client: RpcClient
+  client: Pick<RpcClient, 'wallet'>
   hash: string
   account?: string
   confirmations?: number


### PR DESCRIPTION
## Summary

The SDK creates an RPC client when initialized. Config, rpc, wallet, and worker namespaced CLI commands connect to this RPC client but need to work for both a full node and standalone wallet. This code change adds a new SDK method to connect to the client property but default to a wallet node's memory client on failures or if local / remote is not forced.

We can move this as a utility into the CLI as well, but it seems better to offer this in the SDK for both node types.

There were alternatives that were considered (ex. writing the running context to a store), but this is a quick and functional solution without side effects that can be iterated upon in the future.

## Testing Plan

Running CLI commands under the updated namespaces

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
