### PR TITLE
Make activation flag nullable

### DIFF
--- a/ironfish/src/consensus/consensus.test.ts
+++ b/ironfish/src/consensus/consensus.test.ts
@@ -55,4 +55,18 @@ describe('Consensus', () => {
     expect(consensus.getActiveTransactionVersion(7)).toEqual(TransactionVersion.V2)
     expect(consensus.getActiveTransactionVersion(8)).toEqual(TransactionVersion.V2)
   })
+
+  it('when activation flag is null', () => {
+    consensus = new Consensus({
+      allowedBlockFutureSeconds: 1,
+      genesisSupplyInIron: 2,
+      targetBlockTimeInSeconds: 3,
+      targetBucketTimeInSeconds: 4,
+      maxBlockSizeBytes: 5,
+      minFee: 6,
+      enableAssetOwnership: null,
+    })
+    expect(consensus.getActiveTransactionVersion(5)).toEqual(TransactionVersion.V1)
+    expect(consensus.isActive(consensus.parameters.enableAssetOwnership, 3)).toBe(false)
+  })
 })

--- a/ironfish/src/consensus/consensus.test.ts
+++ b/ironfish/src/consensus/consensus.test.ts
@@ -64,7 +64,7 @@ describe('Consensus', () => {
       targetBucketTimeInSeconds: 4,
       maxBlockSizeBytes: 5,
       minFee: 6,
-      enableAssetOwnership: null,
+      enableAssetOwnership: 'never',
     })
     expect(consensus.getActiveTransactionVersion(5)).toEqual(TransactionVersion.V1)
     expect(consensus.isActive(consensus.parameters.enableAssetOwnership, 3)).toBe(false)

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -39,7 +39,7 @@ export type ConsensusParameters = {
   /**
    * The block height that enables the use of V2 transactions instead of V1
    */
-  enableAssetOwnership: number
+  enableAssetOwnership: number | null
 }
 
 export class Consensus {
@@ -49,7 +49,10 @@ export class Consensus {
     this.parameters = parameters
   }
 
-  isActive(upgrade: number, sequence: number): boolean {
+  isActive(upgrade: number | null, sequence: number): boolean {
+    if (upgrade === null) {
+      return false
+    }
     return Math.max(1, sequence) >= upgrade
   }
 

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -4,6 +4,8 @@
 
 import { TransactionVersion } from '../primitives/transaction'
 
+export type ActivationSequence = number | 'never'
+
 export type ConsensusParameters = {
   /**
    * When adding a block, the block can be this amount of seconds into the future
@@ -39,7 +41,7 @@ export type ConsensusParameters = {
   /**
    * The block height that enables the use of V2 transactions instead of V1
    */
-  enableAssetOwnership: number | null
+  enableAssetOwnership: ActivationSequence
 }
 
 export class Consensus {
@@ -49,8 +51,8 @@ export class Consensus {
     this.parameters = parameters
   }
 
-  isActive(upgrade: number | null, sequence: number): boolean {
-    if (upgrade === null) {
+  isActive(upgrade: ActivationSequence, sequence: number): boolean {
+    if (upgrade === 'never') {
       return false
     }
     return Math.max(1, sequence) >= upgrade

--- a/ironfish/src/networkDefinition.ts
+++ b/ironfish/src/networkDefinition.ts
@@ -47,7 +47,7 @@ export const networkDefinitionSchema: yup.ObjectSchema<NetworkDefinition> = yup
         targetBucketTimeInSeconds: yup.number().integer().defined(),
         maxBlockSizeBytes: yup.number().integer().defined(),
         minFee: yup.number().integer().defined(),
-        enableAssetOwnership: yup.number().integer().defined(),
+        enableAssetOwnership: yup.number().integer().nullable().defined(),
       })
       .defined(),
   })

--- a/ironfish/src/networkDefinition.ts
+++ b/ironfish/src/networkDefinition.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { ConsensusParameters } from './consensus'
+import { ActivationSequence, ConsensusParameters } from './consensus'
 import { DEVNET, isDefaultNetworkId, MAINNET, TESTNET } from './defaultNetworkDefinitions'
 import { Config, InternalStore } from './fileStores'
 import { FileSystem } from './fileSystems'
@@ -47,7 +47,7 @@ export const networkDefinitionSchema: yup.ObjectSchema<NetworkDefinition> = yup
         targetBucketTimeInSeconds: yup.number().integer().defined(),
         maxBlockSizeBytes: yup.number().integer().defined(),
         minFee: yup.number().integer().defined(),
-        enableAssetOwnership: yup.number().integer().nullable().defined(),
+        enableAssetOwnership: yup.mixed<ActivationSequence>().defined(),
       })
       .defined(),
   })

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -261,14 +261,14 @@ describe('Demonstrate the Sapling API', () => {
       })
       const minersFee1 = await strategy.createMinersFee(
         0n,
-        consensusParameters.enableAssetOwnership - 1,
+        consensusParameters.enableAssetOwnership || 1 - 1,
         key.spendingKey,
       )
       expect(minersFee1.version()).toEqual(TransactionVersion.V1)
 
       const minersFee2 = await strategy.createMinersFee(
         0n,
-        consensusParameters.enableAssetOwnership,
+        consensusParameters.enableAssetOwnership || 1,
         key.spendingKey,
       )
       expect(minersFee2.version()).toEqual(TransactionVersion.V2)

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -261,7 +261,7 @@ describe('Demonstrate the Sapling API', () => {
       })
       const minersFee1 = await strategy.createMinersFee(
         0n,
-        consensusParameters.enableAssetOwnership || 1 - 1,
+        (consensusParameters.enableAssetOwnership || 1) - 1,
         key.spendingKey,
       )
       expect(minersFee1.version()).toEqual(TransactionVersion.V1)

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -11,6 +11,7 @@ import {
   Transaction as NativeTransaction,
   TransactionPosted as NativeTransactionPosted,
 } from '@ironfish/rust-nodejs'
+import { Assert } from './assert'
 import { ConsensusParameters, TestnetConsensus } from './consensus'
 import { MerkleTree } from './merkletree'
 import { LeafEncoding } from './merkletree/database/leaves'
@@ -259,16 +260,19 @@ describe('Demonstrate the Sapling API', () => {
         workerPool,
         consensus: new TestnetConsensus(modifiedParams),
       })
+
+      Assert.isTrue(typeof consensusParameters.enableAssetOwnership === 'number')
+      const enableAssetOwnershipSequence = Number(consensusParameters.enableAssetOwnership)
       const minersFee1 = await strategy.createMinersFee(
         0n,
-        (consensusParameters.enableAssetOwnership || 1) - 1,
+        enableAssetOwnershipSequence - 1,
         key.spendingKey,
       )
       expect(minersFee1.version()).toEqual(TransactionVersion.V1)
 
       const minersFee2 = await strategy.createMinersFee(
         0n,
-        consensusParameters.enableAssetOwnership || 1,
+        enableAssetOwnershipSequence,
         key.spendingKey,
       )
       expect(minersFee2.version()).toEqual(TransactionVersion.V2)


### PR DESCRIPTION
## Summary
Existing consensus activation flag has type of number, the issue is before a block sequence is picked for the activation we need to have a fake placeholder for the activation block sequence. 
This PR make the flag type nullable, so we can leave the block sequence as null before we decide on the actual sequence.

## Testing Plan
unit test
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@mat-if @andreacorbellini 