### PR TITLE
updates bridge relay to watch for confirmed release transactions

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/relay.ts
+++ b/ironfish-cli/src/commands/service/bridge/relay.ts
@@ -164,6 +164,9 @@ export default class BridgeRelay extends IronfishCommand {
         }
 
         if (note.sender === bridgeAddress) {
+          this.log(
+            `Confirmed release of bridge request ${note.memo} in transaction ${transaction.hash}`,
+          )
           confirms.push({
             id: Number(note.memo),
             destination_transaction: transaction.hash,


### PR DESCRIPTION
## Summary

updates chain/getTransactionStream to optionally accept an outgoingViewKey to use to decrypt notes

compares the sender address to the bridge address to determine if the bridge sent the transaction

collects confirmed transactions that the bridge sent and passes them to the bridge api to update request statuses to 'CONFIRMED'

## Testing Plan

manual testing:
- created record in local bridge api database with PENDING_IRON_RELEASE_TRANSACTION_CONFIRMATION status
- sent 'release' transaction matching record
- ran relay, verified status updated to CONFIRMED


## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
