### PR TITLE
Rahul/ifl 2093 add frost signature to unsigned spends and mints

### DIFF
--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -663,7 +663,6 @@ mod test {
     fn test_add_signature() {
         let key = SaplingKey::generate_key();
         let public_address = key.public_address();
-        let sender_key = SaplingKey::generate_key();
 
         let asset = Asset::new(public_address, "name", "").expect("should be able to create asset");
         let public_key_randomness = jubjub::Fr::random(thread_rng());
@@ -677,7 +676,7 @@ mod test {
         let msg = [0u8; 32];
         let signature = private_key.sign(&msg, &mut thread_rng(), *SPENDING_KEY_GENERATOR);
         let unsigned_spend_description = builder
-            .build(&sender_key, &public_key_randomness, &randomized_public_key)
+            .build(&key, &public_key_randomness, &randomized_public_key)
             .expect("should be able to build proof");
         unsigned_spend_description.add_signature(signature);
         assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR))

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -147,7 +147,7 @@ impl UnsignedMintDescription {
         Ok(self.description)
     }
 
-    pub fn sign_frost(mut self, signature: Signature) -> Result<MintDescription, IronfishError> {
+    pub fn add_signature(mut self, signature: Signature) -> Result<MintDescription, IronfishError> {
         self.description.authorizing_signature = signature;
         Ok(self.description)
     }
@@ -660,7 +660,7 @@ mod test {
     }
 
     #[test]
-    fn test_sign_frost() {
+    fn test_add_signature() {
         let key = SaplingKey::generate_key();
         let public_address = key.public_address();
         let sender_key = SaplingKey::generate_key();
@@ -680,8 +680,8 @@ mod test {
             .build(&sender_key, &public_key_randomness, &randomized_public_key)
             .expect("should be able to build proof");
         unsigned_spend_description
-            .sign_frost(signature)
-            .expect("should be able to sign");
+            .add_signature(signature)
+            .expect("should be able to add signature");
         assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR) == true)
     }
 }

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -147,8 +147,9 @@ impl UnsignedMintDescription {
         Ok(self.description)
     }
 
-    pub fn add_signature(mut self, signature: Signature) {
+    pub fn add_signature(mut self, signature: Signature) -> MintDescription {
         self.description.authorizing_signature = signature;
+        self.description
     }
 
     pub fn read<R: io::Read>(

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -678,8 +678,7 @@ mod test {
         let unsigned_spend_description = builder
             .build(&sender_key, &public_key_randomness, &randomized_public_key)
             .expect("should be able to build proof");
-        unsigned_spend_description
-            .add_signature(signature);
+        unsigned_spend_description.add_signature(signature);
         assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR))
     }
 }

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -147,9 +147,8 @@ impl UnsignedMintDescription {
         Ok(self.description)
     }
 
-    pub fn add_signature(mut self, signature: Signature) -> Result<MintDescription, IronfishError> {
+    pub fn add_signature(mut self, signature: Signature) {
         self.description.authorizing_signature = signature;
-        Ok(self.description)
     }
 
     pub fn read<R: io::Read>(
@@ -680,8 +679,7 @@ mod test {
             .build(&sender_key, &public_key_randomness, &randomized_public_key)
             .expect("should be able to build proof");
         unsigned_spend_description
-            .add_signature(signature)
-            .expect("should be able to add signature");
-        assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR) == true)
+            .add_signature(signature);
+        assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR))
     }
 }

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -359,7 +359,7 @@ impl MintDescription {
 mod test {
     use ff::Field;
     use ironfish_zkp::{constants::SPENDING_KEY_GENERATOR, redjubjub};
-    use rand::thread_rng;
+    use rand::{random, thread_rng};
 
     use crate::{
         assets::asset::Asset,
@@ -657,5 +657,31 @@ mod test {
 
         let unsigned_mint = mint.build(&key, &public_key_randomness, &randomized_public_key);
         assert!(unsigned_mint.is_err());
+    }
+
+    #[test]
+    fn test_sign_frost() {
+        let key = SaplingKey::generate_key();
+        let public_address = key.public_address();
+        let sender_key = SaplingKey::generate_key();
+
+        let asset = Asset::new(public_address, "name", "").expect("should be able to create asset");
+        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
+            .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
+        let value = random();
+        let builder = MintBuilder::new(asset, value);
+        // create a random private key and sign random message as placeholder
+        let private_key = redjubjub::PrivateKey(jubjub::Fr::random(thread_rng()));
+        let public_key = redjubjub::PublicKey::from_private(&private_key, *SPENDING_KEY_GENERATOR);
+        let msg = [0u8; 32];
+        let signature = private_key.sign(&msg, &mut thread_rng(), *SPENDING_KEY_GENERATOR);
+        let unsigned_spend_description = builder
+            .build(&sender_key, &public_key_randomness, &randomized_public_key)
+            .expect("should be able to build proof");
+        unsigned_spend_description
+            .sign_frost(signature)
+            .expect("should be able to sign");
+        assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR) == true)
     }
 }

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -147,6 +147,11 @@ impl UnsignedMintDescription {
         Ok(self.description)
     }
 
