### PR TITLE
adding string length limit to node name

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -332,7 +332,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     // to parse logPrefix
     logPrefix: yup.string(),
     blockGraffiti: yup.string(),
-    nodeName: yup.string(),
+    nodeName: yup.string().max(32),
     nodeWorkers: yup.number().integer().min(-1),
     nodeWorkersMax: yup.number().integer().min(-1),
     p2pSimulateLatency: YupUtils.isPositiveInteger,

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -30,7 +30,7 @@ import { GetBlockHeadersRequest, GetBlockHeadersResponse } from './messages/getB
 import { GetBlocksRequest, GetBlocksResponse } from './messages/getBlocks'
 import {
   GetBlockTransactionsRequest,
-  GetBlockTransactionsResponse
+  GetBlockTransactionsResponse,
 } from './messages/getBlockTransactions'
 import { GetCompactBlockRequest, GetCompactBlockResponse } from './messages/getCompactBlock'
 import { displayNetworkMessageType, NetworkMessage } from './messages/networkMessage'
@@ -40,16 +40,18 @@ import { NewPooledTransactionHashes } from './messages/newPooledTransactionHashe
 import { NewTransactionsMessage } from './messages/newTransactions'
 import {
   PooledTransactionsRequest,
-  PooledTransactionsResponse
+  PooledTransactionsResponse,
 } from './messages/pooledTransactions'
 import {
-  Direction, RpcId,
-  RpcNetworkMessage, RPC_TIMEOUT_MILLIS
+  Direction,
+  RPC_TIMEOUT_MILLIS,
+  RpcId,
+  RpcNetworkMessage,
 } from './messages/rpcNetworkMessage'
 import {
   CannotSatisfyRequestError,
   NetworkError,
-  RequestTimeoutError
+  RequestTimeoutError,
 } from './peers/connections'
 import { LocalPeer } from './peers/localPeer'
 import { BAN_SCORE, KnownBlockHashesValue, Peer } from './peers/peer'
@@ -64,7 +66,7 @@ import {
   MAX_HEADER_LOOKUPS,
   MAX_REQUESTED_HEADERS,
   SOFT_MAX_MESSAGE_SIZE,
-  VERSION_PROTOCOL
+  VERSION_PROTOCOL,
 } from './version'
 import { WebSocketServer } from './webSocketServer'
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -30,7 +30,7 @@ import { GetBlockHeadersRequest, GetBlockHeadersResponse } from './messages/getB
 import { GetBlocksRequest, GetBlocksResponse } from './messages/getBlocks'
 import {
   GetBlockTransactionsRequest,
-  GetBlockTransactionsResponse,
+  GetBlockTransactionsResponse
 } from './messages/getBlockTransactions'
 import { GetCompactBlockRequest, GetCompactBlockResponse } from './messages/getCompactBlock'
 import { displayNetworkMessageType, NetworkMessage } from './messages/networkMessage'
@@ -40,18 +40,16 @@ import { NewPooledTransactionHashes } from './messages/newPooledTransactionHashe
 import { NewTransactionsMessage } from './messages/newTransactions'
 import {
   PooledTransactionsRequest,
-  PooledTransactionsResponse,
+  PooledTransactionsResponse
 } from './messages/pooledTransactions'
 import {
-  Direction,
-  RPC_TIMEOUT_MILLIS,
-  RpcId,
-  RpcNetworkMessage,
+  Direction, RpcId,
+  RpcNetworkMessage, RPC_TIMEOUT_MILLIS
 } from './messages/rpcNetworkMessage'
 import {
   CannotSatisfyRequestError,
   NetworkError,
-  RequestTimeoutError,
+  RequestTimeoutError
 } from './peers/connections'
 import { LocalPeer } from './peers/localPeer'
 import { BAN_SCORE, KnownBlockHashesValue, Peer } from './peers/peer'
@@ -66,7 +64,7 @@ import {
   MAX_HEADER_LOOKUPS,
   MAX_REQUESTED_HEADERS,
   SOFT_MAX_MESSAGE_SIZE,
-  VERSION_PROTOCOL,
+  VERSION_PROTOCOL
 } from './version'
 import { WebSocketServer } from './webSocketServer'
 
@@ -228,7 +226,7 @@ export class PeerNetwork {
     this.requests = new Map<RpcId, RpcRequest>()
 
     if (options.name && options.name.length > 32) {
-      options.name = options.name.slice(32)
+      options.name = options.name.slice(0, 32)
     }
 
     this.blockFetcher = new BlockFetcher(this)


### PR DESCRIPTION
## Summary

Limiting size of node name to 32 letters. Other peers cannot connect to you if you have a long node name. 

<img width="1381" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/fd0716eb-b736-4c63-8447-b8591f80e35e">


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
