### PR TITLE
Remove unused simulate-latency code

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -96,7 +96,6 @@ export type ConfigOptions = {
    * The max number of node workers. See config "nodeWorkers"
    */
   nodeWorkersMax: number
-  p2pSimulateLatency: number
   peerPort: number
   rpcTcpHost: string
   rpcTcpPort: number
@@ -335,7 +334,6 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     nodeName: yup.string(),
     nodeWorkers: yup.number().integer().min(-1),
     nodeWorkersMax: yup.number().integer().min(-1),
-    p2pSimulateLatency: YupUtils.isPositiveInteger,
     peerPort: YupUtils.isPort,
     rpcTcpHost: yup.string().trim(),
     rpcTcpPort: YupUtils.isPort,
@@ -442,7 +440,6 @@ export class Config extends KeyStore<ConfigOptions> {
       nodeName: '',
       nodeWorkers: -1,
       nodeWorkersMax: 6,
-      p2pSimulateLatency: 0,
       peerPort: DEFAULT_WEBSOCKET_PORT,
       rpcTcpHost: 'localhost',
       rpcTcpPort: 8020,

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -165,7 +165,6 @@ export class PeerNetwork {
     targetPeers?: number
     enableSyncing?: boolean
     logPeerMessages?: boolean
-    simulateLatency?: number
     logger?: Logger
     metrics?: MetricsMonitor
     telemetry: Telemetry
@@ -196,7 +195,6 @@ export class PeerNetwork {
 
     this.localPeer.port = options.port === undefined ? null : options.port
     this.localPeer.name = options.name || null
-    this.localPeer.simulateLatency = options.simulateLatency || 0
 
     const maxPeers = options.maxPeers || 10000
     const targetPeers = options.targetPeers || 50

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -59,19 +59,14 @@ export class WebRtcConnection extends Connection {
     initiator: boolean,
     logger: Logger,
     metrics?: MetricsMonitor,
-    options: { simulateLatency?: number; stunServers?: string[] } = {},
+    options: { stunServers?: string[] } = {},
   ) {
     super(
       ConnectionType.WebRtc,
       initiator ? ConnectionDirection.Outbound : ConnectionDirection.Inbound,
       logger.withTag('webrtcconnection'),
       metrics,
-      options,
     )
-
-    if (this.simulateLatency) {
-      this.addLatencyWrapper()
-    }
 
     this.peer = new nodeDataChannel.PeerConnection('peer', {
       iceServers: options.stunServers ?? [],

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -29,23 +29,13 @@ export class WebSocketConnection extends Connection {
     direction: ConnectionDirection,
     logger: Logger,
     metrics?: MetricsMonitor,
-    options: { simulateLatency?: number; hostname?: string; port?: number } = {},
+    options: { hostname?: string; port?: number } = {},
   ) {
-    super(
-      ConnectionType.WebSocket,
-      direction,
-      logger.withTag('WebSocketConnection'),
-      metrics,
-      options,
-    )
+    super(ConnectionType.WebSocket, direction, logger.withTag('WebSocketConnection'), metrics)
 
     this.socket = socket
     this.hostname = options.hostname
     this.port = options.port
-
-    if (this.simulateLatency) {
-      this.addLatencyWrapper()
-    }
 
     if (this.socket.readyState === this.socket.OPEN) {
       this.setState({ type: 'WAITING_FOR_IDENTITY' })

--- a/ironfish/src/network/peers/localPeer.ts
+++ b/ironfish/src/network/peers/localPeer.ts
@@ -33,8 +33,6 @@ export class LocalPeer {
   port: number | null
   // optional a human readable name for the node
   name: string | null
-  // simulated latency in MS that gets added to connection.send
-  simulateLatency = 0
 
   constructor(
     identity: PrivateIdentity,

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -312,7 +312,6 @@ export class PeerManager {
     port: number | null,
   ): WebSocketConnection {
     const connection = new WebSocketConnection(ws, direction, this.logger, this.metrics, {
-      simulateLatency: this.localPeer.simulateLatency,
       hostname: hostname || undefined,
       port: port || undefined,
     })
@@ -330,7 +329,6 @@ export class PeerManager {
    */
   private initWebRtcConnection(peer: Peer, initiator: boolean): WebRtcConnection {
     const connection = new WebRtcConnection(initiator, this.logger, this.metrics, {
-      simulateLatency: this.localPeer.simulateLatency,
       stunServers: this.stunServers,
     })
 

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -141,7 +141,6 @@ export class FullNode {
       enableSyncing: config.get('enableSyncing'),
       targetPeers: config.get('targetPeers'),
       logPeerMessages: config.get('logPeerMessages'),
-      simulateLatency: config.get('p2pSimulateLatency'),
       bootstrapNodes: config.getArray('bootstrapNodes'),
       stunServers: config.getArray('p2pStunServers'),
       webSocket: webSocket,


### PR DESCRIPTION
## Summary

From what I understand, this doesn't function correctly, and we have better tooling for this now (see ironfish-tank folder)

## Testing Plan

Ran lint, tests, and manually ran a node on mainnet

## Documentation

N/A

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```

This removes the `simulateLatency` config option and functionality
