### PR TITLE
Remove customNetwork config value

### DIFF
--- a/ironfish-cli/src/commands/start.ts
+++ b/ironfish-cli/src/commands/start.ts
@@ -204,16 +204,13 @@ export default class Start extends IronfishCommand {
     if (networkId !== undefined && networkId !== this.sdk.config.get('networkId')) {
       this.sdk.config.setOverride('networkId', networkId)
     }
-    if (customNetwork !== undefined && customNetwork !== this.sdk.config.get('customNetwork')) {
-      this.sdk.config.setOverride('customNetwork', customNetwork)
-    }
 
     if (!this.sdk.internal.get('telemetryNodeId')) {
       this.sdk.internal.set('telemetryNodeId', uuid())
       await this.sdk.internal.save()
     }
 
-    const node = await this.sdk.node()
+    const node = await this.sdk.node({ customNetworkPath: customNetwork })
 
     const nodeName = this.sdk.config.get('nodeName').trim() || null
     const blockGraffiti = this.sdk.config.get('blockGraffiti').trim() || null

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -260,11 +260,6 @@ export type ConfigOptions = {
   networkId: number
 
   /**
-   * Path to a JSON file containing the network definition of a custom network
-   */
-  customNetwork: string
-
-  /**
    * The oldest the tip should be before we consider the chain synced
    */
   maxSyncedAgeBlocks: number
@@ -375,7 +370,6 @@ export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
     feeEstimatorPercentileAverage: YupUtils.isPositiveInteger,
     feeEstimatorPercentileFast: YupUtils.isPositiveInteger,
     networkId: yup.number().integer().min(0),
-    customNetwork: yup.string().trim(),
     maxSyncedAgeBlocks: yup.number().integer().min(0),
     mempoolMaxSizeBytes: yup
       .number()
@@ -486,7 +480,6 @@ export class Config<
       feeEstimatorPercentileAverage: DEFAULT_FEE_ESTIMATOR_PERCENTILE_AVERAGE,
       feeEstimatorPercentileFast: DEFAULT_FEE_ESTIMATOR_PERCENTILE_FAST,
       networkId: DEFAULT_NETWORK_ID,
-      customNetwork: '',
       maxSyncedAgeBlocks: 60,
       memPoolMaxSizeBytes: 60 * MEGABYTES,
       memPoolRecentlyEvictedCacheSize: 60000,

--- a/ironfish/src/networkDefinition.ts
+++ b/ironfish/src/networkDefinition.ts
@@ -59,12 +59,13 @@ export async function getNetworkDefinition(
   config: Config,
   internal: InternalStore,
   files: FileSystem,
+  customNetworkPath?: string,
 ): Promise<NetworkDefinition> {
   let networkDefinitionJSON = ''
 
   // Try fetching custom network definition first, if it exists
-  if (config.isSet('customNetwork')) {
-    networkDefinitionJSON = await files.readFile(files.resolve(config.get('customNetwork')))
+  if (customNetworkPath) {
+    networkDefinitionJSON = await files.readFile(files.resolve(customNetworkPath))
   } else {
     if (
       internal.isSet('networkId') &&
@@ -97,7 +98,7 @@ export async function getNetworkDefinition(
     throw Error('Network ID in network definition does not match network ID stored in datadir')
   }
 
-  if (config.isSet('customNetwork')) {
+  if (customNetworkPath) {
     if (isDefaultNetworkId(networkDefinition.id)) {
       throw Error('Cannot start custom network with a reserved network ID')
     }

--- a/ironfish/src/node.ts
+++ b/ironfish/src/node.ts
@@ -196,6 +196,7 @@ export class FullNode {
     webSocket,
     privateIdentity,
     fishHashContext,
+    customNetworkPath,
   }: {
     pkg: Package
     dataDir?: string
@@ -209,6 +210,7 @@ export class FullNode {
     webSocket: IsomorphicWebSocketConstructor
     privateIdentity?: PrivateIdentity
     fishHashContext?: FishHashContext
+    customNetworkPath?: string
   }): Promise<FullNode> {
     logger = logger.withTag('ironfishnode')
     dataDir = dataDir || DEFAULT_DATA_DIR
@@ -241,7 +243,12 @@ export class FullNode {
 
     metrics = metrics || new MetricsMonitor({ logger })
 
-    const networkDefinition = await getNetworkDefinition(config, internal, files)
+    const networkDefinition = await getNetworkDefinition(
+      config,
+      internal,
+      files,
+      customNetworkPath,
+    )
 
     if (!config.isSet('bootstrapNodes')) {
       config.setOverride('bootstrapNodes', networkDefinition.bootstrapNodes)

--- a/ironfish/src/sdk.ts
+++ b/ironfish/src/sdk.ts
@@ -180,10 +180,12 @@ export class IronfishSdk {
   async node({
     autoSeed,
     privateIdentity,
+    customNetworkPath,
   }: {
     autoSeed?: boolean
     privateIdentity?: PrivateIdentity
     fishHashContext?: FishHashContext
+    customNetworkPath?: string
   } = {}): Promise<FullNode> {
     const webSocket = WebSocketClient as IsomorphicWebSocketConstructor
 
@@ -199,6 +201,7 @@ export class IronfishSdk {
       webSocket: webSocket,
       privateIdentity: privateIdentity,
       dataDir: this.dataDir,
+      customNetworkPath,
     })
 
     if (this.config.get('enableRpcIpc')) {


### PR DESCRIPTION
## Summary
The `customNetwork` config value was originally added to be able to pass in a path to a custom network definition when first initializing a node in a data directory. After the data directory has been initialized the `customNetwork` config value is useless because the network cannot be changed.

Passing along the `customNetworkPath` string accomplishes this same goal of being able to use a custom JSON file and removes the unecessary config option.

## Testing Plan
Started up a new node with the customNetwork flag on startup pointing to a JSON file

## Documentation

Does this change require any updates to the Iron Fish Docs (ex. [the RPC API
Reference](https://ironfish.network/docs/onboarding/rpc/chain))? If yes, link a
related documentation pull request for the website.

```
[ ] Yes
```

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[X] Yes
```
Removes the `customNetwork` value of config. This is technically a breaking change but I can't see how it would actually break anyone's builds since the config value can only be used at initial startup 

