### PR TITLE
Isolate migrator dependencies

### DIFF
--- a/ironfish/src/migrations/data/000-template.ts
+++ b/ironfish/src/migrations/data/000-template.ts
@@ -5,23 +5,22 @@ import { generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetStores } from './000-template/stores'
 
 export class Migration000 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
+  prepare(context: MigrationContext): IDatabase {
     /* replace line below with node.chain.location if applying migration to the blockchain
      * database
      */
-    return createDB({ location: node.config.walletDatabasePath })
+    return createDB({ location: context.config.walletDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -54,7 +53,7 @@ export class Migration000 extends Migration {
    * Writing a backwards migration is optional but suggested
    */
   async backward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/014-blockchain.ts
+++ b/ironfish/src/migrations/data/014-blockchain.ts
@@ -6,17 +6,16 @@ import { Assert } from '../../assert'
 import { FullNode } from '../../node'
 import { IDatabase } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 
 export class Migration014 extends Migration {
   path = __filename
   database = Database.BLOCKCHAIN
 
-  async prepare(node: IronfishNode): Promise<IDatabase> {
-    Assert.isInstanceOf(node, FullNode)
-    await node.files.mkdir(node.chain.location, { recursive: true })
-    return createDB({ location: node.chain.location })
+  async prepare(context: MigrationContext): Promise<IDatabase> {
+    Assert.isInstanceOf(context, FullNode)
+    await context.files.mkdir(context.chain.location, { recursive: true })
+    return createDB({ location: context.chain.location })
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/ironfish/src/migrations/data/015-wallet.ts
+++ b/ironfish/src/migrations/data/015-wallet.ts
@@ -4,16 +4,15 @@
 
 import { IDatabase } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 
 export class Migration015 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  async prepare(node: IronfishNode): Promise<IDatabase> {
-    await node.files.mkdir(node.config.walletDatabasePath, { recursive: true })
-    return createDB({ location: node.config.walletDatabasePath })
+  async prepare(context: MigrationContext): Promise<IDatabase> {
+    await context.files.mkdir(context.config.walletDatabasePath, { recursive: true })
+    return createDB({ location: context.config.walletDatabasePath })
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/ironfish/src/migrations/data/016-sequence-to-tx.ts
+++ b/ironfish/src/migrations/data/016-sequence-to-tx.ts
@@ -4,25 +4,24 @@
 
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration016 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return node.wallet.walletDb.db
+  prepare(context: MigrationContext): IDatabase {
+    return context.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
   ): Promise<void> {
-    const accounts = await GetOldAccounts(node, db, tx)
+    const accounts = await GetOldAccounts(context, db, tx)
 
     logger.info(`Indexing on-chain transactions for ${accounts.length} accounts`)
 
@@ -37,7 +36,7 @@ export class Migration016 extends Migration {
           continue
         }
 
-        await node.wallet.walletDb.saveSequenceToTransactionHash(
+        await context.wallet.walletDb.saveSequenceToTransactionHash(
           account,
           transaction.sequence,
           transaction.transaction.hash(),
@@ -50,7 +49,7 @@ export class Migration016 extends Migration {
     }
   }
 
-  async backward(node: IronfishNode): Promise<void> {
-    await node.wallet.walletDb.sequenceToTransactionHash.clear()
+  async backward(context: MigrationContext): Promise<void> {
+    await context.wallet.walletDb.sequenceToTransactionHash.clear()
   }
 }

--- a/ironfish/src/migrations/data/018-backfill-wallet-assets.ts
+++ b/ironfish/src/migrations/data/018-backfill-wallet-assets.ts
@@ -3,29 +3,28 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration018 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return node.wallet.walletDb.db
+  prepare(context: MigrationContext): IDatabase {
+    return context.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     _db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
   ): Promise<void> {
     // Ensure there are no corrupted records for users who might have failed
     // running this migration
-    await node.wallet.walletDb.assets.clear()
+    await context.wallet.walletDb.assets.clear()
 
-    const accounts = await GetOldAccounts(node, _db, tx)
+    const accounts = await GetOldAccounts(context, _db, tx)
 
     logger.info(`Backfilling assets for ${accounts.length} accounts`)
 
@@ -50,7 +49,7 @@ export class Migration018 extends Migration {
     logger.info('')
   }
 
-  async backward(node: IronfishNode): Promise<void> {
-    await node.wallet.walletDb.assets.clear()
+  async backward(context: MigrationContext): Promise<void> {
+    await context.wallet.walletDb.assets.clear()
   }
 }

--- a/ironfish/src/migrations/data/020-backfill-null-asset-supplies.ts
+++ b/ironfish/src/migrations/data/020-backfill-null-asset-supplies.ts
@@ -3,25 +3,25 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
-import { BufferUtils, IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { BufferUtils } from '../../utils'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetOldAccounts } from './021-add-version-to-accounts/schemaOld'
 
 export class Migration020 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return node.wallet.walletDb.db
+  prepare(context: MigrationContext): IDatabase {
+    return context.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     _db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
   ): Promise<void> {
-    const accounts = await GetOldAccounts(node, _db, tx)
+    const accounts = await GetOldAccounts(context, _db, tx)
 
     logger.info(`Backfilling assets for ${accounts.length} accounts`)
 
@@ -36,7 +36,7 @@ export class Migration020 extends Migration {
         }
 
         logger.info(`  Re-syncing asset ${BufferUtils.toHuman(asset.name)}`)
-        await node.wallet.walletDb.deleteAsset(account, asset.id, tx)
+        await context.wallet.walletDb.deleteAsset(account, asset.id, tx)
         assetCount++
       }
 

--- a/ironfish/src/migrations/data/021-add-version-to-accounts.ts
+++ b/ironfish/src/migrations/data/021-add-version-to-accounts.ts
@@ -3,8 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetNewStores } from './021-add-version-to-accounts/schemaNew'
 import { GetOldStores } from './021-add-version-to-accounts/schemaOld'
 
@@ -12,12 +11,12 @@ export class Migration021 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return node.wallet.walletDb.db
+  prepare(context: MigrationContext): IDatabase {
+    return context.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -42,7 +41,7 @@ export class Migration021 extends Migration {
   }
 
   async backward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/021-add-version-to-accounts/schemaOld.ts
+++ b/ironfish/src/migrations/data/021-add-version-to-accounts/schemaOld.ts
@@ -10,8 +10,8 @@ import {
   IDatabaseTransaction,
   StringEncoding,
 } from '../../../storage'
-import { IronfishNode } from '../../../utils'
 import { Account } from '../../../wallet'
+import { MigrationContext } from '../../migration'
 
 const KEY_LENGTH = 32
 
@@ -85,7 +85,7 @@ export function GetOldStores(db: IDatabase): {
 }
 
 export async function GetOldAccounts(
-  node: IronfishNode,
+  context: MigrationContext,
   db: IDatabase,
   tx?: IDatabaseTransaction,
 ): Promise<Account[]> {
@@ -101,7 +101,7 @@ export async function GetOldAccounts(
         version: 1,
         viewKey: key.viewKey,
         createdAt: null,
-        walletDb: node.wallet.walletDb,
+        walletDb: context.wallet.walletDb,
       }),
     )
   }

--- a/ironfish/src/migrations/data/022-add-view-key-account.ts
+++ b/ironfish/src/migrations/data/022-add-view-key-account.ts
@@ -4,8 +4,7 @@
 import { generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetNewStores } from './022-add-view-key-account/schemaNew'
 import { GetOldStores } from './022-add-view-key-account/schemaOld'
 
@@ -13,12 +12,12 @@ export class Migration022 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return node.wallet.walletDb.db
+  prepare(context: MigrationContext): IDatabase {
+    return context.wallet.walletDb.db
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -45,7 +44,7 @@ export class Migration022 extends Migration {
   }
 
   async backward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/023-wallet-optional-spending-key.ts
+++ b/ironfish/src/migrations/data/023-wallet-optional-spending-key.ts
@@ -3,20 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetStores } from './023-wallet-optional-spending-key/stores'
 
 export class Migration023 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return node.wallet.walletDb.db
+  prepare(context: MigrationContext): IDatabase {
+    return context.wallet.walletDb.db
   }
 
   async forward(
-    _node: IronfishNode,
+    _context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -30,7 +29,7 @@ export class Migration023 extends Migration {
   }
 
   backward(
-    _node: IronfishNode,
+    _context: MigrationContext,
     _db: IDatabase,
     _tx: IDatabaseTransaction | undefined,
     _logger: Logger,

--- a/ironfish/src/migrations/data/024-unspent-notes.ts
+++ b/ironfish/src/migrations/data/024-unspent-notes.ts
@@ -5,21 +5,20 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { IronfishNode } from '../../utils'
 import { Account } from '../../wallet'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetStores } from './024-unspent-notes/stores'
 
 export class Migration024 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return createDB({ location: node.config.walletDatabasePath })
+  prepare(context: MigrationContext): IDatabase {
+    return createDB({ location: context.config.walletDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -33,7 +32,7 @@ export class Migration024 extends Migration {
         new Account({
           ...accountValue,
           createdAt: null,
-          walletDb: node.wallet.walletDb,
+          walletDb: context.wallet.walletDb,
         }),
       )
     }
@@ -66,7 +65,7 @@ export class Migration024 extends Migration {
     }
   }
 
-  async backward(node: IronfishNode, db: IDatabase): Promise<void> {
+  async backward(context: MigrationContext, db: IDatabase): Promise<void> {
     const stores = GetStores(db)
 
     await stores.new.unspentNoteHashes.clear()

--- a/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
+++ b/ironfish/src/migrations/data/025-backfill-wallet-nullifier-to-transaction-hash.ts
@@ -4,21 +4,20 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { IronfishNode } from '../../utils'
 import { Account } from '../../wallet'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetStores } from './025-backfill-wallet-nullifier-to-transaction-hash/stores'
 
 export class Migration025 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return createDB({ location: node.config.walletDatabasePath })
+  prepare(context: MigrationContext): IDatabase {
+    return createDB({ location: context.config.walletDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     _tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -31,7 +30,7 @@ export class Migration025 extends Migration {
         new Account({
           ...account,
           createdAt: null,
-          walletDb: node.wallet.walletDb,
+          walletDb: context.wallet.walletDb,
         }),
       )
     }
@@ -91,7 +90,7 @@ export class Migration025 extends Migration {
   }
 
   async backward(
-    _node: IronfishNode,
+    _context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/026-timestamp-to-transactions.ts
+++ b/ironfish/src/migrations/data/026-timestamp-to-transactions.ts
@@ -4,21 +4,20 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { IronfishNode } from '../../utils'
 import { Account } from '../../wallet'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetStores } from './026-timestamp-to-transactions/stores'
 
 export class Migration026 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return createDB({ location: node.config.walletDatabasePath })
+  prepare(context: MigrationContext): IDatabase {
+    return createDB({ location: context.config.walletDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     _tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -31,7 +30,7 @@ export class Migration026 extends Migration {
         new Account({
           ...account,
           createdAt: null,
-          walletDb: node.wallet.walletDb,
+          walletDb: context.wallet.walletDb,
         }),
       )
     }
@@ -68,7 +67,7 @@ export class Migration026 extends Migration {
     logger.info('')
   }
 
-  async backward(node: IronfishNode, db: IDatabase): Promise<void> {
+  async backward(context: MigrationContext, db: IDatabase): Promise<void> {
     const accounts = []
     const stores = GetStores(db)
 
@@ -77,7 +76,7 @@ export class Migration026 extends Migration {
         new Account({
           ...account,
           createdAt: null,
-          walletDb: node.wallet.walletDb,
+          walletDb: context.wallet.walletDb,
         }),
       )
     }

--- a/ironfish/src/migrations/data/027-account-created-at-block.ts
+++ b/ironfish/src/migrations/data/027-account-created-at-block.ts
@@ -4,20 +4,19 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetStores } from './027-account-created-at-block/stores'
 
 export class Migration027 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return createDB({ location: node.config.walletDatabasePath })
+  prepare(context: MigrationContext): IDatabase {
+    return createDB({ location: context.config.walletDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -34,7 +33,7 @@ export class Migration027 extends Migration {
   }
 
   async backward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/028-backfill-assets-owner.ts
+++ b/ironfish/src/migrations/data/028-backfill-assets-owner.ts
@@ -4,20 +4,19 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetStores } from './028-backfill-assets-owner/stores'
 
 export class Migration028 extends Migration {
   path = __filename
   database = Database.BLOCKCHAIN
 
-  prepare(node: IronfishNode): IDatabase {
-    return createDB({ location: node.config.chainDatabasePath })
+  prepare(context: MigrationContext): IDatabase {
+    return createDB({ location: context.config.chainDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -40,7 +39,7 @@ export class Migration028 extends Migration {
   }
 
   async backward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/data/029-backfill-assets-owner-wallet.ts
+++ b/ironfish/src/migrations/data/029-backfill-assets-owner-wallet.ts
@@ -4,20 +4,19 @@
 import { Logger } from '../../logger'
 import { IDatabase, IDatabaseTransaction } from '../../storage'
 import { createDB } from '../../storage/utils'
-import { IronfishNode } from '../../utils'
-import { Database, Migration } from '../migration'
+import { Database, Migration, MigrationContext } from '../migration'
 import { GetStores } from './028-backfill-assets-owner/stores'
 
 export class Migration029 extends Migration {
   path = __filename
   database = Database.WALLET
 
-  prepare(node: IronfishNode): IDatabase {
-    return createDB({ location: node.config.walletDatabasePath })
+  prepare(context: MigrationContext): IDatabase {
+    return createDB({ location: context.config.walletDatabasePath })
   }
 
   async forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -40,7 +39,7 @@ export class Migration029 extends Migration {
   }
 
   async backward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/migrations/migration.ts
+++ b/ironfish/src/migrations/migration.ts
@@ -2,14 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Config } from '../fileStores'
 import { FileSystem } from '../fileSystems'
 import { Logger } from '../logger'
 import { IDatabase, IDatabaseTransaction } from '../storage'
-import { IronfishNode } from '../utils'
+import { Wallet } from '../wallet'
 
 export enum Database {
   WALLET = 'wallet',
   BLOCKCHAIN = 'blockchain',
+}
+
+export type MigrationContext = {
+  config: Config
+  files: FileSystem
+  wallet: Wallet
 }
 
 export abstract class Migration {
@@ -30,10 +37,10 @@ export abstract class Migration {
     return this
   }
 
-  abstract prepare(node: IronfishNode): Promise<IDatabase> | IDatabase
+  abstract prepare(context: MigrationContext): Promise<IDatabase> | IDatabase
 
   abstract forward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,
@@ -41,7 +48,7 @@ export abstract class Migration {
   ): Promise<void>
 
   abstract backward(
-    node: IronfishNode,
+    context: MigrationContext,
     db: IDatabase,
     tx: IDatabaseTransaction | undefined,
     logger: Logger,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -113,7 +113,7 @@ export class FullNode {
     this.logger = logger
     this.pkg = pkg
 
-    this.migrator = new Migrator({ node: this, logger })
+    this.migrator = new Migrator({ context: this, logger })
 
     const identity = privateIdentity || new BoxKeyPair()
 

--- a/ironfish/src/walletNode.ts
+++ b/ironfish/src/walletNode.ts
@@ -87,7 +87,7 @@ export class WalletNode {
     this.nodeClient = nodeClient
     this.assetsVerifier = assetsVerifier
 
-    this.migrator = new Migrator({ node: this, logger, databases: [Database.WALLET] })
+    this.migrator = new Migrator({ context: this, logger, databases: [Database.WALLET] })
 
     this.nodeClientConnectionWarned = false
     this.nodeClientConnectionTimeout = null


### PR DESCRIPTION
## Summary

This reduces the need for a full node for the Migrator dependencies. It allows anyone to run migrations that can satisify the migrator context requirements. This is useful for letting another CLI other than ironfish-cli run migrations, like the standalone CLI wallet.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
