### PR TITLE
combining call on state changed to one location

### DIFF
--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -739,6 +739,7 @@ export class PeerManager {
         this.peerCandidates.addFromPeer(peer)
         this.onConnect.emit(peer)
         this.onConnectedPeersChanged.emit()
+        peer.send(new PeerListRequestMessage())
       }
       if (prevState.type === 'CONNECTED' && peer.state.type !== 'CONNECTED') {
         this.onDisconnect.emit(peer)
@@ -746,12 +747,6 @@ export class PeerManager {
       }
       if (prevState.type !== 'DISCONNECTED' && peer.state.type === 'DISCONNECTED') {
         this.tryDisposePeer(peer)
-      }
-    })
-
-    peer.onStateChanged.on(({ prevState }) => {
-      if (prevState.type !== 'CONNECTED' && peer.state.type === 'CONNECTED') {
-        peer.send(new PeerListRequestMessage())
       }
     })
 


### PR DESCRIPTION
## Summary

We have a duplicate `onStateChanged.on` call that can be combined to one. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
