### PR TITLE
Rahul/ifl 2044 1 add rust method to split a sapling key into shares for FROST

### DIFF
--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -1009,7 +1009,7 @@ mod tests {
             split_secret(&config, frost::keys::IdentifierList::Default, &mut rng).unwrap();
         assert_eq!(key_packages.len(), 3);
 
-        let key_parts = key_packages.values().cloned().collect();
+        let key_parts: Vec<_> = key_packages.values().cloned().collect();
 
         let signing_key =
             reconstruct::<JubjubBlake2b512>(&key_parts).expect("key reconstruction failed");

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -1018,4 +1018,4 @@ mod tests {
 
         assert_eq!(scalar.to_bytes(), key);
     }
-}f
+}

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -21,12 +21,25 @@ use crate::{
     OutgoingViewKey, OutputDescription, SpendDescription, ViewKey,
 };
 
+use ironfish_frost::frost;
+use ironfish_frost::frost::Error;
+use rand::{
+    rngs::{OsRng, ThreadRng},
+    thread_rng,
+};
+use std::collections::BTreeMap;
+
+use ironfish_frost::frost::keys::SecretShare;
+use ironfish_frost::frost::{
+    keys::{IdentifierList, KeyPackage, PublicKeyPackage},
+    Identifier, SigningKey,
+};
+
 use bellperson::groth16::{verify_proofs_batch, PreparedVerifyingKey};
 use blake2b_simd::Params as Blake2b;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use group::GroupEncoding;
 use jubjub::ExtendedPoint;
-use rand::{rngs::OsRng, thread_rng};
 
 use ironfish_zkp::{
     constants::{
@@ -38,6 +51,7 @@ use ironfish_zkp::{
 };
 
 use std::{
+    collections::HashMap,
     io::{self, Write},
     iter,
     slice::Iter,
@@ -934,4 +948,50 @@ pub fn batch_verify_transactions<'a>(
         &SAPLING.output_verifying_key,
         &SAPLING.mint_verifying_key,
     )
+}
+
+pub struct SecretShareConfig {
+    pub min_signers: u16,
+    pub max_signers: u16,
+    pub secret: Vec<u8>,
+}
+
+pub fn split_secret(
+    config: &SecretShareConfig,
+    identifiers: IdentifierList,
+    rng: &mut ThreadRng,
+) -> Result<(HashMap<Identifier, KeyPackage>, PublicKeyPackage), Error> {
+    let secret_key = SigningKey::deserialize(
+        config
+            .secret
+            .clone()
+            .try_into()
+            .map_err(|_| Error::MalformedSigningKey)?,
+    )?;
+    let (shares, pubkeys) = frost::keys::split(
+        &secret_key,
+        config.max_signers,
+        config.min_signers,
+        identifiers,
+        rng,
+    )?;
+
+    for (_k, v) in shares.clone() {
+        frost::keys::KeyPackage::try_from(v)?;
+    }
+
+    let key_packages = key_package(&shares);
+
+    Ok((key_packages, pubkeys))
+}
+
+fn key_package(shares: &BTreeMap<Identifier, SecretShare>) -> HashMap<Identifier, KeyPackage> {
+    let mut key_packages: HashMap<_, _> = HashMap::new();
+
+    for (identifier, secret_share) in shares {
+        let key_package = frost::keys::KeyPackage::try_from(secret_share.clone()).unwrap();
+        key_packages.insert(*identifier, key_package);
+    }
+
+    key_packages
 }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -71,6 +71,9 @@ mod utils;
 mod value_balances;
 mod version;
 
+#[cfg(test)]
+mod tests;
+
 pub use version::TransactionVersion;
 
 const SIGNATURE_HASH_PERSONALIZATION: &[u8; 8] = b"IFsighsh";
@@ -984,37 +987,4 @@ pub fn split_secret(
     }
 
     Ok((key_packages, pubkeys))
-}
-
-#[cfg(test)]
-mod tests {
-    use ironfish_frost::frost::{frost::keys::reconstruct, JubjubBlake2b512};
-
-    use super::*;
-
-    #[test]
-    fn test_split_secret() {
-        let mut rng = rand::thread_rng();
-
-        let key = SaplingKey::generate_key().spend_authorizing_key.to_bytes();
-
-        let config = SecretShareConfig {
-            min_signers: 2,
-            max_signers: 3,
-            secret: key.to_vec(),
-        };
-
-        let (key_packages, _) =
-            split_secret(&config, frost::keys::IdentifierList::Default, &mut rng).unwrap();
-        assert_eq!(key_packages.len(), 3);
-
-        let key_parts: Vec<_> = key_packages.values().cloned().collect();
-
-        let signing_key =
-            reconstruct::<JubjubBlake2b512>(&key_parts).expect("key reconstruction failed");
-
-        let scalar = signing_key.to_scalar();
-
-        assert_eq!(scalar.to_bytes(), key);
-    }
 }

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -986,7 +986,6 @@ pub fn split_secret(
     Ok((key_packages, pubkeys))
 }
 
