### PR TITLE
updateHead updates to chain head

### DIFF
--- a/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
+++ b/ironfish/src/wallet/__fixtures__/wallet.test.ts.fixture
@@ -6817,5 +6817,76 @@
         }
       ]
     }
+  ],
+  "Accounts updateHead should update until the chainProcessor reaches the chain head": [
+    {
+      "version": 2,
+      "id": "fd8bf8b9-ae0c-453d-b1a1-6b1eadac72cb",
+      "name": "a",
+      "spendingKey": "7d371b1820c5041ffa5eed2b0fcfb59064954b621f6326e32e64e01686551474",
+      "viewKey": "30d882aef1ff46c3d693c451840aaaa7f2d1195c5bc15b7d981bc4c8625359665b8678abaf4e93a94b56523f1b4f58575bf46108dabda831c313abb17bde7586",
+      "incomingViewKey": "7f7985a4a9ba0b8b4d87d95e07fcd240af7d07e70f153f3a68cf1ead9fff6407",
+      "outgoingViewKey": "0aa429f7434c6c928935814ecb862dc566b17d991224d0076c35fdb34f653dfa",
+      "publicAddress": "2fda8d1d92283106bae0068448c74100ed9b5fd2400832912377384f1dd127c6",
+      "createdAt": {
+        "hash": {
+          "type": "Buffer",
+          "data": "base64:iLb6jXRaTlO9oAExjmCwTuLk7gajgJVojVgEnLbxWso="
+        },
+        "sequence": 1
+      }
+    },
+    {
+      "header": {
+        "sequence": 2,
+        "previousBlockHash": "88B6FA8D745A4E53BDA001318E60B04EE2E4EE06A38095688D58049CB6F15ACA",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:1uUsigHjUPQ0HqFtgYxV4+3jjiJfcpDPqmsB31IdeT0="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:ebTR//Lq+mtHjiSQlVF1O8fHajtmSIEK0Rw8/Y6ugXg="
+        },
+        "target": "883423532389192164791648750371459257913741948437809479060803100646309888",
+        "randomness": "0",
+        "timestamp": 1693352704967,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 4,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAA4YOI4zg0q9B7O27p4NtzXhMeCthgcqKVySWKdzoK5VCLUTOecdO2wT+AbvLrMQWnoVECe6ZHPlnsc6yY/nZMa9ITV8d/Ez8G9AbuqmIPaSeUsy6uOHxfS6Y/RbSGx9B6WkW8qYXkbD/V/+46VEkV+/gAcmHI8u24ce4Ni6JAWsoJi1bsU+SPWWH3vNoFr5JIdbWN8KRHISE76jlzuMJJKfaIk0KYIFhC498H+UY9UuqE9F43bN92rwIdFWJCRpfbbwqjKHq8Vtrxq7x1F6aya2X706GxYhFBzcHGqDJZhe/10D1n3YuCygcpLS3W9FGo8JjWzLkXMpXdvCAT9ZaTrIUTgizGl2u1eSEhxwwTHcdbZC7io0gg9N5UBLFOnicUYDthoX2dG1zOi3W1NJeFFIATAc5i6b75solB3QTs8YiKwgrOa9WT6zAuzhhLEiozc12HE7HdnQEvItDlKZpLSwTOts4uAQumLuVeuGmMlGvXeDXQYyJqVfW+Xz3IHykxHaIHMmtvh6JgUnQjkgKjaJg3DIhRiXfUkCxKGparXNNnzInmlCfiReNBJY+m+GIjjKTankiZpnCVL3ExdfjqxZ00vb9HD74efcS0/Qx4CcKLStL1ybK4RElyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw3On85o9GQo3VlSjs1VR0JfRDJgZkKQ8nC9ViPcqUu5TLGMPnjd7pPQHvQUdv64H1CCvRGz5CRT7C6HmjGxtkCg=="
+        }
+      ]
+    },
+    {
+      "header": {
+        "sequence": 3,
+        "previousBlockHash": "4A08ECC6CD855916D9A58C28AEAEEDB2E05B080BFB30A0F1EFB81DABF56F09A8",
+        "noteCommitment": {
+          "type": "Buffer",
+          "data": "base64:0dx6G4HPtFgRZTkwJtejlQfp13oTtrGc9LdLD0Y1vmc="
+        },
+        "transactionCommitment": {
+          "type": "Buffer",
+          "data": "base64:k9tvnWdfARHD53pg5rV52evxxokdK2veukqZdRwkpsU="
+        },
+        "target": "880842937844725196442695540779332307793253899902937591585455087694081134",
+        "randomness": "0",
+        "timestamp": 1693352705441,
+        "graffiti": "0000000000000000000000000000000000000000000000000000000000000000",
+        "noteSize": 5,
+        "work": "0"
+      },
+      "transactions": [
+        {
+          "type": "Buffer",
+          "data": "base64:AQAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGzKiP////8AAAAAlnVAeq2n+bGLQul15aDJYIuPRdJe+xhdM4vmeKTChNivqY+1wkIw+pwo3MrJACpEWL7x2Ykrrw8k1zcTel+q3rAAlP36IN0o44oRXR+Wdc+KcCk37uLWsKEnoWph9wGTpJTCA/7N/aC9BnrwD/iExalPPdPTLxry2D2qdUYSKJUB1Evs9yUn+Ef23l4PPLGc/275qskr/JpcwGSwA0u3lYxeKYXEDuFAjXyGSYH5kvONAgT9rJ40yvrpUO8cgIRibROlpxA8HX/vfyF7VWVWT56572HmF8LqmhXlY/kUyHEQl2ZfqYUjw/Nt0j9zjAqZGIPwXuU1Q+s2caWYWIoduEnXO71WSYgyfY0vsLtsMuWYtDi+9E1J2hIvFfhCVzNcRJ9bCssUFKud83IXwq67qydJXULU6+RBGmLKkzf5tSunhm2fUOuDgP6h38ilxvV+FlMxIhBFwoZ+30WIrqGRCEdtTj6pghVFr7e5RDnaq/zUZtKv8bZ3aUGuBGusrg6RrZAxjM8GN40gxBNhde5p6a+ldwHwRHBbVBAQfAdSIx/XGLn41dyP4835t6WTwOebPZy7Gfi5DIQnufF06DjKmiA+f0fDDd1NaSY+TXYcEW2Lfu4VbjZPG0lyb24gRmlzaCBub3RlIGVuY3J5cHRpb24gbWluZXIga2V5MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw8AztBx/DB+Cy7/4kxIhmW4h4D3/+uktWesodeGgzE1izxC2C0AHCg9Serg20bueGurbXJhCXQ1XUj93YhL6zCg=="
+        }
+      ]
+    }
   ]
 }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -161,15 +161,17 @@ export class Wallet {
     this.updateHeadState = scan
 
     try {
-      const { hashChanged } = await this.chainProcessor.update({
-        signal: scan.abortController.signal,
-      })
-
-      if (hashChanged) {
-        this.logger.debug(
-          `Updated Accounts Head: ${String(this.chainProcessor.hash?.toString('hex'))}`,
-        )
-      }
+      let hashChanged = false
+      do {
+        hashChanged = (
+          await this.chainProcessor.update({ signal: scan.abortController.signal })
+        ).hashChanged
+        if (hashChanged) {
+          this.logger.debug(
+            `Updated Accounts Head: ${String(this.chainProcessor.hash?.toString('hex'))}`,
+          )
+        }
+      } while (hashChanged)
     } finally {
       scan.signalComplete()
       this.updateHeadState = null


### PR DESCRIPTION
## Summary

changes wallet updateHead to iteravely update the chainProcessor until it reaches the chain head

updateHead currently only calls 'update' once per invocation which will sync a limited number of blocks from the node's chain. this slows syncing since the wallet only calls updateHead as part of its eventLoop method which runs at most once per second

## Testing Plan

- adds unit test
- manual testing with ironfish-wallet-cli

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
