### PR TITLE
Bump perf test and regenerate fixture node versions to 20

### DIFF
--- a/.github/workflows/ci-regenerate-fixtures.yml
+++ b/.github/workflows/ci-regenerate-fixtures.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'yarn'
 
       - name: Cache Rust

--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'yarn'
 
       - name: Install packages


### PR DESCRIPTION
## Summary

Tests don't run on Node 18 any more, but the perf tests and regenerate fixtures actions were still using Node 18.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
