### PR TITLE
delete requires confirmation if account scanning

### DIFF
--- a/ironfish/src/rpc/routes/wallet/remove.ts
+++ b/ironfish/src/rpc/routes/wallet/remove.ts
@@ -29,6 +29,11 @@ routes.register<typeof RemoveAccountRequestSchema, RemoveAccountResponse>(
     const account = getAccount(node.wallet, request.data.account)
 
     if (!request.data.confirm) {
+      if (!(await node.wallet.isAccountUpToDate(account))) {
+        request.end({ needsConfirm: true })
+        return
+      }
+
       const balances = await account.getUnconfirmedBalances()
 
       for (const [_, { unconfirmed }] of balances) {


### PR DESCRIPTION
## Summary

deleting an account with a non-zero balance requires confirmation from the user. however, if the account is scanning then the balance may not be accurate at the time that a user tries deletion.

requires confirmation from the user if they try to delete an account while it is scanning

## Testing Plan

manual testing:
- started rescan
- tried to delete account with zero balance and saw that confirmation was needed

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
