### PR TITLE
Rahul/ifl 1604 spike v2 version of burnassets

### DIFF
--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -17,6 +17,8 @@ import {
   BroadcastTransactionResponse,
   BurnAssetRequest,
   BurnAssetResponse,
+  BurnAssetV2Request,
+  BurnAssetV2Response,
   CreateAccountRequest,
   CreateAccountResponse,
   CreateTransactionRequest,
@@ -404,6 +406,15 @@ export abstract class RpcClient {
       return this.request<void, GetNodeStatusResponse>(`${ApiNamespace.wallet}/getNodeStatus`, {
         stream: true,
       })
+    },
+  }
+
+  'v2/wallet' = {
+    burnAsset: (params: BurnAssetV2Request): Promise<RpcResponseEnded<BurnAssetV2Response>> => {
+      return this.request<BurnAssetV2Response>(
+        `${ApiNamespace.walletV2}/burnAsset`,
+        params,
+      ).waitForEnd()
     },
   }
 

--- a/ironfish/src/rpc/routes/index.ts
+++ b/ironfish/src/rpc/routes/index.ts
@@ -1,15 +1,16 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-export * from './wallet'
-export * from './config'
 export * from './chain'
+export * from './config'
 export * from './event'
+export * from './faucet'
+export * from './mempool'
+export * from './miner'
 export * from './node'
 export * from './peer'
 export * from './router'
 export * from './rpc'
-export * from './miner'
-export * from './faucet'
+export * from './v2/wallet'
+export * from './wallet'
 export * from './worker'
-export * from './mempool'

--- a/ironfish/src/rpc/routes/router.ts
+++ b/ironfish/src/rpc/routes/router.ts
@@ -18,8 +18,10 @@ export enum ApiNamespace {
   node = 'node',
   peer = 'peer',
   wallet = 'wallet',
+  walletV2 = 'v2/wallet',
   worker = 'worker',
   rpc = 'rpc',
+  v2 = 'v2',
   mempool = 'mempool',
 }
 

--- a/ironfish/src/rpc/routes/v2/wallet/burnAsset.test.ts
+++ b/ironfish/src/rpc/routes/v2/wallet/burnAsset.test.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
+import {
+  useAccountFixture,
+  useMinerBlockFixture,
+  useMintBlockFixture,
+  usePostTxFixture,
+} from '../../../../testUtilities'
+import { createRouteTest } from '../../../../testUtilities/routeTest'
+import { CurrencyUtils } from '../../../../utils'
+
+describe('Route wallet/burnAsset', () => {
+  const routeTest = createRouteTest(true)
+
+  beforeAll(async () => {
+    await routeTest.node.wallet.createAccount('account', { setDefault: true })
+  })
+
+  describe('with an invalid fee', () => {
+    it('throws a validation error', async () => {
+      await expect(
+        routeTest.client.wallet.burnAsset({
+          account: 'account',
+          assetId: '{ url: hello }',
+          fee: '0',
+          value: '100',
+        }),
+      ).rejects.toThrow(
+        'Request failed (400) validation: value must be equal to or greater than 1',
+      )
+    })
+  })
+
+  describe('with an invalid value', () => {
+    it('throws a validation error', async () => {
+      await expect(
+        routeTest.client.wallet.burnAsset({
+          account: 'account',
+          assetId: '{ url: hello }',
+          fee: '1',
+          value: '-1',
+        }),
+      ).rejects.toThrow(
+        'Request failed (400) validation: value must be equal to or greater than 1',
+      )
+    })
+  })
+
+  describe('with valid parameters', () => {
+    it('returns the asset identifier and transaction hash', async () => {
+      const node = routeTest.node
+      const wallet = node.wallet
+      const account = await useAccountFixture(wallet)
+
+      const block = await useMinerBlockFixture(routeTest.chain, undefined, account, node.wallet)
+      await expect(node.chain).toAddBlock(block)
+      await node.wallet.updateHead()
+
+      const asset = new Asset(account.publicAddress, 'mint-asset', 'metadata')
+      const assetId = asset.id()
+      const value = BigInt(10)
+      const mintBlock = await useMintBlockFixture({ node, account, asset, value })
+      await expect(node.chain).toAddBlock(mintBlock)
+      await node.wallet.updateHead()
+
+      const burnValue = BigInt(2)
+      const burnTransaction = await usePostTxFixture({
+        node: node,
+        wallet: node.wallet,
+        from: account,
+        burns: [{ assetId: asset.id(), value: burnValue }],
+      })
+      jest.spyOn(wallet, 'burn').mockResolvedValueOnce(burnTransaction)
+
+      const accountAsset = await account.getAsset(assetId)
+
+      expect(accountAsset).toBeDefined()
+
+      const response = await routeTest.client.wallet.burnAsset({
+        account: account.name,
+        assetId: assetId.toString('hex'),
+        fee: '1',
+        value: CurrencyUtils.encode(value),
+      })
+
+      expect(response.content).toEqual({
+        asset: {
+          id: asset.id().toString('hex'),
+          metadata: asset.metadata().toString('hex'),
+          name: asset.name().toString('hex'),
+          creator: asset.creator().toString('hex'),
+          nonce: accountAsset?.nonce ?? null,
+          owner: accountAsset?.owner?.toString('hex') ?? null,
+          sequence: accountAsset?.sequence ?? null,
+          supply: accountAsset?.supply?.toString() ?? null,
+          blockHash: accountAsset?.blockHash?.toString('hex') ?? null,
+          createdTransactionHash: accountAsset?.createdTransactionHash?.toString('hex') ?? null,
+        },
+        assetId: asset.id().toString('hex'),
+        name: asset.name().toString('hex'),
+        hash: burnTransaction.hash().toString('hex'),
+        value: burnTransaction.burns[0].value.toString(),
+      })
+    })
+  })
+})

