### PR TITLE
Set the default targetPeers value to 45

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -453,7 +453,7 @@ export class Config extends KeyStore<ConfigOptions> {
       maxPeers: 50,
       confirmations: 2,
       minPeers: 1,
-      targetPeers: 50,
+      targetPeers: 45,
       telemetryApi: '',
       assetVerificationApi: '',
       generateNewIdentity: false,

--- a/ironfish/src/network/blockFetcher.test.ts
+++ b/ironfish/src/network/blockFetcher.test.ts
@@ -468,7 +468,7 @@ describe('BlockFetcher', () => {
   it('correctly sends the first peer to send us a block to telemetry', async () => {
     const { peerNetwork, chain, node } = nodeTest
 
-    const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 50)
+    const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 45)
 
     const newBlock = await useMinerBlockFixture(chain)
 


### PR DESCRIPTION
## Summary

The default maxPeers is 50, as is the current default targetPeers. The logic is currently such that you continuously open outbound connections until you reach targetPeers. If targetPeers threshold is met, but maxPeers is not, you will continue accepting inbound connections. By setting these values separately, we create a buffer to allow for more inbound connections. This should have a downstream effect of allowing other peers to each peer saturation faster.

## Testing Plan

Unit tests, manual testing a node

## Documentation

N/A

## Breaking Change

N/A
