### PR TITLE
Add a consensus parameter for asset ownership

### DIFF
--- a/ironfish/src/consensus/consensus.test.ts
+++ b/ironfish/src/consensus/consensus.test.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { TransactionVersion } from '../primitives/transaction'
+import { Consensus, ConsensusParameters } from './consensus'
+
+describe('Consensus', () => {
+  const params: ConsensusParameters = {
+    allowedBlockFutureSeconds: 1,
+    genesisSupplyInIron: 2,
+    targetBlockTimeInSeconds: 3,
+    targetBucketTimeInSeconds: 4,
+    maxBlockSizeBytes: 5,
+    minFee: 6,
+    enableAssetOwnership: 7,
+  }
+
+  let consensus: Consensus
+
+  beforeAll(() => {
+    consensus = new Consensus(params)
+  })
+
+  it('isActive', () => {
+    expect(consensus.isActive(params.enableAssetOwnership, 5)).toEqual(false)
+    expect(consensus.isActive(params.enableAssetOwnership, 6)).toEqual(false)
+    expect(consensus.isActive(params.enableAssetOwnership, 7)).toEqual(true)
+    expect(consensus.isActive(params.enableAssetOwnership, 8)).toEqual(true)
+  })
+
+  it('getActiveTransactionVersion', () => {
+    expect(consensus.getActiveTransactionVersion(5)).toEqual(TransactionVersion.V1)
+    expect(consensus.getActiveTransactionVersion(6)).toEqual(TransactionVersion.V1)
+    expect(consensus.getActiveTransactionVersion(7)).toEqual(TransactionVersion.V2)
+    expect(consensus.getActiveTransactionVersion(8)).toEqual(TransactionVersion.V2)
+  })
+})

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { TransactionVersion } from '../primitives/transaction'
+
 export type ConsensusParameters = {
   /**
    * When adding a block, the block can be this amount of seconds into the future
@@ -33,6 +35,11 @@ export type ConsensusParameters = {
    * The minimum fee that a transaction must have to be accepted
    */
   minFee: number
+
+  /**
+   * The block height that enables the use of V2 transactions instead of V1
+   */
+  enableAssetOwnership: number
 }
 
 export class Consensus {
@@ -44,6 +51,14 @@ export class Consensus {
 
   isActive(upgrade: number, sequence: number): boolean {
     return sequence >= upgrade
+  }
+
+  getActiveTransactionVersion(sequence: number): TransactionVersion {
+    if (this.isActive(this.parameters.enableAssetOwnership, sequence)) {
+      return TransactionVersion.V2
+    } else {
+      return TransactionVersion.V1
+    }
   }
 }
 

--- a/ironfish/src/defaultNetworkDefinitions.ts
+++ b/ironfish/src/defaultNetworkDefinitions.ts
@@ -21,7 +21,9 @@ export function defaultNetworkName(networkId: number): string | undefined {
   }
 }
 
-export const TESTNET = `{
+// TODO(IFL-1523): Update proper activation sequence for enableAssetOwnership
+export const TESTNET = `
+{
   "id": 0,
   "bootstrapNodes": ["1.test.bn.ironfish.network", "2.test.bn.ironfish.network"],
   "genesis": ${TESTNET_GENESIS},
@@ -31,12 +33,14 @@ export const TESTNET = `{
       "targetBlockTimeInSeconds": 60,
       "targetBucketTimeInSeconds": 10,
       "maxBlockSizeBytes": 524288,
-      "minFee": 1
+      "minFee": 1,
+      "enableAssetOwnership": 9999999
   }
 }`
 
+// TODO(IFL-1523): Update proper activation sequence for enableAssetOwnership
 export const MAINNET = `
- {
+{
     "id": 1,
     "bootstrapNodes": ["1.main.bn.ironfish.network", "2.main.bn.ironfish.network"],
     "genesis": ${MAINNET_GENESIS},
@@ -46,10 +50,12 @@ export const MAINNET = `
         "targetBlockTimeInSeconds": 60,
         "targetBucketTimeInSeconds": 10,
         "maxBlockSizeBytes": 524288,
-        "minFee": 1
+        "minFee": 1,
+        "enableAssetOwnership": 9999999
     }
 }`
 
+// TODO(IFL-1523): Update proper activation sequence for enableAssetOwnership
 export const DEVNET = `
 {
     "id": 2,
@@ -61,6 +67,7 @@ export const DEVNET = `
         "targetBlockTimeInSeconds": 60,
         "targetBucketTimeInSeconds": 10,
         "maxBlockSizeBytes": 524288,
-        "minFee": 0
+        "minFee": 0,
+        "enableAssetOwnership": 9999999
     }
 }`

--- a/ironfish/src/networkDefinition.ts
+++ b/ironfish/src/networkDefinition.ts
@@ -47,6 +47,7 @@ export const networkDefinitionSchema: yup.ObjectSchema<NetworkDefinition> = yup
         targetBucketTimeInSeconds: yup.number().integer().defined(),
         maxBlockSizeBytes: yup.number().integer().defined(),
         minFee: yup.number().integer().defined(),
+        enableAssetOwnership: yup.number().integer().defined(),
       })
       .defined(),
   })

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -68,6 +68,7 @@ const consensusParameters: ConsensusParameters = {
   targetBucketTimeInSeconds: 10,
   maxBlockSizeBytes: 512 * 1024,
   minFee: 1,
+  enableAssetOwnership: 9999999,
 }
 
 /**

--- a/ironfish/src/strategy.test.ts
+++ b/ironfish/src/strategy.test.ts
@@ -16,6 +16,7 @@ describe('Miners reward', () => {
     targetBucketTimeInSeconds: 10,
     maxBlockSizeBytes: 512 * 1024,
     minFee: 1,
+    enableAssetOwnership: 9999999,
   }
 
   beforeAll(() => {


### PR DESCRIPTION
## Summary

**Merging into a feature branch `asset-security`**

Adds a consensus parameter for enabling v2 transactions which enable the transferring of ownership of assets. 

Additionally adds a helper function for getting the correct transaction version for a specific block sequence.

Closes IFL-1330

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
