### PR TITLE
feat(cli,ironfish): Check running context in start and wallet:start

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -202,6 +202,12 @@ export default class Start extends IronfishCommand {
       await this.sdk.internal.save()
     }
 
+    if ((await this.sdk.nodeContext()) === 'walletnode') {
+      throw new Error(
+        'Cannot start a full node on a data directory configured with a standalone wallet',
+      )
+    }
+
     const privateIdentity = this.getPrivateIdentity()
 
     const node = await this.sdk.node({ privateIdentity: privateIdentity })

--- a/ironfish-cli/src/commands/wallet/start.ts
+++ b/ironfish-cli/src/commands/wallet/start.ts
@@ -112,6 +112,12 @@ export default class WalletStart extends IronfishCommand {
       this.sdk.config.setOverride('customNetwork', customNetwork)
     }
 
+    if ((await this.sdk.nodeContext()) === 'fullnode') {
+      throw new Error(
+        'Cannot start a standalone wallet on a data directory configured with a full node',
+      )
+    }
+
     const node = await this.sdk.walletNode()
     const nodeName = this.sdk.config.get('nodeName').trim() || null
 


### PR DESCRIPTION
## Summary

Switching between a full node and standalone per data directory is unsupported behavior. This adds a usability check in the start commands.

* Updates SDK to return a context to allow for initial migrations to run based on which start command is run

## Testing Plan

Ran start and wallet:start in different data directories:
* New data directory with start
* New data directory with wallet:start and node configuration options
* wallet:start in a full node data directory
* start in a standalone data directory

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
