### PR TITLE
formatting all rpc objects in the same order

### DIFF
--- a/ironfish/src/rpc/routes/chain/exportChainStream.ts
+++ b/ironfish/src/rpc/routes/chain/exportChainStream.ts
@@ -19,6 +19,9 @@ export type ExportChainStreamResponse = {
   start: number
   stop: number
   block?: RpcBlockHeader & {
+    main: boolean
+    head: boolean
+    latest: boolean
     /**
      * @deprecated Please use sequence instead
      */
@@ -27,10 +30,6 @@ export type ExportChainStreamResponse = {
      * @deprecated Please use previousBlockHash instead
      */
     prev: string
-
-    main: boolean
-    head: boolean
-    latest: boolean
   }
 }
 

--- a/ironfish/src/rpc/routes/chain/types.ts
+++ b/ironfish/src/rpc/routes/chain/types.ts
@@ -27,29 +27,29 @@ export const RpcSpendSchema: yup.ObjectSchema<RpcSpend> = yup
   .defined()
 
 export type RpcTransaction = {
-  serialized?: string
   hash: string
   size: number
   fee: number
   expiration: number
+  signature: string
   notes: RpcEncryptedNote[]
   spends: RpcSpend[]
   mints: RpcMint[]
   burns: RpcBurn[]
-  signature: string
+  serialized?: string
 }
 
 export const RpcTransactionSchema: yup.ObjectSchema<RpcTransaction> = yup
   .object({
-    serialized: yup.string().optional(),
     hash: yup.string().defined(),
     size: yup.number().defined(),
     fee: yup.number().defined(),
     expiration: yup.number().defined(),
+    signature: yup.string().defined(),
     notes: yup.array(RpcEncryptedNoteSchema).defined(),
     spends: yup.array(RpcSpendSchema).defined(),
     mints: yup.array(RpcMintSchema).defined(),
     burns: yup.array(RpcBurnSchema).defined(),
-    signature: yup.string().defined(),
+    serialized: yup.string().optional(),
   })
   .defined()

--- a/ironfish/src/rpc/routes/peer/getBannedPeers.ts
+++ b/ironfish/src/rpc/routes/peer/getBannedPeers.ts
@@ -19,7 +19,7 @@ export type GetBannedPeersRequest =
     }
 
 export type GetBannedPeersResponse = {
-  peers: Array<BannedPeerResponse>
+  peers: BannedPeerResponse[]
 }
 
 export const GetBannedPeersRequestSchema: yup.ObjectSchema<GetBannedPeersRequest> = yup

--- a/ironfish/src/rpc/routes/peer/getPeerMessages.ts
+++ b/ironfish/src/rpc/routes/peer/getPeerMessages.ts
@@ -26,7 +26,7 @@ export type GetPeerMessagesRequest = {
 }
 
 export type GetPeerMessagesResponse = {
-  messages: Array<PeerMessage>
+  messages: PeerMessage[]
 }
 
 export const GetPeerMessagesRequestSchema: yup.ObjectSchema<GetPeerMessagesRequest> = yup
@@ -92,7 +92,7 @@ routes.register<typeof GetPeerMessagesRequestSchema, GetPeerMessagesResponse>(
   },
 )
 
