### PR TITLE
updates getTransactionStream for relay integration

### DIFF
--- a/ironfish/src/rpc/routes/chain/getTransactionStream.ts
+++ b/ironfish/src/rpc/routes/chain/getTransactionStream.ts
@@ -7,9 +7,9 @@ import { ChainProcessor } from '../../../chainProcessor'
 import { FullNode } from '../../../node'
 import { Block } from '../../../primitives/block'
 import { BlockHeader } from '../../../primitives/blockheader'
-import { BufferUtils, CurrencyUtils } from '../../../utils'
+import { CurrencyUtils } from '../../../utils'
 import { PromiseUtils } from '../../../utils/promise'
-import { isValidIncomingViewKey } from '../../../wallet/validator'
+import { isValidIncomingViewKey, isValidOutgoingViewKey } from '../../../wallet/validator'
 import { ValidationError } from '../../adapters/errors'
 import {
   RpcBlockHeader,
@@ -32,6 +32,7 @@ interface Note {
   hash: string
   value: string
   memo: string
+  sender: string
 }
 
 interface Transaction {
@@ -50,6 +51,8 @@ const NoteSchema = yup
     hash: yup.string().required(),
     value: yup.string().required(),
     memo: yup.string().required(),
+    memoHex: yup.string().required(),
+    sender: yup.string().required(),
   })
   .required()
 
@@ -64,7 +67,11 @@ const TransactionSchema = yup
   })
   .required()
 
-export type GetTransactionStreamRequest = { incomingViewKey: string; head?: string | null }
+export type GetTransactionStreamRequest = {
+  incomingViewKey: string
+  outgoingViewKey?: string
+  head?: string | null
+}
 
 export type GetTransactionStreamResponse = {
   type: 'connected' | 'disconnected' | 'fork'
@@ -79,6 +86,7 @@ export const GetTransactionStreamRequestSchema: yup.ObjectSchema<GetTransactionS
   yup
     .object({
       incomingViewKey: yup.string().required(),
+      outgoingViewKey: yup.string().optional(),
       head: yup.string().nullable().optional(),
     })
     .required()
@@ -104,6 +112,10 @@ routes.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
 
     if (!isValidIncomingViewKey(request.data.incomingViewKey)) {
       throw new ValidationError(`incomingViewKey is not valid`)
+    }
+
+    if (request.data.outgoingViewKey && !isValidOutgoingViewKey(request.data.outgoingViewKey)) {
+      throw new ValidationError(`outgoingViewKey is not valid`)
     }
 
     const head = request.data.head ? Buffer.from(request.data.head, 'hex') : null
@@ -132,16 +144,21 @@ routes.register<typeof GetTransactionStreamRequestSchema, GetTransactionStreamRe
         const burns = new Array<RpcBurn>()
 
         for (const note of tx.notes) {
-          const decryptedNote = note.decryptNoteForOwner(request.data.incomingViewKey)
+          let decryptedNote = note.decryptNoteForOwner(request.data.incomingViewKey)
+
+          if (!decryptedNote && request.data.outgoingViewKey) {
+            decryptedNote = note.decryptNoteForSpender(request.data.outgoingViewKey)
+          }
 
           if (decryptedNote) {
             const assetValue = await node.chain.getAssetById(decryptedNote.assetId())
             notes.push({
               value: CurrencyUtils.encode(decryptedNote.value()),
-              memo: BufferUtils.toHuman(decryptedNote.memo()),
+              memo: decryptedNote.memo().toString('hex'),
               assetId: decryptedNote.assetId().toString('hex'),
               assetName: assetValue?.name.toString('hex') || '',
               hash: decryptedNote.hash().toString('hex'),
+              sender: decryptedNote.sender(),
             })
           }
         }


### PR DESCRIPTION
## Summary

- optionally decrypts notes for spender - adds optional outgoingViewKey to request - attempts to decrypt using outgoingViewKey if decryption fails using incomingViewKey
- adds sender address to note responses
- returns memo as hex string instead of human-readable utf8 string

supports relay applications (e.g., bridges) that require information on outgoing transactions and may encode non-human-readable data in memos

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```

Changes the `memo` field in the returned notes to a hex string instead of human-readable utf8