+    pub fn sign_frost(mut self, signature: Signature) -> Result<MintDescription, IronfishError> {
+        self.description.authorizing_signature = signature;
+        Ok(self.description)
+    }
+
     pub fn read<R: io::Read>(
         mut reader: R,
         version: TransactionVersion,
@@ -347,11 +352,6 @@ impl MintDescription {
         self.authorizing_signature.write(&mut writer)?;
 
         Ok(())
-    }
-
-    pub fn sign_frost(mut self, signature: Signature) -> Result<MintDescription, IronfishError> {
-        self.description.authorizing_signature = signature;
-        Ok(self.description)
     }
 }
 

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -348,6 +348,11 @@ impl MintDescription {
 
         Ok(())
     }
+
+    pub fn sign_frost(mut self, signature: Signature) -> Result<MintDescription, IronfishError> {
+        self.description.authorizing_signature = signature;
+        Ok(self.description)
+    }
 }
 
 #[cfg(test)]

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -194,8 +194,9 @@ impl UnsignedSpendDescription {
         Ok(self.description)
     }
 
-    pub fn add_signature(mut self, signature: Signature) {
+    pub fn add_signature(mut self, signature: Signature) -> SpendDescription {
         self.description.authorizing_signature = signature;
+        self.description
     }
 
     pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -197,9 +197,8 @@ impl UnsignedSpendDescription {
     pub fn add_signature(
         mut self,
         signature: Signature,
-    ) -> Result<SpendDescription, IronfishError> {
-        self.description.authorizing_signature = signature;
-        Ok(self.description)
+    ) {
+        self.description.authorizing_signature = signature;  
     }
 
     pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
@@ -617,14 +616,13 @@ mod test {
         let unsigned_spend_description = builder
             .build(
                 &key.sapling_proof_generation_key(),
-                &key.view_key(),
+                key.view_key(),
                 &public_key_randomness,
                 &randomized_public_key,
             )
             .expect("should be able to build proof");
         unsigned_spend_description
-            .add_signature(signature)
-            .expect("should add signature");
-        assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR) == true)
+            .add_signature(signature);
+        assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR))
     }
 }

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -194,7 +194,7 @@ impl UnsignedSpendDescription {
         Ok(self.description)
     }
 
-    pub fn sign_frost(mut self, signature: Signature) -> Result<SpendDescription, IronfishError> {
+    pub fn add_signature(mut self, signature: Signature) -> Result<SpendDescription, IronfishError> {
         self.description.authorizing_signature = signature;
         Ok(self.description)
     }
@@ -586,7 +586,7 @@ mod test {
     }
 
     #[test]
-    fn test_sign_frost() {
+    fn test_add_signature() {
         let key = SaplingKey::generate_key();
         let public_address = key.public_address();
         let sender_key = SaplingKey::generate_key();
@@ -620,8 +620,8 @@ mod test {
             )
             .expect("should be able to build proof");
         unsigned_spend_description
-            .sign_frost(signature)
-            .expect("should be able to sign");
+            .add_signature(signature)
+            .expect("should add signature");
         assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR) == true)
     }
 }

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -587,7 +587,6 @@ mod test {
 
     #[test]
     fn test_sign_frost() {
-
         let key = SaplingKey::generate_key();
         let public_address = key.public_address();
         let sender_key = SaplingKey::generate_key();
@@ -620,8 +619,9 @@ mod test {
                 &randomized_public_key,
             )
             .expect("should be able to build proof");
-        unsigned_spend_description.sign_frost(signature).expect("should be able to sign");
+        unsigned_spend_description
+            .sign_frost(signature)
+            .expect("should be able to sign");
         assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR) == true)
     }
