### PR TITLE
adding save and create file mutex

### DIFF
--- a/ironfish/src/fileStores/fileStore.test.ts
+++ b/ironfish/src/fileStores/fileStore.test.ts
@@ -40,10 +40,5 @@ describe('FileStore', () => {
 
     await promise2
     expect(save).toHaveBeenCalledTimes(2)
-
-    await store.save({ foo: 'hello' })
-    await store.save({ foo: 'hello' })
-
-    expect(save).toHaveBeenCalledTimes(4)
   })
 })

--- a/ironfish/src/fileStores/fileStore.ts
+++ b/ironfish/src/fileStores/fileStore.ts
@@ -11,6 +11,12 @@ export class FileStore<T extends Record<string, unknown>> {
   dataDir: string
   configPath: string
   configName: string
+  // According to the documentation: "It is unsafe to use filehandle.writeFile() multiple
+  // times on the same file without waiting for the promise to be fulfilled (or rejected)."
+  // https://nodejs.org/api/fs.html#filehandlewritefiledata-options
+  // We have had several complaints especially from Windows users about the json file being corrupted.
+  // We call this function several places in our codebase without waiting for the promise to complete.
+  // This mutex is used to prevent multiple writes to the same file.
   saveFileMutex = new Mutex()
 
   constructor(files: FileSystem, configName: string, dataDir: string) {

--- a/ironfish/src/fileStores/fileStore.ts
+++ b/ironfish/src/fileStores/fileStore.ts
@@ -11,12 +11,6 @@ export class FileStore<T extends Record<string, unknown>> {
   dataDir: string
   configPath: string
   configName: string
-  // According to the documentation: "It is unsafe to use filehandle.writeFile() multiple
-  // times on the same file without waiting for the promise to be fulfilled (or rejected)."
-  // https://nodejs.org/api/fs.html#filehandlewritefiledata-options
-  // We have had several complaints especially from Windows users about the json file being corrupted.
-  // We call this function several places in our codebase without waiting for the promise to complete.
-  // This mutex is used to prevent multiple writes to the same file.
   saveFileMutex = new Mutex()
 
   constructor(files: FileSystem, configName: string, dataDir: string) {


### PR DESCRIPTION
## Summary

According to the documentation: "It is unsafe to use filehandle.writeFile() multiple
times on the same file without waiting for the promise to be fulfilled (or rejected)."
https://nodejs.org/api/fs.html#filehandlewritefiledata-options
We have had several complaints especially from Windows users about the json file being corrupted.
We call this function several places in our codebase without waiting for the promise to complete.
This mutex is used to prevent multiple writes to the same file.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
