### PR TITLE
Use readonly BlockHeader fields in genesis block creation

### DIFF
--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -179,6 +179,9 @@ export async function makeGenesisBlock(
     transactions: block.transactions,
   })
 
+  genesisBlock.header.noteSize = block.header.noteSize
+  genesisBlock.header.work = block.header.work
+
   logger.info('Block complete.')
   return { block: genesisBlock }
 }

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -170,10 +170,15 @@ export async function makeGenesisBlock(
     GraffitiUtils.fromString('genesis'),
   )
 
-  // Modify the block with any custom properties.
-  block.header.target = info.target
-  block.header.timestamp = new Date(info.timestamp)
+  const genesisBlock = Block.fromRaw({
+    header: {
+      ...block.header,
+      target: info.target,
+      timestamp: new Date(info.timestamp),
+    },
+    transactions: block.transactions,
+  })
 
   logger.info('Block complete.')
-  return { block }
+  return { block: genesisBlock }
 }


### PR DESCRIPTION
## Summary
BlockHeader class fields will be changed to be readonly so that a BlockHeader fields cannot be accidentally updated without updating the hash. This requires updating genesis block creation to not directly modify these block header fields

## Testing Plan
Unit tests + creating a new genesis block locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
