### PR TITLE
Rahul/ifl 1670 move peerresponse into types

### DIFF
--- a/ironfish/src/rpc/routes/peer/getPeer.ts
+++ b/ironfish/src/rpc/routes/peer/getPeer.ts
@@ -3,12 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { Connection, PeerNetwork } from '../../../network'
+import { PeerNetwork } from '../../../network'
 import { FullNode } from '../../../node'
+import { ConnectionState, RpcPeerResponse, RpcPeerResponseSchema } from '../../types'
 import { ApiNamespace, routes } from '../router'
-import { PeerResponse } from './getPeers'
-
-type ConnectionState = Connection['state']['type'] | ''
 
 export type GetPeerRequest = {
   identity: string
@@ -16,7 +14,7 @@ export type GetPeerRequest = {
 }
 
 export type GetPeerResponse = {
-  peer: PeerResponse | null
+  peer: RpcPeerResponse | null
 }
 
 export const GetPeerRequestSchema: yup.ObjectSchema<GetPeerRequest> = yup
@@ -28,34 +26,7 @@ export const GetPeerRequestSchema: yup.ObjectSchema<GetPeerRequest> = yup
 
 export const GetPeerResponseSchema: yup.ObjectSchema<GetPeerResponse> = yup
   .object({
-    peer: yup
-      .object({
-        state: yup.string().defined(),
-        address: yup.string().nullable().defined(),
-        port: yup.number().nullable().defined(),
-        identity: yup.string().nullable().defined(),
-        name: yup.string().nullable().defined(),
-        head: yup.string().nullable().defined(),
-        work: yup.string().nullable().defined(),
-        sequence: yup.number().nullable().defined(),
-        version: yup.number().nullable().defined(),
-        agent: yup.string().nullable().defined(),
-        error: yup.string().nullable().defined(),
-        connections: yup.number().defined(),
-        connectionWebSocket: yup.string<ConnectionState>().defined(),
-        connectionWebSocketError: yup.string().defined(),
-        connectionWebRTC: yup.string<ConnectionState>().defined(),
-        connectionWebRTCError: yup.string().defined(),
-        networkId: yup.number().nullable().defined(),
-        genesisBlockHash: yup.string().nullable().defined(),
-        features: yup
-          .object({
-            syncing: yup.boolean().defined(),
-          })
-          .nullable()
-          .defined(),
-      })
-      .defined(),
+    peer: RpcPeerResponseSchema.nullable().defined(),
   })
   .defined()
 
@@ -92,7 +63,7 @@ routes.register<typeof GetPeerRequestSchema, GetPeerResponse>(
   },
 )
 
