### PR TITLE
Use performance.now for snapshot duration

### DIFF
--- a/ironfish-cli/src/snapshot.ts
+++ b/ironfish-cli/src/snapshot.ts
@@ -123,11 +123,11 @@ export class SnapshotDownloader {
     }
 
     const idleTimeout = 30000
-    let idleLastChunk = Date.now()
+    let idleLastChunk = performance.now()
     const idleCancelSource = axios.CancelToken.source()
 
     const idleInterval = setInterval(() => {
-      const timeSinceLastChunk = Date.now() - idleLastChunk
+      const timeSinceLastChunk = performance.now() - idleLastChunk
 
       if (timeSinceLastChunk > idleTimeout) {
         clearInterval(idleInterval)
@@ -186,7 +186,7 @@ export class SnapshotDownloader {
 
         onDownloadProgress(downloaded, downloaded + chunk.length)
         downloaded += chunk.length
-        idleLastChunk = Date.now()
+        idleLastChunk = performance.now()
       })
     })
       .catch((error) => {


### PR DESCRIPTION
## Summary

No significant issue here, but generally we should prefer performance.now or process.hrtime when tracking durations to avoid odd bugs with computer clocks changing. Similar PR was made to the node app: https://github.com/iron-fish/ironfish-node-app/pull/69

## Testing Plan

Tested that snapshots still time out properly when disconnecting from the Internet.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
