### PR TITLE
creates bridge deposit command

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/deposit.ts
+++ b/ironfish-cli/src/commands/service/bridge/deposit.ts
@@ -98,12 +98,7 @@ export class Deposit extends IronfishCommand {
 
     const assetId = flags.assetId ?? Asset.nativeId().toString('hex')
 
-    let to = flags.to
-    if (!to) {
-      to = await CliUx.ux.prompt('Enter the public Iron Fish address of the bridge', {
-        required: true,
-      })
-    }
+    const to = flags.to ?? (await api.getBridgeAddress())
 
     let amount = flags.amount
     if (amount == null) {

--- a/ironfish-cli/src/commands/service/bridge/deposit.ts
+++ b/ironfish-cli/src/commands/service/bridge/deposit.ts
@@ -59,10 +59,6 @@ export class Deposit extends IronfishCommand {
         'Minimum number of block confirmations needed to include a note. Set to 0 to include all blocks.',
       required: false,
     }),
-    assetId: Flags.string({
-      char: 'i',
-      description: 'The identifier for the asset to deposit',
-    }),
     dest: Flags.string({
       description: 'Eth public address to deposit to',
       required: true,
@@ -96,7 +92,7 @@ export class Deposit extends IronfishCommand {
     const account =
       flags.account ?? (await client.wallet.getDefaultAccount()).content.account?.name
 
-    const assetId = flags.assetId ?? Asset.nativeId().toString('hex')
+    const assetId = Asset.nativeId().toString('hex')
 
     const to = flags.to ?? (await api.getBridgeAddress())
 

--- a/ironfish-cli/src/commands/service/bridge/deposit.ts
+++ b/ironfish-cli/src/commands/service/bridge/deposit.ts
@@ -134,6 +134,7 @@ export class Deposit extends IronfishCommand {
     }
 
     const response = await api.createDeposit({
+      amount: amount.toString(),
       asset: assetId,
       source_address: publicKey,
       destination_address: flags.dest,

--- a/ironfish-cli/src/commands/service/bridge/deposit.ts
+++ b/ironfish-cli/src/commands/service/bridge/deposit.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
+import { WebApi } from '@ironfish/sdk'
+import { Flags } from '@oclif/core'
+import { IronfishCommand } from '../../../command'
+
+export class Deposit extends IronfishCommand {
+  static description = `Deposit coins to the bridge`
+
+  static flags = {
+    endpoint: Flags.string({
+      char: 'e',
+      description: 'API host to sync to',
+      parse: (input: string) => Promise.resolve(input.trim()),
+      env: 'IRONFISH_API_HOST',
+    }),
+    token: Flags.string({
+      char: 't',
+      description: 'API token to authenticate with',
+      parse: (input: string) => Promise.resolve(input.trim()),
+      env: 'IRONFISH_API_TOKEN',
+    }),
+    assetId: Flags.string({
+      char: 'i',
+      description: 'The identifier for the asset to deposit',
+    }),
+    source: Flags.string({
+      description: 'Iron Fish public address to deposit from',
+      required: true,
+    }),
+    dest: Flags.string({
+      description: 'Eth public address to deposit to',
+      required: true,
+    }),
+  }
+
+  async start(): Promise<void> {
+    const { flags } = await this.parse(Deposit)
+
+    if (!flags.endpoint) {
+      this.log(
+        `No api host set. You must set IRONFISH_API_HOST env variable or pass --endpoint flag.`,
+      )
+      this.exit(1)
+    }
+
+    if (!flags.token) {
+      this.log(
+        `No api token set. You must set IRONFISH_API_TOKEN env variable or pass --token flag.`,
+      )
+      this.exit(1)
+    }
+
+    const api = new WebApi({ host: flags.endpoint, token: flags.token })
+
+    const assetId = flags.assetId ?? Asset.nativeId().toString('hex')
+
+    const response = await api.createDeposit({
+      asset: assetId,
+      source_address: flags.source,
+      destination_address: flags.dest,
+    })
+
+    const depositId = response[flags.source]
+
+    this.log(`Deposit memo: ${depositId}`)
+  }
+}

--- a/ironfish-cli/src/commands/service/bridge/deposit.ts
+++ b/ironfish-cli/src/commands/service/bridge/deposit.ts
@@ -153,7 +153,7 @@ export class Deposit extends IronfishCommand {
     }
 
     this.log(
-      `\nDepost transaction:\n` +
+      `\nDeposit transaction:\n` +
         `From address:      ${publicKey}\n` +
         `To bridge address: ${to}\n` +
         `Memo:              ${depositId}\n` +

--- a/ironfish-cli/src/utils/currency.ts
+++ b/ironfish-cli/src/utils/currency.ts
@@ -17,6 +17,7 @@ export async function promptCurrency(options: {
     assetId?: string
     confirmations?: number
   }
+  default?: string
 }): Promise<bigint>
 
 export async function promptCurrency(options: {
@@ -30,6 +31,7 @@ export async function promptCurrency(options: {
     assetId?: string
     confirmations?: number
   }
+  default?: string
 }): Promise<bigint | null> {
   let text = options.text
 
@@ -47,6 +49,7 @@ export async function promptCurrency(options: {
   while (true) {
     const input = await CliUx.ux.prompt(text, {
       required: options.required,
+      default: options.default,
     })
 
     if (!input) {

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -218,6 +218,7 @@ export class WebApi {
   }
 
   async createDeposit(payload: {
+    amount: string
     asset: string
     source_address: string
     destination_address: string

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -217,6 +217,33 @@ export class WebApi {
     await axios.post(`${this.host}/bridge/send`, { sends }, this.options())
   }
 
+  async createDeposit(payload: {
+    asset: string
+    source_address: string
+    destination_address: string
+  }): Promise<{ [keyof: string]: number }> {
+    this.requireToken()
+
+    const response = await axios.post<{ [keyof: string]: number }>(
+      `${this.host}/bridge/create`,
+      {
+        requests: [
+          {
+            ...payload,
+            source_chain: 'IRONFISH',
+            destination_chain: 'ETHEREUM',
+            source_transaction: null,
+            destination_transaction: null,
+            status: 'PENDING',
+          },
+        ],
+      },
+      this.options(),
+    )
+
+    return response.data
+  }
+
   options(headers: Record<string, string> = {}): AxiosRequestConfig {
     return {
       headers: {

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -245,6 +245,11 @@ export class WebApi {
     return response.data
   }
 
+  async getBridgeAddress(): Promise<string> {
+    const response = await axios.get<{ address: string }>(`${this.host}/bridge/address`)
+    return response.data.address
+  }
+
   options(headers: Record<string, string> = {}): AxiosRequestConfig {
     return {
       headers: {

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -234,7 +234,7 @@ export class WebApi {
             destination_chain: 'ETHEREUM',
             source_transaction: null,
             destination_transaction: null,
-            status: 'PENDING',
+            status: 'CREATED',
           },
         ],
       },


### PR DESCRIPTION
## Summary

'service:bridge:deposit' creates a bridge deposit request to the bridge API and displays the returned key to use in the deposit transaction memo

## Testing Plan

manual testing:
<img width="206" alt="image" src="https://github.com/iron-fish/ironfish/assets/57735705/f79f7828-ba4d-49da-8417-0edb3cd2ae75">


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
