### PR TITLE
adding peer direction to rpc peers command

### DIFF
--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -47,6 +47,11 @@ export class ListCommand extends IronfishCommand {
       default: false,
       description: 'Display node names',
     }),
+    direction: Flags.boolean({
+      char: 'c',
+      default: false,
+      description: 'Display connection direction',
+    }),
     features: Flags.boolean({
       default: false,
       description: 'Display features that the peers have enabled',
@@ -108,6 +113,16 @@ function renderTable(
         return row.identity || '-'
       },
     },
+  }
+
+  if (flags.direction) {
+    columns['direction'] = {
+      header: 'DIRECTION',
+      minWidth: 5,
+      get: (row: GetPeerResponsePeer) => {
+        return row.connectionDirection || '-'
+      },
+    }
   }
 
   if (flags.names) {

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -115,16 +115,6 @@ function renderTable(
     },
   }
 
-  if (flags.direction) {
-    columns['direction'] = {
-      header: 'DIRECTION',
-      minWidth: 5,
-      get: (row: GetPeerResponsePeer) => {
-        return row.connectionDirection || '-'
-      },
-    }
-  }
-
   if (flags.names) {
     columns['name'] = {
       header: 'NAME',
@@ -171,6 +161,16 @@ function renderTable(
           .filter(Boolean)
           .sort()
           .join(',')
+      },
+    }
+  }
+
+  if (flags.direction) {
+    columns['direction'] = {
+      header: 'DIRECTION',
+      minWidth: 5,
+      get: (row: GetPeerResponsePeer) => {
+        return row.connectionDirection || '-'
       },
     }
   }

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -47,11 +47,6 @@ export class ListCommand extends IronfishCommand {
       default: false,
       description: 'Display node names',
     }),
-    direction: Flags.boolean({
-      char: 'c',
-      default: false,
-      description: 'Display connection direction',
-    }),
     features: Flags.boolean({
       default: false,
       description: 'Display features that the peers have enabled',
@@ -165,16 +160,6 @@ function renderTable(
     }
   }
 
-  if (flags.direction) {
-    columns['direction'] = {
-      header: 'DIRECTION',
-      minWidth: 5,
-      get: (row: GetPeerResponsePeer) => {
-        return row.connectionDirection || '-'
-      },
-    }
-  }
-
   columns = {
     ...columns,
     state: {
@@ -196,6 +181,14 @@ function renderTable(
           address += ':' + String(row.port)
         }
         return address
+      },
+    },
+    connectionDirection: {
+      header: 'DIRECTION',
+      minWidth: 5,
+      extended: true,
+      get: (row: GetPeerResponsePeer) => {
+        return row.connectionDirection || '-'
       },
     },
     connectionWebSocket: {

--- a/ironfish/src/rpc/routes/peer/getPeer.ts
+++ b/ironfish/src/rpc/routes/peer/getPeer.ts
@@ -72,16 +72,19 @@ function getPeer(network: PeerNetwork, identity: string): RpcPeerResponse | null
       let connectionWebSocket: ConnectionState = ''
       let connectionWebRTCError = ''
       let connectionWebSocketError = ''
+      let connectionDirection = ''
 
       if (peer.state.type !== 'DISCONNECTED') {
         if (peer.state.connections.webSocket) {
           connectionWebSocket = peer.state.connections.webSocket.state.type
           connectionWebSocketError = String(peer.state.connections.webSocket.error || '')
+          connectionDirection = peer.state.connections.webSocket.direction
         }
 
         if (peer.state.connections.webRtc) {
           connectionWebRTC = peer.state.connections.webRtc.state.type
           connectionWebRTCError = String(peer.state.connections.webRtc.error || '')
+          connectionDirection = peer.state.connections.webRtc.direction
         }
       }
 
@@ -105,13 +108,14 @@ function getPeer(network: PeerNetwork, identity: string): RpcPeerResponse | null
         sequence: peer.sequence !== null ? Number(peer.sequence) : null,
         connections: connections,
         error: peer.error !== null ? String(peer.error) : null,
-        connectionWebSocket: connectionWebSocket,
-        connectionWebSocketError: connectionWebSocketError,
-        connectionWebRTC: connectionWebRTC,
-        connectionWebRTCError: connectionWebRTCError,
         networkId: peer.networkId,
         genesisBlockHash: peer.genesisBlockHash?.toString('hex') || null,
         features: peer.features,
+        connectionWebSocket,
+        connectionWebSocketError,
+        connectionWebRTC,
+        connectionWebRTCError,
+        connectionDirection,
       }
     }
   }

--- a/ironfish/src/rpc/routes/peer/getPeers.ts
+++ b/ironfish/src/rpc/routes/peer/getPeers.ts
@@ -74,16 +74,19 @@ function getPeers(network: PeerNetwork): RpcPeerResponse[] {
     let connectionWebSocket: ConnectionState = ''
     let connectionWebRTCError = ''
     let connectionWebSocketError = ''
+    let connectionDirection = ''
 
     if (peer.state.type !== 'DISCONNECTED') {
       if (peer.state.connections.webSocket) {
         connectionWebSocket = peer.state.connections.webSocket.state.type
         connectionWebSocketError = String(peer.state.connections.webSocket.error || '')
+        connectionDirection = peer.state.connections.webSocket.direction
       }
 
       if (peer.state.connections.webRtc) {
         connectionWebRTC = peer.state.connections.webRtc.state.type
         connectionWebRTCError = String(peer.state.connections.webRtc.error || '')
+        connectionDirection = peer.state.connections.webRtc.direction
       }
     }
 
@@ -107,13 +110,14 @@ function getPeers(network: PeerNetwork): RpcPeerResponse[] {
       sequence: peer.sequence !== null ? Number(peer.sequence) : null,
       connections: connections,
       error: peer.error !== null ? String(peer.error) : null,
-      connectionWebSocket: connectionWebSocket,
-      connectionWebSocketError: connectionWebSocketError,
-      connectionWebRTC: connectionWebRTC,
-      connectionWebRTCError: connectionWebRTCError,
       networkId: peer.networkId,
       genesisBlockHash: peer.genesisBlockHash?.toString('hex') || null,
       features: peer.features,
+      connectionWebSocket,
+      connectionWebSocketError,
+      connectionWebRTC,
+      connectionWebRTCError,
+      connectionDirection,
     })
   }
 

--- a/ironfish/src/rpc/types.ts
+++ b/ironfish/src/rpc/types.ts
@@ -197,6 +197,7 @@ export type RpcPeerResponse = {
   connectionWebSocketError: string
   connectionWebRTC: ConnectionState
   connectionWebRTCError: string
+  connectionDirection: string
   connections: number
   identity: string | null
   version: number | null
@@ -231,6 +232,7 @@ export const RpcPeerResponseSchema: yup.ObjectSchema<RpcPeerResponse> = yup
     connectionWebSocketError: yup.string().defined(),
     connectionWebRTC: yup.string<ConnectionState>().defined(),
     connectionWebRTCError: yup.string().defined(),
+    connectionDirection: yup.string().defined(),
     networkId: yup.number().nullable().defined(),
     genesisBlockHash: yup.string().nullable().defined(),
     features: yup


### PR DESCRIPTION
## Summary

Adding connection direction field to the peers command. Required an RPC change for the GetPeer and GetPeers endpoints

![image](https://github.com/iron-fish/ironfish/assets/13268167/8ff8419e-a71e-4f14-a4b7-c9914415ab6f)


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
