### PR TITLE
updates relay service to hit /bridge/burn endpoint

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/relay.ts
+++ b/ironfish-cli/src/commands/service/bridge/relay.ts
@@ -1,12 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
 import { Assert, GetTransactionStreamResponse, Meter, TimeUtils, WebApi } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import { isAddress } from 'web3-validator'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
-import { Asset } from '@ironfish/rust-nodejs'
 
 export default class BridgeRelay extends IronfishCommand {
   static hidden = true

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -232,6 +232,22 @@ export class WebApi {
     await axios.post(`${this.host}/bridge/send`, { sends }, this.options())
   }
 
+  async bridgeBurn(
+    burns: {
+      amount: string
+      asset: string
+      source_address: string
+      source_chain: string
+      source_transaction: string
+      destination_address: string
+      destination_chain: string
+    }[],
+  ): Promise<void> {
+    this.requireToken()
+
+    await axios.post(`${this.host}/bridge/burn`, { burns }, this.options())
+  }
+
   async getBridgeNextReleaseRequests(count?: number): Promise<Array<BridgeRequest>> {
     this.requireToken()
 


### PR DESCRIPTION
## Summary

relay services hits the '/bridge/burn' api endpoint for any transaction it receives for non-native assets

this will rely on the api to determine if the asset sent to the bridge was a valid asset that can be released on the Ethereum side

adds 'bridgeBurn' WebApi method

## Testing Plan

manual testing sending custom asset to bridge

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
