### PR TITLE
Rahul/ifl 493 account is not consistently optional in wallet rpcs 2

### DIFF
--- a/ironfish/src/rpc/routes/wallet/burnAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.ts
@@ -9,7 +9,7 @@ import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export interface BurnAssetRequest {
-  account: string
+  account?: string
   assetId: string
   fee: string
   value: string

--- a/ironfish/src/rpc/routes/wallet/createTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/createTransaction.ts
@@ -18,7 +18,7 @@ import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type CreateTransactionRequest = {
-  account: string
+  account?: string
   outputs: {
     publicAddress: string
     amount: string

--- a/ironfish/src/rpc/routes/wallet/mintAsset.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.ts
@@ -11,7 +11,7 @@ import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export interface MintAssetRequest {
-  account: string
+  account?: string
   fee: string
   value: string
   assetId?: string

--- a/ironfish/src/rpc/routes/wallet/sendTransaction.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.ts
@@ -13,7 +13,7 @@ import { ApiNamespace, routes } from '../router'
 import { getAccount } from './utils'
 
 export type SendTransactionRequest = {
-  account: string
+  account?: string
   outputs: {
     publicAddress: string
     amount: string


### PR DESCRIPTION
## Summary

Account is not optional in sendTransaction, createTransaction, mintAsset, and burnAsset. Making it optional so it's consistent with the post transaction endpoint. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
