### PR TITLE
chore(IFL-1355): removes reference to transmission key

### DIFF
--- a/ironfish-rust/src/keys/test.rs
+++ b/ironfish-rust/src/keys/test.rs
@@ -27,7 +27,7 @@ fn test_diffie_hellman_shared_key() {
     let secret_key = key_pair.secret();
     let public_key = key_pair.public();
 
-    let shared_secret1 = shared_secret(secret_key, &address1.transmission_key, public_key);
+    let shared_secret1 = shared_secret(secret_key, &address1.0, public_key);
     let shared_secret2 = shared_secret(&key1.incoming_viewing_key.view_key, public_key, public_key);
     assert_eq!(shared_secret1, shared_secret2);
 }
@@ -44,15 +44,11 @@ fn test_diffie_hellman_shared_key_with_other_key() {
     let secret_key = key_pair.secret();
     let public_key = key_pair.public();
 
-    let shared_secret1 = shared_secret(secret_key, &address.transmission_key, public_key);
+    let shared_secret1 = shared_secret(secret_key, &address.0, public_key);
     let shared_secret2 = shared_secret(&key.incoming_viewing_key.view_key, public_key, public_key);
     assert_eq!(shared_secret1, shared_secret2);
 
-    let shared_secret_third_party1 = shared_secret(
-        secret_key,
-        &third_party_address.transmission_key,
-        public_key,
-    );
+    let shared_secret_third_party1 = shared_secret(secret_key, &third_party_address.0, public_key);
     assert_ne!(shared_secret1, shared_secret_third_party1);
     assert_ne!(shared_secret2, shared_secret_third_party1);
 
@@ -90,8 +86,8 @@ fn test_serialization() {
         .expect("Should be able to construct address from valid bytes");
 
     assert_eq!(
-        ExtendedPoint::from(read_back_address.transmission_key).to_affine(),
-        ExtendedPoint::from(public_address.transmission_key).to_affine()
+        ExtendedPoint::from(read_back_address.0).to_affine(),
+        ExtendedPoint::from(public_address.0).to_affine()
     )
 }
 

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -201,7 +201,7 @@ impl MintDescription {
         public_inputs[0] = randomized_public_key_point.get_u();
         public_inputs[1] = randomized_public_key_point.get_v();
 
-        let public_address_point = ExtendedPoint::from(self.owner.transmission_key).to_affine();
+        let public_address_point = ExtendedPoint::from(self.owner.0).to_affine();
         public_inputs[2] = public_address_point.get_u();
         public_inputs[3] = public_address_point.get_v();
 

--- a/ironfish-rust/src/transaction/outputs.rs
+++ b/ironfish-rust/src/transaction/outputs.rs
@@ -84,7 +84,7 @@ impl OutputBuilder {
 
         let circuit = Output {
             value_commitment: Some(self.value_commitment.clone()),
-            payment_address: Some(self.note.owner.transmission_key),
+            payment_address: Some(self.note.owner.0),
             commitment_randomness: Some(self.note.randomness),
             esk: Some(*diffie_hellman_keys.secret()),
             asset_id: *self.note.asset_id().as_bytes(),

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -99,12 +99,12 @@ impl SpendBuilder {
         let circuit = Spend {
             value_commitment: Some(self.value_commitment.clone()),
             proof_generation_key: Some(spender_key.sapling_proof_generation_key()),
-            payment_address: Some(self.note.owner.transmission_key),
+            payment_address: Some(self.note.owner.0),
             auth_path: self.auth_path.clone(),
             commitment_randomness: Some(self.note.randomness),
             anchor: Some(self.root_hash),
             ar: Some(*public_key_randomness),
-            sender_address: Some(self.note.sender.transmission_key),
+            sender_address: Some(self.note.sender.0),
         };
 
         // Proof that the spend was valid and successful for the provided owner


### PR DESCRIPTION
## Summary
We do not use a diversifier in ironfish. This decision was made to allow auditability of fund sources when someone is receiving funds and uses their incoming view key to decrypt incoming funds.

Because of this transparency of sender, there is no longer a concept of a transmission key, which was an opaque version of the public address. This changes removes the vestigial naming.
## Testing Plan

Tests pass

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
