### PR TITLE
refactor: remove unneeded key build output mints

### DIFF
--- a/benchmarks/benches/merkle_note.rs
+++ b/benchmarks/benches/merkle_note.rs
@@ -22,7 +22,12 @@ pub fn decrypt_note_for_spender(c: &mut Criterion) {
 
                 let ekp = EphemeralKeyPair::new();
                 let value_commitment = ValueCommitment::new(note.value(), note.asset_generator());
-                let merkle_note = MerkleNote::new(&spender_key, &note, &value_commitment, &ekp);
+                let merkle_note = MerkleNote::new(
+                    spender_key.outgoing_view_key(),
+                    &note,
+                    &value_commitment,
+                    &ekp,
+                );
 
                 return (spender_key.outgoing_view_key().clone(), merkle_note);
             },
@@ -53,7 +58,12 @@ pub fn decrypt_note_for_owner(c: &mut Criterion) {
 
                 let ekp = EphemeralKeyPair::new();
                 let value_commitment = ValueCommitment::new(note.value(), note.asset_generator());
-                let merkle_note = MerkleNote::new(&spender_key, &note, &value_commitment, &ekp);
+                let merkle_note = MerkleNote::new(
+                    spender_key.outgoing_view_key(),
+                    &note,
+                    &value_commitment,
+                    &ekp,
+                );
 
                 return (receiver_key.incoming_view_key().clone(), merkle_note);
             },

--- a/ironfish-rust/src/transaction/mints.rs
+++ b/ironfish-rust/src/transaction/mints.rs
@@ -13,6 +13,7 @@ use ironfish_zkp::{
     constants::SPENDING_KEY_GENERATOR,
     proofs::MintAsset,
     redjubjub::{self, Signature},
+    ProofGenerationKey,
 };
 use jubjub::ExtendedPoint;
 use rand::thread_rng;
@@ -58,12 +59,13 @@ impl MintBuilder {
 
     pub fn build(
         &self,
-        spender_key: &SaplingKey,
+        proof_generation_key: &ProofGenerationKey,
+        public_address: &PublicAddress,
         public_key_randomness: &jubjub::Fr,
         randomized_public_key: &redjubjub::PublicKey,
     ) -> Result<UnsignedMintDescription, IronfishError> {
         let circuit = MintAsset {
-            proof_generation_key: Some(spender_key.sapling_proof_generation_key()),
+            proof_generation_key: Some(proof_generation_key.clone()),
             public_key_randomness: Some(*public_key_randomness),
         };
 
@@ -78,7 +80,7 @@ impl MintBuilder {
             proof,
             asset: self.asset,
             value: self.value,
-            owner: spender_key.public_address(),
+            owner: *public_address,
             transfer_ownership_to: self.transfer_ownership_to,
             authorizing_signature: blank_signature,
         };
@@ -386,7 +388,12 @@ mod test {
 
         let mint = MintBuilder::new(asset, value);
         let unsigned_mint = mint
-            .build(&key, &public_key_randomness, &randomized_public_key)
+            .build(
+                &key.sapling_proof_generation_key(),
+                &key.public_address(),
+                &public_key_randomness,
+                &randomized_public_key,
+            )
             .expect("should build valid mint description");
 
         // Signature comes from the transaction, normally
@@ -443,7 +450,7 @@ mod test {
         let mint = MintBuilder::new(asset, value);
 
         assert!(matches!(
-            mint.build(&owner_key, &public_key_randomness, &randomized_public_key),
+            mint.build(&owner_key.sapling_proof_generation_key(), &owner_key.public_address(), &public_key_randomness, &randomized_public_key),
             Err(e) if matches!(e.kind, IronfishErrorKind::InvalidMintProof)
         ))
     }
@@ -549,7 +556,12 @@ mod test {
             .randomize(public_key_randomness, *SPENDING_KEY_GENERATOR);
 
         let unsigned_mint = mint
-            .build(key, &public_key_randomness, &randomized_public_key)
+            .build(
+                &key.sapling_proof_generation_key(),
+                &key.public_address(),
+                &public_key_randomness,
+                &randomized_public_key,
+            )
             .expect("should build valid mint description");
 
         // Signature comes from the transaction, normally
@@ -650,7 +662,12 @@ mod test {
             value,
         );
 
-        let unsigned_mint = mint.build(&key, &public_key_randomness, &randomized_public_key);
+        let unsigned_mint = mint.build(
+            &key.sapling_proof_generation_key(),
+            &key.public_address(),
+            &public_key_randomness,
+            &randomized_public_key,
+        );
         assert!(unsigned_mint.is_err());
     }
 }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -305,7 +305,8 @@ impl ProposedTransaction {
         let mut output_descriptions = Vec::with_capacity(self.outputs.len());
         for output in &self.outputs {
             output_descriptions.push(output.build(
-                &self.spender_key,
+                &self.spender_key.sapling_proof_generation_key(),
+                self.spender_key.outgoing_view_key(),
                 &self.public_key_randomness,
                 &randomized_public_key,
             )?);
@@ -314,7 +315,8 @@ impl ProposedTransaction {
         let mut unsigned_mints = Vec::with_capacity(self.mints.len());
         for mint in &self.mints {
             unsigned_mints.push(mint.build(
-                &self.spender_key,
+                &self.spender_key.sapling_proof_generation_key(),
+                &self.spender_key.public_address(),
                 &self.public_key_randomness,
                 &randomized_public_key,
             )?);


### PR DESCRIPTION
## Summary
Previously the `spender_key` (root key) was being passed to `MerkleNote` constructor, `output.build()` and `mint.build()`. This caused unnecessary propagation of the the `SaplingKey` type to each of these structures.

This refactor passes only the keys that are required for the processes of constructing merkle notes, outputs, mints.

Example

Before:
```
MerkleNote::new(&spender_key, &note, &value_commitment, &diffie_hellman_keys);
```
After
```
MerkleNote::new(
            &spender_key.outgoing_view_key(),
            &note,
            &value_commitment,
            &diffie_hellman_keys,
        );
```
## Testing Plan
tests pas
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
