### PR TITLE
feat: rust std::backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ repository = "https://github.com/iron-fish/ironfish"
 
 [patch.crates-io]
 bellman = { git = "https://github.com/iron-fish/bellman", rev = "1cc52ca33e6db14233f1cbc0c9c5b7c822b229ec" }
+
+[profile.release]
+debug = true

--- a/ironfish-rust/src/assets/asset.rs
+++ b/ironfish-rust/src/assets/asset.rs
@@ -1,7 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use crate::{errors::IronfishError, keys::PUBLIC_ADDRESS_SIZE, util::str_to_array, PublicAddress};
+use crate::{
+    errors::{IronfishError, IronfishErrorKind},
+    keys::PUBLIC_ADDRESS_SIZE,
+    util::str_to_array,
+    PublicAddress,
+};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use ironfish_zkp::constants::{ASSET_ID_LENGTH, ASSET_ID_PERSONALIZATION, GH_FIRST_BLOCK};
 use jubjub::{ExtendedPoint, SubgroupPoint};
@@ -39,7 +44,7 @@ impl Asset {
     pub fn new(creator: PublicAddress, name: &str, metadata: &str) -> Result<Asset, IronfishError> {
         let trimmed_name = name.trim();
         if trimmed_name.is_empty() {
-            return Err(IronfishError::InvalidData);
+            return Err(IronfishError::new(IronfishErrorKind::InvalidData));
         }
 
         let name_bytes = str_to_array(trimmed_name);
@@ -50,7 +55,9 @@ impl Asset {
             if let Ok(asset) = Asset::new_with_nonce(creator, name_bytes, metadata_bytes, nonce) {
                 return Ok(asset);
             }
-            nonce = nonce.checked_add(1).ok_or(IronfishError::RandomnessError)?;
+            nonce = nonce
+                .checked_add(1)
+                .ok_or_else(|| IronfishError::new(IronfishErrorKind::RandomnessError))?;
         }
     }
 

--- a/ironfish-rust/src/assets/asset_identifier.rs
+++ b/ironfish-rust/src/assets/asset_identifier.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use crate::errors::IronfishError;
+use crate::errors::{IronfishError, IronfishErrorKind};
 use group::cofactor::CofactorGroup;
 use ironfish_zkp::{constants::ASSET_ID_LENGTH, util::asset_hash_to_point};
 use jubjub::{ExtendedPoint, SubgroupPoint};
@@ -58,7 +58,9 @@ impl TryFrom<[u8; ASSET_ID_LENGTH]> for AssetIdentifier {
             return Ok(Self(byte_array));
         }
 
-        Err(IronfishError::InvalidAssetIdentifier)
+        Err(IronfishError::new(
+            IronfishErrorKind::InvalidAssetIdentifier,
+        ))
     }
 }
 

