### PR TITLE
fixes status of pending mints

### DIFF
--- a/ironfish-cli/src/commands/service/bridge/release.ts
+++ b/ironfish-cli/src/commands/service/bridge/release.ts
@@ -308,7 +308,7 @@ export default class Release extends IronfishCommand {
     await api.updateBridgeRequests([
       {
         id: mintRequest.id,
-        status: 'PENDING_SOURCE_MINT_TRANSACTION_CONFIRMATION',
+        status: 'PENDING_DESTINATION_MINT_TRANSACTION_CONFIRMATION',
         destination_transaction: mintTransactionResponse.content.hash,
       },
     ])


### PR DESCRIPTION
## Summary

mints are on the destination side, not the source

uses 'PENDING_DESTINATION_MINT_TRANSACTION_CONFIRMATION' status after creating mint transaction

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
