### PR TITLE
fix(ironfish): Pass missing `startWallet` argument

### DIFF
--- a/ironfish/src/walletNode.ts
+++ b/ironfish/src/walletNode.ts
@@ -268,7 +268,10 @@ export class WalletNode {
         this.nodeClientConnectionWarned = true
       }
 
-      this.nodeClientConnectionTimeout = setTimeout(() => void this.startConnectingRpc(startWallet), 5000)
+      this.nodeClientConnectionTimeout = setTimeout(
+        () => void this.startConnectingRpc(startWallet),
+        5000,
+      )
       return
     }
 

--- a/ironfish/src/walletNode.ts
+++ b/ironfish/src/walletNode.ts
@@ -268,7 +268,7 @@ export class WalletNode {
         this.nodeClientConnectionWarned = true
       }
 
-      this.nodeClientConnectionTimeout = setTimeout(() => void this.startConnectingRpc(), 5000)
+      this.nodeClientConnectionTimeout = setTimeout(() => void this.startConnectingRpc(startWallet), 5000)
       return
     }
 


### PR DESCRIPTION
## Summary

There's a missing argument in the lambda that prevents the wallet from starting again on a retry connection.

## Testing Plan

https://github.com/iron-fish/ironfish/assets/5459049/0574bfb4-6b07-4b6b-8026-c950f2c9b736

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
