### PR TITLE
Update `Account.saveAssetFromChain` to support the new `owner` field

### DIFF
--- a/ironfish/src/migrations/data/019-backfill-wallet-assets-from-chain.ts
+++ b/ironfish/src/migrations/data/019-backfill-wallet-assets-from-chain.ts
@@ -76,6 +76,9 @@ export class Migration019 extends Migration {
             chainAsset.name,
             chainAsset.nonce,
             chainAsset.creator,
+            // this migration was created before asset ownership, therefore
+            // owner and creator are the same in the context of this migration
+            chainAsset.creator,
             { hash, sequence },
             tx,
           )

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -243,6 +243,7 @@ export class Account {
     name: Buffer,
     nonce: number,
     creator: Buffer,
+    owner: Buffer,
     blockHeader?: { hash: Buffer | null; sequence: number | null },
     tx?: IDatabaseTransaction,
   ): Promise<void> {
@@ -261,7 +262,7 @@ export class Account {
         name,
         nonce,
         creator,
-        owner: creator,
+        owner,
         sequence: blockHeader?.sequence ?? null,
         supply: null,
       },

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -568,6 +568,7 @@ export class Wallet {
           chainAsset.name,
           chainAsset.nonce,
           chainAsset.creator,
+          chainAsset.owner,
           blockHeader,
           tx,
         )
@@ -1660,6 +1661,7 @@ export class Wallet {
   private async getChainAsset(id: Buffer): Promise<{
     createdTransactionHash: Buffer
     creator: Buffer
+    owner: Buffer
     id: Buffer
     metadata: Buffer
     name: Buffer
@@ -1671,6 +1673,7 @@ export class Wallet {
       return {
         createdTransactionHash: Buffer.from(response.content.createdTransactionHash, 'hex'),
         creator: Buffer.from(response.content.creator, 'hex'),
+        owner: Buffer.from(response.content.owner, 'hex'),
         id: Buffer.from(response.content.id, 'hex'),
         metadata: Buffer.from(response.content.metadata, 'hex'),
         name: Buffer.from(response.content.name, 'hex'),


### PR DESCRIPTION
## Summary

The `saveAssetFromChain` gains a new parameter: `owner`. This change currently has no effect, because change of ownership is not recorded yet on the chain db, but this change is required to support future changes.

## Testing Plan

Because this change has no effect yet, the only testing plan is to make sure that current tests do not break. In the future, once the functionality to transfer ownership is added to both the wallet db and chain db, it will be possible to have new unit tests covering this method.

## Documentation

No doc changes required

## Breaking Change

Not a breaking change