### PR TITLE
Add links to CI jobs on badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Iron Fish
 
-![Node CI](https://github.com/iron-fish/ironfish/actions/workflows/ci.yml/badge.svg)
-![Rust CI](https://github.com/iron-fish/ironfish/actions/workflows/rust_ci.yml/badge.svg)
-![Node CI Regenerate Fixtures](https://github.com/iron-fish/ironfish/actions/workflows/ci-regenerate-fixtures.yml/badge.svg)
+[![Node CI](https://github.com/iron-fish/ironfish/actions/workflows/ci.yml/badge.svg)](https://github.com/iron-fish/ironfish/actions/workflows/ci.yml)
+[![Rust CI](https://github.com/iron-fish/ironfish/actions/workflows/rust_ci.yml/badge.svg)](https://github.com/iron-fish/ironfish/actions/workflows/rust_ci.yml)
+[![Node CI Regenerate Fixtures](https://github.com/iron-fish/ironfish/actions/workflows/ci-regenerate-fixtures.yml/badge.svg)](https://github.com/iron-fish/ironfish/actions/workflows/ci-regenerate-fixtures.yml)
 [![codecov](https://codecov.io/gh/iron-fish/ironfish/branch/master/graph/badge.svg?token=fOjPFN18xZ)](https://codecov.io/gh/iron-fish/ironfish)
 
 Iron Fish is a Layer 1 blockchain that provides the strongest privacy guarantees on every single transaction. Leveraging zero-knowledge proofs (zk-SNARKs), and the highest industry standards for encryption.


### PR DESCRIPTION
## Summary
Add links to GH CI jobs on the badges in readme

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