--- a/ironfish/src/rpc/routes/v2/wallet/burnAsset.ts
+++ b/ironfish/src/rpc/routes/v2/wallet/burnAsset.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { Assert } from '../../../../assert'
+import { CurrencyUtils, YupUtils } from '../../../../utils'
+import { ApiNamespace, routes } from '../../router'
+import { getAccount } from '../../wallet/utils'
+import { RpcAsset, RpcAssetSchema } from './shared/types'
+
+export interface BurnAssetV2Request {
+  account: string
+  assetId: string
+  fee: string
+  value: string
+  expiration?: number
+  expirationDelta?: number
+  confirmations?: number
+}
+
+export interface BurnAssetV2Response {
+  asset: RpcAsset
+  hash: string
+  value: string
+}
+
+export const BurnAssetRequestSchema: yup.ObjectSchema<BurnAssetV2Request> = yup
+  .object({
+    account: yup.string().required(),
+    assetId: yup.string().required(),
+    fee: YupUtils.currency({ min: 1n }).defined(),
+    value: YupUtils.currency({ min: 1n }).defined(),
+    expiration: yup.number().optional(),
+    expirationDelta: yup.number().optional(),
+    confirmations: yup.number().optional(),
+  })
+  .defined()
+
+export const BurnAssetResponseSchema: yup.ObjectSchema<BurnAssetV2Response> = yup
+  .object({
+    asset: RpcAssetSchema.required(),
+    assetId: yup.string().required(),
+    hash: yup.string().required(),
+    name: yup.string().required(),
+    value: yup.string().required(),
+  })
+  .defined()
+
+routes.register<typeof BurnAssetRequestSchema, BurnAssetV2Response>(
+  `${ApiNamespace.wallet}/burnAsset`,
+  BurnAssetRequestSchema,
+  async (request, node): Promise<void> => {
+    const account = getAccount(node.wallet, request.data.account)
+
+    const fee = CurrencyUtils.decode(request.data.fee)
+    const value = CurrencyUtils.decode(request.data.value)
+
+    const assetId = Buffer.from(request.data.assetId, 'hex')
+    const asset = await account.getAsset(assetId)
+    Assert.isNotUndefined(asset)
+
+    const transaction = await node.wallet.burn(
+      account,
+      assetId,
+      value,
+      fee,
+      request.data.expirationDelta ?? node.config.get('transactionExpirationDelta'),
+      request.data.expiration,
+      request.data.confirmations,
+    )
+    Assert.isEqual(transaction.burns.length, 1)
+    const burn = transaction.burns[0]
+
+    request.end({
+      asset: {
+        id: asset.id.toString('hex'),
+        metadata: asset.metadata.toString('hex'),
+        name: asset.name.toString('hex'),
+        nonce: asset.nonce,
+        creator: asset.creator.toString('hex'),
+        owner: asset.owner.toString('hex'),
+        createdTransactionHash: asset.createdTransactionHash.toString('hex'),
+        supply: asset.supply?.toString(),
+        blockHash: asset.blockHash?.toString('hex'),
+        sequence: asset.sequence || undefined,
+      },
+      hash: transaction.hash().toString('hex'),
+      value: CurrencyUtils.encode(burn.value),
+    })
+  },
+)

