### PR TITLE
Pass along peer name to candidate list

### DIFF
--- a/ironfish/src/network/peers/peerCandidates.ts
+++ b/ironfish/src/network/peers/peerCandidates.ts
@@ -42,7 +42,7 @@ export class PeerCandidates {
       websocketRetry: new ConnectionRetry(peer.isWhitelisted),
       localRequestedDisconnectUntil: null,
       peerRequestedDisconnectUntil: null,
-      name: null,
+      name: peer.name,
     }
 
     if (peer.state.identity !== null) {
@@ -73,6 +73,7 @@ export class PeerCandidates {
     } else {
       const tempPeer = new Peer(peer.identity)
       tempPeer.wsAddress = peer.wsAddress
+      tempPeer.name = peer.name ?? null
       this.addFromPeer(tempPeer, new Set([sendingPeerIdentity]))
     }
   }


### PR DESCRIPTION
## Summary
Peer name was not getting set when a new PeerList comes in

## Testing Plan
Tested locally + unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
