### PR TITLE
Simplify displaying NetworkMessage in logs

### DIFF
--- a/ironfish/src/network/messages/networkMessage.ts
+++ b/ironfish/src/network/messages/networkMessage.ts
@@ -5,10 +5,6 @@ import bufio from 'bufio'
 import { Serializable } from '../../common/serializable'
 import { NetworkMessageType } from '../types'
 
-export function displayNetworkMessageType(type: NetworkMessageType): string {
-  return `${NetworkMessageType[type]} (${type})`
-}
-
 export abstract class NetworkMessage implements Serializable {
   readonly type: NetworkMessageType
 
@@ -31,5 +27,9 @@ export abstract class NetworkMessage implements Serializable {
     bw.writeU8(this.type)
     this.serializePayload(bw)
     return bw.render()
+  }
+
+  displayType(): string {
+    return `${NetworkMessageType[this.type]} (${this.type})`
   }
 }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -33,7 +33,7 @@ import {
   GetBlockTransactionsResponse,
 } from './messages/getBlockTransactions'
 import { GetCompactBlockRequest, GetCompactBlockResponse } from './messages/getCompactBlock'
-import { displayNetworkMessageType, NetworkMessage } from './messages/networkMessage'
+import { NetworkMessage } from './messages/networkMessage'
 import { NewBlockHashesMessage } from './messages/newBlockHashes'
 import { NewCompactBlockMessage } from './messages/newCompactBlock'
 import { NewPooledTransactionHashes } from './messages/newPooledTransactionHashes'
@@ -508,9 +508,7 @@ export class PeerNetwork {
         if (request && request.peer.state.type === 'DISCONNECTED') {
           request.peer.onStateChanged.off(onConnectionStateChanged)
 
-          const errorMessage = `Connection closed while waiting for request ${displayNetworkMessageType(
-            message.type,
-          )}: ${rpcId}`
+          const errorMessage = `Connection closed while waiting for request ${message.displayType()}: ${rpcId}`
 
           request.reject(new NetworkError(errorMessage))
         }
@@ -527,9 +525,7 @@ export class PeerNetwork {
         }
         const errorMessage = `Closing connections to ${
           peer.displayName
-        } because RPC message of type ${displayNetworkMessageType(
-          message.type,
-        )} timed out after ${RPC_TIMEOUT_MILLIS} ms in request: ${rpcId}.`
+        } because RPC message of type ${message.displayType()} timed out after ${RPC_TIMEOUT_MILLIS} ms in request: ${rpcId}.`
         const error = new RequestTimeoutError(RPC_TIMEOUT_MILLIS, errorMessage)
         this.logger.debug(errorMessage)
         clearDisconnectHandler()
@@ -572,9 +568,9 @@ export class PeerNetwork {
       if (!connection) {
         return request.reject(
           new Error(
-            `${String(peer.state.identity)} did not send ${displayNetworkMessageType(
-              message.type,
-            )} in state ${peer.state.type}`,
+            `${String(peer.state.identity)} did not send ${message.displayType()} in state ${
+              peer.state.type
+            }`,
           ),
         )
       }
@@ -597,9 +593,7 @@ export class PeerNetwork {
 
     if (!(response instanceof GetBlockHeadersResponse)) {
       // TODO jspafford: disconnect peer, or handle it more properly
-      throw new Error(
-        `Invalid GetBlockHeadersResponse: ${displayNetworkMessageType(message.type)}`,
-      )
+      throw new Error(`Invalid GetBlockHeadersResponse: ${message.displayType()}`)
     }
 
     return { headers: response.headers, time: BenchUtils.end(begin) }
@@ -617,7 +611,7 @@ export class PeerNetwork {
 
     if (!(response instanceof GetBlocksResponse)) {
       // TODO jspafford: disconnect peer, or handle it more properly
-      throw new Error(`Invalid GetBlocksResponse: ${displayNetworkMessageType(message.type)}`)
+      throw new Error(`Invalid GetBlocksResponse: ${message.displayType()}`)
     }
 
     const exceededSoftLimit = response.getSize() >= SOFT_MAX_MESSAGE_SIZE
@@ -645,9 +639,7 @@ export class PeerNetwork {
       }
     } else {
       throw new Error(
-        `Invalid message for handling in peer network: '${displayNetworkMessageType(
-          message.type,
-        )}'`,
+        `Invalid message for handling in peer network: '${message.displayType()}'`,
       )
     }
   }
