### PR TITLE
Fix status follow erroring out

### DIFF
--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -69,7 +69,14 @@ export default class Status extends IronfishCommand {
 
       // eslint-disable-next-line no-constant-condition
       while (true) {
-        const value = await this.sdk.client.node.getStatus()
+        const value = await this.sdk.client.node.getStatus().catch((_) => {
+          return null
+        })
+
+        if (value === null) {
+          break
+        }
+
         statusText.clearBaseLine(0)
         statusText.setContent(renderStatus(value.content, flags.all))
         screen.render()

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -75,9 +75,6 @@ export default class Status extends IronfishCommand {
           value = await this.sdk.client.node.getStatus()
         } catch (e) {
           value = null
-        }
-
-        if (value === null) {
           break
         }
 

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -7,7 +7,6 @@ import {
   FileUtils,
   GetNodeStatusResponse,
   PromiseUtils,
-  RpcResponseEnded,
   TimeUtils,
 } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
@@ -70,18 +69,15 @@ export default class Status extends IronfishCommand {
 
       // eslint-disable-next-line no-constant-condition
       while (true) {
-        let value: RpcResponseEnded<GetNodeStatusResponse> | null = null
         try {
-          value = await this.sdk.client.node.getStatus()
+          previousResponse = (await this.sdk.client.node.getStatus()).content
         } catch (e) {
-          value = null
           break
         }
 
         statusText.clearBaseLine(0)
-        statusText.setContent(renderStatus(value.content, flags.all))
+        statusText.setContent(renderStatus(previousResponse, flags.all))
         screen.render()
-        previousResponse = value.content
         await PromiseUtils.sleep(1000)
       }
     }

--- a/ironfish-cli/src/commands/status.ts
+++ b/ironfish-cli/src/commands/status.ts
@@ -7,6 +7,7 @@ import {
   FileUtils,
   GetNodeStatusResponse,
   PromiseUtils,
+  RpcResponseEnded,
   TimeUtils,
 } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
@@ -69,9 +70,12 @@ export default class Status extends IronfishCommand {
 
       // eslint-disable-next-line no-constant-condition
       while (true) {
-        const value = await this.sdk.client.node.getStatus().catch((_) => {
-          return null
-        })
+        let value: RpcResponseEnded<GetNodeStatusResponse> | null = null
+        try {
+          value = await this.sdk.client.node.getStatus()
+        } catch (e) {
+          value = null
+        }
 
         if (value === null) {
           break


### PR DESCRIPTION
## Summary
With previous changes in https://github.com/iron-fish/ironfish/pull/4312 the status stream breaks if a node disconnects in the middle of a status follow. Fixing that problem

## Testing Plan
Tested locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
