### PR TITLE
fix: binary gha bug with zip filename

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -42,18 +42,12 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
 
-      - name: clean selfhosted node_modules
-        if: matrix.settings.system == 'apple' && matrix.settings.arch == 'arm64'
-        run: |
-          cd $GITHUB_WORKSPACE
-          find . -name . -o -prune -exec rm -rf -- {} +
-
-      - name: Use Node.js
+      - name: Use node.js
         uses: actions/setup-node@v4
         with:
           node-version: 18
       
-      - name: Use Go
+      - name: Use go
         uses: actions/setup-go@v4
         with:
           go-version: '1.20.6'
@@ -104,7 +98,7 @@ jobs:
         if: matrix.settings.system != 'windows'
         run: chmod +x ${{ steps.set_paths.outputs.binary }}
 
-      - name: Sign MacOS
+      - name: Sign macOS
         working-directory: tools
         if: matrix.settings.system == 'apple'
         env:
@@ -144,7 +138,7 @@ jobs:
 
           APPLE_API_KEY="$RUNNER_TEMP/api_key.p8" codesign --deep --force --options=runtime --sign "${APPLE_DEVELOPER_ID_APPLICATION}" --timestamp ${{ steps.set_paths.outputs.binary }}
 
-      - name: Sign Windows
+      - name: Sign windows
         working-directory: tools
         if: matrix.settings.system == 'windows'
         env:
@@ -163,10 +157,10 @@ jobs:
         with:
           directory: tools
           type: 'zip'
-          filename: ${{ steps.set_paths.outputs.name }}
+          filename: ${{ steps.set_paths.outputs.zip }}
           path: ${{ steps.set_paths.outputs.binary }}
       
-      - name: "Notarize app bundle"
+      - name: Notarize app bundle
         working-directory: tools
         if: matrix.settings.system == 'apple'
         env:
@@ -187,13 +181,13 @@ jobs:
           path: tools/${{ steps.set_paths.outputs.zip }}
           if-no-files-found: error
 
-      - name: Upload Release Asset
+      - name: Upload release asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: "${{ github.event.release.upload_url }}?name=${{ steps.set_paths.outputs.zip }}"
-          asset_path: ${{ steps.set_paths.outputs.zip }}
+          asset_path: tools/${{ steps.set_paths.outputs.zip }}
           asset_name: ${{ steps.set_paths.outputs.zip }}
           asset_content_type: application/zip


### PR DESCRIPTION
## Summary

This PR addresses an issue with the binary github action (gha) builder/uploader.

Somehow there was no error when running when the `github.event*` were not populated (when testing on a feature branch). But when they were (during the context of a release) and error was occurring as zip file extention wasn't being included by the zip step. This explicitly adds the `.zip` extention and resolves the error.


For release v`1.15.0` I manually created a branch off master, retrieved the upload url for the release via github actions:
```bash
curl -H "Authorization: token :token" \
     -H "Accept: application/vnd.github.v3+json" \
     https://api.github.com/repos/iron-fish/ironfish/releases/tags/v1.15.0
```
And manually updated the `${{github.event.*}}` references to point to that release. The manually run GHA off master then uploaded the files to the release page.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
