### PR TITLE
Use sdk getPrivateIdentity function

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -214,9 +214,7 @@ export default class Start extends IronfishCommand {
       await this.sdk.internal.save()
     }
 
-    const privateIdentity = this.getPrivateIdentity()
-
-    const node = await this.sdk.node({ privateIdentity: privateIdentity })
+    const node = await this.sdk.node({ privateIdentity: this.sdk.getPrivateIdentity() })
 
     const nodeName = this.sdk.config.get('nodeName').trim() || null
     const blockGraffiti = this.sdk.config.get('blockGraffiti').trim() || null
@@ -323,16 +321,5 @@ export default class Start extends IronfishCommand {
 
     this.log('')
     await node.internal.save()
-  }
-
-  getPrivateIdentity(): PrivateIdentity | undefined {
-    const networkIdentity = this.sdk.internal.get('networkIdentity')
-    if (
-      !this.sdk.config.get('generateNewIdentity') &&
-      networkIdentity !== undefined &&
-      networkIdentity.length > 31
-    ) {
-      return BoxKeyPair.fromHex(networkIdentity)
-    }
   }
 }

--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BoxKeyPair } from '@ironfish/rust-nodejs'
-import { Assert, FullNode, NodeUtils, PrivateIdentity, PromiseUtils } from '@ironfish/sdk'
+import { Assert, FullNode, NodeUtils, PromiseUtils } from '@ironfish/sdk'
 import { Flags } from '@oclif/core'
 import inspector from 'node:inspector'
 import { v4 as uuid } from 'uuid'


### PR DESCRIPTION
## Summary

Uses the function added in #4344 in the CLI start command to bootstrap the node's network identity.

## Testing Plan

* [x] Started a node with an existing network identity to make sure the identity in internal.json doesn't change
* [x] Deleted existing network identity from internal.json and started node to make sure internal.json is updated with new identity

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
