### PR TITLE
Return null from peer.getWebSocketAddress if there is no address

### DIFF
--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -424,22 +424,13 @@ export class Peer {
   /**
    * Get the peers connectable websocket address
    */
-  getWebSocketAddress(includeProtocol = true): string {
-    let address = ''
-
-    if (includeProtocol) {
-      address = 'ws://' + address
+  getWebSocketAddress(): string | null {
+    if (!this.wsAddress) {
+      return null
     }
 
-    if (this.address) {
-      address += this.address
-    }
-
-    if (this.port) {
-      address = address + ':' + String(this.port)
-    }
-
-    return address
+    const port = this.wsAddress.port ? `:${this.wsAddress.port}` : ''
+    return `ws://${this.wsAddress.host}${port}`
   }
 
   /**

--- a/ironfish/src/network/peers/peerCandidates.ts
+++ b/ironfish/src/network/peers/peerCandidates.ts
@@ -33,7 +33,7 @@ export class PeerCandidates {
 
   addFromPeer(peer: Peer, neighbors = new Set<Identity>()): void {
     const address = peer.getWebSocketAddress()
-    const addressPeerCandidate = this.map.get(address)
+    const addressPeerCandidate = address ? this.map.get(address) : undefined
     const newPeerCandidate = {
       wsAddress: peer.wsAddress,
       neighbors,
@@ -45,14 +45,14 @@ export class PeerCandidates {
     }
 
     if (peer.state.identity !== null) {
-      if (addressPeerCandidate) {
+      if (addressPeerCandidate && address) {
         this.map.delete(address)
       }
 
       if (!this.map.has(peer.state.identity)) {
         this.map.set(peer.state.identity, addressPeerCandidate ?? newPeerCandidate)
       }
-    } else if (!addressPeerCandidate) {
+    } else if (address && !addressPeerCandidate) {
       this.map.set(address, newPeerCandidate)
     }
   }

--- a/ironfish/src/network/peers/peerManager.test.ts
+++ b/ironfish/src/network/peers/peerManager.test.ts
@@ -171,7 +171,9 @@ describe('PeerManager', () => {
 
       Assert.isNotUndefined(peer)
 
-      expect(peers.peerCandidates.get(peer.getWebSocketAddress())).not.toBeUndefined()
+      const address = peer.getWebSocketAddress()
+      const candidate = address ? peers.peerCandidates.get(address) : undefined
+      expect(candidate).not.toBeUndefined()
       if (peer.state.type === 'DISCONNECTED') {
         throw new Error('Peer should not be disconnected')
       }
@@ -198,7 +200,9 @@ describe('PeerManager', () => {
       })
       Assert.isNotUndefined(peer)
 
-      expect(peers.peerCandidates.get(peer.getWebSocketAddress())).not.toBeUndefined()
+      const address = peer.getWebSocketAddress()
+      const candidate = address ? peers.peerCandidates.get(address) : undefined
+      expect(candidate).not.toBeUndefined()
       peer.close()
 
       // Create a connected peer

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -211,7 +211,7 @@ export class PeerManager {
     const address = peer.getWebSocketAddress()
     const alternateIdentity = peer.state.identity ?? address
 
-    const candidate = this.peerCandidates.get(alternateIdentity)
+    const candidate = alternateIdentity ? this.peerCandidates.get(alternateIdentity) : undefined
     if (candidate) {
       // If we're trying to connect to the peer, we don't care about limiting the peer's connections to us
       candidate.localRequestedDisconnectUntil = null
@@ -470,7 +470,7 @@ export class PeerManager {
     const isBanned = this.isBanned(peer)
 
     const alternateIdentity = peer.state.identity ?? peer.getWebSocketAddress()
-    const candidate = this.peerCandidates.get(alternateIdentity)
+    const candidate = alternateIdentity ? this.peerCandidates.get(alternateIdentity) : undefined
 
     const canEstablishNewConnection =
       peer.state.type !== 'DISCONNECTED' || this.canCreateNewConnections()


### PR DESCRIPTION
## Summary
The function peer.getWebsocketAddress function returns some unexpected string if the peer doesn't have a websocket address. Likely this is not intended behavior so modifying this function to return null if the address is not set.

I ran the node for a while and never encountered an instance where we were creating a peer candidate with an id of `ws://` which would happen if the peer had neither an identity nor a ws address. This is probably just not a case that happens in the code. Still good to be explicit about it though

## Testing Plan
Running locally + unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
