### PR TITLE
adding ability to select notes in the transaction send command

### DIFF
--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -90,6 +90,11 @@ export class Send extends IronfishCommand {
       default: false,
       description: 'Allow offline transaction creation',
     }),
+    notes: Flags.string({
+      char: 'n',
+      description: 'The notes to include in the transaction',
+      multiple: true,
+    }),
   }
 
   async start(): Promise<void> {
@@ -189,6 +194,7 @@ export class Send extends IronfishCommand {
       feeRate: flags.feeRate ? CurrencyUtils.encode(flags.feeRate) : null,
       expiration: flags.expiration,
       confirmations: flags.confirmations,
+      notes: flags.notes,
     }
 
     let raw: RawTransaction

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -90,9 +90,9 @@ export class Send extends IronfishCommand {
       default: false,
       description: 'Allow offline transaction creation',
     }),
-    notes: Flags.string({
+    note: Flags.string({
       char: 'n',
-      description: 'The notes to include in the transaction',
+      description: 'The note hashes to include in the transaction',
       multiple: true,
     }),
   }
@@ -194,7 +194,7 @@ export class Send extends IronfishCommand {
       feeRate: flags.feeRate ? CurrencyUtils.encode(flags.feeRate) : null,
       expiration: flags.expiration,
       confirmations: flags.confirmations,
-      notes: flags.notes,
+      notes: flags.note,
     }
 
     let raw: RawTransaction


### PR DESCRIPTION
## Summary

Add ability to send notes in the transaction command.

After a lot of back and forth with these PRs (https://github.com/iron-fish/ironfish/pull/4464 and https://github.com/iron-fish/ironfish/pull/4459), I decided it was best to at least get this out there for our users and work on more UX improvements including warnings for larger transactions in subsequent PRs. 

## Testing Plan

Manual testing. 

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
