### PR TITLE
chore: Upgrade rustc from 1.66 to 1.75

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.75.0"


### PR DESCRIPTION
## Summary
Introduction of `ironfish-frost` repo causes build failures as it relies on features that have only been marked stable in newer versions of rust, this updates our repo so we can pull in `ironfish-frost` as a dependency.

## Testing Plan

Tests pass

Perf tests?

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
