### PR TITLE
Upgrade node-datachannel to 0.4.3 for NodeJS 20 support

### DIFF
--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -41,7 +41,7 @@
     "leveldown": "5.6.0",
     "levelup": "4.4.0",
     "lodash": "4.17.21",
-    "node-datachannel": "0.4.0",
+    "node-datachannel": "0.4.3",
     "node-forge": "1.3.1",
     "parse-json": "5.2.0",
     "sqlite": "4.0.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9092,10 +9092,10 @@ node-cleanup@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
 
-node-datachannel@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/node-datachannel/-/node-datachannel-0.4.0.tgz#cd237cbc121221f5f6342cbf2226120dda6dc52f"
-  integrity sha512-4ljypzRaWfM7bLtd4fpQaE4u+bAg5d8wPADycY60RfaZLoxVjcHk+Hsg+gtyyxNIeG6Cdtp3iDN+DUGAAjeVuw==
+node-datachannel@0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/node-datachannel/-/node-datachannel-0.4.3.tgz#56a18cc62df4727f4483309b7b0bb86d5173ba27"
+  integrity sha512-I2SYzgqNd5gX8B+hQcff0qpGGwNiHZnXJNgsFyW0UXk1A3fbC/4L1PhSKGSuc7z0+Bk3raMN939E0KroJ5CJhA==
   dependencies:
     prebuild-install "^7.0.1"
 


### PR DESCRIPTION
## Summary

While spinning up a fresh ec2 instance to do some testing, I was running into issues with node-datachannel 0.4.0 and NodeJS v20. Using 0.4.3 fixed the issue, and testing locally it looks good as well.

## Testing Plan

Manual testing on an Ubuntu EC2 instance and on my local mac machine

## Documentation

N/A

## Breaking Change

N/A