### PR TITLE
Wait for connection status on add peer command

### DIFF
--- a/ironfish-cli/src/commands/peers/add.ts
+++ b/ironfish-cli/src/commands/peers/add.ts
@@ -53,6 +53,11 @@ export class AddCommand extends IronfishCommand {
 
     if (response.content.added) {
       this.log(`Successfully added peer ${request.host}:${request.port}`)
+    } else if (response.content.error !== undefined) {
+      this.log(
+        `Failed to add peer ${request.host}:${request.port} because: ${response.content.error}`,
+      )
+      this.exit(0)
     } else {
       this.log(`Could not add peer ${request.host}:${request.port}`)
       this.exit(0)

--- a/ironfish/src/rpc/routes/peer/addPeer.test.ts
+++ b/ironfish/src/rpc/routes/peer/addPeer.test.ts
@@ -2,28 +2,128 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { formatWebSocketAddress } from '../../../network'
+import { WebSocketConnection } from '../../../network/peers/connections'
+import { mockIdentity } from '../../../network/testUtilities'
 import { createRouteTest } from '../../../testUtilities/routeTest'
+
+jest.mock('ws')
 
 describe('Route peer/addPeer', () => {
   const routeTest = createRouteTest()
 
   it('should add a peer with a correct address and port', async () => {
     const request = { host: 'testhost', port: 9037 }
+    const identity = mockIdentity('peer')
 
-    const response = await routeTest.client.request('peer/addPeer', request).waitForEnd()
+    const req = await routeTest.client.request('peer/addPeer', request).waitForRoute()
 
-    expect(
-      routeTest.node.peerNetwork.peerManager.peerCandidates.has('ws://testhost:9037'),
-    ).toBe(true)
-
-    const matchingPeers = routeTest.node.peerNetwork.peerManager.peers.filter(
+    const matchingPeers = routeTest.peerNetwork.peerManager.peers.filter(
       (p) => formatWebSocketAddress(p.wsAddress) === 'ws://testhost:9037',
     )
 
     expect(matchingPeers.length).toBe(1)
+    expect(routeTest.peerNetwork.peerManager.peerCandidates.has(identity)).toBe(false)
+
+    const peer = matchingPeers[0]
+
+    let connection: WebSocketConnection
+    if (peer.state.type === 'CONNECTING' && peer.state.connections.webSocket) {
+      connection = peer.state.connections.webSocket
+    } else {
+      throw new Error('Peer should be CONNECTING with a WS connection')
+    }
+
+    connection.setState({
+      type: 'CONNECTED',
+      identity,
+    })
+
+    const response = await req.waitForEnd()
 
     expect(response.content).toMatchObject({
       added: true,
     })
+    expect(
+      routeTest.peerNetwork.peerManager
+        .getConnectedPeers()
+        .filter((p) => p.state.identity === identity),
+    ).toHaveLength(1)
+    expect(routeTest.peerNetwork.peerManager.peerCandidates.has(identity)).toBe(true)
+  })
+
+  it('should return false if the peer closes without an error', async () => {
+    const request = { host: 'testhost', port: 9037 }
+    const identity = mockIdentity('peer')
+
+    const req = await routeTest.client.request('peer/addPeer', request).waitForRoute()
+
+    const matchingPeers = routeTest.peerNetwork.peerManager.peers.filter(
+      (p) => formatWebSocketAddress(p.wsAddress) === 'ws://testhost:9037',
+    )
+
+    expect(matchingPeers.length).toBe(1)
+    expect(routeTest.peerNetwork.peerManager.peerCandidates.has(identity)).toBe(false)
+
+    const peer = matchingPeers[0]
+
+    let connection: WebSocketConnection
+    if (peer.state.type === 'CONNECTING' && peer.state.connections.webSocket) {
+      connection = peer.state.connections.webSocket
+    } else {
+      throw new Error('Peer should be CONNECTING with a WS connection')
+    }
+
+    connection.close()
+
+    const response = await req.waitForEnd()
+
+    expect(response.content).toMatchObject({
+      added: false,
+      error: undefined,
+    })
+    expect(
+      routeTest.peerNetwork.peerManager
+        .getConnectedPeers()
+        .filter((p) => p.state.identity === identity),
+    ).toHaveLength(0)
+    expect(routeTest.peerNetwork.peerManager.peerCandidates.has(identity)).toBe(false)
+  })
+
+  it('should return false if the peer closes with an error', async () => {
+    const request = { host: 'testhost', port: 9037 }
+    const identity = mockIdentity('peer')
+
+    const req = await routeTest.client.request('peer/addPeer', request).waitForRoute()
+
+    const matchingPeers = routeTest.peerNetwork.peerManager.peers.filter(
+      (p) => formatWebSocketAddress(p.wsAddress) === 'ws://testhost:9037',
+    )
+
+    expect(matchingPeers.length).toBe(1)
+    expect(routeTest.peerNetwork.peerManager.peerCandidates.has(identity)).toBe(false)
+
+    const peer = matchingPeers[0]
+
+    let connection: WebSocketConnection
+    if (peer.state.type === 'CONNECTING' && peer.state.connections.webSocket) {
+      connection = peer.state.connections.webSocket
+    } else {
+      throw new Error('Peer should be CONNECTING with a WS connection')
+    }
+
+    connection.close(new Error('foo'))
+
+    const response = await req.waitForEnd()
+
+    expect(response.content).toMatchObject({
+      added: false,
+      error: 'foo',
+    })
+    expect(
+      routeTest.peerNetwork.peerManager
+        .getConnectedPeers()
+        .filter((p) => p.state.identity === identity),
+    ).toHaveLength(0)
+    expect(routeTest.peerNetwork.peerManager.peerCandidates.has(identity)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
Wait for the result of the connection before returning from the add peer command

## Testing Plan
Tested locally + unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
