### PR TITLE
Move block explorer urls to CLI client side and out of the SDK

### DIFF
--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -16,7 +16,7 @@ import { Flags } from '@oclif/core'
 import dns from 'dns'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
-import { getExplorerBlockUrl, getExplorerTransactionUrl } from '../../../utils/explorer'
+import { getExplorer } from '../../../utils/explorer'
 
 export class StartPool extends IronfishCommand {
   static description = `Start a mining pool that connects to a node`
@@ -143,8 +143,7 @@ export class StartPool extends IronfishCommand {
       banning: flags.banning,
       tls: flags.tls,
       tlsOptions: tlsOptions,
-      getExplorerBlockUrl,
-      getExplorerTransactionUrl,
+      getExplorer,
     })
 
     await this.pool.start()

--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -16,7 +16,7 @@ import { Flags } from '@oclif/core'
 import dns from 'dns'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
-import { getBlockUrl, getTransactionUrl } from '../../../utils/explorer'
+import { getExplorerBlockUrl, getExplorerTransactionUrl } from '../../../utils/explorer'
 
 export class StartPool extends IronfishCommand {
   static description = `Start a mining pool that connects to a node`
@@ -66,9 +66,6 @@ export class StartPool extends IronfishCommand {
     }
 
     const rpc = this.sdk.client
-    const networkResponse = await rpc.chain.getNetworkInfo()
-    const explorerBlocksUrl = getBlockUrl(networkResponse.content.networkId)
-    const explorerTransactionsUrl = getTransactionUrl(networkResponse.content.networkId)
 
     this.log(`Starting pool with name ${poolName}`)
 
@@ -80,8 +77,6 @@ export class StartPool extends IronfishCommand {
         new Discord({
           webhook: discordWebhook,
           logger: this.logger,
-          explorerBlocksUrl,
-          explorerTransactionsUrl,
         }),
       )
 
@@ -94,8 +89,6 @@ export class StartPool extends IronfishCommand {
         new Lark({
           webhook: larkWebhook,
           logger: this.logger,
-          explorerBlocksUrl,
-          explorerTransactionsUrl,
         }),
       )
 
@@ -150,6 +143,8 @@ export class StartPool extends IronfishCommand {
       banning: flags.banning,
       tls: flags.tls,
       tlsOptions: tlsOptions,
+      getExplorerBlockUrl,
+      getExplorerTransactionUrl,
     })
 
     await this.pool.start()

--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -16,6 +16,7 @@ import { Flags } from '@oclif/core'
 import dns from 'dns'
 import { IronfishCommand } from '../../../command'
 import { RemoteFlags } from '../../../flags'
