### PR TITLE
address manager doesn't require the peer manager reference anymore

### DIFF
--- a/ironfish/src/network/peers/addressManager.test.ts
+++ b/ironfish/src/network/peers/addressManager.test.ts
@@ -34,7 +34,7 @@ describe('AddressManager', () => {
     const hostsStore = mockHostsStore()
     const localPeer = mockLocalPeer()
     const pm = new PeerManager(localPeer, hostsStore)
-    const addressManager = new AddressManager(hostsStore, pm)
+    const addressManager = new AddressManager(hostsStore)
 
     expect(addressManager.priorConnectedPeerAddresses.length).toEqual(0)
 
@@ -72,7 +72,7 @@ describe('AddressManager', () => {
     const hostsStore = mockHostsStore()
     const localPeer = mockLocalPeer()
     const pm = new PeerManager(localPeer, hostsStore)
-    const addressManager = new AddressManager(hostsStore, pm)
+    const addressManager = new AddressManager(hostsStore)
 
     expect(addressManager.priorConnectedPeerAddresses.length).toEqual(0)
 
@@ -109,7 +109,7 @@ describe('AddressManager', () => {
 
     const hostsStore = mockHostsStore()
     const pm = new PeerManager(mockLocalPeer(), hostsStore)
-    const addressManager = new AddressManager(hostsStore, pm)
+    const addressManager = new AddressManager(hostsStore)
     addressManager.hostsStore = hostsStore
     const { peer: connectedPeer } = getConnectedPeer(pm)
     const { peer: connectingPeer } = getConnectingPeer(pm)
@@ -154,7 +154,7 @@ describe('AddressManager', () => {
       }),
     )
 
-    const addressManager = new AddressManager(hostsStore, pm)
+    const addressManager = new AddressManager(hostsStore)
     expect(addressManager.priorConnectedPeerAddresses.length).toEqual(MAX_PEER_ADDRESSES)
   })
 
@@ -164,7 +164,7 @@ describe('AddressManager', () => {
 
     const hostsStore = mockHostsStore()
     const pm = new PeerManager(mockLocalPeer(), hostsStore)
-    const addressManager = new AddressManager(hostsStore, pm)
+    const addressManager = new AddressManager(hostsStore)
 
     const { peer: oldestPeer } = getConnectedPeer(pm)
     await addressManager.addPeer(oldestPeer)
@@ -219,7 +219,7 @@ describe('AddressManager', () => {
 
     const hostsStore = mockHostsStore()
     const pm = new PeerManager(mockLocalPeer(), hostsStore)
-    const addressManager = new AddressManager(hostsStore, pm)
+    const addressManager = new AddressManager(hostsStore)
     const { peer } = getConnectedPeer(pm)
     await addressManager.addPeer(peer)
     const peerAddress = {
@@ -247,7 +247,7 @@ describe('AddressManager', () => {
     const hostsStore = mockHostsStore()
 
     const pm = new PeerManager(mockLocalPeer(), hostsStore)
-    const addressManager = new AddressManager(hostsStore, pm)
+    const addressManager = new AddressManager(hostsStore)
     addressManager.hostsStore = hostsStore
     const { peer: connectedPeer } = getConnectedPeer(pm)
     const address: PeerAddress = {

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -6,7 +6,6 @@ import { Identity } from '../identity'
 import { Peer } from '../peers/peer'
 import { ConnectionDirection } from './connections'
 import { PeerAddress } from './peerAddress'
-import { PeerManager } from './peerManager'
 
 export const MAX_PEER_ADDRESSES = 50
 
@@ -16,12 +15,12 @@ export const MAX_PEER_ADDRESSES = 50
  */
 export class AddressManager {
   hostsStore: HostsStore
-  peerManager: PeerManager
+
   private peerIdentityMap: Map<Identity, PeerAddress>
 
-  constructor(hostsStore: HostsStore, peerManager: PeerManager) {
+  constructor(hostsStore: HostsStore) {
     this.hostsStore = hostsStore
-    this.peerManager = peerManager
+
     // Load prior peers from disk
     this.peerIdentityMap = new Map<string, PeerAddress>()
 

--- a/ironfish/src/network/peers/addressManager.ts
+++ b/ironfish/src/network/peers/addressManager.ts
@@ -15,12 +15,10 @@ export const MAX_PEER_ADDRESSES = 50
  */
 export class AddressManager {
   hostsStore: HostsStore
-
   private peerIdentityMap: Map<Identity, PeerAddress>
 
   constructor(hostsStore: HostsStore) {
     this.hostsStore = hostsStore
-
     // Load prior peers from disk
     this.peerIdentityMap = new Map<string, PeerAddress>()
 

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -157,7 +157,7 @@ export class PeerManager {
     this.maxPeers = maxPeers
     this.targetPeers = Math.min(targetPeers, maxPeers)
     this.logPeerMessages = logPeerMessages
-    this.addressManager = new AddressManager(hostsStore, this)
+    this.addressManager = new AddressManager(hostsStore)
   }
 
   /**


### PR DESCRIPTION
## Summary

Realized that we no longer need the peer manager referenced in the address manager. Address manager is more isolated now. When we inevitably rip out the address manager, this will make things easier. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
