### PR TITLE
Add keepOpenPeerSlot flag; disconnect from peers if above limit

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -24,6 +24,7 @@ export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_AVERAGE = 20
 export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_FAST = 30
 export const DEFAULT_MAX_PEERS = 50
 export const DEFAULT_TARGET_PEERS = 45
+export const DEFAULT_KEEP_OPEN_PEER_SLOT = false
 
 const MEGABYTES = 1000 * 1000
 
@@ -116,6 +117,12 @@ export type ConfigOptions = {
    * establish new connections when below this number.
    */
   targetPeers: number
+  /**
+   * If true, the node will disconnect from a peer if the number of connected
+   * peers is equal to maxPeers in order to always allow incoming connections.
+   */
+  keepOpenPeerSlot: boolean
+
   telemetryApi: string
   assetVerificationApi: string
 
@@ -355,6 +362,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     maxPeers: YupUtils.isPositiveInteger,
     minPeers: YupUtils.isPositiveInteger,
     targetPeers: yup.number().integer().min(1),
+    keepOpenPeerSlot: yup.boolean(),
     telemetryApi: yup.string(),
     assetVerificationApi: yup.string(),
     generateNewIdentity: yup.boolean(),
@@ -463,6 +471,7 @@ export class Config extends KeyStore<ConfigOptions> {
       confirmations: 2,
       minPeers: 1,
       targetPeers: DEFAULT_TARGET_PEERS,
+      keepOpenPeerSlot: DEFAULT_KEEP_OPEN_PEER_SLOT,
       telemetryApi: '',
       assetVerificationApi: '',
       generateNewIdentity: false,

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -176,6 +176,7 @@ export class PeerNetwork {
     chain: Blockchain
     peerStore: PeerStore
     incomingWebSocketWhitelist?: string[]
+    keepOpenPeerSlot?: boolean
   }) {
     this.networkId = options.networkId
     this.enableSyncing = options.enableSyncing ?? true
@@ -222,6 +223,7 @@ export class PeerNetwork {
 
     this.peerConnectionManager = new PeerConnectionManager(this.peerManager, this.logger, {
       maxPeers,
+      keepOpenPeerSlot: options.keepOpenPeerSlot,
     })
 
     this.minPeers = options.minPeers || 1

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -157,6 +157,7 @@ export class FullNode {
       logger: logger,
       telemetry: this.telemetry,
       incomingWebSocketWhitelist: config.getArray('incomingWebSocketWhitelist'),
+      keepOpenPeerSlot: config.get('keepOpenPeerSlot'),
     })
 
     this.miningManager.onNewBlock.on((block) => {

--- a/ironfish/src/utils/array.ts
+++ b/ironfish/src/utils/array.ts
@@ -17,7 +17,7 @@ function shuffle<T>(array: ReadonlyArray<T>): Array<T> {
   return sliceArr
 }
 
-function sample<T>(array: Array<T>): T | null {
+function sample<T>(array: ReadonlyArray<T>): T | null {
   if (array.length === 0) {
     return null
   }


### PR DESCRIPTION
## Summary

The peer connection manager will now disconnect from peers if there are more than maxPeers connected peers. Additionally, if keepOpenPeerSlot is set, it will disconnect if there are more than maxPeers - 1 connected peers. This can be used by nodes who want to ensure they are allowing incoming connections regardless of them being near/at capacity

## Testing Plan

Unit tests
Manual testing

## Documentation

```
[x] Yes
```

https://github.com/iron-fish/website/pull/564

## Breaking Change

N/A