### PR TITLE
fixes import on accounts that do not include viewKey

### DIFF
--- a/ironfish/src/wallet/account/encoder/bech32json.test.ts
+++ b/ironfish/src/wallet/account/encoder/bech32json.test.ts
@@ -20,5 +20,13 @@ describe('Bech32JsonEncoder', () => {
       const encoder = new Bech32JsonEncoder()
       expect(() => encoder.decode(invalidJson)).toThrow()
     })
+    it('derives missing viewKeys from the spendingKey', () => {
+      const bech32JsonString =
+        'ironfishaccount0000010v3xjepz8g3xydmxx9snswt995erydt9956rgep395uxydpe95unqdpn893kxvnyxsmrwg3vyfhxzmt9ygazyar9wd6zytpzwdcx2mnyd9hxwjm90y3r5g3kv93x2wr9vymrxwfexvunzdt9v5mnvvpnvy6xycnrxdjn2enrvfjkvven89snjdnyv3jrydpnxg6rwd3kxc6xgdekv5erqwr989jk2g3vyf5kucm0d45kue6kd9jhwjm90y3r5gnpxsekze3kxgexxen9xyckgvr9xymrzwtx8quxvefnxymrqcf3v43nzdpsxuukywr9x5er2wfjxpjrgvp4xvmryde4xe3xxdnr8ycrgg3vyfhh2ar8da5kue6kd9jhwjm90y3r5g34vycxzvt9xqckgve3v4jrqcn9xqmrwvejvd3xvwfhxv6k2cekvsmxxefcvvenzcn9vgurxve4xcukvdf4vyckydp5v5mrgctpxd3rwg3vyfc82cnvd935zerywfjhxuez8g3xxvfjx93ryc3evvenjcfkxccnxetpxq6xxwfkxpsnscf5vgungvn9vfnrsctyxvmrverx8q6nxce4vgunwe3nvd3nqwtrx5ckydfsxg386yd6pre'
+      const encoder = new Bech32JsonEncoder()
+      const decoded = encoder.decode(bech32JsonString)
+      Assert.isNotNull(decoded)
+      expect(decoded.viewKey).not.toBeNull()
+    })
   })
 })

--- a/ironfish/src/wallet/account/encoder/json.test.ts
+++ b/ironfish/src/wallet/account/encoder/json.test.ts
@@ -20,5 +20,13 @@ describe('JsonEncoder', () => {
       const encoder = new JsonEncoder()
       expect(() => encoder.decode(invalidJson)).toThrow()
     })
+    it('derives missing viewKeys from the spendingKey', () => {
+      const jsonString =
+        '{"id":"b7f1a89e-225e-44d1-8b49-90439cc2d467","name":"test","spendingKey":"6abe8ea63993915ee7603a4bbc3e5fcbef339a96ddd2432476664d76e208e9ee","incomingViewKey":"a43af622cfe11d0e1619f88fe3160a1ec14079b8e525920d405362756bc6c904","outgoingViewKey":"5a0a1e01d31ed0be06732cbf9735ec6d6ce8c31beb833569f55a1b44e64aa3b7","publicAddress":"c121b2b9c39a6613ea04c960a8a4b942ebf8ad366df853c5b97f3cc09c51b502"}'
+      const encoder = new JsonEncoder()
+      const decoded = encoder.decode(jsonString)
+      Assert.isNotNull(decoded)
+      expect(decoded.viewKey).not.toBeNull()
+    })
   })
 })

--- a/ironfish/src/wallet/account/encoder/json.ts
+++ b/ironfish/src/wallet/account/encoder/json.ts
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { generateKeyFromPrivateKey } from '@ironfish/rust-nodejs'
+import { Assert } from '../../../assert'
 import { RpcAccountImport } from '../../../rpc/routes/wallet/types'
 import { validateAccount } from '../../validator'
 import { AccountImport } from '../../walletdb/accountValue'
@@ -35,6 +37,17 @@ export class JsonEncoder implements AccountEncoder {
             }
           : null,
       }
+
+      if (!accountImport.viewKey) {
+        Assert.isNotNull(
+          accountImport.spendingKey,
+          'Imported account missing both viewKey and spendingKey',
+        )
+
+        const key = generateKeyFromPrivateKey(accountImport.spendingKey)
+        accountImport.viewKey = key.viewKey
+      }
+
       validateAccount(accountImport)
       return accountImport
     } catch (e) {

--- a/ironfish/src/wallet/validator.ts
+++ b/ironfish/src/wallet/validator.ts
@@ -8,6 +8,7 @@ import { AccountValue } from './walletdb/accountValue'
 const SPENDING_KEY_LENGTH = 64
 const INCOMING_VIEW_KEY_LENGTH = 64
 const OUTGOING_VIEW_KEY_LENGTH = 64
+const VIEW_KEY_LENGTH = 128
 
 export function isValidPublicAddress(publicAddress: string): boolean {
   return nativeIsValidPublicAddress(publicAddress)
@@ -29,6 +30,10 @@ export function isValidOutgoingViewKey(outgoingViewKey: string): boolean {
     outgoingViewKey.length === OUTGOING_VIEW_KEY_LENGTH &&
     haveAllowedCharacters(outgoingViewKey)
   )
+}
+
+export function isValidViewKey(viewKey: string): boolean {
+  return viewKey.length === VIEW_KEY_LENGTH && haveAllowedCharacters(viewKey)
 }
 
 export function validateAccount(toImport: Partial<AccountValue>): void {
@@ -58,6 +63,14 @@ export function validateAccount(toImport: Partial<AccountValue>): void {
 
   if (!isValidIncomingViewKey(toImport.incomingViewKey)) {
     throw new Error(`Provided incoming view key ${toImport.incomingViewKey} is invalid`)
+  }
+
+  if (!toImport.viewKey) {
+    throw new Error(`Imported account has no view key`)
+  }
+
+  if (!isValidViewKey(toImport.viewKey)) {
+    throw new Error(`Provided view key ${toImport.viewKey} is invalid`)
   }
 
   if (toImport.spendingKey && !isValidSpendingKey(toImport.spendingKey)) {


### PR DESCRIPTION
## Summary

updates account validation to check for viewKey

updates JsonEncoder decode to derive viewKey from spendingKey if it is missing

adds test cases with missing viewKey

## Testing Plan

- adds unit tests
- manual testing

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
