### PR TITLE
Use a floor of 1 for sequence when checking active consensus params

### DIFF
--- a/ironfish/src/consensus/consensus.test.ts
+++ b/ironfish/src/consensus/consensus.test.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Consensus, ConsensusParameters } from './consensus'
+
+describe('Consensus', () => {
+  const params: ConsensusParameters = {
+    allowedBlockFutureSeconds: 1,
+    genesisSupplyInIron: 2,
+    targetBlockTimeInSeconds: 3,
+    targetBucketTimeInSeconds: 4,
+    maxBlockSizeBytes: 5,
+    minFee: 6,
+  }
+
+  let consensus: Consensus
+
+  beforeAll(() => {
+    consensus = new Consensus(params)
+  })
+
+  describe('isActive', () => {
+    describe('returns false when the sequence is less than the upgrade number', () => {
+      const upgradeSequence = 5
+      for (let sequence = 1; sequence < upgradeSequence; sequence++) {
+        it(`sequence: ${sequence}`, () => {
+          expect(consensus.isActive(upgradeSequence, sequence)).toBe(false)
+        })
+      }
+    })
+
+    describe('returns true when the sequence is greater than or equal to the upgrade number', () => {
+      const upgradeSequence = 5
+      for (let sequence = upgradeSequence; sequence < upgradeSequence * 2; sequence++) {
+        it(`sequence: ${sequence}`, () => {
+          expect(consensus.isActive(upgradeSequence, sequence)).toBe(true)
+        })
+      }
+    })
+
+    it('uses a minimum sequence of 1 if given a smaller sequence', () => {
+      const upgradeSequence = 1
+      expect(consensus.isActive(upgradeSequence, -100)).toBe(true)
+      expect(consensus.isActive(upgradeSequence, -1)).toBe(true)
+      expect(consensus.isActive(upgradeSequence, 0)).toBe(true)
+    })
+  })
+})

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -43,7 +43,7 @@ export class Consensus {
   }
 
   isActive(upgrade: number, sequence: number): boolean {
-    return sequence >= upgrade
+    return Math.max(1, sequence) >= upgrade
   }
 }
 


### PR DESCRIPTION
## Summary

Often times, this function will be called with something like `chain.head.sequence - confirmations`. This would lead to incorrect logic when activation sequences are set to 1 on a fresh chain. Primarily, this will only affect devnet, but leads to simpler logic since we won't have to special case this logic everywhere we want to check it. A sequence will never be below 1, since the genesis sequence is 1.

## Testing Plan

Unit tests

## Documentation

N/A

## Breaking Change

Not a breaking change since this function is not used yet