### PR TITLE
sets account.createdAt to null if nodeClient null

### DIFF
--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1325,12 +1325,9 @@ export class Wallet {
 
     const key = generateKey()
 
-    let createdAt = null
-    if (this.chainProcessor.hash && this.chainProcessor.sequence) {
-      createdAt = {
-        hash: this.chainProcessor.hash,
-        sequence: this.chainProcessor.sequence,
-      }
+    let createdAt: HeadValue | null = null
+    if (this.nodeClient) {
+      createdAt = await this.getChainHead()
     }
 
     const account = new Account({


### PR DESCRIPTION
## Summary

if the wallet does not have a nodeClient it cannot read the chain head from the node.

in that case we can only set the account createdAt to null on account creation.

this enables a standalone wallet to create accounts without an active connection to a node.

## Testing Plan

- manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
