### PR TITLE
initializes chainProcessor in load

### DIFF
--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -6050,7 +6050,7 @@
       ]
     }
   ],
-  "Accounts start should set chainProcessor hash and sequence": [
+  "Accounts load should set chainProcessor hash and sequence": [
     {
       "version": 2,
       "id": "8a5fc4a6-a079-4a84-864c-cd7e7422af9c",

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -255,6 +255,31 @@ describe('Accounts', () => {
     expect(await accountA.getNoteHash(forkSpendNullifier)).toBeUndefined()
   })
 
+  describe('load', () => {
+    it('should set chainProcessor hash and sequence', async () => {
+      const { node } = await nodeTest.createSetup()
+
+      const accountA = await useAccountFixture(node.wallet, 'a')
+
+      const blockA1 = await useMinerBlockFixture(node.chain, undefined, accountA, node.wallet)
+      await expect(node.chain).toAddBlock(blockA1)
+      await node.wallet.updateHead()
+
+      expect(node.wallet.chainProcessor.hash).toEqualHash(blockA1.header.hash)
+      expect(node.wallet.chainProcessor.sequence).toEqual(blockA1.header.sequence)
+
+      node.wallet['unload']()
+
+      expect(node.wallet.chainProcessor.hash).toBeNull()
+      expect(node.wallet.chainProcessor.sequence).toBeNull()
+
+      await node.wallet['load']()
+
+      expect(node.wallet.chainProcessor.hash).toEqualHash(blockA1.header.hash)
+      expect(node.wallet.chainProcessor.sequence).toEqual(blockA1.header.sequence)
+    })
+  })
+
   describe('start', () => {
     it('should reset account.createdAt if not in chain', async () => {
       const { node } = await nodeTest.createSetup()
@@ -289,29 +314,6 @@ describe('Accounts', () => {
       expect(resetAccountSpy).toHaveBeenCalledTimes(0)
     })
 
-    it('should set chainProcessor hash and sequence', async () => {
-      const { node } = await nodeTest.createSetup()
-      const account = await useAccountFixture(node.wallet, 'a')
-
-      const block = await useMinerBlockFixture(node.chain, undefined, account, node.wallet)
-      await expect(node.chain).toAddBlock(block)
-
-      await node.wallet.walletDb.saveHead(account, {
-        hash: block.header.hash,
-        sequence: block.header.sequence,
-      })
-
-      expect(node.wallet.chainProcessor.hash).toBeNull()
-      expect(node.wallet.chainProcessor.sequence).toBeNull()
-
-      jest.spyOn(node.wallet, 'scanTransactions').mockReturnValue(Promise.resolve())
-      jest.spyOn(node.wallet, 'eventLoop').mockReturnValue(Promise.resolve())
-
-      await node.wallet.start()
-
-      expect(node.wallet.chainProcessor.hash).toEqualHash(block.header.hash)
-      expect(node.wallet.chainProcessor.sequence).toBe(block.header.sequence)
-    })
   })
 
   describe('scanTransactions', () => {

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -210,6 +210,12 @@ export class Wallet {
       this.accounts.set(account.id, account)
     }
 
+    const latestHead = await this.getLatestHead()
+    if (latestHead) {
+      this.chainProcessor.hash = latestHead.hash
+      this.chainProcessor.sequence = latestHead.sequence
+    }
+
     const meta = await this.walletDb.loadAccountsMeta()
     this.defaultAccount = meta.defaultAccountId
   }
@@ -237,12 +243,6 @@ export class Wallet {
       return
     }
     this.isStarted = true
-
-    const latestHead = await this.getLatestHead()
-    if (latestHead) {
-      this.chainProcessor.hash = latestHead.hash
-      this.chainProcessor.sequence = latestHead.sequence
-    }
 
     if (this.chainProcessor.hash) {
       const hasHeadBlock = await this.chainHasBlock(this.chainProcessor.hash)


### PR DESCRIPTION
## Summary

we recently moved the initiallization of the chainProcessor head from load to start

this has an adverse effect for sending transactions when the walletNode is not running: createTransaction checks whether the account "is up to date" by comparing the account head to the chainProcessor head. if the wallet is not started then the chainProcessor head is now null, so the account is treated as if it were scanning.

moves chainProcessor initialization back to load so that the chainProcessor head will not be null as long as there is an account with a non-null head when the Wallet is loaded

## Testing Plan

- updated unit tests
- manual testing
  - sent transaction without starting wallet

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
