### PR TITLE
Rahul/ifl 1690 remove dependence on deprecated status field

### DIFF
--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -59,16 +59,13 @@ export class AssetsCommand extends IronfishCommand {
 
     for await (const asset of response.contentStream()) {
       let status: string
-
       if (Asset.nativeId().toString('hex') === asset.id) {
         status = AssetStatus.CONFIRMED
       } else {
         const transaction = await client.wallet.getAccountTransaction({
           hash: asset.createdTransactionHash,
         })
-
         Assert.isNotNull(transaction.content.transaction)
-
         status = transaction.content.transaction.status
       }
 

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -8,7 +8,7 @@ import {
   ASSET_NAME_LENGTH,
   PUBLIC_ADDRESS_LENGTH,
 } from '@ironfish/rust-nodejs'
-import { Assert, AssetStatus, BufferUtils } from '@ironfish/sdk'
+import { BufferUtils } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
 import { IronfishCommand } from '../../command'
 import { RemoteFlags } from '../../flags'
@@ -58,17 +58,6 @@ export class AssetsCommand extends IronfishCommand {
     let showHeader = !flags['no-header']
 
     for await (const asset of response.contentStream()) {
-      let status: string
-      if (Asset.nativeId().toString('hex') === asset.id) {
-        status = AssetStatus.CONFIRMED
-      } else {
-        const transaction = await client.wallet.getAccountTransaction({
-          hash: asset.createdTransactionHash,
-        })
-        Assert.isNotNull(transaction.content.transaction)
-        status = transaction.content.transaction.status
-      }
-
       CliUx.ux.table(
         [asset],
         {
@@ -92,10 +81,8 @@ export class AssetsCommand extends IronfishCommand {
             width: assetMetadataWidth,
             get: (row) => BufferUtils.toHuman(Buffer.from(row.metadata, 'hex')),
           }),
-          status: {
-            header: 'Status',
-            minWidth: 12,
-            get: () => status,
+          createdTransactionHash: {
+            header: 'Created Transaction Hash',
           },
           supply: {
             header: 'Supply',

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -95,7 +95,7 @@ export class AssetsCommand extends IronfishCommand {
           status: {
             header: 'Status',
             minWidth: 12,
-            get: (row) => status,
+            get: () => status,
           },
           supply: {
             header: 'Supply',

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -1359,6 +1359,17 @@ export class Wallet {
     }
   }
 
+  /**
+   * Note: This logic will be deprecated when we move the field `status` from the Asset response object. The status field has
+   * more to do with the transaction than the asset itself.
+   *
+   * The getTransactionStatus field above is more relevant.
+   *
+   * @param account Account
+   * @param assetValue AssetValue
+   * @param options: { headSequence?: number | null;  confirmations?: number}
+   * @returns Promise<AssetStatus>
+   */
   async getAssetStatus(
     account: Account,
     assetValue: AssetValue,


### PR DESCRIPTION
## Summary

Using transaction status as single source of truth for status of an asset

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
