### PR TITLE
fixing file store test flaky ness

### DIFF
--- a/ironfish/src/fileStores/fileStore.test.ts
+++ b/ironfish/src/fileStores/fileStore.test.ts
@@ -38,6 +38,7 @@ describe('FileStore', () => {
     // Flush multiple times to ensure all the promises settle as expected
     await flushTimeout()
     await flushTimeout()
+    await flushTimeout()
     expect(writeFileSpy).toHaveBeenCalledTimes(1)
 
     resolve1()


### PR DESCRIPTION
## Summary

We need to wait for one more node event loop to complete to ensure the test is not flaky. I believe it's because we need two promises to settle and depending on when they are launched in the event loop, the first one will settle on the second loop instead of the first. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
