### PR TITLE
feat(ironfish): Throw error if wallet node client is disconnected

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getNodeStatus.ts
+++ b/ironfish/src/rpc/routes/wallet/getNodeStatus.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Assert } from '../../../assert'
+import { ValidationError } from '../../adapters'
+import { RpcSocketClient } from '../../clients'
 import { GetNodeStatusResponse, GetStatusRequestSchema } from '../node/getStatus'
 import { ApiNamespace, routes } from '../router'
 
@@ -11,6 +13,10 @@ routes.register<typeof GetStatusRequestSchema, GetNodeStatusResponse>(
   async (request, { wallet }): Promise<void> => {
     Assert.isNotUndefined(wallet)
     Assert.isNotNull(wallet.nodeClient)
+
+    if (wallet.nodeClient instanceof RpcSocketClient && !wallet.nodeClient.isConnected) {
+      throw new ValidationError('Wallet node client is disconnected')
+    }
 
     if (!request.data?.stream) {
       const status = await wallet.nodeClient.node.getStatus()


### PR DESCRIPTION
## Summary

For the standalone wallet, fetching the node status hangs if the node client is disconnected. This change updates the handler to throw an error if the client is disconnected.

## Testing Plan

Manually tested

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
