### PR TITLE
adds optional multiSigKeys to AccountValue

### DIFF
--- a/ironfish/src/wallet/walletdb/accountValue.test.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.test.ts
@@ -39,7 +39,8 @@ describe('AccountValueEncoding', () => {
       incomingViewKey: key.incomingViewKey,
       outgoingViewKey: key.outgoingViewKey,
       publicAddress: key.publicAddress,
-      spendingKey: key.spendingKey,
+      // NOTE: accounts with multiSigKeys should not have spendingKey
+      spendingKey: null,
       viewKey: key.viewKey,
       version: 1,
       createdAt: null,

--- a/ironfish/src/wallet/walletdb/accountValue.test.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.test.ts
@@ -22,6 +22,32 @@ describe('AccountValueEncoding', () => {
         hash: Buffer.alloc(32, 0),
         sequence: 1,
       },
+      multiSigKeys: undefined,
+    }
+    const buffer = encoder.serialize(value)
+    const deserializedValue = encoder.deserialize(buffer)
+    expect(deserializedValue).toEqual(value)
+  })
+
+  it('serializes an object with multiSigKeys into a buffer and deserializes to the original object', () => {
+    const encoder = new AccountValueEncoding()
+
+    const key = generateKey()
+    const value: AccountValue = {
+      id: 'id',
+      name: 'foobar👁️🏃🐟',
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      spendingKey: key.spendingKey,
+      viewKey: key.viewKey,
+      version: 1,
+      createdAt: null,
+      multiSigKeys: {
+        identifier: 'a',
+        keyPackage: 'b',
+        proofGenerationKey: 'c',
+      },
     }
     const buffer = encoder.serialize(value)
     const deserializedValue = encoder.deserialize(buffer)

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -21,6 +21,11 @@ export interface AccountValue {
   outgoingViewKey: string
   publicAddress: string
   createdAt: HeadValue | null
+  multiSigKeys?: {
+    identifier: string
+    keyPackage: string
+    proofGenerationKey: string
+  }
 }
 
 export type AccountImport = Omit<AccountValue, 'id'>
@@ -31,6 +36,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     let flags = 0
     flags |= Number(!!value.spendingKey) << 0
     flags |= Number(!!value.createdAt) << 1
+    flags |= Number(!!value.multiSigKeys) << 2
     bw.writeU8(flags)
     bw.writeU16(value.version)
     bw.writeVarString(value.id, 'utf8')
@@ -48,6 +54,12 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
       bw.writeBytes(encoding.serialize(value.createdAt))
     }
 
+    if (value.multiSigKeys) {
+      bw.writeVarString(value.multiSigKeys.identifier, 'utf8')
+      bw.writeVarString(value.multiSigKeys.keyPackage, 'utf8')
+      bw.writeVarString(value.multiSigKeys.proofGenerationKey, 'utf8')
+    }
+
     return bw.render()
   }
 
@@ -57,6 +69,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     const version = reader.readU16()
     const hasSpendingKey = flags & (1 << 0)
     const hasCreatedAt = flags & (1 << 1)
+    const hasMultiSigKeys = flags & (1 << 2)
     const id = reader.readVarString('utf8')
     const name = reader.readVarString('utf8')
     const spendingKey = hasSpendingKey ? reader.readBytes(KEY_LENGTH).toString('hex') : null
@@ -71,6 +84,15 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
       createdAt = encoding.deserialize(reader.readBytes(encoding.nonNullSize))
     }
 
+    let multiSigKeys = undefined
+    if (hasMultiSigKeys) {
+      multiSigKeys = {
+        identifier: reader.readVarString('utf8'),
+        keyPackage: reader.readVarString('utf8'),
+        proofGenerationKey: reader.readVarString('utf8'),
+      }
+    }
+
     return {
       version,
       id,
@@ -81,6 +103,7 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
       spendingKey,
       publicAddress,
       createdAt,
+      multiSigKeys,
     }
   }
 
@@ -100,6 +123,11 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     if (value.createdAt) {
       const encoding = new NullableHeadValueEncoding()
       size += encoding.nonNullSize
+    }
+    if (value.multiSigKeys) {
+      size += bufio.sizeVarString(value.multiSigKeys.identifier, 'utf8')
+      size += bufio.sizeVarString(value.multiSigKeys.keyPackage, 'utf8')
+      size += bufio.sizeVarString(value.multiSigKeys.proofGenerationKey, 'utf8')
     }
 
     return size


### PR DESCRIPTION
## Summary

multiSigKeys includes three fields needed for an account to participate in a FROST signing group: identifier, keyPackage, and proofGenerationKey

the identifier field is still to be determined as either a public key identifier for the participant, or a private key from which we can derive the public key identifier

the keyPackage is the key package generated for the participant during key generation and contains the participant's authorizing key shard

the proofGenerationKey is a key shared by the signing group that is needed for any participant to generate spend or mint proofs

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
