### PR TITLE
Add FishHash to node verification

### DIFF
--- a/ironfish/src/blockHasher.test.ts
+++ b/ironfish/src/blockHasher.test.ts
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { blake3 } from '@napi-rs/blake-hash'
+import { BlockHasher, serializeHeaderBlake3, serializeHeaderFishHash } from './blockHasher'
+import { TestnetConsensus } from './consensus'
+import { Target } from './primitives'
+import { RawBlockHeader } from './primitives/blockheader'
+import { FISH_HASH_CONTEXT } from './testUtilities'
+
+const consensusParameters = {
+  allowedBlockFutureSeconds: 15,
+  genesisSupplyInIron: 42000000,
+  targetBlockTimeInSeconds: 60,
+  targetBucketTimeInSeconds: 10,
+  maxBlockSizeBytes: 524288,
+  minFee: 0,
+  enableAssetOwnership: 1,
+  enforceSequentialBlockTime: 1,
+  enableFishHash: 100001,
+}
+
+describe('Hashes blocks with correct hashing algorithm', () => {
+  let blockHasher: BlockHasher
+
+  beforeAll(() => {
+    const modifiedConsensus = new TestnetConsensus(consensusParameters)
+    blockHasher = new BlockHasher({
+      consensus: modifiedConsensus,
+      context: FISH_HASH_CONTEXT,
+    })
+  })
+
+  const rawHeaderFields = {
+    previousBlockHash: Buffer.alloc(32, 'previous'),
+    noteCommitment: Buffer.alloc(32, 'header'),
+    transactionCommitment: Buffer.alloc(32, 'transactionRoot'),
+    target: new Target(17),
+    randomness: BigInt(25),
+    timestamp: new Date(1598467858637),
+    graffiti: Buffer.alloc(32, 'graffiti'),
+  }
+
+  it('Hashes block headers with blake3 before the activation sequence', () => {
+    const rawHeader = {
+      ...rawHeaderFields,
+      sequence: consensusParameters.enableFishHash - 1,
+    }
+    const hash = blockHasher.hashHeader(rawHeader)
+
+    expect(hash.equals(blake3(serializeHeaderBlake3(rawHeader)))).toBe(true)
+
+    expect(hash.equals(blake3(serializeHeaderFishHash(rawHeader)))).toBe(false)
+    expect(hash.equals(FISH_HASH_CONTEXT.hash(serializeHeaderBlake3(rawHeader)))).toBe(false)
+    expect(hash.equals(FISH_HASH_CONTEXT.hash(serializeHeaderFishHash(rawHeader)))).toBe(false)
+  })
+
+  it('Hashes block headers with FishHash after the activation sequence', () => {
+    const rawHeader = {
+      ...rawHeaderFields,
+      sequence: consensusParameters.enableFishHash,
+    }
+    const hash = blockHasher.hashHeader(rawHeader)
+
+    expect(hash.equals(FISH_HASH_CONTEXT.hash(serializeHeaderFishHash(rawHeader)))).toBe(true)
+
+    expect(hash.equals(FISH_HASH_CONTEXT.hash(serializeHeaderBlake3(rawHeader)))).toBe(false)
+    expect(hash.equals(blake3(serializeHeaderFishHash(rawHeader)))).toBe(false)
+    expect(hash.equals(blake3(serializeHeaderBlake3(rawHeader)))).toBe(false)
+  })
+
+  it('Puts graffiti in front of serialized block header for FishHash', () => {
+    const rawHeader = {
+      ...rawHeaderFields,
+      sequence: consensusParameters.enableFishHash,
+    }
+
+    const serialized = serializeHeaderFishHash(rawHeader)
+    expect(serialized.toString('hex', 0, 32)).toEqual(rawHeader.graffiti.toString('hex'))
+  })
+
+  it('Hashes existing mainnet blocks correctly', () => {
+    const block500: RawBlockHeader = {
+      sequence: 500,
+      previousBlockHash: Buffer.from(
+        '000000000000005a307332b6910b730347c1849e4f7772d0c30cf251f7a231b8',
+        'hex',
+      ),
+      timestamp: new Date(1682046624440),
+      graffiti: Buffer.from(
+        '6865726f6d696e6572732e636f6d20575053474a35796a50500702023eb36ed2',
+        'hex',
+      ),
+      noteCommitment: Buffer.from(
+        '365b8d520119591d4adda9a43586732151759bcbab2663dc810df6b479a08557',
+        'hex',
+      ),
+      transactionCommitment: Buffer.from(
+        'fd54b5407c50c45114bc36bc18c6093015f3edd614fff12c4871f02011a2a3cc',
+        'hex',
+      ),
+      target: new Target(756384800508438608204615908259480917815960905158618695086860n),
+      randomness: 2734524376649158465n,
+    }
+
+    const block10000: RawBlockHeader = {
+      sequence: 10000,
+      previousBlockHash: Buffer.from(
+        '000000000000001918ec5e350ec40d3606c865c162439bf1faebf9c23c4689ad',
+        'hex',
+      ),
+      timestamp: new Date(1682604438528),
+      graffiti: Buffer.from(
+        '0000000000000000000000000000000000000000000000008308423f00000000',
+        'hex',
+      ),
+      noteCommitment: Buffer.from(
+        'a6ada17d6dfa066198030403d4b6160633a7064843bd7c7124d9669069c9666b',
+        'hex',
+      ),
+      transactionCommitment: Buffer.from(
+        'a8f937d95020a51c7f7ecf7157d330ee146aeb6cbd4fcce4a42e80db4f6a1f4e',
+        'hex',
+      ),
+      target: new Target(429471422073515230604015821651699605609508434072272216389555n),
+      randomness: 2459773558139518993n,
+    }
+
+    const block100000: RawBlockHeader = {
+      sequence: 100000,
+      previousBlockHash: Buffer.from(
+        '00000000000000726356321bf7c2057feaeaeba771cf997ac6f13038b7fdf9ab',
+        'hex',
+      ),
+      timestamp: new Date(1687943221494),
+      graffiti: Buffer.from(
+        '00000000000000000000000000000000a0b0d100000000000000000023000000',
+        'hex',
+      ),
+      noteCommitment: Buffer.from(
+        '9094c2534f0ee3ae7ed078a3811e2b6de47094f9d710e2ae26ed00e038653819',
+        'hex',
+      ),
+      transactionCommitment: Buffer.from(
+        '97c767928661a813038a44306fd3a5b050ed685c5584d739e0c1833c0123f792',
+        'hex',
+      ),
+      target: new Target(946788478496387895228612647492461330784782254609709025541178n),
+      randomness: 50540119513756614n,
+    }
+
+    expect(blockHasher.hashHeader(block500).toString('hex')).toEqual(
+      '0000000000000032a29b02858a9d22312e1bf7d15bc6c8e36215b0c79b76ab5b',
+    )
+
+    expect(blockHasher.hashHeader(block10000).toString('hex')).toEqual(
+      '0000000000000038cf8ac6f148f2c5edae32b5238c9f0ef53e6fe0aa4cc68043',
+    )
+
+    expect(blockHasher.hashHeader(block100000).toString('hex')).toEqual(
+      '000000000000003eb2e4dfacbcc93079415a784bd7e0887f3375679b2dea7713',
+    )
+  })
+})

