### PR TITLE
remove hardcoded transaction version const

### DIFF
--- a/benchmarks/benches/transaction.rs
+++ b/benchmarks/benches/transaction.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use ironfish::{
     assets::{asset::Asset, asset_identifier::NATIVE_ASSET},
     test_util::make_fake_witness,
-    transaction::{batch_verify_transactions, verify_transaction},
+    transaction::{batch_verify_transactions, verify_transaction, TransactionVersion},
     Note, ProposedTransaction, SaplingKey, Transaction,
 };
 
@@ -24,7 +24,7 @@ pub fn simple(c: &mut Criterion) {
             },
             // Benchmark
             |(key, spend_note, witness, out_note)| {
-                let mut proposed = ProposedTransaction::new(key);
+                let mut proposed = ProposedTransaction::new(key, TransactionVersion::V2);
 
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
@@ -60,7 +60,7 @@ pub fn all_descriptions(c: &mut Criterion) {
             |(key, spend_note, witness, out_note, asset)| {
                 let asset_value = 10;
 
-                let mut proposed = ProposedTransaction::new(key);
+                let mut proposed = ProposedTransaction::new(key, TransactionVersion::V2);
 
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
@@ -92,7 +92,7 @@ pub fn verify(c: &mut Criterion) {
 
                 let out_note = Note::new(public_address, 41, "", NATIVE_ASSET, public_address);
 
-                let mut proposed = ProposedTransaction::new(key);
+                let mut proposed = ProposedTransaction::new(key, TransactionVersion::V2);
 
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
@@ -127,7 +127,7 @@ pub fn batch_verify(c: &mut Criterion) {
 
                     let out_note = Note::new(public_address, 41, "", NATIVE_ASSET, public_address);
 
-                    let mut proposed = ProposedTransaction::new(key);
+                    let mut proposed = ProposedTransaction::new(key, TransactionVersion::V2);
 
                     proposed.add_spend(spend_note, &witness).unwrap();
                     proposed.add_output(out_note).unwrap();

--- a/benchmarks/benches/transaction.rs
+++ b/benchmarks/benches/transaction.rs
@@ -24,7 +24,7 @@ pub fn simple(c: &mut Criterion) {
             },
             // Benchmark
             |(key, spend_note, witness, out_note)| {
-                let mut proposed = ProposedTransaction::new(key, TransactionVersion::V2);
+                let mut proposed = ProposedTransaction::new(key, TransactionVersion::latest());
 
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
@@ -60,7 +60,7 @@ pub fn all_descriptions(c: &mut Criterion) {
             |(key, spend_note, witness, out_note, asset)| {
                 let asset_value = 10;
 
-                let mut proposed = ProposedTransaction::new(key, TransactionVersion::V2);
+                let mut proposed = ProposedTransaction::new(key, TransactionVersion::latest());
 
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
@@ -92,7 +92,7 @@ pub fn verify(c: &mut Criterion) {
 
                 let out_note = Note::new(public_address, 41, "", NATIVE_ASSET, public_address);
 
-                let mut proposed = ProposedTransaction::new(key, TransactionVersion::V2);
+                let mut proposed = ProposedTransaction::new(key, TransactionVersion::latest());
 
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
@@ -127,7 +127,7 @@ pub fn batch_verify(c: &mut Criterion) {
 
                     let out_note = Note::new(public_address, 41, "", NATIVE_ASSET, public_address);
 
-                    let mut proposed = ProposedTransaction::new(key, TransactionVersion::V2);
+                    let mut proposed = ProposedTransaction::new(key, TransactionVersion::latest());
 
                     proposed.add_spend(spend_note, &witness).unwrap();
                     proposed.add_output(out_note).unwrap();

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -47,6 +47,7 @@ export const TRANSACTION_SIGNATURE_LENGTH: number
 export const TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH: number
 export const TRANSACTION_EXPIRATION_LENGTH: number
 export const TRANSACTION_FEE_LENGTH: number
+export const LATEST_TRANSACTION_VERSION: number
 export function verifyTransactions(serializedTransactions: Array<Buffer>): boolean
 export const enum LanguageCode {
   English = 0,

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -47,7 +47,6 @@ export const TRANSACTION_SIGNATURE_LENGTH: number
 export const TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH: number
 export const TRANSACTION_EXPIRATION_LENGTH: number
 export const TRANSACTION_FEE_LENGTH: number
-export const TRANSACTION_VERSION: number
 export function verifyTransactions(serializedTransactions: Array<Buffer>): boolean
 export const enum LanguageCode {
   English = 0,
@@ -165,7 +164,7 @@ export class TransactionPosted {
 }
 export type NativeTransaction = Transaction
 export class Transaction {
-  constructor(spenderHexKey: string, version?: number | undefined | null)
+  constructor(spenderHexKey: string, version: number)
   /** Create a proof of a new note owned by the recipient in this transaction. */
   output(note: Note): void
   /** Spend the note owned by spender_hex_key at the given witness location. */

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, TransactionPosted, Transaction, verifyTransactions, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.contribute = contribute
 module.exports.verifyTransform = verifyTransform
@@ -286,7 +286,6 @@ module.exports.TRANSACTION_SIGNATURE_LENGTH = TRANSACTION_SIGNATURE_LENGTH
 module.exports.TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH = TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH
 module.exports.TRANSACTION_EXPIRATION_LENGTH = TRANSACTION_EXPIRATION_LENGTH
 module.exports.TRANSACTION_FEE_LENGTH = TRANSACTION_FEE_LENGTH
-module.exports.TRANSACTION_VERSION = TRANSACTION_VERSION
 module.exports.TransactionPosted = TransactionPosted
 module.exports.Transaction = Transaction
 module.exports.verifyTransactions = verifyTransactions

--- a/ironfish-rust-nodejs/index.js
+++ b/ironfish-rust-nodejs/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, TransactionPosted, Transaction, verifyTransactions, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
+const { contribute, verifyTransform, KEY_LENGTH, NONCE_LENGTH, BoxKeyPair, randomBytes, boxMessage, unboxMessage, RollingFilter, initSignalHandler, triggerSegfault, ASSET_ID_LENGTH, ASSET_METADATA_LENGTH, ASSET_NAME_LENGTH, ASSET_LENGTH, Asset, NOTE_ENCRYPTION_KEY_LENGTH, MAC_LENGTH, ENCRYPTED_NOTE_PLAINTEXT_LENGTH, ENCRYPTED_NOTE_LENGTH, NoteEncrypted, PUBLIC_ADDRESS_LENGTH, RANDOMNESS_LENGTH, MEMO_LENGTH, AMOUNT_VALUE_LENGTH, DECRYPTED_NOTE_LENGTH, Note, PROOF_LENGTH, TRANSACTION_SIGNATURE_LENGTH, TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH, TRANSACTION_EXPIRATION_LENGTH, TRANSACTION_FEE_LENGTH, LATEST_TRANSACTION_VERSION, TransactionPosted, Transaction, verifyTransactions, LanguageCode, generateKey, spendingKeyToWords, wordsToSpendingKey, generateKeyFromPrivateKey, initializeSapling, FoundBlockResult, ThreadPoolHandler, isValidPublicAddress } = nativeBinding
 
 module.exports.contribute = contribute
 module.exports.verifyTransform = verifyTransform
@@ -286,6 +286,7 @@ module.exports.TRANSACTION_SIGNATURE_LENGTH = TRANSACTION_SIGNATURE_LENGTH
 module.exports.TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH = TRANSACTION_PUBLIC_KEY_RANDOMNESS_LENGTH
 module.exports.TRANSACTION_EXPIRATION_LENGTH = TRANSACTION_EXPIRATION_LENGTH
 module.exports.TRANSACTION_FEE_LENGTH = TRANSACTION_FEE_LENGTH
+module.exports.LATEST_TRANSACTION_VERSION = LATEST_TRANSACTION_VERSION
 module.exports.TransactionPosted = TransactionPosted
 module.exports.Transaction = Transaction
 module.exports.verifyTransactions = verifyTransactions

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -7,15 +7,12 @@ use std::convert::TryInto;
 
 use ironfish::assets::asset_identifier::AssetIdentifier;
 use ironfish::transaction::{
-    batch_verify_transactions, TransactionVersion, TRANSACTION_EXPIRATION_SIZE,
-    TRANSACTION_FEE_SIZE, TRANSACTION_PUBLIC_KEY_SIZE, TRANSACTION_SIGNATURE_SIZE,
+    batch_verify_transactions, TRANSACTION_EXPIRATION_SIZE, TRANSACTION_FEE_SIZE,
+    TRANSACTION_PUBLIC_KEY_SIZE, TRANSACTION_SIGNATURE_SIZE,
 };
-use ironfish::{
-    MerkleNoteHash, ProposedTransaction, PublicAddress, SaplingKey, Transaction,
-    TRANSACTION_VERSION as TX_VERSION,
-};
+use ironfish::{MerkleNoteHash, ProposedTransaction, PublicAddress, SaplingKey, Transaction};
 use napi::{
-    bindgen_prelude::{i64n, BigInt, Buffer, Env, Error, Object, Result, Undefined},
+    bindgen_prelude::{i64n, BigInt, Buffer, Env, Object, Result, Undefined},
     JsBuffer,
 };
 use napi_derive::napi;
@@ -42,9 +39,6 @@ pub const TRANSACTION_EXPIRATION_LENGTH: u32 = TRANSACTION_EXPIRATION_SIZE as u3
 
 #[napi]
 pub const TRANSACTION_FEE_LENGTH: u32 = TRANSACTION_FEE_SIZE as u32;
-
-#[napi]
-pub const TRANSACTION_VERSION: u8 = TX_VERSION.as_u8();
 
 #[napi(js_name = "TransactionPosted")]
 pub struct NativeTransactionPosted {
@@ -170,26 +164,12 @@ pub struct NativeTransaction {
 #[napi]
 impl NativeTransaction {
     #[napi(constructor)]
-    pub fn new(spender_hex_key: String, version: Option<u8>) -> Result<Self> {
+    pub fn new(spender_hex_key: String, version: u8) -> Result<Self> {
         let spender_key = SaplingKey::from_hex(&spender_hex_key).map_err(to_napi_err)?;
-        let transaction = match version {
-            None => ProposedTransaction::new(spender_key),
-            Some(version) => {
-                let version = TransactionVersion::from_u8(version)
-                    .ok_or_else(|| Error::from_reason(format!("unsupported version: {version}")))?;
-                ProposedTransaction::with_version(spender_key, version)
-            }
-        };
-        Ok(NativeTransaction { transaction })
-    }
+        let tx_version = version.try_into().map_err(to_napi_err)?;
+        let transaction = ProposedTransaction::new(spender_key, tx_version);
 
-    pub fn with_version(spender_hex_key: String, version: u8) -> Result<Self> {
-        let spender_key = SaplingKey::from_hex(&spender_hex_key).map_err(to_napi_err)?;
-        let version = TransactionVersion::from_u8(version)
-            .ok_or_else(|| Error::from_reason(format!("unsupported version: {version}")))?;
-        Ok(NativeTransaction {
-            transaction: ProposedTransaction::with_version(spender_key, version),
-        })
+        Ok(NativeTransaction { transaction })
     }
 
     /// Create a proof of a new note owned by the recipient in this transaction.

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -7,8 +7,8 @@ use std::convert::TryInto;
 
 use ironfish::assets::asset_identifier::AssetIdentifier;
 use ironfish::transaction::{
-    batch_verify_transactions, TRANSACTION_EXPIRATION_SIZE, TRANSACTION_FEE_SIZE,
-    TRANSACTION_PUBLIC_KEY_SIZE, TRANSACTION_SIGNATURE_SIZE,
+    batch_verify_transactions, TransactionVersion, TRANSACTION_EXPIRATION_SIZE,
+    TRANSACTION_FEE_SIZE, TRANSACTION_PUBLIC_KEY_SIZE, TRANSACTION_SIGNATURE_SIZE,
 };
 use ironfish::{MerkleNoteHash, ProposedTransaction, PublicAddress, SaplingKey, Transaction};
 use napi::{
@@ -39,6 +39,9 @@ pub const TRANSACTION_EXPIRATION_LENGTH: u32 = TRANSACTION_EXPIRATION_SIZE as u3
 
 #[napi]
 pub const TRANSACTION_FEE_LENGTH: u32 = TRANSACTION_FEE_SIZE as u32;
+
+#[napi]
+pub const LATEST_TRANSACTION_VERSION: u8 = TransactionVersion::latest() as u8;
 
 #[napi(js_name = "TransactionPosted")]
 pub struct NativeTransactionPosted {

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -58,7 +58,7 @@ describe('Demonstrate the Sapling API', () => {
   it(`Should create a miner's fee transaction`, () => {
     const key = generateKey()
 
-    const transaction = new Transaction(key.spendingKey)
+    const transaction = new Transaction(key.spendingKey, 2)
     const note = new Note(key.publicAddress, 20n, 'test', Asset.nativeId(), key.publicAddress)
     transaction.output(note)
 
@@ -95,13 +95,13 @@ describe('Demonstrate the Sapling API', () => {
     const key = generateKey()
     const recipientKey = generateKey()
 
-    const minersFeeTransaction = new Transaction(key.spendingKey)
+    const minersFeeTransaction = new Transaction(key.spendingKey, 2)
     const minersFeeNote = new Note(key.publicAddress, 20n, 'miner', Asset.nativeId(), key.publicAddress)
     minersFeeTransaction.output(minersFeeNote)
 
     const postedMinersFeeTransaction = new TransactionPosted(minersFeeTransaction.post_miners_fee())
 
-    const transaction = new Transaction(key.spendingKey)
+    const transaction = new Transaction(key.spendingKey, 2)
     transaction.setExpiration(10)
     const encryptedNote = new NoteEncrypted(postedMinersFeeTransaction.getNote(0))
     const decryptedNote = Note.deserialize(encryptedNote.decryptNoteForOwner(key.incomingViewKey)!)

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { Asset, DECRYPTED_NOTE_LENGTH, initSignalHandler, LanguageCode, spendingKeyToWords, verifyTransactions, wordsToSpendingKey } from '..'
+import { Asset, DECRYPTED_NOTE_LENGTH, initSignalHandler, LanguageCode, LATEST_TRANSACTION_VERSION, spendingKeyToWords, verifyTransactions, wordsToSpendingKey } from '..'
 import {
   initializeSapling,
   generateKey,
@@ -58,7 +58,7 @@ describe('Demonstrate the Sapling API', () => {
   it(`Should create a miner's fee transaction`, () => {
     const key = generateKey()
 
-    const transaction = new Transaction(key.spendingKey, 2)
+    const transaction = new Transaction(key.spendingKey, LATEST_TRANSACTION_VERSION)
     const note = new Note(key.publicAddress, 20n, 'test', Asset.nativeId(), key.publicAddress)
     transaction.output(note)
 
@@ -95,13 +95,13 @@ describe('Demonstrate the Sapling API', () => {
     const key = generateKey()
     const recipientKey = generateKey()
 
-    const minersFeeTransaction = new Transaction(key.spendingKey, 2)
+    const minersFeeTransaction = new Transaction(key.spendingKey, LATEST_TRANSACTION_VERSION)
     const minersFeeNote = new Note(key.publicAddress, 20n, 'miner', Asset.nativeId(), key.publicAddress)
     minersFeeTransaction.output(minersFeeNote)
 
     const postedMinersFeeTransaction = new TransactionPosted(minersFeeTransaction.post_miners_fee())
 
-    const transaction = new Transaction(key.spendingKey, 2)
+    const transaction = new Transaction(key.spendingKey, LATEST_TRANSACTION_VERSION)
     transaction.setExpiration(10)
     const encryptedNote = new NoteEncrypted(postedMinersFeeTransaction.getNote(0))
     const decryptedNote = Note.deserialize(encryptedNote.decryptNoteForOwner(key.incomingViewKey)!)

--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -26,7 +26,6 @@ pub use {
     note::Note,
     transaction::{
         outputs::OutputDescription, spends::SpendDescription, ProposedTransaction, Transaction,
-        TRANSACTION_VERSION,
     },
 };
 

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -63,7 +63,6 @@ pub use version::TransactionVersion;
 
 const SIGNATURE_HASH_PERSONALIZATION: &[u8; 8] = b"IFsighsh";
 const TRANSACTION_SIGNATURE_VERSION: &[u8; 1] = &[0];
-pub const TRANSACTION_VERSION: TransactionVersion = TransactionVersion::V1;
 pub const TRANSACTION_SIGNATURE_SIZE: usize = 64;
 pub const TRANSACTION_PUBLIC_KEY_SIZE: usize = 32;
 pub const TRANSACTION_EXPIRATION_SIZE: usize = 4;
@@ -123,12 +122,8 @@ pub struct ProposedTransaction {
 }
 
 impl ProposedTransaction {
-    pub fn new(spender_key: SaplingKey) -> Self {
-        Self::with_version(spender_key, TRANSACTION_VERSION)
-    }
-
-    pub fn with_version(spender_key: SaplingKey, version: TransactionVersion) -> Self {
-        ProposedTransaction {
+    pub fn new(spender_key: SaplingKey, version: TransactionVersion) -> Self {
+        Self {
             version,
             spends: vec![],
             outputs: vec![],

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -71,7 +71,7 @@ fn test_transaction() {
         spender_key.public_address(),
     );
 
-    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::V2);
+    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::latest());
 
     // Spend
     transaction.add_spend(in_note, &witness).unwrap();
@@ -175,7 +175,7 @@ fn test_transaction_simple() {
     );
     let witness = make_fake_witness(&in_note);
 
-    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::V2);
+    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::latest());
     transaction.add_spend(in_note, &witness).unwrap();
     assert_eq!(transaction.spends.len(), 1);
     transaction.add_output(out_note).unwrap();
@@ -211,7 +211,7 @@ fn test_miners_fee() {
         NATIVE_ASSET,
         spender_key.public_address(),
     );
-    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::V2);
+    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::latest());
     transaction.add_output(out_note).unwrap();
     let posted_transaction = transaction
         .post_miners_fee()
@@ -236,7 +236,7 @@ fn test_transaction_signature() {
     let receiver_address = receiver_key.public_address();
     let sender_key = SaplingKey::generate_key();
 
-    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::V2);
+    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::latest());
     let in_note = Note::new(
         spender_address,
         42,
@@ -354,7 +354,7 @@ fn test_transaction_value_overflows() {
     );
     let witness = make_fake_witness(&note);
 
-    let mut tx = ProposedTransaction::new(key, TransactionVersion::V2);
+    let mut tx = ProposedTransaction::new(key, TransactionVersion::latest());
 
     // spend
     assert!(tx.add_spend(note.clone(), &witness).is_err());
@@ -458,7 +458,7 @@ fn test_batch_verify_wrong_params() {
         key.public_address(),
     );
 
-    let mut proposed_transaction1 = ProposedTransaction::new(key, TransactionVersion::V2);
+    let mut proposed_transaction1 = ProposedTransaction::new(key, TransactionVersion::latest());
 
     proposed_transaction1.add_spend(in_note, &witness).unwrap();
     proposed_transaction1.add_output(out_note).unwrap();
@@ -474,7 +474,8 @@ fn test_batch_verify_wrong_params() {
         .post(None, 1)
         .expect("should be able to post transaction");
 
-    let mut proposed_transaction2 = ProposedTransaction::new(other_key, TransactionVersion::V2);
+    let mut proposed_transaction2 =
+        ProposedTransaction::new(other_key, TransactionVersion::latest());
     proposed_transaction2.add_mint(asset2, 5).unwrap();
 
     let transaction2 = proposed_transaction2.post(None, 0).unwrap();
@@ -552,7 +553,7 @@ fn test_batch_verify() {
         key.public_address(),
     );
 
-    let mut proposed_transaction1 = ProposedTransaction::new(key, TransactionVersion::V2);
+    let mut proposed_transaction1 = ProposedTransaction::new(key, TransactionVersion::latest());
 
     proposed_transaction1.add_spend(in_note, &witness).unwrap();
     proposed_transaction1.add_output(out_note).unwrap();
@@ -568,7 +569,8 @@ fn test_batch_verify() {
         .post(None, 1)
         .expect("should be able to post transaction");
 
-    let mut proposed_transaction2 = ProposedTransaction::new(other_key, TransactionVersion::V2);
+    let mut proposed_transaction2 =
+        ProposedTransaction::new(other_key, TransactionVersion::latest());
     proposed_transaction2.add_mint(asset2, 5).unwrap();
 
     let transaction2 = proposed_transaction2.post(None, 0).unwrap();

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -71,7 +71,7 @@ fn test_transaction() {
         spender_key.public_address(),
     );
 
-    let mut transaction = ProposedTransaction::new(spender_key);
+    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::V2);
 
     // Spend
     transaction.add_spend(in_note, &witness).unwrap();
@@ -175,7 +175,7 @@ fn test_transaction_simple() {
     );
     let witness = make_fake_witness(&in_note);
 
-    let mut transaction = ProposedTransaction::new(spender_key);
+    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::V2);
     transaction.add_spend(in_note, &witness).unwrap();
     assert_eq!(transaction.spends.len(), 1);
     transaction.add_output(out_note).unwrap();
@@ -211,7 +211,7 @@ fn test_miners_fee() {
         NATIVE_ASSET,
         spender_key.public_address(),
     );
-    let mut transaction = ProposedTransaction::new(spender_key);
+    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::V2);
     transaction.add_output(out_note).unwrap();
     let posted_transaction = transaction
         .post_miners_fee()
@@ -236,7 +236,7 @@ fn test_transaction_signature() {
     let receiver_address = receiver_key.public_address();
     let sender_key = SaplingKey::generate_key();
 
-    let mut transaction = ProposedTransaction::new(spender_key);
+    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::V2);
     let in_note = Note::new(
         spender_address,
         42,
@@ -290,7 +290,7 @@ fn test_transaction_created_with_version_1() {
     );
     let witness = make_fake_witness(&in_note);
 
-    let mut transaction = ProposedTransaction::new(spender_key);
+    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::V1);
     transaction.add_spend(in_note, &witness).unwrap();
     transaction.add_output(out_note).unwrap();
 
@@ -354,7 +354,7 @@ fn test_transaction_value_overflows() {
     );
     let witness = make_fake_witness(&note);
 
-    let mut tx = ProposedTransaction::new(key);
+    let mut tx = ProposedTransaction::new(key, TransactionVersion::V2);
 
     // spend
     assert!(tx.add_spend(note.clone(), &witness).is_err());
@@ -458,7 +458,7 @@ fn test_batch_verify_wrong_params() {
         key.public_address(),
     );
 
-    let mut proposed_transaction1 = ProposedTransaction::new(key);
+    let mut proposed_transaction1 = ProposedTransaction::new(key, TransactionVersion::V2);
 
     proposed_transaction1.add_spend(in_note, &witness).unwrap();
     proposed_transaction1.add_output(out_note).unwrap();
@@ -474,7 +474,7 @@ fn test_batch_verify_wrong_params() {
         .post(None, 1)
         .expect("should be able to post transaction");
 
-    let mut proposed_transaction2 = ProposedTransaction::new(other_key);
+    let mut proposed_transaction2 = ProposedTransaction::new(other_key, TransactionVersion::V2);
     proposed_transaction2.add_mint(asset2, 5).unwrap();
 
     let transaction2 = proposed_transaction2.post(None, 0).unwrap();
@@ -552,7 +552,7 @@ fn test_batch_verify() {
         key.public_address(),
     );
 
-    let mut proposed_transaction1 = ProposedTransaction::new(key);
+    let mut proposed_transaction1 = ProposedTransaction::new(key, TransactionVersion::V2);
 
     proposed_transaction1.add_spend(in_note, &witness).unwrap();
     proposed_transaction1.add_output(out_note).unwrap();
@@ -568,7 +568,7 @@ fn test_batch_verify() {
         .post(None, 1)
         .expect("should be able to post transaction");
 
-    let mut proposed_transaction2 = ProposedTransaction::new(other_key);
+    let mut proposed_transaction2 = ProposedTransaction::new(other_key, TransactionVersion::V2);
     proposed_transaction2.add_mint(asset2, 5).unwrap();
 
     let transaction2 = proposed_transaction2.post(None, 0).unwrap();

--- a/ironfish-rust/src/transaction/version.rs
+++ b/ironfish-rust/src/transaction/version.rs
@@ -35,6 +35,10 @@ impl TransactionVersion {
         }
     }
 
+    pub const fn latest() -> Self {
+        Self::V2
+    }
+
     pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
         writer.write_u8((*self).into())?;
         Ok(())

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -8,6 +8,7 @@ import '../testUtilities/matchers/blockchain'
 import {
   Asset,
   generateKey,
+  LATEST_TRANSACTION_VERSION,
   Note as NativeNote,
   Transaction as NativeTransaction,
 } from '@ironfish/rust-nodejs'
@@ -240,7 +241,7 @@ describe('Verifier', () => {
             Asset.nativeId(),
             owner,
           )
-          const transaction = new NativeTransaction(key.spendingKey, TransactionVersion.V2)
+          const transaction = new NativeTransaction(key.spendingKey, LATEST_TRANSACTION_VERSION)
           transaction.output(minerNote1)
           transaction.output(minerNote2)
           return new Transaction(transaction._postMinersFeeUnchecked())

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -240,7 +240,7 @@ describe('Verifier', () => {
             Asset.nativeId(),
             owner,
           )
-          const transaction = new NativeTransaction(key.spendingKey)
+          const transaction = new NativeTransaction(key.spendingKey, TransactionVersion.V2)
           transaction.output(minerNote1)
           transaction.output(minerNote2)
           return new Transaction(transaction._postMinersFeeUnchecked())

--- a/ironfish/src/genesis/addGenesisTransaction.ts
+++ b/ironfish/src/genesis/addGenesisTransaction.ts
@@ -11,7 +11,7 @@ import { Logger } from '../logger'
 import { FullNode } from '../node'
 import { Block, BlockHeader } from '../primitives'
 import { transactionCommitment } from '../primitives/blockheader'
-import { Transaction } from '../primitives/transaction'
+import { Transaction, TransactionVersion } from '../primitives/transaction'
 import { CurrencyUtils } from '../utils'
 import { Account } from '../wallet'
 import { GenesisBlockAllocation } from './makeGenesisBlock'
@@ -88,7 +88,7 @@ export async function addGenesisTransaction(
   }
 
   // Create the new transaction to be appended to the new genesis block
-  const transaction = new NativeTransaction(account.spendingKey)
+  const transaction = new NativeTransaction(account.spendingKey, TransactionVersion.V2)
   logger.info(`  Generating a spend for ${allocationSumInIron} coins...`)
   transaction.spend(note, witness)
 

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -12,7 +12,7 @@ import { Blockchain } from '../blockchain'
 import { Logger } from '../logger'
 import { Block } from '../primitives'
 import { Target } from '../primitives/target'
-import { Transaction } from '../primitives/transaction'
+import { Transaction, TransactionVersion } from '../primitives/transaction'
 import { CurrencyUtils } from '../utils'
 import { GraffitiUtils } from '../utils/graffiti'
 
@@ -77,7 +77,10 @@ export async function makeGenesisBlock(
     minersFeeKey.publicAddress,
   )
 
-  const minersFeeTransaction = new NativeTransaction(minersFeeKey.spendingKey)
+  const minersFeeTransaction = new NativeTransaction(
+    minersFeeKey.spendingKey,
+    TransactionVersion.V2,
+  )
   minersFeeTransaction.output(note)
   const postedMinersFeeTransaction = new Transaction(minersFeeTransaction.post_miners_fee())
 
@@ -88,7 +91,10 @@ export async function makeGenesisBlock(
    *
    */
   logger.info(`Generating an initial transaction with ${allocationSumInIron} coins...`)
-  const initialTransaction = new NativeTransaction(genesisKey.spendingKey)
+  const initialTransaction = new NativeTransaction(
+    genesisKey.spendingKey,
+    TransactionVersion.V2,
+  )
 
   logger.info('  Generating the output...')
   initialTransaction.output(genesisNote)
@@ -124,7 +130,7 @@ export async function makeGenesisBlock(
    *
    */
   logger.info('Generating a transaction for distributing allocations...')
-  const transaction = new NativeTransaction(genesisKey.spendingKey)
+  const transaction = new NativeTransaction(genesisKey.spendingKey, TransactionVersion.V2)
   logger.info(`  Generating a spend for ${allocationSumInIron} coins...`)
   transaction.spend(genesisNote, witness)
 

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -103,7 +103,7 @@ describe('Demonstrate the Sapling API', () => {
 
       minerNote = new NativeNote(owner, 42n, '', Asset.nativeId(), owner)
 
-      const transaction = new NativeTransaction(spenderKey.spendingKey)
+      const transaction = new NativeTransaction(spenderKey.spendingKey, TransactionVersion.V2)
       transaction.output(minerNote)
       minerTransaction = new NativeTransactionPosted(transaction.post_miners_fee())
       expect(minerTransaction).toBeTruthy()
@@ -131,7 +131,7 @@ describe('Demonstrate the Sapling API', () => {
     })
 
     it('Can create a simple transaction', () => {
-      transaction = new NativeTransaction(spenderKey.spendingKey)
+      transaction = new NativeTransaction(spenderKey.spendingKey, TransactionVersion.V2)
       expect(transaction).toBeTruthy()
     })
 
@@ -299,7 +299,7 @@ describe('Demonstrate the Sapling API', () => {
     })
 
     it('Can create and post a transaction', async () => {
-      transaction = new NativeTransaction(receiverKey.spendingKey)
+      transaction = new NativeTransaction(receiverKey.spendingKey, TransactionVersion.V2)
 
       const witness = await tree.witness(receiverWitnessIndex)
       if (witness === null) {

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -6,6 +6,7 @@ import {
   generateKey,
   generateKeyFromPrivateKey,
   Key,
+  LATEST_TRANSACTION_VERSION,
   Note as NativeNote,
   Transaction as NativeTransaction,
   TransactionPosted as NativeTransactionPosted,
@@ -103,7 +104,10 @@ describe('Demonstrate the Sapling API', () => {
 
       minerNote = new NativeNote(owner, 42n, '', Asset.nativeId(), owner)
 
-      const transaction = new NativeTransaction(spenderKey.spendingKey, TransactionVersion.V2)
+      const transaction = new NativeTransaction(
+        spenderKey.spendingKey,
+        LATEST_TRANSACTION_VERSION,
+      )
       transaction.output(minerNote)
       minerTransaction = new NativeTransactionPosted(transaction.post_miners_fee())
       expect(minerTransaction).toBeTruthy()
@@ -131,7 +135,7 @@ describe('Demonstrate the Sapling API', () => {
     })
 
     it('Can create a simple transaction', () => {
-      transaction = new NativeTransaction(spenderKey.spendingKey, TransactionVersion.V2)
+      transaction = new NativeTransaction(spenderKey.spendingKey, LATEST_TRANSACTION_VERSION)
       expect(transaction).toBeTruthy()
     })
 
@@ -299,7 +303,7 @@ describe('Demonstrate the Sapling API', () => {
     })
 
     it('Can create and post a transaction', async () => {
-      transaction = new NativeTransaction(receiverKey.spendingKey, TransactionVersion.V2)
+      transaction = new NativeTransaction(receiverKey.spendingKey, LATEST_TRANSACTION_VERSION)
 
       const witness = await tree.witness(receiverWitnessIndex)
       if (witness === null) {


### PR DESCRIPTION
## Summary

Removes `TRANSACTION_VERSION` const, since it no longer makes sense as a default value.

Closes IFL-1530

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
