### PR TITLE
Add transferOwnershipTo support to CLI/RPC

### DIFF
--- a/ironfish-cli/src/commands/chain/asset.ts
+++ b/ironfish-cli/src/commands/chain/asset.ts
@@ -32,6 +32,7 @@ export default class Asset extends IronfishCommand {
     this.log(`Name: ${BufferUtils.toHuman(Buffer.from(data.content.name, 'hex'))}`)
     this.log(`Metadata: ${BufferUtils.toHuman(Buffer.from(data.content.metadata, 'hex'))}`)
     this.log(`Creator: ${data.content.creator}`)
+    this.log(`Owner: ${data.content.owner}`)
     this.log(`Supply: ${data.content.supply}`)
     this.log(`Identifier: ${data.content.id}`)
     this.log(`Transaction Created: ${data.content.createdTransactionHash}`)

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -100,6 +100,14 @@ export class AssetsCommand extends IronfishCommand {
                 ? BufferUtils.toHuman(Buffer.from(row.creator, 'hex'))
                 : row.creator,
           },
+          owner: {
+            header: 'Owner',
+            minWidth: PUBLIC_ADDRESS_LENGTH + 1,
+            get: (row) =>
+              row.id === Asset.nativeId().toString('hex')
+                ? BufferUtils.toHuman(Buffer.from(row.owner, 'hex'))
+                : row.owner,
+          },
         },
         {
           printLine: this.log.bind(this),

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -278,6 +278,11 @@ export class Verifier {
       if (reason) {
         return reason
       }
+
+      const { reason: mintOwnersReason } = await this.verifyMintOwners(transaction.mints, tx)
+      if (mintOwnersReason) {
+        return mintOwnersReason
+      }
     })
 
     if (reason) {

--- a/ironfish/src/primitives/rawTransaction.test.ts
+++ b/ironfish/src/primitives/rawTransaction.test.ts
@@ -198,7 +198,7 @@ describe('RawTransactionSerde', () => {
     ]
 
     expect(() => RawTransactionSerde.serialize(raw)).toThrow(
-      'Expected transferOwnershipTo to be undefined',
+      'Version 1 transactions cannot contain transferOwnershipTo',
     )
   })
 

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -213,7 +213,7 @@ export class RawTransactionSerde {
       } else {
         Assert.isUndefined(
           mint.transferOwnershipTo,
-          'Expected transferOwnershipTo to be undefined',
+          'Version 1 transactions cannot contain transferOwnershipTo',
         )
       }
     }

--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -30,6 +30,7 @@ export type CreateTransactionRequest = {
     name?: string
     metadata?: string
     value: string
+    transferOwnershipTo?: string
   }[]
   burns?: {
     assetId: string
@@ -70,6 +71,7 @@ export const CreateTransactionRequestSchema: yup.ObjectSchema<CreateTransactionR
             name: yup.string().optional().max(ASSET_NAME_LENGTH),
             metadata: yup.string().optional().max(ASSET_METADATA_LENGTH),
             value: YupUtils.currency({ min: 1n }).defined(),
+            transferOwnershipTo: yup.string().optional(),
           })
           .defined(),
       )
@@ -158,6 +160,7 @@ routes.register<typeof CreateTransactionRequestSchema, CreateTransactionResponse
           creator,
           name,
           metadata,
+          transferOwnershipTo: mint.transferOwnershipTo,
           value: CurrencyUtils.decode(mint.value),
         })
       }

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -341,11 +341,10 @@ export class Account {
       // block hash, created transaction hash, and sequence for the database
       // upsert. Adjust supply from the current record.
       if (existingAsset && existingAsset.blockHash && existingAsset.sequence) {
-        Assert.isNotNull(existingAsset.supply, 'Supply should be non-null for asset')
         blockHash = existingAsset.blockHash
         createdTransactionHash = existingAsset.createdTransactionHash
         sequence = existingAsset.sequence
-        supply += existingAsset.supply
+        supply += existingAsset.supply ?? 0n
       }
 
       // Only store the supply for the owner


### PR DESCRIPTION
## Summary

Adds a `--transferOwnershipTo` flag to `wallet:mint` CLI command.

Closes IFL-1329

## Testing Plan

Manual testing:
- Pre-activation
- Imminent activation (creates a v2 transaction in anticipation of activation <15 blocks away)
- Post activation

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

https://github.com/iron-fish/website/pull/545

## Breaking Change

No
