### PR TITLE
fixes importAccount rescan if wallet not connected to node

### DIFF
--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -9,8 +9,8 @@ import { createRouteTest } from '../../../testUtilities/routeTest'
 import { encodeAccount } from '../../../wallet/account/encoder/account'
 import { Bech32JsonEncoder } from '../../../wallet/account/encoder/bech32json'
 import { AccountFormat } from '../../../wallet/account/encoder/encoder'
+import { RpcClient } from '../../clients'
 import { ImportResponse } from './importAccount'
-import { RpcClient } from '../..'
 
 describe('Route wallet/importAccount', () => {
   const routeTest = createRouteTest(true)

--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -10,6 +10,7 @@ import { encodeAccount } from '../../../wallet/account/encoder/account'
 import { Bech32JsonEncoder } from '../../../wallet/account/encoder/bech32json'
 import { AccountFormat } from '../../../wallet/account/encoder/encoder'
 import { ImportResponse } from './importAccount'
+import { RpcClient } from '../..'
 
 describe('Route wallet/importAccount', () => {
   const routeTest = createRouteTest(true)
@@ -71,6 +72,53 @@ describe('Route wallet/importAccount', () => {
     expect(response.content).toMatchObject({
       name: accountName,
       isDefaultAccount: false, // This is false because the default account is already imported in a previous test
+    })
+  })
+
+  describe('import rescanning', () => {
+    let nodeClient: RpcClient | null = null
+
+    beforeAll(() => {
+      nodeClient = routeTest.node.wallet.nodeClient
+    })
+
+    afterEach(() => {
+      // restore nodeClient to original value
+      Object.defineProperty(routeTest.node.wallet, 'nodeClient', { value: nodeClient })
+    })
+
+    it('should not skip rescan if nodeClient is null', async () => {
+      const key = generateKey()
+
+      // set nodeClient to null
+      Object.defineProperty(routeTest.node.wallet, 'nodeClient', { value: null })
+
+      const skipRescanSpy = jest.spyOn(routeTest.node.wallet, 'skipRescan')
+
+      const accountName = 'baz'
+      const response = await routeTest.client
+        .request<ImportResponse>('wallet/importAccount', {
+          account: {
+            name: accountName,
+            viewKey: key.viewKey,
+            spendingKey: key.spendingKey,
+            publicAddress: key.publicAddress,
+            incomingViewKey: key.incomingViewKey,
+            outgoingViewKey: key.outgoingViewKey,
+            version: 1,
+            createdAt: null,
+          },
+          // set rescan to true so that skipRescan should not be called
+          rescan: true,
+        })
+        .waitForEnd()
+
+      expect(response.status).toBe(200)
+      expect(response.content).toMatchObject({
+        name: accountName,
+      })
+
+      expect(skipRescanSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -54,8 +54,10 @@ routes.register<typeof ImportAccountRequestSchema, ImportResponse>(
       ...accountImport,
     })
 
-    if (request.data.rescan && node.wallet.nodeClient) {
-      void node.wallet.scanTransactions()
+    if (request.data.rescan) {
+      if (node.wallet.nodeClient) {
+        void node.wallet.scanTransactions()
+      }
     } else {
       await node.wallet.skipRescan(account)
     }


### PR DESCRIPTION
## Summary

when importing an account using ironfish-wallet-cli the wallet's 'nodeClient' may be null.

if the nodeClient is null then it is not possible to rescan. however, that does not mean that the wallet should use skipRescan! skipRescan sets the head of the account equal to the head of the chainProcessor. this results in the wallet incorrectly skipping the rescan automatically if it is not connected.

## Testing Plan

- adds regression test
- manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
