### PR TITLE
removing node name from hidden in the peer command

### DIFF
--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -46,7 +46,6 @@ export class ListCommand extends IronfishCommand {
       char: 'n',
       default: false,
       description: 'Display node names',
-      hidden: true,
     }),
     features: Flags.boolean({
       default: false,


### PR DESCRIPTION
## Summary

Show the names of the peers as an option for the `peers` command

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
