### PR TITLE
Add better peer selection logic to the syncer

### DIFF
--- a/ironfish/src/network/blockFetcher.test.ts
+++ b/ironfish/src/network/blockFetcher.test.ts
@@ -386,7 +386,7 @@ describe('BlockFetcher', () => {
       await chain.addBlock(block)
     }
 
-    const syncSpy = jest.spyOn(node.syncer, 'startSync')
+    const syncSpy = jest.spyOn(node.syncer, 'startSyncIfIdle')
 
     const peers = getConnectedPeersWithSpies(peerNetwork.peerManager, 4)
 

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -753,7 +753,7 @@ export class PeerNetwork {
     if (prevHeader === null) {
       this.chain.addOrphan(block.header)
       this.blockFetcher.removeBlock(block.header.hash)
-      this.node.syncer.startSync(peer)
+      this.node.syncer.startSyncIfIdle(peer)
       return
     }
 
@@ -811,7 +811,7 @@ export class PeerNetwork {
     if (prevHeader === null) {
       this.chain.addOrphan(header)
       this.blockFetcher.removeBlock(header.hash)
-      this.node.syncer.startSync(peer)
+      this.node.syncer.startSyncIfIdle(peer)
       return
     }
 
@@ -1180,7 +1180,7 @@ export class PeerNetwork {
     if (prevHeader === null) {
       this.chain.addOrphan(block.header)
       this.blockFetcher.removeBlock(block.header.hash)
-      this.node.syncer.startSync(peer)
+      this.node.syncer.startSyncIfIdle(peer)
       return
     }
 

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -82,6 +82,10 @@ export class Peer {
     return this._state
   }
 
+  get identity(): Identity | null {
+    return this.state.identity
+  }
+
   get isSaturated(): boolean {
     return this.pendingRPC >= this.pendingRPCMax
   }
@@ -409,10 +413,6 @@ export class Peer {
     if (this.state.identity === null) {
       throw new Error('Called getIdentityOrThrow on an unidentified peer')
     }
-    return this.state.identity
-  }
-
-  getIdentity(): Identity | null {
     return this.state.identity
   }
 

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -82,10 +82,6 @@ export class Peer {
     return this._state
   }
 
-  get identity(): Identity | null {
-    return this.state.identity
-  }
-
   get isSaturated(): boolean {
     return this.pendingRPC >= this.pendingRPCMax
   }

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -412,6 +412,10 @@ export class Peer {
     return this.state.identity
   }
 
+  getIdentity(): Identity | null {
+    return this.state.identity
+  }
+
   /**
    * Get the peers connectable websocket address
    */

--- a/ironfish/src/rpc/routes/node/getStatus.ts
+++ b/ironfish/src/rpc/routes/node/getStatus.ts
@@ -4,6 +4,7 @@
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
 import { FullNode } from '../../../node'
+import { SyncerState } from '../../../syncer'
 import { MathUtils, PromiseUtils } from '../../../utils'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
@@ -65,7 +66,7 @@ export type GetNodeStatusResponse = {
     dbSizeBytes: number
   }
   blockSyncer: {
-    status: 'stopped' | 'idle' | 'stopping' | 'syncing'
+    status: SyncerState
     syncing?: {
       blockSpeed: number
       speed: number

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -13,7 +13,14 @@ import { BAN_SCORE, PeerState } from './network/peers/peer'
 import { Block, GENESIS_BLOCK_SEQUENCE } from './primitives/block'
 import { BlockHeader } from './primitives/blockheader'
 import { Telemetry } from './telemetry'
-import { BenchUtils, ErrorUtils, HashUtils, MathUtils, SetTimeoutToken } from './utils'
+import {
+  BenchUtils,
+  ErrorUtils,
+  HashUtils,
+  MathUtils,
+  SetTimeoutToken,
+  TimeUtils,
+} from './utils'
 import { ArrayUtils } from './utils/array'
 
 const SYNCER_TICK_MS = 10 * 1000
@@ -155,6 +162,9 @@ export class Syncer {
       return
     }
 
+    this.logger.debug('Syncer is beginning peer candidate measurements')
+    const measurementStart = BenchUtils.start()
+
     // Find all allowed peers that have more work than we have
     const peers = this.peerNetwork.peerManager
       .getConnectedPeers()
@@ -240,6 +250,12 @@ export class Syncer {
       return
     }
     const peer = this.peerNetwork.peerManager.getPeer(fastestCandidateIdentity)
+
+    const measurementTime = BenchUtils.end(measurementStart)
+    this.logger.debug(
+      `Syncer took ${TimeUtils.renderSpan(measurementTime)} to measure peer candidates`,
+    )
+
     if (peer) {
       this.startSync(peer)
     }

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -142,7 +142,7 @@ export class Syncer {
         // in-flight requests
         this.state = 'measuring'
         if (this.loader) {
-          this.lastLoaderIdentity = this.loader.getIdentity()
+          this.lastLoaderIdentity = this.loader.identity
           await this.wait()
         }
         break
@@ -188,7 +188,7 @@ export class Syncer {
     // if we have found one.
     if (
       currentPeerIdentity &&
-      !syncCandidates.find((p) => p.getIdentity() === currentPeerIdentity)
+      !syncCandidates.find((p) => p.identity === currentPeerIdentity)
     ) {
       const currentPeer = this.peerNetwork.peerManager.getPeer(currentPeerIdentity)
       if (currentPeer && currentPeer.state.type === 'CONNECTED') {
@@ -212,10 +212,7 @@ export class Syncer {
         break
       }
 
-      const peerIdentity = peer.getIdentity()
-      if (peerIdentity == null) {
-        continue
-      }
+      const peerIdentity = peer.getIdentityOrThrow()
 
       const start = BenchUtils.start()
       try {

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -142,7 +142,7 @@ export class Syncer {
         // in-flight requests
         this.state = 'measuring'
         if (this.loader) {
-          this.lastLoaderIdentity = this.loader.identity
+          this.lastLoaderIdentity = this.loader.state.identity
           await this.wait()
         }
         break
@@ -188,7 +188,7 @@ export class Syncer {
     // if we have found one.
     if (
       currentPeerIdentity &&
-      !syncCandidates.find((p) => p.identity === currentPeerIdentity)
+      !syncCandidates.find((p) => p.state.identity === currentPeerIdentity)
     ) {
       const currentPeer = this.peerNetwork.peerManager.getPeer(currentPeerIdentity)
       if (currentPeer && currentPeer.state.type === 'CONNECTED') {

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -171,7 +171,7 @@ export class Syncer {
       return
     }
 
-    const syncCandidates = ArrayUtils.shuffle(peers).slice(0, 8)
+    const syncCandidates = ArrayUtils.shuffle(peers)
 
     // If we have been syncing from a peer, we want to include this peer in the
     // measurement. This will allow us to maintain a connection to a strong peer
@@ -190,9 +190,16 @@ export class Syncer {
 
     // Measure how long it takes to fetch the genesis block header from each
     // peer as an estimate of connection quality
+    let candidateCheckCount = 0
     for (const peer of syncCandidates) {
       if (this.state === 'stopped' || this.state === 'stopping') {
         return
+      }
+
+      // We only want to successfully measure so many candidates per measurement
+      // phase
+      if (candidateCheckCount > 8) {
+        break
       }
 
       const peerIdentity = peer.getIdentity()
@@ -223,6 +230,7 @@ export class Syncer {
       }
       const rtt = BenchUtils.end(start)
       peerRtt.set(peerIdentity, rtt)
+      candidateCheckCount += 1
     }
 
     // Sort the peers by the round-trip-time of the block header request and get

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -212,6 +212,10 @@ export class Syncer {
         break
       }
 
+      if (peer.state.type !== 'CONNECTED') {
+        continue
+      }
+
       const peerIdentity = peer.getIdentityOrThrow()
 
       const start = BenchUtils.start()

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -244,12 +244,13 @@ export class Syncer {
       candidateCheckCount += 1
     }
 
+    if (peerRtt.size === 0) {
+      return
+    }
+
     // Sort the peers by the round-trip-time of the block header request and get
     // the fastest one to sync from
     const fastestCandidateIdentity = [...peerRtt.entries()].sort((a, b) => a[1] - b[1])[0][0]
-    if (!fastestCandidateIdentity) {
-      return
-    }
     const peer = this.peerNetwork.peerManager.getPeer(fastestCandidateIdentity)
 
     const measurementTime = BenchUtils.end(measurementStart)

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -241,6 +241,13 @@ export class Syncer {
       peerRtt.set(peerIdentity, rtt)
     }
 
+    const measurementTime = BenchUtils.end(measurementStart)
+    this.logger.debug(
+      `Syncer took ${TimeUtils.renderSpan(measurementTime)} to measure peer candidates. Found ${
+        peerRtt.size
+      } suitable candidates`,
+    )
+
     if (peerRtt.size === 0) {
       return
     }
@@ -249,11 +256,6 @@ export class Syncer {
     // the fastest one to sync from
     const fastestCandidateIdentity = [...peerRtt.entries()].sort((a, b) => a[1] - b[1])[0][0]
     const peer = this.peerNetwork.peerManager.getPeer(fastestCandidateIdentity)
-
-    const measurementTime = BenchUtils.end(measurementStart)
-    this.logger.debug(
-      `Syncer took ${TimeUtils.renderSpan(measurementTime)} to measure peer candidates`,
-    )
 
     if (peer) {
       this.startSync(peer)

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -8,21 +8,24 @@ import { VerificationResultReason } from './consensus'
 import { createRootLogger, Logger } from './logger'
 import { Meter, MetricsMonitor } from './metrics'
 import { RollingAverage } from './metrics/rollingAverage'
-import { Peer, PeerNetwork } from './network'
+import { Identity, Peer, PeerNetwork } from './network'
 import { BAN_SCORE, PeerState } from './network/peers/peer'
 import { Block, GENESIS_BLOCK_SEQUENCE } from './primitives/block'
 import { BlockHeader } from './primitives/blockheader'
 import { Telemetry } from './telemetry'
-import { ErrorUtils, HashUtils, MathUtils, SetTimeoutToken } from './utils'
+import { BenchUtils, ErrorUtils, HashUtils, MathUtils, SetTimeoutToken } from './utils'
 import { ArrayUtils } from './utils/array'
 
 const SYNCER_TICK_MS = 10 * 1000
 const LINEAR_ANCESTOR_SEARCH = 3
 const REQUEST_BLOCKS_PER_MESSAGE = 20
+const MAX_MEASUREMENT_DELTA = 60 * 60 * 1000
 
 class AbortSyncingError extends Error {
   name = this.constructor.name
 }
+
+export type SyncerState = 'stopped' | 'idle' | 'stopping' | 'syncing' | 'measuring'
 
 export class Syncer {
   readonly peerNetwork: PeerNetwork
@@ -33,11 +36,14 @@ export class Syncer {
   readonly speed: Meter
   readonly downloadSpeed: RollingAverage
 
-  state: 'stopped' | 'idle' | 'stopping' | 'syncing'
+  state: SyncerState
   stopping: Promise<void> | null
   eventLoopTimeout: SetTimeoutToken | null
   loader: Peer | null = null
   blocksPerMessage: number
+  nextMeasureTime = 0
+  numberOfMeasurements = 0
+  lastLoaderIdentity: Identity | null = null
 
   constructor(options: {
     peerNetwork: PeerNetwork
@@ -71,8 +77,7 @@ export class Syncer {
     }
     this.state = 'idle'
 
-    this.eventLoop()
-    await Promise.resolve()
+    await this.eventLoop()
   }
 
   async stop(): Promise<void> {
@@ -99,21 +104,55 @@ export class Syncer {
     this.state = 'stopped'
   }
 
-  eventLoop(): void {
+  async eventLoop(): Promise<void> {
     if (this.state === 'stopped' || this.state === 'stopping') {
       return
     }
 
-    if (this.state === 'idle') {
-      this.findPeer()
+    const now = new Date().getTime()
+
+    switch (this.state) {
+      case 'idle': {
+        await this.findPeer(null)
+        this.nextMeasureTime = now + this.getNextMeasurementDelta()
+        break
+      }
+
+      case 'measuring': {
+        await this.findPeer(this.lastLoaderIdentity)
+        this.nextMeasureTime = now + this.getNextMeasurementDelta()
+        this.numberOfMeasurements += 1
+        break
+      }
+
+      case 'syncing': {
+        if (this.nextMeasureTime >= now) {
+          break
+        }
+
+        this.logger.info('Checking for a potentially better peer to sync from')
+
+        // If it is time to enter the measuring state, we stop syncing and set
+        // the state to measuring. This gives the syncer time to finish any
+        // in-flight requests
+        this.state = 'measuring'
+        if (this.loader) {
+          this.lastLoaderIdentity = this.loader.getIdentity()
+          await this.wait()
+        }
+        break
+      }
     }
 
-    this.eventLoopTimeout = setTimeout(() => this.eventLoop(), SYNCER_TICK_MS)
+    this.eventLoopTimeout = setTimeout(() => void this.eventLoop(), SYNCER_TICK_MS)
   }
 
-  findPeer(): void {
+  /**
+   * Chooses a peer to sync from based on measuring the connection of a random
+   * sampling of connected peers and begins syncing
+   */
+  async findPeer(currentPeerIdentity: Identity | null): Promise<void> {
     const head = this.chain.head
-
     if (!head) {
       return
     }
@@ -123,16 +162,90 @@ export class Syncer {
       .getConnectedPeers()
       .filter((peer) => peer.features?.syncing && peer.work && peer.work > head.work)
 
-    // Get a random peer with higher work. We do this to encourage
-    // peer diversity so the highest work peer isn't overwhelmed
-    // as well as helping to make sure we don't get stuck with unstable peers
-    if (peers.length > 0) {
-      const peer = ArrayUtils.sampleOrThrow(peers)
+    if (peers.length === 0) {
+      return
+    }
+
+    // If there is only one valid peer to sync from, there is no point in
+    // measuring the connection so begin syncing immediately
+    if (peers.length === 1) {
+      this.startSync(peers[0])
+      return
+    }
+
+    const syncCandidates = ArrayUtils.shuffle(peers).slice(0, 8)
+
+    // If we have been syncing from a peer, we want to include this peer in the
+    // measurement. This will allow us to maintain a connection to a strong peer
+    // if we have found one.
+    if (
+      currentPeerIdentity &&
+      !syncCandidates.find((p) => p.getIdentity() === currentPeerIdentity)
+    ) {
+      const currentPeer = this.peerNetwork.peerManager.getPeer(currentPeerIdentity)
+      if (currentPeer && currentPeer.state.type === 'CONNECTED') {
+        syncCandidates.push(currentPeer)
+      }
+    }
+
+    const peerRtt = new Map<Identity, number>()
+
+    // Measure how long it takes to fetch the genesis block header from each
+    // peer as an estimate of connection quality
+    for (const peer of syncCandidates) {
+      if (this.state === 'stopped' || this.state === 'stopping') {
+        return
+      }
+
+      const peerIdentity = peer.getIdentity()
+      if (peerIdentity == null) {
+        continue
+      }
+
+      const start = BenchUtils.start()
+      try {
+        const response = await this.peerNetwork.getBlockHeaders(peer, 1, 1)
+        if (response.headers.length !== 1) {
+          this.logger.warn(`Peer ${peer.displayName} sent the wrong number of block headers`)
+          peer.punish(BAN_SCORE.MAX, 'invalid response')
+          continue
+        }
+        if (!response.headers[0].hash.equals(this.chain.genesis.hash)) {
+          this.logger.warn(`Peer ${peer.displayName} sent the wrong block header`)
+          peer.punish(BAN_SCORE.MAX, 'invalid response')
+          continue
+        }
+      } catch (e) {
+        this.logger.debug(
+          `Error while trying to measure peer '${
+            peer.displayName
+          }', skipping this peer: ${ErrorUtils.renderError(e)}`,
+        )
+        continue
+      }
+      const rtt = BenchUtils.end(start)
+      peerRtt.set(peerIdentity, rtt)
+    }
+
+    // Sort the peers by the round-trip-time of the block header request and get
+    // the fastest one to sync from
+    const fastestCandidateIdentity = [...peerRtt.entries()].sort((a, b) => a[1] - b[1])[0][0]
+    if (!fastestCandidateIdentity) {
+      return
+    }
+    const peer = this.peerNetwork.peerManager.getPeer(fastestCandidateIdentity)
+    if (peer) {
       this.startSync(peer)
     }
   }
 
-  startSync(peer: Peer): void {
+  startSyncIfIdle(peer: Peer): void {
+    if (this.state === 'idle') {
+      this.startSync(peer)
+    }
+  }
+
+  protected startSync(peer: Peer): void {
     if (this.loader) {
       return
     }
@@ -287,7 +400,7 @@ export class Syncer {
       }
     }
 
-    // Then we try a binary search to fine the forking point between us and peer
+    // Then we try a binary search to find the forking point between us and peer
     let ancestorHash: Buffer | null = null
     let ancestorSequence: number | null = null
     let lower = Number(GENESIS_BLOCK_SEQUENCE)
@@ -516,11 +629,23 @@ export class Syncer {
   }
 
   /**
+   * Returns the amount of time to wait until the next sync candidate
+   * measurement in milliseconds
+   */
+  protected getNextMeasurementDelta(): number {
+    const delta = Math.min(
+      MAX_MEASUREMENT_DELTA,
+      60 * 1000 * 2 ** (this.numberOfMeasurements + 1),
+    )
+    return delta
+  }
+
+  /**
    * Throws AbortSyncingError which safely stops the syncing
    * with a peer if we should no longer sync from this peer
    */
   protected abort(peer: Peer): void {
-    if (this.loader !== peer) {
+    if (this.loader !== peer || this.state !== 'syncing') {
       throw new AbortSyncingError('abort syncing')
     }
   }

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -109,24 +109,22 @@ export class Syncer {
       return
     }
 
-    const now = new Date().getTime()
-
     switch (this.state) {
       case 'idle': {
         await this.findPeer(null)
-        this.nextMeasureTime = now + this.getNextMeasurementDelta()
         break
       }
 
       case 'measuring': {
         await this.findPeer(this.lastLoaderIdentity)
-        this.nextMeasureTime = now + this.getNextMeasurementDelta()
-        this.numberOfMeasurements += 1
+        if (this.loader) {
+          this.numberOfMeasurements += 1
+        }
         break
       }
 
       case 'syncing': {
-        if (this.nextMeasureTime >= now) {
+        if (this.nextMeasureTime >= performance.now()) {
           break
         }
 
@@ -251,6 +249,8 @@ export class Syncer {
     }
 
     Assert.isNotNull(peer.sequence)
+
+    this.nextMeasureTime = performance.now() + this.getNextMeasurementDelta()
 
     const work = peer.work ? ` work: +${(peer.work - this.chain.head.work).toString()},` : ''
     this.logger.info(

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -206,7 +206,7 @@ export class Syncer {
 
       // We only want to successfully measure so many candidates per measurement
       // phase
-      if (candidateCheckCount > 8) {
+      if (candidateCheckCount >= 8) {
         break
       }
 

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -181,18 +181,16 @@ export class Syncer {
       return
     }
 
-    const syncCandidates = ArrayUtils.shuffle(peers)
+    let syncCandidates = ArrayUtils.shuffle(peers)
 
     // If we have been syncing from a peer, we want to include this peer in the
     // measurement. This will allow us to maintain a connection to a strong peer
     // if we have found one.
-    if (
-      currentPeerIdentity &&
-      !syncCandidates.find((p) => p.state.identity === currentPeerIdentity)
-    ) {
+    if (currentPeerIdentity) {
       const currentPeer = this.peerNetwork.peerManager.getPeer(currentPeerIdentity)
-      if (currentPeer && currentPeer.state.type === 'CONNECTED') {
-        syncCandidates.push(currentPeer)
+      if (currentPeer) {
+        syncCandidates = syncCandidates.filter((p) => p.state.identity !== currentPeerIdentity)
+        syncCandidates.unshift(currentPeer)
       }
     }
 

--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -27,6 +27,7 @@ const SYNCER_TICK_MS = 10 * 1000
 const LINEAR_ANCESTOR_SEARCH = 3
 const REQUEST_BLOCKS_PER_MESSAGE = 20
 const MAX_MEASUREMENT_DELTA = 60 * 60 * 1000
+const CANDIDATES_PER_MEASUREMENT = 8
 
 class AbortSyncingError extends Error {
   name = this.constructor.name
@@ -198,7 +199,6 @@ export class Syncer {
 
     // Measure how long it takes to fetch the genesis block header from each
     // peer as an estimate of connection quality
-    let candidateCheckCount = 0
     for (const peer of syncCandidates) {
       if (this.state === 'stopped' || this.state === 'stopping') {
         return
@@ -206,7 +206,7 @@ export class Syncer {
 
       // We only want to successfully measure so many candidates per measurement
       // phase
-      if (candidateCheckCount >= 8) {
+      if (peerRtt.size >= CANDIDATES_PER_MEASUREMENT) {
         break
       }
 
@@ -239,7 +239,6 @@ export class Syncer {
       }
       const rtt = BenchUtils.end(start)
       peerRtt.set(peerIdentity, rtt)
-      candidateCheckCount += 1
     }
 
     if (peerRtt.size === 0) {


### PR DESCRIPTION
## Summary
The Syncer's `findPeer` function will now choose 8 random peers. Of these peers, it will measure the round-trip-time of a blockHeadersRequest of the genesis block. It then chooses the fastest of these peers to sync from.

Additionally, it will check again on a growing interval (2, 4, 8... up to 60) minutes. The purpose of this is that it should check frequently on initial node startup, as the number of connected peers grows so that it has a good chance of selecting a good peer to sync from early.

It includes the current syncing peer in the checks on the interval, so that if you find a good quality peer, you are likely to continue syncing from that peer unless you find a better one.

Closes IFL-1781

## Testing Plan
- Manual testing
- Unit tests where applicable

## Documentation

N/A

## Breaking Change

N/A