### PR TITLE
Use connected peers when deciding peer limits

### DIFF
--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -575,10 +575,6 @@ export class PeerManager {
     peer.close()
   }
 
-  getPeersWithConnection(): ReadonlyArray<Peer> {
-    return this.peers.filter((p) => p.state.type !== 'DISCONNECTED')
-  }
-
   getConnectedPeers(): ReadonlyArray<Peer> {
     return [...this.identifiedPeers.values()].filter((p) => {
       return p.state.type === 'CONNECTED'
@@ -590,14 +586,14 @@ export class PeerManager {
    * than the target amount of peers
    */
   canCreateNewConnections(): boolean {
-    return this.getPeersWithConnection().length < this.targetPeers
+    return this.getConnectedPeers().length < this.targetPeers
   }
 
   /**
    * True if we should reject connections from disconnected Peers.
    */
   shouldRejectDisconnectedPeers(): boolean {
-    return this.getPeersWithConnection().length >= this.maxPeers
+    return this.getConnectedPeers().length >= this.maxPeers
   }
 
   /** For a given peer, try to find a peer that's connected to that peer


### PR DESCRIPTION
## Summary

This uses connected nodes instead of non-disconnected nodes to determine if a node should continue making outbound connections and accepting inbound connections. The main change here is that we are making the assumption that most node connections will fail, so this allows a node to have more active connection attempts. The end goal should be faster peer saturation. This does introduce the possibility of a node to have more than maxPeers connected peers. The current assumption is that natural attrition will take care of this, however, it would be a low amount of effort to add additional logic to prune peers if above maxPeers if it ends up being an issue.

## Testing Plan

Manual testing: run `ironfish peers --all`

## Documentation

N/A

## Breaking Change

N/A