### PR TITLE
Fix some missing logger parameters

### DIFF
--- a/ironfish/src/memPool/feeEstimator.ts
+++ b/ironfish/src/memPool/feeEstimator.ts
@@ -49,7 +49,7 @@ export class FeeEstimator {
     logger?: Logger
     percentiles?: PriorityLevelPercentiles
   }) {
-    this.logger = options.logger || createRootLogger().withTag('recentFeeCache')
+    this.logger = (options.logger ?? createRootLogger()).withTag('recentFeeCache')
     this.maxBlockHistory = options.maxBlockHistory ?? this.maxBlockHistory
     this.consensus = options.consensus
 

--- a/ironfish/src/memPool/recentlyEvictedCache.ts
+++ b/ironfish/src/memPool/recentlyEvictedCache.ts
@@ -203,7 +203,7 @@ export class RecentlyEvictedCache {
       toFlush = this.removeAtSequenceQueue.peek()
     }
 
-    this.logger?.debug(
+    this.logger.debug(
       `Flushed ${flushCount} transactions from RecentlyEvictedCache after adding block ${sequence}`,
     )
 

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -234,7 +234,7 @@ export class FullNode {
 
     const numWorkers = calculateWorkers(config.get('nodeWorkers'), config.get('nodeWorkersMax'))
 
-    const workerPool = new WorkerPool({ metrics, numWorkers })
+    const workerPool = new WorkerPool({ logger, metrics, numWorkers })
 
     metrics = metrics || new MetricsMonitor({ logger })
 
@@ -270,6 +270,7 @@ export class FullNode {
         average: config.get('feeEstimatorPercentileAverage'),
         fast: config.get('feeEstimatorPercentileFast'),
       },
+      logger,
     })
 
     const memPool = new MemPool({
@@ -296,6 +297,7 @@ export class FullNode {
       workerPool,
       consensus,
       nodeClient: memoryClient,
+      logger,
     })
 
     const node = new FullNode({

--- a/ironfish/src/walletNode.ts
+++ b/ironfish/src/walletNode.ts
@@ -140,7 +140,7 @@ export class WalletNode {
 
     const numWorkers = calculateWorkers(config.get('nodeWorkers'), config.get('nodeWorkersMax'))
 
-    const workerPool = new WorkerPool({ metrics, numWorkers })
+    const workerPool = new WorkerPool({ logger, metrics, numWorkers })
 
     metrics = metrics || new MetricsMonitor({ logger })
 


### PR DESCRIPTION
## Summary

Many classes in the codebase take an optional logger parameter, but because it's optional, we often forget to pass it. Fixed a few places where logger should have been propagated through.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
