### PR TITLE
feat(ironfish): Add fallback logic if wallet node is called for full node

### DIFF
--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -397,6 +397,13 @@ export class IronfishSdk {
       ApiNamespace.worker,
     ]
 
+    if (options.connectNodeClient && (await this.isFullNodeContext())) {
+      const node = await this.node()
+      const clientMemory = new RpcMemoryClient(this.logger, node.rpc.getRouter(namespaces))
+      await NodeUtils.waitForOpen(node)
+      return clientMemory
+    }
+
     const node = await this.walletNode({ connectNodeClient: !!options.connectNodeClient })
     const clientMemory = new RpcMemoryClient(this.logger, node.rpc.getRouter(namespaces))
 
@@ -406,5 +413,10 @@ export class IronfishSdk {
     }
 
     return clientMemory
+  }
+
+  private async isFullNodeContext(): Promise<boolean> {
+    const chainDatabasePath = this.fileSystem.resolve(this.config.chainDatabasePath)
+    return this.fileSystem.exists(chainDatabasePath)
   }
 }


### PR DESCRIPTION
## Summary

If you call wallet node for commands that require a node client, these won't work if the data directory is a full node. This infers the context and falls back on a full node if needed.

This is a temporary measure and further cleanup will come.

## Testing Plan

Ran wallet commands on full node without remote node running

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
