### PR TITLE
feat: Add build method proposed transaction

### DIFF
--- a/ironfish-rust/src/transaction/unsigned.rs
+++ b/ironfish-rust/src/transaction/unsigned.rs
@@ -20,28 +20,28 @@ use super::{
 pub struct UnsignedTransaction {
     /// The transaction serialization version. This can be incremented when
     /// changes need to be made to the transaction format
-    version: TransactionVersion,
+    pub(crate) version: TransactionVersion,
 
     /// List of spends, or input notes, that have been destroyed.
-    spends: Vec<UnsignedSpendDescription>,
+    pub(crate) spends: Vec<UnsignedSpendDescription>,
 
     /// List of outputs, or output notes that have been created.
-    outputs: Vec<OutputDescription>,
+    pub(crate) outputs: Vec<OutputDescription>,
 
     /// List of mint descriptions
-    mints: Vec<UnsignedMintDescription>,
+    pub(crate) mints: Vec<UnsignedMintDescription>,
 
     /// List of burn descriptions
-    burns: Vec<BurnDescription>,
+    pub(crate) burns: Vec<BurnDescription>,
 
     /// Signature calculated from accumulating randomness with all the spends
     /// and outputs when the transaction was created.
-    binding_signature: Signature,
+    pub(crate) binding_signature: Signature,
 
     /// This is the sequence in the chain the transaction will expire at and be
     /// removed from the mempool. A value of 0 indicates the transaction will
     /// not expire.
-    expiration: u32,
+    pub(crate) expiration: u32,
 
     /// Randomized public key of the sender of the Transaction
     /// currently this value is the same for all spends[].owner and outputs[].sender
@@ -49,13 +49,13 @@ pub struct UnsignedTransaction {
     /// well as signing of the SpendDescriptions. Referred to as
     /// `rk` in the literature Calculated from the authorizing key and
     /// the public_key_randomness.
-    randomized_public_key: redjubjub::PublicKey,
+    pub(crate) randomized_public_key: redjubjub::PublicKey,
 
     // TODO: Verify if this is actually okay to store on the unsigned transaction
-    public_key_randomness: jubjub::Fr,
+    pub(crate) public_key_randomness: jubjub::Fr,
 
     /// The balance of total spends - outputs, which is the amount that the miner gets to keep
-    fee: i64,
+    pub(crate) fee: i64,
 }
 
 impl UnsignedTransaction {

--- a/ironfish-rust/src/transaction/utils.rs
+++ b/ironfish-rust/src/transaction/utils.rs
@@ -3,6 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use bellperson::groth16;
 use blstrs::Bls12;
+use group::GroupEncoding;
+use ironfish_zkp::ProofGenerationKey;
+use jubjub::{SubgroupPoint, Fr};
 
 use crate::{
     errors::{IronfishError, IronfishErrorKind},
@@ -49,4 +52,24 @@ pub(crate) fn verify_mint_proof(
     }
 
     Ok(())
+}
+
+pub fn proof_generation_key_to_bytes(proof_generation_key: ProofGenerationKey) -> [u8; 64] {
+    let mut proof_generation_key_bytes: [u8; 64] = [0; 64];
+    proof_generation_key_bytes[0..32].copy_from_slice(&proof_generation_key.ak.to_bytes());
+    proof_generation_key_bytes[32..].copy_from_slice(&proof_generation_key.nsk.to_bytes());
+
+    proof_generation_key_bytes
+}
+
+pub fn bytes_to_proof_generation_key(proof_generation_key_bytes: [u8; 64]) -> ProofGenerationKey {
+    let mut ak_bytes: [u8; 32] = [0; 32];
+    let mut nsk_bytes: [u8; 32] = [0; 32];
+
+    ak_bytes[0..32].copy_from_slice(&proof_generation_key_bytes[0..32]);
+    nsk_bytes[0..32].copy_from_slice(&proof_generation_key_bytes[32..64]);
+
+    let ak = SubgroupPoint::from_bytes(&ak_bytes).unwrap();
+    let nsk = Fr::from_bytes(&nsk_bytes).unwrap();
+    ProofGenerationKey { ak, nsk }
 }

--- a/ironfish-rust/src/transaction/utils.rs
+++ b/ironfish-rust/src/transaction/utils.rs
@@ -3,9 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use bellperson::groth16;
 use blstrs::Bls12;
-use group::GroupEncoding;
-use ironfish_zkp::ProofGenerationKey;
-use jubjub::{SubgroupPoint, Fr};
 
 use crate::{
     errors::{IronfishError, IronfishErrorKind},
@@ -52,24 +49,4 @@ pub(crate) fn verify_mint_proof(
     }
 
     Ok(())
-}
-
-pub fn proof_generation_key_to_bytes(proof_generation_key: ProofGenerationKey) -> [u8; 64] {
-    let mut proof_generation_key_bytes: [u8; 64] = [0; 64];
-    proof_generation_key_bytes[0..32].copy_from_slice(&proof_generation_key.ak.to_bytes());
-    proof_generation_key_bytes[32..].copy_from_slice(&proof_generation_key.nsk.to_bytes());
-
-    proof_generation_key_bytes
-}
-
-pub fn bytes_to_proof_generation_key(proof_generation_key_bytes: [u8; 64]) -> ProofGenerationKey {
-    let mut ak_bytes: [u8; 32] = [0; 32];
-    let mut nsk_bytes: [u8; 32] = [0; 32];
-
-    ak_bytes[0..32].copy_from_slice(&proof_generation_key_bytes[0..32]);
-    nsk_bytes[0..32].copy_from_slice(&proof_generation_key_bytes[32..64]);
-
-    let ak = SubgroupPoint::from_bytes(&ak_bytes).unwrap();
-    let nsk = Fr::from_bytes(&nsk_bytes).unwrap();
-    ProofGenerationKey { ak, nsk }
 }


### PR DESCRIPTION
## Summary
This allows us to take the necessary keys and go from a `ProposedTransaction` (raw transaction data), to an `UnsignedTransaction`, which will be used for frost multisig.

This introduces a bit of code duplication in the `post()` and `build()` code paths of `ProposedTransaction`, I suggest we move the `post` and `_partial_post` methods to `UnsignedTransaction` so that we can deduplicate the logic. Then on `ProposedTransaction`.
## Testing Plan
New test passes
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
