### PR TITLE
show minimum 1 second when combining notes

### DIFF
--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -483,7 +483,7 @@ export class CombineNotesCommand extends IronfishCommand {
 
     displayTransactionSummary(raw, Asset.nativeId().toString('hex'), amount, from, to, memo)
 
-    const estimateInMs = Math.ceil(spendPostTime * raw.spends.length)
+    const estimateInMs = Math.max(Math.ceil(spendPostTime * raw.spends.length), 1000)
 
     this.log(
       `Time to send: ${TimeUtils.renderSpan(estimateInMs, {


### PR DESCRIPTION
## Summary

Minimum 1 second to combine notes. 

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
