### PR TITLE
Return whether account is view only from getAccountsStatus RPC

### DIFF
--- a/ironfish-cli/src/commands/wallet/status.ts
+++ b/ironfish-cli/src/commands/wallet/status.ts
@@ -33,6 +33,9 @@ export class StatusCommand extends IronfishCommand {
         id: {
           header: 'Account ID',
         },
+        viewOnly: {
+          header: 'View Only',
+        },
         headHash: {
           header: 'Head Hash',
         },

--- a/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
+++ b/ironfish/src/rpc/routes/wallet/getAccountsStatus.ts
@@ -16,6 +16,7 @@ export type GetAccountStatusResponse = {
     headHash: string
     headInChain?: boolean
     sequence: string | number
+    viewOnly: boolean
   }[]
 }
 
@@ -34,6 +35,7 @@ export const GetAccountStatusResponseSchema: yup.ObjectSchema<GetAccountStatusRe
             headHash: yup.string().defined(),
             headInChain: yup.boolean().optional(),
             sequence: yup.string().defined(),
+            viewOnly: yup.boolean().defined(),
           })
           .defined(),
       )
@@ -67,6 +69,7 @@ routes.register<typeof GetAccountStatusRequestSchema, GetAccountStatusResponse>(
         headHash: head?.hash.toString('hex') || 'NULL',
         headInChain,
         sequence: head?.sequence || 'NULL',
+        viewOnly: !account.isSpendingAccount(),
       })
     }
 


### PR DESCRIPTION
## Summary

We don't provide an RPC for determining whether an account is view-only. We could do this by exporting the account and checking for the presence of a spending key, but it'd be more straightforward to provide a flag directly in getAccountsStatus.

Fixes IFL-1900

## Testing Plan

Added a test to verify viewOnly is set.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[x] Yes
```

https://github.com/iron-fish/website/pull/574

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