--- a/ironfish/src/rpc/routes/v2/wallet/burnAsset.ts
+++ b/ironfish/src/rpc/routes/v2/wallet/burnAsset.ts
@@ -24,7 +24,7 @@ export interface BurnAssetV2Response {
   value: string
 }
 
-export const BurnAssetRequestSchema: yup.ObjectSchema<BurnAssetV2Request> = yup
+export const BurnAssetRequestV2Schema: yup.ObjectSchema<BurnAssetV2Request> = yup
   .object({
     account: yup.string().required(),
     assetId: yup.string().required(),
@@ -36,7 +36,7 @@ export const BurnAssetRequestSchema: yup.ObjectSchema<BurnAssetV2Request> = yup
   })
   .defined()
 
-export const BurnAssetResponseSchema: yup.ObjectSchema<BurnAssetV2Response> = yup
+export const BurnAssetResponseV2Schema: yup.ObjectSchema<BurnAssetV2Response> = yup
   .object({
     asset: RpcAssetSchema.required(),
     assetId: yup.string().required(),
@@ -46,9 +46,9 @@ export const BurnAssetResponseSchema: yup.ObjectSchema<BurnAssetV2Response> = yu
   })
   .defined()
 
-routes.register<typeof BurnAssetRequestSchema, BurnAssetV2Response>(
-  `${ApiNamespace.wallet}/burnAsset`,
-  BurnAssetRequestSchema,
+routes.register<typeof BurnAssetRequestV2Schema, BurnAssetV2Response>(
+  `${ApiNamespace.walletV2}/burnAsset`,
+  BurnAssetRequestV2Schema,
   async (request, node): Promise<void> => {
     const account = getAccount(node.wallet, request.data.account)
 

--- a/ironfish/src/rpc/routes/v2/wallet/index.ts
+++ b/ironfish/src/rpc/routes/v2/wallet/index.ts
@@ -1,0 +1,4 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export * from './burnAsset'

--- a/ironfish/src/rpc/routes/v2/wallet/shared/types.ts
+++ b/ironfish/src/rpc/routes/v2/wallet/shared/types.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+
+export interface RpcAsset {
+  id: string
+  metadata: string
+  name: string
+  nonce: number
+  creator: string
+  owner: string
+  createdTransactionHash: string
+  supply?: string // Populated for assets the account owns
+  blockHash?: string // Populated once the asset has been added to the main chain
+  sequence?: number // Populated once the asset has been added to the main chain
+}
+
+export const RpcAssetSchema: yup.ObjectSchema<RpcAsset> = yup
+  .object({
+    id: yup.string().required(),
+    metadata: yup.string().required(),
+    name: yup.string().required(),
+    nonce: yup.number().required(),
+    creator: yup.string().required(),
+    owner: yup.string().required(),
+    createdTransactionHash: yup.string().required(),
+    supply: yup.string().optional(),
+    blockHash: yup.string().optional(),
+    sequence: yup.number().optional(),
+  })
+  .defined()

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -316,6 +316,7 @@ Use 'ironfish config:set' to connect to a node via TCP, TLS, or IPC.\n`)
       ApiNamespace.config,
       ApiNamespace.faucet,
       ApiNamespace.rpc,
+      ApiNamespace.v2,
       ApiNamespace.wallet,
       ApiNamespace.worker,
       ApiNamespace.node,


### PR DESCRIPTION
## Summary

Adding a `v2` namespace for `wallet` endpoints. Added the burnAsset endpoint with the new response object format. 

New response object: 

<img width="1346" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/524599b9-acdd-417a-bab6-5dd9ce881ada">

Previous response object: 

<img width="1359" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/23f375b1-8773-4ebc-8ca7-703435ab04e4">

The value in this work is that whenever an asset is referenced, a consistent asset object is returned instead of the one off asset fields. 

## Testing Plan

Added unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
