### PR TITLE
moving findPeer log lower to avoid constant spam of the message

### DIFF
--- a/ironfish/src/syncer.ts
+++ b/ironfish/src/syncer.ts
@@ -163,7 +163,6 @@ export class Syncer {
       return
     }
 
-    this.logger.debug('Syncer is beginning peer candidate measurements')
     const measurementStart = BenchUtils.start()
 
     // Find all allowed peers that have more work than we have
@@ -174,6 +173,8 @@ export class Syncer {
     if (peers.length === 0) {
       return
     }
+
+    this.logger.debug('Syncer is beginning peer candidate measurements')
 
     // If there is only one valid peer to sync from, there is no point in
     // measuring the connection so begin syncing immediately


### PR DESCRIPTION
## Summary

Right now, the log will trigger every 2 seconds regardless of the node being fully synced or not. We should only display this log if there's a possibility to sync

## Testing Plan

Start a local node in verbose log mode

## Documentation

N/A

## Breaking Change

N/A