### PR TITLE
fix(ironfish): Update `BoxKeyPair` import to reference the package

### DIFF
--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BoxKeyPair } from '../../ironfish-rust-nodejs'
+import { BoxKeyPair } from '@ironfish/rust-nodejs'
 import {
   Config,
   ConfigOptions,


### PR DESCRIPTION
## Summary

Update the import for `BoxKeyPair` in the SDK

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
