### PR TITLE
Update TESTNET hardfork 1 activation sequence

### DIFF
--- a/ironfish/src/defaultNetworkDefinitions.ts
+++ b/ironfish/src/defaultNetworkDefinitions.ts
@@ -36,8 +36,8 @@ export const TESTNET = `{
       "targetBucketTimeInSeconds": 10,
       "maxBlockSizeBytes": 524288,
       "minFee": 1,
-      "enableAssetOwnership": 9999999,
-      "enforceSequentialBlockTime": "never"
+      "enableAssetOwnership": 246468,
+      "enforceSequentialBlockTime": 246468
   }
 }`
 
@@ -57,7 +57,7 @@ export const MAINNET = `
         "targetBucketTimeInSeconds": 10,
         "maxBlockSizeBytes": 524288,
         "minFee": 1,
-        "enableAssetOwnership": 9999999,
+        "enableAssetOwnership": "never",
         "enforceSequentialBlockTime": "never"
     }
 }`


### PR DESCRIPTION
## Summary
This pr update the hardfork activation sequence for testnet. It updates the two changes in the hardfork 1.
The sequence is picked from FIP https://github.com/iron-fish/FIPs/pull/4
Sequence calculation https://www.notion.so/546dbc79da9f4e9d968da57bc7598905?v=763c971510384a0b80c71891daed2066


## Testing Plan
existing unit test
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
@mat-if @iron-fish/engineering 