-function getPeerMessages(network: PeerNetwork, identity: string): Array<PeerMessage> {
+function getPeerMessages(network: PeerNetwork, identity: string): PeerMessage[] {
   for (const peer of network.peerManager.peers) {
     if (peer.state.identity !== null && peer.state.identity.includes(identity)) {
       return peer.loggedMessages.map((msg) => ({

--- a/ironfish/src/rpc/routes/peer/getPeers.ts
+++ b/ironfish/src/rpc/routes/peer/getPeers.ts
@@ -15,7 +15,7 @@ export type GetPeersRequest =
     }
 
 export type GetPeersResponse = {
-  peers: Array<RpcPeerResponse>
+  peers: RpcPeerResponse[]
 }
 
 export const GetPeersRequestSchema: yup.ObjectSchema<GetPeersRequest> = yup

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
@@ -8,13 +8,13 @@ import { ApiNamespace, routes } from '../router'
 export type GetAccountStatusRequest = { account?: string }
 
 export type GetAccountStatusResponse = {
-  accounts: Array<{
+  accounts: {
     name: string
     id: string
     headHash: string
     headInChain?: boolean
     sequence: string | number
-  }>
+  }[]
 }
 
 export const GetAccountStatusRequestSchema: yup.ObjectSchema<GetAccountStatusRequest> = yup

--- a/ironfish/src/rpc/routes/wallet/getBalance.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalance.ts
@@ -18,10 +18,6 @@ export type GetBalanceRequest =
 export type GetBalanceResponse = {
   account: string
   assetId: string
-  /**
-   * @deprecated Please use getAsset endpoint to get this information
-   * */
-  assetVerification: AssetVerification
   confirmed: string
   unconfirmed: string
   unconfirmedCount: number
@@ -31,6 +27,10 @@ export type GetBalanceResponse = {
   confirmations: number
   blockHash: string | null
   sequence: number | null
+  /**
+   * @deprecated Please use getAsset endpoint to get this information
+   * */
+  assetVerification: AssetVerification
 }
 
 export const GetBalanceRequestSchema: yup.ObjectSchema<GetBalanceRequest> = yup

--- a/ironfish/src/rpc/routes/wallet/getBalances.ts
+++ b/ironfish/src/rpc/routes/wallet/getBalances.ts
@@ -16,6 +16,14 @@ export interface GetBalancesResponse {
   account: string
   balances: {
     assetId: string
+    confirmed: string
+    unconfirmed: string
+    unconfirmedCount: number
+    pending: string
+    pendingCount: number
+    available: string
+    blockHash: string | null
+    sequence: number | null
     /**
      * @deprecated Please use getAsset endpoint to get this information
      */
@@ -32,14 +40,6 @@ export interface GetBalancesResponse {
      * @deprecated Please use getAsset endpoint to get this information
      * */
     assetVerification: AssetVerification
-    confirmed: string
-    unconfirmed: string
-    unconfirmedCount: number
-    pending: string
-    pendingCount: number
-    available: string
-    blockHash: string | null
-    sequence: number | null
   }[]
 }
 

--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -33,7 +33,7 @@ export type GetNotesRequest = {
 }
 
 export type GetNotesResponse = {
-  notes: Array<RpcWalletNote>
+  notes: RpcWalletNote[]
   nextPageCursor: string | null
 }
 

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -4,43 +4,42 @@
 
 import * as yup from 'yup'
 import { TransactionStatus, TransactionType } from '../../../wallet'
-import { AccountImport } from '../../../wallet/walletdb/accountValue'
 import { RpcBurn, RpcBurnSchema, RpcMint, RpcMintSchema } from '../../types'
 import { RpcSpend, RpcSpendSchema } from '../chain'
 
 export type RcpAccountAssetBalanceDelta = {
   assetId: string
+  delta: string
   /**
    * @deprecated Please use the getAsset RPC to fetch additional asset details
    */
   assetName: string
-  delta: string
 }
 
 export const RcpAccountAssetBalanceDeltaSchema: yup.ObjectSchema<RcpAccountAssetBalanceDelta> =
   yup
     .object({
       assetId: yup.string().defined(),
-      assetName: yup.string().defined(),
       delta: yup.string().defined(),
+      assetName: yup.string().defined(),
     })
     .defined()
 
 export type RpcWalletNote = {
-  value: string
   assetId: string
-  /**
-   * @deprecated Please use `asset.name` instead
-   */
-  assetName: string
+  value: string
   memo: string
   sender: string
   owner: string
   noteHash: string
   transactionHash: string
+  spent: boolean
   index: number | null
   nullifier: string | null
-  spent: boolean
+  /**
+   * @deprecated Please use `asset.name` instead
+   */
+  assetName: string
   /**
    * @deprecated Please use `owner` address instead
    */
@@ -73,7 +72,19 @@ export type RpcWalletTransaction = {
   hash: string
   fee: string
   signature: string
+  expiration: number
+  timestamp: number
+  submittedSequence: number
+  type: TransactionType
+  status: TransactionStatus
+  assetBalanceDeltas: RcpAccountAssetBalanceDelta[]
+  burns: RpcBurn[]
+  mints: RpcMint[]
   serialized?: string
+  blockHash?: string
+  blockSequence?: number
+  notes?: RpcWalletNote[]
+  spends?: RpcSpend[]
   /**
    * @deprecated Please use `notes.length` instead
    */
@@ -90,22 +101,10 @@ export type RpcWalletTransaction = {
    * @deprecated Please use `burns.length` instead
    */
   burnsCount: number
-  expiration: number
-  timestamp: number
-  submittedSequence: number
   /**
    * @deprecated This is configuarable via the node config, a setting that the user can pass, so doesn't need to be returned
    */
   confirmations: number
-  type: TransactionType
-  status: TransactionStatus
-  assetBalanceDeltas: RcpAccountAssetBalanceDelta[]
-  blockHash?: string
-  blockSequence?: number
-  notes?: RpcWalletNote[]
-  spends?: RpcSpend[]
-  burns: RpcBurn[]
-  mints: RpcMint[]
 }
 
 export const RpcWalletTransactionSchema: yup.ObjectSchema<RpcWalletTransaction> = yup
@@ -134,12 +133,21 @@ export const RpcWalletTransactionSchema: yup.ObjectSchema<RpcWalletTransaction> 
   })
   .defined()
 
-export type RpcAccountImport = Omit<AccountImport, 'createdAt'> & {
+export type RpcAccountImport = {
+  id: string
+  version: number
+  name: string
+  viewKey: string
+  incomingViewKey: string
+  outgoingViewKey: string
+  publicAddress: string
+  spendingKey: string | null
   createdAt: { hash: string; sequence: number } | null
 }
 
 export const RpcAccountImportSchema: yup.ObjectSchema<RpcAccountImport> = yup
   .object({
+    id: yup.string().defined(),
     name: yup.string().defined(),
     spendingKey: yup.string().nullable().defined(),
     viewKey: yup.string().defined(),

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -7,7 +7,7 @@ import { TransactionStatus, TransactionType } from '../../../wallet'
 import { RpcBurn, RpcBurnSchema, RpcMint, RpcMintSchema } from '../../types'
 import { RpcSpend, RpcSpendSchema } from '../chain'
 
-export type RcpAccountAssetBalanceDelta = {
+export type RpcAccountAssetBalanceDelta = {
   assetId: string
   delta: string
   /**
@@ -16,7 +16,7 @@ export type RcpAccountAssetBalanceDelta = {
   assetName: string
 }
 
-export const RcpAccountAssetBalanceDeltaSchema: yup.ObjectSchema<RcpAccountAssetBalanceDelta> =
+export const RcpAccountAssetBalanceDeltaSchema: yup.ObjectSchema<RpcAccountAssetBalanceDelta> =
   yup
     .object({
       assetId: yup.string().defined(),
@@ -77,7 +77,7 @@ export type RpcWalletTransaction = {
   submittedSequence: number
   type: TransactionType
   status: TransactionStatus
-  assetBalanceDeltas: RcpAccountAssetBalanceDelta[]
+  assetBalanceDeltas: RpcAccountAssetBalanceDelta[]
   burns: RpcBurn[]
   mints: RpcMint[]
   serialized?: string

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -134,7 +134,6 @@ export const RpcWalletTransactionSchema: yup.ObjectSchema<RpcWalletTransaction> 
   .defined()
 
 export type RpcAccountImport = {
-  id: string
   version: number
   name: string
   viewKey: string
@@ -147,7 +146,6 @@ export type RpcAccountImport = {
 
 export const RpcAccountImportSchema: yup.ObjectSchema<RpcAccountImport> = yup
   .object({
-    id: yup.string().defined(),
     name: yup.string().defined(),
     spendingKey: yup.string().nullable().defined(),
     viewKey: yup.string().defined(),

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -11,7 +11,7 @@ import { TransactionValue } from '../../../wallet/walletdb/transactionValue'
 import { WorkerPool } from '../../../workerPool'
 import { ValidationError } from '../../adapters'
 import {
-  RcpAccountAssetBalanceDelta,
+  RpcAccountAssetBalanceDelta,
   RpcAccountImport,
   RpcWalletNote,
   RpcWalletTransaction,
@@ -107,8 +107,8 @@ export function deserializeRpcAccountImport(accountImport: RpcAccountImport): Ac
 export async function getAssetBalanceDeltas(
   account: Account,
   transaction: TransactionValue,
-): Promise<RcpAccountAssetBalanceDelta[]> {
-  const assetBalanceDeltas = new Array<RcpAccountAssetBalanceDelta>()
+): Promise<RpcAccountAssetBalanceDelta[]> {
+  const assetBalanceDeltas = new Array<RpcAccountAssetBalanceDelta>()
 
   for (const [assetId, delta] of transaction.assetBalanceDeltas.entries()) {
     const asset = await account.getAsset(assetId)

--- a/ironfish/src/rpc/routes/worker/getStatus.ts
+++ b/ironfish/src/rpc/routes/worker/getStatus.ts
@@ -21,13 +21,13 @@ export type GetWorkersStatusResponse = {
   executing: number
   change: number
   speed: number
-  jobs: Array<{
+  jobs: {
     name: string
     complete: number
     execute: number
     queue: number
     error: number
-  }>
+  }[]
 }
 
 export const GetWorkersStatusRequestSchema: yup.ObjectSchema<GetWorkersStatusRequest> = yup

--- a/ironfish/src/rpc/types.ts
+++ b/ironfish/src/rpc/types.ts
@@ -33,8 +33,8 @@ export const RpcBurnSchema: yup.ObjectSchema<RpcBurn> = yup
 
 export type RpcMint = {
   assetId: string
-  transferOwnershipTo?: string
   value: string
+  transferOwnershipTo?: string
   /**
    * @deprecated Please use assetId instead
    */
@@ -59,31 +59,31 @@ export type RpcMint = {
 
 export const RpcMintSchema: yup.ObjectSchema<RpcMint> = yup
   .object({
+    assetId: yup.string().defined(),
+    value: yup.string().defined(),
+    transferOwnershipTo: yup.string().optional(),
     id: yup.string().defined(),
     metadata: yup.string().defined(),
     name: yup.string().defined(),
     creator: yup.string().defined(),
-    value: yup.string().defined(),
-    transferOwnershipTo: yup.string().optional(),
-    assetId: yup.string().defined(),
     assetName: yup.string().defined(),
   })
   .defined()
 
 export type RpcAsset = {
   id: string
-  metadata: string
   name: string
   nonce: number
-  creator: string
-  verification: AssetVerification
-  createdTransactionHash: string
   owner: string
+  creator: string
+  metadata: string
+  createdTransactionHash: string
+  verification: AssetVerification
+  supply?: string
   /**
    * @deprecated query for the transaction to find it's status
    */
   status: string
-  supply?: string
 }
 
 export const RpcAssetSchema: yup.ObjectSchema<RpcAsset> = yup
@@ -104,12 +104,12 @@ export const RpcAssetSchema: yup.ObjectSchema<RpcAsset> = yup
   .defined()
 
 export type RpcEncryptedNote = {
+  hash: string
+  serialized: string
   /**
    * @deprecated Please use hash instead
    */
   commitment: string
-  hash: string
-  serialized: string
 }
 
 export const RpcEncryptedNoteSchema: yup.ObjectSchema<RpcEncryptedNote> = yup
@@ -122,10 +122,6 @@ export const RpcEncryptedNoteSchema: yup.ObjectSchema<RpcEncryptedNote> = yup
 
 export type RpcBlockHeader = {
   hash: string
-  /**
-   * @deprecated Please use previousBlockHash instead
-   */
-  previous: string
   sequence: number
   previousBlockHash: string
   difficulty: string
@@ -137,6 +133,10 @@ export type RpcBlockHeader = {
   graffiti: string
   work: string
   noteSize: number | null
+  /**
+   * @deprecated Please use previousBlockHash instead
+   */
+  previous: string
 }
 
 export function serializeRpcBlockHeader(header: BlockHeader): RpcBlockHeader {
@@ -193,6 +193,11 @@ export type ConnectionState = Connection['state']['type'] | ''
 
 export type RpcPeerResponse = {
   state: string
+  connectionWebSocket: ConnectionState
+  connectionWebSocketError: string
+  connectionWebRTC: ConnectionState
+  connectionWebRTCError: string
+  connections: number
   identity: string | null
   version: number | null
   head: string | null
@@ -203,11 +208,6 @@ export type RpcPeerResponse = {
   address: string | null
   port: number | null
   error: string | null
-  connections: number
-  connectionWebSocket: ConnectionState
-  connectionWebSocketError: string
-  connectionWebRTC: ConnectionState
-  connectionWebRTCError: string
   networkId: number | null
   genesisBlockHash: string | null
   features: Features | null


### PR DESCRIPTION
## Summary

Formatting them in the following order: 

- fields
- objects
- optional fields 
- deprecated fields

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
