### PR TITLE
PeerConnectionManager should not disconnect whitelisted nodes

### DIFF
--- a/ironfish/src/network/peers/peerConnectionManager.ts
+++ b/ironfish/src/network/peers/peerConnectionManager.ts
@@ -143,10 +143,11 @@ export class PeerConnectionManager {
       return
     }
 
-    // Choose a random peer, but exclude the newest connections as they are
-    // least likely to have other peers
+    // Choose a random peer with some exceptions:
+    // - Exclude the most recent peer connections as they are more likely to have fewer peers
+    // - Exclude white-listed nodes
     const sampleEnd = Math.floor(connectedPeers.length * 0.8)
-    const peersSlice = connectedPeers.slice(0, sampleEnd)
+    const peersSlice = connectedPeers.slice(0, sampleEnd).filter((p) => !p.isWhitelisted)
     const peer = ArrayUtils.sample(peersSlice)
     if (!peer) {
       return


### PR DESCRIPTION
## Summary

When trying to maintain the max peer count allowed, the peer connection manager should not disconnect whitelisted nodes. The expectation for whitelisted nodes is that they should essentially be treated special and assumed to always be connected.

Closes IFL-1812

## Testing Plan

Unit test

## Documentation

N/A

## Breaking Change

N/A