### PR TITLE
adds prompt for eth dest address to deposit

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/deposit.ts
+++ b/ironfish-cli/src/commands/service/bridge/deposit.ts
@@ -97,7 +97,7 @@ export class Deposit extends IronfishCommand {
 
     let dest = flags.dest
     if (dest == null) {
-      dest = await CliUx.ux.prompt('Enter an Eth address to send WIRON to', { required: true })
+      dest = await CliUx.ux.prompt('Enter an ETH address to send WIRON to on Sepolia testnet', { required: true })
     }
 
     let amount = flags.amount

--- a/ironfish-cli/src/commands/service/bridge/deposit.ts
+++ b/ironfish-cli/src/commands/service/bridge/deposit.ts
@@ -97,7 +97,9 @@ export class Deposit extends IronfishCommand {
 
     let dest = flags.dest
     if (dest == null) {
-      dest = await CliUx.ux.prompt('Enter an ETH address to send WIRON to on Sepolia testnet', { required: true })
+      dest = await CliUx.ux.prompt('Enter an ETH address to send WIRON to on Sepolia testnet', {
+        required: true,
+      })
     }
 
     let amount = flags.amount

--- a/ironfish-cli/src/commands/service/bridge/deposit.ts
+++ b/ironfish-cli/src/commands/service/bridge/deposit.ts
@@ -61,7 +61,6 @@ export class Deposit extends IronfishCommand {
     }),
     dest: Flags.string({
       description: 'Eth public address to deposit to',
-      required: true,
     }),
   }
 
@@ -96,6 +95,11 @@ export class Deposit extends IronfishCommand {
 
     const to = flags.to ?? (await api.getBridgeAddress())
 
+    let dest = flags.dest
+    if (dest == null) {
+      dest = await CliUx.ux.prompt('Enter an Eth address to send WIRON to', { required: true })
+    }
+
     let amount = flags.amount
     if (amount == null) {
       amount = await promptCurrency({
@@ -128,7 +132,7 @@ export class Deposit extends IronfishCommand {
       amount: amount.toString(),
       asset: assetId,
       source_address: publicKey,
-      destination_address: flags.dest,
+      destination_address: dest,
     })
 
     const depositId = response[publicKey]


### PR DESCRIPTION
## Summary

prompts the user to enter an address if one was not provided instead of requiring the flag be set

## Testing Plan

manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
