### PR TITLE
Adding note hash to view transaction output

### DIFF
--- a/ironfish-cli/src/commands/wallet/transaction/index.ts
+++ b/ironfish-cli/src/commands/wallet/transaction/index.ts
@@ -92,6 +92,10 @@ export class TransactionCommand extends IronfishCommand {
       }
 
       CliUx.ux.table(noteAssetPairs, {
+        noteHash: {
+          header: 'Note Hash',
+          get: ({ note }) => note.noteHash,
+        },
         amount: {
           header: 'Amount',
           get: ({ note }) => CurrencyUtils.renderIron(note.value),


### PR DESCRIPTION
## Summary

Debugging + UX improvement for what the output for the user looks like after a transaction 

<img width="1671" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/ef4bb052-dd96-49e0-90e6-3a9f59ee9202">


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
