### PR TITLE
Rahul/ifl 1867 order by field in getnotes rpc

### DIFF
--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -89,7 +89,9 @@ routes.register<typeof GetNotesRequestSchema, GetNotesResponse>(
 
     if (
       request.data.sortByValue &&
-      (request.data.filter?.assetId === undefined || request.data.filter?.spent === true)
+      (request.data.filter?.assetId === undefined ||
+        request.data.filter?.spent === undefined ||
+        request.data.filter?.spent === true)
     ) {
       throw new Error('sortByValue requires assetId to be defined and spent to be false.')
     }

--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -28,6 +28,7 @@ type GetNotesRequestFilter = {
 }
 
 export type GetNotesRequest = {
+  sortByValue?: 'asc' | 'desc'
   account?: string
   pageSize?: number
   pageCursor?: string
@@ -41,6 +42,7 @@ export type GetNotesResponse = {
 
 export const GetNotesRequestSchema: yup.ObjectSchema<GetNotesRequest> = yup
   .object({
+    sortByValue: yup.string().oneOf(['asc', 'desc']).optional(),
     account: yup.string().trim(),
     pageSize: yup.number().min(1),
     pageCursor: yup.string(),

--- a/ironfish/src/rpc/routes/wallet/getNotes.ts
+++ b/ironfish/src/rpc/routes/wallet/getNotes.ts
@@ -87,12 +87,11 @@ routes.register<typeof GetNotesRequestSchema, GetNotesResponse>(
     const notes = []
     let nextPageCursor: Buffer | null = null
 
-    // is sortByValue is used, we need assetId to be defined and spent to be false
     if (
       request.data.sortByValue &&
       (request.data.filter?.assetId === undefined || request.data.filter?.spent === true)
     ) {
-      throw new Error('sortByValue requires assetId and spent to be defined.')
+      throw new Error('sortByValue requires assetId to be defined and spent to be false.')
     }
 
     const iterator =

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -104,12 +104,14 @@ export class Account {
 
   async *getSortedByValueNotes(
     orderBy: 'asc' | 'desc',
-    assetId: Buffer,
-    keyRange?: DatabaseKeyRange,
+    assetId: string,
   ): AsyncGenerator<DecryptedNoteValue & { hash: Buffer }> {
     const valueNoteHash = []
 
-    for await (const [value, noteHash] of this.walletDb.loadUnspentNoteValues(this, assetId)) {
+    for await (const [value, noteHash] of this.walletDb.loadUnspentNoteValues(
+      this,
+      Buffer.from(assetId, 'hex'),
+    )) {
       valueNoteHash.push({ value, noteHash })
     }
 
@@ -122,10 +124,7 @@ export class Account {
     })
 
     for (const { noteHash } of valueNoteHash) {
-      const decryptedNote = await this.getDecryptedNote(
-        noteHash,
-        keyRange ? undefined : undefined,
-      )
+      const decryptedNote = await this.getDecryptedNote(noteHash)
       if (decryptedNote) {
         yield { ...decryptedNote, hash: noteHash }
       }
@@ -1165,7 +1164,6 @@ export class Account {
     for await (const [value, _] of this.walletDb.loadUnspentNoteValues(
       this,
       assetId,
-      undefined,
       maxConfirmedSequence,
       tx,
     )) {

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -1132,7 +1132,7 @@ export class Account {
 
     const maxConfirmedSequence = Math.max(headSequence - confirmations, GENESIS_BLOCK_SEQUENCE)
 
-    for await (const value of this.walletDb.loadUnspentNoteValues(
+    for await (const [value, _] of this.walletDb.loadUnspentNoteValues(
       this,
       assetId,
       maxConfirmedSequence,

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -1135,6 +1135,7 @@ export class Account {
     for await (const [value, _] of this.walletDb.loadUnspentNoteValues(
       this,
       assetId,
+      undefined,
       maxConfirmedSequence,
       tx,
     )) {

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -132,7 +132,13 @@ export class Account {
     }
   }
 
-  async *getNotes(keyRange?: DatabaseKeyRange)
+  async *getNotes(
+    keyRange?: DatabaseKeyRange,
+  ): AsyncGenerator<DecryptedNoteValue & { hash: Buffer }> {
+    for await (const decryptedNote of this.walletDb.loadDecryptedNotes(this, keyRange)) {
+      yield decryptedNote
+    }
+  }
 
   async *getUnspentNotes(
     assetId: Buffer,

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -655,7 +655,7 @@ export class WalletDB {
     assetId: Buffer,
     sequence?: number,
     tx?: IDatabaseTransaction,
-  ): AsyncGenerator<bigint> {
+  ): AsyncGenerator<[bigint, Buffer]> {
     const encoding = new PrefixEncoding(
       BUFFER_ENCODING,
       new PrefixEncoding(BUFFER_ENCODING, U32_ENCODING_BE, 32),
@@ -669,11 +669,11 @@ export class WalletDB {
       encoding.serialize([account.prefix, [assetId, maxConfirmedSequence]]),
     )
 
-    for await (const [, [, [, [value, _]]]] of this.unspentNoteHashes.getAllKeysIter(
+    for await (const [, [, [, [value, noteHash]]]] of this.unspentNoteHashes.getAllKeysIter(
       tx,
       range,
     )) {
-      yield value
+      yield [value, noteHash]
     }
   }
 

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -653,8 +653,7 @@ export class WalletDB {
   async *loadUnspentNoteValues(
     account: Account,
     assetId: Buffer,
-    start?: number,
-    end?: number,
+    sequence?: number,
     tx?: IDatabaseTransaction,
   ): AsyncGenerator<[bigint, Buffer]> {
     const encoding = new PrefixEncoding(
@@ -663,11 +662,10 @@ export class WalletDB {
       4,
     )
 
-    const minConfirmedSequence = start ?? 1
-    const maxConfirmedSequence = end ?? 2 ** 32 - 1
+    const maxConfirmedSequence = sequence ?? 2 ** 32 - 1
 
     const range = getPrefixesKeyRange(
-      encoding.serialize([account.prefix, [assetId, minConfirmedSequence]]),
+      encoding.serialize([account.prefix, [assetId, 1]]),
       encoding.serialize([account.prefix, [assetId, maxConfirmedSequence]]),
     )
 

--- a/ironfish/src/wallet/walletdb/walletdb.ts
+++ b/ironfish/src/wallet/walletdb/walletdb.ts
@@ -653,7 +653,8 @@ export class WalletDB {
   async *loadUnspentNoteValues(
     account: Account,
     assetId: Buffer,
-    sequence?: number,
+    start?: number,
+    end?: number,
     tx?: IDatabaseTransaction,
   ): AsyncGenerator<[bigint, Buffer]> {
     const encoding = new PrefixEncoding(
@@ -662,10 +663,11 @@ export class WalletDB {
       4,
     )
 
-    const maxConfirmedSequence = sequence ?? 2 ** 32 - 1
+    const minConfirmedSequence = start ?? 1
+    const maxConfirmedSequence = end ?? 2 ** 32 - 1
 
     const range = getPrefixesKeyRange(
-      encoding.serialize([account.prefix, [assetId, 1]]),
+      encoding.serialize([account.prefix, [assetId, minConfirmedSequence]]),
       encoding.serialize([account.prefix, [assetId, maxConfirmedSequence]]),
     )
 


### PR DESCRIPTION
## Summary

Adding a sortByValue field to the getNotes RPC. Some design tradeoffs I made:

1. I used getNotes RPC instead of creating a new one because the filtering benefits we get will likely be useful in this context as well 
2. Two additional fields need to be explicitly defined `spent` and `assetId` because in order to use the existing `unspentNotes` index we have in the DB. This allows us to only load the noteHash and value (64 bytes) into memory for all notes. If we were to allow this sorting for all assets and regardless of spends would be inefficient and slow because we would have to load the entire set of notes into memory. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
