### PR TITLE
Add warnings about a change to the RedDSA spec

### DIFF
--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -127,6 +127,11 @@ impl UnsignedMintDescription {
             return Err(IronfishError::new(IronfishErrorKind::InvalidSigningKey));
         }
 
+        // NOTE: The initial versions of the RedDSA specification and the redjubjub crate (that
+        // we're using here) require the public key bytes to be prefixed to the message. The latest
+        // version of the spec and the crate add the public key bytes automatically. Therefore, if
+        // in the future we upgrade to a newer version of redjubjub, `data_to_be_signed` will have
+        // to equal `signature_hash`
         let mut data_to_be_signed = [0; 64];
         data_to_be_signed[..32].copy_from_slice(&randomized_public_key.0.to_bytes());
         data_to_be_signed[32..].copy_from_slice(&signature_hash[..]);
@@ -179,6 +184,12 @@ impl MintDescription {
         if randomized_public_key.0.is_small_order().into() {
             return Err(IronfishError::new(IronfishErrorKind::IsSmallOrder));
         }
+
+        // NOTE: The initial versions of the RedDSA specification and the redjubjub crate (that
+        // we're using here) require the public key bytes to be prefixed to the message. The latest
+        // version of the spec and the crate add the public key bytes automatically. Therefore, if
+        // in the future we upgrade to a newer version of redjubjub, `data_to_be_signed` will have
+        // to equal `signature_hash_value`
         let mut data_to_be_signed = [0; 64];
         data_to_be_signed[..32].copy_from_slice(&randomized_public_key.0.to_bytes());
         data_to_be_signed[32..].copy_from_slice(&signature_hash_value[..]);

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -426,6 +426,11 @@ impl ProposedTransaction {
         public_key: &PublicKey,
         transaction_signature_hash: &[u8; 32],
     ) -> Result<Signature, IronfishError> {
+        // NOTE: The initial versions of the RedDSA specification and the redjubjub crate (that
+        // we're using here) require the public key bytes to be prefixed to the message. The latest
+        // version of the spec and the crate add the public key bytes automatically. Therefore, if
+        // in the future we upgrade to a newer version of redjubjub, `data_to_be_signed` will have
+        // to equal `transaction_signature_hash`
         let mut data_to_be_signed = [0u8; TRANSACTION_SIGNATURE_SIZE];
         data_to_be_signed[..TRANSACTION_PUBLIC_KEY_SIZE].copy_from_slice(&public_key.0.to_bytes());
         data_to_be_signed[TRANSACTION_PUBLIC_KEY_SIZE..]

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -174,6 +174,11 @@ impl UnsignedSpendDescription {
             return Err(IronfishError::new(IronfishErrorKind::InvalidSigningKey));
         }
 
+        // NOTE: The initial versions of the RedDSA specification and the redjubjub crate (that
+        // we're using here) require the public key bytes to be prefixed to the message. The latest
+        // version of the spec and the crate add the public key bytes automatically. Therefore, if
+        // in the future we upgrade to a newer version of redjubjub, `data_to_be_signed` will have
+        // to equal `signature_hash`
         let mut data_to_be_signed = [0; 64];
         data_to_be_signed[..TRANSACTION_PUBLIC_KEY_SIZE]
             .copy_from_slice(&transaction_randomized_public_key.0.to_bytes());
@@ -277,6 +282,12 @@ impl SpendDescription {
         if randomized_public_key.0.is_small_order().into() {
             return Err(IronfishError::new(IronfishErrorKind::IsSmallOrder));
         }
+
+        // NOTE: The initial versions of the RedDSA specification and the redjubjub crate (that
+        // we're using here) require the public key bytes to be prefixed to the message. The latest
+        // version of the spec and the crate add the public key bytes automatically. Therefore, if
+        // in the future we upgrade to a newer version of redjubjub, `data_to_be_signed` will have
+        // to equal `signature_hash_value`
         let mut data_to_be_signed = [0; 64];
         data_to_be_signed[..32].copy_from_slice(&randomized_public_key.0.to_bytes());
         data_to_be_signed[32..].copy_from_slice(&signature_hash_value[..]);


### PR DESCRIPTION
## Summary

The RedDSA specification (and the Rust crates that implement it) has slightly deviated from the code we're using. The changes make the signatures backward compatible, but the code we have written needs to change in order to be compatible. This commit adds some comments to the relevant code so that if in the future someone attempts to update the RedDSA crates, they won't have to spend hours to figure out what's wrong.

## Testing Plan

Not a code change

## Documentation

No doc change required

## Breaking Change

Not a breaking change