### PR TITLE
adds limit to block events in remoteChainProcessor updates

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -294,6 +294,7 @@ export type ConfigOptions = {
   walletNodeTcpPort: number
   walletNodeTlsEnabled: boolean
   walletNodeRpcAuthToken: string
+  walletSyncingMaxQueueSize: number
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -380,6 +381,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     walletNodeTcpPort: yup.number(),
     walletNodeTlsEnabled: yup.boolean(),
     walletNodeRpcAuthToken: yup.string(),
+    walletSyncingMaxQueueSize: yup.number(),
   })
   .defined()
 
@@ -480,6 +482,7 @@ export class Config extends KeyStore<ConfigOptions> {
       walletNodeTcpPort: 8020,
       walletNodeTlsEnabled: true,
       walletNodeRpcAuthToken: '',
+      walletSyncingMaxQueueSize: 100,
     }
   }
 }

--- a/ironfish/src/rpc/response.ts
+++ b/ironfish/src/rpc/response.ts
@@ -22,7 +22,7 @@ export type RpcResponseEnded<TEnd> = Exclude<RpcResponse<TEnd>, 'content'> & { c
 
 export class RpcResponse<TEnd = unknown, TStream = unknown> {
   private promise: Promise<TEnd>
-  stream: Stream<TStream>
+  private stream: Stream<TStream>
   private timeout: SetTimeoutToken | null
 
   status = 0

--- a/ironfish/src/rpc/response.ts
+++ b/ironfish/src/rpc/response.ts
@@ -22,7 +22,7 @@ export type RpcResponseEnded<TEnd> = Exclude<RpcResponse<TEnd>, 'content'> & { c
 
 export class RpcResponse<TEnd = unknown, TStream = unknown> {
   private promise: Promise<TEnd>
-  private stream: Stream<TStream>
+  stream: Stream<TStream>
   private timeout: SetTimeoutToken | null
 
   status = 0

--- a/ironfish/src/rpc/routes/chain/__fixtures__/followChainStream.test.ts.fixture
+++ b/ironfish/src/rpc/routes/chain/__fixtures__/followChainStream.test.ts.fixture
@@ -54,5 +54,59 @@
         }
       ]
     }
+  ],
+  "Route chain/followChainStream ends the stream if the limit is reached": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:3lr+dTcz2jrtSqwHYboWZ0oKs/8CKkYlcJV27FgIxFc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:snT+nOYjPJhtlZ852XzoQYGWzO68BJIWVCoOcG34Skg="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1691522320266,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAdNgqHnmFqx71AaFVNFSklLDT/a4vOAAY4dhsvqLBGSyJFgY9uC/taw3wSAq7WUxaYOuXREMQKBvCBvNbB6nGvfSz2qAHSViuMjrPuwYviz6AVYYBQ7JhCXKkN3ODCjnhu682ek3Dqrk9TfHqjTAJ7D1kWe0+mMRjIARDOAeASf0SwwDpXOrXxgrnYNlXFeovRSHMoVazVmrc/GDEdbepoypTx3SAxBG3DXVUya6u2xmP/5n7b8cXEmMjbglQikdy/MJxCozCrAO3Sn7KzOUubZaKJ7qeyqxMN2QhaStbi4gaRv0oA6kcgYa6Om0LCNM7uqWN74wrh0I+oPJsF1djojTWPWj9XsGbZ0p1X2YmveCcP9+EDiE+LvVoFK3R6n8I9NRov7P38qXu9d3nHpoCXFXF1aXflGUh2x8qtHrwuK6LslRS+ckndSViiv0PgOXygSxlSBWilvudapjjR9M5jHzblnIGPv+15iS7k35KkLkdEGNxxaxFwuDwRD8PB+NmEkIMC33RsnYhAP/JROCgfqh5DTcpsexSGtrg0n+Ka+9369lawADWSJur1HEORwPckANsPc9aQ+CL+OrWWyyZckDZOOnJuWA94Ip5hbRfoaaA6Gj5JMf9oUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwe/wYWCUneKb+EaqkdFK1wvc+WmjQFkYbo76sQ2pNq81jMB/qeDbbf188Xazk8VCaPnG12DZ4lsAoLUiWb2vQAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "263BADA923AA78BBE5593FD8BCD01484C4E89B2D1BD3A89534297D9B957EA3F5",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:EzgjoeM+XqklZx2LjQayXbIOs0EJIwKduCtJSIU5V0c="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:E+Zp+Evf5aPEE9Rwp36sjN5DtZgJJCG+4/FO3EPJs4k="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1691522320740,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAUamyofxqikB37BpFCJvNiCNsKl++TB4nGGyRLiEJtyehFPAamhFxp4RJiKZ11h+Ab+mMhKeexPFpAZD5lmHoWsF/9efxgE4R/3Ze7+etHoKI3DhQbDPsYjLI+dzILTGAzM+CNxlP33e4TiJ3lbaj/Ip73VVxeJ+SHBDYHaDdAoQBMFdXB/ueusvjrm3lo3HmdUB7nVwz/RgRZfxVx++f0FVU7j8MFwWJ94T2d5dUBtSwDGz3LPWt0RvAciHNjfvw93kX/eRVqxrz57e4dEo2VfiL2nwM6qolKtzc2yhuBH+y/IZRFKA4Ke7pmlkFExtuyG4tFZZzfVxqwby5/hcsTrsR711d+hyDVjIn1zJEntM1siebqjslvJMKRWCloeRrjQlUa0BE5om9PriIPJvKn+5u85upSuAbC2OP/yDYNoNiLrvwbRq31RvO8tOSxGOenxvCyMzE6glA757sd7Zsgoj7UsS8hexFHZdcyleQmsWllsRkUV/7SK51cxs+qMhhKSDU9+aAa0I49D1k85iHehc5SuPzBOoPNAg/KBx7vQGm85/6up7FtmClUXswt9ajps5gsYg3nT88IB/r1zTaqO2xkuVQnNmshlUe6tMG1X0Li3dmaBh8CUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmVMDsCUwrWdBYBgt9FlyYbIu9dQ0wFQxiZIK0hMs0+pEQmMx557RbcgoF+9+bysqkjfBqm7nkpxJJ/HtXYe8DA=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/rpc/routes/chain/followChainStream.test.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.test.ts
@@ -84,12 +84,6 @@ describe('Route chain/followChainStream', () => {
     })
 
     streamed = await chainStream.contentStream().next()