-function getPeer(network: PeerNetwork, identity: string): PeerResponse | null {
+function getPeer(network: PeerNetwork, identity: string): RpcPeerResponse | null {
   for (const peer of network.peerManager.peers) {
     if (peer.state.identity !== null && peer.state.identity.includes(identity)) {
       let connections = 0

--- a/ironfish/src/rpc/routes/peer/getPeers.ts
+++ b/ironfish/src/rpc/routes/peer/getPeers.ts
@@ -3,34 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
-import { Connection, PeerNetwork } from '../../../network'
-import { Features } from '../../../network/peers/peerFeatures'
+import { PeerNetwork } from '../../../network'
 import { FullNode } from '../../../node'
+import { ConnectionState, RpcPeerResponse, RpcPeerResponseSchema } from '../../types'
 import { ApiNamespace, routes } from '../router'
-
-type ConnectionState = Connection['state']['type'] | ''
-
-export type PeerResponse = {
-  state: string
-  identity: string | null
-  version: number | null
-  head: string | null
-  sequence: number | null
-  work: string | null
-  agent: string | null
-  name: string | null
-  address: string | null
-  port: number | null
-  error: string | null
-  connections: number
-  connectionWebSocket: ConnectionState
-  connectionWebSocketError: string
-  connectionWebRTC: ConnectionState
-  connectionWebRTCError: string
-  networkId: number | null
-  genesisBlockHash: string | null
-  features: Features | null
-}
 
 export type GetPeersRequest =
   | undefined
@@ -39,7 +15,7 @@ export type GetPeersRequest =
     }
 
 export type GetPeersResponse = {
-  peers: Array<PeerResponse>
+  peers: Array<RpcPeerResponse>
 }
 
 export const GetPeersRequestSchema: yup.ObjectSchema<GetPeersRequest> = yup
@@ -51,38 +27,7 @@ export const GetPeersRequestSchema: yup.ObjectSchema<GetPeersRequest> = yup
 
 export const GetPeersResponseSchema: yup.ObjectSchema<GetPeersResponse> = yup
   .object({
-    peers: yup
-      .array(
-        yup
-          .object({
-            state: yup.string().defined(),
-            address: yup.string().nullable().defined(),
-            port: yup.number().nullable().defined(),
-            identity: yup.string().nullable().defined(),
-            name: yup.string().nullable().defined(),
-            head: yup.string().nullable().defined(),
-            work: yup.string().nullable().defined(),
-            sequence: yup.number().nullable().defined(),
-            version: yup.number().nullable().defined(),
-            agent: yup.string().nullable().defined(),
-            error: yup.string().nullable().defined(),
-            connections: yup.number().defined(),
-            connectionWebSocket: yup.string<ConnectionState>().defined(),
-            connectionWebSocketError: yup.string().defined(),
-            connectionWebRTC: yup.string<ConnectionState>().defined(),
-            connectionWebRTCError: yup.string().defined(),
-            networkId: yup.number().nullable().defined(),
-            genesisBlockHash: yup.string().nullable().defined(),
-            features: yup
-              .object({
-                syncing: yup.boolean().defined(),
-              })
-              .nullable()
-              .defined(),
-          })
-          .defined(),
-      )
-      .defined(),
+    peers: yup.array(RpcPeerResponseSchema).defined(),
   })
   .defined()
 
@@ -119,8 +64,8 @@ routes.register<typeof GetPeersRequestSchema, GetPeersResponse>(
   },
 )
 
-function getPeers(network: PeerNetwork): PeerResponse[] {
-  const result: PeerResponse[] = []
+function getPeers(network: PeerNetwork): RpcPeerResponse[] {
+  const result: RpcPeerResponse[] = []
 
   for (const peer of network.peerManager.peers) {
     let connections = 0

--- a/ironfish/src/rpc/types.ts
+++ b/ironfish/src/rpc/types.ts
@@ -4,6 +4,8 @@
 
 import * as yup from 'yup'
 import { AssetVerification } from '../assets'
+import { Connection } from '../network'
+import { Features } from '../network/peers/peerFeatures'
 import { BlockHeader } from '../primitives'
 import { RpcTransaction, RpcTransactionSchema } from './routes'
 
@@ -186,3 +188,56 @@ export const RpcBlockSchema: yup.ObjectSchema<RpcBlock> = RpcBlockHeaderSchema.c
     })
     .defined(),
 )
+
+export type ConnectionState = Connection['state']['type'] | ''
+
+export type RpcPeerResponse = {
+  state: string
+  identity: string | null
+  version: number | null
+  head: string | null
+  sequence: number | null
+  work: string | null
+  agent: string | null
+  name: string | null
+  address: string | null
+  port: number | null
+  error: string | null
+  connections: number
+  connectionWebSocket: ConnectionState
+  connectionWebSocketError: string
+  connectionWebRTC: ConnectionState
+  connectionWebRTCError: string
+  networkId: number | null
+  genesisBlockHash: string | null
+  features: Features | null
+}
+
+export const RpcPeerResponseSchema: yup.ObjectSchema<RpcPeerResponse> = yup
+  .object({
+    state: yup.string().defined(),
+    address: yup.string().nullable().defined(),
+    port: yup.number().nullable().defined(),
+    identity: yup.string().nullable().defined(),
+    name: yup.string().nullable().defined(),
+    head: yup.string().nullable().defined(),
+    work: yup.string().nullable().defined(),
+    sequence: yup.number().nullable().defined(),
+    version: yup.number().nullable().defined(),
+    agent: yup.string().nullable().defined(),
+    error: yup.string().nullable().defined(),
+    connections: yup.number().defined(),
+    connectionWebSocket: yup.string<ConnectionState>().defined(),
+    connectionWebSocketError: yup.string().defined(),
+    connectionWebRTC: yup.string<ConnectionState>().defined(),
+    connectionWebRTCError: yup.string().defined(),
+    networkId: yup.number().nullable().defined(),
+    genesisBlockHash: yup.string().nullable().defined(),
+    features: yup
+      .object({
+        syncing: yup.boolean().defined(),
+      })
+      .nullable()
+      .defined(),
+  })
+  .defined()


### PR DESCRIPTION
## Summary

Peer response is used and redefined in multiple places in our RPC. Combining them into a single definition and reusing it. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
