### PR TITLE
Rahul/ifl 1848 combine notes command

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -62,7 +62,7 @@ export class CombineNotesCommand extends IronfishCommand {
   }> {
     const timeTakenPerNote = await this.measureNotesPostTransaction(client)
 
-    const minTime = 60000 // 1 minute
+    const minTime = 60000
 
     const notesInMaxTime = Math.floor(minTime / timeTakenPerNote)
 
@@ -131,6 +131,10 @@ export class CombineNotesCommand extends IronfishCommand {
 
     const totalTime = BenchUtils.end(start)
 
+    /**
+     * After some testing, I added this factor to account for the time taken to post and broadcast
+     * the transaction and the time taken to broadcast the transaction
+     */
     const FACTOR = 10
 
     return (totalTime / numberOfNotes) * FACTOR

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -40,6 +40,10 @@ export class CombineNotesCommand extends IronfishCommand {
       minimum: 1n,
       flagName: 'fee rate',
     }),
+    memo: Flags.string({
+      char: 'm',
+      description: 'The memo of transaction',
+    }),
     confirm: Flags.boolean({
       default: false,
       description: 'Confirm without asking',
@@ -403,7 +407,9 @@ export class CombineNotesCommand extends IronfishCommand {
 
     const amount = notes.reduce((acc, note) => acc + BigInt(note.value), 0n)
 
-    const memo = await CliUx.ux.prompt('Enter the memo (or leave blank)', { required: false })
+    const memo =
+      flags.memo?.trim() ??
+      (await CliUx.ux.prompt('Enter the memo (or leave blank)', { required: false }))
 
     const expiration = await this.calculateExpiration(client, spendPostTime, numberOfNotes)
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -185,7 +185,8 @@ export class CombineNotesCommand extends IronfishCommand {
         return 1
       })
 
-    if (notes.length < 2) {
+    // must have at least three notes so that you can combine 2 and use another for fees
+    if (notes.length < 3) {
       this.log(`Your notes are already combined. You currently have ${notes.length} notes.`)
       this.exit(0)
     }

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -88,7 +88,7 @@ export class CombineNotesCommand extends IronfishCommand {
     currentBlockIndex: number,
   ): Promise<number> {
     CliUx.ux.action.start(
-      'Performing a 1-time benchmark to determine how many notes can be combined. This may take a few minutes...',
+      'Performing a 1-time benchmark to determine how many notes can be combined at a time. This may take a few minutes...',
     )
 
     const publicKey = (

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -109,11 +109,15 @@ export class CombineNotesCommand extends IronfishCommand {
     ])
 
     if (result.selection == null) {
-      const numberOfNotes = parseInt(
-        await CliUx.ux.prompt('Enter the number of notes', {
-          required: true,
-        }),
-      )
+      const promptResult = await CliUx.ux.prompt('Enter the number of notes', {
+        required: true,
+      })
+
+      if (isNaN(parseInt(promptResult))) {
+        this.error(`The number of notes must be a number`)
+      }
+
+      const numberOfNotes = parseInt(promptResult)
 
       if (numberOfNotes > high) {
         this.error(`The number of notes cannot be higher than the ${high}`)

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -340,7 +340,7 @@ export class CombineNotesCommand extends IronfishCommand {
     return expiration
   }
 
-  private async getNoteSize(client: RpcClient) {
+  private async getNoteTreeSize(client: RpcClient) {
     const getCurrentBlock = await client.chain.getChainInfo()
 
     const currentBlockSequence = parseInt(getCurrentBlock.content.currentBlockIdentifier.index)
@@ -392,7 +392,8 @@ export class CombineNotesCommand extends IronfishCommand {
       to = response.content.publicKey
     }
 
-    const noteSize = await this.getNoteSize(client)
+    // the confirmation range in the merkle tree for notes that are safe to use
+    const noteSize = await this.getNoteTreeSize(client)
 
     const spendPostTime = await this.getSpendPostTimeInMs(client, from, noteSize)
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -293,29 +293,30 @@ export class CombineNotesCommand extends IronfishCommand {
 
     const client = await this.sdk.connectRpc()
 
-    const getDefaultAccountResponse = await client.wallet.getDefaultAccount()
-    if (!getDefaultAccountResponse.content.account) {
-      this.error(
-        `No account is currently active.
-         Use ironfish wallet:create <name> to first create an account`,
-      )
-    }
-
     const [blockIndex, currentBlockSequence] = await this.getBlockIndex(client)
 
-    const defaultAccountName = getDefaultAccountResponse.content.account.name
-
-    let to = flags.to?.trim()
-    let from = flags.account?.trim()
+    let to = flags.to
+    let from = flags.account
 
     if (!from) {
-      from = defaultAccountName
+      const response = await client.wallet.getDefaultAccount()
+
+      if (!response.content.account) {
+        this.error(
+          `No account is currently active.
+          Use ironfish wallet:create <name> to first create an account`,
+        )
+      }
+
+      from = response.content.account.name
     }
+
     if (!to) {
-      const response1 = await client.wallet.getAccountPublicKey({
+      const response = await client.wallet.getAccountPublicKey({
         account: from,
       })
-      to = response1.content.publicKey
+
+      to = response.content.publicKey
     }
 
     const [noteSelectionOptions, timeToCombineOneNote] = await this.getCombineNoteOptions(

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -392,6 +392,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     Assert.isNotNull(getBlockResponse.content.block.noteSize)
 
+    // Adding a buffer to avoid a mismatch between confirmations used to load notes and confirmations used when creating witnesses to spend them
     const currentBlockIndex = getBlockResponse.content.block.noteSize - 2
     return currentBlockIndex
   }

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -64,9 +64,9 @@ export class CombineNotesCommand extends IronfishCommand {
     average: number
     high: number
   }> {
-    // const config = await client.config.getConfig()
+    const config = await client.config.getConfig()
 
-    let minNotesToCombine = undefined // config.content.minNotesToCombine
+    let minNotesToCombine = config.content.minNotesToCombine
 
     if (minNotesToCombine === undefined || minNotesToCombine <= 0) {
       const timeTakenPerNote = await this.benchmarkTransactionPerformance(

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -12,7 +12,6 @@ import {
   Transaction,
 } from '@ironfish/sdk'
 import { CliUx, Flags } from '@oclif/core'
-import { writeFileSync } from 'fs'
 import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { IronFlag, RemoteFlags } from '../../../flags'
@@ -256,8 +255,6 @@ export class CombineNotesCommand extends IronfishCommand {
         },
       })
     ).content.notes
-
-    writeFileSync('/Users/patni/notes.json', JSON.stringify(notes, null, 2))
 
     if (notes.length < 2) {
       this.error(

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -62,16 +62,12 @@ export class CombineNotesCommand extends IronfishCommand {
   }> {
     let timeToSendOneNote = this.sdk.internal.get('timeToSendOneNote')
 
-    console.log(timeToSendOneNote)
-
     if (timeToSendOneNote <= 0) {
       timeToSendOneNote = await this.benchmarkTimeToSendOneNote(
         client,
         account,
         currentBlockIndex,
       )
-
-      console.log('timeToSendOneNote: ' + timeToSendOneNote.toString())
 
       this.sdk.internal.set('timeToSendOneNote', timeToSendOneNote)
       await this.sdk.internal.save()

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -19,7 +19,7 @@ import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { IronFlag, RemoteFlags } from '../../../flags'
 import { selectFee } from '../../../utils/fees'
-import { watchTransaction } from '../../../utils/transaction'
+import { displayTransactionSummary, watchTransaction } from '../../../utils/transaction'
 
 export class CombineNotesCommand extends IronfishCommand {
   static description = `Combine notes into a single note`
@@ -350,7 +350,7 @@ export class CombineNotesCommand extends IronfishCommand {
       raw = RawTransactionSerde.deserialize(bytes)
     }
 
-    this.renderTransactionSummary(raw, Asset.nativeId().toString('hex'), amount, from, to, memo)
+    displayTransactionSummary(raw, Asset.nativeId().toString('hex'), amount, from, to, memo)
 
     if (!(await CliUx.ux.confirm('Do you confirm (Y/N)?'))) {
       this.error('Transaction aborted.')
@@ -460,30 +460,5 @@ export class CombineNotesCommand extends IronfishCommand {
     const getCurrentBlock = await client.chain.getChainInfo()
     const currentBlockSequence = parseInt(getCurrentBlock.content.currentBlockIdentifier.index)
     return currentBlockSequence
-  }
-
-  renderTransactionSummary(
-    transaction: RawTransaction,
-    assetId: string,
-    amount: bigint,
-    from: string,
-    to: string,
-    memo: string,
-  ): void {
-    const amountString = CurrencyUtils.renderIron(amount, true, assetId)
-    const feeString = CurrencyUtils.renderIron(transaction.fee, true)
-
-    const summary = `\
-\nTRANSACTION DETAILS:
-From                 ${from}
-To                   ${to}
-Amount               ${amountString}
-Fee                  ${feeString}
-Memo                 ${memo}
-Outputs              ${transaction.outputs.length}
-Notes Combined       ${transaction.spends.length} (includes 1 or more notes for the fee)
-Expiration           ${transaction.expiration ? transaction.expiration.toString() : ''}
-`
-    this.log(summary)
   }
 }

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -44,6 +44,9 @@ export class CombineNotesCommand extends IronfishCommand {
       char: 'm',
       description: 'The memo of transaction',
     }),
+    notes: Flags.integer({
+      description: 'How many notes to combine',
+    }),
     confirm: Flags.boolean({
       default: false,
       description: 'Confirm without asking',
@@ -393,7 +396,11 @@ export class CombineNotesCommand extends IronfishCommand {
 
     const spendPostTime = await this.getSpendPostTimeInMs(client, from, noteSize)
 
-    let numberOfNotes = await this.selectNotesToCombine(spendPostTime)
+    let numberOfNotes = flags.notes
+
+    if (numberOfNotes === undefined) {
+      numberOfNotes = await this.selectNotesToCombine(spendPostTime)
+    }
 
     let notes = await this.fetchNotes(client, from, noteSize, numberOfNotes)
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
 import {
+  Assert,
   BenchUtils,
   CreateTransactionRequest,
   CurrencyUtils,
@@ -254,12 +255,7 @@ export class CombineNotesCommand extends IronfishCommand {
     })
     const currentBlockIndex = getBlockResponse.content.block.noteSize
 
-    console.log('currentBlockIndex', currentBlockIndex)
-    if (!currentBlockIndex) {
-      this.error(
-        `The current block index is not available. Please wait for the next block to be mined`,
-      )
-    }
+    Assert.isNotNull(currentBlockIndex)
 
     const defaultAccountName = getDefaultAccountResponse.content.account.name
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -253,9 +253,10 @@ export class CombineNotesCommand extends IronfishCommand {
     const getBlockResponse = await client.chain.getBlock({
       sequence: currentBlockSequence,
     })
-    const currentBlockIndex = getBlockResponse.content.block.noteSize
 
-    Assert.isNotNull(currentBlockIndex)
+    Assert.isNotNull(getBlockResponse.content.block.noteSize)
+
+    const currentBlockIndex = getBlockResponse.content.block.noteSize - 2
 
     const defaultAccountName = getDefaultAccountResponse.content.account.name
 
@@ -302,6 +303,8 @@ export class CombineNotesCommand extends IronfishCommand {
         `You must have at least 2 notes to combine. You currently have ${notes.length} notes`,
       )
     }
+
+    console.log(`You currently have ${notes.length} notes`)
 
     if (notes.length < noteSelectionOptions.low) {
       noteSelectionOptions.low = notes.length - 1

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -116,7 +116,6 @@ export class CombineNotesCommand extends IronfishCommand {
       )
 
       if (numberOfNotes > high) {
-        // TODO: throw error
         this.error(`The number of notes cannot be higher than the ${high}`)
       }
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -40,6 +40,10 @@ export class CombineNotesCommand extends IronfishCommand {
       minimum: 1n,
       flagName: 'fee rate',
     }),
+    confirm: Flags.boolean({
+      default: false,
+      description: 'Confirm without asking',
+    }),
     watch: Flags.boolean({
       default: false,
       description: 'Wait for the transaction to be confirmed',
@@ -441,9 +445,11 @@ export class CombineNotesCommand extends IronfishCommand {
         hideMilliseconds: true,
       })}`,
     )
-
-    if (!(await CliUx.ux.confirm('Do you confirm (Y/N)?'))) {
-      this.error('Transaction aborted.')
+    if (!flags.confirm) {
+      const confirmed = await CliUx.ux.confirm('Do you confirm (Y/N)?')
+      if (!confirmed) {
+        this.error('Transaction aborted.')
+      }
     }
 
     const progressBar = CliUx.ux.progress({

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -85,8 +85,6 @@ export class CombineNotesCommand extends IronfishCommand {
   }
 
   async benchmarkTransactionPerformance(client: RpcClient, account: string): Promise<number> {
-    await Promise.resolve()
-
     const getNotesResponse = await client.wallet.getNotes({
       pageSize: 10,
       filter: {

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -197,7 +197,7 @@ export class CombineNotesCommand extends IronfishCommand {
   }
 
   private async selectNotesToCombine(spendPostTimeMs: number): Promise<number> {
-    const spendsPerMinute = Math.max(Math.floor(60000 / spendPostTimeMs), 1) // minimum of 1 note per minute in case the spentPostTime is very high
+    const spendsPerMinute = Math.max(Math.floor(60000 / spendPostTimeMs), 2) // minimum of 2 notes per minute in case the spentPostTime is very high
 
     const low = spendsPerMinute
     const medium = spendsPerMinute * 5

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -275,7 +275,7 @@ export class CombineNotesCommand extends IronfishCommand {
       }
 
       if (notesToCombine < 2) {
-        this.logger.error(`The number of notes cannot be lower than 2`)
+        this.logger.error(`The number must be larger than 1`)
         continue
       }
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -95,7 +95,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     const notes = await this.fetchNotes(client, account, noteSize, 10)
 
-    CliUx.ux.action.start('Calculating the number of notes to combine')
+    CliUx.ux.action.start('Measuring time to combine 1 note')
 
     const feeRates = await client.wallet.estimateFeeRates()
 
@@ -148,7 +148,7 @@ export class CombineNotesCommand extends IronfishCommand {
         3,
     )
 
-    CliUx.ux.action.stop()
+    CliUx.ux.action.stop(TimeUtils.renderSpan(delta))
 
     return delta
   }

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -436,8 +436,13 @@ export class CombineNotesCommand extends IronfishCommand {
 
     const averageBlockTimeInMs = timeLastFiveBlocksInMs / 5
 
+    const targetBlockTimeInMs =
+      (await client.chain.getConsensusParameters()).content.targetBlockTimeInSeconds * 1000
+
+    const blockTimeForCalculation = Math.min(averageBlockTimeInMs, targetBlockTimeInMs)
+
     const expiration = Math.ceil(
-      currentBlockSequence + (spendPostTimeInMs * numberOfNotes * 1.5) / averageBlockTimeInMs, // * 1.5 added to account for the time it takes to calculate fees
+      currentBlockSequence + (spendPostTimeInMs * numberOfNotes * 2) / blockTimeForCalculation, // * 2 added to account for the time it takes to calculate fees
     )
 
     return expiration

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -279,16 +279,9 @@ export class CombineNotesCommand extends IronfishCommand {
       )
     }
 
-    if (notes.length < noteSelectionOptions.low) {
-      noteSelectionOptions.low = notes.length - 1
-      noteSelectionOptions.average = notes.length - 1
-      noteSelectionOptions.high = notes.length - 1
-    } else if (notes.length < noteSelectionOptions.average) {
-      noteSelectionOptions.average = notes.length - 1
-      noteSelectionOptions.high = notes.length - 1
-    } else if (notes.length < noteSelectionOptions.high) {
-      noteSelectionOptions.high = notes.length - 1
-    }
+    noteSelectionOptions.low = Math.min(notes.length - 1, noteSelectionOptions.low)
+    noteSelectionOptions.average = Math.min(notes.length - 1, noteSelectionOptions.average)
+    noteSelectionOptions.high = Math.min(notes.length - 1, noteSelectionOptions.high)
 
     const numberOfNotes = await this.selectNumberOfNotes(noteSelectionOptions)
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -19,7 +19,6 @@ import { IronFlag, RemoteFlags } from '../../../flags'
 import { selectFee } from '../../../utils/fees'
 import { watchTransaction } from '../../../utils/transaction'
 
-const { sort: _ } = CliUx.ux.table.flags()
 export class CombineNotesCommand extends IronfishCommand {
   static description = `Display the account notes`
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -112,13 +112,16 @@ export class CombineNotesCommand extends IronfishCommand {
       const numberOfNotes = parseInt(
         await CliUx.ux.prompt('Enter the number of notes', {
           required: true,
-          type: 'number',
         }),
       )
 
       if (numberOfNotes > high) {
         // TODO: throw error
         this.error(`The number of notes cannot be higher than the ${high}`)
+      }
+
+      if (numberOfNotes < 1) {
+        this.error(`The number of notes cannot be lower than 1`)
       }
 
       return numberOfNotes

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -433,7 +433,7 @@ export class CombineNotesCommand extends IronfishCommand {
     const averageBlockTimeInMs = timeLastFiveBlocksInMs / 5
 
     const expiration = Math.ceil(
-      currentBlockSequence + (spendPostTimeInMs * numberOfNotes * 2) / averageBlockTimeInMs,
+      currentBlockSequence + (spendPostTimeInMs * numberOfNotes * 1.5) / averageBlockTimeInMs, // * 1.5 added to account for the time it takes to calculate fees
     )
 
     return expiration

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -168,15 +168,15 @@ export class CombineNotesCommand extends IronfishCommand {
     // the + 1 is to account for the note that will be used for the fee
     const choices = [
       {
-        name: `Low (${low + 1} notes) ~1 minute`,
+        name: `Low (${low} notes) ~1 minute`,
         value: low,
       },
       {
-        name: `Average (${average + 1} notes) ~5 minutes`,
+        name: `Average (${average} notes) ~5 minutes`,
         value: average,
       },
       {
-        name: `High (${high + 1} notes) ~10 minutes`,
+        name: `High (${high} notes) ~10 minutes`,
         value: high,
       },
       {
@@ -216,7 +216,7 @@ export class CombineNotesCommand extends IronfishCommand {
       }
 
       // accounting for the fee note
-      return numberOfNotes - 1
+      return numberOfNotes
     }
 
     return result.selection
@@ -279,13 +279,19 @@ export class CombineNotesCommand extends IronfishCommand {
       )
     }
 
+    // -1 because we want to leave a note for the transaction fee
     noteSelectionOptions.low = Math.min(notes.length - 1, noteSelectionOptions.low)
     noteSelectionOptions.average = Math.min(notes.length - 1, noteSelectionOptions.average)
     noteSelectionOptions.high = Math.min(notes.length - 1, noteSelectionOptions.high)
 
     const numberOfNotes = await this.selectNumberOfNotes(noteSelectionOptions)
 
-    const notesToCombine = notes.slice(0, numberOfNotes)
+    const notesToCombine = notes.slice(0, numberOfNotes).sort((a, b) => {
+      if (a.value < b.value) {
+        return -1
+      }
+      return 1
+    })
 
     const amount = notesToCombine.reduce((acc, note) => acc + BigInt(note.value), 0n)
     for (const note of notesToCombine) {
@@ -411,7 +417,7 @@ Amount               ${amountString}
 Fee                  ${feeString}
 Memo                 ${memo}
 Outputs              ${transaction.outputs.length}
-Notes Combined       ${transaction.spends.length} 
+Notes Combined       ${transaction.spends.length} (includes 1 or more notes for the fee)
 Expiration           ${transaction.expiration ? transaction.expiration.toString() : ''}
 `
     this.log(summary)

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -57,16 +57,16 @@ export class CombineNotesCommand extends IronfishCommand {
     account: string,
     noteSize: number,
   ): Promise<number> {
-    let timeToSendOneNoteInMs = this.sdk.internal.get('timeToSendOneNoteInMs')
+    let spendPostTime = this.sdk.internal.get('spendPostTime')
 
-    if (timeToSendOneNoteInMs <= 0) {
-      timeToSendOneNoteInMs = await this.benchmarkTimeToSendOneNote(client, account, noteSize)
+    if (spendPostTime <= 0) {
+      spendPostTime = await this.benchmarkTimeToSendOneNote(client, account, noteSize)
 
-      this.sdk.internal.set('timeToSendOneNoteInMs', timeToSendOneNoteInMs)
+      this.sdk.internal.set('spendPostTime', spendPostTime)
       await this.sdk.internal.save()
     }
 
-    return timeToSendOneNoteInMs
+    return spendPostTime
   }
 
   async benchmarkTimeToSendOneNote(

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -452,25 +452,20 @@ export class CombineNotesCommand extends IronfishCommand {
 
     const startTime = Date.now()
 
-    const startTimer = () => {
-      const timerInterval = setInterval(() => {
-        const durationInMs = Date.now() - startTime
-        const timeRemaining = estimateInMs - durationInMs
-        const progress = Math.round((durationInMs / estimateInMs) * 100)
-
-        progressBar.update(progress, {
-          estimate: TimeUtils.renderSpan(timeRemaining, { hideMilliseconds: true }),
-        })
-      }, 1000)
-
-      return timerInterval
-    }
-
     progressBar.start(100, 0, {
       title: 'Sending the transaction',
       estimate: TimeUtils.renderSpan(estimateInMs, { hideMilliseconds: true }),
     })
-    const timer = startTimer()
+
+    const timer = setInterval(() => {
+      const durationInMs = Date.now() - startTime
+      const timeRemaining = estimateInMs - durationInMs
+      const progress = Math.round((durationInMs / estimateInMs) * 100)
+
+      progressBar.update(progress, {
+        estimate: TimeUtils.renderSpan(timeRemaining, { hideMilliseconds: true }),
+      })
+    }, 1000)
 
     const response = await client.wallet.postTransaction({
       transaction: RawTransactionSerde.serialize(raw).toString('hex'),

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -386,6 +386,7 @@ export class CombineNotesCommand extends IronfishCommand {
       await watchTransaction({
         client,
         logger: this.logger,
+        account: from,
         hash: transaction.hash().toString('hex'),
       })
     }

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -64,11 +64,9 @@ export class CombineNotesCommand extends IronfishCommand {
     average: number
     high: number
   }> {
-    const config = await client.config.getConfig()
+    let minNotesToCombine = this.sdk.internal.get('minNotesToCombine')
 
-    let minNotesToCombine = config.content.minNotesToCombine
-
-    if (minNotesToCombine === undefined || minNotesToCombine <= 0) {
+    if (minNotesToCombine <= 1) {
       const timeTakenPerNote = await this.benchmarkTransactionPerformance(
         client,
         account,

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -20,7 +20,7 @@ import { selectFee } from '../../../utils/fees'
 import { watchTransaction } from '../../../utils/transaction'
 
 export class CombineNotesCommand extends IronfishCommand {
-  static description = `Display the account notes`
+  static description = `Combine notes into a single note`
 
   static flags = {
     ...RemoteFlags,

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -384,8 +384,11 @@ export class CombineNotesCommand extends IronfishCommand {
 
     Assert.isNotNull(getBlockResponse.content.block.noteSize)
 
+    const config = await client.config.getConfig()
+
     // Adding a buffer to avoid a mismatch between confirmations used to load notes and confirmations used when creating witnesses to spend them
-    const currentBlockIndex = getBlockResponse.content.block.noteSize - 2
+    const currentBlockIndex =
+      getBlockResponse.content.block.noteSize - (config.content.confirmations || 2)
     return currentBlockIndex
   }
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -292,7 +292,7 @@ export class CombineNotesCommand extends IronfishCommand {
     )
 
     for (let i = 0; i < 5; i++) {
-      const block = new Date(
+      const blockTime = new Date(
         (
           await client.chain.getBlock({
             sequence: currentBlockSequence - i,
@@ -300,9 +300,9 @@ export class CombineNotesCommand extends IronfishCommand {
         ).content.block.timestamp,
       )
 
-      timeLastFiveBlocksInMs += currentBlockTime.getTime() - block.getTime()
+      timeLastFiveBlocksInMs += currentBlockTime.getTime() - blockTime.getTime()
 
-      currentBlockTime = block
+      currentBlockTime = blockTime
     }
 
     const averageBlockTimeInMs = timeLastFiveBlocksInMs / 5

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -60,10 +60,10 @@ export class CombineNotesCommand extends IronfishCommand {
     average: number
     high: number
   }> {
-    const timeToPostOneNote = this.sdk.internal.get('timeToPostOneNote')
+    let timeToSendOneNote = this.sdk.internal.get('timeToSendOneNote')
 
-    if (timeToPostOneNote <= 0) {
-      const timeToPostOneNote = await this.benchmarkTransactionPerformance(
+    if (timeToSendOneNote <= 0) {
+      timeToSendOneNote = await this.benchmarkTimeToSendOneNote(
         client,
         account,
         currentBlockIndex,
@@ -71,12 +71,12 @@ export class CombineNotesCommand extends IronfishCommand {
 
       await client.config.setConfig({
         name: 'timeToPostOneNote',
-        value: timeToPostOneNote,
+        value: timeToSendOneNote,
       })
     }
 
     const minTime = 60000
-    const minNotesToCombine = Math.floor(minTime / timeToPostOneNote)
+    const minNotesToCombine = Math.floor(minTime / timeToSendOneNote)
 
     return {
       low: minNotesToCombine,

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -64,22 +64,23 @@ export class CombineNotesCommand extends IronfishCommand {
     average: number
     high: number
   }> {
-    let minNotesToCombine = this.sdk.internal.get('minNotesToCombine')
+    const timeToPostOneNote = this.sdk.internal.get('timeToPostOneNote')
 
-    if (minNotesToCombine <= 1) {
-      const timeTakenPerNote = await this.benchmarkTransactionPerformance(
+    if (timeToPostOneNote <= 0) {
+      const timeToPostOneNote = await this.benchmarkTransactionPerformance(
         client,
         account,
         currentBlockIndex,
       )
-      const minTime = 60000
-      minNotesToCombine = Math.floor(minTime / timeTakenPerNote)
 
       await client.config.setConfig({
-        name: 'minNotesToCombine',
-        value: minNotesToCombine,
+        name: 'timeToPostOneNote',
+        value: timeToPostOneNote,
       })
     }
+
+    const minTime = 60000
+    const minNotesToCombine = Math.floor(minTime / timeToPostOneNote)
 
     return {
       low: minNotesToCombine, // roughly 1 minute

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -304,8 +304,6 @@ export class CombineNotesCommand extends IronfishCommand {
       )
     }
 
-    console.log(`You currently have ${notes.length} notes`)
-
     if (notes.length < noteSelectionOptions.low) {
       noteSelectionOptions.low = notes.length - 1
       noteSelectionOptions.average = notes.length - 1

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -25,10 +25,6 @@ export class CombineNotesCommand extends IronfishCommand {
 
   static flags = {
     ...RemoteFlags,
-    confirm: Flags.boolean({
-      default: false,
-      description: 'Confirm without asking',
-    }),
     fee: IronFlag({
       char: 'o',
       description: 'The fee amount in IRON',
@@ -343,9 +339,9 @@ export class CombineNotesCommand extends IronfishCommand {
       raw = RawTransactionSerde.deserialize(bytes)
     }
 
-    this.renderTransactionSummary(raw, ironAssetId, amount, from, to, memo)
+    this.renderTransactionSummary(raw, Asset.nativeId().toString('hex'), amount, from, to, memo)
 
-    if (!flags.confirm && !(await CliUx.ux.confirm('Do you confirm (Y/N)?'))) {
+    if (!(await CliUx.ux.confirm('Do you confirm (Y/N)?'))) {
       this.error('Transaction aborted.')
     }
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -119,7 +119,6 @@ export class CombineNotesCommand extends IronfishCommand {
       notes: [notes[0].noteHash, notes[1].noteHash],
     }
 
-    const start = BenchUtils.start()
     const promisesTxn1 = []
     const promisesTxn2 = []
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -83,9 +83,9 @@ export class CombineNotesCommand extends IronfishCommand {
     const minNotesToCombine = Math.floor(minTime / timeToPostOneNote)
 
     return {
-      low: minNotesToCombine, // roughly 1 minute
-      average: minNotesToCombine * 3, // roughly 5 minutes with some buffer
-      high: minNotesToCombine * 7, // roughly 10 minutes with some buffer
+      low: minNotesToCombine,
+      average: minNotesToCombine * 5,
+      high: minNotesToCombine * 10,
     }
   }
 

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -16,7 +16,7 @@ import { HexFlag, IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
 import { selectFee } from '../../utils/fees'
-import { watchTransaction } from '../../utils/transaction'
+import { displayTransactionSummary, watchTransaction } from '../../utils/transaction'
 
 export class Send extends IronfishCommand {
   static description = `Send coins to another account`
@@ -95,33 +95,6 @@ export class Send extends IronfishCommand {
       description: 'The note hashes to include in the transaction',
       multiple: true,
     }),
-  }
-
-  renderTransactionSummary(
-    transaction: RawTransaction,
-    assetId: string,
-    amount: bigint,
-    from: string,
-    to: string,
-    memo: string,
-  ): void {
-    const amountString = CurrencyUtils.renderIron(amount, true, assetId)
-    const feeString = CurrencyUtils.renderIron(transaction.fee, true)
-
-    const summary = `\
-\nTRANSACTION DETAILS:
-From                 ${from}
-To                   ${to}
-Amount               ${amountString}
-Fee                  ${feeString}
-Memo                 ${memo}
-Outputs              ${transaction.outputs.length}
-Spends               ${transaction.spends.length}
-Expiration           ${transaction.expiration ? transaction.expiration.toString() : ''}
-Version              ${transaction.version}
-`
-
-    this.log(summary)
   }
 
   async start(): Promise<void> {
@@ -246,7 +219,7 @@ Version              ${transaction.version}
       this.exit(0)
     }
 
-    this.renderTransactionSummary(raw, assetId, amount, from, to, memo)
+    displayTransactionSummary(raw, assetId, amount, from, to, memo)
 
     if (!flags.confirm) {
       const confirmed = await CliUx.ux.confirm('Do you confirm (Y/N)?')

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -29,23 +29,25 @@ export async function selectFee(options: {
 
   const feeRates = await options.client.wallet.estimateFeeRates()
 
-  const [slow, average, fast] = [
-    await getTxWithFee(
+  const promises = [
+    getTxWithFee(
       options.client,
       options.transaction,
       CurrencyUtils.decode(feeRates.content.slow),
     ),
-    await getTxWithFee(
+    getTxWithFee(
       options.client,
       options.transaction,
       CurrencyUtils.decode(feeRates.content.average),
     ),
-    await getTxWithFee(
+    getTxWithFee(
       options.client,
       options.transaction,
       CurrencyUtils.decode(feeRates.content.fast),
     ),
   ]
+
+  const [slow, average, fast] = await Promise.all(promises)
 
   const choices = [
     getChoiceFromTx('Slow', slow),

--- a/ironfish-cli/src/utils/fees.ts
+++ b/ironfish-cli/src/utils/fees.ts
@@ -14,6 +14,7 @@ import {
   RpcClient,
   RpcRequestError,
 } from '@ironfish/sdk'
+import { CliUx } from '@oclif/core'
 import inquirer from 'inquirer'
 import { promptCurrency } from './currency'
 
@@ -24,6 +25,8 @@ export async function selectFee(options: {
   confirmations?: number
   logger: Logger
 }): Promise<RawTransaction> {
+  CliUx.ux.action.start('Calculating fees')
+
   const feeRates = await options.client.wallet.estimateFeeRates()
 
   const [slow, average, fast] = [
@@ -53,6 +56,8 @@ export async function selectFee(options: {
       value: null,
     },
   ]
+
+  CliUx.ux.action.stop()
 
   const result = await inquirer.prompt<{
     selection: RawTransaction | null

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -4,13 +4,43 @@
 
 import {
   createRootLogger,
+  CurrencyUtils,
   Logger,
   PromiseUtils,
+  RawTransaction,
   RpcClient,
   TimeUtils,
   TransactionStatus,
 } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
+
+export function displayTransactionSummary(
+  transaction: RawTransaction,
+  assetId: string,
+  amount: bigint,
+  from: string,
+  to: string,
+  memo: string,
+  logger?: Logger,
+): void {
+  logger = logger ?? createRootLogger()
+
+  const amountString = CurrencyUtils.renderIron(amount, true, assetId)
+  const feeString = CurrencyUtils.renderIron(transaction.fee, true)
+
+  const summary = `\
+\nTRANSACTION SUMMARY:
+From                 ${from}
+To                   ${to}
+Amount               ${amountString}
+Fee                  ${feeString}
+Memo                 ${memo}
+Outputs              ${transaction.outputs.length}
+Spends               ${transaction.spends.length}
+Expiration           ${transaction.expiration ? transaction.expiration.toString() : ''}
+`
+  logger.log(summary)
+}
 
 export async function watchTransaction(options: {
   client: Pick<RpcClient, 'wallet'>

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -113,11 +113,6 @@ export type ConfigOptions = {
   maxPeers: number
   minPeers: number
   /**
-   * The minimum notes to combine for the wallet:notes:combine command.
-   * This is calculated and is higher for machines with more processing power.
-   */
-  minNotesToCombine: number
-  /**
    * The ideal number of peers we'd like to be connected to. The node will attempt to
    * establish new connections when below this number.
    */
@@ -355,7 +350,6 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     rpcHttpPort: YupUtils.isPort,
     maxPeers: YupUtils.isPositiveInteger,
     minPeers: YupUtils.isPositiveInteger,
-    minNotesToCombine: yup.number().integer(),
     targetPeers: yup.number().integer().min(1),
     keepOpenPeerSlot: yup.boolean(),
     telemetryApi: yup.string(),
@@ -458,7 +452,6 @@ export class Config extends KeyStore<ConfigOptions> {
       maxPeers: DEFAULT_MAX_PEERS,
       confirmations: 2,
       minPeers: 1,
-      minNotesToCombine: 0,
       targetPeers: DEFAULT_TARGET_PEERS,
       keepOpenPeerSlot: DEFAULT_KEEP_OPEN_PEER_SLOT,
       telemetryApi: '',

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -113,6 +113,11 @@ export type ConfigOptions = {
   maxPeers: number
   minPeers: number
   /**
+   * The minimum notes to combine for the wallet:notes:combine command.
+   * This is calculated and is higher for machines with more processing power.
+   */
+  minNotesToCombine: number
+  /**
    * The ideal number of peers we'd like to be connected to. The node will attempt to
    * establish new connections when below this number.
    */
@@ -350,6 +355,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     rpcHttpPort: YupUtils.isPort,
     maxPeers: YupUtils.isPositiveInteger,
     minPeers: YupUtils.isPositiveInteger,
+    minNotesToCombine: yup.number().integer(),
     targetPeers: yup.number().integer().min(1),
     keepOpenPeerSlot: yup.boolean(),
     telemetryApi: yup.string(),
@@ -452,6 +458,7 @@ export class Config extends KeyStore<ConfigOptions> {
       maxPeers: DEFAULT_MAX_PEERS,
       confirmations: 2,
       minPeers: 1,
+      minNotesToCombine: 0,
       targetPeers: DEFAULT_TARGET_PEERS,
       keepOpenPeerSlot: DEFAULT_KEEP_OPEN_PEER_SLOT,
       telemetryApi: '',

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -12,6 +12,7 @@ export type InternalOptions = {
   rpcAuthToken: string
   networkId: number
   spendPostTime: number // in milliseconds
+  spendPostTimeAt: number // when the spend post time measurement was done
 }
 
 export const InternalOptionsDefaults: InternalOptions = {
@@ -21,6 +22,7 @@ export const InternalOptionsDefaults: InternalOptions = {
   rpcAuthToken: '',
   networkId: DEFAULT_NETWORK_ID,
   spendPostTime: 0,
+  spendPostTimeAt: 0,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -11,6 +11,7 @@ export type InternalOptions = {
   telemetryNodeId: string
   rpcAuthToken: string
   networkId: number
+  minNotesToCombine: number
 }
 
 export const InternalOptionsDefaults: InternalOptions = {
@@ -19,6 +20,7 @@ export const InternalOptionsDefaults: InternalOptions = {
   telemetryNodeId: '',
   rpcAuthToken: '',
   networkId: DEFAULT_NETWORK_ID,
+  minNotesToCombine: 1,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -11,7 +11,7 @@ export type InternalOptions = {
   telemetryNodeId: string
   rpcAuthToken: string
   networkId: number
-  timeToPostOneNote: number
+  timeToSendOneNote: number
 }
 
 export const InternalOptionsDefaults: InternalOptions = {
@@ -20,7 +20,7 @@ export const InternalOptionsDefaults: InternalOptions = {
   telemetryNodeId: '',
   rpcAuthToken: '',
   networkId: DEFAULT_NETWORK_ID,
-  timeToPostOneNote: 1,
+  timeToSendOneNote: 0,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -11,7 +11,7 @@ export type InternalOptions = {
   telemetryNodeId: string
   rpcAuthToken: string
   networkId: number
-  timeToSendOneNote: number
+  timeToSendOneNoteInMs: number
 }
 
 export const InternalOptionsDefaults: InternalOptions = {
@@ -20,7 +20,7 @@ export const InternalOptionsDefaults: InternalOptions = {
   telemetryNodeId: '',
   rpcAuthToken: '',
   networkId: DEFAULT_NETWORK_ID,
-  timeToSendOneNote: 0,
+  timeToSendOneNoteInMs: 0,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -11,7 +11,7 @@ export type InternalOptions = {
   telemetryNodeId: string
   rpcAuthToken: string
   networkId: number
-  timeToSendOneNoteInMs: number
+  spendPostTime: number // in milliseconds
 }
 
 export const InternalOptionsDefaults: InternalOptions = {
@@ -20,7 +20,7 @@ export const InternalOptionsDefaults: InternalOptions = {
   telemetryNodeId: '',
   rpcAuthToken: '',
   networkId: DEFAULT_NETWORK_ID,
-  timeToSendOneNoteInMs: 0,
+  spendPostTime: 0,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {

--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -11,7 +11,7 @@ export type InternalOptions = {
   telemetryNodeId: string
   rpcAuthToken: string
   networkId: number
-  minNotesToCombine: number
+  timeToPostOneNote: number
 }
 
 export const InternalOptionsDefaults: InternalOptions = {
@@ -20,7 +20,7 @@ export const InternalOptionsDefaults: InternalOptions = {
   telemetryNodeId: '',
   rpcAuthToken: '',
   networkId: DEFAULT_NETWORK_ID,
-  minNotesToCombine: 1,
+  timeToPostOneNote: 1,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {


### PR DESCRIPTION
## Summary

Adds a new command CLI command - `ironfish wallet:notes:combine`

Problem: Miners transactions are stuck because they are using too many notes when sending a transaction. The transaction is not posted in time and usually expires (or they have to crank up the expiration and wait a very long time to post). Waiting a long time is also inconvenient because you cannot use your funds for other purposes. 

Goal: We want the miners to combine as many notes possible in a reasonable time. They can re-run this operation to combine as many notes as they like. They can then specifically choose these notes in their next transaction using the `--note` flag in the `wallet:send` command. 

This PR introduces a CLI command to combine the notes the user owns into a single note. A benchmark is run to figure out how fast the users machine is when posting notes. This benchmark is used to determine options for how long the user wants to run this operation (and therefore how many notes they would like to combine). 

<img width="661" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/50ca171d-fc66-42dd-bfce-5c6239dbd566">

The following flags are optional: 
- `o` iron fee 
- `r` fee rate 
- `watch` to watch the transaction 
- `t` recipient address
- `f` account

By default the default account's notes are combined and send to the same account. You can change the recipient and also the account from where the notes originate. 

This command creates a one-time benchmark for how fast a spend is posted. This is stored as an internal config value called `spendPostTime` in the config. 

Edge cases covered: 

1. If the users machine is slow and takes a long time to create spends, we default the minimum notes to combine to 2
2. If the user doesn't have any or less than 2 notes in their account
3. Expiration is calculated by taking into account how fast the blocks are processing (if the block times are shorter then we need to increase the expiration)
4. We filter out the notes that may not be confirmed yet 
5. We use the smallest notes received from the `getNotes` API to ensure that larger ones are selected for the fee

## Testing Plan

Manual testing: Testing using a slower (my personal windows) and faster machine. Testing with different internet speeds (30 mpbs to 1 gbps)

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
