### PR TITLE
adds multiSigKeys to account imports, exports

### DIFF
--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -51,7 +51,7 @@ describe('Route wallet/importAccount', () => {
   it('should import a multisig account that has no spending key', async () => {
     const key = generateKey()
 
-    const accountName = 'foo'
+    const accountName = 'multisig'
     const response = await routeTest.client
       .request<ImportResponse>('wallet/importAccount', {
         account: {
@@ -76,7 +76,7 @@ describe('Route wallet/importAccount', () => {
     expect(response.status).toBe(200)
     expect(response.content).toMatchObject({
       name: accountName,
-      isDefaultAccount: true,
+      isDefaultAccount: false,
     })
   })
 

--- a/ironfish/src/rpc/routes/wallet/importAccount.test.ts
+++ b/ironfish/src/rpc/routes/wallet/importAccount.test.ts
@@ -48,6 +48,38 @@ describe('Route wallet/importAccount', () => {
     })
   })
 
+  it('should import a multisig account that has no spending key', async () => {
+    const key = generateKey()
+
+    const accountName = 'foo'
+    const response = await routeTest.client
+      .request<ImportResponse>('wallet/importAccount', {
+        account: {
+          name: accountName,
+          viewKey: key.viewKey,
+          spendingKey: null,
+          publicAddress: key.publicAddress,
+          incomingViewKey: key.incomingViewKey,
+          outgoingViewKey: key.outgoingViewKey,
+          version: 1,
+          createdAt: null,
+          multiSigKeys: {
+            identifier: 'aaaa',
+            keyPackage: 'bbbb',
+            proofGenerationKey: 'cccc',
+          },
+        },
+        rescan: false,
+      })
+      .waitForEnd()
+
+    expect(response.status).toBe(200)
+    expect(response.content).toMatchObject({
+      name: accountName,
+      isDefaultAccount: true,
+    })
+  })
+
   it('should import a spending account', async () => {
     const key = generateKey()
 

--- a/ironfish/src/rpc/routes/wallet/types.ts
+++ b/ironfish/src/rpc/routes/wallet/types.ts
@@ -142,6 +142,11 @@ export type RpcAccountImport = {
   publicAddress: string
   spendingKey: string | null
   createdAt: { hash: string; sequence: number } | null
+  multiSigKeys?: {
+    identifier: string
+    keyPackage: string
+    proofGenerationKey: string
+  }
 }
 
 export const RpcAccountImportSchema: yup.ObjectSchema<RpcAccountImport> = yup
@@ -160,6 +165,13 @@ export const RpcAccountImportSchema: yup.ObjectSchema<RpcAccountImport> = yup
       })
       .nullable()
       .defined(),
+    multiSigKeys: yup
+      .object({
+        identifier: yup.string().defined(),
+        keyPackage: yup.string().defined(),
+        proofGenerationKey: yup.string().defined(),
+      })
+      .optional(),
   })
   .defined()
 

--- a/ironfish/src/wallet/account/account.ts
+++ b/ironfish/src/wallet/account/account.ts
@@ -24,7 +24,7 @@ import { WalletDB } from '../walletdb/walletdb'
 
 export const ACCOUNT_KEY_LENGTH = 32
 
-export const ACCOUNT_SCHEMA_VERSION = 2
+export const ACCOUNT_SCHEMA_VERSION = 3
 
 export type SpendingAccount = WithNonNull<Account, 'spendingKey'>
 
@@ -100,6 +100,7 @@ export class Account {
       outgoingViewKey: this.outgoingViewKey,
       publicAddress: this.publicAddress,
       createdAt: this.createdAt,
+      multiSigKeys: this.multiSigKeys,
     }
   }
 

--- a/ironfish/src/wallet/account/encoder/bech32.test.ts
+++ b/ironfish/src/wallet/account/encoder/bech32.test.ts
@@ -55,6 +55,30 @@ describe('Bech32AccountEncoder', () => {
     expect(decoded).toMatchObject(accountImport)
   })
 
+  it('encodes and decodes accounts with multisig keys', () => {
+    const accountImport: AccountImport = {
+      version: ACCOUNT_SCHEMA_VERSION,
+      name: 'test',
+      spendingKey: null,
+      viewKey: key.viewKey,
+      incomingViewKey: key.incomingViewKey,
+      outgoingViewKey: key.outgoingViewKey,
+      publicAddress: key.publicAddress,
+      createdAt: null,
+      multiSigKeys: {
+        identifier: 'aaaa',
+        keyPackage: 'bbbb',
+        proofGenerationKey: 'cccc',
+      },
+    }
+
+    const encoded = encoder.encode(accountImport)
+    expect(encoded.startsWith(BECH32_ACCOUNT_PREFIX)).toBe(true)
+
+    const decoded = encoder.decode(encoded)
+    expect(decoded).toMatchObject(accountImport)
+  })
+
   it('encodes and decodes view-only accounts', () => {
     const accountImport: AccountImport = {
       version: ACCOUNT_SCHEMA_VERSION,

--- a/ironfish/src/wallet/account/encoder/json.test.ts
+++ b/ironfish/src/wallet/account/encoder/json.test.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { generateKey } from '@ironfish/rust-nodejs'
 import { Assert } from '../../../assert'
+import { AccountImport } from '../../walletdb/accountValue'
+import { ACCOUNT_SCHEMA_VERSION } from '../account'
 import { JsonEncoder } from './json'
 describe('JsonEncoder', () => {
   describe('encoding/decoding', () => {
@@ -27,6 +30,32 @@ describe('JsonEncoder', () => {
       const decoded = encoder.decode(jsonString)
       Assert.isNotNull(decoded)
       expect(decoded.viewKey).not.toBeNull()
+    })
+    it('encodes and decodes accounts with multisig keys', () => {
+      const key = generateKey()
+
+      const accountImport: AccountImport = {
+        version: ACCOUNT_SCHEMA_VERSION,
+        name: 'test',
+        spendingKey: null,
+        viewKey: key.viewKey,
+        incomingViewKey: key.incomingViewKey,
+        outgoingViewKey: key.outgoingViewKey,
+        publicAddress: key.publicAddress,
+        createdAt: null,
+        multiSigKeys: {
+          identifier: 'aaaa',
+          keyPackage: 'bbbb',
+          proofGenerationKey: 'cccc',
+        },
+      }
+
+      const encoder = new JsonEncoder()
+
+      const encoded = encoder.encode(accountImport)
+
+      const decoded = encoder.decode(encoded)
+      expect(decoded).toMatchObject(accountImport)
     })
   })
 })


### PR DESCRIPTION
## Summary

updates bech32 and json account encoders

adds multiSigKeys to RpcAccountImport

increases account version

## Testing Plan

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
