### PR TITLE
removes spender_key from ProposedTransaction

### DIFF
--- a/benchmarks/benches/transaction.rs
+++ b/benchmarks/benches/transaction.rs
@@ -24,12 +24,12 @@ pub fn simple(c: &mut Criterion) {
             },
             // Benchmark
             |(key, spend_note, witness, out_note)| {
-                let mut proposed = ProposedTransaction::new(key, TransactionVersion::latest());
+                let mut proposed = ProposedTransaction::new(TransactionVersion::latest());
 
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
 
-                let tx = proposed.post(None, 1).unwrap();
+                let tx = proposed.post(key, None, 1).unwrap();
 
                 assert_eq!(tx.spends().len(), 1);
                 assert_eq!(tx.outputs().len(), 1);
@@ -60,14 +60,14 @@ pub fn all_descriptions(c: &mut Criterion) {
             |(key, spend_note, witness, out_note, asset)| {
                 let asset_value = 10;
 
-                let mut proposed = ProposedTransaction::new(key, TransactionVersion::latest());
+                let mut proposed = ProposedTransaction::new(TransactionVersion::latest());
 
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
                 proposed.add_mint(asset, asset_value).unwrap();
                 proposed.add_burn(*asset.id(), asset_value).unwrap();
 
-                let tx = proposed.post(None, 1).unwrap();
+                let tx = proposed.post(key, None, 1).unwrap();
 
                 assert_eq!(tx.spends().len(), 1);
                 assert_eq!(tx.outputs().len(), 1);
@@ -92,12 +92,12 @@ pub fn verify(c: &mut Criterion) {
 
                 let out_note = Note::new(public_address, 41, "", NATIVE_ASSET, public_address);
 
-                let mut proposed = ProposedTransaction::new(key, TransactionVersion::latest());
+                let mut proposed = ProposedTransaction::new(TransactionVersion::latest());
 
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
 
-                proposed.post(None, 1).unwrap()
+                proposed.post(key, None, 1).unwrap()
             },
             // Benchmark
             |tx| {
@@ -127,12 +127,12 @@ pub fn batch_verify(c: &mut Criterion) {
 
                     let out_note = Note::new(public_address, 41, "", NATIVE_ASSET, public_address);
 
-                    let mut proposed = ProposedTransaction::new(key, TransactionVersion::latest());
+                    let mut proposed = ProposedTransaction::new(TransactionVersion::latest());
 
                     proposed.add_spend(spend_note, &witness).unwrap();
                     proposed.add_output(out_note).unwrap();
 
-                    transactions.push(proposed.post(None, 1).unwrap());
+                    transactions.push(proposed.post(key, None, 1).unwrap());
                 }
 
                 transactions

--- a/benchmarks/benches/transaction.rs
+++ b/benchmarks/benches/transaction.rs
@@ -29,7 +29,7 @@ pub fn simple(c: &mut Criterion) {
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
 
-                let tx = proposed.post(key, None, 1).unwrap();
+                let tx = proposed.post(&key, None, 1).unwrap();
 
                 assert_eq!(tx.spends().len(), 1);
                 assert_eq!(tx.outputs().len(), 1);
@@ -67,7 +67,7 @@ pub fn all_descriptions(c: &mut Criterion) {
                 proposed.add_mint(asset, asset_value).unwrap();
                 proposed.add_burn(*asset.id(), asset_value).unwrap();
 
-                let tx = proposed.post(key, None, 1).unwrap();
+                let tx = proposed.post(&key, None, 1).unwrap();
 
                 assert_eq!(tx.spends().len(), 1);
                 assert_eq!(tx.outputs().len(), 1);
@@ -97,7 +97,7 @@ pub fn verify(c: &mut Criterion) {
                 proposed.add_spend(spend_note, &witness).unwrap();
                 proposed.add_output(out_note).unwrap();
 
-                proposed.post(key, None, 1).unwrap()
+                proposed.post(&key, None, 1).unwrap()
             },
             // Benchmark
             |tx| {
@@ -132,7 +132,7 @@ pub fn batch_verify(c: &mut Criterion) {
                     proposed.add_spend(spend_note, &witness).unwrap();
                     proposed.add_output(out_note).unwrap();
 
-                    transactions.push(proposed.post(key, None, 1).unwrap());
+                    transactions.push(proposed.post(&key, None, 1).unwrap());
                 }
 
                 transactions

--- a/ironfish-rust-nodejs/index.d.ts
+++ b/ironfish-rust-nodejs/index.d.ts
@@ -180,7 +180,7 @@ export class TransactionPosted {
 }
 export type NativeTransaction = Transaction
 export class Transaction {
-  constructor(spenderHexKey: string, version: number)
+  constructor(version: number)
   /** Create a proof of a new note owned by the recipient in this transaction. */
   output(note: Note): void
   /** Spend the note owned by spender_hex_key at the given witness location. */
@@ -196,12 +196,12 @@ export class Transaction {
    * a miner would not accept such a transaction unless it was explicitly set
    * as the miners fee.
    */
-  post_miners_fee(): Buffer
+  post_miners_fee(spenderHexKey: string): Buffer
   /**
    * Used to generate invalid miners fee transactions for testing. Call
    * post_miners_fee instead in user-facing code.
    */
-  _postMinersFeeUnchecked(): Buffer
+  _postMinersFeeUnchecked(spenderHexKey: string): Buffer
   /**
    * Post the transaction. This performs a bit of validation, and signs
    * the spends with a signature that proves the spends are part of this
@@ -214,7 +214,7 @@ export class Transaction {
    * sum(spends) - sum(outputs) - intended_transaction_fee - change = 0
    * aka: self.value_balance - intended_transaction_fee - change = 0
    */
-  post(changeGoesTo: string | undefined | null, intendedTransactionFee: bigint): Buffer
+  post(spenderHexKey: string, changeGoesTo: string | undefined | null, intendedTransactionFee: bigint): Buffer
   setExpiration(sequence: number): void
 }
 export class FoundBlockResult {

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -248,7 +248,7 @@ impl NativeTransaction {
         let spender_key = SaplingKey::from_hex(&spender_hex_key).map_err(to_napi_err)?;
         let transaction = self
             .transaction
-            .post_miners_fee(spender_key)
+            .post_miners_fee(&spender_key)
             .map_err(to_napi_err)?;
 
         let mut vec: Vec<u8> = vec![];
@@ -263,7 +263,7 @@ impl NativeTransaction {
         let spender_key = SaplingKey::from_hex(&spender_hex_key).map_err(to_napi_err)?;
         let transaction = self
             .transaction
-            .post_miners_fee_unchecked(spender_key)
+            .post_miners_fee_unchecked(&spender_key)
             .map_err(to_napi_err)?;
 
         let mut vec: Vec<u8> = vec![];
@@ -299,7 +299,7 @@ impl NativeTransaction {
 
         let posted_transaction = self
             .transaction
-            .post(spender_key, change_key, intended_transaction_fee_u64)
+            .post(&spender_key, change_key, intended_transaction_fee_u64)
             .map_err(to_napi_err)?;
 
         let mut vec: Vec<u8> = vec![];

--- a/ironfish-rust-nodejs/src/structs/transaction.rs
+++ b/ironfish-rust-nodejs/src/structs/transaction.rs
@@ -167,10 +167,9 @@ pub struct NativeTransaction {
 #[napi]
 impl NativeTransaction {
     #[napi(constructor)]
-    pub fn new(spender_hex_key: String, version: u8) -> Result<Self> {
-        let spender_key = SaplingKey::from_hex(&spender_hex_key).map_err(to_napi_err)?;
+    pub fn new(version: u8) -> Result<Self> {
         let tx_version = version.try_into().map_err(to_napi_err)?;
-        let transaction = ProposedTransaction::new(spender_key, tx_version);
+        let transaction = ProposedTransaction::new(tx_version);
 
         Ok(NativeTransaction { transaction })
     }
@@ -245,8 +244,12 @@ impl NativeTransaction {
     /// a miner would not accept such a transaction unless it was explicitly set
     /// as the miners fee.
     #[napi(js_name = "post_miners_fee")]
-    pub fn post_miners_fee(&mut self) -> Result<Buffer> {
-        let transaction = self.transaction.post_miners_fee().map_err(to_napi_err)?;
+    pub fn post_miners_fee(&mut self, spender_hex_key: String) -> Result<Buffer> {
+        let spender_key = SaplingKey::from_hex(&spender_hex_key).map_err(to_napi_err)?;
+        let transaction = self
+            .transaction
+            .post_miners_fee(spender_key)
+            .map_err(to_napi_err)?;
 
         let mut vec: Vec<u8> = vec![];
         transaction.write(&mut vec).map_err(to_napi_err)?;
@@ -256,10 +259,11 @@ impl NativeTransaction {
     /// Used to generate invalid miners fee transactions for testing. Call
     /// post_miners_fee instead in user-facing code.
     #[napi(js_name = "_postMinersFeeUnchecked")]
-    pub fn _post_miners_fee_unchecked(&mut self) -> Result<Buffer> {
+    pub fn _post_miners_fee_unchecked(&mut self, spender_hex_key: String) -> Result<Buffer> {
+        let spender_key = SaplingKey::from_hex(&spender_hex_key).map_err(to_napi_err)?;
         let transaction = self
             .transaction
-            .post_miners_fee_unchecked()
+            .post_miners_fee_unchecked(spender_key)
             .map_err(to_napi_err)?;
 
         let mut vec: Vec<u8> = vec![];
@@ -280,9 +284,12 @@ impl NativeTransaction {
     #[napi]
     pub fn post(
         &mut self,
+        spender_hex_key: String,
         change_goes_to: Option<String>,
         intended_transaction_fee: BigInt,
     ) -> Result<Buffer> {
+        let spender_key = SaplingKey::from_hex(&spender_hex_key).map_err(to_napi_err)?;
+
         let intended_transaction_fee_u64 = intended_transaction_fee.get_u64().1;
 
         let change_key = match change_goes_to {
@@ -292,7 +299,7 @@ impl NativeTransaction {
 
         let posted_transaction = self
             .transaction
-            .post(change_key, intended_transaction_fee_u64)
+            .post(spender_key, change_key, intended_transaction_fee_u64)
             .map_err(to_napi_err)?;
 
         let mut vec: Vec<u8> = vec![];

--- a/ironfish-rust-nodejs/tests/demo.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/demo.test.slow.ts
@@ -58,11 +58,11 @@ describe('Demonstrate the Sapling API', () => {
   it(`Should create a miner's fee transaction`, () => {
     const key = generateKey()
 
-    const transaction = new Transaction(key.spendingKey, LATEST_TRANSACTION_VERSION)
+    const transaction = new Transaction(LATEST_TRANSACTION_VERSION)
     const note = new Note(key.publicAddress, 20n, 'test', Asset.nativeId(), key.publicAddress)
     transaction.output(note)
 
-    const serializedPostedTransaction = transaction.post_miners_fee()
+    const serializedPostedTransaction = transaction.post_miners_fee(key.spendingKey)
     const postedTransaction = new TransactionPosted(serializedPostedTransaction)
 
     expect(postedTransaction.fee()).toEqual(-20n)
@@ -95,13 +95,13 @@ describe('Demonstrate the Sapling API', () => {
     const key = generateKey()
     const recipientKey = generateKey()
 
-    const minersFeeTransaction = new Transaction(key.spendingKey, LATEST_TRANSACTION_VERSION)
+    const minersFeeTransaction = new Transaction(LATEST_TRANSACTION_VERSION)
     const minersFeeNote = new Note(key.publicAddress, 20n, 'miner', Asset.nativeId(), key.publicAddress)
     minersFeeTransaction.output(minersFeeNote)
 
-    const postedMinersFeeTransaction = new TransactionPosted(minersFeeTransaction.post_miners_fee())
+    const postedMinersFeeTransaction = new TransactionPosted(minersFeeTransaction.post_miners_fee(key.spendingKey))
 
-    const transaction = new Transaction(key.spendingKey, LATEST_TRANSACTION_VERSION)
+    const transaction = new Transaction(LATEST_TRANSACTION_VERSION)
     transaction.setExpiration(10)
     const encryptedNote = new NoteEncrypted(postedMinersFeeTransaction.getNote(0))
     const decryptedNote = Note.deserialize(encryptedNote.decryptNoteForOwner(key.incomingViewKey)!)
@@ -128,7 +128,7 @@ describe('Demonstrate the Sapling API', () => {
     transaction.spend(decryptedNote, witness)
     transaction.output(newNote)
 
-    const postedTransaction = new TransactionPosted(transaction.post(key.publicAddress, 5n))
+    const postedTransaction = new TransactionPosted(transaction.post(key.spendingKey, key.publicAddress, 5n))
 
     expect(postedTransaction.expiration()).toEqual(10)
     expect(postedTransaction.fee()).toEqual(5n)

--- a/ironfish-rust-nodejs/tests/transaction.test.slow.ts
+++ b/ironfish-rust-nodejs/tests/transaction.test.slow.ts
@@ -10,19 +10,19 @@ describe('Transaction', () => {
       const key = generateKey()
       const asset = new Asset(key.publicAddress, 'testcoin', '')
       // Version 1 transactions cannot have an ownership transfer
-      const proposedTx = new Transaction(key.spendingKey, 1)
+      const proposedTx = new Transaction(1)
       proposedTx.mint(asset, 5n, key.publicAddress)
 
-      expect(() => { proposedTx.post(null, 0n)}).toThrow('InvalidTransactionVersion')
+      expect(() => { proposedTx.post(key.spendingKey, null, 0n)}).toThrow('InvalidTransactionVersion')
     })
 
     it('can post a valid transaction', () => {
       const key = generateKey()
       const asset = new Asset(key.publicAddress, 'testcoin', '')
-      const proposedTx = new Transaction(key.spendingKey, 1)
+      const proposedTx = new Transaction(1)
       proposedTx.mint(asset, 5n)
 
-      expect(() => { proposedTx.post(null, 0n)}).not.toThrow()
+      expect(() => { proposedTx.post(key.spendingKey, null, 0n)}).not.toThrow()
 
     })
   })

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -350,13 +350,13 @@ impl ProposedTransaction {
         // Sign spends now that we have the data needed to be signed
         let mut spend_descriptions = Vec::with_capacity(unsigned_spends.len());
         for spend in unsigned_spends.drain(0..) {
-            spend_descriptions.push(spend.sign(&spender_key, &data_to_sign)?);
+            spend_descriptions.push(spend.sign(spender_key, &data_to_sign)?);
         }
 
         // Sign mints now that we have the data needed to be signed
         let mut mint_descriptions = Vec::with_capacity(unsigned_mints.len());
         for mint in unsigned_mints.drain(0..) {
-            mint_descriptions.push(mint.sign(&spender_key, &data_to_sign)?);
+            mint_descriptions.push(mint.sign(spender_key, &data_to_sign)?);
         }
 
         Ok(Transaction {

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -191,7 +191,7 @@ impl ProposedTransaction {
     /// aka: self.value_balance - intended_transaction_fee - change = 0
     pub fn post(
         &mut self,
-        spender_key: SaplingKey,
+        spender_key: &SaplingKey,
         change_goes_to: Option<PublicAddress>,
         intended_transaction_fee: u64,
     ) -> Result<Transaction, IronfishError> {
@@ -236,7 +236,7 @@ impl ProposedTransaction {
     /// as the miners fee.
     pub fn post_miners_fee(
         &mut self,
-        spender_key: SaplingKey,
+        spender_key: &SaplingKey,
     ) -> Result<Transaction, IronfishError> {
         if !self.spends.is_empty()
             || self.outputs.len() != 1
@@ -253,7 +253,7 @@ impl ProposedTransaction {
     /// Do not call this directly -- see post_miners_fee.
     pub fn post_miners_fee_unchecked(
         &mut self,
-        spender_key: SaplingKey,
+        spender_key: &SaplingKey,
     ) -> Result<Transaction, IronfishError> {
         // Set note_encryption_keys to a constant value on the outputs
         for output in &mut self.outputs {
@@ -273,7 +273,7 @@ impl ProposedTransaction {
     }
 
     // Post transaction without much validation.
-    fn _partial_post(&self, spender_key: SaplingKey) -> Result<Transaction, IronfishError> {
+    fn _partial_post(&self, spender_key: &SaplingKey) -> Result<Transaction, IronfishError> {
         // Generate randomized public key
         let public_key_randomness = jubjub::Fr::random(thread_rng());
 

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -108,22 +108,10 @@ pub struct ProposedTransaction {
     /// removed from the mempool. A value of 0 indicates the transaction will
     /// not expire.
     expiration: u32,
-
-    /// The key used to sign the transaction and any descriptions that need
-    /// signed.
-    spender_key: SaplingKey,
-
-    // randomness used for the transaction to calculate the randomized ak, which
-    // allows us to verify the sender address is valid and stored in the notes
-    // Used to add randomness to signature generation without leaking the
-    // key. Referred to as `ar` in the literature.
-    public_key_randomness: jubjub::Fr,
-    // NOTE: If adding fields here, you may need to add fields to
-    // signature hash method, and also to Transaction.
 }
 
 impl ProposedTransaction {
-    pub fn new(spender_key: SaplingKey, version: TransactionVersion) -> Self {
+    pub fn new(version: TransactionVersion) -> Self {
         Self {
             version,
             spends: vec![],
@@ -132,8 +120,6 @@ impl ProposedTransaction {
             burns: vec![],
             value_balances: ValueBalances::new(),
             expiration: 0,
-            spender_key,
-            public_key_randomness: jubjub::Fr::random(thread_rng()),
         }
     }
 
@@ -205,6 +191,7 @@ impl ProposedTransaction {
     /// aka: self.value_balance - intended_transaction_fee - change = 0
     pub fn post(
         &mut self,
+        spender_key: SaplingKey,
         change_goes_to: Option<PublicAddress>,
         intended_transaction_fee: u64,
     ) -> Result<Transaction, IronfishError> {
@@ -222,14 +209,13 @@ impl ProposedTransaction {
                 return Err(IronfishError::new(IronfishErrorKind::InvalidBalance));
             }
             if change_amount > 0 {
-                let change_address =
-                    change_goes_to.unwrap_or_else(|| self.spender_key.public_address());
+                let change_address = change_goes_to.unwrap_or_else(|| spender_key.public_address());
                 let change_note = Note::new(
                     change_address,
                     change_amount as u64, // we checked it was positive
                     "",
                     *asset_id,
-                    self.spender_key.public_address(),
+                    spender_key.public_address(),
                 );
 
                 change_notes.push(change_note);
@@ -240,7 +226,7 @@ impl ProposedTransaction {
             self.add_output(change_note)?;
         }
 
-        self._partial_post()
+        self._partial_post(spender_key)
     }
 
     /// Special case for posting a miners fee transaction. Miner fee transactions
@@ -248,7 +234,10 @@ impl ProposedTransaction {
     /// or change and therefore have a negative transaction fee. In normal use,
     /// a miner would not accept such a transaction unless it was explicitly set
     /// as the miners fee.
-    pub fn post_miners_fee(&mut self) -> Result<Transaction, IronfishError> {
+    pub fn post_miners_fee(
+        &mut self,
+        spender_key: SaplingKey,
+    ) -> Result<Transaction, IronfishError> {
         if !self.spends.is_empty()
             || self.outputs.len() != 1
             || !self.mints.is_empty()
@@ -258,16 +247,19 @@ impl ProposedTransaction {
                 IronfishErrorKind::InvalidMinersFeeTransaction,
             ));
         }
-        self.post_miners_fee_unchecked()
+        self.post_miners_fee_unchecked(spender_key)
     }
 
     /// Do not call this directly -- see post_miners_fee.
-    pub fn post_miners_fee_unchecked(&mut self) -> Result<Transaction, IronfishError> {
+    pub fn post_miners_fee_unchecked(
+        &mut self,
+        spender_key: SaplingKey,
+    ) -> Result<Transaction, IronfishError> {
         // Set note_encryption_keys to a constant value on the outputs
         for output in &mut self.outputs {
             output.set_is_miners_fee();
         }
-        self._partial_post()
+        self._partial_post(spender_key)
     }
 
     /// Get the expiration sequence for this transaction
@@ -281,22 +273,23 @@ impl ProposedTransaction {
     }
 
     // Post transaction without much validation.
-    fn _partial_post(&self) -> Result<Transaction, IronfishError> {
+    fn _partial_post(&self, spender_key: SaplingKey) -> Result<Transaction, IronfishError> {
         // Generate randomized public key
+        let public_key_randomness = jubjub::Fr::random(thread_rng());
 
         // The public key after randomization has been applied. This is used
         // during signature verification. Referred to as `rk` in the literature
         // Calculated from the authorizing key and the public_key_randomness.
         let randomized_public_key =
-            redjubjub::PublicKey(self.spender_key.view_key.authorizing_key.into())
-                .randomize(self.public_key_randomness, *SPENDING_KEY_GENERATOR);
+            redjubjub::PublicKey(spender_key.view_key.authorizing_key.into())
+                .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
         // Build descriptions
         let mut unsigned_spends = Vec::with_capacity(self.spends.len());
         for spend in &self.spends {
             unsigned_spends.push(spend.build(
-                &self.spender_key.sapling_proof_generation_key(),
-                self.spender_key.view_key(),
+                &spender_key.sapling_proof_generation_key(),
+                spender_key.view_key(),
                 &self.public_key_randomness,
                 &randomized_public_key,
             )?);
@@ -305,8 +298,8 @@ impl ProposedTransaction {
         let mut output_descriptions = Vec::with_capacity(self.outputs.len());
         for output in &self.outputs {
             output_descriptions.push(output.build(
-                &self.spender_key.sapling_proof_generation_key(),
-                self.spender_key.outgoing_view_key(),
+                &spender_key.sapling_proof_generation_key(),
+                spender_key.outgoing_view_key(),
                 &self.public_key_randomness,
                 &randomized_public_key,
             )?);
@@ -315,8 +308,8 @@ impl ProposedTransaction {
         let mut unsigned_mints = Vec::with_capacity(self.mints.len());
         for mint in &self.mints {
             unsigned_mints.push(mint.build(
-                &self.spender_key.sapling_proof_generation_key(),
-                &self.spender_key.public_address(),
+                &spender_key.sapling_proof_generation_key(),
+                &spender_key.public_address(),
                 &self.public_key_randomness,
                 &randomized_public_key,
             )?);
@@ -333,6 +326,7 @@ impl ProposedTransaction {
             &output_descriptions,
             &unsigned_mints,
             &burn_descriptions,
+            &randomized_public_key,
         )?;
 
         // Create and verify binding signature keys
@@ -348,13 +342,13 @@ impl ProposedTransaction {
         // Sign spends now that we have the data needed to be signed
         let mut spend_descriptions = Vec::with_capacity(unsigned_spends.len());
         for spend in unsigned_spends.drain(0..) {
-            spend_descriptions.push(spend.sign(&self.spender_key, &data_to_sign)?);
+            spend_descriptions.push(spend.sign(&spender_key, &data_to_sign)?);
         }
 
         // Sign mints now that we have the data needed to be signed
         let mut mint_descriptions = Vec::with_capacity(unsigned_mints.len());
         for mint in unsigned_mints.drain(0..) {
-            mint_descriptions.push(mint.sign(&self.spender_key, &data_to_sign)?);
+            mint_descriptions.push(mint.sign(&spender_key, &data_to_sign)?);
         }
 
         Ok(Transaction {
@@ -381,6 +375,7 @@ impl ProposedTransaction {
         outputs: &[OutputDescription],
         mints: &[UnsignedMintDescription],
         burns: &[BurnDescription],
+        randomized_public_key: &PublicKey,
     ) -> Result<[u8; 32], IronfishError> {
         let mut hasher = Blake2b::new()
             .hash_length(32)
@@ -391,10 +386,6 @@ impl ProposedTransaction {
         self.version.write(&mut hasher)?;
         hasher.write_u32::<LittleEndian>(self.expiration)?;
         hasher.write_i64::<LittleEndian>(*self.value_balances.fee())?;
-
-        let randomized_public_key =
-            redjubjub::PublicKey(self.spender_key.view_key.authorizing_key.into())
-                .randomize(self.public_key_randomness, *SPENDING_KEY_GENERATOR);
 
         hasher.write_all(&randomized_public_key.0.to_bytes())?;
 

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -69,7 +69,7 @@ fn test_transaction() {
         spender_key.public_address(),
     );
 
-    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::latest());
+    let mut transaction = ProposedTransaction::new(TransactionVersion::latest());
 
     // Spend
     transaction.add_spend(in_note, &witness).unwrap();
@@ -92,7 +92,7 @@ fn test_transaction() {
     assert_eq!(transaction.burns.len(), 1);
 
     let public_transaction = transaction
-        .post(None, 1)
+        .post(spender_key, None, 1)
         .expect("should be able to post transaction");
     verify_transaction(&public_transaction).expect("Should be able to verify transaction");
     assert_eq!(public_transaction.fee(), 1);
@@ -173,14 +173,14 @@ fn test_transaction_simple() {
     );
     let witness = make_fake_witness(&in_note);
 
-    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::latest());
+    let mut transaction = ProposedTransaction::new(TransactionVersion::latest());
     transaction.add_spend(in_note, &witness).unwrap();
     assert_eq!(transaction.spends.len(), 1);
     transaction.add_output(out_note).unwrap();
     assert_eq!(transaction.outputs.len(), 1);
 
     let public_transaction = transaction
-        .post(None, 1)
+        .post(spender_key, None, 1)
         .expect("should be able to post transaction");
     verify_transaction(&public_transaction).expect("Should be able to verify transaction");
     assert_eq!(public_transaction.fee(), 1);
@@ -209,10 +209,10 @@ fn test_miners_fee() {
         NATIVE_ASSET,
         spender_key.public_address(),
     );
-    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::latest());
+    let mut transaction = ProposedTransaction::new(TransactionVersion::latest());
     transaction.add_output(out_note).unwrap();
     let posted_transaction = transaction
-        .post_miners_fee()
+        .post_miners_fee(spender_key)
         .expect("it is a valid miner's fee");
     assert_eq!(posted_transaction.fee, -42);
     assert_eq!(
@@ -234,7 +234,7 @@ fn test_transaction_signature() {
     let receiver_address = receiver_key.public_address();
     let sender_key = SaplingKey::generate_key();
 
-    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::latest());
+    let mut transaction = ProposedTransaction::new(TransactionVersion::latest());
     let in_note = Note::new(
         spender_address,
         42,
@@ -252,7 +252,7 @@ fn test_transaction_signature() {
     transaction.set_expiration(1337);
 
     let public_transaction = transaction
-        .post(None, 0)
+        .post(spender_key, None, 0)
         .expect("should be able to post transaction");
 
     let mut serialized_signature = vec![];
@@ -288,14 +288,14 @@ fn test_transaction_created_with_version_1() {
     );
     let witness = make_fake_witness(&in_note);
 
-    let mut transaction = ProposedTransaction::new(spender_key, TransactionVersion::V1);
+    let mut transaction = ProposedTransaction::new(TransactionVersion::V1);
     transaction.add_spend(in_note, &witness).unwrap();
     transaction.add_output(out_note).unwrap();
 
     assert_eq!(transaction.version, TransactionVersion::V1);
 
     let public_transaction = transaction
-        .post(None, 1)
+        .post(spender_key, None, 1)
         .expect("should be able to post transaction");
 
     assert_eq!(public_transaction.version, TransactionVersion::V1);
@@ -356,7 +356,7 @@ fn test_transaction_value_overflows() {
     );
     let witness = make_fake_witness(&note);
 
-    let mut tx = ProposedTransaction::new(key, TransactionVersion::latest());
+    let mut tx = ProposedTransaction::new(TransactionVersion::latest());
 
     // spend
     assert!(tx.add_spend(note.clone(), &witness).is_err());
@@ -460,7 +460,7 @@ fn test_batch_verify_wrong_params() {
         key.public_address(),
     );
 
-    let mut proposed_transaction1 = ProposedTransaction::new(key, TransactionVersion::latest());
+    let mut proposed_transaction1 = ProposedTransaction::new(TransactionVersion::latest());
 
     proposed_transaction1.add_spend(in_note, &witness).unwrap();
     proposed_transaction1.add_output(out_note).unwrap();
@@ -473,14 +473,13 @@ fn test_batch_verify_wrong_params() {
         .unwrap();
 
     let transaction1 = proposed_transaction1
-        .post(None, 1)
+        .post(key, None, 1)
         .expect("should be able to post transaction");
 
-    let mut proposed_transaction2 =
-        ProposedTransaction::new(other_key, TransactionVersion::latest());
+    let mut proposed_transaction2 = ProposedTransaction::new(TransactionVersion::latest());
     proposed_transaction2.add_mint(asset2, 5).unwrap();
 
-    let transaction2 = proposed_transaction2.post(None, 0).unwrap();
+    let transaction2 = proposed_transaction2.post(other_key, None, 0).unwrap();
     //
     // END TRANSACTION CREATION
     //
@@ -555,7 +554,7 @@ fn test_batch_verify() {
         key.public_address(),
     );
 
-    let mut proposed_transaction1 = ProposedTransaction::new(key, TransactionVersion::latest());
+    let mut proposed_transaction1 = ProposedTransaction::new(TransactionVersion::latest());
 
     proposed_transaction1.add_spend(in_note, &witness).unwrap();
     proposed_transaction1.add_output(out_note).unwrap();
@@ -568,14 +567,13 @@ fn test_batch_verify() {
         .unwrap();
 
     let mut transaction1 = proposed_transaction1
-        .post(None, 1)
+        .post(key, None, 1)
         .expect("should be able to post transaction");
 
-    let mut proposed_transaction2 =
-        ProposedTransaction::new(other_key, TransactionVersion::latest());
+    let mut proposed_transaction2 = ProposedTransaction::new(TransactionVersion::latest());
     proposed_transaction2.add_mint(asset2, 5).unwrap();
 
-    let transaction2 = proposed_transaction2.post(None, 0).unwrap();
+    let transaction2 = proposed_transaction2.post(other_key, None, 0).unwrap();
 
     batch_verify_transactions([&transaction1, &transaction2])
         .expect("should be able to verify transaction");

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -92,7 +92,7 @@ fn test_transaction() {
     assert_eq!(transaction.burns.len(), 1);
 
     let public_transaction = transaction
-        .post(spender_key, None, 1)
+        .post(&spender_key, None, 1)
         .expect("should be able to post transaction");
     verify_transaction(&public_transaction).expect("Should be able to verify transaction");
     assert_eq!(public_transaction.fee(), 1);
@@ -180,7 +180,7 @@ fn test_transaction_simple() {
     assert_eq!(transaction.outputs.len(), 1);
 
     let public_transaction = transaction
-        .post(spender_key, None, 1)
+        .post(&spender_key, None, 1)
         .expect("should be able to post transaction");
     verify_transaction(&public_transaction).expect("Should be able to verify transaction");
     assert_eq!(public_transaction.fee(), 1);
@@ -212,7 +212,7 @@ fn test_miners_fee() {
     let mut transaction = ProposedTransaction::new(TransactionVersion::latest());
     transaction.add_output(out_note).unwrap();
     let posted_transaction = transaction
-        .post_miners_fee(spender_key)
+        .post_miners_fee(&spender_key)
         .expect("it is a valid miner's fee");
     assert_eq!(posted_transaction.fee, -42);
     assert_eq!(
@@ -252,7 +252,7 @@ fn test_transaction_signature() {
     transaction.set_expiration(1337);
 
     let public_transaction = transaction
-        .post(spender_key, None, 0)
+        .post(&spender_key, None, 0)
         .expect("should be able to post transaction");
 
     let mut serialized_signature = vec![];
@@ -295,7 +295,7 @@ fn test_transaction_created_with_version_1() {
     assert_eq!(transaction.version, TransactionVersion::V1);
 
     let public_transaction = transaction
-        .post(spender_key, None, 1)
+        .post(&spender_key, None, 1)
         .expect("should be able to post transaction");
 
     assert_eq!(public_transaction.version, TransactionVersion::V1);
@@ -473,13 +473,13 @@ fn test_batch_verify_wrong_params() {
         .unwrap();
 
     let transaction1 = proposed_transaction1
-        .post(key, None, 1)
+        .post(&key, None, 1)
         .expect("should be able to post transaction");
 
     let mut proposed_transaction2 = ProposedTransaction::new(TransactionVersion::latest());
     proposed_transaction2.add_mint(asset2, 5).unwrap();
 
-    let transaction2 = proposed_transaction2.post(other_key, None, 0).unwrap();
+    let transaction2 = proposed_transaction2.post(&other_key, None, 0).unwrap();
     //
     // END TRANSACTION CREATION
     //
@@ -567,13 +567,13 @@ fn test_batch_verify() {
         .unwrap();
 
     let mut transaction1 = proposed_transaction1
-        .post(key, None, 1)
+        .post(&key, None, 1)
         .expect("should be able to post transaction");
 
     let mut proposed_transaction2 = ProposedTransaction::new(TransactionVersion::latest());
     proposed_transaction2.add_mint(asset2, 5).unwrap();
 
-    let transaction2 = proposed_transaction2.post(other_key, None, 0).unwrap();
+    let transaction2 = proposed_transaction2.post(&other_key, None, 0).unwrap();
 
     batch_verify_transactions([&transaction1, &transaction2])
         .expect("should be able to verify transaction");

--- a/ironfish/src/consensus/verifier.test.ts
+++ b/ironfish/src/consensus/verifier.test.ts
@@ -256,10 +256,10 @@ describe('Verifier', () => {
             Asset.nativeId(),
             owner,
           )
-          const transaction = new NativeTransaction(key.spendingKey, LATEST_TRANSACTION_VERSION)
+          const transaction = new NativeTransaction(LATEST_TRANSACTION_VERSION)
           transaction.output(minerNote1)
           transaction.output(minerNote2)
-          return new Transaction(transaction._postMinersFeeUnchecked())
+          return new Transaction(transaction._postMinersFeeUnchecked(key.spendingKey))
         },
         {
           process: async (): Promise<void> => {},

--- a/ironfish/src/genesis/addGenesisTransaction.ts
+++ b/ironfish/src/genesis/addGenesisTransaction.ts
@@ -88,7 +88,7 @@ export async function addGenesisTransaction(
   }
 
   // Create the new transaction to be appended to the new genesis block
-  const transaction = new NativeTransaction(account.spendingKey, TransactionVersion.V2)
+  const transaction = new NativeTransaction(TransactionVersion.V2)
   logger.info(`  Generating a spend for ${allocationSumInIron} coins...`)
   transaction.spend(note, witness)
 
@@ -109,7 +109,9 @@ export async function addGenesisTransaction(
   }
 
   logger.info('  Posting the transaction...')
-  const postedTransaction = new Transaction(transaction.post(undefined, BigInt(0)))
+  const postedTransaction = new Transaction(
+    transaction.post(account.spendingKey, undefined, BigInt(0)),
+  )
 
   logger.info('Creating the modified genesis block...')
   // Get the existing genesis block

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -77,12 +77,11 @@ export async function makeGenesisBlock(
     minersFeeKey.publicAddress,
   )
 
-  const minersFeeTransaction = new NativeTransaction(
-    minersFeeKey.spendingKey,
-    TransactionVersion.V2,
-  )
+  const minersFeeTransaction = new NativeTransaction(TransactionVersion.V2)
   minersFeeTransaction.output(note)
-  const postedMinersFeeTransaction = new Transaction(minersFeeTransaction.post_miners_fee())
+  const postedMinersFeeTransaction = new Transaction(
+    minersFeeTransaction.post_miners_fee(minersFeeKey.spendingKey),
+  )
 
   /**
    *
@@ -91,16 +90,15 @@ export async function makeGenesisBlock(
    *
    */
   logger.info(`Generating an initial transaction with ${allocationSumInIron} coins...`)
-  const initialTransaction = new NativeTransaction(
-    genesisKey.spendingKey,
-    TransactionVersion.V2,
-  )
+  const initialTransaction = new NativeTransaction(TransactionVersion.V2)
 
   logger.info('  Generating the output...')
   initialTransaction.output(genesisNote)
 
   logger.info('  Posting the initial transaction...')
-  const postedInitialTransaction = new Transaction(initialTransaction.post_miners_fee())
+  const postedInitialTransaction = new Transaction(
+    initialTransaction.post_miners_fee(genesisKey.spendingKey),
+  )
   transactionList.push(postedInitialTransaction)
 
   // Temporarily add the miner's fee note and the note from the transaction to our merkle tree
@@ -130,7 +128,7 @@ export async function makeGenesisBlock(
    *
    */
   logger.info('Generating a transaction for distributing allocations...')
-  const transaction = new NativeTransaction(genesisKey.spendingKey, TransactionVersion.V2)
+  const transaction = new NativeTransaction(TransactionVersion.V2)
   logger.info(`  Generating a spend for ${allocationSumInIron} coins...`)
   transaction.spend(genesisNote, witness)
 
@@ -151,7 +149,9 @@ export async function makeGenesisBlock(
   }
 
   logger.info('  Posting the transaction...')
-  const postedTransaction = new Transaction(transaction.post(undefined, BigInt(0)))
+  const postedTransaction = new Transaction(
+    transaction.post(genesisKey.spendingKey, undefined, BigInt(0)),
+  )
   transactionList.push(postedTransaction)
 
   /**

--- a/ironfish/src/primitives/rawTransaction.ts
+++ b/ironfish/src/primitives/rawTransaction.ts
@@ -117,7 +117,7 @@ export class RawTransaction {
   }
 
   post(spendingKey: string): Transaction {
-    const builder = new NativeTransaction(spendingKey, this.version)
+    const builder = new NativeTransaction(this.version)
     for (const spend of this.spends) {
       builder.spend(spend.note.takeReference(), spend.witness)
       spend.note.returnReference()
@@ -157,7 +157,7 @@ export class RawTransaction {
       builder.setExpiration(this.expiration)
     }
 
-    const serialized = builder.post(null, this.fee)
+    const serialized = builder.post(spendingKey, null, this.fee)
     const posted = new Transaction(serialized)
 
     return posted

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -106,12 +106,11 @@ describe('Demonstrate the Sapling API', () => {
 
       minerNote = new NativeNote(owner, 42n, '', Asset.nativeId(), owner)
 
-      const transaction = new NativeTransaction(
-        spenderKey.spendingKey,
-        LATEST_TRANSACTION_VERSION,
-      )
+      const transaction = new NativeTransaction(LATEST_TRANSACTION_VERSION)
       transaction.output(minerNote)
-      minerTransaction = new NativeTransactionPosted(transaction.post_miners_fee())
+      minerTransaction = new NativeTransactionPosted(
+        transaction.post_miners_fee(spenderKey.spendingKey),
+      )
       expect(minerTransaction).toBeTruthy()
       expect(minerTransaction.notesLength()).toEqual(1)
     })
@@ -137,7 +136,7 @@ describe('Demonstrate the Sapling API', () => {
     })
 
     it('Can create a simple transaction', () => {
-      transaction = new NativeTransaction(spenderKey.spendingKey, LATEST_TRANSACTION_VERSION)
+      transaction = new NativeTransaction(LATEST_TRANSACTION_VERSION)
       expect(transaction).toBeTruthy()
     })
 
@@ -159,7 +158,9 @@ describe('Demonstrate the Sapling API', () => {
       )
       transaction.output(outputNote)
 
-      publicTransaction = new NativeTransactionPosted(transaction.post(null, 0n))
+      publicTransaction = new NativeTransactionPosted(
+        transaction.post(spenderKey.spendingKey, null, 0n),
+      )
 
       expect(publicTransaction).toBeTruthy()
     })
@@ -310,7 +311,7 @@ describe('Demonstrate the Sapling API', () => {
     })
 
     it('Can create and post a transaction', async () => {
-      transaction = new NativeTransaction(receiverKey.spendingKey, LATEST_TRANSACTION_VERSION)
+      transaction = new NativeTransaction(LATEST_TRANSACTION_VERSION)
 
       const witness = await tree.witness(receiverWitnessIndex)
       if (witness === null) {
@@ -342,7 +343,9 @@ describe('Demonstrate the Sapling API', () => {
       transaction.output(noteForSpender)
       transaction.output(receiverNoteToSelf)
 
-      const postedTransaction = new Transaction(transaction.post(undefined, 1n))
+      const postedTransaction = new Transaction(
+        transaction.post(receiverKey.spendingKey, undefined, 1n),
+      )
       expect(postedTransaction).toBeTruthy()
       expect(await workerPool.verifyTransactions([postedTransaction])).toEqual({ valid: true })
     })

--- a/ironfish/src/workerPool/tasks/createMinersFee.ts
+++ b/ironfish/src/workerPool/tasks/createMinersFee.ts
@@ -102,10 +102,10 @@ export class CreateMinersFeeTask extends WorkerTask {
       minerPublicAddress,
     )
 
-    const transaction = new Transaction(spendKey, transactionVersion)
+    const transaction = new Transaction(transactionVersion)
     transaction.output(minerNote)
 
-    const serializedTransactionPosted = transaction.post_miners_fee()
+    const serializedTransactionPosted = transaction.post_miners_fee(spendKey)
     return new CreateMinersFeeResponse(serializedTransactionPosted, jobId)
   }
 }


### PR DESCRIPTION
## Summary

when signing transactions with FROST we will not have a full, valid SaplingKey to pass as the 'spender_key'. FROST will also require that public key randomness is shared between signers with randomized parameters used as an input to signing.

spender_key is only used when posting ProposedTransactions, so these changes remove it from the struct and instead pass it as an input to each of the post functions

~~public_key_randomness is only used in the context of _partial_post, so these changes remove public_key_randomness from the struct and initialize a randomized public address from randomness only when needed~~

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
