### PR TITLE
Adding feerate to mint and burn

### DIFF
--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -38,6 +38,12 @@ export class Burn extends IronfishCommand {
       minimum: 1n,
       flagName: 'fee',
     }),
+    feeRate: IronFlag({
+      char: 'r',
+      description: 'The fee rate amount in IRON/Kilobyte',
+      minimum: 1n,
+      flagName: 'fee rate',
+    }),
     amount: IronFlag({
       char: 'a',
       description: 'Amount of coins to burn',
@@ -149,12 +155,13 @@ export class Burn extends IronfishCommand {
         },
       ],
       fee: flags.fee ? CurrencyUtils.encode(flags.fee) : null,
+      feeRate: flags.feeRate ? CurrencyUtils.encode(flags.feeRate) : null,
       expiration: flags.expiration,
       confirmations: flags.confirmations,
     }
 
     let raw: RawTransaction
-    if (params.fee === null) {
+    if (params.fee === null && params.feeRate === null) {
       raw = await selectFee({
         client,
         transaction: params,

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -43,6 +43,12 @@ export class Mint extends IronfishCommand {
       minimum: 1n,
       flagName: 'fee',
     }),
+    feeRate: IronFlag({
+      char: 'r',
+      description: 'The fee rate amount in IRON/Kilobyte',
+      minimum: 1n,
+      flagName: 'fee rate',
+    }),
     amount: IronFlag({
       char: 'a',
       description: 'Amount of coins to mint in IRON',
@@ -210,13 +216,13 @@ export class Mint extends IronfishCommand {
         },
       ],
       fee: flags.fee ? CurrencyUtils.encode(flags.fee) : null,
+      feeRate: flags.feeRate ? CurrencyUtils.encode(flags.feeRate) : null,
       expiration: flags.expiration,
       confirmations: flags.confirmations,
     }
 
     let raw: RawTransaction
-
-    if (params.fee === null) {
+    if (params.fee === null && params.feeRate === null) {
       raw = await selectFee({
         client,
         transaction: params,


### PR DESCRIPTION
## Summary

Fee rate is accepted in send transaction, mint and burn also "send" transactions. Adding the ability to include fee rate for these transaction wallet apis as well. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
