### PR TITLE
processes multiple burns in a single transaction

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/release.ts
+++ b/ironfish-cli/src/commands/service/bridge/release.ts
@@ -9,6 +9,7 @@ import {
   RpcSocketClient,
   WebApi,
 } from '@ironfish/sdk'
+import { BurnDescription } from '@ironfish/sdk/src/primitives/burnDescription'
 import { Flags } from '@oclif/core'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
@@ -210,51 +211,84 @@ export default class Release extends IronfishCommand {
     account: string,
     api: WebApi,
   ): Promise<void> {
-    // TODO(hughy): group multiple requests into a single transaction
-    const { requests: nextBurnRequests } = await api.getBridgeNextBurnRequests(1)
+    const { requests: nextBurnRequests } = await api.getBridgeNextBurnRequests(MAX_RECIPIENTS_PER_TRANSACTION)
 
     if (nextBurnRequests.length === 0) {
       this.log('No burn requests')
       return
     }
 
-    const burnRequest = nextBurnRequests[0]
+    const pendingRequests = []
 
-    const response = await client.wallet.getAccountBalance({
-      account,
-      assetId: burnRequest.asset,
-    })
-    const availableBalance = BigInt(response.content.available)
+    const balancesResponse = await client.wallet.getAccountBalances({ account })
+    const availableBalances: Map<string, bigint> = new Map()
+    for (const balance of balancesResponse.content.balances) {
+      availableBalances.set(balance.assetId, BigInt(balance.available))
+    }
 
-    if (availableBalance < BigInt(burnRequest.amount)) {
-      this.log(
-        `Available balance too low to burn ${burnRequest.amount} of asset ${burnRequest.asset}`,
-      )
+    const burnDescriptions: Map<string, BurnDescription> = new Map()
+
+    for (const request of nextBurnRequests) {
+      const assetId = request.asset
+
+      const availableBalance = availableBalances.get(assetId) ?? 0n
+
+      const burnDescription = burnDescriptions.get(assetId) ?? {
+        assetId: Buffer.from(assetId, 'hex'),
+        value: 0n,
+      }
+
+      if (burnDescription.value + BigInt(request.amount) > availableBalance) {
+        continue
+      }
+
+      burnDescription.value += BigInt(request.amount)
+      burnDescriptions.set(assetId, burnDescription)
+      pendingRequests.push(request)
+    }
+
+    if (burnDescriptions.size === 0) {
+      this.log('Available balances too low to burn bridged assets')
       return
     }
 
-    const tx = await client.wallet.burnAsset({
+    const burns = []
+    for (const burn of burnDescriptions.values()) {
+      burns.push({
+        assetId: burn.assetId.toString('hex'),
+        value: burn.value.toString(),
+      })
+    }
+
+    const createTransactionResponse = await client.wallet.createTransaction({
       account,
-      assetId: burnRequest.asset,
-      value: burnRequest.amount,
+      outputs: [],
+      burns,
       fee: '1',
     })
 
+    const tx = await client.wallet.postTransaction({
+      account,
+      transaction: createTransactionResponse.content.transaction,
+      broadcast: true,
+    })
+
     this.log(
-      `Burn:
-        id: ${burnRequest.id}
-        asset: ${burnRequest.asset}
-        amount: ${burnRequest.amount}
-        transaction: ${tx.content.transaction.hash}`,
+      `Burn: ${JSON.stringify(pendingRequests, ['id', 'asset', 'amount'], '   ')} ${
+        tx.content.hash
+      }`,
     )
 
-    await api.updateBridgeRequests([
-      {
-        id: burnRequest.id,
+    const updatePayload = []
+    for (const request of pendingRequests) {
+      updatePayload.push({
+        id: request.id,
+        destination_transaction: tx.content.hash,
         status: 'PENDING_SOURCE_BURN_TRANSACTION_CONFIRMATION',
-        source_burn_transaction: tx.content.transaction.hash,
-      },
-    ])
+      })
+    }
+
+    await api.updateBridgeRequests(updatePayload)
   }
 
   async processNextMintTransaction(

--- a/ironfish-cli/src/commands/service/bridge/release.ts
+++ b/ironfish-cli/src/commands/service/bridge/release.ts
@@ -211,7 +211,9 @@ export default class Release extends IronfishCommand {
     account: string,
     api: WebApi,
   ): Promise<void> {
-    const { requests: nextBurnRequests } = await api.getBridgeNextBurnRequests(MAX_RECIPIENTS_PER_TRANSACTION)
+    const { requests: nextBurnRequests } = await api.getBridgeNextBurnRequests(
+      MAX_RECIPIENTS_PER_TRANSACTION,
+    )
 
     if (nextBurnRequests.length === 0) {
       this.log('No burn requests')
@@ -283,7 +285,7 @@ export default class Release extends IronfishCommand {
     for (const request of pendingRequests) {
       updatePayload.push({
         id: request.id,
-        destination_transaction: tx.content.hash,
+        source_burn_transaction: tx.content.hash,
         status: 'PENDING_SOURCE_BURN_TRANSACTION_CONFIRMATION',
       })
     }


### PR DESCRIPTION
## Summary

for each iteration of the release service loop the burn process combines multiple pending burn requests into a single burn transaction

## Testing Plan

manual testing:
- sent multiple deposits
- ran relay
- ran release and created a single burn transaction for both requests:
```
Burn: [
   {
      "id": 33,
      "asset": "213c1795b756e3237a6b7bd1e30b943c079c38f12d831b870152c96a7a9b7f26",
      "amount": "1"
   },
   {
      "id": 34,
      "asset": "213c1795b756e3237a6b7bd1e30b943c079c38f12d831b870152c96a7a9b7f26",
      "amount": "2"
   }
] f2afe7e76bdbd0b3d3283050e50965a49e562984dc548c91ece31f451c6f8d8e
```

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
