### PR TITLE
Rahul/ifl 1838 note hash added to notes command output

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -56,7 +56,7 @@ export class NotesCommand extends IronfishCommand {
               if (row.spent === undefined) {
                 return '-'
               } else {
-                return row.spent ? `✔` : ``
+                return row.spent ? `true` : `false`
               }
             },
           },

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -47,9 +47,6 @@ export class NotesCommand extends IronfishCommand {
           sender: {
             header: 'Sender',
           },
-          noteHash: {
-            header: 'Note Hash',
-          },
           transactionHash: {
             header: 'From Transaction',
           },
@@ -68,6 +65,9 @@ export class NotesCommand extends IronfishCommand {
             header: 'Amount',
             get: (row) => CurrencyUtils.renderIron(row.value),
             minWidth: 16,
+          },
+          noteHash: {
+            header: 'Note Hash',
           },
           nullifier: {
             header: 'Nullifier',

--- a/ironfish-cli/src/commands/wallet/notes.ts
+++ b/ironfish-cli/src/commands/wallet/notes.ts
@@ -56,7 +56,7 @@ export class NotesCommand extends IronfishCommand {
               if (row.spent === undefined) {
                 return '-'
               } else {
-                return row.spent ? `true` : `false`
+                return row.spent ? `✔` : `x`
               }
             },
           },


### PR DESCRIPTION
## Summary

Adding the `x` so we can filter out the unspent transactions

Previously we weren't able to use the native table filtering because it doesn't work with empty strings `--filter="Spent=x"`


## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
