### PR TITLE
feat: add napi method proposed transaction build

### DIFF
--- a/ironfish-rust/src/lib.rs
+++ b/ironfish-rust/src/lib.rs
@@ -19,7 +19,10 @@ pub mod signal_catcher;
 pub mod transaction;
 pub mod util;
 pub mod witness;
+pub use ironfish_zkp::primitives::ProofGenerationKeySerializable;
+pub use ironfish_zkp::ProofGenerationKey;
 pub use {
+    ironfish_frost::frost,
     keys::{IncomingViewKey, OutgoingViewKey, PublicAddress, SaplingKey, ViewKey},
     merkle_note::MerkleNote,
     merkle_note_hash::MerkleNoteHash,


### PR DESCRIPTION
## Summary
Adds nodejs binding for `ProposedTransaction.build()` along with necessary deserialization.
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
