### PR TITLE
Don't use streaming endpoint in status CLI

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -67,13 +67,13 @@ export default class Status extends IronfishCommand {
         continue
       }
 
-      const response = this.sdk.client.node.getStatusStream()
-
-      for await (const value of response.contentStream()) {
+      while(true) {
+        const value = await this.sdk.client.node.getStatus()
         statusText.clearBaseLine(0)
-        statusText.setContent(renderStatus(value, flags.all))
+        statusText.setContent(renderStatus(value.content, flags.all))
         screen.render()
-        previousResponse = value
+        previousResponse = value.content
+        await PromiseUtils.sleep(1000)
       }
     }
   }

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -67,7 +67,8 @@ export default class Status extends IronfishCommand {
         continue
       }
 
-      while(true) {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
         const value = await this.sdk.client.node.getStatus()
         statusText.clearBaseLine(0)
         statusText.setContent(renderStatus(value.content, flags.all))


### PR DESCRIPTION
## Summary
Some endpoints make sense for the server to initiate streaming. Endpoints that only trigger when an event happens on the server side. Status however is not one of those endpoints. Refreshing the status every Xms is something the client should probably handle instead of the server side. Removing usages of the status streaming endpoint so we can eventually deprecate it

## Testing Plan
Tested status command with following locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