--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -38,12 +38,18 @@ pub enum IronfishErrorKind {
     InvalidEntropy,
     InvalidLanguageEncoding,
     InvalidMinersFeeTransaction,
+    InvalidMintProof,
+    InvalidMintSignature,
     InvalidMnemonicString,
     InvalidNonceLength,
     InvalidNullifierDerivingKey,
+    InvalidOutputProof,
     InvalidPaymentAddress,
     InvalidPublicAddress,
+    InvalidSignature,
     InvalidSigningKey,
+    InvalidSpendProof,
+    InvalidSpendSignature,
     InvalidTransaction,
     InvalidTransactionVersion,
     InvalidViewingKey,
@@ -53,7 +59,6 @@ pub enum IronfishErrorKind {
     RandomnessError,
     TryFromInt,
     Utf8,
-    VerificationFailed,
 }
 
 impl IronfishError {

--- a/ironfish-rust/src/keys/mod.rs
+++ b/ironfish-rust/src/keys/mod.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::errors::IronfishError;
+use crate::errors::{IronfishError, IronfishErrorKind};
 use crate::serializing::{bytes_to_hex, hex_to_bytes, read_scalar};
 
 pub use bip39::Language;
@@ -81,7 +81,7 @@ impl SaplingKey {
             jubjub::Fr::from_bytes_wide(&Self::convert_key(spending_key, 0));
 
         if spend_authorizing_key == jubjub::Fr::zero() {
-            return Err(IronfishError::IllegalValue);
+            return Err(IronfishError::new(IronfishErrorKind::IllegalValue));
         }
 
         let proof_authorizing_key =
@@ -123,7 +123,7 @@ impl SaplingKey {
     /// Load a key from a string of hexadecimal digits
     pub fn from_hex(value: &str) -> Result<Self, IronfishError> {
         match hex_to_bytes(value) {
-            Err(_) => Err(IronfishError::InvalidPaymentAddress),
+            Err(_) => Err(IronfishError::new(IronfishErrorKind::InvalidPaymentAddress)),
             Ok(bytes) => Self::new(bytes),
         }
     }
@@ -151,7 +151,7 @@ impl SaplingKey {
     pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), IronfishError> {
         let num_bytes_written = writer.write(&self.spending_key)?;
         if num_bytes_written != SPEND_KEY_SIZE {
-            return Err(IronfishError::InvalidData);
+            return Err(IronfishError::new(IronfishErrorKind::InvalidData));
         }
 
         Ok(())
@@ -176,13 +176,13 @@ impl SaplingKey {
     /// using bip-32 and bip-39 if desired.
     pub fn to_words(&self, language: Language) -> Result<Mnemonic, IronfishError> {
         Mnemonic::from_entropy(&self.spending_key, language)
-            .map_err(|_| IronfishError::InvalidEntropy)
+            .map_err(|_| IronfishError::new(IronfishErrorKind::InvalidEntropy))
     }
 
     /// Takes a bip-39 phrase as a string and turns it into a SaplingKey instance
     pub fn from_words(words: String, language: Language) -> Result<Self, IronfishError> {
         let mnemonic = Mnemonic::from_phrase(&words, language)
-            .map_err(|_| IronfishError::InvalidMnemonicString)?;
+            .map_err(|_| IronfishError::new(IronfishErrorKind::InvalidMnemonicString))?;
         let bytes = mnemonic.entropy();
         let mut byte_arr = [0; SPEND_KEY_SIZE];
         byte_arr.clone_from_slice(&bytes[0..SPEND_KEY_SIZE]);
@@ -261,7 +261,7 @@ impl SaplingKey {
         // Drop the last five bits, so it can be interpreted as a scalar.
         hash_result[31] &= 0b0000_0111;
         if hash_result == [0; 32] {
-            return Err(IronfishError::InvalidViewingKey);
+            return Err(IronfishError::new(IronfishErrorKind::InvalidViewingKey));
         }
         let scalar = read_scalar(&hash_result[..])?;
         Ok(scalar)

--- a/ironfish-rust/src/keys/public_address.rs
+++ b/ironfish-rust/src/keys/public_address.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    errors::IronfishError,
+    errors::{IronfishError, IronfishErrorKind},
     serializing::{bytes_to_hex, hex_to_bytes},
 };
 use group::GroupEncoding;
@@ -58,7 +58,7 @@ impl PublicAddress {
     /// or it fails.
     pub fn from_hex(value: &str) -> Result<Self, IronfishError> {
         match hex_to_bytes(value) {
-            Err(_) => Err(IronfishError::InvalidPublicAddress),
+            Err(_) => Err(IronfishError::new(IronfishErrorKind::InvalidPublicAddress)),
             Ok(bytes) => Self::new(&bytes),
         }
     }
@@ -90,7 +90,7 @@ impl PublicAddress {
         if transmission_key_non_prime.is_some().into() {
             Ok(transmission_key_non_prime.unwrap())
         } else {
-            Err(IronfishError::InvalidPaymentAddress)
+            Err(IronfishError::new(IronfishErrorKind::InvalidPaymentAddress))
         }
     }
 }

--- a/ironfish-rust/src/keys/view_keys.rs
+++ b/ironfish-rust/src/keys/view_keys.rs
@@ -14,7 +14,7 @@
 
 use super::PublicAddress;
 use crate::{
-    errors::IronfishError,
+    errors::{IronfishError, IronfishErrorKind},
     serializing::{bytes_to_hex, hex_to_bytes, read_scalar},
 };
 use bip39::{Language, Mnemonic};
@@ -44,7 +44,7 @@ impl IncomingViewKey {
     /// Load a key from a string of hexadecimal digits
     pub fn from_hex(value: &str) -> Result<Self, IronfishError> {
         match hex_to_bytes::<32>(value) {
-            Err(_) => Err(IronfishError::InvalidViewingKey),
+            Err(_) => Err(IronfishError::new(IronfishErrorKind::InvalidViewingKey)),
             Ok(bytes) => Self::read(&mut bytes.as_ref()),
         }
     }
@@ -52,9 +52,9 @@ impl IncomingViewKey {
     /// Load a key from a string of words to be decoded into bytes.
     pub fn from_words(language_code: &str, value: String) -> Result<Self, IronfishError> {
         let language = Language::from_language_code(language_code)
-            .ok_or(IronfishError::InvalidLanguageEncoding)?;
+            .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidLanguageEncoding))?;
         let mnemonic = Mnemonic::from_phrase(&value, language)
-            .map_err(|_| IronfishError::InvalidPaymentAddress)?;
+            .map_err(|_| IronfishError::new(IronfishErrorKind::InvalidPaymentAddress))?;
         let bytes = mnemonic.entropy();
         let mut byte_arr = [0; 32];
         byte_arr.clone_from_slice(&bytes[0..32]);
@@ -69,7 +69,7 @@ impl IncomingViewKey {
     /// Even more readable
     pub fn words_key(&self, language_code: &str) -> Result<String, IronfishError> {
         let language = Language::from_language_code(language_code)
-            .ok_or(IronfishError::InvalidLanguageEncoding)?;
+            .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidLanguageEncoding))?;
         let mnemonic = Mnemonic::from_entropy(&self.view_key.to_bytes(), language).unwrap();
         Ok(mnemonic.phrase().to_string())
     }
@@ -113,10 +113,11 @@ impl ViewKey {
         nullifier_deriving_key_bytes.clone_from_slice(&bytes[32..]);
 
         let authorizing_key = Option::from(SubgroupPoint::from_bytes(&authorizing_key_bytes))
-            .ok_or(IronfishError::InvalidAuthorizingKey)?;
-        let nullifier_deriving_key =
-            Option::from(SubgroupPoint::from_bytes(&nullifier_deriving_key_bytes))
-                .ok_or(IronfishError::InvalidNullifierDerivingKey)?;
+            .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidAuthorizingKey))?;
+        let nullifier_deriving_key = Option::from(SubgroupPoint::from_bytes(
+            &nullifier_deriving_key_bytes,
+        ))
+        .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidNullifierDerivingKey))?;
 
         Ok(Self {
             authorizing_key,
@@ -149,7 +150,7 @@ impl OutgoingViewKey {
     /// Load a key from a string of hexadecimal digits
     pub fn from_hex(value: &str) -> Result<Self, IronfishError> {
         match hex_to_bytes(value) {
-            Err(_) => Err(IronfishError::InvalidViewingKey),
+            Err(_) => Err(IronfishError::new(IronfishErrorKind::InvalidViewingKey)),
             Ok(bytes) => Ok(Self { view_key: bytes }),
         }
     }
@@ -157,9 +158,9 @@ impl OutgoingViewKey {
     /// Load a key from a string of words to be decoded into bytes.
     pub fn from_words(language_code: &str, value: String) -> Result<Self, IronfishError> {
         let language = Language::from_language_code(language_code)
-            .ok_or(IronfishError::InvalidLanguageEncoding)?;
+            .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidLanguageEncoding))?;
         let mnemonic = Mnemonic::from_phrase(&value, language)
-            .map_err(|_| IronfishError::InvalidPaymentAddress)?;
+            .map_err(|_| IronfishError::new(IronfishErrorKind::InvalidPaymentAddress))?;
         let bytes = mnemonic.entropy();
         let mut view_key = [0; 32];
         view_key.clone_from_slice(&bytes[0..32]);
@@ -174,7 +175,7 @@ impl OutgoingViewKey {
     /// Even more readable
     pub fn words_key(&self, language_code: &str) -> Result<String, IronfishError> {
         let language = Language::from_language_code(language_code)
-            .ok_or(IronfishError::InvalidLanguageEncoding)?;
+            .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidLanguageEncoding))?;
         let mnemonic = Mnemonic::from_entropy(&self.view_key, language).unwrap();
         Ok(mnemonic.phrase().to_string())
     }

--- a/ironfish-rust/src/nacl.rs
+++ b/ironfish-rust/src/nacl.rs
@@ -9,7 +9,7 @@ use crypto_box::{
 };
 use rand::RngCore;
 
-use crate::errors::IronfishError;
+use crate::errors::{IronfishError, IronfishErrorKind};
 
 pub const KEY_LENGTH: usize = crypto_box::KEY_SIZE;
 pub const NONCE_LENGTH: usize = 24;
@@ -57,7 +57,7 @@ pub fn unbox_message(
     recipient_secret_key: [u8; KEY_LENGTH],
 ) -> Result<String, IronfishError> {
     if nonce.len() != NONCE_LENGTH {
-        return Err(IronfishError::InvalidNonceLength);
+        return Err(IronfishError::new(IronfishErrorKind::InvalidNonceLength));
     }
 
     let nonce = GenericArray::from_slice(nonce);

--- a/ironfish-rust/src/note.rs
+++ b/ironfish-rust/src/note.rs
@@ -3,8 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    assets::asset_identifier::AssetIdentifier, errors::IronfishError, keys::PUBLIC_ADDRESS_SIZE,
-    util::str_to_array, ViewKey,
+    assets::asset_identifier::AssetIdentifier,
+    errors::{IronfishError, IronfishErrorKind},
+    keys::PUBLIC_ADDRESS_SIZE,
+    util::str_to_array,
+    ViewKey,
 };
 
 use super::{
@@ -330,7 +333,7 @@ impl<'a> Note {
         if commitment == self.commitment_point() {
             Ok(())
         } else {
-            Err(IronfishError::InvalidCommitment)
+            Err(IronfishError::new(IronfishErrorKind::InvalidCommitment))
         }
     }
 

--- a/ironfish-rust/src/serializing/aead.rs
+++ b/ironfish-rust/src/serializing/aead.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::errors::IronfishError;
+use crate::errors::{IronfishError, IronfishErrorKind};
 use chacha20poly1305::aead::{AeadInPlace, NewAead};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 
@@ -28,7 +28,7 @@ pub(crate) fn encrypt<const SIZE: usize>(
             &[],
             &mut encrypted_output[..plaintext.len()],
         )
-        .map_err(|_| IronfishError::InvalidSigningKey)?;
+        .map_err(|_| IronfishError::new(IronfishErrorKind::InvalidSigningKey))?;
     encrypted_output[plaintext.len()..].copy_from_slice(&tag);
 
     Ok(encrypted_output)
@@ -53,7 +53,7 @@ pub(crate) fn decrypt<const SIZE: usize>(
             &mut plaintext,
             ciphertext[SIZE..].into(),
         )
-        .map_err(|_| IronfishError::InvalidDecryptionKey)?;
+        .map_err(|_| IronfishError::new(IronfishErrorKind::InvalidDecryptionKey))?;
 
     Ok(plaintext)
 }

--- a/ironfish-rust/src/serializing/mod.rs
+++ b/ironfish-rust/src/serializing/mod.rs
@@ -4,7 +4,7 @@
 
 pub mod aead;
 
-use crate::errors::IronfishError;
+use crate::errors::{IronfishError, IronfishErrorKind};
 
 /// Helper functions to convert pairing parts to bytes
 ///
@@ -22,14 +22,16 @@ pub(crate) fn read_scalar<F: PrimeField, R: io::Read>(mut reader: R) -> Result<F
     let mut fr_repr = F::Repr::default();
     reader.read_exact(fr_repr.as_mut())?;
 
-    Option::from(F::from_repr(fr_repr)).ok_or(IronfishError::InvalidData)
+    Option::from(F::from_repr(fr_repr))
+        .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidData))
 }
 
 pub(crate) fn read_point<G: GroupEncoding, R: io::Read>(mut reader: R) -> Result<G, IronfishError> {
     let mut point_repr = G::Repr::default();
     reader.read_exact(point_repr.as_mut())?;
 
-    Option::from(G::from_bytes(&point_repr)).ok_or(IronfishError::InvalidData)
+    Option::from(G::from_bytes(&point_repr))
+        .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidData))
 }
 
 /// Output the bytes as a hexadecimal String
