### PR TITLE
Add missing consensus params to chain/getConsensusParameters

### DIFF
--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.test.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.test.ts
@@ -13,21 +13,13 @@ describe('Route chain.getConsensusParameters', () => {
       .request<GetConsensusParametersResponse>('chain/getConsensusParameters')
       .waitForEnd()
 
-    expect(response.content.allowedBlockFuturesSeconds).toEqual(
-      routeTest.chain.consensus.parameters.allowedBlockFutureSeconds,
+    const chainParams = routeTest.chain.consensus.parameters
+    const expectedResponseParams = Object.fromEntries(
+      Object.entries(chainParams).map(([k, v]) => {
+        return [k, v === 'never' ? null : v]
+      }),
     )
-    expect(response.content.genesisSupplyInIron).toEqual(
-      routeTest.chain.consensus.parameters.genesisSupplyInIron,
-    )
-    expect(response.content.targetBlockTimeInSeconds).toEqual(
-      routeTest.chain.consensus.parameters.targetBlockTimeInSeconds,
-    )
-    expect(response.content.targetBucketTimeInSeconds).toEqual(
-      routeTest.chain.consensus.parameters.targetBucketTimeInSeconds,
-    )
-    expect(response.content.maxBlockSizeBytes).toEqual(
-      routeTest.chain.consensus.parameters.maxBlockSizeBytes,
-    )
-    expect(response.content.minFee).toEqual(routeTest.chain.consensus.parameters.minFee)
+
+    expect(response.content).toEqual(expectedResponseParams)
   })
 })

--- a/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
+++ b/ironfish/src/rpc/routes/chain/getConsensusParameters.ts
@@ -3,21 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as yup from 'yup'
 import { Assert } from '../../../assert'
+import { ActivationSequence, ConsensusParameters } from '../../../consensus/consensus'
 import { FullNode } from '../../../node'
 import { ApiNamespace } from '../namespaces'
 import { routes } from '../router'
 
-interface ConsensusParameters {
-  allowedBlockFuturesSeconds: number
-  genesisSupplyInIron: number
-  targetBlockTimeInSeconds: number
-  targetBucketTimeInSeconds: number
-  maxBlockSizeBytes: number
-  minFee: number
-}
-
 export type GetConsensusParametersRequest = Record<string, never> | undefined
-export type GetConsensusParametersResponse = ConsensusParameters
+export type GetConsensusParametersResponse = {
+  [K in keyof ConsensusParameters]: ConsensusParameters[K] extends number
+    ? ConsensusParameters[K]
+    : number | null
+}
 
 export const GetConsensusParametersRequestSchema: yup.MixedSchema<GetConsensusParametersRequest> =
   yup.mixed().oneOf([undefined] as const)
@@ -25,12 +21,15 @@ export const GetConsensusParametersRequestSchema: yup.MixedSchema<GetConsensusPa
 export const GetConsensusParametersResponseSchema: yup.ObjectSchema<GetConsensusParametersResponse> =
   yup
     .object({
-      allowedBlockFuturesSeconds: yup.number().defined(),
+      allowedBlockFutureSeconds: yup.number().defined(),
       genesisSupplyInIron: yup.number().defined(),
       targetBlockTimeInSeconds: yup.number().defined(),
       targetBucketTimeInSeconds: yup.number().defined(),
       maxBlockSizeBytes: yup.number().defined(),
       minFee: yup.number().defined(),
+      enableAssetOwnership: yup.number().nullable().defined(),
+      enforceSequentialBlockTime: yup.number().nullable().defined(),
+      enableFishHash: yup.number().nullable().defined(),
     })
     .defined()
 
@@ -39,17 +38,18 @@ routes.register<typeof GetConsensusParametersRequestSchema, GetConsensusParamete
   GetConsensusParametersRequestSchema,
   (request, node): void => {
     Assert.isInstanceOf(node, FullNode)
-    Assert.isNotNull(node.chain.consensus, 'no consensus parameters')
 
     const consensusParameters = node.chain.consensus.parameters
 
+    const neverToNull = (value: ActivationSequence): number | null => {
+      return value === 'never' ? null : value
+    }
+
     request.end({
-      allowedBlockFuturesSeconds: consensusParameters.allowedBlockFutureSeconds,
-      genesisSupplyInIron: consensusParameters.genesisSupplyInIron,
-      targetBlockTimeInSeconds: consensusParameters.targetBlockTimeInSeconds,
-      targetBucketTimeInSeconds: consensusParameters.targetBucketTimeInSeconds,
-      maxBlockSizeBytes: consensusParameters.maxBlockSizeBytes,
-      minFee: consensusParameters.minFee,
+      ...consensusParameters,
+      enableAssetOwnership: neverToNull(consensusParameters.enableAssetOwnership),
+      enforceSequentialBlockTime: neverToNull(consensusParameters.enforceSequentialBlockTime),
+      enableFishHash: neverToNull(consensusParameters.enableFishHash),
     })
   },
 )


### PR DESCRIPTION
## Summary
Return all consensus parameters from the endpoint `chain/getConsensusParameters` and fix the naming of `allowedBlockFutureSeconds`

## Testing Plan
Unit tests + running HTTP adapter and making query

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
Adds values to `chain/getConsensusParameters` and fixes the naming of `allowedBlockFutureSeconds`

https://github.com/iron-fish/website/pull/584
