### PR TITLE
chore: Upgrade ironfish mpc dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,9 +353,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"

--- a/ironfish-mpc/Cargo.toml
+++ b/ironfish-mpc/Cargo.toml
@@ -43,7 +43,7 @@ path = "../ironfish-zkp"
 optional = true
 
 [dependencies.byteorder]
-version = "1"
+version = "1.5"
 optional = true
 
 [dependencies.hex-literal]


### PR DESCRIPTION
## Summary
Upgrades byteorder dependency to be compatible with version needed for `ironfish-rust`
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
