### PR TITLE
adding note combine rate to internal json

### DIFF
--- a/ironfish/src/fileStores/internal.ts
+++ b/ironfish/src/fileStores/internal.ts
@@ -11,6 +11,7 @@ export type InternalOptions = {
   telemetryNodeId: string
   rpcAuthToken: string
   networkId: number
+  noteCombineRate: number // notes to combine per minute based on the performance of the machine
 }
 
 export const InternalOptionsDefaults: InternalOptions = {
@@ -19,6 +20,7 @@ export const InternalOptionsDefaults: InternalOptions = {
   telemetryNodeId: '',
   rpcAuthToken: '',
   networkId: DEFAULT_NETWORK_ID,
+  noteCombineRate: 1,
 }
 
 export class InternalStore extends KeyStore<InternalOptions> {


### PR DESCRIPTION
## Summary

Adding an internal flag for how many notes to combine. This field is determined when the user runs the combine command and re-used when the user combines notes again. This computation can take time to run (around 60 seconds on slower machines) so that's why we're storing it to be reused. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
