### PR TITLE
relays confirmed burn transactions to bridge api

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/relay.ts
+++ b/ironfish-cli/src/commands/service/bridge/relay.ts
@@ -168,8 +168,8 @@ export default class BridgeRelay extends IronfishCommand {
 
     const sends = []
     const burns = []
-    const confirmedReleases = []
-    const confirmedBurns = []
+    const releases = []
+    const confirms = []
 
     const transactions = response.transactions
 
@@ -184,9 +184,8 @@ export default class BridgeRelay extends IronfishCommand {
         )
 
         for (const requestId of requestIds) {
-          confirmedBurns.push({
+          releases.push({
             id: requestId,
-            status: 'PENDING_DESTINATION_RELEASE_TRANSACTION_CREATION',
           })
         }
 
@@ -208,7 +207,7 @@ export default class BridgeRelay extends IronfishCommand {
           this.log(
             `Confirmed release of bridge request ${note.memo} in transaction ${transaction.hash}`,
           )
-          confirmedReleases.push({
+          confirms.push({
             id: requestId,
             destination_transaction: transaction.hash,
             status: 'CONFIRMED',
@@ -245,12 +244,12 @@ export default class BridgeRelay extends IronfishCommand {
       }
     }
 
-    if (confirmedReleases.length > 0) {
-      await api.updateBridgeRequests(confirmedReleases)
+    if (confirms.length > 0) {
+      await api.updateBridgeRequests(confirms)
     }
 
-    if (confirmedBurns.length > 0) {
-      await api.updateBridgeRequests(confirmedBurns)
+    if (releases.length > 0) {
+      await api.bridgeRelease(releases)
     }
 
     if (sends.length > 0) {

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -29,6 +29,7 @@ type BridgeRequest = {
   destination_chain: string
   source_transaction?: string
   destination_transaction?: string
+  source_burn_transaction?: string
   status: string
 }
 
@@ -294,6 +295,25 @@ export class WebApi {
       },
       this.options(),
     )
+    return response.data
+  }
+
+  async getBridgePendingBurnRequests(
+    count?: number,
+  ): Promise<{ requests: Array<BridgeRequest> }> {
+    this.requireToken()
+
+    const response = await axios.post<{ requests: Array<BridgeRequest> }>(
+      `${this.host}/bridge/retrieve`,
+      {
+        source_chain: 'IRONFISH',
+        destination_chain: 'ETHEREUM',
+        status: 'PENDING_SOURCE_BURN_TRANSACTION_CONFIRMATION',
+        count,
+      },
+      this.options(),
+    )
+
     return response.data
   }
 

--- a/ironfish/src/webApi.ts
+++ b/ironfish/src/webApi.ts
@@ -249,6 +249,12 @@ export class WebApi {
     await axios.post(`${this.host}/bridge/burn`, { burns }, this.options())
   }
 
+  async bridgeRelease(releases: { id: number }[]): Promise<void> {
+    this.requireToken()
+
+    await axios.post(`${this.host}/bridge/release`, { releases }, this.options())
+  }
+
   async getBridgeNextReleaseRequests(
     count?: number,
   ): Promise<{ requests: Array<BridgeRequest> }> {


### PR DESCRIPTION
## Summary

adds 'getBridgePendingBurnRequests' method to WebApi

for each confirmed block, fetches the list of pending burn requests from the bridge api and compares the transactions in the block to the pending burn transactions

pushes update to api setting status of confirmed burns to 'PENDING_DESTINATION_RELEASE_TRANSACTION_CREATION'

## Testing Plan

manual testing - ran relay to pick up confirmed burn transactions and submit updates to api

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
