### PR TITLE
speeds up findFork for linear fast forward case

### DIFF
--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -363,6 +363,10 @@ export class Blockchain {
     let [base, fork] =
       headerA.sequence < headerB.sequence ? [headerA, headerB] : [headerB, headerA]
 
+    if ((await this.isHeadChain(base, tx)) && (await this.isHeadChain(fork, tx))) {
+      return base
+    }
+
     while (!base.hash.equals(fork.hash)) {
       // Move
       while (fork.sequence > base.sequence) {


### PR DESCRIPTION
## Summary

from the docstring of find fork: 'If one block is a linear fast forward to the other with no forks, then the earlier block will be returned.'

in the case of a linear fast forward where both blocks are on the head chain we can short-circuit the findFork logic and immediately return the earlier block without iterating from one block to the other.

this helps speed up wallet rescans that make multiple calls to the 'chain/followChainStream' RPC: each call finds the fork between the current head of the node's chain and the hash passed to the RPC

## Testing Plan

- existing unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
