### PR TITLE
remove hardcoded transaction version check in batch verify

### DIFF
--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -814,12 +814,6 @@ fn internal_batch_verify_transactions<'a>(
     let mut mint_public_inputs = vec![];
 
     for transaction in transactions {
-        // Currently only support version 1 transactions, the version
-        // field is here for future updates
-        if transaction.version != TRANSACTION_VERSION {
-            return Err(IronfishError::InvalidTransactionVersion);
-        }
-
         // Context to accumulate a signature of all the spends and outputs and
         // guarantee they are part of this transaction, unmodified.
         let mut binding_verification_key = ExtendedPoint::identity();


### PR DESCRIPTION
## Summary

Since #4210, this check is no longer necessary. We need to remove it to support the v2 transition.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
