### PR TITLE
feat(cli,ironfish): Return native asset when streaming wallet assets

### DIFF
--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import {
+  Asset,
   ASSET_ID_LENGTH,
   ASSET_METADATA_LENGTH,
   ASSET_NAME_LENGTH,
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
-import { BufferUtils } from '@ironfish/sdk'
+import { AssetStatus, BufferUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -83,6 +84,8 @@ export class AssetsCommand extends IronfishCommand {
           status: {
             header: 'Status',
             minWidth: 12,
+            get: (row) =>
+              row.id === Asset.nativeId().toString('hex') ? AssetStatus.CONFIRMED : row.status,
           },
           supply: {
             header: 'Supply',
@@ -92,6 +95,10 @@ export class AssetsCommand extends IronfishCommand {
           creator: {
             header: 'Creator',
             minWidth: PUBLIC_ADDRESS_LENGTH + 1,
+            get: (row) =>
+              row.id === Asset.nativeId().toString('hex')
+                ? BufferUtils.toHuman(Buffer.from(row.creator, 'hex'))
+                : row.creator,
           },
         },
         {

--- a/ironfish/src/wallet/account/account.test.ts
+++ b/ironfish/src/wallet/account/account.test.ts
@@ -1472,7 +1472,7 @@ describe('Accounts', () => {
 
       // wallet should have removed the new asset from the expired mint
       assets = await AsyncUtils.materialize(accountA.getAssets())
-      expect(assets).toHaveLength(0)
+      expect(assets).toHaveLength(1)
 
       // expired mint should still be in the wallet
       const expiredMintTx = await accountA.getTransaction(mintTx.hash())

--- a/ironfish/src/wallet/account/account.test.ts
+++ b/ironfish/src/wallet/account/account.test.ts
@@ -1463,8 +1463,9 @@ describe('Accounts', () => {
 
       // wallet should have the new asset
       let assets = await AsyncUtils.materialize(accountA.getAssets())
-      expect(assets).toHaveLength(1)
-      expect(assets[0].id).toEqualBuffer(asset.id())
+      expect(assets).toHaveLength(2)
+      expect(assets[0].id).toEqualBuffer(Asset.nativeId())
+      expect(assets[1].id).toEqualBuffer(asset.id())
 
       // expire the mint transaction
       await accountA.expireTransaction(mintTx)

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -1140,27 +1140,33 @@ export class WalletDB {
     tx?: IDatabaseTransaction,
   ): Promise<AssetValue | undefined> {
     if (assetId.equals(Asset.nativeId())) {
-      return {
-        createdTransactionHash: GENESIS_BLOCK_PREVIOUS,
-        id: Asset.nativeId(),
-        metadata: Buffer.from('Native asset of Iron Fish blockchain', 'utf8'),
-        name: Buffer.from('$IRON', 'utf8'),
-        nonce: 0,
-        creator: Buffer.from('Iron Fish', 'utf8'),
-        owner: Buffer.from('Iron Fish', 'utf8'),
-        blockHash: null,
-        sequence: null,
-        supply: null,
-      }
+      return this.nativeAssetValue()
     }
     return this.assets.get([account.prefix, assetId], tx)
   }
 
   async *loadAssets(account: Account, tx?: IDatabaseTransaction): AsyncGenerator<AssetValue> {
+    yield this.nativeAssetValue()
+
     for await (const asset of this.assets.getAllValuesIter(tx, account.prefixRange, {
       ordered: true,
     })) {
       yield asset
+    }
+  }
+
+  private nativeAssetValue(): AssetValue {
+    return {
+      createdTransactionHash: GENESIS_BLOCK_PREVIOUS,
+      id: Asset.nativeId(),
+      metadata: Buffer.from('Native asset of Iron Fish blockchain', 'utf8'),
+      name: Buffer.from('$IRON', 'utf8'),
+      nonce: 0,
+      creator: Buffer.from('Iron Fish', 'utf8'),
+      owner: Buffer.from('Iron Fish', 'utf8'),
+      blockHash: null,
+      sequence: null,
+      supply: null,
     }
   }
 


### PR DESCRIPTION
## Summary

The `wallet:assets` command does not show `$IRON` whether or not you have the native asset. This includes the asset in the streaming response.

## Testing Plan

Manually tested

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
