### PR TITLE
getAccountsStatus returns undefined headInChain without node

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
@@ -12,7 +12,7 @@ export type GetAccountStatusResponse = {
     name: string
     id: string
     headHash: string
-    headInChain: boolean
+    headInChain?: boolean
     sequence: string | number
   }>
 }
@@ -30,7 +30,7 @@ export const GetAccountStatusResponseSchema: yup.ObjectSchema<GetAccountStatusRe
             name: yup.string().defined(),
             id: yup.string().defined(),
             headHash: yup.string().defined(),
-            headInChain: yup.boolean().defined(),
+            headInChain: yup.boolean().optional(),
             sequence: yup.string().defined(),
           })
           .defined(),
@@ -51,7 +51,11 @@ routes.register<typeof GetAccountStatusRequestSchema, GetAccountStatusResponse>(
     const accountsInfo: GetAccountStatusResponse['accounts'] = []
     for (const account of node.wallet.listAccounts()) {
       const head = heads.get(account.id)
-      const headInChain = head?.hash ? await node.wallet.chainHasBlock(head.hash) : false
+
+      let headInChain = undefined
+      if (node.wallet.nodeClient) {
+        headInChain = head?.hash ? await node.wallet.chainHasBlock(head.hash) : false
+      }
 
       accountsInfo.push({
         name: account.name,


### PR DESCRIPTION
## Summary

the wallet/getAccountsStatus RPC returns a boolean 'headInChain' field for each account

populating that field requires a connection to a node

changes the field to optional so that a standalone walletNode can return a status response without a connection to a running node

## Testing Plan

manual testing:
<img width="1056" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/b78acf77-4cdd-4f8f-9282-7195ff499577">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
