### PR TITLE
test(cli,ironfish): Add option to set birthday on account create

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -296,7 +296,9 @@ export default class Start extends IronfishCommand {
    */
   async setDefaultAccount(node: IronfishNode): Promise<void> {
     if (!node.wallet.accountExists(DEFAULT_ACCOUNT_NAME)) {
-      const account = await node.wallet.createAccount(DEFAULT_ACCOUNT_NAME, true)
+      const account = await node.wallet.createAccount(DEFAULT_ACCOUNT_NAME, {
+        setDefault: true,
+      })
 
       this.log(`New default account created: ${account.name}`)
       this.log(`Account's public address: ${account.publicAddress}`)

--- a/ironfish/src/rpc/routes/faucet/getFunds.test.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.test.ts
@@ -16,7 +16,7 @@ describe('Route faucet.getFunds', () => {
 
   beforeEach(async () => {
     accountName = 'test' + Math.random().toString()
-    const account = await routeTest.node.wallet.createAccount(accountName, true)
+    const account = await routeTest.node.wallet.createAccount(accountName, { setDefault: true })
     publicAddress = account.publicAddress
     routeTest.node.internal.set('networkId', 0)
   })

--- a/ironfish/src/rpc/routes/miner/blockTemplateStream.test.slow.ts
+++ b/ironfish/src/rpc/routes/miner/blockTemplateStream.test.slow.ts
@@ -18,7 +18,7 @@ describe('Block template stream', () => {
   it('creates a new block to be mined when chain head changes', async () => {
     const node = routeTest.node
     const { chain, miningManager } = routeTest.node
-    const account = await node.wallet.createAccount('testAccount', true)
+    const account = await node.wallet.createAccount('testAccount', { setDefault: true })
 
     routeTest.node.config.set('miningForce', true)
 

--- a/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
@@ -14,7 +14,7 @@ describe('Route wallet/burnAsset', () => {
   const routeTest = createRouteTest(true)
 
   beforeAll(async () => {
-    await routeTest.node.wallet.createAccount('account', true)
+    await routeTest.node.wallet.createAccount('account', { setDefault: true })
   })
 
   describe('with an invalid fee', () => {

--- a/ironfish/src/rpc/routes/wallet/create.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/create.test.slow.ts
@@ -19,7 +19,7 @@ describe('Route wallet/create', () => {
   })
 
   it('should create an account', async () => {
-    await routeTest.node.wallet.createAccount('existingAccount', true)
+    await routeTest.node.wallet.createAccount('existingAccount', { setDefault: true })
 
     const name = uuid()
 
@@ -74,7 +74,7 @@ describe('Route wallet/create', () => {
       .spyOn(routeTest.node.wallet, 'scanTransactions')
       .mockReturnValue(Promise.resolve())
 
-    await routeTest.node.wallet.createAccount('existingAccount', true)
+    await routeTest.node.wallet.createAccount('existingAccount', { setDefault: true })
 
     const name = uuid()
 

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.test.ts
@@ -14,7 +14,10 @@ describe('Route wallet/getAccountsStatus', () => {
   const routeTest = createRouteTest(true)
 
   it('should return account status information', async () => {
-    const account = await routeTest.node.wallet.createAccount(uuid(), { setDefault: true })
+    const account = await routeTest.node.wallet.createAccount(uuid(), {
+      setCreatedAt: true,
+      setDefault: true,
+    })
     const response = await routeTest.client
       .request<any>('wallet/getAccountsStatus', {})
       .waitForEnd()

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.test.ts
@@ -14,7 +14,7 @@ describe('Route wallet/getAccountsStatus', () => {
   const routeTest = createRouteTest(true)
 
   it('should return account status information', async () => {
-    const account = await routeTest.node.wallet.createAccount(uuid(), true)
+    const account = await routeTest.node.wallet.createAccount(uuid(), { setDefault: true })
     const response = await routeTest.client
       .request<any>('wallet/getAccountsStatus', {})
       .waitForEnd()

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -10,7 +10,7 @@ describe('Route wallet/mintAsset', () => {
   const routeTest = createRouteTest(true)
 
   beforeAll(async () => {
-    await routeTest.node.wallet.createAccount('account', true)
+    await routeTest.node.wallet.createAccount('account', { setDefault: true })
   })
 
   describe('with an invalid fee', () => {

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.ts
@@ -45,7 +45,7 @@ describe('Route wallet/sendTransaction', () => {
   const routeTest = createRouteTest(true)
 
   beforeAll(async () => {
-    await routeTest.node.wallet.createAccount('existingAccount', true)
+    await routeTest.node.wallet.createAccount('existingAccount', { setDefault: true })
   })
 
   it('throws if account does not exist', async () => {

--- a/ironfish/src/testUtilities/fixtures/account.ts
+++ b/ironfish/src/testUtilities/fixtures/account.ts
@@ -7,12 +7,13 @@ import { FixtureGenerate, useFixture } from './fixture'
 export function useAccountFixture(
   wallet: Wallet,
   generate: FixtureGenerate<SpendingAccount> | string = 'test',
+  options?: { setCreatedAt?: boolean; setDefault?: boolean },
 ): Promise<SpendingAccount> {
   if (typeof generate === 'string') {
     const name = generate
 
     generate = async (): Promise<SpendingAccount> => {
-      const account = await wallet.createAccount(name)
+      const account = await wallet.createAccount(name, options)
       AssertSpending(account)
       return account
     }

--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -2,6064 +2,30 @@
   "Accounts should handle transaction created on fork": [
     {
       "version": 2,
-      "id": "4fa960e1-8e56-426b-8667-a8a663cd4556",
+      "id": "7e641ca8-63f1-4cea-8c7d-535b984b7ce6",
       "name": "a",
-      "spendingKey": "4b06876692a144828021fe0ddc1955468920b7f7521b1ae960406308a038c00c",
-      "viewKey": "6c41c9569d2b1e161150c052b400d99bbfe7230248b80a2fce4eb9812fc340de9798edd4e9887793373d5c21165c1117185e73419e6beec555f0a98a7f2e1e15",
-      "incomingViewKey": "9d2cb111992bf6b51b8500177512a30c23e55686770f8bde498971ed965dd604",
-      "outgoingViewKey": "3b16a3a48fa766712325b44904fc4c8ca2849e4a56714244165071dc79571705",
-      "publicAddress": "79f0b6a3e2b7afdf73a37c6be8d124bbb8bd33da1f18bc85e42c4fbc000c68c4",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "b6d36235-4551-499e-9623-64f764741838",
-      "name": "b",
-      "spendingKey": "ff2a878c70515d89f1d0c387d88c4817c560fd9da83c505695302e03da517df0",
-      "viewKey": "e1624f7eb5e7bdeda2691fd2f2cdc70e928b73fe635a98c3496b6079936ba1f1bcc5c4f824b8fa2744b4ae1b818add3ceec50d39a9aa6ba91d58a60574307c38",
-      "incomingViewKey": "9cf49ca688bd7bfe5bfd9b421b72adb99faecb436c8fe133dd6d6c4c08e52b03",
-      "outgoingViewKey": "89eef359899d53cd15b8d89a36c1adf2f87f74305e1fddb8c25ca2d35e2b1ecb",
-      "publicAddress": "a98b8e5b27636c1d3704694b451911efbcfc4532218aae3560b984e17b1a2caa",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:Ln8d49SWdE8EayBxxDmIC5ioQq89AhvCFN7J7FQ45Ds="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:XEhf/b8WMXWP9ciLoXVs3zEsfelEnvx5OD5QQK38DiA="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802929017,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAS3vLNkk7432Ntzgaigjq9HqU9WZZBNFDK3IB+e/ugXKxrlIT1+VS1/sXvuDbP/Wbe6J+ZMItTUa3bxiovu3GZ32IOfTzukZQFVr/0JTJqO2NFPaVKx4ndYITvXBPPSfB4fCQMR0uPnhCIKTBF1FI9r5gnLosERTMobPzK2qN8s0Xd2aoXXs0/jNJ+FGJ4zHUC0Af2tsug7WLRgGU+w+oW0ZoAc7h4bzl5dU2LZi+7e+TSR+7fkZw2ZY0Pigy55coi8mS9quV++aAoqdR3daTe00HH3honph6T150Hohm9NimDV2S2POmBWjRz0olT3p4eZlpOtATOs7w5MLwOm/hqgye8kCzfsY4svaWIigYgT3DTlWbwTnJ9ChDqaiVJuce8j1CGBimJ0gknFPSraJQHMtRAoiV6kjgiRtEiYJizAYpN1gt6Njo4/5bDUW6xr5mxuFs7hGZlxNn/3Ul3h7YphzaGMZ7vfWZGSwX8tlWua1XjBqPUHAejBWA3PnNqlUaocuDt3wGL8S/GFMOFlRTvEZbWKYCfIetHWIFWZEeHWGvwn+QffxMSJinr7VnQaJbQy3BdHmtFf1I47enDMJT1shpXEcVp+TdMBMKP4w9hl28sHJzyDoX60lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0k62I/U8C1KKy8VhOiRXbZX0C4X2T0HG2wxV28FCZ5Qgj+Wpwc12ojH12LTndNGq11eaqAQsBZV8B+W9FxlbAA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:tsVyXWQVoiwU4j+tepvhEjcfvccrIFTLO8A6YgRbkFI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:jIZu1pqqH7YFFrsJZaW5H/yGDChYxvyfk+DklXuS4XQ="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802929417,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAdoN4gjKjUHUjdJEXYCOb8fiyZpljq6ot8+unWchwWrWkngNoNUjyvUqOPTSmo0K88v8CXgHQ6o/4Chc5/O3hZLDZbP1n3XQC0Rt+F3CjwoW27Ujr5zM0LrRrC9OVV384p6+BS3LrZy2s0cvn33UaEutObrU9QSMhHQgNhvsH2v4WXZ/bdTzLRkNzF+QyL30tGg+e/H2XtmL54MIZLP/Hfy0MhxBbaWVDpUqPRua/V2Oy732MbnBLpuIB+znj8I0hxI00qrL0G41qRNA22bPNIpqJt/o/1Jxjrk60lacMfqEsvDbuXSkXi2NYUr8WqHW2DuQVa4i9vh2LtvgUsWB0X6XowAColKQrBrrwGDU66zPUDK9QD7dTmC/H15RCmx8qe2iaaNZ1V6hAkTq3SDeGGig/0ccL6recppk75R5aAvD7motdppVgbWO0+UW/PcKjNWzldGyrXmYsRb9PqKZTJPAK24IgSq/G+aD2NiFSwnXPKRva7M5snnWNCXrPiZI0RzA5r4pi+8M3FEGl+jzY4riY+heA0SK/bVfQELMyBGcbb7djCdUzXFxELU16uSm8H6DsA3ieyRPboXRLEB7993qEw+MwE+kY4v8JxsWNsmZtjJWyjSA+iUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwL2k6h4VNEXphTb04lnLAWqQGAOkLmVr2xsA7ao/A5Ok5RX3RiPXjnODcmhBmVRq059bejROlkYm4UwTJhzH3DQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "479ED4ECCF0FD389FDD9017B09E08C0F6FA09349006EECA3EAFA62043ABDB623",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:2+8au93sr6TIDWQlY0UgdEUcn4nYs/CFtXEIKkdDimY="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:yl79PuGXxMigBwrB9jtvm276aHa9UGBKBhg+jTCD+uE="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802929833,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA33mJERb9UvTbm38m4acDdeU7DDNV45FVo15CKtEB4daYE9C59Ktfv6sDba2eMg8iqGMlmLQ+pWLicRQJY9Fh927+y0Q40XICA6zWvvuDYlyk9LK+NXu+t5n6EOCkhHUFGXpUNl92KKjlbRvR3iBvdWk4AmFBWUPDQoYsrG+EQNYXS9QCiIa8iMgTZWpoZidA6wJC88j2ECoYKvqFymXQzx/+gBla7EmvCr0B1QFENwayI0Cgb5Y3y2nKlNTs+2K6Wmv6MGfJnj7b9KXXCO+wtqVHKHkM1QLm9dMQDUUPv0wUsbu/5tYHPYPeqAHYf70PZw9QsxRR+yjy+aqUQZVjRdouopOpNmowPmV0VuYVW+yunX2yfge1GvDCev5ddMBVwmTUgTXzau5IttIiuWj+EVcx4AuMzz383KQALkUVRZqosLe8kRGr+PBBbIHE8aEBHtMXx0JpxFWKg4Q3ctQAAQFFRubW8iPvqdaI+UV9DI9f+7Cf9TGAqLtotLssKpFybjtg4dVpEvByhpmyfiWU62FUjfPvW5G2jV6T+iMLM+Sy7RyPWHO6JYdxtgX4ZEdGan2DhhJZoXLP5bE2R3p2TefNm7JwFA48xVIAKTtzErHqJMB/32kSmklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjBy0w9MMyFSGJsijFvRbpMwF/hTc8GTZ3cqwf0aozekDl45460iasVDAXzARo64G39cQu+3pFb3JajbbH/PRDQ=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAArSlhHx6AoBLq49xkaFa/C9/+42V+osz1UlmmTyCRQ1Sq+zRvzoHczJ44SjgLlE3adBX56BtfwupQdlQVcrQz+olUf+0WN50ENuFZgdQa3OGTg7rqufUk3b8DRelNYdfEV57Pp+vkLSVD9wxvc+G9Cd2zAopfZ3SmhwD66bFipIcRx+N0+SjMXluGVZm0T0VkUojXr5fOpaMNzQ52l9wD0rXcA59a2k9aAMmrfxHiSkyCQjkPufbDRZ0Ju6V4+OWhtCgqAIHsqv0Ik5eFOD1nLc3kVGehgljwYADxwA/FzYk5MnygdLkjU0cru4HV70srUjNd2cvBlCIewOoAz+aoKC5/HePUlnRPBGsgccQ5iAuYqEKvPQIbwhTeyexUOOQ7BAAAAA5NNNDqKP2b6aVFRVnYH9T61Q/aT5W3S8UvmQufF5/tZa/9vq2epxt/Ysj125pMIcRctXhpuUYAZ5hvHQEG3NgcAfe/M7ehxUgHBbRJ7BNrgQodUIqSYlToSch5RF5LA6GtgHdNQdjJeIjYT2Cz2stmUW5O0p3v/iIqXYwGcsAwggx9KtIfq33ApkM5wAzwDZc07h6ss+9GqLV4xe7B29wXqJAz1LxtTS62VdVEh2360FrllOeTwKWD+sE2oErE5RgOoFODb/COD+Brr713sL+590qhZav2XSNJP/otYhGRdEAYhZe2fWgP2LT0QV6u/q25Is8o4HnRKtjsKDDYLtHhe/qu+1Yse+dzCWa3V/S1LejW1hM4wX9kKZJ8LzLBhVPhilnO0l9g5BxgsephQOyLjBIsznp5ma07LWRscQ3zsf0GfPYrUKsiAOZkNDQyCGMXSumfynwWgjdvWzBBLWRGr+w+WkVg5/7usdkOeT87YFgNRKoe5/BgayJ/ir0rFL1bCYD4Kvo4lqjesn8sjqavinV8Bx3IYyhlQIp1kKKBAG9+rqnrQVepnc5JqmyQjLbh4MZB3mgIncKAvjC+HC0jaN6+sjI3Cj7hhCZks0Xgewzx0jrWiuVX8LRyahym91bFoBiQc87axXA1Wh93YPBgOmF380X0PLMQQjpo7tRkSQuFs6cnTlkDDJMB3LKKjfwDyavh3b0x5cJXH7lZ1gw+wfCrQVfA6yg4yjM88+/ObcpTH/mwkMC+wMQp9rRN+mMc2i11QeHDVdYhGwCkfoNS9axLM/sW2jH4kaHnkaP+rJ2DFVTl8HS2KMeXIal9J5AACHzLIpT4pCwup975Q+Ug31lQIMHOo+PF18SP/R1zzOiStnYjej+QFzKlsLYQ2seAXojwNlFHC3s8RTcUksjz7YJywtCKgowFqQPtePbGoW/4T3oc3j8Az4KsuOZTsnChrSIzE95VTYHFcQvuqKRaBjuIryHONoWV/JwEtdPnjnPHUE0tdPaD8Z3XFvZlJf7K7gqR1rmxoc+Z4KNTN16Ts9xNSWAzBUZY+wiDD2gg4bAteUb+Yc7DMJd70oLLYSNvaqKNOA1wRpU/enc5BXUXTeDOWA/LuDP6Npcj7qcVJOVoxadJ8bE/e6HeaoXg9Haozbmmf8A0WvG+6dsmclr6WpBFFC7+eXNcfNbaOMIdGo0Vg5P6UNOc+Ngeegop7y2HGESuOugkMdwKL7X8oAjH98tiVDtQKDCM5ByQ0rV1w09wi2tU6IF4Sg+FITlEBFzCfPhNGtEPENC9sJ+2YpEvYyLs5hPRnVb4bwHhqFD11XTgvG8K8JiJo4o4er5XFt6czMtC3Ucg4MsE797u6xmpOq5eJ/LiUAaF2Wlsae9coTrt6Bz0zoihx/40La9z4qHAqc9ajI/7ToziHoXLhlbYgIJdOPFewZDpT+47p+vnVytWmS13omZwxW67Xyz2VZ4Ly2lGbr5gRPBbvX01a84lhr20ruWlDRT7tsPHzfMDXlaPOhSZn1Q6NoWLWyss5UcDyv0PAPNILi6QqPTi8rJzlvEEu9a1DAgTJ5gh5vVL7vg+JPJ8+iHe1askr9eLAw=="
-    }
-  ],
-  "Accounts should update sequenceToNoteHash for notes created on a fork": [
-    {
-      "version": 2,
-      "id": "6ef0211e-c055-47d2-a654-b3f0724979c2",
-      "name": "a",
-      "spendingKey": "fabbdcbb7c3536212fcdafdc1a00d1a4f6b5320bb48e3b35442687dee2073924",
-      "viewKey": "7cdd10686f24bb023240f816b2b1443229c500eed876e59531e985e64400b325bb748bcba91511067917af31b222e246eacf2d15ddde456c248adbfa69cd16b9",
-      "incomingViewKey": "4e03aae0c53e2db0f946be4cbd228c2a0ac5df01bbc57cb5b809f9449dc19307",
-      "outgoingViewKey": "1ec759be2cc07ecd0a99044cdd814f5c493519cc3dc7915a9e3f33b7256fc644",
-      "publicAddress": "595a60320cef8780c78d0dde8a9354af2344765d990722026c30167ee08d9fb3",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "bcf03d2d-a437-44b8-8ac8-b69231f88bd9",
-      "name": "b",
-      "spendingKey": "b479baf4b96030493b0cb133f8ed8636adef832cee6b507e9f80643164b8939c",
-      "viewKey": "f357e8ba0b85de3dda871978aac5ae5cee7f2b51bdd858daeb834846e0b73b72fabe167023f95aa86383c23e586395de16f3c45672227fd57d485f3001d88b89",
-      "incomingViewKey": "3dde87d796f0df7943717640d2e1c49a159179848c96fff594866f47797aaa04",
-      "outgoingViewKey": "82d3f4c299ef7510ecc4a7a61ed7583c194425b6a17d0bf80823b56672755951",
-      "publicAddress": "3c596a8ef2680c75d748d1f2b2c63391871040b65aa796dcffd9a0e995932244",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:fyEnYnNMvjXMsTkmrMXyJJNdSTGptXOxJ+I8bXIVqiY="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:EfAV3zsy2lTVjyR/HGfnULjInzLtSimOxGzGtuuJRLM="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802933234,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA51UixXpfuiT8fSobWiGsQ2da+VuORo9aqwPk3WNaDN24U6002KGdLapAWDTu6624mrriNh8JpR0DnNYjXxEYTOBKggULV4K/2cW5gnnUju+NfHJ+Xy7djTMVVvjHbFGS7QijUnDFtccYGqv28stQdgfdjz+Xg3WcniSuY97Z87wN2B00LLktje80EM/U+7rHjhLc1lZbwf03I/tXTpcSy14V2mj4/LrlIH8mb6pXFhGql/QN9pe9JDeL3jkdnzn0zx9hV4IUX/UikUqiONY/UQIX8xgy3jU0vo+BupJgffMAHxNiDunMtMJjxQLsWVb0xDD0ssvOplXbs4u/nSTsYa35D/sCQ7CRviDKmII/hTp6MBG+Z6T5MtjQkOeeyn1G48C18n+ds8eWaWWXKP6wyQ6zpvBM/SnNDnuwXJJfa5fLKfAHOE0GtOfEbMFB2Aufvg+7MxUV45ubw6zk6n1ZJw78XmKofLp/rxtwJwyK6waIZPC2wob6g9FtOwnCy2YBvY5Il0mQ/wLIqwbrY72Mflgd+jiRrxwKoDQ+l69GaD27h6ReZ4Eoy8vley1VOv7ZPmrIkPufMch4FPpkmbzvwUW4t1QJqBGEU5BlSxC22V5vuiFpdxFmhklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwger611MOxTJTpg+3Wz0qKRXek5jSzLmQFWk4e5FwR7k1y85BZaLa6fgWt9JVSP9C9/yYUOxtAeL68Oewn2GhAg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:FZ0snsMANYaLvK6f55pi9X1RClbfUg+Fyl3gonZiRQ8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:JyDN3HVfrNS2JVpZAOh6cvhQBXDFfEo8SuOygYT8YVY="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802933663,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAI8DQscV6RTbVOU4aAfpVuP5+oBvkW1tFBYpriv0dqV2lOBaZvpA4mWTidpfQrzNjU+G40UOZmRsPI0BDAzZ51WmUGAildO5i20LQceB2qp6gs/0neHMKtBORPRDY7z2nKPXLqdA1pAwU++qkNP1hZhhwJb+4aJWTADG2k6HSGFUNiKYXJPPEZQ4I01fGhteygmSEBJ4PX0BVxwPnHjkUUHT5vUCkJBz7heasUjrd98WHIcRGHAl/6CPL4DxBu+7z8bEnpUsFBCf5YREi84G/v1VtqE4oMzXLetrQR9L8eYG8TIuccL01aTHQmLesFPYAtzJDtTGNgXN8oCWuApTJKXqAFaO7FWRT5yxfRcjUEvmB42CDkSohVpEbMZRKjEEyE4iLSMo4CziyeZNpy5rSYFoN9aOvLW1+B6RA32ijPqlsB9hu0crcrcTpyFGJYLpo513EgEAs/cPk4R0EM7TqDevHcA4n8D/QRQM+Zp+4J6xpuUgVrb3bvoF/wcE7z0M0OzdVUKju3L6BWI6ut/Dtpv+VmxlsJDJI10MIrlbGR7+JeGmGd5o+AdBLBUIZOwopMh0OEV3US9qGVx30dWbMH8XuuvIR0SF9YgCSwD4y1JeA2MrOCF1YZUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxmVJqrYFlHyij1F/N3UlD+1dZA7KcNnTT5je313ntKSKA1ezT2kXQQ0W9khyjdUz4oAK3Fb6l6L5L3C36rKwDA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "381B3D1AB62660F26921526EDA69FD419D56E768F496BB65C65BD8B44CCB7943",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:IsurxP1bYVghy8MkQnYC3/yUwj2w+HZk6XponZVwu1k="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:g1756NgO77Z7j5ZIc7oprXAFEdW2Y9uIPur4HWOX5Io="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802934064,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAk/i6JxRHgP3rLco1eAmGNaimwBpWUgFs18wWdB9zcqalf24uJvkqcVbHoY+5gTgnyMeaCeU39vLUZ1BZpdtsudiT1dJfYklRKw/MFMr+k7WAmYY8s5yJxUqpXaM/9AOTg9FP86XlJ7ljPAUBcqYzs2QVjrL5xrLjHLCpU2bhtVME0MBuoGoHsGjqMyXB6BoCjRsrub9hhLaaD7xXdDlL6qM3OozK0RjufbcjmMr6/3GpnwJDC2G/vt6EDaujzu6wRRfySEJdTzqLfHwwOVgF/OV2eBsVafza1PDrLm720LMyb2dx6wwsaT4rYMLx1LXPGYLMf3shXuoOx+l775EFWIlI7n/VsYSHUlroMsToSxscrP0cy+7upuN/5jLTlJcq84bW5vryBEJ40UmrXKnR6+v4mRNZa4kq6ieihN1EchyaGaH7THr7ACOPNkbwoSVORVVPmm3hXW/7XoL9lyXv8kSL1X9k9wBvOCKNM3nNj2dxBLL/A6Wa5jQeDavrlP3CvY6YqgHg3Tqfec6nTXANSjNWmaRoJ1da+KSSdUn8OG9754J+G9RqeHL2++SaFwubAiYyptaFunfS4+CEgr3c5AnEgIiC2nu54hSiiStgjU4tV1wqM5pkbklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw06d1Eb1qnuHImEeSL3NL6CUuFZCxC3cQv56/3o2vnQ7QcTm+opve2b5g19meGSp1cehKzY0Am4z1ZStPwy6UAA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "C63D07A2B13D074CADDB30289060180F3CBAC4F565375E9DF6BE3CDBFE157416",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:tewYTpSRtRdVkLLu2kcpn51vzWpC1e20II61+odGYTc="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:mttR6DenZaCTOLHZzLi8qdQBEz3zndllbyc2uqWV/T8="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689802934501,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAW064A2UQTL5yFlzCnl8Zop1DtsX3omu6wdGKCeu56kCQuXWIfOktIpwPYfUycMvS6DebbxR74cA8Ocgfj0AByk+BZlQnpDnOZEhfDmKqduCiFG6AG/zWCzKNiL8BTlvIAF5Vft21/IBbViWknqNc5FDbghEAzwL9iUU/boKDGhEDzGcpm5TlKKznThZcr2U1I/0uU1LL5cqUiBl1ahcRKr/IdOgGEVh+DK75zhIxwziwzsVmhNKypB9mzizuEK3ya4QCCH6ankeEfzQrgvzk48ckUS+uCmQoQ1FzNjbA10ts29AkxPErLuOPNu1AH/flFhwaKD920zDrP09fxzT7igk6jHs1YhzlDLoHhHZ6tF/XpN1PP1kZJbz0tyRjiS8fW21X/D9+8/CNMRXJXs96wkvStkx61K4o9P203j782d68RJ5XFNWk2lHARDzM9M/4kqSJCrcjfGiIUOJe6rXsn8n/DM8JZu/zNur7pEhAJ1Nk9XquS6osU/Tsu2y/4CEhGR6NH4vpSpc4TxUZ0GJ5hUCoNiOYT1pTe7Fqb7ApxAb4gGaXxmWRPW8lri53aeXJizkNK27mC+q37I7rBBSsc/9cZxHpPCkEhEkLvvqGvEHF1aTo+gqJfElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3QSSKILBDUmdNkxTLCkNU8Jrh8O2G9oJhwnpTB00OGGMr1L+RrrSP21tTToO9ceQc4O/R7tQmilw+6iKQyDXCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "95D4F38F1416D19B8B091845DDC1080062E0097DE93A7688FF22034DA02E59E4",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:H7SuLHgVG3sc9lfezG4zU1ub7sFkDfDACIPWe9YSBGw="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:QIv50V2QI+ObStvSJslxt3ZIwyOXuFyRhRV0n39lxbs="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802936454,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAdqrhHuEIhXn0AXwZLTr1Pco/4XPjhH3hzkjP+Hta0gmH/5LvQNFfPzpnwRka1Qoazvd3+He+a5rRcBp1KKmn4kkGpPwNUAut/72pnH2Z+L+tstB56VmQfW5jzEYxDl1ppz0tzHVrCi01RCdypPLnRekbOg+HkX4qz17AaO64818SVIU2gKXZ5bolXcf/RaM38RlYSYd5tcLkVAJ+T9vP4yt4bBSFPjCvNqIUbfzuF/mzspf8Hm9wm0rIEOfVZenDLXAnUvTtI1wuiZm+KhQELGgEDlCHjv4PlA26oWFA5+1OibR9yPGEx34JU4amMDKsaOTWo6813zCocC0BS+SmveT3D90gWEkuAom2hLidnmQ8V0/VehyZ6sIzfTpMOsYqTN9/P4YkPQQv6s/ikgoLauQ4rVvTWvMw9h3tofH4NaQSZuHk19UdvlvX5vwnbYMfmtkaW2gYoLPWdMfNngwJKRIC9unCFoLVDQ2jqwfk3dVRQzl/mQw2pFVd8H2MOe7wPaQChQx86xOoTvqyU+GoyOa3lSbbhP7v0hNX+tKKP0TkdSx9ecr2zOeDg0QxjtwY+7r7is9sVkiD3hInXQ3I2WYi2HkNO8L7mV9P4e9+Od34f1v6c7tQi0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAsSseiOnxoRwqF1blQDTK6rE1jkRYdx7PTMgoOSTGE+2Fm+liHOhybt6qGgLRWkRs4N2L5wmnEp+z9TowQDpAQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAh4uAPOBMuNHJllOj/7kauxPXigiMCY8ZbiTnQYcyBlapOAFaRLWiyXPaUzwUgN17osn1sdzI4wgHkkckbo7ZEjWBSxSb5efIh9nKOJZKDASUz2XqWU9QzrmFiE2QeTqwlWKYkLqbSNK+jdyZlR61VdMfUA2+1wB1+fPNTp9eESADbvniN+lKwoLo6k9ZIaLA7k/7l7oLK2ufStNpCp1Ibfd5RxTe/yJ346EN4wjfGoutPdCTTlOO4L6Hl0BXTkuP9GFcquj2WtwlNNLC8oyCDxVJv3L1PFmHL2d3l8lxr0Fp8TKwgXc5pxTDOSEsvX1q3kbQCf/ocXfmD88YeJMfW38hJ2JzTL41zLE5JqzF8iSTXUkxqbVzsSfiPG1yFaomBAAAAElFjEwpd/wiKMffb05wj2lVmaU+xtkrPn/3DD/NnEyjmfkKbY7eSwgvUl3KxhPylbgG3nxEvIn2l1ye7tUWh3JAmmIZYd0lEPpGXYDbdDlGZBXmC01jIR+oI/NJmqB/AqB2rM/BjuPOL/90HzT3trGFSLZ30DhcwcB3MYNWRIwFsj82dKJ8NxKqZKN8XCFtT5H5aFWVjXzrrg2wOXLeHku1bhYWN8GBhEPOpWd+EOUdkq01tPmp5ClWyIfT0E5wbRldDfcAUpyFWHiYF1pmdlLlSP18gZfcFfaIsxWJMhkm02YoEBKHcUTuesHJ5+bvpIhgHgQmv/UWEDnDjSRRPUpB0Hv9eon+U2HHCuV7phpFESDbnlIdmJ52keg5/DlW8nQK+ngxeHQyGKYLSsZGtt4OET6hfeek330R/V1WBhaf7oYgqiXFyePLR+dOQtKMdNnaFaCRaqBP56sMAUKbBQA8gRjArltd2XzwseUlKGm2r3j8IwBrNXZp3xeE2DMcaeHdwhZCsNB0QKQAp9OKfA/MC207f/is3S6aYNfCMruktroSS5o2BjlSivGUWi9/kAGOCEUdri59DD1YSDlVXnJ/ZQTtqXg4VoKSO6bItIrD7jfBC6CIo5GufAvOYdA2MX9xihgBEM6CgNehZsTDy57pYRfsmKzeDvxXEgbkLJ0lfIKsPt2JE2O6VT7P6rYCN/CICyputaDOi3l9sHLpaJz1buHtv0m23Agy4QSS1MorcTemqZSQFJrveHOdosnbZ1ADb6/N5Dbb3peS279yZ31ieMTtHWhoejiLDCjGmh3xcZdPufVP6pGLXb1LF/pSC1FvDs7Ki/EPJjMdHoKgNT10sbuK3VrZog4E7Fyb/K2uduNVnDhUb62tqRtf1c6YLYr1zMBqcFou26mZ3NzZyslk3/iemKm1Y8boRiwsDSwtc1yU2hLDog8DYmQReSJKAH4Vut4FXDGaalWNvP4fd8yZZG5jQGvsKTqJpIwWZYf62FEIB5dUy4q5up2XHCTC1KN6ME5fXAEbCYyz0prkjFdVaEJf+fbka0QHLB4olseJaJ0v3V7VsJv8xGsrmeYuHY/megIXLiiCkR0lqniMWgJYaeTOEL+KwRDmUX18/g2SMEhxXPx/2+wSfNEzg3UDwzMyb3S9Y/9Cu9s3zdTKy/xO7iLNBLo8vKSyE46JDC6Cx7aIFmaSJ0Cp/ltDmFVRuOuEIPWbRbCOFFO7EpVpHaOka+qWq8TZLutR0DhXi798T8wLirXLVO1ugI8cUhhm89KX8yzmF+Eiz/7MB7VTarj8u5Dn3cmyfHEMfxpznPZuNs8bpLeMEiM5fx/dUKsNrkS3aPZLVnRzUn6w4lmHgeF1Xzugn1oAlI83JGtOtSAE1jy8Oq+HJQ4ldpHtSqRyWCL3b6pCNqZTGeY+K31PtWEDN0ufxT3+azdnCA4jOTUv+BNdcjZ1xmpHQLaHGtRDHOmHIchbM6GQl2mPJqaCtkOvPMiyiemw/NtxXMk3WFz6n7wnu7o7ate2b/wp+cSYSFbXcd3nO2h+8n5aXwXe/XABJmMdJN9PfBHHYoivhMP9xU++NTMUs+GDFPlrZpgJAg=="
-        }
-      ]
-    }
-  ],
-  "Accounts should update balances for expired transactions with spends on a fork": [
-    {
-      "version": 2,
-      "id": "10f71678-3921-4447-b6e9-2d06a1d7555c",
-      "name": "a",
-      "spendingKey": "4a38ad2bf9dc6a06c859948dc71c5b5207988f38fba362635f15e279bd22d459",
-      "viewKey": "a5be9c209194897a5e730d4ae07dc9d4d68ffd4fa181fea2aa82f7ca033191a1a4f8f5aa3737091d1753fbf0f80a6323fb7c63f0e8d4971fced9c5d766cae1d1",
-      "incomingViewKey": "92d0cb5beb97c060fb6ab0bae51af08390572851d73981a2d6a81291513d0005",
-      "outgoingViewKey": "b3fd421f2addd62e1244e685b82eed7888c295b411e25fea3a36c0d5662875b3",
-      "publicAddress": "3a7b0a8fe99d0bba39f8be142cebc530ccbc7287847db0d47ded03fc4965135b",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "529637a6-1152-4eeb-9583-d2e612722014",
-      "name": "b",
-      "spendingKey": "840e4de48e378632de14b9e5c237a2046a7f19ee4cd8fec4b0b54c6d0cd8da21",
-      "viewKey": "e2bdb6c841363d7825d7236e598b5b3fd2ef7d1248844dcf496a7a94af224f395148f956f939fe9b0a7d41949fd7246bae3642fe4cfa02cf04691c004bb0725f",
-      "incomingViewKey": "6c9c2eb8399ade95260a5c8778d526a7304056f45386a09047c91dcad47bf607",
-      "outgoingViewKey": "c70070e5a86281dafbecf02ce7cd841731bbcf123f17ab1e4cd00b5cbb5c9e1c",
-      "publicAddress": "0d7518577c4d2022742a22770bce40180af8c263c0ee991a702c0259cbac1942",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:suwNAIo6vl92WGnBCH2tC/3DQZBOyVf4jabs1MOprWE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:yuNWyjIx0c7nm5507j/SZCFNNCQX0tTdJZQ4IgVb+3M="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802938208,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAbCl+mDXdLvwIHDojtlTNU97e12ElD/DA5BXK7bdlNu+ZOLKUG+p4fI6kJl++VJI+HOi9P7nzE1auNxOH5HUxumsgsUuDDuD+VfbHXVHx7iq0LvCzXyMb/ggExzeSATyN17T3DnFlIA+cTO9k/d5wRzBs9OIaAR658wYHM5W1CfQOQBEyyQPJW6Zc7NR9EkSzEOrFIAcg570FCgxmBiwnFhwFseS+FCzsm6WbHFGp3SawwrQDp6l9sUluZdpO7zPOvG6ChotIbtWV8KlPyCK81Antkm/YBDKzTwr0BSCOZcLB5TODQeaWhbUO6/eGxQ/tviw4PHgfS2k+Tyi0ehCi44yQwjo4GNqcQbE69pMkXpmIXQ4aOsEjPJqsVAYc6L8bkqQg/dTro3voPzBjwLXQPy6pLwWkAlC/KpQsklD3kCkxcm4nj+Tu0tX3Qry7ueVJW8NFP1yZhGYcpZr0EPpIl6Bv3KYb77xqabLgij1Zv2oo/p3dd7yajR+1rFBbbDqWpr53QKFQfxZvORkhj6GKQ02wD91Z//HLz/O3EE2gj2R0i2bbiDSWsorv3KKbG+nZbUJ7McBhmv7D4YNLT/rsP7kyu0GJmLTVim8O+YzcRpW6O7z9fApuQklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGrueU1WUPpgV+vYjiJB4Q1Soi5xFFltTo3oNsTm67geAQ3QATIvKygds/rK+ucqRoyJWqAY5/05cu+mok6siBw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:+dvQ2xuWGN9hdBUVicLSvjy/8KPmDiaqFG4x2lxi6T4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:G7pLCT1CwJ+dbL+SYUC3gdyLt8B/Ut3nZvcw2avz/pY="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802938653,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAACNVO0lkR0h/LERHn2J+kp+vJGANoAL/n20uN7uni4J+xsN9yTdSo/WnCYrgq6FHFnfu4QSIt+9753wjNm41hpoHgaR+R17FIAQzfzNBRZlmAxCflZ72fXC+26qW1Mue3bVsb0xNLdU921MdJ9XvY9gdFrad3SY34zCl4MxNWIqQPvX/eZsHnOKt6xYUmUppEGZN2rNjBxnEmTWQ5Fja3zAousiUvxO+qHTm52JqZyg2ke7UtCYSeodzR2CRbCT+ocI7xvRTyG1aNBjAfMo1bOxIkq5NVsKDD6coHpGoR2nKfx0JxOkFTwMRU7qU93S7ZnWgZzLEk5KPfvD/uDpiBoLI7bJ4zhhSdf0jSAx/V3LTnvjnQgkNSJAFh6vyYg29DoeHi657lVzVdA6jQf3Vu7NgUS6qSmQTQyqfNz0Pgm6GHmJ+smzGxlNjDSnOBzb3rXgMQ9guuSgPav1kfoJ2jGCzq85N6vDpXPshGkoNqAfvMWV06d+eGi1Ce8sKcgxepF+zkr2KFYk3xCBASvWf+dTgzmSf7MkHcDrkQcK9rgK/nrFOHASlmiBYRSSwhQOEDS5alooQJPF5F+CsHQvJhF2DxS/frqOWIAvYQFrHML5k0kx5bGWQ4iElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw33WYYb6jyyhchXdKp4uK0cp3LqUW9PwCBjZMiDXzkeweZWOBWLzpi4hZ5i/+2UzaVqMaQ8spWkpuIOJLnGtKBw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "E03ED7915C8B13617D61D1B965206F7E941B3A8DD04F0958EFC758AE784C6093",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:CX7ZKKHZ4H7lSAYhMRiU0HiotQtpdQ28VWgJLsu1hBQ="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:efQ+0k8BTlCadhkKHwQ0b0txmbzfngvvTMASbkhASTc="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802939055,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAANNQbbXK0o1qWGCiWmkZabDM0ycNNhdLeE3nZnbqwYDGpAXTgiRSRl0ttshhjuSpm7SbNEh8D5/m4SDSiSeN7CpC77AwzsvO9siKH35oxA5yr45brd/LO38aK71zuZXgzuWOI8rMoFOV/Klz7GKgWafq8sbPUDlErhp9GUfPfadIAYFOM4xwVmWc9ekmhqh2/Id5VsYz3moQoDo58QMDQPD5uy6nW0oqmmpGon+j++I+iKwZLP2Oii2hkd9x0JQRFt0RhoDc+5LmprXytbBxdaRbYl9JTxh/9ibsxTaaXZ7pLMUVoDwOL1xVe3+mAu7szhi4Tl7Jl5btt3VqX5E4Zk2brdNaj3k93oeRB3dan6plN1Y6c1q+0yqU3xi8Cs+JdXXxeWM9edDeSTFdXg3eD3wzFYAc3z/cb4ZHZ+Gwi8WT17KBGJIaklGge/Y3UCfl4AM0T27GNp/t+iaIcynS46pYKf2EcQW1CMR0rmMfxixZIQo/sRHuM/G2Mdvj1ryTaKY7k/Mlz1iLC8VAcmlqHsB3J+Sv4eWffT++7MJPBIvR9P0g4OUM9q0vYWcHqnithNEd2Tr6qwHCfsL+mTiOipptVATWaJajiTBT1UHGrLic/9DsWGBFKZUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLERgGQ6+Cqhb0CGQceQ/qF6v23WMrtx97aaaaW69F6JscH4QCCb/mQKKriCtrRXNMBpw4n0jZjBnzz+gOxLnAw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "2F9BE685551C5B6CC8C2C6308BA0CCE34BAD5C3C9671FE63D180A3588BE89D89",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:NbjBgiZtEjTWUVyqNqODeNjOmVqq7i780sEmEMFQ6hw="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:EHMeMYYU0kIIMyUfeMklpJ6K3cxHsgxChPSijLe6Mf0="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689802939434,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAIDh3Sg7AXbHIVFM5SLhfUWc2pdFxWhmmFoATAB93kJCyhjPN59Hwlu3shZD5Il29mIu7VdiOuqS6kG5ZeuF+Gp3Tp5P34ZaBELsgOKrd4+aTNxFkXT+BLQkkLPXZGpgFL1xdQaCoFEfhUwJ4YfSerLqmGoXRT9HOojrDlw4UOOcSWOM03cLh5jOMo1RCH8vHwCK1FwSq8HpQfkzBuM7rCFM7R5XzwVxflij/co1vumCOU2KvixSBp/u77zCfCxcZ3+Ft7IVcrmlge1nVRsUoUXKdJzW7Gbyg7eKsACeTSQaWkplil3U4lHt/3N18ub0IrjCgefndM8yx5yd782yuQqCJebMJ1iXnj3Nu4+MwPDaI0JjNfzdSj2DULPIVM0IdnzXUliFQaqL9KH436oT5hXNi1FckPqRbesuPqLjE39SActdztqFKrdJuEyeGUFOdF9CIiTZXgQiqdjDIxm+BV61RxiXUw21kwRk4xXS5pvov7X3po1oxxFsKvWfY7oO41c8i41Vsoz1e7m9XYjdbIIQMPer9puFbnBike0g4y0wxwQPQUlN9mZHEb9RTucbGK5fy0/3JwKbDdATq7OPUavEqB2XZrG8OVu1H4UQPurUBGWbpL0e/WElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJWSvr3KMA1DFeOnuWgip1q62KQoPJOqpy6w9YhNx71RO6XAXi/z+DjBvkfhGMZdvVfGtkDXvLR7QcG4wJJZLCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "D00577BB207CE033FEF14EB81B8977827E4D328C1C33498CA1215D499C924494",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:T6Zw1CjPdBDbPzQJMgmLGxOsIHWW3QvewoyqSwRqkFQ="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:zhzSjxDh+mhzuRscdC8OvKDIvxAYMCArvlnhylj32WQ="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802941396,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAIoZQ4+0ufaIQUs2YsH5IXnzhyK6HpYBRpFsI6kUfrhOy+yYoDICdTDmIS7K1InqgW7gQBPugQSUG2sWyf6exFH9WyBoElXr3VFi6QmxCnPC1iugO48dzyDv0dElwgBfVYHXJUxyO7WA2sJRhtAsPMCT4AjLpyGeGvRBQ202Hek8DYko8OE+X0d9wUn6WVM4nw9OPwoaAqxpOBrwApCK5Q7eJ7MFm4Eb3I/o5oJAA+Xqzut+RLzrFpmbN+4hatIjW41PuJ02nm6EMXhWKvd2QY2P/Awq8M6wCKYKq644GE+X7M4Be2C5DA1JBKwKNA7UQ1OHA1JYyYaS+a9jfwXkisr/+eTR+eej42l4nsgic2QnqOIfPeid2MxNbfV+sae8Wt1MRG/pIvytnyHzILV8A3TLPVXDBg/Xbi8iRAjV6NubBb/gHCw+mzmMg17T18edYifemU5sFwVIzm6ew1FZ1YKpLJ95p7R/ySbJMcTjYzaTkBJnee8Xacv//7OzZsoW7ja2f4iEgofWK4dUrSdioASR5CaBL4HxsVjZ2fO/SafdBcjpx8ngmsa6zL/e7kcZgyumT+BN861kSkZ16/tZGrrmyl+MXrs9sJP7nEhQYpVz8StsAVvOthElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwC956xcyKlk6ubfZ0kL3wwE9ghnCTlnaUx/5izp1hmsc6Lcn2KKpgxJGQbzb2dDOfGMQHCxjSnSCsWb18O/mbBA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA2EEtUGVdXr6DxkvLDHQpN3YqRDcn/3PiBpbyfoNUVPCpnD6zGF4YyWAXHRKMBBej3z99xfoeowxqutslAxC2/3kAlo3Lzo5Got1y1fP2fDeFYtHcqCBKnfWyrv7/YXUqvGpAKDpoVjxwDtE4DDwT+FqiGEhPkDyHM8XAymnljQMKR4D0GF2Pxbc6NWYCklWDP1Hhyw3N61gEzx2L+TL1g9/O8DyFWBLtbZbuZR89JdKUbSN8b2VYPwT/k9Q15Bh6BMJz5DL6gyhITlcZPGLjGZ7dazQYofDqOkGUoQ+sGqv2Wf/jl5ycAgG1nwwPl0B8tlJSXLh1sv7u3JErS3YIIbLsDQCKOr5fdlhpwQh9rQv9w0GQTslX+I2m7NTDqa1hBAAAANO9FZC6L8o0F4oRNvTtc/BuiMWwBa70zNzjd8LrAQXhhO3HMOpR8osJZqA3uqPsV1DUd1gKXO/C7N4cSWHro6LaR5Fjd+eoQJq7iHwFRTD24a23RG5dUfOIMqW/OSTCB6FnUh9acbzb7WtBpFls6STPmxVNn74uqw0AAqmmdNsyViklM78o3zDAlrJSSV6pMYdDcF08AvzBYEXdMvtGPvXp1FEwcSlf9dIgs5T6x7h8znCA6LY0a6dgeYZYIk8GFw2cL4KFJEBjLRq6C+ZQdAork8uK7sZX8bJusMiYZj/WzlX4UU4ijGeOdxna6Pndbo9nITErLkfxl3E3fFOrZTPeRHm0g6yUMZIhxxnWDu0Zxn/q92lkt0WYxLWpluskiiqDliB5deE3S/trQpKac0uMPbEXvT3bmC8d2jzbIAnX/YOIjvWlZGGmwMG0snYzW10oSEF7Nr03/ECZ8UJINCvanvdbr2Xb/LJooAx4Qlpp6oG7zFBf0kmMUZMZbbDu0RcYndiCbwpf+6Ktr63rKK1nLlnqTHwceLSVLlSKgTGlS/M92qteAo+xFzTdDaWtFmdvGzmOIta7jYwceEzYWQlbzJIddcN9Ag4k2vAopNi4PzcncHe7eiJ+8Vcg3cL0aV6kKQRTD2/nmkn8GgjCU7ADteyCIsGf44TPa2Oe8Pn9eiNtAbKlwNGccP70GyMGSjJvfprnilkjMwccblaNWFpbFQyEUpV6+tynbDFOzld0iIoWGkM3yOTdedFI9xI5qHstmaWGeINn87pbVxJx4YyutyztmtXXTSf7hikKTO61zc+IS0y/iRCXXDMwNkrp4B5xRan9BQkeiPXEG1vXl313NiHJa1USGUP3IJCjcZK/aBHdjsQkZ4G3La4mwbZf2zNZUp87V49NqZslFSOy7TMKMydwyaflQJghCzmePkZKWPImg9ebKwYOSYujWveneiWjmMeuJcAIGBjBNKYKB3hgbHo2Sxwcy+mm/GxGYEGXx247+j34d9KYEU7XaxwvrtB3Pj6YC74xV9v1Xl4E979DgLxd3DYaWoyXrElZYzmTzxg//ZaqEphBxLtmcq1I1PnHUDNZqHmnYmrhx1SEfdOLaWvpY+3OOaIEJIvTxYKecFvODxDEw8+wD0PG+LgsRd8ItKIPs/UIAW6aPB+qCnnwuI7bX1yjOpyeAOuZj2kTgqDn9F6MlfK4OSVa6KwpwIS7WYKmEGLpNRiUaK5dAu8A2v1KetlmC9X3cpueJkpch/SiszjivnCPy1sIdyGE5tALPUbAJD3Gl4K2SdVT/FhcDzJX3KmG7mOy58CUkllw8pax15MEeol/jat4PnfIVFQPB81jAJFcTm+t22MCnFzJA2Umu2EYtYEYnssxVkodejQMFvx2n5QWkytIvLaApAhi2pPmVswWUnEJ7qDRtYCv4+D8AE3FpnmZh2JFh5B/UuvqrXEiV8XYz/9jdsjc1IYKLI1IyzyxqXShi9N4ovighDstgKUY76AQLy/jlBDJx8/4du8C7KWIWcdfHHpuLhCBsSDo/N8/lGrZSH4HmrUbCti5UzHMcyCz+nb0x+pu8tYpbIwvzEhcjEEWgt0dDg=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAzeOvlQ0bRczmUQW4mLVPiG2rQo73BsTymKjkcSYANWuIq+eitLDaDQECtlFd8ZGqIDDwqJ56P3foX7p0dIa2wvVsX7+eSBPMUTn9Vj8hmEG59rbDwH6s42uJNaJpN3K99B4qGf0td7k+eWZmE8St8sGeD9OYeitBZ9VUsCgL37wSuAxAlmPAX2a+9sP7rjq2PhwATLv8VbHe/K/lH4Gs3krTbh82THmcSHCnz1zFFy2l9dclVd5Ih7vgGPUK8DKpJ/701Ug37tbzWdF/k6Bx3cx7FcRo7voybFC9cG0YeJpkAw8BcpIyIMPXPc7xyN7ZJyTuL0mAt2J/PDnKpsYOiU+mcNQoz3QQ2z80CTIJixsTrCB1lt0L3sKMqksEapBUBwAAAGxV0cDffSCgz+SZ77h6Crma/Fhepod7LIw+Z/SfvKrzPTXYMO+SX6pGIxEam5B8PjySQiA2WFY80HMYF8HPDJtL9dxdJv7dsREJOP9uqFMDk9dCZ8N3Ceb6k3Zf5REFC7kA56u2oCDx0pEXnD0SMgmAB4mZVRvAJ8Xt4PCHmdSK9hinYHW+m7Cia7pvNyMdvpLprHzdtFMMLk2wcfkaYMTYuP+QFHlbrouYkk92LaaDtGds2it1wTHrAW1WbuQSVhc7IPJ00Ynmmz7e08X/KfNYIAyVZ3art8F4OW4GZgPLZV6OMqPRVOEnGbhQtrcp6aQ/BbSLxQyid/576MMLTz3dHL1Awp3tBaKEtVMp9xH++jlBh9RYjhEdTuijrHTKajOKPqN8oV03WihyxNECkREcN5X0aYN+SuxiyiHS1P8KWeriAq7MlH8vw76DCTJBerzMUrwMZCjVtPXAK1sUhE1b1PIja7ghcrqFeZlSIK9wBQb5/p7N3NvEfW48FcwUMwDDX7b+QAx6Ykx1QviBOHDSv47572iRYZzRMn097JHlSG/nXu1XcS9k2Hzbn9uzGTYRLO2jZQYCqb1XBlWms0faFDe0g8cpe72yBEo4kNaA4KPzhrHSwXOyN0mnnWvVdwvxm+QkPKVCt7W1mW9dlqz5846mhlssnASFKLpQJAMyNq337S6RKLK2HVW5FS2G+AqP17XKe1p+v0LTamO4Fj1bFca/D13gzAW9Z9jCCExPSWEZCy3HJIv/Pz5fpjFTfkvRgyR3WykoTFUyCzVvnPzqpaZ3Tv7HpPhvH02wA5fKM8eBFYCioCq5svs9MIS6CHcJoPhFg80TFWdtp9BN9SyzOgoSCLzFYbxbwBQE9ZdD+sbTL90bUcC4KnV2NAjxa84BU6Gd/e+zzKtri3F1YrhYIVLHnzgEzmUJxqZESVXngFl5LnBogaIP6jRHc4xOagAb7HtzGnHsOMq3zP8hfiDAWQdGqIKxhS6iRFfwXsBFuAY0sTymKyqD+O2+7unS6tevKGlrfD0wXE1XhyKUXVW/rbPjQFt94z11hhcGV5veDPo4IcPU3vrIcV30cBIll0NhK/dahRF288gE13FALI9qn7sUJo1eZkjLcvS0E6y1URDHYj4IcW126dan+NBLzL6UGNRxmzZQ0TkMzCg7VYkyCSdXv5Hf9sICXZvzZCqoiEuG6pDU4h5YPvLpuKTM9bsdfOdXypYW+Ihwf2QnmAHMfrOMz21iYWDM1C3IguB2UagOura1pa6X6yizvTvzSLuW5QSrLSzM6tZaHCl5HyUIO9i4OyThKARiZOW4ez9EE9D9oo+71b7eCemwWpX59K9ftx5D0XrXP/aL5Ziq3yEz0trjN4qbOs9rfI5RJMslwN9M3jUrm1nCvdSSaWaNcYPO+2gTD6dx/B08LqO4BK2EKPhmDHmbnj7nKZluW4ESXmc93jMGTxcKPsnUvIcWJr5pSojsPIy7xYCY/PX9hemTaO2DZqPgFeFkTnATyhFNcijv74Pln5uGEZ8sLs5hUjHd9B3z/+815U2NxGQNr1Y8I1U6JfEbj1kZbNHbF1UT+E1HSY1SzpOkNhcFq80rAw=="
-    }
-  ],
-  "Accounts should update nullifiers for notes created on a fork": [
-    {
-      "version": 2,
-      "id": "d0d33a5d-c49e-4152-b59f-f24f71dce992",
-      "name": "a",
-      "spendingKey": "63714dece658a69aa378fc0d107d5c08599779ddff13f64af8503468d0b27807",
-      "viewKey": "9c3912ace8260740e23bd2880d0a1645262cb38a1e85f0678b124fd8afca6dd18701e262cbaad45f3e614c8c0a86faaa3cef1d18148bbca37d170293478a5db5",
-      "incomingViewKey": "f6e1493448c81d265b98bed048dac67765385fca4592c4b1a5f9cb28f8552806",
-      "outgoingViewKey": "933c14d0a1437b5adb2b8a723c59669b5ff0edea3791db385cd46bf8e1623aa2",
-      "publicAddress": "a0afc9dfa03cf85fecfa55bc5f1fa87ee8e56725df48127b9f4b15e9822c136a",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "d9b47735-5347-4129-a28f-bedbed8c3e8f",
-      "name": "b",
-      "spendingKey": "81c053de8def8a283b10f379846dfd3d0c9fc365f1c5d57d80563b275ca7cc5d",
-      "viewKey": "10479998a69ccce77211ac6adda4f576228ecf3486d6934b37ab6e17bd8047bc7c0d9fb5e10f4aaa264384a6c05ce38b903deddbacf8e11a36fc927e7aebd88a",
-      "incomingViewKey": "a9349f0be6b055592449c957207092d9e27afd1f5b2ab25fc0b65330fb4abb00",
-      "outgoingViewKey": "f80aefad858d682c56b829bc40e96f977b2618b76bf26da0bf10d5e21a0b9b56",
-      "publicAddress": "362b548803395186783bfad9dfa586bba19f9cadda6db6c04d540191a592f64d",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:5QaDD/z/W2OczUlESSqcG6z3bcOLmSAuynhnaspVgE4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:w9jE30W1wy5PVOLQ9feMS1bUyyfsfA2/FhZfuvsbDfg="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802944715,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcsuHj1f5FqCjApkcaLph8ycMqLyaY7XMMAGGzA0JXk6nLamaQe0H3iOkESpTYtsY/Vbi1CjTOleEMf4Z6ZVWMMcqcxyzZytKHGCsqKqalSKuEuyxGBZhFpjZVpNzKEWpKbUKzXpQFoFXEE/PV4voQ4N7guvSFmBxpcRkfSt8c/AE/6Qe+O6jeBWrBWoYy243Je0PJnrWmKS5D2LCOkp8226od58sDDbK7l44nxbRHrGKRLzDvEu3jDFqDD/B7Mn+8UPGKpu4Cv0v8tgT3K6IHBRJM7mSConibwlW9J01qK4nfroQFaz4vAsJ573UotlVL0g6YcJHQHldPras/ymTDAk7ZVs8ju2yV8xTxSA8Wb1lb9vzVQgXJ83FIM3B1hA13epSJhaimpgg2MmN0CwCXz5uWvYws9/NwJ567Rk6vC5j7m6aOfJ/K51t/PjEQ70JVBZWJf0RAvEwyHncUXETIFLrwjUQtxU2wKlsnUvxeUDWtaVUj1/w+KCuVt4zl6rHLjbVYxFbGNt/RP1uevYO0kIuPjVAum05X6yE4SNKQgVdGN3AALChhyw0L64hXtVJREP6nntIVeHEdsupM8JImdkbh5CTLMnNo5fbC70fdceYQc3eVxOGqklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/rNaUxQVPJsPkJh8S7Cqmo7/1EKRgefnh2Yhx27vY2jy1bSrar1p401TqsHfPsw3w2FG7pfaewc/nwwASJEOCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:w2wTxD9m5/D9S5RI2dM2/hsvf3Uqpgi7TLxhhdkHdVU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:/gnW4AxxrihIXLWqWaTjfuNhA1hU8KZhOxes5BgJoTM="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802945112,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA/kKy4TqFfurKPCv4dNSDNeV4Tzf+hzVZw8uAlM/VGZCp7Z8e393ZbTk0i7IxRiKe7DU3jJeX9M+6Y9U2xZhNPSPJGLgwSc6VxqL5Bn3YKHaBoFZv4xLQbLdF5ah7xjTJ6hOwVaaEiu4KIbSoH+jlHNoIIk97tcuhE3u4nbzWmuwPtZDhVZ+xJhwnpEyVhsoHz65YDTKCDrZ4dWkmCTiy35XQXuI4OJNF1Eclaokrq6C3EB6dg+AR0IoIeIJqgSEiG/CWIV9VdE8ZE+RuHEakbHl/QPLZ1y6q72u3ZHwJ0h1pfRKZHlW0yq6c2ynjSxGMjXlu8ycLkBXZYn2tuknVNypK1W8G+wOh5BAQkUl+LALIeOqeUNc9VvtEZUFotIM76Y/f/FPWbpKYrLhYEbp2D8oTnVKQCmFfWEpvR9TD9CEA5ITdorweBW8EPqWTf96hvnw07jwY8LRVcUZ8ft23HOY+KhnLW3OYyrdadfXCoy8cEz7fppm5yApznxfG7C72hFJ1v8tcgr7H6+IHGNCR+/WtA06YqR+w8wBKR14R6vqspNL1JEWvPLMPn3Ifyeww+9CfYaf1GnIaHDsaWuVCq+vllgplZdbngMWS5/NAeZ9ia3/n0mfIXElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwV9DKrhmUFTwgVAb4H+NiuVJdEeKcumLGO6UC1lh8dje36TgL13iKr2w6u8VdJ71K+D8yHNueJUbgrez0UGWRBg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "1A186E4ACC72E31F2A7D87B14AD39C8CE2C0AE6DBA6362500A1C9579F936301D",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:kandjRId+esvt2MXqEdDSeqZOjVOKg5gvgUvh2jvzTI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ORjW//EbNMOwnYKKPr63u95zN3ssWHJMSw8sOB6gxu4="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802945494,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAi0Lru/YqSIvDIXUsq4+xtySdXXOm/nt7bOH5avMwPgytI0koJp8YJwYgbWuG6htkl3rRZmtsL7lPtfk54yqX11gSv4hNgxsLSUharNpNtOes2V/PVNXUe8wgNVuWEFPoMfAJDUou1r8Gi39S2y0T7Wme3m0XQYeX/cqm5lOn+3YDE75syC6O+hkM7IA2j9jTNFS9g6SLK7Go/CDChfZRo/5OXXvQ4NxO0YoLuwIO9VqMUF3m+dtODfSqzAHpEKTOyl2m14ZI826c/XH2MsxByI3Nj26JwskE/WEeFEngoCooxqR9V/oxvARP32bUcmvpbe55yy8iDQxNbHr6WVm4ZUg+GxaDq7tKIaZaqLzPW9WEgB7H6tji5Sq797diM+5XIsKs1JmS9tFp1yTaraSF1zK0TCvxvqcp5bnpqWbMDSIk0uPvOGOs0mGMh6tZDfBv6VfQTDVx/XBrrPQLIkKjlmyETqVemKkQr3YHwJsJhw0FRQq6ZGyFeh5oihKGX++1RJvziYxdq9sWMGfxICb72z+S8bEulf8t5pocB9tHe/hU4tZGyHophMOE5U3FOTEJeRx9HnC0f+evvmINmgLz6wumRyXdDMeNQ8GUWTKSnItqM1V2iuufC0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOt8BOSkIc+Oq8gFxU/T+0ToFuU0f7UkDQAmMikd/V1UpdDpXScKoMBGkF/QJBRpOUMUTqtPNpmq/5hoZfUmsAg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "E6514D324284A3FDA848BCA123053AC3A4CA02BEDE1423594606CE92B00ED293",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:t4lwzq5h287ISWixDf4185TYuQQglryOBbabX73AmCg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:kqLCn10ae1dbx/Vfgird5PJA63OqWyREXRCu4ZudxvY="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689802945868,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAu7AojaAFSMKSRgRj6PjhWC9Jd6LZUM0P17SCUF+6mKuSrqHAnr72LfhzRTYMssuJ0455nq8RlkXuBGdGgI3qmvIl3tKZ66TKu2zWfjbs556n92PWsR+wjMqoFEJaDLcUYKM3xZQ+3YXlKwczc1ghzrbozDoQyrrMfT2rkA5jHdAS3judnMTnPeXvHJMwMzvL1S/0LhJmnQQFYeO9tvHcMUZd+7GID+51knOS+viQ5/6UJN5HwzeJ2YQQwI88Uav+yUKADJABUKVoasPm3s+hJcQDey1XsjbrGIwlSGK9dyi9sNx9zqNxneRfcZ7Ayclkt5o+Aj1lH6ksioTXqc1iamrSwHQxlT4ApuNACf2/9Q8CRZOKW+VqL2MDSnaPKT9hTlBVQKQlozX7gDQbour81YSDrZOJkBpWqCLrdVxzwGIllwXCqEXWz50DBqzW7wa6A71TXSHUe+xzn1Dzdn0BgIHnSnr2IVZwcB2UX8e8Er+oehwWs40HUfvgjbdTNk+MFELPT1InV4Yx3XmDkYRJtDuPU3y8cwZ5f700/RTldpFvMvvYl3h+QF4fOG+fLTn4WQyFu6BUICkHU6bZQQj0ie91NAaBJxrn9Zt9kjQJM2EbUd0y3TOxWklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw39TE4Zr3M34oQtuX6cdXusjpD3OVad/gDgNLfSF+SoVUj1B/p6jMsi7Ik9sz4QalIA8amzmHsNv9nDKiei3NBA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "9F1DDC684EC6072EC23A378F2CD57FC6B42AC2FF39EB30EEA1C045ED9F77871B",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:QEHty+Ypu5Bv8PI0AzLzdjQYKkE/spFW/s8pI8HgUgo="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:Rxbh/YoeHsOlDCYKq35v7y9weSqI+G/yrqaK5/sH93s="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802947816,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAMEqwQBvLJCwtDgfDT6iKtbI5EmIUfgMzboaSiWidhDGSrCKWZeqv+TBrgP0SzG5MyGtTukiQI1VByj0Me1KK3aA7I2jCGSAaZnM2NWTbs8GyjSdVXh4mT6l9rmXG0+DMJXdoMKP17mt9C3RT3MBOceQX6GYr1dViXwSGKa90zYwIh3sqPtRmPtri61R8YWKMq1bM/fBJV6NZeqTa4jW4lt6P8on8xtBLn1FpnCmaBou3HPctF672bb39T/+uCI+LkJk410FmihXI0GM2DeO/LbMbRy3Zf56V/C4kxRPF5xGp3iiyt2R7p83408UA5ieudwcXx67+WafNxI96rbxeN+g8TFz6mkFZR2wsIZSNzvMwa9IZX7s5c+BWTgVYIi5dKbDs6g67rL8arNXtX50eIjdHM2BuniDtTNShc9g9cTGsKsGeyN2NPhn0gKSNk0GMVpecJF27Ogf1/4b8VqPMnULVnEUOQ+8BwOUIOiE3NIdcVaQDzf4nPwRhKZ/cMtLHPt0zlmj4CqLnUS9WigRrDJDlkAxQJHBOG2sSEjaTf8pK9AF8FXXeGPpSSTDP4qOXaVyxbidSDEi86STxHWUHeZpQmF4d2/YfjzDgAnrKIHL5b8nieT24Lklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwopmaZ3TVFj8S27TIh1m00l0OneJBKjbV3ujCONIFr4Bsq2e4QEKIgw37pOrCNRnjIsVBZry1AZA0TcE983isCg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAACHXCzzFDIiVIf2teL08pMfq5yD/6aBOAN869QqnL4Zi4GDlmXmqFn6ziJbKsh322bYNndfK00PgykqhhUckfb8DyHhJgFQjX7LpD5n3LqZaJwdoOLWBxPHGP7iOsxtWdB2poTn90xBWAmns5jEupA3pHnCmN/TKLKkdWPFavwh8MhTZyyBwBmYg5G7C1at7+RN9zQprX+t9hDceBgFexx6J3XJMsJob7BEnIQ0tRHsujM0i8+fv0R9JpPJY/xOaX8GmQGNygUZV2+9g0NWP1pSq+gvoHigMDxV2t7M8gLppWuMg3n/Xw9r24PpVD6ZxKRwebv9myKRUtilbHcy3vtOUGgw/8/1tjnM1JREkqnBus923Di5kgLsp4Z2rKVYBOBAAAAG2Qp2ANmRFMdtEvBRLALRJEuSPPm9zZnTHzPuNba2ugplPQFC1ke5IeKK73+h8Tpp5zGKO3Oh9inSNOt8SoIdzvg2FFc4NAJRfDDt98sTQrgiODhT2pJhaOK7QYK/9cBqF6HUhbPbc/jlCp1pPogvunfsK592yO//v+hyBC62IuArzontdXzpkRMdqlKQuFn6S4QvFkl6nPWgGwSwXXoAwaR2AUXkRvWqltutU9TyfaCYOUI7sSJqvqjzjwugWKsRdFthgc2UbWcT49hh7z9rUKeGnVLLfSaVCy4bs5Ks2+liTmZUCIbl0Lu187JM7vF48AC34CfsECEvCP85NnFT+aaZTx7FBS3xZMZO78t2z33U56QRTlRRev3hzb5TGSCMz2szJXpRTSgOJVUZi3cL+IymJvXaMM0vJAe5FfKcwz/eMpBmmipkGbnmbkipW07v3dxzpMlJYpTqgy5llB/TspBZaMCR+qgzR81hbAR6C5E9EK5G96NR3incLVdDf9g90Iu5UpUEGIueAYOqxfu3aMQpZBWVLlctSpeVan1wJCjHlHWYvlwGcrlNXzDoNfdbIgQ5/1zKGipaRhDRF4Z/38v7oLeE6LMw9HYMPi38rx+Qdhgw9gbTKfAgpAeT12hkSeJ/QdF0bm+T3vJDNvI5UbN8PayL/iDkcAxKrqiA2QxMIqFrm6wtY69oKGPZ9lIfMApu0lkahTRPZS7K6qdtWm4M6gJEhd4JWpyPQx1AaxiXrttOKn2ruyUW6+g8bqug+PmJN4eBfeFtIkwRYJqorUVYkf8jTrHqwojtz4wHVeayDZcuj0q1SnDTuDz5ieolxntX6dUjzNarm1FjjYh0k8GiRCRrTCIjG86/oAp76i93gLWNznQzO4mVOwoQmBsBrVLy2qID7qZNz0dlPGBNLAy7X7wDhX6JOlKehwjMkCPEIwaca7YJgTraL05EpUtaT3RYFkQz5fITKcMZJG0vtHLtMg+LJHH2miV5ju6CHnKTJoE0r/rV+qyWrcJxPO7+JgtHq7p/cKKLsRGZ+zAgNROXLc9ZdiQtV7rn2kaUs6J7gnMemMmsVhcZz4On4GEmMQfW5Rfy6/Cyvp35Jw0Xv/mcimmOBtVvKv6uo2RMLFb8WpQQJTRbnioSrIwhxfW0iGsfWSP41KmEELbbBc5dgOxx5nU1GxBOTHn1NM7d1q46YDNsnUlDv7asBhZQlGVnFCltCyqJ8c1oxPQAfZYoJIyVBRrM7UneBkzVKcdZd/w23DAFzjjsEzaz4WGbBFDs6AUv8o1MK/cD1gfUFKVODAcoUVFjLHanQPVOb3M8t/5DRXzwuCmpOd4MOyltegYpkvYvM9LBlh/pmGYwV8VTHWXi6EUUYVcTTrRVpiogl3oOmq9YQ3cm1Vrj/Nc2g/m9CkF5ZWDFUn8WBtCUP2IVwz35ycgdxQq1+Ra5QBKGpfSxwnOqpzILMh7Z5zC47+uHC08PEoN44EjpNLd49PsFmHNbNX+KnXcfAnp4ZnXk/v0NXqaKqYT7sXkOyETdoDubvuKMKIuTJDxz9dDIS5SaE0Jo9ZhioRCMBY5fqc6+AapXxe+CiaGrKGsLKsfIlJAg=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5qkhjEiRezlne7Sj9xRbDY37pPYz/NN1j8DSugPEtw2lwwhOehkfNtEjr00x7SdYnaNPYpuGBdQSRHeDjSYWB2Ms18IMKlevml2sJpNWP+GHPk5U5j1vNCl4gFvCovSUUjMkLES5sDFU8Z+NO5WjCg1pX8eBcBevnFTgexko9wIKirIQSl4YfoX4s+oCj5SNNYKEQH6nBv3SQaOuRTpxiCsk9AvNRD4P4VrE67yMkZyJ6qvWzCw5MEIYe0wVvV/YlP6eHjXK7hiJ9lFX10IdVF/+3wwJMFrftlgaNKVTFsATomCmZKn1/YuIPoLW4Qg5Vo1am3B/g1MTDvkwZ6RdQEBB7cvmKbuQb/DyNAMy83Y0GCpBP7KRVv7PKSPB4FIKBwAAAJ3RIQPKPIA54SY4Jxt3hIYSiLDD97DrEi8Ls2VcDUyJxdQPI68sUWg3BHk/oCmBpe+ceRwUk7qWS4idvUb2c0pABA5OeowsXTaCSeRH/F3xMACWIWJvq28R3tKEV6QBA6BOkD1V/MsNSvfDVwN3Qq/62OBF61UdlShv2GkLERWjnkzjBZEHtGQygK6FtWg7po2Is7KWRGLsvnAEiy2F7NHxlE3cPQkpEXRVM0kPLb7F1Ug90oPK6s7aTQxgKCf4Ywx8YmrMuXBuD2qm4cizZo6Ewo71UHlTGk1TrRREOitWB6/AUKQu29EzJECAGeqHh4DSTpE4S6BwlwPN4zG9lDd5beidySqFCPr54QuEF3uwYyRSp77NCVGGgPFiAbT5ax35a8z99yrk9JhgNeAVqiWCtLXYE/zj/QjMBoJlln8OVX9lvfcL/Y9/hm7oYj6pQqLmkdbs8l6ho9g3ECHec1CLH1dhUT284RDcMOSbjaoETAoGhqgC2sdSXDv7/F0Xcd6rRi+dp8T57a7K/f7HSGtRDi1gizM0UPCIBuGmRiwy2D91Oe/t2V+lQTALC72T6Fn89WgymDX2HMP2BdIEGtjzWmlU60qJZ9S1Y7OsCUUSwAqP4xtC1yjdWPuMgfhPtPQ31Ax5FU5tOhX+d74qHeQpXRlXyFk/cpUP02tqUkFwaUET3V/csldQvLZRppFuYEkJdsPn3XD9DTu9A5fyD/IOaD5f2t4CGw9Ouabxw5CjBJ5EGQGi1JG0jx6qtxvf7WEAeVwl7wMV2D9ct3qBKJ3TAYA0D/K/MBLMM3qY1EHc6bEDnVxYJ+GhiT2sxprsI2S15RgNWosZsrCedhoeJvxmFYa8Kh+rRfrlroy+L+PrW3vyhnyUp9Ci1NoUIqhllfcBQ2kcYY2UHkePn0+eibSW5m6+P6qPI4x41+qg0sehzjgtRSTgZVMMtd2h5qRVnpYQ7HorQwkUctfssglfaQ+Kud+HkNcupLaQlVCM690o/09aEWyprgSYxWPJ5JvapKMnEmKEyWyHmNAc4gHThwLP5ypM/rbZyz+5c9zlO7gm1cWvURZyCduAqVLRF6tIO69y+1NXclKA2pPh6xeWEur81PQkWa4nVrZbNKVsJzcQ1PC7SQdYhBt2rwPHwK3ZQ0RkGhN37ZRoUXf6e6r23SvXcm/Lt5aL0MOlnCkB0C5Vwgp5XvSCtSEv3xFQJM9pZHE6fWTUNqR9JSQfcqCqTo+Mr90t6Yf4RbAS47x97v5kF8y0TWSNcBGi4vKuGjQhAdpJGEa7oIp3zduresWlJoly6+yITqxyvCNh86SKhAJHIiQAJAjgzDkiciH+KwCsHGW/hMPaM5ObElYjmr+mg6gd4QVjYn+ejdF3TW1kKvB68zGumezVpCrYT+IERQK8AOO8UggCFG6nHlLoP1TK9huh3dsOEynjH3VwweecjYmZxRB/2MozXLBAArMUSB7OoyBAgRPQgp6C7E7cAYfYhWyQtVIr6XIO99Ix4e8HYCivrvE14s4otWFMT9QbuXbcjTKB3sYrVFwe05oyvQjgymcwunNODWsTF3BjNmw2jgIH9VBdWi2BUyaWy3A9gnCQBg=="
-    }
-  ],
-  "Accounts start should not reset account.createdAt if its sequence is ahead of the chainProcessor": [
-    {
-      "version": 2,
-      "id": "d313913c-5e8a-4b4d-aa18-43aae059d0a1",
-      "name": "a",
-      "spendingKey": "7bd8d9baa19532af59e137906a46b9b94b03ff24e0bea3ea8db9e8a11e100a33",
-      "viewKey": "4f8823557637003ce44d1a2d3f07b6f123c85d832da73a8b6442518206e0741a8b13fd6d0e9f8d84d414f0bfda424582c68d6ff6560bba74610a0cc0e9388af3",
-      "incomingViewKey": "e653bbbbfc6f58ef7935d725c68f6bd87abc0ccebaa3ed781d71892a23baa201",
-      "outgoingViewKey": "a67abc528e3b3fc1eac63b2d683d214d1ba278e429c8e4396bea4f90531369f8",
-      "publicAddress": "c9520b38d56be5d3f9c6dade0039ccbe1e4184199a1fd078f873edb007614d36",
-      "createdAt": null
-    }
-  ],
-  "Accounts scanTransactions should update head status": [
-    {
-      "version": 2,
-      "id": "dcc62455-f7e5-4f55-b461-cd6e2d44573e",
-      "name": "accountA",
-      "spendingKey": "d87868a3984051676534599f608f73954b83ba59ff10db1a58413890e027b045",
-      "viewKey": "3924704ea0de4f0032cd4063d04ae6cd2219f3462bfb2b646858388f889f1cddf9cb3cef150fc268491577c3e6e1c4350a459a6b61f784bcd1d1f61b4d865e2f",
-      "incomingViewKey": "1f9322d99a9fc4bff29a4c4c0cadee4ff0aa2e76f4d56f1921c93f24b9f7f005",
-      "outgoingViewKey": "b159d30d6dfecf2cb30d750d737ace34caef19253087214c91511d9d74b1f48e",
-      "publicAddress": "188463a52ac2000561a329c959ad06e6e2783033c3eac02c77cdba3a22849645",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:eeQiygzfDFjKGhD+QoBnoVbLTdPIVCTdtKrG3RhL0E4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:p6u+8pfmysQ4Xh3/sKToYpaqrJcm00Mz1D3B+ulKN1s="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802951962,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAGi1x+Hm3LenoCeXIRV78CMyEelKpvWUPTowQzhQg1mylnCwmUeB/rVKJ2qv43dq8cOxspd+4qzZ/wb1HgjlOIrplJB+VMgnDxSfQOjcRtg6QtDXT7xUTpe6nQZzX8fabEdINlPTphFQOQb03mUC8nnznFwua3Dig6c+almP8qy8S+Rx3pfhcMcJ8HfKQq369KwsiQEhhGujGsT/gkWzb87sof+MCvHTmVo4Y7BGidou5bMR7agt2sIu07IkqHitx3SISS0JP67kd3eJl3UY6jVSVzmxKCcOo9aAPuFlS9EUbV8L26wJJ7jL0JJmKXZruFO/yz25eTLni2WfmKBKTZt1algNUckMe7HYFf+r2PyXvOZtxDTlQyFzUusWua6BlD2ih7WcdPhwUCKjoQB5unT+9m/3ch3qqh9xbhGn9Emd/BsMCuO21m2twBuxz24wZSBCj03SSlkSn0p2//AwlQ0rWIpHE2NPLPKs7suUMY1LwJ+bfpaVkPNibEhUXlLqKnrzRdoPcSs8OlDoj4g5vHuM/OLtKo97ff6kX5VYg1wPVWbauwDaMtf/vjffqCWGJRm6dG6q14CCCiUBG8wc3RRqyChiftD4Xk5ySkstUa3nmnwYNiwbeIklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDGZ9sGFVoa6Ofh5NxoZE2ySc5+wRe0ug1HRI0IkcLNAUx38BoOvbjaxUjuhJJsCNl3SFV35eVhNmIaTAKyXEDA=="
-        }
-      ]
-    },
-    {
-      "version": 2,
-      "id": "47af3715-b575-4ea8-9eb9-89ae006adfe9",
-      "name": "accountB",
-      "spendingKey": "4c2f22fa8d77d32c179c69994deb941b52bea5b96cf06786ce0fdc0d05859632",
-      "viewKey": "3ee243857c727a6e5aa44c895257ddff1e5fba11ac3bbd2ddbf40fd2da913b33c80d8afd94bb14aa0b5885bebbb3049759686b312613bdd4a8d9d85e74921fc7",
-      "incomingViewKey": "931ac9522cdc596bf0a1c1215203c02e5ad013b424244c9718c1676c94e27507",
-      "outgoingViewKey": "2f110a82d89706a3d7134f58504d8759e1bb667d797e9f08ed93a6587146aab4",
-      "publicAddress": "552a7cddc2ac59cd3a8cac745a61a2dd9c5c8489ae61d93782dcb36774ebc01b",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "AE4E01120C7C8F2A7E92DBF83BAD8DEA4ACC78783ACDC16B37389731B837DD40",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:1Rf2WJ0cGqx3K//L5oNmygiP93k00+aPs7I/O0tELws="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:AcPEotSfkaM2momodWsUmEQpyFPAvRvrR6hwgzbREf8="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802952798,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAMuwoTZBy6chO0Yd+2iGGGxQYkkVV/FEfY3uAlsd/5IyjvhpCcDsXSTKTUTRk+QmmD3pxe/y19jdy0128dA8kpOksFspEwsrw5kPaYiyONcOLXRvjeLvkO6TWiiosgF79SdmJho9QZY58uXAdD7s47b1Of0zXom3p9VE6xhJZFw0L5rixGYpQqz5E2ik9a72qftZc0asKTfjNQ3pP1J/d5bI06372IZhW9XlvhOBkNmG3h36E/uW+HbUv2hT4fNec2tWoKM4s5K3hqnctZN7oo4hSbPngHGabMlDb07rIXtcOk2MVGuUZgEFkuPfWx0Ux1iCai0W9QLH3VUWUCxmflTYMwjrfgRiidFrm/qYmJJjtC6Qn/KaiG/rVwJLp1/pJVGEfW8+tnqlNrreGgl2cibbMDi8l2JwLOThGmJNF8s+dVATMJ5R38KgimXMc6xWlV7Xsg/6wGeQ9O/Rk2wIRyZrUs44W+1MOLeBAJHiWHe2fsNO8pLyWZzU4TgzHWh/r4mW6gm83YHRmFTZdd/rwbTcIB7Fw4kTLV0on7tjTHcT/I3D28DRU+4pwliMHh/fNG3VpV63fD/fKvKGKdLuD0BMJ7/vqZuAhD8PbhJIXbwmjHVL4u9zbYklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwzYTbcF16IlxYi/2pCNkNvc1+P1TqwzCeaNY6BpUmSZq7mOIVewv3GDYhFoCIFGp96Y42KdjHYxMn2mIg18kWDg=="
-        }
-      ]
-    }
-  ],
-  "Accounts scanTransactions should rescan and update chain processor": [
-    {
-      "version": 2,
-      "id": "bd93159b-24c0-4232-b880-82fb39465f27",
-      "name": "accountA",
-      "spendingKey": "97feaf137ff346d112a000236ed41b35c2fd7f3ea897503ad0e5b4e7bbe94f0d",
-      "viewKey": "7fa8ca7f7bb7c7bcd292c79e2ccaf06b70b0c60817f92c4c5fa5c547cfaf956a17fe2ccb7c55d066a7510dfe16b6948a72e12688cbc2fed519755900958bbad9",
-      "incomingViewKey": "77a84cc7122ce90460aa6489451ca4e4d6ec9ba9ae29d88a50cd1c7bdbd52a05",
-      "outgoingViewKey": "fccba9042453fc778700abed4bd2a52f61a1dedc842ffd4060cb261246d9d63b",
-      "publicAddress": "aa2dc41d543089074c076ce9fda446764d0e4d6b5237cc74c0e8c7e5b02244ca",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:EvnaHZFKv5WWxVnATEG41/se1CBHw1EiuyNtL7ToNWo="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:WsgyoTh2C+78dh6R0WNswCZBPR45tqLTZEIfGkb5IW4="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802953639,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAhMsi+v0xokgbYhLzGIpwX2fiRk1dm4jhlTV49lUGr52PHPzT8LMUrE2LMw1ivcCkX0pRwfmMO4zRSwT40ZoQZ6+VKheloSEyOuQkiEwn5pqG+pI9aQjdgOZBtx7qR3O2CSciwgAJX7keOWwCJAM6UkBfA7Fvl1CGE3abRWOno0ULN1oOkWNO2z/gJS0RsUVmKV+vdH5gsYBsWLAwkxCjR5vkPVBROAGEc9es6Gj17fyFAbDimO6dQG89I94NjkwZ2aYZMZtJchYDT8hMUhORPUwxjfYK6uizkT2pTojSs3XNJ+C99+xA+G2DJpbop+6Ij12/8Yule8v1QmKEI+SlOVVlAt72YoFioMAB7HEV0ZFvovXj7VlMavIO9DYTU4hsu/EcyJt0FBOIZw17WBpijpYJxEta1WNwDLmnRN7WKTo1Ed3eOBRohPkt7/ymOcH30Oimt91RvRJCgKHttVkenRKxWpBzaK/M68mPr+1CQtt/pxIyojj6zzXx5PqeXEKZl2brL7TkjvQcs/HlF+SqWJG4eaqo3qlM4sShNJYUveG9xvOjR0qZcyLERhTgbzusQ4s8v+njSeXW1sc6PzRoB4Ufm2BfLjwKcAjoiq4a56cbxzMnRyr+MUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwzCxvlo0HdGpLMLiXAQGziXosUebwKHz6fIM7fcFTJwGTqDYkFvzf2v06+SqXjmv9qX33w9RJFzfB1buWNEMnBw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "FEB1305FBC3C98462D159BE8DDA85C67068B15C9528D0CE5D0101087759F27F3",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:1S43QULDEiqmYIkvAcMGbqDau65AOm2h3ssAETwUhUI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:8sxTai+xGy5tHTjSEXTG0PDoeaoepqvGfPZKxHQtcFk="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802954024,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAJ0g3406luI2DfFOG8yZEJsg8hS7IKux5py54J64dS5uTXxyTqd4Z+HQW2mnkeLFhEyltvLlSr/XchwoHlz3Hgd9YODzG/SdG5Fza6sOPDsSAc15hYg0wVaCvvdfqf5fMRvf/U8NBf26xPhUgtxCgTSvNpLI2vKDFVfuaRHtsti0WgnDo6Fl4XTpzdps1aPTBO/6zpMTlskXfl9+kKcP3+5SA09aSK/tEjTIY8nwRBFiPjo/UUBpsqVyj4bz5Cew7lnT45Bbq/ovJ96r0f32L/dhBlgV5p4BCNUOBsjj1J7Zf9JCSxr3u1K6pNJgN3UZ8fMcOwAQYt+vk2WTrE4DNypujF/wLh9V2gQK3Kly7X/rI9k/faXsCL0p4Hp62Ul4G0XQ45Vt21NMPFTM4cnvmVZDJfuUND2tSk8/G0pHlIeZHDadNkbey5JFNA5FQibQ9esPu+zdhXGaKh9LnviGPtxoS6d1ABHEs1VKNy6HXbsUloYXn1VCjYJzoqcflcCVqyHEv22Bl3T3n9XQcIQEsWlbV5DfhFnzV6xwrbizdbinsk2HIwCs8kmnhtfnyjW+EYDrHzySfLnuQMPtW6rLi3EbdMjZktJp7YZcYJBwYrhcqYOgBRtFOG0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbih+Mc0R4eSC/ffwBHE321wA72bJITV/M5Ff4+cvVLiD3K+LDXy+jI7QuG65E1jcFD49WUb5QRI2IAEWJA4tAQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts scanTransactions should not scan if all accounts are up to date": [
-    {
-      "version": 2,
-      "id": "e9a71179-8017-47ab-abc0-0e278ebf1599",
-      "name": "accountA",
-      "spendingKey": "8a4a35b05a9b1908e91ecce7d1ca37652c3808ef1b5b461a11d2125a2504377c",
-      "viewKey": "601b345d948b3a3d35aa4b0bdbdbf99184da430d8cde02b8fc38ffb27cba5559ea4d01e28ebd9f7d5e3c7291bc5eed55cec5e7f59d6823cb94d9566924a100d9",
-      "incomingViewKey": "7928b1f2e0dc9034684187d1795bde106c59bdb5bb9106cd62c4ffd1fd767802",
-      "outgoingViewKey": "401ae0c0283dd8ac583d2e579849cf5ee4cb77e26d1eb30c6bb115217e07d562",
-      "publicAddress": "15cf00a2e1a339c9a50395d66fe3b6c4b35dbd45a277365a0972c8d9cc90a426",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "167fc365-43d4-4396-9b02-a3ff9077157d",
-      "name": "accountB",
-      "spendingKey": "74a379c4ef629cca2146e2715ff9b31fc8e6fbec17e767bf6f6a03239adf83e7",
-      "viewKey": "cea219afb4cb11f2723a8070966db27aff712991d98dcc108882597aba5cdcbdfa360e651bb2eebc0b3cc1fdccb5a2e2d6513ff26db790ceca8f426bcb2d33b6",
-      "incomingViewKey": "14ff638b1fafc8e27d3e45514478ce39b3b391cdf1aa0b0c81a8c1dd3584a200",
-      "outgoingViewKey": "683eaa96348b4cab3a8b13a1b40c16006ffcbe93e0d6cf4135c48e603f75227e",
-      "publicAddress": "91fc63e0fb794994bb836b4e165543889a3dab383e6ca99f6b4b9cf424a5432c",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:XKdDBNbGRuV2apm8bvYTwvvTaUfY8i2ugUa9Jrm4jG0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:INZWS34486go9CU/TjmPM7nTqz9jmw0om8e0VMTVErk="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802954853,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAR1ha1BDDHXp8iRPTqf5uEpgUnOdaJHVgIHOpNWTXR7C3clYVERDIK+0r/l7nleqqQXzqw7Q2h+zuBdDvnjsYH5mj09IDoeQ8W+be0FEpfU6i07BOB6saojyWaQDlcvuOY5DCtGxoxnE344DYhIIzFXunU4w5bIkclX+XFeTnTVsPXXypp/tys3UToYcrn9cPmDigdq1lNs3OOHrQrgQvrCYJ+rr5YUw9HlLpfeyxZcmz8iV+eRbpLDWIdQWn4IKVgPT+l/l4dNitIwR2r3wiFUUg2+NWfVh/mVgC2dCi5Q/R4Qs19094Fco4dESjKWOl4PFGeHo1YkG/qB+57TMuLv5iheHdkapYCJR95WvRP1177UK3jfeyV6e5e2bUs0tQcI6m34L3IHwYoQwMCj683TGv/pZwhj98H0xpRx5TXLCvkRD8cutbCRZUlW7X6V+6TZYzOdZLybJahfPgXyfI65c/AdmJbzlZP08qmuTmGmDlac2fie1gJrIFaT+Daxn2QQNwZDc253wW9YrMQRaknPifZ4lYnvVq7EJPiNJqmzNOVaiotVSBvtMhUzEGK1QJf2tJoFcpeZe1OmGjPu5/EVVGVohPQ74Dc3c32TNCDpe/hXeNYo94r0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhkNFoXjvks3u/Xx2TNp4fUAa5T1vUrJaElIbbjYklHFSskDHqyQgLZiR0FwgCDQnXZrXOYyrPilJzunsw29hDA=="
-        }
-      ]
-    }
-  ],
-  "Accounts getBalances returns balances for all unspent notes across assets for an account": [
-    {
-      "version": 2,
-      "id": "4a4d4b58-c223-4f6b-a859-10214fbe439a",
-      "name": "test",
-      "spendingKey": "9ee3f50d3b757c9e9d665feb22b6b24ca8f0e35b9b9ba1a44c97185f8d037beb",
-      "viewKey": "9d9b9dba1c0e2e283f4d9127bc2234474b4d7d8ffaf12ffe6f8bb5ee681764dd23a91b376bf6aeb28f4d1518c58335b41242441aade98d50952d6777fa75664a",
-      "incomingViewKey": "1daba8603ebbbb0816dd11d179344b7c4603e28c2e3e1168493e082f8703be05",
-      "outgoingViewKey": "7f3315e3a0c0647b21472312f3343acde4f047670e94e32a6dc832b5dc863680",
-      "publicAddress": "0a0df1a479325e5d45c539cf86686f5a7fec9344bc9c4afa78b3db8bb7662a66",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:vgC9y6jZ2bCYreQWthzEPihgwVcU7RoEa67MR+wTdmA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:7E1ENbnYsl++0K+0o0fE7dO6mDDXIPwqfVjs7Ch8rgI="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802956156,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAlt7AnOobOeBchL5v6apq6ZrYtDLRYx5/3Rc7D/VQUcGU9lT5jS7bOLs3xqNdIjLrJbiSrPMWlfUMjUobv9iYGOFdcv/l57OqEm6lUmdypk64uLvvyChesp2F6hubrnWzxkt5JFg39ukJfxDtgGc5wwl/8Kol/VTHRnh9vZi/M7cRirbKyBH4EdNWB17/B5/mW/Xxj9SfhyifpRoNlDymaNO4gkB1hIIDcqQn9mrlqBW2rVtRUoyWOxf5S+sfCwtnDyAMv+EKXFF0N69wvBvEgU8pC+lL3Xp9qbReX3tRsXyaWqJiQ6CUlNmlszAPk3uOvGwMgm4YJ8zVAF7mS1rjgACqFwjv7dhHKOei/1z8idHFZmWN1Sbf7gib3Jd/IsdSdnHGrTK8+7fnZbvYvDaE8RzbmGo0YxyAQDf9w5LBjhgdwY0P4zdilt/xqCu37d04lniDroMN0ahPStLsrXjKGzmMj94zppubTkQGpl46sxagkRMOyuakSKmnYkhKsR6UXh42vuJB/9SuFoO6mhpsr7bxkcc9zxOQvKX6UlxP6K/ZAgk0I79lKnytSQQD0Okf1YY2CCZeUc+JgXYoJ883z5AV5bYBBANnT4TI4XCAli6WhfioE5Ob3Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwh9dAx0cqbRL2G+QVQ9H0UpSGN3587m9X0+lB/JQHkPFR84InjSDwI0Uv132l3fwEVyPGGDvc2ieHGgoYJAhcAw=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYYtp9fLPl4Jq2KtBV11//QS5+KHoeZXXGj2dG9nN0EioyVEMl3PGPiQ/zMIAv/IAipj3+m0Bh+TXjeOYvWlNHkwfkvmc84meiC8adBpRA1CZMjhbZNgkVYdrmoQfTh2Zdos+ID5GmBK6uftcsxGkM2PFkgtYkqB+j8FwVNBrFMUQJwY6LDjrTv8vSdYMrm4amVPKkKLrKZ/NGhLJf9a5V4BVDfis4KaWi0YJgeNZ1yuO519VQU7sQwZ22qu2MlxPgWZCzCFkRZVOtlBalqblv2fKKri/ELrK63LlQhqjinJETLY6BHsy8WEsxIPcjjNY4EplUOB/F6jgL19j/TWd37sm4ulf2ItM+HcOTZRfE0Cs65ciASsbRDQAoPgy2cpKeBQvp9Xqx4uBSoX2qOA8rASqXV+H/2DksEkSeKsnA8XWtsj+rBo8mkJuC3cznN7ijp6zpmfcG5H9+5Ex7BIy8Hfahy3QMkrAXIboPaYMRSNxR7gHG41mZj8JaLFGskpO9RDBGOQPWzAVjN3/FKysPn0h0XUpi5ZyESw4QRbHfJX7jgwH3rx3xj+QI64g6ThCvgq0XSRDBOdYqcjoiN/BI3lcNfxoN/ykVjzkYE5AfAM3KfN16tUZMaTeHwxl+hxWZ4LKUhnhhY4a8+8PUCzdkyv3athJl4UaedB/Dkrikpi5BCnudwslqhbwPQvEErVM0s5rCKr+qaJwP8U5AN0hyHKIGUrh6Z3SiAyxwhlmBjFDIcBDSsF/WL7oA0Ur3tm206quLGy6AtJLbcVsLIl6VJqzHaqnlcC7qddGICEwCrCv07cMS/uBb75BW+t35Fy8cOcmbet5oye9cUXJKlNR3jINrTzrILGPFLAUy0oKgYIRVxRp+t3CtT21o7lTzAq3rAWDZ4/7K0a+ASRjI3zhkN+86VIluLXJjTUDiy1vB0p734iZNUCA8pvR6X01u7XxoZ9gM+ZrH7ymedDvd6eYM9zFBgA1+qbxCg3xpHkyXl1FxTnPhmhvWn/sk0S8nEr6eLPbi7dmKmZmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAALOrz43PMeegzptDaecS/RQwpUyzF6YbEv1WCca+Neu+VKMEAkWrkI5V2mqZ6Uaim9VWDX+SxJshyTMuypWvJwNLbPgyPqzdrw5+t+WXaQW3W4BeIzPMtRkpS4OUcb6j2LVzwR5bkD3vJIJzKbhR7NCygBfV7IbGBOXaqD6Wj5gG"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "C99293FB45CCF26A559FFFBD38395189250B8C125E19615E229916FBD68CAD65",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:+xL3u8olIPCWjzENT3qVzmMfuS54qV48H/QuFCAicgI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ePZ534rMJR4w1ymzc1Wa6egnSCxYKLf+pXBDqaGjElo="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802957166,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAX7dqzM6zzqVrm3Ebtb2dKdYAV/TmCCcNQfaCaABFxRGEil9jDlC3NUscoyfS4u4ZJEtS1hfdlyoxVNHp4bVZwG82l27bqWYMhOTQ3Kf35VutCkm/lZhBg4XBOrFLCERpyyeTYDFImQEIi5LbyPR0eBi2VceA8cdV2hIU/k97G3MSmgzBYQjmlhpg9rjNmx/eL4zJMwPMj24Ait9mhvD1bqeUtaZO5VNFofAdSljtVsGBosWE0cfwrlPjMEy+NPFO8fAXz6Y18Th9IFp5mUHItORsLXcgpJxNIiThY9ezLqOmuRlSd7FXbvvUApmuLnoRsBwRnoIPT2gWdZEDTlgAAb3e1ndXtH0NmwvmfqNg97jMTpfwj+S84h6C2HjzYY4y7c/6E/mupjo7U9ssPnfYr7cNnoSrVmMgnQWElk1WqSmmx0HudCaVShSNg0aAxhnAlWu6XXG1EGpFQtfLcPi73RiDi7oTdNyCaMirJxPFLzEy485H+SzwP+A/mvAtQMQHnoX8U8pXSZI8WkgBMaIbbaUXFKhJXQ0gdmlaD+jKgtnjiKtLxm2J1Kx7/+lNgIiwJ5mG+G2VrpTfj280KmqwL9/EMQR+9NVkNzUntAzXIM8b6nF4YI/AgElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwu5zkxpPHj3KicWtOx72B00nx8JxYthuE8tgn9UVfZ29poKIz7+Owlq3HjGuZISfeaSvFO5kzl0zSwGh7Xn8MCA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYYtp9fLPl4Jq2KtBV11//QS5+KHoeZXXGj2dG9nN0EioyVEMl3PGPiQ/zMIAv/IAipj3+m0Bh+TXjeOYvWlNHkwfkvmc84meiC8adBpRA1CZMjhbZNgkVYdrmoQfTh2Zdos+ID5GmBK6uftcsxGkM2PFkgtYkqB+j8FwVNBrFMUQJwY6LDjrTv8vSdYMrm4amVPKkKLrKZ/NGhLJf9a5V4BVDfis4KaWi0YJgeNZ1yuO519VQU7sQwZ22qu2MlxPgWZCzCFkRZVOtlBalqblv2fKKri/ELrK63LlQhqjinJETLY6BHsy8WEsxIPcjjNY4EplUOB/F6jgL19j/TWd37sm4ulf2ItM+HcOTZRfE0Cs65ciASsbRDQAoPgy2cpKeBQvp9Xqx4uBSoX2qOA8rASqXV+H/2DksEkSeKsnA8XWtsj+rBo8mkJuC3cznN7ijp6zpmfcG5H9+5Ex7BIy8Hfahy3QMkrAXIboPaYMRSNxR7gHG41mZj8JaLFGskpO9RDBGOQPWzAVjN3/FKysPn0h0XUpi5ZyESw4QRbHfJX7jgwH3rx3xj+QI64g6ThCvgq0XSRDBOdYqcjoiN/BI3lcNfxoN/ykVjzkYE5AfAM3KfN16tUZMaTeHwxl+hxWZ4LKUhnhhY4a8+8PUCzdkyv3athJl4UaedB/Dkrikpi5BCnudwslqhbwPQvEErVM0s5rCKr+qaJwP8U5AN0hyHKIGUrh6Z3SiAyxwhlmBjFDIcBDSsF/WL7oA0Ur3tm206quLGy6AtJLbcVsLIl6VJqzHaqnlcC7qddGICEwCrCv07cMS/uBb75BW+t35Fy8cOcmbet5oye9cUXJKlNR3jINrTzrILGPFLAUy0oKgYIRVxRp+t3CtT21o7lTzAq3rAWDZ4/7K0a+ASRjI3zhkN+86VIluLXJjTUDiy1vB0p734iZNUCA8pvR6X01u7XxoZ9gM+ZrH7ymedDvd6eYM9zFBgA1+qbxCg3xpHkyXl1FxTnPhmhvWn/sk0S8nEr6eLPbi7dmKmZmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAALOrz43PMeegzptDaecS/RQwpUyzF6YbEv1WCca+Neu+VKMEAkWrkI5V2mqZ6Uaim9VWDX+SxJshyTMuypWvJwNLbPgyPqzdrw5+t+WXaQW3W4BeIzPMtRkpS4OUcb6j2LVzwR5bkD3vJIJzKbhR7NCygBfV7IbGBOXaqD6Wj5gG"
-        }
-      ]
-    }
-  ],
-  "Accounts getBalance returns balances for unspent notes with minimum confirmations on the main chain": [
-    {
-      "version": 2,
-      "id": "aa37aff0-984f-4766-aa8d-601064efa575",
-      "name": "accountA",
-      "spendingKey": "3237d1d57c4cce7ce86cda330ddcfa55d9614a02758e9c3d74dd84136973e4a6",
-      "viewKey": "496e93d149c43c17a5f61a77767c59ea74381e1ee39ba004ead020ab8e0453bb376b777c4eae2e074f79cc738e6a6dbd4d93c1b88283bd0e7e4ff36d84d99354",
-      "incomingViewKey": "22d21b545c42a6a9cab55065a2e954649e0e15385a7c4eb1b47dbfc6e58e0801",
-      "outgoingViewKey": "1b935a93c64b86d61f816fb4a57bc18559fc611ad96fc48ad42cad19fa23812d",
-      "publicAddress": "aab9ad663a1b13fed424cc866065a62865dd36c056b449184c9e8c1b0e1f2438",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "94d6fbd0-b877-4fc5-abe0-1aa9986af55a",
-      "name": "accountB",
-      "spendingKey": "1aa6ad7d9ede460afc9f6b8b2cd0c1d0152b26f74ee8869acf45463446b75c30",
-      "viewKey": "72961cd259689dc3033c89fcecac47f40d4de0d9fc6d1ed395b31e0610abe86f57a8a2ef75fc7805f85e7ce566b4b30e80122a073e12a92a2b05197b0fe340ee",
-      "incomingViewKey": "aac907a4dd0ee3e138247544e3466dc2c276fb1f673f3b3e3c7f0bccbdce9c01",
-      "outgoingViewKey": "913bb4c8a6ec447b98016a9e09e54033d1fb139ca967166fda17c8b0b32da354",
-      "publicAddress": "ae7ae06fe4dcdc399103cfd2c9ed8dacd0b76296d1c6669469d10f7fc56fc326",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:H04OXZPPvcxIkOm4MnkRF5FsoMcLbdAbYso3/pMnGAg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:4PF9DqTtqIFEAbFCyX1KUWYEyxl6NEo+eucMBGZn6IU="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802958891,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAN7We+wdjnTtiN4hdlewTUnGjifAofjcONF0PsXvznLOTGEjfE5+OkYXujawafZMFENICdhqK2BPRb5eqPoe3A/dRXLynspStg1Gd580LlO+OnTmRuYLghhLwdTEIRb2O1Brf5RiMEomspyazWqc/7i9utFIjwa+2i2samy++FwgMK3ge6OPQ8hlPADq4ekzxcvZ17ikHylEmgNXd9n7QRklMQD9vxbcLVw+AZprdJ+eKOhjgNK3MrHiM0HY+o6n0Tz5rh1QWOsl3S0Grm9yehzXjbIGspTG0zlaj40r828U0HYe1ihQQD0KhQ8PiISA95mOxBVZF8NSecp2CnbaUXVE/3nmLmNU8ylKqSa1KTjt8/73yc2nrX2S8gaLbXUNkJl9/1DVtG26GYpPP2XzDFPFwJc3FGupNylKcbcLan7LcYR66kENACry+m1P477VPhNvxD1vgfVZMEHc+Ro8EsrasJSFLEKQzW8owcN5OS7Dko7fp+Jx3uyZyR4Ad+6b+iB4w1tzEU1AmjxCzLUtkynoaqC1/WlKkDmMRaSS58d0hH2U0lJWIwmizGeFSb/SMlXUi9n19VDOxbk5AcyN/zS2yj5TmKIbPLZHPvM2Tm3mOCE9Z9jS4jklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyGSni7D6/M6Ms/luKeESav/W5DuM+YjSHxbUeOYzsNpVIffDXK9HgVPDsY9HZUa299rTd/1MbqQMVA2cWI4PDg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "16D5CA2555D36F4B2CC7292494DF2650BA88BA9CA5662F4251F5EC64ADC41374",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:+rbW7s7+nFCidxXlV9JQmW9wIkiSkK+jWvO3jhdd3DY="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:q67xmEVVmQeo2zTzE936dTQyLvHiqmUiYS3LPZ6NwOc="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802959302,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAL21F83jAhaiBSIks8jrq7r7nuprNoAMGlfpFcVvSvaCldYcLobX1+D8KWAElqBZh5q6GiL0kvUV0CkcmZ2fHyuVrLoLi2Q0f7ZTyqmMyvFOK24Fh9ytpIM4c8yi/n12Kz+doUEPJPdTCzVOfuB+oasfNnGhk3DZ9JmXhqAf6CDYSQHn2B7BFUnDEWLhuxHlUNhHgQZSAh/0Zzam4GZLHHYJ50XPKQPKSaSVzGvQLzNKPdLt0oABOpObniROVhBUyw5XUlOoVrQNs81f8GjtzcCCwBmDqVSyCI0VN9s0adwWxVDMA9n97wmdzxl0thGPVnvc1pAGiTYix31PXl0qD81O+a9oIaIIKodBDNWZHfrxC5tw9K+AJZeXJkjdEuNdGq20SJm+wR3cLMmxEYYb9UJWyF/Dph5CYrB6wzcx5M5frHWjBJf8aeSJ7pZvntd1qRYjrnMd4syvJ4d78VhOFa8oaQZ9t6POBzEWnwhis9t844nNjCGtUYnFbG1dEzqeYEP/5g08djLfxsCWRIOJs6jGT/QdJwMOByzmZaZlyS11GvR5HDr0cnUGHmAwQ3m1phdQqdAnGnALAAOLnIkmjYDF3In4eL/zwgXYLx7/Q9nAXqqzmiyUMM0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQ5Fxr8I96JoEAo5I8jh5jhj/+FW5FBVPVAc4/Jxi57JPJ3lkIOZkcb+0569IaerynJnK2ruE1zYLW2k8FudvAA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "117F1000013E5FD914F25FB0643A512F66DA5BF93E9E65893BE5841865E9A884",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:c1zqLsCOQTW7PajwiB6BYIhOeF/7iEc72s45VM+mURQ="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:i2VxUJMwGKENs65JqHQVH7TAtgZQdZbxiX8JpDAhBg4="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689802959674,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAR5AomctUWVfLQS5ulZbzO1tuyguvtPVvA65XbSi+BzqCO5XmxgJL6NYzrs7zVR7IHQ4HEM2FxoBb4NTzN23y78makLQ5shkpGJUy9uK8asGR4tcKUL7jYv87IphDgApGOEj8nJp5G+DF5mY69Nko05o4HKBQX6Gsbh6rarrjxYgPtF+uRQtPAd+tEFYSYS1aFd5FAg4F9cYxNMuEL/Rvnca5YXX6k7tRdbC9k/5Ff6imgxu9YT3sscj34b430H6bdeNFsrP5zHRXWSRMo4pe0sNJisciAfoJkxpXJ5dSCMM3kRvIVtDmyRYk4R51mFH38Kzy/vDqVz8K3zHUXkT1i+gvkRSDa0g0oBQ5hKFe1X/4hCZgDotOQiffWEOPX10YnRWYxTikDLfAwZP+EzP+CH1gOhxM14qfhIlXMSGY1vGEhyO5eP3NX/5EVg3M+61vzD7UR/S5wH05jCb7G126FlXQRi50B0jor0TQDvtUeC0Jr5DSf1RYRAnQU7TlOLJOVdKuHsIkyplT2ZXv/t8hSkdaFhtagJtm/mT4x1qvK4ChHqTaGtr/a3c9iyinVlkZ4NgEDTc/lPLFWZ/nHu+RZZN3uJE/VXDLPRe9p9wQc9GM3ZbQpnnpjElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMF4dIsVhDV66MPthEBgZpFv+UI+J/Xe4OZAljdDNkBClZzSkSU2gLub7JgkXHjYOEZxSSC5vCJPWGFeNh5hbCg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "DFCBCEE951A0982017E5003FA751B1ED0599C5B49D14E08105F124E7CCD37FFA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:3fpczL7GFEqbnUCK3+pqxnAxvFWPDCPCwVtEz2vhrVc="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:zXpsSdFSTIW6PE9NTrgqueF/Z65esAUYDzizxLZmIM8="
-        },
-        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
-        "randomness": "0",
-        "timestamp": 1689802960059,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAOxi405IIWOozP5PkhJ93ko6dxG30dCmEQ1um0sk4ulCP7ixPg7eBm0HzWhXX0Lgs8OadyJ5+IbP/GksLwbdypde1T17aJv/B/1T87QbwGPKFLYp6qqWjix4O37jvdcL8PTvBUuHaP2MBxV38FW+7Wi6CUvCVdPrddE3SK/qtAHIFMjqzowRiwRErHXWx+cwt/rw5TRMOQrmPWyN2nm+qlRLwDy1q5qXVp/+v2un4hxG061CX4Q8swAnRerVhxjuhPUaVoQ/Mx9re00bEki+YZ933zkBjJ9VVT2tjfhQN+5qo8+OqeWMGtA2gz/wMHDr3p3lB4w1Zn6bUPUvnJCQ8wgrcA+CMgfR5LnfyYRsYu0SA/qk/Nyq1fTvReUOnpW4fqkdxNzDqy1AmnvYAv3njB+pXAa0QOad0IY1ucrwzHhgnO/k7jAcBUiPNY1sFK0C31b+pQljAhJIcER1wroBGV8Koj3UPHwMqwGHt2sm7VX8Z9RNrCNVR9o1CCUTWOEtFOeMVKLA5zk3+O2DkydR7fFz9FlEAfS72KlxFXw0z6vH5Lc6wFu9QG89opOC+KJcUQ2zX/GBXcgVs77Y4/q1A8tVSu6JU1uhH+2r9Z8+GBOaDLVnPEL0VpUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwkma7z8hWdHYT9zKRlOy7NnkR8yzikRgFaSZmHEbYVa8A7EeSNmwbGUYimiY4R10i7ur409D1Iz4Y5836nRLzDA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 6,
-        "previousBlockHash": "DBDB1D2DA8C10E32AC4E720EF49F3F872F0987444C003A0106C9AC3FDB0DC350",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:5y+0VC6+q64LJ+cVnvkZ5vqU6scrnhdwECgnCGHGbWo="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:K76sSWHgwyT3e4MnyEUfSwhcvGhgdlcUKBb/s2MbmHQ="
-        },
-        "target": "873190827380823143577845869093025366895436057143163037218399975928398962",
-        "randomness": "0",
-        "timestamp": 1689802960474,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABj+rnKcSSYMX+mzuRPFarbJohQ+B6xAi4KA3QgLeDxSBJ5aBtsoUGAI4bElU4kDm7MAZHz4PVcVUoMCmmZa34xlul8DWIn2h0YTqtg285curnaxgtaUIUnyLO8JtRCHxY+CvyjHj7ycNRNujP0EJK7EWzjmqcWhKkDI86ow9S04L7rmjvtISA513OCfS7OaWTzKQSfonoXE/4uqOwNkB0/ni5Pzm3ST/uk8ZosRt0vawVQyG8Jt04SzXPnkfkkosOUD5CDaa7SFwAC+kRdjVdpOzEwVPjoolL8Mo4ereSEIM0h/dZM98hL7aoXS9Louk4oiomhrR9kMxRRr7doDuUW66pbVhJ3uNWN0LrAtVON1Tj0PSEnxbzalyR70+2rMB6WAJ2M8N5jnBPx9EY55vKl64d9Qe+JnIvPfDGl9IBJQaOum+pBTrNnj1jjZza5MBDoXdHqfHXjGgXkRg4jx1F4CvkIdTF05alnqmLGXo4gEQgp2pdf6HUERz1ZWqG/vMokPyf2X84BkIRfyCQ2mAq3nIJuXS3qLUhS75Z/VYsRs+NRzQEIWvoSSTsEoelhvlPv65PopuGRG9GJKGMzd00W/BTcitFApRPeX/9pCBbNGHNwz3ND/HTklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwG+4VGak+qXWxXISneQC8FQ5b6GDuov+jl7RxjDWML41GeIJGOxaE6W4NMbS3MGPNBxwK8wphu6yNcz8x904GDA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:RE9NlBK55A+A1Xak0Y4ulP2bDiwdXzhfFLzvbM1KLXM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:L4qBU5hfZ4GIcMLwNTihANHLzezEKFtDjqAf7kivFC4="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802960867,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKN9RSp0K/vP4QxoIsx+p9Y509gXp2nl8f0UEruTsu6KXlesXv2pFyhFAHAwynltJcruwd2YahlH87QvvVWmFt6P1opyLbEhleOor0X807VO5G2eN94f4+8MVjVfRTZTSGgWfETWz15syiEWyE/c4VUf/ltDl/hL3WaSz/D1xoIIHhjxrT0aRATnt/jqngTOCYNdI1LPwsId4BHA6omKXVpPDAhMXgAgbAjDtgq99yDmPc1e6dBQrQhCqhvy4WJW63Q5T1lnwQDnDnfHfNlrT9anHE2FERGra+V/Xn6pWxaKIAmXjGCd7aDzjsEfltea5dzPyJ2+LFBdJPCtBr2+upvj58Apm+PXE3XjREf1aSznxfxn9YA/5P/BX3fJwNhRlFf+iLKsse6UTBDWbJTDDRLXjXhA5VP62XKnHkgwPmmc/4K+jfwaqiAWXvzpK7WFfPF+YigKhY4vYEpjovdBl+0dESDYZ1rxbgGaczuOIehkVYcVkKNs2iXfXK1ymU/1zyAzUTTbV8ecZohc6Q/ATDQoNCyH3lX5omiQwbdBc7PyqDoTO91OeI4ONeP+tLRVH7DKXe5ivFLieNgxzKwJWdfGl85+y46bqC0E6SL1WMG1qkTOj1foINUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAnm3vTT0eawe5Vp3UA5ZLeL6AwyYEnLCpaMaJQnsIBPXKetRwFSuWev3j6MmFwZU3wNbP6hJtRcbFAKpjYNzBw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "68AAB4616520CD79A98642B60D1D9D996704D7849F4E52C34D1FB8699380AA61",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:3gycoGfUOxv1iww0R7WN5YRSOBJrEqQYqjLQTMU3CUk="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:PdHm+x7u0dOEO5zUTy8DAiapmzzvBK7ZMZX2Pw/9Nt0="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802961273,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAACBT9A6FMWOOD0Jo6MH8QD4TDds18L93XIA/HhCiFwaSX+iMmqzdv+R6x0uxmDbNxx/6h/EG8UuwxdF8uExrebxCrDvZmY1eyBfZdd8HusPaBcBnRVOgTm/EB76eJXAflv2c+/jH1VCQTZ7Ufx5hgCqKdTcNxd14ERo5IoGmKzVEQ78ur+fQ21YcHLikjuz8qgxFtoJ+B9y9MuTfghSAKLB6ie+4uFpwwdmOaULp4KnWKcCcd/RDb+VkQM5bJqLx9oKY6uwLBxbMVUwk/84VoHr1i39HrhMwiX08fURXZBUpXKU1EoHhqWhsEA4hbPG5DmuSbI2A/NKwpNu4HLV6AuD7e2DP+fh9ShchZeQH8Py8PV199JeAMsZWTF7MhsflDMHRs1vNrjmEoUfKYLbbrfYiVmNvxyEg+Y4YULXfawFrORyycwzNTM7Ygjovr2IarwvJABP05AqZnRP+u/Xz0WzNPHwh7+K8ThYrN9zLpjaM5Zl8IXFELwOkeGW92Jwn+gtxSwCpv1c7O1FtbhWwd8gKXfY+e/WxCq4F8Fff2Fhjsn2fDqrtO7r+/7vHtLhKNhmjw0UiZ1n+zOZ3OFIbODFjYcYf4TsSEXApOY1VvXZIvjx+T4UaEDUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRJRocbUpUCmhx4cFCdQm4/V5TPXToz511fqb/soKXkUM/853gwlsC5ayl8y5z9D2ByfXsAR8uxPnMVUEOvx1Cw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "CD9D17F33FBFBB8C6BA3F3B6CA55D88CE201F172A9DBB687805D156D8EC98E76",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:m41K9eshGI3OM09c8ilGS7IbB6O4CYp8Itzev5jkgTA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:0HtBpG1Y/aOfo71Fybi5sTB9muHSXfyMWjT+fbWFRrQ="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689802961662,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAATrLfeI2CNY2gqax2PIErB6FrmDHr2xMIXqJgZyhuZouYX1/q0OhCIdZ6Cfav0duflrpzNBuTfWXhGEmH0GGyYJl7tXY9Czwr0qIHZgWoIZu5JFp/9aOsFWiOGXLzbfqVrdbfEdMYpAa+WI2yXzQTKn2UMQvttLDmJGtOmBl1aP0GKXfGUDntqEr0KqUNKTrrTQhbYPNBbKRhMX4Nz5k56evPXIfkjS1zKo8ChTZms+Wj/bjB0vIXN+76EWCoJUVuQduxt/Hdr6MVW3vH6A1MntGL8bWfo72jQ/iefP0xszVfjvzkoJjxSop/zpKWvLh5csqTRdIMIbeb1A15ekUvq/L1WQh8/MT7XAmxqR/1BNo4VtngiphUtBD/GxxyfGoN7Tg12WD/AACg4WHBfG/qkfRLCq7X1W8f+3n/BPDPXHInV/qWtHO/cHhDBcshT9VnSPZsqUlZpsY+IG7HDDT/yRMUNIOW65QZSbeG61F4Tmiw/TQexK4zZrdnFYZM2LHuolPbhKA50k4W03I1p61ZzUPuvqYJtrCsrBLd4X2QizYrj18SSRH7XncsprCWWEjlEk2wIt5EM4PIQv4giA89xiUsyDFgNlFZbdhhwvk9E27hU7DYmowrJ0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDA6e9nxfdn3v4a8/hQ4PLFzVIHXoVXzv43re/XKPmA32djdYNTg2g9SI2XRs3nGw+/a5eSKY5ir18emgFdTICA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "0C829B3824C1C72B8FF385500411D6C04A4473C0396A164A60464B2537DE48A2",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:/+i8Oo2WvFItj0/FuPkc2afsq5IE0Csz+uWvZQbZMm0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:TOpEgABFo5Ie4SxjlTfQ5gRsw/vqBlAz31gAhIhCR8o="
-        },
-        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
-        "randomness": "0",
-        "timestamp": 1689802962055,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAAQOR897wbb19jl74BYZybOlBZF/s+CSa9NfbLoIQvKuwkj2w45pNeUypNzvWrqc42EceUZwXndmS2UduXZWye+eGXyqeUmTi7OrFlbDA/7CD2gu1V/409p/GiHHY9HbPdUwa7Xekqt+4PYdQ/EHIHUDETEUgVNxXxN2LChNYYqwKXD41H7uUixzvn7BNXEA6P57l7pQ4PMjOgGJcBvACqnKzDCa7/pGypxEKpbE4mIaRsUIKvTJLYSrzl+FsPUnvgdtquupnr9vaSJIICSr8+DTkR1Qw8BrZI9Ft8x2g4KLwLu0/bDI70y3zMNXp7uo1Gm6jxtnQQKQ4hENdhYBWTxN8ySi4LHw2YZKEqITdUE+EgF21iHA9G0rgyxFlvF4z3GsNcSeE78xOIUA4tirwh2l8Bx+M/KbszfZR8oMBLDSGjdt/6Fm8k9B7wayXwKhqWeT9N1fslqx2YUPNWDwrWqxLtlG7xCram0in2bXBxTevmOsdy+5quaMuvFk2oVFUziOHIpAi7xH6/vXJtuEe/mfyjSKh3fnblOUrnoVLog86tEQ7YZ+H0uCVXBJk9aLoQgb2O1PzW0B4BYtsoPEJAX3Zvj6WdAvSKPEtZcZ8pqa9QJ5WARV9yElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw7w9E1gwBnHK68vWG4d50Z8KTbrFH22UPu3hZ7LMk4M9KmsGagdIluxQ1d8ASsq8gnRhq4Whd0RbfB2pMlEXXDA=="
-        }
-      ]
-    }
-  ],
-  "Accounts getEarliestHeadHash should return the earliest head hash": [
-    {
-      "version": 2,
-      "id": "00b0bb62-ca97-4e24-a4f5-2a4113b5c24f",
-      "name": "accountA",
-      "spendingKey": "6bc90b292a6777ed01a3f205add860ba37f5728cb99cb24232a3a6e53baca443",
-      "viewKey": "63b3f4755bd54bc226b2e68097a6e918c3153dcafbdcb227c7dc9b4d8c322eb0a3e8a682779b00ad24b894661a86eae5a36b72ccf137022ccfb671e0bd8fa0c1",
-      "incomingViewKey": "bb438ac3363788982ec9e8023df597df5723070c7e41cb8412f8fd88f3862403",
-      "outgoingViewKey": "cc886551efacb0482bbbdaedd25545d10e8f3ab741c427503a95f9f7e7445dd3",
-      "publicAddress": "ef155627d6264aad514fc40d44b0a82122d7ea2547f0fb15934b03846ceb943d",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "7bb4a623-0a12-41ce-a7ca-bd30af6ff419",
-      "name": "accountB",
-      "spendingKey": "91d67ea4a55bc7147c8c2234faeedeffe70415c51f84f20e1d4ac80d017c3e9e",
-      "viewKey": "410faa1e7dbbba183a2e8ab1cbf885ae089ed818ca09bad714a95ac2929e8ade51df18a278992b5c06267bce65374c53de767b3a5fd84f6771d9ed1d9cec2bcd",
-      "incomingViewKey": "b28a1c25709d1a5384aa8e974011681615168199fc4960df4f482687eeb8b106",
-      "outgoingViewKey": "7d879bbf233f665a8f2ee25ce15e01db48fe8704b50e777f1dcc827d2144508e",
-      "publicAddress": "7a13b0de989c5e3d8415fb393a0d42a868181598572784c9165e471ca81056d1",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "e78e9c3a-222e-442d-ab0c-a60b6129ccf1",
-      "name": "accountC",
-      "spendingKey": "e9124afd54f1a632d181476d0c99f53ccb8332057589e372ef7626eb54525ffd",
-      "viewKey": "13285bc742ff67157298006ca24c89e374e5d6b9d1cac1e698e31878b0518e978ad98006c2fb0083c5cf844741fa0851a1fed2804bedbb8818c54228d3264d30",
-      "incomingViewKey": "c042021504e3f9e23061939fb19d59b2c32514c742ced902e1d4220ced07de01",
-      "outgoingViewKey": "f2d17f52d1b9e9902ed04aef1582dcecefbe4690d95fa7306a21e64ed2892f80",
-      "publicAddress": "e6079088e1cc157c706b6f09b72b24df5e099914a369ce41ce696994772e6000",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "20aae7df-7f85-493c-bb43-1273efe1226d",
-      "name": "accountD",
-      "spendingKey": "95124e1badd45443979b3c762aeceba34fa78b7de1cc8c294e245b658c291165",
-      "viewKey": "ad34e9b1e59ac2a7d149e264850614257b9177830fdb62959de66224392198bf89aef6906f835bc631f61881347deffea1591371fe7ca0b69feb54dde8d7af8c",
-      "incomingViewKey": "e347fc4edacaa660d2c7fe28440485ae0b7a318729aabd612db129bcf5ae9106",
-      "outgoingViewKey": "9b0908622c5adb35c78a0ca5df02a61d174144c4d9274effc0ff19ec7427a12d",
-      "publicAddress": "83d10a39fa1004c016305ba269ff2084108f652d24c975f0a2aca9e535098aa8",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:rHpSmzHg1H9c4jDvFR1T3t2nELbCKCgMwr8Qh/J4JD8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:g7nXnT4nbuYWMpwGbrlw6zl4JfNs/dApwKAKyEREIBM="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802962961,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcXi8Ndd/hrfl+05QpztSWB8ptxGMB4ZoNpam/kvR+jKszKPszLRSHXMQDpl49UIQnOFkzv1QLBMtXLi1qJRIYYEdM6Xk/aKuEPmSdgqL/5azwCpT8rTtDyaCc+S6ZlXKDWduaR7aIfLSfqLTBuITqUw0xEAlN20RTKJgCB/zGcgTCRgFxyqIsyOQ3FG/qeXRPPWrTsEF2QAHlfC9bn+HwSndjoPEllnzSQRPMK7W5aGUoliOvWhXJkWw1tSgafmjbRlTR1m4tsaBNI7zGvBc74BqI03yVYnc/Nz+lBFEWDjqc2UOZSivODhgsWogSwXG14sKVqgpwvHfJQp1+gaeYrrVHiqR5sQHZfv0Wkdn/iwB0VThupUgGBnA9AG9Hl4gGJgD0DZVklEBBfIppY5m7QGZoIHL+J6BPvdBn2ecuTgJ4G11O9JTMFnf/zdAdYLJeL+/CVy7ofDcChcNJ/URpxeTzbKw7WtgRuskRQg9Gf1gzEh0Cjs7Iicmgy0ZOPUXcMzRGqM+f/jVXhP155GZgesI50CWlaorKas8X1V5e/69H0LQh4O1NMCCtLtWzKYrJYStRAwC2WXa+H7Y7xgkwNwwki23FSwga6sAq5jW4an7Gh1CGrWmuUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsfjX1s4CQz4u4v+2Z/QUsAqChlJIkfRKuN/jEmK96LdfEPrSq5zOUkHXBGu4hTmfunkAak3WPNhxn1j/q72eAw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "2A40DC0D9D80D9C24FFF3F6689F34DA727275166AEA731F0873BD77AB22BB608",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ZGk8v7EtsuXSSkxL0waTAPMoNVUW1JNq7DHPRDEx30w="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:oswFs9eHSEM+OfFU2Iix+DrB3XwJ/S7xyk/z9lE1K+o="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802963351,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA+EuUpLgQ/sBXDF+paS5RseGj5Ha2gLp9KmznTzLAUJ2ERQbVtL+Od/IZLHAjmRC8mfJ0s7NgHnf7lY00Z1ljWH1xu4Js4diNlLVAUT4tZ56IjzmKxAoxJhxmodYytvzU09FnnxhCnACtjHD+9ygMdnRMEZbCMP48KwSOayehMmsVpC+HjD9NiRz2h1Gj7QRJa6PISJo+zNKMwYQdwwrQ6sRTI0+zpHABrv9i5TCfHXeQN0H7XzyOtnIbmpJa4WPNCkxY0baBOBdVMvNA/p2kXmmYSLM5eLbu3ILkiAh1tzLooJ9Kt10QXKf7OyemHeyFh+5ZM5sd9rUv6oO9Jceqbg9c5Z16P/tr8U9jfqaQtQxi4ob9UhM+rWhQ1WV82Y1rjnVhKkbkDIc8X3+cnomqNyoQ+E/l3J4gRS+0BfvMCqodfNg7fUBvXyg4Z+sGXh7gIMt2vfo1o9mY/Wnl7/x0SXUNjrjveiX3f+zBxxZposHvNJSAsVAE5sj4vC4EV54Hm60+4i8Nb812Hfzkgpvf3fM7JgPSrnBv6w5XtKOexTW8bJKfX6ZlhvPT4cS1HvoO4qi++kXp2+MPZdmrc/7ilRTa857uJRJ6NAO8eEkqf8YclCG4IJx2jklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3KzrTOU1QseNZZ/zMeRPuHJ8b6261J3z3Nrovqzl3BWftR7ERycsUNT6H9i/2eH+/3Tj7CgLunid2iYYowSAAQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts getLatestHeadHash should return the latest head hash": [
-    {
-      "version": 2,
-      "id": "298bc9b0-5aaf-4bb7-99a4-8c925aa9e3eb",
-      "name": "accountA",
-      "spendingKey": "d0b757ae2cf1cbb69f173f819c1bfb2841359a5ad5294c6376d33d2544735eff",
-      "viewKey": "5342ba151b6273180a27467c6239e3c7e5a561d57c420a55ff963bca81e0c6530bc23669f4a9e6d35967508494cdf4b42cf6910afb64a22e2002785b605f285c",
-      "incomingViewKey": "d20825818a56c479e26267b5f6e5d586296293333dc4fed6ead2dcf3870b1b00",
-      "outgoingViewKey": "7ed136aefcdb5143dbb2e9e7b605db3b6caef623b71ada9d81f42605269464f1",
-      "publicAddress": "e5f9b7845b4877393477368e17f5832fdec12c09f06421a3ece3ac8f90155fab",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "d416f2da-8b4b-4c30-8d43-53d8e44b2d41",
-      "name": "accountB",
-      "spendingKey": "7757d75bb21231096eede370b691fd58d96d30f92c8bde4cc21f08b2c30421f6",
-      "viewKey": "b3e48ba516962bda986a2f0a5b75d9ee85957d2c255c42baaeeeffbb6af990c48c8ce1061e4bb481629acb681c4d6dff7bcd0c4d2b7d4fd9604c34f956639188",
-      "incomingViewKey": "7de545390101adf3b1514cfb7e3f3086e2ab8ac13bc1714fd651cdcf42a2a005",
-      "outgoingViewKey": "815a7219df687e5022e683263ec966946e4fbf1aa377418cd6682d163949b3f8",
-      "publicAddress": "4ec6b988279fd5affa41d81f83dc14ad5779e85882d8ee115e0bfd8f3e5dd0b0",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "25caa584-c151-4df6-8f1f-25bd0c796a70",
-      "name": "accountC",
-      "spendingKey": "6669adbeb7bef9e70574184601d304222adf6529abe0dff5292a202a3699c705",
-      "viewKey": "47f886bdf3a614f9e62849b60cd4f758cfbe128f1c389e02665afbc30f036faa835559d27922aa5e7842d02a1a5ddfa0e11e9c85e4c8958289af4c219f137ef2",
-      "incomingViewKey": "668d7dd8804986bfedb525e6e3d4dd0a9c1b08d72ddd477d6b3b593a063edd05",
-      "outgoingViewKey": "e9b16cd85013f95e4e4a04474ea7fdefb97c6b7c7090038999dcf7645f201afe",
-      "publicAddress": "ae4765a88a77ae0c949ae2c2cdd7f03e83879ffacf08fcd09acf448a9f038481",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "0b8966e5-f59b-4040-bc58-826c6499bdfc",
-      "name": "accountD",
-      "spendingKey": "72b0a41b3a0b0f55dacde52f9d174cdf9332874e38173109cf5bed29bbb07fa8",
-      "viewKey": "24d4d54792e1787b801c92e8c229d292d92befb097ce9ab5e2f5486b076810de128109fbafe7d548faea65a0d608bd6906a82a1cdbb7c8e2ac9b71f3feb0c570",
-      "incomingViewKey": "5d66c156b87e5f66767481635b9a0b23ef549ce69443fc07c97bc0063d638103",
-      "outgoingViewKey": "87824f15a6f45022da62fe948e73ad87d64ed4abeba08f09e0d0b7518ad26e74",
-      "publicAddress": "3e54ed101a74d5ea13489d7cafa2bbec7dc5f56af67fa0c9e97d8a32ec8bb284",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:QxyQFJpN/fxFW3QRG7Wl8i9C23yfKYS+l8dIe6KG0Uc="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:zXi7AFEcJtemFkYMgAtE3o/DJ5Ns23lfAJhSAs1op70="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802964199,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAVk5tKlfUXhrGH4m6SKT+xxsUj0BcNHX530GyzvWWKKGiYTeVxYaHr8fLnyo9FeKJpQQwkfFPnpUdUxYMltN2F47ZfvnXW1k21rEP7CGwRtuMsSfsOG4Zf+INGgetQzCwYQFpkaLFg5eFL3M63uWCIaBgJ/fGDoRQ5EB6np2nEYoSfd5wsS78Ux6lAP1kGQa8yFE+Yvdx+V8qjwd44+jkRqfsAE4Ju0sHkZxOF1JflV+4+U53P5lRKUDwTfco7DpzUQRw9MepBc898BLJKTYOeuDzeMKW2/dcKPqDA6mzibo2Hq9jpyzQ57FXh8f4+eBJWpa+38H494/0Cse9xYVhDkJMHt0ajIDHApGkIfLxM17JgWHnNqf1hWxMA29OUAVk89VwC5dPMvvCk7V3UOCke1KqT493Wd7LqBoGAcpsROlL0hP5gWLZnAqQRvf270dEyHcAVUBOWQAu2tvd1Sq3h0Cv8vFao0NtgDaxCWB+8UglR5KqZNLEOVmIXTVh8O7Lc/LwRBaR73JY4UpyUXuvqE8x2brheJBxfYmoBdyEeidSql1R68Qm7cU4cuWe/728UiD6aNvLHMKuX8tSLuK+y66trCZGuT99I6NQFKL6x1PKE/DgEZ9StUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwc1KmRMvDSSoH8wGqsgpJ9EiSk3x2BbW/5uuEeJX1GFT/0IQ54NZvm59bK01LOQN4PSrWZQwPnpbKCw3h0mfHCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "878051AD15083979416AAC44FFA6EF3536AEB6B35FE117FD8AD28C890AC8BD77",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:JO2TYDBtvuRkvB3FKjcfrvDY/mGVJui9Zse57/WW4kg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:O+HmLsx9UQOjZkXj2E3RVAlL0cxoJcGaJAMlZm7kbJs="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802964600,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAdlTNiWRyzyyDnlIKEsuYmp+SPYTegJJXUAyVRQ8GZT6wYEdsgmLa97hoqMGiGNmwZcjc+5mf/aUQo1SMem3KZYGb6S1pBmketA1K2CEUX3iWW5JU6juIH1SIIBtOhcuDn9cXRuQHUdghKIpKy7kxYrtSWyMi3XIhUetyyW3Ey+sY9YrZwW05pV4Kke3JWle++mHKOJPvU3EdeThBjgJhAqhb7GXHuM4EV7fJAMrbC0qLCC+m+VycHBMeiogfan9DiffooajJCIVfpFagdkepL/XxuWedx/99UJgZrO2OU8OdyDkeELwMvvfqqhDow0kwCyvyBuOHrhVNVVzQovc9ne6FFJuQaDpAP2lW24g5jsHmj0hyRKESYf2flVuQ3OYlS5ZahyU79MApRz3jRRXih/lBBfWfzLQLMa77vIPovUGQ+AnqBMMXBfyZRaM4y27xqNpzslr8Qc5pjjp6duTXvXOinYoEa9x/T9Ey40g6t8kyyXkaAcBLmLWXDF4Fn1phRtzw1aEUvYdXUO0w0nCjWxQtHqF+PZ+tU2J3OKXDDnoGN5tXwQYeUyELw1FPR+5tbrJRnZSB62/Aihyn2ofb+AeeNI/BKM7FOYC6QLCqqwnIrEOa4bsWKklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwlcPL8yhgjCmCcUhlv9L1yXV7PDzRU/bWJ2yuX5MtPOJ8pm9rJdLF5C+UHRFuc1ZDmzogJmRGnlQ5L1jdxrz4Bw=="
-        }
-      ]
-    }
-  ],
-  "Accounts importAccount should not import accounts with duplicate name": [
-    {
-      "version": 2,
-      "id": "b6f1d40b-46c8-444b-91aa-82a07627aab3",
-      "name": "accountA",
-      "spendingKey": "19bd6995bc168b67061625f56436056015e237fa39cdc85a6eecc6d5afa9a110",
-      "viewKey": "6c2af5a72b0f48990190c1c649dd9c1dfff657ac2258e8f44defcbc03bc760bf406b228675f9aa829698dceb9ce22c3169ea8b368ae1425ac64a01009b4cf28e",
-      "incomingViewKey": "834803e38aa65f30842c028e3fa8d14900900b0f3f39e67117b71846ac003101",
-      "outgoingViewKey": "ca9aa27d8137943d41c1f58b6fd9e807ff1e6f4e04f0cfee6a12ec4b76dfb57f",
-      "publicAddress": "30dd616b5a9ab6bddee0e25c835fceaa8e7793afad96a02cddb6937a0c6e7c71",
-      "createdAt": null
-    }
-  ],
-  "Accounts importAccount should not import accounts with duplicate keys": [
-    {
-      "version": 2,
-      "id": "e5fb9f66-5853-4c13-88f3-680c02782bc5",
-      "name": "accountA",
-      "spendingKey": "dc5db101f20495d8b5b79bf67f453c515ac564edb6e794e9aaca2b073f7dc9b4",
-      "viewKey": "560fb23bbded4f6daa8bef0841652b56d904c31d1f722947cf6905595164af032f0911eb162afe25effad426a2aab1e0a578d3dcea8d6d4d46a728ab3d3b1053",
-      "incomingViewKey": "7ac6b1b08716a81cc24e2806960c0e1f8dba4beb36fc39b4eb1cec4a7089a404",
-      "outgoingViewKey": "36fabe7700dff635ef672ed97af3659b97100002064e00e609e057e6ca878bf7",
-      "publicAddress": "4250fd9b96415ed4c5b4c35d7aa6811dbc098d22c0a5b940698a03458ce1d02d",
-      "createdAt": null
-    }
-  ],
-  "Accounts importAccount should set createdAt if that block is in the chain": [
-    {
-      "version": 2,
-      "id": "5deb657a-d634-49d9-a07f-e03a1deb46b6",
-      "name": "accountA",
-      "spendingKey": "e2bba4776276dfd2a869b7d746f4fcce8783cdd349f0726887e0adea46c6ca9f",
-      "viewKey": "5ed93d9184a00ade04df804572ab1967945ca95a0f1a5f10cd121bf88db6e8db221207c4f62f6b2ca45a2b744b3ed93383a6578fe2cab2edc86e44d68132c6dc",
-      "incomingViewKey": "ef4b9bc16b01ec526929d6c7f01044a825c0dc282b1aa43b919502666135c206",
-      "outgoingViewKey": "51d4b59b46516fa73432151f73cabcbea2d65d9882a596ec9f81544da9cdac39",
-      "publicAddress": "e56723425dfa5af3765d28c6a0ffd94be423e5b53a8d9bd37216459372b1f0f1",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:GqDpMi1z8pooez70X6bqXCe5gNFog2FEa10dDt8dsA4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:/EtxXsscu1ln/Rf8HenAslNLXUgz68wYQMOP2TxEEkQ="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802968024,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAAE0LGzQ8EgU28Zf8hCwSLyszntvjWyX3JtmTiAMAFAOgXdZcDy0/Uj/sNPBMTsqji1yAuoLneHqqP8YhlAq1sT/KMmS02PZOXvyrXxiD+WuoSJvJAOKjU9ZG5ImVvSkUOySFaTWatwKlripw7pj0meFsI4NDjvBb3Lzn8gF+HIsZzMktC0ttjBzQu9jk9iSDdFw2YuTWQ9FDv9psxIim+5V9LsZehioFcedJMqRYOaWGgf6smUAaBwNf0B1k7aCjlBnNi+9NjAs+ab4/f02OwOH2VR2r1LeWrd2vguoOXkmJ3cm4UGL/EIpemWGIjNaUF2arNXId50j9xJOkq+tKLW5Fy4FEKurFF7u1SaeWh8FQGBqEGq/mDGqxvcQlkqRHWsXRhDSc8mkFGxaYxhxY+/V/Hh4+stXCMaiPeToTIU5ObeDLHIwnCXDpJctDrYr+NB6RqdSKhlQRTruwovTlYAkbrGfgC8FDBFTO0Rm9U2r6JIiMBJPDf4G1aPKbY0o1mFzrIwz1l/+JXwP5jqCT6lLKytXqwt+U28DH666xp1P8qyLEjXoUUjmEXonXhld7gayRDkgPH1jaxpDtLMZHtoEa8rt26xt2thj+RwqpXh/1X0JjciO2fklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRVGXDEFypbdPrZPKWwZX4YKy7r+pbyIJnq3X+LtwCGixHJHv512nVyN+xc18goCjofhgpGXaosJ07YaulPpZAg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "53B03DF2E7CCAEB6A610280068892DCF556A5C2CA0E1C46CA87AF10C9489CF20",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:9cKWwbz12htMUvG2PyEtX2pRfQrXPQWxoPC8vNMr5nI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:uJ5lQ8renCwtHst7HFdMWcTo+tnhPceEKcJ8TJ/Tigk="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802968413,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA38acY5QdYW0pETYFxFrXLXifBJRhVGlAB+TyJ54GDDuBozbRU30e9ARUBEVKY5QIs8LWA/kaYdcHzEMPuiN2mKivQ8WYgr9GvcHSLidvetaEIlauHwxXuNQTDgBXWWNmPRFSpx3voocBVEOs5ug8IyTeb0vYmvYmF3yhbblAan8FcevA/lAZ0UWNum/aHQTg/J00lHQ2F9uq1Q0jnzidIH/ZWPxXVlT2gWhmRW0MmPG5wmt20YWW4JsRiigSp12/54JLmuVyHIvTYrygRtaX+Kdyepcv1qITt7XP0HdcZYqoqxGsq083vsN0yWbbSCEdm19cW7CvCy95Vdw5ruevbIpp/tKJW5kPKKg8ZCcph1UIu5t7ZJSnHkQyZWiIgf0mmpB9CpubHdDmlWq9fOfo/EMCAUafsv7n1vfSilszD+4P1QU+1oqaTl4XyVup3hs8MkXsWgXnkBVK40NFd2yAzRU3h6yv0gPxrwAmeSK8yc5iwldgCAWppU9UCO6YvWYiV1Hi9Dh/cvSHmyJA8v3T/uiKAhIYs45v6F2I23AsqVVbfyPLIF8dUUUDeSlQs02erfg5U32XS5GZ1NMK+6WSVVqr+TExquHIvDHkyl7vr6+McZQgjOtVQ0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwl6L9gWFOsmtKYovW3awCCG0t2LV93JXNsBiMzZKnBci0GBC2JJ7bTg9X21r4EFhr9v3K84hB/Ji4y4gXVvstBQ=="
-        }
-      ]
-    },
-    {
-      "version": 2,
-      "id": "a6dc0bfd-f77f-4141-aacb-96b1d52b73c7",
-      "name": "accountB",
-      "spendingKey": "b44e46677cbbcd98dea0b49f2ff8595402e0e5128a11e72ff3987368d88440ad",
-      "viewKey": "7a7fd8487347406f4073b221d20ccf050f736803ca4698f41f423db37e032924404261243bd64d2554c756562e5761c6515dbca56761e36986e6d5bbcab502ad",
-      "incomingViewKey": "eb237b126caf3ecab1ab08a868c3fb8497501cd941f907a125c9c2e0e8425c04",
-      "outgoingViewKey": "3565a793c0de99b8c10af3a2a1d9b05c852026194cdd0478fc595033dcda548f",
-      "publicAddress": "d377b79621b920f8b403c2c09ec815b858deafef2d66f13acff532b42c507fa2",
+      "spendingKey": "c27fd1886def1b62ecd2afdd4d0a6b976aeb0a3757e6310709504fbbdf7b73aa",
+      "viewKey": "90bd1b532cdb101d21d426eea0c6ea12e3deceae9e86428a9eafb733fbe8b22241de5250b613f1ac3155330bff4905a7a876ba88568301b0a6da2637ed298f5b",
+      "incomingViewKey": "61f2a36c203e14775cc782cbb47afffa6bce5f2b7c121d17ae844bda03e56b01",
+      "outgoingViewKey": "afa3da32d70da771bbf8de9b1c90c7e9387d5f1e459f609951151987432dec3d",
+      "publicAddress": "8b5b72b014388c30ba439e22c9d4469d4060cb2889cbca3749ab53dab9a371e1",
       "createdAt": {
         "hash": {
           "type": "Buffer",
-          "data": "base64:kSe9tQ8zG9bzc1Yit0mvP8vzzAcZP8R84YSemqNZyeQ="
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
         },
-        "sequence": 3
-      }
-    }
-  ],
-  "Accounts importAccount should set createdAt to null if that block is not in the chain": [
-    {
-      "version": 2,
-      "id": "498c36e8-c30e-4b51-82c3-950b13e9125b",
-      "name": "accountA",
-      "spendingKey": "749cac13c2a49af314378231b77d2a2cec1c4ebdcc801c7ce429033c1fc57d24",
-      "viewKey": "4d58dee2a304ab065ed554f72b76e4c654095e0a17cb974481f9185d90f0be6bbbfb7ff470a5ab5fb6dc50b80ce3a1f0c5afe3bd5e618404dabaee654400656b",
-      "incomingViewKey": "0b1bad8d7d9830d1020bb7759f1797c1a87c512ee55c05b086c087d82a1cc400",
-      "outgoingViewKey": "e33e880c00a4b184010be983713df49c233ee9d4e862e0b542e3b4f1a4d4a8be",
-      "publicAddress": "b8d59606d0976cd3530f1a1eb8c97e72102887ab7bf15a8d10e98f5a49b8cc1e",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:8xRLqjCDYMyTWdUxYRuPG+3zo6VmY8h0IVCKlFPxMkI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:5tRdnn6BxAJTW7oVIBTrgDDWX6iLo3zZ+l02/LqjDn4="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802970155,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAx8BeTc7/P4B0b2BfETGFeOjybHIof1oo81UKCnftLsmI9TGzDriX99U2P2DTsUk/AFtDvDsHu+VFPgwUhj52Nl8vAJ82MNXTGBABJFKCTlaxiLDIVoc6CiT8QffzsV4LxQK3ZiDnVQRHeZttvQKS2icSr5ljulasGZOysMUH76oThBdb9ZUHD21TytidQUPNmVC5XB5pkDFhv4C/BVubWUVoUBuTsI+48wILBmu7VHSRXa4vFOYzsxxge36yWlyynfTG//rh+UFWFCvzJIq11tLfcpMSCvgRRvGdw3KjK8G4R/35713ddukHSjDyRWW9iay0/kzSdTqZjVzfREvBLBr0yNrG/ODDBZ9FfBLLL8Bkq8EiwQVy+mfrsACvHroX/hZxdI61mvvCkgpoM0qA0kOPF6VnOzIwroWgZw7GEOMqHtibyvP61oEWTmvaX64ArIbq1E13yI+gBnDXbRrFVEhakgLKSYdJV0BY34x/gJOlplnLMTwISwhxZAa8dgdsSMNHehb38dB24/exlEN4QpjI1n9qZzZiEXkJDrESxKrgkiGZy4P7neF43bKhaoks05Akkgpw6KX/HR3ZQiEu6v7A7UEMxpUA4yg1MVOX8RiV229FWYyTl0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwv7b66Yrqzmb7XaVkGtp0DWrpB22stmHSv81IpCsBKBqGaFZLxCABjkZP50QlZzO3p3LLAm8TduqS/oqVTvJ6AQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "082961ADD256A7730A9722457290E1ACAA476B1E4DEBA0CAC2FF06E010B96CD0",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:1wEq+4zR9HEtu2tikAQzEvNrn20eZMIJqUWVWbK5C3E="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:c+UWxR6YeZEuGhszdbGn61KEYoOcUj4E9nv8D+lHTX4="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802970542,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAXWtd5F3NAMGtSEohyczYwrg2CYpPfeFwISW1IupIjMWj0/DMtypPzVYrENHnEAJiu4Wqo/M53ptJdgwdIormUGv/kZmWKUo3UxLtSgdJtPGxF/KVTTqdoeZuDpIV6V+BIwY8yvdWcCFPcx+a0zFyzPBdPEAQs3zwFMQw2bKB6pwUd7iBaBjCgXL0/ca+33fKU8KZVNgvluygt0Dra3cBDXGSAATcN84R9DWXX3QhjXm3WPScCnKVzmRVsuXK8P+u/D6Y+SpHU8shdLIg5V8PanfUhlr4AGfkGs1D3aQRaUwOU2HV+AmUGzvg44k6dDWO+iojT1P/yGelmy+1qs7L2nFEP10GXND+U/P3KW+5JzelK5bj80pdWBoVMqbBzgo884B19zA93x9KHuR6hxfPaQyK4o5LvIgGTWv4nDvF7KfRSJERaE2XuRzPKViXXu9jsFwudR9h6cQ8pvNRsN5Gw4GQHLy+Nw67rl2POEliDA0Ec0+/0t4fOhMz4aCMdmicb5PF3Pd9gw7yPf9+6RM+PvgcjhUbuvmi3Iff26EfumPI+Op5Xv2I42TZaU8keyiAjFJA46Ir6PCP+uLqFsu77EYBoDBpAGNYjdKgDRgNcK1N3cN+6QC260lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdoWwC1XicWglqJmEPmvs/LYzOVCrP5rFKs+BjXtoo8uTCc7sZlke0X5oWCdTduu50gq3r3KAnfo1/F9a0N79Cw=="
-        }
-      ]
-    },
-    {
-      "version": 2,
-      "id": "3a7ef98e-0fb8-47ee-bc37-f0f1deee3e74",
-      "name": "accountB",
-      "spendingKey": "050bb1a5dc4334c9ba14c92db149ad7e5317ba8ccb8cd8bd3d530ba00189eb21",
-      "viewKey": "1690e685eabff38ff60612185e73e06d2fc4f1bd49c8ef1cc93dab98dea39901f4c541ba428db153aeb9478af798649143228bb8f5a3c5264f1160d6d35cd1ac",
-      "incomingViewKey": "bca4323b89c47d7587c37df08366d77a3e68bd001fa006a2eba2501d9db29601",
-      "outgoingViewKey": "06467bd365580a35d131f883c0e55df466d1e3251e4864f381c9b8d0f2a44508",
-      "publicAddress": "d9ff2403ec388944ca2dc2bc4987a33ed4a410d39e1a751bb81f8fc11550bb88",
-      "createdAt": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:ZUVDaLFqjh1g9WAlzGewzEp/YlSI1DFrwVqyWHegEYw="
-        },
-        "sequence": 3
-      }
-    }
-  ],
-  "Accounts expireTransactions should not expire transactions with expiration sequence ahead of the chain": [
-    {
-      "version": 2,
-      "id": "9335e2f4-7b79-4b7d-bb59-dc2f29f53f41",
-      "name": "accountA",
-      "spendingKey": "cbb0db317f1051892c3f6094e4c94ff500df3693e057db952bdbe7628a6b638f",
-      "viewKey": "75822695d2217606c44a4d7c089a9ae56dd5b32b31c3237b1abe4fd4687d136709f3a8731b38f74d4f2fc351e818e7791c0862809f19e83b40f3c4b1255ae9e2",
-      "incomingViewKey": "5e4449a2b7eea7c0b301bb6a478d0d625a1d92d7d9ef5cedc391ef0947a80502",
-      "outgoingViewKey": "43933194f166f3c88afcdda7ec2d6adc81624173388b80982b7b5ebc9f499b4c",
-      "publicAddress": "e82b34367a1f40b051bf15459ea499485a8694c681d45ec6eb85ad7c76da09e6",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "68af42c9-8d2d-43a1-ad66-a92c4bf3957e",
-      "name": "accountB",
-      "spendingKey": "d46fc0bc000d53c5b723a1b35c2710b6f645f700e90939e5345f20de7e4116d1",
-      "viewKey": "fd7cbc6df6a6e20f7cf6b682c70d799179a4332ed42b52c45811f6b04c4d52e62b8b001f587e66318e06c916789b39924b06148cc5c5e7d698073d6b30cd6a2f",
-      "incomingViewKey": "b00cef775517d6dedab6332b69af133946a2e79f2dc25f8c6665b6af07e98005",
-      "outgoingViewKey": "f90f69e564ba6f3fda7f26ca1924e7098489cd9529c927bec195e89646118002",
-      "publicAddress": "573d98194504e7bc535423081eaa6c10289ee993c6253bc163b91cc93e438332",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:XkR+85M18rHFXyUeo1tmvFE1ysWAAiEIKbwRf6hn0BQ="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:HauqZULJLBHTRTM27O4Vd7BlLggKJF4ni+iy7Tc+WV4="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802971335,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA7sefZyK74vBA3rpJbwdrAEIHPDePXMnX3kX2hXfZoVykX2KzmfJlIn5dD376ABFj7ikAAHFdhHcCmxpfoHk4WbJskVgMDLnqSG9ZEgJDdiyo5Qp0DdTBNBcUzCZvydhdE6Ox5GskgHL4HH1Ku3fxjdw5Jkn/IMFB7zmTyY0O4pYQCHBceP1mfBVPbdMbRY+XvzotoA5Pt9tgnQbe2DGf+My2mip1BeDmShOeattWrfarAKs6SaNGp199DUiZJnumawKGyAFcSmTftqwcBK2eu2BSDAd8EqJ5mQGhgC5EIBjR58V59/jGG63gugzHbg21qY9zEvT7+/iJNImketOgGlOfFb84bJoPauk2+PmmQlzQCPWrdzLFVthqZr2sX/sNay1Oj7R250Cqa+2tw2BqRSYryUAxABkjj/j3aU8g9pKX2MAZsBeNcbgpL/936MJiWoePIaTMOOayRxy6cOVTJP+wZOuEzbQSvTTz7fnPyVFA8PtYQmeQ3nQSpIxTOnyPex3tibO2rh21HHJ2Nmk664OAfTMN2VjDsXN0F6GGxxvP4D8pDdeBY6ejBbzK6U5p6qFakm7FLS41SnE578l17vI/gVboz3aOCls/SN0R35dDvCqi+YRp6Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwI9EIXuESbvCsbJeNR+lulJiclbBR2yHKK8Jnb7EdOziRVGrCPAKR3Avl1P9/zM6RkLtdcELRYdwivvYXM8QTDQ=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAMZ33anGsBeHO8pkzWuaYx/GBhbZNPv/G3ODCTLmnNhaTzxJnGOLWIZTG+dVDdK79TU+9HQ9x4UiHD3ys725gC2iQwQCIciFwhj8zrgdXUPmzYUVrI/zsJ+th8Tq4EjizTtGiDIM//PDbuVLujYmpzZI4q9TyK/aqXlt+Jm/D0TQFKr+WPwlkBfGUhiBSwYqrIKfr9KNb4MmVsrOnleeFXqPHHrQx/zucnK4EUwDqdQa1JaVT70DiZvtV6FPHDP7snmLXQ0ZRI90oubYFu9U+TQNPpC+26ajavjEABMtMBAqMuihcgsQOa6icUrLrb7TrrVo9f8Dk2MntXx1vi6ZVW15EfvOTNfKxxV8lHqNbZrxRNcrFgAIhCCm8EX+oZ9AUBAAAAOO/jrq44LLX6UK9vV3m3yw6ACtu6DcxzWeR2z8MD55FHNHsqPRf7jTntcfpGgCh8IozhFhOoyfSIHgScjAnYCDwI27I6ttzwAZHDGYCrKPo8Or/ZULO526jdVMMolYPBqZ3dHEU8QL8lxl0+r6lUPVFhbMG09buE06YZ55pJ7+KhIMUAZbYFZ26vDtDDw6gjaYBCjai7YSwGio7jYmaFZoucP1wMTzzFN1HzTkJI3Qpd3TZdJVNKa6CiUEKt/aPZA77NAWeyI4P8p6EZw6qSbDx0BGKvTZt03LcAUlVPXdJm93rRdx+yfti8+Un38FBpIjkaDXV7SHcIrm0UT4F7S4HuxQRgRNfpM957OWKwn/1h+Lq5exrdvgISv5xNskprhpO4/lD90WJKdGlG+0Onmp4YI/UqiOlItpSb9jZbwzN7/SwNmcrXfb/SAf6GEgdbBYF45iwgcPDRG1UJTRDhzDwe70ZdF3Anr3RaV7cLZU71dvGXa/u2yC7rzFQJhXtTU7t0GcdUTaKTtxEC5irAIJCozxmM7VWjnkEFOOySv7ZRnlG9vI1u2wFJxYclOvrWs+88il2Z4gjmeM28blGwtIaye3fNHg9M1HxTz9r1q8kUqzksH0EbQUSrgclH89j6a5Y1qmN8uWMA3hpt0LpjeV0ykDINwjXbMzhaNUiQieNp1Ngx9DnaEqwjrQVMbeAG8Mc1+otLHDGw7zHhc7QQJycUGnNUrio+9k/qiseLj4MZviois2h4F91s3ObKqkNX/tlpkyNNTjV6JO80FHmAYGgUMNj9u7qY9C5EHdUhujxB5XY9RACMBmvAD5JAW9aO3MOipjkic7t//0YBXDEtvtMPD1en1/a3PNWrIdkR2kwRMB4IqEmbomvYLayvfVHMILRhItgSl08RCt6/MUPKTVNFnyVjkgeU6RdfBaA8NCskq/5LbVDO4MOre2oXKyACvOdMEJqfGdqycp3z+/pzb9obxY//esfJ2M5LIEzQit5j/TVRU0w9yu469thIw7qQMN2w+133t7xoMK6L7S3R5VJr9gcNHIfk41u9TaAxPYhq15CPcXO2byTI7CnlbUHdQPXkTtqgzpMGvvpqJTA2ULDxFrgIN/77xMf0g2sypu0bHyyIAraO0fO97qXfMCgc/2uYk5Uqc0Yxfnr8oF6lDHDpCx9IqtyC1mVvFEBYXcX8PcHTLGTzbnsByJuPNj6EiUoVP0ZBsb1kaEKffq9pe6ipbxrQ6GoZingtvP3sJ0MEWehKw6ylMkB33ERDzInZe/0KndwwdJr21GP0zA9nAjOwohLbWSpht4dytyO40JzSXv+r4Ggc7LAhWZL0qMQWS9QrqsIU88YIN//A1H5hDuM0IgWcEsVdGi0A/q4CSAOJuyrHu2VhXg/aKVGrp0MkNZC1ZNyw8SI3Vyiex1A44lRdUaL9ncZZmxNp5ceQkeZrZq3xgY3wr9DOn34+Y7AeuBPahS8eIkB3yeynH1bv95iBOnAtlSxY3kTUYjR/0CUgrtsWs0XUzhyRI77jLywVcyJKgjdJw7J9IEUMg+FVT8JgIq0PJpRqKovwWVVRgCk1BjUSgo9e3bN+o4xLW5TCw=="
-    }
-  ],
-  "Accounts expireTransactions should not expire transactions with expiration sequence of 0": [
-    {
-      "version": 2,
-      "id": "7f1f5a22-b1c1-4d49-9748-80fbe9543881",
-      "name": "accountA",
-      "spendingKey": "acc2a53dd1acacc8e3b8e8f7c94e897b279d3becb3e13ea521db302fac7fb893",
-      "viewKey": "844417fe0341b84e7904d5636cf2f552293a6fae1d9ee52680e7f538d562d6b8835bee70bb20ecc13443214eaaaec3720f22a4f02aeb836cf9329b041451f9e9",
-      "incomingViewKey": "de166a320e52c9a8b6b42b4dcb16a7eb38a16d0608ab0b51b6a4dc2137fa7101",
-      "outgoingViewKey": "549a59f3ebee3bc2edb73bd0fab3ce11d4a230b134888fb8c77c923d4a9f612b",
-      "publicAddress": "d0da61ecd137d548a50f4807d4a455112231277f58736f31dc09bc88001a672f",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "c90cbb6c-c865-45b6-8c77-100eb69cc281",
-      "name": "accountB",
-      "spendingKey": "b767c15b23eaf5ca00c44f5b70b811fc641d9c6267263ec43f8ef0d44bc5827f",
-      "viewKey": "26fd3a605f24a59d5d96c8eee8fab9a3b434d03fd92b0799c2b4973f718376a83cbb4742cdbe020a3ed2de0766dfc543d4205df0cab451c46f630a302c600a6c",
-      "incomingViewKey": "374d3ffae97eff9bf4698a309ca85dca55662227cfc639e98c497136a5e68501",
-      "outgoingViewKey": "d5a24fee6b1db7760f9db647f1bd4a7596d2de3ee4e1d4cc24bd9a31f95e1fb8",
-      "publicAddress": "cd44c965b5e8e66523126745934c3bf4c3c79c7e778572a6549ab79277dc25c3",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:n/S1HxqUEBgvyHAAVrKHYxt3pHl87kEPOMhR93a8e2s="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:bOnkHw3SGFBgEQTaSLfXfESnpbp8AyNPBASkIljWNxs="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802973789,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAAXrEL95SplD0JJPOwMHJXrCWDtyYRA4u7XsEiVYdNtCV+3HvhgjvPRKDrLInvn+FfoJn+fal4Uh3MyUGWM6UpbGznyBdsna5FGeQiJ/4APCLcmzitPwqt9xTSwiwRbYR51jq9+40YcvBe7itiodY3moEt5tVbm5BwaseVTUCXpMRnnoqBI+8R4KVrB0uR4L5HPWsMNhNnrX1iac+U0RKxQRV9q2FD0ORhmnnU49LRK+tY6A5bocBzq16t42Z6HANZ62Ubq8vynGwxjJdUrO+eG8u76KpI1/Ai4+qsnD9NjZ7l6oCdzGYq04tdGaZHhzuOTOZDSyXv1BmDGI1cQE9zer1zzFpNbTgYy5+U3CeySLw2QJMiXz/SgEg3JaCmEQ+KqujxJJo4FejdN0sQ55zX/XM0JVG+JTboLUkKh+sTErYcBg3mxdCiT1xpHod6dSo3qgRb+EGm6G7ks0B1Z8qVGMMq3OGeHkDNPmcqqOot6Y9vRpJY0i3kwBXKyjyykjmN6tDlSb9k72fw61f8TdfNDlXx83pkPYezTGj4fscKXEcv5+hdxtdc93sjDl62OB5CP4jE0ysjeutLYrxo9+sJzDlkC0BIZsLpqNJsH4NnZjKIHszeL0IlElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwliA1h8IWJcm6FiY/yIiAVe1TqOsbMnTjvugcrJcE6B0/Peu405V15ax6JIGs3OfxzaD4rkqabqNJ/+7JML4uDQ=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAmzGCOJN1hunD0NkJc5PHGp8aFJVbSSztysXcHkVoRre3zM6bmLK7S/B0ZViBHqkH7BeoicUo1DQduhxxPKYncOcMhO8/kv0Ju024bjj9A+64xPJvFdrut9xVlzctWy+v1yuiM+lqSKfvWCRIc+WnBdxw9zbPGQ2ZKluAOX5VwYkWmSrskJxOz0PlaA+eGmOGa4Ha7kUMWdcmW8LXvTdFI929J0rXS82ne+w/0QAB4aOVNUKA3S2Nn/2ozZVwKQb7v6LvWYaEBSV5H/1m/HtiIB+eXQUPRM53Inj/Jf7o7QwKMFZsJKDRiazveQXvxnYq+e26Tlk9483oXWadnGMlh5/0tR8alBAYL8hwAFayh2Mbd6R5fO5BDzjIUfd2vHtrBAAAAEwpEbKAS+3FhkfVnrLfqmeJ/gCfVbeDv7IcBHHsX2gkhJpH+DSzoa6OJ9zqFqEgjCDtjE7s+jCZz2o0IrTMoq4pe8B4/u1NnAZmGVyTBAjl1DZDTgUyN6c8rm3zB3R6CJIfObf//2ogdCJ94XqXm6Ea++BxGZ8hQ6wYagRrXC45Bqv+ihvy1maD9doc5lCqpqN5ddgMU3sHccijnFOQa5zDTlvHf1bSejvafpcXX1wrO7anYfWwfDd5vS4rOBQ/8Bm+Fef/FOlPR/tbl+x6gUh4H9WMZYwb5wb548SiQvtNKFJcQrLfns8mtNfBLdNNzqOqKNWdAXjyQzv3hjCVKoGtBi9z9zpFtE6Q2ujmSZxNKcrfFMUfaWMZ5mVU6QubiXmCOF/WxSFcLNKPhMmajHtHeN8IEZ8e6gG62q4lnrZlDSrest/SX10rMXS5OoPAj8jrlX+KNljefeeapYgmIVUmYsnZuwULadsdczEbvVfebEBDz0fmWp3hMOXG8T/dMVjOc8pBA0sk4F+4qsMy7rp4WH1ghdip6jcrbbmu7TsLqldKCfhsy0hnSj2QBT4pvbfzMDQSJ2uo4uTfd+YBe1YDE2E8ZjV7hUUtxJ5zpKUUoTwjt4YW8gc7+mjmz0MQoPcKUKxpXNyYr+Wd+XYgGOaRkzV0obmpsyD4vdvpYEF2bZK7Ho0+YJCpN/XfGhIBsfxeqnf28MJFzglHyMxg8uV8B6GUV1a0rq76u+aJVPbP3ib0j9QXSEayc0CcjTzYb2H/ZZXf9qScrw2U044yEQmCfLf/uCgzsDBBB4TGzIVnRUEro81mP3y3/cO+pkdCM/WQWksR6MItxlfV3qP0KU9wZu94QH539NRdfGfq06nk3otRQAmaGt6uAAnnt/C8GAA0pVoBGJdsBrYgh4yXedx13joVltkmoOxmWtaX3DxE7tJE7890BVEWKLJ2EU30cIjAmU+q1Qz8NmB5pWKjS7e9Q39R6MZ6npAU2B9uLFDsMDHc2DW1p4+X4Hjnt9/Dzit/fYB1bXz2Tc74hDp372I+XmSTcuq5jBhreCdqv6H6/gjaaQOuy1kfjyrw6tqKZVmt8vu934gUY1mNDfzq6z8Ed7oHGKgzyaroaJXzb9Xo5XUy3MY0pUsqLwOVYmFNgNUEd1GN+cZt98u+NxjpzLt7X8InrrfDOIGG+GhGvw+EGW/QooaF0Ndywrz08KUdV70+UpP6pxtKdJD4yO/ZlYHwkQj5o4oB6flJ6JyEUTEgXSkFKjq/MTSmBZRE2h/IVPj0bG1Tv8nMSaM6PEQKPBJzw4qoCFCB1WDAA2EC2L4N8Qan6whiiUy08qjC7W4EF47/KeuPtQEzcoAvrc3/ymAKanRH57jWh9yoBo7M8uxRwDF0AxGG8x+uNTrw1Jc0uaQ6cLbGR+AoQnQ7bD62VgPIlCyNFivB57y5E7wLuP/VXcRnX6cPQnRrDIwRBcvr/4LewCHZkRKccDWbpaqFGLwnRAmBTflmtBZWOwldvTO36ypuAjSdLnmg+BG69fxXQ4FdZ2iJkl8nFzUedWAUBHGn1oivSTrwDxIqjdFhoqoYt8VQGieAoZxYJhsMDEGSCw=="
-    }
-  ],
-  "Accounts expireTransactions should expire transactions for all affected accounts": [
-    {
-      "version": 2,
-      "id": "82641bcb-42fc-4063-b00d-595d75c6a39b",
-      "name": "accountA",
-      "spendingKey": "7bcd33a93398b7352a436c2bdfcbd5a76348b86b6fe480e98fc1b3018fd50a12",
-      "viewKey": "190ed20d9959152df3a8cfe122a408085ef86ae92b98d9845aaf6b0c306b6ca70650116ff962e1be5f12abc558761941eeeb2622283c4e7d476fbfff1dc78d46",
-      "incomingViewKey": "28ce320b3a913bc5023b40aa808ff3e9ed0c0eac5cddae8eb17d43424de52005",
-      "outgoingViewKey": "ed1aa43e52f1585fe46358ef5db7c9e04ea02cbb9a13ba4ff20b552556e4a587",
-      "publicAddress": "2500f8c49da4fe97fa7cdb1c360d33ca9ae8838fc8668a3281176375b2a5f25a",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "2c67dadd-3817-4cff-8bbe-00ffc1becb84",
-      "name": "accountB",
-      "spendingKey": "7acf0f0b7f29e51319aefbaf34a562cc05a0b1bc036dcdf4d70bcd1a4f8940da",
-      "viewKey": "774b100341fdf054823b2af807be5e429dfbf399d1c81d82e1f1c55d036f832d29f9626e562a371fdf6e424ab47299da49afb5f2d92d3f4cf2915a90727bc273",
-      "incomingViewKey": "3047541ea088cf0e82d5446036215a5441d5aa0a3d7cff4c47beae00e3de1a07",
-      "outgoingViewKey": "1eb58f3672745c766b200bf31346dedae6149d072c233194c54cf5fc81821267",
-      "publicAddress": "a2d3cdf584d6c2933cb022b2543f53ec45fb3e637cb113cdaa4a0ebcc474bbaa",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:S45Z/eBM3/xRkUYkf9U83XdOCGcgy9AasE7YRk+rZjM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:349WwszxUelETr+QQoPFuv8rLFudwQTgiRT40Cgyx5o="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802976184,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAflCS5SwI3I5WHboQPyL9WjkhLmJSOQ5w6KAKTfeHJmqN49j/VKoYzLiZ+l4f4PBwx95qCjEi9uCxkYDQDXZzdxz1iDtftYCr++T+O4sr6JqXHP+Nj5fdfBnzPMx5i+Yr4Gq0pyIZIikpl4NSA32jtM0nVzFLKZtqagFNMrJOnPgIRsZjICmKhFc/rB4Ex/TN5DjdgdY24Ma4dRvIGEE6xMyQ4bSLyw8DvGLo7HQm6HuLZbppOlOtCVbVP6yhp1ScVBs8kwXYTH3Y+z6KmC7adec1SGlU6i6wexMc/wdF65ctKKdH4Pb+JQpvj4cxOIUzC3r1+60mn2qy+RdqXb3y6l1AcomAf4serPUJ2BMSPyaZIXJrtoW8QQiT4On1l4sCgb85BPx/JmI4m8Hn+Y7xPx0f4vVf9sBT0PqBYrPTBRb3XS9HAtS+NKJR5kZSKnAcRj9ywuUi5RvZpGPxDgk17k03yaGAoQ71+0U8zlCXRuzN3m5kjhxGvLp85MH/xDwrHrgjCxAu7sQH49zU933nMsIgxRVf8dNsMdqZX/927W5eHsbjhXToj3JeR3PIhVfpfZRf+mr5g7CtG3tW0Hcp1Unx+gRoxUO3a0/rNRX/K2hUz23SeebhDElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwPDV3c7Pvns5QzPNrqQAwWoisNCof5vrgg6C1Zr9L2LpHrhWT8R/4J3yaYS1Rghf/Voyh88EUEqvuPfc4twF3Cw=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAARvjzaYYwjSrala7xJ18y6pum34W50LaE04tOTSLvgQiB3wnjD7RMOad98oWc9B+IQrSav9PXr/dMZigDBh0wY14TuZgKo+lX63bNBv2GEaSomhiFaCJwoYAAevGJqeFyLw7cmRbzvFYrfS5t17KgUGnR2Say+rWYp1zg46vUVZ8GQN82cq4IIZ1yUbPBTjD4yunOWQ8W2g7K/M50uvUdze7qMCo3Ag5SItOiIEEH5xSEvcMbuJSB5Io77/A8nMUHjvsal/2UZKa2WzT/ivxFAWfXTRvpFJF991QfliHy6HAyvHcOMh6jYSre9p1x24HjnmaaIfcJC7BfupnnZcTQ60uOWf3gTN/8UZFGJH/VPN13TghnIMvQGrBO2EZPq2YzBAAAACgHqLTAvomE04YSYcaZ6j+EK0khRk6vdNlrEt2dpD28/sjlb6sC1WSxOY7UH/ue2YfxrD1gtckEPZNB7CGvPZlvAiZ18bgWR2fmeorybyUHAr/blvc78ost3Mpb+2NqA4uLYJCz+XWFd9JsbeZSegGEZaMZxP+rVS24c57wF/8negZEyZ03GZotCaI1Nz+WhYzxypuazHXHL/tVYmdHiHKSeFRfIIFuGILJO8jUE97vhk+1WStJ+OiG/QWVNGbycQgtOt0HRobOSFCQo5+Moln7zj3Pgz/IJ8vTyXpltavpS9/52yVDZY7iY8/EgbbaLpFztwRR3dJgSJw9gq4r8u6oWlVPqdIFzwJd2Ieq3mOSSMB/PcitIPmgH5GRN1hHvpt5xNKyXtS5IN+WgaVT3PogfGeaeKyMpmopu1Ym6Axb+Khp3eSlhOvZ2SSAVXNO6g+D8ktQS5sv8rtTDcknPVHVCXfLLH5Bs3u0KWb0kfo26xYe5dGwDh7ya0lOGss8l663kSoLxUUAMbPle1Ki4lwPwV8xYokjMrjHWHypJnIlOHEBw/+Iqt+4Mcbx4D3PG9t55MYTCS/2MxdGGY6iHwcGQ4vTZMadCY5Bey67TAguIxNpMcfTNwmRpUOi+2q4Q2EzXd7DKSR8Zq+Ycw5VbDp8T7AhH099gZLKGqSa2N0IYWKxglkaf/jI7qAyxoT1L6GCsPiBrKWbP5y0gbAU7kUcGRIYqCYGRguSQwUkI7cofmzYTweH33r0ZLCJnKzcBBTwTWWhj+qJ3UjtBXIgtS1hZRygGpgdsQfl874bURgbe3cVZY7jzhGOOQBnv/GTI1xK56Pl9OYQrK3kSdDgcmzoQMwx2WQdU5AyQtnx/r6PXJXHmYbz42u15udHLYCYQvPtqYIqZeNItxGcmbg/cQJV5bE/6aVpMnYMZbxV0DA56ynKWadNFUMPJHONKg0sJPckDpg1VJDL+T01mwseHkjHRkDbQ6xCMW9J6j5RD01yZ84B7X5tlCO12lAlePrTCJAR1UUOGzOwmiTuqfhLavILstwSxTVaswQ9p96s9bVoUR5O1d5ah85lYr/QYW8zuLxhCas1kjVWXGN9cmR+hQ+h6qVsII59a3xoNh5K7020+B6BfRsGeycHb6Uugu3LU36KqZtAQcQJUkRmdQlzIisqgK/qKdy7bp1cCQ31DAgtMPcsX085o1YqgTfGjV2r2pBv87O1UBOsTnqGLs2t1Oi/f2vq3RTs+rVsXu9z4tQ1sp2YyrfmRYQaWTxJJSb8pBqQHW0gRQfDsXIHkuhbIP4Hqs5cSN8VznGhIgM+8iglvoIj0xoRx5KK0KkPFyByEMoipGIzWxdktZhN2HVDrbE4vRjXGr60iZrPxs8OyJI6b9TFfEGecHnIGEb4hTfbg/InavvUpXE3MD8ExmockU03GqaUccADzec6lWbSKDumXWqrRIsQpIUNAXoSpSjRl/r3pv+qiZloTa5me7N7IZtgcL2CGwfnXmK9NN1uVmceJzoCZ/O7tQ5KDnVf45mgPVIQEnxEKfZTvxuXMKehh4rjqy3EszIXZKYzPspPcYJARVNeFHH+21dGr3AiighyAQ=="
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "01F276F779AD25973C743AAC3C351C5EA9163F5D43F141FA36B775120EA88921",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:k1NkGyl0JtfvqhdwqMrjrvX1JV1jhVmB6I6OlxAV5E0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:wrkA88+p7xUgvjMVfb/w0tyIJEwaRumVx4QNz2oyvmc="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802978135,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAe100ly+W0BbIuZqoPjsH7/aBfTDNLHV2V6yhtZ7Aiuaz1duoB63HKQk9SDzm/rY+ckjtJHItAWUU0UtipQHANvmGsGeIgZti+YPOioPmLQeBNIEMNqPNUXOQqzDu+ZWlZRDofjxv2/kOkN4Bri/TQJDrHGCVebHA0bv7abin758KINMvvuGccpwJFqR1AEzqJeU17Qid6xDqiXbIar+7Nx2aGnoFdWp6lb9tS9wW6JewJ9gkOW+xmAHZU3NJ9h4WXiV9bD+Pc0g63p7RRMoAZUwgQNPosag+XD07sVqaL8PGJ4CsuWFg0PTI6ADYkfmfOpCsNbRsq7PByZ12NFA7pauG6jT9yXU5+BUuSf2kEckbdtxxMDfPp7vJCOlsOVAFsrfYEDAOMahy+U5U9EhMztenta7THGGIxbS2tLX4S4L5qAM63yNJDaqpcCTNg18FjXBLcx2/MPmHtrNvrOpt3tdcyKULbD5SNqwb6Z8Mwkw2KGwZnhImhCzoBZnLq98vz/FK24Ry6TsHF9lX9P7/sadl/rrwzfsn//zryFExljbUIM8+bKNUWnFvGUFfpmpv3+RXC/D8ONi/bIREQhuk2dSVfFRSLF8DGJkaKJ6g4QhQefodWmS/6klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFuMmdKwEG9oWHVqZiHksm/L/OM32oJqqQ8FdgLRDNmc9+Yqnd+d1acWP85QuCvuJmA+3nqjICHGXtC3g861XBQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts expireTransactions should only expire transactions one time": [
-    {
-      "version": 2,
-      "id": "83cc7e8a-6d11-4530-b480-b142921a221c",
-      "name": "accountA",
-      "spendingKey": "ca6b3d1016f80c0f75b6ccb08c425c423b5882cec6e1f6d50a394500c2de5fe5",
-      "viewKey": "339307d16b20839c6aebc3cbda219f3e754d03f0a5c3cb24bca572e7c1adf9067a142831058e877c874563dc08bef511e0f1765510d73223bac76793b44c8f5c",
-      "incomingViewKey": "ee99418d24374b4674dd4bc66823e0df89cd7781f340bb004d61dacc42f8cd02",
-      "outgoingViewKey": "fa05b0686e5b51794f31e7377fdcc883035a32ebbbddb5018b8b77d8f3645cea",
-      "publicAddress": "ea31b19de0e0b05bc63adca0455fd0654d9fdad7058d0c4e9fefb73c2892a1bd",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "7998f803-98ef-48b6-aba4-acace6839c50",
-      "name": "accountB",
-      "spendingKey": "4826aaf088f024b2ffae7cd522657770ec1559a43dfa53607d3bb7b13cbb0438",
-      "viewKey": "81f935357fee3a9cedade1614c688ed9bac914c1642257af764d2668192ff54206863533148015c0e3adcd2867ca04b1ca8e08ed7e83f2e4a242b2ef9e9d6ce0",
-      "incomingViewKey": "0f19bf5f151927a9ff7e24663f8156f6f2c9727b0aeaad36804bff886e48b102",
-      "outgoingViewKey": "c4fe4bcb57a5656ca76c3af719df0b8385c1667643cecf88fe8ee0482832e782",
-      "publicAddress": "2916013d151da780084353a7e090c14eb73cc5c44df29d0b8c89f0f327c1295b",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:JcS2AiL9A8LXeYwAQME5ZqNoMG4ISN0h/FhVPdY73Qo="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:YSOQSYvFAyG597xHsrrgLiy7C+7ldHyY6Vz08DgG/sg="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802978988,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAsty4gfAPKxQp78M4vzyPTnNxR1FKYft0jm/W/CsRjA+4wrCllfuAhwsj7Ygzn6dzfAIkhPnI/i3ZfVCCfc7SF1OWKgko1CNMyggfzB1PYWKmWcSOWrE61hZdAHKTMylybkSrDYz1oJyx0CapSD0C6IMxnL2c6Gf2IDl3DPh+mjQZHUkaYRzxRNFbyO4onXUcrEE3NKP9amKQxZH7ORqnfdhRfzIpDN0a5KI2bNTcfzKGFz8JXq4ovRNhg6i4a1B+zlU7Qk96rRkpZcNs7RXBr+mXeIReNBrB/iGNwGsgbYs9p+kpj+2+deMtPK/9E2s4QHeyVseeNSEBFDk2qPafZY2J72jbayZmk/8mWdSzEV6sz4KytcnZ1AFAsC6qMBA8Gdx9njVs5GnPFW59V8yA56YqMFNVzvfLLlYwU4bOPGLzus5fEUz0eOC09QVBiaTRTkbebzIS+vXpe5bd5Pq61yCvmCvQA8mwiAEgdfR17RhIAS+RRs1EdBuxJtWaCNJs/nOLWcJaOJOKwcitTYmtxlklzicKfs3Dk+IbIuSPUBg87LA1cZLE015QX48smo++chI2UoEOr0Z5JycgnQRg38suJIxVXhm9ERe7SJeMZNCuNbKK/6fbCUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoYtFwyKn2TW19OF4aYqe+P0EFyCQPir5kyIoJGfoZSScVYzqWpodusAl0X7Kxa29RdSjTu15mV+ATTfH3kLDBQ=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAGSZO17x/1As5lQP3w9lCGo0UTH/oIhYDw4f5TQtg8Re0w/zDhoip40palCG04Ta2OjkIjUq8IOPAV01W4pKcNoMXU0YTtz+zEvlvZot/LhCgDhex7RWsAFhD7uvWlZVk0R1Gt/624/8yVGIMJjj+DoMBc2nb9odw8S5F9Nemly0ZwD1HHdHnKCsWATA1ENtN9TcoKY8SygVJt77JvA0RAdBNygZwRu6C+2NFSNcGiGuU76tY0GV8sT2nxXf3o0AcRj/hW17fRbNl7PWBcEeVYT+p6LrtrNgCEZd0yqxA/BeKfVQf5EGzGEfF/j3pd8UTkApJ32SS/utpLovMC9cBJyXEtgIi/QPC13mMAEDBOWajaDBuCEjdIfxYVT3WO90KBAAAANSY7Kr9UPERsM0Xuad7xt5AiXYu06S1W2rqJft7m79W27SaJ0GKLp0doZ9bniSyxkXAhXCsGDlkAuW9h7bZMFybjxg18ZCopNUs89iJvKUdOhJI1lxIQNwQyR3bupPhCrh6xeMTMZDVI6OwKPn3zYG6N6+kw/kPFb+TplecJAB4YvLoG3uSOIYWAeGHuqgjLaU2sMRb9wq5ddS1KbwF6IrLPASp8Yxr+xPtKzQIRhglsf1DQKOxgShuddQtbszikhc+NEYHqOQmTmnIkdU+sj6iGxSBHi2d8E12HOCGl+MrOQjlCdAqJJA5DbZZkeVRyqhMxute4YODmLbw8o085mLyUVJklSRxIqhpe6LCsv8IXEU03n8mO8VobUELdDk3BonqTnAgYjnwFAENBnBMRgwaKd6s9UgNF7yggEVVbW42g1gv8x795JvrjDKO9m62vtzQqE9DmmOXtJePfyiurWVjVaJHu7RwRHOYYyprcAr36QT76KYu9Yht0UD50m2kiaSzQvEAWJucR6kDOCtAospfmyIhxDU0iY/JWd1wHyR+WPWT6Dk2KV21260uE9Cl35PwBuaEoj13DKPvDUFrbPPCvtuQVtGjAG2/dFe6g+roT02XL330LPKFo3d3tE0NDATPdeAgsKTTFcaAkzVBzWjmMUppSDabV0ltWHW5LXSJpZcq/eyZOtFNltuOfftyYwhSY8KFFM0BefzbWi8y8ykBY2ExhGqymoMGyL/0o135F6rAbpWxpFcMuVmpnimtljorlOu37VbcoC+r4ezAQV8RVoo3uhmbtDK/MMfNhaAqakDzVWwiEg239AFU78/hEGmhxAMNk/xzYwf1GqdM9vH5OFB9SQd6yryCi5kV4XajTN5XC8cxkiKyZszKZ0OQPLti3vFVY1yL+k/RAVcbggPGd3csAMeWCCJAM5ptWZ6kwjQroGi4n+MZDXIUlF69YFkKB64ZkL49od9pZmyAkKjkYhlE1LZERhy8dNzju7L/ImlRazHt4gmrO4EF7HVfM4o13BH+HUeR9MwQVPahedG8ceRiiYH7c6rX0NsC91DQe3sQglvyYTOz1MFdmM+BUmZr2SZOJxIi0IGxGy/HMK2lZOq4ZNc/hBcKMM8y+fkna+Kg+Ltd76+w0czjOgzfYYEkw7nEoe1HrqN13CjAJ+CbpBaagpbOpXSVpWUh2tr/KIbHQX8yxBY2z4rqXo8ijOQV7UJlEhiXpGvxYw22Jpjihfj2i150Fbtgatw2GUoBp1650FLQB3MrInHjc9tL7tHdt3eZTZ2VYDis34mJngGlzRRBgAUqbdW4GXbiKBC54j55ICtvLih+SUmwv26467Y/DbPnmuDMTp9rxEyZ0un5UJjAC6IeUZn0ki5lOZ/EHGoGmRhyE9JMkJtNbG2yp3a5NXif/McrP40PJkhsyZS5lG7u4jq12yVm/86O0huZHaQaFCKk3KUK4TLDlxKXrInGF/dUhEx1uo7DoQxZs9Y0BOuZHvQl3TmVVjKh8ojQHxCOwq3wEwx19x8jcZ1QfXpBqbb81XCC8j3LkYneuwCXWDdJJIJXe7baBQru3PRtuKCnoNh+i9lfpR0tQkGTAg=="
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "9BABCCC89CAD8F4A08E578A2BE0C5FD93B20B63E86056D1A1BB3118CB5E6F56A",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:X91xu9Hks3zItkg7IizhIVVIy+MsskmjgT+HFv39GmQ="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:QgIFioGqiq3nM59i3dVGUUEjw35LJdRVwdNsVIfQa+U="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802980983,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAk109m09YZHJQq2ccz5fwyW1BNd91LX/qrqHcBF8IUaSvRgCRzsk2XLx8vkFE/9rZ+y4vmPprgD52VwB3gDplYOH90HPC8o5pEF8seN8MPCayI0+7/xzA8WWdY2zmyPl4SExVizhH3u+xnYYcHwKs77G5Au0Obs6gfxPKV2OsecEFSV96DyzS+xQ5ak+mvHaRyciAC8OT1mq+Q7Npd+oozwSfHiWJwyt9v4SawcaEITOEimUjPLLBs7oZnf8oehGfOoiwe0V7WhDHBgO7paPMru0og3V1lwaNojhXT8bYl+fzngU9ryc+CK0wYTMRXGf9chIhAzWD3x+tnHLdGtw6gq2ug8q4XobQEoOPs5JSKaXZ0WHDIYu+IDun5yN23DxmuUPsesB7LLi4LGAJ2Nv+Di9tjtmr614HxojOcXssMCUKMw4O+g31EIjA1fOtpRH6ubvfUlqQ72dJzRW2cuRoHNyrKHUj7PiCgJOJyd2BI91GYd7TpCcciFXklonAPCS9vVVpTESlMGqgg8ZhEzj2AIQBrhg6kwaLUEsODgNt6Q3WJPwC1rrKxz0Mgm6tnFXF/r11dBPs/V8RZ0TEPKnncZvmf7KpO5mFAxG0YIEREs7+lXRtaJptHUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAttEhoh4ZYAP6qCEfnnuXdeHBEJvabF0bn9iKO8PmBhGeEB+OZDb++WBRAeWHUcmwmw8hwmDjakFXk2mJMNNBQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts removeAccount should delete account": [
-    {
-      "version": 2,
-      "id": "4e259d7f-a5a5-4eef-b069-58fb93141efc",
-      "name": "test",
-      "spendingKey": "42e3ebe1f2edcc4a3d25acf7d416d644248294c9b70beeda5f808ed2201c62d9",
-      "viewKey": "dc9476c5a2554a45047a85d772ed64f468f41b39114354b3a65f478513ff5fe0c818a7bd96e2f6cf6371681e83b7ca0c33069e3f58fe3bdd70a9bb5cc5767735",
-      "incomingViewKey": "3ed5c828306a5b2d735d54c445af996f9e91c2f12aba499b451594ee214a6b05",
-      "outgoingViewKey": "fe1ea8baae48319c3fa7e0c99d20048c77c8ab181de47f92d9bea74eba97c7d2",
-      "publicAddress": "27c98937678a2eaf290881ab9256fe94e5faa6a975ab466432ae4b93dd428613",
-      "createdAt": null
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAALQxV0CWVnjbbI0BNg3w6kLpjsyQII1myXkBKEmDuaRqKUbTMq+Dem4VsMts5F9QLsEFxU1bUNcUkzEU2V460IShLXsekdsojBmESvhGovgKrrqWqPDUvZYX9gYrOunZZlvyQDRpukBuTsua7Zmm3WybyhloXZl3iUUZniisPzHoFFOZm0pLdV8nJfjLYA3jfo4/bClIE3wiaUzTWow4eIvR+CEuzymeJMhgg4CGECpqkHU2qOTvwanLk89NGzITOUSxf8PECeC5v7AGbtJBexwbIsxi8+qIc/3+jTKEqC8MlsEyT5wL56uQ6rlN/RUccoItoNkrGYL4vJ1nNgSbFpoRZotXk1nHPY1c8m8+pBHUfMPbH46VMngPZi1FyxJMsctrkE+nyS6jPcIqN0QfxBu7A0lahecnT4uOO3QypSEFkGCm3U1RV5iIKgLt2rnfYaGeLkR7ZcvrD0yL+dOXTHgAWA3tJWFSL+Woh95XiGffJkuzi1IieLf5IXuorSvT/3c8psdfZ1jgBsq8txe5m0zN26q9JAUZXmqJklmFoS1k6LUqc32iCvf0f+rowOOfw6cmutLF30+srzrWTTaahJ9hEoiRSbOD/fxevN1GxD8XXsH5pRjMMnklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMg2b0KKtMkgXdRDzRGpCoEfU1QfIGVxBazxNzEWIWBfkkI7DrDfqRha/WLADRg/0NYY0FONIuBYuxncMV4BjDA=="
-    }
-  ],
-  "Accounts createTransaction should throw error if fee and fee rate are empty": [
-    {
-      "version": 2,
-      "id": "30ce0871-9e91-4fa1-ab3d-e199f428e3f2",
-      "name": "a",
-      "spendingKey": "ae772847c8e55bea0cfa853c895bd6f83254c8178e192b42d863d79d5cc8a997",
-      "viewKey": "ef6c026af0cdc70c5f5b0f74d9a7aa4e877eb9ea5bdd813a9a1413b1b5f2068e9393b60dc06738c78ca703b07c35b1fcad88111fe25b0b849894c544a1800661",
-      "incomingViewKey": "9b807b781cc2a071509da6d510f7d6d4e0ec35f3d438b79ebc1bc44b6de37104",
-      "outgoingViewKey": "9c5670f6c545478ae0c5341d389ee9bd8c01a8fbba4d9aac7c906d8111f96787",
-      "publicAddress": "6a2b9b769dc89dccd12137699d5838f6931e9a0d9b3a60f88c515eb7e28498c3",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:McI6Tjkz8zbKh1MbAB51+rsiLOZbcvXUu/8wCWYPAxM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:YMUAdce8I+omZcfaWFC/UMOteNI9THX3y0orwRfFb0c="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802982709,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA+AFl2eOq7smF3RnIGc14/4EvgOPgPMJsmT5uIe08lGCIPMVrhuKeh8xEjXEiG8c+T5YAD+phIH/1Ni4QT3bIwp0OIOqAQHt4tKV8HIPy1ISZn6MGIH3g94efDUjvUT8TSG36o8F220pwLltVQCesClu1A/c+9Tvd1SCvXM0+QIUU+rclto88zWIeK7Rqg6KrwIGf0Sv45aji1zj8UwaI46fe4//ekYSk1EfYDm8oDcWBvzfQL+bbuSXc6qxV/4FNzQEKModa1gp96m3KfzykKfntzZ5OW3m3PFrURpF0O+u6mKr9iJEsy8bh8coTp9XXxzGepZnuuGivzvtm4SQjpJpbmHN6GcMXxYKbUT0kMkjSoCrwOR5pH4SV888GmEVke1qzs3zLlsMyRdWev/q+gXkijB52qTktfkGJ+2D8CVNANFGqZlOekbOZKwtatO0Z1/GU1mkoBzEWSiXukF2/5MOYDjZZO0bwwmWjJM2hFMLqIvLEwutH/zdOGnBKknOcWDUUOhJgSMLJ0r0mN8y3OM7gnLFhqBLAX5WaFRpihMRA5PEj0Di18J39qmFnbt408WzOhz+oIgOdL3U1kx+bRgbmpxoWMEP1FMneBTkE8CLXr0/lAg7Mi0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMMyWThTyMHqD+tuxihtngP/Rx4tHHZ3Flg8l/VZw4V1xzfXhCb/FUcL62zBcJLLdR+crOtFYL0os8Y115Zz5Cg=="
-        }
-      ]
-    }
-  ],
-  "Accounts createTransaction should create raw transaction with fee rate": [
-    {
-      "version": 2,
-      "id": "04c5bc11-3ece-4f3f-a9db-832a5bf06437",
-      "name": "a",
-      "spendingKey": "12d66676bc72b437e41613113dc903955c77c6b3341ebe76165ab592e1031e84",
-      "viewKey": "85641d672a0ea90c20aeb4ab8580654b497ca120118e048932b510fbd53bd93902347a745aee81a0c5ee06270448cc127708f7e6f06272317efc3dbe491e91bc",
-      "incomingViewKey": "b270aa1822071516e39ff82354e9555c5d93f1c31b92f3c46d3c5237fa9af103",
-      "outgoingViewKey": "92bd9313b4247e0c2d87410ca261374a2fdf64501041af402a0750795fbae620",
-      "publicAddress": "0f4e1918c737355b0001a39b05c653d58137b38c4c0105f4ec75b46cbfabda17",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:MvCrJYKV3TgA0Y5f2xJs1wFSDR8Hs0o+KUpyHh4cexU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:8q77V4xgZxpj33u7W8noFv54eFhW6QG1TP7IdZnG3oc="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802983536,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAzoSSUom5pw8TUtqVuvUkdNU2nn/8vQff802XrpqQsg6ZvN2/yvvNQC5p/Tot9wRP2jTZ+pf/xnTRBNqTFYSDY3U/Q2HITbMYSuTwfvKaMie2RV9g8v6ObuCxmrGwBmqbADyCDrdftwFQCYYRIkOnQ4Uu99Ahk2FMtKIhUzGIP+4Kbp2GHliGo+qvmW87i8RitZ/8jjLhZ+oYKjtnb+Jqv0TyEvD5P+cRuuro/Ua/HiCvpOwFmKodGDctitWptY5F2KfRFH5kvKcPQMZ2lGyExfKn5cbCGN1a4iYH5zRj1wSj90GSQxyTQunlIq8WKACH5vRuKpT1+1tTlOmjLAdxCu6VXrGGBX+drxlHS2bzwcc5y+XdT/6Q0cJRb8bUn7E3QVw1kz0qlouKRgiiUEv/eQewZCGZYqjpXYLTR0S/bokJBc/hLulrdY2RWKbC9xNgbaSrzkXtd82QyBODT45/JVq+7yrT4U3yHUNk2lAdv8r8dZrpIqiuwbbiro+Uq7c59PQxoX2Gz7FCHDdws18yawOi18fOFPUbQvn+RA22jXNE5R9nBtEWomlalFS5+1j+739osEvmILm9n1d3+0kflI2bFnnjhigx6xKxZ61biTWqDQXGOss6IElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwa+JU8IxIRsj3nsT7+/83VUsxlJMnaHmFSLChclm1huyhTyJScY6MpUB6WKzAydiYPh96rSdL87KSBpwBWusoDA=="
-        }
-      ]
-    }
-  ],
-  "Accounts createTransaction should create transaction with a list of note hashes to spend": [
-    {
-      "version": 2,
-      "id": "db6a0c2a-895a-43c3-baa0-aacf1ab247fd",
-      "name": "a",
-      "spendingKey": "05c041d8b66eb08ab1ad312f6ee5aeefeae6faf6a9ef5d4e0c2985fed30dd5c8",
-      "viewKey": "807fdb878cd8b46fac28d141abae05b6a0d52b368ebcef51237dd0ae694a2ae7c134b3df8526bec432fe04bd771b26a7df7530953f2d5b3cc2258fe8126f6d91",
-      "incomingViewKey": "f2ee1f0dd73945b487255cd731e2f3f3003c68ed5e2a426ba03c14c8248b9f07",
-      "outgoingViewKey": "4e67a99068c8de7aa5cf7389a00b38854ed1fc719c02f33f30452bdffc3ddc1b",
-      "publicAddress": "a935b7fe39fb70c8289550c87de22f0c395703ca94ff76be65f8f8b9aa96bb56",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:tfdl6GZO2U05OVxIhP/SYuo705g3P5efxmSUbcu/hE8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:d7GHyMqulsuvVnPsIh+QWlZi1ngK+d+riutpzQLA4KM="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802984379,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcsNnQUc2xSVwnjIQdNHS+CvhiTAkreV6OGHfUJP69JKykLw6BmXeojpswmftJSgz3bBgU6bsgkqNHzx+smdhbP6WsuwcWvGZVEaYWj5eq6i1r/UrFDIsrwNSvK5Ji/t/twg11BrcZVz1qBdmS+COgL6zUKykEMeVVuZmo9zz9coJqufjuJEzGjRv5Scm4sqgK+SiP9ShZpzehU2JStfAU9Lr/rQ8fFmOUo90HuJBeZqn0EqIpfv5U9jTTGW9SMI3leZo4ET7R2wue4xV9OLXuLzpb1DCgltd93FDcy/3nmx0NPTJkku3AGy79B464B57GRxwvzLUYHhs+hdVrBjc0BBpidaEXVSD/tvOSgw70E4A5AW8Zb2RypOhiud0w7pYLaOCZ0kkjVgXlZ+MagNO1lkMlEpL/8sXUwCPkWWOT19bL39URAJkdogxT5bIE5p99XmWIYzADh/XK6YOC8jD7FOljkV7G/eoKelSdT9VxyEPLjDw3GT47OyZ1abBYuqOJZ5AcZqdRHzWL6rKjzul8wsGHaXR6fjHZSm7KfzMtOQDkC3zLbBEdLTYMFEMq72iVa2UmFNlLd/FXa3ybnoiwSFFimBqIA17A5N+wToYSfadK3LHvFHRC0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/A0ltkiL55JGbrOtKLWAnoQVPoRKXs0YgYX0/xo1JA2DUlXELxO+JPd/l2WgLqL/k0OiDZQTUG/wBEpWPyS3Aw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "6553DB31B597B661D5CFB9004DFAD9ACC373B10C18F06379A7DC894A107DAD41",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:kKS2YblxGYCDvPtpLqBAb9n4wzZuZ96aEyySSBk3DTs="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:3MhD1UIQ6/N2Iu4gl5fv4hobdTi5KVlOdboLZSeJ91Y="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802984764,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAwu48SL/bn0Pawv0aC+nJV3bU7IsgJOzRG/ZjzZMSHLi5Sibukr4xWj/yMEid2NRjvXWIK5d7m5GOFqtqrFv89OMZdHtkDccPG+qbI0uJ2KaukemvcUWacKVzaXX5iw1Edrutyl2dU9h0JjhbNKk2YzWX55EERi/G9Uru+3qAxD4W4CUnG5Sr9OHc8RWdNXtls2RYvRdxsbAqXLxBomq7KL+Fv0w40J31JYCQH1W+KUilOgHaafKlLwo19f5mm38v7hTn2DHtYHm88hhzZKQAZYFMCyGJl3Y8jm7yXY3KqPNcd98Dzc66KiYubBwIA1FjBEUIuxhpdyOFT158VArusOr19caL5qMpTlZG0hXFRigMoc+FSKKV6hLXZlXGz/ph6QDo4VeVII4HovPRHnp1dnSujShp37YRSnR0IOvKNAyEBfJmhls18fvKQZEuClY+VTuDcc3DuwZbNmkrOGGBOm9I1W/7lzXLOHztMwjsgkRDjENZc9DsWlOMLM5rfbs7Z/eMMfNW3PLM+MJUxCnpTEN8pzKFx0bCpM8IZQV0H24YgKQlXP3RQqHCZUM41yQhKTM/BAOfi2+r5TIlOr6wwa7JCIj6mR5f+Tz1EseOyMQ5Yzzt/xi4AElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWIJBd3lwv2vJuFKVl/uzrp9qID01qxoxOCBStBVRSgNklrQbrDXF8+wCXdscTh2Rdz3idOzF3Dre+6eGUz9+Cw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "CF6B1570E64C20A28535431491773BAC9ED1F31A62CBA5C06701F3BB138EF5E9",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:/8qOtXY3EvcHoV2SCUZX1Sg4SYO2e16gavYPbcn/8EI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:rvycOyoYltKgBJZoperheHweKUvwefyCGuBFNmd2Eac="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689802985139,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAOKmedEvqB9hxnDJoEqqBoDo01+4zkqXX5cvnIYepwmStMCSSzBWG/NGS35kdN1wvN1niN5wFHv2RrZRtMzJ9Mc7SE6OmB7LSPcedPtcs8HCvokfmQ73iL5FNRf1vJZbcuu+Uc342DpQ4ajC8uFWXY0BXktwFT4O19+eoa5CNnJsVtwl5nNRxPBQMNjn4evC4rBmnBzWGYunVqq9wsXsEPbmnCGqzo+12SdeEcAUxDC2Je4baq8oWz4veQfoJAaS/xCgFmS1JIDWcgAcnF5uwhBYRoWIIFsa1vFeXNDepx1zW30zXuaMH1lU2zngx+gizCj1GbgPAgKhKmReYdxx+INOKU/ySJLNd4KvlzdU+hj66tZL1F7FjjMF8QZhaN+xh0KDlhrYqrQaBizq8q8onuXZagFEbBpZ3HW+l/vrf14vb8MnyRhzvEEB1NVfUK5AyY7ALJNq29OMgwcy5b5AWZLLPX5oEfmLP/H4B4TPSJWSt8vhc8L6nNo0Tdb1PD0nbvab4wv2oYpi1lW0nj/M1uWUNjnmg4YQbUnFkrTYTG52f3Rxd4KmJcKumLVVoCMECpshJIRJXDXh2A2/jClcQhESrFsp/UanfKue1zjdIUdmNVFoVBAjypklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXtbvROhp72L7+/r3S4qqtwotd8mypQRaleRWsr9KDdMOo9ONzMajiX/GxDAv9aJ8EiP32ikqfIGNeimuHo9sBw=="
-        }
-      ]
-    }
-  ],
-  "Accounts createTransaction should create transaction with a list of multiple note hashes to spend": [
-    {
-      "version": 2,
-      "id": "74cc110b-a021-4adf-a43c-9eb2300c552d",
-      "name": "a",
-      "spendingKey": "9c4378deeb3d772c29c097256116a2080ec83e17e875dccf4c128abe25438a3a",
-      "viewKey": "979ba6d782e19c8cf88f187780ddc6e207115eb4aa5c2676d62e947e7bda08cbaf60bbce357adc7446dba0b7565008aa29b3658a0fc2b82f1c74d529ae93b267",
-      "incomingViewKey": "a4bf1cf4ce505b40e7c29582ec96db25ed840a64b50e20d5e2a674c53313fe06",
-      "outgoingViewKey": "24a789f13033f1e9e38e6d71201747b33fbee779758778dc78ecf78123a3c193",
-      "publicAddress": "e236dc88d6e630a320670c91860f224b86e4f88dc4eb5d03d9941474570f7a38",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:6ToNRGTB5uINi4fc8kJ2zAtnlIkOS9F6RuokDXPR2ww="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:RC1+2T9RIoIwEireeZa0gFTWtVDKw3h3kBcuqni+oLA="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802985987,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAaQQUfnFCE/9lP+cwI0aoECbogG4FfOev+vZ54Zxbe+yUtLBF0XkWDR3FvuFUo56vfXSx9BdfnAWvrl8UsY+cZxTuJ5WFY5bxLvUiHKByFea2A+0cVw6vtlPlKvq3fjG/Rw/7WQ4jV1cufIaJPVPtHKYJY0X8+t3UJGeG61pEWZEP1Bj+mjColhyOnrgp8hfH3ZmelPZLVYQ9FQ/RitzrmxYRcRveWSagL/HFr4tFVtSqkp8k8/NzpqhENdBU4MIDxfr3npFf3jjStzeO6Qk916VsYdUEbcf7b1wLYekLHWURRxm++OEPDgLG+p/FJjl3TVfcIcS6bZ0onItEdHCOpqxIt9BVg5gZczX8Rm8KFODvKZ5dduxmiGi7i7Kewgs1/6D2gybO6SuiGR/IoObNMZMwXHa44TvSSj14haPgGWgrba6bTsm1lsMEtVF7pxfs57Dd+Y6AbVEytDT7n6v6qnMwQLWZvdQhsv/pfHLTx4OjRT8w9QJpvNnGaX8firLEDCvsFWqovJc72BImx/RNBLYEnlKPefxt0DIKrzcJNejO+RU0gTwYVf0zotnM6R1sL/+nQndY9QQEFR5A5OFpbH+TUspppSKtBdzU6nwibsT4TB5wdiCty0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLysL1de1CB8a07BQ/V3uOuJb8sERFBdotQsr+88IZ17Thq7eil8AE9pyhSxpitOPRJqstE+/PCW9JqoFk5VnCQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "3E68BF8E036F63DC624632D5B40A006CD380A716DE98177F3D591CDB826C5F42",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:L4HrWGQ9+mqw9WjXTm/EXfxTISPKs03eaVNgQ2d931M="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:xGJssHZRIIbUtt7JOYDqXF6KXNMMD8VuELcbbtPdKSU="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802986405,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4Esrt3SIHHkYWsHB5w6kvZ1yzZBJf0HgC3ZNaHcEITyTvx7f1DySDJhUZdyXm814aNU3kJ385T4ng3SHtPWrcZmCqAi4c9A+jtd+vhMBdWCUh1/V88OPdDH1hPlNoXvfwOiYl/WkjcyynON26bl/YAjDLj8PU0oPniizP1SxhNYR1L9A34N+iE/3CIt8CT5lOND2XS6t16adHXhIsstPb6x5I37yUKdCk9LOtwTUZy6OTuNDdnOc+nR1B0/kgWu031NwswXvtuQ5tPEIy9GzFd2Wszx9XZRYxnjLR25ioBEN0/+NNU3RbaGKSq5rfWbS4TZMIX1rpnWqEixMEUaZMygxHfCpHH2Ey0EykwsyS4p36DvzfB/s8mLuyE+NoiZD65YShohu/EcUiba85Y2O+jYn3KLxpeCwicKwyIuJM+2rBfa8cyrErpq6VglGSJe5jHzjnkiBK4S1QccggDBMmS70/vBeH1UntNeUc5Mxuc/18zWRlJQPGIcy0PxHGXCbHkMUNApiUCKA8slpK3Toz5CQPPHJFzhSfvUolKHqW3HTcl4ghuMs2ydG7siIjJeyjPM/O26Byxtxfm3N9ODWafiWHMf5eG38451/l92MSxTkSDZqEj4G10lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/3czixUpog596H7vE2iFoeXsOEgTalYBo6BMrKpkfeLV8TF12K0LQkkB1f+f9QbN+o1R48eop1b0r/GYwbQnDA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "30103A3A7B1CDB8709637A7D79BE956D58DCBDEFFA70213D7B2265FAF78F03E2",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ko/HN1f6PVV4jA6ipZEgl+gXI2uDUHotQdQV7DnjUA0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:E0VMkZLd+TRpq3gFf/HxpfbuDK2QT6WuRR7xQO1Il6Q="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689802986795,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAaqRysv5w4Fxcmk9sx40RlLz7AmoyrFJFffLh42568UKjwp5Ezshsh31Z0d3mtwg6s3Mi8DDE4bkhAeL3n1mUtvxcMWbwayLo1EXSOcikKCewS0s1VkSXUWdSoq2PQWo5lJoK3NtYV3CMvW44Mn11gvKD8KRwjX340DLTn/3cPSgXrCM9xkkpISj69XmajfTfkiaCMgALhjrR1Cj3D0gL7k5equv6tmSp1fFHklFK6seW5U53MKWv63nznij1YmAn5wrGss4oeSnvo+ObrUI7S5S2gIDVyjC+xnntYp9nHRnbGkfubgOyMmRDGYq2NLd3vZHKwKpyvwANYpYCadvNMxqPOMW2Mv1R9/abF53VTaljVsiPcGxJjqnWbdEuAeEoJAf6GUEDD5xOKp9Jo2nmdYKRWIXj2B0OzraC0+uwyRkksdNvddZUKkhlyX4zoZr5ffgKYhLU1CQ18nY5lyeFG6g8G4A26CAldYWz5fugymUYWcFBSf7SNCmw3lwuxE+PXWCT7ZWlNDXlJ5s/di/Z/gkefnheo8z02Ze9/Zr2uZw7JFeJ9i5pJRY0ih18EGWlfLZcCof4Uhr7UgBtiOk7EWduMaNcW5EvUpRllrWJr9anE+jY0RNIc0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8lOlNl7oONyr58u/3BXxIEtw0a0nBs9b47z/4Sg8WitVHtxn57bEOq0ateguwdQESxPj+NZRQ59cfuPC9+Y5DQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts createTransaction should partially fund a transaction if the note hashes to spend have insufficient funds": [
-    {
-      "version": 2,
-      "id": "48def5c4-7de5-4fd6-b591-fde46536f9ea",
-      "name": "a",
-      "spendingKey": "ecbd1f8ef6efae2003a3aa97a7f338414daa459e03be31abafd494d1d9366a32",
-      "viewKey": "563e00fe081b113ae31c125560f4bc234868ac6ef6c7e2293941231b437b1c7042f9b4ff93dc0b56e31ceaf018e165042756db721221204d26396ebaad0f1759",
-      "incomingViewKey": "64da02e04b17691a3ba40f3dbaceb1c59ec1f576addd84ba418fe1b1dac23e06",
-      "outgoingViewKey": "baa8ff3e007eced0710b48c07c7137d05d2544e6c35d1414ea24d9a5e493f47c",
-      "publicAddress": "8317d0d20fae287b6ea5237757b69726bdc4b6b6720f7e26cfdfdc67197f9995",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:qvYg+5nmrLbGR6T+V2ufCbYcM/kkwy0yNByQQlmVbgU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:AoJtIOAXWk95/u1+o3xShSu1PPILPmX7r0YCt/H1Wjo="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802987639,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAApx7RBeYQ1sy9TYZKFsKTwPxe6zKnQvTSl+YxatjUHoWtu0r3TJ1mzTNfqx9eileZun+7ehLLHShDk0A141vQLVDP9Cn0VZZcUA9iPP/ZNcmDFTXDGPmOuzlSHn62sc8a50DZdubBgqXk8sZ6Ol0I6iXnRAKZ/b/z5yI6PITWy6UWy9h7aC7gF8R5sRFy2XKBTki3LhnEO4BP8L8tEHAMoOTWQk8NKpgRJgXWsB16i9aJTNn4MjLCXW/PPcO1q9pocCI6kFo/lXkitV+1kt/iTLEsidlbevvek6qGNXnM64AX9r4E0HU2+vWlG6DpX5oHl1LNaAGKIgme+4kcCQC92jRtw2GgcbiAmoBVI2tw5gTpO1G31osNZYzEnCfe5ZUKMIv5ONpalZAjHNNI1vzSRDvqc1Tp4gbZrF8SJRVdeDgmv5dDXr5q1QpCkpl3sWj31VxUBCGY0ZGJM5OH54smmBMt6QR8fpRaaJNAEZ8GP175fCIVbPXQm5ytczjsB8i/GFD80cAT7fPyFTi7IqN88Lj3GUewaQsxl3em/EIgOz3p451NKQ1vbRwrsLwQRl5K0YerQl4tDhP1euw55fMmpfWycKmfa8Wq4wNh3bN8Y4Xfr/bIgvKoPklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWKUk/dSxb3+MA92g3WBFiWPlbBMasB1HF4K5O9/SZwLciZ1tcd+BwDj4naqbUYIwy5QFt9dTNAqn7Ks6vCgJCQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "1BCC068586C52CFAF172384BD2CB30151F15CA59DAB64B318F29BAE65A91D76E",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:YK+98xEkuf0iGK8LZdIO8ARkiIyiKMjgtMp7YuDrbFU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:GBTwwjIHdkgo77ev0SfYQ7NQylEM0Duv/AVmyt/eNO8="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802988047,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAFYHEVBtnOHdym06U+/Nh1ty5UwmFvFH0FQNni/WCi5Sijzu/y92HjDdPPasCj6vL2bXUyEfbwO4Z/SaAF031LqPUjv01FtCO4l9Mlg7A/L62FZ0MQhodXi95W9i2byZ/2M9RoagQaKdW8eBKpxhnom/eWabHEkHJeGG6KfQqpPYWnJEOw4zz6sjgUShINjjx0+wy0hXrsI15KJ0lP/AF4gVqrux94fBOtwZMNjwLNA6UmAnmB/cO3s1bFxMiDmi0ekbjOLGqUZl0liEsVg03bldugtVTwRGbt2TuhC4sTgGqxXsHK5Z4DSRRZ3NVW1OXHsQqNXUnnucodaP04mRQy2fF+1uLr6Sph4qYk5LMnqRQvoJZxEt/rwKuHWAz0L4/PhahEPjQq45tvfmQEw+h0Tb/PzaHijlE4MG7hDphyo7Z2CPre3AD+UHXtXjIF9vtrpU8uYnEV6j0H/SVlxTv+ZEbttTK1k2fd2CxKyeZPl8iWTEC0zo/KJOg1CQf0sJlw1Dk2xytOi98VRKeFsvmFoxqs4t1ZLLgeh6s27fgCUNQpW2l9W6kQZkeb5qOLZ6p/pR2NgHQmcEczQsFcuKbNnNc1HcLwt+rAqRafWStCfdQHR44eNNdJ0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJuj89POmGMMhI4FItn5S0ZrYdkvnsUW6PRyiNtyAEKiCE8O6LLiWdK/9yoni8u4b6hH1Zzt5XKy8uPy1lGXRCg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "5A1191DD26AA33FA9DD5DEC859EB5BE1EA96C9BB42704FFC94FE6BB9E2B92AEF",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:2yjVELTHC0QoPRL8r5YOHhlxNPtiM10zAL3lnCrnQCA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:qpS4hqZMhJCs4XT5EraQpseYkgh/dJtIS2gd6tgNuIc="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689802988449,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAflqeNM0M4fEDbWv+Z0vztPgAhuxSlXfv+Bh2j10606OYyvppHdRAFs5F5VgIz5R0GjTamttCG5xBKaU5HVZ3jfINm/qen1KIf0c5lC6tyC6nGb00GjwBoOsgUZzG1FUi4joRkmU2zsRrrKkSWezo0v7G/BavT8DL4oi4p5hFePYIIr3iTrz6VLeXuVBU63oWkLz2mKl+LDqeIZ+2Y/hUVs20KtKuXCQG1yEu9bd91v2ATKcIL37WpCtvBwSl7DSYGXNA2PKgUrs67dGwLkR5VUlazhqZmV8mEKnnot829YoKducz39BMsO8ESgqX8qcJXgDxV3+bFJrEndnSEsemtds4fbcWGJeQ4dkJtEqA7sZB64kyXJgW72NIrgGdClk+YHl1EFu+ojmPejWCivd88nv87ihjA2Wy1pT4PEr68jnggdubMkVC1UCnQt+4jJG48BBvW+KqoODEmBx7VrxDxWlma0eH+bBzIEZZ6SY41lWaltfjSkw5xImNPPhR4wyxRRTm2SYAUYQv6tGNEhqdpagQ5p/8bQMcgDHf+Yc83oXsAu0abOqAmMj/4lwPUD7JYjxkGtx8dzqDZYeB2rNLl2MSBCyaC/7ctby8e4HVA3qU14pWDIO9nUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIrLmGp3Vv3BHvI1tyP5F3LzWbUq0WR0LC3tW9HjoxxVUOHxln9dul1PRbjwiTS//esNaB0YF0Ycz4zhQ41YEDQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts createTransaction should create transactions with spends valid after a reorg": [
-    {
-      "version": 2,
-      "id": "0dfbca9b-3ff6-434f-8b0c-99e91da98d8f",
-      "name": "a",
-      "spendingKey": "956640d638610dbb5ebb2a3af6aeb9c8a761826d84f468e571f65d0b86fac33d",
-      "viewKey": "67b5a8e6b2c964aaa22e5d486e4304a3c9f4f219a16e7b08e5adbf34ac268f33de3c3c378c0a401ddeb30b9bcd256ac6dd7d65cdc12448ea2c4a8722cd4b88f0",
-      "incomingViewKey": "6ae21e78b604dc1838a08b7c875ff9385027037c5cd67fe238d5807b6b16fe01",
-      "outgoingViewKey": "6e9376968bf4e219d317ce05cd3c1461a5ff44ac65c8b4b9fd0abd4d37d15f72",
-      "publicAddress": "838b18347c90e72bb1cb31789090fa8258d6eb86a8506a6b77882a258378fd63",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "8c274596-967f-4c97-9449-0ac03aa7e733",
-      "name": "b",
-      "spendingKey": "f269aabf7160371b6f724047da2a73719e8b1856a49cce094bc5f603bebbe25c",
-      "viewKey": "66641ef5d248514851ea70df967826474c48f9860e8938d287bb054df4a00621e7f3da106764020eb8aeda9bf124a18cb61df83833d2d03fa29be726fe317859",
-      "incomingViewKey": "49b676d72c762d3ba38bb6a6f9bd5461420a9aa05a27479e48da717d2d847506",
-      "outgoingViewKey": "06ca30df90624b5af8d605fc176a1452cad6898e43dac6e2c66da663b40bd8b3",
-      "publicAddress": "dfd3994f6081710603c7cf532fc0298daab9d61e47683c8742474d7f8a598b8c",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:fSwdSQAUgFDo9kWVD+KBNjGvkf/hIKXwKKX2yoh/b1M="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:0zShCWjofgCCNJSeydClBsCSRvtWfC6qOEpESmFQFtA="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802990159,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA0LF57sU/XfE/Ylj7Q0AHHljs+c1fz35BYs/Q3abmYpSGMmzcCKgq4oKpM93Wv0jjhFyj6ZC2xuqChD9mjm0yG9KT6wo0RHsXZYzXL++c0TaimCQccLaK00E/Zc87Av+96bWMMcWIulFgtQkns3YMHUm+lgxUY/AmXwIFFRk43c4PGfOuo9VDV0J772I9iu4d8o+C9CfhROiKVDoVrjL/CbVicZEh91UVNuwe+2SzD9yTYhJhPZoUVVzijdiBFjXem702Fv27U2yA1sgy8RhUpZpthO4Qhn/pMhbjxg2i43mrz33v02xWyMvosGWvQkh4b/J1S0sSN0qCIIjmq0agcTH9IULBp/SSPYNOUd1m26k+cdWUQG9TRhgshOOZ6l4kLxXhCJI0b/NVbJksdU1UmqWDGpC0csMU0z5NsKJW+QMN3rVHRW7zhewqOrw42rnYRJEiW9P3ZtctdsnxXFO7MggFQwz7udrEs20SVq4LVsA02v1RlLb4A1NFgHn39usZs91+l9DLyhrS1Iwz6KBDLAxk9fwPjKnvwgbUQkz6AmTzhi5lzVjLy06Zx4HH3Jgv/fWeWhhG6A84vY1VvNhCRCk98d8hqTnWmgdAJ65mtnNSoWWytBROTElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwukOzSBh/ncmHkwy80BzZQp2t2cubMnzkxACSDss/M1U6Bnk8MtlEPdg3TpUotjfn1bYRo5b1URxiJEe0CrJbBQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "41A3FD723ADA4FD9F2138639C380BF76CDDB52229A1015BF4D6FB5AF2598D8EA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:LZ46c1fpRbP8ux5JmRxDVBTTS9H8DcJgupr0/jZM4jo="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:BFcuUauk4TJlnLxTVrpP/0q1bD9IdD5W9D3TSZw7VO0="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802990562,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtJ13O/JuNCS9pNJW78CjVChSuFP6ravMzKlJta1ifY6Z7aEP5PzBKKkxSUY+RKgeBpYEoh6FFvbr+JRo5aX6FxJ5l+JZ+CJYBcEH9Erg7UOuat3VCXLX9aOlFArqV2Zj8W/tPUTGI9FAFLRzomb5XIy7B6fUTMlN3GeTX1d8DYoC9BjAV9XgPExiiNjcqNir1Kxc6I5+aG6BMkvruKvDP/TFYxB/G14CVJhykwZTr9iYNbPtdQUVQPxR6wgbEhNp6mdEbdnhFMTcuFQq0qVMzxy26gMOAkiFOmR5ceydnxHRZSBLHAZbalmPIORLSo1CUYaFr4t/2CpmPbipA9em7KD0QiImP0g0IYmGPh1oEU2r872WlQQH4vHBH3wQTTMVGdsMI8TV2FxSv88UekMFdTdqMBzOZytvcu7R7AjIVtYwiN3qH8v8Vhbu8DJZ9iq/b7a5wbRseXAofBLe5ZrsnPdyKHgEEJNmCQ/yOmhkoBNrjr9ioHzw5fUSM95j2UWR/IngTLUI0syNMMqkARdNZ9AplhgAj53KjZ9+2xccI/RKVio/xml2CqdMbJVg86koxDrd/8uC3yDcXPuvsSw1cvZcOdc6frrFc737Yu9NTJ75Y+2QyJsY6Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0B6YyGI2RdXNNXtcnSTD0ikoJok1cqJlAFyk/8QLicUCRoSA9SkNZP8WNDhTaItW7N1wh83ktaRJVpRW2QAgAg=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYrjCIyze+GJpOvX6paOv4p5J5rq/ETsiLrfShNfw8S6Js9nnJ1DS1Xfzk6ITzDHYwSB7NsrHkoQkgw/hzmZG7qHwQVr6rco2FeI/ugDUq1S04qPknmmMT2keVRvQf773N4X0Vx6TPKGHW5wojZHN36U4uCaqMxjg7xNK/REHxXYQmdyxeJU8GCVlXmDTjrub8YVLaO9DfkvQ4EwTGfpOFh59Wth66hMCohIoOxfVloeYzPUXsRHf+QiyXAKChUNoXZjDAmUf+hEcbqVxD3mx9wPdoyYqk793TsHGH8c0lqB0js+8Da5JTOziKyKgWPrRaNbl8bLSe4m1SSWUqqOeVn0sHUkAFIBQ6PZFlQ/igTYxr5H/4SCl8Cil9sqIf29TBAAAAFmJ3sQAPeWZIQMAc/f4YDV+c70UexQ3mt3mthlQvM3rFlNd5RmBH6Y23FHwPJ186X56tUmf9pwaZCtx1NSY/RD2HLmqtOA1oJqtR3AovToAALY2//lOSVSpCEVjkyMCDIdVur/pGEiusXOSdIMGyBGkZSvsQocqQYe8jnVurWUOOXYlMNXiGBlTY4UDmBGcMYhVC3tU3g2IKxl6wX7IC7UvctVgi1Di0ZjOFpIflLSoQxg6hZ2EfrwJfR8MXJ5zjgSoKAqE5Zj7BWffhbzlgT0Xd9bs8GQ/pMxtV6P0X9RqjxDBU6YjgrgEp0DXgV3QMqDkUCBTU+KY27wpluUdXtvsXSSJJ9HvK9W5Pzlc1W3Bn0nC1ie5l2hNgT1W5uqPiNfiaBWVqy2sFeNuH40GIxZjhTkaiFJnfLCzNf3fKGBnCIRUIZAqBld4jusfhjBxuLt6uhAYEKhZzdyqlM7p50qrhl54lmBMoW5BPmWtid/UdvX0I12KmTB9hcQ6Oxyf8L2/kdGkklrBUdqQ2evfIbeYwib9PPXhL0xXT7PFTR4uAqlQIVaPJdt62C0mJNPeOGAvWJ1HQ8S9kv/m6tbu4Th15JIGDaE5zrSNgW3jWixmzBaW4Z7dL/Eged3SBFJb1XteyJ2ZwJUFAwdeQYatzFZ1loble/2IOS1X2h1l7JtK/bZxZr60zpIITr+LgP2XsLZ41AdpE9yWZPNV3gcQypLIduozeOsoIqv91wtapQLWEtt+SZ6Yt1FqTJnVs3NrEFICjCM0iCyyP8FTyD2OAGT1Qhb4r3AJGztzstQCFfHQJawahZwdzauN8ZXbcM+8x9NAsCOsMCYMS7ZYCQPfJQVPReYELxp0mrsR00z7S4bi4fyHijfW+Umpx3B8YaFeeGY0S9qEpCp38ckPWAFJxFV7bfcivM05TXLMwt1e2P5fs9zbZz4bBDsDMcFIHjZTX2wzNzUyFVLKlXu0Up2pcqBCSTs2ArSnmNdaD6fuy7MoKBHSYjC1tZuz4t1YQhuZitl0arIm0kBO6F319pum8VqvDA9+OGCwNdVEW/b1++G2lfzwcRMbIl9VgNFjvU2S3B6q+L+YqzoDikLlvHly/zU2YzNMAjDq3YSGdiWPCrAKi6gADbwNsokxFkn5/pF/+D6dFRXOEawQU9N6DoPiQJEl4FN+zFDvIIznsCieACha/9cdTDcEipnHIOmrZc+lMshqaxQDKGRQVn1c72JtvFFH+p2tp41nrvg1my0Q4IkbdRTWSxNeby5zSIgxN3mnIC/Zl/KX4nASmScBlp67U3tvww47rK5OOKt9ZwsQXk3Huw4KxoweR7RLEuzajSayLSj0TDePQVU/rMy63iafwlJQULzVczwNh5G1FIdD3FoxPz8fzHKFkrGh9xWuqVfvrWWz4wDLmT2f4jpuXpwMJnpPCuxa6bqulEmoUXXHnAbW9tafF1uPEo6/3LYrzHVNhpMc7VoHBs0xRLx9KbloiLD1EWGN6hF9ImczE2mHTZyHgVAIHcTPSqlVSc3Gz/RPrwDgpGmC2gRqvjBYKBhdji/I/FU4EggnbGFkGmNUDHY37t53dpmjrJGr5MdAy5NzCQ=="
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "41A3FD723ADA4FD9F2138639C380BF76CDDB52229A1015BF4D6FB5AF2598D8EA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:JkzGfLMg3/MJ9WwgB3DkKZufKgkFZTmRqWdzlTV/1kY="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ZcgU+atHuioVPyXg44UHnu693+whriyIrM6E0/QTDD4="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689802992571,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAf7yQY7uecFUXo8NQoU3ogQzQDBkamOTwQIK6XftYdqKBeYjyYCtmE8vzzREKr/2hRMYMEHGovZYsIG8t0AlX49ubL1zsI6DlHmAevt6/Nz6oLncQeuJKokTXk+rYj4D63dfJUks9vpLSfWC8n6LJ4sRHb3I44+nZ+H99RDHB8NIJGXXxdMRe6MXxH+ywXBATaYjvUuS/ypwsDJiRHB5DMXcK63j7xpM8/ZzL1WcF2/yNzr7O/iOXhTRk1o32kjhUFRGD0YRTNrrA9W0pb1C00CPS4ockGEbyimCOcBbmb1XKDwJflqIxeWSU7Y11wXW8lyaLdPfIJdo8Wu1PR3l1Rs1RFmyDCRnz5Sfjt9YSoM+aYX5cx9tZXIdYOfAW5KkcxXsoVA+Q72LG1eYrNLDlzCXJjSRWmJTtGZeZaTnyRdgyw+ohBrgJfz+WIcMuK3EY7okG5zILnJ6jFtRkW5cWYLGH+YV4W1GNMUuW/sysDfgswNBbvof8ju6tiLVRcPgIzPEIpFwh5Ya2IeBCE6wM0DuMiZSmmoC0B4qZJKWPJgWIakZmWzP0H+pYg5jh1AYSAsGpdNzRrvt6p6w5GmLyxoSPcUzEV8oWMj/ICjwmPs87YynYpQI630lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSDRrCoHRLpzOsxtNZ4Ws15EPFYGe4Fxdu/eiiJaLhlkzZXwRHkTDNzP4KzuzRBxjGy3k0jveyrq9wzeqvnl8DA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "C8E357B70FA31C94A6125F7D92D81DE5A04DD07BEBC8F7FC739C941DBDF1C833",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:tSk9UhMGdrFNUzUK1aPFZ+YtBuy4xFZ85VevlPFeKlw="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:2AlN73ZGlVFDUw1ToIraEvnVqXalG9GBM2fVYDov+No="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689802992945,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcPCjaIsRcz+XF1ETwW1XC+wS9IlgW8GE+8eMAu0cD7OLQH3mlGozc9MsDfU2GcY9j+wlVwk7vn5c/9SjgWFGMlmn5550LjQxa9km62aV2z+mIp4Y54qRyDLksCG6wBYK8gRy0cSxl3vztzP2qHX0wFAkApwXZbg0fxBRzy9gBtcF3UMBIIfvWJqxUWWT2oBbkDGDfBWGb6pQjmMwbBqZmmhvm0BbkpCmb8XEzYiyQAyh+TzkXm9kRqY11nH1zJTgv1jgiBn/k8pZCEPB2du+wX1nXWNlQYjbX8ePuA7CDEfA9bidjl3sGFTlGOzt/rt/GKIdequplBgslCijfO6eHDFYoxd6ws6Y/HxeRue5mYJC83WfCBVY0+j66OibOUxoSHC18bY7pBkt4G5i/ChWK6essOYcpCBbCl+7NWq1N4LDElJ2uaLuC/Gtr5Xv3BD+WaDpAs93sf3sQjn/32fuKg5WbuGmeAAgcluXcRYMu+0Nx1089QFJs4FY3H73mCaPv8LpGm+FdwIcow+UVkbRjO5kM1HKaU5hy1awEb5daX2EYhZq09e8Bq/FntHp217tcJVEu2cs2e37/X4n+aFkwBef5vvoi/2N6PEsOlrp9Oeirowrl2jBzElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmtwFJuVvAQQWW4B7OLqDejSrNfkwBqywxfDIVEk6lC9IYZcmoB5EDJK/lmK06IcgtuDw1VuopiO1k0NuC5LjAQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts getTransactionStatus should show unconfirmed transactions as unconfirmed": [
-    {
-      "version": 2,
-      "id": "a339385d-89b2-45d0-9d21-0b75046f8939",
-      "name": "a",
-      "spendingKey": "7dcb73ac488a4dee7f83d2450bb293c81be0d84afbdb3086c3c5ec6486ebc89c",
-      "viewKey": "918c4b99a00b087f9f18d98aad0ae27343db86440a10b05d55d4738b5c1cf68fc45ac481492ac688c0ffa69acd909f3c9be93b8e9ad6080d880e8a8acd473ed7",
-      "incomingViewKey": "3b8ec71c6f9fac06c488887ddb6d149f7a9915325fff0a2077dcf7a67f8fbc03",
-      "outgoingViewKey": "86c51e45b202d9e283a20fa86846e983fbc791d9fe7293f0f86d6ae4e94ff673",
-      "publicAddress": "807da0f12b79942ba09a94a9adb9a983ee226accd93a288dcaee868c0bb45bbf",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:gLEN6J+tyRxloMh2IFAPHttBFOblZmII6UtiJTikFU8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:O17zpn1rPygS3Ord2brsEgrDpGbLVOYtzEFhfdFfOb8="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802993798,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAwUhr/2tjlaQ1l5d75pkDIoPnRakjl81si+iKOCxyDrqS909L4S0qadDkrqFUrcmXnI27mypqwSpU1AxHRg5NVSCQ9WW7rwrYKNT/Q8aCd8GmI7gyTkeWQm5hiOuSHg3DU/S6RLdS56uwXxgdoM4xDKp+mMqNjwkgWr6TDQ1IJNEBc4QYXNBCWkZEDwQGdMLSpqDNBGdAeuTj5syO0yZsSSaYhEPNEKe07BoeXwgBh9mLkZJvSOPIZD666tWqk01/uCbSyRajN98Fxap6b6wEu9Vsh/ZKDcWs2PtjIn8VuaGqRAYLwaYdPLFVMhCSJoxKbraSSt0mfupq+7hhm3eXJmyXsn1QLsinoJ2qCaBSEFNJZDsfiVm5YUmgvnQnRVYZL7r4CwSGHwoyekvuUpJDoAOelqdqLXJ/hZW5rn2uTFh0xga26UOmuaBl7s8WSy1eehWlZ4ONoLuPwh7J+1RTxHk3B1JeHaDII0xlPjgYui2l085pN4qf2LtGYZLzlbkx96DxWj8V2tSjk6WrdAddGknqL0G/YfvfCX9bbYPBARSgJsD56dfcphBqGVIDuHxdlOsduOcfW7LFRtY1kdyjjJNQKOwbRaWH6BheT4/8LCixOx6XxPQ7/Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoLoIGZw0p0xOK7+wzLXGmjQjDDkzGVE0LFa5UTb/KT4T4UQaaBmb7JAWwHP7DUa8g/apKZUbW7sq2BvZSuDQAg=="
-        }
-      ]
-    }
-  ],
-  "Accounts getTransactionStatus should show confirmed transactions as confirmed": [
-    {
-      "version": 2,
-      "id": "5e37e2df-f583-4efb-92ab-368fcd294108",
-      "name": "a",
-      "spendingKey": "c25d27a074a5ad92299f3357aa154e27f160806ed75ecd9714f5ece98cc4bb80",
-      "viewKey": "a012b42256e746273a0271c878689fe9e3c1bc4339dcedea44aa2fe6d1ab14838e46a577ab525ebf9e5c080c060d0d5cde332d3635649636b9106cd368628c10",
-      "incomingViewKey": "3ad5a35a5597c8ebf3b4b6f4243e0cc6b75626df918dacdd23b83fed1e7a7805",
-      "outgoingViewKey": "5bd9a8bf675ca3e4b1552bcfdeee5845db0da3460f86775d51aa98a810482d59",
-      "publicAddress": "7a6281f0abab9f42b477ca8990f6d1147ce61e191728d1ce4374bc8f9b0fc192",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:2TLMNPIy1jeJrwHntVxg2j7teVmiNTkCWckAzSS/dmg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:X9SDO5eoLrxSyppl3e/O1CGnprlHZmZBNstINkLhHqc="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802994701,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAHVMc5Pp2zhSqx4x1BtwOCOwzytT9iyXRU9clRu/MfdGiARy8wH4YmJ8eu5NppZ7NDf0ksHPtGZpppWcbhhOeAODT8pyiAzoETwjSD/zpXIWpyDC5vgpldYlyzk2bod4Co/Xdn+YGG1c6cjA9MMDZjtcmrNArOrlYLfXwj0o1wjELMIj7eDgCF2qtTf0KyQgEC0B+xr1X+BD0fSi49Y/kUAyt6xg7yKF8lZ8tXJm2SPiPQhGcoGhlg0QoXqytWItiPkM8g3C0coHbXCcZebgaEBgrsrw18EgIrY0bF4dmxHVuZdUe22JNajeFwlabzuh+HdeCw2TwraehDVfxTvcirswZHv/KIOaYnj+gMvtj4h6q2De+gY9x2lU3dE3dVtcYKVK9gyR0jaPvADSsmpyShxqfJcMvYUldhztjBDCEvURElKNuF7M6XPkILOPjw0ATo2c5IkqD0yVuj1h8g0PouO95xh/XPOGaoxs18whZ+TPL+i8MLhr/okpv9dH3xmovN4nxBX+7O00opwZ3At+MH48jLc4JcSsF4DhwSuDzsLhtgshwehxUaRkrxCvZxiiq9lBjgXToCy5LDWkNygI0jQwu9qMSIS5ze6JvDLz2L23ycjunAKUl+Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw044xeEHgkri0KiyShTRLBCTK0jHwioTwmIxhK4lUHYQm+EkU/R30eKk+WY9sFEZ94PA1F0rRqG7Kclw4xf6DBQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts getTransactionStatus should show pending transactions as pending": [
-    {
-      "version": 2,
-      "id": "050dc928-0298-4bf8-b113-331c37385131",
-      "name": "a",
-      "spendingKey": "249b3532006c8cbd1652143be8643f7ded9d0e49b4692c420468efe9a0b7475c",
-      "viewKey": "84e031cb981628eb1b1dd39a0eb2734a1afda83f36292223718efe781daeb5df8d36cdbcc3635a8333b93fa79a1dec7dea8336258472416eb0b4277e7adfd7c7",
-      "incomingViewKey": "34a9c344bd5b97381dcfcb7a8a19abe3e7ee42d30e720f0352bd9a38578c7e07",
-      "outgoingViewKey": "6c703323690c7f9d4e11faff8b9b1cbda466850b75d787ee632f1e7dd39de6f9",
-      "publicAddress": "629af0241ed534b9aceeec4634b722bacefa113375343602957551ed55d7d029",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "fc63d7f8-f644-4636-951a-3345c3330468",
-      "name": "b",
-      "spendingKey": "ca5dca94b4c4e678f8231dae4498110e2a8672f9c7a7aaa077affa5fe3804abd",
-      "viewKey": "43827807f0cd5a1d1442e70282d7f213f886da2f95c9f271693363537bff7800de22d85920e2087f3666d6e018ed269d464f420e413117e46214c74772899511",
-      "incomingViewKey": "df339c6701be2f1aa5e24be3a16e548d21fe3da0f4355df77100299abccb4a07",
-      "outgoingViewKey": "707e6124665d8f3ffbc2dc6c83c4c03d5dfca8360c61fe24b29833c470ac9b55",
-      "publicAddress": "018146c634dd911b57eb8f813f1f6e0a75fd0f073fc24f675e949426a100d185",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:xj4kOYf/HZGQqwci9+p0LOhQzuj4ziGHhIrxSEKzfFw="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:Zrcml/KYPkF/eQQajqZNQgGGXgzdsU1hQhkiVAIFeCQ="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802995574,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAHHABVkMEUoeb0Ci5qx0TSoQ79WB4TkNJld4AOOpX+KKXozMmw6jr1Hjo/q+VrrsYmKuYPN+aKXangmN0lJ/YLuhJQGVhPD2W14fpEf9GoxG1vfA5IeAc7nVKzYVREruMaVD8AV5GXcRxlFFV2xnwZ8naV1U6Gdtkx86zd2uLJV8Y5fRokPdtvKT9cEDUJQ+I2OcMU2mBX6kWTlTrcoGPO24dH2AwgExStZSfbnYHA/KJlgctQUH19xSiw3FzAUBhn2ndTRL79q39SbhT04hbd4TsC41qa8/muo91DHs5BK288Gez/NCS9UNbruvuh+AZOuFuJVy6zkmY9KLEN8EHJL93NzKSFYNx5LK9qy2Y9MyISGCDGbSzQ9hoVyxaa2hfiyuO1fTDa61bdx4xfdLINyorja9Fygh05lQ0rxMZ77F+Qo82SdB46qQUkOVCVrPLJUvZcvAZK/6VPuN67t8GXXDddNKmFEANKzSRo3IWvgdUJtWOQgK/takFuNUxMmHf5Sr+4Hp6cUq+B8Ae7HI8qjG3kXukYxTN3134SinsY4CYR1Hf3nrJwGhgZcqyQaFcpWGGZYNgsBggMAlrZcn6Hqow0b06J7FTJy7KVuRbzV/13JRB+5IKO0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSGtb6Wwq2RE3NKakIu+2SVa3/sDpdPl353zPwHWwW71dAQnE7NvYifc0z+QLnjxFSk9NJGqafjmCouL3E7bDCA=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVsFCMscE/byopG9W8bJLo8g8IT0Gk/NysOAxkL5MOyGEAAkSGZOYckVhe7AxZhYuQUiiWjWNyIltFr7/pMnHCO7Sd9r32+bBEiSLjC5olOm2WMJd8waGRAQI3XwCcn7MfyW/5hAdYmAZCLoFt4xY0J+c3TFHy6eU8cmzOpRs+Z8Itjd6rh2jocCQTo2QC517YNisiG/cC4r3RuAmSfrQza7ELPxqTEJrAIAPUpncCkawqicffrIAT1/mQcvTsISIwXCOlnn+ku4mHt7GAUGzv6Q9UI+ToGTfjQvHzshyoqrpl6qru3COwb7jxcsEIBQAqr08tYS8/lXq+qjmVAXSPMY+JDmH/x2RkKsHIvfqdCzoUM7o+M4hh4SK8UhCs3xcBAAAAFKOXki0xdPkMDgJMWR2jMJV8pyoF9TFs6mbkrxi2wYcw6MZq5oabPjJvUXb3hM+DRl74jQoXE9h7+iybVK7mNzAUV/Te/Oc9LZbNWIRZcY7jIrmmhrzRsnjeNW/HNCsB7iIgr6Ki43RMzBG2VFVslRmiOoe13xs9z7E2cYTuqd0CvqhoW6WXE24HXOG5FTT768RPZgGnhX55n4sQF+z7bq0qUzgq7GqOwNTKv8f/JL9RE+1O9gwwG8EP6GfyhSowwIJsyabpb9qPKfwfYKpnzpqkapijb40i4W8SeJeiDjGskRMDR3K2DNA3mT26OHj/qpLIOJKmbDJKg42ZS1dkLHkojE9lkhUUaW5Y0sfl3qVoYrDtXqZy1k466S4X8a2WsYrlAgEb7PsTC+Tz1caKASlWrNIjPIaqfya8/6Sqy6cfPAsipf/yzK9XNW7kSsycZLnSXww5bAaMYvYtXJT1QC3YKSIHNq5bhlyDQnaxIPh/PXrWq/fR2mHq2uzyim5OwsZVWnEfejWf7gYjvGpHFRyRPf0K+ncXuD7V1m5PxqMd47X1k96afkVMcwBY2uNv8OiXzm5i0Q6pg//LjG741eaOQsPbZvPIa1WwfVikcJzm2cWnqa3bIftfPDxMGrHeD/xb0sSsHQrZ7rnV3taQFkIlPE/91sOOIJIgZP7h9/P76nPHMIGK0QoaBxP7UvJG4vwnTp86ta/sDQysSBdngwtSZAGfCbZI3f94UI58bR4jgKAOGl7eU5NdrLW2CiSva+F0gx8EUNS2UHQDU5nSAv37M1StDiG+ZilIfcuZgHT5Hr04K4bQmik8NXv4L9QQc7jrt7YzqKEcp0p1oODF53Xs+RrYLn43sBkr6HzI8qiMpbRi3BetvGw2HkzT0M459arHzzQSkjVXm2+a5IPeoknS9MqcpUwTAgggNrLVH3WnO6F9uWy9bQToHSKMgKo1TddKHpLuHgRtSQdORdT3DIQWhW3n3jXfYC1Ug5FVK5fE9SR10XkkFKXwVY7ee0+GeD0WLtNYOU8sBC6bspbMlnrmxtqaIQ7owcLzgkcJOJ025Yl1fjDQU2tFPeUNXeopL+WY14RHsnu/2/6JHX9RuEEAztfFfMvENTxsYrMJs70zFQkfvK+EKDlCxl2UXmgG7L+thEk+I8zuOcnobdPjugtgGb6HmIAajSlh6Fg5FH6qPtHdsEG39+CEGIU4DBdeRo4VOFY8b90uhBmWPKkU5aiwmVMPl7nB66M3XIEaEDaIn115V3yLtUAAyiDBQJIBmGhRf47MZiqBdpRivkOxvpJoMNf87V6t/F6JuX8ZLVQoINJKIOcW8hXvPNMUYjf8PAjUZ4Sy0hrExRfzT42lbo08f5f+1guoJI4S1zlcepW8oyg3w9IUq+02c+vpWiHDzJonL98mxBq53Yx5T9jIcAiwewNqK053+qVIKFNeiJJ8GixzLs7qJ41GNvXQgH8QDirgLIR3Kjc3QVNljaGQvjs7rcvkmG9YEQ31LJOt4+fFnIZPLXk+r8LAoTaQ7CO18Q0/cQ2x1B6OjMyOP2Ecp9YrbaIlEpKvOr6uVO6svfMDPEuPO+6aFK8CuV5oCFtAQ=="
-    }
-  ],
-  "Accounts getTransactionStatus should show expired transactions as expired": [
-    {
-      "version": 2,
-      "id": "02cbd8b8-cdcf-4b23-80b0-8e28b47c03e9",
-      "name": "a",
-      "spendingKey": "9931b0ce0018dd8366c2178dcdf86989a353e2d0613f9591d50a49663b1e8ad4",
-      "viewKey": "cd17569fd43386ad3ff995b9f272ccf2f43c4efe05bd8ade4bae63105d930739b2354bfaf0315bd04444f4fe22d280c83fa19996b3033c54e8b6109e4ddadd2c",
-      "incomingViewKey": "e73601967065c346028790c0ed7384d8fa1ce960526b1e2571a86dafd84a1400",
-      "outgoingViewKey": "a6522c60b57256cf7484709ca28096511ed48343b87866c7ea4d4af2ff3f6884",
-      "publicAddress": "8dff72a02fee6e4e641c00cba8b43a89acffb4611b729a6819ba28a83cedbbd0",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "834fe155-37fa-4352-887a-3369f4084820",
-      "name": "b",
-      "spendingKey": "9370d3fa9b4497a330119331d5b90de401807934fcce9c91cb8ef52d82f0928f",
-      "viewKey": "d5ae053d57808f80aeb2e0210832122c21cb7d379f8aaef4ae0a11c27454c16227771bea572e4a8fb4ed709fd34e9a0b378ccdfd3ce170bef40796d2502a6466",
-      "incomingViewKey": "8f9ead77b3540c9c4e434a3145a814ce8253c623f3c2663468b5ce91545b4d04",
-      "outgoingViewKey": "d39a138b8244a64527258ce0ea783291202868e83d3249066bc7caa62faf62a4",
-      "publicAddress": "cc5c6c096f3094bea462f0825e786381cb5a2ca1ae092951dd61575ed67889cc",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:H/1+mrH7u5KsJZgNyIPufYhno7ggT5jQFp11A7+avEM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:Wrm0wkrW7/QOStu+nu5iXJH0mY1SUZnKbBmD2LF3K5s="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689802998063,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABozEBQ0CcbFiwokB0e9SlaAt7gqBGoPgVgA92LmJWzKrL2aYuGuG43nFFICkyT4aWwu35ZVEFHkPA5Xy93bTbw9pjvVhGror5B6DiP/Szf6if507pluuHV0wG8UJOasiA2V6wXOLfvHlNsT2aZv4s/0DokgoFLvi2dEYYaY7ajACuzB97buk3YHrwWq20qjhawvF55wEEGGpe7ugMx7FdFVEx7ZJCkepHh+V5Ve++cSgLUdgw+SunB4H0e6xGjZlIfmmQp7G8C4rU4JqRaHvatWxsTuyvbXLgW0gMlj43D1hKK3PGtSdpYTYyjnVOa7z7MnVzM7fADfZJVpe0Z6/3VWG20ku64ncbRFT1AUM4m6JcjYV1VOL8UtUSKTx509pAVNsWZ8WKnBvtA1bZKieZsgzGexg/rMCUyZLFuOZNSz8d4onNIvZmgZhh7wFcb3w5PmZtDU9iAu6PBUCKfMJMrV/BToEJr/Th7X/62G2Ed1AEswE4Ca7McmCqrTpZff0zDyXlsNiO7FlNS2AjOVadyWXj6EA6+wOhoJra/RC4CrqAR5oOJn3jB3P94AjP2SJQYCfDZLBjKPG3GVL6m3wZ6s2ndV86WZMFBq81Dur7SVnvmPQBTxTIUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwox5fDddNUmjjpt1n5N7H0cJ4NUZCVdovXm9EEhbuR1Ap5NuOsQuOZ4+Ls4NaQEudCe3Stw6OM7QGrWCXYTVqCg=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAGruZ8FhsZgPVAuo3c10MaJy1L9FxZU56NIRhClvsDxSL3ZyStTxNQGpp2Kctuc4ssanprd15UgP59yLaEBkhIFP5vEgRFGpSVAgq55OlioeBM0uv2QWWKp0Gw31e7HBPWOr9/cRYwdhcGwBBgwU+cLzI5vCwKB5qlkLbeecrudQC28HaEi2BqWB8ncDHe/eLU7hnpdHVvJFJSJDjb6FkYGtEndg30cLon4sMFyRnGL+4Um1OM6OImLT7cy60uEnJRQFFev/SlDrcLrR7+XHk5r2qNYPjHGCcKqGiyv2hAsJ0TjCioLk8iszlq23OVyXCGr5+gXkbOtBkbd06Y3VfrB/9fpqx+7uSrCWYDciD7n2IZ6O4IE+Y0BaddQO/mrxDBAAAABC6X+tUhsEuMZ0syeAdSChYzBGeT/N6YEALevBeylZxd+28Nk98bpMh7pck1inshwWaBSJi4/mJAXdReJhIMaBDPfiaNm14RAry3rWpblMDO1c6QMl88FgJjzmX4UvcDZOBqfERKSFbJVdx3Jlw86DKlF1yn/NHG6+WBbbytFCxGXpXGoRWKwXaJDZ0mz88Bq80I3o26aHuhY3X8IJlZGdEytnTH02C1XpXUAjQiH9pMKSa0CxgSyck5jNdmx61HwnuTYvXzo6+oJvvmX3ux1xPNSBPqXSUPW2zqBFcm29dlcr7lpwRGnZoKJGPBeSkY441agXAOEIA6RN3hwKK/qLtf1x/HvGHXCpH0nrIoaccDd2lo8hXFkP8t/z9+XiuVnNrsCXa/u8M2c7DMflFv0+lS+Fh5EyEb69FA1LAPTe+3VEo7a97WBXN3W1NqNnKpF9KNHAAtUdn2Jf6hHBT9gmBHso+K4O+5jaUfXxqpMfx0mmY34DZSM3tJXRbbh+LNHj3Fq5DeK+qx3ozCq6kAjB18KbQivYHYjUY7tpmivrcvsdMUBc5s0pok/liTYcGUu3MQtlOOQ7yqo1ETEuh8cuMDLwHDYcVJSvMtBfTgW2nRfBUKvVwvuspS/FyalNaTlDMp5RyRJbBocr6FDz1EVp1u4hcn/HmjgkToMtY32f/I1pCxyrtKF3rklp7UmOsXwNdESjodvR7kFFDdEuLM3K2nyO9jGooOx0YvV9bgVqoIkM/UPXa+J1FvDV1FGZbWoWhfsbFIUSgnhDOmLk6R1ztxVPembnXBMMgwamR4E0RaKnMvF6aI8CM+T4/xBuVsxEiH6yCSSxDqtR3CAOLLoXydigc0quayFrwR0iKcXjZsbz81MfHtPeONzjsSvlGYRVMJAsnTiBdLe3qYkqcRiW9wHdrTi/mLA1kdXLthLg3IEKYsRGVG30D8XyscUYS3/W3SFtXrBSa+KH7sTpQd+a0aJ1BY2zsbjg8UvqmOxcBKEZWrav8+mSOfFVeAjYVjWWNPYw4cKzhgoePkYzQkp7liCJRVTyVmQdS4H748y6Tp2a9c3HeeQHrgYGB4GT5Dx93PBk74uOIzYRzV5NYAwN0ee/NtmstYNvBwd/osSjGVSkZjY1Y7yG91fGnHes3sQeXKVi/yikGjIBMfJJBREwKGO4yjz5cOyNGuwBujqih1CV2xKksV4pZaUa4jVjp92gm9q/S8rhRJOp1GJ0BZ8qCCQf4nNqsdKktAM7g56/52tMBhxW/+oJPNApzAeN4ZgwvRFEeux2wGfu1qec0/7cf58+5TozxZRqC679GVousK5WXWu3TPzxWQOoWigR5QWU5Lp5SAd1Nyrtbnu6qVFB64uxoKzOlyPI8XbAGVZFek3FTpP4LuKr6IjT50Sw0LdqGdGuN3igcWPdO6L6WuolWzjYiiKVooM8rFULHR/eBT0eNUT1zoVbGfYfgAiEs59CjyVVz2duPSfLqcc6diUGExC0p3fdYd7g7gvSt/FkgywtqTCNG/Oj6BBOd50yh1g90RGmD9tmSjns1yCg3ND/CbLiGaQWEhgG9D1F+tgbqyT0fYn7yj7W3CaCGjLHyDA=="
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "3FA0E15C3E40B901A911CCDD95196484EA5E5E14D57B43FF984507A2AF23E790",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:1AS9UcIT34s6s2/0WWbTHUp6A0Ncv0PEqDiGLACbN08="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:V7Bh2gcOw92Nfjuo2alvlb/6v139Ffrvc//sPvH5APg="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803000176,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKMEZF3fvIJQFEBWJQ2fI9g7WfNF3gkLHcscvw33VqRSVMyQJUqqRdy4oRj/pQRkgv7rQBrFPS67Exuz9i2qM7AhMlgSttfe3ruePP0vTegCPnhF9cEwqap2PM1Yf+tjZq1WPVIig6yNnAsVNQuMww5RRYMqoPpf5omRWCxXRpKcAcpWQQLSdNO3FXUhjHsP6bsmcO8EvfekmZDGeDy0gCsD3B1Gc07TgTX7VnCdrMNOAU2So0dYPuvJC/YIzh58QU8c4VP/lNtqajER0ltgeRM1puMyGB1nppWIn1RezZjeUy4ovNKZUPgSyabvQQsMjiqNoquzSVe66bJ8KINqBvK4sD8v7YvjnzdB6yH0LM2U8tEELl0AGzRDAB+VTrXNXJ07jinoD3PAKqnYszp4ox9BYnywnyaIpvZSV8ZXIcwwUQ7gQLD4kVmdzX5l4U+1jHF6E0Iw0lYKopJrIh5t0GgmH15F6+N6J2mIxDwFRRXzAmlmvNy4OWmgBbaFHlZt32WIwHic/OYUQpX4+Lu87uctzurB1XcPVTsgarE6Qr4pzAIakWkPTUH4zyCYHm6a0ZBwinsMSMQ2PeuXCHMjoV51zY93ewMxogjiFQ2bX55VlQEBvY/x9mUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtsVh6XSU9UlIqkanCm7dOD6IIc9UZkm7BxP5iwgkTRPzZRwo809+mSudEeJtEfGSEZaBCtBnC3eo19KNJjIxBw=="
-        }
-      ]
-    }
-  ],
-  "Accounts getTransactionStatus should show transactions with 0 expiration as pending": [
-    {
-      "version": 2,
-      "id": "58320cad-d76b-4df3-96d9-75293011ceda",
-      "name": "a",
-      "spendingKey": "33d393decba0e0868641029180f3ae896d9c88cf6903e53b72ea478fbef2a267",
-      "viewKey": "dc0d0108362b873145a2e74ecf63e2039d123495884a86548a6400c8a86ff5694ab4e36524d4958676fe163a6aa35b2b5200c84606237f1870a4d14f981c9b37",
-      "incomingViewKey": "292af2e7472d98618b840ca42e9ed6a0521a81a5227023b010c2807393aabb03",
-      "outgoingViewKey": "7098ae0e3de993648645423e36da1122df435ac2648caca84c64bf0a145368bb",
-      "publicAddress": "6ee2949880dc06e1805e4fab1283fd5284740cd244069fd9b8132dcd68cb5204",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "93323f17-798b-44ae-bda7-fd9bff1594f7",
-      "name": "b",
-      "spendingKey": "54c8a589cb1a1aeb7ccf7de8f557dc44a27cdd06073a4c025c19687cb74a9640",
-      "viewKey": "0cbdf3bf755f58d04a3b4c501d0e9bd093ca42bc4ed28d5956d488dcf39e113eba9fe8e60280c210c59fc00de749b9ed134138812fe5ab53af76021f3ba20f24",
-      "incomingViewKey": "8c2dab2b82ecef00ce7763274d66a1e281fcfbab6858d36fca3627650e2fe902",
-      "outgoingViewKey": "e44a13bf1e67dd687e5b9af2e595df919ae0e7a0c6fc95355125dbab21048c9e",
-      "publicAddress": "a6ff33b51e56c8e5f5e99fdc82b80409f59b5b0b4e53fec8956ffff459d36b66",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:lz/U67JSzOCmH3PVR6SESj+Xk5RJt7U3n/Cl8WhfgiA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:La5TicBluxAYU6Lb54s29O95gu0cUAIWGb65nUKDP3Y="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803001076,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAANWuMG/K5rXbke/jg68ARPJtdbxQw1QkzytO4SgAddGaH1i2cbubO1T5OGSAVLGKiRFXF3U/sREZPsgGdl8PM46pSfTOnUKSLFh2Yb0S27tWKZ+o6dD+IEnpV9P8ZwxiN5b07p+9bUb1iXRnC2XiUiP1SOZXXZfD0vY/3m9N9L4wGbRvM4fFOPfT17V4M1eRqCi5NbTXC7rvLrOAtV1CCkUsDoj0WqfnwuyutMauIFoOTfEuXxAbMo/jfL6tKQ5DqixDAzVIPTQ/n49+ouJ5qcGMqO9B1A7sQb8xXDr+BmHYRBR6YkprfLVb219yZiYcD9wOOl73TRlYf9UQ4Oyc4xs8cOLbAY8F+6lj+KKP9vrh3Y+yhy5wvbrYT8q7NgcEUbkcrGALciHbOdt688Uuc8iCq1bWrKo4yvRha3BaZ8RwMFve++kyJHwAjOIrV9S1fRI1BazI+YXVgTwx6JAMYkB+mXGYRg0R/VFBJ9+ZXygDqDceE+7AHkjxgx0lImJcG81F57//YRJZ3OBv0O6kRIsjpYYu1RH27WRSN/Yheaj70Fvl7GV8GVwQlEEx6SSh6SybYa3+4spfQnD1UBvIrXrEAVeQ5f4Y1AtmiI2xj6hsEHBYkLwLDC0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDzgwFcWcHpOZTaNF82Y9EM9b27t1ZnnzIUq6F5o4aLIUlvXKaciGpCOcSgVxFU5Ns+rqgHGC0R/x4bjLB9vJBw=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6qAQtSathM21SLEKrjwiL8UjZPlVIBY24Ge+hC8L4zGnSRNrZZRxqYeiZBaH6B2HhFnMtEeSAgeo/nvvuRaa1UVY0hQGLRknQKP1reL8qUmRGQmWyBCUdxuWgUz4CgIdAZUOytWd2Kw1ArdSC1Qisy36tKdagTDtbQphrjCOcAAG2TJ7fI+8RDgt9I0/g5txiW2uSNr+8VqJfYCvQgUiYSlW67hmLpllASbG4Cu2CMWn1OXrN6sl6WUUcl8V72wUvUNv3sUcfFZotiXjtUt139iwTRGI+NO3ZHGo4Y9sgFTnBihl2iZKqwau804ZemCwlON/7MZyFKrKUKFMa+w+2Jc/1OuyUszgph9z1UekhEo/l5OUSbe1N5/wpfFoX4IgBAAAAC19+gDeBN+r0t3uQucSkHicy20DN7K4rlgTESRUGv7ozGmLH+i5Zo5i2+mUiSrTVsO0yLn4kP3JvkfF5wWXReZxnZp9yN7kAiFSiw/Pr+dP77y2p+8Y8yRZxXUdMYyHA5cZtLT6iwf/fG2PwxdGtyXDUI1EIjhts2DrBgIhuoy4RWEmJhe1NdBIQHRpM5isv7NqcaL+vw0/zqG5U5Gq08apnZO+1wwTelzdBPZFBirYtpLlTGsvQjEJEiby3hqtNRW7nW5pHqwuYxtjyHYEnZeTYs4LMry3V3vMB3Qb7Wq7B3oUsxDbiVeky3yaj2u7TIbwSSKYcvUKZxH+sHsSOcYUhz6wR0S0C6uPLYp56PM9J/FLTEzkt1AA1q3Vf9wNpmWL4xazvAsN2owbNcaIXD5o7E0ZjAFS9vBoH67u3y3okCpSlBvRVnAMeiFYhcezQEAe3MSHrE9zTZp0WmgyFFfToL5IufrIK6J0NV0JnAHKiXAp3G4hJ4vHpAWOWO9aiGTaOsBZgLP+rk2PVzgLU2fuo6fMu0OmaVC17vUSyI5FlG/NI3QO/9Ba74y2F8jx1vbdtGVxRVCAeHL/aJZAh0zNo5RS9UysfFFCcDItL3Byj6GeKGdJiqfElHBWWq0SbDrK67STfw7Jsyqc6LjMetURpFycKTTJhLai5XwhuUSr3Bo4qixxjv6sYQV5JxnXN25cu0abip1jkMC2JyvfNleMBVsFE6AOBw0LHE7LLK+Uc8YonNV9GVi1xQdTFihvjcq85RCue5H+SVkxovuizlHY+QvIt6XcRcTOTpfPvGknRjZfQwc9bNSiZ4xA7gANcR/7SZl/poGrv5bm/KpVY0m5h5/AwJY2uTFJPcxKl2OHtWw6TPdeh22v5jxDvnrNf9rjyP3VkXQu4KxEdXcSL/KSFnVa0UuisKgu5QLJQVBEH0XmJKZM0PkEw7et96k0IgJPOjuGzcfNuj2aj/FulEX12oNuXi37irX+RRqmXx6f1D2yffZpoNyECAqyYwNdp2uASlbF1LL6y1tZDLMoC1bE+XC5v5RpSPFbErz2LKxjc3LiJEumIOjWElzwn23s7IHWO0ti1ED/2JHWYC4Og3y2yG7qHE8At+hMSEC4NSER3f/jxEC/hdhcXV92A9llyW+0WfeZrPZeOjdBpO0H7QCKeT2Jzk4tejf1su/mpsf6rWAz6Yt5csefYnixothFx3AUUjGZG1WxgBXkXOgJ9d6w0IoCu5UELH8IlT4r1oUOp17BPob5w/2Vkd8UqY0j6jHHgxmOEa+x+AEKZg9xCW6B5lvYBIgh8nHi8l30ytfdtr0HTuRijb1Ndbpu5YXs4Rfgtw6RJUvPOs74VlCtbXxi7Xqgk7fX97Sh8OcZYA3p/fkQ+azvhOBVCM5yiLCaYw04+2g2ryAjHPry4S0WdUtVqY5kTt2i4rBH8ZAL2id9GgrEw42lhuOKw5sUtsUXmhWEMS3peO4Dheo5sncTSjQBMxa1AqvCj3PIgLwcOvSZhA8sr6Rg7UOnta8RB8Ian2F6bGHhMUBBKmruBzMfy0YDF/z6tuos+HJMM340txN2b2ZE5bAzCc3jSC/A7sR6AA=="
-    }
-  ],
-  "Accounts getTransactionStatus should show unknown status if account has no head sequence": [
-    {
-      "version": 2,
-      "id": "d91c25c2-dac6-42be-93f5-38c7bd32334f",
-      "name": "a",
-      "spendingKey": "c9db7be39712348774e3711e5d0267884ef125eb3d16d5b05905586123d585dc",
-      "viewKey": "36e5362bb899a2caed4424ac3908cb9ccedc6dfb460c9081aa7005d1910e8234061398e50aba11ed38fd8580df70e8c44f349e49c572a9fa95989429cb60af34",
-      "incomingViewKey": "f032ee5ca0224699bb988db3d2ae038e1f75edd88dd32938fe2152120f3bbb04",
-      "outgoingViewKey": "91babd47f1fca523e34abddce2c29f8b941e2a401047998f36b8e109a574a0df",
-      "publicAddress": "b51e21ba574c96311857e0d4a9171d83c456fa11896b3e3440ed324bcecb19c9",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:AWdd1m+Em++x7qh1IGacbuH1hSCXFYUaw/p2QjnObgU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:S5G8KcBORyi58CLe6RtJ1+ECyL07alxoweLkpq1tMfM="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803003650,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAsiw0W8j8s1zF699y1SCAy8COBjeabQOgzStOfLdpRk6wy5nL+gfvCIuEPWZPCUr7c1yqW2damBSodaI8RShIArJ6CLp964k3TNBupSFCY2C5QAolzvUHhyJB2p1M78wlhrNNWCfQS+f1UhaJy+ZztcKRegv56ER0cZzIvOmFZo8LUX2KLJpQGZxnxJF1S9fsptfOvA9dOwD8AY4MycEvSSw6qfBS3jdjs9iYzjsy32WYCWkua5XqA1PiKEDgApy6VIVn1khb5EDafcWdnUVlF8e01WOpS/arpZAps6p5bLXeK/vM5zkOc5IUNfZPfX6cosYqbhek/sbsCtBn9Eb23rZzdVbcmkAPAkF0mNjMl4dHA8PhttUqYwAFICUkutVGlivXCI5eZytBTuxRSqK+w/fZZghVGUganvg9YrfV5kOW3k6e7baKIk2sm5mK8NYHq2SV/3cgx1XqrSWxu/NZHhytbpZNp7C2Pv7XdEQxkH+dUckAXkGz1Oy/KryJEfUnvvm0O0tiIqUSRXHm5+M6uFb6FFzBzadD4yv7Nmc0knyeOvr9V23Mx6Ns+x/Dio9tuc6DMy91pgEODBWvl91s4SZ6OqXjD3yDHhH8c+d9WZAmRy0Pai9lvUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFi4j+msQBq9Sa65XOVnA/04hf67s3bTk0NzrVvWbkRlEZ9l+2I3zbzvlrknzRvoZGLA1VBvWFZc0OXf0RF8/Cw=="
-        }
-      ]
-    }
-  ],
-  "Accounts rebroadcastTransactions should not rebroadcast expired transactions": [
-    {
-      "version": 2,
-      "id": "dc8bd0f4-c813-42eb-910e-76edcf9e4b5c",
-      "name": "accountA",
-      "spendingKey": "eb3032002192e5fd1ae7b3c61f733acda0b6bf340f23ccbfdeccbf5b0ba6b44a",
-      "viewKey": "75e819549f9d33c82f45bbeaaccb52e2db05a5d43fbb32924c8a738ab85844cb7c6a5d69f98064df925543e243a500db5898b1ba7db045972b4881773773bac5",
-      "incomingViewKey": "b0c0dda27abedfcb61b001ad94cdcc5ef503ba251e8caed6e941a8f3f7edda06",
-      "outgoingViewKey": "a7a526139b808aa27353e92c35ae83b4be8e05ba520beff5d4daee81bc1b229b",
-      "publicAddress": "8650042bec22ec6b6e248c2aaee9b62a910acee60dc854731ea5c4c082063e83",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:rgNw1O3yBmU82MJZ9Rf2Cg0NbnjlWnIuUoPWNPt2KAI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:Nn+MoRG4cc75UO/nzeeFzxvh4wX68n8JhFXCobYED8A="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803004505,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgsutbk1T72ckaBw4kC20rHmJqT5eJUht05jWj6NAGIKIHSIxLmwn3UvoMM4uX0lg5uBwGDQohQb/FvCN7+HghzoWjEqledfWUzydGqW68NSQaZ9HDx5fdbzqcWzUUwThzZkLGV6X01A0KNp+DWgEkGXNv6nW8YzYr+arjPPsC4gA+sAYaQkFEHyFo+OlgQWNxMPbZIVpGij4XJU3qZNy4x50iWVdp1C1OVOljqbrWzuCrc4Pn7jpR1VeJ+3P8v3+kFD/QZnknMpK4QXoULw/9mo3MICO79KnrEJKcqzZfEV8GgN9bnVG3H99ZWMf1HxDxmihKcD/9YlGm5mvhB+szOlaj8Q1xo/OHgZ/oX6O1FuOlhu8vwxohKw6CaOI1JxvoprNdpD7fDFu+U1MdrdLkHa3Q0VDTU8Am0rrksrvBjxDajqmB4VxZMCYvU07XRnoGhb5YMxAuClwZJFy0e1RupjLc3K+bBml3EKeNDMqNJLyVJnKbm5V8SUF7aPb+twXecAy8+Ey924lnzd0DEMi4Re0nj+fbtyBrjdYXu83svPEKWSBVGbwdT4uuZqP18NlT1y1LOWgHuqolET9GuUW8srNNmSKgsbnG54FT7mW+0QCFaf6QywdqUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwPsUyyEzdM0dOa2f0GwQdHSHj1sNbMHepfhpctafLa1zn4BBjjIfcJhTunjYok6lHtiVlorX0heoddsuA90tTDA=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAwGhh9xmTJAjKTOnf0ASXzTftisxSgMK6keh+UjRBsYeIAtK1GUjPyVdmfRZEfu25JEmLljEdO30c9uURuJHD+VOE53qUYdx8quiREuzV9quN0yzeWiX/NwUiat/VfaoSGm1N2jTz+27czpe4ozzps+xlw5beYCQ6TaVeA4cVVl8U7EPD7aVl4EuoWcNRProgZaRtZwPxWWzghd54PvyR5BpRGFVf76jdWSCnOgs5b7mYMBswRVQqrabR2ZCOA3MFYpWd0tkXDerJrlQg+OmTzfaDcxewsypQsJrq64v1tNquolZH8gdwySU4jT7sl1aLrP/Rg+/BsclyoxKxTTt1LK4DcNTt8gZlPNjCWfUX9goNDW545VpyLlKD1jT7digCBAAAAK3QZfLb45FHCat/61xZwALuerfbBMlBOJvHIzpXv3wyrGhjzkF2XTElxFOagKNfwwOKPIJYw7GnDbPYH7J/e4Hk3IP7KtE2VUsJGwyQ1q1/J9yGHo9AhMxKqEsPxMfDCIalYpA9bSxtKrR3CTYWPPuWjv17jDnblzlkmg/xLMUJjPxpoYN2h5yze5KPZra2k6PZ522AXBAWEboayY5x65XNDxyQDAQ2GjWglPTarjUo5Im2xh3bUDDLA43zeFHZnwbe4wMnx4xiDPzrv7l+27We0hXTEJkLTVy9eHNsmLVuvW0W816s7poBAS8nBWWuSZinGLfcJT2wCV8T5JNS5+3zyqvDm/TQqth6pcY/FLMVMU4d2fLRX4g9NUV2vPYwverycsEEif7wa1fQ5WbqmcAhX7cUrpghnPuKPRjMv6HSobkERMnhKzYTYXJqFoBRDIGREn07luHFIcbzgXnCH0lZzucR/0+EN7BmyY90RX+lRIA1lOgKiQJJ0jjoGW3dIccVW04RMktEXHfitADvJi1FJuso3SRElco8zf4BE8Ky5JvzzQ86+S1sbiX0+QnywsSsdeiR/uci624Tty8MzTC5HegqX4UvAvHWUV5FeVUo/KAqKcKRmvd544HhZz19dHW7aMCvJPlm9+h8Cl6a9LCIS3PF+0fcXGbFsnomOlrG0usCdyVlthIhGo0yKJzrVV4o4vVPm6fHpglm101egqRFfSNuK2DT8r8rt96YWzX4r9gbO9xsMAYVi1wvZ1iZmzokKGAbnNL9ieQxUKizDnAN1TfZ7Hjl1YreMnYLsbBS5MpesI8rWtiFuFEuPaVVmtFp7bjGb3xtvEpIcwWDlFip8nYHXXXCAh4LudOOCdm2S33qdb04N+OXGOcQRukjs/kEd1YQh9uJIyUiwV7LRL4WfUteypIFkAkxN4UWjEurSyZEInZGSf0T9VddWmG1ybzEseoKyoeW3t1wdXBmSaktgkw8EFDvx2wXTRqxIzPwsfPBpffn08OYXn0rUY6s+uBkNhxHxLjiHeQg1LByiI0e5oXfwtfrY3Dh4j15Lcj7Qq2DfCtaeo3Szaxmtlps1De8osWfqUmxFismhohoWBqs/yUuoqeoYfxxDexECNs85kTtQ1/71tzOj/3jMFfgYmpDjnsx+20+XkSJSjkRgrj77XyST7jmv2w35mZkcj/qnSfKf9qvhcz77fRcPxVD5/+sLxK1iozm84jDkhB7C2cY+/fZJ8/Z4eydg8jZ9dGIs1DLf4CX23pfeIqZk9JFvO3pjQI5hvz5T0Y7LdNxXBMOrSVwye1iGXjzk7YTFmQW9NXjSVq3yJRrLTK6SL9BggqWRRs20UJ7Q2FwgU8LwRF6Ug8bQh3xzeTuurP4L4Z0fV024h7ikTbTUcNIY/NizQN+h5OO2JVZ9X2mXoorgNXREO0CpmHlVuJb9OSeh+rk71q2xUieQhx9tmpdDgMMuzbGE+r8OHaMw1GDfYNUu7dNHBd69AHACxchPmY5Mdo6A17SnCnxaV5zUSDU4p7n7OMiXTbhAe0izCqkaVZfvyANri+anBliQKRWxXdnm4ee7lGz5W9mTN1Enz1k6pAVCg=="
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "6D48BCF1A3EEA69A177CDF734C86D2B85B178D71D161A40335D407E6A8C7F70A",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:WwVKB283DrfwmSgexB8AzIdiXYvCXJZT5rqvXwXsW08="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:J2qohAtOFm/feHJ75oqaMTxyEraW1irCQmL8BeIADAE="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803006508,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAmjvx0ykmb2pNmkw3qHTgnQzvDGXFz5b14QOGo/2mvq2H+Kp6MuImQxbRnt7+CSXy1Cji9yzmfqc7VOtFFWBovCwc672qMpsuGAG8/AEkR0Gido3vq6x33YyCSOjpyibmZEQerNApcx2oAXa1U/52eSJ1wUZ1YntdHYa6/QykHCAB5DxhurQFk2BP7urRyemSfGFaSVVUV7+mEL7OHG3wzMpkPnBMfnNgeBxN1qFSI3CAX+JyVQ2Q+uWyrXpkuDzb7KKxNpDGuLT4UuaCiKd6tl8ABD0pYKknJxaSexdu/FTClEkRDdVpIvc6I7Yztz9RMIvlLwnCxpzPEGebNjE+WSCijGk18KI+liWL6Focw6NLmpb0autqyrsKvoAikExIHVcyqa45CjE5G8SvA4ppjCb/IOs3yUi+eEnKbpP6WqWabsGO6S5JWKX60Nf0sAMLGLkvrqrjkIS2yLkptjc4ywGOQL2yT1PPq7QJGPqBCY9jkYa2JFkpCnaGmFL0WOvrPrW4HMmgKRaZ3TNHtYP02WMVL3519kGApwGVMua2mliY+WVfFy5gP9GlYcqa50HrkGqvN66NwjBDvZohQY6zt3pkLjS7DEa1+KHSRiYIlpG2fnqFcZ+5x0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5brCDedW5j4ryxgMJ6DPXq4+AjxfE0H7w72G4+IfL2T+J101F8Ps7Xw9mImJaNtHLZLpDSMYO4FgY4VpZlqOBg=="
-        }
-      ]
-    }
-  ],
-  "Accounts mint for an identifier not stored in the database throws a not found exception": [
-    {
-      "version": 2,
-      "id": "051ff736-2cbf-4cd5-b590-5aa049ff100b",
-      "name": "test",
-      "spendingKey": "c0f530894bc7427f96a09be1094684b94cadfac8c34b38dc28abb026bf155cab",
-      "viewKey": "0e896cb04e16e07d9c3f6b69854501ef7c70073b7845ec8052cdae04a486c0e613f3e07eb86a20d3eb61bd7c30677aa869911c50c4d3772444ffb8852ebee559",
-      "incomingViewKey": "2cbc5466a5f372c2e7c9994a43c9a674c14d3cc37d5de7e4ab6567a7277e7e00",
-      "outgoingViewKey": "b05518cb1453fab85c4f1ae20bb0cb56304147a9c863fab04d09f0231512fcd8",
-      "publicAddress": "22bdd1eb52a53a770988034fecb074716688cc0e78c667717921d5952aef0897",
-      "createdAt": null
-    }
-  ],
-  "Accounts mint for a valid asset identifier adds balance for the asset from the wallet": [
-    {
-      "version": 2,
-      "id": "b307dc7e-2464-4a25-82c2-ed54624be7bc",
-      "name": "test",
-      "spendingKey": "62201555964d06f3169483dcc11dd81243d1d38e55ea86cc07a507de5d96b2d6",
-      "viewKey": "849976eb734b0c7e438060834fcf28c4f77ef703c23619660c681838b88027f335e35e6d63837b03e95ef6d8794c9512e9bab1690e6040e6c1dee60c8fafcd69",
-      "incomingViewKey": "f0a5194c57b859db3e4a55fc2ef023ffc5d27692518f3fe03234e2d35d228a03",
-      "outgoingViewKey": "3c2ae829ba6d49b3f8e40c3e0f60254dc19a00b2facea9217424520d415299f5",
-      "publicAddress": "c7e28dede5b96b24cfa8654d3ecc5d848506baa2e5a208e1b0a49bf4967333cc",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:QKnQHc/oriE0G4Mmy1bab+20mNEury7nBeSaGItKxHA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:HRoTEoLMOBkt0HV7mXOxqn7/jQOli3FhOR0L4UasTIg="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803008689,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAicniaZg+4cIBbs9FsKAiZhQvWYcTk+E84YfBtpmjXVOrtWwFErbZ73apkzzFeCEKUo2Ce/sYBwJgN5EjC9OLFSWSu2HkmFl+Ed7yxnw+pzulG9CAz6PNJ0i5oKuJ8D6EVFGoh2da6GiKa/g2dY6nqi9kcAJ+Swa2wgIdreCKv24RoL4Y0YFuU6JBro7Sg7i4t5kuUUBk6Ehb6FE8z+n0npz3TmDu5RFndV5rEEprJSWVxMoPbxx83loQ7cbKKSrEiNWwlLKDB6u2gHGZsagUNNL4dtXL9D2rsH7iKQV1sw1GZe6HMKKwDFmf8razp6wufR++kfR1nze0NgC/VtOn5rXa3aupEL/TiTI5rD4sIfxJcop+d7vVY58cu+b9/30Wxdh0wigo3xlcIjGYEPwyLIQgh/oKpudkJJDPP3M6pkMbsLAe50aJbdYLQL3iUHhB87SUtAFXwgwpEI7vcakXj63Bnb3ddA/gLHNqCo1J5q1q7wo5GMw4SGR+VfoA8mtDCWbnuIOLYYFQSbu9sMwOAHFgFYlB8CTLhM9EGQsLTmKIbdxhojykjnTx7T3b4W8EugDCUejQiANZcWXFPzYlPDZo/7AxpuVqFCYhPKlBAWhizTeZoD/F1klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLk06mcH3gpX/HNM1iPLPN2+fRkw7HZdyZmcL4qlMFhGklkVFcghNl9BgCzC1R+p9iDKwjsekL4G6GWeecqJ0Dg=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAq6keIMGvFkvHlTdU2ZAKAEY4xJIUfUgXWpjD/ZYqlbOnHgjUC+BHSbn7r+pVYk5KR7SEaKPFWmryy9jg13N02l7dByG7ib6Df5unaiHUJaap62lsMU3AK9ZqGTTaOZzq67Ovo93FEHxaBVYgyi1B+lUoFqNrmxVHMty7HbCIQNcPqlEri6erN5b+Uz3dH1ixXNSsRxAAL+0xS1eJMeZn9YsAvJ+w5UYo0lW9XVwujwCutw4GMv/inBDAWVRrHnhkfa6BcCl5x8Ll9aVqgeW23TjUXYln0xkfhiKawaCvOHfVJC8reNybZHSF/fataoe82lXe0ltvTMBua+4CSgczFOjEaNBv/xcr0isGUpyz3pAE2WS6lYCqyFu7nuupxB4HNLeFqGbaNf291jIq2uNcqYOddCLLMNQEcXgum/NpDR/02Cm9s2WyQQH5gXaCFb5QWtZ1OcQZqhMrsL/2SWFkeryfOaA32wsXhJp0RgRbDSclfvSsUxDRedLO3hVT4DepIZ7KE/cz1kAVntW10BpeVDLYzpGXfWAHUJEtBpWS4YScNwvyPeom/ke2DUYgXrP6G8ofXbXxaXli8/eMG/KYyPnol4Zb2o96na4SfoyfRTXledJtQftT0OFEY+c7XwDMDO65h9n4kN8PFKm3OaUxMsQaZA+S5QAYYuM+5yTG7MB3AkLXWuyDPyTkN7EaHKIXmH3XRLp0xiqkH4iM0RN3HFOnsOta6KDzr/NvazWU38mpcS2TFqvMF/euvcfBk4qukxNCJlKJ67kO5GePxUI1wKBWm6E1Nr7goo8RfLOfjYUH7c0kUNWODWG7lEsm3WKT52jQfLOIadgg49N1WyxloVNi7tlIf8hDDoQx+OIUj5zGeDTWEGlXiys3tUig/4iRw8rhKf2HEjcr1haKL8LMC87yfszH35DMrumPev4NufgX1X/qMhsnzrH19zS8eGOmifjal0fdh18Q5B77N4ED5xcQ5/EUxpDtx+KN7eW5ayTPqGVNPsxdhIUGuqLlogjhsKSb9JZzM8xtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAICAAAAAAAAAF+mY4BW3wmp+ssGzk2DsniH+sUx7uGg5Ut6oR0PzZ0ke+swrFtKkalUWlfA7OL/qDKFsOT0HAC2WXC8yRjqcQTRLfhIKc4QZlCngmBDCzQNVSd2E2QXNVbLAOEgeGLMhLgH/Nb+SGxmPMLOd4B6HfEGZvy1vbYsfNaV9hfbe4oG"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "A07AB2EC6E2D5070327EEF904D3A075F714C048DFCB08B5FD0F89C47B7590A61",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:B7eNUz7gTfXtmDMEkivBDqlCBN5EhVbEp8cDCDgdPnE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:E/8O9I8+9aFmZiuAjmV/Fe7Kllgs6r8/jTMAp4EWB14="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803009703,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAALIQByeOiOqsvcgKW29hmcevRAIZGvxnBJTlxcVRaG4yWcVPoWJp1pFiLDpTyJlnn4Tg9aH0vgckJC8VpH1VbMJ6TjyqrHh0XE4Ih9dgfY4qtglC3PI/K/D2YjQ7vYm+3/edXo5RKnXjVBl3lxplhmP8oogxKKwsWdbODFR2qlhwHz/9+oPW7tkJHyEN3fTb35ehib7rFLU1VzFh4UMl13HrkQX1lbFT0mo0t60P1WP+g3DWkpeWAFYwYqWuusQuGdUaCcBPHu9KyNGUK/lHRYxb9kk7t22+z16Zu/NpPr6Z/Hl9HDRJqw5BCLrzn0jClDNmAEC7X+pbSENiuhUHXlppthDbbLJAUMNwsntKePgvNqN7Dl5PWcs02svbqyhMhwrh6+K+gf9mnpqFP+OjJ6vjz5tZN1YCAgQO0dF52kVwEC3dPQlNVJMeBXW3z4UGugDZyvPXv2BuRdB+GXkscoTJYMvqZzz4XsVlAxlCb8BbY41od2Fs8m1d+Luakd4XwBoAQF7PvtvUisBM52phtQ5j/fmvn1fYCcHjAymyt1cPd9oMh2QA9vo3LJaM/Yag/hcvcRJTJgVFpvEtgS9IfAoTmM9qXkHPI6ve6RT5C3cSZZUUV5m/2W0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/YXO64Ndu/rE7HgZWr98F1wA7ZgM1on34VjJKzAkWYTUGejSAvc0Me5fsowiGUJi2AviGDYC7KlNCZPhsu/2Ag=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAq6keIMGvFkvHlTdU2ZAKAEY4xJIUfUgXWpjD/ZYqlbOnHgjUC+BHSbn7r+pVYk5KR7SEaKPFWmryy9jg13N02l7dByG7ib6Df5unaiHUJaap62lsMU3AK9ZqGTTaOZzq67Ovo93FEHxaBVYgyi1B+lUoFqNrmxVHMty7HbCIQNcPqlEri6erN5b+Uz3dH1ixXNSsRxAAL+0xS1eJMeZn9YsAvJ+w5UYo0lW9XVwujwCutw4GMv/inBDAWVRrHnhkfa6BcCl5x8Ll9aVqgeW23TjUXYln0xkfhiKawaCvOHfVJC8reNybZHSF/fataoe82lXe0ltvTMBua+4CSgczFOjEaNBv/xcr0isGUpyz3pAE2WS6lYCqyFu7nuupxB4HNLeFqGbaNf291jIq2uNcqYOddCLLMNQEcXgum/NpDR/02Cm9s2WyQQH5gXaCFb5QWtZ1OcQZqhMrsL/2SWFkeryfOaA32wsXhJp0RgRbDSclfvSsUxDRedLO3hVT4DepIZ7KE/cz1kAVntW10BpeVDLYzpGXfWAHUJEtBpWS4YScNwvyPeom/ke2DUYgXrP6G8ofXbXxaXli8/eMG/KYyPnol4Zb2o96na4SfoyfRTXledJtQftT0OFEY+c7XwDMDO65h9n4kN8PFKm3OaUxMsQaZA+S5QAYYuM+5yTG7MB3AkLXWuyDPyTkN7EaHKIXmH3XRLp0xiqkH4iM0RN3HFOnsOta6KDzr/NvazWU38mpcS2TFqvMF/euvcfBk4qukxNCJlKJ67kO5GePxUI1wKBWm6E1Nr7goo8RfLOfjYUH7c0kUNWODWG7lEsm3WKT52jQfLOIadgg49N1WyxloVNi7tlIf8hDDoQx+OIUj5zGeDTWEGlXiys3tUig/4iRw8rhKf2HEjcr1haKL8LMC87yfszH35DMrumPev4NufgX1X/qMhsnzrH19zS8eGOmifjal0fdh18Q5B77N4ED5xcQ5/EUxpDtx+KN7eW5ayTPqGVNPsxdhIUGuqLlogjhsKSb9JZzM8xtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAICAAAAAAAAAF+mY4BW3wmp+ssGzk2DsniH+sUx7uGg5Ut6oR0PzZ0ke+swrFtKkalUWlfA7OL/qDKFsOT0HAC2WXC8yRjqcQTRLfhIKc4QZlCngmBDCzQNVSd2E2QXNVbLAOEgeGLMhLgH/Nb+SGxmPMLOd4B6HfEGZvy1vbYsfNaV9hfbe4oG"
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAVQPiU1X0TB+oZErlfbL9NTFrPlqVsDmSmetsopdNpV2MyZfB/XVgv+Jchr9va9/kUHj3ZSvUiBjrd/9o7HNAqC7j7KCLjodhEk4ZBdqG0H239z0E923t3pOYFazqL2dGygNP8HnDkIC1391CSZKxaE7HqYkLRCK8LwwgG6gBQmAX/JcugCoCPVLaYBV6tMgRc7Ag/JDxbotROZUL4YJB9IOIIV2nyqR90dZXLfdxAKaSXKfNdC6MFQhRKXMk+BKfq75G3Oz5o5SBrkIIByjjROFIT2VY5sCip17xPyF9r8S7px1OOGTMeLPpCySzvQfePauP4mwRt7abSOC2+xAuuk5Jw0InJpyuocpqi2h3smSadnq6GEyIxa7faYoNSSMDwJxCG5vXohL3i/7KWb8STcFKDY9e1JZDdo2Hm35se5nfa9feQ/efn8/YgLYswTe13+Rpnr+OBc+U2mmBcibb8GTeRJO2nSg45bDIIYh6PLJEch3mJd1Uf/RMj4hMM5c/8Pue+YENv3V/5hM5M9pxZukjvsG8ysOC3KVcA/NcQNEMSRMIJ2R1LiV5VyVQo9l4sJ3uqr7oDiCnUU26pVHwX9Jl89WLl1krYbf66VXch0G2s9kBSzDnAiYQuf4oqf6+AntIUOWf1ft4K/yAmBqnYElG2z0Y+v43quaBJ0V1XfNfthOhKdQNWmwtC48mUn7bFKHhWxX9aGN+mOCQsOPkCPcRcacOdQoyk3u7vI7DSNGQ3NvlzqQdPysnAFoXmFNWUYpmhldPtvbGzy67ah/ObpVTf69+dIGpkfJIAz8e7Mp/t2IpAAn/KR81NEipuONz5YyCD+oCXV412bbz7zsUS3BkdNtGjo9mFSlA6T2ouEuWE5XC0X5D/3DMqI3ek+rT/QjWx5IBRX57af6B5Fe8DlAskjBNzzLqiQKUPSo+vhXo0IB0buibp7IF1Yh3hu0BJysmhPX3SnZhvDtvNsXatNYirxOMcLaBx+KN7eW5ayTPqGVNPsxdhIUGuqLlogjhsKSb9JZzM8xtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIKAAAAAAAAAMmRwbOwMVNk8WvMN7SgptGDGYyflqy7Y+cntZMa+B4QnORCiYFkd8qivxf2VmaiXT3wkYGbgb8M8qgg1vBhYwNFgsTB7KfzIO7KwYfXJpulfMNbw88yzgjCTUWCCKLrZE3O26IT3x+y1bSVEBYT0/afhEBrOw9Mekjl+x7SqbwE"
-    }
-  ],
-  "Accounts mint for a valid metadata and name returns a transaction with matching mint descriptions": [
-    {
-      "version": 2,
-      "id": "1071f3a5-e8d6-4f96-97ec-f6ae05018f18",
-      "name": "test",
-      "spendingKey": "46ccceed8b87d7997a0d21285b0c5ac1b5141bfed0a1be11fafca01303ba44e4",
-      "viewKey": "f03635d3778d2b7473c551721177b7d7e8723ceadcbcaa1602f028c7ff04f9167f3dedf233669b67a338b29a92c41f928158168d6ba2155390ba253460ebcfa7",
-      "incomingViewKey": "3e215f23518e95d0d0ba61a20ab606717e5de7732b257755d86704920c9e4104",
-      "outgoingViewKey": "40b5126bce6c5801b4dee95ff356184f27d54c0e285b4d91822d70c1436b3a8a",
-      "publicAddress": "f1a40235e90cb0d5e7f3a548b14858a3bb9a292d5a2b1cbb081aaac08c95fc09",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:XBxkUReM9BjeKk5vr2Ggbe6sq8RTA5XGUayZbgatRWg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:loRPey1RycxQU7XMBMbsgAf7LaF9vsKHuPQ3qOAb4Ck="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803012006,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAwYDQPK5FzHqkidsfO7tOMUCiim2+wevW7pVH2/52f0G4wRS5egVpe5VaiOMMje/l7x0SY1+R4MLgaiMOAlevY/mq/5EfWFWGRoq4iGH7NtK5Eu8BHTZFM3NJ9MMAxjocGB/TZNOcaQA2Yvh+J18snDjBdkBKnp7Yhwo0V542gIcGe6ucZ2twWNuxUR0g1U9bKKXCHBqh/RiI33dcPdv2cQrHSs8WLv8pHH4XiyAlWm6FJHfyIx254M/3yO/OpFonAy0kj7DVhSJJ4CPgv0DhkBrtVygVpat9Pw/l9UfADJ25Hi3R37CXfz3biRx52SACl/SPPJASZ+ej2wr9u1NhS38PiWnw2fhnGzzl8njmpxAIu3bS+vYCMUboU8Sqyxsbvi8iFidATKsfRiqm2ELGQjs1MsGG0thLjMH/Ei1HUeR0bx4L+HjPfBe81ZbsEIblrXb09vyMbCZYlhYdCXILa6TURbSvatIKuPromnqpbZqboP9ppqglQEN2NOvIKD0/cOunyjB1O+eWrs1Bl2hJwxs1gnwS+HXPNssov2NZJSVQtgWAt6bImajmYZVGDDldRqJbibA9wXO2pwtiBkJBwvaqbz2GPOy0gi5KWNBFFBAzJr36KX+BIklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmC2Efq/nJ5HSsGrQQuVvRIotJUnJrQ1THJrtQtxbowwW+9/5HVM4PAFE51ZwIi9W8gRodx9Dhrdv1qqkJHbuAw=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAyNKvqOcZbQJVporio4/WKtGI2VsWlAUg8kFA7S4/9iSzGVJqO9V5DR5GdyWS6NSJbbk5ezDP1LHwC5XBo1LxND+WZw4oMs4G6dZXK9upSPyYv965vCts13SDHwyvMcIdtbMV7mLLqxbwjtXXLHjEBFphHqTvCR9lprwpIaCriywLBm1y7Y1USROppB5tQ1s+aUdw0ZueI69EvNVTeZYr1vV7s29URyjUVlsaO1nHOUmryKQfudU2165UJv+5K+y6MXbJ9s/dddqIxJOkT9VaiSVt7pN2B+Fw+tqYDyL5oKKcRBj6Crpl6vA1zmQAZ33VEP4fcH+Zs2XBx1k8rl/8L0kTAcrzldWCAXdsiUEhP/v1mqRrIU2c/I2V7p8r5EQ7b71XlMTzgCLMbKQKtnVJPjXC4A7XdRqW0hNLPHWYlxMbm+SbrdsMivByMcFCHJJCxm2S5QMInbm7oSBJerJboaFyNE90n6+6KKLHrLAJYbnEiySl08KZCHW2kVCu3+j7u6DNd9NNyET+ZBYblaLyUiP8lT5Og4c0Inf7oPGN79KIh3u34B2OtZ7Z3fRPzhg9ZLUP8inGM1x5YtxmUWN4+Ml/mBKxuhofixRKyqqhTFQL0Dg/R4r5tYhOtNd0HDKH6p4vTETgTlUS4aCYicDDYZaIFB+1f1Cyep7pGE3dw1/fYAZtU7qou8ijtt2EKf9zsOR+SC4MGBjT2G+HP0Mhv0C5ILWIDQxEpCbgaGRlQOOs+M5kVl7RNSLcUNnZhmeCNr6W3VwBKC6l4lfA49jSAyHFQF4Tgg9ZrlRRFjWUjMkmUsw7TbhvvRQyq1XTFzVQ5eslzrph5Jhb3+z7uGnySZ17PZXn3rvhB5Pwi8RhW0+S4quPrY8XOaUZTA+RY27IYKptACJZ2rCcpQELuOpxnSLdbOe2Ou3AgfBQbtLv3oLc85PlXDLMq6sD/OEcCg275a0eeYapOz2oQB3WohlGjd6Tx+K2pkf88aQCNekMsNXn86VIsUhYo7uaKS1aKxy7CBqqwIyV/AltaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAAIOyo++mHkO6SccL5rM/kO/4qRP9uaFVkbNDNPSosz3mr3kyGQlEe4tybiLPYDL6l6CtLAMpQ4LSh8hTghuJWg2Ucixjm+lqblD4taBXyka6BR7KulaZ+SyHTtdCqGEw4n/zsuRBszzIL77kFwiU5GvzQrtILE/szQS4ni8YNBIG"
-    }
-  ],
-  "Accounts mint for a valid metadata and name adds balance for the asset from the wallet": [
-    {
-      "version": 2,
-      "id": "c2ec0970-60a4-4059-afcf-4ad75549c7f2",
-      "name": "test",
-      "spendingKey": "e36e7c657ab2fd84a317942b510d13b63048fdadcf382b383ad1bf1fd655c896",
-      "viewKey": "6cce033a4569c9e4bd8cbcebeceb12aed2a69208637d05794c5a1ba292aa0da40d21a2ef688c3a8dc50599b665c2b0cff99afd713fcde3275885d497d432ea41",
-      "incomingViewKey": "07e520a84966cfe9ec6b378c64a6224a544ccdbbebe2818e3967641a41b0e807",
-      "outgoingViewKey": "dfa590df9d2a8380551af18534c55f16d6538214b5878807fe299d82c5208a45",
-      "publicAddress": "cd49f300a6afefcfcbd206ed1f72bbee898fad2b12f201da29234876bf8c612b",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:xxXZvGPXP+w7P+8zu2mXCZ/fRwc38YZtKUzEwrboJV4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:X2CrWl7yBC1ifFB3xZCD/e3yoDGD8rWqVxZcI4gMNaM="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803014072,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAGqisFCiTbBIzc5uOGk3dYaRxh47K5hVjbi7MPszvRbansxPYvV2e2oD3o+zQUwG0kQgPP1Iy1xsifjDLxNXaMifKBOI9BKlwTJSXH0sBd1+1T7BR54DtJqQTj2k5jhtRLWwK+lvYWev92STqCOAvub+IYTd1ygEBoaQMkDvPjowSTMKcOThM3O+rwtvFW8jxPvJQZggGlOA0gjOLOCpdN7ZPqoQW6ALesyEby+jOmL22zmIo49CcXQ0/PgbG+zvQu0MbX4VjVE3kYmQS3VGFr352n1auycn0pDGMYqpa4BKJar73hQw0J4Z1IbUpzmnRdv47J2URe7qKj89z3+YlS5w4/SSk3ePml5071Ynp9KBrIWtAU+6DH9F8cmcioaIZ3AVOE7G826WN/Hc97H7849HEEzbRGE2ZDTsD9HbCemLDRKpkWvoeuwxc2a9uF0KHPCbjDz3t7crY2Fcgts+qg4KKQirkQwXAlKNo7wLzZ2Auv/muB5oRiYV4/cfgcpNJS25W6WpY1QLbLLBVAdqcVZbkIXxnGNG1YOa7J9zgEEutYTaPd7hTO97OoJxj917B0/wdhY59SMPyLXYzxXx6VhxaXIrRYIhRnIy3bb7dUgEnDS6bA3vS20lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw44wBDyqfrAws+DZ8nudsLSVusZQywtQn+FEV0/5ISxl1lQbvtVZkuuZAWYr7dfZipZ0ILwKk6y5cGkyokaXCBw=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6s2PkajjXLYWkkQ02/0XO66pBz98a3WJWFKHiqa32hSvAnVxCAQqgB/f4b8vwFBwubZZ6n2Jwta8GiJ6EzChibj0v7yxZYjLyOGZ0BDxEcGCgKH6DbBnm2FSOJW7YOqgJI/QNizDzwCV4D7FUwXx3byNzSxbCYwu9il12DgW+AkJ4Cl+ujdQrvKPSTXFzu8nFFc5yyh/kuaYgKAxLr4Hd7duPOvpO1J2z/NefM0xOuapGMgO8kMuJ6p4FY3DImhg7YbkunApyxN4iFNnKv/k9S9D0z3Jdyroe1b7xoGdS/JioUiZgAAMH7uR6iSEeS510JnbATcNqVZkBy8J2KoVAqNXsUpMV0PiK4gqDxfGxVPO+YgSgh50WQckdWlE68o2A3WCjyAMR9B+FU4IhC8oEPcbBcJlfigS0EMgW7Kt4VoeCxexxXdx4MltM+4F4llIa50WSQwlfs1PJ6VwWm+0EEWQPQvTKPBelsTYBY9WL8grYhwpGlufEqB9f+EeClHj26LT3mNwIOjw2m3W8VsPcNp8on7aKWB62bxY3qzLTHB8kYkXKxT0jKF21JV7LVYuV/n7RaUYCXk1GWa8Kw1LPXp0YbAvniDKwkeTh6qqmc9ds1OWWVZd8fBozViLjZ9ppQn48RUW287RrwPLqRYmwH8R0TKOF3u+W6Df7imVZ+Lwpjgl/wprJw3dKbHD+NSSjokz1csUk3MLabmlsRtOYl1P72lPMgLNlLLp9mRsSAsbqkk5mMCfVYTmhHKZ4X1OgxFQ6M6SmV34p+jSO23lVlwwBkelIgR+mHo8zQsizSvUfsWAlfeB0Hae0kq1j02TSbM1ZdDVM9vEkrWuP72HXEcjgExdGwPgB1hXrgx6LtgIdu0sOn/DOMZ7BcRm5XCEHJAC6kqKgOPHqJ1ysZYq70baWJNFYGJMkM6x/zK0S3IgSrRFNvyMhnVfUcWnaWMxHocwFLFt9FQ59o1+G21wZkFiI7ztddG6zUnzAKav78/L0gbtH3K77omPrSsS8gHaKSNIdr+MYSttaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAEg855lpv3rcqlCwpZvHE16GEuUUYZvSo/lVzEyCO11sMH5RrKyi08Iy7kAakhkaLBFM6rJWomxQ7AIhoXCKagGAsUvycbY4kbSEhNX9Tl0RQkkPEUhEnBVs1eYMqE6nby66C5FiSLSjEKVhuw5H55cZ9whwAQ2/JKpYYGo62sgF"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "1CABED4402E4059D85322848AD5FB5E91FA86B3C92B8DC7DBE0FD0633D7A28A4",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:meA4G1UYkq5d6LzEBjFOHah4Jtzfm1NWeetAcpEqi1Q="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:PU71vuDjoox347q/C5Bx/hL3eqin0+2Cc4ivSRb/wuA="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803015162,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAxILGD5YZIK1CTvw5NjzEJW+hDXC9h87Qc2HQtGgXCKaKLRIUpt/NN7dVkEIgu5Ej20+2OClo+ZPbkhb0SRRs8zmV38qEHlkXSKdCL5rVLWyRKkPRvVNTx89gtzvMl1rgKIsxpDvlxXx93g1bUcnaWdC6HxITvFC8z3sFLOf2yUgRdoDnf8WVaQrihNBYlXDxoZhOpCsuVKMeU3ToRWWqO55Cmcoid+JGUs4E113kwcWyKGq4FgGO8D4Eg6zKVMPgGPWqfPm4BEOiWT8yMHJGY0+36rcRtWO8W8RqtbVHiLKpoEKFTqfhDp8TvOAbqeEHHU3t5hD+KI0kbWyLL5ZL1ZmYoJdzKu05Dk3OuB/dlsk3Ku7aR15vTB2qNmHS79kloA4c4CxD9z+sn6f1PArDFpKal70pvl7rrY7Q8npcY92B6tkS1gwQ696DMvlebTdck5lxAUBgwdLNUb5aM6ldIjWQjIduejS/6REh3Ade9PqwZRM1naoY9Z0uVWEqhd7V5sSUnBWVyXmzOoay1ls1scxGJs7hAxn9T4gq0S0WdLBU0zoyz8RfEUu7aUfr1bW7+e/xcS17AvdJYARkSEIF6UHljHxt46LL2Wc7HFPC3M2EWhcn7NSv50lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAww3hNXnBDOa9BKWkTyBW0nnuyyAVhy1Onhmx8E2u6o6+OpWvZsedcAKGi5umo9Udt/84iyBuaBNG6dHQGjvmpAg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6s2PkajjXLYWkkQ02/0XO66pBz98a3WJWFKHiqa32hSvAnVxCAQqgB/f4b8vwFBwubZZ6n2Jwta8GiJ6EzChibj0v7yxZYjLyOGZ0BDxEcGCgKH6DbBnm2FSOJW7YOqgJI/QNizDzwCV4D7FUwXx3byNzSxbCYwu9il12DgW+AkJ4Cl+ujdQrvKPSTXFzu8nFFc5yyh/kuaYgKAxLr4Hd7duPOvpO1J2z/NefM0xOuapGMgO8kMuJ6p4FY3DImhg7YbkunApyxN4iFNnKv/k9S9D0z3Jdyroe1b7xoGdS/JioUiZgAAMH7uR6iSEeS510JnbATcNqVZkBy8J2KoVAqNXsUpMV0PiK4gqDxfGxVPO+YgSgh50WQckdWlE68o2A3WCjyAMR9B+FU4IhC8oEPcbBcJlfigS0EMgW7Kt4VoeCxexxXdx4MltM+4F4llIa50WSQwlfs1PJ6VwWm+0EEWQPQvTKPBelsTYBY9WL8grYhwpGlufEqB9f+EeClHj26LT3mNwIOjw2m3W8VsPcNp8on7aKWB62bxY3qzLTHB8kYkXKxT0jKF21JV7LVYuV/n7RaUYCXk1GWa8Kw1LPXp0YbAvniDKwkeTh6qqmc9ds1OWWVZd8fBozViLjZ9ppQn48RUW287RrwPLqRYmwH8R0TKOF3u+W6Df7imVZ+Lwpjgl/wprJw3dKbHD+NSSjokz1csUk3MLabmlsRtOYl1P72lPMgLNlLLp9mRsSAsbqkk5mMCfVYTmhHKZ4X1OgxFQ6M6SmV34p+jSO23lVlwwBkelIgR+mHo8zQsizSvUfsWAlfeB0Hae0kq1j02TSbM1ZdDVM9vEkrWuP72HXEcjgExdGwPgB1hXrgx6LtgIdu0sOn/DOMZ7BcRm5XCEHJAC6kqKgOPHqJ1ysZYq70baWJNFYGJMkM6x/zK0S3IgSrRFNvyMhnVfUcWnaWMxHocwFLFt9FQ59o1+G21wZkFiI7ztddG6zUnzAKav78/L0gbtH3K77omPrSsS8gHaKSNIdr+MYSttaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAEg855lpv3rcqlCwpZvHE16GEuUUYZvSo/lVzEyCO11sMH5RrKyi08Iy7kAakhkaLBFM6rJWomxQ7AIhoXCKagGAsUvycbY4kbSEhNX9Tl0RQkkPEUhEnBVs1eYMqE6nby66C5FiSLSjEKVhuw5H55cZ9whwAQ2/JKpYYGo62sgF"
-        }
-      ]
-    }
-  ],
-  "Accounts burn returns a transaction with matching burn descriptions": [
-    {
-      "version": 2,
-      "id": "53a6970c-47a1-44ef-837f-45df679b92ad",
-      "name": "test",
-      "spendingKey": "90e5a79ab75289c4f129327734e84abda23d4f79139670cd222d5e1d176e64f1",
-      "viewKey": "145275d8728e11d0529355f44746887aaa1ebe3ed14f675365a5fc5b73d4ddd853efcb9ca06b0d9a6c80fe74ff12fd99486dca1ffd45be9e5126682f5cdb9585",
-      "incomingViewKey": "6bfd63181a99b35b000f01e7f8bd4aaffd8183b3c9d671c1de9aa551f0e28105",
-      "outgoingViewKey": "91d0b0f69bd0771e3063866b42b7010914676bf33c5ba0c2b5d01f08bc9768c7",
-      "publicAddress": "a70ad1d846faa47de48f8f3b39415e1157bc0195f9e714fa1bc34490934e60ab",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:+Cs1SMpEdwQIAxjYflhtzsCPaqkgs1L9khgqR8zQJ2E="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:bDj9E1+09eI8uptT/87YwBilq0uRV4bHyDLUYQTw4ZM="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803016465,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAALCmh71D1TmpMUFTdIkbix3OPmDFouyOCOV8J0pcMDmOUabE7KjHjg6tlUa0pRA2/ojc0cHJR9n8RbTlEUdWmmhZeKYiJoADxErv84gzbLGFnV1KeC+np6paJW//A+8REMTtLnP5ITKf6nC7hMjkrVK6oj6tSxASK1WKmsuD480J67jSU2VUQz5mGIYv04SLfwnBs3jWp3JpolPGpVQ76DWu2fodYz7bUghK65NfVwSvEShVVbwOQJsgT+rfz42zZ9uzat4gPo6FvBXbRFRvEL9H8XJWS7PVmO4BVqIvrOJg0fOhIs5mVhxAjfsY6yWijJndcCkkFso0EXMAN+cpwa2knHdjGeayO9UaPwBPJJlFg+POw1B+rSW0WPNW+DcgF9Sz6BG27FG6LC4mSrg0+8fTk0UuGYfp2EvnLWgzO2NdOYFTCmKNS3xfHhyFBQNoMwGjlypLRvw61CTBnC/rfG5SSt/HbzZNSf7eHJGAYWFIaIxilFh0OQRvplxj3C5dFNYVMiofMZc8fRJ9Wb6khzSU0Dzm5HyM9z4SgaCt3jgzjRDgBf4MQ7gaxmb5UHZGfDBn3KkY85NgQdCsgUHz9Z61TiIuIjM+7ccm05zTXiyi73/JOl42+0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsn1+3o9GbsxotkpEbQGxG5i2OphvUHBqChvd434rXL7ObbiZOXXm1nYFEZY6WyoVmzcd0do1aldEjGYKeyeDBQ=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfDgerBGtJSVYe8/eZiX47aYI0TPRFp0aXTna7Ah611Ss9yrDMAa6WuOJbp6rMmSbnTqRdK/vomIV9DjmpfvqxMUdc7EmaCjOXi+Va8bETsKN4vx9bhTsw5LbOcDGVKDxcK2xmXxFUWPLyNkLtWb4eW510s8Ixc6J6yWh/SXroFEPVYguRfeefuBM1/k8xYD1Jf+yv9JqcoYCRwL7wo/RQmQ1YMG6F6UQoCNmgpOsjCWCpSbSM2L9bI0CKDNG/vmoCPeGMD8oXZ02iJSws+vu1M44zWL0nzMNhM3BzJedMrfCinch1R7mQvHo9pk34oR/7AWKXp2R49UPTJni9UKLAmGMKt4KDh9Fotk9K3o+YKGniY/5A0Bzcs6C0t/iXOFriLuWMf4tFAmOHv9x6YxZKRVcDzQRgWBUsQBPP7PI4q9C7MIiy8uVvqv1sd9L1xPhkwyBV6bO85FpxZRAYbjVo5Wdkq1h0DMI5x9Ydi9hjTFBaKcWWDOI70SCB1cwrQ+cGaR9XKlXwsJCORfP3v9fL8CqDCFjFN0RjygcxT/Y14vdai2zOXa5jYK7UGoOf/mpTEd28DSfm3q6MtrBOvYo6+MvvQovLnLHJJOIK6Z5L/wO/B2fJJGSIp2bffYKJm3cg2uT0ezu2PkHVOOuMlfE8MG0jIjPjHGZtWD5FGt2KrQIWDj6orOrKDqo1rD+/m2ij+V4fpLGFCealJSeyi0TrfMW6UIfmneqmXn4k2RJmbpGgctiUkkUN88mKvewV4npZ6njnxGnli/r53ntuBqsHKNYlNsSDbc6hji+aSkrmsrbHELagosLuxqXtApuIoC5TORs+o5LTArD4+1vi1AUwNWzi3bc9eqMAiYzbMrUMh47PEc9xZW1zVd29l+fs/kT/04Akm7D0Ki+xCm3jx17ZGgy+YG/Ypypky0CeEsnFzDZx+z1vSNCg4wHXvNjuWWaPvIFgzwYQTDKOtpA4nK6w4ohsGzrDzkIpwrR2Eb6pH3kj487OUFeEVe8AZX55xT6G8NEkJNOYKttaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAIqhHx3bV934tuQKdwwxXJjZMWVtOkl8JEQRyBN8VM0OdCZJGpzW+NmpteXP+E/W7Vtd4oRfNC79r12D6w5iKAfW0jsRn6LJyNN7rdXla59/AWAcsowhfc4FrPekZOYjCG8iVJ6YMzoBkgxRI8Nti5M8biBdkyZyEjJKtltpw1UK"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "239DAFD5E144E9B542C62EE4CBE202DE433A052022098EB4C93DFE4DEDFC52D6",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:d+JJZ3lmAxBa2tSQHzCK9mJrR9fMS61HFcOiFpHL0EM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:Ow9TIHrjtWpIVkY1E9YDqJovCyIZIprVQxpa15Ru3Jk="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803017574,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA09WT2jaR1S3XgFKQXWrLdKlTKh929gvCzQ3VvTnKFlSB3heAc3Yo/WsoHU3jkvosVbfFDNT/CxkDlyJHCpg+zkThOE1GMgD1uzZHm0rgykWJ9riasF5gmol6XIQv3+ZYeUBmW6WNNUOA27GcWGC6GDzVcsNIvWpwywCrU6Wfc04XPKDsfJyZG8ER+96/tZy5GiqgFdcM/U38gpqg32rbEaJsDEeq6Czdv0cZm7g1lRSCRcTyyPGEuwZkTOv1Tp16ajWN5+eDKyj+KV87/K5WNlzfZ4Yfcpp+i6HwGPX/a9j59EOOUBTXclf5dWxIL6PLuZq8NNocSjTSZPn5yEeWNTVc3PQRLu+P5h0r1hLfNaplTRcppFpZzSw0CU3QIYwgYNLb9ItiFjm3k+PwerCRHTIdW8zhUwlmmRu0/czAWbD/kafQYDhLCdZCnaNxDtB4yuhLQIysNdrRARiyLiQItfAwyoZ05WQVJZqUIw2Ce9l/tptVRuxZDNfHHNx97zMCsk+BdHUdtznS8780axNAw6OZeYEZ4DrpNduLBIDbnJ61BF8ya9ScXJCihKxgrLETN8+lCtBVPoE6rJirFS6hSmHg4FIBpKzrr7tZJLdEgyTMRfg/nd+auUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5tcjB4EZZZxzVhvAU0UbM2DrpO/KzisOplYOAfw03jx3xD2Jm1xCaXwFsMU+TsrZOpS2cgmOhHg7FGVoI9TEAg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfDgerBGtJSVYe8/eZiX47aYI0TPRFp0aXTna7Ah611Ss9yrDMAa6WuOJbp6rMmSbnTqRdK/vomIV9DjmpfvqxMUdc7EmaCjOXi+Va8bETsKN4vx9bhTsw5LbOcDGVKDxcK2xmXxFUWPLyNkLtWb4eW510s8Ixc6J6yWh/SXroFEPVYguRfeefuBM1/k8xYD1Jf+yv9JqcoYCRwL7wo/RQmQ1YMG6F6UQoCNmgpOsjCWCpSbSM2L9bI0CKDNG/vmoCPeGMD8oXZ02iJSws+vu1M44zWL0nzMNhM3BzJedMrfCinch1R7mQvHo9pk34oR/7AWKXp2R49UPTJni9UKLAmGMKt4KDh9Fotk9K3o+YKGniY/5A0Bzcs6C0t/iXOFriLuWMf4tFAmOHv9x6YxZKRVcDzQRgWBUsQBPP7PI4q9C7MIiy8uVvqv1sd9L1xPhkwyBV6bO85FpxZRAYbjVo5Wdkq1h0DMI5x9Ydi9hjTFBaKcWWDOI70SCB1cwrQ+cGaR9XKlXwsJCORfP3v9fL8CqDCFjFN0RjygcxT/Y14vdai2zOXa5jYK7UGoOf/mpTEd28DSfm3q6MtrBOvYo6+MvvQovLnLHJJOIK6Z5L/wO/B2fJJGSIp2bffYKJm3cg2uT0ezu2PkHVOOuMlfE8MG0jIjPjHGZtWD5FGt2KrQIWDj6orOrKDqo1rD+/m2ij+V4fpLGFCealJSeyi0TrfMW6UIfmneqmXn4k2RJmbpGgctiUkkUN88mKvewV4npZ6njnxGnli/r53ntuBqsHKNYlNsSDbc6hji+aSkrmsrbHELagosLuxqXtApuIoC5TORs+o5LTArD4+1vi1AUwNWzi3bc9eqMAiYzbMrUMh47PEc9xZW1zVd29l+fs/kT/04Akm7D0Ki+xCm3jx17ZGgy+YG/Ypypky0CeEsnFzDZx+z1vSNCg4wHXvNjuWWaPvIFgzwYQTDKOtpA4nK6w4ohsGzrDzkIpwrR2Eb6pH3kj487OUFeEVe8AZX55xT6G8NEkJNOYKttaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAIqhHx3bV934tuQKdwwxXJjZMWVtOkl8JEQRyBN8VM0OdCZJGpzW+NmpteXP+E/W7Vtd4oRfNC79r12D6w5iKAfW0jsRn6LJyNN7rdXla59/AWAcsowhfc4FrPekZOYjCG8iVJ6YMzoBkgxRI8Nti5M8biBdkyZyEjJKtltpw1UK"
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAYVcke1su5FuyjF+nJ7+opVWY72/FAnvpnPeCgbCh0hiCAfHQK0gkavVYHaV8p8hC96kA8cd3zOBY+9G4gGF6OA/arCxGdqesPMc5MIH5EjWmLeitekYXf1vPTrTJiwXSFDjbtgyuEmOrdRcF7LCEJJEYlS0VLAE5aA9+VQNDA4oRJZhPtm7PfPMyXRIOcOrWviWk0TOsMui6yda4lZrx2IBK5d8w4KKZcTwlikcjZ3mMXKgajIqvpbvKw98UgJO4jpV3XGw9QzVoZdp5qC8Wu2U9R9YGbS2hCWyyiieTxa7AT28vSU541onw3J+qA2GGTnh4DfOaor/xcRPu8Q1jbHfiSWd5ZgMQWtrUkB8wivZia0fXzEutRxXDohaRy9BDBgAAAFVC4JFMJA4+pKJWLE+IIyTR+D+HqCbo/jEjTUowAV8zP2VeiCkrQbtiuf3xjig7n2MAkg7YVt5hXKt76yUkkbBlplgJBzSCi/H5kWWgrt3iHDD+k3IEkX3bHkzGkvc4BaHyMtKI8fFW8mTHAVS1bFhoOmBywDW48fWKXF7IZWEWhdZkp7F4qN4mXEtDB/bDnYmQNkwvkBjbDAoepwuA8zm/HFhLfWsR4QCL2UWgFFhKezuIib27KPi9twm0pqS7Cgnv0bwpDhElB7+fnkup8MojDIjWYnGtsJJOAEIIAAWfqMpG8IziIhjTr9Sue+RgbJXK1BNUUsmyUVCjooBUt6N2WZNwvJ50YvRHSuv/tWelQJw154sBxGvxYVuTgNq9qu5EANS9WunnMLi5jQ7M8FWRBvL/H2lemama4V2J6S7cY0efwCMRTGuVqt87guYyQbD0Sa74vUyBixy11PjlgFeqF4aY75UuM7ygRpLH6haZvlvrvzZrEILmsRLREzDE8haLM8dpBEKgAViH/SAk/zM2okxL/WUZAlj53yjp8Tju3RCHXE+wg0mowW2or4J+Cchp2JqW3dvxVplL33jwvoGiHRrUaS6D5OtIhTysgDuFv+WrHkkULrEdSVeKWUoyuM8DFvCmqMqX3bm1Cj6hmB/Wwl8XsQ4lRVkYrogeUOCFegp6Rd990fo2jRX8U459VOtXQi7flIUPRQpz860UlI7ikCJPIUkC6edlStLkC/Lb1rdhehrIYGriJ3+MbQ1ZwSLMJtqyjkBzo9vtPbknNPwL2yO5bzOQlofiJzX/HQxUx5R6ihfuQGt29IN1pemRRC3569TM/drLI9iQ6zPlJrdAnC7xtDPi/wIAAAAAAAAAwut8KYpwJOIt+ZvgE0vRt9h8FYqPp/FEZKljZL48chXnvnwXNBAGFZDSGXKbGJ+jGwPBc9ujlO5w6BhsBp+PAA=="
-    }
-  ],
-  "Accounts burn subtracts balance for the asset from the wallet": [
-    {
-      "version": 2,
-      "id": "0642a943-968c-4cfe-85d8-dc30d3b266e4",
-      "name": "test",
-      "spendingKey": "64b841e522c1acf0db3b82553e3085c612b4d5691182f02c890961a36f7dc3d4",
-      "viewKey": "07da9c8c9763e22018b8b3fa333e9e9fb7f55aa87059dbc60cca17d2d8a37cecfea7f06fd1b414ab28eb89b55ce5fd54ddd02dfee528e4bd1c3b0231eab0e065",
-      "incomingViewKey": "57eac3104a3579ae03646d761883b1e15c64eb6cb77918e93e66accc033c1f03",
-      "outgoingViewKey": "30b4afbd42bd1b948135caaf4ae5acb18c886e04198be807877606fdcb413339",
-      "publicAddress": "f2d3a7cd76e099870efd1f6dda4d2644923f5ea5d703dc710f436aebcb1761d8",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:REnm9f+jco5QWSHDQOtRf0rNfdE4G+EPj/RZg2DODkU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:JU/eWwmWM1gdxWQdiQR5u9dNhlu2e1JMAgrezWqM+R0="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803020123,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAFyZwpUqZLrgVxfQic276gFHWAZ/DrO9EDJhRqdxGGMqLEDe7LFQOFId05wJjrK1t/ZZFa9u3FyPhIvEbcRH6tnLrVm4xmQle7xBBSrps7ByLi/1LydQ4oYVwWsI77oFBdK0/uQOY0zwq/WtXlkYsvpSGrXkAbOiuwu/Iq0bqRRESSCRtZcyHaG8SnIYmhIkispmm4Lwyt5eXHazpuMGwW8reoFkpOoDvfeYbjKvuac6U0M2TAlBUDVvzdfaOIeAzJPmIirMUd+L/4uACkAUgWkasA3BcsI9/4lr9BvQdUyjhSa+HTTLn9CEVpRh2KcLW0cmuNkzDJaxr1LTLHhW/ntR7glUXwPVJ0rKR8H2tZsV2xh1FVq89DVigggZ+DZBGnF3A7X4GIJ82k/4siqOhtTipt1mO0VYdJJLwRiOg41ICYVvc+scQiCA92nKpXYcMT5nifpEJULJ73/2T8oDzBJ8bZKmxunqUZU0bwKocLIHTKErJjhjJkj6yxVjS3MiN0ddXGAj2bOwj639G5Ei0/NihwBdulJce0bDgEiidf67j98C6Zz6iDpOpAOoN2O7XOULJVVz/TXvMDP+idFwvZ8kR0A/jYTglXzyKmu8zFb/l2yQEGqKa00lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCxXLEChGGHUdqI62P47GqGikLKI/iA60oGjiQ1NTvuBta3yjKiHvD7P1B1FZLeAshTFQ98ekm0jhmB7aYS8/Ag=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0YsSQmTJpJHEt2vgloH2Nn1yILXyTJK15tPldfUT2ZKJ1RXtDwAf58S7MHPYghHw4bIYNUdFDs+dYLIRvLFchFIxzw+V+i/OdPfhv4qcaiCxwkbttK2PDE10fKLuUq1n9TLt1UvC+1Q+InO3JDsIMq16TsV+P3Qx558+GckcGB0Y5wsw4f82j5HBLZMe6UBT+pS49DfQCYLsR/VdnS5MOYco0SYZJeZ5uiXuNWxqfwWpNUJFxldKBLoCBzSMkWPDn4TVhg3GwdPjvypE/Q4wWxpKsl0aDRJR7i2yc97d9ZySZpXpjJvyAvmFU/5cmWg3i8E+TAMZ17iF8eBXC6NPC7xoNJNhM5Qi7C3F118bYZswRZ4vL0LTsFrpazIQgHMfH2jA52Si618UPnuK+qGcBImtsbUjGb6yx6fKVDcIOiJVwmXPqf/3sqEzfWrmDHsDhnftzuuqzXMU1lqtNdxftN2i+MqUVyocC/jpbbpE+HeWR7dz+0xh51Dgp0jsnj0mvYu3DE/6KOHCbDiE32alpheLPVPcc2YEZ1rqZPv3Q47eqrV70FfVtNEattrZ8KfLC9Z075M/+Qk5W5EXyXVv58aCpF2qhUSlsa3aPiJRkwcUqGkXmTckepKbZElfz6Fpmd0I5Sv+EB5bwUW7E4N+YHvrqXTeWhfq8Ghuy1BLK1SMY5Xves7xSuoWpBrCpSmTcy/cFx8p9qw6gXoRAiEqY+cMsAP/xwEPoXhvW1NdANft3MXFzSClTCPWyutSVuBxBgViJ1fDhY2mDEaFPFQxNSPSOPZqzCsFkIKfhbUFqixlEusOO+Q4KE3xvQo9xqkiziMDBuKUNJ0bVJ1LNrLyXCm7n02zucKbEeK5nwWW7g6R7cRvwEHVR/qWBG8GHWgVuOSTxoudR/9cj81kmgQ5Zl0sF3gdEIg5h6rlQwSz0QPw9E3YdmhDZzDvHhypLgis5tT057uIPO/VFgwmDU72vneiaA+XkjGd8tOnzXbgmYcO/R9t2k0mRJI/XqXXA9xxD0Nq68sXYdhtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAP370gFTGTyY1RDMgpPpOeBE4KJlzJQA9UAzkrrCOFjzS7xBWibaILgBJQmBwKppVx07VChkBhxyqHyW7UR5FwhrO1YQhOwidsEfi6oLcrfunwr2UYpbvqhKhYm+cq7kWXqcbMT0VMq3niP5pvEhqEz6Elbn2EpYD/ETXTyr4qIG"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "112FCE72A9897AF3B1EF63EF125B1A54AA069E44299AF3DAEC6FD69667FE689D",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:kfW2O0a6SxLzw7hKPG3MWylL3yJfL1xvDo3kjxmFbXI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:NgATDYvcMWeFVqeaBPAZ86JdxFqbjFjzb7JrAWBC0eY="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803021279,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA+seCfxX2AI39+N63WMs1l0nXVVOgXYO1QDvmxhcuVaaPd0xcUh5/HQ/wzq4f/ye4pO7LefA6YeEZ4QbH09hDe72Q/M2Y5GiTiMTDDLVPxmmWp982EffOJ99LwJSoE2vwPyZY3zLewvUmVwSk5k3FwLx9a9zrv+6TZqzDOpg1xewLyzxo7E0+wSW1pIE2s11Ichf0bE8xW6y3YM+EJuTk3bJQsyARvLL1LyNL3yjKXTih1x0F+atyi6a3ePxW+i/dSxBneq1E0bHMY1CiRo+qXSySgetf5R8n6cOzdNSYgkorO1knBYgxjAruQEveDorO8M/uulikJ04ntDPXxI0yb1J15wQmsuLs/fBHD0Vw8m4++aQTSuhHA6bYD1idBLVlaLKrC59GPILJc0UOrth1vhn/HMoOtkPM1WNf2tmbtltXyCo4KCAqb/Z9WrHUMuFKGsnUXftqlgUrR3SovmirWCJ3cQuiUzQy5UL7ciME2aykLyOwZVUZPSk0NIA0JkZvIUAsj2O4k1K+QXtFy+7bztMauuBDO1nJOJjRSqZlQ3fJSgI1JexbpyCwJKpVOc0sxD5/m71Bp5RrKdlCudru9gG46Yqa22mIb2Sw/txYpIdh4ZD/UqcpWUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwauJ8Wm7cn5nl8iglTlkp95P8gcRovt8Bt/1K9NriFmGBymwPYyxLcPjxLdh+DjKp5ApM8O4WUKdL9n6bLe9IAQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0YsSQmTJpJHEt2vgloH2Nn1yILXyTJK15tPldfUT2ZKJ1RXtDwAf58S7MHPYghHw4bIYNUdFDs+dYLIRvLFchFIxzw+V+i/OdPfhv4qcaiCxwkbttK2PDE10fKLuUq1n9TLt1UvC+1Q+InO3JDsIMq16TsV+P3Qx558+GckcGB0Y5wsw4f82j5HBLZMe6UBT+pS49DfQCYLsR/VdnS5MOYco0SYZJeZ5uiXuNWxqfwWpNUJFxldKBLoCBzSMkWPDn4TVhg3GwdPjvypE/Q4wWxpKsl0aDRJR7i2yc97d9ZySZpXpjJvyAvmFU/5cmWg3i8E+TAMZ17iF8eBXC6NPC7xoNJNhM5Qi7C3F118bYZswRZ4vL0LTsFrpazIQgHMfH2jA52Si618UPnuK+qGcBImtsbUjGb6yx6fKVDcIOiJVwmXPqf/3sqEzfWrmDHsDhnftzuuqzXMU1lqtNdxftN2i+MqUVyocC/jpbbpE+HeWR7dz+0xh51Dgp0jsnj0mvYu3DE/6KOHCbDiE32alpheLPVPcc2YEZ1rqZPv3Q47eqrV70FfVtNEattrZ8KfLC9Z075M/+Qk5W5EXyXVv58aCpF2qhUSlsa3aPiJRkwcUqGkXmTckepKbZElfz6Fpmd0I5Sv+EB5bwUW7E4N+YHvrqXTeWhfq8Ghuy1BLK1SMY5Xves7xSuoWpBrCpSmTcy/cFx8p9qw6gXoRAiEqY+cMsAP/xwEPoXhvW1NdANft3MXFzSClTCPWyutSVuBxBgViJ1fDhY2mDEaFPFQxNSPSOPZqzCsFkIKfhbUFqixlEusOO+Q4KE3xvQo9xqkiziMDBuKUNJ0bVJ1LNrLyXCm7n02zucKbEeK5nwWW7g6R7cRvwEHVR/qWBG8GHWgVuOSTxoudR/9cj81kmgQ5Zl0sF3gdEIg5h6rlQwSz0QPw9E3YdmhDZzDvHhypLgis5tT057uIPO/VFgwmDU72vneiaA+XkjGd8tOnzXbgmYcO/R9t2k0mRJI/XqXXA9xxD0Nq68sXYdhtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAP370gFTGTyY1RDMgpPpOeBE4KJlzJQA9UAzkrrCOFjzS7xBWibaILgBJQmBwKppVx07VChkBhxyqHyW7UR5FwhrO1YQhOwidsEfi6oLcrfunwr2UYpbvqhKhYm+cq7kWXqcbMT0VMq3niP5pvEhqEz6Elbn2EpYD/ETXTyr4qIG"
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAA/Psc1HJVQ1V7BAm9iJlGA2G7Lmvo6LXNcBV/5p1glG641FkbcUhYvGBv/COSjog/4XL7eOJE5Cl/ZKh+QszxmvaCRWYOZYsiu+nPgFJzAKeCSi57yXShClDA8axbIDuVWwIabJ/py92jadr2jp6ioVudU3bxZFHI8HM4tIaaTkUMqB/XgBPyh76QmUc2e/7ngD/hbu2KJCZR1cRPNpJQ1iSvGEXKWVoxrfJd7S3tb9GpCeLrPxkWZOqNu/ArcHISdBBfHKa+95zNfUe6Xs0bGtUo3fJroLOFeyzcgW78IkogY/HkWt6QKfQ87gvJmLXjfzmEeLv1LBffyo8Dr/udEZH1tjtGuksS88O4SjxtzFspS98iXy9cbw6N5I8ZhW1yBgAAAEWDejeeq6JuJBuLyyp4gC/4AMOCz61RxZqrGv9rYtZIJrzUAWSi2F8uauB0diHxzYIUVAF9VT/vXKc9YZOzzpfnbktFOevArM/2mbtQ/uIoWv+f2J3Udeae7x561kYgArIiJNc4TmrmclqiV7CczbYSEul76uPPNExaIjqQmj0KqiDOJOyiGGfcmloNX9B3QZCn8Fkvzg/TPeALQv23Upr5GAgx4XY5WkzVch1OQZY4+lDFlr4DMa5vyi9aYvHVWweqFgAdLKwtf3M1UHWxc1lXjZp3cQSyGyOwqVWIgG/2bxAQjaT21RYrg/JKxuBQ8oqoBw1pQRP5barHewTYJ4ra+EHgGQ+kw3BHiGko9DVsiUcWUY+yXIzbhUxEG26bpWYIhHRUPy3WzCxjvYeu0TAKEo358TX4LDc+WobJ67urXuY2E9MczLmocyo4LrALC4ySJQ5NLBgVvdGvHfqoM2K9OVR4gUjbAPDhmats2GbBCa9HXv6KvDk6sAwHKHJtSKkzKYT28mmghry5g3hn+m7BzjY7ZznoDELqIZp4iXtMUkw41yyKLnNOjL+rokKyj9YI8llG2hcIKinJnoodb5+YuR/ZEjXJd92zXHaq0DvLH3/Ql840TxfVdJc2Y0EiOapaiRUdf/QvseGMTG+5MSwFAh8iswbeHYHRq4NTm5MHrTHc3+cbkCLy0Tjo2+Qlb1CHXuP1K0rrbpINqPpE87voYgMhjrskhLnThEWDydoIAL1t18v6uaKWHbRMj6NM+crfT3UCx6ufduSmGL/Egf/uc5O6Z+YlGcA4d5VbVn/eF+14E+b0Iug6lT3F8QlYBQaE6JMdfGEC5SMbK1uAALQrT+bF9b48oAIAAAAAAAAAuVqoSLN+W2FIODlvZ9ijgLKcdRarwXKGWv7IcK3LJK3S/faTjeotCnqCJNU7CcoMURFrOzoB1aVZ7fWmMdkhAw=="
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "2D563467909A1384E8F52B398A427155C5EF65BECA5F3A640F09917DE0337B9C",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:Q/3n9mjz5iqs2dYXfl+J4rq3O3Z3Q8+6QMKWXok/uSY="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ObWb6lHlfBOpzWrKJa3DDKmm9o3ndTRtqmSdPmT4Tu4="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803022936,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtigHER/wQu/WJ9OiH7M4uTF6cOYVFZ4MCoZ9X/fFVFyYQeX7c7qCdgHafnf8KAFA/k25bg2GNk0cd6QYxRZAVPGCxhy/Lqjy74vkLWjIguym70dB/Gx9zy6qLYjwOHW3sCiphJgwvctgBsTpAvQ2K2gmXpSfmtEsZai6XH72UnwS/zJ6CKjoQWldyh2hHOeeynVy2tvC0Qul8F+EW56mmIUxwrD3oOYObIg6VO2PLXuo+2vXVLBy8WlmIETDA72Ej1BwN3ooxbzChzg/ZDojCFtsFBJlTgrfYz+ULb7iAC0NNt8RwlgZd6IZp9KFkyN4oXAUoXC8gJRFud4R8cbAEPS1zbw0GIWjR2flsIkbJuZyVB1EIZOKd2FPhjT30gg69QZj1n69/GRshtl/aVroF2BqEIhRFtl0rQSg12DltzjoQo7ADejz2DYxJH1qnYziCKhWwLaqkbOiW8Cd0kKg0hqVkOVqsV+JDSDjG+SEWwsheo6aNJGb9q709GK4qn+GAv0QjTEza0nC928ctMg9fEaLxuunePnEy7uULfGv9S0awOuIHs36y5zTRPwZAk+kiW06P/uddihkNPYVotBcdauAlzEtebzaoC1nb9GFSmjJOZdHoq0InElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9yXkeXh0TTuHy3ytRetZ1awGNmsEPLSTRuph+rOhjULKVSHBU75CN8UoWMoyN4weeCZOdJVeF0+M+IhqVcklBg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAA/Psc1HJVQ1V7BAm9iJlGA2G7Lmvo6LXNcBV/5p1glG641FkbcUhYvGBv/COSjog/4XL7eOJE5Cl/ZKh+QszxmvaCRWYOZYsiu+nPgFJzAKeCSi57yXShClDA8axbIDuVWwIabJ/py92jadr2jp6ioVudU3bxZFHI8HM4tIaaTkUMqB/XgBPyh76QmUc2e/7ngD/hbu2KJCZR1cRPNpJQ1iSvGEXKWVoxrfJd7S3tb9GpCeLrPxkWZOqNu/ArcHISdBBfHKa+95zNfUe6Xs0bGtUo3fJroLOFeyzcgW78IkogY/HkWt6QKfQ87gvJmLXjfzmEeLv1LBffyo8Dr/udEZH1tjtGuksS88O4SjxtzFspS98iXy9cbw6N5I8ZhW1yBgAAAEWDejeeq6JuJBuLyyp4gC/4AMOCz61RxZqrGv9rYtZIJrzUAWSi2F8uauB0diHxzYIUVAF9VT/vXKc9YZOzzpfnbktFOevArM/2mbtQ/uIoWv+f2J3Udeae7x561kYgArIiJNc4TmrmclqiV7CczbYSEul76uPPNExaIjqQmj0KqiDOJOyiGGfcmloNX9B3QZCn8Fkvzg/TPeALQv23Upr5GAgx4XY5WkzVch1OQZY4+lDFlr4DMa5vyi9aYvHVWweqFgAdLKwtf3M1UHWxc1lXjZp3cQSyGyOwqVWIgG/2bxAQjaT21RYrg/JKxuBQ8oqoBw1pQRP5barHewTYJ4ra+EHgGQ+kw3BHiGko9DVsiUcWUY+yXIzbhUxEG26bpWYIhHRUPy3WzCxjvYeu0TAKEo358TX4LDc+WobJ67urXuY2E9MczLmocyo4LrALC4ySJQ5NLBgVvdGvHfqoM2K9OVR4gUjbAPDhmats2GbBCa9HXv6KvDk6sAwHKHJtSKkzKYT28mmghry5g3hn+m7BzjY7ZznoDELqIZp4iXtMUkw41yyKLnNOjL+rokKyj9YI8llG2hcIKinJnoodb5+YuR/ZEjXJd92zXHaq0DvLH3/Ql840TxfVdJc2Y0EiOapaiRUdf/QvseGMTG+5MSwFAh8iswbeHYHRq4NTm5MHrTHc3+cbkCLy0Tjo2+Qlb1CHXuP1K0rrbpINqPpE87voYgMhjrskhLnThEWDydoIAL1t18v6uaKWHbRMj6NM+crfT3UCx6ufduSmGL/Egf/uc5O6Z+YlGcA4d5VbVn/eF+14E+b0Iug6lT3F8QlYBQaE6JMdfGEC5SMbK1uAALQrT+bF9b48oAIAAAAAAAAAuVqoSLN+W2FIODlvZ9ijgLKcdRarwXKGWv7IcK3LJK3S/faTjeotCnqCJNU7CcoMURFrOzoB1aVZ7fWmMdkhAw=="
-        }
-      ]
-    }
-  ],
-  "Accounts addPendingTransaction should not decrypt notes for accounts that have already seen the transaction": [
-    {
-      "version": 2,
-      "id": "24720805-076d-4858-b752-c65c75a4c27c",
-      "name": "a",
-      "spendingKey": "5c11721b1c4e5ef4e2abd4a3532f40b3437e04e5f336e4e461d45424a76d4dd9",
-      "viewKey": "a2cac67c0658317ceab8dae408dc683fa0ccca56a9c69047c84b98eecb693bc9262571d97ae4d575803265856da75ec7803ca5341214431f86c28ba3ea238a62",
-      "incomingViewKey": "d1899ca97eb02c967492ad98565a74cc270b5db91b57d8ae7051e815c1698804",
-      "outgoingViewKey": "346d1f017a263da88d2f212a99ed0461c4d536b579fbc469bcf382a163e0affd",
-      "publicAddress": "0e864cc672969405bbf0c59a9b7f65acf5336f213ea65ec6ed17e5ec815a0c11",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "58c41ea5-29a2-4107-844c-1a6dcccaac15",
-      "name": "b",
-      "spendingKey": "8aca308a75ca3d6e43ccb6517bc17ad44f53a262ec651230e5f8087697cc07db",
-      "viewKey": "b3a99bf0e6e1ad16ebfe5915cab9c2e36a7311537e8db367427d7d4e65c7e631ee490b7732e579d9ad39ee431a2fdc830f89a6cc4ae7077bf0e428e2d2ed7fce",
-      "incomingViewKey": "c486e2e1e995f9d8ca4636af0b093f65d8f3396d9f85c2ec6ea0a0732c682d07",
-      "outgoingViewKey": "f7994b069189510702806e3e140dddbe7eb7979829b979614c31aff2028d86e4",
-      "publicAddress": "6ad2a23c8c363ac3f7b1370c9a40c7cf774b3efa33c25c4e4b90c5bd623fb5b1",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:4u76+oj+hSLlW5qWcrEKLwMPcDUTXObNQYsEdfQATmU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:0bnEYU8zFupmmc0Ymjvpo1t9nyrFpoC3voWhLlaEM3I="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803024333,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAnZK+zqZW1REuQVQ6EuOv3SaDU9VkvXJzgJqCBIuDouu52ZnOiVdB2JhVKAv/uFzvIMLomAd0777DlVnBxYUM6u7mdGHbqg7NmRGfWrDdSw+z4GIMnXMB3ZIrJu3l5QkCjfP0lYatmOuUKKLU8Zca+iZ0Z7bRGi2USSmqDAlE4WMTC+uVq//gm5U5ubqNS7cftv6G8S7erY2rnNhHjeUPQgPEURRvLeq8Do04Hkov9NiLyBpzit+DKRQ1eHOp1vSdgzD0gvTd2qgaQ5IUt7kpYtwuTpCT7sBg4WfvDZxRHsZVo6YEXuTko6iYRnl3hMgQwQ3/zZYPm6xO/zUeU29QXL1UHbl6NmdFc9r+gU8XIL6P8T18unbNVahgeqoK/QZzn2KrXbepFIX+vM+6bAtq/Ch8k3jrc+THiZeeP4bdLMS8ihtW2hgXEL4/bu/p3/k2IdtvTeZfrj8cOi2JDo5ns9h44Y5qn7f7nhP1UDLafatkvH5I2cKxSuvwmcMZLi8hwvzbYWMI0SnkOXM46//0ZcHeuozjQZoegCqmsCT9YWL33ZPsIPJvryEYsdDHhEnJBzr3r8/KprjeX80HEY2gti5iLO7KuN7w06mCYr+8TCfprJ99pLd+HUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4mcWAU3elovWBDed4iqJDXE3G0rLTP+/g+PTv7yyFyfxsYRcLCB6bhbW5xFexZuO4A8C0MIrpXYmukaP9cKAAw=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALLzN2FSzhN+3D5XnKPCBqAL2EbD+ffuSzL1WZYdCHlaQ0nxDsHGlzSUMHvHiYatzTCvCSka75XEXq1Y/JalRI6KS20AECC6n3FLC/U/8FKOZ7njbOZDq4U9sn3+263iFvLJSTsBcEi02ZmXt3C9Y6mGtd84gD057SFNT/pIcalQBSH8wWQ6i4uqCoFZg8vvlkcCKNzk7DxINIdensGvrXiO4Ls/8hZEEasdoTqmHQDaKBbsJcD9xy0KnVrf0W2PfdSid3IWQxjcrViRpRT8MA4C4zzZEooQxk6TNcA+XyY8FBGDf83btGunkqNyAr7P2CWFQNNF5Pvr+/BZG2qpOHOLu+vqI/oUi5VualnKxCi8DD3A1E1zmzUGLBHX0AE5lBAAAADOvTdin0hGIO92vWCFMSxLsW4RhqVn7ilDJv9EDcRzDbBnLdp9ZAHr/99U42fYzplMajvyM7BPITWiCzMVpJsCj7n4BA+C8cnLRNWhgSwUh2XMnKoqyN8VyZqdmH41WAq6cjsAtaUn6Af0eZSMZ4d1fRSX83k/kksUA3XqZgusIdWi8rkg3dYalu0I+sU4FBq5dFxfRink89AE7I4HgOjK4nnnZAyriX4iHBY19opORT3qukMOMRChW/xs6GO022g8ZmY/+DRYZ7H3cFYHdsEWdm0um3vFfhtbrNvrpBgABN2fDWykdUHPwAro2oLJ2KJTY7xD6ZztowaVgGr3gc6IVLByB2ljeTMN5+wMuJnniQ2emCjEZ693RmCUaDdTz/G3mE9HzjTmPdnZGCX8uF0iM4UjNUmWNjCQI8PHX6JO3FXmfjEjn4lr9Jv1wnTxzuR1MX6FGhijM1f688E3XV2KG+k8MbqPG/4UzJ/1NAt2dvvmEylIvMIiigRyVQJV2qocavus8ZjpNSjDkGvJpJ4KBmpju8nPWVUNtSWpqVNy4ymPGhzGt/q6OOfkoAeRFLjoupHTWU5FF1+V2SCMKx78adL6can7aN+/+93Loc4myEbQgGSlB6RWV7yZg68aqclcdI/nPBG5gZPQbzSby7ulcFlqSsmLuCyMKXmUpBvfqsBoNSMDV59YxXxZOLE0bU8RXiu8QuctCrM1AoLnxJZgl01jDgoB94nSECkwwpaQq0dtoDVCNcepHU7EJria9iJWyvAXyFl5C3sUOVbxEyuE5Sfo8DwYLxCF46IqQb28jDLpqAQvjuW+XOirIFMgISBYqtiA1vQEyehK+M1zBpf65/jVbcfxnZiD9OtWS3H4VFyl+Z1o3XcmKmKl/oWV3pQ6Ovb+XJ9tzP2wMETwqVJ9MXqnjWUf+IYxtJHgzSXh2PhYYIW2jan8Ats5hEHJPsgJS6Ke6F1A71sbKfAeR4bzo7+LPQRt4T6Wf0IBrQMNHfoGZsSn0BUqX3sneJ0UOuxodriL/AEE8LgAk3xRITIemYQqJJIy8zWv3GfEVHk/sNe8HY6tYRicBx+e8Pt+72njb+n6Px2foZbVF48CbGsm6eT+YmVZkadZxBSFVQyUswM9qZ1SpE4+73+inzgFQojAhZ6ZB5X5NxAfBGB1dIYe8rcE/r32BwMxu/hB8edcSt0szTNOOFjCBiM5NqEenXaQoEhPsjR/38cON3JM741m4Oi3UjqojUPdVXjnAYH4OzpUO/mEdKqdwAnPfRvP8hL9zsGH2rMNguiDg1ELUPq08dpRIF0rpzOBMb1F2CNoRzO6Dr7cdXbwXM8c4lL8Sj9bKguc8AOiFYEzwZUkP8MbTNfa+phicfhbA5FYlEkJVEeDP1lij5/sODPHTLBLLcbVvWYM9d391PlUoksA42OsK6w/gApxsE0JJWuRJmx1ucyx6hFTPqY70tt6e0NLesFpo4Cl0a5GHEptyCmzIWf6MF1QpYigTT0OaQnKjMTGg1NbKNPiJur4haj8V5iokAhCBGVgBxGM5KjGySj0A8zg06CsNV+aboVATgIbBFtAG/Cw9Zzubc8ZjuBKPy3VfBA=="
-    }
-  ],
-  "Accounts addPendingTransaction should add transactions if an account spent a note but did not receive change": [
-    {
-      "version": 2,
-      "id": "4fede917-a214-4b6e-aac3-e581e612fc71",
-      "name": "a",
-      "spendingKey": "46dfbaee8083679834f98ed48ef99259b5d542832b7aec033db8757746162e80",
-      "viewKey": "8584bff382304b45a6bd45c69354a2427c5f9a3b061b2b18bdc8886e0191efa33c95a7c673d83cc0cbc934b68dac17db669138d2afeb38a3e3d169b9ab3c87cf",
-      "incomingViewKey": "96cb40d8d506698ae28a353f7725156c0027185bca28828430be28db9660e006",
-      "outgoingViewKey": "2cda9e3a3d89d3096efde2e5d68b54e5507a915ff824a513de5595ed3e3aa2e5",
-      "publicAddress": "6e4a954d019b0b52cb71dc8ac1d410af42dde0360df1d1d33101734b159d81e6",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "18b49edb-8bdd-49fa-90c7-106069620bbb",
-      "name": "b",
-      "spendingKey": "a68c1a89b473502aedd213db687f0cc774d23cdb8cd2ee611567b2da3b2cdcc2",
-      "viewKey": "f9dac49d78906278a68cd44c3e04463c8be6ba335a0dd9e49f03e4d3152bbec97dbe45a74a1391e3058ddeaf947f45dd5f0845f4f7d20a24f12679d5287b6fb6",
-      "incomingViewKey": "90c2ed779985fa9562f30e662085923de74ed76107aa8b6bf7d21496330a8901",
-      "outgoingViewKey": "a0074d7aaf5b42f566067d4e0a9784eb10c9846b62bc64f51fdd56c74b6539ff",
-      "publicAddress": "dbbd7768f7da4ae9c339959c3402bdc91b424a01696cb18e5cdd849bd3d00c30",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:GmHbJu+PNUT+SBVT3N0rv94bnJ/jThBZoFC3YNjgFz8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:9Zmgn9R9qsA7kAyd5+jZKwQibX3deLZy6iUVZwv6NGw="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803027273,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAApvmaRq5A7pXMgjWn07T5+BTdWaEXNKigwPCLq2NdZ6CQQkTtMocbFckSLV3NZfUhP+PVZftFxpe9Yg6hBe829N5C4g9aCfChQCOwKea+HMSwT2o2CE+aVHrxFO7YIR0AAzOkLSGARIyELCU/SpGOz31r1iRBJ62jow7aCwPYzIYACwB0iy8Oa66W/GuDOdWOBV6j0V/eFFrV6EuCQRE/xeORCZsHrnm4hchsYrbMS6Cv2XWbajz8A+wiqdSENSqsQLizO20BqKC5bCoNUtO3OQ/zCFQwrFfe3r0llAbfbKSw3SMevtg7vzLIh2IU6qLPnrPooT9oVhmHyRvBersQx2JD/F+MBFjZ/+hOom/fs5RYTqaA0f7GsFUv45DSZpxdn2Sxr4EqoYvSb1dBliScF5oOQzN1m0XyAvoQLArHA0Vkuc5zsiAT5rAVl9cahS7STewIJGg01qd2fbUp7sH3fBBv69ew4TCJb6Wnkq74Xa8uMv2IQUy13HlpilcLLxlDdQ/RPjPa0ouXtsbqE4jU8/ArW7LlOv9EmySOmpJ5Hu2quUoHwF24Gy9X6yJj8eiCdgi0BMpH0hVbXuenppEI/FzcnXUSKUo20CB6Rj+lOZoo+UtRSc6CQklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZRuW80JO6b0VIlvLmEee3JLBbM5GmaUbePhgEyuIGWv8KKAA5Yhlzz+qNxrGFmxpaqN6GlqN2sGniCONJ+pfBw=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/5M1dwAAAAAAAAAAN/cesq9i5DBtmrJSxK6TBiLUzyczf+F6bIhbCS2XOVyyV7GGGWz5/QyqlzssgXvxUdKj9OxLnUxe1MMOKxkjErNS3BeIPulNV6uVHn+TmD+NpMvkWmaeGjqPgL6DHlo/iRNkbqOIq9Xx9bjiPRvZ+m9JYNIfnW4ltDfS7WYx/eYGc46Jw7oOhd1NtzoxYoF/KNwMKWsLsqjpLI7kGsZ94v43VCCO33d71N33tj4tHQaWTGUvfSTP9z5PuSEl2bw4YN4FuAnQJrs2OTyh6BVIoOq5+wBGS3QjPe3SHR+yrjJNc/JgZF4/JzJsJNyYIw/TPCRy3VZ+A6XcvEtIg43f0xph2ybvjzVE/kgVU9zdK7/eG5yf404QWaBQt2DY4Bc/BAAAAC62UPy+IoG7BY048WatqRnvKaOO4Itbpm9SjuV9GueyZr5XtpyP4ge8XyyUCFSRXhve3K+iRgERRJcAiMvUq4V+XjdukQZ+Xqx8lhxwGui5mA6fWACrPeAYEWPR4/etBa/2JI5Bf7kSjaPBbPHn6DNmRatR801WO012kw+ypmjmpkabxAXSpNyzlgPwoDpw6YRsOvvPd/yTX7cZB8Kg1mgBOi2DRws6Dc7nyTNB9KB448b4jCWs3hGMzx1Nu2nf+BCw9PZpRbiRZW74qeOA3MUImvbAY+WClJtefTu5VAYEQmJIt0XeQl8fAt37mJGi/LH69+0NZN6tCKJHrwj+d1mf51C2PC08ldsOKdqjNCCRd4VmqaxPg+918fN/DKVB9vnI1gCAAbX0Z0jC9AhH1mg8aWhGNVygR4TnCoqB9grTQ9ccG/gpjHmwDv2ca0pEyh1i7+rY7u55RNiPK6rSQDUwczvJF9BqvaEuh5zpLIQsIF5kele76dyOmqNNG012X1ogs318n4tgCYIkFT/GRxwTobV88VIBcT8UI9s0PMCz04j7imKxZRgLDkf15McB4hOJJq4yqBLpxqaJUtLv6E0UI2vp1fzw66Nej4ByyIPHZUdUNRNUxTrTU2Vtu6ZjG6FTAOxNj+XiJ81FsI7zBekeEZR2vVIcqV4vu9UhGozt8qLZ2P2k1K6vDfSsAIM4Y3iWuJHlRy+CwuShs8L7AL+uFxPhhpVYjgzhf9PzNYBTVqbcvpD3aTP3M86lOJOWREPeWqWSx1Nxusy6g1qVAVELr2+HI+zJljKHBSz3cVvCC1eUgrx9xQQkbZ+q2t3WvtbOR1GVoLSXfdxtrnNd1fsiHuxqLNvNEhxHODxhFGUGQNx7L63pB+3jDx2XorIlCC9JgFgLHz4A"
-    }
-  ],
-  "Accounts connectBlock should add transactions to the walletDb with blockHash and sequence set": [
-    {
-      "version": 2,
-      "id": "cd87b860-9cd3-48b3-839e-2ca6351c8d90",
-      "name": "a",
-      "spendingKey": "16026f283984f1349352acd04697c505f67e375cdbe37fef044587f2721e65b1",
-      "viewKey": "7b7dcf08fac0019f0f850b69be1192e68f25c536b0c56fed53c076f058a6d4ddd0959018facd055285630cc268ad3e1021a255b41f3609c75244ac3b2a9c46ea",
-      "incomingViewKey": "2244e188172f6caa4728dbb12571eca5662623f773d49a253f97f9478c8e6b03",
-      "outgoingViewKey": "9476e25a8c1451ba8cecfeb0347b2bf7c7da028fa4f92b0b8a22bc06acd20ece",
-      "publicAddress": "a71ca871d5718994982c26f47b0d6cfecdc85a858b3f38b3844d3b8073a844aa",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "5a892eea-1a80-4496-965c-80324322c071",
-      "name": "b",
-      "spendingKey": "8d4497240f078eb7466ad5ebf6e785a1264cf7b07cfeedcaffafc7ab032f245d",
-      "viewKey": "cc39dfa92e5fc056daf0801a6abb6b65e821ff829a0b7db6a885335851415fa68de91d9a753a59b838c3d9aae04685ecb3a2ec3f3bd3e4c2aaebb2893789ebb8",
-      "incomingViewKey": "83d7a8d3a56785cf77daa43a2c04e92ceedaa445777aaa067d2dbdc89c981a06",
-      "outgoingViewKey": "b4e6c8d77f98de4d2c0c88f6d17752182b508cdb5bae5a6b98b149eec8c07f8c",
-      "publicAddress": "846862aeeba43b845f96f5dbfaf02caefcabd247d173a4a4980c5c897552d9cd",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ak5tTTdsk4pOM43v+Rb89i4pxGoBIouQIF7TGuPxkmE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ycAlnQSU+9Th6sUIDyIq284VW97dwqzaxCOlRSxye+g="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803029923,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA/9Gh3XAwxENKHigEjKBbf6yb55FFPGf9qXffGg6VETWFQaqTzCj5dEZmTXcIOg7RPv+23p5Ao7LJW9r117lPTB4a07HqyZz4rPP4IaFJSNW5wIEGY0+HF2ZRel0we1hC0BYZMTFZN41w/XvM6fyTSbZH17BhtFTRm0B/Znx/2DUSHAYuzssSherHvbHI2B1ArDwqzuSJbwliD1T3J+LVHoXr1RLhY11R7oBvKENa+AGUBFMSrxmcnFC/TUqhIaEyF3Vjw+ddpOKNQlhKq1gDvoXtXtfUqr7GPq3HWRLBo6SFTSvKYqk0XxSi1H4ndnF53qlCZDFN+MbJlka1OXbBm1qSpybLA0SGaqP/J3Cpuc8r1OuX7dTm5njtA45YDsQ6XeJ3OUPA/HF3zmN7Tvr8D4nvScFnb11AKpxo4W/dJ8kzUq/873OgldvBCEzZdGmK0A85GdhuZLEUVwxy3QeF/Zq4H8MEniUsTJp4RhXTuKHruaEqI92tDtfTC3DTvEHfol/V70vqgjda3AcA3you/ygu/JAHp6vhc58OTizk2TrCfz705ZV+VHX4FbZuv1D/Yyvt0NYjNBN+SWf+OfNLwUNViWyh0qYCHT7OGIlwBF2VH5mOgsfMcklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXbXRM7dA4qI7+y471tjWLr0wgmrU9/whcLMgHmgVhhPUv7Y1KAFEAxGXcV+m8z++aZwAhUPTzc9xwfIXoE0KAw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "6F7804384BCED539734DF38D957BC6776BB97B01C73DB87436D6A8196EE0AD46",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:qU40aLt9pbMHnViRlg7BDotOhnhwv5L5pXHHve5EQ24="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:sSJ+9+k1F7J/izziWZUUUvyzf5wle6pGklsTs1vA4yE="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803030336,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAArbn5pPBQqqHJtbUognh/jOsxWBXijENED8jadtsxi2uWwEhjb1ZFM9D7doHlZhZFNMfIXyno4NqMfI6W73d4g4py394d80w99fqck9Ngjq6DwbIIDN8T8tuiCP4Wv1shwxG5d1vCDBZ4oR+jsmdGU5Tfmg50i4Ge3IhWjnRM0JQBzXurGmNh+9NeqIXbd2QUGffdLyXAZgAfAfmAS37ZI2VlFmMGnIpOzxnhtu68BR2vmka/4Nj7RVp78MuVYbKIxyi87TpMXb6X/lACwsGFSI7KQSKtnoR18DzIb+gEEI08NHeh679vZculM1DBHZkQGHBFzw4fWsvGu+9QkKM5hJpkDvolsT2KcgDSjPUgy/ATXNJxkcoWDKMj8lIWDY0DcDdpFyfrqqiYwvdJNAeOGWJMX8RiG728hpfJAunjRO420YrVt6SNjcxjgsT1nDdYtg0F9rMCRgdmCIx8zDy5hzTYrpyvcXvbHNluPW+6H9EeocjFW1yZM1R9wywyNr7004YW2IWqaNGMm9C2chs0D4dDQ9VH+1pyFY6WOtzML85Hj1qjFnwr+FsLQcFDEUsvkU7e98VjTiZLXgTQH6WfrYfAVPksSakCtWFoKVQLx3DRfFFddK090Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1WYF7pMxqjWVH8t+QNXfrWQWuNsSslhgPfL1L/emfcnFYIbAZIaHlfJVPfKpCrWPhmgw64c+ZgVoBn0kgA4uDQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "713E37A93CF5650D6DAB6577A588B59C068669129B106862DD4C2ED859B496BE",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:UCURUy01RAut8UvJyVx5soXsF5v1zCHRGj+1aFhc2Rs="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:UllK/56redyeOXVHrKOVw6dMaDcgYjLjlaYAjCTRgDI="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803032348,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAJt/LSGfx9gdgh0v2BSTY85XtypL4mPX4IXxptnAjjgqJr9Dj6kHdOFSGefejUwS9HCkLPNjuzkfsZOM+d4q3VgJfU4GAYB6q6zs9qyQ5XxWMWnNak5X/IFDlRJXpBTOSraPo9sPWs6aRt5LTJVPe7QU4CF/6VICkRuCJJOXt3uAINdROQd4FRVJsPKw1tBXHy2gOpF/J8jPZK/WgRKxgh20JltogbRyRa/G0Uqgn0feqzWkzucV0UrxnAhpqplMYofJNE3uZOFexR5n4WoaxWPZxx2k1Wmn/FL4VmpDGv+NsSw8aDUB1jO8DVrCMjBlH2lGsjn+J8LI4v0t1HTl6s+zUNZFoECfOFByJ6DDXXxqwlQxAqGGG6XVWuFZAckogsehlyMd7yTP/0BpbTfKWFThahCPX6UNpmrsRAx6ajWY1d30yBOVBIAUlYn/i9u+5QPfZxbEVUqFU2FXO2B1YUm8i7Fa/9/08ov8t6ymH9AG3Z7+xegmz/oSKmt0PzgnGwI7erW5rsb9Fyq4UOXlf4utwinRX+IcghQLRrSdr9iRgg9mmYnlsFh44ruOeiO3Pw41SUVb5gV6za/SwlUdLEkhZzARIF8SY1d9EVAMuVAEE6fEeNOmVyUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcHN/eQj3FHZ77GrnaNba3njK/YpOS+kvIjMPojsEV69FLtu5eNRmFpc+oGR+LRdjlcvYcpIU8KzvFUVO+6lqCQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAGYrXrElt78vIrDR9wglM0UdykL1ZRGYIs8SOC5uqcfOxw8zDUQPUn57Y/XJcmwsgosRv1BL1BJH4WWuIK3tPWdPkCf0jVTFlOFh/s1kjGsuPcrGBPXoXZ6uVHO53SuR79Y2xjvjmqyRehD0pi3y6WKA4snzmzO9SgSiTBzv3FJIC9t1ICdKZZbe77nTWspdgPUE+7sAY6NhVI9jJK6RZxwywEE8TzkooPhRA+MsMbLCF2KwyLO3f9ym5m6WG20SduTrLKknUpDTnNzSFioZkqYX67oyOwmTQaDgvE6hEnH8Zd1oCHbpKlGPd7FXq2kMOupfEv/pU+2qeFRqr1iMxGKlONGi7faWzB51YkZYOwQ6LToZ4cL+S+aVxx73uRENuBQAAAPzWbGP83P7RuPaciAwHmzXkfpbOWjz5RHEt07qQXdovgnTyliqOJ1CUFLeW4FrGul5CsTq2EewWTsglKbS3ouRGNhRwxm4HoA+J43rbiX/OED8UVazL3DH6Hs1FvsbTAotMjlGny4HJP2b8Xgbxtar1EMjFHFHFJwDWWJlPY8yMsoGthdCzTqqqdPlCE9qonrLDoB5jGOXxO/PdHx7cCw2eLmebXOVkf+QPXsy92R5vYtH/cgtrLeHjT3+gD14DTxlJkTVbIecp0JRzMgDJ6CccMjSnHynJ8bNNaLiLTtkzFFCsvaHjVgVpWuNJFsRIx5gg3e/hEIRiaFGyql9SDoVfQdN2CdSzlbDacEWMMA1i66HsZfqLiL92wzG/YSobPgMa7rPuDzgYxOGoyCAZpHnV7FyIWn4mQ+Jle3dlIIEDoNCcatDW521C1s81ijJme1NnJ4dK/sEByCOodgRVygLMOFMrmyZQn8T/oKjQrKYteWqWRsXstI6odhkXFACPB8qSdtU6uWFfu27NtwHcC8h4rBIHgbshPoHAJqgh0A9+974EEJRzjN0nRR2q9rgnLGesR+PYO80VQFT9nwRYCvHzaZKq9bAgpc0LW4w8v+tTII9Yj8Xv12mA9En9KOlgwxathQv+vlu3Ckq3EdQkKid2yUitRgWJylDT69gRNpkLh8br88TitXxQLXjCcI7CAYf8xqqNZ/12wJ0IyMycDYmiIZo76WhnMfNjVT4l5ZsRanuc5sdTKSClo7nl+BvJnp1hjNppmpTA486gk+tMNIwhI94ewTamRkWhgdiZtwEkJTO/jekA/wGQM+7yP4dzyjlTazH0ntcm6UU8OBhS4GVueKErGuDX+XsGsI9g4G7RudgGaBXbU3KDcOF9sJypoFwpgMaAO0XjwWJDZlxNuSVKhTLEaR7PbIPGt51qgVNWBm0MH5vnOYUN6PzL3zBzrAd6g/DZLpIKcgvYexgrwu4WpXXt3hgq++0VySYaWTsug0svULUo+faVf9gjPxqg6VsRS4sqEmzawdnbrYiSqBl9CVPrm8YYAUQ5bbYddCdUbdQCvSOlV3Ju1F0isktK1HaKCWeAjz3LBLVyuYH3OaEnrK9X38EqDexvEPHpFWgOG3qDr57ahdFNF8iOqcepqulI7hbOFuZX0BiyaUPuWJ86nIoWD+mRXaaV0Iksusm9GjSk/p5TkqhfoVfIoe3WL/qSUTpkM+a7hy7TLVuJGS4+Inh6oqHdiWzLKAPdhITIAwau4y9eCNPK70pYIDQK73zD+bBH9ynNtQq1qKIKYOFvW5v5by77ZlF8ov6UgZdNJDv+2zROkbEihPOPrwfBhDpsr9q8kiQQ8IV9k8O7TPypHn7p8mGR8o7tA+n8Hl2vprShuCiJfeKZUREGT8q3QFr6f1PtpxV8w1BZlVQdKiEsZ6B9OJD50ZtpB8tpVhgdsBjaqDqgGNC9yKpNv7JpX6htRHTYgCj6aVzyI4uYDdZKSINUjdTE+ersH1m3sNPquBsgY/oLLTeAo7Qj/b5UDBJWv8iV/3HPuK2uiHs9j6fNl+99nC4isem94cHZAJo//DW2IyiJB17/Llx3ikocAA=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should update the account head hash": [
-    {
-      "version": 2,
-      "id": "82c702e1-62fe-46a8-9062-026337a671c9",
-      "name": "a",
-      "spendingKey": "ab288d047cd98acd6c0b6a54c02bcacd944a251f9081616c53d0859a2f609835",
-      "viewKey": "de68154bbd6a5455fa2da2cfd8cb1f90a22f6dd5ed0b11285d5aa1d057c7b9e26deac324b5c686cb3e51a1a431f62d00c14327d3f2e4fb9dc8a314175bfd83b8",
-      "incomingViewKey": "51fdc3754c146054734b82b663794263259a6a829543604c55d07714271fc903",
-      "outgoingViewKey": "e4c4c30ece50b328aabe49137ccbdd6c394e74272af79634415dfc4781b81059",
-      "publicAddress": "697a990cd15d6b687dd54d078f15cc33be53c5ab3073fc92170c389616f64e30",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "a5032aea-127c-4b13-b99e-255a128bc713",
-      "name": "b",
-      "spendingKey": "092bde07b6f643b506db651df83c328dc1a73c36024dd39d4de5dbd39e5c7772",
-      "viewKey": "dff260200d5f64c6d616a53e6605863cf8d2c82fa9a49958a4c570034f38e28cb55d5ada0a9addc177a5270973170768a978312b0c2100442d9eae95eb67bf68",
-      "incomingViewKey": "fa1a103c498f842f0bd1fe0bb28bad2575528821ee37460b3f23f69dbde66403",
-      "outgoingViewKey": "318d25e25ffeda23955103cc1bba87b71a63892a63b2e8dabf6ab7ebc3784a1e",
-      "publicAddress": "c610f70aa21942d79c9c813d13f23411ff80fb86fb9685efdb3e6fc0103d3460",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:eiIFeDeCMhRhynm3JyB8bGVJL39zsRH/tmqrb05NVV4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:Zb+kFSQHJSLKsYMBSxy1b6lq3TJnaaLboDgJ4pDgPxE="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803033657,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAEZ3ZoKpagQLFmlvJ0qI6eMWgxRRXU4dIk5jSnJJL3VGtipNWD43iV0owyPZlt8vS9sA748CuHI5rTi7ko8C65OJmifPRgWmERz+83/D/S3eG3drjGl+koxShd3L11Qg9K+1FglA2AN5HjLFnepMATBZjzcUiGb2wWqIk2xbXKh4BpYNgcZR83Wt2i5tUkcuZHWWMj6xc3v+d+ntMXwfCi5LIarvUcrLHDPgnCE+zfLuAWuUC0QUUaKDNB3O0mhhExcK0oi3bRTx96eRJpsc+cnnFKNa4uP2yMX08zMxbT0HEUP0fHtwA2IVjV6h3Wc6NNJ3S8lTrG5+a2kz1sgbKNOplPaSUgx+Lq/yMw+VkAQnFQjSNgDnDKCF/RLA/oUgGQDQSrAH+BDGzDYNLrcP4tnUf//g4YrSyBWkZkL/Y1mmwdOjBlx59Kvi4eoLcAlmrXgkU+xLwSHtDxM8WNDbKsqOY5Cxc7ohEpX+OPPSgZm1LAD0qJh5lVPJ3l90tgUWBsPKgPgtoc8y7Qpgzu/KVlcLIEjRE8LxhjhAcC5/0PpcAtMBNavd9NPG75Bblh8edFLouDAdA1CNo+xast7XhHeqGOusus91Lh0yE3wOE1epIv6wHFO9TQ0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwknOcvpjY7T7xxtYW2vqfmsWTb4WcxAC/1ehlnAx0RE5d+eGylHXMyWuMN6n9/o2LguW0BZKK8+VB5IibvDmmAA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "BC8DE5C51143502A2FCB2B08213F0998695E69D815F4E543E39223111F223BAB",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:PtELgTwqaJrneQ0oVPvoQXEUXxtBpZaz3XPYY/vucnI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ChtclfGCbEDkt+d322ZAI8txbUb9CzShHH8hQi4Kaqo="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803034085,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA3cjpkH2xcZd6qVM6GYPGVVqswlRfvffBd+Jc2wDgzh2XX9QJe5dRwUaJv1o8cRtvyYKuepmVZTo3WdI3IdJOnLD8n3qDaN5OyKJb99eDMmysjwC0xnQdFqd1g5TRdxwOtXxq/PV2MK+4IUi4CLZ/el9ZZiBKQHwfblhyfiuOYSIR67FjadE+oHbmRaM+lmaTGx67Cfw7Tz4J5qE51L4vppI/gPmGFHLlE0Y09BlWCFKmNu/Qz2djOIKgcNzhgFbS64Tjq0H5UKyd4L9T+adjDwk5+YztBjFdzJBLZc/W5BJDItnr5i7vMaWhko7xhNcqLM29JHPsqj2kVMZkTYzlZRmdQopigNQpk0XmaXfKH6eRqgzsiokjcJg8v8kw1NcDatTEj4qkuRLxg2YrlUU757CGqEPYlJmt02fU6FCx/YoGi1lJz6vbXphohjTfpu9DlkXZJFX4TjiBku1DQ9o8JhPE3rHV7OZirNcH8I5YBlHm3yVi0ow5txWbhgfFuc0bPNWwTaTJsLUkwHBTR+I/M1TYFTFD4K6QZ+bBNh7eZEtZASWqEX2JakMFLkNy/TFyw5AwHg2XJepGSUpWHeM8+BPYNR9vyWJeCjph+BoIpoYnjz61TuVNL0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwj3tYnYSfXwv9oW/YgkEkA9dlvJdzeMeM7voD+rg/BJ9RheHEz1uUnZKmbjsH7+kn4DLibVIXqN/6m2c4Avq2Aw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "4C934CB1E17786647BE0B50D3425A4A38BA14E49A364645891A6B2D0E682329E",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:YkF52/GaWYOzyvBupUFjf+k8uA3FPZPSM8qxlb+H2G4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:TLi7mz9vlJF16S2MhvoHdq/MInoTx2PYtVSl7LPtitg="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803036085,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAb9BVyDHuLqEAGQ3p0hNxKAARAGPHWtH9+IuyqEcsbxWvMaMcZPcXXNJfEX2eDm3LG1E3K9x8p+J1dCIxJIp2wwtlF2iyGVPh+95MNto4ALeLxrdvk+HpWMXx2Vgd8Ler1StZzbhVrHtNaCptJYIUePLZNihEZLcDo8RA1iW2IIcGyKqPzmvvvadrJLTtSWpJVR2ppXChGDT2JrempTaCZG7X6PgqmVg+4irRgikZdZupGJQj9UoBDabAlCpGmfjZ9sj7JQqtY7k2gjda94rfxNwp/orDRQo7RlAn71BUrZRAj/BGadNN6GLLjJjJBMb86W2mRLWklIgChYCdh5GE38DpA8iRkcJInHB/LoMfB5rDorMNcNRpHHatrx++PLtN309JX3NCNnA9jVJGexj8J69VtjdeqO8sAMT2qfavxIpmohV/xj2g1cmwH88x8Nn2LydaNdICTqw6NYHHqqPYTqi+WNTz8oIlPwxNnlzSGHcEl/qNMZQZeiZwfZ4IiLeNGIKoXlS4c7v8t66rOiLFUCuP3vyHOkhRIR915HjS0DCsu+X7Muo2W51L+2eHNIHMiORBg1cBlSnHGH7/d+Tns8OWn0yIhu41lHbsvWtrSGRnZqlk7jYTsElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwln/Y1GXMtYnNEMpWJhyh6Jc1dQqUFK1ym9n9giX2XpPIsmChzuxjwKvC+tRBjgfC6WMl0AR/xMsh0hRkKA/JBA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAUxHZ0g4U6yvzGNp++8m7v/nK0kVf0oenznLFOWUlRdCsyal8kEhP3WHvkXV02gB0SQmTrlD9zSaBUQ89Z1RYGFqxqDT+kkdoLUme3Qv8ztuZG212y06nZPWCRcXA5OVdfGOHJA3evkU9p9G9lHFBh8CC4lei3KWSiLeutKYl3oMFxlFnOY27kJU8M1G8nHOugVXzQXublO5eRccNcfbWty2C7SMdk2Oua0RpQjs0gTC3lAqW748JDd5//wbzh+NjrlP+tPS+IuaKjjcwQbYVuIWUEY3gZdFRJgK6AtRze3Tg5CHm7PgPf1ChJr5bagoRBlO/ODwvT8tVL/nuPYfvkT7RC4E8Kmia53kNKFT76EFxFF8bQaWWs91z2GP77nJyBQAAAOB5jQx6bOaJZFNlDauoUHdSVnEdRLzwFTlblcvS9WU6Ild+y1/khbLdqlv/rnTsrIabuQcOFfvAQF+l1hpDycdifRUFa7kCI5Be/KAaQ/0a2D+sYaLfRNjhq9dF2tmTB7Kne2b21Hy9L4880E2UOu3Ey025nj2HmfdpaGuiZvJKRyRQfd/yfp5ymlZws/E5aqFzGmR8MSa/Knatwq72tfrc+XYP8iigpYjYN3vTxgmHPUw3HdMuXO1JTVfwHrAn3w7JL7jzi4SeIJI5VJUQPxR/vriE1vVM1Dsp5oq9NwMElYg+YFKw4MytWdfI/EgIh6W4222lS1xC8ROGtC6fH3c0L2RQPhUzs7/2mKLuCIXyF/CdePR8IeWFPGrU6YOpppOgjsc33lQWR7v+L5TxKaXA1KI/lrq4QSAYl+fish42U6uXesr1v6FkLScZfb/ymBkt4Fsy1p/gK5dAG+UnSSZEv9TekR/bJpz3fXfwyFvXukn2hiOFZ0JkUoD6Ymz3FZTqzGCbOWw8amtjqGxwzH/wkzbH46LH7oSnsn+fOFU70dru+14U/nSsm9Vt1wVsIsOWzQQ02HMaGHnBhkY6DUifoOQ6wD7q/FuQSDf4uY5QsGp/uqcFKE3DT4jb2duO18eO1tFUvKzTkzQlLsFX1FxNTcvTR8c6lpoOz8Azp1nH9CWlIa78Kin6Sn9VABdvLDC6jepsizX5CHSk8F4CqqppApa7328ZAbBOkIcRzitqPsTa9WAUals9g3hqWcB78OpE4jxxu8zaSQ7U6dbLwrtwgpG60bVfNTY+PFkrP+Z4KK0nWLPbonuGIwpmswuk2JsTFmIOeCS2tgMckLM8kA724HrHlxLa0kiBKn7RM/QXVK4PfzCe5BKIadX93mBSTEaDubGQzmYmFBcZwBUStl8Ex8pJ8AUEyubVRy64kf8kYVHY4a0popEVpWEjYMmmIeGk07wsngOmvz4dtXKZdNB9Hkkgo0TJ3KGGcF3k58lEDQucpmGBh4qFqP3mZO6QHce/dMJVu+z4jtsBPPu/jNdbvllb6ptwEZ90xk1nk5BSTLIIFn+SvOvAoSS6/Kzga3IGM6amno8qkNIwZKYmhbAoHR1fhHItI/OQkx20bKucMx1QOch6yNld8dJUpertJ7A9wqJ3mNIwAUyjd7vrjGETVrtLMWkc22Ynh0CYA87SdeP8fWcSmQJua6LFRbDxh6OtZfN7hfVR55uZnkrcW3eJ84DVRPobgOZY0YreCxiD678koVkiw3xPkJErZpda9k5Bq7YuMz/sOWGZAHMKeOcpk0pK1ltsnBGDLcpKBYV+tzMVP3Ku1szaHVt7L+H8sYd98Hz1lXPGDPRRsAG/GbWWVgMCbwWlGH8cRnPY1/+NM3WkBnQYFoHSJE9t5oj6OKLOeyjMbTFAJbSm3NXVPns5a8ATvmUoq0qhhXC1z6yiodzX3XNbevT+r0WGFnfDZBbFbi/b99btc6FC1UAqTlwDciG9y5POigt1je+Jrez+4rfCYYjZwpdp7eYHt0wgAeuw/jLfkgdWGDeBw3M7J8Wom0Vq0Y6+UG8A0+NqBucs86G7JoRLlFHp6F3QLGjsCg=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should update the account unconfirmed balance": [
-    {
-      "version": 2,
-      "id": "046fe631-ad73-4a5d-a9ba-2802d2713f3a",
-      "name": "a",
-      "spendingKey": "24a4c66efd290fae274a6094d80671a3cb523e49a20ae251202e1d9358de64e9",
-      "viewKey": "2206164095f4691745899f0eebb4cbd3fc67e6d20307603adecc19d1622299c01a0b45331e405c937b7e0e2f45a6f045aeb0db5dc08549104a58320306b42f60",
-      "incomingViewKey": "6d3f6716bc7ab0ad21e171854925be70802d4a71e6415feb6041cd95a2dd8702",
-      "outgoingViewKey": "be4a6530c8b1d15c71e12e5bf821ec44b050de240dda1788dae467bac515a521",
-      "publicAddress": "5c7eaa5aa80bee49ba114e3c3531405712ae9ef462bca6f2f57df04bc604c6ea",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "f8be0a26-9d22-4408-a8ae-0a1788fe660d",
-      "name": "b",
-      "spendingKey": "7985b33ed1099492890ab6265bb19fbcafc54aeefdab3553a562ebd6da5dfbd3",
-      "viewKey": "712dc61652bc3299e544fe46ef96b2a03a8438c937b7bc808888dd5851ee034aa0fc3689825f03c51db24609cd887255c44416cd7159877298280b33c014896c",
-      "incomingViewKey": "e9ff2a2b430df99104ef1acef5b0ea67e9fbb7a15522d3d274366913429c7a00",
-      "outgoingViewKey": "b8e240bcd296ab398e0e96fa9b013e1e1b03606215912055d009860d2288097e",
-      "publicAddress": "f46909dca4be617396fdcedd0c539d17bf510430737a544623167553f3ae88d5",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:nLQvsvKCXC8LwYmwL0pscdAp4tVqMN26/3mOR9locR0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:06TUlHeLBP+lM2AjerQM5XCBozYkiTBwhGBHymsTF5Q="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803037392,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAnB6ouhSIFag4JmDj/oc3IMbkVum1FvDPPlyjYlc3l0a4CCT/QmrStvk4RquVA95KjHvLelK4CBbDtLI+ys4N/byr47noNGeok366qiMsJKOkvGBopQLfjqDGLsARpLzOzmhfs9fFV/jqakdoKShnwrAvwsriIjCqhaAjvpk+a6UHtrZWxkKTS5snJ5AT60ANuL8amxH0nqXqMrARM6mFQ1V51r1rNcA+uj2J85qMCECN8udaVg/gOSEV4D3xcpNKk/RgagCqAxJAqZLoCqc6ksIPptNBJy7XD4z8BJGZsLC8U6BKvVU4njWhBgOOvmzq809fPyCnyVSwMwnw1IhC8GikUbWAa6Zd9Otq5MXzOm2eQisNhdpqRDwmXmCgy5Ib9E4UjemaVxJXf6K/DnCKUMBVNxLJgMb2O8mKVztKno5XbCdCX/V1GwwEtTpWr0m7v59TilUtwuM6tNyBxELCmjoxZsknfU2kMEJwPbsV/XeVtgHfJXKfBB75/cw7qhsAmYyNvm/JMmxR8oojKxWBhDqCVanbDMwgXibqkGPkZK1VIY4NrxnAXKmLYqT7OxDgb5P4L0u3ZFb19Q4+Nxs3jqQARboHDii9zhJOIp1YxmR9n6qJpzyXjElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMONtl0TsS8zj3r9eaLw50i1AtYvR7brwGp60mcphB7lDUeKkEr8EBaTltYPrxO9TaZtDLlWSPvwX+Xmzube3CA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "C472DE661A0D82D39353C6B6D3A976BD750EC8D6098FC2BE5FB3A90FA349A475",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:tYOff8Q4Q7KlqhN7PKT/edqxG6OWMdYWcQ4zfpla1UE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:4Nz+V+Wclnah2lhymewDVnvW98GlUOzmyodYXG0dsmU="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803039445,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAA2jqLkwnH2aoHyUwn3mmwbFrKAYuHBKJhJLGHxoxVUjiPnlRXbvdgQAKhI+lT7gSQJ4DGlo+9Ovw2fpymugi58cBa46GyQJroxX3RQ0lt9kKVfMWOHNAR9CPmNefb7pUAwEEJ9EvqDFRv+Mz8AMgoXAAqy2YS65zpvKae2YKTD6IQ+ZWV5fgas5WkzKL+fXkAIwgGPRBFcCPqxHG53m4o4SbHRFSVDwGh0qLdt8qUl9ihEOa97PIqLTX36WLX9wuyu7BIsc29jvxielSQX/dpL5aOcHpfMD72Y2vIINGPRnPw484013JhLN8mSmEI6NXJ8NZLm23No5BMAs+t1suKtNZl/W6sHu4yfo9lvtoby+6BseUSLNwYKNI5H9kXCmlme3O/yw1Jyz58JxAHzlOPgxK5ntW93PQ+pEiFworr19wPhxrPvv6ah8YKZGvRWG29FcNA2AdD0OCqlB3+azxOEV1PL5shEeWf7nbl+5GtgJKO8NIVYmdkvVuRqVs3+GLnHsAeIiJtnytfAop+5ENRwLOnqn6cFeVcyA87zh4Mx0TfyrkEZwbnx2jFkvO9cY5V3jSLLseuVxOAJV2BSB95WJecFiGwaHzp8BGUBwqmD9xmt/kKqMnTmklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwfMIjTOBbLpRPmc5hgNoY34nGTAVlE5abUrRGXOpxQKOEdu/9xrkjfJkqxXZvXJWUkXWFKi0spMVJ+v43uTUBBw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAANSPVzNcZlh0jOaSsOsyFdw2J3k2JUDq1yT8xmWdZLiO01TIgZHY128eGEnAc9ELYChM1r2MyJYisqxHSSze0hmthDv2hptpJIHEkY3IPTtqEpbibFme5O3nbCFOmmX4h4akxT1eYIWX6jhKvgcaCj7hyJu1v+GkPmOwOgNSnqX8FCrg+hChoSKXAs5KVAmEv9+mYUj/SG3TbMZpY3cWFzcR7L6mrEwSuPqNZn7MBThuGgMAcsX+hDJ+6rDJG2KhG7yYZNAJtcT1fbw1dCb+HuXzS5pfdj8VBYTgz8ScW0IGmen0zgagAC8A5i7HIJSSgcUE/GsG2J6/oCmKeYyh5npy0L7LyglwvC8GJsC9KbHHQKeLVajDduv95jkfZaHEdBAAAAFE2lgQupkxTk9ADxvwN+gtFvQF0V08c5wgI7+5tlkiyt+XTjiVSaGAAWEtpvtrKx3GbZDgdZeVpKF1VXCsN0luNRncbyol6WnC9ukN1xHPcXI8KRSHxGYMtTFtfZEfdBJNYxpJFSI9g42PLfbR1ibJIDixtuSEGylK7RYIwnVYQUCDxGEXsQf5TfXKaMRYGu6rcy2JogFpcTJAwM+eh8CikyLu/bX+d2qbvnn7G30vi4/FsWIA5HRyVlOa4Dqs4HwRZ5INbc6XJblvApSZz+ANQNxspgRro15Ru8/FLcICpL05n/d2NS2F0TdNVVvqiBbF94CM9sJ9lmetGm5RKz8vJxq3ZB1h+iCCun4NaNdI44JNbO2AFbm8k/9rY0nHnpf+NBcI/mvWxkaRTYgv/ffKEo6NjVaVtR5rBHItzTvhlswTEM8xsQqi4pCh291jpfffJ3+jsSe3QAPgSytCJ9HIU7H7GKXXp/Mz9CDmp7j2f6YJq9dYrqYnf0AE7qZyZLK5DR5pZo6mbykk0/EQIT7KHTR6ZAnGYjCbqQfOJOkn77rU5K1CEqphpai6fcBE4uI8DgwtYawtqJ7QlJUEq+2jyW7vb8OS/yy4KSsJSBVIzvKpF0pcUa2aJP/Fv9BP5wj4m60yaAApLtaDQ++CxUP3Yy/cL0CddGgxZpbcrOa6dX/WXCaeOsj/2/FpXJ2mrSXDxXlyC/tlctNTavUWXJamcOS3s7b3ICzT3xUG9jfBjUIoM4vECRRXiNeM5JRKtIpKm4lr3Su9Hgz14/JTLgQBpqyWCnhz1lXUJtogVxE/v7OdSA//nHcmo1S2oAbYVPOHAeguyU9P/UFiqobesSyj0Lj/onwipv8MJiAH+ktXCmZgi7Fkp9tSFUE2nbJdNFy71klbRGYFuDMTXJfMbvL0WjPjSmYig8z9O7hFR7LeYMbHvTsrGorcUE5e43x7efO3xs3izche2pRkuo7WQENa5bDk9nQlVo5U+hz4KQ4wwcBjv7NMYmHyAUdCzbJ2emsA2lZNmCeK+13jzC6dWO4/Hlz1GaHv/7h+Ltl7jbEk2cKwU8nbbq5EKsy2mso5h3LfBDszeuv3ouNlBWRLmz8ncRX/XUucj3MsdFek3DWMZw0JciUOrDGzPzFa4Z5zecDHKgO3OJmNHzBu2Ycz1Gjwkpy4UX9vCYjeQv5NPVdn4H9e7LOsj3zh7mRr4Q/N56qJUBw0laj6pOSIvIb65XMjzqQ5TAgxXySnLsvJqzemkxnmXacBy92R8An5BLMbzc/3awPKsbfHawtZhEPk4euGJOFodoh2grf3OwsmZ+DGZ6q6UlgTIA3v6AMwiPUAEzyVS+XU6wpWgMfmIOz2lD1v4Q1r6AZ06nSnCJlwZU/77F98BUR/+9d43XUbVxBr0MiFsFc2KBnhv7YP3jUKMjnN62jaCwv4ESCjQQl9NLRUxcnZJ3R1agK7IuYCV2GuYSsU41T2Cv8LU/oGCmA3htDWT2+/pTlOVQgaI18qTzAWnIvhZ3Q++cypdZevTUDGmgdP6O9uCVO/tbTEiV6CYD0wVOCpUNuWxFZrCBmEoTkLlkgWaalh/okPP/NU2F1/BDA=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should not connect blocks behind the account head": [
-    {
-      "version": 2,
-      "id": "8f19827a-b0f3-43c3-ae8d-6d0c8fa0b581",
-      "name": "a",
-      "spendingKey": "b084e9426c38c2dde939955efe8a38eabb7dac7d622d0c2d5299dec78fd66b6b",
-      "viewKey": "a7891f64cb76f8bb7ddd421aea3bd5eef98ddfe7c32ac3335da88404b81b3b4a5b77dbe3f8faf9393f9ef1a0fb6638fcd93cfb2187c082f31a266e90386070c2",
-      "incomingViewKey": "bbdcf3dd5d1f20c40243f8d6cd52d55bf62c5de340087c4a5af1b68195946200",
-      "outgoingViewKey": "ac941d9408dbee798957c40866b93d5bdfff4cfa51ddb29373da2e4c34ce26e4",
-      "publicAddress": "a04fef3ce96c79b12ae3f69b305b642de4a1ac21ee75503ddbcbcb0c5b02981a",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:4Pk/lHmsq6tqQHADJY1GJqn46C/CsanSgk7bnveSmB4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:EZILmtYg9sDvE5GpOeN2CHaRsvXKqT68rnPe8bCcCdE="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803040748,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAD9gGiTLr+P832VoM+WE9jRhGQv9lL8KeMSOZ7/HouoOls8I7FztjBGSm9WU9TwPciUHfQ3de61wMlGmAL1UnruUzMNZn7cXuJ3fOceikcxuXK1V87htR49+x2rjEnNw8ruT2/ib/k+BaJjDCkZIdlwIsFc8+s+shhkxDdGHcuMwRjvmwZjHs4vhEOwT53sxQaQOY5B29cQGCZMpgC4+Hpg8XR28aV8GDxWbVlrCOIkWkedC6JMPHh5SxCPo8xx4IENIQAHlKHg7FnMGhXkmdWrFraKcSO9oaXO45hWd36ZQ63ieujEgD9+6rjy63fuqDtCeVCzCiAdE9eT9eHYKDLsjNadO8/iNjEmT3lnbS2VytULaldHvf+NujC2/E15g+Zsx/dHihbBtcj7TK8ADJDxtQcvhy/8kdjPxqAKLWJ04Th7GkAkLC8LPSIbglfYDIDMYRQ4e7zUuDmitFO81DARCUNL1HlCrx2RwVgA5/98vkcBEaNcAV4BnrxLP9lULU3XLZqGDKD3hedGbEydmI+T9x9QLLK1T5KzSoL8f86KOm5q/Do8N1+K80Zty57AMl3KKJsJm/V1p4qazWsjz1VZu4BiOZKioESxv8R8xIsgoirioIcuF7Dklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxcLwDvjML8l4zmgtva8CwDfMj5MAl5r/YjzubvEvoS4I6yaW6EELarlJWNmDx312yqt5fs6/kIFrlieGBqJwCQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "A1BBFF4CA88D40BC3423A6B4CF8C58645803F608EB3051D3C1DBEDAEF1D94740",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:kekH3AXWDGTEJHI1gSacweCxGzRtkW+xxuiVWfRPUCg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:GTzYl3D57qeS3IufnFhTJN2GUIZI8We8diM+9hqlNZ4="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803041161,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAvvkS9J0t6B6/f4GXmsuavgbowKyB0ltr/aCBuKoev5qI/RWfMEplb0mUWznZPzp+4fuaA/2nvRznHo/JstD4mcqWAAM9GI7Mp6UrhTbyAO2uLAdbm9jC0xGQ1Jl/wIIqEGmXLFAKq5x1kaT3jSeAOV8zbzcWWXTzl4r74Nz/mU0A/nuAbDPL6XfkGmeXDoBdQybwlbVGzbhCeREr3+RqOvD02l3XjRlFPxF5B6WUqYykFshYXItb2Wu8fqNbVcIeLSPEXpqBL5fJeKbJM+RHxwr2IEoXAlMy1d7jxAqOsYHL5eswiaM7Ik4Z7rVfiCQCuvxmkwn3KqFuZoXWYI3VSLL46zKwbdjgftOtclf8gjqCxERHsdfqyx/hY+ZxgS0g7bLaLb1XJlbqyQMzhOIF8AgbKk+u711RFmH/xnezEt4RpJJxA6uipjY2ZuK1FOqKx1eaG8L/2OKyHcr/isuzcRDyYM7H3J+OgOuQIzn4aIbT6AZ5ShPBUdMVqBDcNLFHBk+/B2qLTvcghLC2urP25lZWXTmYgAHxDqnZcpH79UnBNkzTiSVFMEuXFUs5bqdtlt7Y8zLozHqREhC4OBb1aTre+N0tlDBmsUKPZtlAY7O/oZFTmoN260lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwUkFn6NbbbG0YZYMlB+ZxFJ5krsks7FGAt/QuB0Y2ODCdKe0JZGeuTA0r80Yk2UHXROsiRkWIcxppx683NBhmAg=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should not connect blocks equal to the account head": [
-    {
-      "version": 2,
-      "id": "02e5c39d-ee2a-4cf6-a0c8-966914fc813c",
-      "name": "a",
-      "spendingKey": "771348788cf937c917152d11a83ff79e782f342e58cb24431399502ae5c9ead5",
-      "viewKey": "e03bf631171c457f06343cfc703e8fdb52c4caec3e77649e3fb2981d3caf0203ff5ee702e83b20844edb8378cc2b857388d935b2da165d8b7174d2c257cb3db8",
-      "incomingViewKey": "76cb8689a064ddade58359b2c76a895730284d019be09d155f223beb2c4b3202",
-      "outgoingViewKey": "e09f25dafe2795df4d01d589c1937f06093d19f69e72aa487e61dcf4ff575318",
-      "publicAddress": "2c7829e59ebdca5450886d13a90475b41bee75e525d65b06d2d6dac7c19b2a66",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:GuLWXFXiVa2xbpu0VePSC4bM6hzNGvqBT+oamlb3CV0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:khTi11r443Q6xqQont50beGIXRzEw8AlnHrPKEshwA0="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803042432,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAv9dOd+HC96jMDsLnAoQOU5vHK78mNqR2yizmTziDZEqVOpZp8+49VCNfRcP+JAQ+sVoNZl/2jVLHBrZZdPE8+qMCBwyepQwe7cYDRKDAMi6U4+lP35I9TbKDKK9UqYs3G9hmZuiyB5+1BRhkZ41W4GWFPPzLitZL+DF6wpHxhCUEEAP99s+h8nqrFJgGoJFmpGnmqXumDlswGU2IzMY/Jwz4WiwgMY3VmqMcAzRwyle0EGyc3mUtbWLnT3p9V9k4Hjd6m7wH97FTe9gpJ8aweH2nNU90KegpysX/G8Xt21ILFdML5FFKlS7OuJXvrzChGNUe9R9wBTsWEc2fnf2P5pdU3QFMV5aKHtV02SXOx4ePMMVD3Vtr9eYx+9PX/INXAHUC7JHw99AFHtRdAGXNPgpBF1Gsny/IsXDZbbzE1IFXyqZ8dq/aVJtcK0V95r7CMQre42zkXg5/58Wk9e/wj+me5HKuQ69dRHIQ1QJn4zL4mCUZNotzD/XqISESsUpSH9OBZhFOoZGD9YeEAQkx4n1AsTGhz6mnFB7ApfZAoFJ0gYOMXhf49BIJdSyxHvJ7QTGKuCDQjEF/8xIBH/LwOfv1Y8rUs5FmXBnHotyFQ8jOcZhzErLGoklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2jyBH8WQHl91tWPl7rs00stYtDaaQALAUqZtX8sdBNDGS/+Xn4QTreURsY6CR4gQXl1bFhKpXlafHAMGZfdQAw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "3D6A0C4B7DDB68DE8BF293C02CA145486E6D5D81C3162FC8BCECC54281B061BC",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:lJwyaKroARxR9YlN/e2Goml3w0gvbPl6T1W2uYp9sRc="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:R1lJXUOh4Y8Lv+l8HaUhi9PnXAOYZ80lSpaU1BgXfPA="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803042839,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAY4K7CJfu5IlENsrImuFagW6qjvmNJLoFkUvWkIUdyd61dxigNTpIr7XNcGcg7gLeiZBMXJ+cDG0WYlqWt1ytg5KQt1pQs54SVCoCYACdrFeCNRei+0U5qD9o6i0eSNKu8Rz9iqC/D5AgQd+ejN0GD4MWC3kP9TaSSFXnM7ZOXu4FOPR6hDDs7kMoeftNe+9b0JLG3tqiOIueC7IKwhmF6TVJH0dk+eJMe2RCxwMEW7uVBcBTo+gXcFDmw2EFHwLHszbgGHyfZhefvxDUBUVajEtAfWNccShudwAuwkPhU7ZPTyvtLJlRyaaQ37PAVLfVLOBQbA9DW5bQQt6Z3qxGFfKQxB5aouHJQHaJlWZ5AUMOqSVaHbtgHKmvhwNOtZQhbPWiprwc1PyYuRo+BXSWHzMBJyEyJW1j28SCoLjUsJ5bwn1lg4uFK1dLavSq4+49fmiXSqsGyGwbGaWFru/rh74qSCXjf5Wcq7xpBvRPGGuQjqROT+3EyjN+fJTMHCUya/1NqWdVcXJybcrxaJPr43EJMka2OE+t5ujkIHVG1M3fEaXK8g61jTgd9RBbty0e2ByK8WMp2SQLQFYukzyTiYIYsOT5DhdbukyjD7taTbLaL8BmYhNn5Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYKiSAlnucLUMQuOvURuzzU0UKAVJeFc4UVo8Enk8kC5IGE8y6VRLDrpPbscVuXQCzlNXMa5/R6Mg2rTB2LIGCw=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should not connect blocks more than one block ahead of the account head": [
-    {
-      "version": 2,
-      "id": "d9d88d50-269b-453c-976b-1b30c93d3e55",
-      "name": "a",
-      "spendingKey": "fb950c5f34a9f20239cbd157ebd422f260d7a63e8d1adc4c13635f03d99eb2ec",
-      "viewKey": "148e6ad3a38d0605fdd86048d6b55c6ff2aea259c1b0812ef339952aeb9477d95bc962694aa01f8ee030579d086fa0829c9efc80c0929faebda120461e54a23d",
-      "incomingViewKey": "05a0ed4071e0ff4952d277d70ee8c4c06140c40160a214b869e1a89f48d00901",
-      "outgoingViewKey": "6e01beffe80277a0267b53c0182d3cb3655c7a8d1d4b821f602ccac4980cf9c0",
-      "publicAddress": "116573e8b8531774df2abe3906c7b9b1faca8f83b063b4cdb1115778df48d7b1",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:GzciHJ0OQoAnLY8nz7ssqY9TDL+D+jRtj+EEItxgVRk="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:pOoBFSGyWNDzRhrNgSuMIEAKrCInGsjLP1TZZru5C6Y="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803044131,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtwuePf8GpTguUT5qA4qzsl8bTs5B1EULH6lgZweAAUijzKK/Mze9dwpw5DQnLlA8DzbYR/A0WpL+zXw/0gij9jQV0EssqCS/H808rTSmypegJfhmgKvz3n2Jc3VB8dU2l4VGLF18SjWTLp3tQ0Ax7bg4+48I5pDuYpsWbEOvJvAQIz5TabDGKi+yqGr/DeolkQoz50y0pLaqcOcE5H/aeamLRlibR6evFid+9yJFieugRWbnNXucJwKQVLSubA0EiDpriBH6ZvI1yGHzq+fThlMSGfG5I7ZkHkKxMhQB5YOwfQbBQlfzapXoCHRCBsC44htqGCYHx25l6e9biHMw7eouvsjIcP1LKuwF5gpqbh4IO58x4l7NPeo7kRUMwik5AlKn7jOcZN1k8NOBePIH/di2iHBTVbGmJg0N3m3xEVot5koLERsVml53XjYbYU4LmFFHg+nhv6+oYn6CHxzvlkXsRjKJLRm/BN59eI2XMVrtDZFPifm4LQIz6jc8HU/oBTYrFVxPSARSnEHKdoCtuophkAVHAv513BxQdnbj9FMztFd0Zj7WqYIWfWqUG7AYG81Y9soxEWbU4zgHWarPGATlL1bMUovUxzdEkf/PxBoiZd8BztpnNUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvPIczL/+UjGEo/WlZd2x8SZORcfjwHpDoXc1pg+SvyhonWyj36wzy143GkWEQYP5kt3FR8eugq/2VYEoTfUoCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "B72FC95433B8B1DA290DB4063858821BBC3CB6A72C941DE1D4C86C4C43CCD54A",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:2mYKd/ZXb3t9btyaoIk2US+PC+gRosETR8W69RyhwFI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:txWaTWYXj7ASl2QfAAONTt30MBoAPchVQU4k8cd2U9I="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803044571,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAkQanaJak8M2H1zXhIhNUy/roenr1h/VNN9/QdOBuTEmJhjDE5k9CJ+GFdwPkgGvIW1Xh7oS9lHTbJs5mU1I/l3I1m0j1tLlifH2EJwAqOUqups5E1/s/ibJNeRBAtqR9FWisoJP5YrgmmmhGgQU2PNOoa9eGPI4Bq/8ZSyj/zpUR1OEGNe40OaU91F9YXF1lf/srqxv1Msp75TLhQP3WHd6xjU3nXB7z20V5A3dITqSRHJtSFiYEVSR9ruDxz2azRRwPre2WsXZ1BFSGkZWoo5NLzoCPamsLPdLuiC5d4G87dSs6UfM/P+eKpCRj7cYV+7R6RnoYt9nvrcQD8xcCzl81jhCGTzEJ4dbe30aZ1OUgpEDog+84WHFD2YMQdjcGlzOOxaW2UQypjETcbQsK+JjpQohgJ8dJ/I4oOz2EZkNCpz5ShjRDj541RCf9YmBPgM8EJFGDS9eBqmj9PUjiIvtliybNRCE00e3wHybLN4eJXwhymwr3FxHtwrjcRd53zdVibCrIyB8exvdMbYjPB7tgfSvFoUST3s7NYQsI4IL64AJd/LG+z/yRtg/hQnFyPa0C/Q40TqJI1+h6I5+UP2RtC5qxY8R0sZNQNwnYO2rOH31nCpSl/0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwejlfDv9AjX8cOrqF1vQl9H3zaaGRvpIhRAHMHYqnMfH9zn+6kDxQj9J9OwnyIPB/BzaX+JYakO+5DL03xFrCAw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "631E083C878DF2D6AF4F38706F44F362D71B720A313534709122C458647CE269",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:7PHrl0dhguF7236u6J0mZRNvq0hZYCaTg/k2zDlR/jo="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ZFHe1FqzzMGjWtdogr9N/Nj/7SXmXLYvDfhDeuvw58g="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803044978,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAALdib6Y4kfGmdn0aDNAAwYL7bUxZ1yjoNpndfzjx70O+3LBgIKGxGcbXqJmMciuftzBpEfOjG5PhWc1g0PqxjGzxpDcH3+FzUTxtvkQWaG9ao12xhUXiF7uzOrQYxj8VWlFktrHdTs1ViUezwSZNYhGg1+ON/ledf+Lmp1Ryyc4cUPROTCA6srUGpJxTWhKbSHGOonTFFxwGBdlbvgP1a+5/iwN2ycEnkI5dIyPmt6aGGqAiVqRn6zMslWpDK3x0oegaMhuVjCos8dMS+6gI68pXqOXFadNfw0NLZr6nhSoA9dB80tB6EomLiB5ggpVUnxFcp07hVfp0U+fyL/b5eERxhQRWWKfUWNoPE9+7595+pV5hJgnmIjkw4deEjwkYyZI5ymIfFwDfwvaIjazhzNejxqYOzRk51eLT9UrYamcE8ilAhIhSt4bvw2UUX/Lr/0Fmc92iW755ObrjVvKKw2voYxoRYuhQFX5ncGO4sseacwEuOMzC1H4fij2SpPpfXW0zshFAlrhXcmfPDa5pl80etYjcb8s/GRFn3OJiRDkb8jDmrucN8CgE+xGFv7J3rhnkobvnXA5gjKw8VHF/zG1ob8Eg4jNKmgPxyWIYue6IeKINwlAumN0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEkBXAWHfktMjCm6ykMDpnBO4BzeOMtSbq3/MuiAhhmEGH+FVpUO4gaqbhXYZo09IH2O9Dp0CGmpfZER/adsnDQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should update balance hash and sequence for each block": [
-    {
-      "version": 2,
-      "id": "278795e0-98c3-4ca2-9507-68c43827f603",
-      "name": "a",
-      "spendingKey": "650e08f6ef343fbd50414a496bf1569696a561eedef91e57109b83e216dca62d",
-      "viewKey": "8667790eb94eb8d3bcc547c612c5a504cf44f40114d0bd1b824a59dd9a62b2368d3fea14616acd22243d0d5651ada96b16f2303e79af54650f7fa7b7f8aeebc6",
-      "incomingViewKey": "7aa741786ddc3919667da8388628cbb8c6e78f78882b89d4d86843a8390a6c02",
-      "outgoingViewKey": "34a887acfbd88e09dd23e40824521eb1c7a3d834d38a711bbb5225bd9ef025e3",
-      "publicAddress": "45e398c93a4879dea6c96ab7f07d0128804aab972912d314a5f84f6d17e10418",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "e91a29f3-fd6b-4c33-9e47-b5a7fc613101",
-      "name": "b",
-      "spendingKey": "74470aa9a53b26501a907582ef6a69b47de91dba6a405bac2af173991b34843d",
-      "viewKey": "12d2f3b1859bbdfb7c594af01376c195b4a68ec72c8397e333fca55a8aff7740219e1c7f434fe9976069be46db118dd665d29936f0377ba91621487bd985148f",
-      "incomingViewKey": "938ce3568fb348cb6bf002f576b290a1010d64097195596df8b397cd93253f04",
-      "outgoingViewKey": "1678c9ac2e45b320c28d4217120c9bf128f642b1c7c8daa7cf8f9297c595ceaf",
-      "publicAddress": "1d33ac25867c84a0a303698a054694570365f8bfd79d1805e38b0801c75c0aeb",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:DTUInH7YF6mcJ4cyZM7JuZv53hGeAWCyTSvq7ccErho="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:LTdHLA8oI6gOvla+8a8QBAQUe3pZDNy/cvGQQkbEH6U="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803046314,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAPJCC8XGPsWQZoc6qudPpytyZsemFTC/uQRVDM29G4OCRXGuZbQg9sYZIIlS/qf9FVI901hyYYUc6mb57/YFVS0mIHXhjSW5F3h2TjkwBL4yJ2NkTanx2TVRTdQ6tft8YeLZSOmF5B/onKr/WQyTD1kU4kZKahMTetvq48J+j/QMLIQsVnnHc30Yk2DISjfB4v4gMWUMgGiKcQgDrzWxtXnPxSCo3eGLQHDUHebzKTO6Uad6dGmZPs5v4gOGZFHzT+pokm/88G3os+zcDWX3y3Jck9Oi2+6UATfmXRMvkAbPzj/aCrTeBofhTRTocAwJ4/2h6DiiFJyHfdKFFY/eZ0WBomkqaaM8fFtc7m+/qSUaTcf+eRFpVEhvIZriTzUZK+0PdIK3+BIR9/NNG49JIdHQN1hnL1QQLJckrrbJS2M+eVpi4TQHtwnNPtVHt3+jUyAnutzo7pCVImY6aF0/1TKrxFXaeWg5IpRDBd4CH5b1PWgtjyMOTsUfYnVIK0OZN/Gqq6wwCAS8NwkQz6h9ZKrxQDbY3eXxiLB/y1WYBJvz1wbpd29euX7ejzv/Pn8OEkoAPmaDp/qqa8wEiVKYyCBEjd8T+2lMS9bFXAVFa3MFz+2D9ZOk8t0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw27/W5Y8xVP7oQkgB8Xuxeznk+/6OJ5hqSfSupe+8sD+vDRgrwhVqB5Zf5Rf0BgLS870R26seYcSlCyHcbjy+Cw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "87885F902E59710B265FF6332670B709BF09FB7A9F350611ADA4741B6AE32DDB",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ZYsN9Ak5O8nL1mC8s3KsyOGY+JPEhVVKoSaCXxRxlWg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:+74NuuIzUh+yS5vOGn/2DG9MDuBKVutA0ylYj9OF+D4="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803046744,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAeDJ86GR2CmhD7Tt3rh82ntKLMNr6YXRt7Vhv5AQ21mGGjsJqDLCn/Z1dZq/KgZRKZPS6CF6TyUJfBVLtop+Nmr7tcgZ6sia9a6gHSQex8WOoUGHZ5RY+Bf3qAr/rNsCcBCtYUWZ4PBMCrlBzVvCVd3cP1cWH6EKbOyzg95lSWsQSJ5WfApZINWCwj7Pg4ql7GqpjFddH/LO/mWh5zHJGTfpLmc76eS2dAxxR5REKCfaUzwk4NsnN97kqn1L/WL6dJypgpTReEeT51lTZUfTGOnrPhHGiW3RaICydDiOmpow0LurFEyECEnrYwMD38LO4BwQlILBKGDGCCDtdffT5oLKTVJbP6UnyiQQZiqs0qNC5BROzhb9PK2QIVd8LpDYBlH+JiZMcQYKPdTYtusL51XTHg6tjaIidwTDlyZTFxRGXlDIGmNA0vT4qSVKlCUKL3+T2YPuIPHWa01TjPTMSMP3U/MxK8/Vqrr9LmOrIa6ZikVpN0mQDwXG/rozmMQdc3DuqT9ItqqyEYNKo1POJ3n+3QdeOFt7bPSNWqEK7g9Fl4/cf+Kf6GWAeUuvXZQisQ5+2kwGTqJrdz57O9r3lZARyhvRJcdu2Q6rEJdAst+N4LnBA1sy9aUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw15+jXO9GojLwk2iULozgG6Q4b1u6JW9P/D32/wk+67g+eqfQcDIQDHyHOSTMT9rixH7YBmVRKi31Wx0d8SyOCA=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should update balance hash and sequence for each asset in each block": [
-    {
-      "version": 2,
-      "id": "2cb794b5-8414-466d-8778-d438ec74b5b5",
-      "name": "a",
-      "spendingKey": "359cc63b826c1bfa0ace052c9b1232f9d08c51bb55eeb0d81199c4a897b211ba",
-      "viewKey": "df48438d6f7e386a8050217536cf35ac03626411f18811d1b592c65cbb81210a79079ec27e65216ff5f6f1f8e6d7c07b21ec924bc218895324df38de4c9ba3dc",
-      "incomingViewKey": "f0ff867232365a645d4dca0af91f2cc478709744d71e3ebf5b5934293cc18800",
-      "outgoingViewKey": "9781e1d7c2438f4a186139dc071902a9f9d9348003ecba719a8736acc2955695",
-      "publicAddress": "bec5d9ed86c6635bd78d06dc35bbde0174d6578c92295bfc5a1c007d3a567a57",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:q8Zv2M3S6LmXOAlKne9PVyLshoH6SAOISI/XvKY4SF8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:sPmxkKiIRcQQDGnCMlkOJjlLXjvlojfwFtOLaeQLdrA="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803048047,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAv32cKfULroNTpGVTRehglfw5vjCIk7BXlP+zJHG1KA2QOh8o+SrnyMo+TfKhPo4KQkhBBIrgrWB0OlsJ47A63+xddok7HTAqPSOpYLwZNg+lTQnC7ezDxVW38dlBkiTUCr/iv1SBMCAwy6uCHLhh/1iTdZkqvywpdYDmNLRa6dkE+/QNAq2FEQCSsdMV5qSb8buv2Jj04uAHE5hFFxuue3Cqybrr2zJBWCqMNQdM0LOPCxdr+KwLWD17gyzcxm8ImDYgclDZwG1ZUH590MBLfkK7tT54LanRXPjOD5nx5FrhpA9Ymr+OyfS6Z5irL0UcDxu3G2esOePaTV7sn9obupFihUpqhzIB7Zs9siXxk5cXaqjlrA1fy24Dn28yd7s6G901ZIonz9htXIRy6lnscgmNfkLNo4RUjEpvmyfG2JrP7OqPaI6xtys19otcfjEvOyMqKv2LLfb2kkLQU4CU3s6lHSTq2MmXkMSc4f+X0N4pzLWu79QFYsiJTv0hzBCs8OB/W1SSrgAMUkmOZ+8fHexDsvjibjn/VZBrAuj0iyyE5cT/i5ZJa5/DzIt5QHnzVhY5b9MH7uOtmuia1tS/pTJrkr8PstzsN3sWooFltBC3onLOLDTJNElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwVA21MXG63LknF+Fi8Fo34Zue0mr4rbLBv2E7EJ1Nsyx0HxfSGBiK4zZ979ang5SxswZnPEtb83LmMlg2FLxgAA=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxZaLm4MXrjhWgnPoKxBeBJbHjmwXRCKI/h5mk2z0mvKYibXqyVeuG8GO6lvJ6HeoRwH7PWTP7lQjSFX1zJuPHCyxkP8t/WaLJYraO2S5dgyuLV6gu4VRx3wsZfA+2T+aX7sgbv1W/b7WcuURenjgFK++cYT/esfFiLN5SDFOuhYAIR1zyIT7lMfeCPX6m1pwn+CkRergafNhpEz6u9B0DYBmD4QbJMvie7zfJpASYKWzXT1ODKeYn0ojTCYeCt6FlbS2bvlkzwUrw2IQcsiWHwu+020V2vhZI4vgb1f27khhOjsSlIPh3O7xn7mKSBDswLsN2mBuIkEGv5i/elDbXSb3X2ibZDUJfupl1q58zb+OlQHJdFt8AsPxipjBok5G5hEGFcUU1w0VeDZIbluqGepGS+xIZf/QTijvQv6tjIGL3RxqymPh2DzUh9u7Aw+DvE9SeUZDP9x/SmWDvYPNizMxhyZfFHks5nCEz/OUnUkEEgcC3yv7Y6yBAPgv60xspDnihAdWI588Fn3l9jutJmTe8W1cZrUJnRwQ7w2BLHkvnyg7U5CJ6rkN+bNuYycdc2X/LSg/6q/GZ/aOt9sTv7KfjRrGNwPl2qI1G9x1g4MTnW3bUIo9grERask3U1HFzSYfBW2UDohnd+VogvKLi0AAWfWpXvGq8ZXJvu7akOcDcCl5AyTYuAd/Ji1Nt2LUBtkU6zmlieSnxETyxWVXvI3Kinbi+QpJqqixKdGoHCFmhtVBdaB4xVk6yRmu2/j3VBLfSxfSuP3Ja2uvRpzhzIyM9qXV6U57hb7YM1s1Gb4g34roU0QmlIyEf8wjeFr6E32Gq1yTvhGejyh75m34+Dx7loLeNstPA7jFyXeynDnThSml05QlPgjQw6YwymZbmAEMhnrcrqjyuZdPznKAdUtCoeGOqDn/mF0kAg+qKlEu1auPN2zRnol1qpahbHX/V9UiR88RNfKFNoOwrRM2M4tQNHewAIsHvsXZ7YbGY1vXjQbcNbveAXTWV4ySKVv8WhwAfTpWeldmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAMIoOEr9IWOtUo+bljhKRxRrlywP+SraLVKrsZmIrmji+nLcva1acijza86VXkvnDk6i8AsE2ZQk7P3E6Kj3cwFYy1q0J5WeqLO17ymcB/tPGckJWDqzbXDrmtJbDfiyIxON7oUus13CW9xB5TJ/huyJLsLYja/kg9gHLwya5/wF"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "737F469E04C2257141E10712D2828CC351AA374CA134861EC3EA2189C99AF491",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:Nsm9gTFKw1D6VU5UcM5K//TNHZaqKutSFi4Sm6WRhRI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:euOkYt8RLKHjPVTFUDucC1WnaKFHjYzG48kXoxanvRw="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803049092,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAm1AeBszyxvD+MEReyvp3tfz+CsPFMDv0H4U7ck9O6UqgmFhqmRj6UkuArjx9Sz/zbaXmTPu2c/QUtGdQ1oyGlapRV8BKg4gF2D6cxqIm7oKJBCbv83mQrlHJlYVKe3/4ZcvOV4jph6uJl76u6B4ClEsmH/7/wl/zLeXkD+Pwa3IHwHAqvzojnuMRpIA4BC1z+A2yI/EMbxzcoQqTsknkEDkS9Oeo7HY4FvA10mkp1COlOiYewEDP+zh2WUivpEbc+dZZ5mKQNKmdcQT8pFVmHxg5fMx8ONJ7vdwU4L2cu4eAH8ARsLG9WWAEm2KHy1GIL75JV+lvPhmyMmK9GWN7xnhs17NBN0YJuBCVHU3j8sz1SVa5AkcyoXvQ7UqpXW0dHNXfuXKPEKNK3Rq507zRYARHlfoOXy8D9UfOizvWDJQYQQoZZ/21MKJ0vhglCxf76ytczfCieqU7EMjfNs9D/odAEe2wMk5mVt6d9QI/ZyyummGGPzNz/Xu5x2KCHpnSHuTZyIm99ZiVP65y+WtMePoDZM6W5ocvuynDh8FlYHgyDcgeQVWi/Nvl9x09Zw3w73xgbHqvBClKiH0CDC9GpeIy1qXL1eFy2eTn0wZhB92EKfU0Y1dUwklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGU6R7hHA3K4ECT4weG/D8elUV8CZjjLGB39iGm68/LR822ij0iyHPRqj5oWT5eIYmvq2qKsPK1ChN5hQJ3o3DA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxZaLm4MXrjhWgnPoKxBeBJbHjmwXRCKI/h5mk2z0mvKYibXqyVeuG8GO6lvJ6HeoRwH7PWTP7lQjSFX1zJuPHCyxkP8t/WaLJYraO2S5dgyuLV6gu4VRx3wsZfA+2T+aX7sgbv1W/b7WcuURenjgFK++cYT/esfFiLN5SDFOuhYAIR1zyIT7lMfeCPX6m1pwn+CkRergafNhpEz6u9B0DYBmD4QbJMvie7zfJpASYKWzXT1ODKeYn0ojTCYeCt6FlbS2bvlkzwUrw2IQcsiWHwu+020V2vhZI4vgb1f27khhOjsSlIPh3O7xn7mKSBDswLsN2mBuIkEGv5i/elDbXSb3X2ibZDUJfupl1q58zb+OlQHJdFt8AsPxipjBok5G5hEGFcUU1w0VeDZIbluqGepGS+xIZf/QTijvQv6tjIGL3RxqymPh2DzUh9u7Aw+DvE9SeUZDP9x/SmWDvYPNizMxhyZfFHks5nCEz/OUnUkEEgcC3yv7Y6yBAPgv60xspDnihAdWI588Fn3l9jutJmTe8W1cZrUJnRwQ7w2BLHkvnyg7U5CJ6rkN+bNuYycdc2X/LSg/6q/GZ/aOt9sTv7KfjRrGNwPl2qI1G9x1g4MTnW3bUIo9grERask3U1HFzSYfBW2UDohnd+VogvKLi0AAWfWpXvGq8ZXJvu7akOcDcCl5AyTYuAd/Ji1Nt2LUBtkU6zmlieSnxETyxWVXvI3Kinbi+QpJqqixKdGoHCFmhtVBdaB4xVk6yRmu2/j3VBLfSxfSuP3Ja2uvRpzhzIyM9qXV6U57hb7YM1s1Gb4g34roU0QmlIyEf8wjeFr6E32Gq1yTvhGejyh75m34+Dx7loLeNstPA7jFyXeynDnThSml05QlPgjQw6YwymZbmAEMhnrcrqjyuZdPznKAdUtCoeGOqDn/mF0kAg+qKlEu1auPN2zRnol1qpahbHX/V9UiR88RNfKFNoOwrRM2M4tQNHewAIsHvsXZ7YbGY1vXjQbcNbveAXTWV4ySKVv8WhwAfTpWeldmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAMIoOEr9IWOtUo+bljhKRxRrlywP+SraLVKrsZmIrmji+nLcva1acijza86VXkvnDk6i8AsE2ZQk7P3E6Kj3cwFYy1q0J5WeqLO17ymcB/tPGckJWDqzbXDrmtJbDfiyIxON7oUus13CW9xB5TJ/huyJLsLYja/kg9gHLwya5/wF"
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "907ED2BD8649585B40741F1DC26B528B8A631C231A285946C3250F5D40DAA668",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:coOupTKbpYoSHK7heB7T3IAXsZUF0Zj8ewgMnySP31Y="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:GvW9+o+gdAZYPejhly2DX0FEpLxtKnrK6ik0qF1SjI0="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803049497,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAWzH5uBRqiJ2UCl5JYzP19ZR/4IH3oX5no1j6Cr6yNiyNVGIk9AkZl7+UFsy9/yIU+mZmWVczF70y37onOfZsRs3Ejj4hk/e2RpE1fl2Q6OulgPz2yZ/cnYbEM7f/Dv99szYnC0E1sR4CStwdsWiMltG7jHpsDBkDhZvxofQW7AUD4CWggvsmYxrnLhCb0hn4DF5dIFonRM1DjK9wnYT1zxL6J3R4vPIVxwY7ecRSQ22EofAuGdq2/ysFYuCa51CKcuxiWGSX9pIrcyL+Vfmijt6z2LKTC3wG+ajiHXu1IpXYVJCizuXSC0YUdUMnhCgoHT9j57Gv8wlRt8p7hjaigz1aAcCWtc7e9g1BVjTD+ksIkkJEWo/YqGl8FTCUEgBL5w8KPef2SWRCII9+E/1oRWosZMgfgO8vWY3a5P3ZIvG6+kFugfhWJwJr9RDtCDDOdSiKhBt7zc8aNk72wa+lQxL6KyIjuEBtp08RZUah5u1fmKis6yOuGOyQhzWplTseslicq97ITi+l/NQI05ash94+S95a7LscyCyg0pex73+V6elhvlyD0c8eEIFMKbqbn30+zUzd+U8QiYbkWJ+lpAyp5DSAVgC23dFqJXF8PNl2sRqcy2dV50lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwY/SChE8ANSfV4I2cXdAXgMAvxeAtYSnqUI1asYaGoq+hedHp18SSKxNppriKy1oS+exPrPyUL/k6N5mPRmo5Cg=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should save assets from the chain the account does not own": [
-    {
-      "version": 2,
-      "id": "73bdc00b-951d-4ee8-8c6e-091d31b6190d",
-      "name": "a",
-      "spendingKey": "378dfe8b99adec256b8150ba6b6aa5b071c9a52b05aab76cecd878c390d45e37",
-      "viewKey": "50c29f33b22b26e301687b8695cc4673504fe26e0fdc6cb89c13b324bf814057de1a91a3093ca349b24770abd28811d6d9aaee9c4ef88de3813024af9058373a",
-      "incomingViewKey": "174cce428af9343a08a0c0c59f634b70f6f4419a741058f0fda9bfc86c049206",
-      "outgoingViewKey": "1832cb48466a2202224c199e6b5caa3e79a0099fce88bb19717063ecd7bd355f",
-      "publicAddress": "a2a51df41dc61bcc5efe4af73a725b7270dd7314604072bba2b7a0254b3d1805",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "f15bf3e2-85c3-4ae9-ae38-e2436f53ecd8",
-      "name": "b",
-      "spendingKey": "a9a3dd26a551d02325d58d658f0054bfb88794332a2ca0c6df8228ae07c949a7",
-      "viewKey": "e9114f6c10b161f4ef8c63d41e61e928160141ea242ae647a5eff0fa5bbd72d048da403f663a7c6176f61427a519eedb9806b289ea1d657941dbfb471c95db05",
-      "incomingViewKey": "bf4d852dcac673dfc99b65770524cd1ef24b02a26a8ac8b6ca813f540f3cf500",
-      "outgoingViewKey": "956c1c17c5a664f4d6775348fe11f337aa9f31779e699be8130746334a255b9f",
-      "publicAddress": "8f1d27b1cd2791cb802d0a39e1082c29fb7cdc31d86f0bb0f94ef53238b94aa9",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:mUVbjSe5XGY+/KMvCSsJq0r8c5HA6dOlVfDXjcQ0IVU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:TsnwPdVEcxOBUPm17++zyRUcplmMACFVlX8b6cAOvzQ="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803050794,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAsYcLAtxAFZXqr3UF7284RO3Bca80bop6HGyMIFGhjw+IPofEXlP4uH6kF/nLlSwAsR+187M2nVAgXRvkKJFmbx5TApb5EpjM5h8J3XBqwfKMIOMle21Qp6jIQXCgzoRPXtiE5Bb0YxpF/ElGveP5LtAI+6XUmEMuO3Dvd9zG7H8Q511Fr/Nu3MuctAb2uYHyCltTtyIY0GftM2wzQ4mpAHiBYpGk5P0j1cycuiqhIXyQwj4c94epMH2emK5/maCkQ9YzSzPaQOcX9p11ULM3n8SdaH78eh8e8OeRupRh3glXzop6YfqN2oN2A43Yf3WIwEyyCtw3sDHi9BUvhL7G0GeVIBZz50YgZOUAvuYn/167zxSg5mctiKD3uCicVGQkefvhsunrl3C8c+jedDY/ejdTxqR3inmLpIinCTF3C7thXxh/vjGh0Hq8fFhNeAJsyc/r30SSdcMeCYoAr3+mqm8C2rkXqfsNxGlS5HjyqG3ynV0Nou88PYTYlFAR8e70OKmhq0ovsWDA7fo3GPplDHG0Z9SsaKyzb2mUkEsB6IM8BhkhkQOrsDIRDaob8vxbOtsTtdaN5pLEagPcw6UxZep5NgZsHHejgJuTGG6tGxxcFU5cej8Z50lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdz2Om0YAyBHt/8Cfu5ajvh7QQmjg41jTqlLC6Wq5HeDWHyWMNVFYK3EeK2WK2CBkUER02sLdGwn3q56l7dCiBA=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAISucRZQwio2g1rsL9tRXU91vK6eipG52rmSjJOs2OTWwO9xsCMmPDiK6adhupUhQgIrXq3f3F5LscoPg+dTWAqRhTn/CN9PpOJaZDDQN8UaTWlPD4lVBoDDHarsH8mfBW4UszyB70F4t0wUHnsnpgLwP/TuHZ2wk2OdTLVr5fW0EmXaj4zNHzYLTo6g4pRe9qEMzamspBqG+KM8FsMxKxnBowSv+fTpNqyMQGpKysD+uEsxDGOXmdwuLkT30dJtNU8hGnJlxcUYGwmW9qTAtTivhad3Qtev7z5vzWJ7KF/W8BExEPOlGlLvmWf25ikRKqtU6MgcerOlFGtCO94bER11Cy/5KArHJlDBSCAqnOdFsmKe+soCBvlPgr2Ihp9cWifEIDrZN3/cS90+w1qoLBxEKLu/Y1hUTuUK8pgCb9yGCl69WOpEZXKYWssOEPreV06gJ3F3oh4i9y9ocLupIBOgj9M3Nm3wOKFU3xIHgTy4UrSY1IkEfHMsNE6IA9YmwHlov9wP1z9cPWvM2eUAJ+wBRXOT3YAC+/5IjeFo/MnJCGjkOYnDwSz1JXDPEhLB15+sjp5sA/p2M85+2OEaXoKGvVSmiOVmsbzBK0oejaJ/PVNywfzbPOmBaSGGLScw352fC3HQgRykjLXerGhdhTASQd6eJGyVnPHN5oar3XSBBENG5PdKYNxt1IE0xQdH/7MP8Eu225pXyMU6Ah1pztF97XOkspArQr+Uf7LTQnoeIjRZv1fIgMYM88LALdN5AezidkSXCQl85YtAzJ0vDyvyV+RBBddIXkDJj9AihLfcefxc8a3onNmaq5aENnOdeXqWy4MT+ec4lCEFEUGTrxyonAmFqLLQLF7km5JKu3m/wuSJH7HcAHasTeF/IJMexj21fWF/BDj9EgGPPoxv6RSYo+mwor3uYg0/LTUbTNHtGaj3n4d8ZsEok7Gn6jiZpSKYcVR9I2qhR2jeMrmN521sJ5HF6tgvKoqUd9B3GG8xe/kr3OnJbcnDdcxRgQHK7oregJUs9GAVmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAAL0dUVsOVeO26cQIoSpXzM3ijGFWFCwcmi8R99lU+7ivpvT8E7jd+7UAZCfEaBp/fBi+DVrJ895h52n7LT4QDQagFgJdNb3CLMAMnBRjSLH4FUG9m8vCfb31LRLtZAqlGWqBOAdPILybaPqrkQfi3/ql0X0pwjABepUro9oBnIoE"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "355958E3DC3F46426B093B8CF7E9365C9929A07D2B8FF55ABD1CB1B002C8F32A",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:Vn0ASPSInfXUHzKmSgfYc77bX2sPgd4KP0Xc93WKDR0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:09y2oZyvq5vvHTC5QlKCP8rMEsGGOc4UFf0IB4v2S6Y="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803051808,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAo+tQ4YNIHvmqYH26omQRPb6mGx4MV60eRKoWnyUPg0W3Y3Fe/SYmVDff5HdJvbKoQNWfcH280GqYEJeRxBwCdvyRsDvdDu8N7pc9uQvpCIqiRt3Fghy4KxoIEoPyGSH5wcyQSYhIz+ULpFeFqw08Ucl0IEFieIekRkr7/VJfjBENM9vFcLdmuzSSRSOqLk3lr9SJsDX4Z8QwU0iFJ1j6n0DZ9oX2BL7lWCFSR/PxqT2gAZVfUBKjTyXbdnSnfcMiTFXZRkV6G4GGh10BBXOrT1UAKUFC4wRaWXv3jj1nTirh9Uf/IJbcfj2tIGUqgacXOqBVitre70vIcNi2Yio6yo+GKvB9Ex6joTAVRtFO86YGqUSo0B4upiVZq4DNXsxSfbSNvFIRNE0CzNOntzNe7UMl52c4l7PdFQedH0MLKT/n4ygi9Lmr2AeYn7q7/HunQTlSp37SPGcDX9MU8BB/H7IcmBkU6w/o+PFb+AlH8lK01V8PlaFZVTgeMwr1C7HGFZKp8Jmza6yTAW9qs5PgqRgW+HwxQGoutC1MZ3tivlM6GiHhqrvVENdz4Mk3kTwNTmJ6XJM9wy2D0ssCvY4dN/uN3lBDs6e32nT19656kqlfR+sYroexCklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXNJkTWEfYd0F4DTwqesg5UqE7ehYHGvqX0dD9Amjk8nMIB4psYhWcsiEq3B6efjAAFnVIXcpTmErNve0Bp0aDg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAISucRZQwio2g1rsL9tRXU91vK6eipG52rmSjJOs2OTWwO9xsCMmPDiK6adhupUhQgIrXq3f3F5LscoPg+dTWAqRhTn/CN9PpOJaZDDQN8UaTWlPD4lVBoDDHarsH8mfBW4UszyB70F4t0wUHnsnpgLwP/TuHZ2wk2OdTLVr5fW0EmXaj4zNHzYLTo6g4pRe9qEMzamspBqG+KM8FsMxKxnBowSv+fTpNqyMQGpKysD+uEsxDGOXmdwuLkT30dJtNU8hGnJlxcUYGwmW9qTAtTivhad3Qtev7z5vzWJ7KF/W8BExEPOlGlLvmWf25ikRKqtU6MgcerOlFGtCO94bER11Cy/5KArHJlDBSCAqnOdFsmKe+soCBvlPgr2Ihp9cWifEIDrZN3/cS90+w1qoLBxEKLu/Y1hUTuUK8pgCb9yGCl69WOpEZXKYWssOEPreV06gJ3F3oh4i9y9ocLupIBOgj9M3Nm3wOKFU3xIHgTy4UrSY1IkEfHMsNE6IA9YmwHlov9wP1z9cPWvM2eUAJ+wBRXOT3YAC+/5IjeFo/MnJCGjkOYnDwSz1JXDPEhLB15+sjp5sA/p2M85+2OEaXoKGvVSmiOVmsbzBK0oejaJ/PVNywfzbPOmBaSGGLScw352fC3HQgRykjLXerGhdhTASQd6eJGyVnPHN5oar3XSBBENG5PdKYNxt1IE0xQdH/7MP8Eu225pXyMU6Ah1pztF97XOkspArQr+Uf7LTQnoeIjRZv1fIgMYM88LALdN5AezidkSXCQl85YtAzJ0vDyvyV+RBBddIXkDJj9AihLfcefxc8a3onNmaq5aENnOdeXqWy4MT+ec4lCEFEUGTrxyonAmFqLLQLF7km5JKu3m/wuSJH7HcAHasTeF/IJMexj21fWF/BDj9EgGPPoxv6RSYo+mwor3uYg0/LTUbTNHtGaj3n4d8ZsEok7Gn6jiZpSKYcVR9I2qhR2jeMrmN521sJ5HF6tgvKoqUd9B3GG8xe/kr3OnJbcnDdcxRgQHK7oregJUs9GAVmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAAL0dUVsOVeO26cQIoSpXzM3ijGFWFCwcmi8R99lU+7ivpvT8E7jd+7UAZCfEaBp/fBi+DVrJ895h52n7LT4QDQagFgJdNb3CLMAMnBRjSLH4FUG9m8vCfb31LRLtZAqlGWqBOAdPILybaPqrkQfi3/ql0X0pwjABepUro9oBnIoE"
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAkBcVuyE92lsX7ga9cAKI5G3QoUhSgU2/2mHzFbzTkOaHJAR/+FzEVwrk2RGBHinIlf/sMM1zXRLO5l4yR59EGZRxhXwvzaqIVq1htFhBHPyKZPEH70Xm+83f5fJ/+Ao2TZzSzM4sd/mjiuCjhlmbzaFgXtAAtMXpKbxb9vR/EpUYdarMgEMEOeeLQvfekrZ4tv+yzAkIkQCxg9/yIH123dI8J/hFekcV9NUD9Ufn+denx/FL6klU8unBzEBccmM+pkO/f2BAZ3j7s385f55isD/08L0MpFGC7RShOla+0FDqp6vH+IpkNlRNjSfFX2VMQuujKSQe4SqU3f0EeY5Gw1Z9AEj0iJ311B8ypkoH2HO+219rD4HeCj9F3Pd1ig0dBgAAAKSh/35xThgRVqtcjT1oSJpcON6BrjyVp6AmTvSW7O1VJVgb9FGQhsjySeolsBLXVJQ/PKWgN6F+cgdKgdlx1kfVORtIT3fYuIGKZOBbmURO/xY20XVhcWnvXHlLOcaPCbAOViRFLOSV8g26CAFc4kyFTDVGpOwBCWc2UWNfayf1Wlv3x0gyPFsR7SxLmraGvYbuhIJ+BUCQNcPHGUot4pl9hkH2PMfTSS+bz/q5n6NlxwNXUNZU/ojmOx78MBBqwgWnXbWsef1+WAHqk2KYEG8zZMsaRjN7C+Mi6pKpwfQoj6jMqsKz4/yawDVipFpzaYbBCC3AlatddSOnevjBn/VC3fkRmsGcnusHh4m/Fa2ahtuE5sRy5OJ9JUxrPmzy+FNnteWBztOwUAdV5G8vgJ6wkRGhLVI4NbGNuRJRCcVNB8JbWaemXmOViWVuq+98pJK9xxCs7rkhowpHCTM2yhFVTB7+BaIpAiQASyCH8GXwrEkBbBBy0oe5vlzZxgJ4hfagIy4ujQo3X+OyNS/5xp5ue0EpMxqhqxG23TJoNrB+WdBzs3P/gLIWJYiseNAPHH/bx07Sg5esWOVUXgUWkZF2w0x6G4rcrkAWhtsO/Ej4/de0t5JDDtdjSLS8jA+/a6zMFzby9Dw0RKSNzwcRQqTu+9hC3ygVOZFaa5D/mpjjDlHyUflgKlj6fCiqbe/t3/DlNaeibXMnrXGtvD2t8crdtPaNq02sPFCOZQPny3ck+tMm2toSGPosPW+gAf1I/Ydj2PaGCl4YWl6MDnOFf8AYGLvJ/8QNuXhecz9lO4cKVO338ucTQXy08/+asdh/lj7uz5ORY+NehUS8pKQAL78pUDUWH6ecmd3HOPN5ocKIZiAQFGxooLGMnyE45j+6BDra+3uXL4REzbNXIEnu/klGZsx2j7Dsbh+g6YOxTx+CGnDy3RRSUPsAINR/O6CQXixr5ShLYLP+MywUG9FxjKzA1s+lktG3kDyK0TBP7RINHTRncQqKj/KiDJF8Kez2wMfAU1mXjf6oSnPmef80LWXG2Ih6UTbRMwnedt9xClE61fjfScI79HwCEzJ0KrRzhrS7qmET6jzOTJZAHFRhgpjKksGJbCP5RDh/1AmGQit4J2rVfFcfsnHhcLPOCb0gpcSEhaCXgadznmwxgCtuaBz2YOEXPT9eMJnZyiKPX7Ld9QdevAiiPzfJrL6jOlv/MJSDEc20VegDcq/ZDVE0IwEu08+VVr4PM8rxWsva9RuFIi7Rm2C+0K3iS/5+B404qe8YQecn/tuDIGS5yW74GixKlIM5DsC45GozaWcCmGLLdV/Nh8VDeQHWrIyrYfhmlnpRkv2N3zPLr5lR+5cPoMajo122YIX54JOxkewS3uP/4VxxiCjN0+nJWjIuyoyJRkKrVyPsWTKKXOr/hJkvx1ebT+OR1J64zrmONMRzwa5vnovrvRVlUxoTljEcLtpOceZz5Fv4fvZJAsz/fddynKnY/9kRDv0nvJFSgdHCTs0utlCDtd1a/pvZYbqOSxvCv0zsMqPdIpWP1lMMJ8CA3md3nMqX/aZ5rB1a9Sf3WrZgmQWz1idvpXEPo3X4ToI/AQ=="
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "D9A6C9D329CC3F514A419DFB570C3F4085F2D7F109FE0F7BD34DC191EE039A87",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:CJqpwxq2yug88wysNYhQF/DBQtYfDod4v0VAp33a5z8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:SQOidJTTzjAMlgfqcVUR9DeaHejxJhmJ9ZlU+hoMnC4="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803053831,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 9,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA+/hUVcfG6IqJm8ufzcU07aHeSdomsq1Yau+7tNLd2VCJT4Ke2qLw0Pnrs408SaBWacwa+VoV688kpvTH4PhkkLTnIObR3AdXBiG/5jOyFLmQij9kuPbdcIRQxsBvmdsZ68ICLAO8Odt90vkf//30nqs8uJvdAwf1nsB+wZ6OW3QHuZ43+mUhvqv2PXzsx1adEnOa13z35eJb65/3DB2V0IgmVOEbeosb2NFfMXI1UeKVHAGu/+x10zXkaVUtzHfEPwfmZbgKl6WBdWuwnFLOaQtp11Uh7W2BZUZt3IvufX5ZtWGB3Lg9I5Mcamkt7Y3EtoDMQTMdfaN7rbbMssUJVEUeh0NmBas//K6N4GkB7xlohb0BYUf1NtFUyjnFAtkyj+hU0tXbvqS8iDGwbLVXByPW4tTHgbhdbGYeRnKaQxIp5PyLOTlqy4+doxe077xElj/rbZU9TxXan/z8SvQrYOluI25aZB7Rp6P/vfjWfmlEDAXENyKfIoChR1qxFxFt74FjUBCkANanSP9G4PdpoyGBS5CveUHuCHhy+nXCpZh6ZWjhiVOXWLP0dfzyzkVqFwtxDFUDPKOzhxqlPVBA5tjgoImidt0jXgy5WqVi2MFBVd9EK8Sdp0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAweTGB+bOhubG6XBVwgTnyPWgSHAUyME5sS7UT22KN1AJ4dAPonTSwE5naN1BfPRlL2dQoIY9zFZmJkLDJuznlDQ=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAkBcVuyE92lsX7ga9cAKI5G3QoUhSgU2/2mHzFbzTkOaHJAR/+FzEVwrk2RGBHinIlf/sMM1zXRLO5l4yR59EGZRxhXwvzaqIVq1htFhBHPyKZPEH70Xm+83f5fJ/+Ao2TZzSzM4sd/mjiuCjhlmbzaFgXtAAtMXpKbxb9vR/EpUYdarMgEMEOeeLQvfekrZ4tv+yzAkIkQCxg9/yIH123dI8J/hFekcV9NUD9Ufn+denx/FL6klU8unBzEBccmM+pkO/f2BAZ3j7s385f55isD/08L0MpFGC7RShOla+0FDqp6vH+IpkNlRNjSfFX2VMQuujKSQe4SqU3f0EeY5Gw1Z9AEj0iJ311B8ypkoH2HO+219rD4HeCj9F3Pd1ig0dBgAAAKSh/35xThgRVqtcjT1oSJpcON6BrjyVp6AmTvSW7O1VJVgb9FGQhsjySeolsBLXVJQ/PKWgN6F+cgdKgdlx1kfVORtIT3fYuIGKZOBbmURO/xY20XVhcWnvXHlLOcaPCbAOViRFLOSV8g26CAFc4kyFTDVGpOwBCWc2UWNfayf1Wlv3x0gyPFsR7SxLmraGvYbuhIJ+BUCQNcPHGUot4pl9hkH2PMfTSS+bz/q5n6NlxwNXUNZU/ojmOx78MBBqwgWnXbWsef1+WAHqk2KYEG8zZMsaRjN7C+Mi6pKpwfQoj6jMqsKz4/yawDVipFpzaYbBCC3AlatddSOnevjBn/VC3fkRmsGcnusHh4m/Fa2ahtuE5sRy5OJ9JUxrPmzy+FNnteWBztOwUAdV5G8vgJ6wkRGhLVI4NbGNuRJRCcVNB8JbWaemXmOViWVuq+98pJK9xxCs7rkhowpHCTM2yhFVTB7+BaIpAiQASyCH8GXwrEkBbBBy0oe5vlzZxgJ4hfagIy4ujQo3X+OyNS/5xp5ue0EpMxqhqxG23TJoNrB+WdBzs3P/gLIWJYiseNAPHH/bx07Sg5esWOVUXgUWkZF2w0x6G4rcrkAWhtsO/Ej4/de0t5JDDtdjSLS8jA+/a6zMFzby9Dw0RKSNzwcRQqTu+9hC3ygVOZFaa5D/mpjjDlHyUflgKlj6fCiqbe/t3/DlNaeibXMnrXGtvD2t8crdtPaNq02sPFCOZQPny3ck+tMm2toSGPosPW+gAf1I/Ydj2PaGCl4YWl6MDnOFf8AYGLvJ/8QNuXhecz9lO4cKVO338ucTQXy08/+asdh/lj7uz5ORY+NehUS8pKQAL78pUDUWH6ecmd3HOPN5ocKIZiAQFGxooLGMnyE45j+6BDra+3uXL4REzbNXIEnu/klGZsx2j7Dsbh+g6YOxTx+CGnDy3RRSUPsAINR/O6CQXixr5ShLYLP+MywUG9FxjKzA1s+lktG3kDyK0TBP7RINHTRncQqKj/KiDJF8Kez2wMfAU1mXjf6oSnPmef80LWXG2Ih6UTbRMwnedt9xClE61fjfScI79HwCEzJ0KrRzhrS7qmET6jzOTJZAHFRhgpjKksGJbCP5RDh/1AmGQit4J2rVfFcfsnHhcLPOCb0gpcSEhaCXgadznmwxgCtuaBz2YOEXPT9eMJnZyiKPX7Ld9QdevAiiPzfJrL6jOlv/MJSDEc20VegDcq/ZDVE0IwEu08+VVr4PM8rxWsva9RuFIi7Rm2C+0K3iS/5+B404qe8YQecn/tuDIGS5yW74GixKlIM5DsC45GozaWcCmGLLdV/Nh8VDeQHWrIyrYfhmlnpRkv2N3zPLr5lR+5cPoMajo122YIX54JOxkewS3uP/4VxxiCjN0+nJWjIuyoyJRkKrVyPsWTKKXOr/hJkvx1ebT+OR1J64zrmONMRzwa5vnovrvRVlUxoTljEcLtpOceZz5Fv4fvZJAsz/fddynKnY/9kRDv0nvJFSgdHCTs0utlCDtd1a/pvZYbqOSxvCv0zsMqPdIpWP1lMMJ8CA3md3nMqX/aZ5rB1a9Sf3WrZgmQWz1idvpXEPo3X4ToI/AQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should add transactions to accounts if the account spends, but does not receive notes": [
-    {
-      "version": 2,
-      "id": "f8e2a152-8cb1-41e9-8c51-24bf4cd4ba85",
-      "name": "a",
-      "spendingKey": "ad14e26f052855945dfeea65bf7b11550d087ad7626cb845b12d3243138e6be8",
-      "viewKey": "d303aaa5ecda0e605cdee21f68ebd4a24242af2eff2879cd23892a7df42ffb144be832846b6a625df0d38ce6649e2c6cb8374e80bce28a10e620bd1875172466",
-      "incomingViewKey": "af55016defd113c2e378cf82d7c46fcf43be0e55bcbee6565f9ae540f2bec604",
-      "outgoingViewKey": "bd1037201a08ddc64ea4736d0c3841996d3387b894e6c58c69090b2c3328269e",
-      "publicAddress": "37670cad33e4b6938d26f22d856017cc32cb3deba0687ffbeda9cb551217b065",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "f3e324c4-f597-4d2f-9e41-7afd2d291f13",
-      "name": "b",
-      "spendingKey": "b1f502e5fa7b7be1a6cb8e5bf5b1b30b010c73045d04c82c7ab1ed14537d54e6",
-      "viewKey": "f07efd8bc4be0eb6eb4d81103e9e3300ff3d7744983cf9808abdaf573741da1a7fcaab6c014c3a99bcd7e68bf96f88f4270298c33dfd15ee5b4e0d96c61796d6",
-      "incomingViewKey": "ab347ebae6344450855e299efd9e6098efa9a84048c58d34a727184ff5af8d01",
-      "outgoingViewKey": "fc881a676ee13a2fc95a49a8e6c3c39014efba21b4190aaa0197ef560e53936a",
-      "publicAddress": "0ead88b1961d28fe3aaca7c37b6974d8f5ec4d07fe96847611879bea1f5365d3",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:j+Oqam+n6rBGH15CuDkV6M7M/ciqBgEti+fDFWtVZi4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:94TN1ZBB03pRMrkSiubVwPKXy7t8MV/+QT6dtTkRdO8="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803055578,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA6FLwgPw1xfj9zp1QD/HDdueqx4rPCAtT3Cscjoa6GMmZ2iMfoVh5OFPF8srs6Vci1/xvruod9zZIgKJsdkWLYkx9rTJ+RDizSjbRDmbG2L2hCFseSVcq033Tidu+Q3FRpBM0ntNUqQUiM+aixlUlQkwKOH79gdSSq5jVSe/Yl5IL+sDfaOlg2QfP3Ng6IpHCftyUjJ7Jv3oSRj5DsTnAdXDjhUQ/2SitleVp0VVGvbaNHamE2mNcOeZrjQgHAUPU4HXVoAVW+ZlQHZ4S8qgg8CwcxBGftFIaLhtAW5k0PZBTUrMNI9iVOqII97embjFjnnmX3rEELKEBAc9QctHhXcXSaPUJL5DYtHZy18AB/f0gLHuCfT4NyJaFQEu7QnldayI8Tymhkatnk/ozirztJe6G8q0UkdwFUbYKHR69tSqb2tb2vyd471etluWIgHApj7cX3QYeDWIRV/AIT3BjXQ1uKMh8T6KYL0NrdxckErtesdQ7dvKUv7xLHRom/KKBxqgi0IZU+jK81hDwD/anyuVeSjRtqe8Ol2lC+RG50RnAV3qFBTWJZhQAJL+dE1RQnfC/qUwucxTSBSSkiTL3rmAamIecNPv3lsdK13/EdRpuWC/d43EHEklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwE47NtcfpAur84R1EjVOgbujy76NSeSmD8QFCQpzDSsdyR+x0NxFOmP1rrj1SJFCbDNMjQEWxHAFaSuvFIEijAg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "D4F6A7B88E71591E1AB5A82197EE75D5AA07CA7ECD06994C253BA6E4749A2C97",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:HQfP1gO8Yz35tllwiaVHrH7wHQ2XNBjf8AXze+T8V2M="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:Ni/kTn/fVWiLyyoFaO1HmdbSxMS73SGe44gPFeNbPlM="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803057158,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdiUEf////8AAAAA/tcUTeGl/dk9igzKxVhV92WSa+g1zkT8m2+YgBNDweasAGxubrEbVBJOfM29Zwmozx8igM6B85OMXKNH4BFnIxvH1fX3/C4XTWeQGchW2oKJ8xsiY9NjG1YGSd7B98oPk5hzuLqnDzW3RpOT5vDXk2zL+z2ObwJySwyk1/9OuOQD2BeDUboqTDqITvPt7ST7HjtGHKJSj+mqCRAOPVPJWIy/VgisvD6aElGX+aht4QWt6sUAVqmlKC/Vvj/jeUI41yT4W/Cws1P/7uhagk2FULJv3Tl12voop9ZSUhiYENOwZ9OvA0DnfM5XAjjmvFz1bEQA7gSMivAKjg19A9iS8tRxXQpnZt8cZROwTOe7+qXNlYGucJXnqqySprHyoFMREGrPD5kLiFXL2CKvDR/FWAOJSlMVCiDfNmSlyJsHUrdbSPUga0kFAqEU8YcjFeb0LMY1ZVmw/ThTPf0kydU6Ps5S87KOY1pyZFE7uGjAdT09FJl/lSy+JgJW73WrQJmcE/3SZ5IWuCdZmpRvToTRzJSsE07J7T8D+leGfZGTq9S8RTNfE4xAHdzzdB3hzlAPrsSAiUjzEyB1TThku0HMmEK5slbTgjezyFv9nnPLIZyKIt9+oRK2E0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9PV2rF1SdFIcYWdnytbDEdiwZkOIeinR5agFo7abWh9mttZBzW0mIPOlVQec34shu0ljWWNxeoNHS+PrNB2sAA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/5M1dwAAAAAAAAAAJXDQsmJUWXGRj5CMux3rrt9zjWWEi1OJ4vehyLB6qDKKt83lDDC/FY4IrwnWMUzW07qtQmUHbq9nbhGsnHcRIz9ZlyxC5qeKfk1Rc7cWPZWG2EB4T3j/6MG2jIIrE0Pow0AbFsk+SoKXE26hBW8aDyjz0ffWyVHCULvGC9MuPggGpNAvB3GX4hIeiC/wo8IZH6kCOQChyJuYJoZWvh3jLFHgW2KTqzONlwKpj+PGa4q0ojnLsMJ1jry1edSP7JZqvz9kEAhuEEXRSUZBYdpmicekAQ8nifA8vZL8w1TREtXNAA/ryhUq3pDjzhhlHmc6UHIJFrIGAZImB/SQVFAAiY/jqmpvp+qwRh9eQrg5FejOzP3IqgYBLYvnwxVrVWYuBAAAADnFm9+D3Sl1cL+Qr57mgBTaDATFXOa8ymn7JVFLDkZxk7y4VAIHJVkvQF833gyqkZTKf6XyovsIho2b+zTHzdUj1v46uRFhs1JaIWU1wG+LQIIsYcVys6qJH8uFDbn6BIVSypR1RV0QpZ9Xih/OYHtbNOP6yU1rD0GkhOcxeGUKKbZuH9XRDfgnElWEctdykabCmpcs/Xbyi+kfaytwlIck2UUb9jQu8opBzuIn4GwlFajMqfC8pmW7MgJcLd7REwNFDLJoLRtEEVSnYmopbhhu4r13+dWfZ58poWaVJ+/GqbpAZrCmdUKU83/BrwPa769OiB3bFW5Q5rCkvaXk9GXc6vrta+fXYo2lbQPRyva2TMi3DWQ7BtxC7q347f5DixeJUNNUtkF4G277nF/BwwAryVW/Bvd6P1z37c7ULGwW8IgglUvAdExq35nnlWY2gikMAWLlrcum/Ut7aTUKKTNMVZILr3838OHnXr4c1zsfJfYleWntyW6/h2TJ62cZrlCqDydnJsQGQ/VjhDKuG5zFUVe/LMqlOLbw+Lf2A61dSZGuYoGn7EGwUmWtFc6Ckqcpm+pEgHaQKfC0zuNSrzIbD2EgYOuQK5rjIyMabUvKb3BA6mzjfrNefeI6WIxDAniCIFBB3Iv4ELoO0nq7ai3TweTQNIW6R29Eu1W843fSBcPXxl69G4KAXfvOj6lUgdy1+lxnlyq4iInZ5XB0Mpov4QqmkPPvAThbwFLyELHAhRPnjztt9grMXh8dRcYa0nwetKhhkcbWOquM5b66T8hjJbiUZxiYWvuEGzs2gPSIzfxlL++gfUboLXw0W1r+Kbhk3zC1hhDM7M9++QuNVfoKixHXCowrxMZ69+rQu+SQWwuylSZsRrOxQEKpeslAEhKMEEHXWv4L"
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should set null account.createdAt for the first on-chain transaction of an account": [
-    {
-      "version": 2,
-      "id": "20899f2b-f41b-4efb-912e-9aec81a84d26",
-      "name": "accountA",
-      "spendingKey": "891fc0cd88f2272b06e78fc1298e2c14494b75c3591f76e7a7dca57352d19887",
-      "viewKey": "d241d8bbf26ed4a263f353c00172c0fbdb755308f064e2962d292ec70f07bbc9dc76ca4de7dd39559b8f04c4c78e8241c71455d01e7bdf252bc66492885e65c9",
-      "incomingViewKey": "ebc3850f8c9be6342341ad54109c41c8b29791d058211c45808a44c708e29207",
-      "outgoingViewKey": "6823af605d6592687274c46fa8619b7aba065bee983ac5c6d6b6bdd0ec93db95",
-      "publicAddress": "b5815b5b8945ef50d83b0e971985e4f592f2db89e9991efe7665b1f762474356",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:hvTFGx5xMzPox0YNUJJuGkbhbcGUXMqRCAW4PP5qZDM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:CqdkjrbbAl9tsXq1R5UmEr2so4fI+yETyzReGO+qB4M="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803058464,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA7bomh149sHCHnM+VrxiJX7865AJKO1A5dErTXeP/uCytdfJTI0makdf1gmuACHqJ6isI4cTcjtpr+nDEcgZMVozsfA0e2+wQni7Ch1jlCHWmqOMGquzoqZ6fkBFb0oC6/ytwlF8wVo47IyQJ0QltauQy1S8Cznw69n0r8+XTwkMKk1gejjrVfMGM6STGYXK/LytOn0Z7xaqmRniMomhTwW0NS0Os+7SwlJSEBbPxoEaDRxLpxeaSy837r3E3qlaqnyk0hY75E6ljG39XACTZXatj59/NRIBE3RwMst6sEARd3Ygr2DmZbZ2cUVqALaKDIfgWS7zTQWGz0o4uAG/OB+BHLbeqpjROvXYd7ilAI7kdgf2AonJVrMtKP2Z3c+lRKo5+fuhwZDnFvD3H2Sxov3r27vC8c6p+5GqgGTOqquushcgKSeZPnMIL1E84+57ZKaTzYTA0Fc1yavcZ7nng2fBfx0M1+B3nZGNRKEQh42MibTIJB8FvuzrXfD57rJc2cLsWSlzO9M+vPqztyzcPgdwwyD5biaVWIUX0VDay1qpPo7eu909IexFrlcDxB238xY6y69jnl0dZ8Afpc6v+6TI1WDdWltZiMN2CTjQ9iYydq2+sI9+TE0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwa0EsKjjq+XfFya83YqmArWI8RnIFMxSrck6C0nM6YK9+W9O//dtgX6RLNqO0QJjifMl1mE+uJf2pCLk/69FTCg=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should not set account.createdAt if the account has no transaction on the block": [
-    {
-      "version": 2,
-      "id": "d0aeb0fb-256c-4c64-a289-70707b314a58",
-      "name": "accountA",
-      "spendingKey": "e27a55f2f304de29d0ab3a5445b384a77f2d0d6cccd0b87a91ccf4ef5a2a8577",
-      "viewKey": "2420a4256c37d822ad9a3e97732ec3ad858b5809573865c212cab3c9960005bb1d887ab567765c722550496a414825760343c54113b5f9accc70f3d790648695",
-      "incomingViewKey": "458178140477e1e9d867db069b3f7c7512f5fc7ff64648a0bfc4e6b3f341e307",
-      "outgoingViewKey": "6b29c7ac0b786fb3d6bc3fa59deaffffcdf43dbfdc042bbbade5fdcb93c58da9",
-      "publicAddress": "e54281fb4ad439247f05212a260c4a915e96a1757b85c62de6547125a3d4ca0e",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "c5fcb959-d5d9-4cad-8275-13f92aeaf5b3",
-      "name": "accountB",
-      "spendingKey": "133123594babd224b3990f781d0c68ad70c786b061ea5e68b358a49a8a521127",
-      "viewKey": "71509f10cc4c20b95571ce2f68c4fa83cd15c89d26508d0f7796e74bce4a52d8368176af3453bef52d32e175f3a38ecfe84f9ccc0372c9da24c70339b4cab5ac",
-      "incomingViewKey": "b0c8050f618fee8668e57f18c9475bd3c0e4024e04fd8838958893f73c32b202",
-      "outgoingViewKey": "b79b4f3858c105d2678ea4d96c05e6c25630f03384688403eb95ec013da6b404",
-      "publicAddress": "c93a4b3b49660973846fb711ff5e85c9bbf2a2e5f4ec51ec08b5bd9015191273",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ZRYhps9GWbOhA6tdY/OR0MnY3jkuRi1s54KEwcdnmkE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:FRUVU1ZxHyr9GgY76OfIaH2VRXxk4RXCnvbO21tIQq8="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803059768,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA5uEWQ1l4skqfoBsnILmHCKGMe6kqii+jfK0SDbXIMyGsWuthQSU0US9ywuwPx3L/WjhlkaL0xsJ11ISUNlgVy7JZ35JHBt4ujKwXR/OHUwyMdbnSai4VgOH9vi6bd0vn/dNMPpGIlgfz/GVY4ZuQFpIvg8ES3fZ6jPfOnFWiKkoO+GnX8FINpaYrJ0XEvhsCLMhbim4FWgDBLWkxouq6GiHTScnwOKqeutKo1izHe4GOJS7HF293JMBIKVW1qoNBXcYz9TSqrmxro9jfYOOGZTqT8wU3d1cuxzNw6AxCbrl8IZX4xKFG2nJIWIHMxgJJHQYrTogGvhaM2TGzLKE9W5n0AEDBxdSwIH1nJPdj9eRMqv6ci5ySCV4cbIQvkqUoCQ9Kvw5htXB02uceDbZQbuE4YtdvO8K8rRon2NdqsjbbqK5jZWOahIHyhPgRKUkVPhquvsBicUedMiITUHeYm16c3kp0xaE0bPawxh65tiL3fCCV8DiruRFc5UkHa3uOZfV1zTmC+QNpTiZlqYNlSFlqZhg4Lnuz9Zse33mijWstm75GJI3S9vyd2l6ZqxpBPTJzSMbjCeb0PM4IVYQzXEZoa6mMZKCOvV9cKgn1tZLK0PbyanhFT0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwUkbPt6MAThN16HPPD/h+2ARBrDXSFKBdpuUNzyTC35yb+oCPx/RqE4yQGdGjAhE7GPhmCjBbFt9fYfTexLAgDA=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should not set account.createdAt if it is not null": [
-    {
-      "version": 2,
-      "id": "ab1b4461-d365-4f7d-9641-9dc2562c47b9",
-      "name": "accountA",
-      "spendingKey": "ed3c2f31974cffe42c76c7a231ac4dbf628f0cb791ca06b53d14c9e95b89418f",
-      "viewKey": "f3d566abe487c4357017d1d5816dbaa19ed57d696b9dd0ffdfc9ba68d09163bac435fce603f73857069bd147edc6050d851cd9461e9557f8fde570cc89263165",
-      "incomingViewKey": "6d05609dc7c1f16aa7907a1396d1756d6744097b28733d37a68d9fb5cdfc6f00",
-      "outgoingViewKey": "aff328585a920e15a54e6dcd81277b73ef4a353c54e57252c036513564c46c3e",
-      "publicAddress": "593c121477e01fff6c60b896fabee149cd8c3a7e0bc416b02fc17315485ea20c",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:uPwamF08jLtoHtD957xhOXtaF8j6ch3gHU5hf2g5IgE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:D7metrHThbJPjyv2A5evin9ccTlEpNCnZhmuR8z0Ifw="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803061129,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAyf1Jrj4WzNvzFVEL9tnZCCKCsUoT4A7ItlDHkegDDeGjiBpPiFbvo6tg3Txl1YEdc3zYwUBzQaCRqxpoDESvNOBCAD0bN3bWKK3M9YKmF060+AS8B1cxfsImRxsn4htIvdoIdQn92aJk/v/2FDsTueiGIdZe5P+aRQT6XT4xlvEOGOaATEd7a1hCZrgbzcZFJmcHP6r68St8Iu+W91wa8sol9mpKJPyQ+faz3PxeZ3ePPPdupeuIg6KKsOjXPV5SCkvVvaVBS+6JSgpIghKP/QhDOmzhnom4IRe5pmc7+65e6dJ6ky6IhVs2ZsMkegsWgwUNHAPyaRTb9QS+NgXiysgHN6IpKAz7SJ+crhK8UAsYQMWwwrarPlMGNhA8Y4oEU+9GQm06FtYBWUfJXLDijDYv2YVMmHSHJSAYS0pHwm2d8c3wyDhN116hzkMRAIXezGnK3ppRLxEv0f+c5tdb46hYi4shdTDbQG0D+QBCQLsIkGpm2IxfZ28zXvczu8LwLkOgoEJrnDvmEbPgN6sJlZgLMJu+QnxOnUmE4afUaXgI73j/sU2vF4C2vXtM6lLFcYjqqXq7uWme5Gn0YFY6JzC+I1z8TcFwh0A0Ylaxi2jXrSxYoNwpjUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwr9/g9FWMDE/leEMEhpJzUSoNq/w4HhJ1fE5fwnvhMHNaffXI4ufMqShR6YyFYT7O1TT9df6SnLnZxUeKQhvSAQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "AA12CF79D5B68A1A6ADC7DE343E95B3B6C0AA7170BBA51ADEE5C8A6D79D36489",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:jt/Pk0kQdZhQIVSXfwBWwwRxhJmOyIrZo+IAvaBoqxI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:dsyr2R3EWCPVIo1XP/Fj0Rz/AV9HwSlwgAQhXeK4tHk="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803061565,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQ6DgpzWxxwg9RwtNu+dVFkpaEjIjHvjTgsv1lj0TzsCM1ATvsTlu8U2iehAVuCQNUw5hYYlBalOoaSW9Uigw7/rzN67hhbvv5Mu0RU1vk76K2Tw6WVuvD1xfkHhuGCW4t1OvGaiWbS/dZ15hOgy3jdAyDFBOvVarcmDFZpxjCwwRCDq2V/dECth+DJ3a9IcidVgFQocLMvqOABvkAUQr/UDIRiZ9ndtZhnyemSLLDuynEmDJbIOEmbsxSDgxqu3s9PhyeigTPQeisS75FLyaaUkYXZsHvqe2xWJvyjldsrlf2c/L72dx3CsjEnn0hRKN57swGjvMLrkFwnLh7V2wKMNbpOmZG/KqHIjndl4U43H48tKAq5V3q3EvbnP7RpALundjTTjrazROvKvQSU1U9nKFa+5UhIfe5TC3vC8HZwaobcnJWyWdBPeONp2st/Uf9x6AkD5i9ixR+WhHg3itsgPcvgsnzNec9y6AnxNqKIMfCIxHoLDiW4VZD5vz6725ztPRjjcu09oZE600TDO169XP+tt5AiWCxeHLeGhtuubwj0XC+QtC3HYOEi9ZkStc8mlKS9B5OaPeNLs37VOlHbU+twmo2sW1h6x3TB4pJfSsBm+kgx6GBUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/OcfAqLgofyuNvnR/vEnPtUR9t5IbC7Fi5BeJp3cm1Cia2NBSn3JJvlS4pbSO0L1eYvF2N5i1lNEYRN7q+z3CQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts connectBlock should skip decryption for accounts with createdAt later than the block header": [
-    {
-      "version": 2,
-      "id": "82afaf18-9ed3-40c5-b0f0-4d5a957e3807",
-      "name": "a",
-      "spendingKey": "eaa84977737304b8395033fea1d22dac5518c2db057db77cabbf6d9de6d1f05e",
-      "viewKey": "7d4e2364fc3780ba241bf9cf838dc9be57e143b25ecbff0396c5b4a526e85912161996c1a79108bc406310eb37ec510c078f2fc90e83b612e250a241b2480c6a",
-      "incomingViewKey": "bb32b37d3890902a56e9119e83cd01809cd1ad3915b219234185db4390d2b907",
-      "outgoingViewKey": "e889bc86a7b495c53cc6725cb59a42954915a9052aaa0092a748cb826abf6a66",
-      "publicAddress": "667f99e41b112dbe5eb6c7c7bb8daa3b56d994f549992528868c77ef0a449a69",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:Xj5IaxfwjxGKLMwue1h5KIKvKprq89abUQqN3ZNJh0I="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:gR0BBDgm3CoT8f/PwpytORVnBW0P/GuXwDWFE8uvXA8="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803062906,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAXL+o6DgIfpKxVvrSTzu+v2BP41ROhmzzmRRha8nSYMqCFdttIwV3AR/zuzdcX6RLonWE07wqP/H7UJn/wzirfAPsSfU4O+oqKBc2K7petJCydsqu+lySQTTbYxrre7MEdQhXYxHpaKeG3NMjtuve71npr/aynX9NqRAEPdU43F0CChkhoq9rzVnnwSeDqTjt8x/044VDMTEnOvpTnhKPGpSWtp3Kr3UC1OLNim5GqXGTUxC1kEXjWqEbtlYK+SsKGiVVg6WE/lqrdYspUrTODQ00RptOlIL4msOjbNV8Vhc3/olLNXgejIwDfKugKLK8rd5k4wbDXyWqptvBQqrvkIUHROHOVNpOyaPoxjda78/dzlzIzANfCEQxakcoxaUHdMcb534ZwwzZ/02pYm4/JpYKJkKDht0YkdRssdWafp8T8lLEObhDcriKf67spyfcuubyNR7HR0M6ocs51WUso1/ts7rE81F1yTLAUoK44tmrEPqZLaPO5Hn7ACO0OArDcoZjK4CD9B5yiETIf6gsKeu9prFhOikgyq/zFKN/q5w6AfqPWkMbzyFp9QOXXjw/O8wXjsumzNshfCs/LEqnjMoaQf3ukMDcObSlFCrhbO9/jnVWovhWkklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAww8eq3bMNz4VxGtFaw8ufn7HKz9I+dzQo4IssJx2X/hC7d2OkXjNdD+uibJwzh/uhx3+Ul8hOPIlY57U5oXAqAA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "EF70638099FE80FFEACC2D12A2DDA3984BCCDAF9EEB6CCE05723B4C5CD86BED9",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:18QhVc3lJzb2MRf+xnDBqsZQbhmY1kif8r2t3kvyNHM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:BBPPy1Ss6qG4RhcpqBc330mqjc4rwcUdWGeG4fsKENM="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803063367,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAwB1EQVhna24iYMCgz5c+meIwqDfwtkb2gv0iyTijtqWgWTLft2Qo1ZrNKiIsl29TLTjf3tjoDXCICuNuMT9XShOUsT3tIOoAvihGdo7C9sOnHig6P8AD9lsOM+SvlhYzXw01q0aTyExIjqmw5BEc3KgyDzZ4ikdn8Ow1O7HVElMTpH4ahEkl+0gXsRUzaFC8UEflXj24rE0/gR07J6Ik3omD+UDdybvHfmPVlh4JfFWs8a33UBZionQhV6ItKpK1EzzfaSlHiLra2ABTY1uahZS137ZHzPgAhHi2C3lfyLoaKqZKKIJpTjg3e+BLvsVNaPKA2IruHWgbeHvXzbGxE/847zRxvoC37lchvKCBv730zic12844WDdhu3ZJc/M8JfFkRSVT8lGZSDJIRDXo4paJ0J5qx2Um0ff0IgDAn+9PzvVEYunbGqjQicgFQGy88+Kb/TRkT9tzHgUmdPTz2ibLNXumPUAAQpXV6FXK+z2E9/+r6OzOmMT+Ov4lh93TBkybo+u966zNrb4EsfXvwFvz8FHxesZtgAb6ljs5Z6MT2lqbfXsLClefKamOpzI213s7+Vs4XyxUd8GlSDulxl/7/yRFcNuIW6a7jxhcm6oLOLwyCmoys0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwKxr3BdwSIB86hGdeq64f7VgqzmkSlzYG0Nl+MDlzHu7LFc048/NMbJostlwXumpvuCCQeY6ZZqUl5X9bCmAaCg=="
-        }
-      ]
-    },
-    {
-      "version": 2,
-      "id": "52df2550-49ab-4fff-bb6e-a0f6585f8e2b",
-      "name": "b",
-      "spendingKey": "95883ecbcf7fb3dde07cf7a680ef46cefaa7a3257db201d2f9b91b23abeaff5b",
-      "viewKey": "de4ca3427ff947ef509d818fe3b503ee0a05bf55d1eaea9f22f385fefa634f59b045130df1a8ff3398f4589219df2b3fa3fb93213da5e9703fcc6b210d49c4a4",
-      "incomingViewKey": "e3830ca00a7f1159fcbac9ffb778ca5f581563d154c8cde75a98894dea21d503",
-      "outgoingViewKey": "a686e59f05149c9526261013723a1271b94542e8fd19b2229e73bb0c3ad1fa74",
-      "publicAddress": "f8ae984af8b8b43bf54b83e3fe1ed2fbad56714dfacdc9cfb44065e949d926ae",
-      "createdAt": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:r0WE4zkfbYNzQwuzVncBi1uENXlz36riotCOc63uEnQ="
-        },
-        "sequence": 3
-      }
-    }
-  ],
-  "Accounts getAssetStatus should return the correct status for assets": [
-    {
-      "version": 2,
-      "id": "68499ba1-37b5-41ba-a047-cfcb8bd12c4d",
-      "name": "test",
-      "spendingKey": "371b4f7c95ddc07aa841faf41e9f6145a4a8ce1954cf01c6e97e8a7e32d2f393",
-      "viewKey": "b7ec32b4c5ade0893e4b0411015e2a6755925d6bda99b9788fda228f36628330189a78f16bf8fb3aa014e528f1d8a96249cc02324a0da90ed05fa6f50854a409",
-      "incomingViewKey": "ed56bab3dfc30e796ee6737d65a37e73f513c5fca4b41eeb14533742b1284104",
-      "outgoingViewKey": "12e4588ba1889daf03bc9b767f017aa8a89a42a91ea94b4472edf56174f4c470",
-      "publicAddress": "46c47ca736fdb051aea0bd6e9715d4a8d8c94133149a8cbbc90487701ff72084",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:EjATc6n7BZ0HC2hLUJMtu5Hxwx0sWYfbd76KEfPjY2Q="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:NrGuZ8xJsgGGSLBRto/SXzAd+/+aGGezuVAwJVY6tV0="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803064627,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA5Tx7eDpHKDWA0/7MHTejIDimBfMnarV/YLwdN/x2aba1s7MPGl+EHvbIOg9DVO/ErnwRFSuSiIwtDQmy7LZX3DA5KNPCoOAHkeTJRc+QIb6XZcji7/YCT8gPTqqfdvtrfjwvnU4A/Q6oPHckHQoDwXIDMe6VD2j2PJOayxAjOrkZY7cgOs9tVO9SLztxeKBWYQUBinDNYiM5x+L5fZ8JLy+L2Fnc7pS/QrIG6lYJ4jWvIfNKtp3fYRThRow0wjgFGBBzXUaN5qwm5jZHsYd/14PssQa4ylvap6Z89wxwCIhQCGd/W429cbUGzOejp9GHX4b0E8UZdeB6L4oIRNYDFbNEa3Urq+aOBiXLetTYGUdCGW9sz7hikQhfs1E7uZ5LKmW1rx962eqLGQCkpmSiKPbJlvYg9p9J0OBzGtkYQihY9q1Ornp1RUBV/w5NXnHx45SMOv8XTQSE5uw1+hDi4NxxWjz6UkrYO9e4LnS6davrTf21rBYryuwHqVxs1KdPXITlJOgNU01AXoQ8a/h8zIYc7mmDScA2DcjWEO6OTp2lZLntjWboikiGXQsSxfc4gY5vUA+G2bQHIPxuURag1uawr/x1bhG0UqjNI5+8i6+yO9nDpy5ekElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxl7eWvTwxJywfxapvC1PvgJuqNo7b8Y23+/JM9JJ1m91Kv0jlx95gjNS87ApBBERDMFaSjXyry3kg6yrkQXXBQ=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAW5KhYugQNGVd4x1d6gA5VYveO35fvny9FaboHXYgtyGoYQKpZuLOmEULccQVIKziuOqGNPGcNWcOsJM7aEuET00BO/2Nu7ACYHCTrWOxL5GU2e8Eng1/slZMdkjFe9NoycCC4+LlhCZ6FPGAA+RWFEbhxspWQV67eVoODvCCwtUFK7e1wsySUAstO1/Z4lOetSDpooiAkQt9H81MQwO2EJVSMUI5OAIN+yV3UoEuFwuB+fnSqu4hK6QS8ddgJCRHqOvc04KVF5pD6Kg2cJIx8YbcSNmBB2rsCWTgNQNs8E6bBcv64CK+7mZyAKmRKp5GENccEpL/HnKzRy4B0QpfwnIy3RHn8LAxAVDrJAIhENcorqMmsZL9pDK8YV4H13Fw5yaVmLUEkIDpOPdsmwlR6E/5C8r99eBIqsIFjFTgVAlzlwuPrn+Rd2ZJnIAyoz7SEWOASKSswVioRo9q5+EER8Cdv3PTN/+L1uPeXAoDI1jxo441DKpC8UGet43KhDhjSUshhykIzHJAztqE8KRvRtbo4UXMeJlFU9xkmiUwNqmyQGEBdlhZWnOMAS6ayQ+86sLm+sujKgZW1LaaXOC9D6PFjK5PSR/pQXDE6a/MfeoOM4LupXrYojZAQeGaxNWbyFq6J6oFaYR6nwVRZXRCtZLQ3m6JHZSjn6xOE1cZ0bCfTFiwsR79myhuiScvALE+c136chcfP/aJYlhBCPQia49WYT/TK/QZgBv4++ifdcq+qHpbImKx0uy6etsulD78j4TsxusXPLubP1xVGNWjlZwqbU6ODutSln86/w8BFXe/7o/Xailckj+IBZwyn3ChGNrdoWduj3rQ4cWu5/DemiavgxIuNwkVBRpRIkJIFJtM1kx9WKlt21Tm81DEQf2fwGKkzLStPD7xLo9CgzLQYrYzgM9LMtZ8tn8X7bFPZe3r6KaRpQTQ7FxvqRBevbr26In/gskg3GmfAxy52jziMuDg69DOLlJYRsR8pzb9sFGuoL1ulxXUqNjJQTMUmoy7yQSHcB/3IIRhc3NldAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMKAAAAAAAAAEobGP2Yt1qtGbZhZAfnE9t7UYuSZU5fWpS3jZ8VvnRbUaGYpAnKapkSBRBvFr50leRvMq/ZCeiRqxTsqhZiMA5sGSSxM7aCJCzus37u3sGpU8BwlOBic6uOd/J8ov7roENwoxmZklndlWCC9SQHzKkmSFgVRGBSI16wlFlUNtQD"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "445F5F1781B21591E52324FF8AA3B7BE33B0660655FF3817A7B6897FEFE7E587",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:gE7HT+MUtj2N/FTdyY4tXoZcmhwAT2heRphb2oG3pUM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:Gu33CW0E4jA7Rh1Gp3j3qeGD78QMZJTX9amllKZcDKs="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803065688,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAMHKXFcrRCJa8huJUI+aaJUbp2D5eQX6DKEgpU8wQas+VBNicWs5x3Z9NYgxXavzdCXXtDHLMhW/N1SULw1sz/Kd1LBK3s0GiMU2/ILS/jeWVG/wi3R98vYPUY14h2TgOYA0TDIQTWtrvxOpBRk0hg7ArHKM7yyPfwV6zk0mozYkG134T1T80ZVTi1GR8zdguafMKghXtMUCT4MkRK9iC+wkMqYY1bPbGbFcMHDN1sFeOGnGng5AhT20EkEVeXjVYBkrXDTT/r9839j2tit8VcGXpfVmPkRH8AA3JxVVTHRRj7SfZFJcOYeMCAaZPsIcfYZzAqFMMyxtUqoLrX5eZVxp/RDqkFdtD239g2FulUKc3GV7ZC7x9pSklF05+YY0LCrqWUrR5+dB/ydYfShWk/HtB69AgUPaMQPbVQt1PzE2GyDpdtBR5YhiI05yYY0VjrfHYCLi8gp5xS9favBjVOq4xbMhpaHqkgnvWqna9eFQPTbQCJOIi2xvth2RDg0AARCsCcEshudLHZNb6y+F5i/0XmPoe3S5FVAfVMXZ43Q4UAatiGVZ7cWPCAvfkS+REJrGXf1BTAhnx3gz6V2gkM5Z1A+XZrD8aNu8K7Pyv+oKYVaEM9oQG40lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvExlax8iAxB+8AMkqjNchEJ7w4SgUJ6NSAL6CByvAJq1v/4UtrzMSxG3T/13qxJn2EuiMQS75vT8S0h/vQGoCw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAW5KhYugQNGVd4x1d6gA5VYveO35fvny9FaboHXYgtyGoYQKpZuLOmEULccQVIKziuOqGNPGcNWcOsJM7aEuET00BO/2Nu7ACYHCTrWOxL5GU2e8Eng1/slZMdkjFe9NoycCC4+LlhCZ6FPGAA+RWFEbhxspWQV67eVoODvCCwtUFK7e1wsySUAstO1/Z4lOetSDpooiAkQt9H81MQwO2EJVSMUI5OAIN+yV3UoEuFwuB+fnSqu4hK6QS8ddgJCRHqOvc04KVF5pD6Kg2cJIx8YbcSNmBB2rsCWTgNQNs8E6bBcv64CK+7mZyAKmRKp5GENccEpL/HnKzRy4B0QpfwnIy3RHn8LAxAVDrJAIhENcorqMmsZL9pDK8YV4H13Fw5yaVmLUEkIDpOPdsmwlR6E/5C8r99eBIqsIFjFTgVAlzlwuPrn+Rd2ZJnIAyoz7SEWOASKSswVioRo9q5+EER8Cdv3PTN/+L1uPeXAoDI1jxo441DKpC8UGet43KhDhjSUshhykIzHJAztqE8KRvRtbo4UXMeJlFU9xkmiUwNqmyQGEBdlhZWnOMAS6ayQ+86sLm+sujKgZW1LaaXOC9D6PFjK5PSR/pQXDE6a/MfeoOM4LupXrYojZAQeGaxNWbyFq6J6oFaYR6nwVRZXRCtZLQ3m6JHZSjn6xOE1cZ0bCfTFiwsR79myhuiScvALE+c136chcfP/aJYlhBCPQia49WYT/TK/QZgBv4++ifdcq+qHpbImKx0uy6etsulD78j4TsxusXPLubP1xVGNWjlZwqbU6ODutSln86/w8BFXe/7o/Xailckj+IBZwyn3ChGNrdoWduj3rQ4cWu5/DemiavgxIuNwkVBRpRIkJIFJtM1kx9WKlt21Tm81DEQf2fwGKkzLStPD7xLo9CgzLQYrYzgM9LMtZ8tn8X7bFPZe3r6KaRpQTQ7FxvqRBevbr26In/gskg3GmfAxy52jziMuDg69DOLlJYRsR8pzb9sFGuoL1ulxXUqNjJQTMUmoy7yQSHcB/3IIRhc3NldAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMKAAAAAAAAAEobGP2Yt1qtGbZhZAfnE9t7UYuSZU5fWpS3jZ8VvnRbUaGYpAnKapkSBRBvFr50leRvMq/ZCeiRqxTsqhZiMA5sGSSxM7aCJCzus37u3sGpU8BwlOBic6uOd/J8ov7roENwoxmZklndlWCC9SQHzKkmSFgVRGBSI16wlFlUNtQD"
-        }
-      ]
-    }
-  ],
-  "Accounts disconnectBlock should update transactions in the walletDb with blockHash and sequence null": [
-    {
-      "version": 2,
-      "id": "65bb0cd7-bad7-4d21-9bee-6e92ba6e3a3e",
-      "name": "a",
-      "spendingKey": "7a6ed7bdade853277597daae5829f1242a115f407b9a288ef4155737516feb9b",
-      "viewKey": "2d187eb5329f3592503e98ac0dcccc773eb08faeaae4440ccf073cbcbef05e6ae5483f800995139674da037520a52e6c18935e587a2c051c66b256bc078d8f84",
-      "incomingViewKey": "c9fa32516347345ee64124b90f7801a40094ab07e5a626484b05e2c6e8544404",
-      "outgoingViewKey": "68918408b6f6eb31664976085542457d0e2be824bce74dfa02fa16e7770e1377",
-      "publicAddress": "96d9ed8181ccecb7793ff5e5f4e17e800b64c01390c8f2de224d66914ec38f3b",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "8a99d193-5932-41c1-9d41-00b3192b0067",
-      "name": "b",
-      "spendingKey": "ebb61c9ee94666fadf312d4022077c5545115b61bc0c2e352af1a529c9d743c6",
-      "viewKey": "12c31501b0f461cd36adf617f9b525db7a4bec4476ed69e1c988d90d077a0286fc903d7246533cb0644cd575b91d25aae27c00c97196f77620fa443f97b71b07",
-      "incomingViewKey": "76b54ad214c65ebb7437091624d6b3779f89f4a24a2be6a0ab9f288e99dc4d06",
-      "outgoingViewKey": "ce9f83d4b7ce6e187b560ea564795c7fba28c8b621d2ca9e2c36efb6c86fed80",
-      "publicAddress": "7bfa63307679ef896dea4a83e8602825167dce62e332e6384ef484ad26c8f9b6",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:19ootm9RcL7P55X/Q6qeoeGgfhX1MKFL1sMW7Go4RFI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:goUR85gghxVn4iKF02XMsTUNTG9s2ZusjiQz+Y9llsw="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803066979,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcUpuqHPQB1C+avt9ZPyX8aUNmy4cid87n3cu3L27UsWW8PJ8ILg8WQzPDICVaoOIdti85fxpFnBFE8B09dxPr/eRr0KaTEXRclD4M47AvBWwMKqhOSLt2EFy9dKPGhzgwrXRG+ICNt4tWZDcrRvrRNXwK08MLusqVcALpKgNmB8Q3MB0u5eDm/EGR8MtLxL0kzTmxMiz3v6TnGwCF9bDMHTaa97c6ffYJImLC838RtGJU83WQevrXYSNKXGFi2TBkCB3S2rjjBzDZhcCstZIFLIXnWiXq83gv9s5ATDvBPudCyPXU7S6CMiHBBdG1J+pfxchWjuetxo2g5jmBkKirIKD4agSZOPo3/cq+bhEQHudFU85nY0418QMb8V/2oVBWH6erRqY0DgX5s1nFZe74HesOH8nWutFpFkfTIWy6F52soF0civ/KWclpHdxqiq4T70tNG75QSOPTskQ5DE2jwswe0dXHvHXlUu/yjFmoQQKOB6YVH+4uy++AovzzD4L3O4i6GhFQszYfMYDoS/3RuTzb6u6xJ1kRgr+eXVhzPDQ3dx9MqFl0xtJUYTDxr3ib7eK9abVCLgJ9H8y5/Be2iaVKoN4feHW+Myp7iMBzWLs/nyCSWEu5Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwt+8DBNnzf8RVuWJcMigU4R6pe2AObdR6GkQUQ0cuwNEkGCjPZrglfULZ5PV3zBCIrivqXMlSnyehykAic/vjCQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "65EF23B9BEB8591E748FBAC3A00AF179AFD0DA4CAEFEB6C8C9A111600477A8CB",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:N3w0iS5969KRqEzl6zq7EdUM4nmmk0fGVctSmPfACGA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:HxpM/pj0twXbkwl5Jv+com11wHjWjLDdizGxaAXssdA="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803067380,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAATqMrSnoIS7X0itkXB2pRiaewR0elcaRpkDZouQoqEtyXTekc/ga6zaOpNggrnR5MPGY7oHcp6lc1gacF1BCfhP8/O3marj34cjaEVugtaBaKjSTvQ7iCeK/eg2Ls/nRM/IRtMyhpG0Dqoa7pLY+qETCiqKqC5jGp/lEgvVBwkecJgUIdOBQ1hKiAzpHzi+C/6NSgiM+kqEDZ95EmbfwbZ0GJGrzZ9z8DMsoCG6lS9h+OHD/2uO/UzZsCg8LrzQNCd2FoUjyHHGsIKwLnMAm1pjj5bmOMNI9kADgZfqsZypumYlmlLDZEUNp81PVp9SUlUGLNxEP7uJCOXG/84ZiVB+IHNNfojLgdIOz3JzFSO+xQ7ObkGN8jDdr/kl1e7pBRfkpvapDD27tkE69/qOuHo7cRK+rRrVRFldmgImGcqtP83vtvg1kKdb7VIYvIDtcq3k7NN+a3+QZ0dLQ8uqosdV5qbSQ/w+g8MLcqKPMVoXoXOdtfHQNMAM6jCaV+eDkyzm5inbMLDmBd/fNy6qK53DPFFpZ/Liq1Y5LGjk2uwUKEJXBKXzH/8rIGDclw0tio0XofhFMyq4F+9wtTRmcTkzHy/WcGez7+yKYV7hJHystSKo4T5MjGAElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcrmImiWwUJJfgXOcZSnYZDYKsQr7m0LsMocu0ttK5b55b/P8Pkxz1MHAvcAVMu0zb5pUjt2iiyHcFqSxgHCnDA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "7C1CCD5B8F9DE069CF5E3F1D182273F0377C11AD4503F990B07E39759F8A3DA2",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:o9ntB3M8ZDD0MMihmukb2n4haN1f4qrKEjlttJIyY28="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:1RW+D69tXUOfnB0cqpRpLTz3RQTDyzxpXX89nIwTZaY="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803069285,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAACsGz3UClYZpuhSKA3cM2trweRwolBf0+nK6hL/S+EcqJe++uEkT1chwGNJdb+I/vsovWP6YjNCRnBsd01luDFhBL3ESjJs6dXZZo+nJAZFuUGAqTrhyyBLI/yAaaB/FfWgBYOaStqPwMysZQp8ywg8yTJQPjolBsLsRyH0DBxnMB1jTNenP62oxS6frW/mcnotzOWqFxUht6zvGrB1mxOC+G8FRG24XqbFY85DCXqIyOj/SNDX26HYfApyPMN9sg1pIjNHok3aWov3XmcofVGlYxTddRrnvCBlO3Hww2t+o7IkEKUAIo6//FqurNRmZSY+om4HgD6s0T82eK8FKSIP9q6Pq+zzm/h/txoFTS3NPjpaLSQsXJj/nRwiebRcEK1jlyd2UFv2Mk5ZPE0qmsc/+AIk0fFUBi9BLqFUM0nAuyo/U7+52p/zRwCLeTmTBkBUnRtlTP8oOg0uMfmlnDNf5YGr4JXQ+dQi+FInYZzCoUw08NSYlGlo1waHYu6WCUsEiUbed78ad1ZkvDgTbR9Po3eUoSsvQFW1wjefS+VtTler5oESgyP7lqFqoTvjKlv/9ujrdUOD4yv1p20EsPghCaJbvD0Lbf8I6RIUwstIijX5tKkEW/lElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwW9rhXYuvUjwchg63xTAbjQE5RlP3YfxAnlJsKj7U6fVzG8gyq2qTu/AqzvobMaA0PS6TFq5yMu6Dd0Bxf8dCA=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAANvIWyVBWTwNo98Bfb6/exAaKl0DW8jaTLra1xt7PCsur7vNOlnEztY9ol/PJFM/aC4R74RwSbZc74YhncY6U+Q51U/PSNuv4JFgbzanwSfKZTFuG4abZ/KMdaC0W3fmvzUV19FiQCNFNYlJcQ8gcRfIJsa/4kq7Z1Xsl4Nc9RmELi/GzWyXAncRiRl9Nv1n+eY2eyzGh2rqFT/Q523eO15F/ts1c4kks0d4g7LJvBY6Dcw7eAsuEH68kgqh4cFtsmWMb1rhz9UxdbTssUu1l3OH+tbaOzzFGEJvFuHfH3wL85q3pxwdginiiS0GaCwukI3PhibcDnosFtSizTI4oRjd8NIkufevSkahM5es6uxHVDOJ5ppNHxlXLUpj3wAhgBQAAAHPHdLWB2OlF+nUzDH5RKkPzjxRNnZgkyq795fK9ISG/95HGMTS1rfvdNqx4BvY5jzcX6kVJxFREV9hVvMMJn0m9xXkvo8Mqp9ok659e69Ja4cATxGzHbG84bfTJArDXBbFd1mJ3b+5silLZPTtoT3l4HXpABUZIIJVU1sHaxjpm6iphoxavCKwSpAx6vI9ddouhj4zZoIRNA/r0sW3ENsMnq08Sgc5H6vKFu+MLfCOI7N0b2t+3SjfljJOzrF7jvgLaU42/uF8V/wQCTeXC5jE7cLwVuAL59TtIMRRuLalOVF4egJhV62gqnI4yRAZjzalKz+Wyn1J5VinlwEGj0dmYaFSasPOacWWT+t6bsHTcR47QsR4GXneZWQFZOzRedkx+Iu86oGeT+qM2rqjMZyLT/rwuQgWE3QD1XiCshy3HJFnw6o6u0QnWHTiJ7VBziQj2WIjqHAk+cRpZeAoSZwbpqFrTl2m9/jlMz6dyXAFldXVbLGXK9MgeKBYRQ9Hm646c4Fj6zYHDfxpKdWdQfFhpByDEMMm5Vwy3bQMDoa2hP3D7uib/O6wTCks2Rph+/9WCP+4i0vhEm0mrEGG5M31jnYeItZ/rRmVkhfWcURfcRlRr9k5JeUnucVrKmXYKw5Pwc3HjW/HPi5rh7uBJ9lYg7iMFYyi0s60fLo/jr6JkpVOiWyI5dJu6u9On7n2QMgMBnagGiGhQR9Gekt+n0CDVnLUJBZSUfWIDrR90NTC9TK0mrKd9q2JUYTCJ/w3qTAkuY+CEX73nr3PboO7eLEPRwNNYa4QSMbKtl3Fv+FgH+XiiBZxEtP2nL19+8+PKVpSBz7eg2YeqiS30Xz67ddbF0S5+GAHTP9xPoNmhfe8diEmVX4X3z2igdezkumY9JyU9AGfYMZmTlnEHZGNaC668iKHNG4qfncw/9iSaYBApG2hPnDL1XhUJBJ9loJvqsztrKA+dD9pLhe4ymYV+1W11aGGBkKyGzsZAlpSq75VlZn8X67GZCDysoypjJh7shElegk7gSxArOzELOBDJO/FbdShbfWoD2hwsZxdDSJ9m4510MLU0/1QavrDxVusbLzn4lYcK1fj8QElfihCFJkD38tzzO7HWPtACr2rBblrre1+E+qpzsVFRo+aD+ZrnnFlHtxDbRqFNbNQTgPPobPVJN2/VbrhLh/Cy1BLTGlXyHwaBjZdNiqCvw83N2SL0zjt+XLyC+Chduv/ByvaPD+/19zHWGbbLXIqFp8Rs50/oK2XrcHfba2q0yIfU4rDcRolXCwQOF93zESyTcw+yjpjPxF8MV2xh4le+TirlqGsCV7GfsEzY9IEGlwD6gBZ2G3gDy2XDrxH/9I+XvVQuicV0fHZ82MPtwDUSet/8SCAFPnlWuSs3w0bV7P7D3KfC4A55rc3yL4J6zOhvgF9DX0sKaqEHKTItEj/kKVBJrxfdRoyu3do6BDsN2ONFs1BAsua8++4Ci24XRmVKdWFA4XNIc6PF6H4uWVhPPeoJst0ORSWUV4PQjVLzLAJZgKfSozgJML8GzCmLEIzxK8gIFwq3V5lbI3vvQqhwsFdWQoAKd5XQCxUCJCYMYN97ynjFDA=="
-        }
-      ]
-    }
-  ],
-  "Accounts disconnectBlock should update the account head hash to the previous block": [
-    {
-      "version": 2,
-      "id": "7edb873e-4436-491f-8319-b8a86ec9fdaa",
-      "name": "a",
-      "spendingKey": "95f4ec1195b51e1da9965fc452aeda160d1368350ea0a04353ad5dc9261cb8e5",
-      "viewKey": "b880ad77ec0b3295b2e7bf68c8aca6e30e59967ae9fb7c194cfbb6e8a1e5d9d9b49da140f96ab4e19c44562cf8ca14f62ce86bdb9d1e1a914f9fc749a777d549",
-      "incomingViewKey": "04742cdec2b78d48cc9a9538acc2fdd210ffc78e6492da7e1e2bc27d87154a00",
-      "outgoingViewKey": "ed6f712e38155ab3a3363523ecf627d449dd0d0a827b241dba256fa0b72bc62e",
-      "publicAddress": "426c86544c90c39b7b0b220e4eaf33f0b33e78b5dc45904bb4b033f634ff05e3",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "200af592-e411-4bc3-8dcd-65ecbe711494",
-      "name": "b",
-      "spendingKey": "37a97f240d38667cbcf269d5d76a165029247514546589d1e944cc824b4818ec",
-      "viewKey": "a1d6dee6808d070a7d57def118779ec9c92887b15b87cd9c759e8ad69ec7cced9070b06fced1125abab104adf25bdb4f9c5312cd67dace37ce657df32cdfb024",
-      "incomingViewKey": "3d01607779a79f166629047798d5a9e13d766881401d141f0f376ea0a3b27c05",
-      "outgoingViewKey": "f96b8eac7d5ad557047eedcef0e94f9abc2930cf86bfee44ba03a160e133e744",
-      "publicAddress": "f0b68d15618c69dde0c7f982297afb32f806a80c2e01da1667f7e36197194180",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:XWJZx56WFiG3lXQ/V202IiZIT2R+yl3YPlz7/xHFJDk="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:SjLKdxGatupGX2KPWXirb5em8lq3+G/VUcU0hirX5R8="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803070692,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAANgZLQU2Q/zkt19RUjum4jw4ik9Fhytly+c5pyz8lzZaywOkjvuZCgWSlB9ohNBqzn5yhth5umqF6npue/dN5K0JZmwqlPDYRYVuMm1M5dDiPWPoePxPgIPUVpVlJiRGma3sq9clW6heolniWtb8Jdoql22gF748YNBJIHCnMsG0KqmtRqm92aCbv7XSQmUrsw9tH1+9LLdv2PS2FOR5LDlby4+KPGmMgKY/gx34ZZ1akKmwH/FapkWROBkJxknjNtOOYMQyMhqTZ2osXMdTzpVO4p4thwTkCDYuUtGu5hL+OB52hbhk88k2M6bb2atuVPyfir4KokWRGWywiDTx26YPJob+/aQeMgodkM0vsTWhk7pV8tGPZcMP2uI15SQ4B4Cm63thj9JzzU6lL7FUshZ0lXidQbdYgyN5qkmdD+J5yS7quNZcLSjHK3s7ZcI3jA1ZxdPwrcTwObPo+I3c95UxrMATXrlxOy+fnz3pzTDvu4BCsW6wLKzUo2YAwMUdOV+GL9X99AAGKqgQb822IPCkHuoM9xH3/+64E17L64XlMkBUjmmhlP5xEHk9iJyJw/d/hXLjCXabPdRw/yQtWo8TO2gLkiye0Om7NPLOcKwv6msLA/vXYgklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGQF2gcraF3XguyxgZItvIR4hB85eE+NaHNs4L3auRB460AZ9K4F3Lx00WaRm0LYO21TWierrIHTvdOyLZFEEDQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "456FEC8BBA17D470D785CD75D6131FB527DD36594E9E5975FCD771CF2067DD1B",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:SCb/bbvBKPOWXyVtO6hihNLzl+VvT2/kIGhVHyee+Rg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:jzIPWwH6h9AxEfsvLDXM+/vEbxNvFoZifrcmcBqjXb4="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803071124,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAS19zqrR+xqEJohHWNm4M5NSRqvxAh3N2ZdY3hvhSUQ2G1eotBmX3KVe5JfeM6Sy4tJ1sVfi4k6OPoMOomflcVqFO6jA+MM/yL3vHtinWmWGPj/XVUEq0ZNA25knJdC+EbKjurB04y7XZCI4djD0bU39TzddJJf/xUROIkykL3z8KGtU8ogXS/JL8vOYvaWDPzZ9NnWTCevYIem67cnhsYpTLpngheDNHZ3u1taHNZsupe6qzhSA75X3eycZlU0YhR+W2Y4rVqYUJHGjYDJmx2IVKfXdp6YlJNy8gQ5XiPSRujukTEzoIEjG00HTQrYXQdi0ERePkbQqhAetabMSRVg9Eq1lC9Eahuz5qq7EYKQxVaxnwN0c0LHm0zkQMmEBHbFtUf4gbzKNiVOG4jStHwTeQl/6oB4oShGPZIC2h5xgnut94bAEkIH9uvscaxdVlxF/Hbb53ncMvzulgYwWfdKjITgQbElIdaRhtSb4QhGUBu41VQ9Re9+JuGr5EXn5KW92vENfha+WwT0TYi41QwkdPo6xu/MR0uI6eImIL32lWqmjlFNIKnfRd98met4BtMkdOSo5I/l/iW1U2ghHCmn1Fb+k7G7mIsKtXjnf+Vv9CQoqWwcJLY0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGJkNCEZcpnmV3ZcD4n6Oo7p61FDHGJHtzK5DMfv62ICTLcKf+JppEA2SgsJXgb9RWUDncTJkmFtFQ1GhV6hQBQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "33E82BCDF220039309847CB72C039CEE9532961C1DD8B159672CF4F8C2E43239",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:0I+OqFE+H6YKXHS/TJuiVlojmcGdtgQ0INxMI7cFiHE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:3ZIvTH8GfhjePkxk57odHljsHLqMCO5Y8pSwk8FoXH8="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803073045,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAUbByqxqIzCRMLS964pqw+Tue31P2mz1+7yXeorOV96mkJX3TXzu6kEjL9B6ih+QXDX7qqlArVUuU0GAgXTDE/2pdVjSRgzt15OX39LvTUJqrWRQGWtjmbJ8jsEkpONrn7FB1fSEj6RDI1F/L4UvbTUkMl9nwNfbMXcN4pJzPBgkKSKOWw16hYJFDFtWIPOFhL34ao5L65EkktA9560Kt2MeFx2bz1oOGx3KjZhmo1NGRXO3t/YVXEANTimxpBpwS4sV3UM0HU+8+dOmlO58m366tHNLoY4unRloKKFVOCT0QSocW/7//RCbKT0nrb1365IxY8rOSpzn0vVoOQRL7WsSWAZyHG5kjVNm60jPrGGW+2B4HjxoOSpe1QR0y1xlAhm1JRCsxCV/tumsO0QOUYG7cZid0mbUtLjkL1EIBEzeRm3/MImbrs41h3vTLIvTKJur2XfU5l0KMGgLpelCYu/pHa0uJ18V3q1SKbE4l628cgUuiJbS03G6HUWa8QFYrjN5yePhsHv5xMsOlgs60iMr7WkVBU0lqmCRV5i0mRWJLp5f4FIetLbB28DD87X9ytVv9MgA/WknXuNOTykbvDZpuQB63mt10GzlxzhHydgvl8O0n6VHLM0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyMDhOmySGlbsU7ttR+IxIpocuGe10BXJDUSpE7Onr4kZ1sEjQQdPnMyGAVX1lcTzTaVRpkcbugobwXmx6m3bCw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAyvM35b4yBgVpvKWIE/fdVWLjuVpLcPkzfUd5+uxpUumpiLHWLhwr6USqd6S3FWBh83WIbfQg3bGL9NydCTQYJ84O5pNvCd+E650rat5AWAqJdLOUMV8T3bpdfvHf5k6FDx+MeTYEpOMqyJRfTNv4RHgd/BC5D8Sj/DEnFYXVQbIShTpCbIRmBU+Wlb4hmRyEZectm5X1wmGRWEsP/kXPNGW5eaEXJddHZ9C0pzYOPN2l20ciYzBv9Ly58LkWWpuS5gzSzo0G7nfONXunmvj749lqMH0A1cvTdVNfWRCjNfSdyKJ8O5FCsihdBXaWVePsEg6sVpFP38ImqkFQ87WnDUgm/227wSjzll8lbTuoYoTS85flb09v5CBoVR8nnvkYBQAAANhcUnoaFW1XfF6AQRW7bUPAJDkaXQ2pVzNCMCusEg36yBNqRZcDAYQI2XRQ72jaDiDw/BNPAt6bfQExhzmD2LYETTCMJQ0/3lTpnaLyFiaTJExh+9ca7EGhJzmdWOkGBZD9eU+RQIhJo/AHWFbzLDTmVMoE492pGmPuj62U3bV/85AlAVJVl7HR8Wq4gXsyKaoLS9E+INYrMLs3WpKcUW3dBbzcF5XXoIsujTlvHvCh5BIXOGFLVCffH4dHs7zs1RIj0EH4abBc4bTCkOJ7soT/9jwRqbyOjfcQdMnbyFkuMZ1SC2/fXOdIgXIZgTPtkqriV6ANyZH8F/v3oivWbOmd201i92MnJ4y3e4nFs7zhNNwV0Bg2alsDzFcXcxHeiYn2SkJE/3QoFnf07YGJ0t/JmrsVOVb+6S/U8VvZpExdwliI7xzKIsyqxGYEnKr9oWDiWENaX7hxgWeDL31b0F8BCtJ1eY2j7t++v4C4Ls/u4VL28kk1FccpO5XtLWC/vzw+z6IpkSNDWwGFVLYK+2R1emG3jOFk8cY1jD17Tnu9AT1ehFq6aJodN+oRJVeHJ4G76L88kBkLQYZ+zLSR7UCmqzWijQVC27IMiHYOJB4ST/MHL/SKG4lmezqu/naVO9aAqJhBaqvZQ6C6o0CuTBLLRk9pus3cknKP9xyyT0aRy9ya0shwQHqcJJRoWezaEE3iElt3n25pydSOEW0z1C63kPtdXPaUKBQmNR8rD4jNWv3csvaJgmhW//b0O6gSuJ3MSIeYvWpT2Xu3ckuILeKxvO4rc//MfxyPG7N+ZCZGY3DF8Yh5zZqTbL4gdGvHdlnZjugq3mcbC9nnNc9By7gV1rzSZfvfc9mg/QwMlBnovvJA3pZ7DIaXBFOgrANqM2Y6zYKevp6axn8TwAKN/iWsAPtCgr8/JxX2vPmmzKDcycl73niQJ9YD/e5rO0yvd2WpN+OJtKaG1FdJ8S0PEj49+QnZFxkamjii3cxxgMHgNFo8Ovp75FW3zMkQLEcHXIevvxPBzgrD2DzELn7BG/WwT7ZZkG9KQ4JPB2N3kl2edpfMsYRCPKLOE5bCfqlEdZg/HyB8EMGT5uv7QjHbpZfbUc/XLywwhIwEpm4De9Yql2zFtsohejfI7v0AV6Wlbz11bkChm5RCELGEbPc2xv9UYR6jXZ+lsHjn4GWyBAw7quP0cksALDWakgcRkZ7ECgO95IyGVmi4uBbTyie0WDffawQbHAjpZXSKvgY/fABRHrtau5PoVeJZQAn0wut7YGd0uvI3FY0epGPHnclk6jWvthYpr06BHgAnB1Ohgfnlot3AuxWniNsjgAZttxJiBCpwzE7kL9rhIkDdwaVUq0TGrx0U1VcyyAfPZdI0Ti1u30ai8K/ERYI/cjT9fKLmU9iAQfoNRcddfAdwWaNJbsSc1RbSmAxRSZJVTp3rd/Ji+8ZVry3+KqzSM8Nl/DrETEYWXxdTDmKg0K5nDT44IxH+xtw4tbiddkKjpR6+uQKsBWRM+oPn16+h/MreFHODKg+/UFUhWAmdQQ+AMeuWwtHgY8bM1bOaNMyxyzqxL19eVZiaev0oL5XYMiR444yjCA=="
-        }
-      ]
-    }
-  ],
-  "Accounts disconnectBlock should update the account unconfirmed balance": [
-    {
-      "version": 2,
-      "id": "7806e135-b420-4b87-8413-34d281350db2",
-      "name": "a",
-      "spendingKey": "49056655f9f4d7be2e2cb4d72d0e69c97f99dd524db30f54fc16151ca991c779",
-      "viewKey": "03c5935499f4c32bcdc9905299efed8ce6bcfd88fa1155a3214d4b49cc71a919f923082bc404bccc89d3fe577f9c3cf2375eecb0374df9e146517d9fba3e498f",
-      "incomingViewKey": "4b72d21db4be521bf29418e32f56c4273c52b54125be9d2bc13ef7716a79b201",
-      "outgoingViewKey": "1b9103272f777e38175d1818408aa57899b0833ac17d283e4841e4dd1a6350e8",
-      "publicAddress": "613f94fb0fecf789386a49bd312b0986ac6320ac31fce3aa5baeacf0597208d6",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "6108c016-d994-4dca-8a46-7602278837f3",
-      "name": "b",
-      "spendingKey": "0ed9167320c20eb73918a6b2b1b1b5f5d75a22442f66a01f88f4860935b2917e",
-      "viewKey": "162e5549f07eab058ebf42382203a1020edc3683211cf3589d072222abac1d307351206587245c7a842a66c9d0b3bbfa986c42cefb926dba8e37a0e221e6ba25",
-      "incomingViewKey": "cea6a00e93209100734b8060cef3f44648d90e890511499d185e412819371506",
-      "outgoingViewKey": "a9c38028fae5da95ceb59b8604b4b7851d7106a8b8c7c3e3024a082e3b9c8e12",
-      "publicAddress": "19b2ae7dc0b5b2827bf4cd7ddbb3dfc8cd6085b23e7ffc4ea8f7004f5002f955",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:IhgPdLO9d4vLAndtfk93/krquncKKqzEfBL2QnaNFgI="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:0houe9mHsshlxfVw+NmXye9gg9JXfUJpkhQdykuyHx8="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803074368,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA6NU4qM266B+RoVoofOmDmHzZfM8SPK3CqH2UHcyUi2iM+3ClH/XhKA6j+DB5FPQU39ZJsNATxMsvFC6Z+CVzxuqEvMP7tXLg6kf/DehXGL+qkVcd4AwWO+QXCKKNV9OcrXckGEj/MC9h18x4Ju90PxGhSs7gRbc1EZjVkNgK4CkQz/+ERtQIrr4fWjNjYaUtlzRww3EYv7aS3/ezKs7jAyGGlrntd7eBBHi1l53YQLaSOUCG1rT+xZNJ0OVx/QZWXjCUwjvVLaIiW3m9sVjJgjDyhS69gRY4GklV0BfCbpqYYGQVCr7fsxDsbhleutncIf/NNuQeF8jhRypBFQ7NQDEB8ag4QEaf+ri97zGPsMys4xmi1LumKqn/MTyeLSYXrt6xrLB/bNG9yQZmR+UfKHd3qx+EeSdt1Gl6ebAscsDtzfMb8XARHss/G+nwym+B9TBiP9U1K8qRv0Ifq2S073cX8oaVWmAbG9+zyJaSwN8ps0BvruabeyIUDuc7BfJh8TecqaLbNH+BYQayWzmHCsQjzHH8I1nhPfFKxwLqNCFfdvpqh+v3SYvUH+QwctPXysFXUB53X+oZuochOgs49i88bK1mOxC8jZtJX/dISFPuykdd/WfvIElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwo9UjDefdj30vfUzSv26vYeYFuaFwrS1aizvsUxjYylRoeJMNtd3AqXjHARpHn6Zvq6ulQgWBaTciBIMz1P/gDA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "4F2288B4F49D06DCFC77C3C0FA2E2D7E300AE9AE46E1187C4E57E0D941CBE403",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:GRzCzWOYgbcHj0pjQv8P90aOjoH5oBA2zPoR46oC8k0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:FQc/e8qYdq9ks6JkNnIDlVsJKrUDPuUcdyfi1KCEC3w="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803076303,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAY6YvUaHAhH8IHLQgIv2rfZxGMmSsXLRFlRqdzBiC87+HVnoJmtKRflc6GpUKe322liQSUIwltWJhmYblhY6ILZAGyeiImDaoClasFsS9ERGXIl5sAtto9mYv9aSvwa/Th5N8yF4hW2GiJIoNEp+Z6cVs8eT046uZsVIyRt2CCXUWhTCNntg2OdX8yfM0cINXNBT+Yiq7tqlZhy4bt+Kmnv6aqCapfbO1Voj/1fWe5q+mGAD96pfGK8MVvzCD1qf7+titWXVAJCj3BsDhreGbicb0ugRRi+T/g3PTLRQBLUITeY4vAB3g6bGvWdSIHJ0yujXHOPc4cKIaQgCSAacgi005NowVUXMb5dqmrctXy2XRE0XWaB/Xc0PtFLienIllald04ZYbE70qcTCzru2u9F3cUdbpKtYV1ZNejmSOBefQK69PLrQvZIXkZBB0FG9A85vj+8oXBpfTo+2TF7QTyjymXJl+Cy5xkbj2qRx2VkeuXuyw3/U2MpdV+j0Aaom4ssgpK6z/MbpxU3L4/nEzi26iRsGoOU3p5RTak0VEYrvhiBLn3MqExowk4RsAgSMKWGRoJjAhFOxRuGGiFQ8yXU4mp3EBmumtN/9LGrCfUBR8Ag9fKrh3HElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxkzBqVzT9Q2qoFu5PPrTJ7fmTJT+rgQT+GJq107yrxr3tIOBCXXikHibNPs3HFE3cO8hU7F6NoVyz0OZv7LkCw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAUiUhXVNd4ujDGvA8AAMknr77WXeiKFt8zqIN59JTMfGDxk+WTpztnbfSpiYnAGeRZVN0MGhBBulKhPKPmlEPX8yoqPCOA7FLBVJ51+COa8OLl7XXUC0CsH5LPj+kcYHDq8xLKo861t5rogbaJro7pCHL7v8aHGyKmUEIPaWs8msAi/4bChlEoms5aoWKCWIG6SWiTesmSEY60jhz5gplDBFCdppXJDj3WN5OvmRlooGkfNDyK6epDSq13gID8PGv3RviXDgp1YNjA3GivxjrUek6BLUyj+n5TpOXAaais74qfnBsb3JMKFwPotnf73Lvay7RJw0aO2SS1+O3hWZUmSIYD3SzvXeLywJ3bX5Pd/5K6rp3CiqsxHwS9kJ2jRYCBAAAAP+GFBq5m2dTHfr8xm+pAqAF943p94W2NP9tWSvtvaFF+KdHHWxP/RoIzWCImN5NsuF7HNRcFeeA3xfjjQQizgLygackwMI2+UpJScTsSIylJpPOVGI36X92m4IH/GGsDa+mm51SxowaDMnHugX6p47/Oaldbvp54t+q4I0QV8WCFkJSgJtT3/761GfPZQoqbasYTc6cjCjROkXJc3k0W8e0I1ZzCcYqLLMtmozzzLbUJhiVGvpzVxrEk5FBlCCERAV71Z+4ODczvjAyhPrZOWed14pNishKYF1Z6WBKJipSnwGFOI8aHMMVPOxn5RMaDqoBnWpapLuUocvl9Ct6AsMtvnaLSNbXoq2urg75Y6YfhCG/0EeJfXi+UKlt7b/HIHPk0k+0Lko7gEpQrYbrbfrE9gIyg3FqcK5d1LZa8o9SKNNUPLm1mut5k7Bc/Dc4LRHR1/w+FYu3o71z5360yEqT83x35Ww6JrGnryE/FPcI8/W6xwUhTGeCOBRE2SzsEPp9gRIKnR/G/BIydPgxmvCeJte5n333JF4mAwULTJKUJ3IJbNLlsinwbI+CUOeXEjmVMFcKWA5AUoc/V3jM06uc2xWU16H8SDGdwgrBMZZ2B445hDYOlbjWCIM/deve9MsCyERGR4x2/0lyrtgtSZCjdy09v9RKxq6LuVfd4XTkZXXoPHwIsq9VfTWUOEVFg3TvPgeyJUsECD9ED61yq4woBZZdmkB0bZDWpRXblN1BIFSbVlLTMqCIa0HY9j0AqKpCFkDlFFY5s0E5DYLFR532lMB82ZyLxr+rVkdGNNFq1d4lkX35jcyQekmbNRlSMzY5WT3cWva8Su1X3LobijNLbodD2ioHSIgFD8yCJFBTMm7jB4H0u4GXryFXc3EBgt3h9KXPC5WzBWV8xdwEoWBEagb6Imw4Qv1+EFf/YLEED9+iQMudyRwHXCfMLhGueu9c590eGY0l2P41a2HbsALM7bmjydb7YWJXmWEutreWs7Qn9GheUvyplFWB4WTh5eZPSrN/Kh3akJG7nMv4BCP0W+odCIzL6VbMG7vsRu2tEmEWmXKG7TJ/X4cXeFS7+d0nEjxqBak+6j2fLVYQNzeEnOmQyWE/T7WmMT0mldzOnMvveyWehMlt3bU17p6FOw0QLF0At4QNWm5/+UteGIjwZi8rsBKDsEXPztL82J5NR17z5IXXdsHGt52TFGb5uekm/OwbEbBbUlXkjDww1nS0UO+tB/WYmtXNI5lRsBnd49HnIsqY7PDLQzWKlLla+rCVtMJPyzVvsscEBCHwK7ysGaFQ2f+VEY+Ub5m+/0LbHYGHVsQAyY5DAt5jfZRSCK0mqRNFHaNtWF1Pq/6j1LDhbkTlpVB2QF4tEhf6iuFFjB9iZwMMQZvFd2Ho4muAaN0ddOF3DusYaT4cSsvKpIJlDq65wZrQkx9g43qDEtkSSRJh9bguah3CP902+qWGKAS+pYY2X7+9m5E8p/8wiUT14LY84l1gZmt5iyMRYjKW1t4/Kge9wcGs4QRPFCndfVrlUJv/k8vcEO0pk/olBEOH0J082Fh6SrUm6HaQ3U1pzSPD+PxAdhNCWu2PEYTpBA=="
-        }
-      ]
-    }
-  ],
-  "Accounts disconnectBlock should not disconnect blocks before the account head": [
-    {
-      "version": 2,
-      "id": "64959926-4bfb-413e-b620-976333765643",
-      "name": "a",
-      "spendingKey": "f3a1e52c6900fff906654f87518c5c9e99983dbbd88e5ad059ef5782f8e206be",
-      "viewKey": "a2fe32a01f2a79b86a85dfbdb2abc97085d12d0fd8b0d114742b6bee1481989a6c7af21d766329f740b61808898023a15de11379f7b773ef7dc19b691996a657",
-      "incomingViewKey": "85ac90ce049e29e35ab2a72bef5cdc13230d6cf10917f73dcfde90f924e93605",
-      "outgoingViewKey": "64fbdf14307334f03bbe1a8957e0c2541e79f426125dc905afe2f8cba06d9eb4",
-      "publicAddress": "c945a0edff4532744862a38e01f288ec5161abfc59117d694f3951b0f53ff25c",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:TC1//6Fwg/98osFOYEYRPb7KI6QVd0mWuGutr1mE6AE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:KWjvXxV5RqmcVaNKgrn8T2ktd1oJ+p4IByvXIOYdnjM="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803077608,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAYuGF+QtKvwxaEVE4bn0p46vQnftfKN0DSEwK+BrYbYigDsctx26Ger2Xp9ZzreZhsve35OpCxRErjC46eKun9h8u05/dmFShPcTp3910GBu3hk5t6rau9AvT1lV8KlZsN2IZ6hke+66GVfWAmUcxlcM++TzB98U3RYWsd5oFnIgL3+xp7YHNbQbQkGZuzu3zHaRxRzQbTEFqTQLMhKf9wT/7agN83j8oZ1dQ7Jg1fqyXI7mfByiyeFOVSE+8MVsIpjVQ7I09cy4EHVe/eunGm8g3PXNx8vmsvFbK3Kp0SPtqCQEXZxlB9r8mJlfUnCfQdmLr45j4yke2Fpas1QzotGzXCTRXrUvVQ72vDgOhm4vUtKuMglYG8slQUGWHwnhhvdH5jJyXZvWi4y82JIRb1S0GvzO0t89NMLUSBFVSACzETY0jtyixSyx+xnVE7bQBhFAvtUAjhQSoqwar6I/m3dbkYhZDp7N36rio4aMT3hFzFvFWL7njI8AlZCze2YAYGzPPKnZooY+z57I5X2wVuAJM+8bBuGKVtcHj2RgU19FvtN9paiAN0el0lcsawkZqi8nueyAuq8v7JHOKSk1PQ1rC9SN+dk4pP3Avi2mvGAjB5VVta35IYUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtWI5dbOwGFC92vuq+Q4I9wI6nILRwLPl7H80R1mrf88ilz6rc69yFm3erOlQHc0eJlbW9q2yqvl7uwjYy7GjCA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "E0C32E0A1615AD55363B0CBD144371297A95009D56C1488C84D81D5655B8213C",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:d5PH+vn1ZQBkIFncIDWay4FGZsccP6qGekWqc1mlJEU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:KVrHZ3K1rCxGD8B7Ub2MGGMdFaOjQXWQk8GC5m1Hpwk="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803078000,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQA0+uHxVh2RCh827SRCpz8vbH019jDJd2g2Luw7n3D2Rwo0oZpDUZvbuB435zBk47V5aW/mm5q0RIaU18781hVDivIEGqjzb8vgtNjyGkCOUgvsgOdSMCRaNZzZnBwKdNe2qiQjFwhoEzROx78wNEO5vg1LdWYVy6F1mpNiAS+UPbZr796xYtaO2EhxclthkF4N8JFYm+30kJh8ldIyH31LQzO6yT+Ts2cErJBUImj6MX9Sku/xLj5iJYwt4Pi7zOJ3ERlF74H2YL4o86PCwC5uEkjNd5FRgSrCDYdxu8FA1ArsvKGtDZq5mzmioXBeO2Nzz9jo8uJoFSEAb45pZt4hPK4M8D0d1y7zRcvNGxx3SBSzHRxHuRzTSXB6nvMNBnZWXufzy5sXpsOFWB36h8zDovO2hClW9S8mq+3wbsIw3xqtUeyyZCIgN6bf4GNm/me6jDQM8vOMazwoWKoYPtfmzWYnW9uGtksILpywnjAWvSyV58iLpBCeEGCEYHoYesAITpJ7e5lH/mi1CYEi/VbciYBReLyOzd6Kq1AiJ1Al274GqtUHHSMqRgqULXdLAfXxhWdtYwEu1hw6+y4W4oko0GoyURGJPXMf0DJRrCJ5hPGdMecqH1klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEWfDtuqzgJy/suHb7YxlmpJyH/eT5pDeezY9IoTS670cogDwe2PnevE0qW7NrFPE2wOLixSWYWX9ei07lKIhBQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts disconnectBlock should not disconnect blocks ahead of the account head": [
-    {
-      "version": 2,
-      "id": "8f0e89dc-8c6d-40be-9ad4-d4cad645c509",
-      "name": "a",
-      "spendingKey": "f8585503511691693b6e087406a94bce329968527eadfaf18921e1bf614a2717",
-      "viewKey": "9a925b7b29cfd673efce7b10abddfda3d5a4905f66116ff3204a419f3b584f717da1a23d33cc78494279adc9500e5abafdd86d265be605dbcec6bf5e7e36db47",
-      "incomingViewKey": "c82b430c68d1d86379f1f8d881cbaa7e42b788418357bbd641ebe0f15ae07a06",
-      "outgoingViewKey": "1efa53cb013696e461b5c43a311ef0d16c47106226d13b5f120b92ec84da339a",
-      "publicAddress": "8ca2108f51ca37b9bcc40d9c049cf5f04323b130e530b7f4686a6f7f458f3831",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:wnbC8JZTlNMOkBdugtfJMBy1z6ER7tZi1JYefrF+lVU="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:bRBAIWjRuytQy3vx3aY+DAWDu8ZFuJsxPgUvI0BtnNc="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803079278,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1mByBRY89icsJL3C5mIVID41n7dGA/UEJC0GdgwWJeq01VgMhu2rrB5mpYklCLrFc8GXEmZuYJmYLhl69bM8UJGkSpLbNd7JFpaMsVZWUrih7OF5CgNIvP6BLBFDUef5dOc8T7S13k7JAHHa+Lwk2D24Zh8NAn/hSrRDZa6UHZsPZJDzrcG5dvd5ovIHdlFZ/f65CzO6OXRam916CdX4PB+OV52+XqSfMiF3EvS7iLy0OHDmP2TKDNKJw2ntNey6VmaCowJrCT0DX1d+J73WRojv+i8oEE1tVg2ne6ttoOjPC43IGZpXxKLYft1mCQY7KWxcNVUxl4pMCIc/HXqGbvUkR2Xd5ZlvKTDh0hX69UwpGllXI+VkCIGYxdAYIjgzWlGMlL4MHmMygTdblHyCcW4arIVBFKHlzNNObK3OK/MivBFYvshHLyTfDJKZMpbWNmeEQS7ZPzeLZTi1mXPKVcwue6mTq31yL0oZN/mSb28VKCusduf9XfgVwn9rZd4rTIagGhhgNPcuNrasuSA3u7CteEf9RO+ME4CsxSYAl+f/odvmWkla3kzI4GbfEMfMx/KmdLXzauN6WUbuqhPqPhgJGlrFRJPqUrjspBirJCNp/5al9D++pklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEtlpVz39qDj6X5SgjLtahmqL4KDj6rIHpvhD08aMcQbJ7RNNXcs67BDZJwi0zIwygyxijGy14u972eBCtg9+BA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "F89A6B26D28FF65C6CE49E3FED4E8B5C862BDFFE0F883E7E4711534EDA034E70",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:6zfF1S3X01ZK6kpW00nYWhZc/Qd+woSCd2AGwSc6DVg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:ZHPJLRImcOqznOibpXZuz5BxEOavSqqyQgOfLQ0AWRs="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803079685,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAkHKaQizTmaar7pufjftORt3XtNSIwIWlYbzfELjEUfOl0237dLvSH7w6Dc+Ggw5qGhtV89/ZNoqUhVdQAFsJxiYQA0/2N+eaKtTFncgcNEaB9wOxtaO5uWlBB68S+0yEADU8WmzymoUvW3Rh78yasjrNt35Y0dkEtkaEgY535RgAb/23k8M8MU+VPKgciHNunAUO4EdPsA8/Q4shuM2ZIHSZkXkg0erJWXIdmPSWHQSscqtX+C0cJmuuBkowHUf5Szd7Ui7U9kxEoVqtVANEIQWke3s++SpZ2Ht92VFmgxo8vyeI1o2ZI6gRITqFZBS2kjoyysmxF1CUtvQsqWz+JgNvMTd2BwUWQhTYu4rwr6PSZZWW6W4YQF2/vjyHBdBu+xdvDXq67Lzi09V2DDgDFsa4W+FJuQ+j1v2i0LIbZVLr7nearxJ3rBj/6anZO3IeNag/gLuL9pefYA6SPdcs3ERI1ENEgwbrot0YREbrcskJokncEYhyBMmR/gu0vPcW491beTKCMUjPTMNQsByYmgsUVP7K3x0FajQxauOP7bLgHwaz4KhkRyUEzGKcUawtRnNMkpddwlTlt6xyKhxYkTSd7/oPpP/ITI37JdSaegI2+j1A6/tv4klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXrrbIXzL+XQIk6gP2Sea5WMd5LaGAu+fDD023p/+8904hqDfRoJyvkBCkQbWvHE89zYaf2LpCri+AKyelK6TBw=="
-        }
-      ]
-    }
-  ],
-  "Accounts disconnectBlock should remove minersFee transactions": [
-    {
-      "version": 2,
-      "id": "ef24821b-1237-4752-a578-ed0d9b2e6612",
-      "name": "a",
-      "spendingKey": "fab4ddccd1a769744abf038ebbac0cc5ec6bf06695f72f78d14e0db5438cea63",
-      "viewKey": "4a07d27e96193c50e57ebf19ec08aa331be092f335875fbd01a3b9ac306ee2114c902f4bc89b13812364d9fccadc5a778c875d5dd501ee96e0641e98763a75d6",
-      "incomingViewKey": "f65731d8b3ef9593f68ef9ab239299092377cfa29d98a15ad270772bc573cd05",
-      "outgoingViewKey": "9fbe2504304e5ef8f5956c049b2d65c7a8850fb71ab490ae3b1f7e02d3d18dfb",
-      "publicAddress": "5d427177cbfa0ab7654872eb0091521d36539480e6d0bd510eb8033c80f33fa5",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:vEA7Pv9WDnMCZnaA9i90ZVoCEFd0p+hOpAilR7catSo="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:npU6KLyfxxXDU2vHdsvcvpY1PQqF6zXntRGNuWG6cBo="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803080945,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAAm3e/p51xOB0wPhKdkVtCdVNk9z+GOBuOAqogKNi5bGT+fwwmUQiSBvBWOqEgDlwQH5jSbp9YK4qlQLLQ+2f/FDVBXZu3E0ZSixDgEaqbsW5UmPnSb5g4MxjpO0TQwIHegGMunC4khAaZtA14jnsPlgW5fpxx5LzBWB0c74NlY0LgeXBwaqvMOvuxe7B5CaRu5R4KlUwRJVuQqVMxP75Nab1K1r+fEsTimPCHA4oIuaSYG2RWL6C8RXQgErUznuNgWK9t+dbr3XT1HvNeMEtu0hk3/g3jXVKGQON6xjYRDW8XhowhYynEcqCj3Jmf9iXJOZLPkcuultzT3TJcu37i5DpGGloGN4+SOjTXTaWkwrlfq0sp5aIwTQmnMrEUdVqsT9qNsNRyZ76JfA1cBf3cbKyfM8eQazSy/G2dK1QGN7bCZiySYTYU36fTXjWFpFNt9evQ1ctp1EDzMztt+v7nPXE6ZAIioyUDMf2+/s15Drlwk6A1ehXhnhoArSyyjTrz+P6zwb3r4ZU1047iXugFCF6E23s2wZZ+3mPEn/joLc314srU3l7zK2wgO1llg9L1maR8CtoW7B0Gh5tSc5Hlk1L6KYt505hKC7SyoSr8LBQMAl9Euj7b0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYvXy5LJOCGtwPk1Q14NB0fkNS7kw4YxLs2NS6l3gHQ9l21h1EpJkelBjfDFb7JhxGkNJJy9uiQpDQTX5GgRNAw=="
-        }
-      ]
-    }
-  ],
-  "Accounts disconnectBlock should update balance hash and sequence for each block": [
-    {
-      "version": 2,
-      "id": "fac5cf8f-5e1a-4e30-bf3a-083a2cebe320",
-      "name": "a",
-      "spendingKey": "6821b4459c28dcd83d197fbb7451b316da0a61175c48d96bdccf0fe209dd3c94",
-      "viewKey": "43ff1f1deef54af1e6e5763c3c9c552210e74ef4106e10b23abb6ba6f493a2d02193d82edf88b453b6c0e55c94d464ca1439d62f89e0528b02f484a628782c19",
-      "incomingViewKey": "a02f146e91eeb2915e4af51cdad2f0f11b3ee2e9e8b33def38fd71b35182a700",
-      "outgoingViewKey": "cbc62f2b766d8b5da7783fa1a630045b273d2c90fb780e97b8671abd81c66003",
-      "publicAddress": "0d1b4e7f60470c94bd3463649a0fb697bc9c6b9bc0c2871d52a68606e0ad3a08",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "f7e33f2a-4850-4af1-8c6e-c64adc634a17",
-      "name": "b",
-      "spendingKey": "3f277b29438aa74b212f61bf9ec1eb134de81142d0179fb1bdc0461887abfd0c",
-      "viewKey": "f0618ce8254857f5ea57b2f881e738c53717ba37f30402f6639a2b4ed4e8c3c2b57f2489b4e2fd1718880fd863b535594a8d0245a247c5cbcfd78d2aef7fa135",
-      "incomingViewKey": "1a8ee5006054c82a4b95584a6b3c12585960839d1ba97239e7936d9e7ad81003",
-      "outgoingViewKey": "eaef14f935dccb5d118c737de8b2afc8df6da5fca5308d4863b575ae890f723b",
-      "publicAddress": "3bdc947d8168e30838fa64d7b1b8fe2a014e0ff405abc67f6a49877803e1ea27",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:VaIZAbn3WdqMBl7HxWk82yT8OMUlbylofOEN4pOCZ0A="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:AjJyzgZDO61sj9ZiFVpkUJpmf8QsGuBPkYfnos0JcpY="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803082209,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAA024mA8AnMuItL2UCvkbWMtyS7S4m9Gvs3CIHlizfpqxtOUPZ8Vc9Ii0DwTgv172yll0aDTSEKxraOS3DNeI2YBf85vLJtMEcjYqs1Szl9aAZQEK50UBHUCgL6K3qlOxHvPo8kB367CLX0WKmT12DYVUR9nTrxxLSVM5H6vpbDEWmhhnM68k3pJFNRBMXht3Ixr/BJaxoDWRADu46Vno3I3fZuqTeRTANQ83YyXyZueAveSI6e6dPm+6z7cRtbjE2Liy5pb0m1VoJUkOJLIqJrR/PDArIWuvC1Y/UaqUTc+j4Vq53rmrw6L77djmgYeCqzXClouoUETbwbSu9rtMk1NiYhArAgbuHg4NeVBR6hV5kQEcz8+QGFVQno/2lTNoB1Tjaa/d0cB1dRIGzbaChxu6i+YRUh5WZ+/UwC09t1IbP/TxY81tV6FB4ErXdmoQPzXD3YjT24Qhvp4zVOmC3pqhkruy9VJ/pK0nD8/qFriIUslQ3cxmSEmCX4j3k3+kHZbvYlS6LWDurx0WIbU5tPmBNwdBUbL/6RCPYDKVxD/bjyT8OZDo2QAgQlHvAfS2/ph/I2I0PbPr/XN+N5AHtos0QstnND/k5V+9MCOVlyvKdPAsvBkjYklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtbRmBHDkfS6qNeBXPpu5a/Thzq+rVXVgwZl23RqVmlK0cFPTQNFS1p5JDDJB7BMWnb4jpVNoSOM8V1Rp2FZKAw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "A591D1E4155DCB6875ADD174721EDB33EC872B944BFB913EAC34DF56DEB8B1B0",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:jTrqY6MpUG1uj8Pug8wp+ZGpSz+UiEpNDMCz6+5KZRA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:rZzZaFwd2bH+/Vo54vVziyZ4nO6LzE/C9VrLtgd8Bjw="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803082627,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAV1FObsf+087nxONEpLG8PsyqWkAJ1wLLDQEHm8CI1kelJDqjL6rKXq5lx/K0A4zwGNdaKQjGZM8j2w76Y8pQ7R1Rep1WYQC0q78+Cu2dDwWB1TkTdo2fZXzeN7tZj14CBPNuNwW2CVoSsIT8VKdKISGUGob1ebhsH7Ci8lANJHUBnvipOS7+2oGnSCQHeji7Jg6dZv+sMF1E84gFDNd7Is/mGWla/YvvE4nIlPR8sK6lkb0p1TVe2s1OLtdOBQDAcV/+Gv57kqK8w6liE8QZarBpR2cDIJY5NFz8N4thYQF+1VP550M7irkUwqr2lKADHIuntXQ+DKE6NjQfET6MLItMcsxbBSUT5Q/nq0s1gu6cLL7eykMJhvhB9WSeCwRWQM0k32lWCWgddD8Iu99WrW2IT8Dtwhgj8CPNAgi3vLO0OWO9F0ID4GgsPzW55RPT6n5x+c4m6RD0SeCl9KsknAJoRfA3FTK6bHkf8PT+pcNst/stbGtfGRBsGfQLE0jo+7hWM+pxKplNgKrMI5p9An4WnkRuIYlPBI3mvDV3sMSNWzK1Jtpkeb4bPHewLzuQL2+QO1ScvEsB4zHzUQHtF1Qr8sGTyIzaPhl7hRj+VRZYpZPz/FWVPElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwllWXKQu+mjFVDfYjqSsENzDM9rCB3KW7gLL1WeWGIZxz1fkXL3aLXhdTzypAXIarFchxHkSMgLZ4uyt5aHFYAw=="
-        }
-      ]
-    }
-  ],
-  "Accounts disconnectBlock should update balance hash and sequence for each asset in each block": [
-    {
-      "version": 2,
-      "id": "c7871609-d397-4dbc-b938-ebf5cc5abe6e",
-      "name": "a",
-      "spendingKey": "bd4956a6a5057f2ad6ef9077d7c5a96576d1a3986f5b2e078ef061beab4f2a32",
-      "viewKey": "37f70d13891a22b5a2bfd158fa91617c8b92f283b9d2935d894f0307b4e147c50ef8ea7ee83656db9aa58871972fcbd6eed4606a25a766184d63160bb97f7306",
-      "incomingViewKey": "f0c271518b714aa16d23d2d9fdbc45c0a4ddc3e9f7840bd40e6748afbe85df00",
-      "outgoingViewKey": "d1c5834dd71e1150205640b0ada17fbf66ecf3f3318ffd73e5dba44726a560fa",
-      "publicAddress": "c05c580709e531dba854665d360583bd2cb853c4f2d3eef0ecd26d26d043c11b",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:MeQAkFHJmBvgV8VDRSsy5qW1eYMJWiST5CfYcHi+X2E="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:XRA45LXy0hLiPd1h8EO2yTzNVQLqxyYFHzsgJkSH+aE="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803083961,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAqYpAahtTJs7+PX8PlPcIqopjl2qcmjlcWE9z3RYOoserRHdtPKZGRbwaCW1jrrOcc0uE3rSMWfSnkc88jncQyJwOcov2Gzh349x34rg7l7KmzjNEIjMs+HREpDdPPl9jsWg7OAAgpmGVWSqsoCW2KaEGzB4t48UimDn03s1us/sYyGKq6zVmFef1aFqqmTyW6lqptKYhmEmkjH84R5dkEvpWkq0jv/LrRQGl2x84zEShobRsDdgZAlhk53DXgx84z+8ZDyUpCKTjYZ/sXnUqJKmY4nPCD3KIWtwud/mQGaBTMopunQcAISnrYR7hLjUk16IKJi0v2dV/edTwqWv0nFWIUNiHcIyzjhhDeRMnwcbGXwfGs72PYA1ef1lMrKZzMD5lZmNYkAKkpTeS/9WncrgiCDLxVqxNLokoNGK5TzXRXcdOUKmAoA+hkgJIFpqhMfhmHAlLIR8ej4m+wvZAPfnchvyViEgDNj81S1JC24ZLiy1HvdHI91Jkckpb0OsX5OZG0zYN6MsC87CPSxODIwu3OOWic7lEBPST+xlRqkE2lCy8gLoaxSGCIcRdW2k9FbCvu9tjj9YTbnYE1DY5KJAkFDhj4ocHWl3LfoNa2ou1ExGWz2+SuElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwr9g5BtLUwKL3z07fCzzj1zjq74A/NdcVGU4rspu5O+7BZAUYvYL6cjsiq6izpjoW/HVHdb4dDNxk+nxIl2hJBA=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAysu1oCKlJLdzmKzaKrdBo+Q8d6TTk83qhunSEC8bcNWrqCSm4rMCbqb1O9bT4TVa9v7JXqGiwlsLBo8zrJTNx0+YC1fjs54bxWg4koC1ej211Dfipi6olbwPhnPVR+Fil/96BhggMoKzNeTzG8BrdOWAdf78EqCiDp6CkwBp30IVg+NkO0z8643th/EBEE4lC9HcVPpJjw9CIdqq5KbY0ivgdUVZZN7/Z27x/fYcl36neeYv+POkjL+coNQf4d9xDELNxffFb4nYU11ORyHhgs0wMsaSP5iQybR55dptgWcROQtD+GDk5Otu0mAFq/ie3AICBBvqq3sMQOaNcfwzCj7kkMdsjUQkIH421rrM5nAxHgyT7eLkpF91J1+tMXUHQw04b4VlC8PLNqLtaGIfwxYASzjAB5eYskdo2Hl5zIdxQetNqJZyLmfPV1kG0J34Rd8NJCIlvwosHoNZBpaHB4Ca6L9JqcwAaf5PnEJjoseIGq1C7aV6IjYFzKU049QERQHxp477oKi9HjSSAf+OFb6wWuOqQgNAhzMF6VmgzZHA7YGgLTM7WAjUlr3y3JLhMAF6ssHjce4rnjeYe/gdA8Wx4KU0dxhxOWab7pfsnyeN1Gp5BfU5FsitP1QBwIg99DP+Ib+xqvXkShid3cePWhmzUosGjho4zz3jgE1Qpzw0+FteT593F/AMfUGF6D7syQa/agdqse96W1bJA8gjb7CrJ6ekNVDlmWt5f3U3kX9bHk1LBuiEBoDKMKOB9rW0d+oP39TeZcXDQj10qFr6xh3iypOqqJQmoX7sA9G6Tle2CIfPi+/r2LBnPclRyNzhz+2h89cB5Qule4MKRyM2+uSNz96je87MAkmCtM3B3FFYtgjNxf8LV46mR6ym9PH4S5GB44nGS6xOYtx2kVAHMAra92l6J3dGjxxEvVJX+9p/98FXfp+hxRfKT87ionSHdGCFXeFSS65QRJfoKnY3ONEDVH2Xe+0fwFxYBwnlMduoVGZdNgWDvSy4U8Ty0+7w7NJtJtBDwRtmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUKAAAAAAAAANHBadNR8f2vjamgWqKtLJL/TGH4khyp7RUFXk1m3rlHUEFWY1exkQ34M0A8Nk6A15f8pNozZkBs+5JddSkRTANdONG8prw4hEPIVAUeWtfyamkHpn394DOge2PWUbo6vX2s3o4hFIho86u4svJ5Q5ATIj3sx8Dqe3b02cmscMYD"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "CA4B083BC7C1210C4865E25756DE763233BBF94B8626B9332DB54AC7FE7741EE",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:UFGMVEwBoAkJFdh3beXhZGAx4igCxuZvqiCFMG9yoV8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:8fk092JYprnjt/5XcEC+zIHcr7EY1O+CjVvTruJE0YM="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803084979,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgSedxa+kUIZjJ/zB1Hl7X8k84T33ovPIs9731QGyx2CYkNrmEfetmhmEoiRk9w0hLe82SZvOgsGjmh3GV9zKmzJBTIHL3DmoPsA3GZapTm2i99stQ0FuizAjoARLhqCqyt91d1otvkP4y1KMHcMFtQGtq8hp7iPeS1WNxNJkLRAJYHpvliQEXe+lHuNS8bN/Nsl0Eyt8pT4NzpS9qolG+Aw2fYTa2eayYPnedHvNXU2hN9fw6owjVnrvlqxfvI0ehIDZ1uEINZtbyTW8F1lSBwIlZedrIUAaZtoRqwcYm3nyEd1ROG7ABXVcIhKA5ujCZZ3PNjpEhoCwFC5RX9RGzMpfGdZ8xaue6tyMoriNjcXTuZ1UxX5shdauZZSAj8gSwpKdAWzz/H2yLMIPfwJsc9i7koDOqOp5Xap1rqFwacu8gAizxBk6YJP6LB7SW37XkasSMFyOvXIIgkpJLBon3V4NNY5TpQV4riOgJ6HdMixTYs0Hye6PmEj9RC3VfF8qQyAtNBY/spNOY5yHUYTRpWxc7+sxHkzTPz03Bb0LbMKz0mJt5ZqHAjuIarSHA8qFX7Yhvr0w64bE4B0v8cwd7SVz38GvRSWvJZNnOU9FifFKwEJ6Q+ROuElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwiXRieSgPYwKrVVvI6/exREsMkV0NR9HCG71E+kXhJiHGDE4odzMpfCHco+HZCAC+wJ3Sazetxzxa6Mx8M4jyAw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAysu1oCKlJLdzmKzaKrdBo+Q8d6TTk83qhunSEC8bcNWrqCSm4rMCbqb1O9bT4TVa9v7JXqGiwlsLBo8zrJTNx0+YC1fjs54bxWg4koC1ej211Dfipi6olbwPhnPVR+Fil/96BhggMoKzNeTzG8BrdOWAdf78EqCiDp6CkwBp30IVg+NkO0z8643th/EBEE4lC9HcVPpJjw9CIdqq5KbY0ivgdUVZZN7/Z27x/fYcl36neeYv+POkjL+coNQf4d9xDELNxffFb4nYU11ORyHhgs0wMsaSP5iQybR55dptgWcROQtD+GDk5Otu0mAFq/ie3AICBBvqq3sMQOaNcfwzCj7kkMdsjUQkIH421rrM5nAxHgyT7eLkpF91J1+tMXUHQw04b4VlC8PLNqLtaGIfwxYASzjAB5eYskdo2Hl5zIdxQetNqJZyLmfPV1kG0J34Rd8NJCIlvwosHoNZBpaHB4Ca6L9JqcwAaf5PnEJjoseIGq1C7aV6IjYFzKU049QERQHxp477oKi9HjSSAf+OFb6wWuOqQgNAhzMF6VmgzZHA7YGgLTM7WAjUlr3y3JLhMAF6ssHjce4rnjeYe/gdA8Wx4KU0dxhxOWab7pfsnyeN1Gp5BfU5FsitP1QBwIg99DP+Ib+xqvXkShid3cePWhmzUosGjho4zz3jgE1Qpzw0+FteT593F/AMfUGF6D7syQa/agdqse96W1bJA8gjb7CrJ6ekNVDlmWt5f3U3kX9bHk1LBuiEBoDKMKOB9rW0d+oP39TeZcXDQj10qFr6xh3iypOqqJQmoX7sA9G6Tle2CIfPi+/r2LBnPclRyNzhz+2h89cB5Qule4MKRyM2+uSNz96je87MAkmCtM3B3FFYtgjNxf8LV46mR6ym9PH4S5GB44nGS6xOYtx2kVAHMAra92l6J3dGjxxEvVJX+9p/98FXfp+hxRfKT87ionSHdGCFXeFSS65QRJfoKnY3ONEDVH2Xe+0fwFxYBwnlMduoVGZdNgWDvSy4U8Ty0+7w7NJtJtBDwRtmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUKAAAAAAAAANHBadNR8f2vjamgWqKtLJL/TGH4khyp7RUFXk1m3rlHUEFWY1exkQ34M0A8Nk6A15f8pNozZkBs+5JddSkRTANdONG8prw4hEPIVAUeWtfyamkHpn394DOge2PWUbo6vX2s3o4hFIho86u4svJ5Q5ATIj3sx8Dqe3b02cmscMYD"
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "8C4ECC8B663B4D99FB5532BED555ECC728B54BF97F0364CA0CA429E2B574E4C7",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:60lbqXaKGqyeskCs8XVjSzM2XdVV5x/PbHDnucetNlc="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:2Mxro95aBXhFRQK5bP1fsuT4OcSpd1HqXmHRNl9lqqA="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803085366,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZJS32357eBDbV/FRLKLf77ANWvNVGX8/FJiFvfig+ViKvSU6TpW7mZOKgr4nNzFUSSYylAy3t3XF2QDurzsg8ufWn2NlcVMQhFehjX86bc+CVs6LA5NYOP/70q6+uuXr+8l0DAaCN4yP80BCVDdpmOzW4MuKAkfQAIMKuqQruYoP/84DXiIvX0qbBTshBYHsknQng9ut5dmy9VPrYAoSFUN+adzBE84/SVhw+BIVVHGN/bxFKT1tUUVkVlx5d0al8S45GgAC98/oPBpFtRdNJ19pW3Wv7F/1A/NQCCVNVbKogo7HDvQZh5LdFGbVoe9fil6GpeQlmPFOgNiEQiOOILAl4Hg2a2tAMeLhYXKlO+bYE0AiQkB+wiiX10P+YkEJsQVlds/kjwN1Z5PY1lTDltcbA9OWiQ9WfxYKU3hGpAEgVJbndis2Z7CoSgTVr9YfG48dFofReXP2TpeQy0vQCZTzWLtAYNEGR4DKRgCn+uOg80vGB7uvU+BacH/fya6UGyyJZgyXY1vaxOkAyVrBACNn6BGxEkXIb6BxhLo2T8/cGDd4cKsJCMnN0wUfgk4Hx8P+nsbqe1/JyWs33yQuq3otnzCXZZc+QywisotthbxIL0pv3DkbAklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOHS/GJIc1Bd9Z2w114EUXX9udBPFofvg8Qmm2UnQAJ/clHb/kRta5+45ZVDIjocQgLaHZhIEgoIBKpPqQEWGAw=="
-        }
-      ]
-    }
-  ],
-  "Accounts disconnectBlock should update an account createdAt field if that block is disconnected": [
-    {
-      "version": 2,
-      "id": "59e2b7be-10c8-4350-966c-9151357c62c2",
-      "name": "accountA",
-      "spendingKey": "9ff226fc93626886010ffd38d5ab57911749ad6dd80984722d093aca3d48a676",
-      "viewKey": "e1a904ffd5dbd42d4d32e61440a06ad9cc14932413f76f205dcbe9b1a8414e2950fbf5b48899793632bd367f052e5175a99c372a080a867cce26162fc2529980",
-      "incomingViewKey": "29d68fbb8a788ec2bcf8b870455db0b7fe7ddd7998296898fd9f16000a0f8b06",
-      "outgoingViewKey": "f145fd629f2df1d93b5e01eec1fc936cf801885cab9e9a226264eec3e5a9c329",
-      "publicAddress": "3092e22d580bcaad7d7a7b620c42b3c65a500ff20cff38096e86b52fd1c549b8",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:rpisO4toXsjqUpk0y7d8QUmnaRo95SktXKCPeIH7vTw="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:D7+Gd1CM3PmiQeZdGKyO1GuSCPvh2msK9UivNTQZ3v0="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803086628,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAc3XwcAlKcg1Ps3BhBmtBd41q93W69e25vqrT9IiYjRODdKFqEBiXZVhoo1wvQqVWrEExEOaXQkrzFs+zYk/WQbkZ/W7pXGaNHYxw5z0t0YeBDhwzufcEIxVtd2rx3bahuVpyNq2d4W6XmwIQEF4FfZqQxqBL7VOeOv9/7LZR8uASdp1cCVsTASyJmcTVhnjwIXl+TqsSBsa04HLJDrJvFLHj4lh7tJkXji8QijzTK2a0lZfdCjvvb+9UjPGZJPQkhlHfvke8ZWsluAtACeJhWKValzi5crBvra86wwO7xYwPzK9uageBuv2naJ5RIx0p3JNNHztA67PwT3ck9KHlGytiHHBE+pO0mD3Vw15zqVFWhZOhq2dDOHWGXZB4YLpMYThZ9TqqzVrVMWvEzPtIIFognwpoPHIt6GQyUDFGE8AboUvr2vHNTyfomDbGlC2GrtVqJNEZFU3seZfgb1WF+ZpgfeOOLachMlNuTbIy3mrhgwB8QsfyXODEej5S6x1peFW5wZ2QJyRa68B35/x0YLNKiN5KIosNZ8dzxMnTCa0j1FOqVjZJWsv3XNmahjz8LzHbKJnbeELPMso34lpSxYs+IyVT6y6Jfkgjvx1NBKSCOrlFbNrToElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwzE9isPMBfWhwd8EzRmykaYAVog5Zzptuy1bxGYEUeGg4ZYkCdvCx0+btnbSzemQtoiJIkRZJM4wvalma/U/mBw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "C44EFA34B3666B6E9427FE8829D3A7695892409416795F43F5A0766DB2241FC0",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:MsXo1PBLi3J0LOicrws0DjkStdrHy8oMIJ4lBRPVMys="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:/TREpydgvzCUUNtIcrVoRcsqfniqwbZVioFT1L5HVQo="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803087008,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAG2kCt6BL1cHR0/X4OPMrX7kIRtPzf16Stix6jzp4cBugM4Ri7CBLZOOWj7SyeDgCbeC32xUrXla7VO6kuBZhF508bH3hrLPdr811Njts7suTFc8rU1Idn4ue6oLd9DqbT4ltvQ/NvrmKKUOAV7xrtRwiJSlxCGSqFZx9Ush1cEUR1/Mveor5NuexKfyRI/FrgXJHuK5roXQmmWCMn1eKrdpqoRC2y8t3RAYenmmIUaaVUQoOnrsZzTMQl31s2OG3MmD99thf2U68oLzD2BQxjiR5eXm9ukHCw0g59n34t6ruv05/GjtLPVdGKIDWSqgzL17VQyaj1NaFZrYtPTw4MKKcC96CMqtngL8nr1BMbunUF3PL1P9RkiziMB9j9L8NzaqUGYEMCYnMTBL2tyniAA/FVIK0xiZZzj5yEVZh5SUl+LFp2iTdYPktI6oFa21q69cplxl00idBPxbGz9kKdZgeO+xjmNQeAacnIEN4ctqLM2OhJRoxBtw+vd+XSFIFL+LJ4khuhGoxCc0t8lncpFcjv0xJqY0oVk8ybG1FwbCAhcgtQ4UYnJ/y7EM9hE/4806dmzCP4yZrz9SVkWlntFqpXa2MpxQg0trx88RqCZNCCm+Ro0sgUElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZBJwkD9qunCmMWD6+dYqNNwNO7HYt6kB29zUmwTERQWw7fVKsmakoCPi9XQ0yZDFfoRXFtPFRB++bcuWqckpCg=="
-        }
-      ]
-    },
-    {
-      "version": 2,
-      "id": "3a4b27c3-76ff-4998-b394-d4f40f6a5ef1",
-      "name": "accountB",
-      "spendingKey": "ed76eb0f79a79aa4b7cef256a396e7966fde48d602ddc07e7fc34febd82c8292",
-      "viewKey": "5b9b85ff77b35d98091ab05467881195ab7a09a519b593a3cd4bbadc44747d0d5c5c3f0e8d2f46336ab43c5f8d42ac5080c5b087a28bf4eae5051718759b8aed",
-      "incomingViewKey": "3d8724d7ce500ae342587900527ca8e765338fb05c91e06e20e0133f31aaef03",
-      "outgoingViewKey": "9100afd4712187ff0ce337237fde6270c6a32b101985634f5913eaf9883afa76",
-      "publicAddress": "0c7e0bdbe81feb921308d471e4a7cf0d4a45f569c04201ab151ceaf1d406883f",
-      "createdAt": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:7d9b1iRW9S3li/n8d87W+uGM69jaRbmvBeiC8UbN/5A="
-        },
-        "sequence": 3
-      }
-    }
-  ],
-  "Accounts disconnectBlock should reset createdAt to the fork point on a fork": [
-    {
-      "version": 2,
-      "id": "6e8d7337-6ffb-405c-9a3c-77c03ab5d3b1",
-      "name": "a1",
-      "spendingKey": "c0c9183ac2c122556d212eb7469b6a315e39ad3db2103929e53d74e00bd88338",
-      "viewKey": "650837aeb3d1b2bec8f65d941842340f7f20f7b5e8422a8a7623a8dafa6925c6df7b5d2c198dfb8608bfb0eaf04d82ab72cf58587c2ac9551a0a4e8784e46d1a",
-      "incomingViewKey": "d820749ec7a6526f27ecca1e83484085d11a2da85a109844822f5363519be501",
-      "outgoingViewKey": "0c4e1d1bdd6be3071a0b2227c509734e04d953acd621eddd53c1d4e1a12b31e7",
-      "publicAddress": "dcb9e1ca44109cdbd6f3fa0a4633eddb414fd4538e40937a75366ea963c27e3f",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:l73v4KWx6DzguGeswkQCw9DCch0Q/DBZ4q740la8IUA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:VOrEuD7/YjJ/coCEjz30m6uXqfVeCdozGLO0btKAQds="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803088748,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAzM0WQDsh+lJn8Ucp9+HWnrcxKjn9b7tyaCjrdaKpdaWkPvg9i3rdCwYklzQjCXlm7LZ7hFhjh/W3UqMhWKqZxSh4Wbr66w9eGRGJAqBwNEeKgUM1gRDayLW3RZ7xYqWdyPEkDmyEoG4dg3RV6o1v3GUVXmlGNjNtr9hkwAkgfbQO6Esf8AU7mDwp0LY/cW1Oou/TldeQ344n57wGZNDHza0u6Llp3CmlLlnV+Vnkf1WyasIhIXnsh3SxEMq3nkzwSX0u79SZChIa2mwrFHVbMRamQ4AsYcxOh5a6MWSSBXWcBkTEe4C63WAiPnBKtFOjNYnd/TthIQ16jyYAo2DLA77doVrIZexQEEYBNHnjDgJUM5ZeMhSYI4CcSYHwQVoiZ2wZiKWOjWWDm8OZc0Ki1Ld7+7v2U9QrAC7VbCedWzwGTxg9ZgT7cRLJ00FWBoRqLrDXt1eG49zmygmcZs17YD/b+ygKG8zfPAOhfq96vZEz3f7RRpIWSN+4pYdrmGmZIArXQxWnLJrY7IzKGKlFvNwe+i1X5hcUAPaKpjrjXonSRrzPB8I+81NvuAlW3bMZMAkxsmdyI5NAPV7AHGGJ4yyNFoWrgYSn8b65zTJpBrJe6vnSky9dJklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDu5glqIqKgj+JGyxoUT1x5SFzA4xriCI8HVc+Rjs4cCnFa0ZGfYiSYgDHaYBBF9wYKcQ9Heen/+m/Zh8bQ65DQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "D055A03541494FB6302C0D8F0A4C8B1073D8B5A21BC8928D9679BD7EC7C5E8C2",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:xe6UIc60T70+FW31YCdFdWyAGFPD9v7ffeLt6QbsLzg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:pEUkEJ+RhG/GK45k7DkQZBAkFHRAHSnGy8am1U0a8Ig="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803089182,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAz8Ra62LD4CAN72s5N2houhTH4sn8Qe+BTpUmZqpv3OWP22luONEI/oo1wDqrwfgxQpai3lqoBLhRvcX2S+J2X1U1PY5pUmiSKQ8YeG+1xguM4RToGXbUR59rcNwqOy7yaGbllJ3VR4kG/MaFwKEMDBc/gHgLIc7qwtT6tfaWG0MAobMAwTgMg0XPcKjQqhxs9Fq3R1yXOg+ikIK6hdj3rQsWv47N13dIecSbvEW9eKymVI/M2i2IWpGuZfTBC7+ioBx7apz7b9D7zUsHC5tfrjx2M+8fujxoxBrq5MGclfXiUyAQy0JKG/PV49BWN0xxjOLytvZf+N47sfrla1a6cn3D7WF4e/3+VBvsiXHFKSv3Y4pCNOIN+n07qNatsnlNW1R+RtVBw4RGfAayamcGPC9JcmtcOZzBxTsvVP/qXsrGRUmDc7Qx4d2bWqqbzQgM1+ju4/KPF2yVAJNEEuTA/uWfHTkURXRMX5xJpEgwlIwf1nxNPv/xFqWntdJsOzS+E3XPflV+cIfR8hKszLBQr45BCbatpi/UVrBG8vy75E7xuloZNB1decKqoAemLCAURYJXTxtv+7vuvzLp9ADt3uaYyrGT2p7cwBw9G+prAILpWjRPpp5c60lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrBBxf7eIBg0sSdc5up3dwnj42pGwxoWO7v1H2bYA2z4X6fCuucPfzjMNX6NgWfzZ5J2rh1KDzNnb7S5TRs1PBQ=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "BC32FFCDBE4D4FBF0A68EC648177755B3E43347959C90A002B488085D04281C8",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:4TYQ66H/+Y8oRy7P2MeuGga0mERwjRLPK98PmorGOkw="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:c1W06R7xrKK87BY8lkyvCiXI8giJpNSJcQUiPErmDhc="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803089563,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAfsvh2rBCjMVKXSJanKIGAUU19bgnsyoCG0Y0lb8RkQaWQQFvN35Mgp7ArZLkMFc03KGCNghS4y0iobPr4iOgeL4niWW3JvrOGRly9vjLGSCKIu0P65OpSS1ObysJaVVcInRox3KskCutJTxOSma9+E3KbzxZi8cDbgDtSCvRczYGiEzgn1+oeDtl/jwLvzF5UGBtQxxhGUHodLtPlmd088u9KwXCPrq138LlS90zJ4+DKKdFggsFqMd9zNR497gDp5Rr0Cn8G6Oj4d8aNBmZpXZbEAT2D+Uzzifqy9yH/Qa/zDwENChT/befXXzzlZVT1E+2Xgfc3z88u3krXY8/Z/iBzjp39TDEpjZubJ9jucJh4NNIn0T5W4A9pvhLrDQjB6JzU+sBjqNi5ArKaT2ogEBhGmTtqnR2D8cTMPfX2GkvtbRKpphre0iCEBM5CwVVGg7jkKhRe91AdWZf6cv6DiHWBMzq0jPLz9MNcC7G5CfneOpvSSeUxuGiegfwbAw+8fmZfHj8YsQdiQ5Gu61ISstlmHn21F3nDrJeUvWrsCrYjY7sBw06IPMQR0WF5ZGsuOQzxg4QnVA6O9C49IHSv0HqbmKfLv9T7zbYI6NyKhgDg0xCkkDUGElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZnLWbq4BuFb80oo23Rjrlz5LE6ZyBDWGYO2TJk+6S1UYOaoKpY/YPA+M6PqKFA2h47lkwaAOFLwX3TZXeK9rBw=="
-        }
-      ]
-    },
-    {
-      "version": 2,
-      "id": "6769fd78-fdae-411a-b4bb-1322ddcfdd7a",
-      "name": "a2",
-      "spendingKey": "65858412c566d32b131dfb56fef96aacde941c34b58c0799d9bb991f91f269f1",
-      "viewKey": "f374ead8723edac78985e34bdf6a192f6d9611c507ea153c7c7c9f327e39bc6e11c232403fb22696bf33be661a599676e0f46c900c84205a80efdba8805d41b9",
-      "incomingViewKey": "460d77f4d9cfe1266ceb483ef4c6e9f6bad6bad2e08ac7dbaec6b8049608dc02",
-      "outgoingViewKey": "089f4043b7915e751b568051d0eb1a17e451e3a5131d6c426b06f5d509764996",
-      "publicAddress": "e607bba646790eae3b51a90402922686e295c35781c176bffbc1643105d0dad0",
-      "createdAt": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:lBiYjYPBpT05CKF+6JScCeFBNJvoM3EwIcHpgp50iXk="
-        },
-        "sequence": 4
+        "sequence": 1
       }
     },
     {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "D055A03541494FB6302C0D8F0A4C8B1073D8B5A21BC8928D9679BD7EC7C5E8C2",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:tkVrqX0zTbzDU1qpLTtbtcoKxGk1UFLYQ+Wa/7mozRg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:qMGBtMg51VUP67N2XGWuP+idPXFWFoMBATvKvG56nPQ="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803089968,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA8Yi1Nfwjf1J2EDTM8/vRhOvZfKY94/OrtZWtO+8/ugSJvaDnU6xNzs9MaQbSs9M0knucqfSpv9TlsuPAn7sTAG/EeR0S3Etr6jdHI400PG6CFb2rJX7XXJoho/fhYEeWvQLdp3NdVw+USMuIzOSAip7WhpPzJ5fWREtlFlH8i9MYBZ15++pHAC5qjsu63DlgVy+wXiqeyiFgJT1p82ZpFzmqw9oxpAFxZzwuSa6UBpW0I5pkp5IjPdOJiH/pMbRDoy+PwVY1AKIa6BB8C0nDpFBy6EC1Br0f4V1bdgOGtsZKqEt+rZomRbT6ACZ/SWfv3FPiULL6Cbfj7/lKlnHL6YBDlJpG5pmDx9MhH9k4HZpM60iJI5ZLcnxg6HdGWS87hwyk44TT/RttkDRS6Uv4scgLTLQdVeZXsDZf+tECO+jnnVuqf7TRGJr0D2QMbvI1hAfMVlOzJcRUMe1VEdXJ4a9Ch+mvoqLs0GykNIoWIb5CNE1kefAL492oLciiZEieP805k6JnYHI0Ho8+wt3YZV9PkRBe/4Q7al0wnYKlU8cPFQTgNqpf6jevevoGY2FLhctvaFDCTBhACtbMS8NSpbYC0hQEQh+OZahE24L4sGtdMFhDY5EjPUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwHbZxSynWgNCU7DM9cf0zqNuqo/OqCcNqcGEIeCo6tczCLQ4070kvPrt2y9wTsVPcgo/vNp7MDRaqa4ijwe7lAg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "BB9E7E9266EE5EB2BD47902325F49DE2971B9EBA94E6C6706A2C4EA50789480E",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:mQJima4WqlOMly334ioQ9WEmgkMCqLySYVl//xlfKw8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:IoyyK+eV5QU12dM326VS0eaQOHJLJglNOocEpe0phs0="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803090356,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA2HTBs1iH7LCnCNxaZuV+nRwHXzD/GeRYRXHzqkPGnimU39v6OrrdT+z3quBrsV7Ku+bRMTi3fhxbGNgP5Tr9RUdelebrxXaaNIH+lT44YNSlO8a98Q4leiOKaUF4zT/kDvfn36SdGyZbYfnMe3r/mJIWPuGzPf7tWLaXwqfizTMHfyfpS/23rDbCKTNBWnp0wW9u95snzaJfWqfXY2DTcUlW1cx9imSUd50q3onrIYaRIlESnqOV6Rd1upuGuF3F7JMYEl6T+0HG31F/PITAzrmHiGkmdEcWNNz0Tcieh1xLZXwQX4EB6WUZfZoIoeB911gu9ujAjygATj5wQeH03mPR3p79AqOD+GqcNNboEqMG6MxMJLoNklLwwlJYVDwDYCX+XMMPN7m6RCE3A2etT1tiKFqK5atdUM6nq7nazCquhiWMTsAZLhdOhI79NdlZvV5DeVcBD4q1+WbpJYkl6//roYt8G83SYxqrZcA4kUoprgsDl1tmOEkRlgihfUJFl+rxDtKLJ3jO13sJCQquct5E+YzUtr8RQdUD+h/ff0iw2GVnn3HrQ+I0ES4mGU5l5WPpRBArv+j2F7qK6XMSUdYzUylJPL7oXXRfLKsGBXg5AeuvWgmTeUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwh3DI+ms2ZV+gQPd82wEn4OoDb8cWrpS3zE5CQ+nuQNCIJeq5RCRarq2EOly+in+5RtKM/JG9+eqjCsz5GhFADA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 5,
-        "previousBlockHash": "DC85E3A361367ACABFD48BE4CE47DEC1C6C2D8338F2D3498B911E90871C760A0",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:88wRDTjf1gOS1fWZXy/nV1lYyDRabSYzvpFGxoibb1s="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:iO5sh07AwLuaVTVpBOOo2vMEY2i/TZvm84WNuJ/FbFA="
-        },
-        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
-        "randomness": "0",
-        "timestamp": 1689803090768,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 7,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcSct7C7TzSR1U67A7tPtmtqCcuksx27rJLO/lRjEui6C+5nJjOTCcJtrdaW3CExKpZLkRyey5J1sJb1JfSmz+yMWRaJ+IF5T7uBONNQMJ++AUKJnpaEQ0EubMY03pTICHmAPewdLc4JIr5vykFcSnNNTP3lYHyKBVkgWPtuqg4UEsAtipY/Brcuf0n63S10kPROTqj8ix4CGWH8GxGAv9hg2IXqR8QXvIgNAcjwMvIGVEVXXxptyvRzk5PvSk1AkDlIELNT0TxRm7Qjrm7jDJCjbuvTtqhyq9RbhLWX+SszhsgtGztzepk3b3SilYVqlwiVrPUEg3HXO4OHv615JvH8fYcdSetAd5D0sOBGcXluncavdGzUOpq0FB6wO1dIVjs1ZDETfeaGzYuQ4pCY3FVmYTDkGGG65SNk6q1WN8yzzYuUrK3yCwEGAmxldJQcvX7UukVAqooNhE2+NGenN+Tfqyp7G/YOXvP6MhMRSJP2H/yPZNAvJodyLu1fB0tkQDEkxcZrvP4LAJZsCwIw9nAFcKV0Zgv7fUMcE0JHJe9oMctAnhM1P+eKUiSC8D/vmMQAVl/7br7I/6AZdhnVQabUuGm1ygkLitZFr3JL83fpxGA2bO4nOhElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnjxI26ICELr4ma4/ZatsT1gFE/13+upvqkkWmmZzrT+sL8tNqU3emYjJbFYH7AZOb5m36OSNJFRhmJZkOq4KCg=="
-        }
-      ]
-    }
-  ],
-  "Accounts resetAccount should create a new account with the same keys but different id": [
-    {
       "version": 2,
-      "id": "7a4e376c-5621-4661-9642-e996b76e55d7",
-      "name": "a",
-      "spendingKey": "6063beeed20d1abafd0ce28e5ba3af215f43acbb58f5c5e8d0d3e8e9b1060441",
-      "viewKey": "69882cfd35136d2e5c61062bba8b2a1adf27e49ee29cacdc6678a91fb3f87e1c9af6385970140476720e966f1b7119ab9ebd9e302b1fb7d7a049b5e69ca986ac",
-      "incomingViewKey": "16bc275bdc82d4ec9b67746c1acf5e839aea249e62cd1348bb5bc41f7f921103",
-      "outgoingViewKey": "8c7ed25620938b0bb6da51d38d0585ca7973f83d107519e814b8184ba20e2def",
-      "publicAddress": "6f40307e9ca45c7e26c3db9d9de755b96de47a57efa9eaf5f67867865e9919ec",
-      "createdAt": null
-    }
-  ],
-  "Accounts resetAccount should set the reset account balance to 0": [
-    {
-      "version": 2,
-      "id": "bda1337d-0054-49ab-913e-73c57251bc5a",
-      "name": "a",
-      "spendingKey": "a931a52c522b33ab0456861d2a10281ad0d2ade52613008e72a915564f95ea9b",
-      "viewKey": "36c1423bff463dc73dca179938c519b0bd63a0e6ea1383c90cd77db3036aa50bbe98d103af46f71421ecf6fba666a7e8d21a1a2e75ec670320f797f1b2af3630",
-      "incomingViewKey": "9e2f41169190a04bf265f1688b59a14a31a46e587b56f827420bb2fb62fbf003",
-      "outgoingViewKey": "679ae72e2a5e51537b8c72cd37a42a80904b4b6851af4e2c648a246c67616f6f",
-      "publicAddress": "208809fa456123a937a8a7dd98366b0e8e7f52cf31b17709d6965627a345c6ba",
-      "createdAt": null
-    }
-  ],
-  "Accounts resetAccount should set the reset account head to null": [
-    {
-      "version": 2,
-      "id": "3e309586-3433-47db-a2ad-ec9fb4ecc2a1",
-      "name": "a",
-      "spendingKey": "4e221e03e57075c5bf6690bba79895d29949283e6bfe113a6655536fab4a502f",
-      "viewKey": "82395ef9213f006baa1507f2a1817487df8e62b6f9a489b2bbb2fe3091265892998a3919871385098bb974b697821f45583bd91015f9d9593b641ce0bb8d72a0",
-      "incomingViewKey": "def087fde7e30971ef6093fad11587e3c394277f2f7b8752c3b77f960415c107",
-      "outgoingViewKey": "c2f3f68abb466dcf251588834cb5a6edb18c4608b44c679e2d19e6b6c27b9440",
-      "publicAddress": "6536266b9a9c2fa7c8c0218c09216e1d97c717d0a4fd174026734d8be017b74a",
-      "createdAt": null
-    }
-  ],
-  "Accounts resetAccount should mark the account for deletion": [
-    {
-      "version": 2,
-      "id": "1ce71b8c-2ce6-4bc1-8bab-c6fde84872e6",
-      "name": "a",
-      "spendingKey": "79cc385806d7b693700ee4656ec49d2db1b28d5f07e9acd9b9cb72d39adbb59f",
-      "viewKey": "e22a08d6a318b225061a1a9f1986a018873b7770f74b15b5007970238f288209bc898a76dcdde2396de8a35286a83362cd19f79e5752cd68d931ba9b2a567980",
-      "incomingViewKey": "0b44b4b5b9f3deb3d07063b8c6060f52243816b0e8e208745ce046969f16cf07",
-      "outgoingViewKey": "d486c8fa1158571f0bba4bcbd064e8a0ed17a191a7de6df51bb8b4c9b5d5b1fb",
-      "publicAddress": "2a98b597a447c77fe865079a88dd73e24131dc1fc14a91153105b7c66b79391e",
-      "createdAt": null
-    }
-  ],
-  "Accounts resetAccount should optionally set createdAt to null": [
-    {
-      "version": 2,
-      "id": "31c0c02e-59d1-4f01-a73d-6f46f1f7a4db",
-      "name": "a",
-      "spendingKey": "d459952b5c3d8367ba4f4310911249eb3e26e182f76f7ca8a0f26f0728539320",
-      "viewKey": "7b2363bc239e5b86199a4e4d47d877511a8ad0fb3fe8134d5daaa4f563e9f2062c93a2101bcaa3cff44d271405b9cfb19a0b7c6b6165da824c27f32c216d45b7",
-      "incomingViewKey": "2d922a033c61aa24b038d82f677f4d00712119d57bab2ee5378bb23645459104",
-      "outgoingViewKey": "c8f12a137fb2899ce2f7d5c6b7f56752e18188a61b9f2604ed432d731bd18d9c",
-      "publicAddress": "71f1c47161ed1c1b47c61ddd8e3065b8d718e2b4d290aeb29d553734bf0fc823",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:2wnE6B6x7rfdkbgVnpPDT2NfewGSv7YLGiRHw31xJiQ="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:MOB31eiFFxlJ3UgCqnfCyvYSBsbz79HFkullnv1Y0ho="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803095554,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABuKHnuu4Sj2qcUyXT13XljSEnnhzUdJXotGsPWhWPaKitgA1hi/Unk5MxkuAqnlwGwDpwdom86a6SiuNJwjxRsSvjIgc/3COa7VVuXwgkF+m7UfBI+BmJ8bMqxePqzaM2qtbe5GF7n5xZefZlGd5wrszYtHX07BP7LyqxETk1FAXRRAPwV5ZTrfxk9XOJI7Ht5juAsSzM13+oBGi8hY1+rinkPgAPfXvtkzcxCofi7qiCKMkVw3KT9E3sWxOygxjjuEYArluo6z/MfjiveuS1L1m4r+66U7/pYCnMkYIw7n9TrGPqKu/MktgAQg6CLs/xB0L3HGHrQpXMyv8oIXdY2peemMuju1w1TPvkOb0bf/sKycUDRSsQ3EEd9ZEnnQb0XGM/ARglgv40sFzG4eKRQeZreInoB877ntdSKN6M8ZqlxTYYsJ/HTLCsbt1vQ4gCOOrgF/yrEOp1fHMNZsnqQRbF7NGkAaehfjH/wDn/enM72evOrLM8n6ZQBLhPK3NukKKWVdSx0zzbHa/NOuUGN1Pz94tKAgN31DKSOX9Pd2mZglTfm6NiGsxqFb5UKB7icW24IJJfAwlwbnREfHc+MbXpzelNo87/RwkXH7GJyq4OHE6iNBhe0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGrKlyadz37L+rDAqqRxsLO2WNpWalc8fIhIOCW1ert3YATGVmaLWdOTaOwUDZ7Ail4UcOCdnwly+qQTQfHBlCw=="
-        }
-      ]
-    },
-    {
-      "version": 2,
-      "id": "1d14094b-138e-4787-8247-fd302b1b6f35",
+      "id": "fedec4c8-92a6-48fc-a45f-145f4bce5b69",
       "name": "b",
-      "spendingKey": "dda1ce7156252f1cbd0b9fcae832776979a57ac9bc7bcc6488d6cab866c1bcae",
-      "viewKey": "28528151667763b44aed84299e4f897394a8f3064545c9b8ff69874851bd496b973e38100efc0afda7a4da57446f0754019928a04c1d2ec1dbd05d4cbe46f568",
-      "incomingViewKey": "f866b73aa82d4ccb8ddabdb86a382cdc061adf3a5d1a8f605f5a53fab9ec5407",
-      "outgoingViewKey": "17b2b279e6c38673885fc73e6716cba37ff83cf0604480bbfece111015fdc551",
-      "publicAddress": "9c54b09d2bd215b94b1e5e65ba6a014373be24f4a123c0fd3c5675462de1fcba",
-      "createdAt": {
-        "hash": {
-          "type": "Buffer",
-          "data": "base64:IxDBBh+NM9PZI7hJ4WWCf/WpZU/LUQOIl1vo2fn9Akw="
-        },
-        "sequence": 2
-      }
-    }
-  ],
-  "Accounts getTransactionType should return miner type for minersFee transactions": [
-    {
-      "version": 2,
-      "id": "a7773c6c-54d0-4faf-90a3-40d912b6b23d",
-      "name": "a",
-      "spendingKey": "175db8b2fd091fb6747612fd6b4f3106f78b1be835c4c7cce560693b9c9fa1cb",
-      "viewKey": "e7d701165305776b36429bd5087f32f2ab8fc684627cd0455a0e498e4992f199adc83ffaa219f74bd961f6fb622633cb4268ff585278f7ae113fdf599a4c6e0d",
-      "incomingViewKey": "05ee2b74ce7948644e7097e4e29ff8bb185733fb903067244d42c55c41958502",
-      "outgoingViewKey": "c9b0aba4c4f030a0b6792b642fc29e79e17efa9cd099ff2cce48f02579061acf",
-      "publicAddress": "b935f30d002ab4e7219fdc39b2c99224bca9e729e8a4a029ed943f30f92b35e4",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:GzLI/5LxQUtTvfJxJW1AZsoRzW7vkb5hrdXGo9ZsaxQ="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:MwNz6+Huj/ffdI0qfurwscMDmTWe1XL+sVbY65fyD1E="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803096814,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAIBYgY12bUa3Fg6kH84Kg0sKv705JwWXam3MjQm4tuJ2rcSjRpZ/zAXBLyeDzcAeuAsgmTEXaREJeNYa8oHMEpdEy3KMsQY2h8asKF33YQdC4UkRDRkJU43poLvNYSGyhGkwrfMO5ryYiuyEQ4hpqGFdgrVdJw2Q4UFmMY3IdkrwWQ/uwxQr0iSf/VNl5C4SLij984P+5s+TbsO0qyXyBKWWNshhItITe2xh7a46CS8yw7zX0kFiq+8yRsCHaqlVP28bZWSsT/kzihl06f5vz6iQyC9ukuHUWDg3sc/hZfVL3fC2QutCvMk+8k/bppLkKLXaKQSX1w7ToPIM0Ra/ezIKAvUP3vPgcvROxThGbmwl3zq17BLIUdrYhANGE4DtaSCRiKGiEkpZOjYmxOxQqQyvF0XoUiPn2ZCqns5JBWKS5TmboPlFzGhabJullf7UZ+/SJW7qx8rb5wLbRsp0htU8msrwC+gCtvglM0ysu+ep05EvkhXG1mzTalojdgDeDlgJYKuPM8mRsNT/urFlM3XAED/wFZ6u7w7U3gU3CHGcK7MqBoFZ1e5KC3c4ezFOtc4y01Jdu1W5zdShTuhZoWW5fnej+VT8uFeyqfHo6UOEcGmLLf2Huj0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtzurbRMYwO6U1Ne39L2q2wA5DMGRPNpWLrYThiv3wd+RHsbFPamqiR45toaMLVD9QWV44QLBtCfWJgWQZhnjBA=="
-        }
-      ]
-    }
-  ],
-  "Accounts getTransactionType should return send type for outgoing transactions": [
-    {
-      "version": 2,
-      "id": "c20a529f-411b-4de7-9e39-9064f34ac474",
-      "name": "a",
-      "spendingKey": "ea94db0f548c73c86b5f245b7df38256a83e15acf7a8a72f37610ee982bb91e2",
-      "viewKey": "215ca6259c495eb5e686b6b1fde670fa912a97381ddd3f699818c6a1585abb6df96af2b755d2d8a9b1e5e0c97d12901e1d7416f3086ba26826c2819de4038032",
-      "incomingViewKey": "9f5c9563036bb28304b655d7fc503279ddc6b71ef93ec324c8a548b5c3cf1a05",
-      "outgoingViewKey": "fba6fcc9d1c0c4bddfd8bdc9f7c0f0fe1b925ccdd344cdaffb016c8b4d7779c7",
-      "publicAddress": "30383954ee5467ffb71e6de69be55be35b9e166eeed2b06fb2657061038c76a8",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "4d87ccc1-8d68-461d-8bbd-0e1d21ce2f38",
-      "name": "b",
-      "spendingKey": "f66598af560b5c3773e47d3a140d65df99498ffa939d2a3a9ea26cc31de158d3",
-      "viewKey": "cadc7cf2d53377c15aad9a0a43effba2e85dcbbeaccde901f8b97e2640bca0b67147cbca056b16c0e55d47370a952d22500e05427f0ac072108f1f4563918c4a",
-      "incomingViewKey": "22ee364b527e7a47ef301997bdd2d08adbbb8f3a5c2b00833b0ade991b669a06",
-      "outgoingViewKey": "13c7891968d1c6b11f990877e7e9972cec2992deca40f5dd37ca3720c55f0312",
-      "publicAddress": "644ec6f5516464751d74a311b860479998b3e7c7b68e56039c0cc96d699d9212",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:Wgafpva46Bgmk+6rJGa74YLWSu7p4ZTJBu2FBN9mYQ4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:R7EXYqXWkx0nVhnZiuG846f5FxMYJJU6pfmld4Bmxmg="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803098056,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAxVsOH1LaIBA4RFB8vZiKXBhEtaZCN5uuUfwVtaACspWEjpJs6OVtOH9+RuirSWJSalFc+/NHIp3UvjFTzpXN1ES8Wj6iWiJbl+xA4aki69CwvMFsjoT8QjuVu6v6CO6jWv9VWwiPk47NoSDjP0K9nAByOnpMuNg3yD6oNqrS894R3lwbqcUovlGxZwWm72mS220zzAkaVB3oKv2Q4MjlovNhChazvAzya8WupitFfg2svodqg35bwdyjLYMGAHM8Kcr9kp1rcJPYl2RMEi6CLOdzOV22evSwh1zHV3USY113CHjgwVXN7klgoswnYlVJW9cf9swI04BE4ZEL1Kk20P0GfD8oYBzPcHOMIwioZgtJZlx0Fz05pzHln5IgSnEHE2jonwRtKL1WfDLviDBjbWvuRVG4g82AaGwgs+x8qS+pkX9/psN1GaxcgiX4U9ZSbPtdFb9Dcb/7s0dLd4Sko4/qD1RcfQcHY/cj3RdZQgIyEV4nLgqvick474J8J79poftq+16FCr26MYHQCIO/ms7q7yQXNrnMurMck7CKeD75zlmkqsn5Qar8EAXoDMiX/Usuvu4tPBkH9UrOPl1HW8+tfSpBxQV1xZC3kwTY+QEaayxX7pVqQklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw71pVTpPEi2cpK3tIIFiby0s6w7owLh3bOl41+1cwt+2B4tVH5zGy4vDAaHKN9ZYvriJiw8kZTmR5vuVs/GR3BA=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "C8BC1E42975911EF4DAE1256780A8E1DA739F43D9CB713E29CE7B1B2416FCCA5",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:0nSfxOT9EdbsKYfb8SPNagOfnmeNAzMXx581QPgHZw8="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:HBZnS5g5KJLvjEB2EEVrQeBgK2JfIhe3Ol+N9KuDKos="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803098461,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAVAw+JaE4vp3CijOnRg8RWba408slXwX8vQzlYfho4KeOxXmKnhHzlaVbp9LfjZNJGEmrxJkvChmqH/9Y+nUO9Xq8WZmDQafl7GhX1Y8Mb+SiCDrzJie2qit6oRWIP70HHWevACrzAURruaAEioS5LStaSXsqowvrNtjkPLefnbgNdSI77lNXsMduUf868Tw5QY8up/Gt8qtzsQ4eojt9IVg2Xk9aJua4JGaekOym9XmG1KhKRVSgK9wt+UpNorrWDIpZSTOKfj8RiEiAbL6hkrBsFlr5kH6EfyRoe/j9YpmvVv4k/r0jx1QUtaRXtSL6IqXr1NRMrO7weAkXOFWyPVI+Qg0qgIcnUSrcCbZKyHvDJZ2AtNqVGkirEU5tegkPyC8VPFHNfiq4zTwsVUeJ0cc5v8iCImckd2W3RhUzrZK95ygzPxSG5aDc5mYFcowAZoqpnCUdysUti1Olmn5epumxO5sl0QuYJhcmpxO/wKp4V0aXoVWvMZ7s5xzgI0zJu8wuC4DD6Xjqmt4AKTUOAi1rveIacEkuYzfyEhzUXkXUP9U7ILMeZLWXWkqtWnUo19QUqWjF2Zta8NJeDHKJvOP8KkbXX0sqZKir+RNYK9t3f+zXuyHrWUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwPRTZDFiJVOxizMjORDfobthl4YFyR1+E3vwHZCFvwZ7D3aOtYff3+9wBbzNxUFeFA2AXYJV7oE5KjpIoS8JADg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "88A300EFD0E973CFEA8BF4EA05EB9D5E773B3A9A44CD96AC16656B819BDE073A",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:kaKViU6iZ37LEpPBKDJ7GAz3WunH/MpRdBbx5WCguUc="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:CweNIwFkHk/Ag6j3Ua1JtOMmhjttn8yvmK4bQIBAQb4="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803100323,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAO1Cf8t++1Wte8g4PW6UpSlSyLh0mMDQZbJyc3uaRTJKj4S6h9aIwXb5CMq5GsY/bmRsWF2/dPuaqUTgcn3mba6uSsNBgOtX+a1w6SKRv7YaFtLsj/aDwt6BoV0QtmpuuXKpVs8fu0+BISaSWb1RSbC8GlGlY1SjPN1OVUj8SOp8JXboFNZq5/5Xh00/kves6LdFVsrBkWhD/o8sJ8+CzkKT6bteLdqFezAigksPOD0u1hDcEIgNqf8ZVZ9tKnVQJ0OrExsawLYgokQ6Z90dybG1YJ9aKq5o9V0JPQ4w8iV0khPcVfoKxBFbNzo8SNDfIvwUafAenVl0iiioL7h2jEux3Dfk+mVZTtF2nCCjIAR1/E0tb0wYgwCCKboRcKeMFsnUokDcjcFNpF54Uw5znI7PpjKjtpKMBGR8FNDyjX1P7o4QaCLszeHkNWxs9k6FXiytDNcOmwYfgK+y44nXsQcRWByhDaT6IRTZqTQkze1RjBqcuMPsRY8hKSi6oZ77X4FvC+zmG5xWX5dSYkN3/R1lWrb+Ohn4mIF4Uj0nRlZhXU15pGTIsoLdGSr+eXqKhBxLGP5s7ghJqzzJoOOpboP9OyuvWV1pPSNxH0y8TwlqemEA0W44Fn0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwGNOcyQFwm3hiDeZYn636TdViT3UlHfZ8hky9hO05H5H4+414sNm6r3aLvqfyCkhkd1JvkTtRpKrWH7i8ITAVDg=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAVaJ+gWeDpZq/px+uVRA/ZQzeNnL0i36/tu4IV/pEp16pKBgM2kinlNKpZaotscwyP7Uo6zFy1op1zq8zWx8+dRVzQmfy8b6PEDdrURGxYXGvW8uQ8sL3qYIu2XMdREUqvKiD3l1cNk359bv3AUmzvhxQWTMuznZSA0at2yMipHAGnhjuwjtqHRmPBShgeUZffvhvmb4DbVWkHbtSIRgAQ2eu8kvizt0Dg+sBn9nivyKK2a14HUzYpM9A4pxizuVy1vW1sM34oiaeh1ZNmp7J8F8/EkQj1bVXfbMUVs2i4h2yRFLO0s89Rhigj/SmZCBN4Es+bpwVDXiVfWgzWn/YHtJ0n8Tk/RHW7CmH2/EjzWoDn55njQMzF8efNUD4B2cPBQAAABGx1DDYd+92pjxfNbiXwgvsTQoWpWWi0RNQLC9csEqugS9A+t7OcA9C64X/vrZ7i1YknN08xNkLuuDdFxY6ntccqoH9wmUUscD+9QTIDq25MbPba8ieC3JA93gWMrG4AIc4ceIulrkgZmBLQZF/i1jEiUEeEEqy3k6a4XAPL9rJTuXPjC6GH6C2ZyrcTAGtkapgy6gBr3k9OhLTglu14u+cdejiHFwnq45c3TqNcOnr0kgWpyFVJnMrP/qSs4TS8gwNG0hjsZNoCfDTlo0z4Rs/aAPX7JTgLS7o1xfgcsbT7UCedJ4xIbksdbBm0pA6u6oSspc3j4i3ale6CWM0OiptHCwn/15AEzIFUrp3iqUeFZKWmMEzgRl1MWnIGKGjv7XrwoBQbMv3Q8VqVycZmuvw3ZTvM/77gf8xKO6W9w26wRRzdDVwiYRMA5wQXwQ6dBuJBxq7AnjX3Wm3qGx9qjPIGaXAEAxAMXCCUDmQqrKdtS18upfwEJdrA+55jBk0SZJIZonmxKL7/fOR0xnno+5AdN3tooWBf6xU/ZkWdCpyCrbZEU9HG/YQjhu9L0UuWBDeexgeknm+7AwRcDWWtrqlhNTdgtrulroJ7GLfCiJuJw2dElE52y7+Zf1EFgHrMMaoDM35Ze4kXU9EPlyntwwWEHMue6JjRg8CtbAmyjvYlBhKSNr+qCkBLy72Td6p4bmw1+JdCzefJ7j1Rf2h/wS6z6B5Eg4M667P8/PZ19jShkBHzu63wPh70NCSoRiMk9XFkysxF2EpcvTEeC/wKr2WUI+WuDIdH26+lT7nZOoqvZxt34qFdai52DQUqtHDWatHu3L6yhblJJHYZpB8zJUYaoQQ+EKWSc6YJpUSs+MvyGdR6RYGTYOIWQ9boIHMpLWziDdbgG8Ly4OwBvtdtDIXqx2in7cqqwwdE0vQLE5YRd8/zVusU50QZHxJJrrkuO8UM1LmYiKSpdTdIco655MaOLRK0X5DaZ4QpMbPCc3+krS2uOo9kZmqFUSKwuld+k6ZJkRSs+0G2/8s6t1BJmQujtbzk5wh9jRm0uHws29zgRb7qkaA+w+eWLjrbjyHVBEsErHw0FXC49GRkTnkPD81MlIeyG/wlPqVukM2/nZRSEzvljJ0v76fTGdW33i6NwYO0bxfCekvThWsxVpJMDmiz1J1rYBYD+qp+a1RM3co9vseXuA0AyhPmPzlZ2iPTnoSdJOE6CF+oPS+u5Y9QmvWHUL9z+/RQlcDCVEvlLqXS6nQKkz0wEFOc2oympwUf5fVu+B2MaZZ1EeSUeMPlLIeVVGH4iWLbXZpc0raMrDfik702xV5pKmi8P/8YsPHz49gMrY2YXxxc2ZED32xrumyI/pZudql/59SZOB+Q4NmFno2qcgSmLhWyR+4c2OQNG1oz6AOm2zWbcMhzS5rPTjClxSWSGs+sG2l4QH0LW6yetjR39kiwtTfA13NQCZ+wcN2tX9GO2yiVbvYowDETwkjtPG3n5wd4zxr+4JGZ7AArN2CxrfZWiiKMPjPP5DIEoSnIGRVJI5j5HSmTi0euqFFu97Iblfdu8PPT5ymHhiz8wW1rv67/g3AH5nNliL8BQ=="
-        }
-      ]
-    }
-  ],
-  "Accounts getTransactionType should return send type for mint transactions": [
-    {
-      "version": 2,
-      "id": "805aefbf-c14e-4f67-aac7-1ef194e40b31",
-      "name": "a",
-      "spendingKey": "9adf848f6f3334f3eb9b8660055303f3862ddc440f71998be9a75dc62aaab330",
-      "viewKey": "64d18d4c6ec75a33e99db9f230260adc59b8e5d8ba8783b7837c2ccaa41a794e60878ed84f2538ea98139bbdae18c927605fd00500a1d8b45c10904768ba3e46",
-      "incomingViewKey": "03647b0446981354fc318ef40127dc9ef3c9be6d4b8af4ca7ad7a0d121a46307",
-      "outgoingViewKey": "80d6d9c9ab89c13fa55018534818ac6a70cb527011a4d0310fb2ebb8303f0c0d",
-      "publicAddress": "d6f4358bb5953f4a87dc6091178b9e8305b8fb5ea3cbe80c9357edb8efe84145",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:YxS1OsmIVOIPl3hw4KHYxr1A7nmnIDcMA5F21YhJRBk="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:/KuYjdluxEaljqSa8E7ZF/IxNJ9dttN1Vm640NF01NM="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803101587,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA9dfLnh3r+BeH7xc2djyJSZ9slSto9IzTYqIsrdgg6ACSeraFPq21tYK2mDjOzOUTyChYTd4NFJgJZUOnW5K9odGMYQTRVOLYhLZp+Dw59firaScJLOBE6ad/nVmhFXERh2Oj8DDrXwPEKqrBOL522MShyq2Zm7lZVMY/j1edxj8JvPgKoSl8zAePlHry4wKUZiCpH+t4hUG+l/Mpy3QXs9s9fdc0GZW9xPIJB880XvGVp0/OwXMvwSypeQ1Y+o4wjyVIYdfw5V3b5kXFGrqnlXjSG02SblTDMnmEmMrNh6eV/F+Zds1bus8ssyXisTrTtk8soz6c3Uxo0bEtA3LiHSxXpJZwpI+kYIB7Vi757+Ep2rfWdeIwmiQW5Yw1OMYLOSu4iZhgeRTEXBo/YoDH0c+k5VpCDtmfRrVkzIjEb+bvdMS1zv6TiDpoSJUdV4y6JuvVEnEShR+K0jX7nA+qG6umJUocrrL5TCrPXaUDsxtC1FnoEdCxi8ft/HehjGwrqmcOtbrD/Y19mW/5UkLomahegtqF1vXjdYgCyC8LpCF3/2429Y/YZ+sixvlZ1uP6JLA2DuqUeZMWvo2OtCLqmudrYArKhwp6Ht+Vb1Z6EzpIXBx+fzwmb0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhhDAkMgx6pHiMPksyJMXL0ZZce5n2YjDYc3VLeEMj7ON2DHjtKC00zpfJmzeo5x8N32l7PLnPTh0b0bOmGL5DA=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxXqMIg+TVbVa/2ONnypcTtZYkLkBctLeGq3E3dVEPYGJDmUYpGEePqN/TrLcqeQoN/03kVXw2SAz9D8JOv9R7tomKJjati8xKLmN3F15TUSEhoM5lGo+YmqQfIATYJJrc8xEzNMIyLB+Dmlj2Um2W8K/ZSfZb+5rMvfJlL3QPyICcytExxz3QLymH/UiZ/lOC0aMoacWfZQuAi8TAMb8F5ovAIzcpYRxlkNxsF7LNbWBRVcY5HuD3/VSTwYrMzGEpTSTAjqlK0k8uKufDXRyuZtPajuPEw3N/gbvdG7vOYniMHVaRAifBlMk3aahnUGrKywBXxcZMJUJN26v9ng5rx0ivMhEtHXl6cN9jHOh2nTrIuRCUr0RNh5cIOBH2Vg/9VGYdNLgI3DdWmUq8ZaVemH+cpEWfoqfuQNYNFSBEtckZNz1I+REelW7rEyQ/jPHYen2JARO6OB9Ncp6f94UTJ1jKLcPnG8iMOW1oRoy6FFE9QDZsvAyZs4LVlt7eK0nn6uVn8XJV+vhy/ZuMx2ME1TxD/FMxWbDBYouU6qpMTcpkWPRWA9XQApxYEoAUfaLb4gOl+AmK38grO36KOD/AN5B7qObpgVa+NzlCQ8NSGBfH1Msr7DpnwdGeif7iVt41kgv0eEYh3E2NZHkXx7nECnHY38zU3Pl9t40Fv4Rv7GjsF+hrvNrp7KIAtNuQgLr1c+ZxIkxb1+qprmGA9DE8BoiZY4Cj8+Li83o25Hrhh1qzl84yAvlAloTkswcWIpeI35TbJyvOHUSk7EC0fPwVN7lWccPIczijaVyPHuir3mVvgc20Fq+gdQklxepVCFaKHuLc97jRXAfW8MaWDJywfatYzoaDi5nFQJWmkc/79oA9sLGPC7D7PsEzwj4v4KWIChKJ3ZkskI7+yslO9QP/WBByx4tg9p0plbOJaeoIm4V0QHgwFMIs1bHTaWKaSC0yPyWC6M0kTX1jVh1wBHWr9415B6LFEQz1vQ1i7WVP0qH3GCRF4uegwW4+16jy+gMk1ftuO/oQUVmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAHV5tEAE+GcAvm5FV9P0V66PAjlOYQ7BqHagsjfMtPFIK2FtVJ2x8IhWu6ezDOAQAFd5GkLodSKEm9ea8X3csQO7ML0sxWRK9QHMerT29b/pth/mskvbQ7S+yepYvRdXRbJLu+VJdIsxGzFNtEi1k6URC3X7/Fdnu/VAt5fvpTMB"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "FE90C8C0CC42F18280EC95D628A09082C32D220F20E87D9C9417171324B17DAF",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:issw1swq+DiDY+QGUoc7VUDYjedrLf5P6gniAzRSkAc="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:rCsF+7sxFxhwht1mGjOgc3MjbLD/3zqE5TAVV0a9+iE="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803102605,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA6ARQl1sjkElRTfVwKtNZ5rRWLA0NWASwca2RS/rTK4+ZvLVz6FEPYqYjPIcmVZycdFrsl1sr+h1sUGie3V6jQWBG4sGIaFVgqHlP3oKqoRGT49W2le5bAb8Z/+ipg2nh76EvnHzUYNFrjhmp2D6oj5wfjZ7SOrPbcoomtMjNz+oZBqnVTA64RD8NwYFaaz91dgNApFaLPizbQLO/46rASQ37tSP+5TPkIrwLi1a2NdqKCf8JhbgfFJguUVQxk5BJrK3VRcJ62gQIFCrCW/YlWZyroj37HUW79lNjPPmmaz/adeZAIl3miimD2KEgD5qynWj18RO1qnsEg2MrFq2TsgGQHNutvUuHTygnzooyUfoxmtg4zOGFXJAiRIQNgmoKNEcPWzkXIRDSCRRW9I4m2dL980pl/xBN9fgvCssByCw2qegJPXJkBGnLSdmGR90nBxEOx5epK0rT8BTOsnC84SV2sL5J8Vh8pEW+qOV+0hPluYN9SvQgiL1A9cmixSJ5gSZFuTD5+3AN5mnvfnTeqoua3mROm0P/tWx+cst9beHWfid/tWRKRg1E4Lz2e+wxAywILdqMEwBkjjFeq44AcZ6RIZHOgRl8rMaav4RembwApt19pJMjIElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1O3PzzFak3vVp6b8Kz3SjBzke0twLthSC4wcyL7dFd7G8Bxs89MJ63I5bJkeOwdniPvQE/hvKhSM+UpZ/fxlBw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxXqMIg+TVbVa/2ONnypcTtZYkLkBctLeGq3E3dVEPYGJDmUYpGEePqN/TrLcqeQoN/03kVXw2SAz9D8JOv9R7tomKJjati8xKLmN3F15TUSEhoM5lGo+YmqQfIATYJJrc8xEzNMIyLB+Dmlj2Um2W8K/ZSfZb+5rMvfJlL3QPyICcytExxz3QLymH/UiZ/lOC0aMoacWfZQuAi8TAMb8F5ovAIzcpYRxlkNxsF7LNbWBRVcY5HuD3/VSTwYrMzGEpTSTAjqlK0k8uKufDXRyuZtPajuPEw3N/gbvdG7vOYniMHVaRAifBlMk3aahnUGrKywBXxcZMJUJN26v9ng5rx0ivMhEtHXl6cN9jHOh2nTrIuRCUr0RNh5cIOBH2Vg/9VGYdNLgI3DdWmUq8ZaVemH+cpEWfoqfuQNYNFSBEtckZNz1I+REelW7rEyQ/jPHYen2JARO6OB9Ncp6f94UTJ1jKLcPnG8iMOW1oRoy6FFE9QDZsvAyZs4LVlt7eK0nn6uVn8XJV+vhy/ZuMx2ME1TxD/FMxWbDBYouU6qpMTcpkWPRWA9XQApxYEoAUfaLb4gOl+AmK38grO36KOD/AN5B7qObpgVa+NzlCQ8NSGBfH1Msr7DpnwdGeif7iVt41kgv0eEYh3E2NZHkXx7nECnHY38zU3Pl9t40Fv4Rv7GjsF+hrvNrp7KIAtNuQgLr1c+ZxIkxb1+qprmGA9DE8BoiZY4Cj8+Li83o25Hrhh1qzl84yAvlAloTkswcWIpeI35TbJyvOHUSk7EC0fPwVN7lWccPIczijaVyPHuir3mVvgc20Fq+gdQklxepVCFaKHuLc97jRXAfW8MaWDJywfatYzoaDi5nFQJWmkc/79oA9sLGPC7D7PsEzwj4v4KWIChKJ3ZkskI7+yslO9QP/WBByx4tg9p0plbOJaeoIm4V0QHgwFMIs1bHTaWKaSC0yPyWC6M0kTX1jVh1wBHWr9415B6LFEQz1vQ1i7WVP0qH3GCRF4uegwW4+16jy+gMk1ftuO/oQUVmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAHV5tEAE+GcAvm5FV9P0V66PAjlOYQ7BqHagsjfMtPFIK2FtVJ2x8IhWu6ezDOAQAFd5GkLodSKEm9ea8X3csQO7ML0sxWRK9QHMerT29b/pth/mskvbQ7S+yepYvRdXRbJLu+VJdIsxGzFNtEi1k6URC3X7/Fdnu/VAt5fvpTMB"
-        }
-      ]
-    }
-  ],
-  "Accounts getTransactionType should return send type for burn transactions": [
-    {
-      "version": 2,
-      "id": "7414cce3-9f99-40ae-a658-456b5ffb50ae",
-      "name": "a",
-      "spendingKey": "01a13671eef123f9fae6276a2b9c504d770cac3879e37b0942c8b9d8ee009262",
-      "viewKey": "a6fe75cc9380e4eec62fcdb2e8ba65d251da9d650cbd27b675a411cbc0d3e268bd8bce3624f338d806d48bf97d08be675d4e43a49fb86abe6d4c16a102595108",
-      "incomingViewKey": "dd73ce19b9e42bf18605505cfcc10d143414f89ba09165f9ad497ed00c5d4a03",
-      "outgoingViewKey": "70e6a079e30ba7f583220f6596751c536bc990e93169c721f9ce7c44816c8097",
-      "publicAddress": "b49fcb7231d2d4a8f0fdf98a833d6b68102e6d2ee5f5af824a87df9f99c8dfe3",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ovf//0Q3lGbOCzrJbF44XnjnfXA5WzFjIoUv0qJ/KAg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:yDQgl+7fg67eLBsOM2WenOvCVcjJxNVwrU2hnyqpyyg="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803103897,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAjV9clTGh/a5BE+QkxOfG8bZiysjm4MWCJwSPYS8qAGuWAodNJZz6YeZRW8z1bK/9WCYalNlFqmVMvCmYuF6PvabJq14Kx1VvMUDx7XuZxD+i2JrHnpQW4+fmhxzvX3RpRNqNfiu/iTlTlB0quYnesILaoyk0znjlwYrgdiHI6gkWqMnVQnkmb2VQ82AaccQIjFJJj3nhHzaUjfjjyq7U9FcQlpckxZ8SFsD9KVsFGGGiriw2wWVE0hxVr8nE0nF4bxPgm3Hle35tRZZwqz8FtB/V6JY8xhx+A9lV8GQyI8wjqSyTzN5yIHzLpiv+KUqLx2egxTNyU3HRhlv+J0LdqYl1/KhhkNF5NeGfqOLpAmlQrQNw647hV2vkNJqn2Hw28Ei8x3JXsMjnC3yFEGZeRK0LNGAibHFH0ZdZF9yoHl5Q0lRaUQAT5/QnVo30k6b0WlmaCqalh5I8j8cT4mbbwEezuaE5afkWuv8K67EpD6ID8S0+Tgvs+xdF8WHsHxzPSrh6Lhs8qZr5XkfI+oihvwfSR3UJvdRsjHrHDEadPMZcR1CR+rW7DrL2EywWer66SB5WPE/rJJkLbZExXswLl5j+AojQz4gyBDFpOzqpPBaIOvm+WR8PqElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3CfIXKhIKpwXsSpgprBsOjTjqD5mKme2FuUApOv9ylJrL2Njdi7B/bwi5WoUwObm7Zx5+nozy1Fcblo+EjBDBg=="
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo4JVnJY8RsycVRXJC+CnseQCr6t8ONqZ0N9NPxPV+EmuPRloTWjoD6gyUC1KqqKa5/tQpBOF3n7OyMxmg4fRmY4kNYHaRE/LgEOzV8TNamSVT6KVRQjVb4sOUAXJuWAuNabWHDKDPXMv9XNmYwoIIRxjmpHV2D2eSMGwcTk4F3sHIs4oQGH5mObajmY6HWrBTmslJyTYBgU54PzlGyiNtDmNj/7QjibqkOOyTKXP8paAljsCPIxxRmnG87ERiwNQoYLFLeylokEpzBIV/yuItM5Bv+W1y4rmY6UiVooOSUX77A0QOCaLvLo4BedlMsHJRdu1j0Rhn8W8VdnpencYEiMG0GYh6p9/qIKRPv2KwpSb89yBfEWR6qOvWvhsZ9oMuKJ4NtT5eusVwlUnnJzKe+GStlvDH7O3Mm3z2SEjtQCSP/bMhhoZ/VcHTa6z2CIZYdqUrnQMVnleityzaT6pCdSBC5tvP57SDDp0hBvgxL612MacPtZNL0FrnnUtll2k08Ny3C9VH/nvmTmSp3vYfZFTGNfyR6FOy6p11XmxaR1Ahd1w27FKizQY6W6QX6S36k1QjZNnSyToteAIr2BNt2/4lo0cNUPT5/xsQ9CmtnKLQ28ObRspqHnok0/fduwISF090nFNgOJlkj26FF7c3JPIS1DAgwFhTPyQuWT8UDkJkgZVDRLFUB4D5oOWe7gfyNMvIL1dzQfBZxTx4AwnSD6LxATlgfWos9XlVwEervWH9Gcx5m8P9g3fDDdx7GDr9Eh20y/o5ifaeq0wdkDg0ySD+jKIEMKag5HNX9G08lHlAQpsm75s1E3hS3Y1T8bJ4mlzsmIwAxZ00gN1V2W/NXiG32v6o1p3F6hM/8l0BNZ/0Q1puOyg/DG52E4C6vyWNm4UKRJDJSMpQbnw7mIjKgpbnEpoPwlcjSdZcJyj6/G1V5L7pncHxpqyVM2K8jjv0AMRyi30d3GuGOKODvetBbKXDrehhULKtJ/LcjHS1Kjw/fmKgz1raBAubS7l9a+CSoffn5nI3+NmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAAGXz2jgLVklD3N4Egv6tPouIV574scowvCWS+ilR020tFXrIMP+Dg9RljGCxSDR3TxmI1JstYbvyMbPew0U8cQi2TfPKCkN+jP3FKmLnhdVponlWK+skNRIIpChbeU+/q2r2QB43pp7t3H3prDUElmKGxf+I5NmnzvIemgdJZaoA"
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "F30DDEF8FCEBF5FB1F5D4690F8A3FEF124885E3969C27313621E18C88C1773E2",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:t96vLfSuWQ6BP7kW7ILZt3CQVMZEfAIfMYKGvXiazRM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:MxOeR3meKDkgA78AqUjo+X32Z5f/C/KzQPLbgxx4wWw="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803104943,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 6,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAu4SrfpFRxJaOgC2gat8Af6qx+ZIkrGqQCVUgz29nB5ODw0DlaV1/rLGkA33NSrZ6d+n3Vd4OmpLYb8OSnMp9OIxuM4kdxpfNmxFwgBJf0oyAanWSlpJEQ/hQU0wFYD1IHvFvqIrBd/9LeWuTa97UlWNyZcb8ulrw4MX9uzqnGf4LSDWtOyFh4xCPIknBYA9Z4S0BPQlk0OpKoG65obCR8jRG88zrgk8D6PZb1Y5HjguNINxoleXwPQoB8A2UCsXC2zOogsXCi/UMeARbvnSFDGIHXZYG9bml+p6TQoo0fqPzNWUuOZq/LiTMuf7PXOMUevmAw37xXPr+SyHIa26Iu+tB6n7bk2an89D1wFkw/JhjC/t2yTb7Lno4gw8c/i1GsjKHhwccsezriRcbRzqLNsz7dWXVXFTb4tRF0sIdPC/jo0qvkdkSitXTaTLHX8ckzlYnqobL+KAzl7wGXyMYIAANexzB+Qu6vUBMnrUYqirUlpEI2PJ5nAismc1aXSYgEBeRVmAxpoZzhHhHQDnRelSZrgeHlm+A/n3HbKActxqBwieC0B34pBmm8xMrFesBHKBYRtE/OX+8FJUI2D1hQ3VK1IslyAkElnm1kKOrT5GlnUtXNip8/klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwqP416TCJHZc8qyxgZSoMmgy/ykqWn3ENZLMsKHg3I2YVfUyDjY9IcFIzv2kev53D80c4I4weJuGKo+FRdI6uBw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAo4JVnJY8RsycVRXJC+CnseQCr6t8ONqZ0N9NPxPV+EmuPRloTWjoD6gyUC1KqqKa5/tQpBOF3n7OyMxmg4fRmY4kNYHaRE/LgEOzV8TNamSVT6KVRQjVb4sOUAXJuWAuNabWHDKDPXMv9XNmYwoIIRxjmpHV2D2eSMGwcTk4F3sHIs4oQGH5mObajmY6HWrBTmslJyTYBgU54PzlGyiNtDmNj/7QjibqkOOyTKXP8paAljsCPIxxRmnG87ERiwNQoYLFLeylokEpzBIV/yuItM5Bv+W1y4rmY6UiVooOSUX77A0QOCaLvLo4BedlMsHJRdu1j0Rhn8W8VdnpencYEiMG0GYh6p9/qIKRPv2KwpSb89yBfEWR6qOvWvhsZ9oMuKJ4NtT5eusVwlUnnJzKe+GStlvDH7O3Mm3z2SEjtQCSP/bMhhoZ/VcHTa6z2CIZYdqUrnQMVnleityzaT6pCdSBC5tvP57SDDp0hBvgxL612MacPtZNL0FrnnUtll2k08Ny3C9VH/nvmTmSp3vYfZFTGNfyR6FOy6p11XmxaR1Ahd1w27FKizQY6W6QX6S36k1QjZNnSyToteAIr2BNt2/4lo0cNUPT5/xsQ9CmtnKLQ28ObRspqHnok0/fduwISF090nFNgOJlkj26FF7c3JPIS1DAgwFhTPyQuWT8UDkJkgZVDRLFUB4D5oOWe7gfyNMvIL1dzQfBZxTx4AwnSD6LxATlgfWos9XlVwEervWH9Gcx5m8P9g3fDDdx7GDr9Eh20y/o5ifaeq0wdkDg0ySD+jKIEMKag5HNX9G08lHlAQpsm75s1E3hS3Y1T8bJ4mlzsmIwAxZ00gN1V2W/NXiG32v6o1p3F6hM/8l0BNZ/0Q1puOyg/DG52E4C6vyWNm4UKRJDJSMpQbnw7mIjKgpbnEpoPwlcjSdZcJyj6/G1V5L7pncHxpqyVM2K8jjv0AMRyi30d3GuGOKODvetBbKXDrehhULKtJ/LcjHS1Kjw/fmKgz1raBAubS7l9a+CSoffn5nI3+NmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAAGXz2jgLVklD3N4Egv6tPouIV574scowvCWS+ilR020tFXrIMP+Dg9RljGCxSDR3TxmI1JstYbvyMbPew0U8cQi2TfPKCkN+jP3FKmLnhdVponlWK+skNRIIpChbeU+/q2r2QB43pp7t3H3prDUElmKGxf+I5NmnzvIemgdJZaoA"
-        }
-      ]
-    },
-    {
-      "type": "Buffer",
-      "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAA523au85kbYr0NXgad3mZHC2wFmW0SnDYDY5eu1mNi/KiXdJFswxU5Owm+7nq4L9M2W4MO9aSZX/kNXFIudO/aSJmaV6vorZObsCiQRhfIXeI6BWi+KsseiW7FUbRzw6Jzgi+jT4CuXnOLyM8YZS2yDfeDsMJGP+LKgw2nBDCmSMFTOm1IVChGAUYNCSa4MaY6dSR3++NcC4l3WVLm2DVCX6bQEY1bJQQJyblb7RYvQ2YBK9zzFKZxf7z5hq+aFg+PqNdMAEdUQdTkmMShHccxu0rjmM3Y1ZTyNmQteT7Ww+iEuId4RHvJceY+7fNkLDs/jzy9/24UgqFyn/fhknaaLfery30rlkOgT+5FuyC2bdwkFTGRHwCHzGChr14ms0TBgAAAHAkVeqP34AwcXNMZf5p/YZ1g26uuGasC28e78D9FyuhCX1FuUuBauYom3bRzl6rzH+9WoFLtgP3XWU9zjIrO6ZPEZntOvTX0PfUBqDR6UmPif1svsO+Dnxa+e3TNyWiCoxTaUoDYzVHOHbKX+k/MlahD4dGjGNcHeWyNvQA6hEtF094o9wpjvpXu4/qkeud8bdi3R9fN7IBvMYW+W9f0Bay3QJG5tnf0vfBl/ZKDMNCXvrb6YF6yd/eqX3HE7X0/Qd3mDga6xniDbGNiJTo13rtXxaCry80MrkcqYfrGJ+7X2+hyFVXWEP1wcIgNvv3G6VC6brZNHHY68+KcnwNkkon5vdn8EvjWGzDfLn0yZ8j03UsgnCHPv0RSjOZEwf/v/XZij+jxeoigkrIqGzOjF/Ki/dKf6dtTZ7NMG2Xk/YNdvVbrsrAmvdky4ERnoM4MG92IfYac6UUbX4xuvH2kUvcbzKliECOO0nv5tnprJ98BVy/r85WcDOb48zMKwblUTSAZp57/jWvUdzjN5bPL/przow4eM39sjR3EMrF7DAvhf89xaDQuhCYPs8t0ztZcbHEoKeH/Hbsj0DrPRfYerQscKiUg5rLqUE8Jqg4zUOnMmnGj5Ez3NgrQ/gJjUk8x/mmbDVDd8ALt5dDdEnFjO/SSrn//Wwjw//5TnZmaI33HUM8CRv+iKBPaNOQmRfFkm/9M2EzgS9wPbPGWVDDZuZdDp8QnlR2EygtIkhY20QLg+9rxkJGGjh3dPDvVpKYJx90BVqeN5WSIu9sGtxS5Jjdmx4dVZKjWmCCehIF3z3QTo/HmeOaF7nT5fDXmFG4OAhVXRac3OQnK4E1YaoDsTJbadfCE7D0KgIAAAAAAAAAej9N4MZgkg0QTg/FlDKAVuWIewQQxxoxJrNEMSJOablNjYksQB9XoYrrQfNyj3//cgKruwQ2axgLhpNvEfjKBw=="
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "FA97798B21E6DF3794F85924FC723E9140E32A821F4E7C6F0B01D4DAFE006E5F",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:n2Fo0Iq6mAR5Pt8rO2PKU79E6x3LDf5239Q78YrfnT4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:eHzb1/dSAAzvbvLn/fc+1pOhPV7tQ5QgLGlJ76Vsg14="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803106501,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA8E08wy21hjPR6BGo5vMSuUDFIFtZlnw2wjMeVBkj1DGhQT8PxNFoSMjcj75hdrJGw2KOdoKA8HqxgcLLZ4mFfl9XELbMQV2fiTYGjVqWyzakV4rgVqzIq4PNwQEeXsGBYgQ7/hGYVjtHAA63TpRIVAOTXv2xO5GHyRUqG1d5y6sR3jolCGDvRuFsy5KbOgrnuiALi7d4Eyxj1uEcKJwHt8AuOhwovk5mwBXebOCj4bWgUchfr0L4uWDO06H+kxxxl4VHhAFtTn6l1iUQXtvnSKuj3FEL/qKtEOJs95OhjiOOxR7QrldWLONhPb0nlNSKMnG2kVA6wGBMHftyOoJ9GA4raeFkHpxM1yWehuz0IACGuu+owUdidNpB2Jf90/kFwhMMk6t9raw/muTolzoztOzO2DoT4OTIc8fPluC6sGzZP2CKNt/pgPoezPPG1RtjggOiJ8x98WV3Iy7b7SxiVbXGVge2R1B9zQEtUNQN7vMkuveFFF/iZ2RUgmwu8K6kSkqY6OSnoU2MpM8j2PUWlyM9XVVDhb44RnKr8fAeiQn4yhA+IbJdHJ5iQ3s9QL1M7kY6czChkjrGLtXbKgdLhriu3se8myJxlFC68xgNCJkuyyREPD5XoUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw6n+KcOEUMt/iYhPlOPSN9WXDs40mlo+1vJbGHyn+5cE74cJ5l01DNLDzbom0Y1tF1SntfRrmY+hhAhODVvcgCw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAA523au85kbYr0NXgad3mZHC2wFmW0SnDYDY5eu1mNi/KiXdJFswxU5Owm+7nq4L9M2W4MO9aSZX/kNXFIudO/aSJmaV6vorZObsCiQRhfIXeI6BWi+KsseiW7FUbRzw6Jzgi+jT4CuXnOLyM8YZS2yDfeDsMJGP+LKgw2nBDCmSMFTOm1IVChGAUYNCSa4MaY6dSR3++NcC4l3WVLm2DVCX6bQEY1bJQQJyblb7RYvQ2YBK9zzFKZxf7z5hq+aFg+PqNdMAEdUQdTkmMShHccxu0rjmM3Y1ZTyNmQteT7Ww+iEuId4RHvJceY+7fNkLDs/jzy9/24UgqFyn/fhknaaLfery30rlkOgT+5FuyC2bdwkFTGRHwCHzGChr14ms0TBgAAAHAkVeqP34AwcXNMZf5p/YZ1g26uuGasC28e78D9FyuhCX1FuUuBauYom3bRzl6rzH+9WoFLtgP3XWU9zjIrO6ZPEZntOvTX0PfUBqDR6UmPif1svsO+Dnxa+e3TNyWiCoxTaUoDYzVHOHbKX+k/MlahD4dGjGNcHeWyNvQA6hEtF094o9wpjvpXu4/qkeud8bdi3R9fN7IBvMYW+W9f0Bay3QJG5tnf0vfBl/ZKDMNCXvrb6YF6yd/eqX3HE7X0/Qd3mDga6xniDbGNiJTo13rtXxaCry80MrkcqYfrGJ+7X2+hyFVXWEP1wcIgNvv3G6VC6brZNHHY68+KcnwNkkon5vdn8EvjWGzDfLn0yZ8j03UsgnCHPv0RSjOZEwf/v/XZij+jxeoigkrIqGzOjF/Ki/dKf6dtTZ7NMG2Xk/YNdvVbrsrAmvdky4ERnoM4MG92IfYac6UUbX4xuvH2kUvcbzKliECOO0nv5tnprJ98BVy/r85WcDOb48zMKwblUTSAZp57/jWvUdzjN5bPL/przow4eM39sjR3EMrF7DAvhf89xaDQuhCYPs8t0ztZcbHEoKeH/Hbsj0DrPRfYerQscKiUg5rLqUE8Jqg4zUOnMmnGj5Ez3NgrQ/gJjUk8x/mmbDVDd8ALt5dDdEnFjO/SSrn//Wwjw//5TnZmaI33HUM8CRv+iKBPaNOQmRfFkm/9M2EzgS9wPbPGWVDDZuZdDp8QnlR2EygtIkhY20QLg+9rxkJGGjh3dPDvVpKYJx90BVqeN5WSIu9sGtxS5Jjdmx4dVZKjWmCCehIF3z3QTo/HmeOaF7nT5fDXmFG4OAhVXRac3OQnK4E1YaoDsTJbadfCE7D0KgIAAAAAAAAAej9N4MZgkg0QTg/FlDKAVuWIewQQxxoxJrNEMSJOablNjYksQB9XoYrrQfNyj3//cgKruwQ2axgLhpNvEfjKBw=="
-        }
-      ]
-    }
-  ],
-  "Accounts getTransactionType should return receive type for incoming transactions": [
-    {
-      "version": 2,
-      "id": "9120d4f0-af26-4158-bd44-e99bc7094703",
-      "name": "a",
-      "spendingKey": "f690c73d4d0b5521badf0d9b67116d5a18763ba787e258be87784eaba3f222f2",
-      "viewKey": "43ead379b0d75f1674eab90384ccb60702e0c2e26eb5925aff6bc4f07963353d22fa7ba8ab5b96ad2e0ad3f75af18ccd10b491b3d2f553abdc7eae69e3cd86d0",
-      "incomingViewKey": "1dfe47280f81d5df1b87996fdf7d537010901417eea22cb52ec97a693bb81f01",
-      "outgoingViewKey": "6ec3dd66dc8ec03575f8bed2b1c398416080b6fcb3a631c3a33f915a8cc1361a",
-      "publicAddress": "1522e95338d30082412384f274de8e213a734867e305fda658fb3562eb637f19",
-      "createdAt": null
-    },
-    {
-      "version": 2,
-      "id": "9321a174-ed0e-4554-905d-3d83ab616b7e",
-      "name": "b",
-      "spendingKey": "ca8189d5989c20395cd0871fc418bf2b59f9b412aa1cbb1ed9568950cc158c29",
-      "viewKey": "e3fad1b6033a8aea51c964743fb181c46e43bd3a928b62694fc0d8791e42cc5d954b55ad95f5e5996f7ef056baf7600bfde471d802060796a90e5a36cf73090d",
-      "incomingViewKey": "80ea1e7204b4be9d61cc38e43cdd48feca947f2161858bde437db4e412b44a06",
-      "outgoingViewKey": "72e934a5106e67362ac07b0cb72057f1015197fecd7513549ca703370ccea978",
-      "publicAddress": "a9c415f8b94933b921e881bbfa64c767d8317466c2f3c6805bc97b54c0507a52",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:OybxF6ewwOUfZpZfdFE7iR5oYKo190M/I10XnRgBnzk="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:VuHXPNr5rwlsGtjIlH86i+YsRVG+yqLQon70yEdjKUU="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803107819,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAB7eoWq6pFOHx4VTqtafo6W4mzm/p51HQm2lCd773zWyhf8IiQVSd1pFKsI0USvEmLJeOYRJBmpWRM9vLwsVlvvVbVdM4WgHdmn6t4uYCGVyo2m3Ngr4g42C5OCFx8OhxWMOkzBLGFjfl3voNelSfHaBqAjf81zXVylbCDRNb+CEVFp+nUK/iBuWLBIgOAIlHN0YNnmneK0Jutx486VxwsurkohozbQqq2wDzZ9trZGW15ua5npBzENRk0DYO2xSWKboAushsUv4LhPVXBSLg/vu+cry1vPFLNjNMTu8AsYg9Vw4aEcORTubxtucdh/hsGyVtsohBG0XrQJah+qQ4TX7Y5pbk7FcZTPrcfXlD7tBQAGvLgavjybnys6voMPVOj05G0iegCp07llYAl+akgg3P9AN3BL9J7s3jFfTMJ+keZY2TGyO3kMvhBc9/XrvriePXysXqLp1tcXV/CKIY64cqG4ROAssZsEm83obcBYy2/Zhf8WXBHiiQCK+T7IWMhbkU4dZrzulQneDTUU/JDw6BKO+f+KGy8N2GFL0ySO4nALshL9h3Y59yTIN07qb0GslnbPbyJ+WGhxHRoUqq/qg4c43SRMd736iXOn/wzkErXcj0aH1jhUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwax7HKvCOdgRkEDHxLvkPljTxQk8x8sI3nzYHoYLz2xyFPRQ9qaRvF0oWQZjex6LOGS4ncVw+6jXFPyVS7LAFDg=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 3,
-        "previousBlockHash": "06E41E8469553921D0E01B5393080B99C2CCD6B4E841E9D52A775339574A2602",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:ECpSTr1+LRduRwesMTfy4DRqPPB5ozJVj73LOfTZOj4="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:NDGG+O2i/1Q62L/Bhdr/bZA+wnrxo1w+t6lGKAA1uuY="
-        },
-        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
-        "randomness": "0",
-        "timestamp": 1689803108225,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 5,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAHWIlWeGSP0YPYCe4iFTNjCMI7t2k3xfYuUzLdaYesN2FIK3aCcRujsk/HcuhDly3uPaHUyPzWGyIys2o/EHzcGzEw0Hr25mpribsiSuoWXmtcQyopkFLsmUse5qS0hcR63T+xNa+o6xyar6zLfoG95e5bWZvXet8TpAcM/xbSWAGQAS05Iyo2jIkiHZOexncE8uCPWQgqkUmAf3H3Fwwd+XMeUdGb+ZIIh0QLvsyzZqz4ktJZGZrSlnTx88F3E984KpqosxMcy/At4HgBaUxoebUS+OWNFR55AWMbTWAFTgo5A6l9K/qDR1bhzawwhc0n8nAO57lGQJW98h6fyYbbVufQmGhEmO0cH10+op8XfcvW3bCoUqsAtiXJp6EwbhYacQHunOY0i+CbvmMRpZff0GUWa/Xsuf7WLbiVhJKL766qSW0YPG20P4smhBflt5MmlMBBDgSdw+EBMbp+o7hwql62acFf31fGP+sQyHuuEZO1n3BCMb+2e35P9Bf72FBxAtCMCpb3259hKtEo4lD5R0V3MTK7KoTDSeafQdHx02pr/GZIPJaK9qPvzRRRBh0BIaZDknlnKjFIngnoNICJUBUqFVL5hPKdRH4gJqpieWxNVcRCTjAWUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwzwO4o//4hX+xmOMYBK2zywCFwKL1xni8TDggCq1vgavB5MXYiTIM9jjfW4ZlQ65Mob1FOl02Z65TNvDF6Wv4Aw=="
-        }
-      ]
-    },
-    {
-      "header": {
-        "sequence": 4,
-        "previousBlockHash": "1C85AAF7031CAB900EAC981787ADDF31370EA07F11B7161A58484C00141AA0FC",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:+bFxehuNgZP8XZOBdK4gGvzx3r6wAUYqHs3igAbTjyE="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:RiTmyN4WCiW3zeQmJ2BwKJ7dtfEHDpXQXOmIpUqMR00="
-        },
-        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
-        "randomness": "0",
-        "timestamp": 1689803110144,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 8,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAARnoZ07VVpVOZQqXfZniUf6rlUQAPBj0Q20YPPVmJA1ejqtj/LKDpmM+C8vMOOPzq18V62TI4A+E+RCDAg1RiwDdvlTLC7+Warv8JzPz7pzqPsaIcQ/tYTwHjzTKkA5639Ffy8BImsvrzncTX5zAXTWIvDCRNP4wMPFsYFcXPJnsCCNIswNnHMZzEErzp7Ah9T/Zt0wIpfWw1X1RqwHtW07NGJYOxahhxg2R0RDcQKDW3sPFzRV6fb9gaFua9541hUCKjqCBKsIyrPKDmEAhC7Id3NZYVoN8LQp9DkwXF0V3kWo8vD1bHYonVLVMR6+gTQ4yQtqXd1QAah0QKOW521nD6JxvgtV1vS4QraiSedz7wzdnqRIcsvx2Mdls/buUHEtQVyq1MDOn18AJ4PfYCaRh+ntusye95g6k2nT3UZkUbVaADlLBsa/gTSvPT9aSLcRiiIHar3lldc1Efe+sArQjNZJJwCYc3gJYx9PL/jHIQz4CJYnoZgUhXe9GkWEO1Y3aNitgF3QFzYJqWybvRrZqgGBZbwsaKMbAqdi8WMe0Mbcyxp2D9/U7NerHgA3xHrTsPFLt0HX1PImm+uXGqHLXyDWJGQnQR1wVtRQBCG/NqNpU/GX1WFUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2JuJeYETQgr2hJbddT6DNr9+639iM/X3X7hYEJ4f2qE8eVVa5qKpXterIoQtOuLMORFXl052sxeihp8jZVY4Aw=="
-        },
-        {
-          "type": "Buffer",
-          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAYifW/WjyKAZEWJTIygQ/NISl1FSS/yrDEP80/cnBU6eCydQdgvvu1DFn2DpEn4LPWJwUZeEEmyYVBAxkvGxon1jRYHq2oMTvJoLY1cRupC+Qg6rWQpdFGvyPoT9Dihq5ntJp4/qWuiQYfecmPrITp71PonM8yt1C/Nl0TYzrI/UQLz0+suE2fhv+t93D3zXU7tnD83pHg3xWqqfKdAVV9oe/P8i2qp3S0zJpBf1/ZXmtjtucuDPlVAb7iiD8hyFBYHgcSlz3zVKrKAnqKCK5osTLD4tsk6xAus3q1O6Lm4XQ3/jgyC40neU9h+34W14oqjWbIIEElMAe6F0l7lxJIRAqUk69fi0XbkcHrDE38uA0ajzweaMyVY+9yzn02To+BQAAALLfg9OLgdqtYedIlkIEF9clPUdLSLcQo6roT56f+i+ixaQ5QbMUoe7PjLVtoMdFf//XszgNpA1mwa+Lxrjuv85C7NO8G/3/FdJ3fQNZAldPCSS8iPjlS/S12PRRlctjAKw33QDBUbuXB3fwiExIrfrLgYhIJm1WEE1Le17+QxICyO8JRn3DAmz8CpqmavX5xZMhzE3WcyptPgs9fUTTJ0ZfO3AWmgaprSwnS5x41tXtjIPEudI5ujhk3N2OX95rZg+u6EJZrFlqE/KpjwyoT/sRwJN/im4XENFVyRBgyie14sjk0dLywbhmqCqd+wmgt66UHagBPIA5x9ZpmjNkbZ9Xl3U2GEMOVEJgA+o3BFTUyS9J/Wb54o+2Rx8A5oMCmq480C/w8iyj7yLzujYCb2CRsOvUxDFJMgBr1HlQlLu5wXbdiS9zJjg/N7S4XbSZba/5gzjzjKuHaKoyVFYKjzD2VVD838BsJqbN+LmDZvLkfh6aJ+OLpsy+juQ9bka2N7gMhVLSzCRcqxwAZQwEaTceZVxRHnkJf+OkI9fJbl1M7AcoaNtb27CfNglRwQAQUSxdI8jwYx+pCReePcH5yEFjUqzfFbWHPa+LiKbhI7n1j8hZg80FS86rNq9NKnb6dc58XWw0kuuol9VR1gMpZ5D7cg1LXpuoJUi7XpbNZXaBU9cUeTugiXk2Tz8FZo7hm+3In65jO26SRgBdUxwt3Gyt/XeTvlbVgzf7scgjfXnEfux3nrCjzWIUfabT6MER6KSYRgDZFiBbyekdVNVD67LbGIAptFLp/88ufNNF/ZoXEd5P+YoT/Q2LNLCiDJy9Gco6uc1rg1M0auvfRGa0TEAx+q8UKdejl3Sxwxq05wSg2zbiLfHnYSiwum6D9U0OY9yGljoA5bCAC4uA+23eReaC6asrSIUjRTrJfwVZppfgCG/l0NbpWp8PoxKF9kfTCYVbeiVAHSmhlOyfQn7UEhU6Wcx3TnmghOVdmV83Vh1GLlgd3qpruQuU7PnJw4anUn1nQ+VUiiuO0kGL0FQhbUbG/CMBmKmfs5uzN7w2ASbOPMzBOJM4Gg6CsQT6JZOc/av9kJSjoZyqIeaVt0Z8LRl1ZZH/EZ6tup5cRhcJTRn45SZ4bI2bPx3uzmMtIIpDzrF0BHdyEftSMkGwW9YZpO8evsxfDCQfjOu4huVDt/7s9Rg/F7KoNCBNEeqTrRN2scy6yv/XNIHeth+NE20LdpxoW/N0Dfgbjbawk54ro6EXeuMrWhw1CH2tEzV08hsK84Nnr8HJ7HKpOnBX+JgyrN79rISLlLgM6qdnkJRGVS0yCFoxxHmSWs531inQFUZK6EhW8KTe3/pa8Dot5tg1tIb3IMQaSw1X2rIxXQDJIqwa/QuOai7flm0O8fnfcwwY6MsDrCYPIeiJR3rMOzo0swJAVyYS8k/s4MBdG2BV63HqYA5qnKsjC1SMQlqFhGPTRPAQyQv7PVnki47YGKiUR/JGeYvlvzNBw9CvmH5VvU6VuQaafC7oAbDzyErDZWQ39V9eZbPsvLHU2FyyFLNQMlgzxxjrm1BrzakIoK8d9lzUsclOisKhwap7uVAep+SPAg=="
-        }
-      ]
-    }
-  ],
-  "Accounts shouldDecryptForAccount should return true for an account with null createdAt": [
-    {
-      "version": 2,
-      "id": "3b8be85b-6069-4578-947f-e65b64abdb61",
-      "name": "test",
-      "spendingKey": "bdac7a7e0467a996e900f79889b3cef2ba04ac3b81d2c2d938df467cbc6833ce",
-      "viewKey": "47a6c373ee2dbb58eb483bd2355e920baaa569d723788a8ce574c62219485c6d58521fc48b5862afba88687ecf9a501701def1abc1cf8bf02181f8b6f0e6a56e",
-      "incomingViewKey": "fab41ce94815a6eca58827ccbe2c74ee7c40fbb6492120c1e56bdfcd78f92006",
-      "outgoingViewKey": "5fc5482fcdc8665784b8ab5fe0e654d1ba7116a33f438466e3be9431f8f06e18",
-      "publicAddress": "b2f925c82012a75322f688c6cf51bdc7e43d25ab2678505327fec3a8bbcc6c6d",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:lEW9kVdmCCyJtxGkRLz6N2dgsZIPTajosa6dEF10czg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:hn1lWxTS0sDhoMb7I3KnoIZfxfQLjDM5nalV0ZUvwyY="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803112254,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAU6H+cB7aFVPQK7vpdIzhj8vCZE/RvDYuuLvFdEQIuIqmDDBsWVG7NqopBUIx4S70ccphuxEpFyMHMcAowux/gWrn9mQwwc9WxNRX+ySZ1gOHqamH+0tHOUSg9Q1mIT+TTlbkRIzWGVoLYlUbWt/nu6Ue084oQxAE9BR2bCemTncTQIofRR+q/zKSFHoXNRGpCG/k0wUAh/9lcmrd6VSma74FG9KeT+tMASJ15ZimxueJX3lD8iAUljyOkirHmOERUkKgyG9JM0VjC4ZHZkWJwEMsSzRDEQ1ETEYz+D6HjmtKYItcbVx5DmEEIzXMOgOX7W65Ep0qKf0ENaaENoJ6BP8f/ca3VZvT3ewyBvoP+m9s9/0cuDD4zeBpNRZnwJs6SXmhiAJAmv7BBZaT/SLKhtAja77p+aVJDBLQqUyCgpAqwLVNhz2LikQvKJ0CqWEEVwhZb7Q1Y/7kfSI3K3EL1+A3nhW5wm1vz5/gDGaBAO3juqtJkLlyWsG2zr4wB7K1uXNSxdgQgEoyxrOVb2MFZZRqlivEwFKVmJCwugFLqlIrHENi0HMLxzO3b3x9ePrOrX6Pa0dE5bb/WoJf3he+9JUQ2hW/PF72t51cJIreXcigV0C32XZMr0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnwmGk1H4HH2U5oz7b2rA6GAh2xY4HRAZ6eo/56LJWTRGa4vWXRRLoX5/dbvz95PUZe/NGCC/2u9mZ9WyFDOqCw=="
-        }
-      ]
-    }
-  ],
-  "Accounts shouldDecryptForAccount should return true for an account with createdAt earlier than the header": [
-    {
-      "version": 2,
-      "id": "090304e3-a7c4-46f7-8061-fe3d746f5b28",
-      "name": "test",
-      "spendingKey": "38cee5263458370f904a773a6c6968fc282143f9f34f4460e122b94432ae996b",
-      "viewKey": "dc704cd8c6a8cb769129be5186868b3416363f4732ce246205acf0d8e818b99956340469974364d778a3a7aa22271937b0b300128946d2a401e15f5f6b356943",
-      "incomingViewKey": "69dd728c7d1705fb7d1d9c66c7e4ab8e59f8503a48a9e20fcb06796570674001",
-      "outgoingViewKey": "e2856bb754cd7d3f44aeb3deb61f7e7d56cb690c1c16fd02b209f2c1c6acee63",
-      "publicAddress": "b1d307fd98d7579929a5c3c45e052952720caac7667bdda51bdd21d27ed68b30",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:Ap+kyH2mlxPWrHFhBrDnwq6EnWWLiwOzrs360bwyOhA="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:oyDAP9dMDo5VrjQdchVmHJnetZTxH0zMclbZOPVLs9Y="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803113070,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAiP1uBnzpDrsSODp52LLQ2OC+hbYd5zb+DVMGsHWXxoyYyQOrMvYE7+pd4TRju/PugGVm4+0cMwiSsI+OGoGB/UviyaazNTgPMd5jJ2GkCxS0WWj0JerF7BEJlwI7iIn5RPRg7nlrbhzEiI0eFvr/WCeJKdruwe8pWz6m4vJ/sVUM06MOFLi4lFGc6sfp6L6k5gDzr7vElEgEz8gM7FYq3oWzrFRPI8yJaEMxkJntUcCJDC9MMCjnUa/W8PV3FkmfyyssVbUICa0b7HAOm08MqbiBMRKmbbpRXsuxuQJIYA5zRz1AWl9UEfdR3NW+oTaEqnlIIP6izczL1L9q74IOm2HFhKp+nHLNmZjNjIUp2xA5dTcaphzGfyuUtGX7/q8oxO7c+CryE5pjNTXm9ruCO98nXHWTwyYzlkMEqKs5u0RKYEBNVBGWsJuysUkF1nbojRVUxtbZSrP78Aw6rF02+guGIF7vufZy2saZEIgtpgAZjm+x6LSCy0DNUdNZG4aOQnkYenCKRPfHV4EXEX3/YeDxLOQTCO+AH0Z6rW3lSD25zlprzSkF6ol0NfvFTV56s/X/z4t459r5N5thA4/5BzivhSGe2M2eyXW8XdNZiaS0NLO6ygdC0Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOHCcKO9lBonGpdIO5sEGsxAd67yC0rgAiJWimtygzFtGm4CaefLASx3OX7vQkGS1QGb1mBY1Elngjj31SJmiAw=="
-        }
-      ]
-    }
-  ],
-  "Accounts shouldDecryptForAccount should return false for an account created after the header": [
-    {
-      "version": 2,
-      "id": "a14ec46f-df23-4eba-ba2f-238ba9a87a93",
-      "name": "test",
-      "spendingKey": "cacbc05e4bcc7551da3d2aa6cddeba078231e31edff3afdd83133b2774335555",
-      "viewKey": "aa1427551e9e2a088dcac9b81508629cd6645e03199da958a55d15cd13c51ae073cc7bdffac711458ec388124a18ade027ef5de2ca19542d2a3765c1bae5b664",
-      "incomingViewKey": "a2780caec71e9a8e8d304491435ccc1f1cd446f928a2a00649c090d6f1a49302",
-      "outgoingViewKey": "a1c48312f5aef94cc144cb3356870b306efaacb987f46646ce1d7ad664429f19",
-      "publicAddress": "9589e3e3128cee95b4a92daf584b68d5c16efc724ae914a2448c0447dda110df",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:/17DjF430XJCCz9zy12Q5nu3vEXggTxb+QzW4DP1JCM="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:qze1DoMEc0p20q/2EMFv58VkmgRVw+Nj+eXfKwqcz+0="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803113915,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtUVXeJraPSsitwdjIitaEPjsSt7P5RsyxwEVnsjp8WWrYvHtyP+Q1iIiep7fAhZdYyVrVZzC5zedVu54oAznVpE7zzOsxSHGb0ixbDkKnVmZ9HJk/aZ8XBAaTDSSNB8e9xkAG6NSw0cq73/HgDEVFFO9783UeSd/KTCzeOmWSEAC4BGR/y9p+IPxXxlSIPiWgDh3sK13Av0a6ZCBROxxz35R703Kqptvhc8Hn466eq+YePAEoVJX7cnNZor90vtI+gFKzFFUD2SUdnfn6esbLxWRixch6G4/cEUX0B+5Pn4t9RxLzmMIsGb2w3jv2BvVKhgNe89GktlKJM2wF91SA0rPS57pv7NflMUPd257mBDPdaVFDqdTU4dIY+0fUPdQGzTZSMaMgJdIOrzETmnoR/Np6zODyHawwihfIOJhDiJlVBz5QGTIvD1qwVvsMIYcqTTXmJJTa34Hp/Nni6psg+1/8Td38UnqArEwfwI1T8v5pvLoWs+tbEG8HH3mMLpURj3Jn/+Dcz71nHB/IANwGzTVmXCRzUK/PHy7yblTvLswAaztF7V2f1CVGf729eRflhcHMmX3zuNQVgFGg1Rls84bY0M7QYZ37VOt1vHasIX51/GsOg46sElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIu3ycl2HcZHx+CbXX9+ujStAubhepn+EB//M3Yirqrwd5brRSkTBbUR7PbXodabxrr5y/I0CZlfU6pOK08hkBg=="
-        }
-      ]
-    }
-  ],
-  "Accounts shouldDecryptForAccount should return true for an account created at the header": [
-    {
-      "version": 2,
-      "id": "5aa66c11-85a1-43ca-9206-423f5a9caff7",
-      "name": "test",
-      "spendingKey": "c1d7210501c0a392782065afe54273d6a3729d6928fc06b02800fe6b3b0113da",
-      "viewKey": "99957bd16762163d81710a02db8d6e4d82c804e50a25399e6e3ce1a90a640e5be7c6e161949b36925353b8b923c6710635e182327a776d3c9e09b6abaa0af3ac",
-      "incomingViewKey": "61aa5c44865607c5323564e86ed35fb2ab221f155e8d4d925e58bfedccaf4805",
-      "outgoingViewKey": "17f7c4d9909e08a0033d349ce5eff391409edaab112d9d5bd6fbb38b4a6b534a",
-      "publicAddress": "e76d6d53af69c2bac6a671a606f3079328213bea77ac32b51e633fa2d39b248f",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:wlx1S9ANpf9pktbW4KdRAbuvdgN1w23PE2fFZ+lYvBg="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:mB8YYwksxgdwv7KhwBD0Kawz79Ed8ri7pAQUPn23imM="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1689803114738,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAALxOWsDHy7IOx9A4u800OF48WsGf1JMi/gU4u9AtIOhakLrCI46aE9w5/1kVdkX5086Gj71FkM0p2HZjc0wzeVMupOFaGhp0mnSuuMAdu14OJVH/BNiLvlI+Zqq8XpnIOBAUPvqBp+BmKPzjTvuFspb46Xffpy7p35qYj5fA/ZDEXwMn9GeysEhPp7AWAeI81iUVAt+l3BbbQTxtauaeuQMC00681Nc7YaHGfg9RaXwGZ55k7UvB+LrN91RlNmC844gQ0j4y6US2qZ+VzIfa8iB6qZzHyypSySOEEiB/0igVIiU95JCE8oFydm8tt70cYlQWrnsfL9ijqKtBiEoIJrG/TXBM1t1HxDsIQCkWOWxvDEyJTq4KTl5q/yEhnx18HRbdmB6GXPgClAl74x3/e1lCi5Kt4Mcc5SAdQce2Qlc9wzFm1nVUASKuP3WkalX8gBv4+wgj2dHeVi+KpbVuYJpet0c9OBc1GaiZy7ShVlVIwmvCzppail+RENdV6MxKSmzl2MZSeWBQgzzVk1a9DB+ZBX7TvhJDI6WmG9wSLD5w98Wza/l7bE38pAiC0YUIHO3iwLyBuPHle12KqyTTt4EaNx47Z38vbaNh0VQJ/tS6Hwz7jCFgp3Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyMhLitXoekyvnLOAY5XiIDtvqZIXgRDqsg1Lxcq7tugnihoKFXvhUYD5Fle80Qfi47xYiQlWGQVmY39MxLTkCw=="
-        }
-      ]
-    }
-  ],
-  "Accounts shouldDecryptForAccount should set the account createdAt if the account was created on a different chain": [
-    {
-      "version": 2,
-      "id": "3a868be4-b005-4a39-871a-d68cef04ef40",
-      "name": "test",
-      "spendingKey": "9324b21030be22f1a250ae51b56566062d908d6416096fece538f8963f5fbbda",
-      "viewKey": "1433af49e71cc13f4bc4dbce6363137cae0479eaffb10b2904c9369a084810409cde822c4e5713ec8b5c00ac386c2fa3daf0ae71e57571fcd0abdbc8f52422e6",
-      "incomingViewKey": "f22f03f23c19cd198893c5ea55852a7712fa6e4c1181de02bf52efc5c1988d07",
-      "outgoingViewKey": "89a9e5577106397d89d41d6567705a3ce6343f01b9a70e596a8be7d6759b011c",
-      "publicAddress": "9c4b5cea2dbed235fe3c3dae40d01e955e58d1bb076f5366aa717db5401a8467",
-      "createdAt": null
-    },
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:k2Sk3ad//7DP85x7WcHgpgJtvymQSBCJalhLJIuHcBs="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:CAF7xOAqo5nFrT/Vt7vjN5rBQJ6Y9mMiTzUjoOFo5PE="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1691098393548,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAaMNnZhXyhbTQtpu4iXUjuNnHX/F6D9VK4DMQLlEl0eWH2SpQ9+K42gHHn7mK/3jtgUryHYl2BqihtSRIp2CNPh3rXy6oTLDLX4Ws79DB7d+SwxLKimntUM9R7R5I9EknjpiiGDuKwfu1HYkP0yQnyoyieNsZaNrUkuaQ1iDhWMkOdY0QG+5ujipu++wx89nMsZqLTDEDhjBSM1WQrjycsOkIurJakcZusEe/c+F1mcmTxujCbvP3MybbryU7BIpqSBTtNdufMLT5ksxaGAii5EAFdlUqhpgf/ylE2dyrBO/3v7jP/99iPDRXGYG6bfXxi2pV6Ndn8cuCyRWWQ33n7U53+B+X1+0F0IezRGsYxuYoAC7Zqp+gdgBWg49esacrxD1UT18wN92fM8Ij51M1kKnVuMn4VlBlCArI9RDWB0SMOMNu0j1O78N940b9k58M8sDG/WOW3oZTQvO5qNhmdXP8efA+p3zZ2iAd7CP69892SwtVhl5VkWGDjib/tal9kDgGoH0QE55j3d0/xuzgFXfIqqN/o02Kdu7AZOCc65OkvLCXgFLwp/UzGXvEAs54B02Wr1mzEXfB3S/gxrRXeS3BLr7bMbvH65qUkkaiTaUADBrg8ae4J0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhfu0bWYqzBJpam8h6hyCeFhf0BXbPMu+IsVo5MZCzIp/jUMvvrjHPDieQC4gy/i92fXPe06AyKRjfCCCAyEdBA=="
-        }
-      ]
-    }
-  ],
-  "Accounts start should reset account.createdAt if not in chain": [
-    {
-      "version": 2,
-      "id": "d4091139-49dc-4444-900f-865fe5e7f6f5",
-      "name": "a",
-      "spendingKey": "32b1334ea1cb94a2ebc66b4dac18e1d3136e807f2cfb940b13f2dcbf882152b2",
-      "viewKey": "d4251d206e7f25256e0ff5699fa771ade19f8382576cad88d859ebca30c96f984c6d476a07f023f08d69edbbc8d4fa202509ef4a59619f12fe5d2b61e7826bba",
-      "incomingViewKey": "d22f9775133933b27fe5a91477ab6e2512868adc551aa1eba420b1330dc11c01",
-      "outgoingViewKey": "4ff4712b3f5336787b278c0d1ae9b406aa6a68cfbe6adc2eb1bd7e28bac14e58",
-      "publicAddress": "bd1760e4e256f8d89556d67212a461a7b3a0e62cd692ac86ca39e78aea436ae7",
-      "createdAt": null
-    }
-  ],
-  "Accounts createAccount should set createdAt to the chain head": [
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:D7iTILxNlMZpqYCfPbLW8sq4L+L4OKnoaRnADjHZaS0="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:uQwxBNixPP6+MFOSfHOsJ1eH+jo9/5np7uZYPF6v+9U="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1691606495398,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAHIu/oGHss9rJWLeO04B1n0ff05jA2bseDqSyQ0Cri9CEBMPHoaN+1zTE1PoC1evN8NvBOn0wqy0aSiiQaVwC9yZhS/gtF+SJSOoAWJtkyOSlxaF38uI+6Z/jXn7V7k1TydttZ5W9l6y6AjNniOKZPn2X7NMiqTQGDEwvZW3aD7cPw1vU2El9kn31ph3YvT6iyw2bUkONcijp9dhwklmcAd7MyVt7pzKBTiESJ+QLjkSBcW4qJvs0J0xe9erQkbZq0eAU7B9z3UtLHK78hgCxJgmlem4D8WOe9sG3iVP/zTOEA672Ot6D2FxfsMmgFVUPmgXpFuOK9XCkcmACX8IbWBQKEVvFqOA53yJ0UYGDi9HK7kmUckUQSPsEX704t9sCXKm4QvNJymWl+J4ktYKvCCmgH3D/H4kOBd/WRvFWxwmm/sloKVcsHycFkXDX/BAYgGBEzDortQBwERsOiYF9ywCp2uidUkFc+m5LdLc0iJVBiGdT/sYgubQ18INPeG/TiGdjpKPQF56HNuj80F1Xm/euTqZOktJ1hmVuN+8QEsQYrBm4kpc4NX6YwgKbmTYsl9SyhRIGDLcNz36Bwz+MeSJhzVV1sxFebLN01nr/k84qk36QsVajoElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAEOjF+rufiWOAooGBc9Q9qqFf06xTYC3llJGxS/TcceThS+gIxRoAMUkcbP4ssoRecnNJ+aFYi+hyKr2UJE8CA=="
-        }
-      ]
-    }
-  ],
-  "Accounts createAccount should set account head to the chain head": [
-    {
-      "header": {
-        "sequence": 2,
-        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
-        "noteCommitment": {
-          "type": "Buffer",
-          "data": "base64:cpgLKj+Ozzt0bHhN8MT718P32bwCZXvyke+Bcl7xkjc="
-        },
-        "transactionCommitment": {
-          "type": "Buffer",
-          "data": "base64:0CTaKy5RjmuIvf2XTC6govYSFVkwd2CqDMN81QIEbIw="
-        },
-        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
-        "randomness": "0",
-        "timestamp": 1691606919483,
-        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
-        "noteSize": 4,
-        "work": "0"
-      },
-      "transactions": [
-        {
-          "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAdMtHv5XOH91Jm3mj7LKzkBTET3NbRCImP3YldCIXHe2tgp6Hi6zCrzdt2rU4o8sut9wD928wkkMHVag+tYn3FHBoRY4u3jSbht11KwwaxiaqlNTTmzFT93BwfYCR6XInwq+rLtRJ7qfT8Oc/QqqAZiaEtn+Becwf8oH2wjEgN4gZ5N79ep8wm+9BYR/enjqyngrseLubYcyKjYh44v8PQa0g/6n7ozDe0wftEk8xtyyPywupj7LFkoyWBZWqhYrECe7GmdRQcjLGwme0pmWpI+HviRQR3j+6NqQ481DzbfkkrjXUQdR0YEtApUZ/QzgwHJ3uWdQ39On0gHGSNZfMRZv3IBVNmoMAqqMzTCRmFVEvOjiiee96uPQ/nzodar1l90TcjHhZMqORjDW7qXaTg8cuWIBdAgQA6PWo0eZOr5kBbIrJROvpxu8a5uSNcFzpkliDFZxeBa5Lkco3AGKx3NtcjWByEodnOmCDOSE027ETh/aAeAA0+TDJhmiBRj+I6kmRaghp2MqRFkHezJkvbK+N5fpNaDR1Ogy2LyOJCRxsIPof90v1+hiUyTyr2kAm/soi3y5qWTPr8w7gESfWQS04NHu7cacx1/nGlft0N+K1o98LJZ6EG0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRMBsRYotdrL8Yv3Syni8kR8I85q11GejCsYJ/231mCTse28+DNHtVasx3w9SCMUotXw2G95KM43IP83tNRwqDg=="
-        }
-      ]
-    }
-  ],
-  "Accounts load should set chainProcessor hash and sequence": [
-    {
-      "version": 2,
-      "id": "8a5fc4a6-a079-4a84-864c-cd7e7422af9c",
-      "name": "a",
-      "spendingKey": "74bc98b79de47e462856535e302ee4e310d67ee4996e916785c0397a13434a57",
-      "viewKey": "95b85406437746fab017abb85a6d636e1b4ab3b279399e8453649bb567073453d4f6f21d1e33c1bad0d47fe7eada84afe4821682e079cf03d40c4515e5bf5013",
-      "incomingViewKey": "62fa5104fa23520c172438b2756a038322dedf4f917e7aa0ad573d4125e74203",
-      "outgoingViewKey": "a8f48f88bb9bf3a08fd89b4d450646cf292c01c384caa7b35c1754f40477e425",
-      "publicAddress": "71a7608cf3e7347bb85c9f20a3539d2db7ed2d5413002228f320604a0cea5e30",
+      "spendingKey": "08e2661f8216aac913d31b1e467355447ecd84ad39060521f3b0d96b1cd8396c",
+      "viewKey": "f5934352b3a9de4f26a277fa88e03dcb140e6c140522f36e962ca2ee7d8c1bb9f86f596f6c81db8c3ca39b8316a1796bae7a11df9a1e03f10a5fa9663d4ef021",
+      "incomingViewKey": "086fc08ca973a0ce4985cc60ff1234d239ba45a5a17ef76b6ecc1a0fcb7b0b00",
+      "outgoingViewKey": "9696b008c4ae77d2e40e8f77cf1219dc8d33948a55a84b52ebd0b4604a773424",
+      "publicAddress": "45c9e99db600393f11e102b55ce6666949c8d6d5ae6a6eeebd06a53794bf8d94",
       "createdAt": {
         "hash": {
           "type": "Buffer",
@@ -6074,15 +40,15 @@
         "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
         "noteCommitment": {
           "type": "Buffer",
-          "data": "base64:zpEaXLRsBOs/85CL/9I26MwKPBEC7Hp+gk8lkriHEj0="
+          "data": "base64:ubEMRh++nIy1SjyGT2JIZBzV8oUZwZG1oNJfojc9xCQ="
         },
         "transactionCommitment": {
           "type": "Buffer",
-          "data": "base64:AdS4GKeNlNS6imgyTNVcSdyknFofrh50G7WX6ZEqGhw="
+          "data": "base64:7duvH3F/ev44EBhLte/ptiOpLHC76T2MYSYpkRt75Bk="
         },
         "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
         "randomness": "0",
-        "timestamp": 1691627220304,
+        "timestamp": 1692156429218,
         "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
         "noteSize": 4,
         "work": "0"
@@ -6090,7 +56,6719 @@
       "transactions": [
         {
           "type": "Buffer",
-          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAWBJyhhW3vSU+BS0p5FOKO/M5CuN6+ZCRq707ONAJqmaWGsyngS6x0dYEFz3pCpyP5ZtL5Aw7M0fxde6AHoZtZWYpo7RuHahEYEFPeciGfO+x8qKcMewCXBpNvDGJ94+o0KcVEboQ8Fjcv2beeYAGiGypgexThWME1RpK3TEV8BEUFdlPOeF/bo7UOXAfS/hY2N5wPM4U98Qe/CJdQJ9fmUl8O+1UfTD5owhvWEM0wlCUjZjb9eV8/bwmLn2fBQkQK7tWAyB6pUCYctYt3QueCc6hwphDCxS+maOqrBN2/gMrNy2AFYpT6auq+cuYyZ/ykhfADoxhOXRfnF2AwRD8BYavdLpEJqtZwy4xL0l8afKTbfUY6X4hWzbDqJsuYG4rs4l6Hgr13t3ff+dSeCGPXOBmtKeGI1P4x8WWs40SJm8zLvJOCEAVWpHiBhUxKj9PQ0lv30r0k60nfTO8KKeDnFGzzFh/PZGFrXOlwWkmUQ3cLQ+5F5MAbOJ8lOg0LbhdkUVAU0hwJ6wL+CLrslo39UcOvQnVU6tYOuqdeCX80IzpHg677R9TTXm6AIj7jtJTl+V/7GZwW63gpldgzasctR8PLZE2JXFMQB6GeIfg5rHu68/9mccKOUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZ9nobEmze4i1maxmhrpSvrFgm5Omf8fNgtLn9BFSG3Lignol+2vigIiXfBxlEQLWmq5MYTH7evPFwGqGz1PhDQ=="
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAXEPXEQqYuDr0yNb9Tp2x35wR66lb0mHzs/p9R4Dl0Kek/XFBCip6O7lzjhpNiGI+MLdOaZKhoLGM1mkSr783Bhv5nVeQeMEzISVOWPktIFijhuGofPaRLtmImJ/W6Jmx9tlVIxjGOHRyh3jCmcEQhJdapACFk1EsaYMitSae6rgYonIl3qStp9g/CA2yHpk8z+2AE2uEuilUh0OkFe5HEhRZ65vR1Am0dqi28rzAnLOvEbsubhSXgOHqUgpMZTVxQ957RSt3Vi0hbQFKUe3S7jP7JBMO9NUt1oTUa9+nNAQP1L/0SRVhUFQ6GRvuTyALP5mlorj4EXLh/RczJqq5xhH5QDh5+Wbvnavq5u+P9wbkfgT8DMWNiJcW5h0nVQkgsMKsFzKgitY2Mlnq0bgr0kyINgNgyXmQS8ByRYei3rwjJEdIfMWWWuUH6BhG/CG6GxAReeBsL+/OU5rloLXAZ4fqhrZepdG9UpCPYAZjNR0XsSeSUPRHUvGGSLOlARp9TSxSJKRrLoezH6k5+1HVL5NMXVzRnhOHr31BCeg6IjqMm/RdTHjJzma/Fi+x228ShvzDXJDE3+uTw25WpdgY/ARyabu8yn50skfPAowcxdrQ3/o9C24WI0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+3BEoYcV8bmdTFMmQj6+fCODBqe2K5TsABCpd/9Xc3PR/+IKf8PPysyqO14Mb9Cs79lqkBoVytoEhwgeqThfBA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ziWkjkHV1bumud08SUzJzifbxw/gX86MDnSmfmmPeRk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:OR4Yi8UDjko0+G4MGIk4kLxcfubp/hM84xQIxjSXHL4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156429758,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA9aDNJywziN29J3W1AZARpteJ8xjeH39Zg9DHRe8tRs+VZ7vDTItVvS5aOXFt4pPwVun5FrkQaP7fQ06WjOZ27Nqm0q6x4JMJttRhYH1d/auPsAteGMoTU6KzyGGRms1MrMI0VyAaTXDvU9xuCj76eniGcqTMG0lxx4WKMOt0qKEI1j+WOX2pYMYasUMzMCaMbmGntH3ggFWl8DvS1wHtfJj2g4TkCanRqB/sXRpGIQGwBzsOnpz4ZmbdlYu18awKv3qe6VW7gombq7y3IuchxLkv7d3LoxEMTZLbcV1vdRhDju5E1QDb6CxuUlV9bTkCywZ/UUpC8E7KK/Vwx32Qsvpng1xkZ27gztGiRi8efU4kxQd0nfDlxzl4sUf/TkYrnQK3i/UOEYMuVfBXFkdFzyz+toX+Yb9+qEFSyh/UoxTjucvvhM4BVpEHrHk2Gwmqb6oVv98iMwZeF2FhtaCYMmWeTTjnhttwMqrGEji/lTghcSIcYxmFQ8ojJ9vLqh6VMRD/mZUlZomfGemJCim3RluRdenJtwlVlp1hcZRWucvv4Gtee2dGUNvbZoxowWVclKlrpdcUp/V9Lopm7/F/enPT/CJoeiG2nyzjYAMR7EmrlCuA/ZBseUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwpHNeLl6e1nYtOxYdZBxAqZtpVLl4R8mibHqr1L8cDlFb32CBmusHFaTn2TGbv5/VVYCLqX32J88Fgvzw+uh1Cw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "4BFDE4085E83A2F4055DA02A724C2D4D2ADBF7A4FD578E690B5DA0F03017B966",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:NN+E49lMquceEXBZxaRdUpQ3jDdTFYQuy7le5J8+0wA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/7yTBsjUihszTjo5W2Lgc79uExj68mLjRdaU2YrxDKY="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156430281,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA2BIcqYVhxHu/hh/rNn5pWz5vff8WdpGuzB1ySgtzYyiXG/MJRzIv1Dp2p6EeWikHpNig1kPj6JlNTa7eQnj6TPnK+HB2Is7ICZFSDKxqS4CgZLTrWw9KcaW8NwuGLpv183/c/pjOJmOlq5jUqxwGy892y1OMkxZBoxpw8Vsb4pQKrWEOjUiY0x7ZPwQ2ApoCg+JAmKdMHhQ3yR8aTC/wyk/zGC1xDtavQp8axHY6KyWiI8gCJmHmHR1UM0Qu0yBtaV1nfdHLY4vNcvyendeWyC7bIztxXTIS8j3uV+SJJKc3fSF19Oht35i5l2PhQtD6+vaY5N6EoBXAf0WgNiViImds6A7DHY8nzrEd/EFBKDfJFitZcdM1JYJH6WaTfL0DpuXPLvHhPcp38eiruZ9jP5rUcmKrdRs131p2/lWWyN7tAKcGSuSvppF2sV8Ww2NFFvDh08ifpukqBYgvfZ2WuxyODk/2pRWvKhYKkZBVpSBeZ0NcyMQtghOTUruf5F8nppclErnwUrxqITXcVPsE5JFkfoOv9+sKCxXMk6aU1hlnN4UJbSXecdHL9IK4z+gStEH0L/Y0t0TGqt8xh+GX4ecJja6wMzWYyLYtnhEvqiSCusNcakm8Rklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjgxHVNSZjcyT9GOmmRoladcuwIRm6nIsp9GNKQxEALMV1qRlqNE23dt3lpD/KEgidjnyomVa95d9JoavHLg/CA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9+fho6P3OzlG3dikBOzyafEqm7ePDRM0STDR6AJWns2StW/mVmFXeIKHyrwmOwILuRwApfrmurFZrT2KSOsUWnyEK8e/8j4NdczhcQvOgK+MGYuqy89J17AI3h44LSphkqn/5DNZcRo2gEPI9oql3aaK8zpE+jh0ivLQiF5GbJsRk3ZrldIC/gJMrprUOggAbqjF2bgMiS6ozRqBM/2MIBb+Ot6kH4xyoeyNayuD6jmKrks0/ktemxSXfJkEtfx6UWwZmcaEekaHHXMLYdNfsG7+Fxibjg7sNA7c7pWa7TbWmwZ/mxHhMK7EjW1UkKmid6gNmjQC7goTxU1fShEcZbmxDEYfvpyMtUo8hk9iSGQc1fKFGcGRtaDSX6I3PcQkBAAAAK0Gaz9fsPS5e8FgOQXPjMY8owrCR6Ew8IDhJmMRhBEdQEusIBBxxcc5bMoUrscD/BEmM3SerZzUr2OuIEXSucMllB+DPxwRd3NY8F1qM5gXG4RsDiSxmIKpU1zzc7RhAZUlTFzxP8sdd4H1PS5J5/Zp5kD7JptmxufgFLZWZTsEZKPDNQLdP0k2XM2n5AFBI6QgSHpdU254coCV0W9fHunRzpg6X08N0i5b+0i4YufPNZy2IeFJTmJQbsqA80StoAWIyXrMVIw19raq5/qZ1gt8mOZP5Ci1/95texE3eTtVTeJ9RP9loXZbqjEcyfNsvbTCBvWrtu4omQj+sCNjbFAEkU5wC6gpysFQqfPcCzNvmTn6jA0m92Wqlhmcf5GRlW1hA/bpi+Q7thTv7GGRXcCY0HmXCabG2Xx8arPaJGVx1S1jptnWsZvmFy2NY6rD92tsWdhBcUpF99DGz/GklgQMbxojjPWFf0iQRFLfoOrPykZFPbRJYTOdjzYYKTtjZ90HRpGONcF0UEh1gj/QXt4tVMLManILMFzM6NjnaG1l7UZqZBFdWwt2wqn3k16fh/m5spC6N20zdfcKVC/gYR3V6a/um6nFLPoifwYBPOFpMARoqYIp4acpsg8YqN4B1t/NUv8txq+eNCI76T1xLVD7Qw2+yH3e+AwgdTn0tc+afwTOtO0FHCj5rj8MIAZv4L30cxSAmKywE7kpqEEkpsuMKHc49Up744dLENjwxwITDAYLjXOmQyzSLLZxEvUhYsN1aFD/rEHc8aIAcXPF4Kii+56cU/ccPMCFLabpkgvmxaS6/TRdOQywuRP1l34bk/DkUHsUTaDIHwTj6NJmBmoR+RJw/lXK31vVXDZWWA8gcl76WAK/Z5Sh/rPS3hb/QerakOhURly+Ttx7m84OGROqZenKJbd3jwpErSGnyDSVCY7b906h8M4AKNV6Nmaeb4dQehhHwmuDsOXiVgiUqxfJVjpD3YFysjP7g99VDrIyEY+tCI8dAx+Nbjd26wk/v66Cgdl9r0D4N4W9bOZQmOsXrFFRH+fzzPHtiAyhJf+I/AN0fEEC9a1GboOH3RFf8XpSboGdY9afXteGVbFUEo/C9hJl5ghq57auKxKM50ygmxUwqMCZ8pm8Tmo1TOrcQeteplCKgMUijBiSCpcmF6A3xBHnLOWuxiUf6gIXRdwGY/qgXSdDiMLhKvNFsY7y3sEg5haHZfgnPn8qf3V/fnBu/IVVKkjn7YPZbSBZ3rCwSb2iiWW4esHDJzcYGLTC7o27yg7iYIFMhcnK63dGi9F7F7tVyF5iYKvuAscO+7KvXY1hCL4A/rdhafjjYSdBX1SFoA9StnRJaxwjAo6PqXmE+1BpunEetjZpRXgWSrPVeZnyKSdKpUrD2v97Z9g4Yxq+HCgJUttmT5yvyt656av0V7LViqACB8bDo81Oko2i997GrmLBtCsfjQWHsgSdi7bIkj7sWbA8Z9542teEG+Qa8TFbRhgH+PxkxizokFWMZRGzlY9+u8eYUe2v2rdlKNjYVWRILnApCrIwmpWPNct+J3BFWL2YAVWBN6OvOrDbgax0IVv2Qhbv8No1zKltCA=="
+    }
+  ],
+  "Accounts should update sequenceToNoteHash for notes created on a fork": [
+    {
+      "version": 2,
+      "id": "898a1179-897a-4194-80aa-f1e3700f8f8b",
+      "name": "a",
+      "spendingKey": "98485c2f81d0c9bcbc9811b481c6e23bf2df645af3d60732aa5bab18b9135a93",
+      "viewKey": "c052498efc55ade077a349bf27d1e9a77f7386285917a63f3aa85c76b429e69c695ea4af35d1cdd80c8dac48855dfb0c9604b263d22f03cb5446c5eebfbd2e1d",
+      "incomingViewKey": "8946b3da8f8fbabb67c7267cb1c182c5a001836522af7b6fd38afb8dbaa98902",
+      "outgoingViewKey": "f962e37e27710018189f577316cab7811a158a2107bab4dfe18e9b5bcf1f635e",
+      "publicAddress": "6a3d2b81beb45999b8fd8c6b3ba52c97b81c8ec9d031a3bfa80b945a16fc836b",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "717fc75f-e46a-41e6-9af4-2d65ed693ca6",
+      "name": "b",
+      "spendingKey": "c9bf82c873447837467234e4da42b79e07858d5cf744e5187f03ba93477739e0",
+      "viewKey": "936ce0800143ad2c8bb48d098152c5872ed9f991048dbb9bfc2d4f8cb178abea7e3ab3bad541e239ea629fd507790ee7d54208a35e03541c9b63f634524e8db7",
+      "incomingViewKey": "af449c395ba34a0e7f4c205ad1b056b2fe6f9201d64629de4f239921198e4f00",
+      "outgoingViewKey": "dbb1bf387a409b41a930c6f7f48f6391ceecddb761cca9cd7280a630afa992fa",
+      "publicAddress": "83078965089552916e782720b81ba12dbb18c2ce7a7e8c8b5dd8116ca28adc4f",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Oi4BrTu3mwVko47DBVNYK9/rEQX9xdhffBnooCyOgkE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:PUMHw99TrX0IU4zDwH7O5Iwu0BpwUqW/HIMFYlJOvpQ="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156433371,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAWinigI6ufqtOV1eAhG9FN8rZTmaLdI83ekU28vUBb1izKjLr5h2IzOD1OBOlv4/6hCtGYA8e9rQR1/F947348GChesRJReSGiEXe2oMq7CaFassZlsX73KT9g/sC4kdkFxUvgo0AwGa2xRDR9KY8tHplRrvf0+9WfpmeMs1yOmATorwqeO+HKXxiwtXD/VovhQWrDoxJiYNh09ThZAdRhzEE11Atm88kLvXFnl65TFKUf9jCmm1Q9jSvzYek2ORHF1RaMUeDX+tGF2+1ZaBaz0esmdeBWYELgdQipTreNrTaIBnRvuUpfdO8GSLCgC/Y7hjP3hquFaMOzw1uqXf8vxQn8YcoVJU7fl5Fu1ghWsL0GYdTwlvTkxnJPQ1k8s9dHP6H1h5sr/HZaxRDVqdP1fPdkj8N2TN1vZ48OriNqvByPy7rnB7WFxJ1J75aKNL/wi6bgmJVMxFJI6LF1pDWUyXL76Y3/MNBEJkWeTaEQcXZ0kg0hvgl0rw+9Ibyqp8UBS9d/+CagxhkBPK8MxnPcDxLNFSJkeGDiqxAEx0QfBCWs7OhEQvwekSy6z9aGuJNhinKIZnYY0ZDPgTVJGS0mHJ29AK8ZWGHiyp1OVgn718p/tQ/n19ujElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwl3MD3Z51zjcx7NkwaZ/GpAgcjCZ8wxni+BPCaEMdDqUbucL5HaHvMXrKiizegtBm74bLa+FXm+EHbabA/tNIBA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:wf5HmRu6KYaxvfQQmh2zV3PyIpmokpFNsrvW6fMZpSo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:TqK4s4KgEtt3fHq0dfZCofi8es9SkZ++R+Z4IxDezq8="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156433955,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAVqgAndy6FMQzD1ex3MwiBHroCnxS5ITI8Eqn/w2ehBmN889a08En/s6g+7g9yJ1epugHYVkYmdUa9SDCLxku6U2tF5WYkBzqsBXpTWLcW/STANG309yyu56ddsBYr1f0DIA32VZy/ZSlw9IcNcgs1hzmdxOkNBoH1PtXF33RAk0LWunFXWO8ZoBQBEJ0a316aa3wLNCyw58KuxhR+GdLli7LF5RPmqhXqJBHJZaMfHaHRAvwPKhybbc1Ga1UmUFY6KR7O2BkQZu3XIXxz2dExfY9xdTrQmm7upIN60b/xNO3OpT+hrdS0UfbUjbL0jeXf9eSIEXHC5JZEZ36l2+xvmymIozMJuTHS1cAxOC8VBhWpiMMgdX3J0YWAKM2FAIsYg023CoDMCHoYQ3kqC1OfkPyH6OQbj5bjrwpSYAFBaPl6jOaxgzp8b/OfsITxB5p+0y2uS+9ogBBL2hSd2jc/UhZ5YONs++NeBSnTOXO/lmbjppgHiey0WA0HloxliQ+sgLXdz52tfg6uhnJ6W0j56T4Ir3995RYfpgC7etDlwDdFUDyyBM8Da6hYqoAf3zPb7fSNB4kI87Ky0gxmW3+Z0p47o/o3lKO3u5Xq5I3E3Pijl5bndB7Iklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsNZJjgHTF+BxtFREtISQJr60IJ771NMPZ0vRSyJkas4c6viI4rjrVm8cf9i8sWOHwb3DTOdVsywceOWkAuYtAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "0ED59C9A3E953C8D3D4EDB06B326C9FD82B83C4322B7524AD13CCC93E44213B3",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:6IVJYI0STIFgymXTw4iTEkxX/L2VW89fQ/Ogtn7zaxg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:mowkuX7D+UpNfoXo6HdeJFAQq+llPnoaUdcpWs6hclI="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156434456,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAArxLGOeD0j9x59USlKLdYvAL6YFo2ct6zexdaaMIGzQGW65q10tgcKUA+gnkJluT8VxX3cqhSwWQ3sYUU96Y+1/VaTizr+ttlz45SLlE2xJmnsZLwWSasRYCbM72rakERfdmUSXQj3yEDqYa/ipZiZtik28PxXFbOKGCr8lRR4YAZ4qV0+hm9GKSQ8B67d49NOTJvmXi6liMsUiepo9IUOcdnLF81bDqjbAs8pTlW/nK0klEN/WFydZm2seTn/4tJqbX6QdlNILxCY3suCUJBSv9R7Tbsbt5/tn3B/LHw+TpDZkOHjFkTr3d9ltaqexvWMDbBYWcHz/eroD0EOLLNBn8qptoY+6Ois7JHttKgSmKXkkW4p+3ncR6d9nphdhA5Lr2SwhkAOEk90Nyyw5UKxyoa9qzvHmBvHDZJvCVc/F6XPpOVIXknuFJJfQlmSpQf6p38XVnjNMFJYqRL2k4F+MgGD9KBqZvmpPLxIOUC1cb0lgDiPV8YpN4wPglD553Lpr8AODHN3Nxqo91HwTnfpLvraKPqcK2DeLRFjgtIYOMW2u+4pib8sqbOTNgVaezk8qk3rrCjyydeEftJ2EuxZFkENENVRMwhNgruYH0kK1MR7Ybu1nAtx0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEOoO7XEDu8Vaj6tp2T7JZicyItjCjfZXGTnSXjzUKM9ebVkMh9grzx7I6qLiG07t9xMk/dYMBJn7+vECr88hDg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "6F165EBEA5BFBEDA588B244EB9BA5C3F69D49CB37BDC7991AF56C1D20D08D928",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:3Dn+EU98ocYK7HcL7iakNYSzRR3wPkwYEovBg4LkKio="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:dfWA8MAV2wtzg+5yFCfqWDAHsuoaKXGdo9d7/NGnRuo="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156434975,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAaTj51knbqCWVGfRoSwZ3PhmIAyL43Psi6Xop6YvkiXCzDS2+1+G1CtwmiVLPc/S0UxjyogvrbvqcdW2HYgx1lpbXoS8/XAS7lla+5j1F1EWqtS5iqUC84Au8GbE2LQrfx2btAsPAPPf5kJSXfMfmC5Ias7oa1G30XBMmo/yhF8UJRmgTaf/TsBdpfhwcbQKf1qbmoLwZh7v6FzecCxwBFf1fs+KCcYW2iAdC273ZYeGmyKRwLaROtQq2RRUACcKD0O0HU22AoDJ+4jQXX09bl9p/Wu51Uh8DOL1ewiXf3vMquXfI39rKm1KrXqB79L6OZuXL5DndpEAKyIfcwR9IttKLY6HQjhGMDGmsgBEffIkaXMtxVsYJStOlCekpPAkns5qWSYbJEmgM9xKjDmad9dnLKv1q1gSBfw6SQRWcbfDUGj2QMzxJUk1MzgAmRbpO0OmOudCsBWiuEOYz2xRAPbJeCQ8tEbrnaGUPy3+hHBMoo6QxO6JCMP45F2FBjzjVcAfbrPn8Hx2KTAZlWAoddw2QMuk6sGlihkWgVLdz8G8SALL4NQ1d2oRMCKtsAEdJ+QKCSPADE+yzjoIOhbfrOskhzMNbe7mIKjfIggxZeUNfrYTeqGhUDklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4rXabcmyu7CzgS3dO1OUm9gidSwFwqt/bb1vMx8maTkBGlYYss/B4cT+3D4rkCKqAauz0EE5dgRWJe2BZHDpAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "050DC424599E2588A3A7959304474CFB41CCE8755F62CE43BF2314FD222CDDE8",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:lKAGt9VLh2LIVG/fySR5jUnPRwOzvG3wiFKYgxQ95DU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:f8Po/qFK7TQ7bVmDNQWmGpjPS/OoJFL6Br7aNYpoX7g="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156437632,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAMvhmO1IzqfdmMMlVEiowc21QneRUN5NCGKuwLs4YsKynMvMRNz0MlRQUkLwK4PSNXy2kAPREvh/jXEJtWn5W/TtuHHOhCgOdaqxDAqf7YHalvtezmEtcGaGmCLdqtO0aP1m+cvtxq1WStHK7S1YTSgh9T1F+ipt6kRqWSCXejRsAE9lu65ab1wHBptNevgM+Vi0RjXGtjLn2wNQXJ32k6hLbDzkSW8zDY3A0CKrj0NeRtL2lDwzpcbi/6AXDaIiA3DKbCMoFxUw1RbH5he7peOnqBfKGHc3x8Fq9PX6BB0E/apXQhMdTzyyM3eN7MlZXKc8xMYBHtdwVQ/x9BxEzWmst5WaJuqhmzDluEklAAs7Ll03DHK+cpta75fdAnosPkg+YIrdR++Ly6JYEdUeUtzjxZiuvNmvVAD6VCfMiriLucA2SNHlqMv3R6ZEpj61VtL8HQ98wyLHRRMxci5kncaxujQGQSkMoIr3J/YmAuCRb+onIHswuGuCDeJ6S4iCIpLZ2bTNVY5XDYdJXuCY/SxuX4nIVj5pd53f/iAtIA9Ct1QbpoFKiWQ2S4FCUkjZ7OVQSJ8WmiKrPOChIZdTKgxv4twO0tYLMZkmrKbHcuFC4Fyb9YFXyB0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwlHP3LYB2ayMYSif6capr/w6KHFGzGM5dEuYaXhYJD8gcLTZ9LKItqSkVwoLp/ixzgW0bfxriTG/pyX4wKAMTBA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAYTZzxAvkQy8KHyfm5X6PNFZJ3QcpG6VNVr1lvFHUWE6MgAhdH4vbtLY+oC/6wH86GtHPzb+U3ym8JOBrhddQhV4wS/mRpjGNHDSxVV1Ii7mJO+acOy3ZVm0JfgdTAenc1n2dDWOULNtJpU4w0Y6J8ZC4mdbzDOi5GxnbIe8HO1oHoG0BT9mhbOe2mDNL9SL2Afka6LoY2IBcFcB+ByAavkE/t2PUXq/tn9NoKNHdANWCKdRie7zuxQOnyTzG/p9csOG+rpUFv86Jb8S34Q6uerZgOX/TFPYAZ3WB7sSFOkuXrtTSfRSUfzHTMGwfn0a4k1ciT7mZ9XhRR6lc7XtLIzouAa07t5sFZKOOwwVTWCvf6xEF/cXYX3wZ6KAsjoJBBAAAALVMWCILbNF9damZj4GEVv3KABSNKjnl/4vzc1cHN6Z8caKcDiuK7odCZhUUCiehOqdVBsdW3w892B6t1dFsKpSOsbyXWKbcZ0Kp4bmWYGHC6JL/XrXygFQAVsxGbBLRC5bGFiZ5mTgNLAiavNcTjGQHTg8cgQfv83GsPJTRMv9nm1qoTVKTYL3WUH/o2apxVoSLSXIYrFvW9xjqZZI4b6zoaJ2IMDoqfvo4GXpHca32a/mHXiFbti0sj9HcP9JPFwUcnxSKNad+vtSBmlKPHDFob84a4P7QaYj3hurNTuQJbnOaNb3DYuj1GYohbLHDeomlP6cGi6y11ohvErLKUuMybdXCs+7ZMlzj5ROhExsL7lcx+47w6b/Wxu0tYUngJH3X4eGdqJBhmDqkJQkQUeFdJcI6A4mZs7I7BeBE+iI8+UgBhUWcK03xgmHTyqomD8Ff5WxzfG+/47orAK3qEyu9Q7378FKwlyHRcjr72vjTsZA5K5sgC8OoV0BER3564NMsPsjUmCB+nfLuMGr9L0FQhSVvVhjxq+m3UO4ajvK1aSIvmZtVEdHkD9TWe5tM6aRisZxCqIBk0jwav74FKVHsZH6WHtRoTDSULAWZO89vDuSJm9KXRL7mnbzkOAiAfeHrShRgyf4dLwQ79rTZ3pgBIlGmWUNHxnVJmNylRBxSEyed4NoLEo8S55jefFFH2RqeLa2SFPQ+O77jr0WFwiJCo/LFaHppDofndvFSb3RUL073dTNY5qhHxRa8zB6GP3ktQgUqwl/d1ytSdjdLKqiohwUzZ0tZBLfGFNkaZKJqIGQ5h8X6rfeqy9Ctv63VqpFRgaGIFRQtfRHTCbWNxm1D/T6rsTQuy3kTjXQOSSvjt1hMtsPHfxutF2H5oDfhm/f9kqAU55IDdqQk7teST+QiGA3aZVuarS4VMcjwx6xRjCuPBGlJQTAFMsZPlIsRX+WKC8vUHk7SmmW6OAIkpankJRUgpHSGAuPQ+IKtu6pioSalGFENH/KUEarrXnAU9vKRXZya7WClu456ADHhwA5E0vB5hNnrE+m8BGyH+NVQxzGQNgCj/BqPPHMm6XJXu6uR0iiEuWlTgUx5YmCY4n2htFLkPvrNqzEvCqH0pkqlSoi5hzTDj9tPsp7MDuRQzmpxM9TgNoFxBozEgRnLjQL8gcdH5LXR9YASnwlLKPu7ABoY1mNzH7EGU9+jcLTY1BaTrPHRVBOra3uTzrIUJW3xnm90ogVcqwFLW8jaD1ZUZ0u9s36TWB50tjrAVmZMH8zMt0KVDqNhXKGKL0VUahRyH4zWquPT3jSdfqMbJN5N4iOLfLFxybCLKCPjKVT0E+EHJPnIcVH5gIUaLrHdeILpRqcxQgyMtrIpVRv1oJaicWcgLtcnZIkHvCQcukLLhNiydhvhqXd0YcFTsSy1eSAd3p5kf0L5DetCs/elnB3ZM19B3+BXERI2FP+7KtFyMW7KTuyf1v2P5M4ouoFpgvPFZHFxwYIccKjIqkVoozA7lmKy28N1e7ohYe6KUdn+So20iJ7Paj2IFG6lOYXqSazV1KFa64j1k+MrNwMH5IzARIsz473ZsfhkYYXVPQISCw=="
+        }
+      ]
+    }
+  ],
+  "Accounts should update balances for expired transactions with spends on a fork": [
+    {
+      "version": 2,
+      "id": "982ac721-c4f6-47de-8ee4-2756fddfa692",
+      "name": "a",
+      "spendingKey": "f69dda83f389fd9198a99db26db0888ff3cc2c34e9394f972746baa4127f540f",
+      "viewKey": "1e068798c138663ac3d07fefe09a16f24038de86edf65f15811c11c7d7be3840fcd5f5dbc8f4517ced890fef9fff7cf7a7fd132d83826b9407bd875dcc6d8bd6",
+      "incomingViewKey": "e503d5b1fd8c3f47ea271eabd9e26ed044fcb9475e3bd315241aaa1e7877e301",
+      "outgoingViewKey": "d97e820cfe47d913cb6ff2d22165e7c9e67951923fe4457c6b4a4224589210f8",
+      "publicAddress": "58ad741600c1a33e42371389edf1344c7a8bf76e3afe9455c4c3ff3161cace4d",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "3421b1b6-747a-4124-b9bb-3b733be18907",
+      "name": "b",
+      "spendingKey": "55c46201453657cae6288b83460328d30b586ebd4389f24c1979415d7ef88377",
+      "viewKey": "7aee9da106ebf5ed5343cdbdac0e4388ae6611113b4ea4ab8be7fcd3f49855a74f8da11d831d57f89722121ce920d17e7ae244bda3d8326787bef293e12555e4",
+      "incomingViewKey": "96f0077990a258e82616e1fe80b53eb1536000ffdee770ac125e81973a766a07",
+      "outgoingViewKey": "f4e110883dc3f0a7b11362723e248f85740e5655c7402681b832df4fcf38df80",
+      "publicAddress": "a805b59a5b4530c7c6a2aa64e0f3d3b57c959a09f8f7b9ee25c846353842daa1",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:LloBWSRwSvqT7EFwosX87bDO2M2dxPV+WVHEYN1dxDU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:s3W/eLlQeJil04NEUzTHgi7bGWokpn8JhkS+h49o4wI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156438645,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAARB5fIkbsJ799GSI1mVBkk3epi2n8z/QA5GS6XuC8NLygqfuceHsl5JF6rsV4H7LEMOP4a19CaoluJYzJtAU2ZHEnOn8a9SpfErk3nZPGI+eByh179h3mf9nCQ0mzqeW0Yoq9Q7n9AR7C6DZ9X0rVn5LEAgf/rIPdML7m7lSNsZoSGqkJWmeapmrIla5a8kY+OfBZ2Z1P3YmX88/xqCbi7rTfuJl01OsAe/FY5GYh3tqBSe0KhLyIu9U/URhWlkv7gjVHAwFp8aeQBUXHR32myItfZetddSjRQGxBINlrFv/FeCjtxM49FwKUBgInmWiYDcpZ2Xrp55DCOc+vimE6HBB98oNitqZmtUq9NwuQZEsEzT8jufAcIQILlH72iociQeg2PhBAPSvVOALCAldYszyhEPFERc4SUkRfeRFiOQPTqltK1pjY14g8wUclFD39PHJU3Xx2+9lXdBhnbMUJB0CGfdLeGh0B5OAJlBUVGx9OC3cIGm6qWBC0lNWgd8y1ai6/Q7RZ0QoEJcfOXwQYJ/b/XiAlgXPlswTVemHNuhmsEneluAlFq/YdeGmiOfTS4Bn7DHGldtT+5B1pkCyN8oGaFKzDyWzTpR4A0xon307mzJRlvDfabklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRagtPASOsPk4JKj+CXGkY1CLeA/WYryakksJwGTqHQZuD5/oFzkcxGWi9Ece8wlskqeHT2OKgTruCXB1KhL3BQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:eX/Hw2hnCMNRsTxX7RYG/yuGWSo/3sklZ5/F8sRY4zA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:seUH6on8DQcAWajkV+Lklc5xmsy0KohnoaH24tL5Lgw="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156439170,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQkN2aJv4Gm67/5foGIYnvsHlHupZFkWBla7KIWWMTuiU/EE0GvsIuVexTpTSzMRsW0AJRTnJZH/iZC/MDe+1LUJeCK+CHmpPj2W/abpK7yKkUqEcZqi14gKLOtuHle4QSVujrJ7qkSwhiPFv7gNpFm+52zuMybDZc9Feo+GrNKsLiCJ5Yh4Tupg4j0N/z02OUE/U4mktl/rS0Jw2alo3Bkm+zXFPOuSows+os/aiX1aPUStglFnBgOXLbhNo3hAwSdZI6+7ZOUiULZwjSEyf/otD+F3OzkCcGH7iAKs2i01rdSh0sFDIbjZSzqk19WZDIWaB8jjPvgJR0kMao3rzVZhNneqW5jhpjKBfcJW/jUNRx5LTtolvZIgNNoJYHFgIcAWyfmqYAa3y3F9Fei/ve8Z/bk4cRf2TNz98F77b4u/UjBDkj1M1E4RP/G3WicfDR8/2EIoBVL71kwKxm8wUI/chxh5wLmxUXTOKRwij+HA6oQ/xyTy4djTlITQhAfP9t4VNyh+06GaVEZHTGhrjpskzQvWSHwK7VYHVk1ZZSPLtWrwoLIVW0PFWyp8by3enl6X3lmy9jAq8SvTjn2GYX8QeQ/AyFUh2nGJajg760CvLFeelbcJxb0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEuUe1Hn9WDnG/GP4WL8aTYJa6Ea9PmNYcjQQZOHFrFeYkLkoj3WhzFvE/cvubEvmBAyNWla8d1wLblnGp/SaBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "AF609480BB75F127551D0C0E0A5EA83C104916252B8BED96F3FE2C88D056EA2A",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:b8HxW4ic5ClgrNdLld1kOt8I1ciMrnT3jIRlBjAaBzQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:B5oz3lE7Y2nu9JddUUrcpw03du/E1yher+02Klu3PJ8="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156439686,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAiC7Z1/2qGCHDrpS3jITTKmmHfi8UH0KBf+4oyeOnd5CJFhTftIVS8/9+qiinY0zQFWrhIYlAoC52Bx6TKZzSXhiV1UU9wysphvHzxBGdlEGDK1py1Q+ja7xZEKpNyPwnirUoqzo3NwTP0u7GPWpj8nen9Lb1B351mXRhjzG/tR4XuKSbNZhzBBMO3gRdum27MFxu/1b99odewdGTbAB57OwAcb3MAxDGbsRy04htfaWXChkHRIGxf0zeXm1L75m9m7p4aSE1fCzM+SHjnJBGRSW37XsrJR3cZJMegyw1IWsTPH2zkotptnO8Zy1VNcSk6chjsKO0vFiRxVhKYOAHCVp2XO/qGvwDG3CiCgaUK69OhCievfiJxIg4HSFgo2E3OGoHsQx5cgD5WR0zG+ahuNFU+/S4koinrvTdKtVNkby47PJ8Ywowf5uClhIS5ciF+aWSzJQ45mMdb6bh+o/tdGwXWyytYNrMQYh82OiCAcnSgh5d6+vlhSf+QWTJOtKhJFbNx9uyTgLxoUBU5D4aaa/eQc2hdEdPR3bp5YaD5YepeiC9qiHSBNjxK/C1EOe5j8AGOQLzNkR7FkhHtnGq9pGIEVwJseE0wgeGR67r9TzZ/BFpCVWsVklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8LkHgzQ0ghnCiNrAAQNgVWe2aq53vftt2oRJNtYk4OVw/5SYKNiCbHRoonYMiYTPK3pRNZgW9L5TtDFTr3xRAg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "E06B85707679DF1E7CDBBC7DEDD55A80FFDA39EE050D1E30017CFED5129C6F46",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:nQxCtMPQuAq92bocWvperdIC2LSSkVX7JmpP20+9wyc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Q8S/vSYdht0OMhLiyTPAQeMTavW4Hsdrxz6an316V/0="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156440189,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtc00qfqgBjfT00b46P2QxHE1MlG5w1nZ/xcVnjKykeeXtS9sM/xV4lSnpdvT3f7doVBTeMBMmaabvxgkKzu0BWpQtArK9hx6Wa9h5EsQlSWQWU4KqaiPcGFK+m+ghyZCFtij5uYFWlx3MAxWAYB6YTaDoyBoNfs5kT2pB2YdhgoOn6lSom27wbvrnnTgJA8N2c8NJZUz9X2Okw5Ynb4a+Q+PoX5xQE35xOZ5DcRdLWCTnNwRudN8GaxsF3OnuTyqiJsOjvtJEaFnkniwYY5MvxGR0mmTTbTwcHtKtdv2s08ZDoiGOj5F9HRZPByIS02o9tsmWAYfV57KguFzjCzWcIsgsVIllBN0BIWPrmy5Ggjqt6rB/VxlxuGEQ/5tXPBwSpCfNWbcPbzyzdRIOt+3YFOeTCD9SWB7JWttokXbg48YQnu3o8Now9mOwpKZXy4BUxMXYdCGKQxU1vps7gyUJ8B2TRT+Pzx1yqVZoN7F2ch0ZQ2VU32UW5bB+M2TaK5urzMjWOZp45l4AAYBrjUz8sBcK2PsoGeTiwJjKo38Wbe549n1g6Ir6LSZzTUnntZ7hiVP+9u6vCORbLxesM4A3Zb4trYhtFAaKR7nOasXcJeLuhYY9Nc/aklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwaTj4pSzQupxO7guuGcxW3qB/vNSIMsrLDr6kkeQXC4qZDuGiqBKHKyGeaBvjwGrnmQijNvOiIZWeAeyPrizVDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "6E87386028E438437DB6B3A63607B8D01FB127A2D8CC33C6B160916079AED41F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:viKf2ZSnIf4z8+9ie49XRuAla/EhPkq5ES7pBT1WWFU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:VVB0cUuESvv4O2B2xjSoNrONg8W8D6QAw0RVS2WfFM0="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156442746,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAA3RAlLiIaz62HlIzFEd+1a+KrZAtRICTgJXIqr+ljzyukoNAXWy825Afy8dZRwiu7W80gm1Q0Mw8vUE2nEmA91OJrrhnQ4QTCLXa9jLEjlvKuWlD2M7NH36ZlqJNE8lMeTLk/HdYvf69BlxB7x0UidHky5qSJAmX/UKHeO+GovxgZ2ACw0Nf7efkU2wIfCAY2GNMJ5DMhzm4KPaOkxD+USfk8TTdRDQWlkx0ZOHoZZ9ikXjIxAOuRZTb78+ExfX880D4Kf+C/DC4iPTzr2CC6BETuYMxf0yU8ys8FcBRwXCkp/TagCHSHB+rZ2/e3MgbFkwNRhWzWiDDGn1FP3nxI03gPttepOwKbO+PWMSnS0CpHCpst1iM3X9IcEPDAUr4H6bp80OXo87fcFX1gfJHpZezpg70jweJ37IWZTm9L8Fr+qUHNlmdPq1mtz83E5XZJzcVHswhgsZGPFJA4TUqE/Id7u2/OHTAOsz8VAg2SnrJvAwtmN9IBqMqBnl/YF+nDvb7n4FqD8vxKJDv58J/OkmmXEfT9GPKD7Na2jMfvwgdQan8bpjnvsMYOZs3XyIIo0G2uPB5DwsP5FQZHBDXNlXZvtDQ4qotS9vqBp66yjxBsufF6VoS2o0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdpJjBi8OjK0b6QRbxAOtU5f66IzocLwRLV0O35qYl7M4GqlZce0P3Oo95XS8x49StmqCTtV9lFWVAZRUsfWMAQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAYt1LydEyMKjnEFAFpH+FZsjolG0JpLt56ZdzH2heRgiQ151CKuRdZcSZgQEsUdBpsKh5UoQjI4ygtaJPF3SdA2puJvxbS2+0svpvT5v/IPmt2546x5Chow0wCUN3C1X86LDWFqPjStCle+7exKGCeZevXHa6fM8iZp30gpD/bsQW5G0PFOucOm/T/DP9mPVVIdPD4+M4pbRQMD5pgbQUYQ8YWmeExLtg0BUHUGcHE0e43kSb8D1IXvjqjAf9Mvsa8RwGimNNJOrK8pRgQSP2/pLuzowdWuPjYejehfhlCOVLzzQSlxWDhPtEyyh4/bAKEKC07LBD3jKi7mFwgQM9Fi5aAVkkcEr6k+xBcKLF/O2wztjNncT1fllRxGDdXcQ1BAAAABo3UNQS5+MNsQEusTnnodE7z8B+PDJQR62TCh2fvMu/pK4RMYAGVGp+zktlQwVLYApHIL3j4TjlywDhp58Tv+gvOb1yxNdTWZUuH5Qs4V/o/qRR+t8YOvKFSLTgdtkgCq7kH8oA0A4Rcuat5W2tRdyOwp0JcBR90tBVooW+VXNj9dLL+2X10FRxq05+AAiwVIbGF486fO60tL7530y/YFr6xYIreanP02QR9kCIqty6InHhKBgaemldNmKmSexnSQFqEDCDU7VCo+20hrgoQ/IQqHcEVIjLyl3Q7EjwN6Vj4xRsVHMzNAvwLwmoEstp0oJmJFSmKp2ejYR/vqk6STRXM5+rQifpJDICwd/tzy8mrABNSiiXPFQclw2s0PQ0mIxwEexwc+ndG+2Vj9BrQ+z/v9+qEX0n773BdxE2KgqUxP7zIHK9xaD7y9veYtMO1l8Oei0qhZsW2FhzTSDmqWtECSzD/OrYgl7iI+KWd8+nPomgXFrEWR7eoOLsgeO4KAlXdcRwzptHjxUNR3ELIUtnfmLYZe5UBb1Ui9dJRFYZmxfYUsITR5LtIos0Vw4H+9VWx8oy4HK4STZYVR+zXlZYi1l3eQEq3AZfu/iFlRl6S4MBZfEaNsUbDBrOhZ3W5I7oSr5v7qga/Ftswtg7hWAceirvYaE641W38Lq/M18NpWIpa81m03cxBKQJ4cI7Nf8Rw1NUgyOn8IlSuI9pxE94IwVWuU7X4SQaCvjL0+zw4itiFwIyvpfJ8lC70LD5oYb3U8MJAP6FMBgfXM37uZPzyimzMvq/nGfxUN/WddPrUUCjp+mdHUKEP1slh6MJ56458cQl6q35RLQ09MnPhVvHOybKLoRPw16s3o6MOh5vN11/qJSbL3SEYURsfxgacNecEfMcwREdTKfPkfeW3HbMb6Mqr2B3wfaWQVGNLed6XNQrtV0mthkE76Q1IE2VwlZNsS38Yrx70YK6v+KglAsE1Yq3LX2Eh5FbE7TfA2sCW2IgNfrBpTSHABw+JIEdFFDEs+d4a10P8Dzi9UcVU65HVs1IoAt+Zfhww9ftNfr1j6J3l2hsy7l7OaACo6dcv7VS24JHAyzIMl1ZSM4PyV//5sFcwkV+R4YsmcYmcIynqSMHE3uUZRT0f5BZZUQKIM6DC5S0sGhHPzRxvbGbRCowW4o1xQo5XRhOkCAteWDRWMvii8OEpGXXalTdImBl/GdzPPcxwO3vHRt7LWgzvqSAxPa+yFPcG22VKo1uCG96E8y6hxOByBdEk5ecIr7LRKmCxAcfSFwTetRmwb7wx40nkK0JZm/765GOCa1N+GydUuFzDM5qGxcarfYEMBspvsTshbpvHImN8b4t0UDgny9g5v3SrJKABseqe+/tQWifaj3zNGlrrDr+q9kB99Lxjn602DV6dYEFgulFHdIEKSbZMGKwj2pB3JKBxnms7hlx2KUgVH17PEyJmwVZCOFvBxfcfgk+OcHId5YsZyl1Ej6Lw8JvE9xzflHECDVXVkto8/J8p/I8uScItCBvIRcXFo9BZRnBS78z+0cJ375rmoQYWyeIvVxBiLrfDS107QXqqfYVrsDzaqsn8Yy5yjNyBg=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaXZW5IK6uG94x15siANjo0B+mzDnbD0TJKQnOa6zkUyMh/61+VGPX6Qlp/7JNegZI2AfXJj4f3WUTIkg6IUd5SiuUYm2pqqIEukzl6NMTg+g1vYkZz92qlBKe0szeuQcjRFTafkSMAuwpDUmTzd13Jv/pAbGBvWLyXnV5AeKKjkZGXdZhQXG30w63JgAgVbpDO5tn/SXvOX4WLGe2YVOSvaHReiQLHRkc4j7X11eFCeZb7DFTeCfdcCQQIQuD0RlMRmAmoLV4c8mDRpAkkh5Pzc/is9zMZ9dn+78DixFI9TQ7Hoh9VoPfU0G0YYunUsKQvbP+9VFwkDIsMnU8BCdkr4in9mUpyH+M/PvYnuPV0bgJWvxIT5KuREu6QU9VlhVBwAAAK2y1LuDSMhuzz5820nwFy0Tp9R6hw6xqhUOhPXd01uAGfLtVIIjd070gwyxQe9fsbLMYAja8DAFwz7BWGeuJw2FxExvSh/kxH+8v7ZiOreFD3TKUWaK7uw2EQUnku/CDKcdECsfQh3j0a/h4tzGMjY7Qe8fqaveTrqNXWV6i99P37nQhpVjxQ/AfGkIdU8dbbbzS5YgKHBUZvcTNGgsYfijpqAEfuvPWHhxenOLQQUg+Cr8r5eeT+L5/10vBe/d4gnweNJr9urYY2SJHikNxvz0GTaPFanK3ISXE7MW8lw3XXd01dC9+Vg0wTbIq0HCHoeq6ix1WS64GusfYeskKtZssF1Wv4uPADG/1z9pZDzLPA8x+qV3/GVsH8Wsz4tYqg9IvOG9bPeERCnJhf4f8ysTWwPSCw52pbvj6+yHvDcwHriPeTICbgjnA9inYKBoSFyCcY0cmLUFlDHnrPbfkzpIKOaX/uP57MfR0RIIffhDeZbfwIJIY9vUYv9sqYn9iUEOcTYCRbMeYEPfrEwcg3X9oJeAQe+FUm9+QQZseVwj2I863xueTli7PYWc9xaJXm3a6ooyHSt6YhdkUmt+/lRbniJaak5u6spEioPfAiOBeKbg2zoZVMt0ZmMBdEr6+aqQeb1KwGnVPLKblzAExcICn+yQtprIf2LTncl44AgV4eeXJt4S7O2GZnAu6kKDJUXb9b16YnQrNf5QwTJ8rvjDLHhZi+2l/ZC4QMX1ZoZt88BrI3TU/OziqY1ZoHRMlVURQduiRXNeq7XShQ00xKYKE0zPneEeneu8hybjzpA+6iQMM75yk5C4z9UQ0ZRtJwpWX7kPpJ6mH0ASQ4u0CCeIyjD+Qc6NXtwEUY79p57d5kDXiDFYP1qNlEGbuDyE5ES0IO4EwPXKQhShywoO/n2+WFjxuWcZKz/lm2973SAq+KxitjiCPlwAWeKEv80b8BH1JraTFbbsRtcHUF2kEI49B36wCI/OlT0JN4wmWjLnVpbQbfRdCmm54sI3gRoj1fYOm2z/9R5BQ5FTMPGiWLKxR9hmjl9IscP6OREQSJDIJJB/QTlTudUMxINrspiZSutY6YaaOpcILgklaC5fb2y+YrtY+f9rZOWQ/o19xFUxbX7shHS1IeP5cw13qsoVdVX165pNlGwLioWxUbDIKodZE0oxU2h6nyAuvtjDLPuWfZetpdW1LqFnGDfdfzXNk0WLCdnHYWnVF2dUXmPdtabtSvg3QrWs6537/EEXQ17YPv5rdBtHB2J4pWU9Mswcumw1ttKSQhBW1KcDBiXE3OmorTMpu9PUqT9snk3k8ZAJpml+e9592XyxxD5hDyE3+wBGkN0d0ziKhJOyrvSzQT6FCFtwsCQBpaAAH+lTK2Zx53CtIHjbMA5Eb7idv7rT5fRr9BiFCrmr+jMVMdFkBi03NzSgdv604ilXeE/f1JiApvDT0YtbFXG5nZ8VmZQQtwi7FqcGzuNCHWu1MiZQ4ewhf4hpUk1qmQcr7GOlg/Q9t+2UUtPmq9nEIuNn0oDqztLmUef//bJWqOBMuz3j1Zes9qSUXz67uVSywouAsDtzu5GurvjN7kpDnOCyFQ/HBw=="
+    }
+  ],
+  "Accounts should update nullifiers for notes created on a fork": [
+    {
+      "version": 2,
+      "id": "616ada68-8657-412e-9f0f-a93794941bd5",
+      "name": "a",
+      "spendingKey": "fa778a8c090126c7790c8a3e440c2d7e2441c5272dc7a8428d05a68d0164410d",
+      "viewKey": "c8615567481d4c55ed91fb332e3c5095b00d8055b9cf6e5e3f43ba0733d2df66b29ef52cd49de53721a42b0e8fb97364f50171ea6c5848722e9789344237df17",
+      "incomingViewKey": "1a8128a4c7fab46923c3dfb9d4ec082940bbe86edaaaa73ba4b286b78f050603",
+      "outgoingViewKey": "1b063e2aee4d69dfb0c442b3a17d03d4753fe3157e21739f27703d769bb85fa2",
+      "publicAddress": "b93c060fc5e8d1f73cebc9568ac4c51c512f73cd08be34d20f200b8f7b68bdba",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "5d9fb22d-68f4-425c-bc6d-7878cda57a67",
+      "name": "b",
+      "spendingKey": "bde1b0b68595c499f1dfb2403ea2379df306bb1dea79fb8e1522f631dbd57ab7",
+      "viewKey": "3cab23e6564cf2f513f294235ec2bdba9d4ce9a4289b974cc809fcbac4d566be512d0aad9d52549a7e4892ee9e9ee1ae45a58cafe5c53d166f92d1464a8c351a",
+      "incomingViewKey": "e66ba5de0f3dc74bf6305a71e11b658a14b3f7e22b50d2d8a8dc5cc4634c9504",
+      "outgoingViewKey": "55907b846e24859d1d8b23fa6942f47144905520ea87b3fea12cf1ab3898c914",
+      "publicAddress": "fb4a2b5616253e24903c7bd1a78b1ef97e95f563e962f23aac3dbd0d6d86d694",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:7iow4a0648C3BfFfX1I37IcuI6h0kJ75J9IOuvhAtFI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Q4+mJo1Ur/RbsXY6Q4ofaeKyKTeODR1pKgdB13Qeh0k="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156445944,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA2yCACB18MnXrFJydlZPmNcrpqQ+VL3qeLFGVCyjTZWSn6i/OMWepV+xZeIjC23OTI4x100WgHPR7UPPIrRikE4X6YV8jSPV1c2HMJJCUTwStbd7DDJMYrdy5ie3kENlASpIWvGNfEG4O5lMaAU3YyCwotRhGcx/yf1hNdhDA1ssEPKQF9xGiVdTJ6ii4kIKza7JFbRGw6iiPRclM3+MnRqk08l+EBP6H0IQ7VMWX31WQJ3C0jiuCDathGPm1SMOnK2lOwV53UX/9UqabTM0aETd3rqGPAlGigM5FWRhVAjv5vS/ttL5DV3+zIgVmXzIRn/RcKl8v0umwew/hboJVgvxDzF7QrKE/Svw9/q6GZ9mL4zAgY1rtIGFMYIPOKR8/t2zKwzvL7vshPsQ2YJJcCsjte+YVsNcU1I2R1zUl6LmxJwlLtpVgqPtzEmr0Qr+4rtbV3ia+TSHOPSG9Y+oMAqGI4fMTAFQfZQviLucDHl4mTa5NxMV27VgCwjRwb3ZwN2xfsOeONrEqGX1Q0Kkyi6j2mcjuFz+8ab3Gk1OXS+25xlOo8qOBHgFLV625Xvx7vYBlMmfiuxlXAndwZekApGtbaOYNrdytslGjm/jUQXoCjgfiwMHVZUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3QLpDuBeccRjdYYIgCxxAQpxOlIUBb9BkoOGXM+RjFXBudJfopeFVIh1spsVA2viKwOeBkA6qpbILaWWfyFzCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+p93bKRuIGYYqHkhtihWtKLNRJUK+BHtZgf/MK2onnM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:zGM993KsnzfrfbRerefcm/AXb5hu7k24P+/BqpTaRyI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156446528,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA7IA/mHchSkVtYKOQwLcLFb0AG5UAZJHwx14JcWonG+q5PUxhgtEP2tNfFlBxkfk9AsEi+aYgP30JJb8Gg/ug/29qKllgr+r710J3qbXtO72H1Qy2dwQSIFXyw3LND9t1Sn1BVp0/Zw4FekeZ4CmUiE/xAhn77Qu2GwUVtm8Gd84EF6mYZFMly/NVqktcENO2qggw6hk6SZIohr4o30E29B0Z1InpNTOphNWIoatMegiZMk+wM0bb5MVKnFyHFpqpTzNkyc9DYY1vtXIgmYy3Reo4xBzwJMsyelHnUJ2z1C1pOZrMm+Nat2vkOhqXT3y7omhtJRAVJ+j7oU+OOMygjyp/3sHLsAtWZx0ye2a8tAyTn+C4yXTcgZRdesLuig0QZbsdrh0EduiPVT3bhjl7xyPTbIyWHktk0nmAOSdim+LTsvCZhoPFeCsr35ynCIgY91+vcN5XVyDMLEKGd9lc+k4Gv0GhqdwtQaXzgAYQL+wVte+ixaxT3LRMJbw/eTPmUIBWCmrFCVyTlXnhsCUxLdx+9/AZp7J70JAzeUjy+Wn4PNCzeEoBbnydg7xUaDINChMK+VGsTvq1oAzm/fm0X79tlHx2P5VN8UuVmkKBkagqEgYlzLBwaUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwpGpCvbjNfczcvkEGeImztrQ9aC67KzawCrFgV+IoHVZ9/woVqhThvzWGk/GLfhUmcHxDKoZpFWPRWrv6CfguDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A93D35ED0016797228CC73F2A03395BD92C33D26CE98F216C697913F866320A4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:RaTCrsCnqzofM3bjD+B/EDZQw/yjm2kbmRQt57PFChY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:MzHLZy4ZxqmZYp8fDubu8AsRu1a3X0nQMSUk5yKYD/w="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156447066,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAALQ4udLNIVo6d3cEnNe0pK56GXgaXZO6oT8YLHbSRd2GJgLtF4zHWuveB6JruVrDsOAi8F4f8O+CaZQTmP4t8hGIwE40m9aKXn9H899MmhS6WsFUi40qURtxaqqUxURWPLR4dfYGb0zR7dMCgQAhBhTRiUiFdCBtCehUbdiKhawUZO0ZNmUuXQiRZhuGs2MBi1Wkyc6pRLoCM2a1IIeemKsS7tdHpA9AOrkZ2VlMgTeenSDyhHrn3ea2tLsIOp4HGeMmJbQEybTLDr7GvxItwMZujuTR1KR+08x75SBL2gJlqXjpgU+Ctp9yDsg7OiFWVCsM8BGmALu+2lriJaQLa26Jz2C1cLvIpv91eHPGPW43EC2Gn6f4r1+3EbVbooAE3Zfjo+xHvLc/jWe0wtRTYRskfhAMM1GIBod40EkzJ5c8BzcDB+AIJinAWwL+/RyTIApE3QSc3pNOAz+S3cQf1aj0GRr9ETydBfK5x4oMniCtB+ZuCwQQOzLNj/sM39LrdeoezodFb4Dm2FtvgYQ21PU8OsxDKA/U958VDTFwj/vM0FDCZiWVgtobRAAIxAvOPNs0yU7qvfYQ5mEwbl9WuDA/nxa017smBWUHrWrOlrpbOtzanxoeH+Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAL4ofidnlewuRo1ndvIznDb3pPmuUD0rziHQsu+0hZ7eq+jOSgAnxpf6uSc9wkxofyU5TDO5KUW61skSSk7hBQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "57253EC1628B454F80D3FEFC441ECD0ECDF9EBE272E77B61353F70AF002B3230",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:F/xtS51bmDomVCp5++GI2ImPnxxhsUqFwTQtGEW9dTY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:J2F66PnorS3oI8bVfYsjKuM6aYbjNnwRJKe2IMebG80="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156447565,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAhLc/sXjGj8PyKc0ablBQ5iWU/Ta978W5UJiA9xGvDzun703QiiTPgdIFG88M1bBzQPYvw7/5tUa1oDDe76O9qV4hd7zRgDQEbAH2uZ7seleM67B975MH8Tprf/Z/JfXPMbMCi5h7wD5+nSQtoMVdPhdQMJD2ehCLAogqae84w4QWn8qA3khD1a0oJc+0HBUtpY6UkJPBu45WE3Qs9xmwZTbpR4IY1DGd2nQBiGNCCgOA+OjAYc9DTyCH31nY6ee4wPu7+dYUH8vT704piodd5xQFJgGqVEAHduIU76w5uTby72ZYv7tBSBs08qVCZbwzadk9QqBDoQcKYxuGd9/454T1ciJd4dsZt+2Co6UaZzqEW8a81jxHFAZJ0F/xHb8qU4NfyuT404m+XkmFSbsOkH63ht0JRq1G+NN3wkHngPGOZ3nIlbmjnMbip5V6DSe8xb3n5KOCdYBNjYJyLXXdqRZ1EhzmefDL/X8WQWHOESCRGu0kgCoaANovyTEKmF5nmUZr6D1kX5WaX6sJJEltkEr67QTqWCdPvjg3Nz6Vl9NUfRHbmeue+XiDCcsKoUkAP/zgsVRQWBylC2y1urw2kBNT4b38pXK56QZkvowNEz6ORTqLFKyFq0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRpCi6snnKrvZwXjq/fbVVeBOELIR+S0In8kR3py+ZY1RTxcFIKW893NuBiklj9gMUPyC1lK1eNhktC41/bhICQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "96099B35763521364B1FAAC5E2532DA875E46ED5003E70FC496FF351688BF4B0",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:tPef/YWPlHlVpUkrFWGhsFojBK1QvqxjsXRRrAUHMAM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Mws7IbPAmFqiu5Z8v3kOmGCpOISezPY/0/b168EgEo8="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156450093,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAA5+KJMPZSPOGvmr/uuAwQcTqtNSJ+hHzNqaSrdE8QnqOlHpAfe6hvUAzP5ZOtX1wNKUqBNNN6WpRRVZVcD0NEWyTPRWlYJ24aEctYYnGEXqmRxr2FRGsW7sDsAWkK84eoUiBhQOonE0bQF2FH7xvGZcBrM9JLAojpMJVPphy5p9wUf7Iv7yjoy9e8ZrgRwga+d6LQdc8qZNepZKvpNVxJ8LJzDEvWXF4rvp46JpYA2463JTZzDdU1K8BoPB6kMzYzsG8Sugv3L4aAv5NBz4+GE3rg07HB0hQoG5QvW034g3Ak1+goWXc7YjA+oKZiAwxPj8YwXu7yalvQ9BMuFon9W5rJy2Ss2EhfAqhrXlQR3hFFYd97esc/8acNOeZwPoxDXcyRtnGpWKQ38/xxbwEryZqN0SauQFCH0wjE67BKnkwBsUFZNlcom0Z7uJRLo41LOrCD25LpeXhRhx5+xU8vsgFYSMaYYogGJ2qRLKMwljA6FUW/z7NP9sTJNTnzibapg54HOgRHfbES4h6A9AB0orDoFBdH/j1tUmViU087Bm+/iPb4g9rqBQ3+qVb69yRSaHpztDA1kvwy57pOyr852dG94ZwHHZdTkSw4dqJpskL1USQFNcKG00lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw9MxcPdMeC9U0HGyHK2IiExO/rnygpZ680Raetw1MCRNfawwUXUExWE84/WOFBdYkVcExISYcQPVkhC00+5l7Bw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAXsq1NACk30JT6IjPaJMCPgjfaEVxp0uk8Yf1PaMCsRGnJbtOC4kerHZz4i3k760deC+uZ+fS8749+/OWK/BddbZ3wpcz05jc9RtF6fOFNeulRY+MZIiObM/dm5IdGGufxBNSxyhZzVa3YNYvwCCKdgC5gOyRwZPgcQ1rFl7uB4UNLA+vz6QVdKTciXyBRIxk/pLAiWwkO/iiTnqUq0geVshqFTJdjKrMJlA6qRoF1Pug/r2qt2OpgbzrX+EvCrcczx6yGXWIbuddU3/Cq++M/WZyg5zYaUtgm6R1IRSS5bcXigfyvHrGkwuiODM5oA+M6cHZqWm1LQtE1DhXXXgY8e4qMOGtOuPAtwXxX19SN+yHLiOodJCe+SfSDrr4QLRSBAAAAPu2WM7seUaxb10YTSkvTUv8u6K0ya03dLsrV2SauH4xFY8DS6LHxcF0VBu4wp5pY6C90hysYx8H+YXx8RmDqLq0lBw1he7MwIEc8CmcyK3SawvCvIuTKGKR687Z5vTGB7JiOLHSmNSfMp7vewZP1F2LTYNF9XCcib4uhiR2eHS0hvD5NkxRWFwuY2geirw4ka/KiPZZDzQ2xPUYECZmDQ0h0uhz+Aqvk2c8/exkB9I4O6bhYdmhBmS/MVxlAT1OLgApshIEzR6pEqNdf/ClwWYJvfbi2/UuPv9Yw6PFrwRohy4tI4m8ikc9p1Q0WByHx5FNdyc7kZ3ctYwuGDpJ/Mp8Sy5AXn+VSep7RfChmitJDXuYRRhVylbxHBTBNXKrGN8eJexhDvd/kAt8TA03J5ctBrPC2K65CXHSIy1M54/LXTmq8bHuPdpo18mXmplDn7o1+kzOGz4hZVRFc2hSKzhiq0msjjrQqF6EnJrcjz9iBHedSt6S2YjmgBFVdswH2rE0CviKU/uEE9ajydqqtm7foJ9YYbJG7p6ziVIh0xsW1w6CpS+jpHmm9RodrVvS8jvXUlkV4OkZqrD+pfPcAyd2Lj/HQ7ev+gpQRGqZfKd1pwXOCOjh+NXHrt9wJzJQtkdOszyyNYdgyu20IUToVmLpmPiZ+OOqVnqR73EqyMljPFWQVK1BA4xC2RcF11wLifU7658955Et2doDX7d6fHzQwBqGmEMAT5j/OxIluIdG9Cv4LmcEtKrJwW0DiTi/QKTiZsEqG7eMSyS5LyUEgVbZRXbPuDo+SY1QWPEwomZZ8V0s4v2fj/yIB4219Z8ZvDl/fszXGlhzLMXvan1fUkA2g9UpKZECjSerLDp9BcEyUyBoe2fO94SHXb9R3+z0SfFZA2MrvBvLBe5RJ1Yj2DEXUuoZksu+CbmS5BeZJ4jMzu9gUQn9mj4C+VcMQIquNnJEbRilp20EVc8aHiRSaVh4sl821GsWycDGuw0dqUK9ltGiYTqzGDyS+nVqRtsHELh74l7BGRaAjzTbND1KyXZcNkBJUJOqf1WujXhxZxhqC0QpZ+BpeCqVTL3OB6rSlfdNYrrvJUQdjkftgyilVGlodoO1msAcBQqq0w3Fs+6P0OA7/OcvGi86FpB2yLep0iv26D1nKmRK07Pu2H9cfxdFf+lfteEXh8tSWJv1y50UeABoIt20abIm2HL7JVgnzKSvbeW640c/OPc8hjSiX+v2Y5sqNw+jWXafQt84OtJPjNuh55pmE1uK55IbDvgT/lRKqczJ0nmurZl7PE4XO7Yi3yUmYZE8bcB7CmDFDXaaCTwpcYyPyiHN1ij6rtada755YHFD7IxLHjNN1cGG8CWF1EdVx+7Bq3lv77TP4+iRrCF/0SYSzyRqlJa6aO6bQ5Du2rXUGwLx+BPXLuFMnhAi+t6u4BdRAB5oTCeyr8wFEvWAut8jgByHKmR0CgLSVygnop6BnLsq+EU4Wb3nEr63QtjQDRInkj2FHtaDOh02761OB4Jf2k6YzVvfzK5cvUCITuEN0NbPL9W7sYzlM4YlC2ltJ3bGQgTtleqggJyMQ2tgJSQrKPt60o+P8yz3CQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfR04ueCeCP1CnkosSOMk8kOj8sY7TpnbJlSuCIxbATCWXteLkzJcX/CZp4ewCKS4hLYokvgaXlzbQhc7CWyBsSM0knVohCGKbBZoJjRly8GxgqWXacFczmhUTCgefBEp/4OFqw5/UZ7N2wHOQxix476XINAnxCnzJJMw7Pk/nDMYOZwJ8ow8D1keNlAzNEGJvrtWEHYdLm52Rmbw2zhSg7cRjOcUTotUIuhxLK1jqO2h36cT3XPIpaXT00t6lvIXqRuOL8fOxY0TSnSkfX1LdMKQT0U69yRgdU5YhsYpoo+slpq8MBBvSb82VlopaaLZHnKPW7itZpUnSeyYIR5YqLT3n/2Fj5R5VaVJKxVhobBaIwStUL6sY7F0UawFBzADBwAAAAdbobH454nie3PAr4dfaHwqCggJ72Hzw4KQHouc0g+HXG3pj2/4TCi9sw0R0Rj0vnAFJt6gjpYk5OTQoIk11AY1NcJdGmECY/W4Prt0hRHZTKmDIjm0YGnShURM3sQuBILYhk+S0yyNbUH2tT/somz66IGZd18T9PwVGsw8QnHe3p4lLYSHClGnzOGB+E8Ed4uVGD0aLzUjNkE5CNyyAuL/n8ZxOUpuiv6T682kXQmynPw/Ks9xVdg4w4xbCXqY9wPlUmInix+U8ztRYSYGHMIhc4mk1RCnSRCzqBqA0/qKH4Yul7FYXeyAX/7ni3cqmJZC87BjVbZkaiEvBNGNg08crI7NVFyj/POiCcFglUBGWM1Iw15Hd3aWEPLv6eYiBsEgJWWe5iv+FYgnDso4x/AsmS1wS4v7JhUo2Eii+KslNqXlijmtWbsiE6xashJldDk7N4ad9g+sAjgPt2nj0TfU8K6v2DZkQcx7keN6qntZIp7iaCUbszDqPuO/1sZjs3MzQaqX5RdAnr8CuQuQV7R/ykgVpzp+Tp+zsgdiWW7JnIV9aby14J9Vn9eZynlq/imvdAplSZnmcvGkJGI5HTc2V8PCxYkxPuy144zlw1Gi9ox+EeRNlphjVZX0GbV0cEuYQc3kz2wa3mfmvA0DIwWSiLoUqUPFzAi4Z3RUTq/IuiOF6e4/LQCZUqBZb5dncSqlpIsILFgX5vOrpy2xyvsz+wAtrmVlfNsfr2BnhVoRzMYu2u2lUtmMje1iwd1G5fw+49A1hcJLn4atLmydLESlwldI3Jv+/EdUp+zILpdCS/lutu7cEJ2BIwpzAoqXmWoe89h0+m3IcRdZXwQm7krZBBXwMkVpCiosrlr8QOP7b2Rhl+fmOXOwVOKOH/s1I1LAiqSMJ+GJVXE6Ecz1J8XBtn/mJW5JtafAcrHLUD6/ib+DOvGg41cMjhDKzKFzuCuO4f4RoK9fypWkZKRlUYq8O+Xw+apd1Ziy0INZafMHqqmKDyyhUVWm3k/XuduM/ap2OMQ41GU7qlhCX/pytTCT8g54X5jfT4lh7svrLoRw+SRoH5voCOHt3SRQ5b4P2oIcDQ0s8bw2F9hyYeBGgmQq2C6ZvrkmAtSAV8VGeNPemDrHcVGtDJOqRVdcZCkY/rW4PuCaPqFjsYJJaEKbSFTd7XcEtNdJAKBGHnKkOP1UZIcMIIX6/hs2h8BJuxuSJ4sqRDQqi1SNtmqfUVeH9TILMkoJ4gc/SMKW/R/Zb2G0cSTpZ7tyzpduIdSFP0j47ICd8nb98tnV20CTo2nOU1pJEGdQ34qN+loaY9dubdm0EsdMyPs/+nz1r8DJhwYggumvq5CPMMg5XlymPdh4z0fjluQPbA+5PmEGm30OxB43S6yXyvRwO1SrBPcVVorxmgMwySsY4T7+PyqB42mwALZYV5gKlVNFLW2N5ieMJ/8YBa8iuokpIoP5y81+VbGKT/i0/Go52tyuPi0/aM7zMBh2DY2R2a7lQFCjec+Q1gAT59Q8QizZNAPmgMPTmb2djK1hMoLvRZn5o+r9DVtP1xsoxaOt+crTkPVcUTyqXGhD5OviorMGo+U46zxouuFDBg=="
+    }
+  ],
+  "Accounts load should set chainProcessor hash and sequence": [
+    {
+      "version": 2,
+      "id": "99a25ccd-b51a-400a-960a-0e81fa1beab8",
+      "name": "a",
+      "spendingKey": "fdb1e44e008022e68aa2d5ca51dcef41427ee32e5646481fc79f5679c7efa0cb",
+      "viewKey": "e0e77953296dfe0761b2d8b790d998472739dccfbc7693f97656390a5101c7224ba3874723b9cc9145bcb8de150229176653e9d5a7de3453e85d35ffa434be68",
+      "incomingViewKey": "d21af914f11be5eafd6d6c5d0c730da074f7546631ce4c445ac3f7af126a7406",
+      "outgoingViewKey": "4f1184454ff8f80ebbcab0ed481dcb09871642b1c20c225897ddadf67a1477c6",
+      "publicAddress": "9345be50b95b05500f81b904620cbd86bb0a8847c09f5067d2fe41f66ffe8826",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+ZuqX8jGFo6crrP0UX1bx11lhFQ3foDnW/EtKiREFz0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:pi1x8UcEXlq5YHv2Qh9FhRiEWRCLd7/m55jEakP/jy8="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156453024,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAASDgqttYkE6l9oMsm0bqcURiyfgWgFIFu9EDxvz9GhFeQcSOZ/v0J8P4ZafqSFrdJaKBe3rmZvrL+TfFmllfCGAZWx2R5eECqIKXk9w9z076kdjl48o/dsK+P5AB3VR63mtO4W44ourNPq1M/SRtVivsj37Cv/AWmPAe1fiYaVVIZN5LUyGc05hZY81wEx5CgDlncg8mZn//nVpLHYUpXoPjZKUx3GlzJgDKuFj88cu6PeE11ZMcOFk2tBVxQzSPSUzOsLuNIc44KVaMEvlKfBTZzrlOzWoGdN982y0cu5kzNRUf0WnTVTD/OUK6Zpd0U75qGmkdU+cQMTmUn+tmM6ElD94oynZi/NgT7wCdHn+R0ZwboO3j7ampt5wMhqShgM9dStvLl9G1I5AvvNXea68IawnisgG/FyGqT0fD9L5o5lix/B3QPocRen0rVABz2dO1X7kJJdD4sKiKaqJqHQmWIG/5M7ZoWIz0uhioz5EPqUlpMwlFcfWCoXxSWWl3NxMOS6fSQOp25iOk4uXpkNF6BJze/5S7YQ3vSWQ5PSS7DbmupugkztlYtZfpG22QcG596Rj2kQiSemgtCVw17346Pz/rEshncfICC1vaZYQWeGeLH86CDXUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwY/h5dCNfMvz9K2zbUy+tRjQwj9ZBrYU0oH0C0YWYOXLC9TVkrmwThyVpTVo/goFPtobVNWQZzYDKE5uzX3UOBw=="
+        }
+      ]
+    }
+  ],
+  "Accounts start should reset account.createdAt if not in chain": [
+    {
+      "version": 2,
+      "id": "fd538aa0-ee9d-41f0-a342-144f3624d5e8",
+      "name": "a",
+      "spendingKey": "3456d28daf64eea17aabe04f2310efa52717c8acfe8d39fb0bd5666e8a27d99a",
+      "viewKey": "673a46f52648d83aa3191545fa14273f033ab08a7a42ccaf6482308a1a08bf1c2a2ae8f2ef3435e89f2c8263bac855c207f58a6532547319a599743d3363831b",
+      "incomingViewKey": "3d889b2f5462c2e532006a436d1fbab7b242e721b0c4cb8a2d320cb0c8727b07",
+      "outgoingViewKey": "277439e31bc5a07dbb33231c9dea19ace8b2aa7fd1c2ab2e450b48938f2eb7c1",
+      "publicAddress": "6bfea83c12841bd62849250e5aa45cddc1dc7b52e2064cea4c2acef5128a55c6",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Accounts start should not reset account.createdAt if its sequence is ahead of the chainProcessor": [
+    {
+      "version": 2,
+      "id": "8396e957-a053-4395-9c8f-cf85edde9d79",
+      "name": "a",
+      "spendingKey": "aa87e9b05e11c3e5a9abd17c48ba235ec9ff78a66c05ee3dc7cb8c0db0eaa9f3",
+      "viewKey": "0d8df20165f08699a1a63c8ae2756df9e13fea6253e5f2a34ca1ae7eecf1722fb6139f1bb974b0fd592796d69cfb2fd16524dbfa91d48dc08904e4d00f849c20",
+      "incomingViewKey": "5f53ec2e482ac2cad66d6ec27f2d4ad6ec593bea6d91e77bf5c86b207f41f507",
+      "outgoingViewKey": "a4f781c1e57aad6eebb92ea4d24678924a1c0dfb6229da089e40a841e0d71a63",
+      "publicAddress": "652c41a3f687fedf0781ad9de8d9552fbcab26587e39e937500d84b620f4d143",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Accounts scanTransactions should update head status": [
+    {
+      "version": 2,
+      "id": "120efae3-a6e5-4fc4-b844-27e1dea1034b",
+      "name": "accountA",
+      "spendingKey": "685339d98f3a53c7b1c6181e07e4b2226dd763369b08a73a11257f0fdeeae204",
+      "viewKey": "36111cc8a543eb6cf6d78932f3e82bb22af09632c6160dfff6ffe0a45807b902b22b23874f9018f7a8706c6e127b0923b1929241094bb4ec662ea163a0152ba1",
+      "incomingViewKey": "3f3d8ce897a457b18579fa851bb86b806d9a1b5e252ac0398703abe625342502",
+      "outgoingViewKey": "186a187173a8ff3a8190f6530e0919c1760c53291dfdb597c02911def75356ae",
+      "publicAddress": "1f57d3b84adc979ed169e202f4b5beac6a3ef522c0f0d1b3289a1d888a115a23",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Zaetkur0YYDFFJ6GqHCG4l/Kdkqdq/KIYFYFiHg/chc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:2oXFfMvJSfwnhqrjrH1gvK60iO5jBrtUF1XgJPVOm7A="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156454290,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAVQCjGETvdRnlg7UY4Bt2DT5r+vvEajrJpk8sfdbyjeOP2zhM51BRvGa95gPTSUSLdIW2Da4iFqwdmeIfu+dDIHs8jis9p+1mFRYdxImRueGgxOSOZhMWy5Y1saWEQB1L4CjYHkLNqIB+S/RX01dAVuDhVBzyBZExvuRfUcLXmzkSg0zISTrwPrAUrqpuJEAhEXwfm2z0qW3jCznhh2m7C02sVifnnz44r7+5Etd4HO6l4FxyWJz/gPtTcjgg106bpYosJFc9GNr7H1TMqmFbyysGXPdxoJpuF3hFLGPo3+3h+/Qfu38L5Gw0yr6h1TMWk5ou1STRRHvotHQfVxNYi4uD3heivpPhY03BhOps0g/cFjGhIlvWqX+f3gix3EAo34owdrs072KyUmnFvQ1mlPwus8OI7AeRaN4sVxZB9pyNCkdCJ9NbHje2qrhyVcIcOsx9O5D9soXewm/y/vpyiQBnJctaQv5bdT/l2ykRt24aesEhqWQ8B7iHHK/6KDKBlc8QaGZFDEVEcqukIj9rE76PZoq/3qh7szjows2zfbCV/jjrWU6YtD3Kf9W2QnE59S+PNIaJKjdkq8aQjQDG42nhJUF5BeC+cCOSnYdKrc4bu060n44S2klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWZ0oG70jfrP2qMReL4BA0ur/thmG8wsWb+tZ/75fi/OiLBccvzuNdvqnIlkdgmKnoqNmWATNbTCvce3zRuGnCg=="
+        }
+      ]
+    },
+    {
+      "version": 2,
+      "id": "a6f03556-6b83-4508-8cf9-2d87b9f57c45",
+      "name": "accountB",
+      "spendingKey": "548d48caa4a44b8350b8fe694197eaf9da131ab2e68b26c7c073c8d2e73bd13b",
+      "viewKey": "6571ece578fb7cba9ea34975db8ac37b81d5fdbfd224aa3c87b433d0cafcb794a7debf37e152686d0c1241dfd44ee261299a9d3060ff403828615b9396aef669",
+      "incomingViewKey": "6902431f8c402b8c32f42af6fa3b32e887eb164ccd48883af7e646a31862fe03",
+      "outgoingViewKey": "5de138af8f96534c89d87e7e04822df1fbed378231bba547aa301d414000bffa",
+      "publicAddress": "13b9e863a782fbcb70f2d714702bd419823b63d49a011a9a1765d88818c01e49",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "B99FC4C47ED0A88E0AE02C85968BCEB3C49DC97F583B5E12100D7C483CBDE551",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:qHQwRKnQTc3Tfvx4xY5J9IBUoZQpVuETJwU+kIRN7HE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:n/3LJospb7FqRYFRuG46wYoN1iYps35xDWpSRqQtlmU="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156454981,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAArEfqm7BDN4efr8Q8tEPa0v5LI6KyAKrga9SMuNoi9hagRkU4WLRkKZuhWQuTEPhXGAkqlpDI2nR2z+5H9fjouZCPp70hgppddY06VNcWa8esvWk14zwAQDgY7KiRTz1gqAF6QKlKHJXzg5xOge+Lgmx14hKFa0W0hBfVWhDw3I4UkpK5c7aaf+1ENlSqzM5DaVVenZ5yXXHT1I56f8BV0oXBglBbm8Pv6O5LND/xNsWBh8e7k7vadqfU6jGpFE2aNcscEkn7eebJvRrhXq6ZTkvqdpmZxGs8097OU77fQsQ6WZLaEP60wHCP4Y9JHvYeJ0Ho/3EtiZn5gbGisQpKF3Ueb8MPsMmbpyDldNqCpLWMo9VeSj+BdvypgHdT4r8JqoRbbQiUOm67qEgY+esgBPuOkOnUq4gkdzhFaAYDfjqv0MWVExX+VDmivtI1oBoujS1fMrA4wk41n8EJ6Osnwrq+ZNva7S3ocYcKKTX1GE7PZaxmMSKOVZUwyElMgCj50xdWxglKpLo0+HJSKSGYspf7ZJT3oESSd1t3ErgUdRXJrvNvBcVNougYZ6Q5ddC82eqLZf6EjIk3pWL2ki6kWh3+S9ITAeTPbJQr5K5pW6atSaGRRA1ay0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCU2sI9Q4Jd7X4omJ8Istq8Obh8clFIZMcMMAEjz9AjV5iIMZFzzEdxLybhMWfzJL9Ernu/RGAujAJrepbifkCQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts scanTransactions should rescan and update chain processor": [
+    {
+      "version": 2,
+      "id": "ffa34d88-4aa8-4ce8-8957-3dbbc878ff73",
+      "name": "accountA",
+      "spendingKey": "a73565b5bb78416ed45022babeed570f8542503a6aa94729574887c3440bc085",
+      "viewKey": "474552414535e8ce689ad957cc8e38fe243c51022c6c2e43ca03d3e03cf11663de590771591e8d6c6ffa6a9acfad78654b0ecdb7bee37464e3a9695fc7b5292c",
+      "incomingViewKey": "e60bd48b38889533d0e2c49ff99862d3d50027a5a636d46b16291e2c1aad3102",
+      "outgoingViewKey": "a93b3abbaebb38acd177bad8dd9f72961a9c941db16c6e1d9d06e88de686a57d",
+      "publicAddress": "e1c6ded48b6d3c8335e8007cbf87dd2ee893a9ffa8d5c37bc324d9c673233d81",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:gHu8n81rze4+03y3ql83/6N1ogpmJU06NkqUTrUN5RI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:qNiKDBvPSQK/r+WaZu9pl/rm9PRQ9jqF1+DNgxFbbW8="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156455664,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAcu2AESTY5GonJmdYA2bCM5foD7hu2FUC56ejE98D7meJ5wW3cTfXMwNt1ejElifsybBPZZi2gyPGUQzpoawZKVvFbbSQeefPefpLJ+fTA7eW2nHr+I4BuzRJzimsmsHrTIeh/Y6rgJrAWnnPvlYQ+tzn13MC+47eJDE6rTY/4nwDAkSZcuyIo01ymmc9PRfa2WIcHwaqXlgWtVk7wAUUvmEVhszuM7PLd85IxgDJcZ2Wg0J/zOpa9J5b1P7Gp5BqhgGFNyYUsb6U/OiNXv9/3mnHVmEJXT7AgeiI2KyhQYD17nvXll+VQwTUC/LUUlfxDnAArVaDFbzG7maN/OTHP/eYl5/hPhc1qYCMBnAQswBG0KluhHgJ8rOmoo5GlgBSmyLU8LexKteraa7XElLFg3pzIdQWLI+vOmfrKT+6rm4gd0Cx6Ho0yZwJjuHQbPw1WoL7qmJfulCyvv+vx68KBZQip41sZKmoTvEvcr1YdiZxAbCHDVQzy05ohptAhczkADIetg+W7ehNB8E6d/3tAN+7iG+DPxHdvmdLKtohYCc1uPe4l8JZWzFQK4hjreTpSaN32nFrxYNW7Kf7M65Ini/E/vy2T6IdQfno9V43PPFhJ/0E+UlAyUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwDX2L11GzdZ0eCUHKRFgVr8a4JdzVB0Cg5wMHRoialER8EH48DR2fq/ZXCPUne+x7ZwOpkpjoks+G/6BGBENkDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "1ADD7C1BEB12CC9B9E33FE9B06E7CBC2BBCA28ADC92720FA1A30C038F80708F7",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:fOlRr+yJ0vtHVLkvrBGX+c4gRdz63Xn4Pva4MyBgJz0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/TG96C8+GkNRlgszeu8Du+xZ4O0F7S3anvgibskiBRA="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156456208,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAjy0E+pR3IJqJG0O5vLKnLD6Yb02J9QPXIJxa2fEt3iihQ+zd6V/KocXXH8pzVQsRzCb79L3h43jSctOqw5BOtLgOEtk5FxcSng3rCpbdzbSR2UnuNNqueInOIbH5rLtH9bqlQKKSs1pk9mYM94kfBtnTpJlPBYVeLpXOlUOi+0EIpefvAuvoMHwGuLTHtin7qavDjtoha0stMc44bynhcyVvQwhnom5CUkXd0NoKvfiP6uqQPOjC7XghdwKzybqpWq31fsj86iiVdj7ezZBfc9N4y6LHpnqf7bd152gvpgsd5Wjz+E0AA6JYQlG3UEw5fzHEbSGlpiOnZOZx/TB3ZuFJ85TrVgRmR+GseA1rJ6zttbNkrI0JEwU/XQKRPutoGRpNmXNTYg/DEkKaU/yYcFqnm3m5rvqq6sdH8mPZOiWNcyLutQPidm3qeYeNnN1sg5CgmbXgpAwI3SscAvWVAVvTCifOWu5Zck8M/c1YoD2ssHivlYcN5QTvXyzeG9gcQ08m13KgKs9qmW/SXSPO/C78R+Nwwtj9OooMEkWfxL8WRciIsHrIpDrFu8Hhisd62yZ6PJ+f2aiVHj80LTzIBGOe1rcP6vIoVvfnj70VpTpnXEpPLB9QJklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFAMEzNwzD/QUZKxB9IOHJDqVKdJQEUo/6LX2PQ3Mjq/U2GP28uibeQV5RnOfQqnmNUL8CE8+g5opmxJW1RtYBQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts scanTransactions should not scan if all accounts are up to date": [
+    {
+      "version": 2,
+      "id": "cb2b18cc-970e-47c3-a341-f9012d3e5a0a",
+      "name": "accountA",
+      "spendingKey": "81e992000fddecab3266ddf41d9adddd198bbb72e1ab66ca1bde4dafd30aa8db",
+      "viewKey": "a567a2d11627884f884bec70b94c7c8d13fac24e3b31fe0a49d9090826961c51b48e3bdc8660b0896320565616ee09fed582422e22c8a2d30d2169061998d365",
+      "incomingViewKey": "b0d508494006681de4b81f2fb8285c5f95bc89849b55cd555efc14833ebb6505",
+      "outgoingViewKey": "e314fb1fcca201470ef987eb90043bb6a852e5eff743939d856d503fdc32fbdf",
+      "publicAddress": "27e1231c0e6be12bc11c5b25906e46c9f89a808d65797e29c8d1f45544dca74f",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "42b886bc-182d-42ea-8418-628787018238",
+      "name": "accountB",
+      "spendingKey": "fa0134a0d4ab4dfefb086f2cda038c478d9e87e02f8e163a9106bd23b5284d2d",
+      "viewKey": "67019428c683c2284849f6b8f8f77f5f9fb65333f029904eeae4b4e69e7ba40edf16072fcf14f92b24412c9a37b05c84dfdf5ee284ade932a8a8c605a9a76d9b",
+      "incomingViewKey": "ef56898d504d25d15485fc0d08726e531f56f91afe0e283cfc46b939fa440a07",
+      "outgoingViewKey": "097a8e0ce8717c128a632f2bc533d1cd67e8c05a7dc68bc3b6f8d78948fb9f7d",
+      "publicAddress": "e69958e2c90da4e82699d120e57f1d1b03d376cd71b53053d1f58e319ebeef60",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:vY518OIVcDJ7zzIh1g6BE4xMV2K/X7a4lIA/Y6C6fUo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:7fzF7JWu3L3D2nD4zQLTG1mrbussNG+JglEEgKehtcQ="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156456870,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAYyZWM9C3PijbTWAR+7NVleDo++trkkq9S6/qJiBN+I6Cd9pwSTpJtLhK5yzXca1e2dh1fTkVloH5BagiUlJBwK+qEcjR58obcpPVJW79cCqVJm/MBC0ky9iLYfqMMzdmuMuO066kiS6JR3hPJYKssTxSV+4PH3qXR/ay8QhHyZYYa0qTXwKUDzXM7DpAaxSrJhb4xL8fp8c+OzcnzCh1UK9egVlVJkEtFrv7eMDoDjynRZAQuCHtcSyL3bQpkjszEnqu09XVHoNzS3nNLzfw1D0XN95ONnmJGeb8hzjJmop3INr/b6+FgH1J+2Esj9tw/EkkkIFp/fH3o+JFWDTVRsFIiPhvNNbxirXmKVp8hY0Bun4Gr6W4GfcP9Y2Bn/5ElrYS5otv6iRZ+3+SMs2LYGa118a70PEuqBN7Whb+c2C9YpmHloRN8GbsFEJeu4dUoVoVmqo1NcFY560FXUHOaman/TE/1UN4UHkpZdwRyUp45wazg8QBSzFOpNCcquZSjYPk6fRtQiK/3qJ7/znsX+W9/nqm3S+VqoRjSYSHU0p6QTvBXfD9ewDbVcRg3AaX+uuikFKqFHNT594NWG9c8IVkQ+G+MYAVUi3Wr80go94mUJ4YEA9f7klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrjIi5Zbi8bpZiHooxWK9C3kPZHIpk2KxNTUfbhlWWQr1QAGwexp3RLqWgw5r3UmkNBpPqvNZdxaPK6gr9jT4Cw=="
+        }
+      ]
+    }
+  ],
+  "Accounts getBalances returns balances for all unspent notes across assets for an account": [
+    {
+      "version": 2,
+      "id": "f112912a-2214-4ece-8ac0-35c8896c3d0b",
+      "name": "test",
+      "spendingKey": "593c089bc9fb3feb24ff2846dbec5698ff81acf688bdd90180b93e2c50310de9",
+      "viewKey": "34661caa8aa143257e391ff06cd374968b70c192290f68643e24b652b97ff6ba8df096286bb67f96f87560bade60d95dca631d573eaccc521fd82711365d4228",
+      "incomingViewKey": "b8f0debf07b9e35f5fb39e5a88f2b54c15b0ac853b9f83c581f4d75659b0c900",
+      "outgoingViewKey": "3e79e0a1ee2177443b66a65430eb81fbfe0ae619bd9f611aa960017a0d233e6a",
+      "publicAddress": "7f23c7e0f7c7507f85341a290b43940bbb83b6e8b8e3ca02acbd1ce3fe243197",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:GCawZBiRUes/yMJewnXOVoCzmwUTxC0wPjkHUkK1ziU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:X/Po9ZLNSsX+Y53ZNZiKv41ehhjrjlpzMrT+8UwJdoI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156457709,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAMN9z68KCgxyUd2h/0+eJi7c5bDxm/yRPzS9W58kfukaoD5UDe6wVnbbozjViwdK7ICrqj3rtfNNktrBIbsvpAHueGs+Rv5O2zdgFeGQyA+uK8d46oMXjOFSN1jEU8UJvjG0DRn5E+HQwSII9UVTDUt8jj6KFzVUPbfQCoV2fZUgOOCHb3JbMscdUaHyIVvAccOz/IBqqN3bMjLVIZN1y9TiEJGfdDrBeE3ixYfNtnHWBDMW1PKcfXxO9oZstjSKeJ03fcR/lQH8AvR5XbtUuDCBvImDx/fQGxtKI3mYc7px4/DkYINHKXDO87Gu/+kl2ogZH079dQtxKhsFmNuh7MfTYRmU4QBJPiF/Th/BDCNeuW9BIPcWP9vSLdlRQKG8G8XuXPNF2nKDGR16a3LFgMVT+AZkASPAoBwkdI5wG6V0Zvo6vivWVeHCThDgt/ExLsx0Nmfk4egWCNk1V83Bq8gqlEMn7dYwkFMzxnxKpcc6qeJdJVU0EcbrZp7CIV1r/HXKqMsljIIR52et4y827/fnR7hfZ0Ydn+sIpVWwbvJ7RgHknAaHtbbJVQQ/52gIk1X3gFKxIF/qJIsg7hJcNglu1C3wyBjX8iEEw8lvNOdZjo9B7SPUiuklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRVABnAB7CeOIw3p3bz2gMd87np3b5urfUyu/6MHfBmv5MH4jdCc1GlLwp6uCYX6JCSxkbHiMowXqTKX9kGV1CQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAkELkCyKQb80/gKh+9SyKc1cGdGCNPHr+OioK46Ic+UOV7YSgjkZMXvOUcRrV1OSFeB7SvjEYBaR8/c8/a+bcvHgUwcx2y70dUxs6ZA74Wd6vQ5KgcLnDuhz2RpQxuXWdVmWUaGRe2u5uTwN3kZkPWOl+azfIR+1k2DLjm8MrKqYUdoq5h08CzoQmNzwU9nzup0UngY9gH9PrKBYpEMNzDr78yFBY6GAqmaOXle5OYx+L6Q8t9cQoT+yynhAUjT15FWyljvsEoBpUSfldAYHekXxCfJ3wbg0NYopDqZlxmX6sI9BcauUFakdgLR1Na4ZkfN4cVxOUvcUuz6bvh4t3tGfxmkCAWtF0mQO4upRqDVUhImSwkboITdvlKVN90M9OV0E72xL8ROUFwbr7YseUDMkp/fLCOZxww+Kp5SPEWy/NXeauR473Y+ifNZX/AFq5MdSJ86rxaQbIE1TEUzSAzfEF2hFq6V7bPXwIGrSS6Hv97vqJJNC3SL4ZDnUtaPwstS7ma+CPqQSz8RwhMBY7HSb9XtJ2fqVMKKalmEvD1Npn81S3a88zmR/DjczqxlJqfMFNulwPw2VfqEOFGA9/52z+YEZcDF1VtTgE8+t3pvFlVyUBbcZCqhzTAIlff6saItnWrpI80LPMK2m6+/4kIZeed1pofRg3/2FLBYKGLz8YOKbyDr4A2xk+xSzJ6bhenXWixF42M0LPxAbgRf17SYFORVVrHgdRr72CJzLzv0Vh07ul6aZOe6DB7sr2uhnho17DtDutS0yLTW077kJNpoDuJoCSsX54pmQ54TJPK1ir0VU6EYv49ubUowOohyFcS3/yi7/2kLbSXeAIkzUje8hhQq60wFpVEl9dfWTpKHy70qS7zNv8nO/zacKGdYXdBBXcXGcYG2PumMDLt7PYnyou3qF2PpERgoy0XhYUmO//+aUK+5nczICCqeJ7Y+H4RbaDOMjNKPGBRSn6WTgfwrjmEaZSJkrbfyPH4PfHUH+FNBopC0OUC7uDtui448oCrL0c4/4kMZdmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAJv1SK72s5pSBTdSQiVXbR11XUs51xl6ugX2NedvZYAOtaKUvEEFuC+eBw9Ol+LwILkqnH8NN0Va90goHj3eKw4OaQJorNNtAFoKPij1VPbLvHeQqe5J8De0S6XDilLLmrQcR6jWyOUMBI7rFzaAI949up9VHzkVV5nLQW8p89kN"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "EB3FFBC4ACA4BDF979CDBFA87360822C686CA24C8A210959E0E795FF3E58E5C4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:DWb/VCVtjnH3oqVdWFQfiCOdpuHlbTW5PVx16qkJYUA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:rf0PZj/8YLDjXMPmI4o2wJnIKKlT6P0uMVpuQfnj7YM="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156459038,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAOD7dlFKJHqy6BMh/dyHBwnQEZNLxMXEnXgKwj/kWjWu0Y/mOab1uwPsq3a6gMKlaJyktVGyaIsOJaCx6I6pCOi1WpygQVxtHZeZdtlJ9YEauX5rIMCoUS7NupODyyNLeDwWj6rNioPZklvs2Ln/PLYjri0Z7/gqn3wV7g7OrBZoDki419UEaizYShokn17Y+2AR/bKJoRu+tgFFgD3kNml8lmxN494Vk18dlb+UisjuSgAzHP6DUdm2s0utnOhGYwxwjKKGjSqdCPtrnjNIJO9ZN3dl0w/oqs821nXJSM8Y44ew3pbmNEecNc3UwyNpkZTh46oj8weyQGNK0Nfd8FvWqWrZRhJxwB7sPEIiAjfmoWP1Eh5H29zRb6DzMzHkxtSfMVQEqyoHOHQ9wttbd1MpZNd3Zo/2+Kth+xPSEIN6Pg2hS9vbJ6yRTRHRk0wJ+tDK6Yq97Sz8KeblQZ7NBHLR7/wR7M9X+qa2T6LG1vUA3xXYUJrWEHxai+l+4e+rQ1DUNwEKutNGqfR5joWyBM7ORjS4ZFH6IGbhAXGpyknPbypVU6DZXf2BZj573krZ+MTAHaXcChN9Fl13VfUgRrYnFaS17EZ8k1drgvYzUaQscRooY4QUY40lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSD4l3a7g2ktK+E4MGBwp8Cl4qmxTCHMGKRW2wd0OpJS5Fo5pAwC/t0b6WscSe7Q4ztGXupHbiF18Eubd/VaoCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAkELkCyKQb80/gKh+9SyKc1cGdGCNPHr+OioK46Ic+UOV7YSgjkZMXvOUcRrV1OSFeB7SvjEYBaR8/c8/a+bcvHgUwcx2y70dUxs6ZA74Wd6vQ5KgcLnDuhz2RpQxuXWdVmWUaGRe2u5uTwN3kZkPWOl+azfIR+1k2DLjm8MrKqYUdoq5h08CzoQmNzwU9nzup0UngY9gH9PrKBYpEMNzDr78yFBY6GAqmaOXle5OYx+L6Q8t9cQoT+yynhAUjT15FWyljvsEoBpUSfldAYHekXxCfJ3wbg0NYopDqZlxmX6sI9BcauUFakdgLR1Na4ZkfN4cVxOUvcUuz6bvh4t3tGfxmkCAWtF0mQO4upRqDVUhImSwkboITdvlKVN90M9OV0E72xL8ROUFwbr7YseUDMkp/fLCOZxww+Kp5SPEWy/NXeauR473Y+ifNZX/AFq5MdSJ86rxaQbIE1TEUzSAzfEF2hFq6V7bPXwIGrSS6Hv97vqJJNC3SL4ZDnUtaPwstS7ma+CPqQSz8RwhMBY7HSb9XtJ2fqVMKKalmEvD1Npn81S3a88zmR/DjczqxlJqfMFNulwPw2VfqEOFGA9/52z+YEZcDF1VtTgE8+t3pvFlVyUBbcZCqhzTAIlff6saItnWrpI80LPMK2m6+/4kIZeed1pofRg3/2FLBYKGLz8YOKbyDr4A2xk+xSzJ6bhenXWixF42M0LPxAbgRf17SYFORVVrHgdRr72CJzLzv0Vh07ul6aZOe6DB7sr2uhnho17DtDutS0yLTW077kJNpoDuJoCSsX54pmQ54TJPK1ir0VU6EYv49ubUowOohyFcS3/yi7/2kLbSXeAIkzUje8hhQq60wFpVEl9dfWTpKHy70qS7zNv8nO/zacKGdYXdBBXcXGcYG2PumMDLt7PYnyou3qF2PpERgoy0XhYUmO//+aUK+5nczICCqeJ7Y+H4RbaDOMjNKPGBRSn6WTgfwrjmEaZSJkrbfyPH4PfHUH+FNBopC0OUC7uDtui448oCrL0c4/4kMZdmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAJv1SK72s5pSBTdSQiVXbR11XUs51xl6ugX2NedvZYAOtaKUvEEFuC+eBw9Ol+LwILkqnH8NN0Va90goHj3eKw4OaQJorNNtAFoKPij1VPbLvHeQqe5J8De0S6XDilLLmrQcR6jWyOUMBI7rFzaAI949up9VHzkVV5nLQW8p89kN"
+        }
+      ]
+    }
+  ],
+  "Accounts getBalance returns balances for unspent notes with minimum confirmations on the main chain": [
+    {
+      "version": 2,
+      "id": "6807d4ed-911a-4914-83d9-795124fad775",
+      "name": "accountA",
+      "spendingKey": "8a9bb3fe0f7d8345aa6e10e29c64547c5b1af159ae9bb1a6ca734930af887b0d",
+      "viewKey": "ad10db8da6581eb2e9b6e7bb43c297cca36ef91b4220dba16df556aa8304d607e4da293bc83f4f2b7fa4808688e445a1258e854f58fe07715a680584bd787504",
+      "incomingViewKey": "b593adcf93a39dbc71bcc1253b21cde80a10963c8ccfe9c7b872a51d0b8d8e01",
+      "outgoingViewKey": "6595bd145a255b3e9ba200025a79ff4122dc1e6401067ec50d64fd1dc048bf59",
+      "publicAddress": "ee796695165f21209f2f80c240e934ab500f151acc000bf372ef777c999ba11a",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "ddb879e9-7c29-46e0-be05-e312c31158d7",
+      "name": "accountB",
+      "spendingKey": "4f00be20bde2f6dd025dc5e7026f416b9d93bcde4c3f54284424baa4fbbf3b64",
+      "viewKey": "63f5a35c59e95e53c7087ff3b56c317ff0a48a30611184b16a3cd82ad5b7c03940803236ae18314cb6b0826de0cfcc17cc8b79efc03f115fec16a5aa1eac2614",
+      "incomingViewKey": "38506546850d7d71cd2e838559d34e21079a83a9b4fea0d27af80e14f14be504",
+      "outgoingViewKey": "e1f63b80594db624f2f345a94db2afac20ff5df260e136d3a3387a4abd939dfd",
+      "publicAddress": "e0b525f71faf88276156bf32a858c8605b8ea1d7b8fd26860712eb4784ff90d2",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:O8ly84RjN63AtivTds1zepA/JxtQfg2kYpSjhjhszy4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:2uacug67Ik5vKyKJDtFMoQZmaDylKun8bQAS0Lof41s="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156460048,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAALzOSiyGH4UqNBl+hJ3BIbjg/LCvsqpkeK99cBCHWigSyuKg5ks6ABLG0Cb+4eMR2LuH+CO8QD9kuWMSbQA6mHZdyC5tguD8xF2RPLV35aaOX3rg3niIkz454NAq4O+GXVEAT72WttTkfP/ygj2pu37ihizsFpXAyXEvmcyEUNCIFODtxPRbr1Jc5SRlGjomwZ92/uclF8REtQDOwr/1bE4qtX8f9wbKfD5yS5RTaK025HZ8Y73exJl3AYKnNEzqM6vz5/CJKJ9jhEcamABfSekElgt/ksFC2k0dsoMfLgQ++3uj3RLb+nH8Gruye/PGQuqMrXDGUHGNyUsL4KpCc4B/5d43TAtDbh52yUi3C1QgWI1a4unbEgMnLCXTcsAk9Slp9XEWzf4Up6LzBze6f+B6pmEffya8zOXB4Bbd9QU2nzXxshwex8CcJCXN1U9/HOyPGrtCX9SoBKYEaXaIcXwFQr0BcGPUzcRhCR3CkxdyrOAwjYR5lHrJAW8dnBSoJAXX2WLqrFqhsLGsdbY6l473BKcx/eECIRBS5jDgBTdrQIFRN9mqSTkm9+UpzmRTYtjUSNSTfUjx/5Y6R8qawvlVHoNY78XALCgMsnyoA3zxbXxDo80d8i0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhDKv3uP34rjB4VF9JTNHivNbhSkG4bQjp8hNh5Igw9nt5MFa0JKxajdQsbfRytow5MdQz4ZKyOOUbe5gyNXWCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A10827358CCBDD7B37A935B088FB6CA56A01000CD749A15091F085B5BECD1A7C",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:95LX0eQb59BB5Z2coKc4T0qG4dBsTF50X1sqlkm4szM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:BwlNRx/oLAu/j6HjG/x1S6jMM+nV2BExjJjAMT086aM="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156460548,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAq7GUPe24YkxpcIP3NbANmLWIo6LIYV1fRBD1HhAaBNKDqB2Kci+bhsfKJFmmtDdsfZi+nbrVS4gyMgxQ6XTuZLSfaC2hGVEXeVIhP0xTLT6MG8FqDO6egllKSSiMJ5Z++qAxkxDDXDuxd5rI33T6QSDOp3JrfTmtjwq1eP9EMeULe4kERIA0DcVWeMIOjxurvHNzx3UfUo21XikvXZRBrWvTu6h3AJWjJfFDX5hKBGyJURTeojjSGyOAaVUDPi943HPWSodb9ik6wpXyGcoUKg03xKMjCTf3H1KS1642lkoYckwRVRxddT4vrHDZ11QYd9W1SETOsTlDZLZTqeKyccWCl/Qe8CGUq7pwQf23PR20MV7iYJgP4EwtPEkBwr4tP/Nt1kdsS66rMxZOBgZrAf0Q6B94fegcEifyuTrQ1CNVa4G4X5lud8UqqYdeDTRRjKygSrWfnF2a7ZQ2gGbon5qKdcmF+4owGMAo0IV0kO3fqOFL2NpeOFq8OI0m7211uLvm259AGug29NplDPHFCwyANG1FdXVWFvfHOQfy+dQzzwuyQYH9IJL7TqLDzWCnC08/upQPx5Db4KTBoY1TguKFVj/BWWgKcsOsg1EXCIUwOBZlOvDB50lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3Shs4AFxWULmWnm0wbpFDlLlDv9W9Qh83iu1i23yvtDjTKf64pNT7ZNugJTU4KYIJdfKbrNP+uCSC6uGXqTxCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "F8BEDC0238514497F5059139487784EA63629B87A8329C40178E506A56B4F56D",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:4vwFnmmUKWlhFWtDirkg4dt5NerSK/CTe92g17GoABg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:YPnE2oky7Bt1jJYIQthDudB/E9C5Grmf+0tuhQnlae0="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156461053,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAwr5LW22Z6yqI/jQqwvILyTYTJroWh6sJQUqSiiY+9NmMzSy2M4jMSQCIgGq8jc2zDIwEvBEUt8dUqWyJuRbko72JNWroD9VxYsp+8pMnRRa0/HFBFh3TeIhyVVz2whqfe6gKnXbFCmSzCGa5H6zQmn03LufKbh2dc8JXSmrIPZIVT+At/3sE+DqpI98i+tlMwn9XBmMHR4sqj+g/7/WWx1SiLr0bb0+nEpE1KwrBuaKlc8/K46ZsLkIrxXerXRuqd7KOTa/BSc1DhNonrDWvG51eV7Cmt1i+IJR3mwgij4fnMRpLTWAkVn7yzXq2PooX5K1XfmB05ZF+anBNM3uFjwJR9VcCtU1NIN4ucTfwkpf/2pGGiGEZOn4ufxmFzTNHdib6IpYEFNzAlL6WN3Hd1KnjorgXEawQTO9kqpqpl1vtVwfdUOufFoibJQpEDfYI1LlXpLuorubiVb+G8cfyKi65enOlkcpIfxPrsYJrCePx6XruDUzIo6VRitmJesZYwaLmKy7KRSpVWMGEHRBN1QAajtcP0zBV0Mv6SaHZ7otyHQ266CFRzluth0qnC8236NyDtvo+xT00LraxwDSP1QHux9NFBSxmFZ7eSeADXsVVzx2Brstwkklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoggsQSrFcOo8qwaz+KWTSJKkxzVCK0LrGk89IIYEqMcIwddJbVkXJsnbLMujj0ENpqp8LsFLiIcXHna2GDYZAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "C8CDE1798EA969FABDF160F6694AC914ED67EBED9EF16C80FCA1F40E8D7820B0",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:TxdjAG3UarM1YsjEV/zaMNTMYitIKP4Zf5PURxnD/Us="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:eWYiBH2HNR2KJ+OdzWYFImRabn0ZxRq560Tq+3O3wbE="
+        },
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
+        "randomness": "0",
+        "timestamp": 1692156461549,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAxlMln4t5iIOP04b7sz6Fd3OdZWpN/zKLK0tplRcCQOmr2rcsc08vBMinlYyip77E3NNBUsYVGsaAvzcUBiIYs4GJ5haq9KgTn2wusyrY3W65/A0xsklT1uBID0L7sr8zG8MFFZp817uuuCqclONJFOXMcQEMtagozCHOFv8aZZYIUSTbtort7pauozu+fak3UENXZsTmAusQrc+c0bZVbLOSPnSSILtywd2svgh4X1aAotz7ehZ6n2ioxlu4NjDM/GHRC7oLbAerT5kSDDz+CLiNgJ9hoC4Oxxq2GnY+nItCcPnmB4e1v5Q2AkEWeSmktU5vRKqPp4Rtb53d3DpWOMsmI2pDj1Wj/4NwwAlMqL1j+lKTNoHz9YYa3Z6PBzprsBtMG8mrEDe8O0vegD0P4degz3dROY7u3TbhtiLLs9FgrFA1Ygy+Cts+0RjcMZx2GfCa7NROSdB5Jk7QUR1SXjN+7gdRX9fd1G7F+ry5ZxKIQDd8MqLq1ljGZAjrbPVEs0h9+JFX5XCbonY+lPIhnN7C+Ai/Py1Pw/m2IJSRS/yOeazG8CPLQwj3PjhdxU843IuUZk3S3tVEoH0a0yXQMLDoMnxv/zQEJ7epBZBMqKmX/cMF17AYwklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/XWsgD2e4ujfivc+/Q3UK+/gi+O+QTryrRP28D6hzQG2JNnUDGyaduzgOrDo5kdYiqkh1mYwNQf11lnkjYbRAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 6,
+        "previousBlockHash": "3C5BABE8D6E58138FBEA9E1EA76B64399C95539A1F858398A41C951D509B62E0",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:FxB/IYQq2dGZxvHCGhHnH77HDz8LMZYZLAuLBzPt3UE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:7jzQF0xZmGnlMZRbeUalUFpVKyi7EQxeumJvO9q6hk8="
+        },
+        "target": "873190827380823143577845869093025366895436057143163037218399975928398962",
+        "randomness": "0",
+        "timestamp": 1692156462058,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAPY7qPtQeLali0Pp9AImSuc/7ufORX8RLS6bmBdYN356I8v5kLL/7IxwW6nfyaxpwV/39AK1b3d/rytH3iL8ohGsX1DFxtkGbIGCyN8sKrKil0qNGIl0Sm0HWoGouBdWSC7/zU91xmz2sCpe6WImqAEP0Yn3I8jy13ngSDz1+eQoRrMbbQXZAEm7aRGlcxT5ZpyzGTAXC9NVMhdkYhEATINGuOTLWV/lXQjiS6+a6Yt6hBCgQ3Ou68PndiTQgdGv6UG6081nI1whilrxSFoaGkEmyMCS++qOU2/uTJU9Qfs+Lc92AQ4zg1Fwo/KwXcUb1JhPU8oHiQgV531z5GukB4NQj8NFST7yCqFlVBp4f6TBzAeCdGUfTL1pwPtLV74BHjeqJF4bLX6iSMTMNyelVl92kpQ++9lmAQhd8CejlnXMNnl9Cc2gmifgNpa1UBDfIo/U4rd6im2kSZJdxyRzZh59hNG176UTvz882EPB1RKF2u5ynt/zm5/vPX0BkMAshAxc4vwRon5LqkttVfqJe1jk6leVCKnSJiGKoRQrsbVjXoeaYklOJY8ikpR9L2QQQvzg3jURLqkFwlykd19JFMjqmyRXMfviUGbQXYNdg1PvdEB8TFiB5Q0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwr6gBJacC0J/2U4aaq6j5VGZQCJeZN/sXdOOoFfVhIq1+i5NAB3yTfMd16wfB1rm7uTcV3qiq6vUkEHM+DRXOBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:dEynDh/lc6zBPHXNsSfRTa4TusziTywNpnyvyCWIOx0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:C5ZmFcC2nHyn29fKC2AvT43/wXyLYuuKp9v05tq/5Rs="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156462559,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAnqB1C5ozmO1J4gPTEtCW9P+Gt0UHkdhiMFbnurS4/bKinvdx4FWeZO2ENZF/AmD0AYLtb1CdwA1t9FkiyzfEbRF9W73Xc68tqYJUYCvDJuC5kiCHVvr8/3OK7R/KHPPTICgozGJKFV4M1sy1KzlVNhXmyB8vWsOE++804WS1sKUGzI63bBKLSnmP8rh5Gzh5Do/g1uH8Kz4V4qM35Q4SnyuegxWvHeVmuk6XfaCAycKgCzofLwea39CGG4z+Fi+O37n5H9bzLjmqsjjtIgjk8l9bHy5YMLnFxj7n4Oe8Li/fztTNLVTwcelX7rzJmtBfI9xaK7zRqVY+NX6Rl7izZ4Y6orbREpF1yk6GnMYI6u2Ypky0aUvjegGY2onsm/IYwsyWftcIR/wE2XgyOZaC07N7EQUlNfe18dIGR1PnQprOvnhpkKXHW1vSDnA66UNzz9exake6zbqQrb/o9k8wwSj9u6GiexovX0uh2QqoS2BgJtyKAJt/Q2TX9ZoBY32M94drRw/EKXy+QCeeaRYrdhfDbyDC5f1oto8Jn1VAlIyG3dnd7nmbQtu65HlvpwrwMtqtZB84nn8cSBGdDR/5w5Ojh1vzaWiqG/5IJ8H0k3oAMxUNecpOtElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw6rT5QQH1g6VP9USS7p8prYcf0QeBF1KZxUXmzcBr0SfVP4WxVXmnzv/JnUTBFKCX2hkqTxPh/fYofMMP53DcCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "751D00227527959C1D0EB705DC8BFD1B686F9EACA823CF4EFD08432253B2413B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:lOeXnH4ZDkAynCuUAwDxZjRmdqeTJV+qxnHgb4OQaR0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:q2byAHKXz+MOCUwo/YdEXKGKi6boWrI+hnv+9wNSgrI="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156463057,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAUtcidNpTzgzufq4/sXpqh+Rg+WjvIrZ2w2x0wwz/em2LWhMnEY6PkUxq3ZPhE5ShvDp/SFsb5KVCHVoy795ftkf3+VWH+7tfhXHjoQU3cZ2Zl+blQKq6fkfrPBAVSlG+8Xo7VDoxk/8UM9XOz5iXW9ZVOYsJV/V4PLFJxFeP28cT3ZYmQiZD7Tt1et71lHg9rvP1xT+F2E9oSEeqLqiG19GHozq0qjLheaRig8SW51m5yW5AlxJgV0AloVSZ/Z14VByoCbIcvVwz7kA1DHqdnrlwS6tWeLA2qhy8JPk9MA01eI9fWRWq6UHJ0i/mLLF8ay1p5fTzyEwufAZaQk8SyjRzlLwJ8Xm4RBr5oyiN+QZ8acZAxsW9nh8r3ZYS2BYW794sBLjC4ns+u7ljBbrrwFoZRmgRc8FF1bxjHGBb/RiL5m1Dn1FGtEO2j8EzrTSss9FBmqMY2j84BhPLg+AhfxvAGplkgbMrznEcDfepTN7vjry6r4P5D3g4NbWv3W79dhKjFF2a8Aem4JXqOoxA3tU5Er/QUo4Uh40cBRCqkXHe7ZsNz5DK4TCm587m1f592eCxHHlXD4khGLOJtsB2IhIDl2J7fJ0gdNH7d6Bx3jqTRJtIXuzXWUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoXBxON0G7ZnP2W77jaOhj4u3REn906XK/5uKaVns1ZAoIecE/VhRuexErcsq1HRxhmNc9skiyO2dwSPhbB5cDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "CE119E0C633FFF18BC8D5B4A813C4287B2F7496A0F6412053ECC91499AE15599",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:O0j3qN/lTpnTVZOLxZ+GKOCEDTy1gBD3ZXNdU2O3sAA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:mswHEBuo8oP9tWG1437GtvLbL0WJLHiHnPBbDZ8U+pc="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156463554,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAHBb5Mq8y39NRrHZFkRo3VOcfbPjHmWAAQUFwv1A7Fd6Rk1DuhLoyTQaN9//av0M1sYKcqFH8Qz1AnMI0ia+sQHrc8fmJ/66DcoKPZlEkjGCtsLX9doOsU9yINFibm3MjPJa/Wueb/G2U5xa7mFKwZaozJXMeRCdjHav6DLg3osYAF7zIiWvpU8+PHrX4MY10G6gI0nIWgPfZEjYM+rfWMKxUvNZwcHOItEQTus7VHjiBWVRHGk4OBmmSqEJ70MWjA/yBZwlzcQ39Rht1UOjPDCFnE1O4xEE4uxH5RIQXDeTFOhn1XRZv5CA3LfrE2MfL8rEMBgRHVAYP+B3LVbJ28PdoLVLk6mdKF4/17sTCU7j+H8kVl1T8agKMgppuSdFczLEyJv69aWNr6HG9tJ2pSyNLPD0PYshEyf4a9lVUmRGZsO0CYlxRF/ktE3nZJ/G8jjNtjV2VrUrS1D6pHXLzuvlTbDJaAj/7Tnbskn7GIPllAMpEubHT5j9j7neDPhPXPDeeAiB2/kd00l1fhRlWodkHwHhjTji6F76MggvvEDMOn0VSCv7dQSDyQ4NwY02NpKD2ABQDOApXnnS+B+FZllgOAW1jCjX81BHE21X+5nweZ9IaV4NuDUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQMr1Or3sW/BEKAbF9qBrAxLRGdyDKRbA/N8oHVdRGlbbysbwFXAgOG7OpojT7o6JsaSinnpwI8W/w2T7GtJXCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "A7612BF466C0FA38B7ECBA3FBFE7A3B1F5B03D9D5FBB980EDE1736FD90AF39C1",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Vx1TUWn5xRMKaYZ3kwKdRbzvybN8il8g3mTOTK2BFwg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:N4OLHi77Vwd0j5hEc46R0fvxYVqmre86T2QovXWw7J4="
+        },
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
+        "randomness": "0",
+        "timestamp": 1692156464058,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAmVqpiKjOWvbbpj/48P6v5h8FMzVV4phXxIm45se/yFqivqKgmiecSE7LAh3LmLGzd0zy0qmOLRKX9zvnWvRhtTQ8qWjPxw8wXMeJsoiVB6aFk8p7lnV9uQLdLWr1L5CpBCXcaV0LTB2FABZmlIIKx9U3lS7FDPvOfHopdfPCz98UePNEUpfIsbP87+bzslVxvoJwKAXHG6ytm0e6fw1LJ5i8DCuYh9lh2skQVxDev0+NuBVlD6fzOw1vlj0Ozkw5plg6nzcgzSxz1vcZ1xufHIy/YME9XCCmkuinq/IF9/Ixm8uKu6WXXnAA5oHXoFQfSqaZ7/9+f4ONpoENSSWZciNL5JWW1MEcU0SjlqzbfEE8ZGF3RLm8dkB/DuJQHMRX39KrMd+5kmgnG/adHd7/SANAPDMg/9KWVYvr621EcjR7sgHfY+8zXYrFwPd1Cr3aOqT+o0xvTKcWYCcprN8dx4TzSTqLhzJMc4Mlw3qFjz5RPqzWyyUCTtC82/Jiji0LlZp8XZxGX3DmhnCUx3L6kzIKNrjIy5AZKCqJ3PYNHh4qqYUHNDgVVYzO/4Dt/VwA5sL64jkZAf7BtS3E1ZrqvO2CHZufIzFcK4dBfyJPmKa2KH41c4X70klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjD+FzyD59XnlqAoSdcsKY7Xx1FpWIyPME+Jb4oh8xM6905nJ3N52pHJLPKqD+lvYcrqcWLKx6AAANi/gEzaaDA=="
+        }
+      ]
+    }
+  ],
+  "Accounts getEarliestHeadHash should return the earliest head hash": [
+    {
+      "version": 2,
+      "id": "f314552b-ae86-4077-ba68-7be42e951790",
+      "name": "accountA",
+      "spendingKey": "854a716246862d161daeefe17c21a81471a7e260fbabdd851d3071a849cfaebe",
+      "viewKey": "2e1aa40b6a742303a6926ba2be085fc193ec2410aafbe7516fdf8f33a00dfb918dc0dfc844bb7f7eb99dec73ba1b2a5bdfa02c99d3512b9e40ef334932c62d49",
+      "incomingViewKey": "9eb27643a8faec128a9dc8a6cbbda36bcca9d9c8eccdaf724eb3c9c8115c3c01",
+      "outgoingViewKey": "f0b03c4c3092615177fba2cea194028d1fa5dd8c48306c8e936e38011c42fd78",
+      "publicAddress": "4776a97c8c384875a05e6b36e36926da303fa74d0d88958df826928a41a0c9c8",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "4a7b986a-203a-4f60-a8e5-7ce2609f59d4",
+      "name": "accountB",
+      "spendingKey": "93320c4d384d9b1a92addf3af151b6603e636b377edd194618dd4b825fdfd357",
+      "viewKey": "37fdab766b95dac2422d2afb4ee7ff134b87f0f4441cc4f014ad99e61f28c6abec0ed2072ad98f1b2a02bf7d540d03ccd62f0056b2eb227f5f360912411484a9",
+      "incomingViewKey": "4fd966dbad7904d096bb0fb728e488ccda3c4e5fd9b421dcefe330a0d5fada06",
+      "outgoingViewKey": "54189953c4856d0bfdd906f3245aeb7df86c3ff6c415f32ea8b045a32125d215",
+      "publicAddress": "d178d83eeb04469b6f83d693986b5b1cbedb2b36fb8e2c73b86c038f1a283e6f",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "3f4e2417-2a9f-413d-a88b-6df896793424",
+      "name": "accountC",
+      "spendingKey": "d7f5e60f37e02face728a64d20dbb54ac6445a5dac6775b88008fe463e75c94d",
+      "viewKey": "26dafa9d001258c2a8229234906b39cacf1010f1a36675c6c2c2bd9c8856bf02ad2571d1aaec3c377a2cea8794f4d7dd300e708dee0ffde87da7716955cbcb58",
+      "incomingViewKey": "9555c4d481797f44228cf607c3c4c27024faef4ef6bd836ac674c202bb2efe01",
+      "outgoingViewKey": "62157c2416a6376da94fdb59666a220a4a56a6fc532b0a22535f6278a0149aee",
+      "publicAddress": "6a3a5675441ca3a4e804d6308b0d8ebdbf219b29d65c68acd8e53f767083b087",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "8f1f7673-5512-48dc-b02a-431d0eea2714",
+      "name": "accountD",
+      "spendingKey": "67e3ee168c3d10b1392081ca4a9f0b8015521288f84b28211b508950fb604216",
+      "viewKey": "f34bbc5aafcb273efad2cf5cc871401a6b43a0378c650c43305b8c8ad8b487b95950f851012b7f772a4e6e9d29efdabb955b97dc851052b7c6fa6d133883f58d",
+      "incomingViewKey": "6b4731d7728b148d7b790864c2205e57d0dea47e6032015a04ed7083b588e901",
+      "outgoingViewKey": "59b3eb3d2897d73b0046d2748806f1f5e4d49353058b0f3be0d2dadedca7cb88",
+      "publicAddress": "9d6f9d88166f22ac5f9be1896d6e8d45b8c7c997a673f12c084722c6e021dbbf",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Fnnhm72O1BsL1cyluWOQDl9EJJ6AYG0Jt/CgshfdZDM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:oBWtG3cpfdnb/8y9xnVTDRATIEaE6gxyibqrvpY9CJI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156464773,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA2EKvSY10pS1YJBbd6YZyaZaKdG3tO0LxwWk/yY5w95KJLqCGD0IJHmesnyXz8VIhx/UMS8iYHIuwkgmOi2XIuuPXWZpoARE82/9aGzSdyQiUIXa3vweviJbKpbLYq0TwAkTp+M/3gxpdBQgb9a0GFbcfadVUdC1z1TFhLzH2K20OROeD9ABLesTzFac7zZuYbeZWt9vnig7oPW1ueZLkpBdrsgmdn5uUjHXgE5B/XaGmN3UIYhjZn2sUdx46OjkVBnRHXmYhgrG20/BDsSmphcbcu4UQlmwYG17gqzIzJC0sBJ8F2ijpbY+d4fBudnJ5QbuXkkg02PQpOK/e7tu4I3GrqLuyGlVFbPa1IF1BeKsb4JIESMD27iBXe/V06d8vbYXFsiCB7cyJyV7ppu0Ka456buikW/6nX7CJxKnryPA51rYWXerigNgNc82k3NYXwiBokaUvRsZ3N+CTf/Oz8wrzNbQFBetVBbf9i4X2Dx7TQIJRWlrNB+UZPqMr50f7sOAzEVr58kgtw3CEbQQkJVhd8g+v3N7JMCZAgIoynlw2voTA0VZWXurQeO5/2A4hiuTgKmAl3dDfZfdYMEjCS06p7x8gY4qGhnYhmaigdSAfrk8IuwQgbUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCx3wuxdNSiUZv84BCf9oi91s4GGjjhHvkIg8GNv6Dqu4sQvyXISm/432LItwYmQ+1C2BjCtCoYcItAy4cl9JAg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "2CD1C6FD870EA69630351EC97FC966FAF6C364D18DA8925828C0F0B7ED3404D8",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:NeGE2y2leIVfDJSA7Eh4nGugK6UZvfVlBxEi2tEcBms="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:nbmIhwGYv6HIXi3629FoUYD6M0nfKGT3coJCa9fx0TM="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156465289,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtq/2R//c3gsyQoEtktuxJgdhc/jbqJFBbZDaeSXE3g62q2afscwiBF+8xDSAlq/04R3luYEHqpkcuQPNBAaZe3Ik4QPxm/zWryfysMq6Vqmv2CPkZgtco6C5YVaAow8fmtFinYzMK4JOPjYfzoLs+DlJ/x4QzfDSESHbpXcb854XdsaHm7Qg86cEuTqt3Pvsmmzcqg+tBQDxtsGMRr8ze4vvrQMUqJK/79mOu4U28vKEMDGmyG3QCNWuHZJI5mUuv2mjEFD7N2bTCm3XjbVdjbf2FhLLTd4v5N5r2TlbgZLz7YyywhhMdKKUITwlh94oUckersuwv99oU6TvVFH/N3sjTszgF3dpd51UK6hYg1ONUKZWRcoC9UNKSXe2mhEXypVHnPGJOfWO+aIoKPCer2/tJeJYCnHy3TpAXz+1VJ42VLpY0AKQWDstaVmMT7kCcI9s+tQkteigQAmnqzzJYQtOgpcA2iDonfkunER8H8RFzRHmj/abYSmWqJGB9ZPuDhudg2ULFV27bp3fy1UHAtlIpftT4VORZUDcEWKwHanRxsNOHgozyHioDL/ECrx3ahRPWqW4yQjhZm/LmyWQKqHtJ3Xb6OwxsiESiZHrImL+rzJjY5kd2Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFaLk4dGjD12+yQVxJRsWdfuhcKbvCKze//U80Y+E9gHZr2qlTjmdp4MQVyhE4OO5YL+/MxtTpUZLvOBjJYv+CQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts getLatestHeadHash should return the latest head hash": [
+    {
+      "version": 2,
+      "id": "732b475d-4b02-49a6-a013-ed25a72cbbf7",
+      "name": "accountA",
+      "spendingKey": "4f36346dc8a8ed9a81ad77e637e98182634757d9329a60fbff3e07cf4c4fd8a4",
+      "viewKey": "155141cbb9100f7bf020798c2d17625ab1926ec2053c466ccc4e566347fa1d3b61bd5a76314210f93cca12657337df5716ed95d3c38e40119fd35f8ab7019c9b",
+      "incomingViewKey": "8353e95210308fc4c1a87ee78f7120a8877ea8d76c44b57a9a41c85449c44c05",
+      "outgoingViewKey": "b1f5890a43cf69cd8a8c8bd16a0c531450629bc25fec2c5133daf33f1302775b",
+      "publicAddress": "da161b38c23113192baef27596a6f6c08a562e72cfaad7ac2727aad82a5c9c03",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "d6b6c60a-d8d0-49f2-8703-0be0fbd48dc3",
+      "name": "accountB",
+      "spendingKey": "a563b0953a21474314ad191ba8a9a93ffc2c5f61d8e23e744bebef76f6e0f8a7",
+      "viewKey": "3a63db9de7520e2ca18b30743dffeb887d8c7620628bc244e89c691f169aa6216bb26f46ea538734a4802ac906bb015e94dda62c8b1f16343acf4c92de3b3a6c",
+      "incomingViewKey": "ee1f4401726c90b4db1ab0a268b40d9b5266c1bda38d318e38afc035de39a602",
+      "outgoingViewKey": "8e7b2e9d716a7aec4fe8914c4098a372ae0a69d15116c770bc0ebd0bc5b91a6e",
+      "publicAddress": "ebf0d7ca4fa22bd8172ffd36e669dd219dd924cad4958c26b7e965670ebf7723",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "1cad8abf-b7e6-47c3-bba6-23c88e892825",
+      "name": "accountC",
+      "spendingKey": "b8293d5cfc55baa57de3454fe59401c3c5173ab151404d85f659f5883f24414a",
+      "viewKey": "d94f0ed0eade65af83fcd3b7a1872f85cb45f96b09eecf8b46dcc23c6c28e7d6024f5f5438363f2f655e35a598e773a736d514c4c3792ac866f0666de5ad2d0c",
+      "incomingViewKey": "8561b8b2e3fcec42ac6adddfccd8d55d36a6f35625d78471c8ce84ebab81bb04",
+      "outgoingViewKey": "cd0d281fa2a7221d607f3a39f2657b89e6cea97ffd43016106895211046d4981",
+      "publicAddress": "d9a9dd09763b256667c9987171a4a1325d25deb745ec8e655682c77492ef5385",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "c4803e22-58d1-47af-98a5-7edb2599cc91",
+      "name": "accountD",
+      "spendingKey": "6969e60835ed5f93c5ff8b2bd885f0b24fde14f76c09481e0cd1581c5002e8a5",
+      "viewKey": "285f171031fc00b983143cae525beec95523824bf6b62ca2a4ec3444ce5d27adf2bedafa82df2dc281ace41f0e9e9e52bfba8582c4745a5b84fe0087e1ef78ec",
+      "incomingViewKey": "186c0ffaf4271d980cdefdedfcb5ef88900c60aba19b9ac6313010ed81b93606",
+      "outgoingViewKey": "976867a02f0937c3dc389b435653a9414072ae5adab4330e7a37a452d3044c84",
+      "publicAddress": "ddd20c7079f167121badda468748e6019e20631a6eb026789c034c361e90e2ca",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:pTsJYdv0w7s6AP/SFnJXcVSR89cYjdudGJaPZM9/Oyg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Y67Z7T8AhRphh0riXOA0paOT7CEAkQTUrLGSLQ355z4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156465939,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAzZUfBsOAW+NFPKzgR4mTqd4I82vgBb1uqC2cP7eddput3PkeJWEGcxIyZZEJhH4I457XreoMCIFC7ot6L/hlyAN65hyww7Zsi/cFDpEIppOAObM6ZHVBhYUGI4+9JkzWX3IDBUcWY/QCm1N1kYcM98ImWzfATctsX1SaxqKONz4G+kY0w8xPaF5Ct6BjipprcKMxnKKMMFgqTXtJN9QdjIaT/lcwnanoRDlYLA4HAb+YJYWc1sPJAOakWgOILG9yp2/foS+0UteagCE+e7EdJHLgA0T3bvNYB6JcoRGHBqCZn3rIOJQfL+aM4vYnPD3pCvPb1QJwOrQVD54wi1WqsAxITNKOXFpoQAP9jw0i4+365s/gkCjj5lIr5R8mWLpTVef5aLIb6BlkVOrdppdTO5jp5Cg8bu4v+fXxhiy0XeXVJILUeg367vAsUyl/yUknkRi+DhLP4MUfbdbSnnfrJallPqVEKhKIqomIod72uKhnkRqeK6FG6YnvTgsBLyUzMOWmZAeFVhYe5k2a3wNEQMizHTzMzuvCDQ+Wx8P31HqFedJSrX3Zw0UgnOqFbRbtKMCvdIIWDhJerPfb0BDJ7Jgf/rgkUdLLgqPk6mvyG4FK06X7GIuM6Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwEbfapToFP5eXQBQyXxD4uF+skKsxOnQ9kGYGNFMol20p8RyF+epaiswQq7QZYcb7dhusDpjCqZ0+hrlUlVQ1CA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "8951054A211805B0329A98B79B1E7F1C6612D8108B2DA240DF7DAB71481BCA77",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:RTZ9r5HeMg6jLTSFdguNFWGF2hjCVu9JN3UDgkuliy4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:UN761BYKk6gx6fyEPugsw47lgrJzDmX23vzhjH+yn50="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156466433,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA6ztGLxp0G4ikynGo05WE3xPZy1SOidaafUqgoZzivDilvNr2+OGsetOuEvGxEKzXFYsELUUHs2Fn+PxeGa8P7t/zhvoGHFwxLHHPSRB13q+kRk9odi0bY1/hDc7OxcOhOdw5AEc2OAipvhsjmGFNZiSMmxwpo8TSB+p70zsYiyAPeDU/yJQl8y1ewP8wNtOa2gN1cZtIj/gmhZC62HEb//IArLiwNrNQ0XvPmMz/nHijSKXhRdx+UetgshRajozJdqwaB618007FmmenWXzJlFLllru2Poa7XWFFm+aloqe7IiUOuhSCyiJKqoXlF9+4kIoe6tToLDvaD+IzojXrpjnao6dSFY5Ki1jpzMuxaAkUt3CGoXg44rSKYoyh2MJy/2xPRp8/kErgn3ZPH2yjk8bKwXCskGwWI9MnPG1fDQkudRX7spCWbTbRsldxxcPxV+9PrjKJeWYeCWIkLgr/wQXE5jS2qvJuuf2CGvYS5x4XlrDtYmdGvJbS4cInhGNTY/fgyy6absDotSai/XIuekbuq9U7ausECk8+LaPqXKqGOaklHUbNApyA2KWsCFDoBe8tYDXS20NyeAE+fMT5kyOypnrQPXUBaOVFbIYQoVIsjkY6RJbV2klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4Mdsv4oM0Q1NQ+P3IP2+iCdjFvtzXiz6pCdcjQy9gSoBMBCigAugIrn6kQyr8urjnSshsKl+pVIACMSeT+3mBw=="
+        }
+      ]
+    }
+  ],
+  "Accounts importAccount should not import accounts with duplicate name": [
+    {
+      "version": 2,
+      "id": "3a45c02f-834a-45f6-a274-54f366a76c37",
+      "name": "accountA",
+      "spendingKey": "a63f2afbf88c9bf2721545e95c319d49186649740ac9e58717721de20d724f34",
+      "viewKey": "7184a412ae616d36d77fb7d66d4a5e83fca1b4eaf4e04e5fe942d29e872daea1a091f127ffb29424b8d3ecfdf151b2ca095d3792f6a5da7b1e1575631c991b90",
+      "incomingViewKey": "5e8c57172e2f2cc824d7c7b437a67fe5a747274f5c7d63df9163fb9e71add302",
+      "outgoingViewKey": "b4ba3d21e6b9066e40414a6f5d9518a4404ff16a1dee3f33d5f73ee3386d3425",
+      "publicAddress": "56edc42dcde47c5d92483abd62e0760c967d95c9699ba6c8f871abe27a6e42de",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Accounts importAccount should not import accounts with duplicate keys": [
+    {
+      "version": 2,
+      "id": "6539a935-0baf-4eff-9fce-a574bcc03771",
+      "name": "accountA",
+      "spendingKey": "1108fd9640ab9363fe7c265c15c17b95aa485239c673c495aab86b84c4d30a45",
+      "viewKey": "16806162316e9208a337454a265ccb12f2432c49c203ec15b123cbc729acd9a30cb637395e9bd84f9c5488e7f2b96c2fa49fd6ef3b4334eea977c8a22853f0c2",
+      "incomingViewKey": "90ad60de734482c828f7c6af7e69bbc75e59be0b3fbf7fb13981ef65cb9ac400",
+      "outgoingViewKey": "742adac75ffc11e259609f4aea9467ed57305501b41f670f7a0061be46cd9e7b",
+      "publicAddress": "510e76482562448a59b86a53dd226e20c454939384e1703b4f423f1bdbd50981",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Accounts importAccount should set createdAt if that block is in the chain": [
+    {
+      "version": 2,
+      "id": "46fe3046-aa81-40a9-a94d-01be1699b19a",
+      "name": "accountA",
+      "spendingKey": "0b92b450b7bb99c4ab1832e83ed99b9a5fc6ebf93c6b957145acb573b2ab6fbd",
+      "viewKey": "f98a1fabdcb12a0b87f5014c8e62f76ce4087905813c7999692876411b427f6a530463d7e90cf2f6d1a863d4033fbd80a668076bf31cfa80e32e2dc49e72fc8f",
+      "incomingViewKey": "74959414de489f035b7257b715fc32bb4e4eb01d51b63b15f31f30745918ea07",
+      "outgoingViewKey": "a567fe8aaa464a3aad50a19ea704b686a996cd2f668c546fe6f3d2a184816444",
+      "publicAddress": "4238eee59bc7e744700dbe9e769e9f85f6f26483f5a5cc8a1ef57733a67b1fd4",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Qaoa0XH+EY1wfzvTMJem7H7vt4L/VpWrvIksnkvENAA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:wVRLFoTpV3fxWYWTZsOZXcWmevYTPinlDMaJAOf5WO0="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156467983,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAt4V6CbsDGKZJ6L6Iwkw3rfdYiq9Gj4dn7odHbe3Yi2iUvrDV79cYPq4pQ7QyAB9KRKSGHlpnBqxbLobPncuRBl4kFR00tY7y+/G/mSmflKa0f6q+F0qw09oVnNvyn1Ju5Bq8Pu5izs+ICVCEVipEGUQyoH/xRdS2MrGo7dMywRgIOTlOI+SqiGC/9V/OA5Tt47XqFrycN0u5G6ogUPeCCCXIc08aq/47Eol+fNH0FyKI3k/pYqYjAaTMYzaKuPiNSfapI8+b9Co6TjgD4hg5JJejZTiT9a1kBbJZe2fJTxvZfgW5aLLvfNLNWbbsK8qA2Owc9IMIgwFxMbHoedozHwoqKWTKP+H+US8ryMNpnp/eUdbErLtyaH0lvocyl2BDXoeq2RP3GKuMGn1EvfREilE+4KlnISXO11Df/iLZT+7ba412LNrhqhoYvCTaJC0eWJz4zUhsGSerEgYw1qap3XOO+YdGoPqBYSLTpNU3Rl1Oz7HuoAWR7ge49eRWbjGlMDyLUu9ffQNx7A3dSUG2xYqnfnNnLrqwOa83uOKHm+tgnDe7phCT38EVK0V1bODITRZM8VICImjonoAOo9KQoYj0R0vrB6OHCp+RAA2+iQL4638fHJSNSklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAws74cjXWEKjbDMGEPKPq1tyyrL468ZyHeJJUHAsivn9jYPmtiZBtInj+OLvdQCMuoW6j2xboOWqvOWTORReRvCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "73F5C34D833A868F9BFA95224C385F5451F33A29F13AD08901B078F26950C3F3",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:rWAJ8MD6fPXLo1gi+9eg99Lyxo3SFA22CbU1NweHC0I="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:tq9qT3TzdswdZK5u4DccNe7wJsAf69gammyoLk3sebs="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156468513,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAu4PZdRWJvxaVo+1xLtu0HU/25SjXplEv+pI0RxvMG02j9xN5qeSWYD9X2kwQzA9bNnzV/PMLtkIBaVqm93Vlf/Adyme5B4mNPQsIlhYFzemLbnuuqNgJnZW3yWRJjL9+7CdTRbRk9QX+Z/rwDgZOOfydQ66ELySU5lOA+OYBjxEXHrBqXmN3HH1/t1w7hUiJTWQueIrR9CZxnt6k+b6gy8HOHTgVYUb0xG9ruBsol+2uMJLcUXZGAM5jKbm6A9iukToapAXRFZGhqVy5SiIdMEjG1+748QvEXqGYYskh/F2mvhnNBNDj01MrRqTTWd/salE4M1MT2Kq5gDPXeXfJ0H702iTG9OSIukwOP8yHlFqwHpeajdhfzjgkq/phabNgz769fn6AYSg7UUDbvPujK6Y/INWxbXDWs3hUJLKdEGnvQb9p+judWTG5ENky/UqYEKpcwxN/b4ylG13vIY8U7hP7ZKOykO1qBsLpm4Pd9Cc6ubQM2hv/M8ZOJbSpDoG5WKptaYvyX2vdhEpg64HSS6kQ0BmUQlw0kLIVYDBfNU4c/vMmAKwivkMlj5zRhU9y2Sl6J291/I0iLRSX+NdEw7vf8mAdS28gqaLCgQLoj5jYgrGqkMovPUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXAxWGYXGPrueZOUfaIP4m4NDM8QFQgnEz/Fx+zgZSbUxriRjEkh4Cp7k2P92ZwFtcH4hX9m+5suXYNOiCo+VBg=="
+        }
+      ]
+    },
+    {
+      "version": 2,
+      "id": "37e0d373-9cf9-4079-a2d9-05a21e9034d4",
+      "name": "accountB",
+      "spendingKey": "549a2ada4e3073d0d3fd6c1094d04a81b35dc1d31912fa2aaa6df532628ca9ae",
+      "viewKey": "e4c3083b575a613190ba3083a1327114f87232c8e90e1936b1b2ed47010fd3f2be3f082af89323f5da8284a696e4b4acea2a4eaae2447c29272e6e1b1a1f593b",
+      "incomingViewKey": "1282938e5efa7cc019669128706f00c496222c213df60e8d3059580e628aa302",
+      "outgoingViewKey": "0ca1a4ee5bd5f0f21022869c2cf6f8a3ec2b533ca4455aa96fb407c3b8bdc873",
+      "publicAddress": "0db5ddb68ab4f77cb8b8fb1bf23d638e26ad830a70143a0a216f1ce9834d87e0",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:+wSA6TuSqutZF7GQXRz5D8szhXjdXLWhW+VOdzTBjqs="
+        },
+        "sequence": 3
+      }
+    }
+  ],
+  "Accounts importAccount should set createdAt to null if that block is not in the chain": [
+    {
+      "version": 2,
+      "id": "daa6cc71-f9b2-487b-90ef-3b26e805c6da",
+      "name": "accountA",
+      "spendingKey": "1f6b66926689151fde236fa01dfd5130d7000455a0d007b82cde8ad2ef6e291c",
+      "viewKey": "60160d11b5c5668c1d9357d9c3094e3c75229c2e5d858991581f64659262103e8e3da48da595b21fecb2cdd0beb5ea1f8d5cccf7e9640f217eb3fe4c3cd622f1",
+      "incomingViewKey": "f6deebda98c930c54925a822e93b78b9251d09f219174de06fc2ce9e014cb904",
+      "outgoingViewKey": "edda9fb8c95e52fbc9112e1375a9953bbeaa7bbb6e72663acf1a643dec1cd2be",
+      "publicAddress": "8ce578543d4e99b57afef1c00960e111793d6527a30f50e364d5b42a70a0b966",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+4VrrH+PbONa7h0llVxmw0Digs2gO+L0yj8M6yCbYBc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:8Bel/P/5G3M6eKr7M4bARx7saGs+qsDMUT0cSfsC8Fg="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156469467,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA8By6DlRMsEjDrkTp9GJu6Xbu3hipYHnjvCKJYkBzPFmPCsDitYmqwdiHmB/l86DQlwSS9B+Z6S1blCRa0NrjBTVRUeTiyGKXLVufQZpotFqGcjT6j5qtd33xEvQAuUTIZA61oQxMMFrJ8P2K+WZOKYgaihIgPrBt1e8JeSpVDN0BFRy75yxh5vKXdAt/pyAmlF3tBwpdwyM43c0CLMgrWdVYT+Y1qehxs4Zi9MwjOgyPhDZ6ABsnt1cJ0rK9hXznKzXX54wGEvrGeJTAtke70pvPkka3W6Kv/fh4sYaV/DQeNqruobQt6SGaTM+F2+u+i6gbewzRZcfE9/Mo11hfp9YBHhnTzJf1bZdwz14gt/HbLCwdRv4oyxirq71/NrpjyilDH2qdPndv9xQtbd5fF6cTUx6NHptk/JbUo3sjI6IK4ZAjFaxWIETBU2iNVnQPmO4hIce4CYlj2cAWV13BSTMC945yRmw5eV00qmdKDpuSi0kn42Lqj0mqpK41oczUgrkwiYZHxuRkyZM1BmiuYET8VknJKGoAHm2mSeMaoiZ5ZjHwoTXKLKWf5weRPsmZ4wQ+FuOj9XYqm2xhWx7AtK2qPG03xCb7TfxQ73Bh/VuSMhO21/jGT0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+jSJnYoWA0D9IGrNIUOFQ6Y1EurSgBAPfKyXtgNFSEnNzIgGzKDQz7Jy6tCtt5M8GbAej0IXUmGTX2LOZjMdBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "D301561772887631697E8FF75990D8FF9BDAB563B79499443E9E50EB45F18256",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:g/MPki8NskpCUxU/ersr6+SPaUKDLE0eAkZsQLSeEUA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:2c2jybkUO1ntLnTqp7A7zqjVpPBoBPbVwdA8LWZYKpA="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156469986,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAr+JwWko6cM/T6mdY0gBsZH0OMcRVZ6pHUg8aRJscyFSPc48167Wu0NgCrBMmeOdMPLS7wxxJRYfCYfYRStqIBur298K+TweAxDtS3FzUV/ihaJ+/DejQ4O3kU2+O+8oWeJ2JQHeco08ggKb63oYM2twqNJ1CZYegUxnkldUoAq4Ze8w1axDakCqeqHP9ZUFtVB8mszf2yBHSHar/a+mJQsJG/ahfcY+kyMjrNo+2OBOZzRPEh96kEKVAOVtrqidXdR1wNKmYyxHcseaKYhjj5GHjvrHLP0E27QYlrIXg7x5sH0CdGPNHq6kuam9iW4yF28Zt/V+jDVU+RLrzEr1Ju2OzY1E9HXR6YiSAQe01l+5wjNfpF2BkFl7MT+jz9z4ZM6tmnp3uBeswb3KuWvEt6axF7HndfWW7PQbtL7d4VET9W2oSgK+pUgzxtkQA1qdeFuTmDRrsp7qgi5q/S+6IpIAVsyqQXt63pRSDCy0rj6PYhehMGqOIVYt2+hn5VYSfDVD1NDwy8ZMKYD8+4+ks9//qcEg7j0gKT3vGKE2bAchivzA8ZdYHe+JyXT+g4vnxxNZyjvRGGftUAVwUFDEXvuaAK4zVkqTXAzS407pr5wE2Gpx0/0EESElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoVtSGHZWKB0ua4K+y1EZGmoFXROChKg4tKvunoycoHHR6bSBlaYcDBs2XifxIZeZFgGpyrctDl9knbLlVgk0AA=="
+        }
+      ]
+    },
+    {
+      "version": 2,
+      "id": "a23db41e-03e2-4334-b967-9ba46fd5a9cb",
+      "name": "accountB",
+      "spendingKey": "7e58040d183c65955192e69eb0919ebb4b7c783e694d8918ffcdbe1a37b358b1",
+      "viewKey": "095a5ba5e3f84c6f13321da2e493888b32ab35d3c4a0f7d0c1e47ad03dd68736c948ad348d4e3dd95adb886851d0f5f14b3954ad5d112055ef591fd9f3ca0ae8",
+      "incomingViewKey": "726a6b7f93f82551b8c8c4a71a9faa5584392caa9bcc8c0bcbd37b32bb0cb606",
+      "outgoingViewKey": "1acb88be09f912ed44a64931649e998352564fa031855f72c8f522cb2e046c67",
+      "publicAddress": "1d326729ae565ccdd4dda4874dae82a343bd573fc90678380c578c3c14e9665b",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:zPcz9bOwW4aJwgxY+1kTidTSTv4aCY1B+8Yyeki+4Uw="
+        },
+        "sequence": 3
+      }
+    }
+  ],
+  "Accounts expireTransactions should not expire transactions with expiration sequence ahead of the chain": [
+    {
+      "version": 2,
+      "id": "860514ae-575d-42a1-8714-47b4ed5f76ec",
+      "name": "accountA",
+      "spendingKey": "1dd34fb303a56552e81c033dd7afb2952ad470da798d419d823751f21f338cd2",
+      "viewKey": "5fd048f48bb25e9e07a199490eb46c542b0f0938f0627b8f89e97041ac3e3eeedfb52d2a5111b53978c7fbd9fd4dc320d7ef007a356e7c49b8b5e25454448483",
+      "incomingViewKey": "f5aff28777e325e26cc06dbb72c531410dac4778febfd9061f9970272e466f00",
+      "outgoingViewKey": "d93112581f7d765b6847ccfbc4c82789f7a4e8b1ed4a408f4fd1e243486afac2",
+      "publicAddress": "49737b6876a2a2a7ff0785de1831034c98743b603af8f71f03fae3522975d2e4",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "ea2bb949-d985-4dfb-9c5b-7b7565ab274e",
+      "name": "accountB",
+      "spendingKey": "89cac40424f1b00d1ac7a7175761c9e01c2379a511541693886d493914b8b950",
+      "viewKey": "df56d86d57b6c733718a2d8dbff7ffcf60ebc347424cd1463cd83a3fb44c08826a7370e0f2fcef8e46bced48ffd0fe4b88a0bbf2ff08c0cb2eaa22a0f2a56d6c",
+      "incomingViewKey": "4e48004f8d4252291128e2f2cbfcf4fd3a8c0c2c2230cb188018a0ce4a8aca04",
+      "outgoingViewKey": "0cdfcdbbbb5227fd4f2a3bb5fdd4f170633bb4e4b218612164bf0d3c99955364",
+      "publicAddress": "286fc50221bdc93252a023de20e869498e661d2929573f65fecbce61ab1aaf89",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:aHgGwK9C22PE07UJg+yOu/0bG/Pg5yX2dJTX1BbbBhA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:g2P+Yyqgrw3aswuIN8p2xQbGpq3Z3HH8/O29fOHDzIk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156470671,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4qZiWjqJVA5WhgbeR9L8K20NMPu8f67wb6nViNrzvtWWirU3gMQZ+WzbHAZfzNR5rnvtEJhkv5PIYMUViJbwiGMSlT8uNXdjNBduQWJcH/+VIK1GJ4nH0Om9d7s9bRdhAME1NsSlPYzkq0fF2IwHDyE0MoT00CnSEYyzg/+NYCgJfQIr6Foiun8zGNCykWUa281RrVpZzUUtpisWL4avN+zDdE0ERznE+zEnU5XhJEmNbFvEYUbqZJvldnj1DJlvHjIcSnLfrcdqKiSf7Vdv7z3s7n/OW2SAEzXNmVtVsxlxCsSmLF7VtFX/U8jYeO3wjg6JJMvf9Fo3ba3x0ugfBu5/LkhlJAsY3ApIns8Yc3JTpNoROcpzfb8DfMzG6wgv0ZeItxf86x4gHTHXm0yWT/EzPzmHqyHKYHXOGr0TIoeAqniKjqceiuAdBwcXKmMZ4D6H2nGHlMavQ/1nJpt3pGBbCm5FhQrs+YbrN54uWUFcWa1mDnYosXPluJNmd5nzgS/6AC9/fpaiR2vyiJ1lw/kXzY3ojVvQJ2IG3kNceUogUlUQB5yqYo3Zy0oNU2pq5/f2ZWh2Wg0O4CdmEXwZcVWfgPbssOIlgxP3KhAhU7xIfWEoMCYDa0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIstUPkUvziQ9ZWnf0manvIUH/siwnxksrh76tKE4UIshY7y7Z4LYbuD7x3iOnOnW4sfZktSyTBiuW4pHeJ50Cg=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAaJIgOSUVCPxrE+0zJJJUqRGEifbp2xCCJhZdbIgStQOy2b3ElQLPym1Y9j4AeOxVg8Qxv0+kZnV+DQf0xNe1iZkI2JzRq7f/gZaogGAVj76G7IF+d7KkhJ/MZZxfhTWsJvlkfGK/KkvvCSzP1UvgnUfrqm1mX75j6n+5XxZ7yWQUYEnnvTTg3XMAUUWQnkSgZ1oRQ6XnzA92H46sV7d8iZEoIoSolCrbCEdtf0mGeouSW4TvgE/yNEOESaDIBcCcL0OmWpJcsJNHRieww/tgywZmyghndHdN4WBnHsuBNyPC3Tht8zAXCWIY98dkNBbnHi/uQArMJPiLruK/kvOO3Gh4BsCvQttjxNO1CYPsjrv9Gxvz4Ocl9nSU19QW2wYQBAAAADMV278u1DIcAhfeN8Vc7w9qlADU6BuVYFgBmjKaID/K0l9Dh2E4hvQfvVR8jHc8zvPW4AKRyrV2akloFjw2+dWVHfqc/QSG9Vo806LJupTF+l3jwPvnHUlaHK+gHg80DbgYZ1rm2W00ew0J/j48tu7P/yCz3da0++OSTVju7PJoTRRJLQ17KTtfwh0mRIkApKJw9bGBMQvJ33QbORl1TmIVrSGsKIyOsoJ5Q3bCC1bjE4Q9Xy+GK6tlsBYpuPdoGhWar7paH1WPYW2rKVSId4KpL+bA82+2Mf2Pa89ST5E5CgtShuC9tk3NxK8yGukFfqDJbGfuKdiX3pq88UzGyhILXz0jBKroUtXivPQxVoLF/iQi918FW/pOqIaKq5CwePOTkSa+WLUdAoTQBZghfUWa4FalJ7Cnr9FEBrteKsPbCRWGA4kAyZ6TcvRxsoZdVwbtjyvzxp/jzP1dx1b7dDasZtz7wsqf3OQD4ddukQwxMDFrgDNG06xJ5x8bTDwZzYNdAGeqCOdFs5x8782wBzvZNOSGes14Xmb4FvJ3K/OyLVjYukN/RVAWNjzThHANO2/5J+6DWwqkHekM4jkcAq9Fec3vK15tqYi3PLQp9VVezBrINPWa0xXMwbodvYW6r6LH9D3/zrZvRabhs5+UXKo36OaXycbIWtC2CrWgvjC6AbU/NftU5EPQqF6xNm1o01a+woaVVFdeoAtlZFXzplPWx0vpKTTMJKfNutbJaE+EqOMFdeXzL1px0wzaVyEZIjU51IG4Ly9qHekVjJcQ5SnsvF1cUSKXPu/UkhFzfwIeGJBP+HgaJ0OCJFhKMzqDLCZXp8T0X5V/Mww19nmxKXRu3bXs6KwWiCdhqWl9tfEB4E+KaShwjLqyE7V8uBjgxwJbAHdYDQojYzriNRH0pPRUxK7/12ZK+6ZoiAm/ZyCtrzQQGBV7N4cReqUGk1RrhAiZ3MkoZQEjtfAnHTNTSeHptEEeIqO3vfq0extebJkxKMQSwSltZ5Km4JPwR7DMXTDZBLVneKYmZJ7d2vHWKL9PzQdRlgC2CjebqRotWlxX981BU/tVUBdQoFlXxkKPHQJ4eP/A1+f+RzvEPNgUJs/aS0vpTCHeswwT60EjiwumMleVhxESNQdQAw7tmIFS2XG9IhC63iZQPv8dbsKHbE2oAxuIDId/jR7v16viSe/CjxzTznsNAdnPS7RHf30d4XFc1BmOqAdqWumiSTGJp5TdCK1E9vpXTYDwC4p9SjGl4K6J8FHz0eTB9WyzeQEGC4CdD1ldjKpgb+7x38gBwsZzPlkBHwqsMeExkmq/EGkeCOQKLf0+CmdOj4anwoq1ORi0CSZMMp9Yi+6HjDrC4xudMVnCrBt9SXiv8Uge7UIZGZUe6WkVwDFxnwdHEbF3sE+Kj7YymCI+xUt57mL/533usM93d78dRrploBETH1JjcqPnlp/QDzL/CNmL1qQ18Gg4Mi7dOeKIcqQ8WghR19nkBdyuImRBwPLjsuFVG/yxE3f9sY8/YZy+xjsNjTRUtxsVRs6QbGEUAFwVVBz/PTcOIJQ5P1p2WO0El67Aj6zRjUaAYrdK54UBK1u3u8fvBQ=="
+    }
+  ],
+  "Accounts expireTransactions should not expire transactions with expiration sequence of 0": [
+    {
+      "version": 2,
+      "id": "a660016f-3f59-4f1a-afd7-29d3a79191d6",
+      "name": "accountA",
+      "spendingKey": "cc8e2e1fde2904ea71a288fe34c27d3ed9e8296a185569a1d499607d8028f992",
+      "viewKey": "9c1da97eb093a0941c42805b13dc8ef900cd2ff24f425a364e3f482cd6fb7f5b584a2b791a729651d1aaaf16d1bd6dfe86170b09df4ea254b21ac6e4d0a15371",
+      "incomingViewKey": "247f252be203d3b4014ea7e578862705915340296dd91107e64a5e7953e44d06",
+      "outgoingViewKey": "3a1edc79144f5aa6497f55e9f753466aaf7edbd0a7a5ab5e790700ac604a3177",
+      "publicAddress": "8545a5cbd420f9e8bc0688c9ebf0238e63248309a25feae12c6c2dd9f4b6fd32",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "f3bd150f-4c65-4454-9259-983a00846134",
+      "name": "accountB",
+      "spendingKey": "45c3e72a488faecaf29e9f464c9200d6b8017947432e07de323991d372f63946",
+      "viewKey": "00528ff7083c320994e03980c37490487b21077e7e32692eab576dcb45a202c763aee74c11a2cb2cf9c8170628afb97c6bdaef5510360f209449e6a664749c20",
+      "incomingViewKey": "fb9a407f6c9b0198d21d27110e1b7f8640f7d9eb435eb89f9306433fb8911604",
+      "outgoingViewKey": "06e24aaf1e8c2c026ebdcfbf1978c686de549bea145dc1ce6561b03fe5f862a3",
+      "publicAddress": "b02b1476f987fb07f461ed5cfc127b89a0ef96112301c2bdb430634279f604b2",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:H6/P1lz2M5a6ci2pGsVf1dMsbMD9SLY7BDoaYA/JUTk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:GqMOqrA+R9Hx/BVLZouU/kJCgkSZOt0lhEgYa+OMPhk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156473380,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1zRvNvg8rNrl3B8dX99wYUHU3ZrBKfhVeR6BS652ctiFY8TrIjFhgbjXPFdCfyisJ1RkNzpwlyLCH6F7204xUFCHEJhxr98EIO78IDBcA2uWor5v5Nzjx85szp9X3ESru4ztFUMWpqYM9UGvEQHEmi3zazXwlZkVhpegNpo8PGEXD3JDw43HTXi3u1AqcjP1YB833sLuQdynY62jNQm1V6PrG9RL2Jlc0pVuH28TK7ukcsUySWKVCRqhL9+ubBKonI+G85Bk4Kp/Km0P61qmUJbSy+u0fQXH9/hBlIjBnJcTZotgFnh97r/E+qKHY1XhCcxv4syOW6zcHsuEqm7mrWj4DEtqFARb54FnvufELCZuR2UrI1BRTQzp4TrWyf9TsOZzY9aZbuPyE5b6790+xjTEa+PyZT94qdcZQQEhumZv5pK2YQl/I3u1arXdWIKq3IeLdyRNCrem8R2lcrIzg5gPSccW8ykgUQgvLUeC15ZMgZmBk/UTKU065rWDUXvPsGMQad2rh+MhrQIRjxEjImMX4SXr2ARmRFjOcDWGTOJVIYvRraTrrQs6IOK9JyeHKjJRdfBGfRJNofLAdjCaFxEwqTwZWYdIsaVGriXL8rUdWY9Dmwh4pElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+HzOiupWjDwxhLozKxy/6JWTvxIdZ4mGg94EAaeLCIp9rwrsKaGT7HCnAqaaFENnNDzHAsXIhzfjAwXxJp+MCw=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABD91aYY+AgR3sAIPIXul1fzPGSJP2e5GvWn3QjNcvmOhUeFY03KbFZVt9kHKyxIPeu3pIcxHmQbKeEoz+sS4MHJe10e8OmBGi7PxizgoX4SpqzjlS/TdJoDPTYfjItImHfm9PVVN2aexIBLtJxiE1f059IglHtQDRqFHUVwt+ssP57ccgOGtBRqhdQRf8Z0ikEwnz5dNh5ca3M9hSuHheh8MyuYMtTJSJpYcCYo6fryjX2JgtMGrNmdIKbclGyGDwSiQqCPZ524fRsolKJWl8in27FTogtb7ea7yCx1lriufFrrOZ6PKW1ogyiNj70gAsaieo//+DPW+FqC4QJU7Kh+vz9Zc9jOWunItqRrFX9XTLGzA/Ui2OwQ6GmAPyVE5BAAAAHr4/1QmFpFAfidHM+Y0eemqzopLqcnIAwwpwQTBaYpX4OWBvDH/EUX9mrTyvktHOamKf2fzCpiZ/xcdc9AwX2KaLuW+MAmcgxCBb/EqeSTz1hZUEOy75zL0oGYCjN9UBKe96JQLy52A3C26iwijBmQ8gu2zAhxUvkSIS0Qi20d/WJg08o7Cjhexpdg/vnfkeIY1sslNZvCCfMemQcD6Fw5GTdYyETEOljohsDutYwCYKchg9Z1MxMI3/SRQ2mKeCQU4cqACI5xedfwK0Qj+YDDGFKaSFfMxtvgnDu2M4gm0/KKvty5O0klkI9LuK1b2JYQOlEB2wyOHh5VoFT8h88NMMW18HEnHR03jH7kPhOdUBsqd0yHHTJafyu2RBSciQ0GLZeTgz6Cy3HsCSxGIZrX2FSbfubXkOpOF0R0vSrqqp+dEaLxKKe1UE3dMffbc7e4wB03zOYtRthmyWqjRKAjdyAmOfa3DT/OUYGA85Kl9Ji+ergzaUgBnsCwGBxX4n24sVXktZ5gff8oES32L94ydq+GJPgwwpbW6scH/IH5jIpG3zxzPv5dPsbLa3eakE8wa/00DIJW4wGCzgIAuclJPqzV6kjAk1LMwSQYbayoBlTBwL7UUDh6vWgmIqL5ME9M9iPFFpskD8YrEHWy7VfhkEJbQvpLnLFN1nN4UY1CU+5IlfK6VpZ+Ud4+qR9r8rPhTh97D8N7dCQevi7uLjJZt/eit+4BlcAv06a8L7AkM8L2ESMzR5f0CTyizTOiypFsEXIg1LlFOZ/Xm0y3wJ0JGw31TrA5Quq5uOxS2AlMZR/HL9mIjOGuHxCiTYPzXnaVTpGoBgZ7cpQM/Hzl3Jjbgh1t4Evcllxy0c9adUt7cDwwMD0/duv2uHYMYltGtOeanmBVoAsEXKmhFW+NbeR4E6JKQ+qlgkiMLySXC8SwoGW8M7kNspicM5YEwDfIOl9W3l4g4CubIWN1vLmoj+KXtjpYLbTK51t1kV6DEE6AHu5jd/VcMhtOujXcSvkciOOh6ecLJPMSY8bPJHcMJxusVDB3uJuItw2MrRhngmEUSvUP/u3hzpzcG5D1rRc+WTRxd7yGdNWjrHt9joUeebstK6aBJ4zotVBntQ1wdt+sqzq67uj9RVQHNKSaRB46dFFFAUfDlU3wwBt2HK65K05vthntDzwwEY4Nlh+CWTUGWhhH+0u/OOMDdme6EfM4oYbKqn+tUbScKjfhNKui72Fc8ZCRMBnw0B5u+X6Xwl7zfd05IW+XD1HfVpKMhc9hJ8b8wlVxKEFXg1mMbWObVOVbJQZGXCQCAB8RiIPF68ZHzhxbi6F/a4+M25RqIePDm1Jr2WeY94TsZoXXZ7XOnfp7FCELWyeVEoRANhQWKSYNFwrvQNuaqakN6vJ8zeombUwv5/OUCqPyhlqL/29/GTnTx3G70K3BoyC+7rlggjB8PeCVG+YgMI76s9GWNzNL3zlTXD56ZAQFsBYeCM58fGryW1Cr958OR2PSPJOVDSWUJD7LrmDmKXQhyV2R4HoGOP2vcisbAqY7+lI29kGkBeUwRjzgzhSWWacVIToteaSWSVuDykcwFDjq29AjSy6igDQ=="
+    }
+  ],
+  "Accounts expireTransactions should expire transactions for all affected accounts": [
+    {
+      "version": 2,
+      "id": "de106571-d664-4d79-be76-d624f31c5e86",
+      "name": "accountA",
+      "spendingKey": "93e8ba206714df39ded0542fc441c1625d062ddc1d6e5ec6ef1b62e16c2fe4da",
+      "viewKey": "288834827545697b690fa2e4c41465a85dbefb0a2a91ba1bcb7d0dcb75ae6e144b0a6bfff361c2f688534ce2c1a424bd77bac630ef8aaa1c0f057d7c6419b217",
+      "incomingViewKey": "a629bfb862ad51653aed305bc00fc50706662ab63a00119ca06a08bf15955602",
+      "outgoingViewKey": "bcc79541ff64f0d0644bf6722cc411804fddeea1e07aae369265669d102d6c69",
+      "publicAddress": "b3060ac7f36550cc94daff15b55feae512c3bd83e8714c7bca36fa3372fd734a",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "e80862e2-b53c-4d57-b2bd-a53b4ce25ddb",
+      "name": "accountB",
+      "spendingKey": "03fc18784d12b0922bc2da630e5723a395e10b9db3ff934c6b090f72c0e994aa",
+      "viewKey": "097e45c92ac977c560a927a3e63de58b9e6278104f209ae5313c3cd21f332769cb12ae87bf3bf58ffae21339ebedc0ac9cac70bb3efffb85b8cc7e431503215a",
+      "incomingViewKey": "2e3769006fae1aa75a34d6672a6dd127ef287b8dfab7c75f15ef91b3ee8ae706",
+      "outgoingViewKey": "79cb944c0c9b336a94e4e32205895b0b88d9840f27702e6b7b501fd6eaeb0133",
+      "publicAddress": "7ce14f982033982f0cdd330d871f2acc3f7e7d6ad37dd6da18e93a7bcf64d9b7",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:DstQa+dVPgq0KuN2MhQetFUGjvNn0Zqsf5i7ioaafFM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:9QPPuBiW9hUsxg1S1BDbgQr34afXZ33oLLZtx1to75M="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156476107,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA249KGUVyUWznaCnS7/3I6bpboID5adzrAO+TfRB2fMSHzHb04QwLZaamw4v15wwQQHiKZWF5PXJ1Mqw+0ZXgTCh70T4ihdSBld+oC9J0vAeN62eGUrDycBhE8TezWXsoaXXHP/mmFy1DlQIingsmU+MWlW/YxX3HorqaGXQ9vkwOP/eZfuJiFhgDCY3Q/Z/kqkpNJszaUFDyYekwXoYKImMGG6aWl93HRc7SJIeO+bOmrijmUnm8b4udWIEdoKeOnegIg3LpfBozJHy+9jG683ARknL/SfTfZIz8a7vXSAmW9EbOqmIss99JvvyIzp3E/Sm7xN1KrUBIYsOzcEuZHQOJAKJeliuSToAA5+0y63gPbXkEIbXiNHGJz1Q5gggNIXI30lulrP8n39GqI72Tjqj5FTQ7YkfLUdzGShaLj2MtgEVrgYpXPdRfHsTmdjAwsAMrEk6sEFVLBewF6xq0NsaK1RSV1ohm7dhJyBCGEGjqHLM7Qa4oKHOWg4YyOlp3OxRXe+axe9JkddL+hU0qZ7a76fVZnpdzE9sZ50xzxNeDS7iZSHXOJ1dtHtC2ZCpZMJ6etV+QvJpZHcLGNRq6/01kEzXCEl04IauPOBmOyVJjrupSfnBXrElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4VaHhE+PduaCvnoSNZw18ZMSuvGWTinbEK53E7sQj8X2nQ8gqJfFcUtbuRR3EjgupYf22DFo6kwAIXnPTEZCAA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAApd+THq+tXgZocw7oWIYO/SaYSpJHiPlKIA/NpymfzRKpob5HaEays1hkd4VPEeRFLCaMRhROjMCuG3tFXuoChaxZbT6phL4AO1nGU3D4F7O4APoNoFyIrizRDDETHI+X04JtfoTpwlhFlOh3pTl06EYO+wH5U0CUxzfnuLg8gbkY2KaMinxJ2CNwEbjl8I76H2aekNbIcIOM6qNYtsO/173wmLP0PTuf9RbWSjaVHu+oad6xGU+BxiWUdv8OD7sO0Dd4YhUh/UZWd8TDGH8/Ic5b5ZQAu8onudUNG8fmnZ9/sG7ks5XfFv+P2DHcmCJursk7ubGkJfMlprjmZ719TQ7LUGvnVT4KtCrjdjIUHrRVBo7zZ9GarH+Yu4qGmnxTBAAAAGX3TOZAyPaEOzeQKSKC/yvGE4hbl5Xu4C6jCkEKqNwt7Clc1ti1XEPQwsnlKk1knz5Y9UHoYJS+MMczehhsQOZ9wIf3H3/uZqjL8VuzWS7v493/hKBtZ0nRdtJOWfY9CoaiyM/1IHqDRfVF2rFKtRhGM7GKMFxmJWmRjHoSC/SN75h0rn6fg1jUGJU77tmwc5QNPnOdbrL9ImzGQe3PAcoC97oLVgzgN73O+il/KnQCf5WCWn9bKPYzp+5PV2QQnATyl2eFStOnwm8OBwHzbYz8bOaRF0yKki3DgEOmJ/v/Byt/bD1a1QgzhE6js2jC07ap1nG4of4VggsG1EUDFHoJlOiH0tlJ/KfK+7IGwbaiaYoMjGXO6AidP+ruoRWmU/2kGUxc8U8Ds00VOFCd8LDtcCRONFycDpWJi90R8tSyyNnRmwDQ+5nCZ2VXD8uu9zg6RPZBlkfu2zonNUFeQBb7/6twqzLSNRM2YZjUyLsPvu6HpPfSyh851oR6gg9vN0hy7/A1LMHN5oUQp9UA3fHE6vymUgTGU2RGInTqhJtK/ibizplaGkkSRnDyUwDrAW7aDk3Griy/qdpMxeMBrBm5qf850mNC1XovBbxH/Ea95s87GBapWuT+AsuCCRUKaEQDgWEnki4SHE956isYNiGofhPrNJtsuBfPRwWO8Ccwoaz/Eh64BZvLIYa5K9QIWk7HwdYtCUKSbe2SqDkLTybIVjS82FLXALeXnAaLRBEJMiGlE1krCPuY+iRsRL1ioKupBj/JSVMmbMhNi8e+wfUadoi8xu2MhHGoOSWaFpgjhkazAAxDQja34klYWJRE3emLTEnz/sK4E83fyWvfwFg84PxLMeycuUJ/lu5uQZU19vSkUpMp3vi2dWgOgz5y7Vkrh7i/zubvmyyL2xERyGqgZVO0Mff5n4T3cejpp7wHn1IvCosihOISpQMvXvyZFV8aOov7oY86HxCLGWnYlx01VkAeN3VFX3J6ts0Ki6rr/B1s0IXr8J6mWrLXCGor7lnbEaOpa/srNS6nQqGyk6EjoycQiry+uj7WM8fSqkPAa2UfphlpXM7a4vR/8PNmbk2eTvg5+Yn3zetkViwaQDZfuobVY7MsWQKaLAVvhwgRiNsS3drFn4Ha8Pw62HftymjSmlTL5sEgIqF7dIaPMkHN+qyzlZSZ7IcQJcBrhBAVo9aZlhoJ6g4cRIgMn+iXxdc3g03sYJ/bYPMNfgwweBCBxnt6V1E0PSekSdBnPPRDpux8Gs/i3suLjErymvcY3b+HEEqTrvmhwLcL9NxZyoUeOE6eHfTou76qhzUtNxgzwkhE3IRN1INxaDrQ6eoMr7gbY69HETLRVR9rqOcDxTgWr7bhYa5xGHhX6xuE5XO7K/BzIG1yfcF3PlLC774uzvtCScWd3b/bL7Efwv58nAO5itrGnGyL1SBV/FwUTVx7wfpeKeT8AIRz4grSJPLPppkwAmj3PtxcoayXcyjS660aOaxjYOtw3R8iZMHkuaSEXOr+HgahTjUi1cH0lcDo5zmOyBGWKt+QTMtYilkSx22JRP6E0V8o9sNrCU8Euuvn4yxyGYk5ZV+q6Ww95TSSAg=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "75AB7F0C66B77B9BFDAD9F87FE635834E91176A89935801616E2F28435F0DA89",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:9BOHS/0rqlmP/Ny9k5Lzvl3WlbwIzn61MdXfeSCJVUM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:LtDk1+hdphUj7KU/MnPuMeLcJmm7T7+rFgD3d9YbFMw="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156478718,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1//EuU6H03eYsk3US7PbiWXF3qBnghnTbasnw2JDN4qP2MZxce0m9xu6nP+97ROhIZKaiw1Ehax5COiFvNd+fSkrk/hq5wWfy6XD3f9U236KGAgpwEDyzcmVEy+JmKssbQavhtFXFpyIHwlv4ZK6ARoyosesm8D+/bP2oTGrW3cTAn2eAN8WiGAOH5M9u7ntsWrxtbTiENHVtNd+H6nqZg4KOvqWFZsLgvvtNi/+OX+HJVvWJHPZiUupRSZ0BLR8DI3Rnu6YVedO03Enl7rxIsUwOG+cLbPmkI2SDC6pQ3SrA8pDk2w9ZALdmamOUuLy+wj6qo4t1XXxpoH36plqOmsG0/2RQTqR544THZBB+zIweto3QKn+2AlEP+cKOfkAmq8hSPsF3LPeHfNZF/corCQDbhZYHiHUDpiSnp1hlDJfqjW6/ql6Me8yzxaCuvLGUT/iKKJ687yusmKK5+lg8/XP0IsDdFsIKqp9USol+WxHICY5xnqHvFRYKiVUSV1Fhrr3M85WyDxqI0jrmECVm0XM7lRt/pt60fQVWwqtMmccI8GoA23Jxbtz2fTBfbm/8b6JNI2fWmc5CfDPumMLiVuhl9IwWlD07pSg5eoG/YN0xhXxg1aFLklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCT0P9D9hZaxwNM/ot5PpjcsomGJHrMByEaVQ5hM2hNyn0iOXS7eF+bftLpMkoyqJ8FF+LY5skEb4y5U5KXxODg=="
+        }
+      ]
+    }
+  ],
+  "Accounts expireTransactions should only expire transactions one time": [
+    {
+      "version": 2,
+      "id": "e530ba54-afc4-43e6-90b7-c226d57570a5",
+      "name": "accountA",
+      "spendingKey": "faf057a71eab4ce846013746f846a251db0a55d4c7405725c716da3da1527cb8",
+      "viewKey": "d74ac2d54b604f12897a80498be79d894f7258039d615f393555fce876735789577f2a6e16ab48e2d83244ef3fc35fc138e6b1418ba8287eee2a340555b60500",
+      "incomingViewKey": "324099a8b53dc0703ee22ec393acb6b3f553cdd7ff69c056c2bdacf72c0a1803",
+      "outgoingViewKey": "db74de712ec11a4291e22cfe76d5c7eec73562c5eb0290757458616c4332fd72",
+      "publicAddress": "227d74d353f8995ad3e48670ff6d6812f4d5d3885300c592f441d64bcb19912b",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "29a04717-372c-4a3d-8823-e2c71509feec",
+      "name": "accountB",
+      "spendingKey": "47a165ef6d8e8a6067c883c1d961eca0d775ac471bd5011438dd1a3c8f651dc5",
+      "viewKey": "3d003a8cd45f932403130c4ff374a3de655ad805e31342b635359c08014f79451ab6798a7d2f08af26484835f955d3d7592675cc9717c3f642e02e9ddddcb327",
+      "incomingViewKey": "a4bef34c136d61d3b56430fbcc65a984f69d6c957996ce7f705c71aceac53d03",
+      "outgoingViewKey": "0e70eb4952123a4ab919790b433f6d3691b50881f488e04a9bf41630c4fcc3ca",
+      "publicAddress": "aa79861a3eb79d247987dec25169ca1b63f90eedefacbf795083c1064daf2f28",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+Wq5pT/CQ8pBBa0qkKLS7tsVfZIXHyRyrBjNHC2IEWk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Y7bbuYfsiZ8eDraIRs6a4Y8KzwJup2JWONhOpt5V6fA="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156479361,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4moA/YuF5PS0c5QSkDyT7TmeIsvqzBFnNoiSavZZ6Tu1Y9xbCIj3/5G6UMgTyO+ZPaRH6GyaAc6yKnu9q163Qd+RSWB1qXyOoeTKvS2wRwmWWH5YYz9+e+FK4eFsjrX+nMyaeCp/5TOWpvHHaJsFIHoaYMMcUS3csHc0t5aqal8Wi32TgdkfWfK9n989xv7nFZZCYzz0Xd1KEiWsQXH6IisGUmaU2RJnCz39zHtX3K6X9v4Imh78euqmAA2jZO6VG1XxzWuhmjtV9vq0Z47COhKZdzPjefRTM8JgQWET1MwZp+E7KuTFScI4xY00wVSDmxZcwTqGszf7YR2bYN+ZIrHd2Dk3SojzS8QsXV3v0nH9KQhRnKsMOmqTx4LN4F5Ktg8QyGZxqWnA2BEqCA3IUNP+5Y/kCO8r2INB9OyMILw33w2rAuupVp6TP/O0sOUJMAVmHgrp0QfEAD4fqb396nY94mudnn0GCEJ3CE6oKc5B7fPi739drKoCk9YEY/Y/g40wGCWag1tJJjjF9eD7Kvxom+yB5J/Ldbkzlg2Kfl1Lvbl+8Z7VPdxpCwUbgbCWpT5kP5SD7KAXgrgIJ7q52Y/DRKgohdT6sBkAhinX5SSdSTZImwgEiklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjC3IAvXphT3ZDiYPcE/37yI7F2WTRvtLpmdVWzbFss9j09EVyHyGLwBX8R2Y5hi7x1QeQpwqQHRoFMSpzeFVBA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAA3bth6TT6paZ2Ee7m1Rfb3oVoKT8Bfe9PUc2LiI2RJauqFGqpSCA9UJcRf/KU3I6rMBAPYSHaFiLeOrYJyGiI987F4aKzEMsWpsin+OS8Ruq1eXN9Ecs7HBplwzEzdPVjTkFG2LQfkLXtLYWLysn6qFtH/34xuSPFctxNOwPmE7cDuxxzLNSspSyPfTOIIZsENqz3dd9VKdUhyaXy4yhVuwc/Jfgav5APVMtBI4JGQb6FdIctnLHUu0ppZ9dPhBNS9382P9QO3Qn8AzzsQ1yiEowd1cwXIddRup/bHqyam+3ruh7vL7yy0gbPtNB4m2CIbJm5Lcrn3cWKz302PuiS1flquaU/wkPKQQWtKpCi0u7bFX2SFx8kcqwYzRwtiBFpBAAAAClRzkhUjwdEJMq7xWjtXqjOyeekGfCvE24hS0tYB712Y3y1WGGLF39233dj+1mpWzYf36Ww3nqb8nQ3lm3r4JnlkzpLWrLmbsKRUoakZIFQIiumK0Q249CIzo796oCnB5i1fO4yADAxlJ0Y+0srR1+PPCLEIFKVc1z3gxFZnCqjA58L/2vPtuIC0esMXXKirpWpCSBYxZysiBX+64Q2QHd3LodalaYk0sTaJfp/grClqXCFjRb7dEH+/28kQyTRkhFUkb31A39SBNPIr7g5vy7asq5zWmeUfDA0evPH4kpQbZuq522l+PQz9RByvCyweqiJkHhxuy03ViRO4z36RrktKQDcemupyhrp0DWfqIapJE73esqycXhdSNBeGGtpOoo2GJj9ExGuLxOxOsP+EKrDHXf/pLNgYpsQhwobOjhNNMmIe37mEr00+2oBpQTRq71EmAaqBprPV9p3jCTAuBCxEsFZbKgomWiVD90HwAYUdu3hVFLstDWU/me2OdREGnhC2tf2EsZ9kT+1WxxX1W45sctWlTgcK4DG5p/Pc/nd2OpO9uUOkZG/hqPMD+U8YTM1/curbOKJtwHxr1rCy770t2dI2bUIe/8l5R9NcYkpTHF1Te2pmVNwH2pZF/elizR1HrszBsOnYtRn9cPCoVgoAWQ1O8arqrzWyv6sDNxEB1DDafHSie5d9StZHGV0hpIonq2RHJlgahfh2UrYB8PbZ/XiyF3CDPgq8hNfhedF4aDkbdNAXtOw2k0Esg1+vTAvA1L+VfHvfNaiU4MRE0LaTODpwDjljFWvw7wQiepT3bOgThXoO8CRc2tj2r94v9/xyWKJChYADVSehjYNMVV7E1m7Dcu/zBSoqVRsTPMsq1coVndYbdS2vaesFpK6afQtTETNU1olMR8b1EYdiyikAESk/5aESVKKB1epQMueIWBAtV9AeVcZ2sLqsoATZcCrq+I8+42atdx8Jx2FMl4Bn7STVY81EmX+vNGJpGmDsxo2JkOkCoWkGquZHefoyU0F5hXeFAuBBskL+VrpOsUCK0OjNBO/smrb1SlgegGeT8L/kqamtXVtB7LtneB6C5mUxBTnZpMuQwgmlRD16dukmmaBPWIL19zzT7p0KIBrufLPbv5pUF0Bjr47sWMBybqPcz+JsnpRGiuDlejkh3GP4ZlxReRgboCNwRkaa/iYQQAdxlG9deIj8u4kJv5cGXecffVSXtcrnLQRfHtzGiicqsfAWlmEnCTJVcFPAJHnVr+zXicvPI4S/huX5YGloemk86qysK4Y3RVjcLwEj60LkFgGzr9MQ7Mric+f0EgIy1iN46EC7mbvDp9Njp+gMmovTXf/qQOtAXRNTdz8nj6OmriguiDTaGhnsQu/aJDBm0W+aigJEEp7WWwtWoMgC8I6GepFf8i2Iu8ItzIrKfrs6VvOy7ltQEa8v3Tt1mMgYdTDL120saGIMON1535PuYHVihG//7onIyIIz+pfmnT64lS5udyAp9BeQc+sOmi5i8gfAWjISu0M1iijzJDfk8OdUjvj9EfGJWGKfGhu4erY06uCOzyPyRSgV9fpDvyAcNL42VvmSjdRHVeEMgViDA=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9619AB136D576903F108CDEFD83DE0E0B9C460919D03EC3EB6B17837BA7B1C1E",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:cUAkGB6g3hUkVuPtR6Qp96HJkB8l20iF2Ejr3fviNTg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:K8zC+Ue6WoNZSldLaWtnyeemsSHuVgcZPs8+4VEYPrI="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156481949,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAoZs8gGR2JLbYT7jib0cNah0FM/mQoVGKIMx6UZDRbMiT4sk0ilJQ3lZDgXzy1HgH6411Ao1sdshspgaTLqxOWg0k/IWQPggMTnFbWbSRczeCWPucs4ck0cfjYoHk+EFt+mmPBasHBffwaDsIFfc/AeOtq0Bl3cK9621N6PD2Xn0Iq8ph5WyRCWvUjJEwqQzZjptYtkTntU0D/whJCzmWErcZzARI1LFetq9gFBNLmEqwyAhQH3RVEBayzYfL+Q9HgnUcFt44u2523J0hjh84nVnHoJmbKqfvZ6ci0w1qGs/+riUg7GcqaQX2NyWv4x0As6P9zbgWFi9P03tvlgKeRB/yTE8NENZcf9EWYW0etIGKHds+hoSfOZ71SFzZ9mkUhvTGuldRBoZQb2eBcdrOdnv/K1R1kodDorqMREggk8QiCjvqChEK5tW8hiy4z0ISLSf7tGHDg8bwQwnOcG7XUKh4w1wAUcHzaVLKrHOv/1saj/WnZlFEar1oflJOrEjvF9gOZs1klERW7CGKtQxXl535zJQ3zs0TBagjQOlIhvrMXg1Fx82tsfxyq8MQRIa0/C+Uw1y0hm4ro8JDDNUS/4YxNqN+V9WaHhT/ujgaExsnEnZ3Ov+DtElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwICuFdsGMSXMdWYjyi6We5qGwJ4lGEI0dU5NMySxRbLVnfbp9gBox6HLHZFjU7qWnNj0uFLsfQJLmQVaFzFb3Bw=="
+        }
+      ]
+    }
+  ],
+  "Accounts createAccount should set createdAt to the chain head": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:S6P3WJxFfxmk0fSlXQQVNNoHlMwTx9jbk8ftc2f7RF0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Mpr6vAvzQL7xESKToFr7m6Qh/NDRVWRX5i5qqzDCUKc="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156482612,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtsMyFwUKLEwOT7TxVX51ekA1WEWCyoHC7iN1Zsho5kiDMpsvjPcq+Utfn8/EsHXwZJcJ/FFZYt+pFU3u0E2ic8naNQlQIGTv5E7UHQtpkIescjLC7dDDCECoIRk+3/X0kq44wF+eBDhQx/2/OpWeWSZq8bkd7xhkWXEZ1J/++vQW1fR1eK4AO13nZQmb98oUp0qdvkkdmUTQBZuu+udahKmzAyN15PNd0wKB/zRW1ryPiBscyphRaFbaInQvP005UDQUD/4vIG/4mvu6h/UpxQAbxs/+AnvLq7xDYhFf9lVFWgTCNlPXlG38dz8VgZGsN94/rssoaYbw8IQKk/iHcrDSy6i1JPLDveYpKz7SJCcHN9aSZqc0UnhytA9TpsJgBmr8ETJyYrfTpWfrP/ArnxodtakgOeRDwR1NSXe530CcPwF083larmDQ+UnOT2NVE6t6PDXeOLtxNyeSmgg8PJ27w3DnLsP6qcKzylqAQXHYSmOkAWjQgqLwZU837nQ6vaDpC6b/2sGyW/T+7DvBFxyFCoJDv9ClX7KKU3DffDUYA8ts7LdlmZTI9FQ9cM4Vnj6RJ4kmXHZcimN3Nl9xOMUr6fM/icmtILk8WAhLCGGGQbY5yzUF5klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwlcn/lVCMNhj17MHHGPtat2Q70WQfTohf99Fa6j7Zu+UX/Nfnc7B1mDa9yuSubRZjMMPMI88qeRU20znStLy0AA=="
+        }
+      ]
+    }
+  ],
+  "Accounts createAccount should set account head to the chain head": [
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:4gKBuM02TxlTjscETIzbWkYb4Xv9L7ZVVHLxvUPeUnM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:VOY95LiubNwbiobpqjXEsZclqgcqqVcHQS7kHZk6Ey8="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156483275,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAF5CK4gjJeGiTKOAUp10/r9ZFDCxa/Rt1IvCshl3avzqX3rhSTy0+A8u73qlgZzCOzMn2tFJB3ro1Q6zUbxmMrsuE794rXqV8zsSR/7KR4ByjCcL6nY5YwpkBlZ80wkX40I8210XnYUxUikSq8P3Awk+oMc1Y/UYK8k49iKPs2CkTQJRY0yFDW4gdfI+jMxecv/FYxEys9mmZtAipZkMn2Btby41KnJbABuVh2+8PuqO1ciV4l/VnnE58RLfOtZDQvFGJDzoVvyh+phe6hi4pKrRx4FRXq+vDmz6ceT3bi35BiT9LGnZ5nXMeGxKVKrGrLaAeR+0LTGN92A0JtxthjJ1pYMhUnUqhuQFgkdGgdQ5Ir9QllkgXm5Q6e9Pk+aM8tYknjc4MPFVmQXBjPH+/gydOL0hna32zI9dovKZBFGvkJx6LwLNRBVvU5ZxdOIYNDHZY50ekU3U+Uu+ff58TqVQy5S16GOT6xw7y2zliKncSIPEJ93Dw0b2JDCmiFAm9jtxuJJmZibM4+QyBHTi4TC6vTdfzbU9qqZwYNq4G50RpR3VFTuxKtUc3D99rp2O9bd9gJboZZ63Fs0zfTYgt2ylBLwPzdybz5wBdaVF4fL0cutmeJWfLLklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwKl5PwOTflIBBamQfcJ7vDCdOrYvW8pLuat2lQGUFDWSMf06qSMuk72L/WYZW7Ti0wvlaoBFNxNAYZ3yYR4QPCw=="
+        }
+      ]
+    }
+  ],
+  "Accounts removeAccount should delete account": [
+    {
+      "version": 2,
+      "id": "970be3bd-d2fe-4281-83ce-d28747f2c541",
+      "name": "test",
+      "spendingKey": "1ceb1197603f08cfbad28088c5c10eb2dc47114aca5db244b328d35d156b0783",
+      "viewKey": "4bcbaae53e0cfe4ecc8d2025edba8538b80d7b27fbc05e93341240f18e414d35e28315946b0f44f13be15b4d2253286788286d765e2ca260822c2c137c8cc29b",
+      "incomingViewKey": "1eb969fdce3469735fc2fc2887661376e5c0a24c01cd11a963c62e2bbbd23306",
+      "outgoingViewKey": "5acf20c28da7bece86d1b89945cf316c7f7425c5b4ccf5347b311b7ec2727e47",
+      "publicAddress": "67e46f52fe676be387c437a8ebebef1bad75615215dd2ccc637172e6f5aa5e51",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZdm/CD4dCZlP3LRTzwOT/YVP2sIruHg/LgSxXkYS0s6BFBkU8/6zlVkQ/c7rnQKldq+8c2MHOb6kriiIUgsl8XAT+zAasdzUNDbvcC5BPS6oHYuafW/7MS1C4l5rd2xRZ8jQsDjSCZn4mcxiaTkokA9vKrEOhZjcUqqAuOZcEF4HaYqqW5RQIuOWo3sv+lHXcPfbho9+AVO/goszPMu/k+FLpcjn2qqJ5Ufg6Iz2tyaVmmKXmcVikvaityEVIQDkGzh5MEdAxm4htS7FLyFeW3LMMlUFBiaYdvYahyQtYw3vkVmwuglz4Kld6bUYmOofH16nARgLsExhHkJOK+FZH0ki4HEn/36bGyxSdJ2JPOHlDuZheWMAgXbhlMqHsmtOo24ysiqYHIos6MdQ+oEvX0f/GCg0f8Ftcyqf7nhQawIP2yEPBIgSB1ENMCYbrp42BZ9mJTzzIu+z8lXtmclngQwzVCt2lIk/cGLTvo7rC4MxRuIRqc4ui7EvratJhpDStv+E05UmpE+yS7nXiYD6cShLIuIEIxH1aiTIrs5ynYgfWWbCPKzBLvpp5wppO4vBAXXYDE+KKyAU4PMA4JZ4J9U7AzPc0qKJNV5QEU74jdZvHTORpZhgtklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbauk0d5oByoVOrBVaxNFITTommeXNBCt/eg+iypZIBmT+0mZS0XzaWeJkpwYhB4H65RRwESV11jT9KPwGmvLAg=="
+    }
+  ],
+  "Accounts createTransaction should throw error if fee and fee rate are empty": [
+    {
+      "version": 2,
+      "id": "9bb8e321-7ca1-40b2-a7fa-f2ac3cc9fcfc",
+      "name": "a",
+      "spendingKey": "19d56e5917664aea80a5e64e08b17cf69d967344a65965ce0feb019cdcf61044",
+      "viewKey": "b2291f69734706bad5df776b2a59de1ff91c2cf7e5144d0a12800e330b57e1f3edb4c25f809ae846d183575b866fb7893c72f3095039ed94b4b1cf6c1fb459a1",
+      "incomingViewKey": "f342958164ee0a160f1ba19bb817810e61b10b7824fd0ac3402d72f56ca42707",
+      "outgoingViewKey": "1f016a0f7443391681f58fd994ed606bb16c4cb729ffc210a1d0b5316291dc00",
+      "publicAddress": "1adcb1910c8d46c05c3f3443ddf5d1362b4faf06b1fb648cac188faf0033b855",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:G22SE+W5ns6ngfXvkcfEdc4PrO6gEGRWJ+2s6T3BNhA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:LMzrIv5A3sdxoAyqGM621LDOkiqe0kR8Li2I8k7aKfE="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156484622,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKw7qbv63c7TZ5WGrVCSqMzt9D4Hz9aq1FBv/KPJEdMiuB4kgJcKiFaXb6JmFV4IJVnBHFDjTlg48GEEHBYZvEk9sAqTR3b5HN0CHY2MYp+KB8uYJ3g5MsHmIGEogA16Jnz5SYX0MLOT5PyTqzZO9JNgfKftAXMuihs206JTlgSAEA+EilcTUNG82ET5LyEGw35R8QlNEoW8F1uH/JEr0j7vRSDDXjTl2BELSbriLMEemnYxPdz8zUsvpczPgSRp7QGxDaUEQEdwO1LvdP9QUl8cznKNP6Put80aN4EdnVbmxLECOrHmcgSO2Ia/KnBIzwoR7xsNXm8tjRbbfHhVRPevoiOJMIg4bklgJm7fie6OGAMx1ivTD99R9zs3rxws5AwqJmvV9gDk74QCjg8QtMOzS9T92A1KNAMQHSuBYJUjOjPkxqwofWCC49gfKYvSyz2e2xmrOgOvWv/qLLohSjCr1/HfumVVCSWv5SLznDk5eP/J+Wg4WFCsu2TEHp3XseXx1Iq5jJdi2zV6/zRXh+G8rrOhQPmL6MHO7Kylw5Dq3+OBSaa7hd8oGe3Dl/WsoG9QLQhmyWZssTueIqdSjF/VzuzjBHg9hD+fPYrT45/OOSZi3JUT4zklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwm9t6e0SesRNidzEHyJ9oXMbUmrElNFdoO/UJ4v6jh+jZPPHAwulnGdDfnJ7jySCpSD5K9lpYquMerOgi6JzLCg=="
+        }
+      ]
+    }
+  ],
+  "Accounts createTransaction should create raw transaction with fee rate": [
+    {
+      "version": 2,
+      "id": "4a466971-f9ae-48fa-ba64-cb8877312e9e",
+      "name": "a",
+      "spendingKey": "3b6e1d8883202e39b8918d6ea96fe41596a45123b23cdb5b235b60376727b62b",
+      "viewKey": "54bb082b4d07e12be5d032c82c91ab70ee1008850749f3fda725a751c07869b0df617324b78ae291827a0fd605544cf7f8a294ab9545e18cb77b8267c19d8fd9",
+      "incomingViewKey": "6419eb4187e00d2a7615dd3b45ad9128e5904c82fb838f963d8da0350ea4b403",
+      "outgoingViewKey": "832ee9457aaf5783bd51c526884954af9065ced0dbfc45e52f3e5ffbda3d29d6",
+      "publicAddress": "f318c151919bc4966b703ae0b23852c55f2c6d3ac919ce76096e62cdca68c671",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:O3ssIXNI6clrwuoQ0LZwv2jbVHRmd9wHPzivelF6Wwc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Krm0YZHTPNPaU5GrtdS8QhMWGtqSkkWzV3nnvKA+tlQ="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156485274,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAN8PWr6qQdd765y9iHXxi94gRF2GYTOuIsjoHCBFfspOHMU1aVFH56WmDI/BmeVoS34hQ928ByBO2bE7Df9JeE8KsnE1HOv90ZMb3x09pl7yVGVDMchEFe620y5iph0pm/XwREl8UudUmQPcnown40ZajFtAPzr5MIMSqHihLBb4I70HicVDP0+sqo2vAgeTwiPF4bDm7JX6Ad01cCPBY1s16E062/Kk1HCK6iaWL6W2OFZU+/tIxhoqzwfRJUEtF7CWIAFh/KfMKeesIhN0/scjXyt+NSeTpPi+5tYsrCSwKurR6l1ZuPROAiMJXg9WNeByyVS1INJ3YcDbfNKAzQOZZY1VVewtCZJVsXaPl5xDI89P5ShKMwPtVVSUI4xoTvCW4S+4IIzK6Sr2sy7ACBiITYzpa8gkxzYIM0x7BwMJ395HzMnHV851ZeNM6qiBR5++P4JoXNdGcs9EgmWZG60LJUnUAZhVV3Dbog0m14YPGv3RXQbfCG/YrkcenscOVfIijBUfL3URuYY9asphXsCcthZ3k/JAEws8MJxIkLKGUGrvq0m0EFj/g1e0GVQyqDcIK2/PTuIyu4rVWyZ0uM1YXNcfavNRe7rlyc+xZQfP5LN+ebd2jiklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw5bjz2KcbacZBzbmeiYbkTjnuiUKiwz8ChlRYcw9sdMfLcDYdI68D2NeDT+ArcD2UZDqEA2PzDPSsyzc6PnRCAw=="
+        }
+      ]
+    }
+  ],
+  "Accounts createTransaction should create transaction with a list of note hashes to spend": [
+    {
+      "version": 2,
+      "id": "d027dcf9-2496-4626-ac9d-183185c85daf",
+      "name": "a",
+      "spendingKey": "0a09c894f78a69396c51a1dda9466116f80a388d9fe5984f5f5b936c04edd63f",
+      "viewKey": "0bfa6447cf6e24128e2fb01c939d72190279867fb2eb36afb74759bdbfcc8e98cf6478c46b0369276084642b7cf79f26d9af258bd0017bde3158bdf4554f792a",
+      "incomingViewKey": "c9c5877f63f9b01fa16e49fd480884a10b532f1a64a335a6bb951d1534fc1202",
+      "outgoingViewKey": "dc940a4376cb4d504dbbc324ef72bfd9a827627e3c3d44ff09a599a6e1ac3ed7",
+      "publicAddress": "d031a09974dbfa425111b8b608e161f97652475bc030de1016caf454b067a901",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:rh/fBVxksMLYnZ+Pt0MsUPP/OYVAPXzbC0GUv60J+0w="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:E6rbKdhL+AkRl8iqxVAkJwVqz5mVIaqFraXJICMt2O0="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156485934,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAYwvrnm27fYxtu4zOeHwA9ipI4FndWpIYNCBeN3lxXTKBPQerijN7Urkgd0ET+TByXa80bxaN12D/Pi2q2X80eghaM5pFZ3Mm+UZoAU9MV8eXN/vwV6GMmI0aeSs+zgXmyNhTJq8zYXQiGv9JUBP2I/wPIWn/xaY6OMvn23z5Vq4QCMfBN5Bf2bqNvtoDFohJw4BG6MwvxkOw3XIFC4GRvxDEhGiOtFO5sOY67qWqGzqwMZ1k7rPM57a9fF9USEw5ZoigtYPngiEPenGRbPurVx53STbFwYCnAmi/T948/cydL23orbUlis4sMfZt/6lp5zLnvtQZhhOP2ws5GWCH0DYKlq0OH4An1Q91s8W+jR/1+lZ5Vgmr5ONIDwgTrWhpVbXjYNuSBkgEEnt+MbRJ8i0hQM1l2PIQNRsQnOjuBgYIuDN8RkNzdhJwJxuc6GnME0H/SKsllnoUasvK6i6ZW3YS7PqxAcjgJgwKwlOid+13RPHXtDvebV6moCD8wgUzJ9zy0WdZ1hCaBTCQTgFY9MjZNwgs84Ao75jnu1X2vjAEl7i8w1/gdbnziRZsciXViGy8Sp5ev6kOLF9XbMn1icv5x8ayTxwSwQ1pzygUiUv//TtBHyss+klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcEjJw7tGZH9L0tJFs4IF2heVq1UPGw76c9iV5vi790xvaBpCLzDge/b/X57Z9L9C43T7hcsxuv/aMfY3JjmECg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "33E517163021E385EDACAF85D9551B878A30F1EC0FB2ADC3C8AC598409398794",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Z6YdqOha5nKKg+y9zu1uBrnyBYjfBaqXComD0JqW6TU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:rR8VQ+zR2s/K7CbSTM0rXHfSZgcFPCpV4yAiHCN/SK8="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156486464,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAyQqlqiVFQ+5XCfaMB3RwWowdTRyo6MCmlEEDqeyvKO6Z4S4UwfFBvhwLJMZ9d0vECObQLZpuxVwefKAsCRMmORGSquq3xZgdUfowJ4g8NNG4y4Xe4j5dIO7gA9Qk4MX2/iqrb7YqlXtTVUmBxz+GOmmomLKeOCvyAeDRiQ2QXVMW+D2mtxOsU6rFHxG4wRB5l+GipOaDqlRLXDQC3ccO+ddkZvCI/VQJmrEEal5MFTGg4KuZYxxd9XCPCRMStvgwnh6M29YUebVM9DqYPNn3iYx+v6ku09QbPRnDUuzvA2NKbvwfaamWlhbYRxT3q/eokiQQyLffXKHLFsEicRaNWvPfndV0RRVoRV5QwEFWML0ZVwaj/j2l+0M1a/hvLvoKE1x0+w+ffZy/BUZ5doAttQKXfo5Dng/GFBZhhh0IwitqTN2FcexXjx9uv+8qfW+77SmYJ874m3hnWKvHnW0P/nhAwicuhJrr4COv1ETdwlwGOfZ/2JQlpK15BmjZ+Om8ZZjqQyhlY6Dyk2jYvWuvDzqwTzR8qoixFC1vJyM+VrJG6EeO8Puv+Cwjuff4sSllEiSPJGKbtPf2WuBWwtVKbe6exAJcC0fCBknFhrjCmriqF5ujVkzfSklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwcugUd3+/meT6ykfz7AXwL/0QCGWLF5RdBTUPR+qRwrOpbBDHvCcAcuaAQ5T0UvPQJ98b6KVWbTjeZjJUlbbhAg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "F53F62E38593252D1207DC422B26B55851C1C2F75DC916A40DFD50E2003D2300",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:AFG/R9fFlNiQ0LFcLGgVnKkUETe3rV5Ah2z7N2s+9Do="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:5fhE6CqYI5J3zrPrRwPfCF1UgT9dr4EWxzqjnFmB6bs="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156486983,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAt5njwroDvpIhVyK3jKXzy4GJ0HSJORyq8uMasexFiuC5YcRuOrib0UoGohg9wOaAhIMeLtBb4Q4EiNr2dG0x9jWvJEx9GHSqvL4hCSFdRtmYxCsIndUNtKWMJKNlLSQRl/3K8MYWkbjeh2bRIqPuSb7GKS1n1w9jdDS6TYK/WEQEO6CE/VGa8hN8ClL/8AGknypx9E2gIzGRy9R7KCzcU3l9EkLKQZqAwSDMyUV3cXSUM6SFw5PjCyRYW2rK9+9hESa+ewNMye53pgFprJE78cBYWFqzWXzEhY6f68VuSniKRtYns4GMWTCi3FeIGpXYVY1wAzdcjZcxiSZdC1A41g+u384cHCclfGSyCR4BJOseAFRp8Qh3+nu79f2rFLk20ErLyPny8kEmHUe0OT1DMxpVYG1Cz0nqQNzylGB0oWDhDpxJs43JEnj0wIkOuzRW+KQmIS8ILTlPPE00ILpWMrQCRNcmd6Rpc59X49965oE1vkU9OEwlJmQWCP83cNPLA8E6Vmk5n9e0bTyYyGCy2/mNKl8xQVQSwqe2dmAVvZln2Us0ou13LS28JrxIyF1XQJ1A87Zb6kQooWQDJdiTtf2lgbu4BO+c73YFNqY9EgNZyyqxq36wOUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwf0ycoPQZlW5n/lXlnQLW4AHZjtRYzoee2X+59zPy/x9r/W+Ud0TiHkgJUBFrbb+Z/Zb3657cyLRCfxb+znIlAw=="
+        }
+      ]
+    }
+  ],
+  "Accounts createTransaction should create transaction with a list of multiple note hashes to spend": [
+    {
+      "version": 2,
+      "id": "4a7cbe11-6d4a-4863-8c3b-28be2412f3fc",
+      "name": "a",
+      "spendingKey": "441485b8665ad6f6dc40598549d2919d8086cad94874f5098059a9bdafb0526a",
+      "viewKey": "c2ee3dde1e6a16fae1d925b33b9e40a5a3e61257df4536a7f9563fab7170e431e6275b2cc94904d993dea9ca45f4dfa0ef0328d02466717c043cf20d85a664b2",
+      "incomingViewKey": "fa6f5dcf1f8640cf39f9362b2bc8518e6599faed79ae0c5859437d597ea3b605",
+      "outgoingViewKey": "b8feb6c58ddfc9de2139e4c9d50e0113ceb2d7d97429d81d25769ab60f7ffd00",
+      "publicAddress": "bbd77538eae89f570e3c85ca306a153197f07b968654499b9457d242e927748b",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:EheZarJr/4sKcms2tyEmwRMoz/RZPnNLxuKoqI3xyFM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:QtBDJ6D1bYpD0N9OKd34nwtsoxQ+SHqfwvvrB3Gs8LI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156487696,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAEewGq9NmrpShg1fkOVFyxzhaNtD3TN+4XSOt9ukyt2GHhYBgpCVMogW1ApgU7dXufuYgJ4DjLCzSPS8VmG1L2j2uctUR+LyNcRGxwOp1u8OKveTsjuffFa68wBiCw5hLqS6qT2UTTyaQ2ffzsnsKs1H6QMId5hxMKKukP8Vy19QDOGse4GkE/bzPTJhcTxtE+4Cp1ihzzjkP10BaF0bMb3X9XyunbYhO0vF/2TuuZi+RzfWrefe4XuJsFopp4wCKntvUcD2sp1lE/VNAZMtVfxsaDGcQQO8ZEfhzqEbTTqbTsbjyjIlCfBtwJ3zWkQCORo2VoVnyG3/9nePnq7Hmxir8Gs8bVmvJsiKvnJFJPGQ7PUrcJPsmtY0XfVsp4vAqRJc+NSnumCZO2/thodHhoq9CXtuvstjiN0/NI9S6bBPa90fsce/2CnmkSwTi9kq+KH2rBQR4GBOY3uGTVbyTqkqJ1NdZeZHaEZvqWlAj4E8OY646r5QeGcw1w6lVu569M2TIzJ3oOuCf8tNJrJyDAtL1SwZOMA/gHIxeqWRPa++JxA/3xYy1TxkkWEqB4wXHdqUo5VFzuL2MdYWtb8gBQl43XNDGxxOBoDgcilu7VREXMJJt0y9oG0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/H6fphHuA6N6dFWJzWt8K0Knk/cuqeJ1jYEaK00BzAV8ivbV1PUHRk82zOhOEL0gGujym94UAftZxewx63tMAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "8903EF442C39BDB64EBBB5980CEEEA470C00C081963B5D3E955866944D98D33E",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:lFDS1QJiurlokH4mv8jnrE1jB2TE7iB9CaTO9cV1U0w="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZS4iXxhxIgBLEQysUN6C1l727oTgklXitWnyrieAvJA="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156488219,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAEE9KVmjQTybu0pNFuhTSeBr8i4Oksez+l9i5uNI7ohuEk2RwGZv88ODly5AgUoQzv21TfeXcU1svFLksVE6jVlOU7yJTA/xc1m1xiPeg3CmKdJX6BDUkX0JobkAJAL3nVKbTI40DRROsGyvtwtzS2MCtc3+EpzkB8UgrBZIyYWQTBql/zepl4Gag6kkTEIpoVLjjnhTRSAvpZ9brKL0yvaJFjEpRjN0schjN4BbyNluCw8jDYmCb5u8EhBNrf6f7mOnuBP2up+0KnAnZTuxL+8OaCzNR4CTWgPiBNwXXTt/bcpjHHz6SLQeRS3OxvYEzECXGNLMObrljtA4i3/yFtXtBWYMoTbA/wo8JaVqnqxrmF6bfb/KaNkXXdHoX+ugckTaab8wLczhuImcP5xyiBWvQ/M+zp0uQj7bq4Ex8lIiPZWXn39FLfX0iqxCpH4vJ9Yvlh/Fj+NCy3ZFqJqejQYBYVgGBiG1vVwW482g4Zwh6mD7Yow0KKBP7mNPnpwtfAaiQyZEr8dUsrdo+NquKGIJMqsF+77yLh0XCQf41ly8L8to+ybuAvM9/TGGc2MafPRkGNsQoPDe1KYM9zpOng+cUsHMfoPBqKN8GjbWT8xmH9BBNafFym0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSz/iYJgq8yId68pjdTS5JGj5kyGmxTsaZdkYBLnO5qfnjgVJsg7VfGF/NtPBncp64CCkuNN8eGxj/6E6K9rIBA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "CC0FAA147EB45E8BB10B4E8E07A85DDED07E4CA063BD2EA0BB073522B4179615",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:s4ScuZkfKCDhnfH3QhwFHFrXn84w3Db5PXCwwenG3y0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:rPHM6nNqRI8Kk5eekYhnOv5tKY7u66PWEu1rvFTB1AY="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156488726,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA0fMKeSCPz4fSLf9GHspe0DTUX6L2RYpuZOdPKss3v8WkeA1qh5M12PhZMQ3lCCsm/o/kFmQ2izL8OknsuWSrLDBIvJ8J8vfV/C3SnoJ/llaIElxk7nXjpEIgJMs92poHkJKnjUk5vFPvV6E01XupuRbepZUP6A+jWPZhCZHKOlUFmiv+wQevC7eIk2x3Wm+p1C5Rol8mCtq5+NeP91fz7iCRVux38/TmaCWUEmBUuYWugK7OxmewGJk1S1+Om7JzhAJZAfJanlBY2NWCJcRmvU+NNQ26kCx5ktVRd8DuxlLCJVEm0gSrn12Ba6X4AAcNYccK4o/xzVBCUlkTaRy9lKNNrVXuEPqC4kT82Y5McqDgHPxrrT/lSn5WpdYvFENnRSJ4NS1QGfCwnmRC/qD+8ghNd+gxjEF0uKzxrd3eUJzZPLjkOGBtWKG/FPZfgKrGnZR2AORatbWRMRC7PKAAR5axXJaLspr0tV6d9OSHyuh9q/RnAtrFQgVy37pppmrHvPFTqJAekEV+2zI2Yxhen0DRIPl0icIMyv77A6mYX3Xq330CY6Qo1smdpytX0a6AYN51KfMBel95ON3XVrGttuzeF1M6jFFK6IdTMJzR6xGDfTmk7yy1fklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw0yQkiopDFaakCrdnXOLSDSr7oAIC7vBwgzZdYpVQQuQpdpBpBU9yhCL9Og+u63co8cJlooTK71WzWyQ/Z/PxAQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts createTransaction should partially fund a transaction if the note hashes to spend have insufficient funds": [
+    {
+      "version": 2,
+      "id": "3598d4c4-26eb-48b0-97ed-23f6543aec74",
+      "name": "a",
+      "spendingKey": "60b66755d4996fc0486706e31f3ecfb0565affd5da6486926fa6d955ad31aa56",
+      "viewKey": "1356d6ef0630fec8a633c4e15e19ecbc13ecf14be18db3e1ab67ab4397a8fec91a03b55ed09b12eab40c37c114d721f118bc91c6b34ab2db47b6b2dd697a6edc",
+      "incomingViewKey": "14bacf06e9289f159a4f51282ed67a4b0bf8ba1af32a4cdf0985ebf08b33ab00",
+      "outgoingViewKey": "f1ed681eda06944a06b477974056bf2aef9ce7eecbbc8ed1a5e76fd6878e90fa",
+      "publicAddress": "fbc83ba2f07e6816ac603aaa3a727b640595847b29c6b18e4e87b4b4c970b8c7",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ESrdzRN4XrY2lopKPqx7Cer2Gse/Hh/RlHLQWqFmxVI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:I45SITZ1HpPEcrftVI8N0DL75hlvj6u33e2CU27JbsU="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156489400,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAW+mdVSmkn8MmlKVRHuYSGqmEM0Mx8blDPqd4jnAgtD+EmtoOccIyLw/KFCQ1fXetSbqzExSgU3FtuQelBMdNMVKIEXzmHiJyleGjcXY1V3aZtY0VuQC+W6n117VYPp2zW55dl+A1xO7O35pAJqpQbnOomnU9QEz3fiPZhw9oAJoCJWNnYuZJl4aLmTOByUy4KE1YbRXM1LHSqRVDRvyCla1LYV6mAiz8SpwH0BZqNXe19qVabozBOaXsHk58zQ0Quju4egmklDl8+a8eFfqKcSozC3BshNInSoTyr9ldf7D8JrJpBCXmVljjjkCk8rItiJCj9Y/tBV9iypv+OdGphDtc6PzAUVvIoK6kKvPvE9gs44vNPUdkURNEaB0uMUIFaH88MB6T8HQDAHdlT9d5sp/LCGQ47Q3m7sNqCvmKPgPIedwsuTZbxUeUs6sdR4jJog4kBM+0YhpRIzr9YowX069KkmAa45wg5h3mauWe3dFKFD3X1aqbtBQQOBO78JmemGcrucqCnEriEy+6Vv+wDIPEOAm0Yk1AhiVTW2YVABcNYZunUX2BWZNUqZSvg6Z6rMhRM78XCsKm9IR5qXqKmsD5Hxo+wyBve/GMNUb/OZ0z1v7r8gmxkElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCFXwwISZkzvgGPGVvtaufOdOMCxDw8GzbPstnoMAyWbqaEmNPDFkf4Ks/JfDgYY2VkwKtx5CDDCZRw+Hu54ODQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "76A0A89ACB87A67A7C1856598D981AD56D5803BCF5CF32AB47E8F340C73DE169",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:kh3clMG3BLZY6ZldFpYdC7uIj9sFD1Dbi26lBXJKuW0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:VzQbAIsMHu8dAQWa8jPjU1zrRsmqz1G6M0C9Ivtce9s="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156489927,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAIv0wXChvQsrzMhZbn4vkYMDFH7oq57a/WaYD1EcZbpuCAXHJUmcUscHLoy1F9cxTenwNpMaaeEnRaR6KdRdlm3KJGgqt2KHlMwJmx263lEiWdF2id+3lVHqlkImdZvPdV1apMMcWPfyrS0xToFJnyS6Lc0T9tUmJE5j1bTcW8NEQcdmvgtED9feaLJiD28w3BHu6COWwgJkWDm1MxuYNreniGVNeGAtZxHOa0PSCgTqUdQaKydi37oXU2Tzib7IYqMPu/CJ6XznxLkHogk4fIuQ/wcnhr9gtWnjXJGSP4zFTfWVoQNriX+HEg+pGDwAI0AG9jwMgcezW+pDt1CFXLC88mYUMIHf/XV/chU7lEY5aI9fZRfkFjwmd7khMMG1p9XIlxnrCFk4Ey5VaoxFtE9gwib6or9bfnHMwCD5EJNcKSUnWSkP1ECk7OvLp8bN1MYYLqm7qiU2U2otsW1OpQDWXGT3mx0brFJfEcU1CEog0lwAdPSs2fmPbrDC46z+SpOterLadyH/v6b9cNdAFel/rtDN7bPuiQyRwdDeh1YHqpgWAL1E0n34yaeptKj73FOw9tkB+FVo7PLd5v/bSMGapVpbRWLWeqX0wepTpHJevYD6aqciSXUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYrcUM/xuWq8GjmSzjD4XM5tmx4FAhZBrwOQ/jP7szSFgm9E/4UtgkBe9vOvh5LBeyDns3d90iiVzcNRco45WBg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "5539806658F72BE0B1511266A4F1DC0E2B122222369AFC834CC238556CEB6E9F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:OG6ZjIdk2UIPel02tArspu1oDUkeTPt65O4ihYbGBV0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:tioJ1UjREJWVnkhOlmHl7coMeGvCA1Xn/qXlGOyER28="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156490431,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAqxi/ETZceBlddeoG6RdiUOhbEGHZUlMHq1+6/ffMsKGlDDEfUHB4Xj3YGRnUBFnlHkkKz0HG7mJX36J9HizphXeRt2gcMIlNVCwPgcl7H/2jwMNDQXVn77LZSckplCJrdQLF97X58gZlY4+Es1MzYA3lUzVPqYgbMJvPeNj8KL0GzfqXod6GlYa0Dj1hy2GH5UJnKIqPtD3yVcnoJb833q42PVrQ2HK2iADkp1CPjFSBFza/d3eskKyaBNLYzbyICcnDcRcqmheWcJfg4rOWjT1HsQMwVMk6o6vToKbdH+1uAvyatcDWnaBJk/cKvkvbAUugnvqZn50sQFQCgQcYxHbWBeCwPPBcIo2hFhT5vQhF476teJPZ4RPKvDWHVGJLWkxcnY2oboZMPouxzjXXGQJozLBSO24E64A5hD890G55Y5DHm01kvM0R0Nzq7/+rMUYnmRdL9JsvYfXg3Iqv59LNHcXzrh4p5oYbtvVXDp0VKWzMVRmdSK0UZOxehZ8XjcCfBN2yxmbuGrSGP+LNNoWEkT8k0cZP/ZjgnyKMAe68ezHOKJmwDfAeVo2gwjVnDwORXQtGsLMuwtVH7vt/r+64BAfiCJikYf5vv+W7lTz4Yo5aetI7WElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZPRIgh6f1znrb3Tom3bhKRALthhQpEtQFd2IiehGuNAgkc6wDspNR/GnEZ+9Blb7VWdPXactwzq/HZi5A+veBg=="
+        }
+      ]
+    }
+  ],
+  "Accounts createTransaction should create transactions with spends valid after a reorg": [
+    {
+      "version": 2,
+      "id": "f6fdbc73-be4d-45ba-b7c5-9096df819bbc",
+      "name": "a",
+      "spendingKey": "f27061500252940a27dda3eb04c38d755b42471caaa6231cb07192cb0ef37111",
+      "viewKey": "494a90d5d3dc58c1ce84f894caf4adec3cf8583290859ef61c9db65311ff0b135281cc6172e38804f613ac77d6994829687e06e72236c740eed01e3f4031c69d",
+      "incomingViewKey": "e422446a02cad1f0a128ba5538ff99b8e92d53085f170a06a5dddce7338d0b06",
+      "outgoingViewKey": "5d08658ffeb03853d9118e7141df3b59fe280460df4de71abecde06e9d9527ce",
+      "publicAddress": "5a65442b66dfa649d1c2667d26acde050d40d989af8603ab72abda92d749008f",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "8818caf9-18aa-4ba4-9c1b-7585b3e9016d",
+      "name": "b",
+      "spendingKey": "1e50becc8a99e4a8006f79b1412f169304c94141bbfb175e9be7a1fd7f98dbd1",
+      "viewKey": "987f6575e8a19691ca8acb36351491962aa20635c7c414c6c1ef4e8b8ecd7aed366ac8d7752b3630756292b06f4722064040e654b2d23e0f5017a421503b210d",
+      "incomingViewKey": "ececd0c7bb5eb16d0a1be2004f493583c29daaae37fdc3e41ad4c41636f3f502",
+      "outgoingViewKey": "adc9aa50c40b3ab7fc33add56e795ef7ee851c15a9d8d3915e1db6c44811b12d",
+      "publicAddress": "427d3d08af6a39a8d54a018532fb61366be8e1c848b248560f794e384e78131c",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:jkkcf/s/PJmogpvBzVCWdUDlD5M8V1zgdR/42Oj0+yc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:lPnHtMbZTs+XMXhe8dKY8LHG8f7X5hxxY50Jk2tsdWk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156491391,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA2yPN/ibB14XcxNlYkDxVBWw8wAJtwFaSkEzISaVedmGJxY64+TN0mVoxppgozhZnbjl4SwUDHIvkgceoaiiqn9+s89Azj8/JtuSRnX86s8esqKyQJS21hG4MqL57de8CBnJeB9lZA61+Ni/oTOo3wP6k7q9KgXATHYjpzn6vlpkTAxWvbuZaWwZF46PaewRIypcyNNLImB4OpdA3jLVEEEWSgrRB+aK73wBB40l7mGyxS+MTRLodGRvHxBJrD+zAzKaf7EMTSLXwoWxa3d/l8l5PZoDqk36qBH2PCmRZkwHTzslljwxE8uRkgVFXDjv/Ge3zjmz7BUNWO1rFC5BgH0zyJu7Ki4Y7M8o3Wjv4vk0EKwzscYQM/Y2ZIvAjdatudYV8dyS5B7QyOH7vBHVyDFGPsVH5O8fsBMw3cNnux4FCNevJ/lTQ9/jBiF0MK9d87hD8dSKPtxmcXvuRjNKGxhQZBKQJeolr4FMmig/VqglZbAiNVQ/0THtl6U4Kzy15fEaQImb/YYFKENNNf3pekx+4fsaZfjOrIyfJXaaeCWW1pv0LN6D7s4cSESZHGoGFhWFdvNISYw4DJ1W06oSRqUaqxtiVMnkjizQugr7ACof4uNTr6+6ndElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAJuccsiRgoRnjKVFnH95pwTPIBlrCjZLMXeI9nE8fZ6u8NGKMEmk6uDq2QTXKQTtwGO8MSu4tc2v2pnRP18yAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "E4BDEBD5DC9598533533D0F218D8BE8A95A0565F0A87F225D085C7C7E2E1C436",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:NqtYKrl9Sc/IVcK4PbKO8HWonW68lB3DC0/NcFkZLEY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:meWvY9aOD4r+WSSr35vkGLRBwZ7pVGoZRe00tsQDP7w="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156491907,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAbz0tO5M9AFVOi/jIggb1sd9dhdaAHYFNLgPbEc3/x3KukY2owoS95w9SDKhNi2v0T+jquL7Yungu1j8UwVo2oQLl6sKWvvZJdhOpUAzUPQWSiD2z8fglaVcoK8thrv04YcjCmapVebXOIPeWCPI4uQKsyNYUGFZdoqlKZZMS9PMEVGSEJlMvF69FcoZoZ7LMWTiNTxMPqxz7W2JWnhOAJCl2nBHuMY7vJjOaEG/lxSyC0XlKBbWfXNl1tNomNj3L/Tzx94IouwFv2oPMxixUw1Sb0OJTzxQOmYQvkJC95GTfssxGaQJBYaT+7Hziom4Ps05iv6U7jbVUd+du2VLBX6PjVWBm98k+duPUwsV4lv80R69rWVHlkWU3ACOw3OMTbkLD8D2BzM850cM0TXyA8kRFUfrD+oI9i65wKXcB/GPU1Jc7knMVfOja5eVyoUivy77TJuJoJdZHtnYOpT4OgSD0BaJNQTGK+/+XjUGZ4cP4qCSi0e17TixoiqyLqCWvWlzl44VPnEj6MerD4sumffQBugmWWcIQt8O0TTwaSYxZOl53XiU/uIQkIqtOu9wZMSz5ExUVEcYGrc1YiwVlXs6dBF4Y0vKe/s+g4Cks6LQ0pfhzZ8l2I0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw/cM9EqT2E5UriFA0Z9HjCv27a922/ce4VBnqpFsHr0UFCnZ47fD8QOqe9474M8qTtgCd+sBWibRXxm8wAz+KDA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMwIBAwpnduyu097k05GnVUbmZafYAonlediJNtuu3VWmuw9P7qbsTxPwtftwJIxhw6t2Hj7jPyt57T0S5f0fi2M/qfU3GEYE4wee2vOz7bWukNlBOHnQAQdWRxyGnlRLb4jJHR2vJg2OGpjCvnRfXWcSkmEuxDQ4xkk9NiuX5/cZDwOy/IAuwbqTr5oQXhkqN3D5h/aAFTo5L4HVCThBmLmNMkyblYwnYorVp82M0TeAMr8hVfZkvxeT4hIacBmHyNf5oCIm+ABeQZ/hRzY22fvUEr5dx0HCkKxifEP27bCfTs4iU/3T7p8cbreSfeknWMI1Cc21wFYqxB24v7lNMY5JHH/7PzyZqIKbwc1QlnVA5Q+TPFdc4HUf+Njo9PsnBAAAAI7YlF4P1Pty0xluepbvTifx1WvkFtZQ09FmLN/f0iWh0Wl6hAq4fDkv6dkkxBE6lKHq4bL3FuC7efhH6OBEEgTr8iXf0ZSbc42JCpcfz1DDjJiv83D8Nsu696vzj7cTB5P1SohLAAL6ygeB7+hrLWbWzjFLmyho+Ap/GeY9UQZs5Fo1T4/utIl9+CHjViE6LpJZgtWmUP7tpBOQB2xElZO93Hk12aL7uuJ2oOYBov9y1QMkah9twQx+eRjw8zkIUwfE60N6n/dD6cWaTwEUr3Xz2MkqTr0RBoRL4/snKiJ7MFsFVCbe4wHUV4CzH0Whqq5WbNiAnq0shb4dI/ebAnoAzQ8eSFd38l7EGwJhrCwVhE8T/kGEARSmXWHv7MSYKtoVrO8hLeKuUuKf9eCF0+Vb1oVqnJpQQXN8jcfznuiLzhtbU1kwAKpYifj9Ezg64wsadZUotkMtsN//MVVNA1XJgl6p8mwC2Pr9ufjuZ8Z/Q9/PSso7nOyqTrs06FGrn7HkYeORixiEqLEYqsLIAMBfvwblbbUEkRH2l0Z9bTY1V5BlIHq+m4krZX8I1/QfWji1rfqcAenov05r9Tyl7CeqExnIuBt/sqyLPLpfwuLvENjmoVcjF8S6Ulkc+xCyUFlIKzGCGIeGrezb7AhecVG9AxjzyNIEWEqf7ZyA4uWRCbCPc5RxRCtdjAhMoc3mz2Z2JnT2Ki7xrQGfSHH5XCqYeX76qLBhxU0YUC+l7S9dwY1Za/C/Gvsz7YtAigp1dfjbiZ0rJKLCvRu/XKRaXpjhSX9jdXDfA9pMjd6RqelSQHDIukeiHGKvRAbTsrhDQzvlgrqRUU2lLVy9fYVNZ9RpCRCdqz4iOv8ydaKfkFcmSL7NC7kqi66Sblq3SX7CYPd7J7nE5AHfUsuheVH9x3Drkeq9hKYsZtMr7K6FlQYlJJGldh1xpMQUQt/aqqW6K2hWD6SXWSvtOny+sdbmnML2jSCuSsmaAxwwaQgo1pj9xtH+66z2YI+XiVQsIvVhf81ZgeKE4NRsVua+1dxJi1xY1410cZsDEpf2HEH1Kufk/qsvWkOV93zJfii+8JgIh65tBTUQ8fIAJK6epQcLvfvLLus3yl9fkJSPCEPF050cZtTzIqjvGjhVUWuLB7hPJ9fKNxBomHYNlQbvroLKcOgxm0uHpv3kr/AD6MQ8FULrCCxxa5cBLs7/EycwWrzkvqUSmxVYdxf1qYbA5cI3PzWZgHvsPdILJTLzYp6CNOOroEgmRsSqkph8NMzifHigwP71uLx84aEjSQPDWBxHoKWqEVriOnqhv3yO6jaygO8/m/b7KKZFAzc3ijAgyYrcHy+ujG1gWzjqhYc1+tlWzzGjbC2hX9aslrg8a1ID3lzYnkRQF3ZZcpO8782uTGwkSWxws2w8c/FR/1cBJbpX/IXBzoASYcgD1oRmI5n0p5ivkQ0QU8O6qABe3cMWASYGq2HqYvbMP1hgXremXUPn2uUYProDd2gvAlHVnD402zDsoqE4YbAHPJA0Y2HQVK3LjYqFJitZWT6YxS1XKQkvgZw8JxV7iP1v97J7dFjgw1z9lz6rtqYvAyZFBs2YCwq2BQ=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "E4BDEBD5DC9598533533D0F218D8BE8A95A0565F0A87F225D085C7C7E2E1C436",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:/YS0X9yjPbrGmrpoyaSpHQQx4xZn2btxA53i2MrXyAY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:N69aq2xdBcz2QEC+jOT3+KDpybnyUP/ZZjhYGywjNiY="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156494471,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAW89fQ+l8gVG40YwWFoqxk7UVk3JfW2+Q1zeuec6VxRuxbEA1ony3dhFZa8z5kjHPQaGgB62byMyZ9y+XDqeR6cB3xAIYpptY5e7xCEEGTRenP+UuBmHgp+jCMBXJ7aR4TpkvphMEit1ZE+IzT853y2RI9X6V8rPltD6vJO+XcpwSNR7uaa1fsX0nx5Poab6pp4KREZ6SM2H9/Fy5ruzP1jlufssfXQTArWFiN/KFaB6RaBWweg6t7JvuX/iEA3n5ubPfzDNUT8e5Pxdmm2C9bbr3Fy7UdcU9p8CB9jGLPNU9Az7KZbuFApNvyuaijBFsk6U8SfOThTz5hFhh10DGnRvjyxQCKnfZLlG6rhfz/656nxytC0jcD+vf14VAdr8YlAGnXfkNkoHIuQZ2RfXElgRZY9He2VO1nQtRGueFJmSVtmzUZgobjY8okRegEKyQB2F8Cy5EN5WezrEMFm25nATg4BSMXR3GWFLN31wh9qwT+/JLv6u+yQS4XjmNNbffkvTUech7NKOz3voIUD7NmbNCLkmsGF/RgGwIbTJXHeCj59r/lT9rcmGFMFDNaEKHanJ2s7pjH+FYUanssQBMunISwMn9mUxNIWN2nqLPMLlizuztPUooEklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwN92NNSoA3D4ZL4sCMqvn76tFjxk52vymbNDa6lWwQnNstM8d4iDDH4qIi5vU2NkeGwrC8/CTasoWNqUy1Uv6AQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "F391CC9646E2C8731D6AA608A3C85D2900A3DC4E2A15A76EC264DF717F1A607B",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:HpUYmfAMOuCuxo0yfumm8r06loBG4LD1piSIoGlBBzQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:K3Fxd7CKhulfmWnHR0sbrqnu2LH0LKFlbQXZTK2ZUs4="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156494994,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAM6Hv2ZsnOIkLmHGW+Ytwl8F8fC8nHl8VTZFCUktkLvKRnW7a9NBoUZVA+hzj9nCtgoQI17Fix9NYFmWMZf0KHPnraYR2susFREGVxhcSLLeJwLvkohCdhX59v5y29o/zbobwhKBFLnSKPzeMo+hsEhoBAekwFGuDXw//0Xd0ptkMoNwKXlC3wdyTjixfvHIdBePCVIMEmEbBMhDXveomBL4o/CBkaYhEShXyWBUHcXSWuMLnJADYi6g2X6jHkKNDe0w8cHl39HIcWm5yf3gQA2DJ60E0oAgrGtDDLlPr/WeSXKUVFESwwS4lyy+rCjBYxrqKt/sFARkYnBvOIopfu5q+9hC/i7XD84QRiXy6LSQzHnNq5LXwzNRNKRQpvYAefxlZmjXOwemKP1JVCRMdsmNyTESJ26wjezFZzoYEhZIsqoPkJAD2dd1DKBi4QlDjFDM1O7Sx+LBo0wzisb2/YO6la8qXq2QpaVVwhTt4rmtTESARc4SYAGplIwzS8S60mKu/gJCar09y0cN0ba80ZRlsf9zRIoaQBY65/0PoyKwXdy7hD12Hs810B1tKav8tjH/rqEQlLzq9O3xpTViWdNovLoSQzOOQnP48OM1qnYFigIg52CZW2Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQse/GHtWjwqgtSOzmYQ1P23PxTWcaZKcK74y+84gLSUYg3WhF9R1kDAfPOo0H0D3gKEWxkqZRgf1G208j5A8Bw=="
+        }
+      ]
+    }
+  ],
+  "Accounts getTransactionStatus should show unconfirmed transactions as unconfirmed": [
+    {
+      "version": 2,
+      "id": "ab20e12f-893c-4689-afa4-5403e107a2fe",
+      "name": "a",
+      "spendingKey": "f2ab79d15a2a91e3d75818bb02165f9756d37e0e8341b859a529e585497073b8",
+      "viewKey": "5104bf572af18d8bbedc8f66e84e7e4d25d4c74bdac90695c9315ba190e582e95fb5bb5dd0bc3aedd09757e2b695aa516e17afd2365d112032a241cdf3641f26",
+      "incomingViewKey": "d80e3a89ad8df18567e7dffeb45799b40cbf37d1169e83990542f2f4825ebd04",
+      "outgoingViewKey": "60fe35546b77008dbfc437e58a46890457c14912990b5e3f98cc2d2960300f81",
+      "publicAddress": "c11d066d2a5605addecffbfa691226ba052e6209637b919690acfd242b943b1e",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:xeRurx52pEVPftRJGQ5qCaT0fhogHVmMQh8oYi6HHlc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:fTDNatJ0V/qEbHjFmczZDoIdqL64ynr4RYPSktCfBWs="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156495715,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAJO60uMihfspS8tMStcsMHuNLAFW4lhbg+wPM9+OPRjqZ9ZuFQtRGa7JOZpWYkEn+QIWrOJVGsf8xTfftqdCUdkxF4jGs9mCDDVmK3Cb6hxamPzdh2a635UkBm3EKVJqCHQPE6hLSrWUd+pY4i0hp+2o2NTDtKD75j9YEChiZs0gM5i6gbCjOwE2t0LpEiHrisdXencXcT0lVbfkQ5608+9eOAafS2wCwuqId9Uqh66ypkef3cBk7IoMDVcKsU2mvod0+ovPR0mcvMuDE6o47jEFYzIYfgCUTp9DiDKYamC0vFebcg7dV56ttEcZcBj8jy5S9zc0PTFDgHnJ6jtelAu1RCuEmkCA0Iwx5LiP+pm2Vra/jud4v1J4SvZ8xe7IAB92uGXGC5f5KBDPUikuBHTFoakkINx1unaXnCpnMQotzvSQyUQicr0f2yRicvcEyxkl625tvng+JzqF+w5Fz8OZ0LermFTv//BZy3rLug29W/uqQnqUoLulrkT882NyMCAmy1ircE4AqD4EWaoObgYfzQFSQruQw3ljA0ksP4fP54cA2JCQi0A9tkSYUkCoQ3Axb7OfKOeu/vzKWahgzw1WkkkjvYS2WTHPhSzyQMRWiXrZE7KQvLklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNutOqp0m2laHWR0MNInGUI1/84Kitshg3aR/GeTSVFbD4MeO840ObPzZrPIAJlqawmwA61UCf7SWTOvLLyNnAQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts getTransactionStatus should show confirmed transactions as confirmed": [
+    {
+      "version": 2,
+      "id": "9e834f55-39f3-4547-949e-7bd01d551c7d",
+      "name": "a",
+      "spendingKey": "005a5f08c0aab0cb0d8cb200ea87e132ea06b847c7c3bcdd92c91a46c033fafc",
+      "viewKey": "f74928b20cfbf05907446bc6516e70ec29ca9fdc3785a7780b20ac63c913bdc18b8712f5dbe60fcf5c76feaffe9e0ea1eaa0d428831a714b2761b3ed5c167de8",
+      "incomingViewKey": "a5175e44796ac922c496df44c1c8b80f4ecb88b6f6c65395e1a074e93d2a8506",
+      "outgoingViewKey": "b03d17148101c660b8835a270f9b59c8e95eb8920912b50f121f08553cfe2b39",
+      "publicAddress": "19caf836745cc56fdfbd50c6ce65031ab244967f0a4ee19af052397a4c2afdcc",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:1tfDOBZu8rf3+o5S5mLlTUSHTg9TXUJR4PmcN2IvfhY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:qKwvIAtdzQmM1IxXXqfkr3dzp6RDUNQdoTFSXzZTlWY="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156496416,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAR6Pc3wwM7rUJon2cvVEJK1VH8/GqC5jAbKfDwdJGlUuQgu+hNjr4UILg/koMkX1bEXpH1w2fdt7mbqZoASJNsId3z47RyNnTDtTd/g2f0v2NH17kw3vTxEjkG79qdx/mM9yQElpiw3liai/ik+GK1klvX3soG5ZBP+jhicxxibEUasdmA7CMbFvk7UzBhXZXicsZFYyGb74BWX6B8HyYkipM8lO4baF36IbFC3hEDO6KMHvOHpqLSeW9zax2ApuP7zHHNnlYiGq88moVVn5/x8SYT+hfLDPJXdj4dZ/ly5JE0uHA+DPQ/0rUbYoLMBq7Gn4XUVgtBvXBslYd+AV/PYELAN0a44zYXF8tzoWs4z32unAh/v7l8WX/ilMXYhhpycwVsOVD17Wc8SMFF9qJWGQM0V9+Iyg25nXYixpPUJO0z4pt/zqZCwjkU7awPTEfbrPc9Gos0AW0VKwvEQY/ed5+hP8A1mvtOqD40yHGgToJvWuqUEn30SrTSRcXEEohDjBbccQT9939YCfZGHtpGQ25QuszXDp2nvC6SNkIxfyBtdRBc/0Gvt9e8cRLJNlQUt1FR61J9TuAN9kAaJjDgSK9DFs5V8WVgn4YnfoFxjJq9VWavIZCZElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwKB8q4O5RCwMhvlNcfxoH744gyAogrDAsad4JW3M9hYJ9ldNzVwH2qLn4ZYiur2Siw3t50Q5B7nkG87XtsA42AQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts getTransactionStatus should show pending transactions as pending": [
+    {
+      "version": 2,
+      "id": "a8d65471-50fd-4e3c-928c-9fe9e9f0ecf7",
+      "name": "a",
+      "spendingKey": "06fb598b4a1ed9ed998a5eb68dbb3f1c788748d137d34446963c716c3d7522d1",
+      "viewKey": "50e5c8b9d89bf0593ea4d1ba4dfbdbe676fdfaf4ab1d331288a4082813ec8b5afdedc3e2ae805f3468fb47e1b90b44b2f10e2d9014ae2ef34b54e68a9bcfcf68",
+      "incomingViewKey": "2039b8bfbe4b027d78c9891d239fba9f30f520058da64b3d82dcaf63debdbd06",
+      "outgoingViewKey": "3a9d3b381ce12155cff833e70237ebd86db6047a833ff5d48501542aef65fbef",
+      "publicAddress": "921befc3efa0127f740aed91ab22a9048fb50f44c742f767404e230ba491f6b4",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "bd13d69c-5dd4-4e1f-a970-51e4bbacff28",
+      "name": "b",
+      "spendingKey": "8584a00f6aae35b960074d2356b1b84bbce59e9da719e45579b9db4358ce202c",
+      "viewKey": "0063342da7c9cded002c289d4e4a04e7cfe214bd78a2bae8ba2a31e46500185642efb014181b7166b595aebe86ae916003fbd56ba3ec0a97c47fdd97ead8b49a",
+      "incomingViewKey": "54ef68275a6b2c8a191955d39e4340c93fa7e8927b2a20bc685943cf3eb5db05",
+      "outgoingViewKey": "c4c03349a8a2b49de751205b7ce991818e4dc1b71f8946070b7234f9b50de830",
+      "publicAddress": "4bada4d18df393880cf42d41f59bbd3118380c996effd9c80f36ce02ca0870c7",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:RE0gLZbSGv/0TbakgYbKDoDmwNTgVbV62OPd1UgTljQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:D8r6nKrP1AwNzUzdd2DYV0VFW+TX83/W3h+fQJHcAEU="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156497149,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAMjRxK6DsgQyOZi/zDk8LHmgUPljYNr7balvbVzIJm8O5lZ1zz5+g3NTLyKPWY17JIIPinulQcNAE6uLLWhrsBiibsfnmuFqjM7sxrM8Wo0eRKJM84k5xjx/pSTWEMID7W39Oe/Cb9y7sFF1APvGbj2nKqQrzw52iPb2Kgnl3WloMz0oXM/fFapvjiN362RYTMBJx1VXrS8WUZmC579de/G3QhLcXX7BQwFaXX1zQHg6W/5ZGfmlKNN5edE+OzZ59LsDf+1jgGCE0zCIn8DQoOQKHSkptZh6ZLTLcPgC8gx9WVz27chVILLJqTj6/eHT4S9rqrN+k4+5Og033uwSNOMIoRR6dMHMNIbDkztBAP/yW7BLi54kB2fp9+1wHO6w9+n5W8iYH52j62P7jhd+gVUCw8sP20/n8BtBot88FrFGyfKWRn2jOHxDR9l0bEVmE533UUX+gvA1BWZIWSkKm6cwNpWNzu7EgGg59J+UVt7ZXBtpcuBW7BWmoHeLr91/RXvEGQ+t2zQQp1PsmzhRJ82HwicKJclfeuJggzbxSgDxRcAePX2jTndhp7p0DFLh8ucweaiBd+ZZPEhedXxKqQW6g9MRMe/UZTeArJlRGDETgnmIQomUkh0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1BNlhQtxmeNUYpM4W0Uxw/HkzrcYwzF1Rpt9gTkVMUFWJNbx3mmNOUltbUJ7Wevbd5OScqdxLONUVn73JrpLCA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3QLjOmYHomSLoD1jkEp00RfruG1ibyANuQtjMhWnaJiwrt5+hhoTcP6hV55fZmccqujPR9XSLuXPp0u/DAkIg90g4Q4UkgX+F9eQ7bkGBHiW2zZVPS2Oj6/RBBngJoytCP0RA3AwPMJCK2e2GuX6Or0rZ/nid5swX/kkD03/T0oLqekDXnk7J5mHtmuBGlOsbOzMFSMVGgpBRQDiTnseY/VJRgU8FeD8GQtoOEs5Mla4D2rcqMlIiEH5C9vzg0G80wbcRXKGfYfXJJqFzJYNDMlZueY0Gg3LB5APezdKQw45Y4lwrE6pxeWqKAhLsuAjL/AOM6j5CQFVuG+36VFZD0RNIC2W0hr/9E22pIGGyg6A5sDU4FW1etjj3dVIE5Y0BAAAAJ4N0fDZmihOkOyesyDLCZ9NTyoxWaN1UJzf91M49i+T5Yu8k1Of8VvlqLsiPmn1GAJE1k2nkY9BUuW2+4g5PZVed3XVaUJuAQit8l30jIf6qPGtLAyqtKoRmL2B78UFCapmdHp0IuGw1E/rQx7p3NWjDdDdtOXCuV9/zoxMiekDsMrRXFqv8jSxPOdCwHDQnZJHWtDFtUqZeg/MhIS5Du/bUSzxu4CuNTy08mhI9fpZ4Dekd/NBcqjHc7jgtVfm9hnX/7ulI69OXrbbhvg4DdiKxjAQVbjO3BRaAVjqfVo8IlXi/whVOmaCoCAEybIeWKCjIqqybtyQ3dIdxF4HSkoa3KL6AcUpwfk+FSMVmVDK1hlvGhPNICaaWFXEiV5uGEePYHUfvgM4prlrGG0RXeKxn0jPPHTFBOSJLmNuNf/bfwBEAVGQ0QtrW52/ciP6/qKB2SUx5rJBfyELzNnSkVNrUpG0U1JR0NFIYBQHXYJjI7ZDicBcu5Eek5UHZQslLSxK8LCKky02xHzXdNXLjqXKIkbgVdxB9lGV9uiMSNf8OEzwKxBTP8+J41PQRqOKBQh6LThZWt9WpTSj94p131MC9H0a0pp7gcRrYMALSyJfWdHyOftc9P79728Sz9+aqV38nVYgA1e3LubO5vi0joGSuA8VjtHK7ASzR3m88gErTrX4eoaNj4SmcboAXQBZXRgz0FpHSga/tCZvJ3fEXDKP7SbmylgywOxwaw8fRNk7G4F2gJylPPfdBdEC5pp2hy1n1X3COIFPMnLKHl2gdB23Fe26iB6cBjFdSeag+j0DzeeVkUV8wHOVP/UlNN8MNYKsXTtJiWZ32EEc069r6kC5yW9oUt/VRLSlDOm+FzMpCOvdq4pcqxqix/bhE+kRzQqOmCHsU+BgiOq4zfNXit32Bz2VQ2RUYoHpH6mADQSgliM3YJTcDHcNejz7G12JfmlUqrbBJi+n67F/wq+uGxTdi2CIifhN8mkbMSkTxcL4sxnnbas9mPaOVbC+fZy5onlYb/1h4tjMM12+l0mKwGAV0Z1fuDoT0cEMD0jtMfa76bQMN8+WxTfVHCkoZzLtXgiukY0Gvfz0D8jZSlrCbDhcRkcG6UfMpWOgx+crNBAkbCSJKDM9HCVSJdehYfsBNd67H2CP12tEea2DTxyM2aGzLmsYlQXJkrK69dfX7bgGH8MM+HWM1KNu2OcPTtQFwbf1eKPy1gRgpuvc/mFQkP6JPyNtgdOWCHWv2Lj8Dtx6S0HPJekT29sFkf7OyEQTr/8fkWUzKTtlU0sxDfP2pvTt7lkFkRlrbuzHMhsb6qpGs0WnuXd4sw+fCyeKCznlPAErIZcUIO50hRtNgasVfnpfBTe1lS00F1y0oZ3twimNRIFhKnibpv8YZF78i0SwWZsiI5iJHTrTZJKMWfNryXgAxTaJEgrtqdwYktj6rBJpD4BYtBy2nzvxawUjksjcfyKM704mzvzlGVPyd+9iJrlloL7UJwSq9HrBwPBz5HTDjLeS8OfHPU+ORkgjFpe5QOBXER07vIFYTPX9ataP+MdMM6c0YdQGKSJW2kbLkk3EVL+rKHmhe7LdyWSGQP0UBg=="
+    }
+  ],
+  "Accounts getTransactionStatus should show expired transactions as expired": [
+    {
+      "version": 2,
+      "id": "2a28f30f-3ef0-4c86-8a64-3431424cca4c",
+      "name": "a",
+      "spendingKey": "3deb8bfecf6c0b375d6d63b264cecd2279ab80e0d8120d03ea3efdc486c18e0b",
+      "viewKey": "32b10b3fa23ab5415f966ca19eb182146d4c82d5d0cad108d7fe898d688dbd92430abbd31fe570bfb567d545a3fa4a7c046f495405b6b56a37a0a14980124d5d",
+      "incomingViewKey": "70f49a751e7267cd110a082cf37a44a2696b9abaccd382947414976d0a2d5d02",
+      "outgoingViewKey": "ad6291efa53412411c658419da3a6abcc90529467cef167e5054ab01e3dd9b88",
+      "publicAddress": "702eff43bfd63b3c205c186284c9f7f65e2efdf9f572b247ddd064b371e17c82",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "8a157a50-5e04-4f48-807c-bf5b416f7564",
+      "name": "b",
+      "spendingKey": "133f97588a001b75c78e38d55f9cac0c7005543c0e6bf7a855e8d1ccdb3532d8",
+      "viewKey": "390bb5ccf2ca8d9ddf942eb815606f4dfcb01db52b1542aa10c2ae1c276f8fef69605828bd29b979915ea529b80eeff9ecd8a128b16ed6a7bd36d7fe5cf26392",
+      "incomingViewKey": "3984304d66f6fb8374b2cfa70e46a6dd1a6c68ca322cd8abfb386120df5a1503",
+      "outgoingViewKey": "9648c33c3bf17f13aaf17c3427f359aebd5cf58a5953b2ea427d2bd4702efbf7",
+      "publicAddress": "b1dfff82c19fd792bb0cebaf3a34e18df461a50db99c3874e7e8d9430a776523",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:PAO/j21XoQynbvpYfiul01TP3MGMEBBdXgy++sAFWjA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:OieiiIkO+f9IJuowD9EHCT4jYdVGlKK2kqXHBPAecmE="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156499824,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAehyeyoTDUPRFC2DB8cxvqG4FMI3oHqCNprEvOpT+R9S457+v9ohnhd/ovY/K1lm3bnpVVTEs0gAIRo32/fILLoDPJzC4Nt26Wq73kdWQZJipVq1xBnSZJNbq+QwsN37Cpodaef+MWGFF5SA7xHaG4vXrKaK0iDH9ihJi6b7lF8EGo5uu0Otu6+eGJ/Dmv9+uIYA64H3Aq8N95AVBc+k9AC8eT5uSAU3PXb9A5uqhvuiCBtyoQFwvOwVDKVYd62ZijIL8GQumbeZ84Av5NOz/ogEcMGYIHF3+6KzdBXlbQw17KX/b0mejbDKI53Jvt47DgJ2I2b4l4GldMZVw38TgRczC6X919VyIbRGoI5sFxhdyf1h4DbEe67R1vhwc9qYb2cT1TnNrqhyGDITdvOwLrXiMScLoCIe94H1Q6rBk0NnJrdi8ZK+YJV9z1sY0Y7kxxsfCNFrR3qjrJZFe0PUjfkX5Na+VD3z7/ZpiUUDJInGeVOdFpxLoFmFvwbVc9rsQZ3YGNHJhJDvQVOPu3H2qxIOOGLMDVSKQ33BtyFAyfs1FX3vtBwoLuIjalqpiACKDulF5SoSSFZrnx0eIEK0vCENF+b7Qjoz/6g506ZVKgV8B0A5yXZ6moklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwU/qSojicYThHup158/7jRUsj8odoYzKCncgMl8zj2FgF665BLwyL5CqWDQuCrN0BQ+JNR0QJUD+WS+nV9d84Bw=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAQsFSs+s9vVuG8MBpjvzkFQMu+iSHADSdsOUhqet/E8OhyvWmoL79XQ2vi8+/hy19Mlh6tzf0TG+kCNCYXIoqSrmcbfgng+Ll8gsEUfkF/zqElX036qwVXtYeDbaqqTu69LE57uN5JRHnI+U7fZGoM+u71ttUEdgSoWVKDjNkAb8KRn256Lwqj6XFPWmpOu0/rMIhpgavfOL3hM8aahpkGpXUHRdXq5YL0LeRVVDYoKqUXVyx6wXTsQsCHuWhZE3dS8EQSfDxH/i9tLCKg3wbb7aGDtV6m0uiTyWZMXNL9w15jEGD4Ns10iZy90S3nrERnnI7m+aU8mlE6JdjzGH9wjwDv49tV6EMp276WH4rpdNUz9zBjBAQXV4MvvrABVowBAAAAF92Hu/MsiLw3yhogcXehPt3XVXgZ9j1Vc+mXMSpmfLGm4onzURVS2QT9iHgBIiInFD1Ww/wmSW0jtGYmRKSdAKaBD8bPeme7Il0wpBaFE1Y4FMLJcDm11RtApETu8uDBLT7jLKHaZ6FIEHFCW2D7MWQWybE+PgVUbRqoX/tD2O4+SBdvGXhqlrt7JxLv4DQkJOydXIRdCVj0OxaMn+jr17m2K3e6utw3QdMP9YqVPTMHb/m1TRCSYCdHeyeUjBEWAcdxXH/boedVbroroNoqz5i4xkLH6y1J2Fh8s1tYbaPbzLFaMHm2DyKG6Y7dSDVzquwRQNkfr6mOcBOG6TRnuKihlr3rPo7TDzPPsDr+yr8prRWZEPHC+AOkicDj7hFoHbPqkC0mvsDA6+rpoGsHCkViCJ60HD1liO4PO0umjRPwtz3aK9Gve+QiXT+k4qaM6lGIKiIu/1lxobDXB01K0jQGhAEzFlfGu0uB/rcZqepUYdxGWfJvE6BCZOYU3IXS8cg33EzK+qDYPmIWKnSMAgLFw6s/ssHqhJbuFjrQOElEtBKs9xK7SGxQCXO9Dpf/IrvHILyOV5u2LO/89jh9Fvml+XZK9u8XO/yNHIzNgW3ciU4/0CkQhm96z3aXa9TrbYmwT8HH2tzCP3T2iOgxW/ELHQXvqIGtGJEXHUwPt/4NJ98Zj0e1ZlagVWOMKvTdraQMa42IahSGIPwNsuLfuUHkN6maBujEaI1ZmIaOeSaHnw2zwoG5/DGpw5UdxZ6DfWh+k1+mZb+Xo0x0Br3lTt4Y5UmYWAx7E1Udr10cJwVhyQMMuDrlvmxmZSc6HpEpwI3P6NA7rh26Xc7Weq/M1hH+a9U+AS3A+nKrdcEm0cH2wTi0HK+VvSQGM2V4bHI8ldKqTEgTaYl92VmKL3fkmuQuzTS0pfPLMNrANhUulC17fLwlKSoiKEA8uBKEETtdxzgwNtdMjLSrPKthPROdSEkE1I8avAbpCGtMf5FrZ5KPNmvWbi2jxKtFWPHqhjLXpL7nHlqu0lZH7wCc60IjglwU7s99XBJbvUY+JqQo8+YJVYW0Bx60ov1qcdO/sEb4qFnpfbdPDGaWijh+zNBn0yVGZNRI4WrH9e3T9fLQHCnaaZZH1kAewYH4Mlxf+FLst5a8JijKu8+cuaNzzsthjOC+wGs2etjj0e3RoEkpyuzHOw+rH8Ecbc/K0Lk7lz9UyxV71a6/+0ulA/gev2gUMN90963e6fjOVyLL2mwzRLBYiNrlpRdlTMHpZOqvIhNRUtul3W3uVVH2r0jzq4A0rzQrZfDpL3DXlvsu8dM92tYgmZgXDA2s/e68P2GkRRUnuJRpFBwnbMpPtg6TW8W7NFLlVbyntOTAQW0DcgC47UJNx92osFFkxyZUHanzGXei3pyBQ1CNOH2xjBlmxFwOJTM5P2cYXSFkDzAp90qNkKcNlj2S+jiFHAQ7Y7PJpD2pReOvKooagHgh9QIPTk5Vgdx8RD3G+jf82vU1Cq8TsmclbiDqhEm0lVHFApJI7i0RLpH9xRO1EzvVe5YcFo6TUUy7G0amwDAmv7k6HI89ZsEK/OyZ4Ed+MVreT4IhFuNAA=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9988567BBBA3704E40C32855DBD30838FDCC11740F4DB99FCA342DBE2656C706",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Q8f+hdefzczKpJKGwR3mwJgUE11jOa38XS7/rQsAoi4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:sQGhvtN2hqRITblZua1izmqRmWcxTCkadNzflBzl4lE="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156502310,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1XUGsvk17OpjCDbf1lP09YF0NKcx7ZpbGmRXvs1GQKyiFq6xl2a7PfacNm2E3gDAarD5EUN84p6koUdFKaFn3eq3timwUPr42jG8OjhfWJSQLzToA3iiDZ1eCToIIYex0zxgHcBw/P6JiHZk8fdMDQH0/BCc3NUNtGAv3mO5o1cCePEpWA7n4RM7rjHaA0mnBp0UJ9+KKSRVGrsJadf/MeOOS8qYf2IT23ZgoIy9zXqQgsbfMacO/dwj/NlCJMH/ykVcbYP42xmfqFgwOJtPuF46uDu2SoRRphODjoe1tj496lyPbXXXe7vZ5/Mc1KXbeuWzsF0fnB7FbXAM90T5GGYvOkL1q1ydzUnZwBpdakIBelK+Lb603YbrIZnRab9NJ0GyInKII/nTXd29NDr0zlKyYoXuDJG7JNMIMV2TxxqGpWreIqXJxZEfmT5qnSQVwUumrV3+MZ3BK2Fecf3EQxiftIxEy8CcNI5YPWncqIRICNzVU7qnDN1TsvTiqgPl9IBpWz9QUKjk1A2ag88O7v4/xlp2chAvD9UAtPR3+f0fvd/EGZHuGk5F3Kj/+98AZ90s6+ApJbWeWTcKus2SpvLmisPWH+RS/lbzOKgeV7+WYA8DnDIkqElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4f4ZX/X+3SWHF6SbJV0p8cJ14uq1UnQhMTtJ+oHAJxj0QAcEQkuMlgi0FVzVI2+B7JSJ3gQQdQpmdexCO2qYDQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts getTransactionStatus should show transactions with 0 expiration as pending": [
+    {
+      "version": 2,
+      "id": "b16f1b28-4a24-47b3-812c-edbf8fa61454",
+      "name": "a",
+      "spendingKey": "b8d51ef30a9fcd949f893bac40406e2b7c2a135158900a036e1bfd739ae3f4ce",
+      "viewKey": "9f9240e4ce5720f5a28d80cef60f95086a5a82554fcfd2455c4f1537215b9a82acd997363aed062438e54ae0d4fef050b026b1d5bae0d859464a09d359195acb",
+      "incomingViewKey": "bec6271df06424cfa787cb51a80b98218ed0c9884286cd6ebef3c82fc3592506",
+      "outgoingViewKey": "e25adc54a2d57428cfe61a1b126c7b5dc4b48526ad025c9c3dc6bd3a86f0f792",
+      "publicAddress": "e0775fe540022cd95bed6304cd55777378628cfc4c758ceeff994034d48bb994",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "a5d7acfa-506e-48fd-a5fe-cf363f98683e",
+      "name": "b",
+      "spendingKey": "bf1e19f9248f8cf575609d23e2a47727df6e69f86cbb0e9f7e5cda3be9b349a2",
+      "viewKey": "cb9e7579ec38f0d2791846b53205db2c88c0e1be176694c1882b47a5839b266dae4c13e503752e10ad1d6f9af47d4945fc3fc0fc0a2aa1d622e68ee5abb19895",
+      "incomingViewKey": "9943fb0543bc2fea5e20898fbe9c018e39bd0a6f996373ce8e52eae84d8cb702",
+      "outgoingViewKey": "0210acf1c23362a73cc31c2d7074785c217960150209a960cadd509f2ffbb3a9",
+      "publicAddress": "349465f53a9d55214bf96889c9657167ac12c99b19b70cd436f126e67abdc938",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:QW6ylZCkQw94fcQtaXH6tKVpQm3xeErvGKQQgbPbKSs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:dBi/zyzF8D5aG3mi0DK91PPkprbNp4Kz7Gtq37GiKgw="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156502971,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA3A5nMXeK3NJmRzY7VH0zEKcT35E8tChUWuXVpSfkETiKZsUf5k0f0a7yt0bFV34s26zmG0459xAzMzRSILfxcuy6cGrNxziLtbeCdqvHH16gkZ8muTkEv+WwVkc+w2EfLrd4dohPq3pdqiwelt6X1rNwiFLOvAXqcqNGrCZDXKMHgzMItiotgo4u2Z+tz2yCxt5BUPMZC68/9XtJHAy5tpQCmdaw2YoEH9mJKYWYbBeAv/FFS5nPBab40YuYaDo3mDoStaTUI172PV9ZmUF/2H9ZDJ1G8Xai1eEVZe0wxdv3nZOC6l+UAM+4nv5wbpBUS1PmsrCAxWXOfQqs57eorN0bAnGPK1fVr92y4I/LUqyO2JmdqHt7HeWw5uUPD2IBX91X9n7tiFdm6Y0u6dUXEU4NJ6s+LwAiKsBba/5XgdSjV1CFj9zqXkfFCKPeEl4gaCeFHIzPOgSFeZLmZ1iqwylgM+Mgx1y06L3zzeW+NepVbaK3w9cNXC+LD7yoZMFcZUEsYLs8Fi5aFEgn1F6LuFEC/UGr6+y4ilrwzuHrknsQE0IGvVgOAZ/nsq3Ozl5lWKh84ZxDtHRAwRTYJ6kwlJ6kZXhSPwU/HpIvAMwjwR3Njqq31i8pqUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjMgoxHTaXGkKSsOsmVW/0I2Ewwkq7AWYV2jBfDEWeoWBMHGP5JRGb2Ru2b4XQgOCvKj9cJENmIiFac6eG39VBA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWYNXeOfQJ9HoxNAfInMEgq1UK7aOameb7j3oF/k1fNeIXKPzNGrMDOOFf6M7fqLTQzrUAE2mK3C/V5K+OkpNZvqwehIDQGYCHNSOY24vFme3wCBXI0e2Pxo58TiAGSDa3shJOFZBZhdysaHW004mPi69brpH96nyXvgJCHgkfhkIfPAgwdlkuQ4sof4LT1tJ6JcjHkiBgR9kA0sHag6N4cZT5TDhdjcMfMrfxF433TCVPbDM1Y7yHdDGSxI6Ik/c141T+bC33nDMUDgUQwlmHVaOOGWIOd6h4ZqWa3CvfPnlWI4Pqp/o2VDwZuklsTn9CnVS/x9BtNHRPjBRmIGNgUFuspWQpEMPeH3ELWlx+rSlaUJt8XhK7xikEIGz2ykrBAAAAAZOoq972TOHz4Pbg40rkkVRrnbMdJkLHMJkjVo3HDhGkft02w2SWglzKANfXBwTOzGmDWRgAL2e0H7LDTDBAiLrQ7eUyL/bkxnrRyIdijvNP9uUwwKuA8ILjmjSrC5CCK2aNJOOuYBSKvx8uqyyJjLS8p+TnSmucKJVb2xipuflS/cLdjSAAsMDQ/fyXBcVwI4EehgnAtOkOrDmHx59DM5Yd3Rivgt7gLMQGxELatgAblUKgREH3adsSQx6laUxDwRWyIYXIAjzwjRTAtBYOGXdv7E/Ar6V2b+VjHVNg2JWqhMZFWOcIYbAfegw+/qD7Jflh5GfQMtadHMB3VQb5Zf8wJRWuq3y7GGIZvVOqC0lpIoHltg20QC4I+rvWk2xMUgzKWUWv8lqv4+8rws6IA8aaX7MTk4bldf1y/koUq/Hh/+Cvh/w+MyTq/Qom9ygnCBoPS9npFFDvpdYmOvX+AXA4Z+hrZF4Zb93rguBHhAdfDf2LN2lap408yN9umGvWvLEcr4vMMtKRKONtr8dfyGDcQ6CZMCqVH39VjwO1dIbCDiMKToLfYWgyF3IV2OfqkOUFQY1l4Z0YTtx8Ul2q1Iuw7Dr7uMI201Ys6KN9UY18x2omcZZ/pmz/8QuqVmLlgXZZ5BXz8KU5yV5idBTNoiJN0nMcBkrNOqSgGlyZ/wRlFxvCxKvyBX9yD7SAsq/iu20Y0rYy4JWm9SBqyk6oWdW6hMpAvjjwy+oDoSCKyb53QuuS6TOwz3twCpNPtVGcVt23qO+OS5VzIfTbz9PH4ogTn51NvSUewLhc9ziWdAZURrXPdcfAIqTWaYnQT+D5/PQ6MHZKqtRMBJQpgNfBxz5SIO/fMWu1VvhM1Jtbqs3r+alLoZlaN2J7gaqryuD+XjC4tNYhSjqIg7sWYDKC98cOSpDi1DegqWaRK4yCFHdXK64rtCIUB8INWMYIdKPWE52UVKg035WkObFPYUkDlFVO8Gzd+QWfPk/2LjvF3Les6akGFPOVRKt0bHhZoI1hBDKrhSUP3yDjLq79FOuLwlLkWuwi8lFEgUJOvTyEFf8AjrfIXhVU2Oxo8KQoWQ06XfwkMa0ivBBdgJ0uBHVck5E5cqKPLLCprHA3y1qeexPfaFDrSJEaFXCfSfYgBdLM0fWk8FBmvROEKoTSEuaUh7iCCkbeQ9jyG3mA9aU+oTZrp01CR17CDDHEEok7U2DaraYiC8wU1u6fHnebWhgQ+/G13gmLT0k7Kp2sWvLyBNX0jGwTa7DNCrWVP0W92oq80QfTTGsJLpswORtIi18xIYTDEjttT9UapuwRgBB2/VVQy3SF3CzCU/L19zBvjB+ZIFaPr7YLsrh7h69Xoi7TjILaBHSQ7D2Ud/l3TJ1kM9frfmjJeogpgDQYwsdGFAalXo4HumwHeh6V2m9tNAhPDPwFJnG9wjdkoFcsw2EKQP3JsKtkG5CMGwbDUFqi+o0UMHxuO/IQUcHogmNAA7fdikpLKiYOYzrgH26HSXIP4c4FxUj2CG9EMPWokgU+57A5odnhEBDqG9L3vYMihinUEC8JjnGOqQGpWHHhrOP0B8nRJfXXO1bCbTpM8GYLhDaBw=="
+    }
+  ],
+  "Accounts getTransactionStatus should show unknown status if account has no head sequence": [
+    {
+      "version": 2,
+      "id": "46183cae-600f-42ef-ae08-6194575cfb5f",
+      "name": "a",
+      "spendingKey": "3133fe07174a857121f3d1705a7ea2c0f524f5918b563606c1a6f56f7e2a3474",
+      "viewKey": "a69baa724a1255bd29ba18ba1a5a4104d2895a301bb6292fe7fb4aeb3a2bf114c8c820a13b86d4224384803044b528aada7e4c0c02eca8a83558200db81c77b3",
+      "incomingViewKey": "a9373a1a6ef57c2a341d09f24de02fcdcdec653dcb85670cb7f810d5e4f28307",
+      "outgoingViewKey": "d9458fd673a80e43c7759166d67766e2c58e9139a7ae861a7a9cf424ae29a1dd",
+      "publicAddress": "44d43e0c8514fe3691f1abbb248c858b315a0a648111530e7fad1cc612a0aed2",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:6aBJE6rECkAyOpnEV0LRplnM9i3wZWOKtQJ4xbCSESY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:OA9trRpqJDeyZ4fMZrbB9v9M4ZKpnoKV8ZyZEqEJ/T4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156505631,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA9Y2AKfjxHZTMiF401tJ80j4R2iHZgNaH/Sjsqj4PC5eF28nHIyYOmbCHvkH/6SyqVt9OzEMy+VjM1KhFXjDJd8UnJSvfioZzf9WyMTbfn9yPQqA/xEi8VmagvtpZoULEPWI18bR52SO6FgsSlF4oYUMLYPLqZAZK1aXqliJ3fisYQ/6ehZq5WdJXhHkMpWJcqYw9wiH2Gv2hhxYUjchLCBYqXAkgrP2IbqPU/MmF+euJsXvgF4gP0jGm2rKB6zhcRULF6r7NiBFdKdXJh6aOAqqBowqKQjM9flk/EHwN9OdjVQdz/zg1BkGl1ZHbVGAYYKTD88nOzYvCJEzr9rOWKhA/ZY6XzjrTAnikQcplcq9h3rYoleQe4DrPvj38TwU2qPF8ubg9J4kKSOajk0P+rJPqlrFhoqXRXPmHZxE0KRw/0QUb3cXcpnsIQVJGDPXtWAZduWEDTXH0y28EFuGdsjtNYRrtN6nkbNss83udxrIgsgRwQv2y9HFcLXjxPrHX3byD3hlTzqgUYtZWcWCchmvfV3pj7nw5paNdOEOfhvqfDBGcypS9vS5vYNBpTHmwXhpzT0Bu8Bd2fIsM8KzrIUONw/DrDeHnpnSmgdMNKMFUPm9Eo+zXE0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwzeB5HSao4b5r7mRvb3uWZtkaoPvSEBOInqcBJolIWg/2hEktbG4NLu+UJWKqljvRf7AlttpP6Jkeiy617X7IBw=="
+        }
+      ]
+    }
+  ],
+  "Accounts rebroadcastTransactions should not rebroadcast expired transactions": [
+    {
+      "version": 2,
+      "id": "e70030ae-af2b-4d9e-ba0e-6f105f2c2f05",
+      "name": "accountA",
+      "spendingKey": "2e82df9e41d91f568c427be3b387bcc8180e1f967803292331b5e5b3e28915d6",
+      "viewKey": "0c230d31df3361261fc857e30bd98b89b38b992e874f431daba3eccc25400592b7ed40a7a7762ab3c5e9ed6a079b41e5c95cd2cb12c7e9c403f0b3138dd9eec2",
+      "incomingViewKey": "4dbf8ca74e97f92b1278dca4f5acf3a10b78c707066e1ac8b912e0444753c604",
+      "outgoingViewKey": "d5ada13a8c22715542bcdf2c7d663a86464533d117338c24c93465e10eb900c0",
+      "publicAddress": "c05f7766834b62b9e23ec86ef205f4d40f7c1c12914bf7a0e25cae41bf612ec5",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:/2haTpaIUStGtxElKZo4RfKnHyKpTHkTCGeylCmCTmQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:IEisF5fwuI7uBuVLl1wpO0PX//Th0iMxfIgyMak5t0w="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156506392,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAOk4WtdoaduPjM25Ks0fTf/S+XEeqRXkKPdrnk4HltJiTEib3vEymFJ0OycG5Fg6jvvRTcZmyr7G9kAqUdi8qdm5HLfY/YZgiDEozLnVz+c208AUpTx9V2nJ/aZM89Xlo4grjZG/jzT2JZjvneC06rkqL/UbQI2lvEHhfAZqb27MEAW45EIiLCLV1su0ltrBZFrokn0PwjpKpk5/BKgBOsPtUePn33fJOfM3haZysUx+5qYD7KZuG26CMYCcUHhQE5hBnuftrRxTtdMB4q2JkImJbIJBJV2qvQC5QQXMQd1XiMHj0ig/8ultvwfxOy6U4T4kZrdRm2xCLUsc/gk0rZktVrQbhog6/NT5gGMKWOiNlT4ZVL2dR5RijGoTSajQTNnEc6fsK3Tebdof0eT+yZ7ryAA6OZH1w60XbV3sBUYVGMLKODm7cKCYIxNqYy9zOung8VGUK7EqFXi/3/u/QRsZHk2uQgPRZeo66jAD7VOTouyLoBswonQILzKMO+/KvODCJrlcug68+/8Xijoltj8avNtAgMTx3WnIp/u+eOUO+Umb2jIGSAnz0DkPhFSjjCS9sBX/XmTART+L9G2S6bLZ3culEPM+87Jmy4gF1k2qLEmAGx9GZ30lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw4SI8ZHbVV07WHPSWjP+5y2OmOIMqTtFdoyXsDA5hWgRaRMS/QtZ9xXgcXYK0gkkrl1pz1ubUDUG8uUx6VYzwDQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAASLSec3gT+W/Ih2KUl7wT8U/NlXoLIhhKKmfSI+dNHNGXFfr/Dphq/Xg9IaIskzZxWtn5hEfZkyFXBRQy3+meWzz3yoWSngd/rYYrhyvqVuWndU5V5AnPYnD4J1jiVIJQ5x3WzEt6OCAFnNAtj+Op53N6lSaUVtI8ORcqcbuDwvgL/NiXFWXo2oA/533BQAq8U9lctOQQ55ufIvMMainzjLKmfIvcex5iGQ+tveCqMViFE7i7hqmuwrxGmndnnvl6PH4cTXZPpiorQtdBcOb8bcWkLhru16BGEypHPWklxQRZdYI7mqvuun5YPFgkGGDeoczkPOZDwBgKHH0Z0+C0Nf9oWk6WiFErRrcRJSmaOEXypx8iqUx5EwhnspQpgk5kBAAAADYnS0Exqv7U70rymwn96+kIC0y8Kb4U2mxUg/ZpX8p5KtthW8SOzB0upTMRwkMxzAtclVNS5FmGCDWg6sN9IBsLPaddsh0WYjHMcRScALX0eow0/LIKbIP11XbIaKpTA4SQaIiNOuGu9ZubyWsqAtSYZ7r+ELcdu0GnGkfDuxEedMnALBRcdmm6B+GkvEfIqIun4Hp5cdjDb+yulstajzlrjqkZ/1YLgmV+NL5upctClQN01qu7avNhvi0CbHtYlBcL7rZlekCaNGHhvVzU+zBJRyAukuSz4KHejVaE1Tm0I2O6Y+aaq982quRSmG0RW5MKtnEck6U1UY2WEGTIWsHbTyk33fbEsX0SestB0gvb/Gf1RIwBpv1QcMck5XIVjAlMfYhxvHaUYORG2NIyWD7AG+BmDpyRZKTkGD4C0IwyPJykEUOmsIIiS/hcLhDtoTm384vF5l3kZRg9CdEFOE+B6LP2jIDlrw+IKNCKo4ukKzfGkt5q8ysoeCGLIg46H+gXhQBxoa7dtQ18QjpjBjjNPM0zQNFqdLfuZnZu+Zis/fMBpwiVHMGUwcqXdEJXA+gRAGhvD4iCc3U2nsXZypyjPfe4BN2woXgOQku8BiH6oR9jD/NY8dDDjt+mSzsaqQCgj80SlEQtGFKwZlQhEe9IIUAwDrI8Knt01N848t8uSXsfWdJdmIhXcIYsZY6ubv6FE7h2/EyyMBBMQa/OOxKQ6juFGVsPwYDjmCkCyVkC+oDCQwljDkfb1E4QvCEyONog2bsWGop5ejTyiv4gBgxOGxXyKXc3ykRn+I5iFQVsXTlrYpmMKnGldOcojCBVrp1vEV9SITC6JTf+Q9ex14KEm7Dxp/l35f13tXh0iOKxPO0FdaOz9j2loKsQFKMgYjsrYT+ZHRzQeDY+TiJi6CADob7hnqUz2bsdqKPCrs5/HQQ4qKBVvqACI4Ls+Wjq1ij25+a6u3aq76++Gok/c/9EwKXWSIREX6154VqVuvSIUNEwLQBg6CiriAptIc94Xb1Qc6y33cJ9+e9o1O4oncjx8DAFf1qItDK7+xj+iFudJtkZpdhFNuZoTG1/RMoCQnjqGiOksrNXHPRA+3O8N4JxdmI5mdvm4UmjumJN2eruiOPgKVupZx8Mte/tv5L1Kgzb4b513oBYZlbA8nGd+WzciGH2a9uVhIBwe4V5pZdDNnUvTFK+IEpqjy0/jwU4jS5d84xtyioc3zG/pC/BXsnr0CxI3bCU5jGI+p97wVOHEdH5oNr58qxHEq7Xj4ugY2VEtGkh3Lml3rNz7C3q8TAxkKf5zuV1lAb4T3OPUGR7/8AOOX3GlILL1ux125S+FoJKMRWfCra56FozaGZ/edH2D4Q8X23aT7whnHdcFMP1QZldUFS/cVjxLxSJ/x7UqdOZ/l0S9BTcYnBXYvWYoMqlX42O/gGQXM4RRpfmv9DyXQH8J+RWyLD+A/TLhOnXZ/SVLw+3eIZ920s9zIctHsl0AWYAqqIjcskEyyJWOdG2yI+zpB4CRj7GeSPNPt4UkFqKafcGN8571yBgwbRrUycp3/SPGzu3reaCscNE/sMXHGjJNN3nKa5/bZPHBZlOCw=="
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "61E6E4150CEE5B52391B4CDE0117FE4CE03E33EDA18C499C7AA3C7396F32D3E9",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:GyQ6BF8WWhfOSq9r2uLbAxkRbUqABrWjDC75WoMILAk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:wCq7uOQnRNmHWzeRcK5OMJxlZ4unVqqKm0HwetNfprE="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156508888,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAR5bc8l37itjIcVsTZetR5xoZaS8fQAykoDpwoNFjQKit/GYmNSUvQoUSr/A1vpfMlhYM1zkA+H1wSOC5OXIfXAI86Tkv/zMiuFknDvvKrsmpJZKxxujL7TFJS/cZZrJ8XDrDNHeVmkq9Hk8trLXeKSnAv5EzJLmwIZTKx1wflowEzobOogahiWAbKByap9p723bG930MC+ywFVBw/8mHnjGIgNwtMC9qRzO8lvgddoyGZ2BGOEDD91LrV82kwoWwJZJ/ns09cHOikPhMSOfguqTC9V2e1lhO9Ca1y3o50mpaOXb6rS86SsPXIrCz21Ntd2WuXG4eKzugRJM7kqg+F8lGDAFAd0iyMOLL2wyDbzRvGHY3ChfV6SezvDZGEX1qpRpgsTVwmCm7h1XkJ0GeiMQcKF5GHHDwe/wn7BhrrF6fSbZcPg6hTkvQ786jlI2cxxyCNr/uiPhEhfE18Jw4VvhVGuERGKdUpAcRCDFeQC0v4ouuoISW3NHutjpKQ0QPWDPMP1eH2YDfyKRJ/BSE4icMWLtV4sh0OmK/lz6cvou8sp9HXE5Box0GMUEBqf3Em0hm8/ahheQ75DLDXjRNayXLQKbGT/kI6JHZJjvhSs6SdtAYIBKBzUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1+gu+PT6B+UwCh8gDjD1paup1U1lpKcojAuk6WVs0abyUW1kJBfQOs62SbIII1fbseavnZR52o9apf4HlAvTAA=="
+        }
+      ]
+    }
+  ],
+  "Accounts mint for an identifier not stored in the database throws a not found exception": [
+    {
+      "version": 2,
+      "id": "e14fbc53-0eeb-4031-aee3-fe47fbcbb8a3",
+      "name": "test",
+      "spendingKey": "6acbc2a266e39253b05db9fa20ac1422a43ce14114302ecd103486e12b1b8cd2",
+      "viewKey": "c41fb47586759e8dbfbf09343ae65be8a12dbc22d873b206e91864eb51d553d326f5d97dd717a5a59fb2bf04fb052b72745ce8bcaea933f518e789fe4c49fe01",
+      "incomingViewKey": "d269fd3fe787c4e419087d2662d3dfca01fde3313c78fed2fd273d990c116901",
+      "outgoingViewKey": "a34a1f28d88a3fe0fc2b0587b2144d27182e588eeebdd9649f02cd93f7c05c95",
+      "publicAddress": "d899eba6b1036bffe5de153f544b272f029fc79f642b7a462c0ebcaa4eaa30b1",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Accounts mint for a valid asset identifier adds balance for the asset from the wallet": [
+    {
+      "version": 2,
+      "id": "f1c63336-0e0a-40e0-a75f-a9f52b9ab993",
+      "name": "test",
+      "spendingKey": "cc2b397e18b5cce9fee5a3c1f4143296aee93fab3aa61ec0979f23e191e8b69c",
+      "viewKey": "91fb72573e3530a6f625bc9ad06dbe30e2c1a7b3cf11b2b1c15c686b7fa95a9de11b49a8768321a3f25d7828cc1f460700656a8c246c8584b4440d60543c73a2",
+      "incomingViewKey": "00e47fd1d355b1505a07cb76cc7104fb069c54b91e4d711d88a3fa81d3a5be04",
+      "outgoingViewKey": "54101a49b25f3d91223a15d01f2fa22762e0bec1971bc0686cbdcd13380c2417",
+      "publicAddress": "5a66144a52717233d63237d1c5931e49967c7e7d53c24bddddd710dc0b36eed3",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Pss+BmffV95XPXnvMq39sObgHTg6VngEPR1WY4W4P0Y="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:izxpwk80trrq/L3lfqmKO+huuYajLb5WKoDihcc9xDI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156510028,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAPwBHRm8+rjz3CinAE1etbaEi/de9BMpehPdk1OrC9NWmHqyP3jIKcFVIpoEunosdN2cQXBpBo5pL/bBSwZcpAuhBypLYxIET6Avnr2I3baCLO23e88nkVT+pjYG8/tUr+ZktzOcnv/yMa1Wz7cmh/gXDHsEjAfNCRZpiKzDYLDgVIh4+pmQkxrmfe75gx8hltPpsy8VHV/WotLrZLiwbKkA9/hoqiE3zO4D6bpBsyYmRJ4CZEQtfATWD5Hg1S4+WkLqBosZwiMIOopewpFECx8KHUyPm6SOXuP91TQ5U+GK7eDy7zrE1r59EUtiBee6Rc+Gez+rJBYqlhpVkZlQvgAIDUUJVfiIRpK1OAecQ6PJnUdtqI84Pj9M3j9T3YRFkHX2dfb3OZZOkBQFYUFZieubU2ZQJWWMYrj6r2UEMqqUBMZD8AN4WmStSezZwl07z8od/ZTAgtDeVFZoziw0k8kJf/XScbuFzzwNvSShXMvicchjBh5HwbbIqzxGo5uVhSCMU31QNQtGN6SO0cuXNDzaG7HS6hf1shx1WanZrgewbm/XMVxDclPn0/agKQWJ3dNT7tPoUY6WDjfLeWStU9I8Dmd96T7mU98VwChxoLzaSNWAkCmZqcElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwibGr3hcJ2LBrrR1t7rZfq/bbr95quwtnxGMzpVuXoNItfFiY5QABIW5v0ZgIIa2XnKS4WnFW+igS9bCCYQFwDQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQeGxmKeC8NLAjrU09CXSlhL6WmY+K4bc89+xgYHuOaKV2+b2KrTaXlIrkDt1BuMgW2usY/UoaHpFfY6HT1ytOctxCKqxRlmdX2rh0IlxkqGgH/LaOxfZABdX7WFE5QgnfM0OT3k27P67ema0KWnRHfRLLfxoqeqUFVEO0b7B2tsBV67jDz7YejTXRWZKIxtkHf3xJwGL5ogjWVEACb9NZTbhxlCD056yRMXvyBYgAhqpqcqANl7tdRqRJaOLNjeOkhy3meoprjozIUDvaP3n2rPCAB5z3qvR0husovmxlyRLWHkelCUpY7Wr8t5+fSgurMXrQ8l5opRSgzhsuJEVw8Olm6TkL9q4YNotqwYCL274tl2898pKTLN1gYHr26c9/qzTCjtC8dkb/Vs/p7Jk04LJdk0LkesokVy4ggAAXBsQ1cjlD2RTjqboHBMQg7Y9KA0JPMISilly0whjmCtK4iuiWF9OA7eqtnVDMt4Z82T4fiwvqXWYwvKOscZjBLvgIA6PJPzszrqyA0qgaNbAr1x1ByZ2u1KTSy6XME5/bqAyS2DYWE0zMmyhyPNQb8D2L9Z8g/VIlMFwIAEr12CXXJiJ0LuxwQv6K9xeXHXwGpppXK433wmF5urc4RHWIGBe7wpeKlVCoO609zcWwTBWOWLqvvTWcouYbrYXQV2zMxTccXqNfK98+MRHfnasuVTraysjB480hJs+F1BiKA56HuC0dxg1gnjyo+U8HYqJs1hbrq7N1jlbMFi2FuaWGQDYeZq4icJrcnABLO6+iomF7UEfpDcxm5RYsXylrXEmMtzoYhQu1wHVmG1z/FOI+W5aSuhdR+qJD80+Nz9sDFsBzzpqk5xK+QxmDzAPxsMmSPyeUSQvp9WC0p4s27pG8gqoJHkKXmychE0Y7LZ9olAmBmo+tbIwxVtaiV/9JAhHxQHoas6AbhkeibBhmu6l5pCih7jGIm2kxD06r1ygeOI4XoET0s6wAZOEWmYUSlJxcjPWMjfRxZMeSZZ8fn1Twkvd3dcQ3As27tNtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAECAAAAAAAAAG6OFW1CgS4oK0abkpHe83+nxkO8YMtztHeszIANcCFrxzSo3Ai7YOMYHHE8jZfPc2dtav9/yFFI6Qvy6iNVmgjkWQByon2CdL1nh3EswNBiYq5EWzHw7lzwo+CX2R6scDwResVVdTza1wAws53p++6nLE55CnPiE8r/mIsa6tMG"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "8ABAEE1B23282E23497EEF1407E284F7459870181ACA58F19042C201ED639B3C",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:v9/DDP+GaVZBbxGR7pjzd0Y6A/rqPakDpE1iLSatEx0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:HJYEB2eknguFluTRUnG98GZfQF7Mp8DuTj5Q2VTk9Io="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156511319,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAz6QUUn7ZWTwkpL7dGnnmtnOVLKwdYSVFpBDZptZ9yjGDQMDAAhntD/ZWVH1NxIe9E1eBb+D9D8fymcQc3Rc8KrWB+VKQO4dNA8dHhtH6aa6ENIaPQtMjBwFONbgAAmy6YdW7N6OoqToPsFyx30z4HCKvwMIPI70yFRlgPI+JWa0MkjwBqHEHiyc+bqTe29yTd/MSGI0eboEPdVCprZIe6xJG47/mtmuwt479T33Wf8Oq9jdvl3nC5eldOYd4lsAz5rNWXhjCTxap4MO850Zh9ezqFtkqGWtRMOIuIw/+X5DkDNs73lzIS8L0XxqhHXFrzzzQw3PDYJ/rIwI5A+1hTbZQlpXA0c9UuEdEGFQQ+/CUJ/nrVcpqvnsORUQFIt5x8hDnyDnyFweixh1sEh/2CbgUGqJ4f5cHtGyox9uYUUwukMJ6ojhLH5RGqwu67tFVFdvGGp2oPnukiV/jky9wP/WIlnEZxNU1a50qvF2Pk7q2U26GtChRGS3PKl0yaLbzF4NKFoF0Jgqq5ah5/PgD0UqWhv2dXm56+zGPl2STlPvIXWyOF6l5B2/MyL8EbWGhC6slkHHqTScxQODLyfW5NQYt61Vpkn3Q8vyoFu2OokWJohdiTUSRF0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnbTzwyo820qjuv0bxZVatMTE8X6qqhPPpzb1Acn4yUjMt9crz32HPhFefwE77OkG5gs2+E2AQ4O2OyTre/Y5DQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQeGxmKeC8NLAjrU09CXSlhL6WmY+K4bc89+xgYHuOaKV2+b2KrTaXlIrkDt1BuMgW2usY/UoaHpFfY6HT1ytOctxCKqxRlmdX2rh0IlxkqGgH/LaOxfZABdX7WFE5QgnfM0OT3k27P67ema0KWnRHfRLLfxoqeqUFVEO0b7B2tsBV67jDz7YejTXRWZKIxtkHf3xJwGL5ogjWVEACb9NZTbhxlCD056yRMXvyBYgAhqpqcqANl7tdRqRJaOLNjeOkhy3meoprjozIUDvaP3n2rPCAB5z3qvR0husovmxlyRLWHkelCUpY7Wr8t5+fSgurMXrQ8l5opRSgzhsuJEVw8Olm6TkL9q4YNotqwYCL274tl2898pKTLN1gYHr26c9/qzTCjtC8dkb/Vs/p7Jk04LJdk0LkesokVy4ggAAXBsQ1cjlD2RTjqboHBMQg7Y9KA0JPMISilly0whjmCtK4iuiWF9OA7eqtnVDMt4Z82T4fiwvqXWYwvKOscZjBLvgIA6PJPzszrqyA0qgaNbAr1x1ByZ2u1KTSy6XME5/bqAyS2DYWE0zMmyhyPNQb8D2L9Z8g/VIlMFwIAEr12CXXJiJ0LuxwQv6K9xeXHXwGpppXK433wmF5urc4RHWIGBe7wpeKlVCoO609zcWwTBWOWLqvvTWcouYbrYXQV2zMxTccXqNfK98+MRHfnasuVTraysjB480hJs+F1BiKA56HuC0dxg1gnjyo+U8HYqJs1hbrq7N1jlbMFi2FuaWGQDYeZq4icJrcnABLO6+iomF7UEfpDcxm5RYsXylrXEmMtzoYhQu1wHVmG1z/FOI+W5aSuhdR+qJD80+Nz9sDFsBzzpqk5xK+QxmDzAPxsMmSPyeUSQvp9WC0p4s27pG8gqoJHkKXmychE0Y7LZ9olAmBmo+tbIwxVtaiV/9JAhHxQHoas6AbhkeibBhmu6l5pCih7jGIm2kxD06r1ygeOI4XoET0s6wAZOEWmYUSlJxcjPWMjfRxZMeSZZ8fn1Twkvd3dcQ3As27tNtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAECAAAAAAAAAG6OFW1CgS4oK0abkpHe83+nxkO8YMtztHeszIANcCFrxzSo3Ai7YOMYHHE8jZfPc2dtav9/yFFI6Qvy6iNVmgjkWQByon2CdL1nh3EswNBiYq5EWzHw7lzwo+CX2R6scDwResVVdTza1wAws53p++6nLE55CnPiE8r/mIsa6tMG"
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAwCAdrFAyI06Y923CVDExRrDJ7RJnZQyYm61AZNpXy0yxO4RwhxwIqIA+eblvgkGjWop1QRAZu99buHdcxJ1VcM1U5lv7yBHNs+JJ04qkeKmWx8mOa833z0ilRD3GheSvK4wNJ1zkawly0guT5rKygh1+rKKs7cQq4J3AIY94mOMBvZYPIvOevqUIcFz1b6GZGp+QhVdn10j8Iv9Ri7CPxACahCGhD7RpFSjd9fHqP8WZmYD6HHiaYoLhiEcCurE7drnKg2sTidrCI3Gk6gQGEPIV6O/n3B1HLrm12qN49UTmClI0R5cw9SmfQzISSHL39xbZnXaqrCEShOk2v2d9s1IWmbRRH4t4Tz46OsZCx2aduWZ/IAicyyojZxQsVe1P97RkKC3CU+npchEc2quSvPxCEeZMHKyvuQgtDkvUCiSm+i84cavMqrQwvMCi+HD6gCFKy68DGobllS15gfobfRYDBf6l0l6H1QM3bQjpRDHif8Hiea8G6fnOrc65VCmPyAlHqSDb1LeF6Wn0veKn49d/gQcdjKh1xpegTkrQGYk9NwNaG8h8EO7nDsSKL68ZXhaomUdRVbds+klsj5FgT4qLJ7mp9h6gCy233KDhQJ43HdploxutR9vtYISAxF6nv/QqEipffF9Y4FJWRg9OA0ggELwcMBhUaRgZ4X0bT9LoXv6gIfjGre0wHfgydTFxfnLaBYfRt4IVWu+EaCGBj9rUpV57AGF6kG2Zn+yHEoYxp+ntt1k550B3GvMlpn8GLOuaetkPOqdDPSzVC+9BjN4aH6CdzPe9or0qOBKUuMPZByh3p7T+Aui28MQiaZfHySYcyhieGMObHfWrMsJqTzfZnU7xfdJaBNAv7XEyz81hVnLexvEQaMyySxnQfvppQni1sXJ0e48cK1gzlEjDCAF6c3znfkdArBEjhJ5hQwOYsdYbAUY4RbEsl+gyyNQ2Z/t+IkBExXCJKSvPonUj5DbWewvi0SebWmYUSlJxcjPWMjfRxZMeSZZ8fn1Twkvd3dcQ3As27tNtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAALR/hp6wouOHKDsUgp2sNYF01U8uOn0JcZbr3BqQMmdtc5gl/YwSRY7M9D67tDF9Z7PhEytHExAaloTEzZwgmwgYd8q2kDOgCY0R9amy+Pr3aryv1heANhHx5jRv8N4ZSIJ/r81Q+NB3ABxQnQrFMemeiKQxZ6d3D+IYlPZ7sOcH"
+    }
+  ],
+  "Accounts mint for a valid metadata and name returns a transaction with matching mint descriptions": [
+    {
+      "version": 2,
+      "id": "af9b5e73-2c20-4d12-af2a-f6a556c17057",
+      "name": "test",
+      "spendingKey": "2bfd5cc35a9f48fe20f02e98f3be5e9f9666659f0e62b31faf24d60a241a59a5",
+      "viewKey": "64ed679fecbc8d33e4390758f9e54043d9e5fe1ffa18b3e982e349a5f5c40dae958d3beae18dc078e85c0f7067359400ddb05463a21b2925ef107f39e546024a",
+      "incomingViewKey": "b1fc2bd9606c78b3efef525e0ba46bd00d5ace5cf4164772d3b758477495df03",
+      "outgoingViewKey": "0f03ded7761e43e0c646986b8906750d230444f021459c272cb35f2e549cc4e1",
+      "publicAddress": "3d12113532e9ed0ac907080c391487a8ade175acf0468d79cbc485317ea25ca4",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ARzhA1A3873lsUd3uF4t1EHmf0mDtoO3aVZw2ns2nAQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:BybBmTwaJAeHjunRaj//k8yeN41hxoA2+GEfegRb0sU="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156513423,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAFiptmGtTON4onsN9YkeCUIPPaJI6hiDTnkodXBs3ANKuKk292WEn7TAXND20fbUzwp8sKH4WYg5GrTLQaEN75QFV+UvF5yP+zKjTJCCr/SKH0u/B8NWgZKJTsFrbhHy18lr2MdvBvtTilwFTbyS8H9p2F5YUxMS6ZuGHMbY7XAARaolpX83Sz7GwVML93DURnAH36i69GfAa9UVQsyELEEArnoxh0hYxs9NbyRwajhuOSUTYGnsMscklkO4RG+zIMktLtqRKxcs/QZ2THJMwWyxSErHzad+7cNMAtGq0q6O7tO+OwWbdZdmWtMhfcyW6aMVIhDTt2nXTBA9ZXsJfwsDiw47gA9gRg2+NDpAR+ZjIamDJJL6c0oqd1T+ay8whSTJJPZRGBD8SsWRP6Yd8MHCur3u7VqybLyU3oAL129sQzj48LW3JmFbUDILjADRLRMKoDk8AAeNeWfuhRQKiAYuOi60SGHGs5MpkwoNYxZWCwtE9zETHgi2spcwKqfqYEWoldgZJ3SQRys8PUeoAQfUjBlrJItEQxSjQOVPqgfc0j36m1o3o4q3dPrWTYYWUSiKgTFh6JCn1TYeKD0PAiakRxv8a/PkIc92Wu2+iH+2Yv2HmqC6KqElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsgJl7+cKUqYJHp9TYdKaaMAvgo93K+3MhDeOMZFhQp0ivL+06kbr+pxVZSBySCZkJ2m7DB1MYtB1C5WcVmgmDQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIVio2eHSubwLMbQNcg5gxi3snkev0KDkcD4lhxcEqhmt/pTQQPjmy0GGK+RHEPoWZtrh2suNjhjpyPPE7HoYr5LZrsx1DP7vmXG4M7kgrGewA9oth3VxKUoEsBCFA/YV1iR0Uo+tYMtoGXpZCP717urYcO8aamMusfi+l+NZFZ0MzzMQwz3LtnSOqxy1oG1x+ale5BBxLc7eLVj5TJ1u3NuBVGuymFidVepQD0gZWo6kXs9vyfWA5CpKnzPlvOTyY5ssjurzYQbGQ1+86UqU2l1IoSfluoqBJBtIXFxOrUv0TkCHLksDigFEWbACuEP2K5O+CUk288x7upzGGfKR6SRokV9GSnIeORN2hIsl79SP+bl3CS8wANprFbQcUeUPCbPGgXJkCmZrwsLIt8A044iGWD+9yrwUryQVaTau1W4iHudCnLiTLnu9xL9+NyXrSnSTuc37uQK2xJwAy766UY9ltLdxP/eOvVHJbmHBsAwYpI15Zn9Q11+zRRmCIN44zBBkHFrrQdxwAPr/V9QUfsgpczqkCIYp6FeGIoEQc+8rkg3fvJS78duUzXI0zMPBgUbtVq8m70SFOOAFCbId+ztJ+QFabCDqBBYScxN3mE0NV5xm4fFlWAu22TD+pG9AZBQhJ3E3NKqoPIHQhkwaLFF2nYR7R032PZci02LPoA2shs3Bqurk6H/zPP8N1HpS6QtOKuCyCNArobFngCkuc4BsTipGk7ogmDIyLmC8OLykk+oZoFfKmUliesqU/i0jNKATHsFYPc8YrDZ20xnfnlyGvkLPKg86os4EA3CRwX4iq/pf+BQ7sb44ndKrQ5ClXuMKAlhI/QoTnx6AAk09ALBXlN9+J9iPBtN4ucefyk4h9EBBjMN6P/RjUg3jpdlW2ttyPh7qW+fSXoVxydRfuXCEE0Ku4lYShokfEILE4hbqxBKabhDC79CmKQIuSs6MdsbJVXlLyOTzda57A9lyMASwVvq+tEGsPRIRNTLp7QrJBwgMORSHqK3hdazwRo15y8SFMX6iXKRtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAANYDTEY6bUox+ZaJtcwjEPiQlP0/aQuJmiXrcy40FBoui29c+jBjTLGJNAfe/SyJsXUkr98IU6GH6gFLlf2VvAxyU7zPu+j3a3tScikrpTmaMkwz70tR2bMyP2+gPVjFuDNhQ4KgX8w39cZaAAbLcwKhiQSLYFbQ5Lj6gcEuzPUM"
+    }
+  ],
+  "Accounts mint for a valid metadata and name adds balance for the asset from the wallet": [
+    {
+      "version": 2,
+      "id": "1e31d4d3-1b9a-47a1-8e28-f1618f934d4b",
+      "name": "test",
+      "spendingKey": "f38412072bfd0b441c45127ef1d60dc74dab19fc4a07d1ed547d558fc66d9619",
+      "viewKey": "5ffdad936a1348a51740567cfca43df190a823301586c30b5c04d430cf85500739169399c7d93cef99b1b808e104b94f1e98bb0374388aabbad44feebcb39a73",
+      "incomingViewKey": "8a5329cdf7726a27793138fc514071f40d3c2e562eb4584cb03bbc74f637c605",
+      "outgoingViewKey": "01154dbfaf57ce70786c7ea384f86f5e07293f072fb7636f67f0b761c7581e43",
+      "publicAddress": "8384ff2c621eb7bdefa44bfbba6be4ce31d8a9dc4aa6117c1014c680e6459721",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:EdGuQPdOQ2x7LeXNQcus5WW3Qs9nPfh4dXOeWbdRd2o="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ntiEArEujH52tFhLXUwWG+5DH5ICTEX9W7Dqs+os17Q="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156515010,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAATiHxUWQZ+2Jc8N00A8oGSA3VUSHy1mBWcCP3kuuS8Uqn0SFnMxFEKXzHqL2B2Y2bVX2a2GbvQSvA/9BOAZwsn1BOUHws0TUh1osg3qW5v+ezp5nyeaF8C2IqvcWJDaczEJYoA+li/7YjSiZXN+2Ip8h3I6Dgy44oAsjK3JTGykAF38yNwenUm2efszwPsgHRzoKojnbB7HLBhnqjFaWV7tX721pPURZnqAFAGuHbvcSs3QBDyvzjCnrjXTB6NdvBVguF8T3THr6/2hHKf6IAghi+7de9M+f7A98kj43tvYxciyWIvPEFq+Cvfkr9Uz8mVmPLbfLfDKMFWlpAjRvyAO+qBsOe61Hqa6G85kNFdI8FwWxxJnKQbuLZY0P8EL4+NVcJYhz9b21YkMYJuSTmmd2U/NxTieZ9tZimdCC0g+VQQMRWWY4PeAs4pCBJ9OD1sjPOi33EUsqh/lqPL0iG6GiWsduiMfW6TPeZiXJld3FtnPWXPL6FXbCsONCAJmYkthIpw8BZUjHd7ZtOQ64a/FCeyxTeyyPWOLimcAUScQmHcqoOGjQ32uABgkKM+eqaVWb4rLxlL5kKJYscgWDaJvjKJwz1a0xRiPQHbfGpcbsJevROkBTqWUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwa802CK35kca6PJCICGo8xwURpt128NVgKOhwI8jJW/N7QTc24L7QzxqeWCymxAVMEcq39NtMQ1X0w4LBdw8nDQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAs9Z1N2DKqQaT/0DW8Ucqo7UQoqynepqbXIJY6zRyCYWq9XIdaA6IIRSG8VANe9QuhcHqg4pvmsTGL9h//4jtnMN02q1Fa4aofsnJyPXOng+j/n9p+dtJX4To+3GqXRFdr33wMXtpn8zxUsBUwrAmfDqIQ6aabb84PFCj+h73pdMRJueyTYOchFPcmKI0xKXJ/ab+ZCpUfI4+D6h/L41Z5UUBdMOjWYouJHfDr7/iz2+qbFWD5wt86LWmhHanfz9uNYYv16zzaTotX+026iqgXtb11sPL8Ixo7pEV1zY/gQv2B3zGvGM8P/6TtV/x67ghSKt1I6FCtW4nJ42Dy+Yon2YaVzKH3SeovHNjOMW7DLgLdVGhHg5G28oIB8Bcc+FANGklhPR3stCJndpseb7FUwoCsuuJ0PTYZnEhCqwznzhZkqcg/HjJ9CVL9VtXlgUsgLjdW57X6CVT9Yqlmzmg+EDv+YmmohHqUl0ff5kdbnJ14BxFssaiznfffHD09iKx9up/H7XGnuMs4Q26KdzMh00vxtlNUTsnmoTT0U0KYVIzYQhxgP2oxjhG7pcDeQ9KxFDZkNbbCOZ7N8ZNmoTmfphYXNYl7q+eio9tXHuNfktlpaadjPd76ZcYGiZLUo9xd02EwIxu2T6Le693TUcOKzKyyasraYnR1aWrHrZSVesjF5ipCEbl3QmPtwHwlElFAo+Lu+cBAFSruHCqvYOqeBkbn/QIn/Wsr519wghGqLrYfjzyXaq54OqtsdkrgqGKCNEMHGDR9LLex+a8xfsaLDm7nFysZxY3mHQOCm8EMOI7NWW+vU1oLGwbwImAq7a1G+JDeSzpguKoFHsMBm2PVBqCKa+eY8VIAt2ef+nlTBG/wgc7VdxDs1lNrUJ6SlyFGF1rAIo5njtKUp/c+q0BhsDyFEGBlYQ9oLLSRH09+fdsGsAX20+5xvrWP26kf2vjmw9zTXr17ZS/+PIRVoG+wi4ihnqZZqs9g4T/LGIet73vpEv7umvkzjHYqdxKphF8EBTGgOZFlyFtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAMwwdr/MeY64CH7Gv1qH1TCvzg9swvvblvD/4t+TIIa09JLfhgKMkXuumtU7kRWnAY9AmY/iM5XifBtHckiMXgHzbUPJShM09sNETqFg2b+70jFqELGHLl0h23pyC+MCMM43+mRv/PvRxdlIzWyBkMxDnOs01RRQSViAQtveEg8C"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "F5AF322B38179271407FE5CCBBD0A0DFDB8537D211291B960D003E10CC7E33EC",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:N25lVYo4C8TCvhJ6TbrNcqEP/cHPCu1owcJGOs9e3gw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Pr9WaAkI6GJZHoECqeWx0Krlh7/wZDR7TFKuhCloIrI="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156516323,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAYthqSu2EcOmYM40zfQ//1J9GW2/O+e1sYNvnxrDpbQ+DA9MuvtZaDdxRE0nQslrj3vJuR0aWPw1Y79KC/xdycjNtEjNIVOX1hhYMQcvdDpmg4ytb3XxpA/2iFi82vQ0SRF1tuJjomHahYrdaP8oVMCqWjFhQY7Geujywn3XHVYwE91yGfxuuCoFrHnNso6JIX2+Xfb96ESH1Jmuui93rQUz61W4EkL9140HgRHLxLYymcCXraNZdKO8p5Jv1M7R0PAvtIpyZ4ldRoRSFCwt4NZCnktmos8MrEjZ7Fz85TLQ0moAfPpH+hxp9VNSDMHKUkZ5IAupGVLkztx4bLiRqx0g6iD1KPQ/lOX7IA4/1P9kr/vYR8qe5eIJuMpLZmVobKRAOAGDfKeyhAiOWyV43QWtYz9hJAfvTWQg+ELwxkZgQ18hhVOU/kgB3WpIii+wySaZeJyGiTZ9LK0h8wc4X3cU6k7V4nuvjjtxnJrYZNonj8Y6jL55wFLCMSeJ/Lb5lMsLu9TaK8m6imBJzQLjnNTMKZTirmzknU5Y7+0rMsNsGhTRLT+nSHBsmV1OU7CqM3fkT8lIy8JxyDPfSrCYrxkEgIILa95VoXcx8o/LFYjDj0nj0CdNdU0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwuEsz0ntrGfZ0XO1My9V8J7zoBQD7tCgCm2IW99e7gdDUUaXBTwSjee0Vh4qJiY3G+hP046c9y1P+KwM530HOBA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAs9Z1N2DKqQaT/0DW8Ucqo7UQoqynepqbXIJY6zRyCYWq9XIdaA6IIRSG8VANe9QuhcHqg4pvmsTGL9h//4jtnMN02q1Fa4aofsnJyPXOng+j/n9p+dtJX4To+3GqXRFdr33wMXtpn8zxUsBUwrAmfDqIQ6aabb84PFCj+h73pdMRJueyTYOchFPcmKI0xKXJ/ab+ZCpUfI4+D6h/L41Z5UUBdMOjWYouJHfDr7/iz2+qbFWD5wt86LWmhHanfz9uNYYv16zzaTotX+026iqgXtb11sPL8Ixo7pEV1zY/gQv2B3zGvGM8P/6TtV/x67ghSKt1I6FCtW4nJ42Dy+Yon2YaVzKH3SeovHNjOMW7DLgLdVGhHg5G28oIB8Bcc+FANGklhPR3stCJndpseb7FUwoCsuuJ0PTYZnEhCqwznzhZkqcg/HjJ9CVL9VtXlgUsgLjdW57X6CVT9Yqlmzmg+EDv+YmmohHqUl0ff5kdbnJ14BxFssaiznfffHD09iKx9up/H7XGnuMs4Q26KdzMh00vxtlNUTsnmoTT0U0KYVIzYQhxgP2oxjhG7pcDeQ9KxFDZkNbbCOZ7N8ZNmoTmfphYXNYl7q+eio9tXHuNfktlpaadjPd76ZcYGiZLUo9xd02EwIxu2T6Le693TUcOKzKyyasraYnR1aWrHrZSVesjF5ipCEbl3QmPtwHwlElFAo+Lu+cBAFSruHCqvYOqeBkbn/QIn/Wsr519wghGqLrYfjzyXaq54OqtsdkrgqGKCNEMHGDR9LLex+a8xfsaLDm7nFysZxY3mHQOCm8EMOI7NWW+vU1oLGwbwImAq7a1G+JDeSzpguKoFHsMBm2PVBqCKa+eY8VIAt2ef+nlTBG/wgc7VdxDs1lNrUJ6SlyFGF1rAIo5njtKUp/c+q0BhsDyFEGBlYQ9oLLSRH09+fdsGsAX20+5xvrWP26kf2vjmw9zTXr17ZS/+PIRVoG+wi4ihnqZZqs9g4T/LGIet73vpEv7umvkzjHYqdxKphF8EBTGgOZFlyFtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAMwwdr/MeY64CH7Gv1qH1TCvzg9swvvblvD/4t+TIIa09JLfhgKMkXuumtU7kRWnAY9AmY/iM5XifBtHckiMXgHzbUPJShM09sNETqFg2b+70jFqELGHLl0h23pyC+MCMM43+mRv/PvRxdlIzWyBkMxDnOs01RRQSViAQtveEg8C"
+        }
+      ]
+    }
+  ],
+  "Accounts burn returns a transaction with matching burn descriptions": [
+    {
+      "version": 2,
+      "id": "55f4c104-0a3f-4e85-9be1-90cd9a6ca8fb",
+      "name": "test",
+      "spendingKey": "ef66739440e9b70d6c32939dc4b3b1adcf1059666736acdfd3e969ea22f717e1",
+      "viewKey": "7fe2cc2068858ab12a5f6302d3244a7ec718d4248bfdead0e21966e3f3845a2221101fe42b0364730c3119d703904c3004f1defb3e1b095a517aa9151d9b91a6",
+      "incomingViewKey": "86dc55dc668174927529d1b871e3000295e2b62d20fc71b749acacf54b467603",
+      "outgoingViewKey": "8542a5025acced9f2747d7f995da28181923613f3133aed183575b1cbc9ad9b8",
+      "publicAddress": "7d049392f90a0e18d1305f072983786cb29218e0c6b9183c81dcadb9906d79cb",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:vKQ4czQCa54iVv4wpmVXvzgkWFKCWbGzhSz8GPU1sC0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:AtnYhxnuwLkgSSBOh93FT+NI7n3c95wWeRLaPyr+Eiw="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156517136,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAUa55lb/kYDWUhIO99XoHPHNPzI4nAziu0p6UAHi+4W6mZ04aUq7thjXNPesbFuYmgkxsMw79MkP00xZWgJr9Bq1uLHjv6I5Z/aSvllPBB8mqVW62fvnJ2pKQ/tbVUlJqn9JITi60Mf2hZkCH9teBHoBC3Wzg9O4VwzAHHYiALrINm9wvplkH1KpAFVOtoKwiJIk4mu6UMTUCBSWzQuWkd753nyWHvIy1j9seRm9NrhWzCiccJWEGqy+H2AS+kFZjHbjzxGulWIZODttjWjNt3BAi03HkhX8yHP9Jq0+noROPADuysWOtALXN/6EitpL6bSXjpm9/raFd6feizNGfDN0+9LM1cvrWcNDikXklL6WORiXNKZHfX9NnEmnVpbBioiMGrb5+QEUZTY6sWSjFHlxxi/trWvLFl3/fOMPUzselI/mRjWM46o+a28hTg6ZYARW141x/9ogDwBGjfXObvaDv3nzl1GqDhgKsTlAzqyh/jEFXznRkWzmD05Kk0x7BN9Xq/9sXb62KtUvqS9SCEdxrsxLE4OU6gn1oiL8VblXeY2MO3rXWxMrS59PDS5EToUL6HledskfaO863E6RBxqAvXwV3XkHKF7zcKZEc16s3ENRK5Y349klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwD2m/bgggPl9iQ3zwK7uCYyPtn0NWS7zK49LGzIxAcbGSK5WykhW4QGkyonnG2mBJAXxkrfO0jaqfCn8cye7HAw=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARgGEsKsm7VntYVBT1tnQhUP/w1md4zyuGS2WeeVVGpSnCtSsuK0oBFMEN91suCQJXXtOzBu2NJhe2m2WJTo2uqp50CqLLNPDEAO1YTbL85CQ4VyxAE0K1ecX4IQEsYZzHhdMnASjCD7TYn4a2I+aZZXSkMkVUNJ9IL6iGVppzEkKqcAVwShVPAJoUs3aGP3xynXR4wMVjfK9ksRdvWaTGRfj0DIBuM8wlicoo0EBmgazdftFL23wLDzJGgdBsuybR1DQkTAhrjunfeJl1ZDBhpU+RoMwFEQPEhhtNB1DJeTGJANFd+UcU2iNNx824KAl0tdHpCiZBiULV31KGi6+42+QlTNPSDv04t4MRmW8PgWn22aAk8nmWQHm3/lsPNtQZptJ+buCpkwPU+53Ne0sDmoWpE32SxGmbpZ9UDuD6CVCT+l3WXWWuYStz+lxaolR+TUF0BpxZA8eiUgVPezWk8wrQVu/uBG+KC84WWJe9t1rB1occ8M88DsdU2WZjCmHezW/pKLjUP2pRuQmm56CcxTEHI/3Ko9RBzEyglV3yh/8UvGNn+Qd5/y89ZtkVagpVawTKz4RisfBZRoAThh9akSEwZI0p1tMf9zQEFg3L+miI3PDSsNNSGZXzaZ97CAGxklPma9Z5KQK7PqC2c+lvtisDs28ceI5ZRN0GHnUwxeCCQkdb0FPyHEkQ0iqVRjtkmeNtmsHWEI2QHtz/+0Wfn7UqNol2Jbbha4k3DF8PispED9FMJRcvlgJTcqT5BChTnQNyqsIlcBzVFtC18LqvE8GmLBeJr9XplA2zUn61H/HCxkwpSvoeyVF6E2zbmBqNtegRfUkArsxbQ0KXzPCtoKdllSc+2fDD4sVsdHMBfh/80/bRkK//LLYHTbCQrKYJqy30Y4Mm/bGltCMiLUFlZVIr4aVka8JuMcl4voz6djDmt6vBDXow6l3pbwxAjud18cwXLU5OHlQPRTcDBOsdpItSGX5l4rWfQSTkvkKDhjRMF8HKYN4bLKSGODGuRg8gdytuZBtecttaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAGNPAxEcX/a5lsbLyHbKRm5dzcgVtXdMDq9Y9pePPD+QcLpa9Hpv+NH5Bov9VHToU+luHxJo58JDEPXkZMqHVA5//tMkxuGDAOyimwDnmcscnU5Rx41ZQoV9FeU3ZeQ+KBVehGWHydKmX/IUKUXhHQSzPs0r0y222ZLWkVKCY78M"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "583B260EE92636586D2226C7643E10E22688810096DBDE58A8172C2CFE32FFE3",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:SLKPdEJaOFaF5pUku9VXq5L6NYW3nLyFZaZ77tRaVko="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/AHQcYVyXf0mBxXex28hdDzploGYBkXBehfYdxO+y+Q="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156518424,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAN5rZzphjbv7V1nlj2SMqNh5VgE9tAbNfV8+aJ2gFU9iK5eSf97yLU837tNorOx0ijSJOHGYHkEzwIM4OQZT8mv6FOK5ELGIhVFlyOuLl9jyW2m2INtjbWEH6UwwLz+F8J28E/SaoHBdp1+LCYfEdHS1eQkSubeYbwH1BMJRluMYKI7yK/bHbwJgDfWN9f2uKKM+bl0oHkbuFhppQAgy88lUS6O7tEHVccdmk5PHL7qawCe3ScKFZ74mkDCk1WrKgqEcOzg4jUz/fRgFmGqHUPX96LMMcJKRsCaMZLF6xYSrau+29Hl+VqZVqKZ3m9kekuHtny3BK9ePxHG4cE95tgD2jpTWG4/znmVrzd/zvr43otMvVZgkUUsPZEiFM171Z/Kv9IZ1socI3k8BuALEMCzYEbpzHVFNQsXl5BdhIBu8VaStUp5x9YHXdBpqaH2PmKJNJ+PBFK1buEOG0uhmBHwqHbJ/kueYgC8gxEBf7fqwgP7yzMoqVZyGxRz/FCk1Bz5TYDh/OlM+jLx+plnAj4hxicv95pWbE1VlEhtjawGdDKD2tGY9YyAfoVo5R5RMPzkWOixDYpqobFDVLOLdLnUpPdGKhfwTQppUmrh2laIofSXbHF9Oti0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbAYNbh7LXowO+5dB5+a1vP5A+F4in3wZclI1PZLfgchkXocsB8Ra5jHYohgnYBA+HSrJdZQgYvqPGYJQZZlkAg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARgGEsKsm7VntYVBT1tnQhUP/w1md4zyuGS2WeeVVGpSnCtSsuK0oBFMEN91suCQJXXtOzBu2NJhe2m2WJTo2uqp50CqLLNPDEAO1YTbL85CQ4VyxAE0K1ecX4IQEsYZzHhdMnASjCD7TYn4a2I+aZZXSkMkVUNJ9IL6iGVppzEkKqcAVwShVPAJoUs3aGP3xynXR4wMVjfK9ksRdvWaTGRfj0DIBuM8wlicoo0EBmgazdftFL23wLDzJGgdBsuybR1DQkTAhrjunfeJl1ZDBhpU+RoMwFEQPEhhtNB1DJeTGJANFd+UcU2iNNx824KAl0tdHpCiZBiULV31KGi6+42+QlTNPSDv04t4MRmW8PgWn22aAk8nmWQHm3/lsPNtQZptJ+buCpkwPU+53Ne0sDmoWpE32SxGmbpZ9UDuD6CVCT+l3WXWWuYStz+lxaolR+TUF0BpxZA8eiUgVPezWk8wrQVu/uBG+KC84WWJe9t1rB1occ8M88DsdU2WZjCmHezW/pKLjUP2pRuQmm56CcxTEHI/3Ko9RBzEyglV3yh/8UvGNn+Qd5/y89ZtkVagpVawTKz4RisfBZRoAThh9akSEwZI0p1tMf9zQEFg3L+miI3PDSsNNSGZXzaZ97CAGxklPma9Z5KQK7PqC2c+lvtisDs28ceI5ZRN0GHnUwxeCCQkdb0FPyHEkQ0iqVRjtkmeNtmsHWEI2QHtz/+0Wfn7UqNol2Jbbha4k3DF8PispED9FMJRcvlgJTcqT5BChTnQNyqsIlcBzVFtC18LqvE8GmLBeJr9XplA2zUn61H/HCxkwpSvoeyVF6E2zbmBqNtegRfUkArsxbQ0KXzPCtoKdllSc+2fDD4sVsdHMBfh/80/bRkK//LLYHTbCQrKYJqy30Y4Mm/bGltCMiLUFlZVIr4aVka8JuMcl4voz6djDmt6vBDXow6l3pbwxAjud18cwXLU5OHlQPRTcDBOsdpItSGX5l4rWfQSTkvkKDhjRMF8HKYN4bLKSGODGuRg8gdytuZBtecttaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAGNPAxEcX/a5lsbLyHbKRm5dzcgVtXdMDq9Y9pePPD+QcLpa9Hpv+NH5Bov9VHToU+luHxJo58JDEPXkZMqHVA5//tMkxuGDAOyimwDnmcscnU5Rx41ZQoV9FeU3ZeQ+KBVehGWHydKmX/IUKUXhHQSzPs0r0y222ZLWkVKCY78M"
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAADk+1l2cYerNhgO67AKMlaumRXvC8nPlPkzdJy5J+tRWrBBI28HOrTLs27KYwzq+H6vbc6TG/TBCArMAYfyMPrZgO3JBQ1vn4Eg5C2KxSgfWANdgu/w8CDFyz+c6as9XGxohbJFIkuIECdogupFgzBDAcs5PFuCplwcVFSxGd7lANH02Itjw/OcmvvW74VCPtnzJ3GtqphS12GfUQ0V7VYB+mj/BrTktF+E6udMemHayFLRnL0u05UUY5DCpTxMlzkFNzpw9gCi5D53rC/6uwYLXyBMo8LTGOsC7DOVong1Wh3rolQMMR6i4mE6HaPmcVTNsOWflVht1F7Orc7+t320iyj3RCWjhWheaVJLvVV6uS+jWFt5y8hWWme+7UWlZKBgAAAGLQydGLlFUnhY28GzKJ8Ig1aKl7+sgPNsa0xceWmsvZR6kZEJIrS4E4NCgikEVezlT6Wb1qV815en1MzD4z8ofj87BGpDLZkl+1YDI4EfyxYDptLnUqvyJg764y3lVUBIymvif0/NJptrzbEyFpS/45+3yn0ZXfBpFzC+o2gJkRL/88mpcKpGgOiCEfBl78couiy1nBaFInwBTb8nLe3Yk1oNk5iTLI/BaUTPCBNXp1JokOQ6R3TjiL+gWAV4yVPg9E49hOjAW23QRAwqaUb+0PpRP0b9BBy+MmGfwQN4v0/UBEUqzpRF/R+80qFcRihZF7NO2qnGHGaBICjP/bbIITe3yPMioDer5cHnccagp0z7YOSRCQDq2WVsInlLsHM7jJc6mPKAqSySk6KPLTdmik7kVWMyA/VEEjGR///YzABOOoFiWmAHVJEk76giByZjVGtlx7OI2nxSThAOAR0hy0+7kQ2K8JSENAIT0KGZbN/+wHgkYFHjez883kExVymwee0txdsYqZpydOH0ZB/8FysQV4lI2LEHCEyhVChcL6iwd67N6h5RU4oIee/RRJbf41aWu5FMsMJA5AJlfHHU1hXuwBryXmBCavOchdQNnLfiFgFj7jpXNWzSPRNrPQdTcCNimJT6pEpPjUDM2PMqF7kATWdLRDZAgFwGlgedKaBh493Pyemi+LVCZP28UmH4ajDtpqiPfNin4LsEm7gINu4yDxismwH5uTf4SAaywXssc4BQC9RA229MBzpm8XS7yOxP6bCouF6rcOfK0I8Acc3Ioi6P2MP5oxllVziOGDLFqeP75RrtY9zl1v3pvrDjdfvyjCei2HnitBXulN15ZU+Xz+lf3zOQIAAAAAAAAAhGPwRILk9Qt1VqC8Wjw0cL1pLG3EJaKNXPl484sENjjYEYw9Mrm9iVIZZi01UMEYqCyMRcl9hDuPN4p864CjCQ=="
+    }
+  ],
+  "Accounts burn subtracts balance for the asset from the wallet": [
+    {
+      "version": 2,
+      "id": "a0126d90-c940-45c0-8deb-e5fab09c0b42",
+      "name": "test",
+      "spendingKey": "f5cf8415e275a15d9ff6d960d2ff82abba40fd5879f2b6a5f02bda03deac3f34",
+      "viewKey": "392014bd2d152dd51e62c5c430907f57a29649443ed1beb5d19633cee5d8ed83bd3dd2052c13e33515652bd498b85f05eae6af52821ba7c0c0b73a1a86818dcb",
+      "incomingViewKey": "807baf60e60c66833e65eba3b5b0af79b3bc0dbc51914a16cfd344370001c305",
+      "outgoingViewKey": "e7c9b24bd05129a2f789409dbad3c55fa9fc2f688ab9aae1c03d600e4010cee5",
+      "publicAddress": "6c3e8201bb6659775843cd4e66084a443401932854ec5969881663d936b1988c",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:wZCVUVMXrzWc6NvJ/EBL4CPRuL2L7RlHCpNEAZLN4ho="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:jQCym8cUiICeizVXKcT4bTtYlruRBJjsr2O5napec/M="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156520754,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAKVlO0+OZsQ1UcPq3p6q8tEQ/19xTfqxQp9E9eMHRr7CmAgVQA2y0sMmt3cfF3zezDP1tDgBBdEn+h+c6l2tISjNvMZMhq/gIY4lxH+UTM6+5MPsF4wv/OIrLJyB77FNNsskYJ99vvIkulnCljEhLG+Ux8syzsZuUOjOoxV5aDFwY052mjpG/jeACZq9XOz37KTtFLlN1s+jnw8zYRTcWPDb3rvVz41W+HdTNEtNItVCYknJB+2EB7kyAln4KRhIY9rMrbBcMFbNMqxLDbV88izciiSYsCoN1mSCi2Fx2Puq1Hw1LRKg6InE5M5G4n6cqFamzJkIdU7FBOwx0zpBnUa56Jegfmpuhm2/DWZleH4IiIjMC1E+l5xWNHqJy73wItyN72jPTRgEIo8PQ+6XyDaUXO3cj5QnfNDDa8MuqX8eWWSodYJhfWL6c1WbrbQLh2aD5ygxZl3ssD5qFCWHEBCPyDL4p50mNvxasNTfUfrVUfoJ7FAkjaKBEnIeO+txymO3v8PCvHswYeOe5D3LHCGIo5iyKCyaZhom8SPTcakcIbJZR2ovwQOu++WkMnRlrJTOGNKa958ds1FMTM7AoKYEBwsn5FwPZsyhuWHsBUJJPNYhuNFkSDUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIVBApEPNIDTYQiGSZCjPc+fs09aF757NwK/buyLJvsoRT7/ND1aBbbJFfiABxC9AqPlQnN8WKlOJZrTMuucQCQ=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAiKki6xFo2/dtevqczor1k6M3NXg71DUsS0oJ+WSbqtOob1plmn7YXBZaUe7sbzqq8HTPrFT+aLdA1YjiUWl8cSxqysmokd2jiivvWfifY5SkAEvCJsRF3YmF7Ei58OGOQhMz70Ug5vWFnZ7d+lRohCr71D303KfgL8l6Wxf0YUgHr6/T6Tsmw1mhyPIkFr0CyRcZrqQ1nEgd0hGWTlztqeMKKJveU9eoEyNAbCty/yaZA497hZMVeBEcBJzKV5cRtO5fYlsi0d5uG92casJBHtG9ShOui3ae7Ot2Mz141UqbUg07A2vXTcjcJ+sN1Ki25nn4qr62u56UQyC3EJXwt/3tOIwGg1Rv0FR7Im9GN7XPODKWF9uUQJ4oj/7jvi4ueYaYLvySfRNneN2tfQXQN3Iydm3bCuBHD15fnNvjooAhgCYHPXdgzHle6jkMLNEGtdmIuECTAuEhI50v9CdqkBywH4tK564RD0mVzPQkn/nYADGix/f+hb1qSKdPtMDounB+N6fDjhGq+j/f5+q3lDLiwj6rmF/tJrbkhOUd8zDiaJiVEQL/jwWhFOA4hcYe97JTfGK1lHybhCgSbGbWBkz/xBu850mQ2AvTWJW5jEabpV6YuqymiYCFu/wpj18EE8V6Y6IyEvzwwPfsaCL2rKkbv2GuqFiTc6BVXWfHMjCZV4+rd/RdN5oeqdz8LwZAU1CKMCCnvTWAWO82CpG4kHIihgJUlhVXqueakM/xjxAnam2HxC36cNLdxMTNoZu+3hCoKS+gXUPa66RYC91bR3FkdXfNjon5lNqoaDIvpnlqxzithnMmso2yMadlvr2zgy6aDMfbMQJoPX3fT5rjLvoDzs4h+7d7FbGGDrgau2vjd8QriU82YNkAQ9CBqb4NZV+mE5Kr4JzvwYLLGTAy76LcGtBdweB/kx8sClVLnNd2+0/ezUH86boliGTYbfdabftVuejSbYs68ZWGABzUX3wsMaS+9mAgbD6CAbtmWXdYQ81OZghKRDQBkyhU7FlpiBZj2TaxmIxtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAAP0DpyaFILseRZh97ffEvFEuIG2U8etJFThjutM+UVSo3qKe5BeQQUK5d64EaAliD5etKStV0aMYq+mM5DO5igSdJOA0V2oz74ftqRh965RnISId2BSRFVZgek5ZVw/aMxQ8icnmZAbg/rclbQTZyM8F47JMrOieD/rFbPXQ68UC"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "829967A24A58C5B01610AC719435DFADC6B329AB6D8F69769AED7E828EC6610A",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:U0QUIPpaJXvdhwQqbHsl18T7AOzX0MQ1c1K1hBcHGBA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:deeHQpMuwos0HsElLUkSb/T1l7F7bgajQ53jFH8GQys="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156522026,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAmW00yqoeB9VCgPFXFKP0KDMYbS741VYqiMR5zDLMg8WCKZfYVAtuDqKwucPqtzTmJUiive5Ju9Tub+PPW6k18fVyQIMo0QnQwuW6XUdc/bSDd2qPFN3qkm8e60tgLmxoLRBpx8c/abpvmDmOIGe/uiKeScwdlZSCp1HREin6JBYYQK1wr0lN+XCSsIAyiy8nwT6LnHms3yx91bB6G5OTvKv6tPZYg7qC1ljqJe8li8eudh6vs5umxvpzJlCWHNPWq7CxlEgygHo51ev3TXpxaU1iy4q6dtAml2EFAEZbuCk2Yl6DD2bmTce4ZmnwN0umOZUm2XJ9lC3kVKASSFZPtH80rojpYimRuth7cxDfEudgox2UTa5YR9mNhV4hBXpM61AybAALlHSgFHu9PB3soFUnGLsjaEM7DTzSXGMYLjCE4w2tsN9TCjvPq3V0REbuTHZpoSo6U77GkbbMZwu8V3asdsEMeLa8GoOmrmP8p7YqvqkUE7Pm650w6sK81b/48f7dY/bywZuyeU8RfMrnQbHCV+0Mla5UfqCDygPO/cIi7v9B0Ho/OM2LPz/1JwAFD8WrSJVgFh6y4TfrisMKn7RLbG4UXKBrgTPHJxV23jOnsVR3PbKvHklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwv+JWpayOT8c8Wxgf/COCoF1E4E4YFsFVIh1plxK+2kPc0kaaeYc2WSyian2LToCkBlTdE6329A2opUrQPGroCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAiKki6xFo2/dtevqczor1k6M3NXg71DUsS0oJ+WSbqtOob1plmn7YXBZaUe7sbzqq8HTPrFT+aLdA1YjiUWl8cSxqysmokd2jiivvWfifY5SkAEvCJsRF3YmF7Ei58OGOQhMz70Ug5vWFnZ7d+lRohCr71D303KfgL8l6Wxf0YUgHr6/T6Tsmw1mhyPIkFr0CyRcZrqQ1nEgd0hGWTlztqeMKKJveU9eoEyNAbCty/yaZA497hZMVeBEcBJzKV5cRtO5fYlsi0d5uG92casJBHtG9ShOui3ae7Ot2Mz141UqbUg07A2vXTcjcJ+sN1Ki25nn4qr62u56UQyC3EJXwt/3tOIwGg1Rv0FR7Im9GN7XPODKWF9uUQJ4oj/7jvi4ueYaYLvySfRNneN2tfQXQN3Iydm3bCuBHD15fnNvjooAhgCYHPXdgzHle6jkMLNEGtdmIuECTAuEhI50v9CdqkBywH4tK564RD0mVzPQkn/nYADGix/f+hb1qSKdPtMDounB+N6fDjhGq+j/f5+q3lDLiwj6rmF/tJrbkhOUd8zDiaJiVEQL/jwWhFOA4hcYe97JTfGK1lHybhCgSbGbWBkz/xBu850mQ2AvTWJW5jEabpV6YuqymiYCFu/wpj18EE8V6Y6IyEvzwwPfsaCL2rKkbv2GuqFiTc6BVXWfHMjCZV4+rd/RdN5oeqdz8LwZAU1CKMCCnvTWAWO82CpG4kHIihgJUlhVXqueakM/xjxAnam2HxC36cNLdxMTNoZu+3hCoKS+gXUPa66RYC91bR3FkdXfNjon5lNqoaDIvpnlqxzithnMmso2yMadlvr2zgy6aDMfbMQJoPX3fT5rjLvoDzs4h+7d7FbGGDrgau2vjd8QriU82YNkAQ9CBqb4NZV+mE5Kr4JzvwYLLGTAy76LcGtBdweB/kx8sClVLnNd2+0/ezUH86boliGTYbfdabftVuejSbYs68ZWGABzUX3wsMaS+9mAgbD6CAbtmWXdYQ81OZghKRDQBkyhU7FlpiBZj2TaxmIxtaW50LWFzc2V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAAP0DpyaFILseRZh97ffEvFEuIG2U8etJFThjutM+UVSo3qKe5BeQQUK5d64EaAliD5etKStV0aMYq+mM5DO5igSdJOA0V2oz74ftqRh965RnISId2BSRFVZgek5ZVw/aMxQ8icnmZAbg/rclbQTZyM8F47JMrOieD/rFbPXQ68UC"
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAA/XSZ4JWWr3bbJmG2JSSc/6dltft2umrnRHDHQzOfedO3GP1+KwBuOzy4Tm/Qctgzb/CgEbqGuiGn9SpIONpyxuiZweVtdWGIyHS8OtIZLvmD0FIv/ajlPcvLv6FXtmYWW1+z3ce830vPh4EVfuk0P4jjk2iht+NaCVioXqfuursCdyA2Rss9OzTrZwP0YIVkqPHvx67TJtYVgIjI5t0cJcTTctBCgou7Elfo1V42MbqUkHeudminMwqhFHIpmkbpgQPJyajcUL3IXxxrmmOxlpPF1gtuakfsDgSoDH8581nJNFtOb5VdS0t77b1ZoAH8HL2Cbun4dEVnVgdfkVA4vVNEFCD6WiV73YcEKmx7JdfE+wDs19DENXNStYQXBxgQBgAAAAOyl8fr2Rk2Z0Recq3kJmFygDjtRFvl7gBS1E/te9ZezYu1t32Wm3+0st/0dj1qWImNsCmAVvrWLxKYeeTCQYzkJhAl16breDfRKRVunolXGuQOkDf+y4r+IgNwPxBNCIXnaHimFd+fRYsh4o6o+duzrp5wq6i3YHZ3Q/3ookE//dEdI5lYcgcTq6l5oNRiPJFuF2kOS27uHZ2sAGRNRSdXkdc3LVyAbcrmrd5XnNZSqOZ1+MrpmhXDovBOwzx7ggprC5aqsRlYLIxtvQFNvYFeTEd11in2mfyTVGB7EL26psu175cUTdz/X7F/tNxwCIfN9BYARDu8EWNIiCDzDlfGsiaz6VJ7Dhk0PqqlOuaZ7LGFhkZAMq728ZvqANP/A1h8krv5YzP/S39BHm4nGLaoHM7pICCOKe8A7FcDq4LTvAV80FEWC7UAA7CwfntAWkf5Jy7yF6GTJ268CZWLag2bN/JwI4nv4cSjphr2osXRnKvYS5xPoyI+0dBef3uypbH/YIVhRhDytneMqVsyim5Daq/9Q3BpV3zBbgd9aZeO7T2vUcM/PNT1L4ntwh57PZV8+hTr73iFpBgJZc6CmIimIEtcB84taiGLd2Bn5PbJESa5nnWc+kDKJ4mqEUVbkXMJd9PLVocAY3suuc/5wLdTDHmpvlC/70afrkGip2K4cNRBl14SqoHItqokk9LVl1fG34Tia3dOYuuHy5djwcl15cQGZapXWnEgA4TyqZWqLZt5iazAunx3UTKZpcbQoUNbxhpzZClMbv1AS83eKYRguWMsVjyIxwqQ3oyg8fcEmIvms4rrC6rehK2GIRp8S4PEYZ/e+HLEhkpyCdTEPkRn9aK2/mt0QwIAAAAAAAAAvkBpdOtzXrSNh7jxkj1psSbL6u7/Q9O3SzcRy9Skd4hgcjFQZPtrxQSpnjo/RgsivQhx+YZnO+e19lpxMA6hAQ=="
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "4A59BE98DFBBECEF82542D14363E5B0C87187AF91003A373A893F54494691225",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:yZonS2GXl48/ljpSLQCmJZ+2tqR7/dzTGfux/Vkk3FQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:39LN4BffMQ4UAvyjyYrwpPPdzIOliwH+mObigty9dQQ="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156524055,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA75OnM7M9TILQ3SkKP4Gt0cxdf+engzezh95pFbl/drywZ4KLaf9/LWS56yX40xIEUkQQxRODckn5RLYl7U4KwDGawndfh9MB0XXx1ZGr8h2G7iF4o2tyNJrLQqqLa4qxtvYjJkOv8qrpRKINl5WwMRcqHjdL/mq5wUPuDdfOYqwOrIovFKjkLp5E45b2EljCeR7BfPKOKmJKEhoBzGWyzgpJgz0bB2DuNzgN0MvHqZ6YYST8oK+4NsKE73293tI8VPgO6HREniMZUdyGbfKAawP05yqSAgaLyoulTjPdAVnOJa08edBZGWBpv8cHIuqBcatZ3+fvLsxRBDnV7IaDreoF0ltWnc6U90mzTzov+vvsoH7MV98rvrjriSXmrQQc3HBVHsA236mbenEQJdXK35zDiNHLcbT91Gy25hlUNrp9qvgctQOBe3rfT4ZHUtY2zgyNj+jK+MhrBqVIP4kcIExnRuh/J4nYvg3OROqZUOarwxzKCjTNi1vBKDRuLWnVGauzaFkclaPP0614esLcNGUN2qjM449yyrspxe21D+ZgzWxnOOp0osxeo5p1Qqpopl4j2RAP7Zq+RSw7D8O0mtz4nw/Yu+96QHKAFx+qgi7Yj2C7mtMPJklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSN6hH/ZDzNaJk5rG7HkUBv8KReRuuj1U+6dN+/qaTxKcrBsJWMPxNvgYjSyveq/gPjA2tcYlCG+C0QAZHb5sBA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAA/XSZ4JWWr3bbJmG2JSSc/6dltft2umrnRHDHQzOfedO3GP1+KwBuOzy4Tm/Qctgzb/CgEbqGuiGn9SpIONpyxuiZweVtdWGIyHS8OtIZLvmD0FIv/ajlPcvLv6FXtmYWW1+z3ce830vPh4EVfuk0P4jjk2iht+NaCVioXqfuursCdyA2Rss9OzTrZwP0YIVkqPHvx67TJtYVgIjI5t0cJcTTctBCgou7Elfo1V42MbqUkHeudminMwqhFHIpmkbpgQPJyajcUL3IXxxrmmOxlpPF1gtuakfsDgSoDH8581nJNFtOb5VdS0t77b1ZoAH8HL2Cbun4dEVnVgdfkVA4vVNEFCD6WiV73YcEKmx7JdfE+wDs19DENXNStYQXBxgQBgAAAAOyl8fr2Rk2Z0Recq3kJmFygDjtRFvl7gBS1E/te9ZezYu1t32Wm3+0st/0dj1qWImNsCmAVvrWLxKYeeTCQYzkJhAl16breDfRKRVunolXGuQOkDf+y4r+IgNwPxBNCIXnaHimFd+fRYsh4o6o+duzrp5wq6i3YHZ3Q/3ookE//dEdI5lYcgcTq6l5oNRiPJFuF2kOS27uHZ2sAGRNRSdXkdc3LVyAbcrmrd5XnNZSqOZ1+MrpmhXDovBOwzx7ggprC5aqsRlYLIxtvQFNvYFeTEd11in2mfyTVGB7EL26psu175cUTdz/X7F/tNxwCIfN9BYARDu8EWNIiCDzDlfGsiaz6VJ7Dhk0PqqlOuaZ7LGFhkZAMq728ZvqANP/A1h8krv5YzP/S39BHm4nGLaoHM7pICCOKe8A7FcDq4LTvAV80FEWC7UAA7CwfntAWkf5Jy7yF6GTJ268CZWLag2bN/JwI4nv4cSjphr2osXRnKvYS5xPoyI+0dBef3uypbH/YIVhRhDytneMqVsyim5Daq/9Q3BpV3zBbgd9aZeO7T2vUcM/PNT1L4ntwh57PZV8+hTr73iFpBgJZc6CmIimIEtcB84taiGLd2Bn5PbJESa5nnWc+kDKJ4mqEUVbkXMJd9PLVocAY3suuc/5wLdTDHmpvlC/70afrkGip2K4cNRBl14SqoHItqokk9LVl1fG34Tia3dOYuuHy5djwcl15cQGZapXWnEgA4TyqZWqLZt5iazAunx3UTKZpcbQoUNbxhpzZClMbv1AS83eKYRguWMsVjyIxwqQ3oyg8fcEmIvms4rrC6rehK2GIRp8S4PEYZ/e+HLEhkpyCdTEPkRn9aK2/mt0QwIAAAAAAAAAvkBpdOtzXrSNh7jxkj1psSbL6u7/Q9O3SzcRy9Skd4hgcjFQZPtrxQSpnjo/RgsivQhx+YZnO+e19lpxMA6hAQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts addPendingTransaction should not decrypt notes for accounts that have already seen the transaction": [
+    {
+      "version": 2,
+      "id": "e7b1bcf6-ca71-421a-bc03-90498e9a0d64",
+      "name": "a",
+      "spendingKey": "416bf29900e3eba186ef5a4ae4d18a1302f7c7f41551ca3aed5e13cb6d5f7253",
+      "viewKey": "13f0e5964fd7afcc63d165d628c6234dc69425687f2867f165e43dbe89ebeed5f329c240c313d3659824ceb3f1b00d48b665d00a92ac37feb0182973a1525bc4",
+      "incomingViewKey": "612f6b44eaa3bd7d873bb4a202b63fa1e14044c67f411259e6a4730cc898d707",
+      "outgoingViewKey": "77b1eaf30ef8ca01521b12a314168c2cb377c5295c7c9bd1a2d88ad99fd07ceb",
+      "publicAddress": "ac23ffcfb89e7ea1550f429925fea3eed3c82b1c00cb09f6b70889c78d833d22",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "896b3c01-63ce-4001-ad09-2af8b6b9f7f5",
+      "name": "b",
+      "spendingKey": "3d076ebe24bbaf0f2b2c568fc025019a9db824a33df6e5fb96516ee9faa9c0cf",
+      "viewKey": "6037038416d06a7604f8d71cb854feb177370a23177105bd8be2a775a5a7d625f08aab26d2a12f31f48bd92630b19a86fd56fbbd3c8ba32197f202d8b4bd2de7",
+      "incomingViewKey": "b805a6efc2e5bafb0e8c8966d860d480b613269632a22afe216b47d60f70e707",
+      "outgoingViewKey": "ca5005bb5234a8365b2a8b9599ca776c7881f3cc87c744e67cad54195dd0025f",
+      "publicAddress": "8aa2ede671a1021ab1d7b5bd9df2a5cd2d44d336a0432a73dd04721d3d7eefbf",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+dfv/yTSxtJU3Fe5hZbGhMi9JPURTDk2zHPp7fY6Xj0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:EtlD8ltqeWYyabQ0pk01RAWE1pQcrclxhNt5+Diw5/s="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156524868,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAY45nPLQAsR95NE2rM5UTBPB+R9tk6vCA39L/nlocLtORpGdCK8BXtkNTlgmi+Uxy7ixqlAcrEY6PrJ4SwsHLI3fRva5kHxp7gigmnecBSa6qA1b4xUkaS05FcegSce+LtqlgFHuIRexihPT8tEwkUm0q1RshxdHOtoWi1LhcrNMVev6Yf7QEoPvUhIsWZ+aA1tPdIFU0FsKJS9wu9Mtl6TshxfXn4EYZlh2QCEOBCduKew1Q2Xs5kWFfEp6t05FjvjDxRN4cbxcWaYspPEyqRyfSCJP+cF5Kvp2dsXS4H2t6HOWEfVnF67lIlvkZLcLJUaiNbCNfdwqRgjnFAqK1jLhBFf7+RJSN2VGyGIwSaNK/XY5HOV+7rmpbJxPedz9PzGsVsVMMUVDWqoNwxihgHilxNChV/LXUFa0kP7OLQ0lcEejr6WIr+jTsxN62lZYo9nHM/bpyoBI9SQtq090OQpWtmql4swbhBaN8KiXsAK2J3VZuNsfzbIuWP0kysOzUCiJzIFAxDI2J2XGnweKFBkGvRYNQ9pUtes7RstxdFZW+k4rpO+t8kTjv+6A6NVcISFAlMbN1Ka/BJNkIucSXPW5pNp2cNZMp1EUOqUNKbPfedZqWccAo1Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJ+IlIberqgfsifTe4EiWizAN3MHbiC8ybPKpGirIyBw64urxHJmXhF3AX1MYAeU1H2GRoxSiK+7K922euXBqAg=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAApjaX5dJrRCOenqV6+swlt57HkUH2+z9qAoRC3BIjLhKCY12jSqdXobo5XY/5StlNSzz9rysrVDbTW4R0DY50eYSEZSyEHnto23mdHoEU7JKPkfQ5cppj+YYplWyzzVYBsxMlxso80vCNAMXncUkPrvi5o9aTc9U4aWH57C7QWzwQgb42fVHx35YFunwUY1pjQmkzy/pHPhQSJYTuGrdLAHhVMn6Z+oNHtgLFc+KMNWSqQCO5+NWbuo60cOONzOe6cuHLOAcgUNQVtUOaxBh6nOlgTbLg3oOqGrePwM3MBGPO3yqRz7vSuTg7PgKcUOJnOoUURHPBKvJ8kH0hndQt5vnX7/8k0sbSVNxXuYWWxoTIvST1EUw5Nsxz6e32Ol49BAAAAAofCi0TGbaMS1UjiO+E4k1z4dcl+Vo6iCeDBnaa9+lHxVlEd1idPaFFasbQcZzXaSunDLHzxrFP/MUnhTwKIME8FCnkW3aifkp5rpMyOdScvCu7Mcgwjnxp9mFV2mbFC5KU+65gmcirIUoQJRHzP8CJE4gjh9kuw1mP1MbOt3C+Po1fjmnju+OpAJU5RvkqlIgCmPNh/qup0t8i7GrLXeG5Z4Ub8NW/u5wOHsIqRMTj+iShkeWAtB8fWZdEmvoWOAqL4InmwPs94tzueLxa8vays+5Ja5j2MAbpmfb2M+h/vMjYVBbQaQde5n++8Uv7kofazRJtNoKVyuHhgHfPFn+oNdXC4mvvPcJ9lonY1metFAylk1pjOLXk6uCAf5WSX6xuIjZmBuT9aaby6Xtw13R55LzUOUMUVNVZXQzyXRgM9lmtmJpsn7FOphGSJr7eOVeWGY2X3xn352GJD0AzYwHZmeGdAS4YVmTcgCjV1pnxgubESOSr+zqkACS4q6ttZy4bv4de9e34J/eC7k/YfkAs6A4R+jRE0QT32h/BWf97ox32JQJZciK7R3hG2W152iZqCx45AniErinem7EnaGkFhCLBU/p9WLan7EQrL/JatLv9HscEnI+1IZRLYdy1WNf53jH9XDkx+RZF0VzN6Kh7RXssWNgULdtt2Pc01vSZ7p6i7ioT2C+zhgstAL/aHDNZe2Uokswbw8IKM5xiaU3jldDLWMvzplvUiWrHSKu51cDkOIaKdHgNwNtwjfDQAf8NYlWrr8N+o6+C7921NxgWYxwT4mjcq3FEKTDfPKqONDobNqsUnFeEVS1+R31uf+4yBiGHQK+nEV6xYTk0VLAC4L3J1yq+IWViYzQYg0FOEwvGTtzPmIGJwHGKa5QSpNLIOqPwc3DdFZbJarePdQpzdW3b3a3Nqco4p0nJ9gEeHujC4WEOzXAGzrT16lpwDR/vX3YAXg1NtjicR4h9csqxWMJkGdwGyh9QviSJ4Q/m0CCrM4o64CK2RJu46dGieMdwPd+/LgEr74VQSkdpiQHN0x/KKQve/drtjxogWEniTjxVJps+Sc5PgM7jL+HuasEbDow2lFcLeH9zaTORqLsbHLhuluS4ieLQqkxQybc0qDhJdHOikaqdJgVOVUVnRAb/nLsz0/ggvGQ8ycNPXvIssvNLtGInNVr33k95JJ2iBQxYsjzO9jFS3nAIhMdIObJwWMuaowYhRSDP4JGM/2MSjuc+FmFBcW3jkvwui8JsvC2gS4STvoUutsrFmep5Pvuztbrw80ZO/OClCnm44qazwphl8kfDclDEElVNXDyzvZ5ZslvuP1+Uz+EAYnpDwwSQULTppLczSc61RbjwyPo1neOF1t0QaKH2bPkgrQtlmCK6ImhfXIlBTzPPJg+zNlvR6UkSU1YF14/XNE3Pnf2w+ouzYRKcuHCYDzmWSN1gvlpfFlBGxagALKQwpRnK/TvDCsF6vmElb8KHsZr2WK9XaCWko9UuQOBVd+EFYrp4qJ5PbZYUuZnOp6vmQQgh2SEqYwC2R4JLXPhJAvio3OUSkxF2ECGvjG7toFyjn/3jTRGJxxr58j/xoPSYmjPRBg=="
+    }
+  ],
+  "Accounts addPendingTransaction should add transactions if an account spent a note but did not receive change": [
+    {
+      "version": 2,
+      "id": "2bfe6bfa-aa6e-4093-8fb2-9b1f814478d5",
+      "name": "a",
+      "spendingKey": "8a216456861596f363964fa076a00c430e3f18f5d4e30384eb1b88716f867517",
+      "viewKey": "274dcf5fb03e3c12eb362e48bd8701e3164d8d6810d483119540be379b9a93378440138bf81ea9584d319fd2d87dd6dc0bbc0775e25033e46f5b76b9dfddac4a",
+      "incomingViewKey": "d11de7dfe4018f01ede951ebe31c3cae0314a92b9ac8dd731586621a4b5f9d06",
+      "outgoingViewKey": "3da96c8ea5613c0b69d379df3b3f73fe435bb0dd7d3010eb0d87921e78a50989",
+      "publicAddress": "d770ecd1fe593f120900778f93b946f4bf4fe76da66005dc0b8f8a98a572761c",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "2fe582ff-0a66-4c82-ac0f-acdc1130a979",
+      "name": "b",
+      "spendingKey": "7461bd6b498f184d16dba12fd3b379b25ae874fc045c94509414d0e9aca2f399",
+      "viewKey": "3418b94153aaee375eec637a3e5f639f48da552cc332eb2fe4efffc3a6e4fccda8272fccb78b62f173bc244d453b2f38889fd447906bc2ac1f3a442e657eef21",
+      "incomingViewKey": "c56beab3da099498ebd6b84d8789c26584b351039bd198f635f78ba903f76304",
+      "outgoingViewKey": "2f3f824004f26f336cafdc33ad22326e8840e5052d358b93b67a29779f9fec48",
+      "publicAddress": "4132c66536232e6b8abeadfbf55768e89bc873965438ae06b2ddb648b7ce1249",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:BBkPeTMjYJT5F+6VtxSMew4mmJmyjaU3p8NmiJfRyRM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:noA8IFlUnTm/RRyC0B5R/+lCYutGu39z5/sae3VOU08="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156527692,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAASc6U72W3Jnqs+DNu3bOQ2LzlPY03B34oyL+5QruZKR+ijUQpdrsNjNZjbSG6yka3cGWahaQBKa1sHDIGbSj++jxleYUqT2a9VHCr7y/sQZCHUWKzPqTXYfV27HQJbQ14FWb3I0RBMNIR4y1BUzr5u7LMagDyURdNpCK7Abdkad0Bhz5+3/BsrKTSvnDg0AW/fL/rOfCzwEYUh1BUwGIs+ayu5amAvYESLU4kXeNzFnm5L0UJ2yLYbAaq5DQCvYCEOS94fVWdDGKwNnX1tXhDnmzoeWKmKTGQ0A8HSe12vIynODQ5fBNa2zKydrraFC1IPPVM2HOCFA+WEBxGqYS911zhdnCIh3ne+yePK0kZvlsaE/jG2WZ5JzplVu9iJ5VD7FOAX8NMKhsTS/M97ssaQRC9ae/6cmbZcqUD1Ge8C+PGSWT0Yo8Co7Flt9lZVJ9+jspkp8O2U9hXYKcuGQesLGHa959b6g3HY+SgwRCZr7vCk4qw/T70GNmJMPekvbs+VtLB4pyATKHdAe2+LuzY2hH2zfKQFYeEnUDHwKnXVGimCYxXCB75Km+QWyEeT9ys2yXaBM9TqMfTvJHsYbxnXKcGo1S7+3zIuSpRwSCLJyVfiWscqSp6XUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwlaipJMcTDkBHti8XTRlHCJN3lfXgC39T0RyceH2RlCbq0JpOhroghpTIrCeJBso2aMLj8KselQqm27JO6EmjCg=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/5M1dwAAAAAAAAAA1RM3U33cTCQqR1ikyEp8goegBJF6AmPVCTx+1VIaIYqEl1rRtUFKc06jlTGmAip8AXS3qY9TjDDTDAYp+3AKSjOOdqio8L0GLIf5DokTfU+XuK12tdTopu1elKXicyaaNTW+2XJyKqdc+dw3vJMPBdHRb5cpyGZrKrN2Y7RacFYWSvyUK9gQVuP97sMocQYXW2IU8S6g0XIotqO6iJJbMp2sP+gifdc9hXhN+fYssaOmEGJuRh7P8VGsB7YGlwx8sDCLAPmrpZ3IPc2HQyHV542hwA/bk4UYC+rxR/Ij7RSnOUPMQvSJk8atYwEM4IDeRL3aQSKknRktkxbhI0g3jQQZD3kzI2CU+RfulbcUjHsOJpiZso2lN6fDZoiX0ckTBAAAALBCoL3d7jk52CTJFQLbsoMdcbYP+lRudGwAu4vlxMl5rpNFN2J/GMMPzMnfe+QsXVSyn+SvJcJQnbSufBJK3FObPeQnBcmdw2MYrj2MTdJjG22lIEqQXCUvn1D5lPMlB69DYupOvR315SXYgKXYiwdqMhrEfplDRT+KJX6XZYzq104SWaLi1Y+RqYoHMWllkrdqWqGMqgeJe1VgfswEP1Wmd8m02g7VS8OuDTyFzJbfQ7NN2tJu4sB5vj5Z7xrQjgjFROAxhPVrfNQN/FhKaTaPR6iBM6MQV1izjevCfZgItdI9045G6+916Z+q1R8DwZTUE90e7igH6XPOlltHnZI9Z3kOTYMoph5Okv8NpnGSSRJgtuRtWizWiMfGCpQy4YusBAxHCZl11MBxaKjAbBAnWSQoOuODARir2n1LMLjI3/nF6YDOiUsZkIhgetsH9ki52fWOo3v2lqZ6mVfVOzT5qzth1/YjMmt0VOxCR0xg9GaqeYhczmlbcIAzj/XmDyY9m0dq6tkJJlCCmtVcM97/2cc8gYRgjnWV2wgVIjLUauX67leDTRfJjfbv5ilt+0/VGRROm+BCnPsqFvJXUXh0+bE9J/61foU1c7xvszyzGaTQLCdYe5vvy3IBweZR4Or3JG7GO8Kf5KrAsfw3tazSnenzfLoN/Kxr8+NW/cMITg2FkEFQA5HfqF4+E8uk7cHk28NuiOT4HyQIss7AEsH/vCXDbQ3RNM5PXpAhS0S6bTa+qBhZxz6uyF19x60Vq1u9F3vCUc66DeU4xlsL0RavkMVn2E5kfe9OG75qYV42ZC8f12+QdlGFEKDE/vzE/c4h7kvXtVjZj+pJjkRIpwUv6nmH0/QA5BTCVLxK8JjA0uBnU3AREfMlalUhJlMrJDdi1CMTzBQF"
+    }
+  ],
+  "Accounts connectBlock should add transactions to the walletDb with blockHash and sequence set": [
+    {
+      "version": 2,
+      "id": "1a89759b-be0b-4ab5-abcc-3533e81b9cd6",
+      "name": "a",
+      "spendingKey": "97e7308f9722d4b441801fd863ce879a0b396fa9404a4cf483bf0671bd5ae570",
+      "viewKey": "a3bf586cc4c5f4f2813352ae4a2530a6687ac6dced031aa981f1b77b54142cb6d05cfe5d35755d46419871f410269745557540c13e49dd06951789c6f1a5f61b",
+      "incomingViewKey": "3aa4f936709cb5f5a63ffa8a2a4e2dcf29e2ebf8c543f9cbff6d81d257647206",
+      "outgoingViewKey": "19e71c5c2460198e75ebafde2462bf19a8c4fab8b85a978e77ba5d6d95a5f9f1",
+      "publicAddress": "e2cd422e972552ce0441e19ca5ec067df1f70e0015cccc5da17df8ad59bbbccd",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "c1dd8938-6bf2-4894-9c00-1f16fa4f27f6",
+      "name": "b",
+      "spendingKey": "32e24634154118911897965656badb469a1b7eaac806271b2424de3f81e26ed3",
+      "viewKey": "56476e7266e3824dd9e94b78cb5477271acda8ccedd740654e353d505ccbe96793b1413b6a1de4b3ae13f3f797ec60c06a9d8e66ded2749c57b7b7ea9212412e",
+      "incomingViewKey": "12a08edb34fc01e759be16105e770915347f9aedd1a454b6d36a9d025b12e203",
+      "outgoingViewKey": "ba3c1331223ff701f7a83949624c3d64b02f955cc13f756d1cc424e243cfba9d",
+      "publicAddress": "e6166afda43eb9e7014bc486a8ffd0c6257ae9382b85219119834134c661cd3c",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:QyndEsBXHPQSvsr9pd7Abh0mEegINuwjfb4kb6tGFik="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:KDWP4jFP1o04vZUmwMyvtsdozCLDA9PdxNZMtx9RCEI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156530055,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAnvxYJTXattl2Z9SnaWK6Ndw8CvmtA73yzlvyehJnTYygHSYqH296w96swXqCGflrxSYFTvu3kh8vl5yoovZRSn1hz+FxbsJanxTJrbW6Hg6w3+sWxB3CNFEo6ZBkHRv5XykAkMLykvFTNGSkRFfO3f67R+DGacSCrGTqQCqCAYcWjXdMfZUVMCEaJ2riJRzduJke6X64euBX1spa70QsjusnNKaMp3kJd3J5sUYIXHuiQXGdK4RkaPbjZk9/hJU//uQ/F6R4KmwIjqQUoF7UHB3BB+vlMXQ0ppQaD5GNtU15STPDq52lJUHkV4DY9x+CvynWFDJPbAuL/OM/PjUqJhWpm5WmjAn+B6WDkXzUp0WOMNmSFoTSC8sCqfhRdNIIvuyiiQhH9/iv0NmC+G0alaBzMQIfzXtFuh0j/zQ0s7xGJNiImBaxgQ4jULVOgX4L6Fhcq+iML1Ey84rPsA98Wg/oTHZPmLIMkzNYE6cc+UlAFjwQq3QUjLJjyPAe5xANNhxiqid973UZDWw2Vu4uD5ygjba8CQvrDOVfOh/I5UmlVrZT0Bs8B32o6Cb07xuO0vWEJWumBH7T5P9YRZ8ScEL2N/9WupOZxjDND/vQB9pVif8dfCfnzklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwOSiCXha7hQjMc+1ebJ1F+636sDwUOz7i+VQhE4FWjJCW2ge8onwx/yQnOE+Df233lWi67Ad0j61cA4ck6OlgCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "D585C7E869734B99790A4FA64F7E25A7159617DE0B5A8363D3C492D3FFEFD2E7",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:48F0MEtLzO9R4MyXB0H8QtGhpn4Yl4zIdAK5YD8X11o="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:y3yxL8oAQFl0apDr3ASOg9fw1g2hG1kGE/VjB6pGo1k="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156530556,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAACemZUeL0lJqBo3pXgcUdUkkib7DVGTCGzg+xnu+tTtmAxoXWI8BsFUuM5eDJHv/JCvIgoirj/FzbYfEgcqoyGhstEUW0NI0MwgFEsHGW1IWmCsnEXxvbx1Jw2PkRAhJvAAz3iRgC86aKBOLQy5fwqfwKgPyo8TLMhfMA5QzK06wSW9trxRpCqUp3+raOkfm7+K7TGjvYDWTM1/BvgRSYMYtaz+cgdc3O16eDkcUGtNOFY1xqznbQh5/QcD5ewOWzEe4euZhfg01PqkLu+wE7AVJDml6Lm1g3j+5mRbYvZ6tAtBbGTQ79Yv49/xaqIh+Uz0xB3VkhHBb1+u2tor4U5MVhwLPUE5UluzKrXR7vDlZ+94UvZvSiVtkldNbR8YoSnIVQpKCbFI4Fv0+NrEJzDGrsqmYbp6D/qoXfEuKKsAyS0/+P8Ex1TlQ/5GznH1T3v4+HisVlwCpddiY7DYoC6JVbVcot2gT7jZcKW/CEkCEJ1Y6X0aj7Z8wX2NNZSUf/9aP8wnIe0kglx8he+T4noUHinMatWM9tMR8OV7G697uB1lxRwiT/gTviA+P01lqpSa36Ht9yOjXKOPDZRGqOz+iay63IjFG2HsA3vPUSGIUibapztn545Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwL1PO746EKSb9sCK9FSR+WNVua9kOrm2cQWfYSN650xGuF2gzxOwvQt1vcBYksYhM1IHfAJEEHU89dU0vpXweDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "780CAB654A1299F19F1CDEA710162986C68E1C03D5DC7EC72AD99E52239655AA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:W0kcOnMIw7QzZ3SCjo9KcTuyLxXlvi/Fp2/u0KETShs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Z57dhmJCfVRY4KUlI1v5EkQSFCsFAcTp71lkAbeMAyE="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156533037,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAjBzcW2EEfQix9sbkgP68H0fDbIRwtLmv4Ths/8Elem64PU9orIGWnISjt3Q0J8/gUU1H2ox0AYJy3U8F8pb6k6KoiFQ08bjELGlPaRciYLuMeQC00V8BZ+g8Gu11rWrcy4WognOReeXJZfrGr2ab2y/h4vyHNoH4ztzdVi/kE3sWJEGqr4gqFOeX1Tooj1kPStSHb0aa8LGr2pQmJjlh8pb4w4TPB2re9/GISnkDIz60mTJhqlCY2vDWVdczJLINw8Ze5HziJxujAjs3VpGJraGYeihRd/qs6GsC3MdceSDhRGw1oUvuCZzjsir5vTfcBDSJ9kaVma8d6V+2PYzDW3+b5fJjAErO4UTUkj4Kj3ibdU8y11vbC/fcIerSr70tLMQEpNlDUPjqYVacipXJTU/EGWm29IDpPYVPHa61WzsyJJ+5J1X03ViyTQVf6BJRmu6WgKg8g99o1gahe42ZCJRWcgGBKNbFyQyZvcStA7jAmwDA8FrtuWk14PUT3tR2VXIwzFzEzPnWpQiDSD4zYUNqy7H6FZ9eva7R5T1OivwTpeYMGaYSTYsJrCkLyts/xUQkcojbCpZTI+/M4sDHoZzzxTpTP6aUnKwgs10oNsn3PIVmAb2zc0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZ9MvLGVT3tP9APwuY8z1elgIVcvht6me5zndDjt0vodf7aTx3REd2kZSNFalwIS/cHUOfbsmBp7BgG4zcQ1oDg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA3dEBF8VjErNbKVkVurWm/6rXtSUnXFoQ2yo/YWrEBx6ufcSLtZscnXIo5QFxpHpaZEebTDdnWfsVYGtiWMHdtd7A3PiySU8i/OrRX/HJdwygMt1K4taLLt+fSIkQmiuuuRMwOWFRtq4ubhdFqPEVK6vspt6HYJvRNQAAuF1w89YFLMw4rNjVdAQqvrgnlYQ+78XOlR6OAweP9VaEsCck3YWIZSb06ZLWULxkdQiElkysVU1sOnMrNAxXu88RnDTgC4719qTjrsaFKsPdOsa1fUGULv0If3uEYOht+z2jxmVsHlC3skEfdCvLWZAqKu46psAw/vXJuDAkDAlcZ4V8lOPBdDBLS8zvUeDMlwdB/ELRoaZ+GJeMyHQCuWA/F9daBQAAABuEEUisxW+l+iKAN/rWQ1WY1eKIq+fEEqMtN/TCfoCNB6iLCVcyM/P+mdWX29eb0ov6Y/PfVA8Xzn2+LKUNAzh8z8OHq0uRdztBEr+NK4ffwz39zATQRfZlikOIa62KAoQmZLP6eM2EbQzLV34SFbSN0BGeoTItcayx6usbkwto4n71Cgsewex6GkgNbCM18qEFFZVa7hvkV55kVrGgWFqVs3H+sMrt7BuO1YIYsndl35rboTNvnLhjLQp7L2+PihcRICrSOwNOugGq8+d42G/ERA0cRlULtajTHdJUeKBNJajHs5W/OvFRHbmHZpiG0qoY1aJVehQI92kChOGJc0EeEoNCGJA/orFxJwlMt4boljxkKYClvP4abIWeCLYFdfehCA8iMI4yJv8hniFYUXuTErs4U0cdM9AqDa9s75QM2Ugo9XjVrOaiYgYj+A9y7viIN88G9xJa2VLkQrUmDG/QWfkvZmtA3cIXtHuRHJQeNBt0C+OeP0ikqX92d2DA1cSCwwSt4i9t//G7VZsqzQXY4FEYoeacDdSixAkA17kt5xUeMCwEuxa2CJhiH/3IpeQ05lp1cuNivXJpdIDsbs6E0NN/GzbyUcH8SuM6f4a4s4zLjTS0yH/JxfX5io5yrr9I56PskXpTNo0uGRl8kcN0+j2/13RMItBgUCajliEyIfGgat34xSmmt7VmOrMEGXEtzeTGsEcDKqicgUX9mqE0FtmQ8gMVZhNHDb0YqxgbmI+7lwuJcMWUv71n8Iz5+p7m7Tusl/AqNeKbnrLsskxzm1gT3agWBe7u3BuHZ1ykfHWYMxVfDBuJBwlOmNHOAz01QYUly5FcDbGM8eKYOCiS0siSoNiK6VCpmJPC69002wWCKXyTuLSz2KWWlXfanT0Dnw3DbQG9ttiyEitrdX72AklpCdbQNTroozC/WonHoIERWS29RFIHfMIz7lOi2FF9OjTMuZghCX8NrYPQIvOqs5VtIYwiREVTU9bMwSCzowInVO+J0OCRoJ3keZJXxckAW0EYfgBm/9UGfzx9NuC1IeDWr+nltxj0VetsIGNNMvBLUf4evdqoMeUBG+zeUDijKNiX4caJbX/7z2beMKoy15LwGyJts+8iDGIOcRrOEyDjV2DAxSwCOzzxRKiW6ww9+791J54qVae9VJKXA8G4QiOzhpmsgvOxj/Q4u6b5KPgsSLzQKI2OF2P8wfe+wvsRNKbJWCyziiJSr9mLYrDf1lzJBZVVLzKh7zWy0oY1VTJWV/FW/FREe15V1VnAOAn/mDcvHCLpb6NUaPCAS5Ihj+Y3dPPrS23tzqUvYYyY1YtiZ0xpq3rwy2viSJWaWP+ft40YS9lXbHOJxMruGcPDUvK/N8oDKGHTJVqihh/bLNVyVF+AqyS7c0GGex33zEElqv0kmWAL7ysIBV7cdi4hEf3qEojEBmxipQUf4gFC7Z/v1EW6pQV1Ny2RpiwHrWDLOQr1TceLXmAJaGlHs/O7xSDnzPGF+pbesBcK2QEWnyTypSixaxExExMn6mCCsqpbwwwA/7CJCIUcqLQ/W6Ucro9Z9tj5hPWUgDALdouvP/UXAaGE3/W5iRNQZ1nmAQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should update the account head hash": [
+    {
+      "version": 2,
+      "id": "8f7f822e-ae8c-4470-8db0-aced73185bda",
+      "name": "a",
+      "spendingKey": "4e66c0bb55f3aef3ec1ae84b8ca9676d3da34e5e1bd9bfe6cee15f72b6d7f8e8",
+      "viewKey": "38f3963f3727158504ada607d3d015cb0f25c0c2e5975b787cf9d618743d6b4a1a5063b1349e9cd597d1308c71c3ce3c2aab315faae36ed6e55d7a2a48c2cc6e",
+      "incomingViewKey": "128dd695c638da2472da6fdc48f7c4460e1823e4ab1614bd124537f81ae15005",
+      "outgoingViewKey": "d46be3cd4895a31a99a0f9408b6a6507c91247628aa93fa6988eb05d0e5b3d26",
+      "publicAddress": "cc20ca27d4abda7c863a130470d436fe983e49223e9969b48770457f029bfb2d",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "db7499f2-30bd-445b-b667-8cd77ef97a0f",
+      "name": "b",
+      "spendingKey": "61e5643cd15733ae3ded9d8c6a26b0d789227003ae68ecb44ffc7e6e2b73c19f",
+      "viewKey": "bf90a1fa24f966a14ce4d343875eb5c4a0bc5f4e74ee9b4782bcae31ae279a2a74291a2dd2a576bbd48b1d552eb30d7ab2f669e5aca593adc43991f358a995b9",
+      "incomingViewKey": "ff7cf3a8b14c7a4d759151d9b8f879f383596d6cf3a58c60d44590f47d988005",
+      "outgoingViewKey": "45b7bd0bceabe7c7d661c2d5535a4013a4459b49d761bc7900d1d76d5676f7ec",
+      "publicAddress": "26c3e207850e707342ba630abfa0a392a9aad142c0229cc21c99c08b95ef9ccc",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:UoZNQ5KkrdQFIUnClMN95HLX/TM9BLOVIZqXAwqSoiU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:FiLLKecNptcRvIQSWb0w5kzoyi1NNWcWfcsE0B99ezk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156533845,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAwFvnCFzweZRwF50PHAWz+UQwXDfk+VT9MkX5s49SUNKxulxQQ2ZnoA0El8S4fPRPEz/2K2wER8horY7pBq7QIEL+fa2Q7YmTjldhZ6bv10SFGBNghOq/z1AAhKkhVMiOeLNW6bGPDpkJexYR0VjrXRub412tiOfQBV97jj6solUXAmK3S7BAsMfZFbV8cgVNYpDgry+jrpUwIcIBrcD2pJbaKZljYf53gA5Lm42iBUGZ9gE+lSMI3LjodBQamia7Dj5uhiEU4wxmJku9ooI2qW9aktVYBjrYfhJdBXd0zL84LNBQPjU8ROfUdkiv72qLmtEBDfQVl3teZbQ2TKYtSzqs9StBhgI/qy5MyOBV2LUde4u9gbZXi5NHmVcdE4sdOJW5Mh57HhgDkhv7wx3tj7LxFtCvXLriNKD1vyE1cLweMzUwqW6DpzeQ4tEVVZ5BGmdSTXu+cLohB9tUYOZwGoRLVL1Zwt4IOhhx89fMFHsyDD8Yf4StO8R5WWH/x8mr2SwDVqkwclHjxD8MW3fHE+M8a1muGMYtkFuQ/gY9KoptwVA7blIxItiDNA8I/WLEwlO7Wg0u8o71f46keweyMikud/p18Sw9dQDmWETBK2dBglqEanXq5Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwVm2eovqNZwytrlLrDicQ92A9xmNnB6IUea7v7/mMOsoyqynzcX9iFk+3C+87A/xmoYfeyM81In/IFUJFf+EjBQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "0495D184CCD0BFF9453D26964BABADCA1FFB1143154E774B640C3C9E56D5EF97",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:QCbenrs42WaXoVgUE4xoRHpVkRvw2DkpsZhVD2ZmNC8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ow+8XixbRgjgKLve0qaZBTIGPWeOyLutvJbGuX/4jh8="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156534348,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgtMP/LvAzmyH48U99sKrfiRIXApcOI8n6T6iSAaP8CWnSLOOjGVT8gNLnz9U+/kCU1xKQdkVykJ66iRyRLv2vG1O83mp5kRLiU7ytm62bRyFMcsRwtbRzv7igXKONjtW/l3Q4jpuRMuvRcwAY2usfIhqWpxQ6/QD3/rJ8pPlbU8XhIo1IJmoNEYSIRo/sMjt4P0KO5eL3Ac908MEEGixIXz9zd/6NGT8TTMM+IKWHFmCwoH7+HEy6ZhRJdLSshdcipHjjKPi10+Zj9ZHwC1Din0iMjuA91JGGC1xIev4oVTrKEhIN88l9/YHUfTQz97OMo06bu4bHULKQlEbDr1nKzoS6kTRZhwQAvKvjv0kB2tgmMS8R81AyGXld0S1W9ZHF4Grvap+1GdY94gc7L2yvVx4Q7PFLWeKnYwm0P3aEODerpKP8TuLBlQoMX5g5oQ1trNCS/6e1ciG9Gd9oQQpiWzUEN1MeX5jB5P7/f2HrX3vuRRAGw4dJPdgLGpXX9zv+3StDUSMC5qFcbg1UHt4OUz6uf72vXhbgzvcg5lSeHYmHrjHbAei9JNE9tVX0qIt9mxMQNJn4fO7k8e/Na39eA5ApU+K5i6GjIqGpDbGzaUu2CeJOb7iyElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw54UxbJJV3nSTObnAdhZWmElHGqDtpfIQtncb1jBsRZqDYA75zewNVt/p9rcIFR/weUlbwcUh/ArPknKmhVx3DA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "622F96111B90CC674D5B5A0B923FC92E147830B65B301B1CC9761FE8F5859725",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:f2sF9a0xaO6IyHhcKZb4JWOvFmY1Mi3RwfI3syneTVE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:R4t/aEE+Wswf33ZKWhaEVSe63DMwLL/J8Mq0TX+KlPA="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156536832,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAANjUlhZhoqnY1xMOCYc0xNkMb5EyNrwKfhTJrZHWa4SevDIHhJmbx3P/dsqxYsI5FT4GkQVATCE3XrSQ6YLJUASo9R7f4nNGoO9Ti7W4FgemOt4XykxnF65xAapDn72FE18Dc2Dn7bBQ8Yp+4V8OdZGAn8bSx9FHATwTlXTkRrWwSIcuxvV2ll65/IqOHqVnCM/+TpPesMhkOl0+WBDo3/p3UBZfCMTcR3Yy2I0uBAtitL1CtcK/NOtEA9mODYMdv+tShq5aT3wVCOjZTBzLhZHWUVbso9IWRT2wAFNz2MAo1SbJoNGbVF21arakCoYP3bKOnR89Sgog/6hl/3rMrjK+71aSEnGyTgoUkY1lE/DeNbRTb7Kjs3c59TOtLwGNU/c/9kBDrRoFxXLKGB6Hc3PG1OOxzrZl5jlPXKkIyw5AWrC/N1p+82Ir0nJS83W9E7Yt49D1kNlWt0I1mfHsxvsNcUbWI2xCA00o5IAkarSW9vMJopGH36qVP4AVdbmonbS1YQRpEkMORguY43twfMnvEb5g87wdfcxYXfX/Smz4l8BbM0GU/HxxZPQIOq1YP5gI4PiTirnFlVN+OrN46cFHdFkF8jYwCkr4VcHpNi1yKchU7KLbf6Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwYx1D2PrzJtLmC3HMR5GoP+N9WIy1xTFqctNuHWqJ9bCqVdRSyiMXtOY2KsOEcH9dXRQ5tm7eBZ8IYSEgkfkPAQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAApm/UdmItiiImWz/0cPvvBwoo9/HTGHR6NQR3JNKgbK+tzI0va0TcBnVkHCYo6m0wxAiUeE2Mr9Q/afSfKUf9koqeKIN5ou08fsrrlD3EbkmQ0bslwyeor9YFYfPW2VB5Surv3TN/d4a+g5wUFdZI0b2fjZwzUv9TNMa3CZ6j99QURQ/PPdGZ/J/u+n6GTNeCO8fMh74NQZTdGmiSfleVyUEt1RIRJWpiyk6GAJNnskuQrsw0yGB6RpjT3P0wBf8yHgURH7bnBWTXjgWTWevEhMJ77R3cumkNTG/WfYDMt3BoLtHBhywc2o8Kt6bmlBH15drbSFOpLlcn9lTrbTRd0EAm3p67ONlml6FYFBOMaER6VZEb8Ng5KbGYVQ9mZjQvBQAAAGUdhGScEt7P9NzkuPMVMYCCemAGdmKUqMs/h4otoNjT6Z4SZw+VMa2bL0YGNzOA6mnWigTkK7HKzkM/PcK6u9eJ1C0z6zta4YfGjafzjaYsyweneweVQG4WjuTckTYpDbFrpoWAr8V0+uYhcPQz+Svym/AwwEyPmPNyzS8HbNTXkjYSPw/XRZEVams+5J0YWbO90SMIG7iW/r/N/LS5JD1IBhpWT1JTB66kpFRKXLFoRyPDNq9Oc2wPqr09i1iDCw7pe7jdC7EhcEy10XyLL6Nof/NgtPPYSTWM/Hwi07LLBbU0+5Ny2DcTPaYh9SBE2rMwSdDcU7Gl87dATyBl/FMIHXR8Zwoev5mNZpIS99Bz5Soo8d634aaYQwA/TDnYLmq7wVvLITYrngheec07Z7IreczTcO5/cQKdLN1L/CmSp2ef52TXvlXOjBQneqNEM2nPu7s37KbQgCzgB5BW/GSPXMqhYozv9bfAVPLW+x23PIUyulXki0EjI7FjnUFAshkN7ldi2XDmH6FMBw06dzA17ZYr8hoURa7k03KOzUJQZ2n1NFsUhjXu1vNQsi2pNue3d8290Dfmnr3IVcT7V321Jgy6qdM7K3gsrDDZExAbQFHZ19PzbfjLt8KianvYkMmqODzVgEBqhUAc5+OAeljJtIo1mfDpGRpI/Qd1jDUZOyXq2hQ2z58Iu3OgOmVSBm3QrzY2M5w3Z1g/65v9+NjsXnub3VaTjvjwAoHFNGJiWLTlhIzJ1iN43oB8PcRQzOKj+LiCxSbYtKpsN1XwjmvoNdKEeCUpMM7vQt8y2Idq5x6yUyUMr2ekwI2Jv8yz5RC6RNqyAT8I4qF5SpGFToMq7HA0tMcNtYUvu1mR/WV6orQb6zN9jvGo6mcEUq5xrIISr7FoGrxBZtTyM3doLjXS4qHq28y/ofHKbytJpnx9P2BmxtczXPsTJEehZMb0U9OUfmRH0SKghgQfg7G0i1tltbyviZXI63t291JNUa9MSQ9izYRcxfyLfLaBBwT8oQmUB5lp4nIdjkowSvirUzrM/WuraMwPI+x+pkWHtzBFYJ50V6huj2v+EFIARhz8C6Gl4a9HbKsG55bG1YiPbSN9W0/UcRSCK7Z33xCrrP5LHIghmMhZMyPevv4RZQ1RdrOLCnHXNb4/NtIuhbVCXh4dUOpZKx5v9oBuQXNHeLuqCz0GIARP2NxHmIH0zM0Gxmyd7X+m7htuQWxfh3bO/vJKFwwBmCR+zC/NrZ4X1HnamQD3UJ8Uu6zn/oO0uaUfoztQnIS0UzScZVXSl2VkL2ZUa+Aewq5wyE1jilWtgYhZ/aZgamVEULB8tBY1kFZ0WNAF0/s5EJ+iu037ua/rYzCkCTkBKem/7O6lvtRaE6tKSOnj9xtOwH38v5mjR4T4yezM4krP3pzGNzxPaCieH7OTNDdYsnz7ljcz/JBWN9mM/ZdShidtorvOH2iq8L8NsdeD6x6sjiW9Ef2gUa6u8Q9hXfwiGhxM5XbcqXvw01MMWUjUvsnjG3FHS/lHGMe5cAL1AtBaodZfy6V6vxbb0YrV8cNDArSQ49tASFb0ljyc5A/4rJ7GWPSV2C1H5qz4BA=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should update the account unconfirmed balance": [
+    {
+      "version": 2,
+      "id": "fe9517bc-d581-4dee-8823-8b4a9453fb57",
+      "name": "a",
+      "spendingKey": "5bf1d7e81a51bb708eb806f6ae07c5cd6c8834cc8c0fbfe356caf43eed0a3c1d",
+      "viewKey": "25fa935a59a3def9039ada42c99c6b614451f7e64cccaf28086432aefcf9e5d240935da70a5258d15a2375ab121066d88b17bc3aba37dcd1b4f6b8702c8a841b",
+      "incomingViewKey": "f4c6e7917fbe4bf3b2ca5d9cc43f10088c75453d91b6f3a78450e5a0e990a601",
+      "outgoingViewKey": "862446706363ecb05dc3a3b2b2a0a1db5af57a58795d6bcc7da418a8251eb984",
+      "publicAddress": "5d23c2fcaf740d26b7d719bb0471121784df4a9a529c22af79d2f8ea0aef6e35",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "65f675a3-53c2-4ed7-ab16-16a442f720e5",
+      "name": "b",
+      "spendingKey": "ad439d6f502568744494a29329d24fc7b655a56c28e0c9da9a52bd4ee1812ead",
+      "viewKey": "740b9275be04194b6a7287e4258fc9e749559755422cba34eeaf349a37e711f365122d0040bb0c86d5fb2f0c9e416f310235074e3c4aee619c44dac3439ae9e1",
+      "incomingViewKey": "8a7915c8b877d24ee93c9a611cc6f39b34026b1438ba0921090e3aafef628405",
+      "outgoingViewKey": "db7c285b811c346e8ee94faef4fa83f99f812fe8b60fb953d27a32e2313f963f",
+      "publicAddress": "f865f5fbfc6331b7e91f2f0ee3a6c202dfe6907af5caecd4c777de3368987086",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:pJYN2zoqmCd56TDoqleFskKQpiKeAzHTz67ownYuRE8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:eqjsfvPEMFaVE3h33w1IPsI2XJS1llP3xUNv+fLeW+E="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156537653,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAkN+D0R2csuwkb13++CvyRNfJflwHrK8cibb42hD4mmqwSteticn1U1L6/quHPNeudEIxoiWmbmaX4D00X76VenMcwJwmzGpUgJFPCd3ms3eo9BUhQmhhTgdsipayognFUnQux9QljP2EkBY6YlaghBAOwgk0w5ZUtR6R7uMB67wZnPgfIaUhdTfKrgOo9bCKHgxPpS40JAcELUod0SttrnI1NaK9qw5/BlnBcSP6NXyCbAnm8NK7XlL2KgjdDMOkcrh1CLnWKghxuO48GICTCiDd6rZGx+ZGvdT60nNoEFXda6pjx/EKvDdaK6jWEmT7vSsxAIGnPHnWwv69GTOvb2TubtuQxo7jLnS2svMVnjRuTOTr+aRlCZey6oQHILwNAo4lX2dUS0zVaEBOhGQ+Xrjl38/dGzqaxSr6ooQ8Az906zvMPhrtRhZVUUW3sRALoKSIVegyDyH3zWjTeYOLvVs/izy9YB6iNe361JUQhX0F+YGtGPQHRW13HNlh0CoYnKykKkx6CsBKfZdiFelHQB2Omx6gEi9X6FFz003rKTEbNz4eRfP48bwj9K5VmbZhRwAE//j/5jWfBNcT9LWi+CRE1uB/or66vx9n0NIpUicTOHXnhPbr0Ulyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwRDWEx6q+o5djTo2eaUP7knJaTTdKMjFMtB6iF0gNU+qkNklQ7Xw4b4ByHjaSMrIXMB4W5hGsi4QToRPd7pkvCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "204685458A1095BB0DBDC268F7E8B87172873EB06837A155DC1F254D931C3845",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:HI8L4Pl+EEq3xGU//WuJ7F4UVPauTqQJo614Cqxzk0U="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:yuc2MvkXqPM8FNEfZBaYNs2BkGluoE0Enr+5LYfD57A="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156540126,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAL2tP/t20BZDbpljZNaZJBNI+Crdf2Zwr2nTMUmJ4KkWB/ece+c7/hy+VSKSHH16b9y4kKLzbjnHjmpscB1GlyUvgCb1ETv5ls9KX4hZ+MyuIEilw+qEc8Xfo9NAqqdzQY+f/ReVv+DWgzjfP+gt4w76PLjFS5AHaf1hA9jtYW1UK61BqBkJRS67e6h+1bDe9scRueAYQALsWrxdlNNlAUfb3eH97+/Uo7dDpdIiPAjaXn7AeON2jN4DNYuJ00X7iaPCjomRcxN/MRvXcRBHPaAe0GE9NtynwGm2KXkll5gGpKp7TbGUkQ6ljK+m95pxSatm0Pe6IiIijihNtd3zMTVmlDukPy09yZJc0Zi89ZCjW91DJwdmHDdQJVqhlZutDwpn1NgGHoVjd0QGiy6NF52XeRaQJvT6TXbNgwdaT7ySOPgfIS6gSGQnv1S5nBsShkJO71dXFT49c90YRh1hT7zwQKme60vqSWjIw+pUrdPiDWmhsYI3aCchC0oNghc34D58CYzTYZqiF8glkUjPYo3gTJJl0P0L02irleDY3W/i/NYZJ1fz0ZkPKHeF0BvcM3IsHHJ1hU8QZY+Ohz1JkRcdn81YL8fq0U0dsCjKy3kfhrdFwiUA/7Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQhoDgiAqLdIWm3lSTAwV6mWzEsMbJiTvsVMu/5yzHDDFHNzZZAPivDeg6tCf4wH0nC1gFi3jX0GjXEXf+AMRAg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA4hsjfbYgKewEJAZ54ig8Ie5cC/wI81Ba6ImZQqs5Ezqq5g9lWM/Xii70fxu/Go/hSQOo9wHmqafdtoJVlS7jbYs2r+anmp6xEviHubzt4RqrxOBlveBN/Jv/6j8vev3TsMTMUaOdGAad/O5eDPhF2MRgNYO/U0m+ECmnuFy2b/cLhRUigS+ER9ZpehrDsqM2K7ydPMJ7WXv/5/Xr2ZwNKKZVu24x9Bd9DPg3DZUkYheg0enBvb+KIAKqOFfR49maMER8DpTLU1gE4j/K8w7Fm953Z174bnLwJoqYEALwkNS9Kq35wbR1eZqAJONe5jBaOuedyhZOD4kHNWVP+jL5saSWDds6Kpgneekw6KpXhbJCkKYingMx08+u6MJ2LkRPBAAAAPQuLdK23Xxm535V1nsowvRC25xpW+viaKiCYQ+VRG0GUSp3PH4KXvymOyjUfrNer200WJGoxznihDlTvYN48aRioVRZTZXXAlmgMWbPn4hyeBJec34yoE9dXiyiU7b6C648Uwd6EhtFNnKZUbZzflzgSiz/zG6oHS1nxvGPIPk6Dbl+RbYLKFhp+LsN0JdKl5k7W4xVsoIc+xK+N2QqJmeqxw+OUQGd6WwpCtgFLYDYOYN8pgbQWgHhYSR1GVnnSwCAFdimF7MYCQw8FHDsdyi7ivAGelcy/GqqHNV3JDg0KLjKp3GD5l7rdb/JkK2tpqrYjWz6K+qFW6xdxYd3YJNMD43KqgeD0V04dugzGx8wZhOHNv6/vTI0qCAXwOlIyyj9WXjYWATW8YWSq1IIdYaMdeeuYHvxT85gXckbDiRF0rs9YWPGX/2Tp1BJEbmkVv9OhKZeuxwSEyQqOu9rAnNX9nCdKt7ZtQfhfUTyUPC/cQJfL/9Une8f48bImeZLYRVDc9zhF3Hr3cExjstUOlGCNtmvW2Sf5ueU9nqB0ZiFmNMIs+tK1/v26H3XqqrByGfv80kxJIex1cRr7ZVOXC4d577HXi4xwp+4ZqdxcNeIPqjUiY3adQv7twfW2QWzcFVttFreQ/EpnERuwocTSN383XDYa2UiogQpeW+n35iSjJTmTdtbDobXueB7BGfc++R88kFJ2UICuBSMuRB59w91HVJ88DMs7Hz+dfQK/e1hfxogxzOnw6L61POfJh5FweHYA6BSAPuh3JqGWAmeI41vS8ii+rCTBxJ3NpsiuWH5nD1fFUyk3X6LovSJcPWQNIJNJCRM9ujuK5eBgvlosvX5mG0+qK/iuXD7YMFgkrt/NIDUdOQtyBuKi2gCs5SOnOvxh6s9bVt9p6LRrxYhIiO1hz9dyfxNbi/c5LinKDhiAHXjhNqjk2sJmEpqJMvXhN5c7cdvtDGoxOIHHu0xYZptAyvmccKPeKetA+oYDl5uq+z9yS2LG4ivmabQd8j9tiXhVgqQdzfWdBoTjhFSExMVbaKXRdZ4VXk5xlYqDT6gW13iLMKbc3eHveYQrHeAGAPiN+Y6MKnq/lR9F1g6TkBI6WOHTR9WO2flTRwk98Xq/9Ew/RkpsdhbR/eDGRzi6UMc/vxa3PJwKStFcT5RO0OQiFg7Fq4g2k5p1VjWWWpoQwaBHL16h+UH6x13wTTDyI0+8CQMWG7yGo6lRLweYId9EhX/jbWEQ7LI+NYcB2Plpt/MDO0jGvuFGd+VMuKOBxt3zAth66S0UOyno9fR7vQqUmKwE8nAV9Dxy7JYcN+keWL3iOEHrdXYQUc7Ca7UhDtkMW8JSFLstEh340WXs0rVDrLszlEvNH+Ye1WIbdu7HgeRL/QjfUDyuC28ehwnmm+SdXJjE05VXV6JHxGcyIT+9Efo0nGFZEqubriMrgYKRdmZ1OB7g+noLAlHtQwu251CFh58QIXV9RW6V+BwSL1Elyu63I1cnzQgTOFNmnbD42i4C+jOT7x95UXJ2aqUio4N0sPjzVNfrJbXhFbcVWuNNtjsjh/hcd6sFby40Iv4COU1pIao7whMyqddCKN3Bg=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should not connect blocks behind the account head": [
+    {
+      "version": 2,
+      "id": "f1e4b2bc-014a-454f-998d-b9d828d01530",
+      "name": "a",
+      "spendingKey": "ccfbf437be6955cc8e4fc16c6e9a9e5563b66def604ddd0dfd6b6b4d3d8e8964",
+      "viewKey": "b9624c8794ec36379488cfc15742c264069ec57537179c4e42747e70254a38a5a3d587291793a85ee25f2610514a14b2415a998f1537c0aa8818ba4666653151",
+      "incomingViewKey": "544fec7f24bb0f1573e518b06a6b49b43d6df57eb91015583d200cb29b760b01",
+      "outgoingViewKey": "63d89e0b9abae69abbb065fd5a37d1507c8f00f902639ae3c02134a9eb21c43f",
+      "publicAddress": "2cb8bae591309a44207a04ddbca0a26fcd0891ea299a70fd8ad54669e81b5dcc",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:m3sraHf/ruQ8ggon/mM/eRe602PrF9wFjqljDGQjgCo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:xUNgTa6RPaP4Er7P12yNMh8DEP8b8q3F9gB2L+pG5cs="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156540974,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAEDC2PjJmBVQdrDagrVKkFD6URL5Vqgkpgddnxs1/3WGV6d4MZf6tH+z3a7dBu/rPCiQzy82quMpUDIp4rxHNvVbDoOVRdLRDmh2mdpipxken2/ieuYAmKLhiFih6VQTeghj1P7H7TDAsGExudDJLM2thtOfIf/uJDiN2Jbo+C3wPebSv3z9rRYhxlN5F/2jMgo5t7B5xx2ti6mthI5KwVBY3lWllfCBQkGKFmXzWis2CtGQuJsfxvKlHF2swA0nOCpbcHlwiO2uhyi1nuvSqVN+q3MMNLkIvO76F0csZEvWHI8xxTGPgOsTdNWFEwRuKFUaQoJMAtyr9X5jZWcBeOAPK8YK40ugXQaBXA/qBaH7VFrNN/9fh+PSz9A4TT2MntzuMU3RJSWjKD94carjw/vNan7ByO+tlqc4cSIbx7gFAvoEUKsm/144a/6OjqXabP0fzC2ndOBS9kaeciAQS0rmOU5ZFZWkJFqPCwKjisaMv47/MfMwDh3gvffCl8OMR52qJwS6sRU0UvYZwTG6V/aOBbN4BqUQlO/VWl/oN1UMtZd44SqDWJxnHs9TGw6mYRrbFwY6iwlnyg3+C1EnrO2PGJ+BF8YpaqHli4CE/QNsD1fwBf5WUP0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwnM7KGPD3SttBR/8ZdYYLhxjeySJDIH43Je1F1bpLzTIZUshy/+hvj2V3Siuld+cFfQoNbTu1lRZHGDh/YvZSAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9F075F26A12CF18BC60A311902B160872BE7E4C65DAFD0BAD76A5A80656C62A3",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:PL+QV+qkaFZvNUD/FLiWPjgF9MPcm8sS+isJuXm48hc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:DV+lUg5ME7Wo9sbXqwSQs7KSnXiNqcmAJaqIndzIsRM="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156541489,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAJGeLPiw0f5+BSMIk8IYSXa+54EOxPc3BY200twyC1j6ldZwP8meQynoZ/9OTB5wjbhz/DLlVmXQvMmea0BZDhW00cdeUzrVvPMjTDF4yn8eHx7g0rzBMXbC7cKQ4EncyHuLU8Wj+2P9pShupHNaWNiM8h/JXTNIGwkA3JkCmqjcOn0BMFHY/M4u5jPKyQaykk8tPQDCPCmdGi5oxDkNVoyn3SZHTZlUHBkZ+DPGFeN6tlqAIaQ03gGTxfLmiKZDAkDYLSDOcRG0zW3bLt5KWzGT044/Av5LnH+RlAwJnOUxLXO9Odb44ug+sXjrTwtW/EKxvvV7gp7PcG0cszfEphXgIfEFzO98sqQ5J4NB0V2vPWOVny1Ix77PFao2ReapEwhVdop69LvTfneGlE+emvMgw0gBK2hqSjO+jJDUktaXWpbAlQauB8SnxPqHw3QHUGSNHzpEkD4uvWC7XISMVfN/5rnWNr/MHso5VU0a7aykEXYVjLUle7f0WamAnVNCVo3v6kf6L60i5TaoZ9BXTeyObI4CTCkEH7mPKes64A8OQ2JAugAtLuUrRIQjRpslTrONGkKZo9t9S5zaTQMjV0KlPZ9uE80EVzzqX3d94Q3Q6TuIXaqMLSUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvsa/8kyypmsiz4aUESne1ei/uFDQ7k9WFil2RuCEX7b4yW3Cny92Uiv3SlZRXkUwwcVxdwxOn+vklEZqrbouAg=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should not connect blocks equal to the account head": [
+    {
+      "version": 2,
+      "id": "2730811b-e455-4055-92f8-2b8177bc4f75",
+      "name": "a",
+      "spendingKey": "9bb3dced1c2e8c1f3a39365c7bc5af5fb129344f0ce7455cea9a8616608648b7",
+      "viewKey": "ec31e335d8823f246f6e4105ec2725827373c12cada05e495e1c7fa815ea5f6ad0a7927bad489b0e9b7b19f323d719bc2fc85695d2e10c4f3418ec76a36506b0",
+      "incomingViewKey": "8ab85762025d3504ad80f699e39a6cad58afdc2539d44ec826745cf21a2e0205",
+      "outgoingViewKey": "32bcaa4e9357a45e9ae074d8746c0f969f7d187594d5bd4a051dc4e69fd4a1ad",
+      "publicAddress": "ab4c74af7524e30a7762adec4a6aebe405c130e767e4ef8adcc1b233b6730058",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:VAOAavQcQDWjgLIXKGAkoo4Qq3vGdtGH2kxKIuQDbDE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZZ4TEf3VO7K77j72wIWim9dVdRUb8VOkUWbufjOFVps="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156542296,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA03N1Y7GUQAIeuRHLuFOwLA/niAr5SOPSochOPfnHzoaYos0cUSgC6Go5cgBByE6eHLK2BysGshfvaHjotjI8D8S+0xS547wUwPBbLyepLpuhTPPKfuWjbFza+Zxy2LGPEmCduNZGywxiAFl8lSn0EqqNh0eAn6oj6NkAocHR/e4Phc60pUYBIfIYmCPGkw6984Gh5yq2gO9uh/FBDDbM72Yvv8nAB0joWVbpz8GpnQypIkt2nTmsOS3zweH1LJJ35twCtY6BI8df+F6DByYcJiXNWN/D34v/DIMcg8RFz/NR9I2O6iB3CNXqQXF+M5puRwaBdChnYzFEmC/4LXgHJE4/by725kKrl27TUPbysIG8sI8xVCnEusUq+IUccGhMehT7OFtbGU31GRU+dSs6N5xqRCxakdIrBDIyf607b5bHxyi3MxmGZ/Tgvr0s8kTM+CyLkIkqDioT1eLfdFES8XfaKadlJsTFWZcGbSl7ORbjy1hBO8tNXIxt29WLjQ7i2WQkhWdwidMIvECBAdsE5S3ZwkO5TBos71MzNnL/q5YJi2CmUYImSNwK++LrKHy9Mok+sdnGutB15iSxKC79qTGqbTn12pTeZd5gcuDjoSdKNXvmrG8q+klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwiyjSC6Lf74ogt0YWW3OwFvNh+MSozgqvTEK6RK7ROxRaeOY21Y22eclwnDbmIqhbpVf+3M7SPf8yk+Y/xi2zBQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "205B79DD0E4058DB6AE9917FE918965AE8D17F4FA46EC01ADAEA4F67204B8287",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:sQLl0iMV2JvjhKqHmMWnTBvTvLcrgb1yti6D4sroUDM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:3dwxq0SC2NOUw2M8SxZY0B2vsqzwOP+VG8jQbdnj7jM="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156542822,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAR84P9JbgcxKkvNwzOmnHoNHE48KKp7E+VOwW4CuVVyaMjPtRwWwNdVR+zX9ar5Qs+DMDXWGrT6NYVOC7Qr6UC/YPc9KCr68t5lOZSJnwVEu0uwPrxn5wkX+KoTHpxuBfs2mHF3wwZ6At89LtK78E2E3vrs9cRh6B0mDGAMMpgrUQCnhOiMAXoFCDgLby0nVNSBfZiYsTLizhm+6+FTOGSu0JQ30ALzylpn2TKPbAH5+Pl6wN1nOmmdiBv+g7LXLPXlCF0Lkp5AmjTuqQdjSKqZEFrzfpiY68VwWp26sgiALYZ4Ethhd2IexZEo0PP0Y+Zx95533ZUryn1tU0mz/v4Z+aJmJIDDCCITwTVZu1qxfeWrNoejXXy5fisMeVxqsuaD7WSa+5R86bax6e22YjUKp5MIFv/7VV0hPiWcZOnOhOJKf/gAsdkOyt8bOc1yrs4+hObIULZvN08wY9RCUZ6yr0+8H4+EABQlZN9ixU3G8vs0+czlKl7ZX2WPicviiOZQ8R9d+CDl+LuzVPb8br2x+kINK8ThCSqfL2E5M8xvpk5/t3mXnFrpnAG5f80iGlwQNq3Rxpo04wOCZwtPkB3t12jGHgrC207JaYGA9ts3I2mZZTJP1a60lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJjAszJea/gfeB3Ao2sBaPtx64YYEdhWOykSN2CITkElkxXPeoturPO5OYWjcFy8SKkmcxRwwUn5LqH9qaorFBA=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should not connect blocks more than one block ahead of the account head": [
+    {
+      "version": 2,
+      "id": "b3ddc5ff-f30e-4b82-9e96-47b495194169",
+      "name": "a",
+      "spendingKey": "e85e47c2ef3a447ced3615ea38007e55ed5af454bcf0a4fee4de6499a9819b44",
+      "viewKey": "4e6ce25f56a74f2b9d0776ec62a3546c182235cc9ec6ad80ccff7d8d5164fd02809917fc26096467bb096e530f9348e13d73b3eff82b7bd099aff786522b824c",
+      "incomingViewKey": "0b16cb2543662baaf777a3201bc2e2a9b8015770ff53aea15dc1276a003bad06",
+      "outgoingViewKey": "0e3f4d93a2199020c503652fdb6c5677e19e9c6e586474090cac32f9c228d20d",
+      "publicAddress": "3ab94947c0fad940e34d9747afaf8c82d8b91775ca1cebe7454d6b5a7a279b3b",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:rzNJlBXgQ3fwXF0NBfU2Rr1yP0ssrdkDPv5AEpnDWnA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/4y4NC8Oj0HwpFpkc8Qb9RCwzopll/Ybu8tKJJ5+bo8="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156543605,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtqchBcFkMtcQlVTFiyUWx9pmrr4KzwyoA0y41w6G98W1+9xNuZVjaVKxg7k5hUEgSrgsxCPfbNH9jSw/IzUzqqd11mLOqKh/T1VRI2/H41WPk02OHPeWJaDY0QpnF7Aep1Sgpjo2CBYkDWDczl32D4lV/TlYlrZwdS9bpSeuDFMBa4SgAsNgNsbTemr9/EiwfHCCzTNyKrvaE8SKK1eLO22gOAmrf20bZqHeizHn7I2r+Da2ACoWaNJcKLFvb4B/vB01CCfFx/utYVRVW+KwzUVyW5C71HRJZRoTAOH7mgoZas3mpwH032GIslhKCS4h5HgAIynf1sOCBxT5FEump3Ii5/FU5+tqFV36rnqeqkksSARioqqchfMbwM4LVIJm4C1pU65QxOWXdlvILqTlAK0Y3bhVX2N4FnBSwdM16pXN+GlZ6u+ItUhUCWVkG2H10iGFlwtq/tXlnUih1DcHAbVKajVQW0+uKBdZcEajBcP6yXzwDelC6YW4aF5JPWnn5KTMxHtmUU5nTZw5TOvmy0SaLL4LzohmtemZEJIG7fz6HYn1fz9tkUjdtp4wcqyo/fS7MWG35wyLndgzbtkVbp1E8L+Tdx564ZVwN54pYKXz5sOkb4fgmklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwxJzZ768RuSa0Jx+es0JfpCMV6VlnNUO6FlHeRyBwuc8Vc5d1gzvH/6PN4GgDaHH6+mj39L8fZrzNCwxLmofaCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "E2D48BDB083C1AE798B990C5ABCB84CB81620EBCE2EEBD601085D3EA3FED52B0",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:zu4U/bWFQbR/s8TZO9G9LfuGMnmWtU6s/jc7zs4XOys="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:IMgcywPs4KAkF7xiq5P2HrHemZZsUqQ2cG7sIhdBACI="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156544118,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA6XpOMogon9zo+yNdOXv2r25fraMO87e6A0oanSTo+Dy1gQFkOoSOtEW1s29CikdDRrpAAdr5+79kK61EDFkkX1q/SAEE1MKZPB3wHqL7L8eXyRO8o3ab9UfkZca3PFosyL8n3cnlSo0/Lmtaf/wtUBz55avbhJRap/+gix+qjWUI4eNFPTMpqBvODeWTq5zECtfEt8XL66sbnzDOb1lXbs/oSTas6sW4q2BZpLBUGbumtuAZUmNiKh0y968H86GuAemP5/hZxYT/l/YC4HuoUeHhjgXFkirCkpVG0U4WcoC/hG7F0j2JiYcRhLw5vRp8lCmq8PnzVaAFlnVKIY3wH63B0NBNmC2iKekKgZWvAJmGInO14kQMdtAGqdhkmEsgcrkns5vDgydDgE78QX58gpDSZDj/ROJlJHdKnjjU7jTnkcGCEM/fNZDShnXFRMVhQC/XGymI6+yrLaH6Kuxlj1yry59A/ekWxMCqeBGmoT6Wu02TpOZSfTLify+NVsyFz3FwJavQsk05aoZGThsJUSxYhezuGBUiMPA6X3+vOwel/YNhAiBiFE1v11Nbve0DMuz9oUM8IvMFSkJ0VQgDSrIp8JtJklNgCTbkGMC/3oDTId0KB/f8VUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyhGXJSQKsllVdIsyb0XXbvwOpy8qKzV8l7v3UQqd9NRgZvAACPYlfzW9+gTDVWE8KkqSz/orVdy5lFbzKyiyAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "63C1312738894849B88D28578B2A872EF2800A35BF352BB33299E3A0514F5A6C",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:AN8fFpv9l0WLx1GtgaT9Ay7I+rQhhqtgpHZpuYx1LB8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:McxxSRzdCx1efC6oNDURFxmF0/bUkh06uR0b/4iCFNs="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156544612,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAjvlLUIQvwBFgPHC4rY8v78qSrBzk44CX5jkVK5WI4muOLWOrRQJcLUU2ZC4xxk72i6xFCyYncKHSNCmMBcmjn/JHv6JiyJVGbr4H23VXPkq272RFFjwci/9EGE9PZRa14xek0ERHXPfYfKHkIj37NQp+JL5kYRgPl3RbnSv278ERgQpVv/Mqt+0hkpfiOxjV5ziPn4Ut4KqVaw0nRiAI26fpnT7StCK6AyQWNsH+4yaq+1nnkSuSs8mZDyu1Cm0X3luDOFLSy81pf8x3e2xzfchd9KC0Cx7vx4XbF/IK7aIx7zCBENYKQhZugOK8BQcVOQkbtI8gRRRf0i6MDQo9Ld0oqd2I0xwROtzizfYjMksdYuGfWvne6e+1pBoOqEMluzWocmSA0ngQWsZZYYL0IpZtfEHbYL9WF9uasPL91zTNKUE7AH6OcDsyGy4opT/jKkcilDTsQ0/XinZ77erV9x33AvrQiHrzWbT4Bj1toKx7pWS3rMtC2ZWy5vBcP0DIgkFleXjcyf1zhwU33MB6LrqUUwPS2w7DC42I4LbWRna9kcaWCz991EkBN5ycsFQoFt+uPWax6wpfSNQKoQhz3IDvbVPYBvASJYaBdpXMYwN9sDAo/u0Z1klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXpLTPOsTaYdhWnSBe5UGJG3IfHRSgguIfKeVKmoKdleb0YpQ+naT9DKXdrPfP6pMTeEjcioI7tmgvvDfHRkLCQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should update balance hash and sequence for each block": [
+    {
+      "version": 2,
+      "id": "c0131278-0a21-449f-89d3-9d0743026bb1",
+      "name": "a",
+      "spendingKey": "ccc71a4bc8c0df34fc047479654b3b2c50d6627f8e8a7a963ef6f302d7002432",
+      "viewKey": "5cf3971ac9a0014f698090986f8f9ff937b1dd34e198d3dea15a2aa47674508a728c5ca39c59e3ab4726b6adfce8bbad0dc3f399a5db5aac415e5648fc641cb0",
+      "incomingViewKey": "5c25e5751baeac4c73c9b7e39129566e18f069d47ec60c437053ab399531dc07",
+      "outgoingViewKey": "2ade656eb2d12fa4900874273880ae42bffdb959354204b0eb47861aebc21cfe",
+      "publicAddress": "084e92e4e1d2e27424ad46011572ee78f7d2b7b6e94b7972751b512d08392d86",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "719e689c-334c-4941-ab55-22b93b36c99e",
+      "name": "b",
+      "spendingKey": "7f597d99f42cb9b7f4d2829131813ad573e5d8073b1e7c92b0a563e8a98c29e0",
+      "viewKey": "42e17dad1f80692983931a3e0380345a6fcba10f8ae4368ccb3abb7922020794f1a75038a08474c4b6728b5b35bf6e41d6ec43215e563e18c3e3c3477be8b20d",
+      "incomingViewKey": "7ccbad07c8e8e56551508ce7b95e8a3f72af2491fe2403463e9c287512c68205",
+      "outgoingViewKey": "74715a6830e670587b5774e66f6bc3bfbea87d118d81804a86c3e0f5d9a3dc41",
+      "publicAddress": "438b19d0f461a04cc542d93aec7f585129d489ccefad8310f13e145d83a31e06",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:JChkQwuQFg81HX6y3uCvn/yQjl8JpRufokHzcqr7uGU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:viqOYNrvqtu5prnQWtHV91XVzmXtAUOT9XbzfrAoBYk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156545406,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA1JXZhVP1HPDMIjitWz43U/vvNpWFi1wlJEwHjBpQmeWsCzZ7wPCWG/h8I1V+O+ot5Oz2dkhGSqnQHhpHWZC5CarN1fAiIwudHiUi4EAMqNal61L4FKwX5CBdbtAOPOGL0cNIcZHbeiStNfvaHumKTmwnAAJ4karmQr+Y2pVcR90Kj8fyaeuW+HI7UP+PjDhdks0QVR7E4W8bIZaZhHlurdK3j7iXxavLvKoE2+YiWvGiQ06N9krn1bDFZZB9yWOyj6P8LFwlFNmNTjLGEmaxqEjplEl1Ck0axxmJtJr4YF3GYLTCdRTgkHmRDm+gu5kFpBK00sIxzlnIWYIX/7uxNV7WOzez1YzH7bmh5b/6TrYax4/88KH0ofROf84mMFgVLr010g5BjOpz5mYxE3kz5PaLsbkhNz7DaVocFhrzqYvBktP+kl635iOcVnvjszJjVZBXpPtr3ZDAsQA5x5RSvVzf+qunhGEVv+bC2lJMuTLprmecwIexdkZ1BPQAcK4lPIaPh7ZDLIUwNTHd+pwg3f3UrLI7i/lp4ff4WCcAvVQrGyIcsS5hz+O/F2GoCiGY98RDialXsn1UpLmA47NBMXEq9MYaF23s/SROpYmrIbOrXCkYEajV1klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwSRq5MyS++UybxTcFsBJ3eDqaK/0VhvXHnuLYy8gq1a/Hicab+j4IP1Fsl5WTuzqYP/rLULKq1FUulVpq8uYKBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "CD0A092DAA0A29946FF2C5940B5D692CDE25F81FA1A98A02EC062212617C2CF2",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:tkW5pVrQTL5kz74cCXpIGjGgSV9sfTE4D55wZI8fIgU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:BsZlPojGukOt52vIL+6VGOKCvb9g2+OJbCLmFNC4Amo="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156545926,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAsN9prDdrk/8DQ0xYXD7cONY80JdEyWwOz1/EVQVfAzGuXez9N0wODLW/9ulsHp3DA0kn+EAroHA76Dn40C4k/Iqod7phW2yjy1WvzTI2aHKyUUN9uKQO1eIheLI4EeJKCy7A2uU5UcuBtStgMC4iKd7q4PX62YzBjPFLGc1gQU4M3TrQ6UbRGJSkDOslivbO/33JAloiKXSII5GGwcXaSb+nfSjsJlbGliYpwFcT9JaZeZ5UP2jQiYJ2QtNskUC/3J/T8hC7s0c0qukpqj9ElStOBap3Gwj/PH+UYrmwLDaBSJen4rsUCZ8Ub8lr2CtnkplxXXmd63ifmibByJ1Y0ZGV0y9xvI35ZqK3WEncrsA7K+CurxI8SKN6rqGqluILBflnUsIkEYrhCgwHffZnTniKNUhWnhUBObNjD4bpP6OBCUy2I+NmVfd5gouIKllSF5Ou5unQlIXwQxldu2aEGUOOGb0SXtGZ83IWMOmP8dr470k6hY/gsaY1Zc9TxpIFiSsiXb+XS/aJk3cGswweJUxshvuvb81AOghTozKs5kkC2ioT2035r/0ELENq9aqQggUg3+D8cJDyJffcXYBxqHKYrd6qg3SN8D6MxxhWUC/R/bqmY3DWdElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwdyKxPN9zlQ9wX8s7UdUBvlw+WmvsHBVxEygUSKClEJuX0KjU5LNOMihPXNjJnngfsO4T9IkAlSVkrMOorVIFCQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should update balance hash and sequence for each asset in each block": [
+    {
+      "version": 2,
+      "id": "7c1ed440-7dc5-4c44-b0ba-f1cd5d197dc0",
+      "name": "a",
+      "spendingKey": "4910c22364051ea1ca5c07fa42c3029c97c83623ba35c79f39b395111360fac9",
+      "viewKey": "3aea89bdf6fd573386fd17072436b9d4d5b9a36c839f45a6fef7607ebdbeac9e7782f84f5005e15e60a96da9802bc38841b837252669efc404db1c83f6a18854",
+      "incomingViewKey": "cd1829fb4416aedc437a2c0dbb1e01b9a96714e4e47536df154d87767fe93300",
+      "outgoingViewKey": "78a3d547f050f0a7574a4c51d3418158049822ead40669c67ef1ac749c3e1b1e",
+      "publicAddress": "f5a58f0dbbeb4011a328274903adcd5591087f1db908d0525c108830145b251e",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZirjkHZqH/bSdpet0UKQNtMUzNcjBGgE/glJFy+Bwyc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:W387cLGVlOGIcR2G+PgAGI9awnBd0uFDGKQb9u90Igs="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156546729,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAlLQB1NujFQIZM067U+0oR7BFJy5rmSxrpSaXxvXdPqiScrVET+vyMMC/k3eWXclMUCuPJu/q3RcgxDQf3rzsmzOXuYkkU2ryeMxZ1YAbUXuL5syHoZDmxTpT1E+RKIfFufbqliGYyCZB/Yuxi6tqsRLQJfbnbqDExDF4QJcnIG0VLOt5NORwgq+W7+foMs2eU+HELEdPbQ+91QcNGLl68DyMcFlU/VkIw6zPO26x9Q2QLeKBpslh+mJW6+Stt9K8i6VnHtt0LOwwtlfpUHrfo6iA+vQB1lJtHPe/DR/yN5L4XCbPRfpHX88edt1jjDSL78J9+JCJeyM/BGsTiRLERvnuw1RO4MmF8rRpchkb+tjwRrk2RxFXcJHckvmNMAhG+aJS1yD6Q+oZeUEVxvfde8EfJlnAqIbQ6E6ycCO+r1FO/fdqHioolhrMPYYxfOR26k2C/J/ayZnkJszPs+EIOzm2zHpwKIjGGFLRT20U5OOCIAmHHGSnQOjX93KVIxElb5o9BbxVdPAUIOq3oroRF9OwWTY0xC4mZlFluQfikLGKrn0AT8LX6oomnvABVG7cspvV6YWO5g+d5/7zyn6WFkqRtzgTZicR9ZJwhFsq/hzkNPxn3HEfbUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwG5Qkw7gELb7Mys9gqEq4U2NSrhic+qQ5kkGaK6erzuY6CXW/GQsWJNDsy7Ff22luNii5H10IwPEM2sA4f7fjDA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFcW5rOwIQuOmkzS4cu4vvKQbLKwFvg6pPMgulxFG0iqGwqH+LysW/NFyCEApI0vwPHxaH3mhlQBRUIydG+IlL6RJ38EZcjYW7JCYcZwte8ihtxoL2y7JPM/2lGkkrx+DsNJCwX5LjWl1dprHd5JpSaoRS1ZsYCGFpPExyxx1TCYRDgCNF9EZiGu92NMnp4O9vtIJXooOFPu2iUdPy1OwESL8Euyuz1uI6JnX7DAtpQiGB7IO1faADXwFCrUXCuLoHQzgyJqdlUx+ZeGbayqe8yy/PSfGDSHqIxU6J1unrBJ8FbrxijbVNgIddd6QSydqk6IZkM1Vm28LiLBTNWKjUHd0FRR72404TLGzhhmKJmx5ACfxkEcz3UCysixRTMph0t6G7IlIrqrSYO9ecCjHnVJ3tJsbBX+dMbo6K7bCa96ps0DHvh4jh2L9lRut8oyxtYFRbP7yiRxlpfSRxAY6gyY9wCRirU7bmyxAP9ND5FI/xaI7QESAdf7WTFMWdP1i0Px8aep8OVhILcuXwSeI3F2v0zrVIOSwXP/RBXBp64sG+bG4VKJo4jWiRFw+pXiWAvMBJX/X6Tgr52hb2b2bORWE4ClDhrBMsnEAIz1jvFxjxpXlcdeN6tG2KiXlNybJPMARmZ30MsXjgBySFn8ZHeapmjCtrXwipIeg021vbInGzr9TWHYVkFJxXawjuZNQrjird0LusNcoPLa60k9eA1yMizfLXCO0tXYYEabMvs+WJWYUxeFrAW7g/2Nc1Fhvlov4NFDyUpiGIELnluSreof850VwdyqTsxTt/PtoyupVqcwX6ULsBksrcwQjbgBK5VGgMl4Fe32Il6fJBAguL1SnAadyJbtrEyrSsdArIz3yISosAXYzQPoB6NCbn7wSIyohMTnDj5fpqJaWo01XXv/bRsqopavTg/8ZmfvXJ7ayh+F0Axm802JK0Jhd3v//mQ3EUa5/8xlmPXVRLOat9hJUZKV4IJWV9aWPDbvrQBGjKCdJA63NVZEIfx25CNBSXBCIMBRbJR5mYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIKAAAAAAAAAB5bNECZqPI7APF0285aJlfiin+79mf9HY1nxYqQbFIdZ9z+wxhT2rKU1HCRsvV8NQWH72lSe4kaCjiVJ5x6gwZQWsUtajvPYebbn3/AxpubwlfNQ/3lXUGSaBpAOMAXtXkOeB3yAjWC2mAgndw24asbFi56jQcgkKD+EUUON1gN"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "51C3F73FDCCF391285991AB96AC364E066AC4A3605141552897D9951F3C5EE51",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:DR184S+qCJ5OlTnYhO8MjynrLPp6xoejZhCTp8Tkjxc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:hbqOkIOqiIUvDR924fNX/yLcNutYCoSvNn7DG5YIpvQ="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156548023,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAru5IP8pyfmBkHpDRuiiZkXTey7qjpeFQuZQkhk2+uIi4UPFsPVArQqlXBBkfjXmaUSOdDhwMj1FZ25aQK9bQFUaoi5jdiK8PVUmGgapxMKGl/EybcdUinbFAvN/krEOsBGttOP8wQH+7rkgKx3NNLjcs17m2cN5KOS0EyMQZBRgCUqRS5ZVzn5inC8wCl8z+4r3J2q+maj7qaaqMetb1AkWvRQ74KPWyrskpIUp/s16gU4uWdC/yQplgEnKAXcyPz4HxnpkmA0lm34S0yY0LD9H/Yr1Bp76AtJVQ5+gYWxhuZrhohb5VOBfkpxbXev2KJHqma+JdJmMEwmdqM/G5BWrQy87MQrPzuECChRRW1KTpU1gkebSNRMmnPEjQqOI+Ci6XK3tWNbHgEgtF7Mj8Ots7E36NtTCulrZoi8luFER86gsH0L/HhVS7XcYwL+W3OzxAL3NF/KsCQDfQ2e2L5BSrrFXBP4y8CS3w826uCAMETs0qEJ0nYKpJY4ecA1AIJ9B7Xm45ie9AHhSw+QuyKxFxljLFy9dGoSkfoOhsENnuwdQi96BnWHwBufS0+2GLeyRifFn7XdAJLhsi9zajeX/+eKNipoiWhY5C2kEgkGvYaBkXUUqWj0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwK/5Sny/dfGdVDlHQ+Dedtb98dlE90TexI+0q3oo9Pbv8ScwSXeTbBKOwO/WAYHpmGLPR/7iZLmcP4fIvwhiiDQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFcW5rOwIQuOmkzS4cu4vvKQbLKwFvg6pPMgulxFG0iqGwqH+LysW/NFyCEApI0vwPHxaH3mhlQBRUIydG+IlL6RJ38EZcjYW7JCYcZwte8ihtxoL2y7JPM/2lGkkrx+DsNJCwX5LjWl1dprHd5JpSaoRS1ZsYCGFpPExyxx1TCYRDgCNF9EZiGu92NMnp4O9vtIJXooOFPu2iUdPy1OwESL8Euyuz1uI6JnX7DAtpQiGB7IO1faADXwFCrUXCuLoHQzgyJqdlUx+ZeGbayqe8yy/PSfGDSHqIxU6J1unrBJ8FbrxijbVNgIddd6QSydqk6IZkM1Vm28LiLBTNWKjUHd0FRR72404TLGzhhmKJmx5ACfxkEcz3UCysixRTMph0t6G7IlIrqrSYO9ecCjHnVJ3tJsbBX+dMbo6K7bCa96ps0DHvh4jh2L9lRut8oyxtYFRbP7yiRxlpfSRxAY6gyY9wCRirU7bmyxAP9ND5FI/xaI7QESAdf7WTFMWdP1i0Px8aep8OVhILcuXwSeI3F2v0zrVIOSwXP/RBXBp64sG+bG4VKJo4jWiRFw+pXiWAvMBJX/X6Tgr52hb2b2bORWE4ClDhrBMsnEAIz1jvFxjxpXlcdeN6tG2KiXlNybJPMARmZ30MsXjgBySFn8ZHeapmjCtrXwipIeg021vbInGzr9TWHYVkFJxXawjuZNQrjird0LusNcoPLa60k9eA1yMizfLXCO0tXYYEabMvs+WJWYUxeFrAW7g/2Nc1Fhvlov4NFDyUpiGIELnluSreof850VwdyqTsxTt/PtoyupVqcwX6ULsBksrcwQjbgBK5VGgMl4Fe32Il6fJBAguL1SnAadyJbtrEyrSsdArIz3yISosAXYzQPoB6NCbn7wSIyohMTnDj5fpqJaWo01XXv/bRsqopavTg/8ZmfvXJ7ayh+F0Axm802JK0Jhd3v//mQ3EUa5/8xlmPXVRLOat9hJUZKV4IJWV9aWPDbvrQBGjKCdJA63NVZEIfx25CNBSXBCIMBRbJR5mYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIKAAAAAAAAAB5bNECZqPI7APF0285aJlfiin+79mf9HY1nxYqQbFIdZ9z+wxhT2rKU1HCRsvV8NQWH72lSe4kaCjiVJ5x6gwZQWsUtajvPYebbn3/AxpubwlfNQ/3lXUGSaBpAOMAXtXkOeB3yAjWC2mAgndw24asbFi56jQcgkKD+EUUON1gN"
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "972F14FA3782698BE43841ED51332A955136EDA4FE9A25A301C852142B9FC724",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:szaEaJ3g6FGXa8H3tuV/EKaYf7JxVo+LDl0Tyc+GqBA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:/DaFFpW9N3HxLnZ5QSKtEFkAtg34lEGLljcyTG3nZNk="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156548550,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAopnUYDCo96gS71QVbtNuHg01vgRy69E/qsswPuHteNCoQHZXV4RIbmJ89CbfhLoX1kUn+RsuTxYy7Iw+aAHsjBa0dMHuN+5aVcJYXeY77W6g/goy60GeFuf2tEPuJLaQs48AUMkoaBltOU99QylwF/VMQSt4FHo494x50YdY+eUGCtHlLY4KG1fGKO/ZgE2a97LYocUX3NrltRSEPT88+dWQy8gQJwQW82Iu5s2HdbKQisLurVOMuWPZYAufrAcRJwLl9PEvQ2TfBYsK6AcgSPHk/A0IwN0smvzeap/+lX3h/6wGoLuGwloMUBmBiJ0ahpyexd3JnIv/SKiYtbFHn7LY4p7IR+8Pd1RyyJ4UgdM7VXw6ZJDTQNg+f/vmTa9TkDKH9jioft4Y8pVY8tD2eRzplUShFILBwUu3c5wWszKvDIoIQgmkcKslicPJoCTi+MlHR2F8OmtWwf7dcY7jZNA/vCMsnItLwl+UijQpoH8HWzzwRvN5bGoZhuFVsxHuBZbXrw0i0BXxQLtyr5/9SAXMY3qwWEs2x5KHKvfUIFZ2/akZc9x+3/Ju5w/Ij++5F8aC4isftFOAbyXDGz0ZGShKrZjKm+NS81KrHI1TQ7VIzyNe5ciqs0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwyQJwy5JhHSHCm8lZYEREbk6CoXIwhtKfFY50NgFNeJ4ChQK5vUnL9O4ndEsfZra6cWLGlKB4IL/OH0rx+OH5BA=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should save assets from the chain the account does not own": [
+    {
+      "version": 2,
+      "id": "d84ebf56-519d-4ccf-a14b-dc118326f7af",
+      "name": "a",
+      "spendingKey": "926bbd64124da8d2dc251b7f7d502405e8f84bfcbdc8def818236b90d0341ae7",
+      "viewKey": "4fb70a4ffd697caa96e2a5ad7139639365be9d2ddb088b4f487d5f1b162a56e59f4b08447d7b12cd1b600e9c8b8c7933479e11c1022978ca9967ad58121b54a4",
+      "incomingViewKey": "89ab61adda092e9a3b825d65c243f1586a9759fe2b8293b8791fe171f6e47605",
+      "outgoingViewKey": "e57d3ac9c223a8f33ea9e54c926c1ffb5f1bc28265af25ee8adbad4e305d532d",
+      "publicAddress": "adf21544bd374d10010096d81cb5aeed8bcd4fa81a9a27b43112fe7d74779ddb",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "132add21-327c-4d30-adc8-5a1999d83019",
+      "name": "b",
+      "spendingKey": "712bd732a6c1b51357b7ab1dcb993cc4bd888fa56e1a90aa3e4bc8c0da1af65f",
+      "viewKey": "310367565efbd1fe9b29b56e25a748f4e2271befc4d99591a720d0008630e14f31b74761f606f02b33e8e4de181bc5298ed3a51ca0665690a9f084b39c41544c",
+      "incomingViewKey": "6eafb338acfa6fda28731d47acd454066b2472772039a70748d3dbef445dfe03",
+      "outgoingViewKey": "0e9107c94faadd23e8922622adc3533870528384cea321a3622fc7bd26857f23",
+      "publicAddress": "bb3a65d3919b3fb3acbfd7c27bbcbbc2ea9ff7ecacaad9caeab9a40dc50cf326",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:3SpcD8N8rRTV+5ChPUW9R29hsfzQcYTcpM5J4+HFfDs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:GpU1hjvf668nFAI+iS9Wy+esenxxje6Giyq1mFfwgoI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156549332,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAyB8eV68UJBscse3RQnZb3s+GIii9i50YOJqgJtVfzvKYXf1a5qreZeNKFwU2R4bHjdixCXTLmqIMlE2vH1pm+JBrVRrtEu3rWJ93V1SHmWmYhVb1JhiP3OoUD/GKhtNx07doQfc8qZQXnClmhMxBbOVyli7utVXZRHUh6HXB5CIFQY4xUcJAmMIzSJe0Vu41q/kp7fyhAGxsddGRn2M/X4A0aFSYbrwixBSl3orTLlqTr7PzKrKUSXW7iqFbLMobItVHt4TAu738u7neOgKoGCxri5OcjWBnEsvs+2kGgyURu8SGF9JKVlcX4eBLbInikbbgwwdq/+gLdb6HvN2RDMlu/1vAnqWHIdqPvVLqjvpwlLdshcquB6fptHmBivcl4tmaPaz2UWDuhte4YMmJ7S8JRaFojbSfcNrKC8Zz15EF+iW0pMWBkfSxVP2JSlruyVQZ6VKOuw+2zKYyXeGRDsqVWK1+1fasc8p+LVboNDHl4hzZPv/SQDOzRZTCejVofLkg2Fr1YTrEdIcXIgAp08sob0PQa8Dk008DSv54kF1hQwP/4bgXe1xjyj+N6m5PGjouZHXcRyTEwRxgEl+oRlm4jbiZdzsUgOxGZgGcDwt+YXoWxyzv1klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw2u37yFTCLEkjdhE+bNgwI+2yY61YzDGyhSnzZNnN4okAD3yt/Gp8m/8PDeVHUPzWAHd1z4JEfzHdHASrzBS+Bw=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgiYIKhWEmDu0glXX/qxUTyPsk8ivOpWB1d1dtLNpfl21SEct6GqFq7xwhfWE0QjWSe1ddryelIpHYwJWrCfOLwlNrfs2otDy9mAIPWY8RvGj7MtezIzHeFf5GSxGguNSKXUyCZRgQWXCY8sEyFh53O6YzjB3ehbnvLP5bPKU5a8L1x2O5FjRFSyQMcQRsnbpQQlbma2qMJS9IDoZCNvbm4BkwyJSBTzmuAa4jI0sckyDDKQN/x+o5ayVHak1fVbOLponEm076gAje4JMrLbNKc13keQu7K7qiVNAgPBH7NaC4usf1W0tFG/83gJGXHYufIhFoGOmSnEjl8icRcF4HJWEmRW22chrXvKSGUQdpR1eSgFIY+xIZsdcsucPVoJP3Vr9qGRO9X7/5VZEk52KkjHpcLBjSmdoQbo2PkJz8mHOzQGDo8cNz9ztJbQp2V8MeC90RiJS5YttEUXKTTM8JKk0+HZc2EF5rDUkFnZ9PfTpsnZZNKSoVF4BRDzPAYgZ8BF09ODX43NPqlH7QwP+iBTAvoQHDDfGatH1M30cEXwPZR08bG69ngieeQ9VIRaiR89/r+oKQe38cGxRnDOqV56be/Cuv4XLmettuFunai3PlU87CWNm9gutVSv9j4SIRxgzJpamOJf6o5GO3OECFgWjaRhQJ7MEjDWKYqicn/Hwodeyyes6G7nWckQGkyGeL1SAh3SdkwrejhrDCJSeOCPEGceSurJLo1Bmth8d2A0EeG3uVLN5CXwfVzgjBVH6LX2hV9IkkAUZ13Dphrf7oolKnngVVREfiEF+2pIDOaqQx/23aJhItQwA3knozrD8w9Klo2lx5VDyMdJSUQHXSeHkYvZD0Zm3C9fdo64OremE0ApJxrKcIXSznv1gduks/QaB6w3y3n6SZBixSUx/+mrQSPxPjdfgr6xrZueeZu5l1VMiobqaoZcD9MBuYnK45uz+xSj8WgEKlTCbWxog56aeYPB4U2TOrfIVRL03TRABAJbYHLWu7YvNT6gamie0MRL+fXR3ndtmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAMkZeEJoCJkKZhZQoIMExpFgYoAh9RcjoK+UIZMXaDaJcNoFVCTVt+bNF1u3zzv4ePkx0q8N9RyZJfdocRhT0wUvRC8kjcpiWqdDgwUaZyGpIKPwrSgceB9/4uTHU63sgyDUzkuv6lWtrOWRZnqNloVNj+2rh8pMyKxrkhFbuiYJ"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "16143AAE507FDCBD9F5F9BBCA84030C0D9B7F005241596FD7195D29CC3148608",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:WwYzhRSXnSUxbiwE5OulpNTBzJSDwMxwJH22tIyFZmw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:8d1yNOZZnYqqoSloW6OyEHonF+qdy6VbctcHDpeuVgs="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156550621,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAMv2ORQ2H5SVJszgF2eDZYl7nMrgQx1OHHSLdBarWPuqDU422Mqect3gs5eOP3lb92mPixTNP3I58a/5LV1B8c+i1IOtB+u9F+XWFJMiLpGqCF6AiO3i1qzXSj3ctcNZZz4Zz7USjC/3k+Mt0u6h7jph5cYQ1A4LbmTaPSV5vV9MPONOEdoXhJC0NSnI/x2BvU4iP0QFD0C1HWq+M1q8X+Ekp4/ZcM+zNh3d7pxCyaFWoiwvo7inwVIpyabvhl10aoqFnmZMFY14BkmjhCbmb6zbpKfQ74ShT39NwqhT7IhexBW4AEwY4p+5rXMcFJoWOqPNSqDLW2+ThIekUgEkySxhBY7GovAq28ASTvrfw1YcjHvNABX1sWM1mEiGcBW4LsWIpv2Poq5xT3b7xxLXzqG/TQpnH2n5VaBDWpsoAtz2gk3feys8G196anb0SYnwQBgUc9oFNgjvPRtgOIJqmfJAP1gmQA0aL9+2/iKoB/HMcSzLdoiyPjy7ZCilWqSbA1c2w/xmu8NMbeoMlm0D3nvOk2lrTHiEbzHTNrLCGaytTlYqO6IfxNX+gy9holTk3mDusZnXmbNY/x+bfsn1r0TeZ/OdJ0IdeppYzyg0+E6T/j5i+9w8nZElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmiMcclzg3vGJKTC95+mWvSaycwged7jS5j1PfDAZ7yc2ppafUeDPvslLZryt2vFh4v/HBSxogiakfGZ81UFRAg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgiYIKhWEmDu0glXX/qxUTyPsk8ivOpWB1d1dtLNpfl21SEct6GqFq7xwhfWE0QjWSe1ddryelIpHYwJWrCfOLwlNrfs2otDy9mAIPWY8RvGj7MtezIzHeFf5GSxGguNSKXUyCZRgQWXCY8sEyFh53O6YzjB3ehbnvLP5bPKU5a8L1x2O5FjRFSyQMcQRsnbpQQlbma2qMJS9IDoZCNvbm4BkwyJSBTzmuAa4jI0sckyDDKQN/x+o5ayVHak1fVbOLponEm076gAje4JMrLbNKc13keQu7K7qiVNAgPBH7NaC4usf1W0tFG/83gJGXHYufIhFoGOmSnEjl8icRcF4HJWEmRW22chrXvKSGUQdpR1eSgFIY+xIZsdcsucPVoJP3Vr9qGRO9X7/5VZEk52KkjHpcLBjSmdoQbo2PkJz8mHOzQGDo8cNz9ztJbQp2V8MeC90RiJS5YttEUXKTTM8JKk0+HZc2EF5rDUkFnZ9PfTpsnZZNKSoVF4BRDzPAYgZ8BF09ODX43NPqlH7QwP+iBTAvoQHDDfGatH1M30cEXwPZR08bG69ngieeQ9VIRaiR89/r+oKQe38cGxRnDOqV56be/Cuv4XLmettuFunai3PlU87CWNm9gutVSv9j4SIRxgzJpamOJf6o5GO3OECFgWjaRhQJ7MEjDWKYqicn/Hwodeyyes6G7nWckQGkyGeL1SAh3SdkwrejhrDCJSeOCPEGceSurJLo1Bmth8d2A0EeG3uVLN5CXwfVzgjBVH6LX2hV9IkkAUZ13Dphrf7oolKnngVVREfiEF+2pIDOaqQx/23aJhItQwA3knozrD8w9Klo2lx5VDyMdJSUQHXSeHkYvZD0Zm3C9fdo64OremE0ApJxrKcIXSznv1gduks/QaB6w3y3n6SZBixSUx/+mrQSPxPjdfgr6xrZueeZu5l1VMiobqaoZcD9MBuYnK45uz+xSj8WgEKlTCbWxog56aeYPB4U2TOrfIVRL03TRABAJbYHLWu7YvNT6gamie0MRL+fXR3ndtmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAMkZeEJoCJkKZhZQoIMExpFgYoAh9RcjoK+UIZMXaDaJcNoFVCTVt+bNF1u3zzv4ePkx0q8N9RyZJfdocRhT0wUvRC8kjcpiWqdDgwUaZyGpIKPwrSgceB9/4uTHU63sgyDUzkuv6lWtrOWRZnqNloVNj+2rh8pMyKxrkhFbuiYJ"
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAr9eWZIsc90M1amqPI7JdsdSypkiqD4ZXNRx6mv6JRBmrfNr0EX4c/4LnwZxdJFZpxeJvagzHEPyBdHi61FwMxPXU3KzMyao3k1PPkFgs/CSt3b2BD4gHgzkzNyJS0YJi/wYvb8g4lJ7795h04+d5wf3In5gT9QS3vWmNxutaqYMKLc5CX6b2wsWgyN7lIducfSb2ITQaToiRJnmFJUrqBV+Ixb+k7JrhDTxeb1mk5cSQVxZ9sEcexbTkzP0VrQiyyd5T3ckhD/PFe1KHiX8yPAx9oeohNwFqxISnHj7wjY6dNT95ORQj59VGMRd8vPFwzU+iOXfAjORNRQf4a5hrn1sGM4UUl50lMW4sBOTrpaTUwcyUg8DMcCR9trSMhWZsBgAAAFFz1dy8emOY55ofCB4QQUladz1f0QuLIusUbGR1hq//ix9pHVbNxj9Igg8wL7sm5caqvCyCMS8GfBvpmIq4Z7s/Xrb2pKaYWAgJ3oDl56GgM2+qE3SGoxw02q8z8AKYAIsW9pxTUIqSavn1OEPBojsnFLMueKicfi/svA9lcJGY//HPPkQD1pY5/psEdPMxxaQ5AXEPeuDIgmtXJ70YMu3GRMRZsy05F0geP7e/KJTiL8qjFjGJLEVxxfRmoINIaQdbyRgxHgLs83myxmXBUu484WJ5zP6hrc52er+xLndBES+cmkrLOhnDOWJ6oAPkiYC1kpiyLxagyPd7ldsVLRF7eVqo2jytNX36Hsw6lzrw28My9ydMcBOBlO7JS5+AlwAkNxOw/86qcwl0ZM2+r8lCjm7SfyS0K4t0oUo42G4N/r/YSHv6WFcTCLoWlFH45oLwDBG0gnpgRKeKQUiLQkxnB0LtmuBobIAoXr8E9Ng0rOxTOzP34X9TbXikdpeBEO2yOiR3NipUN24v9pdC35xJpYtWgxyeowCQitltcWGrKCG/Azja4no+Fhj5mTO9G+5l+EwLy0MCIHyT5CiKYoRqUlynYWpJdELQGBHfa4gq2y89uQzvVuyfjNqZuxOMHn+HytBT5lXes4ut4bCYNNNoquzLHaCKqxYw6aAz7g3RV/HCd4pwRro96hCfOdv4J7aPC1q71RareN3VrPDJMUkKfLzDHBtS8I+ZdkBoisEefmWu245VBg/KDntoe3gOiDXASvY25ACaTK2fgfokz4mc8UZTzPwxjHVJ1lR6M4pGwFbiX67XPT2TQ6qomeSnTUwSh71BaviqDzgTS8qInbu0CKXWqwmWKR0a+MNuU5yT9TiXVPhUekeykYVuAygkYO0QfLfZrWYflR/R713pwjKaFxFcHlOAGmLfCQRvvpCeV+SUtaSv/SIOqHX9LjgeGS058RQaqWVsJHz9vMocVnSgXDO7rNifGZkjO2Bd8SYXRU1cA+E62vmVqqvCWr683wsyva5CvTJ3f51/ca/dX4CQP0cpOTjdpr1yBK/ff9OBvC653axrEeFDNbYK+B2HUQbBHO3GBWUBQtrniJwv1bxqll8ZlUZL2sn5BRyDUrmlhuDrTBwtBmlhtaxIg7+iExDyA48gS0Av/DgSrVq87g+vifymcacxqpbEJwmbof5QCOr59tBtvINN0HEHBDA/QiIz2aC7CuGDTnaWjV5CGxieHibJ/+LkmfZOUJ6GeWC99rhsGyQkd9dMpqiPcw5V5IMDI+qZ09770s5W7mZ7WhdJBeqBabgogmHAFIvOPeZBBVQh1sOMbTLE2tYFRa+0oOrhNSya5gSnJFwTk4qIyRO7ImoBZ/YUvPAjZHOvX8M/x+chvMmNcEHht9ToBfT4coaC5FUBOYjXRqfHFF73q0s8617iZBrRuTpN0Lbu6nfg3WUOJFlzvjQ7o5XchqkmS7KraSTMjyRzQfPdG8tQnA6MAYcAUhf1hhP9HwMjMSiotyDE/fYWH9SwD8jx+M3LUtXcZio708P1KNUVooWyQTAcSXNLnjEqd6sWZKDk67FB+Gk1YdqEJN3jvQW2c6DiAA=="
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "5549E3CD78D8B15A7CDC7CFE8D5352D58D31488ADBA925E7AB053CA2AA83E7A8",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:yT5cO62wfLOli6XWFmTpg5otaQGkTDAIYHn0TgKkaV0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:rN2gjYcCq/Yf5BrGln8UulKP3WuZNpnJ/IE4G4tKEY0="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156553137,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 9,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAan/qOf/HqxWLATQz8tm+y6fTAN5LKLUnAsqROw7Y7iephrbJO9Q7PSPiUrby2hw4Zj55rqQsCoVTyqMgKP5MOycraza81tVUco8Q4YalC/SuWj2Ld/FTXa9NkrykUUaGtokXGT/jdsMOkBr8fOiBIfPOYP6n/wBOFoZzw2dfokQSXlAWmX9XYhKnLvXD5YPueifRRwfFlgNqeGMj2cO+DKLS3j8tW9sjQNbSops0wU6Ew77Rkqe9U3OaSDwec+qpQwgYcFy8jhS8wIk+GOhDWhi1+7hJnGHPX5f5SKAQmD3wO8MOVQrlG395WnVTUALKsOfv3vlElG+jZ2AGqS7n6V9EwrEUyfGSf78/CIRko8Gh7hQo9FiwgT/BbWqqa/ZRcwE0+o9WI3hA/K2CQKUCW/0jxIh8JtlsR0i7zH4TuSxv2lrJdvJiuuBihToQsUpazAaUHvA+rPI9IPhmEmW64S49VsbAMCOYPvx7sbMaSkttLGZL/AT+0X+R+ZUOm2J89slcMRA0DrQEF91sGaLJBEomJO9RY23jp9mc07jPan8m3xnIhfQGFsjaSSpgcYP9aBOKyxnDRFlxI9hbSaA8fUCVkx6A2cTZHLtO7PKArtyseXCZ34DGKUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw77soLC68U6cuJ0mAKb/Fm+DvaWLdTM6uVUsctVkYxalo+PvO2ECa0GnwjkGt8yM/qBNWASWnYECwYs2lyvFpCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAr9eWZIsc90M1amqPI7JdsdSypkiqD4ZXNRx6mv6JRBmrfNr0EX4c/4LnwZxdJFZpxeJvagzHEPyBdHi61FwMxPXU3KzMyao3k1PPkFgs/CSt3b2BD4gHgzkzNyJS0YJi/wYvb8g4lJ7795h04+d5wf3In5gT9QS3vWmNxutaqYMKLc5CX6b2wsWgyN7lIducfSb2ITQaToiRJnmFJUrqBV+Ixb+k7JrhDTxeb1mk5cSQVxZ9sEcexbTkzP0VrQiyyd5T3ckhD/PFe1KHiX8yPAx9oeohNwFqxISnHj7wjY6dNT95ORQj59VGMRd8vPFwzU+iOXfAjORNRQf4a5hrn1sGM4UUl50lMW4sBOTrpaTUwcyUg8DMcCR9trSMhWZsBgAAAFFz1dy8emOY55ofCB4QQUladz1f0QuLIusUbGR1hq//ix9pHVbNxj9Igg8wL7sm5caqvCyCMS8GfBvpmIq4Z7s/Xrb2pKaYWAgJ3oDl56GgM2+qE3SGoxw02q8z8AKYAIsW9pxTUIqSavn1OEPBojsnFLMueKicfi/svA9lcJGY//HPPkQD1pY5/psEdPMxxaQ5AXEPeuDIgmtXJ70YMu3GRMRZsy05F0geP7e/KJTiL8qjFjGJLEVxxfRmoINIaQdbyRgxHgLs83myxmXBUu484WJ5zP6hrc52er+xLndBES+cmkrLOhnDOWJ6oAPkiYC1kpiyLxagyPd7ldsVLRF7eVqo2jytNX36Hsw6lzrw28My9ydMcBOBlO7JS5+AlwAkNxOw/86qcwl0ZM2+r8lCjm7SfyS0K4t0oUo42G4N/r/YSHv6WFcTCLoWlFH45oLwDBG0gnpgRKeKQUiLQkxnB0LtmuBobIAoXr8E9Ng0rOxTOzP34X9TbXikdpeBEO2yOiR3NipUN24v9pdC35xJpYtWgxyeowCQitltcWGrKCG/Azja4no+Fhj5mTO9G+5l+EwLy0MCIHyT5CiKYoRqUlynYWpJdELQGBHfa4gq2y89uQzvVuyfjNqZuxOMHn+HytBT5lXes4ut4bCYNNNoquzLHaCKqxYw6aAz7g3RV/HCd4pwRro96hCfOdv4J7aPC1q71RareN3VrPDJMUkKfLzDHBtS8I+ZdkBoisEefmWu245VBg/KDntoe3gOiDXASvY25ACaTK2fgfokz4mc8UZTzPwxjHVJ1lR6M4pGwFbiX67XPT2TQ6qomeSnTUwSh71BaviqDzgTS8qInbu0CKXWqwmWKR0a+MNuU5yT9TiXVPhUekeykYVuAygkYO0QfLfZrWYflR/R713pwjKaFxFcHlOAGmLfCQRvvpCeV+SUtaSv/SIOqHX9LjgeGS058RQaqWVsJHz9vMocVnSgXDO7rNifGZkjO2Bd8SYXRU1cA+E62vmVqqvCWr683wsyva5CvTJ3f51/ca/dX4CQP0cpOTjdpr1yBK/ff9OBvC653axrEeFDNbYK+B2HUQbBHO3GBWUBQtrniJwv1bxqll8ZlUZL2sn5BRyDUrmlhuDrTBwtBmlhtaxIg7+iExDyA48gS0Av/DgSrVq87g+vifymcacxqpbEJwmbof5QCOr59tBtvINN0HEHBDA/QiIz2aC7CuGDTnaWjV5CGxieHibJ/+LkmfZOUJ6GeWC99rhsGyQkd9dMpqiPcw5V5IMDI+qZ09770s5W7mZ7WhdJBeqBabgogmHAFIvOPeZBBVQh1sOMbTLE2tYFRa+0oOrhNSya5gSnJFwTk4qIyRO7ImoBZ/YUvPAjZHOvX8M/x+chvMmNcEHht9ToBfT4coaC5FUBOYjXRqfHFF73q0s8617iZBrRuTpN0Lbu6nfg3WUOJFlzvjQ7o5XchqkmS7KraSTMjyRzQfPdG8tQnA6MAYcAUhf1hhP9HwMjMSiotyDE/fYWH9SwD8jx+M3LUtXcZio708P1KNUVooWyQTAcSXNLnjEqd6sWZKDk67FB+Gk1YdqEJN3jvQW2c6DiAA=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should add transactions to accounts if the account spends, but does not receive notes": [
+    {
+      "version": 2,
+      "id": "5495d6f5-06a1-4698-82d6-b97ce54bc467",
+      "name": "a",
+      "spendingKey": "b537e8104d57e569985e82dcc0ae06adb89627706fad4cca4814c2a3e99bc956",
+      "viewKey": "038b0595800d27449a04445102fd9562b7def7a18d14854b738f6d8dd1bc9835930fc22ff574ecec476493097f313e812b045ef4916172af07d4a0444932949e",
+      "incomingViewKey": "fd010407dd716aee8cd7fce08f37a1dd50bc4a6962db62550116294d49754a04",
+      "outgoingViewKey": "f612319b9c6313a2550845c2a7b20aa96c070850066d4c21f6370b9c994588fe",
+      "publicAddress": "8ced0b411f6306a879b382d7ce1277149e49a5b8946cf8d43604720a7029072e",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "96a011e8-7f8a-4b3e-a817-37f473956d5d",
+      "name": "b",
+      "spendingKey": "4cbad4555c1c47e5b4ce33768ec9be8a93a544820c27cf5244bef458833ceba8",
+      "viewKey": "cf8955adf6e4273afe1faf97c19aa386b1ac294dc7411856781a3872892422131d8eb6ef87fb933695ee81e1c545566bfb0e7db6cf6f86d9c92d9293594ffd04",
+      "incomingViewKey": "1b4d4576e28210386360d72efc1461c8528d35356739306a7fa3ac12cf755e05",
+      "outgoingViewKey": "53e509abe89a94410f83e19781521e68ce1d128ca1bbc28a1d87473cd4f3feb2",
+      "publicAddress": "395abdcd39b48cc0829799f2dc7fa08820bc2c6d8c651ec9aeceab4d491fdcc0",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:vqP3MxN0kPammQ5CL2tLoMq3wcyJBDZLmyLl/63s8ls="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:hBIsWSie0HQSAANLh5OyiEX1rEzBNtrlONh4csJTpEs="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156554118,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAFP0R42REKsh+nJbSaaK9+Fvni7HK/Zo76Dqw/CbHFymmhAjsiNA92sjeu06fgZvcnm6Y+lTcLKW4KmwKf6qVeHI1/ieGB++SB3dICh6S0y+mJEkcPE8Ap4IHJh6PLnbKwE1zG3NXdeidDbqsBgyl37c/NnclRus+Gy90mzn6V5gDvknjY3iEDDNoQir+FoHQZeu0XF7F+lGtU7VLLpN2duXYMgKnCj+0bAhmgOkivGaFJ2WIvCbxI5d8nUokfqw5Le0kKEZjR/xPRqjlp3BPj2XxlmV7b/C1wT7Zs4dwCX6zZNBpofo+0oBE91OSicp3cEeVfO056XJf7qpJ189/le03PIdpTWPYmtvYAUHCH2oNQqALzoVJnmp/AlDBSJhJc8ZOiI0eBBMjo4VNt3O7AOO4ywVEplrnfL+VySYcms38ZY1W065eecH6dKgcympOLX6iaArHhgVOZf8YVjZl47YrarMZn1lSzLB5d1pHJzrWeQfyr5cELDEEKQlAJnpARKWPAWDhw1Kb/aCTdTSUOSzh04+OTKnRvoC/fTixFT96syK63n8UCpvjtG6REjxXzs8Cx9dNMVGInWv0RjeFJrcCREiWG6IiXG2p360h4ucZHzW5DvBYz0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhmOGZAPdz9rPb+jSi7fcUzk6OgI9tHL+stNW+FEluUkMV1IsqYsCopmA6WZsjdUpnofCS+J1yx2SWVSx9vBZAA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "9DF28964F47F08B9012C3B6A281374E3BBFAEFE399F323E87CF24EF74E5E59EE",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:rsAVo321LPapJz6mH0MjTOedv34+55DTSD856LmCCQs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:HiJEwY27zpkW4G3u44X1IwZrTxgsLNtYURMcdzgubeo="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156556176,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdiUEf////8AAAAAfgDC4UM9IEmyigADvrFzW/wGbkoFu1IrfzR8ycKJcySrUNKfkADkN78ic8vMGk4BIusHFlh1Mqoymw0oG049zLsjipOnXJ9WhHoNmIrgb0uziAGPzSqVHuJB1g/INlUWCnDgc0T20A64B9HM20GWCJCi2SG5Z5pGbbjfnGGh4qoPB2jOOKz7NaNnFJcGpqkvnrAU4dkd1xXnHyStz/3tN2e1bKXXP+Uh5PUzcCSY+QiMqeNe5tIL/lB0nLtLyMD8Kmq67WqSmjWOeNPVh//3wMsIc0pgWXmcAu7ht5ESauLsrxr64RnbpiOhamtKclY5Ebp5oMQkSm15TcP13KpWZ9xcQ+Byzw2b9C9qMdp/8ZTcv33M4l4Yu0OAv9dRdbsnae5AGY4mdgrKnwSXXe4atHnsyhqxZKdGmjSj+l75ZDSdmEI/cKXVbLzVTC6Qr49BSRk1Jiejo/uMHWWCnOnx2Kj2VPqOobaANAe2/gpqfXKamnIcHv4w1341raFJvqMXnaxKqtvCvCA7quf68yYVxZHsTm7XZ8kLYpJZv8KYPJFE3ehNk01m6MEGXZlW2+0iGiKVLXQg1+4GPCnblJOIcJwZYLjEdzWJI/Jv1NC4TMTF2Ucncvd+t0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwvUY5nWjqcYqdYgKbiG/g4Z5T49pAFLAyX5/83sxA2cq7MSsL/VWG/IwauIKu6ryxWPvDx1D1B7iMHH4iNpXYBA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/5M1dwAAAAAAAAAA3pOWnkNPPPPjY/O/9tGuoROrNvU8LjGorjClcmz8jpiQ0VpgMNwHVh+nVjLBi9DHHZGmTIkzF9MXhWv2zJmZt5PA/dYTh20ABtEruLFrUjqS32WisbBykiOahuJ6KXwCO4GPxiYI5NzaEPC7hm1XTc7djEg2UIc2Z/GPRr+M3V4Ay63LoZ8VgRYwkW1Z7GNuUd3wX+Msx91AvliIH51JgjXLnrEUND6u05CVmpFmCNuSl+c7YjmKTSaC0a6RO9KDCfZ4waO2jpbRkhvgCkgWLMba8BBGQcMQapFGgZ1GWnB+roNTAYg3k7BYMOoW7eInxAikFFZIKHk0JijIbqQbqb6j9zMTdJD2ppkOQi9rS6DKt8HMiQQ2S5si5f+t7PJbBAAAAKCt0PUWymN0IHY/rH9LD5BM/ypibSECXIg5W4LTd1PQR/zvrLC6ElwOb8bYb8SH4hZT4TAWxtFRz7eXXwPU3uiSGeiV9bdcfCQznj/WDPEWW6VPLfyBzl1giYt2WWolDZLhYKvdb2uwvl0VWqCRwuov7PcNuxvpjjA0JvBiufqu7gLb5u23AKK4RhYlBBEHSpB81IQFupWBqJlh5EpdgT50cbPYL52Vyi60X6Kn0I+oYyXGTn4FWwmM2Pbppxo/9BiD/R4tsNxuqIpKMoTIXllp1gHx5KLYGfCmeCNv2qOjLalLoo7a+2z+h0EoXO609a/FZfXKvGS8C4tF+rBDJoKcwk98WWvIXTQEOwi8gBLi2HAJxiLZFGNeCAJUWM56OxyjOb/CIQEX91ZaqwRDJqqc5Y9k2GvNZczoE4eNQr22OqEXkmsDKwKdAdD+1kVIdnDR7rVWsKaoe2IlP/EpvmfT3Ngxe2/gRlRawN63k14qlFpFoRPXCkiqbDLm8lgKPCCM1RHQBs6p2f2SNZXq1IdFo2tUTadB99YJE8gUXsSIi0K94H4odrzq4S3Wshc+Ha/xBzhYQvDw0ZlELk+Hn4Euy54fZZiwwriEdiUZNYfxeRZ8tNwFU0iy6tcCOOnrYBkyHYpP5vWef6L7tyvrOSiHqG++Ve81RpnIrmJ9iyZHgFa9KsBAmwB7b7dZUX191kSDoZEc2kuli278WvF0v1TE46cIfN2P5vC4U2RnssmvncXmLzfNKmn8q2hTdR0bRCyrZNNJX3hmKlH4i4Kuz44nQMJGRJM+xVJGGb6t042wtWunalTkFesNZuLWqjXJHaW11VZjsQ/wf3W4LWns+jrs2h0Q+dsShDkA72SW2+lUu1QcJXpIAYkW6h3r1/vva4z/c26xvlIC"
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should set null account.createdAt for the first on-chain transaction of an account": [
+    {
+      "version": 2,
+      "id": "41000019-5ee5-4607-8040-90a27232c304",
+      "name": "accountA",
+      "spendingKey": "3776b4caaa6d8d9d43912262d23b69702d595d6bfbcb8f9f2c544474375ebf4b",
+      "viewKey": "e2a58b78d0027488407fd127bc9b6fe8248ad1ad2d1a3dd357b8b1b64871d33f807c871f2c57b42dadcba52004f511fbb3a5db29caad2a6c2d54fbbf1e65f44d",
+      "incomingViewKey": "32e98a6bfdcd04b2d1f0925afb8b571bd847ffb7541c34f9a21fa1c9c7f55c03",
+      "outgoingViewKey": "3af257be850dcac37b4e3673995932f9d93d89e1ebe25d5802edaff75adf2a18",
+      "publicAddress": "a00faaea59ade1a2b204240d13d60c28a479a2f7d763ff2172196ec370c73d63",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:BImk3NLZcf6VYK6yw/5SymKWMVFKC6JXWP3abAY4ohQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:9eUAgjM/qlXoZZrVxtNxLVlkrIf5S58WLlP8LIPDd2Q="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156556997,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAhUHTfMKj+SH/BX9jW/jhIfcfFJAQIhxGtr/AR7ZLRCqsVyRvzVfgzJvqjIkVVsuXG+aM/XOZ2W89JP/cN5QScE1jnIuftbMnz7RumXQPRb2UhjMlxA0bniwkPfR8yLaUB+fFHXzYQhjZPN0Kzam6YQRQtR13iJZ6oZCny3f/ngERtDZP91c+BHklqndDd9e2WV4TO8vLbhqqx9sW3/IJsUrwJoSemLYxW89SUmUdKSiQuGOoKxSfcRIC94q9fs2zsa4kVpIEh899RPhOJJHElWDuuSu4LEcEbe84BODhG/TZZ+8HCntSqa7qNiOCsSgPJfKeQ707G3KVfi41PK4ISOAsWVwNu4wfm24f7fCHzIL4ewN3ycdA/0bNdN6YFx1GtjMbeAtEXl509Y9EZuBh/fKDbFnDwoFQm1aIQqw1unI2BZz3HAgqSaiELa2WFjN1R4/Vw8Vt6JQJjUc9YhUx3NkVhe1NGGbbdtrheOp6ngRctUScpM7SmgIG3aUow4Kn6kesC8wGwl3a17H3YCkj6hcv4y3p/7tQJNTrBgT7TiJvo+k4vXHKiC7f/dj5u/a/cso+3qbflTFKas6YjqEplHq3BI+ECznsPlQ7eizOBxcYu5DEHrElb0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXecesRUDed557PueugD466GRaiWdBWr5z+rjAyXVzi4ga7ExnaqrJq6K+Ab6q6d5CXz1KUwE0QkuBkHWNierBg=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should not set account.createdAt if the account has no transaction on the block": [
+    {
+      "version": 2,
+      "id": "43ea32bb-5605-4d83-a694-1e182ffba7b5",
+      "name": "accountA",
+      "spendingKey": "98fac67a3bc108d9e7efebee9945b11e71b9a17c5e973100507c91a35648d397",
+      "viewKey": "899553a999d705502d5f8ac6abe85d545c5f53b9d24b142c6489aa7fb5099f4a5ab8ed712f6fdc2c2558111e8617438db999e4d18d43f6e7c719d8eb1ccc2866",
+      "incomingViewKey": "f47d18df786303253490b84e9cf4db30eb0581ea391013a0ec576e48cc645e01",
+      "outgoingViewKey": "17b8a62099ff8366c88a144b19e9fc3816f6a38a4d842578cf4dcaec94374f24",
+      "publicAddress": "85b16cce3b131b374c8192d24ec8c72def7cc629ab43315848fb6d3bd08ba286",
+      "createdAt": null
+    },
+    {
+      "version": 2,
+      "id": "73a44a3b-2c9c-4190-9de9-e9de59599f4d",
+      "name": "accountB",
+      "spendingKey": "a4ef5d7622d867dd2531b936d04d099b381d4bafbe21d9ef6c6f9957eb8dbe26",
+      "viewKey": "5d2516e86749c5ea7be330234210917f3a7494f9e86e08df7bcfbe7609b7b4c889a09c51be94ee0137ca457f1146ece72ded1d1e6aa5266598ce1819d9c1ff68",
+      "incomingViewKey": "37ef862d09931ee53764871b2227f4e7ab0d1931db9c48748da9188779daf002",
+      "outgoingViewKey": "3b378f91ee14025137cf781abda326e4774e61a3a9500db7a5af67e2f686f5bc",
+      "publicAddress": "ed0fa5c96281889ece7a7d104bab787f14157772857bb0042ee385afe3331642",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:2EAX6MdcN4PO81a3ww0yFmuHmfbrJTU9RBnJDnMJ0EI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:yexg7JANTkyhSie7jKRIOFNqQ4zBSviktdcvBZPmtIs="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156557825,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAlAMJYDUCjdBPBZjDRV8tS61J6GfZm2UdKuwV6sH0P7iIPg1NgGjB7tgdcyqZ5GxQ6cevwXkVtWxHhuJy9nev8a4+19cuemAdCaHkgc7inweP/RIdqgl/qaVr/jc022MQw8nsHrKGRhfLij7v0VodMU8GIK2Bj/x3ZN/NUsjIpvsZy7ULrbvQyg+jV1TMKXx3MonkxFNsWTWC9FNZ7oy6dsT3aHhRALe/BYA/i+SuGtOGWId37tx+5sg5eGTbY54pK2LBX6QxIwgIgBTtv/GxWB8iP6E9KxWj8q/EdvN0wdlgkStd21Xv4U1zN91P9gzMpF/OpeOlZ2gDL7TAxJTdWsVilIrTdWB3Y8Y+NzAqeq4aKsae+jQczvQu8B2tutUt1RPlH7mS6BQyMqSsK320hufz1CgXmlWBLrfC+x0YkpmFjteRd8SIPoUzOfZuTMDL2lC35HPh9+7ZQMaralK5IAbVZQrETK5NVldg3NQWe9tf3Viive8C0X+5T6wT+vxGyQj39GoWE1t7SNAhbTI1m95wBtg1Xwa3WgkX6wfGqBloKi0tqd3E/IN7M4jEYVXgrYBuop5wbugkz+dfXglLXQU3+5Vx40kVLbHUK6+m1y6Eg0iQ1FOTGElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwHnYuPZ6KNk3H1urgojc9HRflELTcOzeh4ugZ0ZoGeSIvA/8AI+ifK8F3AY6aKrn+H4G/H+ke3Ke3OX1VYMhyAg=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should not set account.createdAt if it is not null": [
+    {
+      "version": 2,
+      "id": "c110f746-1827-4102-9bc1-3920413eae60",
+      "name": "accountA",
+      "spendingKey": "90f195ee933cfe868b7ac98dbed8910bd565b25d738b59e64d2b34cc45abef96",
+      "viewKey": "3db14011c7fe98c1b69c1b11db298c4a05bc498f19820d03d37580b145392cf11c066c9a0acf6ad7ce14582ffc57ba98632c6822b97825107d74f4400acd0b33",
+      "incomingViewKey": "629ab3f4afd0de0a9fc765d3e61142ceea4a6fcecef77ec98305a411442fb803",
+      "outgoingViewKey": "cd8d1aa3ce9f421f3e3457e8a60b4a071f144f8bb5b11c719ad41968ab269c19",
+      "publicAddress": "64d501647304cd58fc697ccf40ebb7e9f82548ff69fb0e3cdffcc4620e161229",
+      "createdAt": null
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:9zvdUdEVxMQxzfdBGLgOIR6/WTdvfWjbpBs/mSL6Ixg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:6QXmcUNG1v0+6dbOKLU10kjkUG6oG1cJcQDD1RN7Bkk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156558650,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAJwU55cyim+mxNe0zBSYg777+jd1KZFxHY24KpFaWTz2qJdoHxQzv+ngypY5vHnAoBgQdjmPXQdl5+ghC+MI4S9GV64buvFOo4+xg2Cpwxk+Ia/S/+2bUgpNwevVTAnonD6X1lzba9TEaUhyVaumbRwKuCZhJEM6ksoLZgRO/EIEDDPacr9RG1/BuOsf3+djNecvIdeLEdxEXHBQtvymGAtyj2ys+HFIgzMc4NpU4pm2GI3swLFkc2zrJvyYgZaio8zN1c//mL+wD/CZ7IqQIH5lBYK6zG34VpV93DkxMPne9WGg9LkDsF+28PK8N51QQy1be7clF5cba8ncGiWNRklOlGBSabYwEXy8C/owjLZTYaOaHMphjuRwS2GW0klkNwrDNnnRq3KI7WaseozhRoLlQSFV0ocyQ4WawgpWOnMxWG7u/Iv9LHoENx0Krm4trjCx6KYENkI4DBl/hTyUY7aLLqjwKfTJO4tDIsffmiuOM/C2ADBW0nOcC5qSFoLSjkkfjWX66XmnKsWLjN9Pq1t0dTp7iXUi+DkECGDsM3iQF16tTlEf+zpjEt6Qm8RHamL1TUfrqtMW+yeRmkWwKmKv4Os62JMcwQzCGGwwz5yeScXFtBjzxaElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjX2kGSBkipEg11K+WH8XRKaJCo9g4MTOas5n+3tD8SSlTjkcykGGRbrEx489Aeh9NZXiuHTmvBtLcf7WpOnlCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "6DA97D6F0A69F746C21961DCE21A3A0C496399E6AC861CF92C30D253E7954788",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:GMFR1p72cG2ls6I4OhrKJOH4SCQGlDWyfvceLZHqVFk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:TmQVOsquSAB+U3R0cRum7ZxeMTiZ9FmMOIXVFwRs/no="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156559157,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAASJAVneoH8rzxyJ8+OymEdSbKNVJyK7zBYlvY7x7mKRWC8EyTrH81L0oibFJrJlaIppHt4FIVkvWP2d3gglWeg3WPlyU1RCBQZNUhGrkecC2znbB1sBtNKdMOg6wwUq2KrsorUclc8GA4ZvrJp/YaGCAxs/3r3hl9YRq68VLhHO4QcTgzX7PRjrrb3wfdciQAytXhkFsnLuwuFNCCa+BiGSv2w4M4uNqnjoZwCxwjNO+2Sb8+GUGpgTZHciDh9Cc2XLPx+9U2NLyklV2ac8EKhHjPPjhUdB8lYwp9MJVcsqE64SvLf8Myif1w6wPH8nbHqeiFYOZWLGxnsSVMqy2Brcwl/0Nr06oz4tYerNhEESWy4Six9lPgWsy/oNl0VuYQUC6skY/pm2xaQRk+gQfdJegAE+ipVvrOLzWkBLr+O3N9/Dy3yk0XzLlHxuNPdbz0pLQxKjTpNzTT9CNqUnsaH4JqQkz7Gn7NeGQLks2HGeKT28u+YZQqqL3C+R/qbvX474UAg8HxkJtQVQfwPVLVuDgXzyR+HnihIYYy9+SmN57IdfoObm8DoF/NnnddSYx6wQZkNfPTxYqvo1O3Kwedd0OhADGEvd1etOHCAnNczzFil3VKSYcYVklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCTR4RBt7TIs/mD2gZvXwMPHoB4XiLfH01NfQ/umPSoNHekjP7NyFC7LaRNe2PJqrYRt76zJSfL5KzcyEwN7mAA=="
+        }
+      ]
+    }
+  ],
+  "Accounts connectBlock should skip decryption for accounts with createdAt later than the block header": [
+    {
+      "version": 2,
+      "id": "775baf86-241a-4985-8e27-74cd47cca482",
+      "name": "a",
+      "spendingKey": "6a692a79b0dbcdacd60f5c3ab3263ffc04cf2158275dbf22d4350d10cb24149e",
+      "viewKey": "57784946c2492c403957e11712536dec55589aa90d37bdcb7dd525c060626a0c0413582795663d912b74c41c180703abcb68119a0fe5bfe0fcdb41de0bf23f07",
+      "incomingViewKey": "15b967271a0cccc5fda19c859e5481c784e0c19bc215e2e8e5cfeca1c42ed202",
+      "outgoingViewKey": "e6bae7ac0068b970e784f4155a07db1541d7c739ad0ddaa60114b6ce6c537f58",
+      "publicAddress": "62517b3ad7e6240fd508006a2e1fc8b8df6657953c77fe77e107821d8e29ba20",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:/tPEg7Y/ydwmuXEM+nUWJgdx7E6ZepWDDS3mJ1jOTV8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Gby6M4yJGAYRKWkQyVgFvjSAj6+/Ymba5x2oA5IsXFA="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156559971,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAuBvd3T8n171vzfaTWHpDM2MMuDnA+D96yseGfC5qL0CPBN9jVXMakjNBfS2qMR8/zkl4KS4187e+Wy3QKGFDzvZUAodXrikJKSCxoreBcpWpHBBITinBRSA0RgS1sy6CSy1+20vhx+N6Tj156YVPzFFAod1+EIhVzXjANczrWWgM0jP3NKnB5fYTUB5mWllrtzy3SKQylLGYeXUS6hFKv0/WOJVjGeAFEtTNTjEQZSiy9gjyiT6jGFTRB0BNsUQbxJs8BmF2T39w+gPpLkqtJwM2apcwSVdt4UV9HEso60Kt5dRztKFJ58jyULZ77CEzO4mr8eKyOGKr6I2sqp+QCnmUEaU6oCy+cWnY6CXQLVzOUocP41zgh6LaHsoY+vQq/DtT6XVZk30MLTiJP5jiE5E/fyHnZ0DgmqXhd+Y8yqw5Y/Bo0DA7hSccVjzJZ2Qtgavu/B9F+A1xSqENxpMgBZQxz5ry4k6PNhw1+Gwq26if7IjWlku/NkxggMKi0F8okjfkN+9LbqFU4WG+Ub8ejfUW22qbRnw0qiEtk36JhjYrGtGEfvPb+DSxM9DeGKk38ESGFgqmu0sUmZyEleAl9tnX+PbH/+cojYpA3dKDZpb6xpUaJLUDyUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwmee9gQZsCrBsXQlG5RsbRHhhXnEjF5SJSjx0y3wh+0PrxCB8kirh50DgPQnlrX0PKfAEkKTiQnjwO+pc0EH8CQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "8DA9CD90C87253B240F71CA90F9FCD843AE6D04D7E19B854528A779B746C7EAA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:zCPjxJjD6urAqSRpbcAKLuUpNydIisc+WVv56grdmmQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:5PR2MfHQLyRi7xt8DQZzh9FRS8LeqDEPSHmmMhMZsOM="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156560482,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgkCcvv80R5zKX0bbdKEA3ekQymJAxbtM/UfnjCBTkpSxTMrFV3oU0OIhjSO0ZgH5AE1RjXo7IT5jcmepDk+7Dj+rj9imIK6K6kiw0a2LwYmE9Pske5S2GW97B95fqGN5+/YqzABwkDnTPhfhb1DDt6bxg9AnWZyI7VadOUrK/5QVe5Jun7En+MCiCx3LlwTvhIl/W4mmtzw0xULg+98diKzjKDBSzCvVYjkyQ0bgONG3wvvgEP6FDa6M+7cOkUjg1zAseOxe2wwwufeieAHc+tDT5gAriioITLx+ztSccYiQAfYDvJrk4ytHZLmU7cUzHKkoD2TDn2LC5X00FlslblxWOT8K8sL63ae5MMCT8GbFmA6PKlBfnj1qOT3JAf8jjpXHXYs84OmV9VHyWVdFLkhrqWuWcnwG+ROuuQo1Xy/TW6pa/diQJRHkUeRRtKh8CMUQdpZgn49mnQiCSD7hgpFgZ3bwbLUyazCFiGklN/8sIdMHunpMNvDvyITIeq57j1YnM3cACa3ARpLqdhj2g40BYFYj5BD5++cy7NrgZRdbfGi9Rt8ONbiY4F7BxKK5KXeNFPdOFBjdE6m2I5+LhB2eNnybfJSzNfj1cCYx8pDcDOelecZPhUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwze6yBg7atTN5kHzAuEDGu8B3gk9MMvYR/aY7QDJe8D13zpkZGkrvTzuM4MIHO0n8nLK2eu3Ciby1bjS5wIMIAg=="
+        }
+      ]
+    },
+    {
+      "version": 2,
+      "id": "5dd63c44-432c-4914-95af-50e44b8bf767",
+      "name": "b",
+      "spendingKey": "099b88e4a287c47834d29ae932db2e14562aebd5a39420faac8aba8e46c557d6",
+      "viewKey": "a374336a9cf66718e3cd5a35ae95b44b94947fee40a97dcbf5dcf1ae01550547050b5f5ebb4be5f401c43f36907faa230ef89a254e10b9d848ac261bfc3b7815",
+      "incomingViewKey": "9ef5d39406098c5761bb2a788768f7d3592f3f67fb3c8d860f4c827440831000",
+      "outgoingViewKey": "d517664666c40a3fb4ce95e6a8f85ef3c4e974d635ef946ce08aba69fad7f58f",
+      "publicAddress": "4d460b640aad0c5a75b04e811c1c5cb99e162222b47682225c83a4cfe1e8d44e",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:UyJidEAs2va5WENxE7DMfmI47VSlQtzZ7CbhFze8Zas="
+        },
+        "sequence": 3
+      }
+    }
+  ],
+  "Accounts getAssetStatus should return the correct status for assets": [
+    {
+      "version": 2,
+      "id": "3f190beb-39b6-4ce8-bc3c-6809bd19cbd6",
+      "name": "test",
+      "spendingKey": "2609a9ae6daa851170a94b617a06d0144ea6090d5b2b79dcb64ab3cc0b7570c2",
+      "viewKey": "2a7c2fd7a2934163eae7995b7561063023598ecb65dfd7be2e94df777aa3d2a0b1a96597d3cdfa3fffa42d6f8016cf1754f64ef38744249804da11afbbe5f05a",
+      "incomingViewKey": "08d25e0aa1e1181be7d272a074b21bd8690c0fc7423ca28cf7a6ca00bf61cd02",
+      "outgoingViewKey": "3072ee3eeb2ecb41afd1b1442a7dcdd4dede84e784c12b5c34a3663f615a8661",
+      "publicAddress": "ab8ef320b8c010b069f73a521b47768b6aa2e6ec18ed77296ac5b499e4d0e086",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:gxfmQY8m2p8wQmbjf0cDx+ZTPOt6cJ9NOfqwg+/6QEI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:AzIf3duChSA0VZwb4ZN8ioilotIqdcGU/vRQxltEsq8="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156561302,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAuYByWuSg3s9QVHSf3m+wEyhICEcPJ6oaogvdogc0eo6Wu2ym++9TNX7j3e+O2c7Mb3b/KcXGZW+jcr5dGQ44LrW+a6m/WN5etPfcVHcYPzixmLdTcVk2PbjVtBYAuGT2Ipz5f1H1QeCtvTVxw30lnVX8pClt24NG3k/mTy2faL8QruPieD4dIynU3bBcCe4/6NEYXlAOFRA2QUbapYqIeE7uZzkXCEPb79bJEkbqwIysl8BtlnUOlabqMF3UgqVzAF6SPNtvtE6O4EOl2ups2hReIZtLWTaJ+PCVNAFQHDwlpV7Ar8ZAFK7qGwMtflIbDxWLcncAPtgevNymgvPCwkeSqEX0KSVfMRLrMNhabGK3TIlUE2aYiH3XNxtToqBv41BGFwiyTqbeLyzMULecV3rBLYjalBgSX0onldDWzkMWvAE8IT8AFFF2J7nykBRDAXwmjO2h8RA1XQIsiUvb/xUP2WQgjU6oBmm5Fm3eVCIAtD8VnxXKsR1BqdeysdMD+MlE+Yx4iqkNtxrZ6jyucpQL6euWygQz/Cr6WISxji2EjMcqvcWj67Tguhl4Vk0AjwnUcpC5qXVcpETtf+hYpvOj8V+1f74B96NUS9xs5TsoEtpCY/uggklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwfyGaKzA6Yjm6WGw3opy3km5n3j3qxz0gbdQbS5qGbVK2pto9sWmGD6VEeLVunaZI2miku0pHyeVWJtxtCXxeBg=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUEWha15Wrn6Js+FqcnKR1AE828GnwdUMvKZeAIClYJugrH98ikDXAKMIsuPEosLVUupLT/pB77mo1j8FdyskwlDSx7R3WD/b7LsznBAaZ/O0+wVmKDTOo2K+MjOFno2Z6LhzOZe5kTj1UrBLyPrrU8Em95iOptYES1YwvThLLtAQLD9gYb0wlGKdosuxjGvRmCzs+68uHw6ojTQc8npP/7BK9CqWpuY0IegM3TkxmUCQjNNXbu+11mP7Pzfqn6hfCO6DKLHpQQzxWkvgONQiq5qj1vlcLLKyj6qmyqiJx5w6Sa6W5ClF6PObgtheLFu8eEzZbXg6SQBT1GRExwqDYLEGRzxh8mCjNVqQcZcpkXr2CuBKyONb8DeF+IlEcYBqIYVzizb+FnY7rDj718mRUCDSV9w4YlW60ImH0xay8MQATUV84a3TXGGgYZMJ1YSlJCRjWXb4tKtk1ha7ZHsBXK+yXWYyqmLUcVw9+myc6VHskg97FGv+K+xA/Yy7kBfvZhcLvndF9t+0+B87fUhMN2PP7yNwuzBua6Zjg8Jfln/KIPDzymPj56N1b2s51pm5/+ouYj0wgHxHVNUZz8nOaDvXrFyZ6i5OcF49svxh+dNRTg/cCSKjpqGOf398FPV97bGqqushkm+TLmRtuT2Gp9YU+CCJP3pbQIr7QwX7s+/Nq5tgJxEzpPHm3W8oR2JUbCBsgGDUB9z/+2qmHxzhDSLAvKIyEYTDtrRoHBBpYEXZG0u6OWGXvnLJ2rWR0YgEPM2+eiql793ZzEICU5isw66JcFEBQ/Z8lo8kVv5YL7LdRltGunGK//hyoP+cbLdcr3EMSp3/xSoiQNt5tm5VHESZkC80LQgdADKy4MQdBtVFNdTbEjCWkGkzm+0n6FsWUZYd3y3v8CoMn9Nw1ZFCxBqfGUGJniS0mYxQx74qpOiMtr7cxGN4iLT5La5BzSnJIT2CodI22AVeJ/PqXzhWOxk9i0TYG3PCq47zILjAELBp9zpSG0d2i2qi5uwY7XcpasW0meTQ4IZhc3NldAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAD02q1iTuhukDW2kLlTJZEa+Hrot51k+AUX0tfKUCQrhnHenmOk7ECY5wb+gnbQfAvfO17SHAxrjYWEyJgNmXgViDXmI1AmC1qU39vawsZXVfWxIoasmfaB5vNiiJ3o5MeprWlfJKJKgyI9ISUqInqd73T5MVeS1Sho+eGeGcv0A"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "291940D0BEDB551BF34622594C1916632A25D323116F3E35924FD2C3CB609686",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:eqkHjH35LE5gD8hECCP4eGdtifooI6vOzH3XBS+JrFQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:vMCOhI/PWQDLy4MEqvIqhOAN1p9hsU5Gwjft6FM8BiU="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156562590,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAmuYFMRa/qHOtX9nR4ufR2wh7RzBRHDYkGzTxZ5XL9Zyr3Rw7QdfD4GFhOp4buyUlPZkULxEMnGy462YL53a44V4A5dBE9kc2Ug+DP/RDuZeSEOfjt4wqmQpYThIjBO9/QyhPv/Zpr8R3gwh3+0i0FdBJE5nCY5s7LKbBfIX9VCATQZ4r9Q3CRKXLwzCgEAFWRZqO+m8hb8+yFSS4vYDwVUwfWkJyBjqOMXX0poNVNUy2Ml5NMWqqAOSP2IEQKZTnUaFm93daxz35vKCu77zyDdViwSG58iLFbDTXj4ktW8ksTFDrFbDbZrKp14z3ChaPx9rknRsioKl48od2u0SbA6qwObGYeNnsYSUrWmFHsod+IjKSxgMsJjkq22AktycrMNZxOmddfs2O/DxqgcZIKt3xF9JtYK8+i3YOwuhGFTb9W1PhNSAtwfdCQ6XZ/XvcIgXedV7rghHS2BOOoC5YSnRPSqFHvY6gn/wb4e3Ma/toqPkjNLIRhzLle1+9RlyHQOa7FnolMaR9jrDRofgLy/pfjUOBooPDgc7X0/Qg/8Ds0uRs24eZr+7P/TH1ufUfYHmyufjHOdbdbB8FdMz1GlN/sVmTeaqsULHlDgGlbu/1aU/Rnjd+gElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwJhACOGJg26RKh9cAlDwq+me2XDmUx15G+NA1G6w+TxpVJtjxeNmn/T5kHxNCoMoAd+tTixqFFw1ox7GjwYi6DQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUEWha15Wrn6Js+FqcnKR1AE828GnwdUMvKZeAIClYJugrH98ikDXAKMIsuPEosLVUupLT/pB77mo1j8FdyskwlDSx7R3WD/b7LsznBAaZ/O0+wVmKDTOo2K+MjOFno2Z6LhzOZe5kTj1UrBLyPrrU8Em95iOptYES1YwvThLLtAQLD9gYb0wlGKdosuxjGvRmCzs+68uHw6ojTQc8npP/7BK9CqWpuY0IegM3TkxmUCQjNNXbu+11mP7Pzfqn6hfCO6DKLHpQQzxWkvgONQiq5qj1vlcLLKyj6qmyqiJx5w6Sa6W5ClF6PObgtheLFu8eEzZbXg6SQBT1GRExwqDYLEGRzxh8mCjNVqQcZcpkXr2CuBKyONb8DeF+IlEcYBqIYVzizb+FnY7rDj718mRUCDSV9w4YlW60ImH0xay8MQATUV84a3TXGGgYZMJ1YSlJCRjWXb4tKtk1ha7ZHsBXK+yXWYyqmLUcVw9+myc6VHskg97FGv+K+xA/Yy7kBfvZhcLvndF9t+0+B87fUhMN2PP7yNwuzBua6Zjg8Jfln/KIPDzymPj56N1b2s51pm5/+ouYj0wgHxHVNUZz8nOaDvXrFyZ6i5OcF49svxh+dNRTg/cCSKjpqGOf398FPV97bGqqushkm+TLmRtuT2Gp9YU+CCJP3pbQIr7QwX7s+/Nq5tgJxEzpPHm3W8oR2JUbCBsgGDUB9z/+2qmHxzhDSLAvKIyEYTDtrRoHBBpYEXZG0u6OWGXvnLJ2rWR0YgEPM2+eiql793ZzEICU5isw66JcFEBQ/Z8lo8kVv5YL7LdRltGunGK//hyoP+cbLdcr3EMSp3/xSoiQNt5tm5VHESZkC80LQgdADKy4MQdBtVFNdTbEjCWkGkzm+0n6FsWUZYd3y3v8CoMn9Nw1ZFCxBqfGUGJniS0mYxQx74qpOiMtr7cxGN4iLT5La5BzSnJIT2CodI22AVeJ/PqXzhWOxk9i0TYG3PCq47zILjAELBp9zpSG0d2i2qi5uwY7XcpasW0meTQ4IZhc3NldAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAD02q1iTuhukDW2kLlTJZEa+Hrot51k+AUX0tfKUCQrhnHenmOk7ECY5wb+gnbQfAvfO17SHAxrjYWEyJgNmXgViDXmI1AmC1qU39vawsZXVfWxIoasmfaB5vNiiJ3o5MeprWlfJKJKgyI9ISUqInqd73T5MVeS1Sho+eGeGcv0A"
+        }
+      ]
+    }
+  ],
+  "Accounts disconnectBlock should update transactions in the walletDb with blockHash and sequence null": [
+    {
+      "version": 2,
+      "id": "0ad98886-0d9e-45d4-9898-bd02329c263c",
+      "name": "a",
+      "spendingKey": "defab7878b12cdd434ed9680e32bc5a7016537cf1f7e9c4b8e7078606b5a95e8",
+      "viewKey": "761be64a66210cba1a4dafe214d45ee1bfb234286ea36d7cf37f57d96553b373a682f6ca87f54c79b754666b816244a0f2eb7357e822cf6eacc5191390188919",
+      "incomingViewKey": "11a8985d4f19099304f890966c5d301f8a78e247ca6f388a9305772262bf7002",
+      "outgoingViewKey": "532e7dc02ff7f132baaab8a75cfd0ce848fe16178cdfbd05bd938b9b84b580c7",
+      "publicAddress": "bb6b687eac216c891ff10994c167c846d723d591dc7ecfc046fa7d1a8bfc682e",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "1df7379d-939b-4d1d-b5b1-8c19f3342d02",
+      "name": "b",
+      "spendingKey": "83050d913389618d5d7fa9091f5370eb6275e180a708d1110da066baa7cf97a3",
+      "viewKey": "3d426738a6766dd2f97c5933e6538d9cbca0f0c0da61175fff858bf9ef09ebd9f59076bceed2facec3e618765771e4fa4a5857bef0238ae94f0445b87b05f269",
+      "incomingViewKey": "bd149dc252a6c0949a526bd1bb8a7d8d8f7f08f34ec3a0d91592ee74a4606c06",
+      "outgoingViewKey": "54bf0b1a5bdfc40c2d93791f5d72f42a1d4f14f1b4e3ba0acaec0e41a40519e0",
+      "publicAddress": "888066dc4ebc28bb1c6de2d753616b9b97900bd46eccbc3a6e8dffc7c539cded",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:sWinNNiR1ldp9JGpVJO2tFhKYF2zeAIE4fuxJLDt2SU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:9fBmUx6NWY0evYx7AZoEhbOpIiPACskVIjCT0WkDaQs="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156563417,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA60sr0QBocoMSiF0Scggkzcp8VmrtX5n8F1lRMCFYz4qRfyD8diZBycUbTEkObTUBOEkUeo3ju/PZPPGsOvZtdJHxin+9/N8QdK94pXmWQ92OT0VZrtp8bzNowiUkFD5e7vZ/CpFVkHlJPdpP/oAabTOJcBd78Ori0pVizenAsEkOhKgKhgCo3nIIpCtyBGL6Xur9PGwzTTUavrsN6OEWdBpKLHvWgt7g6OOpVSxZZoaCkiGR769qITq48VmAw3bgd0n/Ws5AArq0Z6q+xlHx2tbRr/xPpk+8OBzyangrdFCfWhnZGfVtesvHnfWKU7SG/+PMhNFWL2PUoTuJSMwo6IJP8Iri9X2U+9LNqRsTLaHGuClKYwxiUS2KGC+0Cy8zS7H+hfj4KHBURrsiTwgaknTJOHF1g5cQC9BVGctW8Vp4O+64MSPakUcxyeLE/+OLTZRkIz7P9++z8VrokPx9Z9htw/+kHvtQqkYdhrXSRfelZjdNexjddYngL/LTNwLVzufQw32PYuI97eBPVCn9Q6q6eBYBfYW36Q/kzpIqI7nB7adRaPjOYE08TrQsbl0enkbYME9sNVsCO3ttyP60EiTZ8d/R5sFnqykoj9GL7tw1gARne+/ke0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsTGO9JPlL4gVWm2uKKBoiXJA7/C++1YQtw2Qloxz/goq4ayHf4yeOmomS45dKAW+n0dBqMx4rJUHBi5Ma+kuDQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "7223C67E3CE0CFA7B31E55B02A7E8BB8E7B7E66650249956EE6BDD4E8C4AA3DB",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:rUAuNJ7A2FH1vvqEFR4EW2JupsdhxNJXPqFWuS2u9Rs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:6Eg7aZPLEkDhMt5s71ydHSwa/SgstEW9Zle8B19Gc5c="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156563945,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAhsWH+/QCQcDbzrWp8AlCOOYUfABBP3pqrn/yr6NKFbukwv5J+EfESgLtZ1CsqCEumGVlrHlDQcC0nSvkYOVrRj1rMcP4JuKDRI3JFGIV7UikQO0x1pqtpfWCLujECg4Uqpn/nESLAZmaHPk15ftbLersBl5zXrPMyta4xp4YKRoYDW4jlHD3uboiWhq1/1pb5RFE7MJKGLq59pWKJVpawjEv5KjsEKNAKsRizRL+nI6YCaK0RAZy+0rXUI8t3ru3Ub+db8ti67HF1TCBh3CjaiOHd+svocNMhWzweXUkVHtiQejNIcUxgRSAi/4Xzt/YY+Bcxy/YzStCrqkWZ1IQtkVcwq+Irgkx93saDnsEDWo8vwN85AeGlIVsDA84v8o78+7V1B54ZZl6Mh3I5u+ABj5CL9coCAxgK68WT8xWLwSL8pwRgCHSoSctBn6I1QCCUwImR/sTf1Pw8VMy6EQeCnvIy2R4GzY1wCTgnQ45m3q3qpM2P9Bx+ZOkkJmwwvpmH9xDHR51xlWBcWRdQRdnwxFo9n+bEeYsR79Lj9VemRU2w+0k8F2XYlv4MYLHSbx3PFWUSBO4KlVm2S/3+tEDWdcZaJMA5UL4pVuGOcX1l4a1/jofS7Lmt0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwfeS3n+/qABjp6swfYxTgjfYYpB+6sG9WbmyG/9aI7NKGCg48Hw5m+7PkLv2U+7GbW3d5i28Lvv9IaWEQFaJOAg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "DD08990E3B574CEAD2610ECD1B628D864576675EE3A8BB29792C2120348CFC1A",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:A4weNUCGb8RLU7qw5DG/NKm/MB6yZ4BCI1Y3MG/I5D4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:WOYm33kIr0GCAptyzoLujA9HTokiL2Jea+VnCpoFlaU="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156566421,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAA7pFiJ775tjxZKqVZ+jcwW4t6w5aslEC4OuLALdfKdEei4GmbattsR47fttODNOhFMc4+zXxYp/AaUwZov1tNO+Lc2m9Y0F8umd0B5dBg56SDfmJkM+KZ1B5lSiN8Xn0b9glqatkdlw7dobzm/cTvi0MkVhN9IuzlaSblpJU5kjQDy5VuS/0wIciEw73F6klCJSV45u9D1JW3ecm0j1VAcZJLAaaYGqzwyR7qYEtrS0aKuQ5ZzGYGRdlnV7RnfT0rlj2OVOFG2IliOxzbvFOzHbVFgopkWNRss33keTqYOvZs30eCVoxmkeFM8SA70R/hln/6caDOKHkvLj7DRODiXJyXwqNDxMxdYVXxhPcKl2/Qtbw7zuzwo43RULwaK1tw7UjVOtprH/IfdjPcE6Jj47A/87uLQD0jwegGKtTSS9dQgY/N0hg/tZCt5xZ1SpaxPlMWm4Fyea8MCSIO25igu08oKhHZwZIXIeX07eeEzG4VF0xltRRTkztHj/KFGfxMcbqbRz0lByVLdNaAdNer9tqM5F0V+TKflvcnHuc0BoUCkf1lQQMa9znXKFpx5GQKIbiCX3uacQ3oXdPyC5hfXiHQx0jpV5+ORzeXem9AwOp1mlm7M6k/Y0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZfnlRQ1r9dMPLsw/T7wZMn3aIxs+c+3MuFUPEMs3LDCWcU+QtehwMYZ3R3TjzJxBgu/DQ1VJpkiPEKu8xVxVDg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA10ZXqKlnoU8wh/Yvh7TzpbXSyH5MoHPkrFEReA4JUW6Eau4jnIJkRcyanoElNlGqy33oNbx9O91Dxd88K1/Z2pPtCQSRVCjVISh+9On4uEivajZIlsKkl/VVk6/2nmvXmtiWPFsFuymBY3EsTqcSNpt4jNzje0qlaVnEoAH7gA0Uys7NCs2NdHAUEpmPiI9RmQXnRSCMIWwoxpSP6u2ei04fCHKmMS9LtFkPVo5zIGyybRT+gZJs7Rz5DVt6hHuaWFWuC1h6tixblcoi3dqWZHwQ6lEwCG6Lp0V7zYSpLS/YudV/ZVcGCX8yrjd1PZkcl27fjLNvs5xk80CT4AeZoa1ALjSewNhR9b76hBUeBFtibqbHYcTSVz6hVrktrvUbBQAAAI/4JRH2qQ1m4QzE3o4QrWD0BCnrPiFbLCBqX4zI5iDvlp236MOjutrlvEebKlxoi+qIR5R399X8/bJ7YtRql1LiqgC+TioUDpPMRaOYf2v53yYWZHAQUdp/xdhi1cztAIFMZWVZ5aogVN92B93q+zAuu6pZGIPPYG0n4/XfjGDC+29MQPuScuNEABkweZO5VIJCqthEQLWNAR9AQlHq0zXB6u74UaNZfZ5FV8yXq93szSu7Ap9R2OYghKENTLeXFg5Ut28gxG/377zxHD6LgrRex0aLYRu3+7gcGQ8nrIY/9gOU2jdCktUK8UC7FP+OcbivhFgivCwD4ipFm783aNbev4l0EtaIifnTXoK8UUlgEu4S0bktqdMUNQ5MuhfEVwSMaJB8Ls6DCEXKYOoX1gHrtNBRqh/A9q3W37Fl94eqbBz6vCQsxGKHmKa4YXO0up/sIBXIJHYfNHGZxpiDjlXZCGt/ADfpwG4oo0CpeUP1vrhZXg4lJwrAo+INOVgsO9ogwAsopwuEtZePb3a8dM/iFPV9ayHxzeHImNBUuJwYAfv232O0xpMXdUo/a1wKV48af6hTRPan2v8Ql1535qfXxrSPHKMByEgPOZM652XfAibEp2zN+qKC6B8h05QR+PqPHDKyE4tqz/vUItFV+EEhABsOOcc25hyWYdkYI9uuzkBZETfN1OYZtCygR3UINzESB3jxFDTkWv0q1UmNnJJkSiNIB0Aw0MHEiJ6tdhgRNrpGXYY6Vota0xYQb1NMfpfvMmNnCbqTsDvPllF+nMU8n2mDv9rXlCl+UM+9WNRncgTy7LU053CVOCNmBGwZ+FH8Y8GaXIY8J5BMpfJarFcjootE4dvhTfj98GrQ+2bFw2lQKv2d98S25xvSgMBm8k1yHbyefz2FLDfTtub3qP0d3ZkuTT+h9Nth8KCtDXDsi/wVgyjK6/EZR4CBA5GMpQVdmvVgW2aLV+n8r36Snyw/s2VWH+YY6+TWyIyyygwLYokCK6WereSWihkl97A3NOR8lGaaVVUC5ciWcNtEh+KbvwbFibc2a36ThIJT8JT9k2do91SO/Od1YTEpsOdcytdMPUc+wZbmzGBN9/J3OLxIfOh19cUAofAJTJz3Fm0ql69YFP9dg2mAv06/nAiK5qdjf8Zs4nI2BvrrZUI88nI5NmY9QgnqUYfg0HaQH4m3MUj0akTfd1jkSKqyhXPS7KxOU7AjGjvUQacrOQKCT+OO+3u1Ug9L/KWzKiaEEBjGn7rVTFhuXYLY7S2UzHyHFijdgDSVJyu1evOE4+8/UTG3EodB7MY28aw29bcXyaczoGrQUQMhyp3sF8+DJPBkiUcoUHlUxZnK9EkhejxbuKRjr1npgcBGConm1LnRWsTl/cX0Eqw145zDmQPrlHR94BSD5bqS65lrzlJ0VVFzBQOLZGCbeO7WtEBe+lnX/E2Oreo5iqc1DwfhPMq+fLhMQHn5vtyscJyITjzlPFKzAbE0A9V7XYsDPLSJauBKlhtEq06bV5ju3KXBzEnZZ3G0oX+WsNzDqQxsD/9oQBBwZmS+We4mSS8MBd4ecUIeNfS1dYBVyVf6ebRd/XTf1qPoAQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts disconnectBlock should update the account head hash to the previous block": [
+    {
+      "version": 2,
+      "id": "ca23c661-09f5-438a-b712-2fe0a164e10a",
+      "name": "a",
+      "spendingKey": "cdff0bd51d77ea0f360f86f7fc9924111b94faa07ddbe1c271bc0a33b98941f6",
+      "viewKey": "b813af97a49744e51b537da78f7b5c223b03d21ef3ae8873519ede8a45f61cadeeec9964da27826819fea9ea12f1117c236b27c9ab57cd4f417f0e36092b0cac",
+      "incomingViewKey": "ed8260620ec2ee0283925f66be2dc7854154ebdfecccc81959fb96734d698605",
+      "outgoingViewKey": "33c8c538c9e30712e85d847025aa3b91e8f25ef6311e7a6fcc73939f3a1e770f",
+      "publicAddress": "da885f659e75ee989b0466d6deed4ef70a80ad58decd6b06f6a16670100f15c0",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "ca8762a6-f78e-426a-a6ff-9891a96ade0d",
+      "name": "b",
+      "spendingKey": "673d91c86d60d37be72a9869720991492e2367a54ce953fa500a8ee64a3f692d",
+      "viewKey": "dd74180587998fb376af156608ab5c6fd239241fb1bb738e7167984d9b912280e9f3e4a2fa822645a8967327f2433f3f0b98f86ce73805c8a12a5885e065cda4",
+      "incomingViewKey": "39e5f465361484afb9fe371773865262a68f2881df259123dad60cccc4fc6f03",
+      "outgoingViewKey": "5af585b3774217f619336717aaab1a5738094652cd0f70093fe03e132ce00ec5",
+      "publicAddress": "c9a24403e7ae31079995c5c9445be30ea3446725466da46c918a9a0b4f730ad9",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:gEub8C+F06x6d2VAXQWUNyoccA7Z/0LiUEaUePKQ8gg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:SZtznjumfcNLQkIGI92gHdGqeIddH8FzVESCU7DWWSE="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156567255,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAbT1rhFdP1I9DQwXmkpTgs3bWCZ8/yw10PEmrKOdIWWSi7CGxLEfXFaLSQioIOqu9beqyTMs0aJmadwK52DaMSMryFlwfCY6lPfhEDN7Yhx20PlSJRrnamlyMZgQerDAUmhHfSYOmT4ozSwLN8qSMMTQUfEM7cJbX7ZTvfQDC+3QQZoPDP99lvhy0R+W/Lj8RGajesiXmOPZw2OMZNU9qawLUZ8WfhYwKNB4ZFbZ1y2y50eb19+VhOQJTYBj2cBOCILSkE26pUevZ47R+mwrFCGQyun3fmUn3R3BABz6ePkTZ81NO3kaa5G9d9O5b8VD1fO7rvbNodx+dfEyIhUVwW2+qygCMuBJX7yuyiYIe7asqXWLRsdSadAUfXE7WNJoyW1Rtzbd5U+RkvfF7MXM4M2zy/+IdRd4DJ85w1bB555aISF5zznczxcx+4K7qaqyYr8FJRqKyzlHqQP/rmY/NrBkcOTIBU+BT7Qcg0jk/Rj9mI6BB8yIndE+tsP3ih+j+46uRPRy1OCQ4+U9L3i0o4cy7E+uZlkZR4aqesLSRRy0nvTaeqc5kFCjvZM4VzcuE9ivHqZ/nZtbOwLwsN+0YMXrVNB9Vhiue8sPGpF01PQ/ILuvmNVjSrElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWXZ0o3ZIqnJX5ObrzuRHxNuSeuQiK6qjM98L7lgoypC4PSbdtZXDNz++eqLJZAxylv7kJfbUASfRVhH1wC5JBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "A0140ADDA5B835947CCB401074E5863CBB96BD363BA29DFAE5140A56DE41A28A",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:BLb+SN0JkbQWYz8IbWQkuow3JAnmjobtXqpZLwhlcg0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:LQDCMjS6xUqAL9bJti09Ug/qU2zNwyPj+TbZ/6xLUH4="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156567776,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAvCZygUGWs638wzkygtjPoT4UiGl8oCkMp/7zY0DVYaGVBDBiYtn/xZ7tXM6mDz6kqz93ZoOemM54I+JpZYPrTbDaO4ByR4XSFGYhsHZnLuiARmtASvK0+wXADwqGcKjuQ4QGeifqCtP5UEuSQAOiu70IV5itQJRLTiMnpXWrj4wNhE7hlN03e9QQR+5bnSglJPJFp7/Yx7U5lmu2PbG2kbsJTJpHLuv2qaxv0dnwg6Sv8JKH7XjSQdKbMZqJLHggxUNYQLVqbYjVScLcj1fUPXvGZJGWVElzOJo2piZCTUvu+hpvVBTVrm0O+9Lq8MTh/TSLuef3DHSi0slmaizxpA+mY1/JdGvbqz1UmglAQrVq1qRTbzB7q9mM327Xj/4ByYbTQmt7lCoY39niTmGbn8Gpw9KK19i+TqLlnYPuy6XUZHFEqZ1uWRFyK39Pzc7kXCPCzKhlrlqzYbvj/bUxVifR/m6668gTvFS937QWrnw4P8swieNC0ZAFpNtAraKcVDd+D/z5oP/2+ZrKv+eZ+isYaebc4A8reYTU1YO5pMd+qG3akSNMRykqsjhiWzuflzIO3d/ctBdUJLS18hC5qobJqauXmeGrqX7toSqrl50IMNnvvpc4s0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw1fi4Rqd4X6218LmToLVTWuHS3ZF+6VtVir2R1s13fm0qYKPF+hXPrlbO7WXDEhfmbU92JHsfkiIsu3mugnF/CA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "D575F12C99C488AC0213E485B25DCCA547E7F746AE30F36474DFA4C491242C88",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:P0CSGCdJfp3IeiXtZDGIbBBL1IsLvBcXtrWlhvpyx20="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:LB08nSwET7pVvlAYOhFSqiCf6CfhMeVZiWcu0jG4k08="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156570222,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAfnlakr7ehiisY/5phinTdWdCuHxkP/lZZoRihFG2RUul59+XTMJu4m3HEYiUKmEoulmbXh9VX8Ho6/IDy7smdBZcap8SH04q7z18Z1xCfkyykkfO5i4GNTHpvufD5Ba0eEvnNBo8JWW7fqScxPpislRa0shDfIZOloUe4adN9iMQbo95VIH5XrN/Tj8k3m0Pif4KO6tmwOvi3ehe+2EFDtvu+0RHHQb+yp0klstytyWrIQQj12S8HAs+fMn7Dwp0XXWo7f4BWZydLRApZtNR3jzxRgOxWYx6NO9TJovYA6QostIjP7zqvMHS+oMxaiRPPgGOlffXsvES3qqusVJ2SMwiGV8Rt9LD1xd47gP2yMyaJY7rp4r2LQ7GEa5/6O1XwXluhKpSG3/Q/R3uagy3T652kZXoXHgkxZ8K/1HMixMq2PsTSSrRcLQvKyWRsJZ64yEQ01YJMZwOW6BnEk8zo7e5ST7zxE1f/5Gv9YW8tnggx9tcvYarTxF0PjZ9o4fKGS3fctIarhcpVWR+etq/bc9f9Sdor1g1wikJtWt/B+SV4oU/UN7KKdDj/1yyfiphSHm7geCLIalJJm+pLocHrM/ubDNTw7CHdkndEkyuXskUyc8n64Z37klyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwbH5JLGHDtzcWiHSOVSRqkRUr+tYVtKfDj1b57QMiGwpK1flZ+07avFOM7Tu7k962Uq3H59H5KiDqpsL4x8UQCQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAc6qSgnAkgt5hxVAPaoNBdsX6D9Arnqs4naC/ZvapAC2uN89dClvsI4qQ7P9ya435t/wnJKXKIV+MK8TpyQnR0fvjZz9wh04p3vN6lSiVHZ+t0PiZN7BJJ/d0AvTDmCVEoBM2MiVv4EZqD6La6qtLt/SJJfHClo/umEPjxw/gLtwLL09jAq++j6gz1Yt0Lj3fc9NHKowikyvQElaHY/wUkGB7XJiGQ0IlTZ/PfVsjPhWvElnAL1OazKzYz/0hryBzDX5A1DAfcKp5ii7Qzb65rIesU/g3wzzgzCgDOT5xhnWas7M/NP9YrJKpAUhqntocaK8XFdGXk6Qra6xr5+dkywS2/kjdCZG0FmM/CG1kJLqMNyQJ5o6G7V6qWS8IZXINBQAAAFMst3e3V3Sh8dik0yxKjrOIhSE/xAyuadT5IoXAKzMEa4UJ5DkiEX1QfOnGrO7w9ZyiFe7sG2h3+v+n2PnWS9oV53crMvGDOjnnxZnWnUk6VIRQBd85vnGTHBffCZUWBpRbDsOUMFnQeJutLgvJJezTVsaXQ9Z04rRB4dl708IGvdq8gzY4WPqXVmaCuo34y5ZPsXlSGv41xw8cmy4DYnA5JciO3YC5G+3py0KQU5gpyQ+Hv6GPGP4PPxv0h0XvbBTBaz+tKqf3UGCDCaY8VUaa446jGfKWJir5TB7OdDjmKXKrOTQ+Qz52gMO8HfbINJEm33BpflZtVXNjcWDqzn4SzIczi7t3cGYJaLku9g7Vcrv0djemk765NCULSET/oiOiTYq2aFEDrmI1F3Ug6KCJhL4u9TCcKKYaFHGCibkyaJQoqQsHTGhW0+Ann2aGnDeqVOUY/tPBcNtnrC2txGhEGF/9VxRdmvoyE9Wp4xTPsvxTrPUeSy+ZmiT5rELnjVgA+XIm3rHtWmdWKdbQcFPGKmQMf/5l56YYSJ0YsGXUsuMVyTOFSuW3SUtRDHWfgluZ776oQSA4f+fVLh++fz+rUmEd8F+XnSsRnYObVnrEZljLn5Wq7AY2xxhXkL1DC0czVDLPzpl+IyA8Kr5oM9rHMkp+JEktUruuTCX14K2/7LKx2iEObYLm8xSby7+b1+n+kzDpggTGT0uSbtqQdi6uwEY+E6zfW/ZyiBU3YIn8zX6SqxsNm/vWunX4qQMliZWT8F9EqZsc5Dd+RL70BDdNqJw2LObGzeff1zsKNKT8eEvU5N6or/WrxLZLofPyU0KbM48tPBh+Nb+r5g1/0RahEAWdjcPy9CSyoaKB1hEfs8bShayD0keKrYCFssLVU97LVZ7XmZPFOvZryx/nINI+lVEub0a2HGY1im36L7QcP48C+E/nc+IXVaCvjK/w7cWcbkjZjGPFDX6qpKGgV+GDwuEbG+BLIXY7YkvELkXqxII5+uoNjbaJNm6cXZ2BcBYM/NAohPdtZUVqdsjsuOS5MtlmNIHtqnztCaJjEJpzGE+9iySUOCpaaaFpRJPuoXhy/YxHtyhWxNXjg0eNSnGzDovomoyrX7rLKFTh62xvoVnVG+cv3qGUSmYIJdgIHiQgATje/mwJ7uhGj7I/QfHrJbTYDegrh0A6c5rJuF+YbIZaVEPRGdToXIvPm2BHktmAv5mexlvyDFc2cOHPvMWrWAK5L/rbzEBMoaCACD9XSP+uckFIZyMi8uS3WtvfO7UhzMfmlAYuG+NRqcQLWbcAjAND+sGGge02QI1NNDOpebXSgObLPwM24K/lyiiJBf1uyda5oMmFvVjEIl+aZxIzaxxQqDcel4fF5mVgrCiHwl7tNG6qHztQy42ClHjfZzeKPSlluSLNjULM/JldUawx75CXwzFOd51H/CUxF1jEtfdToWrbG1VsTyCv+74e0lcWpbT68vfiDiPbpxl5qWTLRN6p9G1E0IvYvjas4yUkvaFCw28yZiAkXlKp5slkMqxOA98Th6BCfC4/wnkI2OxLhRUFn8JDOrISQhcWeaUEJSSz1INJ0VDv9qjdwitKBw=="
+        }
+      ]
+    }
+  ],
+  "Accounts disconnectBlock should update the account unconfirmed balance": [
+    {
+      "version": 2,
+      "id": "aa038128-5eb5-4a62-8128-18ac565becfa",
+      "name": "a",
+      "spendingKey": "e729343bb85c6a55da957b2a6c6429f5493cf41fb92595e83c8db9d9735f68c0",
+      "viewKey": "32ead1475728c463731084f80cdf5363fad7b23cd3507b9e9c2a45a2213b272d557810d65011332bf4a4a5041877a4cb8a2b095f36386aab0223fb5642f4885a",
+      "incomingViewKey": "31f7f047461808ec9cc528458a048498672eae2f730d49f0ca7ec7f544870703",
+      "outgoingViewKey": "7a7e8fdbf7c9bd8af7b1df9c9e8d938b98e84b791bd210b6c73d81079d2c791e",
+      "publicAddress": "ca0dd1d587060303a6b840a22b00b6d8713491e7485d18ee0ce7d030872fd354",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "858a4d43-aa00-41a4-81e3-70669c4b1199",
+      "name": "b",
+      "spendingKey": "880f75734bd7640134f9fdae74d10500666dec3ee3eb65759aa28956a132f5a1",
+      "viewKey": "1b8f53bed259793c548306b69e5aabe453862248daf9938360a6d95f17b8b52054dc20c87ab1e5873822308007b64d93316039f4158fb540042c8d44edbd276c",
+      "incomingViewKey": "7719f772e9a6eb6dc1fecadec6c30983363528419880e97c81af5ae97b062204",
+      "outgoingViewKey": "0df88882d2b337914f44f1e16cf9f2304057f403628b77631c0957b3ea3d0392",
+      "publicAddress": "59ea42d100ef01125e00a0bd45e0a014b8f966fdbe05f1641e1a230e857a7c3f",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:frA357B5OX8MouBjlp8j0cL3ekkbvAFZ2kIk+vVRKTM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:PdiwNZVbdNDEpnPpEyaLNrnwuczcmlX/QvnVtmZ/uPk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156571166,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAmfpB+s55uep2q3Aq5oJkJJTRGyyWvvOihHZ23K7A8bmByp5XlpuIw3tSU4OtZoj6E3sLjzs8iqzW/iN3/Sv2VPXdAX16lJti1wfO8KegohWiRuoKNsrC265M5faxiP0YW9qipqJC8vpsXM5y49LT0a9zzVvOLWeJwImJ/fgWjvoQc3C5JDNDdalybYCVTgy6jfBmZU69Zb0BHtKUu1qlGNwh5vePVQ5usN3bBODiRmOWFU/P7GtpJFR2sgJgkMnGpnNO/NhUj+BvVsWfyKZ/v3FwWY9ojeFc4rBz2ypYUfuhfAKnSF8x/8+mcCN00fBiC3SkvgMmBm6IuTJoKlg7qzBMwRaB7e0YBuHFHJdgvFzE2wxY/wyK4bEe0rlo75hPcRf8mI+idAHY2PVkovBBnDq6cKw1bHm52lVvX2Ag65QlH8xR6EXvrlfIL26kkoKKCKDdA+0Jic068IqJPT1ctBXK4zKuRzrkcYuKBggNWsB+BjTFh5noGOEf1mKWOkrfd22v2HX9auvrhRynRZ8vxaRBS/i+QbyXIMjEQLLccn+VqtlIarrmrfJ9olwcHL3/LPRF/dMUjfQ65OdkDZ0IL7xYfS9pIs460Ha6W++PAzTYqYIkK+kdcElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwn2LnzSTMxxCBDsU1Nu3G/Ma6zJP0dB6zCEU0qa8IbloBiAVtUOhsqlz4MCFCyTtbrLbIC1avzzQQ+jYO5bQlCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "15CCD7FB04935BD9CE00C8A9F501F46ED3943C2235F9AD0FE9092CE122AB55D1",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:aFrurdEDhisD8+a2VX/X+L+cANo4mF31Tw6wVWLQvg8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:dwp4uc37upSVYwUtgySQUFLVcyj9HpIFS2XXep3ynbs="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156573665,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAYPfLLF22U3m0yBi4l3Gh8zM5XevNIY9QuyquFb/c+7isOtAg895O2+WA8+estfzHrvWXbU8jSjRR2UQpeKYedRPipM6S2SnwLCxAZHrHyxWW7nZ4jve72ZgORoQhqp0GXBAwZ8F092qHu6x5PzDuHBb8l3OrJpQU5liqi+Eea4YYt0mM1I0Pmz7exXOzIom2YgMrgQ/ym4iZJZV/apHbdPsbofYjlPHiFqKzpmqcXzKNJNMSWpyAW0px5nexpZOxJg4JqqjcBzQdiEQL1cM5WPm4UYbJFie3QWPjMjbieprjr/PmyRgYcCtPjcvUrCl7HKqaaVnce0+vaEBA/A0YKNQdcgE9hPriMB7l+q31w9a24sorfzCJasBRsBDsbiINnRuh185A8YIt6zjwcfSzQDAOD4oK2dko+PLVK2heqzZmPFkI+sJoSv1RBmP2u64kpvh8oJ9M9gaV8KmHqk/3G+epFxLQ0utAv6+g9Sup0R07eV4081v1MT8APa1HjwRmWw1KZO2R0QpBBSjzcGEPKW2ZJ4WDTMErpMvN5nIkCQqsvmwvrR2zKN4NEL0LNp1WFoTsl8fBHAqgm8BN7cZQj9dEhPes+lj1PkZBtvBHUakSoi4kk/P0eElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwgQQ/zjjytDHCmbkQmzTd22+kAA0iu7mw1O9FJ3VGVclRg1dVBHlfqRK8OdheSBuhOJ5OOkBZdk4k9qq0a0kQAw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA0g9kW3DarxN2EMQU6MAGL4D2cQlOcK2jZhowdndo9lKRKz3Q/w/vynnOSlvLJrbFm0VrAFAo9IUoiaPA4XQmcpcPDlpsxp3biD56+l73eemEZNg26jj5UtjTaHkyyeCTR3H2getp9BcmSXn7TodtKwgbGQQ++U7AEpsndFVjYZoGpV+C9c3Bfz2PqiKC8eoj0bp/WSB6bhJ6Ds+y3f19stSn6Dr+k4YAASBg968eYtSz2l+rHFF63mj0x0365lpxJL6C39uaWRMkB7PI/sVRyUwIENlI/e1Jjpnga0rFz+knkXdBpxl6irIFOpBm4+h28z+jcEo39XpH4dOFTEmTD36wN+eweTl/DKLgY5afI9HC93pJG7wBWdpCJPr1USkzBAAAAK0SQmmoYq8RTt0fX9LMdndGkc7oR6ssl7JjZyuvzORLCS66l8ua+vmsHlkXCJvECSU+lEA3KYAh/p8cVU5JJrjG+ZavXYnacSITTQlbCoTpCxMG6z66EPJt6TzGhMWrDZlxuPqPQIxbEsYfgCvOmxxb0FoxDMw5yh9P3tH1ap0UclEBmQdvws45oFGRIitPBK78ZCMXbR3IwFjJdM+QE4pE6iybgqPo61yS+6zf38WRV8VwowxOmX8XAfrnKpeBrweGTwzKNw3cPzjOk3DTeeGDegKAMp44Qr1qPbggNco35ovXb3HzHgkBZ6687wBl37bFiyd+e4sg79RdH9gLwMPTnERCm+ROGAmlJTajKeD+OvXWJV8YApIMbKfy+rP+QSPOWZQhY1lmMPwJYKDYca2CnDbbyCxTP3cUQZfPG3XTPVkXh+qAcGqev5EXTeYNUyzTkHoy/gGBBmUQvmGDpxAKSd49+YILOGJ5y69DB6izP1cyl1QI4X9E9QVQZ1VoAzPdp64tQoy+Mx9bt9UN7wshaZzstZrWuUenYG4speSEvkEEySgNQle/YfvRpIzz53r8EwBt3bLDs3i62vhLxbX+JYMup7S2MiaiNy6Mr+RNlByqv+ZKOs5xE5/6uk9hMLTNdhF+pyYgZYpHHTvZP13JoQ16frPSaxk+1LqTjUpvg3bl0vy3bdphZ0b+QmoL0WWHSulgbIN37+LJevziXYPJjs5nDUklpVz+K9wT/m7RCpC3wVcQT1I21TvnnB5D1V7yuUzr0UZz06/o8yB+UhTrlG3uJ07NGSd6u//mZsAE6RFqpBBIBD+JjIso7OF4emrGCaI5B5XEC0Ie9MHG8kzVyqqDr45Ge9VHzHLFPD11zdJQX4/xmLOwrZMmWtDAdvHf24xVe/uipKyX0xmv8N5h3J6yrY9HSYfLipYyz/k3IJub00ghROkJ77lS0GZHcO5EvembQeQx+3QH8BtZRxICdC+vKViKzEWzG5qRchik5JYzdDHkgm+T2RmOzhEL8R1V/E3PCfWlUhbc2G2gHtEFAUOyjZgy52WmaLKaLyOMv+FJSt2gJxP4XPlxiupah9k7Af2W6GI8xDWOBFUDrd224czDUHxcXxQMICnUGVZ1O4RavjzxBQEpeNTCvx6s3PVicyfCP9UJJkN9KuVDViEpXTj3UsKQgC/q9M/FGpfXhRz+7imO85S81fnySSP4IL2A3kS9BSXSG1U6TPUCzO5QRkeSVM1Q+W/NYoLm2b7XfTUxP2fGDPmNzr3CyC5vHCA2IWpi2s6VlmW4hSeWiG1OzAlpBnR1/1Hxk7+PAo4VKrwXzEB1wkfTjeryPqunWnFc6n/+oSSDnkxAVTbs8McoAtoKdM/X6kfxv6AIVHK8xH439WO+o5odEQG3fxQek2sW3FKq3kqN4GNCX1TNCCh2jU02sTLRg2TUeAbvRp2x6ze/vKeh9nJiYcBRwW8za6aUB09V200xuH0ltVk+VxO84IzSZo1Yc5pCNAZUGc8D+JJr1qKdjzyEWjTgUfGo39zyW7WpYcMGepN99sDmeRsdwJuazyA2CI035QvDNYdmAGaj4Zc+78GOeTsCQla4CQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts disconnectBlock should not disconnect blocks before the account head": [
+    {
+      "version": 2,
+      "id": "04d2736d-dc29-4348-a110-250f622c6369",
+      "name": "a",
+      "spendingKey": "48b3e80faba37f14c5aea3d43887df3aea68d186a23a39de36beb46c872f7ff4",
+      "viewKey": "8f13d2b6e65ab536f8b710eae62c9e99019d02ee0e46face8eddf40954294d4ba26468f5b4f6449fb267d7dcd2fc742afb7f376a55e954335f98f63e00546b5a",
+      "incomingViewKey": "69ec074e9e381b77f99f7cfea0d26379cabe1ab2b1f8a028df3b881e5692a003",
+      "outgoingViewKey": "1778da94fffcad11c251f46efae8f06f1bd034952e6c943f007e9230cefad112",
+      "publicAddress": "545c492b4043ff9c2bdf8fe49fdb8a4f031cec5cfbe76a6ce990723acaab8ade",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:L/4u2BRxonMYn8z0ue8Ni6RkcTidPZ9ENiKmw36zgAc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Htv/yksujd2lpZr5jlJaUAMYU0kdIgIiMLwQOCLZ7QI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156574492,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAApOoNHXeWMqIjRHOgsRtbrsHPSM3B89v/TurW3ob+Z7uAnghtWoDN2GGlBaKd+YVBJjtKMKpg516IjVFLuRJglfzrSt8FrxUWZIuGKnAUNgKvnhroYOlTZ9YII7cV+RMHwu64Ws0S1MeZQK47fDvEZEPpyxl2zpNhPGYBa7rvDYgSPv8UscTBqr95684iOodczylMc9B1lr0BvW0++Ip5VWLuOSNkHPFNU0u+BRdrkBKvg9oZ/ErkRtQP7lty6C4SAPAAFFI4n5/JAy6lnu7Z58V4+eml0Ty0rRlbEsx99rFKJ6VbXukuAWH/VeKuNC/a1C7dKQ6jpFtn9fvDCtMTUgjL3oxKJIVDSP04oAtoeTsrYrhI+sklIT545p6U6X1OxRZVUKLYOBiWH8Rs/XrBdZVIgtZDH+gQL2V/6weo8t/e6FPXMdC4yhdkiamp6mmYfelc6TAr5uwsi5Phl9TkVpJ0HrS6Oi/uONKkqT4qqNZoI2NXexe9NZlIu6wiPSRIIQ5jGg9OsbszZkeBEOEFuF5eBBD3Rgi/kHI7hHKzx37BD4LuZ5T6x6p4pJrh06YXmb2/T0nFwGvADTzs6VgDFJU17ftpfZPnXGMouy1QtCB68RogPyxRFUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwXjD2qsQhxjQ8pcC580/drX8C0vDt8ahhwLJB5QQDM9gvp2YFuDtxcoI4CYS3TpZ55tsdHRAPHVfXIHnYs6RNBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "C5151283F6D21E866E8E97E7CF1E2E11EF82412E40026F4CD820F7347E3115D4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:acGq0u6MSVvpf7kdkULofuZDeZIRNyu/dSqouESKAQ8="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:5EDDyGQ+pUxsGoxauG0aWL2EXxOhRgcXea7j9C9h7G8="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156574997,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAgZd8dY/fV4bn2QckW2aCAghntdZFePOzGjqSfWz2K9KSsn5flrb/Fvdhy8U+m67Fu7cUjtSYozQh76dnNW/54ksFXrofRGExFkIzbpE5Pf65gAfopNIdvBGVz8PUP/HVh8Vjf8BbUdHHhoPWfMlVKttxOXiYaWMshWz2k5hBHQsC76yQUrxv64urNX/6/6ck5cL+n+MHCr/+hi4Zyum8deDlG7VZ9F7TDg/H/2RcbReK1s+mc6Jf86HuIPJzXjfoYlz8khMrLqIiuW0R1YHQhV1IqqeEzE6Z1ds7mgEIDGoVPXw/qSbIKVm5m4zkt0jAqqqRJxn7blO3PsHPXN+zWa6pf43ars/pAKL2lLtqqbruwSPF2k/byjYPpCPwJjM2RwpEXtgDh3+AXUM0mKdHx3LZn0Vm5W7+AZt5rhsmqOvsTrVsjaqlt1vEXRJk4QmteAUMAbCsgZFG6TSWOuU5J7eYyek5h5F37D/pfYFwjpeURWl4QWyeVD/WIfMpVW4169Z32R0vXCPOx0HU2kc1ghG4VxuuBkQOHnTGkBixVQRdlkegVCpFFNFVXCmBD3sBcA7DSV+HLdYfTySVbI13PBIfcSEns7BsGBDL4kS1D5lJZzff9sVxy0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8Pd6Sj6bYmuPzgPc5PDxhQjhQhwduukn0Ssor+WJJfLMS5h34xsaafRDdgrW9Kefkgq58u3NPZA4PwGIsalMBA=="
+        }
+      ]
+    }
+  ],
+  "Accounts disconnectBlock should not disconnect blocks ahead of the account head": [
+    {
+      "version": 2,
+      "id": "5ccef543-f94c-4644-9b44-bd8417c7d7ec",
+      "name": "a",
+      "spendingKey": "885394bc885e9cc1d4ec2986a6d2eb60be567494135f091a7db400d508b92360",
+      "viewKey": "d7447d4a2a17caaa3862f27cda277a3498391066a7ff825913197493f301c28e913655434a25558d0c1f369895b62393a38553906244145f72bde740e3c21cad",
+      "incomingViewKey": "d9ed873ee5cad61135ada162f2d0c391ba084c66109743daa818509aeb68f901",
+      "outgoingViewKey": "98f0f8623fea60fec9931a3c5e4fef8e9097e94b9aaf80a068e93cb1f5972573",
+      "publicAddress": "0d3c3a30a79dc3933013ae15d3427b5228af92c06f25750cf95411fac4a23c34",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Y7FH5haJYR7P4cnzw0/NmliQ/1YLwE4dId+d4BMr5jw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Ll2+CK9UEmHo+e6uz8FG8VQEqmJqW/KSCYVHpy/E67s="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156575811,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAM34II7QxGE3XYGVCJC+O0C/ovxBtvFrba3Lm+rpc7j2GTMnMXJ3oFpsgrotYk5CtJKPLi5qyhbHQNKAv///TZXITxNiv65G0oqdovfbuGYKYvn9wBG9xlkl1oblMEKsepj4JDwoStmTBeSB7BnxHmkt0/xETzsJ9VShl1u5S56IVsiDRLQ2/7zNZE7e79CvXAWuAkSKwxQK09tafX+gTj74jq/7QU2HXrOt5pyMXeFCBoQk/C/i4NuyD3Xh+4BF8RSXHLaxMCE00JW2f+wNP+mstNRcf7pR54sioSNF+3cSVF0rpTDbIqvZip4IMjxaBdSWmwhxbjlzmqmzZ2FV1bg6gjy7nHLTDM/JtTzdJvJnVC7iy3EVowz2sGGeNBXkQeQ7kaTTifbrHGAIzu6py61NEiOLftMBRoy5irzres2YgF3JN14Kvn7h+nSRvfI8zT3mh8t7RKWmIKMRDw5xq/Wr59i5XahFmpwnS4AYD77NUHgJ8P3nsUhOYm5zpFLpIK02XQc2pcE8wytPiOgppY9rEmkLGzyA3SOSh9kvARMy3xjeIvh7SS9na76b22fPMq+W8TWTyiHM0cU5mc6lZt66OmgDSfltfmX2MS3KN0RDEXG1dArVGpklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAu3Z3Z/2JoP8xFwAPInQdUvJqZEqCMBqUOjg4Jebz1utomMZcJ2/aBIMIcEHI71UNmLrMesxgdjxW+HHONOGCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "648A94B06FF58C50A4648D5FBB2CAD259696A2F8EC9013C3F0BB630A7B4B2606",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:xBH7GnJkgzHMXvdEGWwCNm1MzV8gLTFsItfPmVcVtkI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:n1blMLkemDoZyC8I2YjLZTAgtJ+MX3f+CA1U3K4ptds="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156576327,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAE/btZZ1JJc4pbn3g40hiBttSq+YSgXgq+yMau/hST4eyGinT5BdH72CZn8v0VuS+ohYnqaeD1GfwaFAnzsS7rirMIQbDIKm4qLGVRtyx3gu0r2dsPOvmjsT/7smyv//ko/tP8FUfsUR1PbBTQcVl6e9dF9haM4buA70z8UIYmgACCRWnkAC7+t9S8GTXQU725ROM5Trk2QPSFtgzdf7/ex32Wurcu3z/RX7z/DPs6fa4wvodM8iQL+sG8CKy5u8wIz6F3sGa4hyIOkppB7PCDvM6OGpTQpfpxXzud9IgzC5mT1JQFaPwc0xAAB4O4wcXLVgaqb02YFhVam2KkQzE2IVHMGZGKVBSgsnxKkRRd5VcSq8MZH0urmiaJFkTdrkmROr3vq4v0TUeidNTW7CfJ4sf9soYWZfAhadvMC1oCpMJ1bMlU59ih5+/PEgWuI+1SD6l5efhvoICfBuIU8PBtc7zmcv68N5N5vUJxFe4bvlj0qnq96oEwnqxHDrk1HTMHRL4Oz7v637Q1dH0mo2lohJG+YxUPdaeLHCqv1PHigkJFwodEpODqk8eKfuyAolKIad68GLX8052Pv2xHKvy42Pj+/d2aCl/Zslj0RPkXDQoJUBKMC9xJUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAweu9KE5fPsmsAUouPPLMo5sjUMsPIbm6ATF4+dl1ZDkPAL0Jda5PpsEGyCxZTWxevPfzmdVI9IxKVwO7zHcYYDA=="
+        }
+      ]
+    }
+  ],
+  "Accounts disconnectBlock should remove minersFee transactions": [
+    {
+      "version": 2,
+      "id": "c1e8917b-526e-4c45-93fe-ed2cfe0a8abe",
+      "name": "a",
+      "spendingKey": "cfc33773ff25d8952e6bb735b0245422a35e71058a2f9fac82962c43f62a269c",
+      "viewKey": "d12455587d12d43b5c5405558d838d36c626555b1578a5037dad1e98bc607a5431ffa65fbb7a7825ac7d79f886d28695d045702620e12568f24d95bb0a7b9e42",
+      "incomingViewKey": "603fbe5566abe690a22d67764ca8dfeed899889a9b6c0a9a0b060bf1dcb4fd00",
+      "outgoingViewKey": "5b809d250180d535e3002e6d3ba66f83c0e6dbf2397f942be5bf412079462f96",
+      "publicAddress": "c8572867d0c1c85961559055137e80624fad72a7c6473e41d8374689d2438ae5",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:+7xKarEtBVG/D1e+pe8N0noIiyIvtx8GqbCIjgz4p0o="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:F06eMjRBt+DniL2uvh6e16tTI8Kd64I7K73gNwMW2NE="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156577120,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAtsbkW28PUEmVchZae/QdgwxjTYU7vTrXu4lSJRt2SaeghCDVAbwPL1a9flSv0rkzScRIxu6s+rptswhvZyMy5qXCYzx50X+El+EaQ+IqYzmniPpjcAFEE+5m98MTevic6gMC0StTG0jNaZsYX1MdKaAZbi83PKCvVT9Bh3CpNtwTlSusOEkvz/NAqbxx+1ogqTUKbKXhIziQ1bNjkVoiBCB6HKlz/UMm47hamBL7qGKT2TC8vUzudfWxdkYgy6/CINsrcMb90ICWze4cQlOX8vO8QQ3cvw+Agnlo79zZvXINtaUpS3eEbTKqRCGjZMV+3BKY0J8habaXfro7YoLzpvdIMsd1iv0uo07AJ5TO2gBGO0CoqXzCKUxCWUOxHp1A3qDQut7ID+oKN/dBm480YuOzJBaeEZh7nAipdORu5q50vnFHOANYCRImLxgbwyjE3CouMjf1R3yqUfruqR3x/APRdIA6VRuIqzkQxoGy0eyf7U/SLfW7jojwIYcKT9FWZpQ4CeuxRLBmW2d9PhdF00Ki0yOPK2IaFBC51c7EMznYj08UA9Nx784717LVBk2k38EINKQ3yQlavpWgeO5vMqhCe2YjrX0WzmxVdrhq7oehxZ0U39vMB0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwgfY+fNbHYHh6g6Fc0MWN7vKEZSCSgWavokvScpvTq9vcpVKQ2o5nhhguUqLW/cSRjX01W3rK8hYCDIUNnp+QBQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts disconnectBlock should update balance hash and sequence for each block": [
+    {
+      "version": 2,
+      "id": "e71f5c33-fca2-4fe8-baf8-a3e40005cfca",
+      "name": "a",
+      "spendingKey": "32c331159e4f564106f4e55c7de0c84c68599b72287f9574992b03edb05dcc0b",
+      "viewKey": "348726fc9ddcb4088ee14fbf8450b626d93d1809f5f4d04f14625c384cb2ba1a5251ab1d18584e0b37c256ea029757d3a042824016cb54fcd761035c395f3ad8",
+      "incomingViewKey": "dd387e0b24b355cc494fe70111d5509d0475f3a5774d550410949f0160bdb107",
+      "outgoingViewKey": "e47cfffb9150e23186b6d3980eed8f2014399e746fc779e214dc502023dcd7d2",
+      "publicAddress": "258d02921f77828dde244cb6cd7f4a708035b4e8d5ff8605352ebeb92555f612",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "5694310f-c572-48a4-904d-110b737ff232",
+      "name": "b",
+      "spendingKey": "4d8e03b444a5d81b34684cf92c8e4017540cdb2be8cf54be501ca24b59fcb38a",
+      "viewKey": "43650c1011d5ea4f7f47c7c39ab07b9e1a00c2ef54abc7e02154a3310a0c49efd5a8816e3636d623cbed0d88791129e44263705e330b388271cadb5627ca830f",
+      "incomingViewKey": "84e047a17fb99861af9ab73eeedd261f59dd63a327fdf27e32abaed0529e7802",
+      "outgoingViewKey": "61ae20e5c9e4a6a0d5dbbb69735867f2d78521c43ba92929c45c62e7bf0e696a",
+      "publicAddress": "f8619df96d894147843c3334a6f6f23e53a6733feafbb5118484c97f19c3e9d0",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:UlxS3HTYG4KucpcsWJboPJoyfUQm9wdnuCrFZ0+8elU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Z7xD4QTvnPjVO2CA+OaKKNObbp3T+RAWrUFic75XBEg="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156577952,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAADpU2WlaPk3pU5+EQAdJ3+sGk+le2TxujtuN0V8h5OT6gkaEWmoj5UyeGnW4onMFxVoMnLtmdRmKUAxj9LMs+g7EQCu/vdTZ6e+S9b+pQLJejo1mbPySXwycXsgZ7q1WrNm823/q7tnBL46vymDZBbnDp2GewmWe2+zuNxQAYVrwEi9vEsKQBGDljlVk/akLRGtLfgn+vSCNb4GBBHddU0i/hMG6p5dgyKypRUN1mYtiDtEdNxjIRor/m/lKh7YgzYLjEk2Kk2vTEty2eK6VMkKLyXaqsvrMVcCfZkyTIJoOGAH/7F9Dz2u4KCkliCpWLIq/LkqkG2/rSjLCy+lgMmxxF1U3VFDugjQdmMtKxfLqDAfEIP4qB6X92TUAZcywRB6ECebHdhB4sICT6zXN/1EbFhJ3nHIV7F9byXM70U+9STQYFHQsac6rR5Gt58LOKuRDOYA0BRFmQ5NW5shnHC2QxkZANAgqxpzr1fnb0tVXt/qhDwxH74spJq56KOMFyT5JhcXWBcUmUL3pXAWkwGZ9sgU1sdjCGxnBJU4m5WqW792Yo3LNXveTZx2DS11bsoRpKdQUenf+CG3TojvXeIE0zySeCUsorlCUr7gNkktECQr8PV0PubUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAo1HD+diBQ+l0+gAVc/MZyn2Yn3xqI+DqVwIB1DJVuQSUzlTykWMas5CFLLNtYYPl4OMF+7LIvTvbNr0DicPCQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "E638D6CA06158459AB4C6E622884377A1BC5615851218C24C35CAC5B45ECAE5F",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:lkvZJYkp08X9ML/DpoWjXM3BudGHIv8xzv/kFQWwuGQ="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ZeewBi2xMciJ6q88aghi7VC0R1kMfBwwUNJeGvCTZiU="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156578474,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAQcfhLgg9zuIEaFlZbRdqSgaF5EzIQCB8Iry6mJlVZuSn8MKt5K2TmNm13J3IR3rnfmgbVb/8i06gS1zJP8oza6sYVPs5VSoxQdJfrOtl/+2jRgcjowox+X2a3K+hZ2lObk3yBJJ+N019z7QjhxHa1QDwZoejaTZBGqwL3+J5WTYHrcZHX7mmiOwddXVyz+EMVNnTzu1D//Fud3ZgI/lu1EOqvxrhmHQhFFwCVHBvgMyK0qZk4Ig7nfXnlRpYt81wA/3JVB1vg4x7uRPQijTPZF9kWVI+WZkVTYiglnwZ0sXapoOitCSPHVmpt70Eg9it5jl6gCMubXL8mvMzDn0jM7aGEfWgfa/UVXqcP1Jc0W0YesppSshvfIx6M/za/WQfJz73F+WwBNyie3GCosfZIMRdLrg4izVPJABOL5EkfAjveKeDPnLSJ9xvQsO7CUsEigJJeM22TiOhet1XRNVgX854lUSYxdzDJOcKmn9Tm6E3mDbH4IOuwdzLARylGI2XEq9SkKCegR+O9lM7AoKQon6MxcAzuPC8jY0bJQayK3mZweDwC8/ccfeaka5ArhfAWae3+opsGarywNe4aftDCxBvC7fgWUUzhMpJp7sNseGoYY+t7vX7Pklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwI261V0qZ7NrREn/88BQSC4F1NKOsJss4yFLX/F9CRFy0XE7GjugrQQTK+0138mE0+4NGbru7/RpDRO8KZGLNAA=="
+        }
+      ]
+    }
+  ],
+  "Accounts disconnectBlock should update balance hash and sequence for each asset in each block": [
+    {
+      "version": 2,
+      "id": "c81e0915-15be-4a2e-810d-946dcb27f262",
+      "name": "a",
+      "spendingKey": "0205040263a9ac13459f5284b02998d56bfd5693b667736ff2f8a5f5072dfffb",
+      "viewKey": "2a62ce5973812523d1bea4706c4dcf8531b3ac1640924c9fea47673947cec15af7d4600ce6ab891a75e72fe12aede5b2e22512c65dd402ee79d8c05ac3939ebd",
+      "incomingViewKey": "9994989bc9222271e5b4de2c1dbda955b21e63b68e2f5be02fea2018c64a0a03",
+      "outgoingViewKey": "aa128dc3a6abbe6fee7beafbc9a4d05d6da019c16ef0f83ebd0699af1610815f",
+      "publicAddress": "12a1d07597b4f3e08370685fbc50aae4fc8a20e93f1b65909b1b9b3210a6772b",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:4TAn3DZvI7fgI1M2gLMp+kusCjHSS04lVFfdAOLL1zs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:7VlHXYQKtBo/0nweh+2r0e37iDdF8cLqBmmDhq8am9Q="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156579271,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA+oa0AiAUdcTgnxxXB6Sbhc7UBIph2lpOwUoA4J/yMUusRdZX4TuWKvX5EyMXUqq8iLkauyLb5jsMA4cykE5w4XPkNyoSx6mtKmESAAq/KVWxioFn/zXraSAHkqtNVnGQ3XPzn+qWLNXPS6flpB5rrsb65JAWRDzfF4gZtG+wfIkMcJQPvoS+eNCviCSFag063c1osndnrt0270/O4tqdMXtE1mXYn4TdQHVP7cArv5WyG5y01loMh0s3C7T785AERKWpR1emhRs5dCvedbmPaAfrwODwmT9ryrqfTxW+/dWKaSC+9V26oOTKj68lbnHyzPm0ptmZwNfVSL8jver8t0o0rAMD9kKW3RVM/ZUOS7ICnSkTzodOOocToCONAvA+IzscqppAj6/HD8701Q3o9AvLeP0GQ1jSpsBAitD1MTk2kk0DRvfShB/7AwcS/mWQGelp/+taRizx4F1xlih5/Vlghk0l9JKXsayblCZmmyIIyP6fM43ScOFKgRQ3Vl0Li9WY23ioGtqO0+8fKNVJGoVYPNnmiKImhoEovZp94bt2LwS/PshGwe6F/uNDFzrQzABjTxpEl9z4/JldNy2OvZFCTGDeF40tOHuB9FAh5wrbsJXYpSLhcElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwX0/sdCWclkuqf3gg+P2QroX0ASvaBqZelHKr14PsxTmbH/Fht+qyZNRXcpc2JZZvO8AL16qexaT09l/INuiNCw=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAArGBgCkdL/JTY8Qt+U4SDy2tV1XZsD1YvvSoE+KM0QEyDDz6a79b/Jj1EOC22D6PwSIzsE3k5Q8eNyMUCb4knzvt2PCmJH94Qf9br4UNRruKmvVMICHmCq2hDl1RIQ5uzyGri7cn8GmPv/iFGP+jjxV5gszPGR/CBUy7NBZSsUcwLYdghX8sXnxOpAqfEPI3PXsk8CZ+BLIfD4iqwvmBQZU0Rd2wZvn8/voYsK5jFylWuK1+FalYbiGuNf5vUV0hcvzpgitx2SGXpPjZxk1rtocxR+NRQIUEiy2TyLymYsN9HFODuXtU9EREql+4hqz4W/hvy0E+SUOWIM6BX7MVmXS0/px5Z2a4hHkH0WI/kK/ovMJhCQeoYNshkeasV4ukVLp+/tWxWEdnHHoDzfvCH8c2hiRTZJbFQiPsaE99Uv2TWOXK7pJu9KhLj/bDHZbdRE1pgGMrJNe4ISwQnxSCdqtg9+heBx96dB/NczWTxj/a4tdbxSslqYQKy7Yywb9jv1TsbVN0FSuaTu5EMurnbUZHHe6X6fnRdO2U8HAbQZv52gu2lfggy32lLmN9OupEVHEPjb/vrV2dz/BqJZi4kxw0mnjAo99X0OdpbqREZ47eW5HR4k5ngAe4iE3wGWukKCOCiGCHUu9Ck+yeU8SKPfTGmg2K9VTORQxoGCikfVVNkROwxEAB2KwQW2A7WzPL8zyQ/cB7N+6rq7EhH+WHBvycWWfz36fmjlAwp+Ah+eFpMR6b91KPBa1bv595a3BeY4ezHUDxe+0wAfQsayW/ozZmDb0lmLiD0mSLDyODeygDo1dYjZ7UVJWAaUG8WP/D9Vufka+u66MFjH4HgY5zpxUQxsoBnW7GdE9cdcmf/c14qAoJ1FuRf3MYh3UNGFTZzKpRPExc1iPu7IHH2FsId77FDx66v/xtXpH7zasabpc2oX/064V6wVHnZZ/v6xuMNlhzYSH3JC1mltEDD8DDfIPYx2SP8BUk9EqHQdZe08+CDcGhfvFCq5PyKIOk/G2WQmxubMhCmdytmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAFIejWfxo/dPrXr6mFiXFYiF87TDYDczlD5k285p2jmbcHwt6PhT7FBinEfOOKOfA1lGj+J4vYIk0Kbv3HMinQT4Zy6o5yYqzvdPz2RHXqTs7nF/TPdrqp72z8CIYiLlQvYRdv0v1xzq1b5zY3rTHRmPBdTsj94PCOAI7KNOkfYF"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "BA36E05C1F60E2701B7903185D5F8BFDC60916A7E2B2C4DBBA722756E845B006",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:2CF/eJrEjl7hDVMSyH6UZkcX4ZsptfOiijxfzmc6HHE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:cZHuPCYWHHsg5YOfGDSE/PUwZJOVIo3BmY82qZupVMw="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156580645,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA08Ro/xrfCUY23S0EhGqiVA9yq/5eE6XbZuD/ahMIJlKSCHRP0y72BvueC2VQBdI53TAA9JXelvZfLTskBO2iyIkHxhC4W2FYvERXO97+FfKkmAMMa3dNgYiNH/qg+eELe8rr80g6eMRhgMb47ckB6aVIM9L6m+hgiNHP+7n4G50POui/uxhYM6UPW6jzBSU/Wt3A6wNRpKzjgRg2sYGGiLxWiQ681j5uagLmo8mH+42R9VORsmAi/AhMg+rucCdbK7cccVuyp8Q5DQxvnQbvXHDu9c1Ko04Zz6niIrmND1g/+yWSiXLZfzzUCZdwZk66BxQ38BThU1VEq8E2hJwEco2Y6Bm8lxFusODmORxcsqspbP2Xa5B6jJc6y9cdZFxhbOfGg/bZ7CG3gqVYIXtpQcfmmfO/9sXw8jUaCwP8qwAF0uNJf/krVWkeQJea3Ynxp60mRIkpLFp9NGq4R0v/d48+b7VwADzfpDdoBb2FTF0OUhCdwAFY4RIseAWOZLqeWqdeIadICVLhkPe6T3FUzbLUv8MqK0bZ/9ms2CHJBVBivhR/A0Ubk3OfLxb6Xte1XDojuas/hq7vqMlfbYzaLpafr6K3olk8ReySPIqjMHUaczkpLhZ/Dklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw+TK+MlyHFyyPkz2yJ+CKHCP/0Q58Rggp2yrIQ7nvMl6GDL+smqfTXoDNICzdQiUEjBxu4VFIgepBx542sKb5BA=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAArGBgCkdL/JTY8Qt+U4SDy2tV1XZsD1YvvSoE+KM0QEyDDz6a79b/Jj1EOC22D6PwSIzsE3k5Q8eNyMUCb4knzvt2PCmJH94Qf9br4UNRruKmvVMICHmCq2hDl1RIQ5uzyGri7cn8GmPv/iFGP+jjxV5gszPGR/CBUy7NBZSsUcwLYdghX8sXnxOpAqfEPI3PXsk8CZ+BLIfD4iqwvmBQZU0Rd2wZvn8/voYsK5jFylWuK1+FalYbiGuNf5vUV0hcvzpgitx2SGXpPjZxk1rtocxR+NRQIUEiy2TyLymYsN9HFODuXtU9EREql+4hqz4W/hvy0E+SUOWIM6BX7MVmXS0/px5Z2a4hHkH0WI/kK/ovMJhCQeoYNshkeasV4ukVLp+/tWxWEdnHHoDzfvCH8c2hiRTZJbFQiPsaE99Uv2TWOXK7pJu9KhLj/bDHZbdRE1pgGMrJNe4ISwQnxSCdqtg9+heBx96dB/NczWTxj/a4tdbxSslqYQKy7Yywb9jv1TsbVN0FSuaTu5EMurnbUZHHe6X6fnRdO2U8HAbQZv52gu2lfggy32lLmN9OupEVHEPjb/vrV2dz/BqJZi4kxw0mnjAo99X0OdpbqREZ47eW5HR4k5ngAe4iE3wGWukKCOCiGCHUu9Ck+yeU8SKPfTGmg2K9VTORQxoGCikfVVNkROwxEAB2KwQW2A7WzPL8zyQ/cB7N+6rq7EhH+WHBvycWWfz36fmjlAwp+Ah+eFpMR6b91KPBa1bv595a3BeY4ezHUDxe+0wAfQsayW/ozZmDb0lmLiD0mSLDyODeygDo1dYjZ7UVJWAaUG8WP/D9Vufka+u66MFjH4HgY5zpxUQxsoBnW7GdE9cdcmf/c14qAoJ1FuRf3MYh3UNGFTZzKpRPExc1iPu7IHH2FsId77FDx66v/xtXpH7zasabpc2oX/064V6wVHnZZ/v6xuMNlhzYSH3JC1mltEDD8DDfIPYx2SP8BUk9EqHQdZe08+CDcGhfvFCq5PyKIOk/G2WQmxubMhCmdytmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAFIejWfxo/dPrXr6mFiXFYiF87TDYDczlD5k285p2jmbcHwt6PhT7FBinEfOOKOfA1lGj+J4vYIk0Kbv3HMinQT4Zy6o5yYqzvdPz2RHXqTs7nF/TPdrqp72z8CIYiLlQvYRdv0v1xzq1b5zY3rTHRmPBdTsj94PCOAI7KNOkfYF"
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "079A26D8C6A9F2EA58BC4F19F913A2943CA172D0E2AD63B44318B229AE947801",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:KEZ8+5RDsdTJh2UUDiq49nmLwvyJ4a+7HEIv/c9mXRg="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:APwpGfkYqS2/hdyEjGr3EXxE7p9hZ4jeR587tehCRS0="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156581170,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAYO6JY0nL+sriLbS8iodSfpd5Em7xnR1194E5/rh9412v69tMaBzGRiaSqckVWV0pLoH9Ik6JSI6Apk8aiTIP/25IMtXdJDdijkNv1W+TdVqokFT39f8LqirTW2HO0Tk6eXudw3Nsil2w4SMwlg2OHnRFt9E5OBRBRUaWDblhhHwKyHdk835FHH8QUmWlXEQ1nRPOZUjeOLS/tRHOCv3GWs1R30WcldudZM3pQhU9vZuQtA9x6Es1G9vgNaWUP2YLdDl2i5UC0kR0vnWspIB6Uz0Cq5VOaEAzs+yUnT985bWVZ0m8iaopJd9dNa98avf3eGZGnf4v2HyHxODC8MoaZxbRbpQHYqi169pFK0a2drkQxwc+GtK9WOnAlCNnChYAsuK1HlQ222tn05JZsRptsBFAudsZ+z9K7Xx5Jddi7wqmPebiqD5IvrTpSPDFZ4z8gAxET+VjXlR2CcdCsd04cKR0z0J4WKt0g91rGwA5V/uik/bURQd1ih8T20/Tf3BN5ui0PV7B92YsMv3M7WFkZtpNCcrd0Gg4JQFrNjL94+ypmBNxZqUT1yNeANNLlFZBQe4FfvKpVhOVfWlByLlly/3oDgy7+p0Ea+6yZXLE5wVgV+eyb78h80lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLjiNNG+A0paT5UOV+jaP6gMpBf0S4j5llnf96xJ7bTB7yyNM3sQDmY9fT+tlMGXwFpcZKPrZi3A5lQNo0EAYDg=="
+        }
+      ]
+    }
+  ],
+  "Accounts disconnectBlock should update an account createdAt field if that block is disconnected": [
+    {
+      "version": 2,
+      "id": "8da945b2-b447-4b4b-8ff4-55e286c2f22f",
+      "name": "accountA",
+      "spendingKey": "609da60c573c67b5e7eab521cf26e9203617ee4d4c80af8a9508d5ab3f96e98a",
+      "viewKey": "f3daf4d53a5a97f7e37f523ab56ee7eb839dc435f33dc49fc789722d6f29bbb9bc5b5127f126f87a9dc61eaafe7aa25e6ceb71c0573f61a4675094d13fe281c3",
+      "incomingViewKey": "a1a538ac855bd1faea9cffed49b1e2c589104569af1a699991bc585e3bb59a05",
+      "outgoingViewKey": "d9a8971e3e73e081938d3b2c8e8284c42df009e3e2714bd2eba5dcadca69b719",
+      "publicAddress": "bc30d158555ee34c0af91f835a8c8e951fa821c2d40a9f6bbe5a97c9b13991cf",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:QeTqEUKkGGEx1P3T6WCxbZ+cUOkZ53fPmsExRG1WnDc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:sKamWqAPnYxZTTHmyFPx1NSCMV8wPjx5GZ9AIvFQkFk="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156582000,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAzr09Rz8wi8CYhHPnIOqX50ji09Zq6rij8H1mqs+nYOeNIDWSRXy6/FU636ow6LX2xuHGtjvtC+BuFZz9v/G7fV8k1yEzrDjRUpKBSKFTaUOBy1Uqy6oMgISXG4SRBtmE+uOwrvTMLIF1YMk14OpldSN/4/IMP2L8D5t2NajGoLERsyXuyaGYx24Ez11FxIcvWtuvkPgz8hTZniALZGJIqTC285jnI3E7HRnbOhlQUWGMZhNhEoOp5svvo1uhSV1Hu6Z7fvorAOAbx+7+Na66/s06fXLMNyzEeRvoptwS92yHhjqk8tMTIZEb2WqOlIq5CMR+ZP8ohL1nNNeOAZmpuO/M7WSR7+S1R+1YnD+OEJpyHf5jLNgV38uRdIOPx30VWVw763kYn/ZaQ+keGSY/VzZvGixlUtE4KjISMg4jQRxYHWBveag6vmSkWxeyL0oi0e9g670Z7lVx+oIvCl8hMtlVZ2e6y4IKLfJ/hhVc715cw+eDXIWjdQYGXdE9AMSopF19ciDu3vRXgDz8Uy9TS9dEhsH+fDGc2uKv1OUeaaQUYEMTdkoR2/h8jZVn9Z8POfirc9Rj+D9rIVeyf+VJJcII1yEc8ZiFqoxRjjZGgLU93ZKnZ2f8cUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQFhSdMG12SvPKt372h3vLsqQfYc1RW1wdtd/uIwZy0IZdHkpKRs8aXXuN5p/5ipXvQ23Ly2iM+IOu/JB2ksvCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "F354A922FCFA735C6A17EA6B5E20C01C4C94C5B86B996144AFB49EAC29C20446",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:AUgZF+veQagEbf7ITD+ECerm3eaO42YZpmDIyKerGVw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:IaiL+B3BTl3u671TZ3EPO2ymFDmGVFtJqI8dTe6+4/M="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156582517,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA6VZEWbSrVjXDnExOTlnWGlwOYnZXt/p8ceSepEXWFoehsYGqNnJEr5k044YViTUNu2JzeAuwAScSAuAjTmVmM6AgqZsLz3/GCwgoVc6n6dyL0NCoLbjUrcEFrKb4cuk+/As+yhMx9IFFnFm5UyxjdvlrVtU9rVS3LpDxK9690vEB79n5qf2PZjBQWlPobSf8sPTyf185OhNNwh55vYhN+2IqthK7czi5qkFiOh+vXACiLA0yyjoyLUxKYtz1KySf4fNxVFX1D1po6uTBwuBwYxP4Hu3zUbS2XXHU2RfD/UEWg9xqIjB0gOjI98VMPhwviVxUJ6uKlL36ppNB1NVCSg+vI8+NdsOTi6uFJx3sdKvos/nHzzImdMiTXh6/PHdx3eodosAG95nyDOEARp00UwZLJckg+JNhJpghTHs1jFKCJYeR9B0WN9cGxz7UiMqKrlcq739WB71/pi5SartBD60jLzmznaMnml/Nhgvl/5YL2I+IydyKMLe3gRZcv3t20IEH2rqnGzMPcb1th8IdclqoS42J3+nfW85GpKrOrHlATdGufIWKPjJciUXeYfeJSsToSZ+ucgIDhKfP5+RS0tY6ILuEcrIhdWlsVlASDAuMVHvN/Lh2fklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwFN/NACKL4b8uRESGgmayTeHByI3WMfMb1134ZrjcuBxswpB7JNCExRyMdk2szCuyNfMQiO6wCAa9+Gclay6RAw=="
+        }
+      ]
+    },
+    {
+      "version": 2,
+      "id": "93975e48-9d68-47e9-8de3-418466723cb6",
+      "name": "accountB",
+      "spendingKey": "992addd4ec3a46875c9f1504c981e9b32d2e7dc7996564952a64f36ffa6bca83",
+      "viewKey": "66fc051eb5455876c2db4b73035f07044135864eec7f37e8be3d4756cf92536a6e30755067375afb3bf01683d678c86b6b97aaa6eb35973d958535648371c130",
+      "incomingViewKey": "cc4a52d4e0e5674fd9edd55af9937c9df3b870bbfb8d88e918319f641c5fb403",
+      "outgoingViewKey": "3482dcb2c9caed1f71500c3236b81610ae9f0d9ff76772fb4127e754d9c00d96",
+      "publicAddress": "fda747b4124cf53dbbbe661ef9456e299b79ee0b8780b03219b3c49410198ddd",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:98AytLR4yZRTHXhhFeC3MEljxAhYtGJmtd69cezDfQM="
+        },
+        "sequence": 3
+      }
+    }
+  ],
+  "Accounts disconnectBlock should reset createdAt to the fork point on a fork": [
+    {
+      "version": 2,
+      "id": "d7d145e9-b738-4c6a-ab07-692aa93a018b",
+      "name": "a1",
+      "spendingKey": "b5e0a8f0c6b3b19656a35840299d4881fa884ba744c0adf7ac2e2803de400b21",
+      "viewKey": "6803d31413ec6c5f25dafefb285fa57f60f517673136cc23d045c4ad67654b9da36505db0b32539125d633584384f3cba61597823bf5a5aaf28bfc5791cace64",
+      "incomingViewKey": "6204bacb8bb50cea75e3eb3b4e9db9766dad71be0731315ebf41da34d9a5f802",
+      "outgoingViewKey": "2753416fb0a0ec1390f2ea56ac51bcf5cc2c29f78719abf5116d315c5c59eeea",
+      "publicAddress": "b6f14822aab3385801ef51385343344367c07a3e761e2489476cde6c17e2b785",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:8YGXIvPKmZf48qnxEl6/ABw0BtgfBCbd1v+P8XSSBBY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:yxk8nu6ohuQhZn6ewB6l4+4iWx/ftGWC1On2snZgvu4="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156583511,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAASQykNDCLLfsLVnv1QoQ0sdfnA6ugafz3T0YCYjnkdpenvZ3bVd0U8lgchbHLa4EmB82tCKWCslD1hbP0FJKD1C3QBck7Ebi4R5+aAJvRURKF5e9h2zv2c9pUsxxweHvl+lCMRHiLoOQTHKjxa1GlWLL+H3qhnqZt7eiJKXGfWckZ65TnZdjhRYTrte1HU6zqffYj7Yls6IpqnEIhoP4OLWkhnodI2o3Y9mvj6Cgs7qKEZmkxQGkipjwkU10Q1arbo5lqVtvwcKSeCUaVvYkTZxGr01LisRAddLztDJAiM/blVCGynzBQjRrHfuOCDwxXUv+G6uj3BXMNwlL4DrZUrMRpQR1SNz2SZQpZ8t850TsGJh6SCkpdQqnMKyYiYJETKNgYOBgElWf2mZQmVdMune9Bq/RrK1DaQc0EbnyZUkQ3MMXuzsLITV9Oqkh8+Nt8/0M+NW8PSJlHqhgveGmoVWGjvb08FpRiw2cawc1/rkUUXVmFjQQ80YPp4Z/C+ldKFm3cXC6WfjUmL+QfeAiawqOP3m3GbIKyiip8XGlB9v6rqOcC0SbiSpF+skvn/gKU3dy00D3fC/FSwzSV3xheXLzobjp0n4MFKEgCRPe766rHva/5ijyCBUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwjQi467oykjQFgSmmQkKqK1CAFqC+W3kO0TrjnKHlWNSI/wKrFyJMJMgQAGMBc21v7tfXs63yCoyybBM9B4vSAQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "6839D42E3C3E900BEEF6AC642DF8C833C8DB73CDDD76341DDDCA5895268CE738",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:qLmf8lckSgn16O0UuSew//IxBSBNvxCxpO5akL0OvUY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:RK2/YvWSlCO9QzRT033eXZi3cGH/Tk8NRN7HJ/DO6vc="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156584038,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAjPl/DvN0A/LJp+dG+fX10LDewYWuPMdmHRQ6PT6N9fGndb/gDdIDruOfdzAXMHTyfj72/Uu4M8AlOu9/Vn0zM0eK9zh5brqVHx494KW1seO1tUhfSYxEM9LLHCJk4KugD60gDJ/SB5DY7wB+GT3WCLclmPXG94B5LwV+dmAoDNEP0gMAu9pI1Z9hHSeq79JhwKKg+FKVHMjqfcKV1Q+Nl3Z/nEAcyR/w23qv2N+AGz6BEaWRuS4Xu+rvypKbQf+aVrfX7uIHhMKPoREHe9YbKcBl0ygZROAIQTDzXh0AtHc7jj4Cjlgg7dcKlsOKxBGompE3271/xxRGrjgU0lz6297JMCWqdZBeMxb7QsAjw2EIaQXbgewigUc6icQydO5HHglHCbqHYiOLjYzck6nPlBOprXuOLL/FAKRnEyXwjwo81lKSa0bfYtmcFwaSvM+i534mEe/kzkAU2S8KxcTUvQyjB1unpD+EfCkYHVarG1qyxC/NOYxWHnkXtACc5gKXhvY1RWVJxBx11/T3CriYD+WG2AuHRpoigpziOA3JA7wO/u5qjH9W5pd5k//q6e+NJyQoLK7580skm2KYJ1BK9lT77l9MZETbemxmRV2UIoVKDW4ebO+9hElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwBQoIDNqCVZSw44IvI+bNsol0KQyoha+C7udg9p5Jc3Onp7Lza3LrYpS9qg6v2jgbSiYyykX4FzFWZeKcgKVPAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "AA3D400D39DBD1D2D8DB07FC31D04C315D3E28A4F3D8D2D9EEAEE6DB0FC15B48",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:j+Qeb0lwAsjxpSPzJtLs9arMx8gVu120Gxl3LZ2SVWA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:19IcKNmwNfvJfwlOcuIZ28+LI2IvRly9k8X0F9Q6Mtc="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156584545,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAEMUVF2UuviXjMSBbeKvzBn6o0hoxm6tkwUaXaKjo8QmE0yOSlokFlVMTNiyGUXGaQefabjUr4oCrTZTB1/XPHDJYCdi+knNEdqy/Ec2/GA+IcRLVJNmQKVTqcTN4lyhdxcOPAQwoL9l7mWTnYF3DUHiFlEnl9JOrzu91oP96YQkTXytIwAaww4yogDQs/YGp4UPLRmuYn9FtQqsJcr8R3pJUcE6ytINoePVmb5SQnDWXJAxmXhGh1xuwF3/OQheHi/4xVvQKbhlDxuSjoYnVZ11X/A2FSLJoaqfclUCLpE6PkCbyYFEAtfiCiFcEnpheCXMyOtfW3hCJxbeQlyPgWrYUUwA+0/Plh/vlgyztjMSMoUxFJiwnHwrm+8Oco+0WPfO52LU7r/ka6rWJoYbIsMoAABgy7Dva3EMdSODGbGSi87A5K/gs1ao7EtEnBSV6hohELjg75uz8QuQTNPCQNxC+bCvYSNiuumSNNKU6WrPWV8lZwpiuHe2//8zN6c2QE0ByKjeKMfd7gSqM7T13apt2yWPTT5zcrR+2zYrhWfNS7PJxhO137TOxk3ZMEdt1d4ZVwcw1mV0BI5YS0tVrMYJxyxn/LjI9zU2WqRJyhzUsTDWt7LSIQklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwoDmHT5wdehHxnPYDJdiU4KwLZV67LnkT/Eo4H0wM2VLmcrCu6fulPpWoymV2PicwZ1cCSIF4VmFEDAgGYTjcBw=="
+        }
+      ]
+    },
+    {
+      "version": 2,
+      "id": "29a6b4b9-14ae-4e57-9fff-0ec4db2e0991",
+      "name": "a2",
+      "spendingKey": "9718e024cf05ba08f82496922fcf7d42b8e49244276d3d5733e20fc15c485736",
+      "viewKey": "f34d1b491d64c84a33b30c7e15fbd94e430dca2cbdbbcb28beaa36b23d267228322406e31b9302b3fc26e312bdc32b9a3c7f3526157db36c96a34ac4d026b0b3",
+      "incomingViewKey": "059e7f524e3bcc706649ea43596673b53da27fab983f0a0072eabf52eec00106",
+      "outgoingViewKey": "5a03e35f23c948cd228a4ba8f9c71669d646f183e90cbf094aff895e5fe62729",
+      "publicAddress": "f3931cb2d57ab9b57643ca760b65cd03fe7ff104e3953c5d540d597ddf3052d7",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:P9tfiJwaBkRO5eBeRxqY1igV9Jvhm2r7zPng/MEATD8="
+        },
+        "sequence": 4
+      }
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "6839D42E3C3E900BEEF6AC642DF8C833C8DB73CDDD76341DDDCA5895268CE738",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:bfOHgNnAOhyW2M4jFgb8oLXaRKKHWBfhDWJhvO4odww="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:Dms/XA220Rs2o29qZqHNWgJPJ8PbjolfiJ5nvQq4CdQ="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156585068,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4P7P6B8nzxrBezLHpyA5QXNJ1DLje6uzcqKO6Wbt0VyiheSMLK/SslDo6WF/iEFvvliVR+Dw2BDhvw0pD8lw1xe56A6cfWSrseO6pP/YC3OVNUFqXaC2CJQjJWQjUUXaPLhBQNTZUrIe4Qn3XhpBJxz39uh3RlN/o3tpOv8yOwIKJJk/JAQ39CjTW1OJ7i07iInNE/O14bcCFapgjSZUS2Xbf8HO4CAPYgrhAlOWSnWUHUSAm5biKDav62twB0Rr+xIr+7sVIgIvjkzPTotEroAhGMXuS1PHaG+LDTszzPa2AVW81Utc0QFyIa3IRQ3gRZFmc5uKCugrTdZvTZr8hcV92Yq9x/D3IH6vSA+5ATsKslwkmXys3tiN2gUGGA1NrvB7Xzl9wDCNpP8CW5FX0aieRBX05zV8+Z4O8Gpt1pH5jwpjYRJUe4bGutVlMBZzC6TrFFVTaWvA+ZKzokoXeKnz166oG6MDDY2QvCi5nsSH7Yv8D/LcPY4ikoSnNGHOyq0xDuHqnxYrxBLEVYuGLQuo1IL9Up/tijkThgFNFdKEx6XNQ/S2khjUAM/Jlwb5wLfOEWxORPph2QXcJBlGWjaYjf4Kt6Q7irIxzr0RqRMcZLIJg4QlZklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwsK4V9LTn7fKolO449hgFid5+Q1WUwVQPTLbAAes7SrGbxbbcSZHJtyR+QKbBMmacZUBXjX409xQfSiwTuWywBw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "9207136ABA48D1C870D15D217379B08C74ED9EB0AA8485518A333E0AF09D8930",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:CuRFxwPfaMX9vCIIxJ7AzesGZKbCA7oDNUdEEySIyhY="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:hNt0FW+Wwv3tWU0L27sIhga0qpHuGrjkAGdONTBOUYY="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156585585,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZ9ZAc8z4hX9lCj9wemQdEeUye+z6d5TAMZa3UtiFGoSFvvwRxW6MRvAt42QTCxQ4VWbOO0UDWGr7tHNVMTmTIRkcIdsciF51Ky6wBe0FBrOvkXnRo11WSKvlL84g9apXs0zW+N/1NoF3TxLYB3Ui+m1rkEvbyg/5hckRwHbs+ywXu4D/Xdqcj27IsmmCEITdl/A4ULXrM6hOHJTeGGrJ//nsMcbPB8SMiWdQw1rSioC3rlMGJwvWl87jRkUzDIU63Y24e7G78P9ALMuSPZ1fmcZMNYaiPpWSZHwI1eR7+tfWc5kV+/J4i0QDtNQjUcdt9PPu2CAHTAsyxb48UgZr4Q8avdCp5GkgEUL6+lMDBaRIIE2gTDfew/GN/GABu6gZUtA3Ef+cIUWmLeQizhiLkCMKNPNWgTa6dTu+9jPZxRT8/Zw5zlosnFI6NJcc9uqUVuLJyfbu5CURgfjvmG0rL/UT7R2Yxoh3ttMpYxa+vWcYPLl+dUpo9W2hCAfTbhuZUkisbK7jUmTRIZwkbkXpbS7ji+jDA5lwYMVpxQWx6wgzYQFEma36os05lvvwN84w8/3LlCScofh1qnI5uQP1gejr5RwMIAo8Ipg43Du+M1v4U5OfehJQXElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwauLRp8sifqOP4I5D2Wf9e9/vxwVRW3V0JZ9ZzI+sh+D1Uh2e0DEmrQ0ZiwgEwXdEn7LdyhGtZexTtEK3SWMQDA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 5,
+        "previousBlockHash": "0057BF6BC796AAFFEE5CD8595ECF1266301BC78930054C2513DA3EFFA0D09E23",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:nOo/C18iQcy0g2cJ8K60QjLxAfML7AfJcmvBHcdJWHE="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:od/WxQBndIEwL0fNSwS1/GqZDLtMQCYZZSB6laiqsaY="
+        },
+        "target": "875726715553274711274586950997458160797358911132930209640137826778142618",
+        "randomness": "0",
+        "timestamp": 1692156586089,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 7,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAdp6OKw8CoA/gvF6s1ASgo0OszEIfrb6zekx0rhbJloWEjVwObyGQa6C04K+0U/XJqYCAKlUsjOHUgFd1hQ0ErauUdSlYBze17K2FSBO6hzWr31JwHt4AOQfRMOJZjNLisZN+OxlVMLEwqh7pIFPZaGX0PP2UoWiTRSrCoWQbcQUUC0r9mtAiOLe+Z2KhhhPrdlWFV2/WHQPbv54SvUNFP3uF2pOM09LHi2T5KgjiKa6VkFyAa5GhO2X0YBhaWNz5rirxM0kZtglkHgAIZvUojmzrQiJRdpnKQYMSazGEtNpifv9+0/yX8gl1NSVg3My0SdeAS4omMhYsSgCuHPLCrI6ucYzq+51LOEobMkumn1nnQ8Vwv5UqlxZ3+Kd8v8QEI5xdot3Tvv1EzqJad+pxYhzYaIHHUNxkfqH7xBcQ7HGI2LrM7gUOwg968uwK9U2/4hE/so3txXy8Ev6RPDZApoCA7nH0upw6QHvja45IaR644pwoehsAStZHredqcwlyNoRnjpS1EKW0ttRm3dSL2TmSXojyZz1GLKgTU/xWprUBMCQoh6g/tZyru9etIia3EgV716eOLuAa37xVv52gf7mdWa3YZfwNYGcS5qgYCIV7zp8AG/g+vUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwtUNutqRTcEaa8Ofnxzss+qzbV7rDbB2D187XyX7MkqSqycWjFlStnU2Rp8cptgO50WvCYRgP+VsfJ+c8zTPEBQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts resetAccount should create a new account with the same keys but different id": [
+    {
+      "version": 2,
+      "id": "c9946eba-4c27-4cf7-b42d-e700777160fd",
+      "name": "a",
+      "spendingKey": "606bbaee3507fd31af9f5cce6232aab01d98ea815dd0d1c72e90bcd2c84e8398",
+      "viewKey": "aa8475554f300fa7409ecc454cbaed14418e90f78af822230a7c642ab81de3e6dbc22abfc5f17b2e8eb52403d6bfeb634249c6bc08dd42da0839bf2335c0fec4",
+      "incomingViewKey": "b7fd38c59833dbe5e2c77057faf736e1c5ab8a5bab99411381a65fff2f7bdb01",
+      "outgoingViewKey": "3c47080933e5de3f7012a3dedcc214d7a25a7d5b9dd3b274b9f3fae60d4afb22",
+      "publicAddress": "65fbe3d1c9feeffbae67c2062ec953ef03c5e955fa9ca073bf6ff42594ec0d32",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Accounts resetAccount should set the reset account balance to 0": [
+    {
+      "version": 2,
+      "id": "f6da5c66-1b4f-4ca5-8df2-85e7c5919345",
+      "name": "a",
+      "spendingKey": "7d2f2253fecb4bc297f6458795e73c1160e5d52b70a7617a5e7ef945cdbbfa9c",
+      "viewKey": "7b134e12d14f6609dec5003d765b1657eb4dc511371109568d805a043a588283a7230a1401b6cef76393286b31f22334adfb2ee57b78b14c2cf8657b31439ba6",
+      "incomingViewKey": "c0de5188ca771a04609a1ba81a9eaab632a113550bb667e181533ebcd2414503",
+      "outgoingViewKey": "e12435521450a1d105815243127c0baab1248190f8920b270816dcfd7089737a",
+      "publicAddress": "8573d6a6f3f87a3396057066351dd7bbc67d1cd6f629f9de01a1c40db27dd1a9",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Accounts resetAccount should set the reset account head to null": [
+    {
+      "version": 2,
+      "id": "433e778e-309f-4f95-92e8-806f91a82a3c",
+      "name": "a",
+      "spendingKey": "73d969bcbe5cdd585176719f7164949f42941d02c7a7756a97f8476c84778912",
+      "viewKey": "f4ffb756bae492431a95701d7f62eee384f0ab1dc0266561cb78f85180ff99f13b3e951e991825167fc447255a00c036cf76a3c5dd839a4ee6fdd14b4d48431f",
+      "incomingViewKey": "c32ebe2d9caec227640a37828e6636de70c4addd538d022f45050b71a7304701",
+      "outgoingViewKey": "5506316523fb1e9c06827908373afa5f27f70fbee6d8f289651ca7b1548cfd21",
+      "publicAddress": "4379186cd19223d2b1f42375ef4c60580334d31f726fd3b8e63b1e5f62976d5a",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Accounts resetAccount should mark the account for deletion": [
+    {
+      "version": 2,
+      "id": "0d217b70-173f-4a0c-b90c-11a94a040c80",
+      "name": "a",
+      "spendingKey": "46559cc922d8ac3e9f9d9214a471e782fd430fcf496f5da4cf0ea5e556403c50",
+      "viewKey": "cc0359f2173558e1af8789e40e3aa2f47e9311678cb3dc01b0af74fc77cbb8739b58d98d974d8a0a699ab54c932b833060fa4307692b11ed171ce795bd046b4b",
+      "incomingViewKey": "5825ed5c5eef750ca35b81c72ded33a00203429d7dcfa71494c4ff91bbf67707",
+      "outgoingViewKey": "19b4cd78f9c2fe0909407a3e87cd0f24146895733a5f449b86378b7d58280748",
+      "publicAddress": "eb565a91a15112df86003af91224581559c4dfec58ad821aeb69e8927df40847",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    }
+  ],
+  "Accounts resetAccount should optionally set createdAt to null": [
+    {
+      "version": 2,
+      "id": "fe821697-d060-4f3e-abfe-8f017d99dbd2",
+      "name": "a",
+      "spendingKey": "bb1e2ee2808dddef546a853943b806c063fc9d7b2ec7e199a05fe3497b6ce65b",
+      "viewKey": "8235419c61bac87640aa76b1fdecf8b0e441f8964d861c1eac71186334fed9bfe2dd24342f1232b44e0f215fd96db0528689cfd67a2e116ad48a574333745ce4",
+      "incomingViewKey": "80489f32216ba2c3d1ac7499d79b475aba53312587ea8a9ffedf32036835d602",
+      "outgoingViewKey": "79408bcd27ddab7e919ff0e001349fdc46e4e6724efadca4f90910e2602620c4",
+      "publicAddress": "571eac6dea68386858edba80e5a8afebd0fd8c0b3eb4dc7f183fcd8afff88531",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:Zpr87oT6SaGorEXcCQkv0meLEMooflP0a5d5+y2/x0A="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:FntoMv+XIrvSGMembkxvB2IkO5gL764KDB7B+Z7PmIA="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156588211,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAPzTKU2yCrreppFPzxCKMlgEo9l6HOWIyaFdeWbX+JVqGqWONhUShth+uLNhqGTnkGgx72s15+DOEUG1QXyrVj28Jbitv3/H8PELs1lvP+uiMiU4efYexhD/JJeOqfnUHn7HNsTFgXHvDqg2559l4UcH4rMtAQGwSp6C5FuAg9Q4BekQ1RV+trWIRDU2HEI87YWaQklsU7X8d2e5U/jTBvpJu95v8X0H1WM9RpHmDMoKxo6P7b4nr8gvkYidG3yNGdalQ4LV1AmiYIy8ZiKpQnzPQ2RRCwfNgr0jI8upLNxXPc04cVLwNfSgPmWjJrXDosidbpKZpvBTRjFq1bCxIY9PN11wpwCU0b7LCFOMd/7RDe+L3AcFFVO9SFpEULNYYaTwK7j0vIg4NpIHrImKg/HyYXzQ3fvWqdQlL1elormxZrC0PPNu4OXwRrYRne5O4RZGtiSPOFKWKoiwu5Q44nbzp+d3cCbBMpaJBvIScrZVPvInH7BL0f6WCfukiRiKxb6I1S8nE9hw7uS7Da3WmRz9hZVZW1mQk9rgRohyN/MuiP4FikqF7Py3yRaNART4vzAimoSy3MDsybIfL4MS5JbKN+bs7fe/bi8GVYp8jDsWEREMtFJ0ljUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIKnP3OP+wFk0IB90cUxE4gLKRPlYRWzr8mQrpeRqIiUAK3ae95LaTWu4LNa4hXwU7N9R+DHfnYx4/pGmUQArAg=="
+        }
+      ]
+    },
+    {
+      "version": 2,
+      "id": "564eaa4c-a563-448a-89b5-6df3e60e389a",
+      "name": "b",
+      "spendingKey": "a94c1ca360768883bc12c98d8907b2052d24571928a04feb0b98b798b41fa84a",
+      "viewKey": "ebdfb42f90a7e8d64c306e5ffaf2f2951ef66fdb8d42f0415f96a9f7c13c2a5e9a3f862604b646662d613c6945926abccdccf8f572bb835c67d17bbb56d197e7",
+      "incomingViewKey": "ca8b1a68a93633e910945956c0e9dde919476a987d69cfe7837e582e66f52705",
+      "outgoingViewKey": "cbf074db596ee9cc19859c88dba4edb8b172da439c9876743ef991198b791b90",
+      "publicAddress": "513057f155d6c51b3fe41603f48cb286db29dec2dc6670d0c35dc91424301dad",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:atVWBWkOk9ItRtdcn+WUkUu47AZAlJiWrqmZWZZal3g="
+        },
+        "sequence": 2
+      }
+    }
+  ],
+  "Accounts getTransactionType should return miner type for minersFee transactions": [
+    {
+      "version": 2,
+      "id": "5fac7795-0ac3-4c0f-b6ca-1a353e0028b0",
+      "name": "a",
+      "spendingKey": "7ce80ad2454de8ca4c55ee08f66452dda4dba657a2edb2e27abcdfba42591bdb",
+      "viewKey": "86477013e40199356141f04763eb668ff9439b56ca79eff2cd8bd04bb02e8f16df000e20abe3e5a64623d143b5355d3744459b6444d45a8bc0e9cd45bf33a1f1",
+      "incomingViewKey": "2a7c310971cdcf8fd3f041f4a94928fb41cb6dbc9db3882ef8dffadac6111402",
+      "outgoingViewKey": "acbd8b77f823d6a618233835cdc0551d7076cf0236ddb52ecad2ade91b7c3e28",
+      "publicAddress": "4630f7169a52c173885770ae033b6a46fe8d162904dbddb472dafc51fe3d66a7",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:cswv07kkSXlg6OYAOtUGcIBvt19LqE4A8HOfgS6hfzA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:VsYO/Gcl5TTCP8rgGz+QnsvZ4d+sqB9Lz2venxbL5ik="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156589024,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAEA5wJyA38dKJVIZTzA9Ea7SQ1YyJCjf7rmbOiiGoid6CkikC3U8mku2NrLOdizwoohSPvEJBh4VCfCDcOzRs/Zx6W0ku3efiqZEmZvpurtWUl+34DQiBzyiujytccJX/M+PmSVDUVdFRBAsE3Z+OIZie3tiZIQ9R8/eo5TuRfHcZEtIirJgXs7rIqk4Sdq+Miglb65QpFEwIfPrNTWEWybRGtNkzydT0sHuKKBUsXiGPMELL0rxYUiZVJUE54Jt79jimVPXW6xZy+jE00Acccau8KxyU2+/s3uotnal3qSPBXn2E1SKpvSLZVhJmLml/5Vwnr/ywFNx1Li/jXNmVMGPC1Gn1LvvKJxL7KTb4HQfduFycIHK1pbrJ39o1ZfU5vXmtrAYGj92Zk0f213jHtEhA4CFAqH1+97zbegNhTwFqRr5BMLKhypj6bDKSfNbZkz9PDJWSIXrnDIo5ukPgj39wJeAc+Fp39T9O9qGTGlpDt1a/bqdATLoeX0/9zgrP3Zoef2udunqBLQm0GBK1ZC5MrGO1UlKVuAKiyS6v5k0X4NC2oCTwpRDCM8PcEX8vUv5TrL7rmQ7REf2+3jEST1XmhLRCAmRQKTL5+72fbUJuP/D6OKTdh0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMUxHGTG420Kv6NSsT+WK1Z2bZUgk5RUAerLQl5zP2klCEZefiUataGy5TV1/aNuvWNMoRWtAeXbNGXZbuoUPBg=="
+        }
+      ]
+    }
+  ],
+  "Accounts getTransactionType should return send type for outgoing transactions": [
+    {
+      "version": 2,
+      "id": "c69c54b5-07c9-469f-9be7-5f650a16da08",
+      "name": "a",
+      "spendingKey": "74354b07c2061b72309a20f2bfc2d3dd787ad3855a51c0b8bc47b583f84e090e",
+      "viewKey": "a3ab98d099af05d7e8e0650c3a29ee7c42cf89537d5431e462bbe56b80c722372603ab8cd252bbe1c43a8f93d0b0cf87cd2fc1ef344dc21c60f5b16192c3c660",
+      "incomingViewKey": "d36e78423c817de9403df4463af416e371ce6cf8d06d4db0ab5b2b41fe4e2307",
+      "outgoingViewKey": "83940fb73763b09a27c46e2e0f161bc1ba6b5e9d48d80fca94cc4073ce3b2257",
+      "publicAddress": "54388174e0bef76ef50541e739f3d039092c10e12cea3a8fd8bd027bdc688b43",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "3fb9df98-deed-47b0-bcb9-b0a2188ec78a",
+      "name": "b",
+      "spendingKey": "0f9bf5858a2ca0b427325993dec38fbcc8c8fd2c3c6d19f1afd6c1f692117300",
+      "viewKey": "81579a4b42d2bf5ed26fe984800164609f1046c0257333bc6a4a4805ca412a14b6343e26c8de40d1ea2ca3d49420e5632ad73ccf0650b5561d7197c06f476726",
+      "incomingViewKey": "42d06787cc0f23422dc50c7311c1fe58cfa82a4f16b65b9cb460bcb6a9b5e007",
+      "outgoingViewKey": "1d7103c3c45e7158b5eb9ed8be52f96a25e9df7699e3c4ff264969d4826e4e9f",
+      "publicAddress": "6eefdb46c76fcffc487ee2b540a34b840800f3ea5608762585c2acf44ba239b5",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:WpEQtQM8m4/hAe9cTdh7m2ByLwlJ5UOUa4TW1E06JEo="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:pV/PDfWpvCqWok9GhkDXv7dH8lyaepC98H2wSpfGzZs="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156589847,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA3mLamGMLKmLxojVJL5ajz/+DJ01dbBrKdhB+ZbdzQkCBeS+VilSnZpo1w8Sm0Q+q03oPFFQwfq0m7IjUZteYApPjIuc8fJW/4YqcpSj/RBy3bECna103MubkAOVa7+TSYN+lw7hBx+RN2HPO13dhBs9HzYuwyIFpXZyzCVvbZ0QWvZjla/gpZ2MtfI8eP+uQDouRg73VjXAkHX1EASjxdDaSdgFsDIoU/O3qxoVj0p2yKFD+CTQ7uB/jdB6b325eVR2Bargn+lxoY7s4RCkihVe/tCq5WfRfwpZWE6fhWeb1M50U49Xnvpmcg+MKCbmUoAsUQdy7Kh1tjLwX8xzg8vZsKU50qBGYd2H6ipRGfEgEVsYuus9EaS0lbh6KimNDzKAXIVrm6usQxXK/w34HrheM0k8Q+LRQ6/5xxAch5ue6Oz1NSmPL3JtJTx2T71kvbesRkFjCAn74PLf84QX6kFbrAphsZhu0TZc1xUm1fb9YSPdVmC8mKd2+xBewUmxqBrAomwNYA9IcQwa7tzxl2oarm7BKqZFhrlGaadhy8qa6C9CaiqfYExMfzGWzZjU+vhUjVB95sGZdecSr8FV+j8CgIN0LWGyA8EqziLjllYTNDdBZY+JyxElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwuzg8CbTprTSpcTPepJ+ywrDDSPHkS7/ktEhcRdtd5E2diGfKeQqXHNWHb9axaCDwrJwcV3ytWqUi9tKT2mgPBQ=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "536872E31F7564BA3093C7332B00F13E1D5CB0A9907290FEE4B883D007AB5336",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:LuhEl5ISH5GWE93mcbQ2EQYq4C3bkx4nC4+AQgTaGDA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:53+cl5uPOwZaO1OYfyuw39G6UnoVWyuzW0sOsCJJIcA="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156590353,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZOb4mIF2hxTvGKuYBDhNKkvm52yWRZub6R1NUcQ7KMuDvmltQJ5c84PoXFBbPgsc8ZoIRU1QWQv2S4sPKqJPQ7HDBMFfUQ+DwlFubsNVAz2llwOkotqlhvAw+/PMdpWt/mxs2mEXUqbtGXTnFAfNZ4jH48s40r7OExAMD0b3u3gDLJBI9emNOhe1Z/k8Ro4GwkOWK4POdm3FKvy/AwgKE/CIT3MetBFMk0pCUBdsc0m2nTpgDURZ/ShD07gjIhIBUolIdftt5ZRhnr4kuD1l3BxACqG1tOklZ8TtrMPrHiDrXYDB0pmihzrhygWiNWiIdpH1GMtxOfVMgv/xgnjxQ5mZWQjGvEIhuDCGPH7nayysn/HdiydMs1MBXclW/J0zmQfYyFMvv28MbJ9Rc4W6a2wXwUPlfYABYshtNuGZa69WpvGcG+1og8BlUk0Ke0r669cy1Ol8FDjbZPjbJqLPoRmMBRuCgf4tuVqY1hgVhBFKPADK21LeNLn3QlCK4KwBNoPW58ao/8Nsq6l1pqYYMcMMFebIwBhBVDU0xtv5GG9ASoR9gi6AJ7FxCTnan0rRNjTx1lf5nlDVExEv85CZfKpXM/dc951kwLUkkX4pgNymCkYgHnzVs0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3W91G6VZa0uCar43QkS4TVtSUHHklqUZ92T4VZCWWfMvcUNNMWqnlcvJZNbXLWC0Y1AcSF2m6+3qsCAconEYCA=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "E5849638442DDF988079141164DE50D9E9B094959D9F8953DF4B33B6A60A7CD1",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:zxf0lOhyMlDRZOvbpIu8aG728mmhCjUUekU7d5PrjUI="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:bf5yzh6cEiH7obhhkyofaaMw5LnyrbpEg16QN4KeK7c="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156592829,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAAwWdZjmsCxiOaGQibcGl7/3erhmU0ivOkrKAwJ8P0dueN/4PbxJ3uo7C5mbB0BkfKTUZmEsFsHUnPW6Td+MUfJnS+P8F5UEcTiDqAkJaUUhKym6E8dVDqJpxqmuE1oeE5269Qf0HHDSdC3NA3Hrw88eOmJH4LtzUlSuEwv5zo6fcWpK08ryqgu2464EAFowPfuHbPXEMQX7AVJUTQhSKXBWalm+1iA9B9l32iwA99nGigMJCyOO/Ga6JaH+LHvK4CEcgf+P1/XGLs1LDLIekIJtpzBkmoc240j14q/xj2jqUDfMKlB7FgDzZGUcEz5cUvPnIN0Fgp8kjYLeZshfzhBdS4T/J+uEGeGFp6yE7xITyjT4myYYx/gP5r6BCs8A4sc2+zpXo8rIEY+OkbSSAxTvL34QuRcOmZWg4EQP0IXIlk/ta4sV4FQHyXn5VMhRlOEa/U5J6uhnbjaki3otWMv5/OMVd8TSZU9bycPVppZoGNdisHaE/u40ho70dD9IfUXJsyBIStypH+oUZ5uhpufpFOy7OWNUMEz5Cz4Ddv3um329PkZs+sWSM1XV6rLRDyUQ2ut89yW7YqTRFg2enRPzSacBrK+fQ0CKlRntDGEZ+8cZ2JHNgQV0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwitYak5ZrRdavPg+8eg722IIXLjYtNi0WNeq0U2mBAoHzja+SEGkekX18FKjJyQncBmdJwoWE5AMa+HfENH9yDQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAV2wDA+ho2ffD97WHsaxWlc4tCZoUxZy3tbl7G27glZ+g9Urb/AYdGkymSuOpJCSf49pCRXal9CnGsWlbGuf+9P5Qc8ppNy0dz5oZbww7i3aPTE5TxxYkyKFnJuoaWa2l2IeiiXfasw+BokY7jJuD70aFUDBg6L4Rr5WqtgcOE3sLe0ht0CSvroSg6GUe3/ryvbbc5NZ612aD2pGAx+GGRGT1PrSPmxZ7ZvoCwVCZ96KT/mX7dEVnMSBOs+7gDshuLdWIE+M2ZXGDTQfrivrYm8cwdRR+4lVXy2jqJMDzvFTPOF+/e+c/dQpJMeck8CXFLJpYf+vjedIfkRAy2ccIKi7oRJeSEh+RlhPd5nG0NhEGKuAt25MeJwuPgEIE2hgwBQAAAOiUVxO3RbmvjNmQiaVtG6sXiJ+hkfdsA70yvg5IkJT74RBx+MYtnGFfCVQ3xkWU42lAt5b/NqDb00ad659MnAns8O0GxNOYZyLBLOIV7FdpZiC+mweA9pUeCXP68gBOCoZSrMd5nGpLqSyZj5YHf9yMA0HS5kcDqotHD8tpnGZCI/8O/99S8zm+eKLn2L7XyLDYijNSB4a+3Fl5K9ycqiNagBxXeFoXFfhO7RaT7xVBENlGaJHdO7Xpwrl6MEo1UwdW0zgyL3RwIMEvsupnSlxGiTrof0QO/PhsAXr8O1yrdHKmqAmjtz9louqVZBphCJZJ5GYqHcg5JbBq77iVRagymlL2nVnAoBoLUCpDjNrlsWda9om/LUg0aBk3q8spEaXb1+lXVHY3DqgKnTndur4Tn+z4Xa1xz0ncBWtoGI6ae+3yQs/FAdhi+fL8RTpmAcq7FsySETr3+wDNzFv2BRBrBp7CAYKi3XV5FY4dGphiP871KKaUV4tDC+Ws+Ob5E5VThGeempa1zJ35fTo3VIfa8NqxWcz4AcmZOSc9EXVobFXqnzf6gv0ZAjYIExORkX8VNO2lreGCztg3fyXxTT+6J4CW2ys9d2RtyMFx/DkzqGYOSa7Lf7Tuz4zbsA1+Wj2QTfCbMAiehN36FmgKhTXmE+MnfJ65Kp2IsX1bajDvSbAkUzcWBrNTpv+NwGBKnvBlI92rJJz1abi/autemd6pQuuRiatIPiV/VxWHXOFhteaccyZjHPSwIbAdU49b6HNcYiGIryadz6I1o783u0VnDsUdanUtGOGRc06ojxtJzpMJrEQ7hgKE7Vq4H4DaZERzj5QaF7cJQsMaJlrnR04dAqkTJ68IdeewzLjRMu4aus2M/ZO+oRWyIN2xrF1ZzVuPEpoLmaJ0uco+ceUSOq0Ducw3btxMNiT07Vkuv3dEAEOF+/299uwNPEBl3ihoWKgnbHhsOvgKdAFqrc4xGCLbxLa06rWQp8YK7oZju93gB1VeEaiuylSpfhZlIhj1UBf+OagHFI8JAN9riOLVQeMqZuMaIVc16CsZpx4TygXONudLOmlMWhhYmT/tuJY05SWsuzyyk6HMjPGlZK/TxgW4ml9OJZ8ZnMcWdP3Mft78WBEF4kgWgPLGl2lmClrUf0aAtXk5aAhQM0gNpZ2OipBbTuqZ016gbwDVB9OnwY9bQs0ZI/vhZIgMBJtoSNKbTljYt/Od0ZQ2mL+g5xl9Wor9HBU5MAaUlQrJPzlLa9n0IUFoBEl3uCJhYM6XRPUpSEGfQnkF4j/pCDAFX/wYGlPIfKk4kuq0hWy0gPSWRycdjZ/m/c8tjCN5Os0CWO362a2kpsAfuMKLALqM/TouTyLsGR++mgCYoDKVJViLmV9NNmGuNnWKpoPSgi0AA+ObSECd8paWaIorUtZJI8alHpVWrrdL4pTzBMkLPjfXFrVZXgt83xUc1aKzRvnrmyf8d73CMON4wnGJ9lkaaT+zyL72cCO3YFpYxNcQpOsxjz/duAeUGhqjMPZ013J5mA2yTW03kiK6Lo4XgZTWaAQkVWBnuuqWPNJ/sB7uyxMC5KHyltM3MtMyKYcp+DEBZ4pTAA=="
+        }
+      ]
+    }
+  ],
+  "Accounts getTransactionType should return send type for mint transactions": [
+    {
+      "version": 2,
+      "id": "36682802-093e-46dd-9dde-3599bdbc1c58",
+      "name": "a",
+      "spendingKey": "a3da790fa898f8951d720328fbdbe2d0e4dde2ad09e688765eeca1b993b6113e",
+      "viewKey": "c771eacdaa3aebfbbec5b89c3cd14eccf2e4b130b6f7ffdc2b5d45fbcc4a5ccfec9874bb7f99c340bf3fc34ef73ff9e60fbf1ade39f37fc0c3d596a33a59f7ec",
+      "incomingViewKey": "e301439dd2159e8d20713e8716d3f77c6c7e252183df13f18133941403d41300",
+      "outgoingViewKey": "cfa2785cb7832f2517d783111ea7ac0a65d4502c1926f668638a3605e8f5aaa2",
+      "publicAddress": "e5db1dade32f7b750c7cc4597e51a603b7f8fd71ee1e4d618ab0525e52bfe39f",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:qYxV/QChN/5qjIfRINV4i2zayrrd3wRaYwfyZaLwaWw="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:nMQHB/ERVqOMA9J0VAiSCH1Q7JfNm7eozNoyKKwNh0Y="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156593673,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAGNikdJ7rXWD2hhTPVc6AyughMvtbTHNV9I3gmh7xxwyoqlD3a0yTSfzFR4KJmySiKthrVPH2bOaKkv6kJaiODS16P7SDMccjxRq7mk3+A3+p2/eaY8YpP5LOtPaz13vk6GkCnAqCMenxXXfH98pGCMIKFfufiRd1zCxtOvSKwqkDVzVIcCz+IgTETWYmGhii95iceqV/Mj0vhiTaBIvCEzYgV4i5SkOd+x2jHOvzAiaMFTgGN1KtkYpzWCuBxkn0T2tSondTNx1+oVOWCTrgOL5HOQnXUycJizCIyDMCtEaUcD5Z+uL7Qcb110yo7+DRvCgCMXWlLJ8dzDwpmTElUxslRFuQ0hjNTRhWJUBhSbbwShU2eLjR1xHW4iE9GWAhKm0PeXJLAozP8b1W0Kw+FgtWiDiQg5AgtjGxJ3XM4vDfaCPGbvRmpSmlgLvIUtJzJrD3URKh4xILLC6JQB/7snyU9nDUAfT961dE8wZojd3cakEcCWHrmaaGB10GZj9GIBJrlmxKUBQGgEH7qie8CrMLpizWk4ClAPpza6uwL6XTtzG/LmnX2aX/RkKdFVkY5+lGMfdXqPh3OwYPzMP23QOO1udyabug2fAx/xaWKzNLU+HJlMhsBklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwrNebIUPWdNPldx39PiwkrLOvofIvVN56Z/ytv2SpJsAtUf7YTNM0MqOYpTvd6jUnBBx/roevjqx1zijDH8NDA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMFn/yKIdBZ3vsIo5Yo02bMGnbKZUFwPZJx1cPhMQut+tR3O9wv36evyrbjGF1lQTUmjatrsphOgTbDkHm1nElrrMw0CL26VP9uRq6BvTh+GKGekmCd2xwvnaIAoFGSbwrxiA2UCKW1VHHB0JLTDIzQItTlQjrljh0s9tPoZ2hj4FDkrZfVXibhGkT5F2msZN2sAqvddghCSn8SmAKupsSbnFWSJmHLSVILLvrFBMu62gy+SfUYI2BM2v5uGluxMZI0OHsjZRZAdJONwsfQ7D4LCpGdbhgH17cgNO5q4ZsKq4paRPnckrQm5R8jK50DFzTvEfa/ZbEV6WrKgvppZcmBpEpRwIgjpGIzgGnE6a6DmC6Dr9m3y3qAb9Ox0GCycy2HGWg7TtQT5ToUX//5F+S9TNGhkItFRzQho1MNKdPur8wAHSCpRqkXPTfhn3hW07vWxgItMALdDD5MRFagwWz2vgE9GcweN3FyhKPLPlPMnOD251PRxdlnPwWjnCa0n1OYTGteMs4FP17qroeNCAcxE15DCwbOIz81EbVFcj+Z6Ob0ITHxU34JQVVMfFUREWEH+wTAAfgePvnyhslee3aOsr7BOILWMa6Zdwf04yiWrKoOaRgxSx+haBrM/humHtS1kk81Ay6dogoLZrDVT9tWd/VMk8gLugttw+myEtgI8FBoboIioSM/Ho1iD2IGu+AoA323+r57j9bMS3DskPPCu7mavtw31xjo1Hqunpelj9FBFtVB09tRdM7ElZ7P+MMkF3WYLGO+dyAJ5+MvqH3TS44O+wnVbbhjJMaaJDRUOs9Q6w2zRrxJdV0ZgHpxq5M1Ib6wK/e15sZZxtZ292NQO5xhPMhwvqBoVnuUdjWh5EPKHIZZYAw1MYgqO4tVp35po1IFQicsIoW5Ejt6Ezorz1VYibBpksrjVdihpBGWV+VYKvZD9GovHuhmbmlEoAtS+MHvVUO3dKp/tJlY2yBFYJ70X8sYrq5dsdreMve3UMfMRZflGmA7f4/XHuHk1hirBSXlK/459mYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAALsF9qHnG03z+QZ+7mX24yzmepH07g6qFJk8q+Eng7Mr0pMZZM48caqqARBk6Eq/oaRY3XsOMIKZZ1zdBeH8cgmRXsEfN7cE294wbWokkYabOsTJcywNrC++mFmRKCTa7uqzB/Z1wJsAYX0tB7g8WtEJ8ZpY6YBpSLXk4AgU8DQI"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "5B124527F333B31743348F1181B8AF0D577A2A3C3ED8F01A626A39A3AD047985",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:h+8TjMHeNAb0qBOPdjoIfIFH+NNVtBd2hPes6hU111I="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:RTXVnSrSNVK8J8fFLi90eWaRwSzeMlFr9e/zDEwux8M="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156594952,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAVdsQe8k0ZTfYo5tYaMsW1jQopeQm6rGY6ovM2K+I4EqiOfDWx0nWn2nZlqSiemifVkHPG6MrJFi4Jc5c64/0fwt9ilvro+7v4B1bNzSXSBajMIcOVI0mJ4ftQajB4JJsSbk69BeOUOCi3fsuCfCAX8cut4HxuLL1CBSUC913Nv4J3JL/GAI22+88IQyjs4dXi7dnNcsbN5DYNlc55tBeguHnHkpg25zsNksMFVVUmJqrNgdVVpeCTjOP8BJ7rUO9y/jgKzlZyF3E1cLbd2MKrvjZvpaZMPOcF6/pQ1riBZsa+8jSe4kRucxkwZQ2dPjFhr64BNeQGrDCpSf5ed4ql61wd/cnvsH2SlstBAgQMo3h7D0zk2EcxXDVE46jmvldwmC2PUs5OdGLdJa1N7OxKOCxMquBqKlzNBFRAvtcgLBcvcBXZLVqywy+mBj/p1qYyQ8aKw8+Lx+28DNavbVpa+z5wmYELc5Mqexh8ULz2ZSwsQ0hts897RcXnrL/lb5FiJECekgKUO6x9+NGKWbBltr5vhEwiDzc7vnOYybKg9wfDE7ocJ2NDqTHo7ZSAqT4I5MYc70DJ8xTbvJE+xlDqlefkNGBrjctBFhMRUdVWT4nfAQEmLVrH0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwLnXbSxSIzdIGFnm1Jthxnx5hHqs6wcjdsH0l3MfhQV+WyWCfvJ60giJJV29ZfUBcfxVxGvHFKtxx+8wcb/6QBw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMFn/yKIdBZ3vsIo5Yo02bMGnbKZUFwPZJx1cPhMQut+tR3O9wv36evyrbjGF1lQTUmjatrsphOgTbDkHm1nElrrMw0CL26VP9uRq6BvTh+GKGekmCd2xwvnaIAoFGSbwrxiA2UCKW1VHHB0JLTDIzQItTlQjrljh0s9tPoZ2hj4FDkrZfVXibhGkT5F2msZN2sAqvddghCSn8SmAKupsSbnFWSJmHLSVILLvrFBMu62gy+SfUYI2BM2v5uGluxMZI0OHsjZRZAdJONwsfQ7D4LCpGdbhgH17cgNO5q4ZsKq4paRPnckrQm5R8jK50DFzTvEfa/ZbEV6WrKgvppZcmBpEpRwIgjpGIzgGnE6a6DmC6Dr9m3y3qAb9Ox0GCycy2HGWg7TtQT5ToUX//5F+S9TNGhkItFRzQho1MNKdPur8wAHSCpRqkXPTfhn3hW07vWxgItMALdDD5MRFagwWz2vgE9GcweN3FyhKPLPlPMnOD251PRxdlnPwWjnCa0n1OYTGteMs4FP17qroeNCAcxE15DCwbOIz81EbVFcj+Z6Ob0ITHxU34JQVVMfFUREWEH+wTAAfgePvnyhslee3aOsr7BOILWMa6Zdwf04yiWrKoOaRgxSx+haBrM/humHtS1kk81Ay6dogoLZrDVT9tWd/VMk8gLugttw+myEtgI8FBoboIioSM/Ho1iD2IGu+AoA323+r57j9bMS3DskPPCu7mavtw31xjo1Hqunpelj9FBFtVB09tRdM7ElZ7P+MMkF3WYLGO+dyAJ5+MvqH3TS44O+wnVbbhjJMaaJDRUOs9Q6w2zRrxJdV0ZgHpxq5M1Ib6wK/e15sZZxtZ292NQO5xhPMhwvqBoVnuUdjWh5EPKHIZZYAw1MYgqO4tVp35po1IFQicsIoW5Ejt6Ezorz1VYibBpksrjVdihpBGWV+VYKvZD9GovHuhmbmlEoAtS+MHvVUO3dKp/tJlY2yBFYJ70X8sYrq5dsdreMve3UMfMRZflGmA7f4/XHuHk1hirBSXlK/459mYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEKAAAAAAAAALsF9qHnG03z+QZ+7mX24yzmepH07g6qFJk8q+Eng7Mr0pMZZM48caqqARBk6Eq/oaRY3XsOMIKZZ1zdBeH8cgmRXsEfN7cE294wbWokkYabOsTJcywNrC++mFmRKCTa7uqzB/Z1wJsAYX0tB7g8WtEJ8ZpY6YBpSLXk4AgU8DQI"
+        }
+      ]
+    }
+  ],
+  "Accounts getTransactionType should return send type for burn transactions": [
+    {
+      "version": 2,
+      "id": "31423e5e-8850-4680-be64-6eea390bbcb8",
+      "name": "a",
+      "spendingKey": "0ccbf9be81cba7425a0e9349cd28b9dbc8d1dea487386be35a8c9d40e5ff1e9c",
+      "viewKey": "c0fd9ae1f607ad624a73553bad76bea30890de32715a2399658152a8f05f7fdb5ae228be3bd795cb6decd7c819b9f6b91e14bf3266ffed370231811985198808",
+      "incomingViewKey": "74f2f5ad0248d34001f037aa6d14f8b4de789bf9bf84d57f484d64c2741f2a07",
+      "outgoingViewKey": "6b032642e5c8d238f5e1eceaecb96bec7cbbad586f7630360364f5ad0f15aadf",
+      "publicAddress": "5c9cff66366fa27c58e1a1ddf9192b9e85008a4dd997264157c15fd36d80b04a",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:0vlGqIit2syvzRp2Rsoc6ODxXGseXBs6tF4jAFpvMGs="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:NEt3hfwRviJawAJ/+I2girEiFJcrpsHkZs6ZOOsBowM="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156595794,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAjjscpDje1b2hJA9DpLNuwjXoG6ljJQsJ1KVVBc8PgyeBHL2/dpOt9E80ox6plNyNJDsNkDcevJwUGPGuk4BoFPQjEVaiPVWsUwMer1B9iLyV72XE9YC4sy1GtaY6MQfqCprFIBzWD9FCpg+KwLfWt5cuihKL6heuluRAXbdsVwgXkoeEvJPJm6fUuc9pdaBmCbGe7Ww8hqnlfMERql9u07Kjg1SUrPqTXcAwBCNQ7vCqBASDWqavTkV3d9HunbGt9/C+PP94oj+3uuSXU4kS/+JLfGjIDqU4y7zNA0UHS8bdntNgAwN9jg+19jCD0cch7AAweWcukpqXmObZii4hnnNIvRZwDyJUORpFFftKLhCLUX/D+215cvLCw0Z6EZlh4746WLWPST1xHrbVNS7F2fNA9RNlr7w3PY5RPViS5GMUEEamEQICXiUOk1k16zCLVYtZJ7ia6RU9MysEyNpuE2vN0uUL1pIfOR1Q32Rp8h5z+NeBvsaFTmpVFVH+pbnDnqcGY23TKx7rcuHrXMQuqxpiOCImis8PqRBEQKKfyLxuLxXDf67944KGErspMRzNK/hy+i1LC7R/Dc/nZ96rIqDAsb9vESscBlWN0lRs91JTX23JcbnmMklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAww87za5UNOsBHKEHAEQS2l9JVu/C/bkLfroFFFRVbw7DFZgG9ETKZkHkuovFBJFRvqQYDtYBcnhciOnU5AExzCA=="
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALcIgUxG2AMtChfRaHi+8BahKLS2YMv3QE6P8ExX2iTO06VzTkIfK4AzwJruAPYUoe3P24Al9/B+gbggzwrqkn4m0UknghQ/J8s//xUSKaSKI88bXVbvu77BQ2wGvEwlWIJ8CK+ABOdwBnaoe7t/o9qK41nJDgFZY7PuEeNarNnEAnc9GUZ/Cflj+L68ldDawnhzD8w3aEvXo/OIwNmZdDkA+pttzOP+WgIfdiflhWyyHgC0HCU9JEQpDKTwr0GrL5VNYJLprjQt1e/sNceUSJIoFyz6hPI9xRT1D5sTfhVyAe8yVCsBW1Y1WathO/DJIABLEqrliXTVQb/X/4MmP3L5XXfF42br8ZKzBQU5yGByy7XtpU++y51/ajskUg88KNZyEMUnkz5LXNQ/8WF+2n/zg17U+W1GlhFAEr+vroB0C+L/ak0Ezi1OhRYXkXQm+EGiPZqhy1NtjpKpTi9ZfXn9jfeKJKa/TWuZy8b/g3onqyWYU4r2cwzZvRRTEjdNx9QPxWR1UvKY1GM3sZi/mQXTmFYrBMYhQjAO/Z4A3ckpXvmjsoNCtmdSUCgj1WxIxC8qKcAjtofhgNKQ4uF1lwuLTwzX2JesGKbKDjNtvXL/A83+qVFM/2Tbyy3rg4yYwXx/3L6IZGylU5beDguZdkwIbm+O5CvU7KlCe6FMdUa6GxCPKxrfOFWX+24xL5kV2d2Txt7jw5EB5WXc1GNkZULUdovxNaR9fjGJG5PbX67qZBXhEmlArRCJrp3GvmCV0i4DZh/G65z7ks/QpFFDeh/Oicmgx8gCQrOp89rauClmMscq9FNUshR8p6BJb8WYTUcWudRZUtUmCTykza33N62z1VAIKQevEBfQmEWjSLplnA3DirXIbgcVO1M9nU3sAYmXLTy2kfKzcxgLgcHVQmZlWXpvJQbMyuD9aTIBv/3SEHAOHYDAfAMNyF4LePYpzYNJYiyAGWrz2dntV6xoGJ+EvYmpc2PbuXJz/ZjZvonxY4aHd+RkrnoUAik3ZlyZBV8Ff022AsEpmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAALE9A+JrXkEebiuIywTcX6kEmVq3aZQRcP7mimF7IbAfpOFVDCxSq30ydj3CtvVBH0CTN67s7C7FwEs6oFz3UgbpmipGJJbDM1FFmGaCWsb8rUO3WGr8tKdp2o5DcoVZgTPhbMzSgn6eLOeaB8WNMNN3Nz93D0XzLgmVydAOm9kC"
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "C3F36A88788D50FBC9619651D691AA363C1B60FD361D1C3D76EE54F15A6571C9",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:w6jH0ESv6lJD7bCdm+htTxPyHLblVsP+dGgWYuDlil4="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:KgmM9aeqIMJ/q6K/sNQiQnfQn3OkGpFcTaxPnEVmNn4="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156597083,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 6,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA8DEjVDzKBvCf4P9URopAN+IA5cF+je0vhfJLneqkndqYLH15mu4iMe5rrXE6XAvK+kGDpE8VqNFWHsxfq6v+RN1iCrRknSqdu+vgsq+JlDWydTnrNZKOoen7wLEIuE1K+M2xzENeoXpz7KUZQSMVLWH7OF9Iwgo1X/eYyasTxVcZjFW8wHMkSQ2Gp80adywi2BpKSp5EBdenZoqTdkGsc+CCG6H6DILDNHq/LODnK36uOiB7HzT4YnIV42J4tc2E3nEUfaoDbpIedPoFE6FN8Xs0dS+LRMfnuzt/lT7GangDwHGKHkIYaqBzlhwFjCUzezrEbQ/Mb9+iWsBDk+LoiSVnfxGbqa6qphw4RJUge1qFV/oNdZOwE4Xfx0LoUN9m4TcRrye4RPHfOo3Kiz/JoQSHXwZCSn3PMTwZH1juhDOQ42lW4uJs4HRxuwX1v34fBeuBQKuaqdYihLnN+pM0TnlHV7w+83aiA89p9V49EU3YZvwnyeUUulv8hov58r3ZOIBSNGYBnfbpXOsndmEqVoTQfW8q+LqT7eu26XU0f5pSXDfDXICN+Js9q0OfQCC3ykNIaLGxVjEU+glik/S+2tsFA0kxJ4P2joqyFnbDLsifzK2lprOZrklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwebTYn7yqJ+9X36jz3APWrZ390s7uAE+3csVIsf4GB5kOTq94Lddjp5+ETdcCppoYb6DsTsr7jzNCuLTDdK2xBg=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALcIgUxG2AMtChfRaHi+8BahKLS2YMv3QE6P8ExX2iTO06VzTkIfK4AzwJruAPYUoe3P24Al9/B+gbggzwrqkn4m0UknghQ/J8s//xUSKaSKI88bXVbvu77BQ2wGvEwlWIJ8CK+ABOdwBnaoe7t/o9qK41nJDgFZY7PuEeNarNnEAnc9GUZ/Cflj+L68ldDawnhzD8w3aEvXo/OIwNmZdDkA+pttzOP+WgIfdiflhWyyHgC0HCU9JEQpDKTwr0GrL5VNYJLprjQt1e/sNceUSJIoFyz6hPI9xRT1D5sTfhVyAe8yVCsBW1Y1WathO/DJIABLEqrliXTVQb/X/4MmP3L5XXfF42br8ZKzBQU5yGByy7XtpU++y51/ajskUg88KNZyEMUnkz5LXNQ/8WF+2n/zg17U+W1GlhFAEr+vroB0C+L/ak0Ezi1OhRYXkXQm+EGiPZqhy1NtjpKpTi9ZfXn9jfeKJKa/TWuZy8b/g3onqyWYU4r2cwzZvRRTEjdNx9QPxWR1UvKY1GM3sZi/mQXTmFYrBMYhQjAO/Z4A3ckpXvmjsoNCtmdSUCgj1WxIxC8qKcAjtofhgNKQ4uF1lwuLTwzX2JesGKbKDjNtvXL/A83+qVFM/2Tbyy3rg4yYwXx/3L6IZGylU5beDguZdkwIbm+O5CvU7KlCe6FMdUa6GxCPKxrfOFWX+24xL5kV2d2Txt7jw5EB5WXc1GNkZULUdovxNaR9fjGJG5PbX67qZBXhEmlArRCJrp3GvmCV0i4DZh/G65z7ks/QpFFDeh/Oicmgx8gCQrOp89rauClmMscq9FNUshR8p6BJb8WYTUcWudRZUtUmCTykza33N62z1VAIKQevEBfQmEWjSLplnA3DirXIbgcVO1M9nU3sAYmXLTy2kfKzcxgLgcHVQmZlWXpvJQbMyuD9aTIBv/3SEHAOHYDAfAMNyF4LePYpzYNJYiyAGWrz2dntV6xoGJ+EvYmpc2PbuXJz/ZjZvonxY4aHd+RkrnoUAik3ZlyZBV8Ff022AsEpmYWtlYXNzZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG1ldGFkYXRhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAALE9A+JrXkEebiuIywTcX6kEmVq3aZQRcP7mimF7IbAfpOFVDCxSq30ydj3CtvVBH0CTN67s7C7FwEs6oFz3UgbpmipGJJbDM1FFmGaCWsb8rUO3WGr8tKdp2o5DcoVZgTPhbMzSgn6eLOeaB8WNMNN3Nz93D0XzLgmVydAOm9kC"
+        }
+      ]
+    },
+    {
+      "type": "Buffer",
+      "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAD65CmtPAlHzh6zV7na4kkMm//8gTuLoKVWSzIOCBJWur7N8/DXpfAoeRTSTrNw/thbSB0ekT56RWQNfXFj7fuEnvTMQXsk+c/29IXqOtrlmZ+aspC0l0VTmv673DA739TiS7aPaKin0nzlJAP8oA/33rW20k/0s7qTnrB69xfssCRFQFOgDWYDoWm+cSVYH8h4dYDCsrr34NH8sohoEtJV4Q1vtvTW41nKHpiNSgw6iY4fiGPgqxdSLgmcbXwt9336bXjc6gn+N3BF98BugTL+Dk+Wh5L7/4DRWojw2GxKEf/YLwwNrhRWa9B6NxMcx/XrjVOcc+CieG82k4JheL8sOox9BEr+pSQ+2wnZvobU8T8hy25VbD/nRoFmLg5YpeBgAAADWh1tGjYxrUdA1536+pCbdPmAuL33Nkj8OiHqOXDPEbT9vM2U0krFeHEspURr+fBr9uhsf++X4HjEHej+/izine78u5OT3p0N+eOu+13zXhg1V6WOyrAW+ZCrwuLYYMBInZ1ZnR0+kTlD0jFAhkizhnCfheRyTaeWObR0HOjtJ53L+s6cUNgEK9j6rb+zSgIYBtuiqNMwkZ3Ec6VJ1XMaoD8r71Msx2VR6NsdrziQrlwPfOvgKZmFk9eDrg+wsoAgOwb3+OEOGfoaf51OmciPLnd6bM1WgzVdhcBlHCrUAtLNh5hbyHVLScPgCwszV186XwgoYPzmTlCudFccYMIUnI5dGzhwSQ6gdlhxD1ly66vlpCjELdSztaN6s7QYcy2Uey06sHuVjgfIg83c5eXOTZJC7S8hnJaUWEP2QpwV3feDkxdLCHc1qs/JZwcWC7LJyMKDCLyEtqiO9HG6Bl2Wp/yzpziQ7D6UVzrY+VqND25JjL9V89Aih8fd6xW1BNMIOmITnTRwQ16TwyJWdQPb/opURGjYOCRCjAH1lxU3FQc9I4EWLn3sI+6ooeTVgkFovGAWj7lipgnytWTxQLzUGK6LzRAbjm8T5O8S2tjgU+oarHEyE0Invq/JUl3JuJAk0Wz/OlL5D4ysV0JwOd/o05HPhaZmeSokUuNt/HU3KlcNjgl8ODtEtzJd1c8fX14/kGXhFJnWEQObz0obrIOdA0S0gGlCXH/S2cQH7sVLNAqlU/jMBLO1XY4+DOuk0Z/vFN0W15dIFrXmOwJzSbBB3zUmpeSUZtEEYP+SJbLLwAz9+ttMMcYgDMJvG2eEr7JGah9lCK1Ju9IDCNzmNciPjVOVUvoo7jywIAAAAAAAAAbEAgzp9qiEtoqFXRbRFg0MJktbJFc/P0VHde8oA58sVgzePHpS0SpvTJc7ajq9QjJdpS6oU8CGxSQ1Qfo6p9BQ=="
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "E1E27C316C24C4C6FAF1A3C197C3CD0A28E961C45A51A27AA65279E05C4ABDE4",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:vhjy+r8TWK4HMTd36Md39adOSl1Db9qtsUQxFCzfGUU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:xH3tjkOa4X+ar1M+4/NtU6QLoGbz9FQ36rVH0WGrxOM="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156599087,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAGnZdt9/bBh0CVEWE4y4YN3Utr43QOU7M50in6ESY8MSMWU0LHfEKldN9NKNFq4PCVLqEeSr6D20sPP3nYxkoGksI5VF5TTJYpNOUZ35yuFmSzV5vmYOJiQyNEXFZqNOmIOIdkHtRn73ObusWwjvRupsdFIxj8Emqx6gObSsefFwFndy6mKQDi58VH/RVRJqSpPZWO+/cHoEZ/96hqTPXlWRScAJI0AhFBw5inv1znpShkuv9qQRlWsxZHiAejWJ1Hx7nwh88k+4wb8tW1YnuXRQGxJcpsEszAnDstOnL+rPXJo5RpPwdgPb0JVScAFCiu86QU9kU7VzXBBdxcvdtFm2m4RCwEksdGg+VKhahX3TGsYuASVzD661yYZN0v8lu3YaEKDF054CN3oTl8NsLl+LAH1f6tjhJTjm9PvqgsDKaaF/Q2tlvn6C4tcC664sFULrfCBhNxXl3bbIwr4RqUns1Y1JYEkOI4BCG8Np9AmQRf9PUnnDx6kaUp44gAW2awO9R3Wo3z5noej9LGJXdjeuhQSTlg/WoY+fkuQH0Xk0jNT993MAq1Paj+0Gqpted6quqb5dhCTQhHnibxMRDcczOZDN+rXlSP9P/mdEWS/Gp+Im+ag+bzklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwQRwLw4/ccNZylb+f/pGOpIiE5H11lThN3AjxJLsk7cpGul3GJcJKJ2DS+dA8hluFQd42WW751fZk82waUH/DAQ=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAD65CmtPAlHzh6zV7na4kkMm//8gTuLoKVWSzIOCBJWur7N8/DXpfAoeRTSTrNw/thbSB0ekT56RWQNfXFj7fuEnvTMQXsk+c/29IXqOtrlmZ+aspC0l0VTmv673DA739TiS7aPaKin0nzlJAP8oA/33rW20k/0s7qTnrB69xfssCRFQFOgDWYDoWm+cSVYH8h4dYDCsrr34NH8sohoEtJV4Q1vtvTW41nKHpiNSgw6iY4fiGPgqxdSLgmcbXwt9336bXjc6gn+N3BF98BugTL+Dk+Wh5L7/4DRWojw2GxKEf/YLwwNrhRWa9B6NxMcx/XrjVOcc+CieG82k4JheL8sOox9BEr+pSQ+2wnZvobU8T8hy25VbD/nRoFmLg5YpeBgAAADWh1tGjYxrUdA1536+pCbdPmAuL33Nkj8OiHqOXDPEbT9vM2U0krFeHEspURr+fBr9uhsf++X4HjEHej+/izine78u5OT3p0N+eOu+13zXhg1V6WOyrAW+ZCrwuLYYMBInZ1ZnR0+kTlD0jFAhkizhnCfheRyTaeWObR0HOjtJ53L+s6cUNgEK9j6rb+zSgIYBtuiqNMwkZ3Ec6VJ1XMaoD8r71Msx2VR6NsdrziQrlwPfOvgKZmFk9eDrg+wsoAgOwb3+OEOGfoaf51OmciPLnd6bM1WgzVdhcBlHCrUAtLNh5hbyHVLScPgCwszV186XwgoYPzmTlCudFccYMIUnI5dGzhwSQ6gdlhxD1ly66vlpCjELdSztaN6s7QYcy2Uey06sHuVjgfIg83c5eXOTZJC7S8hnJaUWEP2QpwV3feDkxdLCHc1qs/JZwcWC7LJyMKDCLyEtqiO9HG6Bl2Wp/yzpziQ7D6UVzrY+VqND25JjL9V89Aih8fd6xW1BNMIOmITnTRwQ16TwyJWdQPb/opURGjYOCRCjAH1lxU3FQc9I4EWLn3sI+6ooeTVgkFovGAWj7lipgnytWTxQLzUGK6LzRAbjm8T5O8S2tjgU+oarHEyE0Invq/JUl3JuJAk0Wz/OlL5D4ysV0JwOd/o05HPhaZmeSokUuNt/HU3KlcNjgl8ODtEtzJd1c8fX14/kGXhFJnWEQObz0obrIOdA0S0gGlCXH/S2cQH7sVLNAqlU/jMBLO1XY4+DOuk0Z/vFN0W15dIFrXmOwJzSbBB3zUmpeSUZtEEYP+SJbLLwAz9+ttMMcYgDMJvG2eEr7JGah9lCK1Ju9IDCNzmNciPjVOVUvoo7jywIAAAAAAAAAbEAgzp9qiEtoqFXRbRFg0MJktbJFc/P0VHde8oA58sVgzePHpS0SpvTJc7ajq9QjJdpS6oU8CGxSQ1Qfo6p9BQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts getTransactionType should return receive type for incoming transactions": [
+    {
+      "version": 2,
+      "id": "fd46c935-9a09-4d61-adf3-b1516655248c",
+      "name": "a",
+      "spendingKey": "666f2b65c998c8e249a91871ff5907d6b3991e748e8335789c93e2dcb657db8e",
+      "viewKey": "725faa6ddacf3d074e369989e10be36742d38ddcadf1e0164cefd35b2256cf3ef2cf03d2a29073900a54365b4f4868cc8076773a8873ca1b7d87b132314e2fbc",
+      "incomingViewKey": "3d5014d987a55401a80a897a81392905c24d21beb8feabf38d5425b15dcf5501",
+      "outgoingViewKey": "d06439748b73a03fedca5334daa257c992bfc9e72c1546728cb744f3fa36c86b",
+      "publicAddress": "1a7cb8d313f0a39e0e33ca750ede89db4f05185110a8ed9890897ed11c34c1e0",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "version": 2,
+      "id": "3922b1b2-2f07-42e8-a878-52d41e040c7c",
+      "name": "b",
+      "spendingKey": "adf1d393624cd9c046e5e05cc9a357a50450ec0235769187a921e5dc7b07038c",
+      "viewKey": "a562536ac0f9fc7c4229692b96e69497624288d5e48103fa55037e9cbb4694f09af3fb564678e8818a0066e3d60982e073a1117e2d0f502026199f6527f1005f",
+      "incomingViewKey": "1034771a8a4448c50ba36eeaeb96a7d3a152cd2b26d6af44810af6a76399e606",
+      "outgoingViewKey": "37c0e880959ea2b023ff8e81f09d0b1cf3b0b1bd54f8be4ddb216b2c6ff8c652",
+      "publicAddress": "b0d5a587a8c2341e46834d588ebadf2abfb53f81011f4700173a959a4fd4ee5c",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:XwSRVpN6DoMsK2hiLlNxkVEuQHSLz53LN2aME86F9iA="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:296qkyb47DSz+QHngzrU/AoJ4jKBPmMHAhxjA4idHfQ="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156599935,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAF5THtvhuYB1pl28dZNLpzV2zl9Vnjr+dhtMGWz0mrWO5Ywj3yqDEJBPsTj1XFmVUuL2B9F8/rbRlbkyijK6IbeLPys/PH9wE+xzH+WWOMCeX7NTfJqQ9K8ICD9eSL+KIg/+2gKCDFPPVh7nbZ89Z3bz39l9dssMCIOnFot9md+8DdPf8GNfIFJ3J7vkH16wwY2DbfSXapzTeXAgSoImdKJcqQK4xfAfjNv/EimRw37i4K3ZOfGFSVZYEWfzXv+bJVzF736Y+ipA/bGnbCNUWQ8hz+9zf3UjpZLsCC44TpvCK1MJbdzzk1LnNSYAGL5rBQg6HXl3hX57h3eY2/U744J+1ZUA9Q6n9wZ6zvPN+lof6Sg0TqB2X4P0mZ993grE4yTFwFIK3AxlXVIxKYdZryayhJ12FSmQ4Y9tz5GL+6FmO8bK9emNRDl/pPG8n+tfUIOEhfXxOUdOz0N+gzeSnw93WMNn1a3gn+B1nUWCNzUFohc57EJq0ns8o02nXRwrQPK3KMeUKU8Rug8dnjZFsZ7/rDkADm7DSnu81AYAuz/LZKkzjwM8hQ+e9C/FWXp9LU5UFLVM0luYYuotFajY8VJDPtOIUAguZPk8euNYoBZUr3/zYlIgR6Elyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwrIJo19kVaL/B5m9ZDzBLt668003hn6PsGWPSiKgYn6wcyzX9OVtj3YyCoZVmxcHhskzjsXKEdl9mQ69PA+lkAw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "BCB3B0BFE307DFA1DC3A9F2AD3BB81513071DA1C6719A954C54BC5F836407A8A",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:cyFPr8H/o7zjEcRJN99aDHhbkyuYifl9GDu3/cRglTk="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:wM4Hn9xB91mQZGUuRy0qOKHalFgvyIB1Sa1xYNe0t/o="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1692156600453,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAArNqmUuBug5+ODpv58dbybRUxr1e/c44NfC0oVc+BpdanS0obwxMrg4MvM2+qMhtwxMC/PRlj9p4XVGnm7VW9KNf43I/topfW5r8Dpp1J7JC2lEEsEhCqEL0m59OsANDIVHSTSbkwOvY5LkWvceN4NfCCOKiTcXLwR9Hwo3Ajo7YXYJn6P+hevRsZGJDl0PeNwjg0O8S9QoLePA61yom1OWKXZmLELFyytFqhPKihHg2wLycMvT7KW/r6hs2OaDD3w2QDHDLDvVmrrsi+q05mO0pWy/wvwUqVFMHMgRKhFNSP9X7FOFz+sX7w/M+MUHCog7iJO5zBJhkkCdDN4lKZYjuyUce1/9jSToY//2N1HQcGN5KLfFlJS4AQbPWWIFgU+gw6IO5Fy40RsqQDcJBP43AHxMm3a29cnp2xzYJOQKWliMGOrxkPI+Dx19YxmLx5uhk4xBKWMnid045iC2OfHlKjs8Mz9w5ikyUWl0RXsgrc331ubQAwP0dwCOmshPQ7vwx8UN+jHVjb10+3CL6ZtbbUHkAniUAblyXfDDJCwo8Zd6nxUI8jwBS0B1sLzQoA5fsOHzNGJ7y2qWXChGLIH6PpOF72MSxQNRGznoBzEsjF5naUxIqbA0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwWY3nuniwUdc7c/EtiO6JdIyEEPZw7bub01pr+hT+OMfCRrxHqVRTVE48MizAWwsU0P+HuK1ZLDOYQruOaPozCw=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 4,
+        "previousBlockHash": "378D69EC327D7462BF933828020F61F177DBB25F96C7BE3CD65DCAE7AAE6D618",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:xDQcTXJZdES/XM+HSJzhTFTjoEV0Tapd06e9xsholU0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:3qoyeOMB8NlJmTwsm9+atJtTU5tm+luWKYEdbzrrOBM="
+        },
+        "target": "878277375889837647326843029495509009809390053592540685978895509768758568",
+        "randomness": "0",
+        "timestamp": 1692156602919,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 8,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2vKiP////8AAAAATXiw+nYf6xRUYQiNzdDQzWHmStGm0v464rR/B/uAt+axDW7ynjULam8ApW3lSEQTT1xrjUF77WNBLHeBePnt0y68+DMcACa4ZcL+MESnt4uu+Lg2omiqdcRA/bK+XQEbbrQt2Tv4//qIRVYIa/xvbC2hzWnhnHAFhc2DsVB9sbYBbqjH3+tgEH0eggWsH30E4BDDNZmVK1movP/CLglJ+8bRXBxSyxbRJyTfigX4yPGr1hmFZBaCKTGNQiPXQl1uwARPPTw074za1nqprjVdQWPxjML5y3SG4yXJbhPAfwKoJqFxna54+djQGydSf7IS4h0tqHKUcFRpsjdlz31o5UvIUA/Qn9dLkMrkT1xju9/VcYzK1TDaHl9kLhxWS3k5TiUXm5P/ka6V58fwDZxSWaUrw7OrxgOptrEuur7PQDsckCL7BpUGpi2131C4HY76QfYXsKdD9AVFgiUeYFCwGIlRLtiuuRdx0j650nd5q6jF0KVdWcOoc4cq42/RDV0+6KiP4+PzhcEQxL53eVdEibNUkq57UWvJfbwycJe7ma7UT6ZHUOiSyhE0zLuRwl7cndvoBLrI9Le8i4GZG/AhJnYaZBjsKEo74rJwPMdca9+GIKZusqdNlElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCGDnSz01jYFsJD7RYBzaAnrmZlNMwCx5WEhjrY9JlVcABPKnDIANPtCtwXWmGblmBfobigu9LvjIJqihyo1KBw=="
+        },
+        {
+          "type": "Buffer",
+          "data": "base64:AQEAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAvMLIQmY2vh52dVPBxqsOvHsOXkyIpqCdWGMW3mLq/tiVjUbhywkaj+CKnqcilP7R0TgONmq6lnHWQAjFzJ1LLI4fGkZypNFUn7hmEObweRKMXWywQ+ucxTBNsKwbDoQwURGIBzCAO58F4NMsB+Ac7pFx1IwR184upiIzsTtBiwcBV0GoHBBEQKN3qzBEyOYIp/8TGSrDN6ncCjCHIJuRM4nwIy3tAYyhXkkXZolMdiGwuO+QNfHwqhB6kWDiMb/RRWbplB+IsyOjJukp+zhMNRLaZLBq6aU1ljikRzDYzLXiDao82wlmcyFk+0dZuKwfwi020lkL5aH7J8B5QEUhF3MhT6/B/6O84xHESTffWgx4W5MrmIn5fRg7t/3EYJU5BQAAAEV18xdvRPIFA8qYooXN3jYIL7p/S1MiLHqjuyEsByfPeYGN/5rUFUJ1oB5Z1BFj5F6yZ1AXevMAcjgHU9+BugkEK6JSxRzn4dsh81rWhIiAjIbNJk9F93Jwru9qabmKAIYBsw7Y4kmlwbg6lOHDNzjvcJ+jFEeQFnB1bfc8m02kSrdhbIF1DKMCWg4mWb2Od6lHhti5S1ofv5igsxNBCn5LqW/S8aCdhZ2HwkATp0CZ3VYKCw+gtsJLVknu3bZg/QZt9PjUUttV0WNtofb4ILLdz8lSSDdfASu8nwraid/XEQDmO9e5gJ6eD4v4Voq/m7kXyjRzA+odIPKwS8v8v80IV9n5lGVbpRIvoDsa+eP6LO7A7Mzhdqv2Iv2uHBS17NYrlUpzXXggH1JIhKOFKzzh7IVHVnzIEDB3veDT2Xya9hxOui3KSvXQnvI2bWzTmd7JqCTKHyIjxq9mDQIpQxZ/ZD3egoPTmJUpnsWVUSEfuLBgfkOwXGJc0cRGlTM+saYDSoUxbtRyh5QJH1jXmYzzEp70sJqO2cGsuconiHEolr6epSRU8cqwBGBuPTnql8efzVJtq/URvkVLkh1PAl2xe6KUS+qiSwTtFwi1yDauAMEiBPaPZDNNvFDbAnF79uMbRNDhaMrdYE1ET6WdXN+FFARmIQTSXcxJx6y3+U9SJ8HrmQBDW5t/tHIWAB0rIX9x11at+dfRc3m9VkuwGYCSlX+x0IDNVZg88+YknKXn2p3vCn9DSVKJPJvmSZvO8h9RiSDZw02DmWJ62GjSVaFEblgo2ZQtzzcuF3ZYi2lFeYc3FZhhkD2rZHLI4IKJ1v9J6ZYfpm1Rq6U701UZkmF0icGgcifWbXMo2DG7FM2qBhhrJjt1nQWJ9TqreCFjCm+k0R2gndMHNdiWJSZu44qeSivCat1cBVwBHBe+zYxKvHYQUVs5p7YDf02kbaFQtbSP+GLUSI/OPatjt3rpvJFz+/6AuihR4MAFwVh689qQjxVC3R4ISLmvACvkS5TyxelLhfHiGnAQ5IrElE6y1OkCE9zJKY2o47BQ5yHLapIdHkw5N9cDClX0rSvuYyNz4p3EgL2ZiuU85T/1Hwiar+NPWzufDk8eh2WCSieC82XgZPjDJdLT3D8uL/haAiF0s0Wm8SH2Snslxn4OTZ/wai4U90dsj+ihlTGdzgowehna2/q2JRki/LpIKrHX687XM3FKTlVH4uAWT0ofDDu/YMSfczc4lHX6U7Haxe5NKp4EvRkj8DPNJJp0pFZPtqnF/hgyhnF9QH2nsuZg4qbCvcoel8uF2+0GfBKaVuon6MbrlCucDY9FB7NCjycQGl8ehfUaGkrCCrf892oEIqR+WecC25p1LzxDIyuebD8X11QifRb7cTnQm7jkTYIqyfKnhsQRmmEHDD07pRUxDSQzIrZRb9qLDHsWF/oms+HsXHnVgpNWh7cYR21bdhFR/DLrV2TiIShXRsP77JiX7iNdsWS4dLRiBf9+HZjH/kt1uvoFeAjYiYhtd7BKIY3GRZN5QBrUCvVkHHejgEeU/7crIK+QUnw5ZuPN2w85AORhUQc+1vW+QuKQRU2qvVBS3qnqBQ=="
+        }
+      ]
+    }
+  ],
+  "Accounts shouldDecryptForAccount should return true for an account with null createdAt": [
+    {
+      "version": 2,
+      "id": "139ee0c7-cb52-4984-8eb2-ab9d4de59ed0",
+      "name": "test",
+      "spendingKey": "05fa7ce037819aed412e39ab41179ad87681c44e31952228ef870432452f8f08",
+      "viewKey": "069cb77b509e7c22f6748f5c2654108c9fae74aa9394178e2e3ceefad4cdfc158e69db48afdf9746c8516709a180705a96c0bc341c7eae89683ce120fecd9448",
+      "incomingViewKey": "049770bfeda2544040b6b846a3df1c36ec6e1a6e067521222f6ef93d8a0a7b02",
+      "outgoingViewKey": "00757c128c41ab426145a5ad01980260819397b7b67bd32a27456543058c8665",
+      "publicAddress": "fdbba628812d87948c15781a59e1eb59acc9a8a2e15b5c4e35b5b59eddca6abe",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:fLd8hmbDX/Zs8bx5uydlXTbGkBuaDbS37ddSYDaeoAU="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:AHfC9E5GMY3nMfh92A4jBFd4uEka1N0mQuiEVD/EJ3s="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156603608,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA93Us3P4FpXxGFKqIl89NBuow3Lk5quvgweNC/HTrt8OsnHQxHuV5ViskSH54ULjhCPdPnHFmWXa+a8qwyCB/uvFLuMqgMoKueMl97hdu6MSGeGQgdafDCV15KfqRNskw7KcOV6rF9wbMIgqAcar4gybk2Odu3zPn3Y1DNeI3hCsGZE65XSGL9wosw8ebFXdxN+sh0BXge01K8qQJaaSI+PzxNV/hRNTdMUyTarZPJu+2+tjXMRwMY0vQodOOiGZcP4p8KglTFjLn7YDE6wfopfU09KvsOIgBXNGJ9WbJ6tJpEoevzv7FjOgsJbbZSDwjZOQ8HY0yezye+LtsYU56KrBDj15u9+uDCjzLuvcGdrndN9riI2iZyKEbVvuMcONh+0+ftJ8Bq3CmYItyyauuShmc6m3kxvQKGtiZWqXunJihVFwlJCERn2LuWgD5V3wp4dAHNER5z7sOVIcSTveFTv0iESnFM5QNkwTv1LJEOnWFRCoD6sJKjKdMdCcVnLqzU5kyRicKtmOQ1AXlBluGISJeMXDaspfF73OnjneM4VxmlO92qyF+j+v6f+xV3q5J6NrPJVXuon6phTtODCS4+N/h9sgjbUx1QgQd7saVplUKXGWQBrDXLklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwwTVj92UBG0KQ+qWwA2hALeE++HBbtXpjD0PXpsNG3icgaWhAo2e9BO7noioY+vTkpZekcccQ9EMR8UWP2eTGCg=="
+        }
+      ]
+    }
+  ],
+  "Accounts shouldDecryptForAccount should return true for an account with createdAt earlier than the header": [
+    {
+      "version": 2,
+      "id": "56102a44-fecd-4fce-904f-2ad139db4342",
+      "name": "test",
+      "spendingKey": "03f4ed9b5af9a7319f5331f1ae3d1cf08c93e0d5c6a54d8ad648a374cc8a4d5b",
+      "viewKey": "9360464e798060e6ad1bd0db8b3ba95692214484aefa46dc94d5a59801e706afba54ea3f1c546d4b40a78f56f3e71371727e8d02e3677716575db9681bad2781",
+      "incomingViewKey": "1447e37b259fb60aca02d27734e2ebc065f3dfb825eb32061efe14839cef1907",
+      "outgoingViewKey": "c1ea222c3d4c275881b6edcac7b2d3c46fabae4682b8da8be2943132021cdb9b",
+      "publicAddress": "6466bac5850981436e4654e7b3eadd893d53a2a1b9f4ab8c53f2bb82c9cb5866",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:k0qwKpgMspB0YD0NEOQAFnCBxy8XNagTy9d54NKvRhM="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:1qKBplI8Dg64OiPMNPYEdjg3B4MVehqqT/fUcXZ+i3Y="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156604281,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAABUsK3BvKCGQHlmpg/1sJ2BywaG65WlyhyvVRMFbRCgCp6RUazoaLHSNm7XC+C/HeDfc2PSB3ED1OZ2RRpmfh6B0e3eJihIFMA+trwbBio8SnDa/RouwyfzPcVlQZ7ifFc4yxXP5INgNX9gzXdL2/Dd7dHdRlCWAg6tGRBUVk6rwXYkbIfxRvVA+zy3+FA8bZf6qNaxktythFzRcp74mlE6kBUonQ18mucckD9O7apnSGfwRHJUx8jR4I5hR1sYZiNpZlyaqFpWVjlGBcubKeA2qGqJS63fPXhGwThVutmtk1HwCJ5q5LgZ307k7sIW1871Vsprzyq5eJeqRFzReWXKmvNK/HPztA97Fsv1jB0KACTXJYfHjuoTIPg1GMfhA9A5mSzY2NsMdGswuH0eyoJdcvKdrUSvVUzC2dA40kNRcTJhtUSWSzIe+FtR9bT7bOek8DJ54FFIgOaACQwP7ONCxYuGBEVShfe3zn5AfZeGtJ2BD5lc9NEjFxUb6kaDNF6QmGOfcMTEnImjmAr+9DaXiFiDX7SW+9BHYv6VmpL5DpiESRjbA164wHqrbExL2Q4iMW50/V7pH6I7ZZ3pCSo/12PidCaNKgVrD4BzHj5yFJILTL5DIcMklyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwhpwESgl4sfPczZn24Z+oDdsit/bYvDH8i+ZpM8MbwmLIm5lzn5DIhccz6+omOeLpqA6ItERD62C99l9dGdAVCg=="
+        }
+      ]
+    }
+  ],
+  "Accounts shouldDecryptForAccount should return false for an account created after the header": [
+    {
+      "version": 2,
+      "id": "58cd67d7-a7ca-4684-852c-d7e3ddc418f1",
+      "name": "test",
+      "spendingKey": "270e245fde315d9a0e6c3a797980a4b4d4b8296742717fad7a7b83753caca775",
+      "viewKey": "be56d8f8475c9da1daaa151a793621955eab673d467a727e10f1da96b776d86ac8a1e5ac5054e3c1635a0693e22f6bdd1cd1150659621f1c86a6e775618003f2",
+      "incomingViewKey": "093264010d58f8e28447ff46fd24ab6fc1f1e25a1e54cfbb690cdcdaf5470d00",
+      "outgoingViewKey": "d6e6df201d366b801dab14402ee1c901b654e21e99cebd5926e4915873d89628",
+      "publicAddress": "c1aefdfd1867841d29a1c69939738f5f55ed2e8a53d7cca12bf478eb8ef620eb",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:6dRww5ehXExvfckqikppw3uh8Jmwd1xihrDbOsVTaW0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:uipnvjfthlIrV/WO9kXwaGAqVHXd+66bMYwek9YZWjE="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156605084,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAZ8/B2q38Pr0yxs2demOYAdvbi0SQdltnwsckPqC4UaCA6W8MtoUs9j6/GLWmcs6BoCQfeZXxVpP8FvrSc/CmMxK1wiKVSO4WTaUi+chjj9ak0w8n7kRAKGFNOKOnMWcots2ZfeIqBIGa+iFnlJChODtHtHuAQxWE4dD2kmAX+TIDDuXNVPcwGPunh0wiYnXlUVyO2BF7dbOUXSccQdjpnaaZ71AC7/NFNmfhZbTTVRKXRrvp3bF8xggTMlf1us91fhKmH8TUt+bVAnZPJb7YFcoLYq3SCuBLfYrlf/ifQNuG4ZZyqFWD8czBmcbNe16Gtz6/DMVw080JZUYZIB8Z80nr/S1JccqXqrKmOA8CQt3mY0QAaZIiFEvmzysNkMMQwQrOyeWBMsnQNv4K6M6JZVRDfeLG72GBeRwhCgWny+EeCiNZGoj+Qu1BKu0LljoxX5xrF6ppD6NS9Me2Y97drlSKP8s6Buj/mATX3J+vS/u8Yms2j5s1RlPhvgDFFTGZUD/DZRVwGL1G7xIuEr0P5tcfYca1EV7C20RF6kwYYsFXwpN9fsSPe3HwqQ/DqD1N0gKim4rjY8hSj79hE0mCi15yNc+dZ+x2xaIF+gksRYehgPGWwgx0ZUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwAVHUYxoGfi2Df+epGbh7Jhs+0BY/HAaGgkwXdq7jFvOH9k5ZYnyF+mXO/xogo8RQtUE2LIRLSv9uDQ1LQzTyBw=="
+        }
+      ]
+    }
+  ],
+  "Accounts shouldDecryptForAccount should return true for an account created at the header": [
+    {
+      "version": 2,
+      "id": "58a375e3-d2c8-4580-beee-35f4418a9f1d",
+      "name": "test",
+      "spendingKey": "1fa3c3763484fb7f9da4bc18eb9fb45e7f503ed0570772b3e6b9b3726fe226cb",
+      "viewKey": "7c2d62d631349c9b46650c2cc923612029c8db2e898aa899b9a52666950732eafee24ae6ae3ef50c379de1fd3c54140b787740e57896cd714961b030ce5872da",
+      "incomingViewKey": "65d401faa3ffc8fb6e20633791221f3c1a2c23d7273eccef278997f26cd24207",
+      "outgoingViewKey": "3dd437a2c30cc3be04334b11de3df77ca6d88f311552239d404b0d47008d1833",
+      "publicAddress": "ab45b00592a1f323d92f2deb1ae673596f50242e2f1fe2260f9701b225448d9c",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:hWk9xiVexqEkjkJI557Eyk2JylSV1eq2jRGmkFIEa2Y="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:BmsTJV8xKq5CGYd7GXPWn1Jsfc2jSX+cDnNhmcRhMzM="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156605799,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAwkMZdD1+JZCxjq3VnfYCwOTZVD+2vlmvkYA0Tyvbj1eyoGIZUwJlKM8n6pdsd0y/iCHVNrNA2Vct7HmovzfydFzUKm4NVPMOSMKSBGhO0SmFGjUcB1fTKtz5IeZGmjl7UqG/ZJ3okrVStGeoSwjUi9BrhadwfOlyiZ+G4LfpGSgRt1jVyjFlgmZwKOg76X9nXHZbCkCec5a6PchdPSZo2wOw7G2DbllWiIjRu+D3Ga65AppLt5D3zxlKlZvtFS6if1LKuq2E5Rn4FM2+Z9saW9uSEss1zS6i9Ley6daUWKNbqdAqufl8+aCPYwaP4oZ0+guRRuMPZNxw2TSJql97ok5ItO4qfIS/aLnVj34c79zZfm5kXkhY+YUKE4JRQl5abdkJcX8LK9nfJivQHXQMe6tQIOF9uxBcw4U+fSmqYapXdEzZVJCg9+6ur7MwMLq1jLo2gseenc2ycSMNTIC061Gx9u3A6LtHi6ZZDofXA6Zp1wks66xPsAdNaM7ifR9vdft7IVXDM5CzYSkfUt1s0fZrH0Ul3Ak54WX4uiN4x2uFIEHu0rM1ZZdloxB+1vevTxC7ZUd/3/2bDPJ5h5kucldr/5sSoWMtVJgqXSSugyK9gErowAfRIUlyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwZcirY9eNEO1N7yLtSriRRvNnztTh7381XOtQXRAXU+Xj6i6vCgi4XbE1B+CdinxaFhNs6Dv6dWEpQ9cage/oAw=="
+        }
+      ]
+    }
+  ],
+  "Accounts shouldDecryptForAccount should set the account createdAt if the account was created on a different chain": [
+    {
+      "version": 2,
+      "id": "ae753789-aab9-469b-a6a3-c7eac3b1dc49",
+      "name": "test",
+      "spendingKey": "e8e76e90961e0cc07e7f66da1e5d89663714b34b668a9467029f591c156a8d7c",
+      "viewKey": "8d0d744792272f9e99397d9a54920888dfee0b17a9f024841dc0b8649bd27b51ca1a3d0dc9151a77321b44e41ded9cf31d0274b8fc9f8d34acb3dc5564584688",
+      "incomingViewKey": "1120a44fdde22fbdda4a803a6182031731474da69dd74275867d375d5c6ef503",
+      "outgoingViewKey": "c43dae9fb38ea3ab2b2885feb19e80e2a109c45e98a21c1293396c5d5782089a",
+      "publicAddress": "7e3f2457529b2c932cf4d8e4b1203c59493bc0dae3efe9316762d0d9fc311508",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:/pl5OdO0UfANuQ/Fj7rUlYAYFUUiF0WwTW3F6Kk1RRc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:uyRP3BWTOe/IRw9AyFkynpMQM4RAqHNCuiRmCyBu0ZI="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1692156606478,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAWM5g2IwScQyzNYm9hU4mFSMdumEyTkLvnYLgIFTqQA2zMkKASvFvRC3fAnyHfbg9WpEhbhXFa3Ph7OEQsoMXxKjqGBjbHznu+ys8Pg9Qt46uV/tZPQPP7AGIdJL8YK3PWmB5fu/4q+bgh1wSOcjXUzubEa+LsQ8JyHRlquYi+2ICV+qI2Icht937KuY4hX2LSEXrM/VmX2NvburCo6wsbni0KkmPG7RIRXIL2Wn2yMeoNSlYNDdcNrYhpEQ0oaLJPQaASQqfK5gzoS0tjkEEY3HvU+sm+OnYjTCNaDmr90A/cVnLNiYIsc4xFnD1kyRWrgI2I47b8vYrTf+JfFsepk7dXXVrwB7NIbUyxuuepLenxPbiuljDR1YNGIADgKtJ0gZu92uZ/PImhnJbdBDdl4PW66Qx1o10t+oKbl+l7y8tAUVs/iz7J/IH69L0pLh/RycMJ0+Y2UsElFVxKzufliaxyDN9kiEVPVHI4CsHr9a+A7OdEnp+O+r4WvXQg5+oo0LtAM1kgx6brJOau06vcTcJ8Fm0RNLNDDhacBasnhWDBLHUr0Hjr3HVIFzixMWqUqOqvPtyiVrf4LKQzmDAw+yQ8ON5QlwgsyAQrrV+vXLj5YVEgNo5sElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwY1nNswb58oZoMmlwQpcqRZnrxpEDBeyAKnV0JnqnMq7U5YCRHFb96q+Ufqx7tkzktyahvkBNkCb/OiV1ZzRbCw=="
         }
       ]
     }

--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -643,7 +643,9 @@ describe('Accounts', () => {
       const { node: nodeA } = await nodeTest.createSetup()
       const { node: nodeB } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(nodeA.wallet, 'accountA')
+      const accountA = await useAccountFixture(nodeA.wallet, 'accountA', {
+        setCreatedAt: false,
+      })
       expect(accountA.createdAt).toBe(null)
 
       // create blocks and add them to both chains
@@ -672,7 +674,9 @@ describe('Accounts', () => {
       const { node: nodeA } = await nodeTest.createSetup()
       const { node: nodeB } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(nodeA.wallet, 'accountA')
+      const accountA = await useAccountFixture(nodeA.wallet, 'accountA', {
+        setCreatedAt: false,
+      })
       expect(accountA.createdAt).toBe(null)
 
       // create blocks but only add them to one chain
@@ -1946,7 +1950,7 @@ describe('Accounts', () => {
     it('should set null account.createdAt for the first on-chain transaction of an account', async () => {
       const { node } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(node.wallet, 'accountA')
+      const accountA = await useAccountFixture(node.wallet, 'accountA', { setCreatedAt: false })
 
       expect(accountA.createdAt).toBeNull()
 
@@ -1961,8 +1965,8 @@ describe('Accounts', () => {
     it('should not set account.createdAt if the account has no transaction on the block', async () => {
       const { node } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(node.wallet, 'accountA')
-      const accountB = await useAccountFixture(node.wallet, 'accountB')
+      const accountA = await useAccountFixture(node.wallet, 'accountA', { setCreatedAt: false })
+      const accountB = await useAccountFixture(node.wallet, 'accountB', { setCreatedAt: false })
 
       expect(accountA.createdAt).toBeNull()
       expect(accountB.createdAt).toBeNull()
@@ -1977,7 +1981,7 @@ describe('Accounts', () => {
     it('should not set account.createdAt if it is not null', async () => {
       const { node } = await nodeTest.createSetup()
 
-      const accountA = await useAccountFixture(node.wallet, 'accountA')
+      const accountA = await useAccountFixture(node.wallet, 'accountA', { setCreatedAt: false })
 
       expect(accountA.createdAt).toBeNull()
 


### PR DESCRIPTION
## Summary

The fixture regeneration is failing on the wallet because of birthdays in account creation. The birthday is set to the node client's head (if defined), which is the local memory client in the test suite. Therefore, it'll always be the genesis block when we expect it to be null in some cases. 

We could update some of the tests to use the genesis, but that behavior is already covered. It's useful to still test null `createdAt` values since offline account creation should be supported with a standalone wallet that is not connected to a remote node.

This code change updates the wallet method to take an option for whether or not to set the birthday.

## Testing Plan

Updated unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
