### PR TITLE
resets account heads and birthdays in reset command

### DIFF
--- a/ironfish-cli/src/commands/reset.ts
+++ b/ironfish-cli/src/commands/reset.ts
@@ -74,20 +74,17 @@ export default class Reset extends IronfishCommand {
       fsAsync.rm(hostFilePath, { recursive: true, force: true }),
     ])
 
+    let networkChanged = false
     if (flags.networkId != null && flags.networkId !== existingId) {
       this.sdk.internal.set('networkId', flags.networkId)
+      networkChanged = true
     }
     this.sdk.internal.set('isFirstRun', true)
     await this.sdk.internal.save()
 
     const node = await this.sdk.node()
-    const walletDb = node.wallet.walletDb
-
-    await walletDb.db.open()
-
-    for (const store of walletDb.cacheStores) {
-      await store.clear()
-    }
+    await node.wallet.open()
+    await node.wallet.reset({ resetCreatedAt: networkChanged })
 
     CliUx.ux.action.stop('Databases deleted successfully')
   }

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -359,15 +359,18 @@ export class Wallet {
     }
   }
 
-  async reset(): Promise<void> {
-    await this.resetAccounts()
+  async reset(options?: { resetCreatedAt?: boolean }): Promise<void> {
+    await this.resetAccounts(options)
 
     this.chainProcessor.hash = null
   }
 
-  private async resetAccounts(tx?: IDatabaseTransaction): Promise<void> {
+  private async resetAccounts(options?: {
+    tx?: IDatabaseTransaction
+    resetCreatedAt?: boolean
+  }): Promise<void> {
     for (const account of this.listAccounts()) {
-      await this.resetAccount(account, { tx })
+      await this.resetAccount(account, options)
     }
   }
 


### PR DESCRIPTION
## Summary

the 'ironfish reset' command deletes the chain database and most wallet datastores

however, it does not clear the 'heads' store. this prevents the wallet from starting the next time the node starts because the account head will reference a block that is missing from the chain

updates 'ironfish reset' to use 'wallet.reset' to reset all database stores, including the heads store

adds arguments to reset, resetAccounts to optionally reset the 'createdAt' field on each account

resets account 'createdAt' field in 'ironfish reset' if the command is used to change from one network to another because the createdAt field will reference a block on a different chain after changing networks

## Testing Plan

- manual testing:
  - used `ironfish reset --networkId=` to reset and change networks
  - used `ironfish start` to start the node

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
