### PR TITLE
Rahul/ifl 2006 combine command produces a single note as output

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -469,8 +469,7 @@ export class CombineNotesCommand extends IronfishCommand {
       raw = RawTransactionSerde.deserialize(bytes)
     }
 
-    // This allows us to have a single note as an output.
-
+    // This allows for a single note output.
     const amount = amountIncludingFees - raw.fee
     params.outputs[0].amount = CurrencyUtils.encode(amount)
     params.fee = raw.fee ? CurrencyUtils.encode(raw.fee) : null

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -473,6 +473,8 @@ export class CombineNotesCommand extends IronfishCommand {
 
     const amount = amountIncludingFees - raw.fee
     params.outputs[0].amount = CurrencyUtils.encode(amount)
+    params.fee = raw.fee ? CurrencyUtils.encode(raw.fee) : null
+
     const createTransactionResponse = await client.wallet.createTransaction(params)
     const createTransactionBytes = Buffer.from(
       createTransactionResponse.content.transaction,

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -472,7 +472,7 @@ export class CombineNotesCommand extends IronfishCommand {
     // This allows for a single note output.
     const amount = amountIncludingFees - raw.fee
     params.outputs[0].amount = CurrencyUtils.encode(amount)
-    params.fee = raw.fee ? CurrencyUtils.encode(raw.fee) : null
+    params.fee = CurrencyUtils.encode(raw.fee)
 
     const createTransactionResponse = await client.wallet.createTransaction(params)
     const createTransactionBytes = Buffer.from(

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -432,7 +432,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     notes = notes.slice(0, numberOfNotes)
 
-    const amountExcludingFees = notes.reduce((acc, note) => acc + BigInt(note.value), 0n)
+    const amountIncludingFees = notes.reduce((acc, note) => acc + BigInt(note.value), 0n)
 
     const memo =
       flags.memo?.trim() ??
@@ -445,7 +445,7 @@ export class CombineNotesCommand extends IronfishCommand {
       outputs: [
         {
           publicAddress: to,
-          amount: CurrencyUtils.encode(amountExcludingFees),
+          amount: CurrencyUtils.encode(amountIncludingFees),
           memo,
         },
       ],
@@ -471,7 +471,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     // This allows us to have a single note as an output.
 
-    const amount = amountExcludingFees - raw.fee
+    const amount = amountIncludingFees - raw.fee
     params.outputs[0].amount = CurrencyUtils.encode(amount)
     const createTransactionResponse = await client.wallet.createTransaction(params)
     const createTransactionBytes = Buffer.from(


### PR DESCRIPTION
## Summary

Changing the amount the transaction so that the combine command produces 1 note as the output: 

<img width="1670" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/52fdf367-5c93-45a9-82ba-011780832d41">

<img width="1499" alt="image" src="https://github.com/iron-fish/ironfish/assets/13268167/728c8b6d-02bd-4abb-9434-bf56d14c25e4">



## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
