### PR TITLE
removes account name trimming in wallet cli inputs

### DIFF
--- a/ironfish-cli/src/commands/wallet/address.ts
+++ b/ironfish-cli/src/commands/wallet/address.ts
@@ -16,7 +16,6 @@ export class AddressCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to get the address for',
     },

--- a/ironfish-cli/src/commands/wallet/assets.ts
+++ b/ironfish-cli/src/commands/wallet/assets.ts
@@ -34,7 +34,6 @@ export class AssetsCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/balance.ts
+++ b/ironfish-cli/src/commands/wallet/balance.ts
@@ -37,7 +37,6 @@ export class BalanceCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to get balance for',
     },

--- a/ironfish-cli/src/commands/wallet/balances.ts
+++ b/ironfish-cli/src/commands/wallet/balances.ts
@@ -28,7 +28,6 @@ export class BalancesCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to get balances for',
     },

--- a/ironfish-cli/src/commands/wallet/create.ts
+++ b/ironfish-cli/src/commands/wallet/create.ts
@@ -12,7 +12,6 @@ export class CreateCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/export.ts
+++ b/ironfish-cli/src/commands/wallet/export.ts
@@ -45,7 +45,6 @@ export class ExportCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to export',
     },

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -19,7 +19,6 @@ export class NotesCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account to get notes for',
     },

--- a/ironfish-cli/src/commands/wallet/post.ts
+++ b/ironfish-cli/src/commands/wallet/post.ts
@@ -43,7 +43,6 @@ export class PostCommand extends IronfishCommand {
     {
       name: 'transaction',
       required: true,
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       description: 'The raw transaction in hex encoding',
     },
   ]

--- a/ironfish-cli/src/commands/wallet/rename.ts
+++ b/ironfish-cli/src/commands/wallet/rename.ts
@@ -10,13 +10,11 @@ export class RenameCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the account to rename',
     },
     {
       name: 'new-name',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'New name to assign to the account',
     },

--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -29,7 +29,6 @@ export class TransactionCommand extends IronfishCommand {
     },
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/transaction/watch.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/watch.ts
@@ -26,7 +26,6 @@ export class WatchTxCommand extends IronfishCommand {
     },
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/transactions.ts
+++ b/ironfish-cli/src/commands/wallet/transactions.ts
@@ -49,7 +49,6 @@ export class TransactionsCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: false,
       description: 'Name of the account',
     },

--- a/ironfish-cli/src/commands/wallet/use.ts
+++ b/ironfish-cli/src/commands/wallet/use.ts
@@ -10,7 +10,6 @@ export class UseCommand extends IronfishCommand {
   static args = [
     {
       name: 'account',
-      parse: (input: string): Promise<string> => Promise.resolve(input.trim()),
       required: true,
       description: 'Name of the account',
     },


### PR DESCRIPTION
## Summary

trimming the account name makes any account with leading or trailing whitespace unusable with the cli

we don't trim whitespace in the rpc or sdk when creating accounts, so it's possible for users to have accounts that have leading or trailing whitespace

limits scope from #4303 to account name inputs in the wallet only

## Testing Plan

manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
