### PR TITLE
Add ability to extend Config

### DIFF
--- a/ironfish/src/fileStores/config.test.ts
+++ b/ironfish/src/fileStores/config.test.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
+import { NodeFileProvider } from '../fileSystems'
+import { getUniqueTestDataDir } from '../testUtilities'
+import { Config } from './config'
+
+describe('Config', () => {
+  it('should load and save config', async () => {
+    const dir = getUniqueTestDataDir()
+    const files = await new NodeFileProvider().init()
+
+    let config = new Config(files, dir, {})
+    await config.load()
+    expect(config.isSet('miningForce')).toBe(false)
+
+    config.set('miningForce', true)
+    expect(config.isSet('miningForce')).toBe(true)
+
+    await config.save()
+    config = new Config(files, dir, {})
+    await config.load()
+
+    expect(config.isSet('miningForce')).toBe(true)
+    expect(config.get('miningForce')).toBe(true)
+  })
+
+  it('should let you extend config', async () => {
+    const dir = getUniqueTestDataDir()
+    const files = await new NodeFileProvider().init()
+
+    const extendDefaults = { bar: 5 }
+    const extendSchema = yup.object({ bar: yup.number() }).defined()
+
+    const config = new Config(files, dir, extendDefaults, undefined, extendSchema)
+    await config.load()
+
+    expect(config.isSet('bar')).toBe(false)
+    expect(config.get('bar')).toBe(5)
+
+    config.set('bar', 10)
+    expect(config.isSet('bar')).toBe(true)
+    await config.save()
+  })
+})

--- a/ironfish/src/mining/poolDatabase/database.test.ts
+++ b/ironfish/src/mining/poolDatabase/database.test.ts
@@ -21,7 +21,7 @@ describe('poolDatabase', () => {
     const fileSystem = new NodeFileProvider()
     await fileSystem.init()
     // TODO(mat): It would be convenient if we didn't need a filesystem for Config for tests
-    const config = new Config(fileSystem, dataDir)
+    const config = new Config(fileSystem, dataDir, {})
 
     db = await PoolDatabase.init({
       config,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -8,7 +8,6 @@ import { Blockchain } from './blockchain'
 import { TestnetConsensus } from './consensus'
 import {
   Config,
-  ConfigOptions,
   DEFAULT_DATA_DIR,
   InternalStore,
   PeerStore,
@@ -214,7 +213,7 @@ export class FullNode {
     dataDir = dataDir || DEFAULT_DATA_DIR
 
     if (!config) {
-      config = new Config(files, dataDir)
+      config = new Config(files, dataDir, {})
       await config.load()
     }
 
@@ -423,10 +422,7 @@ export class FullNode {
     void this.syncer.stop()
   }
 
-  async onConfigChange<Key extends keyof ConfigOptions>(
-    key: Key,
-    newValue: ConfigOptions[Key],
-  ): Promise<void> {
+  async onConfigChange(key: string, newValue: unknown): Promise<void> {
     switch (key) {
       case 'enableTelemetry': {
         if (newValue) {

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -106,7 +106,7 @@ export class IronfishSdk {
     logger = logger.withTag('ironfishsdk')
     dataDir = dataDir || DEFAULT_DATA_DIR
 
-    const config = new Config(fileSystem, dataDir, configName)
+    const config = new Config(fileSystem, dataDir, {}, configName)
     await config.load()
 
     const internal = new InternalStore(fileSystem, dataDir)

--- a/ironfish/src/utils/yup.test.ts
+++ b/ironfish/src/utils/yup.test.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as yup from 'yup'
 import { CurrencyUtils } from './currency'
 import { YupUtils } from './yup'
 
@@ -39,5 +40,13 @@ describe('YupUtils', () => {
       expect(YupUtils.currency().isValidSync('hello world')).toBe(false)
       expect(YupUtils.currency().isValidSync(0.00046)).toBe(false)
     })
+  })
+
+  it('union', () => {
+    const a = yup.object({ foo: yup.number() }).defined()
+    const b = yup.object({ bar: yup.number() }).defined()
+    const result = YupUtils.union(a, b)
+    expect(result.isValidSync({ foo: 'a', bar: 'b' })).toBe(false)
+    expect(result.isValidSync({ foo: 2, bar: 3 })).toBe(true)
   })
 })

--- a/ironfish/src/utils/yup.ts
+++ b/ironfish/src/utils/yup.ts
@@ -103,4 +103,20 @@ export class YupUtils {
       throw e
     }
   }
+
+  static union<
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    T extends object | null | undefined = object | undefined,
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    U extends object | null | undefined = object | undefined,
+  >(schema: yup.ObjectSchema<T>, append: yup.ObjectSchema<U>): yup.ObjectSchema<T & U> {
+    const result = yup
+      .object({
+        ...schema.fields,
+        ...append.fields,
+      })
+      .defined()
+
+    return result as yup.ObjectSchema<T & U>
+  }
 }


### PR DESCRIPTION
https://github.com/iron-fish/ironfish/pull/4475/files?diff=split&w=1

This allows you to extend Config with custom extended config types. It
does now require you to pass the extended defeults into the Config()
constructor even if you are not extending it for type reasons.

This makes the Config API slightly more burdensome to use but it's a
small price to pay. This also leads to a breaking compatability change in
the SDK in the case that third parties are creating a Config. I'll document
this in the release notes.