### PR TITLE
`transaction_signature_hash` functions return a result instead of panic

### DIFF
--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -147,10 +147,13 @@ impl NativeTransactionPosted {
     }
 
     #[napi]
-    pub fn hash(&self) -> Buffer {
-        let hash = self.transaction.transaction_signature_hash();
+    pub fn hash(&self) -> Result<Buffer> {
+        let hash = self
+            .transaction
+            .transaction_signature_hash()
+            .map_err(to_napi_err)?;
 
-        Buffer::from(hash.as_ref())
+        Ok(Buffer::from(hash.as_ref()))
     }
 
     #[napi]

--- a/ironfish-rust-nodejs/tests/transaction.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/transaction.test.slow.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Asset, Transaction, generateKey } from ".."
+
+describe('Transaction', () => {
+  describe('post', () => {
+    it('throws an error when posting an invalid transaction version', () => {
+      const key = generateKey()
+      const asset = new Asset(key.publicAddress, 'testcoin', '')
+      // Version 1 transactions cannot have an ownership transfer
+      const proposedTx = new Transaction(key.spendingKey, 1)
+      proposedTx.mint(asset, 5n, key.publicAddress)
+
+      expect(() => { proposedTx.post(null, 0n)}).toThrow('InvalidTransactionVersion')
+    })
+
+    it('can post a valid transaction', () => {
+      const key = generateKey()
+      const asset = new Asset(key.publicAddress, 'testcoin', '')
+      const proposedTx = new Transaction(key.spendingKey, 1)
+      proposedTx.mint(asset, 5n)
+
+      expect(() => { proposedTx.post(null, 0n)}).not.toThrow()
+
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Previously, these functions would call `.unwrap()` on Results instead of bubbling up the error. These functions now properly bubble up the error instead of using unwraps and panics.

Closes IFL-1522

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
