### PR TITLE
fixing wallet/sendTransaction slow test setting route test isready and synced to true

### DIFF
--- a/ironfish/src/rpc/routes/wallet/sendTransaction.test.slow.ts
+++ b/ironfish/src/rpc/routes/wallet/sendTransaction.test.slow.ts
@@ -9,10 +9,13 @@ import { createRouteTest } from '../../../testUtilities/routeTest'
 import { AsyncUtils } from '../../../utils'
 
 describe('Route wallet/sendTransaction (with note selection)', () => {
-  const routeTest = createRouteTest(true)
+  const routeTest = createRouteTest()
 
   it('spends the specified notes', async () => {
     const sender = await useAccountFixture(routeTest.node.wallet, 'accountA')
+
+    routeTest.node.peerNetwork['_isReady'] = true
+    routeTest.chain.synced = true
 
     const block = await useMinerBlockFixture(
       routeTest.chain,


### PR DESCRIPTION
## Summary

This test passed on my PR and is failing on staging. Requires a 2 line fix

This is the original PR: https://github.com/iron-fish/ironfish/pull/4545

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
