### PR TITLE
Feature/support wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,8 +1020,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1381,10 +1383,12 @@ dependencies = [
  "blstrs",
  "byteorder",
  "ff 0.12.1",
+ "getrandom 0.2.8",
  "group 0.12.1",
  "jubjub 0.9.0 (git+https://github.com/iron-fish/jubjub.git?branch=blstrs)",
  "lazy_static",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "zcash_primitives",
  "zcash_proofs",
 ]

--- a/ironfish-rust/src/signal_catcher.rs
+++ b/ironfish-rust/src/signal_catcher.rs
@@ -2,9 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+ #[cfg(target_family = "wasm")]
+use core::ffi::c_void;
+#[cfg(target_family = "wasm")]
+use core::ffi::c_int;
+#[cfg(not(target_family = "wasm"))]
+use libc::c_void;
+#[cfg(not(target_family = "wasm"))]
+use libc::c_int;
+
 extern "C" {
     // This is present in libc on unix, but not on linux
-    fn backtrace_symbols_fd(buffer: *const *mut libc::c_void, size: libc::c_int, fd: libc::c_int);
+    fn backtrace_symbols_fd(buffer: *const *mut c_void, size: c_int, fd: c_int);
 }
 
 /// # Safety
@@ -19,7 +28,7 @@ unsafe fn display_trace() {
 #[cfg(all(unix, not(target_env = "musl")))]
 unsafe fn display_trace() {
     const MAX_FRAMES: usize = 256;
-    static mut STACK_TRACE: [*mut libc::c_void; MAX_FRAMES] = [std::ptr::null_mut(); MAX_FRAMES];
+    static mut STACK_TRACE: [*mut c_void; MAX_FRAMES] = [std::ptr::null_mut(); MAX_FRAMES];
     let depth = libc::backtrace(STACK_TRACE.as_mut_ptr(), MAX_FRAMES as i32);
     backtrace_symbols_fd(STACK_TRACE.as_ptr(), depth, 2);
     libc::exit(libc::EXIT_FAILURE);

--- a/ironfish-zkp/Cargo.toml
+++ b/ironfish-zkp/Cargo.toml
@@ -29,6 +29,8 @@ ff = "0.12.0"
 group = "0.12.0"
 jubjub = { git = "https://github.com/iron-fish/jubjub.git", branch = "blstrs" }
 lazy_static = "1.4.0"
+getrandom = { version = "0.2", features = ["js"] }
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 rand = "0.8.5"
 zcash_primitives = { git = "https://github.com/iron-fish/librustzcash.git", branch = "blstrs", package = "zcash_primitives" }
 zcash_proofs = { git = "https://github.com/iron-fish/librustzcash.git", branch = "blstrs", package = "zcash_proofs" }


### PR DESCRIPTION
## Summary

I want to compile ironfish-rust and ironfish-zkp to WebAssembly (wasm). Currently, ironfish-rust uses libc::c_void and libc::c_int, but there is no libc library in wasm. Therefore, these parts need to be replaced with ffi::c_void and ffi::c_int, which have equivalent implementations in wasm. Additionally, in ironfish-zkp, the rand library is used for generating random numbers, and this library relies on the getrandom library at its core. To support this functionality in wasm, it is necessary to enable js feature for the getrandom library, as described in https://docs.rs/getrandom/#webassembly-support.

## Testing Plan

## Documentation

None

## Breaking Change

None

