### PR TITLE
Replace old hard-coded default numbers with config

### DIFF
--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -22,6 +22,8 @@ export const DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY = 10
 export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW = 10
 export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_AVERAGE = 20
 export const DEFAULT_FEE_ESTIMATOR_PERCENTILE_FAST = 30
+export const DEFAULT_MAX_PEERS = 50
+export const DEFAULT_TARGET_PEERS = 45
 
 const MEGABYTES = 1000 * 1000
 
@@ -457,10 +459,10 @@ export class Config extends KeyStore<ConfigOptions> {
       tlsCertPath: files.resolve(files.join(dataDir, 'certs', 'node-cert.pem')),
       rpcHttpHost: 'localhost',
       rpcHttpPort: 8021,
-      maxPeers: 50,
+      maxPeers: DEFAULT_MAX_PEERS,
       confirmations: 2,
       minPeers: 1,
-      targetPeers: 45,
+      targetPeers: DEFAULT_TARGET_PEERS,
       telemetryApi: '',
       assetVerificationApi: '',
       generateNewIdentity: false,

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -9,7 +9,11 @@ import { Assert } from '../assert'
 import { Blockchain } from '../blockchain'
 import { VerificationResultReason } from '../consensus'
 import { Event } from '../event'
-import { DEFAULT_WEBSOCKET_PORT } from '../fileStores/config'
+import {
+  DEFAULT_MAX_PEERS,
+  DEFAULT_TARGET_PEERS,
+  DEFAULT_WEBSOCKET_PORT,
+} from '../fileStores/config'
 import { PeerStore } from '../fileStores/peerStore'
 import { createRootLogger, Logger } from '../logger'
 import { MetricsMonitor } from '../metrics'
@@ -196,8 +200,8 @@ export class PeerNetwork {
     this.localPeer.port = options.port === undefined ? null : options.port
     this.localPeer.name = options.name || null
 
-    const maxPeers = options.maxPeers || 10000
-    const targetPeers = options.targetPeers || 50
+    const maxPeers = options.maxPeers || DEFAULT_MAX_PEERS
+    const targetPeers = options.targetPeers || DEFAULT_TARGET_PEERS
     const logPeerMessages = options.logPeerMessages ?? false
 
     this.peerManager = new PeerManager(

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -4,6 +4,7 @@
 
 import type { SignalData } from './connections/webRtcConnection'
 import { Event } from '../../event'
+import { DEFAULT_MAX_PEERS, DEFAULT_TARGET_PEERS } from '../../fileStores'
 import { PeerStore } from '../../fileStores/peerStore'
 import { createRootLogger, Logger } from '../../logger'
 import { MetricsMonitor } from '../../metrics'
@@ -145,8 +146,8 @@ export class PeerManager {
     peerStore: PeerStore,
     logger: Logger = createRootLogger(),
     metrics?: MetricsMonitor,
-    maxPeers = 10000,
-    targetPeers = 50,
+    maxPeers = DEFAULT_MAX_PEERS,
+    targetPeers = DEFAULT_TARGET_PEERS,
     logPeerMessages = false,
     stunServers: string[] = [],
   ) {


### PR DESCRIPTION
## Summary

These are old values I'm assuming that are no longer relevant, so might as well define a singular source of truth and use that. Follows our usual pattern of defining defaults with the config and utilizing where needed

## Testing Plan

## Documentation

N/A

## Breaking Change

N/A