@@ -47,7 +49,7 @@ pub fn bytes_to_hex(bytes: &[u8]) -> String {
 /// Output the hexadecimal String as bytes
 pub fn hex_to_bytes<const SIZE: usize>(hex: &str) -> Result<[u8; SIZE], IronfishError> {
     if hex.len() != SIZE * 2 {
-        return Err(IronfishError::InvalidData);
+        return Err(IronfishError::new(IronfishErrorKind::InvalidData));
     }
 
     let mut bytes = [0; SIZE];
@@ -67,7 +69,7 @@ fn hex_to_u8(char: u8) -> Result<u8, IronfishError> {
         b'0'..=b'9' => Ok(char - b'0'),
         b'a'..=b'f' => Ok(char - b'a' + 10),
         b'A'..=b'F' => Ok(char - b'A' + 10),
-        _ => Err(IronfishError::InvalidData),
+        _ => Err(IronfishError::new(IronfishErrorKind::InvalidData)),
     }
 }
 

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -188,7 +188,7 @@ impl MintDescription {
             &self.authorizing_signature,
             *SPENDING_KEY_GENERATOR,
         ) {
-            return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
+            return Err(IronfishError::new(IronfishErrorKind::InvalidMintSignature));
         }
 
         Ok(())
@@ -321,6 +321,7 @@ mod test {
 
     use crate::{
         assets::asset::Asset,
+        errors::IronfishErrorKind,
         transaction::{
             mints::{MintBuilder, MintDescription},
             utils::verify_mint_proof,
@@ -406,7 +407,7 @@ mod test {
 
         assert!(matches!(
             mint.build(&owner_key, &public_key_randomness, &randomized_public_key),
-            Err(_)
+            Err(e) if matches!(e.kind, IronfishErrorKind::InvalidMintProof)
         ))
     }
 

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -18,8 +18,11 @@ use jubjub::ExtendedPoint;
 use rand::thread_rng;
 
 use crate::{
-    assets::asset::Asset, errors::IronfishError, sapling_bls12::SAPLING,
-    transaction::TransactionVersion, PublicAddress, SaplingKey,
+    assets::asset::Asset,
+    errors::{IronfishError, IronfishErrorKind},
+    sapling_bls12::SAPLING,
+    transaction::TransactionVersion,
+    PublicAddress, SaplingKey,
 };
 
 use super::utils::verify_mint_proof;
@@ -121,7 +124,7 @@ impl UnsignedMintDescription {
                 .randomize(self.public_key_randomness, *SPENDING_KEY_GENERATOR);
 
         if randomized_public_key.0 != transaction_randomized_public_key.0 {
-            return Err(IronfishError::InvalidSigningKey);
+            return Err(IronfishError::new(IronfishErrorKind::InvalidSigningKey));
         }
 
         let mut data_to_be_signed = [0; 64];
@@ -174,7 +177,7 @@ impl MintDescription {
         randomized_public_key: &redjubjub::PublicKey,
     ) -> Result<(), IronfishError> {
         if randomized_public_key.0.is_small_order().into() {
-            return Err(IronfishError::IsSmallOrder);
+            return Err(IronfishError::new(IronfishErrorKind::IsSmallOrder));
         }
         let mut data_to_be_signed = [0; 64];
         data_to_be_signed[..32].copy_from_slice(&randomized_public_key.0.to_bytes());
@@ -185,7 +188,7 @@ impl MintDescription {
             &self.authorizing_signature,
             *SPENDING_KEY_GENERATOR,
         ) {
-            return Err(IronfishError::VerificationFailed);
+            return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
         }
 
         Ok(())
@@ -224,7 +227,9 @@ impl MintDescription {
             self.asset.nonce,
         )?;
         if asset.id != self.asset.id {
-            return Err(IronfishError::InvalidAssetIdentifier);
+            return Err(IronfishError::new(
+                IronfishErrorKind::InvalidAssetIdentifier,
+            ));
         }
 
         Ok(())
@@ -253,7 +258,9 @@ impl MintDescription {
                 writer.write_u8(0)?;
             }
         } else if self.transfer_ownership_to.is_some() {
-            return Err(IronfishError::InvalidTransactionVersion);
+            return Err(IronfishError::new(
+                IronfishErrorKind::InvalidTransactionVersion,
+            ));
         }
 
         Ok(())
@@ -314,7 +321,6 @@ mod test {
 
     use crate::{
         assets::asset::Asset,
-        errors::IronfishError,
         transaction::{
             mints::{MintBuilder, MintDescription},
             utils::verify_mint_proof,
@@ -400,7 +406,7 @@ mod test {
 
         assert!(matches!(
             mint.build(&owner_key, &public_key_randomness, &randomized_public_key),
-            Err(IronfishError::VerificationFailed)
+            Err(_)
         ))
     }
 

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         asset::Asset,
         asset_identifier::{AssetIdentifier, NATIVE_ASSET},
     },
-    errors::IronfishError,
+    errors::{IronfishError, IronfishErrorKind},
     keys::{PublicAddress, SaplingKey},
     note::Note,
     sapling_bls12::SAPLING,
@@ -218,7 +218,7 @@ impl ProposedTransaction {
             };
 
             if change_amount < 0 {
-                return Err(IronfishError::InvalidBalance);
+                return Err(IronfishError::new(IronfishErrorKind::InvalidBalance));
             }
             if change_amount > 0 {
                 let change_address =
@@ -253,7 +253,9 @@ impl ProposedTransaction {
             || !self.mints.is_empty()
             || !self.burns.is_empty()
         {
-            return Err(IronfishError::InvalidMinersFeeTransaction);
+            return Err(IronfishError::new(
+                IronfishErrorKind::InvalidMinersFeeTransaction,
+            ));
         }
         self.post_miners_fee_unchecked()
     }
@@ -470,7 +472,7 @@ impl ProposedTransaction {
         // the final value balance point. The binding verification key is how verifiers
         // check the consistency of the values in a transaction.
         if value_balance != public_key.0 {
-            return Err(IronfishError::InvalidBalance);
+            return Err(IronfishError::new(IronfishErrorKind::InvalidBalance));
         }
 
         Ok((private_key, public_key))
@@ -722,7 +724,7 @@ impl Transaction {
             &self.binding_signature,
             *VALUE_COMMITMENT_RANDOMNESS_GENERATOR,
         ) {
-            return Err(IronfishError::VerificationFailed);
+            return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
         }
 
         Ok(())
@@ -737,7 +739,7 @@ fn fee_to_point(value: i64) -> Result<ExtendedPoint, IronfishError> {
     let is_negative = value.is_negative();
     let abs = match value.checked_abs() {
         Some(a) => a as u64,
-        None => return Err(IronfishError::IllegalValue),
+        None => return Err(IronfishError::new(IronfishErrorKind::IllegalValue)),
     };
 
     let mut value_balance = *NATIVE_VALUE_COMMITMENT_GENERATOR * jubjub::Fr::from(abs);
@@ -861,7 +863,7 @@ fn internal_batch_verify_transactions<'a>(
             &spend_public_inputs[..],
         )?
     {
-        return Err(IronfishError::VerificationFailed);
+        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
     }
     if !output_proofs.is_empty()
         && !verify_proofs_batch(
@@ -871,7 +873,7 @@ fn internal_batch_verify_transactions<'a>(
             &output_public_inputs[..],
         )?
     {
-        return Err(IronfishError::VerificationFailed);
+        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
     }
     if !mint_proofs.is_empty()
         && !verify_proofs_batch(
@@ -881,7 +883,7 @@ fn internal_batch_verify_transactions<'a>(
             &mint_public_inputs[..],
         )?
     {
-        return Err(IronfishError::VerificationFailed);
+        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
     }
 
     Ok(())

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -724,7 +724,7 @@ impl Transaction {
             &self.binding_signature,
             *VALUE_COMMITMENT_RANDOMNESS_GENERATOR,
         ) {
-            return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
+            return Err(IronfishError::new(IronfishErrorKind::InvalidSignature));
         }
 
         Ok(())
@@ -863,7 +863,7 @@ fn internal_batch_verify_transactions<'a>(
             &spend_public_inputs[..],
         )?
     {
-        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
+        return Err(IronfishError::new(IronfishErrorKind::InvalidSpendProof));
     }
     if !output_proofs.is_empty()
         && !verify_proofs_batch(
@@ -873,7 +873,7 @@ fn internal_batch_verify_transactions<'a>(
             &output_public_inputs[..],
         )?
     {
-        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
+        return Err(IronfishError::new(IronfishErrorKind::InvalidOutputProof));
     }
     if !mint_proofs.is_empty()
         && !verify_proofs_batch(
@@ -883,7 +883,7 @@ fn internal_batch_verify_transactions<'a>(
             &mint_public_inputs[..],
         )?
     {
-        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
+        return Err(IronfishError::new(IronfishErrorKind::InvalidOutputProof));
     }
 
     Ok(())

--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    errors::IronfishError,
+    errors::{IronfishError, IronfishErrorKind},
     keys::{EphemeralKeyPair, SaplingKey},
     merkle_note::MerkleNote,
     note::Note,
@@ -166,7 +166,7 @@ impl OutputDescription {
                 .is_small_order()
                 .into()
         {
-            return Err(IronfishError::IsSmallOrder);
+            return Err(IronfishError::new(IronfishErrorKind::IsSmallOrder));
         }
 
         Ok(())

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -286,7 +286,7 @@ impl SpendDescription {
             &self.authorizing_signature,
             *SPENDING_KEY_GENERATOR,
         ) {
-            return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
+            return Err(IronfishError::new(IronfishErrorKind::InvalidSpendSignature));
         }
 
         Ok(())

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    errors::IronfishError,
+    errors::{IronfishError, IronfishErrorKind},
     keys::SaplingKey,
     merkle_note::{position as witness_position, sapling_auth_path},
     note::Note,
@@ -171,7 +171,7 @@ impl UnsignedSpendDescription {
                 .randomize(self.public_key_randomness, *SPENDING_KEY_GENERATOR);
 
         if randomized_public_key.0 != transaction_randomized_public_key.0 {
-            return Err(IronfishError::InvalidSigningKey);
+            return Err(IronfishError::new(IronfishErrorKind::InvalidSigningKey));
         }
 
         let mut data_to_be_signed = [0; 64];
@@ -275,7 +275,7 @@ impl SpendDescription {
         randomized_public_key: &redjubjub::PublicKey,
     ) -> Result<(), IronfishError> {
         if randomized_public_key.0.is_small_order().into() {
-            return Err(IronfishError::IsSmallOrder);
+            return Err(IronfishError::new(IronfishErrorKind::IsSmallOrder));
         }
         let mut data_to_be_signed = [0; 64];
         data_to_be_signed[..32].copy_from_slice(&randomized_public_key.0.to_bytes());
@@ -286,7 +286,7 @@ impl SpendDescription {
             &self.authorizing_signature,
             *SPENDING_KEY_GENERATOR,
         ) {
-            return Err(IronfishError::VerificationFailed);
+            return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
         }
 
         Ok(())
@@ -305,7 +305,7 @@ impl SpendDescription {
 
     fn verify_not_small_order(&self) -> Result<(), IronfishError> {
         if self.value_commitment.is_small_order().into() {
-            return Err(IronfishError::IsSmallOrder);
+            return Err(IronfishError::new(IronfishErrorKind::IsSmallOrder));
         }
 
         Ok(())

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -7,7 +7,7 @@ use super::internal_batch_verify_transactions;
 use super::{ProposedTransaction, Transaction};
 use crate::{
     assets::{asset::Asset, asset_identifier::NATIVE_ASSET},
-    errors::IronfishError,
+    errors::{IronfishError, IronfishErrorKind},
     keys::SaplingKey,
     merkle_note::NOTE_ENCRYPTION_MINER_KEYS,
     note::Note,
@@ -310,8 +310,12 @@ fn test_transaction_version_is_checked() {
     fn assert_invalid_version(result: Result<Transaction, IronfishError>) {
         match result {
             Ok(_) => panic!("expected an error"),
-            Err(IronfishError::InvalidTransactionVersion) => (),
-            Err(ref err) => panic!("expected InvalidTransactionVersion, got {:?} instead", err),
+            Err(IronfishError { kind, .. }) => match kind {
+                IronfishErrorKind::InvalidTransactionVersion => {}
+                _ => {
+                    panic!("expected InvalidTransactionVersion, got {:?} instead", kind);
+                }
+            },
         }
     }
 
@@ -583,7 +587,7 @@ fn test_batch_verify() {
 
     assert!(matches!(
         batch_verify_transactions([&bad_transaction, &transaction2]),
-        Err(IronfishError::VerificationFailed)
+        Err(_)
     ));
 
     let mut bad_transaction = transaction1.clone();
@@ -591,7 +595,7 @@ fn test_batch_verify() {
 
     assert!(matches!(
         batch_verify_transactions([&bad_transaction, &transaction2]),
-        Err(IronfishError::VerificationFailed)
+        Err(_)
     ));
 
     let mut bad_transaction = transaction1.clone();
@@ -599,7 +603,7 @@ fn test_batch_verify() {
 
     assert!(matches!(
         batch_verify_transactions([&bad_transaction, &transaction2]),
-        Err(IronfishError::VerificationFailed)
+        Err(_)
     ));
 
     let mut bad_transaction = transaction1;
@@ -607,6 +611,6 @@ fn test_batch_verify() {
 
     assert!(matches!(
         batch_verify_transactions([&bad_transaction, &transaction2]),
-        Err(IronfishError::VerificationFailed)
+        Err(_)
     ));
 }

--- a/ironfish-rust/src/transaction/utils.rs
+++ b/ironfish-rust/src/transaction/utils.rs
@@ -4,7 +4,10 @@
 use bellperson::groth16;
 use blstrs::Bls12;
 
-use crate::{errors::IronfishError, sapling_bls12::SAPLING};
+use crate::{
+    errors::{IronfishError, IronfishErrorKind},
+    sapling_bls12::SAPLING,
+};
 
 /// Helper function for verifying spend proof internally. Note that this is not
 /// called by verifiers as part of transaction verification. See
@@ -14,7 +17,7 @@ pub(crate) fn verify_spend_proof(
     inputs: &[blstrs::Scalar],
 ) -> Result<(), IronfishError> {
     if !groth16::verify_proof(&SAPLING.spend_verifying_key, proof, inputs)? {
-        return Err(IronfishError::VerificationFailed);
+        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
     }
 
     Ok(())
@@ -28,7 +31,7 @@ pub(crate) fn verify_output_proof(
     inputs: &[blstrs::Scalar],
 ) -> Result<(), IronfishError> {
     if !groth16::verify_proof(&SAPLING.output_verifying_key, proof, inputs)? {
-        return Err(IronfishError::VerificationFailed);
+        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
     }
 
     Ok(())
@@ -42,7 +45,7 @@ pub(crate) fn verify_mint_proof(
     inputs: &[blstrs::Scalar],
 ) -> Result<(), IronfishError> {
     if !groth16::verify_proof(&SAPLING.mint_verifying_key, proof, inputs)? {
-        return Err(IronfishError::VerificationFailed);
+        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
     }
 
     Ok(())

--- a/ironfish-rust/src/transaction/utils.rs
+++ b/ironfish-rust/src/transaction/utils.rs
@@ -17,7 +17,7 @@ pub(crate) fn verify_spend_proof(
     inputs: &[blstrs::Scalar],
 ) -> Result<(), IronfishError> {
     if !groth16::verify_proof(&SAPLING.spend_verifying_key, proof, inputs)? {
-        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
+        return Err(IronfishError::new(IronfishErrorKind::InvalidSpendProof));
     }
 
     Ok(())
@@ -31,7 +31,7 @@ pub(crate) fn verify_output_proof(
     inputs: &[blstrs::Scalar],
 ) -> Result<(), IronfishError> {
     if !groth16::verify_proof(&SAPLING.output_verifying_key, proof, inputs)? {
-        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
+        return Err(IronfishError::new(IronfishErrorKind::InvalidOutputProof));
     }
 
     Ok(())
@@ -45,7 +45,7 @@ pub(crate) fn verify_mint_proof(
     inputs: &[blstrs::Scalar],
 ) -> Result<(), IronfishError> {
     if !groth16::verify_proof(&SAPLING.mint_verifying_key, proof, inputs)? {
-        return Err(IronfishError::new(IronfishErrorKind::VerificationFailed));
+        return Err(IronfishError::new(IronfishErrorKind::InvalidMintProof));
     }
 
     Ok(())

--- a/ironfish-rust/src/transaction/value_balances.rs
+++ b/ironfish-rust/src/transaction/value_balances.rs
@@ -5,7 +5,7 @@ use std::collections::{hash_map, HashMap};
 
 use crate::{
     assets::asset_identifier::{AssetIdentifier, NATIVE_ASSET},
-    errors::IronfishError,
+    errors::{IronfishError, IronfishErrorKind},
 };
 
 pub struct ValueBalances {
@@ -25,7 +25,7 @@ impl ValueBalances {
         let current_value = self.values.entry(*asset_id).or_insert(0);
         let new_value = current_value
             .checked_add(value)
-            .ok_or(IronfishError::InvalidBalance)?;
+            .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidBalance))?;
 
         *current_value = new_value;
 
@@ -40,7 +40,7 @@ impl ValueBalances {
         let current_value = self.values.entry(*asset_id).or_insert(0);
         let new_value = current_value
             .checked_sub(value)
-            .ok_or(IronfishError::InvalidBalance)?;
+            .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidBalance))?;
 
         *current_value = new_value;
 

--- a/ironfish-rust/src/transaction/version.rs
+++ b/ironfish-rust/src/transaction/version.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::errors::IronfishError;
+use crate::errors::{IronfishError, IronfishErrorKind};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::io;
 
@@ -60,7 +60,8 @@ impl TryFrom<u8> for TransactionVersion {
 
     #[inline]
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Self::from_u8(value).ok_or(IronfishError::InvalidTransactionVersion)
+        Self::from_u8(value)
+            .ok_or_else(|| IronfishError::new(IronfishErrorKind::InvalidTransactionVersion))
     }
 }
 


### PR DESCRIPTION
## Summary

Currently we have no backtrace when an error occurs in rust. This makes debugging in javascript and `ironfish-rust-nodejs` very challenging. This PR uses `std::backtrace` to include backtrace info into the returned error information.

If we include debug info with our profile:
```
RUST_BACKTRACE=1 yarn test:slow                                                                                                                                                                     yarn run v1.22.19
$ jest --testPathIgnorePatterns --testMatch "**/*.test.slow.ts"
 FAIL   @ironfish/rust-nodejs  tests/demo.test.slow.ts
  ● Demonstrate the Sapling API › Should create a standard transaction

    InvalidBalance
    Backtrace:
       0: std::backtrace_rs::backtrace::libunwind::trace

      at ../../../../../rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/backtrace/src/backtrace/libunwind.rs:93:5
         1: std::backtrace_rs::backtrace::trace_unsynchronized
      at ../../../../../rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/backtrace/src/backtrace/mod.rs:66:5
         2: std::backtrace::Backtrace::create
      at ../../../../../rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/backtrace.rs:332:13
         3: ironfish::errors::IronfishError::new
      at ../ironfish-rust/src/errors.rs:61:24
         4: ironfish::transaction::ProposedTransaction::post
      at ../ironfish-rust/src/transaction/mod.rs:221:28
      5: ironfish_rust_nodejs::structs::transaction::NativeTransaction::post
      at src/structs/transaction.rs:293:34
      6: ironfish_rust_nodejs::structs::transaction::__napi_impl_helper__NativeTransaction__8::__napi__post::{{closure}}::{{closure}}
      at src/structs/transaction.rs:167:1
         7: napi::bindgen_prelude::within_runtime_if_available
      at ../../../.cargo/registry/src/github.com-1ecc6299db9ec823/napi-2.13.2/src/lib.rs:171:5
      8: ironfish_rust_nodejs::structs::transaction::__napi_impl_helper__NativeTransaction__8::__napi__post::{{closure}}
      at src/structs/transaction.rs:167:1
         9: core::result::Result<T,E>::and_then
      at ../../../../../rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/result.rs:1372:22
      10: ironfish_rust_nodejs::structs::transaction::__napi_impl_helper__NativeTransaction__8::__napi__post
      at src/structs/transaction.rs:167:1
      at Object.<anonymous> (tests/demo.test.slow.ts:131:65)

 PASS   @ironfish/rust-nodejs  tests/transaction.test.slow.ts

Test Suites: 1 failed, 1 passed, 2 total
Tests:       1 failed, 8 passed, 9 total
Snapshots:   0 total
Time:        3.774 s, estimated 4 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

If we don't include debug for our release profile:
```
RUST_BACKTRACE=1 yarn test:slow
yarn run v1.22.19
$ jest --testPathIgnorePatterns --testMatch "**/*.test.slow.ts"
 FAIL   @ironfish/rust-nodejs  tests/demo.test.slow.ts
  ● Demonstrate the Sapling API › Should create a standard transaction

    InvalidBalance
    Backtrace:
       0: std::backtrace_rs::backtrace::libunwind::trace

      at ../../../../../rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/backtrace/src/backtrace/libunwind.rs:93:5
         1: std::backtrace_rs::backtrace::trace_unsynchronized
      at ../../../../../rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/backtrace/src/backtrace/mod.rs:66:5
         2: std::backtrace::Backtrace::create
      at ../../../../../rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/backtrace.rs:332:13
         3: ironfish::transaction::ProposedTransaction::post
      4: ironfish_rust_nodejs::structs::transaction::NativeTransaction::post
      5: ironfish_rust_nodejs::structs::transaction::__napi_impl_helper__NativeTransaction__8::__napi__post
      at Object.<anonymous> (tests/demo.test.slow.ts:131:65)
```

If RUST_BACKTRACE isn't set:
```
yarn test:slow
yarn run v1.22.19
$ jest --testPathIgnorePatterns --testMatch "**/*.test.slow.ts"
 FAIL   @ironfish/rust-nodejs  tests/demo.test.slow.ts
  ● Demonstrate the Sapling API › Should create a standard transaction

    InvalidBalance
    To enable Rust backtraces, use RUST_BACKTRACE=1

      129 |     transaction.output(newNote)
      130 |
    > 131 |     const postedTransaction = new TransactionPosted(transaction.post(key.publicAddress, 100n))
          |                                                                 ^
      132 |
      133 |     expect(postedTransaction.expiration()).toEqual(10)
      134 |     expect(postedTransaction.fee()).toEqual(5n)

      at Object.<anonymous> (tests/demo.test.slow.ts:131:65)

 PASS   @ironfish/rust-nodejs  tests/transaction.test.slow.ts
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
