### PR TITLE
restarts wallet scan on import

### DIFF
--- a/ironfish/src/rpc/routes/wallet/importAccount.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.ts
@@ -56,7 +56,7 @@ routes.register<typeof ImportAccountRequestSchema, ImportResponse>(
 
     if (request.data.rescan) {
       if (node.wallet.nodeClient) {
-        void node.wallet.scanTransactions()
+        void node.wallet.scanTransactions(undefined, true)
       }
     } else {
       await node.wallet.skipRescan(account)

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -669,7 +669,7 @@ export class Wallet {
     }
   }
 
-  async scanTransactions(fromHash?: Buffer): Promise<void> {
+  async scanTransactions(fromHash?: Buffer, force?: boolean): Promise<void> {
     if (!this.isOpen) {
       throw new Error('Cannot start a scan if accounts are not loaded')
     }
@@ -680,8 +680,13 @@ export class Wallet {
     }
 
     if (this.scan) {
-      this.logger.info('Skipping Scan, already scanning.')
-      return
+      if (force) {
+        this.logger.info('Aborting scan in progress and starting new scan.')
+        await this.scan.abort()
+      } else {
+        this.logger.info('Skipping Scan, already scanning.')
+        return
+      }
     }
 
     const scan = new ScanState()


### PR DESCRIPTION
## Summary

when a user imports an account the wallet starts scanning the chain for transactions involving that account.

if a user imports multiple accounts into a single wallet, then only the first import will initiate a scan: secondary imports will not scan because a scan is already in progress. this forces the user to restart their node to start scanning for the other imported accounts.

updates importAccount to force a new scan to start on each import

adds 'force' parameter to 'scanTransactions'

fixes #4216

## Testing Plan

- manual testing: imported multiple accounts to a wallet and checked 'wallet:status' to see that all accounts were scanning

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