@@ -685,9 +677,7 @@ export class PeerNetwork {
         const asError = error as Error
         if (!(asError.name && asError.name === 'CannotSatisfyRequestError')) {
           this.logger.error(
-            `Unexpected error in ${displayNetworkMessageType(
-              rpcMessage.type,
-            )} handler: ${String(error)}`,
+            `Unexpected error in ${rpcMessage.displayType()} handler: ${String(error)}`,
           )
         }
         responseMessage = new CannotSatisfyRequest(rpcId)

--- a/ironfish/src/network/peers/connections/connection.ts
+++ b/ironfish/src/network/peers/connections/connection.ts
@@ -8,7 +8,7 @@ import { Event } from '../../../event'
 import { MetricsMonitor } from '../../../metrics'
 import { ErrorUtils, SetTimeoutToken } from '../../../utils'
 import { Identity } from '../../identity'
-import { displayNetworkMessageType, NetworkMessage } from '../../messages/networkMessage'
+import { NetworkMessage } from '../../messages/networkMessage'
 import { RPC_TIMEOUT_MILLIS } from '../../messages/rpcNetworkMessage'
 import { NetworkMessageType } from '../../types'
 import { MAX_MESSAGE_SIZE } from '../../version'
@@ -119,11 +119,7 @@ export abstract class Connection {
     }
 
     if (this.shouldLogMessageType(object.type)) {
-      this.logger.debug(
-        `${colors.yellow('SEND')} ${this.displayName}: ${displayNetworkMessageType(
-          object.type,
-        )}`,
-      )
+      this.logger.debug(`${colors.yellow('SEND')} ${this.displayName}: ${object.displayType()}`)
     }
 
     let sendResult
@@ -131,9 +127,9 @@ export abstract class Connection {
       sendResult = this._send(data)
     } catch (e) {
       this.logger.debug(
-        `Error occurred while sending ${displayNetworkMessageType(
-          object.type,
-        )} message in state ${this.state.type} ${ErrorUtils.renderError(e)}`,
+        `Error occurred while sending ${object.displayType()} message in state ${
+          this.state.type
+        } ${ErrorUtils.renderError(e)}`,
       )
       this.close(e)
       return false

--- a/ironfish/src/network/peers/connections/webRtcConnection.ts
+++ b/ironfish/src/network/peers/connections/webRtcConnection.ts
@@ -10,7 +10,6 @@ import { Event } from '../../../event'
 import { MetricsMonitor } from '../../../metrics'
 import { ErrorUtils } from '../../../utils'
 import { parseNetworkMessage } from '../../messageRegistry'
-import { displayNetworkMessageType } from '../../messages/networkMessage'
 import { MAX_MESSAGE_SIZE } from '../../version'
 import { Connection, ConnectionDirection, ConnectionType } from './connection'
 import { NetworkError } from './errors'
@@ -148,9 +147,7 @@ export class WebRtcConnection extends Connection {
 
       if (this.shouldLogMessageType(message.type)) {
         this.logger.debug(
-          `${colors.yellow('RECV')} ${this.displayName}: ${displayNetworkMessageType(
-            message.type,
-          )}`,
+          `${colors.yellow('RECV')} ${this.displayName}: ${message.displayType()}`,
         )
       }
 

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -6,7 +6,6 @@ import type { Logger } from '../../../logger'
 import colors from 'colors/safe'
 import { MetricsMonitor } from '../../../metrics'
 import { parseNetworkMessage } from '../../messageRegistry'
-import { displayNetworkMessageType } from '../../messages/networkMessage'
 import { IsomorphicWebSocket, IsomorphicWebSocketErrorEvent } from '../../types'
 import { Connection, ConnectionDirection, ConnectionType } from './connection'
 import { NetworkError } from './errors'
@@ -93,9 +92,7 @@ export class WebSocketConnection extends Connection {
 
       if (this.shouldLogMessageType(message.type)) {
         this.logger.debug(
-          `${colors.yellow('RECV')} ${this.displayName}: ${displayNetworkMessageType(
-            message.type,
-          )}`,
+          `${colors.yellow('RECV')} ${this.displayName}: ${message.displayType()}`,
         )
       }
 

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -10,7 +10,7 @@ import { createRootLogger, Logger } from '../../logger'
 import { MetricsMonitor } from '../../metrics'
 import { ErrorUtils } from '../../utils'
 import { Identity } from '../identity'
-import { displayNetworkMessageType, NetworkMessage } from '../messages/networkMessage'
+import { NetworkMessage } from '../messages/networkMessage'
 import { NetworkMessageType } from '../types'
 import { NetworkError, WebRtcConnection, WebSocketConnection } from './connections'
 import { Connection, ConnectionType } from './connections/connection'
@@ -487,9 +487,9 @@ export class Peer {
     // Return early if peer is not in state CONNECTED
     if (this.state.type !== 'CONNECTED') {
       this.logger.debug(
-        `Attempted to send a ${displayNetworkMessageType(message.type)} message to ${
-          this.displayName
-        } in state ${this.state.type}`,
+        `Attempted to send a ${message.displayType()} message to ${this.displayName} in state ${
+          this.state.type
+        }`,
       )
       return null
     }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -16,7 +16,7 @@ import {
 } from '../identity'
 import { DisconnectingMessage, DisconnectingReason } from '../messages/disconnecting'
 import { IdentifyMessage } from '../messages/identify'
-import { displayNetworkMessageType, NetworkMessage } from '../messages/networkMessage'
+import { NetworkMessage } from '../messages/networkMessage'
 import { PeerListMessage } from '../messages/peerList'
 import { PeerListRequestMessage } from '../messages/peerListRequest'
 import { SignalMessage } from '../messages/signal'
@@ -861,9 +861,7 @@ export class PeerManager {
     } else {
       if (peer.state.identity === null) {
         this.logger.debug(
-          `Closing connection to unidentified peer that sent an unexpected message: ${displayNetworkMessageType(
-            message.type,
-          )}`,
+          `Closing connection to unidentified peer that sent an unexpected message: ${message.displayType()}`,
         )
         peer.close()
         return
@@ -974,9 +972,7 @@ export class PeerManager {
       this.logger.debug(
         `Disconnecting from ${
           peer.displayName
-        } - Sent unexpected message ${displayNetworkMessageType(
-          message.type,
-        )} while waiting for identity`,
+        } - Sent unexpected message ${message.displayType()} while waiting for identity`,
       )
       peer.close()
       return


### PR DESCRIPTION
## Summary
Shorten displaying NetworkMessage code for readability

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
