### PR TITLE
Sign ironfish binaries

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -85,19 +85,6 @@ jobs:
           npm install ironfish
           tar -czf ../tools/build.tar.gz -C . .
 
-      - name: Create random identifier so binary extraction will be unique
-        id: identifier
-        run: |
-          identifier=$(awk 'BEGIN {
-            srand(); 
-            chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-            for (i = 1; i <= 10; i++) {
-                printf "%s", substr(chars, int(rand() * length(chars)) + 1, 1);
-            }
-            print "";
-          }')
-          echo "identifier=${identifier}" >> $GITHUB_OUTPUT
-
       - name: Create binary
         id: binary
         run: |

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,11 +1,11 @@
 name: Build @ironfish binaries
 
-on:
-  push
 # on:
-#   release:
-#     types:
-#       - published
+#   push
+on:
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -26,9 +26,9 @@ jobs:
             arch: x86_64
             system: linux
 
-          # - host: macos-latest-large
-          #   arch: arm64
-          #   system: apple
+          - host: macos-latest-large
+            arch: arm64
+            system: apple
 
           # currently no way to build arm64
           # - host: ubuntu-20.04
@@ -187,13 +187,13 @@ jobs:
           path: tools/${{ steps.set_paths.outputs.zip }}
           if-no-files-found: error
 
-      # - name: Upload Release Asset
-      #   id: upload-release-asset
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: "${{ github.event.release.upload_url }}?name=${{ steps.set_paths.outputs.zip }}"
-      #     asset_path: ${{ steps.set_paths.outputs.zip }}
-      #     asset_name: ${{ steps.set_paths.outputs.zip }}
-      #     asset_content_type: application/zip
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: "${{ github.event.release.upload_url }}?name=${{ steps.set_paths.outputs.zip }}"
+          asset_path: ${{ steps.set_paths.outputs.zip }}
+          asset_name: ${{ steps.set_paths.outputs.zip }}
+          asset_content_type: application/zip

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -85,6 +85,19 @@ jobs:
           npm install ironfish
           tar -czf ../tools/build.tar.gz -C . .
 
+      - name: Create random identifier so binary extraction will be unique
+        id: identifier
+        run: |
+          identifier=$(awk 'BEGIN {
+            srand(); 
+            chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+            for (i = 1; i <= 10; i++) {
+                printf "%s", substr(chars, int(rand() * length(chars)) + 1, 1);
+            }
+            print "";
+          }')
+          echo "identifier=${identifier}" >> $GITHUB_OUTPUT
+
       - name: Create binary
         id: binary
         run: |

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -129,3 +129,10 @@ jobs:
           asset_path: ${{ steps.set_paths.outputs.zip }}
           asset_name: ${{ steps.set_paths.outputs.zip }}
           asset_content_type: application/zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.set_paths.outputs.name }}
+          path: tools/${{ steps.set_paths.outputs.zip }}
+          if-no-files-found: error

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,11 +1,11 @@
 name: Build @ironfish binaries
 
-on:
-  push
 # on:
-#   release:
-#     types:
-#       - published
+#   push
+on:
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -129,4 +129,3 @@ jobs:
           asset_path: ${{ steps.set_paths.outputs.zip }}
           asset_name: ${{ steps.set_paths.outputs.zip }}
           asset_content_type: application/zip
-

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,11 +1,11 @@
 name: Build @ironfish binaries
 
-# on:
-#   push
 on:
-  release:
-    types:
-      - published
+  push
+# on:
+#   release:
+#     types:
+#       - published
 
 jobs:
   build:
@@ -26,9 +26,9 @@ jobs:
             arch: x86_64
             system: linux
 
-          - host: macos-latest-large
-            arch: arm64
-            system: apple
+          # - host: macos-latest-large
+          #   arch: arm64
+          #   system: apple
 
           # currently no way to build arm64
           # - host: ubuntu-20.04
@@ -104,6 +104,57 @@ jobs:
         if: matrix.settings.system != 'windows'
         run: chmod +x ${{ steps.set_paths.outputs.binary }}
 
+      - name: Sign MacOS
+        if: matrix.settings.system == 'apple'
+        env: 
+          APPLE_IFLABS_SIGNING_CERT: ${{ secrets.APPLE_IFLABS_SIGNING_CERT }}
+          APPLE_IFLABS_SIGNING_CERT_PASSWORD: ${{ secrets.APPLE_IFLABS_SIGNING_CERT_PASSWORD }}
+          APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        run: |
+          # create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          API_KEY_PATH=$RUNNER_TEMP/api_key.p8
+  
+          # import certificate and provisioning profile from secrets
+          echo -n "$APPLE_IFLABS_SIGNING_CERT" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$APPLE_PROVISIONING_PROFILE" | base64 --decode -o $PP_PATH
+          echo -n "$APPLE_API_KEY" | base64 --decode -o $API_KEY_PATH
+  
+          # create temporary keychain
+          security create-keychain -p "$APPLE_IFLABS_SIGNING_CERT_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$APPLE_IFLABS_SIGNING_CERT_PASSWORD" $KEYCHAIN_PATH
+  
+          # import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$APPLE_IFLABS_SIGNING_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+  
+          # apply provisioning profile
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+          ls $RUNNER_TEMP
+
+          APPLE_API_KEY="$RUNNER_TEMP/api_key.p8" codesign --deep --force --options=runtime --sign --timestamp ${{ steps.set_paths.outputs.binary }}
+
+      - name: Sign Windows
+        if: matrix.settings.system == 'windows'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
+        run: |
+          dotnet tool install --global AzureSignTool
+          AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v ${{ steps.set_paths.outputs.binary }}
+
       - name: Zip binary
         uses: thedoctor0/zip-release@0.7.1
         with:
