### PR TITLE
Remove unused field from block fetcher

### DIFF
--- a/ironfish/src/network/blockFetcher.ts
+++ b/ironfish/src/network/blockFetcher.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { BufferMap } from 'buffer-map'
-import { Block, CompactBlock } from '../primitives/block'
+import { Block } from '../primitives/block'
 import { BlockHash, BlockHeader } from '../primitives/blockheader'
 import { ArrayUtils } from '../utils/array'
 import { CompactBlockUtils } from '../utils/compactblock'
@@ -48,7 +48,6 @@ type BlockState =
   | {
       action: 'PROCESSING_COMPACT_BLOCK'
       peer: Identity
-      compactBlock: CompactBlock
       sources: Set<Identity> // Set of peers that have sent us the hash or compact block
       firstSeenBy: Identity
     }
@@ -189,8 +188,7 @@ export class BlockFetcher {
    * but has not yet been processed (validated, assembled into a full
    * block, etc.) Returns true if the caller (PeerNetwork) should continue
    * processing this compact block or not */
-  receivedCompactBlock(compactBlock: CompactBlock, peer: Peer): boolean {
-    const hash = compactBlock.header.hash
+  receivedCompactBlock(hash: BlockHash, peer: Peer): boolean {
     const currentState = this.pending.get(hash)
 
     // If the peer is not connected or identified, ignore them
@@ -221,7 +219,6 @@ export class BlockFetcher {
     this.pending.set(hash, {
       action: 'PROCESSING_COMPACT_BLOCK',
       peer: peer.state.identity,
-      compactBlock,
       sources: currentState ? currentState.sources : new Set<Identity>(),
       firstSeenBy: currentState ? currentState.firstSeenBy : peer.state.identity,
     })

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -782,15 +782,16 @@ export class PeerNetwork {
       return
     }
 
+    const header = compactBlock.header
+
     // mark the block as received in the block fetcher and decide whether to continue
     // to validate this compact block or not
-    const shouldProcess = this.blockFetcher.receivedCompactBlock(compactBlock, peer)
+    const shouldProcess = this.blockFetcher.receivedCompactBlock(header.hash, peer)
     if (!shouldProcess) {
       return
     }
 
     // verify the header
-    const header = compactBlock.header
     if (header.sequence === GENESIS_BLOCK_SEQUENCE) {
       this.chain.addInvalid(header.hash, VerificationResultReason.GOSSIPED_GENESIS_BLOCK)
       this.blockFetcher.removeBlock(header.hash)


### PR DESCRIPTION
## Summary
It doesn't look like this field on the block fetcher is ever being accessed. It is making BlockHeader refactor for the hashing algorithm more compliacated so removing it

## Testing Plan
Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
