### PR TITLE
adds faucet namespace to walletNode RPC server

### DIFF
--- a/ironfish/src/rpc/routes/faucet/getFunds.ts
+++ b/ironfish/src/rpc/routes/faucet/getFunds.ts
@@ -4,7 +4,6 @@
 import { AxiosError } from 'axios'
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { FullNode } from '../../../node'
 import { WebApi } from '../../../webApi'
 import { ERROR_CODES, ResponseError } from '../../adapters'
 import { ApiNamespace, routes } from '../router'
@@ -30,7 +29,6 @@ routes.register<typeof GetFundsRequestSchema, GetFundsResponse>(
   `${ApiNamespace.faucet}/getFunds`,
   GetFundsRequestSchema,
   async (request, node): Promise<void> => {
-    Assert.isInstanceOf(node, FullNode)
     // check node network id
     const networkId = node.internal.get('networkId')
 

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -314,6 +314,7 @@ Use 'ironfish config:set' to connect to a node via TCP, TLS, or IPC.\n`)
 
     const namespaces = [
       ApiNamespace.config,
+      ApiNamespace.faucet,
       ApiNamespace.rpc,
       ApiNamespace.wallet,
       ApiNamespace.worker,


### PR DESCRIPTION
## Summary

enables standalone wallet to implement faucet command

## Testing Plan

manual testing with faucet command in ironfish-wallet-cli

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
