### PR TITLE
Sorting for peers command 

### DIFF
--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -19,10 +19,7 @@ export class ListCommand extends IronfishCommand {
   static flags = {
     ...RemoteFlags,
     ...tableFlags,
-    sort: {
-      ...sort,
-      exclusive: ['follow'],
-    },
+    sort,
     follow: Flags.boolean({
       char: 'f',
       default: false,
@@ -58,10 +55,9 @@ export class ListCommand extends IronfishCommand {
 
   async start(): Promise<void> {
     const { flags } = await this.parse(ListCommand)
+    flags.sort = flags.sort ?? STATE_COLUMN_HEADER
 
     if (!flags.follow) {
-      flags.sort = flags.sort ?? STATE_COLUMN_HEADER
-
       await this.sdk.client.connect()
       const response = await this.sdk.client.peer.getPeers()
       this.log(renderTable(response.content, flags))
@@ -237,16 +233,6 @@ function renderTable(
   }
 
   let result = ''
-
-  peers.sort((a, b) => {
-    if (a.state !== b.state) {
-      //sorting peers by connected state: CONNECTED, CONNECTING, DISCONNECTED
-      return a.state < b.state ? -1 : 1
-    }
-
-    // will show inbound connections first if the state is the same
-    return (a.identity ?? '') > (b.identity ?? '') ? -1 : 1
-  })
 
   CliUx.ux.table(peers, columns, {
     printLine: (line) => (result += `${String(line)}\n`),

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -160,7 +160,16 @@ function renderTable(
     }
   }
 
+  let index = 1
+
   columns = {
+    index: {
+      header: '#',
+      minWidth: 2,
+      get: () => {
+        return String(index++)
+      },
+    },
     ...columns,
     state: {
       header: STATE_COLUMN_HEADER,
@@ -228,6 +237,17 @@ function renderTable(
   }
 
   let result = ''
+
+  //sorting peers by connected state: CONNECTED, CONNECTING, DISCONNECTED
+
+  peers.sort((a, b) => {
+    if (a.state !== b.state) {
+      return a.state < b.state ? -1 : 1
+    }
+
+    // will show inbound connections first
+    return (a.identity ?? '') > (b.identity ?? '') ? -1 : 1
+  })
 
   CliUx.ux.table(peers, columns, {
     printLine: (line) => (result += `${String(line)}\n`),

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -238,14 +238,13 @@ function renderTable(
 
   let result = ''
 
-  //sorting peers by connected state: CONNECTED, CONNECTING, DISCONNECTED
-
   peers.sort((a, b) => {
     if (a.state !== b.state) {
+      //sorting peers by connected state: CONNECTED, CONNECTING, DISCONNECTED
       return a.state < b.state ? -1 : 1
     }
 
-    // will show inbound connections first
+    // will show inbound connections first if the state is the same
     return (a.identity ?? '') > (b.identity ?? '') ? -1 : 1
   })
 

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -11,15 +11,13 @@ import { CommandFlags } from '../../types'
 type GetPeerResponsePeer = GetPeersResponse['peers'][0]
 
 const STATE_COLUMN_HEADER = 'STATE'
-const { sort, ...tableFlags } = CliUx.ux.table.flags()
 
 export class ListCommand extends IronfishCommand {
   static description = `List all connected peers`
 
   static flags = {
     ...RemoteFlags,
-    ...tableFlags,
-    sort,
+    ...CliUx.ux.table.flags(),
     follow: Flags.boolean({
       char: 'f',
       default: false,

--- a/ironfish-cli/src/commands/peers/index.ts
+++ b/ironfish-cli/src/commands/peers/index.ts
@@ -156,16 +156,7 @@ function renderTable(
     }
   }
 
-  let index = 1
-
   columns = {
-    index: {
-      header: '#',
-      minWidth: 2,
-      get: () => {
-        return String(index++)
-      },
-    },
     ...columns,
     state: {
       header: STATE_COLUMN_HEADER,


### PR DESCRIPTION
## Summary

Since we are displaying a single table, we can sort the output for the follow state.

<img width="2056" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/40ac2629-b5d2-4bf0-8d4a-2f90cc330880">



## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
