### PR TITLE
Remove getPeerOrThrow function

### DIFF
--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -138,7 +138,8 @@ describe('connectToDisconnectedPeers', () => {
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })
     pcm.start()
 
-    const peer = pm.getPeerOrThrow(peerIdentity)
+    const peer = pm.getPeer(peerIdentity)
+    Assert.isNotNull(peer)
     expect(peer.state).toEqual({
       type: 'CONNECTING',
       identity: peerIdentity,

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -687,18 +687,6 @@ export class PeerManager {
   }
 
   /**
-   * Given an identity, fetch a Peer with that identity or throw an error
-   * @param identity A peer identity.
-   */
-  getPeerOrThrow(identity: Identity): Peer {
-    const peer = this.identifiedPeers.get(identity)
-    if (peer) {
-      return peer
-    }
-    throw new Error(`No peer found with identity ${identity}`)
-  }
-
-  /**
    * If a null identity is passed, creates a new Peer. If an identity is passed, returns the Peer
    * if we already have one with that identity, else creates a new Peer with that identity.
    * @param identity The identity of the peer to create, or null if the peer does not yet have one.


### PR DESCRIPTION
## Summary
Removing a function because it's only used in one test

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
