### PR TITLE
adding full transaction object to burn and mint asset response

### DIFF
--- a/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/burnAsset.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { CurrencyUtils } from '../../../utils'
+import { serializeRpcWalletTransaction } from './utils'
 
 describe('Route wallet/burnAsset', () => {
   const routeTest = createRouteTest(true)
@@ -86,6 +87,9 @@ describe('Route wallet/burnAsset', () => {
         value: CurrencyUtils.encode(value),
       })
 
+      const walletTransaction = await account.getTransaction(burnTransaction.hash())
+      Assert.isNotUndefined(walletTransaction)
+
       expect(response.content).toEqual({
         asset: {
           id: asset.id().toString('hex'),
@@ -100,11 +104,11 @@ describe('Route wallet/burnAsset', () => {
           verification: node.assetsVerifier.verify(asset.id()),
           createdTransactionHash: accountAsset.createdTransactionHash.toString('hex') ?? null,
         },
+        transaction: await serializeRpcWalletTransaction(node, account, walletTransaction),
         id: asset.id().toString('hex'),
         assetId: asset.id().toString('hex'),
         name: asset.name().toString('hex'),
         assetName: asset.name().toString('hex'),
-        transactionHash: burnTransaction.hash().toString('hex'),
         hash: burnTransaction.hash().toString('hex'),
         value: burnTransaction.burns[0].value.toString(),
       })

--- a/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
+++ b/ironfish/src/rpc/routes/wallet/mintAsset.test.ts
@@ -6,6 +6,7 @@ import { Assert } from '../../../assert'
 import { useAccountFixture, useMinerBlockFixture, useTxFixture } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
 import { CurrencyUtils } from '../../../utils'
+import { serializeRpcWalletTransaction } from './utils'
 
 describe('Route wallet/mintAsset', () => {
   const routeTest = createRouteTest(true)
@@ -93,6 +94,9 @@ describe('Route wallet/mintAsset', () => {
         value: CurrencyUtils.encode(mintData.value),
       })
 
+      const walletTransaction = await account.getTransaction(mintTransaction.hash())
+      Assert.isNotUndefined(walletTransaction)
+
       expect(response.content).toEqual({
         asset: {
           id: asset.id().toString('hex'),
@@ -108,11 +112,11 @@ describe('Route wallet/mintAsset', () => {
           }),
           verification: node.assetsVerifier.verify(asset.id()),
         },
+        transaction: await serializeRpcWalletTransaction(node, account, walletTransaction),
         id: asset.id().toString('hex'),
         creator: asset.creator().toString('hex'),
         assetId: asset.id().toString('hex'),
         metadata: asset.metadata().toString('hex'),
-        transactionHash: mintTransaction.hash().toString('hex'),
         hash: mintTransaction.hash().toString('hex'),
         name: asset.name().toString('hex'),
         assetName: asset.name().toString('hex'),


### PR DESCRIPTION
## Summary

Adding a `transaction` object to the response from Mint and Burn asset. This way, the user has access to both the `asset` and `transaction` when creating/ burning an asset, creating a more consistent experience wrt `createTransaction` and `postTransaction`

Note: I removed the `transactionHash` field. This was added as a replacement to the `hash` field for a better naming convention here https://github.com/iron-fish/ironfish/pull/4294/files. Since we haven't release this change, it's OK to remove it all together and point the user to the transaction object. 

Example result: 

```json
{
    "status": 200,
    "data": {
        "asset": {
            "id": "fe6daf7a862592f4111497aed4da7c9dc9bf060a5a769ef8a3a998d7b4ad0757",
            "metadata": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
            "name": "68656c6c6f20776f726c642068656c6c6f000000000000000000000000000000",
            "nonce": 1,
            "creator": "96b738054e2933fc670df8ddd25d34e21dd3c15b3e0a28cc980a6d0aad113319",
            "owner": "96b738054e2933fc670df8ddd25d34e21dd3c15b3e0a28cc980a6d0aad113319",
            "verification": {
                "status": "unverified"
            },
            "status": "pending",
            "createdTransactionHash": "ec58cb8ec6d0ab8511ab2c5633f2c1e51a00a00cf12220a7188c58b92b007998"
        },
        "transaction": {
            "signature": "fae57fd00e469952f0c58bacf69fcdf64a97ad78f5709165f4e7ad17616e068a49b81136c1407d860dca4f2d40ea4791fa8f79ee6b34038eb8d671bbd95b6608",
            "hash": "ec58cb8ec6d0ab8511ab2c5633f2c1e51a00a00cf12220a7188c58b92b007998",
            "fee": "1",
            "notesCount": 2,
            "spendsCount": 1,
            "mintsCount": 1,
            "burnsCount": 0,
            "expiration": 1151,
            "timestamp": 1695245590365,
            "submittedSequence": 1136,
            "mints": [
                {
                    "id": "fe6daf7a862592f4111497aed4da7c9dc9bf060a5a769ef8a3a998d7b4ad0757",
                    "metadata": "",
                    "name": "hello world hello",
                    "creator": "96b738054e2933fc670df8ddd25d34e21dd3c15b3e0a28cc980a6d0aad113319",
                    "value": "100",
                    "assetId": "fe6daf7a862592f4111497aed4da7c9dc9bf060a5a769ef8a3a998d7b4ad0757",
                    "assetName": "68656c6c6f20776f726c642068656c6c6f000000000000000000000000000000"
                }
            ],
            "burns": [],
            "type": "send",
            "status": "pending",
            "assetBalanceDeltas": [
                {
                    "assetId": "51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c",
                    "assetName": "2449524f4e",
                    "delta": "-1"
                },
                {
                    "assetId": "fe6daf7a862592f4111497aed4da7c9dc9bf060a5a769ef8a3a998d7b4ad0757",
                    "assetName": "68656c6c6f20776f726c642068656c6c6f000000000000000000000000000000",
                    "delta": "100"
                }
            ],
            "confirmations": 2
        },
        "assetId": "fe6daf7a862592f4111497aed4da7c9dc9bf060a5a769ef8a3a998d7b4ad0757",
        "hash": "ec58cb8ec6d0ab8511ab2c5633f2c1e51a00a00cf12220a7188c58b92b007998", // deprecated
        "name": "68656c6c6f20776f726c642068656c6c6f000000000000000000000000000000", // deprecated
        "value": "100", 
        "id": "fe6daf7a862592f4111497aed4da7c9dc9bf060a5a769ef8a3a998d7b4ad0757", // deprecated
        "assetName": "68656c6c6f20776f726c642068656c6c6f000000000000000000000000000000", // deprecated
        "metadata": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", // deprecated
        "creator": "96b738054e2933fc670df8ddd25d34e21dd3c15b3e0a28cc980a6d0aad113319" // deprecated
    }
}
```

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
