### PR TITLE
Fix typescript eslint in perf tests

### DIFF
--- a/ironfish/src/workerPool/tasks/workerMessages.test.perf.ts
+++ b/ironfish/src/workerPool/tasks/workerMessages.test.perf.ts
@@ -13,7 +13,7 @@ import {
   writeTestReport,
 } from '../../testUtilities'
 import { BenchUtils, CurrencyUtils, PromiseUtils, SegmentResults } from '../../utils'
-import { Account } from '../../wallet'
+import { SpendingAccount } from '../../wallet'
 import { CreateMinersFeeRequest } from './createMinersFee'
 import { DecryptNoteOptions, DecryptNotesRequest } from './decryptNotes'
 import { WORKER_MESSAGE_HEADER_SIZE } from './workerMessage'
@@ -23,7 +23,7 @@ describe('WorkerMessages', () => {
 
   const TEST_ITERATIONS = 50
 
-  let account: Account
+  let account: SpendingAccount
 
   beforeAll(async () => {
     account = await useAccountFixture(nodeTest.wallet, 'account')


### PR DESCRIPTION
## Summary

The PR #4544 broke perf tests with new changes to typescript eslint. This fixes the account type.

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
