### PR TITLE
updates relay service to decode eth address from memo

### DIFF
--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -93,6 +93,10 @@ export class Note {
     return BufferUtils.toHuman(this._memo)
   }
 
+  memoHex(): string {
+    return this._memo.toString('hex')
+  }
+
   assetId(): Buffer {
     return this._assetId
   }

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -31,6 +31,8 @@ interface Note {
   hash: string
   value: string
   memo: string
+  // unsanitized hex string representation of the memo
+  memoHex: string
   sender: string
 }
 
@@ -50,6 +52,7 @@ const NoteSchema = yup
     hash: yup.string().required(),
     value: yup.string().required(),
     memo: yup.string().required(),
+    memoHex: yup.string().required(),
     sender: yup.string().required(),
   })
   .required()
@@ -153,6 +156,7 @@ routes.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
             notes.push({
               value: CurrencyUtils.encode(decryptedNote.value()),
               memo: decryptedNote.memo(),
+              memoHex: decryptedNote.memoHex(),
               assetId: decryptedNote.assetId().toString('hex'),
               assetName: assetValue?.name.toString('hex') || '',
               hash: decryptedNote.hash().toString('hex'),

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -218,11 +218,13 @@ export class WebApi {
 
   async sendBridgeDeposits(
     sends: {
-      id: number
       amount: string
       asset: string
       source_address: string
+      source_chain: string
       source_transaction: string
+      destination_address: string
+      destination_chain: string
     }[],
   ): Promise<void> {
     this.requireToken()


### PR DESCRIPTION
## Summary

adds 'memoHex' function to the Note to be able to return the memo as a string without stripping out non-human-readable characters

returns 'memoHex' with each note in getTransactionStream

decodes eth address from memo by converting to utf8, then base64, then back to hex. the memo string is converted to a buffer with utf8 encoding during transaction creation, so we need to convert it to a utf8 string before converting to a base64 string

updates request payload for '/bridge/send'

## Testing Plan

manual testing with deposit changes and bridge API changes

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
