### PR TITLE
fixes bridge request id type in relay service

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/relay.ts
+++ b/ironfish-cli/src/commands/service/bridge/relay.ts
@@ -133,7 +133,7 @@ export default class BridgeRelay extends IronfishCommand {
       for (const note of transaction.notes) {
         this.log(`Received deposit ${note.memo} in transaction ${transaction.hash}`)
         sends.push({
-          id: note.memo,
+          id: Number(note.memo),
           amount: note.value,
           asset: note.assetId,
           source_address: note.sender,

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -205,7 +205,7 @@ export class WebApi {
 
   async sendBridgeDeposits(
     sends: {
-      id: string
+      id: number
       amount: string
       asset: string
       source_address: string


### PR DESCRIPTION
## Summary

request id is a number, not a string

## Testing Plan

manual testing: ran `service:bridge:relay` to sync a deposit to local bridge api

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
