### PR TITLE
Support resuming snapshot downloads if supported

### DIFF
--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -205,7 +205,7 @@ export default class Download extends IronfishCommand {
         url: snapshotUrl,
         cancelToken: idleCancelSource.token,
         headers: {
-          ...(canAcceptRanges
+          ...(canAcceptRanges && downloaded > 0
             ? { range: `bytes=${downloaded}-${manifest.file_size - 1}` }
             : {}),
         },

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -186,7 +186,7 @@ export default class Download extends IronfishCommand {
           url: snapshotUrl,
           cancelToken: idleCancelSource.token,
           headers: {
-            range: `bytes=${downloaded}-${manifest.file_size - 1}`,
+            range: `bytes=${downloaded}-`,
           },
         })
 

--- a/ironfish-cli/src/commands/chain/download.ts
+++ b/ironfish-cli/src/commands/chain/download.ts
@@ -190,10 +190,11 @@ export default class Download extends IronfishCommand {
           },
         })
 
+        const resumingDownload = response.data.statusCode === 206
         const writer = fs.createWriteStream(snapshotPath, {
-          flags: response.data.statusCode === 206 ? 'a' : 'w',
+          flags: resumingDownload ? 'a' : 'w',
         })
-        downloaded = response.data.statusCode === 206 ? downloaded : 0
+        downloaded = resumingDownload ? downloaded : 0
 
         await new Promise<void>((resolve, reject) => {
           const onWriterError = (e: unknown) => {


### PR DESCRIPTION
## Summary

As the chain snapshot grows larger, it's increasingly inconvenient for the download to error midway, which requires restarting from 0. This PR checks if the server supports range requests, and if so, passes a range header to the server if a previously existing file with the same name is in the temp directory.

## Testing Plan

* [x] Downloaded part of a snapshot, canceled the download, then resumed it and verified the chain status on completion 

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
