### PR TITLE
Normalize WS Address on Peer Candidates

### DIFF
--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -163,6 +163,10 @@ export class Peer {
     return identitySlice
   }
 
+  /**
+   * The address by which the peer can be connected to over WebSockets.
+   * Setting this to null makes a peer unconnectable via WebSocket outbound connections.
+   */
   wsAddress: WebSocketAddress | null = null
 
   /**
@@ -439,16 +443,6 @@ export class Peer {
   }
 
   /**
-   * Sets the address and peer by which the peer can be connected to over WebSockets.
-   * Setting address and port to null makes a peer unconnectable via WebSocket outbound connections.
-   * @param address Hostname of the address, or null to remove the address.
-   * @param port Port to connect over. Must be null if address is null.
-   */
-  setWebSocketAddress(wsAddress: WebSocketAddress | null): void {
-    this.wsAddress = wsAddress
-  }
-
-  /**
    * Records number messages sent using a rolling average
    */
   private recordMessageSent() {
@@ -569,7 +563,7 @@ export class Peer {
       connection instanceof WebSocketConnection &&
       connection.hostname
     ) {
-      this.setWebSocketAddress({ host: connection.hostname, port: connection.port || null })
+      this.wsAddress = { host: connection.hostname, port: connection.port || null }
     }
 
     // onMessage
@@ -612,10 +606,7 @@ export class Peer {
         if (connection.state.type === 'CONNECTED') {
           // If connection goes to connected, transition the peer to connected
           if (connection instanceof WebSocketConnection && connection.hostname) {
-            this.setWebSocketAddress({
-              host: connection.hostname,
-              port: connection.port || null,
-            })
+            this.wsAddress = { host: connection.hostname, port: connection.port || null }
           }
           this.setState(this.state.connections.webSocket, this.state.connections.webRtc)
         }

--- a/ironfish/src/network/peers/peerCandidates.ts
+++ b/ironfish/src/network/peers/peerCandidates.ts
@@ -7,9 +7,8 @@ import { ConnectionRetry } from './connectionRetry'
 import { Peer, WebSocketAddress } from './peer'
 
 export type PeerCandidate = {
-  name?: string
-  address: string | null
-  port: number | null
+  name: string | null
+  wsAddress: WebSocketAddress | null
   neighbors: Set<Identity>
   webRtcRetry: ConnectionRetry
   websocketRetry: ConnectionRetry
@@ -36,13 +35,13 @@ export class PeerCandidates {
     const address = peer.getWebSocketAddress()
     const addressPeerCandidate = this.map.get(address)
     const newPeerCandidate = {
-      address: peer.address,
-      port: peer.port,
+      wsAddress: peer.wsAddress,
       neighbors,
       webRtcRetry: new ConnectionRetry(peer.isWhitelisted),
       websocketRetry: new ConnectionRetry(peer.isWhitelisted),
       localRequestedDisconnectUntil: null,
       peerRequestedDisconnectUntil: null,
+      name: null,
     }
 
     if (peer.state.identity !== null) {
@@ -72,7 +71,7 @@ export class PeerCandidates {
       peerCandidateValue.neighbors.add(sendingPeerIdentity)
     } else {
       const tempPeer = new Peer(peer.identity)
-      tempPeer.setWebSocketAddress(peer.wsAddress)
+      tempPeer.wsAddress = peer.wsAddress
       this.addFromPeer(tempPeer, new Set([sendingPeerIdentity]))
     }
   }

--- a/ironfish/src/network/peers/peerConnectionManager.test.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.test.ts
@@ -42,7 +42,7 @@ describe('connectToDisconnectedPeers', () => {
     const pm = new PeerManager(mockLocalPeer(), mockPeerStore())
 
     const peer = pm.getOrCreatePeer(null)
-    peer.setWebSocketAddress({ host: 'testuri.com', port: 9033 })
+    peer.wsAddress = { host: 'testuri.com', port: 9033 }
     pm['tryDisposePeer'](peer)
 
     pm.peerCandidates.addFromPeer(peer)
@@ -64,7 +64,7 @@ describe('connectToDisconnectedPeers', () => {
 
     const identity = mockIdentity('peer')
     const peer = pm.getOrCreatePeer(identity)
-    peer.setWebSocketAddress({ host: 'testuri.com', port: 9033 })
+    peer.wsAddress = { host: 'testuri.com', port: 9033 }
     pm['tryDisposePeer'](peer)
 
     pm.peerCandidates.addFromPeer(peer)
@@ -94,7 +94,7 @@ describe('connectToDisconnectedPeers', () => {
 
     const identity = mockIdentity('peer')
     const createdPeer = peers.getOrCreatePeer(identity)
-    createdPeer.setWebSocketAddress({ host: 'testuri.com', port: 9033 })
+    createdPeer.wsAddress = { host: 'testuri.com', port: 9033 }
     peers['tryDisposePeer'](createdPeer)
 
     peers.peerCandidates.addFromPeer(createdPeer)

--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -93,13 +93,9 @@ export class PeerConnectionManager {
         const val = this.peerManager.peerCandidates.get(peerCandidateIdentity)
         if (val) {
           const peer = this.peerManager.getOrCreatePeer(peerCandidateIdentity)
-          peer.name = val.name ?? null
 
-          if (val.port !== null && val.address === null) {
-            throw new Error('Peer port is not null but address is null')
-          }
-
-          peer.setWebSocketAddress(val.address ? { host: val.address, port: val.port } : null)
+          peer.name = val.name
+          peer.wsAddress = val.wsAddress
 
           if (this.connectToEligiblePeers(peer)) {
             connectAttempts++

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -388,7 +388,7 @@ describe('PeerManager', () => {
       })
 
       // Verify peer2 is not connected
-      peer2.setWebSocketAddress({ host: 'testuri', port: 9033 })
+      peer2.wsAddress = { host: 'testuri', port: 9033 }
       expect(peer2.state).toEqual({
         type: 'DISCONNECTED',
         identity: peer2Identity,
@@ -579,7 +579,7 @@ describe('PeerManager', () => {
       // Add a second peer that's disconnected
       const peer2Identity = mockIdentity('peer2')
       const peer2 = pm.getOrCreatePeer(peer2Identity)
-      peer2.setWebSocketAddress({ host: 'testuri.com', port: 9033 })
+      peer2.wsAddress = { host: 'testuri.com', port: 9033 }
 
       // Mock the logger
       pm['logger'].mockTypes(() => jest.fn())

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -507,7 +507,7 @@ export class PeerManager {
       disconnectOk &&
       hasNoConnection &&
       retryOk &&
-      peer.address !== null
+      peer.wsAddress !== null
     )
   }
 
@@ -1060,7 +1060,7 @@ export class PeerManager {
         if (
           connection.type === ConnectionType.WebSocket &&
           connection.direction === ConnectionDirection.Outbound &&
-          originalPeer.address !== null
+          originalPeer.wsAddress !== null
         ) {
           peer.wsAddress = originalPeer.wsAddress
           const candidate = this.peerCandidates.get(message.identity)

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -190,7 +190,7 @@ export class PeerManager {
     forceConnect?: boolean
   }): Peer | undefined {
     const peer = this.getOrCreatePeer(null)
-    peer.setWebSocketAddress({ host: options.host, port: options.port })
+    peer.wsAddress = { host: options.host, port: options.port }
     peer.isWhitelisted = !!options.whitelist
 
     this.peerCandidates.addFromPeer(peer)
@@ -1027,7 +1027,7 @@ export class PeerManager {
         connection.type === ConnectionType.WebSocket &&
         connection.direction === ConnectionDirection.Outbound
       ) {
-        peer.setWebSocketAddress(null)
+        peer.wsAddress = null
       }
 
       const error = `Closing ${connection.type} connection from our own identity`
@@ -1062,15 +1062,14 @@ export class PeerManager {
           connection.direction === ConnectionDirection.Outbound &&
           originalPeer.address !== null
         ) {
-          peer.setWebSocketAddress({ host: originalPeer.address, port: originalPeer.port })
+          peer.wsAddress = originalPeer.wsAddress
           const candidate = this.peerCandidates.get(message.identity)
           if (candidate) {
-            candidate.address = originalPeer.address
-            candidate.port = originalPeer.port
+            candidate.wsAddress = originalPeer.wsAddress
             // Reset ConnectionRetry since some component of the address changed
             candidate.websocketRetry.successfulConnection()
           }
-          originalPeer.setWebSocketAddress(null)
+          originalPeer.wsAddress = null
         }
         peer.setWebSocketConnection(connection)
       }
@@ -1443,10 +1442,6 @@ export class PeerManager {
       // Don't include banned peers
       if (this.banned.has(identity)) {
         continue
-      }
-
-      if (connectedPeer.port !== null && connectedPeer.address === null) {
-        throw new Error('Peer port is not null but address is null')
       }
 
       const wsAddress = connectedPeer.address

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -163,7 +163,7 @@ export function getSignalingWebRtcPeer(
   })
 
   // Verify peer2 is not connected
-  expect(peer.address).toBeNull()
+  expect(peer.wsAddress).toBeNull()
   expect(peer.state).toEqual({
     type: 'DISCONNECTED',
     identity: peerIdentity,


### PR DESCRIPTION
## Summary
For Peer candidates remove the unrepresentable state of having a null address but a non-null port. Also in this PR changing the way we process PeerList messages. If a peer sends us a PeerList containing a null `address` but non-null `port` just set the `wsAddress` to null instead of throwing an error. This would cause the node to crash if a peer sent us a message like that

## Testing Plan
Running local node + unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