@@ -112,6 +163,18 @@ jobs:
           filename: ${{ steps.set_paths.outputs.name }}
           path: ${{ steps.set_paths.outputs.binary }}
       
+      - name: "Notarize app bundle"
+        env:
+          PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.APPLE_ID }}
+          PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.APPLE_NOTARIZATION_PWD }}
+        run: |
+          echo "Create keychain profile"
+          xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
+      
+          echo "Notarize app"
+          xcrun notarytool submit "${{ steps.set_paths.outputs.zip }}" --keychain-profile "notarytool-profile" --wait
+      
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -119,13 +182,13 @@ jobs:
           path: tools/${{ steps.set_paths.outputs.zip }}
           if-no-files-found: error
 
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: "${{ github.event.release.upload_url }}?name=${{ steps.set_paths.outputs.zip }}"
-          asset_path: ${{ steps.set_paths.outputs.zip }}
-          asset_name: ${{ steps.set_paths.outputs.zip }}
-          asset_content_type: application/zip
+      # - name: Upload Release Asset
+      #   id: upload-release-asset
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: "${{ github.event.release.upload_url }}?name=${{ steps.set_paths.outputs.zip }}"
+      #     asset_path: ${{ steps.set_paths.outputs.zip }}
+      #     asset_name: ${{ steps.set_paths.outputs.zip }}
+      #     asset_content_type: application/zip

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,11 +1,11 @@
 name: Build @ironfish binaries
 
-# on:
-#   push
 on:
-  release:
-    types:
-      - published
+  push
+# on:
+#   release:
+#     types:
+#       - published
 
 jobs:
   build:
@@ -130,9 +130,3 @@ jobs:
           asset_name: ${{ steps.set_paths.outputs.zip }}
           asset_content_type: application/zip
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.set_paths.outputs.name }}
-          path: tools/${{ steps.set_paths.outputs.zip }}
-          if-no-files-found: error

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -105,8 +105,10 @@ jobs:
         run: chmod +x ${{ steps.set_paths.outputs.binary }}
 
       - name: Sign MacOS
+        working-directory: tools
         if: matrix.settings.system == 'apple'
-        env: 
+        env:
+          APPLE_DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
           APPLE_IFLABS_SIGNING_CERT: ${{ secrets.APPLE_IFLABS_SIGNING_CERT }}
           APPLE_IFLABS_SIGNING_CERT_PASSWORD: ${{ secrets.APPLE_IFLABS_SIGNING_CERT_PASSWORD }}
           APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
@@ -140,9 +142,10 @@ jobs:
           cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
           ls $RUNNER_TEMP
 
-          APPLE_API_KEY="$RUNNER_TEMP/api_key.p8" codesign --deep --force --options=runtime --sign --timestamp ${{ steps.set_paths.outputs.binary }}
+          APPLE_API_KEY="$RUNNER_TEMP/api_key.p8" codesign --deep --force --options=runtime --sign "${APPLE_DEVELOPER_ID_APPLICATION}" --timestamp ${{ steps.set_paths.outputs.binary }}
 
       - name: Sign Windows
+        working-directory: tools
         if: matrix.settings.system == 'windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,6 +167,8 @@ jobs:
           path: ${{ steps.set_paths.outputs.binary }}
       
       - name: "Notarize app bundle"
+        working-directory: tools
+        if: matrix.settings.system == 'apple'
         env:
           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.APPLE_ID }}
           PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}


### PR DESCRIPTION
## Summary
Sign binaries for macos/windows
## Testing Plan
Build successful for all:
https://github.com/iron-fish/ironfish/actions/runs/7254275380?pr=4490#artifacts
<img width="373" alt="Screenshot 2023-12-18 at 2 21 47 PM" src="https://github.com/iron-fish/ironfish/assets/26990067/76e6469f-c13e-4a16-b566-4d58ab487fa7">

Windows signed correctly:
<img width="438" alt="Screenshot 2023-12-18 at 2 19 39 PM" src="https://github.com/iron-fish/ironfish/assets/26990067/9578a5a7-2abe-406c-9e53-7bacc5670250">

MacOS signed correctly (no rejection at runtime of binary):
<img width="256" alt="Screenshot 2023-12-18 at 2 11 48 PM" src="https://github.com/iron-fish/ironfish/assets/26990067/66ed33c7-d97c-4cac-8194-a31872d9e884">




## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