-        
-}   
+}

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -194,7 +194,10 @@ impl UnsignedSpendDescription {
         Ok(self.description)
     }
 
-    pub fn add_signature(mut self, signature: Signature) -> Result<SpendDescription, IronfishError> {
+    pub fn add_signature(
+        mut self,
+        signature: Signature,
+    ) -> Result<SpendDescription, IronfishError> {
         self.description.authorizing_signature = signature;
         Ok(self.description)
     }

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -194,11 +194,8 @@ impl UnsignedSpendDescription {
         Ok(self.description)
     }
 
-    pub fn add_signature(
-        mut self,
-        signature: Signature,
-    ) {
-        self.description.authorizing_signature = signature;  
+    pub fn add_signature(mut self, signature: Signature) {
+        self.description.authorizing_signature = signature;
     }
 
     pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
@@ -621,8 +618,7 @@ mod test {
                 &randomized_public_key,
             )
             .expect("should be able to build proof");
-        unsigned_spend_description
-            .add_signature(signature);
+        unsigned_spend_description.add_signature(signature);
         assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR))
     }
 }

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -194,6 +194,11 @@ impl UnsignedSpendDescription {
         Ok(self.description)
     }
 
+    pub fn sign_frost(mut self, signature: Signature) -> Result<SpendDescription, IronfishError> {
+        self.description.authorizing_signature = signature;
+        Ok(self.description)
+    }
+
     pub fn read<R: io::Read>(mut reader: R) -> Result<Self, IronfishError> {
         let public_key_randomness = read_scalar(&mut reader)?;
         let description = SpendDescription::read(&mut reader)?;

--- a/ironfish-rust/src/transaction/spends.rs
+++ b/ironfish-rust/src/transaction/spends.rs
@@ -414,7 +414,7 @@ mod test {
     use ff::Field;
     use group::Curve;
     use ironfish_zkp::constants::SPENDING_KEY_GENERATOR;
-    use ironfish_zkp::redjubjub;
+    use ironfish_zkp::redjubjub::{self, PrivateKey, PublicKey};
     use rand::prelude::*;
     use rand::{thread_rng, Rng};
 
@@ -584,4 +584,44 @@ mod test {
             .expect("should be able to serialize proof again");
         assert_eq!(serialized_proof, serialized_again);
     }
-}
+
+    #[test]
+    fn test_sign_frost() {
+
+        let key = SaplingKey::generate_key();
+        let public_address = key.public_address();
+        let sender_key = SaplingKey::generate_key();
+
+        let note_randomness = random();
+
+        let note = Note::new(
+            public_address,
+            note_randomness,
+            "",
+            NATIVE_ASSET,
+            sender_key.public_address(),
+        );
+        let witness = make_fake_witness(&note);
+        let public_key_randomness = jubjub::Fr::random(thread_rng());
+        let randomized_public_key = redjubjub::PublicKey(key.view_key.authorizing_key.into())
+            .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
+
+        let builder = SpendBuilder::new(note, &witness);
+        // create a random private key and sign random message as placeholder
+        let private_key = PrivateKey(jubjub::Fr::random(thread_rng()));
+        let public_key = PublicKey::from_private(&private_key, *SPENDING_KEY_GENERATOR);
+        let msg = [0u8; 32];
+        let signature = private_key.sign(&msg, &mut thread_rng(), *SPENDING_KEY_GENERATOR);
+        let unsigned_spend_description = builder
+            .build(
+                &key.sapling_proof_generation_key(),
+                &key.view_key(),
+                &public_key_randomness,
+                &randomized_public_key,
+            )
+            .expect("should be able to build proof");
+        unsigned_spend_description.sign_frost(signature).expect("should be able to sign");
+        assert!(public_key.verify(&msg, &signature, *SPENDING_KEY_GENERATOR) == true)
+    }
+        
+}   


### PR DESCRIPTION
## Summary

Add a method to assign the authorizing signature. This will be used in the signature aggregate method when we construct the transaction for multi signature wallets. 

## Testing Plan

Unit tests

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
