### PR TITLE
Rahul/ifl 493 account is not consistently optional in wallet rpcs

### DIFF
--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -26,7 +26,7 @@ export class PostCommand extends IronfishCommand {
     ...RemoteFlags,
     account: Flags.string({
       description: 'The account that created the raw transaction',
-      required: false,
+      required: true,
     }),
     confirm: Flags.boolean({
       default: false,

--- a/ironfish/src/rpc/routes/wallet/postTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/postTransaction.ts
@@ -7,7 +7,7 @@ import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type PostTransactionRequest = {
-  account?: string
+  account: string
   transaction: string
   broadcast?: boolean
 }
@@ -21,7 +21,7 @@ export type PostTransactionResponse = {
 
 export const PostTransactionRequestSchema: yup.ObjectSchema<PostTransactionRequest> = yup
   .object({
-    account: yup.string().trim(),
+    account: yup.string().trim().defined(),
     transaction: yup.string().defined(),
     broadcast: yup.boolean().optional(),
   })


### PR DESCRIPTION
## Summary

Making account required on post transaction request. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
