### PR TITLE
Support a minimum of NodeJS v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See https://ironfish.network
 
 The following steps should only be used to install if you are planning on contributing to the Iron Fish codebase. Otherwise, we **strongly** recommend using the installation methods here: https://ironfish.network/use/get-started/installation
 
-1. Install [Node.js 18.x](https://nodejs.org/en/download/)
+1. Install [Node.js LTS](https://nodejs.org/en/download/)
 1. Install [Rust](https://www.rust-lang.org/learn/get-started).
 1. Install [Yarn](https://classic.yarnpkg.com/en/docs/install).
 1. Windows:

--- a/ironfish-cli/bin/run
+++ b/ironfish-cli/bin/run
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const MIN_NODE_VERSION = 18
+
 // the signal handler does not support windows yet
 if (process.platform !== 'win32') {
   require('@ironfish/rust-nodejs').initSignalHandler()
@@ -12,12 +14,12 @@ if (process.platform === 'win32' && process.arch === 'ia32') {
   process.exit(1)
 }
 
-if (process.versions.node.split('.')[0] !== '18') {
+if (Number(process.versions.node.split('.')[0]) < MIN_NODE_VERSION) {
   console.log(
-    `NodeJS version ${process.versions.node} is not compatible. Must have Node v18 installed: https://nodejs.org/en/download/`,
+    `NodeJS version ${process.versions.node} is not compatible. Must have at least Node v${MIN_NODE_VERSION} installed: https://nodejs.org/en/download/`,
   )
   console.log(
-    'After v18 is installed, MAKE SURE TO run `npm install -g ironfish` again to install ironfish with the correct Node version',
+    'After an updated version is installed, MAKE SURE TO run `npm install -g ironfish` again to install ironfish with the correct Node version',
   )
   process.exit(1)
 }

--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -20,7 +20,7 @@
     "/oclif.manifest.json"
   ],
   "engines": {
-    "node": "18.x"
+    "node": ">=18"
   },
   "devDependencies": {
     "@oclif/test": "2.1.0",

--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -30,7 +30,7 @@
     }
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "devDependencies": {
     "@napi-rs/cli": "2.16.1",

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -17,7 +17,7 @@
     "build/**/*.json"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@ethersproject/bignumber": "5.7.0",

--- a/simulator/bin/run
+++ b/simulator/bin/run
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const MIN_NODE_VERSION = 18
+
 // the signal handler does not support windows yet
 if (process.platform !== 'win32') {
   require('@ironfish/rust-nodejs').initSignalHandler()
@@ -12,9 +14,9 @@ if (process.platform === 'win32' && process.arch === 'ia32') {
   process.exit(1)
 }
 
-if (process.versions.node.split('.')[0] !== '18') {
+if (Number(process.versions.node.split('.')[0]) < 18) {
   console.log(
-    `NodeJS version ${process.versions.node} is not compatible. Must have Node v18 installed: https://nodejs.org/en/download/`,
+    `NodeJS version ${process.versions.node} is not compatible. Must have at least Node v${MIN_NODE_VERSION} installed: https://nodejs.org/en/download/`,
   )
   process.exit(1)
 }

--- a/simulator/package.json
+++ b/simulator/package.json
@@ -20,7 +20,7 @@
     "/oclif.manifest.json"
   ],
   "engines": {
-    "node": "18.x"
+    "node": ">=18"
   },
   "devDependencies": {
     "@oclif/test": "2.1.0",


### PR DESCRIPTION
## Summary

Since NodeJS LTS version was just bumped to v20, we need to support it properly.
- Bumps any minimum versions of 16 to 18
- Allows the CLI and the main entrypoint to support 18 _or higher_
- Update install instructions to simply reference latest LTS version so we can avoid manually bumping it all the time

## Testing Plan

Tested running a node on NodeJS 18 and 20

## Documentation

https://github.com/iron-fish/website/pull/561

## Breaking Change

We are removing NodeJS 16 support. This was only semi-supported in the first place so it should not be a huge change, but is worth noting.