+import { getBlockUrl, getTransactionUrl } from '../../../utils/explorer'
 
 export class StartPool extends IronfishCommand {
   static description = `Start a mining pool that connects to a node`
@@ -65,6 +66,9 @@ export class StartPool extends IronfishCommand {
     }
 
     const rpc = this.sdk.client
+    const networkResponse = await rpc.chain.getNetworkInfo()
+    const explorerBlocksUrl = getBlockUrl(networkResponse.content.networkId)
+    const explorerTransactionsUrl = getTransactionUrl(networkResponse.content.networkId)
 
     this.log(`Starting pool with name ${poolName}`)
 
@@ -76,8 +80,8 @@ export class StartPool extends IronfishCommand {
         new Discord({
           webhook: discordWebhook,
           logger: this.logger,
-          explorerBlocksUrl: this.sdk.config.get('explorerBlocksUrl'),
-          explorerTransactionsUrl: this.sdk.config.get('explorerTransactionsUrl'),
+          explorerBlocksUrl,
+          explorerTransactionsUrl,
         }),
       )
 
@@ -90,8 +94,8 @@ export class StartPool extends IronfishCommand {
         new Lark({
           webhook: larkWebhook,
           logger: this.logger,
-          explorerBlocksUrl: this.sdk.config.get('explorerBlocksUrl'),
-          explorerTransactionsUrl: this.sdk.config.get('explorerTransactionsUrl'),
+          explorerBlocksUrl,
+          explorerTransactionsUrl,
         }),
       )
 

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -14,7 +14,7 @@ import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
-import { getExplorerTransactionUrl } from '../../utils/explorer'
+import { getExplorer } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { watchTransaction } from '../../utils/transaction'
 
@@ -222,13 +222,13 @@ export class Burn extends IronfishCommand {
     this.log(`Hash: ${transaction.hash().toString('hex')}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
 
-    const networkResponse = await client.chain.getNetworkInfo()
-    const transactionUrl = getExplorerTransactionUrl(
-      networkResponse.content.networkId,
+    const networkId = (await client.chain.getNetworkInfo()).content.networkId
+    const transactionUrl = getExplorer(networkId)?.getTransactionUrl(
       transaction.hash().toString('hex'),
     )
-    transactionUrl &&
+    if (transactionUrl) {
       this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
+    }
 
     if (flags.watch) {
       this.log('')

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -14,6 +14,7 @@ import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
+import { getTransactionUrl } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { watchTransaction } from '../../utils/transaction'
 
@@ -220,11 +221,14 @@ export class Burn extends IronfishCommand {
     this.log(`Amount: ${CurrencyUtils.renderIron(amount)}`)
     this.log(`Hash: ${transaction.hash().toString('hex')}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
-    this.log(
-      `\nIf the transaction is mined, it will appear here https://explorer.ironfish.network/transaction/${transaction
-        .hash()
-        .toString('hex')}`,
+
+    const networkResponse = await client.chain.getNetworkInfo()
+    const transactionUrl = getTransactionUrl(
+      networkResponse.content.networkId,
+      transaction.hash().toString('hex'),
     )
+    transactionUrl &&
+      this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
 
     if (flags.watch) {
       this.log('')

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -14,7 +14,7 @@ import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
-import { getTransactionUrl } from '../../utils/explorer'
+import { getExplorerTransactionUrl } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { watchTransaction } from '../../utils/transaction'
 
@@ -223,7 +223,7 @@ export class Burn extends IronfishCommand {
     this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
 
     const networkResponse = await client.chain.getNetworkInfo()
-    const transactionUrl = getTransactionUrl(
+    const transactionUrl = getExplorerTransactionUrl(
       networkResponse.content.networkId,
       transaction.hash().toString('hex'),
     )

--- a/ironfish-cli/src/commands/wallet/burn.ts
+++ b/ironfish-cli/src/commands/wallet/burn.ts
@@ -226,6 +226,7 @@ export class Burn extends IronfishCommand {
     const transactionUrl = getExplorer(networkId)?.getTransactionUrl(
       transaction.hash().toString('hex'),
     )
+
     if (transactionUrl) {
       this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
     }

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -17,7 +17,7 @@ import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
-import { getTransactionUrl } from '../../utils/explorer'
+import { getExplorerTransactionUrl } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { watchTransaction } from '../../utils/transaction'
 
@@ -296,7 +296,7 @@ export class Mint extends IronfishCommand {
     this.log(`Hash: ${transaction.hash().toString('hex')}`)
 
     const networkResponse = await client.chain.getNetworkInfo()
-    const transactionUrl = getTransactionUrl(
+    const transactionUrl = getExplorerTransactionUrl(
       networkResponse.content.networkId,
       transaction.hash().toString('hex'),
     )

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -299,6 +299,7 @@ export class Mint extends IronfishCommand {
     const transactionUrl = getExplorer(networkId)?.getTransactionUrl(
       transaction.hash().toString('hex'),
     )
+
     if (transactionUrl) {
       this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
     }

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -17,7 +17,7 @@ import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
-import { getExplorerTransactionUrl } from '../../utils/explorer'
+import { getExplorer } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { watchTransaction } from '../../utils/transaction'
 
@@ -295,13 +295,13 @@ export class Mint extends IronfishCommand {
     this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
     this.log(`Hash: ${transaction.hash().toString('hex')}`)
 
-    const networkResponse = await client.chain.getNetworkInfo()
-    const transactionUrl = getExplorerTransactionUrl(
-      networkResponse.content.networkId,
+    const networkId = (await client.chain.getNetworkInfo()).content.networkId
+    const transactionUrl = getExplorer(networkId)?.getTransactionUrl(
       transaction.hash().toString('hex'),
     )
-    transactionUrl &&
+    if (transactionUrl) {
       this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
+    }
 
     if (flags.watch) {
       this.log('')

--- a/ironfish-cli/src/commands/wallet/mint.ts
+++ b/ironfish-cli/src/commands/wallet/mint.ts
@@ -17,6 +17,7 @@ import { IronfishCommand } from '../../command'
 import { IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
+import { getTransactionUrl } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { watchTransaction } from '../../utils/transaction'
 
@@ -293,11 +294,14 @@ export class Mint extends IronfishCommand {
     )
     this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
     this.log(`Hash: ${transaction.hash().toString('hex')}`)
-    this.log(
-      `\nIf the transaction is mined, it will appear here https://explorer.ironfish.network/transaction/${transaction
-        .hash()
-        .toString('hex')}`,
+
+    const networkResponse = await client.chain.getNetworkInfo()
+    const transactionUrl = getTransactionUrl(
+      networkResponse.content.networkId,
+      transaction.hash().toString('hex'),
     )
+    transactionUrl &&
+      this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
 
     if (flags.watch) {
       this.log('')

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -20,7 +20,7 @@ import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { IronFlag, RemoteFlags } from '../../../flags'
 import { ProgressBar } from '../../../types'
-import { getExplorerTransactionUrl } from '../../../utils/explorer'
+import { getExplorer } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
 import { displayTransactionSummary, watchTransaction } from '../../../utils/transaction'
 
@@ -551,13 +551,15 @@ export class CombineNotesCommand extends IronfishCommand {
 
     this.log(`Transaction hash: ${transaction.hash().toString('hex')}`)
 
-    const networkResponse = await client.chain.getNetworkInfo()
-    const transactionUrl = getExplorerTransactionUrl(
-      networkResponse.content.networkId,
-      transaction.hash().toString('hex'),
-    )
-    transactionUrl &&
-      this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
+    const networkId = (await client.chain.getNetworkInfo()).content.networkId
+    const explorer = getExplorer(networkId)
+    if (explorer) {
+      this.log(
+        `\nIf the transaction is mined, it will appear here: ${explorer.getTransactionUrl(
+          transaction.hash().toString('hex'),
+        )}`,
+      )
+    }
 
     if (flags.watch) {
       this.log('')

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -552,13 +552,12 @@ export class CombineNotesCommand extends IronfishCommand {
     this.log(`Transaction hash: ${transaction.hash().toString('hex')}`)
 
     const networkId = (await client.chain.getNetworkInfo()).content.networkId
-    const explorer = getExplorer(networkId)
-    if (explorer) {
-      this.log(
-        `\nIf the transaction is mined, it will appear here: ${explorer.getTransactionUrl(
-          transaction.hash().toString('hex'),
-        )}`,
-      )
+    const transactionUrl = getExplorer(networkId)?.getTransactionUrl(
+      transaction.hash().toString('hex'),
+    )
+
+    if (transactionUrl) {
+      this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
     }
 
     if (flags.watch) {

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -20,6 +20,7 @@ import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { IronFlag, RemoteFlags } from '../../../flags'
 import { ProgressBar } from '../../../types'
+import { getTransactionUrl } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
 import { displayTransactionSummary, watchTransaction } from '../../../utils/transaction'
 
@@ -549,11 +550,14 @@ export class CombineNotesCommand extends IronfishCommand {
     await this.displayCombinedNoteHashes(client, from, transaction)
 
     this.log(`Transaction hash: ${transaction.hash().toString('hex')}`)
-    this.log(
-      `If the transaction is mined, it will appear here https://explorer.ironfish.network/transaction/${transaction
-        .hash()
-        .toString('hex')}`,
+
+    const networkResponse = await client.chain.getNetworkInfo()
+    const transactionUrl = getTransactionUrl(
+      networkResponse.content.networkId,
+      transaction.hash().toString('hex'),
     )
+    transactionUrl &&
+      this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
 
     if (flags.watch) {
       this.log('')

--- a/ironfish-cli/src/commands/wallet/notes/combine.ts
+++ b/ironfish-cli/src/commands/wallet/notes/combine.ts
@@ -20,7 +20,7 @@ import inquirer from 'inquirer'
 import { IronfishCommand } from '../../../command'
 import { IronFlag, RemoteFlags } from '../../../flags'
 import { ProgressBar } from '../../../types'
-import { getTransactionUrl } from '../../../utils/explorer'
+import { getExplorerTransactionUrl } from '../../../utils/explorer'
 import { selectFee } from '../../../utils/fees'
 import { displayTransactionSummary, watchTransaction } from '../../../utils/transaction'
 
@@ -552,7 +552,7 @@ export class CombineNotesCommand extends IronfishCommand {
     this.log(`Transaction hash: ${transaction.hash().toString('hex')}`)
 
     const networkResponse = await client.chain.getNetworkInfo()
-    const transactionUrl = getTransactionUrl(
+    const transactionUrl = getExplorerTransactionUrl(
       networkResponse.content.networkId,
       transaction.hash().toString('hex'),
     )

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -15,7 +15,7 @@ import { IronfishCommand } from '../../command'
 import { HexFlag, IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
-import { getTransactionUrl } from '../../utils/explorer'
+import { getExplorerTransactionUrl } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { displayTransactionSummary, watchTransaction } from '../../utils/transaction'
 
@@ -257,7 +257,7 @@ export class Send extends IronfishCommand {
     this.log(`Memo: ${memo}`)
 
     const networkResponse = await client.chain.getNetworkInfo()
-    const transactionUrl = getTransactionUrl(
+    const transactionUrl = getExplorerTransactionUrl(
       networkResponse.content.networkId,
       transaction.hash().toString('hex'),
     )

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -260,6 +260,7 @@ export class Send extends IronfishCommand {
     const transactionUrl = getExplorer(networkId)?.getTransactionUrl(
       transaction.hash().toString('hex'),
     )
+
     if (transactionUrl) {
       this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
     }

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -15,6 +15,7 @@ import { IronfishCommand } from '../../command'
 import { HexFlag, IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
+import { getTransactionUrl } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { displayTransactionSummary, watchTransaction } from '../../utils/transaction'
 
@@ -254,11 +255,14 @@ export class Send extends IronfishCommand {
     this.log(`Hash: ${transaction.hash().toString('hex')}`)
     this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
     this.log(`Memo: ${memo}`)
-    this.log(
-      `\nIf the transaction is mined, it will appear here https://explorer.ironfish.network/transaction/${transaction
-        .hash()
-        .toString('hex')}`,
+
+    const networkResponse = await client.chain.getNetworkInfo()
+    const transactionUrl = getTransactionUrl(
+      networkResponse.content.networkId,
+      transaction.hash().toString('hex'),
     )
+    transactionUrl &&
+      this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
 
     if (flags.watch) {
       this.log('')

--- a/ironfish-cli/src/commands/wallet/send.ts
+++ b/ironfish-cli/src/commands/wallet/send.ts
@@ -15,7 +15,7 @@ import { IronfishCommand } from '../../command'
 import { HexFlag, IronFlag, RemoteFlags } from '../../flags'
 import { selectAsset } from '../../utils/asset'
 import { promptCurrency } from '../../utils/currency'
-import { getExplorerTransactionUrl } from '../../utils/explorer'
+import { getExplorer } from '../../utils/explorer'
 import { selectFee } from '../../utils/fees'
 import { displayTransactionSummary, watchTransaction } from '../../utils/transaction'
 
@@ -256,13 +256,13 @@ export class Send extends IronfishCommand {
     this.log(`Fee: ${CurrencyUtils.renderIron(transaction.fee(), true)}`)
     this.log(`Memo: ${memo}`)
 
-    const networkResponse = await client.chain.getNetworkInfo()
-    const transactionUrl = getExplorerTransactionUrl(
-      networkResponse.content.networkId,
+    const networkId = (await client.chain.getNetworkInfo()).content.networkId
+    const transactionUrl = getExplorer(networkId)?.getTransactionUrl(
       transaction.hash().toString('hex'),
     )
-    transactionUrl &&
+    if (transactionUrl) {
       this.log(`\nIf the transaction is mined, it will appear here: ${transactionUrl}`)
+    }
 
     if (flags.watch) {
       this.log('')

--- a/ironfish-cli/src/utils/explorer.ts
+++ b/ironfish-cli/src/utils/explorer.ts
@@ -16,12 +16,12 @@ export const getExplorerUrl = (networkId: number): string | null => {
   }
 }
 
-export const getTransactionUrl = (networkId: number, txId?: string): string | null => {
+export const getExplorerTransactionUrl = (networkId: number, txId: string): string | null => {
   const explorerUrl = getExplorerUrl(networkId)
-  return explorerUrl ? `${explorerUrl}/transaction${txId ? `/${txId}` : ''}` : null
+  return explorerUrl ? `${explorerUrl}/transaction/${txId}` : null
 }
 
-export const getBlockUrl = (networkId: number, blockHash?: string): string | null => {
+export const getExplorerBlockUrl = (networkId: number, blockHash: string): string | null => {
   const explorerUrl = getExplorerUrl(networkId)
-  return explorerUrl ? `${explorerUrl}/blocks${blockHash ? `/${blockHash}` : ''}` : null
+  return explorerUrl ? `${explorerUrl}/blocks/${blockHash}` : null
 }

--- a/ironfish-cli/src/utils/explorer.ts
+++ b/ironfish-cli/src/utils/explorer.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 export const EXPLORER_URLS = {
-  0: 'https://explorer.ironfish.network',
-  1: 'https://testnet.explorer.ironfish.network',
+  0: 'https://testnet.explorer.ironfish.network',
+  1: 'https://explorer.ironfish.network',
 }
 
 type ValidNetworkId = keyof typeof EXPLORER_URLS

--- a/ironfish-cli/src/utils/explorer.ts
+++ b/ironfish-cli/src/utils/explorer.ts
@@ -5,7 +5,7 @@
 export const EXPLORER_URL_MAINNET = 'https://explorer.ironfish.network'
 export const EXPLORER_URL_TESTNET = 'https://testnet.explorer.ironfish.network'
 
-export const getExlorerUrl = (networkId: number): string | null => {
+export const getExplorerUrl = (networkId: number): string | null => {
   switch (networkId) {
     case 0:
       return EXPLORER_URL_TESTNET
@@ -17,11 +17,11 @@ export const getExlorerUrl = (networkId: number): string | null => {
 }
 
 export const getTransactionUrl = (networkId: number, txId?: string): string | null => {
-  const explorerUrl = getExlorerUrl(networkId)
+  const explorerUrl = getExplorerUrl(networkId)
   return explorerUrl ? `${explorerUrl}/transaction${txId ? `/${txId}` : ''}` : null
 }
 
 export const getBlockUrl = (networkId: number, blockHash?: string): string | null => {
-  const explorerUrl = getExlorerUrl(networkId)
+  const explorerUrl = getExplorerUrl(networkId)
   return explorerUrl ? `${explorerUrl}/blocks${blockHash ? `/${blockHash}` : ''}` : null
 }

--- a/ironfish-cli/src/utils/explorer.ts
+++ b/ironfish-cli/src/utils/explorer.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export const EXPLORER_URL_MAINNET = 'https://explorer.ironfish.network'
+export const EXPLORER_URL_TESTNET = 'https://testnet.explorer.ironfish.network'
+
+export const getExlorerUrl = (networkId: number): string | null => {
+  switch (networkId) {
+    case 0:
+      return EXPLORER_URL_TESTNET
+    case 1:
+      return EXPLORER_URL_MAINNET
+    default:
+      return null
+  }
+}
+
+export const getTransactionUrl = (networkId: number, txId?: string): string | null => {
+  const explorerUrl = getExlorerUrl(networkId)
+  return explorerUrl ? `${explorerUrl}/transaction${txId ? `/${txId}` : ''}` : null
+}
+
+export const getBlockUrl = (networkId: number, blockHash?: string): string | null => {
+  const explorerUrl = getExlorerUrl(networkId)
+  return explorerUrl ? `${explorerUrl}/blocks${blockHash ? `/${blockHash}` : ''}` : null
+}

--- a/ironfish-cli/src/utils/explorer.ts
+++ b/ironfish-cli/src/utils/explorer.ts
@@ -2,26 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-export const EXPLORER_URL_MAINNET = 'https://explorer.ironfish.network'
-export const EXPLORER_URL_TESTNET = 'https://testnet.explorer.ironfish.network'
+export const EXPLORER_URLS = {
+  0: 'https://explorer.ironfish.network',
+  1: 'https://testnet.explorer.ironfish.network',
+}
 
-export const getExplorerUrl = (networkId: number): string | null => {
-  switch (networkId) {
-    case 0:
-      return EXPLORER_URL_TESTNET
-    case 1:
-      return EXPLORER_URL_MAINNET
-    default:
-      return null
+type ValidNetworkId = keyof typeof EXPLORER_URLS
+
+type Explorer = {
+  getBlockUrl: (hash: string) => string
+  getTransactionUrl: (hash: string) => string
+}
+
+export const getExplorer = (networkId: number): Explorer | null => {
+  if (!(networkId in EXPLORER_URLS)) {
+    return null
   }
-}
 
-export const getExplorerTransactionUrl = (networkId: number, txId: string): string | null => {
-  const explorerUrl = getExplorerUrl(networkId)
-  return explorerUrl ? `${explorerUrl}/transaction/${txId}` : null
-}
-
-export const getExplorerBlockUrl = (networkId: number, blockHash: string): string | null => {
-  const explorerUrl = getExplorerUrl(networkId)
-  return explorerUrl ? `${explorerUrl}/blocks/${blockHash}` : null
+  const url = EXPLORER_URLS[networkId as ValidNetworkId]
+  return {
+    getBlockUrl: (hash: string) => `${url}/blocks/${hash}`,
+    getTransactionUrl: (hash: string) => `${url}/transaction/${hash}`,
+  }
 }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -234,16 +234,6 @@ export type ConfigOptions = {
   jsonLogs: boolean
 
   /**
-   * URL for viewing block information in a block explorer
-   */
-  explorerBlocksUrl: string
-
-  /**
-   * URL for viewing transaction information in a block explorer
-   */
-  explorerTransactionsUrl: string
-
-  /**
    * How many blocks back from the head of the chain to use to calculate the fee
    * estimate
    */
@@ -373,8 +363,6 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     poolMaxConnectionsPerIp: YupUtils.isPositiveInteger,
     poolLarkWebhook: yup.string(),
     jsonLogs: yup.boolean(),
-    explorerBlocksUrl: YupUtils.isUrl,
-    explorerTransactionsUrl: YupUtils.isUrl,
     feeEstimatorMaxBlockHistory: YupUtils.isPositiveInteger,
     feeEstimatorPercentileSlow: YupUtils.isPositiveInteger,
     feeEstimatorPercentileAverage: YupUtils.isPositiveInteger,
@@ -473,8 +461,6 @@ export class Config extends KeyStore<ConfigOptions> {
       poolMaxConnectionsPerIp: 0,
       poolLarkWebhook: '',
       jsonLogs: false,
-      explorerBlocksUrl: 'https://explorer.ironfish.network/blocks/',
-      explorerTransactionsUrl: 'https://explorer.ironfish.network/transaction/',
       feeEstimatorMaxBlockHistory: DEFAULT_FEE_ESTIMATOR_MAX_BLOCK_HISTORY,
       feeEstimatorPercentileSlow: DEFAULT_FEE_ESTIMATOR_PERCENTILE_SLOW,
       feeEstimatorPercentileAverage: DEFAULT_FEE_ESTIMATOR_PERCENTILE_AVERAGE,

--- a/ironfish/src/mining/pool.ts
+++ b/ironfish/src/mining/pool.ts
@@ -27,8 +27,6 @@ import { Explorer, WebhookNotifier } from './webhooks'
 const RECALCULATE_TARGET_TIMEOUT = 10000
 const EVENT_LOOP_MS = 10 * 1000
 
-type GetExplorer = (networkId: number) => Explorer | null
-
 export class MiningPool {
   readonly stratum: StratumServer
   readonly rpc: RpcSocketClient
@@ -61,7 +59,7 @@ export class MiningPool {
   private recalculateTargetInterval: SetIntervalToken | null
   private notifyStatusInterval: SetIntervalToken | null
 
-  private getExplorer: GetExplorer = () => null
+  private getExplorer: (networkId: number) => Explorer | null = () => null
 
   private constructor(options: {
     rpc: RpcSocketClient
@@ -70,7 +68,7 @@ export class MiningPool {
     logger: Logger
     webhooks?: WebhookNotifier[]
     banning?: boolean
-    getExplorer?: GetExplorer
+    getExplorer?: (networkId: number) => Explorer | null
   }) {
     this.rpc = options.rpc
     this.logger = options.logger
@@ -118,7 +116,7 @@ export class MiningPool {
     banning?: boolean
     tls?: boolean
     tlsOptions?: tls.TlsOptions
-    getExplorer?: GetExplorer
+    getExplorer?: (networkId: number) => Explorer | null
   }): Promise<MiningPool> {
     const shares = await MiningPoolShares.init({
       rpc: options.rpc,

--- a/ironfish/src/mining/webhooks/index.ts
+++ b/ironfish/src/mining/webhooks/index.ts
@@ -4,4 +4,4 @@
 
 export { Discord } from './discord'
 export { Lark } from './lark'
-export { WebhookNotifier } from './webhookNotifier'
+export { Explorer, WebhookNotifier } from './webhookNotifier'

--- a/ironfish/src/rpc/clients/client.ts
+++ b/ironfish/src/rpc/clients/client.ts
@@ -742,7 +742,7 @@ export abstract class RpcClient {
 
     getNetworkInfo: (
       params?: GetNetworkInfoRequest,
-    ): Promise<RpcResponse<GetNetworkInfoResponse>> => {
+    ): Promise<RpcResponseEnded<GetNetworkInfoResponse>> => {
       return this.request<GetNetworkInfoResponse>(
         `${ApiNamespace.chain}/getNetworkInfo`,
         params,


### PR DESCRIPTION
## Summary
This PR accomplishes two tasks:
1. The CLI now shows the correct link for transactions whether they are made on mainnet or testnet
2. Any logic relating to ironfish's block explorer is removed from the SDK

The second change is related to an ongoing effort to only have information that is necessary for the blockchain operation in the SDK. Finding blocks and transactions on the block explorer is a layer on top of the network but not part of the network itself. For this it seems to make sense to remove this information from the SDK to the CLI.

## Testing Plan
- Tested running a pool on mainnet + testnet to see if urls match
- Tested transaction send on testnet to see if URL is correct

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[X] Yes
```
https://github.com/iron-fish/website/pull/581

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```

This removes two fields from the SDK config `explorerBlocksUrl` and `explorerTransactionsUrl`