-    expect(streamed?.value).toMatchObject({
-      type: 'connected',
-      block: { hash: blockA1.header.hash.toString('hex') },
-    })
-
-    streamed = await chainStream.contentStream().next()
     expect(streamed?.value).toBeUndefined()
     expect(streamed?.done).toBe(true)
   })

--- a/ironfish/src/rpc/routes/chain/followChainStream.test.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.test.ts
@@ -62,4 +62,35 @@ describe('Route chain/followChainStream', () => {
       },
     })
   })
+
+  it('ends the stream if the limit is reached', async () => {
+    const { chain } = routeTest
+    await chain.open()
+
+    const blockA1 = await useMinerBlockFixture(chain)
+
+    await expect(chain).toAddBlock(blockA1)
+
+    const blockA2 = await useMinerBlockFixture(chain)
+
+    await expect(chain).toAddBlock(blockA2)
+
+    chainStream = routeTest.client.request('chain/followChainStream', { limit: 1 })
+
+    let streamed = await chainStream.contentStream().next()
+    expect(streamed?.value).toMatchObject({
+      type: 'connected',
+      block: { hash: chain.genesis.hash.toString('hex') },
+    })
+
+    streamed = await chainStream.contentStream().next()
+    expect(streamed?.value).toMatchObject({
+      type: 'connected',
+      block: { hash: blockA1.header.hash.toString('hex') },
+    })
+
+    streamed = await chainStream.contentStream().next()
+    expect(streamed?.value).toBeUndefined()
+    expect(streamed?.done).toBe(true)
+  })
 })

--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -141,7 +141,7 @@ routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
         },
       })
 
-      if (request.data?.limit && streamed++ >= request.data.limit) {
+      if (request.data?.limit && ++streamed >= request.data.limit) {
         onClose()
         request.end()
       }

--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -17,6 +17,7 @@ export type FollowChainStreamRequest =
       head?: string | null
       serialized?: boolean
       wait?: boolean
+      limit?: number
     }
   | undefined
 
@@ -45,6 +46,7 @@ export const FollowChainStreamRequestSchema: yup.ObjectSchema<FollowChainStreamR
     head: yup.string().nullable().optional(),
     serialized: yup.boolean().optional(),
     wait: yup.boolean().optional().default(true),
+    limit: yup.number().optional(),
   })
   .optional()
 
@@ -86,6 +88,8 @@ routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
       logger: node.logger,
       head: head,
     })
