### PR TITLE
feat: enable rpc.tcp automatically if tcp port or host is provided

### DIFF
--- a/ironfish-cli/src/command.ts
+++ b/ironfish-cli/src/command.ts
@@ -134,11 +134,13 @@ export abstract class IronfishCommand extends Command {
     const rpcTcpHostFlag = getFlag(flags, RpcTcpHostFlagKey)
     if (typeof rpcTcpHostFlag === 'string') {
       configOverrides.rpcTcpHost = rpcTcpHostFlag
+      configOverrides.enableRpcTcp = true
     }
 
     const rpcTcpPortFlag = getFlag(flags, RpcTcpPortFlagKey)
     if (typeof rpcTcpPortFlag === 'number') {
       configOverrides.rpcTcpPort = rpcTcpPortFlag
+      configOverrides.enableRpcTcp = true
     }
 
     const rpcConnectHttpFlag = getFlag(flags, RpcUseHttpFlagKey)
@@ -152,11 +154,13 @@ export abstract class IronfishCommand extends Command {
     const rpcHttpHostFlag = getFlag(flags, RpcHttpHostFlagKey)
     if (typeof rpcHttpHostFlag === 'string') {
       configOverrides.rpcHttpHost = rpcHttpHostFlag
+      configOverrides.enableRpcHttp = true
     }
 
     const rpcHttpPortFlag = getFlag(flags, RpcHttpPortFlagKey)
     if (typeof rpcHttpPortFlag === 'number') {
       configOverrides.rpcHttpPort = rpcHttpPortFlag
+      configOverrides.enableRpcHttp = true
     }
 
     const rpcTcpTlsFlag = getFlag(flags, RpcTcpTlsFlagKey)


### PR DESCRIPTION
## Summary
Currently a command run with only `--rpc.tcp.host` or `--rpc.tcp.port` will fail to connect to remote nodes unless the `--rpc.tcp` flag is also provided. This makes that argument optional in that case.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
