### PR TITLE
Refactor isActive function on Consensus

### DIFF
--- a/ironfish/src/blockHasher.ts
+++ b/ironfish/src/blockHasher.ts
@@ -24,10 +24,7 @@ export class BlockHasher {
   }
 
   hashHeader(header: RawBlockHeader): BlockHash {
-    const useFishHash = this.consensus.isActive(
-      this.consensus.parameters.enableFishHash,
-      header.sequence,
-    )
+    const useFishHash = this.consensus.isActive('enableFishHash', header.sequence)
 
     if (useFishHash) {
       Assert.isNotNull(this.fishHashContext, 'FishHash context was not initialized')

--- a/ironfish/src/consensus/consensus.test.ts
+++ b/ironfish/src/consensus/consensus.test.ts
@@ -14,65 +14,90 @@ describe('Consensus', () => {
     maxBlockSizeBytes: 5,
     minFee: 6,
     enableAssetOwnership: 7,
-    enforceSequentialBlockTime: 1,
-    enableFishHash: 'never',
+    enforceSequentialBlockTime: 8,
+    enableFishHash: 9,
   }
 
-  let consensus: Consensus
+  const consensus = new Consensus(params)
 
-  beforeAll(() => {
-    consensus = new Consensus(params)
+  const consensusWithNevers = new Consensus({
+    ...params,
+    enableAssetOwnership: 'never',
+    enforceSequentialBlockTime: 'never',
+    enableFishHash: 'never',
   })
 
   describe('isActive', () => {
-    describe('returns false when the sequence is less than the upgrade number', () => {
-      const upgradeSequence = 5
-      for (let sequence = 1; sequence < upgradeSequence; sequence++) {
-        it(`sequence: ${sequence}`, () => {
-          expect(consensus.isActive(upgradeSequence, sequence)).toBe(false)
-        })
-      }
+    it('returns false when the sequence is less than the upgrade number', () => {
+      expect(consensus.isActive('genesisSupplyInIron', 1)).toBe(false)
+      expect(consensus.isActive('targetBlockTimeInSeconds', 2)).toBe(false)
+      expect(consensus.isActive('targetBucketTimeInSeconds', 3)).toBe(false)
+      expect(consensus.isActive('maxBlockSizeBytes', 4)).toBe(false)
+      expect(consensus.isActive('minFee', 5)).toBe(false)
+      expect(consensus.isActive('enableAssetOwnership', 6)).toBe(false)
+      expect(consensus.isActive('enforceSequentialBlockTime', 7)).toBe(false)
+      expect(consensus.isActive('enableFishHash', 8)).toBe(false)
     })
 
-    describe('returns true when the sequence is greater than or equal to the upgrade number', () => {
-      const upgradeSequence = 5
-      for (let sequence = upgradeSequence; sequence < upgradeSequence * 2; sequence++) {
-        it(`sequence: ${sequence}`, () => {
-          expect(consensus.isActive(upgradeSequence, sequence)).toBe(true)
-        })
-      }
+    it('returns true when the sequence is equal to the upgrade number', () => {
+      expect(consensus.isActive('genesisSupplyInIron', 2)).toBe(true)
+      expect(consensus.isActive('targetBlockTimeInSeconds', 3)).toBe(true)
+      expect(consensus.isActive('targetBucketTimeInSeconds', 4)).toBe(true)
+      expect(consensus.isActive('maxBlockSizeBytes', 5)).toBe(true)
+      expect(consensus.isActive('minFee', 6)).toBe(true)
+      expect(consensus.isActive('enableAssetOwnership', 7)).toBe(true)
+      expect(consensus.isActive('enforceSequentialBlockTime', 8)).toBe(true)
+      expect(consensus.isActive('enableFishHash', 9)).toBe(true)
+    })
+
+    it('returns true when the sequence is greater than the upgrade number', () => {
+      expect(consensus.isActive('genesisSupplyInIron', 3)).toBe(true)
+      expect(consensus.isActive('targetBlockTimeInSeconds', 4)).toBe(true)
+      expect(consensus.isActive('targetBucketTimeInSeconds', 5)).toBe(true)
+      expect(consensus.isActive('maxBlockSizeBytes', 6)).toBe(true)
+      expect(consensus.isActive('minFee', 7)).toBe(true)
+      expect(consensus.isActive('enableAssetOwnership', 8)).toBe(true)
+      expect(consensus.isActive('enforceSequentialBlockTime', 9)).toBe(true)
+      expect(consensus.isActive('enableFishHash', 10)).toBe(true)
     })
 
     it('uses a minimum sequence of 1 if given a smaller sequence', () => {
-      const upgradeSequence = 1
-      expect(consensus.isActive(upgradeSequence, -100)).toBe(true)
-      expect(consensus.isActive(upgradeSequence, -1)).toBe(true)
-      expect(consensus.isActive(upgradeSequence, 0)).toBe(true)
+      expect(consensus.isActive('allowedBlockFutureSeconds', -100)).toBe(true)
+      expect(consensus.isActive('allowedBlockFutureSeconds', -1)).toBe(true)
+      expect(consensus.isActive('allowedBlockFutureSeconds', 0)).toBe(true)
+    })
+
+    it('returns false if flag activation is never', () => {
+      expect(consensusWithNevers.isActive('enableAssetOwnership', 3)).toBe(false)
+      expect(consensusWithNevers.isActive('enforceSequentialBlockTime', 3)).toBe(false)
+      expect(consensusWithNevers.isActive('enableFishHash', 3)).toBe(false)
     })
   })
 
-  it('getActiveTransactionVersion', () => {
-    expect(consensus.getActiveTransactionVersion(5)).toEqual(TransactionVersion.V1)
-    expect(consensus.getActiveTransactionVersion(6)).toEqual(TransactionVersion.V1)
-    expect(consensus.getActiveTransactionVersion(7)).toEqual(TransactionVersion.V2)
-    expect(consensus.getActiveTransactionVersion(8)).toEqual(TransactionVersion.V2)
+  describe('isNeverActive', () => {
+    it('returns true if flag activation is never', () => {
+      expect(consensusWithNevers.isNeverActive('enableAssetOwnership')).toBe(true)
+      expect(consensusWithNevers.isNeverActive('enforceSequentialBlockTime')).toBe(true)
+      expect(consensusWithNevers.isNeverActive('enableFishHash')).toBe(true)
+    })
+
+    it('returns false if flag has activation sequence', () => {
+      expect(consensus.isNeverActive('enableAssetOwnership')).toBe(false)
+      expect(consensus.isNeverActive('enforceSequentialBlockTime')).toBe(false)
+      expect(consensus.isNeverActive('enableFishHash')).toBe(false)
+    })
   })
 
-  it('when activation flag is never', () => {
-    consensus = new Consensus({
-      allowedBlockFutureSeconds: 1,
-      genesisSupplyInIron: 2,
-      targetBlockTimeInSeconds: 3,
-      targetBucketTimeInSeconds: 4,
-      maxBlockSizeBytes: 5,
-      minFee: 6,
-      enableAssetOwnership: 'never',
-      enforceSequentialBlockTime: 'never',
-      enableFishHash: 'never',
+  describe('getActiveTransactionVersion', () => {
+    it('returns the correct transaction version based on activation sequence', () => {
+      expect(consensus.getActiveTransactionVersion(5)).toEqual(TransactionVersion.V1)
+      expect(consensus.getActiveTransactionVersion(6)).toEqual(TransactionVersion.V1)
+      expect(consensus.getActiveTransactionVersion(7)).toEqual(TransactionVersion.V2)
+      expect(consensus.getActiveTransactionVersion(8)).toEqual(TransactionVersion.V2)
     })
-    expect(consensus.getActiveTransactionVersion(5)).toEqual(TransactionVersion.V1)
-    expect(consensus.isActive(consensus.parameters.enableAssetOwnership, 3)).toBe(false)
-    expect(consensus.isActive(consensus.parameters.enforceSequentialBlockTime, 3)).toBe(false)
-    expect(consensus.isActive(consensus.parameters.enableFishHash, 3)).toBe(false)
+
+    it('returns V1 transaction when activation flag is never', () => {
+      expect(consensusWithNevers.getActiveTransactionVersion(5)).toEqual(TransactionVersion.V1)
+    })
   })
 })

--- a/ironfish/src/consensus/consensus.ts
+++ b/ironfish/src/consensus/consensus.ts
@@ -64,11 +64,12 @@ export class Consensus {
     this.parameters = parameters
   }
 
-  isActive(upgrade: ActivationSequence, sequence: number): boolean {
-    if (upgrade === 'never') {
+  isActive(upgrade: keyof ConsensusParameters, sequence: number): boolean {
+    const upgradeSequence = this.parameters[upgrade]
+    if (upgradeSequence === 'never') {
       return false
     }
-    return Math.max(1, sequence) >= upgrade
+    return Math.max(1, sequence) >= upgradeSequence
   }
 
   /**
@@ -79,7 +80,7 @@ export class Consensus {
   }
 
   getActiveTransactionVersion(sequence: number): TransactionVersion {
-    if (this.isActive(this.parameters.enableAssetOwnership, sequence)) {
+    if (this.isActive('enableAssetOwnership', sequence)) {
       return TransactionVersion.V2
     } else {
       return TransactionVersion.V1

--- a/ironfish/src/consensus/verifier.ts
+++ b/ironfish/src/consensus/verifier.ts
@@ -217,12 +217,7 @@ export class Verifier {
       return { valid: false, reason: VerificationResultReason.PREV_HASH_MISMATCH }
     }
 
-    if (
-      this.chain.consensus.isActive(
-        this.chain.consensus.parameters.enforceSequentialBlockTime,
-        current.sequence,
-      )
-    ) {
+    if (this.chain.consensus.isActive('enforceSequentialBlockTime', current.sequence)) {
       if (current.timestamp.getTime() <= previousHeader.timestamp.getTime()) {
         return { valid: false, reason: VerificationResultReason.BLOCK_TOO_OLD }
       }


### PR DESCRIPTION
## Summary
Change the `Consensus.isActive` function to only take one sequence. It seems like all usages should want to by default use the activation sequence of the parameter so there should be no reason to have to pass it in. 

## Testing Plan
Unit tests + running node locally

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
This changes a the exported function `Consensus.isActive` in the SDK

