### PR TITLE
Rahul/ifl 1844 WIP create transaction note selection

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -90,6 +90,11 @@ export class Send extends IronfishCommand {
       default: false,
       description: 'Allow offline transaction creation',
     }),
+    notes: Flags.string({
+      char: 'n',
+      description: 'The notes to include in the transaction',
+      multiple: true,
+    }),
   }
 
   async start(): Promise<void> {
@@ -189,6 +194,7 @@ export class Send extends IronfishCommand {
       feeRate: flags.feeRate ? CurrencyUtils.encode(flags.feeRate) : null,
       expiration: flags.expiration,
       confirmations: flags.confirmations,
+      notes: flags.notes,
     }
 
     let raw: RawTransaction

--- a/ironfish/src/utils/array.ts
+++ b/ironfish/src/utils/array.ts
@@ -35,4 +35,8 @@ function remove<T>(array: Array<T>, item: T): boolean {
   return false
 }
 
-export const ArrayUtils = { shuffle, sample, remove }
+function isSuperset<T>(superset: T[], subset: T[]): boolean {
+  return subset.every((element) => superset.includes(element))
+}
+
+export const ArrayUtils = { shuffle, sample, remove, isSuperset }

--- a/ironfish/src/wallet/errors.ts
+++ b/ironfish/src/wallet/errors.ts
@@ -18,3 +18,12 @@ export class NotEnoughFundsError extends Error {
     )} available to spend. Please fund your account and/or wait for any pending transactions to be confirmed.'`
   }
 }
+
+export class NoteSpent extends Error {
+  name = this.constructor.name
+
+  constructor(noteHash: Buffer) {
+    super()
+    this.message = `Note ${noteHash.toString('hex')} has already been spent`
+  }
+}

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -36,7 +36,6 @@ import {
 } from '../utils'
 import { WorkerPool } from '../workerPool'
 import { DecryptedNote, DecryptNoteOptions } from '../workerPool/tasks/decryptNotes'
-import { AccountValue } from '.'
 import { Account, ACCOUNT_SCHEMA_VERSION } from './account/account'
 import { AssetBalances } from './assetBalances'
 import { NotEnoughFundsError } from './errors'
@@ -47,6 +46,7 @@ import {
   WalletBlockTransaction,
 } from './remoteChainProcessor'
 import { validateAccount } from './validator'
+import { AccountValue } from './walletdb/accountValue'
 import { AssetValue } from './walletdb/assetValue'
 import { DecryptedNoteValue } from './walletdb/decryptedNoteValue'
 import { HeadValue } from './walletdb/headValue'

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -38,7 +38,7 @@ import { WorkerPool } from '../workerPool'
 import { DecryptedNote, DecryptNoteOptions } from '../workerPool/tasks/decryptNotes'
 import { Account, ACCOUNT_SCHEMA_VERSION } from './account/account'
 import { AssetBalances } from './assetBalances'
-import { NotEnoughFundsError } from './errors'
+import { NotEnoughFundsError, NoteSpent } from './errors'
 import { MintAssetOptions } from './interfaces/mintAssetOptions'
 import {
   RemoteChainProcessor,
@@ -1141,6 +1141,10 @@ export class Wallet {
           options.account.name
         }`,
       )
+
+      if (decryptedNote.spent) {
+        throw new NoteSpent(decryptedNote.note.hash())
+      }
 
       const witness = await this.getNoteWitness(decryptedNote, options.confirmations)
 

--- a/ironfish/src/wallet/wallet.ts
+++ b/ironfish/src/wallet/wallet.ts
@@ -21,7 +21,7 @@ import { Note } from '../primitives/note'
 import { NoteEncrypted } from '../primitives/noteEncrypted'
 import { MintData, RawTransaction } from '../primitives/rawTransaction'
 import { Transaction } from '../primitives/transaction'
-import { RpcClient } from '../rpc'
+import { GetBlockRequest, GetBlockResponse, RpcClient } from '../rpc'
 import { IDatabaseTransaction } from '../storage/database/transaction'
 import {
   ArrayUtils,
@@ -36,6 +36,7 @@ import {
 } from '../utils'
 import { WorkerPool } from '../workerPool'
 import { DecryptedNote, DecryptNoteOptions } from '../workerPool/tasks/decryptNotes'
+import { AccountValue } from '.'
 import { Account, ACCOUNT_SCHEMA_VERSION } from './account/account'
 import { AssetBalances } from './assetBalances'
 import { NotEnoughFundsError } from './errors'
@@ -49,6 +50,7 @@ import { validateAccount } from './validator'
 import { AssetValue } from './walletdb/assetValue'
 import { DecryptedNoteValue } from './walletdb/decryptedNoteValue'
 import { HeadValue } from './walletdb/headValue'
+import { TransactionValue } from './walletdb/transactionValue'
 import { WalletDB } from './walletdb/walletdb'
 
 export enum AssetStatus {


### PR DESCRIPTION
## Summary

Adds the ability to add notes to the CLI command 
Some behavior improvements on the RPC side

Reasoning: If the user provides notes, we want to use those notes and those notes only. We don't want to select other notes to construct the transaction (which is what we do now). We chose other notes in these two cases: 

1. If the provided notes are spent 
2. If the provided notes are not of sufficient quantity to create the transaction

## Testing Plan

Unit tests (being written)

Manual testing. Some examples:
Passing a note that is spent:  
<img width="1025" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/b0a02725-2a71-4598-98d0-64c1b7a0e19d">

Passing a note for another asset: 
<img width="1034" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/15cab35c-d43d-48c2-8e99-3502562adc91">

Multi asset notes selected: 
<img width="1027" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/3a98849d-e772-4c51-8390-d745ab7175a3">

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
