### PR TITLE
filters out non-numeric memos before sending to bridge api

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/relay.ts
+++ b/ironfish-cli/src/commands/service/bridge/relay.ts
@@ -163,19 +163,25 @@ export default class BridgeRelay extends IronfishCommand {
           continue
         }
 
+        const requestId = Number(note.memo)
+
+        if (isNaN(requestId)) {
+          continue
+        }
+
         if (note.sender === bridgeAddress) {
           this.log(
             `Confirmed release of bridge request ${note.memo} in transaction ${transaction.hash}`,
           )
           confirms.push({
-            id: Number(note.memo),
+            id: requestId,
             destination_transaction: transaction.hash,
             status: 'CONFIRMED',
           })
         } else {
           this.log(`Received deposit ${note.memo} in transaction ${transaction.hash}`)
           sends.push({
-            id: Number(note.memo),
+            id: requestId,
             amount: note.value,
             asset: note.assetId,
             source_address: note.sender,


### PR DESCRIPTION
## Summary

we use note memos to track the bridge request ID associated with transactions

if the memo is non-numeric then the transaction can't be tied to any bridge request in the api

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
