### PR TITLE
Rahul/ifl 2088 add hex to vec bytes

### DIFF
--- a/ironfish-rust/src/serializing/mod.rs
+++ b/ironfish-rust/src/serializing/mod.rs
@@ -63,6 +63,18 @@ pub fn hex_to_bytes<const SIZE: usize>(hex: &str) -> Result<[u8; SIZE], Ironfish
     Ok(bytes)
 }
 
+pub fn hex_to_vec_bytes(hex: &str) -> Result<Vec<u8>, IronfishError> {
+    let mut bytes = Vec::new();
+
+    let hex_iter = hex.as_bytes().chunks_exact(2);
+
+    for (i, hex) in hex_iter.enumerate() {
+        bytes.push(hex_to_u8(hex[0])? << 4 | hex_to_u8(hex[1])?);
+    }
+
+    Ok(bytes)
+}
+
 #[inline]
 fn hex_to_u8(char: u8) -> Result<u8, IronfishError> {
     match char {

--- a/ironfish-rust/src/serializing/mod.rs
+++ b/ironfish-rust/src/serializing/mod.rs
@@ -93,7 +93,10 @@ mod test {
     fn test_hex_to_vec_bytes_valid() {
         let hex = "A1B2C3";
         let expected_bytes = vec![161, 178, 195];
-        assert_eq!(hex_to_vec_bytes(hex).unwrap(), expected_bytes);
+
+        let result = hex_to_vec_bytes(hex).expect("valid hex");
+
+        assert_eq!(result, expected_bytes);
     }
 
     #[test]

--- a/ironfish-rust/src/serializing/mod.rs
+++ b/ironfish-rust/src/serializing/mod.rs
@@ -72,7 +72,7 @@ pub fn hex_to_vec_bytes(hex: &str) -> Result<Vec<u8>, IronfishError> {
 
     let hex_iter = hex.as_bytes().chunks_exact(2);
 
-    for (_i, hex) in hex_iter.enumerate() {
+    for (_, hex) in hex_iter.enumerate() {
         bytes.push(hex_to_u8(hex[0])? << 4 | hex_to_u8(hex[1])?);
     }
 

--- a/ironfish-rust/src/serializing/mod.rs
+++ b/ironfish-rust/src/serializing/mod.rs
@@ -106,14 +106,13 @@ mod test {
     #[test]
     fn test_hex_to_vec_bytes_invalid_char() {
         let hex = "A1B2G3";
-        let result: Result<Vec<u8>, crate::errors::IronfishError> = hex_to_vec_bytes(hex);
-        assert!(result.is_err());
+        hex_to_vec_bytes(hex).expect_err("invalid hex should throw an error");
+    }
 
-        let error = result.unwrap_err();
-        assert!(matches!(
-            error.kind,
-            crate::errors::IronfishErrorKind::InvalidData
-        ));
+    #[test]
+    fn test_hex_to_vec_bytes_invalid_hex_with_odd_length() {
+        let hex = "A1B2C";
+        hex_to_vec_bytes(hex).expect_err("invalid hex should throw an error");
     }
 
     #[test]

--- a/ironfish-rust/src/serializing/mod.rs
+++ b/ironfish-rust/src/serializing/mod.rs
@@ -72,7 +72,7 @@ pub fn hex_to_vec_bytes(hex: &str) -> Result<Vec<u8>, IronfishError> {
 
     let hex_iter = hex.as_bytes().chunks_exact(2);
 
-    for (i, hex) in hex_iter.enumerate() {
+    for (_i, hex) in hex_iter.enumerate() {
         bytes.push(hex_to_u8(hex[0])? << 4 | hex_to_u8(hex[1])?);
     }
 

--- a/ironfish-rust/src/serializing/mod.rs
+++ b/ironfish-rust/src/serializing/mod.rs
@@ -64,6 +64,10 @@ pub fn hex_to_bytes<const SIZE: usize>(hex: &str) -> Result<[u8; SIZE], Ironfish
 }
 
 pub fn hex_to_vec_bytes(hex: &str) -> Result<Vec<u8>, IronfishError> {
+    if hex.len() % 2 != 0 {
+        return Err(IronfishError::new(IronfishErrorKind::InvalidData));
+    }
+
     let mut bytes = Vec::new();
 
     let hex_iter = hex.as_bytes().chunks_exact(2);

--- a/ironfish-rust/src/serializing/mod.rs
+++ b/ironfish-rust/src/serializing/mod.rs
@@ -87,7 +87,27 @@ fn hex_to_u8(char: u8) -> Result<u8, IronfishError> {
 
 #[cfg(test)]
 mod test {
-    use crate::serializing::{bytes_to_hex, hex_to_bytes};
+    use crate::serializing::{bytes_to_hex, hex_to_bytes, hex_to_vec_bytes};
+
+    #[test]
+    fn test_hex_to_vec_bytes_valid() {
+        let hex = "A1B2C3";
+        let expected_bytes = vec![161, 178, 195];
+        assert_eq!(hex_to_vec_bytes(hex).unwrap(), expected_bytes);
+    }
+
+    #[test]
+    fn test_hex_to_vec_bytes_invalid_char() {
+        let hex = "A1B2G3";
+        let result: Result<Vec<u8>, crate::errors::IronfishError> = hex_to_vec_bytes(hex);
+        assert!(result.is_err());
+
+        let error = result.unwrap_err();
+        assert!(matches!(
+            error.kind,
+            crate::errors::IronfishErrorKind::InvalidData
+        ));
+    }
 
     #[test]
     fn hex_serde() {


### PR DESCRIPTION
## Summary

Adding `hex_to_vec_bytes` function. 

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
