### PR TITLE
adds github workflow to deploy bridge-prototype docker image

### DIFF
--- a/.github/workflows/deploy-bridge-docker-image.yml
+++ b/.github/workflows/deploy-bridge-docker-image.yml
@@ -1,0 +1,44 @@
+name: Deploy Bridge Prototype Node Docker Image
+on:
+  push:
+    branches:
+      - bridge-prototype
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  Deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Registry
+        run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_USER} --password-stdin ghcr.io
+        env:
+          GITHUB_USER: ${{ secrets.BREW_GITHUB_USERNAME }}
+          GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to AWS Registry
+        run: aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $AWS_REGISTRY_URL
+        env:
+          AWS_REGISTRY_URL: ${{ secrets.AWS_NODE_REGISTRY_URL }}
+
+      - name: Build Node Image
+        run: ./ironfish-cli/scripts/build-docker.sh
+
+      - name: Deploy Node Image to AWS:${{ github.ref_name }}
+        run: |
+          docker tag ironfish ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}
+          docker push ${{ secrets.AWS_NODE_REGISTRY_URL }}/ironfish:${{ github.ref_name }}


### PR DESCRIPTION
## Summary

pushes to 'bridge-prototype' branch will trigger a docker image deployment with the 'bridge-prototype' tag

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