-// test key package and split_secret
 #[cfg(test)]
 mod tests {
     use ironfish_frost::frost::{frost::keys::reconstruct, JubjubBlake2b512};

--- a/ironfish-rust/src/transaction/mod.rs
+++ b/ironfish-rust/src/transaction/mod.rs
@@ -995,3 +995,48 @@ fn key_package(shares: &BTreeMap<Identifier, SecretShare>) -> HashMap<Identifier
 
     key_packages
 }
+
+// test key package and split_secret
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use frost::keys::{Identifier, SigningKey};
+    use ironfish_frost::frost::{frost::Identifier, Identifier};
+    use rand::rngs::ThreadRng;
+    use std::collections::HashMap;
+
+    // Helper function to create a valid SecretShareConfig
+    fn create_valid_config() -> SecretShareConfig {
+        SecretShareConfig {
+            min_signers: 2,
+            max_signers: 5,
+            secret: Vec::new(), // Populate with a valid secret
+        }
+    }
+
+    fn create_valid_identifiers() -> IdentifierList {}
+
+    #[test]
+    fn test_split_secret_success() {
+        let config = create_valid_config();
+        let identifiers = create_valid_identifiers();
+        let mut rng = rand::thread_rng();
+
+        let result = split_secret(&config, identifiers, &mut rng);
+        assert!(result.is_ok());
+        // Further assertions to verify the correctness of the result
+    }
+
+    #[test]
+    fn test_split_secret_malformed_key() {
+        let mut config = create_valid_config();
+        config.secret = vec![0; 10]; // Invalid secret
+
+        let identifiers = create_valid_identifiers();
+        let mut rng = rand::thread_rng();
+
+        let result = split_secret(&config, identifiers, &mut rng);
+        assert!(result.is_err());
+        // Assert the specific type of error
+    }
+}

--- a/ironfish-rust/src/transaction/tests.rs
+++ b/ironfish-rust/src/transaction/tests.rs
@@ -14,12 +14,14 @@ use crate::{
     sapling_bls12::SAPLING,
     test_util::make_fake_witness,
     transaction::{
-        batch_verify_transactions, verify_transaction, TransactionVersion,
-        TRANSACTION_EXPIRATION_SIZE, TRANSACTION_FEE_SIZE, TRANSACTION_SIGNATURE_SIZE,
+        batch_verify_transactions, split_secret, verify_transaction, SecretShareConfig,
+        TransactionVersion, TRANSACTION_EXPIRATION_SIZE, TRANSACTION_FEE_SIZE,
+        TRANSACTION_SIGNATURE_SIZE,
     },
 };
 
 use ff::Field;
+use ironfish_frost::frost::{frost::keys::reconstruct, JubjubBlake2b512};
 use ironfish_zkp::{
     constants::{ASSET_ID_LENGTH, SPENDING_KEY_GENERATOR, TREE_DEPTH},
     proofs::{MintAsset, Output, Spend},
@@ -642,4 +644,34 @@ fn test_batch_verify() {
         batch_verify_transactions([&transaction1, &transaction2]),
         Err(e) if matches!(e.kind, IronfishErrorKind::InvalidSpendSignature)
     ));
+}
+
+#[test]
+fn test_split_secret() {
+    let mut rng = rand::thread_rng();
+
+    let key = SaplingKey::generate_key().spend_authorizing_key.to_bytes();
+
+    let config = SecretShareConfig {
+        min_signers: 2,
+        max_signers: 3,
+        secret: key.to_vec(),
+    };
+
+    let (key_packages, _) = split_secret(
+        &config,
+        ironfish_frost::frost::keys::IdentifierList::Default,
+        &mut rng,
+    )
+    .unwrap();
+    assert_eq!(key_packages.len(), 3);
+
+    let key_parts: Vec<_> = key_packages.values().cloned().collect();
+
+    let signing_key =
+        reconstruct::<JubjubBlake2b512>(&key_parts).expect("key reconstruction failed");
+
+    let scalar = signing_key.to_scalar();
+
+    assert_eq!(scalar.to_bytes(), key);
 }


### PR DESCRIPTION
## Summary

Adding a method to split a sapling key. 
Defining the ShareSecretConfig

These two items are dependencies for splitting the spender key which will be next

## Testing Plan
Tests pass
## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
