### PR TITLE
Adding hex flag to handle invalid hex field

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -12,7 +12,7 @@ import {
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
 import { IronfishCommand } from '../../command'
-import { IronFlag, RemoteFlags } from '../../flags'
+import { HexFlag, IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
 import { selectFee } from '../../utils/fees'
@@ -77,7 +77,7 @@ export class Send extends IronfishCommand {
         'Minimum number of block confirmations needed to include a note. Set to 0 to include all blocks.',
       required: false,
     }),
-    assetId: Flags.string({
+    assetId: HexFlag({
       char: 'i',
       description: 'The identifier for the asset to use when sending',
     }),

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -156,3 +156,14 @@ export const parseIron = (input: string, opts: IronOpts): Promise<bigint> => {
     }
   })
 }
+
+export const HexFlag = Flags.custom<string>({
+  parse: async (input, _ctx, opts) => {
+    const hexRegex = /^[0-9A-Fa-f]+$/g
+    if (!hexRegex.test(input)) {
+      throw new Error(`The hex string is invalid for field ${opts.name}`)
+    }
+
+    return Promise.resolve(input)
+  },
+})

--- a/ironfish-cli/src/flags.ts
+++ b/ironfish-cli/src/flags.ts
@@ -161,7 +161,9 @@ export const HexFlag = Flags.custom<string>({
   parse: async (input, _ctx, opts) => {
     const hexRegex = /^[0-9A-Fa-f]+$/g
     if (!hexRegex.test(input)) {
-      throw new Error(`The hex string is invalid for field ${opts.name}`)
+      throw new Error(
+        `The value provided for ${opts.name} is an invalid format. It must be a hex string.`,
+      )
     }
 
     return Promise.resolve(input)


### PR DESCRIPTION
## Summary

Fixes: IFL-1714

https://linear.app/if-labs/issue/IFL-1714/cli-crashes-with-assetid-flag

Result (on Testnet)

Invalid hex value for asset id: 
<img width="1422" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/e1f7aebc-4e7d-4072-b868-c36ce1e4c1c8">

Valid hex value: 
<img width="1406" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/4a4b8651-568e-48db-a6b4-2d5280b89509">


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
