### PR TITLE
fixes wallet.updateHead test to be independent of fixture generation

### DIFF
--- a/ironfish/src/wallet/wallet.test.ts
+++ b/ironfish/src/wallet/wallet.test.ts
@@ -2807,12 +2807,16 @@ describe('Accounts', () => {
       // create an account so that the wallet will sync
       await useAccountFixture(node.wallet, 'a')
 
+      // update wallet to genesis block
+      await node.wallet.updateHead()
+
       const block2 = await useMinerBlockFixture(node.chain, undefined)
       await expect(node.chain).toAddBlock(block2)
       const block3 = await useMinerBlockFixture(node.chain, undefined)
       await expect(node.chain).toAddBlock(block3)
 
       expect(node.chain.head.hash).toEqualHash(block3.header.hash)
+      expect(node.wallet.chainProcessor.hash).toEqualHash(node.chain.genesis.hash)
 
       // set max syncing queue to 1 so that wallet only fetches one block at a time
       node.wallet.chainProcessor.maxQueueSize = 1
@@ -2824,8 +2828,8 @@ describe('Accounts', () => {
       // chainProcessor should sync all the way to head with one call to updateHead
       expect(node.wallet.chainProcessor.hash).toEqualHash(node.chain.head.hash)
 
-      // one call for each block and a fourth to find that hash doesn't change
-      expect(updateSpy).toHaveBeenCalledTimes(4)
+      // one call for each block and a third to find that hash doesn't change
+      expect(updateSpy).toHaveBeenCalledTimes(3)
     })
   })
 })


### PR DESCRIPTION
## Summary

the test of updateHead fails when fixtures are regenerated, but passes if they already exist

this is because creating an account may update the wallet's chainProcessor head state, but importing an account does not
(https://linear.app/if-labs/issue/IFL-1585/createaccount-and-importaccount-inconsistent)

fixes test to pass indpendently of fixture generation by always updating the wallet head to the genesis block before adding more blocks

## Testing Plan

- tested with fixture regeneration and without

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
