### PR TITLE
Check transactions validity before syncing to the wallet

### DIFF
--- a/ironfish/src/rpc/routes/event/onTransactionGossip.ts
+++ b/ironfish/src/rpc/routes/event/onTransactionGossip.ts
@@ -12,6 +12,7 @@ export type OnTransactionGossipRequest = {} | undefined
 
 export type OnTransactionGossipResponse = {
   serializedTransaction: string
+  valid: boolean
 }
 
 export const OnTransactionGossipRequestSchema: yup.ObjectSchema<OnTransactionGossipRequest> =
@@ -21,6 +22,7 @@ export const OnTransactionGossipResponseSchema: yup.ObjectSchema<OnTransactionGo
   yup
     .object({
       serializedTransaction: yup.string().defined(),
+      valid: yup.boolean().defined(),
     })
     .defined()
 
@@ -30,9 +32,10 @@ routes.register<typeof OnTransactionGossipRequestSchema, OnTransactionGossipResp
   (request, node): void => {
     Assert.isInstanceOf(node, FullNode)
 
-    const onTransactionGossip = (transaction: Transaction) => {
+    const onTransactionGossip = (transaction: Transaction, valid: boolean) => {
       request.stream({
         serializedTransaction: transaction.serialize().toString('hex'),
+        valid,
       })
     }
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -324,6 +324,10 @@ export class Wallet {
       this.isSyncingTransactionGossip = true
 
       for await (const content of response.contentStream()) {
+        if (!content.valid) {
+          continue
+        }
+
         const transaction = new Transaction(Buffer.from(content.serializedTransaction, 'hex'))
         await this.addPendingTransaction(transaction)
       }


### PR DESCRIPTION
## Summary
When the wallet listens for incoming unconfirmed transactions, limit the, number of transactions the wallet can queue up before it starts dropping them.

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
