### PR TITLE
MintDescription: make `transferOwnershipTo` a `Buffer` to be consistent with `owner`

### DIFF
--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -634,7 +634,9 @@ describe('Verifier', () => {
         asset,
         value,
         owner: Buffer.from(ownerAccount.publicAddress, 'hex'),
-        transferOwnershipTo: transferOwnershipTo ? transferOwnershipTo.publicAddress : null,
+        transferOwnershipTo: transferOwnershipTo
+          ? Buffer.from(transferOwnershipTo.publicAddress, 'hex')
+          : null,
       }
     }
 

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -632,8 +632,7 @@ export class Verifier {
         }
 
         if (transferOwnershipTo) {
-          const newOwner = Buffer.from(transferOwnershipTo, 'hex')
-          assetOwners.set(assetId, newOwner)
+          assetOwners.set(assetId, transferOwnershipTo)
         } else if (!assetOwners.has(assetId)) {
           assetOwners.set(assetId, existingAssetOwner)
         }

--- a/ironfish/src/primitives/mintDescription.ts
+++ b/ironfish/src/primitives/mintDescription.ts
@@ -7,5 +7,5 @@ export interface MintDescription {
   asset: Asset
   value: bigint
   owner: Buffer
-  transferOwnershipTo: string | null
+  transferOwnershipTo: Buffer | null
 }

--- a/ironfish/src/primitives/transaction.ts
+++ b/ironfish/src/primitives/transaction.ts
@@ -123,9 +123,8 @@ export class Transaction {
       let transferOwnershipTo = null
       if (TransactionFeatures.hasMintTransferOwnershipTo(this._version)) {
         owner = reader.readBytes(PUBLIC_ADDRESS_LENGTH)
-
         if (reader.readU8()) {
-          transferOwnershipTo = reader.readBytes(PUBLIC_ADDRESS_LENGTH).toString('hex')
+          transferOwnershipTo = reader.readBytes(PUBLIC_ADDRESS_LENGTH)
         }
       } else {
         owner = asset.creator()

--- a/ironfish/src/rpc/routes/chain/followChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/followChainStream.ts
@@ -114,7 +114,7 @@ routes.register<typeof FollowChainStreamRequestSchema, FollowChainStreamResponse
           name: BufferUtils.toHuman(mint.asset.name()),
           creator: mint.asset.creator().toString('hex'),
           value: mint.value.toString(),
-          transferOwnershipTo: mint.transferOwnershipTo ? mint.transferOwnershipTo : undefined,
+          transferOwnershipTo: mint.transferOwnershipTo?.toString('hex'),
         })),
         burns: transaction.burns.map((burn) => ({
           id: burn.assetId.toString('hex'),


### PR DESCRIPTION
## Summary

Changed `transferOwnershipTo` to a buffer so that it's easier to write code like `mint.transferOwnershipTo || mint.owner`.

## Testing Plan

Unit tests

## Documentation

No doc change required.

## Breaking Change

Not a breaking change.