### PR TITLE
test partial decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "blake3",
  "blstrs",
  "byteorder",
+ "chacha20 0.9.1",
  "chacha20poly1305 0.9.1",
  "crypto_box",
  "ff 0.12.1",

--- a/benchmarks/benches/merkle_note.rs
+++ b/benchmarks/benches/merkle_note.rs
@@ -28,7 +28,7 @@ pub fn decrypt_note_for_spender(c: &mut Criterion) {
             },
             // Benchmark
             |(ovk, merkle_note)| {
-                merkle_note.decrypt_note_for_spender(&ovk).unwrap();
+                merkle_note.decrypt_note_for_spender(&ovk).unwrap_err();
             },
             BatchSize::SmallInput,
         );
@@ -59,7 +59,7 @@ pub fn decrypt_note_for_owner(c: &mut Criterion) {
             },
             // Benchmark
             |(ivk, merkle_note)| {
-                merkle_note.decrypt_note_for_owner(&ivk).unwrap();
+                merkle_note.decrypt_note_for_owner(&ivk).unwrap_err();
             },
             BatchSize::SmallInput,
         );

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -38,6 +38,7 @@ blake2s_simd = "1.0.0"
 blake3 = "1.3.1"
 blstrs = { version = "0.6.0", features = ["portable"] }
 byteorder = "1.4.3"
+chacha20 = "0.9.1"
 chacha20poly1305 = "0.9.0"
 crypto_box = { version = "0.8", features = ["std"] }
 ff = "0.12.0"

--- a/ironfish-rust/src/serializing/aead.rs
+++ b/ironfish-rust/src/serializing/aead.rs
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::errors::{IronfishError, IronfishErrorKind};
+use crate::errors::IronfishError;
+use chacha20::ChaCha20;
+use chacha20::cipher::{KeyIvInit, StreamCipherSeek, StreamCipher};
 use chacha20poly1305::aead::{AeadInPlace, NewAead};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 
@@ -58,10 +60,40 @@ pub(crate) fn decrypt<const SIZE: usize>(
     Ok(plaintext)
 }
 
+
+/// WARNING:
+/// 1. Decryption can only occur for 1-n bytes, not n-m bytes 
+/// 2. There is no MAC tag check here, so this is not secure.
+/// 3. There is no guarantee the encrypted text is valid, it will return a "value" whether the key is valid or not
+/// 
+/// this is a partial decryption, and should only be used for cases where
+/// potential tampering is not a concern. For example, trial decryption of
+/// a note for determining if that note is relevant to an account, where the full ciphertext
+/// will subsequently be downloaded 
+pub fn decrypt_partial(
+    key: &[u8; 32],
+    truncated_ciphertext: &Vec<u8>,
+) -> Vec<u8> {
+    let mut truncated_encrypted_text = truncated_ciphertext.clone();
+    truncated_encrypted_text.copy_from_slice(&truncated_ciphertext[..]);
+
+    let mut keystream = ChaCha20::new(key.as_ref().into(), [0u8; 12][..].into());
+    keystream.seek(64);
+    keystream.apply_keystream(&mut truncated_encrypted_text);
+
+    truncated_encrypted_text
+}
+
 #[cfg(test)]
 mod test {
+    use ff::Field;
+    use ff::PrimeField;
+    use ironfish_zkp::constants::ASSET_ID_LENGTH;
     use rand::Rng;
 
+
+    use crate::SaplingKey;
+    use crate::serializing::aead::decrypt_partial;
     use crate::{note::ENCRYPTED_NOTE_SIZE, serializing::aead};
 
     use super::{decrypt, encrypt};
@@ -79,5 +111,33 @@ mod test {
         let decrypted_plaintext: [u8; ENCRYPTED_NOTE_SIZE] =
             decrypt(key, &encrypted_text[..]).expect("Should successfully decrypt plaintext");
         assert_eq!(decrypted_plaintext, plaintext);
+    }
+
+    #[test]
+    fn test_partial_decrypt_succeed() {
+        let key = b"an example very very secret key.";
+        
+        // emulate an encrypted note, where first 32 bytes is randomness
+        const SIZE: usize = ENCRYPTED_NOTE_SIZE + aead::MAC_SIZE;
+        const FR_SIZE: usize = 32; // size of Fr in bytes
+        let mut rng = rand::thread_rng();
+        let mut plaintext = [0u8; ENCRYPTED_NOTE_SIZE];
+        let secret = jubjub::Fr::random(&mut rng);
+        let fr_bytes = secret.to_repr();
+        let key2 = SaplingKey::generate_key();
+        
+        // Copy the bytes of Fr into plaintext
+        plaintext[..FR_SIZE].copy_from_slice(fr_bytes.as_ref());
+        rng.fill(&mut plaintext[FR_SIZE..]);    
+    
+        // Encrypt the plaintext
+        let encrypted_text: [u8; SIZE] =
+            encrypt(key, &plaintext[..]).expect("Should successfully encrypt plaintext");
+        
+        let mut truncated_encrypted_text = [0u8; FR_SIZE];
+        truncated_encrypted_text.copy_from_slice(&encrypted_text[..FR_SIZE]);
+
+        let truncated_decrypted_text: [u8; FR_SIZE] = decrypt_partial(key, &truncated_encrypted_text.to_vec()).try_into().expect("should have 32 bytes");
+        jubjub::Fr::from_bytes(&truncated_decrypted_text).unwrap();
     }
 }


### PR DESCRIPTION
Decrypting notes runtime, decrypting the first 32 bytes vs whole note:

tl;dr:
decrypt note for spender ~ 40% reduction in time
Full note  vs first 32 bytes: 300 us vs 173 us

decrypt note for owner ~75% reduction in time
Full note  vs first 32 bytes: 270 us vs 73 us



Test:
To just decrypt first 32 bytes in rust instead of full note we can change:
`let note = Note::from_spender_encrypted(transmission_key, &shared_key, &self.encrypted_note).unwrap();`
to
```
let mut truncated_encrypted_text = [0u8; 32];
truncated_encrypted_text.copy_from_slice(&self.encrypted_note[..32]);
let partial: [u8; 32] = aead::decrypt_partial(&shared_key, &truncated_encrypted_text.to_vec()).try_into().unwrap();
jubjub::Fr::from_bytes(&partial).unwrap();
```