### PR TITLE
marking counts fields as deprecated

### DIFF
--- a/ironfish/src/rpc/routes/chain/getTransaction.ts
+++ b/ironfish/src/rpc/routes/chain/getTransaction.ts
@@ -24,7 +24,13 @@ export type GetTransactionResponse = {
   fee: string
   expiration: number
   noteSize: number
+  /**
+   * @deprecated Please use `notes.length` instead
+   */
   notesCount: number
+  /**
+   * @deprecated Please use `spends.length` instead
+   */
   spendsCount: number
   signature: string
   spends: RpcSpend[]

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -71,9 +71,21 @@ export const RpcWalletNoteSchema: yup.ObjectSchema<RpcWalletNote> = yup
 export type RpcAccountTransaction = {
   hash: string
   fee: string
+  /**
+   * @deprecated Please use `notes.length` instead
+   */
   notesCount: number
+  /**
+   * @deprecated Please use `spends.length` instead
+   */
   spendsCount: number
+  /**
+   * @deprecated Please use `mints.length` instead
+   */
   mintsCount: number
+  /**
+   * @deprecated Please use `burns.length` instead
+   */
   burnsCount: number
   expiration: number
   timestamp: number


### PR DESCRIPTION
## Summary

Marking counts fields as deprecated. User should use count the number of subObjects returned instead. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
