### PR TITLE
updates status for pending release

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/release.ts
+++ b/ironfish-cli/src/commands/service/bridge/release.ts
@@ -212,7 +212,7 @@ export default class Release extends IronfishCommand {
       updatePayload.push({
         id: request.id,
         destination_transaction: tx.content.hash,
-        status: 'PENDING_IRON_RELEASE_TRANSACTION_CONFIRMATION',
+        status: 'PENDING_DESTINATION_RELEASE_TRANSACTION_CONFIRMATION',
       })
     }
 


### PR DESCRIPTION
## Summary

propagates status name change from API:
PENDING_IRON_RELEASE_TRANSACTION_CONFIRMATION changed to PENDING_DESTINATION_RELEASE_TRANSACTION_CONFIRMATION

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
