### PR TITLE
fixes account import if wallet not conneted to node

### DIFF
--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -54,7 +54,7 @@ routes.register<typeof ImportAccountRequestSchema, ImportResponse>(
       ...accountImport,
     })
 
-    if (request.data.rescan) {
+    if (request.data.rescan && node.wallet.nodeClient) {
       void node.wallet.scanTransactions()
     } else {
       await node.wallet.skipRescan(account)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1392,6 +1392,16 @@ export class Wallet {
     validateAccount(accountValue)
 
     let createdAt = accountValue.createdAt
+
+    if (createdAt && !this.nodeClient) {
+      this.logger.debug(
+        `Wallet not connected to node to verify that account createdAt block ${createdAt.hash.toString(
+          'hex',
+        )} (${createdAt.sequence}) in chain. Setting createdAt to null`,
+      )
+      createdAt = null
+    }
+
     if (createdAt !== null && !(await this.chainHasBlock(createdAt.hash))) {
       this.logger.debug(
         `Account ${accountValue.name} createdAt block ${createdAt.hash.toString('hex')} (${


### PR DESCRIPTION
## Summary

importAccount has two dependencies on a node connection: it checks to see if the account birthday is in the chain and it (by default) begins a scan following import. if there is no connection to a running node the wallet cannot do either of these things.

fixes node connection dependencies in import:
- sets account createdAt to null if it cannot be checked against the chain. this is what the wallet does during import if the account birthday is not found in the chain
- skips rescanning if there is no node connection

## Testing Plan

manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
