### PR TITLE
feat: round_two napi binding for frost signing

### DIFF
--- a/ironfish-rust-nodejs/src/frost.rs
+++ b/ironfish-rust-nodejs/src/frost.rs
@@ -3,9 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use ironfish::{
-    frost::keys::KeyPackage,
-    frost_utils::round_one::round_one as round_one_rust,
-    serializing::{bytes_to_hex, hex_to_vec_bytes},
+    frost::{
+        keys::KeyPackage,
+        round2::{Randomizer, SignatureShare},
+        SigningPackage,
+    },
+    frost_utils::{round_one::round_one as round_one_rust, round_two::round_two as round_two_rust},
+    serializing::{bytes_to_hex, hex_to_bytes, hex_to_vec_bytes},
 };
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -32,4 +36,22 @@ pub fn round_one(key_package: String, seed: u32) -> Result<RoundOneSigningData> 
         commitment_hiding: bytes_to_hex(&commitment.hiding().serialize()),
         commitment_binding: bytes_to_hex(&commitment.binding().serialize()),
     })
+}
+
+pub fn round_two(
+    signing_package: String,
+    key_package: String,
+    public_key_randomness: String,
+    seed: u64,
+) -> Result<SignatureShare> {
+    let key_package =
+        KeyPackage::deserialize(&hex_to_vec_bytes(&key_package).map_err(to_napi_err)?[..])
+            .map_err(to_napi_err)?;
+    let signing_package =
+        SigningPackage::deserialize(&hex_to_vec_bytes(&signing_package).map_err(to_napi_err)?[..])
+            .map_err(to_napi_err)?;
+    let randomizer =
+        Randomizer::deserialize(&hex_to_bytes(&public_key_randomness).map_err(to_napi_err)?)
+            .map_err(to_napi_err)?;
+    round_two_rust(signing_package, key_package, randomizer, seed).map_err(to_napi_err)
 }


### PR DESCRIPTION
## Summary
NAPI binding for round_two implementation (generating signature share).

Related `ironfish-rust` changes:
https://github.com/iron-fish/ironfish/pull/4558
## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
