### PR TITLE
Use RawBlock for network messages

### DIFF
--- a/ironfish/src/network/blockFetcher.test.ts
+++ b/ironfish/src/network/blockFetcher.test.ts
@@ -4,7 +4,6 @@
 
 import { Blockchain } from '../blockchain'
 import { VerificationResultReason } from '../consensus'
-import { BlockHeader } from '../primitives'
 import { Block } from '../primitives/block'
 import {
   createNodeTest,
@@ -497,13 +496,13 @@ describe('BlockFetcher', () => {
     }
 
     expect(telemetrySpy).toHaveBeenCalledWith(
-      Block.fromRaw({
-        header: BlockHeader.fromRaw(compactBlock.header),
-        transactions: newBlock.transactions,
-      }),
+      expect.any(Block),
       expect.any(Date),
       peers[0].peer.state.identity,
     )
+
+    const calledBlockHash = telemetrySpy.mock.calls[0][0].header.hash
+    expect(calledBlockHash).toEqual(newBlock.header.hash)
 
     await peerNetwork.stop()
   })

--- a/ironfish/src/network/blockFetcher.ts
+++ b/ironfish/src/network/blockFetcher.ts
@@ -189,8 +189,7 @@ export class BlockFetcher {
    * but has not yet been processed (validated, assembled into a full
    * block, etc.) Returns true if the caller (PeerNetwork) should continue
    * processing this compact block or not */
-  receivedCompactBlock(compactBlock: CompactBlock, peer: Peer): boolean {
-    const hash = compactBlock.header.hash
+  receivedCompactBlock(hash: BlockHash, compactBlock: CompactBlock, peer: Peer): boolean {
     const currentState = this.pending.get(hash)
 
     // If the peer is not connected or identified, ignore them

--- a/ironfish/src/network/messages/getBlockHeaders.ts
+++ b/ironfish/src/network/messages/getBlockHeaders.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import bufio from 'bufio'
-import { BlockHeader } from '../../primitives'
+import { RawBlockHeader } from '../../primitives/blockheader'
 import { NetworkMessageType } from '../types'
 import { getBlockHeaderSize, readBlockHeader, writeBlockHeader } from '../utils/serializers'
 import { Direction, RpcNetworkMessage } from './rpcNetworkMessage'
@@ -72,9 +72,9 @@ export class GetBlockHeadersRequest extends RpcNetworkMessage {
 }
 
 export class GetBlockHeadersResponse extends RpcNetworkMessage {
-  readonly headers: BlockHeader[]
+  readonly headers: RawBlockHeader[]
 
-  constructor(headers: BlockHeader[], rpcId: number) {
+  constructor(headers: RawBlockHeader[], rpcId: number) {
     super(NetworkMessageType.GetBlockHeadersResponse, Direction.Response, rpcId)
     this.headers = headers
   }

--- a/ironfish/src/network/messages/getBlocks.test.ts
+++ b/ironfish/src/network/messages/getBlocks.test.ts
@@ -25,15 +25,7 @@ describe('GetBlocksResponse', () => {
   const nodeTest = createNodeTest()
 
   function expectGetBlocksResponseToMatch(a: GetBlocksResponse, b: GetBlocksResponse): void {
-    // Test blocks separately because Block is not a primitive type
-    expect(a.blocks.length).toEqual(b.blocks.length)
-    a.blocks.forEach((blockA, blockIndexA) => {
-      const blockB = b.blocks[blockIndexA]
-
-      expect(blockA.equals(blockB)).toBe(true)
-    })
-
-    expect({ ...a, blocks: undefined }).toMatchObject({ ...b, blocks: undefined })
+    expect(a.serialize().equals(b.serialize())).toBe(true)
   }
 
   it('serializes the object into a buffer and deserializes to the original object', async () => {

--- a/ironfish/src/network/messages/getBlocks.ts
+++ b/ironfish/src/network/messages/getBlocks.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import bufio from 'bufio'
-import { Block } from '../../primitives/block'
+import { RawBlock } from '../../primitives/block'
 import { NetworkMessageType } from '../types'
 import { getBlockSize, readBlock, writeBlock } from '../utils/serializers'
 import { Direction, RpcNetworkMessage } from './rpcNetworkMessage'
@@ -38,9 +38,9 @@ export class GetBlocksRequest extends RpcNetworkMessage {
 }
 
 export class GetBlocksResponse extends RpcNetworkMessage {
-  readonly blocks: Block[]
+  readonly blocks: RawBlock[]
 
-  constructor(blocks: Block[], rpcId: number) {
+  constructor(blocks: RawBlock[], rpcId: number) {
     super(NetworkMessageType.GetBlocksResponse, Direction.Response, rpcId)
     this.blocks = blocks
   }

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -11,7 +11,7 @@ import net from 'net'
 import ws from 'ws'
 import { Assert } from '../assert'
 import { VerificationResultReason } from '../consensus/verifier'
-import { Block, Transaction } from '../primitives'
+import { Block, BlockHeader, Transaction } from '../primitives'
 import { CompactBlock } from '../primitives/block'
 import {
   useAccountFixture,
@@ -763,7 +763,7 @@ describe('PeerNetwork', () => {
             expect(sendSpy).not.toHaveBeenCalled()
           }
 
-          const invalidHeader = invalidBlock.header
+          const invalidHeader = BlockHeader.fromRaw(invalidBlock.header)
           await expect(chain.hasBlock(invalidHeader.hash)).resolves.toBe(false)
           expect(chain.isInvalid(invalidHeader)).toBe(reason)
         }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -21,7 +21,7 @@ import { FullNode } from '../node'
 import { IronfishPKG } from '../package'
 import { Platform } from '../platform'
 import { GENESIS_BLOCK_SEQUENCE, Transaction } from '../primitives'
-import { Block, CompactBlock } from '../primitives/block'
+import { Block, CompactBlock, RawBlock } from '../primitives/block'
 import { BlockHash, BlockHeader } from '../primitives/blockheader'
 import { TransactionHash } from '../primitives/transaction'
 import { Telemetry } from '../telemetry'
@@ -614,7 +614,9 @@ export class PeerNetwork {
       throw new Error(`Invalid GetBlockHeadersResponse: ${message.displayType()}`)
     }
 
-    return { headers: response.headers, time: BenchUtils.end(begin) }
+    const headers = response.headers.map((rawHeader) => BlockHeader.fromRaw(rawHeader))
+
+    return { headers, time: BenchUtils.end(begin) }
   }
 
   async getBlocks(
@@ -634,7 +636,10 @@ export class PeerNetwork {
 
     const exceededSoftLimit = response.getSize() >= SOFT_MAX_MESSAGE_SIZE
     const isMessageFull = exceededSoftLimit || response.blocks.length >= limit
-    return { blocks: response.blocks, time: BenchUtils.end(begin), isMessageFull }
+
+    const blocks = response.blocks.map((rawBlock) => Block.fromRaw(rawBlock))
+
+    return { blocks, time: BenchUtils.end(begin), isMessageFull }
   }
 
   private async handleMessage(peer: Peer, message: NetworkMessage): Promise<void> {
@@ -782,15 +787,20 @@ export class PeerNetwork {
       return
     }
 
+    const header = BlockHeader.fromRaw(compactBlock.header)
+
     // mark the block as received in the block fetcher and decide whether to continue
     // to validate this compact block or not
-    const shouldProcess = this.blockFetcher.receivedCompactBlock(compactBlock, peer)
+    const shouldProcess = this.blockFetcher.receivedCompactBlock(
+      header.hash,
+      compactBlock,
+      peer,
+    )
     if (!shouldProcess) {
       return
     }
 
     // verify the header
-    const header = compactBlock.header
     if (header.sequence === GENESIS_BLOCK_SEQUENCE) {
       this.chain.addInvalid(header.hash, VerificationResultReason.GOSSIPED_GENESIS_BLOCK)
       this.blockFetcher.removeBlock(header.hash)
@@ -880,7 +890,7 @@ export class PeerNetwork {
       partial.type === 'FULL' && fullTransactions.push(partial.value)
     }
 
-    const fullBlock = new Block(compactBlock.header, fullTransactions)
+    const fullBlock = new Block(header, fullTransactions)
     await this.onNewFullBlock(peer, fullBlock, prevHeader)
   }
 
@@ -1158,10 +1168,12 @@ export class PeerNetwork {
     return new GetCompactBlockResponse(block.toCompactBlock(), message.rpcId)
   }
 
-  private async handleRequestedBlock(peer: Peer, block: Block) {
+  private async handleRequestedBlock(peer: Peer, rawBlock: RawBlock) {
     if (!this.shouldProcessNewBlocks()) {
       return
     }
+
+    const block = Block.fromRaw(rawBlock)
 
     if (await this.alreadyHaveBlock(block.header)) {
       return

--- a/ironfish/src/network/testUtilities/helpers.ts
+++ b/ironfish/src/network/testUtilities/helpers.ts
@@ -204,19 +204,7 @@ export function expectGetCompactBlockResponseToMatch(
   a: GetCompactBlockResponse,
   b: GetCompactBlockResponse,
 ): void {
-  // Test transactions separately because Transaction is not a primitive type
-  expect(a.compactBlock.transactions.length).toEqual(b.compactBlock.transactions.length)
-  a.compactBlock.transactions.forEach((transactionA, transactionIndexA) => {
-    const transactionB = b.compactBlock.transactions[transactionIndexA]
-
-    expect(transactionA.index).toEqual(transactionB.index)
-    expect(transactionA.transaction.hash().equals(transactionB.transaction.hash())).toBe(true)
-  })
-
-  expect({
-    ...a,
-    compactBlock: { ...a.compactBlock, transactions: undefined },
-  }).toMatchObject({ ...b, compactBlock: { ...b.compactBlock, transactions: undefined } })
+  expect(a.serialize().equals(b.serialize())).toBe(true)
 }
 
 export function expectGetBlockTransactionsResponseToMatch(
@@ -238,14 +226,7 @@ export function expectGetBlockHeadersResponseToMatch(
   a: GetBlockHeadersResponse,
   b: GetBlockHeadersResponse,
 ): void {
-  expect(a.headers.length).toEqual(b.headers.length)
-  a.headers.forEach((headerA, headerIndexA) => {
-    const headerB = b.headers[headerIndexA]
-
-    expect(headerA.hash).toEqual(headerB.hash)
-  })
-
-  expect({ ...a, headers: undefined }).toMatchObject({ ...b, headers: undefined })
+  expect(a.serialize().equals(b.serialize())).toBe(true)
 }
 
 export function expectGetBlocksResponseToMatch(

--- a/ironfish/src/primitives/block.ts
+++ b/ironfish/src/primitives/block.ts
@@ -4,7 +4,12 @@
 
 import { zip } from 'lodash'
 import { Assert } from '../assert'
-import { BlockHeader, BlockHeaderSerde, SerializedBlockHeader } from './blockheader'
+import {
+  BlockHeader,
+  BlockHeaderSerde,
+  RawBlockHeader,
+  SerializedBlockHeader,
+} from './blockheader'
 import { MintDescription } from './mintDescription'
 import { NoteEncrypted, NoteEncryptedHash } from './noteEncrypted'
 import { Nullifier } from './nullifier'
@@ -119,7 +124,7 @@ export class Block {
   }
 
   toCompactBlock(): CompactBlock {
-    const header = this.header
+    const header = this.header.toRaw()
 
     const [minersFee, ...transactions] = this.transactions
     const transactionHashes = transactions.map((t) => t.hash())
@@ -135,6 +140,11 @@ export class Block {
       ],
     }
   }
+
+  static fromRaw(raw: RawBlock): Block {
+    const header = BlockHeader.fromRaw(raw.header)
+    return new Block(header, raw.transactions)
+  }
 }
 
 export type CompactBlockTransaction = {
@@ -143,9 +153,14 @@ export type CompactBlockTransaction = {
 }
 
 export type CompactBlock = {
-  header: BlockHeader
+  header: RawBlockHeader
   transactionHashes: Buffer[]
   transactions: CompactBlockTransaction[]
+}
+
+export type RawBlock = {
+  header: RawBlockHeader
+  transactions: Transaction[]
 }
 
 export type SerializedBlock = {

--- a/ironfish/src/primitives/blockheader.ts
+++ b/ironfish/src/primitives/blockheader.ts
@@ -241,6 +241,43 @@ export class BlockHeader {
       this.serialize().equals(other.serialize())
     )
   }
+
+  toRaw(): RawBlockHeader {
+    return {
+      sequence: this.sequence,
+      previousBlockHash: this.previousBlockHash,
+      noteCommitment: this.noteCommitment,
+      transactionCommitment: this.transactionCommitment,
+      target: this.target,
+      randomness: this.randomness,
+      timestamp: this.timestamp,
+      graffiti: this.graffiti,
+    }
+  }
+
+  static fromRaw(raw: RawBlockHeader): BlockHeader {
+    return new BlockHeader(
+      raw.sequence,
+      raw.previousBlockHash,
+      raw.noteCommitment,
+      raw.transactionCommitment,
+      raw.target,
+      raw.randomness,
+      raw.timestamp,
+      raw.graffiti,
+    )
+  }
+}
+
+export type RawBlockHeader = {
+  sequence: number
+  previousBlockHash: BlockHash
+  noteCommitment: NoteEncryptedHash
+  transactionCommitment: Buffer
+  target: Target
+  randomness: bigint
+  timestamp: Date
+  graffiti: Buffer
 }
 
 export type SerializedBlockHeader = {


### PR DESCRIPTION
## Summary
Preparation for upcoming hashing algorithm changes. The hashing algorithm becomes more expensive and requires a 75mb light cache to calculate. Instead of doing this calculation in the network message deserialization we should do it more explicitly further up the chain. For this we need another representation of a block without a hash (RawBlockHeader + RawBlock)

## Testing Plan
Unit tests + running node locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
