### PR TITLE
Test multiple NodeJS versions in CI

### DIFF
--- a/.github/workflows/build-ironfish-rust-nodejs.yml
+++ b/.github/workflows/build-ironfish-rust-nodejs.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18
           cache: yarn
 
       - name: Install Rust
@@ -121,7 +121,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18
 
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci-regenerate-fixtures.yml
+++ b/.github/workflows/ci-regenerate-fixtures.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18
           cache: 'yarn'
 
       - name: Cache Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18
           cache: 'yarn'
 
       - name: Install packages
@@ -39,9 +39,13 @@ jobs:
       - name: Lint
         run: yarn lint
 
-  test:
-    name: Test
+  test-matrix:
+    name: Test Matrix
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
+        test-type: ["test", "test:slow"]
 
     steps:
       - name: Check out Git repository
@@ -50,7 +54,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: ${{ matrix.version }}
           cache: 'yarn'
 
       - name: Cache Rust
@@ -62,7 +66,7 @@ jobs:
         run: yarn --non-interactive --frozen-lockfile
 
       - name: Run tests
-        run: yarn test:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
+        run: yarn ${{ matrix.test-type}}:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
 
       - name: Check for missing fixtures
         run: |
@@ -75,38 +79,13 @@ jobs:
         if: github.repository == 'iron-fish/ironfish'
         run: CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} ROOT_PATH=$GITHUB_WORKSPACE/ yarn coverage:upload
 
-  testslow:
-    name: Slow Tests
+  # This is a workaround to have status checks on jobs that use a matrix.
+  # See: https://github.com/orgs/community/discussions/26822
+  test:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
-
+    name: Test
+    needs: [test-matrix]
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.12.1'
-          cache: 'yarn'
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: nodejs
-
-      - name: Install packages
-        run: yarn --non-interactive --frozen-lockfile
-
-      - name: Run slow tests & coverage
-        run: yarn test:slow:coverage --maxWorkers=2 --workerIdleMemoryLimit=2000MB
-
-      - name: Check for missing fixtures
-        run: |
-          if [[ $(git status | grep fixture) ]]; then
-            echo "New test fixtures have not been checked in, please check them in."
-            exit 1
-          fi
-
-      - name: Upload coverage
-        if: github.repository == 'iron-fish/ironfish'
-        run: CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} ROOT_PATH=$GITHUB_WORKSPACE/ yarn coverage:upload
+      - run: exit 1
+        if: ${{ !contains(needs.*.result, 'success')}}

--- a/.github/workflows/deploy-brew.yml
+++ b/.github/workflows/deploy-brew.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18
           cache: 'yarn'
 
       - name: Build Ironfish CLI

--- a/.github/workflows/deploy-npm-ironfish-cli.yml
+++ b/.github/workflows/deploy-npm-ironfish-cli.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
 

--- a/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
+++ b/.github/workflows/deploy-npm-ironfish-rust-nodejs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
 

--- a/.github/workflows/deploy-npm-ironfish.yml
+++ b/.github/workflows/deploy-npm-ironfish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
 

--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18
           cache: 'yarn'
 
       - name: Install packages

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -23,7 +23,7 @@ jobs:
           - host: ubuntu-20.04
             arch: x86_64
             system: linux
-          
+
           - host: [self-hosted, macOS, ARM64]
             arch: arm64
             system: apple
@@ -32,7 +32,6 @@ jobs:
           # - host: ubuntu-20.04
           #   arch: aarch64
           #   system: linux
-          
 
           # - host: ubuntu-20.04
           #   target: aarch64-apple-darwin
@@ -50,11 +49,11 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18
 
       - name: npm init
         run: npm init -y
-      
+
       - name: install dependencies
         run: npm install ironfish caxa@3.0.1
 
@@ -63,7 +62,7 @@ jobs:
         run: |
           npx caxa --uncompression-message "Running the CLI for the first time may take a while, please wait..." --input . --output "${{ matrix.settings.system != 'windows' && 'ironfish' || 'ironfish.exe' }}" -- "{{caxa}}/node_modules/.bin/node" "--enable-source-maps" "{{caxa}}/node_modules/ironfish/bin/run"
           echo "RELEASE_NAME=ironfish-${{ matrix.settings.system }}-${{ matrix.settings.arch }}-${{ github.event.release.tag_name }}.zip"
-      
+
       - name: set paths
         id: set_paths
         shell: bash


### PR DESCRIPTION
## Summary

Since we officially support NodeJS v18 and v20 (https://github.com/iron-fish/ironfish/pull/4395), we should test them in CI as well.

## Testing Plan

CI

## Documentation

N/A

## Breaking Change

N/A