### PR TITLE
chore: refactor next release

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/release.ts
+++ b/ironfish-cli/src/commands/service/bridge/release.ts
@@ -125,7 +125,7 @@ export default class Release extends IronfishCommand {
     account: string,
     api: WebApi,
   ): Promise<void> {
-    const unprocessedReleaseRequests = await api.getBridgeNextReleaseRequests(
+    const { requests: unprocessedReleaseRequests } = await api.getBridgeNextReleaseRequests(
       MAX_RECIPIENTS_PER_TRANSACTION,
     )
 
@@ -211,7 +211,7 @@ export default class Release extends IronfishCommand {
     api: WebApi,
   ): Promise<void> {
     // TODO(hughy): group multiple requests into a single transaction
-    const nextBurnRequests = await api.getBridgeNextBurnRequests(1)
+    const { requests: nextBurnRequests } = await api.getBridgeNextBurnRequests(1)
 
     if (nextBurnRequests.length === 0) {
       this.log('No burn requests')
@@ -262,7 +262,7 @@ export default class Release extends IronfishCommand {
     account: string,
     api: WebApi,
   ): Promise<void> {
-    const nextMintRequests = await api.getBridgeNextMintRequests(1)
+    const { requests: nextMintRequests } = await api.getBridgeNextMintRequests(1)
     if (nextMintRequests.length === 0) {
       this.log('No mint requests')
       return

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -248,46 +248,53 @@ export class WebApi {
     await axios.post(`${this.host}/bridge/burn`, { burns }, this.options())
   }
 
-  async getBridgeNextReleaseRequests(count?: number): Promise<Array<BridgeRequest>> {
+  async getBridgeNextReleaseRequests(
+    count?: number,
+  ): Promise<{ requests: Array<BridgeRequest> }> {
     this.requireToken()
-
-    const response = await axios.get<{ data: Array<BridgeRequest> }>(
-      `${this.host}/bridge/next_release_requests/`,
+    const response = await axios.post<{ requests: Array<BridgeRequest> }>(
+      `${this.host}/bridge/retrieve/`,
       {
-        ...this.options(),
-        params: { count },
+        source_chain: 'ETHEREUM',
+        destination_chain: 'IRONFISH',
+        status: 'PENDING_DESTINATION_RELEASE_TRANSACTION_CREATION',
+        count: count ?? 1,
       },
+      this.options(),
     )
-
-    return response.data.data
+    return response.data
   }
 
-  async getBridgeNextMintRequests(count?: number): Promise<Array<BridgeRequest>> {
+  async getBridgeNextMintRequests(count?: number): Promise<{ requests: Array<BridgeRequest> }> {
     this.requireToken()
 
-    const response = await axios.get<{ data: Array<BridgeRequest> }>(
-      `${this.host}/bridge/next_mint_requests/`,
+    const response = await axios.post<{ requests: Array<BridgeRequest> }>(
+      `${this.host}/bridge/retrieve/`,
       {
-        ...this.options(),
-        params: { count },
+        source_chain: 'ETHEREUM',
+        destination_chain: 'IRONFISH',
+        status: 'PENDING_DESTINATION_MINT_TRANSACTION_CREATION',
+        count: count ?? 1,
       },
+      this.options(),
     )
-
-    return response.data.data
+    return response.data
   }
 
-  async getBridgeNextBurnRequests(count?: number): Promise<Array<BridgeRequest>> {
+  async getBridgeNextBurnRequests(count?: number): Promise<{ requests: Array<BridgeRequest> }> {
     this.requireToken()
 
-    const response = await axios.get<{ data: Array<BridgeRequest> }>(
-      `${this.host}/bridge/next_burn_requests/`,
+    const response = await axios.post<{ requests: Array<BridgeRequest> }>(
+      `${this.host}/bridge/retrieve/`,
       {
-        ...this.options(),
-        params: { count },
+        source_chain: 'IRONFISH',
+        destination_chain: 'ETHEREUM',
+        status: 'PENDING_SOURCE_BURN_TRANSACTION_CREATION',
+        count: count ?? 1,
       },
+      this.options(),
     )
-
-    return response.data.data
+    return response.data
   }
 
   async updateBridgeRequests(


### PR DESCRIPTION
## Summary
Uses `bridge/release` endpoint instead of `next_release_requests`
## Testing Plan
```
fish service:bridge:release --datadir ~/.devnet                                                                   ─╯
yarn run v1.22.19
$ yarn build && yarn start:js service:bridge:release --datadir /Users/joe/.devnet
$ tsc -b
$ cross-env OCLIF_TS_NODE=0 IRONFISH_DEBUG=1 node --expose-gc --inspect=:0 --inspect-publish-uid=http --enable-source-maps bin/run service:bridge:release --datadir /Users/joe/.devnet
Fetching bridge account
Using account default
No bridge requests, waiting 5s
```
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
