### PR TITLE
Fix an RPC timing attack

### DIFF
--- a/ironfish/src/rpc/server.test.ts
+++ b/ironfish/src/rpc/server.test.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { createNodeTest } from '../testUtilities'
+
+describe('RpcServer', () => {
+  const nodeTest = createNodeTest()
+
+  it('should authentiacte', () => {
+    nodeTest.node.rpc.internal.set('rpcAuthToken', 'foo')
+    expect(nodeTest.node.rpc.authenticate('')).toBe(false)
+    expect(nodeTest.node.rpc.authenticate('foobar')).toBe(false)
+  })
+})

--- a/ironfish/src/rpc/server.test.ts
+++ b/ironfish/src/rpc/server.test.ts
@@ -6,9 +6,12 @@ import { createNodeTest } from '../testUtilities'
 describe('RpcServer', () => {
   const nodeTest = createNodeTest()
 
-  it('should authentiacte', () => {
-    nodeTest.node.rpc.internal.set('rpcAuthToken', 'foo')
+  it('should authentiacte', async () => {
+    nodeTest.node.rpc.internal.set('rpcAuthToken', 'ironfish')
+    await nodeTest.node.rpc.start()
+
     expect(nodeTest.node.rpc.authenticate('')).toBe(false)
     expect(nodeTest.node.rpc.authenticate('foobar')).toBe(false)
+    expect(nodeTest.node.rpc.authenticate('ironfish')).toBe(true)
   })
 })

--- a/ironfish/src/rpc/server.test.ts
+++ b/ironfish/src/rpc/server.test.ts
@@ -6,12 +6,25 @@ import { createNodeTest } from '../testUtilities'
 describe('RpcServer', () => {
   const nodeTest = createNodeTest()
 
-  it('should authentiacte', async () => {
+  it('should authenticate', () => {
     nodeTest.node.rpc.internal.set('rpcAuthToken', 'ironfish')
-    await nodeTest.node.rpc.start()
-
+    expect(nodeTest.node.rpc.authenticate('ironfish')).toBe(true)
     expect(nodeTest.node.rpc.authenticate('')).toBe(false)
     expect(nodeTest.node.rpc.authenticate('foobar')).toBe(false)
-    expect(nodeTest.node.rpc.authenticate('ironfish')).toBe(true)
+  })
+
+  it('should generate auth when started', async () => {
+    // token should be empty
+    expect(nodeTest.node.rpc.internal.get('rpcAuthToken')).toEqual('')
+    expect(nodeTest.node.rpc.authenticate('')).toBe(false)
+
+    // token should be generated
+    await nodeTest.node.rpc.start()
+    expect(nodeTest.node.rpc.internal.get('rpcAuthToken')).not.toEqual('')
+    expect(nodeTest.node.rpc.authenticate('')).toBe(false)
+
+    // should be able to auth with generated token
+    const token = nodeTest.node.rpc.internal.get('rpcAuthToken')
+    expect(nodeTest.node.rpc.authenticate(token)).toBe(true)
   })
 })

--- a/ironfish/src/rpc/server.ts
+++ b/ironfish/src/rpc/server.ts
@@ -96,8 +96,14 @@ export class RpcServer {
       return false
     }
 
-    const userTokenBuffer = Buffer.from(requestAuthToken)
-    const authTokenBuffer = Buffer.from(rpcAuthToken)
+    const maxLength = Math.max(requestAuthToken.length, rpcAuthToken.length)
+
+    const userTokenBuffer = Buffer.alloc(maxLength)
+    userTokenBuffer.write(requestAuthToken)
+
+    const authTokenBuffer = Buffer.alloc(maxLength)
+    authTokenBuffer.write(rpcAuthToken)
+
     return timingSafeEqual(userTokenBuffer, authTokenBuffer)
   }
 

--- a/ironfish/src/rpc/server.ts
+++ b/ironfish/src/rpc/server.ts
@@ -101,7 +101,7 @@ export class RpcServer {
       return false
     }
 
-    if (requestAuthToken.length >= AUTH_MAX_LENGTH) {
+    if (requestAuthToken.length > AUTH_MAX_LENGTH) {
       return false
     }
 
@@ -121,7 +121,7 @@ export class RpcServer {
     this.logger.debug(
       `Missing RPC Auth token in internal.json config. Automatically generating auth token.`,
     )
-    const newPassword = randomBytes(AUTH_MAX_LENGTH).toString('hex')
+    const newPassword = randomBytes(AUTH_MAX_LENGTH / 2).toString('hex')
     this.internal.set('rpcAuthToken', newPassword)
     await this.internal.save()
   }

--- a/ironfish/src/rpc/server.ts
+++ b/ironfish/src/rpc/server.ts
@@ -3,10 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { randomBytes, timingSafeEqual } from 'crypto'
-import { InternalStore } from '../fileStores'
+import { Assert } from '../assert'
+import { InternalOptions, InternalStore } from '../fileStores'
 import { createRootLogger, Logger } from '../logger'
 import { IRpcAdapter } from './adapters'
 import { ApiNamespace, RequestContext, Router, routes } from './routes'
+
+const AUTH_MAX_LENGTH = 256
 
 export class RpcServer {
   readonly internal: InternalStore
@@ -15,7 +18,8 @@ export class RpcServer {
 
   private _isRunning = false
   private _startPromise: Promise<unknown> | null = null
-  logger: Logger
+  private logger: Logger
+  private authTokenBuffer = Buffer.alloc(0)
 
   constructor(
     context: RequestContext,
@@ -25,6 +29,10 @@ export class RpcServer {
     this.context = context
     this.internal = internal
     this.logger = logger.withTag('rpcserver')
+
+    this.internal.onConfigChange.on(([key, value]) =>
+      this.onConfigChange(key as keyof InternalOptions, value),
+    )
   }
 
   get isRunning(): boolean {
@@ -86,37 +94,51 @@ export class RpcServer {
   /** Authenticate the RPC request */
   authenticate(requestAuthToken: string | undefined | null): boolean {
     if (!requestAuthToken) {
-      this.logger.debug(`Missing Auth token in RPC request.`)
       return false
     }
 
-    const rpcAuthToken = this.internal.get('rpcAuthToken')
-
-    if (!rpcAuthToken) {
+    if (!this.authTokenBuffer.byteLength) {
       return false
     }
 
-    const maxLength = Math.max(requestAuthToken.length, rpcAuthToken.length)
+    if (requestAuthToken.length >= AUTH_MAX_LENGTH) {
+      return false
+    }
 
-    const userTokenBuffer = Buffer.alloc(maxLength)
-    userTokenBuffer.write(requestAuthToken)
-
-    const authTokenBuffer = Buffer.alloc(maxLength)
-    authTokenBuffer.write(rpcAuthToken)
-
-    return timingSafeEqual(userTokenBuffer, authTokenBuffer)
+    const requestAuthBuffer = Buffer.alloc(AUTH_MAX_LENGTH)
+    requestAuthBuffer.write(requestAuthToken)
+    return timingSafeEqual(requestAuthBuffer, this.authTokenBuffer)
   }
 
   private async generateAuth(): Promise<void> {
     const rpcAuthToken = this.internal.get('rpcAuthToken')
 
     if (rpcAuthToken) {
-      this.logger.debug(
-        `Missing RPC Auth token in internal.json config. Automatically generating auth token.`,
-      )
-      const newPassword = randomBytes(32).toString('hex')
-      this.internal.set('rpcAuthToken', newPassword)
-      await this.internal.save()
+      this.loadAuth(this.internal.get('rpcAuthToken'))
+      return
     }
+
+    this.logger.debug(
+      `Missing RPC Auth token in internal.json config. Automatically generating auth token.`,
+    )
+    const newPassword = randomBytes(AUTH_MAX_LENGTH).toString('hex')
+    this.internal.set('rpcAuthToken', newPassword)
+    await this.internal.save()
+  }
+
+  private onConfigChange<Key extends keyof InternalOptions>(
+    key: Key,
+    newValue: InternalOptions[Key],
+  ): void {
+    if (key === 'rpcAuthToken') {
+      Assert.isInstanceOf(newValue, String)
+      this.loadAuth(newValue)
+    }
+  }
+
+  private loadAuth(token: string): void {
+    const buffer = Buffer.alloc(AUTH_MAX_LENGTH)
+    buffer.write(token)
+    this.authTokenBuffer = buffer
   }
 }

--- a/ironfish/src/rpc/server.ts
+++ b/ironfish/src/rpc/server.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { randomBytes } from 'crypto'
+import { randomBytes, timingSafeEqual } from 'crypto'
 import { InternalStore } from '../fileStores'
 import { createRootLogger, Logger } from '../logger'
 import { IRpcAdapter } from './adapters'
@@ -93,11 +93,12 @@ export class RpcServer {
     const rpcAuthToken = this.internal.get('rpcAuthToken')
 
     if (!rpcAuthToken) {
-      this.logger.debug(`Missing RPC Auth token in internal.json config.`)
       return false
     }
 
-    return requestAuthToken === rpcAuthToken
+    const userTokenBuffer = Buffer.from(requestAuthToken)
+    const authTokenBuffer = Buffer.from(rpcAuthToken)
+    return timingSafeEqual(userTokenBuffer, authTokenBuffer)
   }
 
   private async generateAuth(): Promise<void> {


### PR DESCRIPTION
## Summary

This fixes a timing attack where the comparater for strings is not constant time. You can find the password over time by trying different bytes which allow you to get closer and closer to the actual password.

See https://en.wikipedia.org/wiki/Timing_attack

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
