### PR TITLE
Hash block header with strategy class

### DIFF
--- a/ironfish/src/blockchain/blockchain.test.ts
+++ b/ironfish/src/blockchain/blockchain.test.ts
@@ -435,7 +435,7 @@ describe('Blockchain', () => {
     const genesis = nodeTest.chain.genesis
     expect(node.chain.head?.hash).toEqualBuffer(genesis.hash)
 
-    const blockB3Invalid = Block.fromRaw({
+    const blockB3Invalid = nodeTest.strategy.newBlock({
       header: {
         ...blockB3.header,
         noteCommitment: Buffer.alloc(32),
@@ -731,7 +731,7 @@ describe('Blockchain', () => {
       valid: true,
     })
 
-    const invalidBlock = Block.fromRaw({
+    const invalidBlock = nodeTest.strategy.newBlock({
       header: {
         ...block.header,
         timestamp: new Date(0),

--- a/ironfish/src/blockchain/blockchain.ts
+++ b/ironfish/src/blockchain/blockchain.ts
@@ -200,7 +200,7 @@ export class Blockchain {
   }
 
   private async seed() {
-    const genesis = BlockSerde.deserialize(this.seedGenesisBlock)
+    const genesis = BlockSerde.deserialize(this.seedGenesisBlock, this.strategy)
 
     const result = await this.addBlock(genesis)
     Assert.isTrue(result.isAdded, `Could not seed genesis: ${result.reason || 'unknown'}`)
@@ -230,7 +230,7 @@ export class Blockchain {
     if (genesisHeader) {
       Assert.isTrue(
         genesisHeader.hash.equals(
-          BlockHeaderSerde.deserialize(this.seedGenesisBlock.header).hash,
+          BlockHeaderSerde.deserialize(this.seedGenesisBlock.header, this.strategy).hash,
         ),
         'Genesis block in network definition does not match existing chain genesis block',
       )
@@ -948,7 +948,7 @@ export class Blockchain {
         graffiti,
       }
 
-      const header = new BlockHeader(rawHeader, noteSize, BigInt(0))
+      const header = this.strategy.newBlockHeader(rawHeader, noteSize, BigInt(0))
 
       const block = new Block(header, transactions)
       if (verifyBlock && !previousBlockHash.equals(GENESIS_BLOCK_PREVIOUS)) {

--- a/ironfish/src/blockchain/database/headers.ts
+++ b/ironfish/src/blockchain/database/headers.ts
@@ -63,7 +63,7 @@ export class HeaderEncoding implements IDatabaseEncoding<HeaderValue> {
       timestamp: new Date(timestamp),
       graffiti,
     }
-    const header = new BlockHeader(rawHeader, noteSize, work, hash)
+    const header = new BlockHeader(rawHeader, hash, noteSize, work)
 
     return { header }
   }

--- a/ironfish/src/genesis/addGenesisTransaction.ts
+++ b/ironfish/src/genesis/addGenesisTransaction.ts
@@ -9,7 +9,7 @@ import {
 } from '@ironfish/rust-nodejs'
 import { Logger } from '../logger'
 import { FullNode } from '../node'
-import { Block, BlockHeader } from '../primitives'
+import { Block } from '../primitives'
 import { transactionCommitment } from '../primitives/blockheader'
 import { Transaction, TransactionVersion } from '../primitives/transaction'
 import { CurrencyUtils } from '../utils'
@@ -139,7 +139,7 @@ export async function addGenesisTransaction(
     graffiti: genesisBlock.header.graffiti,
   }
 
-  const newGenesisHeader = new BlockHeader(rawHeader, noteSize)
+  const newGenesisHeader = node.chain.strategy.newBlockHeader(rawHeader, noteSize)
 
   genesisBlock.header = newGenesisHeader
 

--- a/ironfish/src/genesis/genesis.test.slow.ts
+++ b/ironfish/src/genesis/genesis.test.slow.ts
@@ -121,7 +121,7 @@ describe('Create genesis block', () => {
 
     // Deserialize the block and add it to the new chain
     const result = IJSON.parse(jsonedBlock) as SerializedBlock
-    const deserializedBlock = BlockSerde.deserialize(result)
+    const deserializedBlock = BlockSerde.deserialize(result, nodeTest.strategy)
     const addedBlock = await newChain.addBlock(deserializedBlock)
     expect(addedBlock.isAdded).toBe(true)
 
@@ -274,7 +274,7 @@ describe('addGenesisTransaction', () => {
 
     // Deserialize the block and add it to the new chain
     const result = IJSON.parse(jsonedBlock) as SerializedBlock
-    const deserializedBlock = BlockSerde.deserialize(result)
+    const deserializedBlock = BlockSerde.deserialize(result, nodeTest.strategy)
     const addedBlock = await chain.addBlock(deserializedBlock)
     expect(addedBlock.isAdded).toBe(true)
 

--- a/ironfish/src/genesis/makeGenesisBlock.ts
+++ b/ironfish/src/genesis/makeGenesisBlock.ts
@@ -170,17 +170,18 @@ export async function makeGenesisBlock(
     GraffitiUtils.fromString('genesis'),
   )
 
-  const genesisBlock = Block.fromRaw({
-    header: {
-      ...block.header,
-      target: info.target,
-      timestamp: new Date(info.timestamp),
+  const genesisBlock = chain.strategy.newBlock(
+    {
+      header: {
+        ...block.header,
+        target: info.target,
+        timestamp: new Date(info.timestamp),
+      },
+      transactions: block.transactions,
     },
-    transactions: block.transactions,
-  })
-
-  genesisBlock.header.noteSize = block.header.noteSize
-  genesisBlock.header.work = block.header.work
+    block.header.noteSize,
+    block.header.work,
+  )
 
   logger.info('Block complete.')
   return { block: genesisBlock }

--- a/ironfish/src/mining/manager.test.slow.ts
+++ b/ironfish/src/mining/manager.test.slow.ts
@@ -4,7 +4,7 @@
 import { Assert } from '../assert'
 import { VerificationResultReason } from '../consensus'
 import { getBlockWithMinersFeeSize, getTransactionSize } from '../network/utils/serializers'
-import { Block, Target, Transaction } from '../primitives'
+import { Target, Transaction } from '../primitives'
 import { TransactionVersion } from '../primitives/transaction'
 import { BlockTemplateSerde, SerializedBlockTemplate } from '../serde'
 import {
@@ -626,7 +626,7 @@ describe('Mining manager', () => {
       // Create 2 blocks at the same sequence, one with higher difficulty
       const blockA1 = await useMinerBlockFixture(chain, undefined, account, wallet)
       const blockB1Temp = await useMinerBlockFixture(chain, undefined, account, wallet)
-      const blockB1 = Block.fromRaw({
+      const blockB1 = nodeTest.strategy.newBlock({
         header: {
           ...blockB1Temp.header,
           target: Target.fromDifficulty(blockA1.header.target.toDifficulty() + 1n),
@@ -641,8 +641,8 @@ describe('Mining manager', () => {
       await expect(chain).toAddBlock(blockB1)
 
       // Increase difficulty of submitted template so it
-      const blockA2Temp = BlockTemplateSerde.deserialize(templateA2)
-      const blockA2 = Block.fromRaw({
+      const blockA2Temp = BlockTemplateSerde.deserialize(templateA2, nodeTest.strategy)
+      const blockA2 = nodeTest.strategy.newBlock({
         header: {
           ...blockA2Temp.header,
           target: Target.fromDifficulty(blockA2Temp.header.target.toDifficulty() + 2n),
@@ -680,7 +680,7 @@ describe('Mining manager', () => {
         MINED_RESULT.SUCCESS,
       )
 
-      const submittedBlock = BlockTemplateSerde.deserialize(template)
+      const submittedBlock = BlockTemplateSerde.deserialize(template, nodeTest.strategy)
       const newBlock = onNewBlockSpy.mock.calls[0][0]
       expect(newBlock.header.hash).toEqual(submittedBlock.header.hash)
     })

--- a/ironfish/src/mining/manager.ts
+++ b/ironfish/src/mining/manager.ts
@@ -198,7 +198,7 @@ export class MiningManager {
       this.metrics.mining_newBlockTemplate.add(BenchUtils.end(connectedAt))
       this.streamBlockTemplate(currentBlock, template)
 
-      const block = BlockTemplateSerde.deserialize(template)
+      const block = BlockTemplateSerde.deserialize(template, this.chain.strategy)
       const verification = await this.chain.verifier.verifyBlock(block, {
         verifyTarget: false,
       })
@@ -366,7 +366,7 @@ export class MiningManager {
   }
 
   async submitBlockTemplate(blockTemplate: SerializedBlockTemplate): Promise<MINED_RESULT> {
-    const block = BlockTemplateSerde.deserialize(blockTemplate)
+    const block = BlockTemplateSerde.deserialize(blockTemplate, this.chain.strategy)
 
     const blockDisplay = `${block.header.hash.toString('hex')} (${block.header.sequence})`
     if (!block.header.previousBlockHash.equals(this.node.chain.head.hash)) {

--- a/ironfish/src/network/messages/getBlocks.test.ts
+++ b/ironfish/src/network/messages/getBlocks.test.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { Block, BlockHeader, Target } from '../../primitives'
+import { Block, Target } from '../../primitives'
 import { transactionCommitment } from '../../primitives/blockheader'
 import {
   createNodeTest,
@@ -36,7 +36,7 @@ describe('GetBlocksResponse', () => {
     const message = new GetBlocksResponse(
       [
         new Block(
-          new BlockHeader({
+          nodeTest.strategy.newBlockHeader({
             sequence: 2,
             previousBlockHash: Buffer.alloc(32, 2),
             noteCommitment: Buffer.alloc(32, 4),
@@ -49,7 +49,7 @@ describe('GetBlocksResponse', () => {
           [transactionA, transactionB],
         ),
         new Block(
-          new BlockHeader({
+          nodeTest.strategy.newBlockHeader({
             sequence: 2,
             previousBlockHash: Buffer.alloc(32, 1),
             noteCommitment: Buffer.alloc(32, 5),

--- a/ironfish/src/network/messages/getCompactBlock.test.ts
+++ b/ironfish/src/network/messages/getCompactBlock.test.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BlockHeader, Target } from '../../primitives'
+import { Target } from '../../primitives'
 import { CompactBlock } from '../../primitives/block'
 import {
   createNodeTest,
@@ -33,7 +33,7 @@ describe('GetCompactBlockResponse', () => {
     const transactionB = await useMinersTxFixture(nodeTest.node, account)
 
     const compactBlock: CompactBlock = {
-      header: new BlockHeader({
+      header: nodeTest.strategy.newBlockHeader({
         sequence: 2,
         previousBlockHash: Buffer.alloc(32, 2),
         noteCommitment: Buffer.alloc(32, 1),

--- a/ironfish/src/network/messages/newCompactBlock.test.ts
+++ b/ironfish/src/network/messages/newCompactBlock.test.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BlockHeader, Target } from '../../primitives'
+import { Target } from '../../primitives'
 import { CompactBlock } from '../../primitives/block'
 import { transactionCommitment } from '../../primitives/blockheader'
 import {
@@ -40,7 +40,7 @@ describe('NewCompactBlockMessage', () => {
     const transactionB = await useMinersTxFixture(nodeTest.node, account)
 
     const compactBlock: CompactBlock = {
-      header: new BlockHeader({
+      header: {
         sequence: 2,
         previousBlockHash: Buffer.alloc(32, 2),
         noteCommitment: Buffer.alloc(32, 1),
@@ -49,7 +49,7 @@ describe('NewCompactBlockMessage', () => {
         randomness: BigInt(1),
         timestamp: new Date(200000),
         graffiti: Buffer.alloc(32, 'graffiti1', 'utf8'),
-      }),
+      },
       transactions: [
         { transaction: transactionA, index: 0 },
         { transaction: transactionB, index: 2 },

--- a/ironfish/src/network/peerNetwork.test.ts
+++ b/ironfish/src/network/peerNetwork.test.ts
@@ -11,7 +11,7 @@ import net from 'net'
 import ws from 'ws'
 import { Assert } from '../assert'
 import { VerificationResultReason } from '../consensus/verifier'
-import { Block, BlockHeader, Transaction } from '../primitives'
+import { Block, Transaction } from '../primitives'
 import { CompactBlock } from '../primitives/block'
 import {
   useAccountFixture,
@@ -763,7 +763,7 @@ describe('PeerNetwork', () => {
             expect(sendSpy).not.toHaveBeenCalled()
           }
 
-          const invalidHeader = new BlockHeader(invalidBlock.header)
+          const invalidHeader = nodeTest.strategy.newBlockHeader(invalidBlock.header)
           await expect(chain.hasBlock(invalidHeader.hash)).resolves.toBe(false)
           expect(chain.isInvalid(invalidHeader)).toBe(reason)
         }

--- a/ironfish/src/network/peerNetwork.ts
+++ b/ironfish/src/network/peerNetwork.ts
@@ -614,7 +614,9 @@ export class PeerNetwork {
       throw new Error(`Invalid GetBlockHeadersResponse: ${message.displayType()}`)
     }
 
-    const headers = response.headers.map((rawHeader) => new BlockHeader(rawHeader))
+    const headers = response.headers.map((rawHeader) =>
+      this.chain.strategy.newBlockHeader(rawHeader),
+    )
 
     return { headers, time: BenchUtils.end(begin) }
   }
@@ -637,7 +639,7 @@ export class PeerNetwork {
     const exceededSoftLimit = response.getSize() >= SOFT_MAX_MESSAGE_SIZE
     const isMessageFull = exceededSoftLimit || response.blocks.length >= limit
 
-    const blocks = response.blocks.map((rawBlock) => Block.fromRaw(rawBlock))
+    const blocks = response.blocks.map((rawBlock) => this.chain.strategy.newBlock(rawBlock))
 
     return { blocks, time: BenchUtils.end(begin), isMessageFull }
   }
@@ -787,7 +789,7 @@ export class PeerNetwork {
       return
     }
 
-    const header = new BlockHeader(compactBlock.header)
+    const header = this.chain.strategy.newBlockHeader(compactBlock.header)
 
     // mark the block as received in the block fetcher and decide whether to continue
     // to validate this compact block or not
@@ -1173,7 +1175,7 @@ export class PeerNetwork {
       return
     }
 
-    const block = Block.fromRaw(rawBlock)
+    const block = this.chain.strategy.newBlock(rawBlock)
 
     if (await this.alreadyHaveBlock(block.header)) {
       return

--- a/ironfish/src/primitives/block.test.ts
+++ b/ironfish/src/primitives/block.test.ts
@@ -8,7 +8,7 @@ import {
   useMinersTxFixture,
 } from '../testUtilities/fixtures'
 import { createNodeTest } from '../testUtilities/nodeTest'
-import { Block, BlockSerde, SerializedBlock } from './block'
+import { BlockSerde, SerializedBlock } from './block'
 
 describe('Block', () => {
   const nodeTest = createNodeTest()
@@ -36,14 +36,14 @@ describe('Block', () => {
     const serialized = BlockSerde.serialize(block)
     expect(serialized).toMatchObject({ header: { timestamp: expect.any(Number) } })
 
-    const deserialized = BlockSerde.deserialize(serialized)
+    const deserialized = BlockSerde.deserialize(serialized, nodeTest.strategy)
     expect(block.equals(deserialized)).toBe(true)
   })
 
   it('throws when deserializing invalid block', () => {
-    expect(() => BlockSerde.deserialize({ bad: 'data' } as unknown as SerializedBlock)).toThrow(
-      'Unable to deserialize',
-    )
+    expect(() =>
+      BlockSerde.deserialize({ bad: 'data' } as unknown as SerializedBlock, nodeTest.strategy),
+    ).toThrow('Unable to deserialize')
   })
 
   it('check block equality', async () => {
@@ -52,10 +52,10 @@ describe('Block', () => {
     const { block: block1 } = await useBlockWithTx(nodeTest.node, account, account)
 
     // Header change
-    const block2 = BlockSerde.deserialize(BlockSerde.serialize(block1))
+    const block2 = BlockSerde.deserialize(BlockSerde.serialize(block1), nodeTest.strategy)
     expect(block1.equals(block2)).toBe(true)
 
-    let toCompare = Block.fromRaw({
+    let toCompare = nodeTest.strategy.newBlock({
       header: {
         ...block2.header,
         randomness: BigInt(400),
@@ -64,7 +64,7 @@ describe('Block', () => {
     })
     expect(block1.equals(toCompare)).toBe(false)
 
-    toCompare = Block.fromRaw({
+    toCompare = nodeTest.strategy.newBlock({
       header: {
         ...block2.header,
         sequence: block2.header.sequence + 1,
@@ -73,7 +73,7 @@ describe('Block', () => {
     })
     expect(block1.equals(toCompare)).toBe(false)
 
-    toCompare = Block.fromRaw({
+    toCompare = nodeTest.strategy.newBlock({
       header: {
         ...block2.header,
         timestamp: new Date(block2.header.timestamp.valueOf() + 1),
@@ -83,13 +83,13 @@ describe('Block', () => {
     expect(block1.equals(toCompare)).toBe(false)
 
     // Transactions length
-    const block3 = BlockSerde.deserialize(BlockSerde.serialize(block1))
+    const block3 = BlockSerde.deserialize(BlockSerde.serialize(block1), nodeTest.strategy)
     expect(block1.equals(block3)).toBe(true)
     block3.transactions.pop()
     expect(block1.equals(block3)).toBe(false)
 
     // Transaction equality
-    const block4 = BlockSerde.deserialize(BlockSerde.serialize(block1))
+    const block4 = BlockSerde.deserialize(BlockSerde.serialize(block1), nodeTest.strategy)
     expect(block1.equals(block4)).toBe(true)
     block4.transactions.pop()
     block4.transactions.push(tx)

--- a/ironfish/src/primitives/block.ts
+++ b/ironfish/src/primitives/block.ts
@@ -4,6 +4,7 @@
 
 import { zip } from 'lodash'
 import { Assert } from '../assert'
+import { Strategy } from '../strategy'
 import {
   BlockHeader,
   BlockHeaderSerde,
@@ -140,11 +141,6 @@ export class Block {
       ],
     }
   }
-
-  static fromRaw(raw: RawBlock): Block {
-    const header = new BlockHeader(raw.header)
-    return new Block(header, raw.transactions)
-  }
 }
 
 export type CompactBlockTransaction = {
@@ -178,7 +174,7 @@ export class BlockSerde {
     }
   }
 
-  static deserialize(data: SerializedBlock): Block {
+  static deserialize(data: SerializedBlock, strategy: Strategy): Block {
     if (
       typeof data === 'object' &&
       data !== null &&
@@ -186,7 +182,7 @@ export class BlockSerde {
       'transactions' in data &&
       Array.isArray(data.transactions)
     ) {
-      const header = BlockHeaderSerde.deserialize(data.header)
+      const header = BlockHeaderSerde.deserialize(data.header, strategy)
       const transactions = data.transactions.map((t) => new Transaction(t))
       return new Block(header, transactions)
     }

--- a/ironfish/src/serde/BlockTemplateSerde.ts
+++ b/ironfish/src/serde/BlockTemplateSerde.ts
@@ -3,10 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Block } from '../primitives/block'
-import { BlockHeader } from '../primitives/blockheader'
 import { NoteEncryptedHashSerde } from '../primitives/noteEncrypted'
 import { Target } from '../primitives/target'
 import { Transaction } from '../primitives/transaction'
+import { Strategy } from '../strategy'
 import { BigIntUtils } from '../utils'
 
 export type SerializedBlockTemplate = {
@@ -54,10 +54,10 @@ export class BlockTemplateSerde {
     }
   }
 
-  static deserialize(blockTemplate: SerializedBlockTemplate): Block {
+  static deserialize(blockTemplate: SerializedBlockTemplate, strategy: Strategy): Block {
     const noteHasher = new NoteEncryptedHashSerde()
 
-    const header = new BlockHeader({
+    const header = strategy.newBlockHeader({
       sequence: blockTemplate.header.sequence,
       previousBlockHash: Buffer.from(blockTemplate.header.previousBlockHash, 'hex'),
       noteCommitment: noteHasher.deserialize(

--- a/ironfish/src/testUtilities/fixtures/blocks.ts
+++ b/ironfish/src/testUtilities/fixtures/blocks.ts
@@ -57,7 +57,7 @@ export async function useBlockFixture(
       return BlockSerde.serialize(block)
     },
     deserialize: (serialized: SerializedBlock): Block => {
-      return BlockSerde.deserialize(serialized)
+      return BlockSerde.deserialize(serialized, chain.strategy)
     },
   })
 }

--- a/ironfish/src/utils/blockutil.test.ts
+++ b/ironfish/src/utils/blockutil.test.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BlockHeader } from '../primitives'
 import { useMinerBlockFixture } from '../testUtilities'
 import { createNodeTest } from '../testUtilities/nodeTest'
 import { BlockchainUtils, getBlockRange } from './blockchain'
@@ -69,7 +68,7 @@ describe('BlockchainUtils', () => {
       [{ start: 3.14, stop: 6.28 }, 3, 6],
       [{ start: 6.28, stop: 3.14 }, 6, 6],
     ])('%o returns %d %d', (param, expectedStart, expectedStop) => {
-      nodeTest.chain.latest = new BlockHeader({
+      nodeTest.chain.latest = nodeTest.strategy.newBlockHeader({
         ...nodeTest.chain.latest,
         sequence: 10000,
       })
@@ -80,7 +79,7 @@ describe('BlockchainUtils', () => {
     })
 
     it('{ start: null, stop: 6000 } returns 1 6000', () => {
-      nodeTest.chain.latest = new BlockHeader({
+      nodeTest.chain.latest = nodeTest.strategy.newBlockHeader({
         ...nodeTest.chain.latest,
         sequence: 10000,
       })
@@ -91,7 +90,7 @@ describe('BlockchainUtils', () => {
     })
 
     it('{ start: 6000, stop: null } returns 6000 10000', () => {
-      nodeTest.chain.latest = new BlockHeader({
+      nodeTest.chain.latest = nodeTest.strategy.newBlockHeader({
         ...nodeTest.chain.latest,
         sequence: 10000,
       })


### PR DESCRIPTION
## Summary
FishHash will need a global cache as well as check activation height to hash a block header. Move block header hashing to strategy class to facilitate this

## Testing Plan
Unit tests + running node locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
