### PR TITLE
stores multiSigKeys as hex instead of utf8

### DIFF
--- a/ironfish/src/wallet/walletdb/accountValue.test.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.test.ts
@@ -45,9 +45,9 @@ describe('AccountValueEncoding', () => {
       version: 1,
       createdAt: null,
       multiSigKeys: {
-        identifier: 'a',
-        keyPackage: 'b',
-        proofGenerationKey: 'c',
+        identifier: 'deaf',
+        keyPackage: 'beef',
+        proofGenerationKey: 'feed',
       },
     }
     const buffer = encoder.serialize(value)

--- a/ironfish/src/wallet/walletdb/accountValue.ts
+++ b/ironfish/src/wallet/walletdb/accountValue.ts
@@ -55,9 +55,9 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     }
 
     if (value.multiSigKeys) {
-      bw.writeVarString(value.multiSigKeys.identifier, 'utf8')
-      bw.writeVarString(value.multiSigKeys.keyPackage, 'utf8')
-      bw.writeVarString(value.multiSigKeys.proofGenerationKey, 'utf8')
+      bw.writeVarBytes(Buffer.from(value.multiSigKeys.identifier, 'hex'))
+      bw.writeVarBytes(Buffer.from(value.multiSigKeys.keyPackage, 'hex'))
+      bw.writeVarBytes(Buffer.from(value.multiSigKeys.proofGenerationKey, 'hex'))
     }
 
     return bw.render()
@@ -87,9 +87,9 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
     let multiSigKeys = undefined
     if (hasMultiSigKeys) {
       multiSigKeys = {
-        identifier: reader.readVarString('utf8'),
-        keyPackage: reader.readVarString('utf8'),
-        proofGenerationKey: reader.readVarString('utf8'),
+        identifier: reader.readVarBytes().toString('hex'),
+        keyPackage: reader.readVarBytes().toString('hex'),
+        proofGenerationKey: reader.readVarBytes().toString('hex'),
       }
     }
 
@@ -125,9 +125,9 @@ export class AccountValueEncoding implements IDatabaseEncoding<AccountValue> {
       size += encoding.nonNullSize
     }
     if (value.multiSigKeys) {
-      size += bufio.sizeVarString(value.multiSigKeys.identifier, 'utf8')
-      size += bufio.sizeVarString(value.multiSigKeys.keyPackage, 'utf8')
-      size += bufio.sizeVarString(value.multiSigKeys.proofGenerationKey, 'utf8')
+      size += bufio.sizeVarString(value.multiSigKeys.identifier, 'hex')
+      size += bufio.sizeVarString(value.multiSigKeys.keyPackage, 'hex')
+      size += bufio.sizeVarString(value.multiSigKeys.proofGenerationKey, 'hex')
     }
 
     return size


### PR DESCRIPTION
## Summary

uses hex strings and stores multisig keys as buffers in the wallet db instead of using utf8 strings

this more closely matches the precedent set with our other keys and may simplify ser/de between TypeScript and Rust

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
