### PR TITLE
feat(cli,ironfish): Process mint transactions in release service

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/release.ts
+++ b/ironfish-cli/src/commands/service/bridge/release.ts
@@ -277,7 +277,7 @@ export default class Release extends IronfishCommand {
           amount: mintRequest.amount,
           assetId: mintRequest.asset,
           publicAddress: mintRequest.destination_address,
-          memo: 'Bridged asset',
+          memo: mintRequest.id.toString(),
         },
       ],
       mints: [

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -246,6 +246,20 @@ export class WebApi {
     return response.data.data
   }
 
+  async getBridgeNextMintRequests(count?: number): Promise<Array<BridgeRequest>> {
+    this.requireToken()
+
+    const response = await axios.get<{ data: Array<BridgeRequest> }>(
+      `${this.host}/bridge/next_mint_requests/`,
+      {
+        ...this.options(),
+        params: { count },
+      },
+    )
+
+    return response.data.data
+  }
+
   async getBridgeNextBurnRequests(count?: number): Promise<Array<BridgeRequest>> {
     this.requireToken()
 


### PR DESCRIPTION
## Summary

On each loop, query for the next mint transaction that is pending creation on Iron Fish

## Testing Plan

Manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
