### PR TITLE
adding enable wallet flag to node start command

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -110,6 +110,11 @@ export default class Start extends IronfishCommand {
       description:
         'Path to a JSON file containing the network definition of a custom network to connect to',
     }),
+    enableWallet: Flags.boolean({
+      allowNo: true,
+      default: false,
+      description: 'Enable the wallet from syncing with the blockchain and decrypting notes.',
+    }),
   }
 
   node: IronfishNode | null = null
@@ -140,6 +145,7 @@ export default class Start extends IronfishCommand {
       upgrade,
       networkId,
       customNetwork,
+      enableWallet,
     } = flags
 
     if (bootstrap !== undefined) {
@@ -200,6 +206,9 @@ export default class Start extends IronfishCommand {
     if (!this.sdk.internal.get('telemetryNodeId')) {
       this.sdk.internal.set('telemetryNodeId', uuid())
       await this.sdk.internal.save()
+    }
+    if (enableWallet !== undefined && enableWallet !== this.sdk.config.get('enableWallet')) {
+      this.sdk.config.setOverride('enableWallet', enableWallet)
     }
 
     const privateIdentity = this.getPrivateIdentity()

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -110,9 +110,9 @@ export default class Start extends IronfishCommand {
       description:
         'Path to a JSON file containing the network definition of a custom network to connect to',
     }),
-    enableWallet: Flags.boolean({
+    wallet: Flags.boolean({
       allowNo: true,
-      default: false,
+      default: true,
       description: `Enable the node's wallet to scan transactions and decrypt notes from the blockchain`,
     }),
   }
@@ -145,7 +145,7 @@ export default class Start extends IronfishCommand {
       upgrade,
       networkId,
       customNetwork,
-      enableWallet,
+      wallet,
     } = flags
 
     if (bootstrap !== undefined) {
@@ -174,6 +174,9 @@ export default class Start extends IronfishCommand {
     }
     if (forceMining !== undefined && forceMining !== this.sdk.config.get('miningForce')) {
       this.sdk.config.setOverride('miningForce', forceMining)
+    }
+    if (wallet !== undefined && wallet !== this.sdk.config.get('enableWallet')) {
+      this.sdk.config.setOverride('enableWallet', wallet)
     }
     if (
       logPeerMessages !== undefined &&
@@ -206,9 +209,6 @@ export default class Start extends IronfishCommand {
     if (!this.sdk.internal.get('telemetryNodeId')) {
       this.sdk.internal.set('telemetryNodeId', uuid())
       await this.sdk.internal.save()
-    }
-    if (enableWallet !== undefined && enableWallet !== this.sdk.config.get('enableWallet')) {
-      this.sdk.config.setOverride('enableWallet', enableWallet)
     }
 
     const privateIdentity = this.getPrivateIdentity()

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -113,7 +113,7 @@ export default class Start extends IronfishCommand {
     enableWallet: Flags.boolean({
       allowNo: true,
       default: false,
-      description: 'Enable the wallet from syncing with the blockchain and decrypting notes.',
+      description: `Enable the node's wallet to scan transactions and decrypt notes from the blockchain`,
     }),
   }
 


### PR DESCRIPTION
## Summary

Adding an `wallet` and `no-wallet` flag to control wallet rescan and note decryption

## Testing Plan

Add these flags when running the start command. Depending on these values, when you try to rescan transactions, it should fail/ pass. 
There is also an `enableWallet` config setting. Set that value and ensure that the flag that is set in the cli command overrides the config value. 

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
