### PR TITLE
Display a clearer error when passing --path and an invalid argument

### DIFF
--- a/ironfish-cli/src/commands/wallet/import.ts
+++ b/ironfish-cli/src/commands/wallet/import.ts
@@ -40,6 +40,13 @@ export class ImportCommand extends IronfishCommand {
     const client = await this.sdk.connectRpc()
 
     let account: string
+
+    if (blob && blob.length !== 0 && flags.path && flags.path.length !== 0) {
+      this.error(
+        `Your command includes an unexpected argument. Please pass either --path or the output of wallet:export.`,
+      )
+    }
+
     if (blob) {
       account = blob
     } else if (flags.path) {


### PR DESCRIPTION
## Summary

Currently, if someone passes `--path` as well as an invalid argument or flag, the command will try to parse the invalid arg/flag as an account and fail. This attempts to add a clearer error message to that situation. I didn't want to log the exact unexpected argument in case someone pasted both their private key and a --path argument, and I felt it was better to clarify with the user if both were passed rather than just assuming one vs the other. Open to opinions here though.

## Testing Plan

Ran `yarn start wallet:import --json --path ~/default.json` and ensured the message displays, then removed `--json` and ensured the import works.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
