### PR TITLE
removes input trimming from cli commands

### DIFF
--- a/ironfish-cli/src/commands/blocks/show.ts
+++ b/ironfish-cli/src/commands/blocks/show.ts
@@ -10,7 +10,6 @@ export default class ShowBlock extends IronfishCommand {
   static args = [
     {
       name: 'search',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The hash or sequence of the block to look at',
     },

--- a/ironfish-cli/src/commands/chain/asset.ts
+++ b/ironfish-cli/src/commands/chain/asset.ts
@@ -11,7 +11,6 @@ export default class Asset extends IronfishCommand {
   static args = [
     {
       name: 'id',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The identifier of the asset',
     },

--- a/ironfish-cli/src/commands/chain/export.ts
+++ b/ironfish-cli/src/commands/chain/export.ts
@@ -16,7 +16,6 @@ export default class Export extends IronfishCommand {
     ...RemoteFlags,
     path: Flags.string({
       char: 'p',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'The path to export the chain to',
     }),

--- a/ironfish-cli/src/commands/chain/readd-block.ts
+++ b/ironfish-cli/src/commands/chain/readd-block.ts
@@ -18,7 +18,6 @@ export default class ReAddBlock extends IronfishCommand {
   static args = [
     {
       name: 'hash',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The hash of the block in hex format',
     },

--- a/ironfish-cli/src/commands/chain/rewind.ts
+++ b/ironfish-cli/src/commands/chain/rewind.ts
@@ -22,13 +22,11 @@ export default class Rewind extends IronfishCommand {
   static args = [
     {
       name: 'to',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'The block sequence to rewind to',
     },
     {
       name: 'from',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'The sequence to start removing blocks from',
     },

--- a/ironfish-cli/src/commands/config/get.ts
+++ b/ironfish-cli/src/commands/config/get.ts
@@ -13,7 +13,6 @@ export class GetCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the config item',
     },

--- a/ironfish-cli/src/commands/config/set.ts
+++ b/ironfish-cli/src/commands/config/set.ts
@@ -11,13 +11,11 @@ export class SetCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the config item',
     },
     {
       name: 'value',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Value of the config item',
     },

--- a/ironfish-cli/src/commands/config/unset.ts
+++ b/ironfish-cli/src/commands/config/unset.ts
@@ -11,7 +11,6 @@ export class UnsetCommand extends IronfishCommand {
   static args = [
     {
       name: 'name',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the config item',
     },

--- a/ironfish-cli/src/commands/rpc/token.ts
+++ b/ironfish-cli/src/commands/rpc/token.ts
@@ -11,7 +11,6 @@ export default class Token extends IronfishCommand {
   static flags = {
     ...LocalFlags,
     token: Flags.string({
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Set the RPC auth token to <value>',
     }),

--- a/ironfish-cli/src/commands/service/faucet.ts
+++ b/ironfish-cli/src/commands/service/faucet.ts
@@ -22,19 +22,16 @@ export default class Faucet extends IronfishCommand {
     ...RemoteFlags,
     api: Flags.string({
       char: 'a',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'API host to sync to',
     }),
     token: Flags.string({
       char: 't',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'API host token to authenticate with',
     }),
     account: Flags.string({
       char: 'f',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to send faucet transactions from',
     }),

--- a/ironfish-cli/src/commands/service/snapshot.ts
+++ b/ironfish-cli/src/commands/service/snapshot.ts
@@ -42,13 +42,11 @@ export default class Snapshot extends IronfishCommand {
     }),
     path: Flags.string({
       char: 'p',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'The local path where the snapshot will be saved',
     }),
     webhook: Flags.string({
       char: 'w',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Webhook to notify on successful snapshot upload',
     }),

--- a/ironfish-cli/src/commands/wallet/address.ts
+++ b/ironfish-cli/src/commands/wallet/address.ts
@@ -16,7 +16,6 @@ export class AddressCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to get the address for',
     },

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -34,7 +34,6 @@ export class AssetsCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -37,7 +37,6 @@ export class BalanceCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to get balance for',
     },

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -26,7 +26,6 @@ export class BalancesCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to get balances for',
     },

--- a/ironfish-cli/src/commands/wallet/create.ts
+++ b/ironfish-cli/src/commands/wallet/create.ts
@@ -12,7 +12,6 @@ export class CreateCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/delete.ts
+++ b/ironfish-cli/src/commands/wallet/delete.ts
@@ -12,7 +12,6 @@ export class DeleteCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -45,7 +45,6 @@ export class ExportCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to export',
     },

--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -27,7 +27,6 @@ export class ImportCommand extends IronfishCommand {
   static args = [
     {
       name: 'blob',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'The copy-pasted output of wallet:export; or, a raw spending key',
     },

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -19,7 +19,6 @@ export class NotesCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to get notes for',
     },

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -43,7 +43,6 @@ export class PostCommand extends IronfishCommand {
     {
       name: 'transaction',
       required: true,
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       description: 'The raw transaction in hex encoding',
     },
   ]

--- a/ironfish-cli/src/commands/wallet/rename.ts
+++ b/ironfish-cli/src/commands/wallet/rename.ts
@@ -10,13 +10,11 @@ export class RenameCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the account to rename',
     },
     {
       name: 'new-name',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'New name to assign to the account',
     },

--- a/ironfish-cli/src/commands/wallet/transaction/add.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/add.ts
@@ -21,7 +21,6 @@ export class TransactionAddCommand extends IronfishCommand {
     {
       name: 'transaction',
       required: true,
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       description: 'The transaction in hex encoding',
     },
   ]

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -16,13 +16,11 @@ export class TransactionCommand extends IronfishCommand {
   static args = [
     {
       name: 'hash',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Hash of the transaction',
     },
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -20,13 +20,11 @@ export class WatchTxCommand extends IronfishCommand {
   static args = [
     {
       name: 'hash',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Hash of the transaction',
     },
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -47,7 +47,6 @@ export class TransactionsCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/use.ts
+++ b/ironfish-cli/src/commands/wallet/use.ts
@@ -10,7 +10,6 @@ export class UseCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the account',
     },

--- a/simulator/src/commands/start.ts
+++ b/simulator/src/commands/start.ts
@@ -13,7 +13,6 @@ export abstract class Start extends Command {
   static args = [
     {
       name: 'simulation',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: `The name of the simulation to run, one of: ${Object.keys(SIMULATIONS).join(
         ', ',


### PR DESCRIPTION
## Summary

oclif automatically splits on whitespace when parsing inputs, so using 'trim' typically isn't doing anything

in cases where a user _wants_ leading or trailing whitespace, such as `ironfish
wallet:delete 'trailing   '`, trim removes the trailing whitespace that the user
has tried to include

## Testing Plan

manual testing:
- ran wallet cli commands for account name with trailing whitespace

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
