### PR TITLE
changes Note.memo() to return Buffer

### DIFF
--- a/ironfish/src/primitives/note.ts
+++ b/ironfish/src/primitives/note.ts
@@ -10,7 +10,6 @@ import {
   RANDOMNESS_LENGTH,
 } from '@ironfish/rust-nodejs'
 import bufio from 'bufio'
-import { BufferUtils } from '../utils/buffer'
 import { NoteEncryptedHash } from './noteEncrypted'
 
 export class Note {
@@ -89,8 +88,8 @@ export class Note {
     return this._sender
   }
 
-  memo(): string {
-    return BufferUtils.toHuman(this._memo)
+  memo(): Buffer {
+    return this._memo
   }
 
   assetId(): Buffer {

--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -7,7 +7,7 @@ import { ChainProcessor } from '../../../chainProcessor'
 import { FullNode } from '../../../node'
 import { Block } from '../../../primitives/block'
 import { BlockHeader } from '../../../primitives/blockheader'
-import { CurrencyUtils } from '../../../utils'
+import { BufferUtils, CurrencyUtils } from '../../../utils'
 import { PromiseUtils } from '../../../utils/promise'
 import { isValidIncomingViewKey } from '../../../wallet/validator'
 import { ValidationError } from '../../adapters/errors'
@@ -138,7 +138,7 @@ routes.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
             const assetValue = await node.chain.getAssetById(decryptedNote.assetId())
             notes.push({
               value: CurrencyUtils.encode(decryptedNote.value()),
-              memo: decryptedNote.memo(),
+              memo: BufferUtils.toHuman(decryptedNote.memo()),
               assetId: decryptedNote.assetId().toString('hex'),
               assetName: assetValue?.name.toString('hex') || '',
               hash: decryptedNote.hash().toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/getAccountNotesStream.test.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountNotesStream.test.ts
@@ -5,7 +5,7 @@ import { BufferMap } from 'buffer-map'
 import { Assert } from '../../../assert'
 import { useAccountFixture, useBlockWithTx } from '../../../testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
-import { AsyncUtils, CurrencyUtils } from '../../../utils'
+import { AsyncUtils, BufferUtils, CurrencyUtils } from '../../../utils'
 import { DecryptedNoteValue } from '../../../wallet/walletdb/decryptedNoteValue'
 
 describe('Route wallet/getAccountNotesStream', () => {
@@ -46,7 +46,7 @@ describe('Route wallet/getAccountNotesStream', () => {
 
       expect(note.value).toEqual(CurrencyUtils.encode(expectedNote.note.value()))
       expect(note.assetId).toEqual(expectedNote.note.assetId().toString('hex'))
-      expect(note.memo).toEqual(expectedNote.note.memo())
+      expect(note.memo).toEqual(BufferUtils.toHuman(expectedNote.note.memo()))
       expect(note.sender).toEqual(expectedNote.note.sender())
       expect(note.owner).toEqual(expectedNote.note.owner())
       expect(note.noteHash).toEqual(expectedNote.note.hash().toString('hex'))

--- a/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
-import { CurrencyUtils } from '../../../utils'
+import { BufferUtils, CurrencyUtils } from '../../../utils'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 import { RpcWalletNote, RpcWalletNoteSchema } from './types'
@@ -46,7 +46,7 @@ routes.register<typeof GetAccountNotesStreamRequestSchema, GetAccountNotesStream
           value: CurrencyUtils.encode(note.value()),
           assetId: note.assetId().toString('hex'),
           assetName: asset?.name.toString('hex') || '',
-          memo: note.memo(),
+          memo: BufferUtils.toHuman(note.memo()),
           sender: note.sender(),
           owner: note.owner(),
           noteHash: note.hash().toString('hex'),

--- a/ironfish/src/rpc/routes/wallet/utils.ts
+++ b/ironfish/src/rpc/routes/wallet/utils.ts
@@ -211,7 +211,7 @@ export function serializeRpcWalletNote(
     value: CurrencyUtils.encode(note.note.value()),
     assetId: note.note.assetId().toString('hex'),
     assetName: asset?.name.toString('hex') || '',
-    memo: note.note.memo(),
+    memo: BufferUtils.toHuman(note.note.memo()),
     owner: note.note.owner(),
     sender: note.note.sender(),
     noteHash: note.note.hash().toString('hex'),


### PR DESCRIPTION
## Summary

the 'memo' method on the Note class returns the memo as a human-readable string by using 'BufferUtils.toHuman' on a utf8 decoded string of the memo

this human-readable representation may lose some information from the memo

returning the buffer instead allows sdk clients to choose how to interpret the data encoded in the note memo

for instance, a memo might contain a base64-encoded Ethereum public address. if this string is treated as a human-readable utf8 string, then the encoded address cannot be recovered accurately

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```

This is a breaking change to the SDK. Clients that use the `Note.memo()` method will need to use `BufferUtils.toHuman(note.memo())` to produce the same value