### PR TITLE
Rahul/ifl 1555 add node to wallet rpc namespace

### DIFF
--- a/ironfish/src/rpc/routes/node/stopNode.ts
+++ b/ironfish/src/rpc/routes/node/stopNode.ts
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { Assert } from '../../../assert'
-import { FullNode } from '../../../node'
 import { ApiNamespace, routes } from '../router'
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -22,8 +20,6 @@ routes.register<typeof StopNodeRequestSchema, StopNodeResponse>(
   `${ApiNamespace.node}/stopNode`,
   StopNodeRequestSchema,
   async (request, node): Promise<void> => {
-    Assert.isInstanceOf(node, FullNode)
-
     node.logger.withTag('stopnode').info('Shutting down')
     request.end()
     await node.shutdown()

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -317,6 +317,7 @@ Use 'ironfish config:set' to connect to a node via TCP, TLS, or IPC.\n`)
       ApiNamespace.rpc,
       ApiNamespace.wallet,
       ApiNamespace.worker,
+      ApiNamespace.node,
     ]
 
     if (this.config.get('enableRpcIpc')) {


### PR DESCRIPTION
## Summary

This change allows for the wallet cli to call the stopNode command on the sdk: 
<img width="1728" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/9dbbbf3b-b8e3-4c31-a271-364c232b9ba4">


## Testing Plan

- manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
