### PR TITLE
Bump version to 0.16.0 CLI

### DIFF
--- a/ironfish-cli/package.json
+++ b/ironfish-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ironfish",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "CLI for running and interacting with an Iron Fish node",
   "author": "Iron Fish <contact@ironfish.network> (https://ironfish.network)",
   "main": "build/src/index.js",
@@ -62,8 +62,8 @@
     "@aws-sdk/client-s3": "3",
     "@aws-sdk/client-secrets-manager": "3",
     "@aws-sdk/s3-request-presigner": "3",
-    "@ironfish/rust-nodejs": "1.12.0",
-    "@ironfish/sdk": "1.15.0",
+    "@ironfish/rust-nodejs": "1.13.0",
+    "@ironfish/sdk": "1.16.0",
     "@oclif/core": "1.23.1",
     "@oclif/plugin-help": "5.1.12",
     "@oclif/plugin-not-found": "2.3.1",

--- a/ironfish-rust-nodejs/npm/darwin-arm64/package.json
+++ b/ironfish-rust-nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ironfish/rust-nodejs-darwin-arm64",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "os": [
     "darwin"
   ],

--- a/ironfish-rust-nodejs/npm/darwin-x64/package.json
+++ b/ironfish-rust-nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ironfish/rust-nodejs-darwin-x64",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "os": [
     "darwin"
   ],

--- a/ironfish-rust-nodejs/npm/linux-arm64-gnu/package.json
+++ b/ironfish-rust-nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ironfish/rust-nodejs-linux-arm64-gnu",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "os": [
     "linux"
   ],

--- a/ironfish-rust-nodejs/npm/linux-arm64-musl/package.json
+++ b/ironfish-rust-nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ironfish/rust-nodejs-linux-arm64-musl",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "os": [
     "linux"
   ],

--- a/ironfish-rust-nodejs/npm/linux-x64-gnu/package.json
+++ b/ironfish-rust-nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ironfish/rust-nodejs-linux-x64-gnu",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "os": [
     "linux"
   ],

--- a/ironfish-rust-nodejs/npm/linux-x64-musl/package.json
+++ b/ironfish-rust-nodejs/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ironfish/rust-nodejs-linux-x64-musl",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "os": [
     "linux"
   ],

--- a/ironfish-rust-nodejs/npm/win32-x64-msvc/package.json
+++ b/ironfish-rust-nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ironfish/rust-nodejs-win32-x64-msvc",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "os": [
     "win32"
   ],

--- a/ironfish-rust-nodejs/package.json
+++ b/ironfish-rust-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ironfish/rust-nodejs",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Node.js bindings for Rust code required by the Iron Fish SDK",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ironfish/package.json
+++ b/ironfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ironfish/sdk",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "SDK for running and interacting with an Iron Fish node",
   "author": "Iron Fish <contact@ironfish.network> (https://ironfish.network)",
   "main": "build/src/index.js",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@ethersproject/bignumber": "5.7.0",
     "@fast-csv/format": "4.3.5",
-    "@ironfish/rust-nodejs": "1.12.0",
+    "@ironfish/rust-nodejs": "1.13.0",
     "@napi-rs/blake-hash": "1.3.3",
     "axios": "0.21.4",
     "bech32": "2.0.0",


### PR DESCRIPTION
## Summary
- Bump CLI to 1.16.0
- Bump SDK to 1.16.0
- Bump rust to 1.13.0

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
