### PR TITLE
feat: frost round two in ironfish-rust

### DIFF
--- a/ironfish-rust/src/errors.rs
+++ b/ironfish-rust/src/errors.rs
@@ -57,6 +57,7 @@ pub enum IronfishErrorKind {
     Io,
     IsSmallOrder,
     RandomnessError,
+    RoundTwoSigningFailure,
     TryFromInt,
     Utf8,
 }

--- a/ironfish-rust/src/frost_utils/mod.rs
+++ b/ironfish-rust/src/frost_utils/mod.rs
@@ -3,4 +3,5 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 pub mod round_one;
+pub mod round_two;
 pub mod split_secret;

--- a/ironfish-rust/src/frost_utils/round_two.rs
+++ b/ironfish-rust/src/frost_utils/round_two.rs
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use ironfish_frost::frost::{
+    self,
+    keys::KeyPackage,
+    round1::SigningNonces,
+    round2::{Randomizer, SignatureShare},
+    SigningPackage,
+};
+use rand::{rngs::StdRng, SeedableRng};
+
+use crate::errors::{IronfishError, IronfishErrorKind};
+
+// Wrapper around frost::round2::sign that provides a seedable rng from u64
+pub fn round_two(
+    signing_package: SigningPackage,
+    key_package: KeyPackage,
+    randomizer: Randomizer,
+    seed: u64,
+) -> Result<SignatureShare, IronfishError> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let signer_nonces = SigningNonces::new(key_package.signing_share(), &mut rng);
+    frost::round2::sign(&signing_package, &signer_nonces, &key_package, randomizer)
+        .map_err(|_| IronfishError::new(IronfishErrorKind::RoundTwoSigningFailure))
+}


### PR DESCRIPTION
## Summary
Wrapper around [round two](https://github.com/ZcashFoundation/reddsa/blob/038505d6c51a13b58193d2767710227fcbe2b799/src/frost/redjubjub.rs#L328) of frost signing protocol.

The wrapper is implemented here only so that the `rand` package is not needed as dependency when using this function (ie in `ironfish-rust-nodejs`
## Testing Plan
A test here is difficult because it requires splitting the keys, performing round one, coordinator creating the signing package, and then round two can be performed. We should test this in a mock integration test once the rust components are completed.

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
