### PR TITLE
Rahul fixing void calls to file system in address manager

### DIFF
--- a/ironfish/src/network/peers/peerStoreManager.test.ts
+++ b/ironfish/src/network/peers/peerStoreManager.test.ts
@@ -65,6 +65,27 @@ describe('PeerStoreManager', () => {
     expect(peerStoreManager.priorConnectedPeerAddresses.length).toEqual(0)
   })
 
+  it('testing isSaving mutex', async () => {
+    const hostsStore = mockPeerStore()
+    const saveSpy = jest.spyOn(hostsStore, 'save')
+
+    const peerStoreManager = new PeerStoreManager(hostsStore)
+
+    const promise1 = peerStoreManager.save()
+    const promise2 = peerStoreManager.save()
+    // should only be called once
+    expect(saveSpy).toHaveBeenCalledTimes(1)
+
+    await promise1
+    await promise2
+    // confirms that the second save was not called because of the mutex
+    expect(saveSpy).toHaveBeenCalledTimes(1)
+
+    await peerStoreManager.save()
+    await peerStoreManager.save()
+    expect(saveSpy).toHaveBeenCalledTimes(3)
+  })
+
   it('Confirming the functionality even when voiding the remove and add peer functions', () => {
     const now = Date.now()
     jest.setSystemTime(now)


### PR DESCRIPTION
## Summary

According to https://nodejs.org/api/fs.html#filehandlewritefiledata-options 

<img width="1416" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/e0efe97b-fc2f-4f26-a391-430b4f79f6e8">

This adds a basic mutex functionality to prevent fileWrite from being called multiple times without the promise completing. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
