### PR TITLE
requires node connection for wallet:status

### DIFF
--- a/ironfish-cli/src/commands/wallet/status.ts
+++ b/ironfish-cli/src/commands/wallet/status.ts
@@ -17,7 +17,7 @@ export class StatusCommand extends IronfishCommand {
     const { args, flags } = await this.parse(StatusCommand)
     const account = args.account as string | undefined
 
-    const client = await this.sdk.connectWalletRpc()
+    const client = await this.sdk.connectWalletRpc({ connectNodeClient: true })
 
     const response = await client.wallet.getAccountsStatus({
       account: account,


### PR DESCRIPTION
## Summary

the wallet/getAccountsStatus RPC uses a connection to the node to determine whether the head of each account is in the chain

## Testing Plan

- manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
