### PR TITLE
Refactor Wallet.fund method to be more re-usable

### DIFF
--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -39,6 +39,16 @@ export interface MintData {
   transferOwnershipTo?: string
 }
 
+export type RawTransactionSpend = {
+  note: Note
+  witness: Witness<
+    NoteEncrypted,
+    NoteEncryptedHash,
+    NoteEncryptedHash,
+    SerializedNoteEncryptedHash
+  >
+}
+
 export class RawTransaction {
   version: TransactionVersion
   expiration: number | null = null
@@ -46,16 +56,7 @@ export class RawTransaction {
   mints: MintData[] = []
   burns: BurnDescription[] = []
   outputs: { note: Note }[] = []
-
-  spends: {
-    note: Note
-    witness: Witness<
-      NoteEncrypted,
-      NoteEncryptedHash,
-      NoteEncryptedHash,
-      SerializedNoteEncryptedHash
-    >
-  }[] = []
+  spends: RawTransactionSpend[] = []
 
   constructor(version: TransactionVersion) {
     this.version = version


### PR DESCRIPTION
## Summary
For custom note selection we will want to implement different algorithms for funding a transaction. This refactor will make it easier to implement and swap out different funding methods

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
