### PR TITLE
Rahul/ifl 1771 change address manager to store outbound websocket connections

### DIFF
--- a/ironfish/src/network/peers/addressManager.test.ts
+++ b/ironfish/src/network/peers/addressManager.test.ts
@@ -7,7 +7,6 @@ import {
   getConnectedPeer,
   getConnectingPeer,
   getDisconnectedPeer,
-  getInboundConnectedPeer,
   getSignalingWebRtcPeer,
   mockHostsStore,
   mockIdentity,
@@ -15,6 +14,7 @@ import {
   webRtcCanInitiateIdentity,
 } from '../testUtilities'
 import { AddressManager } from './addressManager'
+import { ConnectionDirection } from './connections'
 import { Peer } from './peer'
 import { PeerAddress } from './peerAddress'
 import { PeerManager } from './peerManager'
@@ -125,7 +125,11 @@ describe('AddressManager', () => {
       expect(addressManager.priorConnectedPeerAddresses).not.toContainEqual(address2)
 
       // inboundWebSocketPeer
-      const { peer: inboundWebSocketPeer } = getInboundConnectedPeer(pm)
+      const { peer: inboundWebSocketPeer } = getConnectedPeer(
+        pm,
+        undefined,
+        ConnectionDirection.Inbound,
+      )
       const address3: PeerAddress = {
         address: inboundWebSocketPeer.address,
         port: inboundWebSocketPeer.port,

--- a/ironfish/src/network/peers/addressManager.test.ts
+++ b/ironfish/src/network/peers/addressManager.test.ts
@@ -118,9 +118,8 @@ describe('AddressManager', () => {
       }
 
       await addressManager.save()
-      expect(addressManager.priorConnectedPeerAddresses.length).toEqual(1)
       expect(addressManager.priorConnectedPeerAddresses).toContainEqual(address)
-      expect(addressManager.priorConnectedPeerAddresses).toContainEqual(address2)
+      expect(addressManager.priorConnectedPeerAddresses).not.toContainEqual(address2)
     })
   })
 })

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -4,6 +4,7 @@
 import { HostsStore } from '../../fileStores'
 import { ArrayUtils } from '../../utils'
 import { Peer } from '../peers/peer'
+import { ConnectionDirection } from './connections'
 import { PeerAddress } from './peerAddress'
 import { PeerManager } from './peerManager'
 
@@ -77,7 +78,11 @@ export class AddressManager {
     // successfully established an outbound Websocket connection at
     // least once.
     const inUsePeerAddresses: PeerAddress[] = this.peerManager.peers.flatMap((peer) => {
-      if (peer.state.type === 'CONNECTED') {
+      if (
+        peer.state.type === 'CONNECTED' &&
+        peer.state.connections.webSocket &&
+        peer.state.connections.webSocket.direction === ConnectionDirection.Outbound
+      ) {
         return {
           address: peer.address,
           port: peer.port,

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -71,12 +71,9 @@ export class AddressManager {
   }
 
   /**
-   * Persist all currently connected peers to disk
+   * Persist connected peers via outbound websocket connections to disk
    */
   async save(): Promise<void> {
-    // TODO: Ideally, we would like persist peers with whom we've
-    // successfully established an outbound Websocket connection at
-    // least once.
     const inUsePeerAddresses: PeerAddress[] = this.peerManager.peers.flatMap((peer) => {
       if (
         peer.state.type === 'CONNECTED' &&

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -101,32 +101,12 @@ export const getConnectedPeersWithSpies = (
   })
 }
 
-export function getInboundConnectedPeer(
-  pm: PeerManager,
-  identity?: string | Identity,
-): { peer: Peer; connection: WebSocketConnection } {
-  const { peer, connection } = getConnectingPeer(pm, ConnectionDirection.Inbound)
-
-  if (!identity) {
-    identity = jest.requireActual<typeof import('uuid')>('uuid').v4()
-  }
-
-  if (!isIdentity(identity)) {
-    identity = mockIdentity(identity)
-  }
-
-  connection.setState({ type: 'CONNECTED', identity })
-
-  peer.features = defaultFeatures()
-
-  return { peer, connection: connection }
-}
-
 export function getConnectedPeer(
   pm: PeerManager,
   identity?: string | Identity,
+  direction: ConnectionDirection = ConnectionDirection.Outbound,
 ): { peer: Peer; connection: WebSocketConnection } {
-  const { peer, connection } = getConnectingPeer(pm)
+  const { peer, connection } = getConnectingPeer(pm, direction)
 
   if (!identity) {
     identity = jest.requireActual<typeof import('uuid')>('uuid').v4()

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -101,6 +101,27 @@ export const getConnectedPeersWithSpies = (
   })
 }
 
+export function getInboundConnectedPeer(
+  pm: PeerManager,
+  identity?: string | Identity,
+): { peer: Peer; connection: WebSocketConnection } {
+  const { peer, connection } = getConnectingPeer(pm, ConnectionDirection.Inbound)
+
+  if (!identity) {
+    identity = jest.requireActual<typeof import('uuid')>('uuid').v4()
+  }
+
+  if (!isIdentity(identity)) {
+    identity = mockIdentity(identity)
+  }
+
+  connection.setState({ type: 'CONNECTED', identity })
+
+  peer.features = defaultFeatures()
+
+  return { peer, connection: connection }
+}
+
 export function getConnectedPeer(
   pm: PeerManager,
   identity?: string | Identity,


### PR DESCRIPTION
## Summary

Spec: https://www.notion.so/Address-Manager-Improvement-Spec-431c0fa6423948748ef85da30d99d7a2?pvs=4

This addresses the following section: 
`Only store peers with which we successfully created outbound websocket connections`

## Testing Plan
1. Added tests to check the above functionality
2. Manually tested this logic on Mainnet and Testnet 

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
