### PR TITLE
Rahul/ifl 1881 transaction progress bar for send transaction

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -3,15 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { Asset } from '@ironfish/rust-nodejs'
 import {
-  Assert,
-  BenchUtils,
   CreateTransactionRequest,
   CurrencyUtils,
-  EstimateFeeRatesResponse,
   RawTransaction,
   RawTransactionSerde,
   RpcClient,
-  RpcResponseEnded,
   TimeUtils,
   Transaction,
 } from '@ironfish/sdk'
@@ -22,7 +18,12 @@ import { IronFlag, RemoteFlags } from '../../../flags'
 import { ProgressBar } from '../../../types'
 import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
-import { displayTransactionSummary, watchTransaction } from '../../../utils/transaction'
+import { fetchSortedNotes } from '../../../utils/notes'
+import {
+  displayTransactionSummary,
+  getSpendPostTimeInMs,
+  watchTransaction,
+} from '../../../utils/transaction'
 
 export class CombineNotesCommand extends IronfishCommand {
   static description = `Combine notes into a single note`
@@ -69,167 +70,6 @@ export class CombineNotesCommand extends IronfishCommand {
       default: false,
       description: 'Force run the benchmark to measure the time to combine 1 note',
     }),
-  }
-
-  private async getSpendPostTimeInMs(
-    client: RpcClient,
-    account: string,
-    noteSize: number,
-    forceBenchmark: boolean,
-  ): Promise<number> {
-    let spendPostTime = this.sdk.internal.get('spendPostTime')
-
-    const spendPostTimeAt = this.sdk.internal.get('spendPostTimeAt')
-
-    const shouldbenchmark =
-      forceBenchmark ||
-      spendPostTime <= 0 ||
-      Date.now() - spendPostTimeAt > 1000 * 60 * 60 * 24 * 30 // 1 month
-
-    if (shouldbenchmark) {
-      spendPostTime = await this.benchmarkSpendPostTime(client, account, noteSize)
-
-      this.sdk.internal.set('spendPostTime', spendPostTime)
-      this.sdk.internal.set('spendPostTimeAt', Date.now())
-      await this.sdk.internal.save()
-    }
-
-    return spendPostTime
-  }
-
-  private async benchmarkSpendPostTime(
-    client: RpcClient,
-    account: string,
-    noteSize: number,
-  ): Promise<number> {
-    const publicKey = (
-      await client.wallet.getAccountPublicKey({
-        account: account,
-      })
-    ).content.publicKey
-
-    const notes = await this.fetchNotes(client, account, noteSize, 10)
-
-    CliUx.ux.action.start('Measuring time to combine 1 note')
-
-    const feeRates = await client.wallet.estimateFeeRates()
-
-    /** Transaction 1: selects 1 note */
-
-    const txn1Params: CreateTransactionRequest = {
-      account: account,
-      outputs: [
-        {
-          publicAddress: publicKey,
-          amount: CurrencyUtils.encode(BigInt(notes[0].value)),
-          memo: '',
-        },
-      ],
-      fee: null,
-      feeRate: null,
-      notes: [notes[0].noteHash],
-    }
-
-    /** Transaction 2: selects two notes */
-
-    const txn2Params: CreateTransactionRequest = {
-      account: account,
-      outputs: [
-        {
-          publicAddress: publicKey,
-          amount: CurrencyUtils.encode(BigInt(notes[0].value) + BigInt(notes[1].value)),
-          memo: '',
-        },
-      ],
-      fee: null,
-      feeRate: null,
-      notes: [notes[0].noteHash, notes[1].noteHash],
-    }
-
-    const promisesTxn1 = []
-    const promisesTxn2 = []
-
-    for (let i = 0; i < 3; i++) {
-      promisesTxn1.push(this.measureTransactionPostTime(client, txn1Params, feeRates))
-      promisesTxn2.push(this.measureTransactionPostTime(client, txn2Params, feeRates))
-    }
-
-    const resultTxn1 = await Promise.all(promisesTxn1)
-    const resultTxn2 = await Promise.all(promisesTxn2)
-
-    const delta = Math.ceil(
-      (resultTxn2.reduce((acc, curr) => acc + curr, 0) -
-        resultTxn1.reduce((acc, curr) => acc + curr, 0)) /
-        3,
-    )
-
-    CliUx.ux.action.stop(TimeUtils.renderSpan(delta))
-
-    return delta
-  }
-
-  private async measureTransactionPostTime(
-    client: RpcClient,
-    params: CreateTransactionRequest,
-    feeRates: RpcResponseEnded<EstimateFeeRatesResponse>,
-  ) {
-    const response = await client.wallet.createTransaction({
-      ...params,
-      feeRate: feeRates.content.fast,
-    })
-
-    const bytes = Buffer.from(response.content.transaction, 'hex')
-    const raw = RawTransactionSerde.deserialize(bytes)
-
-    const start = BenchUtils.start()
-
-    await client.wallet.postTransaction({
-      transaction: RawTransactionSerde.serialize(raw).toString('hex'),
-      broadcast: false,
-    })
-
-    return BenchUtils.end(start)
-  }
-
-  private async fetchNotes(
-    client: RpcClient,
-    account: string,
-    noteSize: number,
-    notesToCombine: number,
-  ) {
-    notesToCombine = Math.max(notesToCombine, 10) // adds a buffer in case the user selects a small number of notes and they get filtered out by noteSize
-
-    const getNotesResponse = await client.wallet.getNotes({
-      account,
-      pageSize: notesToCombine,
-      filter: {
-        assetId: Asset.nativeId().toString('hex'),
-        spent: false,
-      },
-    })
-
-    // filtering notes by noteSize and sorting them by value in ascending order
-    const notes = getNotesResponse.content.notes
-      .filter((note) => {
-        if (!note.index) {
-          return false
-        }
-        return note.index < noteSize
-      })
-      .sort((a, b) => {
-        if (a.value < b.value) {
-          return -1
-        }
-        return 1
-      })
-
-    // must have at least three notes so that you can combine 2 and use another for fees
-    if (notes.length < 3) {
-      this.log(`Your notes are already combined. You currently have ${notes.length} notes.`)
-      this.exit(0)
-    }
-
-    return notes
   }
 
   private async selectNotesToCombine(spendPostTimeMs: number): Promise<number> {
@@ -355,23 +195,6 @@ export class CombineNotesCommand extends IronfishCommand {
     return expiration
   }
 
-  private async getNoteTreeSize(client: RpcClient) {
-    const getCurrentBlock = await client.chain.getChainInfo()
-
-    const currentBlockSequence = parseInt(getCurrentBlock.content.currentBlockIdentifier.index)
-
-    const getBlockResponse = await client.chain.getBlock({
-      sequence: currentBlockSequence,
-    })
-
-    Assert.isNotNull(getBlockResponse.content.block.noteSize)
-
-    const config = await client.config.getConfig()
-
-    // Adding a buffer to avoid a mismatch between confirmations used to load notes and confirmations used when creating witnesses to spend them
-    return getBlockResponse.content.block.noteSize - (config.content.confirmations || 2)
-  }
-
   private async getCurrentBlockSequence(client: RpcClient) {
     const getCurrentBlock = await client.chain.getChainInfo()
     const currentBlockSequence = parseInt(getCurrentBlock.content.currentBlockIdentifier.index)
@@ -408,14 +231,17 @@ export class CombineNotesCommand extends IronfishCommand {
     }
 
     // the confirmation range in the merkle tree for notes that are safe to use
-    const noteSize = await this.getNoteTreeSize(client)
 
-    const spendPostTime = await this.getSpendPostTimeInMs(
-      client,
-      from,
-      noteSize,
-      flags.benchmark,
-    )
+    const ensureMinNotes = await fetchSortedNotes(client, from, 10)
+
+    if (ensureMinNotes.length < 3) {
+      this.log(
+        `Your notes are already combined. You currently have ${ensureMinNotes.length} notes.`,
+      )
+      this.exit(0)
+    }
+
+    const spendPostTime = await getSpendPostTimeInMs(client, this.sdk, from, flags.benchmark)
 
     let numberOfNotes = flags.notes
 
@@ -423,7 +249,7 @@ export class CombineNotesCommand extends IronfishCommand {
       numberOfNotes = await this.selectNotesToCombine(spendPostTime)
     }
 
-    let notes = await this.fetchNotes(client, from, noteSize, numberOfNotes)
+    let notes = await fetchSortedNotes(client, from, numberOfNotes)
 
     // If the user doesn't have enough notes for their selection, we reduce the number of notes so that
     // the largest note can be used for fees.

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -18,9 +18,9 @@ import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
 import { fetchSortedNotes } from '../../../utils/notes'
 import {
-  TransactionTimer,
   displayTransactionSummary,
   getSpendPostTimeInMs,
+  TransactionTimer,
   watchTransaction,
 } from '../../../utils/transaction'
 

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -18,9 +18,9 @@ import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
 import { fetchSortedNotes } from '../../../utils/notes'
 import {
+  TransactionTimer,
   displayTransactionSummary,
   getSpendPostTimeInMs,
-  TransactionTimer,
   watchTransaction,
 } from '../../../utils/transaction'
 
@@ -309,6 +309,10 @@ export class CombineNotesCommand extends IronfishCommand {
     const assetId = Asset.nativeId().toString('hex')
     displayTransactionSummary(raw, assetId, amount, from, to, memo)
 
+    const transactionTimer = new TransactionTimer(spendPostTime, raw)
+
+    transactionTimer.displayEstimate()
+
     if (!flags.confirm) {
       const confirmed = await CliUx.ux.confirm('Do you confirm (Y/N)?')
       if (!confirmed) {
@@ -316,7 +320,6 @@ export class CombineNotesCommand extends IronfishCommand {
       }
     }
 
-    const transactionTimer = new TransactionTimer(spendPostTime, raw)
     transactionTimer.start()
 
     const response = await client.wallet.postTransaction({

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -109,6 +109,11 @@ export class Send extends IronfishCommand {
       description: 'The note hashes to include in the transaction',
       multiple: true,
     }),
+    benchmark: Flags.boolean({
+      hidden: true,
+      default: false,
+      description: 'Force run the benchmark to measure the time to combine 1 note',
+    }),
   }
 
   async start(): Promise<void> {

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -251,13 +251,17 @@ export class Send extends IronfishCommand {
 
     displayTransactionSummary(raw, assetId, amount, from, to, memo)
 
+    const transactionTimer = new TransactionTimer(spendPostTime, raw)
+
+    transactionTimer.displayEstimate()
+
     if (!flags.confirm) {
       const confirmed = await CliUx.ux.confirm('Do you confirm (Y/N)?')
       if (!confirmed) {
         this.error('Transaction aborted.')
       }
     }
-    const transactionTimer = new TransactionTimer(spendPostTime, raw)
+
     transactionTimer.start()
 
     const response = await client.wallet.postTransaction({

--- a/ironfish-cli/src/utils/notes.ts
+++ b/ironfish-cli/src/utils/notes.ts
@@ -4,7 +4,7 @@
 import { Asset } from '@ironfish/rust-nodejs'
 import { Assert, RpcClient, RpcWalletNote } from '@ironfish/sdk'
 
-export async function getNoteTreeSize(client: RpcClient): Promise<number> {
+async function getNoteTreeSize(client: RpcClient): Promise<number> {
   const getCurrentBlock = await client.chain.getChainInfo()
 
   const currentBlockSequence = parseInt(getCurrentBlock.content.currentBlockIdentifier.index)

--- a/ironfish-cli/src/utils/notes.ts
+++ b/ironfish-cli/src/utils/notes.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { Asset } from '@ironfish/rust-nodejs'
+import { Assert, RpcClient, RpcWalletNote } from '@ironfish/sdk'
+
+export async function getNoteTreeSize(client: RpcClient): Promise<number> {
+  const getCurrentBlock = await client.chain.getChainInfo()
+
+  const currentBlockSequence = parseInt(getCurrentBlock.content.currentBlockIdentifier.index)
+
+  const getBlockResponse = await client.chain.getBlock({
+    sequence: currentBlockSequence,
+  })
+
+  Assert.isNotNull(getBlockResponse.content.block.noteSize)
+
+  const config = await client.config.getConfig()
+
+  // Adding a buffer to avoid a mismatch between confirmations used to load notes and confirmations used when creating witnesses to spend them
+  return getBlockResponse.content.block.noteSize - (config.content.confirmations || 2)
+}
+
+export async function fetchSortedNotes(
+  client: RpcClient,
+  account: string,
+  pageSize: number,
+): Promise<RpcWalletNote[]> {
+  const noteSize = await getNoteTreeSize(client)
+
+  pageSize = Math.max(pageSize, 10) // adds a buffer in case the user selects a small number of notes and they get filtered out by noteSize
+
+  const getNotesResponse = await client.wallet.getNotes({
+    account,
+    pageSize: pageSize,
+    filter: {
+      assetId: Asset.nativeId().toString('hex'),
+      spent: false,
+    },
+  })
+
+  // filtering notes by noteSize and sorting them by value in ascending order
+  const notes = getNotesResponse.content.notes
+    .filter((note) => {
+      if (!note.index) {
+        return false
+      }
+      return note.index < noteSize
+    })
+    .sort((a, b) => {
+      if (a.value < b.value) {
+        return -1
+      }
+      return 1
+    })
+
+  return notes
+}

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -41,6 +41,17 @@ export class TransactionTimer {
     this.logger = logger ?? createRootLogger()
   }
 
+  displayEstimate(): void {
+    if (this.spendPostTime <= 0) {
+      return
+    }
+    this.logger.log(
+      `Time to send: ${TimeUtils.renderSpan(this.estimateInMs, {
+        hideMilliseconds: true,
+      })}`,
+    )
+  }
+
   start(): void {
     if (this.startTime > 0) {
       return
@@ -60,12 +71,6 @@ export class TransactionTimer {
 
       return
     }
-
-    this.logger.log(
-      `Time to send: ${TimeUtils.renderSpan(this.estimateInMs, {
-        hideMilliseconds: true,
-      })}`,
-    )
 
     this.progressBar.start(100, 0, {
       title: 'Progress',

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -34,7 +34,7 @@ export class TransactionTimer {
     this.estimateInMs = Math.max(Math.ceil(spendPostTime * raw.spends.length), 1000)
     this.spendPostTime = spendPostTime
     this.progressBar = CliUx.ux.progress({
-      format: '{title}: [{bar}] {percentage}% {estimate}',
+      format: '{title}: [{bar}] {percentage}% | {estimate}\n',
     }) as ProgressBar
     this.startTime = 0
     this.timer = null

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -23,17 +23,13 @@ import { ProgressBar } from '../types'
 import { fetchSortedNotes } from './notes'
 
 export class TransactionTimer {
-  spendPostTime: number
-  raw: RawTransaction
   estimateInMs: number
   startTime: number
   timer: NodeJS.Timeout | null
   progressBar: ProgressBar
 
-  constructor(raw: RawTransaction, spendPostTime: number) {
-    this.spendPostTime = spendPostTime
-    this.raw = raw
-    this.estimateInMs = Math.max(Math.ceil(spendPostTime * raw.spends.length), 1000)
+  constructor(estimateInMs: number) {
+    this.estimateInMs = estimateInMs
     this.progressBar = CliUx.ux.progress({
       format: '{title}: [{bar}] {percentage}% | {estimate}',
     }) as ProgressBar

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -3,16 +3,139 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import {
+  BenchUtils,
   createRootLogger,
+  CreateTransactionRequest,
   CurrencyUtils,
+  EstimateFeeRatesResponse,
+  IronfishSdk,
   Logger,
   PromiseUtils,
   RawTransaction,
+  RawTransactionSerde,
   RpcClient,
+  RpcResponseEnded,
   TimeUtils,
   TransactionStatus,
 } from '@ironfish/sdk'
 import { CliUx } from '@oclif/core'
+import { fetchSortedNotes } from './notes'
+
+async function measureTransactionPostTime(
+  client: RpcClient,
+  params: CreateTransactionRequest,
+  feeRates: RpcResponseEnded<EstimateFeeRatesResponse>,
+) {
+  const response = await client.wallet.createTransaction({
+    ...params,
+    feeRate: feeRates.content.fast,
+  })
+
+  const bytes = Buffer.from(response.content.transaction, 'hex')
+  const raw = RawTransactionSerde.deserialize(bytes)
+
+  const start = BenchUtils.start()
+
+  await client.wallet.postTransaction({
+    transaction: RawTransactionSerde.serialize(raw).toString('hex'),
+    broadcast: false,
+  })
+
+  return BenchUtils.end(start)
+}
+
+async function benchmarkSpendPostTime(client: RpcClient, account: string): Promise<number> {
+  const publicKey = (
+    await client.wallet.getAccountPublicKey({
+      account: account,
+    })
+  ).content.publicKey
+
+  const notes = await fetchSortedNotes(client, account, 10)
+
+  CliUx.ux.action.start('Measuring time to combine 1 note')
+
+  const feeRates = await client.wallet.estimateFeeRates()
+
+  /** Transaction 1: selects 1 note */
+
+  const txn1Params: CreateTransactionRequest = {
+    account: account,
+    outputs: [
+      {
+        publicAddress: publicKey,
+        amount: CurrencyUtils.encode(BigInt(notes[0].value)),
+        memo: '',
+      },
+    ],
+    fee: null,
+    feeRate: null,
+    notes: [notes[0].noteHash],
+  }
+
+  /** Transaction 2: selects two notes */
+
+  const txn2Params: CreateTransactionRequest = {
+    account: account,
+    outputs: [
+      {
+        publicAddress: publicKey,
+        amount: CurrencyUtils.encode(BigInt(notes[0].value) + BigInt(notes[1].value)),
+        memo: '',
+      },
+    ],
+    fee: null,
+    feeRate: null,
+    notes: [notes[0].noteHash, notes[1].noteHash],
+  }
+
+  const promisesTxn1 = []
+  const promisesTxn2 = []
+
+  for (let i = 0; i < 3; i++) {
+    promisesTxn1.push(measureTransactionPostTime(client, txn1Params, feeRates))
+    promisesTxn2.push(measureTransactionPostTime(client, txn2Params, feeRates))
+  }
+
+  const resultTxn1 = await Promise.all(promisesTxn1)
+  const resultTxn2 = await Promise.all(promisesTxn2)
+
+  const delta = Math.ceil(
+    (resultTxn2.reduce((acc, curr) => acc + curr, 0) -
+      resultTxn1.reduce((acc, curr) => acc + curr, 0)) /
+      3,
+  )
+
+  CliUx.ux.action.stop(TimeUtils.renderSpan(delta))
+
+  return delta
+}
+
+export async function getSpendPostTimeInMs(
+  client: RpcClient,
+  sdk: IronfishSdk,
+  account: string,
+  forceBenchmark: boolean,
+): Promise<number> {
+  let spendPostTime = sdk.internal.get('spendPostTime')
+
+  const spendPostTimeAt = sdk.internal.get('spendPostTimeAt')
+
+  const shouldbenchmark =
+    forceBenchmark ||
+    spendPostTime <= 0 ||
+    Date.now() - spendPostTimeAt > 1000 * 60 * 60 * 24 * 30 // 1 month
+
+  if (shouldbenchmark) {
+    spendPostTime = await benchmarkSpendPostTime(client, account)
+
+    sdk.internal.set('spendPostTime', spendPostTime)
+    sdk.internal.set('spendPostTimeAt', Date.now())
+    await sdk.internal.save()
+  }
+
+  return spendPostTime
+}
 
 export function displayTransactionSummary(
   transaction: RawTransaction,

--- a/ironfish-cli/src/utils/transaction.ts
+++ b/ironfish-cli/src/utils/transaction.ts
@@ -150,7 +150,7 @@ async function benchmarkSpendPostTime(client: RpcClient, account: string): Promi
     return 0
   }
 
-  CliUx.ux.action.start('Measuring time to combine 1 note')
+  CliUx.ux.action.start('Benchmark transaction send time')
 
   const feeRates = await client.wallet.estimateFeeRates()
 

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -6,7 +6,7 @@ import bufio from 'bufio'
 import { IDatabaseEncoding } from '../../storage'
 import { ACCOUNT_KEY_LENGTH } from '../account/account'
 import { MultisigKeysEncoding } from '../account/encoder/multisigKeys'
-import { MultisigKeys as MultisigKeys } from '../interfaces/multisigKeys'
+import { MultisigKeys } from '../interfaces/multisigKeys'
 import { HeadValue, NullableHeadValueEncoding } from './headValue'
 
 export const KEY_LENGTH = ACCOUNT_KEY_LENGTH


### PR DESCRIPTION
## Summary

1. Creates a transaction timer class
2. Adds countdown logic to send command
3. Moves countdown helper functions

Edgecases: 
1. Not enough notes -> Spend post time is 0 -> We don't provide an estimate and just count up

## Testing Plan

1. Send a transaction 
2. Send a transaction with an account that has less than 3 notes
3. Send a transaction with a view only account

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
