### PR TITLE
Normalize WebSocket fields on Peer

### DIFF
--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -163,19 +163,20 @@ export class Peer {
     return identitySlice
   }
 
-  private _wsAddress: WebSocketAddress | null = null
+  wsAddress: WebSocketAddress | null = null
+
   /**
    * address associated with this peer
    */
   get address(): string | null {
-    return this._wsAddress?.host || null
+    return this.wsAddress?.host || null
   }
 
   /**
    * port associated with this peer
    */
   get port(): number | null {
-    return this._wsAddress?.port || null
+    return this.wsAddress?.port || null
   }
 
   /** how many outbound connections does the peer have */

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -163,20 +163,19 @@ export class Peer {
     return identitySlice
   }
 
+  private _wsAddress: WebSocketAddress | null = null
   /**
    * address associated with this peer
    */
-  private _address: string | null = null
   get address(): string | null {
-    return this._address
+    return this._wsAddress?.host || null
   }
 
   /**
    * port associated with this peer
    */
-  private _port: number | null = null
   get port(): number | null {
-    return this._port
+    return this._wsAddress?.port || null
   }
 
   /** how many outbound connections does the peer have */
@@ -445,8 +444,7 @@ export class Peer {
    * @param port Port to connect over. Must be null if address is null.
    */
   setWebSocketAddress(wsAddress: WebSocketAddress | null): void {
-    this._address = wsAddress?.host || null
-    this._port = wsAddress?.port || null
+    this._wsAddress = wsAddress
   }
 
   /**

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -445,7 +445,7 @@ export class Peer {
    * @param port Port to connect over. Must be null if address is null.
    */
   setWebSocketAddress(wsAddress: WebSocketAddress | null): void {
-    this._wsAddress = wsAddress
+    this.wsAddress = wsAddress
   }
 
   /**

--- a/ironfish/src/network/peers/peerCandidates.ts
+++ b/ironfish/src/network/peers/peerCandidates.ts
@@ -5,7 +5,7 @@ import { ArrayUtils } from '../../utils/array'
 import { Identity } from '../identity'
 import { Peer as PeerListPeer } from '../messages/peerList'
 import { ConnectionRetry } from './connectionRetry'
-import { Peer } from './peer'
+import { Peer, WebSocketAddress } from './peer'
 
 export type PeerCandidate = {
   name?: string
@@ -31,6 +31,16 @@ export class PeerCandidates {
 
   get size(): number {
     return this.map.size
+  }
+
+  getWsAddress(candidate: {
+    address: string | null
+    port: number | null
+  }): WebSocketAddress | null {
+    if (candidate.port !== null && candidate.address === null) {
+      throw new Error('Peer port is not null but address is null')
+    }
+    return candidate.address ? { host: candidate.address, port: candidate.port } : null
   }
 
   addFromPeer(peer: Peer, neighbors = new Set<Identity>()): void {
@@ -67,7 +77,7 @@ export class PeerCandidates {
       peerCandidateValue.neighbors.add(sendingPeerIdentity)
     } else {
       const tempPeer = new Peer(peerIdentity)
-      tempPeer.setWebSocketAddress(peer.address, peer.port)
+      tempPeer.setWebSocketAddress(this.getWsAddress(peer))
       this.addFromPeer(tempPeer, new Set([sendingPeerIdentity]))
     }
   }

--- a/ironfish/src/network/peers/peerCandidates.ts
+++ b/ironfish/src/network/peers/peerCandidates.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { ArrayUtils } from '../../utils/array'
 import { Identity } from '../identity'
-import { Peer as PeerListPeer } from '../messages/peerList'
 import { ConnectionRetry } from './connectionRetry'
 import { Peer, WebSocketAddress } from './peer'
 
@@ -69,15 +68,21 @@ export class PeerCandidates {
     }
   }
 
-  addFromPeerList(sendingPeerIdentity: Identity, peer: PeerListPeer): void {
-    const peerIdentity = peer.identity.toString('base64')
-    const peerCandidateValue = this.map.get(peerIdentity)
+  addFromPeerList(
+    sendingPeerIdentity: Identity,
+    peer: {
+      identity: Identity
+      name?: string
+      wsAddress: WebSocketAddress | null
+    },
+  ): void {
+    const peerCandidateValue = this.map.get(peer.identity)
 
     if (peerCandidateValue) {
       peerCandidateValue.neighbors.add(sendingPeerIdentity)
     } else {
-      const tempPeer = new Peer(peerIdentity)
-      tempPeer.setWebSocketAddress(this.getWsAddress(peer))
+      const tempPeer = new Peer(peer.identity)
+      tempPeer.setWebSocketAddress(peer.wsAddress)
       this.addFromPeer(tempPeer, new Set([sendingPeerIdentity]))
     }
   }

--- a/ironfish/src/network/peers/peerCandidates.ts
+++ b/ironfish/src/network/peers/peerCandidates.ts
@@ -32,16 +32,6 @@ export class PeerCandidates {
     return this.map.size
   }
 
-  getWsAddress(candidate: {
-    address: string | null
-    port: number | null
-  }): WebSocketAddress | null {
-    if (candidate.port !== null && candidate.address === null) {
-      throw new Error('Peer port is not null but address is null')
-    }
-    return candidate.address ? { host: candidate.address, port: candidate.port } : null
-  }
-
   addFromPeer(peer: Peer, neighbors = new Set<Identity>()): void {
     const address = peer.getWebSocketAddress()
     const addressPeerCandidate = this.map.get(address)

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -42,7 +42,7 @@ describe('connectToDisconnectedPeers', () => {
     const pm = new PeerManager(mockLocalPeer(), mockPeerStore())
 
     const peer = pm.getOrCreatePeer(null)
-    peer.setWebSocketAddress('testuri.com', 9033)
+    peer.setWebSocketAddress({ host: 'testuri.com', port: 9033 })
     pm['tryDisposePeer'](peer)
 
     pm.peerCandidates.addFromPeer(peer)
@@ -64,7 +64,7 @@ describe('connectToDisconnectedPeers', () => {
 
     const identity = mockIdentity('peer')
     const peer = pm.getOrCreatePeer(identity)
-    peer.setWebSocketAddress('testuri.com', 9033)
+    peer.setWebSocketAddress({ host: 'testuri.com', port: 9033 })
     pm['tryDisposePeer'](peer)
 
     pm.peerCandidates.addFromPeer(peer)
@@ -94,7 +94,7 @@ describe('connectToDisconnectedPeers', () => {
 
     const identity = mockIdentity('peer')
     const createdPeer = peers.getOrCreatePeer(identity)
-    createdPeer.setWebSocketAddress('testuri.com', 9033)
+    createdPeer.setWebSocketAddress({ host: 'testuri.com', port: 9033 })
     peers['tryDisposePeer'](createdPeer)
 
     peers.peerCandidates.addFromPeer(createdPeer)
@@ -125,14 +125,12 @@ describe('connectToDisconnectedPeers', () => {
     const { peer: brokeringPeer } = getConnectedPeer(pm, 'brokering')
     // Link the peers
     pm.peerCandidates.addFromPeerList(brokeringPeer.getIdentityOrThrow(), {
-      address: null,
-      port: null,
-      identity: Buffer.from(peerIdentity, 'base64'),
+      wsAddress: null,
+      identity: peerIdentity,
     })
     pm.peerCandidates.addFromPeerList(peerIdentity, {
-      address: null,
-      port: null,
-      identity: Buffer.from(brokeringPeer.getIdentityOrThrow(), 'base64'),
+      wsAddress: null,
+      identity: brokeringPeer.getIdentityOrThrow(),
     })
 
     const pcm = new PeerConnectionManager(pm, createRootLogger(), { maxPeers: 50 })

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -94,10 +94,13 @@ export class PeerConnectionManager {
         if (val) {
           const peer = this.peerManager.getOrCreatePeer(peerCandidateIdentity)
           peer.name = val.name ?? null
+
           if (val.port !== null && val.address === null) {
             throw new Error('Peer port is not null but address is null')
           }
-          peer.setWebSocketAddress(this.peerManager.peerCandidates.getWsAddress(val))
+
+          peer.setWebSocketAddress(val.address ? { host: val.address, port: val.port } : null)
+
           if (this.connectToEligiblePeers(peer)) {
             connectAttempts++
           } else {

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -94,7 +94,10 @@ export class PeerConnectionManager {
         if (val) {
           const peer = this.peerManager.getOrCreatePeer(peerCandidateIdentity)
           peer.name = val.name ?? null
-          peer.setWebSocketAddress(val.address, val.port)
+          if (val.port !== null && val.address === null) {
+            throw new Error('Peer port is not null but address is null')
+          }
+          peer.setWebSocketAddress(this.peerManager.peerCandidates.getWsAddress(val))
           if (this.connectToEligiblePeers(peer)) {
             connectAttempts++
           } else {

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -379,18 +379,16 @@ describe('PeerManager', () => {
 
       // Link the peers
       pm.peerCandidates.addFromPeerList(peer2Identity, {
-        address: null,
-        port: null,
-        identity: Buffer.from(peer1Identity, 'base64'),
+        wsAddress: null,
+        identity: peer1Identity,
       })
       pm.peerCandidates.addFromPeerList(peer1Identity, {
-        address: null,
-        port: null,
-        identity: Buffer.from(peer2Identity, 'base64'),
+        wsAddress: null,
+        identity: peer2Identity,
       })
 
       // Verify peer2 is not connected
-      peer2.setWebSocketAddress('testuri', 9033)
+      peer2.setWebSocketAddress({ host: 'testuri', port: 9033 })
       expect(peer2.state).toEqual({
         type: 'DISCONNECTED',
         identity: peer2Identity,
@@ -418,14 +416,12 @@ describe('PeerManager', () => {
 
       // Link the peers
       peers.peerCandidates.addFromPeerList(targetPeer.getIdentityOrThrow(), {
-        address: null,
-        port: null,
-        identity: Buffer.from(brokeringPeer.getIdentityOrThrow(), 'base64'),
+        wsAddress: null,
+        identity: brokeringPeer.getIdentityOrThrow(),
       })
       peers.peerCandidates.addFromPeerList(brokeringPeer.getIdentityOrThrow(), {
-        address: null,
-        port: null,
-        identity: Buffer.from(targetPeer.getIdentityOrThrow(), 'base64'),
+        wsAddress: null,
+        identity: targetPeer.getIdentityOrThrow(),
       })
 
       peers.connectToWebRTC(targetPeer)
@@ -503,14 +499,12 @@ describe('PeerManager', () => {
 
       // Link the peers
       peers.peerCandidates.addFromPeerList(targetPeer.getIdentityOrThrow(), {
-        address: null,
-        port: null,
-        identity: Buffer.from(brokeringPeer.getIdentityOrThrow(), 'base64'),
+        wsAddress: null,
+        identity: brokeringPeer.getIdentityOrThrow(),
       })
       peers.peerCandidates.addFromPeerList(brokeringPeer.getIdentityOrThrow(), {
-        address: null,
-        port: null,
-        identity: Buffer.from(targetPeer.getIdentityOrThrow(), 'base64'),
+        wsAddress: null,
+        identity: targetPeer.getIdentityOrThrow(),
       })
 
       peers.connectToWebRTC(targetPeer)
@@ -585,7 +579,7 @@ describe('PeerManager', () => {
       // Add a second peer that's disconnected
       const peer2Identity = mockIdentity('peer2')
       const peer2 = pm.getOrCreatePeer(peer2Identity)
-      peer2.setWebSocketAddress('testuri.com', 9033)
+      peer2.setWebSocketAddress({ host: 'testuri.com', port: 9033 })
 
       // Mock the logger
       pm['logger'].mockTypes(() => jest.fn())

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -190,7 +190,7 @@ export class PeerManager {
     forceConnect?: boolean
   }): Peer | undefined {
     const peer = this.getOrCreatePeer(null)
-    peer.setWebSocketAddress(options.host, options.port)
+    peer.setWebSocketAddress({ host: options.host, port: options.port })
     peer.isWhitelisted = !!options.whitelist
 
     this.peerCandidates.addFromPeer(peer)
@@ -1027,7 +1027,7 @@ export class PeerManager {
         connection.type === ConnectionType.WebSocket &&
         connection.direction === ConnectionDirection.Outbound
       ) {
-        peer.setWebSocketAddress(null, null)
+        peer.setWebSocketAddress(null)
       }
 
       const error = `Closing ${connection.type} connection from our own identity`
@@ -1062,7 +1062,7 @@ export class PeerManager {
           connection.direction === ConnectionDirection.Outbound &&
           originalPeer.address !== null
         ) {
-          peer.setWebSocketAddress(originalPeer.address, originalPeer.port)
+          peer.setWebSocketAddress({ host: originalPeer.address, port: originalPeer.port })
           const candidate = this.peerCandidates.get(message.identity)
           if (candidate) {
             candidate.address = originalPeer.address
@@ -1070,7 +1070,7 @@ export class PeerManager {
             // Reset ConnectionRetry since some component of the address changed
             candidate.websocketRetry.successfulConnection()
           }
-          originalPeer.setWebSocketAddress(null, null)
+          originalPeer.setWebSocketAddress(null)
         }
         peer.setWebSocketConnection(connection)
       }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -1445,7 +1445,19 @@ export class PeerManager {
         continue
       }
 
-      this.peerCandidates.addFromPeerList(peer.state.identity, connectedPeer)
+      if (connectedPeer.port !== null && connectedPeer.address === null) {
+        throw new Error('Peer port is not null but address is null')
+      }
+
+      const wsAddress = connectedPeer.address
+        ? { host: connectedPeer.address, port: connectedPeer.port }
+        : null
+
+      this.peerCandidates.addFromPeerList(peer.state.identity, {
+        identity,
+        name: connectedPeer.name,
+        wsAddress,
+      })
     }
   }
 }

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -156,15 +156,9 @@ export function getSignalingWebRtcPeer(
   // we're not resetting pre-existing peer candidate data.
   Assert.isFalse(pm.peerCandidates.has(peerIdentity))
 
-  if (peer.port !== null && peer.address === null) {
-    throw new Error('Peer port is not null but address is null')
-  }
-
-  const wsAddress = peer.address ? { host: peer.address, port: peer.port } : null
-
   // Link the peers
   pm.peerCandidates.addFromPeerList(brokeringPeerIdentity, {
-    wsAddress,
+    wsAddress: peer.wsAddress,
     identity: peerIdentity,
   })
 

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -156,11 +156,16 @@ export function getSignalingWebRtcPeer(
   // we're not resetting pre-existing peer candidate data.
   Assert.isFalse(pm.peerCandidates.has(peerIdentity))
 
+  if (peer.port !== null && peer.address === null) {
+    throw new Error('Peer port is not null but address is null')
+  }
+
+  const wsAddress = peer.address ? { host: peer.address, port: peer.port } : null
+
   // Link the peers
   pm.peerCandidates.addFromPeerList(brokeringPeerIdentity, {
-    address: peer.address,
-    port: peer.port,
-    identity: Buffer.from(peerIdentity, 'base64'),
+    wsAddress,
+    identity: peerIdentity,
   })
 
   // Verify peer2 is not connected


### PR DESCRIPTION
## Summary
A WebSocket address with a port but no host is not a valid address. Catch these cases earlier so we can have better type safety in the rest of the code

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
