### PR TITLE
updates webApi bridge endpoints

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/relay.ts
+++ b/ironfish-cli/src/commands/service/bridge/relay.ts
@@ -206,7 +206,7 @@ export default class BridgeRelay extends IronfishCommand {
     }
 
     if (confirms.length > 0) {
-      await api.updateWIronRequests(confirms)
+      await api.updateBridgeRequests(confirms)
     }
 
     if (sends.length > 0) {

--- a/ironfish-cli/src/commands/service/bridge/release.ts
+++ b/ironfish-cli/src/commands/service/bridge/release.ts
@@ -135,7 +135,7 @@ export default class Release extends IronfishCommand {
       return
     }
 
-    const unprocessedReleaseRequests = await api.getBridgeNextWIronRequests(
+    const unprocessedReleaseRequests = await api.getBridgeNextReleaseRequests(
       MAX_RECIPIENTS_PER_TRANSACTION,
     )
 
@@ -216,6 +216,6 @@ export default class Release extends IronfishCommand {
       })
     }
 
-    await api.updateWIronRequests(updatePayload)
+    await api.updateBridgeRequests(updatePayload)
   }
 }

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -232,11 +232,11 @@ export class WebApi {
     await axios.post(`${this.host}/bridge/send`, { sends }, this.options())
   }
 
-  async getBridgeNextWIronRequests(count?: number): Promise<Array<BridgeRequest>> {
+  async getBridgeNextReleaseRequests(count?: number): Promise<Array<BridgeRequest>> {
     this.requireToken()
 
     const response = await axios.get<{ data: Array<BridgeRequest> }>(
-      `${this.host}/bridge/next_wiron_requests/`,
+      `${this.host}/bridge/next_release_requests/`,
       {
         ...this.options(),
         params: { count },
@@ -246,13 +246,13 @@ export class WebApi {
     return response.data.data
   }
 
-  async updateWIronRequests(
+  async updateBridgeRequests(
     payload: Array<{ id: number; destination_transaction: string; status: string }>,
   ): Promise<{ [keyof: string]: { status: string } }> {
     this.requireToken()
 
     const response = await axios.post<{ [keyof: number]: { status: string } }>(
-      `${this.host}/bridge/update_wiron_requests/`,
+      `${this.host}/bridge/update_requests/`,
       { transactions: payload },
       this.options(),
     )


### PR DESCRIPTION
## Summary

'next_wiron_requests' renamed to 'next_release_requests'

'update_wiron_requests' renamed to 'update_requests'

## Testing Plan

ran both `relay` and `release` against local test api

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
