### PR TITLE
returning list of brokering peers to try a variety of brokering peers for web rtc connections

### DIFF
--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -1166,7 +1166,7 @@ describe('PeerManager', () => {
       peer.onMessage.emit(message, connection)
       expect(initWebRtcConnectionMock).toHaveBeenCalledTimes(1)
       expect(initWebRtcConnectionMock).toHaveBeenCalledWith(peer, true)
-      expect(pm['getBrokeringPeer'](peer)).toEqual(peer)
+      expect(pm['getBrokeringPeers'](peer)[0]).toEqual(peer)
     })
 
     it('Sends a disconnect message if we are at max peers', () => {

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -639,12 +639,12 @@ export class PeerManager {
 
     for (const neighbor of val.neighbors) {
       const neighborPeer = this.identifiedPeers.get(neighbor)
-      if (!neighborPeer || neighborPeer.state.type !== 'CONNECTED') {
-        val.neighbors.delete(neighbor)
-        continue
-      }
 
-      candidates.push(neighborPeer)
+      if (neighborPeer && neighborPeer.state.type === 'CONNECTED') {
+        candidates.push(neighborPeer)
+      } else {
+        val.neighbors.delete(neighbor)
+      }
     }
 
     return candidates

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -628,14 +628,14 @@ export class PeerManager {
       return []
     }
 
-    // Find another peer to broker the connection
-    const candidates = []
-
     // The peer candidate map tracks any brokering peer candidates
     const val = this.peerCandidates.get(peer.state.identity)
     if (!val) {
       return []
     }
+
+    // Find another peer to broker the connection
+    const candidates = []
 
     for (const neighbor of val.neighbors) {
       const neighborPeer = this.identifiedPeers.get(neighbor)

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -286,8 +286,10 @@ export class PeerManager {
 
     const connection = this.initWebRtcConnection(peer, false)
     connection.setState({ type: 'REQUEST_SIGNALING' })
-    const brokeringPeer = ArrayUtils.shuffle(brokeringPeers)[0]
+
+    const brokeringPeer = brokeringPeers[0]
     brokeringPeer.send(signal)
+
     return true
   }
 
@@ -372,12 +374,9 @@ export class PeerManager {
         peer.getIdentityOrThrow(),
       )
 
-      const shuffledPeers = ArrayUtils.shuffle(brokeringPeers).slice(
-        0,
-        MAX_WEBRTC_BROKERING_ATTEMPTS,
-      )
+      const limitedBrokeringPeers = brokeringPeers.slice(0, MAX_WEBRTC_BROKERING_ATTEMPTS)
 
-      for (const brokeringPeer of shuffledPeers) {
+      for (const brokeringPeer of limitedBrokeringPeers) {
         if (brokeringPeer === null) {
           const message = 'Cannot establish a WebRTC connection without a brokering peer'
           this.logger.debug(message)
@@ -647,7 +646,7 @@ export class PeerManager {
       }
     }
 
-    return candidates
+    return ArrayUtils.shuffle(candidates)
   }
 
   /**


### PR DESCRIPTION
## Summary

Removes the logical inconsistency that would allow trying the same peer as a brokering peer multiple times even if we didn't necessarily need it more than once.

This tackles that by changing the logic in the `initWebRtcConnection` function

## Testing Plan

In draft state at the moment, I'll update unit tests if this is viable solution

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