--- a/ironfish/src/blockHasher.ts
+++ b/ironfish/src/blockHasher.ts
@@ -13,10 +13,16 @@ export class BlockHasher {
   readonly consensus: Consensus
   readonly fishHashContext: FishHashContext | null = null
 
-  constructor(options: { consensus: Consensus; fullCache?: boolean }) {
+  constructor(options: {
+    consensus: Consensus
+    fullContext?: boolean
+    context?: FishHashContext
+  }) {
     this.consensus = options.consensus
     if (this.consensus.parameters.enableFishHash !== 'never') {
-      this.fishHashContext = new FishHashContext(!!options.fullCache)
+      this.fishHashContext = options.context
+        ? options.context
+        : new FishHashContext(!!options.fullContext)
     }
   }
 

--- a/ironfish/src/blockHasher.ts
+++ b/ironfish/src/blockHasher.ts
@@ -10,8 +10,8 @@ import { Consensus } from './consensus'
 import { BlockHash, RawBlockHeader } from './primitives/blockheader'
 
 export class BlockHasher {
-  readonly consensus: Consensus
-  readonly fishHashContext: FishHashContext | null = null
+  private readonly consensus: Consensus
+  private readonly fishHashContext: FishHashContext | null = null
 
   constructor(options: {
     consensus: Consensus
@@ -44,7 +44,7 @@ export class BlockHasher {
   }
 }
 
-function serializeHeaderBlake3(header: RawBlockHeader): Buffer {
+export function serializeHeaderBlake3(header: RawBlockHeader): Buffer {
   const bw = bufio.write(180)
   bw.writeBigU64BE(header.randomness)
   bw.writeU32(header.sequence)
@@ -58,7 +58,7 @@ function serializeHeaderBlake3(header: RawBlockHeader): Buffer {
   return bw.render()
 }
 
-function serializeHeaderFishHash(header: RawBlockHeader): Buffer {
+export function serializeHeaderFishHash(header: RawBlockHeader): Buffer {
   const bw = bufio.write(180)
   bw.writeBytes(header.graffiti)
   bw.writeU32(header.sequence)

--- a/ironfish/src/blockHasher.ts
+++ b/ironfish/src/blockHasher.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { FishHashContext } from '@ironfish/rust-nodejs'
+import { blake3 } from '@napi-rs/blake-hash'
+import bufio from 'bufio'
+import { Assert } from './assert'
+import { Consensus } from './consensus'
+import { BlockHash, RawBlockHeader } from './primitives/blockheader'
+
+export class BlockHasher {
+  readonly consensus: Consensus
+  readonly fishHashContext: FishHashContext | null = null
+
+  constructor(options: { consensus: Consensus; fullCache?: boolean }) {
+    this.consensus = options.consensus
+    if (this.consensus.parameters.enableFishHash !== 'never') {
+      this.fishHashContext = new FishHashContext(!!options.fullCache)
+    }
+  }
+
+  hashHeader(header: RawBlockHeader): BlockHash {
+    const useFishHash = this.consensus.isActive(
+      this.consensus.parameters.enableFishHash,
+      header.sequence,
+    )
+
+    if (useFishHash) {
+      Assert.isNotNull(this.fishHashContext, 'FishHash context was not initialized')
+
+      const serialized = serializeHeaderFishHash(header)
+      return this.fishHashContext.hash(serialized)
+    }
+
+    const serialized = serializeHeaderBlake3(header)
+    return blake3(serialized)
+  }
+}
+
+function serializeHeaderBlake3(header: RawBlockHeader): Buffer {
+  const bw = bufio.write(180)
+  bw.writeBigU64BE(header.randomness)
+  bw.writeU32(header.sequence)
+  bw.writeHash(header.previousBlockHash)
+  bw.writeHash(header.noteCommitment)
+  bw.writeHash(header.transactionCommitment)
+  bw.writeBigU256BE(header.target.asBigInt())
+  bw.writeU64(header.timestamp.getTime())
+  bw.writeBytes(header.graffiti)
+
+  return bw.render()
+}
+
+function serializeHeaderFishHash(header: RawBlockHeader): Buffer {
+  const bw = bufio.write(180)
+  bw.writeBytes(header.graffiti)
+  bw.writeU32(header.sequence)
+  bw.writeHash(header.previousBlockHash)
+  bw.writeHash(header.noteCommitment)
+  bw.writeHash(header.transactionCommitment)
+  bw.writeBigU256BE(header.target.asBigInt())
+  bw.writeU64(header.timestamp.getTime())
+  bw.writeBigU64BE(header.randomness)
+
+  return bw.render()
+}

--- a/ironfish/src/consensus/consensus.test.ts
+++ b/ironfish/src/consensus/consensus.test.ts
@@ -15,6 +15,7 @@ describe('Consensus', () => {
     minFee: 6,
     enableAssetOwnership: 7,
     enforceSequentialBlockTime: 1,
+    enableFishHash: 'never',
   }
 
   let consensus: Consensus
@@ -67,9 +68,11 @@ describe('Consensus', () => {
       minFee: 6,
       enableAssetOwnership: 'never',
       enforceSequentialBlockTime: 'never',
+      enableFishHash: 'never',
     })
     expect(consensus.getActiveTransactionVersion(5)).toEqual(TransactionVersion.V1)
     expect(consensus.isActive(consensus.parameters.enableAssetOwnership, 3)).toBe(false)
     expect(consensus.isActive(consensus.parameters.enforceSequentialBlockTime, 3)).toBe(false)
+    expect(consensus.isActive(consensus.parameters.enableFishHash, 3)).toBe(false)
   })
 })

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -48,6 +48,13 @@ export type ConsensusParameters = {
    * block we enforce the block timestamps in the sequential order as the block sequences.
    */
   enforceSequentialBlockTime: ActivationSequence
+
+  /**
+   * Sequence at which to start mining and validating blocks with the FishHash algorithm
+   * instead Blake3. This sequence also modifies the block header serialization to move graffiti
+   * to the beginning of the block header before mining.
+   */
+  enableFishHash: ActivationSequence
 }
 
 export class Consensus {

--- a/ironfish/src/defaultNetworkDefinitions.ts
+++ b/ironfish/src/defaultNetworkDefinitions.ts
@@ -37,7 +37,8 @@ export const TESTNET = `{
       "maxBlockSizeBytes": 524288,
       "minFee": 1,
       "enableAssetOwnership": 9999999,
-      "enforceSequentialBlockTime": "never"
+      "enforceSequentialBlockTime": "never".
+      "enableFishHash": "never"
   }
 }`
 
@@ -58,7 +59,8 @@ export const MAINNET = `
         "maxBlockSizeBytes": 524288,
         "minFee": 1,
         "enableAssetOwnership": 9999999,
-        "enforceSequentialBlockTime": "never"
+        "enforceSequentialBlockTime": "never",
+        "enableFishHash": "never"
     }
 }`
 
@@ -76,6 +78,7 @@ export const DEVNET = `
         "maxBlockSizeBytes": 524288,
         "minFee": 0,
         "enableAssetOwnership": 1,
-        "enforceSequentialBlockTime": 1
+        "enforceSequentialBlockTime": 1,
+        "enableFishHash": "never"
     }
 }`

--- a/ironfish/src/defaultNetworkDefinitions.ts
+++ b/ironfish/src/defaultNetworkDefinitions.ts
@@ -37,7 +37,7 @@ export const TESTNET = `{
       "maxBlockSizeBytes": 524288,
       "minFee": 1,
       "enableAssetOwnership": 9999999,
-      "enforceSequentialBlockTime": "never".
+      "enforceSequentialBlockTime": "never",
       "enableFishHash": "never"
   }
 }`

--- a/ironfish/src/networkDefinition.ts
+++ b/ironfish/src/networkDefinition.ts
@@ -49,6 +49,7 @@ export const networkDefinitionSchema: yup.ObjectSchema<NetworkDefinition> = yup
         minFee: yup.number().integer().defined(),
         enableAssetOwnership: yup.mixed<ActivationSequence>().defined(),
         enforceSequentialBlockTime: yup.mixed<ActivationSequence>().defined(),
+        enableFishHash: yup.mixed<ActivationSequence>().defined(),
       })
       .defined(),
   })

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -5,6 +5,7 @@ import { BoxKeyPair } from '@ironfish/rust-nodejs'
 import { v4 as uuid } from 'uuid'
 import { AssetsVerifier } from './assets'
 import { Blockchain } from './blockchain'
+import { BlockHasher } from './blockHasher'
 import { TestnetConsensus } from './consensus'
 import {
   Config,
@@ -247,9 +248,11 @@ export class FullNode {
     }
 
     const consensus = new TestnetConsensus(networkDefinition.consensus)
+    // TODO: config value for fullCache
+    const blockHasher = new BlockHasher({ consensus, fullCache: false })
 
     strategyClass = strategyClass || Strategy
-    const strategy = new strategyClass({ workerPool, consensus })
+    const strategy = new strategyClass({ workerPool, consensus, blockHasher })
 
     const chain = new Blockchain({
       location: config.chainDatabasePath,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BoxKeyPair } from '@ironfish/rust-nodejs'
+import { BoxKeyPair, FishHashContext } from '@ironfish/rust-nodejs'
 import { v4 as uuid } from 'uuid'
 import { AssetsVerifier } from './assets'
 import { Blockchain } from './blockchain'
@@ -197,6 +197,7 @@ export class FullNode {
     strategyClass,
     webSocket,
     privateIdentity,
+    fishHashContext,
   }: {
     pkg: Package
     dataDir?: string
@@ -209,6 +210,7 @@ export class FullNode {
     strategyClass: typeof Strategy | null
     webSocket: IsomorphicWebSocketConstructor
     privateIdentity?: PrivateIdentity
+    fishHashContext?: FishHashContext
   }): Promise<FullNode> {
     logger = logger.withTag('ironfishnode')
     dataDir = dataDir || DEFAULT_DATA_DIR
@@ -248,8 +250,12 @@ export class FullNode {
     }
 
     const consensus = new TestnetConsensus(networkDefinition.consensus)
-    // TODO: config value for fullCache
-    const blockHasher = new BlockHasher({ consensus, fullCache: false })
+    // TODO: config value for fullContext
+    const blockHasher = new BlockHasher({
+      consensus,
+      context: fishHashContext,
+      fullContext: false,
+    })
 
     strategyClass = strategyClass || Strategy
     const strategy = new strategyClass({ workerPool, consensus, blockHasher })

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { BoxKeyPair } from '@ironfish/rust-nodejs'
+import { BoxKeyPair, FishHashContext } from '@ironfish/rust-nodejs'
 import {
   Config,
   ConfigOptions,
@@ -183,6 +183,7 @@ export class IronfishSdk {
   }: {
     autoSeed?: boolean
     privateIdentity?: PrivateIdentity
+    fishHashContext?: FishHashContext
   } = {}): Promise<FullNode> {
     const webSocket = WebSocketClient as IsomorphicWebSocketConstructor
 

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -73,6 +73,7 @@ const consensusParameters: ConsensusParameters = {
   minFee: 1,
   enableAssetOwnership: 1,
   enforceSequentialBlockTime: 3,
+  enableFishHash: 'never',
 }
 
 /**

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -190,7 +190,7 @@ describe('Demonstrate the Sapling API', () => {
 
   describe('Serializes and deserializes transactions', () => {
     const consensus = new TestnetConsensus(consensusParameters)
-    const blockHasher = new BlockHasher({ consensus, fullCache: false })
+    const blockHasher = new BlockHasher({ consensus, fullContext: false })
     const strategy = new Strategy({
       workerPool,
       consensus,
@@ -259,7 +259,7 @@ describe('Demonstrate the Sapling API', () => {
 
       const key = generateKey()
       const consensus = new TestnetConsensus(modifiedParams)
-      const blockHasher = new BlockHasher({ consensus, fullCache: false })
+      const blockHasher = new BlockHasher({ consensus, fullContext: false })
       const modifiedStrategy = new Strategy({
         workerPool,
         consensus,

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -24,6 +24,7 @@ import { NoteEncrypted, NoteEncryptedHash } from './primitives/noteEncrypted'
 import { TransactionVersion } from './primitives/transaction'
 import { BUFFER_ENCODING, IDatabase } from './storage'
 import { Strategy } from './strategy'
+import { FISH_HASH_CONTEXT } from './testUtilities'
 import { makeDb, makeDbName } from './testUtilities/helpers/storage'
 import { WorkerPool } from './workerPool'
 
@@ -190,7 +191,7 @@ describe('Demonstrate the Sapling API', () => {
 
   describe('Serializes and deserializes transactions', () => {
     const consensus = new TestnetConsensus(consensusParameters)
-    const blockHasher = new BlockHasher({ consensus, fullContext: false })
+    const blockHasher = new BlockHasher({ consensus, context: FISH_HASH_CONTEXT })
     const strategy = new Strategy({
       workerPool,
       consensus,
@@ -259,7 +260,7 @@ describe('Demonstrate the Sapling API', () => {
 
       const key = generateKey()
       const consensus = new TestnetConsensus(modifiedParams)
-      const blockHasher = new BlockHasher({ consensus, fullContext: false })
+      const blockHasher = new BlockHasher({ consensus, context: FISH_HASH_CONTEXT })
       const modifiedStrategy = new Strategy({
         workerPool,
         consensus,

--- a/ironfish/src/strategy.test.ts
+++ b/ironfish/src/strategy.test.ts
@@ -24,7 +24,7 @@ describe('Miners reward', () => {
 
   beforeAll(() => {
     const consensus = new Consensus(consensusParameters)
-    const blockHasher = new BlockHasher({ consensus, fullCache: false })
+    const blockHasher = new BlockHasher({ consensus, fullContext: false })
     strategy = new Strategy({
       workerPool: new WorkerPool(),
       consensus,

--- a/ironfish/src/strategy.test.ts
+++ b/ironfish/src/strategy.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { BlockHasher } from './blockHasher'
 import { Consensus, ConsensusParameters } from './consensus'
 import { Strategy } from './strategy'
 import { WorkerPool } from './workerPool'
@@ -22,9 +23,12 @@ describe('Miners reward', () => {
   }
 
   beforeAll(() => {
+    const consensus = new Consensus(consensusParameters)
+    const blockHasher = new BlockHasher({ consensus, fullCache: false })
     strategy = new Strategy({
       workerPool: new WorkerPool(),
-      consensus: new Consensus(consensusParameters),
+      consensus,
+      blockHasher,
     })
   })
 

--- a/ironfish/src/strategy.test.ts
+++ b/ironfish/src/strategy.test.ts
@@ -5,6 +5,7 @@
 import { BlockHasher } from './blockHasher'
 import { Consensus, ConsensusParameters } from './consensus'
 import { Strategy } from './strategy'
+import { FISH_HASH_CONTEXT } from './testUtilities'
 import { WorkerPool } from './workerPool'
 
 describe('Miners reward', () => {
@@ -24,7 +25,7 @@ describe('Miners reward', () => {
 
   beforeAll(() => {
     const consensus = new Consensus(consensusParameters)
-    const blockHasher = new BlockHasher({ consensus, fullContext: false })
+    const blockHasher = new BlockHasher({ consensus, context: FISH_HASH_CONTEXT })
     strategy = new Strategy({
       workerPool: new WorkerPool(),
       consensus,

--- a/ironfish/src/strategy.test.ts
+++ b/ironfish/src/strategy.test.ts
@@ -18,6 +18,7 @@ describe('Miners reward', () => {
     minFee: 1,
     enableAssetOwnership: 1,
     enforceSequentialBlockTime: 3,
+    enableFishHash: 'never',
   }
 
   beforeAll(() => {

--- a/ironfish/src/strategy.ts
+++ b/ironfish/src/strategy.ts
@@ -1,12 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
-import { blake3 } from '@napi-rs/blake-hash'
-import bufio from 'bufio'
+import { BlockHasher } from './blockHasher'
 import { Consensus } from './consensus'
 import { Block, RawBlock } from './primitives/block'
-import { BlockHash, BlockHeader, RawBlockHeader } from './primitives/blockheader'
+import { BlockHeader, RawBlockHeader } from './primitives/blockheader'
 import { Transaction } from './primitives/transaction'
 import { MathUtils } from './utils'
 import { WorkerPool } from './workerPool'
@@ -17,13 +15,19 @@ import { WorkerPool } from './workerPool'
 export class Strategy {
   readonly workerPool: WorkerPool
   readonly consensus: Consensus
+  readonly blockHasher: BlockHasher
 
   private miningRewardCachedByYear: Map<number, number>
 
-  constructor(options: { workerPool: WorkerPool; consensus: Consensus }) {
+  constructor(options: {
+    workerPool: WorkerPool
+    consensus: Consensus
+    blockHasher: BlockHasher
+  }) {
     this.miningRewardCachedByYear = new Map<number, number>()
     this.workerPool = options.workerPool
     this.consensus = options.consensus
+    this.blockHasher = options.blockHasher
   }
 
   /**
@@ -97,13 +101,8 @@ export class Strategy {
     return this.workerPool.createMinersFee(minerSpendKey, amount, '', transactionVersion)
   }
 
-  hashHeader(header: RawBlockHeader): BlockHash {
-    const serialized = serializeHeaderBlake3(header)
-    return blake3(serialized)
-  }
-
   newBlockHeader(raw: RawBlockHeader, noteSize?: number | null, work?: bigint): BlockHeader {
-    const hash = this.hashHeader(raw)
+    const hash = this.blockHasher.hashHeader(raw)
     return new BlockHeader(raw, hash, noteSize, work)
   }
 
@@ -111,18 +110,4 @@ export class Strategy {
     const header = this.newBlockHeader(raw.header, noteSize, work)
     return new Block(header, raw.transactions)
   }
-}
-
-function serializeHeaderBlake3(header: RawBlockHeader): Buffer {
-  const bw = bufio.write(180)
-  bw.writeBigU64BE(header.randomness)
-  bw.writeU32(header.sequence)
-  bw.writeHash(header.previousBlockHash)
-  bw.writeHash(header.noteCommitment)
-  bw.writeHash(header.transactionCommitment)
-  bw.writeBigU256BE(header.target.asBigInt())
-  bw.writeU64(header.timestamp.getTime())
-  bw.writeBytes(header.graffiti)
-
-  return bw.render()
 }

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import './matchers'
+import { FishHashContext } from '@ironfish/rust-nodejs'
 import { Blockchain } from '../blockchain'
 import { Verifier } from '../consensus/verifier'
 import { ConfigOptions } from '../fileStores/config'
@@ -20,6 +21,9 @@ export type NodeTestOptions =
       autoSeed?: boolean
     }
   | undefined
+
+// Create global FishHash context for tests
+const FISH_HASH_CONTEXT = new FishHashContext(false)
 
 /**
  * Used as an easy wrapper for testing the node, and blockchain. Use
@@ -91,7 +95,10 @@ export class NodeTest {
       }
     }
 
-    const node = await sdk.node({ autoSeed: this.options?.autoSeed })
+    const node = await sdk.node({
+      autoSeed: this.options?.autoSeed,
+      fishHashContext: FISH_HASH_CONTEXT,
+    })
     const strategy = node.strategy as TestStrategy
     const chain = node.chain
     const wallet = node.wallet

--- a/ironfish/src/testUtilities/nodeTest.ts
+++ b/ironfish/src/testUtilities/nodeTest.ts
@@ -23,7 +23,7 @@ export type NodeTestOptions =
   | undefined
 
 // Create global FishHash context for tests
-const FISH_HASH_CONTEXT = new FishHashContext(false)
+export const FISH_HASH_CONTEXT = new FishHashContext(false)
 
 /**
  * Used as an easy wrapper for testing the node, and blockchain. Use


### PR DESCRIPTION
## Summary
Add a consensus parameter for FishHash activation and use it to determine how to hash blocks according to seqeunce

## Testing Plan
- Unit tests
- running dev network
- syncing mainnet from genesis + monitoring RAM usage

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
