### PR TITLE
Add WSAddress type to connection

### DIFF
--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -24,7 +24,9 @@ export class WebSocketConnection extends Connection {
   }
 
   set port(port: number) {
-    this._address = this._address ? { host: this._address.host, port } : null
+    if (this._address) {
+      this._address.port = port
+    }
   }
 
   constructor(

--- a/ironfish/src/network/peers/connections/webSocketConnection.ts
+++ b/ironfish/src/network/peers/connections/webSocketConnection.ts
@@ -7,6 +7,7 @@ import colors from 'colors/safe'
 import { MetricsMonitor } from '../../../metrics'
 import { parseNetworkMessage } from '../../messageRegistry'
 import { IsomorphicWebSocket, IsomorphicWebSocketErrorEvent } from '../../types'
+import { WebSocketAddress } from '../../utils'
 import { Connection, ConnectionDirection, ConnectionType } from './connection'
 import { NetworkError } from './errors'
 
@@ -17,24 +18,26 @@ import { NetworkError } from './errors'
 export class WebSocketConnection extends Connection {
   private readonly socket: IsomorphicWebSocket
 
-  // The hostname of the address that was used to establish the WebSocket connection, if any
-  readonly hostname?: string
+  private _address: WebSocketAddress | null
+  get address(): WebSocketAddress | null {
+    return this._address
+  }
 
-  // The port of the address that was used to establish the WebSocket connection, if any
-  port?: number
+  set port(port: number) {
+    this._address = this._address ? { host: this._address.host, port } : null
+  }
 
   constructor(
     socket: IsomorphicWebSocket,
     direction: ConnectionDirection,
     logger: Logger,
     metrics?: MetricsMonitor,
-    options: { hostname?: string; port?: number } = {},
+    address: WebSocketAddress | null = null,
   ) {
     super(ConnectionType.WebSocket, direction, logger.withTag('WebSocketConnection'), metrics)
 
     this.socket = socket
-    this.hostname = options.hostname
-    this.port = options.port
+    this._address = address
 
     if (this.socket.readyState === this.socket.OPEN) {
       this.setState({ type: 'WAITING_FOR_IDENTITY' })

--- a/ironfish/src/network/peers/peer.ts
+++ b/ironfish/src/network/peers/peer.ts
@@ -536,9 +536,9 @@ export class Peer {
     if (
       connection.state.type === 'CONNECTED' &&
       connection instanceof WebSocketConnection &&
-      connection.hostname
+      connection.address
     ) {
-      this.wsAddress = { host: connection.hostname, port: connection.port || null }
+      this.wsAddress = connection.address
     }
 
     // onMessage
@@ -580,8 +580,8 @@ export class Peer {
 
         if (connection.state.type === 'CONNECTED') {
           // If connection goes to connected, transition the peer to connected
-          if (connection instanceof WebSocketConnection && connection.hostname) {
-            this.wsAddress = { host: connection.hostname, port: connection.port || null }
+          if (connection instanceof WebSocketConnection && connection.address) {
+            this.wsAddress = connection.address
           }
           this.setState(this.state.connections.webSocket, this.state.connections.webRtc)
         }

--- a/ironfish/src/network/peers/peerCandidates.ts
+++ b/ironfish/src/network/peers/peerCandidates.ts
@@ -42,7 +42,7 @@ export class PeerCandidates {
       websocketRetry: new ConnectionRetry(peer.isWhitelisted),
       localRequestedDisconnectUntil: null,
       peerRequestedDisconnectUntil: null,
-      name: null,
+      name: peer.name,
     }
 
     if (peer.state.identity !== null) {
@@ -73,6 +73,7 @@ export class PeerCandidates {
     } else {
       const tempPeer = new Peer(peer.identity)
       tempPeer.wsAddress = peer.wsAddress
+      tempPeer.name = peer.name ?? null
       this.addFromPeer(tempPeer, new Set([sendingPeerIdentity]))
     }
   }

--- a/ironfish/src/network/peers/peerManager.ts
+++ b/ironfish/src/network/peers/peerManager.ts
@@ -319,10 +319,13 @@ export class PeerManager {
     direction: ConnectionDirection,
     wsAddress: WebSocketAddress | null,
   ): WebSocketConnection {
-    const connection = new WebSocketConnection(ws, direction, this.logger, this.metrics, {
-      hostname: wsAddress?.host,
-      port: wsAddress?.port || undefined,
-    })
+    const connection = new WebSocketConnection(
+      ws,
+      direction,
+      this.logger,
+      this.metrics,
+      wsAddress,
+    )
 
     this.initConnectionHandlers(peer, connection)
     peer.setWebSocketConnection(connection)
@@ -1133,7 +1136,7 @@ export class PeerManager {
       connection instanceof WebSocketConnection &&
       connection.direction === ConnectionDirection.Inbound
     ) {
-      connection.port = message.port || undefined
+      connection.port = message.port
     }
 
     peer.name = message.name


### PR DESCRIPTION
## Summary
Changing WebSocketConnection to use address type instead of host and port

## Testing Plan
Running locally + unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