+
+    let streamed = 0
 
     const send = (block: Block, type: 'connected' | 'disconnected' | 'fork') => {
       const transactions = block.transactions.map((transaction) => ({
@@ -136,6 +140,11 @@ routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
           transactions,
         },
       })
+
+      if (request.data?.limit && streamed++ >= request.data.limit) {
+        onClose()
+        request.end()
+      }
     }
 
     const onClose = () => {

--- a/ironfish/src/wallet/remoteChainProcessor.test.ts
+++ b/ironfish/src/wallet/remoteChainProcessor.test.ts
@@ -43,6 +43,7 @@ describe('RemoteChainProcessor', () => {
       logger: nodeA.logger,
       head: chain.genesis.hash,
       nodeClient: client,
+      maxQueueSize: 10,
     })
 
     const onEvent: jest.Mock<void, [WalletBlockHeader, 'add' | 'remove']> = jest.fn()
@@ -97,6 +98,7 @@ describe('RemoteChainProcessor', () => {
       logger: node.logger,
       head: chain.genesis.hash,
       nodeClient: client,
+      maxQueueSize: 10,
     })
 
     const onEvent: jest.Mock<void, [WalletBlockHeader, 'add' | 'remove']> = jest.fn()
@@ -140,6 +142,7 @@ describe('RemoteChainProcessor', () => {
       logger: node.logger,
       head: chain.genesis.hash,
       nodeClient: client,
+      maxQueueSize: 10,
     })
 
     const blockA1 = await useMinerBlockFixture(chain)

--- a/ironfish/src/wallet/remoteChainProcessor.ts
+++ b/ironfish/src/wallet/remoteChainProcessor.ts
@@ -25,16 +25,23 @@ export class RemoteChainProcessor {
   sequence: number | null = null
   logger: Logger
   nodeClient: RpcClient
+  maxQueueSize: number
 
   onAdd = new Event<[{ header: WalletBlockHeader; transactions: WalletBlockTransaction[] }]>()
   onRemove = new Event<
     [{ header: WalletBlockHeader; transactions: WalletBlockTransaction[] }]
   >()
 
-  constructor(options: { logger: Logger; nodeClient: RpcClient; head: Buffer | null }) {
+  constructor(options: {
+    logger: Logger
+    nodeClient: RpcClient
+    head: Buffer | null
+    maxQueueSize: number
+  }) {
     this.logger = options.logger
     this.nodeClient = options.nodeClient
     this.hash = options.head
+    this.maxQueueSize = options.maxQueueSize
   }
 
   async update({ signal }: { signal?: AbortSignal } = {}): Promise<{ hashChanged: boolean }> {
@@ -42,6 +49,7 @@ export class RemoteChainProcessor {
       head: this.hash?.toString('hex') ?? null,
       serialized: true,
       wait: false,
+      limit: this.maxQueueSize,
     })
 
     const oldHash = this.hash

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -687,13 +687,11 @@ export class Wallet {
       await this.disconnectBlock(header, transactions)
     })
 
-    let currentHash = scanProcessor.hash
+    let { hashChanged } = await scanProcessor.update({ signal: scan.abortController.signal })
 
-    await scanProcessor.update({ signal: scan.abortController.signal })
-
-    while (!BufferUtils.equalsNullable(scanProcessor.hash, currentHash)) {
-      currentHash = scanProcessor.hash
-      await scanProcessor.update({ signal: scan.abortController.signal })
+    while (hashChanged) {
+      const result = await scanProcessor.update({ signal: scan.abortController.signal })
+      hashChanged = result.hashChanged
     }
 
     // Update chainProcessor following scan

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -687,8 +687,13 @@ export class Wallet {
       await this.disconnectBlock(header, transactions)
     })
 
-    while (scanProcessor.sequence ?? 1 <= chainHead.sequence) {
+    let currentHash = scanProcessor.hash
+
+    await scanProcessor.update({ signal: scan.abortController.signal })
+
+    while (!BufferUtils.equalsNullable(scanProcessor.hash, currentHash)) {
       await scanProcessor.update({ signal: scan.abortController.signal })
+      currentHash = scanProcessor.hash
     }
 
     // Update chainProcessor following scan

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -687,12 +687,11 @@ export class Wallet {
       await this.disconnectBlock(header, transactions)
     })
 
-    let { hashChanged } = await scanProcessor.update({ signal: scan.abortController.signal })
-
-    while (hashChanged) {
-      const result = await scanProcessor.update({ signal: scan.abortController.signal })
-      hashChanged = result.hashChanged
-    }
+    let hashChanged = false
+    do {
+      hashChanged = (await scanProcessor.update({ signal: scan.abortController.signal }))
+        .hashChanged
+    } while (hashChanged)
 
     // Update chainProcessor following scan
     this.chainProcessor.hash = scanProcessor.hash

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -692,8 +692,8 @@ export class Wallet {
     await scanProcessor.update({ signal: scan.abortController.signal })
 
     while (!BufferUtils.equalsNullable(scanProcessor.hash, currentHash)) {
-      await scanProcessor.update({ signal: scan.abortController.signal })
       currentHash = scanProcessor.hash
+      await scanProcessor.update({ signal: scan.abortController.signal })
     }
 
     // Update chainProcessor following scan


### PR DESCRIPTION
## Summary

remoteChainProcessor uses the chain/followChainStream RPC to stream block events from a node. the endpoint can write messages to the queue much more quickly than the wallet consumes them because the wallet decrypts the notes on each transaction on each block as it processes the stream

adds a 'limit' parameter to the chain/followChainStream RPC to close the stream once that number of events have been streamed to the client

adds a wallet config, 'walletSyncingMaxQueueSize', to configure the limit to use when syncing or scanning using the RemoteChainProcessor

updates scanTransactions to make multiple calls to 'update' until the RemoteChainProcessor instance used for scanning has reached a sequence greater than or equal to the head of the chain when the scan began

## Testing Plan

- unit tests
- manual testing: rescanning on mainnet, testnet, devnet

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
