### PR TITLE
updates bridge-relay to use API for head state

### DIFF
--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -178,6 +178,31 @@ export class WebApi {
     await axios.post(`${this.host}/telemetry`, payload)
   }
 
+  async getBridgeHead(): Promise<string | undefined> {
+    this.requireToken()
+
+    const response = await axios
+      .get<{ hash: string }>(`${this.host}/bridge/head`)
+      .catch((e) => {
+        // The API returns 404 for no head
+        if (IsAxiosError(e) && e.response?.status === 404) {
+          return null
+        }
+
+        throw e
+      })
+
+    return response?.data.hash
+  }
+
+  async setBridgeHead(head: string): Promise<void> {
+    this.requireToken()
+
+    const options = this.options({ 'Content-Type': 'application/json' })
+
+    await axios.post(`${this.host}/bridge/head`, { head }, options)
+  }
+
   options(headers: Record<string, string> = {}): AxiosRequestConfig {
     return {
       headers: {

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -182,7 +182,7 @@ export class WebApi {
     this.requireToken()
 
     const response = await axios
-      .get<{ hash: string }>(`${this.host}/bridge/head`)
+      .get<{ hash: string }>(`${this.host}/bridge/head`, this.options())
       .catch((e) => {
         // The API returns 404 for no head
         if (IsAxiosError(e) && e.response?.status === 404) {


### PR DESCRIPTION
## Summary

gets head hash from '/bridge/head' if head flag is not set

posts head hash to '/bridge/head' after processing all deposits from a confirmed block

## Testing Plan

- manual testing
  - ran `service:bridge:relay` without starting head, stopped process after a few blocks
  - ran again, observed that it started at the most recently processed head

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
