### PR TITLE
Add (de)serialization for `Asset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hex-literal-impl"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1346,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "hex",
+ "hex-literal 0.4.1",
  "ironfish_zkp",
  "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
  "lazy_static",
@@ -1385,7 +1392,7 @@ version = "0.2.0"
 dependencies = [
  "blake2",
  "byteorder",
- "hex-literal",
+ "hex-literal 0.1.4",
  "ironfish-phase2",
  "ironfish_zkp",
  "pairing 0.23.0",

--- a/ironfish-rust/Cargo.toml
+++ b/ironfish-rust/Cargo.toml
@@ -50,6 +50,9 @@ rand = "0.8.5"
 tiny-bip39 = "0.8"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
 
+[dev-dependencies]
+hex-literal = "0.4"
+
 [build-dependencies]
 hex = "0.4"
 reqwest = { optional = true, version = "0.11", features = ["blocking"] }


### PR DESCRIPTION
## Summary

Add a simple test to check that the serialization/deserialization for `Asset` in Rust works correctly.

## Testing Plan

## Documentation

No doc changes required.

## Breaking Change

Not a breaking change.