### PR TITLE
Add config value for building the full FishHash context

### DIFF
--- a/ironfish/src/blockHasher.ts
+++ b/ironfish/src/blockHasher.ts
@@ -13,16 +13,13 @@ export class BlockHasher {
   private readonly consensus: Consensus
   private readonly fishHashContext: FishHashContext | null = null
 
-  constructor(options: {
-    consensus: Consensus
-    fullContext?: boolean
-    context?: FishHashContext
-  }) {
+  constructor(options: { consensus: Consensus; context?: FishHashContext }) {
     this.consensus = options.consensus
-    if (this.consensus.parameters.enableFishHash !== 'never') {
-      this.fishHashContext = options.context
-        ? options.context
-        : new FishHashContext(!!options.fullContext)
+
+    if (this.consensus.isNeverActive('enableFishHash')) {
+      this.fishHashContext = null
+    } else {
+      this.fishHashContext = options.context ?? new FishHashContext(false)
     }
   }
 

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -71,6 +71,13 @@ export class Consensus {
     return Math.max(1, sequence) >= upgrade
   }
 
+  /**
+   * Returns true if the upgrade can never activate on the network
+   */
+  isNeverActive(upgrade: keyof ConsensusParameters): boolean {
+    return this.parameters[upgrade] === 'never'
+  }
+
   getActiveTransactionVersion(sequence: number): TransactionVersion {
     if (this.isActive(this.parameters.enableAssetOwnership, sequence)) {
       return TransactionVersion.V2

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -298,6 +298,13 @@ export type ConfigOptions = {
    * The max number of transactions to process at one time when syncing
    */
   walletSyncingMaxQueueSize: number
+
+  /**
+   * Whether or not to build the full fish hash context at node startup. Setting this
+   * to `true` will slightly increase node performance but use ~4GB more RAM. The majority of
+   * network users will not need this speed increase and so should keep the default of `false`.
+   */
+  fishHashFullContext: boolean
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -379,6 +386,7 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     incomingWebSocketWhitelist: yup.array(yup.string().trim().defined()),
     walletGossipTransactionsMaxQueueSize: yup.number(),
     walletSyncingMaxQueueSize: yup.number(),
+    fishHashFullContext: yup.boolean(),
   })
   .defined()
 
@@ -486,6 +494,7 @@ export class Config<
       incomingWebSocketWhitelist: [],
       walletGossipTransactionsMaxQueueSize: 1000,
       walletSyncingMaxQueueSize: 100,
+      fishHashFullContext: false,
     }
   }
 }

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -301,7 +301,7 @@ export type ConfigOptions = {
 
   /**
    * Whether or not to build the full fish hash context at node startup. Setting this
-   * to `true` will slightly increase node performance but use ~4GB more RAM. The majority of
+   * to `true` will slightly increase node performance but use ~4.5GB more RAM. The majority of
    * network users will not need this speed increase and so should keep the default of `false`.
    */
   fishHashFullContext: boolean

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -250,12 +250,16 @@ export class FullNode {
     }
 
     const consensus = new TestnetConsensus(networkDefinition.consensus)
-    // TODO: config value for fullContext
-    const blockHasher = new BlockHasher({
-      consensus,
-      context: fishHashContext,
-      fullContext: false,
-    })
+
+    if (consensus.isNeverActive('enableFishHash')) {
+      fishHashContext = undefined
+    } else if (!fishHashContext) {
+      const isFull = config.get('fishHashFullContext')
+      fishHashContext = new FishHashContext(isFull)
+      fishHashContext.prebuildDataset(numWorkers)
+    }
+
+    const blockHasher = new BlockHasher({ context: fishHashContext, consensus })
 
     strategyClass = strategyClass || Strategy
     const strategy = new strategyClass({ workerPool, consensus, blockHasher })

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -5,7 +5,6 @@ import { BoxKeyPair, FishHashContext } from '@ironfish/rust-nodejs'
 import { v4 as uuid } from 'uuid'
 import { AssetsVerifier } from './assets'
 import { Blockchain } from './blockchain'
-import { BlockHasher } from './blockHasher'
 import { TestnetConsensus } from './consensus'
 import {
   Config,
@@ -259,10 +258,8 @@ export class FullNode {
       fishHashContext.prebuildDataset(numWorkers)
     }
 
-    const blockHasher = new BlockHasher({ context: fishHashContext, consensus })
-
     strategyClass = strategyClass || Strategy
-    const strategy = new strategyClass({ workerPool, consensus, blockHasher })
+    const strategy = new strategyClass({ workerPool, consensus, fishHashContext })
 
     const chain = new Blockchain({
       location: config.chainDatabasePath,

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -255,7 +255,6 @@ export class FullNode {
     } else if (!fishHashContext) {
       const isFull = config.get('fishHashFullContext')
       fishHashContext = new FishHashContext(isFull)
-      fishHashContext.prebuildDataset(numWorkers)
     }
 
     strategyClass = strategyClass || Strategy

--- a/ironfish/src/strategy.test.slow.ts
+++ b/ironfish/src/strategy.test.slow.ts
@@ -12,7 +12,7 @@ import {
   TransactionPosted as NativeTransactionPosted,
 } from '@ironfish/rust-nodejs'
 import { blake3 } from '@napi-rs/blake-hash'
-import { BlockHasher, serializeHeaderBlake3, serializeHeaderFishHash } from './blockHasher'
+import { serializeHeaderBlake3, serializeHeaderFishHash } from './blockHasher'
 import { ConsensusParameters, TestnetConsensus } from './consensus'
 import { MerkleTree } from './merkletree'
 import { LeafEncoding } from './merkletree/database/leaves'
@@ -102,15 +102,10 @@ describe('Demonstrate the Sapling API', () => {
     spenderKey = generateKey()
     receiverKey = generateKey()
     workerPool = new WorkerPool()
-    const consensus = new TestnetConsensus(consensusParameters)
-    const blockHasher = new BlockHasher({
-      consensus,
-      context: FISH_HASH_CONTEXT,
-    })
     strategy = new Strategy({
       workerPool,
-      consensus,
-      blockHasher,
+      consensus: new TestnetConsensus(consensusParameters),
+      fishHashContext: FISH_HASH_CONTEXT,
     })
   })
 
@@ -262,15 +257,10 @@ describe('Demonstrate the Sapling API', () => {
       }
 
       const key = generateKey()
-      const modifiedConsensus = new TestnetConsensus(modifiedParams)
-      const blockHasher = new BlockHasher({
-        consensus: modifiedConsensus,
-        context: FISH_HASH_CONTEXT,
-      })
       const modifiedStrategy = new Strategy({
         workerPool,
-        consensus: modifiedConsensus,
-        blockHasher,
+        consensus: new TestnetConsensus(modifiedParams),
+        fishHashContext: FISH_HASH_CONTEXT,
       })
 
       const minersFee1 = await modifiedStrategy.createMinersFee(
@@ -367,15 +357,10 @@ describe('Demonstrate the Sapling API', () => {
     }
 
     beforeAll(() => {
-      const modifiedConsensus = new TestnetConsensus(modifiedParams)
-      const blockHasher = new BlockHasher({
-        consensus: modifiedConsensus,
-        context: FISH_HASH_CONTEXT,
-      })
       modifiedStrategy = new Strategy({
         workerPool,
-        consensus: modifiedConsensus,
-        blockHasher,
+        consensus: new TestnetConsensus(modifiedParams),
+        fishHashContext: FISH_HASH_CONTEXT,
       })
     })
 

--- a/ironfish/src/strategy.test.ts
+++ b/ironfish/src/strategy.test.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { BlockHasher } from './blockHasher'
 import { Consensus, ConsensusParameters } from './consensus'
 import { Strategy } from './strategy'
 import { FISH_HASH_CONTEXT } from './testUtilities'
@@ -24,12 +23,10 @@ describe('Miners reward', () => {
   }
 
   beforeAll(() => {
-    const consensus = new Consensus(consensusParameters)
-    const blockHasher = new BlockHasher({ consensus, context: FISH_HASH_CONTEXT })
     strategy = new Strategy({
       workerPool: new WorkerPool(),
-      consensus,
-      blockHasher,
+      consensus: new Consensus(consensusParameters),
+      fishHashContext: FISH_HASH_CONTEXT,
     })
   })
 

--- a/ironfish/src/strategy.ts
+++ b/ironfish/src/strategy.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { FishHashContext } from '@ironfish/rust-nodejs'
 import { BlockHasher } from './blockHasher'
 import { Consensus } from './consensus'
 import { Block, RawBlock } from './primitives/block'
@@ -22,12 +23,15 @@ export class Strategy {
   constructor(options: {
     workerPool: WorkerPool
     consensus: Consensus
-    blockHasher: BlockHasher
+    fishHashContext?: FishHashContext
   }) {
     this.miningRewardCachedByYear = new Map<number, number>()
     this.workerPool = options.workerPool
     this.consensus = options.consensus
-    this.blockHasher = options.blockHasher
+    this.blockHasher = new BlockHasher({
+      consensus: this.consensus,
+      context: options.fishHashContext,
+    })
   }
 
   /**


### PR DESCRIPTION
## Summary
For power users like mining pools they may want to enable the full 4GB FishHash cache to increase performance of verifying block headers. This gives that option as a config value

## Testing Plan
Unit tests + running node locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
