### PR TITLE
Fix custom asset fetching when passing a non-default account to wallet:transactions

### DIFF
--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -91,12 +91,16 @@ export class TransactionsCommand extends IronfishCommand {
         const assetLookup = await getAssetsByIDs(
           client,
           transaction.notes.map((n) => n.assetId) || [],
+          account,
+          flags.confirmations,
         )
         transactionRows = this.getTransactionRowsByNote(assetLookup, transaction, format)
       } else {
         const assetLookup = await getAssetsByIDs(
           client,
           transaction.assetBalanceDeltas.map((d) => d.assetId),
+          account,
+          flags.confirmations,
         )
         transactionRows = this.getTransactionRows(assetLookup, transaction, format)
       }

--- a/ironfish-cli/src/utils/asset.ts
+++ b/ironfish-cli/src/utils/asset.ts
@@ -102,6 +102,8 @@ export async function selectAsset(
   const assetLookup = await getAssetsByIDs(
     client,
     balances.map((b) => b.assetId),
+    account,
+    options.confirmations,
   )
   if (!options.showNativeAsset) {
     balances = balances.filter((b) => b.assetId !== Asset.nativeId().toString('hex'))
@@ -164,9 +166,13 @@ export async function selectAsset(
 export async function getAssetsByIDs(
   client: Pick<RpcClient, 'wallet'>,
   assetIds: string[],
+  account: string | undefined,
+  confirmations: number | undefined,
 ): Promise<{ [key: string]: RpcAsset }> {
   assetIds = [...new Set(assetIds)]
-  const assets = await Promise.all(assetIds.map((id) => client.wallet.getAsset({ id })))
+  const assets = await Promise.all(
+    assetIds.map((id) => client.wallet.getAsset({ id, account, confirmations })),
+  )
   const assetLookup: { [key: string]: RpcAsset } = {}
   assets.forEach((asset) => {
     assetLookup[asset.content.id] = asset.content


### PR DESCRIPTION
## Summary

In `selectAsset` and `ironfish wallet:transactions`, the account flag and confirmation flag weren't being passed to the getAsset RPC call. This resulted in an error when running `ironfish wallet:transactions <nonDefaultAccount>` when the non-default account had custom assets that the default account did not:

```
No asset found with identifier 2822ed1455752040fd780d43d64f56ea624be6f17c5c96e20ae06ff3f2c7ec39
```

Fixed this by passing the flags through to `getAsset`.

## Testing Plan

* [x] Ran `ironfish wallet:transactions` on an account with hashing algo vote tokens to verify the bug, then again to verify the fix

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
