### PR TITLE
Load or generate networkIdentity if none is passed

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -213,7 +213,7 @@ export default class Start extends IronfishCommand {
       await this.sdk.internal.save()
     }
 
-    const node = await this.sdk.node({ privateIdentity: this.sdk.getPrivateIdentity() })
+    const node = await this.sdk.node()
 
     const nodeName = this.sdk.config.get('nodeName').trim() || null
     const blockGraffiti = this.sdk.config.get('blockGraffiti').trim() || null
@@ -253,12 +253,6 @@ export default class Start extends IronfishCommand {
 
       this.exit(1)
     }
-
-    const newSecretKey = Buffer.from(
-      node.peerNetwork.localPeer.privateIdentity.secretKey,
-    ).toString('hex')
-    node.internal.set('networkIdentity', newSecretKey)
-    await node.internal.save()
 
     if (node.internal.get('isFirstRun')) {
       await this.firstRun(node)

--- a/ironfish/src/network/identity.ts
+++ b/ironfish/src/network/identity.ts
@@ -33,6 +33,18 @@ export const secretKeyLength = KEY_LENGTH
  */
 export const base64IdentityLength = Math.ceil(identityLength / 3) * 4
 
+/**
+ * Length of the secret key as a hex-encoded string.
+ */
+export const hexSecretKeyLength = secretKeyLength * 2
+
+export function isHexSecretKey(obj: string): boolean {
+  return (
+    obj.length === hexSecretKeyLength &&
+    Buffer.from(obj, 'hex').toString('hex').toLowerCase() === obj.toLowerCase()
+  )
+}
+
 export function isIdentity(obj: string): boolean {
   // Should be a base64-encoded string with the expected length
   return (

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -205,8 +205,8 @@ export class FullNode {
     metrics?: MetricsMonitor
     files: FileSystem
     strategyClass: typeof Strategy | null
-    webSocket: IsomorphicWebSocketConstructor,
-    privateIdentity?: PrivateIdentity,
+    webSocket: IsomorphicWebSocketConstructor
+    privateIdentity?: PrivateIdentity
   }): Promise<FullNode> {
     logger = logger.withTag('ironfishnode')
     dataDir = dataDir || DEFAULT_DATA_DIR
@@ -249,7 +249,9 @@ export class FullNode {
       privateIdentity = new BoxKeyPair()
     } else if (!privateIdentity) {
       const internalNetworkIdentity = internal.get('networkIdentity')
-      privateIdentity = isHexSecretKey(internalNetworkIdentity) ? BoxKeyPair.fromHex(internalNetworkIdentity) : new BoxKeyPair()
+      privateIdentity = isHexSecretKey(internalNetworkIdentity)
+        ? BoxKeyPair.fromHex(internalNetworkIdentity)
+        : new BoxKeyPair()
     }
     internal.set('networkIdentity', privateIdentity.secretKey.toString('hex'))
     await internal.save()

--- a/ironfish/src/sdk.test.ts
+++ b/ironfish/src/sdk.test.ts
@@ -209,7 +209,9 @@ describe('IronfishSdk', () => {
 
         const newInternal = new InternalStore(fileSystem, dataDir)
         await newInternal.load()
-        expect(newInternal.get('networkIdentity')).toEqual(overrideIdentity.secretKey.toString('hex'))
+        expect(newInternal.get('networkIdentity')).toEqual(
+          overrideIdentity.secretKey.toString('hex'),
+        )
 
         const peerNetworkIdentity =
           node.peerNetwork.localPeer.privateIdentity.secretKey.toString('hex')

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -20,7 +20,7 @@ import {
 } from './logger'
 import { FileReporter } from './logger/reporters'
 import { MetricsMonitor } from './metrics'
-import { PrivateIdentity } from './network/identity'
+import { isHexSecretKey, PrivateIdentity } from './network/identity'
 import { IsomorphicWebSocketConstructor } from './network/types'
 import { WebSocketClient } from './network/webSocketClient'
 import { FullNode } from './node'
@@ -271,11 +271,7 @@ export class IronfishSdk {
 
   getPrivateIdentity(): PrivateIdentity | undefined {
     const networkIdentity = this.internal.get('networkIdentity')
-    if (
-      !this.config.get('generateNewIdentity') &&
-      networkIdentity !== undefined &&
-      networkIdentity.length > 31
-    ) {
+    if (!this.config.get('generateNewIdentity') && isHexSecretKey(networkIdentity)) {
       return BoxKeyPair.fromHex(networkIdentity)
     }
   }


### PR DESCRIPTION
## Summary

Currently, we manage the network identity in the `start` CLI command, which requires some code duplication for everyone instantiating the node (The CLI and the node app, at least). My goal with this PR was to bring the saving and loading into the SDK without changing any behavior when `generateNewIdentity` is used or an identity is passed in to `sdk.node()`. See below for the current vs new behaviors:

### Current Behavior

Saving and loading `networkIdentity` is delegated to the CLI start command.

* If no identity is set in internal.json, one will be generated when `sdk.node()` is called. It is then saved to `internal.json` in the `start` command.
* If an identity is set in internal.json, a new one will be generated when `sdk.node()` is called. Instead, the `start` command should load the identity and pass it in via `sdk.node({ privateIdentity })`.
* If an identity is set or unset in internal.json and `generateNewIdentity` config is true, a new identity will be generated when `sdk.node()` is called. It is then saved to `internal.json` in the `start` command.
* If an identity is set in internal.json and `sdk.node({ privateIdentity })` is called, the passed-in identity will be used. It is then saved to `internal.json` in the `start` command.
* If an identity is set in internal.json, `sdk.node({ privateIdentity })` is called, and `generateNewIdentity` config is `true`, a new identity will be generated and used. It is then saved to `internal.json` in the `start` command.

### New Behavior

* If no identity is set in internal.json, one will be generated **and saved** when `sdk.node()` is called.
* If an identity is set in internal.json, **it will be loaded** when `sdk.node()` is called.
* If an identity is set or unset in internal.json and `generateNewIdentity` config is `true`, a new identity will be generated **and saved** when `sdk.node()` is called.
* If an identity is set in internal.json and `sdk.node({ privateIdentity })` is called, the passed-in identity will be used **and saved** to `internal.json`.
* If an identity is set in internal.json, `sdk.node({ privateIdentity })` is called, and `generateNewIdentity` config is `true`, a new identity will be generated **and saved**.

## Testing Plan

* [x] Added yarn tests to verify networkIdentity is saved as expected.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[x] Yes
```

If a user was calling `sdk.node()` without passing in a private identity, previously it would generate a new identity on each call to `sdk.node()`, but now it loads the identity from `internal.json` unless overridden with `sdk.node({ privateIdentity })` or the `generateNewIdentity` config.
